### PR TITLE
fix(preflight): treat unreachable ClickHouse as transient, not a fatal boot failure

### DIFF
--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -482,13 +482,15 @@ func setupSchema(
 // table that EXISTS but is WRONG-SHAPE) never self-heals, so the returned
 // error aggregates every such requirement and the caller exits non-zero —
 // the precise boot-time failure replaces the opaque query-time error a
-// too-old server or divergent schema would otherwise produce. A schema that
-// is ENTIRELY ABSENT (not yet provisioned) is TRANSIENT — the
-// cerberus+collector startup race — so it does NOT fail startup: the
-// returned health.SchemaPresentFunc reports NOT READY on /readyz with the
-// absent reason, and a background re-probe (reusing the auto-create retry
-// cadence) flips it ready once an external writer provisions the schema,
-// with no restart.
+// too-old server or divergent schema would otherwise produce. Two cases are
+// instead TRANSIENT and do NOT fail startup: a schema that is ENTIRELY ABSENT
+// (not yet provisioned — the cerberus+collector race), and a ClickHouse that
+// is ENTIRELY UNREACHABLE (a dial / connection-refused error — cerberus
+// booted ahead of the database). In both the returned
+// health.SchemaPresentFunc reports NOT READY on /readyz with a precise
+// reason, and a background re-probe (reusing the auto-create retry cadence)
+// flips it ready once the server appears and the schema is provisioned, with
+// no restart.
 //
 // When the check is disabled, both gates are bypassed (one log line) and a
 // nil SchemaPresentFunc is returned — readiness does not gate on the schema.
@@ -515,6 +517,22 @@ func runRequirementsCheck(
 		// some tables are also absent: a too-old server won't fix itself by
 		// waiting, and a wrong-shape table is a genuine misconfiguration.
 		return nil, res.Fatal
+	}
+
+	if res.Unreachable {
+		// Transient: ClickHouse is not accepting connections yet (cerberus
+		// booted ahead of the database). A dial / connection-refused error is
+		// NOT a misconfiguration and self-heals once the server appears, so
+		// boot but stay NOT READY; the same background re-probe that waits on
+		// an absent schema also waits out an unreachable server. No restart.
+		reason := res.UnreachableReason()
+		logger.Warn(
+			"clickhouse not reachable at startup; serving unready until it appears (/readyz gates traffic)",
+			"reason", reason,
+		)
+		present := newSchemaPresentSignal(reason)
+		go reprobeSchema(ctx, logger, client, req, present, schemaRetryInterval)
+		return present.Func(), nil
 	}
 
 	if !res.SchemaProvisioned() {
@@ -586,13 +604,15 @@ func (s *schemaPresentSignal) setReason(reason string) {
 }
 
 // reprobeSchema re-runs the requirements check on the auto-create retry
-// cadence until the configured schema is fully provisioned (or ctx is
-// cancelled). It only ever transitions a not-present schema to present: a
-// re-probe that turns up a FATAL finding (e.g. an external writer created a
-// wrong-shape table) is logged and retried rather than crashing a
-// already-serving process — the boot-time fail-fast contract covers the
-// cold-start case, and a running replica must not exit on a transient
-// introspection blip. Once present it flips readiness and returns.
+// cadence until the configured schema is fully provisioned AND ClickHouse is
+// reachable (or ctx is cancelled). It only ever transitions a not-present
+// schema to present: a re-probe that turns up a FATAL finding (e.g. an
+// external writer created a wrong-shape table) is logged and retried rather
+// than crashing an already-serving process — the boot-time fail-fast contract
+// covers the cold-start case, and a running replica must not exit on a
+// transient introspection blip. A still-unreachable server keeps the
+// unreachable reason fresh and waits. Once the schema is present it flips
+// readiness and returns.
 func reprobeSchema(
 	ctx context.Context,
 	logger *slog.Logger,
@@ -612,6 +632,11 @@ func reprobeSchema(
 		res := preflight.Run(ctx, client, req)
 		if res.Fatal != nil {
 			logger.Warn("schema re-probe found a fatal requirement; staying unready and retrying", "err", res.Fatal)
+			continue
+		}
+		if res.Unreachable {
+			// Still no ClickHouse: keep the unreachable reason fresh and wait.
+			signal.setReason(res.UnreachableReason())
 			continue
 		}
 		if !res.SchemaProvisioned() {

--- a/internal/preflight/preflight.go
+++ b/internal/preflight/preflight.go
@@ -33,20 +33,26 @@
 //     column, an attribute map typed something other than
 //     Map(String, String)). These never self-heal, so they fail startup
 //     fast with an aggregated diff (every unmet requirement at once).
-//   - TRANSIENT — the configured tables are ENTIRELY ABSENT (system.columns
-//     reports zero rows for them): the schema has not been provisioned yet.
-//     This does NOT fail startup; cerberus boots but reports NOT READY on
-//     /readyz with a precise reason, and an external re-probe flips it ready
-//     once the writer creates the schema — no restart.
+//   - TRANSIENT — either (a) the configured tables are ENTIRELY ABSENT
+//     (system.columns reports zero rows for them): the schema has not been
+//     provisioned yet; or (b) ClickHouse is ENTIRELY UNREACHABLE at boot
+//     (the version / introspection probes fail with a transport / dial /
+//     connection-refused error — cerberus started before ClickHouse
+//     accepted connections). Neither is a misconfiguration: both heal on
+//     their own. This does NOT fail startup; cerberus boots but reports NOT
+//     READY on /readyz with a precise reason, and an external re-probe flips
+//     it ready once the server appears (and the schema exists) — no restart.
 //
-// Run returns a Result that carries both buckets separately. The caller
-// turns the fatal bucket into a non-zero exit and feeds the absent bucket
-// into the readiness machinery.
+// Run returns a Result that carries the buckets separately. The caller
+// turns the fatal bucket into a non-zero exit and feeds the absent /
+// unreachable buckets into the readiness machinery.
 package preflight
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net"
 	"strconv"
 	"strings"
 
@@ -153,20 +159,46 @@ type Querier interface {
 //     non-empty AbsentTables with a nil Fatal is the transient "schema not
 //     yet provisioned" state: the caller boots NOT READY and re-probes
 //     rather than exiting.
+//   - Unreachable is set when a probe failed with a transport / dial /
+//     connection-refused error, i.e. ClickHouse is not yet accepting
+//     connections. Like AbsentTables this is transient (it self-heals once
+//     the server appears), so a Result with Unreachable set and a nil Fatal
+//     is the "boot ahead of ClickHouse" race: the caller boots NOT READY and
+//     re-probes rather than exiting. UnreachableErr carries the underlying
+//     transport error for the /readyz reason + logs.
 //
-// The two buckets are independent. A pass can report both (e.g. an old
-// server AND an absent table) — the Fatal bucket still wins (the caller
-// exits), because a too-old server never heals on its own.
+// The buckets are independent. A pass can report several (e.g. an old server
+// AND an absent table) — the Fatal bucket still wins (the caller exits),
+// because a too-old server never heals on its own. An unreachable server
+// short-circuits the shape gate (it cannot be introspected) so it never
+// coexists with a Fatal wrong-shape finding.
 type Result struct {
-	Fatal        error
-	AbsentTables []string
+	Fatal          error
+	AbsentTables   []string
+	Unreachable    bool
+	UnreachableErr error
 }
 
-// SchemaProvisioned reports whether no configured table is missing — i.e.
-// the schema is fully present (whatever its shape). The readiness wiring
-// consults this to decide whether to gate /readyz on a not-yet-provisioned
-// schema.
-func (r Result) SchemaProvisioned() bool { return len(r.AbsentTables) == 0 }
+// SchemaProvisioned reports whether the schema is fully present (whatever
+// its shape) AND ClickHouse was reachable enough to confirm it: no
+// configured table missing and no transport failure. The readiness wiring
+// consults this to decide whether to gate /readyz on a not-yet-ready
+// backend (an unreachable server can't have a confirmed-present schema).
+func (r Result) SchemaProvisioned() bool { return len(r.AbsentTables) == 0 && !r.Unreachable }
+
+// UnreachableReason renders a precise /readyz body reason for the
+// transport-failure case, e.g. "clickhouse not reachable: dial tcp
+// clickhouse:9000: connect: connection refused". Returns "" when the server
+// was reachable.
+func (r Result) UnreachableReason() string {
+	if !r.Unreachable {
+		return ""
+	}
+	if r.UnreachableErr != nil {
+		return fmt.Sprintf("clickhouse not reachable: %v", r.UnreachableErr)
+	}
+	return "clickhouse not reachable"
+}
 
 // AbsentReason renders the absent-tables list into a single precise reason
 // string for the /readyz body, e.g. "schema not yet provisioned: tables
@@ -201,11 +233,22 @@ func RunIfEnabled(ctx context.Context, enabled bool, q Querier, req Requirements
 // caller boot-but-wait on a not-yet-provisioned schema. Use RunIfEnabled
 // for the CERBERUS_REQUIREMENTS_CHECK gate.
 func Run(ctx context.Context, q Querier, req Requirements) Result {
-	var problems []string
-	problems = append(problems, checkVersion(ctx, q, req)...)
+	// Gate 1 (version) probes ClickHouse first. A transport failure here means
+	// the server isn't accepting connections yet — the boot-ahead-of-ClickHouse
+	// race. That's transient, not a misconfiguration, so short-circuit to an
+	// Unreachable Result rather than running the shape gate against a server
+	// that can't answer (and rather than mislabelling a dial error as fatal).
+	versionProblems, unreachable := checkVersion(ctx, q, req)
+	if unreachable != nil {
+		return Result{Unreachable: true, UnreachableErr: unreachable}
+	}
 
-	schemaProblems, absent := checkSchema(ctx, q, req)
-	problems = append(problems, schemaProblems...)
+	schemaProblems, absent, unreachable := checkSchema(ctx, q, req)
+	if unreachable != nil {
+		return Result{Unreachable: true, UnreachableErr: unreachable}
+	}
+
+	problems := append(versionProblems, schemaProblems...)
 
 	res := Result{AbsentTables: absent}
 	if len(problems) == 0 {
@@ -221,10 +264,64 @@ func Run(ctx context.Context, q Querier, req Requirements) Result {
 	return res
 }
 
+// isUnreachable reports whether err is a transport / connectivity failure
+// (ClickHouse not accepting connections yet) rather than a server-side
+// rejection. It prefers typed detection — a *net.OpError (dial / read / write
+// at the socket layer, e.g. connect: connection refused, no route to host)
+// or any net.Error reporting a timeout — over string matching, since the
+// clickhouse-go/v2 driver returns the raw dial error through its connection
+// acquire path (the chclient stage-prefix wrappers use %w, preserving the
+// chain). The named broad-substring fallback below only catches transport
+// failures the driver might wrap opaquely enough to defeat errors.As; it is
+// deliberately narrow to transport phrasing so a server-side error (a too-old
+// version rejection, a wrong-shape introspection result) never matches.
+func isUnreachable(err error) bool {
+	if err == nil {
+		return false
+	}
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		return true
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+	return matchesTransportPhrase(err)
+}
+
+// transportPhrases are the lower-cased substrings that mark a connectivity
+// failure when the driver wraps the underlying error opaquely enough that
+// errors.As on *net.OpError / net.Error no longer reaches it. Kept narrow to
+// transport vocabulary so a server-side rejection never trips it.
+var transportPhrases = []string{
+	"connection refused",
+	"connection reset",
+	"no route to host",
+	"network is unreachable",
+	"no such host",
+	"i/o timeout",
+	"dial tcp",
+}
+
+// matchesTransportPhrase is the string-matching fallback for isUnreachable.
+func matchesTransportPhrase(err error) bool {
+	msg := strings.ToLower(err.Error())
+	for _, p := range transportPhrases {
+		if strings.Contains(msg, p) {
+			return true
+		}
+	}
+	return false
+}
+
 // checkVersion runs gate 1: it reads version() and compares the parsed
-// major.minor against the effective floor. An unreadable or unparseable
-// version is itself a failure (never a silent pass).
-func checkVersion(ctx context.Context, q Querier, req Requirements) []string {
+// major.minor against the effective floor. A TRANSPORT error (ClickHouse not
+// reachable) is returned as the second value so the caller short-circuits to
+// the transient Unreachable state; an unreadable-but-reachable response
+// (server-side query error, empty result, or unparseable / too-old version)
+// is a fatal problem (never a silent pass).
+func checkVersion(ctx context.Context, q Querier, req Requirements) (problems []string, unreachable error) {
 	min := req.minVersion()
 	rateNote := "native rate disabled"
 	if req.NativeRateEnabled {
@@ -234,20 +331,23 @@ func checkVersion(ctx context.Context, q Querier, req Requirements) []string {
 	sql, args := chsql.NewQuery().Select(chsql.Call("version")).Build()
 	rows, err := q.QueryStrings(ctx, sql, args...)
 	if err != nil {
-		return []string{fmt.Sprintf("could not read clickhouse version: %v", err)}
+		if isUnreachable(err) {
+			return nil, err
+		}
+		return []string{fmt.Sprintf("could not read clickhouse version: %v", err)}, nil
 	}
 	if len(rows) == 0 {
-		return []string{"clickhouse version query returned no rows"}
+		return []string{"clickhouse version query returned no rows"}, nil
 	}
 	raw := strings.TrimSpace(rows[0])
 	got, ok := parseCHVersion(raw)
 	if !ok {
-		return []string{fmt.Sprintf("clickhouse version %q is unparseable; required minimum %s (%s)", raw, min, rateNote)}
+		return []string{fmt.Sprintf("clickhouse version %q is unparseable; required minimum %s (%s)", raw, min, rateNote)}, nil
 	}
 	if !got.atLeast(min) {
-		return []string{fmt.Sprintf("clickhouse version %s is below the required minimum %s (%s)", raw, min, rateNote)}
+		return []string{fmt.Sprintf("clickhouse version %s is below the required minimum %s (%s)", raw, min, rateNote)}, nil
 	}
-	return nil
+	return nil, nil
 }
 
 // parseCHVersion extracts the leading major.minor from a ClickHouse
@@ -386,20 +486,27 @@ func nonEmpty(vals ...string) []string {
 // zero rows for, i.e. not yet provisioned. An entirely-absent table is
 // transient (the schema race), so it lands in the second slice and is NOT
 // a wrong-shape problem; a table that exists but has the wrong columns is.
-func checkSchema(ctx context.Context, q Querier, req Requirements) (problems, absent []string) {
+func checkSchema(ctx context.Context, q Querier, req Requirements) (problems, absent []string, unreachable error) {
 	seen := map[string]bool{}
 	for _, t := range requiredTables(req) {
 		if t.name == "" || seen[t.name] {
 			continue
 		}
 		seen[t.name] = true
-		probs, isAbsent := checkTable(ctx, q, req.Database, t)
+		probs, isAbsent, unreach := checkTable(ctx, q, req.Database, t)
+		if unreach != nil {
+			// A transport failure mid-introspection means the server dropped
+			// (or never came up): abandon the shape gate and report unreachable
+			// so the caller waits rather than recording a half-introspected
+			// schema as wrong-shape.
+			return nil, nil, unreach
+		}
 		problems = append(problems, probs...)
 		if isAbsent {
 			absent = append(absent, t.name)
 		}
 	}
-	return problems, absent
+	return problems, absent, nil
 }
 
 // checkTable introspects one table via system.columns and validates its
@@ -408,11 +515,15 @@ func checkSchema(ctx context.Context, q Querier, req Requirements) (problems, ab
 //   - A table that reports ZERO columns is treated as absent (not yet
 //     provisioned): absent=true, no wrong-shape problem. The caller turns
 //     this into a transient NOT-READY state, not a boot failure.
-//   - A query error is itself fatal (it is not a clean "table missing"
-//     signal — the introspection failed) and is reported as a problem.
+//   - A TRANSPORT error (ClickHouse unreachable) is returned via the third
+//     value so the caller short-circuits to the transient Unreachable state —
+//     a dial failure is not a clean "table missing" signal, but it is just as
+//     transient as an absent table.
+//   - A non-transport query error is fatal (the introspection failed against
+//     a reachable server) and is reported as a problem.
 //   - Otherwise each missing column and each wrong attribute-map type is
 //     reported individually so the aggregated message is complete.
-func checkTable(ctx context.Context, q Querier, database string, t tableReq) (problems []string, absent bool) {
+func checkTable(ctx context.Context, q Querier, database string, t tableReq) (problems []string, absent bool, unreachable error) {
 	sql, args := chsql.NewQuery().
 		Select(chsql.Col("name"), chsql.Col("type")).
 		From(chsql.Qual("system", "columns")).
@@ -423,13 +534,16 @@ func checkTable(ctx context.Context, q Querier, database string, t tableReq) (pr
 		Build()
 	rows, err := q.QueryNameTypePairs(ctx, sql, args...)
 	if err != nil {
-		return []string{fmt.Sprintf("could not introspect table %s: %v", t.name, err)}, false
+		if isUnreachable(err) {
+			return nil, false, err
+		}
+		return []string{fmt.Sprintf("could not introspect table %s: %v", t.name, err)}, false, nil
 	}
 	if len(rows) == 0 {
 		// Entirely absent: the schema has not been provisioned yet. This is
 		// the transient startup race, not a misconfiguration — surface it as
 		// absent so the caller waits (NOT READY) rather than exiting.
-		return nil, true
+		return nil, true, nil
 	}
 
 	types := make(map[string]string, len(rows))
@@ -457,7 +571,7 @@ func checkTable(ctx context.Context, q Querier, database string, t tableReq) (pr
 			))
 		}
 	}
-	return problems, false
+	return problems, false, nil
 }
 
 // normalizeType canonicalises a ClickHouse type string for comparison:

--- a/internal/preflight/preflight_test.go
+++ b/internal/preflight/preflight_test.go
@@ -3,12 +3,31 @@ package preflight
 import (
 	"context"
 	"errors"
+	"fmt"
+	"net"
+	"os"
 	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/tsouza/cerberus/internal/chclient"
 	"github.com/tsouza/cerberus/internal/schema"
 )
+
+// dialRefusedErr mimics the error the clickhouse-go/v2 driver surfaces when
+// ClickHouse is not accepting connections yet: a *net.OpError wrapping an
+// ECONNREFUSED syscall, then wrapped again under the chclient stage prefix
+// (preserved via %w, exactly as client.go does). isUnreachable must see
+// through both wrappers via errors.As.
+func dialRefusedErr() error {
+	opErr := &net.OpError{
+		Op:   "dial",
+		Net:  "tcp",
+		Addr: &net.TCPAddr{IP: net.IPv4(10, 0, 0, 5), Port: 9000},
+		Err:  os.NewSyscallError("connect", syscall.ECONNREFUSED),
+	}
+	return fmt.Errorf("chclient: query: %w", opErr)
+}
 
 // stubQuerier is the in-memory ClickHouse stub the preflight tests drive.
 // It answers the version() scalar from Version (or VersionErr) and the
@@ -282,10 +301,14 @@ func TestRunUnparseableVersionFails(t *testing.T) {
 
 func TestRunVersionQueryErrorFails(t *testing.T) {
 	t.Parallel()
-	q := &stubQuerier{VersionErr: errors.New("connection refused"), Columns: healthyColumns()}
+	// A reachable server that rejects the version query server-side (NOT a
+	// transport error) is still fatal — the check ran but couldn't read the
+	// version. A connection-refused / dial error is the transient case,
+	// covered separately by TestRunUnreachableVersionIsTransient.
+	q := &stubQuerier{VersionErr: errors.New("code 241: memory limit exceeded"), Columns: healthyColumns()}
 	err := Run(context.Background(), q, defaultReq()).Fatal
 	if err == nil {
-		t.Fatal("version query error must fail startup")
+		t.Fatal("server-side version query error must fail startup")
 	}
 	if !strings.Contains(err.Error(), "could not read clickhouse version") {
 		t.Errorf("message missing version-read note: %v", err)
@@ -448,7 +471,11 @@ func TestRunWrongShapeFatalEvenIfOtherTableAbsent(t *testing.T) {
 // the same signal as a cleanly-absent table.
 func TestRunIntrospectionErrorIsFatal(t *testing.T) {
 	t.Parallel()
-	q := &stubQuerier{Version: "25.8.2.1", ColumnsErr: errors.New("read timeout")}
+	// A server-side introspection rejection (NOT a transport error) is fatal —
+	// the check ran against a reachable server but couldn't read the columns.
+	// A dial / connection-refused error is transient, covered by
+	// TestRunUnreachableTableIsTransient.
+	q := &stubQuerier{Version: "25.8.2.1", ColumnsErr: errors.New("code 60: unknown table")}
 	res := Run(context.Background(), q, defaultReq())
 	if res.Fatal == nil {
 		t.Fatal("introspection query error must be fatal")
@@ -555,4 +582,95 @@ func (c *countingQuerier) QueryNameTypePairs(ctx context.Context, sql string, ar
 		}
 	}
 	return c.stubQuerier.QueryNameTypePairs(ctx, sql, args...)
+}
+
+// assertTransient is the shared assertion for the unreachable cases: the
+// Result must be transient (not fatal, not provisioned), carry the
+// Unreachable flag, and render a precise not-reachable reason.
+func assertTransient(t *testing.T, res Result) {
+	t.Helper()
+	if res.Fatal != nil {
+		t.Fatalf("unreachable ClickHouse must NOT be fatal (transient boot race), got: %v", res.Fatal)
+	}
+	if !res.Unreachable {
+		t.Fatal("unreachable ClickHouse must set Result.Unreachable")
+	}
+	if res.SchemaProvisioned() {
+		t.Fatal("unreachable ClickHouse must report schema NOT provisioned")
+	}
+	reason := res.UnreachableReason()
+	if !strings.Contains(reason, "clickhouse not reachable") {
+		t.Errorf("UnreachableReason = %q, want a precise not-reachable reason", reason)
+	}
+}
+
+// TestRunUnreachableVersionIsTransient: a connection-refused / dial error on
+// the version probe means ClickHouse hasn't come up yet — the residual sibling
+// of the absent-schema race. It must be TRANSIENT (Unreachable), never fatal,
+// so the pod boots NOT READY and re-probes instead of crash-looping.
+func TestRunUnreachableVersionIsTransient(t *testing.T) {
+	t.Parallel()
+	q := &stubQuerier{VersionErr: dialRefusedErr(), Columns: healthyColumns()}
+	assertTransient(t, Run(context.Background(), q, defaultReq()))
+}
+
+// TestRunUnreachableTableIsTransient: the version probe succeeds but the
+// server drops before the schema gate, so introspection fails with a dial
+// error. That too is transient — abandon the shape gate and wait, don't crash.
+func TestRunUnreachableTableIsTransient(t *testing.T) {
+	t.Parallel()
+	q := &stubQuerier{Version: "25.8.2.1", ColumnsErr: dialRefusedErr()}
+	assertTransient(t, Run(context.Background(), q, defaultReq()))
+}
+
+// TestRunUnreachableVersionShortCircuitsShapeGate: an unreachable server on
+// the version probe must NOT then run (and fail) the shape gate — the Result
+// carries only the Unreachable signal, no wrong-shape fatal even though the
+// columns would diverge.
+func TestRunUnreachableVersionShortCircuitsShapeGate(t *testing.T) {
+	t.Parallel()
+	q := &stubQuerier{VersionErr: dialRefusedErr(), ColumnsErr: errors.New("code 60: unknown table")}
+	res := Run(context.Background(), q, defaultReq())
+	assertTransient(t, res)
+	if res.Fatal != nil {
+		t.Fatalf("unreachable on version probe must short-circuit the shape gate, got fatal: %v", res.Fatal)
+	}
+}
+
+// TestRunUnreachableSubstringFallback: when the driver wraps the dial failure
+// opaquely (a plain error whose message carries transport vocabulary but no
+// *net.OpError in the chain), the named substring fallback still classifies it
+// transient.
+func TestRunUnreachableSubstringFallback(t *testing.T) {
+	t.Parallel()
+	q := &stubQuerier{
+		VersionErr: errors.New("chclient: query: dial tcp clickhouse:9000: connect: connection refused"),
+		Columns:    healthyColumns(),
+	}
+	assertTransient(t, Run(context.Background(), q, defaultReq()))
+}
+
+// TestIsUnreachableClassification pins the typed vs server-side split that the
+// fatal/transient routing depends on.
+func TestIsUnreachableClassification(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"typed-dial-refused", dialRefusedErr(), true},
+		{"net-timeout", &net.OpError{Op: "read", Net: "tcp", Err: os.ErrDeadlineExceeded}, true},
+		{"substring-no-route", errors.New("dial tcp: no route to host"), true},
+		{"substring-conn-reset", errors.New("read: connection reset by peer"), true},
+		{"server-side-memory", errors.New("code 241: memory limit exceeded"), false},
+		{"server-side-unknown-table", errors.New("code 60: unknown table"), false},
+		{"too-old-shape-text", errors.New("table otel_logs: missing required column Body"), false},
+	}
+	for _, tc := range cases {
+		if got := isUnreachable(tc.err); got != tc.want {
+			t.Errorf("isUnreachable(%s) = %v, want %v", tc.name, got, tc.want)
+		}
+	}
 }


### PR DESCRIPTION
## Problem

When cerberus boots **before** ClickHouse is accepting connections, the boot-time requirements preflight crash-loops. Both gates — `checkVersion` (gate 1) and `checkTable` (gate 2) — treated **any** query error as a fatal `problem`:

```
ERROR cerberus exited with error err="requirements check failed:
  - could not read clickhouse version: chclient: query: dial tcp ...: connect: connection refused
  - could not introspect table otel_metrics_gauge: chclient: query: dial tcp ...: connect: connection refused"
```

`main` exits non-zero → Kubernetes `CrashLoopBackOff` → the e2e **`dashboard`** job's **"Assert zero cerberus restarts"** step (`.github/workflows/e2e.yml`) sees `restartCount>0` and fails. This made the `dashboard` job red on recent `main` runs.

## Why this is the residual sibling of #900

PR #900 routed a *provisioned-but-ABSENT* schema (system.columns returns zero rows) to a transient path: serve **NOT READY** on `/readyz`, re-probe in the background, **do not exit**. But it left a *fully UNREACHABLE* ClickHouse on the **fatal** path. An unreachable server self-heals once it comes up — exactly like an absent schema — so it belongs on the same transient path. This PR extends #900's path to cover the transport-error case.

## The fix

- New `isUnreachable` helper classifies a transport / dial / connection-refused error as **transient**. Detection is **typed-first**: `errors.As` on `*net.OpError` (and a `net.Error` timeout), which sees through the `chclient: query: %w` stage-prefix wrappers since clickhouse-go/v2 returns the raw dial error through its connection-acquire path. A **named broad-substring fallback** (`transportPhrases`) catches driver errors wrapped opaquely enough to defeat `errors.As` — deliberately narrow to transport vocabulary (`connection refused`, `dial tcp`, `no route to host`, …) so a server-side rejection never trips it.
- An unreachable version probe **short-circuits the shape gate** (an unreachable server can't be introspected) and surfaces a new `Result.Unreachable` + `UnreachableReason()`. `runRequirementsCheck` routes it through the **same** NOT-READY / background re-probe branch #900 used; `reprobeSchema` keeps the unreachable reason fresh until the server appears.
- **VERSION-too-old and WRONG-SHAPE stay FATAL** (fail-fast). A server-side (non-transport) version/introspection error also stays fatal.

## Tests

New unit tests in `internal/preflight/preflight_test.go`:
- connection-refused (`*net.OpError` ECONNREFUSED) on the **version** probe → transient
- same on the **table** probe → transient
- unreachable on version probe **short-circuits** the shape gate (no wrong-shape fatal)
- the **substring fallback** path
- old-version → still **fatal**
- wrong-shape → still **fatal**
- absent-but-reachable schema → still **transient** (#900)
- an `isUnreachable` typed-vs-server-side classification table

`go test ./internal/preflight/... ./cmd/cerberus/...` is green; `go vet` + `gofumpt -extra` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)