### PR TITLE
ci(e2e): de-gate slow/flaky crawl + dashboard lanes from PR + release gates

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -33,18 +33,28 @@ wrapper, plus `appendStepSummary` / `setOutput` for the runner files.
   - Env: `REPORT` (default `gremlins.json`), `THRESHOLD` (a number).
   - Exit: `0` when efficacy is `>=` threshold, `1` when below.
 - **`release-preflight.mjs`** — `release.yml`, the `preflight` job. The
-  GATE that refuses to publish a release unless the WHOLE of `main` is
-  green on the exact commit being tagged — every push-triggered lane
-  (ci, compatibility, chdb, coverage, e2e dashboard+chaos, mutation,
-  perf-profile, property, CodeQL, …), not just the PR-required subset.
-  Reads the check-runs + commit statuses on `GITHUB_SHA` and fails on any
+  GATE that refuses to publish a release unless the substantive lanes of
+  `main` are green on the exact commit being tagged — every stable
+  push-triggered lane (ci/check, lint, compatibility ×3, chdb, coverage,
+  mutation/gremlins, perf-profile, property, probe, roundtrip ×3,
+  compose-smoke, CodeQL, …), not just the PR-required subset. Reads the
+  check-runs + commit statuses on `GITHUB_SHA` and fails on any
   non-`success`/`skipped`/`neutral` or still-pending lane. Re-runs are
-  deduped by name (latest wins); the release run's own jobs are excluded.
+  deduped by name (latest wins); the release run's own jobs are excluded;
+  scheduled (nightly) re-runs are excluded (the merge-time push result is
+  the truth). **Flaky UI COVERAGE lanes are also excluded** (`FLAKY_UI_LANE_RE`):
+  the BFS `crawl` shards (`compose-smoke-shard-info (shard-crawl)`, the k3d
+  `dashboard-shard (shard-crawl)`) and the whole informational `dashboard`
+  k3d lane (`dashboard` / `dashboard-setup` / `dashboard-shard (…)`). These
+  are coverage, not correctness gates (exploretraces "Failed to fetch",
+  the app-init-race 400 = #115/#934), so a coverage flake must not block a
+  release; the regex is anchored/specific (fail SAFE — only these lanes are
+  dropped, the required `compose-smoke` still gates).
   - Env: `GITHUB_TOKEN`, `GITHUB_REPOSITORY`, `GITHUB_SHA`; optional
     `GITHUB_API_URL` (default `https://api.github.com`) and
     `RELEASE_SELF_JOBS` (default `preflight,goreleaser`).
-  - Exit: `0` when every non-self check on the commit is green, `1`
-    otherwise (with one `::error::` per red/pending lane).
+  - Exit: `0` when every non-self, non-scheduled, non-flaky-UI check on the
+    commit is green, `1` otherwise (with one `::error::` per red/pending lane).
 - **`compat-step-summary.mjs`** — `compatibility.yml`, the three
   `Append score to step summary` steps.
   - Env: `HEAD` (`prometheus`, `tempo`, or `loki`), `SCORE` (path to that
@@ -115,10 +125,22 @@ wrapper, plus `appendStepSummary` / `setOutput` for the runner files.
   forbidden gap), double-assigned, phantom/stale, and bad-shard-name are each
   reported, then `exit 1`. `compose-smoke-matrix.test.mjs` is the `node --test`
   guard (run on the cheap `gate` lane) that pins the invariant + proves the
-  detectors fire.
+  detectors fire. Two extra responsibilities: (1) it carries the per-shard
+  `timeoutMinutes` ceiling on each emitted entry — the crawl shard gets a hard
+  30-min cap (`CRAWL_SHARD_TIMEOUT_MIN`; fail fast, release the concurrency
+  slot), non-crawl shards keep 120 (nightly full, `IS_SCHEDULE=true`) / 45
+  (PR/push lean); (2) it splits the partition into a REQUIRED `matrix` and an
+  informational `matrix_informational` (the `GATE_EXCLUDED_SHARDS` coverage
+  shards — today `shard-crawl`). The required `compose-smoke` aggregator
+  `needs:` only the required matrix, so a crawl flake/hang reports its own
+  visible `compose-smoke-shard-info (shard-crawl)` check but does NOT fail the
+  required gate. Both matrices derive from the same `SHARDS` +
+  `GATE_EXCLUDED_SHARDS`, so they can't drift.
   - Env: `MODE` (`verify` | `emit`; also `argv[2]`; default `verify`),
-    `PLAYWRIGHT_DIR` (default `test/e2e/playwright`), `GITHUB_OUTPUT` (emit:
-    the runner file the `{include:[{name,specs}]}` matrix JSON is written to).
+    `PLAYWRIGHT_DIR` (default `test/e2e/playwright`), `IS_SCHEDULE` (emit:
+    `"true"` selects the full non-crawl timeout), `GITHUB_OUTPUT` (emit: the
+    runner file the `matrix` / `matrix_informational` / `has_informational` /
+    `gate_excluded` outputs are written to).
   - Exit: `0` clean / matrix emitted, `1` on any coverage violation or bad
     `MODE`.
 
@@ -138,11 +160,18 @@ wrapper, plus `appendStepSummary` / `setOutput` for the runner files.
   runs Go e2e" invariant), then `exit 1`. `dashboard-matrix.test.mjs` is the
   `node --test` guard (run on the cheap `gate` lane) pinning the invariant +
   proving the detectors fire. k3d is heavy + flaky, so the shard count is kept
-  deliberately small.
+  deliberately small. Each emitted entry also carries a per-shard
+  `timeoutMinutes`: the crawl shard gets a hard 30-min cap
+  (`CRAWL_SHARD_TIMEOUT_MIN`; fail fast, release the k3d concurrency slot), the
+  smoke shards keep their 75-min cluster-lifetime bound (`SMOKE_SHARD_TIMEOUT_MIN`).
+  The whole `dashboard` lane is informational (never a PR gate), and the crawl
+  shard is also excluded from the release preflight.
   - Env: `MODE` (`verify` | `emit`; also `argv[2]`; default `verify`),
-    `PLAYWRIGHT_DIR` (default `test/e2e/playwright`), `GITHUB_OUTPUT` (emit:
-    the runner file the `{include:[{name,specs,crawlStack,runGoE2E}]}` matrix
-    JSON is written to).
+    `PLAYWRIGHT_DIR` (default `test/e2e/playwright`), `INCLUDE_CRAWL` (emit:
+    `"true"` adds the crawl shard — schedule/dispatch only), `GITHUB_OUTPUT`
+    (emit: the runner file the
+    `{include:[{name,specs,crawlStack,runGoE2E,timeoutMinutes}]}` matrix JSON is
+    written to).
   - Exit: `0` clean / matrix emitted, `1` on any coverage violation or bad
     `MODE`.
 

--- a/.github/scripts/compose-smoke-matrix.mjs
+++ b/.github/scripts/compose-smoke-matrix.mjs
@@ -39,6 +39,9 @@
 // Env:
 //   MODE            `emit` | `verify` (also argv[2]); default `verify`.
 //   PLAYWRIGHT_DIR  glob root; default `test/e2e/playwright`.
+//   IS_SCHEDULE     (emit) "true" on the nightly schedule — selects the FULL
+//                   per-shard timeout for non-crawl shards (120 vs the 45 lean
+//                   PR/push ceiling). The crawl shard's 30-min cap is constant.
 //   GITHUB_OUTPUT   (emit) runner file the matrix JSON is appended to.
 //
 // Exit: 0 clean / matrix emitted; 1 on any coverage violation or bad MODE.
@@ -49,6 +52,40 @@ import process from 'node:process';
 import { error, notice, log, lsFiles, setOutput, appendStepSummary } from './lib/gh.mjs';
 
 const PW_DIR = process.env.PLAYWRIGHT_DIR || 'test/e2e/playwright';
+
+// ---------------------------------------------------------------------------
+// Per-shard wall-clock ceilings (timeout-minutes on the compose-smoke-shard
+// job, interpolated as `matrix.timeoutMinutes`).
+//
+// The CRAWL shard gets a HARD 30-min cap regardless of event. crawl/crawl.spec.ts
+// is a slow BFS COVERAGE lane (NOT a correctness gate — it is de-gated from the
+// required `compose-smoke` aggregate, see GATE_EXCLUDED_SHARDS below) whose single
+// indivisible BFS test() intermittently flakes (the app-init-race 400, #115/#934)
+// and, on a hang, runs out to its long job timeout holding the
+// `cancel-in-progress: false` concurrency slot for ~2h. A 30-min cap makes it FAIL
+// FAST and release the slot instead. The PR/push lean crawl's internal budget is
+// 14min (testInfo.setTimeout in crawl.spec.ts), so 30min is comfortable headroom
+// for a healthy run; a hung/flaking run is cut at 30 instead of riding to 120.
+//
+// NON-CRAWL shards keep their prior effective ceilings: the nightly schedule runs
+// SWEEP_DEPTH=full (the heavier sweep) at 120, PR/push run SWEEP_DEPTH=lean at 45.
+// Those shards are fast (≤~35s lean per spec) so they comfortably fit; the 45/120
+// split is preserved verbatim from the old per-job `timeout-minutes` expression.
+const CRAWL_SHARD_TIMEOUT_MIN = 30;
+const NONCRAWL_SHARD_TIMEOUT_FULL_MIN = 120;
+const NONCRAWL_SHARD_TIMEOUT_LEAN_MIN = 45;
+
+// Shards EXCLUDED from the required `compose-smoke` aggregate roll-up. The crawl
+// shard still RUNS and reports its own `compose-smoke-shard (shard-crawl)` check
+// (visible, never masked with continue-on-error), but its pass/fail does NOT fail
+// the required `compose-smoke` status. Rationale: the crawl is slow BFS COVERAGE,
+// not a correctness gate; it is slow/flaky by nature (~6min compose / ~50min k3d,
+// app-init-race 400 = #115/#934), and a coverage flake must not block every PR.
+// The required gate keeps the real correctness shards (smoke, kiosk). The
+// `compose-smoke` aggregator reads this list (emitted as `gate_excluded`) to
+// decide which shard outcomes gate it. Emitted from a single source of truth so
+// the de-gate can't drift from the partition.
+const GATE_EXCLUDED_SHARDS = ['shard-crawl'];
 
 // ---------------------------------------------------------------------------
 // The wall-clock-balanced partition of the compose-smoke spec set.
@@ -238,16 +275,60 @@ function verify() {
   process.exit(0);
 }
 
+// shardTimeoutMinutes() — the per-shard `timeout-minutes` ceiling. The crawl
+// shard is a constant 30-min hard cap (fail fast, release the concurrency slot);
+// non-crawl shards take the full (nightly) or lean (PR/push) ceiling.
+export function shardTimeoutMinutes(shardName, { isSchedule } = {}) {
+  if (GATE_EXCLUDED_SHARDS.includes(shardName)) return CRAWL_SHARD_TIMEOUT_MIN;
+  return isSchedule ? NONCRAWL_SHARD_TIMEOUT_FULL_MIN : NONCRAWL_SHARD_TIMEOUT_LEAN_MIN;
+}
+
+// shardEntry() — the strategy.matrix `include` row for a shard.
+const shardEntry = (s, isSchedule) => ({
+  name: s.name,
+  specs: s.specs.join(' '),
+  timeoutMinutes: shardTimeoutMinutes(s.name, { isSchedule }),
+});
+
+const isGateExcluded = (name) => GATE_EXCLUDED_SHARDS.includes(name);
+
 function emit() {
   const discovered = discover();
   assertCoverageOrExit(discovered);
-  const include = SHARDS.map((s) => ({ name: s.name, specs: s.specs.join(' ') }));
-  setOutput('matrix', JSON.stringify({ include }));
+  const isSchedule = process.env.IS_SCHEDULE === 'true';
+
+  // The partition is split into TWO matrices so the de-gate is structural, not
+  // a fragile after-the-fact result filter. A GitHub matrix exposes only ONE
+  // rolled-up `.result` to dependents (success iff EVERY child succeeded), so a
+  // single matrix can't let one shard fail without failing the whole roll-up.
+  // Splitting at the source — both matrices derived from the SAME SHARDS +
+  // GATE_EXCLUDED_SHARDS list, so they can't drift — lets the required
+  // `compose-smoke` aggregator `needs` only the REQUIRED matrix while the crawl
+  // shard runs in its own informational matrix and reports its own child check
+  // (`compose-smoke-shard-info (shard-crawl)`), visible and unmasked.
+  const required = SHARDS.filter((s) => !isGateExcluded(s.name));
+  const informational = SHARDS.filter((s) => isGateExcluded(s.name));
+
+  setOutput('matrix', JSON.stringify({ include: required.map((s) => shardEntry(s, isSchedule)) }));
+  setOutput('matrix_informational', JSON.stringify({ include: informational.map((s) => shardEntry(s, isSchedule)) }));
+  setOutput('has_informational', informational.length > 0 ? 'true' : 'false');
   setOutput('shard_names', JSON.stringify(SHARDS.map((s) => s.name)));
+  setOutput('gate_excluded', JSON.stringify(GATE_EXCLUDED_SHARDS));
   appendStepSummary(
-    ['### compose-smoke shard matrix', '', '| shard | specs |', '| --- | --- |', ...SHARDS.map((s) => `| \`${s.name}\` | ${s.specs.length} |`)].join('\n'),
+    [
+      '### compose-smoke shard matrix',
+      '',
+      '| shard | specs | timeout (min) | gates required check |',
+      '| --- | --- | --- | --- |',
+      ...SHARDS.map(
+        (s) =>
+          `| \`${s.name}\` | ${s.specs.length} | ${shardTimeoutMinutes(s.name, { isSchedule })} | ${isGateExcluded(s.name) ? 'no (coverage)' : 'yes'} |`,
+      ),
+    ].join('\n'),
   );
-  log(`compose-smoke-matrix: emitted ${include.length}-shard matrix.`);
+  log(
+    `compose-smoke-matrix: emitted ${required.length} required + ${informational.length} informational shard(s).`,
+  );
   process.exit(0);
 }
 
@@ -265,4 +346,4 @@ if (invokedDirectly) {
 }
 
 // Exported for the unit guard (.github/scripts/compose-smoke-matrix.test.mjs).
-export { SHARDS, EXCLUDED, SHARD_NAME_RE };
+export { SHARDS, EXCLUDED, SHARD_NAME_RE, GATE_EXCLUDED_SHARDS, CRAWL_SHARD_TIMEOUT_MIN };

--- a/.github/scripts/dashboard-matrix.mjs
+++ b/.github/scripts/dashboard-matrix.mjs
@@ -83,6 +83,19 @@ const PW_DIR = process.env.PLAYWRIGHT_DIR || 'test/e2e/playwright';
 const CRAWL_STACK_K3D = 'k3d';
 const CRAWL_STACK_NONE = '';
 
+// Per-shard wall-clock ceilings (timeout-minutes on the dashboard-shard job,
+// interpolated as `matrix.timeoutMinutes`).
+//
+// The CRAWL shard gets a HARD 30-min cap. The k3d crawl is a slow BFS COVERAGE
+// lane (not a correctness gate — the whole `dashboard` lane is informational,
+// never a PR gate); on a hang it rode the job to its long timeout holding the
+// `cancel-in-progress: false` k3d concurrency slot. A 30-min cap makes it FAIL
+// FAST and release the slot. The smoke shards keep their prior effective 75-min
+// job ceiling (k3d bring-up ~3-5min + the non-crawl smoke specs fit comfortably);
+// the value is preserved verbatim from the old single per-job `timeout-minutes`.
+const CRAWL_SHARD_TIMEOUT_MIN = 30;
+const SMOKE_SHARD_TIMEOUT_MIN = 75;
+
 // ---------------------------------------------------------------------------
 // The partition of the dashboard-lane spec set across isolated k3d clusters.
 //
@@ -267,6 +280,14 @@ export function collectViolations(discovered) {
   return v;
 }
 
+// shardTimeoutMinutes() — the per-shard `timeout-minutes` ceiling. The crawl
+// shard (CRAWL_STACK=k3d) is a constant 30-min hard cap (fail fast, release the
+// k3d concurrency slot); the smoke shards keep the prior effective 75-min job
+// ceiling.
+export function shardTimeoutMinutes(shard) {
+  return shard.crawlStack === CRAWL_STACK_K3D ? CRAWL_SHARD_TIMEOUT_MIN : SMOKE_SHARD_TIMEOUT_MIN;
+}
+
 function assertCoverageOrExit(discovered) {
   const v = collectViolations(discovered);
   if (v.length === 0) return;
@@ -306,6 +327,7 @@ function emit() {
     specs: s.specs.join(' '),
     crawlStack: s.crawlStack,
     runGoE2E: s.runGoE2E,
+    timeoutMinutes: shardTimeoutMinutes(s),
   }));
   setOutput('matrix', JSON.stringify({ include }));
   setOutput('shard_names', JSON.stringify(shards.map((s) => s.name)));
@@ -313,10 +335,11 @@ function emit() {
     [
       '### dashboard (k3d) shard matrix',
       '',
-      '| shard | specs | CRAWL_STACK | Go e2e |',
-      '| --- | --- | --- | --- |',
+      '| shard | specs | CRAWL_STACK | Go e2e | timeout (min) |',
+      '| --- | --- | --- | --- | --- |',
       ...shards.map(
-        (s) => `| \`${s.name}\` | ${s.specs.length} | ${s.crawlStack || '(none)'} | ${s.runGoE2E ? 'yes' : 'no'} |`,
+        (s) =>
+          `| \`${s.name}\` | ${s.specs.length} | ${s.crawlStack || '(none)'} | ${s.runGoE2E ? 'yes' : 'no'} | ${shardTimeoutMinutes(s)} |`,
       ),
     ].join('\n'),
   );
@@ -341,4 +364,4 @@ if (invokedDirectly) {
 }
 
 // Exported for the unit guard (.github/scripts/dashboard-matrix.test.mjs).
-export { SHARDS, EXCLUDED, SHARD_NAME_RE };
+export { SHARDS, EXCLUDED, SHARD_NAME_RE, CRAWL_SHARD_TIMEOUT_MIN, SMOKE_SHARD_TIMEOUT_MIN, CRAWL_STACK_K3D };

--- a/.github/scripts/release-preflight.mjs
+++ b/.github/scripts/release-preflight.mjs
@@ -25,8 +25,22 @@
 //                      release workflow, excluded from the gate
 //                      (default "preflight,goreleaser").
 //
-// Exit 0 when every non-self check on the commit is success/skipped/neutral;
-// exit 1 (with ::error:: annotations) otherwise.
+// Flaky-UI-lane exclusions (FLAKY_UI_LANE_RE): the e2e UI COVERAGE lanes — the
+// BFS `crawl` shards (compose-smoke-shard-info (shard-crawl) + the k3d
+// dashboard-shard (shard-crawl)) and the whole `dashboard` k3d lane
+// (dashboard / dashboard-setup / dashboard-shard) — are slow + flaky by nature
+// (exploretraces "Failed to fetch", the app-init-race 400 = #115/#934) and are
+// COVERAGE, not correctness gates. They are de-gated from the required
+// `compose-smoke` PR check and the dashboard lane is informational-only, so a
+// coverage flake must not block a RELEASE either. We drop check-runs whose name
+// matches FLAKY_UI_LANE_RE from the gate. Everything else still gates: the
+// required status checks + the stable substantive lanes (ci/check, lint, compat
+// ×3, compose-smoke [now crawl-independent], probe, roundtrip ×3, chdb,
+// mutation/gremlins, property, perf-profile, coverage, CodeQL). Fail SAFE: only
+// names that clearly match these lanes are dropped; anything ambiguous is KEPT.
+//
+// Exit 0 when every non-self, non-flaky-UI check on the commit is
+// success/skipped/neutral; exit 1 (with ::error:: annotations) otherwise.
 
 import { error, notice, log } from './lib/gh.mjs';
 
@@ -93,6 +107,24 @@ async function combinedStatus() {
 // hung nightly supersede the green push result and block a release forever.
 // So resolve each check-run's triggering workflow event and drop the scheduled
 // ones; the push/PR/dispatch results are the merge-time truth the gate wants.
+// Flaky UI COVERAGE lanes dropped from the release gate. Anchored, specific
+// patterns — fail SAFE by matching only these lanes, never a broad substring
+// that could swallow a substantive lane:
+//   - any `shard-crawl` matrix child — the BFS crawl coverage lane. GitHub
+//     builds a multi-dimension matrix child's check name from ALL include
+//     fields joined by ", ", e.g.
+//       `compose-smoke-shard-info (shard-crawl, crawl/crawl.spec.ts …)`
+//       `dashboard-shard (shard-crawl, crawl/crawl.spec.ts …)`
+//     so we match `(shard-crawl` followed by `,` or `)` (NOT `(shard-crawl-…`).
+//   - the whole k3d `dashboard` lane: the `dashboard` aggregate, `dashboard-setup`,
+//     and every `dashboard-shard (...)` child (smoke shards included — the k3d
+//     lane is informational-only and flaky end-to-end, exploretraces "Failed to
+//     fetch"). The required `compose-smoke` lane is NOT matched (no `dashboard`
+//     token, and its required shards are `(shard-kiosk …)` / `(shard-smoke …)`,
+//     never `shard-crawl`), so it still gates.
+const FLAKY_UI_LANE_RE = /(\(shard-crawl[,)]|^dashboard($|-setup$|-shard( |$)))/;
+const isFlakyUILane = (name) => FLAKY_UI_LANE_RE.test(name);
+
 const SCHEDULED_EVENT = 'schedule';
 const runEventCache = new Map();
 async function checkRunEvent(cr) {
@@ -137,8 +169,15 @@ for (const cr of checkRuns) {
 const problems = [];
 let gated = 0;
 
+let skippedFlakyUI = 0;
 for (const cr of latestByName.values()) {
   if (selfJobs.has(cr.name)) continue; // never gate on this release run itself
+  if (isFlakyUILane(cr.name)) {
+    // De-gated flaky UI COVERAGE lane (crawl shard / dashboard lane). It still
+    // ran + reported its own check; it just doesn't block the release.
+    skippedFlakyUI += 1;
+    continue;
+  }
   gated += 1;
   if (cr.status !== 'completed') {
     problems.push(`${cr.name}: still ${cr.status} (not completed)`);
@@ -149,6 +188,10 @@ for (const cr of latestByName.values()) {
 
 // Legacy statuses: each individual context must be success.
 for (const st of status.statuses ?? []) {
+  if (isFlakyUILane(st.context)) {
+    skippedFlakyUI += 1;
+    continue;
+  }
   gated += 1;
   if (st.state !== 'success') {
     problems.push(`${st.context}: status ${st.state}`);
@@ -165,7 +208,8 @@ if (problems.length > 0) {
 }
 
 notice(
-  `release-preflight: all ${gated} CI checks on commit ${sha.slice(0, 8)} are green — proceeding with the release.`,
+  `release-preflight: all ${gated} CI checks on commit ${sha.slice(0, 8)} are green ` +
+    `(${skippedFlakyUI} flaky UI coverage lane(s) excluded from the gate) — proceeding with the release.`,
 );
-log(`release-preflight: ${gated} checks verified green on ${sha}`);
+log(`release-preflight: ${gated} checks verified green on ${sha}; ${skippedFlakyUI} flaky UI lane(s) excluded`);
 process.exit(0);

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,7 +17,17 @@ name: e2e
 #     status check on branch protection — DO NOT rename the AGGREGATOR
 #     job (the check name is pinned to `compose-smoke`; the matrix
 #     children report as `compose-smoke-shard (shard-x)` and are NOT
-#     the gate).
+#     the gate). The slow BFS `shard-crawl` COVERAGE lane is split OUT
+#     of the required roll-up into a SEPARATE informational matrix job
+#     (`compose-smoke-shard-info`): it still runs + reports its own
+#     visible child check, but its result does NOT gate the required
+#     `compose-smoke` (crawl = coverage, not a correctness gate; it is
+#     slow + intermittently flaky — the app-init-race 400 is #115/#934 —
+#     and must not block PR merges). The crawl shard also carries a hard
+#     30-min `timeout-minutes` so a hang fails fast and releases the
+#     `cancel-in-progress: false` concurrency slot instead of riding to
+#     a 2h ceiling. The split + per-shard timeouts live in the
+#     single-source-of-truth .github/scripts/compose-smoke-matrix.mjs.
 #   - `dashboard` — full-stack k3d + cerberus + Grafana + Playwright
 #     smoke, SHARDED across a modest matrix of isolated-k3d-cluster jobs
 #     (dashboard-setup emits the matrix from the single-source-of-truth
@@ -253,7 +263,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
+      # `matrix` = the REQUIRED gating shards (smoke, kiosk). The required
+      # `compose-smoke` aggregator gates ONLY on these.
       matrix: ${{ steps.emit.outputs.matrix }}
+      # `matrix_informational` = the de-gated COVERAGE shards (crawl). These run
+      # + report their own child check but do NOT gate the required aggregate.
+      matrix_informational: ${{ steps.emit.outputs.matrix_informational }}
+      has_informational: ${{ steps.emit.outputs.has_informational }}
     steps:
       - uses: actions/checkout@v6
 
@@ -270,12 +286,15 @@ jobs:
 
       # Emit the strategy.matrix JSON to $GITHUB_OUTPUT. emit re-runs the
       # assertions internally, so even without the verify step above it can
-      # never ship a matrix that silently drops a spec.
+      # never ship a matrix that silently drops a spec. IS_SCHEDULE selects the
+      # FULL (120) vs lean (45) per-shard timeout for the non-crawl shards; the
+      # crawl shard's 30-min cap is constant.
       - id: emit
         name: emit shard matrix
         run: node .github/scripts/compose-smoke-matrix.mjs
         env:
           MODE: emit
+          IS_SCHEDULE: ${{ github.event_name == 'schedule' }}
 
   compose-smoke-shard:
     name: compose-smoke-shard
@@ -297,13 +316,13 @@ jobs:
       # aggregator sees a clean `failure`.
       fail-fast: false
       matrix: ${{ fromJSON(needs.compose-smoke-setup.outputs.matrix) }}
-    # Per-lane AND now per-shard. PR/push run SWEEP_DEPTH=lean (required
-    # fast-feedback gate); the nightly schedule runs SWEEP_DEPTH=full. At full
-    # depth shard-crawl's single BFS test() is the ~50min long pole and needs
-    # the 120 ceiling; PR/push shards stay at 45. Because each shard is its own
-    # job, 45/120 is now per-shard wall-clock — more headroom than the old
-    # shared monolith, not less. See docs/test-strategy.md (interaction sweep).
-    timeout-minutes: ${{ github.event_name == 'schedule' && 120 || 45 }}
+    # Per-shard wall-clock ceiling, computed in compose-smoke-matrix.mjs and
+    # carried on each matrix entry. Non-crawl shards take 120 (nightly full) /
+    # 45 (PR/push lean); the crawl shard (now in the SEPARATE informational
+    # matrix below) carries a hard 30-min cap. Keeping the value in the manifest
+    # — the single source of truth for the partition — means the timeout policy
+    # can't drift from the shard it applies to.
+    timeout-minutes: ${{ matrix.timeoutMinutes }}
     concurrency:
       # Per-shard-keyed: sibling shards in the SAME run must not cancel each
       # other (a shared group + cancel-in-progress would do exactly that), but
@@ -449,12 +468,145 @@ jobs:
         if: always()
         run: docker compose down -v --remove-orphans
 
+  # ---------------------------------------------------------------------------
+  # compose-smoke-shard-info — the INFORMATIONAL (coverage) shard matrix. Today
+  # this is the `shard-crawl` BFS coverage lane, de-gated from the required
+  # `compose-smoke` aggregate (see GATE_EXCLUDED_SHARDS in
+  # compose-smoke-matrix.mjs). It is byte-for-byte the same job as
+  # compose-smoke-shard — same stack boot, same Playwright run, same evidence
+  # dumps — but it consumes the SEPARATE `matrix_informational` output and the
+  # required `compose-smoke` aggregator does NOT `needs:` it. So the crawl shard
+  # STILL RUNS and STILL REPORTS its own visible child check
+  # (`compose-smoke-shard-info (shard-crawl)`) — NOT masked with
+  # continue-on-error — but a crawl flake/hang no longer fails the required
+  # `compose-smoke` status, so it can't block a PR merge.
+  #
+  # Why split the matrix instead of filtering results: a GitHub matrix exposes
+  # only ONE rolled-up `.result` to dependents, so a single matrix can't let one
+  # child fail without failing the whole roll-up. Both matrices derive from the
+  # SAME SHARDS + GATE_EXCLUDED_SHARDS list in the manifest, so the required and
+  # informational sets can't drift apart.
+  #
+  # Rationale for de-gating crawl: it is slow BFS COVERAGE, not a correctness
+  # gate; it is slow + flaky by nature (~6min compose / ~50min k3d at full
+  # depth; the app-init-race 400 is #115 / #934), and intermittently runs out to
+  # its timeout holding the cancel-in-progress:false concurrency slot. The hard
+  # 30-min per-shard cap (matrix.timeoutMinutes) makes a hang fail fast.
+  compose-smoke-shard-info:
+    name: compose-smoke-shard-info
+    needs: [changes, gate, compose-smoke-setup]
+    # Same trigger guard as compose-smoke-shard, plus: only fan out when setup
+    # actually emitted an informational matrix (has_informational == true).
+    if: |
+      always() &&
+      needs.compose-smoke-setup.result == 'success' &&
+      needs.compose-smoke-setup.outputs.has_informational == 'true' &&
+      (github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'schedule') &&
+      (github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true') &&
+      (github.event_name != 'pull_request' || needs.gate.result == 'success')
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.compose-smoke-setup.outputs.matrix_informational) }}
+    # Hard 30-min cap (CRAWL_SHARD_TIMEOUT_MIN in the manifest) — fail fast
+    # instead of riding to a 2h hang holding the concurrency slot.
+    timeout-minutes: ${{ matrix.timeoutMinutes }}
+    concurrency:
+      group: compose-smoke-info-${{ github.ref }}-${{ matrix.name }}
+      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Log in to Docker Hub
+        if: ${{ env.DOCKERHUB_TOKEN_SET == 'true' }}
+        env:
+          DOCKERHUB_TOKEN_SET: ${{ secrets.DOCKERHUB_TOKEN != '' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: docker compose up --wait
+        run: docker compose up --wait --wait-timeout 300
+
+      - name: smoke cerberus /healthz + /readyz
+        run: |
+          curl -fsS --max-time 5 http://localhost:8080/healthz
+          curl -fsS --max-time 5 http://localhost:8080/readyz
+
+      - name: smoke Grafana /api/health
+        run: |
+          curl -fsS --max-time 5 http://localhost:3000/api/health \
+            | tee /tmp/grafana-health.json
+          grep -q '"database":[[:space:]]*"ok"' /tmp/grafana-health.json
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: install Playwright deps
+        working-directory: test/e2e/playwright
+        run: |
+          if [ -f package-lock.json ]; then
+            npm ci
+          else
+            npm install --no-audit --no-fund
+          fi
+          npx playwright install --with-deps chromium
+
+      - name: playwright compose-grafana-smoke (${{ matrix.name }})
+        id: playwright_smoke
+        working-directory: test/e2e/playwright
+        env:
+          GRAFANA_BASE_URL: http://localhost:3000
+          GRAFANA_URL: http://localhost:3000
+          CERBERUS_URL: http://localhost:8080
+          SWEEP_DEPTH: ${{ github.event_name == 'schedule' && 'full' || 'lean' }}
+          CRAWL_STACK: compose
+        run: npx playwright test ${{ matrix.specs }} --reporter=list
+
+      - name: upload Playwright report on failure
+        if: steps.playwright_smoke.outcome == 'failure'
+        uses: actions/upload-artifact@v7
+        with:
+          name: compose-grafana-smoke-report-${{ matrix.name }}
+          path: |
+            test/e2e/playwright/playwright-report
+            test/e2e/playwright/test-results
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: dump compose state + logs on failure
+        if: failure() || steps.playwright_smoke.outcome == 'failure'
+        run: |
+          echo "=== compose ps ==="
+          docker compose ps
+          echo "=== clickhouse logs (last 200) ==="
+          docker compose logs --tail=200 clickhouse || true
+          echo "=== cerberus logs (last 200) ==="
+          docker compose logs --tail=200 cerberus || true
+          echo "=== grafana logs (last 200) ==="
+          docker compose logs --tail=200 grafana || true
+          echo "=== otel-collector logs (last 200) ==="
+          docker compose logs --tail=200 otel-collector || true
+
+      - name: teardown
+        if: always()
+        run: docker compose down -v --remove-orphans
+
   # The AGGREGATOR — named EXACTLY `compose-smoke` so the required
   # branch-protection status-check context still appears and gates. The matrix
   # children report as `compose-smoke-shard (shard-x)`, NOT `compose-smoke`;
   # branch protection waits on `compose-smoke` specifically, so this job MUST
   # exist and report green/red. DO NOT add the setup/shard job names to branch
   # protection — only this aggregator is the gate.
+  #
+  # Crawl de-gate: this aggregator `needs:` ONLY compose-smoke-shard (the
+  # REQUIRED matrix), NOT compose-smoke-shard-info (the crawl coverage matrix).
+  # So a crawl flake/hang reports its own red `compose-smoke-shard-info
+  # (shard-crawl)` check but does NOT roll into this required gate.
   compose-smoke:
     name: compose-smoke
     needs: [changes, gate, compose-smoke-setup, compose-smoke-shard]
@@ -465,7 +617,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: gate on every shard
+      - name: gate on every required shard
         run: |
           echo "setup  = ${{ needs.compose-smoke-setup.result }}"
           echo "shards = ${{ needs.compose-smoke-shard.result }}"
@@ -477,23 +629,25 @@ jobs:
             echo "compose-smoke skipped (docs-only PR / gate not green / not applicable) — passing the required check."
             exit 0
           fi
-          # Otherwise setup must have succeeded and the matrix must be a clean
-          # success. A matrix exposes ONE rolled-up .result to dependents:
+          # Otherwise setup must have succeeded and the REQUIRED matrix must be a
+          # clean success. A matrix exposes ONE rolled-up .result to dependents:
           # `success` only if EVERY child succeeded; `failure` if any failed;
           # `cancelled` if any was cancelled. The strict `!= 'success'` form
           # catches failure AND cancelled AND skipped — `contains(…,'failure')`
           # would miss `cancelled`, letting a cancelled shard set pass the
           # required check silently. fail-fast:false keeps a real spec failure
-          # a clean `failure`, not an ambiguous `cancelled`.
+          # a clean `failure`, not an ambiguous `cancelled`. NOTE: the crawl
+          # coverage shard lives in compose-smoke-shard-info, NOT this need set,
+          # so a crawl flake/hang can't fail this required gate.
           if [ "${{ needs.compose-smoke-setup.result }}" != "success" ]; then
             echo "::error::compose-smoke-setup did not succeed (${{ needs.compose-smoke-setup.result }})."
             exit 1
           fi
           if [ "${{ needs.compose-smoke-shard.result }}" != "success" ]; then
-            echo "::error::one or more compose-smoke shards failed/cancelled (rolled-up: ${{ needs.compose-smoke-shard.result }})."
+            echo "::error::one or more REQUIRED compose-smoke shards failed/cancelled (rolled-up: ${{ needs.compose-smoke-shard.result }})."
             exit 1
           fi
-          echo "all compose-smoke shards passed."
+          echo "all required compose-smoke shards passed (crawl coverage shard is informational, de-gated)."
 
   # ---------------------------------------------------------------------------
   # dashboard (k3d) lane — SHARDED across a modest matrix of isolated k3d
@@ -597,12 +751,14 @@ jobs:
       # sees a clean failure rather than an ambiguous cancelled.
       fail-fast: false
       matrix: ${{ fromJSON(needs.dashboard-setup.outputs.matrix) }}
-    # 40 to match the old monolith. Per-shard now: the crawl shard's single BFS
-    # test() is the ~50min long pole at SWEEP_DEPTH=full and needs the headroom;
-    # because it runs ALONE on its own cluster, the smoke shards no longer wait
-    # behind it. The crawl shard's own internal testInfo.setTimeout (75min in
-    # crawl.spec.ts) governs the BFS; this job cap is the cluster-lifetime bound.
-    timeout-minutes: 75
+    # Per-shard wall-clock ceiling, computed in dashboard-matrix.mjs and carried
+    # on each matrix entry. Smoke shards keep the prior 75-min cluster-lifetime
+    # bound; the crawl shard gets a HARD 30-min cap (CRAWL_SHARD_TIMEOUT_MIN) so a
+    # hung BFS fails fast and releases the cancel-in-progress:false k3d slot
+    # instead of riding to the long ceiling. The k3d crawl is informational
+    # COVERAGE (the whole dashboard lane is non-gating), so a 30-min cut never
+    # blocks a merge or a release.
+    timeout-minutes: ${{ matrix.timeoutMinutes }}
     concurrency:
       # Per-shard-keyed: sibling shards in the SAME run must not cancel each
       # other; never cancel-in-progress (a half-killed k3d teardown leaks


### PR DESCRIPTION
## Why

The BFS `crawl` lane is **coverage, not a correctness gate**. It is slow (~6 min on the compose stack, ~50 min on k3d), intermittently flaky (the app-init-race 400, separately fixed in #934's oracle — #115), and on a hang rides to its long timeout holding the `cancel-in-progress: false` concurrency slot. Today a crawl flake/hang blocks **every PR** (it rolls up into the required `compose-smoke` aggregate) and **every release** (the preflight gates on every non-scheduled green check). This makes the crawl + the informational `dashboard` UI lane unable to stall merges or releases. Maintainer-approved CI hardening.

## Changes

### 1. Hard 30-min timeout on the crawl shard(s)
Per-shard `timeout-minutes` carried as `matrix.timeoutMinutes` from the matrix manifests (single source of truth), referenced on `compose-smoke-shard`, the new `compose-smoke-shard-info`, and `dashboard-shard`:
- **crawl shard = 30 min** (named `CRAWL_SHARD_TIMEOUT_MIN`) — fail fast, release the concurrency slot instead of riding to a 2h ceiling.
- non-crawl compose shards keep **45 (PR/push lean) / 120 (nightly full)** via `IS_SCHEDULE`; dashboard smoke shards keep their prior effective **75**.

### 2. Crawl OUT of the required `compose-smoke` gate
`compose-smoke-matrix.mjs` now splits its partition into a **required `matrix`** (smoke + kiosk) and an **informational `matrix_informational`** (the `GATE_EXCLUDED_SHARDS` = `shard-crawl`). A new `compose-smoke-shard-info` job runs the informational matrix; the required `compose-smoke` aggregator `needs:` **only** the required matrix. The crawl shard still **runs and reports its own visible `compose-smoke-shard-info (shard-crawl)` check** — *not* masked with `continue-on-error` — but its result no longer fails the required PR gate. Both matrices derive from the same `SHARDS` + `GATE_EXCLUDED_SHARDS`, so they can't drift.

> Why split the matrix rather than filter results: a GitHub matrix exposes only ONE rolled-up `.result` to dependents, so a single matrix can't let one child fail without failing the whole roll-up. The structural split is the clean de-gate.

The required gate keeps the real correctness shards (smoke, kiosk). The light companion specs that happened to share the crawl shard (`crawl/dsquery`, `crawl/lints`, `iterate-panel-shape`) — only the heavy indivisible `crawl/crawl.spec.ts` BFS is the long pole; the de-gate moves the whole `shard-crawl` partition, and `dsquery` is independently still gated on `shard-kiosk`.

### 3. Release preflight excludes the flaky UI lanes
`release-preflight.mjs` drops check-runs matching `FLAKY_UI_LANE_RE` — the crawl shards (`(shard-crawl…`) and the whole informational k3d `dashboard` lane (`dashboard` / `dashboard-setup` / `dashboard-shard (…)`) — from the release gate. Keeps gating every substantive lane (ci/check, lint, compat ×3, compose-smoke [now crawl-independent], probe, roundtrip ×3, chdb, mutation/gremlins, property, perf-profile, coverage, CodeQL). Anchored/specific regex, **fails SAFE** on ambiguous names; the existing scheduled-exclusion behavior is preserved.

## Verification
- `compose-smoke-matrix` / `dashboard-matrix` `verify` + `node --test` guards green.
- Emit inspected: required compose matrix = `[shard-kiosk, shard-smoke]` (timeout 45 PR / 120 schedule); informational = `[shard-crawl]` (timeout 30). dashboard crawl shard = timeout 30, smoke shards = 75.
- `release-preflight.mjs` against `origin/main` HEAD: exit 0, **35 substantive checks gated, 5 flaky UI lanes excluded** (compose `shard-crawl` + `dashboard` / `dashboard-setup` / `dashboard-shard ×2`). Regex unit-checked against the real matrix-child name format `(shard-crawl, <specs>)`.

Docs: `.github/scripts/README.md` (preflight + both matrix entries) + the `e2e.yml` header comment updated.

> Note: this touches `.github/workflows/`; if the token lacks `workflow` scope, auto-merge enablement isn't attempted — opening for review/merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)