### PR TITLE
docs: prepare 1.0.0 GA — flip experimental framing, reconcile CHANGELOG, scrub CLAUDE.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,102 @@
 
 All notable changes to cerberus will be documented in this file. The format roughly follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), with one entry per tagged release.
 
-## [v1.0.0-RC1]
+## [v1.0.0] — 2026-06-17
 
-The first release candidate on the `v1.0.0` line. This is an early,
-experimental cut: the three heads parse → lower → execute and the
-differential harnesses gate every merge, but the surface is still
-evolving and must be validated against your own corpus before any real
-use.
+First general-availability release. Cerberus is a drop-in Prometheus /
+Loki / Tempo HTTP gateway for ClickHouse: each head parses with its
+reference upstream parser, lowers to a shared plan IR, runs a rule-based
+optimizer, and emits parameterised ClickHouse SQL — so Grafana, alerting,
+and CLI tooling see three normal datasources speaking unmodified PromQL /
+LogQL / TraceQL.
+
+**Wire-format API stability.** The three upstream HTTP surfaces cerberus
+serves are the 1.0 compatibility contract and follow semantic versioning
+from here. The query languages are the upstream parsers' own, so they
+track upstream. The `CERBERUS_*` configuration surface is stable;
+additive changes only within 1.x.
+
+This is a young, actively-developed project: a confident 1.0 because the
+behaviour is held to reference engines by differential harnesses on every
+merge — not because every edge is explored. Two areas carry honestly lower
+confidence and are called out below.
+
+### Capabilities at 1.0
+
+- **PromQL** scored against the third-party CNCF / PromLabs
+  [PromQL Compliance Tester](https://github.com/prometheus/compliance) —
+  574/574 cases passing against a real Prometheus, no allow-list — plus
+  subqueries, `histogram_quantile` over classic and native histograms,
+  `predict_linear` / `holt_winters`, `@start()` / `@end()`,
+  `group_left` / `group_right`, and the full instant + range-query surface.
+- **LogQL** diffed against a real Loki on Grafana's own `pkg/logql/bench`
+  corpus: pipeline stages (`| json` / `| logfmt` / `| pattern` / `| unpack`
+  / `| line_format` / `| label_format` / …), metric queries, structured
+  metadata, and the `/labels` / `/series` / `/index/stats` metadata surface.
+- **TraceQL** diffed against a real Tempo: structural operators, nested-set
+  intrinsics in `| select(...)`, set ops, `group` / `coalesce`, the metrics
+  pipeline, and the `/api/search` + tag-discovery surface.
+- **Coverage** ([`docs/coverage.md`](docs/coverage.md)): 226 of 228
+  catalogued symbols supported across the three heads, 2 intentional
+  parity rejections (bare `start()` / `end()`), **zero** wrong-rejections.
+- **OpenTelemetry-native** schema (the `clickhouseexporter` table shape),
+  with resource attributes projected as Prometheus labels and the
+  `CERBERUS_SCHEMA_*` overrides for non-default layouts.
+- **Operations**: `ReplicatedMergeTree` / `Replicated`-database schema
+  bootstrap (`CERBERUS_AUTO_CREATE_SCHEMA`), per-head ClickHouse circuit
+  breakers, OTLP self-telemetry export, `/readyz` / `/healthz` probes, and
+  the full ClickHouse connection surface (TLS, timeouts, pool sizing).
+- **Performance**: single-pass prefix-sum range aggregation, sharded
+  pushdown solver, PREWHERE promotion + late materialisation, metadata
+  fan-in batching, and an optional experimental native-rate path
+  (`CERBERUS_EXPERIMENTAL_TS_GRID_RANGE`, off by default) — all held
+  against regression by the compute-fan-out perf-guard ratchets.
+
+### Changed since the v1.0.0-rc series
+
+- **Metadata endpoints scan the full `[start,end]` window.** `/api/v1/series`,
+  `/labels`, and `/label/<name>/values` enumerate every series/label/value
+  with any sample in the requested window instead of an instant staleness
+  window at `now`, fixing intermittent empty results for late-arriving
+  (delta-temporality) data.
+- **Instant range-vector queries anchor to `time=T`**, not ClickHouse
+  wall-clock, closing an intermittent empty-window class.
+- **GCP / cloud metric-name translation**: slash-containing OTel names,
+  `histogram_quantile` over `sum_over_time` of delta-histogram buckets,
+  aggregated-range ÷ scalar, and standalone `_sum` / `_count`-suffixed
+  gauges all resolve.
+- **Resource attributes as Prometheus labels** (env / namespace / pod /
+  cluster) with bounded query-time memory.
+- **Replicated schema**: emit explicit bare `ReplicatedMergeTree` under a
+  `Replicated` database; cold-cluster boot creates the database itself
+  instead of fatally exiting.
+- **Full ClickHouse connection configuration** surface exposed (TLS,
+  read timeout, pool limits).
+
+### Known limitations (honest at 1.0)
+
+- **TraceQL conformance is the lightest of the three heads.** There is no
+  third-party TraceQL conformance suite; its corpus is cerberus-owned
+  author-written TXTAR diffed against a real Tempo, so its breadth is
+  author-bounded rather than reference-derived. Raising TraceQL's
+  confidence is the top post-1.0 item. See
+  [`docs/compatibility.md`](docs/compatibility.md).
+- **Cerberus is a query gateway, not a store.** It runs no ingestion and
+  caches nothing (only the `/readyz` TTL); bring your own ClickHouse and
+  OTel pipeline.
+- **Per-head circuit-breaker recovery may briefly flap** as HALF-OPEN
+  probes re-converge after a ClickHouse restart ([#94]).
+
+## [v1.0.0-rc.1]
+
+The first published release candidate on the `v1.0.0` line — the core
+slice plus the advanced-QL surface. This was an early cut: the three
+heads parse → lower → execute and the differential harnesses gate every
+merge, but the surface was still evolving. The `rc.2` → `rc.9`
+prereleases that followed (replicated-schema bootstrap, resource-attribute
+labels, the perf collapses, and the GCP / metadata query-translation
+fixes) are summarised under [v1.0.0] above and listed individually on the
+[releases page](https://github.com/tsouza/cerberus/releases).
 
 ### Added
 
@@ -234,9 +323,10 @@ maintainer-accepted caveats specific to this candidate:
   Do not stand it in for a running Prometheus / Loki / Tempo deployment
   without first evaluating it against your own queries and data.
 
-## [v0.1.0] — Seed
+## v0.1.0 — Seed (pre-release history, not tagged)
 
-First tagged release. Closes the seed series (PR1–PR7 + admin + roadmap):
+The seed series (PR1–PR7 + admin + roadmap) that predates the published
+`v1.0.0-rc.*` tags:
 
 - Module `github.com/tsouza/cerberus` on `go 1.26.2` with the `replace github.com/hashicorp/memberlist => github.com/grafana/memberlist@…` hygiene fix.
 - Shared plan IR (`internal/chplan`), ClickHouse SQL emitter (`internal/chsql`), TXTAR spec runner under `test/spec/`.
@@ -247,5 +337,5 @@ First tagged release. Closes the seed series (PR1–PR7 + admin + roadmap):
 - CI: two-job workflow (`check` + `lint`), commitlint relaxed for Dependabot, markdownlint, mutation testing (gremlins) on a nightly cron.
 - Branch protection on `main`: required checks, linear history, no force pushes / deletions.
 
-[v1.0.0-RC1]: https://github.com/tsouza/cerberus/releases/tag/v1.0.0-RC1
-[v0.1.0]: https://github.com/tsouza/cerberus/releases/tag/v0.1.0
+[v1.0.0]: https://github.com/tsouza/cerberus/releases/tag/v1.0.0
+[v1.0.0-rc.1]: https://github.com/tsouza/cerberus/releases/tag/v1.0.0-rc.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,15 +119,6 @@ replace github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-
 
 Grafana's Loki, Tempo, and `dskit` all use a forked memberlist internally (via their own `replace` directives). Those replaces **do not propagate** to consumers. Without our own replace, the build fails with `undefined: memberlist.NodeState`, `mlCfg.NodeSelection`, `mlCfg.PushPullNodes` from `dskit/kv/memberlist`. If you bump Loki / Tempo and the build breaks here, check whether they've updated their pinned memberlist version and bump ours in lock-step.
 
-## GitHub identity
-
-Local SSH config has two GitHub identities:
-
-- `github.com` (default) → `tsouza-squid` (work). **Don't push cerberus work through this.**
-- `github.com-tsouza` → `tsouza` (personal). All cerberus commits + pushes go through this alias. Remote URL is `git@github.com-tsouza:tsouza/cerberus.git`.
-
-`gh` CLI may need `gh auth switch -u tsouza` if it lands on a different account. Project ops require the `project` scope on the `tsouza` token.
-
 ## Pointers if you're lost
 
 - "How does this PR ship?" → branch + push + `gh pr create` → CI must pass → squash-merge with `gh pr merge --squash --delete-branch`.

--- a/README.md
+++ b/README.md
@@ -3,18 +3,17 @@
 **Drop-in Prometheus / Loki / Tempo HTTP gateway for ClickHouse.**
 Keep Grafana, alerting, and your CLI tooling. Swap the backend.
 
-> [!WARNING]
-> **EXPERIMENTAL — NOT PRODUCTION-READY.** Cerberus is in the `v1.0.0-rc.*`
-> release-candidate stage, early and under active development (see the
-> [releases page](https://github.com/tsouza/cerberus/releases) for the
-> current tag). The differential harnesses run on every
-> PR and score parity against real Prometheus / Loki / Tempo, but correctness,
-> performance, and operational behaviour are still being shaken out, and the
-> surface is evolving. **Validate it against your
-> own corpus before pointing anything real at it** — do not stand it in for
-> a running Prom / Loki / Tempo deployment without that evaluation — and
-> expect breaking changes. See [`CHANGELOG.md`](CHANGELOG.md) for what has
-> landed so far.
+> [!NOTE]
+> **1.0.0 — stable wire API, young project.** The Prometheus / Loki /
+> Tempo HTTP surfaces cerberus serves are its 1.0 compatibility contract
+> and follow semantic versioning from here. Behaviour is held to reference
+> Prometheus / Loki / Tempo by differential harnesses on every merge
+> (PromQL at **574/574** on the CNCF compliance tester). It's a confident
+> 1.0 on behaviour — but a young, actively-developed project, so evaluate
+> it against your own corpus before production, and expect TraceQL to carry
+> the lightest conformance confidence of the three heads
+> ([details](#compatibility)). See [`CHANGELOG.md`](CHANGELOG.md) for what
+> has landed.
 
 [![CI](https://github.com/tsouza/cerberus/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/tsouza/cerberus/actions/workflows/ci.yml)
 [![Mutation](https://github.com/tsouza/cerberus/actions/workflows/mutation.yml/badge.svg?branch=main)](https://github.com/tsouza/cerberus/actions/workflows/mutation.yml)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported versions
 
-cerberus is pre-1.0; only the latest tagged release (or `main` if no tag exists) is supported. Once v1.0 ships, this section will document an N-1 support window.
+Security fixes land on the latest tagged release. As the 1.x line grows we'll widen this to an N-1 support window; until there's more than one minor release to support, "latest release (or `main`)" is the supported surface.
 
 ## Reporting a vulnerability
 


### PR DESCRIPTION
## What

Public-facing prep to cut **v1.0.0 GA**. Maintainer call: the project is good enough for GA. Docs-only; no code change.

- **README** — replace the `EXPERIMENTAL / NOT-PRODUCTION-READY` warning with a `[!NOTE]` stating the 1.0 wire-API compatibility contract + semver going forward. Keeps the honest "young, actively-developed, evaluate against your own corpus" line and the TraceQL-is-the-lightest-leg caveat. No rc version string, no "expect breaking changes". (Tone per maintainer: *stable 1.0, honestly young*.)
- **SECURITY** — drop the `pre-1.0` framing; supported surface is the latest tagged release, widening to N-1 as the 1.x line grows.
- **CHANGELOG** — add the `[v1.0.0]` GA entry (capabilities at 1.0, the wire-API stability statement, the notable changes across rc.2→rc.10, honest known-limitations). **Reconcile to the actually-published tags:** the old headings/links named `v1.0.0-RC1` and `v0.1.0` — *neither was ever tagged* (the real series is `v1.0.0-rc.1` … `rc.9`). Renamed the RC entry to `v1.0.0-rc.1` with a working release link; de-linked the never-tagged seed entry and labelled it pre-release history. (Closes the stale-link issue + the CHANGELOG-accuracy item.)
- **CLAUDE.md** — remove the "GitHub identity" section (personal `tsouza` / `tsouza-squid` SSH routing). Account-routing details don't belong in a checked-in public file; retained in local agent memory.

## Kept intentionally

The genuinely-experimental `CERBERUS_EXPERIMENTAL_TS_GRID_RANGE` feature flag and the upstream PromQL experimental-function gates keep their "experimental" wording — those are off-by-default feature toggles, not project maturity. A repo-wide inventory confirmed every other doc is already clean.

## Sequencing

Lands the docs that ship *with* the 1.0.0 tag. Merge after #958 (the rc.10 metadata window fix); once main is green, cut **v1.0.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)