### PR TITLE
docs: finalize v1.0.0-RC1 changelog + known-limitations (TraceQL corpus, #94)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,43 @@ delivers most of these. The remainder are honest gaps still to close:
 - LogQL: `| json`, `| logfmt`, `| regexp` parser stages; `unwrap`-based ops.
 - TraceQL: recursive structural ops `>>` / `<<` and sibling ops.
 
+### Known limitations / experimental notes (RC1 posture)
+
+RC1 is an early, experimental cut. The differential harnesses gate every
+merge, but correctness, performance, and operational behaviour are still
+being shaken out — **validate cerberus against your own corpus before
+pointing anything real at it** (see the README warning). The
+maintainer-accepted caveats specific to this candidate:
+
+- **TraceQL conformance is the weakest of the three heads.** PromQL is
+  scored against the third-party CNCF / PromLabs
+  [PromQL Compliance Tester](https://github.com/prometheus/compliance) and
+  LogQL against a real reference Loki seeded from Grafana's own
+  `pkg/logql/bench` corpus, but **there is no third-party TraceQL
+  conformance suite** to draw on. The TraceQL harness diffs against a real
+  reference Tempo, yet its corpus is author-written cerberus-owned TXTAR, so
+  its breadth is author-bounded rather than reference-derived. Raising
+  TraceQL's confidence is the top post-RC1 improvement item. See
+  [`docs/compatibility.md`](docs/compatibility.md#traceql--cerberus-owned-driver)
+  for the per-head confidence table and the full reasoning.
+
+- **Per-head circuit-breaker isolation is in place but not fully hardened
+  ([#94]).** The single `chclient.Client` holds a registry of breakers —
+  one per data-plane head (`prom` / `loki` / `tempo`) plus a dedicated
+  `probe` breaker for `/readyz` — so one head tripping OPEN no longer 503s
+  the others or evicts the pod (see
+  [`docs/operations.md`](docs/operations.md#clickhouse-circuit-breaker) for
+  the blast-radius contract). Full isolation and independent-recovery
+  hardening is post-RC1 work: after a ClickHouse restart, recovery may
+  briefly flap as the per-head HALF-OPEN probes re-converge. This is being
+  improved separately and is a known experimental rough edge, not a
+  blocker.
+
+- **Not production-ready.** Cerberus remains experimental and under active
+  development; the surface is evolving and breaking changes are expected.
+  Do not stand it in for a running Prometheus / Loki / Tempo deployment
+  without first evaluating it against your own queries and data.
+
 ## [v0.1.0] — Seed
 
 First tagged release. Closes the seed series (PR1–PR7 + admin + roadmap):


### PR DESCRIPTION
## What

Finalizes the `CHANGELOG.md` for the **first** cerberus release, `v1.0.0-RC1`.

The CHANGELOG was **already RC1-shaped** after #905 ("collapse changelog to RC1 only + honest experimental tone") — a single `[v1.0.0-RC1]` entry plus the `[v0.1.0]` seed entry, with an honest-experimental intro and no leftover RC2/RC3/RC4 stamps. This PR does **not** re-shape it; it adds the maintainer-accepted RC1 *known-limitations* posture that was still missing.

## Added — "Known limitations / experimental notes (RC1 posture)"

A focused subsection at the end of the RC1 entry, capturing the accepted caveats and cross-referencing the canonical docs rather than duplicating them:

- **TraceQL conformance is the weakest leg.** PromQL is scored against the third-party CNCF / PromLabs PromQL Compliance Tester and LogQL against a real reference Loki + Grafana's `pkg/logql/bench` corpus, but there is no third-party TraceQL conformance suite — the TraceQL harness diffs a real reference Tempo against an *author-written cerberus-owned TXTAR* corpus, so breadth is author-bounded. Documented as the top post-RC1 improvement item; links to `docs/compatibility.md` (the per-head confidence table, already landed via #907 — extended, not duplicated).
- **Per-head circuit-breaker isolation (#94).** Per-head breakers (`prom` / `loki` / `tempo`) + a dedicated `/readyz` `probe` breaker exist; full isolation / independent-recovery hardening is post-RC1, and recovery may briefly flap after a ClickHouse restart (improved separately). Phrased as an honest experimental rough edge, not alarm; links to `docs/operations.md`.
- **Not production-ready.** Reaffirms the experimental stance, consistent with the README warning block.

## Discipline

- Docs / CHANGELOG only — no code touched.
- `markdownlint-cli2 CHANGELOG.md` → **0 errors** (MD060 aligned, MD024 siblings-only, the `[#94]` ref matches the file's existing bare reference-link style).
- No maturity overclaim; timeless-docs discipline (no evolution narrative).

🤖 Generated with [Claude Code](https://claude.com/claude-code)