### PR TITLE
fix(e2e): stop the false-positive DiskPressure breadcrumb mislabelling failures

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -486,12 +486,16 @@ jobs:
           docker compose logs --tail=200 grafana 2>&1 | tee -a /tmp/compose-state.log || true
           echo "=== otel-collector logs (last 200) ==="
           docker compose logs --tail=200 otel-collector 2>&1 | tee -a /tmp/compose-state.log || true
-          # Infra-flake breadcrumb: if the captured state shows a disk /
-          # eviction signal, print a loud, actionable one-liner so a
-          # reviewer knows this is an infra flake (full runner disk), not a
-          # code regression — a fresh-runner re-run is the fix.
-          if grep -qiE 'DiskPressure|Evicted|ephemeral-storage|no space left on device' /tmp/compose-state.log; then
-            echo "::notice::infra: DiskPressure/ephemeral-storage eviction detected — this is an infra flake, safe to re-run on a fresh runner"
+          # Infra-flake breadcrumb. Fire ONLY on a REAL disk-full signal —
+          # the kernel ENOSPC string in a container log, or root >=90% full.
+          # The bare field names
+          # 'DiskPressure'/'ephemeral-storage' were dropped: they are k8s
+          # terms that don't appear in compose container logs anyway, and
+          # keeping them invited the same false-positive that plagued the
+          # k3d lanes (see the dashboard job + PR diagnosis).
+          if grep -qiE 'no space left on device' /tmp/compose-state.log \
+             || [ "$(df --output=pcent / | tail -1 | tr -dc '0-9')" -ge 90 ]; then
+            echo "::notice::infra: real disk-full / ephemeral-storage eviction detected (ENOSPC or root >=90% full) — this is an infra flake, safe to re-run on a fresh runner"
           fi
 
       - name: teardown
@@ -639,8 +643,15 @@ jobs:
           docker compose logs --tail=200 grafana 2>&1 | tee -a /tmp/compose-state.log || true
           echo "=== otel-collector logs (last 200) ==="
           docker compose logs --tail=200 otel-collector 2>&1 | tee -a /tmp/compose-state.log || true
-          if grep -qiE 'DiskPressure|Evicted|ephemeral-storage|no space left on device' /tmp/compose-state.log; then
-            echo "::notice::infra: DiskPressure/ephemeral-storage eviction detected — this is an infra flake, safe to re-run on a fresh runner"
+          # Fire ONLY on a REAL disk-full signal — the kernel ENOSPC string
+          # in a container log, or root >=90% full. The bare field names
+          # 'DiskPressure'/'ephemeral-storage' were dropped: they are k8s
+          # terms that don't appear in compose container logs anyway, and
+          # keeping them invited the same false-positive that plagued the
+          # k3d lanes (see the dashboard job + PR diagnosis).
+          if grep -qiE 'no space left on device' /tmp/compose-state.log \
+             || [ "$(df --output=pcent / | tail -1 | tr -dc '0-9')" -ge 90 ]; then
+            echo "::notice::infra: real disk-full / ephemeral-storage eviction detected (ENOSPC or root >=90% full) — this is an infra flake, safe to re-run on a fresh runner"
           fi
 
       - name: teardown
@@ -1076,12 +1087,30 @@ jobs:
           tail -200 /tmp/cerberus-e2e-seed-rolling.log 2>/dev/null || true
           echo "=== rolling seeder port-forward log (tail 50) ==="
           tail -50 /tmp/cerberus-e2e-seed-pf.log 2>/dev/null || true
-          # Infra-flake breadcrumb: if the captured cluster state shows a
-          # disk / eviction signal, print a loud, actionable one-liner so a
-          # reviewer knows this is an infra flake (full runner disk), not a
-          # code regression — a fresh-runner re-run is the fix.
-          if grep -qiE 'DiskPressure|Evicted|ephemeral-storage' /tmp/cluster-state.log 2>/dev/null; then
-            echo "::notice::infra: DiskPressure/ephemeral-storage eviction detected — this is an infra flake, safe to re-run on a fresh runner"
+          # Infra-flake breadcrumb: fire ONLY on a REAL ephemeral-storage
+          # eviction, so a reviewer can trust the "safe to re-run" hint.
+          #
+          # The previous guard grepped cluster-state.log for the bare field
+          # names 'DiskPressure' / 'ephemeral-storage'. But `kubectl describe
+          # nodes` (tee'd into that file above) ALWAYS prints those words on a
+          # HEALTHY node — `DiskPressure  False`, `KubeletHasNoDiskPressure`,
+          # `ephemeral-storage: <capacity>Ki`. So the breadcrumb fired on
+          # EVERY k3d failure regardless of cause (e.g. a cerberus /readyz 503
+          # timing bug), mislabelling real regressions as "infra flake, safe
+          # to re-run" and inventing a recurring disk flake that the df
+          # numbers show never happened (root sits <40% on these 145 GB
+          # runners; there is no /mnt). See PR for the full diagnosis.
+          #
+          # Match only the AFFIRMATIVE-pressure signals, none of which appear
+          # on a healthy node:
+          #   no space left on device   - the kernel ENOSPC string
+          #   DiskPressure +True        - the node condition flipped True
+          #   KubeletHasDiskPressure    - the pressure event (NOT the healthy
+          #   NodeHasDiskPressure         'KubeletHasNoDiskPressure'/'No' form)
+          #   Evicted                   - a pod actually evicted
+          if grep -qiE 'no space left on device|DiskPressure +True|KubeletHasDiskPressure|NodeHasDiskPressure|Evicted' /tmp/cluster-state.log 2>/dev/null \
+             || [ "$(df --output=pcent / | tail -1 | tr -dc '0-9')" -ge 90 ]; then
+            echo "::notice::infra: real DiskPressure/ephemeral-storage eviction detected (node condition flipped or root >=90% full) — this is an infra flake, safe to re-run on a fresh runner"
           fi
 
       - name: Tear down
@@ -1356,11 +1385,18 @@ jobs:
           kubectl -n cerberus logs daemonset/otel-collector-agent --tail 200 || true
           echo "=== rolling seeder log (tail 200) ==="
           tail -200 /tmp/cerberus-e2e-seed-rolling.log 2>/dev/null || true
-          # Infra-flake breadcrumb: a disk / eviction signal in the captured
-          # cluster state means a full runner disk, not a code regression —
-          # a fresh-runner re-run is the fix.
-          if grep -qiE 'DiskPressure|Evicted|ephemeral-storage' /tmp/cluster-state.log 2>/dev/null; then
-            echo "::notice::infra: DiskPressure/ephemeral-storage eviction detected — this is an infra flake, safe to re-run on a fresh runner"
+          # Infra-flake breadcrumb: fire ONLY on a REAL ephemeral-storage
+          # eviction. The previous guard grepped for the bare field names
+          # 'DiskPressure' / 'ephemeral-storage', which `kubectl describe
+          # nodes` ALWAYS prints on a healthy node ('DiskPressure  False',
+          # 'KubeletHasNoDiskPressure', 'ephemeral-storage: <cap>Ki'), so it
+          # fired on every chaos failure regardless of cause. Match only the
+          # affirmative-pressure signals (none present on a healthy node) plus
+          # a true root-disk-full threshold. See the dashboard job + PR for
+          # the full diagnosis.
+          if grep -qiE 'no space left on device|DiskPressure +True|KubeletHasDiskPressure|NodeHasDiskPressure|Evicted' /tmp/cluster-state.log 2>/dev/null \
+             || [ "$(df --output=pcent / | tail -1 | tr -dc '0-9')" -ge 90 ]; then
+            echo "::notice::infra: real DiskPressure/ephemeral-storage eviction detected (node condition flipped or root >=90% full) — this is an infra flake, safe to re-run on a fresh runner"
           fi
 
       - name: Tear down


### PR DESCRIPTION
## Diagnosis: the "DiskPressure eviction" is a FALSE POSITIVE

The compose-smoke / dashboard / chaos e2e lanes self-label their failures with:

> `##[notice]infra: DiskPressure/ephemeral-storage eviction detected — this is an infra flake, safe to re-run on a fresh runner`

I went looking for the actual disk consumer behind it. There isn't one — **there is no real disk pressure.** The breadcrumb fires on every k3d/compose failure regardless of cause.

### Evidence (the one job that fired it)
`dashboard-shard (shard-smoke-b, …)` in run [27779261145](https://github.com/tsouza/cerberus/actions/runs/27779261145) — the only job out of 11 shard/chaos logs across 6 failed runs that emitted the notice.

Verbatim `df` from its failure dump:
```
Filesystem      Size  Used Avail Use% Mounted on
/dev/root       145G   49G   96G  34% /     <- at breadcrumb fire
/dev/root       145G   56G   89G  39% /     <- worst seen
/dev/root       145G   37G  108G  26% /     <- typical
```
- Root `/` is **145 GB** and **never exceeds ~56 GB used (39%)** — 89–108 GB free the whole run.
- **There is no `/mnt` mount** — root already *is* the large disk.
- Node condition: `DiskPressure  False … KubeletHasNoDiskPressure … kubelet has no disk pressure`, `NodeHasNoDiskPressure`.
- The actual failure was cerberus pods returning **503 on `/readyz`** (a readiness/timing issue) — nothing to do with disk.

### Root cause (the top "consumer" is the grep, not the disk)
The failure-dump step pipes `kubectl describe nodes` into `cluster-state.log` via `tee -a`, then the breadcrumb does:
```sh
if grep -qiE 'DiskPressure|Evicted|ephemeral-storage' /tmp/cluster-state.log; then
  echo "::notice::infra: DiskPressure/ephemeral-storage eviction detected — …safe to re-run…"
fi
```
Those bare field names appear in **every healthy node description** — `DiskPressure  False`, `KubeletHasNoDiskPressure`, `ephemeral-storage: <capacity>Ki`. So the guard matches the *field name*, not a pressure *event*, and fires on any failure. That both **hides real regressions** behind a "safe to re-run" hint and manufactures the appearance of a recurring disk flake.

## The fix
Tighten all four guards in `e2e.yml` to fire **only on affirmative, real-pressure signals** that are absent on a healthy node, plus a true root-disk threshold:

```sh
grep -qiE 'no space left on device|DiskPressure +True|KubeletHasDiskPressure|NodeHasDiskPressure|Evicted' /tmp/cluster-state.log \
  || [ "$(df --output=pcent / | tail -1 | tr -dc '0-9')" -ge 90 ]
```

- `KubeletHasDiskPressure` / `NodeHasDiskPressure` are the affirmative event strings — they do **not** match the healthy `KubeletHasNoDiskPressure` / `NodeHasNoDiskPressure` forms.
- `DiskPressure +True` catches the condition table flipping to `True`.
- `Evicted` catches a genuinely evicted pod; `no space left on device` catches kernel ENOSPC.
- The `df … >= 90%` arm is a belt-and-suspenders real-disk-full check (and the only meaningful disk signal for the compose lanes, which have no node conditions).

Validated locally: the pattern matches **zero** lines of the captured healthy node output and **fires correctly** on synthetic `NodeHasDiskPressure` / `Evicted` output. `actionlint` (which shellchecks the inline scripts) passes.

### Why no `/mnt` / data-root move, and why `compatibility.yml` is untouched
The runner already gives 145 GB of root with >100 GB free — there's nothing to relocate, and no `/mnt` to relocate to. `compatibility.yml` already gates its breadcrumb on a **real** df check (`< 2 GB free on /`), so it never had this bug and is left unchanged. The original author of that lane got it right; the e2e lane had regressed to the field-name grep.

## Files changed
- `.github/workflows/e2e.yml` — tightened 4 breadcrumb guards (compose-smoke shard, compose-smoke-shard-info, dashboard-shard, e2e-chaos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
