### PR TITLE
docs: sync docs to code ahead of v1.1.0 (feature table, COW, dead links, counts)

### DIFF
--- a/.github/workflows/chdb.yml
+++ b/.github/workflows/chdb.yml
@@ -261,6 +261,13 @@ jobs:
   #   - TestSeriesFanout_ChDB: a don't-regress-upward /series round-trip
   #     ceiling (the #790 fan-in batching is held off main, so this pins
   #     the current N rather than asserting ==1).
+  #   - TestSliceAllocs_ChDB: a don't-regress-upward allocation pin on the
+  #     plan-slicer copy-on-write off-spine sharing. It asserts (*Planner)
+  #     .slice()'s allocs/op stay under a bound at K=4 and K=16, so a revert
+  #     of the COW sharing in internal/chplan/reanchor.go back to a per-shard
+  #     CloneNode re-inflates the count past the bound and fails here. The
+  #     wall-clock companion (internal/solver.BenchmarkSlice) is informational
+  #     in perf-benchmark.yml; this is the gating arm.
   #
   # Wall-clock perf stays in the informational `perf-benchmark.yml`
   # (benchstat, never gates) to avoid runner-variance flake; only the

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -30,6 +30,7 @@ on:
       - 'internal/traceql/**'
       - 'internal/chplan/**'
       - 'internal/chsql/**'
+      - 'internal/solver/**'
       - 'internal/optimizer/**'
       - 'internal/chclient/**'
       - 'internal/api/format/**'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,14 +49,14 @@ compatibility/tempo/         TraceQL differential harness vs reference Tempo + v
 docs/                        engine.md, compatibility.md, test-strategy.md, observability.md, operations.md, upstream-forks.md, health.md, …
 ```
 
-See [`docs/test-strategy.md`](docs/test-strategy.md) for the canonical 12-layer test map, the CI-gate inventory, the gremlins phased rollout, and the property-test phase plan.
+See [`docs/test-strategy.md`](docs/test-strategy.md) for the canonical 13-layer test map, the CI-gate inventory, the gremlins phased rollout, and the property-test phase plan.
 
 Top-level reading order for any new contributor (human or agent):
 
 1. `README.md` — what the project is, quick start.
 2. `docs/engine.md` — shared query pipeline (`internal/engine/`), the `Lang` contract, and the extension points each new head plugs into.
 3. `docs/operations.md` — runtime contract: configuration, lifecycle, scaling.
-4. `docs/test-strategy.md` — 12-layer test map + CI gate inventory.
+4. `docs/test-strategy.md` — 13-layer test map + CI gate inventory.
 5. `internal/promql/lower.go` — the canonical lowering pattern; mirror it when adding LogQL / TraceQL slices.
 
 ## Common workflows

--- a/README.md
+++ b/README.md
@@ -237,21 +237,24 @@ map, the CI-gate inventory, and the gremlins rollout.
 
 ## Documentation
 
-| Doc                                                | What's in it                                                                                    |
-| -------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| [`docs/engine.md`](docs/engine.md)                 | The shared query pipeline, the `Lang` contract, and the per-stage breakdown.                    |
-| [`docs/coverage.md`](docs/coverage.md)             | Per-function / per-construct support status across PromQL / LogQL / TraceQL.                    |
-| [`docs/configuration.md`](docs/configuration.md)   | The full `CERBERUS_*` environment-variable reference, grouped by area, with types and defaults. |
-| [`docs/operations.md`](docs/operations.md)         | Runtime contract: lifecycle, scaling, the solver and experimental knobs in context.             |
-| [`docs/performance.md`](docs/performance.md)       | The compute-fan-out strategy, per-layer optimisations, and how they're held against regression. |
-| [`docs/solver.md`](docs/solver.md)                 | The sharded-pushdown solver: eligibility, slicing, execution, and the cancellation contract.    |
-| [`docs/benchmarks.md`](docs/benchmarks.md)         | Benchmark methodology and the recorded numbers (regenerable).                                   |
-| [`docs/compatibility.md`](docs/compatibility.md)   | The differential-harness playbook for all three heads.                                          |
-| [`docs/test-strategy.md`](docs/test-strategy.md)   | The 13-layer test map and CI-gate inventory.                                                    |
-| [`docs/observability.md`](docs/observability.md)   | Self-observability across logs / metrics / traces (OTLP export).                                |
-| [`docs/health.md`](docs/health.md)                 | `/readyz` / `/healthz` probe semantics.                                                         |
-| [`docs/upstream-forks.md`](docs/upstream-forks.md) | The `tsouza/*` parser-fork + Dependabot-watch flow.                                             |
-| [`docs/forbid-skip.md`](docs/forbid-skip.md)       | The forbidden-pattern reference for the `forbid-skip` gate.                                     |
+| Doc                                                                      | What's in it                                                                                                                 |
+| ------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
+| [`docs/engine.md`](docs/engine.md)                                       | The shared query pipeline, the `Lang` contract, and the per-stage breakdown.                                                 |
+| [`docs/coverage.md`](docs/coverage.md)                                   | Per-function / per-construct support status across PromQL / LogQL / TraceQL.                                                 |
+| [`docs/configuration.md`](docs/configuration.md)                         | The full `CERBERUS_*` environment-variable reference, grouped by area, with types and defaults.                              |
+| [`docs/operations.md`](docs/operations.md)                               | Runtime contract: lifecycle, scaling, the solver and experimental knobs in context.                                          |
+| [`docs/performance.md`](docs/performance.md)                             | The compute-fan-out strategy, per-layer optimisations, and how they're held against regression.                              |
+| [`docs/optimization-rules.md`](docs/optimization-rules.md)               | The standing optimizer-design rules (feature-registry single-source-of-truth, clone-less-not-faster).                        |
+| [`docs/clickhouse-optimizations.md`](docs/clickhouse-optimizations.md)   | The ClickHouse-optimization suite: feature registry, version gating, the runtime probe, and the query_log corpus reconciler. |
+| [`docs/solver.md`](docs/solver.md)                                       | The sharded-pushdown solver: eligibility, slicing, execution, and the cancellation contract.                                 |
+| [`docs/native-clickhouse-roadmap.md`](docs/native-clickhouse-roadmap.md) | The research roadmap for shipping heavy lowerings as native `timeSeries*ToGrid` ClickHouse aggregates.                       |
+| [`docs/benchmarks.md`](docs/benchmarks.md)                               | Benchmark methodology and the recorded numbers (regenerable).                                                                |
+| [`docs/compatibility.md`](docs/compatibility.md)                         | The differential-harness playbook for all three heads.                                                                       |
+| [`docs/test-strategy.md`](docs/test-strategy.md)                         | The 13-layer test map and CI-gate inventory.                                                                                 |
+| [`docs/observability.md`](docs/observability.md)                         | Self-observability across logs / metrics / traces (OTLP export).                                                             |
+| [`docs/health.md`](docs/health.md)                                       | `/readyz` / `/healthz` probe semantics.                                                                                      |
+| [`docs/upstream-forks.md`](docs/upstream-forks.md)                       | The `tsouza/*` parser-fork + Dependabot-watch flow.                                                                          |
+| [`docs/forbid-skip.md`](docs/forbid-skip.md)                             | The forbidden-pattern reference for the `forbid-skip` gate.                                                                  |
 
 ## Contributing
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -61,12 +61,12 @@ parse the query  →  lower to the plan IR  →  optimize (optimizer.Default)
 Nothing is stubbed: the SQL measured is the SQL cerberus emits, and it runs on the same 500k-row dataset described above. The query shapes span all three heads and the API endpoints a Grafana dashboard actually hits — an instant evaluation, a **`query_range`** rate over a step grid (the workhorse panel query), a `/series` label lookup, a TraceQL span search, and a LogQL range count.
 
 | query                   | head    | scan rows | latency |
-| ----------------------- | ------- | --------: | ------: |
-| instant query           | promql  |   500,000 |  66.1ms |
-| range query (240 steps) | promql  |   500,000 | 529.9ms |
-| series lookup           | promql  |   500,000 |  17.5ms |
-| TraceQL search          | traceql |   500,000 |  18.5ms |
-| LogQL range             | logql   |   500,000 |  42.2ms |
+| ----------------------- | ------- | --------- | ------- |
+| instant query           | promql  | 500,000   | 66.1ms  |
+| range query (240 steps) | promql  | 500,000   | 529.9ms |
+| series lookup           | promql  | 500,000   | 17.5ms  |
+| TraceQL search          | traceql | 500,000   | 18.5ms  |
+| LogQL range             | logql   | 500,000   | 42.2ms  |
 
 ![End-to-end latency by query shape](benchmarks/e2e-latency.svg)
 
@@ -91,11 +91,11 @@ Because native rate *removes* the fan-out, the two levers do not stack: with nat
 
 **The focus query** is the same rate range query_range from the table above — `sum(rate(e2e_http_requests[5m]))` over 1h at a 15s step (fan-out F = Range/Step = **20**, grid N = **241** steps), on the **500,000**-row metrics seed. Each strategy drives the full pipeline for its configuration and reports two numbers: the measured **wall** time and the modeled per-statement **peak memory**.
 
-| strategy             | statements |    wall | peak mem | note                                    |
-| -------------------- | ---------: | ------: | -------: | --------------------------------------- |
-| single (native off)  |          1 | 522.9ms |  216 MiB | baseline — whole fan-out in one query   |
-| sharded (native off) |          8 | 915.1ms |  123 MiB | fan-out sliced to fit (K=8 shards)      |
-| native rate          |          1 |  83.8ms |   11 MiB | fan-out removed (single-pass aggregate) |
+| strategy             | statements | wall    | peak mem | note                                    |
+| -------------------- | ---------- | ------- | -------- | --------------------------------------- |
+| single (native off)  | 1          | 522.9ms | 216 MiB  | baseline — whole fan-out in one query   |
+| sharded (native off) | 8          | 915.1ms | 123 MiB  | fan-out sliced to fit (K=8 shards)      |
+| native rate          | 1          | 83.8ms  | 11 MiB   | fan-out removed (single-pass aggregate) |
 
 `auto` (the production default) picks the sharded route for this query when native rate is off; with native rate on it collapses to a single statement — so `auto` does not earn its own row, it lands on one of the three above depending on the flag.
 
@@ -118,9 +118,9 @@ The matrix showed *that* sharding cuts per-query memory; this section shows it a
 **The fixture.** `sum(rate(bench_shard_total[5m]))` @ 15s over 1h — fan-out F = **20**, grid N = **241**. Seeded with **13,000** series and **3,393,000** scanned samples, sized so a single statement crosses the cap while every shard stays under it.
 
 | route                | statements | (sample,anchor) pairs | modeled peak | vs 1.00 GiB cap       |
-| -------------------- | ---------: | --------------------: | -----------: | --------------------- |
-| A — single statement |          1 |            62,660,000 |     1.32 GiB | **OOM** (exceeds cap) |
-| B — sharded (K=8)    |          8 |       8,060,000 (max) |      174 MiB | clears                |
+| -------------------- | ---------- | --------------------- | ------------ | --------------------- |
+| A — single statement | 1          | 62,660,000            | 1.32 GiB     | **OOM** (exceeds cap) |
+| B — sharded (K=8)    | 8          | 8,060,000 (max)       | 174 MiB      | clears                |
 
 Route A's modeled peak (**1.32 GiB**) **exceeds** the cap; every route-B shard's modeled peak (**174 MiB**) sits under it with **5.9× headroom**. The shards partition route A's work exactly — the per-shard pair counts sum to route A's total (62,660,000), with no double-count — so the worst shard carries ~1/K of the fan-out, a **7.8×** reduction.
 
@@ -136,11 +136,11 @@ A query optimization is only durable if it stays bounded as the data grows. Each
 
 Scan rows held fixed at 180,000.
 
-| param |   wall | peak rows | fan_factor |
-| ----: | -----: | --------: | ---------: |
-|    61 | 21.2ms |    48,000 |       0.27 |
-|   121 | 25.1ms |    84,000 |       0.47 |
-|   241 | 38.2ms |   156,000 |       0.87 |
+| param | wall   | peak rows | fan_factor |
+| ----- | ------ | --------- | ---------- |
+| 61    | 21.2ms | 48,000    | 0.27       |
+| 121   | 25.1ms | 84,000    | 0.47       |
+| 241   | 38.2ms | 156,000   | 0.87       |
 
 ![range_lwr scaling](benchmarks/scaling-range_lwr.svg)
 
@@ -150,11 +150,11 @@ Parameter grew **4.0×** across the sweep; wall grew **1.8×** (sub-linear). `fa
 
 Scan rows held fixed at 9.
 
-| param |    wall | peak rows | fan_factor |
-| ----: | ------: | --------: | ---------: |
-|     2 |  21.6ms |         3 |       0.33 |
-|     4 |  66.7ms |         5 |       0.56 |
-|     8 | 318.9ms |         9 |       1.00 |
+| param | wall    | peak rows | fan_factor |
+| ----- | ------- | --------- | ---------- |
+| 2     | 21.6ms  | 3         | 0.33       |
+| 4     | 66.7ms  | 5         | 0.56       |
+| 8     | 318.9ms | 9         | 1.00       |
 
 ![setop_chain scaling](benchmarks/scaling-setop_chain.svg)
 
@@ -166,8 +166,8 @@ Parameter grew **4.0×** across the sweep; wall grew **14.8×** (tracks the para
 
 Cerberus's optimizer rewrites each plan before emission. These are the individual wins, each pairing the **naive** pre-optimization SQL against the **optimized** shape cerberus actually emits, both run live on chDB. The `win` column is the deterministic structural ratio where one exists (granules read, rows scanned, peak cardinality), else the indicative wall-time speedup.
 
-| optimization              |   win | basis                                         |
-| ------------------------- | ----: | --------------------------------------------- |
+| optimization              | win   | basis                                         |
+| ------------------------- | ----- | --------------------------------------------- |
 | range-LWR collapse        | 56.9× | wall time (indicative)                        |
 | set-op single-pass        | 18.1× | arm rows scanned (deterministic)              |
 | MetricName-first ORDER BY | 17.0× | granules read (deterministic)                 |
@@ -207,44 +207,48 @@ Cerberus's optimizer rewrites each plan before emission. These are the individua
 
 ## Micro-benchmarks
 
-Per-stage Go benchmarks, no database involved — they isolate the cost of one pipeline stage so an allocation regression in, say, lowering can't hide behind a fast query. `allocs/op` and `B/op` are deterministic; `ns/op` is indicative. Read the `package` column as the stage: `promql`/`logql`/`traceql` parse + lower, `optimizer` rewrites the plan, `chsql` emits SQL, `chplan` is the IR, `api/*` is the wire layer.
+Per-stage Go benchmarks, no database involved — they isolate the cost of one pipeline stage so an allocation regression in, say, lowering can't hide behind a fast query. `allocs/op` and `B/op` are deterministic; `ns/op` is indicative. Read the `package` column as the stage: `promql`/`logql`/`traceql` parse + lower, `optimizer` rewrites the plan, `chsql` emits SQL, `chplan` is the IR, `solver` is the sharded-pushdown slicer (`Slice/K=*` measures one `unpinSpine` plus K `ReanchorRange` calls on the copy-on-write off-spine sharing path), `api/*` is the wire layer.
 
-| package    | benchmark                            |         ns/op |          B/op | allocs/op |
-| ---------- | ------------------------------------ | ------------: | ------------: | --------: |
-| api/format | CanonicalKey_Large                   |         2,508 |         1,016 |         8 |
-| api/format | CanonicalKey_Small                   |           710 |           216 |         6 |
-| api/format | PromLabelToOTelCandidates_Cached     |            45 |             0 |         0 |
-| api/format | PromLabelToOTelCandidates_SumByQuery |           299 |             0 |         0 |
-| api/format | PromLabelToOTelCandidates_Uncached   |         1,378 |           136 |         4 |
-| api/prom   | ExecuteRangeStreaming                |   144,739,449 |   120,175,240 |   1402461 |
-| api/prom   | HandleLabels                         |        87,205 |        28,027 |       161 |
-| api/prom   | HandleQueryRange_Large               |     2,022,945 |     1,614,742 |     16325 |
-| api/prom   | HandleQueryRange_Small               |       248,646 |       110,661 |      1101 |
-| api/prom   | HandleQuery_Small                    |       183,543 |        49,244 |       492 |
-| api/prom   | HandleSeries/broad                   | 4,311,226,392 | 4,965,324,523 |  37765296 |
-| api/prom   | HandleSeries/typical                 |     2,258,302 |     2,062,501 |     18988 |
-| api/prom   | StreamingCursor_100K_Series          | 1,550,127,460 | 1,529,472,056 |  15598476 |
-| api/prom   | StreamingCursor_1M_Points            | 1,423,789,780 | 1,432,337,993 |  14759491 |
-| api/prom   | StreamingCursor_Stop_Mid             |    91,919,924 |    77,311,208 |    851937 |
-| chclient   | RowsCursor_DrainLarge                |     3,807,831 |     2,320,259 |     80002 |
-| chclient   | RowsCursor_DrainSmall                |        32,643 |        17,056 |       602 |
-| chplan     | Equal                                |         1,658 |             0 |         0 |
-| chplan     | Walk                                 |           231 |            80 |         5 |
-| chsql      | Builder_NewAndBuild                  |         3,354 |         1,064 |        12 |
-| chsql      | Frag_Construction                    |         1,179 |           952 |        34 |
-| chsql      | QueryBuilder_Build                   |         2,668 |         1,064 |        12 |
-| logql      | Lower_LineFilterChain                |         1,320 |           968 |        22 |
-| logql      | Lower_MetricForm                     |         5,851 |         4,640 |       119 |
-| logql      | Lower_StreamMatcher                  |         1,157 |           680 |        15 |
-| optimizer  | Driver_Run                           |         9,566 |         4,880 |        62 |
-| promql     | Lower_Aggregation                    |         5,524 |         4,019 |       100 |
-| promql     | Lower_Binary                         |         3,456 |         2,576 |        64 |
-| promql     | Lower_Instant                        |         3,491 |         2,080 |        50 |
-| promql     | Lower_Range                          |         2,181 |         1,160 |        25 |
-| promql     | Lower_Subquery                       |         2,590 |         1,464 |        29 |
-| traceql    | Lower_AttributeMatcher               |         2,282 |           624 |        13 |
-| traceql    | Lower_MetricsPipeline                |         1,338 |           713 |        13 |
-| traceql    | Lower_StructuralChain                |         1,744 |         1,240 |        24 |
+| package    | benchmark                            | ns/op         | B/op          | allocs/op |
+| ---------- | ------------------------------------ | ------------- | ------------- | --------- |
+| api/format | CanonicalKey_Large                   | 2,508         | 1,016         | 8         |
+| api/format | CanonicalKey_Small                   | 710           | 216           | 6         |
+| api/format | PromLabelToOTelCandidates_Cached     | 45            | 0             | 0         |
+| api/format | PromLabelToOTelCandidates_SumByQuery | 299           | 0             | 0         |
+| api/format | PromLabelToOTelCandidates_Uncached   | 1,378         | 136           | 4         |
+| api/prom   | ExecuteRangeStreaming                | 144,739,449   | 120,175,240   | 1402461   |
+| api/prom   | HandleLabels                         | 87,205        | 28,027        | 161       |
+| api/prom   | HandleQueryRange_Large               | 2,022,945     | 1,614,742     | 16325     |
+| api/prom   | HandleQueryRange_Small               | 248,646       | 110,661       | 1101      |
+| api/prom   | HandleQuery_Small                    | 183,543       | 49,244        | 492       |
+| api/prom   | HandleSeries/broad                   | 4,311,226,392 | 4,965,324,523 | 37765296  |
+| api/prom   | HandleSeries/typical                 | 2,258,302     | 2,062,501     | 18988     |
+| api/prom   | StreamingCursor_100K_Series          | 1,550,127,460 | 1,529,472,056 | 15598476  |
+| api/prom   | StreamingCursor_1M_Points            | 1,423,789,780 | 1,432,337,993 | 14759491  |
+| api/prom   | StreamingCursor_Stop_Mid             | 91,919,924    | 77,311,208    | 851937    |
+| chclient   | RowsCursor_DrainLarge                | 3,807,831     | 2,320,259     | 80002     |
+| chclient   | RowsCursor_DrainSmall                | 32,643        | 17,056        | 602       |
+| chplan     | Equal                                | 1,658         | 0             | 0         |
+| chplan     | Walk                                 | 231           | 80            | 5         |
+| chsql      | Builder_NewAndBuild                  | 3,354         | 1,064         | 12        |
+| chsql      | Frag_Construction                    | 1,179         | 952           | 34        |
+| chsql      | QueryBuilder_Build                   | 2,668         | 1,064         | 12        |
+| logql      | Lower_LineFilterChain                | 1,320         | 968           | 22        |
+| logql      | Lower_MetricForm                     | 5,851         | 4,640         | 119       |
+| logql      | Lower_StreamMatcher                  | 1,157         | 680           | 15        |
+| optimizer  | Driver_Run                           | 9,566         | 4,880         | 62        |
+| promql     | Lower_Aggregation                    | 5,524         | 4,019         | 100       |
+| promql     | Lower_Binary                         | 3,456         | 2,576         | 64        |
+| promql     | Lower_Instant                        | 3,491         | 2,080         | 50        |
+| promql     | Lower_Range                          | 2,181         | 1,160         | 25        |
+| promql     | Lower_Subquery                       | 2,590         | 1,464         | 29        |
+| solver     | Slice/K=2                            | 1,900         | 1,984         | 28        |
+| solver     | Slice/K=4                            | 2,700         | 3,072         | 37        |
+| solver     | Slice/K=8                            | 3,650         | 5,376         | 54        |
+| solver     | Slice/K=16                           | 5,570         | 9,184         | 83        |
+| traceql    | Lower_AttributeMatcher               | 2,282         | 624           | 13        |
+| traceql    | Lower_MetricsPipeline                | 1,338         | 713           | 13        |
+| traceql    | Lower_StructuralChain                | 1,744         | 1,240         | 24        |
 
 ## Reproducing
 
@@ -262,3 +266,5 @@ just bench-report   # measures everything and rewrites this file in place
 - [`docs/performance.md`](performance.md) — the optimizer + perf architecture these numbers exercise.
 - [`docs/solver.md`](solver.md) — the sharded-pushdown solver (route B) in full: eligibility, slicing geometry, the memory cap.
 - [`docs/test-strategy.md`](test-strategy.md) — the perf-assessment test layers (scaling harness, corpus profiler, cardinality ratchet) that gate structural regressions in CI.
+
+The wall-clock micro-benchmarks above (including `solver.Slice/K=*`) run in the **weekly informational** `perf-benchmark` lane (`benchstat` diff, never gates) to avoid runner-variance flake. The deterministic structural regressions are guarded by the **gating** `perf-guards` chDB job instead: `TestOrderByDecision_ChDB` (granule-prune ratio floor), `TestSeriesFanout_ChDB` (the /series fan-in ceiling), and `TestSliceAllocs_ChDB` (the slicer copy-on-write allocation pin — fails if `slice()`'s allocs/op regress past their K=4 / K=16 bounds, i.e. if the off-spine sharing reverts to a per-shard `CloneNode`).

--- a/docs/clickhouse-optimizations.md
+++ b/docs/clickhouse-optimizations.md
@@ -90,6 +90,8 @@ field.
 | `condition_cache`        | 25.3       | stable       | (none)                                               | stamps `use_query_condition_cache=1` (+`enable_analyzer=1`, analyzer-gated) on predicate-stable read paths. Result-equivalent (a cache).                                                      |
 | `ts_grid_range`          | 25.6       | experimental | `allow_experimental_time_series_aggregate_functions` | opts eligible `rate(<counter>[<range>])` query_range shapes onto the native `timeSeriesRateToGrid` aggregate. Explicit-only (never auto).                                                     |
 | `ts_grid_resample`       | 25.6       | experimental | `allow_experimental_time_series_aggregate_functions` | opts the range-mode instant-vector staleness shape onto the native `timeSeriesResampleToGridWithStaleness` aggregate, retiring the argMax fan-out. Explicit-only (never auto).                |
+| `ts_grid_changes`        | 25.9       | experimental | `allow_experimental_time_series_aggregate_functions` | opts eligible `changes(<counter>[<range>])` query_range shapes onto the native `timeSeriesChangesToGrid` aggregate. Explicit-only (never auto).                                               |
+| `ts_grid_resets`         | 25.9       | experimental | `allow_experimental_time_series_aggregate_functions` | opts eligible `resets(<counter>[<range>])` query_range shapes onto the native `timeSeriesResetsToGrid` aggregate. Explicit-only (never auto).                                                 |
 | `columnar_result_decode` | none       | opt-in       | (none)                                               | client-side: decodes the `query_range` matrix shape via the ch-go columnar path (label map built once per run, not per row). No server setting, no version floor. Explicit-only (never auto). |
 
 Notes:
@@ -117,6 +119,18 @@ Notes:
   (`[anchor - lookback, anchor]`) which matches reference Prometheus, vs the
   fan-out's half-open `(anchor - lookback, anchor]`; they diverge only on a
   sample landing exactly on the left boundary.
+- **`ts_grid_changes`** / **`ts_grid_resets`** are the `changes()` / `resets()`
+  siblings of the `timeSeries*ToGrid` family: both are experimental and
+  **never** enabled by `auto`, reachable only by explicit listing in
+  `CERBERUS_CH_OPTIMIZATIONS`. Their floor is **25.9, NOT 25.6** -- the
+  `timeSeriesChangesToGrid` / `timeSeriesResetsToGrid` aggregates shipped a
+  quarter after the 25.6 rate/resample set, in ClickHouse PR #86010 (CH 25.9);
+  a 25.6 floor would mis-advertise support on 25.6-25.8 and fail with
+  `UNKNOWN_AGGREGATE_FUNCTION`. They share the same family experimental setting
+  (`allow_experimental_time_series_aggregate_functions`), co-stamped by the
+  engine on exactly the queries that emit the native node. Each wires as an
+  independent boot-decided PromQL lowering strategy (either can be on without
+  the other, and independently of `ts_grid_range` / `ts_grid_resample`).
 - **`columnar_result_decode`** is a **client-side** decode optimization with
   **no version floor** (`minVersion` is the always-available zero floor): it
   changes how cerberus reads the result blocks, not what it asks the server to
@@ -300,8 +314,11 @@ Nothing in this suite can break ClickHouse 24.8:
 - `aggregation_in_order` and `log_comment` are 24.8-safe (long-standing
   result-equivalent / free-form knobs).
 - `condition_cache` activates only on `>= 25.3`; below that it is a no-op.
-- `ts_grid_range` activates only on `>= 25.6` and is experimental
-  (explicit-only).
+- `ts_grid_range` and `ts_grid_resample` activate only on `>= 25.6` and are
+  experimental (explicit-only).
+- `ts_grid_changes` and `ts_grid_resets` activate only on `>= 25.9` and are
+  experimental (explicit-only); their native aggregates shipped a quarter after
+  the 25.6 family (CH PR #86010).
 - `columnar_result_decode` is client-side and version-agnostic (no server
   setting); it is explicit-only, so `auto` never engages it.
 - Under `auto`, an unsupported feature is simply not enabled.
@@ -310,8 +327,14 @@ Nothing in this suite can break ClickHouse 24.8:
 
 ## Build contract
 
-This section pins the exact public API, config names, consumption points,
-and wiring the builders must implement verbatim. It is derived from the
+This section is the **illustrative** API / config / wiring sketch the suite was
+built from. The feature list below is illustrative, not a verbatim mirror of the
+registry: the live source of truth for the feature ids, floors, and stability
+classes is the [Feature registry](#feature-registry) table above (and
+`internal/chopt/registry.go`), which now seeds seven features
+(`aggregation_in_order`, `condition_cache`, `ts_grid_range`, `ts_grid_resample`,
+`ts_grid_changes`, `ts_grid_resets`, `columnar_result_decode`). Treat the code
+blocks here as the shape, not the current count. It is derived from the
 `feat/chclient-query-instrumentation` foundation
 (`internal/chclient/query_settings.go`, `internal/engine/plan_shape_id.go`,
 `internal/engine/query_settings_rules.go`, `internal/config/config.go`,
@@ -388,7 +411,8 @@ func (s EnabledSet) Has(id string) bool
 func (s EnabledSet) IDs() []string // sorted, for boot logging
 
 // Registry returns the seeded feature registry (aggregation_in_order,
-// condition_cache, ts_grid_range). Exposed so tests can enumerate it.
+// condition_cache, ts_grid_range, ts_grid_resample, ts_grid_changes,
+// ts_grid_resets, columnar_result_decode). Exposed so tests can enumerate it.
 func Registry() []Feature
 
 // Resolve runs ONCE at startup, after the version probe. It returns the
@@ -404,19 +428,28 @@ stringly-typed drift):
 
 ```go
 const (
-  FeatureAggregationInOrder = "aggregation_in_order"
-  FeatureConditionCache     = "condition_cache"
-  FeatureTSGridRange        = "ts_grid_range"
+  FeatureAggregationInOrder   = "aggregation_in_order"
+  FeatureConditionCache       = "condition_cache"
+  FeatureTSGridRange          = "ts_grid_range"
+  FeatureTSGridResample       = "ts_grid_resample"
+  FeatureTSGridChanges        = "ts_grid_changes"
+  FeatureTSGridResets         = "ts_grid_resets"
+  FeatureColumnarResultDecode = "columnar_result_decode"
 )
 ```
 
-Seeded `Registry()` entries (verbatim):
+Seeded `Registry()` entries (illustrative -- the registry in
+`internal/chopt/registry.go` is the source of truth):
 
-| ID                       | MinVersion   | Stability        |
-| ------------------------ | ------------ | ---------------- |
-| `aggregation_in_order`   | `{24, 8}`    | `Stable`         |
-| `condition_cache`        | `{25, 3}`    | `Stable`         |
-| `ts_grid_range`          | `{25, 6}`    | `Experimental`   |
+| ID                       | MinVersion          | Stability        |
+| ------------------------ | ------------------- | ---------------- |
+| `aggregation_in_order`   | `{24, 8}`           | `Stable`         |
+| `condition_cache`        | `{25, 3}`           | `Stable`         |
+| `ts_grid_range`          | `{25, 6}`           | `Experimental`   |
+| `ts_grid_resample`       | `{25, 6}`           | `Experimental`   |
+| `ts_grid_changes`        | `{25, 9}`           | `Experimental`   |
+| `ts_grid_resets`         | `{25, 9}`           | `Experimental`   |
+| `columnar_result_decode` | `AlwaysAvailable`   | `Experimental`   |
 
 ### New config field names + env consts (`internal/config`)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -453,8 +453,10 @@ fatal startup error in **both** modes (a typo guard). The registry seeds
 `aggregation_in_order` (24.8, stable), `condition_cache` (25.3, stable),
 `ts_grid_range` (25.6, experimental), `ts_grid_resample` (25.6, experimental —
 opts the range-mode instant-vector staleness shape onto native
-`timeSeriesResampleToGridWithStaleness`), and `columnar_result_decode` (no
-version floor, opt-in); see
+`timeSeriesResampleToGridWithStaleness`), `ts_grid_changes` (25.9, experimental
+-- opts `changes()` onto native `timeSeriesChangesToGrid`), `ts_grid_resets`
+(25.9, experimental -- opts `resets()` onto native `timeSeriesResetsToGrid`), and
+`columnar_result_decode` (no version floor, opt-in); see
 [`clickhouse-optimizations.md`](clickhouse-optimizations.md) for the full table.
 Everything is version-safe: a feature whose floor sits above the connected
 server is simply not enabled, so the binary keeps emitting its 24.8-safe SQL.

--- a/docs/forbid-skip.md
+++ b/docs/forbid-skip.md
@@ -20,31 +20,39 @@ known baseline instead of re-deriving from CI failure tickers.
 
 ## Where the patterns live
 
-The patterns run in **two places**, and the two MUST stay in sync:
+The scans are implemented **once**, in `.github/scripts/forbid-skip.mjs`,
+which runs ONE discipline check per invocation selected by the `$CHECK`
+env var (`t-skip`, `not-implemented`, `soft-assert`, `should-skip`,
+`escape-hatch`). The regexes were extracted out of the old inline
+`ci.yml` bash into that script so the CI job and the local pre-push hook
+share a single source of truth. The script runs from **two callers**, and
+the two MUST stay in sync:
 
 1. `.github/workflows/ci.yml` job `forbid-skip` — required status check
-   on `main`.
+   on `main`. Each scan is a step that runs
+   `node .github/scripts/forbid-skip.mjs` with the matching `CHECK`.
 2. `lefthook.yml` `pre-push` hook — local-mirror of the same gate so a
    push that would have failed CI fails locally first.
 
 `scripts/test-forbid-skip.sh` is the assertion that the regexes still
 match their canonical positive examples and still reject the matching
 counter-examples below. It runs both as a standalone unit-test (invoke
-the script directly) and as a step inside the `forbid-skip` CI job. The
-lefthook `forbid-skip-self-test` command runs the same script on
-pre-push.
+the script directly) and as the "Self-test forbid-skip regex set" step
+inside the `forbid-skip` CI job. The lefthook `forbid-skip-self-test`
+command runs the same script on pre-push.
 
-The two locations carry **identical** patterns for rows 1–5 of the
-summary table below. Row 6 is enforced by the CI `forbid-skip` job step
-"Reject should_skip overlay entries", which rejects every non-empty
-`should_skip:` block in `compatibility/**/*.{yml,yaml}` outright.
+The `should_skip:` overlay rejection is the `should-skip` check, and the
+escape-hatch rejection is the `escape-hatch` check; both are CHECK
+selectors in the same `forbid-skip.mjs`, not separate inline steps.
 
 ## Adding a new pattern
 
 When a new offender shape is discovered:
 
-1. Add the new regex to **both** `.github/workflows/ci.yml` and
-   `lefthook.yml` in the same PR.
+1. Add the new regex to the matching `$CHECK` scan in
+   `.github/scripts/forbid-skip.mjs` (or add a new `$CHECK` and wire a
+   step for it in **both** `.github/workflows/ci.yml` and `lefthook.yml`)
+   in the same PR.
 2. Add a new row to the summary table below + a detailed subsection
    covering the regex, its intent, a match-example, and a
    counter-example.
@@ -58,19 +66,33 @@ shape.
 
 ## Summary
 
-| #   | Intent                                                                                                      | Scope                                                           | Origin        |
-| --- | ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- | ------------- |
-| 1   | Reject `t.Skip[fN]?` calls                                                                                  | `*_test.go`                                                     | #309          |
-| 2   | Reject "not implemented" wording in production code                                                         | `internal/**/*.go` (non-test)                                   | #197          |
-| 3   | Reject `assert.Contains(x, "")` soft assertion (2-arg + testify 3-arg)                                      | `*_test.go`                                                     | #587 / #277   |
-| 4   | Reject `assert.ElementsMatch(x, []T{})` soft assertion (2-arg + testify 3-arg)                              | `*_test.go`                                                     | #587 / #277   |
-| 5   | Reject silent panic recovery (`defer recover()` and the multi-line `defer func(){ _ = recover() }()` block) | `*_test.go`                                                     | #587 / #648   |
-| 6   | Reject any non-empty `should_skip:` block                                                                   | `compatibility/**/*.{yml,yaml}`                                 | #596          |
+The gate is **five `$CHECK` scans** (one `forbid-skip.mjs` invocation
+each). Two of them — `t-skip` and `not-implemented` — are a single regex
+apiece; the `soft-assert` scan bundles three related shapes (patterns 3-5
+below) into one invocation; `should-skip` and `escape-hatch` are the
+structural overlay / allow-list rejections. The pattern rows below
+expand the regexes; the `CHECK` column maps each to the scan that runs it.
 
-Row 6 rejects any non-empty `should_skip:` block outright (see
-`.github/workflows/ci.yml` `forbid-skip` job step "Reject should_skip
-overlay entries"). The only accepted form is `should_skip: []`; any
-element under the key fails CI.
+| #   | CHECK             | Intent                                                                                                      | Scope                                                           | Origin        |
+| --- | ----------------- | ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- | ------------- |
+| 1   | `t-skip`          | Reject `t.Skip[fN]?` calls                                                                                  | `*_test.go`                                                     | #309          |
+| 2   | `not-implemented` | Reject "not implemented" wording in production code                                                         | `internal/**/*.go` (non-test)                                   | #197          |
+| 3   | `soft-assert`     | Reject `assert.Contains(x, "")` soft assertion (2-arg + testify 3-arg)                                      | `*_test.go`                                                     | #587 / #277   |
+| 4   | `soft-assert`     | Reject `assert.ElementsMatch(x, []T{})` soft assertion (2-arg + testify 3-arg)                              | `*_test.go`                                                     | #587 / #277   |
+| 5   | `soft-assert`     | Reject silent panic recovery (`defer recover()` and the multi-line `defer func(){ _ = recover() }()` block) | `*_test.go`                                                     | #587 / #648   |
+| 6   | `should-skip`     | Reject any non-empty `should_skip:` block                                                                   | `compatibility/**/*.{yml,yaml}`                                 | #596          |
+| 7   | `escape-hatch`    | Reject test-suite escape-hatch / tolerance primitives                                                       | `*.ts`, `*.tsx`, `*.go`                                         | #712 / #844   |
+
+So: **seven documented pattern rows across five `$CHECK` scans**. The
+prior "6 patterns" framing both predated the escape-hatch row (a
+pre-existing documentation gap — the scan has shipped since #712/#844 but
+was never tabled here) and counted the three `soft-assert` shapes as
+separate "patterns" while the gate runs them as one check.
+
+Row 6 (`should-skip`) rejects any non-empty `should_skip:` block outright
+(`forbid-skip.mjs` `CHECK=should-skip`, the "Reject should_skip overlay
+entries" step). The only accepted form is `should_skip: []`; any element
+under the key fails CI.
 
 Vendored upstream snapshots under `compatibility/*/upstream/**` are
 excluded from every test-file / fixture grep — they sit outside
@@ -180,12 +202,44 @@ used in real tests.
 
 ## Pattern 6 — `should_skip:` compatibility overlay
 
-The `forbid-skip` CI job step "Reject should_skip overlay entries"
-rejects ANY non-empty `should_skip:` block in
-`compatibility/**/*.{yml,yaml}` outright. A compatibility corpus entry
-is either scored against the reference or it is not in the corpus —
-there is no per-case skip overlay, so the gate forbids the construct
-itself rather than auditing each entry's tracking ref.
+The `should-skip` scan (`forbid-skip.mjs` `CHECK=should-skip`, the
+"Reject should_skip overlay entries" CI step) rejects ANY non-empty
+`should_skip:` block in `compatibility/**/*.{yml,yaml}` outright. A
+compatibility corpus entry is either scored against the reference or it
+is not in the corpus — there is no per-case skip overlay, so the gate
+forbids the construct itself rather than auditing each entry's tracking
+ref.
+
+## Pattern 7 - test escape-hatch primitives (PR #712, widened #844)
+
+The `escape-hatch` scan (`forbid-skip.mjs` `CHECK=escape-hatch`, the
+"Reject test escape-hatch patterns" CI step) rejects the allow-list /
+tolerance / soft-assert primitives that mask a real failure instead of
+surfacing it. The deletion of the harness escape-hatch mechanisms landed
+in #712; the scan keeps them from coming back.
+
+Regex (ERE alternation over `*.ts`, `*.tsx`, `*.go`, excluding
+`compatibility/*/upstream/**`, `**/node_modules/**`, `vendor/**`,
+`.claude/**`):
+
+```text
+EXPECTED_EMPTY|EXPECTED_TOLERATED|isKnownTolerated|tolerated404|
+expect\.soft|should_tolerate|skipReason|SkipReason|
+APP_NOT_INSTALLED_BANNER_PATTERNS|DRILLDOWN_UPSTREAM_GRAFANA_CONSOLE_NOISE
+```
+
+Each alternative is a documented anti-pattern: `EXPECTED_EMPTY` /
+`EXPECTED_TOLERATED` / `isKnownTolerated*` / `tolerated404` are allow-list
+arrays consulted before failing; `expect.soft(...)` is a Playwright
+assertion that records a failure but lets the test continue; `should_skip`
+/ `should_tolerate` in code re-introduce the removed YAML schema;
+`skipReason` / `SkipReason` is the removed loki-driver overlay skip field.
+The rule: every assertion must fail loud — fix the bug at the source
+(cerberus code, seed, dashboard, panel) rather than mask it.
+
+- Matches: `if (EXPECTED_TOLERATED.includes(name)) return;`
+- Matches: `expect.soft(rows).toHaveLength(0)`
+- Does NOT match: `expect(rows).toHaveLength(0)` (a hard assertion)
 
 ## Redundancy review
 
@@ -201,7 +255,9 @@ redundancies — each catches a shape the others would miss:
   patterns 3 / 4 because pattern 5 needs the `perl -0777` slurp to
   span lines.
 
-The gate's total active pattern count: **6** (patterns 1–6 above).
-Patterns 1–5 run over Go test files / production code;
-pattern 6 is the strict overlay-entry rejection over the compatibility
-YAML.
+The gate's total active pattern count: **7** documented pattern rows
+(patterns 1–7 above), run as **5 `$CHECK` scans** (patterns 3–5 share the
+single `soft-assert` scan). Patterns 1–5 run over Go test files /
+production code; pattern 6 is the strict overlay-entry rejection over the
+compatibility YAML; pattern 7 (`escape-hatch`) runs over the `*.ts` /
+`*.tsx` / `*.go` tree.

--- a/docs/native-clickhouse-roadmap.md
+++ b/docs/native-clickhouse-roadmap.md
@@ -1,8 +1,8 @@
 # Native ClickHouse roadmap — shipping cerberus's heavy lowerings as `timeSeries*ToGrid` aggregates
 
 Status: research synthesis + ranked roadmap. The first weapon
-(`timeSeriesIncreaseToGrid`) is staged ready-to-apply under
-[`docs/clickhouse-contrib/timeSeriesIncreaseToGrid/`](./clickhouse-contrib/timeSeriesIncreaseToGrid/).
+(`timeSeriesIncreaseToGrid`) was staged out-of-tree as a ClickHouse upstream
+contribution (removed from this repo in #987).
 
 CI-UNVALIDATED: no C++ in this roadmap or the staged contrib was compiled in
 this environment. Everything is source-grounded and fidelity-reviewed against
@@ -116,8 +116,9 @@ Cerberus-side follow-up: add `"increase": "timeSeriesIncreaseToGrid"` to
 setting is stamped by the engine (`chopt.FeatureTSGridRange` ->
 `allow_experimental_time_series_aggregate_functions=1`), not emitted as SQL.
 
-Full instructions, the C++ snippet/patch, and the test are staged under
-[`docs/clickhouse-contrib/timeSeriesIncreaseToGrid/`](./clickhouse-contrib/timeSeriesIncreaseToGrid/).
+The full instructions, the C++ snippet/patch, and the test were staged
+out-of-tree as a ClickHouse upstream contribution (removed from this repo in
+PR #987).
 
 ## Bypass-SQL verdict
 

--- a/docs/optimization-rules.md
+++ b/docs/optimization-rules.md
@@ -75,10 +75,12 @@ speedup, and a reflection or library clone that cannot preserve unexported and
 interface fields correctly is disqualified regardless of its speed.)
 
 The real lever is structural: clone LESS. On the slicer hot path,
-`chplan.ReanchorRange` deep-copies a byte-identical off-spine subtree K+1
-times; copy-on-write sharing of the immutable off-spine collapses that to
-O(spine-depth) and measures 9-13x faster with ~17x fewer allocations at
-K = 2..16.
+`chplan.ReanchorRange` used to deep-copy a byte-identical off-spine subtree K+1
+times; copy-on-write sharing of the immutable off-spine now collapses that to
+O(spine-depth). On the committed reproducible `BenchmarkSlice` (the canonical
+`sum by (job)(rate(...))` shape) this measures ~2-2.5x faster with ~50-73% fewer
+allocations at K = 2..16. A wide off-spine subtree can push the win far higher
+(the 17-37x range), but that is an outlier, not the representative figure.
 
 Process rule: any change motivated by cloning cost must be backed by a
 benchmark against the current code, in a throwaway tree, before it is adopted.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -44,8 +44,10 @@ Two architectural invariants frame the whole approach:
   `sum(rate(m[5m]))` at a fine step over a wide range), where one statement's
   peak intermediate cardinality exceeds the CH memory cap. For *that class
   only*, the `internal/solver` orchestrator ([`solver.md`](solver.md))
-  re-anchors `K` deep copies of the **same already-optimized plan** onto
-  disjoint slices of the anchor grid, emits each via the existing `chsql.Emit`,
+  re-anchors `K` copy-on-write views of the **same already-optimized plan** onto
+  disjoint slices of the anchor grid -- each shard shares the immutable off-spine
+  subtree and clones only the `O(spine-depth)` re-gridded spine path --
+  emits each via the existing `chsql.Emit`,
   and concatenates the result streams behind the existing cursor. There is **no
   new evaluator and no new SQL template** — every shard runs the same
   compat-gated route-A SQL, restricted to its anchor sub-grid. The solver routes
@@ -186,6 +188,17 @@ the unknown shapes.
 Improvements are always allowed (a fan-factor *decrease* never blocks); the
 ceiling only tightens when a maintainer re-runs
 `just update-cardinality-baseline`.
+
+A separate structural win holds the slicer's copy-on-write off-spine sharing in
+place. `chplan.ReanchorRange` shares the immutable off-spine subtree across the
+`K` shards instead of `CloneNode`-ing it K+1 times; the wall-clock measurement
+lives in the weekly informational `perf-benchmark` lane
+(`internal/solver.BenchmarkSlice`, which never gates), so the gating guard is a
+deterministic allocation pin -- `TestSliceAllocs_ChDB` in the `perf-guards` chDB
+job. It asserts `slice()`'s allocs/op stays under a pinned ceiling at K=4 and
+K=16, so a revert of the COW sharing back to a per-shard `CloneNode` re-inflates
+the allocation count past the bound and fails a required check rather than
+silently regressing.
 
 ### Set-op chains: N-ary linearisation
 

--- a/docs/solver.md
+++ b/docs/solver.md
@@ -97,8 +97,11 @@ header.
 ## Slicing geometry
 
 Slicing decomposes the eval grid into `K` disjoint, on-grid anchor sub-grids
-and re-anchors a deep copy of the plan onto each. It is pure arithmetic over
-the anchor grid plus one re-anchor per slice; the input plan is never mutated.
+and re-anchors a copy-on-write view of the plan onto each: each shard SHARES the
+immutable off-spine subtree verbatim and clones only the `O(spine-depth)`
+re-gridded spine path. It is pure arithmetic over the anchor grid plus one
+re-anchor per slice; the input plan is never mutated, and no shard ever aliases
+a mutable node.
 
 Anchors are defined backward from `End`:
 
@@ -148,13 +151,22 @@ emptied. `D` is the cumulative spine lookback recovered by walking the spine.
 **Re-anchoring.** The plan that reaches the slicer is pinned at the full
 request grid (the grid-prediction guard already verified it sits exactly
 there). To re-grid each slice onto a sub-window, the slicer first builds one
-deep, spine-unpinned copy: the windowed-spine bounds (`RangeWindow` /
-`RangeLWR` `Start`, `End`, and the matrix `OuterRange`) are zeroed. This is
-safe because signal 5 already proved every spine node sits on the predicted
-grid, so the zeroed information is exactly what the re-anchor recomputes.
-`ReanchorRange` then fills each slice's grid into a deep copy of that base.
-Off-spine nodes are carried verbatim by the clone; the original plan is never
-touched.
+spine-unpinned, copy-on-write view (`unpinSpine`): the windowed-spine bounds
+(`RangeWindow` / `RangeLWR` `Start`, `End`, and the matrix `OuterRange`) are
+zeroed. This is safe because signal 5 already proved every spine node sits on
+the predicted grid, so the zeroed information is exactly what the re-anchor
+recomputes. `unpinSpine` clones ONLY the spine-path nodes it zeroes (and their
+ancestors back to the root, the `O(spine-depth)` chain) and SHARES every
+immutable off-spine subtree -- with a descend-and-clone guard that, on an
+off-spine subtree which itself carries a windowed node needing zeroing (e.g. a
+`TopK.KExpr` computed-K plan), clones the path down to that inner node so the
+shared original is never mutated. `ReanchorRange` then fills each slice's grid
+in, again sharing the immutable off-spine across all `K` shards rather than deep
+copying it. The original plan is never touched, and the no-mutate-after-slice
+invariant holds: the shards run through emit only, which never mutates a plan
+node in place, so the shared off-spine is safe to alias (enforced by the
+immutability guards in `internal/solver`). A later pass that mutates a shared
+off-spine node must add its own clone.
 
 ## Execution and cursor model
 


### PR DESCRIPTION
Reconciles a 4-cluster docs-vs-code audit ahead of the v1.1.0 tag. Every claim
was verified against the actual source of truth: `internal/chopt/registry.go`,
`internal/solver/slicer.go`, `internal/chplan/reanchor.go`,
`.github/scripts/forbid-skip.mjs`, and the committed `BenchmarkSlice` /
`TestSliceAllocs_ChDB`. Docs-only + CI-config-only; no Go behaviour changes.

## Checklist (audit finding -> fix)

### Blockers
- [x] **1.** `native-clickhouse-roadmap.md` two dead `clickhouse-contrib`
  links (dir removed in #987) reworded to plain text; file kept; added to the
  README docs index.
- [x] **2.** `clickhouse-optimizations.md` feature-registry table: added
  `ts_grid_changes` and `ts_grid_resets` rows (floor 25.9, experimental,
  `allow_experimental_time_series_aggregate_functions`, native
  `timeSeriesChangesToGrid` / `timeSeriesResetsToGrid`).
- [x] **3.** Per-feature note for the changes/resets siblings: floor **25.9 NOT
  25.6** (CH PR #86010), experimental + explicit-only, shared family setting,
  independent boot-decided strategies.
- [x] **4.** Build-contract snapshot marked **illustrative** (registry is the
  SoT) and its id/registry tables refreshed to all 7 features; Version-safety
  list extended with changes/resets (+ resample).
- [x] **5.** `solver.md` slicing reworded from deep-copy to the merged
  **copy-on-write** share-immutable-off-spine contract (#988): clones only the
  O(spine-depth) spine path, descend-and-clone for off-spine windowed subtrees,
  no-mutate-after-slice invariant. Cross-checked against `reanchor.go` +
  `slicer.go` as merged on main.
- [x] **6.** `optimization-rules.md` Rule 2 (minimal): figure corrected to the
  committed reproducible `BenchmarkSlice` (canonical `sum(rate())`) at
  **~2-2.5x faster / ~50-73% fewer allocs**, wide-off-spine case noted as the
  17-37x outlier; present-tense "deep-copies" -> past-tense "used to deep-copy
  ... now shares". Only this rule touched.

### Should-fix
- [x] **7.** `configuration.md` inline registry summary: appended
  `ts_grid_changes` / `ts_grid_resets` (25.9).
- [x] **8.** `performance.md`: "re-anchors K deep copies" -> COW wording; added
  a note on the COW slicer win + the gating `TestSliceAllocs_ChDB` alloc pin.
- [x] **9.** `benchmarks.md`: added `solver.BenchmarkSlice` rows to the
  micro-bench table; added the weekly-informational-`perf-benchmark`-vs-gating-
  `perf-guards` distinction and `TestSliceAllocs_ChDB` to the structural-
  regressions pointer.
- [x] **10.** `forbid-skip.md`: documented the `escape-hatch` scan (pre-existing
  gap from #712/#844); reconciled "6 patterns" vs the canonical **5 `$CHECK`
  scans**; fixed the where-the-patterns-live text (scans run via
  `.github/scripts/forbid-skip.mjs`, not inline in `ci.yml`).
- [x] **11.** `CLAUDE.md` (AGENTS.md symlink): "12-layer" -> "13-layer".
- [x] **12.** `README.md` docs index: added `optimization-rules.md`,
  `clickhouse-optimizations.md`, `native-clickhouse-roadmap.md`.

### CI gaps (docs/CI in sync with code)
- [x] **13.** `perf-benchmark.yml`: added `internal/solver/**` to the path
  filter so `BenchmarkSlice` runs on solver PRs, not only the Sunday cron.
- [x] **14.** `chdb.yml`: added `TestSliceAllocs_ChDB` to the `perf-guards`
  doc-comment.

## Scope boundaries (owned by other PRs - NOT touched here)
- The roadmap ranked-table changes/resets **rows** are owned by #990 (now merged
  to main). This PR only reworded the 2 dead links in that file; the rebase took
  main's ranked table verbatim (rows 3a/3b intact).
- The version-sync rule + central versions file + version refs are owned by a
  separate version-SoT PR. In `optimization-rules.md` only the minimal Rule 2
  perf-number fix was made; no rules added or restructured.
- `deploy/helm/cerberus/Chart.yaml` version/appVersion bump + CHANGELOG entries
  belong to the release-cut, not this PR.

## Validation
- `markdownlint-cli2` on all 10 changed docs: 0 errors (tables realigned via
  `scripts/align-md-tables.py` for MD060).
- `actionlint` on both changed workflows: clean.
- `scripts/test-forbid-skip.sh`: 15/15 OK (doc still matches the regex set).
- Post-rebase, #990's registry entries (`FeatureTSGridChanges` /
  `FeatureTSGridResets`, `{25, 9}`) are on main, so the changes/resets docs
  additions are backed by code, not pre-staged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)