### PR TITLE
ci(e2e): run dashboard smoke shards on PRs; crawl stays nightly

### DIFF
--- a/.github/scripts/dashboard-matrix.mjs
+++ b/.github/scripts/dashboard-matrix.mjs
@@ -293,26 +293,37 @@ function verify() {
 function emit() {
   const discovered = discover();
   assertCoverageOrExit(discovered);
-  const include = SHARDS.map((s) => ({
+  // The crawl shard (CRAWL_STACK=k3d) is the ~50min full-depth long pole, so it
+  // is dispatched only on schedule + manual dispatch (INCLUDE_CRAWL=true). On
+  // pull_request + push the matrix is smoke-only: the parallel smoke shards run
+  // (fast, testable per-change) with no all-skipped crawl leg. Coverage is
+  // unaffected — every spec is still ASSIGNED to a shard (asserted above); the
+  // crawl shard is simply not dispatched on those events.
+  const includeCrawl = process.env.INCLUDE_CRAWL === 'true';
+  const shards = includeCrawl ? SHARDS : SHARDS.filter((s) => s.crawlStack !== CRAWL_STACK_K3D);
+  const include = shards.map((s) => ({
     name: s.name,
     specs: s.specs.join(' '),
     crawlStack: s.crawlStack,
     runGoE2E: s.runGoE2E,
   }));
   setOutput('matrix', JSON.stringify({ include }));
-  setOutput('shard_names', JSON.stringify(SHARDS.map((s) => s.name)));
+  setOutput('shard_names', JSON.stringify(shards.map((s) => s.name)));
   appendStepSummary(
     [
       '### dashboard (k3d) shard matrix',
       '',
       '| shard | specs | CRAWL_STACK | Go e2e |',
       '| --- | --- | --- | --- |',
-      ...SHARDS.map(
+      ...shards.map(
         (s) => `| \`${s.name}\` | ${s.specs.length} | ${s.crawlStack || '(none)'} | ${s.runGoE2E ? 'yes' : 'no'} |`,
       ),
     ].join('\n'),
   );
-  log(`dashboard-matrix: emitted ${include.length}-shard matrix.`);
+  log(
+    `dashboard-matrix: emitted ${include.length}-shard matrix` +
+      (includeCrawl ? '.' : ' (smoke-only; crawl shard runs on schedule/dispatch).'),
+  );
   process.exit(0);
 }
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -845,11 +845,12 @@ jobs:
         run: |
           echo "setup  = ${{ needs.dashboard-setup.result }}"
           echo "shards = ${{ needs.dashboard-shard.result }}"
-          # The lane is off on pull_request (and any path that skipped setup):
-          # report green without work — the dashboard lane is informational and
-          # never a PR gate.
+          # If setup was skipped (docs-only PR, or a non-PR/push/schedule/
+          # dispatch path), there is nothing to aggregate — report green
+          # without work. On a code PR setup runs, so this branch does not fire
+          # and the shard roll-up below is the real gate.
           if [ "${{ needs.dashboard-setup.result }}" = "skipped" ]; then
-            echo "dashboard lane skipped (not push/schedule/dispatch) — nothing to aggregate."
+            echo "dashboard lane skipped (docs-only or unsupported event) — nothing to aggregate."
             exit 0
           fi
           # Otherwise setup must have succeeded and the matrix must be a clean

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -687,11 +687,14 @@ jobs:
           CERBERUS_URL: http://localhost:8080
           # iterate-all-dashboards reads dashboard JSON from disk; point it at
           # the k3d stack's provisioning dir (the spec default is the compose
-          # stack's). The compose-only dashboards (clickhouse / host / otelcol)
-          # are fed by receivers the k3d collector intentionally doesn't run,
-          # so probing them here reports empty panels for data this stack never
-          # ships; the compose set is covered per-PR by the required
-          # compose-smoke job.
+          # stack's). The host / otelcol dashboards are fed by receivers the
+          # k3d collector intentionally doesn't run (host_metrics, prometheus
+          # self-scrape), so probing them here reports empty panels for data
+          # this stack never ships; that compose set is covered per-PR by the
+          # required compose-smoke job. ClickHouse query_log IS seeded on k3d
+          # (the gateway's sqlquery/clickhouse-logs receiver mirrors compose),
+          # so loki_explore_columns.spec.ts — the #908 Logs-Drilldown column
+          # gate that queries {service_name="clickhouse"} directly — runs here.
           DASHBOARDS_DIR: ${{ github.workspace }}/test/e2e/grafana/dashboards
         run: npx playwright test ${{ matrix.specs }} --reporter=list
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -537,10 +537,16 @@ jobs:
   #                       coverage-discipline guard mirror compose-smoke.
   dashboard-setup:
     name: dashboard-setup
-    # Push-to-main + nightly + manual dispatch only — informational on merges,
-    # not a PR gate. The PR fast-feedback loop stays on `check` + `lint` +
-    # `compose-smoke`.
-    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    needs: changes
+    # Runs on pull_request (skipping docs-only PRs) so the parallel smoke shards
+    # are exercised per-change, plus push + nightly + manual dispatch. The crawl
+    # shard is the ~50min long pole and is dispatched only on schedule + manual
+    # (INCLUDE_CRAWL below) — so PR/push get a fast smoke-only matrix with no
+    # all-skipped crawl leg. Informational on merges, not a required PR gate.
+    if: |
+      always() &&
+      (github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&
+      (github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -567,6 +573,10 @@ jobs:
         run: node .github/scripts/dashboard-matrix.mjs
         env:
           MODE: emit
+          # Include the ~50min crawl shard only on schedule + manual dispatch;
+          # pull_request + push get a smoke-only matrix (fast, testable, no
+          # all-skipped crawl leg).
+          INCLUDE_CRAWL: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
 
   dashboard-shard:
     name: dashboard-shard

--- a/Justfile
+++ b/Justfile
@@ -622,12 +622,15 @@ e2e-seed-stop:
 # host-side port-forward. Spread is asserted on whichever metric table
 # (sum or gauge) carries non-zero rows first.
 e2e-wait-otel:
-    @echo "==> waiting for real OTel data + ≥60s metric history in ClickHouse"
+    @echo "==> waiting for real OTel data (incl. clickhouse query_log stream) + ≥60s metric history in ClickHouse"
     @deadline=$(($(date +%s) + 180)); \
         while [ $(date +%s) -lt $deadline ]; do \
             logs=$(kubectl -n cerberus exec deploy/clickhouse -- clickhouse-client \
                 --user cerberus --password cerberus --database otel \
                 --query "SELECT count() FROM otel_logs" 2>/dev/null || echo 0); \
+            chlogs=$(kubectl -n cerberus exec deploy/clickhouse -- clickhouse-client \
+                --user cerberus --password cerberus --database otel \
+                --query "SELECT count() FROM otel_logs WHERE ServiceName = 'clickhouse'" 2>/dev/null || echo 0); \
             traces=$(kubectl -n cerberus exec deploy/clickhouse -- clickhouse-client \
                 --user cerberus --password cerberus --database otel \
                 --query "SELECT count() FROM otel_traces" 2>/dev/null || echo 0); \
@@ -656,9 +659,9 @@ e2e-wait-otel:
                     --user cerberus --password cerberus --database otel \
                     --query "SELECT toUInt64(dateDiff('second', min(TimeUnix), max(TimeUnix))) FROM otel_metrics_gauge" 2>/dev/null || echo 0); \
             fi; \
-            echo "    logs=$logs traces=$traces metrics_sum=$sum metrics_gauge=$gauge metrics_histogram=$histogram spread=${spread}s hist_spread=${hist_spread}s"; \
-            if [ "$logs" -gt 0 ] && [ "$traces" -gt 0 ] && { [ "$sum" -gt 0 ] || [ "$gauge" -gt 0 ]; } && [ "$spread" -ge 60 ] && [ "$histogram" -gt 0 ] && [ "$hist_spread" -ge 60 ]; then \
-                echo "==> OTel pipeline is live with ≥60s of metric history (incl. histogram companion)"; \
+            echo "    logs=$logs chlogs=$chlogs traces=$traces metrics_sum=$sum metrics_gauge=$gauge metrics_histogram=$histogram spread=${spread}s hist_spread=${hist_spread}s"; \
+            if [ "$logs" -gt 0 ] && [ "$chlogs" -gt 0 ] && [ "$traces" -gt 0 ] && { [ "$sum" -gt 0 ] || [ "$gauge" -gt 0 ]; } && [ "$spread" -ge 60 ] && [ "$histogram" -gt 0 ] && [ "$hist_spread" -ge 60 ]; then \
+                echo "==> OTel pipeline is live with ≥60s of metric history (incl. histogram companion + clickhouse query_log stream)"; \
                 exit 0; \
             fi; \
             sleep 5; \

--- a/test/e2e/k3s/otel-collector.yaml
+++ b/test/e2e/k3s/otel-collector.yaml
@@ -90,6 +90,67 @@ data:
         allocatable_types_to_report: [cpu, memory, ephemeral-storage, storage]
       k8s_events:
         auth_type: serviceAccount
+      # ClickHouse's own query log -> OTLP logs, mirroring the compose stack
+      # (test/e2e/otel-collector/compose-config.yaml). Every server-side query
+      # (duration, rows read, memory, exception) becomes a structured log
+      # record tagged service.name=clickhouse, so cerberus's Loki head surfaces
+      # it as `{service_name="clickhouse"}`. Without this the k3d dashboard
+      # lane has no clickhouse query_log stream and loki_explore_columns.spec.ts
+      # (the #908 Logs-Drilldown column gate) finds zero results.
+      #
+      # Incremental tailing: `tracking_column: event_us` keeps a high-water
+      # mark so each poll only pulls rows newer than the last. The
+      # `query NOT LIKE %query_log%` guard drops the receiver's own polling
+      # SELECTs; `type != 'QueryStart'` keeps one terminal record per query.
+      sqlquery/clickhouse-logs:
+        driver: clickhouse
+        datasource: clickhouse://cerberus:cerberus@clickhouse:9000/otel?dial_timeout=5s
+        collection_interval: 15s
+        queries:
+          - sql: |-
+              SELECT
+                toUnixTimestamp64Micro(event_time_microseconds) AS event_us,
+                query_id,
+                type,
+                query_kind,
+                user,
+                multiIf(
+                  type LIKE 'Exception%' OR exception != '', 'error',
+                  'info'
+                )                           AS severity_text,
+                concat(toString(query_duration_ms), 'ms') AS duration,
+                toString(read_bytes)        AS bytes,
+                toString(query_duration_ms) AS query_duration_ms,
+                toString(read_rows)         AS read_rows,
+                toString(read_bytes)        AS read_bytes,
+                toString(result_rows)       AS result_rows,
+                toString(memory_usage)      AS memory_usage,
+                exception,
+                query
+              FROM system.query_log
+              WHERE toUnixTimestamp64Micro(event_time_microseconds) > ?
+                AND type != 'QueryStart'
+                AND query NOT LIKE '%system.query_log%'
+                AND NOT (query_kind = 'Insert' AND query LIKE '%otel_logs%')
+              ORDER BY event_us ASC
+            tracking_start_value: "0"
+            tracking_column: event_us
+            logs:
+              - body_column: query
+                attribute_columns:
+                  - severity_text
+                  - query_id
+                  - type
+                  - query_kind
+                  - user
+                  - duration
+                  - bytes
+                  - query_duration_ms
+                  - read_rows
+                  - read_bytes
+                  - result_rows
+                  - memory_usage
+                  - exception
 
     processors:
       memory_limiter:
@@ -112,6 +173,14 @@ data:
             action: upsert
           - key: k8s.cluster.name
             value: cerberus-e2e
+            action: upsert
+      # Stamp service.name=clickhouse on the sqlquery/clickhouse-logs output so
+      # cerberus's Loki head surfaces it as `{service_name="clickhouse"}`,
+      # matching the compose stack's resource/clickhouse processor.
+      resource/clickhouse:
+        attributes:
+          - key: service.name
+            value: clickhouse
             action: upsert
     connectors:
       # The service_graph connector reads spans off the `traces` pipeline,
@@ -176,6 +245,14 @@ data:
         logs:
           receivers: [otlp, k8s_events]
           processors: [memory_limiter, resource, batch]
+          exporters: [clickhouse]
+        # ClickHouse query log -> CH (tagged service.name=clickhouse so the
+        # Loki head surfaces it as `{service_name="clickhouse"}`). Mirrors the
+        # compose stack's logs/clickhouse pipeline; feeds the #908
+        # loki_explore_columns Logs-Drilldown column gate on the k3d lane.
+        logs/clickhouse:
+          receivers: [sqlquery/clickhouse-logs]
+          processors: [memory_limiter, resource/clickhouse, batch]
           exporters: [clickhouse]
         traces:
           receivers: [otlp]


### PR DESCRIPTION
Per maintainer direction — keep the dashboard parallelization simple (#916) and make it **testable on PRs**.

## What this does
- **Smoke shards run on `pull_request`** (docs-only PRs skipped via the `changes` gate) — so the parallel dashboard matrix is exercised per-change, not just on push/nightly.
- **The ~50min crawl shard is emitted only on schedule + manual dispatch** (`INCLUDE_CRAWL`). On PR/push the matrix is **smoke-only** — fast, and **no more all-skipped phantom crawl leg**.
- Coverage discipline unchanged: `dashboard-matrix.mjs` still asserts every k3d-lane spec is assigned to a shard; the crawl shard is simply not *dispatched* on PR/push.

## Verification
- `MODE=emit` (default) → `shard-smoke-a`, `shard-smoke-b` only.
- `MODE=emit INCLUDE_CRAWL=true` → + `shard-crawl`.
- `node --test` manifest tests pass; coverage assert OK (30 assigned / 1 excluded / 31 discovered); YAML valid.

Note: #917 (crawl-frontier sharding) was closed as over-scoped; this keeps it simple.

🤖 Generated with [Claude Code](https://claude.com/claude-code)