### PR TITLE
fix(e2e): de-flake k3d bring-up — import images one-at-a-time with retry+verify

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -444,14 +444,21 @@ e2e-up: e2e-down
         echo "    docker pull $img"; \
         docker pull "$img" >/dev/null || { echo "ERROR: docker pull $img failed" >&2; exit 1; }; \
     done
-    @echo "==> importing images into k3d ({{K3D_CLUSTER}})"
-    k3d image import {{CERBERUS_IMAGE}} {{E2E_EXTERNAL_IMAGES}} -c {{K3D_CLUSTER}}
-    @echo "==> verifying images landed in the k3d node's containerd"
-    @# `k3d image import` exits 0 on partial/silent failures (observed:
-    @# run 27274975563 — cerberus pods in ImagePullBackOff trying
-    @# docker.io/library/cerberus:e2e because the local-only image never
-    @# reached the node). Verify every image is actually present;
-    @# normalise short names the way containerd stores them
+    @echo "==> importing images into k3d ({{K3D_CLUSTER}}) — one at a time, with retry+verify"
+    @# k3d bundles EVERY image into one tarball, mounts it into a transient
+    @# tools node, and runs `ctr image import`. Two failure modes bite:
+    @#   1. the bundled tarball intermittently vanishes mid-import
+    @#      ("ctr: open /k3d/images/...tar: no such file or directory" —
+    @#      run 27511641349), a transient image-volume race whose window
+    @#      grows with the bundle size, so importing ONE image at a time
+    @#      shrinks both the tarball and the race;
+    @#   2. `k3d image import` prints "Successfully imported" and exits 0
+    @#      even when a node-level import failed (run 27274975563 left
+    @#      cerberus:e2e absent → ImagePullBackOff), so success has to be
+    @#      VERIFIED against the node's containerd, not trusted.
+    @# So: import each image on its own, then verify it actually landed,
+    @# retrying the import until it's present or the attempt budget is
+    @# spent. Normalise short names the way containerd stores them
     @# (docker.io/ + library/ prefixes).
     @for img in {{CERBERUS_IMAGE}} {{E2E_EXTERNAL_IMAGES}}; do \
         ref="$img"; \
@@ -460,8 +467,17 @@ e2e-up: e2e-down
             */*) ref="docker.io/$ref" ;; \
             *)   ref="docker.io/library/$ref" ;; \
         esac; \
-        if ! docker exec k3d-{{K3D_CLUSTER}}-server-0 ctr -n k8s.io images ls -q | grep -qF "$ref"; then \
-            echo "ERROR: $ref missing from k3d node containerd after import" >&2; \
+        landed=0; \
+        for attempt in 1 2 3 4 5; do \
+            k3d image import "$img" -c {{K3D_CLUSTER}} || true; \
+            if docker exec k3d-{{K3D_CLUSTER}}-server-0 ctr -n k8s.io images ls -q | grep -qF "$ref"; then \
+                landed=1; break; \
+            fi; \
+            echo "    import attempt $attempt: $ref not in containerd yet, retrying after backoff" >&2; \
+            sleep $((attempt * 2)); \
+        done; \
+        if [ "$landed" != "1" ]; then \
+            echo "ERROR: $ref missing from k3d node containerd after 5 import attempts" >&2; \
             exit 1; \
         fi; \
         echo "    ok $ref"; \


### PR DESCRIPTION
## Problem

The k3d `dashboard` / `chaos` bring-up (`just e2e-up`) intermittently fails at the image-import step:

```
Importing images from tarball '/k3d/images/...tar' into node 'k3d-cerberus-e2e-server-0'...
ERRO failed to import images: ctr: open /k3d/images/...tar: no such file or directory
INFO Successfully imported 5 image(s)          # <- k3d swallows the per-node error
ERROR: docker.io/library/cerberus:e2e missing from k3d node containerd after import
```

(run [27511641349](https://github.com/tsouza/cerberus/actions/runs/27511641349/job/81312705672), and earlier the silent-partial-failure variant in run 27274975563.)

`k3d image import` bundles **every** image into one tarball, mounts it into a transient tools node, and runs `ctr image import`. The bundled tarball intermittently **vanishes mid-import** — a transient image-volume race whose window grows with the bundle size — and k3d still prints "Successfully imported" and exits 0, so the bring-up went red on a missing `cerberus:e2e`.

## Fix

Import each image **on its own** (smaller tarball → smaller race window), then **verify** it actually landed in the node's containerd, retrying the import until present or a 5-attempt budget is spent. The existing silent-partial-failure guard is kept.

Touches only the `e2e-up` recipe in `Justfile` — no product code. De-flakes both the `dashboard` and `chaos` informational lanes' bring-up. Addresses #83.

🤖 Generated with [Claude Code](https://claude.com/claude-code)