### PR TITLE
ci(release): gate publish on the whole of main being green at the tagged commit

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -32,6 +32,19 @@ wrapper, plus `appendStepSummary` / `setOutput` for the runner files.
   `enforce efficacy threshold` step.
   - Env: `REPORT` (default `gremlins.json`), `THRESHOLD` (a number).
   - Exit: `0` when efficacy is `>=` threshold, `1` when below.
+- **`release-preflight.mjs`** — `release.yml`, the `preflight` job. The
+  GATE that refuses to publish a release unless the WHOLE of `main` is
+  green on the exact commit being tagged — every push-triggered lane
+  (ci, compatibility, chdb, coverage, e2e dashboard+chaos, mutation,
+  perf-profile, property, CodeQL, …), not just the PR-required subset.
+  Reads the check-runs + commit statuses on `GITHUB_SHA` and fails on any
+  non-`success`/`skipped`/`neutral` or still-pending lane. Re-runs are
+  deduped by name (latest wins); the release run's own jobs are excluded.
+  - Env: `GITHUB_TOKEN`, `GITHUB_REPOSITORY`, `GITHUB_SHA`; optional
+    `GITHUB_API_URL` (default `https://api.github.com`) and
+    `RELEASE_SELF_JOBS` (default `preflight,goreleaser`).
+  - Exit: `0` when every non-self check on the commit is green, `1`
+    otherwise (with one `::error::` per red/pending lane).
 - **`compat-step-summary.mjs`** — `compatibility.yml`, the three
   `Append score to step summary` steps.
   - Env: `HEAD` (`prometheus`, `tempo`, or `loki`), `SCORE` (path to that

--- a/.github/scripts/release-preflight.mjs
+++ b/.github/scripts/release-preflight.mjs
@@ -1,0 +1,137 @@
+// release-preflight.mjs — refuse to publish a release unless EVERY CI check
+// on the tagged commit is green.
+//
+// Why: RC / GA tags are cut from `main` HEAD, so the tagged commit is a main
+// commit whose push-triggered workflows (ci, compatibility, chdb, coverage,
+// e2e dashboard+chaos, mutation, perf-profile, property, CodeQL, …) have
+// already run. Branch protection only gates a SUBSET of those (the required
+// checks) at PR time; this guard raises the bar for a release specifically:
+// the whole of main must be green on the exact commit being tagged, including
+// the informational lanes. If ANY check on the commit concluded non-green —
+// or is still pending — the release aborts before goreleaser publishes.
+//
+// Only `release.yml` triggers on tags (verified: no other workflow has a
+// `tags:` trigger), so the tagged commit's check-runs are exactly the
+// push-to-main runs plus this release run's own jobs. The latter are excluded
+// by name (RELEASE_SELF_JOBS) to avoid a self-deadlock.
+//
+// Env:
+//   GITHUB_TOKEN       token with checks:read + statuses:read (the default
+//                      workflow token has this).
+//   GITHUB_REPOSITORY  "owner/name".
+//   GITHUB_SHA         the tagged commit SHA (== the main commit).
+//   GITHUB_API_URL     API base (default https://api.github.com).
+//   RELEASE_SELF_JOBS  comma-separated check-run names belonging to THIS
+//                      release workflow, excluded from the gate
+//                      (default "preflight,goreleaser").
+//
+// Exit 0 when every non-self check on the commit is success/skipped/neutral;
+// exit 1 (with ::error:: annotations) otherwise.
+
+import { error, notice, log } from './lib/gh.mjs';
+
+const repo = process.env.GITHUB_REPOSITORY;
+const sha = process.env.GITHUB_SHA;
+const token = process.env.GITHUB_TOKEN;
+const apiBase = process.env.GITHUB_API_URL || 'https://api.github.com';
+const selfJobs = new Set(
+  (process.env.RELEASE_SELF_JOBS ?? 'preflight,goreleaser')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean),
+);
+
+if (!repo || !sha || !token) {
+  error('release-preflight: GITHUB_REPOSITORY, GITHUB_SHA and GITHUB_TOKEN are all required');
+  process.exit(1);
+}
+
+const headers = {
+  authorization: `Bearer ${token}`,
+  accept: 'application/vnd.github+json',
+  'x-github-api-version': '2022-11-28',
+  'user-agent': 'cerberus-release-preflight',
+};
+
+async function getJSON(url) {
+  const res = await fetch(url, { headers });
+  if (!res.ok) {
+    throw new Error(`GET ${url} -> ${res.status} ${res.statusText}`);
+  }
+  return res.json();
+}
+
+// All check-runs for the commit (GitHub Actions jobs, CodeQL, app checks),
+// following pagination until a short page.
+async function allCheckRuns() {
+  const out = [];
+  let page = 1;
+  for (;;) {
+    const data = await getJSON(
+      `${apiBase}/repos/${repo}/commits/${sha}/check-runs?per_page=100&page=${page}`,
+    );
+    const runs = data.check_runs ?? [];
+    out.push(...runs);
+    if (runs.length < 100) break;
+    page += 1;
+  }
+  return out;
+}
+
+// Legacy combined commit status (some security apps post here, not as a
+// check-run). `state` is the rolled-up success/failure/pending.
+async function combinedStatus() {
+  return getJSON(`${apiBase}/repos/${repo}/commits/${sha}/status?per_page=100`);
+}
+
+// A check-run is green when it completed with an accepting conclusion. A job
+// that is genuinely not applicable to this commit reports `skipped` (path
+// filters, `if:` guards) and counts as green — that is a deliberate pass, not
+// a failure.
+const GREEN_CONCLUSIONS = new Set(['success', 'skipped', 'neutral']);
+
+const [checkRuns, status] = await Promise.all([allCheckRuns(), combinedStatus()]);
+
+// Re-runs leave multiple check-runs with the same name; keep only the most
+// recent per name (highest id) so a green re-run supersedes an earlier fail.
+const latestByName = new Map();
+for (const cr of checkRuns) {
+  const prev = latestByName.get(cr.name);
+  if (!prev || cr.id > prev.id) latestByName.set(cr.name, cr);
+}
+
+const problems = [];
+let gated = 0;
+
+for (const cr of latestByName.values()) {
+  if (selfJobs.has(cr.name)) continue; // never gate on this release run itself
+  gated += 1;
+  if (cr.status !== 'completed') {
+    problems.push(`${cr.name}: still ${cr.status} (not completed)`);
+  } else if (!GREEN_CONCLUSIONS.has(cr.conclusion)) {
+    problems.push(`${cr.name}: ${cr.conclusion}`);
+  }
+}
+
+// Legacy statuses: each individual context must be success.
+for (const st of status.statuses ?? []) {
+  gated += 1;
+  if (st.state !== 'success') {
+    problems.push(`${st.context}: status ${st.state}`);
+  }
+}
+
+if (problems.length > 0) {
+  error(
+    `release-preflight: commit ${sha.slice(0, 8)} (main) is NOT all-green — refusing to publish the release. ` +
+      `Fix every CI lane on main, then re-tag.`,
+  );
+  for (const p of problems.sort()) error(`  - ${p}`);
+  process.exit(1);
+}
+
+notice(
+  `release-preflight: all ${gated} CI checks on commit ${sha.slice(0, 8)} are green — proceeding with the release.`,
+);
+log(`release-preflight: ${gated} checks verified green on ${sha}`);
+process.exit(0);

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,30 @@ permissions:
   # `attestations` (writes the attestation record back to the repo).
   id-token: write
   attestations: write
+  # The preflight gate reads the check-runs / statuses on the tagged commit.
+  checks: read
+  statuses: read
 
 jobs:
+  # Refuse to publish unless the WHOLE of main is green on the exact commit
+  # being tagged — not just the PR-required subset, but every push-triggered
+  # lane (ci, compatibility, chdb, coverage, e2e dashboard+chaos, mutation,
+  # perf-profile, property, CodeQL, …). A tag cut from a commit with any red
+  # or still-pending lane aborts here, before goreleaser publishes anything.
+  preflight:
+    name: preflight
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Verify all CI on the tagged commit is green
+        run: node .github/scripts/release-preflight.mjs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_SELF_JOBS: preflight,goreleaser
+
   release:
     name: goreleaser
+    needs: preflight
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Why

A release tag is cut from `main` HEAD, so the tagged commit is a main commit whose **push-triggered** lanes (ci, compatibility, chdb, coverage, e2e dashboard+chaos, mutation, perf-profile, property, CodeQL, …) have already run. Branch protection only gates the **required subset** at PR time — nothing stopped a tag being cut from a commit whose *informational* lanes were red.

For the first real release (RC1), the bar is **the whole of main is green on the exact tagged commit**, not just the required checks.

## What

- New `release-preflight.mjs` (`.github/scripts`, node + `node:` builtins only, per convention) reads every check-run + commit status on `GITHUB_SHA` and exits 1 on any non-`success`/`skipped`/`neutral` or still-pending lane. Re-runs dedupe by name (latest wins); the release run's own jobs (`preflight`, `goreleaser`) are excluded to avoid self-deadlock.
- `release.yml` gains a `preflight` job; `goreleaser` now `needs: preflight`, so a not-all-green main **aborts before anything is published**.

Only `release.yml` triggers on tags (verified — no other workflow has a `tags:` trigger), so the tagged commit's check-runs are exactly the push-to-main runs plus this release run's own jobs.

## Verified

Ran locally against a real main commit that had a flaky `dashboard` lane — the gate correctly refused:

```
::error::release-preflight: commit 00e7d040 (main) is NOT all-green — refusing to publish the release.
::error::  - dashboard: failure
::error::  - dashboard-shard (shard-smoke-b, …): failure
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)