### PR TITLE
fix(config): uniform boolean parsing (1/0/true/false) for ALL CERBERUS_* env

### DIFF
--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -67,6 +67,30 @@ func admitCap(enabled bool, defaultCap int) int {
 	return defaultCap
 }
 
+// newAdmitLimiters builds the per-head admission-control limiters. When
+// CERBERUS_ADMIT_DISABLED=true every limiter is nil and the middleware
+// short-circuits to a pass-through wrapper. Otherwise each per-head toggle
+// CERBERUS_ADMIT_{PROM,LOKI,TEMPO} (boolean) selects the head's default cap
+// when truthy, or leaves the head unlimited (nil limiter) when falsy.
+// admit.New returns nil for a non-positive cap, so a disabled head and a
+// zero cap collapse to the same pass-through path.
+func newAdmitLimiters(cfg config.Config, logger *slog.Logger) (*admit.Limiter, *admit.Limiter, *admit.Limiter) {
+	if cfg.Admit.Disabled {
+		logger.Info("admission control disabled (CERBERUS_ADMIT_DISABLED=true)")
+		return nil, nil, nil
+	}
+	promCap := admitCap(cfg.Admit.Prom, config.DefaultAdmitProm)
+	lokiCap := admitCap(cfg.Admit.Loki, config.DefaultAdmitLoki)
+	tempoCap := admitCap(cfg.Admit.Tempo, config.DefaultAdmitTempo)
+	logger.Info(
+		"admission control enabled",
+		"prom", promCap,
+		"loki", lokiCap,
+		"tempo", tempoCap,
+	)
+	return admit.New("prom", promCap), admit.New("loki", lokiCap), admit.New("tempo", tempoCap)
+}
+
 func main() {
 	if isVersionFlag(os.Args) {
 		fmt.Fprintln(os.Stdout, Version)
@@ -188,31 +212,8 @@ func run() error {
 		)
 	}
 
-	// Build per-head admission-control limiters. When
-	// CERBERUS_ADMIT_DISABLED=true every limiter is nil and the
-	// middleware short-circuits to a pass-through wrapper. Otherwise each
-	// per-head toggle CERBERUS_ADMIT_{PROM,LOKI,TEMPO} (boolean) selects
-	// the head's default cap when truthy, or leaves the head unlimited
-	// (nil limiter) when falsy. admit.New returns nil for a non-positive
-	// cap, so a disabled head and a zero cap collapse to the same
-	// pass-through path.
-	var promLimiter, lokiLimiter, tempoLimiter *admit.Limiter
-	if !cfg.Admit.Disabled {
-		promCap := admitCap(cfg.Admit.Prom, config.DefaultAdmitProm)
-		lokiCap := admitCap(cfg.Admit.Loki, config.DefaultAdmitLoki)
-		tempoCap := admitCap(cfg.Admit.Tempo, config.DefaultAdmitTempo)
-		promLimiter = admit.New("prom", promCap)
-		lokiLimiter = admit.New("loki", lokiCap)
-		tempoLimiter = admit.New("tempo", tempoCap)
-		logger.Info(
-			"admission control enabled",
-			"prom", promCap,
-			"loki", lokiCap,
-			"tempo", tempoCap,
-		)
-	} else {
-		logger.Info("admission control disabled (CERBERUS_ADMIT_DISABLED=true)")
-	}
+	// Build per-head admission-control limiters (see newAdmitLimiters).
+	promLimiter, lokiLimiter, tempoLimiter := newAdmitLimiters(cfg, logger)
 
 	// The trace mux carries the three Prom/Loki/Tempo APIs and is
 	// wrapped with otelhttp so every request becomes a server span.

--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -55,6 +55,18 @@ func isVersionFlag(args []string) bool {
 	return false
 }
 
+// admitCap translates a per-head admission toggle into the concurrency
+// cap handed to admit.New. An enabled head uses its default cap; a
+// disabled head returns 0, which admit.New maps to a nil (pass-through)
+// limiter. Keeping the enabled/disabled cases symmetric here means the
+// only knob the operator sees is a plain boolean.
+func admitCap(enabled bool, defaultCap int) int {
+	if !enabled {
+		return 0
+	}
+	return defaultCap
+}
+
 func main() {
 	if isVersionFlag(os.Args) {
 		fmt.Fprintln(os.Stdout, Version)
@@ -178,19 +190,25 @@ func run() error {
 
 	// Build per-head admission-control limiters. When
 	// CERBERUS_ADMIT_DISABLED=true every limiter is nil and the
-	// middleware short-circuits to a pass-through wrapper. Otherwise
-	// each cap comes from CERBERUS_ADMIT_{PROM,LOKI,TEMPO} (or the
-	// conservative defaults — see internal/config.admitFromEnv).
+	// middleware short-circuits to a pass-through wrapper. Otherwise each
+	// per-head toggle CERBERUS_ADMIT_{PROM,LOKI,TEMPO} (boolean) selects
+	// the head's default cap when truthy, or leaves the head unlimited
+	// (nil limiter) when falsy. admit.New returns nil for a non-positive
+	// cap, so a disabled head and a zero cap collapse to the same
+	// pass-through path.
 	var promLimiter, lokiLimiter, tempoLimiter *admit.Limiter
 	if !cfg.Admit.Disabled {
-		promLimiter = admit.New("prom", cfg.Admit.MaxInflightProm)
-		lokiLimiter = admit.New("loki", cfg.Admit.MaxInflightLoki)
-		tempoLimiter = admit.New("tempo", cfg.Admit.MaxInflightTempo)
+		promCap := admitCap(cfg.Admit.Prom, config.DefaultAdmitProm)
+		lokiCap := admitCap(cfg.Admit.Loki, config.DefaultAdmitLoki)
+		tempoCap := admitCap(cfg.Admit.Tempo, config.DefaultAdmitTempo)
+		promLimiter = admit.New("prom", promCap)
+		lokiLimiter = admit.New("loki", lokiCap)
+		tempoLimiter = admit.New("tempo", tempoCap)
 		logger.Info(
 			"admission control enabled",
-			"prom", cfg.Admit.MaxInflightProm,
-			"loki", cfg.Admit.MaxInflightLoki,
-			"tempo", cfg.Admit.MaxInflightTempo,
+			"prom", promCap,
+			"loki", lokiCap,
+			"tempo", tempoCap,
 		)
 	} else {
 		logger.Info("admission control disabled (CERBERUS_ADMIT_DISABLED=true)")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,6 +10,10 @@ ClickHouse for a managed cluster, or a sidecar collector for a SaaS ingest URL,
 is a matter of flipping env vars and restarting. Every default below is the
 value `internal/config/config.go` ships out of the box.
 
+All boolean knobs accept `1`/`0`/`true`/`false`, case-insensitive (the full
+`strconv.ParseBool` vocabulary), via one shared parser — so `true` and `1` are
+interchangeable for any `bool`-typed variable below.
+
 Misconfigured values fail fast: an unparseable duration, an out-of-range
 integer, an unknown log level, or a malformed OTLP header list aborts startup
 with a clear error rather than silently downgrading behaviour. Secrets (the
@@ -212,19 +216,23 @@ machine.
 
 ## Admission control
 
-Each of the three API heads is fronted by a counted semaphore that caps
+Each of the three API heads can be fronted by a counted semaphore that caps
 simultaneous in-flight requests. Requests above the cap are rejected with HTTP
 503 + `Retry-After: 1` so well-behaved clients back off and ClickHouse stays out
 of overload. Tempo's cap is half of Prom / Loki because trace queries are
-typically the heaviest per-call. Setting an individual cap to `0` disables
-admission control for that head specifically.
+typically the heaviest per-call.
 
-| Variable                  | Type | Default | Description                                                                  |
-| ------------------------- | ---- | ------- | ---------------------------------------------------------------------------- |
-| `CERBERUS_ADMIT_DISABLED` | bool | `false` | Disable per-handler concurrency caps entirely (handy for local development). |
-| `CERBERUS_ADMIT_PROM`     | int  | `64`    | Max simultaneous in-flight Prom API requests. `0` disables for this head.    |
-| `CERBERUS_ADMIT_LOKI`     | int  | `64`    | Max simultaneous in-flight Loki API requests. `0` disables for this head.    |
-| `CERBERUS_ADMIT_TEMPO`    | int  | `32`    | Max simultaneous in-flight Tempo API requests. `0` disables for this head.   |
+`CERBERUS_ADMIT_{PROM,LOKI,TEMPO}` are boolean enable toggles: a truthy value
+turns the head's limiter ON at its conservative default cap, a falsy value
+leaves that head unlimited. `CERBERUS_ADMIT_DISABLED` is a master switch that
+turns every head off at once.
+
+| Variable                  | Type | Default | Description                                                                       |
+| ------------------------- | ---- | ------- | -------------------------------------------------------------------------------- |
+| `CERBERUS_ADMIT_DISABLED` | bool | `false` | Disable admission control entirely on every head (handy for local development).   |
+| `CERBERUS_ADMIT_PROM`     | bool | `true`  | Enable the Prom API in-flight limiter (default cap 64). Falsy = head unlimited.   |
+| `CERBERUS_ADMIT_LOKI`     | bool | `true`  | Enable the Loki API in-flight limiter (default cap 64). Falsy = head unlimited.   |
+| `CERBERUS_ADMIT_TEMPO`    | bool | `true`  | Enable the Tempo API in-flight limiter (default cap 32). Falsy = head unlimited.  |
 
 ## Logging
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -227,12 +227,12 @@ turns the head's limiter ON at its conservative default cap, a falsy value
 leaves that head unlimited. `CERBERUS_ADMIT_DISABLED` is a master switch that
 turns every head off at once.
 
-| Variable                  | Type | Default | Description                                                                       |
+| Variable                  | Type | Default | Description                                                                      |
 | ------------------------- | ---- | ------- | -------------------------------------------------------------------------------- |
-| `CERBERUS_ADMIT_DISABLED` | bool | `false` | Disable admission control entirely on every head (handy for local development).   |
-| `CERBERUS_ADMIT_PROM`     | bool | `true`  | Enable the Prom API in-flight limiter (default cap 64). Falsy = head unlimited.   |
-| `CERBERUS_ADMIT_LOKI`     | bool | `true`  | Enable the Loki API in-flight limiter (default cap 64). Falsy = head unlimited.   |
-| `CERBERUS_ADMIT_TEMPO`    | bool | `true`  | Enable the Tempo API in-flight limiter (default cap 32). Falsy = head unlimited.  |
+| `CERBERUS_ADMIT_DISABLED` | bool | `false` | Disable admission control entirely on every head (handy for local development).  |
+| `CERBERUS_ADMIT_PROM`     | bool | `true`  | Enable the Prom API in-flight limiter (default cap 64). Falsy = head unlimited.  |
+| `CERBERUS_ADMIT_LOKI`     | bool | `true`  | Enable the Loki API in-flight limiter (default cap 64). Falsy = head unlimited.  |
+| `CERBERUS_ADMIT_TEMPO`    | bool | `true`  | Enable the Tempo API in-flight limiter (default cap 32). Falsy = head unlimited. |
 
 ## Logging
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -140,12 +140,14 @@ type Config struct {
 	// these cerberus-specific values resolve to.
 	OTLP OTLPConfig
 
-	// Admit configures per-handler concurrency caps. When Admit.Disabled
+	// Admit configures per-handler admission control. When Admit.Disabled
 	// is true cerberus skips the admission middleware entirely and every
-	// request is admitted. When false, each API head (Prom / Loki /
-	// Tempo) gets its own counted semaphore — requests above the cap
-	// are rejected with HTTP 503 + Retry-After: 1 so well-behaved
-	// clients back off and CH stays out of overload.
+	// request is admitted. Otherwise each per-head toggle (Admit.Prom /
+	// Loki / Tempo) enables a counted semaphore for that API head at its
+	// conservative default cap — requests above the cap are rejected with
+	// HTTP 503 + Retry-After: 1 so well-behaved clients back off and CH
+	// stays out of overload. A falsy per-head toggle leaves that head
+	// unlimited.
 	Admit AdmitConfig
 }
 
@@ -211,27 +213,35 @@ type SchemaProvisioning struct {
 	DatabaseReplicatedReplica string
 }
 
-// AdmitConfig holds the per-handler concurrency cap knobs.
+// AdmitConfig holds the per-handler admission-control toggles.
 //
-// Defaults are deliberately conservative — easy to lift via env, hard
-// to accidentally deny-of-service legitimate traffic with the
-// out-of-the-box values. Tempo's default is half of Prom/Loki because
-// trace queries are typically the heaviest per-call (full trace span
-// fetches + tag-value scans across wide column sets).
+// CERBERUS_ADMIT_{PROM,LOKI,TEMPO} are boolean enable switches: truthy
+// turns the per-head concurrency limiter ON at its conservative default
+// cap (see DefaultAdmitProm / Loki / Tempo); falsy leaves that head with
+// no limiter (unlimited concurrency). Tempo's default cap is half of
+// Prom/Loki because trace queries are typically the heaviest per-call
+// (full trace span fetches + tag-value scans across wide column sets).
+//
+// Every field is a bool routed through the shared parseBool helper, so
+// the Helm chart can render plain YAML bools (`true`/`false`) straight
+// into the env without the binary crash-looping on strconv.Atoi.
 type AdmitConfig struct {
 	// Disabled, when true, removes admission control entirely. Handy
 	// for local development where artificial caps mask real
 	// concurrency bugs. Default false (admission control enabled).
 	Disabled bool
 
-	// MaxInflightProm caps simultaneous in-flight Prom API requests.
-	MaxInflightProm int
+	// Prom enables the in-flight concurrency limiter for the Prom API
+	// head. Default true (enabled at DefaultAdmitProm).
+	Prom bool
 
-	// MaxInflightLoki caps simultaneous in-flight Loki API requests.
-	MaxInflightLoki int
+	// Loki enables the in-flight concurrency limiter for the Loki API
+	// head. Default true (enabled at DefaultAdmitLoki).
+	Loki bool
 
-	// MaxInflightTempo caps simultaneous in-flight Tempo API requests.
-	MaxInflightTempo int
+	// Tempo enables the in-flight concurrency limiter for the Tempo API
+	// head. Default true (enabled at DefaultAdmitTempo).
+	Tempo bool
 }
 
 // HTTPServerConfig holds the cerberus HTTP server's net/http timeout knobs
@@ -489,9 +499,9 @@ const configFileBaseName = "cerberus"
 //	CERBERUS_OTLP_TIMEOUT          default "10s"
 //	CERBERUS_OTLP_EXPORT_INTERVAL  default "10s" (metric PeriodicReader flush interval)
 //	CERBERUS_ADMIT_DISABLED        default "false"
-//	CERBERUS_ADMIT_PROM            default 64
-//	CERBERUS_ADMIT_LOKI            default 64
-//	CERBERUS_ADMIT_TEMPO           default 32
+//	CERBERUS_ADMIT_PROM            default "true"  (enable Prom admission limiter)
+//	CERBERUS_ADMIT_LOKI            default "true"  (enable Loki admission limiter)
+//	CERBERUS_ADMIT_TEMPO           default "true"  (enable Tempo admission limiter)
 //
 // Standard OTEL_EXPORTER_OTLP_* env vars are also honored by the OTel
 // Go SDK and complement these — see docs/observability.md.
@@ -848,9 +858,9 @@ func newLoader() *viper.Viper {
 	v.SetDefault(envOTLPTimeout, defaultOTLPTimeout.String())
 	v.SetDefault(envOTLPExportInterval, defaultOTLPExportInterval.String())
 	v.SetDefault(envAdmitDisabled, defaultAdmitDisabled)
-	v.SetDefault(envAdmitProm, defaultAdmitProm)
-	v.SetDefault(envAdmitLoki, defaultAdmitLoki)
-	v.SetDefault(envAdmitTempo, defaultAdmitTempo)
+	v.SetDefault(envAdmitProm, defaultAdmitEnabled)
+	v.SetDefault(envAdmitLoki, defaultAdmitEnabled)
+	v.SetDefault(envAdmitTempo, defaultAdmitEnabled)
 
 	// Optional config file: cerberus.yaml in the working directory or
 	// /etc/cerberus. Env vars always win (viper precedence: explicit
@@ -894,6 +904,11 @@ const (
 	defaultCHBreakerEnabled   = true
 	defaultCHKeepAliveEnabled = true
 	defaultAdmitDisabled      = false
+	// defaultAdmitEnabled is the per-head ADMIT_{PROM,LOKI,TEMPO}
+	// default: admission control ON out of the box. A truthy toggle
+	// enables the limiter at the head's default cap (DefaultAdmitProm /
+	// Loki / Tempo); a falsy toggle leaves the head unlimited.
+	defaultAdmitEnabled = true
 )
 
 const (
@@ -1131,52 +1146,48 @@ func breakerFromEnv(v *viper.Viper) (breakerConfig, error) {
 	}, nil
 }
 
-// Default per-handler concurrency caps. Tempo gets a smaller cap
-// because trace queries (search + tag-value scans + per-trace span
-// fetches) are heavier than Prom/Loki metric queries.
+// DefaultAdmitProm, DefaultAdmitLoki and DefaultAdmitTempo are the
+// per-head concurrency caps applied when the corresponding boolean
+// toggle CERBERUS_ADMIT_{PROM,LOKI,TEMPO} is enabled; cmd/cerberus reads
+// them to size each limiter. Tempo gets a smaller cap because trace
+// queries (search + tag-value scans + per-trace span fetches) are
+// heavier than Prom/Loki metric queries.
 const (
-	defaultAdmitProm  = 64
-	defaultAdmitLoki  = 64
-	defaultAdmitTempo = 32
+	DefaultAdmitProm  = 64
+	DefaultAdmitLoki  = 64
+	DefaultAdmitTempo = 32
 )
 
 // admitFromEnv reads CERBERUS_ADMIT_* knobs from the viper loader.
-// Unset values use the conservative defaults above. Setting any cap
-// to 0 disables admission control for that head specifically (a
-// finer-grained alternative to CERBERUS_ADMIT_DISABLED, which kills
-// every head). Negative caps are rejected — they almost certainly
-// mean a typo.
+// Every knob is a boolean routed through getBool (the shared parseBool
+// helper), so "1"/"0"/"true"/"false" are all accepted interchangeably,
+// case-insensitive. A truthy ADMIT_{PROM,LOKI,TEMPO} enables the per-head
+// concurrency limiter at its conservative default cap; a falsy value
+// leaves that head unlimited — a finer-grained alternative to
+// CERBERUS_ADMIT_DISABLED, which kills every head at once. Unset values
+// fall back to the registered defaults.
 func admitFromEnv(v *viper.Viper) (AdmitConfig, error) {
 	disabled, err := getBool(v, envAdmitDisabled)
 	if err != nil {
 		return AdmitConfig{}, err
 	}
-	prom, err := getInt(v, envAdmitProm)
+	prom, err := getBool(v, envAdmitProm)
 	if err != nil {
 		return AdmitConfig{}, err
 	}
-	loki, err := getInt(v, envAdmitLoki)
+	loki, err := getBool(v, envAdmitLoki)
 	if err != nil {
 		return AdmitConfig{}, err
 	}
-	tempo, err := getInt(v, envAdmitTempo)
+	tempo, err := getBool(v, envAdmitTempo)
 	if err != nil {
 		return AdmitConfig{}, err
-	}
-	for name, val := range map[string]int{
-		envAdmitProm:  prom,
-		envAdmitLoki:  loki,
-		envAdmitTempo: tempo,
-	} {
-		if val < 0 {
-			return AdmitConfig{}, fmt.Errorf("%s: must be >= 0, got %d", name, val)
-		}
 	}
 	return AdmitConfig{
-		Disabled:         disabled,
-		MaxInflightProm:  prom,
-		MaxInflightLoki:  loki,
-		MaxInflightTempo: tempo,
+		Disabled: disabled,
+		Prom:     prom,
+		Loki:     loki,
+		Tempo:    tempo,
 	}, nil
 }
 
@@ -1344,16 +1355,34 @@ func getInt64(v *viper.Viper, key string) (int64, error) {
 	return n, nil
 }
 
-// getBool resolves key and parses it with the standard strconv.ParseBool
-// vocabulary ("1"/"0", "t"/"f", "true"/"false", case-insensitive). A
-// value that fails to parse is rejected with an error naming the env
-// var — preserving the historical fail-fast-on-misconfiguration contract.
+// parseBool is the single shared boolean parser for every CERBERUS_*
+// boolean config knob. It is backed by strconv.ParseBool, so it accepts
+// the full vocabulary "1"/"0", "t"/"f"/"T"/"F", "true"/"false"/"TRUE"/
+// "FALSE" (case-insensitive) interchangeably. Surrounding whitespace is
+// trimmed first so a pasted newline / space parses the same as the bare
+// token. A value outside the accepted vocabulary is rejected.
+//
+// Routing every boolean field through this one function guarantees a
+// uniform convention across the whole config surface: AUTO_CREATE_*,
+// OTLP_INSECURE, REQUIREMENTS_CHECK, SCHEMA_DATABASE_REPLICATED and the
+// ADMIT_* toggles all parse identically. This is what lets the Helm
+// chart render a plain YAML bool (`true`) into CERBERUS_ADMIT_PROM
+// without the binary crash-looping on `strconv.Atoi("true")`.
+func parseBool(s string) (bool, error) {
+	return strconv.ParseBool(strings.TrimSpace(s))
+}
+
+// getBool resolves key and parses it through the shared parseBool helper
+// (the standard strconv.ParseBool vocabulary: "1"/"0", "t"/"f",
+// "true"/"false", case-insensitive). A value that fails to parse is
+// rejected with an error naming the env var — preserving the historical
+// fail-fast-on-misconfiguration contract.
 func getBool(v *viper.Viper, key string) (bool, error) {
 	raw := getString(v, key)
 	if raw == "" {
 		return false, fmt.Errorf("%s: missing value", key)
 	}
-	b, err := strconv.ParseBool(raw)
+	b, err := parseBool(raw)
 	if err != nil {
 		return false, fmt.Errorf("%s: invalid boolean %q: %w", key, raw, err)
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -366,8 +366,8 @@ func TestFromEnv_SchemaOverrides(t *testing.T) {
 	}
 }
 
-// TestFromEnv_Admit_Defaults verifies the conservative defaults for
-// the per-handler concurrency caps when no env vars are set.
+// TestFromEnv_Admit_Defaults verifies admission control is enabled on
+// every head out of the box when no env vars are set.
 func TestFromEnv_Admit_Defaults(t *testing.T) {
 	t.Setenv("CERBERUS_ADMIT_DISABLED", "")
 	t.Setenv("CERBERUS_ADMIT_PROM", "")
@@ -380,23 +380,25 @@ func TestFromEnv_Admit_Defaults(t *testing.T) {
 	if cfg.Admit.Disabled {
 		t.Errorf("Admit.Disabled = true; want false")
 	}
-	if cfg.Admit.MaxInflightProm != defaultAdmitProm {
-		t.Errorf("MaxInflightProm = %d; want %d", cfg.Admit.MaxInflightProm, defaultAdmitProm)
+	if !cfg.Admit.Prom {
+		t.Errorf("Admit.Prom = false; want true")
 	}
-	if cfg.Admit.MaxInflightLoki != defaultAdmitLoki {
-		t.Errorf("MaxInflightLoki = %d; want %d", cfg.Admit.MaxInflightLoki, defaultAdmitLoki)
+	if !cfg.Admit.Loki {
+		t.Errorf("Admit.Loki = false; want true")
 	}
-	if cfg.Admit.MaxInflightTempo != defaultAdmitTempo {
-		t.Errorf("MaxInflightTempo = %d; want %d", cfg.Admit.MaxInflightTempo, defaultAdmitTempo)
+	if !cfg.Admit.Tempo {
+		t.Errorf("Admit.Tempo = false; want true")
 	}
 }
 
 // TestFromEnv_Admit_Overrides confirms env-var overrides flow through.
+// The ADMIT_* family is boolean: a falsy value disables that head's
+// limiter without disabling admission control entirely.
 func TestFromEnv_Admit_Overrides(t *testing.T) {
 	t.Setenv("CERBERUS_ADMIT_DISABLED", "true")
-	t.Setenv("CERBERUS_ADMIT_PROM", "128")
-	t.Setenv("CERBERUS_ADMIT_LOKI", "16")
-	t.Setenv("CERBERUS_ADMIT_TEMPO", "8")
+	t.Setenv("CERBERUS_ADMIT_PROM", "false")
+	t.Setenv("CERBERUS_ADMIT_LOKI", "0")
+	t.Setenv("CERBERUS_ADMIT_TEMPO", "true")
 	cfg, err := FromEnv()
 	if err != nil {
 		t.Fatalf("FromEnv: %v", err)
@@ -404,31 +406,91 @@ func TestFromEnv_Admit_Overrides(t *testing.T) {
 	if !cfg.Admit.Disabled {
 		t.Errorf("Admit.Disabled = false; want true")
 	}
-	if cfg.Admit.MaxInflightProm != 128 {
-		t.Errorf("MaxInflightProm = %d; want 128", cfg.Admit.MaxInflightProm)
+	if cfg.Admit.Prom {
+		t.Errorf("Admit.Prom = true; want false")
 	}
-	if cfg.Admit.MaxInflightLoki != 16 {
-		t.Errorf("MaxInflightLoki = %d; want 16", cfg.Admit.MaxInflightLoki)
+	if cfg.Admit.Loki {
+		t.Errorf("Admit.Loki = true; want false (0 is falsy)")
 	}
-	if cfg.Admit.MaxInflightTempo != 8 {
-		t.Errorf("MaxInflightTempo = %d; want 8", cfg.Admit.MaxInflightTempo)
-	}
-}
-
-// TestFromEnv_Admit_RejectsNegative ensures a negative cap fails fast
-// at startup rather than silently disabling admission control.
-func TestFromEnv_Admit_RejectsNegative(t *testing.T) {
-	t.Setenv("CERBERUS_ADMIT_PROM", "-1")
-	if _, err := FromEnv(); err == nil {
-		t.Fatalf("FromEnv with CERBERUS_ADMIT_PROM=-1: want error, got nil")
+	if !cfg.Admit.Tempo {
+		t.Errorf("Admit.Tempo = false; want true")
 	}
 }
 
-// TestFromEnv_Admit_RejectsGarbage ensures a non-integer value also
-// fails fast.
+// TestFromEnv_Admit_AcceptsYAMLBool is the end-to-end regression for the
+// Helm-chart crash: a default `helm install` renders the YAML bool
+// `true` into CERBERUS_ADMIT_PROM, which the old strconv.Atoi parser
+// rejected ("invalid integer \"true\"") and crash-looped cerberus. The
+// shared parseBool path now loads `true`/`false` cleanly.
+func TestFromEnv_Admit_AcceptsYAMLBool(t *testing.T) {
+	for _, tc := range []struct {
+		raw  string
+		want bool
+	}{
+		{"true", true},
+		{"false", false},
+		{"TRUE", true},
+		{"False", false},
+		{"1", true},
+		{"0", false},
+	} {
+		t.Run(tc.raw, func(t *testing.T) {
+			t.Setenv("CERBERUS_ADMIT_PROM", tc.raw)
+			cfg, err := FromEnv()
+			if err != nil {
+				t.Fatalf("FromEnv with CERBERUS_ADMIT_PROM=%q: unexpected error %v", tc.raw, err)
+			}
+			if cfg.Admit.Prom != tc.want {
+				t.Errorf("Admit.Prom = %v; want %v for %q", cfg.Admit.Prom, tc.want, tc.raw)
+			}
+		})
+	}
+}
+
+// TestFromEnv_Admit_RejectsGarbage ensures a value outside the boolean
+// vocabulary fails fast at startup rather than silently mis-parsing.
 func TestFromEnv_Admit_RejectsGarbage(t *testing.T) {
-	t.Setenv("CERBERUS_ADMIT_PROM", "not-a-number")
+	t.Setenv("CERBERUS_ADMIT_PROM", "maybe")
 	if _, err := FromEnv(); err == nil {
-		t.Fatalf("FromEnv with CERBERUS_ADMIT_PROM=not-a-number: want error, got nil")
+		t.Fatalf("FromEnv with CERBERUS_ADMIT_PROM=maybe: want error, got nil")
+	}
+}
+
+// TestParseBool is the table-driven contract for the shared boolean
+// parser every CERBERUS_* boolean knob routes through. It must accept
+// the full strconv.ParseBool vocabulary (1/0/true/false, case-
+// insensitive) and reject anything else.
+func TestParseBool(t *testing.T) {
+	for _, tc := range []struct {
+		raw     string
+		want    bool
+		wantErr bool
+	}{
+		{"1", true, false},
+		{"0", false, false},
+		{"true", true, false},
+		{"false", false, false},
+		{"TRUE", true, false},
+		{"False", false, false},
+		{"  true  ", true, false},
+		{"maybe", false, true},
+		{"2", false, true},
+		{"", false, true},
+	} {
+		t.Run(tc.raw, func(t *testing.T) {
+			got, err := parseBool(tc.raw)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("parseBool(%q): want error, got nil", tc.raw)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseBool(%q): unexpected error %v", tc.raw, err)
+			}
+			if got != tc.want {
+				t.Errorf("parseBool(%q) = %v; want %v", tc.raw, got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/config/matrix_test.go
+++ b/internal/config/matrix_test.go
@@ -468,13 +468,13 @@ func TestFromEnv_Log_FormatErrorMessageMentionsKey(t *testing.T) {
 	}
 }
 
-// TestFromEnv_AdmitDisabled_DoesNotCascadeToCaps confirms setting
-// CERBERUS_ADMIT_DISABLED=true leaves the per-head caps intact in the
+// TestFromEnv_AdmitDisabled_DoesNotCascadeToToggles confirms setting
+// CERBERUS_ADMIT_DISABLED=true leaves the per-head toggles intact in the
 // resolved Config. The wiring in main.go is responsible for skipping
 // limiter construction — the config layer just reports both signals.
-func TestFromEnv_AdmitDisabled_DoesNotCascadeToCaps(t *testing.T) {
+func TestFromEnv_AdmitDisabled_DoesNotCascadeToToggles(t *testing.T) {
 	t.Setenv("CERBERUS_ADMIT_DISABLED", "true")
-	t.Setenv("CERBERUS_ADMIT_PROM", "256")
+	t.Setenv("CERBERUS_ADMIT_PROM", "true")
 	cfg, err := FromEnv()
 	if err != nil {
 		t.Fatalf("FromEnv: %v", err)
@@ -482,53 +482,43 @@ func TestFromEnv_AdmitDisabled_DoesNotCascadeToCaps(t *testing.T) {
 	if !cfg.Admit.Disabled {
 		t.Errorf("Disabled = false; want true")
 	}
-	if cfg.Admit.MaxInflightProm != 256 {
-		t.Errorf("MaxInflightProm = %d; want 256 (caps reported even when disabled)", cfg.Admit.MaxInflightProm)
+	if !cfg.Admit.Prom {
+		t.Errorf("Admit.Prom = false; want true (per-head toggle reported even when globally disabled)")
 	}
 }
 
-// TestFromEnv_AdmitZeroIsAllowed pins the "zero disables this head"
-// contract — the config layer accepts 0 (only negative values fail).
-func TestFromEnv_AdmitZeroIsAllowed(t *testing.T) {
-	t.Setenv("CERBERUS_ADMIT_LOKI", "0")
+// TestFromEnv_AdmitFalsyDisablesHead pins the "falsy disables this head"
+// contract — a per-head toggle accepts 0/false to leave that head
+// unlimited without touching the others.
+func TestFromEnv_AdmitFalsyDisablesHead(t *testing.T) {
+	t.Setenv("CERBERUS_ADMIT_LOKI", "false")
 	cfg, err := FromEnv()
 	if err != nil {
-		t.Fatalf("FromEnv with zero loki: %v", err)
+		t.Fatalf("FromEnv with loki disabled: %v", err)
 	}
-	if cfg.Admit.MaxInflightLoki != 0 {
-		t.Errorf("MaxInflightLoki = %d; want 0", cfg.Admit.MaxInflightLoki)
+	if cfg.Admit.Loki {
+		t.Errorf("Admit.Loki = true; want false")
 	}
-}
-
-// TestFromEnv_AdmitLargeValueRoundtrip confirms large but valid ints
-// survive the parser (no premature overflow check).
-func TestFromEnv_AdmitLargeValueRoundtrip(t *testing.T) {
-	t.Setenv("CERBERUS_ADMIT_TEMPO", "100000")
-	cfg, err := FromEnv()
-	if err != nil {
-		t.Fatalf("FromEnv: %v", err)
-	}
-	if cfg.Admit.MaxInflightTempo != 100000 {
-		t.Errorf("MaxInflightTempo = %d; want 100000", cfg.Admit.MaxInflightTempo)
+	if !cfg.Admit.Prom || !cfg.Admit.Tempo {
+		t.Errorf("disabling loki must not touch prom/tempo: prom=%v tempo=%v", cfg.Admit.Prom, cfg.Admit.Tempo)
 	}
 }
 
-// TestFromEnv_AdmitTempoNegative ensures every per-head cap reports
-// negative values consistently. (The existing Prom-specific test
-// confirms the symmetric path.)
-func TestFromEnv_AdmitTempoNegative(t *testing.T) {
+// TestFromEnv_AdmitTempoGarbage ensures a value outside the boolean
+// vocabulary fails fast for the tempo head too (symmetry with prom).
+func TestFromEnv_AdmitTempoGarbage(t *testing.T) {
 	t.Setenv("CERBERUS_ADMIT_TEMPO", "-5")
 	if _, err := FromEnv(); err == nil {
-		t.Fatal("FromEnv: want error for negative tempo, got nil")
+		t.Fatal("FromEnv: want error for non-boolean tempo, got nil")
 	}
 }
 
-// TestFromEnv_AdmitLokiNegative covers the loki-cap negative-path
+// TestFromEnv_AdmitLokiGarbage covers the loki-head garbage-rejection
 // symmetry.
-func TestFromEnv_AdmitLokiNegative(t *testing.T) {
+func TestFromEnv_AdmitLokiGarbage(t *testing.T) {
 	t.Setenv("CERBERUS_ADMIT_LOKI", "-10")
 	if _, err := FromEnv(); err == nil {
-		t.Fatal("FromEnv: want error for negative loki, got nil")
+		t.Fatal("FromEnv: want error for non-boolean loki, got nil")
 	}
 }
 

--- a/internal/config/viper_test.go
+++ b/internal/config/viper_test.go
@@ -102,14 +102,14 @@ func TestFromEnv_ViperDefaults_NoEnv(t *testing.T) {
 	if cfg.Admit.Disabled {
 		t.Errorf("Admit.Disabled = true; want false")
 	}
-	if cfg.Admit.MaxInflightProm != defaultAdmitProm {
-		t.Errorf("MaxInflightProm = %d; want %d", cfg.Admit.MaxInflightProm, defaultAdmitProm)
+	if !cfg.Admit.Prom {
+		t.Errorf("Admit.Prom = false; want true (enabled by default)")
 	}
-	if cfg.Admit.MaxInflightLoki != defaultAdmitLoki {
-		t.Errorf("MaxInflightLoki = %d; want %d", cfg.Admit.MaxInflightLoki, defaultAdmitLoki)
+	if !cfg.Admit.Loki {
+		t.Errorf("Admit.Loki = false; want true (enabled by default)")
 	}
-	if cfg.Admit.MaxInflightTempo != defaultAdmitTempo {
-		t.Errorf("MaxInflightTempo = %d; want %d", cfg.Admit.MaxInflightTempo, defaultAdmitTempo)
+	if !cfg.Admit.Tempo {
+		t.Errorf("Admit.Tempo = false; want true (enabled by default)")
 	}
 }
 


### PR DESCRIPTION
## Problem
A default \`helm install\` of the cerberus chart crash-looped: \`load config: CERBERUS_ADMIT_PROM: invalid integer "true": strconv.Atoi: parsing "true"\`. The \`CERBERUS_ADMIT_{PROM,LOKI,TEMPO,DISABLED}\` family was parsed as integers via \`strconv.Atoi\` (only \`1\`/\`0\`), while every other CERBERUS_* boolean already accepted \`true\`/\`false\`. The chart renders YAML bools, so it always crashed on a default install. (It merged red in #966 because the \`dashboard\` e2e lane wasn't a required check — fixed separately in branch protection.)

## Fix - uniform boolean convention for ALL flags (not just ADMIT_*)
Every boolean knob now accepts \`1\`/\`0\`/\`true\`/\`false\` (case-insensitive) through one shared \`parseBool\` (backed by \`strconv.ParseBool\`). Audited the full config surface - **all 18 boolean flags** route through a ParseBool-backed parser:
- **17** via \`getBool -> parseBool\`: the admit family, \`AUTO_CREATE_{SCHEMA,DATABASE}\`, \`OTLP_INSECURE\`, \`REQUIREMENTS_CHECK\`, \`SCHEMA_DATABASE_REPLICATED\`, \`CH_TLS_{ENABLED,SKIP_VERIFY}\`, \`CH_BREAKER_ENABLED\`, \`CH_KEEPALIVE_ENABLED\`, \`CH_DEBUG\`, \`CH_FREE_BUF_ON_RELEASE\`, \`DEBUG_PPROF\`, \`EXPERIMENTAL_TSGRID\`.
- **1** via the solver's \`envBool\`: \`MEMORY_APPORTION\`.
- The remaining \`getInt\`/\`getInt64\` are **genuine integers** (conns/sizes/counts/thresholds), unchanged. \`ADMIT_*\` was the only boolean wrongly on \`Atoi\`.

\`ADMIT_{PROM,LOKI,TEMPO}\` are redefined from int inflight-caps to booleans (enabled -> default cap 64/64/32, disabled -> nil pass-through limiter); see \`newAdmitLimiters\`.

## Tests + docs
- Table-driven \`TestParseBool\` (\`1\`/\`0\`/\`true\`/\`false\`/\`TRUE\`/\`False\` + invalid -> error) and \`TestFromEnv_Admit_AcceptsYAMLBool\`.
- \`docs/configuration.md\`: top-of-reference line "All boolean knobs accept \`1\`/\`0\`/\`true\`/\`false\`, case-insensitive"; ADMIT rows int -> bool.

## Verified locally (Go 1.26.2 / golangci-lint v2.12.2 / markdownlint)
\`golangci-lint run\` = 0 issues; \`go test ./internal/config\` = ok; \`gofmt\` clean; \`markdownlint\` 0 errors.

The Helm chart needs no change - the plain-bool \`admit\` block now boots.