### PR TITLE
feat(config): expose the full ClickHouse connection + HTTP-server config surface as CERBERUS_* knobs

### DIFF
--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -244,6 +244,7 @@ func run() error {
 	lokiHandler.Limiter = lokiLimiter
 	lokiHandler.Version = Version
 	lokiHandler.QueryTimeout = cfg.ClickHouse.QueryTimeout
+	lokiHandler.TailWriteTimeout = cfg.LokiTailWriteTimeout
 	lokiHandler.Mount(traceMux)
 
 	tempoHandler := tempo.New(tempoClient, cfg.Traces, Version, logger.With("api", "tempo"))
@@ -286,7 +287,7 @@ func run() error {
 	tempoGRPCService := tempogrpc.NewService(tempoHandler, tempoLimiter, logger.With("api", "tempo-grpc"))
 	grpcServer := tempogrpc.NewServer(tempoGRPCService)
 
-	srv := buildDualStackServer(cfg.HTTPAddr, rootMux, grpcServer)
+	srv := buildDualStackServer(cfg.HTTPAddr, cfg.HTTPServer, rootMux, grpcServer)
 
 	serverErr := make(chan error, 1)
 	go func() {
@@ -706,7 +707,7 @@ func retrySchemaApply(
 // Cloud Run) the proxy negotiates h2 with the client and forwards
 // h2c upstream — the standard pattern. See
 // docs/operations.md#port-binding.
-func buildDualStackServer(addr string, rootMux, grpcServer http.Handler) *http.Server {
+func buildDualStackServer(addr string, httpCfg config.HTTPServerConfig, rootMux, grpcServer http.Handler) *http.Server {
 	dispatcher := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.ProtoMajor == 2 && strings.HasPrefix(r.Header.Get("Content-Type"), "application/grpc") {
 			grpcServer.ServeHTTP(w, r)
@@ -717,10 +718,19 @@ func buildDualStackServer(addr string, rootMux, grpcServer http.Handler) *http.S
 	protocols := new(http.Protocols)
 	protocols.SetHTTP1(true)
 	protocols.SetUnencryptedHTTP2(true)
+	// All five timeout / size knobs come from CERBERUS_HTTP_* (internal/config).
+	// ReadHeaderTimeout defaults to the promoted 5s; ReadTimeout / WriteTimeout
+	// default to 0 (unlimited) so the Loki /tail WebSocket and long query_range
+	// matrix streams are never severed mid-response; IdleTimeout bounds an idle
+	// keep-alive connection; MaxHeaderBytes 0 leaves Go's 1 MiB default.
 	return &http.Server{
 		Addr:              addr,
 		Handler:           dispatcher,
 		Protocols:         protocols,
-		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       httpCfg.ReadTimeout,
+		ReadHeaderTimeout: httpCfg.ReadHeaderTimeout,
+		WriteTimeout:      httpCfg.WriteTimeout,
+		IdleTimeout:       httpCfg.IdleTimeout,
+		MaxHeaderBytes:    httpCfg.MaxHeaderBytes,
 	}
 }

--- a/cmd/cerberus/server_timeouts_test.go
+++ b/cmd/cerberus/server_timeouts_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/config"
+)
+
+// TestBuildDualStackServer_CarriesConfiguredTimeouts asserts every
+// CERBERUS_HTTP_* timeout / size knob threads onto the http.Server the dual
+// stack builder returns — the wiring that makes the timeouts more than dead
+// config.
+func TestBuildDualStackServer_CarriesConfiguredTimeouts(t *testing.T) {
+	t.Parallel()
+	hs := config.HTTPServerConfig{
+		ReadTimeout:       30 * time.Second,
+		ReadHeaderTimeout: 3 * time.Second,
+		WriteTimeout:      45 * time.Second,
+		IdleTimeout:       60 * time.Second,
+		MaxHeaderBytes:    1 << 20,
+	}
+	mux := http.NewServeMux()
+	srv := buildDualStackServer(":0", hs, mux, http.NewServeMux())
+
+	if srv.ReadTimeout != hs.ReadTimeout {
+		t.Errorf("ReadTimeout = %v; want %v", srv.ReadTimeout, hs.ReadTimeout)
+	}
+	if srv.ReadHeaderTimeout != hs.ReadHeaderTimeout {
+		t.Errorf("ReadHeaderTimeout = %v; want %v", srv.ReadHeaderTimeout, hs.ReadHeaderTimeout)
+	}
+	if srv.WriteTimeout != hs.WriteTimeout {
+		t.Errorf("WriteTimeout = %v; want %v", srv.WriteTimeout, hs.WriteTimeout)
+	}
+	if srv.IdleTimeout != hs.IdleTimeout {
+		t.Errorf("IdleTimeout = %v; want %v", srv.IdleTimeout, hs.IdleTimeout)
+	}
+	if srv.MaxHeaderBytes != hs.MaxHeaderBytes {
+		t.Errorf("MaxHeaderBytes = %d; want %d", srv.MaxHeaderBytes, hs.MaxHeaderBytes)
+	}
+}
+
+// TestBuildDualStackServer_StreamingSafeDefaults pins that the streaming-safe
+// zero defaults (read/write unlimited) survive the builder unchanged.
+func TestBuildDualStackServer_StreamingSafeDefaults(t *testing.T) {
+	t.Parallel()
+	hs := config.HTTPServerConfig{ReadHeaderTimeout: 5 * time.Second, IdleTimeout: 120 * time.Second}
+	srv := buildDualStackServer(":0", hs, http.NewServeMux(), http.NewServeMux())
+	if srv.ReadTimeout != 0 || srv.WriteTimeout != 0 {
+		t.Fatalf("read/write timeouts = (%v,%v); want both 0 (streaming-safe)", srv.ReadTimeout, srv.WriteTimeout)
+	}
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,26 +67,85 @@ defaults.
 
 ## HTTP server
 
-| Variable             | Type   | Default | Description                                                                                 |
-| -------------------- | ------ | ------- | ------------------------------------------------------------------------------------------- |
-| `CERBERUS_HTTP_ADDR` | string | `:8080` | HTTP listen address for the Prom / Loki / Tempo APIs and the `/healthz` / `/readyz` probes. |
-
 A single listener serves all three upstream APIs plus the health probes; there
 is no separate admin port. See [`operations.md`](operations.md#port-binding)
 for the port-binding contract (including h2c + gRPC on the same socket).
 
+The timeout knobs map 1:1 to `http.Server` fields. `ReadTimeout` and
+`WriteTimeout` default to `0` (unlimited) deliberately: the Loki `/tail`
+WebSocket and long `query_range` matrix responses stream for an unbounded
+duration and a non-zero server-side write deadline would sever them
+mid-response. `ReadHeaderTimeout` (the promoted 5s) still bounds slow-header
+attacks; `IdleTimeout` reclaims idle keep-alive connections.
+
+| Variable                            | Type     | Default | Description                                                                                             |
+| ----------------------------------- | -------- | ------- | ------------------------------------------------------------------------------------------------------- |
+| `CERBERUS_HTTP_ADDR`                | string   | `:8080` | HTTP listen address for the Prom / Loki / Tempo APIs and the `/healthz` / `/readyz` probes.             |
+| `CERBERUS_HTTP_READ_TIMEOUT`        | duration | `0s`    | Whole-request read deadline (headers + body). `0` = unlimited (streaming-safe).                         |
+| `CERBERUS_HTTP_READ_HEADER_TIMEOUT` | duration | `5s`    | Request-header read deadline. Must be `<=` `CERBERUS_HTTP_READ_TIMEOUT` when that is `> 0`.             |
+| `CERBERUS_HTTP_WRITE_TIMEOUT`       | duration | `0s`    | Response write deadline. `0` = unlimited — required so `/tail` + long matrices stream uninterrupted.    |
+| `CERBERUS_HTTP_IDLE_TIMEOUT`        | duration | `120s`  | Idle keep-alive connection lifetime.                                                                    |
+| `CERBERUS_HTTP_MAX_HEADER_BYTES`    | int      | `0`     | Max request header size. `0` leaves Go's 1 MiB default.                                                 |
+
 ## ClickHouse connection
 
 ClickHouse is the only mandatory backing service, reached exclusively through
-these connection inputs.
+these connection inputs. `CERBERUS_CH_ADDR` accepts a comma-separated list of
+hosts for a replicated / sharded cluster; with more than one host the driver
+selects per `CERBERUS_CH_CONN_OPEN_STRATEGY`. The protocol defaults to the
+native binary protocol (port 9000); set `CERBERUS_CH_PROTOCOL=http` for the
+HTTP protocol (port 8123) when only 8123 is reachable. Every knob below is
+unset-by-default to the exact connection cerberus has always opened — setting
+none of them is byte-identical to the pre-knob behaviour.
 
-| Variable                   | Type     | Default          | Description                                            |
-| -------------------------- | -------- | ---------------- | ------------------------------------------------------ |
-| `CERBERUS_CH_ADDR`         | string   | `localhost:9000` | ClickHouse native-protocol endpoint.                   |
-| `CERBERUS_CH_DATABASE`     | string   | `otel`           | ClickHouse database name.                              |
-| `CERBERUS_CH_USERNAME`     | string   | `default`        | ClickHouse user.                                       |
-| `CERBERUS_CH_PASSWORD`     | string   | (empty)          | ClickHouse password.                                   |
-| `CERBERUS_CH_DIAL_TIMEOUT` | duration | `5s`             | ClickHouse dial timeout (`time.ParseDuration` syntax). |
+| Variable                               | Type     | Default          | Description                                                                                                                                                  |
+| -------------------------------------- | -------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `CERBERUS_CH_ADDR`                     | string   | `localhost:9000` | ClickHouse endpoint(s). Comma-separated for multiple hosts (each trimmed; at least one required).                                                            |
+| `CERBERUS_CH_DATABASE`                 | string   | `otel`           | ClickHouse database name.                                                                                                                                    |
+| `CERBERUS_CH_USERNAME`                 | string   | `default`        | ClickHouse user.                                                                                                                                             |
+| `CERBERUS_CH_PASSWORD`                 | string   | (empty)          | ClickHouse password.                                                                                                                                         |
+| `CERBERUS_CH_DIAL_TIMEOUT`             | duration | `5s`             | ClickHouse dial timeout (`time.ParseDuration` syntax).                                                                                                       |
+| `CERBERUS_CH_PROTOCOL`                 | enum     | `native`         | Wire protocol: `native` (port 9000) or `http` (port 8123). The HTTP-only knobs below require `http`.                                                         |
+| `CERBERUS_CH_CONN_OPEN_STRATEGY`       | enum     | `in_order`       | Multi-host selection: `in_order` (try hosts in order) or `round_robin` (rotate). Pointless but benign with a single host.                                    |
+| `CERBERUS_CH_READ_TIMEOUT`             | duration | (derived)        | Socket read ceiling. Unset → derived from `CERBERUS_QUERY_TIMEOUT`. When set must be `>=` `CERBERUS_QUERY_TIMEOUT`. clickhouse-go has no write-timeout knob. |
+| `CERBERUS_CH_COMPRESSION`              | enum     | `none`           | Wire compression: `none`, `lz4`, or `zstd`.                                                                                                                  |
+| `CERBERUS_CH_COMPRESSION_LEVEL`        | int      | `0`              | Compression level. `0` = method default. Requires a method. lz4: `0..12`; zstd: `1..22`.                                                                     |
+| `CERBERUS_CH_BLOCK_BUFFER_SIZE`        | int      | `0`              | Per-connection block buffer count (`0` → driver default 2; valid `1..255`).                                                                                  |
+| `CERBERUS_CH_MAX_COMPRESSION_BUFFER`   | int      | `0`              | Compression buffer cap in bytes (`0` → driver default 10 MiB; otherwise `> 0`).                                                                              |
+| `CERBERUS_CH_FREE_BUF_ON_CONN_RELEASE` | bool     | `false`          | Drop the preserved memory buffer after each query (lower steady-state memory, less buffer reuse).                                                            |
+| `CERBERUS_CH_DEBUG`                    | bool     | `false`          | clickhouse-go legacy stdout debug logging. Noisy; local diagnosis only.                                                                                      |
+
+### TLS / mTLS
+
+Set `CERBERUS_CH_TLS_ENABLED=true` to dial ClickHouse over TLS. The TLS
+sub-knobs are inert (and **rejected at startup**) unless TLS is enabled — a
+silently-ignored TLS config is a security footgun. For mutual TLS supply both
+`_TLS_CERT_FILE` and `_TLS_KEY_FILE` (a lone one is rejected). `_TLS_CA_FILE`
+pins a custom CA bundle; `_TLS_SERVER_NAME` overrides the verified hostname
+(SNI). `_TLS_INSECURE_SKIP_VERIFY=true` disables certificate verification
+entirely and is **rejected in combination with** `_TLS_CA_FILE` or
+`_TLS_SERVER_NAME` (skip-verify ignores both — the combo is incoherent).
+
+| Variable                               | Type   | Default | Description                                                              |
+| -------------------------------------- | ------ | ------- | ------------------------------------------------------------------------ |
+| `CERBERUS_CH_TLS_ENABLED`              | bool   | `false` | Dial ClickHouse over TLS. Required for any other TLS sub-knob.           |
+| `CERBERUS_CH_TLS_CA_FILE`              | string | (empty) | PEM CA bundle path. A set-but-unreadable path fails fast.                |
+| `CERBERUS_CH_TLS_CERT_FILE`            | string | (empty) | Client certificate (mTLS). Must be set together with the key file.       |
+| `CERBERUS_CH_TLS_KEY_FILE`             | string | (empty) | Client private key (mTLS). Must be set together with the cert file.      |
+| `CERBERUS_CH_TLS_SERVER_NAME`          | string | (empty) | Verified server hostname / SNI override.                                 |
+| `CERBERUS_CH_TLS_INSECURE_SKIP_VERIFY` | bool   | `false` | Skip certificate verification. Incompatible with CA / server-name knobs. |
+
+### HTTP-protocol knobs
+
+Consulted only under `CERBERUS_CH_PROTOCOL=http`; setting any of them under
+`native` is **rejected at startup** (they would be silently ignored).
+
+| Variable                              | Type   | Default | Description                                                       |
+| ------------------------------------- | ------ | ------- | ----------------------------------------------------------------- |
+| `CERBERUS_CH_HTTP_HEADERS`            | string | (empty) | Extra HTTP request headers, `k=v,k2=v2` (e.g. multi-tenant IDs).  |
+| `CERBERUS_CH_HTTP_URL_PATH`           | string | (empty) | Extra URL path prefix for HTTP requests.                          |
+| `CERBERUS_CH_HTTP_MAX_CONNS_PER_HOST` | int    | `0`     | `http.Transport` per-host connection cap (`0` → driver default).  |
+| `CERBERUS_CH_HTTP_PROXY_URL`          | string | (empty) | HTTP proxy URL (absolute, with scheme + host).                    |
 
 ## Connection pool
 
@@ -285,3 +344,39 @@ Prometheus `extrapolatedRate` inside the engine, closing the execution-layer gap
 the SQL array machinery leaves at high cardinality. Default off is byte-for-byte
 the established fan-out. See [`performance.md`](performance.md#the-durable-answer)
 for the why and [`benchmarks.md`](benchmarks.md) for the recorded numbers.
+
+## Loki streaming
+
+| Variable                           | Type     | Default | Description                                                                                            |
+| ---------------------------------- | -------- | ------- | ------------------------------------------------------------------------------------------------------ |
+| `CERBERUS_LOKI_TAIL_WRITE_TIMEOUT` | duration | `10s`   | Bound on a single `/loki/api/v1/tail` WebSocket write before a slow / dead client is torn down. `> 0`. |
+
+## Dependency matrix
+
+Most knobs are validated in isolation (unknown enum, out-of-range buffer,
+malformed URL, non-positive where positive is required). Some knobs, however,
+only make sense in combination — an individually-valid value can be incoherent
+next to another. Cerberus rejects these **combinations** at startup with an
+error that names both knobs, rather than silently ignoring or downgrading one
+of them. The full set of cross-setting rules:
+
+| Rule                                                | Knobs involved                                                                                                           | Why it fails fast                                                                                                                                                                                          |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| TLS cert/key are both-or-neither                    | `_TLS_CERT_FILE`, `_TLS_KEY_FILE`                                                                                        | A lone cert or key cannot form an mTLS client key pair.                                                                                                                                                    |
+| TLS sub-knobs require enable                        | `_TLS_ENABLED` vs `_TLS_CA_FILE` / `_TLS_CERT_FILE` / `_TLS_KEY_FILE` / `_TLS_SERVER_NAME` / `_TLS_INSECURE_SKIP_VERIFY` | Silently-ignored TLS config is a security footgun.                                                                                                                                                         |
+| skip-verify contradicts CA / server-name            | `_TLS_INSECURE_SKIP_VERIFY` vs `_TLS_CA_FILE` / `_TLS_SERVER_NAME`                                                       | skip-verify ignores both — pinning a CA or hostname alongside it is incoherent.                                                                                                                            |
+| HTTP-protocol knobs require `http`                  | `CERBERUS_CH_PROTOCOL` vs `_HTTP_HEADERS` / `_HTTP_URL_PATH` / `_HTTP_MAX_CONNS_PER_HOST` / `_HTTP_PROXY_URL`            | Under `native` they would be silently dropped.                                                                                                                                                             |
+| Compression level requires a method                 | `CERBERUS_CH_COMPRESSION` vs `CERBERUS_CH_COMPRESSION_LEVEL`                                                             | A level with `none` does nothing; a level must also sit in the method's range (lz4 `0..12`, zstd `1..22`).                                                                                                 |
+| Read timeout ≥ query timeout                        | `CERBERUS_CH_READ_TIMEOUT` vs `CERBERUS_QUERY_TIMEOUT`                                                                   | A socket read shorter than the query budget would kill legitimate long queries.                                                                                                                            |
+| Idle conns ≤ open conns                             | `CERBERUS_CH_MAX_IDLE_CONNS` vs `CERBERUS_CH_MAX_OPEN_CONNS`                                                             | More idle than total pooled connections is a degenerate pool. Fires only when idle is **explicitly set** — lowering only `MAX_OPEN_CONNS` below the default idle is fine (the driver clamps idle to open). |
+| Server header timeout ≤ read timeout                | `CERBERUS_HTTP_READ_HEADER_TIMEOUT` vs `CERBERUS_HTTP_READ_TIMEOUT`                                                      | A header deadline longer than the whole-request deadline can never fire.                                                                                                                                   |
+
+Benign-but-pointless combinations are **not** hard errors — they are noted here
+rather than rejected:
+
+- `CERBERUS_CH_CONN_OPEN_STRATEGY=round_robin` with a single `CERBERUS_CH_ADDR`
+  host: the strategy has nothing to rotate over, but it is harmless.
+- Keepalive timing sub-knobs (`CERBERUS_CH_KEEPALIVE_IDLE` / `_INTERVAL` /
+  `_COUNT`) while `CERBERUS_CH_KEEPALIVE_ENABLED=false`: inert (the kernel never
+  arms a probe schedule), so a degenerate value is accepted, not rejected, when
+  keepalive is disabled.

--- a/internal/api/loki/handler.go
+++ b/internal/api/loki/handler.go
@@ -89,6 +89,13 @@ type Handler struct {
 	// Config.ClickHouse.QueryTimeout in cmd/cerberus; 0 applies no
 	// per-request override (the Client default still caps every query).
 	QueryTimeout time.Duration
+
+	// TailWriteTimeout bounds a single /tail WebSocket write before a slow /
+	// dead client is torn down. Wired from CERBERUS_LOKI_TAIL_WRITE_TIMEOUT
+	// (Config.LokiTailWriteTimeout) in cmd/cerberus. Zero falls back to the
+	// package default (defaultTailWriteTimeout) so tests that build a bare
+	// Handler keep the historical 10s bound.
+	TailWriteTimeout time.Duration
 }
 
 // New constructs a Handler with the seed optimizer wired in.

--- a/internal/api/loki/tail.go
+++ b/internal/api/loki/tail.go
@@ -31,11 +31,22 @@ const (
 	// new rows. Upstream Loki streams chunks every ~1s; we match that.
 	tailPollInterval = 1 * time.Second
 
-	// tailWriteTimeout caps how long a single WebSocket write may block
-	// before we tear the connection down. Catches slow / dead clients
-	// without leaking the polling goroutine.
-	tailWriteTimeout = 10 * time.Second
+	// defaultTailWriteTimeout caps how long a single WebSocket write may
+	// block before we tear the connection down. Catches slow / dead clients
+	// without leaking the polling goroutine. Operators override it via
+	// CERBERUS_LOKI_TAIL_WRITE_TIMEOUT (Handler.TailWriteTimeout); this is
+	// the fallback when the handler field is zero (bare-Handler tests).
+	defaultTailWriteTimeout = 10 * time.Second
 )
+
+// tailWriteTimeout resolves the effective per-write deadline: the handler's
+// configured TailWriteTimeout when positive, else the package default.
+func (h *Handler) tailWriteTimeout() time.Duration {
+	if h.TailWriteTimeout > 0 {
+		return h.TailWriteTimeout
+	}
+	return defaultTailWriteTimeout
+}
 
 // tailUpgrader is the default gorilla/websocket upgrader. It permits
 // every origin since /tail is consumed by the Loki datasource (Grafana
@@ -260,7 +271,7 @@ func (h *Handler) runTailLoop(ctx context.Context, conn *websocket.Conn, cfg tai
 			continue
 		}
 
-		if err := writeTailChunk(conn, streams); err != nil {
+		if err := writeTailChunk(conn, streams, h.tailWriteTimeout()); err != nil {
 			// Write failure usually means client disconnected; bail
 			// cleanly so the deferred Close runs.
 			h.Logger.Debug("cerberus loki tail write failed", "err", err)
@@ -272,12 +283,12 @@ func (h *Handler) runTailLoop(ctx context.Context, conn *websocket.Conn, cfg tai
 // writeTailChunk encodes streams + an empty dropped_entries slice and
 // writes the JSON frame with a bounded write deadline. Caller is
 // responsible for tearing the connection down on error.
-func writeTailChunk(conn *websocket.Conn, streams []Stream) error {
+func writeTailChunk(conn *websocket.Conn, streams []Stream, writeTimeout time.Duration) error {
 	// SetWriteDeadline only fails if the underlying connection has
 	// already been torn down — in which case the WriteJSON below will
 	// surface the real failure to the caller. Discarding this error is
 	// intentional, not silenced.
-	_ = conn.SetWriteDeadline(time.Now().Add(tailWriteTimeout))
+	_ = conn.SetWriteDeadline(time.Now().Add(writeTimeout))
 	return conn.WriteJSON(tailResponse{
 		Streams:        streams,
 		DroppedEntries: []droppedEntryStream{},

--- a/internal/api/loki/tail_write_timeout_test.go
+++ b/internal/api/loki/tail_write_timeout_test.go
@@ -1,0 +1,25 @@
+package loki
+
+import (
+	"testing"
+	"time"
+)
+
+// TestHandler_TailWriteTimeout confirms the /tail per-write deadline resolves
+// from the configured Handler.TailWriteTimeout, falling back to the package
+// default when the field is zero (the bare-Handler convention tests rely on).
+func TestHandler_TailWriteTimeout(t *testing.T) {
+	t.Parallel()
+	t.Run("default_when_unset", func(t *testing.T) {
+		h := &Handler{}
+		if got := h.tailWriteTimeout(); got != defaultTailWriteTimeout {
+			t.Errorf("tailWriteTimeout() = %v; want default %v", got, defaultTailWriteTimeout)
+		}
+	})
+	t.Run("configured_value_wins", func(t *testing.T) {
+		h := &Handler{TailWriteTimeout: 25 * time.Second}
+		if got := h.tailWriteTimeout(); got != 25*time.Second {
+			t.Errorf("tailWriteTimeout() = %v; want 25s", got)
+		}
+	})
+}

--- a/internal/chclient/client.go
+++ b/internal/chclient/client.go
@@ -4,8 +4,10 @@ package chclient
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net"
+	"net/url"
 	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
@@ -80,10 +82,104 @@ func startExecuteSpan(ctx context.Context, sql, addr string) (context.Context, t
 
 // Config describes a single ClickHouse connection.
 type Config struct {
-	Addr     string // host:port, e.g. "clickhouse:9000"
+	Addr     string // host:port, e.g. "clickhouse:9000"; the canonical endpoint stamped on execute spans
 	Database string
 	Username string
 	Password string
+
+	// Addrs is the full ClickHouse endpoint list when more than one host is
+	// configured (CERBERUS_CH_ADDR accepts a comma-separated list). When
+	// non-empty it is the authoritative Addr slice handed to the driver; the
+	// scalar Addr field is then Addrs[0] and is used only for the execute-span
+	// server.address attribute + startup logging (one logical CH service from
+	// the caller's view — sharding / replication is below the trace's
+	// abstraction). When empty the driver dials the single Addr. clickhouse-go
+	// applies ConnOpenStrategy across the slice (see ConnOpenStrategy below).
+	Addrs []string
+
+	// Protocol selects the ClickHouse wire protocol: clickhouse.Native (the
+	// default, host:port 9000) or clickhouse.HTTP (8123). The native protocol
+	// is the cerberus default and the only one the chaos / e2e lanes exercise;
+	// HTTP is offered for environments that can only egress 8123 (some managed
+	// CH offerings, restrictive proxies). The HTTP-only knobs (HTTPHeaders,
+	// HTTPURLPath, HTTPMaxConnsPerHost, HTTPProxyURL) are inert under Native —
+	// internal/config rejects setting them with Protocol=native so a
+	// silently-ignored value can never ship.
+	Protocol clickhouse.Protocol
+
+	// ConnOpenStrategy controls how the driver picks a host from Addrs:
+	// clickhouse.ConnOpenInOrder (the default — try hosts in listed order,
+	// falling through to the next on failure) or clickhouse.ConnOpenRoundRobin
+	// (rotate per connection). It is meaningful only with a multi-host Addrs; a
+	// round-robin strategy with a single address is benign but pointless
+	// (internal/config notes it, not rejects it).
+	ConnOpenStrategy clickhouse.ConnOpenStrategy
+
+	// TLS, when non-nil, makes the driver dial ClickHouse over TLS. cerberus
+	// builds it (crypto/tls + crypto/x509) only when CERBERUS_CH_TLS_ENABLED is
+	// true, populating the CA pool / client cert (mTLS) / ServerName /
+	// InsecureSkipVerify from the CERBERUS_CH_TLS_* knobs. A nil TLS (the
+	// default) dials plaintext, byte-unchanged from before this knob existed.
+	TLS *tls.Config
+
+	// ReadTimeout caps how long a single socket read may block waiting for data
+	// from ClickHouse. When zero, buildOptions DERIVES it from QueryTimeout (the
+	// per-query wall-clock budget) so a stale half-open socket to a force-killed
+	// pod cannot block past the query budget — the deterministic restart-recovery
+	// ceiling. A positive ReadTimeout overrides that derivation verbatim (the
+	// first-class CERBERUS_CH_READ_TIMEOUT knob); internal/config enforces
+	// ReadTimeout >= QueryTimeout so a socket read shorter than the query budget
+	// can never kill a legitimate long query. clickhouse-go has NO native
+	// write-timeout knob, so there is no symmetric WriteTimeout field.
+	ReadTimeout time.Duration
+
+	// Compression configures wire compression for the CH connection. nil (the
+	// default) sends data uncompressed, byte-unchanged from before this knob.
+	// cerberus builds it from CERBERUS_CH_COMPRESSION (none|lz4|zstd) +
+	// CERBERUS_CH_COMPRESSION_LEVEL. Under the native protocol the driver honours
+	// the level only for the lz4hc path; the level is still validated against the
+	// method's documented range so a typo fails fast.
+	Compression *clickhouse.Compression
+
+	// BlockBufferSize is the driver's per-connection block buffer count
+	// (clickhouse.Options.BlockBufferSize, default 2). Valid range 1..255 (uint8).
+	// 0 leaves the driver default. Raising it can improve throughput on wide
+	// result sets at the cost of memory.
+	BlockBufferSize uint8
+
+	// MaxCompressionBuffer caps the driver's compression buffer in bytes
+	// (clickhouse.Options.MaxCompressionBuffer, default 10485760 = 10 MiB). 0
+	// leaves the driver default; a positive value must be > 0.
+	MaxCompressionBuffer int
+
+	// FreeBufOnConnRelease, when true, makes the driver drop its preserved
+	// memory buffer after each query (clickhouse.Options.FreeBufOnConnRelease) —
+	// trades buffer-reuse throughput for a lower steady-state memory footprint.
+	// Default false (driver default).
+	FreeBufOnConnRelease bool
+
+	// Debug enables clickhouse-go's legacy stdout debug logging
+	// (clickhouse.Options.Debug). Default false. Noisy; for local diagnosis only.
+	Debug bool
+
+	// HTTPHeaders are extra headers attached to every HTTP-protocol request
+	// (clickhouse.Options.HttpHeaders). Only consulted under Protocol=HTTP;
+	// internal/config rejects setting them under Native.
+	HTTPHeaders map[string]string
+
+	// HTTPURLPath is an extra URL path prefix for HTTP-protocol requests
+	// (clickhouse.Options.HttpUrlPath). HTTP-only (see HTTPHeaders).
+	HTTPURLPath string
+
+	// HTTPMaxConnsPerHost bounds the underlying http.Transport's per-host
+	// connection count (clickhouse.Options.HttpMaxConnsPerHost). 0 leaves the
+	// driver default. HTTP-only (see HTTPHeaders).
+	HTTPMaxConnsPerHost int
+
+	// HTTPProxyURL routes HTTP-protocol requests through an HTTP proxy
+	// (clickhouse.Options.HTTPProxyURL). nil dials directly. HTTP-only
+	// (see HTTPHeaders).
+	HTTPProxyURL *url.URL
 
 	// DialTimeout caps the initial connection dial. Zero falls back to 5s.
 	DialTimeout time.Duration
@@ -421,14 +517,22 @@ func buildOptions(cfg Config) *clickhouse.Options {
 	if dial == 0 {
 		dial = 5 * time.Second
 	}
+	// Addrs (multi-host) is authoritative when present; otherwise dial the
+	// single scalar Addr — byte-unchanged from before the multi-host knob.
+	addrs := cfg.Addrs
+	if len(addrs) == 0 {
+		addrs = []string{cfg.Addr}
+	}
 	opts := &clickhouse.Options{
-		Addr: []string{cfg.Addr},
+		Addr: addrs,
 		Auth: clickhouse.Auth{
 			Database: cfg.Database,
 			Username: cfg.Username,
 			Password: cfg.Password,
 		},
-		DialTimeout: dial,
+		Protocol:         cfg.Protocol,
+		ConnOpenStrategy: cfg.ConnOpenStrategy,
+		DialTimeout:      dial,
 		// DialContext routes every CH connection through a net.Dialer so we
 		// can put TCP keepalive on the socket — the root-cause fix for slow
 		// breaker recovery after a CH restart (see Config.KeepAliveEnabled).
@@ -437,6 +541,46 @@ func buildOptions(cfg Config) *clickhouse.Options {
 		// dial through the same net.Dialer (Enable:false) so DialContext
 		// behaviour is uniform — only the keepalive policy changes.
 		DialContext: dialContext(dial, cfg),
+	}
+	// TLS / compression / buffer / HTTP knobs are left at the driver's
+	// zero-value default unless an operator set them — every unset knob keeps
+	// cerberus byte-identical to its pre-knob behaviour. internal/config does
+	// the cross-setting validation (TLS-enabled iff sub-knobs set, HTTP knobs
+	// require Protocol=HTTP, etc.) so by the time a Config reaches buildOptions
+	// the fields are already coherent.
+	if cfg.TLS != nil {
+		opts.TLS = cfg.TLS
+	}
+	if cfg.Compression != nil {
+		opts.Compression = cfg.Compression
+	}
+	if cfg.BlockBufferSize > 0 {
+		opts.BlockBufferSize = cfg.BlockBufferSize
+	}
+	if cfg.MaxCompressionBuffer > 0 {
+		opts.MaxCompressionBuffer = cfg.MaxCompressionBuffer
+	}
+	if cfg.FreeBufOnConnRelease {
+		opts.FreeBufOnConnRelease = true
+	}
+	if cfg.Debug {
+		// opts.Debug is the documented CERBERUS_CH_DEBUG surface — the legacy
+		// stdout debug toggle is the only zero-dep knob clickhouse-go exposes
+		// without wiring a custom slog.Logger, which cerberus deliberately does
+		// not (Logger is on the non-exposable list).
+		opts.Debug = true //nolint:staticcheck // SA1019: legacy Debug is the exposed CERBERUS_CH_DEBUG knob
+	}
+	if len(cfg.HTTPHeaders) > 0 {
+		opts.HttpHeaders = cfg.HTTPHeaders
+	}
+	if cfg.HTTPURLPath != "" {
+		opts.HttpUrlPath = cfg.HTTPURLPath
+	}
+	if cfg.HTTPMaxConnsPerHost > 0 {
+		opts.HttpMaxConnsPerHost = cfg.HTTPMaxConnsPerHost
+	}
+	if cfg.HTTPProxyURL != nil {
+		opts.HTTPProxyURL = cfg.HTTPProxyURL
 	}
 	// Pool sizing is explicit and configurable (#81). A zero field is
 	// left unset so clickhouse-go's own default applies — that keeps the
@@ -476,7 +620,16 @@ func buildOptions(cfg Config) *clickhouse.Options {
 	//
 	// Zero is left unset (driver default applies) so a bare Config — notably
 	// the ones tests build — keeps the driver's out-of-the-box behaviour.
-	if cfg.QueryTimeout > 0 {
+	//
+	// An explicit Config.ReadTimeout (CERBERUS_CH_READ_TIMEOUT) is first-class
+	// and OVERRIDES the QueryTimeout derivation verbatim: an operator who wants
+	// a socket-read ceiling decoupled from the query budget sets it directly.
+	// internal/config guarantees ReadTimeout >= QueryTimeout, so the explicit
+	// value can never be shorter than a legitimate query's first-block wait.
+	switch {
+	case cfg.ReadTimeout > 0:
+		opts.ReadTimeout = cfg.ReadTimeout
+	case cfg.QueryTimeout > 0:
 		opts.ReadTimeout = cfg.QueryTimeout
 	}
 	return opts

--- a/internal/chclient/connection_options_test.go
+++ b/internal/chclient/connection_options_test.go
@@ -1,0 +1,144 @@
+package chclient
+
+import (
+	"crypto/tls"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+)
+
+// TestBuildOptions_MultiHost confirms a multi-element Addrs is the
+// authoritative Addr slice handed to the driver, and a single scalar Addr is
+// used when Addrs is empty.
+func TestBuildOptions_MultiHost(t *testing.T) {
+	t.Parallel()
+	t.Run("multi", func(t *testing.T) {
+		opts := buildOptions(Config{Addr: "a:9000", Addrs: []string{"a:9000", "b:9000", "c:9000"}})
+		if len(opts.Addr) != 3 {
+			t.Fatalf("Addr = %v; want 3 hosts", opts.Addr)
+		}
+	})
+	t.Run("single", func(t *testing.T) {
+		opts := buildOptions(Config{Addr: "a:9000"})
+		if len(opts.Addr) != 1 || opts.Addr[0] != "a:9000" {
+			t.Fatalf("Addr = %v; want [a:9000]", opts.Addr)
+		}
+	})
+}
+
+// TestBuildOptions_ProtocolStrategyCompression maps the enum + compression
+// fields onto the driver options.
+func TestBuildOptions_ProtocolStrategyCompression(t *testing.T) {
+	t.Parallel()
+	compr := &clickhouse.Compression{Method: clickhouse.CompressionZSTD, Level: 5}
+	opts := buildOptions(Config{
+		Addr:             "a:9000",
+		Protocol:         clickhouse.HTTP,
+		ConnOpenStrategy: clickhouse.ConnOpenRoundRobin,
+		Compression:      compr,
+	})
+	if opts.Protocol != clickhouse.HTTP {
+		t.Errorf("Protocol = %v; want HTTP", opts.Protocol)
+	}
+	if opts.ConnOpenStrategy != clickhouse.ConnOpenRoundRobin {
+		t.Errorf("ConnOpenStrategy = %v; want RoundRobin", opts.ConnOpenStrategy)
+	}
+	if opts.Compression != compr {
+		t.Errorf("Compression = %v; want the configured pointer", opts.Compression)
+	}
+}
+
+// TestBuildOptions_TLSSetIffEnabled confirms a non-nil Config.TLS is wired and
+// a nil one leaves opts.TLS nil (plaintext) — the "TLS set iff enabled" rule.
+func TestBuildOptions_TLSSetIffEnabled(t *testing.T) {
+	t.Parallel()
+	t.Run("enabled", func(t *testing.T) {
+		tlsCfg := &tls.Config{ServerName: "ch.internal", MinVersion: tls.VersionTLS12}
+		opts := buildOptions(Config{Addr: "a:9000", TLS: tlsCfg})
+		if opts.TLS != tlsCfg {
+			t.Fatalf("TLS = %v; want the configured pointer", opts.TLS)
+		}
+	})
+	t.Run("disabled", func(t *testing.T) {
+		opts := buildOptions(Config{Addr: "a:9000"})
+		if opts.TLS != nil {
+			t.Fatalf("TLS = %v; want nil (plaintext)", opts.TLS)
+		}
+	})
+}
+
+// TestBuildOptions_Buffers maps the buffer + free-buf + debug knobs.
+func TestBuildOptions_Buffers(t *testing.T) {
+	t.Parallel()
+	opts := buildOptions(Config{
+		Addr:                 "a:9000",
+		BlockBufferSize:      8,
+		MaxCompressionBuffer: 20 << 20,
+		FreeBufOnConnRelease: true,
+		Debug:                true,
+	})
+	if opts.BlockBufferSize != 8 {
+		t.Errorf("BlockBufferSize = %d; want 8", opts.BlockBufferSize)
+	}
+	if opts.MaxCompressionBuffer != 20<<20 {
+		t.Errorf("MaxCompressionBuffer = %d; want %d", opts.MaxCompressionBuffer, 20<<20)
+	}
+	if !opts.FreeBufOnConnRelease {
+		t.Error("FreeBufOnConnRelease = false; want true")
+	}
+	if !opts.Debug { //nolint:staticcheck // SA1019: asserting the exposed CERBERUS_CH_DEBUG knob
+		t.Error("Debug = false; want true")
+	}
+}
+
+// TestBuildOptions_HTTPKnobs maps the HTTP-protocol-only fields.
+func TestBuildOptions_HTTPKnobs(t *testing.T) {
+	t.Parallel()
+	proxy, _ := url.Parse("http://proxy:3128")
+	opts := buildOptions(Config{
+		Addr:                "a:8123",
+		Protocol:            clickhouse.HTTP,
+		HTTPHeaders:         map[string]string{"X-Scope-OrgID": "t"},
+		HTTPURLPath:         "/query",
+		HTTPMaxConnsPerHost: 16,
+		HTTPProxyURL:        proxy,
+	})
+	if opts.HttpHeaders["X-Scope-OrgID"] != "t" {
+		t.Errorf("HttpHeaders = %v; want X-Scope-OrgID=t", opts.HttpHeaders)
+	}
+	if opts.HttpUrlPath != "/query" {
+		t.Errorf("HttpUrlPath = %q; want /query", opts.HttpUrlPath)
+	}
+	if opts.HttpMaxConnsPerHost != 16 {
+		t.Errorf("HttpMaxConnsPerHost = %d; want 16", opts.HttpMaxConnsPerHost)
+	}
+	if opts.HTTPProxyURL != proxy {
+		t.Errorf("HTTPProxyURL = %v; want the configured pointer", opts.HTTPProxyURL)
+	}
+}
+
+// TestBuildOptions_ReadTimeoutKnobBeatsDerived confirms an explicit
+// Config.ReadTimeout overrides the QueryTimeout-derived ceiling.
+func TestBuildOptions_ReadTimeoutKnobBeatsDerived(t *testing.T) {
+	t.Parallel()
+	opts := buildOptions(Config{
+		Addr:         "a:9000",
+		ReadTimeout:  90 * time.Second,
+		QueryTimeout: 30 * time.Second,
+	})
+	if opts.ReadTimeout != 90*time.Second {
+		t.Fatalf("ReadTimeout = %v; want 90s (explicit knob beats derived 30s)", opts.ReadTimeout)
+	}
+}
+
+// TestBuildOptions_ReadTimeoutDerivedWhenKnobZero confirms a zero
+// Config.ReadTimeout falls back to the QueryTimeout derivation.
+func TestBuildOptions_ReadTimeoutDerivedWhenKnobZero(t *testing.T) {
+	t.Parallel()
+	opts := buildOptions(Config{Addr: "a:9000", QueryTimeout: 30 * time.Second})
+	if opts.ReadTimeout != 30*time.Second {
+		t.Fatalf("ReadTimeout = %v; want 30s (derived from QueryTimeout)", opts.ReadTimeout)
+	}
+}

--- a/internal/config/ch_connection.go
+++ b/internal/config/ch_connection.go
@@ -1,0 +1,611 @@
+package config
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/spf13/viper"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+)
+
+// chExtra is the parsed result of the "full surface" ClickHouse connection
+// knobs (protocol, multi-host, TLS, compression, buffers, HTTP-only). It is an
+// internal carrier between chExtraFromEnv and FromEnv; the fields land flat on
+// chclient.Config, which is the one place the driver options are assembled.
+type chExtra struct {
+	Addrs                []string
+	Protocol             clickhouse.Protocol
+	ConnOpenStrategy     clickhouse.ConnOpenStrategy
+	ReadTimeout          time.Duration
+	TLS                  *tls.Config
+	Compression          *clickhouse.Compression
+	BlockBufferSize      uint8
+	MaxCompressionBuffer int
+	FreeBufOnConnRelease bool
+	Debug                bool
+	HTTPHeaders          map[string]string
+	HTTPURLPath          string
+	HTTPMaxConnsPerHost  int
+	HTTPProxyURL         *url.URL
+
+	// protocolHTTP records whether Protocol resolved to HTTP, so the
+	// cross-setting checks in FromEnv can reject HTTP-only knobs under native
+	// without re-deriving the enum.
+	protocolHTTP bool
+
+	// raw* fields preserve the operator's literal input for the cross-setting
+	// dependency checks that run in FromEnv (where every parsed value, including
+	// the query timeout, is visible). Validation that needs only a single knob
+	// happens here; validation that spans knobs from different groups defers to
+	// chValidateDependencies.
+	rawTLSEnabled      bool
+	rawTLSCAFile       string
+	rawTLSCertFile     string
+	rawTLSKeyFile      string
+	rawTLSServerName   string
+	rawTLSSkipVerify   bool
+	rawCompression     string
+	rawCompressionLvl  int
+	rawCompressionLvlS string
+	rawHTTPHeaders     string
+	rawHTTPURLPath     string
+	rawHTTPMaxConns    int
+	rawHTTPProxyURL    string
+	rawConnStrategy    string
+	singleAddr         bool
+}
+
+// keepAliveInputs groups the four already-parsed TCP-keepalive knobs so they
+// thread through assembleCHConfig as one field, not four.
+type keepAliveInputs struct {
+	enabled  bool
+	idle     time.Duration
+	interval time.Duration
+	probes   int
+}
+
+// chConfigInputs carries every already-parsed, already-validated scalar
+// FromEnv resolved for the ClickHouse client, so assembling the
+// chclient.Config is a single helper call rather than a long inline literal
+// that pushes FromEnv past the statement-count linter.
+type chConfigInputs struct {
+	database        string
+	username        string
+	password        string
+	dial            time.Duration
+	maxOpen         int
+	maxIdle         int
+	connMaxLifetime time.Duration
+	keepAlive       keepAliveInputs
+	maxSamples      int64
+	maxMemory       int64
+	queryTimeout    time.Duration
+	breaker         breakerConfig
+	extra           chExtra
+}
+
+// assembleCHConfig builds the chclient.Config from the parsed scalars and
+// overlays the full-surface connection knobs (applyCHExtra). It is the single
+// place the driver config is assembled; FromEnv hands it the validated inputs.
+func assembleCHConfig(in chConfigInputs) chclient.Config {
+	cc := chclient.Config{
+		Database:            in.database,
+		Username:            in.username,
+		Password:            in.password,
+		DialTimeout:         in.dial,
+		MaxOpenConns:        in.maxOpen,
+		MaxIdleConns:        in.maxIdle,
+		ConnMaxLifetime:     in.connMaxLifetime,
+		KeepAliveEnabled:    in.keepAlive.enabled,
+		KeepAliveIdle:       in.keepAlive.idle,
+		KeepAliveInterval:   in.keepAlive.interval,
+		KeepAliveProbes:     in.keepAlive.probes,
+		MaxQuerySamples:     in.maxSamples,
+		MaxQueryMemoryBytes: in.maxMemory,
+		QueryTimeout:        in.queryTimeout,
+		BreakerThreshold:    in.breaker.Threshold,
+		BreakerWindow:       in.breaker.Window,
+		BreakerOpenInterval: in.breaker.OpenInterval,
+		BreakerDisabled:     in.breaker.Disabled,
+	}
+	applyCHExtra(&cc, in.extra)
+	return cc
+}
+
+// surfaceConfig bundles the parsed full-surface connection knobs, the HTTP
+// server timeouts, and the Loki tail write timeout. It is the single carrier
+// surfaceFromEnv returns so FromEnv threads one value, not four, keeping its
+// branch count (cyclomatic complexity) under the linter ceiling.
+type surfaceConfig struct {
+	ch                   chExtra
+	httpServer           HTTPServerConfig
+	lokiTailWriteTimeout time.Duration
+}
+
+// poolKnobs carries the pool sizing FromEnv parsed plus whether the operator
+// EXPLICITLY set MAX_IDLE_CONNS (viper.IsSet), so the idle<=open dependency
+// rule fires only on operator input and not on a defaulted idle.
+type poolKnobs struct {
+	maxOpen      int
+	maxIdle      int
+	idleExplicit bool
+}
+
+// surfaceFromEnv parses + cross-validates the full-surface ClickHouse
+// connection knobs, the HTTP server timeouts, and the Loki tail write timeout
+// in one place. The query / pool knobs (owned by FromEnv) are threaded in so
+// the cross-setting dependency checks that span groups can run here rather than
+// inflating FromEnv.
+func surfaceFromEnv(v *viper.Viper, queryTimeout time.Duration, pools poolKnobs) (surfaceConfig, error) {
+	ch, err := chExtraFromEnv(v)
+	if err != nil {
+		return surfaceConfig{}, err
+	}
+	if err := chValidateDependencies(ch, queryTimeout, pools); err != nil {
+		return surfaceConfig{}, err
+	}
+	httpServer, err := httpServerFromEnv(v)
+	if err != nil {
+		return surfaceConfig{}, err
+	}
+	lokiTailWriteTimeout, err := getDuration(v, envLokiTailWriteTO)
+	if err != nil {
+		return surfaceConfig{}, err
+	}
+	if lokiTailWriteTimeout <= 0 {
+		return surfaceConfig{}, fmt.Errorf("%s: must be > 0, got %s", envLokiTailWriteTO, lokiTailWriteTimeout)
+	}
+	return surfaceConfig{ch: ch, httpServer: httpServer, lokiTailWriteTimeout: lokiTailWriteTimeout}, nil
+}
+
+// chExtraFromEnv parses every "full surface" ClickHouse connection knob from
+// the viper loader, applying per-field fail-fast validation (unknown enum,
+// out-of-range buffer, malformed URL / header list, missing TLS file). The
+// CROSS-setting dependency checks (TLS sub-knobs require enable, HTTP knobs
+// require http, compression level requires a method, …) run in FromEnv via
+// chValidateDependencies, where the query timeout and pool knobs are also in
+// scope. Every unset knob resolves to a zero value that leaves the driver's
+// pre-knob default in place, so an operator who sets none of these gets the
+// exact connection cerberus has always opened.
+func chExtraFromEnv(v *viper.Viper) (chExtra, error) {
+	var out chExtra
+
+	// Multi-host address list. CERBERUS_CH_ADDR is comma-separated; trim each
+	// entry, drop empties, require at least one. A single host (the common
+	// case) yields a one-element slice and singleAddr=true (used to note the
+	// pointless round_robin-with-one-host combo).
+	addrs, err := parseAddrs(getString(v, envCHAddr))
+	if err != nil {
+		return chExtra{}, fmt.Errorf("%s: %w", envCHAddr, err)
+	}
+	out.Addrs = addrs
+	out.singleAddr = len(addrs) == 1
+
+	// Protocol enum.
+	switch proto := strings.ToLower(getString(v, envCHProtocol)); proto {
+	case chProtocolNative:
+		out.Protocol = clickhouse.Native
+	case chProtocolHTTP:
+		out.Protocol = clickhouse.HTTP
+		out.protocolHTTP = true
+	default:
+		return chExtra{}, fmt.Errorf("%s: invalid value %q (want %q or %q)", envCHProtocol, proto, chProtocolNative, chProtocolHTTP)
+	}
+
+	// Connection-open strategy enum.
+	strategy := strings.ToLower(getString(v, envCHConnOpenStrategy))
+	out.rawConnStrategy = strategy
+	switch strategy {
+	case chConnOpenInOrder:
+		out.ConnOpenStrategy = clickhouse.ConnOpenInOrder
+	case chConnOpenRoundRobin:
+		out.ConnOpenStrategy = clickhouse.ConnOpenRoundRobin
+	default:
+		return chExtra{}, fmt.Errorf("%s: invalid value %q (want %q or %q)", envCHConnOpenStrategy, strategy, chConnOpenInOrder, chConnOpenRoundRobin)
+	}
+
+	// First-class read timeout (empty → derived from QueryTimeout downstream).
+	if raw := getString(v, envCHReadTimeout); raw != "" {
+		rt, err := getDuration(v, envCHReadTimeout)
+		if err != nil {
+			return chExtra{}, err
+		}
+		if rt < 0 {
+			return chExtra{}, fmt.Errorf("%s: must be >= 0, got %s", envCHReadTimeout, rt)
+		}
+		out.ReadTimeout = rt
+	}
+
+	// Compression method + level. The cross-method validation (level requires a
+	// method; level in the method's range) is split: the method enum is checked
+	// here, the level↔method coupling in chValidateDependencies.
+	out.rawCompression = strings.ToLower(getString(v, envCHCompression))
+	out.rawCompressionLvlS = getString(v, envCHCompressionLevel)
+	switch out.rawCompression {
+	case chCompressionNone, chCompressionLZ4, chCompressionZSTD:
+	default:
+		return chExtra{}, fmt.Errorf("%s: invalid value %q (want %q, %q, or %q)", envCHCompression, out.rawCompression, chCompressionNone, chCompressionLZ4, chCompressionZSTD)
+	}
+	lvl, err := getInt(v, envCHCompressionLevel)
+	if err != nil {
+		return chExtra{}, err
+	}
+	out.rawCompressionLvl = lvl
+	out.Compression = buildCompression(out.rawCompression, lvl)
+
+	// Block buffer size (uint8 1..255; 0 = unset/driver default).
+	bbs, err := getInt(v, envCHBlockBufferSize)
+	if err != nil {
+		return chExtra{}, err
+	}
+	if bbs < 0 || bbs > chBlockBufferMax {
+		return chExtra{}, fmt.Errorf("%s: must be in 0..%d, got %d", envCHBlockBufferSize, chBlockBufferMax, bbs)
+	}
+	out.BlockBufferSize = uint8(bbs)
+
+	// Max compression buffer (bytes; 0 = unset/driver default; positive only).
+	mcb, err := getInt(v, envCHMaxComprBuffer)
+	if err != nil {
+		return chExtra{}, err
+	}
+	if mcb < 0 {
+		return chExtra{}, fmt.Errorf("%s: must be >= 0, got %d", envCHMaxComprBuffer, mcb)
+	}
+	out.MaxCompressionBuffer = mcb
+
+	freeBuf, err := getBool(v, envCHFreeBufOnRelease)
+	if err != nil {
+		return chExtra{}, err
+	}
+	out.FreeBufOnConnRelease = freeBuf
+
+	debug, err := getBool(v, envCHDebug)
+	if err != nil {
+		return chExtra{}, err
+	}
+	out.Debug = debug
+
+	// TLS group: parse the raw inputs; the coherence checks (cert/key pairing,
+	// sub-knob requires enable, skip-verify contradicts CA/serverName) run in
+	// chValidateDependencies. The *tls.Config is built here only when enabled.
+	if err := out.parseTLS(v); err != nil {
+		return chExtra{}, err
+	}
+
+	// HTTP-protocol-only knobs. Parse + per-field validate here; the
+	// "requires Protocol=http" coupling is in chValidateDependencies.
+	if err := out.parseHTTP(v); err != nil {
+		return chExtra{}, err
+	}
+
+	return out, nil
+}
+
+// parseAddrs splits a comma-separated CERBERUS_CH_ADDR into a trimmed,
+// empty-dropped slice and requires at least one host.
+func parseAddrs(raw string) ([]string, error) {
+	out := make([]string, 0, 1)
+	for _, part := range strings.Split(raw, ",") {
+		if p := strings.TrimSpace(part); p != "" {
+			out = append(out, p)
+		}
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("at least one host is required")
+	}
+	return out, nil
+}
+
+// buildCompression maps the method enum + level onto the driver's
+// *clickhouse.Compression, or nil for the "none" method (so the connection
+// stays byte-identical to the no-compression default). A level of 0 means
+// "unset" and is left at the driver's per-method default.
+func buildCompression(method string, level int) *clickhouse.Compression {
+	switch method {
+	case chCompressionLZ4:
+		return &clickhouse.Compression{Method: clickhouse.CompressionLZ4, Level: level}
+	case chCompressionZSTD:
+		return &clickhouse.Compression{Method: clickhouse.CompressionZSTD, Level: level}
+	default:
+		return nil
+	}
+}
+
+// parseTLS reads the CERBERUS_CH_TLS_* raw inputs and, when TLS is enabled,
+// builds the *tls.Config (CA pool from CA_FILE, client cert from CERT/KEY for
+// mTLS, ServerName, InsecureSkipVerify). A path that is set but unreadable /
+// unparseable fails fast. The cross-knob coherence (sub-knobs require enable,
+// cert/key both-or-neither, skip-verify vs CA/serverName) is enforced in
+// chValidateDependencies, which runs before this is consulted by the caller.
+func (c *chExtra) parseTLS(v *viper.Viper) error {
+	c.rawTLSCAFile = getString(v, envCHTLSCAFile)
+	c.rawTLSCertFile = getString(v, envCHTLSCertFile)
+	c.rawTLSKeyFile = getString(v, envCHTLSKeyFile)
+	c.rawTLSServerName = getString(v, envCHTLSServerName)
+
+	enabled, err := getBool(v, envCHTLSEnabled)
+	if err != nil {
+		return err
+	}
+	c.rawTLSEnabled = enabled
+
+	skip, err := getBool(v, envCHTLSSkipVerify)
+	if err != nil {
+		return err
+	}
+	c.rawTLSSkipVerify = skip
+
+	if !enabled {
+		// Building the *tls.Config is deferred to chValidateDependencies having
+		// already proven the sub-knobs are coherent (which, when disabled, means
+		// they are all empty). Leave c.TLS nil → plaintext dial.
+		return nil
+	}
+
+	cfg := &tls.Config{
+		MinVersion:         tls.VersionTLS12,
+		ServerName:         c.rawTLSServerName,
+		InsecureSkipVerify: skip, //nolint:gosec // operator-opt-in; rejected in combo with CA/ServerName
+	}
+	if c.rawTLSCAFile != "" {
+		pool, err := loadCAPool(c.rawTLSCAFile)
+		if err != nil {
+			return fmt.Errorf("%s: %w", envCHTLSCAFile, err)
+		}
+		cfg.RootCAs = pool
+	}
+	if c.rawTLSCertFile != "" && c.rawTLSKeyFile != "" {
+		cert, err := tls.LoadX509KeyPair(c.rawTLSCertFile, c.rawTLSKeyFile)
+		if err != nil {
+			return fmt.Errorf("%s / %s: load client key pair: %w", envCHTLSCertFile, envCHTLSKeyFile, err)
+		}
+		cfg.Certificates = []tls.Certificate{cert}
+	}
+	c.TLS = cfg
+	return nil
+}
+
+// loadCAPool reads a PEM CA bundle from path and returns an x509 pool. A
+// missing file or a bundle with no parseable certificate is an error.
+func loadCAPool(path string) (*x509.CertPool, error) {
+	pem, err := os.ReadFile(path) //nolint:gosec // operator-supplied CA path
+	if err != nil {
+		return nil, err
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(pem) {
+		return nil, fmt.Errorf("no PEM certificates found in %s", path)
+	}
+	return pool, nil
+}
+
+// parseHTTP reads the CERBERUS_CH_HTTP_* raw inputs and per-field validates
+// them (header list shape, proxy URL parse, non-negative per-host cap). The
+// "requires Protocol=http" coupling runs in chValidateDependencies.
+func (c *chExtra) parseHTTP(v *viper.Viper) error {
+	c.rawHTTPHeaders = getString(v, envCHHTTPHeaders)
+	c.rawHTTPURLPath = getString(v, envCHHTTPURLPath)
+	c.rawHTTPProxyURL = getString(v, envCHHTTPProxyURL)
+
+	headers, err := parseHeaders(c.rawHTTPHeaders)
+	if err != nil {
+		return fmt.Errorf("%s: %w", envCHHTTPHeaders, err)
+	}
+	c.HTTPHeaders = headers
+	c.HTTPURLPath = c.rawHTTPURLPath
+
+	maxConns, err := getInt(v, envCHHTTPMaxConns)
+	if err != nil {
+		return err
+	}
+	if maxConns < 0 {
+		return fmt.Errorf("%s: must be >= 0, got %d", envCHHTTPMaxConns, maxConns)
+	}
+	c.rawHTTPMaxConns = maxConns
+	c.HTTPMaxConnsPerHost = maxConns
+
+	if c.rawHTTPProxyURL != "" {
+		u, err := url.Parse(c.rawHTTPProxyURL)
+		if err != nil {
+			return fmt.Errorf("%s: invalid URL %q: %w", envCHHTTPProxyURL, c.rawHTTPProxyURL, err)
+		}
+		if u.Scheme == "" || u.Host == "" {
+			return fmt.Errorf("%s: invalid URL %q: missing scheme or host", envCHHTTPProxyURL, c.rawHTTPProxyURL)
+		}
+		c.HTTPProxyURL = u
+	}
+	return nil
+}
+
+// chValidateDependencies enforces the cross-setting dependency matrix: rules
+// that span knobs (and the query / pool knobs FromEnv already parsed) so an
+// incoherent COMBINATION of individually-valid values is rejected at startup
+// with an error naming both knobs. queryTimeout / pools are passed in because
+// they are owned by FromEnv, not chExtra.
+func chValidateDependencies(c chExtra, queryTimeout time.Duration, pools poolKnobs) error {
+	tlsSubKnobSet := c.rawTLSCAFile != "" || c.rawTLSCertFile != "" || c.rawTLSKeyFile != "" ||
+		c.rawTLSServerName != "" || c.rawTLSSkipVerify
+
+	// TLS sub-knobs require enable — a silently-ignored TLS config is a
+	// security footgun.
+	if !c.rawTLSEnabled && tlsSubKnobSet {
+		return fmt.Errorf("%s is false but a TLS sub-knob (%s / %s / %s / %s / %s) is set; enable TLS or unset the sub-knob",
+			envCHTLSEnabled, envCHTLSCAFile, envCHTLSCertFile, envCHTLSKeyFile, envCHTLSServerName, envCHTLSSkipVerify)
+	}
+
+	// TLS cert/key must be BOTH set or BOTH empty (a lone one cannot form a
+	// client key pair for mTLS).
+	if (c.rawTLSCertFile == "") != (c.rawTLSKeyFile == "") {
+		return fmt.Errorf("%s and %s must be set together (got one without the other)", envCHTLSCertFile, envCHTLSKeyFile)
+	}
+
+	// skip-verify contradicts CA / serverName: skip-verify makes the driver
+	// ignore both, so the combination is incoherent and dangerous.
+	if c.rawTLSSkipVerify && c.rawTLSCAFile != "" {
+		return fmt.Errorf("%s=true ignores %s; the combination is incoherent — set one, not both", envCHTLSSkipVerify, envCHTLSCAFile)
+	}
+	if c.rawTLSSkipVerify && c.rawTLSServerName != "" {
+		return fmt.Errorf("%s=true ignores %s; the combination is incoherent — set one, not both", envCHTLSSkipVerify, envCHTLSServerName)
+	}
+
+	// HTTP-protocol knobs require Protocol=http — under native they would be
+	// silently ignored.
+	if !c.protocolHTTP {
+		httpSet := []struct {
+			name string
+			set  bool
+		}{
+			{envCHHTTPHeaders, c.rawHTTPHeaders != ""},
+			{envCHHTTPURLPath, c.rawHTTPURLPath != ""},
+			{envCHHTTPMaxConns, c.rawHTTPMaxConns > 0},
+			{envCHHTTPProxyURL, c.rawHTTPProxyURL != ""},
+		}
+		for _, k := range httpSet {
+			if k.set {
+				return fmt.Errorf("%s is set but %s is %q; HTTP-protocol knobs require %s=%s",
+					k.name, envCHProtocol, chProtocolNative, envCHProtocol, chProtocolHTTP)
+			}
+		}
+	}
+
+	// Compression level requires a method, and must sit in the method's range.
+	if err := validateCompressionLevel(c); err != nil {
+		return err
+	}
+
+	// Read timeout >= query timeout (when both > 0): a socket read shorter than
+	// the query budget would kill legitimate long queries.
+	if c.ReadTimeout > 0 && queryTimeout > 0 && c.ReadTimeout < queryTimeout {
+		return fmt.Errorf("%s (%s) must be >= %s (%s); a shorter socket read would kill legitimate long queries",
+			envCHReadTimeout, c.ReadTimeout, envQueryTimeout, queryTimeout)
+	}
+
+	// Idle conns <= open conns. Fires ONLY when the operator EXPLICITLY set
+	// MAX_IDLE_CONNS (idleExplicit) — lowering only MAX_OPEN_CONNS below the
+	// default idle of 5 is a coherent idiom (clickhouse-go clamps idle to open
+	// internally), so a defaulted idle above a lowered open is not rejected.
+	if pools.idleExplicit && pools.maxIdle > 0 && pools.maxOpen > 0 && pools.maxIdle > pools.maxOpen {
+		return fmt.Errorf("%s (%d) must be <= %s (%d)", envCHMaxIdleConns, pools.maxIdle, envCHMaxOpenConns, pools.maxOpen)
+	}
+
+	return nil
+}
+
+// validateCompressionLevel enforces the level↔method coupling: a level set
+// while the method is "none" is rejected (it would do nothing), and a level
+// for lz4 / zstd must sit in that method's documented range.
+func validateCompressionLevel(c chExtra) error {
+	// "level set" means the operator supplied a non-empty, non-zero value.
+	// 0 is "unset / driver default", which is benign for any method.
+	levelSet := c.rawCompressionLvlS != "" && c.rawCompressionLvl != 0
+	if c.rawCompression == chCompressionNone {
+		if levelSet {
+			return fmt.Errorf("%s=%d is set but %s=%s; a level needs a compression method (%s or %s)",
+				envCHCompressionLevel, c.rawCompressionLvl, envCHCompression, chCompressionNone, chCompressionLZ4, chCompressionZSTD)
+		}
+		return nil
+	}
+	if !levelSet {
+		return nil
+	}
+	var lo, hi int
+	switch c.rawCompression {
+	case chCompressionLZ4:
+		lo, hi = chCompressionLZ4MinLevel, chCompressionLZ4MaxLevel
+	case chCompressionZSTD:
+		lo, hi = chCompressionZSTDMinLevel, chCompressionZSTDMaxLevel
+	}
+	if c.rawCompressionLvl < lo || c.rawCompressionLvl > hi {
+		return fmt.Errorf("%s=%d out of range for %s=%s (valid %d..%d)",
+			envCHCompressionLevel, c.rawCompressionLvl, envCHCompression, c.rawCompression, lo, hi)
+	}
+	return nil
+}
+
+// httpServerFromEnv parses the CERBERUS_HTTP_* server-timeout knobs into an
+// HTTPServerConfig. Read / write default to 0 (unlimited, streaming-safe);
+// the header timeout is the promoted 5s; idle defaults to 120s. The
+// "header-timeout <= read-timeout when read-timeout > 0" coupling is enforced
+// here since both knobs belong to this group.
+func httpServerFromEnv(v *viper.Viper) (HTTPServerConfig, error) {
+	readTO, err := getDuration(v, envHTTPReadTimeout)
+	if err != nil {
+		return HTTPServerConfig{}, err
+	}
+	if readTO < 0 {
+		return HTTPServerConfig{}, fmt.Errorf("%s: must be >= 0, got %s", envHTTPReadTimeout, readTO)
+	}
+	readHdrTO, err := getDuration(v, envHTTPReadHdrTimeout)
+	if err != nil {
+		return HTTPServerConfig{}, err
+	}
+	if readHdrTO < 0 {
+		return HTTPServerConfig{}, fmt.Errorf("%s: must be >= 0, got %s", envHTTPReadHdrTimeout, readHdrTO)
+	}
+	writeTO, err := getDuration(v, envHTTPWriteTimeout)
+	if err != nil {
+		return HTTPServerConfig{}, err
+	}
+	if writeTO < 0 {
+		return HTTPServerConfig{}, fmt.Errorf("%s: must be >= 0, got %s", envHTTPWriteTimeout, writeTO)
+	}
+	idleTO, err := getDuration(v, envHTTPIdleTimeout)
+	if err != nil {
+		return HTTPServerConfig{}, err
+	}
+	if idleTO < 0 {
+		return HTTPServerConfig{}, fmt.Errorf("%s: must be >= 0, got %s", envHTTPIdleTimeout, idleTO)
+	}
+	maxHdr, err := getInt(v, envHTTPMaxHeaderBytes)
+	if err != nil {
+		return HTTPServerConfig{}, err
+	}
+	if maxHdr < 0 {
+		return HTTPServerConfig{}, fmt.Errorf("%s: must be >= 0, got %d", envHTTPMaxHeaderBytes, maxHdr)
+	}
+
+	// Cross-setting: a header read deadline longer than the whole-request read
+	// deadline can never fire — reject the incoherent pair.
+	if readTO > 0 && readHdrTO > readTO {
+		return HTTPServerConfig{}, fmt.Errorf("%s (%s) must be <= %s (%s)", envHTTPReadHdrTimeout, readHdrTO, envHTTPReadTimeout, readTO)
+	}
+
+	return HTTPServerConfig{
+		ReadTimeout:       readTO,
+		ReadHeaderTimeout: readHdrTO,
+		WriteTimeout:      writeTO,
+		IdleTimeout:       idleTO,
+		MaxHeaderBytes:    maxHdr,
+	}, nil
+}
+
+// applyCHExtra writes the parsed full-surface connection knobs onto a
+// chclient.Config (the single assembly point). Addr stays the canonical scalar
+// (Addrs[0]); the multi-host slice is set only when more than one host is
+// configured so the bare single-host path is byte-unchanged.
+func applyCHExtra(cc *chclient.Config, c chExtra) {
+	cc.Addr = c.Addrs[0]
+	if len(c.Addrs) > 1 {
+		cc.Addrs = c.Addrs
+	}
+	cc.Protocol = c.Protocol
+	cc.ConnOpenStrategy = c.ConnOpenStrategy
+	cc.ReadTimeout = c.ReadTimeout
+	cc.TLS = c.TLS
+	cc.Compression = c.Compression
+	cc.BlockBufferSize = c.BlockBufferSize
+	cc.MaxCompressionBuffer = c.MaxCompressionBuffer
+	cc.FreeBufOnConnRelease = c.FreeBufOnConnRelease
+	cc.Debug = c.Debug
+	cc.HTTPHeaders = c.HTTPHeaders
+	cc.HTTPURLPath = c.HTTPURLPath
+	cc.HTTPMaxConnsPerHost = c.HTTPMaxConnsPerHost
+	cc.HTTPProxyURL = c.HTTPProxyURL
+}

--- a/internal/config/ch_connection_test.go
+++ b/internal/config/ch_connection_test.go
@@ -1,0 +1,294 @@
+package config
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+)
+
+// TestFromEnv_CHConnection_Defaults pins that with none of the full-surface
+// connection knobs set, the resolved chclient.Config is byte-identical to the
+// pre-knob connection: native protocol, in-order strategy, no TLS, no
+// compression, single addr, zero buffers.
+func TestFromEnv_CHConnection_Defaults(t *testing.T) {
+	clearAllEnv(t)
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	cc := cfg.ClickHouse
+	if cc.Addr != "localhost:9000" {
+		t.Errorf("Addr = %q; want localhost:9000", cc.Addr)
+	}
+	if cc.Addrs != nil {
+		t.Errorf("Addrs = %v; want nil (single-host path)", cc.Addrs)
+	}
+	if cc.Protocol != clickhouse.Native {
+		t.Errorf("Protocol = %v; want Native", cc.Protocol)
+	}
+	if cc.ConnOpenStrategy != clickhouse.ConnOpenInOrder {
+		t.Errorf("ConnOpenStrategy = %v; want InOrder", cc.ConnOpenStrategy)
+	}
+	if cc.TLS != nil {
+		t.Errorf("TLS = %v; want nil (plaintext)", cc.TLS)
+	}
+	if cc.Compression != nil {
+		t.Errorf("Compression = %v; want nil (uncompressed)", cc.Compression)
+	}
+	if cc.ReadTimeout != 0 {
+		t.Errorf("ReadTimeout = %v; want 0 (derived from QueryTimeout)", cc.ReadTimeout)
+	}
+	if cc.BlockBufferSize != 0 || cc.MaxCompressionBuffer != 0 {
+		t.Errorf("buffers = (%d,%d); want (0,0)", cc.BlockBufferSize, cc.MaxCompressionBuffer)
+	}
+	if cc.FreeBufOnConnRelease || cc.Debug {
+		t.Errorf("FreeBufOnConnRelease/Debug = (%v,%v); want both false", cc.FreeBufOnConnRelease, cc.Debug)
+	}
+}
+
+// TestFromEnv_CHMultiHost confirms a comma-separated CERBERUS_CH_ADDR resolves
+// to a multi-element Addrs slice (trimmed) with Addr = the first host.
+func TestFromEnv_CHMultiHost(t *testing.T) {
+	clearAllEnv(t)
+	t.Setenv(envCHAddr, " ch-1:9000 , ch-2:9000 ,ch-3:9000")
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	want := []string{"ch-1:9000", "ch-2:9000", "ch-3:9000"}
+	if cfg.ClickHouse.Addr != "ch-1:9000" {
+		t.Errorf("Addr = %q; want ch-1:9000 (first host)", cfg.ClickHouse.Addr)
+	}
+	if len(cfg.ClickHouse.Addrs) != len(want) {
+		t.Fatalf("Addrs = %v; want %v", cfg.ClickHouse.Addrs, want)
+	}
+	for i := range want {
+		if cfg.ClickHouse.Addrs[i] != want[i] {
+			t.Errorf("Addrs[%d] = %q; want %q", i, cfg.ClickHouse.Addrs[i], want[i])
+		}
+	}
+}
+
+// TestFromEnv_CHEnums exercises the protocol / strategy / compression enum
+// overrides and rejection of unknown values.
+func TestFromEnv_CHEnums(t *testing.T) {
+	t.Run("protocol_http", func(t *testing.T) {
+		clearAllEnv(t)
+		t.Setenv(envCHProtocol, "http")
+		cfg, err := FromEnv()
+		if err != nil {
+			t.Fatalf("FromEnv: %v", err)
+		}
+		if cfg.ClickHouse.Protocol != clickhouse.HTTP {
+			t.Errorf("Protocol = %v; want HTTP", cfg.ClickHouse.Protocol)
+		}
+	})
+	t.Run("strategy_round_robin", func(t *testing.T) {
+		clearAllEnv(t)
+		t.Setenv(envCHConnOpenStrategy, "round_robin")
+		t.Setenv(envCHAddr, "a:9000,b:9000")
+		cfg, err := FromEnv()
+		if err != nil {
+			t.Fatalf("FromEnv: %v", err)
+		}
+		if cfg.ClickHouse.ConnOpenStrategy != clickhouse.ConnOpenRoundRobin {
+			t.Errorf("ConnOpenStrategy = %v; want RoundRobin", cfg.ClickHouse.ConnOpenStrategy)
+		}
+	})
+	t.Run("compression_lz4", func(t *testing.T) {
+		clearAllEnv(t)
+		t.Setenv(envCHCompression, "lz4")
+		cfg, err := FromEnv()
+		if err != nil {
+			t.Fatalf("FromEnv: %v", err)
+		}
+		if cfg.ClickHouse.Compression == nil || cfg.ClickHouse.Compression.Method != clickhouse.CompressionLZ4 {
+			t.Errorf("Compression = %v; want lz4", cfg.ClickHouse.Compression)
+		}
+	})
+	invalid := []struct{ env, val string }{
+		{envCHProtocol, "grpc"},
+		{envCHConnOpenStrategy, "random_pick"},
+		{envCHCompression, "snappy"},
+	}
+	for _, tc := range invalid {
+		t.Run("invalid_"+tc.env+"="+tc.val, func(t *testing.T) {
+			clearAllEnv(t)
+			t.Setenv(tc.env, tc.val)
+			_, err := FromEnv()
+			if err == nil {
+				t.Fatalf("FromEnv accepted %s=%q; want error", tc.env, tc.val)
+			}
+			if !strings.Contains(err.Error(), tc.env) {
+				t.Errorf("error %q does not name %s", err, tc.env)
+			}
+		})
+	}
+}
+
+// TestFromEnv_CHBuffers covers the block buffer / max-compression-buffer
+// override + range validation.
+func TestFromEnv_CHBuffers(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		clearAllEnv(t)
+		t.Setenv(envCHBlockBufferSize, "8")
+		t.Setenv(envCHMaxComprBuffer, "20971520")
+		cfg, err := FromEnv()
+		if err != nil {
+			t.Fatalf("FromEnv: %v", err)
+		}
+		if cfg.ClickHouse.BlockBufferSize != 8 {
+			t.Errorf("BlockBufferSize = %d; want 8", cfg.ClickHouse.BlockBufferSize)
+		}
+		if cfg.ClickHouse.MaxCompressionBuffer != 20971520 {
+			t.Errorf("MaxCompressionBuffer = %d; want 20971520", cfg.ClickHouse.MaxCompressionBuffer)
+		}
+	})
+	invalid := []struct{ env, val string }{
+		{envCHBlockBufferSize, "256"}, // > 255
+		{envCHBlockBufferSize, "-1"},
+		{envCHBlockBufferSize, "nope"},
+		{envCHMaxComprBuffer, "-1"},
+		{envCHMaxComprBuffer, "huge"},
+	}
+	for _, tc := range invalid {
+		t.Run("invalid_"+tc.env+"="+tc.val, func(t *testing.T) {
+			clearAllEnv(t)
+			t.Setenv(tc.env, tc.val)
+			_, err := FromEnv()
+			if err == nil {
+				t.Fatalf("FromEnv accepted %s=%q; want error", tc.env, tc.val)
+			}
+			if !strings.Contains(err.Error(), tc.env) {
+				t.Errorf("error %q does not name %s", err, tc.env)
+			}
+		})
+	}
+}
+
+// TestFromEnv_CHReadTimeout confirms the first-class read-timeout knob
+// overrides the QueryTimeout derivation and is validated as non-negative.
+func TestFromEnv_CHReadTimeout(t *testing.T) {
+	clearAllEnv(t)
+	t.Setenv(envCHReadTimeout, "90s")
+	t.Setenv(envQueryTimeout, "30s")
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	if cfg.ClickHouse.ReadTimeout != 90*time.Second {
+		t.Errorf("ReadTimeout = %v; want 90s (first-class knob)", cfg.ClickHouse.ReadTimeout)
+	}
+}
+
+// TestFromEnv_CHTLS_mTLS builds a real cert/key/CA on disk and confirms the
+// *tls.Config carries the client certificate, the CA pool, and ServerName.
+func TestFromEnv_CHTLS_mTLS(t *testing.T) {
+	clearAllEnv(t)
+	caPEM, certPEM, keyPEM := genTestPKI(t)
+	dir := t.TempDir()
+	caFile := writeFile(t, dir, "ca.pem", caPEM)
+	certFile := writeFile(t, dir, "cert.pem", certPEM)
+	keyFile := writeFile(t, dir, "key.pem", keyPEM)
+
+	t.Setenv(envCHTLSEnabled, "true")
+	t.Setenv(envCHTLSCAFile, caFile)
+	t.Setenv(envCHTLSCertFile, certFile)
+	t.Setenv(envCHTLSKeyFile, keyFile)
+	t.Setenv(envCHTLSServerName, "clickhouse.internal")
+
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	tlsCfg := cfg.ClickHouse.TLS
+	if tlsCfg == nil {
+		t.Fatal("TLS = nil; want non-nil when enabled")
+	}
+	if tlsCfg.ServerName != "clickhouse.internal" {
+		t.Errorf("ServerName = %q; want clickhouse.internal", tlsCfg.ServerName)
+	}
+	if len(tlsCfg.Certificates) != 1 {
+		t.Errorf("Certificates = %d; want 1 (mTLS client cert)", len(tlsCfg.Certificates))
+	}
+	if tlsCfg.RootCAs == nil {
+		t.Error("RootCAs = nil; want the configured CA pool")
+	}
+	if tlsCfg.InsecureSkipVerify {
+		t.Error("InsecureSkipVerify = true; want false")
+	}
+}
+
+// TestFromEnv_CHTLS_SkipVerify confirms a bare enable + skip-verify yields a
+// permissive *tls.Config (no CA / serverName).
+func TestFromEnv_CHTLS_SkipVerify(t *testing.T) {
+	clearAllEnv(t)
+	t.Setenv(envCHTLSEnabled, "true")
+	t.Setenv(envCHTLSSkipVerify, "true")
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	if cfg.ClickHouse.TLS == nil || !cfg.ClickHouse.TLS.InsecureSkipVerify {
+		t.Fatalf("TLS = %v; want InsecureSkipVerify=true", cfg.ClickHouse.TLS)
+	}
+}
+
+// TestFromEnv_CHTLS_BadCAFile confirms a missing CA path fails fast naming the
+// env var.
+func TestFromEnv_CHTLS_BadCAFile(t *testing.T) {
+	clearAllEnv(t)
+	t.Setenv(envCHTLSEnabled, "true")
+	t.Setenv(envCHTLSCAFile, "/nonexistent/ca.pem")
+	_, err := FromEnv()
+	if err == nil {
+		t.Fatal("FromEnv accepted a missing CA file; want error")
+	}
+	if !strings.Contains(err.Error(), envCHTLSCAFile) {
+		t.Errorf("error %q does not name %s", err, envCHTLSCAFile)
+	}
+}
+
+// TestFromEnv_CHHTTPKnobs confirms the HTTP-protocol knobs thread through when
+// Protocol=http.
+func TestFromEnv_CHHTTPKnobs(t *testing.T) {
+	clearAllEnv(t)
+	t.Setenv(envCHProtocol, "http")
+	t.Setenv(envCHHTTPHeaders, "X-Scope-OrgID=tenant-a,X-Trace=1")
+	t.Setenv(envCHHTTPURLPath, "/query")
+	t.Setenv(envCHHTTPMaxConns, "16")
+	t.Setenv(envCHHTTPProxyURL, "http://proxy.internal:3128")
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	cc := cfg.ClickHouse
+	if cc.HTTPHeaders["X-Scope-OrgID"] != "tenant-a" {
+		t.Errorf("HTTPHeaders = %v; want X-Scope-OrgID=tenant-a", cc.HTTPHeaders)
+	}
+	if cc.HTTPURLPath != "/query" {
+		t.Errorf("HTTPURLPath = %q; want /query", cc.HTTPURLPath)
+	}
+	if cc.HTTPMaxConnsPerHost != 16 {
+		t.Errorf("HTTPMaxConnsPerHost = %d; want 16", cc.HTTPMaxConnsPerHost)
+	}
+	if cc.HTTPProxyURL == nil || cc.HTTPProxyURL.Host != "proxy.internal:3128" {
+		t.Errorf("HTTPProxyURL = %v; want proxy.internal:3128", cc.HTTPProxyURL)
+	}
+}
+
+// TestFromEnv_CHHTTPProxy_Malformed rejects a bad proxy URL.
+func TestFromEnv_CHHTTPProxy_Malformed(t *testing.T) {
+	clearAllEnv(t)
+	t.Setenv(envCHProtocol, "http")
+	t.Setenv(envCHHTTPProxyURL, "://nohost")
+	_, err := FromEnv()
+	if err == nil {
+		t.Fatal("FromEnv accepted a malformed proxy URL; want error")
+	}
+	if !strings.Contains(err.Error(), envCHHTTPProxyURL) {
+		t.Errorf("error %q does not name %s", err, envCHHTTPProxyURL)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -27,8 +28,14 @@ import (
 // Config is the cerberus runtime configuration.
 type Config struct {
 	HTTPAddr   string
+	HTTPServer HTTPServerConfig
 	ClickHouse chclient.Config
 	Schema     schema.Metrics
+
+	// LokiTailWriteTimeout bounds a single /tail WebSocket write before a
+	// slow / dead client is torn down. Promoted from the hardcoded 10s in
+	// internal/api/loki/tail.go via CERBERUS_LOKI_TAIL_WRITE_TIMEOUT.
+	LokiTailWriteTimeout time.Duration
 	// Logs is the OTel logs schema (table + columns the Loki API reads).
 	// Defaults to schema.DefaultOTelLogs() with any CERBERUS_SCHEMA_LOGS_*
 	// env overrides applied.
@@ -129,6 +136,39 @@ type AdmitConfig struct {
 	MaxInflightTempo int
 }
 
+// HTTPServerConfig holds the cerberus HTTP server's net/http timeout knobs
+// (cmd/cerberus's http.Server). Every field maps 1:1 to an http.Server field.
+//
+// Defaults preserve today's behaviour: ReadHeaderTimeout is the promoted 5s
+// that was previously hardcoded; ReadTimeout and WriteTimeout default to 0
+// (unlimited) so the Loki /tail WebSocket and long query_range matrix streams
+// are never severed mid-response by a server-side deadline; IdleTimeout bounds
+// an otherwise-leaked keep-alive connection; MaxHeaderBytes 0 leaves Go's
+// 1 MiB default.
+type HTTPServerConfig struct {
+	// ReadTimeout caps the time to read the ENTIRE request including the body
+	// (http.Server.ReadTimeout). 0 = unlimited. A streaming-safe default.
+	ReadTimeout time.Duration
+
+	// ReadHeaderTimeout caps the time to read request HEADERS
+	// (http.Server.ReadHeaderTimeout). Default 5s (the promoted hardcoded
+	// value). Must be <= ReadTimeout when ReadTimeout > 0.
+	ReadHeaderTimeout time.Duration
+
+	// WriteTimeout caps the time to write the response
+	// (http.Server.WriteTimeout). 0 = unlimited — required so the /tail
+	// WebSocket and long matrix responses are not cut mid-stream.
+	WriteTimeout time.Duration
+
+	// IdleTimeout caps how long an idle keep-alive connection is held open
+	// (http.Server.IdleTimeout). Default 120s.
+	IdleTimeout time.Duration
+
+	// MaxHeaderBytes caps request header size (http.Server.MaxHeaderBytes).
+	// 0 leaves Go's 1 MiB default.
+	MaxHeaderBytes int
+}
+
 // LogConfig controls the slog setup applied at startup.
 //
 //   - Format is the slog handler kind. "text" produces a human-readable
@@ -197,6 +237,31 @@ const (
 	envCHBreakerThreshold  = "CERBERUS_CH_BREAKER_THRESHOLD"
 	envCHBreakerWindow     = "CERBERUS_CH_BREAKER_WINDOW"
 	envCHBreakerOpenIntrvl = "CERBERUS_CH_BREAKER_OPEN_INTERVAL"
+	envCHProtocol          = "CERBERUS_CH_PROTOCOL"
+	envCHConnOpenStrategy  = "CERBERUS_CH_CONN_OPEN_STRATEGY"
+	envCHReadTimeout       = "CERBERUS_CH_READ_TIMEOUT"
+	envCHCompression       = "CERBERUS_CH_COMPRESSION"
+	envCHCompressionLevel  = "CERBERUS_CH_COMPRESSION_LEVEL"
+	envCHBlockBufferSize   = "CERBERUS_CH_BLOCK_BUFFER_SIZE"
+	envCHMaxComprBuffer    = "CERBERUS_CH_MAX_COMPRESSION_BUFFER"
+	envCHFreeBufOnRelease  = "CERBERUS_CH_FREE_BUF_ON_CONN_RELEASE"
+	envCHDebug             = "CERBERUS_CH_DEBUG"
+	envCHTLSEnabled        = "CERBERUS_CH_TLS_ENABLED"
+	envCHTLSCAFile         = "CERBERUS_CH_TLS_CA_FILE"
+	envCHTLSCertFile       = "CERBERUS_CH_TLS_CERT_FILE"
+	envCHTLSKeyFile        = "CERBERUS_CH_TLS_KEY_FILE"
+	envCHTLSServerName     = "CERBERUS_CH_TLS_SERVER_NAME"
+	envCHTLSSkipVerify     = "CERBERUS_CH_TLS_INSECURE_SKIP_VERIFY"
+	envCHHTTPHeaders       = "CERBERUS_CH_HTTP_HEADERS"
+	envCHHTTPURLPath       = "CERBERUS_CH_HTTP_URL_PATH"
+	envCHHTTPMaxConns      = "CERBERUS_CH_HTTP_MAX_CONNS_PER_HOST"
+	envCHHTTPProxyURL      = "CERBERUS_CH_HTTP_PROXY_URL"
+	envHTTPReadTimeout     = "CERBERUS_HTTP_READ_TIMEOUT"
+	envHTTPReadHdrTimeout  = "CERBERUS_HTTP_READ_HEADER_TIMEOUT"
+	envHTTPWriteTimeout    = "CERBERUS_HTTP_WRITE_TIMEOUT" //nolint:gosec // env-var name, not a credential
+	envHTTPIdleTimeout     = "CERBERUS_HTTP_IDLE_TIMEOUT"
+	envHTTPMaxHeaderBytes  = "CERBERUS_HTTP_MAX_HEADER_BYTES"
+	envLokiTailWriteTO     = "CERBERUS_LOKI_TAIL_WRITE_TIMEOUT"
 	envAutoCreateSchema    = "CERBERUS_AUTO_CREATE_SCHEMA"
 	envRequirementsCheck   = "CERBERUS_REQUIREMENTS_CHECK"
 	envExperimentalTSGrid  = "CERBERUS_EXPERIMENTAL_TS_GRID_RANGE"
@@ -246,6 +311,32 @@ const configFileBaseName = "cerberus"
 //	CERBERUS_CH_BREAKER_THRESHOLD     default 5   (consecutive failures to trip OPEN)
 //	CERBERUS_CH_BREAKER_WINDOW        default "10s" (rolling failure window)
 //	CERBERUS_CH_BREAKER_OPEN_INTERVAL default "5s"  (OPEN-state backoff before a probe)
+//	CERBERUS_CH_PROTOCOL           default "native" ("native" | "http")
+//	CERBERUS_CH_CONN_OPEN_STRATEGY default "in_order" ("in_order" | "round_robin")
+//	CERBERUS_CH_READ_TIMEOUT       default "" (empty → derived from CERBERUS_QUERY_TIMEOUT;
+//	    when set must be >= CERBERUS_QUERY_TIMEOUT; clickhouse-go has NO write-timeout knob)
+//	CERBERUS_CH_COMPRESSION        default "none" ("none" | "lz4" | "zstd")
+//	CERBERUS_CH_COMPRESSION_LEVEL  default 0 (unset; lz4 0..12, zstd 1..22; requires a method)
+//	CERBERUS_CH_BLOCK_BUFFER_SIZE  default 0 (unset → driver 2; valid 1..255)
+//	CERBERUS_CH_MAX_COMPRESSION_BUFFER default 0 (unset → driver 10 MiB; bytes, > 0)
+//	CERBERUS_CH_FREE_BUF_ON_CONN_RELEASE default "false"
+//	CERBERUS_CH_DEBUG              default "false" (clickhouse-go legacy stdout debug)
+//	CERBERUS_CH_TLS_ENABLED        default "false" (dial CH over TLS; sub-knobs require this)
+//	CERBERUS_CH_TLS_CA_FILE        default "" (PEM CA bundle path)
+//	CERBERUS_CH_TLS_CERT_FILE      default "" (client cert for mTLS; pairs with KEY_FILE)
+//	CERBERUS_CH_TLS_KEY_FILE       default "" (client key for mTLS; pairs with CERT_FILE)
+//	CERBERUS_CH_TLS_SERVER_NAME    default "" (SNI / cert-verify hostname override)
+//	CERBERUS_CH_TLS_INSECURE_SKIP_VERIFY default "false" (skip cert verify; incompatible with CA/SERVER_NAME)
+//	CERBERUS_CH_HTTP_HEADERS       default "" (HTTP-protocol only; "k=v,k2=v2")
+//	CERBERUS_CH_HTTP_URL_PATH      default "" (HTTP-protocol only)
+//	CERBERUS_CH_HTTP_MAX_CONNS_PER_HOST default 0 (HTTP-protocol only; unset → driver default)
+//	CERBERUS_CH_HTTP_PROXY_URL     default "" (HTTP-protocol only; absolute URL)
+//	CERBERUS_HTTP_READ_TIMEOUT     default "0s" (whole-request read; 0 = unlimited / streaming-safe)
+//	CERBERUS_HTTP_READ_HEADER_TIMEOUT default "5s" (header read; <= READ_TIMEOUT when that is > 0)
+//	CERBERUS_HTTP_WRITE_TIMEOUT    default "0s" (response write; 0 = unlimited / streaming-safe)
+//	CERBERUS_HTTP_IDLE_TIMEOUT     default "120s" (idle keep-alive connection)
+//	CERBERUS_HTTP_MAX_HEADER_BYTES default 0 (0 → Go's 1 MiB default)
+//	CERBERUS_LOKI_TAIL_WRITE_TIMEOUT default "10s" (single /tail WebSocket write bound; > 0)
 //	CERBERUS_AUTO_CREATE_SCHEMA    default "false"
 //	CERBERUS_REQUIREMENTS_CHECK     default "true" — run the boot-time
 //	    requirements check (CH server version >= the config-derived minimum
@@ -389,29 +480,51 @@ func FromEnv() (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
-	return Config{
-		HTTPAddr: v.GetString(envHTTPAddr),
-		ClickHouse: chclient.Config{
-			Addr:                v.GetString(envCHAddr),
-			Database:            v.GetString(envCHDatabase),
-			Username:            v.GetString(envCHUsername),
-			Password:            v.GetString(envCHPassword),
-			DialTimeout:         dial,
-			MaxOpenConns:        maxOpenConns,
-			MaxIdleConns:        maxIdleConns,
-			ConnMaxLifetime:     connMaxLifetime,
-			KeepAliveEnabled:    keepAliveEnabled,
-			KeepAliveIdle:       keepAliveIdle,
-			KeepAliveInterval:   keepAliveInterval,
-			KeepAliveProbes:     keepAliveCount,
-			MaxQuerySamples:     maxSamples,
-			MaxQueryMemoryBytes: maxMemory,
-			QueryTimeout:        queryTimeout,
-			BreakerThreshold:    breaker.Threshold,
-			BreakerWindow:       breaker.Window,
-			BreakerOpenInterval: breaker.OpenInterval,
-			BreakerDisabled:     breaker.Disabled,
+	// Full-surface ClickHouse connection knobs (protocol, multi-host, TLS,
+	// compression, buffers, HTTP-only) + the HTTP server timeouts + the Loki
+	// tail write timeout, all parsed and cross-validated in one helper so
+	// FromEnv stays readable. The CROSS-setting dependency matrix is enforced
+	// inside surfaceFromEnv, where the query / pool knobs are threaded in.
+	// The idle<=open rule fires only when the operator EXPLICITLY set idle:
+	// lowering only MAX_OPEN_CONNS below the default idle of 5 is a common,
+	// coherent idiom (clickhouse-go clamps idle to open internally), so a
+	// defaulted idle must not be punished. viper.IsSet can't distinguish a
+	// SetDefault from a real override, so explicit-set is detected from the
+	// value source directly (env var or config-file key present).
+	pools := poolKnobs{
+		maxOpen:      maxOpenConns,
+		maxIdle:      maxIdleConns,
+		idleExplicit: explicitlySet(v, envCHMaxIdleConns),
+	}
+	surface, err := surfaceFromEnv(v, queryTimeout, pools)
+	if err != nil {
+		return Config{}, err
+	}
+	chCfg := assembleCHConfig(chConfigInputs{
+		database:        getString(v, envCHDatabase),
+		username:        getString(v, envCHUsername),
+		password:        v.GetString(envCHPassword),
+		dial:            dial,
+		maxOpen:         maxOpenConns,
+		maxIdle:         maxIdleConns,
+		connMaxLifetime: connMaxLifetime,
+		keepAlive: keepAliveInputs{
+			enabled:  keepAliveEnabled,
+			idle:     keepAliveIdle,
+			interval: keepAliveInterval,
+			probes:   keepAliveCount,
 		},
+		maxSamples:   maxSamples,
+		maxMemory:    maxMemory,
+		queryTimeout: queryTimeout,
+		breaker:      breaker,
+		extra:        surface.ch,
+	})
+	return Config{
+		HTTPAddr:                getString(v, envHTTPAddr),
+		HTTPServer:              surface.httpServer,
+		LokiTailWriteTimeout:    surface.lokiTailWriteTimeout,
+		ClickHouse:              chCfg,
 		Schema:                  schema.DefaultOTelMetricsFromEnv(),
 		Logs:                    schema.DefaultOTelLogsFromEnv(),
 		Traces:                  schema.DefaultOTelTracesFromEnv(),
@@ -448,6 +561,31 @@ var allEnvKeys = []string{
 	envCHBreakerThreshold,
 	envCHBreakerWindow,
 	envCHBreakerOpenIntrvl,
+	envCHProtocol,
+	envCHConnOpenStrategy,
+	envCHReadTimeout,
+	envCHCompression,
+	envCHCompressionLevel,
+	envCHBlockBufferSize,
+	envCHMaxComprBuffer,
+	envCHFreeBufOnRelease,
+	envCHDebug,
+	envCHTLSEnabled,
+	envCHTLSCAFile,
+	envCHTLSCertFile,
+	envCHTLSKeyFile,
+	envCHTLSServerName,
+	envCHTLSSkipVerify,
+	envCHHTTPHeaders,
+	envCHHTTPURLPath,
+	envCHHTTPMaxConns,
+	envCHHTTPProxyURL,
+	envHTTPReadTimeout,
+	envHTTPReadHdrTimeout,
+	envHTTPWriteTimeout,
+	envHTTPIdleTimeout,
+	envHTTPMaxHeaderBytes,
+	envLokiTailWriteTO,
 	envAutoCreateSchema,
 	envRequirementsCheck,
 	envExperimentalTSGrid,
@@ -510,6 +648,31 @@ func newLoader() *viper.Viper {
 	v.SetDefault(envCHBreakerThreshold, defaultCHBreakerThreshold)
 	v.SetDefault(envCHBreakerWindow, defaultCHBreakerWindow.String())
 	v.SetDefault(envCHBreakerOpenIntrvl, defaultCHBreakerOpenInterval.String())
+	v.SetDefault(envCHProtocol, defaultCHProtocol)
+	v.SetDefault(envCHConnOpenStrategy, defaultCHConnOpenStrategy)
+	v.SetDefault(envCHReadTimeout, defaultCHReadTimeout)
+	v.SetDefault(envCHCompression, defaultCHCompression)
+	v.SetDefault(envCHCompressionLevel, defaultCHCompressionLevel)
+	v.SetDefault(envCHBlockBufferSize, defaultCHBlockBufferSize)
+	v.SetDefault(envCHMaxComprBuffer, defaultCHMaxCompressionBuffer)
+	v.SetDefault(envCHFreeBufOnRelease, defaultCHFreeBufOnConnRelease)
+	v.SetDefault(envCHDebug, defaultCHDebug)
+	v.SetDefault(envCHTLSEnabled, defaultCHTLSEnabled)
+	v.SetDefault(envCHTLSCAFile, "")
+	v.SetDefault(envCHTLSCertFile, "")
+	v.SetDefault(envCHTLSKeyFile, "")
+	v.SetDefault(envCHTLSServerName, "")
+	v.SetDefault(envCHTLSSkipVerify, defaultCHTLSSkipVerify)
+	v.SetDefault(envCHHTTPHeaders, "")
+	v.SetDefault(envCHHTTPURLPath, "")
+	v.SetDefault(envCHHTTPMaxConns, defaultCHHTTPMaxConns)
+	v.SetDefault(envCHHTTPProxyURL, "")
+	v.SetDefault(envHTTPReadTimeout, defaultHTTPReadTimeout.String())
+	v.SetDefault(envHTTPReadHdrTimeout, defaultHTTPReadHeaderTimeout.String())
+	v.SetDefault(envHTTPWriteTimeout, defaultHTTPWriteTimeout.String())
+	v.SetDefault(envHTTPIdleTimeout, defaultHTTPIdleTimeout.String())
+	v.SetDefault(envHTTPMaxHeaderBytes, defaultHTTPMaxHeaderBytes)
+	v.SetDefault(envLokiTailWriteTO, defaultLokiTailWriteTimeout.String())
 	v.SetDefault(envAutoCreateSchema, defaultAutoCreateSchema)
 	v.SetDefault(envRequirementsCheck, defaultRequirementsCheck)
 	v.SetDefault(envExperimentalTSGrid, defaultExperimentalTSGrid)
@@ -572,6 +735,84 @@ const (
 	defaultOTLPTimeout        time.Duration = 10 * time.Second
 	defaultOTLPExportInterval time.Duration = 10 * time.Second
 )
+
+// ClickHouse protocol / strategy / compression enum vocabularies. The
+// defaults reproduce today's behaviour exactly: native protocol, in-order
+// host selection, and no wire compression — so an operator who sets none of
+// these knobs gets the same connection cerberus has always opened.
+const (
+	chProtocolNative = "native"
+	chProtocolHTTP   = "http"
+
+	chConnOpenInOrder    = "in_order"
+	chConnOpenRoundRobin = "round_robin"
+
+	chCompressionNone = "none"
+	chCompressionLZ4  = "lz4"
+	chCompressionZSTD = "zstd"
+
+	defaultCHProtocol         = chProtocolNative
+	defaultCHConnOpenStrategy = chConnOpenInOrder
+	defaultCHCompression      = chCompressionNone
+	// defaultCHReadTimeout is empty so a socket ReadTimeout is DERIVED from
+	// CERBERUS_QUERY_TIMEOUT (the deterministic restart-recovery ceiling, see
+	// chclient.buildOptions). A non-empty CERBERUS_CH_READ_TIMEOUT overrides
+	// the derivation. Empty (not "0s") keeps the value "unset" so the
+	// derivation path stays in effect rather than forcing ReadTimeout to 0.
+	defaultCHReadTimeout = ""
+	// defaultCHCompressionLevel is 0: "no explicit level". Sending a level
+	// while CERBERUS_CH_COMPRESSION=none is rejected (see the dependency
+	// matrix); 0 means the driver's per-method default level applies.
+	defaultCHCompressionLevel = 0
+	// defaultCHBlockBufferSize / defaultCHMaxCompressionBuffer / the HTTP
+	// per-host cap are all 0 = "leave the driver default" (2 / 10 MiB / Go's
+	// default), so an unset knob is byte-identical to before it existed.
+	defaultCHBlockBufferSize      = 0
+	defaultCHMaxCompressionBuffer = 0
+	defaultCHHTTPMaxConns         = 0
+	defaultCHFreeBufOnConnRelease = false
+	defaultCHDebug                = false
+	defaultCHTLSEnabled           = false
+	defaultCHTLSSkipVerify        = false
+)
+
+// Compression level bounds. clickhouse-go consumes Compression.Level
+// differently per method (lz4hc honours it; the SpeedDefault-pinned zstd
+// writer ignores it), but cerberus still validates the level against the
+// method's documented range so a typo fails fast at startup instead of
+// silently doing nothing. lz4: 0..12 (0 = driver default = LZ4HC level 9;
+// 12 = compress.LevelLZ4HCMax). zstd: 1..22, the conventional ZSTD range
+// that ClickHouse's server-side network_zstd_compression_level accepts.
+const (
+	chCompressionLZ4MinLevel  = 0
+	chCompressionLZ4MaxLevel  = 12
+	chCompressionZSTDMinLevel = 1
+	chCompressionZSTDMaxLevel = 22
+)
+
+// chBlockBufferMax is the inclusive upper bound on CERBERUS_CH_BLOCK_BUFFER_SIZE
+// — the driver field is a uint8, so 255 is the hard ceiling. The lower bound
+// is 1 (0 means "unset / driver default 2", handled before this check).
+const chBlockBufferMax = 255
+
+// HTTP server timeout defaults (cmd/cerberus's http.Server). The header
+// timeout is the promoted 5s that was previously hardcoded; read / write
+// default to 0 (unlimited) so streaming responses (Loki /tail WebSocket,
+// long query_range matrices) are never cut mid-stream; idle bounds an
+// otherwise-leaked keep-alive connection. MaxHeaderBytes 0 = Go's 1 MiB
+// default.
+const (
+	defaultHTTPReadTimeout       time.Duration = 0
+	defaultHTTPReadHeaderTimeout time.Duration = 5 * time.Second
+	defaultHTTPWriteTimeout      time.Duration = 0
+	defaultHTTPIdleTimeout       time.Duration = 120 * time.Second
+	defaultHTTPMaxHeaderBytes                  = 0
+)
+
+// defaultLokiTailWriteTimeout promotes the previously-hardcoded
+// tailWriteTimeout in internal/api/loki/tail.go: the bound on a single
+// /tail WebSocket write before a slow / dead client is torn down.
+const defaultLokiTailWriteTimeout time.Duration = 10 * time.Second
 
 // defaultQueryMaxSamples is the default per-query sample budget,
 // mirroring upstream Prometheus's --query.max-samples default
@@ -884,6 +1125,19 @@ func parseHeaders(raw string) (map[string]string, error) {
 		out[k] = val
 	}
 	return out, nil
+}
+
+// explicitlySet reports whether key was supplied by the operator — via the
+// environment OR the optional config file — as opposed to resolving from a
+// built-in SetDefault. viper.IsSet conflates a registered default with a real
+// override, so it can't answer this; we inspect the two operator-controlled
+// sources directly. A present-but-empty env value counts as NOT set (it is the
+// same "unset" the rest of the loader treats it as via getString's trim).
+func explicitlySet(v *viper.Viper, key string) bool {
+	if raw, ok := os.LookupEnv(key); ok && strings.TrimSpace(raw) != "" {
+		return true
+	}
+	return v.InConfig(key)
 }
 
 // getString returns the resolved string value for key (env > file >

--- a/internal/config/dependency_test.go
+++ b/internal/config/dependency_test.go
@@ -1,0 +1,189 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestFromEnv_DependencyRules exercises the cross-setting dependency matrix:
+// each case is a COMBINATION of individually-valid values that is incoherent
+// together and must be rejected at startup with an error naming the knobs.
+func TestFromEnv_DependencyRules(t *testing.T) {
+	caPEM, certPEM, keyPEM := genTestPKI(t)
+	dir := t.TempDir()
+	caFile := writeFile(t, dir, "ca.pem", caPEM)
+	certFile := writeFile(t, dir, "cert.pem", certPEM)
+	keyFile := writeFile(t, dir, "key.pem", keyPEM)
+
+	cases := []struct {
+		name    string
+		env     map[string]string
+		wantSub []string // substrings the error must contain (knob names)
+	}{
+		{
+			name:    "tls_cert_without_key",
+			env:     map[string]string{envCHTLSEnabled: "true", envCHTLSCertFile: certFile},
+			wantSub: []string{envCHTLSCertFile, envCHTLSKeyFile},
+		},
+		{
+			name:    "tls_key_without_cert",
+			env:     map[string]string{envCHTLSEnabled: "true", envCHTLSKeyFile: keyFile},
+			wantSub: []string{envCHTLSCertFile, envCHTLSKeyFile},
+		},
+		{
+			name:    "tls_subknob_without_enable",
+			env:     map[string]string{envCHTLSCAFile: caFile},
+			wantSub: []string{envCHTLSEnabled, envCHTLSCAFile},
+		},
+		{
+			name:    "tls_servername_without_enable",
+			env:     map[string]string{envCHTLSServerName: "ch.internal"},
+			wantSub: []string{envCHTLSEnabled},
+		},
+		{
+			name:    "skipverify_with_ca",
+			env:     map[string]string{envCHTLSEnabled: "true", envCHTLSSkipVerify: "true", envCHTLSCAFile: caFile},
+			wantSub: []string{envCHTLSSkipVerify, envCHTLSCAFile},
+		},
+		{
+			name:    "skipverify_with_servername",
+			env:     map[string]string{envCHTLSEnabled: "true", envCHTLSSkipVerify: "true", envCHTLSServerName: "ch.internal"},
+			wantSub: []string{envCHTLSSkipVerify, envCHTLSServerName},
+		},
+		{
+			name:    "http_headers_under_native",
+			env:     map[string]string{envCHProtocol: "native", envCHHTTPHeaders: "k=v"},
+			wantSub: []string{envCHHTTPHeaders, envCHProtocol},
+		},
+		{
+			name:    "http_urlpath_under_native",
+			env:     map[string]string{envCHHTTPURLPath: "/q"},
+			wantSub: []string{envCHHTTPURLPath, envCHProtocol},
+		},
+		{
+			name:    "http_maxconns_under_native",
+			env:     map[string]string{envCHHTTPMaxConns: "8"},
+			wantSub: []string{envCHHTTPMaxConns, envCHProtocol},
+		},
+		{
+			name:    "http_proxy_under_native",
+			env:     map[string]string{envCHHTTPProxyURL: "http://p:3128"},
+			wantSub: []string{envCHHTTPProxyURL, envCHProtocol},
+		},
+		{
+			name:    "compression_level_without_method",
+			env:     map[string]string{envCHCompression: "none", envCHCompressionLevel: "5"},
+			wantSub: []string{envCHCompressionLevel, envCHCompression},
+		},
+		{
+			name:    "compression_level_lz4_out_of_range",
+			env:     map[string]string{envCHCompression: "lz4", envCHCompressionLevel: "13"},
+			wantSub: []string{envCHCompressionLevel, envCHCompression},
+		},
+		{
+			name:    "compression_level_zstd_out_of_range",
+			env:     map[string]string{envCHCompression: "zstd", envCHCompressionLevel: "23"},
+			wantSub: []string{envCHCompressionLevel, envCHCompression},
+		},
+		{
+			name:    "read_timeout_below_query_timeout",
+			env:     map[string]string{envCHReadTimeout: "10s", envQueryTimeout: "30s"},
+			wantSub: []string{envCHReadTimeout, envQueryTimeout},
+		},
+		{
+			name:    "idle_exceeds_open",
+			env:     map[string]string{envCHMaxIdleConns: "20", envCHMaxOpenConns: "10"},
+			wantSub: []string{envCHMaxIdleConns, envCHMaxOpenConns},
+		},
+		{
+			name:    "http_header_timeout_exceeds_read_timeout",
+			env:     map[string]string{envHTTPReadTimeout: "5s", envHTTPReadHdrTimeout: "10s"},
+			wantSub: []string{envHTTPReadHdrTimeout, envHTTPReadTimeout},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			clearAllEnv(t)
+			for k, v := range tc.env {
+				t.Setenv(k, v)
+			}
+			_, err := FromEnv()
+			if err == nil {
+				t.Fatalf("FromEnv accepted incoherent combo %v; want error", tc.env)
+			}
+			for _, sub := range tc.wantSub {
+				if !strings.Contains(err.Error(), sub) {
+					t.Errorf("error %q does not name %q", err, sub)
+				}
+			}
+		})
+	}
+}
+
+// TestFromEnv_DependencyRules_CoherentCombosAccepted confirms the matrix does
+// NOT over-reject: combos that ARE coherent must pass.
+func TestFromEnv_DependencyRules_CoherentCombosAccepted(t *testing.T) {
+	t.Run("read_timeout_equal_query_timeout", func(t *testing.T) {
+		clearAllEnv(t)
+		t.Setenv(envCHReadTimeout, "30s")
+		t.Setenv(envQueryTimeout, "30s")
+		if _, err := FromEnv(); err != nil {
+			t.Fatalf("FromEnv rejected read==query timeout: %v", err)
+		}
+	})
+	t.Run("idle_equal_open", func(t *testing.T) {
+		clearAllEnv(t)
+		t.Setenv(envCHMaxIdleConns, "10")
+		t.Setenv(envCHMaxOpenConns, "10")
+		if _, err := FromEnv(); err != nil {
+			t.Fatalf("FromEnv rejected idle==open: %v", err)
+		}
+	})
+	t.Run("lower_open_only_keeps_default_idle", func(t *testing.T) {
+		// The chaos overlay lowers MAX_OPEN_CONNS to 4 and leaves idle at its
+		// default 5. That is coherent (the driver clamps idle to open) and must
+		// be accepted — the idle<=open rule only fires on an EXPLICIT idle.
+		clearAllEnv(t)
+		t.Setenv(envCHMaxOpenConns, "4")
+		cfg, err := FromEnv()
+		if err != nil {
+			t.Fatalf("FromEnv rejected lowered open with default idle: %v", err)
+		}
+		if cfg.ClickHouse.MaxOpenConns != 4 || cfg.ClickHouse.MaxIdleConns != 5 {
+			t.Errorf("pool = (open %d, idle %d); want (4, 5)", cfg.ClickHouse.MaxOpenConns, cfg.ClickHouse.MaxIdleConns)
+		}
+	})
+	t.Run("http_knobs_under_http", func(t *testing.T) {
+		clearAllEnv(t)
+		t.Setenv(envCHProtocol, "http")
+		t.Setenv(envCHHTTPURLPath, "/query")
+		if _, err := FromEnv(); err != nil {
+			t.Fatalf("FromEnv rejected http knobs under http protocol: %v", err)
+		}
+	})
+	t.Run("compression_level_in_range", func(t *testing.T) {
+		clearAllEnv(t)
+		t.Setenv(envCHCompression, "lz4")
+		t.Setenv(envCHCompressionLevel, "9")
+		cfg, err := FromEnv()
+		if err != nil {
+			t.Fatalf("FromEnv rejected in-range lz4 level: %v", err)
+		}
+		if cfg.ClickHouse.Compression.Level != 9 {
+			t.Errorf("Compression.Level = %d; want 9", cfg.ClickHouse.Compression.Level)
+		}
+	})
+	t.Run("keepalive_subknobs_inert_when_disabled", func(t *testing.T) {
+		// Sub-knobs that are inert when keepalive is OFF must not be rejected
+		// (they have no runtime effect) — a degenerate idle/interval/count is
+		// only validated when keepalive is enabled.
+		clearAllEnv(t)
+		t.Setenv(envCHKeepAliveEnabled, "false")
+		t.Setenv(envCHKeepAliveIdle, "0s")
+		t.Setenv(envCHKeepAliveInterval, "0s")
+		t.Setenv(envCHKeepAliveCount, "0")
+		if _, err := FromEnv(); err != nil {
+			t.Fatalf("FromEnv rejected inert keepalive sub-knobs when disabled: %v", err)
+		}
+	})
+}

--- a/internal/config/http_server_test.go
+++ b/internal/config/http_server_test.go
@@ -1,0 +1,113 @@
+package config
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestFromEnv_HTTPServer_Defaults pins the streaming-safe HTTP server
+// timeouts: header timeout is the promoted 5s, read/write are 0 (unlimited)
+// so /tail and long matrices stream uninterrupted, idle is 120s.
+func TestFromEnv_HTTPServer_Defaults(t *testing.T) {
+	clearAllEnv(t)
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	hs := cfg.HTTPServer
+	if hs.ReadHeaderTimeout != 5*time.Second {
+		t.Errorf("ReadHeaderTimeout = %v; want 5s (promoted)", hs.ReadHeaderTimeout)
+	}
+	if hs.ReadTimeout != 0 {
+		t.Errorf("ReadTimeout = %v; want 0 (streaming-safe)", hs.ReadTimeout)
+	}
+	if hs.WriteTimeout != 0 {
+		t.Errorf("WriteTimeout = %v; want 0 (streaming-safe)", hs.WriteTimeout)
+	}
+	if hs.IdleTimeout != 120*time.Second {
+		t.Errorf("IdleTimeout = %v; want 120s", hs.IdleTimeout)
+	}
+	if hs.MaxHeaderBytes != 0 {
+		t.Errorf("MaxHeaderBytes = %d; want 0 (Go default)", hs.MaxHeaderBytes)
+	}
+}
+
+// TestFromEnv_HTTPServer_Overrides confirms every knob threads through.
+func TestFromEnv_HTTPServer_Overrides(t *testing.T) {
+	clearAllEnv(t)
+	t.Setenv(envHTTPReadTimeout, "30s")
+	t.Setenv(envHTTPReadHdrTimeout, "3s")
+	t.Setenv(envHTTPWriteTimeout, "45s")
+	t.Setenv(envHTTPIdleTimeout, "60s")
+	t.Setenv(envHTTPMaxHeaderBytes, "1048576")
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	hs := cfg.HTTPServer
+	if hs.ReadTimeout != 30*time.Second || hs.ReadHeaderTimeout != 3*time.Second ||
+		hs.WriteTimeout != 45*time.Second || hs.IdleTimeout != 60*time.Second ||
+		hs.MaxHeaderBytes != 1048576 {
+		t.Errorf("HTTPServer = %+v; overrides not applied", hs)
+	}
+}
+
+// TestFromEnv_HTTPServer_Invalid rejects negative durations / sizes.
+func TestFromEnv_HTTPServer_Invalid(t *testing.T) {
+	cases := []struct{ env, val string }{
+		{envHTTPReadTimeout, "-1s"},
+		{envHTTPReadHdrTimeout, "-1s"},
+		{envHTTPWriteTimeout, "-1s"},
+		{envHTTPIdleTimeout, "-1s"},
+		{envHTTPMaxHeaderBytes, "-1"},
+		{envHTTPReadTimeout, "nope"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.env+"="+tc.val, func(t *testing.T) {
+			clearAllEnv(t)
+			t.Setenv(tc.env, tc.val)
+			_, err := FromEnv()
+			if err == nil {
+				t.Fatalf("FromEnv accepted %s=%q; want error", tc.env, tc.val)
+			}
+			if !strings.Contains(err.Error(), tc.env) {
+				t.Errorf("error %q does not name %s", err, tc.env)
+			}
+		})
+	}
+}
+
+// TestFromEnv_LokiTailWriteTimeout covers the promoted /tail write timeout.
+func TestFromEnv_LokiTailWriteTimeout(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		clearAllEnv(t)
+		cfg, err := FromEnv()
+		if err != nil {
+			t.Fatalf("FromEnv: %v", err)
+		}
+		if cfg.LokiTailWriteTimeout != 10*time.Second {
+			t.Errorf("LokiTailWriteTimeout = %v; want 10s", cfg.LokiTailWriteTimeout)
+		}
+	})
+	t.Run("override", func(t *testing.T) {
+		clearAllEnv(t)
+		t.Setenv(envLokiTailWriteTO, "25s")
+		cfg, err := FromEnv()
+		if err != nil {
+			t.Fatalf("FromEnv: %v", err)
+		}
+		if cfg.LokiTailWriteTimeout != 25*time.Second {
+			t.Errorf("LokiTailWriteTimeout = %v; want 25s", cfg.LokiTailWriteTimeout)
+		}
+	})
+	t.Run("invalid", func(t *testing.T) {
+		for _, val := range []string{"0s", "-5s", "nope"} {
+			clearAllEnv(t)
+			t.Setenv(envLokiTailWriteTO, val)
+			if _, err := FromEnv(); err == nil {
+				t.Errorf("FromEnv accepted %s=%q; want error", envLokiTailWriteTO, val)
+			}
+		}
+	})
+}

--- a/internal/config/pki_test.go
+++ b/internal/config/pki_test.go
@@ -1,0 +1,59 @@
+package config
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// genTestPKI mints a throwaway self-signed CA-style leaf cert + its EC private
+// key, returned as PEM bundles (caPEM == certPEM here — the leaf doubles as the
+// CA pool entry, which is all the config loader needs to prove RootCAs is
+// populated). Used by the TLS / mTLS config tests so they exercise the real
+// crypto/tls + crypto/x509 load path without a fixture file checked into the
+// repo.
+func genTestPKI(t *testing.T) (caPEM, certPEM, keyPEM []byte) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("genkey: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "cerberus-test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	return certPEM, certPEM, keyPEM
+}
+
+// writeFile writes content into dir/name and returns the absolute path.
+func writeFile(t *testing.T, dir, name string, content []byte) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, content, 0o600); err != nil {
+		t.Fatalf("write %s: %v", p, err)
+	}
+	return p
+}


### PR DESCRIPTION
## Why

#928 (merged) bounded CH-restart recovery via `ReadTimeout = QueryTimeout`. This
follow-up exposes the **entire** ClickHouse connection + cerberus HTTP-server
configuration surface as `CERBERUS_*` env knobs, so every protocol / TLS posture
/ compression / buffer / multi-host scenario is operator-tunable instead of
hardcoded — with fail-fast validation that rejects incoherent *combinations*,
not just bad individual values.

Every knob is **unset-by-default to today's exact behaviour**: setting none of
them opens the same connection and the same `http.Server` cerberus has always
built.

## What

### ClickHouse client (`internal/chclient`)
Every settable `clickhouse.Options` field cerberus didn't already wire:
multi-host `CERBERUS_CH_ADDR` (comma-separated), `_PROTOCOL` (native|http),
`_CONN_OPEN_STRATEGY` (in_order|round_robin), first-class `_READ_TIMEOUT`
(overrides the QueryTimeout derivation; clickhouse-go has no write-timeout),
TLS/mTLS group (`_TLS_ENABLED` + CA/CERT/KEY/SERVER_NAME/INSECURE_SKIP_VERIFY,
building a real `*tls.Config` only when enabled), `_COMPRESSION`
(none|lz4|zstd) + `_COMPRESSION_LEVEL`, `_BLOCK_BUFFER_SIZE` (1..255),
`_MAX_COMPRESSION_BUFFER`, `_FREE_BUF_ON_CONN_RELEASE`, `_DEBUG`, and the
HTTP-protocol-only `_HTTP_HEADERS` / `_HTTP_URL_PATH` /
`_HTTP_MAX_CONNS_PER_HOST` / `_HTTP_PROXY_URL`.

### cerberus HTTP server (`cmd/cerberus`)
`CERBERUS_HTTP_READ_TIMEOUT` (0 = unlimited, streaming-safe),
`_READ_HEADER_TIMEOUT` (promotes the hardcoded 5s), `_WRITE_TIMEOUT` (0 =
streaming-safe), `_IDLE_TIMEOUT` (120s), `_MAX_HEADER_BYTES`.

### Misc
`CERBERUS_LOKI_TAIL_WRITE_TIMEOUT` promotes the hardcoded `/tail` 10s.

### Not exposable (documented why)
`DialContext` (keepalive-driven), `DialStrategy`, `Logger`, `Debugf`, `GetJWT`,
`TransportFunc`, `ClientInfo`, per-query `Settings` (covered by
`QUERY_MAX_MEMORY`).

## Cross-setting dependency validation (the key requirement)

Incoherent *combinations* of individually-valid values are rejected at startup,
each error naming both knobs. Full matrix in `docs/configuration.md`:

- TLS cert/key both-or-neither; TLS sub-knobs require `_TLS_ENABLED`;
  skip-verify contradicts CA / server-name.
- HTTP-protocol knobs require `PROTOCOL=http`.
- Compression level requires a method; level range-checked per method (lz4
  `0..12`, zstd `1..22`).
- `READ_TIMEOUT >= QUERY_TIMEOUT`; `MAX_IDLE_CONNS <= MAX_OPEN_CONNS`;
  HTTP header-timeout <= read-timeout.
- Benign-but-pointless combos (round_robin with one host; keepalive timing
  sub-knobs while keepalive is off) are noted, not rejected.

## Tests

New unit tests per knob (default / override / fail-fast), one per dependency
rule (incoherent combo must error naming the knobs), chclient field-mapping
(TLS set iff enabled, ReadTimeout knob beats derived, multi-addr, HTTP knobs),
a server-builder test (timeouts carried onto `http.Server`), and a loki-tail
timeout test. mTLS tests mint a throwaway cert/key/CA on disk and exercise the
real `crypto/tls` + `crypto/x509` load path.

`go test -race ./internal/config/... ./internal/chclient/... ./cmd/... ./internal/api/loki/...` passes; golangci-lint clean; go-arch-lint OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
