### PR TITLE
docs(compat): honest conformance framing — verify claims from source, scope the three heads

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@ Keep Grafana, alerting, and your CLI tooling. Swap the backend.
 
 > [!WARNING]
 > **EXPERIMENTAL — NOT PRODUCTION-READY.** Cerberus is at `v1.0.0-RC1`,
-> early and under active development. The differential harnesses gate every
-> merge, but correctness, performance, and operational behaviour are still
-> being shaken out, and the surface is evolving. **Validate it against your
+> early and under active development. The differential harnesses run on every
+> PR and score parity against real Prometheus / Loki / Tempo, but correctness,
+> performance, and operational behaviour are still being shaken out, and the
+> surface is evolving. **Validate it against your
 > own corpus before pointing anything real at it** — do not stand it in for
 > a running Prom / Loki / Tempo deployment without that evaluation — and
 > expect breaking changes. See [`CHANGELOG.md`](CHANGELOG.md) for what has
@@ -24,7 +25,13 @@ Keep Grafana, alerting, and your CLI tooling. Swap the backend.
 
 The three `*QL compat` badges are **differential parity scores** —
 `passed / total` cases where cerberus matched a reference Prometheus /
-Loki / Tempo on the same seeded corpus ([details](#compatibility)).
+Loki / Tempo on the same seeded corpus ([details](#compatibility)). The
+PromQL leg runs the third-party
+[PromLabs / CNCF **PromQL Compliance Tester**](https://github.com/prometheus/compliance)
+(`prometheus/compliance`) — the same tool the CNCF Prometheus Conformance
+Program uses — at **574/574 cases passing, no allow-list**, against a real
+`prom/prometheus`. The scores are tracked, not gated: see
+[Compatibility](#compatibility) for exactly what the CI checks enforce.
 
 ---
 
@@ -146,25 +153,49 @@ see [`docs/performance.md`](docs/performance.md).
 
 ## Compatibility
 
-Each query language is gated by a **differential harness**: cerberus and
-a reference engine answer the same corpus against the same seeded data,
-and the responses are diffed case-for-case — pinning *observed semantics
-on real ClickHouse* against an upstream oracle, not just emitted SQL.
+Each query language has a **differential harness**: cerberus and a
+reference engine answer the same corpus against the same seeded data, and
+the responses are diffed case-for-case — pinning *observed semantics on
+real ClickHouse* against an upstream oracle, not just emitted SQL.
 
-| Head    | Reference + corpus                                          | Required gate              |
-| ------- | ----------------------------------------------------------- | -------------------------- |
-| PromQL  | bundled Prometheus engine vs `prometheus/compliance` corpus | `compatibility/prometheus` |
-| LogQL   | reference Loki vs `grafana/loki:pkg/logql/bench` corpus     | `compatibility/loki`       |
-| TraceQL | reference Tempo vs cerberus-owned TXTAR corpus              | `compatibility/tempo`      |
+The strongest leg is **PromQL**, which runs the third-party **PromQL
+Compliance Tester** (`prometheus/compliance`, the PromLabs / CNCF
+Prometheus Conformance Program tooling) against a real `prom/prometheus`,
+seeded identically on both sides via remote-write. **574/574 cases pass,
+no allow-list.** LogQL diffs against a real Loki on Grafana's own
+`pkg/logql/bench` corpus — solid, but a Grafana bench corpus rather than a
+standardised conformance suite. TraceQL is the lighter leg: there is **no
+third-party TraceQL conformance suite**, so its corpus is cerberus-owned
+(author-written TXTAR), and its numerical confidence is correspondingly
+lower than PromQL's.
+
+| Head    | Reference + corpus                                                  | Required check             | Conformance leg                           |
+| ------- | ------------------------------------------------------------------- | -------------------------- | ----------------------------------------- |
+| PromQL  | real `prom/prometheus` vs `prometheus/compliance` (PromLabs / CNCF) | `compatibility/prometheus` | third-party conformance suite (strongest) |
+| LogQL   | real Loki vs `grafana/loki:pkg/logql/bench` corpus                  | `compatibility/loki`       | real-backend diff, Grafana bench corpus   |
+| TraceQL | real Tempo vs cerberus-owned TXTAR corpus                           | `compatibility/tempo`      | author-written corpus (lightest)          |
 
 ```sh
 just compat-all          # or compat-promql / compat-logql / compat-traceql
 ```
 
+**What the required checks enforce.** The three `compatibility/<head>`
+checks run on every PR and **fail on infrastructure breakage** (stack
+won't boot, seed fails, report unparseable). Per-case **parity drift is
+report-only** by design ([#503](https://github.com/tsouza/cerberus/pull/503)):
+it is recorded in `report.json` and rendered into the live `compat-score.json`
+badge, but does not turn the required check red. The one lane that
+*hard-fails on any parity diff* is `compatibility/prometheus-forced-route`
+(`FAIL_ON_DIFF=1`, proving the sharded solver route is byte-identical to
+reference Prometheus over the whole corpus) — that lane is informational,
+not a required check. The honest reading: the badges are a continuously
+re-measured conformance score, not a merge gate on numeric correctness.
+
 **No allow-lists** — every diff against the reference is a real bug to
-fix at the source. The full playbook (per-head drivers, local
-reproduction, rejection parity, the sole pinned `upstream-skip-baseline`
-contract) is in [`docs/compatibility.md`](docs/compatibility.md).
+fix at the source, not an exception to suppress. The full playbook
+(per-head drivers, local reproduction, rejection parity, the sole pinned
+`upstream-skip-baseline` contract) is in
+[`docs/compatibility.md`](docs/compatibility.md).
 
 ## Testing
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,9 +1,29 @@
 # Compatibility harnesses
 
-Cerberus's correctness is verified by three differential-parity
+Cerberus's correctness is measured by three differential-parity
 harnesses, one per upstream API. Each diffs query results between a
 reference backend and cerberus, both seeded with the same deterministic
 fixture over the same time window.
+
+The strongest of the three is PromQL: it runs the **third-party PromQL
+Compliance Tester** (`prometheus/compliance`, the PromLabs / CNCF
+Prometheus Conformance Program tooling) against a real `prom/prometheus`
+— not a home-grown diff. LogQL and TraceQL use cerberus-owned drivers
+against real Loki / Tempo; TraceQL additionally has no third-party
+conformance suite to draw on, so its corpus is author-written and its
+numerical confidence is honestly lower (see
+[Per-head confidence](#per-head-confidence) below).
+
+> **What gates vs. what scores.** All three `compatibility/<head>` checks
+> run on every PR and are required, but they fail the check only on
+> **infrastructure breakage** — per-case parity drift is **report-only**
+> by design ([#503](https://github.com/tsouza/cerberus/pull/503)),
+> captured in the report + the live badge score, not in the check's exit
+> code. The one lane that hard-fails on any numeric parity diff is
+> `compatibility/prometheus-forced-route` (`FAIL_ON_DIFF=1`), which is
+> informational, not a required check. Treat the badges as a
+> continuously re-measured conformance score, not a merge gate on numeric
+> correctness. See [CI integration](#ci-integration).
 
 | Harness | Location                    | Reference backend                  | Corpus source                                                                                |
 | ------- | --------------------------- | ---------------------------------- | -------------------------------------------------------------------------------------------- |
@@ -21,10 +41,23 @@ branch as shields.io badge JSON; the README shows them live. On
 
 ### PromQL — `prometheus/compliance`
 
-- **Driver**: upstream `promql-compliance-tester`.
+- **Driver**: the upstream third-party `promql-compliance-tester` — the
+  PromLabs / CNCF Prometheus Conformance Program tool, vendored as the
+  `prometheus/compliance` submodule under
+  `compatibility/prometheus/upstream/`. Not a cerberus-authored diff.
+- **Reference**: a real `prom/prometheus` container seeded with the
+  *same* fixture as cerberus's ClickHouse (the seeder reads the CH rows
+  back and mirrors them into Prometheus over remote-write — see
+  `cmd/seed/prom_remote.go` — so both backends answer from byte-identical
+  data).
 - **Corpus**: vendored
-  [`prometheus/compliance/promql/promql-test-queries.yml`](https://github.com/prometheus/compliance).
-- **Today**: **574/574** cases pass; no allow-list exists.
+  [`prometheus/compliance/promql/promql-test-queries.yml`](https://github.com/prometheus/compliance),
+  template-expanded to 574 concrete cases.
+- **Today**: **574/574** cases pass; no allow-list exists. This is the
+  highest-confidence leg — an industry-standard conformance suite against
+  a real reference. (Parity drift is report-only in CI; the 574/574 is a
+  measured score, not a merge gate — see the note at the top of this
+  page.)
 
 ### LogQL — `grafana/loki:pkg/logql/bench`
 
@@ -35,8 +68,13 @@ branch as shields.io badge JSON; the README shows them live. On
   [`grafana/loki:pkg/logql/bench/queries/{fast,regression,exhaustive}`](https://github.com/grafana/loki/tree/main/pkg/logql/bench/queries);
   the widened corpus's `${SELECTOR}` / `${LABEL_*}` templates resolve
   off `dataset_metadata.json`.
-- **Today**: shipped and gating as the required `compatibility/loki` PR
-  check; no allow-list exists.
+- **Reference**: a real Loki container on `:23100`, seeded from the same
+  in-memory fixture as cerberus.
+- **Today**: shipped and running as the required `compatibility/loki` PR
+  check; no allow-list exists. Solid confidence — a real backend on a
+  real corpus — but Grafana's `bench` set is a benchmark corpus, not a
+  standardised conformance suite like PromQL's. Parity drift is
+  report-only.
 
 ### TraceQL — cerberus-owned driver
 
@@ -44,11 +82,33 @@ branch as shields.io badge JSON; the README shows them live. On
   (OTLP push to Tempo + direct CH `INSERT` to cerberus, both from one
   in-memory fixture so per-span fields stay 1:1 across both read paths),
   patterned on `cmd/tempo-vulture`.
-- **Corpus**: cerberus-owned TXTAR corpus.
-- **Today**: shipped and gating. `/api/search`, `/api/traces/<id>`, the
+- **Corpus**: cerberus-owned TXTAR corpus. **There is no third-party
+  TraceQL conformance suite** (no TraceQL analogue of
+  `prometheus/compliance`), so this corpus is author-written rather than
+  derived from an external standard — the lightest of the three legs.
+- **Today**: shipped and running. `/api/search`, `/api/traces/<id>`, the
   four tag / tag-values endpoints (V1 + V2), and the metrics endpoints
   (`/api/metrics/query_range` + `/api/metrics/query`) all run under the
-  required `compatibility/tempo` PR check; no allow-list exists.
+  required `compatibility/tempo` PR check; no allow-list exists. Parity
+  drift is report-only, like the other two heads.
+
+## Per-head confidence
+
+The three legs are *not* equally strong, and the docs should not imply
+they are:
+
+| Head    | Reference          | Corpus origin                                  | Numerical confidence                                                                        |
+| ------- | ------------------ | ---------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| PromQL  | real Prometheus    | third-party `prometheus/compliance` (CNCF)     | **Highest** — industry-standard conformance suite, 574/574, no allow-list                   |
+| LogQL   | real Loki          | Grafana's own `pkg/logql/bench` corpus         | **Solid** — real backend + real corpus, but a Grafana bench set, not a conformance standard |
+| TraceQL | real Tempo         | cerberus-owned author-written TXTAR            | **Lowest** — real backend, but no third-party suite; corpus breadth is author-bounded       |
+
+All three run against a real reference backend on identical seeded data,
+so each catches genuine semantic divergence. The difference is *corpus
+provenance and breadth*: PromQL inherits an externally-curated standard;
+TraceQL's coverage is only as wide as the author wrote it. Raising
+TraceQL's confidence is the top improvement item (see the project
+roadmap / the PR that introduced this section).
 
 ## Local run
 
@@ -206,6 +266,29 @@ real bug rather than a silent wrong-rejection:
 Each harness job uploads its report as a workflow artifact (30-day
 retention). On push-to-main, the per-head pass-rate is appended to the
 orphan `compat-scores` branch so the README badges refresh.
+
+**Required, but report-only on parity.** All three `compatibility/<head>`
+checks are required status checks on `main`, but — per
+[#503](https://github.com/tsouza/cerberus/pull/503) — the required check
+fails only on **infrastructure** errors (compose-up, seed, build,
+unparseable report). Per-case numeric parity drift is captured in
+`report.json` + the badge and **does not** turn the required check red.
+Concretely: the PromQL run script is report-only by default and only
+hard-fails under `FAIL_ON_DIFF=1`
+(`compatibility/prometheus/scripts/run-compatibility.sh`); the LogQL
+driver removed its `os.Exit(1)`-on-diff
+(`compatibility/loki/cmd/loki-compliance-tester/main.go`); and the TraceQL
+differ is report-only by construction
+(`compatibility/tempo/driver/diff.go`) — it ignores the `FAIL_ON_DIFF`
+env the workflow passes it.
+
+The single lane that **hard-fails on any parity diff** is
+`compatibility/prometheus-forced-route` (`FAIL_ON_DIFF=1`), the
+corpus-wide proof that the sharded solver route is byte-identical to
+reference Prometheus. It is intentionally an *informational* job, not a
+required check, so it doesn't gate every unrelated PR on the full
+forced-route corpus run. Closing this gap — promoting a fail-on-parity
+gate to required — is tracked as an improvement item.
 
 ## Adding new test cases
 

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -47,6 +47,14 @@ the pinned ledger of every grammar symbol the three upstream parsers expose.
 | TraceQL   | 45             | 45                             | 0                               | 0                 |
 | **Total** | **228**        | **226**                        | **2**                           | **0**             |
 
+> **This is an accept/reject ledger, not a correctness score.** "226/228
+> supported" means cerberus *lowers to SQL that the reference also accepts*
+> for 226 of 228 grammar symbols. It does **not** mean those 226 symbols
+> return numerically correct rows — that is what the
+> [differential harnesses](compatibility.md) measure (an accepted symbol
+> can still emit wrong rows). Cite this number as **surface / rejection
+> parity**, never as numerical correctness coverage.
+
 There are **zero** wrong-rejections across all three heads: cerberus lowers
 every grammar symbol the reference backends accept. The two PromQL parity
 rejections are the bare `start()` / `end()` query-context calls, which the

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -47,6 +47,17 @@ tolerated: a red informational lane is a real failure to fix, it is just
 not wired as a branch-protection gate (typically because it needs the chDB
 substrate, a Docker stack, or a soak streak before promotion).
 
+One subtlety on the three `compatibility/<head>` checks: they are required,
+but the *check* fails only on infrastructure breakage — per-case **numeric
+parity drift is report-only** (rendered into the badge score, not the exit
+code; see [`compatibility.md`](compatibility.md#ci-integration) and
+[#503](https://github.com/tsouza/cerberus/pull/503)). The only lane that
+hard-fails on a numeric parity diff is the *informational*
+`compatibility/prometheus-forced-route` (`FAIL_ON_DIFF=1`). So the
+required differential checks gate *that the harness runs clean*, while the
+parity number itself is a continuously-measured score rather than a merge
+gate. Promoting a fail-on-parity gate to required is a tracked improvement.
+
 | Gate                                    | Workflow (job)                                       | Trigger                             | Required? | Scope                                                                                                                                                                                                                    |
 | --------------------------------------- | ---------------------------------------------------- | ----------------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `check`                                 | `ci.yml` (`check`)                                   | PR + push                           | Required  | `just test` (`go test -race -cover ./...`) + `just build`. Default-tag lanes: 1, 2a, 2b, 3, 4, 5, **6d** (surface / rejection / inventory parity ratchets), 7, 7b stub, 8, 10, 11, 12 solver-decision ratchet            |


### PR DESCRIPTION
## What this is

An adversarial review concluded cerberus's validation story is *stronger* than the README claims — but flagged several claims to verify against source before repeating them publicly. This PR **verifies each claim from the actual source + workflow YAML** (the reviewer could only read `docs/`), corrects the doc framing to match the verified reality, and lays out an improvement plan. Docs-only; markdownlint clean.

## Source-verified findings (per claim)

### ⚠️ Lead finding — one claim is REFUTED

**"The PromQL differential gate FAILS on a numeric result mismatch (a required PR gate)" — REFUTED.**

The required differential checks are **report-only on numeric parity** by deliberate design (PR #503, "downgrade parity diffs to report-only"). The required `compatibility/<head>` checks fail **only on infrastructure breakage** (stack won't boot, seed fails, report unparseable). Per-case numeric drift is captured in `report.json` + the live badge score, never in the check's exit code.

- PromQL: `compatibility/prometheus/scripts/run-compatibility.sh:11-16,159-165,233-235` — report-only by default; only `FAIL_ON_DIFF=1` hard-fails.
- LogQL: `compatibility/loki/cmd/loki-compliance-tester/main.go:209-215` — the `os.Exit(1)`-on-diff was removed; driver is report-only.
- TraceQL: `compatibility/tempo/driver/diff.go:9-15,42-47` + `main.go:17` — report-only by construction; it **ignores** the `FAIL_ON_DIFF: "1"` env the workflow passes it (`compatibility.yml:594`) — that env var is dead.

The **only** lane that hard-fails on any parity diff is `compatibility/prometheus-forced-route` (`FAIL_ON_DIFF=1`), and the workflow comment states it is "intentionally a NORMAL CI job, not a branch-protection-required check" (`compatibility.yml:414-416`).

So the numerically-meaningful enforcement is **not** wired as a required gate. This doesn't make the harnesses weak — they run on every PR and produce a real, externally-standardised score — but the framing "gates every merge" overstates enforcement.

### Claims that HOLD

| Claim | Verdict | Evidence |
| --- | --- | --- |
| Seeder writes identical data to BOTH Prometheus and cerberus+CH | **HOLDS** | `cmd/seed/main.go:99-103` inserts the fixture into CH then mirrors it to Prom via remote-write; `cmd/seed/prom_remote.go:48-126` reads the CH rows back and POSTs them to Prom's remote-write receiver. Byte-identical data both sides. |
| Real `prom/prometheus` reference service | **HOLDS** | `docker-compose.yml:54-78` runs `prom/prometheus:v3.11.3` with the remote-write receiver enabled. |
| Suite is the third-party PromLabs / CNCF PromQL Compliance Tester, not home-grown | **HOLDS** | `.gitmodules`: `compatibility/prometheus/upstream → github.com/prometheus/compliance`. The run script builds + invokes the upstream `promql-compliance-tester` (`run-compatibility.sh:113-116,167-171`). |
| 574/574 passing, no allow-list | **HOLDS** | `docs/compatibility.md` records 574/574; the 151 query templates expand to 574 concrete cases; `expected-failures.json` is deleted (no allow-list). The score is real — but report-only, not a gate. |
| `pull_request` trigger present (runs on every PR) | **HOLDS** | `compatibility.yml:40-41` — `on: pull_request: branches:[main]`, no path filter, so the three head checks always appear in the PR rollup. |
| LogQL diffed vs real Loki on Grafana's `pkg/logql/bench` corpus | **HOLDS** | Real Loki on `:23100`; corpus vendored from `grafana/loki/pkg/logql/bench`. Report-only on parity. |
| TraceQL has no third-party conformance suite; corpus is author-written | **HOLDS** | `compatibility/tempo/driver/corpus/` is a cerberus-owned TXTAR corpus; no external standard exists. |
| "226/228 supported" is an accept/reject ledger, not numerical correctness | **HOLDS** | `docs/coverage.md` already frames it as a ledger ("lowers to SQL the reference also accepts"); `inventory.json` classifies `parity-accept` / `parity-reject` / `wrong-reject` / `wrong-accept`. It explicitly does NOT measure whether an accepted symbol returns correct rows. |
| Dashboard crawl dropped its PR trigger (merge/nightly only) | **HOLDS** | `e2e.yml` `dashboard` job is push + nightly + dispatch, informational — not a PR gate. |

Empirical run note: I relied on source + workflow reading (per the brief) rather than `just compat-promql`, which needs a heavy multi-container Docker stack (ClickHouse + Prometheus + cerberus build). The source is unambiguous on every point above.

## Per-head honest confidence map

- **PromQL — highest.** Third-party CNCF/PromLabs conformance suite vs a real Prometheus, identical seeded data, 574/574, no allow-list.
- **LogQL — solid.** Real Loki + Grafana's own `bench` corpus — real backend, real corpus, but a benchmark set, not a standardised conformance suite.
- **TraceQL — lowest.** Real Tempo, but no third-party TraceQL conformance suite exists; corpus is author-written, so coverage breadth is author-bounded.

## Framing fixes in this PR

- **README**: lead the badge description with the named PromLabs/CNCF PromQL Compliance Tester (574/574, no allow-list, real Prometheus); rewrite the Compatibility section to scope LogQL / flag TraceQL and add an explicit "What the required checks enforce" paragraph (required-but-report-only; forced-route is the only fail-on-parity lane). Soften the WARNING from "gate every merge" → "run on every PR and score parity".
- **docs/compatibility.md**: name the third-party tool; add a top-of-page "What gates vs. what scores" callout; add a **Per-head confidence** section; document the report-only-vs-gating reality in CI integration with file-level citations.
- **docs/coverage.md**: add a visible callout that 226/228 is an accept/reject **ledger**, not numerical correctness — cite the differential harnesses for the latter.
- **docs/test-strategy.md**: clarify that the required `compatibility/<head>` checks gate "the harness runs clean", while numeric parity is a measured score, not a merge gate.

No "smoke test" mislabel of the differential layer was found (README/test-strategy already call it a differential parity harness).

## Improvement plan (prioritised)

1. **(Top) Close the parity-gate gap.** The headline gap: numeric parity drift on the required checks is report-only. Promote a fail-on-parity gate to required — e.g. add a small CI step that reads `compat-score.json` and fails if `passed < total` (or a ratchet that fails on any *regression* from the published badge baseline). This is the cheapest high-value change: the data already exists in the report; only the exit-code wiring is missing. (Was downgraded deliberately in #503 to avoid flaky-diff churn — so the right shape is a ratchet/baseline, not a raw fail-on-any-diff, except for the forced-route lane which already proves byte-identity.)
2. **Raise TraceQL's numerical confidence (weakest leg).** Options, cheapest-first:
   - **(Recommended, cheapest high-value)** Derive cases from `tempo-vulture` — the differ is already patterned on it; lifting its generated query/trace shapes into the corpus widens coverage with little new code.
   - Expand the author-written TXTAR corpus by hand (linear effort, bounded breadth).
   - Add a property-test/oracle leg like PromQL/LogQL have (`test/property/`), generating random spans + a from-scratch TraceQL evaluator — highest confidence, highest cost.
3. **Surface the conformance numbers durably.** The badges exist; add a generated score doc (or expand the README badge block) so "574/574, no allow-list" is self-evidencing from a committed artifact, not prose that can drift.

## Status

**Left OPEN and un-armed** — no auto-merge. Launch framing / gate-promotion is the maintainer's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
