### PR TITLE
fix(chclient): active background recovery probe so a traffic-starved breaker self-heals

### DIFF
--- a/internal/chclient/breaker_recovery.go
+++ b/internal/chclient/breaker_recovery.go
@@ -1,0 +1,184 @@
+package chclient
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+)
+
+// Active background breaker recovery.
+//
+// The breaker state machine (breaker.go) recovers PASSIVELY: only an inbound
+// request that calls allow() drives the OPEN→HALF-OPEN transition, and the
+// HALF-OPEN probe IS the caller's own CH operation under the caller's own
+// (often short) context. That coupling has one pathological case, hit by the
+// k8s `ch-pod-kill` chaos scenario with ≥2 cerberus replicas behind one
+// ClickHouse:
+//
+//   - CH is killed; both replicas' breakers trip OPEN.
+//   - The replica still in the k8s Service keeps getting query traffic
+//     (10–12s client budgets), so its HALF-OPEN probe completes and it
+//     re-CLOSEs in ~30s.
+//   - The OTHER replica goes /readyz-red, k8s pulls it from the Service, and
+//     its ONLY remaining traffic is k8s readiness pings — which the health
+//     package caps at PingTimeout (default 1s). A recovering clickhouse-go
+//     pool needs up to the dial timeout (~5s) to dial fresh or to fail-and-
+//     evict a stale half-open socket, so every 1s-bounded probe deadline-
+//     exceeds → recorded as a FAILURE → the breaker re-opens → the broken
+//     conn is never drained → the breaker stays OPEN until the pod is
+//     deleted (~5min). That makes the chaos lane flaky.
+//
+// The recovery loop closes that gap. It is a per-root-Client background
+// goroutine that, on a fixed cadence, fires a SYNTHETIC CH ping through any
+// non-CLOSED breaker's existing allow()/record() path under a DEDICATED
+// internal context whose timeout is large enough to complete a fresh dial or
+// evict a stale conn (≥ the CH dial timeout — see recoveryPingTimeout). That
+// makes recovery deterministic and traffic-independent: a Service-pulled
+// replica self-heals on the loop's schedule instead of starving on
+// too-short readiness pings, and the HeadProbe breaker recovers so /readyz
+// flips green and k8s rejoins the pod.
+//
+// It deliberately reuses the EXISTING state machine — allow() admits the
+// probe slot (returning false, and the loop skipping, if a REAL request
+// already holds it, so there is never a double-probe), and record() drives
+// the HALF-OPEN→CLOSED (success) or HALF-OPEN→OPEN (failure) edge. The loop
+// adds no second state machine; it is purely a traffic source for the one
+// that already exists.
+
+// recoveryPinger is the narrow slice of driver.Conn the recovery loop needs:
+// a single Ping. Narrowing it (rather than holding the whole driver.Conn)
+// keeps the loop's contract minimal and makes the unit tests' fake trivial.
+type recoveryPinger interface {
+	Ping(ctx context.Context) error
+}
+
+// recoveryLoop is the lifecycle handle for one Client's background
+// breaker-recovery goroutine. It is created and started exactly once, by New,
+// on the root Client; ForHead views share the pointer but never start a
+// second loop. stop() is idempotent and joins the goroutine so Close is
+// goleak-clean.
+type recoveryLoop struct {
+	stopOnce sync.Once
+	stopCh   chan struct{} // closed by stop() to signal the goroutine to exit
+	doneCh   chan struct{} // closed by the goroutine just before it returns
+}
+
+// recoveryPingTimeout is the per-tick synthetic-ping budget. It MUST be at
+// least the CH dial timeout so a fresh dial (or the read that fails+evicts a
+// stale half-open socket) can complete inside one probe instead of deadline-
+// exceeding and being miscounted as a CH-health failure — the exact bug that
+// stranded a traffic-starved replica's breaker OPEN. We size it to the dial
+// timeout verbatim: that is the smallest budget that always clears a fresh
+// dial, and a probe that needs longer than a full dial is itself evidence CH
+// is still unhealthy (a correct FAILURE verdict, not a premature one).
+func recoveryPingTimeout(cfg Config) time.Duration {
+	return resolveDialTimeout(cfg)
+}
+
+// startRecoveryLoop builds the recovery handle and launches its goroutine,
+// returning the handle so the root Client can store it (and join it in
+// Close). interval is the tick cadence — the same OPEN-state backoff the
+// breaker itself would admit a probe on, so the loop never probes faster than
+// the breaker's own recovery rhythm. pingTimeout is the per-probe budget
+// (recoveryPingTimeout). The breakers slice is every breaker the loop drives:
+// the default plus every per-head registry entry.
+func startRecoveryLoop(
+	conn recoveryPinger,
+	breakers []*breaker,
+	interval, pingTimeout time.Duration,
+) *recoveryLoop {
+	r := &recoveryLoop{
+		stopCh: make(chan struct{}),
+		doneCh: make(chan struct{}),
+	}
+	go r.run(conn, breakers, interval, pingTimeout)
+	return r
+}
+
+// run is the goroutine body: a ticker loop that, on each tick, drives every
+// non-CLOSED breaker toward recovery via a synthetic ping. It returns (and
+// closes doneCh) as soon as stopCh is signalled.
+func (r *recoveryLoop) run(
+	conn recoveryPinger,
+	breakers []*breaker,
+	interval, pingTimeout time.Duration,
+) {
+	defer close(r.doneCh)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-r.stopCh:
+			return
+		case <-ticker.C:
+			r.probeOnce(conn, breakers, pingTimeout)
+		}
+	}
+}
+
+// probeOnce drives a single recovery pass over every breaker. For each
+// breaker it first peeks (zero CH I/O) and skips any CLOSED breaker — the
+// happy path, where a healthy replica's loop never touches ClickHouse. For a
+// non-CLOSED breaker it tries to take the HALF-OPEN probe slot via allow();
+// if allow() admits (backoff elapsed and no REAL request already holds the
+// slot), it fires the synthetic ping under a fresh dedicated-timeout context
+// and feeds the outcome to record(), which either closes the circuit
+// (success) or re-opens it and restarts the backoff (failure). If allow()
+// declines — a real request is mid-probe, or the backoff hasn't elapsed — the
+// loop skips, so it never races or double-probes a real recovery in flight.
+func (r *recoveryLoop) probeOnce(conn recoveryPinger, breakers []*breaker, pingTimeout time.Duration) {
+	for _, br := range breakers {
+		// Cheap read-only gate: a CLOSED breaker needs no recovery, so
+		// skip it WITHOUT touching CH. This is what keeps a healthy
+		// replica's loop a pure no-op — peek() takes only the breaker's
+		// own mutex, never the network.
+		if br.peek() == "closed" {
+			continue
+		}
+		// allow() returns true for a CLOSED breaker too, but peek() above
+		// already skipped those; here a true means the OPEN backoff elapsed
+		// and we hold the single HALF-OPEN probe slot. A false means either
+		// the backoff hasn't elapsed or a REAL request is mid-probe — skip,
+		// so we never double-probe.
+		if !br.allow() {
+			continue
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), pingTimeout)
+		err := conn.Ping(ctx)
+		br.record(ctx, err)
+		cancel()
+	}
+}
+
+// stop signals the goroutine to exit and blocks until it has. It is
+// idempotent — a sync.Once guards the channel close — so a double Close (or a
+// Close on a ForHead view that shares this handle) is safe. The join is what
+// makes Close goleak-clean: by the time stop returns, the recovery goroutine
+// has run its deferred close(doneCh) and exited.
+func (r *recoveryLoop) stop() {
+	r.stopOnce.Do(func() {
+		close(r.stopCh)
+	})
+	<-r.doneCh
+}
+
+// breakerList flattens the default breaker plus every per-head registry entry
+// into the slice the recovery loop iterates. Order is irrelevant — each
+// breaker is probed independently — so it is built once at construction and
+// never mutated, matching the immutable-registry contract buildBreakers
+// already relies on.
+func breakerList(def *breaker, registry map[Head]*breaker) []*breaker {
+	out := make([]*breaker, 0, len(registry)+1)
+	out = append(out, def)
+	for _, br := range registry {
+		out = append(out, br)
+	}
+	return out
+}
+
+// assert at compile time that a real driver.Conn satisfies recoveryPinger —
+// the production conn the root Client hands the loop. Keeps the narrow
+// interface honest against the driver surface.
+var _ recoveryPinger = driver.Conn(nil)

--- a/internal/chclient/breaker_recovery_test.go
+++ b/internal/chclient/breaker_recovery_test.go
@@ -1,0 +1,158 @@
+package chclient
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+)
+
+// Layer 11 — active background breaker-recovery tests.
+//
+// These exercise the recovery loop (breaker_recovery.go) in isolation: the
+// loop must drive an OPEN breaker back to CLOSED with NO external
+// allow()/record() traffic (the traffic-starved-replica fix), must exit
+// cleanly on Close (goleak), and must do ZERO CH I/O while every breaker is
+// CLOSED (the happy-path no-op).
+
+// recoveryFakeConn is a minimal recoveryPinger whose Ping fails the first
+// failFirst calls and then succeeds — modelling a ClickHouse that comes back
+// after the breaker has tripped. pingCount records every Ping so a test can
+// assert "the loop pinged N times" or "the loop never pinged at all".
+type recoveryFakeConn struct {
+	failFirst int64
+	pingCount atomic.Int64
+}
+
+func (c *recoveryFakeConn) Ping(context.Context) error {
+	n := c.pingCount.Add(1)
+	if n <= c.failFirst {
+		return errors.New("recoveryFakeConn: simulated CH outage")
+	}
+	return nil
+}
+
+// newRecoveryTestClient builds a Client over conn whose background recovery
+// loop runs at the supplied (short) interval and per-probe budget, so a test
+// can observe recovery in bounded wall-clock without waiting the production 5s
+// cadence. The per-head breakers are built with the SAME short interval as
+// their OPEN-state backoff so a tripped breaker becomes probe-eligible
+// immediately — otherwise allow() would gate the loop on the production 5s
+// default. It mirrors what New does for the loop while skipping the live CH
+// driver. The caller MUST Close the returned Client — that is what stops +
+// joins the goroutine the goleak test asserts on.
+func newRecoveryTestClient(conn recoveryPinger, interval, pingTimeout time.Duration) *Client {
+	// window=0 keeps the default rolling failure window; openInterval=interval
+	// makes the OPEN backoff elapse on the same tiny cadence the loop ticks at.
+	def, registry := buildBreakers(false, 0, 0, interval, nil)
+	c := &Client{br: def, breakers: registry}
+	c.recovery = startRecoveryLoop(conn, breakerList(def, registry), interval, pingTimeout)
+	return c
+}
+
+// tripBreaker drives br to OPEN by recording threshold consecutive failures —
+// the same path a burst of failing requests would take, but invoked directly
+// so the test sets up the precondition without any request traffic.
+func tripBreaker(br *breaker) {
+	failErr := errors.New("trip")
+	for i := 0; i < br.resolveThreshold(); i++ {
+		br.record(context.Background(), failErr)
+	}
+}
+
+// TestRecoveryLoop_DrivesOpenToClosed — the background loop alone, with NO
+// external allow()/record() calls, must drive a tripped breaker back to
+// CLOSED once the fake conn starts answering Ping. This is the
+// traffic-starved-replica fix: recovery happens on the loop's schedule, not on
+// inbound request traffic.
+func TestRecoveryLoop_DrivesOpenToClosed(t *testing.T) {
+	t.Parallel()
+
+	const (
+		interval     = 5 * time.Millisecond
+		pingTimeout  = 100 * time.Millisecond
+		failFirstTwo = 2
+	)
+	conn := &recoveryFakeConn{failFirst: failFirstTwo}
+	client := newRecoveryTestClient(conn, interval, pingTimeout)
+	t.Cleanup(func() { _ = client.Close() })
+
+	// Trip the default breaker OPEN with no request traffic.
+	tripBreaker(client.br)
+	require.Equal(t, "open", client.br.currentState(),
+		"precondition: breaker must be OPEN before the loop runs")
+
+	// The loop's first probes fail (conn answers an error failFirst times),
+	// re-opening the breaker each time; once the conn starts succeeding the
+	// next probe closes the circuit. Assert it reaches CLOSED within a
+	// bounded wall-clock — the interval is tiny so this resolves fast.
+	require.Eventually(t, func() bool {
+		return client.br.currentState() == "closed"
+	}, 2*time.Second, interval,
+		"recovery loop did not drive the breaker OPEN→CLOSED")
+
+	// And the conn was actually pinged more than once (failed probes + the
+	// closing one) — proof recovery came from the loop, not from any caller.
+	require.Greater(t, conn.pingCount.Load(), int64(1),
+		"loop should have fired multiple recovery pings")
+}
+
+// TestRecoveryLoop_CloseStopsGoroutine — Close must stop + join the recovery
+// goroutine so nothing leaks. goleak.VerifyNone after Close fails if the
+// goroutine is still parked on its ticker.
+func TestRecoveryLoop_CloseStopsGoroutine(t *testing.T) {
+	// Not parallel: goleak inspects the whole-process goroutine set, so it
+	// must not race sibling tests' goroutines. IgnoreCurrent snapshots the
+	// pre-existing (test-framework / runtime) goroutines so only ours count.
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	const (
+		interval    = time.Millisecond
+		pingTimeout = 50 * time.Millisecond
+	)
+	conn := &recoveryFakeConn{}
+	client := newRecoveryTestClient(conn, interval, pingTimeout)
+
+	// Let the loop spin at least once so the goroutine is provably live, then
+	// Close and assert it is gone.
+	time.Sleep(5 * time.Millisecond)
+	require.NoError(t, client.Close())
+
+	// Close is idempotent + view-safe: a second Close (e.g. via a ForHead
+	// view sharing the handle) must not panic on a re-closed stop channel.
+	require.NoError(t, client.Close())
+}
+
+// TestRecoveryLoop_ClosedBreakerNoPing — while every breaker is CLOSED the
+// loop must do ZERO CH I/O: the peek() gate short-circuits before any Ping, so
+// a healthy replica's recovery loop is a pure no-op.
+func TestRecoveryLoop_ClosedBreakerNoPing(t *testing.T) {
+	t.Parallel()
+
+	const (
+		interval    = time.Millisecond
+		pingTimeout = 50 * time.Millisecond
+	)
+	conn := &recoveryFakeConn{}
+	client := newRecoveryTestClient(conn, interval, pingTimeout)
+	t.Cleanup(func() { _ = client.Close() })
+
+	// All breakers start CLOSED. Give the loop many tick windows to run.
+	time.Sleep(50 * time.Millisecond)
+
+	require.Equal(t, int64(0), conn.pingCount.Load(),
+		"loop pinged CH while all breakers were CLOSED — peek() gate failed")
+}
+
+// TestRecoveryLoop_PingerIsConnSubset — compile-proof that the production
+// driver.Conn satisfies the narrow recoveryPinger the loop holds, so New can
+// hand its real conn to startRecoveryLoop unchanged.
+func TestRecoveryLoop_PingerIsConnSubset(t *testing.T) {
+	t.Parallel()
+	var _ recoveryPinger = driver.Conn(nil)
+}

--- a/internal/chclient/client.go
+++ b/internal/chclient/client.go
@@ -49,6 +49,25 @@ var (
 // abstraction layer.
 const peerServiceClickHouse = "clickhouse"
 
+// defaultDialTimeout is the fallback connection-dial budget applied when
+// Config.DialTimeout is left zero. It mirrors clickhouse-go's own implicit
+// 5s default and is named here so both buildOptions (the driver option) and
+// resolveDialTimeout (the breaker recovery-ping budget) read the same value —
+// the recovery ping MUST be allowed at least one full fresh dial.
+const defaultDialTimeout = 5 * time.Second
+
+// resolveDialTimeout returns the effective connection-dial budget for cfg:
+// the operator-set Config.DialTimeout, or defaultDialTimeout when unset. It
+// is the single source of truth for the dial ceiling — buildOptions hands it
+// to the driver, and the breaker recovery loop sizes its synthetic-ping
+// timeout off it (see recoveryPingTimeout).
+func resolveDialTimeout(cfg Config) time.Duration {
+	if cfg.DialTimeout > 0 {
+		return cfg.DialTimeout
+	}
+	return defaultDialTimeout
+}
+
 // startExecuteSpan opens an `execute` span carrying the standard
 // db.system + db.statement semantic-conventions attributes plus the
 // cerberus.sql_length counter. The span is opened as SpanKindClient
@@ -374,6 +393,17 @@ type Client struct {
 	// every data-plane query via queryContext (overridable per-request,
 	// min'd, via WithQueryTimeout). 0 = setting not sent.
 	queryTimeout time.Duration
+
+	// recovery owns the background breaker-recovery goroutine (see
+	// recoveryLoop). It is non-nil ONLY on the root Client that New created
+	// and started the loop on; the lightweight ForHead views are shallow
+	// copies that SHARE this pointer but never start a second loop — the one
+	// loop already drives every per-head breaker in the shared registry. A
+	// nil pointer (the test-only newWithConn seam, or a bare struct literal)
+	// means "no background recovery" and Close skips the join. Sharing the
+	// pointer also makes Close idempotent + view-safe: whichever Client calls
+	// Close first stops the single loop exactly once via recovery.stop.
+	recovery *recoveryLoop
 }
 
 // buildBreakers constructs the per-head breaker registry shared by all of a
@@ -513,10 +543,7 @@ func New(cfg Config) (*Client, error) {
 // is unit-testable without a live ClickHouse (clickhouse.Open is lazy and
 // never dials, but it also doesn't expose the resolved Options back to us).
 func buildOptions(cfg Config) *clickhouse.Options {
-	dial := cfg.DialTimeout
-	if dial == 0 {
-		dial = 5 * time.Second
-	}
+	dial := resolveDialTimeout(cfg)
 	// Addrs (multi-host) is authoritative when present; otherwise dial the
 	// single scalar Addr — byte-unchanged from before the multi-host knob.
 	addrs := cfg.Addrs
@@ -655,7 +682,7 @@ func assembleClientFromConn(cfg Config, conn driver.Conn) *Client {
 		cfg.BreakerOpenInterval,
 		newGlobalBreakerMetrics(),
 	)
-	return &Client{
+	c := &Client{
 		conn:         conn,
 		addr:         cfg.Addr,
 		br:           def,
@@ -664,6 +691,22 @@ func assembleClientFromConn(cfg Config, conn driver.Conn) *Client {
 		maxMemory:    cfg.MaxQueryMemoryBytes,
 		queryTimeout: cfg.QueryTimeout,
 	}
+	// Start the active background breaker-recovery loop on the ROOT Client
+	// (ForHead views are shallow copies that share — never restart — it).
+	// The tick cadence is the breaker's own resolved OPEN-state backoff, so
+	// the loop probes at exactly the rhythm the breaker would admit a probe
+	// on; the per-probe budget is recoveryPingTimeout (≥ the dial timeout) so
+	// a synthetic ping can complete a fresh dial or evict a stale conn
+	// instead of deadline-exceeding under a too-short caller ctx. See
+	// breaker_recovery.go for the full rationale (traffic-starved replica
+	// stuck OPEN ~5min in the ch-pod-kill chaos scenario).
+	c.recovery = startRecoveryLoop(
+		conn,
+		breakerList(def, registry),
+		def.resolveOpenInterval(),
+		recoveryPingTimeout(cfg),
+	)
+	return c
 }
 
 // querySettings returns the per-query ClickHouse settings map applied
@@ -756,6 +799,14 @@ func (c *Client) Conn() driver.Conn {
 // option validation. This constructor bypasses it — it is unexported and
 // intentionally narrow.
 //
+// It deliberately does NOT start the background breaker-recovery loop: the
+// chaos / failure-mode tests drive recovery synchronously via an injected
+// clock (newBreakerTestClient) plus real request traffic, and most of them
+// never call Close — starting a goroutine here would leak it. The recovery
+// loop itself is exercised by its own dedicated constructor
+// (newRecoveryTestClient) whose tests always Close. c.recovery stays nil, so
+// Close on a newWithConn Client is a plain conn.Close.
+//
 //nolint:revive // test-only seam; production code must use New.
 func newWithConn(conn driver.Conn) *Client {
 	// Route through buildBreakers so the test seam gets the SAME per-head
@@ -767,8 +818,20 @@ func newWithConn(conn driver.Conn) *Client {
 	return &Client{conn: conn, br: def, breakers: registry}
 }
 
-// Close releases all pooled connections.
+// Close stops the background breaker-recovery goroutine (joining it so the
+// shutdown is goleak-clean) and then releases all pooled connections. The two
+// steps are ordered: the recovery loop pings through c.conn, so the conn must
+// stay open until the loop has provably exited.
+//
+// It is idempotent and view-safe. c.recovery is non-nil only on the root
+// Client New started the loop on; its stop() is sync.Once-guarded, so a
+// double Close — or a Close on a shared-pointer ForHead view — stops the
+// single loop exactly once and joins without panicking. A nil c.recovery (the
+// test-only newWithConn seam, or a bare struct literal) has no loop to stop.
 func (c *Client) Close() error {
+	if c.recovery != nil {
+		c.recovery.stop()
+	}
 	if c.conn == nil {
 		return nil
 	}


### PR DESCRIPTION
## Root cause

The CH circuit breaker in `internal/chclient/breaker.go` recovered **passively**: only an inbound request calling `allow()` drove the `OPEN→HALF-OPEN` transition, and the single HALF-OPEN probe was the **caller's own** CH operation, under the caller's own (often short) context.

In the k8s `ch-pod-kill` chaos scenario there are ≥2 cerberus replicas sharing one ClickHouse. On a CH kill both replicas' breakers trip OPEN. Then:

- The replica still in the k8s **Service** keeps getting query traffic (10–12s client budgets) → its HALF-OPEN probe completes → it re-CLOSEs in ~30s.
- The **other** replica goes `/readyz`-red, so k8s pulls it from the Service. Its *only* remaining traffic is k8s readiness pings, and `internal/api/health` `runCheck` caps each CH ping at `PingTimeout` (default **1s**). A recovering clickhouse-go pool needs up to the dial timeout (~5s) to dial fresh or to fail-and-evict a stale half-open socket, so every 1s-bounded probe **deadline-exceeds → recorded as a FAILURE → breaker re-opens → the broken conn is never drained**. The breaker stays OPEN for ~5 minutes, until the pod is deleted.

That is the chaos-lane flake.

## Fix: active background recovery probe

A per-root-`Client` background goroutine (the *breaker recovery loop*) drives any OPEN breaker's `HALF-OPEN→CLOSED` transition by firing a **synthetic CH ping** through that breaker's existing `allow()`/`record()` path, using a **dedicated** internal context whose timeout is `≥` the CH dial timeout. Recovery becomes deterministic and traffic-independent — independent of any too-short caller ctx.

Key properties:

- **Reuses the existing state machine** — no second one. `peek()` skips CLOSED breakers with **zero CH I/O** (the healthy-replica happy path is a pure no-op). `allow()` yields (returns false → loop skips) if a *real* request already holds the HALF-OPEN slot, so there is **never a double-probe**. `record()` drives the close / re-open edge exactly as before.
- **`/readyz` HeadProbe breaker now recovers via the background ping**, so a Service-pulled replica self-heals and rejoins the Service without needing inbound traffic it can no longer receive.
- **Cadence (`interval`)** = the breaker's resolved OPEN-state backoff (`def.resolveOpenInterval()`, default 5s) — the loop never probes faster than the breaker's own recovery rhythm.
- **Per-probe budget (`pingTimeout`)** = the resolved CH dial timeout (`resolveDialTimeout(cfg)`, default 5s, named const `defaultDialTimeout`) — the smallest budget that always clears a fresh dial; a probe needing longer is genuine evidence CH is still unhealthy (a correct FAILURE, not a premature one). No inline magic literals.
- **`Close()`** stops + joins the goroutine (goleak-clean), is idempotent (`sync.Once`), and view-safe: `ForHead` views share the handle and never start a second loop; only the root Client New started owns it. The test-only `newWithConn` seam deliberately does **not** start the loop (those tests drive recovery via an injected clock and never Close), so it stays leak-free.

## Tests (`internal/chclient/breaker_recovery_test.go`)

- `TestRecoveryLoop_DrivesOpenToClosed` — the loop alone, with no external `allow()`/`record()` traffic, drives a tripped breaker `OPEN→CLOSED` once the fake conn starts answering Ping.
- `TestRecoveryLoop_CloseStopsGoroutine` — `goleak.VerifyNone` after Close; also asserts a double Close is panic-free.
- `TestRecoveryLoop_ClosedBreakerNoPing` — zero `conn.Ping` calls while every breaker is CLOSED (the `peek()` happy-path gate).

## Validation

The chaos lane is **informational** (runs on push-to-main + workflow_dispatch, not a PR gate), so end-to-end validation lands post-merge or via manual `workflow_dispatch`. Locally: `go build ./...` green, `go test ./internal/chclient/... -race` green (155 + 4 new), `cmd/cerberus` + goleak regression green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)