### PR TITLE
test(e2e): de-flake drilldown-apps at source (third-party init/teardown races)

### DIFF
--- a/test/e2e/playwright/crawl/reconcile.spec.ts
+++ b/test/e2e/playwright/crawl/reconcile.spec.ts
@@ -36,7 +36,11 @@ import {
   succeededDsQuerySignatures,
   type DsResponseView,
 } from './lib.js';
-import { reportableConsoleErrors } from '../helpers/reconcile.js';
+import {
+  isClientSideFetchAbort,
+  isResourceStatusTwin,
+  reportableConsoleErrors,
+} from '../helpers/reconcile.js';
 
 const tempoBody = (query: string, refId = 'A'): string =>
   JSON.stringify({ queries: [{ refId, query, datasource: { type: 'tempo' } }] });
@@ -285,7 +289,7 @@ test.describe('isTransientMalformedTraceQLFailure', () => {
     ).toBe(false);
   });
 
-  test('does NOT reconcile an empty/unparseable request body', () => {
+  test('does NOT reconcile an empty/unparseable request body (no response body)', () => {
     expect(
       isTransientMalformedTraceQLFailure({
         url: '/api/ds/query?ds_type=tempo&requestId=SQR1',
@@ -293,6 +297,99 @@ test.describe('isTransientMalformedTraceQLFailure', () => {
         requestBody: '<streamed>',
       }),
     ).toBe(false);
+  });
+
+  // Response-side fallback: a rapid drill can tear the request reference down
+  // before postData resolves, leaving requestBody empty. cerberus's 400 body
+  // names the dangling-operand syntax error verbatim, so the SAME proven shape
+  // is recognisable response-side. Live-captured body (k3d, 2026-06-16):
+  //   {"error":true,"message":"parse error at line 0, col 3: syntax error: unexpected &&"}
+  test('reconciles via the cerberus 400 body when the request body is unavailable', () => {
+    for (const body of [
+      // raw HTML-escaped `&` (as cerberus emits it on the wire)
+      '{"error":true,"message":"parse error at line 0, col 3: syntax error: unexpected \\u0026\\u0026"}',
+      // decoded form (defensive — if the harness ever JSON-parses first)
+      'parse error: syntax error: unexpected &&',
+      // the `||` variant
+      'parse error: syntax error: unexpected ||',
+    ]) {
+      expect(
+        isTransientMalformedTraceQLFailure({
+          url: '/api/ds/query?ds_type=tempo&requestId=SQR1',
+          status: 400,
+          requestBody: '<streamed>',
+          responseBody: body,
+        }),
+      ).toBe(true);
+    }
+  });
+
+  test('does NOT reconcile a DIFFERENT syntax error via the response body', () => {
+    // A genuine wrong-rejection of some other malformed/valid query carries a
+    // different `unexpected <token>` and must still fail loudly.
+    for (const body of [
+      'parse error: syntax error: unexpected }',
+      'parse error: syntax error: unexpected identifier',
+      'parse error: syntax error: unexpected (',
+      '{"error":true,"message":"internal error"}',
+    ]) {
+      expect(
+        isTransientMalformedTraceQLFailure({
+          url: '/api/ds/query?ds_type=tempo&requestId=SQR1',
+          status: 400,
+          requestBody: '<streamed>',
+          responseBody: body,
+        }),
+      ).toBe(false);
+    }
+  });
+});
+
+/**
+ * isClientSideFetchAbort — the lokiexplore "Detected fields" / RxJS
+ * network-abort class (k3d dashboard-shard, 2026-06-16; ~60% of runs).
+ *
+ * A browser `TypeError: Failed to fetch` is a CLIENT-SIDE abort — the fetch
+ * never completed (teardown of a third-party app's background fetch as the
+ * rapid drill unmounts its scene). cerberus errors are HTTP non-2xx (a resolved
+ * fetch the wire-sweep owns). Verified live: cerberus serves
+ * /loki/api/v1/detected_fields + /detected_labels with HTTP 200, and no
+ * Playwright requestfailed fires for them.
+ */
+test.describe('isClientSideFetchAbort', () => {
+  test('matches the network-abort TypeError (with + without app context)', () => {
+    expect(isClientSideFetchAbort('TypeError: Failed to fetch')).toBe(true);
+    expect(
+      isClientSideFetchAbort(
+        'TypeError: Failed to fetch {app: grafana-lokiexplore-app, version: 2.1.2, msg: Detected fields error}',
+      ),
+    ).toBe(true);
+  });
+
+  test('does NOT match real application errors', () => {
+    for (const m of [
+      'ChunkLoadError: Loading chunk 3399 failed',
+      'TypeError: x is undefined',
+      'Failed to load resource: the server responded with a status of 500',
+      'Error: panic rendering scene',
+    ]) {
+      expect(isClientSideFetchAbort(m)).toBe(false);
+    }
+  });
+});
+
+test.describe('isResourceStatusTwin', () => {
+  test('matches the browser non-2xx resource twin', () => {
+    expect(
+      isResourceStatusTwin(
+        'Failed to load resource: the server responded with a status of 400 (Bad Request)',
+      ),
+    ).toBe(true);
+  });
+
+  test('does NOT match a real application error', () => {
+    expect(isResourceStatusTwin('ChunkLoadError: boom')).toBe(false);
+    expect(isResourceStatusTwin('TypeError: Failed to fetch')).toBe(false);
   });
 });
 
@@ -336,5 +433,55 @@ test.describe('reportableConsoleErrors', () => {
   test('a clean window stays clean', () => {
     expect(reportableConsoleErrors([], 0)).toEqual([]);
     expect(reportableConsoleErrors([], 3)).toEqual([]);
+  });
+
+  test('drops the client-side fetch-abort class (lokiexplore teardown race)', () => {
+    expect(reportableConsoleErrors(['TypeError: Failed to fetch'], 0)).toEqual(
+      [],
+    );
+    expect(
+      reportableConsoleErrors(
+        [
+          'TypeError: Failed to fetch {app: grafana-lokiexplore-app, version: 2.1.2, msg: Detected fields error}',
+        ],
+        0,
+      ),
+    ).toEqual([]);
+  });
+
+  test('keeps a real error sitting next to a fetch-abort', () => {
+    expect(
+      reportableConsoleErrors(
+        ['TypeError: Failed to fetch', 'ChunkLoadError: boom'],
+        0,
+      ),
+    ).toEqual(['ChunkLoadError: boom']);
+  });
+
+  test('resolves the resource-status twin of a reconciled 400, up to budget', () => {
+    // 1 reconciled dangling-operand 400 → its browser twin
+    // "Failed to load resource: … status of 400" is resolved.
+    expect(
+      reportableConsoleErrors(
+        ['Failed to load resource: the server responded with a status of 400 (Bad Request)'],
+        1,
+      ),
+    ).toEqual([]);
+  });
+
+  test('keeps a resource-status twin BEYOND the reconciled-400 budget', () => {
+    // 2 twins but only 1 reconciled 400 → 1 stays reportable (a real,
+    // un-reconciled non-2xx still surfaces here as well as in the wire-sweep).
+    const twin =
+      'Failed to load resource: the server responded with a status of 400 (Bad Request)';
+    expect(reportableConsoleErrors([twin, twin], 1)).toEqual([twin]);
+  });
+
+  test('a non-400 resource twin with no reconciled race still reports', () => {
+    // A 500 resource twin with zero reconciled races is NOT resolved — it is a
+    // real failure twin (also caught by the wire-sweep).
+    const twin500 =
+      'Failed to load resource: the server responded with a status of 500';
+    expect(reportableConsoleErrors([twin500], 0)).toEqual([twin500]);
   });
 });

--- a/test/e2e/playwright/helpers/reconcile.ts
+++ b/test/e2e/playwright/helpers/reconcile.ts
@@ -20,6 +20,12 @@ export type DsResponseView = {
   url: string;
   status: number;
   requestBody: string;
+  // Captured cerberus error body, when readable. Used as a postData-independent
+  // fallback: a rapid drill can tear the request reference down before
+  // `request.postData()` resolves, leaving requestBody empty — but cerberus's
+  // 400 body still names the exact syntax error, so the dangling-operand shape
+  // is recognisable response-side too.
+  responseBody?: string;
 };
 
 /**
@@ -68,6 +74,60 @@ export const DANGLING_TRACEQL_OPERAND =
   /\{\s*(?:&&|\|\|)|(?:&&|\|\|)\s*\}|(?:&&|\|\|)\s*(?:&&|\|\|)/;
 
 /**
+ * Matches cerberus's HTTP-400 body for a dangling-operand TraceQL spanset —
+ * the RESPONSE-side signature of the same primarySignal-init race. cerberus's
+ * Tempo head rejects an empty operand around `&&`/`||` with
+ * `parse error … syntax error: unexpected &&` (or `||`); `&` is HTML-escaped to
+ * `&` in the JSON body, so both the raw-escaped and decoded forms are
+ * matched. `unexpected <operator>` is specific to a dangling operand — any
+ * other malformed query yields `unexpected <other-token>` — so this stays as
+ * narrow as the request-side DANGLING_TRACEQL_OPERAND: a genuine wrong-rejection
+ * carries a different message and still fails loudly.
+ *
+ * This is the fallback the wire-sweep uses when a torn-down request left the
+ * forwarded query body uncapturable (postData empty); the cerberus error body
+ * proves the shape just as well.
+ */
+export const DANGLING_TRACEQL_REJECTION =
+  /unexpected\s+(?:&&|\\u0026\\u0026|\|\|)/;
+
+/**
+ * True iff a captured console message is a browser `TypeError: Failed to fetch`
+ * — the network-abort class. This is NOT how cerberus signals an error: a
+ * cerberus 4xx/5xx arrives as an HTTP response with a JSON body (the fetch
+ * promise RESOLVES with a non-ok response), captured and failed-on by the
+ * wire-status sweep. `Failed to fetch` only fires when the fetch itself never
+ * completes — connection abort / cancellation / teardown. The Grafana drilldown
+ * apps fire background fetches (grafana-lokiexplore-app's "Detected fields"
+ * feature; the RxJS data-source subscription layer) during the rapid multi-app
+ * drill; when the test navigates on, Grafana unmounts the scene and the
+ * in-flight fetch is aborted, surfacing as this TypeError. Verified live on the
+ * k3d stack: cerberus serves /loki/api/v1/detected_fields and /detected_labels
+ * with HTTP 200, and no Playwright `requestfailed` fires for them — a pure
+ * client-side abort. Recognising ONLY this exact TypeError class keeps every
+ * other console error (chunk-load failures, real JS exceptions, datasource 5xx
+ * logs) reportable; real cerberus HTTP failures remain owned by the wire-sweep.
+ */
+export function isClientSideFetchAbort(consoleMessage: string): boolean {
+  return /TypeError:\s*Failed to fetch/i.test(consoleMessage);
+}
+
+/**
+ * True iff a captured console message is the browser's generic
+ * "Failed to load resource: the server responded with a status of N" line — the
+ * console TWIN every non-2xx HTTP response emits. It is redundant with the
+ * wire-status sweep (which inspects the SAME cerberus responses and fails on any
+ * un-reconciled non-2xx), so on its own it carries no signal the wire-sweep
+ * doesn't already own. Used to resolve the browser twin of a reconciled
+ * dangling-operand 400 without masking application-level console errors.
+ */
+export function isResourceStatusTwin(consoleMessage: string): boolean {
+  return /Failed to load resource: the server responded with a status of \d/i.test(
+    consoleMessage,
+  );
+}
+
+/**
  * True iff `resp` is a non-2xx Tempo ds/query whose EVERY forwarded TraceQL
  * query carries a dangling-operand spanset (see DANGLING_TRACEQL_OPERAND) —
  * the Traces Drilldown app's primarySignal-init-race shape. cerberus correctly
@@ -88,8 +148,18 @@ export function isTransientMalformedTraceQLFailure(
   const dsType = new URL(resp.url, 'http://x').searchParams.get('ds_type');
   if (dsType !== 'tempo') return false;
   const exprs = [...refIdToExpr(resp.requestBody).values()];
-  if (exprs.length === 0) return false;
-  return exprs.every((expr) => DANGLING_TRACEQL_OPERAND.test(expr));
+  if (exprs.length > 0) {
+    // Request-side: EVERY forwarded query must carry the dangling shape (a
+    // mixed request with one well-formed query is a genuine failure).
+    return exprs.every((expr) => DANGLING_TRACEQL_OPERAND.test(expr));
+  }
+  // Request body uncapturable (a torn-down request left postData empty). Fall
+  // back to cerberus's 400 body, which names the dangling-operand syntax error
+  // verbatim — the same proven shape, observed response-side.
+  return (
+    resp.responseBody !== undefined &&
+    DANGLING_TRACEQL_REJECTION.test(resp.responseBody)
+  );
 }
 
 /**
@@ -112,14 +182,27 @@ export function reportableConsoleErrors(
   consoleErrors: ReadonlyArray<string>,
   reconciledInitRace: number,
 ): string[] {
-  const substantive = consoleErrors.filter((m) => m.trim() !== '');
-  const emptyCount = consoleErrors.length - substantive.length;
-  const unexplainedEmpty = Math.max(0, emptyCount - Math.max(0, reconciledInitRace));
-  return [
-    ...substantive,
-    ...Array.from(
-      { length: unexplainedEmpty },
-      () => '<empty-text console error>',
-    ),
-  ];
+  // 1. Drop the browser network-abort class outright (client-side teardown of a
+  //    third-party app's background fetch — see isClientSideFetchAbort). Real
+  //    cerberus HTTP failures are owned by the wire-status sweep, not this rule.
+  const afterAbort = consoleErrors.filter((m) => !isClientSideFetchAbort(m));
+
+  // 2. Resolve the browser TWINS of the reconciled dangling-operand 400s: each
+  //    reconciled init-race 400 surfaces to the console either as an empty-text
+  //    message or as the generic "Failed to load resource: … status of 400"
+  //    twin. Resolve up to `reconciledInitRace` such twins (the wire-sweep
+  //    already accounted for the underlying 400); everything else is kept, so a
+  //    genuine app error or more twins than the init race explains still
+  //    reports.
+  let twinsBudget = Math.max(0, reconciledInitRace);
+  const reportable: string[] = [];
+  for (const m of afterAbort) {
+    const isTwin = m.trim() === '' || isResourceStatusTwin(m);
+    if (isTwin && twinsBudget > 0) {
+      twinsBudget--;
+      continue;
+    }
+    reportable.push(m.trim() === '' ? '<empty-text console error>' : m);
+  }
+  return reportable;
 }

--- a/test/e2e/playwright/iterate-drilldown-apps.spec.ts
+++ b/test/e2e/playwright/iterate-drilldown-apps.spec.ts
@@ -295,6 +295,7 @@ async function sweepDrilldownApp(
         url: resp.url,
         status: resp.status,
         requestBody: resp.requestBody,
+        responseBody: resp.bodyPreview,
       })
     ) {
       reconciledInitRace++;
@@ -307,16 +308,22 @@ async function sweepDrilldownApp(
     });
   }
 
-  // 2. Console-error sweep — every browser console error is a real
-  //    failure, with ONE reconciliation: each primarySignal-init-race
-  //    400 reconciled above ALSO surfaces to the browser as a single
-  //    EMPTY-text console error (Grafana logs the failed background
-  //    fetch; the message text is empty). Resolve up to
-  //    `reconciledInitRace` empty-text console errors as those twins. A
-  //    console error with substantive text ALWAYS fails (mask nothing of
-  //    value), and any empty error beyond the reconciled-400 count fails
-  //    too — so a genuinely-broken app (non-reconciled wire failure, or
-  //    more console noise than the init race explains) still reports.
+  // 2. Console-error sweep — every browser console error is a real failure,
+  //    EXCEPT two narrow browser-generated network classes the wire-status
+  //    sweep above already owns or that are provably client-side (see
+  //    reportableConsoleErrors):
+  //      a) `TypeError: Failed to fetch` — the network-abort class. cerberus
+  //         errors are HTTP non-2xx (a RESOLVED fetch the wire-sweep captures);
+  //         `Failed to fetch` only fires when the fetch never completes, i.e. a
+  //         third-party drilldown app's background fetch (lokiexplore "Detected
+  //         fields"; the RxJS data-source layer) aborted as the rapid drill
+  //         unmounts its scene. Verified live: cerberus serves
+  //         /loki/api/v1/detected_fields + /detected_labels with HTTP 200.
+  //      b) the "Failed to load resource: … status of 400" browser TWIN of each
+  //         reconciled dangling-operand 400 (resolved up to reconciledInitRace).
+  //    Every other console error — chunk-load failures, real JS exceptions,
+  //    datasource 5xx logs — still fails loudly, and real cerberus HTTP failures
+  //    remain owned by the wire-status sweep.
   const reportableErrors = reportableConsoleErrors(
     consoleErrors,
     reconciledInitRace,


### PR DESCRIPTION
## What

Fixes the dominant `dashboard-shard (shard-smoke-b)` flake (~60% fail; reproduced live 11/18) in `iterate-drilldown-apps.spec.ts`, **at source**, with narrow reconcilers — without leaning on the blunt `FLAKY_UI_LANE_RE` release de-gate.

Prompted by "shouldn't we understand and fix instead of avoiding it?" on the rc.6 dashboard failure. Live verification against a fresh k3d stack (cerberus `a4853516`) pinned both signatures as **third-party Grafana drilldown-app artifacts, not cerberus faults**.

## Root cause (live-verified)

1. **lokiexplore "Detected fields" → `TypeError: Failed to fetch`** (~60%). Browser network-abort: the Logs Drilldown app's background "Detected fields" fetch is cancelled when the rapid drill unmounts its scene. **cerberus serves `/loki/api/v1/detected_fields` AND `/detected_labels` with HTTP 200** (curled directly); no Playwright `requestfailed` fires.
2. **exploretraces dangling-operand TraceQL 400** (~4%). The #934 primarySignal-init race: `{ && …} | rate()` before the variable resolves; cerberus 400s it with `parse error … syntax error: unexpected &&` (captured live), exactly as reference Tempo does. The existing reconciler missed it when a torn-down request left `postData` empty.

cerberus is correct in both (strict TraceQL rejection-parity; 200 detected_fields).

## Fix (narrow, test-layer)

- `isClientSideFetchAbort` — drops the `TypeError: Failed to fetch` network-abort class from the console sweep. cerberus HTTP errors are non-2xx (owned by the wire-status sweep); every other console error still reports.
- `isTransientMalformedTraceQLFailure` — response-body fallback (`unexpected &&`/`||`) when the request body is uncapturable. A different syntax error still fails loud.
- `isResourceStatusTwin` — resolves the browser "Failed to load resource: … status of 400" twin of a reconciled init-race 400.

## Verification

- Live k3d: **25/25 green** (was ~60% fail).
- **34 reconcile unit tests pass**, incl. new narrowness cases (a genuine wrong-rejection, a real app error, a 500 twin all still fail loud).

## NOT included (separate, pre-existing — re-gate blockers)

Live-verifying the rest of the smoke surface surfaced two **independent** issues that block fully re-gating the dashboard lane:
- `iterate-all-dashboards` deterministically probes the **compose-only** `clickhouse-observability` dashboard against the k3d stack (provisions only `cerberus.json`; no `clickhouse_metric` self-metrics) → "no series". Test-scoping / collector-config gap, not a cerberus bug.
- #82 (otel-collector-gateway BackOff) remains open.

So this PR fixes the actual failure at source; the blunt de-gate stays until those are resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)