### PR TITLE
docs: de-stale README rc framing + verify quickstart for launch readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@
 Keep Grafana, alerting, and your CLI tooling. Swap the backend.
 
 > [!WARNING]
-> **EXPERIMENTAL — NOT PRODUCTION-READY.** Cerberus is at `v1.0.0-rc.1`,
-> early and under active development. The differential harnesses run on every
+> **EXPERIMENTAL — NOT PRODUCTION-READY.** Cerberus is in the `v1.0.0-rc.*`
+> release-candidate stage, early and under active development (see the
+> [releases page](https://github.com/tsouza/cerberus/releases) for the
+> current tag). The differential harnesses run on every
 > PR and score parity against real Prometheus / Loki / Tempo, but correctness,
 > performance, and operational behaviour are still being shaken out, and the
 > surface is evolving. **Validate it against your

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 # One-command local dev stack for cerberus.
 #
 #   docker compose up --wait
-#   open http://localhost:3000   # Grafana (admin/admin)
+#   open http://localhost:3000   # Grafana (anonymous auto-login as Admin)
 #
 # Services:
 #   clickhouse      single-node CH server, OTel-aware (db=otel,


### PR DESCRIPTION
## What

Small doc/framing fixes to make the project presentation honest and self-consistent ahead of a wider audience:

- **README EXPERIMENTAL warning** pinned `v1.0.0-rc.1`, but releases have moved through `rc.9`. A reader cross-checking the [releases page](https://github.com/tsouza/cerberus/releases) saw a contradiction. Reframed as the `v1.0.0-rc.*` release-candidate stage and linked the releases page for the current tag instead of hard-coding one — so it never goes stale again.
- **compose header comment** said `Grafana (admin/admin)`; the stack actually uses anonymous auto-login as Admin (no prompt). Aligned the comment.

## Verification

Booted the published quickstart end-to-end from a cold state on this branch:

- `docker compose down -v` then `docker compose up --wait` (builds cerberus from source): **all five services healthy in ~2m25s**.
- **PromQL** instant (`up`) and range (`sum(rate(http_server_request_duration_count[5m]))`) — real series returned.
- **Loki** `/loki/api/v1/labels` — real label set.
- **Tempo** `/api/search/tags` — real tag set.
- Grafana healthy; three `Cerberus-*` datasources + the drilldown-app UID aliases provisioned.

No code or behaviour change — docs + one comment only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)