### PR TITLE
test(property): adapt LogQL outcome decoder to StreamValue struct (#908 follow-up)

### DIFF
--- a/test/property/logql_test.go
+++ b/test/property/logql_test.go
@@ -166,8 +166,8 @@ func runCerberusLogQLInstant(ctx context.Context, baseURL string, q property.Que
 		ErrorType string `json:"errorType"`
 		Error     string `json:"error"`
 		Data      struct {
-			ResultType string         `json:"resultType"`
-			Result     []loki.Stream  `json:"result"`
+			ResultType string        `json:"resultType"`
+			Result     []loki.Stream `json:"result"`
 		} `json:"data"`
 	}
 	if err := json.Unmarshal(body, &parsed); err != nil {
@@ -196,14 +196,14 @@ func runCerberusLogQLInstant(ctx context.Context, baseURL string, q property.Que
 	for _, s := range parsed.Data.Result {
 		stripped := copyLabels(s.Stream)
 		for _, v := range s.Values {
-			ts, line, perr := parseStreamSample(v)
+			ts, perr := parseStreamSample(v)
 			if perr != nil {
 				return property.Outcome{Err: fmt.Errorf("property: parse stream sample: %w", perr)}
 			}
 			out.Rows = append(out.Rows, property.OutcomeRow{
 				Labels:      copyLabels(stripped),
 				TimestampMs: ts / int64(1e6),
-				Line:        line,
+				Line:        v.Line,
 			})
 		}
 	}
@@ -220,14 +220,15 @@ func runCerberusLogQLInstant(ctx context.Context, baseURL string, q property.Que
 	return out
 }
 
-// parseStreamSample decodes a [unix_nanos_string, line_text] tuple
-// from Loki's streams response shape.
-func parseStreamSample(v [2]string) (int64, string, error) {
-	ts, err := strconv.ParseInt(v[0], 10, 64)
+// parseStreamSample decodes the nanosecond timestamp from a Loki stream
+// value. [loki.StreamValue] already carries the parsed Line + structured
+// Metadata; only the unix-nanos Timestamp string still needs conversion.
+func parseStreamSample(v loki.StreamValue) (int64, error) {
+	ts, err := strconv.ParseInt(v.Timestamp, 10, 64)
 	if err != nil {
-		return 0, "", fmt.Errorf("parse timestamp %q: %w", v[0], err)
+		return 0, fmt.Errorf("parse timestamp %q: %w", v.Timestamp, err)
 	}
-	return ts, v[1], nil
+	return ts, nil
 }
 
 // copyLabels returns a fresh map[string]string identical to in. The


### PR DESCRIPTION
## Root cause

The `property` CI lane (oracle property tests) failed on push-to-main **run 27506750940** — not a property divergence, but a **build break**:

```
test/property/logql_test.go:199:40: cannot use v (variable of struct type loki.StreamValue) as [2]string value in argument to parseStreamSample
FAIL github.com/tsouza/cerberus/test/property [build failed]
```

**Classification: regression-from-merge.** PR #908 ("surface per-line structured metadata for Logs Drilldown columns") changed `internal/api/loki.StreamValue` from a positional `[2]string` tuple into a struct:

```go
type StreamValue struct {
    Timestamp  string
    Line       string
    Metadata   map[string]string
    Categorize bool
}
```

`test/property` is build-tagged `chdb` and so isn't compiled by the per-PR `check` job — only the nightly/push `property` lane builds it. #908's PR CI was therefore green; the break only surfaced on the push-to-main property run. The LogQL outcome decoder still called `parseStreamSample(v [2]string)` against `s.Values` (now `[]loki.StreamValue`).

## Fix

`internal/api/loki.StreamValue` already decodes via its custom `UnmarshalJSON`, so the parsed `Line` is available directly off the struct. Read `v.Line` inline and narrow `parseStreamSample` to converting the unix-nanos `Timestamp` string:

- before: `func parseStreamSample(v [2]string) (int64, string, error)` → returns `(ts, v[1])`
- after: `func parseStreamSample(v loki.StreamValue) (int64, error)` → parses `v.Timestamp`; caller reads `v.Line`

No semantic change to the comparator: `OutcomeRow` pairs by (labels, ts, line); structured metadata isn't part of the LogQL stream comparison.

## Verification

- `go vet -tags chdb ./test/property/` — clean
- `go test -tags chdb -run TestLogQL_Property ./test/property/ -rapid.checks=80` — PASS
- `go test -tags chdb ./test/property/ -rapid.checks=120` (PromQL + LogQL) — 3 PASS, no divergence
- `go build ./...` — Success
- `gofumpt -extra -l` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)