### PR TITLE
refactor(promql): pure polymorphic range-lowering dispatch (harden #985, no nil-check)

### DIFF
--- a/cmd/bench-report/matrix_chdb.go
+++ b/cmd/bench-report/matrix_chdb.go
@@ -250,7 +250,7 @@ func lowerMatrixPlan(ctx context.Context, tsgrid bool) (chplan.Node, error) {
 	}
 	var lowerers promql.RangeLowerers
 	if tsgrid {
-		lowerers.Rate = promql.NativeRateLowerer{}
+		lowerers.Rate = promql.NativeRateLowerer{Fallback: promql.FanoutRateLowerer{}}
 	}
 	plan, err := promql.LowerAtRangeOpts(ctx, expr, schema.DefaultOTelMetrics(),
 		matrixStart, matrixEnd, matrixStep, promql.LowerOpts{Lowerers: lowerers})

--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -393,18 +393,29 @@ func newPromHandler(client *chclient.Client, cfg config.Config, optSet chopt.Ena
 // for the ClickHouse-native timeSeries*ToGrid family from the resolved
 // optimization EnabledSet. The feature/version decision is made HERE, ONCE, at
 // boot (optSet was produced by the single boot-time version probe in
-// resolveCHOptimizations): each native strategy is wired only when its feature
-// resolved, and left nil (the fan-out fallback) otherwise. The features are
+// resolveCHOptimizations) and is the ONLY place the feature is read: each field
+// is wired to a CONCRETE non-nil strategy —
+//
+//	rate      = enabled ? NativeRateLowerer{Fallback: FanoutRateLowerer{}} : FanoutRateLowerer{}
+//	staleness = enabled ? NativeStalenessLowerer{Fallback: FanoutStalenessLowerer{}} : FanoutStalenessLowerer{}
+//
+// The fan-out impl is the concrete DEFAULT (never nil), and the native impl
+// embeds it as the fallback for shapes it cannot handle. The features are
 // independent, so the table composes per-function — native rate can be on while
 // native staleness is off, and vice versa. The per-query lowering then
-// dispatches through this table with NO feature-flag or server-version read.
+// dispatches through this table as a plain interface method call: NO
+// feature/version read, NO nil/presence check.
 func nativeRangeLowerers(optSet chopt.EnabledSet) promql.RangeLowerers {
 	var l promql.RangeLowerers
 	if optSet.Has(chopt.FeatureTSGridRange) {
-		l.Rate = promql.NativeRateLowerer{}
+		l.Rate = promql.NativeRateLowerer{Fallback: promql.FanoutRateLowerer{}}
+	} else {
+		l.Rate = promql.FanoutRateLowerer{}
 	}
 	if optSet.Has(chopt.FeatureTSGridResample) {
-		l.Staleness = promql.NativeStalenessLowerer{}
+		l.Staleness = promql.NativeStalenessLowerer{Fallback: promql.FanoutStalenessLowerer{}}
+	} else {
+		l.Staleness = promql.FanoutStalenessLowerer{}
 	}
 	return l
 }

--- a/internal/chsql/range_window_native_chdb_test.go
+++ b/internal/chsql/range_window_native_chdb_test.go
@@ -213,7 +213,7 @@ func runDualEmit(t *testing.T, db *sql.DB, native, optimize bool) map[gridCell]f
 	rangeEnd := rangeStart.Add(5 * time.Minute)
 	var lowerers promql.RangeLowerers
 	if native {
-		lowerers.Rate = promql.NativeRateLowerer{}
+		lowerers.Rate = promql.NativeRateLowerer{Fallback: promql.FanoutRateLowerer{}}
 	}
 	plan, err := promql.LowerAtRangeOpts(context.Background(), expr, schema.DefaultOTelMetrics(),
 		rangeStart, rangeEnd, 30*time.Second,

--- a/internal/chsql/range_window_resample_chdb_test.go
+++ b/internal/chsql/range_window_resample_chdb_test.go
@@ -166,7 +166,7 @@ func runResampleEmit(t *testing.T, db *sql.DB, native, optimize bool) map[resamp
 	rangeEnd := rangeStart.Add(10 * time.Minute)
 	var lowerers promql.RangeLowerers
 	if native {
-		lowerers.Staleness = promql.NativeStalenessLowerer{}
+		lowerers.Staleness = promql.NativeStalenessLowerer{Fallback: promql.FanoutStalenessLowerer{}}
 	}
 	plan, err := promql.LowerAtRangeOpts(context.Background(), expr, schema.DefaultOTelMetrics(),
 		rangeStart, rangeEnd, time.Minute,

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -42,7 +42,7 @@ var tracer = otel.Tracer("github.com/tsouza/cerberus/internal/promql")
 func Lower(ctx context.Context, expr parser.Expr, s schema.Metrics) (chplan.Node, error) {
 	_, span := tracer.Start(ctx, cerbtrace.SpanLower, trace.WithAttributes(cerbtrace.AttrQL.String("promql")))
 	defer span.End()
-	plan, err := lower(expr, s, lowerCtx{})
+	plan, err := lower(expr, s, lowerCtx{lowerers: RangeLowerers{}.withDefaults()})
 	if err != nil {
 		span.RecordError(err)
 		return nil, err
@@ -93,13 +93,17 @@ type LowerOpts struct {
 	// Lowerers is the BOOT-WIRED polymorphic dispatch table for the
 	// ClickHouse-native timeSeries*ToGrid family. cmd/cerberus builds it ONCE
 	// at boot from the resolved chopt.EnabledSet (per-function: native rate and
-	// native staleness are independent) and threads it through the prom handler
-	// -> lang adapter into here. The zero value (nil strategy fields) is the
-	// all-fan-out default, so a caller that does not opt in lowers
+	// native staleness are independent), wiring each field to a CONCRETE
+	// strategy (the native impl with an embedded fan-out fallback, or the
+	// fan-out impl directly), and threads it through the prom handler -> lang
+	// adapter into here. The zero value (nil strategy fields) is the
+	// "no caller opted in" sentinel, resolved to the all-fan-out table at the
+	// lowering-entry seam, so a caller that does not opt in lowers
 	// byte-identically to the pre-seam path. The per-query lowering dispatches
-	// through this table with NO feature-flag / version conditional — the only
-	// per-query decisions are AST node-type and query-SHAPE eligibility, which
-	// live inside each strategy. See [RangeLowerers].
+	// through this table as a plain interface method call — NO feature-flag /
+	// version conditional AND NO nil/presence check; the only per-query
+	// decisions are AST node-type and query-SHAPE eligibility, which live inside
+	// each strategy. See [RangeLowerers].
 	Lowerers RangeLowerers
 }
 
@@ -115,7 +119,7 @@ func LowerAtRangeOpts(ctx context.Context, expr parser.Expr, s schema.Metrics, s
 		start:    start,
 		end:      end,
 		step:     step,
-		lowerers: opts.Lowerers,
+		lowerers: opts.Lowerers.withDefaults(),
 	})
 	if err != nil {
 		span.RecordError(err)
@@ -145,7 +149,7 @@ func LowerAtRangeOpts(ctx context.Context, expr parser.Expr, s schema.Metrics, s
 func LowerMetadataRange(ctx context.Context, expr parser.Expr, s schema.Metrics, start, end time.Time) (chplan.Node, error) {
 	_, span := tracer.Start(ctx, cerbtrace.SpanLower, trace.WithAttributes(cerbtrace.AttrQL.String("promql")))
 	defer span.End()
-	plan, err := lower(expr, s, lowerCtx{start: start, end: end, metadataFullRange: true})
+	plan, err := lower(expr, s, lowerCtx{start: start, end: end, metadataFullRange: true, lowerers: RangeLowerers{}.withDefaults()})
 	if err != nil {
 		span.RecordError(err)
 		return nil, err
@@ -1130,17 +1134,18 @@ func wrapRangeLatestPerSeries(scan chplan.Node, pred chplan.Expr, anchor evalAnc
 		rawSide = &chplan.Filter{Input: scan, Predicate: pred}
 	}
 
-	// BOOT-WIRED native dispatch: substitute the ClickHouse-native
-	// timeSeriesResampleToGridWithStaleness lowering for this range-mode
-	// staleness shape when the ts_grid_resample strategy was wired at boot.
-	// The decision was made ONCE at boot and is encoded in the injected
-	// ctx.lowerers table — there is NO feature-flag / version read here. A
-	// fan-out-only boot wiring (nil strategy) returns nil and the fan-out
-	// RangeLWR below is kept. The native node produces the IDENTICAL canonical
-	// 4-column Sample row shape as RangeLWR (proven on the chDB substrate by
-	// the resample dual-emit parity test), so the surrounding plan tree is
-	// unaffected by the substitution.
-	if native := ctx.lowerers.lowerStaleness(stalenessLowerInput{
+	// BOOT-WIRED native dispatch (PURE polymorphic — no branching here): hand
+	// the resolved staleness input to the boot-wired staleness strategy. The
+	// decision of WHETHER the native timeSeriesResampleToGridWithStaleness path
+	// is active was made ONCE at boot (the ts_grid_resample feature) and is
+	// encoded in the injected ctx.lowerers.Staleness impl — there is NO
+	// feature-flag / version read AND NO nil/presence check here. The strategy
+	// ALWAYS returns a valid lowering: the native impl emits the resample node,
+	// the concrete fan-out impl emits the RangeLWR. Both produce the IDENTICAL
+	// canonical 4-column Sample row shape (proven on the chDB substrate by the
+	// resample dual-emit parity test), so the surrounding plan tree is
+	// unaffected by which strategy is wired.
+	return ctx.lowerers.Staleness.LowerStaleness(stalenessLowerInput{
 		input:         rawSide,
 		start:         ctx.start.UTC(),
 		end:           ctx.end.UTC(),
@@ -1151,22 +1156,7 @@ func wrapRangeLatestPerSeries(scan chplan.Node, pred chplan.Expr, anchor evalAnc
 		attributesCol: s.AttributesColumn,
 		timestampCol:  s.TimestampColumn,
 		valueCol:      s.ValueColumn,
-	}); native != nil {
-		return native
-	}
-
-	return &chplan.RangeLWR{
-		Input:         rawSide,
-		Start:         ctx.start.UTC(),
-		End:           ctx.end.UTC(),
-		Step:          ctx.step,
-		Lookback:      instantLookback,
-		Offset:        anchor.Offset,
-		MetricNameCol: s.MetricNameColumn,
-		AttributesCol: s.AttributesColumn,
-		TimestampCol:  s.TimestampColumn,
-		ValueCol:      s.ValueColumn,
-	}
+	})
 }
 
 // wrapRangeAbsoluteAtBroadcast is the range-mode lowering for a bare
@@ -1866,6 +1856,12 @@ func lowerRangeVectorCall(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chpla
 	}
 	rangeMode := ctx.step > 0 && !ctx.start.IsZero() && !ctx.end.IsZero()
 	pinned := hasAbsoluteAt(vs)
+	// node is the lowering that flows to the name-preservation seam below.
+	// Outside range mode it is the fan-out RangeWindow rw; in plain range mode
+	// the boot-wired rate strategy re-derives it (native or fan-out). The
+	// name-preservation wrap keys off c.Func.Name (PromQL semantics), never off
+	// the dispatch, so the two concerns compose without a dispatch-site branch.
+	node := chplan.Node(rw)
 	switch {
 	case rangeMode && pinned:
 		// `@`-pinned range-vector call (`rate(m[5m] @ <ts>)`,
@@ -1899,26 +1895,31 @@ func lowerRangeVectorCall(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chpla
 		rw.Step = ctx.step
 		rw.OuterRange = ctx.end.Sub(ctx.start)
 
-		// BOOT-WIRED native dispatch: substitute the ClickHouse-native
-		// timeSeriesRateToGrid lowering for the eligible rate query_range
-		// shape. The decision of WHETHER the native path is active was made
-		// ONCE at boot (the ts_grid_range feature) and is encoded in the
-		// injected ctx.lowerers table — there is NO feature-flag or version
-		// read here. The strategy itself only checks intrinsic SHAPE
-		// eligibility (rate func, materialised grid, plain Scan/Filter input);
-		// a shape it cannot handle (or a fan-out-only boot wiring) returns nil
-		// and the fan-out RangeWindow below is kept. The native node carries
-		// the same Func/Range/Step/Start/End/Offset/columns/GroupBy as the
-		// fan-out RangeWindow above — only the emitter differs — and produces
-		// the identical per-(series, anchor) row shape (proven byte-identical
-		// on the chDB substrate; see
+		// BOOT-WIRED native dispatch (PURE polymorphic — no branching here):
+		// hand the fan-out RangeWindow to the boot-wired rate strategy. The
+		// decision of WHETHER the native path is active was made ONCE at boot
+		// (the ts_grid_range feature) and is encoded in the injected
+		// ctx.lowerers.Rate impl — there is NO feature-flag / version read AND
+		// NO nil/presence check here. The strategy ALWAYS returns a valid
+		// lowering: the native impl emits timeSeriesRateToGrid for a
+		// shape-eligible rate window (rate func, materialised grid, plain
+		// Scan/Filter input) and delegates to its embedded fan-out fallback for
+		// any other shape; the fan-out impl returns this RangeWindow unchanged.
+		// All intrinsic SHAPE / AST-node dispatch lives INSIDE the impl. The
+		// native node carries the same Func/Range/Step/Start/End/Offset/columns/
+		// GroupBy as the fan-out RangeWindow — only the emitter differs — and
+		// produces the identical per-(series, anchor) row shape (proven
+		// byte-identical on the chDB substrate; see
 		// test/spec/promql/native_rate_range_step.txtar and the dual-emit
-		// parity test). `rate` drops `__name__` (it is a derived sample), so
-		// the native node returns directly here, bypassing the
-		// last/first_over_time name-preservation wrap below.
-		if native := ctx.lowerers.lowerRate(rw, s); native != nil {
-			return native, nil
-		}
+		// parity test).
+		//
+		// For a non-rate window (increase / delta / *_over_time) the strategy
+		// returns rw unchanged, so node stays rw and the last/first_over_time
+		// name-preservation wrap below applies exactly as before. For rate the
+		// returned node IS the lowering (native or fan-out RangeWindow); rate
+		// drops `__name__`, so it never matches the name-preservation wrap and
+		// flows through as-is.
+		node = ctx.lowerers.Rate.LowerRate(rw, s)
 	}
 	// `last_over_time` and `first_over_time` preserve `__name__`
 	// per Prometheus semantics — they're position-shift reducers that
@@ -1948,17 +1949,18 @@ func lowerRangeVectorCall(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chpla
 	if c.Func.Name == "last_over_time" || c.Func.Name == "first_over_time" {
 		return wrapRangeWindowPreserveName(rw, s, metricNameFromMatchers(vs.LabelMatchers)), nil
 	}
-	return rw, nil
+	return node, nil
 }
 
 // nativeTSGridRateNode returns a chplan.RangeWindowNative when rw is a
 // SHAPE-eligible `rate(<counter>[<range>])` query_range RangeWindow; otherwise
-// nil (the caller keeps the fan-out RangeWindow). This is the intrinsic
-// query-shape eligibility predicate ONLY — it reads NO feature flag or server
-// version. The boot decision of whether the native path is active lives in the
-// injected RangeLowerers table (a nil rate strategy never calls this), so this
-// function is a pure shape classifier and stays on the per-query path under the
-// no-feature-branch rule. The predicate is intentionally narrow — every clause
+// nil (the NativeRateLowerer then delegates to its embedded fan-out fallback).
+// This is the intrinsic query-shape eligibility predicate ONLY — it reads NO
+// feature flag or server version. The boot decision of whether the native path
+// is active lives in WHICH strategy cmd/cerberus wired (NativeRateLowerer vs
+// FanoutRateLowerer); this function is a pure shape classifier called only from
+// inside NativeRateLowerer.LowerRate, so it stays on the per-query path under
+// the no-feature-branch rule. The predicate is intentionally narrow — every clause
 // that fails sends the query down the unchanged fan-out path:
 //
 //   - rw.Func must be "rate". increase / delta have no proven-equivalent

--- a/internal/promql/lower_strategy.go
+++ b/internal/promql/lower_strategy.go
@@ -12,10 +12,13 @@ import (
 // to use (native aggregate vs. the generic SQL fan-out) is made ONCE at boot —
 // from the already-resolved chopt.EnabledSet — and injected as a RangeLowerers
 // table. The per-query lowering path then calls through that table with NO
-// feature-flag or server-version conditional: the only per-query decisions are
-// AST node-type dispatch and query-SHAPE eligibility, which live INSIDE the
-// chosen strategy (a shape it can't handle delegates to the fan-out fallback by
-// returning nil).
+// feature-flag or server-version conditional, AND NO nil/presence check on the
+// strategy: every field is ALWAYS a concrete non-nil impl, so the dispatch site
+// is a plain interface method call. The only per-query decisions are AST
+// node-type dispatch and query-SHAPE eligibility, which live INSIDE the chosen
+// strategy: a native impl that cannot handle a shape DELEGATES to its embedded
+// fan-out fallback (never returns nil), so the interface method ALWAYS returns
+// a valid lowering.
 //
 // Why a per-FUNCTION table rather than one global bool: the features are
 // independent (native rate may be on while native resample is off, and vice
@@ -25,32 +28,46 @@ import (
 // handler -> lang adapter -> LowerOpts. The promql package cannot import chopt
 // (the dependency-cone rule), so the strategy TYPES live here and the
 // feature/version READ lives at boot — exactly where the rule requires it.
+//
+// Wiring shape (at boot, the ONLY place the feature read happens):
+//
+//	rate = enabled ? NativeRateLowerer{Fallback: FanoutRateLowerer{}} : FanoutRateLowerer{}
+//
+// The fan-out impl is the concrete DEFAULT; it is never nil. The zero value of
+// RangeLowerers carries nil fields, which is the "no caller opted in" sentinel
+// resolved to the all-fan-out table by [RangeLowerers.withDefaults] at the
+// single lowering-entry seam — never at the per-query dispatch site.
 
-// RateLowerer lowers an eligible range-mode rate RangeWindow to its native
-// chplan node, or returns nil to fall through to the generic fan-out
-// (RangeWindow). The shape eligibility (rate-over-counter with a materialised
-// grid and a plain Scan/Filter input) is intrinsic and lives inside the
-// implementation; it is NOT a feature-flag branch.
+// RateLowerer lowers a range-mode rate RangeWindow to a chplan node. It ALWAYS
+// returns a valid lowering: the native impl emits the native node for a
+// shape-eligible window and delegates to its embedded fan-out fallback for any
+// other shape; the fan-out impl returns the generic RangeWindow directly. The
+// shape eligibility (rate-over-counter with a materialised grid and a plain
+// Scan/Filter input) is intrinsic and lives inside the implementation; it is
+// NOT a feature-flag branch.
 type RateLowerer interface {
-	// LowerRate returns a non-nil RangeWindowNative for a shape it handles, or
-	// nil to keep the caller's fan-out RangeWindow.
+	// LowerRate returns the chplan node for rw — the native RangeWindowNative
+	// for a shape the impl handles, or the fan-out lowering otherwise. It never
+	// returns nil.
 	LowerRate(rw *chplan.RangeWindow, s schema.Metrics) chplan.Node
 }
 
-// StalenessLowerer lowers an eligible range-mode bare instant-vector selection
-// (the staleness shape) to its native chplan node, or returns nil to fall
-// through to the generic fan-out (RangeLWR). The build closure carries the
-// already-resolved scan/pred/anchor/grid for the selector; the strategy reads
-// only intrinsic shape from it (never a feature flag).
+// StalenessLowerer lowers a range-mode bare instant-vector selection (the
+// staleness shape) to a chplan node. It ALWAYS returns a valid lowering: the
+// native impl emits the native resample node and the fan-out impl emits the
+// generic RangeLWR. The build closure carries the already-resolved
+// scan/pred/anchor/grid for the selector; the strategy reads only intrinsic
+// shape from it (never a feature flag).
 type StalenessLowerer interface {
-	// LowerStaleness returns a non-nil RangeWindowResample for a shape it
-	// handles, or nil to keep the caller's fan-out RangeLWR.
+	// LowerStaleness returns the chplan node for in — the native
+	// RangeWindowResample for a shape the impl handles, or the fan-out RangeLWR
+	// otherwise. It never returns nil.
 	LowerStaleness(in stalenessLowerInput) chplan.Node
 }
 
 // stalenessLowerInput carries the resolved inputs the range-mode staleness wrap
 // has already computed (the matchers-filtered scan, the eval grid, the offset,
-// and the schema column names), so a native strategy can build the resample
+// and the schema column names), so a strategy can build the resample / RangeLWR
 // node without re-deriving them. It is the intrinsic SHAPE description — no
 // feature/version state rides here.
 type stalenessLowerInput struct {
@@ -68,72 +85,113 @@ type stalenessLowerInput struct {
 }
 
 // RangeLowerers is the boot-wired dispatch table the lowering reads. Each field
-// is the concrete strategy for one promql function family, decided once at
-// boot. A nil field means "fan-out only" for that family — the zero value of
-// RangeLowerers is therefore the all-fan-out default, so any caller that does
-// not opt in (every path but the query_range handler) lowers byte-identically
-// to the pre-seam behaviour.
+// is the CONCRETE strategy for one promql function family, decided once at
+// boot. Every field is ALWAYS non-nil on the lowering path — a fan-out-only
+// deployment wires the concrete fan-out impl, NOT nil. The zero value (nil
+// fields) is the "no caller opted in" sentinel, resolved to the all-fan-out
+// table by [withDefaults] at the single lowering-entry seam; the per-query
+// dispatch then calls the interface method directly, with no nil/presence
+// check.
 type RangeLowerers struct {
-	// Rate handles eligible range-mode rate(...) shapes. Nil => fan-out only.
+	// Rate handles range-mode rate(...) shapes. Concrete fan-out impl when the
+	// native path is off; never nil on the lowering path.
 	Rate RateLowerer
-	// Staleness handles eligible range-mode bare instant-vector selection
-	// (staleness) shapes. Nil => fan-out only.
+	// Staleness handles range-mode bare instant-vector selection (staleness)
+	// shapes. Concrete fan-out impl when the native path is off; never nil on
+	// the lowering path.
 	Staleness StalenessLowerer
 }
 
-// lowerRate dispatches through the boot-wired rate strategy when one is wired,
-// else returns nil (the caller keeps its fan-out RangeWindow). This is the
-// per-query seam: NO feature flag is read here — the strategy presence already
-// encodes the boot decision.
-func (l RangeLowerers) lowerRate(rw *chplan.RangeWindow, s schema.Metrics) chplan.Node {
+// withDefaults returns a copy of l with any nil strategy field filled with its
+// concrete fan-out impl. This is the SINGLE normalization seam (called once at
+// the lowering entry, never per query) that turns the zero-value
+// "no caller opted in" sentinel into the all-fan-out table. After this, every
+// field is a concrete non-nil impl and the per-query dispatch is a plain
+// interface method call with no nil check.
+func (l RangeLowerers) withDefaults() RangeLowerers {
 	if l.Rate == nil {
-		return nil
+		l.Rate = FanoutRateLowerer{}
 	}
-	return l.Rate.LowerRate(rw, s)
+	if l.Staleness == nil {
+		l.Staleness = FanoutStalenessLowerer{}
+	}
+	return l
 }
 
-// lowerStaleness dispatches through the boot-wired staleness strategy when one
-// is wired, else returns nil (the caller keeps its fan-out RangeLWR). Per-query
-// seam: NO feature flag is read here.
-func (l RangeLowerers) lowerStaleness(in stalenessLowerInput) chplan.Node {
-	if l.Staleness == nil {
-		return nil
-	}
-	return l.Staleness.LowerStaleness(in)
+// FanoutRateLowerer is the concrete DEFAULT RateLowerer: it returns the generic
+// fan-out RangeWindow unchanged. It is the fallback the native impl embeds AND
+// the strategy a fan-out-only deployment wires directly, so the dispatch site
+// never needs a nil check.
+type FanoutRateLowerer struct{}
+
+// LowerRate returns the fan-out RangeWindow rw unchanged.
+func (FanoutRateLowerer) LowerRate(rw *chplan.RangeWindow, _ schema.Metrics) chplan.Node {
+	return rw
 }
 
 // NativeRateLowerer is the boot-wired RateLowerer that emits the native
 // timeSeriesRateToGrid lowering (a chplan.RangeWindowNative) for shape-eligible
 // rate range-windows. cmd/cerberus wires it ONLY when chopt resolved the
-// ts_grid_range feature at boot. It embeds no fallback: a shape it cannot
-// handle returns nil and the caller keeps the fan-out — the embedded-fallback
-// composition is the RangeLowerers table itself (a nil strategy is the
-// fan-out).
-type NativeRateLowerer struct{}
+// ts_grid_range feature at boot. It embeds a concrete Fallback (the fan-out
+// impl): a shape it cannot handle delegates to Fallback rather than returning
+// nil, so the interface method ALWAYS yields a valid lowering and the dispatch
+// site stays branch-free.
+type NativeRateLowerer struct {
+	// Fallback is the concrete lowerer for shapes the native path cannot
+	// handle. Boot wires it to FanoutRateLowerer{}.
+	Fallback RateLowerer
+}
 
 // LowerRate returns a RangeWindowNative for an eligible range-mode rate shape,
-// or nil otherwise. The eligibility predicate is the intrinsic SHAPE check
-// (rate func, materialised grid, plain Scan/Filter input) — see
-// nativeTSGridRateNode.
-func (NativeRateLowerer) LowerRate(rw *chplan.RangeWindow, s schema.Metrics) chplan.Node {
-	if n := nativeTSGridRateNode(rw, s); n != nil {
-		return n
+// or delegates to the embedded Fallback otherwise. The eligibility predicate is
+// the intrinsic SHAPE check (rate func, materialised grid, plain Scan/Filter
+// input) — see nativeTSGridRateNode.
+func (n NativeRateLowerer) LowerRate(rw *chplan.RangeWindow, s schema.Metrics) chplan.Node {
+	if native := nativeTSGridRateNode(rw, s); native != nil {
+		return native
 	}
-	return nil
+	return n.Fallback.LowerRate(rw, s)
+}
+
+// FanoutStalenessLowerer is the concrete DEFAULT StalenessLowerer: it builds the
+// generic fan-out RangeLWR from the resolved staleness input. It is the
+// fallback the native impl embeds AND the strategy a fan-out-only deployment
+// wires directly.
+type FanoutStalenessLowerer struct{}
+
+// LowerStaleness builds the fan-out RangeLWR node from in.
+func (FanoutStalenessLowerer) LowerStaleness(in stalenessLowerInput) chplan.Node {
+	return &chplan.RangeLWR{
+		Input:         in.input,
+		Start:         in.start,
+		End:           in.end,
+		Step:          in.step,
+		Lookback:      in.lookback,
+		Offset:        in.offset,
+		MetricNameCol: in.metricNameCol,
+		AttributesCol: in.attributesCol,
+		TimestampCol:  in.timestampCol,
+		ValueCol:      in.valueCol,
+	}
 }
 
 // NativeStalenessLowerer is the boot-wired StalenessLowerer that emits the
 // native timeSeriesResampleToGridWithStaleness lowering (a
 // chplan.RangeWindowResample). cmd/cerberus wires it ONLY when chopt resolved
-// the ts_grid_resample feature at boot. A shape it cannot handle returns nil
-// and the caller keeps the fan-out RangeLWR.
-type NativeStalenessLowerer struct{}
+// the ts_grid_resample feature at boot. It embeds a concrete Fallback (the
+// fan-out impl) for future shape carve-outs, so the interface method always
+// yields a valid lowering and the dispatch site stays branch-free.
+type NativeStalenessLowerer struct {
+	// Fallback is the concrete lowerer for shapes the native path cannot
+	// handle. Boot wires it to FanoutStalenessLowerer{}.
+	Fallback StalenessLowerer
+}
 
 // LowerStaleness returns a RangeWindowResample for the (already shape-validated
 // by the caller) range-mode staleness input. The caller only reaches the
-// staleness seam in range mode over a non-@-pinned bare selector, so the
-// strategy builds the node directly; the nil-return path is reserved for future
-// shape carve-outs without changing the seam contract.
+// staleness seam in range mode over a non-@-pinned bare selector, so the native
+// shape always applies; the embedded Fallback is reserved for future shape
+// carve-outs without changing the seam contract.
 func (NativeStalenessLowerer) LowerStaleness(in stalenessLowerInput) chplan.Node {
 	return &chplan.RangeWindowResample{
 		Input:         in.input,

--- a/internal/promql/lower_test.go
+++ b/internal/promql/lower_test.go
@@ -111,10 +111,10 @@ func TestLower(t *testing.T) {
 				// so every existing fixture stays byte-identical.
 				var lowerers promql.RangeLowerers
 				if _, native := c.Section("experimental_ts_grid_range"); native {
-					lowerers.Rate = promql.NativeRateLowerer{}
+					lowerers.Rate = promql.NativeRateLowerer{Fallback: promql.FanoutRateLowerer{}}
 				}
 				if _, resample := c.Section("experimental_ts_grid_resample"); resample {
-					lowerers.Staleness = promql.NativeStalenessLowerer{}
+					lowerers.Staleness = promql.NativeStalenessLowerer{Fallback: promql.FanoutStalenessLowerer{}}
 				}
 				plan, err = promql.LowerAtRangeOpts(context.Background(), expr, s, rangeStart, rangeEnd, stepDur,
 					promql.LowerOpts{Lowerers: lowerers})

--- a/test/perf/native_scan_projection_chdb_test.go
+++ b/test/perf/native_scan_projection_chdb_test.go
@@ -133,7 +133,7 @@ func innerScanColumns(t *testing.T, optimize bool) []string {
 	rangeEnd := rangeStart.Add(5 * time.Minute)
 	plan, err := promql.LowerAtRangeOpts(context.Background(), expr, schema.DefaultOTelMetrics(),
 		rangeStart, rangeEnd, 30*time.Second,
-		promql.LowerOpts{Lowerers: promql.RangeLowerers{Rate: promql.NativeRateLowerer{}}})
+		promql.LowerOpts{Lowerers: promql.RangeLowerers{Rate: promql.NativeRateLowerer{Fallback: promql.FanoutRateLowerer{}}}})
 	if err != nil {
 		t.Fatalf("lower: %v", err)
 	}


### PR DESCRIPTION
## Follow-up to #985 (merged)

PR #985 boot-wired the `promql.RangeLowerers` dispatch table, but a **nil strategy field meant fan-out**, so the per-query dispatch still did a presence/nil check (`if native := ctx.lowerers.lowerRate(rw, s); native != nil { ... }`). That nil-check is a per-query branch. #985 merged before this hardening could land on its branch, so this ships as a follow-up onto `main`.

## Pure polymorphic form (repo-owner directive)

"Boot resolves everything; at query, all optimizations already landed." ZERO branching at the dispatch site — not feature flag, not version, **not nil/presence check**.

- Every strategy field is ALWAYS a concrete non-nil impl. The fallback is a **concrete default impl** (`FanoutRateLowerer` / `FanoutStalenessLowerer`), NOT nil.
- Boot wiring: `rate = enabled ? NativeRateLowerer{Fallback: FanoutRateLowerer{}} : FanoutRateLowerer{}` (same for staleness). The feature/version read stays ONLY at boot (`cmd/cerberus`).
- The native impl checks query-SHAPE eligibility **internally** and delegates to its embedded fallback for ineligible shapes, so the interface method ALWAYS returns a valid lowering (never nil). Shape/AST dispatch lives INSIDE the impl.
- `RangeLowerers.withDefaults()` resolves the zero-value sentinel (nil fields) to the all-fan-out table at the SINGLE lowering-entry seam, never at the per-query dispatch.

### Dispatch site: before → after

```go
// before (nil-check branch at dispatch)
if native := ctx.lowerers.lowerRate(rw, s); native != nil { return native, nil }
// ... fan-out RangeWindow kept below

// after (plain interface method call)
node = ctx.lowerers.Rate.LowerRate(rw, s)
```

```go
// before
if native := ctx.lowerers.lowerStaleness(in); native != nil { return native }
return &chplan.RangeLWR{ ... }   // fan-out fallback inline

// after
return ctx.lowerers.Staleness.LowerStaleness(in)   // fan-out is a concrete impl
```

## Pure refactor — zero golden churn

Identical emitted SQL for all inputs/flags. No fixture/testdata/SQL files touched.

## Gates (all green)

- `go build`, `go vet`, `golangci-lint run` (0 issues, gofumpt-clean), `go-arch-lint check` — default + `--build-tags chdb` (chdb deltas vs base: zero; pre-existing only)
- All 6 forbid-skip scans + regex self-test (17/17)
- `-race` on promql/chsql/chplan/engine
- Full `go test ./...`
- chDB lanes: `spec-chdb`, `perf-chdb`, chsql native-rate + resample dual-emit parity, prom handler chdb

🤖 Generated with [Claude Code](https://claude.com/claude-code)