### PR TITLE
fix(e2e): gate showcase probes on seed-fixture signal to kill unless-panel flake

### DIFF
--- a/test/e2e/playwright/crawl/crawl.spec.ts
+++ b/test/e2e/playwright/crawl/crawl.spec.ts
@@ -109,6 +109,7 @@ import {
 } from '@playwright/test';
 
 import {
+  awaitSeedFixtureSignal,
   awaitSelfTelemetryRangeSignal,
   captureConsoleErrors,
   describeSweepDepth,
@@ -622,6 +623,13 @@ test('crawl: BFS over every reachable Grafana surface with universal oracles + i
   // rate()-able — parity with dsquery.spec.ts + lints.spec.ts. Loud
   // deadline failure, never a skip.
   await awaitSelfTelemetryRangeSignal(request);
+  // The wait above only covers cerberus SELF-TELEMETRY. The showcase-*
+  // surfaces this crawl audits render the one-shot FIXTURE seed, whose
+  // compose service has no healthcheck — so the boot can hand off to the
+  // crawl before the seed's first INSERT lands and the showcase-promql
+  // set-operator panel (`up unless up{job="db"}`) renders an empty
+  // anti-join. Gate the crawl on the seed being queryable too.
+  await awaitSeedFixtureSignal(request);
 
   // The engine drives no login flow — every stack config declares
   // anonymousAuth and the crawl proves the assumption live before

--- a/test/e2e/playwright/helpers/sweep.ts
+++ b/test/e2e/playwright/helpers/sweep.ts
@@ -294,3 +294,53 @@ export async function awaitSelfTelemetryRangeSignal(
     await awaitSelfTelemetryExprSignal(request, expr, deadlineSec);
   }
 }
+
+/**
+ * Block until the deterministic FIXTURE seed the showcase-* dashboards
+ * depend on has landed in ClickHouse and is queryable over the probe
+ * window, or throw after `deadlineSec`.
+ *
+ * Why this is needed ON TOP of awaitSelfTelemetryRangeSignal: that wait
+ * gates on cerberus's own SELF-TELEMETRY (`cerberus_queries_total`),
+ * which the collector exports continuously. It says NOTHING about the
+ * separate, one-shot FIXTURE seed (the `test/e2e/seed` program's `up`,
+ * `http_requests_total`, exp-histogram, … rows) that the showcase-promql
+ * / showcase-logql dashboards render. The fixture seed runs as the
+ * `seed` compose service, which has NO healthcheck — so
+ * `docker compose up --wait` (the exact compose-smoke CI boot) returns
+ * as soon as cerberus + grafana are healthy, WITHOUT waiting for the
+ * seed's initial INSERT. Playwright then probes the showcase panels in a
+ * race with that first seed tick.
+ *
+ * The `set operators: and / or / unless` panel's `up unless up{job="db"}`
+ * target is the sharpest victim: when the probe lands before the seed's
+ * `up{job="api"}` rows exist (and the collector's own self-scrape `up`
+ * is absent or has gone stale outside the 5m window), the anti-join over
+ * an `up` set that holds only `{job="db"}` — or nothing — yields zero
+ * series, tripping the default:nonempty contract. Adversarial repro on a
+ * healthy compose stack: truncating the gauge table reproduces count=0
+ * on that exact target deterministically.
+ *
+ * We gate on the panel's OWN expression so "warmup passed" implies "the
+ * showcase-promql set-operator panel has data": once this returns, an
+ * empty `up unless up{job="db"}` frame is a real bug (seed/eval/expr),
+ * never a boot race. Polls cerberus DIRECTLY (not through Grafana) for
+ * the same wire-vs-decode isolation as awaitSelfTelemetryExprSignal. The
+ * deadline failure is loud and actionable (a seed regression), never a
+ * skip.
+ */
+export async function awaitSeedFixtureSignal(
+  request: APIRequestContext,
+  deadlineSec = 120,
+): Promise<void> {
+  // The exact target the showcase-promql set-operator panel renders.
+  // The seeded `up{job="api"}` series is the deterministic non-`db`
+  // member that keeps this anti-join nonempty for the life of the
+  // rolling re-seed; probing the panel expression itself closes the
+  // gap between "the seed exists" and "the panel has series".
+  await awaitSelfTelemetryExprSignal(
+    request,
+    'up unless up{job="db"}',
+    deadlineSec,
+  );
+}

--- a/test/e2e/playwright/iterate-all-dashboards.spec.ts
+++ b/test/e2e/playwright/iterate-all-dashboards.spec.ts
@@ -61,6 +61,7 @@ import {
 
 import {
   type VariableJSON,
+  awaitSeedFixtureSignal,
   awaitSelfTelemetryRangeSignal,
   checkDashboardVariable,
   describeSweepDepth,
@@ -529,6 +530,14 @@ test.describe('iterate-all-dashboards: full provisioned-dashboard sweep', () => 
     // bounded, data-driven wait so an empty panel is a real bug, not a
     // boot race. Loud deadline failure, never a skip.
     await awaitSelfTelemetryRangeSignal(request);
+    // The previous wait only covers cerberus SELF-TELEMETRY. The
+    // showcase-* dashboards render the one-shot FIXTURE seed, whose
+    // compose service has no healthcheck — so `docker compose up --wait`
+    // can hand off to Playwright before the first seed INSERT lands. Gate
+    // the showcase-promql set-operator panel (`up unless up{job="db"}`) on
+    // the seed being queryable too, so an empty anti-join is a real bug,
+    // not a seed boot race.
+    await awaitSeedFixtureSignal(request);
   });
 
   for (const d of dashboards) {


### PR DESCRIPTION
## Root cause: seed boot race (not eval / expr)

The intermittent compose-smoke failure

```
dashboard=showcase-promql panel="set operators: and / or / unless" target=C
expr="up unless up{job=\"db\"}" (declared=default:nonempty):
panel returned no series (count=0)
```

is a **seed boot race**, not a PromQL `unless` evaluation bug and not a wrong panel expression.

### Mechanism

- The `compose-smoke` CI job boots with `docker compose up --wait` then runs Playwright **immediately**.
- The fixture `seed` service (the `test/e2e/seed` program that inserts the deterministic `up{job="api"}` / `up{job="db"}` rows the showcase-promql dashboard renders) has **no healthcheck**, so `--wait` returns as soon as `cerberus` + `grafana` are healthy — **without waiting for the seed's initial INSERT**.
- The existing `beforeAll` warmup (`awaitSelfTelemetryRangeSignal`) only gates on cerberus **self-telemetry** (`cerberus_queries_total`), which the collector exports continuously. It says nothing about the one-shot fixture seed.
- When a probe lands before the first seed tick — and the collector's own self-scrape `up` series (added by the recent ResourceAttributes-as-labels work, #947) is absent or has gone stale outside the 5m window — the anti-join `up unless up{job="db"}` runs over an `up` set that holds only `{job="db"}` (or nothing) and returns **zero series**, tripping the `default:nonempty` contract.

The `unless` lowering itself is correct: the anti-join keeps every `up` series whose Attributes signature is not in the RHS `{job:db}` set. With the seed present, `up{job="api"}` is the deterministic non-`db` member that keeps the panel nonempty.

### Adversarial reproduction (live compose stack, healthy)

- Steady state: `up unless up{job="db"}` → `count=2` (seeded `up{job="api"}` + collector self-scrape `up`), stable across 40+ rapid probes.
- Truncating `otel_metrics_gauge` (the pre-first-seed-INSERT state) → `count=0` **deterministically** on that exact target. This is the race window CI hits.

## Fix at the source

Add `awaitSeedFixtureSignal` (helpers/sweep.ts), mirroring the flake-#89 `awaitSelfTelemetryRangeSignal` pattern, that polls cerberus directly for the panel's own expression `up unless up{job="db"}` with a loud bounded deadline. Call it in the `beforeAll` of:

- `iterate-all-dashboards.spec.ts` (the spec that emitted the failure)
- `crawl/crawl.spec.ts` (also probes showcase surfaces via the same oracle)

Once the wait returns, an empty `up unless up{job="db"}` frame is a real bug (seed / eval / expr), never a boot race — and the deadline failure is loud and actionable, never a skip. No test was loosened.

## Proof it is now deterministic

Live compose stack (`docker compose up --wait`):

- **Pre-seed** (truncated gauge): gate probe returns **0 points** → `awaitSeedFixtureSignal` BLOCKS (never reaches the MIN=3 threshold). OLD code probed the panel here and got `count=0`.
- **Post-seed**: within **1s** of the first seed INSERT, the probe crosses to 18+ points → gate releases.
- **Post-gate**: 25 consecutive `up unless up{job="db"}` probes → **deterministically `count=2`**.
- Full `iterate-all-dashboards.spec.ts` run against the live stack: **8/8 dashboards pass**, including `showcase-promql probed=131 non_empty=129`.
- `tsc --noEmit -p tsconfig.json` (the CI typecheck gate): clean.

## Files changed

- `test/e2e/playwright/helpers/sweep.ts` — new `awaitSeedFixtureSignal`
- `test/e2e/playwright/iterate-all-dashboards.spec.ts` — call it in `beforeAll`
- `test/e2e/playwright/crawl/crawl.spec.ts` — call it in `beforeAll`

🤖 Generated with [Claude Code](https://claude.com/claude-code)