### PR TITLE
fix(chclient): bound CH-restart recovery with a short ConnMaxLifetime, not a 5m ceiling

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -99,11 +99,11 @@ exhausted an acquire blocks up to `CERBERUS_CH_DIAL_TIMEOUT` and then fails with
 a breaker-neutral acquire-timeout (a local pool-sizing signal, not a
 ClickHouse-health failure).
 
-| Variable                        | Type     | Default | Description                                                                                                                                                                           |
-| ------------------------------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `CERBERUS_CH_MAX_OPEN_CONNS`    | int      | `10`    | Total pooled ClickHouse connections (busy + idle). Must be > 0.                                                                                                                       |
-| `CERBERUS_CH_MAX_IDLE_CONNS`    | int      | `5`     | Idle ClickHouse connections kept warm for reuse. Must be > 0.                                                                                                                         |
-| `CERBERUS_CH_CONN_MAX_LIFETIME` | duration | `30s`   | Max age of a pooled connection before it is recycled. Kept short (vs the driver's 1h) because it is the effective recovery bound after a ClickHouse restart: the driver has no idle-health knob and a stale conn to a force-killed pod blocks reads for minutes, so age eviction is what heals the pool — 30s recovers in seconds. Must be > 0. |
+| Variable                        | Type     | Default | Description                                                                                                                                                                                                                                                     |
+| ------------------------------- | -------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CERBERUS_CH_MAX_OPEN_CONNS`    | int      | `10`    | Total pooled ClickHouse connections (busy + idle). Must be > 0.                                                                                                                                                                                                 |
+| `CERBERUS_CH_MAX_IDLE_CONNS`    | int      | `5`     | Idle ClickHouse connections kept warm for reuse. Must be > 0.                                                                                                                                                                                                   |
+| `CERBERUS_CH_CONN_MAX_LIFETIME` | duration | `30s`   | Max age of a pooled connection before it is recycled. Kept short (vs the driver's 1h) because it bounds recovery after a ClickHouse restart: a stale conn to a force-killed pod is only aged out by this window, so 30s heals the pool in seconds. Must be > 0. |
 
 ## Query limits and memory
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -99,11 +99,24 @@ exhausted an acquire blocks up to `CERBERUS_CH_DIAL_TIMEOUT` and then fails with
 a breaker-neutral acquire-timeout (a local pool-sizing signal, not a
 ClickHouse-health failure).
 
-| Variable                        | Type     | Default | Description                                                                                                                                                                                                                                                     |
-| ------------------------------- | -------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `CERBERUS_CH_MAX_OPEN_CONNS`    | int      | `10`    | Total pooled ClickHouse connections (busy + idle). Must be > 0.                                                                                                                                                                                                 |
-| `CERBERUS_CH_MAX_IDLE_CONNS`    | int      | `5`     | Idle ClickHouse connections kept warm for reuse. Must be > 0.                                                                                                                                                                                                   |
-| `CERBERUS_CH_CONN_MAX_LIFETIME` | duration | `30s`   | Max age of a pooled connection before it is recycled. Kept short (vs the driver's 1h) because it bounds recovery after a ClickHouse restart: a stale conn to a force-killed pod is only aged out by this window, so 30s heals the pool in seconds. Must be > 0. |
+TCP keepalive (`CERBERUS_CH_KEEPALIVE_*`, on by default) is the primary
+recovery mechanism after a ClickHouse restart: the kernel probes idle sockets
+and tears down a connection to a force-killed pod within roughly
+`IDLE + INTERVAL × COUNT` (≈25s at the defaults), so the next query fails fast
+with a broken-conn error that is retried and evicted instead of blocking on a
+half-open socket. Probes fire only on idle connections, so long streaming
+queries are never interrupted. `CERBERUS_CH_CONN_MAX_LIFETIME` is the
+age-eviction backstop if keepalive is disabled.
+
+| Variable                         | Type     | Default | Description                                                                                                                                                                                                                                                     |
+| -------------------------------- | -------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CERBERUS_CH_MAX_OPEN_CONNS`     | int      | `10`    | Total pooled ClickHouse connections (busy + idle). Must be > 0.                                                                                                                                                                                                 |
+| `CERBERUS_CH_MAX_IDLE_CONNS`     | int      | `5`     | Idle ClickHouse connections kept warm for reuse. Must be > 0.                                                                                                                                                                                                   |
+| `CERBERUS_CH_CONN_MAX_LIFETIME`  | duration | `30s`   | Max age of a pooled connection before it is recycled. Age-eviction backstop for a stale conn to a restarted backend (keepalive is the primary mechanism). Must be > 0.                                                                                          |
+| `CERBERUS_CH_KEEPALIVE_ENABLED`  | bool     | `true`  | Enable TCP keepalive on ClickHouse connection sockets so the kernel detects a dead peer after a restart.                                                                                                                                                        |
+| `CERBERUS_CH_KEEPALIVE_IDLE`     | duration | `10s`   | Idle time before the first keepalive probe. Must be > 0 when keepalive is enabled.                                                                                                                                                                              |
+| `CERBERUS_CH_KEEPALIVE_INTERVAL` | duration | `5s`    | Gap between successive keepalive probes. Must be > 0 when keepalive is enabled.                                                                                                                                                                                 |
+| `CERBERUS_CH_KEEPALIVE_COUNT`    | int      | `3`     | Unanswered keepalive probes before the socket is declared dead. Must be > 0 when keepalive is enabled.                                                                                                                                                          |
 
 ## Query limits and memory
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -103,7 +103,7 @@ ClickHouse-health failure).
 | ------------------------------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `CERBERUS_CH_MAX_OPEN_CONNS`    | int      | `10`    | Total pooled ClickHouse connections (busy + idle). Must be > 0.                                                                                                                       |
 | `CERBERUS_CH_MAX_IDLE_CONNS`    | int      | `5`     | Idle ClickHouse connections kept warm for reuse. Must be > 0.                                                                                                                         |
-| `CERBERUS_CH_CONN_MAX_LIFETIME` | duration | `5m`    | Max age of a pooled connection before it is recycled. Kept short (vs the driver's 1h) so a stale conn to a restarted ClickHouse pod is recycled in minutes, not an hour. Must be > 0. |
+| `CERBERUS_CH_CONN_MAX_LIFETIME` | duration | `30s`   | Max age of a pooled connection before it is recycled. Kept short (vs the driver's 1h) because it is the effective recovery bound after a ClickHouse restart: the driver has no idle-health knob and a stale conn to a force-killed pod blocks reads for minutes, so age eviction is what heals the pool — 30s recovers in seconds. Must be > 0. |
 
 ## Query limits and memory
 

--- a/internal/chclient/client.go
+++ b/internal/chclient/client.go
@@ -109,20 +109,25 @@ type Config struct {
 	// 1h; cerberus makes it explicit. Zero falls back to
 	// defaultConnMaxLifetime.
 	//
-	// It doubles as the recovery-speed ceiling for a restarted ClickHouse
-	// backend (ch-pod-kill, run 27509796946). clickhouse-go (v2.46.0) has
-	// no separate idle-time knob: a pooled conn to the OLD pod is dropped
-	// at acquire only once acquire()'s isBad() check trips — either the
-	// non-blocking socket read in conn_check.go notices the dead peer, OR
-	// the conn crosses ConnMaxLifetime (isBad checks both). A force-killed
-	// pod often leaves the socket in ESTABLISHED with no FIN/RST, so the
-	// socket check passes and the conn is only retired once it ages past
-	// ConnMaxLifetime — which at the 1h default is far too long. The
-	// transport-retry on the data path (see retry.go) makes a stale conn
-	// transparent on the FIRST query regardless of this value; this cap is
-	// the backstop that bounds how long a never-queried idle stale conn can
-	// otherwise loiter, so a modest value (minutes, not an hour) keeps the
-	// pool self-healing without churning conns under healthy load.
+	// It is the recovery-speed CEILING for a restarted ClickHouse backend
+	// (ch-pod-kill, run 27509796946). clickhouse-go (v2.46.0) has no
+	// idle-health knob: a pooled conn to the OLD pod is dropped at acquire
+	// only once acquire()'s isBad() check trips — either the non-blocking
+	// socket read in conn_check.go notices the dead peer, OR the conn
+	// crosses ConnMaxLifetime (isBad checks both). A force-killed pod often
+	// leaves the socket in ESTABLISHED with no FIN/RST, so the socket check
+	// passes the dead conn through as healthy. The driver evicts a conn the
+	// instant a query against it errors (release(conn, err) → close), but
+	// the error only surfaces AFTER the read on the dead peer unblocks — and
+	// that read blocks for the driver's ReadTimeout (300s default) or the
+	// request's ctx budget (minutes). So the transport-retry can NOT make a
+	// stale conn transparent in seconds: the FIRST attempt blocks for
+	// minutes before it can even retry. ConnMaxLifetime is therefore the
+	// effective heal bound — the only age-eviction lever — so it must be
+	// SHORT (tens of seconds) for fast restart recovery, not minutes. See
+	// internal/config defaultCHConnMaxLifetime for the chosen value + churn
+	// trade-off; the retry.go path remains the in-window absorber for the
+	// rare stale conn that fails fast.
 	ConnMaxLifetime time.Duration
 
 	// MaxQuerySamples caps the number of Sample rows a single query may

--- a/internal/chclient/client.go
+++ b/internal/chclient/client.go
@@ -5,6 +5,7 @@ package chclient
 import (
 	"context"
 	"fmt"
+	"net"
 	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
@@ -107,28 +108,41 @@ type Config struct {
 	// ConnMaxLifetime caps how long a single pooled connection may live
 	// before the driver recycles it. clickhouse-go's implicit default is
 	// 1h; cerberus makes it explicit. Zero falls back to
-	// defaultConnMaxLifetime.
-	//
-	// It is the recovery-speed CEILING for a restarted ClickHouse backend
-	// (ch-pod-kill, run 27509796946). clickhouse-go (v2.46.0) has no
-	// idle-health knob: a pooled conn to the OLD pod is dropped at acquire
-	// only once acquire()'s isBad() check trips — either the non-blocking
-	// socket read in conn_check.go notices the dead peer, OR the conn
-	// crosses ConnMaxLifetime (isBad checks both). A force-killed pod often
-	// leaves the socket in ESTABLISHED with no FIN/RST, so the socket check
-	// passes the dead conn through as healthy. The driver evicts a conn the
-	// instant a query against it errors (release(conn, err) → close), but
-	// the error only surfaces AFTER the read on the dead peer unblocks — and
-	// that read blocks for the driver's ReadTimeout (300s default) or the
-	// request's ctx budget (minutes). So the transport-retry can NOT make a
-	// stale conn transparent in seconds: the FIRST attempt blocks for
-	// minutes before it can even retry. ConnMaxLifetime is therefore the
-	// effective heal bound — the only age-eviction lever — so it must be
-	// SHORT (tens of seconds) for fast restart recovery, not minutes. See
-	// internal/config defaultCHConnMaxLifetime for the chosen value + churn
-	// trade-off; the retry.go path remains the in-window absorber for the
-	// rare stale conn that fails fast.
+	// defaultConnMaxLifetime. It is an age-eviction backstop for a stale
+	// conn to a restarted backend (see KeepAliveEnabled for the primary
+	// dead-peer detection mechanism).
 	ConnMaxLifetime time.Duration
+
+	// KeepAliveEnabled turns on TCP keepalive on every CH connection's
+	// socket (via the New() DialContext dialer). It is the ROOT-CAUSE fix
+	// for slow breaker recovery after a ClickHouse restart: clickhouse-go
+	// (v2.46.0) has no idle-health knob, and a force-killed pod often
+	// leaves the socket ESTABLISHED with no FIN/RST, so the driver's cheap
+	// per-acquire socket check passes the dead conn through as healthy and
+	// the next query blocks on a read until ReadTimeout (300s) — surfacing
+	// as context.DeadlineExceeded, which is NOT a broken-conn error and so
+	// is neither fast-retried nor evicted. With keepalive on, the kernel
+	// probes the idle socket and, after KeepAliveProbes unanswered probes,
+	// declares the peer dead; the blocked read then returns ECONNRESET fast
+	// — which isBrokenConnError classifies, so withTransportRetry evicts +
+	// redials. Keepalive probes fire ONLY on IDLE sockets, so a long
+	// streaming query is never interrupted. Default false on a bare Config
+	// (tests); internal/config always supplies the production true default.
+	KeepAliveEnabled bool
+
+	// KeepAliveIdle is how long a connection stays idle before the kernel
+	// sends the first keepalive probe. Only consulted when KeepAliveEnabled.
+	KeepAliveIdle time.Duration
+
+	// KeepAliveInterval is the gap between successive keepalive probes once
+	// probing has started. Only consulted when KeepAliveEnabled.
+	KeepAliveInterval time.Duration
+
+	// KeepAliveProbes is the number of unanswered keepalive probes after
+	// which the socket is declared dead. Idle + Interval*Probes is the
+	// worst-case dead-peer detection window. Only consulted when
+	// KeepAliveEnabled.
+	KeepAliveProbes int
 
 	// MaxQuerySamples caps the number of Sample rows a single query may
 	// load into memory. When a cursor drain crosses the budget,
@@ -351,6 +365,28 @@ func (c *Client) ForHead(h Head) *Client {
 	return &view
 }
 
+// dialContext builds the clickhouse.Options.DialContext function: a
+// net.Dialer that applies the dial timeout plus the per-Config TCP
+// keepalive policy. When cfg.KeepAliveEnabled is false the dialer still
+// dials (KeepAliveConfig.Enable:false) so DialContext behaviour is
+// uniform — keepalive is simply not armed. The network is forced to
+// "tcp" because the CH native protocol is always TCP; the driver passes
+// the configured host:port as addr.
+func dialContext(dial time.Duration, cfg Config) func(context.Context, string) (net.Conn, error) {
+	d := &net.Dialer{
+		Timeout: dial,
+		KeepAliveConfig: net.KeepAliveConfig{
+			Enable:   cfg.KeepAliveEnabled,
+			Idle:     cfg.KeepAliveIdle,
+			Interval: cfg.KeepAliveInterval,
+			Count:    cfg.KeepAliveProbes,
+		},
+	}
+	return func(ctx context.Context, addr string) (net.Conn, error) {
+		return d.DialContext(ctx, "tcp", addr)
+	}
+}
+
 // New opens a connection pool to ClickHouse. Construction is lazy:
 // clickhouse.Open only validates options and never dials, so New
 // succeeds even when ClickHouse is unreachable — the first Ping/Query
@@ -380,6 +416,14 @@ func New(cfg Config) (*Client, error) {
 			Password: cfg.Password,
 		},
 		DialTimeout: dial,
+		// DialContext routes every CH connection through a net.Dialer so we
+		// can put TCP keepalive on the socket — the root-cause fix for slow
+		// breaker recovery after a CH restart (see Config.KeepAliveEnabled).
+		// Keepalive probes fire ONLY on idle sockets, so a long streaming
+		// query is never interrupted. When keepalive is disabled we still
+		// dial through the same net.Dialer (Enable:false) so DialContext
+		// behaviour is uniform — only the keepalive policy changes.
+		DialContext: dialContext(dial, cfg),
 	}
 	// Pool sizing is explicit and configurable (#81). A zero field is
 	// left unset so clickhouse-go's own default applies — that keeps the

--- a/internal/chclient/keepalive_test.go
+++ b/internal/chclient/keepalive_test.go
@@ -1,0 +1,79 @@
+package chclient
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+)
+
+// TestNew_KeepAliveEnabled_BuildsDialer asserts New succeeds with TCP keepalive
+// configured (the production default) and that the resulting dialer dials a TCP
+// socket. clickhouse.Open is lazy (no dial), so we exercise dialContext
+// directly against a local listener to prove the dialer actually connects with
+// keepalive armed — the root-cause restart-recovery fix.
+func TestNew_KeepAliveEnabled_BuildsDialer(t *testing.T) {
+	t.Parallel()
+	cfg := Config{
+		Addr:              "localhost:9000",
+		KeepAliveEnabled:  true,
+		KeepAliveIdle:     10 * time.Second,
+		KeepAliveInterval: 5 * time.Second,
+		KeepAliveProbes:   3,
+	}
+	client, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New (keepalive enabled): %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+
+	assertDialerConnects(t, dialContext(5*time.Second, cfg))
+}
+
+// TestNew_KeepAliveDisabled_StillDials asserts that with keepalive OFF New
+// still succeeds and the dialer still dials (Enable:false) — disabling
+// keepalive must not drop DialContext behaviour, only the keepalive policy.
+func TestNew_KeepAliveDisabled_StillDials(t *testing.T) {
+	t.Parallel()
+	cfg := Config{Addr: "localhost:9000", KeepAliveEnabled: false}
+	client, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New (keepalive disabled): %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+
+	assertDialerConnects(t, dialContext(5*time.Second, cfg))
+}
+
+// TestNew_ZeroConfig_Succeeds pins the bare-Config zero-value convention: a
+// Config with no fields set (as many tests build) opens cleanly — keepalive is
+// simply not armed (Enable:false), matching the documented zero-value sanity.
+func TestNew_ZeroConfig_Succeeds(t *testing.T) {
+	t.Parallel()
+	client, err := New(Config{Addr: "localhost:9000"})
+	if err != nil {
+		t.Fatalf("New (zero config): %v", err)
+	}
+	_ = client.Close()
+}
+
+// assertDialerConnects spins up a throwaway TCP listener and proves the
+// DialContext func actually opens a connection to it (independent of keepalive
+// being enabled or not).
+func assertDialerConnects(t *testing.T, dial func(context.Context, string) (net.Conn, error)) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	conn, err := dial(context.Background(), ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	if conn == nil {
+		t.Fatal("dial returned nil conn")
+	}
+	_ = conn.Close()
+}

--- a/internal/chclient/retry_test.go
+++ b/internal/chclient/retry_test.go
@@ -169,6 +169,43 @@ func TestQuery_ManyStaleConns_DrainedInOneRequest(t *testing.T) {
 	}
 }
 
+// TestWithTransportRetry_BlockingStaleConn_NotRetried pins the failure mode
+// the ConnMaxLifetime fix targets — the one the retry path CANNOT absorb. A
+// force-killed CH pod leaves its socket half-open (ESTABLISHED, no FIN/RST),
+// so a read against it does NOT fail fast: it blocks until the request's ctx
+// deadline (or the driver's ReadTimeout), surfacing context.DeadlineExceeded.
+// That error is deliberately NOT a broken-conn error (isBrokenConnError ==
+// false), so withTransportRetry makes exactly ONE attempt and returns it —
+// there is no fast re-acquire that drains the bad conn. record() then counts
+// the deadline as a real breaker failure. Hence the stale conn lingers and
+// re-trips every probe until something AGES it out: ConnMaxLifetime is that
+// lever, which is why it (not the retry) bounds restart recovery and must be
+// short. If this ever starts retrying, the fast-recovery reasoning in
+// internal/config defaultCHConnMaxLifetime needs revisiting.
+func TestWithTransportRetry_BlockingStaleConn_NotRetried(t *testing.T) {
+	t.Parallel()
+	if isBrokenConnError(context.DeadlineExceeded) {
+		t.Fatal("context.DeadlineExceeded must NOT be a broken-conn error — a blocking stale conn is not fast-retryable")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var calls int
+	// The call models a read that blocked on the dead peer until the ctx
+	// budget expired: it returns DeadlineExceeded, exactly as the driver's
+	// firstBlock read does once SetDeadline fires.
+	_, err := withTransportRetry(ctx, func() (struct{}, error) {
+		calls++
+		return struct{}{}, context.DeadlineExceeded
+	})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("err = %v; want the deadline surfaced unmodified", err)
+	}
+	if calls != 1 {
+		t.Errorf("calls = %d; want 1 (a blocking stale conn is NOT retried — age eviction heals it)", calls)
+	}
+}
+
 // TestPing_StaleConn_RecoversSilently — the readiness-probe path (Ping) gets
 // the same stale-conn recovery, so /readyz doesn't flap red on a transient
 // stale conn after a restart.

--- a/internal/config/ch_keepalive_test.go
+++ b/internal/config/ch_keepalive_test.go
@@ -1,0 +1,110 @@
+package config
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestFromEnv_CHKeepAlive_Defaults pins the TCP-keepalive defaults: enabled,
+// 10s idle, 5s interval, 3 probes (≈25s worst-case dead-peer detection). These
+// are the ROOT-CAUSE fix for slow breaker recovery after a ClickHouse restart —
+// the kernel tears down a half-open socket to a force-killed pod so the next
+// query fails fast (broken-conn → retried + evicted) instead of blocking.
+func TestFromEnv_CHKeepAlive_Defaults(t *testing.T) {
+	t.Setenv("CERBERUS_CH_KEEPALIVE_ENABLED", "")
+	t.Setenv("CERBERUS_CH_KEEPALIVE_IDLE", "")
+	t.Setenv("CERBERUS_CH_KEEPALIVE_INTERVAL", "")
+	t.Setenv("CERBERUS_CH_KEEPALIVE_COUNT", "")
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	if !cfg.ClickHouse.KeepAliveEnabled {
+		t.Errorf("KeepAliveEnabled = false; want true (root-cause restart-recovery fix)")
+	}
+	if cfg.ClickHouse.KeepAliveIdle != 10*time.Second {
+		t.Errorf("KeepAliveIdle = %s; want 10s", cfg.ClickHouse.KeepAliveIdle)
+	}
+	if cfg.ClickHouse.KeepAliveInterval != 5*time.Second {
+		t.Errorf("KeepAliveInterval = %s; want 5s", cfg.ClickHouse.KeepAliveInterval)
+	}
+	if cfg.ClickHouse.KeepAliveProbes != 3 {
+		t.Errorf("KeepAliveProbes = %d; want 3", cfg.ClickHouse.KeepAliveProbes)
+	}
+}
+
+// TestFromEnv_CHKeepAlive_Overrides confirms the four env vars thread through
+// to chclient.Config.
+func TestFromEnv_CHKeepAlive_Overrides(t *testing.T) {
+	t.Setenv("CERBERUS_CH_KEEPALIVE_ENABLED", "true")
+	t.Setenv("CERBERUS_CH_KEEPALIVE_IDLE", "30s")
+	t.Setenv("CERBERUS_CH_KEEPALIVE_INTERVAL", "7s")
+	t.Setenv("CERBERUS_CH_KEEPALIVE_COUNT", "5")
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	if !cfg.ClickHouse.KeepAliveEnabled {
+		t.Errorf("KeepAliveEnabled = false; want true")
+	}
+	if cfg.ClickHouse.KeepAliveIdle != 30*time.Second {
+		t.Errorf("KeepAliveIdle = %s; want 30s", cfg.ClickHouse.KeepAliveIdle)
+	}
+	if cfg.ClickHouse.KeepAliveInterval != 7*time.Second {
+		t.Errorf("KeepAliveInterval = %s; want 7s", cfg.ClickHouse.KeepAliveInterval)
+	}
+	if cfg.ClickHouse.KeepAliveProbes != 5 {
+		t.Errorf("KeepAliveProbes = %d; want 5", cfg.ClickHouse.KeepAliveProbes)
+	}
+}
+
+// TestFromEnv_CHKeepAlive_DisabledSkipsTimingValidation confirms that when
+// keepalive is OFF the inert timing knobs are not gated — a degenerate idle /
+// interval / count is tolerated because the dialer never arms keepalive.
+func TestFromEnv_CHKeepAlive_DisabledSkipsTimingValidation(t *testing.T) {
+	t.Setenv("CERBERUS_CH_KEEPALIVE_ENABLED", "false")
+	t.Setenv("CERBERUS_CH_KEEPALIVE_IDLE", "0s")
+	t.Setenv("CERBERUS_CH_KEEPALIVE_INTERVAL", "0s")
+	t.Setenv("CERBERUS_CH_KEEPALIVE_COUNT", "0")
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v; disabled keepalive must tolerate inert timing knobs", err)
+	}
+	if cfg.ClickHouse.KeepAliveEnabled {
+		t.Errorf("KeepAliveEnabled = true; want false")
+	}
+}
+
+// TestFromEnv_CHKeepAlive_Invalid confirms unparseable values, and non-positive
+// timing knobs WHILE ENABLED, fail fast naming the offending env var.
+func TestFromEnv_CHKeepAlive_Invalid(t *testing.T) {
+	cases := []struct {
+		env, val string
+	}{
+		{"CERBERUS_CH_KEEPALIVE_ENABLED", "maybe"},
+		{"CERBERUS_CH_KEEPALIVE_IDLE", "forever"},
+		{"CERBERUS_CH_KEEPALIVE_IDLE", "0s"},
+		{"CERBERUS_CH_KEEPALIVE_IDLE", "-1s"},
+		{"CERBERUS_CH_KEEPALIVE_INTERVAL", "nope"},
+		{"CERBERUS_CH_KEEPALIVE_INTERVAL", "0s"},
+		{"CERBERUS_CH_KEEPALIVE_INTERVAL", "-5s"},
+		{"CERBERUS_CH_KEEPALIVE_COUNT", "lots"},
+		{"CERBERUS_CH_KEEPALIVE_COUNT", "0"},
+		{"CERBERUS_CH_KEEPALIVE_COUNT", "-3"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.env+"="+tc.val, func(t *testing.T) {
+			// Keepalive must be ENABLED for the timing knobs to be validated.
+			t.Setenv("CERBERUS_CH_KEEPALIVE_ENABLED", "true")
+			t.Setenv(tc.env, tc.val)
+			_, err := FromEnv()
+			if err == nil {
+				t.Fatalf("FromEnv accepted %s=%q; want error", tc.env, tc.val)
+			}
+			if !strings.Contains(err.Error(), tc.env) {
+				t.Errorf("error %q does not name the env var %s", err, tc.env)
+			}
+		})
+	}
+}

--- a/internal/config/ch_pool_test.go
+++ b/internal/config/ch_pool_test.go
@@ -9,9 +9,10 @@ import (
 // TestFromEnv_CHPool_Defaults pins the explicit pool defaults (#81).
 // MaxOpenConns / MaxIdleConns reproduce clickhouse-go/v2's implicit values
 // (10 / 5) so the non-sharded path stays behaviour-compatible. ConnMaxLifetime
-// DEPARTS from the driver's 1h default: it is 5m, the backstop that bounds how
-// long a stale pooled conn to a restarted backend can loiter (ch-pod-kill
-// recovery, run 27509796946).
+// DEPARTS from the driver's 1h default: it is 30s — the effective restart
+// heal bound, since the driver's only age-eviction lever ages out a stale conn
+// to a force-killed pod whose socket reads block for minutes (ch-pod-kill
+// recovery, the 5m value re-flaked because that was the heal ceiling).
 func TestFromEnv_CHPool_Defaults(t *testing.T) {
 	t.Setenv("CERBERUS_CH_MAX_OPEN_CONNS", "")
 	t.Setenv("CERBERUS_CH_MAX_IDLE_CONNS", "")
@@ -26,8 +27,8 @@ func TestFromEnv_CHPool_Defaults(t *testing.T) {
 	if cfg.ClickHouse.MaxIdleConns != 5 {
 		t.Errorf("MaxIdleConns = %d; want 5 (clickhouse-go implicit default)", cfg.ClickHouse.MaxIdleConns)
 	}
-	if cfg.ClickHouse.ConnMaxLifetime != 5*time.Minute {
-		t.Errorf("ConnMaxLifetime = %s; want 5m (restart-recovery backstop, not the driver's 1h)", cfg.ClickHouse.ConnMaxLifetime)
+	if cfg.ClickHouse.ConnMaxLifetime != 30*time.Second {
+		t.Errorf("ConnMaxLifetime = %s; want 30s (restart heal bound, not the driver's 1h)", cfg.ClickHouse.ConnMaxLifetime)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -595,9 +595,9 @@ const defaultCHQueryMaxMemory int64 = 1 << 30 // 1073741824 bytes
 // cheap to redial, so recycling the idle pool every 30s is negligible churn —
 // the steady-state trade-off the short window costs.
 const (
-	defaultCHMaxOpenConns                       = 10
-	defaultCHMaxIdleConns                       = 5
-	defaultCHConnMaxLifetime      time.Duration = 30 * time.Second
+	defaultCHMaxOpenConns                  = 10
+	defaultCHMaxIdleConns                  = 5
+	defaultCHConnMaxLifetime time.Duration = 30 * time.Second
 )
 
 // Circuit-breaker defaults (#95). These reproduce the previously-

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -228,7 +228,7 @@ const configFileBaseName = "cerberus"
 //	CERBERUS_CH_DIAL_TIMEOUT       default "5s"
 //	CERBERUS_CH_MAX_OPEN_CONNS     default 10 (total pooled conns, busy + idle)
 //	CERBERUS_CH_MAX_IDLE_CONNS     default 5  (idle conns kept warm for reuse)
-//	CERBERUS_CH_CONN_MAX_LIFETIME  default "5m" (max age before a conn is recycled; short so a stale conn to a restarted CH pod recycles fast)
+//	CERBERUS_CH_CONN_MAX_LIFETIME  default "30s" (max age before a conn is recycled; short so a stale conn to a restarted CH pod ages out in seconds — the effective restart heal bound)
 //	CERBERUS_QUERY_MAX_SAMPLES     default 50000000 (0 disables the budget)
 //	CERBERUS_QUERY_TIMEOUT         default "2m" — per-query wall-clock cap stamped
 //	    as ClickHouse max_execution_time (timeout_overflow_mode=throw); the
@@ -571,22 +571,33 @@ const defaultCHQueryMaxMemory int64 = 1 << 30 // 1073741824 bytes
 // circuit breaker treats neutrally (local pool-sizing signal, not CH-health
 // failure).
 //
-// ConnMaxLifetime DEPARTS from the driver's 1h default: it is the backstop
-// that bounds how long a stale pooled conn to a RESTARTED ClickHouse backend
-// can loiter (ch-pod-kill recovery, run 27509796946). clickhouse-go v2.46.0
-// has no idle-time knob, and a force-killed pod's socket can stay ESTABLISHED
-// (no FIN/RST) so the driver's per-acquire socket check passes the dead conn
-// through; the conn is only retired once it ages past ConnMaxLifetime. At 1h
-// that left a never-queried idle conn dead-but-pooled for the better part of
-// an hour. 5m keeps the pool self-healing after a restart while staying long
-// enough that healthy conns are not churned on every request. The data-path
-// transport-retry (internal/chclient/retry.go) already makes a stale conn
-// transparent on the first QUERY regardless of this value; this just caps the
-// loiter window for idle conns that are never queried.
+// ConnMaxLifetime DEPARTS from the driver's 1h default: it is the
+// recovery-speed CEILING for a RESTARTED ClickHouse backend (ch-pod-kill
+// recovery, run 27509796946 — then re-flaked at the 5m value, run
+// 27572XXXXXX). clickhouse-go v2.46.0 exposes NO idle-health knob, and a
+// force-killed pod's socket can stay ESTABLISHED (no FIN/RST), so the driver's
+// per-acquire socket check (conn_check.go) passes the dead conn through as
+// healthy. The driver DOES evict a conn the moment a query against it errors
+// (clickhouse.release(conn, err) → conn.close()), but the error only surfaces
+// AFTER the socket read on the dead peer unblocks — and an idle-but-not-noticed
+// stale conn's read blocks for the driver's full ReadTimeout (300s default) or
+// the request's ctx budget (the prom head's 2m QueryTimeout). So neither the
+// transport-retry nor the per-query eviction fires in seconds: recovery is
+// bounded by whichever ages the stale conn out first. ConnMaxLifetime is the
+// ONLY age-eviction lever — isBad() retires any conn older than it at acquire,
+// and the pool's background drain ticker fires on the same period — so it
+// directly sets the worst-case heal window. 5m bounded recovery at ~5m (the
+// observed flake: one replica's breaker stayed OPEN until exactly
+// process-start + 5m). 30s bounds it to ~30s + one breaker probe interval
+// (well under the chaos BREAKER_CLOSE_DEADLINE_MS=300s, and under 60s),
+// deterministically and on EVERY replica, because age eviction is
+// unconditional. CH native conns are stateless (no session temp tables) and
+// cheap to redial, so recycling the idle pool every 30s is negligible churn —
+// the steady-state trade-off the short window costs.
 const (
-	defaultCHMaxOpenConns                  = 10
-	defaultCHMaxIdleConns                  = 5
-	defaultCHConnMaxLifetime time.Duration = 5 * time.Minute
+	defaultCHMaxOpenConns                       = 10
+	defaultCHMaxIdleConns                       = 5
+	defaultCHConnMaxLifetime      time.Duration = 30 * time.Second
 )
 
 // Circuit-breaker defaults (#95). These reproduce the previously-

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -186,6 +186,10 @@ const (
 	envCHMaxOpenConns      = "CERBERUS_CH_MAX_OPEN_CONNS"
 	envCHMaxIdleConns      = "CERBERUS_CH_MAX_IDLE_CONNS"
 	envCHConnMaxLifetime   = "CERBERUS_CH_CONN_MAX_LIFETIME"
+	envCHKeepAliveEnabled  = "CERBERUS_CH_KEEPALIVE_ENABLED"
+	envCHKeepAliveIdle     = "CERBERUS_CH_KEEPALIVE_IDLE"
+	envCHKeepAliveInterval = "CERBERUS_CH_KEEPALIVE_INTERVAL"
+	envCHKeepAliveCount    = "CERBERUS_CH_KEEPALIVE_COUNT"
 	envQueryMaxSamples     = "CERBERUS_QUERY_MAX_SAMPLES"
 	envQueryTimeout        = "CERBERUS_QUERY_TIMEOUT"
 	envCHQueryMaxMemory    = "CERBERUS_CH_QUERY_MAX_MEMORY"
@@ -228,7 +232,11 @@ const configFileBaseName = "cerberus"
 //	CERBERUS_CH_DIAL_TIMEOUT       default "5s"
 //	CERBERUS_CH_MAX_OPEN_CONNS     default 10 (total pooled conns, busy + idle)
 //	CERBERUS_CH_MAX_IDLE_CONNS     default 5  (idle conns kept warm for reuse)
-//	CERBERUS_CH_CONN_MAX_LIFETIME  default "30s" (max age before a conn is recycled; short so a stale conn to a restarted CH pod ages out in seconds — the effective restart heal bound)
+//	CERBERUS_CH_CONN_MAX_LIFETIME  default "30s" (max age before a pooled conn is recycled)
+//	CERBERUS_CH_KEEPALIVE_ENABLED  default "true" (TCP keepalive on CH sockets; bounds dead-peer detection after a restart)
+//	CERBERUS_CH_KEEPALIVE_IDLE     default "10s"  (idle before the first keepalive probe)
+//	CERBERUS_CH_KEEPALIVE_INTERVAL default "5s"   (gap between keepalive probes)
+//	CERBERUS_CH_KEEPALIVE_COUNT    default 3      (unanswered probes before the socket is declared dead)
 //	CERBERUS_QUERY_MAX_SAMPLES     default 50000000 (0 disables the budget)
 //	CERBERUS_QUERY_TIMEOUT         default "2m" — per-query wall-clock cap stamped
 //	    as ClickHouse max_execution_time (timeout_overflow_mode=throw); the
@@ -313,6 +321,37 @@ func FromEnv() (Config, error) {
 	if connMaxLifetime <= 0 {
 		return Config{}, fmt.Errorf("%s: must be > 0, got %s", envCHConnMaxLifetime, connMaxLifetime)
 	}
+	keepAliveEnabled, err := getBool(v, envCHKeepAliveEnabled)
+	if err != nil {
+		return Config{}, err
+	}
+	keepAliveIdle, err := getDuration(v, envCHKeepAliveIdle)
+	if err != nil {
+		return Config{}, err
+	}
+	keepAliveInterval, err := getDuration(v, envCHKeepAliveInterval)
+	if err != nil {
+		return Config{}, err
+	}
+	keepAliveCount, err := getInt(v, envCHKeepAliveCount)
+	if err != nil {
+		return Config{}, err
+	}
+	// Validate the keepalive timing knobs only when keepalive is enabled —
+	// a degenerate idle/interval/count would arm a useless or never-firing
+	// probe schedule. When disabled the values are inert, so they are not
+	// gated (mirrors how the breaker knobs are inert when the breaker is off).
+	if keepAliveEnabled {
+		if keepAliveIdle <= 0 {
+			return Config{}, fmt.Errorf("%s: must be > 0, got %s", envCHKeepAliveIdle, keepAliveIdle)
+		}
+		if keepAliveInterval <= 0 {
+			return Config{}, fmt.Errorf("%s: must be > 0, got %s", envCHKeepAliveInterval, keepAliveInterval)
+		}
+		if keepAliveCount <= 0 {
+			return Config{}, fmt.Errorf("%s: must be > 0, got %d", envCHKeepAliveCount, keepAliveCount)
+		}
+	}
 	maxSamples, err := getInt64(v, envQueryMaxSamples)
 	if err != nil {
 		return Config{}, err
@@ -361,6 +400,10 @@ func FromEnv() (Config, error) {
 			MaxOpenConns:        maxOpenConns,
 			MaxIdleConns:        maxIdleConns,
 			ConnMaxLifetime:     connMaxLifetime,
+			KeepAliveEnabled:    keepAliveEnabled,
+			KeepAliveIdle:       keepAliveIdle,
+			KeepAliveInterval:   keepAliveInterval,
+			KeepAliveProbes:     keepAliveCount,
 			MaxQuerySamples:     maxSamples,
 			MaxQueryMemoryBytes: maxMemory,
 			QueryTimeout:        queryTimeout,
@@ -394,6 +437,10 @@ var allEnvKeys = []string{
 	envCHMaxOpenConns,
 	envCHMaxIdleConns,
 	envCHConnMaxLifetime,
+	envCHKeepAliveEnabled,
+	envCHKeepAliveIdle,
+	envCHKeepAliveInterval,
+	envCHKeepAliveCount,
 	envQueryMaxSamples,
 	envQueryTimeout,
 	envCHQueryMaxMemory,
@@ -452,6 +499,10 @@ func newLoader() *viper.Viper {
 	v.SetDefault(envCHMaxOpenConns, defaultCHMaxOpenConns)
 	v.SetDefault(envCHMaxIdleConns, defaultCHMaxIdleConns)
 	v.SetDefault(envCHConnMaxLifetime, defaultCHConnMaxLifetime.String())
+	v.SetDefault(envCHKeepAliveEnabled, defaultCHKeepAliveEnabled)
+	v.SetDefault(envCHKeepAliveIdle, defaultCHKeepAliveIdle.String())
+	v.SetDefault(envCHKeepAliveInterval, defaultCHKeepAliveInterval.String())
+	v.SetDefault(envCHKeepAliveCount, defaultCHKeepAliveCount)
 	v.SetDefault(envQueryMaxSamples, defaultQueryMaxSamples)
 	v.SetDefault(envQueryTimeout, defaultQueryTimeout.String())
 	v.SetDefault(envCHQueryMaxMemory, defaultCHQueryMaxMemory)
@@ -512,6 +563,7 @@ const (
 	defaultOTLPInsecure       = false
 	defaultOTLPHeaders        = ""
 	defaultCHBreakerEnabled   = true
+	defaultCHKeepAliveEnabled = true
 	defaultAdmitDisabled      = false
 )
 
@@ -571,33 +623,37 @@ const defaultCHQueryMaxMemory int64 = 1 << 30 // 1073741824 bytes
 // circuit breaker treats neutrally (local pool-sizing signal, not CH-health
 // failure).
 //
-// ConnMaxLifetime DEPARTS from the driver's 1h default: it is the
-// recovery-speed CEILING for a RESTARTED ClickHouse backend (ch-pod-kill
-// recovery, run 27509796946 — then re-flaked at the 5m value, run
-// 27572XXXXXX). clickhouse-go v2.46.0 exposes NO idle-health knob, and a
-// force-killed pod's socket can stay ESTABLISHED (no FIN/RST), so the driver's
-// per-acquire socket check (conn_check.go) passes the dead conn through as
-// healthy. The driver DOES evict a conn the moment a query against it errors
-// (clickhouse.release(conn, err) → conn.close()), but the error only surfaces
-// AFTER the socket read on the dead peer unblocks — and an idle-but-not-noticed
-// stale conn's read blocks for the driver's full ReadTimeout (300s default) or
-// the request's ctx budget (the prom head's 2m QueryTimeout). So neither the
-// transport-retry nor the per-query eviction fires in seconds: recovery is
-// bounded by whichever ages the stale conn out first. ConnMaxLifetime is the
-// ONLY age-eviction lever — isBad() retires any conn older than it at acquire,
-// and the pool's background drain ticker fires on the same period — so it
-// directly sets the worst-case heal window. 5m bounded recovery at ~5m (the
-// observed flake: one replica's breaker stayed OPEN until exactly
-// process-start + 5m). 30s bounds it to ~30s + one breaker probe interval
-// (well under the chaos BREAKER_CLOSE_DEADLINE_MS=300s, and under 60s),
-// deterministically and on EVERY replica, because age eviction is
-// unconditional. CH native conns are stateless (no session temp tables) and
-// cheap to redial, so recycling the idle pool every 30s is negligible churn —
-// the steady-state trade-off the short window costs.
+// ConnMaxLifetime departs from the driver's 1h default to 30s: it is the
+// age-eviction backstop that bounds recovery after a ClickHouse restart even
+// if TCP keepalive (see below) is disabled. CH native conns are stateless and
+// cheap to redial, so recycling the idle pool every 30s is negligible churn.
 const (
 	defaultCHMaxOpenConns                  = 10
 	defaultCHMaxIdleConns                  = 5
 	defaultCHConnMaxLifetime time.Duration = 30 * time.Second
+)
+
+// TCP keepalive defaults — the ROOT-CAUSE fix for slow breaker recovery after
+// a ClickHouse restart. clickhouse-go v2.46.0 exposes NO idle-health knob, and
+// a force-killed pod's socket can stay ESTABLISHED (no FIN/RST), so the
+// driver's per-acquire socket check passes the dead conn through as healthy.
+// The next query then blocks on a read until the driver's ReadTimeout (300s)
+// or the request's ctx budget — surfacing as context.DeadlineExceeded, which
+// is NOT a broken-conn error, so withTransportRetry neither fast-retries nor
+// evicts it; the stale conn lingers and re-trips every breaker probe until
+// something AGES it out. With keepalive armed, the kernel probes the idle
+// socket and, after defaultCHKeepAliveCount unanswered probes, declares the
+// peer dead; the blocked read returns ECONNRESET fast, which isBrokenConnError
+// classifies → withTransportRetry evicts + redials. Idle(10s) +
+// Interval(5s)*Count(3) ≈ 25s worst-case dead-peer detection — well under the
+// chaos BREAKER_CLOSE_DEADLINE_MS=300s and under 60s, deterministically and on
+// EVERY replica. Probes fire only on IDLE sockets, so a long streaming query
+// is never interrupted. ConnMaxLifetime remains the age-eviction backstop if
+// keepalive is turned off.
+const (
+	defaultCHKeepAliveIdle     time.Duration = 10 * time.Second
+	defaultCHKeepAliveInterval time.Duration = 5 * time.Second
+	defaultCHKeepAliveCount                  = 3
 )
 
 // Circuit-breaker defaults (#95). These reproduce the previously-

--- a/internal/config/viper_test.go
+++ b/internal/config/viper_test.go
@@ -48,6 +48,18 @@ func TestFromEnv_ViperDefaults_NoEnv(t *testing.T) {
 	if cfg.ClickHouse.ConnMaxLifetime != 30*time.Second {
 		t.Errorf("ConnMaxLifetime = %v; want 30s", cfg.ClickHouse.ConnMaxLifetime)
 	}
+	if !cfg.ClickHouse.KeepAliveEnabled {
+		t.Errorf("KeepAliveEnabled = false; want true")
+	}
+	if cfg.ClickHouse.KeepAliveIdle != 10*time.Second {
+		t.Errorf("KeepAliveIdle = %v; want 10s", cfg.ClickHouse.KeepAliveIdle)
+	}
+	if cfg.ClickHouse.KeepAliveInterval != 5*time.Second {
+		t.Errorf("KeepAliveInterval = %v; want 5s", cfg.ClickHouse.KeepAliveInterval)
+	}
+	if cfg.ClickHouse.KeepAliveProbes != 3 {
+		t.Errorf("KeepAliveProbes = %d; want 3", cfg.ClickHouse.KeepAliveProbes)
+	}
 	if cfg.ClickHouse.MaxQuerySamples != 50_000_000 {
 		t.Errorf("MaxQuerySamples = %d; want 50000000", cfg.ClickHouse.MaxQuerySamples)
 	}

--- a/internal/config/viper_test.go
+++ b/internal/config/viper_test.go
@@ -45,8 +45,8 @@ func TestFromEnv_ViperDefaults_NoEnv(t *testing.T) {
 	if cfg.ClickHouse.MaxIdleConns != 5 {
 		t.Errorf("MaxIdleConns = %d; want 5", cfg.ClickHouse.MaxIdleConns)
 	}
-	if cfg.ClickHouse.ConnMaxLifetime != 5*time.Minute {
-		t.Errorf("ConnMaxLifetime = %v; want 5m", cfg.ClickHouse.ConnMaxLifetime)
+	if cfg.ClickHouse.ConnMaxLifetime != 30*time.Second {
+		t.Errorf("ConnMaxLifetime = %v; want 30s", cfg.ClickHouse.ConnMaxLifetime)
 	}
 	if cfg.ClickHouse.MaxQuerySamples != 50_000_000 {
 		t.Errorf("MaxQuerySamples = %d; want 50000000", cfg.ClickHouse.MaxQuerySamples)


### PR DESCRIPTION
## Problem

The informational `chaos` CI lane (`ch-pod-kill` scenario) flakes: after the
ClickHouse pod is killed and rescheduled, one cerberus replica's per-head CH
circuit breaker stays **OPEN for almost exactly 5 minutes** before recovering,
tripping the `cerberus_ch_breaker_state should be 0 (CLOSED)` assertion.

Real CI timeline: CH killed ~21:03:55; one replica's breaker closed at 21:04:41
(CH already healthy), but a **second replica stayed OPEN until 21:09:47** —
process-start + 5m. That 5m == the prior `ConnMaxLifetime` default.

## Root cause

cerberus uses clickhouse-go/v2's **native** `clickhouse.Conn` pool, which has
**no idle-health knob** (v2.46.0). A force-killed CH pod leaves its old socket
half-open (ESTABLISHED, no FIN/RST), so the driver's per-acquire non-blocking
socket check (`conn_check.go`) passes the dead conn through as **healthy** and
hands it out. The next query then blocks on a read against the dead peer until
the driver's `ReadTimeout` (300s) or the request's ctx budget, surfacing as
`context.DeadlineExceeded` — which is *not* a broken-conn error, so it is
neither fast-retried (`withTransportRetry`) nor fast-evicted, and it counts as a
real breaker failure. Recovery is therefore bounded by whatever **ages the stale
conn out** first.

## Fix — TCP keepalive (root cause), ConnMaxLifetime as backstop

The **preferred root-cause fix** is to detect the dead peer at the *socket*
layer. `New()` now dials every CH connection through a `net.Dialer` with
`KeepAliveConfig` (Go 1.26 `net.KeepAliveConfig{Enable,Idle,Interval,Count}`),
so the kernel probes idle sockets and, after `COUNT` unanswered probes, declares
the peer dead. The blocked read then returns **ECONNRESET fast**, which
`isBrokenConnError` classifies → `withTransportRetry` evicts + redials. With the
defaults (Idle 10s, Interval 5s, Count 3) dead-peer detection is **~25s**, well
under the chaos `BREAKER_CLOSE_DEADLINE_MS` (300s) and under 60s, on **every**
replica. Keepalive probes fire **only on idle sockets**, so a long streaming
query is never interrupted. When keepalive is disabled the dialer still dials
(`Enable:false`) — `DialContext` behaviour is uniform.

Four new env knobs (every-knob-is-env), wired through the full config pipeline
with fail-fast validation (idle/interval/count must be > 0 when enabled):

| Variable | Default | Meaning |
| --- | --- | --- |
| `CERBERUS_CH_KEEPALIVE_ENABLED` | `true` | Arm TCP keepalive on CH sockets |
| `CERBERUS_CH_KEEPALIVE_IDLE` | `10s` | Idle before first probe |
| `CERBERUS_CH_KEEPALIVE_INTERVAL` | `5s` | Gap between probes |
| `CERBERUS_CH_KEEPALIVE_COUNT` | `3` | Unanswered probes → socket dead (~25s) |

`ConnMaxLifetime` stays at **30s** as the **age-eviction backstop** if keepalive
is ever disabled; its verbose 5-min-recovery-saga docs are trimmed to a light
field description (the rationale now lives with the keepalive consts/comment).

## Why keepalive, not just the lifetime backstop

A short `ConnMaxLifetime` heals via *unconditional age eviction*, recycling the
whole idle pool on a timer even in steady state. Keepalive heals via *targeted
dead-peer detection* — only the actually-dead socket is torn down, the moment
the kernel proves the peer is gone, independent of how long the conn has lived.
It is the mechanism the maintainer asked for as the real fix.

## Tests

- `internal/config`: `ch_keepalive_test.go` (defaults / overrides /
  disabled-skips-validation / fail-fast invalid) + `viper_test.go` default pins.
- `internal/chclient`: `keepalive_test.go` asserts `New()` builds a working
  dialer with keepalive enabled and disabled (dials a local listener), plus the
  bare zero-Config sanity. Existing `retry_test.go` (incl.
  `TestWithTransportRetry_BlockingStaleConn_NotRetried`) kept.
- `go test -race ./internal/config/... ./internal/chclient/...` green.

## k3d verification

See the verification comment for the recorded recovery timings, including the
**high-`ConnMaxLifetime` variant** (1h lifetime + keepalive on) that isolates
keepalive as the mechanism doing the recovery.
