### PR TITLE
fix(release): draft release, publish after assets attach (immutable-releases fix)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,19 @@ jobs:
         with:
           subject-path: 'dist/*.tar.gz'
 
+      # goreleaser created the release as a DRAFT (see .goreleaser.yml
+      # release.draft) so it could attach the binary archives + checksums
+      # while the release was still mutable. Flip it to published now, AFTER
+      # the assets and provenance are in place: the repo's immutable-releases
+      # policy then freezes the release WITH its assets. Publishing up-front
+      # (e.g. `gh release create`) would lock it before goreleaser could
+      # upload -- the 422 that broke v1.0.1. Idempotent: a no-op if already
+      # published.
+      - name: Publish the release (flip draft -> published)
+        run: gh release edit "${{ github.ref_name }}" --draft=false
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   # Publish the Helm chart to GHCR as an OCI artifact, cosign-sign it keyless,
   # attest provenance, and (idempotently) push the Artifact Hub metadata. Gated
   # on the same preflight as the binary release. The chart is published ONLY

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -143,7 +143,17 @@ docker_manifests:
       - "ghcr.io/tsouza/cerberus:latest-arm64"
 
 release:
-  draft: false
+  # draft:true so goreleaser creates the GitHub release as a DRAFT (mutable)
+  # and can attach the binary archives + checksums to it. The repo has
+  # immutable releases enabled, which freezes a release the moment it is
+  # PUBLISHED -- so a published release cannot receive assets afterwards
+  # (422 "cannot upload assets to an immutable release"). release.yml flips
+  # the draft to published in a step AFTER goreleaser + provenance attest, so
+  # it is frozen WITH the assets already attached. The tag must be pushed
+  # WITHOUT pre-creating a release (push the git tag only, never
+  # `gh release create`), or goreleaser would find an already-immutable
+  # release and fail the same way.
+  draft: true
   prerelease: auto
   github:
     owner: tsouza


### PR DESCRIPTION
## Why
The repo has **immutable releases** enabled, which freezes a release on **publish**. v1.0.1's cut created the release published-up-front, so goreleaser's asset-upload step hit `422 cannot upload assets to an immutable release` — the **image + chart published fine, but the binary archives, checksums, and SLSA provenance were lost** and release.yml went red.

## Fix (keeps immutable releases ON)
- `.goreleaser.yml`: `release.draft: true` — goreleaser creates the release as a **draft** (mutable) and attaches binaries/checksums.
- `release.yml`: new step after goreleaser + provenance attest — `gh release edit <tag> --draft=false` flips it to **published**, freezing it **with** the assets in place.
- **Cut procedure change:** push the git **tag only** (never `gh release create`), else goreleaser finds an already-immutable release and fails the same way.

`goreleaser check` passes; both YAML files parse. v1.0.1 stays as-is (already immutable; image+chart unaffected). This unblocks a green, fully-published **v1.0.2**.