### PR TITLE
fix(e2e): dashboard-shard matrix skips on push — missing always() in if

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -581,7 +581,14 @@ jobs:
   dashboard-shard:
     name: dashboard-shard
     needs: [dashboard-setup]
-    if: needs.dashboard-setup.result == 'success'
+    # always() is REQUIRED: without a status function GitHub prepends an
+    # implicit success(), which is false whenever a transitive need is skipped
+    # — and dashboard-setup's `changes` need is skipped on push/schedule, so
+    # the matrix never expanded there (green on PRs, skipped on push). Mirror
+    # compose-smoke-shard: run regardless, then require setup to have emitted.
+    if: |
+      always() &&
+      needs.dashboard-setup.result == 'success'
     runs-on: ubuntu-latest
     strategy:
       # MANDATORY: one shard's failure must NOT cancel its siblings — each


### PR DESCRIPTION
## Root cause
`dashboard-shard`'s `if: needs.dashboard-setup.result == 'success'` has no status function, so GitHub **implicitly prepends `success()`** — which requires *all transitive* needs to have succeeded. `dashboard-setup` has `needs: changes`, and the `changes` job is **skipped on push/schedule** → implicit `success()` is false → `dashboard-shard` is skipped → the matrix never expands → the `dashboard` aggregate gate fails (`shards = skipped`).

This is why the dashboard lane was **green on PRs** (where `changes` runs) but **red on every push-to-main** since the matrix split (#916) — it's non-required, so it went unnoticed until the lane started running on PRs (#919).

## Fix
Add `always() &&` (mirroring the working `compose-smoke-shard`), so the matrix expands regardless of the skipped transitive need, then explicitly require `needs.dashboard-setup.result == 'success'`. One-line behavioral fix; no other change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)