### PR TITLE
test(e2e): reconcile Traces Drilldown primarySignal-init race in drilldown-apps sweep

### DIFF
--- a/test/e2e/playwright/crawl/lib.ts
+++ b/test/e2e/playwright/crawl/lib.ts
@@ -40,6 +40,18 @@ import type { Page } from '@playwright/test';
 // Type-only (erased at runtime) — stacks.ts value-imports the scope
 // constants below, so a value import here would be a cycle.
 import type { CrawlStackConfig } from './stacks.js';
+// The shared init-race reconciler (dangling-operand TraceQL) + its request
+// helpers now live in helpers/reconcile.ts so the drilldown-apps sweep shares
+// one source of truth. Imported for the supersession reconcilers below
+// (dsQuerySignature / isSupersededDsQueryFailure) and re-exported so crawl's
+// existing consumers (crawl.spec.ts, reconcile.spec.ts) keep their import path.
+import {
+  type DsResponseView,
+  isTransientMalformedTraceQLFailure,
+  refIdToExpr,
+} from '../helpers/reconcile.js';
+
+export { type DsResponseView, isTransientMalformedTraceQLFailure, refIdToExpr };
 
 /**
  * The scope slice of a stack config the canonicalizer consumes:
@@ -743,38 +755,6 @@ export function diffInventory(
 // ---------------------------------------------------------------------------
 
 /**
- * Minimal structural view of a captured datasource-API response the
- * supersession reconciler needs. Mirrors the wire-capture shape in
- * crawl.spec.ts without coupling to its full type.
- */
-export type DsResponseView = {
-  url: string;
-  status: number;
-  requestBody: string;
-};
-
-/**
- * Map refId → expr/query from a ds/query request body. Returns an
- * empty map for non-JSON bodies. Both the Prom/Loki `expr` shape and
- * the Tempo `query` (TraceQL) shape are handled.
- */
-export function refIdToExpr(requestBody: string): Map<string, string> {
-  const out = new Map<string, string>();
-  try {
-    const parsed = JSON.parse(requestBody) as {
-      queries?: Array<{ refId?: string; expr?: string; query?: string }>;
-    };
-    for (const q of parsed.queries ?? []) {
-      const expr = (q.expr ?? q.query ?? '').trim();
-      if (q.refId) out.set(q.refId, expr);
-    }
-  } catch {
-    // fallthrough — empty map; caller treats every refId as undeclared
-  }
-  return out;
-}
-
-/**
  * Stable signature of a ds/query request by its LOGICAL query payload
  * — the datasource-typed set of `refId=expr` pairs — with the
  * per-request `requestId`/`SQR…` nonce deliberately excluded. Two
@@ -833,65 +813,9 @@ export function isSupersededDsQueryFailure(
   return succeededSigs.has(dsQuerySignature(resp));
 }
 
-// ---------------------------------------------------------------------------
-// app-init-race reconciliation: dangling-operand TraceQL
-// ---------------------------------------------------------------------------
-
-/**
- * Matches a TraceQL spanset whose boolean filter has a DANGLING /
- * EMPTY operand around `&&` / `||` — i.e. a `{` followed immediately
- * by a binary operator (empty left operand: `{ && true}`), or a
- * binary operator immediately followed by the closing `}` (empty
- * right operand: `{true && }`), or two adjacent operators (`{a && &&
- * b}`). This is a SYNTAX ERROR, not a value-level filter: TraceQL's
- * grammar requires a non-empty operand on each side of `&&` / `||`,
- * so cerberus's parser (and reference Tempo's identical grammar)
- * rejects it with `syntax error: unexpected &&` (HTTP 400).
- *
- * The shape is produced by the Grafana Traces Drilldown app
- * (grafana-exploretraces-app), NOT by cerberus. The app's
- * `PrimarySignalVariable` (a Scenes CustomVariable) applies its
- * default value inside the component's `useEffect`, not in its
- * constructor — so during the initial-load / rapid-navigation window,
- * before that effect fires, the `${primarySignal}` interpolation is
- * EMPTY and the app builds `{ && ${filters}} | rate()` (and the
- * errors / duration variants). The instant the effect resolves the
- * default, the app re-fires the well-formed query; the user only ever
- * sees the settled result. See
- * src/pages/Explore/PrimarySignalVariable.tsx in
- * grafana/traces-drilldown.
- */
-const DANGLING_TRACEQL_OPERAND =
-  /\{\s*(?:&&|\|\|)|(?:&&|\|\|)\s*\}|(?:&&|\|\|)\s*(?:&&|\|\|)/;
-
-/**
- * True iff `resp` is a non-2xx Tempo ds/query whose EVERY forwarded
- * TraceQL query carries a dangling-operand spanset (see
- * DANGLING_TRACEQL_OPERAND) — the Traces Drilldown app's
- * primarySignal-init-race shape. cerberus correctly 400s these
- * (reference Tempo rejects the identical syntax-error), so they are a
- * transient app-side artifact, not a cerberus fault.
- *
- * This is NOT the supersession reconciler's twin: the malformed query
- * has a DIFFERENT expr than the settled one, so it never shares a
- * signature with a 2xx sibling and `isSupersededDsQueryFailure` can't
- * resolve it. It is also NOT a blanket 400 suppressor — a non-2xx
- * carrying any well-formed query still fails loudly; only the specific
- * dangling-`&&`/`||` syntax shape the app's known init race emits is
- * reconciled, and ALL queries in the request must exhibit it (a mixed
- * request with one well-formed query is a genuine failure).
- */
-export function isTransientMalformedTraceQLFailure(
-  resp: DsResponseView,
-): boolean {
-  if (!resp.url.includes('/api/ds/query')) return false;
-  if (resp.status >= 200 && resp.status <= 299) return false;
-  const dsType = new URL(resp.url, 'http://x').searchParams.get('ds_type');
-  if (dsType !== 'tempo') return false;
-  const exprs = [...refIdToExpr(resp.requestBody).values()];
-  if (exprs.length === 0) return false;
-  return exprs.every((expr) => DANGLING_TRACEQL_OPERAND.test(expr));
-}
+// The dangling-operand TraceQL init-race reconciler
+// (isTransientMalformedTraceQLFailure + DANGLING_TRACEQL_OPERAND) moved to
+// helpers/reconcile.ts — imported + re-exported at the top of this file.
 
 // ---------------------------------------------------------------------------
 // Misc

--- a/test/e2e/playwright/crawl/reconcile.spec.ts
+++ b/test/e2e/playwright/crawl/reconcile.spec.ts
@@ -36,6 +36,7 @@ import {
   succeededDsQuerySignatures,
   type DsResponseView,
 } from './lib.js';
+import { reportableConsoleErrors } from '../helpers/reconcile.js';
 
 const tempoBody = (query: string, refId = 'A'): string =>
   JSON.stringify({ queries: [{ refId, query, datasource: { type: 'tempo' } }] });
@@ -292,5 +293,48 @@ test.describe('isTransientMalformedTraceQLFailure', () => {
         requestBody: '<streamed>',
       }),
     ).toBe(false);
+  });
+});
+
+test.describe('reportableConsoleErrors', () => {
+  test('resolves one empty-text twin per reconciled init-race 400', () => {
+    // The observed flake: 1 reconciled dangling-query 400 → 1 empty-text
+    // console error. Fully explained → nothing reportable.
+    expect(reportableConsoleErrors([''], 1)).toEqual([]);
+    expect(reportableConsoleErrors(['', ''], 2)).toEqual([]);
+  });
+
+  test('keeps empty-text errors BEYOND the reconciled-400 count', () => {
+    // 2 empty errors but only 1 reconciled 400 → 1 stays reportable.
+    expect(reportableConsoleErrors(['', ''], 1)).toEqual([
+      '<empty-text console error>',
+    ]);
+  });
+
+  test('NEVER masks a substantive console error', () => {
+    // A real, non-empty console error always reports, even when an
+    // init-race 400 was reconciled in the same window.
+    expect(reportableConsoleErrors(['ChunkLoadError: boom'], 1)).toEqual([
+      'ChunkLoadError: boom',
+    ]);
+    expect(
+      reportableConsoleErrors(['', 'TypeError: x is undefined'], 1),
+    ).toEqual(['TypeError: x is undefined']);
+  });
+
+  test('with zero reconciled races, every console error reports', () => {
+    expect(reportableConsoleErrors([''], 0)).toEqual([
+      '<empty-text console error>',
+    ]);
+    expect(reportableConsoleErrors(['boom'], 0)).toEqual(['boom']);
+  });
+
+  test('whitespace-only errors count as empty (twins), not substantive', () => {
+    expect(reportableConsoleErrors(['   ', '\n'], 2)).toEqual([]);
+  });
+
+  test('a clean window stays clean', () => {
+    expect(reportableConsoleErrors([], 0)).toEqual([]);
+    expect(reportableConsoleErrors([], 3)).toEqual([]);
   });
 });

--- a/test/e2e/playwright/helpers/index.ts
+++ b/test/e2e/playwright/helpers/index.ts
@@ -18,3 +18,4 @@ export * from './validity.js';
 export * from './expectations.js';
 export * from './variables.js';
 export * from './depth.js';
+export * from './reconcile.js';

--- a/test/e2e/playwright/helpers/reconcile.ts
+++ b/test/e2e/playwright/helpers/reconcile.ts
@@ -1,0 +1,125 @@
+/**
+ * Shared wire-failure reconcilers for the Grafana e2e lanes.
+ *
+ * These reconcile KNOWN, transient third-party-app artifacts that are not
+ * cerberus faults — most notably the Grafana Traces Drilldown app's
+ * primarySignal-init race, which forwards a dangling-operand TraceQL query
+ * that cerberus (and reference Tempo) correctly reject with HTTP 400. They
+ * are deliberately NARROW: a genuinely-broken query still fails loudly. The
+ * crawl lane (`crawl/`) and the drilldown-apps sweep
+ * (`iterate-drilldown-apps.spec.ts`) both consume them, so the matcher lives
+ * here as the single source of truth rather than being duplicated per lane.
+ */
+
+/**
+ * Minimal view of a captured `/api/ds/query` response the reconcilers need:
+ * the URL (carries `?ds_type=…`), the HTTP status, and the request body
+ * (carries the forwarded `expr`/`query` per refId).
+ */
+export type DsResponseView = {
+  url: string;
+  status: number;
+  requestBody: string;
+};
+
+/**
+ * Map refId → expr/query from a ds/query request body. Returns an empty map
+ * for non-JSON bodies. Both the Prom/Loki `expr` shape and the Tempo `query`
+ * (TraceQL) shape are handled.
+ */
+export function refIdToExpr(requestBody: string): Map<string, string> {
+  const out = new Map<string, string>();
+  try {
+    const parsed = JSON.parse(requestBody) as {
+      queries?: Array<{ refId?: string; expr?: string; query?: string }>;
+    };
+    for (const q of parsed.queries ?? []) {
+      const expr = (q.expr ?? q.query ?? '').trim();
+      if (q.refId) out.set(q.refId, expr);
+    }
+  } catch {
+    // fallthrough — empty map; caller treats every refId as undeclared
+  }
+  return out;
+}
+
+/**
+ * Matches a TraceQL spanset whose boolean filter has a DANGLING / EMPTY
+ * operand around `&&` / `||` — i.e. a `{` followed immediately by a binary
+ * operator (empty left operand: `{ && true}`), or a binary operator
+ * immediately followed by the closing `}` (empty right operand: `{true && }`),
+ * or two adjacent operators (`{a && && b}`). This is a SYNTAX ERROR, not a
+ * value-level filter: TraceQL's grammar requires a non-empty operand on each
+ * side of `&&` / `||`, so cerberus's parser (and reference Tempo's identical
+ * grammar) rejects it with `syntax error: unexpected &&` (HTTP 400).
+ *
+ * The shape is produced by the Grafana Traces Drilldown app
+ * (grafana-exploretraces-app), NOT by cerberus. The app's
+ * `PrimarySignalVariable` (a Scenes CustomVariable) applies its default value
+ * inside the component's `useEffect`, not in its constructor — so during the
+ * initial-load / rapid-navigation window, before that effect fires, the
+ * `${primarySignal}` interpolation is EMPTY and the app builds
+ * `{ && ${filters}} | rate()` (and the errors / duration variants). The
+ * instant the effect resolves the default, the app re-fires the well-formed
+ * query; the user only ever sees the settled result. See
+ * src/pages/Explore/PrimarySignalVariable.tsx in grafana/traces-drilldown.
+ */
+export const DANGLING_TRACEQL_OPERAND =
+  /\{\s*(?:&&|\|\|)|(?:&&|\|\|)\s*\}|(?:&&|\|\|)\s*(?:&&|\|\|)/;
+
+/**
+ * True iff `resp` is a non-2xx Tempo ds/query whose EVERY forwarded TraceQL
+ * query carries a dangling-operand spanset (see DANGLING_TRACEQL_OPERAND) —
+ * the Traces Drilldown app's primarySignal-init-race shape. cerberus correctly
+ * 400s these (reference Tempo rejects the identical syntax-error), so they are
+ * a transient app-side artifact, not a cerberus fault.
+ *
+ * It is NOT a blanket 400 suppressor — a non-2xx carrying any well-formed
+ * query still fails loudly; only the specific dangling-`&&`/`||` syntax shape
+ * the app's known init race emits is reconciled, and ALL queries in the
+ * request must exhibit it (a mixed request with one well-formed query is a
+ * genuine failure).
+ */
+export function isTransientMalformedTraceQLFailure(
+  resp: DsResponseView,
+): boolean {
+  if (!resp.url.includes('/api/ds/query')) return false;
+  if (resp.status >= 200 && resp.status <= 299) return false;
+  const dsType = new URL(resp.url, 'http://x').searchParams.get('ds_type');
+  if (dsType !== 'tempo') return false;
+  const exprs = [...refIdToExpr(resp.requestBody).values()];
+  if (exprs.length === 0) return false;
+  return exprs.every((expr) => DANGLING_TRACEQL_OPERAND.test(expr));
+}
+
+/**
+ * Resolve the browser-side twins of the reconciled primarySignal-init-race
+ * 400s and return the console errors that remain REPORTABLE.
+ *
+ * When an interactive drill drives the Traces Drilldown app through its
+ * primarySignal-init race, each dangling-operand TraceQL 400 that
+ * isTransientMalformedTraceQLFailure reconciled on the wire ALSO surfaces to
+ * the browser as a single EMPTY-text console error — Grafana logs the failed
+ * background fetch, and the captured `msg.text()` is empty. Given
+ * `reconciledInitRace` such reconciled 400s, up to that many empty-text console
+ * errors are those twins and are resolved away; EVERY substantive (non-empty)
+ * console error is kept (mask nothing of value), and any empty-text error
+ * BEYOND the reconciled-400 count is kept too (placeholder text), so a
+ * genuinely-broken app — which produces either a non-reconciled wire failure or
+ * more console noise than the init race explains — still reports.
+ */
+export function reportableConsoleErrors(
+  consoleErrors: ReadonlyArray<string>,
+  reconciledInitRace: number,
+): string[] {
+  const substantive = consoleErrors.filter((m) => m.trim() !== '');
+  const emptyCount = consoleErrors.length - substantive.length;
+  const unexplainedEmpty = Math.max(0, emptyCount - Math.max(0, reconciledInitRace));
+  return [
+    ...substantive,
+    ...Array.from(
+      { length: unexplainedEmpty },
+      () => '<empty-text console error>',
+    ),
+  ];
+}

--- a/test/e2e/playwright/iterate-drilldown-apps.spec.ts
+++ b/test/e2e/playwright/iterate-drilldown-apps.spec.ts
@@ -59,7 +59,9 @@ import {
   captureConsoleErrors,
   captureRoleAlertBanners,
   drillTwoLevels,
+  isTransientMalformedTraceQLFailure,
   iterateDrilldownApps,
+  reportableConsoleErrors,
   waitForAppInstalled,
 } from './helpers/index.js';
 
@@ -69,12 +71,15 @@ import {
 // cerberus).
 
 // Captured response shape: stripped down so the failure detail isn't
-// dragged down by a 1MB ds/query body.
+// dragged down by a 1MB ds/query body. `requestBody` carries the forwarded
+// ds/query payload (the per-refId expr/query) so the init-race reconciler can
+// inspect the TraceQL shape — see isTransientMalformedTraceQLFailure.
 type CapturedResponseSummary = {
   url: string;
   method: string;
   status: number;
   bodyPreview: string;
+  requestBody: string;
 };
 
 type DrilldownFailure = {
@@ -203,6 +208,9 @@ async function sweepDrilldownApp(
       // Read body lazily — kept short to keep memory bounded.
       const status = resp.status();
       const method = resp.request().method();
+      // postData() is synchronous and carries the forwarded ds/query body —
+      // needed by the init-race reconciler to read the TraceQL shape.
+      const requestBody = resp.request().postData() ?? '';
       const summaryPromise = (async () => {
         let bodyPreview = '';
         // Only read the body when it's a failure so we don't spam
@@ -220,6 +228,7 @@ async function sweepDrilldownApp(
           method,
           status,
           bodyPreview,
+          requestBody,
         });
       })();
       captureBodies.push(summaryPromise);
@@ -265,26 +274,58 @@ async function sweepDrilldownApp(
   await Promise.all(captureBodies);
 
   // 1. Wire-status sweep over every captured response — zero
-  //    tolerance for 4xx/5xx.
+  //    tolerance for 4xx/5xx, EXCEPT the Traces Drilldown app's
+  //    primarySignal-init race. That app applies its primarySignal
+  //    default inside a React useEffect, so during the initial-load /
+  //    rapid-drill window it transiently forwards a dangling-operand
+  //    TraceQL (`{ && …} | rate()`) that cerberus correctly 400s
+  //    (reference Tempo rejects the identical syntax error). It is a
+  //    third-party app artifact, not a cerberus fault — and racy: the
+  //    400 fires on every run but only lands inside the capture window
+  //    intermittently, which is what makes this spec flaky. The
+  //    reconciler is narrow (every query in the request must carry the
+  //    dangling shape); a well-formed-query non-2xx still fails loudly.
+  //    Mirrors the crawl lane (#934). Count the reconciled races so the
+  //    console sweep below can resolve their browser-side twin.
+  let reconciledInitRace = 0;
   for (const resp of captured) {
-    if (resp.status < 200 || resp.status > 299) {
-      failures.push({
-        app: app.id,
-        rule: 'http-non-2xx',
-        detail: `${resp.method} ${resp.url} → ${resp.status}\n  body: ${resp.bodyPreview}`,
-      });
+    if (resp.status >= 200 && resp.status <= 299) continue;
+    if (
+      isTransientMalformedTraceQLFailure({
+        url: resp.url,
+        status: resp.status,
+        requestBody: resp.requestBody,
+      })
+    ) {
+      reconciledInitRace++;
+      continue;
     }
+    failures.push({
+      app: app.id,
+      rule: 'http-non-2xx',
+      detail: `${resp.method} ${resp.url} → ${resp.status}\n  body: ${resp.bodyPreview}`,
+    });
   }
 
   // 2. Console-error sweep — every browser console error is a real
-  //    failure. No noise filter (any upstream-Grafana console error is
-  //    either a Grafana bug to file or a state cerberus's compose stack
-  //    can pre-empt; mask nothing here).
-  if (consoleErrors.length > 0) {
+  //    failure, with ONE reconciliation: each primarySignal-init-race
+  //    400 reconciled above ALSO surfaces to the browser as a single
+  //    EMPTY-text console error (Grafana logs the failed background
+  //    fetch; the message text is empty). Resolve up to
+  //    `reconciledInitRace` empty-text console errors as those twins. A
+  //    console error with substantive text ALWAYS fails (mask nothing of
+  //    value), and any empty error beyond the reconciled-400 count fails
+  //    too — so a genuinely-broken app (non-reconciled wire failure, or
+  //    more console noise than the init race explains) still reports.
+  const reportableErrors = reportableConsoleErrors(
+    consoleErrors,
+    reconciledInitRace,
+  );
+  if (reportableErrors.length > 0) {
     failures.push({
       app: app.id,
       rule: 'console-error',
-      detail: `${consoleErrors.length} console error(s):\n${consoleErrors
+      detail: `${reportableErrors.length} console error(s):\n${reportableErrors
         .map((m) => `  - ${truncate(m, 400)}`)
         .join('\n')}`,
     });


### PR DESCRIPTION
## The flake

`iterate-drilldown-apps.spec.ts:86` flaked on the `dashboard` lane (run [27579238973](https://github.com/tsouza/cerberus/actions/runs/27579238973)) — ✘ attempt 1, ✓ retry #1 (Playwright: *1 flaky, 189 passed, 0 failed*; the zero-flake gate turns that into a job FAILURE).

**Root cause (not a cerberus bug, not task #82):** the Grafana **Traces Drilldown** app (`grafana-exploretraces-app`) applies its `primarySignal` default inside a React `useEffect`. During the initial-load / rapid-drill window it transiently forwards a **dangling-operand TraceQL** (`{ && <filters>} | rate()`, seen in the log as `var-primarySignal=nestedSetParent%3C0`). That's a genuine TraceQL syntax error — cerberus 400s it, **exactly as reference Tempo does** (`status_source=downstream`). The 400 fires on every run but only lands inside the spec's capture window intermittently → flaky. It surfaces on **two** of the spec's rule-checks: the wire `http-non-2xx` *and* a single **empty-text** browser console error (Grafana's failed-fetch log) — one event, two surfaces.

This is the **same race the crawl lane already reconciles** in #934 (`373fc184`); the drilldown-apps sweep was simply never given the same seam.

## Fix

- **Share the reconciler:** lift `isTransientMalformedTraceQLFailure` + `DANGLING_TRACEQL_OPERAND` + `refIdToExpr` + `DsResponseView` out of `crawl/lib.ts` into a new `helpers/reconcile.ts` (single source of truth). `crawl/lib.ts` re-exports them, so its consumers are unchanged — `crawl/reconcile.spec.ts` stays **17/17 green** (verified locally).
- **Wire sweep:** apply the reconciler — **narrow**: every query in the failing request must carry the dangling shape, so a well-formed-query 400 still fails loudly.
- **Console sweep:** new `reportableConsoleErrors()` resolves at most **one empty-text console error per reconciled init-race 400** (the browser twin of the same event). **Substantive (non-empty) console errors are never masked**, and empty errors beyond the reconciled count still report. Unit-tested — **6 new cases**.

## Not gaming the test
Reconciles a *provably-malformed third-party query* that reference Tempo rejects identically. **No** retries bumped, **no** allowlist/skip/quarantine, **no** soft assertion, the zero-flake gate untouched. A real cerberus wrong-rejection (well-formed TraceQL 400) or any substantive console error still fails loudly.

## Validation
`npx tsc --noEmit` clean; `crawl/reconcile.spec.ts` **23/23** (17 existing + 6 new console-reconciler cases). The drilldown-apps spec itself runs on the push-to-main/nightly `dashboard` lane (not a PR gate); the shared reconciler + its tests run on the PR via the crawl shard.

Diagnosis was offloaded to a sub-agent against the failing run logs + spec/helper code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)