### PR TITLE
fix(config): restore integer per-head admission caps with bool aliases

### DIFF
--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -55,23 +55,11 @@ func isVersionFlag(args []string) bool {
 	return false
 }
 
-// admitCap translates a per-head admission toggle into the concurrency
-// cap handed to admit.New. An enabled head uses its default cap; a
-// disabled head returns 0, which admit.New maps to a nil (pass-through)
-// limiter. Keeping the enabled/disabled cases symmetric here means the
-// only knob the operator sees is a plain boolean.
-func admitCap(enabled bool, defaultCap int) int {
-	if !enabled {
-		return 0
-	}
-	return defaultCap
-}
-
 // newAdmitLimiters builds the per-head admission-control limiters. When
 // CERBERUS_ADMIT_DISABLED=true every limiter is nil and the middleware
-// short-circuits to a pass-through wrapper. Otherwise each per-head toggle
-// CERBERUS_ADMIT_{PROM,LOKI,TEMPO} (boolean) selects the head's default cap
-// when truthy, or leaves the head unlimited (nil limiter) when falsy.
+// short-circuits to a pass-through wrapper. Otherwise each per-head cap
+// CERBERUS_ADMIT_{PROM,LOKI,TEMPO} sizes its limiter directly (resolved by
+// config.admitFromEnv from an explicit integer or a true/false alias).
 // admit.New returns nil for a non-positive cap, so a disabled head and a
 // zero cap collapse to the same pass-through path.
 func newAdmitLimiters(cfg config.Config, logger *slog.Logger) (*admit.Limiter, *admit.Limiter, *admit.Limiter) {
@@ -79,9 +67,9 @@ func newAdmitLimiters(cfg config.Config, logger *slog.Logger) (*admit.Limiter, *
 		logger.Info("admission control disabled (CERBERUS_ADMIT_DISABLED=true)")
 		return nil, nil, nil
 	}
-	promCap := admitCap(cfg.Admit.Prom, config.DefaultAdmitProm)
-	lokiCap := admitCap(cfg.Admit.Loki, config.DefaultAdmitLoki)
-	tempoCap := admitCap(cfg.Admit.Tempo, config.DefaultAdmitTempo)
+	promCap := cfg.Admit.Prom
+	lokiCap := cfg.Admit.Loki
+	tempoCap := cfg.Admit.Tempo
 	logger.Info(
 		"admission control enabled",
 		"prom", promCap,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -222,17 +222,21 @@ simultaneous in-flight requests. Requests above the cap are rejected with HTTP
 of overload. Tempo's cap is half of Prom / Loki because trace queries are
 typically the heaviest per-call.
 
-`CERBERUS_ADMIT_{PROM,LOKI,TEMPO}` are boolean enable toggles: a truthy value
-turns the head's limiter ON at its conservative default cap, a falsy value
-leaves that head unlimited. `CERBERUS_ADMIT_DISABLED` is a master switch that
-turns every head off at once.
+`CERBERUS_ADMIT_{PROM,LOKI,TEMPO}` set the per-head in-flight concurrency cap.
+Each accepts **either** an explicit non-negative integer cap **or** a boolean
+alias: `true` enables the head at its conservative default cap, `false` (or
+`0`) leaves that head unlimited, and a positive integer (e.g. `2`) pins an exact
+cap. `1`/`0` read as the integer caps 1 and 0, so the canonical 1/0/true/false
+all behave intuitively while an exact cap stays expressible. A negative or
+otherwise unparseable value is rejected at startup. `CERBERUS_ADMIT_DISABLED` is
+a separate master switch that turns every head off at once.
 
-| Variable                  | Type | Default | Description                                                                      |
-| ------------------------- | ---- | ------- | -------------------------------------------------------------------------------- |
-| `CERBERUS_ADMIT_DISABLED` | bool | `false` | Disable admission control entirely on every head (handy for local development).  |
-| `CERBERUS_ADMIT_PROM`     | bool | `true`  | Enable the Prom API in-flight limiter (default cap 64). Falsy = head unlimited.  |
-| `CERBERUS_ADMIT_LOKI`     | bool | `true`  | Enable the Loki API in-flight limiter (default cap 64). Falsy = head unlimited.  |
-| `CERBERUS_ADMIT_TEMPO`    | bool | `true`  | Enable the Tempo API in-flight limiter (default cap 32). Falsy = head unlimited. |
+| Variable                  | Type        | Default | Description                                                                                       |
+| ------------------------- | ----------- | ------- | ------------------------------------------------------------------------------------------------- |
+| `CERBERUS_ADMIT_DISABLED` | bool        | `false` | Disable admission control entirely on every head (handy for local development).                   |
+| `CERBERUS_ADMIT_PROM`     | int \| bool | `true`  | Prom API in-flight cap. Integer caps the head; `true` = default cap 64; `false`/`0` = unlimited.  |
+| `CERBERUS_ADMIT_LOKI`     | int \| bool | `true`  | Loki API in-flight cap. Integer caps the head; `true` = default cap 64; `false`/`0` = unlimited.  |
+| `CERBERUS_ADMIT_TEMPO`    | int \| bool | `true`  | Tempo API in-flight cap. Integer caps the head; `true` = default cap 32; `false`/`0` = unlimited. |
 
 ## Logging
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -364,7 +364,10 @@ heads with a counted semaphore that caps simultaneous in-flight
 requests. Caps are env-driven via `CERBERUS_ADMIT_PROM` /
 `CERBERUS_ADMIT_LOKI` / `CERBERUS_ADMIT_TEMPO` (defaults: 64 / 64 / 32
 — Tempo is half because trace queries are typically the heaviest
-per-call). Requests above the cap are rejected with HTTP 503 +
+per-call). Each accepts an explicit integer cap or a boolean alias
+(`true` = the default cap, `false`/`0` = that head unlimited), so a plain
+chart bool and a precise operator cap both work. Requests above the cap
+are rejected with HTTP 503 +
 `Retry-After: 1` so well-behaved clients back off and ClickHouse stays
 out of overload.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -213,35 +213,48 @@ type SchemaProvisioning struct {
 	DatabaseReplicatedReplica string
 }
 
-// AdmitConfig holds the per-handler admission-control toggles.
+// AdmitConfig holds the per-handler admission-control concurrency caps.
 //
-// CERBERUS_ADMIT_{PROM,LOKI,TEMPO} are boolean enable switches: truthy
-// turns the per-head concurrency limiter ON at its conservative default
-// cap (see DefaultAdmitProm / Loki / Tempo); falsy leaves that head with
-// no limiter (unlimited concurrency). Tempo's default cap is half of
+// CERBERUS_ADMIT_{PROM,LOKI,TEMPO} set the per-head in-flight concurrency
+// cap. Each accepts EITHER an explicit non-negative integer cap OR a
+// boolean spelling, so one knob serves both an operator pinning an exact
+// cap and the Helm chart rendering a plain YAML bool:
+//
+//   - a positive integer N -> cap the head at N concurrent requests
+//   - "true"  / "t"        -> enable at the head's conservative default
+//     cap (DefaultAdmitProm / Loki / Tempo)
+//   - "false" / "f" / "0"  -> no limiter for that head (unlimited)
+//   - a negative or otherwise unparseable value -> rejected (fail fast)
+//
+// "1"/"0" are read as the integer caps 1 and 0 (and 0 == unlimited), so
+// the four canonical booleans 1/0/true/false all behave intuitively while
+// an exact cap like 2 is still honoured. Tempo's default cap is half of
 // Prom/Loki because trace queries are typically the heaviest per-call
 // (full trace span fetches + tag-value scans across wide column sets).
 //
-// Every field is a bool routed through the shared parseBool helper, so
-// the Helm chart can render plain YAML bools (`true`/`false`) straight
-// into the env without the binary crash-looping on strconv.Atoi.
+// CERBERUS_ADMIT_DISABLED is a separate plain-bool master switch that
+// removes admission control on every head at once, independent of the
+// per-head caps below.
 type AdmitConfig struct {
 	// Disabled, when true, removes admission control entirely. Handy
 	// for local development where artificial caps mask real
 	// concurrency bugs. Default false (admission control enabled).
 	Disabled bool
 
-	// Prom enables the in-flight concurrency limiter for the Prom API
-	// head. Default true (enabled at DefaultAdmitProm).
-	Prom bool
+	// Prom caps simultaneous in-flight Prom API requests. 0 leaves the
+	// head unlimited. Default DefaultAdmitProm (CERBERUS_ADMIT_PROM
+	// unset or "true").
+	Prom int
 
-	// Loki enables the in-flight concurrency limiter for the Loki API
-	// head. Default true (enabled at DefaultAdmitLoki).
-	Loki bool
+	// Loki caps simultaneous in-flight Loki API requests. 0 leaves the
+	// head unlimited. Default DefaultAdmitLoki (CERBERUS_ADMIT_LOKI
+	// unset or "true").
+	Loki int
 
-	// Tempo enables the in-flight concurrency limiter for the Tempo API
-	// head. Default true (enabled at DefaultAdmitTempo).
-	Tempo bool
+	// Tempo caps simultaneous in-flight Tempo API requests. 0 leaves the
+	// head unlimited. Default DefaultAdmitTempo (CERBERUS_ADMIT_TEMPO
+	// unset or "true").
+	Tempo int
 }
 
 // HTTPServerConfig holds the cerberus HTTP server's net/http timeout knobs
@@ -498,10 +511,10 @@ const configFileBaseName = "cerberus"
 //	CERBERUS_OTLP_HEADERS          default ""   ("k=v,k2=v2" comma-separated)
 //	CERBERUS_OTLP_TIMEOUT          default "10s"
 //	CERBERUS_OTLP_EXPORT_INTERVAL  default "10s" (metric PeriodicReader flush interval)
-//	CERBERUS_ADMIT_DISABLED        default "false"
-//	CERBERUS_ADMIT_PROM            default "true"  (enable Prom admission limiter)
-//	CERBERUS_ADMIT_LOKI            default "true"  (enable Loki admission limiter)
-//	CERBERUS_ADMIT_TEMPO           default "true"  (enable Tempo admission limiter)
+//	CERBERUS_ADMIT_DISABLED        default "false" (master off switch, bool)
+//	CERBERUS_ADMIT_PROM            default "64"  (Prom cap; int N, or true/false)
+//	CERBERUS_ADMIT_LOKI            default "64"  (Loki cap; int N, or true/false)
+//	CERBERUS_ADMIT_TEMPO           default "32"  (Tempo cap; int N, or true/false)
 //
 // Standard OTEL_EXPORTER_OTLP_* env vars are also honored by the OTel
 // Go SDK and complement these — see docs/observability.md.
@@ -858,9 +871,9 @@ func newLoader() *viper.Viper {
 	v.SetDefault(envOTLPTimeout, defaultOTLPTimeout.String())
 	v.SetDefault(envOTLPExportInterval, defaultOTLPExportInterval.String())
 	v.SetDefault(envAdmitDisabled, defaultAdmitDisabled)
-	v.SetDefault(envAdmitProm, defaultAdmitEnabled)
-	v.SetDefault(envAdmitLoki, defaultAdmitEnabled)
-	v.SetDefault(envAdmitTempo, defaultAdmitEnabled)
+	v.SetDefault(envAdmitProm, DefaultAdmitProm)
+	v.SetDefault(envAdmitLoki, DefaultAdmitLoki)
+	v.SetDefault(envAdmitTempo, DefaultAdmitTempo)
 
 	// Optional config file: cerberus.yaml in the working directory or
 	// /etc/cerberus. Env vars always win (viper precedence: explicit
@@ -904,11 +917,11 @@ const (
 	defaultCHBreakerEnabled   = true
 	defaultCHKeepAliveEnabled = true
 	defaultAdmitDisabled      = false
-	// defaultAdmitEnabled is the per-head ADMIT_{PROM,LOKI,TEMPO}
-	// default: admission control ON out of the box. A truthy toggle
-	// enables the limiter at the head's default cap (DefaultAdmitProm /
-	// Loki / Tempo); a falsy toggle leaves the head unlimited.
-	defaultAdmitEnabled = true
+	// The per-head ADMIT_{PROM,LOKI,TEMPO} defaults are the numeric caps
+	// DefaultAdmitProm / Loki / Tempo (registered directly as the viper
+	// defaults): admission control is ON out of the box at each head's
+	// conservative cap. An explicit env value (an integer, or true/false)
+	// overrides; see getAdmitCap.
 )
 
 const (
@@ -1147,11 +1160,12 @@ func breakerFromEnv(v *viper.Viper) (breakerConfig, error) {
 }
 
 // DefaultAdmitProm, DefaultAdmitLoki and DefaultAdmitTempo are the
-// per-head concurrency caps applied when the corresponding boolean
-// toggle CERBERUS_ADMIT_{PROM,LOKI,TEMPO} is enabled; cmd/cerberus reads
-// them to size each limiter. Tempo gets a smaller cap because trace
-// queries (search + tag-value scans + per-trace span fetches) are
-// heavier than Prom/Loki metric queries.
+// per-head concurrency caps applied when CERBERUS_ADMIT_{PROM,LOKI,TEMPO}
+// is unset or set to "true"; an explicit integer in that env overrides
+// the default. cmd/cerberus reads the resolved cap to size each limiter.
+// Tempo gets a smaller cap because trace queries (search + tag-value
+// scans + per-trace span fetches) are heavier than Prom/Loki metric
+// queries.
 const (
 	DefaultAdmitProm  = 64
 	DefaultAdmitLoki  = 64
@@ -1159,27 +1173,29 @@ const (
 )
 
 // admitFromEnv reads CERBERUS_ADMIT_* knobs from the viper loader.
-// Every knob is a boolean routed through getBool (the shared parseBool
-// helper), so "1"/"0"/"true"/"false" are all accepted interchangeably,
-// case-insensitive. A truthy ADMIT_{PROM,LOKI,TEMPO} enables the per-head
-// concurrency limiter at its conservative default cap; a falsy value
-// leaves that head unlimited — a finer-grained alternative to
-// CERBERUS_ADMIT_DISABLED, which kills every head at once. Unset values
-// fall back to the registered defaults.
+// CERBERUS_ADMIT_DISABLED is a plain bool (getBool). The per-head
+// CERBERUS_ADMIT_{PROM,LOKI,TEMPO} are concurrency caps read through
+// getAdmitCap, which accepts an explicit non-negative integer OR a
+// boolean spelling: "true" -> the head's default cap, "false"/"0" ->
+// unlimited, a positive N -> cap N, negative/garbage -> rejected. This
+// keeps the 1/0/true/false ergonomics the Helm chart relies on while
+// still letting an operator pin an exact cap (e.g. 2). Unset values fall
+// back to the registered per-head defaults (DefaultAdmitProm / Loki /
+// Tempo).
 func admitFromEnv(v *viper.Viper) (AdmitConfig, error) {
 	disabled, err := getBool(v, envAdmitDisabled)
 	if err != nil {
 		return AdmitConfig{}, err
 	}
-	prom, err := getBool(v, envAdmitProm)
+	prom, err := getAdmitCap(v, envAdmitProm, DefaultAdmitProm)
 	if err != nil {
 		return AdmitConfig{}, err
 	}
-	loki, err := getBool(v, envAdmitLoki)
+	loki, err := getAdmitCap(v, envAdmitLoki, DefaultAdmitLoki)
 	if err != nil {
 		return AdmitConfig{}, err
 	}
-	tempo, err := getBool(v, envAdmitTempo)
+	tempo, err := getAdmitCap(v, envAdmitTempo, DefaultAdmitTempo)
 	if err != nil {
 		return AdmitConfig{}, err
 	}
@@ -1189,6 +1205,41 @@ func admitFromEnv(v *viper.Viper) (AdmitConfig, error) {
 		Loki:     loki,
 		Tempo:    tempo,
 	}, nil
+}
+
+// getAdmitCap resolves a per-head admission cap env var. It accepts both
+// an explicit non-negative integer cap and the boolean spellings, so the
+// four canonical values 1/0/true/false all behave intuitively AND an
+// exact cap like 2 is honoured:
+//
+//	"true" / "t"   -> defaultCap (enable at the head's default)
+//	"false" / "f"  -> 0 (unlimited; no limiter for this head)
+//	a non-negative integer N (incl. 0 and 1) -> cap N (0 == unlimited)
+//	negative or otherwise unparseable        -> error (fail fast)
+//
+// The boolean spellings are case-insensitive. A failing value is rejected
+// with an error naming the env var, preserving the fail-fast contract a
+// misconfiguration must trip at startup rather than silently mis-size.
+func getAdmitCap(v *viper.Viper, key string, defaultCap int) (int, error) {
+	raw := getString(v, key)
+	if raw == "" {
+		return 0, fmt.Errorf("%s: missing value", key)
+	}
+	trimmed := strings.TrimSpace(raw)
+	switch strings.ToLower(trimmed) {
+	case "true", "t":
+		return defaultCap, nil
+	case "false", "f":
+		return 0, nil
+	}
+	n, err := strconv.Atoi(trimmed)
+	if err != nil {
+		return 0, fmt.Errorf("%s: invalid admission cap %q: want a non-negative integer or true/false", key, raw)
+	}
+	if n < 0 {
+		return 0, fmt.Errorf("%s: invalid admission cap %q: must be >= 0", key, raw)
+	}
+	return n, nil
 }
 
 // NewLogger builds a *slog.Logger from a LogConfig writing to w. The

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -380,20 +380,21 @@ func TestFromEnv_Admit_Defaults(t *testing.T) {
 	if cfg.Admit.Disabled {
 		t.Errorf("Admit.Disabled = true; want false")
 	}
-	if !cfg.Admit.Prom {
-		t.Errorf("Admit.Prom = false; want true")
+	if cfg.Admit.Prom != DefaultAdmitProm {
+		t.Errorf("Admit.Prom = %d; want %d (default cap)", cfg.Admit.Prom, DefaultAdmitProm)
 	}
-	if !cfg.Admit.Loki {
-		t.Errorf("Admit.Loki = false; want true")
+	if cfg.Admit.Loki != DefaultAdmitLoki {
+		t.Errorf("Admit.Loki = %d; want %d (default cap)", cfg.Admit.Loki, DefaultAdmitLoki)
 	}
-	if !cfg.Admit.Tempo {
-		t.Errorf("Admit.Tempo = false; want true")
+	if cfg.Admit.Tempo != DefaultAdmitTempo {
+		t.Errorf("Admit.Tempo = %d; want %d (default cap)", cfg.Admit.Tempo, DefaultAdmitTempo)
 	}
 }
 
 // TestFromEnv_Admit_Overrides confirms env-var overrides flow through.
-// The ADMIT_* family is boolean: a falsy value disables that head's
-// limiter without disabling admission control entirely.
+// The per-head ADMIT_* caps accept a falsy value ("false"/"0") to leave
+// that head unlimited (cap 0) and a truthy value ("true") to enable at the
+// head's default cap, independent of the CERBERUS_ADMIT_DISABLED master.
 func TestFromEnv_Admit_Overrides(t *testing.T) {
 	t.Setenv("CERBERUS_ADMIT_DISABLED", "true")
 	t.Setenv("CERBERUS_ADMIT_PROM", "false")
@@ -406,33 +407,41 @@ func TestFromEnv_Admit_Overrides(t *testing.T) {
 	if !cfg.Admit.Disabled {
 		t.Errorf("Admit.Disabled = false; want true")
 	}
-	if cfg.Admit.Prom {
-		t.Errorf("Admit.Prom = true; want false")
+	if cfg.Admit.Prom != 0 {
+		t.Errorf("Admit.Prom = %d; want 0 (false disables the head)", cfg.Admit.Prom)
 	}
-	if cfg.Admit.Loki {
-		t.Errorf("Admit.Loki = true; want false (0 is falsy)")
+	if cfg.Admit.Loki != 0 {
+		t.Errorf("Admit.Loki = %d; want 0 (\"0\" disables the head)", cfg.Admit.Loki)
 	}
-	if !cfg.Admit.Tempo {
-		t.Errorf("Admit.Tempo = false; want true")
+	if cfg.Admit.Tempo != DefaultAdmitTempo {
+		t.Errorf("Admit.Tempo = %d; want %d (\"true\" = default cap)", cfg.Admit.Tempo, DefaultAdmitTempo)
 	}
 }
 
-// TestFromEnv_Admit_AcceptsYAMLBool is the end-to-end regression for the
-// Helm-chart crash: a default `helm install` renders the YAML bool
-// `true` into CERBERUS_ADMIT_PROM, which the old strconv.Atoi parser
-// rejected ("invalid integer \"true\"") and crash-looped cerberus. The
-// shared parseBool path now loads `true`/`false` cleanly.
-func TestFromEnv_Admit_AcceptsYAMLBool(t *testing.T) {
+// TestFromEnv_Admit_AcceptsIntOrBool pins the per-head cap contract: an
+// explicit integer caps the head at that value, while the boolean
+// spellings act as aliases ("true" -> the head's default cap, "false"/"0"
+// -> unlimited). The boolean path is also the end-to-end regression for
+// the Helm-chart crash — a default `helm install` renders the YAML bool
+// `true` into CERBERUS_ADMIT_PROM, which a strict integer parser would
+// reject ("invalid integer \"true\"") and crash-loop cerberus. The
+// explicit-integer path (e.g. "2") is what the e2e chaos overlay relies on
+// to force a low backpressure cap.
+func TestFromEnv_Admit_AcceptsIntOrBool(t *testing.T) {
 	for _, tc := range []struct {
 		raw  string
-		want bool
+		want int
 	}{
-		{"true", true},
-		{"false", false},
-		{"TRUE", true},
-		{"False", false},
-		{"1", true},
-		{"0", false},
+		{"true", DefaultAdmitProm},
+		{"t", DefaultAdmitProm},
+		{"TRUE", DefaultAdmitProm},
+		{"false", 0},
+		{"False", 0},
+		{"f", 0},
+		{"0", 0},
+		{"1", 1},
+		{"2", 2},
+		{"128", 128},
 	} {
 		t.Run(tc.raw, func(t *testing.T) {
 			t.Setenv("CERBERUS_ADMIT_PROM", tc.raw)
@@ -441,18 +450,23 @@ func TestFromEnv_Admit_AcceptsYAMLBool(t *testing.T) {
 				t.Fatalf("FromEnv with CERBERUS_ADMIT_PROM=%q: unexpected error %v", tc.raw, err)
 			}
 			if cfg.Admit.Prom != tc.want {
-				t.Errorf("Admit.Prom = %v; want %v for %q", cfg.Admit.Prom, tc.want, tc.raw)
+				t.Errorf("Admit.Prom = %d; want %d for %q", cfg.Admit.Prom, tc.want, tc.raw)
 			}
 		})
 	}
 }
 
-// TestFromEnv_Admit_RejectsGarbage ensures a value outside the boolean
-// vocabulary fails fast at startup rather than silently mis-parsing.
+// TestFromEnv_Admit_RejectsGarbage ensures a value outside the int/bool
+// vocabulary (and a negative cap) fails fast at startup rather than
+// silently mis-parsing.
 func TestFromEnv_Admit_RejectsGarbage(t *testing.T) {
-	t.Setenv("CERBERUS_ADMIT_PROM", "maybe")
-	if _, err := FromEnv(); err == nil {
-		t.Fatalf("FromEnv with CERBERUS_ADMIT_PROM=maybe: want error, got nil")
+	for _, raw := range []string{"maybe", "-1", "1.5", "2x"} {
+		t.Run(raw, func(t *testing.T) {
+			t.Setenv("CERBERUS_ADMIT_PROM", raw)
+			if _, err := FromEnv(); err == nil {
+				t.Fatalf("FromEnv with CERBERUS_ADMIT_PROM=%q: want error, got nil", raw)
+			}
+		})
 	}
 }
 

--- a/internal/config/matrix_test.go
+++ b/internal/config/matrix_test.go
@@ -469,7 +469,7 @@ func TestFromEnv_Log_FormatErrorMessageMentionsKey(t *testing.T) {
 }
 
 // TestFromEnv_AdmitDisabled_DoesNotCascadeToToggles confirms setting
-// CERBERUS_ADMIT_DISABLED=true leaves the per-head toggles intact in the
+// CERBERUS_ADMIT_DISABLED=true leaves the per-head caps intact in the
 // resolved Config. The wiring in main.go is responsible for skipping
 // limiter construction — the config layer just reports both signals.
 func TestFromEnv_AdmitDisabled_DoesNotCascadeToToggles(t *testing.T) {
@@ -482,34 +482,52 @@ func TestFromEnv_AdmitDisabled_DoesNotCascadeToToggles(t *testing.T) {
 	if !cfg.Admit.Disabled {
 		t.Errorf("Disabled = false; want true")
 	}
-	if !cfg.Admit.Prom {
-		t.Errorf("Admit.Prom = false; want true (per-head toggle reported even when globally disabled)")
+	if cfg.Admit.Prom != DefaultAdmitProm {
+		t.Errorf("Admit.Prom = %d; want %d (per-head cap reported even when globally disabled)", cfg.Admit.Prom, DefaultAdmitProm)
 	}
 }
 
 // TestFromEnv_AdmitFalsyDisablesHead pins the "falsy disables this head"
-// contract — a per-head toggle accepts 0/false to leave that head
-// unlimited without touching the others.
+// contract — a per-head cap accepts 0/false to leave that head unlimited
+// (cap 0) without touching the others.
 func TestFromEnv_AdmitFalsyDisablesHead(t *testing.T) {
 	t.Setenv("CERBERUS_ADMIT_LOKI", "false")
 	cfg, err := FromEnv()
 	if err != nil {
 		t.Fatalf("FromEnv with loki disabled: %v", err)
 	}
-	if cfg.Admit.Loki {
-		t.Errorf("Admit.Loki = true; want false")
+	if cfg.Admit.Loki != 0 {
+		t.Errorf("Admit.Loki = %d; want 0", cfg.Admit.Loki)
 	}
-	if !cfg.Admit.Prom || !cfg.Admit.Tempo {
-		t.Errorf("disabling loki must not touch prom/tempo: prom=%v tempo=%v", cfg.Admit.Prom, cfg.Admit.Tempo)
+	if cfg.Admit.Prom != DefaultAdmitProm || cfg.Admit.Tempo != DefaultAdmitTempo {
+		t.Errorf("disabling loki must not touch prom/tempo: prom=%d tempo=%d", cfg.Admit.Prom, cfg.Admit.Tempo)
 	}
 }
 
-// TestFromEnv_AdmitTempoGarbage ensures a value outside the boolean
-// vocabulary fails fast for the tempo head too (symmetry with prom).
+// TestFromEnv_AdmitIntegerCap pins the explicit-integer cap path the e2e
+// chaos overlay depends on — CERBERUS_ADMIT_{PROM,LOKI,TEMPO}=2 forces a
+// low backpressure cap, distinct from the boolean default-cap alias.
+func TestFromEnv_AdmitIntegerCap(t *testing.T) {
+	t.Setenv("CERBERUS_ADMIT_PROM", "2")
+	t.Setenv("CERBERUS_ADMIT_LOKI", "2")
+	t.Setenv("CERBERUS_ADMIT_TEMPO", "2")
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv with integer admit caps: %v", err)
+	}
+	if cfg.Admit.Prom != 2 || cfg.Admit.Loki != 2 || cfg.Admit.Tempo != 2 {
+		t.Errorf("integer caps not honoured: prom=%d loki=%d tempo=%d; want 2/2/2",
+			cfg.Admit.Prom, cfg.Admit.Loki, cfg.Admit.Tempo)
+	}
+}
+
+// TestFromEnv_AdmitTempoGarbage ensures a negative cap (outside the int /
+// true-false vocabulary) fails fast for the tempo head too (symmetry with
+// prom).
 func TestFromEnv_AdmitTempoGarbage(t *testing.T) {
 	t.Setenv("CERBERUS_ADMIT_TEMPO", "-5")
 	if _, err := FromEnv(); err == nil {
-		t.Fatal("FromEnv: want error for non-boolean tempo, got nil")
+		t.Fatal("FromEnv: want error for negative tempo cap, got nil")
 	}
 }
 
@@ -518,7 +536,7 @@ func TestFromEnv_AdmitTempoGarbage(t *testing.T) {
 func TestFromEnv_AdmitLokiGarbage(t *testing.T) {
 	t.Setenv("CERBERUS_ADMIT_LOKI", "-10")
 	if _, err := FromEnv(); err == nil {
-		t.Fatal("FromEnv: want error for non-boolean loki, got nil")
+		t.Fatal("FromEnv: want error for negative loki cap, got nil")
 	}
 }
 

--- a/internal/config/viper_test.go
+++ b/internal/config/viper_test.go
@@ -102,14 +102,14 @@ func TestFromEnv_ViperDefaults_NoEnv(t *testing.T) {
 	if cfg.Admit.Disabled {
 		t.Errorf("Admit.Disabled = true; want false")
 	}
-	if !cfg.Admit.Prom {
-		t.Errorf("Admit.Prom = false; want true (enabled by default)")
+	if cfg.Admit.Prom != DefaultAdmitProm {
+		t.Errorf("Admit.Prom = %d; want %d (default cap)", cfg.Admit.Prom, DefaultAdmitProm)
 	}
-	if !cfg.Admit.Loki {
-		t.Errorf("Admit.Loki = false; want true (enabled by default)")
+	if cfg.Admit.Loki != DefaultAdmitLoki {
+		t.Errorf("Admit.Loki = %d; want %d (default cap)", cfg.Admit.Loki, DefaultAdmitLoki)
 	}
-	if !cfg.Admit.Tempo {
-		t.Errorf("Admit.Tempo = false; want true (enabled by default)")
+	if cfg.Admit.Tempo != DefaultAdmitTempo {
+		t.Errorf("Admit.Tempo = %d; want %d (default cap)", cfg.Admit.Tempo, DefaultAdmitTempo)
 	}
 }
 


### PR DESCRIPTION
## Why (release-blocking)

`main` is **chaos-red**, which blocks v1.0.1 — `release-preflight.mjs` gates on the `chaos` lane (it is **not** in `FLAKY_UI_LANE_RE`).

**Root cause:** #967 turned `CERBERUS_ADMIT_{PROM,LOKI,TEMPO}` from an integer concurrency cap (`MaxInflight*`) into a **bool-only toggle**. That both deleted the per-head cap capability and broke the e2e chaos overlay, which sets `CERBERUS_ADMIT_PROM=2` to force a low backpressure cap — `parseBool("2")` is rejected, cerberus crash-loops, and `kubectl rollout status` times out.

## Fix (Option A — int cap + bool aliases)

Restore the integer cap, keeping #967's `1/0/true/false` ergonomics as aliases via a new `getAdmitCap`:

| value | result |
|---|---|
| `2` | cap 2 (the chaos case) |
| `true`/`t` | default cap (64/64/32) |
| `1` | cap 1 |
| `0` / `false`/`f` | unlimited (disabled) |
| `-5`, `1.5`, `maybe` | rejected at startup |

`AdmitConfig.{Prom,Loki,Tempo}` go `bool`->`int`; cmd/cerberus sizes each limiter directly (the `admitCap` helper is removed). `CERBERUS_ADMIT_DISABLED` stays a plain bool master switch.

## Fully documented
`AdmitConfig` + `getAdmitCap` doc comments, the env-var reference block, chart `values.yaml` + regenerated `README.md`, `docs/configuration.md` (table now `int | bool`), `docs/operations.md`.

## Tests
- `config_test`: `AcceptsIntOrBool` (int caps + bool aliases + exact cap 2/128), `RejectsGarbage` (negative / float / garbage).
- `matrix_test`: `AdmitIntegerCap` (the chaos 2/2/2 case) + updated default / falsy / disabled assertions.
- `go build ./...`, `go vet`, `golangci-lint` (0 issues), config + cmd tests green locally.

Rides into **v1.0.1** alongside #971.