### PR TITLE
chore(chart): cerberus 0.3.1 / appVersion 1.0.2 + document integer admit caps

### DIFF
--- a/deploy/helm/cerberus/Chart.yaml
+++ b/deploy/helm/cerberus/Chart.yaml
@@ -8,11 +8,11 @@ type: application
 # upgrade?" and is the publish trigger: a chart-only fix bumps this without an
 # app re-tag; an app-only release bumps appVersion + a PATCH here for the new
 # default image. Starts 0.x because the values contract is not yet frozen.
-version: 0.3.0
+version: 0.3.1
 
 # appVersion tracks the GA cerberus binary. Quoted so SemVer-shaped values
 # aren't coerced to floats. image.tag defaults from this when left empty.
-appVersion: "1.0.1"
+appVersion: "1.0.2"
 
 # autoscaling/v2 + policy/v1 (PDB) + networking/v1 (Ingress) are all GA from
 # 1.21+; 1.23 is the conservative floor matching the manifests this chart
@@ -45,15 +45,11 @@ annotations:
       url: https://github.com/tsouza/cerberus/blob/main/docs/operations.md
   artifacthub.io/images: |
     - name: cerberus
-      image: ghcr.io/tsouza/cerberus:v1.0.1
+      image: ghcr.io/tsouza/cerberus:v1.0.2
   # Bump the `1.0.0` floor here when the chart raises its minimum supported
   # cerberus release; informational for Artifact Hub's compatibility hints.
   artifacthub.io/changes: |
-    - kind: added
-      description: "query.* typed block (maxSamples / timeout / chMaxMemory) for query safety limits"
-    - kind: added
-      description: "clickhouse.pool.* typed block (maxOpenConns / maxIdleConns / connMaxLifetime)"
-    - kind: added
-      description: "debug.pprof toggle for the net/http/pprof handlers"
     - kind: changed
-      description: "documented the full CERBERUS_* surface: every binary env var is reachable via a typed block or the config passthrough"
+      description: "appVersion -> 1.0.2: histogram_quantile phi-domain (+/-Inf out of range) + vector(scalar) vector-typing fixes, plus dependency updates"
+    - kind: changed
+      description: "admit.{prom,loki,tempo} documented as integer per-head concurrency caps with true/false aliases (matches the binary's restored integer admission caps)"

--- a/deploy/helm/cerberus/README.md
+++ b/deploy/helm/cerberus/README.md
@@ -5,7 +5,7 @@
      pipe-aligned, and the version footer adds a trailing blank — both are
      owned by helm-docs; realigning would fight the chart-ci drift check. -->
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.1](https://img.shields.io/badge/AppVersion-1.0.1-informational?style=flat-square)
+![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.2](https://img.shields.io/badge/AppVersion-1.0.2-informational?style=flat-square)
 
 Drop-in Prometheus / Loki / Tempo HTTP gateway for ClickHouse — a single stateless gateway that speaks three upstream query wire formats and lowers each to parameterised ClickHouse SQL.
 
@@ -163,10 +163,10 @@ Kubernetes: `>=1.23.0-0`
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| admit.disabled | bool | `false` | Disable admission entirely (CERBERUS_ADMIT_DISABLED). |
-| admit.loki | bool | `true` | Admit LogQL queries (CERBERUS_ADMIT_LOKI). |
-| admit.prom | bool | `true` | Admit PromQL queries (CERBERUS_ADMIT_PROM). |
-| admit.tempo | bool | `true` | Admit TraceQL queries (CERBERUS_ADMIT_TEMPO). |
+| admit.disabled | bool | `false` | Disable admission entirely on every head (CERBERUS_ADMIT_DISABLED). |
+| admit.loki | bool | `true` | Loki API in-flight cap (CERBERUS_ADMIT_LOKI): integer cap, or true (default cap 64) / false (unlimited). |
+| admit.prom | bool | `true` | Prom API in-flight cap (CERBERUS_ADMIT_PROM): integer cap, or true (default cap 64) / false (unlimited). |
+| admit.tempo | bool | `true` | Tempo API in-flight cap (CERBERUS_ADMIT_TEMPO): integer cap, or true (default cap 32) / false (unlimited). |
 | affinity | object | `{}` | Affinity. Composed UNDER `affinityPresets` below — any field set here wins; the presets only inject podAffinity terms. |
 | affinityPresets | object | `{"colocateWithClickHouse":{"enabled":false,"mode":"preferred","podSelector":{"matchLabels":{"app.kubernetes.io/name":"clickhouse"}},"topologyKey":"kubernetes.io/hostname"}}` | Scheduling affinity presets (a convenience over hand-writing raw affinity). Composed over `affinity` above. |
 | affinityPresets.colocateWithClickHouse | object | `{"enabled":false,"mode":"preferred","podSelector":{"matchLabels":{"app.kubernetes.io/name":"clickhouse"}},"topologyKey":"kubernetes.io/hostname"}` | Co-locate cerberus pods with the ClickHouse pods they query, to keep the hot native :9000 path node-local instead of crossing nodes/AZs. CAVEAT: this gives only PROBABILISTIC locality (~1/N), because `clickhouse.addr` is the ClickHouse Service, which round-robins across all replicas — it cuts cross-AZ traffic but does not guarantee the node-local replica is queried. See the chart README + docs/operations.md. |

--- a/deploy/helm/cerberus/values.yaml
+++ b/deploy/helm/cerberus/values.yaml
@@ -122,14 +122,20 @@ autoCreate:
   # -- Create the target database if absent (CERBERUS_AUTO_CREATE_DATABASE).
   database: false
 
+# Per-head admission control (in-flight concurrency caps). prom / loki / tempo
+# each accept EITHER an explicit integer cap OR a boolean: `true` enables the
+# head at its conservative default cap (64 / 64 / 32), `false` (or `0`) leaves
+# the head unlimited, and a positive integer (e.g. `2`) pins an exact cap.
+# `disabled: true` is the master switch that removes admission control on every
+# head at once.
 admit:
-  # -- Admit PromQL queries (CERBERUS_ADMIT_PROM).
+  # -- Prom API in-flight cap (CERBERUS_ADMIT_PROM): integer cap, or true (default cap 64) / false (unlimited).
   prom: true
-  # -- Admit LogQL queries (CERBERUS_ADMIT_LOKI).
+  # -- Loki API in-flight cap (CERBERUS_ADMIT_LOKI): integer cap, or true (default cap 64) / false (unlimited).
   loki: true
-  # -- Admit TraceQL queries (CERBERUS_ADMIT_TEMPO).
+  # -- Tempo API in-flight cap (CERBERUS_ADMIT_TEMPO): integer cap, or true (default cap 32) / false (unlimited).
   tempo: true
-  # -- Disable admission entirely (CERBERUS_ADMIT_DISABLED).
+  # -- Disable admission entirely on every head (CERBERUS_ADMIT_DISABLED).
   disabled: false
 
 otlp:


### PR DESCRIPTION
Chart release for the **v1.0.2** binary.

- **appVersion 1.0.1 → 1.0.2** — picks up histogram_quantile phi-domain + `vector(scalar)` vector-typing fixes (#974) and dependency updates (#975).
- **chart version 0.3.0 → 0.3.1** — a chart change requires the SemVer increment (ct-lint enforces it; 0.3.0 is published/immutable).
- artifacthub image pin → `v1.0.2`.
- Lands the **admit chart-doc polish deferred from #973** (it would have forced a ct-lint bump on the frozen 0.3.0): `admit.{prom,loki,tempo}` now documented as integer per-head caps with true/false aliases, matching the binary's restored integer admission caps. README regenerated via the `jnorwood/helm-docs:v1.14.2` docker image (footer preserved).

Merges into main ahead of the **v1.0.2** tag; release.yml then publishes image `v1.0.2` + chart `0.3.1`. `helm lint` clean locally.