### PR TITLE
test(perf): de-flake setop_chain wall gate — calibrate slack to its O(K) shape

### DIFF
--- a/test/perf/scaling/construct_setop_chain_test.go
+++ b/test/perf/scaling/construct_setop_chain_test.go
@@ -77,11 +77,22 @@ func init() {
 		// scan keeps the intermediate well within a small multiple while an
 		// exponential re-materialisation regression blows straight past.
 		CardinalityBound: float64(maxK + 2),
-		SubLinearSlack:   0.9,
-		// Post-#90 the chain flattens into ONE NaryVectorSetOp single-pass
-		// (one UNION ALL over all K arms + one window partition), so both the
-		// intermediate (3->9 rows, disjoint arms) AND the wall are (sub-)linear
-		// in K. No quarantine — both axes hard-gate. See the package doc above.
+		// Post-#90 the chain flattens into ONE NaryVectorSetOp single-pass (one
+		// UNION ALL over all K arms + one window partition). The intermediate
+		// CARDINALITY is flat (3->9 rows, disjoint arms — the hard
+		// CardinalityBound axis), but the single pass still SCANS all K+1 arms,
+		// so the wall is inherently ~LINEAR in K (≈paramGrowth, measured ~0.97x
+		// of K across 2->8), NOT sub-linear. The wall axis here is the backstop
+		// for an EXECUTION re-regression — a #88-class CTE re-execution
+		// (exponential) or a #814-class per-level window re-pass (~1.7x/param) —
+		// which all land well above linear. So the gate must clear healthy
+		// linear + runner jitter (~1.15x param) yet stay below the cheapest
+		// regression (~1.7x param): slack 1.3 -> gate ≈1.36x param, comfortably
+		// between. Tighter (the old 0.9, demanding sub-linear for an O(K) scan)
+		// sat ON the healthy floor and flaked on runner noise. The cardinality
+		// axis stays the primary hard anti-fan-out invariant; this only
+		// calibrates the secondary wall heuristic to the construct's real shape.
+		SubLinearSlack: 1.3,
 		Seed: func() string {
 			return setOpChainSeed(maxK)
 		},


### PR DESCRIPTION
## What

The `chdb`/`perf-guards` lane flaked on push-to-main ([run 27687818602](https://github.com/tsouza/cerberus/actions/runs/27687818602)): `TestScaling_ChDB/setop_chain` wall grew **3.87× vs a 3.85× gate** — a 0.02× overshoot on a loaded runner — while the deterministic cardinality axis passed clean (peak intermediate 3→5→9, perfectly linear). Re-run went green, confirming a flake, not a regression.

## Root cause — gate mis-calibration, not the code

Post-#90 the `or` chain flattens into one `NaryVectorSetOp` single-pass, but that pass still **scans all K+1 arms**, so healthy wall is inherently **~linear in K** (~0.97× of param; locally 2.56–2.99×, on a loaded CI runner 3.87×) — *not* sub-linear. The old `SubLinearSlack=0.9` demanded sub-linear (gate 3.85× ≈ 0.9× param), sitting right **on** the healthy floor → noise-triggered failures.

## Fix

`SubLinearSlack` 0.9 → 1.3 (gate ≈ **5.45×**, 1.36× param). Clears healthy linear + runner jitter, yet stays **below** the cheapest real regression the wall axis exists to catch — a #814-class per-level window re-pass (~1.7× param ≈ 6.8×) or a #88-class CTE re-execution (exponential). The **cardinality axis is unchanged** and remains the primary hard anti-fan-out invariant; this only tunes the secondary wall heuristic to the construct's real shape, so regression coverage is intact. Verified locally 5× (wall 2.56–2.99×, all pass with wide margin).

## The other failure on that merge commit

The same push also flaked `ci`/`check` → `TestHTTPServer_Shutdown_BlocksNewConnections` ("Accept did not return after Shutdown"). That one is **not a logic bug**: 200× local `-race` runs are clean, the test logic is correct (Shutdown synchronously closes the listener before the wait), and it passed on re-run — a rare CI-runner-saturation artifact, unrelated to any code change. Tracked separately; not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)