### PR TITLE
ci(e2e): shard the crawl BFS frontier across dashboard k3d shards

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -112,25 +112,51 @@ wrapper, plus `appendStepSummary` / `setOutput` for the runner files.
 - **`dashboard-matrix.mjs`** — `e2e.yml`, the `dashboard-setup` job. The k3d
   twin of `compose-smoke-matrix.mjs`: single source of truth for how the
   `dashboard` (k3d) lane fans its Playwright spec set across a MODEST matrix
-  (3) of isolated-k3d-cluster shards. The dominant cost is the crawl BFS — one
-  indivisible async `test()`, the ~50min long pole — so the parallelism is
-  COARSE: two smoke shards (non-crawl specs, `CRAWL_STACK` unset → `crawl/**`
-  ignored) run CONCURRENTLY with a DEDICATED crawl shard (`CRAWL_STACK=k3d`,
-  `SWEEP_DEPTH=full`). Splitting the crawl frontier itself is the follow-up.
-  The `SHARDS` partition (each carrying `specs` + `crawlStack` + `runGoE2E`) +
-  `EXCLUDED` list live in this module; specs are DISCOVERED (`git ls-files`) so
-  a new `*.spec.ts` is a hard failure unless assigned or excluded — no silent
-  no-run. Coverage assertion is collect-all-violations (unassigned,
-  double-assigned, phantom/stale, bad-shard-name, and the "exactly one shard
-  runs Go e2e" invariant), then `exit 1`. `dashboard-matrix.test.mjs` is the
+  of isolated-k3d-cluster shards. Two smoke shards (non-crawl specs,
+  `CRAWL_STACK` unset → `crawl/**` ignored) run CONCURRENTLY with
+  `CRAWL_SUB_SHARDS` (2) dedicated crawl shards (`CRAWL_STACK=k3d`,
+  `SWEEP_DEPTH=full`), each carrying a distinct `CRAWL_SHARD_INDEX` /
+  `CRAWL_SHARD_COUNT`. The crawl engine (`crawl/sharding.ts`) has every
+  sub-shard run the WHOLE cheap BFS discovery but audit + pin only the ~1/N of
+  surfaces it OWNS (the heavy interaction sweep), so the ~50min BFS long pole
+  drops toward ~50/N. The crawl trio is REPLICATED across the crawl sub-shards
+  (same specs, distinct index) — the coverage check treats that as one logical
+  assignment, and a crawl spec leaking onto a smoke shard is a hard failure.
+  The `SHARDS` partition (each carrying `specs` + `crawlStack` + `runGoE2E` +
+  `crawlShardIndex`/`crawlShardCount`) + `EXCLUDED` list live in this module;
+  specs are DISCOVERED (`git ls-files`) so a new `*.spec.ts` is a hard failure
+  unless assigned or excluded — no silent no-run. Coverage assertion is
+  collect-all-violations (unassigned, double-assigned, phantom/stale,
+  bad-shard-name, the crawl-replication leak, and the "exactly one shard runs
+  Go e2e" invariant), then `exit 1`. `dashboard-matrix.test.mjs` is the
   `node --test` guard (run on the cheap `gate` lane) pinning the invariant +
-  proving the detectors fire. k3d is heavy + flaky, so the shard count is kept
-  deliberately small.
+  proving the detectors fire. k3d is heavy + flaky, so the cluster count is
+  kept deliberately small.
   - Env: `MODE` (`verify` | `emit`; also `argv[2]`; default `verify`),
     `PLAYWRIGHT_DIR` (default `test/e2e/playwright`), `GITHUB_OUTPUT` (emit:
-    the runner file the `{include:[{name,specs,crawlStack,runGoE2E}]}` matrix
-    JSON is written to).
+    the runner file the
+    `{include:[{name,specs,crawlStack,runGoE2E,crawlShardIndex,crawlShardCount}]}`
+    matrix JSON + the `crawl_shard_count` output are written to).
   - Exit: `0` clean / matrix emitted, `1` on any coverage violation or bad
+    `MODE`.
+
+- **`crawl-inventory-merge.mjs`** — `e2e.yml`, the `dashboard-merge` job (only
+  on the `update_crawl_inventory=true` dispatch). Unions the per-shard crawl
+  surface SLICES the sharded BFS crawl emits (`grafana-surface-slice.<stack>.
+  shard-<i>.json`) into ONE full inventory, asserting an EXACT, DISJOINT, TOTAL
+  cover — a surface missing from every slice (discovery gap), a surface owned
+  by two shards (non-disjoint), a missing shard index, or a slice smuggling in
+  a surface the deterministic assignment doesn't map to it all `::error::` +
+  `exit 1`. This is the coverage guarantee that keeps frontier-sharding from
+  weakening the inventory ratchet. Mirrors
+  `crawl/sharding.ts:mergeShardSlices` (same FNV-1a hash, path-only ownership
+  key, disjoint-union rules) — the two are kept in lockstep, pinned by
+  `crawl-inventory-merge.test.mjs` (run on the cheap `gate` lane).
+  - Env: `MODE` (`merge` | `verify`; also `argv[2]`; default `merge`),
+    `SLICES_DIR` (dir of downloaded slice JSONs), `STACK` (e.g. `k3d`),
+    `INVENTORY_DOC` (the `doc` header for the merged inventory), `INVENTORY_OUT`
+    (merge: the inventory path to write).
+  - Exit: `0` clean / inventory written, `1` on any partition violation or bad
     `MODE`.
 
 ## Notes

--- a/.github/scripts/crawl-inventory-merge.mjs
+++ b/.github/scripts/crawl-inventory-merge.mjs
@@ -1,0 +1,228 @@
+// crawl-inventory-merge.mjs — union-merge the per-shard crawl surface
+// slices emitted by the sharded BFS frontier crawl (e2e.yml dashboard
+// lane) into ONE full surface inventory, asserting the union is an
+// EXACT, DISJOINT cover.
+//
+// Why this exists
+// ---------------
+// crawl/crawl.spec.ts is one async BFS test(); the only way below its
+// full-depth wall-clock floor is to shard the frontier (see
+// test/e2e/playwright/crawl/sharding.ts). Each shard runs the WHOLE
+// cheap discovery walk but only audits + pins the ~1/N of surfaces it
+// OWNS (fnv1a(path) % CRAWL_SHARD_COUNT == CRAWL_SHARD_INDEX). On the
+// bootstrap/regen dispatch (update_crawl_inventory=true) every shard
+// writes its owned slice as an artifact; this script downloads them all,
+// unions them, and writes the full inventory — IDENTICAL to what a
+// single full crawl would pin (the single-shard run owns everything, so
+// its one slice IS the full inventory).
+//
+// THE COVERAGE GUARANTEE lives in the assertions: a surface missing from
+// every slice (a discovery gap), a surface owned by two shards (a
+// non-disjoint partition), a missing shard slice, or a slice that
+// smuggles in a surface the deterministic assignment doesn't map to it,
+// all `::error::` + exit 1. The merge can never silently drop or double
+// a surface.
+//
+// This mirrors test/e2e/playwright/crawl/sharding.ts:mergeShardSlices
+// (the TS the spec runs); the two are kept in lockstep — the same FNV-1a
+// hash, the same path-only ownership key, the same disjoint-union rules.
+// The unit guard (crawl-inventory-merge.test.mjs) pins that lockstep on
+// a sample partition.
+//
+// Modes (env MODE or argv[2]; default `merge`):
+//   - merge  : read every $SLICES_DIR/grafana-surface-slice.<stack>.shard-*.json,
+//              union + assert, write $INVENTORY_OUT (the canonical
+//              marshalled inventory, byte-for-byte the spec's
+//              marshalInventory output). exit 1 on any partition
+//              violation.
+//   - verify : run the same assertions over the slices without writing —
+//              for a dry CI check.
+//
+// Env:
+//   MODE          `merge` | `verify`; default `merge`.
+//   SLICES_DIR    dir holding the downloaded per-shard slice JSONs.
+//   STACK         stack name the slices + inventory pin (e.g. `k3d`).
+//   INVENTORY_DOC the `doc` header to write into the merged inventory.
+//   INVENTORY_OUT (merge) path to write the full inventory to.
+//
+// node: builtins only (via lib/gh.mjs) — no npm deps, no setup-node.
+
+import process from 'node:process';
+import { readFileSync, writeFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { error, notice, log } from './lib/gh.mjs';
+
+// FNV-1a 32-bit — MUST match sharding.ts fnv1a32 exactly so this script
+// agrees with the spec on who owns what.
+const FNV_OFFSET_BASIS_32 = 0x811c9dc5;
+const FNV_PRIME_32 = 0x01000193;
+
+export function fnv1a32(s) {
+  let h = FNV_OFFSET_BASIS_32;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, FNV_PRIME_32) >>> 0;
+  }
+  return h >>> 0;
+}
+
+// PATH-only ownership key — strip the `#<state>` suffix AND the `?<query>`
+// so a surface, its structural-param children, and its in-place states
+// all hash to one shard. MUST match sharding.ts baseSurfaceOf.
+export function baseSurfaceOf(stateKey) {
+  const noState = stateKey.split('#', 1)[0] ?? stateKey;
+  return noState.split('?', 1)[0] ?? noState;
+}
+
+export function ownsSurface(stateKey, index, count) {
+  if (count === 1) return true;
+  return fnv1a32(baseSurfaceOf(stateKey)) % count === index;
+}
+
+// Canonical inventory marshalling — MUST be byte-for-byte identical to
+// sharding/lib.ts marshalInventory so the committed file and the
+// merge-written file agree (the spec asserts the committed inventory
+// round-trips through the marshaller).
+export function marshalInventory(inv) {
+  const surfaces = [...inv.surfaces].sort((a, b) => a.url.localeCompare(b.url));
+  return `${JSON.stringify({ doc: inv.doc, stack: inv.stack, surfaces }, null, 2)}\n`;
+}
+
+// collectViolations() — pure: returns a string[] of partition violations
+// (empty == a clean, total, disjoint cover). Collect-then-fail so a
+// maintainer sees every problem in one run.
+export function collectViolations(slices) {
+  const v = [];
+  if (slices.length === 0) {
+    v.push('no shard slices supplied');
+    return v;
+  }
+  const count = slices[0].shardCount;
+  if (!Number.isInteger(count) || count < 1) {
+    v.push(`first slice declares a bad shardCount ${JSON.stringify(count)}`);
+    return v;
+  }
+
+  const seen = new Map();
+  for (const s of slices) {
+    if (s.shardCount !== count) {
+      v.push(`slice (index ${s.shardIndex}) declares shardCount ${s.shardCount}, expected ${count} — inconsistent CRAWL_SHARD_COUNT`);
+    }
+    if (!Number.isInteger(s.shardIndex) || s.shardIndex < 0 || s.shardIndex >= count) {
+      v.push(`slice declares shardIndex ${s.shardIndex} out of range [0, ${count})`);
+      continue;
+    }
+    if (seen.has(s.shardIndex)) {
+      v.push(`shard index ${s.shardIndex} appeared twice`);
+    }
+    seen.set(s.shardIndex, s);
+  }
+  for (let i = 0; i < count; i++) {
+    if (!seen.has(i)) {
+      v.push(`missing slice for shard index ${i} of ${count} — every shard must upload its slice or the union is incomplete (coverage gap)`);
+    }
+  }
+
+  const byUrl = new Map();
+  for (const s of slices) {
+    for (const surface of s.surfaces || []) {
+      if (byUrl.has(surface.url)) {
+        v.push(`surface ${JSON.stringify(surface.url)} owned by more than one shard — the partition is not disjoint`);
+        continue;
+      }
+      if (!ownsSurface(surface.url, s.shardIndex, count)) {
+        v.push(`shard ${s.shardIndex} claims surface ${JSON.stringify(surface.url)} that the deterministic assignment does NOT map to it`);
+      }
+      byUrl.set(surface.url, surface);
+    }
+  }
+  return v;
+}
+
+// mergeShardSlices() — assert + union into a full inventory.
+export function mergeShardSlices(slices, doc, stack) {
+  for (const s of slices) {
+    if (s.stack !== stack) {
+      throw new Error(`slice (index ${s.shardIndex}) pins stack ${JSON.stringify(s.stack)} but the merge target stack is ${JSON.stringify(stack)}`);
+    }
+  }
+  const v = collectViolations(slices);
+  if (v.length > 0) {
+    const err = new Error(`partition violations:\n  - ${v.join('\n  - ')}`);
+    err.violations = v;
+    throw err;
+  }
+  const byUrl = new Map();
+  for (const s of slices) {
+    for (const surface of s.surfaces || []) byUrl.set(surface.url, surface);
+  }
+  const surfaces = [...byUrl.values()].sort((a, b) => a.url.localeCompare(b.url));
+  return { doc, stack, surfaces };
+}
+
+const SLICE_PREFIX = 'grafana-surface-slice.';
+
+function loadSlices(dir, stack) {
+  const want = `${SLICE_PREFIX}${stack}.shard-`;
+  const files = readdirSync(dir).filter(
+    (f) => f.startsWith(want) && f.endsWith('.json'),
+  );
+  if (files.length === 0) {
+    error(`crawl-inventory-merge: no slice files matching ${want}*.json under ${dir}`);
+    process.exit(1);
+  }
+  return files.map((f) => {
+    const parsed = JSON.parse(readFileSync(join(dir, f), 'utf8'));
+    if (!Array.isArray(parsed.surfaces)) {
+      error(`crawl-inventory-merge: ${f} has no surfaces[] array`);
+      process.exit(1);
+    }
+    return parsed;
+  });
+}
+
+function run(mode) {
+  const dir = process.env.SLICES_DIR;
+  const stack = process.env.STACK;
+  if (!dir || !stack) {
+    error('crawl-inventory-merge: SLICES_DIR and STACK are required');
+    process.exit(1);
+  }
+  const slices = loadSlices(dir, stack);
+  let inv;
+  try {
+    inv = mergeShardSlices(slices, process.env.INVENTORY_DOC || '', stack);
+  } catch (e) {
+    for (const m of e.violations || [String(e.message)]) {
+      error(`crawl-inventory-merge: ${m}`, { title: 'crawl shard partition violation' });
+    }
+    error(`crawl-inventory-merge: the shard slices are not a clean, disjoint, total cover — fix the crawl shard run, never relax the merge`);
+    process.exit(1);
+  }
+  notice(
+    `crawl-inventory-merge: merged ${slices.length} shard slice(s) into ${inv.surfaces.length} surface(s) for stack ${stack}.`,
+  );
+  if (mode === 'merge') {
+    const out = process.env.INVENTORY_OUT;
+    if (!out) {
+      error('crawl-inventory-merge: INVENTORY_OUT is required in merge mode');
+      process.exit(1);
+    }
+    writeFileSync(out, marshalInventory(inv));
+    log(`crawl-inventory-merge: wrote ${out}`);
+  }
+  process.exit(0);
+}
+
+const invokedDirectly =
+  process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href;
+if (invokedDirectly) {
+  const mode = (process.env.MODE || process.argv[2] || 'merge').toLowerCase();
+  if (mode === 'merge' || mode === 'verify') run(mode);
+  else {
+    error(`crawl-inventory-merge: unknown MODE "${mode}" (want merge|verify)`);
+    process.exit(1);
+  }
+}
+
+export { SLICE_PREFIX };

--- a/.github/scripts/crawl-inventory-merge.test.mjs
+++ b/.github/scripts/crawl-inventory-merge.test.mjs
@@ -1,0 +1,139 @@
+// crawl-inventory-merge.test.mjs — node:test guard for the crawl shard
+// slice union-merge's coverage invariant (the partition guarantee).
+//
+// Runs on the cheap gate lane (`node --test .github/scripts/*.test.mjs`)
+// — no setup-node, no k3d, no deps. Proves the merge is an EXACT,
+// DISJOINT, TOTAL cover and that its assertions actually fire.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  fnv1a32,
+  baseSurfaceOf,
+  ownsSurface,
+  collectViolations,
+  mergeShardSlices,
+} from './crawl-inventory-merge.mjs';
+
+// The same key cross-section the spec's sharding pins use — bare
+// surfaces, dashboards, structural-param surfaces, parameterized
+// families, in-place states.
+const SAMPLE_KEYS = [
+  '/',
+  '/dashboards',
+  '/explore',
+  '/d/cerberus-self',
+  '/d/clickhouse',
+  '/a/grafana-exploretraces-app/explore',
+  '/a/grafana-exploretraces-app/explore?var-groupBy=kind',
+  '/a/grafana-exploretraces-app/explore?actionView=comparison&var-groupBy=kind',
+  '/a/grafana-metricsdrilldown-app/drilldown?metric={metric}',
+  '/a/grafana-lokiexplore-app/explore/service/{service}/logs',
+  '/a/grafana-lokiexplore-app/explore/service/{service}/logs?visualizationType="table"',
+  '/a/grafana-exploretraces-app/explore#var-metric={rep}',
+  '/d/cerberus-self#tab=overview',
+];
+
+const sliceFor = (index, count, keys = SAMPLE_KEYS) => ({
+  stack: 'k3d',
+  shardIndex: index,
+  shardCount: count,
+  surfaces: keys
+    .filter((k) => ownsSurface(k, index, count))
+    .map((url) => ({ url, lean: false })),
+});
+
+test('fnv1a32 is deterministic and unsigned (lockstep anchor with sharding.ts)', () => {
+  // A fixed vector — if this changes, the .mjs and .ts hashes diverged.
+  assert.equal(fnv1a32(''), 0x811c9dc5);
+  assert.equal(fnv1a32('a'), 0xe40c292c);
+  assert.equal(fnv1a32('/'), fnv1a32('/'));
+  assert.ok(fnv1a32('/dashboards') >= 0);
+});
+
+test('baseSurfaceOf strips both the query and the state suffix to the bare path', () => {
+  assert.equal(baseSurfaceOf('/a/x/explore?var-groupBy=kind'), '/a/x/explore');
+  assert.equal(baseSurfaceOf('/a/x/explore#var-metric={rep}'), '/a/x/explore');
+  assert.equal(
+    baseSurfaceOf('/a/x/explore?actionView=comparison#k=v'),
+    '/a/x/explore',
+  );
+  assert.equal(baseSurfaceOf('/d/abc'), '/d/abc');
+});
+
+test('a surface + its structural-param children + in-place states co-locate on one shard', () => {
+  const path = '/a/grafana-exploretraces-app/explore';
+  const family = [
+    path,
+    `${path}?var-groupBy=kind`,
+    `${path}?actionView=comparison&var-groupBy=kind`,
+    `${path}#var-metric={rep}`,
+  ];
+  for (const count of [2, 3, 4]) {
+    for (let index = 0; index < count; index++) {
+      const owned = family.map((k) => ownsSurface(k, index, count));
+      assert.ok(
+        owned.every((v) => v === owned[0]),
+        `family not co-located at ${count}/${index}`,
+      );
+    }
+  }
+});
+
+test('the partition is total, disjoint, deterministic over the sample set', () => {
+  for (const count of [1, 2, 3, 4, 5]) {
+    for (const k of SAMPLE_KEYS) {
+      const owners = [];
+      for (let index = 0; index < count; index++) {
+        if (ownsSurface(k, index, count)) owners.push(index);
+      }
+      assert.equal(owners.length, 1, `${k} owned by ${owners.length} shards at count ${count}`);
+    }
+  }
+});
+
+test('mergeShardSlices: the union of owned slices is the EXACT full set, disjoint', () => {
+  const count = 3;
+  const slices = Array.from({ length: count }, (_, i) => sliceFor(i, count));
+  const merged = mergeShardSlices(slices, 'doc', 'k3d');
+  assert.deepEqual(
+    new Set(merged.surfaces.map((s) => s.url)),
+    new Set(SAMPLE_KEYS),
+  );
+  assert.equal(merged.surfaces.length, SAMPLE_KEYS.length, 'no duplicates');
+  assert.equal(merged.stack, 'k3d');
+  assert.equal(merged.doc, 'doc');
+});
+
+test('collectViolations flags a missing shard slice (coverage gap)', () => {
+  const v = collectViolations([sliceFor(0, 2)]);
+  assert.ok(v.some((m) => m.includes('missing slice for shard index 1')), v.join('\n'));
+});
+
+test('collectViolations flags a double-owned surface (not disjoint)', () => {
+  const count = 2;
+  const a = sliceFor(0, count);
+  const b = sliceFor(1, count);
+  const dupUrl = a.surfaces[0].url;
+  b.surfaces.push({ url: dupUrl, lean: false });
+  const v = collectViolations([a, b]);
+  assert.ok(
+    v.some((m) => m.includes('owned by more than one shard') || m.includes('does NOT map to it')),
+    v.join('\n'),
+  );
+});
+
+test('collectViolations flags a smuggled surface (assignment mismatch)', () => {
+  const count = 2;
+  const notMine = SAMPLE_KEYS.find((k) => !ownsSurface(k, 0, count));
+  const a = { stack: 'k3d', shardIndex: 0, shardCount: count, surfaces: [{ url: notMine, lean: false }] };
+  const b = sliceFor(1, count);
+  const v = collectViolations([a, b]);
+  assert.ok(v.some((m) => m.includes('does NOT map to it')), v.join('\n'));
+});
+
+test('mergeShardSlices rejects a stack mismatch', () => {
+  const slices = [sliceFor(0, 1)];
+  assert.throws(() => mergeShardSlices(slices, 'doc', 'compose'), /merge target stack/);
+});

--- a/.github/scripts/dashboard-matrix.mjs
+++ b/.github/scripts/dashboard-matrix.mjs
@@ -23,22 +23,25 @@
 // instead of serially after them. Wall-clock drops from
 // (smoke serial + crawl) toward max(crawl ~50min, slowest smoke shard).
 //
-// What this manifest does NOT do (the follow-up): it does not split the crawl
-// BFS frontier itself. Beating the ~50min floor needs the crawl engine to
-// PARTITION its discovered frontier across shards (a CRAWL_SHARD_INDEX /
-// CRAWL_SHARD_COUNT contract that deterministically assigns each discovered
-// surface to a shard, with each shard emitting its visited slice and a final
-// job merging + asserting the union against the pinned inventory). That is a
-// deep change to the 1383-line BFS + the inventory ratchet (lib.ts diffInventory
-// asserts the WHOLE visited set) and is blocked today by the k3d inventory being
-// unbootstrapped (grafana-surface-inventory.k3d.json carries surfaces: []), so
-// the union couldn't be validated. It is tracked as the explicit next step in
-// the PR body. This manifest is the safe, coarse win that lands first.
+// What this manifest DOES with the crawl (the frontier split): it fans the
+// crawl trio across CRAWL_SUB_SHARDS dedicated k3d clusters, each a matrix entry
+// carrying a CRAWL_SHARD_INDEX / CRAWL_SHARD_COUNT pair. The crawl engine
+// (test/e2e/playwright/crawl/sharding.ts) has every shard run the WHOLE cheap
+// BFS discovery walk but audit + pin only the ~1/N of surfaces it OWNS
+// (fnv1a(path) % COUNT == INDEX) — the heavy per-surface interaction sweep is
+// the dominant cost, so splitting it drops the ~50min long pole toward ~50/N.
+// On the bootstrap/regen dispatch each sub-shard writes its owned slice as an
+// artifact and a final merge job (crawl-inventory-merge.mjs) unions them into
+// the full inventory, asserting an exact disjoint cover (no surface missed, none
+// doubled). The per-shard inventory ratchet (lib.ts diffInventory, scoped to the
+// shard's owned rows) plus that union-merge together preserve the WHOLE-set
+// coverage guarantee the unsharded crawl had.
 //
 // k3d cost/flake trade-off: a k3d cluster is heavy (~3-5min bring-up) and flaky
 // (telemetrygen / otel-collector-gateway readiness BackOff). A matrix of N
-// clusters multiplies BOTH cost and flake surface, so the shard count is kept
-// deliberately MODEST (3): two smoke shards + one crawl shard.
+// clusters multiplies BOTH cost and flake surface, so the total cluster count is
+// kept deliberately MODEST: two smoke shards + CRAWL_SUB_SHARDS (2) crawl
+// shards = 4 clusters.
 //
 // Two modes (env MODE, or argv[2]; default `verify`):
 //   - verify : assert the SHARDS partition is a total, disjoint cover of the
@@ -83,30 +86,56 @@ const PW_DIR = process.env.PLAYWRIGHT_DIR || 'test/e2e/playwright';
 const CRAWL_STACK_K3D = 'k3d';
 const CRAWL_STACK_NONE = '';
 
+// How many dedicated k3d clusters the crawl frontier fans across. The crawl
+// engine has every shard run the WHOLE cheap BFS discovery but audit only the
+// ~1/N of surfaces it owns (the heavy interaction sweep), so the ~50min long
+// pole drops toward ~50/N. Kept MODEST (2): k3d is heavy + flaky, so total
+// cluster count (2 smoke + this) stays at 4. Bumping it is a one-line reviewed
+// change — and re-bootstrapping the k3d inventory via a dispatch is NOT required
+// (the merge unions whatever COUNT the shards ran with), but the merge job's
+// CRAWL_SHARD_COUNT must match.
+const CRAWL_SUB_SHARDS = 2;
+
+// The crawl trio every crawl sub-shard runs. Each sub-shard runs the SAME specs
+// but with a distinct CRAWL_SHARD_INDEX, so the BFS partition (sharding.ts)
+// gives each a disjoint ~1/N slice of the heavy audit work.
+const CRAWL_TRIO = [
+  'crawl/crawl.spec.ts', //                  full BFS — frontier sharded across CRAWL_SUB_SHARDS
+  'crawl/dsquery.spec.ts',
+  'crawl/lints.spec.ts',
+];
+
+// Smoke shards carry no crawl sharding (CRAWL_STACK empty → crawl/** ignored);
+// their crawlShardIndex/Count render to empty env so the spec sees the
+// single-shard default. A crawl sub-shard sets all three.
+const NO_CRAWL_SHARD = { crawlShardIndex: '', crawlShardCount: '' };
+
 // ---------------------------------------------------------------------------
 // The partition of the dashboard-lane spec set across isolated k3d clusters.
 //
-// Three shards, each its own k3d cluster:
-//   - shard-smoke-a / shard-smoke-b — the 27 non-crawl specs, split by
-//     wall-clock weight (the three internally-looping heavies —
-//     iterate-panel-kiosk, compose_grafana_smoke, the iterate-* sweeps — are
-//     spread across the two so neither shard carries all the long poles).
-//     CRAWL_STACK is empty → crawl/** is ignored, exactly as the old
-//     unfiltered smoke step ran. Go e2e runs ONCE, on shard-smoke-a, so the
-//     Go suite isn't redundantly re-run on every cluster.
-//   - shard-crawl — the crawl trio ONLY, CRAWL_STACK=k3d, SWEEP_DEPTH=full.
-//     The ~50min BFS long pole runs ALONE on its own cluster, concurrently
-//     with the smoke shards. It carries no companion specs (its single BFS
-//     test() already saturates the shard's wall-clock budget).
+// Shards, each its own k3d cluster:
+//   - shard-smoke-a / shard-smoke-b — the non-crawl specs, split by
+//     wall-clock weight (the internally-looping heavies — iterate-panel-kiosk,
+//     compose_grafana_smoke, the iterate-* sweeps — are spread across the two
+//     so neither shard carries all the long poles). CRAWL_STACK is empty →
+//     crawl/** is ignored, exactly as the old unfiltered smoke step ran. Go e2e
+//     runs ONCE, on shard-smoke-a, so the Go suite isn't redundantly re-run on
+//     every cluster.
+//   - shard-crawl-<i> (CRAWL_SUB_SHARDS of them) — the crawl trio, CRAWL_STACK=k3d,
+//     SWEEP_DEPTH=full, each with its own CRAWL_SHARD_INDEX. Every sub-shard runs
+//     the whole cheap BFS discovery; the heavy per-surface interaction sweep is
+//     partitioned across them, so the BFS long pole drops toward ~50/N. The
+//     sub-shards run concurrently with the smoke shards.
 //
 // Spec paths are relative to PLAYWRIGHT_DIR — exactly how they're passed to
 // `npx playwright test <files>` — so the matrix entry's space-joined string
 // drops verbatim into the run step.
 // ---------------------------------------------------------------------------
-const SHARDS = [
+const SMOKE_SHARDS = [
   {
     name: 'shard-smoke-a',
     crawlStack: CRAWL_STACK_NONE,
+    ...NO_CRAWL_SHARD,
     // Go e2e tests (`just e2e-run`) run once across the matrix, here — they're
     // stack-health Go tests, not Playwright, and don't need re-running per
     // cluster. The crawl + the other smoke shard skip them.
@@ -131,6 +160,7 @@ const SHARDS = [
   {
     name: 'shard-smoke-b',
     crawlStack: CRAWL_STACK_NONE,
+    ...NO_CRAWL_SHARD,
     runGoE2E: false,
     specs: [
       'iterate-time-ranges.spec.ts', //          phase-5 matrix sweep — heavy anchor
@@ -148,17 +178,30 @@ const SHARDS = [
       'helpers-variables.spec.ts',
     ],
   },
-  {
-    name: 'shard-crawl',
-    crawlStack: CRAWL_STACK_K3D,
-    runGoE2E: false,
-    specs: [
-      'crawl/crawl.spec.ts', //                  ~50min full BFS long pole — runs ALONE
-      'crawl/dsquery.spec.ts',
-      'crawl/lints.spec.ts',
-    ],
-  },
 ];
+
+// The crawl sub-shards, generated so adding a cluster is a single const bump.
+// Each runs the WHOLE crawl trio (the dsquery/lints pins are cheap + run on
+// every sub-shard; the BFS is the sharded long pole).
+const CRAWL_SHARDS = Array.from({ length: CRAWL_SUB_SHARDS }, (_, i) => ({
+  name: `shard-crawl-${i}`,
+  crawlStack: CRAWL_STACK_K3D,
+  runGoE2E: false,
+  crawlShardIndex: String(i),
+  crawlShardCount: String(CRAWL_SUB_SHARDS),
+  // Each sub-shard lists the same crawl specs; double-assignment across crawl
+  // sub-shards is EXPECTED (they differ by CRAWL_SHARD_INDEX, not spec set), so
+  // the coverage check below treats crawl specs as sub-shard-replicated rather
+  // than a double-assignment violation.
+  specs: [...CRAWL_TRIO],
+}));
+
+const SHARDS = [...SMOKE_SHARDS, ...CRAWL_SHARDS];
+
+// The crawl trio is intentionally replicated across every crawl sub-shard
+// (same specs, different CRAWL_SHARD_INDEX). The coverage check must treat
+// those as ONE logical assignment, not N double-assignments.
+const CRAWL_REPLICATED_SPECS = new Set(CRAWL_TRIO);
 
 // ---------------------------------------------------------------------------
 // Specs that live under PLAYWRIGHT_DIR but are NOT part of the dashboard
@@ -231,8 +274,19 @@ export function collectViolations(discovered) {
     v.push('EXCLUDED contains duplicate entries');
   }
 
-  // double-assignment (wasted work + a spec running on two clusters).
+  // double-assignment (wasted work + a spec running on two clusters) — EXCEPT
+  // the crawl trio, which is deliberately replicated across the crawl
+  // sub-shards (same specs, distinct CRAWL_SHARD_INDEX). A replicated crawl
+  // spec must appear ONLY on crawl sub-shards (a `shard-crawl-*` name), never
+  // leak onto a smoke shard.
   for (const [spec, who] of owners) {
+    if (CRAWL_REPLICATED_SPECS.has(spec)) {
+      const nonCrawl = who.filter((n) => !n.startsWith('shard-crawl-'));
+      if (nonCrawl.length > 0) {
+        v.push(`crawl-replicated spec ${spec} assigned to non-crawl shard(s) [${nonCrawl.join(', ')}]`);
+      }
+      continue;
+    }
     if (who.length > 1) {
       v.push(`double-assigned spec ${spec} -> shards [${who.join(', ')}]`);
     }
@@ -282,10 +336,10 @@ function assertCoverageOrExit(discovered) {
 function verify() {
   const discovered = discover();
   assertCoverageOrExit(discovered);
-  const assignedCount = SHARDS.reduce((n, s) => n + s.specs.length, 0);
+  const uniqueAssigned = new Set(SHARDS.flatMap((s) => s.specs)).size;
   notice(
-    `dashboard-matrix OK: ${SHARDS.length} shards, ${assignedCount} specs assigned, ` +
-      `${EXCLUDED.length} excluded, ${discovered.length} discovered.`,
+    `dashboard-matrix OK: ${SHARDS.length} shards (${CRAWL_SUB_SHARDS} crawl sub-shards), ` +
+      `${uniqueAssigned} unique specs assigned, ${EXCLUDED.length} excluded, ${discovered.length} discovered.`,
   );
   process.exit(0);
 }
@@ -298,17 +352,27 @@ function emit() {
     specs: s.specs.join(' '),
     crawlStack: s.crawlStack,
     runGoE2E: s.runGoE2E,
+    // Empty string on smoke shards → the run step renders empty env, so the
+    // crawl spec sees CRAWL_SHARD_INDEX/COUNT unset (single-shard default).
+    crawlShardIndex: s.crawlShardIndex ?? '',
+    crawlShardCount: s.crawlShardCount ?? '',
   }));
   setOutput('matrix', JSON.stringify({ include }));
   setOutput('shard_names', JSON.stringify(SHARDS.map((s) => s.name)));
+  // The merge job needs the crawl shard count to assert the slice union is
+  // complete (every shard index in [0, count) uploaded a slice).
+  setOutput('crawl_shard_count', String(CRAWL_SUB_SHARDS));
   appendStepSummary(
     [
       '### dashboard (k3d) shard matrix',
       '',
-      '| shard | specs | CRAWL_STACK | Go e2e |',
-      '| --- | --- | --- | --- |',
+      '| shard | specs | CRAWL_STACK | crawl shard | Go e2e |',
+      '| --- | --- | --- | --- | --- |',
       ...SHARDS.map(
-        (s) => `| \`${s.name}\` | ${s.specs.length} | ${s.crawlStack || '(none)'} | ${s.runGoE2E ? 'yes' : 'no'} |`,
+        (s) =>
+          `| \`${s.name}\` | ${s.specs.length} | ${s.crawlStack || '(none)'} | ` +
+          `${s.crawlShardCount ? `${Number(s.crawlShardIndex) + 1}/${s.crawlShardCount}` : '(n/a)'} | ` +
+          `${s.runGoE2E ? 'yes' : 'no'} |`,
       ),
     ].join('\n'),
   );
@@ -330,4 +394,4 @@ if (invokedDirectly) {
 }
 
 // Exported for the unit guard (.github/scripts/dashboard-matrix.test.mjs).
-export { SHARDS, EXCLUDED, SHARD_NAME_RE };
+export { SHARDS, EXCLUDED, SHARD_NAME_RE, CRAWL_SUB_SHARDS, CRAWL_TRIO };

--- a/.github/scripts/dashboard-matrix.test.mjs
+++ b/.github/scripts/dashboard-matrix.test.mjs
@@ -16,7 +16,13 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { discover, collectViolations, SHARDS } from './dashboard-matrix.mjs';
+import {
+  discover,
+  collectViolations,
+  SHARDS,
+  CRAWL_SUB_SHARDS,
+  CRAWL_TRIO,
+} from './dashboard-matrix.mjs';
 
 test('live tree: SHARDS ∪ EXCLUDED is a total, disjoint cover (no violations)', () => {
   const violations = collectViolations(discover());
@@ -48,4 +54,37 @@ test('exactly one shard runs the Go e2e suite', () => {
     1,
     `expected exactly one runGoE2E shard; got ${goE2E.length}: ${goE2E.map((s) => s.name).join(', ')}`,
   );
+});
+
+test('crawl trio is replicated across exactly CRAWL_SUB_SHARDS crawl sub-shards, each a distinct contiguous index', () => {
+  const crawl = SHARDS.filter((s) => s.crawlStack === 'k3d');
+  assert.equal(crawl.length, CRAWL_SUB_SHARDS, 'one crawl shard per sub-shard');
+  const indices = crawl.map((s) => Number(s.crawlShardIndex)).sort((a, b) => a - b);
+  assert.deepEqual(
+    indices,
+    Array.from({ length: CRAWL_SUB_SHARDS }, (_, i) => i),
+    'crawl sub-shard indices are 0..CRAWL_SUB_SHARDS-1',
+  );
+  for (const s of crawl) {
+    assert.equal(Number(s.crawlShardCount), CRAWL_SUB_SHARDS, `${s.name} count`);
+    assert.deepEqual(s.specs, CRAWL_TRIO, `${s.name} runs the whole crawl trio`);
+    assert.match(s.name, /^shard-crawl-\d+$/, `${s.name} naming`);
+  }
+});
+
+test('crawl specs live exclusively on crawl sub-shards (replication never leaks onto a smoke shard)', () => {
+  // A crawl spec on a non-crawl shard would run with CRAWL_STACK empty →
+  // crawl/** ignored → the spec silently never runs there. The replication
+  // exception in collectViolations explicitly guards against this; assert the
+  // live partition honours it.
+  for (const s of SHARDS) {
+    for (const spec of s.specs) {
+      if (!CRAWL_TRIO.includes(spec)) continue;
+      assert.equal(
+        s.crawlStack,
+        'k3d',
+        `crawl spec ${spec} found on non-crawl shard ${s.name}`,
+      );
+    }
+  }
 });

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,13 +28,17 @@ name: e2e
 #     Informational on merges, not a PR gate (never runs on
 #     pull_request, so NOT a branch-protection check); regressions are
 #     caught at merge-to-main time and reverted from main if they break.
-#     On schedule + dispatch the DEDICATED crawl shard runs the Grafana
+#     On schedule + dispatch the DEDICATED crawl sub-shards run the Grafana
 #     surface crawler with CRAWL_STACK=k3d (same engine as compose-smoke's
 #     crawl lane, this stack's config + inventory — see
 #     test/e2e/playwright/crawl/stacks.ts) at SWEEP_DEPTH=full,
 #     CONCURRENTLY with the smoke shards. The ~50min crawl BFS is a single
-#     indivisible test(); splitting its frontier across shards is the
-#     follow-up that beats the 50min wall-clock floor.
+#     indivisible test(), so its FRONTIER is sharded across CRAWL_SUB_SHARDS
+#     clusters (CRAWL_SHARD_INDEX/COUNT, see crawl/sharding.ts): every
+#     sub-shard runs the whole cheap discovery walk but audits only its ~1/N
+#     of surfaces (the heavy interaction sweep), dropping the long pole toward
+#     ~50/N. The dashboard-merge job unions the per-shard inventory slices on
+#     the update_crawl_inventory dispatch, asserting an exact disjoint cover.
 #   - `startup-bench` — startup-speed bench (cerberus to /healthz in
 #     <2s). Same trigger set as `dashboard`; informational only.
 #
@@ -213,6 +217,15 @@ jobs:
       # PR gate, same as the compose-smoke guard above.
       - name: dashboard shard coverage (unit guard)
         run: node --test .github/scripts/dashboard-matrix.test.mjs
+
+      # crawl inventory union-merge coverage guard. The merge job only runs on
+      # the update_crawl_inventory dispatch, so without this its partition
+      # assertions (exact disjoint cover; lockstep with crawl/sharding.ts's
+      # FNV-1a hash + path-only ownership) would only be exercised on a manual
+      # bootstrap run. Pinning them on the cheap PR gate keeps the merge logic
+      # and the spec's sharding logic from drifting apart silently.
+      - name: crawl inventory merge coverage (unit guard)
+        run: node --test .github/scripts/crawl-inventory-merge.test.mjs
 
   # compose-smoke is sharded into a balanced matrix of isolated-compose-stack
   # jobs. The three heaviest specs are each a SINGLE async test() that loops
@@ -501,27 +514,35 @@ jobs:
   #
   # The dominant cost is crawl/crawl.spec.ts: a SINGLE async BFS test() (the
   # ~50min long pole at SWEEP_DEPTH=full) that is indivisible by Playwright's
-  # native --shard AND by spec-file sharding (one file, one test). So spec-file
-  # sharding alone can't beat the 50min floor; the win this lane buys is COARSE
-  # and LOGICAL: run the non-crawl smoke specs on their own k3d clusters
-  # CONCURRENTLY with a DEDICATED crawl cluster, so the ~50min crawl no longer
-  # runs serially after the smoke set. Wall-clock drops from
-  # (smoke serial + crawl) toward max(crawl ~50min, slowest smoke shard).
+  # native --shard AND by spec-file sharding (one file, one test). Two layers of
+  # parallelism beat that:
+  #   1. COARSE: the non-crawl smoke specs run on their own k3d clusters
+  #      CONCURRENTLY with the crawl clusters, so the crawl no longer runs
+  #      serially after the smoke set.
+  #   2. FRONTIER SHARDING: the crawl BFS frontier is fanned across
+  #      CRAWL_SUB_SHARDS dedicated clusters (CRAWL_SHARD_INDEX/COUNT — see
+  #      crawl/sharding.ts). Every sub-shard runs the WHOLE cheap BFS discovery
+  #      walk (so the visited set converges identically) but audits + pins only
+  #      the ~1/N of surfaces it OWNS (fnv1a(path) % COUNT == INDEX) — the heavy
+  #      per-surface interaction sweep, the actual long pole. Wall-clock drops
+  #      toward ~50/N.
   #
-  # Beating the 50min floor itself needs the crawl ENGINE to partition its
-  # discovered BFS frontier across shards (a CRAWL_SHARD_INDEX/COUNT contract +
-  # a final union-merge-and-assert against the pinned inventory). That is a deep
-  # change to the 1383-line BFS + the inventory ratchet, blocked today by the
-  # k3d inventory being unbootstrapped — tracked as the explicit follow-up in
-  # this lane's PR. This sharding is the safe coarse win that lands first.
+  # The inventory ratchet stays whole: each sub-shard's per-shard ratchet
+  # asserts the rows it owns (lib.ts diffInventory, scoped to its slice), and on
+  # the update_crawl_inventory dispatch every sub-shard uploads its owned slice
+  # which the dashboard-merge job unions into the full inventory, asserting an
+  # EXACT, DISJOINT, TOTAL cover (crawl-inventory-merge.mjs). A per-shard ratchet
+  # alone could miss a surface no shard owned; the union-merge proves the slices
+  # reconstitute the whole.
   #
   # k3d cost/flake: a cluster is heavy (~3-5min bring-up) and flaky
   # (telemetrygen / otel-collector-gateway readiness BackOff). A matrix of N
-  # clusters multiplies BOTH, so the shard count is kept MODEST (3) — two smoke
-  # shards + one crawl shard. The partition + coverage assertion live in the
-  # single source of truth .github/scripts/dashboard-matrix.mjs — never
-  # hand-listed in YAML, so a new spec that isn't sharded is a HARD failure
-  # (verify step below), never a silent no-run.
+  # clusters multiplies BOTH, so the total cluster count is kept MODEST — two
+  # smoke shards + CRAWL_SUB_SHARDS (2) crawl shards = 4. The partition +
+  # coverage assertion live in the single source of truth
+  # .github/scripts/dashboard-matrix.mjs — never hand-listed in YAML, so a new
+  # spec that isn't sharded is a HARD failure (verify step below), never a
+  # silent no-run.
   #
   # Topology:
   #   dashboard-setup   — verify the partition covers every k3d-lane spec, then
@@ -529,8 +550,13 @@ jobs:
   #   dashboard-shard   — the matrix; each shard boots its OWN k3d cluster and
   #                       runs only its assigned specs (smoke shards with
   #                       CRAWL_STACK unset = crawl/** ignored, exactly as the
-  #                       old unfiltered smoke step; the crawl shard with
-  #                       CRAWL_STACK=k3d SWEEP_DEPTH=full = the crawl trio).
+  #                       old unfiltered smoke step; the crawl sub-shards with
+  #                       CRAWL_STACK=k3d SWEEP_DEPTH=full + a distinct
+  #                       CRAWL_SHARD_INDEX = the crawl trio over a ~1/N
+  #                       frontier slice).
+  #   dashboard-merge   — only on the update_crawl_inventory dispatch; unions
+  #                       the crawl sub-shards' inventory slices into the full
+  #                       inventory, asserting an exact disjoint cover.
   #   dashboard         — the AGGREGATOR; a single clean pass/fail over every
   #                       shard. NOT a branch-protection check (the lane never
   #                       runs on pull_request), but a clean roll-up + the
@@ -545,6 +571,9 @@ jobs:
     timeout-minutes: 5
     outputs:
       matrix: ${{ steps.emit.outputs.matrix }}
+      # The number of crawl sub-shards the frontier fanned across — the merge
+      # job asserts it saw exactly this many slices (no shard index missing).
+      crawl_shard_count: ${{ steps.emit.outputs.crawl_shard_count }}
     steps:
       - uses: actions/checkout@v6
 
@@ -701,7 +730,13 @@ jobs:
       # bootstrap (or deliberately regenerate after surface growth): dispatch
       # this workflow with update_crawl_inventory=true, then commit the uploaded
       # artifact.
-      - name: Run Playwright crawl (${{ matrix.name }}, CRAWL_STACK=k3d)
+      # CRAWL_SHARD_INDEX/COUNT fan the BFS frontier across the crawl
+      # sub-shards (dashboard-matrix.mjs CRAWL_SUB_SHARDS): every sub-shard runs
+      # the WHOLE cheap discovery walk but audits + pins only the ~1/N of
+      # surfaces it owns (the heavy interaction sweep), so the ~50min BFS long
+      # pole drops toward ~50/N. crawl/sharding.ts treats both unset as the
+      # single-shard default, so a non-sharded run is unchanged.
+      - name: Run Playwright crawl (${{ matrix.name }}, CRAWL_STACK=k3d, shard ${{ matrix.crawlShardIndex }}/${{ matrix.crawlShardCount }})
         id: playwright_crawl
         if: env.RUN_SHARD == 'true' && matrix.crawlStack == 'k3d'
         working-directory: test/e2e/playwright
@@ -710,16 +745,24 @@ jobs:
           CERBERUS_URL: http://localhost:8080
           CRAWL_STACK: ${{ matrix.crawlStack }}
           SWEEP_DEPTH: full
+          CRAWL_SHARD_INDEX: ${{ matrix.crawlShardIndex }}
+          CRAWL_SHARD_COUNT: ${{ matrix.crawlShardCount }}
           CERBERUS_UPDATE_INVENTORY: ${{ github.event_name == 'workflow_dispatch' && inputs.update_crawl_inventory && '1' || '' }}
         run: npx playwright test ${{ matrix.specs }} --reporter=list
 
-      - name: Upload regenerated k3d crawl inventory
+      # On the bootstrap/regen dispatch each crawl sub-shard emits its OWNED
+      # SLICE (grafana-surface-slice.k3d.shard-<i>.json); the dashboard-merge
+      # job downloads every slice and unions them into the full inventory
+      # (asserting an exact disjoint cover). A per-shard artifact name avoids the
+      # upload-artifact 409 across the matrix.
+      - name: Upload this shard's crawl inventory slice
         if: always() && matrix.crawlStack == 'k3d' && github.event_name == 'workflow_dispatch' && inputs.update_crawl_inventory
         uses: actions/upload-artifact@v7
         with:
-          name: grafana-surface-inventory-k3d
-          path: test/e2e/playwright/crawl/grafana-surface-inventory.k3d.json
+          name: grafana-surface-slice-k3d-${{ matrix.name }}
+          path: test/e2e/playwright/crawl/grafana-surface-slice.k3d.shard-${{ matrix.crawlShardIndex }}.json
           retention-days: 14
+          if-no-files-found: error
 
       # Hard gate: zero cerberus container restarts across this shard,
       # asserted even when every spec passed. The nightly at run 27253909069
@@ -813,6 +856,66 @@ jobs:
         if: always() && env.RUN_SHARD == 'true'
         run: just e2e-down
 
+  # The MERGE job — only on the bootstrap/regen dispatch
+  # (update_crawl_inventory=true). Each crawl sub-shard uploaded its OWNED slice
+  # of the surface inventory; this job downloads every slice and unions them
+  # into the full inventory, asserting an EXACT, DISJOINT, TOTAL cover (no
+  # surface missed, none double-owned, no shard index missing). The merged
+  # inventory is byte-for-byte what a single full crawl would pin — download its
+  # artifact and commit it to bootstrap/regenerate
+  # test/e2e/playwright/crawl/grafana-surface-inventory.k3d.json. This is the
+  # coverage guarantee that keeps the frontier-sharding from weakening the
+  # inventory ratchet: a per-shard ratchet alone could miss a surface no shard
+  # owned; the union-merge proves the slices reconstitute the whole.
+  dashboard-merge:
+    name: dashboard-merge
+    needs: [dashboard-setup, dashboard-shard]
+    # Only the regen dispatch produces slices to merge. needs.* must have
+    # succeeded (a failed shard means an incomplete/aborted crawl — merging a
+    # partial slice set would silently under-cover).
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      inputs.update_crawl_inventory &&
+      needs.dashboard-setup.result == 'success' &&
+      needs.dashboard-shard.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+
+      # Collect every crawl sub-shard's slice artifact into one dir. The slice
+      # artifacts are named grafana-surface-slice-k3d-shard-crawl-<i>; the glob
+      # pattern pulls them all, merge-multiple flattens them into SLICES_DIR.
+      - name: Download crawl inventory slices
+        uses: actions/download-artifact@v6
+        with:
+          pattern: grafana-surface-slice-k3d-*
+          path: ${{ github.workspace }}/crawl-slices
+          merge-multiple: true
+
+      # Union + assert an exact disjoint cover, then write the full inventory.
+      # The doc header MUST match the k3d stack config's inventoryDoc so the
+      # committed file round-trips through the spec's marshaller (the
+      # canonicalization pin asserts this); it is read straight from the
+      # committed inventory's existing doc field, which the stack config keeps in
+      # sync.
+      - name: Merge slices into the full k3d inventory
+        env:
+          SLICES_DIR: ${{ github.workspace }}/crawl-slices
+          STACK: k3d
+          INVENTORY_OUT: test/e2e/playwright/crawl/grafana-surface-inventory.k3d.json
+        run: |
+          doc=$(node -e "process.stdout.write(JSON.parse(require('fs').readFileSync('test/e2e/playwright/crawl/grafana-surface-inventory.k3d.json','utf8')).doc)")
+          INVENTORY_DOC="$doc" node .github/scripts/crawl-inventory-merge.mjs merge
+
+      - name: Upload merged k3d crawl inventory
+        uses: actions/upload-artifact@v7
+        with:
+          name: grafana-surface-inventory-k3d
+          path: test/e2e/playwright/crawl/grafana-surface-inventory.k3d.json
+          retention-days: 14
+          if-no-files-found: error
+
   # The AGGREGATOR — a single clean pass/fail over every dashboard shard. The
   # dashboard lane never runs on pull_request, so this is NOT a
   # branch-protection required check (unlike compose-smoke's aggregator); it
@@ -823,7 +926,7 @@ jobs:
   # is off).
   dashboard:
     name: dashboard
-    needs: [dashboard-setup, dashboard-shard]
+    needs: [dashboard-setup, dashboard-shard, dashboard-merge]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -851,6 +954,16 @@ jobs:
           fi
           if [ "${{ needs.dashboard-shard.result }}" != "success" ]; then
             echo "::error::one or more dashboard shards failed/cancelled (rolled-up: ${{ needs.dashboard-shard.result }})."
+            exit 1
+          fi
+          # dashboard-merge only runs on the update_crawl_inventory dispatch;
+          # `skipped` is the expected steady state and is NOT a failure. When it
+          # DID run (the regen dispatch), it must have succeeded — a failed
+          # union-merge means the slices weren't a clean disjoint cover.
+          merge="${{ needs.dashboard-merge.result }}"
+          echo "merge  = $merge"
+          if [ "$merge" != "skipped" ] && [ "$merge" != "success" ]; then
+            echo "::error::dashboard-merge did not succeed ($merge) — the crawl shard slices failed the union-merge coverage assertion."
             exit 1
           fi
           echo "all dashboard shards passed."

--- a/test/e2e/playwright/crawl/crawl.spec.ts
+++ b/test/e2e/playwright/crawl/crawl.spec.ts
@@ -152,6 +152,16 @@ import {
   knownStackNames,
   stackByName,
 } from './stacks.js';
+import {
+  marshalShardSlice,
+  mergeShardSlices,
+  ownsSurface,
+  resolveShardAssignment,
+  shardAssignmentFromEnv,
+  shardSlicePath,
+  type ShardAssignment,
+  type ShardSlice,
+} from './sharding.js';
 
 // Self-traffic warmup — same rationale + value as the iterate-* specs:
 // without populated counters/streams/traces, a "No data" panel on a
@@ -586,6 +596,179 @@ test.describe('crawl: canonicalization pins', () => {
 });
 
 // ---------------------------------------------------------------------------
+// BFS-frontier sharding pins — pure-function proofs that the partition
+// is deterministic, that a surface + its derived states co-locate on one
+// shard, and that the per-shard slices union back to the WHOLE set
+// disjointly. These are the coverage guarantee the sharded crawl rests
+// on; pinning them here (no live stack) means a partition regression
+// fails on a fast unit check, not a 50min k3d run.
+// ---------------------------------------------------------------------------
+
+test.describe('crawl: BFS-frontier sharding pins', () => {
+  // A representative cross-section of the surface/state key shapes the
+  // real crawl pins: bare surfaces, dashboards, structural-param
+  // surfaces, parameterized families, and in-place interaction states.
+  const SAMPLE_KEYS: ReadonlyArray<string> = [
+    '/',
+    '/dashboards',
+    '/explore',
+    '/d/cerberus-self',
+    '/d/clickhouse',
+    '/a/grafana-exploretraces-app/explore',
+    '/a/grafana-exploretraces-app/explore?var-groupBy=kind',
+    '/a/grafana-exploretraces-app/explore?actionView=comparison&var-groupBy=kind',
+    '/a/grafana-metricsdrilldown-app/drilldown?metric={metric}',
+    '/a/grafana-lokiexplore-app/explore/service/{service}/logs',
+    '/a/grafana-lokiexplore-app/explore/service/{service}/logs?visualizationType="table"',
+    '/a/grafana-exploretraces-app/explore#var-metric={rep}',
+    '/d/cerberus-self#tab=overview',
+  ];
+
+  test('resolveShardAssignment: unset env is the single-shard identity, bad values fail loudly', () => {
+    expect(resolveShardAssignment({})).toEqual({ index: 0, count: 1 });
+    expect(resolveShardAssignment({ index: '1', count: '3' })).toEqual({
+      index: 1,
+      count: 3,
+    });
+    // half-configured, out-of-range, and non-integer all throw.
+    expect(() => resolveShardAssignment({ count: '3' })).toThrow(
+      /must be set together/,
+    );
+    expect(() => resolveShardAssignment({ index: '0' })).toThrow(
+      /must be set together/,
+    );
+    expect(() => resolveShardAssignment({ index: '3', count: '3' })).toThrow(
+      /must be an integer in \[0, 3\)/,
+    );
+    expect(() => resolveShardAssignment({ index: '0', count: '0' })).toThrow(
+      /must be an integer ≥ 1/,
+    );
+    expect(() => resolveShardAssignment({ index: '1.5', count: '3' })).toThrow(
+      /must be an integer in \[0, 3\)/,
+    );
+  });
+
+  test('count==1 owns every key (the unsharded identity)', () => {
+    const single: ShardAssignment = { index: 0, count: 1 };
+    for (const k of SAMPLE_KEYS) {
+      expect(ownsSurface(k, single), `single shard owns ${k}`).toBe(true);
+    }
+  });
+
+  test('a surface, its structural-param children, and its in-place states co-locate on one shard', () => {
+    // baseSurfaceOf strips both the `?…` query and the `#…` state, so
+    // every key sharing a PATH hashes to the same owner — discovery and
+    // ownership coincide (the sweep that finds the children runs on the
+    // owner of the bare surface).
+    const path = '/a/grafana-exploretraces-app/explore';
+    const family = [
+      path,
+      `${path}?var-groupBy=kind`,
+      `${path}?actionView=comparison&var-groupBy=kind`,
+      `${path}#var-metric={rep}`,
+      `${path}#actionView={rep}`,
+    ];
+    for (const count of [2, 3, 4]) {
+      for (let index = 0; index < count; index++) {
+        const a: ShardAssignment = { index, count };
+        const ownedByThis = family.map((k) => ownsSurface(k, a));
+        // All-or-nothing: the whole family lands on exactly one shard.
+        const allSame = ownedByThis.every((v) => v === ownedByThis[0]);
+        expect(allSame, `family co-located at ${count}/${index}`).toBe(true);
+      }
+    }
+  });
+
+  test('the per-shard partition is total, disjoint, and deterministic over a sample set', () => {
+    for (const count of [1, 2, 3, 4, 5]) {
+      const ownerOf = new Map<string, number>();
+      for (const k of SAMPLE_KEYS) {
+        const owners = [];
+        for (let index = 0; index < count; index++) {
+          if (ownsSurface(k, { index, count })) owners.push(index);
+        }
+        // EXACTLY one shard owns each key — total cover + disjoint.
+        expect(owners.length, `exactly one owner for ${k} at count ${count}`).toBe(
+          1,
+        );
+        ownerOf.set(k, owners[0]!);
+      }
+      // Determinism: a second pass yields identical assignments.
+      for (const k of SAMPLE_KEYS) {
+        const second = [];
+        for (let index = 0; index < count; index++) {
+          if (ownsSurface(k, { index, count })) second.push(index);
+        }
+        expect(second).toEqual([ownerOf.get(k)]);
+      }
+    }
+  });
+
+  test('mergeShardSlices: the union of owned slices is the EXACT full set, disjoint', () => {
+    const count = 3;
+    const stack = 'k3d';
+    const doc = 'pinned';
+    // Partition the sample set into per-shard owned slices exactly the
+    // way the live crawl does.
+    const slices: ShardSlice[] = Array.from({ length: count }, (_, index) => ({
+      stack,
+      shardIndex: index,
+      shardCount: count,
+      surfaces: SAMPLE_KEYS.filter((k) =>
+        ownsSurface(k, { index, count }),
+      ).map((url) => ({ url, lean: false })),
+    }));
+    const merged = mergeShardSlices(slices, doc, stack);
+    expect(new Set(merged.surfaces.map((s) => s.url))).toEqual(
+      new Set(SAMPLE_KEYS),
+    );
+    expect(merged.surfaces.length, 'no duplicates in the union').toBe(
+      SAMPLE_KEYS.length,
+    );
+    expect(merged.stack).toBe(stack);
+    expect(merged.doc).toBe(doc);
+  });
+
+  test('mergeShardSlices fails loudly on a missing shard, a double-owned surface, and a smuggled surface', () => {
+    const count = 2;
+    const stack = 'k3d';
+    const good: ShardSlice[] = Array.from({ length: count }, (_, index) => ({
+      stack,
+      shardIndex: index,
+      shardCount: count,
+      surfaces: SAMPLE_KEYS.filter((k) =>
+        ownsSurface(k, { index, count }),
+      ).map((url) => ({ url, lean: false })),
+    }));
+    // Missing a shard → incomplete union (coverage gap).
+    expect(() => mergeShardSlices([good[0]!], 'd', stack)).toThrow(
+      /missing slice for shard index/,
+    );
+    // The same surface owned by two shards → not disjoint.
+    const dup0 = good[0]!.surfaces[0]!.url;
+    const overlap: ShardSlice[] = [
+      good[0]!,
+      {
+        ...good[1]!,
+        surfaces: [...good[1]!.surfaces, { url: dup0, lean: false }],
+      },
+    ];
+    expect(() => mergeShardSlices(overlap, 'd', stack)).toThrow(
+      /owned by more than one shard|does NOT map to it/,
+    );
+    // A shard smuggling a surface the assignment doesn't map to it.
+    const notMine = SAMPLE_KEYS.find((k) => !ownsSurface(k, { index: 0, count }))!;
+    const smuggled: ShardSlice[] = [
+      { ...good[0]!, surfaces: [{ url: notMine, lean: false }] },
+      good[1]!,
+    ];
+    expect(() => mergeShardSlices(smuggled, 'd', stack)).toThrow(
+      /does NOT map to it|owned by more than one shard/,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
 // The crawl
 // ---------------------------------------------------------------------------
 
@@ -595,13 +778,24 @@ test('crawl: BFS over every reachable Grafana surface with universal oracles + i
 }, testInfo) => {
   const stack = activeStack();
   const depth = sweepDepth();
-  // Budget: lean ≈ 10 pages × ~6s + 30s seed + the representative
-  // interaction sweep over the 3 drilldown roots (~3 min); full ≈
-  // cap pages + the exhaustive interaction sweep (a fresh navigation
-  // per planned gesture).
+  // BFS-frontier sharding (see sharding.ts). Unset env = single shard =
+  // today's behavior (COUNT=1 owns everything). When CRAWL_SHARD_COUNT>1
+  // every shard runs the WHOLE cheap discovery walk (navigate + harvest +
+  // expand the frontier) so the visited set converges identically, but
+  // this shard only runs the HEAVY work — the base-surface oracle
+  // battery + the interaction sweep + the in-place state audits — on
+  // surfaces it OWNS (fnv1a(surface) % COUNT == INDEX). The dominant cost
+  // is the per-gesture-navigation interaction sweep, so this splits the
+  // long pole ~evenly while every shard keeps a complete frontier.
+  const shard = shardAssignmentFromEnv(process.env);
   testInfo.setTimeout(depth === 'full' ? 75 * 60_000 : 14 * 60_000);
   // eslint-disable-next-line no-console
-  console.log(`crawl stack: ${stack.name} — ${describeSweepDepth(depth)}`);
+  console.log(
+    `crawl stack: ${stack.name} — ${describeSweepDepth(depth)}` +
+      (shard.count > 1
+        ? ` — shard ${shard.index + 1}/${shard.count} (owns ~1/${shard.count} of the heavy interaction sweep)`
+        : ''),
+  );
 
   const baseURL =
     process.env.GRAFANA_URL ??
@@ -701,10 +895,16 @@ test('crawl: BFS over every reachable Grafana surface with universal oracles + i
 
   const pageCap = depth === 'full' ? stack.pageCapFull : stack.pageCapLean;
   const visited = new Map<string, string>(); // canonical → concrete navigated
+  // Surfaces this shard OWNS (audited the heavy work for). With a single
+  // shard this equals `visited`; with N shards it is this shard's ~1/N
+  // slice. Only owned surfaces pin into this shard's inventory slice —
+  // the final merge step unions all shards' slices back to the full set.
+  const ownedSurfaces = new Map<string, string>();
   // In-place interaction states (`<canonical>#<control>=<value>`) →
   // concrete URL the gesture ran against. Kept separate from
   // `visited` because they are gestures on an already-counted page,
-  // not navigations — the page cap governs navigations.
+  // not navigations — the page cap governs navigations. Only the
+  // owning shard runs a surface's sweep, so these are all owned.
   const inPlaceVisited = new Map<string, string>();
   const failures: CrawlFailure[] = [];
 
@@ -729,6 +929,12 @@ test('crawl: BFS over every reachable Grafana surface with universal oracles + i
       }
 
       visited.set(entry.canonical, entry.concrete);
+      // Every shard navigates + harvests every surface (discovery is
+      // cheap and must stay complete so the frontier converges). Only
+      // the OWNING shard runs the oracle battery + interaction sweep —
+      // the dominant cost — and pins the surface into its slice.
+      const owned = ownsSurface(entry.canonical, shard);
+      if (owned) ownedSurfaces.set(entry.canonical, entry.concrete);
 
       const { harvested, pageFailures } = await visitAndAudit(
         lease,
@@ -736,6 +942,7 @@ test('crawl: BFS over every reachable Grafana surface with universal oracles + i
         entry,
         declaredNoData,
         declaredErrorExprs,
+        owned,
       );
       failures.push(...pageFailures);
 
@@ -774,7 +981,11 @@ test('crawl: BFS over every reachable Grafana surface with universal oracles + i
       // the pairwise bound: surfaces pinning ≥2 structural params are
       // terminal (planInteractions returns an empty plan for them).
       const isLeanRoot = stack.leanInteractionRoots.includes(entry.canonical);
-      if (depth === 'full' || isLeanRoot) {
+      // Sweep only OWNED surfaces: the per-gesture-navigation sweep is
+      // the dominant cost and the whole point of the partition. A
+      // surface and all its in-place states share one shard (ownsSurface
+      // hashes the base canonical), so the sweep stays atomic.
+      if (owned && (depth === 'full' || isLeanRoot)) {
         const sweep = await sweepInteractions(
           lease,
           baseURL,
@@ -805,21 +1016,25 @@ test('crawl: BFS over every reachable Grafana surface with universal oracles + i
     await lease.close();
   }
 
-  // The full audited state set: navigated surfaces plus the in-place
-  // interaction states (`<canonical>#<control>=<value>` notation) —
-  // both pin into the same inventory ratchet.
+  // This shard's audited state set: the surfaces it OWNS plus their
+  // in-place interaction states (`<canonical>#<control>=<value>`
+  // notation) — both pin into the same inventory ratchet. Under a single
+  // shard this equals every navigated surface + state (today's full set);
+  // under N shards it is this shard's ~1/N slice, and the merge step
+  // unions every shard's slice back to the whole.
   const auditedStates = new Map<string, string>([
-    ...visited,
+    ...ownedSurfaces,
     ...inPlaceVisited,
   ]);
 
   // eslint-disable-next-line no-console
   console.log(
-    `crawl: audited ${auditedStates.size} state(s) (${visited.size} navigated surface(s), ` +
-      `${inPlaceVisited.size} in-place interaction state(s)) at depth=${depth} stack=${stack.name}:\n${[...auditedStates.keys()]
-      .sort()
-      .map((u) => `  - ${u}`)
-      .join('\n')}`,
+    `crawl: shard ${shard.index + 1}/${shard.count} audited ${auditedStates.size} owned state(s) ` +
+      `(${ownedSurfaces.size} navigated surface(s), ${inPlaceVisited.size} in-place interaction state(s)) ` +
+      `of ${visited.size} discovered surface(s) at depth=${depth} stack=${stack.name}:\n${[...auditedStates.keys()]
+        .sort()
+        .map((u) => `  - ${u}`)
+        .join('\n')}`,
   );
 
   // -------------------------------------------------------------------------
@@ -829,25 +1044,49 @@ test('crawl: BFS over every reachable Grafana surface with universal oracles + i
   // regen against a stack carrying known-red states (e.g. a found bug
   // whose fix is in flight) must still capture the coverage, and the
   // run still fails loudly on the failures right below.
+  //
+  // Sharded vs unsharded regen:
+  //   - single shard (count==1) → write the FULL inventory exactly as
+  //     before (this shard owns everything).
+  //   - N shards → write THIS shard's owned SLICE artifact; the e2e
+  //     workflow's merge step unions every shard's slice and writes the
+  //     full inventory (identical to what a single full crawl produces).
   // -------------------------------------------------------------------------
   if (process.env.CERBERUS_UPDATE_INVENTORY) {
     expect(
       depth,
       'inventory regeneration requires the exhaustive crawl: rerun with SWEEP_DEPTH=full',
     ).toBe('full');
-    const inv: SurfaceInventory = {
-      doc: stack.inventoryDoc,
-      stack: stack.name,
-      surfaces: [...auditedStates.keys()].map((url) => ({
-        url,
-        lean: leanSet.has(url),
-      })),
-    };
-    writeFileSync(inventoryPath(stack), marshalInventory(inv));
-    // eslint-disable-next-line no-console
-    console.log(
-      `crawl: regenerated ${inventoryPath(stack)} with ${inv.surfaces.length} surface(s)`,
-    );
+    const ownedRows = [...auditedStates.keys()].map((url) => ({
+      url,
+      lean: leanSet.has(url),
+    }));
+    if (shard.count === 1) {
+      const inv: SurfaceInventory = {
+        doc: stack.inventoryDoc,
+        stack: stack.name,
+        surfaces: ownedRows,
+      };
+      writeFileSync(inventoryPath(stack), marshalInventory(inv));
+      // eslint-disable-next-line no-console
+      console.log(
+        `crawl: regenerated ${inventoryPath(stack)} with ${inv.surfaces.length} surface(s)`,
+      );
+    } else {
+      const slice: ShardSlice = {
+        stack: stack.name,
+        shardIndex: shard.index,
+        shardCount: shard.count,
+        surfaces: ownedRows,
+      };
+      const out = shardSlicePath(__dirname, stack.name, shard.index);
+      writeFileSync(out, marshalShardSlice(slice));
+      // eslint-disable-next-line no-console
+      console.log(
+        `crawl: shard ${shard.index + 1}/${shard.count} wrote ${out} with ${ownedRows.length} owned surface(s) ` +
+          `— the workflow merge step unions all ${shard.count} slices into ${inventoryPath(stack)}`,
+      );
+    }
   }
 
   if (failures.length > 0) {
@@ -867,16 +1106,23 @@ test('crawl: BFS over every reachable Grafana surface with universal oracles + i
   // row per visited page.
   const committed = loadInventory(stack);
   assertInventoryBootstrapped(committed, stack);
+  // Each shard asserts coverage of the rows IT OWNS — it only audited
+  // its slice. ownsThisShard mirrors the live partition, so the shard
+  // can't be held to rows another shard is responsible for. The merge
+  // step (workflow) proves the slices' union equals the whole inventory,
+  // closing the gap a per-shard diff alone would leave.
+  const ownsThisShard = (url: string): boolean => ownsSurface(url, shard);
   const violations = diffInventory(
     new Set(auditedStates.keys()),
     committed,
     loadExclusions(stack),
     depth,
     stack,
+    ownsThisShard,
   );
   expect(
     violations,
-    `surface-inventory ratchet violated:\n  - ${violations.join('\n  - ')}`,
+    `surface-inventory ratchet violated (shard ${shard.index + 1}/${shard.count}):\n  - ${violations.join('\n  - ')}`,
   ).toEqual([]);
 });
 
@@ -1108,6 +1354,15 @@ async function visitAndAudit(
   entry: QueueEntry,
   declaredNoData: ReadonlyMap<string, Set<string>>,
   declaredErrorExprs: ReadonlyMap<string, Set<string>>,
+  /**
+   * Whether THIS shard owns the surface. Every shard navigates +
+   * harvests every surface (discovery must stay complete so the frontier
+   * converges identically), but only the OWNING shard runs the oracle
+   * battery (DOM + wire + console) and reports its failures — the
+   * non-owning shards never double-audit it. With a single shard `owned`
+   * is always true, so the unsharded behavior is unchanged.
+   */
+  owned: boolean,
 ): Promise<{ harvested: string[]; pageFailures: CrawlFailure[] }> {
   const pageFailures: CrawlFailure[] = [];
   const fail: FailFn = (rule, detail) =>
@@ -1136,16 +1391,24 @@ async function visitAndAudit(
 
     harvested = await harvestLinks(page);
 
-    await evaluateDomOracles(page, contracts, entry.concrete, fail);
+    // Oracles 3 + 4 only on the owning shard — a non-owning shard
+    // visits purely to harvest the frontier.
+    if (owned) await evaluateDomOracles(page, contracts, entry.concrete, fail);
   } catch (err) {
-    fail(
-      'navigation-threw',
-      `goto(${entry.concrete}) threw: ${(err as Error).message}`,
-    );
+    // A navigation failure is a real oracle failure ONLY on the owning
+    // shard; on a non-owning visit it just means harvest came back
+    // empty (the owning shard will report the genuine failure).
+    if (owned) {
+      fail(
+        'navigation-threw',
+        `goto(${entry.concrete}) threw: ${(err as Error).message}`,
+      );
+    }
   } finally {
     stopConsole();
   }
   await wire.stop();
+  if (!owned) return { harvested, pageFailures };
   evaluateWireOracles(wire.captured, contracts, fail);
 
   // Oracle 1 — console errors. Zero, with no noise filter (see the

--- a/test/e2e/playwright/crawl/lib.ts
+++ b/test/e2e/playwright/crawl/lib.ts
@@ -695,6 +695,16 @@ export function diffInventory(
   exclusions: SurfaceExclusions,
   depth: 'lean' | 'full',
   stack: StackFiles,
+  /**
+   * Frontier-sharding predicate: the inventory rows THIS shard owns
+   * (audited the heavy work for). A sharded crawl only audited its ~1/N
+   * slice, so it can only assert coverage of the rows it owns — the
+   * other rows are asserted by their owning shards, and the final
+   * merge step proves the slices' union equals the whole inventory. The
+   * default owns EVERY url (the single-shard / unsharded run), so the
+   * unsharded behavior is byte-for-byte unchanged.
+   */
+  owns: (url: string) => boolean = () => true,
 ): string[] {
   const out: string[] = [];
 
@@ -718,6 +728,10 @@ export function diffInventory(
         `surface ${JSON.stringify(s.url)} is in BOTH the inventory and the exclusions file — a crawled surface cannot be excluded (stale exclusion)`,
       );
     }
+    // Only assert the rows this shard owns. Disjointness + completeness
+    // of the OWNERSHIP partition is the merge step's job; here each
+    // shard guards its own slice against the committed inventory.
+    if (!owns(s.url)) continue;
     if (depth === 'full' || s.lean) expected.add(s.url);
   }
 

--- a/test/e2e/playwright/crawl/sharding.ts
+++ b/test/e2e/playwright/crawl/sharding.ts
@@ -1,0 +1,343 @@
+/**
+ * Crawl BFS-frontier sharding — the deterministic partition that lets
+ * the ~50min single-test() crawl run concurrently across N isolated
+ * k3d clusters.
+ *
+ * The problem it solves
+ * ---------------------
+ * crawl.spec.ts is one async BFS `test()`: Playwright's native
+ * `--shard` (which splits at test() granularity) can't divide it, and
+ * spec-file sharding can't either (one file, one test). The only path
+ * below the full-depth wall-clock floor is to split the BFS frontier
+ * itself.
+ *
+ * The cost asymmetry the partition exploits
+ * -----------------------------------------
+ * DISCOVERY — navigating to a surface and harvesting its nav links to
+ * grow the frontier — is comparatively cheap (one navigation + a DOM
+ * `a[href]` read per surface). The DOMINANT cost is the per-surface
+ * INTERACTION SWEEP (sweepInteractions in crawl.spec.ts drives a FRESH
+ * navigation per planned gesture — many navigations per eligible
+ * surface at full depth) plus the per-surface oracle battery. The
+ * renderer-recycle budget (CONTEXT_RECYCLE_NAVIGATIONS) is spent
+ * overwhelmingly on those gesture navigations.
+ *
+ * So the partition boundary is: EVERY shard runs the WHOLE (cheap) BFS
+ * discovery walk — navigate every surface, harvest, expand the
+ * frontier — so the visited set converges identically on every shard
+ * and discovery stays correct. But shard `i` only runs the HEAVY work
+ * (base-surface oracle battery + the interaction sweep + the in-place
+ * interaction-state audits) on surfaces it OWNS:
+ *
+ *     owns(surface) ⇔ fnv1a(surface) % CRAWL_SHARD_COUNT == CRAWL_SHARD_INDEX
+ *
+ * That splits the dominant cost ~evenly while every shard keeps a
+ * correct, complete frontier.
+ *
+ * Ownership is keyed by the BASE canonical surface, never the in-place
+ * state key (`<canonical>#<control>=<value>`): a surface and ALL its
+ * interaction states must land on the SAME shard so the sweep runs
+ * atomically (the sweep is driven from the base surface). ownerOf()
+ * strips any `#…` state suffix before hashing for exactly this reason.
+ *
+ * The coverage guarantee
+ * ----------------------
+ * The inventory ratchet (lib.ts diffInventory) asserts the FULL audited
+ * set. Per-shard we must NOT weaken it. Each shard emits its OWNED
+ * slice of audited states as an artifact; a final merge step unions
+ * every shard's slice and asserts the union EXACTLY equals the pinned
+ * inventory — no surface missed, none double-owned. mergeShardSlices()
+ * is that exact, disjoint union; it fails loudly on a gap or an overlap.
+ *
+ * Default (unset env) = single shard = today's behavior: COUNT=1,
+ * INDEX=0 owns everything, so compose-smoke's CRAWL_STACK=compose crawl
+ * and any non-sharded run are byte-for-byte unchanged.
+ */
+
+import { join } from 'node:path';
+
+import type { InventorySurface, SurfaceInventory } from './lib.js';
+
+// Env var names — the contract the workflow matrix sets per shard.
+export const CRAWL_SHARD_INDEX_ENV = 'CRAWL_SHARD_INDEX';
+export const CRAWL_SHARD_COUNT_ENV = 'CRAWL_SHARD_COUNT';
+
+// The single-shard default: one shard owning everything, identical to
+// the pre-sharding behavior. Unset env resolves to exactly this.
+export const SINGLE_SHARD_COUNT = 1;
+export const SINGLE_SHARD_INDEX = 0;
+
+// FNV-1a 32-bit constants — a tiny, dependency-free, deterministic
+// string hash. The value only has to be stable run-to-run and
+// well-distributed across the modest shard counts the lane uses; FNV-1a
+// is the canonical pick for that (the same family Go's hash/fnv ships).
+const FNV_OFFSET_BASIS_32 = 0x811c9dc5;
+const FNV_PRIME_32 = 0x01000193;
+
+/**
+ * Stable 32-bit FNV-1a hash of a string, as an unsigned integer.
+ * Deterministic across runs and platforms — the assignment must be
+ * reproducible so every shard agrees on who owns what without any
+ * cross-shard coordination.
+ */
+export function fnv1a32(s: string): number {
+  let h = FNV_OFFSET_BASIS_32;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    // `Math.imul` keeps the multiply in 32-bit space; `>>> 0` coerces
+    // back to unsigned after each step.
+    h = Math.imul(h, FNV_PRIME_32) >>> 0;
+  }
+  return h >>> 0;
+}
+
+/**
+ * The PATH-only base an audited-state key hashes to — the unit of
+ * ownership. Two kinds of derived key must follow their parent surface
+ * onto ONE shard, because the parent's interaction sweep is the ONLY
+ * place they are discovered:
+ *
+ *   - in-place interaction states `<canonical>#<control>=<value>` —
+ *     audited in place during the parent's sweep.
+ *   - structural-param surfaces `<path>?<structural-params>` (e.g.
+ *     `/a/…/explore?var-groupBy=kind`) — URL-encoding deviations the
+ *     parent's sweep enqueues as first-class surfaces; no other shard's
+ *     link-harvest reliably reaches them (they are click-driven).
+ *
+ * Hashing by the bare PATH (strip the first `#…` AND the `?…` query)
+ * groups a surface, all its structural-param children, and all their
+ * in-place states onto the shard that owns the path — the same shard
+ * that sweeps the surface and DISCOVERS the children. Discovery and
+ * ownership coincide, so the frontier never needs a child that a
+ * different shard alone could find. It also makes a surface's whole
+ * sweep an atomic unit of work, which is exactly the cost we balance.
+ */
+export function baseSurfaceOf(stateKey: string): string {
+  const noState = stateKey.split('#', 1)[0] ?? stateKey;
+  return noState.split('?', 1)[0] ?? noState;
+}
+
+/** A resolved, validated shard assignment. */
+export type ShardAssignment = {
+  index: number;
+  count: number;
+};
+
+/**
+ * Resolve the shard assignment from env (or explicit values), with the
+ * unset case defaulting to the single-shard identity. Validates loudly:
+ * a malformed CRAWL_SHARD_INDEX/COUNT must fail the run, never silently
+ * degrade to mis-partitioned coverage.
+ *
+ * Rules:
+ *   - both unset → { index: 0, count: 1 } (today's behavior).
+ *   - count must be an integer ≥ 1.
+ *   - index must be an integer in [0, count).
+ *   - setting one without the other is a configuration error.
+ */
+export function resolveShardAssignment(env: {
+  index?: string;
+  count?: string;
+}): ShardAssignment {
+  const rawIndex = env.index ?? '';
+  const rawCount = env.count ?? '';
+  if (rawIndex === '' && rawCount === '') {
+    return { index: SINGLE_SHARD_INDEX, count: SINGLE_SHARD_COUNT };
+  }
+  if (rawIndex === '' || rawCount === '') {
+    throw new Error(
+      `crawl sharding: ${CRAWL_SHARD_INDEX_ENV} and ${CRAWL_SHARD_COUNT_ENV} must be set together ` +
+        `(got ${CRAWL_SHARD_INDEX_ENV}=${JSON.stringify(rawIndex)}, ${CRAWL_SHARD_COUNT_ENV}=${JSON.stringify(rawCount)}) — ` +
+        `set both for a sharded crawl, or neither for the single-shard default`,
+    );
+  }
+  const count = Number(rawCount);
+  const index = Number(rawIndex);
+  if (!Number.isInteger(count) || count < 1) {
+    throw new Error(
+      `crawl sharding: ${CRAWL_SHARD_COUNT_ENV}=${JSON.stringify(rawCount)} must be an integer ≥ 1`,
+    );
+  }
+  if (!Number.isInteger(index) || index < 0 || index >= count) {
+    throw new Error(
+      `crawl sharding: ${CRAWL_SHARD_INDEX_ENV}=${JSON.stringify(rawIndex)} must be an integer in [0, ${count})`,
+    );
+  }
+  return { index, count };
+}
+
+/** Resolve directly from process.env (the spec's entry point). */
+export function shardAssignmentFromEnv(
+  procEnv: NodeJS.ProcessEnv,
+): ShardAssignment {
+  return resolveShardAssignment({
+    index: procEnv[CRAWL_SHARD_INDEX_ENV],
+    count: procEnv[CRAWL_SHARD_COUNT_ENV],
+  });
+}
+
+/**
+ * Does THIS shard own (run the heavy audit + interaction sweep on) the
+ * given surface/state key? Ownership is by the base canonical surface
+ * so a surface and all its in-place states share one shard. With
+ * count==1 every key is owned (the single-shard identity).
+ */
+export function ownsSurface(
+  stateKey: string,
+  assignment: ShardAssignment,
+): boolean {
+  if (assignment.count === SINGLE_SHARD_COUNT) return true;
+  return fnv1a32(baseSurfaceOf(stateKey)) % assignment.count === assignment.index;
+}
+
+/**
+ * Marshalled per-shard slice artifact. Carries the shard identity (so
+ * the merge can verify it saw every shard exactly once) and the OWNED
+ * audited surfaces this shard pinned. `surfaces` is the same
+ * InventorySurface shape the inventory uses, so the merge can assemble a
+ * full inventory directly.
+ */
+export type ShardSlice = {
+  stack: string;
+  shardIndex: number;
+  shardCount: number;
+  surfaces: InventorySurface[];
+};
+
+/**
+ * Filesystem name of a shard's emitted slice, for stack `stack` and
+ * shard `index`. Lives next to the inventory (crawl/) so the bootstrap
+ * dispatch can upload it as an artifact and the merge step can collect
+ * every shard's slice by glob. Deterministic + filename-safe.
+ */
+export function shardSliceFilename(stack: string, index: number): string {
+  return `grafana-surface-slice.${stack}.shard-${index}.json`;
+}
+
+/** Absolute path of a shard's slice within the crawl/ directory. */
+export function shardSlicePath(
+  crawlDir: string,
+  stack: string,
+  index: number,
+): string {
+  return join(crawlDir, shardSliceFilename(stack, index));
+}
+
+/**
+ * Render a shard's owned slice to its canonical serialized form (sorted
+ * by url, two-space indent, trailing newline) — same convention as
+ * marshalInventory so slices diff cleanly.
+ */
+export function marshalShardSlice(slice: ShardSlice): string {
+  const surfaces = [...slice.surfaces].sort((a, b) =>
+    a.url.localeCompare(b.url),
+  );
+  return `${JSON.stringify(
+    {
+      stack: slice.stack,
+      shardIndex: slice.shardIndex,
+      shardCount: slice.shardCount,
+      surfaces,
+    },
+    null,
+    2,
+  )}\n`;
+}
+
+/**
+ * Exact, disjoint union-merge of every shard's owned slice into the
+ * full surface inventory.
+ *
+ * The coverage guarantee lives here: the merge FAILS LOUDLY when the
+ * slices are not a clean partition. It asserts that
+ *   - exactly `count` slices arrived, one per shard index in [0, count),
+ *     none missing, none duplicated;
+ *   - every slice agrees on the stack and the shard count;
+ *   - no surface url is owned by two shards (disjointness);
+ *   - every owned surface's ownership matches the deterministic
+ *     assignment (a slice can't smuggle in a surface it doesn't own).
+ *
+ * The result is a SurfaceInventory whose surface set is the exact union
+ * of the slices — identical to what a single full crawl would pin (the
+ * single-shard run owns everything, so its one slice IS the full
+ * inventory). The caller marshals it through marshalInventory.
+ */
+export function mergeShardSlices(
+  slices: ReadonlyArray<ShardSlice>,
+  doc: string,
+  stack: string,
+): SurfaceInventory {
+  if (slices.length === 0) {
+    throw new Error('mergeShardSlices: no shard slices supplied');
+  }
+  const count = slices[0]!.shardCount;
+  if (!Number.isInteger(count) || count < 1) {
+    throw new Error(
+      `mergeShardSlices: first slice declares a bad shardCount ${JSON.stringify(count)}`,
+    );
+  }
+
+  const seenIndices = new Map<number, ShardSlice>();
+  for (const slice of slices) {
+    if (slice.stack !== stack) {
+      throw new Error(
+        `mergeShardSlices: slice (index ${slice.shardIndex}) pins stack ${JSON.stringify(slice.stack)} ` +
+          `but the merge target stack is ${JSON.stringify(stack)}`,
+      );
+    }
+    if (slice.shardCount !== count) {
+      throw new Error(
+        `mergeShardSlices: slice (index ${slice.shardIndex}) declares shardCount ${slice.shardCount}, ` +
+          `expected ${count} — the shards ran with inconsistent CRAWL_SHARD_COUNT`,
+      );
+    }
+    if (slice.shardIndex < 0 || slice.shardIndex >= count) {
+      throw new Error(
+        `mergeShardSlices: slice declares shardIndex ${slice.shardIndex} out of range [0, ${count})`,
+      );
+    }
+    if (seenIndices.has(slice.shardIndex)) {
+      throw new Error(
+        `mergeShardSlices: shard index ${slice.shardIndex} appeared twice`,
+      );
+    }
+    seenIndices.set(slice.shardIndex, slice);
+  }
+  for (let i = 0; i < count; i++) {
+    if (!seenIndices.has(i)) {
+      throw new Error(
+        `mergeShardSlices: missing slice for shard index ${i} of ${count} — ` +
+          `every shard must upload its slice or the union is incomplete (coverage gap)`,
+      );
+    }
+  }
+
+  const assignment = (idx: number): ShardAssignment => ({ index: idx, count });
+  const byUrl = new Map<string, InventorySurface>();
+  for (const slice of slices) {
+    for (const surface of slice.surfaces) {
+      // Disjointness: a surface owned by two shards is a partition bug.
+      const prior = byUrl.get(surface.url);
+      if (prior !== undefined) {
+        throw new Error(
+          `mergeShardSlices: surface ${JSON.stringify(surface.url)} owned by more than one shard — ` +
+            `the partition is not disjoint`,
+        );
+      }
+      // The slice can only legitimately own a surface the deterministic
+      // assignment maps to it — guards a hand-tampered slice.
+      if (!ownsSurface(surface.url, assignment(slice.shardIndex))) {
+        throw new Error(
+          `mergeShardSlices: shard ${slice.shardIndex} claims surface ${JSON.stringify(surface.url)} ` +
+            `that the deterministic assignment does NOT map to it`,
+        );
+      }
+      byUrl.set(surface.url, surface);
+    }
+  }
+
+  const surfaces = [...byUrl.values()].sort((a, b) =>
+    a.url.localeCompare(b.url),
+  );
+  return { doc, stack, surfaces };
+}


### PR DESCRIPTION
Follow-up to #916 (which landed the coarse 3-shard matrix). This shards the **crawl BFS frontier itself** so the ~50min single-`test()` full-depth crawl parallelizes across multiple k3d clusters — the only path below the 50min floor.

## Where the cost is
Reading the engine confirms the asymmetry the task assumed: **discovery** (navigate + `harvestLinks` + `canonicalTarget`) is one cheap nav per surface; the **dominant cost** is the per-surface interaction sweep (`sweepInteractions` drives a *fresh navigation per planned gesture* — many per eligible surface at full depth, governed by `CONTEXT_RECYCLE_NAVIGATIONS`) plus the per-page oracle battery.

## How it's partitioned
Every shard runs the **whole** cheap BFS discovery walk (so the visited set converges identically), but shard `i` audits + pins only the surfaces it **owns**: `fnv1a(path) % CRAWL_SHARD_COUNT == CRAWL_SHARD_INDEX`. Ownership hashes the **bare path** (strip `?query` and `#state`), so a surface, its structural-param children (`?var-groupBy=kind`, click-discovered by the sweep), and its in-place states all co-locate on one shard — **discovery and ownership coincide**, so no shard depends on a surface only another shard could discover. Default (unset env) = single shard = today's behavior; compose-smoke is unchanged.

## How coverage stays exact
- Per-shard ratchet: `diffInventory` gains an `owns` predicate so each shard asserts only its owned rows.
- Union-merge: on the `update_crawl_inventory` dispatch each shard emits its owned slice; the new `dashboard-merge` job (`crawl-inventory-merge.mjs`) unions them, asserting an **exact, disjoint, total** cover — missing shard / double-owned surface / smuggled surface all fail loudly. A per-shard ratchet alone could miss a surface no shard owned; the union-merge proves the slices reconstitute the whole.

## Unit tests (pure, isolated)
`crawl-inventory-merge.test.mjs` + the sharding pins in `crawl.spec.ts` prove: assignment is total + disjoint + deterministic over a sample set; a family co-locates on one shard; the union of slices == the full set; the merge fails on missing/overlapping/smuggled slices; FNV-1a lockstep between the `.mjs` and `.ts`. All 15 mjs tests + `tsc --noEmit` pass.

## Layout
2 smoke shards + `CRAWL_SUB_SHARDS=2` crawl shards = 4 k3d clusters (kept modest — k3d is heavy/flaky). Expected wall-clock 50min → ~50/2 ≈ 25min for the crawl long pole.

## Needs a dispatch to validate
The k3d inventory is still unbootstrapped (`surfaces: []`). A `workflow_dispatch` with `update_crawl_inventory=true` is required to bootstrap: each sub-shard runs the full crawl, emits its slice, and `dashboard-merge` unions them into the full inventory artifact to commit. The logic is correct-by-construction (single-shard == full crawl) but cannot be validated against a live cluster locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)