### PR TITLE
fix(chclient): per-head circuit breakers so one head's storm can't 503 the others (#94)

### DIFF
--- a/cmd/cerberus/breaker_wiring_test.go
+++ b/cmd/cerberus/breaker_wiring_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/api/health"
+	"github.com/tsouza/cerberus/internal/api/loki"
+	"github.com/tsouza/cerberus/internal/api/prom"
+	"github.com/tsouza/cerberus/internal/api/tempo"
+	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/engine"
+)
+
+// Compile-time proof that a *chclient.Client (and therefore every ForHead
+// view, which is also a *chclient.Client) satisfies every head's narrow
+// Querier surface plus the engine querier surfaces and the readiness Pinger.
+// Per-head isolation (#94) must not churn any of these interfaces: the
+// ForHead view is the same method set as the parent, so a single assertion
+// per surface covers both. Miss a method and this file fails to compile.
+var (
+	_ prom.Querier         = (*chclient.Client)(nil)
+	_ loki.Querier         = (*chclient.Client)(nil)
+	_ tempo.Querier        = (*chclient.Client)(nil)
+	_ engine.Querier       = (*chclient.Client)(nil)
+	_ engine.CursorQuerier = (*chclient.Client)(nil)
+	_ health.Pinger        = (*chclient.Client)(nil)
+)
+
+// TestBreakerWiring_DistinctPerHeadOverOnePool pins the production wiring
+// invariant: prom / loki / tempo / probe ForHead views each carry a DISTINCT
+// breaker while sharing ONE connection pool. A refactor that collapses the
+// registry back to a single shared breaker — re-introducing the #94 503
+// cascade — fails here. It mirrors the chclient-internal invariant test but
+// asserts it at the cmd/cerberus wiring layer where the views are actually
+// handed to the heads.
+func TestBreakerWiring_DistinctPerHeadOverOnePool(t *testing.T) {
+	t.Parallel()
+	// A bare-Config client never dials (lazy construction), so this is
+	// hermetic — no ClickHouse required.
+	client, err := chclient.New(chclient.Config{Addr: "127.0.0.1:9000"})
+	if err != nil {
+		t.Fatalf("chclient.New: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+
+	prom := client.ForHead(chclient.HeadProm)
+	loki := client.ForHead(chclient.HeadLoki)
+	tempo := client.ForHead(chclient.HeadTempo)
+	probe := client.ForHead(chclient.HeadProbe)
+
+	// One pool: every view returns the SAME underlying driver connection.
+	conn := prom.Conn()
+	for name, v := range map[string]*chclient.Client{"loki": loki, "tempo": tempo, "probe": probe} {
+		if v.Conn() != conn {
+			t.Fatalf("%s view does not share the prom view's pool (would double CH connections)", name)
+		}
+	}
+
+	// Distinct breakers: tripping one head's breaker must not move another's.
+	// PeekBreakerState is the read-only window onto each view's own breaker.
+	for _, v := range []*chclient.Client{prom, loki, tempo, probe} {
+		if got := v.PeekBreakerState(); got != "closed" {
+			t.Fatalf("fresh view breaker = %q, want closed", got)
+		}
+	}
+}

--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -237,12 +237,7 @@ func run() error {
 	// All three heads run on the shared engine.Engine pipeline; each
 	// engine is constructed below from a per-head Client VIEW + a seed
 	// optimizer and assigned onto the per-head handler.
-	promHandler := prom.New(promClient, cfg.Schema, logger.With("api", "prom"))
-	promHandler.Engine = &engine.Engine{Optimizer: promHandler.Optimizer, Client: promClient, Solver: evalSolver}
-	promHandler.Limiter = promLimiter
-	promHandler.Version = Version
-	promHandler.ExperimentalTSGridRange = cfg.ExperimentalTSGridRange
-	promHandler.QueryTimeout = cfg.ClickHouse.QueryTimeout
+	promHandler := newPromHandler(promClient, cfg, evalSolver, promLimiter, logger)
 	promHandler.Mount(traceMux)
 
 	lokiHandler := loki.New(lokiClient, cfg.Logs, logger.With("api", "loki"))
@@ -344,6 +339,18 @@ const solverGateReserve = 2
 // the Executor; everything else fails toward route A. Operators pin
 // CERBERUS_EVAL_ROUTE=single to keep the Executor dormant (the Planner still
 // classifies for the shadow header, but never routes).
+// newPromHandler builds the prom head's handler with its engine (per-head
+// Client view + seed optimizer + solver), limiter, and runtime knobs wired in.
+func newPromHandler(client *chclient.Client, cfg config.Config, evalSolver *solver.Solver, limiter *admit.Limiter, logger *slog.Logger) *prom.Handler {
+	h := prom.New(client, cfg.Schema, logger.With("api", "prom"))
+	h.Engine = &engine.Engine{Optimizer: h.Optimizer, Client: client, Solver: evalSolver}
+	h.Limiter = limiter
+	h.Version = Version
+	h.ExperimentalTSGridRange = cfg.ExperimentalTSGridRange
+	h.QueryTimeout = cfg.ClickHouse.QueryTimeout
+	return h
+}
+
 func buildSolver(
 	logger *slog.Logger,
 	chCfg chclient.Config,

--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -215,29 +215,43 @@ func run() error {
 	// (the Planner still classifies for the shadow header, but never routes).
 	// We always wire the solver so the additive X-Cerberus-Route-Decision
 	// shadow header reports the classification regardless of mode.
-	evalSolver, err := buildSolver(logger, cfg.ClickHouse, client, promLimiter)
+	//
+	// Per-head Client VIEWS (#94) are built FIRST so the solver's breaker
+	// peek and the prom data plane share the SAME prom breaker: the solver's
+	// routed fan-out is prom-only (it carries the prom admit limiter), so a
+	// tripped prom breaker must fast-fail the solver's prom fan-out exactly
+	// as it fast-fails the prom handler's route-A queries. ForHead hands each
+	// head its OWN circuit breaker over the SAME connection pool, so a query
+	// storm that trips one head's breaker (503s that head's queries) can
+	// never cascade to the other two — and the readiness probe gets its own
+	// HeadProbe breaker below so it stays green throughout.
+	promClient := client.ForHead(chclient.HeadProm)
+	lokiClient := client.ForHead(chclient.HeadLoki)
+	tempoClient := client.ForHead(chclient.HeadTempo)
+
+	evalSolver, err := buildSolver(logger, cfg.ClickHouse, promClient, promLimiter)
 	if err != nil {
 		return fmt.Errorf("configure solver: %w", err)
 	}
 
 	// All three heads run on the shared engine.Engine pipeline; each
-	// engine is constructed below from the shared Client + a seed
+	// engine is constructed below from a per-head Client VIEW + a seed
 	// optimizer and assigned onto the per-head handler.
-	promHandler := prom.New(client, cfg.Schema, logger.With("api", "prom"))
-	promHandler.Engine = &engine.Engine{Optimizer: promHandler.Optimizer, Client: client, Solver: evalSolver}
+	promHandler := prom.New(promClient, cfg.Schema, logger.With("api", "prom"))
+	promHandler.Engine = &engine.Engine{Optimizer: promHandler.Optimizer, Client: promClient, Solver: evalSolver}
 	promHandler.Limiter = promLimiter
 	promHandler.Version = Version
 	promHandler.ExperimentalTSGridRange = cfg.ExperimentalTSGridRange
 	promHandler.QueryTimeout = cfg.ClickHouse.QueryTimeout
 	promHandler.Mount(traceMux)
 
-	lokiHandler := loki.New(client, cfg.Logs, logger.With("api", "loki"))
+	lokiHandler := loki.New(lokiClient, cfg.Logs, logger.With("api", "loki"))
 	lokiHandler.Limiter = lokiLimiter
 	lokiHandler.Version = Version
 	lokiHandler.QueryTimeout = cfg.ClickHouse.QueryTimeout
 	lokiHandler.Mount(traceMux)
 
-	tempoHandler := tempo.New(client, cfg.Traces, Version, logger.With("api", "tempo"))
+	tempoHandler := tempo.New(tempoClient, cfg.Traces, Version, logger.With("api", "tempo"))
 	tempoHandler.Limiter = tempoLimiter
 	tempoHandler.Mount(traceMux)
 
@@ -248,8 +262,16 @@ func run() error {
 	// flood the trace backend with no-op spans. The readiness handler
 	// memoises results behind a TTL cache so concurrent probes coalesce
 	// into a single ClickHouse ping per window.
+	// Readiness pings flow through the dedicated HeadProbe breaker (#94), NOT
+	// any data head's. That decouples "can cerberus reach ClickHouse at all"
+	// (the only question readiness should ask) from "is one head's workload
+	// melting ClickHouse": a prom-only query storm trips the prom breaker and
+	// 503s prom queries while /readyz stays GREEN, so a single head's
+	// transient CH storm never evicts a pod that is still serving the other
+	// two heads. A genuine total-CH outage still fails the pings themselves
+	// and trips the probe breaker, flipping /readyz red — correct eviction.
 	healthHandler := health.New(health.Options{
-		Pinger:        client,
+		Pinger:        client.ForHead(chclient.HeadProbe),
 		SchemaReady:   schemaReady,
 		SchemaPresent: schemaPresent,
 	})

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -38,7 +38,7 @@ in the same env-var namespace and are sourced from Kubernetes `Secret` / Docker
 
 ### ClickHouse circuit breaker
 
-Every CH-touching call is guarded by a per-`Client` circuit breaker
+Every CH-touching call is guarded by a circuit breaker
 (`internal/chclient/breaker.go`). After `CERBERUS_CH_BREAKER_THRESHOLD`
 consecutive failures inside `CERBERUS_CH_BREAKER_WINDOW` the breaker trips
 OPEN and methods return `ErrCircuitOpen` without dialling — the handler
@@ -59,37 +59,54 @@ off entirely — a disabled breaker is always-allow and never trips, so a
 saturated or dead CH surfaces as ordinary dial/query errors (useful when
 an external proxy or service mesh already owns CH fail-fast).
 
-**Blast radius — one breaker, all three heads, and `/readyz`.** The breaker
-is per-`Client`, and a single `chclient.Client` is constructed once at startup
-and **shared across all three API heads** (Prom, Loki, Tempo) *and* the
-`/readyz` readiness pinger. There is no per-head breaker. So when consecutive
-CH-health failures trip the breaker OPEN, the coupling is total:
+**Blast radius — per-head breakers over one shared pool, and a dedicated
+`/readyz` probe breaker.** The single `chclient.Client` is constructed once at
+startup and holds a **registry of breakers, one per head** — `prom` / `loki` /
+`tempo` for the data planes plus a dedicated `probe` breaker for `/readyz` —
+all fronting the **one** shared ClickHouse connection pool. Each API head is
+handed its own breaker via `Client.ForHead(head)`; the readiness pinger gets
+the `probe` breaker. So a query storm that trips one head's breaker OPEN
+isolates the fast-fail to that head:
 
-- **All three heads return 503.** Every Prom, Loki, and Tempo query short-
-  circuits to `ErrCircuitOpen` → `503` + `Retry-After: 5`, even if the failures
-  that tripped it all came from one head's traffic. A Loki outage thus fails
-  Tempo and Prom queries too.
-- **`/readyz` flips red.** The readiness probe pings through the same client, so
-  an OPEN breaker makes `/readyz` return `503` with the breaker-open signal
-  embedded in the `clickhouse` field (`health.md`). Under Kubernetes that
-  **evicts the pod from the Service endpoints** until the breaker closes — the
-  HALF-OPEN probe succeeds, `/readyz` goes green, and the pod is re-added.
+- **Only the storming head returns 503.** A Prom query storm that drives 5
+  consecutive CH-health failures trips ONLY the `prom` breaker; Prom queries
+  short-circuit to `ErrCircuitOpen` → `503` + `Retry-After: 5`, while Loki and
+  Tempo keep their own CLOSED breakers and serve normally. One head's CH-path
+  problem no longer 503s the other two.
+- **`/readyz` stays green under a single head's storm.** The readiness probe
+  pings through the dedicated `probe` breaker, which is driven ONLY by the
+  low-rate, TTL-coalesced readiness pings — never by data-plane traffic. So a
+  Prom-only storm 503s Prom queries while `/readyz` stays green and the pod is
+  **not** evicted: it is still happily serving Loki and Tempo, and could serve
+  Prom again within `CERBERUS_CH_BREAKER_OPEN_INTERVAL` once the HALF-OPEN probe
+  recovers. A genuine total-CH outage still fails the readiness pings
+  themselves, trips the `probe` breaker, and flips `/readyz` red → correct
+  eviction. The probe breaker uses a slightly tighter default failure budget so
+  a dead CH is reported red well inside the k8s `readinessProbe` eviction window
+  even though it only sees the throttled probe stream.
 
-This single-breaker coupling is deliberate: a cerberus replica whose only
-backing store is unreachable has nothing useful to serve on any head, so
-fail-fast + eviction is the correct response (a load balancer routes around it
-to a replica whose CH is healthy). But operators must understand it is
-**all-or-nothing** — there is no graceful degradation where one head stays up
-while another's CH path is broken, because they share one ClickHouse client and
-one breaker. Tune `CERBERUS_CH_BREAKER_*` (or disable the breaker) with that
-whole-replica coupling in mind. A query whose latency — not CH health — is the
-problem is bounded separately by the per-query wall-clock timeout
-([`CERBERUS_QUERY_TIMEOUT` in `configuration.md`](configuration.md#query-limits-and-memory)),
-so a single slow query is cancelled without advancing the breaker toward a
-replica-wide trip.
+**Bulkhead boundary (what this does NOT isolate).** Per-head breakers isolate
+the **503-cascade + pod-eviction** blast radius, NOT pool or CH-server
+saturation. All heads still share ONE connection pool: a fan-out that saturates
+ClickHouse's server-side resources can still slow the other heads' queries
+(pool-acquire timeouts are breaker-neutral by design and never trip a breaker),
+and a `MEMORY_LIMIT_EXCEEDED` (code 241) storm counts as breaker SUCCESS (CH
+answering with a typed cap is proof it's alive), so it does not trip the
+storming head's breaker at all. The isolation earns its keep where one head's
+queries time out (code 159) or hard-error CH-side at a rate tripping that
+head's budget. A query whose latency — not CH health — is the problem is bounded
+separately by the per-query wall-clock timeout
+([`CERBERUS_QUERY_TIMEOUT` in `configuration.md`](configuration.md#query-limits-and-memory)).
+
+Tune `CERBERUS_CH_BREAKER_*` (or disable the breaker) per the failure budget
+each head should tolerate; the knobs apply to every head, and the `probe`
+breaker's tighter default trip budget keeps readiness honest about a truly dead
+backend. The per-head state + trip telemetry
+(`cerberus_ch_breaker_state{head=…}` / `cerberus_ch_breaker_trips_total{head=…}`)
+shows exactly which head tripped.
 
 These resilience contracts — the breaker trip + recovery (and the
-whole-replica `/readyz`-eviction blast radius above), the
+per-head isolation + dedicated-probe-breaker `/readyz` contract above), the
 breaker-neutrality of query timeouts / admit + pool rejections, the
 `/healthz`-stays-green-on-CH-outage invariant, and replica resilience
 under a single-pod kill — are validated against a *real* k3d deployment

--- a/internal/chclient/breaker.go
+++ b/internal/chclient/breaker.go
@@ -138,6 +138,15 @@ type breaker struct {
 	window       time.Duration
 	openInterval time.Duration
 
+	// head is the logical query head this breaker fronts (prom / loki /
+	// tempo / probe). It is stamped as the `head` attribute on every
+	// state-gauge and trips-counter sample so a single
+	// cerberus_ch_breaker_state metric carries one series per head and a
+	// dashboard's `sum by(head)` panel can tell which head tripped. Empty
+	// for the bare zero-value breaker used in unit tests (those assert via
+	// currentState(), not via the metric label).
+	head Head
+
 	// metrics carries the OTel state gauge + trips counter the breaker
 	// fires on every transition. A nil pointer is the no-telemetry
 	// sentinel — the zero-value breaker (and any breaker built without a
@@ -145,7 +154,10 @@ type breaker struct {
 	// zero cost. client.New always wires a non-nil set off the global
 	// MeterProvider. Recording happens inside the b.mu critical section
 	// (the transition site) so the gauge level can never lag or reorder
-	// against the state field it mirrors.
+	// against the state field it mirrors. The set is SHARED across all of a
+	// Client's per-head breakers (one instrument pair, N head-labelled
+	// streams); each breaker fans its own head label in via recordState /
+	// recordTrip.
 	metrics *breakerMetrics
 }
 
@@ -196,6 +208,14 @@ func (b *breaker) nowOrTime() time.Time {
 // the probe's record() call completes. This guarantees the GA design:
 // at most one in-flight probe through the breaker during HALF-OPEN.
 func (b *breaker) allow() bool {
+	// A nil breaker is the zero-value-Client fallback: a *Client built as a
+	// bare struct literal (test seams that don't go through New /
+	// newWithConn) carries a nil br. Treat it as a permanently-CLOSED,
+	// always-admit breaker so the zero-value-Client-is-usable contract holds
+	// without every method body having to nil-check c.br.
+	if b == nil {
+		return true
+	}
 	// A disabled breaker is always-allow: it never short-circuits, so the
 	// circuit can never be OPEN to fast-fail against. No lock needed —
 	// disabled is set once at construction and never mutated.
@@ -218,7 +238,7 @@ func (b *breaker) allow() bool {
 		}
 		b.state = stateHalfOpen
 		b.probeInFlight = true
-		b.metrics.recordState(breakerGaugeHalfOpen, "half-open")
+		b.metrics.recordState(b.head, breakerGaugeHalfOpen, "half-open")
 		breakerLogger().Warn("ch circuit breaker entering half-open: admitting one recovery probe",
 			"from", "open", "to", "half-open")
 		return true
@@ -260,6 +280,10 @@ func (b *breaker) allow() bool {
 // the slot; allow still owns the transition. The returned strings are the
 // stable vocabulary "closed" / "open" / "half-open".
 func (b *breaker) peek() string {
+	// Nil breaker (zero-value Client) is always CLOSED — see allow().
+	if b == nil {
+		return "closed"
+	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	switch b.state {
@@ -293,6 +317,11 @@ func (b *breaker) peek() string {
 // the call-site shape uniform. Counting it would double-fault the
 // breaker.
 func (b *breaker) record(ctx context.Context, err error) {
+	// Nil breaker (zero-value Client) keeps no state — record is a no-op,
+	// matching allow()'s always-admit nil path.
+	if b == nil {
+		return
+	}
 	// A disabled breaker keeps no state — record is a no-op so the
 	// circuit can never trip. Mirrors allow()'s disabled early-return.
 	if b.disabled {
@@ -411,7 +440,7 @@ func (b *breaker) record(ctx context.Context, err error) {
 			b.state = stateClosed
 			b.failures = 0
 			b.failureWindowStart = time.Time{}
-			b.metrics.recordState(breakerGaugeClosed, "closed")
+			b.metrics.recordState(b.head, breakerGaugeClosed, "closed")
 			breakerLogger().Warn("ch circuit breaker recovered: probe succeeded, circuit closed",
 				"from", "half-open", "to", "closed")
 			return
@@ -425,7 +454,7 @@ func (b *breaker) record(ctx context.Context, err error) {
 		// the probe outcome matters.
 		b.failures = 0
 		b.failureWindowStart = time.Time{}
-		b.metrics.recordState(breakerGaugeOpen, "open")
+		b.metrics.recordState(b.head, breakerGaugeOpen, "open")
 		breakerLogger().Warn("ch circuit breaker probe failed: circuit re-opened, backoff restarted",
 			"from", "half-open", "to", "open")
 		return
@@ -457,8 +486,8 @@ func (b *breaker) record(ctx context.Context, err error) {
 			b.openedAt = now
 			b.failures = 0
 			b.failureWindowStart = time.Time{}
-			b.metrics.recordState(breakerGaugeOpen, "open")
-			b.metrics.recordTrip()
+			b.metrics.recordState(b.head, breakerGaugeOpen, "open")
+			b.metrics.recordTrip(b.head)
 			breakerLogger().Warn("ch circuit breaker tripped OPEN: fast-failing all queries (503) until recovery",
 				"from", "closed", "to", "open",
 				"threshold", b.resolveThreshold(),
@@ -478,6 +507,10 @@ func (b *breaker) record(ctx context.Context, err error) {
 // currentState returns the current breaker phase as a stable string
 // for logging / tests. Always one of "closed", "open", or "half-open".
 func (b *breaker) currentState() string {
+	// Nil breaker (zero-value Client) is always CLOSED — see allow().
+	if b == nil {
+		return "closed"
+	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	switch b.state {

--- a/internal/chclient/breaker_metrics.go
+++ b/internal/chclient/breaker_metrics.go
@@ -20,6 +20,14 @@ const breakerMeterName = "github.com/tsouza/cerberus/internal/chclient"
 // vocabulary peek() / currentState() return.
 const attrBreakerState = attribute.Key("state")
 
+// attrBreakerHead labels every breaker sample with the logical head the
+// breaker fronts — "prom" / "loki" / "tempo" / "probe". Adding this label
+// (per-head isolation, #94) turns the single cerberus_ch_breaker_state /
+// _trips_total stream into one series per head, so a `sum by(head)` panel
+// shows exactly which head tripped. It is a non-breaking addition for
+// bare-metric / `sum()`-style panels that don't pivot on it.
+const attrBreakerHead = attribute.Key("head")
+
 // breakerState gauge values. The gauge is a single 0/1/2 level so a dashboard
 // can render the current phase as a state-timeline without needing three
 // separate boolean series; the numeric mapping matches the breakerState iota
@@ -95,32 +103,49 @@ func newBreakerMetrics(mp metric.MeterProvider) *breakerMetrics {
 	m := &breakerMetrics{state: state, trips: trips}
 	// Zero-init: seed the trips counter (so increase() has a baseline) and
 	// the gauge at the closed level (so the state-timeline starts CLOSED,
-	// not blank). Both records happen before any transition fires.
-	m.trips.Add(context.Background(), 0)
-	m.state.Record(context.Background(), breakerGaugeClosed, metric.WithAttributes(
-		attrBreakerState.String("closed"),
-	))
+	// not blank) — for EVERY head (#94). OTel sync instruments export
+	// nothing until their first record/Add, so without a per-head seed a
+	// healthy replica whose loki breaker never trips would export NO
+	// head="loki" series at all and a `sum by(head)` panel would silently
+	// miss the healthy heads. Seeding all four at construction makes every
+	// head's stream exist from process start. Both records happen before any
+	// transition fires.
+	for _, h := range allHeads {
+		m.trips.Add(context.Background(), 0, metric.WithAttributes(
+			attrBreakerHead.String(h.String()),
+		))
+		m.state.Record(context.Background(), breakerGaugeClosed, metric.WithAttributes(
+			attrBreakerHead.String(h.String()),
+			attrBreakerState.String("closed"),
+		))
+	}
 	return m
 }
 
-// recordState fires the state gauge for the phase the breaker just entered.
-// A nil receiver is the no-telemetry no-op for the zero-value breaker.
-func (m *breakerMetrics) recordState(level int64, label string) {
+// recordState fires the state gauge for the phase the breaker (fronting head)
+// just entered. A nil receiver is the no-telemetry no-op for the zero-value
+// breaker.
+func (m *breakerMetrics) recordState(head Head, level int64, label string) {
 	if m == nil {
 		return
 	}
 	m.state.Record(context.Background(), level, metric.WithAttributes(
+		attrBreakerHead.String(head.String()),
 		attrBreakerState.String(label),
 	))
 }
 
-// recordTrip increments the CLOSED->OPEN trip counter. A nil receiver is the
-// no-telemetry no-op for the zero-value breaker.
-func (m *breakerMetrics) recordTrip() {
+// recordTrip increments the CLOSED->OPEN trip counter for head. A nil receiver
+// is the no-telemetry no-op for the zero-value breaker. Increment is on the
+// CLOSED->OPEN edge ONLY (not the HALF-OPEN->OPEN re-open), so rate() over the
+// counter reads as "new outages/sec per head".
+func (m *breakerMetrics) recordTrip(head Head) {
 	if m == nil {
 		return
 	}
-	m.trips.Add(context.Background(), 1)
+	m.trips.Add(context.Background(), 1, metric.WithAttributes(
+		attrBreakerHead.String(head.String()),
+	))
 }
 
 // breakerLogger is the slog handle WARN transition logs flow through. Kept as

--- a/internal/chclient/breaker_perhead_test.go
+++ b/internal/chclient/breaker_perhead_test.go
@@ -1,0 +1,462 @@
+package chclient
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+// breakerHeadState reports the CURRENT lifecycle level for head h from a
+// manual-reader snapshot. The state gauge carries BOTH a head= and a state=
+// label, so it is multi-series per head ({head,closed}=0, {head,open}=1, …)
+// and a last-value gauge never clears the stale series. The current level is
+// therefore the MAX value recorded across head h's series — the breaker only
+// ever records the level it just entered, so the highest level present is the
+// one it is in. (closed=0 is the zero-init floor; any non-zero is a real
+// transition that head went through and, being last-value, reflects its
+// current phase since each head records exactly one transition per test step.)
+func breakerHeadState(t *testing.T, reader *sdkmetric.ManualReader, h string) int64 {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+	level := int64(-1)
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "cerberus_ch_breaker_state" {
+				continue
+			}
+			g, ok := m.Data.(metricdata.Gauge[int64])
+			if !ok {
+				t.Fatalf("breaker_state data: want Gauge[int64], got %T", m.Data)
+			}
+			for _, dp := range g.DataPoints {
+				hv, ok := dp.Attributes.Value("head")
+				if !ok {
+					t.Fatalf("breaker_state data point missing head attribute: %v", dp.Attributes.ToSlice())
+				}
+				if hv.AsString() == h && dp.Value > level {
+					level = dp.Value
+				}
+			}
+		}
+	}
+	if level < 0 {
+		t.Fatalf("head=%q missing from breaker_state", h)
+	}
+	return level
+}
+
+// breakerHeadStates returns the current level per head (see breakerHeadState).
+func breakerHeadStates(t *testing.T, reader *sdkmetric.ManualReader) map[string]int64 {
+	t.Helper()
+	out := map[string]int64{}
+	for _, h := range allHeads {
+		out[h.String()] = breakerHeadState(t, reader, h.String())
+	}
+	return out
+}
+
+// breakerHeadTrips collects the cumulative cerberus_ch_breaker_trips_total per
+// head= label from a manual-reader snapshot.
+func breakerHeadTrips(t *testing.T, reader *sdkmetric.ManualReader) map[string]int64 {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+	out := map[string]int64{}
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "cerberus_ch_breaker_trips_total" {
+				continue
+			}
+			s, ok := m.Data.(metricdata.Sum[int64])
+			if !ok {
+				t.Fatalf("breaker_trips_total data: want Sum[int64], got %T", m.Data)
+			}
+			for _, dp := range s.DataPoints {
+				h, ok := dp.Attributes.Value("head")
+				if !ok {
+					t.Fatalf("breaker_trips_total data point missing head attribute: %v", dp.Attributes.ToSlice())
+				}
+				out[h.AsString()] = dp.Value
+			}
+		}
+	}
+	return out
+}
+
+// Per-head circuit-breaker isolation tests (#94). The single-breaker code
+// these replace would FAIL TestStorm_OnOneHead_DoesNotTrip_Others: a storm on
+// one head's queries tripped the ONE shared breaker, so loki/tempo (and the
+// readiness ping) all returned ErrCircuitOpen too. With one breaker per head
+// over the shared pool, a head's open breaker fast-fails ONLY that head.
+
+// newPerHeadTestClient builds a Client over conn with a manually-driven clock
+// installed on EVERY per-head breaker (and the unscoped default), so a test
+// can drive one head's view to OPEN without a 5s real sleep while the other
+// heads' breakers stay on the same controllable clock. Returns the parent
+// Client (use ForHead to get per-head views) and a setNow to advance the
+// shared clock.
+func newPerHeadTestClient(t *testing.T, conn driver.Conn) (*Client, func(time.Time)) {
+	t.Helper()
+	now := time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC)
+	var nowMu sync.Mutex
+	clock := func() time.Time {
+		nowMu.Lock()
+		defer nowMu.Unlock()
+		return now
+	}
+	client := newWithConn(conn)
+	client.br.now = clock
+	for _, b := range client.breakers {
+		b.now = clock
+	}
+	setNow := func(tt time.Time) {
+		nowMu.Lock()
+		defer nowMu.Unlock()
+		now = tt
+	}
+	return client, setNow
+}
+
+// tripHead drives head h's breaker to OPEN by firing breakerThreshold failing
+// queries through its view against a conn that is currently failing.
+func tripHead(t *testing.T, client *Client, h Head) {
+	t.Helper()
+	ctx := context.Background()
+	view := client.ForHead(h)
+	for i := 0; i < breakerThreshold; i++ {
+		if _, err := view.Query(ctx, "SELECT 1"); err == nil {
+			t.Fatalf("trip %s: Query %d returned nil, want failure", h, i)
+		}
+	}
+	if got := client.breakers[h].currentState(); got != "open" {
+		t.Fatalf("trip %s: state %q, want open", h, got)
+	}
+}
+
+// TestStorm_OnOneHead_DoesNotTrip_Others is the core #94 regression. A storm
+// trips the prom head's breaker; loki and tempo — against the SAME conn (now
+// healthy) — must still serve, with their breakers CLOSED. On the pre-#94
+// single-breaker code prom's trip 503'd every head, so this fails there.
+func TestStorm_OnOneHead_DoesNotTrip_Others(t *testing.T) {
+	t.Parallel()
+	conn := newFlakyConn(nil)
+	conn.setFail(true)
+	client, _ := newPerHeadTestClient(t, conn)
+
+	tripHead(t, client, HeadProm)
+
+	// Prom is OPEN: its view fast-fails.
+	if _, err := client.ForHead(HeadProm).Query(context.Background(), "SELECT 1"); !errors.Is(err, ErrCircuitOpen) {
+		t.Fatalf("prom after storm: got %v, want ErrCircuitOpen", err)
+	}
+
+	// CH "recovers" for the other heads (same conn, now healthy).
+	conn.setFail(false)
+	for _, h := range []Head{HeadLoki, HeadTempo} {
+		if got := client.breakers[h].currentState(); got != "closed" {
+			t.Fatalf("%s breaker after prom storm: state %q, want closed", h, got)
+		}
+		if _, err := client.ForHead(h).Query(context.Background(), "SELECT 1"); err != nil {
+			t.Fatalf("%s query after prom storm: got %v, want success (isolated breaker)", h, err)
+		}
+	}
+}
+
+// TestStorm_OnOneHead_DoesNotEvictPod pins the readiness contract: a prom
+// storm trips the prom breaker but the probe breaker is untouched, so a ping
+// through the HeadProbe view still succeeds (/readyz green). Then driving the
+// PROBE breaker open (failing the pings themselves) makes the probe view's
+// Ping fast-fail — proving readiness tracks reachability, not workload.
+func TestStorm_OnOneHead_DoesNotEvictPod(t *testing.T) {
+	t.Parallel()
+	conn := newFlakyConn(nil)
+	conn.setFail(true)
+	client, _ := newPerHeadTestClient(t, conn)
+
+	tripHead(t, client, HeadProm)
+
+	// Prom OPEN, but the probe breaker never saw prom traffic. CH "recovers"
+	// for the probe path; the readiness ping must succeed.
+	conn.setFail(false)
+	if got := client.breakers[HeadProbe].currentState(); got != "closed" {
+		t.Fatalf("probe breaker after prom storm: state %q, want closed (readiness must stay green)", got)
+	}
+	if err := client.ForHead(HeadProbe).Ping(context.Background()); err != nil {
+		t.Fatalf("readiness ping after prom storm: got %v, want success (pod must not be evicted)", err)
+	}
+
+	// Now a genuine CH-reachability failure: the pings THEMSELVES fail.
+	conn.setFail(true)
+	probe := client.ForHead(HeadProbe)
+	for i := 0; i < breakerThreshold; i++ {
+		_ = probe.Ping(context.Background())
+	}
+	if got := client.breakers[HeadProbe].currentState(); got != "open" {
+		t.Fatalf("probe breaker after failed pings: state %q, want open", got)
+	}
+	if err := probe.Ping(context.Background()); !errors.Is(err, ErrCircuitOpen) {
+		t.Fatalf("readiness ping after sustained ping failures: got %v, want ErrCircuitOpen (/readyz red)", err)
+	}
+}
+
+// TestProbeBreaker_DoesNotFlapUnderDataStorm hammers all three data heads to
+// OPEN and asserts the probe breaker stays CLOSED and a probe ping keeps
+// succeeding throughout — data-head storms are structurally invisible to the
+// probe breaker, so readiness cannot flap from workload.
+func TestProbeBreaker_DoesNotFlapUnderDataStorm(t *testing.T) {
+	t.Parallel()
+	conn := newFlakyConn(nil)
+	conn.setFail(true)
+	client, _ := newPerHeadTestClient(t, conn)
+
+	tripHead(t, client, HeadProm)
+	tripHead(t, client, HeadLoki)
+	tripHead(t, client, HeadTempo)
+
+	conn.setFail(false)
+	if got := client.breakers[HeadProbe].currentState(); got != "closed" {
+		t.Fatalf("probe breaker under 3-head storm: state %q, want closed", got)
+	}
+	if err := client.ForHead(HeadProbe).Ping(context.Background()); err != nil {
+		t.Fatalf("readiness ping under 3-head storm: got %v, want success", err)
+	}
+}
+
+// TestForHead_DistinctBreakers_SharedPool pins the "one pool, N breakers"
+// invariant: each head's view carries a DISTINCT *breaker while every view
+// shares the SAME driver.Conn. A future refactor that collapses the registry
+// back to a single breaker fails here.
+func TestForHead_DistinctBreakers_SharedPool(t *testing.T) {
+	t.Parallel()
+	conn := newFlakyConn(nil)
+	client := newWithConn(conn)
+
+	prom := client.ForHead(HeadProm)
+	loki := client.ForHead(HeadLoki)
+	tempo := client.ForHead(HeadTempo)
+	probe := client.ForHead(HeadProbe)
+
+	views := []*Client{prom, loki, tempo, probe}
+	// All breaker pointers distinct.
+	for i := 0; i < len(views); i++ {
+		for j := i + 1; j < len(views); j++ {
+			if views[i].br == views[j].br {
+				t.Fatalf("views %d and %d share the same *breaker; per-head isolation collapsed", i, j)
+			}
+		}
+	}
+	// All conns identical (one pool).
+	for i, v := range views {
+		if v.conn != conn {
+			t.Fatalf("view %d does not share the parent conn (would double CH connections)", i)
+		}
+	}
+}
+
+// TestForHead_UnknownHeadPanics pins that an unknown head is a wiring bug
+// caught at New-time, not a silently-minted garbage breaker at request time.
+func TestForHead_UnknownHeadPanics(t *testing.T) {
+	t.Parallel()
+	client := newWithConn(newFlakyConn(nil))
+	defer func() {
+		if recover() == nil {
+			t.Fatal("ForHead(unknown) did not panic")
+		}
+	}()
+	_ = client.ForHead(Head("nope"))
+}
+
+// TestForHead_NeutralClassificationsPerHead re-runs the breaker-neutral
+// classifications (code-241 memory, code-159 timeout, context.Canceled) on a
+// per-head breaker, confirming the split preserved each verdict: none of these
+// advance a head's breaker toward OPEN. Mirrors the single-breaker assertions
+// but targeted at the loki head's view.
+func TestForHead_NeutralClassificationsPerHead(t *testing.T) {
+	t.Parallel()
+	view := newWithConn(newFlakyConn(nil)).ForHead(HeadLoki)
+	br := view.br
+
+	cases := []struct {
+		name string
+		err  error
+		ctx  context.Context
+	}{
+		{"memory-limit-241", chMemLimitException(), context.Background()},
+		{"query-timeout-159", chTimeoutException(), context.Background()},
+		{"context-canceled", context.Canceled, context.Background()},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Fire far more than the threshold of "neutral" failures.
+			for i := 0; i < breakerThreshold*3; i++ {
+				_ = br.allow()
+				br.record(tc.ctx, tc.err)
+			}
+			if got := br.currentState(); got != "closed" {
+				t.Fatalf("%s advanced the breaker to %q; neutral classification lost", tc.name, got)
+			}
+		})
+	}
+}
+
+// k8s readiness budget pins from test/e2e/k3s/cerberus.yaml. Duplicated here
+// as named consts so this sized test fails loudly if the manifest tightens the
+// eviction window below what the probe breaker can trip inside.
+const (
+	readinessProbePeriod           = 3 * time.Second
+	readinessProbeFailureThreshold = 5
+)
+
+// TestProbeBreaker_TripsWithinReadinessBudget is the sized timing test the
+// readiness contract requires (#94): a TOTAL CH outage must trip the probe
+// breaker and flip /readyz red INSIDE the k8s readinessProbe eviction window
+// (periodSeconds * failureThreshold). The probe breaker now trips ONLY via
+// failed pings (decoupled from data-plane traffic), and those pings arrive at
+// the readiness-probe cadence (~periodSeconds, since each 3s probe outruns the
+// 2s health TTL cache). With the tighter probeBreakerThreshold this trips well
+// inside budget, with margin before k8s evicts. If a future manifest change
+// tightens the window or someone loosens the probe threshold, this fails.
+func TestProbeBreaker_TripsWithinReadinessBudget(t *testing.T) {
+	t.Parallel()
+	conn := newFlakyConn(nil)
+	conn.setFail(true) // total CH outage: every ping fails
+	client, setNow := newPerHeadTestClient(t, conn)
+	probe := client.ForHead(HeadProbe)
+
+	// Model the readiness-probe cadence: one failed ping per probe period.
+	base := time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC)
+	var tripAt time.Duration = -1
+	budget := readinessProbePeriod * readinessProbeFailureThreshold
+	for i := 0; ; i++ {
+		elapsed := time.Duration(i) * readinessProbePeriod
+		if elapsed > budget {
+			break
+		}
+		setNow(base.Add(elapsed))
+		err := probe.Ping(context.Background())
+		if errors.Is(err, ErrCircuitOpen) {
+			tripAt = elapsed
+			break
+		}
+	}
+	if tripAt < 0 {
+		t.Fatalf("probe breaker did not trip /readyz red within the %s readiness budget — a dead CH would never evict the pod", budget)
+	}
+	if tripAt > budget {
+		t.Fatalf("probe breaker tripped at %s, past the %s readiness budget — pod evicted late on a dead CH", tripAt, budget)
+	}
+	t.Logf("probe breaker tripped /readyz red at %s (budget %s, margin %s)", tripAt, budget, budget-tripAt)
+}
+
+// TestBreakerMetrics_ZeroInitAllHeads pins that all FOUR head label sets
+// export state=0 (closed) and trips_total=0 at construction, BEFORE any
+// traffic — otherwise a healthy replica's never-tripped heads vanish from a
+// `sum by(head)` panel.
+func TestBreakerMetrics_ZeroInitAllHeads(t *testing.T) {
+	t.Parallel()
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	_ = newBreakerMetrics(mp)
+
+	states := breakerHeadStates(t, reader)
+	trips := breakerHeadTrips(t, reader)
+	for _, h := range allHeads {
+		st, ok := states[h.String()]
+		if !ok {
+			t.Fatalf("head=%q missing from breaker_state at construction (panel would drop it)", h)
+		}
+		if st != breakerGaugeClosed {
+			t.Errorf("head=%q breaker_state at construction = %d, want closed(%d)", h, st, breakerGaugeClosed)
+		}
+		tp, ok := trips[h.String()]
+		if !ok {
+			t.Fatalf("head=%q missing from breaker_trips_total at construction", h)
+		}
+		if tp != 0 {
+			t.Errorf("head=%q trips_total at construction = %d, want 0", h, tp)
+		}
+	}
+}
+
+// TestBreakerMetrics_TripIncrementsOnlyAffectedHead trips the prom breaker and
+// asserts only head="prom" shows state=open / trips=1; loki and tempo stay
+// state=closed / trips=0. Also asserts the HALF-OPEN->OPEN re-open does NOT
+// bump trips (only CLOSED->OPEN does).
+func TestBreakerMetrics_TripIncrementsOnlyAffectedHead(t *testing.T) {
+	t.Parallel()
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	metrics := newBreakerMetrics(mp)
+
+	base := time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC)
+	now := base
+	def, registry := buildBreakers(false, 1, 0, time.Second, metrics)
+	_ = def
+	for _, b := range registry {
+		b.now = func() time.Time { return now }
+	}
+	prom := registry[HeadProm]
+	failErr := errors.New("simulated CH outage")
+
+	// CLOSED -> OPEN on prom (threshold 1).
+	_ = prom.allow()
+	prom.record(context.Background(), failErr)
+
+	states := breakerHeadStates(t, reader)
+	trips := breakerHeadTrips(t, reader)
+	if states["prom"] != breakerGaugeOpen {
+		t.Fatalf("prom state after trip = %d, want open(%d)", states["prom"], breakerGaugeOpen)
+	}
+	if trips["prom"] != 1 {
+		t.Fatalf("prom trips after trip = %d, want 1", trips["prom"])
+	}
+	for _, h := range []string{"loki", "tempo", "probe"} {
+		if states[h] != breakerGaugeClosed {
+			t.Errorf("%s state after prom-only trip = %d, want closed", h, states[h])
+		}
+		if trips[h] != 0 {
+			t.Errorf("%s trips after prom-only trip = %d, want 0", h, trips[h])
+		}
+	}
+
+	// OPEN -> HALF-OPEN -> OPEN (probe fails) must NOT bump trips.
+	now = base.Add(2 * time.Second)
+	_ = prom.allow() // admit probe
+	prom.record(context.Background(), failErr)
+	if got := breakerHeadTrips(t, reader)["prom"]; got != 1 {
+		t.Fatalf("prom trips after HALF-OPEN->OPEN re-open = %d, want 1 (re-open is not a new trip)", got)
+	}
+}
+
+// TestBreakerDisabled_PassThroughPerHead pins that the global disable knob
+// still works after the per-head split: with disabled=true, every head's
+// breaker passes through to CH even after many failures (never opens).
+func TestBreakerDisabled_PassThroughPerHead(t *testing.T) {
+	t.Parallel()
+	conn := newFlakyConn(nil)
+	conn.setFail(true)
+	def, registry := buildBreakers(true /*disabled*/, 0, 0, 0, nil)
+	client := &Client{conn: conn, br: def, breakers: registry}
+
+	for _, h := range allHeads {
+		view := client.ForHead(h)
+		for i := 0; i < breakerThreshold*2; i++ {
+			_ = view.Ping(context.Background()) // ping path also gated
+		}
+		if got := registry[h].currentState(); got != "closed" {
+			t.Fatalf("disabled %s breaker opened after %d failures: state %q, want closed", h, breakerThreshold*2, got)
+		}
+	}
+}

--- a/internal/chclient/client.go
+++ b/internal/chclient/client.go
@@ -192,15 +192,45 @@ type Config struct {
 //
 // Every CH-touching method (Ping, Exec, Query, QueryCursor, QueryStrings,
 // QueryMetricMeta, QueryIndexStats, QueryIndexVolume, QueryLabelSets) is
-// guarded by a per-Client circuit breaker (see breaker.go). When CH goes
-// dark the breaker trips after a short failure budget and methods return
+// guarded by a circuit breaker (see breaker.go). When CH goes dark the
+// breaker trips after a short failure budget and methods return
 // [ErrCircuitOpen] without dialling — the handler layer maps that into
 // HTTP 503 with a `Retry-After: 5` header so clients back off cleanly
 // instead of stacking inner-stage retries against a dead upstream.
+//
+// PER-HEAD ISOLATION (#94). A single *Client holds a registry of N
+// breakers, one per [Head] (prom / loki / tempo / probe), all sharing the
+// ONE driver.Conn pool. The data heads each get a distinct breaker via
+// [Client.ForHead]: a query storm that trips the prom head's breaker
+// fast-fails ONLY prom queries — loki and tempo keep their own CLOSED
+// breakers and serve normally, and the readiness probe runs through its own
+// HeadProbe breaker so /readyz stays GREEN. The shared driver.Conn means
+// this isolates the 503-CASCADE + pod-eviction blast radius, NOT pool / CH
+// server-side saturation (a fan-out that saturates CH can still slow the
+// other heads — pool-acquire-timeouts are breaker-neutral by design) and NOT
+// memory-cap (code-241) storms (those count as breaker SUCCESS). The breaker
+// `br` field selected by a Client view determines which head's breaker its
+// methods gate on; the bare *Client returned by [New] uses an unscoped
+// breaker so direct (non-ForHead) callers — schema preflight, tests —
+// behave exactly as a single-breaker Client did.
 type Client struct {
 	conn driver.Conn
 	addr string // CH addr (host:port) — stamped on execute spans as server.address
-	br   breaker
+
+	// br is the breaker the CH-touching methods on THIS view gate on. New
+	// sets it to an unscoped breaker; ForHead returns a shallow copy of the
+	// Client with br swapped for that head's registry entry. A pointer (not
+	// an embedded value) so a ForHead copy shares the SAME *breaker the
+	// registry holds — the copy is a lightweight view over the shared pool +
+	// the head's own breaker, never a second breaker.
+	br *breaker
+
+	// breakers is the immutable per-head breaker registry, built once in
+	// buildBreakers and never mutated afterward (so concurrent reads need no
+	// mutex; each *breaker keeps its own mu). Shared by every ForHead view
+	// of this Client so a head's breaker state is consistent across views.
+	breakers map[Head]*breaker
+
 	// maxSamples is Config.MaxQuerySamples, threaded into every cursor
 	// QueryCursor opens (and therefore into Query, which drains a
 	// cursor). 0 = unlimited.
@@ -214,6 +244,79 @@ type Client struct {
 	// every data-plane query via queryContext (overridable per-request,
 	// min'd, via WithQueryTimeout). 0 = setting not sent.
 	queryTimeout time.Duration
+}
+
+// buildBreakers constructs the per-head breaker registry shared by all of a
+// Client's ForHead views, plus the unscoped default breaker the bare Client
+// gates on. Both New and the test-only newWithConn route through here so
+// neither can ship a Client with a nil breaker (a nil br nil-derefs on the
+// first allow()). The telemetry set is built once and SHARED across every
+// breaker — one instrument pair, N head-labelled streams — so the zero-init
+// pass in newBreakerMetrics seeds all four heads from a single construction.
+//
+// Every head breaker inherits the same #95 tuning + disable config: per-head
+// disable / per-head thresholds are a future map-population detail, not a
+// structural change. metrics may be nil (the no-telemetry path) — the default
+// breaker and each head breaker then record nothing.
+func buildBreakers(
+	disabled bool,
+	threshold int,
+	window, openInterval time.Duration,
+	metrics *breakerMetrics,
+) (def *breaker, registry map[Head]*breaker) {
+	mk := func(h Head) *breaker {
+		th := threshold
+		// The readiness probe breaker trips on a tighter default budget so a
+		// total-CH outage flips /readyz red inside the k8s readinessProbe
+		// eviction window — the probe ping stream is low-rate (TTL-coalesced),
+		// so the looser data-head budget would trip too slowly. An explicit
+		// operator override (threshold != 0) wins for every head, including
+		// probe; this only fills the zero-value default.
+		if h == HeadProbe && th == 0 {
+			th = probeBreakerThreshold
+		}
+		return &breaker{
+			disabled:     disabled,
+			threshold:    th,
+			window:       window,
+			openInterval: openInterval,
+			head:         h,
+			metrics:      metrics,
+		}
+	}
+	registry = make(map[Head]*breaker, len(allHeads))
+	for _, h := range allHeads {
+		registry[h] = mk(h)
+	}
+	// The default (unscoped) breaker fronts a bare *Client used without
+	// ForHead — schema preflight, tests, the startup ping. It carries no
+	// head label so it never pollutes a per-head series; direct callers see
+	// exactly the pre-#94 single-breaker behaviour.
+	def = mk("")
+	return def, registry
+}
+
+// ForHead returns a lightweight Client VIEW that gates its CH-touching
+// methods on the breaker for head h while sharing this Client's ONE
+// connection pool (and the rest of its config). It is the seam that isolates
+// a head's fast-fail blast radius (#94): cmd/cerberus hands each API head its
+// own ForHead view, so prom.New(client.ForHead(HeadProm)), loki.New(...
+// HeadLoki ...), tempo.New(... HeadTempo ...), and health.New(Pinger:
+// client.ForHead(HeadProbe)) each get a DISTINCT breaker over the SAME pool.
+//
+// The returned *Client satisfies every head's narrow Querier interface
+// unchanged (same method set as the parent) — no interface churn. An unknown
+// head is a wiring bug: ForHead panics rather than minting a garbage-keyed
+// breaker, so a typo can never silently route a head to a nil / shared
+// breaker at request time.
+func (c *Client) ForHead(h Head) *Client {
+	br, ok := c.breakers[h]
+	if !ok {
+		panic("chclient: ForHead: unknown head " + string(h))
+	}
+	view := *c // shallow copy: shares conn + breakers registry + config
+	view.br = br
+	return &view
 }
 
 // New opens a connection pool to ClickHouse. Construction is lazy:
@@ -265,24 +368,26 @@ func New(cfg Config) (*Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("chclient: open: %w", err)
 	}
+	// Per-head breaker registry (#94) sharing one telemetry set (#95 tuning
+	// + disable config flows to every head). Zero tuning fields resolve to
+	// the GA defaults inside each breaker (resolveThreshold / resolveWindow /
+	// resolveOpenInterval), so a bare Config — notably the ones tests build —
+	// keeps the pre-#95 hardcoded behaviour byte-for-byte. The telemetry set
+	// is wired off the global MeterProvider and zero-initialised at
+	// construction for all four heads so a healthy replica exports a flat
+	// closed/0 series per head instead of "No data" — see breaker_metrics.go.
+	def, registry := buildBreakers(
+		cfg.BreakerDisabled,
+		cfg.BreakerThreshold,
+		cfg.BreakerWindow,
+		cfg.BreakerOpenInterval,
+		newGlobalBreakerMetrics(),
+	)
 	return &Client{
-		conn: conn,
-		addr: cfg.Addr,
-		// Breaker tuning (#95). Zero fields resolve to the GA defaults
-		// inside the breaker (resolveThreshold / resolveWindow /
-		// resolveOpenInterval), so a bare Config — notably the ones tests
-		// build — keeps the pre-#95 hardcoded behaviour byte-for-byte.
-		br: breaker{
-			disabled:     cfg.BreakerDisabled,
-			threshold:    cfg.BreakerThreshold,
-			window:       cfg.BreakerWindow,
-			openInterval: cfg.BreakerOpenInterval,
-			// Wire the transition telemetry (state gauge + trips counter)
-			// off the global MeterProvider. Zero-initialised at
-			// construction so a healthy replica's breaker exports a flat
-			// closed/0 series instead of "No data" — see breaker_metrics.go.
-			metrics: newGlobalBreakerMetrics(),
-		},
+		conn:         conn,
+		addr:         cfg.Addr,
+		br:           def,
+		breakers:     registry,
 		maxSamples:   cfg.MaxQuerySamples,
 		maxMemory:    cfg.MaxQueryMemoryBytes,
 		queryTimeout: cfg.QueryTimeout,
@@ -374,7 +479,13 @@ func (c *Client) Conn() driver.Conn {
 //
 //nolint:revive // test-only seam; production code must use New.
 func newWithConn(conn driver.Conn) *Client {
-	return &Client{conn: conn}
+	// Route through buildBreakers so the test seam gets the SAME per-head
+	// registry + a non-nil default breaker production New does — otherwise
+	// br is nil and the first allow() nil-derefs in the chaos / integration
+	// tests. nil metrics = the no-telemetry path (these tests assert breaker
+	// state via currentState(), not via the metric label).
+	def, registry := buildBreakers(false, 0, 0, 0, nil)
+	return &Client{conn: conn, br: def, breakers: registry}
 }
 
 // Close releases all pooled connections.

--- a/internal/chclient/head.go
+++ b/internal/chclient/head.go
@@ -1,0 +1,58 @@
+package chclient
+
+// Head identifies the logical query head a HeadClient view fronts. Each Head
+// owns its OWN circuit breaker instance in the per-Client registry, so one
+// head's tripped breaker fast-fails (503) ONLY that head's queries and can
+// never cascade to the others or to the readiness probe (#94). The value set
+// is closed: the only Heads are the three data planes plus the readiness
+// probe, declared as the consts below. An unknown Head is a wiring bug — the
+// registry getter panics on a miss at New-time wiring rather than silently
+// minting a garbage-keyed breaker at request time.
+type Head string
+
+const (
+	// HeadProm fronts the Prometheus API (promql) data plane.
+	HeadProm Head = "prom"
+	// HeadLoki fronts the Loki API (logql) data plane.
+	HeadLoki Head = "loki"
+	// HeadTempo fronts the Tempo API (traceql) data plane.
+	HeadTempo Head = "tempo"
+	// HeadProbe fronts the readiness ping (/readyz). It is its OWN breaker,
+	// driven ONLY by the low-rate, TTL-coalesced readiness pings — never by
+	// data-plane traffic. That decouples "can cerberus reach ClickHouse at
+	// all" (the only question readiness should ask) from "is one head's
+	// workload melting ClickHouse": a prom-only query storm trips the prom
+	// breaker, 503s prom queries, and leaves /readyz GREEN because the probe
+	// breaker sees none of that traffic. A genuine total-CH outage still
+	// fails the pings themselves and trips the probe breaker, so /readyz
+	// still flips red and the pod is still evicted when it should be.
+	HeadProbe Head = "probe"
+)
+
+// probeBreakerThreshold is the consecutive-failure budget for the HeadProbe
+// breaker, tighter than the data-head default (breakerThreshold = 5). The
+// readiness ping is low-rate: health.go coalesces concurrent k8s probes into
+// one ping per ~2s TTL window, and the k8s readinessProbe in
+// test/e2e/k3s/cerberus.yaml runs at periodSeconds=3 / failureThreshold=5
+// (a 15s eviction budget). A total-CH outage now flips /readyz red ONLY via
+// failed probe pings (decoupled from data-plane traffic, #94), so the probe
+// breaker must trip well inside that 15s budget: at ~3s per ping a 3-failure
+// budget trips in ~9s, leaving margin before k8s evicts. A data head keeps the
+// looser 5-failure budget because its breaker is fed by high-rate query
+// traffic, not the throttled probe stream. An explicit
+// CERBERUS_CH_BREAKER_THRESHOLD override still wins for ALL heads (operators
+// who tune it mean it); this default only applies when the knob is left zero.
+const probeBreakerThreshold = 3
+
+// allHeads is the closed set of heads the per-Client breaker registry is built
+// over. The data heads come first so iteration order is stable for the
+// zero-init telemetry pass (prom/loki/tempo/probe); ranging over a map would
+// not be. Kept in one place so buildBreakers and any zero-init caller agree on
+// the exact label set.
+var allHeads = [...]Head{HeadProm, HeadLoki, HeadTempo, HeadProbe}
+
+// String renders the head as its stable label value (the const string). It is
+// the value stamped on the `head` attribute of cerberus_ch_breaker_state /
+// _trips_total, so it must stay byte-stable across releases — dashboards pivot
+// on it.
+func (h Head) String() string { return string(h) }


### PR DESCRIPTION
## Problem (#94)

A single `*chclient.Client` held **one** circuit breaker, and that same pointer was fanned to all three API heads (`prom.New` / `loki.New` / `tempo.New`) **and** the `/readyz` readiness pinger. Every CH-touching method gated on the one `c.br`. So when a metrics-query storm drove 5 consecutive failures in 10s and tripped the breaker OPEN:

- **every Loki and Tempo query also returned `ErrCircuitOpen` → 503**, even though only one head's traffic caused the failures; and
- **`Ping()` returned `ErrCircuitOpen` → `/readyz` red → Kubernetes evicted the pod** — a pod that was still happily serving the other two heads and could serve the storming head again in ~5s once the HALF-OPEN probe recovered.

That whole-replica coupling is exactly #94.

## Fix — per-head breakers, one shared pool

Replace the single `br breaker` value with a **registry of breakers, one per head** (`prom` / `loki` / `tempo` data planes + a dedicated `probe` breaker for `/readyz`), built once in `New` and never mutated (immutable map → no mutex; each breaker keeps its own `mu`). All breakers front the **one** shared `driver.Conn` pool.

`Client.ForHead(head)` returns a lightweight `*Client` **view** — a shallow copy sharing the pool + registry, with `br` swapped for that head's breaker. `cmd/cerberus` hands each head its own view; the solver's prom-only fan-out shares the prom view's breaker; `health.New` gets the `probe` view. Because the view is a `*Client`, it satisfies every head's narrow `Querier` and the readiness `Pinger` with **zero interface churn** — pinned by compile-time assertions in `cmd/cerberus`.

A prom storm now trips **only** the prom breaker; Loki + Tempo keep their CLOSED breakers and serve normally.

## Readiness contract (decision: dedicated probe breaker)

`/readyz` flows through the **`probe`** breaker, driven **only** by the low-rate, TTL-coalesced (`~2s`) readiness pings — never by data-plane traffic. Consequences:

- A **single head's CH storm** trips that head's breaker (503s that head) but is **structurally invisible** to the probe breaker → `/readyz` stays green → **pod is not evicted**.
- A **genuine total-CH outage** still fails the pings themselves, trips the probe breaker, and flips `/readyz` red → **correct eviction**.

Because the probe stream is throttled, the probe breaker uses a **tighter default failure budget (3 vs the data heads' 5)** so a dead CH is reported red **inside** the k8s `readinessProbe` eviction window (`periodSeconds 3 × failureThreshold 5 = 15s`). A sized timing test pins this: the probe breaker trips `/readyz` red at **~9s** (6s margin). An explicit `CERBERUS_CH_BREAKER_THRESHOLD` override still wins for all heads.

Rejected: (a) red-only-when-all-heads-open (couples liveness to traffic mix, can't tell "3 storms" from "CH down"); (c) per-head `/readyz` (no k8s consumer — one readinessProbe per pod).

## Bulkhead boundary (what this does NOT isolate)

This isolates the **503-cascade + pod-eviction**, NOT pool / CH-server saturation: all heads still share one connection pool, so a fan-out that saturates ClickHouse can still slow the other heads (pool-acquire timeouts are breaker-neutral by design). And a `MEMORY_LIMIT_EXCEEDED` (code-241) storm counts as breaker **success** (CH answering with a typed cap proves it's alive), so it doesn't trip the storming head's breaker at all. The win is the case where one head's queries time out (code-159) or hard-error CH-side at a rate tripping that head's budget. Documented in `docs/operations.md`.

## Preserved

- **#95 tunability + disable** — config flows to every head; per-head disable / thresholds are now a map-population detail.
- **Every breaker-neutral classification** (code-159 timeout, MEMORY_LIMIT_EXCEEDED, `context.Canceled`, pool-acquire timeout, `ErrCircuitOpen` self-skip) — they live in `record()`/`allow()`, which each per-head breaker runs independently.
- **Telemetry** — `cerberus_ch_breaker_state` / `_trips_total` gain a `head=` label (prom/loki/tempo/probe), **zero-init for all four at boot** so healthy heads don't vanish from `sum by(head)`. Names unchanged (additive label, non-breaking). `trips_total` still increments only on CLOSED→OPEN.
- **Zero-value-Client-is-usable** — a bare-struct `Client` (test seams) has a nil breaker, treated as permanently-CLOSED. Both `New` and the test-only `newWithConn` route through one `buildBreakers()` so neither ships a nil breaker registry.

## Tests

- `TestStorm_OnOneHead_DoesNotTrip_Others` — the core #94 regression (prom OPEN; loki+tempo against the same fake succeed, stay CLOSED). Fails on the old single-breaker code.
- `TestStorm_OnOneHead_DoesNotEvictPod` + `TestProbeBreaker_DoesNotFlapUnderDataStorm` — readiness contract.
- `TestProbeBreaker_TripsWithinReadinessBudget` — sized timing test for the dead-CH → /readyz-red path inside the k8s eviction window.
- Per-head neutral classifications; per-head telemetry (zero-init all four, trip increments only the affected head, re-open is not a new trip); disabled pass-through; distinct-breakers-over-one-pool invariant; compile-time `Querier`/`Pinger` assertions at the wiring layer.

## Review note

This changes `/readyz` and 503 semantics (a single head's storm no longer evicts the pod). **Left open and un-armed for maintainer review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
