### PR TITLE
docs(readme): bump version reference to v1.0.0-rc.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 Keep Grafana, alerting, and your CLI tooling. Swap the backend.
 
 > [!WARNING]
-> **EXPERIMENTAL — NOT PRODUCTION-READY.** Cerberus is at `v1.0.0-RC1`,
+> **EXPERIMENTAL — NOT PRODUCTION-READY.** Cerberus is at `v1.0.0-rc.1`,
 > early and under active development. The differential harnesses run on every
 > PR and score parity against real Prometheus / Loki / Tempo, but correctness,
 > performance, and operational behaviour are still being shaken out, and the


### PR DESCRIPTION
Bumps the README version notice from `v1.0.0-RC1` to the actual first-release tag `v1.0.0-rc.1`.

Context: the `v1.0.0-RC1` name was created+deleted on the remote in May, so GitHub's backend now rejects re-creating that exact ref; the first release ships under the canonical-semver `v1.0.0-rc.1` instead.

Scope: README version line only. License is already **Apache 2.0** on main (LICENSE + README badge + footer, via #914) and is unchanged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)