### PR TITLE
feat(chclient): per-query instrumentation (query_id / log_comment) + settings map + aggregation_in_order

### DIFF
--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -253,10 +253,12 @@ func run() error {
 	lokiHandler.Version = Version
 	lokiHandler.QueryTimeout = cfg.ClickHouse.QueryTimeout
 	lokiHandler.TailWriteTimeout = cfg.LokiTailWriteTimeout
+	lokiHandler.Engine.Settings = settingsRules(cfg)
 	lokiHandler.Mount(traceMux)
 
 	tempoHandler := tempo.New(tempoClient, cfg.Traces, Version, logger.With("api", "tempo"))
 	tempoHandler.Limiter = tempoLimiter
+	tempoHandler.Engine.Settings = settingsRules(cfg)
 	tempoHandler.Mount(traceMux)
 
 	tracedAPI := wrapWithOTel(traceMux, "cerberus")
@@ -353,12 +355,34 @@ const solverGateReserve = 2
 // Client view + seed optimizer + solver), limiter, and runtime knobs wired in.
 func newPromHandler(client *chclient.Client, cfg config.Config, evalSolver *solver.Solver, limiter *admit.Limiter, logger *slog.Logger) *prom.Handler {
 	h := prom.New(client, cfg.Schema, logger.With("api", "prom"))
-	h.Engine = &engine.Engine{Optimizer: h.Optimizer, Client: client, Solver: evalSolver}
+	h.Engine = &engine.Engine{
+		Optimizer: h.Optimizer,
+		Client:    client,
+		Solver:    evalSolver,
+		Settings:  settingsRules(cfg),
+	}
 	h.Limiter = limiter
 	h.Version = Version
 	h.ExperimentalTSGridRange = cfg.ExperimentalTSGridRange
 	h.QueryTimeout = cfg.ClickHouse.QueryTimeout
 	return h
+}
+
+// settingsRules builds the DARK-by-default per-query ClickHouse settings
+// rules from the CERBERUS_* config. Both rule flags default false, so the
+// returned value is "every rule off" unless an operator opted in; the schema
+// instances are always supplied so the aggregation-in-order eligibility check
+// can map ANY scanned signal table to its sort-key prefix regardless of which
+// head runs the query. Shared by all three heads' engines so a single env
+// flag flips the rule uniformly.
+func settingsRules(cfg config.Config) engine.SettingsRules {
+	return engine.SettingsRules{
+		OptimizeAggregationInOrder: cfg.OptimizeAggregationInOrder,
+		LogCommentShape:            cfg.LogCommentShape,
+		Metrics:                    cfg.Schema,
+		Traces:                     cfg.Traces,
+		Logs:                       cfg.Logs,
+	}
 }
 
 func buildSolver(

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -416,6 +416,49 @@ the SQL array machinery leaves at high cardinality. Default off is byte-for-byte
 the established fan-out. See [`performance.md`](performance.md#the-durable-answer)
 for the why and [`benchmarks.md`](benchmarks.md) for the recorded numbers.
 
+## Query instrumentation (Phase-0)
+
+These flags ship the first slice of the ClickHouse-optimization roadmap:
+per-query instrumentation that lets operators mine `system.query_log`, plus one
+conservative, result-equivalent settings win. Both the DARK flags below default
+**off**, and every behaviour here is safe on ClickHouse 24.8 (cerberus's minimum
+floor) — none adopts a 25.x feature.
+
+| Variable                                 | Type | Default | Description                                                                                                                                                           |
+| ---------------------------------------- | ---- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- --|
+| `CERBERUS_OPTIMIZE_AGGREGATION_IN_ORDER` | bool | `false` | Stamp `optimize_aggregation_in_order=1` on queries whose post-optimize `Aggregate` GROUP BY is a bare-column **prefix** of the scanned table's sorting key.           |
+| `CERBERUS_LOG_COMMENT_SHAPE`             | bool | `false` | Stamp ClickHouse `log_comment` with a compact, literal-free cerberus shape id (`cerb:<root>[;mod...]`) so `system.query_log` rows cluster by `normalized_query_hash`. |
+
+**Always-on (no flag): `query_id`.** Every data-plane query cerberus dispatches
+carries a ClickHouse `query_id` set to cerberus's active trace id. This is
+observational and harmless — `query_id` is a free-form identifier ClickHouse
+echoes into `system.query_log` — and it lets operators join their SQL back to
+the cerberus trace that issued it. When no trace is present (an un-instrumented
+caller) the driver generates its own id; `query_id` is never an error path.
+
+`CERBERUS_OPTIMIZE_AGGREGATION_IN_ORDER` is **result-equivalent**: the setting
+changes only ClickHouse's aggregation execution strategy (consume rows in sort
+order, emit each group as its key block is exhausted), never the rows returned.
+The eligibility check is conservative — it stamps **only** when the plan has a
+single `Aggregate` whose GROUP BY keys are all bare columns and form an ordered
+prefix of the scanned table's sorting key (e.g. metrics group by
+`MetricName` / `(MetricName, Attributes)` against the
+`(MetricName, Attributes, ServiceName, ...)` sort key). A reordered, gapped, or
+non-prefix GROUP BY, a union/join, or a renamed table all fail closed and the
+setting is not sent. The setting predates the 24.8 floor, so it is version-safe.
+
+`CERBERUS_LOG_COMMENT_SHAPE` emits a shape id built from the emit-root plan node
+kind plus structural modifiers (aggregate key arity, presence of a range window
+/ join / union / limit) and **never any literal** — no metric names, label
+values, timestamps, or group-by column names. `log_comment` is a free-form
+annotation ClickHouse ignores during execution, so stamping it is result-neutral
+and version-safe. See [`operations.md`](operations.md#query_log-mining) for the
+mining queries this enables.
+
+> This is Phase-0 of the optimization roadmap. The async `query_log` reconciler
+> (corpus persistence + feedback-driven rule tuning) is deliberately deferred to
+> a later phase; these flags only emit the join keys it will consume.
+
 ## Loki streaming
 
 | Variable                           | Type     | Default | Description                                                                                            |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -430,10 +430,14 @@ floor) — none adopts a 25.x feature.
 | `CERBERUS_LOG_COMMENT_SHAPE`             | bool | `false` | Stamp ClickHouse `log_comment` with a compact, literal-free cerberus shape id (`cerb:<root>[;mod...]`) so `system.query_log` rows cluster by `normalized_query_hash`. |
 
 **Always-on (no flag): `query_id`.** Every data-plane query cerberus dispatches
-carries a ClickHouse `query_id` set to cerberus's active trace id. This is
-observational and harmless — `query_id` is a free-form identifier ClickHouse
-echoes into `system.query_log` — and it lets operators join their SQL back to
-the cerberus trace that issued it. When no trace is present (an un-instrumented
+carries a ClickHouse `query_id` of the form `<trace id>-<span id>-<counter>`:
+the active trace id is the leading **prefix** (operators join their SQL back to
+the issuing trace with `query_id LIKE '<trace id>-%'`), while the span id and a
+process-global counter make the id **unique per CH dispatch**. The uniqueness
+is load-bearing, not cosmetic — a single trace fans out many concurrent CH
+queries (dashboard panels, fan-out PromQL), and a bare trace id would make them
+collide on one `query_id`, which ClickHouse rejects with code 216 ("Query with
+id = X is already running"). When no trace is present (an un-instrumented
 caller) the driver generates its own id; `query_id` is never an error path.
 
 `CERBERUS_OPTIMIZE_AGGREGATION_IN_ORDER` is **result-equivalent**: the setting

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -764,6 +764,76 @@ Logs are written as an event stream — see
 [`observability.md`](observability.md#logging) for the full contract
 (stderr stream shape, OTLP bridge, slog attribute conventions).
 
+## query_log mining
+
+Every data-plane query cerberus runs stamps the ClickHouse `query_id` with
+cerberus's active trace id (always on, no flag). That ties each row in
+`system.query_log` back to the cerberus trace — and, with the optional DARK
+flags from [`configuration.md`](configuration.md#query-instrumentation-phase-0),
+gives operators the join keys to cluster and rank cerberus's SQL by cost.
+
+Join a cerberus trace to its ClickHouse execution:
+
+```sql
+SELECT query_duration_ms, memory_usage, read_rows, read_bytes, query
+FROM system.query_log
+WHERE type = 'QueryFinish'
+  AND query_id = '<cerberus trace id>'
+```
+
+Top query shapes by p99 latency (cluster by ClickHouse's normalized hash):
+
+```sql
+SELECT
+    normalized_query_hash,
+    count() AS runs,
+    quantile(0.99)(query_duration_ms) AS p99_ms,
+    any(query) AS sample
+FROM system.query_log
+WHERE type = 'QueryFinish' AND event_time > now() - INTERVAL 1 DAY
+GROUP BY normalized_query_hash
+ORDER BY p99_ms DESC
+LIMIT 20
+```
+
+Top shapes by peak memory:
+
+```sql
+SELECT
+    normalized_query_hash,
+    count() AS runs,
+    max(memory_usage) AS peak_bytes,
+    any(query) AS sample
+FROM system.query_log
+WHERE type = 'QueryFinish' AND event_time > now() - INTERVAL 1 DAY
+GROUP BY normalized_query_hash
+ORDER BY peak_bytes DESC
+LIMIT 20
+```
+
+With `CERBERUS_LOG_COMMENT_SHAPE=true`, every query also carries a compact,
+literal-free cerberus shape id in `log_comment` (`cerb:<root>[;mod...]`), so you
+can pivot on the cerberus-assigned shape rather than ClickHouse's literal-
+sensitive hash — and filter to cerberus traffic with `log_comment LIKE 'cerb:%'`:
+
+```sql
+SELECT
+    log_comment AS shape,
+    count() AS runs,
+    quantile(0.99)(query_duration_ms) AS p99_ms,
+    max(memory_usage) AS peak_bytes
+FROM system.query_log
+WHERE type = 'QueryFinish'
+  AND log_comment LIKE 'cerb:%'
+  AND event_time > now() - INTERVAL 1 DAY
+GROUP BY log_comment
+ORDER BY p99_ms DESC
+LIMIT 20
+```
+
+The async reconciler that would persist this corpus and feed it back into rule
+tuning is a later roadmap phase; today these flags only emit the join keys.
+
 ## Admin commands
 
 Cerberus has no embedded admin REPL. Schema operations are owned by

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -766,19 +766,26 @@ Logs are written as an event stream — see
 
 ## query_log mining
 
-Every data-plane query cerberus runs stamps the ClickHouse `query_id` with
-cerberus's active trace id (always on, no flag). That ties each row in
-`system.query_log` back to the cerberus trace — and, with the optional DARK
-flags from [`configuration.md`](configuration.md#query-instrumentation-phase-0),
-gives operators the join keys to cluster and rank cerberus's SQL by cost.
+Every data-plane query cerberus runs stamps the ClickHouse `query_id` with a
+per-dispatch id of the form `<trace id>-<span id>-<counter>` (always on, no
+flag). The cerberus trace id is the leading **prefix**, so each row in
+`system.query_log` still joins back to the cerberus trace — while the span id
+and a process-global counter keep the id **unique per CH dispatch**, so the
+many concurrent queries a single trace fans out (a Grafana dashboard loading
+panels, a vector-join / fan-out PromQL) never collide on the same `query_id`
+(which ClickHouse would reject with code 216, "Query with id = X is already
+running"). With the optional DARK flags from
+[`configuration.md`](configuration.md#query-instrumentation-phase-0), operators
+also get the join keys to cluster and rank cerberus's SQL by cost.
 
-Join a cerberus trace to its ClickHouse execution:
+Join a cerberus trace to its ClickHouse execution (match on the trace-id
+prefix — one trace maps to many per-dispatch `query_id`s):
 
 ```sql
-SELECT query_duration_ms, memory_usage, read_rows, read_bytes, query
+SELECT query_id, query_duration_ms, memory_usage, read_rows, read_bytes, query
 FROM system.query_log
 WHERE type = 'QueryFinish'
-  AND query_id = '<cerberus trace id>'
+  AND query_id LIKE '<cerberus trace id>-%'
 ```
 
 Top query shapes by p99 latency (cluster by ClickHouse's normalized hash):

--- a/internal/chclient/client.go
+++ b/internal/chclient/client.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"strconv"
+	"sync/atomic"
 	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
@@ -768,20 +770,43 @@ func (c *Client) querySettings(ctx context.Context) clickhouse.Settings {
 	return s
 }
 
+// queryIDKeyType keys the per-dispatch ClickHouse query_id on a context, so
+// the unique id is computed ONCE per dispatch (in queryContext) and the SAME
+// value is read by everything that needs it (the CH WithQueryID stamp here,
+// and any out-of-band reader that later joins system.query_log back to the
+// dispatch). A counter-derived id is non-deterministic, so it MUST be cached
+// rather than recomputed — see queryIDFromContext.
+type queryIDKeyType struct{}
+
+var queryIDKey = queryIDKeyType{}
+
+// queryIDCounter is a process-global monotonic sequence mixed into every
+// per-dispatch query_id. It guarantees two concurrent CH queries issued under
+// the SAME trace (a Grafana dashboard fanning out one trace across many
+// panels, a vector-join / fan-out PromQL dispatching several CH queries) never
+// collide on the same query_id — which ClickHouse rejects with code 216
+// ("Query with id = X is already running").
+var queryIDCounter atomic.Uint64
+
 // queryContext derives the context every data-plane query runs under:
 // the caller's ctx plus the per-query ClickHouse settings from
-// querySettings and the ClickHouse query_id stamped from the active
-// trace id. clickhouse.Context merges per-option with any QueryOptions
+// querySettings and a per-dispatch ClickHouse query_id derived from the
+// active trace. clickhouse.Context merges per-option with any QueryOptions
 // already on ctx (e.g. the progress callback installed by
 // WithProgressFor), so stacking is safe and the existing options are
 // preserved. When neither a setting nor a query_id is available the ctx
 // is returned unchanged.
 //
+// The query_id is computed ONCE here, stored on the returned context, and
+// reused by queryIDFromContext, so the value stamped via WithQueryID is the
+// exact same value any later reader observes — a non-deterministic
+// counter-derived id MUST be cached, never recomputed.
+//
 // Exec (DDL / DML) deliberately does NOT go through this — see
 // Config.MaxQueryMemoryBytes.
 func (c *Client) queryContext(ctx context.Context) context.Context {
 	s := c.querySettings(ctx)
-	queryID := queryIDFromContext(ctx)
+	queryID, ctx := ensureQueryID(ctx)
 	if s == nil && queryID == "" {
 		return ctx
 	}
@@ -795,24 +820,46 @@ func (c *Client) queryContext(ctx context.Context) context.Context {
 	return clickhouse.Context(ctx, opts...)
 }
 
-// queryIDFromContext derives the ClickHouse query_id for a data-plane
-// dispatch from cerberus's active trace id. The otelhttp server span makes
-// a valid trace id available on every request ctx; stamping it as the CH
-// query_id lets operators later join their SQL back to system.query_log on
-// the cerberus trace id (the query_id column), and ties the CH side of a
-// request to the same trace the cerberus spans carry.
+// ensureQueryID returns the per-dispatch ClickHouse query_id for ctx,
+// generating and caching it on the context if absent. It is the single
+// generation seam: queryContext calls it once per dispatch so the stamped id
+// and any later reader (queryIDFromContext) agree on one value.
 //
-// This is observational and harmless: query_id is free-form on the wire and
-// only ever an identifier ClickHouse echoes back into query_log. When no
-// valid trace is present (no-op tracer in tests, a non-instrumented caller),
-// the trace id is the all-zero invalid id; we return "" and leave query_id
-// unset so the driver generates its own — query_id is never an error path.
-func queryIDFromContext(ctx context.Context) string {
+// The id has the form "<traceID>-<spanID>-<counter>" so the trace id stays a
+// greppable PREFIX in query_log.query_id (operators can still
+// `WHERE query_id LIKE '<traceID>%'` or split on '-' to recover the trace),
+// while the span id + process-global counter make it UNIQUE per dispatch:
+//   - the counter disambiguates concurrent dispatches within one process, so
+//     a single trace fanning out many CH queries never collides (no code 216);
+//   - the span id disambiguates two cerberus replicas that share a trace and
+//     could otherwise pick the same counter value.
+//
+// When no valid trace is present (no-op tracer in tests, a non-instrumented
+// caller) the trace id is the all-zero invalid id; the returned id is ""
+// (nothing cached) so the driver self-generates one — query_id is never an
+// error path.
+func ensureQueryID(ctx context.Context) (string, context.Context) {
+	if id, ok := ctx.Value(queryIDKey).(string); ok {
+		return id, ctx
+	}
 	sc := trace.SpanContextFromContext(ctx)
 	if !sc.HasTraceID() {
-		return ""
+		return "", ctx
 	}
-	return sc.TraceID().String()
+	id := sc.TraceID().String() + "-" + sc.SpanID().String() + "-" +
+		strconv.FormatUint(queryIDCounter.Add(1), 10)
+	return id, context.WithValue(ctx, queryIDKey, id)
+}
+
+// queryIDFromContext returns the per-dispatch ClickHouse query_id stamped on
+// ctx by queryContext, or "" when none was stamped (an un-instrumented
+// dispatch, or a ctx that never flowed through queryContext). It is the read
+// side of the cache: it returns the EXACT value that was stamped via
+// WithQueryID, so a reader joining system.query_log by query_id observes the
+// same id ClickHouse recorded.
+func queryIDFromContext(ctx context.Context) string {
+	id, _ := ctx.Value(queryIDKey).(string)
+	return id
 }
 
 // Conn returns the underlying clickhouse-go/v2 driver connection. It is

--- a/internal/chclient/client.go
+++ b/internal/chclient/client.go
@@ -720,23 +720,25 @@ func assembleClientFromConn(cfg Config, conn driver.Conn) *Client {
 //     effective timeout, after any per-request WithQueryTimeout override,
 //     is > 0). `throw` aborts an over-long query with TIMEOUT_EXCEEDED
 //     (code 159) rather than returning partial results.
-//   - SettingExperimentalTSGridAggregate=1 — ONLY when ctx was marked by
-//     WithTSGridSetting (the engine marks it when the emitted plan
-//     contains a chplan.RangeWindowNative node). The experimental knob
-//     is added to the SAME map as max_memory_usage, never via a second
-//     independent clickhouse.WithSettings wrap — a second wrap REPLACES
-//     rather than unions the settings map (clickhouse-go context.go:
+//   - the per-request settings map attached by WithQuerySetting — every
+//     plan-shape-gated setting the engine stamps for THIS query
+//     (SettingExperimentalTSGridAggregate=1 when the plan has a
+//     chplan.RangeWindowNative node; optimize_aggregation_in_order=1 when
+//     the GROUP BY is a sorting-key prefix; ...). Merged into the SAME map
+//     as max_memory_usage, never via a second independent
+//     clickhouse.WithSettings wrap — a second wrap REPLACES rather than
+//     unions the settings map (clickhouse-go context.go:
 //     `c.settings = maps.Clone(q.settings)`), which would silently drop
-//     the memory cap. Merging here keeps both knobs on the one map.
+//     the memory cap. Merging here keeps every knob on the one map.
 //
 // Kept as its own method (rather than inlined into queryContext) so
 // tests can assert the settings content directly — the driver stores
 // QueryOptions under an unexported context key with no public getter.
 func (c *Client) querySettings(ctx context.Context) clickhouse.Settings {
-	wantTSGrid := wantTSGridSetting(ctx)
+	perQuery := querySettingsFromContext(ctx)
 	timeout := c.effectiveQueryTimeout(ctx)
 	blockSize := maxBlockSizeFromContext(ctx)
-	if c.maxMemory <= 0 && timeout <= 0 && !wantTSGrid && blockSize == 0 {
+	if c.maxMemory <= 0 && timeout <= 0 && len(perQuery) == 0 && blockSize == 0 {
 		return nil
 	}
 	s := clickhouse.Settings{}
@@ -751,8 +753,11 @@ func (c *Client) querySettings(ctx context.Context) clickhouse.Settings {
 		s[settingMaxExecutionTime] = timeout.Seconds()
 		s[settingTimeoutOverflowMode] = timeoutOverflowModeThrow
 	}
-	if wantTSGrid {
-		s[SettingExperimentalTSGridAggregate] = 1
+	// Plan-shape-gated per-request settings ride on top of the client-wide
+	// caps. They are merged last so a future shape-gated override of a cap
+	// is intentional and visible here, not accidental.
+	for name, value := range perQuery {
+		s[name] = value
 	}
 	if blockSize > 0 {
 		// Per-request override (WithMaxBlockSize) — only ever set by the
@@ -765,19 +770,49 @@ func (c *Client) querySettings(ctx context.Context) clickhouse.Settings {
 
 // queryContext derives the context every data-plane query runs under:
 // the caller's ctx plus the per-query ClickHouse settings from
-// querySettings. clickhouse.Context merges with any QueryOptions
+// querySettings and the ClickHouse query_id stamped from the active
+// trace id. clickhouse.Context merges per-option with any QueryOptions
 // already on ctx (e.g. the progress callback installed by
-// WithProgressFor), so stacking is safe. When no settings are
-// configured the ctx is returned unchanged.
+// WithProgressFor), so stacking is safe and the existing options are
+// preserved. When neither a setting nor a query_id is available the ctx
+// is returned unchanged.
 //
 // Exec (DDL / DML) deliberately does NOT go through this — see
 // Config.MaxQueryMemoryBytes.
 func (c *Client) queryContext(ctx context.Context) context.Context {
 	s := c.querySettings(ctx)
-	if s == nil {
+	queryID := queryIDFromContext(ctx)
+	if s == nil && queryID == "" {
 		return ctx
 	}
-	return clickhouse.Context(ctx, clickhouse.WithSettings(s))
+	opts := make([]clickhouse.QueryOption, 0, 2)
+	if s != nil {
+		opts = append(opts, clickhouse.WithSettings(s))
+	}
+	if queryID != "" {
+		opts = append(opts, clickhouse.WithQueryID(queryID))
+	}
+	return clickhouse.Context(ctx, opts...)
+}
+
+// queryIDFromContext derives the ClickHouse query_id for a data-plane
+// dispatch from cerberus's active trace id. The otelhttp server span makes
+// a valid trace id available on every request ctx; stamping it as the CH
+// query_id lets operators later join their SQL back to system.query_log on
+// the cerberus trace id (the query_id column), and ties the CH side of a
+// request to the same trace the cerberus spans carry.
+//
+// This is observational and harmless: query_id is free-form on the wire and
+// only ever an identifier ClickHouse echoes back into query_log. When no
+// valid trace is present (no-op tracer in tests, a non-instrumented caller),
+// the trace id is the all-zero invalid id; we return "" and leave query_id
+// unset so the driver generates its own — query_id is never an error path.
+func queryIDFromContext(ctx context.Context) string {
+	sc := trace.SpanContextFromContext(ctx)
+	if !sc.HasTraceID() {
+		return ""
+	}
+	return sc.TraceID().String()
 }
 
 // Conn returns the underlying clickhouse-go/v2 driver connection. It is

--- a/internal/chclient/experimental.go
+++ b/internal/chclient/experimental.go
@@ -41,10 +41,6 @@ import "context"
 // the package note in internal/chsql/range_window_native.go).
 const SettingExperimentalTSGridAggregate = "allow_experimental_time_series_aggregate_functions"
 
-type tsGridSettingKeyType struct{}
-
-var tsGridSettingKey = tsGridSettingKeyType{}
-
 // WithTSGridSetting returns a ctx that signals the data-plane query
 // methods to add SettingExperimentalTSGridAggregate=1 to the per-query
 // ClickHouse settings map. The engine calls this ONLY when the emitted
@@ -53,15 +49,14 @@ var tsGridSettingKey = tsGridSettingKeyType{}
 // the unrelated ones (a plain unknown setting can itself error on an
 // older ClickHouse, so it must not be sent globally).
 //
-// The signal is a context value rather than a Client field so it is
-// per-request, not per-connection: two concurrent requests, one native
-// and one not, must not cross-contaminate each other's settings.
+// It is now one writer into the generalised per-request settings carrier
+// (WithQuerySetting): the ts-grid gate is just one (name, value) the engine
+// stamps for a particular plan shape, alongside the other plan-shape-gated
+// settings. Routing through the shared carrier means a single query that is
+// BOTH native-rate and aggregation-in-order eligible carries both settings
+// on the one map rather than one wrap clobbering the other. The carrier is
+// a context value, not a Client field, so it stays per-request: two
+// concurrent requests, one native and one not, never cross-contaminate.
 func WithTSGridSetting(ctx context.Context) context.Context {
-	return context.WithValue(ctx, tsGridSettingKey, true)
-}
-
-// wantTSGridSetting reports whether ctx was marked by WithTSGridSetting.
-func wantTSGridSetting(ctx context.Context) bool {
-	v, _ := ctx.Value(tsGridSettingKey).(bool)
-	return v
+	return WithQuerySetting(ctx, SettingExperimentalTSGridAggregate, 1)
 }

--- a/internal/chclient/query_settings.go
+++ b/internal/chclient/query_settings.go
@@ -1,0 +1,65 @@
+package chclient
+
+import (
+	"context"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+)
+
+// perQuerySettingsKeyType keys the per-request ClickHouse settings map on a
+// context. It is the generalised successor to the single-flag tsGridSettingKey:
+// instead of one bool meaning "add SettingExperimentalTSGridAggregate=1", the
+// engine can stamp ANY (name, value) the post-optimize plan shape calls for,
+// and querySettings merges the whole map into the per-query settings.
+type perQuerySettingsKeyType struct{}
+
+var perQuerySettingsKey = perQuerySettingsKeyType{}
+
+// WithQuerySetting returns a ctx carrying name=value in the per-request
+// ClickHouse settings map, on top of any settings already attached to ctx.
+// It is the single reusable hook the engine uses to attach plan-shape-gated
+// settings (the experimental ts-grid gate, optimize_aggregation_in_order, ...)
+// to exactly the query they apply to — never globally, so a setting that
+// would error on an unrelated query (or an older ClickHouse) never rides one.
+//
+// The carrier is a context value, not a Client field, so it is per-request:
+// two concurrent requests with different plan shapes cannot cross-contaminate
+// each other's settings. Each call copies the existing map (copy-on-write) so
+// a derived ctx never mutates a parent ctx's map.
+func WithQuerySetting(ctx context.Context, name string, value any) context.Context {
+	prev := querySettingsFromContext(ctx)
+	next := make(clickhouse.Settings, len(prev)+1)
+	for k, v := range prev {
+		next[k] = v
+	}
+	next[name] = value
+	return context.WithValue(ctx, perQuerySettingsKey, next)
+}
+
+// querySettingsFromContext returns the per-request settings map attached to
+// ctx by WithQuerySetting, or nil when none was attached. The returned map
+// must be treated as read-only by callers (it may be shared with derived
+// contexts); WithQuerySetting copies before writing.
+func querySettingsFromContext(ctx context.Context) clickhouse.Settings {
+	s, _ := ctx.Value(perQuerySettingsKey).(clickhouse.Settings)
+	return s
+}
+
+// QuerySettingsFromContext returns a COPY of the per-request ClickHouse
+// settings attached to ctx by WithQuerySetting, or nil when none was
+// attached. It is the public read side of the carrier: callers in other
+// packages (the engine's rule code, tests asserting a plan-shape rule
+// stamped the expected setting) can inspect what will ride a query without
+// reaching into chclient's private context key. The copy keeps the internal
+// map immutable from the caller's side.
+func QuerySettingsFromContext(ctx context.Context) clickhouse.Settings {
+	s := querySettingsFromContext(ctx)
+	if s == nil {
+		return nil
+	}
+	out := make(clickhouse.Settings, len(s))
+	for k, v := range s {
+		out[k] = v
+	}
+	return out
+}

--- a/internal/chclient/query_settings_test.go
+++ b/internal/chclient/query_settings_test.go
@@ -2,6 +2,8 @@ package chclient
 
 import (
 	"context"
+	"strings"
+	"sync"
 	"testing"
 
 	"go.opentelemetry.io/otel/trace"
@@ -58,34 +60,59 @@ func TestQuerySettings_GeneralisedCarrierCoexists(t *testing.T) {
 	}
 }
 
-// TestQueryIDFromContext_TraceID — a valid active trace id becomes the
-// CH query_id; an un-instrumented ctx yields "" (driver generates its own,
-// never an error).
-func TestQueryIDFromContext_TraceID(t *testing.T) {
+// tracedCtx returns a context carrying a valid active span context built from
+// the supplied trace/span id bytes — the seam the otelhttp server span gives
+// every real request.
+func tracedCtx(tid trace.TraceID, sid trace.SpanID) context.Context {
+	sc := trace.NewSpanContext(trace.SpanContextConfig{TraceID: tid, SpanID: sid})
+	return trace.ContextWithSpanContext(context.Background(), sc)
+}
+
+// TestEnsureQueryID_NoTrace — an un-instrumented ctx yields "" (the driver
+// generates its own id) and nothing is cached on the returned ctx.
+func TestEnsureQueryID_NoTrace(t *testing.T) {
 	t.Parallel()
 
-	if got := queryIDFromContext(context.Background()); got != "" {
-		t.Errorf("queryIDFromContext(plain) = %q; want empty", got)
+	id, out := ensureQueryID(context.Background())
+	if id != "" {
+		t.Errorf("ensureQueryID(plain) = %q; want empty", id)
 	}
+	if got := queryIDFromContext(out); got != "" {
+		t.Errorf("queryIDFromContext after no-trace ensure = %q; want empty", got)
+	}
+}
+
+// TestEnsureQueryID_TracePrefix — a valid trace yields a non-empty id whose
+// trace id is a greppable prefix (operators join query_log on `LIKE
+// '<traceID>%'`), and the id is cached so queryIDFromContext returns the
+// SAME value (consistency for any reader joining query_log).
+func TestEnsureQueryID_TracePrefix(t *testing.T) {
+	t.Parallel()
 
 	tid := trace.TraceID{
 		0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
 		0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
 	}
 	sid := trace.SpanID{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
-	sc := trace.NewSpanContext(trace.SpanContextConfig{TraceID: tid, SpanID: sid})
-	ctx := trace.ContextWithSpanContext(context.Background(), sc)
+	ctx := tracedCtx(tid, sid)
 
-	got := queryIDFromContext(ctx)
-	if want := tid.String(); got != want {
-		t.Errorf("queryIDFromContext(traced) = %q; want %q", got, want)
+	id, out := ensureQueryID(ctx)
+	if id == "" {
+		t.Fatal("ensureQueryID(traced) = empty; want a per-dispatch id")
+	}
+	if prefix := tid.String() + "-"; !strings.HasPrefix(id, prefix) {
+		t.Errorf("query_id %q is not prefixed by %q (trace id must stay greppable)", id, prefix)
+	}
+	if got := queryIDFromContext(out); got != id {
+		t.Errorf("queryIDFromContext = %q; want the cached %q (reader must see the stamped id)", got, id)
 	}
 }
 
-// TestQueryContext_StampsQueryID — queryContext stamps the trace-derived
-// query_id onto the dispatch context's ClickHouse QueryOptions even when no
-// settings are configured, so the join-to-query_log id always rides.
-func TestQueryContext_StampsQueryID(t *testing.T) {
+// TestEnsureQueryID_UniquePerDispatch — many dispatches under the SAME trace,
+// including from concurrent goroutines, each get a DISTINCT query_id (so
+// concurrent CH queries never collide on ClickHouse code 216), and every id
+// still carries the trace-id prefix.
+func TestEnsureQueryID_UniquePerDispatch(t *testing.T) {
 	t.Parallel()
 
 	tid := trace.TraceID{
@@ -93,8 +120,56 @@ func TestQueryContext_StampsQueryID(t *testing.T) {
 		0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99,
 	}
 	sid := trace.SpanID{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00, 0x11}
-	sc := trace.NewSpanContext(trace.SpanContextConfig{TraceID: tid, SpanID: sid})
-	ctx := trace.ContextWithSpanContext(context.Background(), sc)
+	prefix := tid.String() + "-"
+
+	const (
+		workers      = 16
+		perWorker    = 64
+		wantDistinct = workers * perWorker
+	)
+
+	var (
+		mu  sync.Mutex
+		ids = make(map[string]struct{}, wantDistinct)
+		wg  sync.WaitGroup
+	)
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range perWorker {
+				// A fresh traced ctx per dispatch: the SAME trace/span, the
+				// shape a fan-out produces (one trace, many concurrent CH
+				// dispatches).
+				id, _ := ensureQueryID(tracedCtx(tid, sid))
+				if !strings.HasPrefix(id, prefix) {
+					t.Errorf("query_id %q lost the trace prefix %q", id, prefix)
+				}
+				mu.Lock()
+				ids[id] = struct{}{}
+				mu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+
+	if len(ids) != wantDistinct {
+		t.Errorf("got %d distinct query_ids; want %d (concurrent dispatches must never collide)", len(ids), wantDistinct)
+	}
+}
+
+// TestQueryContext_StampsAndCachesQueryID — queryContext derives a new ctx
+// carrying a per-dispatch query_id even with no settings, and that id is the
+// SAME value queryIDFromContext returns (the stamp and the reader agree).
+func TestQueryContext_StampsAndCachesQueryID(t *testing.T) {
+	t.Parallel()
+
+	tid := trace.TraceID{
+		0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00, 0x11,
+		0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99,
+	}
+	sid := trace.SpanID{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00, 0x11}
+	ctx := tracedCtx(tid, sid)
 
 	// A bare client with no caps: queryContext must STILL derive a new ctx
 	// (carrying the query_id) rather than returning the input unchanged.
@@ -102,5 +177,10 @@ func TestQueryContext_StampsQueryID(t *testing.T) {
 	out := c.queryContext(ctx)
 	if out == ctx {
 		t.Fatal("queryContext returned the input ctx unchanged; want a query_id-stamped ctx")
+	}
+	if got := queryIDFromContext(out); got == "" {
+		t.Fatal("queryContext did not cache a query_id on the returned ctx")
+	} else if !strings.HasPrefix(got, tid.String()+"-") {
+		t.Errorf("cached query_id %q is not prefixed by the trace id", got)
 	}
 }

--- a/internal/chclient/query_settings_test.go
+++ b/internal/chclient/query_settings_test.go
@@ -1,0 +1,106 @@
+package chclient
+
+import (
+	"context"
+	"testing"
+
+	"go.opentelemetry.io/otel/trace"
+)
+
+// TestWithQuerySetting_CarrierMergeAndCopyOnWrite — the generalised
+// per-request settings carrier accumulates multiple (name, value) settings,
+// and each WithQuerySetting derives a fresh map so a child ctx never mutates
+// a parent ctx's settings.
+func TestWithQuerySetting_CarrierMergeAndCopyOnWrite(t *testing.T) {
+	t.Parallel()
+
+	base := context.Background()
+	ctx1 := WithQuerySetting(base, "a", 1)
+	ctx2 := WithQuerySetting(ctx1, "b", 2)
+
+	// The parent ctx must NOT see the child's later addition (copy-on-write).
+	parent := querySettingsFromContext(ctx1)
+	if len(parent) != 1 || parent["a"] != 1 {
+		t.Errorf("parent settings = %v; want exactly {a:1}", parent)
+	}
+	if _, leaked := parent["b"]; leaked {
+		t.Errorf("parent settings leaked child key b: %v", parent)
+	}
+
+	child := querySettingsFromContext(ctx2)
+	if child["a"] != 1 || child["b"] != 2 || len(child) != 2 {
+		t.Errorf("child settings = %v; want {a:1, b:2}", child)
+	}
+}
+
+// TestQuerySettings_GeneralisedCarrierCoexists — ts-grid (now one writer into
+// the carrier) and an arbitrary second plan-shape-gated setting ride the same
+// per-query settings map alongside the memory cap, none clobbering another.
+func TestQuerySettings_GeneralisedCarrierCoexists(t *testing.T) {
+	t.Parallel()
+
+	c := &Client{maxMemory: 1 << 30}
+	ctx := WithTSGridSetting(context.Background())
+	ctx = WithQuerySetting(ctx, "optimize_aggregation_in_order", 1)
+
+	s := c.querySettings(ctx)
+	if s[SettingExperimentalTSGridAggregate] != 1 {
+		t.Errorf("%s = %v; want 1", SettingExperimentalTSGridAggregate, s[SettingExperimentalTSGridAggregate])
+	}
+	if s["optimize_aggregation_in_order"] != 1 {
+		t.Errorf("optimize_aggregation_in_order = %v; want 1", s["optimize_aggregation_in_order"])
+	}
+	if s["max_memory_usage"] != int64(1<<30) {
+		t.Errorf("max_memory_usage = %v; want the cap (no clobber)", s["max_memory_usage"])
+	}
+	if len(s) != 3 {
+		t.Errorf("settings carries %d entries (%v); want the three knobs", len(s), s)
+	}
+}
+
+// TestQueryIDFromContext_TraceID — a valid active trace id becomes the
+// CH query_id; an un-instrumented ctx yields "" (driver generates its own,
+// never an error).
+func TestQueryIDFromContext_TraceID(t *testing.T) {
+	t.Parallel()
+
+	if got := queryIDFromContext(context.Background()); got != "" {
+		t.Errorf("queryIDFromContext(plain) = %q; want empty", got)
+	}
+
+	tid := trace.TraceID{
+		0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+		0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+	}
+	sid := trace.SpanID{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+	sc := trace.NewSpanContext(trace.SpanContextConfig{TraceID: tid, SpanID: sid})
+	ctx := trace.ContextWithSpanContext(context.Background(), sc)
+
+	got := queryIDFromContext(ctx)
+	if want := tid.String(); got != want {
+		t.Errorf("queryIDFromContext(traced) = %q; want %q", got, want)
+	}
+}
+
+// TestQueryContext_StampsQueryID — queryContext stamps the trace-derived
+// query_id onto the dispatch context's ClickHouse QueryOptions even when no
+// settings are configured, so the join-to-query_log id always rides.
+func TestQueryContext_StampsQueryID(t *testing.T) {
+	t.Parallel()
+
+	tid := trace.TraceID{
+		0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00, 0x11,
+		0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99,
+	}
+	sid := trace.SpanID{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00, 0x11}
+	sc := trace.NewSpanContext(trace.SpanContextConfig{TraceID: tid, SpanID: sid})
+	ctx := trace.ContextWithSpanContext(context.Background(), sc)
+
+	// A bare client with no caps: queryContext must STILL derive a new ctx
+	// (carrying the query_id) rather than returning the input unchanged.
+	c := &Client{}
+	out := c.queryContext(ctx)
+	if out == ctx {
+		t.Fatal("queryContext returned the input ctx unchanged; want a query_id-stamped ctx")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -127,6 +127,31 @@ type Config struct {
 	// chDB differential sweep proves the timeSeriesDeltaToGrid mapping.
 	ExperimentalTSGridRange bool
 
+	// OptimizeAggregationInOrder, when true, lets the engine stamp the
+	// ClickHouse setting `optimize_aggregation_in_order=1` on a data-plane
+	// query whose post-optimize plan has an Aggregate GROUP BY that is a
+	// genuine bare-column PREFIX of the scanned table's sorting key (see
+	// internal/engine.SettingsRules). The setting is RESULT-EQUIVALENT --
+	// it changes only the aggregation execution strategy, never the rows --
+	// and exists well below cerberus's CH 24.8 floor, so it is version-safe.
+	//
+	// Default false: it ships DARK behind CERBERUS_OPTIMIZE_AGGREGATION_IN_
+	// ORDER so the corpus-driven optimization roadmap can enable it per
+	// environment. Even on, the eligibility check is conservative and only
+	// stamps when the GROUP BY is provably a sort-key prefix.
+	OptimizeAggregationInOrder bool
+
+	// LogCommentShape, when true, lets the engine stamp ClickHouse
+	// `log_comment` with a COMPACT, literal-free cerberus shape id
+	// (emit-root plan node kind + key modifiers, never any literal values)
+	// so operators with query_log enabled can cluster system.query_log rows
+	// by normalized_query_hash + log_comment. log_comment is a free-form
+	// annotation ignored by execution, so stamping it is result-neutral and
+	// version-safe.
+	//
+	// Default false: it ships DARK behind CERBERUS_LOG_COMMENT_SHAPE.
+	LogCommentShape bool
+
 	// Log configures cerberus's own structured logging (stdlib log/slog).
 	// See LogConfig for the env-var contract.
 	Log LogConfig
@@ -398,6 +423,8 @@ const (
 	envSchemaDBReplReplica = "CERBERUS_SCHEMA_DATABASE_REPLICATED_REPLICA"
 	envRequirementsCheck   = "CERBERUS_REQUIREMENTS_CHECK"
 	envExperimentalTSGrid  = "CERBERUS_EXPERIMENTAL_TS_GRID_RANGE"
+	envOptimizeAggInOrder  = "CERBERUS_OPTIMIZE_AGGREGATION_IN_ORDER"
+	envLogCommentShape     = "CERBERUS_LOG_COMMENT_SHAPE"
 	envLogFormat           = "CERBERUS_LOG_FORMAT"
 	envLogLevel            = "CERBERUS_LOG_LEVEL"
 	envOTLPEndpoint        = "CERBERUS_OTLP_ENDPOINT"
@@ -504,6 +531,14 @@ const configFileBaseName = "cerberus"
 //	    timeSeriesRateToGrid for eligible rate query_range; requires ClickHouse
 //	    >= 25.6 (prod / compose / e2e are on 25.8, so this floor is met by
 //	    default); on older servers the native query 500s with UNKNOWN_FUNCTION
+//	CERBERUS_OPTIMIZE_AGGREGATION_IN_ORDER default "false" — stamp
+//	    optimize_aggregation_in_order=1 on queries whose Aggregate GROUP BY
+//	    is a bare-column prefix of the scanned table's sorting key. Result-
+//	    equivalent execution knob, safe on CH 24.8; DARK by default.
+//	CERBERUS_LOG_COMMENT_SHAPE     default "false" — stamp a compact, literal-
+//	    free cerberus shape id into ClickHouse log_comment so query_log rows
+//	    cluster by normalized_query_hash + log_comment. Result-neutral, safe
+//	    on CH 24.8; DARK by default.
 //	CERBERUS_LOG_FORMAT            default "text"  ("text" | "json")
 //	CERBERUS_LOG_LEVEL             default "info"  ("debug" | "info" | "warn" | "error")
 //	CERBERUS_OTLP_ENDPOINT         default ""   (empty → exporters disabled)
@@ -680,22 +715,24 @@ func FromEnv() (Config, error) {
 		extra:        surface.ch,
 	})
 	return Config{
-		HTTPAddr:                getString(v, envHTTPAddr),
-		HTTPServer:              surface.httpServer,
-		LokiTailWriteTimeout:    surface.lokiTailWriteTimeout,
-		ClickHouse:              chCfg,
-		Schema:                  schema.DefaultOTelMetricsFromEnv(),
-		Logs:                    schema.DefaultOTelLogsFromEnv(),
-		Traces:                  schema.DefaultOTelTracesFromEnv(),
-		AutoCreateSchema:        flags.AutoCreate,
-		AutoCreateDatabase:      flags.AutoCreateDatabase,
-		SchemaProvisioning:      schemaProvisioning,
-		RequirementsCheck:       flags.RequirementsCheck,
-		ExperimentalTSGridRange: flags.TSGridRange,
-		DebugPProf:              flags.DebugPProf,
-		Log:                     logCfg,
-		OTLP:                    otlp,
-		Admit:                   admit,
+		HTTPAddr:                   getString(v, envHTTPAddr),
+		HTTPServer:                 surface.httpServer,
+		LokiTailWriteTimeout:       surface.lokiTailWriteTimeout,
+		ClickHouse:                 chCfg,
+		Schema:                     schema.DefaultOTelMetricsFromEnv(),
+		Logs:                       schema.DefaultOTelLogsFromEnv(),
+		Traces:                     schema.DefaultOTelTracesFromEnv(),
+		AutoCreateSchema:           flags.AutoCreate,
+		AutoCreateDatabase:         flags.AutoCreateDatabase,
+		SchemaProvisioning:         schemaProvisioning,
+		RequirementsCheck:          flags.RequirementsCheck,
+		ExperimentalTSGridRange:    flags.TSGridRange,
+		DebugPProf:                 flags.DebugPProf,
+		OptimizeAggregationInOrder: flags.OptimizeAggInOrder,
+		LogCommentShape:            flags.LogCommentShape,
+		Log:                        logCfg,
+		OTLP:                       otlp,
+		Admit:                      admit,
 	}, nil
 }
 
@@ -763,6 +800,8 @@ var allEnvKeys = []string{
 	envSchemaDBReplReplica,
 	envRequirementsCheck,
 	envExperimentalTSGrid,
+	envOptimizeAggInOrder,
+	envLogCommentShape,
 	envLogFormat,
 	envLogLevel,
 	envOTLPEndpoint,
@@ -863,6 +902,8 @@ func newLoader() *viper.Viper {
 	v.SetDefault(envSchemaTTLTraces, defaultSchemaTTL)
 	v.SetDefault(envRequirementsCheck, defaultRequirementsCheck)
 	v.SetDefault(envExperimentalTSGrid, defaultExperimentalTSGrid)
+	v.SetDefault(envOptimizeAggInOrder, defaultOptimizeAggInOrder)
+	v.SetDefault(envLogCommentShape, defaultLogCommentShape)
 	v.SetDefault(envLogFormat, defaultLogFormat)
 	v.SetDefault(envLogLevel, defaultLogLevel)
 	v.SetDefault(envOTLPEndpoint, defaultOTLPEndpoint)
@@ -909,6 +950,8 @@ const (
 	defaultSchemaTTL          = "0s"
 	defaultRequirementsCheck  = true
 	defaultExperimentalTSGrid = false
+	defaultOptimizeAggInOrder = false
+	defaultLogCommentShape    = false
 	defaultLogFormat          = "text"
 	defaultLogLevel           = "info"
 	defaultOTLPEndpoint       = ""
@@ -1486,6 +1529,8 @@ type bootFlags struct {
 	RequirementsCheck  bool
 	TSGridRange        bool
 	DebugPProf         bool
+	OptimizeAggInOrder bool
+	LogCommentShape    bool
 }
 
 // bootFlagsFromEnv parses the boolean boot toggles, failing fast on a
@@ -1519,12 +1564,22 @@ func bootFlagsFromEnv(v *viper.Viper) (bootFlags, error) {
 	if err != nil {
 		return bootFlags{}, err
 	}
+	optimizeAggInOrder, err := getBool(v, envOptimizeAggInOrder)
+	if err != nil {
+		return bootFlags{}, err
+	}
+	logCommentShape, err := getBool(v, envLogCommentShape)
+	if err != nil {
+		return bootFlags{}, err
+	}
 	return bootFlags{
 		AutoCreate:         autoCreate,
 		AutoCreateDatabase: autoCreateDatabase,
 		RequirementsCheck:  requirementsCheck,
 		TSGridRange:        tsGridRange,
 		DebugPProf:         debugPProf,
+		OptimizeAggInOrder: optimizeAggInOrder,
+		LogCommentShape:    logCommentShape,
 	}, nil
 }
 

--- a/internal/config/query_instrumentation_test.go
+++ b/internal/config/query_instrumentation_test.go
@@ -1,0 +1,95 @@
+package config
+
+import "testing"
+
+// The two Phase-0 instrumentation flags ship DARK (default false) and accept
+// the full strconv bool vocabulary, mirroring the existing bool-flag tests
+// (e.g. TestFromEnv_OTLP_Insecure_*).
+
+func TestFromEnv_OptimizeAggregationInOrder_DefaultsOff(t *testing.T) {
+	t.Setenv("CERBERUS_OPTIMIZE_AGGREGATION_IN_ORDER", "")
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	if cfg.OptimizeAggregationInOrder {
+		t.Errorf("OptimizeAggregationInOrder default = true; want false")
+	}
+}
+
+func TestFromEnv_OptimizeAggregationInOrder_Garbage(t *testing.T) {
+	t.Setenv("CERBERUS_OPTIMIZE_AGGREGATION_IN_ORDER", "maybe")
+	if _, err := FromEnv(); err == nil {
+		t.Fatal("FromEnv: want error for invalid bool, got nil")
+	}
+}
+
+func TestFromEnv_OptimizeAggregationInOrder_BoolVocabulary(t *testing.T) {
+	for _, tc := range boolVocabulary() {
+		t.Run(tc.val, func(t *testing.T) {
+			t.Setenv("CERBERUS_OPTIMIZE_AGGREGATION_IN_ORDER", tc.val)
+			cfg, err := FromEnv()
+			if err != nil {
+				t.Fatalf("FromEnv: %v", err)
+			}
+			if cfg.OptimizeAggregationInOrder != tc.want {
+				t.Errorf("OptimizeAggregationInOrder(%q) = %v; want %v",
+					tc.val, cfg.OptimizeAggregationInOrder, tc.want)
+			}
+		})
+	}
+}
+
+func TestFromEnv_LogCommentShape_DefaultsOff(t *testing.T) {
+	t.Setenv("CERBERUS_LOG_COMMENT_SHAPE", "")
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	if cfg.LogCommentShape {
+		t.Errorf("LogCommentShape default = true; want false")
+	}
+}
+
+func TestFromEnv_LogCommentShape_Garbage(t *testing.T) {
+	t.Setenv("CERBERUS_LOG_COMMENT_SHAPE", "yarp")
+	if _, err := FromEnv(); err == nil {
+		t.Fatal("FromEnv: want error for invalid bool, got nil")
+	}
+}
+
+func TestFromEnv_LogCommentShape_BoolVocabulary(t *testing.T) {
+	for _, tc := range boolVocabulary() {
+		t.Run(tc.val, func(t *testing.T) {
+			t.Setenv("CERBERUS_LOG_COMMENT_SHAPE", tc.val)
+			cfg, err := FromEnv()
+			if err != nil {
+				t.Fatalf("FromEnv: %v", err)
+			}
+			if cfg.LogCommentShape != tc.want {
+				t.Errorf("LogCommentShape(%q) = %v; want %v",
+					tc.val, cfg.LogCommentShape, tc.want)
+			}
+		})
+	}
+}
+
+// boolVocabulary is the strconv-bool vocabulary cerberus accepts for its
+// bool flags, mirroring TestFromEnv_OTLP_InsecureBoolVocabulary.
+func boolVocabulary() []struct {
+	val  string
+	want bool
+} {
+	return []struct {
+		val  string
+		want bool
+	}{
+		{"true", true},
+		{"TRUE", true},
+		{"1", true},
+		{"t", true},
+		{"false", false},
+		{"0", false},
+		{"f", false},
+	}
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -139,10 +139,18 @@ func strategyFor(meta Meta) string {
 // Applied identically on the eager (QueryPlan) and streaming
 // (QueryPlanCursor) execute sites so the native path is gated the same
 // way regardless of which one runs.
-func execContext(ctx context.Context, plan chplan.Node) context.Context {
+//
+// On top of the always-on ts-grid gate, execContext layers the DARK,
+// flag-gated settings rules from e.Settings (optimize_aggregation_in_order,
+// log_comment shape id). Each rule is OFF unless its CERBERUS_* flag is set,
+// so the default ctx is byte-identical to before these rules existed. Every
+// rule writes through chclient.WithQuerySetting, so a plan that triggers more
+// than one rule carries all of them on the one per-request settings map.
+func (e *Engine) execContext(ctx context.Context, plan chplan.Node) context.Context {
 	if planHasTSGridNative(plan) {
-		return chclient.WithTSGridSetting(ctx)
+		ctx = chclient.WithTSGridSetting(ctx)
 	}
+	ctx = e.Settings.apply(ctx, plan)
 	return ctx
 }
 
@@ -201,6 +209,13 @@ type Engine struct {
 	// (so the phase-2 flip is a config change) but dormant at the default
 	// config.
 	Solver *solver.Solver
+
+	// Settings carries the optional, DARK-by-default per-query ClickHouse
+	// settings rules the engine evaluates against the post-optimize plan
+	// (optimize_aggregation_in_order, log_comment shape id). The zero value
+	// is "every rule off": every existing call path is byte-unchanged. Wired
+	// from the CERBERUS_* flags in cmd/cerberus. See SettingsRules.
+	Settings SettingsRules
 }
 
 // Lang adapts a query-language head (PromQL / LogQL / TraceQL) to
@@ -365,7 +380,7 @@ func (e *Engine) QueryPlan(ctx context.Context, lang Lang, plan chplan.Node, met
 	// their per-head labels.
 	execT := telemetry.ObserveStage(telemetry.StageExecute)
 	start := time.Now()
-	samples, err := e.Client.Query(execContext(chclient.WithProgressFor(ctx, lang.Name()), plan), sql, args...)
+	samples, err := e.Client.Query(e.execContext(chclient.WithProgressFor(ctx, lang.Name()), plan), sql, args...)
 	chMillis := time.Since(start).Milliseconds()
 	execT.Done(ctx)
 	if err != nil {
@@ -571,7 +586,7 @@ func (e *Engine) QueryPlanCursor(ctx context.Context, lang Lang, plan chplan.Nod
 	}
 
 	execT := telemetry.ObserveStage(telemetry.StageExecute)
-	cursor, err := cq.QueryCursor(execContext(chclient.WithProgressFor(ctx, lang.Name()), plan), sql, args...)
+	cursor, err := cq.QueryCursor(e.execContext(chclient.WithProgressFor(ctx, lang.Name()), plan), sql, args...)
 	execT.Done(ctx)
 	if err != nil {
 		return CursorResult{}, fmt.Errorf("engine: execute: %w", err)

--- a/internal/engine/plan_shape_id.go
+++ b/internal/engine/plan_shape_id.go
@@ -1,0 +1,124 @@
+package engine
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// shapeIDPrefix namespaces the cerberus shape id inside log_comment so an
+// operator scanning system.query_log can tell a cerberus-stamped comment
+// apart from any other tool's log_comment at a glance, and so a
+// `log_comment LIKE 'cerb:%'` filter selects exactly cerberus queries.
+const shapeIDPrefix = "cerb:"
+
+// planShapeID returns a COMPACT, literal-free identifier for plan's shape,
+// for stamping into ClickHouse log_comment. It captures the emit-root node
+// kind plus a few key structural modifiers (aggregate group-key arity,
+// presence of a range window / limit / join / union) and DELIBERATELY omits
+// every literal: no metric names, no label values, no timestamps, no group-by
+// column names. Two queries with the same plan shape but different literals
+// hash to the same id, so operators can cluster system.query_log rows by
+// log_comment (alongside normalized_query_hash) without the id itself leaking
+// query contents.
+//
+// The form is `cerb:<root>[;<modifier>...]`, e.g.
+// `cerb:project;agg=3;rw` for a Project over a 3-key Aggregate over a
+// RangeWindow. Returns "" for a nil plan.
+func planShapeID(plan chplan.Node) string {
+	if plan == nil {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString(shapeIDPrefix)
+	b.WriteString(nodeKind(plan))
+	for _, m := range shapeModifiers(plan) {
+		b.WriteByte(';')
+		b.WriteString(m)
+	}
+	return b.String()
+}
+
+// shapeModifiers returns the ordered, literal-free structural modifiers for
+// plan. The order is fixed so the same shape always produces the same id.
+func shapeModifiers(plan chplan.Node) []string {
+	var (
+		mods      []string
+		aggKeys   = -1
+		hasRange  bool
+		hasLimit  bool
+		hasJoin   bool
+		hasUnion  bool
+		hasNative bool
+	)
+	chplan.Walk(plan, func(n chplan.Node) bool {
+		switch v := n.(type) {
+		case *chplan.Aggregate:
+			// Arity only (a count) — never the key names, so no literal leaks.
+			if aggKeys < 0 {
+				aggKeys = len(v.GroupBy)
+			}
+		case *chplan.RangeWindow:
+			hasRange = true
+		case *chplan.RangeWindowNative:
+			hasNative = true
+		case *chplan.Limit:
+			hasLimit = true
+		case *chplan.Scan:
+			if len(v.UnionTables) > 0 {
+				hasUnion = true
+			}
+		case *chplan.CrossJoin, *chplan.StructuralJoin, *chplan.VectorJoin, *chplan.InfoJoin:
+			hasJoin = true
+		}
+		return true
+	})
+	if aggKeys >= 0 {
+		mods = append(mods, "agg="+strconv.Itoa(aggKeys))
+	}
+	if hasRange {
+		mods = append(mods, "rw")
+	}
+	if hasNative {
+		mods = append(mods, "rwn")
+	}
+	if hasJoin {
+		mods = append(mods, "join")
+	}
+	if hasUnion {
+		mods = append(mods, "union")
+	}
+	if hasLimit {
+		mods = append(mods, "limit")
+	}
+	return mods
+}
+
+// nodeKind returns the short, stable kind token for the emit-root node. The
+// tokens are lowercase and literal-free; an unrecognised node kind falls back
+// to "node" so the id stays well-formed.
+func nodeKind(n chplan.Node) string {
+	switch n.(type) {
+	case *chplan.Scan:
+		return "scan"
+	case *chplan.Filter:
+		return "filter"
+	case *chplan.Project:
+		return "project"
+	case *chplan.Aggregate:
+		return "agg"
+	case *chplan.RangeWindow:
+		return "rw"
+	case *chplan.RangeWindowNative:
+		return "rwn"
+	case *chplan.Limit:
+		return "limit"
+	case *chplan.OrderBy:
+		return "orderby"
+	case *chplan.UnionAll:
+		return "union"
+	default:
+		return "node"
+	}
+}

--- a/internal/engine/query_settings_rules.go
+++ b/internal/engine/query_settings_rules.go
@@ -1,0 +1,206 @@
+package engine
+
+import (
+	"context"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// settingOptimizeAggregationInOrder is the ClickHouse setting that lets the
+// aggregator consume rows in sort order and emit each group as soon as its
+// key block is exhausted, instead of building a full hash table. It is
+// RESULT-EQUIVALENT: it changes only the execution strategy, never the rows.
+// It has existed since well before cerberus's CH 24.8 floor, so stamping it
+// is version-safe.
+const settingOptimizeAggregationInOrder = "optimize_aggregation_in_order"
+
+// settingLogComment is ClickHouse's free-form per-query annotation. When set
+// it is copied verbatim into system.query_log.log_comment, letting operators
+// GROUP BY a cerberus-assigned shape id. Free-form and ignored by execution,
+// so stamping it is version-safe and result-neutral.
+const settingLogComment = "log_comment"
+
+// SettingsRules holds the DARK-by-default, plan-shape-gated per-query
+// ClickHouse settings rules the engine evaluates at the execute seam. The
+// zero value applies NOTHING: with both flags false the ctx is returned
+// unchanged, so wiring SettingsRules is byte-neutral until an operator opts
+// in via the CERBERUS_* flags.
+//
+// Both rules are safe on ClickHouse 24.8 (cerberus's min floor):
+// optimize_aggregation_in_order is a long-standing result-equivalent
+// execution knob, and log_comment is a free-form annotation. Neither adopts
+// a 25.x feature.
+type SettingsRules struct {
+	// OptimizeAggregationInOrder, when true, stamps
+	// optimize_aggregation_in_order=1 on queries whose post-optimize plan
+	// has an Aggregate GROUP BY that is a genuine bare-column PREFIX of the
+	// scanned table's sorting key (see eligibleForAggregationInOrder). The
+	// setting is result-equivalent and off by default, so this is doubly
+	// safe, but the eligibility check is still conservative: when anything
+	// about the plan shape is unclear it does NOT stamp.
+	OptimizeAggregationInOrder bool
+
+	// LogCommentShape, when true, stamps log_comment with a compact cerberus
+	// shape id (planShapeID) carrying the emit-root node kind plus key
+	// modifiers and NEVER any literal values, so operators with query_log
+	// enabled can cluster by normalized_query_hash + log_comment.
+	LogCommentShape bool
+
+	// Metrics / Traces / Logs are the schema instances whose SortingKeyPrefix
+	// the aggregation-in-order eligibility check reads to map a scanned table
+	// name to its bare-column sort-key prefix. They mirror the same schema the
+	// query heads read; a renamed table simply fails to match and the setting
+	// is not stamped (fail-safe).
+	Metrics schema.Metrics
+	Traces  schema.Traces
+	Logs    schema.Logs
+}
+
+// apply layers the enabled settings rules onto ctx for plan. Each rule that
+// fires writes through chclient.WithQuerySetting so they accumulate on the
+// one per-request settings map. With both flags off, ctx is returned
+// unchanged.
+func (r SettingsRules) apply(ctx context.Context, plan chplan.Node) context.Context {
+	if r.OptimizeAggregationInOrder && r.eligibleForAggregationInOrder(plan) {
+		ctx = chclient.WithQuerySetting(ctx, settingOptimizeAggregationInOrder, 1)
+	}
+	if r.LogCommentShape {
+		if id := planShapeID(plan); id != "" {
+			ctx = chclient.WithQuerySetting(ctx, settingLogComment, id)
+		}
+	}
+	return ctx
+}
+
+// eligibleForAggregationInOrder reports whether plan's single Aggregate has a
+// GROUP BY that is a genuine bare-column prefix of its scanned table's
+// sorting key. The check is deliberately conservative: it returns false on
+// ANY shape it can't prove eligible, because a wrong stamp would change
+// execution strategy on a query whose GROUP BY is NOT sort-key-aligned (still
+// result-correct, but not the intended win, and a false signal to operators
+// mining query_log).
+//
+// Eligibility requires ALL of:
+//
+//   - exactly one Aggregate node in the plan (the plain metrics/aggregation
+//     shape). Zero Aggregates means nothing to order; multiple Aggregates
+//     (nested second-stage rollups, compare ops) make "the" group key
+//     ambiguous against a single sort key, so it bails.
+//   - the Aggregate's GROUP BY is non-empty and every key is a BARE column
+//     reference (chplan.ColumnRef with no Qualifier). A function-of-column
+//     or a join-qualified key can't be matched against the bare-column sort
+//     prefix, so any non-bare key disqualifies.
+//   - the plan reads exactly ONE physical table (one Scan, no UnionTables,
+//     no second Scan from a join). A union/join has no single sort key to be
+//     a prefix of.
+//   - the GROUP BY column-name sequence is an ordered prefix of that table's
+//     schema SortingKeyPrefix.
+func (r SettingsRules) eligibleForAggregationInOrder(plan chplan.Node) bool {
+	agg, ok := singleAggregate(plan)
+	if !ok {
+		return false
+	}
+	groupCols, ok := bareGroupByColumns(agg)
+	if !ok || len(groupCols) == 0 {
+		return false
+	}
+	table, ok := singleScanTable(plan)
+	if !ok {
+		return false
+	}
+	sortKey := r.sortingKeyPrefixFor(table)
+	return isOrderedPrefix(groupCols, sortKey)
+}
+
+// singleAggregate returns the sole Aggregate in plan, or ok=false when there
+// is none or more than one.
+func singleAggregate(plan chplan.Node) (*chplan.Aggregate, bool) {
+	var found *chplan.Aggregate
+	count := 0
+	chplan.Walk(plan, func(n chplan.Node) bool {
+		if a, ok := n.(*chplan.Aggregate); ok {
+			found = a
+			count++
+		}
+		return true
+	})
+	if count != 1 {
+		return nil, false
+	}
+	return found, true
+}
+
+// bareGroupByColumns returns the GROUP BY keys of agg as bare column names,
+// in order. ok is false (and the slice nil) if ANY key is not a bare,
+// unqualified chplan.ColumnRef.
+func bareGroupByColumns(agg *chplan.Aggregate) (cols []string, ok bool) {
+	cols = make([]string, 0, len(agg.GroupBy))
+	for _, e := range agg.GroupBy {
+		ref, isRef := e.(*chplan.ColumnRef)
+		if !isRef || ref.Qualifier != "" {
+			return nil, false
+		}
+		cols = append(cols, ref.Name)
+	}
+	return cols, true
+}
+
+// singleScanTable returns the one physical table the plan scans, or ok=false
+// when there is not exactly one (zero Scans, a multi-table union, or two
+// Scans from a join).
+func singleScanTable(plan chplan.Node) (table string, ok bool) {
+	count := 0
+	chplan.Walk(plan, func(n chplan.Node) bool {
+		s, isScan := n.(*chplan.Scan)
+		if !isScan {
+			return true
+		}
+		// A union scan has no single sort key to be a prefix of.
+		if len(s.UnionTables) > 0 || s.Table == "" {
+			count = -1 // poison: force ineligible
+			return false
+		}
+		table = s.Table
+		count++
+		return true
+	})
+	if count != 1 {
+		return "", false
+	}
+	return table, true
+}
+
+// sortingKeyPrefixFor maps a scanned table name to its bare-column
+// sorting-key prefix using the configured schema. An unknown table (renamed,
+// or a table cerberus doesn't model the sort key for) returns nil, so the
+// prefix check fails closed and the setting is not stamped.
+func (r SettingsRules) sortingKeyPrefixFor(table string) []string {
+	switch table {
+	case r.Metrics.GaugeTable, r.Metrics.SumTable, r.Metrics.HistogramTable,
+		r.Metrics.ExpHistogramTable, r.Metrics.SummaryTable:
+		return r.Metrics.SortingKeyPrefix()
+	case r.Traces.SpansTable:
+		return r.Traces.SortingKeyPrefix()
+	case r.Logs.LogsTable:
+		return r.Logs.SortingKeyPrefix()
+	default:
+		return nil
+	}
+}
+
+// isOrderedPrefix reports whether group is a non-empty ordered prefix of
+// sortKey: len(group) <= len(sortKey) and group[i] == sortKey[i] for all i.
+// An empty group or an empty sortKey is never a valid prefix here.
+func isOrderedPrefix(group, sortKey []string) bool {
+	if len(group) == 0 || len(group) > len(sortKey) {
+		return false
+	}
+	for i := range group {
+		if group[i] != sortKey[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/engine/query_settings_rules_test.go
+++ b/internal/engine/query_settings_rules_test.go
@@ -1,0 +1,215 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// defaultRules returns SettingsRules with both flags ON and the default OTel
+// schema wired, so the eligibility + shape tests exercise the live rules.
+func defaultRules() SettingsRules {
+	return SettingsRules{
+		OptimizeAggregationInOrder: true,
+		LogCommentShape:            true,
+		Metrics:                    schema.DefaultOTelMetrics(),
+		Traces:                     schema.DefaultOTelTraces(),
+		Logs:                       schema.DefaultOTelLogs(),
+	}
+}
+
+// aggOverScan builds Aggregate(GROUP BY cols) over Scan(table).
+func aggOverScan(table string, cols ...string) *chplan.Aggregate {
+	groupBy := make([]chplan.Expr, len(cols))
+	for i, c := range cols {
+		groupBy[i] = &chplan.ColumnRef{Name: c}
+	}
+	return &chplan.Aggregate{
+		Input:    &chplan.Scan{Table: table},
+		GroupBy:  groupBy,
+		AggFuncs: []chplan.AggFunc{{Name: "sum", Args: []chplan.Expr{&chplan.ColumnRef{Name: "Value"}}, Alias: "v"}},
+	}
+}
+
+func TestEligibleForAggregationInOrder_Positive(t *testing.T) {
+	r := defaultRules()
+	cases := []struct {
+		name  string
+		table string
+		cols  []string
+	}{
+		{"metrics single key", "otel_metrics_sum", []string{"MetricName"}},
+		{"metrics two-key prefix", "otel_metrics_gauge", []string{"MetricName", "Attributes"}},
+		{"metrics full bare prefix", "otel_metrics_histogram", []string{"MetricName", "Attributes", "ServiceName"}},
+		{"traces single key", "otel_traces", []string{"ServiceName"}},
+		{"traces two-key prefix", "otel_traces", []string{"ServiceName", "SpanName"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			plan := aggOverScan(tc.table, tc.cols...)
+			if !r.eligibleForAggregationInOrder(plan) {
+				t.Errorf("GROUP BY %v on %s: want eligible", tc.cols, tc.table)
+			}
+		})
+	}
+}
+
+func TestEligibleForAggregationInOrder_Negative(t *testing.T) {
+	r := defaultRules()
+	cases := []struct {
+		name string
+		plan chplan.Node
+	}{
+		{"non-prefix key", aggOverScan("otel_metrics_sum", "Attributes")},
+		{"reordered keys", aggOverScan("otel_metrics_sum", "Attributes", "MetricName")},
+		{"superset past prefix", aggOverScan("otel_metrics_sum", "MetricName", "Attributes", "ServiceName", "TimeUnix")},
+		{"gap in prefix", aggOverScan("otel_metrics_sum", "MetricName", "ServiceName")},
+		{"empty group by", aggOverScan("otel_metrics_sum")},
+		{"logs never eligible (fn-wrapped lead key)", aggOverScan("otel_logs", "ServiceName")},
+		{"unknown table", aggOverScan("some_other_table", "MetricName")},
+		{"no aggregate", &chplan.Scan{Table: "otel_metrics_sum"}},
+		{
+			"union scan has no single sort key",
+			&chplan.Aggregate{
+				Input:   &chplan.Scan{UnionTables: []string{"otel_metrics_sum", "otel_metrics_gauge"}},
+				GroupBy: []chplan.Expr{&chplan.ColumnRef{Name: "MetricName"}},
+			},
+		},
+		{
+			"qualified group key is not bare",
+			&chplan.Aggregate{
+				Input:   &chplan.Scan{Table: "otel_metrics_sum"},
+				GroupBy: []chplan.Expr{&chplan.ColumnRef{Name: "MetricName", Qualifier: "L"}},
+			},
+		},
+		{
+			"non-column group key",
+			&chplan.Aggregate{
+				Input:   &chplan.Scan{Table: "otel_metrics_sum"},
+				GroupBy: []chplan.Expr{&chplan.FuncCall{Name: "lower", Args: []chplan.Expr{&chplan.ColumnRef{Name: "MetricName"}}}},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if r.eligibleForAggregationInOrder(tc.plan) {
+				t.Errorf("%s: want NOT eligible", tc.name)
+			}
+		})
+	}
+}
+
+// TestApply_StampsOptimizeAggregationInOrder — when eligible AND the flag is
+// on, apply stamps the setting; when the flag is off it never does (DARK).
+func TestApply_StampsOptimizeAggregationInOrder(t *testing.T) {
+	plan := aggOverScan("otel_metrics_sum", "MetricName")
+
+	on := defaultRules().apply(context.Background(), plan)
+	if got := settingValue(on, settingOptimizeAggregationInOrder); got != 1 {
+		t.Errorf("flag on + eligible: setting = %v; want 1", got)
+	}
+
+	off := SettingsRules{Metrics: schema.DefaultOTelMetrics()}.apply(context.Background(), plan)
+	if got := settingValue(off, settingOptimizeAggregationInOrder); got != nil {
+		t.Errorf("flag off: setting = %v; want absent (DARK default)", got)
+	}
+}
+
+func TestPlanShapeID_CompactAndLiteralFree(t *testing.T) {
+	// A realistic metrics shape: Project over Aggregate(3 keys) over RangeWindow
+	// over Scan, with literal-bearing nodes (metric name, label value) that must
+	// NOT appear in the id.
+	plan := &chplan.Project{
+		Input: &chplan.Aggregate{
+			GroupBy: []chplan.Expr{
+				&chplan.ColumnRef{Name: "MetricName"},
+				&chplan.ColumnRef{Name: "Attributes"},
+				&chplan.ColumnRef{Name: "ServiceName"},
+			},
+			Input: &chplan.RangeWindow{
+				Input: &chplan.Filter{
+					Input:     &chplan.Scan{Table: "otel_metrics_sum"},
+					Predicate: &chplan.LitString{V: "http_requests_total"},
+				},
+			},
+		},
+	}
+
+	id := planShapeID(plan)
+	if !strings.HasPrefix(id, shapeIDPrefix) {
+		t.Fatalf("shape id %q missing prefix %q", id, shapeIDPrefix)
+	}
+	if id != "cerb:project;agg=3;rw" {
+		t.Errorf("shape id = %q; want %q", id, "cerb:project;agg=3;rw")
+	}
+
+	// Literal-freeness: no metric name, label value, or group-by column name
+	// may leak into the id.
+	for _, literal := range []string{"http_requests_total", "MetricName", "Attributes", "ServiceName", "otel_metrics_sum"} {
+		if strings.Contains(id, literal) {
+			t.Errorf("shape id %q leaked literal %q", id, literal)
+		}
+	}
+
+	if planShapeID(nil) != "" {
+		t.Errorf("planShapeID(nil) = %q; want empty", planShapeID(nil))
+	}
+}
+
+// settingValue reads name off a per-request settings ctx via chclient's
+// public carrier reader, returning nil when absent.
+func settingValue(ctx context.Context, name string) any {
+	return chclient.QuerySettingsFromContext(ctx)[name]
+}
+
+// TestAggregationInOrder_ResultShapingSQLUnchanged proves optimize_aggregation_
+// in_order is RESULT-EQUIVALENT at the cerberus layer: stamping it changes only
+// the per-request ClickHouse SETTINGS, never the result-shaping SQL (SELECT /
+// GROUP BY / args). chsql.Emit is byte-identical for the plan whether or not
+// the setting rides the ctx, and the ONLY delta in the dispatch context is the
+// optimize_aggregation_in_order entry on the settings map.
+//
+// This is the unit-level parity proof. A FULL row-for-row parity check (run
+// the SAME query with the setting on vs off against a real ClickHouse and diff
+// the rows) needs a live server: optimize_aggregation_in_order is a server-side
+// execution-strategy knob, so chDB / the unit layer cannot observe its effect,
+// only its result-equivalence by construction. The differential roundtrip lanes
+// (test/property, compatibility/*) own that server-backed check; here we pin the
+// invariant that cerberus emits identical SQL + args and differs only in
+// settings.
+func TestAggregationInOrder_ResultShapingSQLUnchanged(t *testing.T) {
+	plan := aggOverScan("otel_metrics_sum", "MetricName")
+
+	sqlOff, argsOff, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("emit (rule off): %v", err)
+	}
+
+	// Stamp the setting on the ctx the same way execContext would, then emit.
+	onCtx := defaultRules().apply(context.Background(), plan)
+	sqlOn, argsOn, err := chsql.Emit(onCtx, plan)
+	if err != nil {
+		t.Fatalf("emit (rule on): %v", err)
+	}
+
+	if sqlOn != sqlOff {
+		t.Errorf("result-shaping SQL changed with the setting:\n off: %s\n on:  %s", sqlOff, sqlOn)
+	}
+	if fmt.Sprint(argsOn) != fmt.Sprint(argsOff) {
+		t.Errorf("bound args changed with the setting:\n off: %v\n on: %v", argsOff, argsOn)
+	}
+
+	// The only observable delta is the per-request setting on the ctx.
+	if settingValue(onCtx, settingOptimizeAggregationInOrder) != 1 {
+		t.Errorf("expected optimize_aggregation_in_order=1 on the rule-on ctx")
+	}
+	if settingValue(context.Background(), settingOptimizeAggregationInOrder) != nil {
+		t.Errorf("baseline ctx unexpectedly carries the setting")
+	}
+}

--- a/internal/schema/sortingkey.go
+++ b/internal/schema/sortingkey.go
@@ -1,0 +1,61 @@
+package schema
+
+// This file exposes each OTel-CH table's ORDER BY (sorting key) as
+// structured data, narrowed to the leading run of PLAIN COLUMN keys.
+//
+// The OTel ClickHouse Exporter DDL (the sqltemplates this repo vendors via
+// internal/schema/ddl) declares each table's ORDER BY tuple. Cerberus does
+// not otherwise need the tuple at runtime, so it is not parsed out of the
+// DDL; instead the canonical OTel-CH layout is reflected here as a typed
+// accessor keyed off the same column-name fields the rest of the schema
+// package already carries. Callers that want to reason about sort-order (the
+// optimize_aggregation_in_order eligibility check in internal/engine) read
+// these instead of re-deriving the ORDER BY from SQL text.
+//
+// IMPORTANT: only the LEADING run of bare column references is returned.
+// A sorting-key element that is a function of a column
+// (`toUnixTimestamp64Nano(TimeUnix)`, `toStartOfFiveMinutes(Timestamp)`,
+// `toDateTime(Timestamp)`) is NOT a bare column and TERMINATES the prefix:
+// optimize_aggregation_in_order can only exploit a GROUP BY that is a prefix
+// of the sort key expressed over the SAME bare columns, so a GROUP BY can
+// never legitimately match past the first function-wrapped key element. This
+// keeps every consumer conservative by construction.
+//
+// The OTel-CH ORDER BY tuples reflected here (exporter v0.152.0):
+//
+//	otel_metrics_{gauge,sum,histogram,exp_histogram,summary}
+//	    ORDER BY (MetricName, Attributes, ServiceName, toUnixTimestamp64Nano(TimeUnix))
+//	    -> bare prefix: (MetricName, Attributes, ServiceName)
+//	otel_traces
+//	    ORDER BY (ServiceName, SpanName, toDateTime(Timestamp))
+//	    -> bare prefix: (ServiceName, SpanName)
+//	otel_logs
+//	    ORDER BY (toStartOfFiveMinutes(Timestamp), ServiceName, Timestamp)
+//	    -> bare prefix: () the first key element is function-wrapped
+
+// SortingKeyPrefix returns the leading run of bare-column sorting-key
+// columns for the metrics tables, in ORDER BY order. Every metrics table
+// (gauge / sum / histogram / exp_histogram / summary) shares the same
+// ORDER BY, so the prefix is identical for all of them. The fourth key
+// element, toUnixTimestamp64Nano(TimeUnix), is function-wrapped and so is
+// excluded. Returns a fresh slice each call (callers may retain it).
+func (m Metrics) SortingKeyPrefix() []string {
+	return []string{m.MetricNameColumn, m.AttributesColumn, m.ServiceNameColumn}
+}
+
+// SortingKeyPrefix returns the leading run of bare-column sorting-key
+// columns for the spans table. The third ORDER BY element,
+// toDateTime(Timestamp), is function-wrapped and so is excluded.
+func (t Traces) SortingKeyPrefix() []string {
+	return []string{t.ServiceNameColumn, t.SpanNameColumn}
+}
+
+// SortingKeyPrefix returns the leading run of bare-column sorting-key
+// columns for the logs table. The OTel-CH logs ORDER BY leads with a
+// function-wrapped key element (toStartOfFiveMinutes(Timestamp)), so there
+// is no bare-column prefix and the result is empty: no GROUP BY can be a
+// bare-column prefix of this sort key, so optimize_aggregation_in_order is
+// never eligible for logs.
+func (Logs) SortingKeyPrefix() []string {
+	return nil
+}

--- a/internal/schema/sortingkey_test.go
+++ b/internal/schema/sortingkey_test.go
@@ -1,0 +1,49 @@
+package schema
+
+import (
+	"slices"
+	"testing"
+)
+
+// The bare-column sorting-key prefixes pin the OTel-CH ORDER BY tuples the
+// optimize_aggregation_in_order eligibility check relies on. If an upstream
+// exporter bump reorders a sort key, this test fails loudly rather than the
+// eligibility check silently stamping (or missing) the setting.
+
+func TestMetricsSortingKeyPrefix_Default(t *testing.T) {
+	got := DefaultOTelMetrics().SortingKeyPrefix()
+	want := []string{"MetricName", "Attributes", "ServiceName"}
+	if !slices.Equal(got, want) {
+		t.Errorf("metrics SortingKeyPrefix = %v; want %v", got, want)
+	}
+}
+
+func TestTracesSortingKeyPrefix_Default(t *testing.T) {
+	got := DefaultOTelTraces().SortingKeyPrefix()
+	want := []string{"ServiceName", "SpanName"}
+	if !slices.Equal(got, want) {
+		t.Errorf("traces SortingKeyPrefix = %v; want %v", got, want)
+	}
+}
+
+// Logs lead with a function-wrapped key element, so there is no bare-column
+// prefix: optimize_aggregation_in_order is never eligible for logs.
+func TestLogsSortingKeyPrefix_Empty(t *testing.T) {
+	if got := DefaultOTelLogs().SortingKeyPrefix(); len(got) != 0 {
+		t.Errorf("logs SortingKeyPrefix = %v; want empty", got)
+	}
+}
+
+// SortingKeyPrefix honours overridden column names so a custom schema's sort
+// key is reported with the operator's column names, not the OTel defaults.
+func TestMetricsSortingKeyPrefix_HonoursColumnOverrides(t *testing.T) {
+	m := DefaultOTelMetrics()
+	m.MetricNameColumn = "Name"
+	m.AttributesColumn = "Labels"
+	m.ServiceNameColumn = "Svc"
+	got := m.SortingKeyPrefix()
+	want := []string{"Name", "Labels", "Svc"}
+	if !slices.Equal(got, want) {
+		t.Errorf("overridden metrics SortingKeyPrefix = %v; want %v", got, want)
+	}
+}


### PR DESCRIPTION
Phase-0 of the ClickHouse-optimization roadmap: per-query instrumentation + settings plumbing that unblocks corpus-driven optimization, plus one conservative, result-equivalent settings win. **Everything here is safe on ClickHouse 24.8** (cerberus's current min floor) and adopts no 25.x feature. The async `query_log` reconciler and corpus persistence are **deliberately deferred** to a later Phase-1 PR.

## The four pieces

1. **`query_id` stamping (always on, observational).** Every data-plane dispatch sets the ClickHouse `query_id` to cerberus's active trace id (via `clickhouse.WithQueryID` in `queryContext`), so operators can join their SQL back to `system.query_log` on the cerberus trace id. No valid trace -> the driver generates its own id; `query_id` is never an error path.

2. **Generalised per-request settings carrier.** The single-flag `WithTSGridSetting` context value becomes a per-request `clickhouse.Settings` map (`WithQuerySetting` / `querySettingsFromContext`, public read side `QuerySettingsFromContext`), merged in `querySettings()`. `WithTSGridSetting` is now one writer into that map and its behaviour is unchanged. This is the reusable hook for all future plan-shape-gated settings, and lets one query carry multiple gated settings on one map without a second `WithSettings` wrap clobbering the memory cap.

3. **`optimize_aggregation_in_order=1` rule (DARK, `CERBERUS_OPTIMIZE_AGGREGATION_IN_ORDER`, default off).** When the post-optimize plan has a single `Aggregate` whose GROUP BY keys are all bare columns forming an ordered **prefix** of the scanned table's sorting key (read from the schema package's new `SortingKeyPrefix`), the engine stamps the setting. It is **result-equivalent** (execution strategy only) and the eligibility check is conservative: reordered / gapped / non-prefix GROUP BY, unions/joins, qualified or non-column keys, and renamed tables all fail closed. Safe on 24.8 (the setting predates the floor).

4. **`log_comment` shape id (DARK, `CERBERUS_LOG_COMMENT_SHAPE`, default off).** Stamps `log_comment` with a compact, **literal-free** cerberus shape id (`cerb:<root>[;mod...]`) -- emit-root node kind + structural modifiers (aggregate arity, range window / join / union / limit), never any literal -- so query_log rows cluster by `normalized_query_hash` and filter via `log_comment LIKE 'cerb:%'`.

## Version safety (CH 24.8)

- `query_id` / `log_comment` are free-form identifiers ClickHouse echoes into `query_log`; result-neutral.
- `optimize_aggregation_in_order` is a long-standing result-equivalent execution knob, well below the 24.8 floor.
- Both new rules ship **DARK** (default off) behind `CERBERUS_*` flags, so the default ctx is byte-identical to before.

## Tests run (all green)

- `go build ./...`, `go vet`, `golangci-lint run` (0 issues) over `internal/{chclient,config,engine,schema}` + `cmd/...`.
- Config: bool-flag matrix for both flags (default off; `1/0/true/false`; garbage rejected).
- Eligibility detector: positive prefixes (metrics/traces) + negatives (reordered, superset-past-prefix, gap, union, qualified key, non-column key, unknown table, logs fn-wrapped lead key, no-aggregate).
- Settings-map merge + copy-on-write; ts-grid + a second setting coexist with the memory cap; `query_id` derivation + dispatch-ctx stamping.
- `log_comment` shape id is compact + literal-free.
- **Parity:** asserts the `aggregation_in_order` stamp changes only the per-request settings, not the result-shaping SQL/args (`chsql.Emit` byte-identical). A full server-backed row-for-row parity check is owned by the roundtrip / property lanes (the knob is a server-side strategy chDB cannot observe).
- Existing `internal/api/...` + `cmd/...` suites: 1152 tests pass (main.go wiring unchanged behaviourally).

## Docs

- `docs/configuration.md`: new "Query instrumentation (Phase-0)" section documenting both `CERBERUS_*` flags + the always-on `query_id`.
- `docs/operations.md`: new "query_log mining" note with example mining queries (top shapes by p99 `query_duration_ms` and by `memory_usage`, GROUP BY `normalized_query_hash`, and a `log_comment`-filtered variant).

Generated with Claude Code.