### PR TITLE
fix(e2e): gateway waits for ClickHouse query-readiness (#82) + re-gate dashboard smoke shards

### DIFF
--- a/.github/scripts/release-preflight.mjs
+++ b/.github/scripts/release-preflight.mjs
@@ -116,13 +116,20 @@ async function combinedStatus() {
 //       `compose-smoke-shard-info (shard-crawl, crawl/crawl.spec.ts …)`
 //       `dashboard-shard (shard-crawl, crawl/crawl.spec.ts …)`
 //     so we match `(shard-crawl` followed by `,` or `)` (NOT `(shard-crawl-…`).
-//   - the whole k3d `dashboard` lane: the `dashboard` aggregate, `dashboard-setup`,
-//     and every `dashboard-shard (...)` child (smoke shards included — the k3d
-//     lane is informational-only and flaky end-to-end, exploretraces "Failed to
-//     fetch"). The required `compose-smoke` lane is NOT matched (no `dashboard`
-//     token, and its required shards are `(shard-kiosk …)` / `(shard-smoke …)`,
-//     never `shard-crawl`), so it still gates.
-const FLAKY_UI_LANE_RE = /(\(shard-crawl[,)]|^dashboard($|-setup$|-shard( |$)))/;
+//     This is a genuinely non-deterministic ~50-min BFS sweep that routinely
+//     hits its timeout and ends `cancelled`/`failure`; it stays de-gated.
+//   - the k3d `dashboard` AGGREGATE + `dashboard-setup` only. The aggregate
+//     rolls up every shard (including the de-gated `shard-crawl`), so it can
+//     never be greener than its weakest shard — gating it would re-import the
+//     crawl flake. The deterministic `dashboard-shard (shard-smoke-*)` children
+//     are NO LONGER dropped: they GATE again now that the two flakes that
+//     justified dropping them are fixed at source — the drilldown-apps
+//     init/teardown races (#950) and the otel-collector-gateway boot-order
+//     CrashLoopBackOff (#82, gateway initContainer waits for ClickHouse to be
+//     query-ready). The required `compose-smoke` lane is unaffected (no
+//     `dashboard` token; its shards are `(shard-kiosk …)` / `(shard-smoke …)`,
+//     never `shard-crawl`).
+const FLAKY_UI_LANE_RE = /(\(shard-crawl[,)]|^dashboard($|-setup$))/;
 const isFlakyUILane = (name) => FLAKY_UI_LANE_RE.test(name);
 
 const SCHEDULED_EVENT = 'schedule';

--- a/test/e2e/k3s/otel-collector.yaml
+++ b/test/e2e/k3s/otel-collector.yaml
@@ -456,6 +456,28 @@ spec:
         role: gateway
     spec:
       serviceAccountName: otel-collector
+      initContainers:
+        # The clickhouseexporter runs `create database` at Start() and the
+        # collector exits 1 if ClickHouse can't serve a query then — a boot-order
+        # race that BackOff-loops the gateway and cascades the sample-apps into
+        # FATAL (#82: "telemetrygen FATALs if otel-collector-gateway not ready").
+        # Block until ClickHouse can EXECUTE A QUERY, not merely accept a TCP
+        # connection: CH opens the native 9000 port (and answers /ping) early in
+        # boot, before the query engine is ready, so a bare `nc -z 9000` /
+        # /ping wait lets the collector start a hair too soon and still
+        # CrashLoopBackOff (observed: 3 restarts on a cold race). A
+        # `SELECT 1` over the HTTP interface (8123) returns "1" only once the
+        # query engine — what `create database` needs — is actually up.
+        - name: wait-for-clickhouse
+          image: busybox:1.37
+          command:
+            - sh
+            - -c
+            - |
+              until [ "$(wget -qO- 'http://clickhouse:8123/?query=SELECT+1' 2>/dev/null)" = "1" ]; do
+                echo "waiting for clickhouse query engine (8123 SELECT 1) ..."
+                sleep 2
+              done
       containers:
         - name: collector
           # 0.152.1 mirrors the compose stack (docker-compose.yml). The


### PR DESCRIPTION
Stacks on #950 (drilldown-apps de-flake, merged). Closes the second and final re-gate blocker, then flips the gate.

## #82 — gateway boot-order CrashLoopBackOff (root cause, live-diagnosed)

The otel-collector-gateway's `clickhouseexporter` runs `create database` at `Start()` and the collector **exits 1** when ClickHouse can't serve a query yet:
```
failed to start "clickhouse" exporter: create database: dial tcp …:9000: connect: connection refused
```
On a cold cluster the gateway races ClickHouse startup → CrashLoopBackOff → while its OTLP port is down the sample-apps' telemetrygen FATALs (the #82 cascade → intermittent dashboard red).

**Fix:** a `wait-for-clickhouse` initContainer that blocks until ClickHouse can **execute a query**, not merely accept a TCP connection. CH opens native 9000 (and answers `/ping`) early in boot, before the query engine is ready — so a bare `nc -z 9000` wait still let the collector start a hair too soon (**observed 3 restarts** on a cold race). A `SELECT 1` over HTTP 8123 returns `1` only once the query engine is up.

**Verified (live k3d):** 4/4 cold-start races (delete CH + gateway together) → gateway `restartCount=0` — vs. `0/2/0/3` with the `nc -z` wait.

## Re-gate

With both flakes that justified dropping the k3d dashboard **smoke** shards now fixed at source — the drilldown-apps init/teardown races (#950) and this gateway BackOff — narrow `FLAKY_UI_LANE_RE` so `dashboard-shard (shard-smoke-*)` **gates a release again**. Still de-gated (correctly): the genuinely-non-deterministic ~50-min BFS `shard-crawl` lane, and the `dashboard` aggregate / `dashboard-setup` (which roll up the de-gated crawl shard). `compose-smoke` unaffected. Lane classification verified against the real check-run names (11/11 cases).

This is the "understand and fix instead of avoiding" follow-through: the blunt blanket de-gate is now narrowed to only the lanes that are genuinely non-deterministic, each with a named reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)