### PR TITLE
feat(config): wire CERBERUS_SCHEMA_* auto-create knobs + per-signal TTL

### DIFF
--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -115,7 +115,7 @@ func run() error {
 
 	// schemaReady reports whether the auto-create-schema startup hook
 	// has finished at least once; /readyz consults it on every probe.
-	schemaReady := setupSchema(ctx, logger, client, cfg.ClickHouse.Database, cfg.AutoCreateSchema)
+	schemaReady := setupSchema(ctx, logger, client, schemaApplyConfig(cfg), cfg.AutoCreateSchema)
 
 	// Boot-time requirements preflight (ON by default). It MUST run AFTER
 	// the schema-create step above — on a fresh DB cerberus has just
@@ -428,6 +428,52 @@ func warnIfClickHouseUnreachable(ctx context.Context, logger *slog.Logger, clien
 	}
 }
 
+// schemaApplyConfig maps the runtime config into the typed internal/schema/ddl
+// Config the auto-create hook applies. The database name comes from the
+// ClickHouse connection config; the cluster / table-engine / TTL / Replicated
+// database-engine knobs come from CERBERUS_SCHEMA_* (SchemaProvisioning); and
+// the per-signal TABLE NAMES are threaded from the SAME resolved schema structs
+// the query heads read (cfg.Schema / cfg.Logs / cfg.Traces), so a
+// CERBERUS_SCHEMA_*_TABLE override creates and queries the same table instead of
+// silently diverging.
+func schemaApplyConfig(cfg config.Config) ddl.Config {
+	p := cfg.SchemaProvisioning
+	// Per-signal TTL: a non-zero per-signal override wins; otherwise the
+	// signal inherits the global CERBERUS_SCHEMA_TTL default (which is itself
+	// 0 = no retention unless the operator sets it).
+	signalTTL := func(override time.Duration) time.Duration {
+		if override > 0 {
+			return override
+		}
+		return p.TTL
+	}
+	return ddl.Config{
+		Database: cfg.ClickHouse.Database,
+		Cluster:  p.Cluster,
+		Engine:   p.TableEngine,
+		TTL: ddl.TTL{
+			Metrics: signalTTL(p.TTLMetrics),
+			Logs:    signalTTL(p.TTLLogs),
+			Traces:  signalTTL(p.TTLTraces),
+		},
+		DatabaseEngine: ddl.DatabaseEngine{
+			Replicated:        p.DatabaseReplicated,
+			ReplicatedZooPath: p.DatabaseReplicatedPath,
+			ReplicatedShard:   p.DatabaseReplicatedShard,
+			ReplicatedReplica: p.DatabaseReplicatedReplica,
+		},
+		Tables: ddl.Tables{
+			Logs:                cfg.Logs.LogsTable,
+			Traces:              cfg.Traces.SpansTable,
+			MetricsGauge:        cfg.Schema.GaugeTable,
+			MetricsSum:          cfg.Schema.SumTable,
+			MetricsHistogram:    cfg.Schema.HistogramTable,
+			MetricsExpHistogram: cfg.Schema.ExpHistogramTable,
+			MetricsSummary:      cfg.Schema.SummaryTable,
+		},
+	}
+}
+
 // setupSchema runs the auto-create-schema startup hook (when enabled)
 // and returns the SchemaReadyFunc the /readyz handler consults. When
 // auto-create is off, readiness must not gate on it, so the returned
@@ -441,7 +487,7 @@ func setupSchema(
 	ctx context.Context,
 	logger *slog.Logger,
 	client *chclient.Client,
-	database string,
+	applyCfg ddl.Config,
 	autoCreate bool,
 ) health.SchemaReadyFunc {
 	ready := new(atomic.Bool)
@@ -451,10 +497,11 @@ func setupSchema(
 	}
 	logger.Info(
 		"auto-creating OTel ClickHouse schema",
-		"database", database,
+		"database", applyCfg.Database,
+		"cluster", applyCfg.Cluster,
+		"replicated_db", applyCfg.DatabaseEngine.Replicated,
 		"signals", "metrics,logs,traces",
 	)
-	applyCfg := ddl.Config{Database: database}
 	apply := func(ctx context.Context) error {
 		return ddl.ApplyWithConfig(ctx, client.Conn(), applyCfg, ddl.All)
 	}

--- a/cmd/cerberus/schema_apply_config_test.go
+++ b/cmd/cerberus/schema_apply_config_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/config"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestSchemaApplyConfig_PerSignalTTLFallback pins the per-signal TTL
+// resolution schemaApplyConfig performs: a non-zero per-signal override
+// wins, and a zero per-signal value inherits the global CERBERUS_SCHEMA_TTL.
+func TestSchemaApplyConfig_PerSignalTTLFallback(t *testing.T) {
+	cfg := config.Config{
+		SchemaProvisioning: config.SchemaProvisioning{
+			TTL:        90 * 24 * time.Hour, // global default
+			TTLLogs:    7 * 24 * time.Hour,  // logs override
+			TTLTraces:  14 * 24 * time.Hour, // traces override
+			TTLMetrics: 0,                   // metrics inherit the global
+		},
+	}
+	got := schemaApplyConfig(cfg)
+	if got.TTL.Metrics != 90*24*time.Hour {
+		t.Errorf("metrics TTL = %v; want global 90d (inherited)", got.TTL.Metrics)
+	}
+	if got.TTL.Logs != 7*24*time.Hour {
+		t.Errorf("logs TTL = %v; want 7d (override)", got.TTL.Logs)
+	}
+	if got.TTL.Traces != 14*24*time.Hour {
+		t.Errorf("traces TTL = %v; want 14d (override)", got.TTL.Traces)
+	}
+}
+
+// TestSchemaApplyConfig_TableNamesThreaded pins that auto-create uses the
+// SAME resolved table names the query heads read (cfg.Schema / Logs /
+// Traces), so a CERBERUS_SCHEMA_*_TABLE override creates and queries the
+// same table rather than silently diverging onto the upstream defaults.
+func TestSchemaApplyConfig_TableNamesThreaded(t *testing.T) {
+	cfg := config.Config{
+		Schema: schema.Metrics{
+			GaugeTable:        "m_gauge",
+			SumTable:          "m_sum",
+			HistogramTable:    "m_hist",
+			ExpHistogramTable: "m_exp",
+			SummaryTable:      "m_summary",
+		},
+		Logs:   schema.Logs{LogsTable: "my_logs"},
+		Traces: schema.Traces{SpansTable: "my_spans"},
+	}
+	got := schemaApplyConfig(cfg)
+	if got.Tables.MetricsGauge != "m_gauge" || got.Tables.MetricsSum != "m_sum" ||
+		got.Tables.MetricsHistogram != "m_hist" || got.Tables.MetricsExpHistogram != "m_exp" ||
+		got.Tables.MetricsSummary != "m_summary" {
+		t.Errorf("metrics table names not threaded: %+v", got.Tables)
+	}
+	if got.Tables.Logs != "my_logs" {
+		t.Errorf("logs table = %q; want my_logs", got.Tables.Logs)
+	}
+	if got.Tables.Traces != "my_spans" {
+		t.Errorf("traces table = %q; want my_spans", got.Tables.Traces)
+	}
+}
+
+// TestSchemaApplyConfig_ReplicatedThreaded pins the Replicated database
+// engine knobs flow through to the ddl Config.
+func TestSchemaApplyConfig_ReplicatedThreaded(t *testing.T) {
+	cfg := config.Config{
+		SchemaProvisioning: config.SchemaProvisioning{
+			Cluster:                   "", // mutually exclusive with replicated
+			DatabaseReplicated:        true,
+			DatabaseReplicatedPath:    "/clickhouse/databases/otel",
+			DatabaseReplicatedShard:   "shard0",
+			DatabaseReplicatedReplica: "replica0",
+		},
+	}
+	got := schemaApplyConfig(cfg)
+	if !got.DatabaseEngine.Replicated ||
+		got.DatabaseEngine.ReplicatedZooPath != "/clickhouse/databases/otel" ||
+		got.DatabaseEngine.ReplicatedShard != "shard0" ||
+		got.DatabaseEngine.ReplicatedReplica != "replica0" {
+		t.Errorf("replicated engine not threaded: %+v", got.DatabaseEngine)
+	}
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -253,10 +253,27 @@ also honored by the OTel Go SDK and merge with these. See
 
 ## Schema
 
-| Variable                      | Type | Default | Description                                                                                                                                                                                                            |
-| ----------------------------- | ---- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `CERBERUS_AUTO_CREATE_SCHEMA` | bool | `false` | When `true`, run the idempotent OTel-CH exporter DDL at startup before HTTP serving begins.                                                                                                                            |
-| `CERBERUS_REQUIREMENTS_CHECK` | bool | `true`  | Run the boot-time requirements check after the schema-create step. Fails startup on a fatal finding (too-old server, wrong-shape table); an absent (not-yet-provisioned) schema instead boots NOT READY and re-probes. |
+| Variable                                      | Type     | Default                          | Description                                                                                                                                                                                                            |
+| --------------------------------------------- | -------- | -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CERBERUS_AUTO_CREATE_SCHEMA`                 | bool     | `false`                          | When `true`, run the idempotent OTel-CH exporter DDL at startup before HTTP serving begins. The knobs below shape that DDL — all are no-ops unless this is `true`.                                                     |
+| `CERBERUS_SCHEMA_CLUSTER`                     | string   | (empty)                          | Render an `ON CLUSTER <name>` clause into the auto-create DDL (classic distributed-DDL clusters). Mutually exclusive with `CERBERUS_SCHEMA_DATABASE_REPLICATED`.                                                       |
+| `CERBERUS_SCHEMA_TABLE_ENGINE`                | string   | `MergeTree()`                    | Override the table engine. Only needed for a classic `ON CLUSTER` cluster that wants an explicit `ReplicatedMergeTree(...)`; inside a Replicated database the plain default auto-converts.                             |
+| `CERBERUS_SCHEMA_TTL`                         | duration | `0s`                             | Global default retention for every signal's tables (no TTL clause when `0`; e.g. `2160h` = 90 days). Per-signal overrides below take precedence.                                                                       |
+| `CERBERUS_SCHEMA_TTL_METRICS`                 | duration | (inherits `CERBERUS_SCHEMA_TTL`) | Retention for the five metrics tables. A non-zero value overrides the global default for metrics.                                                                                                                      |
+| `CERBERUS_SCHEMA_TTL_LOGS`                    | duration | (inherits `CERBERUS_SCHEMA_TTL`) | Retention for the logs table.                                                                                                                                                                                          |
+| `CERBERUS_SCHEMA_TTL_TRACES`                  | duration | (inherits `CERBERUS_SCHEMA_TTL`) | Retention for the spans + `trace_id_ts` tables.                                                                                                                                                                        |
+| `CERBERUS_SCHEMA_DATABASE_REPLICATED`         | bool     | `false`                          | Create the database with `ENGINE = Replicated(...)` so DDL auto-replicates across replicas and `MergeTree` tables auto-convert to `ReplicatedMergeTree` (no `ON CLUSTER` needed).                                      |
+| `CERBERUS_SCHEMA_DATABASE_REPLICATED_PATH`    | string   | (empty)                          | ZooKeeper/Keeper path the Replicated engine coordinates on (e.g. `/clickhouse/databases/otel`). **Required** when `CERBERUS_SCHEMA_DATABASE_REPLICATED=true`.                                                          |
+| `CERBERUS_SCHEMA_DATABASE_REPLICATED_SHARD`   | string   | `{shard}`                        | Shard name for the Replicated engine — defaults to the ClickHouse server macro.                                                                                                                                        |
+| `CERBERUS_SCHEMA_DATABASE_REPLICATED_REPLICA` | string   | `{replica}`                      | Replica name for the Replicated engine — defaults to the ClickHouse server macro.                                                                                                                                      |
+| `CERBERUS_REQUIREMENTS_CHECK`                 | bool     | `true`                           | Run the boot-time requirements check after the schema-create step. Fails startup on a fatal finding (too-old server, wrong-shape table); an absent (not-yet-provisioned) schema instead boots NOT READY and re-probes. |
+
+> The auto-create hook reuses the same table names the query heads read
+> (the `CERBERUS_SCHEMA_*_TABLE` overrides), so a renamed table is created
+> **and** queried consistently. Retention is keyed per **signal**, not per
+> individual table — the five metrics tables share one TTL, etc. — because
+> that matches how observability retention is set (logs short, metrics long).
+> A deployment needing genuinely per-table retention runs the DDL itself.
 
 The preflight runs two gates, both parameterised by the active
 (override-resolved) configuration:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -356,6 +356,44 @@ crash-loop; see [`health.md`](health.md)). Fail-fast is reserved for
 misconfiguration that can never succeed — a bad env value or invalid
 connection options abort startup with a clear error.
 
+### Auto-create schema: single-node vs clustered
+
+When `CERBERUS_AUTO_CREATE_SCHEMA=true`, the `CERBERUS_SCHEMA_*` knobs shape
+the DDL cerberus emits (all are no-ops when auto-create is off). The DDL is
+built through the typed `internal/chsql` builder — cerberus never
+hand-concatenates SQL — and the table column bodies still come verbatim from
+the upstream OTel ClickHouse exporter templates; only the database engine,
+`ON CLUSTER`, table engine and TTL clauses are cerberus-parameterised.
+
+- **Single-node (default).** No cluster, no TTL, an Atomic database, plain
+  `MergeTree` tables. Nothing to set.
+- **Replicated database (recommended for a cluster).** Set
+  `CERBERUS_SCHEMA_DATABASE_REPLICATED=true` and
+  `CERBERUS_SCHEMA_DATABASE_REPLICATED_PATH=/clickhouse/databases/otel`. The
+  database is created with `ENGINE = Replicated(<path>, {shard}, {replica})`;
+  a Replicated database **auto-replicates all DDL** across replicas and
+  **auto-converts `MergeTree` → `ReplicatedMergeTree`**, so you leave
+  `CERBERUS_SCHEMA_CLUSTER` and `CERBERUS_SCHEMA_TABLE_ENGINE` unset — the
+  `{shard}`/`{replica}` server macros do the rest. This mirrors how a
+  Replicated database is run in practice (no `ON CLUSTER` inside it).
+- **Classic `ON CLUSTER` cluster.** Set `CERBERUS_SCHEMA_CLUSTER=<name>` and,
+  if the engine isn't replicated by the cluster default, an explicit
+  `CERBERUS_SCHEMA_TABLE_ENGINE=ReplicatedMergeTree('/clickhouse/tables/{uuid}/{shard}', '{replica}')`.
+  `ON CLUSTER` and the Replicated database engine are mutually exclusive —
+  pick one.
+
+**Retention is per signal.** `CERBERUS_SCHEMA_TTL` sets a global default;
+`CERBERUS_SCHEMA_TTL_{METRICS,LOGS,TRACES}` override one signal each (a zero
+override inherits the global). Retention keys on the signal — the five
+metrics tables share one TTL, the spans + `trace_id_ts` lookup share another
+— because that is how observability retention is actually managed (logs
+short, metrics long). A deployment that needs genuinely per-table retention
+runs the DDL itself rather than via the auto-create hook.
+
+Auto-create also reuses the **same** table names the query heads read
+(`CERBERUS_SCHEMA_*_TABLE`), so a renamed table is created and queried
+consistently rather than silently diverging onto the upstream defaults.
+
 ### Startup requirements preflight
 
 `CERBERUS_REQUIREMENTS_CHECK` (**on by default**) runs a boot-time

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -54,6 +54,16 @@ type Config struct {
 	// the flag on an already-populated ClickHouse is a no-op.
 	AutoCreateSchema bool
 
+	// SchemaProvisioning carries the DDL knobs the auto-create hook
+	// (CERBERUS_AUTO_CREATE_SCHEMA) uses when it creates the OTel schema.
+	// Every field is a no-op unless AutoCreateSchema is true. The zero value
+	// is cerberus's single-node shape: an Atomic database, MergeTree tables,
+	// no ON CLUSTER, no TTL. The table names are NOT here — auto-create
+	// reuses the same Schema / Logs / Traces table names the query heads
+	// read, so a CERBERUS_SCHEMA_*_TABLE override creates and reads the same
+	// table.
+	SchemaProvisioning SchemaProvisioning
+
 	// RequirementsCheck, when true (the default), runs the boot-time
 	// requirements check after the schema-create step: it inspects the
 	// connected ClickHouse server version against the config-derived
@@ -111,6 +121,62 @@ type Config struct {
 	// are rejected with HTTP 503 + Retry-After: 1 so well-behaved
 	// clients back off and CH stays out of overload.
 	Admit AdmitConfig
+}
+
+// SchemaProvisioning carries the DDL-shaping knobs the auto-create hook
+// applies when CERBERUS_AUTO_CREATE_SCHEMA=true. They mirror the typed
+// internal/schema/ddl Config surface; the zero value is the single-node
+// shape cerberus ships by default (Atomic database, MergeTree tables, no
+// cluster, no TTL).
+type SchemaProvisioning struct {
+	// Cluster (CERBERUS_SCHEMA_CLUSTER) renders an ON CLUSTER clause into
+	// every CREATE statement — the classic distributed-DDL model. Mutually
+	// exclusive with DatabaseReplicated (a Replicated database replicates
+	// DDL itself); leave it empty for a single-node or Replicated-database
+	// deployment.
+	Cluster string
+
+	// TableEngine (CERBERUS_SCHEMA_TABLE_ENGINE) overrides the table engine.
+	// Empty renders the upstream default `MergeTree()`. Inside a Replicated
+	// database the plain default is correct — ClickHouse auto-converts it to
+	// ReplicatedMergeTree — so this is only for classic ON CLUSTER clusters
+	// that need an explicit `ReplicatedMergeTree(<zoo>, <replica>)`.
+	TableEngine string
+
+	// TTL (CERBERUS_SCHEMA_TTL) is the DEFAULT retention applied to every
+	// signal's tables (e.g. `2160h` = 90 days). Zero (the default) leaves
+	// retention to the operator — no TTL clause is emitted. The per-signal
+	// overrides below take precedence when set.
+	TTL time.Duration
+
+	// TTLMetrics / TTLLogs / TTLTraces (CERBERUS_SCHEMA_TTL_METRICS / _LOGS /
+	// _TRACES) override TTL for a single signal. Observability retention is
+	// conventionally per-signal — logs are voluminous and short-lived,
+	// metrics long-lived — so each signal can diverge from the global
+	// default. A zero value inherits TTL; a non-zero value overrides it.
+	TTLMetrics time.Duration
+	TTLLogs    time.Duration
+	TTLTraces  time.Duration
+
+	// DatabaseReplicated (CERBERUS_SCHEMA_DATABASE_REPLICATED) creates the
+	// database with `ENGINE = Replicated(...)`. A Replicated database
+	// auto-replicates all DDL across replicas and auto-converts MergeTree
+	// tables to ReplicatedMergeTree, so no ON CLUSTER / explicit replicated
+	// table engine is needed. Requires DatabaseReplicatedPath.
+	DatabaseReplicated bool
+
+	// DatabaseReplicatedPath (CERBERUS_SCHEMA_DATABASE_REPLICATED_PATH) is
+	// the ZooKeeper/Keeper path the Replicated engine coordinates on, e.g.
+	// `/clickhouse/databases/otel`. Required when DatabaseReplicated is true.
+	DatabaseReplicatedPath string
+
+	// DatabaseReplicatedShard / DatabaseReplicatedReplica
+	// (CERBERUS_SCHEMA_DATABASE_REPLICATED_SHARD / _REPLICA) name the shard
+	// and replica the engine identifies this node by. Empty falls back to
+	// the ClickHouse server macros `{shard}` / `{replica}` (the conventional
+	// cluster setup), resolved in internal/schema/ddl.
+	DatabaseReplicatedShard   string
+	DatabaseReplicatedReplica string
 }
 
 // AdmitConfig holds the per-handler concurrency cap knobs.
@@ -263,6 +329,16 @@ const (
 	envHTTPMaxHeaderBytes  = "CERBERUS_HTTP_MAX_HEADER_BYTES"
 	envLokiTailWriteTO     = "CERBERUS_LOKI_TAIL_WRITE_TIMEOUT"
 	envAutoCreateSchema    = "CERBERUS_AUTO_CREATE_SCHEMA"
+	envSchemaCluster       = "CERBERUS_SCHEMA_CLUSTER"
+	envSchemaTableEngine   = "CERBERUS_SCHEMA_TABLE_ENGINE"
+	envSchemaTTL           = "CERBERUS_SCHEMA_TTL"
+	envSchemaTTLMetrics    = "CERBERUS_SCHEMA_TTL_METRICS"
+	envSchemaTTLLogs       = "CERBERUS_SCHEMA_TTL_LOGS"
+	envSchemaTTLTraces     = "CERBERUS_SCHEMA_TTL_TRACES"
+	envSchemaDBReplicated  = "CERBERUS_SCHEMA_DATABASE_REPLICATED"
+	envSchemaDBReplPath    = "CERBERUS_SCHEMA_DATABASE_REPLICATED_PATH"
+	envSchemaDBReplShard   = "CERBERUS_SCHEMA_DATABASE_REPLICATED_SHARD"
+	envSchemaDBReplReplica = "CERBERUS_SCHEMA_DATABASE_REPLICATED_REPLICA"
 	envRequirementsCheck   = "CERBERUS_REQUIREMENTS_CHECK"
 	envExperimentalTSGrid  = "CERBERUS_EXPERIMENTAL_TS_GRID_RANGE"
 	envLogFormat           = "CERBERUS_LOG_FORMAT"
@@ -338,6 +414,23 @@ const configFileBaseName = "cerberus"
 //	CERBERUS_HTTP_MAX_HEADER_BYTES default 0 (0 → Go's 1 MiB default)
 //	CERBERUS_LOKI_TAIL_WRITE_TIMEOUT default "10s" (single /tail WebSocket write bound; > 0)
 //	CERBERUS_AUTO_CREATE_SCHEMA    default "false"
+//	CERBERUS_SCHEMA_CLUSTER        default "" — ON CLUSTER clause for auto-create
+//	    DDL (classic distributed-DDL clusters). Mutually exclusive with
+//	    CERBERUS_SCHEMA_DATABASE_REPLICATED.
+//	CERBERUS_SCHEMA_TABLE_ENGINE   default "" → MergeTree(); override only for a
+//	    classic ON CLUSTER cluster needing an explicit ReplicatedMergeTree(...)
+//	CERBERUS_SCHEMA_TTL            default "0s" — global default retention for all
+//	    signals (no TTL clause when 0; e.g. "2160h" = 90d)
+//	CERBERUS_SCHEMA_TTL_METRICS   default inherits CERBERUS_SCHEMA_TTL; per-signal override
+//	CERBERUS_SCHEMA_TTL_LOGS      default inherits CERBERUS_SCHEMA_TTL; per-signal override
+//	CERBERUS_SCHEMA_TTL_TRACES    default inherits CERBERUS_SCHEMA_TTL; per-signal override
+//	CERBERUS_SCHEMA_DATABASE_REPLICATED default "false" — create the database with
+//	    ENGINE = Replicated(...) so DDL auto-replicates and MergeTree tables
+//	    auto-convert to ReplicatedMergeTree (no ON CLUSTER needed)
+//	CERBERUS_SCHEMA_DATABASE_REPLICATED_PATH default "" — Keeper path, required when
+//	    CERBERUS_SCHEMA_DATABASE_REPLICATED=true (e.g. "/clickhouse/databases/otel")
+//	CERBERUS_SCHEMA_DATABASE_REPLICATED_SHARD   default "{shard}" server macro
+//	CERBERUS_SCHEMA_DATABASE_REPLICATED_REPLICA default "{replica}" server macro
 //	CERBERUS_REQUIREMENTS_CHECK     default "true" — run the boot-time
 //	    requirements check (CH server version >= the config-derived minimum
 //	    AND deployed schema shape) AFTER the schema-create step; any unmet
@@ -379,15 +472,11 @@ func FromEnv() (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
-	autoCreate, err := getBool(v, envAutoCreateSchema)
+	flags, err := bootFlagsFromEnv(v)
 	if err != nil {
 		return Config{}, err
 	}
-	requirementsCheck, err := getBool(v, envRequirementsCheck)
-	if err != nil {
-		return Config{}, err
-	}
-	tsGridRange, err := getBool(v, envExperimentalTSGrid)
+	schemaProvisioning, err := schemaProvisioningFromEnv(v)
 	if err != nil {
 		return Config{}, err
 	}
@@ -528,9 +617,10 @@ func FromEnv() (Config, error) {
 		Schema:                  schema.DefaultOTelMetricsFromEnv(),
 		Logs:                    schema.DefaultOTelLogsFromEnv(),
 		Traces:                  schema.DefaultOTelTracesFromEnv(),
-		AutoCreateSchema:        autoCreate,
-		RequirementsCheck:       requirementsCheck,
-		ExperimentalTSGridRange: tsGridRange,
+		AutoCreateSchema:        flags.AutoCreate,
+		SchemaProvisioning:      schemaProvisioning,
+		RequirementsCheck:       flags.RequirementsCheck,
+		ExperimentalTSGridRange: flags.TSGridRange,
 		Log:                     logCfg,
 		OTLP:                    otlp,
 		Admit:                   admit,
@@ -587,6 +677,16 @@ var allEnvKeys = []string{
 	envHTTPMaxHeaderBytes,
 	envLokiTailWriteTO,
 	envAutoCreateSchema,
+	envSchemaCluster,
+	envSchemaTableEngine,
+	envSchemaTTL,
+	envSchemaTTLMetrics,
+	envSchemaTTLLogs,
+	envSchemaTTLTraces,
+	envSchemaDBReplicated,
+	envSchemaDBReplPath,
+	envSchemaDBReplShard,
+	envSchemaDBReplReplica,
 	envRequirementsCheck,
 	envExperimentalTSGrid,
 	envLogFormat,
@@ -674,6 +774,16 @@ func newLoader() *viper.Viper {
 	v.SetDefault(envHTTPMaxHeaderBytes, defaultHTTPMaxHeaderBytes)
 	v.SetDefault(envLokiTailWriteTO, defaultLokiTailWriteTimeout.String())
 	v.SetDefault(envAutoCreateSchema, defaultAutoCreateSchema)
+	// Schema-provisioning bool + duration knobs need a non-empty default so
+	// the getBool / getDuration parsers don't reject an unset value. The
+	// string knobs (cluster, table engine, replicated path/shard/replica)
+	// resolve "" via getString and need none — internal/schema/ddl supplies
+	// the {shard}/{replica} macro fallbacks when the database is Replicated.
+	v.SetDefault(envSchemaDBReplicated, defaultSchemaDBReplicated)
+	v.SetDefault(envSchemaTTL, defaultSchemaTTL)
+	v.SetDefault(envSchemaTTLMetrics, defaultSchemaTTL)
+	v.SetDefault(envSchemaTTLLogs, defaultSchemaTTL)
+	v.SetDefault(envSchemaTTLTraces, defaultSchemaTTL)
 	v.SetDefault(envRequirementsCheck, defaultRequirementsCheck)
 	v.SetDefault(envExperimentalTSGrid, defaultExperimentalTSGrid)
 	v.SetDefault(envLogFormat, defaultLogFormat)
@@ -718,6 +828,8 @@ const (
 	defaultCHUsername         = "default"
 	defaultCHPassword         = ""
 	defaultAutoCreateSchema   = false
+	defaultSchemaDBReplicated = false
+	defaultSchemaTTL          = "0s"
 	defaultRequirementsCheck  = true
 	defaultExperimentalTSGrid = false
 	defaultLogFormat          = "text"
@@ -1206,6 +1318,79 @@ func getDuration(v *viper.Viper, key string) (time.Duration, error) {
 		return 0, fmt.Errorf("%s: %w", key, err)
 	}
 	return d, nil
+}
+
+// bootFlags groups the boolean boot-time toggles FromEnv resolves: the
+// auto-create-schema hook, the requirements preflight, and the experimental
+// native-rate path. Grouping them keeps the per-flag parse + fail-fast error
+// checks out of FromEnv's body.
+type bootFlags struct {
+	AutoCreate        bool
+	RequirementsCheck bool
+	TSGridRange       bool
+}
+
+// bootFlagsFromEnv parses the three boolean boot toggles, failing fast on a
+// malformed value exactly as the inline parses did.
+func bootFlagsFromEnv(v *viper.Viper) (bootFlags, error) {
+	autoCreate, err := getBool(v, envAutoCreateSchema)
+	if err != nil {
+		return bootFlags{}, err
+	}
+	requirementsCheck, err := getBool(v, envRequirementsCheck)
+	if err != nil {
+		return bootFlags{}, err
+	}
+	tsGridRange, err := getBool(v, envExperimentalTSGrid)
+	if err != nil {
+		return bootFlags{}, err
+	}
+	return bootFlags{
+		AutoCreate:        autoCreate,
+		RequirementsCheck: requirementsCheck,
+		TSGridRange:       tsGridRange,
+	}, nil
+}
+
+// schemaProvisioningFromEnv parses the CERBERUS_SCHEMA_* auto-create knobs
+// into a SchemaProvisioning. Extracted from FromEnv so the boolean +
+// duration parses (each fail-fast on a malformed value) live in one place
+// rather than inflating FromEnv's branch count. The string knobs resolve via
+// getString (empty is valid); internal/schema/ddl supplies the
+// {shard}/{replica} macro fallbacks when the database is Replicated.
+func schemaProvisioningFromEnv(v *viper.Viper) (SchemaProvisioning, error) {
+	replicated, err := getBool(v, envSchemaDBReplicated)
+	if err != nil {
+		return SchemaProvisioning{}, err
+	}
+	ttl, err := getDuration(v, envSchemaTTL)
+	if err != nil {
+		return SchemaProvisioning{}, err
+	}
+	ttlMetrics, err := getDuration(v, envSchemaTTLMetrics)
+	if err != nil {
+		return SchemaProvisioning{}, err
+	}
+	ttlLogs, err := getDuration(v, envSchemaTTLLogs)
+	if err != nil {
+		return SchemaProvisioning{}, err
+	}
+	ttlTraces, err := getDuration(v, envSchemaTTLTraces)
+	if err != nil {
+		return SchemaProvisioning{}, err
+	}
+	return SchemaProvisioning{
+		Cluster:                   getString(v, envSchemaCluster),
+		TableEngine:               getString(v, envSchemaTableEngine),
+		TTL:                       ttl,
+		TTLMetrics:                ttlMetrics,
+		TTLLogs:                   ttlLogs,
+		TTLTraces:                 ttlTraces,
+		DatabaseReplicated:        replicated,
+		DatabaseReplicatedPath:    getString(v, envSchemaDBReplPath),
+		DatabaseReplicatedShard:   getString(v, envSchemaDBReplShard),
+		DatabaseReplicatedReplica: getString(v, envSchemaDBReplReplica),
+	}, nil
 }
 
 // envLog parses CERBERUS_LOG_FORMAT + CERBERUS_LOG_LEVEL from the viper

--- a/internal/config/matrix_test.go
+++ b/internal/config/matrix_test.go
@@ -6,6 +6,66 @@ import (
 	"time"
 )
 
+// TestFromEnv_SchemaProvisioning_Defaults confirms the schema-provisioning
+// knobs default to the single-node zero shape (no cluster / engine / TTL /
+// replicated database).
+func TestFromEnv_SchemaProvisioning_Defaults(t *testing.T) {
+	for _, k := range []string{
+		"CERBERUS_SCHEMA_CLUSTER", "CERBERUS_SCHEMA_TABLE_ENGINE", "CERBERUS_SCHEMA_TTL",
+		"CERBERUS_SCHEMA_TTL_METRICS", "CERBERUS_SCHEMA_TTL_LOGS", "CERBERUS_SCHEMA_TTL_TRACES",
+		"CERBERUS_SCHEMA_DATABASE_REPLICATED", "CERBERUS_SCHEMA_DATABASE_REPLICATED_PATH",
+		"CERBERUS_SCHEMA_DATABASE_REPLICATED_SHARD", "CERBERUS_SCHEMA_DATABASE_REPLICATED_REPLICA",
+	} {
+		t.Setenv(k, "")
+	}
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	p := cfg.SchemaProvisioning
+	if p.Cluster != "" || p.TableEngine != "" || p.DatabaseReplicated ||
+		p.TTL != 0 || p.TTLMetrics != 0 || p.TTLLogs != 0 || p.TTLTraces != 0 ||
+		p.DatabaseReplicatedPath != "" {
+		t.Errorf("schema provisioning defaults not zero: %+v", p)
+	}
+}
+
+// TestFromEnv_SchemaProvisioning_Overrides confirms every schema-provisioning
+// env var (including the per-signal TTL overrides and the Replicated engine
+// knobs) parses into SchemaProvisioning.
+func TestFromEnv_SchemaProvisioning_Overrides(t *testing.T) {
+	t.Setenv("CERBERUS_SCHEMA_CLUSTER", "prod")
+	t.Setenv("CERBERUS_SCHEMA_TABLE_ENGINE", "ReplicatedMergeTree('/p', '{replica}')")
+	t.Setenv("CERBERUS_SCHEMA_TTL", "2160h")
+	t.Setenv("CERBERUS_SCHEMA_TTL_LOGS", "168h")
+	t.Setenv("CERBERUS_SCHEMA_DATABASE_REPLICATED", "true")
+	t.Setenv("CERBERUS_SCHEMA_DATABASE_REPLICATED_PATH", "/clickhouse/databases/otel")
+	t.Setenv("CERBERUS_SCHEMA_DATABASE_REPLICATED_SHARD", "shard0")
+	t.Setenv("CERBERUS_SCHEMA_DATABASE_REPLICATED_REPLICA", "replica0")
+
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	p := cfg.SchemaProvisioning
+	if p.Cluster != "prod" {
+		t.Errorf("Cluster = %q; want prod", p.Cluster)
+	}
+	if p.TableEngine != "ReplicatedMergeTree('/p', '{replica}')" {
+		t.Errorf("TableEngine = %q", p.TableEngine)
+	}
+	if p.TTL != 2160*time.Hour {
+		t.Errorf("TTL = %v; want 2160h", p.TTL)
+	}
+	if p.TTLLogs != 168*time.Hour {
+		t.Errorf("TTLLogs = %v; want 168h", p.TTLLogs)
+	}
+	if !p.DatabaseReplicated || p.DatabaseReplicatedPath != "/clickhouse/databases/otel" ||
+		p.DatabaseReplicatedShard != "shard0" || p.DatabaseReplicatedReplica != "replica0" {
+		t.Errorf("replicated knobs not parsed: %+v", p)
+	}
+}
+
 // TestFromEnv_HTTPAddr_Default confirms the documented :8080 fallback
 // when CERBERUS_HTTP_ADDR is unset.
 func TestFromEnv_HTTPAddr_Default(t *testing.T) {

--- a/internal/schema/ddl/ddl.go
+++ b/internal/schema/ddl/ddl.go
@@ -62,9 +62,12 @@ type Config struct {
 	// "MergeTree()" — matches the upstream exporter default.
 	Engine string
 
-	// TTL, when non-zero, renders a `TTL <timeField> + toIntervalXxx(N)`
-	// clause into each template. Cerberus leaves TTL to the operator.
-	TTL time.Duration
+	// TTL sets per-signal retention on the created tables — a zero duration
+	// for a signal emits no TTL clause (operator-managed retention).
+	// Retention is conventionally keyed on the signal (logs short, metrics
+	// long), not the individual table, so the five metrics tables share
+	// TTL.Metrics and the spans + lookup tables share TTL.Traces. See TTL.
+	TTL TTL
 
 	// DatabaseEngine selects the ClickHouse engine for the CREATE DATABASE
 	// statement. The zero value emits no ENGINE clause (server default
@@ -106,6 +109,25 @@ type DatabaseEngine struct {
 	// the conventional cluster setup, so most operators leave them unset.
 	ReplicatedShard   string
 	ReplicatedReplica string
+}
+
+// TTL carries per-signal retention durations for the auto-created tables.
+// A zero duration leaves that signal's tables with no TTL clause. Retention
+// is keyed on the signal rather than the individual table because that is
+// how observability retention is actually set — logs are voluminous and
+// short-lived, metrics are long-lived — and the tables within a signal
+// (the five metrics tables; the traces spans + trace_id_ts lookup) share a
+// lifecycle. An operator needing genuinely per-table retention runs the DDL
+// themselves instead of via the auto-create hook.
+type TTL struct {
+	// Metrics applies to the five metrics tables (retention keyed on the
+	// TimeUnix column).
+	Metrics time.Duration
+	// Logs applies to the logs table (keyed on Timestamp).
+	Logs time.Duration
+	// Traces applies to the spans table (keyed on Timestamp) and the
+	// trace_id_ts lookup table (keyed on Start).
+	Traces time.Duration
 }
 
 // Tables overrides the per-signal table name used when rendering each
@@ -201,13 +223,13 @@ func (c Config) clusterClause() string {
 
 // ttlExpr renders the optional `TTL toDateTime(<column>) + toIntervalXxx(N)`
 // fragment that upstream templates expect as one slot per signal, or ""
-// when no TTL is configured. column is the bare time column retention
-// keys on — Metrics use TimeUnix, Logs and Traces spans use Timestamp,
-// the traces lookup uses Start. Built via the typed chsql.TableTTL
-// constructor (Add(Call(toDateTime, …), Call(toIntervalXxx, …))), which
-// reproduces upstream's `internal.GenerateTTLExpr` shape byte-for-byte.
-func (c Config) ttlExpr(column string) string {
-	frag := chsql.TableTTL(column, c.TTL)
+// when ttl <= 0. column is the bare time column retention keys on — Metrics
+// use TimeUnix, Logs and Traces spans use Timestamp, the traces lookup uses
+// Start. Built via the typed chsql.TableTTL constructor (Add(Call(toDateTime,
+// …), Call(toIntervalXxx, …))), which reproduces upstream's
+// `internal.GenerateTTLExpr` shape byte-for-byte.
+func ttlExpr(column string, ttl time.Duration) string {
+	frag := chsql.TableTTL(column, ttl)
 	if frag == nil {
 		return ""
 	}
@@ -314,7 +336,7 @@ func applySignal(ctx context.Context, conn driver.Conn, cfg Config, s Signal) er
 func renderSignal(cfg Config, s Signal) ([]string, error) {
 	switch s {
 	case Metrics:
-		ttl := cfg.ttlExpr("TimeUnix")
+		ttl := ttlExpr("TimeUnix", cfg.TTL.Metrics)
 		return []string{
 			renderMetricsTable(sqltemplates.MetricsGaugeCreateTable, cfg, cfg.Tables.MetricsGauge, ttl),
 			renderMetricsTable(sqltemplates.MetricsSumCreateTable, cfg, cfg.Tables.MetricsSum, ttl),
@@ -361,7 +383,7 @@ func renderLogsTable(cfg Config) (string, error) {
 		TableName:         cfg.Tables.Logs,
 		ClusterString:     cfg.clusterClause(),
 		Engine:            cfg.Engine,
-		TTL:               cfg.ttlExpr("Timestamp"),
+		TTL:               ttlExpr("Timestamp", cfg.TTL.Logs),
 		HasFullTextSearch: false,
 	}
 	var buf strings.Builder
@@ -379,7 +401,7 @@ func renderTracesTable(cfg Config) string {
 		sqltemplates.TracesCreateTable,
 		cfg.Database, cfg.Tables.Traces, cfg.clusterClause(),
 		cfg.Engine,
-		cfg.ttlExpr("Timestamp"),
+		ttlExpr("Timestamp", cfg.TTL.Traces),
 	)
 }
 
@@ -393,7 +415,7 @@ func renderTracesCreateTsTable(cfg Config) string {
 		sqltemplates.TracesCreateTsTable,
 		cfg.Database, cfg.Tables.Traces, cfg.clusterClause(),
 		cfg.Engine,
-		cfg.ttlExpr("Start"),
+		ttlExpr("Start", cfg.TTL.Traces),
 	)
 }
 

--- a/internal/schema/ddl/ddl_test.go
+++ b/internal/schema/ddl/ddl_test.go
@@ -140,7 +140,7 @@ func TestRenderSignal_CustomConfig(t *testing.T) {
 		Database: "cerberus_test",
 		Cluster:  "my_cluster",
 		Engine:   "ReplicatedMergeTree('/clickhouse/{shard}/tables/{table}', '{replica}')",
-		TTL:      48 * time.Hour,
+		TTL:      TTL{Metrics: 48 * time.Hour, Logs: 48 * time.Hour, Traces: 48 * time.Hour},
 		Tables: Tables{
 			MetricsGauge:        "custom_gauge",
 			MetricsSum:          "custom_sum",
@@ -218,11 +218,42 @@ func TestTTLExpr_RoundingBuckets(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := (Config{TTL: tc.ttl}).ttlExpr("t")
+			got := ttlExpr("t", tc.ttl)
 			if got != tc.want {
 				t.Errorf("ttlExpr: got %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+// TestRenderSignal_PerSignalTTL pins independent per-signal retention: a
+// different TTL for metrics, logs, and traces lands on the right tables
+// (and a zero for a signal emits no TTL), proving the signals don't share
+// one global duration.
+func TestRenderSignal_PerSignalTTL(t *testing.T) {
+	cfg := Config{
+		TTL: TTL{
+			Metrics: 90 * 24 * time.Hour, // 90 days
+			Logs:    7 * 24 * time.Hour,  // 7 days
+			Traces:  0,                   // no TTL on traces
+		},
+	}.withDefaults()
+
+	metrics, _ := renderSignal(cfg, Metrics)
+	for i, stmt := range metrics {
+		if !strings.Contains(stmt, "TTL toDateTime(TimeUnix) + toIntervalDay(90)") {
+			t.Errorf("metrics[%d]: want 90d TTL:\n%s", i, stmt)
+		}
+	}
+	logs, _ := renderSignal(cfg, Logs)
+	if !strings.Contains(logs[0], "TTL toDateTime(Timestamp) + toIntervalDay(7)") {
+		t.Errorf("logs: want 7d TTL:\n%s", logs[0])
+	}
+	traces, _ := renderSignal(cfg, Traces)
+	for i, stmt := range traces {
+		if strings.Contains(stmt, "TTL toDateTime") {
+			t.Errorf("traces[%d]: TTL=0 must emit no TTL clause:\n%s", i, stmt)
+		}
 	}
 }
 

--- a/internal/schema/ddl/idempotency_test.go
+++ b/internal/schema/ddl/idempotency_test.go
@@ -415,7 +415,7 @@ func TestRenderSignal_ConcurrentRendersDoNotRace(t *testing.T) {
 // produces statements without a TTL keyword. Cerberus's default leaves
 // retention to the operator.
 func TestRenderSignal_TTLZeroSkipsTTLClause(t *testing.T) {
-	cfg := Config{TTL: 0}.withDefaults()
+	cfg := Config{TTL: TTL{}}.withDefaults()
 	for _, sig := range All {
 		stmts, _ := renderSignal(cfg, sig)
 		for i, stmt := range stmts {
@@ -436,7 +436,7 @@ func TestRenderSignal_TTLZeroSkipsTTLClause(t *testing.T) {
 // toDateTime(TimeUnix). A swap would silently render valid SQL against
 // the wrong column.
 func TestRenderSignal_TTLAppliesCorrectTimeFieldPerSignal(t *testing.T) {
-	cfg := Config{TTL: 24 * time.Hour}.withDefaults()
+	cfg := Config{TTL: TTL{Metrics: 24 * time.Hour, Logs: 24 * time.Hour, Traces: 24 * time.Hour}}.withDefaults()
 	logs, _ := renderSignal(cfg, Logs)
 	if !strings.Contains(logs[0], "TTL toDateTime(Timestamp) + toIntervalDay(1)") {
 		t.Errorf("logs TTL: missing toDateTime(Timestamp) field:\n%s", logs[0])


### PR DESCRIPTION
Follow-up to #940 (the typed DDL builder + Replicated capability). That PR added the typed parameterisation; this one makes it reachable by operators and documents it.

## Operator config (`CERBERUS_SCHEMA_*`)

`CERBERUS_AUTO_CREATE_SCHEMA` now honours a `SchemaProvisioning` block instead of only the database name:

- `CERBERUS_SCHEMA_CLUSTER` → `ON CLUSTER` (classic distributed DDL)
- `CERBERUS_SCHEMA_TABLE_ENGINE` → table engine override
- `CERBERUS_SCHEMA_DATABASE_REPLICATED` (+ `_PATH`/`_SHARD`/`_REPLICA`) → `ENGINE = Replicated(...)` (the squid-style clustered shape: DDL auto-replicates, `MergeTree` auto-converts, no `ON CLUSTER`)
- **Table names are threaded** from the same resolved `Schema`/`Logs`/`Traces` structs the query heads read — so a `CERBERUS_SCHEMA_*_TABLE` override now creates **and** queries the same table (fixes a latent divergence where auto-create used the upstream defaults regardless of the override).

## Per-signal TTL

A single global TTL is too coarse for observability (logs short, metrics long). `ddl.Config.TTL` becomes a typed **per-signal** struct (`Metrics`/`Logs`/`Traces`); config exposes a global `CERBERUS_SCHEMA_TTL` default plus `CERBERUS_SCHEMA_TTL_{METRICS,LOGS,TRACES}` overrides (a zero override inherits the global). Retention keys on the **signal**, not the individual table — the five metrics tables share one TTL — because that matches how observability retention is managed; genuinely per-table retention is left to operators running the DDL themselves.

## Notes

- **Defaults unchanged**: the zero `SchemaProvisioning` is the single-node Atomic / `MergeTree` / no-cluster / no-TTL shape cerberus already shipped.
- `FromEnv` parse extracted into `bootFlagsFromEnv` + `schemaProvisioningFromEnv` (keeps it under the cyclop/funlen limits).
- **Docs**: `docs/configuration.md` (the full `CERBERUS_SCHEMA_*` table) + `docs/operations.md` (single-node vs Replicated-database vs classic `ON CLUSTER`, and the per-signal retention model).

## Tests

Per-signal TTL render + independence (different TTL per signal, zero = no clause); `schemaApplyConfig` TTL fallback + table-name threading + replicated-knob threading; config default + override parsing for every new env var.