### PR TITLE
fix(chclient): evict+retry stale pooled conns so the breaker recovers promptly after CH restart

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -90,18 +90,20 @@ these connection inputs.
 
 ## Connection pool
 
-These reproduce clickhouse-go/v2's previously-implicit pool defaults verbatim,
-made explicit so the sharded-pushdown solver can raise the ceiling for fan-out
-rather than inherit a hidden driver default. When the pool is exhausted an
-acquire blocks up to `CERBERUS_CH_DIAL_TIMEOUT` and then fails with a
-breaker-neutral acquire-timeout (a local pool-sizing signal, not a
+The connection-count defaults reproduce clickhouse-go/v2's previously-implicit
+pool sizing verbatim, made explicit so the sharded-pushdown solver can raise the
+ceiling for fan-out rather than inherit a hidden driver default. The
+connection-lifetime default departs deliberately (see the row below) so a stale
+conn to a restarted ClickHouse backend is recycled fast. When the pool is
+exhausted an acquire blocks up to `CERBERUS_CH_DIAL_TIMEOUT` and then fails with
+a breaker-neutral acquire-timeout (a local pool-sizing signal, not a
 ClickHouse-health failure).
 
-| Variable                        | Type     | Default | Description                                                        |
-| ------------------------------- | -------- | ------- | ------------------------------------------------------------------ |
-| `CERBERUS_CH_MAX_OPEN_CONNS`    | int      | `10`    | Total pooled ClickHouse connections (busy + idle). Must be > 0.    |
-| `CERBERUS_CH_MAX_IDLE_CONNS`    | int      | `5`     | Idle ClickHouse connections kept warm for reuse. Must be > 0.      |
-| `CERBERUS_CH_CONN_MAX_LIFETIME` | duration | `1h`    | Max age of a pooled connection before it is recycled. Must be > 0. |
+| Variable                        | Type     | Default | Description                                                                                                                                                                           |
+| ------------------------------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CERBERUS_CH_MAX_OPEN_CONNS`    | int      | `10`    | Total pooled ClickHouse connections (busy + idle). Must be > 0.                                                                                                                       |
+| `CERBERUS_CH_MAX_IDLE_CONNS`    | int      | `5`     | Idle ClickHouse connections kept warm for reuse. Must be > 0.                                                                                                                         |
+| `CERBERUS_CH_CONN_MAX_LIFETIME` | duration | `5m`    | Max age of a pooled connection before it is recycled. Kept short (vs the driver's 1h) so a stale conn to a restarted ClickHouse pod is recycled in minutes, not an hour. Must be > 0. |
 
 ## Query limits and memory
 

--- a/internal/chclient/breaker.go
+++ b/internal/chclient/breaker.go
@@ -503,8 +503,11 @@ func (b *breaker) record(ctx context.Context, err error) {
 }
 
 // observeLevel returns the breaker's CURRENT lifecycle phase as the gauge
-// level (breakerGaugeClosed / _Open / _HalfOpen) plus its stable string label,
-// read under b.mu so the observable-gauge callback gets a tear-free snapshot.
+// level (breakerGaugeClosed / _Open / _HalfOpen), read under b.mu so the
+// observable-gauge callback gets a tear-free snapshot. The level IS the phase
+// — there is no companion string label, because a phase-keyed label would
+// orphan the prior-phase series on every transition and leave it stale (see
+// registerStateCallback).
 //
 // Unlike peek(), it does NOT evaluate the OPEN backoff window: the gauge must
 // mirror the breaker's STORED state field exactly (the same value
@@ -512,19 +515,19 @@ func (b *breaker) record(ctx context.Context, err error) {
 // allow() has yet driven to HALF-OPEN still reports OPEN — the gauge tracks
 // what the breaker IS, not what the next allow() would make it. A nil breaker
 // (zero-value Client) is permanently CLOSED, matching allow().
-func (b *breaker) observeLevel() (int64, string) {
+func (b *breaker) observeLevel() int64 {
 	if b == nil {
-		return breakerGaugeClosed, "closed"
+		return breakerGaugeClosed
 	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	switch b.state {
 	case stateOpen:
-		return breakerGaugeOpen, "open"
+		return breakerGaugeOpen
 	case stateHalfOpen:
-		return breakerGaugeHalfOpen, "half-open"
+		return breakerGaugeHalfOpen
 	default:
-		return breakerGaugeClosed, "closed"
+		return breakerGaugeClosed
 	}
 }
 

--- a/internal/chclient/breaker_metrics.go
+++ b/internal/chclient/breaker_metrics.go
@@ -15,11 +15,6 @@ import (
 // trip events.
 const breakerMeterName = "github.com/tsouza/cerberus/internal/chclient"
 
-// attrBreakerState labels the gauge with the lifecycle phase the gauge sample
-// corresponds to — "closed" / "open" / "half-open" — using the same stable
-// vocabulary peek() / currentState() / observeLevel() return.
-const attrBreakerState = attribute.Key("state")
-
 // attrBreakerHead labels every breaker sample with the logical head the
 // breaker fronts — "prom" / "loki" / "tempo" / "probe". Adding this label
 // (per-head isolation, #94) turns the single cerberus_ch_breaker_state /
@@ -55,10 +50,21 @@ type breakerMetrics struct {
 	// lifecycle phase (closed/open/half-open). It is reported by a callback
 	// on every collection interval, reading each live breaker's current
 	// state, so the exported series always reflects the breaker's real state
-	// and can NEVER go stale — the failure mode of a synchronous gauge
-	// recorded only on transitions, which lingers at the last-transitioned
-	// value (e.g. a transient HALF-OPEN) long after the breaker has actually
-	// closed.
+	// and can NEVER go stale. Two distinct staleness traps are avoided:
+	//
+	//   1. A SYNCHRONOUS gauge recorded only on transitions lingers at the
+	//      last-transitioned value (e.g. a transient HALF-OPEN) long after the
+	//      breaker has closed. The OBSERVABLE callback re-reads live state
+	//      every interval, so it can't.
+	//   2. Keying the phase as a metric LABEL (state="open" / "closed") makes
+	//      every transition mint a NEW series and ORPHAN the previous one. An
+	//      OTel observable gauge only overwrites series it re-observes, so the
+	//      orphaned series lingers at its last value over OTLP forever — a
+	//      recovered breaker would still export a stale state="open"=1 next to
+	//      the live state="closed"=0, and a max()-across-series read (the chaos
+	//      lane's recovery assert) would read the breaker as permanently OPEN.
+	//      So the phase rides ONLY the numeric level; the gauge is keyed on
+	//      `head` alone — one series per head, overwritten in place.
 	state metric.Int64ObservableGauge
 	// trips is the cumulative count of CLOSED->OPEN trips — the
 	// highest-blast-radius event (one trip 503s all three heads and
@@ -142,10 +148,21 @@ func (m *breakerMetrics) registerStateCallback(breakers ...*breaker) {
 	_, err := m.meter.RegisterCallback(
 		func(_ context.Context, observer metric.Observer) error {
 			for _, b := range breakers {
-				level, label := b.observeLevel()
-				observer.ObserveInt64(m.state, level, metric.WithAttributes(
+				// The level (0/1/2) IS the phase — do NOT also stamp the
+				// phase as a `state` label. A leveled gauge must keep ONE
+				// series per head: if the phase rode a label, every
+				// transition would mint a NEW series (state="open" →
+				// state="closed") and ORPHAN the previous one. An OTel
+				// observable gauge only overwrites series it re-observes each
+				// interval, so an orphaned series lingers at its last value
+				// forever — a recovered breaker would still export a stale
+				// state="open"=1 alongside the live state="closed"=0, and any
+				// max()-across-series read (the chaos lane's recovery assert)
+				// would read the breaker as permanently OPEN. One series per
+				// head, keyed only on head, overwrites in place every interval
+				// and is the only encoding that can never go stale.
+				observer.ObserveInt64(m.state, b.observeLevel(), metric.WithAttributes(
 					attrBreakerHead.String(b.head.String()),
-					attrBreakerState.String(label),
 				))
 			}
 			return nil

--- a/internal/chclient/breaker_metrics_test.go
+++ b/internal/chclient/breaker_metrics_test.go
@@ -13,11 +13,16 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
-// breakerGaugeLevels collects every cerberus_ch_breaker_state data point from
-// a manual-reader snapshot, keyed by its "state" attribute. The gauge is
-// observable: its callback reports exactly one sample per breaker (the head's
-// CURRENT state) on each collection, so the map holds the live level per
-// state-label present in this snapshot.
+// breakerGaugeLevels collects the cerberus_ch_breaker_state data points from a
+// manual-reader snapshot, keyed by the breaker's HEAD. The gauge carries ONE
+// series per head, keyed only on `head` — the numeric level (0/1/2) IS the
+// phase, so there is deliberately NO `state` label. A leveled gauge keyed on
+// the phase would orphan the prior-phase series on every transition (an OTel
+// observable gauge only overwrites series it re-observes), leaving a stale
+// state="open"=1 lingering after recovery — exactly the chaos-lane bug. So the
+// helper additionally asserts NO data point carries a `state` attribute, and
+// that no head appears more than once: the invariants that keep the gauge from
+// going stale over OTLP.
 func breakerGaugeLevels(t *testing.T, reader *metric.ManualReader) map[string]int64 {
 	t.Helper()
 	var rm metricdata.ResourceMetrics
@@ -37,11 +42,17 @@ func breakerGaugeLevels(t *testing.T, reader *metric.ManualReader) map[string]in
 				t.Fatalf("breaker_state data: want Gauge[int64], got %T", m.Data)
 			}
 			for _, dp := range g.DataPoints {
-				st, ok := dp.Attributes.Value("state")
-				if !ok {
-					t.Fatalf("breaker_state data point missing state attribute: %v", dp.Attributes.ToSlice())
+				if _, ok := dp.Attributes.Value("state"); ok {
+					t.Fatalf("breaker_state must NOT carry a `state` label (orphan-series bug): %v", dp.Attributes.ToSlice())
 				}
-				levels[st.AsString()] = dp.Value
+				h, ok := dp.Attributes.Value("head")
+				if !ok {
+					t.Fatalf("breaker_state data point missing head attribute: %v", dp.Attributes.ToSlice())
+				}
+				if _, dup := levels[h.AsString()]; dup {
+					t.Fatalf("breaker_state head %q appears twice in one collection (orphan-series bug)", h.AsString())
+				}
+				levels[h.AsString()] = dp.Value
 			}
 		}
 	}
@@ -108,12 +119,12 @@ func TestBreakerMetrics_ZeroInitAtConstruction(t *testing.T) {
 		t.Errorf("trips_total before any trip: want 0, got %d", got)
 	}
 	levels := breakerGaugeLevels(t, reader)
-	got, ok := levels["closed"]
+	got, ok := levels[HeadProm.String()]
 	if !ok {
-		t.Fatalf("breaker_state: missing closed stream (panel would show No data)")
+		t.Fatalf("breaker_state: missing prom-head stream (panel would show No data)")
 	}
 	if got != breakerGaugeClosed {
-		t.Errorf("breaker_state closed: want %d at construction, got %d", breakerGaugeClosed, got)
+		t.Errorf("breaker_state prom: want %d (closed) at construction, got %d", breakerGaugeClosed, got)
 	}
 }
 
@@ -157,17 +168,15 @@ func TestBreakerMetrics_ObservableNeverStale(t *testing.T) {
 	}
 
 	// Many collection intervals later, with NO further transition, the
-	// observable callback must still report the CURRENT level: 0/closed.
+	// observable callback must still report the CURRENT level: 0/closed. The
+	// single prom-head series is overwritten in place each collection, so it
+	// reads 0 — and breakerGaugeLevels asserts there is exactly ONE series for
+	// the head with NO `state` label, so no transient open/half-open level can
+	// survive as an orphan series (the OTLP stale-gauge bug the chaos lane hit).
 	now = base.Add(5 * time.Minute)
 	levels := breakerGaugeLevels(t, reader)
-	if got, ok := levels["closed"]; !ok || got != breakerGaugeClosed {
-		t.Fatalf("stale-gauge regression: closed level = %d (ok=%v), want %d", got, ok, breakerGaugeClosed)
-	}
-	// Critically, NO half-open sample must survive: the pre-fix bug left a
-	// lingering 2. The observable gauge reports exactly one sample per head
-	// (the current state), so half-open must be absent entirely.
-	if _, ok := levels["half-open"]; ok {
-		t.Fatalf("stale-gauge regression: half-open sample lingers after breaker closed (the chaos-lane bug)")
+	if got, ok := levels[HeadProm.String()]; !ok || got != breakerGaugeClosed {
+		t.Fatalf("stale-gauge regression: prom level = %d (ok=%v), want %d (closed)", got, ok, breakerGaugeClosed)
 	}
 }
 
@@ -201,8 +210,8 @@ func TestBreakerMetrics_TransitionsRecorded(t *testing.T) {
 	if got := breakerTripsTotal(t, reader); got != 1 {
 		t.Fatalf("trips_total after one trip: want 1, got %d", got)
 	}
-	if lv := breakerGaugeLevels(t, reader); lv["open"] != breakerGaugeOpen {
-		t.Fatalf("gauge open level after trip: want %d, got %d", breakerGaugeOpen, lv["open"])
+	if lv := breakerGaugeLevels(t, reader); lv[HeadProm.String()] != breakerGaugeOpen {
+		t.Fatalf("gauge level after trip: want %d (open), got %d", breakerGaugeOpen, lv[HeadProm.String()])
 	}
 
 	// OPEN -> HALF-OPEN (probe admitted past the 1s backoff).
@@ -210,8 +219,8 @@ func TestBreakerMetrics_TransitionsRecorded(t *testing.T) {
 	if !b.allow() {
 		t.Fatal("allow() did not admit the half-open probe")
 	}
-	if lv := breakerGaugeLevels(t, reader); lv["half-open"] != breakerGaugeHalfOpen {
-		t.Fatalf("gauge half-open level: want %d, got %d", breakerGaugeHalfOpen, lv["half-open"])
+	if lv := breakerGaugeLevels(t, reader); lv[HeadProm.String()] != breakerGaugeHalfOpen {
+		t.Fatalf("gauge level in half-open: want %d, got %d", breakerGaugeHalfOpen, lv[HeadProm.String()])
 	}
 
 	// HALF-OPEN -> CLOSED (probe succeeds).
@@ -219,8 +228,8 @@ func TestBreakerMetrics_TransitionsRecorded(t *testing.T) {
 	if got := b.currentState(); got != "closed" {
 		t.Fatalf("after probe success: state = %q, want closed", got)
 	}
-	if lv := breakerGaugeLevels(t, reader); lv["closed"] != breakerGaugeClosed {
-		t.Fatalf("gauge closed level after recovery: want %d, got %d", breakerGaugeClosed, lv["closed"])
+	if lv := breakerGaugeLevels(t, reader); lv[HeadProm.String()] != breakerGaugeClosed {
+		t.Fatalf("gauge level after recovery: want %d (closed), got %d", breakerGaugeClosed, lv[HeadProm.String()])
 	}
 	// The trip counter is monotonic: recovery does NOT decrement it.
 	if got := breakerTripsTotal(t, reader); got != 1 {

--- a/internal/chclient/client.go
+++ b/internal/chclient/client.go
@@ -108,6 +108,21 @@ type Config struct {
 	// before the driver recycles it. clickhouse-go's implicit default is
 	// 1h; cerberus makes it explicit. Zero falls back to
 	// defaultConnMaxLifetime.
+	//
+	// It doubles as the recovery-speed ceiling for a restarted ClickHouse
+	// backend (ch-pod-kill, run 27509796946). clickhouse-go (v2.46.0) has
+	// no separate idle-time knob: a pooled conn to the OLD pod is dropped
+	// at acquire only once acquire()'s isBad() check trips — either the
+	// non-blocking socket read in conn_check.go notices the dead peer, OR
+	// the conn crosses ConnMaxLifetime (isBad checks both). A force-killed
+	// pod often leaves the socket in ESTABLISHED with no FIN/RST, so the
+	// socket check passes and the conn is only retired once it ages past
+	// ConnMaxLifetime — which at the 1h default is far too long. The
+	// transport-retry on the data path (see retry.go) makes a stale conn
+	// transparent on the FIRST query regardless of this value; this cap is
+	// the backstop that bounds how long a never-queried idle stale conn can
+	// otherwise loiter, so a modest value (minutes, not an hour) keeps the
+	// pool self-healing without churning conns under healthy load.
 	ConnMaxLifetime time.Duration
 
 	// MaxQuerySamples caps the number of Sample rows a single query may
@@ -532,7 +547,7 @@ func (c *Client) Ping(ctx context.Context) error {
 	if !c.br.allow() {
 		return fmt.Errorf("chclient: ping: %w", ErrCircuitOpen)
 	}
-	err := c.conn.Ping(ctx)
+	err := c.pingOpen(ctx)
 	c.br.record(ctx, err)
 	if err != nil {
 		return fmt.Errorf("chclient: ping: %w", err)
@@ -656,7 +671,7 @@ func (c *Client) QueryStrings(ctx context.Context, sql string, args ...any) ([]s
 	ctx, span := startExecuteSpan(ctx, sql, c.addr)
 	defer span.End()
 	defer flushProgress(ctx)
-	rows, err := c.conn.Query(ctx, sql, args...)
+	rows, err := c.queryOpen(ctx, sql, args...)
 	c.br.record(ctx, err)
 	if err != nil {
 		span.RecordError(err)
@@ -710,7 +725,7 @@ func (c *Client) QueryDetectedFieldRows(ctx context.Context, sql string, args ..
 	ctx, span := startExecuteSpan(ctx, sql, c.addr)
 	defer span.End()
 	defer flushProgress(ctx)
-	rows, err := c.conn.Query(ctx, sql, args...)
+	rows, err := c.queryOpen(ctx, sql, args...)
 	c.br.record(ctx, err)
 	if err != nil {
 		span.RecordError(err)
@@ -762,7 +777,7 @@ func (c *Client) QueryTimestampedLines(ctx context.Context, sql string, args ...
 	ctx, span := startExecuteSpan(ctx, sql, c.addr)
 	defer span.End()
 	defer flushProgress(ctx)
-	rows, err := c.conn.Query(ctx, sql, args...)
+	rows, err := c.queryOpen(ctx, sql, args...)
 	c.br.record(ctx, err)
 	if err != nil {
 		span.RecordError(err)
@@ -811,7 +826,7 @@ func (c *Client) QueryMetricMeta(ctx context.Context, sql, metricType string, ar
 	ctx, span := startExecuteSpan(ctx, sql, c.addr)
 	defer span.End()
 	defer flushProgress(ctx)
-	rows, err := c.conn.Query(ctx, sql, args...)
+	rows, err := c.queryOpen(ctx, sql, args...)
 	c.br.record(ctx, err)
 	if err != nil {
 		span.RecordError(err)
@@ -862,7 +877,7 @@ func (c *Client) QueryIndexStats(ctx context.Context, sql string, args ...any) (
 	ctx, span := startExecuteSpan(ctx, sql, c.addr)
 	defer span.End()
 	defer flushProgress(ctx)
-	rows, err := c.conn.Query(ctx, sql, args...)
+	rows, err := c.queryOpen(ctx, sql, args...)
 	c.br.record(ctx, err)
 	if err != nil {
 		span.RecordError(err)
@@ -905,7 +920,7 @@ func (c *Client) QueryIndexVolume(ctx context.Context, sql string, args ...any) 
 	ctx, span := startExecuteSpan(ctx, sql, c.addr)
 	defer span.End()
 	defer flushProgress(ctx)
-	rows, err := c.conn.Query(ctx, sql, args...)
+	rows, err := c.queryOpen(ctx, sql, args...)
 	c.br.record(ctx, err)
 	if err != nil {
 		span.RecordError(err)
@@ -969,7 +984,7 @@ func (c *Client) QueryExemplars(ctx context.Context, sql string, args ...any) ([
 	ctx, span := startExecuteSpan(ctx, sql, c.addr)
 	defer span.End()
 	defer flushProgress(ctx)
-	rows, err := c.conn.Query(ctx, sql, args...)
+	rows, err := c.queryOpen(ctx, sql, args...)
 	c.br.record(ctx, err)
 	if err != nil {
 		span.RecordError(err)
@@ -1014,7 +1029,7 @@ func (c *Client) QueryLabelSets(ctx context.Context, sql string, args ...any) ([
 	ctx, span := startExecuteSpan(ctx, sql, c.addr)
 	defer span.End()
 	defer flushProgress(ctx)
-	rows, err := c.conn.Query(ctx, sql, args...)
+	rows, err := c.queryOpen(ctx, sql, args...)
 	c.br.record(ctx, err)
 	if err != nil {
 		span.RecordError(err)
@@ -1062,7 +1077,7 @@ func (c *Client) QueryNameTypePairs(ctx context.Context, sql string, args ...any
 	ctx, span := startExecuteSpan(ctx, sql, c.addr)
 	defer span.End()
 	defer flushProgress(ctx)
-	rows, err := c.conn.Query(ctx, sql, args...)
+	rows, err := c.queryOpen(ctx, sql, args...)
 	c.br.record(ctx, err)
 	if err != nil {
 		span.RecordError(err)

--- a/internal/chclient/cursor.go
+++ b/internal/chclient/cursor.go
@@ -368,7 +368,7 @@ func (c *Client) QueryCursor(ctx context.Context, sql string, args ...any) (Curs
 	}
 	ctx = c.queryContext(ctx)
 	ctx, span := startExecuteSpan(ctx, sql, c.addr)
-	rows, err := c.conn.Query(ctx, sql, args...)
+	rows, err := c.queryOpen(ctx, sql, args...)
 	c.br.record(ctx, err)
 	if err != nil {
 		span.RecordError(err)

--- a/internal/chclient/retry.go
+++ b/internal/chclient/retry.go
@@ -1,0 +1,161 @@
+package chclient
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"syscall"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+)
+
+// maxTransportRetries bounds how many EXTRA times a read-path call is
+// re-driven against the pool after a broken-connection error before the
+// breaker is told the call failed. The first attempt plus this many retries
+// means a call makes at most maxTransportRetries+1 dials.
+//
+// This mirrors Go's database/sql, which is the canonical precedent for the
+// exact failure this fixes. When a driver returns driver.ErrBadConn ("the
+// server having earlier closed the connection"), database/sql transparently
+// retries on a fresh connection up to maxBadConnRetries=2 pooled attempts and
+// then one final guaranteed-fresh dial — IMMEDIATELY, with NO backoff,
+// because the server is up and a fresh dial succeeds at once (delaying would
+// only slow recovery). clickhouse-go's NATIVE clickhouse.Conn interface (the
+// one cerberus uses, not the database/sql wrapper) does NOT get that retry —
+// the broken-conn error surfaces straight to the caller — so cerberus
+// replicates the database/sql contract here. 3 ≈ database/sql's 2-pooled +
+// 1-fresh shape; the upper bound also lets a single request drain a small
+// pool of stale conns left by a restarted pod.
+//
+// Why this is needed (the ch-pod-kill flap, run 27509796946). When the
+// ClickHouse pod is killed and recreated (k3d Recreate, PVC-backed), the new
+// pod comes up at a fresh IP but the OLD pod's TCP connections are NOT cleanly
+// closed — they sit in ESTABLISHED with no FIN/RST. clickhouse-go's acquire()
+// validates a pooled conn with a non-blocking socket read (conn_check.go); an
+// idle-but-not-yet-noticed-dead socket returns EAGAIN, so isBad() reports the
+// STALE conn healthy and hands it out. The query against it then fails with a
+// broken-conn error, and clickhouse-go evicts THAT conn (release(conn, err) →
+// close) — but the failure has ALREADY surfaced to chclient, which recorded it
+// against the breaker. With several stale conns pooled, each first use trips
+// one breaker failure; in bursts that re-opens the breaker and it flaps
+// open↔half-open↔closed for the full recovery deadline. Retrying re-acquires
+// PAST the just-evicted bad conn (dialling fresh, or grabbing another conn the
+// next failed attempt likewise evicts), so a handful of stale conns is
+// absorbed silently instead of re-tripping the breaker.
+//
+// No backoff, and a genuine outage still trips the breaker. A dead backend
+// fails the dial on EVERY attempt, so the bounded loop costs at most
+// maxTransportRetries+1 fast immediate dials and then returns the broken-conn
+// error to record() — so the breaker trips exactly as before for a real
+// outage. Recovery from a restart is fast and deterministic; a real CH-down is
+// not masked.
+const maxTransportRetries = 3
+
+// isBrokenConnError reports whether err is a broken-CONNECTION failure — the
+// pooled conn (or the dial to a still-recovering pod) failed at the transport
+// layer, so a retry on a fresh conn can transparently absorb it. It mirrors
+// clickhouse-go's own (unexported) isConnBrokenError predicate — io.EOF /
+// EPIPE / ECONNRESET / *net.OpError — the exact set the driver uses to decide
+// a conn is no longer usable, plus ECONNREFUSED (a fresh dial to a pod still
+// in warm-up) and io.ErrUnexpectedEOF (a half-read response on a dropped
+// conn). Using the SAME classification the driver evicts on keeps the retry
+// in lock-step with which conns the pool actually drops between attempts.
+//
+// It is deliberately a NARROW allow-list, not a broad "any non-Exception
+// error" denylist: only errors that genuinely indicate a dead conn are
+// retried. A *clickhouse.Exception (the server answered with a typed error —
+// CH is alive), a pool acquire-timeout (local saturation), a context
+// cancellation/deadline (the caller walked away), and ErrCircuitOpen are NOT
+// broken-conn errors and must surface on the first attempt.
+func isBrokenConnError(err error) bool {
+	if err == nil {
+		return false
+	}
+	// A typed server exception is positive proof CH is alive — never a
+	// transport failure, even if its message happens to mention a socket.
+	var ex *clickhouse.Exception
+	if errors.As(err, &ex) {
+		return false
+	}
+	// Caller-driven cancellation / deadline is not a CH fault; ErrCircuitOpen
+	// and acquire-timeout are local signals. None are retryable.
+	if errors.Is(err, context.Canceled) ||
+		errors.Is(err, context.DeadlineExceeded) ||
+		errors.Is(err, clickhouse.ErrAcquireConnTimeout) ||
+		errors.Is(err, ErrCircuitOpen) {
+		return false
+	}
+	// The driver's own broken-conn set (clickhouse-go isConnBrokenError) plus
+	// the dial-refused / unexpected-EOF shapes a restarted backend produces.
+	if errors.Is(err, io.EOF) ||
+		errors.Is(err, io.ErrUnexpectedEOF) ||
+		errors.Is(err, syscall.EPIPE) ||
+		errors.Is(err, syscall.ECONNRESET) ||
+		errors.Is(err, syscall.ECONNREFUSED) {
+		return true
+	}
+	var opErr *net.OpError
+	return errors.As(err, &opErr)
+}
+
+// withTransportRetry invokes call and, when it fails with a broken-connection
+// error (isBrokenConnError), re-invokes it on a freshly-acquired pooled conn
+// up to maxTransportRetries more times — immediately, no backoff (the
+// database/sql ErrBadConn precedent: the server is up, a fresh dial succeeds
+// at once). It returns the result of the LAST attempt: the first
+// non-broken-conn outcome (success, or a CH-semantic error that must surface),
+// or — if every attempt was a broken-conn error — the final error. That
+// returned error is what the caller records against the breaker, so a stale
+// conn the retry recovered from never counts as a breaker failure, while a
+// genuinely-down CH (every attempt a broken-conn error) still does.
+//
+// Each retry's call re-runs c.conn.<op>, whose acquire() skips the conn the
+// previous failed attempt already evicted — so the retry dials fresh against
+// the restarted backend rather than re-using the dead conn.
+//
+// SAFETY: only read-path opens (SELECT) and Ping route through this. SELECTs
+// are idempotent, so a retry can never double-apply an effect. The write path
+// (Exec: DDL/DML, incl. INSERT) deliberately does NOT retry — a broken pipe
+// mid-send could have partially applied, and the database/sql ErrBadConn
+// contract itself forbids retrying when "the database server might have
+// performed the operation."
+//
+// ctx is honoured between attempts: a cancelled/expired ctx stops the retry
+// loop immediately (the next call would fail with the ctx error anyway;
+// short-circuiting avoids a needless dial).
+func withTransportRetry[T any](ctx context.Context, call func() (T, error)) (T, error) {
+	res, err := call()
+	for attempt := 0; attempt < maxTransportRetries && isBrokenConnError(err); attempt++ {
+		if ctx.Err() != nil {
+			break
+		}
+		res, err = call()
+	}
+	return res, err
+}
+
+// queryOpen opens a result set against the pool with broken-conn retry: a
+// stale pooled conn handed out by acquire() after a CH restart fails the
+// initial round-trip, which clickhouse-go evicts; the retry re-acquires past
+// it and dials fresh. It is the single open-time seam every read-path query
+// method routes through, so the stale-conn recovery is uniform across all of
+// them. The DRAIN side (rows.Err()) is deliberately NOT retried — once rows
+// have started flowing a mid-stream drop can't be replayed without
+// double-reading.
+func (c *Client) queryOpen(ctx context.Context, sql string, args ...any) (driver.Rows, error) {
+	return withTransportRetry(ctx, func() (driver.Rows, error) {
+		return c.conn.Query(ctx, sql, args...)
+	})
+}
+
+// pingOpen pings the pool with broken-conn retry so a stale pooled conn does
+// not surface a transport error to the readiness probe / breaker when a fresh
+// dial would succeed. Ping is a read-only round-trip, so retrying is safe.
+func (c *Client) pingOpen(ctx context.Context) error {
+	_, err := withTransportRetry(ctx, func() (struct{}, error) {
+		return struct{}{}, c.conn.Ping(ctx)
+	})
+	return err
+}

--- a/internal/chclient/retry_test.go
+++ b/internal/chclient/retry_test.go
@@ -1,0 +1,244 @@
+package chclient
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"sync/atomic"
+	"syscall"
+	"testing"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+)
+
+// staleConn models the ch-pod-kill failure: the first failUntil Query /
+// Ping calls return brokenErr (a stale pooled conn handed out by acquire
+// after a restart), and every call after that succeeds (the retry re-dialled
+// a fresh conn). It counts calls so a test can assert how many attempts the
+// retry made.
+//
+// It is the unit-test stand-in for clickhouse-go's pool behaviour: each
+// failed Query against a stale conn evicts that conn (release(conn, err) →
+// close), so the NEXT acquire dials fresh — modelled here by simply making
+// the next call succeed once failUntil attempts are spent. failForever makes
+// every call fail (a genuinely-down backend) so the breaker-trip path stays
+// covered.
+type staleConn struct {
+	brokenErr   error
+	failUntil   int32 // first N calls fail with brokenErr, then succeed
+	failForever bool  // every call fails (models a dead backend)
+	calls       atomic.Int32
+}
+
+func (c *staleConn) fail() error {
+	n := c.calls.Add(1)
+	if c.failForever {
+		return c.brokenErr
+	}
+	if n <= c.failUntil {
+		return c.brokenErr
+	}
+	return nil
+}
+
+func (c *staleConn) Query(context.Context, string, ...any) (driver.Rows, error) {
+	if err := c.fail(); err != nil {
+		return nil, err
+	}
+	return &chaosRows{}, nil
+}
+
+func (c *staleConn) Ping(context.Context) error { return c.fail() }
+
+func (c *staleConn) Contributors() []string { return nil }
+func (c *staleConn) ServerVersion() (*driver.ServerVersion, error) {
+	return &driver.ServerVersion{}, nil
+}
+func (c *staleConn) Select(context.Context, any, string, ...any) error { return c.fail() }
+func (c *staleConn) QueryRow(context.Context, string, ...any) driver.Row {
+	return chaosRow{c.fail()}
+}
+
+func (c *staleConn) PrepareBatch(context.Context, string, ...driver.PrepareBatchOption) (driver.Batch, error) {
+	return nil, c.fail()
+}
+func (c *staleConn) Exec(context.Context, string, ...any) error              { return c.fail() }
+func (c *staleConn) AsyncInsert(context.Context, string, bool, ...any) error { return c.fail() }
+func (c *staleConn) Stats() driver.Stats                                     { return driver.Stats{} }
+func (c *staleConn) Close() error                                            { return nil }
+
+// errBrokenPipe is the canonical broken-conn error a stale pooled conn to a
+// restarted CH pod surfaces (clickhouse-go classifies EPIPE / ECONNRESET /
+// EOF / *net.OpError as broken). Wrapped so the test also exercises the
+// errors.Is chain-walk isBrokenConnError relies on.
+var errBrokenPipe = fmt.Errorf("clickhouse: send data: %w", syscall.EPIPE)
+
+// TestQueryCursor_StaleConn_RecoversSilently — a single stale pooled conn
+// (one broken-pipe failure, then a fresh conn succeeds) is absorbed by the
+// retry: QueryCursor returns a usable cursor, and — critically — the breaker
+// records a SUCCESS, not a failure, so a lone stale conn can never advance
+// the breaker toward OPEN. This is the core of the ch-pod-kill flap fix.
+func TestQueryCursor_StaleConn_RecoversSilently(t *testing.T) {
+	t.Parallel()
+	conn := &staleConn{brokenErr: errBrokenPipe, failUntil: 1}
+	client := newWithConn(conn)
+
+	cursor, err := client.QueryCursor(context.Background(), "SELECT 1")
+	if err != nil {
+		t.Fatalf("QueryCursor: %v; want silent recovery after one stale conn", err)
+	}
+	_ = cursor.Close()
+
+	if got := conn.calls.Load(); got != 2 {
+		t.Errorf("conn.calls = %d; want 2 (1 stale + 1 fresh retry)", got)
+	}
+	if st := client.br.currentState(); st != "closed" {
+		t.Errorf("breaker state = %q; want closed (a recovered stale conn is no failure)", st)
+	}
+}
+
+// TestQuery_StaleConn_DoesNotTripBreaker — even a burst of queries, each
+// hitting ONE stale conn before recovering, must never trip the breaker:
+// the default threshold is 5 consecutive failures, but every query recovers
+// on retry so the failure counter stays at 0. Without the retry each of
+// these would have been a recorded failure and the 5th would OPEN the
+// breaker — exactly the flap the chaos lane saw.
+func TestQuery_StaleConn_DoesNotTripBreaker(t *testing.T) {
+	t.Parallel()
+	conn := &staleConn{brokenErr: errBrokenPipe}
+	client := newWithConn(conn)
+
+	const queries = breakerThreshold * 3 // well past the trip threshold
+	for i := 0; i < queries; i++ {
+		// Each query sees exactly one fresh stale conn: bump failUntil so the
+		// next single call fails, then succeeds on retry.
+		conn.failUntil = conn.calls.Load() + 1
+		if _, err := client.Query(context.Background(), "SELECT 1"); err != nil {
+			t.Fatalf("Query %d: %v; want silent recovery", i, err)
+		}
+		if st := client.br.currentState(); st != "closed" {
+			t.Fatalf("after query %d breaker state = %q; want closed", i, st)
+		}
+	}
+}
+
+// TestQuery_DeadBackend_StillTripsBreaker — a genuinely-down CH (every
+// attempt a broken-conn error, including all retries) must STILL trip the
+// breaker. The retry only absorbs a recovered stale conn; an outage where
+// the fresh dial also fails exhausts the bound, returns the broken-conn
+// error to record(), and after breakerThreshold such failures the breaker
+// OPENs. This proves the fix doesn't mask a real outage.
+func TestQuery_DeadBackend_StillTripsBreaker(t *testing.T) {
+	t.Parallel()
+	conn := &staleConn{brokenErr: errBrokenPipe, failForever: true}
+	client := newWithConn(conn)
+
+	for i := 0; i < breakerThreshold; i++ {
+		if _, err := client.Query(context.Background(), "SELECT 1"); err == nil {
+			t.Fatalf("Query %d: nil error; want broken-conn error from a dead backend", i)
+		}
+	}
+	if st := client.br.currentState(); st != "open" {
+		t.Errorf("breaker state = %q; want open after %d dead-backend failures", st, breakerThreshold)
+	}
+	// Each failing query made maxTransportRetries+1 attempts before giving up.
+	wantAttempts := int32(breakerThreshold * (maxTransportRetries + 1))
+	if got := conn.calls.Load(); got != wantAttempts {
+		t.Errorf("conn.calls = %d; want %d (%d queries × %d attempts)",
+			got, wantAttempts, breakerThreshold, maxTransportRetries+1)
+	}
+}
+
+// TestQuery_ManyStaleConns_DrainedInOneRequest — a pool holding several
+// stale conns is drained within a single request: the retry re-acquires past
+// each evicted bad conn until it lands a fresh one, all within
+// maxTransportRetries. The query succeeds and the breaker stays closed.
+func TestQuery_ManyStaleConns_DrainedInOneRequest(t *testing.T) {
+	t.Parallel()
+	conn := &staleConn{brokenErr: errBrokenPipe, failUntil: maxTransportRetries}
+	client := newWithConn(conn)
+
+	if _, err := client.Query(context.Background(), "SELECT 1"); err != nil {
+		t.Fatalf("Query: %v; want recovery within %d retries", err, maxTransportRetries)
+	}
+	if st := client.br.currentState(); st != "closed" {
+		t.Errorf("breaker state = %q; want closed", st)
+	}
+}
+
+// TestPing_StaleConn_RecoversSilently — the readiness-probe path (Ping) gets
+// the same stale-conn recovery, so /readyz doesn't flap red on a transient
+// stale conn after a restart.
+func TestPing_StaleConn_RecoversSilently(t *testing.T) {
+	t.Parallel()
+	conn := &staleConn{brokenErr: errBrokenPipe, failUntil: 1}
+	client := newWithConn(conn)
+
+	if err := client.Ping(context.Background()); err != nil {
+		t.Fatalf("Ping: %v; want silent recovery after one stale conn", err)
+	}
+	if st := client.br.currentState(); st != "closed" {
+		t.Errorf("breaker state = %q; want closed", st)
+	}
+}
+
+// TestIsBrokenConnError pins the classification contract: the broken-conn
+// shapes a restarted backend produces are retryable; a server-side typed
+// exception, a context error, an acquire-timeout, and ErrCircuitOpen are NOT
+// (they must surface on the first attempt rather than burning retries).
+func TestIsBrokenConnError(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"eof", io.EOF, true},
+		{"unexpected-eof", io.ErrUnexpectedEOF, true},
+		{"epipe", syscall.EPIPE, true},
+		{"econnreset", syscall.ECONNRESET, true},
+		{"econnrefused", syscall.ECONNREFUSED, true},
+		{"wrapped-epipe", fmt.Errorf("send data: %w", syscall.EPIPE), true},
+		{"net-op-error", &net.OpError{Op: "dial", Err: syscall.ECONNREFUSED}, true},
+		{"wrapped-net-op-error", fmt.Errorf("dial ch: %w", &net.OpError{Op: "read", Err: io.EOF}), true},
+		{"ch-exception", &clickhouse.Exception{Code: 241, Message: "memory limit"}, false},
+		{"wrapped-ch-exception", fmt.Errorf("query: %w", &clickhouse.Exception{Code: 159}), false},
+		{"context-canceled", context.Canceled, false},
+		{"context-deadline", context.DeadlineExceeded, false},
+		{"acquire-timeout", clickhouse.ErrAcquireConnTimeout, false},
+		{"circuit-open", ErrCircuitOpen, false},
+		{"plain-error", errors.New("some other error"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isBrokenConnError(tc.err); got != tc.want {
+				t.Errorf("isBrokenConnError(%v) = %v; want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestWithTransportRetry_StopsOnCtxCancel — a cancelled ctx halts the retry
+// loop immediately rather than burning the full retry budget against a
+// backend the caller has already abandoned.
+func TestWithTransportRetry_StopsOnCtxCancel(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var calls int
+	_, err := withTransportRetry(ctx, func() (struct{}, error) {
+		calls++
+		return struct{}{}, errBrokenPipe
+	})
+	if !errors.Is(err, syscall.EPIPE) {
+		t.Errorf("err = %v; want the broken-pipe error surfaced", err)
+	}
+	if calls != 1 {
+		t.Errorf("calls = %d; want 1 (cancelled ctx stops the retry loop)", calls)
+	}
+}

--- a/internal/config/ch_pool_test.go
+++ b/internal/config/ch_pool_test.go
@@ -6,10 +6,12 @@ import (
 	"time"
 )
 
-// TestFromEnv_CHPool_Defaults pins the explicit pool defaults (#81) to
-// clickhouse-go/v2's previously-implicit values, so the non-sharded path
-// stays behaviour-compatible: MaxOpenConns 10, MaxIdleConns 5,
-// ConnMaxLifetime 1h.
+// TestFromEnv_CHPool_Defaults pins the explicit pool defaults (#81).
+// MaxOpenConns / MaxIdleConns reproduce clickhouse-go/v2's implicit values
+// (10 / 5) so the non-sharded path stays behaviour-compatible. ConnMaxLifetime
+// DEPARTS from the driver's 1h default: it is 5m, the backstop that bounds how
+// long a stale pooled conn to a restarted backend can loiter (ch-pod-kill
+// recovery, run 27509796946).
 func TestFromEnv_CHPool_Defaults(t *testing.T) {
 	t.Setenv("CERBERUS_CH_MAX_OPEN_CONNS", "")
 	t.Setenv("CERBERUS_CH_MAX_IDLE_CONNS", "")
@@ -24,8 +26,8 @@ func TestFromEnv_CHPool_Defaults(t *testing.T) {
 	if cfg.ClickHouse.MaxIdleConns != 5 {
 		t.Errorf("MaxIdleConns = %d; want 5 (clickhouse-go implicit default)", cfg.ClickHouse.MaxIdleConns)
 	}
-	if cfg.ClickHouse.ConnMaxLifetime != time.Hour {
-		t.Errorf("ConnMaxLifetime = %s; want 1h (clickhouse-go implicit default)", cfg.ClickHouse.ConnMaxLifetime)
+	if cfg.ClickHouse.ConnMaxLifetime != 5*time.Minute {
+		t.Errorf("ConnMaxLifetime = %s; want 5m (restart-recovery backstop, not the driver's 1h)", cfg.ClickHouse.ConnMaxLifetime)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -228,7 +228,7 @@ const configFileBaseName = "cerberus"
 //	CERBERUS_CH_DIAL_TIMEOUT       default "5s"
 //	CERBERUS_CH_MAX_OPEN_CONNS     default 10 (total pooled conns, busy + idle)
 //	CERBERUS_CH_MAX_IDLE_CONNS     default 5  (idle conns kept warm for reuse)
-//	CERBERUS_CH_CONN_MAX_LIFETIME  default "1h" (max age before a conn is recycled)
+//	CERBERUS_CH_CONN_MAX_LIFETIME  default "5m" (max age before a conn is recycled; short so a stale conn to a restarted CH pod recycles fast)
 //	CERBERUS_QUERY_MAX_SAMPLES     default 50000000 (0 disables the budget)
 //	CERBERUS_QUERY_TIMEOUT         default "2m" — per-query wall-clock cap stamped
 //	    as ClickHouse max_execution_time (timeout_overflow_mode=throw); the
@@ -558,23 +558,35 @@ const defaultQueryTimeout time.Duration = 2 * time.Minute
 // setting entirely (ClickHouse server defaults apply).
 const defaultCHQueryMaxMemory int64 = 1 << 30 // 1073741824 bytes
 
-// ClickHouse connection-pool defaults (#81). These reproduce
-// clickhouse-go/v2's previously-implicit defaults verbatim so the
-// non-sharded path stays behaviour-compatible: the driver defaulted
-// MaxIdleConns to 5, MaxOpenConns to MaxIdleConns+5 (= 10), and
-// ConnMaxLifetime to 1h. Cerberus now sets them explicitly here — the
-// ONE place pool sizing is derived — so the sharded-pushdown solver can
-// raise the ceiling for fan-out by bumping these (or the matching
-// CERBERUS_CH_MAX_OPEN_CONNS / CERBERUS_CH_MAX_IDLE_CONNS /
-// CERBERUS_CH_CONN_MAX_LIFETIME env vars) rather than inheriting an
-// implicit driver default. When the pool is exhausted an acquire blocks
-// up to DialTimeout and then fails with clickhouse.ErrAcquireConnTimeout,
-// which the circuit breaker treats neutrally (local pool-sizing signal,
-// not CH-health failure).
+// ClickHouse connection-pool defaults (#81). MaxIdleConns / MaxOpenConns
+// reproduce clickhouse-go/v2's previously-implicit defaults verbatim so the
+// non-sharded path stays behaviour-compatible (the driver defaulted
+// MaxIdleConns to 5, MaxOpenConns to MaxIdleConns+5 = 10). Cerberus sets
+// them explicitly here — the ONE place pool sizing is derived — so the
+// sharded-pushdown solver can raise the ceiling for fan-out by bumping these
+// (or the matching CERBERUS_CH_MAX_OPEN_CONNS / CERBERUS_CH_MAX_IDLE_CONNS /
+// CERBERUS_CH_CONN_MAX_LIFETIME env vars) rather than inheriting an implicit
+// driver default. When the pool is exhausted an acquire blocks up to
+// DialTimeout and then fails with clickhouse.ErrAcquireConnTimeout, which the
+// circuit breaker treats neutrally (local pool-sizing signal, not CH-health
+// failure).
+//
+// ConnMaxLifetime DEPARTS from the driver's 1h default: it is the backstop
+// that bounds how long a stale pooled conn to a RESTARTED ClickHouse backend
+// can loiter (ch-pod-kill recovery, run 27509796946). clickhouse-go v2.46.0
+// has no idle-time knob, and a force-killed pod's socket can stay ESTABLISHED
+// (no FIN/RST) so the driver's per-acquire socket check passes the dead conn
+// through; the conn is only retired once it ages past ConnMaxLifetime. At 1h
+// that left a never-queried idle conn dead-but-pooled for the better part of
+// an hour. 5m keeps the pool self-healing after a restart while staying long
+// enough that healthy conns are not churned on every request. The data-path
+// transport-retry (internal/chclient/retry.go) already makes a stale conn
+// transparent on the first QUERY regardless of this value; this just caps the
+// loiter window for idle conns that are never queried.
 const (
 	defaultCHMaxOpenConns                  = 10
 	defaultCHMaxIdleConns                  = 5
-	defaultCHConnMaxLifetime time.Duration = time.Hour
+	defaultCHConnMaxLifetime time.Duration = 5 * time.Minute
 )
 
 // Circuit-breaker defaults (#95). These reproduce the previously-

--- a/internal/config/viper_test.go
+++ b/internal/config/viper_test.go
@@ -45,8 +45,8 @@ func TestFromEnv_ViperDefaults_NoEnv(t *testing.T) {
 	if cfg.ClickHouse.MaxIdleConns != 5 {
 		t.Errorf("MaxIdleConns = %d; want 5", cfg.ClickHouse.MaxIdleConns)
 	}
-	if cfg.ClickHouse.ConnMaxLifetime != time.Hour {
-		t.Errorf("ConnMaxLifetime = %v; want 1h", cfg.ClickHouse.ConnMaxLifetime)
+	if cfg.ClickHouse.ConnMaxLifetime != 5*time.Minute {
+		t.Errorf("ConnMaxLifetime = %v; want 5m", cfg.ClickHouse.ConnMaxLifetime)
 	}
 	if cfg.ClickHouse.MaxQuerySamples != 50_000_000 {
 		t.Errorf("MaxQuerySamples = %d; want 50000000", cfg.ClickHouse.MaxQuerySamples)


### PR DESCRIPTION
## The flap (chaos ch-pod-kill, run 27509796946)

The chaos `ch-pod-kill` scenario deletes the ClickHouse pod (Recreate, PVC-backed → comes back with data). On the affected run the breaker recovered at 19:42:55 (`ch circuit breaker recovered: probe succeeded, circuit closed`) and then **immediately re-entered half-open and flapped open↔half-open↔closed for the full ~300s recovery deadline**, ending OPEN. `/readyz` and all three heads returned 200 throughout (the `HeadProbe` breaker recovered fine), but the main `HeadProm` breaker kept re-tripping — and a prior identical run recovered cleanly, so the behaviour was non-deterministic.

## Root cause (code-confirmed)

The probe breaker (`HeadProbe`) and the main breaker (`HeadProm`) are separate breakers over the **one shared** `clickhouse-go` connection pool. After the pod is killed+recreated:

- The OLD pod's TCP conns sit in `ESTABLISHED` with **no FIN/RST** (force-killed pod, IP gone).
- `clickhouse-go`'s `acquire()` validates a pooled conn with a **non-blocking socket read** (`conn_check.go`): an idle-but-not-yet-noticed-dead socket returns `EAGAIN` → `isBad()` reports the **stale conn healthy** and hands it out.
- The query against it then fails with a broken-conn error. `clickhouse-go` evicts that one conn (`release(conn, err) → close`), **but the failure has already surfaced** to `chclient`, which did `c.br.record(ctx, err)` — counting it as a real CH-health failure.
- With several stale conns pooled (`MaxIdleConns=5`/`MaxOpenConns=10`), each first use trips one breaker failure. In bursts of ≥`threshold` within the window the main breaker re-opens. The probe happened to dial a fresh conn and recovered, while main queries kept grabbing stale conns — hence the asymmetric multi-minute flap.

The native `clickhouse.Conn` interface cerberus uses (unlike the `database/sql` wrapper) does **no `ErrBadConn`-style transparent retry** — one acquire, one query, one failure, straight to the breaker.

## The fix

Replicate Go's `database/sql` `ErrBadConn` precedent (the canonical handling of exactly this "server earlier closed the connection" case): on a **broken-conn error**, retry the read-path open on a freshly-acquired conn — **bounded and immediate, no backoff** (the server is up; a fresh dial succeeds at once, so backoff would only delay recovery).

- New `internal/chclient/retry.go`:
  - `isBrokenConnError` mirrors `clickhouse-go`'s own (unexported) `isConnBrokenError` set — `io.EOF` / `io.ErrUnexpectedEOF` / `EPIPE` / `ECONNRESET` / `*net.OpError` — plus `ECONNREFUSED` (a fresh dial to a pod still in warm-up). It is a **narrow allow-list**: a typed `*clickhouse.Exception` (CH answered → alive), a context cancel/deadline, an acquire-timeout, and `ErrCircuitOpen` are **not** retried.
  - `withTransportRetry` runs the call and re-drives it up to `maxTransportRetries (=3)` times while the error stays a broken-conn error (≈ `database/sql`'s 2-pooled + 1-fresh shape; the bound also drains a small stale-conn pool in one request). Each retry's `acquire()` skips the just-evicted bad conn, so it dials fresh.
  - `queryOpen` / `pingOpen` route the SELECT/Ping open through it. **Exec (DDL/DML incl. INSERT) deliberately does not retry** — a broken pipe mid-send could have partially applied, and the `ErrBadConn` contract forbids retrying when the server might have performed the operation.
- A recovered stale conn now records breaker **SUCCESS** (the retry returns `nil`), so a lone stale conn can never advance the breaker. A genuinely-down CH fails every attempt, exhausts the bound, returns the broken-conn error to `record()`, and **still trips the breaker** — the outage path is unmasked, recovery is deterministic.
- Defense-in-depth: pool `ConnMaxLifetime` default `1h → 5m` (official ClickHouse guidance is to lower it for restart-heavy workloads). `clickhouse-go` v2.46.0 has no idle-time knob, and a force-killed socket can pass the per-acquire socket check, so a never-queried idle stale conn is otherwise only retired once it ages past `ConnMaxLifetime`. The retry handles queried conns instantly; this caps the loiter window for idle ones.

## Why not exponential backoff / a retry lib

Researched the precedent: for the **stale-conn-to-a-restarted-healthy-backend** case the server is up, so immediate retry (the `database/sql` no-backoff `ErrBadConn` path) is correct — backoff would only slow recovery. Backoff belongs to the **genuinely-down** mode, which here is already owned by the circuit breaker. A hand-rolled bounded immediate retry mirroring `db.retry()` is more idiomatic than pulling in a backoff lib and configuring its delay to zero.

## Tests

`internal/chclient/retry_test.go`:
- single stale conn recovers silently, breaker stays closed (and exactly 2 attempts: 1 stale + 1 fresh);
- a burst of stale-conn queries past the trip threshold never opens the breaker;
- a dead backend (every attempt fails) **still** opens the breaker after `threshold` failures, at `threshold × (maxTransportRetries+1)` attempts;
- several stale conns drained within one request;
- Ping recovery (readiness path);
- `isBrokenConnError` classification matrix (broken-conn shapes retryable; exception/ctx/acquire-timeout/circuit-open not);
- cancelled ctx halts the retry loop.

`go build ./...`, `go test -race ./internal/chclient/... ./internal/config/...`, and `go test ./internal/api/...` all green.

The real integration gate is the chaos `ch-pod-kill` dispatch (the driver runs it). Auto-merge intentionally NOT enabled.