### PR TITLE
fix(prom): metadata endpoints scan full [start,end] window, not instant staleness (rc.10)

### DIFF
--- a/internal/api/prom/handler_chdb_metadata_window_sweep_test.go
+++ b/internal/api/prom/handler_chdb_metadata_window_sweep_test.go
@@ -241,10 +241,15 @@ func TestMetadataWindowSweep_ChDB(t *testing.T) {
 
 			// /api/v1/labels — the now-wallclock sibling. `__name__` is
 			// always prepended; `job` appears IFF an in-window series
-			// carries it. So `job` presence tracks "any in-window series".
+			// carries it. Full set-equality (not just job-presence) so a
+			// stray extra key would also fail.
 			gotLabels := stringData(t, getMetaData(t, c.query(srv.URL, "/api/v1/labels", "m", "")))
-			if hasJob := contains(gotLabels, "job"); hasJob != nonEmpty {
-				t.Errorf("/labels hasJob=%v, want %v (labels=%v)  (%s)", hasJob, nonEmpty, gotLabels, c.description)
+			wantLabels := []string{"__name__"}
+			if nonEmpty {
+				wantLabels = []string{"__name__", "job"}
+			}
+			if !setEqual(gotLabels, wantLabels) {
+				t.Errorf("/labels = %v, want %v  (%s)", gotLabels, wantLabels, c.description)
 			}
 
 			// /api/v1/label/__name__/values — existence of the metric in
@@ -262,9 +267,12 @@ func TestMetadataWindowSweep_ChDB(t *testing.T) {
 }
 
 // TestMetadataWindowSweep_SingleTable_ChDB covers the single-table
-// lowering branch (a suffixed `_total` counter resolves to otel_metrics_sum
-// alone, not the gauge∪sum union), so both metadataFullRange seams in
-// lowerVectorSelector are exercised. mc_total has samples at t0 and t3.
+// lowering seam: a suffixed `_total` counter resolves to otel_metrics_sum
+// alone (not the Gauge∪Sum scan the unsuffixed `m` uses), so the
+// metadataFullRange branch on the primary lowerVectorSelector return path
+// is exercised against a single physical table. mc_total has samples at
+// t0 and t3. (The companion-union seam in lowerCompanionUnion is covered
+// separately by TestMetadataWindowSweep_HistogramCompanion_ChDB.)
 func TestMetadataWindowSweep_SingleTable_ChDB(t *testing.T) {
 	seed, jt := metaWindowSeed()
 	srv, _ := newChDBServer(t, seed)
@@ -289,6 +297,116 @@ func TestMetadataWindowSweep_SingleTable_ChDB(t *testing.T) {
 			gotSeries := getMetaData(t, cc.query(srv.URL, "/api/v1/series", "mc_total", ""))
 			if len(gotSeries) != len(c.want) {
 				t.Errorf("/series match[]=mc_total returned %d series, want %d", len(gotSeries), len(c.want))
+			}
+		})
+	}
+}
+
+// TestMetadataWindowSweep_HistogramCompanion_ChDB covers the SECOND,
+// distinct lowering seam — lowerCompanionUnion — which a classic-histogram
+// `_count` / `_sum` selector routes through (histogram arm UNION-ALL
+// literal-suffixed value-table arms). This is the exact shape of the GCP
+// production metric the rc.9 bug was reported on
+// (loadbalancing_…_https_request_count, a DELTA histogram), so its window
+// handling MUST be verified with real in/out-of-window rows: a regression
+// dropping the window on this arm would pass the gauge sweep above green.
+func TestMetadataWindowSweep_HistogramCompanion_ChDB(t *testing.T) {
+	jt := map[string]time.Time{
+		"t0": metaWindowSeedBase.Add(-2 * time.Hour),
+		"t1": metaWindowSeedBase.Add(-1 * time.Hour),
+		"t2": metaWindowSeedBase.Add(-10 * time.Minute),
+		"t3": metaWindowSeedBase.Add(-30 * time.Second),
+	}
+	lit := func(t time.Time) string { return t.Format("2006-01-02 15:04:05.000000000") }
+	// `mh` lives in otel_metrics_histogram at all four sample times, one
+	// per job. All three tables exist so the companion union (histogram +
+	// literal-name value arms) resolves; the gauge/sum tables stay empty.
+	seed := metaShapedGaugeDDL + metaShapedSumDDL + metaShapedHistogramDDL + fmt.Sprintf(`
+INSERT INTO otel_metrics_histogram (MetricName, Attributes, TimeUnix, Count, Sum, BucketCounts, ExplicitBounds) VALUES
+    ('mh', map('job', 't0'), toDateTime64('%s', 9), 1, 1.0, [1, 0], [0.5]),
+    ('mh', map('job', 't1'), toDateTime64('%s', 9), 1, 1.0, [1, 0], [0.5]),
+    ('mh', map('job', 't2'), toDateTime64('%s', 9), 1, 1.0, [1, 0], [0.5]),
+    ('mh', map('job', 't3'), toDateTime64('%s', 9), 1, 1.0, [1, 0], [0.5]);`,
+		lit(jt["t0"]), lit(jt["t1"]), lit(jt["t2"]), lit(jt["t3"]))
+	srv, _ := newChDBServer(t, seed)
+
+	for _, c := range metaWindowCases(jt) {
+		t.Run(c.name, func(t *testing.T) {
+			// `mh_count` is the companion-union selector. Its job values are
+			// the jobs of the in-window mh rows — the same window oracle.
+			got := stringData(t, getMetaData(t, c.query(srv.URL, "/api/v1/label/job/values", "mh_count", "")))
+			if !setEqual(got, c.expectJobs) {
+				t.Errorf("/label/job/values match[]=mh_count = %v, want %v  (%s)", got, c.expectJobs, c.description)
+			}
+		})
+	}
+}
+
+// TestMetadataWindowSweep_ResourceAttr_ChDB reproduces the exact
+// production trigger: label_values(metric, deployment_environment_name),
+// where the label is a ResourceAttributes-map key merged into Attributes
+// by augmentSelectorAttributes BEFORE the window wrap. The merge-then-
+// window path is only exercised when the seed carries a ResourceAttributes
+// column AND the request window is offset from the (past-anchored) samples
+// — which no prior resource-attr test does (they seed at time.Now()).
+func TestMetadataWindowSweep_ResourceAttr_ChDB(t *testing.T) {
+	jt := map[string]time.Time{
+		"t0": metaWindowSeedBase.Add(-2 * time.Hour),
+		"t1": metaWindowSeedBase.Add(-1 * time.Hour),
+		"t2": metaWindowSeedBase.Add(-10 * time.Minute),
+		"t3": metaWindowSeedBase.Add(-30 * time.Second),
+	}
+	// env value per sample time, so the in-window env set is the oracle.
+	envOf := map[string]string{"t0": "env0", "t1": "env1", "t2": "env2", "t3": "env3"}
+	lit := func(t time.Time) string { return t.Format("2006-01-02 15:04:05.000000000") }
+	row := func(job string) string {
+		return fmt.Sprintf("('rm', map('job', '%s'), map('deployment.environment.name', '%s'), toDateTime64('%s', 9), 1.0)",
+			job, envOf[job], lit(jt[job]))
+	}
+	seed := resourceAttrGaugeDDL + resourceAttrSumDDL + resourceAttrHistogramDDL + fmt.Sprintf(`
+INSERT INTO otel_metrics_gauge (MetricName, Attributes, ResourceAttributes, TimeUnix, Value) VALUES
+    %s, %s, %s, %s;`, row("t0"), row("t1"), row("t2"), row("t3"))
+	srv, _ := newChDBServer(t, seed)
+
+	for _, c := range metaWindowCases(jt) {
+		t.Run(c.name, func(t *testing.T) {
+			wantEnvs := make([]string, 0, len(c.expectJobs))
+			for _, j := range c.expectJobs {
+				wantEnvs = append(wantEnvs, envOf[j])
+			}
+			got := stringData(t, getMetaData(t, c.query(srv.URL, "/api/v1/label/deployment_environment_name/values", "rm", "")))
+			if !setEqual(got, wantEnvs) {
+				t.Errorf("/label/deployment_environment_name/values match[]=rm = %v, want %v  (%s)", got, wantEnvs, c.description)
+			}
+		})
+	}
+}
+
+// TestMetadataWindowSweep_Boundary_ChDB pins the CLOSED interval — a
+// sample exactly at `start` or exactly at `end` is INCLUDED — so an
+// `OpGe`/`OpLe` → `OpGt`/`OpLt` regression (off-by-one at the window edge)
+// fails. Whole-second sample times keep the unix-second bounds exact.
+func TestMetadataWindowSweep_Boundary_ChDB(t *testing.T) {
+	seed, jt := metaWindowSeed()
+	srv, _ := newChDBServer(t, seed)
+	t2 := jt["t2"]
+
+	cases := []struct {
+		name       string
+		start, end time.Time
+		wantT2     bool
+	}{
+		{"start_eq_sample", t2, t2.Add(time.Hour), true},                     // sample at start → included
+		{"end_eq_sample", t2.Add(-time.Hour), t2, true},                      // sample at end → included
+		{"zero_width_at_sample", t2, t2, true},                               // start==end==sample → included
+		{"just_after_sample", t2.Add(time.Second), t2.Add(time.Hour), false}, // start > sample → excluded
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cc := metaWindowCase{start: c.start, end: c.end}
+			got := stringData(t, getMetaData(t, cc.query(srv.URL, "/api/v1/label/job/values", "m", "")))
+			if hasT2 := contains(got, "t2"); hasT2 != c.wantT2 {
+				t.Errorf("boundary %s: hasT2=%v want %v (got=%v)", c.name, hasT2, c.wantT2, got)
 			}
 		})
 	}

--- a/internal/api/prom/handler_chdb_metadata_window_sweep_test.go
+++ b/internal/api/prom/handler_chdb_metadata_window_sweep_test.go
@@ -1,0 +1,295 @@
+//go:build chdb
+
+// Exploratory window-vs-freshness sweep for the Prometheus metadata
+// endpoints (/series, /labels, /label/<name>/values). This is the
+// metadata analogue of the rc.9 eval-instant sweep
+// (test/spec/eval_instant_sweep.go): it seeds series at FIXED sample
+// times anchored well in the past, then varies the REQUEST window
+// [start,end] independently of wall-clock and asserts each endpoint
+// returns exactly the series/labels/values whose sample falls in the
+// window.
+//
+// Why this closes a real blind spot: every prior metadata chDB test
+// seeds and queries at (or near) the same anchor, so a handler that
+// ignores the request window — evaluating at `now` with a 5m staleness
+// window (/series, /labels pre-fix) or clamping to an instant window at
+// `end` (/label_values pre-fix) — still passed. Those exact defects are
+// the rc.9 /series empty-window bug and its /labels + /label/<name>/values
+// siblings. Anchoring the seed ~37 days before wall-clock means a
+// now()-anchored handler returns EMPTY for every window here, so the
+// sweep is red pre-fix and green only once all three endpoints honour the
+// full closed [start,end] window (promql.LowerMetadataRange).
+
+package prom_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sort"
+	"testing"
+	"time"
+)
+
+// metaWindowSeedBase anchors the sweep's sample times. It is deliberately
+// weeks before any plausible test wall-clock so a handler that evaluates a
+// metadata request at `now` (the pre-fix /series + /labels behaviour)
+// returns empty for EVERY window below — making the window-drop bug fail
+// the sweep instead of hiding behind a now-aligned seed.
+var metaWindowSeedBase = time.Date(2026, 5, 11, 12, 0, 0, 0, time.UTC)
+
+// metaWindowSeed builds the gauge/sum/histogram tables plus four `m`
+// series (one per `job`), each with a single sample at a distinct time
+// spread across a two-hour past span. A sample's job label uniquely
+// identifies which sample time produced it, so the per-window oracle is
+// exactly "the jobs whose sample time lies in [winStart,winEnd]".
+func metaWindowSeed() (string, map[string]time.Time) {
+	t0 := metaWindowSeedBase.Add(-2 * time.Hour)
+	t1 := metaWindowSeedBase.Add(-1 * time.Hour)
+	t2 := metaWindowSeedBase.Add(-10 * time.Minute)
+	t3 := metaWindowSeedBase.Add(-30 * time.Second)
+	jobTimes := map[string]time.Time{"t0": t0, "t1": t1, "t2": t2, "t3": t3}
+
+	lit := func(t time.Time) string { return t.Format("2006-01-02 15:04:05.000000000") }
+	seed := metaShapedGaugeDDL + metaShapedSumDDL + metaShapedHistogramDDL + fmt.Sprintf(`
+INSERT INTO otel_metrics_gauge (MetricName, Attributes, TimeUnix, Value) VALUES
+    ('m', map('job', 't0'), toDateTime64('%s', 9), 1.0),
+    ('m', map('job', 't1'), toDateTime64('%s', 9), 1.0),
+    ('m', map('job', 't2'), toDateTime64('%s', 9), 1.0),
+    ('m', map('job', 't3'), toDateTime64('%s', 9), 1.0);
+INSERT INTO otel_metrics_sum (MetricName, Attributes, TimeUnix, Value, IsMonotonic) VALUES
+    ('mc_total', map('job', 't0'), toDateTime64('%s', 9), 1.0, true),
+    ('mc_total', map('job', 't3'), toDateTime64('%s', 9), 1.0, true);`,
+		lit(t0), lit(t1), lit(t2), lit(t3), lit(t0), lit(t3))
+	return seed, jobTimes
+}
+
+// metaWindowCase is one row of the sweep: a request window and the set of
+// jobs whose sample falls inside it. omitBounds drives the no-start/no-end
+// case (whole-table scan; reference Prometheus's min/max-retention
+// default).
+type metaWindowCase struct {
+	name        string
+	start       time.Time
+	end         time.Time
+	omitBounds  bool
+	expectJobs  []string
+	description string
+}
+
+func metaWindowCases(jt map[string]time.Time) []metaWindowCase {
+	sec := time.Second
+	return []metaWindowCase{
+		{
+			name:        "W1_full",
+			start:       jt["t0"].Add(-sec),
+			end:         jt["t3"].Add(sec),
+			expectJobs:  []string{"t0", "t1", "t2", "t3"},
+			description: "window spans all four samples — pre-fix /series & /labels return empty (now-anchored), /label_values drops t0,t1,t2 (instant-at-end)",
+		},
+		{
+			name:        "W2_early",
+			start:       jt["t0"].Add(-sec),
+			end:         jt["t1"].Add(sec),
+			expectJobs:  []string{"t0", "t1"},
+			description: "window ends ~1h in the past — pre-fix everything is empty (no sample in a now/instant-at-end window)",
+		},
+		{
+			name:        "W3_late",
+			start:       jt["t2"].Add(-sec),
+			end:         jt["t3"].Add(sec),
+			expectJobs:  []string{"t2", "t3"},
+			description: "excludes t0,t1 — catches a handler that ignores `start` and returns all series",
+		},
+		{
+			name:        "W4_outside",
+			start:       jt["t3"].Add(time.Hour),
+			end:         jt["t3"].Add(2 * time.Hour),
+			expectJobs:  nil,
+			description: "window entirely after every sample — must be empty; catches a handler that ignores the window and returns everything",
+		},
+		{
+			name:        "W5_omitted",
+			omitBounds:  true,
+			expectJobs:  []string{"t0", "t1", "t2", "t3"},
+			description: "no start/end — whole-table scan returns all series; pins the now64(9)-default break",
+		},
+	}
+}
+
+func (c metaWindowCase) query(base, path, metric, extra string) string {
+	v := url.Values{}
+	v.Set("match[]", metric)
+	if !c.omitBounds {
+		v.Set("start", fmt.Sprintf("%d", c.start.Unix()))
+		v.Set("end", fmt.Sprintf("%d", c.end.Unix()))
+	}
+	if extra != "" {
+		return fmt.Sprintf("%s%s?%s&%s", base, path, v.Encode(), extra)
+	}
+	return fmt.Sprintf("%s%s?%s", base, path, v.Encode())
+}
+
+// getMetaData GETs a metadata endpoint and returns the decoded `data`
+// array as raw JSON messages (each is a string for /labels + /values, or
+// an object for /series).
+func getMetaData(t *testing.T, u string) []json.RawMessage {
+	t.Helper()
+	resp, err := http.Get(u)
+	if err != nil {
+		t.Fatalf("GET %s: %v", u, err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET %s: status=%d body=%s", u, resp.StatusCode, body)
+	}
+	var parsed struct {
+		Status string            `json:"status"`
+		Error  string            `json:"error"`
+		Data   []json.RawMessage `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		t.Fatalf("GET %s: unmarshal: %v body=%s", u, err, body)
+	}
+	if parsed.Status != "success" {
+		t.Fatalf("GET %s: status=%q err=%s", u, parsed.Status, parsed.Error)
+	}
+	return parsed.Data
+}
+
+func stringData(t *testing.T, raw []json.RawMessage) []string {
+	t.Helper()
+	out := make([]string, 0, len(raw))
+	for _, r := range raw {
+		var s string
+		if err := json.Unmarshal(r, &s); err != nil {
+			t.Fatalf("decode string element %s: %v", r, err)
+		}
+		out = append(out, s)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func seriesJobs(t *testing.T, raw []json.RawMessage) []string {
+	t.Helper()
+	out := make([]string, 0, len(raw))
+	for _, r := range raw {
+		var m map[string]string
+		if err := json.Unmarshal(r, &m); err != nil {
+			t.Fatalf("decode series element %s: %v", r, err)
+		}
+		if m["__name__"] != "m" {
+			t.Errorf("series missing __name__=m: %v", m)
+		}
+		out = append(out, m["job"])
+	}
+	sort.Strings(out)
+	return out
+}
+
+func setEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	as := append([]string(nil), a...)
+	bs := append([]string(nil), b...)
+	sort.Strings(as)
+	sort.Strings(bs)
+	for i := range as {
+		if as[i] != bs[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// TestMetadataWindowSweep_ChDB is the core sweep. For each window it
+// asserts every metadata endpoint returns exactly the in-window series.
+func TestMetadataWindowSweep_ChDB(t *testing.T) {
+	seed, jt := metaWindowSeed()
+	srv, _ := newChDBServer(t, seed)
+
+	for _, c := range metaWindowCases(jt) {
+		t.Run(c.name, func(t *testing.T) {
+			want := c.expectJobs
+			nonEmpty := len(want) > 0
+
+			// /api/v1/series — the endpoint the rc.9 bug was reported on.
+			// Oracle: the series whose sample is in [start,end].
+			gotSeries := seriesJobs(t, getMetaData(t, c.query(srv.URL, "/api/v1/series", "m", "")))
+			if !setEqual(gotSeries, want) {
+				t.Errorf("/series jobs = %v, want %v  (%s)", gotSeries, want, c.description)
+			}
+
+			// /api/v1/label/job/values — the /label_values sibling
+			// (instant-at-end pre-fix). Oracle: same in-window job set.
+			gotValues := stringData(t, getMetaData(t, c.query(srv.URL, "/api/v1/label/job/values", "m", "")))
+			if !setEqual(gotValues, want) {
+				t.Errorf("/label/job/values = %v, want %v  (%s)", gotValues, want, c.description)
+			}
+
+			// /api/v1/labels — the now-wallclock sibling. `__name__` is
+			// always prepended; `job` appears IFF an in-window series
+			// carries it. So `job` presence tracks "any in-window series".
+			gotLabels := stringData(t, getMetaData(t, c.query(srv.URL, "/api/v1/labels", "m", "")))
+			if hasJob := contains(gotLabels, "job"); hasJob != nonEmpty {
+				t.Errorf("/labels hasJob=%v, want %v (labels=%v)  (%s)", hasJob, nonEmpty, gotLabels, c.description)
+			}
+
+			// /api/v1/label/__name__/values — existence of the metric in
+			// the window.
+			gotNames := stringData(t, getMetaData(t, c.query(srv.URL, "/api/v1/label/__name__/values", "m", "")))
+			wantNames := []string{}
+			if nonEmpty {
+				wantNames = []string{"m"}
+			}
+			if !setEqual(gotNames, wantNames) {
+				t.Errorf("/label/__name__/values = %v, want %v  (%s)", gotNames, wantNames, c.description)
+			}
+		})
+	}
+}
+
+// TestMetadataWindowSweep_SingleTable_ChDB covers the single-table
+// lowering branch (a suffixed `_total` counter resolves to otel_metrics_sum
+// alone, not the gauge∪sum union), so both metadataFullRange seams in
+// lowerVectorSelector are exercised. mc_total has samples at t0 and t3.
+func TestMetadataWindowSweep_SingleTable_ChDB(t *testing.T) {
+	seed, jt := metaWindowSeed()
+	srv, _ := newChDBServer(t, seed)
+
+	sec := time.Second
+	cases := []struct {
+		name       string
+		start, end time.Time
+		want       []string
+	}{
+		{"full", jt["t0"].Add(-sec), jt["t3"].Add(sec), []string{"t0", "t3"}},
+		{"late_only_t3", jt["t2"].Add(-sec), jt["t3"].Add(sec), []string{"t3"}},
+		{"early_only_t0", jt["t0"].Add(-sec), jt["t1"].Add(sec), []string{"t0"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cc := metaWindowCase{start: c.start, end: c.end}
+			got := stringData(t, getMetaData(t, cc.query(srv.URL, "/api/v1/label/job/values", "mc_total", "")))
+			if !setEqual(got, c.want) {
+				t.Errorf("/label/job/values match[]=mc_total = %v, want %v", got, c.want)
+			}
+			gotSeries := getMetaData(t, cc.query(srv.URL, "/api/v1/series", "mc_total", ""))
+			if len(gotSeries) != len(c.want) {
+				t.Errorf("/series match[]=mc_total returned %d series, want %d", len(gotSeries), len(c.want))
+			}
+		})
+	}
+}

--- a/internal/api/prom/metadata.go
+++ b/internal/api/prom/metadata.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/tsouza/cerberus/internal/api/format"
 	"github.com/tsouza/cerberus/internal/chclient"
-	"github.com/tsouza/cerberus/internal/chplan"
 	"github.com/tsouza/cerberus/internal/chsql"
 	"github.com/tsouza/cerberus/internal/promql"
 )
@@ -211,6 +210,34 @@ type renderedQuery struct {
 // all metric tables, plus the synthetic `__name__` for the metric-name
 // dimension. Optional `match[]` selectors narrow the result to labels of
 // the matched series only.
+// parseMetadataWindow extracts the optional `start` / `end` parameters
+// shared by the metadata endpoints (/series, /labels, /label/<name>/values).
+// r.ParseForm must already have run. Both bounds are optional; an absent
+// one returns zero-time, which promql.LowerMetadataRange treats as "no
+// bound on that side" (whole-table scan, matching reference Prometheus's
+// min/max-retention default). A malformed value is a bad_data error. The
+// returned [start,end] is the closed window a metadata enumeration scans —
+// it must NOT be collapsed to an instant staleness window at `end`, which
+// silently drops any series/label/value whose only sample sits earlier in
+// the window.
+func parseMetadataWindow(r *http.Request) (start, end time.Time, err error) {
+	if raw := r.Form.Get("start"); raw != "" {
+		t, perr := format.ParseTimeProm(raw, time.Time{})
+		if perr != nil {
+			return time.Time{}, time.Time{}, fmt.Errorf("invalid 'start' parameter: %w", perr)
+		}
+		start = t
+	}
+	if raw := r.Form.Get("end"); raw != "" {
+		t, perr := format.ParseTimeProm(raw, time.Time{})
+		if perr != nil {
+			return time.Time{}, time.Time{}, fmt.Errorf("invalid 'end' parameter: %w", perr)
+		}
+		end = t
+	}
+	return start, end, nil
+}
+
 func (h *Handler) handleLabels(w http.ResponseWriter, r *http.Request) {
 	if err := r.ParseForm(); err != nil {
 		writeError(w, http.StatusBadRequest, ErrBadData, err)
@@ -218,12 +245,17 @@ func (h *Handler) handleLabels(w http.ResponseWriter, r *http.Request) {
 	}
 	matchers := r.Form["match[]"]
 
+	startT, endT, err := parseMetadataWindow(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, ErrBadData, err)
+		return
+	}
+
 	var names []string
-	var err error
 	if len(matchers) == 0 {
 		names, err = h.fetchLabelNames(r.Context())
 	} else {
-		names, err = h.fetchLabelNamesMatched(r.Context(), matchers)
+		names, err = h.fetchLabelNamesMatched(r.Context(), matchers, startT, endT)
 	}
 	if err != nil {
 		h.respondError(w, err)
@@ -248,12 +280,14 @@ func (h *Handler) handleLabels(w http.ResponseWriter, r *http.Request) {
 // across metric tables. For other labels we read `Attributes[<name>]` and
 // drop the empty-string sentinel.
 //
-// Optional `start` / `end` parameters anchor the LWR (latest-with-respect-
-// to-T) window used when lowering each `match[]` selector. Without them
-// the lowering defaults to `now64(9)` and the staleness window may
-// exclude any sample older than the default lookback — the request would
-// then return an empty value list even when matching rows exist in the
-// table.
+// Optional `start` / `end` parameters bound the closed [start,end] window
+// the `match[]` enumeration scans (promql.LowerMetadataRange). A value is
+// returned if it appears on any series with a sample ANYWHERE in that
+// window — not just within a staleness lookback at `end`. Without the
+// bounds the scan covers the whole table. (Reference Prometheus matches
+// label values over the full [start,end] metadata range; an instant
+// staleness window would drop a value whose only sample sits early in the
+// range — the rc.9 /series window-drop bug, same class.)
 func (h *Handler) handleLabelValues(w http.ResponseWriter, r *http.Request) {
 	name := r.PathValue("name")
 	if name == "" {
@@ -271,35 +305,17 @@ func (h *Handler) handleLabelValues(w http.ResponseWriter, r *http.Request) {
 	}
 	matchers := r.Form["match[]"]
 
-	// `start` / `end` are optional on label/values; when present they
-	// anchor the matcher lowering's eval timestamp so the LWR window
-	// can include samples within the requested range. Parse errors are
-	// reported as bad_data; missing values fall through as zero-time
-	// (handler retains the legacy `now64(9)` default in that case).
-	startRaw := r.Form.Get("start")
-	endRaw := r.Form.Get("end")
-	var startT, endT time.Time
-	if startRaw != "" {
-		t, err := format.ParseTimeProm(startRaw, time.Time{})
-		if err != nil {
-			writeError(w, http.StatusBadRequest, ErrBadData,
-				fmt.Errorf("invalid 'start' parameter: %w", err))
-			return
-		}
-		startT = t
-	}
-	if endRaw != "" {
-		t, err := format.ParseTimeProm(endRaw, time.Time{})
-		if err != nil {
-			writeError(w, http.StatusBadRequest, ErrBadData,
-				fmt.Errorf("invalid 'end' parameter: %w", err))
-			return
-		}
-		endT = t
+	// `start` / `end` are optional on label/values; when present they bound
+	// the closed [start,end] window the matcher enumeration scans (see
+	// parseMetadataWindow + promql.LowerMetadataRange). Missing values fall
+	// through as zero-time (no bound on that side — whole-table scan).
+	startT, endT, err := parseMetadataWindow(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, ErrBadData, err)
+		return
 	}
 
 	var values []string
-	var err error
 	if len(matchers) == 0 {
 		values, err = h.fetchLabelValues(r.Context(), name)
 	} else {
@@ -512,6 +528,18 @@ func (h *Handler) handleSeries(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Grafana's `label_values(metric, label)` template vars and panel
+	// series probes pass the dashboard time range as start/end. Honour it
+	// as the closed enumeration window — evaluating /series at wall-clock
+	// `now` with a 5m staleness window (the pre-fix behaviour) silently
+	// dropped any series whose newest sample was older than 5m (late
+	// delta-temporality ingestion), so the env dropdown flapped empty.
+	startT, endT, err := parseMetadataWindow(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, ErrBadData, err)
+		return
+	}
+
 	// Two-layer matcher fan-out — `expandUnderscoredMetricNameMatcher`
 	// (dotted-storage candidates) nested inside `expandBareHistogramMatcher`
 	// (classic-histogram companion variants). See the per-helper docstrings
@@ -525,7 +553,7 @@ func (h *Handler) handleSeries(w http.ResponseWriter, r *http.Request) {
 	// N round-trips → 1. Pathologically broad probes chunk into ⌈N/K⌉
 	// bounded queries (still ≪ N); see fetchSeries.
 	variants := expandSeriesMatchers(h.parser, matchers, h.Schema.HistogramTable)
-	sets, err := h.fetchSeries(r.Context(), variants)
+	sets, err := h.fetchSeries(r.Context(), variants, startT, endT)
 	if err != nil {
 		h.respondError(w, err)
 		return
@@ -756,16 +784,17 @@ func (h *Handler) catalogNameTables() (bareTables []string, histogramTable strin
 // — would see only `__name__` and render "Unable to fetch labels".
 // Non-histogram inputs short-circuit through the no-op (single-element)
 // return of the expander.
-func (h *Handler) fetchLabelNamesMatched(ctx context.Context, matchers []string) ([]string, error) {
+func (h *Handler) fetchLabelNamesMatched(ctx context.Context, matchers []string, start, end time.Time) ([]string, error) {
 	// Fan-in batching (task #71): the variant fan-out across all matchers
 	// collapses into ONE combined query (chunked under CH's max_query_size
 	// when broad). Each variant lowers to its inner matcher SELECT; the
 	// arms UNION-ALL into the FROM source of a single
 	// `SELECT DISTINCT arrayJoin(mapKeys(Attributes))` — N round-trips → 1
 	// (⌈N/K⌉ for a pathologically broad probe), same distinct key set the
-	// per-arm loop collected.
+	// per-arm loop collected. start/end bound the closed metadata window
+	// each variant scans (zero = whole table).
 	variants := expandSeriesMatchers(h.parser, matchers, h.Schema.HistogramTable)
-	keys, err := h.labelKeysForMatchers(ctx, variants)
+	keys, err := h.labelKeysForMatchers(ctx, variants, start, end)
 	if err != nil {
 		return nil, err
 	}
@@ -849,7 +878,7 @@ func (h *Handler) matcherArms(ctx context.Context, matchers []string, start, end
 // breaches maxRenderedQueryBytes. The caller (fetchLabelNamesMatched)
 // re-dedupes via format.NormalizeLabelNames, so the per-query key sets can
 // overlap safely. An empty variant list yields no keys (and no query).
-func (h *Handler) labelKeysForMatchers(ctx context.Context, matchers []string) ([]string, error) {
+func (h *Handler) labelKeysForMatchers(ctx context.Context, matchers []string, start, end time.Time) ([]string, error) {
 	if len(matchers) == 0 {
 		return nil, nil
 	}
@@ -863,7 +892,7 @@ func (h *Handler) labelKeysForMatchers(ctx context.Context, matchers []string) (
 	}
 	var all []string
 	for _, chunk := range chunkMatcherVariants(matchers) {
-		arms, err := h.matcherArms(ctx, chunk, time.Time{}, time.Time{})
+		arms, err := h.matcherArms(ctx, chunk, start, end)
 		if err != nil {
 			return nil, err
 		}
@@ -972,22 +1001,19 @@ func (h *Handler) labelValueCombine(name string) func([]chsql.Frag) (string, []a
 	}
 }
 
-// matcherSQL lowers a single matcher to its inner SQL + args. The caller
-// wraps this in whatever projection it needs (DISTINCT mapKeys, etc.).
-// When end is non-zero the lowering threads start/end through to
-// promql.LowerAt so the matcher's LWR window anchors at the request's
-// `end` rather than the lowering default (`now64(9)`).
+// matcherSQL lowers a single /labels or /label/<name>/values matcher to
+// its inner SQL + args. The caller wraps this in whatever projection it
+// needs (DISTINCT mapKeys, DISTINCT Attributes[name], etc.). start/end
+// bound the closed [start,end] metadata window (promql.LowerMetadataRange);
+// a zero bound is omitted. The full-range window — not an instant
+// staleness window at `end` — is what lets these endpoints surface a
+// label/value whose only sample sits early in the requested range.
 func (h *Handler) matcherSQL(ctx context.Context, matcher string, start, end time.Time) (string, []any, error) {
 	expr, err := h.parseExpr(ctx, matcher)
 	if err != nil {
 		return "", nil, &apiError{Kind: ErrBadData, Err: err, Status: http.StatusBadRequest}
 	}
-	var plan chplan.Node
-	if !end.IsZero() {
-		plan, err = promql.LowerAt(ctx, expr, h.Schema, start, end)
-	} else {
-		plan, err = promql.Lower(ctx, expr, h.Schema)
-	}
+	plan, err := promql.LowerMetadataRange(ctx, expr, h.Schema, start, end)
 	if err != nil {
 		return "", nil, &apiError{Kind: ErrBadData, Err: err, Status: http.StatusBadRequest}
 	}
@@ -1040,14 +1066,10 @@ func expandSeriesMatchers(parser promparser.Parser, matchers []string, histogram
 // breaches maxRenderedQueryBytes — typical requests stay one round-trip;
 // only a pathologically broad probe fans into a few bounded queries
 // (still ≪ N), merged through the dedup below.
-func (h *Handler) fetchSeries(ctx context.Context, matchers []string) ([]map[string]string, error) {
+func (h *Handler) fetchSeries(ctx context.Context, matchers []string, start, end time.Time) ([]map[string]string, error) {
 	if len(matchers) == 0 {
 		return nil, nil
 	}
-	// Series matchers don't carry @ start()/end(); pass `now` for both
-	// anchors so any literal @<ts> still resolves but the start()/end()
-	// variants surface as errors at lowering time.
-	now := time.Now()
 
 	seen := make(map[string]map[string]string)
 	// No labelMemo here: this loop folds samples from SEVERAL independent
@@ -1058,7 +1080,7 @@ func (h *Handler) fetchSeries(ctx context.Context, matchers []string) ([]map[str
 	// per series, not K samples per series, and the `seen` map already dedups
 	// by canonical key. So normalise directly, per row.
 	for _, chunk := range chunkMatcherVariants(matchers) {
-		samples, err := h.fetchSeriesChunk(ctx, chunk, now)
+		samples, err := h.fetchSeriesChunk(ctx, chunk, start, end)
 		if err != nil {
 			return nil, err
 		}
@@ -1081,7 +1103,7 @@ func (h *Handler) fetchSeries(ctx context.Context, matchers []string) ([]map[str
 // when the rendered-size guard splits) over a single arm-cap chunk of
 // matcher variants and returns the raw samples. The caller folds the
 // per-chunk samples into the cross-chunk dedup.
-func (h *Handler) fetchSeriesChunk(ctx context.Context, matchers []string, now time.Time) ([]chclient.Sample, error) {
+func (h *Handler) fetchSeriesChunk(ctx context.Context, matchers []string, start, end time.Time) ([]chclient.Sample, error) {
 	// Single-matcher fast path: run the lowered Sample-shape SELECT
 	// directly as the top-level statement — byte-identical to the
 	// pre-#71 per-arm query (the engine ran this same SQL). Avoids
@@ -1089,7 +1111,7 @@ func (h *Handler) fetchSeriesChunk(ctx context.Context, matchers []string, now t
 	// (…)` boundary, which some CH drivers (chdb) refuse to cast back to
 	// MAP.
 	if len(matchers) == 1 {
-		sql, args, err := h.seriesMatcherSQL(ctx, matchers[0], now, now)
+		sql, args, err := h.seriesMatcherSQL(ctx, matchers[0], start, end)
 		if err != nil {
 			return nil, err
 		}
@@ -1103,7 +1125,7 @@ func (h *Handler) fetchSeriesChunk(ctx context.Context, matchers []string, now t
 	// byte budget.
 	arms := make([]chsql.Frag, 0, len(matchers))
 	for _, m := range matchers {
-		s, a, err := h.seriesMatcherSQL(ctx, m, now, now)
+		s, a, err := h.seriesMatcherSQL(ctx, m, start, end)
 		if err != nil {
 			return nil, err
 		}
@@ -1144,19 +1166,17 @@ func (h *Handler) querySamples(ctx context.Context, sql string, args []any) ([]c
 // optimize, emit. The Sample shape is what lets every variant become a
 // UNION-ALL arm of the one combined query fetchSeries runs.
 //
-// start/end anchor the matcher lowering's eval timestamp (`now` for both
-// on the series path); zero-time falls back to the lowering default.
+// start/end bound the closed [start,end] metadata window the matcher
+// enumeration scans (promql.LowerMetadataRange) — NOT an instant
+// staleness window at `end`. A zero start/end omits that bound. This is
+// what makes /series return a series with any in-window sample instead of
+// only series with a sample in the last 5m at wall-clock `now`.
 func (h *Handler) seriesMatcherSQL(ctx context.Context, matcher string, start, end time.Time) (string, []any, error) {
 	expr, err := h.parseExpr(ctx, matcher)
 	if err != nil {
 		return "", nil, &apiError{Kind: ErrBadData, Err: err, Status: http.StatusBadRequest}
 	}
-	var plan chplan.Node
-	if !end.IsZero() {
-		plan, err = promql.LowerAt(ctx, expr, h.Schema, start, end)
-	} else {
-		plan, err = promql.Lower(ctx, expr, h.Schema)
-	}
+	plan, err := promql.LowerMetadataRange(ctx, expr, h.Schema, start, end)
 	if err != nil {
 		return "", nil, &apiError{Kind: ErrBadData, Err: err, Status: http.StatusBadRequest}
 	}

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -120,6 +120,35 @@ func LowerAtRangeOpts(ctx context.Context, expr parser.Expr, s schema.Metrics, s
 	return plan, nil
 }
 
+// LowerMetadataRange lowers a bare metadata matcher (one match[] selector
+// from /api/v1/series, /api/v1/labels, or /api/v1/label/<name>/values)
+// over the FULL [start,end] request window.
+//
+// Reference Prometheus answers these metadata endpoints by enumerating
+// every series/label/value with ANY sample anywhere in [start,end]. That
+// is NOT the instant-query contract [LowerAt] implements: an instant
+// lowering anchors a 5-minute LWR staleness window at `end` and collapses
+// to the latest sample per series — which silently drops any series whose
+// only sample sits earlier in the requested window (the rc.9 /series
+// empty-window bug, and the same defect in /labels + /label/<name>/values
+// once you account for late-arriving samples). LowerMetadataRange is the
+// single chokepoint that gives all three endpoints the correct full-range
+// window: the [metadataFullRange] flag routes the bare-selector path to
+// [wrapMetadataFullRange], which emits a closed `Timestamp >= start AND
+// Timestamp <= end` filter (a zero start/end omits that bound — whole-
+// table scan, matching reference defaults) with NO staleness collapse.
+func LowerMetadataRange(ctx context.Context, expr parser.Expr, s schema.Metrics, start, end time.Time) (chplan.Node, error) {
+	_, span := tracer.Start(ctx, cerbtrace.SpanLower, trace.WithAttributes(cerbtrace.AttrQL.String("promql")))
+	defer span.End()
+	plan, err := lower(expr, s, lowerCtx{start: start, end: end, metadataFullRange: true})
+	if err != nil {
+		span.RecordError(err)
+		return nil, err
+	}
+	span.SetAttributes(cerbtrace.AttrPlanNodeCount.Int(cerbtrace.CountNodes(plan)))
+	return plan, nil
+}
+
 func lower(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
 	switch e := expr.(type) {
 	case *parser.VectorSelector:
@@ -503,6 +532,14 @@ func lowerVectorSelector(v *parser.VectorSelector, s schema.Metrics, ctx lowerCt
 		}
 		return wrapRangeLatestPerSeries(selectorInput, pred, anchor, ctx, s), nil
 	}
+	// Metadata enumeration (/series, /labels, /label/<name>/values): full
+	// [start,end] window, no LWR staleness collapse — see
+	// [wrapMetadataFullRange]. Checked before the instant LWR wrap because
+	// metadata lowerings run with step==0 and inRangeVector==false, so they
+	// fall through to exactly this seam.
+	if ctx.metadataFullRange {
+		return wrapMetadataFullRange(selectorInput, pred, ctx.start, ctx.end, s), nil
+	}
 	// Instant-vector context: the LWR wrapper applies both the
 	// `Timestamp <= anchor` upper bound and the staleness lower
 	// bound, so we DON'T pre-add the modifier's timeBoundExpr here —
@@ -643,6 +680,12 @@ func lowerCompanionUnion(
 			return wrapRangeAbsoluteAtBroadcast(selectorInput, nil, anchor, ctx, s), nil
 		}
 		return wrapRangeLatestPerSeries(selectorInput, nil, anchor, ctx, s), nil
+	}
+	// Metadata enumeration over the (Gauge, Sum) union: full [start,end]
+	// window, no LWR staleness collapse — same seam as the single-table
+	// path above. pred is nil here (already applied per union arm).
+	if ctx.metadataFullRange {
+		return wrapMetadataFullRange(selectorInput, nil, ctx.start, ctx.end, s), nil
 	}
 	return wrapInstantLatestPerSeries(selectorInput, nil, anchor, s), nil
 }
@@ -945,6 +988,98 @@ func wrapInstantLatestPerSeries(scan chplan.Node, pred chplan.Expr, anchor evalA
 			{Expr: &chplan.ColumnRef{Name: s.AttributesColumn}, Alias: s.AttributesColumn},
 			{Expr: &chplan.ColumnRef{Name: lwrTsAlias}, Alias: s.TimestampColumn},
 			{Expr: &chplan.ColumnRef{Name: lwrValueAlias}, Alias: s.ValueColumn},
+		},
+	}
+}
+
+// wrapMetadataFullRange filters (scan, pred) to the closed [start,end]
+// request window and collapses to one row per `(MetricName, Attributes)`
+// series via `any()`. It is the metadata-endpoint analogue of
+// [wrapInstantLatestPerSeries]: same canonical 4-column Sample output
+// shape, but with two deliberate differences that implement metadata
+// enumeration semantics instead of instant-query semantics —
+//
+//   - WINDOW: a closed `Timestamp >= start AND Timestamp <= end` filter
+//     (each bound omitted when zero — a no-bound side scans the whole
+//     table, matching reference Prometheus's min/max-retention default),
+//     NOT the instant `(end - 5m, end]` LWR + staleness window. A series
+//     whose only sample sits early in [start,end] must still surface.
+//   - COLLAPSE: `any(TimeUnix)` / `any(Value)` per series — we only need
+//     existence-of-a-series, not the latest-per-series value — so there
+//     is no `argMax`/`max` LWR pick. The downstream /series dedup and the
+//     /labels + /label/<name>/values DISTINCT projections fold the
+//     one-row-per-series output exactly as they did the instant shape.
+//
+// Collapsing here (rather than streaming every in-window sample) bounds
+// the row count to the number of distinct series, keeping a wide
+// metadata window cheap on the wire.
+func wrapMetadataFullRange(scan chplan.Node, pred chplan.Expr, start, end time.Time, s schema.Metrics) chplan.Node {
+	combined := pred
+	addBound := func(b chplan.Expr) {
+		if combined == nil {
+			combined = b
+			return
+		}
+		combined = &chplan.Binary{Op: chplan.OpAnd, Left: combined, Right: b}
+	}
+	if !start.IsZero() {
+		addBound(&chplan.Binary{
+			Op:    chplan.OpGe,
+			Left:  &chplan.ColumnRef{Name: s.TimestampColumn},
+			Right: metadataBoundExpr(start),
+		})
+	}
+	if !end.IsZero() {
+		addBound(&chplan.Binary{
+			Op:    chplan.OpLe,
+			Left:  &chplan.ColumnRef{Name: s.TimestampColumn},
+			Right: metadataBoundExpr(end),
+		})
+	}
+
+	input := scan
+	if combined != nil {
+		input = &chplan.Filter{Input: scan, Predicate: combined}
+	}
+
+	const (
+		metaTsAlias    = "meta_ts"
+		metaValueAlias = "meta_value"
+	)
+	agg := &chplan.Aggregate{
+		Input: input,
+		GroupBy: []chplan.Expr{
+			&chplan.ColumnRef{Name: s.MetricNameColumn},
+			&chplan.ColumnRef{Name: s.AttributesColumn},
+		},
+		GroupByAliases: []string{s.MetricNameColumn, s.AttributesColumn},
+		AggFuncs: []chplan.AggFunc{
+			{Name: "any", Args: []chplan.Expr{&chplan.ColumnRef{Name: s.TimestampColumn}}, Alias: metaTsAlias},
+			{Name: "any", Args: []chplan.Expr{&chplan.ColumnRef{Name: s.ValueColumn}}, Alias: metaValueAlias},
+		},
+	}
+	return &chplan.Project{
+		Input: agg,
+		Projections: []chplan.Projection{
+			{Expr: &chplan.ColumnRef{Name: s.MetricNameColumn}, Alias: s.MetricNameColumn},
+			{Expr: &chplan.ColumnRef{Name: s.AttributesColumn}, Alias: s.AttributesColumn},
+			{Expr: &chplan.ColumnRef{Name: metaTsAlias}, Alias: s.TimestampColumn},
+			{Expr: &chplan.ColumnRef{Name: metaValueAlias}, Alias: s.ValueColumn},
+		},
+	}
+}
+
+// metadataBoundExpr renders a metadata window bound as a
+// `toDateTime64('YYYY-MM-DD HH:MM:SS.fffffffff', 9)` literal — the same
+// literal shape [anchorBaseExpr] emits for an absolute eval anchor, so
+// the metadata window bounds read identically to the instant-query
+// bounds in emitted SQL.
+func metadataBoundExpr(t time.Time) chplan.Expr {
+	return &chplan.FuncCall{
+		Name: "toDateTime64",
+		Args: []chplan.Expr{
+			&chplan.LitString{V: t.UTC().Format("2006-01-02 15:04:05.000000000")},
+			&chplan.LitInt{V: chplan.NanoScale},
 		},
 	}
 }

--- a/internal/promql/modifiers.go
+++ b/internal/promql/modifiers.go
@@ -50,6 +50,18 @@ type lowerCtx struct {
 	// kept for byte-stable SQL on the existing fixtures.
 	step          time.Duration
 	inRangeVector bool
+	// metadataFullRange marks a lowering driven by a Prometheus metadata
+	// endpoint (/series, /labels, /label/<name>/values). Metadata
+	// enumerates which series/labels/values have ANY sample in the
+	// requested [start,end] window — NOT the latest-per-series staleness
+	// semantics of an instant query. When set, the bare-selector path
+	// emits a closed [start,end] Timestamp filter (start/end carried in
+	// ctx.start/ctx.end; a zero bound is omitted) and collapses to one
+	// row per series WITHOUT the 5m LWR staleness window — so a series
+	// whose only sample sits early in the window still surfaces. Set only
+	// by [LowerMetadataRange]; every query-evaluation path leaves it
+	// false and keeps the instant/range LWR semantics.
+	metadataFullRange bool
 	// outerByLabels carries the by-clause labels of an enclosing
 	// vector aggregation, threaded down so the inner selector path
 	// can inflate Attributes with the top-level OTel-CH columns


### PR DESCRIPTION
## The bug (rc.9 `/api/v1/series` empty-window flake — and two siblings)

The battle-tester's GCP dashboard intermittently showed no environments in its `env` template var (every panel "No data"), then rendered on reload. Root cause: the Prometheus **metadata** endpoints reused the **instant-query** lowering instead of a full-range one, so they silently dropped results whose only in-window sample was older than the staleness lookback. An orchestrated cross-head audit found it's broader than `/series`:

| Endpoint | Pre-fix window | Effect |
|---|---|---|
| `/api/v1/series` | `(serverNow−5m, serverNow]` — request window **ignored entirely** (`fetchSeries` hardcoded `now:=time.Now()`) | late (GCP ~5-min delta) samples vanish |
| `/api/v1/labels` (`match[]`) | `now64(9)` wall-clock instant (`labelKeysForMatchers` passed zero start/end) | same drop |
| `/api/v1/label/<name>/values` (`match[]`) | instant-at-`end` staleness (`LowerAt`) | drops any value whose only sample sits in `[start, end−5m]` |

Reference Prometheus answers all three by enumerating every series/label/value with **any** sample in the full `[start,end]` range — staleness lookback is a query-evaluation concept, not a metadata one. Loki/Tempo metadata endpoints were audited and are already full-range.

This is the same class as PR #956 (which fixed the instant *query* path), one endpoint family over.

## The fix — one chokepoint

`promql.LowerMetadataRange` + a `metadataFullRange` lowerCtx flag route the bare-selector path (the single-table seam **and** the `lowerCompanionUnion` histogram-companion seam) through `wrapMetadataFullRange`, which emits a closed `Timestamp >= start AND Timestamp <= end` filter (a zero bound is omitted → whole-table scan, matching reference defaults) and collapses per series with `any()` — no `argMax` LWR pick, no 5m staleness bound. `handleSeries`/`handleLabels` parse the window via a shared `parseMetadataWindow` and thread it through. Typed chsql Frags only; no raw SQL.

## Tests — exploratory window-vs-freshness sweep (the anti-recurrence guard)

`handler_chdb_metadata_window_sweep_test.go` seeds series at fixed times **~37 days before wall-clock** and sweeps the request window independently across all four endpoints + both lowering seams + the resource-attr path + closed-interval boundaries. **Proven red pre-fix** (every now-anchored handler returns empty; the instant-at-`end` path returns only the freshest sample) and **green post-fix**. This is the metadata analogue of the rc.9 eval-instant sweep — it closes the blind spot where every prior metadata test seeded and queried at the same anchor. `W4_outside` correctly stays green pre-fix (not trivially always-red).

Verification: full build green; `internal/promql`/`chplan`/`chsql`/`spec` green; **431 prom chDB tests** pass, no regression.

## Adversarial review

A 4-reviewer adversarial pass (correctness / missed-callsites / perf / test-rigor) returned **GO, zero confident blockers**. Its should-fix items are folded in: the histogram-companion seam case (the exact GCP `_count` shape), the resource-attr `label_values(metric, deployment_environment_name)` case (the literal production trigger), the closed-interval boundary case, and a tightened `/labels` set-equality oracle.

### Intended behavior change (called out per review)
When `start`/`end` are **omitted**, the metadata endpoints now emit a whole-table scan (matching reference Prometheus's min/max-retention default) where the pre-fix path was always 5m-bounded. This is correct-over-fast, but Grafana issues bare `match[]` for some template vars — on a very large, long-retention table that is a wider scan. The existing arm-count / rendered-query-size cap is the current guard.

### Deferred follow-ups (non-blocking)
- Add a no-bounds `/series` row to the `cardinality-baseline.json` perf ratchet so metadata scan-volume is visible to the guard.
- Reject (or document) `@`/`offset`/`start()`/`end()` modifiers on a metadata `match[]` selector, and restrict `match[]` to `VectorSelector` (reference Prom uses `ParseMetricSelector`). Pre-existing, not a regression.

Closes the rc.9 `/series` window-drop class → cut **v1.0.0-rc.10** after merge (tag creation needs the maintainer to lift the tag-creation ruleset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)