### PR TITLE
ci(compat): parity-regression ratchet gates required compat checks on a below-baseline drop

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -37,6 +37,19 @@ wrapper, plus `appendStepSummary` / `setOutput` for the runner files.
   - Env: `HEAD` (`prometheus`, `tempo`, or `loki`), `SCORE` (path to that
     head's `compat-score.json`).
   - Exit: always `0` (housekeeping; never gates).
+- **`compat-ratchet.mjs`** — `compatibility.yml`, the three
+  `Parity-regression ratchet` steps. The GATE that makes the required
+  `compatibility/{prometheus,loki,tempo}` checks fail on a numeric parity
+  regression (not just on infra breakage). Compares the run's
+  `compat-score.json` against the committed floor in
+  `compatibility/parity-baseline.json` and fails when `passed` or `total`
+  drops below baseline. Integer comparison only, so it can't flake. Not
+  an allow-list — pins the aggregate floor, never individual cases.
+  - Env: `HEAD` (`prometheus`, `tempo`, or `loki`), `SCORE` (path to that
+    head's `compat-score.json`), `BASELINE` (optional; default
+    `compatibility/parity-baseline.json`).
+  - Exit: `0` at or above baseline, `1` on a below-baseline regression or
+    a missing/malformed score or baseline.
 - **`resolve-bench-refs.mjs`** — `perf-benchmark.yml`, the
   `resolve baseline + ref SHAs` step.
   - Env: `INPUT_BASELINE_REF` (optional); writes `ref_sha`,

--- a/.github/scripts/compat-ratchet.mjs
+++ b/.github/scripts/compat-ratchet.mjs
@@ -1,0 +1,159 @@
+// compat-ratchet.mjs — parity-regression RATCHET for the required
+// compatibility/{prometheus,loki,tempo} checks.
+//
+// Background: PR #503 ("compat is informational", task #68) downgraded
+// per-case parity diffs to report-only — the three harnesses score
+// parity into compat-score.json and exit 0 even when parity drifts, so a
+// real numeric regression on the main route used to merge GREEN. This
+// script restores a GATE: it reads the run's compat-score.json for one
+// head and the committed per-head baseline, and FAILS the job when the
+// run drops below baseline. Noise WITHIN the baseline (a run that matches
+// or exceeds it) passes; only a real DROP gates.
+//
+// Why this can't flake: the three differs compare with absolute +
+// relative epsilon tolerance (1e-9) over canonical-key-sorted result
+// sets against a deterministic seed, so passed/total are stable run to
+// run (verified: three consecutive green main runs produced byte-
+// identical 574/574, 116/116, 48/48). The ratchet compares integers, not
+// floats — there is no float/timing/ordering surface left to jitter. It
+// is NOT an allow-list: it never names individual cases or excuses a real
+// failure; it only pins the aggregate floor and rejects any drop below
+// it. (Contrast the deleted expected-failures.json, which allow-listed
+// specific known-failing cases — that is exactly what this is not.)
+//
+// Two floors per head, both gating:
+//   - passed: a run with FEWER agreeing cases than baseline is a real
+//     regression -> fail.
+//   - total : a run whose corpus SHRANK below baseline is rejected ->
+//     fail, so a regression can't hide by silently dropping a failing
+//     case from the corpus (which would otherwise keep `passed` flat
+//     while parity actually got worse).
+//
+// Raising the floor: when the harness legitimately gains passing cases
+// or the corpus grows, BUMP the matching entry in
+// compatibility/parity-baseline.json in the same PR. The ratchet tells
+// you the exact new numbers in its pass log.
+//
+// Env contract:
+//   HEAD      head name: prometheus | loki | tempo (selects the baseline
+//             entry + labels the messages).
+//   SCORE     path to that head's compat-score.json (the run's score).
+//   BASELINE  path to the committed baseline JSON
+//             (default: compatibility/parity-baseline.json).
+//
+// Exit codes:
+//   0  run is at or above baseline on both floors (no regression).
+//   1  run dropped below baseline (regression), OR the baseline / score
+//      file is missing or malformed (a missing score means the harness
+//      never produced one — that is itself a hard failure the separate
+//      "Fail job" step also re-raises; failing here keeps the ratchet
+//      honest rather than silently passing on absent data).
+
+import { existsSync, readFileSync } from 'node:fs';
+import process from 'node:process';
+import { error, log, notice } from './lib/gh.mjs';
+
+const DEFAULT_BASELINE = 'compatibility/parity-baseline.json';
+
+const head = process.env.HEAD || '';
+const scorePath = process.env.SCORE || '';
+const baselinePath = process.env.BASELINE || DEFAULT_BASELINE;
+
+function fail(message, props) {
+  error(message, props);
+  process.exit(1);
+}
+
+if (!head) {
+  fail('compat-ratchet: HEAD env var is required (prometheus|loki|tempo)', {
+    title: 'compat ratchet misconfigured',
+  });
+}
+if (!scorePath) {
+  fail('compat-ratchet: SCORE env var (path to compat-score.json) is required', {
+    title: 'compat ratchet misconfigured',
+  });
+}
+
+function readJson(path, label) {
+  if (!existsSync(path)) {
+    fail(
+      `compat-ratchet: ${label} not found at ${path} — the harness must have ` +
+        `failed before producing it; cannot verify parity against baseline`,
+      { title: `compatibility/${head} ratchet: missing ${label}` },
+    );
+  }
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch (e) {
+    fail(`compat-ratchet: could not parse ${label} at ${path}: ${e.message}`, {
+      title: `compatibility/${head} ratchet: malformed ${label}`,
+    });
+  }
+  return undefined; // unreachable; fail() exits.
+}
+
+const baseline = readJson(baselinePath, 'baseline');
+const entry = baseline?.heads?.[head];
+if (!entry || typeof entry.passed !== 'number' || typeof entry.total !== 'number') {
+  fail(
+    `compat-ratchet: no baseline entry for head '${head}' in ${baselinePath} ` +
+      `(expected heads.${head}.{passed,total} as numbers)`,
+    { title: `compatibility/${head} ratchet: no baseline entry` },
+  );
+}
+
+const score = readJson(scorePath, 'compat-score.json');
+if (typeof score.passed !== 'number' || typeof score.total !== 'number') {
+  fail(
+    `compat-ratchet: ${scorePath} is missing numeric passed/total fields`,
+    { title: `compatibility/${head} ratchet: malformed score` },
+  );
+}
+
+const { passed: basePassed, total: baseTotal } = entry;
+const { passed: runPassed, total: runTotal } = score;
+
+const passedRegressed = runPassed < basePassed;
+const totalShrank = runTotal < baseTotal;
+
+if (passedRegressed || totalShrank) {
+  const lines = [`compatibility/${head} PARITY REGRESSION vs committed baseline:`];
+  if (passedRegressed) {
+    lines.push(
+      `  passing cases dropped: baseline ${basePassed}, this run ${runPassed} ` +
+        `(${basePassed - runPassed} case(s) that used to agree with the reference now diverge)`,
+    );
+  }
+  if (totalShrank) {
+    lines.push(
+      `  corpus shrank: baseline total ${baseTotal}, this run ${runTotal} ` +
+        `(a shrunk corpus can mask a regression by dropping a failing case — rejected)`,
+    );
+  }
+  lines.push(
+    `Fix the regression at the source (this is the source of truth for the ${head} head). ` +
+      `If the drop is a deliberate, documented corpus change, update ` +
+      `${baselinePath} (heads.${head}) in the same PR with the rationale — ` +
+      `but never to mask a real parity bug.`,
+  );
+  fail(lines.join('\n'), { title: `compatibility/${head} parity regression` });
+}
+
+// At or above baseline. If the run IMPROVED, nudge the maintainer to
+// raise the floor so the ratchet keeps tracking the new best.
+if (runPassed > basePassed || runTotal > baseTotal) {
+  notice(
+    `compatibility/${head} improved over baseline (baseline ${basePassed}/${baseTotal}, ` +
+      `this run ${runPassed}/${runTotal}). Bump heads.${head} in ${baselinePath} to ` +
+      `{ "passed": ${runPassed}, "total": ${runTotal} } to ratchet the floor up.`,
+    { title: `compatibility/${head} ratchet: floor can be raised` },
+  );
+} else {
+  log(
+    `compat-ratchet: compatibility/${head} at baseline ` +
+      `(${runPassed}/${runTotal} == ${basePassed}/${baseTotal}) — no regression.`,
+  );
+}
+
+process.exit(0);

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -292,6 +292,24 @@ jobs:
           HEAD: prometheus
           SCORE: compatibility/prometheus/compat-score.json
 
+      - name: Parity-regression ratchet
+        # GATE: this is what makes compatibility/prometheus a real
+        # source-of-truth check rather than an informational badge. PR
+        # #503 (task #68) downgraded per-case diffs to report-only so the
+        # harness exits 0 even on a numeric regression; this step restores
+        # the gate by failing the job when the run's compat-score.json
+        # drops below the committed per-head floor in
+        # compatibility/parity-baseline.json. It compares integers
+        # (passed/total), not floats, so it can't flake (see the script
+        # header). Runs only when the harness itself succeeded — a harness
+        # infra failure is re-raised by the "Fail job" step below, and the
+        # ratchet shouldn't double-report a missing score in that path.
+        if: steps.compat.outcome == 'success'
+        run: node .github/scripts/compat-ratchet.mjs
+        env:
+          HEAD: prometheus
+          SCORE: compatibility/prometheus/compat-score.json
+
       - name: Upload report
         if: always()
         uses: actions/upload-artifact@v7
@@ -590,13 +608,31 @@ jobs:
 
       - name: Run tempo-compatibility harness
         id: harness
-        env:
-          FAIL_ON_DIFF: "1"
+        # NOTE: the old `FAIL_ON_DIFF: "1"` env here was DEAD — PR #503
+        # deleted the `--fail-on-diff` flag from compatibility/tempo/
+        # driver/diff.go, so nothing in compatibility/tempo/ ever read
+        # this var (grep is clean). It gave a false sense that tempo
+        # parity was gated when it wasn't. The real gate is now the
+        # "Parity-regression ratchet" step below, which works uniformly
+        # across all three heads off compat-score.json. Removed to kill
+        # the dead signal.
         run: ./compatibility/tempo/scripts/run-tempo-compatibility.sh
 
       - name: Append score to step summary
         if: always()
         run: node .github/scripts/compat-step-summary.mjs
+        env:
+          HEAD: tempo
+          SCORE: compatibility/tempo/reports/compat-score.json
+
+      - name: Parity-regression ratchet
+        # GATE: see the prometheus job for the full rationale. Fails the
+        # job when tempo's compat-score.json drops below the committed
+        # floor in compatibility/parity-baseline.json (heads.tempo). This
+        # replaces the dead FAIL_ON_DIFF env removed from the harness step
+        # above — it is the actual tempo parity gate.
+        if: steps.harness.outcome == 'success'
+        run: node .github/scripts/compat-ratchet.mjs
         env:
           HEAD: tempo
           SCORE: compatibility/tempo/reports/compat-score.json
@@ -727,6 +763,16 @@ jobs:
       - name: Append score to step summary
         if: always()
         run: node .github/scripts/compat-step-summary.mjs
+        env:
+          HEAD: loki
+          SCORE: compatibility/loki/reports/compat-score.json
+
+      - name: Parity-regression ratchet
+        # GATE: see the prometheus job for the full rationale. Fails the
+        # job when loki's compat-score.json drops below the committed
+        # floor in compatibility/parity-baseline.json (heads.loki).
+        if: steps.harness.outcome == 'success'
+        run: node .github/scripts/compat-ratchet.mjs
         env:
           HEAD: loki
           SCORE: compatibility/loki/reports/compat-score.json

--- a/compatibility/parity-baseline.json
+++ b/compatibility/parity-baseline.json
@@ -1,0 +1,18 @@
+{
+  "_comment": "Parity-regression ratchet baseline. The required compatibility/{prometheus,loki,tempo} checks compare each run's compat-score.json against the matching entry here and FAIL the job when a run drops below baseline (a real numeric regression on the main route). Noise WITHIN the baseline is tolerated; only a DROP gates. This makes 'compat is the source of truth' a real gate, not just an informational badge. See .github/scripts/compat-ratchet.mjs + docs/compatibility.md.",
+  "_contract": "Per head: 'passed' is the floor of agreeing cases (a run with fewer passing cases regresses); 'total' is the corpus floor (a run whose corpus shrank below this is rejected, so a regression can't hide by dropping a failing case). RAISE these numbers in lock-step whenever the harness legitimately gains passing cases or the corpus grows — never lower them without a documented reason.",
+  "heads": {
+    "prometheus": {
+      "passed": 574,
+      "total": 574
+    },
+    "loki": {
+      "passed": 116,
+      "total": 116
+    },
+    "tempo": {
+      "passed": 48,
+      "total": 48
+    }
+  }
+}

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -15,15 +15,18 @@ numerical confidence is honestly lower (see
 [Per-head confidence](#per-head-confidence) below).
 
 > **What gates vs. what scores.** All three `compatibility/<head>` checks
-> run on every PR and are required, but they fail the check only on
-> **infrastructure breakage** — per-case parity drift is **report-only**
-> by design ([#503](https://github.com/tsouza/cerberus/pull/503)),
-> captured in the report + the live badge score, not in the check's exit
-> code. The one lane that hard-fails on any numeric parity diff is
-> `compatibility/prometheus-forced-route` (`FAIL_ON_DIFF=1`), which is
-> informational, not a required check. Treat the badges as a
-> continuously re-measured conformance score, not a merge gate on numeric
-> correctness. See [CI integration](#ci-integration).
+> run on every PR and are required. The *harness* is report-only on
+> per-case parity drift by design
+> ([#503](https://github.com/tsouza/cerberus/pull/503)) — drift is
+> captured in the report + the live badge score, not in the harness exit
+> code — but the required check also runs a **parity-regression ratchet**
+> that fails the job if the score drops below a committed per-head floor.
+> So the badges are a continuously re-measured conformance score, *and* a
+> drop below baseline is a merge gate: noise within the baseline is
+> tolerated, a real regression is not. The
+> `compatibility/prometheus-forced-route` lane additionally hard-fails on
+> *any* numeric parity diff (`FAIL_ON_DIFF=1`) but is informational, not a
+> required check. See [CI integration](#ci-integration).
 
 | Harness | Location                    | Reference backend                  | Corpus source                                                                                |
 | ------- | --------------------------- | ---------------------------------- | -------------------------------------------------------------------------------------------- |
@@ -267,28 +270,68 @@ Each harness job uploads its report as a workflow artifact (30-day
 retention). On push-to-main, the per-head pass-rate is appended to the
 orphan `compat-scores` branch so the README badges refresh.
 
-**Required, but report-only on parity.** All three `compatibility/<head>`
-checks are required status checks on `main`, but — per
-[#503](https://github.com/tsouza/cerberus/pull/503) — the required check
-fails only on **infrastructure** errors (compose-up, seed, build,
-unparseable report). Per-case numeric parity drift is captured in
-`report.json` + the badge and **does not** turn the required check red.
-Concretely: the PromQL run script is report-only by default and only
-hard-fails under `FAIL_ON_DIFF=1`
-(`compatibility/prometheus/scripts/run-compatibility.sh`); the LogQL
-driver removed its `os.Exit(1)`-on-diff
-(`compatibility/loki/cmd/loki-compliance-tester/main.go`); and the TraceQL
-differ is report-only by construction
-(`compatibility/tempo/driver/diff.go`) — it ignores the `FAIL_ON_DIFF`
-env the workflow passes it.
+**Required: scored, plus a regression ratchet.** All three
+`compatibility/<head>` checks are required status checks on `main`. The
+*harness* step itself is report-only on parity — per
+[#503](https://github.com/tsouza/cerberus/pull/503) it captures per-case
+numeric drift in `report.json` + the badge and exits 0, failing only on
+**infrastructure** errors (compose-up, seed, build, unparseable report).
+But the required job no longer passes on a numeric regression: a
+**parity-regression ratchet** step (next section) runs after the harness
+and fails the job when the run's score drops below the committed
+per-head floor. So the required check gates **both** infrastructure
+breakage **and** a parity *regression* — while still tolerating noise
+within the baseline, which is what #503 was protecting against.
 
-The single lane that **hard-fails on any parity diff** is
-`compatibility/prometheus-forced-route` (`FAIL_ON_DIFF=1`), the
-corpus-wide proof that the sharded solver route is byte-identical to
-reference Prometheus. It is intentionally an *informational* job, not a
-required check, so it doesn't gate every unrelated PR on the full
-forced-route corpus run. Closing this gap — promoting a fail-on-parity
-gate to required — is tracked as an improvement item.
+The `compatibility/prometheus-forced-route` lane additionally
+**hard-fails on any parity diff** (`FAIL_ON_DIFF=1` in
+`run-compatibility.sh`) as the corpus-wide proof that the sharded solver
+route is byte-identical to reference Prometheus; it is intentionally an
+*informational* job, not a required check, so it doesn't gate every
+unrelated PR on the full forced-route corpus run.
+
+### Parity-regression ratchet (the gate)
+
+The three differs are **scored** — they accumulate per-case results,
+write `compat-score.json`, and exit 0 even when a case diverges, so the
+harness step turns the job red only on infrastructure breakage (corpus
+load, compose-up, missing report). On its own that makes the score an
+informational badge, not a gate: a real numeric regression on the main
+route would merge green.
+
+The **parity-regression ratchet** closes that hole and makes
+"compatibility is the source of truth" a real gate. After each harness
+runs, `.github/scripts/compat-ratchet.mjs` reads the run's
+`compat-score.json` and the committed floor in
+`compatibility/parity-baseline.json`, and **fails the required job when
+the run drops below baseline** — either fewer passing cases (a real
+regression) or a corpus smaller than baseline (which could otherwise
+mask a regression by dropping a failing case). A run that matches or
+exceeds the floor passes; noise *within* the baseline is tolerated.
+
+The floors today (`heads.<name>.{passed,total}`):
+
+| head       | passed/total |
+| ---------- | ------------ |
+| prometheus | 574 / 574    |
+| loki       | 116 / 116    |
+| tempo      | 48 / 48      |
+
+This is **not** an allow-list and does not resurrect the deleted
+`expected-failures.json`: it never names an individual case or excuses a
+specific failure — it pins only the aggregate floor and rejects any drop
+below it. It cannot flake because the differs compare with
+absolute + relative epsilon tolerance over canonical-key-sorted result
+sets against a deterministic seed, so `passed`/`total` are stable run to
+run (verified: three consecutive green main runs produced byte-identical
+574/574, 116/116, 48/48); the ratchet then compares **integers**, with
+no float/timing/ordering surface left to jitter.
+
+When the harness legitimately gains passing cases or the corpus grows,
+**raise the matching floor** in `compatibility/parity-baseline.json` in
+the same PR — the ratchet's pass log prints the exact new numbers. Never
+*lower* a floor to make a real parity bug merge; fix the bug at the
+source instead.
 
 ## Adding new test cases
 


### PR DESCRIPTION
## What & why

The required `compatibility/{prometheus,loki,tempo}` checks **score** numeric parity (574/574 + badge) but are **report-only** — PR #503 deliberately downgraded per-case diffs to report-only, so they fail ONLY on infra breakage; a real numeric regression on the main route merges green. This wires a **baseline ratchet** so "compatibility is the source of truth" becomes a real gate for RC1, without re-introducing flaky-diff churn.

> ⚠️ **Leave OPEN for maintainer review — un-armed.** This reverses a deliberate #503 decision and changes required-check semantics.

## #503's actual rationale

#503 ("feat(compatibility): emit score JSON + downgrade per-case diffs from hard fail to report") was **not** a flakiness retreat. It was the deliberate "compat is informational" workstream (**task #68**): the three harnesses accumulate per-case results, write a shields.io `compat-score.json`, and **exit 0 even on parity drift** — only driver-wide HARD errors (corpus load, compose-up, missing/malformed report, scorer failure) escalate. The PR body states this explicitly; there is **no mention of non-deterministic / flaky / timing / float-ULP cases**. The downgrade was a policy choice to make the badge the signal, not an admission that the diffs can't be trusted.

Phase-1 confirmed the scores are in fact **deterministic**: the three differs compare with absolute + relative epsilon tolerance (`1e-9`) over canonical-key-sorted result sets against a fixed deterministic seed, so float/ordering jitter is already absorbed. Three consecutive green `main` runs produced **byte-identical** `passed`/`total` for all heads.

## Ratchet design — why it can't flake & isn't an allow-list

Because the scores are deterministic, the strongest + simplest shape applies: a **strict per-head floor**.

- `.github/scripts/compat-ratchet.mjs` reads the run's `compat-score.json` and the committed floor in `compatibility/parity-baseline.json`, and **fails the required job** when:
  - `passed` drops below baseline (a real regression — cases that used to agree now diverge), or
  - `total` shrinks below baseline (a smaller corpus could otherwise mask a regression by dropping a failing case).
- A run **at or above** the floor passes; noise *within* the baseline is tolerated.
- **Can't flake:** it compares **integers**, not floats — there is no timing/float/ordering surface left to jitter (the differs already absorbed it before the score was written).
- **Not an allow-list:** it never names an individual case or excuses a specific failure — it pins only the aggregate floor and rejects any drop below it. This is the opposite of the deleted `expected-failures.json` (which allow-listed specific known-failing cases). Raising the floor when parity legitimately improves is a documented, in-PR bump.

Wired as a `Parity-regression ratchet` step inside each of the three existing required jobs (gated on the harness step succeeding), so the **gate count stays the same** — no new required check.

## Committed baselines

Obtained from the latest green `main` compatibility run's score artifacts, cross-checked identical across three consecutive runs:

| head       | passed / total |
| ---------- | -------------- |
| prometheus | 574 / 574      |
| loki       | 116 / 116      |
| tempo      | 48 / 48        |

## Tempo dead-env fix

The tempo job ran `FAIL_ON_DIFF: "1"` on its harness step — but #503 **deleted** the `--fail-on-diff` flag from `compatibility/tempo/driver/diff.go`, so nothing in `compatibility/tempo/` ever read it (grep is clean). It was a dead signal implying tempo parity was gated when it wasn't. Removed; the ratchet is the real tempo gate now.

## Proof it gates (local)

`node .github/scripts/compat-ratchet.mjs` against the real baseline:

| scenario | score | result |
| --- | --- | --- |
| at baseline | 574/574 | exit **0** (no regression) |
| below baseline | 573/574 | exit **1** + `::error::` parity regression |
| corpus shrank | 570/570 | exit **1** + `::error::` (rejected) |
| above baseline | 575/575 | exit **0** + `::notice::` (raise the floor) |
| missing score | — | exit **1** + `::error::` |
| real loki artifact | 116/116 | exit **0** |
| real tempo artifact | 48/48 | exit **0** |

## Docs

`docs/compatibility.md` gains a "Parity-regression ratchet (the gate)" section; `.github/scripts/README.md` documents the new module + env contract. A sibling PR (#907) reframes the docs as "scored, not gated" — this change makes the final story **"scored + a regression ratchet gates a drop below baseline"**; the orchestrator reconciles any wording overlap.

## Constraints honored

actionlint + markdownlint clean; only `node:` builtins; env-driven; `::error::` + `process.exit(1)` on regression; named baseline file (no magic constants); no allow-list of real failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)