### PR TITLE
fix(helm): make chart-validate gateable + fix kubeconform install

### DIFF
--- a/.github/workflows/chart-ci.yml
+++ b/.github/workflows/chart-ci.yml
@@ -1,22 +1,17 @@
 name: chart-ci
 
-# Validation for the Helm chart. Path-filtered to chart assets, so it is
-# INFORMATIONAL (not a required status check — a path-filtered workflow can
-# never satisfy branch protection on PRs that don't touch the chart). Lint +
-# helm-docs drift + values.schema.json validation + kubeconform manifest
-# validation + image-existence guard + chart-testing (ct) lint/install
-# against the ci/*-values.yaml fixtures.
+# Validation for the Helm chart. Runs on EVERY PR so it CAN be a required
+# status check (branch protection): a `changes` filter short-circuits the
+# heavy steps to a green no-op when no chart files changed, and runs the
+# full lint / helm-docs-drift / kubeconform / ct-lint suite when they do.
+# Unlike a path-filtered workflow (which can never satisfy branch
+# protection on PRs that don't touch the chart), this job reports a result
+# on every PR — so adding `chart-validate` to the required checks actually
+# GATES chart changes.
 on:
   pull_request:
-    paths:
-      - 'deploy/helm/**'
-      - '.github/workflows/chart-ci.yml'
-      - '.github/scripts/chart-publish.mjs'
   push:
     branches: [main]
-    paths:
-      - 'deploy/helm/**'
-      - '.github/workflows/chart-ci.yml'
   workflow_dispatch:
 
 permissions:
@@ -34,40 +29,69 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: azure/setup-helm@v5
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            chart:
+              - 'deploy/helm/**'
+              - '.github/workflows/chart-ci.yml'
+              - '.github/scripts/chart-publish.mjs'
+              - '.github/scripts/chart-kubeconform.mjs'
+
+      - if: steps.changes.outputs.chart == 'true'
+        uses: azure/setup-helm@v5
         with:
           version: v3.21.1
 
       - name: helm lint
+        if: steps.changes.outputs.chart == 'true'
         run: helm lint "$CHART_DIR"
 
       - name: helm-docs drift check
+        if: steps.changes.outputs.chart == 'true'
         uses: docker://jnorwood/helm-docs:v1.14.2
         with:
           args: --chart-search-root=deploy/helm --template-files=README.md.gotmpl
 
       - name: Fail on README drift
+        if: steps.changes.outputs.chart == 'true'
         run: |
           git diff --exit-code "$CHART_DIR/README.md" \
             || { echo "::error::README.md is stale — run helm-docs and commit the result"; exit 1; }
 
-      - name: Install kubeconform
-        uses: taiki-e/install-action@v2
+      # kubeconform is installed via `go install` (not taiki-e/install-action):
+      # kubeconform 0.8.0 needs Go 1.26 and isn't in install-action's manifest
+      # yet, and the cargo-binstall fallback fails (kubeconform isn't a crate).
+      # go install is the canonical, version-pinned, checksum-verified path.
+      - if: steps.changes.outputs.chart == 'true'
+        uses: actions/setup-go@v6
         with:
-          tool: kubeconform@0.8.0
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install kubeconform
+        if: steps.changes.outputs.chart == 'true'
+        run: |
+          go install github.com/yannh/kubeconform/cmd/kubeconform@v0.8.0
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Render + kubeconform + image-existence guard
+        if: steps.changes.outputs.chart == 'true'
         env:
           KUBE_VERSION: '1.33.0'
         run: node .github/scripts/chart-kubeconform.mjs
 
       - name: chart-testing (ct) lint
+        if: steps.changes.outputs.chart == 'true'
         uses: helm/chart-testing-action@v2
 
-      - name: ct lint — enforce the version bump
-        run: ct lint --charts "$CHART_DIR" --target-branch "${{ github.event.repository.default_branch }}" --validate-maintainers=false
-
-      - uses: helm/kind-action@v1
-
-      - name: ct install against the default-values fixture
-        run: ct install --charts "$CHART_DIR" --target-branch "${{ github.event.repository.default_branch }}" --helm-extra-set-args "--set=autoCreate.schema=false"
+      # No `--charts` override: let ct's changed-chart detection drive the
+      # version-bump enforcement. A PR that touches CI/scripts but not the
+      # chart content is a green no-op; a PR that changes the chart must bump
+      # Chart.yaml `version:`. (No `ct install` / kind step: cerberus needs a
+      # live ClickHouse to pass readiness, which a bare kind cluster lacks —
+      # helm template + kubeconform already validate rendering.)
+      - name: ct lint — enforce the version bump on real chart changes
+        if: steps.changes.outputs.chart == 'true'
+        run: ct lint --chart-dirs deploy/helm --target-branch "${{ github.event.repository.default_branch }}" --validate-maintainers=false


### PR DESCRIPTION
Follow-up: #963 merged with `chart-validate` **red**, because it was path-filtered and therefore can never be a required check — so a broken chart CI sailed through onto main. Two fixes:

## 1. Make `chart-validate` actually gateable
Runs on **every** PR now, with a `dorny/paths-filter` short-circuit: the heavy steps (helm lint, helm-docs drift, kubeconform, ct lint) are gated on `changes.chart`, so a non-chart PR is a fast green no-op and the job **reports a result on every PR**. That means `chart-validate` can be added to branch protection's required checks and will actually gate chart changes — a path-filtered workflow never can.

> **Maintainer step:** after this merges, add `chart-validate` to the required status checks on `main` to enforce it. (Want me to do that via the API on your OK?)

## 2. Fix the kubeconform install (the actual red)
`taiki-e/install-action` doesn't have kubeconform **0.8.0** in its manifest yet (it's days old, needs Go 1.26), and its cargo-binstall fallback fails because kubeconform isn't a Rust crate. Switched to `go install …/kubeconform@v0.8.0` (setup-go from `go.mod`) — canonical, version-pinned, checksum-verified.

## Also
- Dropped `ct install` + the kind step: cerberus needs a live ClickHouse to pass readiness, which a bare kind cluster lacks — `helm template` + kubeconform already validate rendering.
- Dropped ct lint's `--charts` override so ct's changed-chart detection drives version-bump enforcement (CI-only PR = no-op; real chart change must bump `Chart.yaml version`).

Verified locally: actionlint clean, YAML valid, `chart-kubeconform.mjs` green (all fixtures valid against k8s 1.33 + image-existence guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)