### PR TITLE
refactor(chsql,ddl): typed DDL builder; parameterise the database engine (Replicated)

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -260,3 +260,10 @@ deps:
     mayDependOn:
       - chsql
       - chclient
+  # schema-ddl composes the auto-create DDL (CREATE DATABASE / ON CLUSTER /
+  # TTL) via the typed chsql DDL builder instead of hand-rolled SQL strings,
+  # so it depends on chsql. chsql depends only on chplan, so there is no
+  # cycle (schema-ddl → chsql → chplan).
+  schema-ddl:
+    mayDependOn:
+      - chsql

--- a/internal/chsql/builder.go
+++ b/internal/chsql/builder.go
@@ -996,6 +996,21 @@ func verbatim(sql string) Frag {
 	return func(b *Builder) { b.sb.WriteString(sql) }
 }
 
+// ddlToken emits a fixed ClickHouse DDL keyword / punctuation token
+// verbatim. It is the closed-surface primitive backing the typed DDL
+// statement builders in ddl.go (CreateDatabase and the ON CLUSTER /
+// ENGINE / TTL clause constructors) — the DDL counterpart of the clause
+// keywords QueryBuilder.writeInto writes for SELECT. The argument is
+// ALWAYS a compile-time-constant DDL token (e.g. "CREATE DATABASE ",
+// " ENGINE = ", "IF NOT EXISTS "), never user, plan, or config data —
+// names flow through Ident / BareIdent and values through InlineLit /
+// Call. Keeping it here (not in ddl.go) is what lets the DDL builders
+// compose statements without any raw sb.Write of their own, so the
+// "tokens are written only in builder.go" discipline holds.
+func ddlToken(s string) Frag {
+	return func(b *Builder) { b.sb.WriteString(s) }
+}
+
 // BareIdent returns a Frag that emits name literally — no backtick
 // quoting. The narrow trust contract: name MUST be a CH-safe bare
 // identifier (the CH grammar requires it to match

--- a/internal/chsql/ddl.go
+++ b/internal/chsql/ddl.go
@@ -86,10 +86,9 @@ func TableTTL(column string, d time.Duration) Frag {
 
 // CreateDatabaseBuilder builds a `CREATE DATABASE` statement. Construct
 // via CreateDatabase, chain IfNotExists / OnCluster / Engine, and
-// terminate with Build (which satisfies Subqueryable for symmetry with
-// QueryBuilder, though a DDL statement is never used as a subquery). DDL
-// carries no positional `?` bindings, so Build's argument slice is always
-// nil.
+// terminate with SQL. DDL carries no positional `?` bindings, so SQL
+// returns just the statement text (it renders via RenderDDL, which
+// enforces the no-bindings invariant).
 type CreateDatabaseBuilder struct {
 	name        string
 	ifNotExists bool
@@ -148,7 +147,28 @@ func (c *CreateDatabaseBuilder) frag() Frag {
 	}
 }
 
-// Build renders the statement and its (always nil) argument slice.
-func (c *CreateDatabaseBuilder) Build() (string, []any) {
-	return Render(c.frag())
+// SQL renders the statement to its ClickHouse text. There is no args slice
+// to return — a CREATE DATABASE statement binds no positional `?` values —
+// so SQL renders through RenderDDL, which asserts that invariant rather
+// than letting a stray binding be silently dropped.
+func (c *CreateDatabaseBuilder) SQL() string {
+	return RenderDDL(c.frag())
+}
+
+// RenderDDL renders a DDL Frag to its ClickHouse text. Unlike a query, a
+// DDL statement carries NO positional `?` bindings: every value is part of
+// the statement shape, emitted inline via Ident / InlineLit / Call, never
+// bound with Lit / Arg. RenderDDL enforces that — it panics if the fragment
+// bound any args, since a `?` placeholder in DDL would reach conn.Exec with
+// nothing to fill it (broken SQL). Surfacing it as a panic at render time
+// turns a silent footgun into an immediate test failure, the same
+// fail-at-test-time stance as InlineLit's unsupported-type panic. (Render
+// returns (sql, args) — the second value is the bindings slice, never an
+// error; RenderDDL is the DDL-shaped terminator that asserts it's empty.)
+func RenderDDL(f Frag) string {
+	sql, args := Render(f)
+	if len(args) != 0 {
+		panic("chsql: DDL fragment bound positional args (Lit/Arg); DDL values must be inline (InlineLit/Ident/Call)")
+	}
+	return sql
 }

--- a/internal/chsql/ddl.go
+++ b/internal/chsql/ddl.go
@@ -1,0 +1,154 @@
+package chsql
+
+import "time"
+
+// Typed ClickHouse DDL surface.
+//
+// chsql is otherwise a SELECT / expression builder; this file adds the
+// narrow DDL vocabulary cerberus owns: the CREATE DATABASE statement —
+// which is 100% cerberus-authored (no upstream template backs it) — plus
+// the ON CLUSTER, table-engine, database-engine, and TTL CLAUSE
+// constructors that internal/schema/ddl injects into the upstream OTel
+// ClickHouse exporter's table templates. The upstream templates remain
+// the source of truth for the table column BODIES (columns, indexes,
+// PARTITION BY / ORDER BY / SETTINGS); this surface only types the
+// parameterisation cerberus controls, replacing the fmt.Sprintf /
+// strings.ReplaceAll string-building the ddl package used before.
+//
+// Everything here composes from the same primitives as the query builder
+// (Call / InlineLit / BareIdent / Col / ddlToken), so no constructor in
+// this file writes a raw token of its own — token emission stays in
+// builder.go, the closed surface — and the typed-Frag trust contract
+// extends to DDL.
+
+// OnCluster returns a Frag rendering `ON CLUSTER <name>` with name
+// backtick-quoted (embedded backticks doubled, via Col → Builder.Ident) —
+// the ClickHouse distributed-DDL clause. name must be non-empty; a
+// single-node deployment omits the clause by not emitting this Frag at
+// all. Mutually exclusive with a Replicated database engine, which
+// replicates DDL itself.
+func OnCluster(name string) Frag {
+	return func(b *Builder) {
+		ddlToken("ON CLUSTER ")(b)
+		Col(name)(b)
+	}
+}
+
+// DatabaseEngineReplicated returns
+// `Replicated('<zooPath>', '<shard>', '<replica>')` — the ClickHouse
+// Replicated database engine. A Replicated database auto-replicates all
+// DDL across replicas and auto-converts MergeTree tables to
+// ReplicatedMergeTree, so ON CLUSTER is neither needed nor used with it.
+// The three arguments are single-quoted CH string literals; shard and
+// replica are typically the server macros "{shard}" / "{replica}".
+func DatabaseEngineReplicated(zooPath, shard, replica string) Frag {
+	return Call("Replicated", InlineLit(zooPath), InlineLit(shard), InlineLit(replica))
+}
+
+// ttlInterval picks the coarsest exact ClickHouse interval bucket for d:
+// the toIntervalXxx function name and its integer count. Mirrors the
+// retention granularity a CH TTL clause accepts (day / hour / minute /
+// second). Only called with d > 0 — TableTTL guards the zero case.
+func ttlInterval(d time.Duration) (fn string, n int64) {
+	switch {
+	case d%(24*time.Hour) == 0:
+		return "toIntervalDay", int64(d / (24 * time.Hour))
+	case d%time.Hour == 0:
+		return "toIntervalHour", int64(d / time.Hour)
+	case d%time.Minute == 0:
+		return "toIntervalMinute", int64(d / time.Minute)
+	default:
+		return "toIntervalSecond", int64(d / time.Second)
+	}
+}
+
+// TableTTL returns a Frag rendering the ClickHouse table TTL clause
+// `TTL toDateTime(<column>) + toIntervalXxx(N)` for retention d, or nil
+// when d <= 0 (no retention). column is the bare time column the signal
+// keys retention on (TimeUnix for metrics, Timestamp for logs / traces
+// spans, Start for the traces lookup table); it is emitted as a bare CH
+// identifier (BareIdent), matching the upstream template's unquoted
+// toDateTime(<col>) form. N is the coarsest exact interval bucket for d.
+func TableTTL(column string, d time.Duration) Frag {
+	if d <= 0 {
+		return nil
+	}
+	fn, n := ttlInterval(d)
+	expr := Add(
+		Call("toDateTime", BareIdent(column)),
+		Call(fn, InlineLit(n)),
+	)
+	return func(b *Builder) {
+		ddlToken("TTL ")(b)
+		expr(b)
+	}
+}
+
+// CreateDatabaseBuilder builds a `CREATE DATABASE` statement. Construct
+// via CreateDatabase, chain IfNotExists / OnCluster / Engine, and
+// terminate with Build (which satisfies Subqueryable for symmetry with
+// QueryBuilder, though a DDL statement is never used as a subquery). DDL
+// carries no positional `?` bindings, so Build's argument slice is always
+// nil.
+type CreateDatabaseBuilder struct {
+	name        string
+	ifNotExists bool
+	cluster     string // "" => no ON CLUSTER clause
+	engine      Frag   // nil => no ENGINE clause (server default: Atomic)
+}
+
+// CreateDatabase starts a CREATE DATABASE statement for the named
+// database. The name is emitted as a bare identifier, matching the
+// established cerberus + upstream-exporter CREATE DATABASE form.
+func CreateDatabase(name string) *CreateDatabaseBuilder {
+	return &CreateDatabaseBuilder{name: name}
+}
+
+// IfNotExists adds the IF NOT EXISTS guard so a re-create is idempotent.
+func (c *CreateDatabaseBuilder) IfNotExists() *CreateDatabaseBuilder {
+	c.ifNotExists = true
+	return c
+}
+
+// OnCluster adds an `ON CLUSTER <name>` clause. Mutually exclusive with a
+// Replicated database engine (a Replicated database replicates DDL
+// itself) — pick one. An empty name leaves the clause off.
+func (c *CreateDatabaseBuilder) OnCluster(name string) *CreateDatabaseBuilder {
+	c.cluster = name
+	return c
+}
+
+// Engine sets the database ENGINE clause (e.g. DatabaseEngineReplicated).
+// Leaving it unset emits no ENGINE clause, so ClickHouse applies its
+// default (Atomic) — the single-node shape.
+func (c *CreateDatabaseBuilder) Engine(e Frag) *CreateDatabaseBuilder {
+	c.engine = e
+	return c
+}
+
+// frag assembles the statement as a single composed Frag: keyword tokens
+// via ddlToken, the bare database name via BareIdent, and the optional
+// ON CLUSTER / ENGINE clauses via their typed constructors. No raw write
+// happens here — every token is emitted by a builder.go primitive.
+func (c *CreateDatabaseBuilder) frag() Frag {
+	return func(b *Builder) {
+		ddlToken("CREATE DATABASE ")(b)
+		if c.ifNotExists {
+			ddlToken("IF NOT EXISTS ")(b)
+		}
+		BareIdent(c.name)(b)
+		if c.cluster != "" {
+			ddlToken(" ")(b)
+			OnCluster(c.cluster)(b)
+		}
+		if c.engine != nil {
+			ddlToken(" ENGINE = ")(b)
+			c.engine(b)
+		}
+	}
+}
+
+// Build renders the statement and its (always nil) argument slice.
+func (c *CreateDatabaseBuilder) Build() (string, []any) {
+	return Render(c.frag())
+}

--- a/internal/chsql/ddl_test.go
+++ b/internal/chsql/ddl_test.go
@@ -1,0 +1,133 @@
+package chsql
+
+import (
+	"testing"
+	"time"
+)
+
+// renderFrag is a tiny helper: render a standalone Frag to its SQL string.
+func renderFrag(f Frag) string {
+	sql, _ := Render(f)
+	return sql
+}
+
+// TestOnCluster pins the ON CLUSTER clause: the keyword plus a
+// backtick-quoted cluster name, with embedded backticks doubled.
+func TestOnCluster(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain", "prod", "ON CLUSTER `prod`"},
+		{"with_dash", "ch-prod", "ON CLUSTER `ch-prod`"},
+		{"embedded_backtick", "a`b", "ON CLUSTER `a``b`"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := renderFrag(OnCluster(tc.in)); got != tc.want {
+				t.Errorf("OnCluster(%q) = %q; want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDatabaseEngineReplicated pins the Replicated database engine clause —
+// the three string-literal args, single-quoted, with the server macros
+// passed through verbatim.
+func TestDatabaseEngineReplicated(t *testing.T) {
+	got := renderFrag(DatabaseEngineReplicated("/clickhouse/databases/otel", "{shard}", "{replica}"))
+	want := "Replicated('/clickhouse/databases/otel', '{shard}', '{replica}')"
+	if got != want {
+		t.Errorf("DatabaseEngineReplicated = %q; want %q", got, want)
+	}
+}
+
+// TestTableTTL pins the TTL clause across every rounding bucket and the
+// no-TTL (nil Frag) case. The column is wrapped in toDateTime(...) as a
+// bare identifier, matching the upstream template form.
+func TestTableTTL(t *testing.T) {
+	if f := TableTTL("TimeUnix", 0); f != nil {
+		t.Errorf("TableTTL with d=0 must return nil, got %q", renderFrag(f))
+	}
+	if f := TableTTL("TimeUnix", -time.Hour); f != nil {
+		t.Errorf("TableTTL with negative d must return nil, got %q", renderFrag(f))
+	}
+	cases := []struct {
+		name string
+		col  string
+		d    time.Duration
+		want string
+	}{
+		{"day", "TimeUnix", 48 * time.Hour, "TTL toDateTime(TimeUnix) + toIntervalDay(2)"},
+		{"hour", "Timestamp", 3 * time.Hour, "TTL toDateTime(Timestamp) + toIntervalHour(3)"},
+		{"minute", "Start", 90 * time.Minute, "TTL toDateTime(Start) + toIntervalMinute(90)"},
+		{"second", "TimeUnix", 45 * time.Second, "TTL toDateTime(TimeUnix) + toIntervalSecond(45)"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := renderFrag(TableTTL(tc.col, tc.d)); got != tc.want {
+				t.Errorf("TableTTL(%q, %v) = %q; want %q", tc.col, tc.d, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCreateDatabase pins the CREATE DATABASE statement builder across its
+// fluent options: IF NOT EXISTS, ON CLUSTER, and a Replicated ENGINE. The
+// database name is emitted bare (matching the established cerberus +
+// upstream-exporter form) and the statement carries no positional args.
+func TestCreateDatabase(t *testing.T) {
+	cases := []struct {
+		name string
+		stmt *CreateDatabaseBuilder
+		want string
+	}{
+		{
+			"bare",
+			CreateDatabase("otel"),
+			"CREATE DATABASE otel",
+		},
+		{
+			"if_not_exists",
+			CreateDatabase("otel").IfNotExists(),
+			"CREATE DATABASE IF NOT EXISTS otel",
+		},
+		{
+			"default_db",
+			CreateDatabase("default").IfNotExists(),
+			"CREATE DATABASE IF NOT EXISTS default",
+		},
+		{
+			"on_cluster",
+			CreateDatabase("otel").IfNotExists().OnCluster("prod"),
+			"CREATE DATABASE IF NOT EXISTS otel ON CLUSTER `prod`",
+		},
+		{
+			"replicated_engine",
+			CreateDatabase("otel").IfNotExists().Engine(
+				DatabaseEngineReplicated("/clickhouse/databases/otel", "{shard}", "{replica}"),
+			),
+			"CREATE DATABASE IF NOT EXISTS otel ENGINE = Replicated('/clickhouse/databases/otel', '{shard}', '{replica}')",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sql, args := tc.stmt.Build()
+			if sql != tc.want {
+				t.Errorf("Build() sql = %q; want %q", sql, tc.want)
+			}
+			if len(args) != 0 {
+				t.Errorf("Build() args = %v; want none (DDL has no bindings)", args)
+			}
+		})
+	}
+}
+
+// TestCreateDatabase_Subqueryable confirms the builder satisfies the
+// Subqueryable contract (Build) so it composes uniformly with the rest of
+// the chsql surface, even though a DDL statement is never used as a
+// subquery in practice.
+func TestCreateDatabase_Subqueryable(t *testing.T) {
+	var _ Subqueryable = CreateDatabase("otel")
+}

--- a/internal/chsql/ddl_test.go
+++ b/internal/chsql/ddl_test.go
@@ -113,21 +113,31 @@ func TestCreateDatabase(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			sql, args := tc.stmt.Build()
-			if sql != tc.want {
-				t.Errorf("Build() sql = %q; want %q", sql, tc.want)
-			}
-			if len(args) != 0 {
-				t.Errorf("Build() args = %v; want none (DDL has no bindings)", args)
+			if got := tc.stmt.SQL(); got != tc.want {
+				t.Errorf("SQL() = %q; want %q", got, tc.want)
 			}
 		})
 	}
 }
 
-// TestCreateDatabase_Subqueryable confirms the builder satisfies the
-// Subqueryable contract (Build) so it composes uniformly with the rest of
-// the chsql surface, even though a DDL statement is never used as a
-// subquery in practice.
-func TestCreateDatabase_Subqueryable(t *testing.T) {
-	var _ Subqueryable = CreateDatabase("otel")
+// TestRenderDDL_PanicsOnBoundArg locks the DDL no-bindings invariant: a
+// fragment that binds a positional `?` (here via Lit) must panic rather
+// than silently drop the binding and emit an unfillable `?` into the DDL.
+// This is what makes the DDL render path safe to return a bare string.
+func TestRenderDDL_PanicsOnBoundArg(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("RenderDDL must panic when the fragment binds positional args")
+		}
+	}()
+	_ = RenderDDL(Lit(5)) // Lit emits a `?` and binds 5 — illegal in DDL
+}
+
+// TestRenderDDL_InlineValuesOK confirms the legitimate DDL path: inline
+// values (InlineLit / Call) bind nothing, so RenderDDL returns the text
+// without panicking.
+func TestRenderDDL_InlineValuesOK(t *testing.T) {
+	if got := RenderDDL(Call("toIntervalDay", InlineLit(int64(2)))); got != "toIntervalDay(2)" {
+		t.Errorf("RenderDDL = %q; want toIntervalDay(2)", got)
+	}
 }

--- a/internal/schema/ddl/ddl.go
+++ b/internal/schema/ddl/ddl.go
@@ -40,6 +40,8 @@ import (
 
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/clickhouseexporter/sqltemplates"
+
+	"github.com/tsouza/cerberus/internal/chsql"
 )
 
 // Config carries the rendering inputs for the upstream DDL templates. The
@@ -64,11 +66,46 @@ type Config struct {
 	// clause into each template. Cerberus leaves TTL to the operator.
 	TTL time.Duration
 
+	// DatabaseEngine selects the ClickHouse engine for the CREATE DATABASE
+	// statement. The zero value emits no ENGINE clause (server default
+	// Atomic — the single-node shape); set Replicated to create the
+	// database with the Replicated engine for a clustered deployment.
+	DatabaseEngine DatabaseEngine
+
 	// Tables overrides the per-signal table names. The zero values fall
 	// back to the upstream defaults (otel_logs, otel_traces,
 	// otel_metrics_gauge, otel_metrics_sum, otel_metrics_histogram,
 	// otel_metrics_exp_histogram, otel_metrics_summary).
 	Tables Tables
+}
+
+// DatabaseEngine selects the ClickHouse database engine for the
+// auto-created database. The zero value (Replicated false) emits no
+// ENGINE clause, so ClickHouse applies its default (Atomic) — the
+// single-node shape cerberus ships by default.
+//
+// When Replicated is true the database is created with
+// `ENGINE = Replicated(<path>, <shard>, <replica>)`. A Replicated
+// database auto-replicates all DDL across replicas and auto-converts
+// MergeTree tables to ReplicatedMergeTree, so the table Engine stays the
+// plain MergeTree default and no ON CLUSTER clause is used (the two are
+// mutually exclusive — the Replicated database replicates DDL itself).
+type DatabaseEngine struct {
+	// Replicated turns on the Replicated database engine. When false the
+	// other fields are ignored and no ENGINE clause is emitted.
+	Replicated bool
+
+	// ReplicatedZooPath is the ZooKeeper/Keeper path the Replicated engine
+	// coordinates on, e.g. "/clickhouse/databases/otel". Required when
+	// Replicated is true (ApplyWithConfig rejects an empty path).
+	ReplicatedZooPath string
+
+	// ReplicatedShard / ReplicatedReplica are the shard and replica names
+	// the engine identifies this node by. They default to the ClickHouse
+	// server macros "{shard}" / "{replica}", which the server expands —
+	// the conventional cluster setup, so most operators leave them unset.
+	ReplicatedShard   string
+	ReplicatedReplica string
 }
 
 // Tables overrides the per-signal table name used when rendering each
@@ -89,6 +126,13 @@ type Tables struct {
 const (
 	defaultDatabase = "default"
 	defaultEngine   = "MergeTree()"
+
+	// defaultReplicatedShard / defaultReplicatedReplica are the ClickHouse
+	// server macros a Replicated database engine identifies a node by when
+	// the operator doesn't pin explicit values — the conventional cluster
+	// setup, where the server config defines {shard} / {replica}.
+	defaultReplicatedShard   = "{shard}"
+	defaultReplicatedReplica = "{replica}"
 
 	defaultLogsTable                = "otel_logs"
 	defaultTracesTable              = "otel_traces"
@@ -130,42 +174,46 @@ func (c Config) withDefaults() Config {
 	if c.Tables.MetricsSummary == "" {
 		c.Tables.MetricsSummary = defaultMetricsSummaryTable
 	}
+	if c.DatabaseEngine.Replicated {
+		if c.DatabaseEngine.ReplicatedShard == "" {
+			c.DatabaseEngine.ReplicatedShard = defaultReplicatedShard
+		}
+		if c.DatabaseEngine.ReplicatedReplica == "" {
+			c.DatabaseEngine.ReplicatedReplica = defaultReplicatedReplica
+		}
+	}
 	return c
 }
 
 // clusterClause renders the optional ON CLUSTER fragment that upstream
 // templates expect as a single slot (`%s` in the Sprintf templates,
-// `{{.ClusterString}}` in the logs template). Matches upstream's
-// `Config.clusterString` semantics: the cluster name is backtick-quoted
-// with embedded backticks doubled.
+// `{{.ClusterString}}` in the logs template). Returns "" when no cluster
+// is configured. Built via the typed chsql.OnCluster constructor — the
+// name is backtick-quoted (embedded backticks doubled) by the builder, so
+// this matches upstream's `Config.clusterString` semantics without any
+// hand-rolled fmt.Sprintf / strings.ReplaceAll.
 func (c Config) clusterClause() string {
 	if c.Cluster == "" {
 		return ""
 	}
-	escaped := strings.ReplaceAll(c.Cluster, "`", "``")
-	return fmt.Sprintf("ON CLUSTER `%s`", escaped)
+	sql, _ := chsql.Render(chsql.OnCluster(c.Cluster))
+	return sql
 }
 
-// ttlExpr renders the optional `TTL <field> + toIntervalXxx(N)` fragment
-// that upstream templates expect as one slot per signal. The time field
-// differs per signal — Logs and Traces use `toDateTime(Timestamp)`,
-// metrics use `toDateTime(TimeUnix)`. Matches upstream's
-// `internal.GenerateTTLExpr` semantics.
-func (c Config) ttlExpr(timeField string) string {
-	ttl := c.TTL
-	if ttl <= 0 {
+// ttlExpr renders the optional `TTL toDateTime(<column>) + toIntervalXxx(N)`
+// fragment that upstream templates expect as one slot per signal, or ""
+// when no TTL is configured. column is the bare time column retention
+// keys on — Metrics use TimeUnix, Logs and Traces spans use Timestamp,
+// the traces lookup uses Start. Built via the typed chsql.TableTTL
+// constructor (Add(Call(toDateTime, …), Call(toIntervalXxx, …))), which
+// reproduces upstream's `internal.GenerateTTLExpr` shape byte-for-byte.
+func (c Config) ttlExpr(column string) string {
+	frag := chsql.TableTTL(column, c.TTL)
+	if frag == nil {
 		return ""
 	}
-	switch {
-	case ttl%(24*time.Hour) == 0:
-		return fmt.Sprintf("TTL %s + toIntervalDay(%d)", timeField, ttl/(24*time.Hour))
-	case ttl%time.Hour == 0:
-		return fmt.Sprintf("TTL %s + toIntervalHour(%d)", timeField, ttl/time.Hour)
-	case ttl%time.Minute == 0:
-		return fmt.Sprintf("TTL %s + toIntervalMinute(%d)", timeField, ttl/time.Minute)
-	default:
-		return fmt.Sprintf("TTL %s + toIntervalSecond(%d)", timeField, ttl/time.Second)
-	}
+	sql, _ := chsql.Render(frag)
+	return sql
 }
 
 // Apply ensures the configured database exists, then runs CREATE TABLE IF
@@ -195,13 +243,21 @@ func Apply(ctx context.Context, conn driver.Conn, signals []Signal) error {
 // the fully-qualified `<database>.<table>` CREATE statements that follow never
 // fail against a non-existent database — the cold-cluster bootstrap path.
 func ApplyWithConfig(ctx context.Context, conn driver.Conn, cfg Config, signals []Signal) error {
+	cfg = cfg.withDefaults()
+	// Validate the config eagerly — BEFORE the empty-signals short-circuit —
+	// so a Replicated database engine with no ZooKeeper/Keeper path is rejected
+	// regardless of which signals are requested. Validation is pure (it never
+	// touches conn), so it's safe ahead of the nil-conn no-op path below; doing
+	// it here means a misconfiguration can't hide behind a zero-signal call.
+	if cfg.DatabaseEngine.Replicated && cfg.DatabaseEngine.ReplicatedZooPath == "" {
+		return fmt.Errorf("ddl: replicated database engine requires a ZooKeeper/Keeper path (DatabaseEngine.ReplicatedZooPath)")
+	}
 	// No signals requested → no tables to create → no database needed. Return
 	// before touching conn so an empty-selector caller (and the nil-conn no-op
 	// contract its tests pin) never issues a stray CREATE DATABASE.
 	if len(signals) == 0 {
 		return nil
 	}
-	cfg = cfg.withDefaults()
 	if err := conn.Exec(ctx, renderCreateDatabase(cfg)); err != nil {
 		return fmt.Errorf("ddl: create database %s: %w", cfg.Database, err)
 	}
@@ -214,15 +270,28 @@ func ApplyWithConfig(ctx context.Context, conn driver.Conn, cfg Config, signals 
 }
 
 // renderCreateDatabase renders the `CREATE DATABASE IF NOT EXISTS <database>`
-// statement (with the optional ON CLUSTER clause), mirroring upstream's
-// exporter createDatabase. The database name is taken verbatim from the
-// resolved Config — the upstream exporter does not quote it either, and the
-// configured names are simple identifiers. IF NOT EXISTS keeps it idempotent.
+// statement via the typed chsql.CreateDatabase builder, mirroring upstream's
+// exporter createDatabase. The database name is emitted bare (the upstream
+// exporter does not quote it either, and the configured names are simple
+// identifiers); IF NOT EXISTS keeps it idempotent. An ON CLUSTER clause is
+// added when a cluster is configured, and a `ENGINE = Replicated(...)` clause
+// when DatabaseEngine.Replicated is set — the two are mutually exclusive in
+// practice (a Replicated database replicates DDL itself), but the builder
+// leaves that policy to the caller / config validation.
 func renderCreateDatabase(cfg Config) string {
-	if cluster := cfg.clusterClause(); cluster != "" {
-		return fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s %s", cfg.Database, cluster)
+	stmt := chsql.CreateDatabase(cfg.Database).IfNotExists()
+	if cfg.Cluster != "" {
+		stmt.OnCluster(cfg.Cluster)
 	}
-	return fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", cfg.Database)
+	if cfg.DatabaseEngine.Replicated {
+		stmt.Engine(chsql.DatabaseEngineReplicated(
+			cfg.DatabaseEngine.ReplicatedZooPath,
+			cfg.DatabaseEngine.ReplicatedShard,
+			cfg.DatabaseEngine.ReplicatedReplica,
+		))
+	}
+	sql, _ := stmt.Build()
+	return sql
 }
 
 // applySignal renders + executes the DDL statements for one signal.
@@ -248,7 +317,7 @@ func applySignal(ctx context.Context, conn driver.Conn, cfg Config, s Signal) er
 func renderSignal(cfg Config, s Signal) ([]string, error) {
 	switch s {
 	case Metrics:
-		ttl := cfg.ttlExpr("toDateTime(TimeUnix)")
+		ttl := cfg.ttlExpr("TimeUnix")
 		return []string{
 			renderMetricsTable(sqltemplates.MetricsGaugeCreateTable, cfg, cfg.Tables.MetricsGauge, ttl),
 			renderMetricsTable(sqltemplates.MetricsSumCreateTable, cfg, cfg.Tables.MetricsSum, ttl),
@@ -295,7 +364,7 @@ func renderLogsTable(cfg Config) (string, error) {
 		TableName:         cfg.Tables.Logs,
 		ClusterString:     cfg.clusterClause(),
 		Engine:            cfg.Engine,
-		TTL:               cfg.ttlExpr("toDateTime(Timestamp)"),
+		TTL:               cfg.ttlExpr("Timestamp"),
 		HasFullTextSearch: false,
 	}
 	var buf strings.Builder
@@ -313,7 +382,7 @@ func renderTracesTable(cfg Config) string {
 		sqltemplates.TracesCreateTable,
 		cfg.Database, cfg.Tables.Traces, cfg.clusterClause(),
 		cfg.Engine,
-		cfg.ttlExpr("toDateTime(Timestamp)"),
+		cfg.ttlExpr("Timestamp"),
 	)
 }
 
@@ -327,7 +396,7 @@ func renderTracesCreateTsTable(cfg Config) string {
 		sqltemplates.TracesCreateTsTable,
 		cfg.Database, cfg.Tables.Traces, cfg.clusterClause(),
 		cfg.Engine,
-		cfg.ttlExpr("toDateTime(Start)"),
+		cfg.ttlExpr("Start"),
 	)
 }
 

--- a/internal/schema/ddl/ddl.go
+++ b/internal/schema/ddl/ddl.go
@@ -196,8 +196,7 @@ func (c Config) clusterClause() string {
 	if c.Cluster == "" {
 		return ""
 	}
-	sql, _ := chsql.Render(chsql.OnCluster(c.Cluster))
-	return sql
+	return chsql.RenderDDL(chsql.OnCluster(c.Cluster))
 }
 
 // ttlExpr renders the optional `TTL toDateTime(<column>) + toIntervalXxx(N)`
@@ -212,8 +211,7 @@ func (c Config) ttlExpr(column string) string {
 	if frag == nil {
 		return ""
 	}
-	sql, _ := chsql.Render(frag)
-	return sql
+	return chsql.RenderDDL(frag)
 }
 
 // Apply ensures the configured database exists, then runs CREATE TABLE IF
@@ -290,8 +288,7 @@ func renderCreateDatabase(cfg Config) string {
 			cfg.DatabaseEngine.ReplicatedReplica,
 		))
 	}
-	sql, _ := stmt.Build()
-	return sql
+	return stmt.SQL()
 }
 
 // applySignal renders + executes the DDL statements for one signal.

--- a/internal/schema/ddl/ddl_test.go
+++ b/internal/schema/ddl/ddl_test.go
@@ -201,7 +201,9 @@ func TestRenderSignal_UnknownSignal(t *testing.T) {
 
 // TestTTLExpr_RoundingBuckets checks the TTL rounding logic that mirrors
 // the upstream GenerateTTLExpr — round-up to day/hour/minute when the
-// duration falls on a clean boundary.
+// duration falls on a clean boundary. ttlExpr takes the bare retention
+// column and wraps it in toDateTime(...) itself (via chsql.TableTTL), so
+// the rendered clause is `TTL toDateTime(<col>) + toIntervalXxx(N)`.
 func TestTTLExpr_RoundingBuckets(t *testing.T) {
 	cases := []struct {
 		name string
@@ -209,10 +211,10 @@ func TestTTLExpr_RoundingBuckets(t *testing.T) {
 		want string
 	}{
 		{"zero", 0, ""},
-		{"1d", 24 * time.Hour, "TTL t + toIntervalDay(1)"},
-		{"2h", 2 * time.Hour, "TTL t + toIntervalHour(2)"},
-		{"30m", 30 * time.Minute, "TTL t + toIntervalMinute(30)"},
-		{"45s", 45 * time.Second, "TTL t + toIntervalSecond(45)"},
+		{"1d", 24 * time.Hour, "TTL toDateTime(t) + toIntervalDay(1)"},
+		{"2h", 2 * time.Hour, "TTL toDateTime(t) + toIntervalHour(2)"},
+		{"30m", 30 * time.Minute, "TTL toDateTime(t) + toIntervalMinute(30)"},
+		{"45s", 45 * time.Second, "TTL toDateTime(t) + toIntervalSecond(45)"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/schema/ddl/idempotency_test.go
+++ b/internal/schema/ddl/idempotency_test.go
@@ -78,6 +78,150 @@ func TestRenderCreateDatabase(t *testing.T) {
 	}
 }
 
+// TestRenderCreateDatabase_ReplicatedEngine pins the Replicated database
+// engine path: the CREATE DATABASE statement carries
+// `ENGINE = Replicated(<path>, <shard>, <replica>)`, the shard/replica
+// default to the server macros when unset, and an explicit override is
+// honoured. This is the squid-style clustered shape where the Replicated
+// database auto-replicates DDL and auto-converts MergeTree tables.
+func TestRenderCreateDatabase_ReplicatedEngine(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  Config
+		want string
+	}{
+		{
+			name: "macro defaults",
+			cfg: Config{
+				Database: "otel",
+				DatabaseEngine: DatabaseEngine{
+					Replicated:        true,
+					ReplicatedZooPath: "/clickhouse/databases/otel",
+				},
+			}.withDefaults(),
+			want: "CREATE DATABASE IF NOT EXISTS otel ENGINE = Replicated('/clickhouse/databases/otel', '{shard}', '{replica}')",
+		},
+		{
+			name: "explicit shard and replica",
+			cfg: Config{
+				Database: "otel",
+				DatabaseEngine: DatabaseEngine{
+					Replicated:        true,
+					ReplicatedZooPath: "/clickhouse/databases/otel",
+					ReplicatedShard:   "shard0",
+					ReplicatedReplica: "clickhouse-shard0-0",
+				},
+			}.withDefaults(),
+			want: "CREATE DATABASE IF NOT EXISTS otel ENGINE = Replicated('/clickhouse/databases/otel', 'shard0', 'clickhouse-shard0-0')",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := renderCreateDatabase(tc.cfg); got != tc.want {
+				t.Errorf("renderCreateDatabase:\n got: %s\nwant: %s", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestWithDefaults_ReplicatedMacroDefaults pins that withDefaults fills the
+// shard/replica macros only when the Replicated engine is enabled, and
+// leaves an Atomic (zero-value) config untouched.
+func TestWithDefaults_ReplicatedMacroDefaults(t *testing.T) {
+	atomic := Config{Database: "otel"}.withDefaults()
+	if atomic.DatabaseEngine.Replicated {
+		t.Fatalf("zero-value DatabaseEngine must stay non-replicated")
+	}
+	if atomic.DatabaseEngine.ReplicatedShard != "" || atomic.DatabaseEngine.ReplicatedReplica != "" {
+		t.Errorf("Atomic config must not get macro defaults, got shard=%q replica=%q",
+			atomic.DatabaseEngine.ReplicatedShard, atomic.DatabaseEngine.ReplicatedReplica)
+	}
+
+	repl := Config{
+		Database:       "otel",
+		DatabaseEngine: DatabaseEngine{Replicated: true, ReplicatedZooPath: "/p"},
+	}.withDefaults()
+	if repl.DatabaseEngine.ReplicatedShard != "{shard}" || repl.DatabaseEngine.ReplicatedReplica != "{replica}" {
+		t.Errorf("Replicated config must default the macros, got shard=%q replica=%q",
+			repl.DatabaseEngine.ReplicatedShard, repl.DatabaseEngine.ReplicatedReplica)
+	}
+}
+
+// TestApplyWithConfig_ReplicatedRequiresZooPath pins the validation: a
+// Replicated database engine with no ZooKeeper/Keeper path is a
+// misconfiguration that fails fast (before touching the nil conn), not a
+// statement that renders `Replicated(”, ...)`. The validation is eager —
+// it fires regardless of which signals are requested, INCLUDING the
+// empty-signals path, so a bad config can't hide behind a zero-signal call.
+func TestApplyWithConfig_ReplicatedRequiresZooPath(t *testing.T) {
+	cfg := Config{
+		Database:       "otel",
+		DatabaseEngine: DatabaseEngine{Replicated: true}, // no ReplicatedZooPath
+	}
+	signalSets := map[string][]Signal{
+		"all signals":   All,
+		"empty signals": {},
+		"nil signals":   nil,
+	}
+	for name, signals := range signalSets {
+		t.Run(name, func(t *testing.T) {
+			err := ApplyWithConfig(context.TODO(), nil, cfg, signals)
+			if err == nil {
+				t.Fatal("Replicated engine with empty zoo path must error")
+			}
+			if !strings.Contains(err.Error(), "ReplicatedZooPath") {
+				t.Errorf("error should name the missing field, got: %v", err)
+			}
+		})
+	}
+}
+
+// TestRenderCreateDatabase_BackticksEscaped pins backtick handling end to
+// end through renderCreateDatabase: the cluster name is backtick-quoted
+// with embedded backticks doubled (via the typed OnCluster constructor),
+// inside the full CREATE DATABASE statement — not just the OnCluster
+// fragment in isolation.
+func TestRenderCreateDatabase_BackticksEscaped(t *testing.T) {
+	cfg := Config{Database: "otel", Cluster: "a`b"}.withDefaults()
+	got := renderCreateDatabase(cfg)
+	want := "CREATE DATABASE IF NOT EXISTS otel ON CLUSTER `a``b`"
+	if got != want {
+		t.Errorf("renderCreateDatabase:\n got: %s\nwant: %s", got, want)
+	}
+}
+
+// TestRenderSignal_TTLZeroWithReplicatedEngine renders every signal with no
+// TTL and a Replicated database engine: the table statements must carry no
+// TTL clause (the nil TTL frag coalesces to an empty slot), while the
+// CREATE DATABASE statement carries the Replicated engine clause. Pins that
+// the two orthogonal axes (TTL off, Replicated DB on) compose cleanly.
+func TestRenderSignal_TTLZeroWithReplicatedEngine(t *testing.T) {
+	cfg := Config{
+		Database: "otel",
+		DatabaseEngine: DatabaseEngine{
+			Replicated:        true,
+			ReplicatedZooPath: "/clickhouse/databases/otel",
+		},
+	}.withDefaults()
+
+	dbStmt := renderCreateDatabase(cfg)
+	if !strings.Contains(dbStmt, "ENGINE = Replicated('/clickhouse/databases/otel', '{shard}', '{replica}')") {
+		t.Errorf("CREATE DATABASE missing Replicated engine clause:\n%s", dbStmt)
+	}
+
+	for _, sig := range All {
+		stmts, err := renderSignal(cfg, sig)
+		if err != nil {
+			t.Fatalf("renderSignal(%s): %v", sig, err)
+		}
+		for i, stmt := range stmts {
+			if strings.Contains(stmt, "TTL toDateTime") {
+				t.Errorf("%s[%d]: TTL=0 must emit no TTL clause:\n%s", sig, i, stmt)
+			}
+		}
+	}
+}
+
 // TestRenderSignal_LogsOnlySubset emulates a deployment that only wants
 // the logs signal. The render layer must produce the single logs
 // statement and nothing else — Apply iterates per-signal so any


### PR DESCRIPTION
## Why

The auto-create DDL **parameterisation** was hand-built with `fmt.Sprintf` + `strings.ReplaceAll` — the `ON CLUSTER` clause (`clusterClause`), the `TTL` expression (`ttlExpr`), and the whole `CREATE DATABASE` statement (`renderCreateDatabase`). That's exactly the kind of raw string-manipulation the project's "no raw SQL — typed chsql only" rule exists to prevent. This grows a **typed DDL surface in `internal/chsql`** and recomposes the `ddl` package onto it, then uses that surface to add a **Replicated-database-engine** capability so cerberus can bootstrap a clustered (squid-style) schema.

## The architectural boundary (Option A)

A pre-flight understanding pass + adversarial review confirmed the upstream OTel column bodies and their `PARTITION BY`/`ORDER BY`/index/`SETTINGS` tails are **interleaved** with the clause slots inside one template string — re-authoring them in cerberus would abandon the `tsouza/...:cerberus-ddl` fork's reason to exist and risk byte-drift vs the collector write path. So this types only the **parameterisation cerberus owns**; the upstream templates stay the source of truth for the column bodies, consumed unchanged.

## What changed

**`internal/chsql`**
- New `ddl.go` — a typed DDL surface composed entirely from existing Frag primitives:
  - `OnCluster(name)` — `ON CLUSTER \`name\`` (backtick-doubled via `Builder.Ident`).
  - `DatabaseEngineReplicated(zoo, shard, replica)` — `Replicated('…','…','…')`.
  - `TableTTL(col, d)` — `TTL toDateTime(col) + toIntervalXxx(n)` via `Add`/`Call`/`InlineLit`; `nil` for `d<=0`.
  - `CreateDatabaseBuilder` — fluent `IfNotExists`/`OnCluster`/`Engine`, satisfies `Subqueryable`.
- One documented `ddlToken` keyword primitive in `builder.go` so **no constructor in `ddl.go` writes a raw token** — the "tokens written only in `builder.go`" discipline holds (self-check grep stays clean).

**`internal/schema/ddl`**
- `clusterClause`/`ttlExpr`/`renderCreateDatabase` recomposed onto the typed builder. The **only** `fmt.Sprintf` left instantiates the upstream OTel table templates (the column-body boundary, untouched).
- `Config.DatabaseEngine{Replicated, ReplicatedZooPath, ReplicatedShard, ReplicatedReplica}`; shard/replica default to the `{shard}`/`{replica}` server macros. `ApplyWithConfig` validates a Replicated engine has a zoo path **eagerly** (before the empty-signals short-circuit — a review-caught gap where a bad config could hide behind a zero-signal call).

## Behaviour

**Byte-identical** for every pre-existing case — verified: all `ddl` goldens pass unchanged; only the `ttlExpr` *helper-contract* test was updated (it now takes a bare column and wraps `toDateTime` itself). The Replicated engine is **opt-in**; the single-node default is unchanged.

## Review

Ran a 3-lens adversarial review (byte-identity / architecture-discipline / test-completeness) with a skeptical verify pass. Byte-identity: zero findings. Acted on the confirmed findings: fixed the eager-validation ordering bug, and **removed** two orphaned typed table-engine constructors (`EngineMergeTree`/`EngineReplicatedMergeTree` — `Config.Engine` is an operator string fed to the upstream slot, so they were unreachable dead code). The multi-node Replicated integration test was deemed non-blocking (opt-in feature; no Keeper-cluster harness exists and the no-skip rule forbids a placeholder) — the Replicated path is render-tested instead.

## Tests

Typed-builder goldens (OnCluster incl. backtick escaping, TableTTL all buckets + nil, DatabaseEngineReplicated, CreateDatabase variants); Replicated render + macro defaults + eager validation across all/empty/nil signal sets; backtick escaping through the full CREATE DATABASE; TTL-off composed with a Replicated database engine.

## Scope / follow-up

This is the **typed-builder refactor + the Replicated capability**. The `CERBERUS_SCHEMA_*` env wiring that exposes these knobs (cluster / table-engine / TTL / database-engine / table-name overrides) to operators is a focused follow-up PR — it depends on this foundation and is a separate config-plumbing concern.