### PR TITLE
test(crawl): reconcile Traces Drilldown primarySignal-init-race 400

### DIFF
--- a/test/e2e/playwright/crawl/crawl.spec.ts
+++ b/test/e2e/playwright/crawl/crawl.spec.ts
@@ -130,6 +130,7 @@ import {
   harvestLinks,
   inventoryPath,
   isSupersededDsQueryFailure,
+  isTransientMalformedTraceQLFailure,
   loadExclusions,
   loadInventory,
   marshalInventory,
@@ -1014,6 +1015,15 @@ function evaluateWireOracles(
       continue;
     }
     if (isSupersededDsQueryFailure(resp, succeededSigs)) {
+      continue;
+    }
+    // The Traces Drilldown app's primarySignal-init race transiently
+    // forwards a dangling-operand TraceQL (`{ && …} | rate()`) that
+    // cerberus correctly 400s (reference Tempo rejects the identical
+    // syntax error). Distinct expr → no 2xx sibling, so the
+    // supersession reconciler above can't catch it; this one keys on
+    // the malformed shape itself. See isTransientMalformedTraceQLFailure.
+    if (isTransientMalformedTraceQLFailure(resp)) {
       continue;
     }
     fail(

--- a/test/e2e/playwright/crawl/lib.ts
+++ b/test/e2e/playwright/crawl/lib.ts
@@ -834,6 +834,66 @@ export function isSupersededDsQueryFailure(
 }
 
 // ---------------------------------------------------------------------------
+// app-init-race reconciliation: dangling-operand TraceQL
+// ---------------------------------------------------------------------------
+
+/**
+ * Matches a TraceQL spanset whose boolean filter has a DANGLING /
+ * EMPTY operand around `&&` / `||` — i.e. a `{` followed immediately
+ * by a binary operator (empty left operand: `{ && true}`), or a
+ * binary operator immediately followed by the closing `}` (empty
+ * right operand: `{true && }`), or two adjacent operators (`{a && &&
+ * b}`). This is a SYNTAX ERROR, not a value-level filter: TraceQL's
+ * grammar requires a non-empty operand on each side of `&&` / `||`,
+ * so cerberus's parser (and reference Tempo's identical grammar)
+ * rejects it with `syntax error: unexpected &&` (HTTP 400).
+ *
+ * The shape is produced by the Grafana Traces Drilldown app
+ * (grafana-exploretraces-app), NOT by cerberus. The app's
+ * `PrimarySignalVariable` (a Scenes CustomVariable) applies its
+ * default value inside the component's `useEffect`, not in its
+ * constructor — so during the initial-load / rapid-navigation window,
+ * before that effect fires, the `${primarySignal}` interpolation is
+ * EMPTY and the app builds `{ && ${filters}} | rate()` (and the
+ * errors / duration variants). The instant the effect resolves the
+ * default, the app re-fires the well-formed query; the user only ever
+ * sees the settled result. See
+ * src/pages/Explore/PrimarySignalVariable.tsx in
+ * grafana/traces-drilldown.
+ */
+const DANGLING_TRACEQL_OPERAND =
+  /\{\s*(?:&&|\|\|)|(?:&&|\|\|)\s*\}|(?:&&|\|\|)\s*(?:&&|\|\|)/;
+
+/**
+ * True iff `resp` is a non-2xx Tempo ds/query whose EVERY forwarded
+ * TraceQL query carries a dangling-operand spanset (see
+ * DANGLING_TRACEQL_OPERAND) — the Traces Drilldown app's
+ * primarySignal-init-race shape. cerberus correctly 400s these
+ * (reference Tempo rejects the identical syntax-error), so they are a
+ * transient app-side artifact, not a cerberus fault.
+ *
+ * This is NOT the supersession reconciler's twin: the malformed query
+ * has a DIFFERENT expr than the settled one, so it never shares a
+ * signature with a 2xx sibling and `isSupersededDsQueryFailure` can't
+ * resolve it. It is also NOT a blanket 400 suppressor — a non-2xx
+ * carrying any well-formed query still fails loudly; only the specific
+ * dangling-`&&`/`||` syntax shape the app's known init race emits is
+ * reconciled, and ALL queries in the request must exhibit it (a mixed
+ * request with one well-formed query is a genuine failure).
+ */
+export function isTransientMalformedTraceQLFailure(
+  resp: DsResponseView,
+): boolean {
+  if (!resp.url.includes('/api/ds/query')) return false;
+  if (resp.status >= 200 && resp.status <= 299) return false;
+  const dsType = new URL(resp.url, 'http://x').searchParams.get('ds_type');
+  if (dsType !== 'tempo') return false;
+  const exprs = [...refIdToExpr(resp.requestBody).values()];
+  if (exprs.length === 0) return false;
+  return exprs.every((expr) => DANGLING_TRACEQL_OPERAND.test(expr));
+}
+
+// ---------------------------------------------------------------------------
 // Misc
 // ---------------------------------------------------------------------------
 

--- a/test/e2e/playwright/crawl/reconcile.spec.ts
+++ b/test/e2e/playwright/crawl/reconcile.spec.ts
@@ -31,6 +31,7 @@ import { expect, test } from '@playwright/test';
 import {
   dsQuerySignature,
   isSupersededDsQueryFailure,
+  isTransientMalformedTraceQLFailure,
   refIdToExpr,
   succeededDsQuerySignatures,
   type DsResponseView,
@@ -178,5 +179,118 @@ test.describe('supersession reconciliation', () => {
       requestBody: '',
     };
     expect(isSupersededDsQueryFailure(resp, new Set())).toBe(false);
+  });
+});
+
+/**
+ * isTransientMalformedTraceQLFailure — the Traces Drilldown
+ * primarySignal-init race (compose-smoke crawl run 27527911418).
+ *
+ * The app's PrimarySignalVariable applies its default inside the
+ * component's useEffect, not its constructor, so during the
+ * initial-load / rapid-nav window `${primarySignal}` interpolates to
+ * EMPTY and the app forwards a dangling-operand spanset
+ * `{ && ${filters}} | rate()` (and the errors / duration variants).
+ * That is a TraceQL SYNTAX ERROR — cerberus 400s it with
+ * `unexpected &&`, exactly as reference Tempo's identical grammar
+ * does. The malformed expr differs from the settled one, so it has no
+ * 2xx sibling and the supersession reconciler can't resolve it; this
+ * reconciler keys on the malformed shape instead. Verified live on
+ * the compose stack: `GET /api/metrics/query_range?q={ && true} |
+ * rate()` → HTTP 400; the settled `{true && true} | rate() by(…)` →
+ * HTTP 200.
+ */
+const dsqTempo = (
+  query: string,
+  status: number,
+  requestId = 'SQR108',
+): DsResponseView => ({
+  url: `/api/ds/query?ds_type=tempo&requestId=${requestId}`,
+  status,
+  requestBody: tempoBody(query),
+});
+
+test.describe('isTransientMalformedTraceQLFailure', () => {
+  test('reconciles the empty-primarySignal leading-`&&` rate query', () => {
+    expect(
+      isTransientMalformedTraceQLFailure(dsqTempo('{ && true} | rate()', 400)),
+    ).toBe(true);
+  });
+
+  test('reconciles the errors + duration init-race variants', () => {
+    for (const q of [
+      '{ && true && status=error} | rate()',
+      '{ && true} | quantile_over_time(duration, 0.9)',
+      '{ && true} | rate() by(resource.service.version)',
+    ]) {
+      expect(isTransientMalformedTraceQLFailure(dsqTempo(q, 400))).toBe(true);
+    }
+  });
+
+  test('reconciles `||` and trailing-operand dangling shapes', () => {
+    for (const q of [
+      '{ || true} | rate()',
+      '{true && } | rate()',
+      '{true && && false} | rate()',
+    ]) {
+      expect(isTransientMalformedTraceQLFailure(dsqTempo(q, 400))).toBe(true);
+    }
+  });
+
+  test('does NOT reconcile a well-formed TraceQL 400 (real wrong-rejection)', () => {
+    // A genuine cerberus wrong-rejection of a valid query must still
+    // fail loudly — this reconciler is not a blanket 400 suppressor.
+    for (const q of [
+      '{true && true} | rate()',
+      '{nestedSetParent<0 && true} | rate() by(resource.service.version)',
+      '{true && true && resource.service.version != nil} | rate()',
+      '{kind=server && true} | quantile_over_time(duration, 0.9)',
+    ]) {
+      expect(isTransientMalformedTraceQLFailure(dsqTempo(q, 400))).toBe(false);
+    }
+  });
+
+  test('does NOT reconcile when one query in the request is well-formed', () => {
+    const mixed: DsResponseView = {
+      url: '/api/ds/query?ds_type=tempo&requestId=SQR1',
+      status: 400,
+      requestBody: JSON.stringify({
+        queries: [
+          { refId: 'A', query: '{ && true} | rate()', datasource: { type: 'tempo' } },
+          { refId: 'B', query: '{true && true} | rate()', datasource: { type: 'tempo' } },
+        ],
+      }),
+    };
+    expect(isTransientMalformedTraceQLFailure(mixed)).toBe(false);
+  });
+
+  test('does NOT reconcile a 2xx, a non-ds/query, or a non-tempo ds_type', () => {
+    expect(
+      isTransientMalformedTraceQLFailure(dsqTempo('{ && true} | rate()', 200)),
+    ).toBe(false);
+    expect(
+      isTransientMalformedTraceQLFailure({
+        url: '/api/dashboards/uid/abc',
+        status: 400,
+        requestBody: '',
+      }),
+    ).toBe(false);
+    expect(
+      isTransientMalformedTraceQLFailure({
+        url: '/api/ds/query?ds_type=prometheus&requestId=SQR1',
+        status: 400,
+        requestBody: promBody('{ && up'),
+      }),
+    ).toBe(false);
+  });
+
+  test('does NOT reconcile an empty/unparseable request body', () => {
+    expect(
+      isTransientMalformedTraceQLFailure({
+        url: '/api/ds/query?ds_type=tempo&requestId=SQR1',
+        status: 400,
+        requestBody: '<streamed>',
+      }),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## What

The compose-smoke crawl (CI run 27527911418, `shard-crawl`) caught an **intermittent** `POST /api/ds/query?ds_type=tempo&requestId=SQR108 → 400` on the `grafana-exploretraces-app` explore surface (`var-metric=duration|errors|rate`, `var-groupBy=resource.service.version`, `var-primarySignal=true`, `actionView=structure`). The maintainer correctly rejected dismissing it as a flake. This PR root-causes it and adds the right narrowly-scoped reconciliation.

## Root cause — verdict: app-side init race, NOT a cerberus bug

The exact 400'd query is a **dangling-operand TraceQL** spanset:

```
{ && true} | rate()        (and the errors / duration variants)
```

This is generated by the Grafana **Traces Drilldown** app, not cerberus. The app's `PrimarySignalVariable` (a Scenes `CustomVariable`, `src/pages/Explore/PrimarySignalVariable.tsx` in `grafana/traces-drilldown`) applies its default value inside the component's `useEffect`, **not** its constructor. During the initial-load / rapid-navigation window — before that effect fires — `${primarySignal}` interpolates to **empty string**, and the app builds `{ && ${filters}} | <metricFn>` (a leading `&&` with an empty left operand). The instant the effect resolves the default, the app re-fires the well-formed query; the user only ever sees the settled result. This is intermittent precisely because the window is narrow (matches the CI report: passed on retry, clean on `ed4068fc`).

A leading/dangling `&&` is a **TraceQL syntax error**. cerberus's parser — `tsouza/tempo:cerberus-accessors`, an accessor-only fork whose `pkg/traceql` grammar is **identical to reference Tempo** — rejects it. The rejection lands at `internal/api/tempo/metrics_query_range.go:258`:

```go
expr, perr := parseExpr(ctx, q)   // line 255
if perr != nil {
    writeError(w, http.StatusBadRequest, "", "", perr)   // line 258
    return
}
```

### Evidence

- **Parser probe** (cerberus's `traceql.Parse` = reference Tempo's grammar): `{ && true} | rate()` → `parse error at line 0, col 3: syntax error: unexpected &&`. Every legitimate guarded query the app builds — `{true && true} | rate() by(resource.service.version)`, `… && status=error`, `quantile_over_time(duration, ...)`, `… != nil`, `nestedSetParent<0`, `kind=server`, `{}` — **parses and lowers cleanly**. No wrong-rejection.
- **Live compose stack** (`docker compose up` + seeded traces):
  - `GET /api/metrics/query_range?q={ && true} | rate()` → **HTTP 400** `unexpected &&` (same for the errors + duration variants)
  - settled `{true && true} | rate() by(resource.service.version)` / `quantile_over_time(duration, 0.9)` → **HTTP 200**

Reference Tempo rejects the identical syntax error, so cerberus is **correct**. This is verdict **(b)**: cerberus correctly 400s an app-generated transient malformed query.

## Why the existing reconciler doesn't catch it

The crawl already reconciles Grafana's last-write-wins supersession via `isSupersededDsQueryFailure` — a non-2xx whose **exact query signature** also produced a 2xx sibling is a superseded ghost. But the malformed `{ && …}` query is a **different expr string** than the settled `{true && …}` one, so it never shares a signature with a 2xx response. The supersession reconciler structurally cannot resolve it — which is exactly why the crawl flagged it.

## The fix

`isTransientMalformedTraceQLFailure` in `crawl/lib.ts` — a sibling reconciler keyed on the **malformed shape itself**, not a 2xx sibling. It sanctions a non-2xx `ds_type=tempo` ds/query only when **every** forwarded TraceQL query carries a dangling/empty operand around `&&` / `||` (`{ &&`, `&& }`, `&& &&`). Wired into `evaluateWireOracles` next to the supersession check.

This is **not** a blanket 400 suppressor:
- A non-2xx carrying any **well-formed** query (a genuine cerberus wrong-rejection) still fails loudly.
- A **mixed** request (one malformed + one well-formed query) fails loudly.
- Only the specific empty-operand syntax shape the app's known init race emits is reconciled.

## Tests

`crawl/reconcile.spec.ts` gains 7 unit cases (pure logic, no browser): the rate/errors/duration init-race variants and `||`/trailing shapes reconcile; well-formed 400s, mixed requests, 2xx, non-ds/query, non-tempo `ds_type`, and unparseable bodies all do **not**. Full reconcile suite: 17/17 green. TS typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)