### PR TITLE
fix(chaos): re-seed ClickHouse after pod-kill so downstream scenarios see data

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -62,8 +62,10 @@ wrapper, plus `appendStepSummary` / `setOutput` for the runner files.
   contracts (circuit breaker, per-query wall-clock timeout, admission
   control, replica resilience) hold under real faults. Phase-1 scenarios
   run sequentially with heal-between-each; metric corroboration is read
-  back through cerberus's own Prom head (settle poll). INFORMATIONAL —
-  never a PR gate.
+  back through cerberus's own Prom head (settle poll). After a
+  CH-destructive scenario (which recreates CH empty on ephemeral storage),
+  the heal gate shells out to `just e2e-reseed` to repopulate ClickHouse
+  before the next scenario asserts. INFORMATIONAL — never a PR gate.
   - Env: `CERBERUS_URL` (default `http://localhost:8080`), `CHAOS_NS`
     (default `cerberus`), `CHAOS_PHASE` (`phase-1` | `all`, default
     `phase-1`), `CHAOS_SCENARIOS` (comma list to run a subset),

--- a/.github/scripts/chaos-run.mjs
+++ b/.github/scripts/chaos-run.mjs
@@ -61,6 +61,28 @@ const METRIC_SETTLE_DEADLINE_MS = 90_000; // OTLP flush lag before self-metrics 
 const POLL_INTERVAL_MS = 2_000;
 const SETTLE_INTERVAL_MS = 3_000;
 
+// cerberus_ch_breaker_state gauge encoding — mirrors the breakerGauge* consts
+// in internal/chclient/breaker_metrics.go (closed=0, open=1, half-open=2). The
+// chaos asserts key on CLOSED (0) as the only correct steady state for a
+// breaker-neutral fault; the labels make a failure message read truthfully
+// (a bare "got 2" misleads — 2 is HALF-OPEN, not a fresh trip).
+const BREAKER_STATE_CLOSED = 0;
+const BREAKER_STATE_OPEN = 1;
+const BREAKER_STATE_HALF_OPEN = 2;
+
+function breakerStateName(v) {
+  switch (v) {
+    case BREAKER_STATE_CLOSED:
+      return 'CLOSED';
+    case BREAKER_STATE_OPEN:
+      return 'OPEN';
+    case BREAKER_STATE_HALF_OPEN:
+      return 'HALF-OPEN';
+    default:
+      return `unknown(${v})`;
+  }
+}
+
 // ---- deliberately-expensive query (slow-query / admit-saturation) ----
 //
 // Both the ch-slow-query-timeout and load-admit-saturation scenarios need a
@@ -389,10 +411,10 @@ async function scenarioChPodKill() {
     log(`    cerberus_ch_breaker_trips_total == ${tripsSeen === null ? '(absent; OTLP lag / ephemeral-CH wipe, tolerated — trip already asserted via 503)' : tripsSeen}`);
   }
   const state = await queryBreakerMetric('cerberus_ch_breaker_state');
-  if (state !== null && state !== 0) {
-    failures.push(`cerberus_ch_breaker_state should be 0 (CLOSED) after recovery; got ${state}`);
+  if (state !== null && state !== BREAKER_STATE_CLOSED) {
+    failures.push(`cerberus_ch_breaker_state should be ${BREAKER_STATE_CLOSED} (CLOSED) after recovery; got ${state} (${breakerStateName(state)})`);
   } else {
-    log(`    cerberus_ch_breaker_state == ${state === null ? '(pending, tolerated)' : state}`);
+    log(`    cerberus_ch_breaker_state == ${state === null ? '(pending, tolerated)' : `${state} (${breakerStateName(state)})`}`);
   }
 
   // CH outage must NEVER restart cerberus.
@@ -812,10 +834,18 @@ async function scenarioLoadAdmitSaturation() {
     log('    cerberus_admit_rejected_total >= 1');
   }
   const stateAfter = await queryBreakerMetric('cerberus_ch_breaker_state');
-  if (stateAfter !== null && stateAfter !== 0) {
-    failures.push(`cerberus_ch_breaker_state should stay 0 under admit saturation (admit/pool rejections are breaker-neutral); got ${stateAfter}`);
+  if (stateAfter !== null && stateAfter !== BREAKER_STATE_CLOSED) {
+    // The gauge encodes closed=0 / open=1 / half-open=2 (breaker_metrics.go).
+    // Admit/pool rejections shed at the admission layer and never reach the
+    // breaker, so the only correct steady state here is CLOSED (0). A 2
+    // (HALF-OPEN) or 1 (OPEN) would mean a saturation shed leaked into the
+    // breaker — name the observed state so a future failure reads truthfully
+    // instead of the misleading bare "got 2".
+    failures.push(
+      `cerberus_ch_breaker_state must stay ${BREAKER_STATE_CLOSED} (CLOSED) under admit saturation — admit/pool rejections are breaker-neutral; got ${stateAfter} (${breakerStateName(stateAfter)})`,
+    );
   } else {
-    log(`    cerberus_ch_breaker_state == ${stateAfter === null ? `(pending; baseline ${baselineState})` : stateAfter} (breaker CLOSED)`);
+    log(`    cerberus_ch_breaker_state == ${stateAfter === null ? `(pending; baseline ${baselineState})` : `${stateAfter} (${breakerStateName(stateAfter)})`} (breaker CLOSED)`);
   }
 
   // After load drops, all heads 200.
@@ -847,13 +877,26 @@ async function endOfRunHealthGate() {
 
 // ---- scenario registry + driver --------------------------------------
 
+// `wipesCh: true` marks a scenario that destroys the ClickHouse pod. Because
+// CH runs `strategy: Recreate` on container-ephemeral storage
+// (test/e2e/k3s/clickhouse.yaml), the pod comes back EMPTY — every seeded
+// table is gone. The heal gate after such a scenario must RE-SEED before the
+// next scenario asserts, otherwise downstream queries hit `code:60 Unknown
+// table … otel_*`. The rolling seeder (e2e-seed-rolling) cannot do this: its
+// long-lived port-forward is bound to the killed pod and never reconnects, so
+// it writes into a dead socket for the rest of the run. The heal step issues a
+// one-shot `just e2e-reseed` through a FRESH port-forward instead.
 const PHASE1 = [
-  { name: 'ch-pod-kill', run: scenarioChPodKill },
+  { name: 'ch-pod-kill', run: scenarioChPodKill, wipesCh: true },
   { name: 'ch-slow-query-timeout', run: scenarioChSlowTimeout },
   { name: 'cerberus-pod-kill', run: scenarioCerberusPodKill },
 ];
 
 const PHASE2 = [
+  // ch-network-partition only blackholes egress with a NetworkPolicy; it never
+  // deletes the CH pod, so CH data survives — no re-seed needed after it. (On
+  // the k3d image where kube-router does not enforce NetworkPolicy this
+  // scenario records not-applicable; see scenarioChNetworkPartition.)
   { name: 'ch-network-partition', run: scenarioChNetworkPartition },
   { name: 'load-admit-saturation', run: scenarioLoadAdmitSaturation },
 ];
@@ -889,23 +932,75 @@ async function preflight() {
 }
 
 // healBetweenScenarios re-establishes the green-stack precondition each
-// scenario assumes. The lane is sequential and a CH-outage scenario tears CH
-// down (Recreate + ephemeral storage), so the NEXT scenario must not start
-// until /readyz + all heads are green again AND the data plane has had a
-// settle window for the rolling re-seed + OTLP re-export to repopulate the
-// freshly-recreated CH — otherwise a still-recovering stack from the prior
+// scenario assumes. The lane is sequential and a CH-destructive scenario tears
+// CH down (Recreate + ephemeral storage), so the NEXT scenario must not start
+// until /readyz + all heads are green again AND the data plane has been
+// REPOPULATED — otherwise a still-recovering or EMPTY stack from the prior
 // fault masquerades as the next scenario's failure (e.g. cerberus-pod-kill's
-// aggregate-success loop running while CH is mid-re-DDL). This implements the
-// heal-between-each-scenario invariant the lane's header documents.
-const HEAL_SETTLE_MS = 15_000; // rolling re-seed cadence (~30s) + OTLP flush headroom
-async function healBetweenScenarios(nextName) {
+// aggregate-success loop running while CH is empty, or ch-slow-query's nested
+// subquery 502'ing on a missing `otel_metrics_histogram` table). This
+// implements the heal-between-each-scenario invariant the lane's header
+// documents.
+//
+// CH recreates EMPTY (container-ephemeral storage), and the rolling seeder
+// cannot refill it: its long-lived port-forward died with the killed pod and
+// never reconnects. So after a `wipesCh` scenario the heal gate RE-SEEDS via a
+// one-shot `just e2e-reseed` (fresh port-forward, idempotent DDL + INSERTs),
+// then waits for the seeded fixtures to be visible through the Prom head
+// before clearing the gate. After a non-destructive scenario, CH data
+// survives and only a short settle window is needed.
+const HEAL_SETTLE_MS = 15_000; // OTLP flush headroom for a non-destructive scenario
+const RESEED_DEADLINE_MS = 120_000; // bound the `just e2e-reseed` one-shot (DDL + INSERTs + verify)
+const RESEED_VISIBLE_DEADLINE_MS = 90_000; // wait for the re-seeded `up` series to read back via the Prom head
+
+// reseedClickHouse runs the one-shot re-seed recipe (fresh port-forward,
+// idempotent DDL + fixture INSERTs + rowcount verify). Returns true on a
+// clean exit; logs + returns false otherwise. Bounded so a hung port-forward
+// can't stall the lane past its budget.
+function reseedClickHouse() {
+  log('  heal: re-seeding freshly-recreated (empty) ClickHouse via `just e2e-reseed`...');
+  const res = capture('just', ['e2e-reseed'], { timeout: RESEED_DEADLINE_MS });
+  if (res.stdout) log(res.stdout.trimEnd());
+  if (res.status !== 0) {
+    if (res.stderr) log(res.stderr.trimEnd());
+    return false;
+  }
+  return true;
+}
+
+async function healBetweenScenarios(nextName, priorScenario) {
   log(`heal gate: waiting for the stack to return green before scenario ${nextName}...`);
   const green = await assertStackGreen(CH_RECOVERY_DEADLINE_MS);
   if (!green) {
     return `heal gate before ${nextName}: stack did not return to /readyz 200 + all heads 200 within the recovery budget after the prior scenario`;
   }
-  // A short data-plane settle so the next scenario sees repopulated CH, not
-  // an empty freshly-recreated one (heads can be 200 on an empty table).
+
+  if (priorScenario && priorScenario.wipesCh) {
+    // CH came back empty — re-seed it before the next scenario asserts.
+    if (!reseedClickHouse()) {
+      return `heal gate before ${nextName}: re-seed of the recreated ClickHouse failed; downstream scenarios would query empty tables`;
+    }
+    // Confirm the seeded data is actually queryable through the Prom head
+    // before clearing the gate (heads can be 200 on an empty table, so a
+    // bare assertHeadsHealthy is not enough — assert the `up` series is back).
+    const visible = await pollUntil(
+      async () => {
+        const r = await httpGet('/api/v1/query?query=up');
+        if (r.status !== 200) return false;
+        const result = jsonField(r.body, 'data')?.result;
+        return Array.isArray(result) && result.length > 0;
+      },
+      { deadlineMs: RESEED_VISIBLE_DEADLINE_MS, label: 're-seed-visible' },
+    );
+    if (!visible) {
+      return `heal gate before ${nextName}: re-seeded data did not become queryable (\`up\` series absent) within budget after CH recreation`;
+    }
+    log('heal gate: ClickHouse re-seeded + data visible through the Prom head');
+    return null;
+  }
+
+  // Non-destructive prior scenario: CH data survived. A short data-plane
+  // settle absorbs OTLP flush lag before the next scenario asserts.
   await sleep(HEAL_SETTLE_MS);
   log('heal gate: stack green + settled');
   return null;
@@ -927,12 +1022,15 @@ async function main() {
     const s = scenarios[i];
     // Between scenarios (not before the first — preflight already gated it),
     // re-establish the green-stack precondition each scenario assumes. A
-    // prior CH-outage scenario leaves CH freshly recreated (ephemeral) and
-    // re-seeding; starting the next scenario on that still-recovering stack
-    // is what turned ch-pod-kill's CH wipe into ch-slow-query / cerberus-pod-
-    // kill failures (a 502 fast-query, a 72% aggregate-success loop).
+    // prior CH-DESTRUCTIVE scenario leaves CH freshly recreated (ephemeral)
+    // and EMPTY — the heal gate re-seeds it (the rolling seeder's tunnel died
+    // with the killed pod). Without the re-seed, ch-pod-kill's CH wipe turned
+    // into ch-slow-query / cerberus-pod-kill failures (a 502 fast-query, a
+    // sub-floor aggregate-success loop) because every later query hit empty
+    // tables. Pass the PRIOR scenario so the heal gate knows whether to
+    // re-seed.
     if (i > 0) {
-      const healFail = await healBetweenScenarios(s.name);
+      const healFail = await healBetweenScenarios(s.name, scenarios[i - 1]);
       if (healFail) {
         error(healFail);
         failed.push(`heal-gate-before-${s.name}`);

--- a/.github/scripts/lib/gh.mjs
+++ b/.github/scripts/lib/gh.mjs
@@ -73,7 +73,9 @@ export function log(line = '') {
 
 // capture() — run a command, return { status, stdout, stderr }. Never
 // throws on a non-zero exit; the caller decides what a failure means.
-// `input` (Buffer|string) is fed to stdin when provided.
+// `input` (Buffer|string) is fed to stdin when provided. `timeout` (ms), when
+// set, bounds the run — spawnSync kills the child past the deadline and sets
+// res.error, which we surface as a non-zero { status }.
 export function capture(cmd, args, opts = {}) {
   const res = spawnSync(cmd, args, {
     encoding: opts.encoding === undefined ? 'utf8' : opts.encoding,
@@ -81,9 +83,11 @@ export function capture(cmd, args, opts = {}) {
     input: opts.input,
     cwd: opts.cwd,
     env: opts.env ?? process.env,
+    timeout: opts.timeout,
+    killSignal: opts.killSignal,
   });
   if (res.error) {
-    return { status: 127, stdout: '', stderr: String(res.error.message) };
+    return { status: 127, stdout: res.stdout ?? '', stderr: String(res.error.message) };
   }
   return {
     status: res.status === null ? 1 : res.status,

--- a/Justfile
+++ b/Justfile
@@ -505,6 +505,40 @@ e2e-seed:
             go run ./test/e2e/seed/cmd/seed
     @echo "==> seed done"
 
+# One-shot RE-seed through a fresh, self-contained port-forward — used by the
+# chaos lane's heal step after a CH-destructive scenario recreates ClickHouse
+# EMPTY (test/e2e/k3s/clickhouse.yaml: `strategy: Recreate`, no volumes ⇒
+# container-ephemeral storage). The rolling seeder's long-lived port-forward
+# (`e2e-seed-rolling`) is bound to a single backing pod, so `ch-pod-kill`
+# breaks that tunnel and it never reconnects — the rolling seeder then writes
+# into a dead socket for the rest of the run and CH stays empty, so every
+# downstream scenario fails with `code:60 Unknown table … otel_*`. This recipe
+# stands up its OWN throwaway forward on a DISTINCT local port (so it never
+# races the rolling forward's 19000 socket), re-applies the idempotent
+# OTel-CH DDL, re-inserts every fixture, verifies the rowcounts, and tears the
+# forward down — exactly the one-shot the seeder already performs on boot, so
+# a freshly-recreated empty CH is repopulated before the next scenario asserts.
+# Idempotent + re-runnable: the seeder's DDL is CREATE … IF NOT EXISTS and the
+# INSERTs re-anchor on now64(9), so running it against either an empty or an
+# already-populated CH is safe.
+#
+# One-shot re-seed of a recreated (empty) ClickHouse for the chaos heal step.
+e2e-reseed:
+    @echo "==> re-seeding OTel data (one-shot, fresh port-forward) after CH recreation"
+    @kubectl -n cerberus port-forward svc/clickhouse 19001:9000 > /tmp/cerberus-e2e-reseed-pf.log 2>&1 & \
+        pf_pid=$!; \
+        trap "kill $pf_pid 2>/dev/null || true" EXIT; \
+        for i in 1 2 3 4 5 6 7 8 9 10; do \
+            if nc -z 127.0.0.1 19001 2>/dev/null; then break; fi; \
+            sleep 1; \
+        done; \
+        CH_ADDR=127.0.0.1:19001 \
+        CH_DATABASE=otel \
+        CH_USERNAME=cerberus \
+        CH_PASSWORD=cerberus \
+            go run ./test/e2e/seed/cmd/seed
+    @echo "==> re-seed done"
+
 # Rolling seeder. Performs the same INSERTs as `e2e-seed` and then stays
 # alive, re-anchoring the metric/log windows on now64(9) every 30 s until
 # stopped via `just e2e-seed-stop` (or SIGTERM). Replaces the static-window


### PR DESCRIPTION
## Problem

The `chaos` lane went red after #911 with a cascade of `code:60 Unknown table … otel_metrics_histogram` / `Table otel.otel_traces does not exist` failures — six red line-items spanning ch-slow-query (502), cerberus-pod-kill (sub-floor aggregate success), and heal-gate failures. A deep diagnosis confirmed this is a **test-harness bug, not a cerberus production bug**: the breaker / admit / pool are all correct per contract.

## Root cause

The rolling seeder (`just e2e-seed-rolling`, `Justfile`) writes OTel fixtures to ClickHouse through a single long-lived host tunnel:

```
kubectl port-forward svc/clickhouse 19000:9000
```

A **Service** port-forward binds to **one backing pod**. The `ch-pod-kill` scenario (`chaos-run.mjs`) deletes the CH pod, so the tunnel breaks — and a Service port-forward **never reconnects** to the replacement pod. CH recreates **EMPTY** (`test/e2e/k3s/clickhouse.yaml`: `strategy: Recreate`, no volumes ⇒ container-ephemeral storage). The rolling seeder then writes into a dead socket for the rest of the run, so ClickHouse stays empty and every scenario after the first CH wipe queries missing tables. One wipe → the whole downstream cascade.

The heal gate's old 15s settle window assumed the rolling re-seed would repopulate CH — but it can't, because the tunnel is dead.

## Fix — re-seed in the heal step (approach (a))

Contained to the chaos lane, directly matches the failure (CH comes back empty), and doesn't depend on the broken rolling tunnel:

- **`just e2e-reseed`** — a one-shot re-seed through its **own fresh** port-forward on a **distinct local port** (`19001`, so it never races the rolling forward's `19000` socket). It re-applies the idempotent OTel-CH DDL (`CREATE … IF NOT EXISTS`, guaranteed by `internal/schema/ddl/idempotency_test.go`), re-inserts every fixture (re-anchored on `now64(9)`), verifies rowcounts, and tears the forward down — exactly the one-shot the seeder already runs on boot.
- **`chaos-run.mjs`** — CH-destructive scenarios are tagged `wipesCh`. `healBetweenScenarios()` now re-seeds after such a scenario and **waits for the `up` series to read back through the Prom head** before clearing the gate (heads can be 200 on an empty table, so a bare health check is not enough). Non-destructive scenarios keep the short settle window.

This restores the lane invariant: **after any CH-destructive scenario, CH is repopulated before the next scenario's asserts run.** Scenario assertion strength is unchanged — the goal is to let the *real* assertions pass honestly against populated CH.

## Assertion-label fix

The admit-saturation breaker-state check reported `should stay 0 … got 2`, implying `2 = OPEN`. But the gauge encodes `closed=0 / open=1 / half-open=2` (`internal/chclient/breaker_metrics.go`). Added named `BREAKER_STATE_*` constants + a `breakerStateName()` helper so a failure reads truthfully (`got 2 (HALF-OPEN)`, not a fresh trip). The same truthful labelling is applied to the ch-pod-kill recovery check. **The contract is unchanged**: the breaker must be CLOSED under admit saturation (admit/pool rejections shed before they reach the breaker — correct cerberus behavior).

## Out of scope (left as-is)

`ch-network-partition` keeps its honest not-applicable recording on the k3d image where kube-router does not enforce NetworkPolicy; a one-line coverage-gap note was added. It never deletes the CH pod, so it needs no re-seed.

## Verification

- `node --check` clean on `chaos-run.mjs` + `lib/gh.mjs`.
- `just --show e2e-reseed` / `just --list` parse the new recipe (its shell uses the same single-`$` patterns as the proven `e2e-seed`).
- Confirmed the seeder DDL is idempotent (`IF NOT EXISTS` + dedicated idempotency test) and the INSERTs re-anchor on `now64(9)`, so `e2e-reseed` is safe to re-run.
- Cannot run the live k3d chaos job locally, and chaos does **not** run on `pull_request` — so this needs a `workflow_dispatch` run of `e2e.yml` on this branch to verify end-to-end. Auto-merge is intentionally **NOT** enabled (the #911 lesson: chaos changes can't be PR-verified).

No cerberus production code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)