### PR TITLE
ci: add internal/external link + doc-to-code reference gates

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -38,6 +38,33 @@ wrapper, plus `appendStepSummary` / `setOutput` for the runner files.
   - Args: `--self-test` pins the parse / compare / drift-detection logic
     (run as a CI step before the gate); no args runs the gate over the tree.
   - Exit: `0` consistent (or self-test green), `1` on any drift.
+- **`doc-refs.mjs`** — `ci.yml`, the `doc-to-code reference check` step in
+  the `lint` job. The GATE that keeps prose docs honest about the code they
+  cite: greps `docs/**/*.md` for inline `(internal|cmd|test|deploy)/<path>.go`
+  references (with an optional leading module prefix, so
+  `compatibility/prometheus/cmd/seed/prom_remote.go` is captured WHOLE) and
+  HARD-FAILS when the path no longer exists (`git ls-files`). A `:line` /
+  `:start-end` pin is BOUNDS-checked only — fail iff the (high) line exceeds
+  the file's length; docs pin approximate / tilde line numbers that drift by
+  a line as code moves, so the cited line is NOT required to contain anything
+  specific, only to be in range. A trailing-slash / no-`.go` token is a
+  directory-existence check. `./`/`../`-prefixed tokens are accepted under
+  EITHER the repo-root or doc-relative interpretation (a `go test ./test/...`
+  snippet vs a `[..](../test/..)` markdown link), so only a path dead under
+  every interpretation is a violation. Vendored snapshots
+  (`compatibility/*/upstream/**`) are excluded, mirroring the markdownlint /
+  forbid-skip exclude set. Structure mirrors `forbid-skip.mjs`: pure exported
+  helpers + a `--self-test` flag; `doc-refs.test.mjs` is the `node --test`
+  guard (cheap lint lane) that pins the extraction regex + verdict logic and
+  proves each detector fires. The companion lychee gates are the OFFLINE
+  internal `link-check` job (ci.yml) and the schedule-only
+  `link-check-external.yml` — link existence/anchors vs doc-to-code path
+  existence are complementary, non-overlapping concerns.
+  - Env: `DOCS_GLOBS` (optional; default `:(glob)docs/**/*.md`); argv
+    `--self-test` runs the in-process assertion suite.
+  - Exit: `0` when every cited path exists + pins are in range (or self-test
+    passes), `1` on any dead reference / out-of-range pin (or a failed
+    self-test).
 - **`gremlins-threshold.mjs`** — `mutation.yml`, the
   `enforce efficacy threshold` step.
   - Env: `REPORT` (default `gremlins.json`), `THRESHOLD` (a number).

--- a/.github/scripts/doc-refs.mjs
+++ b/.github/scripts/doc-refs.mjs
@@ -1,0 +1,363 @@
+// doc-refs.mjs — the doc-to-code reference-integrity gate.
+//
+// Scans the prose docs (docs/**/*.md) for inline references to cerberus
+// source files and HARD-FAILS when a referenced path no longer exists. A
+// doc that cites `internal/promql/lower.go:1924` or
+// `compatibility/prometheus/cmd/seed/prom_remote.go` is making a promise the
+// tree must keep; this gate catches the promise rotting after a rename /
+// delete (the dead `cmd/seed/prom_remote.go` cite in docs/compatibility.md
+// is the canonical motivating case).
+//
+// What it matches. A reference is a path-like token, bounded by a
+// non-path character on both sides, whose segments include one of the
+// cerberus top-level source dirs as a path segment:
+//
+//   (internal|cmd|test|deploy)
+//
+// allowing an OPTIONAL leading prefix (so a nested module path such as
+// `compatibility/prometheus/cmd/seed/prom_remote.go` is captured WHOLE, not
+// truncated to its `cmd/...` tail — truncating would make a valid path look
+// dead). Two shapes:
+//
+//   - FILE ref: the token ends in `.go`, optionally pinned with `:line`
+//     or `:start-end`. The file must exist (`git ls-files`). For a pin we
+//     do a BOUNDS check only: fail iff the (high) line number exceeds the
+//     file's line count. Docs pin approximate / tilde line numbers and
+//     ranges that drift by a line or two as code moves, so we deliberately
+//     do NOT require the cited line to contain anything in particular —
+//     only that it is in range. An out-of-range pin is a real staleness
+//     signal (the file shrank past the cite); a slightly-off in-range pin
+//     is tolerated by design.
+//
+//   - DIR ref: the token ends in `/` and has no `.go`. The directory must
+//     exist as a tracked path (any `git ls-files` entry under it).
+//
+// Non-goals. This is NOT a markdown link checker (lychee owns that) and
+// NOT a symbol/line-content checker. It only answers "does the cited path
+// still exist, and is the line pin in range".
+//
+// Vendored upstream snapshots (`compatibility/*/upstream/**`) are NOT
+// scanned for references and NEVER count as the existence target — they
+// mirror the markdownlint / forbid-skip exclude set.
+//
+// Structure mirrors forbid-skip.mjs: pure exported helpers (so
+// doc-refs.test.mjs can drive them with `node --test`), an env/argv entry
+// point, and a `--self-test` flag that runs the same in-process assertions
+// the test file does (parity with forbid-skip's self-test idiom) so the
+// detectors can't silently rot into a no-op.
+//
+// Env / argv contract:
+//   argv `--self-test`   run the in-process assertion suite, exit 0/1.
+//   DOCS_GLOBS           pathspec list (default `docs/**/*.md`).
+//   (no other input)     scan the live tree, exit 0 clean / 1 on any
+//                        missing path or out-of-range pin.
+//
+// Exit codes: 0 = every referenced path exists and pins are in range,
+// 1 = at least one dead reference (or a failed --self-test).
+
+import { readFileSync, existsSync, statSync } from 'node:fs';
+import { posix as posixPath } from 'node:path';
+import process from 'node:process';
+import { lsFiles, error, log, notice } from './lib/gh.mjs';
+
+// Top-level cerberus source dirs a reference may anchor on. A token only
+// counts as a code reference if one of these appears as a path SEGMENT.
+const ANCHOR = '(?:internal|cmd|test|deploy)';
+
+// FILE ref: optional `prefix/` segments, then the anchor segment, then the
+// rest of the path ending in `.go`, then an OPTIONAL `:line` / `:start-end`
+// pin. Bounded by a non-path char (or string edge) on the left via a
+// look-behind and by a non-word char on the right.
+const FILE_RE = new RegExp(
+  String.raw`(?<![\w./-])((?:[\w.-]+\/)*` + ANCHOR + String.raw`\/[\w./-]*?\.go)(?::(\d+)(?:-(\d+))?)?(?![\w])`,
+  'g',
+);
+
+// DIR ref: optional `prefix/` segments, the anchor segment, then one or
+// more further segments, ending in `/` (and NOT a `.go` path — the `(?![\w])`
+// right-bound plus the trailing slash rule out file paths, whose next char
+// after a slash is a word char).
+const DIR_RE = new RegExp(
+  String.raw`(?<![\w./-])((?:[\w.-]+\/)*` + ANCHOR + String.raw`\/(?:[\w.-]+\/)+)(?![\w])`,
+  'g',
+);
+
+// extractRefs(text) — parse one doc's text into { files, dirs }.
+//   files: [{ path, line }]  line = high line number of the pin, or null.
+//   dirs:  [path, ...]       each ends in `/`.
+// Duplicates are preserved so the caller can report every citing site; the
+// reporter dedupes for the summary.
+export function extractRefs(text) {
+  const files = [];
+  const dirs = [];
+  let m;
+  FILE_RE.lastIndex = 0;
+  while ((m = FILE_RE.exec(text)) !== null) {
+    const high = m[3] !== undefined ? Number(m[3]) : m[2] !== undefined ? Number(m[2]) : null;
+    files.push({ path: m[1], line: high });
+  }
+  DIR_RE.lastIndex = 0;
+  while ((m = DIR_RE.exec(text)) !== null) {
+    dirs.push(m[1]);
+  }
+  return { files, dirs };
+}
+
+// candidatePaths(token, docPath) — the set of repo-root-relative paths a
+// matched token could legitimately denote. A token is "alive" iff ANY
+// candidate exists; only a token dead under EVERY interpretation is a
+// violation. Two interpretations are inherently ambiguous in prose:
+//
+//   - REPO-ROOT: bare tokens (`test/spec/`, `internal/promql/lower.go`) and
+//     shell-snippet `./`-prefixed tokens (`go test ./test/rejection-parity/`,
+//     where `./` is the cwd = repo root) are root-relative.
+//   - DOC-RELATIVE: a markdown link target written `../x` (and sometimes
+//     `./x`) is relative to the CITING doc's directory
+//     (docs/coverage.md -> `../test/...` = repo-root `test/...`).
+//
+// Rather than guess which one a given `./`/`../` token is, we try BOTH and
+// accept existence under either. A genuinely stale citation (the dead
+// `cmd/seed/prom_remote.go`) resolves to a non-existent path under every
+// interpretation, so the gate still fires. Trailing slash is preserved for
+// dir tokens so the classifier keeps treating them as directories.
+export function candidatePaths(token, docPath) {
+  const isDir = token.endsWith('/');
+  const finish = (p) => {
+    let r = posixPath.normalize(p);
+    if (isDir && !r.endsWith('/')) r += '/';
+    return r;
+  };
+  const out = new Set();
+  // Repo-root interpretation: strip a leading `./`, keep `../` literal (a
+  // `../` from repo root escapes the tree and simply won't exist — harmless).
+  out.add(finish(token.replace(/^\.\//, '')));
+  // Doc-relative interpretation for `./` and `../` tokens.
+  if (token.startsWith('./') || token.startsWith('../')) {
+    out.add(finish(posixPath.join(posixPath.dirname(docPath), token)));
+  }
+  return [...out].filter((p) => p && !p.startsWith('../'));
+}
+
+// isUpstream(path) — vendored snapshot under compatibility/<head>/upstream/.
+// Such paths are excluded as BOTH a scan source and an existence target.
+export function isUpstream(path) {
+  return /^compatibility\/[^/]+\/upstream\//.test(path);
+}
+
+// lineCount(path) — number of lines in a file. A trailing newline does not
+// add a phantom line (matches `wc -l + 1`-free intuition for pins: the last
+// content line is the max valid pin).
+function lineCount(path) {
+  const text = readFileSync(path, 'utf8');
+  if (text.length === 0) return 0;
+  const n = text.split('\n').length;
+  // A trailing newline yields a final empty element; the last real line is n-1.
+  return text.endsWith('\n') ? n - 1 : n;
+}
+
+// checkFileRef(ref, { exists, count }) — pure verdict for one file ref.
+// Injectable fs probes keep it unit-testable. Returns null on OK, or a
+// violation string. `exists(path)` -> bool, `count(path)` -> number.
+export function checkFileRef(ref, probes) {
+  if (isUpstream(ref.path)) return null; // never target a vendored snapshot
+  if (!probes.exists(ref.path)) {
+    return `missing file: ${ref.path}`;
+  }
+  if (ref.line !== null) {
+    const n = probes.count(ref.path);
+    if (ref.line > n) {
+      return `line pin out of range: ${ref.path}:${ref.line} (file has ${n} lines)`;
+    }
+  }
+  return null;
+}
+
+// checkDirRef(path, { dirExists }) — pure verdict for one dir ref.
+export function checkDirRef(path, probes) {
+  if (isUpstream(path)) return null;
+  if (!probes.dirExists(path)) {
+    return `missing directory: ${path}`;
+  }
+  return null;
+}
+
+// Live-tree probes backed by git ls-files (tracked-only — an untracked
+// scratch file does not satisfy a doc reference) and the filesystem.
+function liveProbes() {
+  const tracked = new Set(lsFiles(['*.go']).map((p) => p));
+  // For dir existence we need ALL tracked paths, not just *.go.
+  const allTracked = lsFiles([':/']);
+  const trackedPrefixes = allTracked;
+  return {
+    exists: (p) => tracked.has(p) || (existsSync(p) && allTracked.includes(p)),
+    count: (p) => lineCount(p),
+    dirExists: (dir) => {
+      const norm = dir.endsWith('/') ? dir : `${dir}/`;
+      return trackedPrefixes.some((p) => p.startsWith(norm)) || (existsSync(dir) && safeIsDir(dir));
+    },
+  };
+}
+
+function safeIsDir(p) {
+  try {
+    return statSync(p).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+// scan() — the live-tree gate. Returns { violations, refCount }.
+export function scan({ globs } = {}) {
+  // `:(glob)` magic makes `**` cross directory boundaries AND match files
+  // directly under docs/ (a bare `docs/**/*.md` git pathspec requires an
+  // intermediate dir and so silently matches NONE of the top-level docs).
+  const pathspecs = (globs && globs.length ? globs : [':(glob)docs/**/*.md']).concat([
+    ':!:compatibility/*/upstream/**',
+  ]);
+  const docFiles = lsFiles(pathspecs);
+  const probes = liveProbes();
+  const violations = [];
+  let refCount = 0;
+  for (const doc of docFiles) {
+    const text = readFileSync(doc, 'utf8');
+    const { files, dirs } = extractRefs(text);
+    for (const ref of files) {
+      refCount += 1;
+      const candidates = candidatePaths(ref.path, doc);
+      // Alive iff SOME candidate passes; report the first (repo-root) verdict
+      // when all fail, so the message names the canonical interpretation.
+      const verdicts = candidates.map((p) => checkFileRef({ path: p, line: ref.line }, probes));
+      if (candidates.length === 0 || verdicts.every((v) => v !== null)) {
+        violations.push(`${doc}: ${verdicts[0] ?? `missing file: ${ref.path}`}`);
+      }
+    }
+    for (const dir of dirs) {
+      refCount += 1;
+      const candidates = candidatePaths(dir, doc);
+      const verdicts = candidates.map((p) => checkDirRef(p, probes));
+      if (candidates.length === 0 || verdicts.every((v) => v !== null)) {
+        violations.push(`${doc}: ${verdicts[0] ?? `missing directory: ${dir}`}`);
+      }
+    }
+  }
+  return { violations, refCount };
+}
+
+// ---------------------------------------------------------------------------
+// --self-test: in-process assertions that pin the regex + verdict behaviour,
+// mirroring forbid-skip's self-test idiom. doc-refs.test.mjs drives the same
+// exported helpers via `node --test`; this flag keeps a dep-free smoke run.
+// ---------------------------------------------------------------------------
+function selfTest() {
+  let failures = 0;
+  const ok = (cond, msg) => {
+    if (cond) {
+      log(`  ok   ${msg}`);
+    } else {
+      failures += 1;
+      log(`  FAIL ${msg}`);
+    }
+  };
+
+  // 1. Nested-module path is captured WHOLE (not truncated to its cmd/ tail).
+  {
+    const { files } = extractRefs('see `compatibility/prometheus/cmd/seed/prom_remote.go` here');
+    ok(
+      files.length === 1 && files[0].path === 'compatibility/prometheus/cmd/seed/prom_remote.go',
+      'nested cmd/ path captured whole',
+    );
+  }
+
+  // 2. Bare anchor path + line range parse; high bound is taken.
+  {
+    const { files } = extractRefs('`internal/promql/lower.go:1924-1926`');
+    ok(
+      files.length === 1 && files[0].path === 'internal/promql/lower.go' && files[0].line === 1926,
+      'line range high-bound parsed',
+    );
+  }
+
+  // 3. Single-line pin parses.
+  {
+    const { files } = extractRefs('`internal/config/config.go:425`');
+    ok(files[0] && files[0].line === 425, 'single line pin parsed');
+  }
+
+  // 4. A directory ref is classified as a dir, not a file.
+  {
+    const { files, dirs } = extractRefs('staged under `internal/foo/bar/`');
+    ok(files.length === 0 && dirs.length === 1 && dirs[0] === 'internal/foo/bar/', 'dir ref classified');
+  }
+
+  // 5. A non-anchored path (e.g. docs/foo.go) is NOT a code reference.
+  {
+    const { files } = extractRefs('`docs/clickhouse-contrib/example.md` and `pkg/util/x.go`');
+    ok(files.length === 0, 'non-anchored paths ignored');
+  }
+
+  // 6. checkFileRef HARD-FAILS on a missing file (the motivating case).
+  {
+    const probes = { exists: () => false, count: () => 0 };
+    const v = checkFileRef({ path: 'cmd/seed/prom_remote.go', line: null }, probes);
+    ok(v !== null && v.includes('missing file'), 'missing file fails');
+  }
+
+  // 7. checkFileRef tolerates an in-range pin, fails an out-of-range pin.
+  {
+    const probes = { exists: () => true, count: () => 500 };
+    ok(checkFileRef({ path: 'internal/x.go', line: 425 }, probes) === null, 'in-range pin passes');
+    const v = checkFileRef({ path: 'internal/x.go', line: 9999 }, probes);
+    ok(v !== null && v.includes('out of range'), 'out-of-range pin fails');
+  }
+
+  // 8. A vendored upstream snapshot is never targeted.
+  {
+    const probes = { exists: () => false, count: () => 0 };
+    ok(
+      checkFileRef({ path: 'compatibility/prometheus/upstream/x.go', line: null }, probes) === null,
+      'upstream snapshot excluded',
+    );
+  }
+
+  // 9. checkDirRef fails a missing directory.
+  {
+    const v = checkDirRef('internal/gone/', { dirExists: () => false });
+    ok(v !== null && v.includes('missing directory'), 'missing dir fails');
+  }
+
+  if (failures > 0) {
+    error(`doc-refs.mjs --self-test: ${failures} assertion(s) failed`);
+    process.exit(1);
+  }
+  notice('doc-refs.mjs --self-test: all assertions passed');
+  process.exit(0);
+}
+
+// ---------------------------------------------------------------------------
+// Entry point.
+// ---------------------------------------------------------------------------
+function isMain() {
+  // True when executed directly (`node doc-refs.mjs`), false when imported.
+  const invoked = process.argv[1] || '';
+  return invoked.endsWith('doc-refs.mjs');
+}
+
+if (isMain()) {
+  if (process.argv.includes('--self-test')) {
+    selfTest();
+  } else {
+    const globsEnv = (process.env.DOCS_GLOBS || '').trim();
+    const globs = globsEnv ? globsEnv.split(/\s+/) : undefined;
+    const { violations, refCount } = scan({ globs });
+    if (violations.length > 0) {
+      for (const v of violations) log(v);
+      error(
+        `doc-to-code reference check: ${violations.length} dead reference(s) found across ${refCount} cited paths. ` +
+          `Update the doc to the current path/line, or remove the stale citation.`,
+      );
+      process.exit(1);
+    }
+    notice(`doc-to-code reference check: all ${refCount} cited code paths exist and pins are in range`);
+    process.exit(0);
+  }
+}

--- a/.github/scripts/doc-refs.test.mjs
+++ b/.github/scripts/doc-refs.test.mjs
@@ -1,0 +1,101 @@
+// doc-refs.test.mjs — node:test guard for the doc-to-code reference gate.
+//
+// Runs on the CHEAP lint/check lane (`node --test .github/scripts/*.test.mjs`)
+// — no setup-node, no deps — so a stale doc citation fails on a much cheaper
+// required check than any heavy job, and on every PR (including docs-only
+// PRs). Mirrors compose-smoke-matrix.test.mjs / dashboard-matrix.test.mjs.
+//
+// Guards three layers:
+//   1. the live docs tree is clean (the real invariant: every cited path
+//      exists, every pin is in range);
+//   2. the extraction regex captures the shapes it must (nested module
+//      paths whole, line ranges, dir refs) and rejects non-anchored paths;
+//   3. the verdict + candidate-resolution logic actually fires on a dead
+//      file, an out-of-range pin, and a missing dir — so the detectors can't
+//      rot into a silent no-op.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  scan,
+  extractRefs,
+  checkFileRef,
+  checkDirRef,
+  candidatePaths,
+  isUpstream,
+} from './doc-refs.mjs';
+
+test('live docs tree: every cited code path exists and pins are in range', () => {
+  const { violations } = scan();
+  assert.deepEqual(violations, [], `unexpected dead references:\n${violations.join('\n')}`);
+});
+
+test('a nested-module path is captured WHOLE, not truncated to its cmd/ tail', () => {
+  const { files } = extractRefs('see `compatibility/prometheus/cmd/seed/prom_remote.go` here');
+  assert.equal(files.length, 1);
+  assert.equal(files[0].path, 'compatibility/prometheus/cmd/seed/prom_remote.go');
+});
+
+test('a :start-end line range parses with the HIGH bound as the pin', () => {
+  const { files } = extractRefs('`internal/promql/lower.go:1924-1926`');
+  assert.equal(files.length, 1);
+  assert.equal(files[0].path, 'internal/promql/lower.go');
+  assert.equal(files[0].line, 1926);
+});
+
+test('a single :line pin parses', () => {
+  const { files } = extractRefs('`internal/config/config.go:425`');
+  assert.equal(files[0].line, 425);
+});
+
+test('a trailing-slash token is classified as a DIR ref, not a file ref', () => {
+  const { files, dirs } = extractRefs('staged under `internal/foo/bar/`');
+  assert.equal(files.length, 0);
+  assert.deepEqual(dirs, ['internal/foo/bar/']);
+});
+
+test('a non-anchored path (docs/*, pkg/*) is NOT treated as a code reference', () => {
+  const { files, dirs } = extractRefs('`docs/clickhouse-contrib/x.md` and `pkg/util/x.go`');
+  assert.equal(files.length, 0);
+  assert.equal(dirs.length, 0);
+});
+
+test('candidatePaths offers both repo-root and doc-relative interpretations for ../', () => {
+  const cands = candidatePaths('../test/surface-parity/', 'docs/coverage.md');
+  assert.ok(cands.includes('test/surface-parity/'), `got: ${cands.join(', ')}`);
+});
+
+test('candidatePaths strips a leading ./ to the repo-root interpretation', () => {
+  const cands = candidatePaths('./test/rejection-parity/', 'docs/compatibility.md');
+  assert.ok(cands.includes('test/rejection-parity/'), `got: ${cands.join(', ')}`);
+});
+
+test('checkFileRef HARD-FAILS on a missing file (the motivating dead-ref case)', () => {
+  const v = checkFileRef({ path: 'cmd/seed/prom_remote.go', line: null }, {
+    exists: () => false,
+    count: () => 0,
+  });
+  assert.ok(v && v.includes('missing file'), `expected a missing-file verdict; got: ${v}`);
+});
+
+test('checkFileRef tolerates an in-range pin but fails an out-of-range pin (bounds only)', () => {
+  const probes = { exists: () => true, count: () => 500 };
+  assert.equal(checkFileRef({ path: 'internal/x.go', line: 425 }, probes), null);
+  const v = checkFileRef({ path: 'internal/x.go', line: 9999 }, probes);
+  assert.ok(v && v.includes('out of range'), `expected an out-of-range verdict; got: ${v}`);
+});
+
+test('a vendored upstream snapshot is never a target', () => {
+  assert.ok(isUpstream('compatibility/prometheus/upstream/foo.go'));
+  const v = checkFileRef({ path: 'compatibility/prometheus/upstream/foo.go', line: null }, {
+    exists: () => false,
+    count: () => 0,
+  });
+  assert.equal(v, null);
+});
+
+test('checkDirRef fails a missing directory', () => {
+  const v = checkDirRef('internal/gone/', { dirExists: () => false });
+  assert.ok(v && v.includes('missing directory'), `expected a missing-dir verdict; got: ${v}`);
+});

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,19 @@ jobs:
             !compatibility/loki/upstream/**
             !**/node_modules/**
 
+      # doc-to-code reference integrity. Greps docs/**/*.md for inline
+      # `(internal|cmd|test|deploy)/<path>.go[:line]` (+ dir) citations and
+      # HARD-FAILS on a path that no longer exists or a line pin past EOF.
+      # See .github/scripts/doc-refs.mjs + .github/scripts/README.md. The
+      # `--test` guard pins the extraction regex + verdict logic so the
+      # detectors can't silently rot into a no-op (same idiom as the
+      # compose-smoke / dashboard matrix guards).
+      - name: doc-refs self-test (regex + verdict guard)
+        run: node --test .github/scripts/doc-refs.test.mjs
+
+      - name: doc-to-code reference check
+        run: node .github/scripts/doc-refs.mjs
+
   # `forbid-skip` is the GA test-discipline gate. The maintainer's
   # NON-NEGOTIABLE rule is "no t.Skip in test files — fix the bug, do
   # not skip." Greps `*_test.go` for `t.Skip` / `t.Skipf` / `t.SkipNow`
@@ -346,3 +359,47 @@ jobs:
         run: node .github/scripts/clickhouse-version-sync.mjs --self-test
       - name: ClickHouse version-sync gate
         run: node .github/scripts/clickhouse-version-sync.mjs
+
+  # `link-check` is the INTERNAL markdown link + anchor integrity gate. It
+  # runs lychee in pure OFFLINE mode (`--offline --include-fragments`): no
+  # network is touched, so it CANNOT flake on a slow/blocked host — every
+  # check is a same-process filesystem + in-document anchor resolution. It
+  # validates that every relative `[text](./other.md#anchor)` link points at a
+  # file that exists AND, for `#fragment` links, that the target heading /
+  # anchor exists in the target document. External `http(s)://` links are
+  # NOT checked here — host availability is inherently flaky and must never
+  # red a PR or abort a tag; that lives in the schedule-only
+  # `link-check-external.yml` workflow instead.
+  #
+  # Runs on pull_request AND push-to-main so it is eligible as a required
+  # status check (branch protection) and is enumerated by the release
+  # preflight gate (release-preflight.mjs gates every non-self push-to-main
+  # check-run), making it a release gate too.
+  #
+  # Vendored upstream snapshots under `compatibility/*/upstream/**` are
+  # excluded, mirroring the markdownlint + forbid-skip exclude set — they are
+  # reference material outside cerberus's authorship boundary.
+  link-check:
+    name: link-check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # OFFLINE link + fragment check. `--root-dir` anchors absolute-style
+      # `/foo` links at the repo root; `--include-fragments` turns on the
+      # in-document `#anchor` existence check. `fail: true` makes a broken
+      # link/anchor fail the job. No `GITHUB_TOKEN` and no network: this lane
+      # is deterministic by construction.
+      - name: lychee (offline internal links + anchors)
+        uses: lycheeverse/lychee-action@v2
+        with:
+          fail: true
+          args: >-
+            --offline
+            --include-fragments
+            --root-dir "$GITHUB_WORKSPACE"
+            --exclude-path compatibility/prometheus/upstream
+            --exclude-path compatibility/tempo/upstream
+            --exclude-path compatibility/loki/upstream
+            --exclude-path node_modules
+            "**/*.md"

--- a/.github/workflows/link-check-external.yml
+++ b/.github/workflows/link-check-external.yml
@@ -1,0 +1,76 @@
+name: link-check-external
+
+# EXTERNAL link checker. Deliberately split from the OFFLINE internal
+# `link-check` job in ci.yml: external `http(s)://` links depend on third-
+# party host availability, which is inherently flaky. A transient 5xx / DNS
+# blip / rate-limit on someone else's server must NEVER red a PR or abort a
+# release tag, so this lane runs ONLY on a weekly schedule + manual dispatch
+# and reports `fail: false`. The internal gate (offline, deterministic) is
+# the one wired into PRs and the release preflight.
+on:
+  schedule:
+    # Mondays 06:00 UTC. Weekly is plenty for catching link rot.
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+# `issues: write` lets the tracking-issue step open/update the rot report.
+# `contents: read` for the checkout.
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: link-check-external
+  cancel-in-progress: false
+
+jobs:
+  external-links:
+    name: external-links
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # Persist lychee's response cache across runs so a known-good link is
+      # not re-fetched every week (and a known-bad one is not hammered).
+      - name: Restore lychee cache
+        uses: actions/cache@v4
+        with:
+          path: .lycheecache
+          key: lychee-${{ github.run_id }}
+          restore-keys: |
+            lychee-
+
+      # ONLINE check: no `--offline`. `--cache` + `--max-cache-age 1d` reuse
+      # recent verdicts; `GITHUB_TOKEN` is passed so github.com links are
+      # checked authenticated (dodging the anonymous API rate-limit that
+      # otherwise yields false 429/404 negatives). `fail: false` -> the job
+      # stays green even with dead links; the report below carries the signal.
+      # The same upstream-snapshot + node_modules excludes as the internal gate.
+      - name: lychee (external links)
+        id: lychee
+        uses: lycheeverse/lychee-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          fail: false
+          output: ./lychee-report.md
+          args: >-
+            --cache
+            --max-cache-age 1d
+            --exclude-path compatibility/prometheus/upstream
+            --exclude-path compatibility/tempo/upstream
+            --exclude-path compatibility/loki/upstream
+            --exclude-path node_modules
+            "**/*.md"
+
+      # Open or update a single tracking issue when rot is found. `exit_code`
+      # is non-zero iff lychee saw at least one broken link. The action
+      # de-dupes by title, so reruns update the existing issue rather than
+      # spamming new ones. Never fails the job.
+      - name: Open/update link-rot tracking issue
+        if: steps.lychee.outputs.exit_code != 0
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: Weekly external link check found dead links
+          content-filepath: ./lychee-report.md
+          labels: link-rot, automated

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -51,7 +51,7 @@ branch as shields.io badge JSON; the README shows them live. On
 - **Reference**: a real `prom/prometheus` container seeded with the
   *same* fixture as cerberus's ClickHouse (the seeder reads the CH rows
   back and mirrors them into Prometheus over remote-write — see
-  `cmd/seed/prom_remote.go` — so both backends answer from byte-identical
+  `compatibility/prometheus/cmd/seed/prom_remote.go` — so both backends answer from byte-identical
   data).
 - **Corpus**: vendored
   [`prometheus/compliance/promql/promql-test-queries.yml`](https://github.com/prometheus/compliance),


### PR DESCRIPTION
Three docs-integrity CI gates, plus fixes for the violations they catch.

## The three gates

1. **Internal link + anchor gate** (`ci.yml` -> new `link-check` job). lychee in pure OFFLINE mode (`--offline --include-fragments`, `--root-dir` = workspace, all `**/*.md`), `fail: true`. Runs on `pull_request` + `push`-to-`main`, so it is eligible as a required status check and is enumerated by `release-preflight.mjs` (which gates every non-self push-to-main check-run) -> a release gate too. Zero network -> deterministic, cannot flake. Excludes the vendored `compatibility/*/upstream/**` snapshots + `node_modules`, mirroring the markdownlint / forbid-skip exclude set.

2. **Doc-to-code reference check** (new `.github/scripts/doc-refs.mjs`, wired into the `lint` job). node builtins only, mirrors `forbid-skip.mjs` (pure exported helpers + a `--self-test` flag). Greps `docs/**/*.md` for inline `(internal|cmd|test|deploy)/<path>.go[:line|:range]` citations and HARD-FAILS when the path no longer exists (`git ls-files`). For `:line` pins it does a BOUNDS check only (fail iff line > file length) - docs pin approximate/tilde lines and ranges, so not byte-exact. A trailing-slash / no-`.go` token is a directory-existence check. Nested module prefixes are captured whole (`compatibility/prometheus/cmd/seed/prom_remote.go`, not the `cmd/...` tail); `./`/`../` tokens are accepted under EITHER repo-root or doc-relative resolution (a `go test ./test/...` snippet vs a `[..](../test/..)` link). Guarded by `doc-refs.test.mjs` (`node --test`, cheap lint lane) pinning the regex + verdict logic and proving each detector fires. Documented in `.github/scripts/README.md`.

3. **External link check** (new `.github/workflows/link-check-external.yml`). `schedule` (weekly cron) + `workflow_dispatch` ONLY - never `pull_request`/release. lychee WITHOUT `--offline`, `--cache --max-cache-age 1d`, `GITHUB_TOKEN` env (dodge GH rate-limit false negatives), `actions/cache` for the lychee cache, `fail: false`, opens/updates a single link-rot tracking issue. Host flake can never red a PR or abort a tag.

## Violations fixed (so gates 1+2 pass)

- `docs/native-clickhouse-roadmap.md` (lines ~5, ~120): the 2 dead links to the removed `./clickhouse-contrib/timeSeriesIncreaseToGrid/` reworded to plain text (removed in #987).
- `docs/compatibility.md:54`: the dead `cmd/seed/prom_remote.go` ref corrected to its current path `compatibility/prometheus/cmd/seed/prom_remote.go`.

## Proof they gate

- lychee `--offline --include-fragments`: 127 OK / 0 errors / 65 excluded after the fixes (1 error before, on the roadmap link).
- `doc-refs.mjs`: green across 116 cited paths; proven to FAIL on a deliberately-bad ref (`internal/does/not/exist.go`), on the ORIGINAL `cmd/seed/prom_remote.go` ref, and on an out-of-range line pin.
- `doc-refs.mjs --self-test` + `node --test doc-refs.test.mjs`: 12/12 pass.
- actionlint clean on both workflows.

No exotic-anchor false positives surfaced in the non-failing reconnaissance run, so no `--exclude` workarounds were needed.

## Files changed

- new: `.github/scripts/doc-refs.mjs`, `.github/scripts/doc-refs.test.mjs`, `.github/workflows/link-check-external.yml`
- edited: `.github/workflows/ci.yml` (`link-check` job + doc-refs steps in `lint`), `.github/scripts/README.md`, `docs/native-clickhouse-roadmap.md`, `docs/compatibility.md`

Generated with Claude Code