### PR TITLE
chore(release): cerberus v1.1.0 / chart 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,56 @@ All notable changes to cerberus will be documented in this file. The format roug
 
 ## [Unreleased]
 
+## [v1.1.0] — 2026-06-19
+
+### Added
+
+- **Native ClickHouse 25.9 grid aggregates for `changes()` / `resets()`.**
+  `ts_grid_changes` / `ts_grid_resets` lower eligible `changes(<v>[range])` /
+  `resets(<counter>[range])` query_range shapes onto `timeSeriesChangesToGrid` /
+  `timeSeriesResetsToGrid`, retiring the `arrayPopBack`/`arrayPopFront` fan-out
+  (experimental, explicit-only). (#990)
+- **`ts_grid_resample`** — native instant-vector staleness via
+  `timeSeriesResampleToGridWithStaleness`, retiring the argMax fan-out
+  (experimental, explicit-only).
+- **`columnar_result_decode`** — client-side `query_range` matrix decode via the
+  ch-go columnar path (label map built once per run, not per row); no server
+  setting, no version floor; explicit-only. (#983)
+- **Generated, drift-gated docs.** `docs/configuration.md` is generated from the
+  viper config and the `docs/clickhouse-optimizations.md` feature table from the
+  chopt registry, each with a CI gate that fails on drift. (#998, #1000)
+- **CI documentation gates** keeping prose in lock-step with code: internal
+  link + anchor checks, doc-to-code reference checks, and assert-from-source
+  doc-count checks. (#997, #999)
+- **Central `versions.yaml`** as the single source of truth for the supported
+  ClickHouse version, with a version-sync gate across the quickstart,
+  compatibility images, preflight floor, and per-optimization floors. (#995)
+
+### Changed
+
+- **Every version/feature-gated optimization is boot-wired.** Each optimization
+  resolves once at startup into an immutable enabled-set and a concrete
+  pure-polymorphic strategy — no per-query flag, version branch, or nil-check on
+  any data-plane path. PromQL range-lowering and native-grid dispatch were
+  migrated to this model; columnar decode became a `CH_OPTIMIZATIONS` feature. (#986)
+
+### Performance
+
+- **Copy-on-write plan slicing.** The slicer shares immutable off-spine subtrees
+  instead of deep-cloning them — ~2-2.5x fewer allocations on representative
+  slices, up to ~37x on wide off-spine plans. (#988)
+
+### Fixed
+
+- Serialize chDB engine access to stop a process-global SIGABRT in
+  `result.Free` under parallel tests. (#984)
+- E2E stability: kill the unless-panel seed-race, the false-positive
+  DiskPressure breadcrumb mislabelling (#992), and DiskPressure evictions by
+  freeing runner disk before the stack (#981).
+- Cache Playwright chromium across e2e shards. (#994)
+
+## [v1.0.2] — 2026-06-18
+
 ### Added
 
 - **ClickHouse-optimization suite + auto-picker.** A cohesive optimization
@@ -43,6 +93,28 @@ All notable changes to cerberus will be documented in this file. The format roug
   `CERBERUS_CH_OPTIMIZATIONS` choice — a list **or** the `off` kill-switch —
   overrides the legacy flag, so `off` stays absolute) — and emits a one-time
   startup deprecation warning.
+
+### Changed
+
+- **Per-query instrumentation** (query_id / `log_comment` shape id) and a
+  ClickHouse settings map, plus the `aggregation_in_order` optimization. (#978)
+- `histogram_quantile` phi-domain handling (+/-Inf out of range) and
+  `vector(scalar)` vector-typing fixes. (#974)
+
+## [v1.0.1] — 2026-06-18
+
+### Added
+
+- **Publishable cerberus Helm chart + OCI release pipeline**, exposing the full
+  `CERBERUS_*` config surface, prod-HA typed values with ClickHouse co-location,
+  and a chart-validate / kubeconform / helm-docs drift gate. (#962, #968)
+
+### Fixed
+
+- Restore integer per-head admission caps with bool aliases. (#973)
+- `on()`/`ignoring()` one-to-one binop leaking non-matching labels; vector-join
+  dropping operand `MetricName`/`TimeUnix` (code-47). (#971)
+- Uniform boolean parsing (1/0/true/false) across all `CERBERUS_*` env vars.
 
 ## [v1.0.0] — 2026-06-17
 

--- a/deploy/helm/cerberus/Chart.yaml
+++ b/deploy/helm/cerberus/Chart.yaml
@@ -8,11 +8,11 @@ type: application
 # upgrade?" and is the publish trigger: a chart-only fix bumps this without an
 # app re-tag; an app-only release bumps appVersion + a PATCH here for the new
 # default image. Starts 0.x because the values contract is not yet frozen.
-version: 0.3.2
+version: 0.4.0
 
 # appVersion tracks the GA cerberus binary. Quoted so SemVer-shaped values
 # aren't coerced to floats. image.tag defaults from this when left empty.
-appVersion: "1.0.2"
+appVersion: "1.1.0"
 
 # autoscaling/v2 + policy/v1 (PDB) + networking/v1 (Ingress) are all GA from
 # 1.21+; 1.23 is the conservative floor matching the manifests this chart
@@ -45,11 +45,13 @@ annotations:
       url: https://github.com/tsouza/cerberus/blob/main/docs/operations.md
   artifacthub.io/images: |
     - name: cerberus
-      image: ghcr.io/tsouza/cerberus:v1.0.2
+      image: ghcr.io/tsouza/cerberus:v1.1.0
   # Bump the `1.0.0` floor here when the chart raises its minimum supported
   # cerberus release; informational for Artifact Hub's compatibility hints.
   artifacthub.io/changes: |
+    - kind: added
+      description: "appVersion -> 1.1.0: native ClickHouse 25.9 grid aggregates (ts_grid_changes/resets/resample), columnar query_range decode, and a boot-wired pure-polymorphic optimization model (no per-query branch)"
+    - kind: added
+      description: "central versions.yaml source-of-truth plus generated, drift-gated configuration and optimization-feature docs"
     - kind: changed
-      description: "appVersion -> 1.0.2: histogram_quantile phi-domain (+/-Inf out of range) + vector(scalar) vector-typing fixes, plus dependency updates"
-    - kind: changed
-      description: "admit.{prom,loki,tempo} documented as integer per-head concurrency caps with true/false aliases (matches the binary's restored integer admission caps)"
+      description: "copy-on-write plan slicing: ~2-2.5x fewer allocations on representative slices"

--- a/deploy/helm/cerberus/README.md
+++ b/deploy/helm/cerberus/README.md
@@ -5,7 +5,7 @@
      pipe-aligned, and the version footer adds a trailing blank — both are
      owned by helm-docs; realigning would fight the chart-ci drift check. -->
 
-![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.2](https://img.shields.io/badge/AppVersion-1.0.2-informational?style=flat-square)
+![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
 
 Drop-in Prometheus / Loki / Tempo HTTP gateway for ClickHouse — a single stateless gateway that speaks three upstream query wire formats and lowers each to parameterised ClickHouse SQL.
 


### PR DESCRIPTION
Release-prep for **v1.1.0** (chart **0.4.0**).

**Chart.yaml:** version 0.3.2 → 0.4.0, appVersion 1.0.2 → 1.1.0, image tag v1.1.0, refreshed `artifacthub.io/changes`; chart README regenerated via helm-docs.

**CHANGELOG:** the accumulated `[Unreleased]` block is split into the tags it actually shipped under — back-filled `[v1.0.1]` (helm chart) and `[v1.0.2]` (optimization framework) — and a new `[v1.1.0]`:
- native ClickHouse 25.9 grid aggregates (`ts_grid_changes`/`resets`/`resample`)
- columnar `query_range` decode
- boot-wired pure-polymorphic optimization model (no per-query branch)
- generated + drift-gated configuration / optimization-feature docs
- central `versions.yaml` SoT
- copy-on-write plan slicing (~2-2.5x fewer allocs)
- chDB SIGABRT + e2e flake fixes

Merge after CI is green; the v1.1.0 tag is cut once this lands so release.yml builds the v1.1.0 image and publishes chart 0.4.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)