### PR TITLE
fix(test): serialize chDB engine access to stop SIGABRT in result.Free under parallel roundtrip

### DIFF
--- a/test/spec/runner_chdb.go
+++ b/test/spec/runner_chdb.go
@@ -24,11 +24,35 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	_ "github.com/chdb-io/chdb-go/chdb/driver"
 )
+
+// chdbEngineMu serializes ALL access to the chDB engine across the whole
+// test process.
+//
+// chDB / libchdb is an EMBEDDED ClickHouse: a single native engine is
+// shared by every `sql.Open("chdb", "")` in the process (the empty-DSN
+// sessions are NOT isolated — see applySeed's "chdb-go shares one engine
+// across a process" note). That engine is NOT thread-safe for concurrent
+// in-process execution. The round-trip suite runs fixtures under
+// t.Parallel() (see roundtrip_chdb_test.go) and spec.Walk fans each
+// fixture into a t.Run subtest, so without serialization two goroutines
+// can drive queries — and, worse, free native result state — at the same
+// time. The observed failure is an intermittent
+//
+//	SIGABRT: abort / signal arrived during cgo execution
+//
+// inside chdb-purego.(*result).Free, which fires when a *sql.Rows is
+// closed and when a *sql.DB is closed (driver teardown). To make this
+// safe, every chDB engine call — Open/Ping/Exec(SET), seed Exec, Query,
+// row iteration, rows.Close, AND the per-case db.Close — runs under this
+// mutex. Only the parse / lower / SQL-build work of OTHER cases stays
+// parallel; the engine span itself is single-threaded.
+var chdbEngineMu sync.Mutex
 
 // chdbEOFSentinel is the spurious end-of-iteration error chdb-go's
 // parquet driver returns instead of io.EOF (see chdb-go v1.11.0's
@@ -842,7 +866,17 @@ func openChDB(t *testing.T) *sql.DB {
 	if err != nil {
 		t.Fatalf("open chdb: %v", err)
 	}
-	t.Cleanup(func() { _ = db.Close() })
+	// db.Close tears down native engine state (chdb-purego result Free),
+	// so it must not race another case's engine call. The cleanup runs
+	// AFTER RunRoundTrip returns and has released chdbEngineMu, so it
+	// takes the lock itself here. (openChDB itself is always called with
+	// chdbEngineMu already held by RunRoundTrip, hence no lock around the
+	// Open/Ping/Exec below.)
+	t.Cleanup(func() {
+		chdbEngineMu.Lock()
+		defer chdbEngineMu.Unlock()
+		_ = db.Close()
+	})
 	if err := db.Ping(); err != nil {
 		t.Fatalf("ping chdb: %v", err)
 	}
@@ -1223,6 +1257,19 @@ func RunRoundTrip(t *testing.T, c *Case) {
 	if strings.TrimSpace(rt.SQL) == "" {
 		t.Fatalf("fixture %s has seed/expected_rows but missing sql section", c.Name)
 	}
+
+	// Acquire the process-global chDB engine lock for the FULL engine
+	// span of this case: open/ping/seed, query, row iteration, and
+	// rows.Close (whose driver teardown calls native result Free — the
+	// site of the SIGABRT under parallel cases). The unlock is deferred
+	// FIRST so it runs LAST (after the deferred rows.Close below, defers
+	// being LIFO), keeping the lock held across the entire result
+	// lifecycle. The interleaved SQL-build helpers below are pure string
+	// work; holding the lock across them costs microseconds and keeps the
+	// scope coarse and deadlock-free. db.Close runs later, in t.Cleanup,
+	// which re-acquires this lock itself.
+	chdbEngineMu.Lock()
+	defer chdbEngineMu.Unlock()
 
 	db := openChDB(t)
 	applySeed(t, db, rt.Seed)


### PR DESCRIPTION
## Root cause

chDB / libchdb is an **embedded ClickHouse**: a single native engine is shared **process-wide** by every `sql.Open("chdb", "")`. The empty-DSN sessions are NOT isolated -- the harness itself documents this in `applySeed`: *"chdb-go shares one engine across a process."* That engine is **not thread-safe** for concurrent in-process execution.

`TestRoundTripChDB` runs with `t.Parallel()` (`test/spec/promql/roundtrip_chdb_test.go:24`), and `spec.Walk` fans every `*.txtar` fixture into its own `t.Run` subtest. Parallel fixtures therefore drive **concurrent chDB queries** and -- worse -- **concurrently free native result state** on the one shared engine. The result is an intermittent

```
SIGABRT: abort / signal arrived during cgo execution
```

inside `chdb-io/chdb-go/chdb-purego.(*result).Free`. This is a **native crash, not a golden mismatch and not a re-runnable flake**. `Free` fires when a `*sql.Rows` is closed and when a `*sql.DB` is closed (driver teardown), so the unsafe window spans the whole result lifecycle, including the per-case `db.Close()` registered via `t.Cleanup`.

## Fix

A package-level `sync.Mutex` (`chdbEngineMu`) that serializes **all** chDB engine access in the round-trip harness:

- **`RunRoundTrip`** takes the lock for the FULL engine span of each case -- `openChDB` (open/ping/`SET`), `applySeed` Execs, `db.Query`, row iteration, and `rows.Close`. The unlock is `defer`-ed *first* so it runs *last* (defers are LIFO), keeping the lock held across the deferred `rows.Close` -- i.e. across the native `Free` in driver teardown.
- **`openChDB`'s `t.Cleanup`** (the per-case `db.Close`) re-acquires the lock itself, because cleanup runs *after* `RunRoundTrip` has released it. `db.Close` also frees native state, so it must not race another case.
- The interleaved SQL-build helpers (`substituteNow64`, `expandStarProjection`, `rewriteMapProjections`, ...) are pure string work; holding the lock across them costs microseconds and keeps the scope **coarse and deadlock-free**.

`t.Parallel()` is **kept** -- a mutex suffices, so non-engine parallelism (parse/lower/SQL-build of other cases) is preserved.

## Access points serialized

| Site | Call | Coverage |
|------|------|----------|
| `openChDB` | `sql.Open` / `db.Ping` / `db.Exec(SET ...)` | lock held by `RunRoundTrip` |
| `applySeed` | `db.Exec(stmt)` per statement | lock held by `RunRoundTrip` |
| `RunRoundTrip` | `db.Query`, `rows.Next/Scan/Columns/Err`, `rows.Close` | lock held across full span |
| `openChDB` `t.Cleanup` | `db.Close` (native `Free`) | lock re-acquired inside cleanup |

The three parallel callers in the suite are only the per-package roundtrip tests (`promql`/`logql`/`traceql`), each in its own package/test binary; the sweep test (`TestEvalInstantWindowSweep`) is non-parallel and runs to completion before the parallel roundtrip resumes, so it shares its `db` sequentially.

## Evidence

- `for i in $(seq 1 30); do go test -tags chdb -count=1 ./test/spec/promql/...; done` -> **30/30 clean** (391 fixtures each).
- `go test -tags chdb -p 4 -parallel 8 ./test/spec/...` -> **739 pass**, run **8/8 clean** (max-contention cross-package).
- `go build ./...` + `-tags chdb`, `go vet -tags chdb`, `golangci-lint run` (default + `--build-tags chdb`) -> **0 issues**, `gofumpt`/`gofmt` clean.
- `go-arch-lint check` -> OK; all 5 forbid-skip scans + self-test (17/17) pass.
- Non-chdb `go test ./test/spec/...` -> pass.

> Go's `-race` cannot observe the CGO race, so the evidence is the serialization argument (no two goroutines touch the engine concurrently, including `Free`) plus the repeated clean runs against the previously-intermittent abort.

All fixtures still PASS -- serialization does not change results.