### PR TITLE
ci(e2e): cache Playwright chromium across e2e shards

### DIFF
--- a/.github/actions/setup-playwright-browsers/action.yml
+++ b/.github/actions/setup-playwright-browsers/action.yml
@@ -1,0 +1,80 @@
+name: Setup Playwright browsers (cached)
+description: >
+  Install the Playwright npm deps and the chromium browser binary, caching
+  ~/.cache/ms-playwright keyed on the EXACT resolved Playwright version so the
+  ~15-min Microsoft-CDN chromium download is paid once per version (across all
+  shards and all runs) instead of on every shard of every run.
+
+# Why a composite action: the same install+cache logic runs in three e2e jobs
+# (compose-smoke-shard, compose-smoke-shard-info, dashboard-shard). Keeping the
+# cache-key derivation in one place means the key can't drift between jobs - a
+# correct shared key is the whole point (first shard populates, the rest restore).
+
+inputs:
+  working-directory:
+    description: Directory containing the Playwright package.json + lockfile.
+    required: false
+    default: test/e2e/playwright
+
+runs:
+  using: composite
+  steps:
+    # npm deps first: `npx playwright` and the version probe both need the
+    # @playwright/test package installed under node_modules.
+    - name: Install Playwright npm deps
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        # npm ci needs a lockfile; fall back to `npm install` if one is ever
+        # missing (keeps the action robust if the lockfile is removed).
+        if [ -f package-lock.json ]; then
+          npm ci
+        else
+          npm install --no-audit --no-fund
+        fi
+
+    # Resolve the EXACT browser-pinned version from playwright-core in the
+    # lockfile (NOT the `^1.50.0` range in package.json - that would let two
+    # runs at different resolved versions share a key and restore stale
+    # browsers). playwright-core is what actually pins the bundled chromium
+    # build; @playwright/test tracks it lockstep. Reading the lockfile (not
+    # `npx playwright --version`) keeps the key derivable without the binary.
+    - name: Resolve Playwright version
+      id: pw
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        version="$(node -p "require('./package-lock.json').packages['node_modules/playwright-core'].version")"
+        if [ -z "$version" ] || [ "$version" = "undefined" ]; then
+          echo "::error::could not resolve playwright-core version from package-lock.json"
+          exit 1
+        fi
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+        echo "Resolved Playwright version: $version"
+
+    # Cache the browser binaries, NOT node_modules - chromium is the 15-min
+    # download; node_modules is seconds. Key is version-only (+ OS), so:
+    #   * every shard in a run shares ONE key  -> first miss populates, rest hit
+    #   * every run at the same version hits    -> steady-state download = 0
+    #   * a Playwright bump changes the version -> key changes -> one fresh pull
+    - name: Cache Playwright browsers
+      id: cache
+      uses: actions/cache@v5
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-browsers-${{ runner.os }}-${{ steps.pw.outputs.version }}
+
+    # Cache HIT: browser binaries are already restored; only install the OS
+    # shared-library deps (apt; fast, not cached because they're an apt op, not
+    # the CDN download). Cache MISS: download chromium AND install OS deps.
+    - name: Install chromium (deps only on hit, browser + deps on miss)
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        if [ "${{ steps.cache.outputs.cache-hit }}" = "true" ]; then
+          echo "Playwright browser cache hit - installing OS deps only."
+          npx playwright install-deps chromium
+        else
+          echo "Playwright browser cache miss - downloading chromium + OS deps."
+          npx playwright install --with-deps chromium
+        fi

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -398,27 +398,21 @@ jobs:
       # per-target error in a /api/ds/query body fails the job — that
       # was the gap that let dashboard-load regressions land on main
       # for hours unnoticed.
-      # No npm cache here — the playwright suite doesn't currently
-      # ship a package-lock.json, and setup-node's cache lookup hard-
-      # fails before the install fallback below ever runs when the
-      # cache-dependency-path is unresolvable. Re-add cache: npm once a
-      # lockfile lands under test/e2e/playwright/.
+      # npm cache keyed on the playwright suite's lockfile (it now ships one).
+      # Speeds `npm ci` inside the cached-browsers action below; the heavy item
+      # (chromium) is cached separately by that action.
       - uses: actions/setup-node@v6
         with:
           node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: 'test/e2e/playwright/package-lock.json'
 
-      - name: install Playwright deps
-        working-directory: test/e2e/playwright
-        run: |
-          # npm ci needs a lockfile; fall back to `npm install` if the
-          # repo doesn't ship one yet (the existing playwright suite
-          # uses the same pattern in the k3d e2e job).
-          if [ -f package-lock.json ]; then
-            npm ci
-          else
-            npm install --no-audit --no-fund
-          fi
-          npx playwright install --with-deps chromium
+      # Installs npm deps + chromium, caching ~/.cache/ms-playwright keyed on
+      # the resolved Playwright version. Shared key across every shard of every
+      # run -> the ~15-min CDN chromium download is paid once per version, not
+      # once per shard. On a cache hit it runs only `install-deps` (fast).
+      - name: install Playwright + browsers (cached)
+        uses: ./.github/actions/setup-playwright-browsers
 
       - name: playwright compose-grafana-smoke (${{ matrix.name }})
         id: playwright_smoke
@@ -591,16 +585,13 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: 'test/e2e/playwright/package-lock.json'
 
-      - name: install Playwright deps
-        working-directory: test/e2e/playwright
-        run: |
-          if [ -f package-lock.json ]; then
-            npm ci
-          else
-            npm install --no-audit --no-fund
-          fi
-          npx playwright install --with-deps chromium
+      # See compose-smoke-shard: cached npm deps + chromium, shared version-keyed
+      # ~/.cache/ms-playwright so the chromium download is paid once per version.
+      - name: install Playwright + browsers (cached)
+        uses: ./.github/actions/setup-playwright-browsers
 
       - name: playwright compose-grafana-smoke (${{ matrix.name }})
         id: playwright_smoke
@@ -868,7 +859,7 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
-          cache-dependency-path: 'test/e2e/playwright/package.json'
+          cache-dependency-path: 'test/e2e/playwright/package-lock.json'
 
       - uses: taiki-e/install-action@v2
         if: env.RUN_SHARD == 'true'
@@ -916,12 +907,12 @@ jobs:
         if: env.RUN_SHARD == 'true' && matrix.runGoE2E
         run: just e2e-run
 
-      - name: Install Playwright + browsers
+      # See compose-smoke-shard: cached npm deps + chromium, shared version-keyed
+      # ~/.cache/ms-playwright so the chromium download is paid once per version
+      # (the k3d dashboard lane shares the same cache key as the compose lanes).
+      - name: Install Playwright + browsers (cached)
         if: env.RUN_SHARD == 'true'
-        working-directory: test/e2e/playwright
-        run: |
-          npm ci || npm install
-          npx playwright install --with-deps chromium
+        uses: ./.github/actions/setup-playwright-browsers
 
       # ---- smoke shards (CRAWL_STACK unset => crawl/** ignored) ----
       # Runs this shard's assigned non-crawl spec subset (the space-joined list


### PR DESCRIPTION
## Problem

The three GitHub-hosted e2e lanes -- `compose-smoke-shard`, `compose-smoke-shard-info`, and `dashboard-shard` -- each ran:

```
npx playwright install --with-deps chromium
```

with **no browser cache**. So every shard of every run re-downloaded the chromium binary from Microsoft's CDN (`playwright.download.prss.microsoft.com`, formerly `playwright.azureedge.net`). That download is ~15 min, and it was paid **N times per run** across the sharded matrices.

(chromium-only install was already in place -- the slow part was the missing cache, not the browser set.)

## Fix

A small composite action, `.github/actions/setup-playwright-browsers`, installs the npm deps + chromium and caches `~/.cache/ms-playwright` via `actions/cache@v5`, keyed on the **exact resolved Playwright version** (`playwright-core` in the lockfile = `1.60.0` today, read with `node -p`, not the `^1.50.0` range in `package.json`).

On a cache **hit** it runs only `npx playwright install-deps chromium` (apt OS deps, seconds); on a **miss** it runs the full `npx playwright install --with-deps chromium`.

The action is shared by all three lanes so the cache key is identical everywhere (single source of truth -- the key cannot drift between jobs).

### Cache-key design

Key: `playwright-browsers-${{ runner.os }}-<resolved-playwright-core-version>`

- **Across shards (same run):** all shards share ONE key. First miss populates, every sibling restores. 15 min x N shards -> ~15 min once, then ~seconds.
- **Across runs (same version):** steady-state browser download = **0**.
- **On a Playwright bump:** the lockfile version changes -> key changes -> exactly one fresh pull, then back to 0.
- It does **not** key on a package-lock hash (which churns on any unrelated dep bump) -- only the browser-pinning version, so it invalidates exactly when the browsers actually change.

### Why not the `mcr.microsoft.com/playwright` container

Honestly evaluated and rejected: all three lanes need **docker/k3d on the host** (`docker compose up`, k3d cluster boot). The prebaked-browser Playwright container runs the job *inside* a container and conflicts with docker-in-docker / k3d here, so it does not fit these lanes. Caching is the right tool.

### Bonus

- Enables `setup-node` npm caching on the two compose lanes (a `package-lock.json` now ships under `test/e2e/playwright/`; the old "no lockfile yet" comment was stale).
- Points the dashboard lane's `cache-dependency-path` at the lockfile instead of `package.json`.

## Expected time saved

Steady-state: the ~15-min chromium download drops to **near-zero on every shard** after the first populate at a given Playwright version. The only run that pays the full download is the first one after a Playwright version bump (and only one shard of it).

## Files changed

- `.github/actions/setup-playwright-browsers/action.yml` (new composite action)
- `.github/workflows/e2e.yml` (3 install steps -> the cached action; npm caching on the compose lanes)

## Validation

`actionlint` passes on `e2e.yml`. The `node -p` version extraction was verified against the real lockfile (resolves `1.60.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)