### PR TITLE
fix(e2e): gate telemetrygen on otel-collector-gateway readiness (#82)

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -407,7 +407,7 @@ CERBERUS_BUILD_TAGS := env_var_or_default("CERBERUS_BUILD_TAGS", "")
 # MUST stay in lock-step with the image pins in test/e2e/k3s/*.yaml —
 # a stale entry here means the pod pulls straight from the registry at
 # start-up (no pre-pull, no import, full Docker-Hub-flake exposure).
-E2E_EXTERNAL_IMAGES := "clickhouse/clickhouse-server:25.8-alpine ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.116.0 grafana/grafana:12.2.9 otel/opentelemetry-collector-contrib:0.152.1"
+E2E_EXTERNAL_IMAGES := "clickhouse/clickhouse-server:25.8-alpine ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.116.0 grafana/grafana:12.2.9 otel/opentelemetry-collector-contrib:0.152.1 busybox:1.37"
 
 # Extra args appended verbatim to `k3d cluster create` in `e2e-up`. Empty by
 # default (CI uses none). Interpolated unquoted, so the value is shell-parsed:

--- a/test/e2e/k3s/sample-app.yaml
+++ b/test/e2e/k3s/sample-app.yaml
@@ -27,6 +27,17 @@ spec:
         app: sample-app
         signal: traces
     spec:
+      # Gate telemetrygen on gateway readiness. telemetrygen FATALs (and the
+      # pod CrashLoopBackOffs) if it dials otel-collector-gateway:4317 before
+      # the gateway is accepting OTLP — a pure startup-ordering race. Block
+      # until the gateway's gRPC port is up so start-up is deterministic.
+      initContainers:
+        - name: wait-for-otel-gateway
+          image: busybox:1.37
+          command:
+            - sh
+            - -c
+            - 'until nc -z otel-collector-gateway 4317; do echo "waiting for otel-collector-gateway:4317"; sleep 1; done'
       containers:
         - name: telemetrygen
           image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.116.0
@@ -67,6 +78,17 @@ spec:
         app: sample-app
         signal: metrics
     spec:
+      # Gate telemetrygen on gateway readiness. telemetrygen FATALs (and the
+      # pod CrashLoopBackOffs) if it dials otel-collector-gateway:4317 before
+      # the gateway is accepting OTLP — a pure startup-ordering race. Block
+      # until the gateway's gRPC port is up so start-up is deterministic.
+      initContainers:
+        - name: wait-for-otel-gateway
+          image: busybox:1.37
+          command:
+            - sh
+            - -c
+            - 'until nc -z otel-collector-gateway 4317; do echo "waiting for otel-collector-gateway:4317"; sleep 1; done'
       containers:
         - name: telemetrygen
           image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.116.0
@@ -110,6 +132,17 @@ spec:
         app: sample-app
         signal: logs
     spec:
+      # Gate telemetrygen on gateway readiness. telemetrygen FATALs (and the
+      # pod CrashLoopBackOffs) if it dials otel-collector-gateway:4317 before
+      # the gateway is accepting OTLP — a pure startup-ordering race. Block
+      # until the gateway's gRPC port is up so start-up is deterministic.
+      initContainers:
+        - name: wait-for-otel-gateway
+          image: busybox:1.37
+          command:
+            - sh
+            - -c
+            - 'until nc -z otel-collector-gateway 4317; do echo "waiting for otel-collector-gateway:4317"; sleep 1; done'
       containers:
         - name: telemetrygen
           image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.116.0


### PR DESCRIPTION
## The flake (#82)

In the k3d `dashboard` e2e lane, the `telemetrygen` sample-app containers
start before `otel-collector-gateway` is ready to accept OTLP on port 4317.
telemetrygen dials `otel-collector-gateway:4317`, gets `connection refused`,
and FATALs:

```
FATAL metrics/worker.go:99 exporter failed: failed to upload metrics:
  context deadline exceeded: dial tcp <gw-ip>:4317: connect: connection refused
Warning BackOff: Back-off restarting failed container telemetrygen ...
```

The pod then CrashLoopBackOffs. If the dashboard test asserts during that
window, the (informational) `dashboard` job goes red. It is a pure
startup-ordering race — intermittent and substrate-timing dependent.

## The fix

Gate telemetrygen start on gateway readiness with an `initContainer`.
Each of the three sample-app Deployments (`sample-app-traces` /
`sample-app-metrics` / `sample-app-logs`) gets a `wait-for-otel-gateway`
initContainer that blocks until `otel-collector-gateway:4317` accepts TCP:

```yaml
initContainers:
  - name: wait-for-otel-gateway
    image: busybox:1.37
    command:
      - sh
      - -c
      - 'until nc -z otel-collector-gateway 4317; do echo "waiting for otel-collector-gateway:4317"; sleep 1; done'
```

The wait target (`otel-collector-gateway:4317`) matches each telemetrygen
container's `--otlp-endpoint` exactly, so telemetrygen can never start
against a not-yet-ready gateway. Startup becomes deterministic.

## Why busybox is added to `E2E_EXTERNAL_IMAGES`

The Justfile's `e2e-up` pre-pulls every manifest image on the host docker
daemon and imports it into k3d in lock-step (the `E2E_EXTERNAL_IMAGES`
contract), to dodge DockerHub anonymous-pull rate limits in CI. A new image
referenced by a manifest but absent from that list would face the full
Docker-Hub pull-flake exposure the contract exists to avoid — so
`busybox:1.37` is added there too, keeping both sides in sync.

## Scope

Manifest + Justfile-pin only. No changes to the collector config, the
gateway, or any Go code. The change purely delays telemetrygen until the
gateway is up.

## Validation

- `python3 yaml.safe_load_all` over `sample-app.yaml`: all 3 docs parse;
  the initContainer sits under `spec.template.spec` (pod spec) in each;
  the wait target matches the telemetrygen `--otlp-endpoint` per Deployment.
- `just --evaluate E2E_EXTERNAL_IMAGES` confirms `busybox:1.37` is in the list.
- `busybox` `nc` supports `-z` (the TCP-probe flag used here).

Closes #82.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
