### PR TITLE
fix(e2e): gateway init must authenticate to ClickHouse (unbreak dashboard lane)

### DIFF
--- a/test/e2e/k3s/otel-collector.yaml
+++ b/test/e2e/k3s/otel-collector.yaml
@@ -461,21 +461,24 @@ spec:
         # collector exits 1 if ClickHouse can't serve a query then — a boot-order
         # race that BackOff-loops the gateway and cascades the sample-apps into
         # FATAL (#82: "telemetrygen FATALs if otel-collector-gateway not ready").
-        # Block until ClickHouse can EXECUTE A QUERY, not merely accept a TCP
-        # connection: CH opens the native 9000 port (and answers /ping) early in
-        # boot, before the query engine is ready, so a bare `nc -z 9000` /
-        # /ping wait lets the collector start a hair too soon and still
-        # CrashLoopBackOff (observed: 3 restarts on a cold race). A
-        # `SELECT 1` over the HTTP interface (8123) returns "1" only once the
-        # query engine — what `create database` needs — is actually up.
+        # Block until ClickHouse can EXECUTE AN AUTHENTICATED QUERY, not merely
+        # accept a TCP connection: CH opens native 9000 early in boot, before
+        # the query engine is ready. The probe MUST authenticate as the
+        # configured cerberus user (CLICKHOUSE_USER/PASSWORD) the same way the
+        # exporter does — an unauthenticated check is rejected and the init
+        # loops forever (the default user is locked down when CLICKHOUSE_USER is
+        # set). Use clickhouse-client over the native protocol — the exact path
+        # the exporter's `create database` takes — so a green probe proves the
+        # exporter's first Start() will succeed.
         - name: wait-for-clickhouse
-          image: busybox:1.37
+          image: clickhouse/clickhouse-server:25.8-alpine
           command:
             - sh
             - -c
             - |
-              until [ "$(wget -qO- 'http://clickhouse:8123/?query=SELECT+1' 2>/dev/null)" = "1" ]; do
-                echo "waiting for clickhouse query engine (8123 SELECT 1) ..."
+              until clickhouse-client --host clickhouse --port 9000 \
+                  --user cerberus --password cerberus --query 'SELECT 1' >/dev/null 2>&1; do
+                echo "waiting for clickhouse query engine (native SELECT 1) ..."
                 sleep 2
               done
       containers:


### PR DESCRIPTION
**Hotfix for #951.** My #82 gateway initContainer probed ClickHouse **unauthenticated** (`wget http://clickhouse:8123/?query=SELECT+1`). CH runs with `CLICKHOUSE_USER=cerberus`/`CLICKHOUSE_PASSWORD=cerberus`, which **locks down the default user** — so the probe is rejected, the `until` loop never sees `1`, and the initContainer **hangs forever** → gateway stuck `Init:0/1` → `e2e-up` times out on the gateway Deployment (Justfile:491) → the whole k3d dashboard lane fails (main push run 27618204432, post-#951).

It passed in a warm local k3d by luck (default-user timing) but hangs on a cold CI cluster — the exact local-vs-CI gap I should have caught.

## Fix

Probe with `clickhouse-client` over the **native 9000 protocol, authenticated** as the cerberus user — the exact path the clickhouseexporter's `create database` takes, so a green probe proves the exporter's first `Start()` will succeed. Authenticating (rather than relying on the default user) removes the local-vs-CI fragility entirely.

**Verified** locally against `clickhouse-server:25.8-alpine` with the same `CLICKHOUSE_USER`/`PASSWORD` env: unauthenticated `SELECT 1` is rejected; authenticated `clickhouse-client SELECT 1` returns `1`. The clickhouse image is already imported into the k3d node.

## Verification gate

Merging this **only after this PR's own `dashboard-shard` lane goes green in CI** (real k3d) — not on a local pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)