### PR TITLE
test(property): add LogAttributes column to the LogQL logs schema + oracle

### DIFF
--- a/test/property/framework.go
+++ b/test/property/framework.go
@@ -66,13 +66,17 @@ type LogsModel struct {
 }
 
 // LogRecord is one row in a LogsModel. ResourceAttributes carries the
-// stream-identity labels (job, service_name, …); Body is the raw log
-// line; SeverityText is the OTel SeverityText column; Timestamp is
-// unix nanoseconds (DateTime64(9) precision in chDB).
+// stream-identity labels (job, service_name, …); LogAttributes carries
+// the structured-metadata map (the OTel-CH `LogAttributes` column —
+// per-log-record level/severity keys cerberus's detected_level cascade
+// reads); Body is the raw log line; SeverityText is the OTel
+// SeverityText column; Timestamp is unix nanoseconds (DateTime64(9)
+// precision in chDB).
 type LogRecord struct {
 	Body               string
 	SeverityText       string
 	ResourceAttributes map[string]string
+	LogAttributes      map[string]string
 	TimestampNanos     int64
 }
 

--- a/test/property/gen/logql.go
+++ b/test/property/gen/logql.go
@@ -37,8 +37,35 @@ var LogStreamLabelValues = map[string][]string{
 // SeverityText vocabulary the CH-exporter writes. Not yet used as a
 // matcher target (the M3.x lowering surfaces severity through
 // SeverityNumber, not stream labels), but stored on every record so
-// the dataset shape matches production.
-var LogSeverityPool = []string{"INFO", "WARN", "ERROR", "DEBUG"}
+// the dataset shape matches production. The empty string is included
+// so the detected_level cascade's empty → "unknown" branch is
+// exercised (a severity-free row resolves its level from the
+// LogAttributes structured-metadata map, or falls through to
+// "unknown" when that's empty too).
+var LogSeverityPool = []string{"INFO", "WARN", "ERROR", "DEBUG", ""}
+
+// LogStructuredMetadataKeys is the structured-metadata key pool the
+// generator splices into the OTel-CH `LogAttributes` column. The keys
+// are exactly the level-source keys cerberus's detected_level cascade
+// scans, in its precedence order (see
+// internal/logql/detected_level.go: detected_level → level →
+// log.level → severity → severity_text → SeverityText column), so the
+// generated rows actually exercise every branch of the cascade rather
+// than always falling through to SeverityText.
+var LogStructuredMetadataKeys = []string{
+	"detected_level",
+	"level",
+	"log.level",
+	"severity",
+	"severity_text",
+}
+
+// LogStructuredMetadataValues is the value pool for a structured-
+// metadata level key. Mixed-case + abbreviated forms exercise
+// cerberus's normaliseLevelExpr case-folding (`err` → `error`, `WARN`
+// → `warn`, …); a value outside the canonical vocabulary
+// ("verbose") exercises the cascade's pass-through default branch.
+var LogStructuredMetadataValues = []string{"error", "ERR", "Warn", "info", "debug", "verbose"}
 
 // LogBodyTokenPool is the per-line word pool. Each generated body is
 // a space-joined sequence of 2-4 tokens drawn from this pool. Keeping
@@ -107,11 +134,13 @@ func LogsDataset() *rapid.Generator[property.Dataset] {
 			lset := drawStreamLabels(t, fmt.Sprintf("labels_%d", i))
 			body := drawBody(t, fmt.Sprintf("body_%d", i))
 			severity := rapid.SampledFrom(LogSeverityPool).Draw(t, fmt.Sprintf("severity_%d", i))
+			structured := drawStructuredMetadata(t, fmt.Sprintf("meta_%d", i))
 			ts := logAnchorTime.Add(time.Duration(i) * step).UnixNano()
 			records = append(records, property.LogRecord{
 				Body:               body,
 				SeverityText:       severity,
 				ResourceAttributes: lset,
+				LogAttributes:      structured,
 				TimestampNanos:     ts,
 			})
 		}
@@ -140,6 +169,29 @@ func drawStreamLabels(t *rapid.T, id string) map[string]string {
 	return out
 }
 
+// drawStructuredMetadata picks a 0-2 key subset from
+// LogStructuredMetadataKeys and assigns each a random level value from
+// LogStructuredMetadataValues. Keys are picked in the pool's
+// precedence order (not reshuffled) so the rapid shrinker focuses on
+// count, and so a multi-key draw deterministically exercises the
+// cascade's "first non-empty in precedence order wins" rule. Returning
+// a nil/empty map ~1/3 of the time keeps the SeverityText-only path
+// (and the empty → "unknown" branch when SeverityText is also empty)
+// well-represented.
+func drawStructuredMetadata(t *rapid.T, id string) map[string]string {
+	count := rapid.IntRange(0, 2).Draw(t, id+"_count")
+	if count == 0 {
+		return nil
+	}
+	picked := LogStructuredMetadataKeys[:count]
+	out := make(map[string]string, len(picked))
+	for _, key := range picked {
+		v := rapid.SampledFrom(LogStructuredMetadataValues).Draw(t, id+"_"+key)
+		out[key] = v
+	}
+	return out
+}
+
 // drawBody picks 2-4 tokens from LogBodyTokenPool and joins them with
 // single spaces, optionally appending one delimited IP token from
 // LogIPTokenPool (~half the draws) so the `ip()` line-filter shapes
@@ -164,24 +216,34 @@ func drawBody(t *rapid.T, id string) string {
 //   - One `CREATE OR REPLACE TABLE otel_logs (...) ENGINE = MergeTree
 //     ORDER BY Timestamp;`
 //   - One batched `INSERT INTO otel_logs (Timestamp, SeverityText,
-//     Body, ResourceAttributes) VALUES (...), (...);`
+//     Body, ResourceAttributes, LogAttributes) VALUES (...), (...);`
 //
 // `CREATE OR REPLACE TABLE` keeps re-runs inside the same chDB
 // process idempotent. MergeTree (not Memory) matches the metrics-
 // side rationale: the optimizer's PREWHERE promotion fires
 // unconditionally and chDB's Memory engine refuses PREWHERE.
 //
-// The DDL must declare every top-level OTel-CH scalar column the
-// LogQL lowering routes through `topLevelLogColumnFor` — even though
-// the property generator only populates `ResourceAttributes`,
-// `SeverityText`, `Body`, and `Timestamp`. The matcher lowering
-// emits `coalesce(nullIf(ServiceName, ”),
-// ResourceAttributes['service_name'])` (and the matching shape for
-// each other top-level label), so chDB rejects the query with
-// `Unknown expression identifier ServiceName` if the column is
-// missing. The empty-string / zero-value defaults keep the `nullIf`
-// branch falsy, so the coalesce still falls through to the
-// ResourceAttributes map the generator populated.
+// The DDL must declare every column the LogQL lowering can reference
+// — even those the generator leaves empty on a given row. Two classes:
+//
+//   - Top-level OTel-CH scalar columns the matcher lowering routes
+//     through `topLevelLogColumnFor`: it emits `coalesce(nullIf(
+//     ServiceName, ”), ResourceAttributes['service_name'])` (and the
+//     matching shape for each other top-level label), so chDB rejects
+//     the query with `Unknown expression identifier ServiceName` if
+//     the column is missing. The empty-string / zero-value defaults
+//     keep the `nullIf` branch falsy, so the coalesce still falls
+//     through to the ResourceAttributes map.
+//   - The `LogAttributes` structured-metadata map: the detected_level
+//     cascade (and structured-metadata label filters) read
+//     `LogAttributes['level'/'severity'/…]`, and the log-stream
+//     projection ALWAYS selects `LogAttributes` to synthesise
+//     `detected_level`. A query as simple as `{job="api"}` therefore
+//     projects `LogAttributes`; without the column chDB rejects the
+//     SELECT with `Unknown expression identifier LogAttributes`. The
+//     generator populates structured-metadata level keys on a subset
+//     of rows so the cascade's LogAttributes branches are exercised,
+//     not just declared.
 func renderLogsDDL(records []property.LogRecord) string {
 	var b strings.Builder
 	b.WriteString(`CREATE OR REPLACE TABLE `)
@@ -192,6 +254,7 @@ func renderLogsDDL(records []property.LogRecord) string {
     SeverityNumber UInt8 DEFAULT 0,
     Body String,
     ResourceAttributes Map(LowCardinality(String), String),
+    LogAttributes Map(String, String),
     ServiceName LowCardinality(String) DEFAULT '',
     ScopeName String DEFAULT '',
     ScopeVersion String DEFAULT '',
@@ -206,7 +269,7 @@ func renderLogsDDL(records []property.LogRecord) string {
 	}
 	b.WriteString(`INSERT INTO `)
 	b.WriteString(LogsTableName)
-	b.WriteString(` (Timestamp, SeverityText, Body, ResourceAttributes) VALUES `)
+	b.WriteString(` (Timestamp, SeverityText, Body, ResourceAttributes, LogAttributes) VALUES `)
 	for i, r := range records {
 		if i > 0 {
 			b.WriteString(", ")
@@ -219,7 +282,9 @@ func renderLogsDDL(records []property.LogRecord) string {
 
 // renderLogRow renders one
 // `(toDateTime64('YYYY-MM-DD HH:MM:SS.fff', 9), 'severity', 'body',
-// map(...))` literal row.
+// map(...), map(...))` literal row — the trailing two maps are
+// ResourceAttributes (stream identity) and LogAttributes (structured
+// metadata), in the INSERT column order.
 func renderLogRow(r property.LogRecord) string {
 	var b strings.Builder
 	b.WriteString("(toDateTime64('")
@@ -233,15 +298,17 @@ func renderLogRow(r property.LogRecord) string {
 	b.WriteString("', '")
 	b.WriteString(escapeSQLString(r.Body))
 	b.WriteString("', ")
-	b.WriteString(renderResourceAttrs(r.ResourceAttributes))
+	b.WriteString(renderAttrMap(r.ResourceAttributes))
+	b.WriteString(", ")
+	b.WriteString(renderAttrMap(r.LogAttributes))
 	b.WriteByte(')')
 	return b.String()
 }
 
-// renderResourceAttrs renders a label set as a CH
+// renderAttrMap renders a label set as a CH
 // `map('k1','v1', 'k2','v2')` expression. Sorted keys for
 // determinism.
-func renderResourceAttrs(labels map[string]string) string {
+func renderAttrMap(labels map[string]string) string {
 	if len(labels) == 0 {
 		return "map()"
 	}

--- a/test/property/oracle/logql/evaluator.go
+++ b/test/property/oracle/logql/evaluator.go
@@ -45,18 +45,20 @@ func Evaluate(d property.Dataset, q property.Query) property.Outcome {
 	// handler's toStreamsWithTransform path groups by the
 	// CanonicalKey of the (post-format) labels — match that here.
 	//
-	// Each row's labels also carry the synthesized `detected_level`
-	// derived from the record's SeverityText — Loki surfaces this as a
-	// stream-identity dimension whenever the source row has severity
-	// metadata, and cerberus's wire-wrap (Lang.ProjectSamples on the
-	// log-stream branch) mirrors that. Strip the detection at the
-	// oracle so the comparator sees the same shape.
+	// Each row's labels also carry the synthesized `detected_level`,
+	// resolved via cerberus's detected_level cascade (see
+	// [detectedLevel] — structured-metadata `detected_level` /
+	// `level` / `log.level` / `severity` / `severity_text` keys in the
+	// LogAttributes map take precedence, then the dedicated
+	// SeverityText column). Loki surfaces this as a stream-identity
+	// dimension on EVERY row (a row with no detectable level resolves
+	// to "unknown"), and cerberus's wire-wrap (Lang.ProjectSamples on
+	// the log-stream branch) mirrors that — so the oracle stamps it
+	// unconditionally too.
 	out := property.Outcome{Rows: make([]property.OutcomeRow, 0, len(records))}
 	for _, r := range records {
 		labels := copyLabels(r.ResourceAttributes)
-		if lvl := normaliseLogLevel(r.SeverityText); lvl != "" {
-			labels["detected_level"] = lvl
-		}
+		labels["detected_level"] = detectedLevel(r)
 		// TimestampMs is unix milliseconds, matching the prom-side
 		// convention. Cerberus's stream-wire format uses nanos, but
 		// the property runner normalises to milliseconds (the
@@ -70,15 +72,52 @@ func Evaluate(d property.Dataset, q property.Query) property.Outcome {
 	return out
 }
 
+// detectedLevelKeys is the structured-metadata key precedence cerberus
+// scans before falling back to the SeverityText column — it must match
+// [internal/logql.detectedLevelSourceExpr]'s order exactly: the
+// canonical `detected_level` key first, then the allowed level fields
+// (`level` / `log.level` / `severity` / `severity_text`). The first key
+// present with a non-empty value wins.
+var detectedLevelKeys = []string{
+	"detected_level",
+	"level",
+	"log.level",
+	"severity",
+	"severity_text",
+}
+
+// detectedLevel resolves a record's synthesized `detected_level` value,
+// mirroring cerberus's [internal/logql.detectedLevelExpr]: it picks the
+// raw level source per [detectedLevelKeys] precedence (structured
+// metadata in the LogAttributes map, then the SeverityText column) and
+// normalises it via [normaliseLogLevel]. An all-empty row resolves to
+// "unknown" — reference Loki stamps detected_level on every record.
+func detectedLevel(r property.LogRecord) string {
+	src := ""
+	for _, key := range detectedLevelKeys {
+		if v := r.LogAttributes[key]; v != "" {
+			src = v
+			break
+		}
+	}
+	if src == "" {
+		src = r.SeverityText
+	}
+	return normaliseLogLevel(src)
+}
+
 // normaliseLogLevel mirrors cerberus's [internal/logql.normaliseLevelExpr]
 // — maps the case-insensitive forms upstream Loki accepts onto the
-// canonical lowercase level strings. Empty input returns the empty
-// string so the caller can skip the label entirely (matches the
-// `mapFilter((k, v) -> v != ”, ...)` shape on the SQL side).
+// canonical lowercase level strings. Empty input returns "unknown":
+// reference Loki's distributor stamps `detected_level="unknown"` on
+// every record with no detectable level, and cerberus's
+// `normaliseLevelExpr` mirrors that with its leading empty → "unknown"
+// branch. Non-empty inputs outside the known vocabulary pass through
+// lowercased, matching upstream `normalizeLogLevel`'s default branch.
 func normaliseLogLevel(severity string) string {
 	switch strings.ToLower(severity) {
 	case "":
-		return ""
+		return "unknown"
 	case "trace", "trc":
 		return "trace"
 	case "debug", "dbg":
@@ -308,6 +347,7 @@ func applyLabelFmt(e *syntax.LabelFmtExpr, records []property.LogRecord) []prope
 			Body:               r.Body,
 			SeverityText:       r.SeverityText,
 			ResourceAttributes: newLabels,
+			LogAttributes:      r.LogAttributes,
 			TimestampNanos:     r.TimestampNanos,
 		})
 	}


### PR DESCRIPTION
## The drift (property LogQL lane RED on main)

Push-to-main run 27499989107 (`property (PromQL + LogQL, rapid N=500)`) failed the LogQL property test. Shrunk counterexample was as minimal as `{job="api"}`:

```
error mismatch: want_err=<nil> got_err= Code: 47 DB::Exception: Unknown
  expression identifier `LogAttributes` ... SELECT Body, LogAttributes, ...
  FROM otel_logs WHERE ... (UNKNOWN_IDENTIFIER)
```

PR #903 (Loki Explore `detected_level`) made the LogQL emit reference the OTel-CH **`LogAttributes`** structured-metadata column: the detected_level cascade reads `LogAttributes['detected_level'/'level'/'log.level'/'severity'/'severity_text']`, and the log-stream projection now always selects `LogAttributes` to synthesise `detected_level`. The real default OTel-CH logs table HAS `LogAttributes Map(String, String)` — but the **property-test** logs schema (`test/property/`) still modelled a LogAttributes-LESS `otel_logs` table. So cerberus's now-correct emit projected a column the test DDL didn't declare → CH error 47. Even `{job="api"}`, which never references LogAttributes, failed purely because the projection selects it.

The fix is in the test schema (stale vs the real default table), not in cerberus.

## The fix

- **`gen/logql.go`** — declare `LogAttributes Map(String, String)` in the generated DDL (matching `test/spec/logql/*` seeds + `schema.DefaultOTelLogs()`), add it to the INSERT column list, and **populate** structured-metadata level keys (`detected_level` / `level` / `log.level` / `severity` / `severity_text`, in the cascade's precedence order) on a subset of rows so the cascade's LogAttributes branches are exercised, not merely declared. The `SeverityText` pool gains the empty string so the cascade's empty → `"unknown"` branch is covered.
- **`framework.go`** — add `LogAttributes map[string]string` to `LogRecord`.
- **`oracle/logql/evaluator.go`** — resolve `detected_level` via the same cascade cerberus uses (LogAttributes precedence, then the `SeverityText` column) and stamp it on **every** row (empty → `"unknown"`), so the oracle and cerberus still AGREE rather than just "make the error go away". The label-format stage now preserves `LogAttributes` through the pipeline.

## No prod-side guard needed

`internal/logql.detectedLevelSourceExpr` already guards: when `AttributesColumn == ""` (a custom schema with no structured-metadata column) the cascade collapses to the bare `SeverityText` column and never references `LogAttributes`. So a legitimately-configured custom schema lacking `LogAttributes` does not 500 in prod. The property lane models the DEFAULT schema (`AttributesColumn = "LogAttributes"`), which HAS the column — so the only bug is the stale test DDL.

## Local rapid re-run (chdb tag, `-rapid.checks=500` each)

- **LogQL** — PASS (replays the shrunk seed `13638545490157206225`; full 500-check sweep green, 29.8s).
- **PromQL** — PASS (500 checks, 24.8s).
- **TraceQL** — PASS (500 checks, 14.5s).

Restores main's property lane; the `property` / `chdb` gates are the safety net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)