### PR TITLE
feat(ci): manual prepare-release workflow + generator

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -126,12 +126,13 @@ wrapper, plus `appendStepSummary` / `setOutput` for the runner files.
     workflow. Bumps the chart `version:` + `appVersion:`, the image tag, and the
     Artifact Hub `changes` annotation, and rewrites the CHANGELOG `[Unreleased]`
     section into a dated `## [vX.Y.Z]` one — deriving the change summary and the
-    PR body from the conventional commits since the last `v*` tag. Hand-curated
-    `[Unreleased]` entries are preserved as-is; the commit-derived section is the
-    fallback only when `[Unreleased]` is empty. Pure exported helpers
-    (`bumpSemver`, `parseCommits`, `renderChangelogSection`, `renderAhChanges`,
-    `editChart`, `editChangelog`) + a `--self-test` flag the workflow runs before
-    it edits anything.
+    PR body from the conventional commits since the last `v*` tag. The commit
+    history is the single source of truth: the generated section is always what
+    lands and any stale `[Unreleased]` content is discarded (maintainers enrich
+    the prose by editing the opened PR, not by hand-staging `[Unreleased]`). Pure
+    exported helpers (`bumpSemver`, `parseCommits`, `renderChangelogSection`,
+    `renderAhChanges`, `editChart`, `editChangelog`) + a `--self-test` flag the
+    workflow runs before it edits anything.
   - Env: `VERSION` (explicit target appVersion; overrides `BUMP`), `BUMP`
     (`patch`|`minor`|`major`, or the workflow's `none` placeholder),
     `CHART_BUMP` (default `patch`), `PR_BODY_FILE` (default `release-pr-body.md`),

--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -122,6 +122,22 @@ wrapper, plus `appendStepSummary` / `setOutput` for the runner files.
     `RELEASE_SELF_JOBS` (default `preflight,goreleaser`).
   - Exit: `0` when every non-self, non-scheduled, non-flaky-UI check on the
     commit is green, `1` otherwise (with one `::error::` per red/pending lane).
+- **`prepare-release.mjs`** — `prepare-release.yml`, the manual release-staging
+    workflow. Bumps the chart `version:` + `appVersion:`, the image tag, and the
+    Artifact Hub `changes` annotation, and rewrites the CHANGELOG `[Unreleased]`
+    section into a dated `## [vX.Y.Z]` one — deriving the change summary and the
+    PR body from the conventional commits since the last `v*` tag. Hand-curated
+    `[Unreleased]` entries are preserved as-is; the commit-derived section is the
+    fallback only when `[Unreleased]` is empty. Pure exported helpers
+    (`bumpSemver`, `parseCommits`, `renderChangelogSection`, `renderAhChanges`,
+    `editChart`, `editChangelog`) + a `--self-test` flag the workflow runs before
+    it edits anything.
+  - Env: `VERSION` (explicit target appVersion; overrides `BUMP`), `BUMP`
+    (`patch`|`minor`|`major`, or the workflow's `none` placeholder),
+    `CHART_BUMP` (default `patch`), `PR_BODY_FILE` (default `release-pr-body.md`),
+    `GITHUB_OUTPUT` (runner-provided; sets `new_version` / `chart_version`).
+  - Exit: `0` after staging the files (or a green self-test), `1` on a bad /
+    missing version input or a malformed Chart.yaml / CHANGELOG.
 - **`chart-publish.mjs`** — `release.yml`, the `chart-release` job. Three
   subcommands (argv[2]): `version-gate` compares the local Chart.yaml
   `version:` against the latest chart tag in the OCI registry and sets the

--- a/.github/scripts/prepare-release.mjs
+++ b/.github/scripts/prepare-release.mjs
@@ -107,14 +107,24 @@ export function renderAhChanges(parsed) {
 
 // --- Chart.yaml + CHANGELOG edits -------------------------------------------
 
+// Swap the tag on the `${IMAGE}:<tag>` reference without building a RegExp from
+// IMAGE (dynamic-regex construction is an injection smell and never fully
+// escapes its input). IMAGE is a fixed prefix; find it and replace the
+// non-whitespace tag run that follows.
+export function replaceImageTag(text, appVersion) {
+  const needle = `${IMAGE}:`
+  const i = text.indexOf(needle)
+  if (i === -1) return text
+  const start = i + needle.length
+  const tag = /^\S+/.exec(text.slice(start))
+  return text.slice(0, start) + `v${appVersion}` + text.slice(start + (tag ? tag[0].length : 0))
+}
+
 export function editChart(text, { chartVersion, appVersion, ahChanges }) {
   let out = text
   out = out.replace(/^version:\s.*$/m, `version: ${chartVersion}`)
   out = out.replace(/^appVersion:\s.*$/m, `appVersion: "${appVersion}"`)
-  out = out.replace(
-    new RegExp(`(image:\\s*${IMAGE.replace(/[.]/g, '\\.')}:)v[\\w.\\-]+`),
-    `$1v${appVersion}`,
-  )
+  out = replaceImageTag(out, appVersion)
   // Replace the whole `artifacthub.io/changes: |` block scalar (it is the last
   // key in the file, so it runs to EOF).
   out = out.replace(
@@ -257,6 +267,8 @@ function selfTest() {
   assert(/^version: 0\.4\.0$/m.test(edited), 'chart version bumped')
   assert(/^appVersion: "1\.1\.0"$/m.test(edited), 'appVersion bumped')
   assert(edited.includes('cerberus:v1.1.0'), 'image tag bumped')
+  assert(replaceImageTag('image: ghcr.io/tsouza/cerberus:v9.9.9\n', '1.1.0')
+    === 'image: ghcr.io/tsouza/cerberus:v1.1.0\n', 'replaceImageTag swaps tag, no dynamic regex')
   assert(edited.includes('kind: added') && !edited.includes('"old"'), 'ah block replaced')
 
   const cl = '# Changelog\n\n## [Unreleased]\n\n### Added\n\n- carried entry\n\n## [v1.0.0] — 2026-06-17\n\nfirst\n'

--- a/.github/scripts/prepare-release.mjs
+++ b/.github/scripts/prepare-release.mjs
@@ -84,11 +84,19 @@ export function renderChangelogSection(parsed) {
   return out.join('\n')
 }
 
+// yamlDq escapes a single-line string for a YAML double-quoted scalar:
+// backslash FIRST (so we don't double-escape the escapes we add), then the
+// quote char. Complete escaping — partial schemes (e.g. quote-only) are an
+// injection vector into the rendered YAML.
+export function yamlDq(s) {
+  return s.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+}
+
 export function renderAhChanges(parsed) {
   const lines = []
   for (const [type, kind] of Object.entries(AH_KIND)) {
     for (const e of parsed.groups[type] || []) {
-      const text = `${e.scope ? `${e.scope}: ` : ''}${e.desc}`.replace(/"/g, "'")
+      const text = yamlDq(`${e.scope ? `${e.scope}: ` : ''}${e.desc}`)
       lines.push(`    - kind: ${kind}`)
       lines.push(`      description: "${text}"`)
     }
@@ -231,6 +239,9 @@ function selfTest() {
   const ah = renderAhChanges(p)
   assert(ah.includes('kind: added') && ah.includes('kind: fixed'), 'ah kinds')
   assert(!ah.includes('kind: chore'), 'ah excludes chore')
+  assert(yamlDq('say "hi"\\n') === 'say \\"hi\\"\\\\n', 'yamlDq escapes quote + backslash')
+  const ahQuoted = renderAhChanges(parseCommits(['feat: add "fast" path \\ here']))
+  assert(ahQuoted.includes('add \\"fast\\" path \\\\ here'), 'ah description fully escaped')
 
   const chart = [
     'version: 0.3.2',

--- a/.github/scripts/prepare-release.mjs
+++ b/.github/scripts/prepare-release.mjs
@@ -139,17 +139,15 @@ export function editChangelog(text, { version, date, section }) {
   const i = text.indexOf(marker)
   if (i === -1) throw new Error(`no "${marker}" section in ${CHANGELOG}`)
   const after = i + marker.length
-  // Capture any hand-written entries currently under [Unreleased] up to the
-  // next "## [" heading; fold them into the release section above the
-  // generated one, then leave a fresh empty [Unreleased].
+  // Always-generated policy: the commit-derived section is the source of truth.
+  // Whatever currently sits under [Unreleased] (up to the next "## [" heading)
+  // is discarded; we leave a fresh empty [Unreleased] and the generated release
+  // section. Maintainers enrich the prose by editing the opened PR, not by
+  // hand-staging [Unreleased].
   const rest = text.slice(after)
   const next = rest.search(/\n## \[/)
-  const carried = (next === -1 ? rest : rest.slice(0, next)).trim()
   const tail = next === -1 ? '' : rest.slice(next)
-  // Prefer hand-curated [Unreleased] entries (Keep a Changelog flow); fall back
-  // to the commit-derived section only when [Unreleased] was left empty.
-  const body = carried || section
-  return `${text.slice(0, after)}\n\n## [v${version}] — ${date}\n\n${body}\n${tail}`
+  return `${text.slice(0, after)}\n\n## [v${version}] — ${date}\n\n${section}\n${tail}`
 }
 
 // --- driver -----------------------------------------------------------------
@@ -271,13 +269,15 @@ function selfTest() {
     === 'image: ghcr.io/tsouza/cerberus:v1.1.0\n', 'replaceImageTag swaps tag, no dynamic regex')
   assert(edited.includes('kind: added') && !edited.includes('"old"'), 'ah block replaced')
 
-  const cl = '# Changelog\n\n## [Unreleased]\n\n### Added\n\n- carried entry\n\n## [v1.0.0] — 2026-06-17\n\nfirst\n'
+  const cl = '# Changelog\n\n## [Unreleased]\n\n### Added\n\n- stale staging entry\n\n## [v1.0.0] — 2026-06-17\n\nfirst\n'
   const ecl = editChangelog(cl, { version: '1.1.0', date: '2026-06-19', section: sec })
   assert(ecl.indexOf('## [Unreleased]') < ecl.indexOf('## [v1.1.0]'), 'fresh unreleased on top')
-  assert(ecl.includes('carried entry'), 'carried entries preserved')
-  assert(!ecl.includes('### BREAKING'), 'generated section not duplicated when curated entries exist')
+  assert(!ecl.includes('stale staging entry'), 'always-generated: [Unreleased] content discarded')
+  assert(ecl.includes('### Added') && ecl.includes('native grid'), 'generated section is the body')
   assert(ecl.indexOf('## [v1.1.0]') < ecl.indexOf('## [v1.0.0]'), 'new release above old')
   assert((ecl.match(/## \[v1\.1\.0\]/g) || []).length === 1, 'single v1.1.0 header')
+  // [Unreleased] is left empty (header immediately followed by the release).
+  assert(/## \[Unreleased\]\n\n## \[v1\.1\.0\]/.test(ecl), 'empty [Unreleased] header retained')
 
   console.log('::notice::prepare-release --self-test: all assertions passed')
 }

--- a/.github/scripts/prepare-release.mjs
+++ b/.github/scripts/prepare-release.mjs
@@ -1,0 +1,263 @@
+// Command prepare-release stages a cerberus release: it bumps the chart
+// `version` + `appVersion`, refreshes the Artifact Hub `changes` annotation,
+// rewrites the CHANGELOG `[Unreleased]` section into a dated release section,
+// and writes a PR body — all derived from the conventional commits since the
+// last `v*` tag. The `prepare-release.yml` workflow runs it, regenerates the
+// chart README via helm-docs, then opens the PR.
+//
+// Env:
+//   VERSION     explicit target appVersion (e.g. "1.2.0"); overrides BUMP
+//   BUMP        patch | minor | major — used when VERSION is empty
+//   CHART_BUMP  patch | minor | major — chart `version:` bump (default patch)
+//   GITHUB_OUTPUT  runner file for step outputs (optional)
+//   PR_BODY_FILE   path to write the generated PR body (default release-pr-body.md)
+//
+// argv `--self-test` runs the in-process assertion suite and exits.
+import { readFileSync, writeFileSync, appendFileSync } from 'node:fs'
+import { execFileSync } from 'node:child_process'
+
+const CHART = 'deploy/helm/cerberus/Chart.yaml'
+const CHANGELOG = 'CHANGELOG.md'
+const IMAGE = 'ghcr.io/tsouza/cerberus'
+
+// --- semver -----------------------------------------------------------------
+
+export function bumpSemver(version, level) {
+  const m = /^v?(\d+)\.(\d+)\.(\d+)$/.exec(version.trim())
+  if (!m) throw new Error(`not a 3-part semver: "${version}"`)
+  let [maj, min, pat] = m.slice(1).map(Number)
+  if (level === 'major') return `${maj + 1}.0.0`
+  if (level === 'minor') return `${maj}.${min + 1}.0`
+  if (level === 'patch') return `${maj}.${min}.${pat + 1}`
+  throw new Error(`unknown bump level: "${level}"`)
+}
+
+// --- conventional-commit grouping -------------------------------------------
+
+// type -> changelog section heading (order matters; unlisted types are dropped
+// from the user-facing changelog but still listed in the PR body's "Other").
+const SECTIONS = [
+  ['feat', 'Added'],
+  ['fix', 'Fixed'],
+  ['perf', 'Performance'],
+  ['refactor', 'Changed'],
+  ['ci', 'CI'],
+  ['docs', 'Documentation'],
+]
+// type -> Artifact Hub change kind (only these types seed annotations).
+const AH_KIND = { feat: 'added', fix: 'fixed', perf: 'changed', refactor: 'changed' }
+
+export function parseCommits(subjects) {
+  const groups = {}
+  const breaking = []
+  for (const raw of subjects) {
+    const s = raw.trim()
+    if (!s) continue
+    const m = /^(\w+)(?:\(([^)]+)\))?(!)?:\s*(.+)$/.exec(s)
+    if (!m) continue
+    const [, type, scope, bang, descRaw] = m
+    const desc = descRaw.trim()
+    const entry = { type, scope: scope || '', desc, breaking: !!bang }
+    ;(groups[type] ||= []).push(entry)
+    if (bang) breaking.push(entry)
+  }
+  return { groups, breaking }
+}
+
+function bullets(entries) {
+  return entries.map((e) => `- ${e.scope ? `**${e.scope}:** ` : ''}${e.desc}`).join('\n')
+}
+
+// Renders only the `### ...` subsections for a release; the caller owns the
+// `## [vX] — date` heading so there is exactly one.
+export function renderChangelogSection(parsed) {
+  const out = []
+  if (parsed.breaking.length) {
+    out.push('### BREAKING', '', bullets(parsed.breaking), '')
+  }
+  for (const [type, heading] of SECTIONS) {
+    const entries = parsed.groups[type]
+    if (entries && entries.length) out.push(`### ${heading}`, '', bullets(entries), '')
+  }
+  // Trim trailing blank line so we don't accumulate them on insert.
+  while (out.length && out[out.length - 1] === '') out.pop()
+  return out.join('\n')
+}
+
+export function renderAhChanges(parsed) {
+  const lines = []
+  for (const [type, kind] of Object.entries(AH_KIND)) {
+    for (const e of parsed.groups[type] || []) {
+      const text = `${e.scope ? `${e.scope}: ` : ''}${e.desc}`.replace(/"/g, "'")
+      lines.push(`    - kind: ${kind}`)
+      lines.push(`      description: "${text}"`)
+    }
+  }
+  // Artifact Hub caps the list usefully; keep the top ~10 entries.
+  return lines.slice(0, 20).join('\n')
+}
+
+// --- Chart.yaml + CHANGELOG edits -------------------------------------------
+
+export function editChart(text, { chartVersion, appVersion, ahChanges }) {
+  let out = text
+  out = out.replace(/^version:\s.*$/m, `version: ${chartVersion}`)
+  out = out.replace(/^appVersion:\s.*$/m, `appVersion: "${appVersion}"`)
+  out = out.replace(
+    new RegExp(`(image:\\s*${IMAGE.replace(/[.]/g, '\\.')}:)v[\\w.\\-]+`),
+    `$1v${appVersion}`,
+  )
+  // Replace the whole `artifacthub.io/changes: |` block scalar (it is the last
+  // key in the file, so it runs to EOF).
+  out = out.replace(
+    /( {2}artifacthub\.io\/changes:\s*\|\n)([\s\S]*)$/,
+    (_all, head) => `${head}${ahChanges}\n`,
+  )
+  return out
+}
+
+export function editChangelog(text, { version, date, section }) {
+  const marker = '## [Unreleased]'
+  const i = text.indexOf(marker)
+  if (i === -1) throw new Error(`no "${marker}" section in ${CHANGELOG}`)
+  const after = i + marker.length
+  // Capture any hand-written entries currently under [Unreleased] up to the
+  // next "## [" heading; fold them into the release section above the
+  // generated one, then leave a fresh empty [Unreleased].
+  const rest = text.slice(after)
+  const next = rest.search(/\n## \[/)
+  const carried = (next === -1 ? rest : rest.slice(0, next)).trim()
+  const tail = next === -1 ? '' : rest.slice(next)
+  // Prefer hand-curated [Unreleased] entries (Keep a Changelog flow); fall back
+  // to the commit-derived section only when [Unreleased] was left empty.
+  const body = carried || section
+  return `${text.slice(0, after)}\n\n## [v${version}] — ${date}\n\n${body}\n${tail}`
+}
+
+// --- driver -----------------------------------------------------------------
+
+function git(args) {
+  return execFileSync('git', args, { encoding: 'utf8' })
+}
+
+function commitsSinceLastTag() {
+  let range = 'HEAD'
+  try {
+    const last = git(['describe', '--tags', '--abbrev=0', '--match', 'v*']).trim()
+    if (last) range = `${last}..HEAD`
+  } catch {
+    // no prior tag — use whole history
+  }
+  return git(['log', range, '--no-merges', '--format=%s'])
+    .split('\n')
+    .filter(Boolean)
+}
+
+function today() {
+  return new Date().toISOString().slice(0, 10)
+}
+
+function setOutput(k, v) {
+  if (process.env.GITHUB_OUTPUT) appendFileSync(process.env.GITHUB_OUTPUT, `${k}=${v}\n`)
+  console.log(`${k}=${v}`)
+}
+
+function main() {
+  const chartText = readFileSync(CHART, 'utf8')
+  const curChart = /^version:\s*(.+)$/m.exec(chartText)[1].trim()
+  const curApp = /^appVersion:\s*"?([^"\n]+)"?$/m.exec(chartText)[1].trim()
+
+  const explicit = (process.env.VERSION || '').trim()
+  let bump = (process.env.BUMP || '').trim()
+  if (bump === 'none') bump = '' // the workflow's no-op placeholder
+  if (!explicit && !bump) throw new Error('one of VERSION or BUMP is required')
+  const appVersion = explicit ? explicit.replace(/^v/, '') : bumpSemver(curApp, bump)
+  if (!/^\d+\.\d+\.\d+$/.test(appVersion)) throw new Error(`bad target appVersion: "${appVersion}"`)
+  const chartVersion = bumpSemver(curChart, (process.env.CHART_BUMP || 'patch').trim())
+
+  const parsed = parseCommits(commitsSinceLastTag())
+  const date = today()
+  const section = renderChangelogSection(parsed)
+  const ahChanges = renderAhChanges(parsed) || '    - kind: changed\n      description: "release v' + appVersion + '"'
+
+  writeFileSync(CHART, editChart(chartText, { chartVersion, appVersion, ahChanges }))
+  writeFileSync(CHANGELOG, editChangelog(readFileSync(CHANGELOG, 'utf8'), { version: appVersion, date, section }))
+
+  const prBody = [
+    `Release-prep for **v${appVersion}** (chart **${chartVersion}**), generated by \`prepare-release.yml\`.`,
+    '',
+    `- appVersion ${curApp} -> ${appVersion}, chart ${curChart} -> ${chartVersion}`,
+    '',
+    '### Changes',
+    '',
+    section,
+    '',
+    'Generated from the conventional commits since the last tag. Review and edit before merging; the tag is cut once this lands.',
+  ].join('\n')
+  writeFileSync(process.env.PR_BODY_FILE || 'release-pr-body.md', prBody + '\n')
+
+  setOutput('new_version', appVersion)
+  setOutput('chart_version', chartVersion)
+}
+
+// --- self-test --------------------------------------------------------------
+
+function selfTest() {
+  const assert = (c, m) => { if (!c) throw new Error('self-test: ' + m) }
+  assert(bumpSemver('1.0.2', 'patch') === '1.0.3', 'patch')
+  assert(bumpSemver('1.0.2', 'minor') === '1.1.0', 'minor')
+  assert(bumpSemver('v1.2.3', 'major') === '2.0.0', 'major (v-prefix)')
+  let threw = false
+  try { bumpSemver('1.2', 'patch') } catch { threw = true }
+  assert(threw, 'rejects non-3-part')
+
+  const p = parseCommits([
+    'feat(promql): native grid (#1)',
+    'fix: leak (#2)',
+    'perf(solver): cow',
+    'chore: noise',
+    'refactor(api)!: drop legacy field',
+  ])
+  assert(p.groups.feat.length === 1 && p.groups.feat[0].scope === 'promql', 'feat parsed')
+  assert(p.groups.chore.length === 1, 'chore captured but not rendered')
+  assert(p.breaking.length === 1 && p.breaking[0].type === 'refactor', 'breaking flagged')
+
+  const sec = renderChangelogSection(p)
+  assert(!sec.includes('## [v'), 'section omits the version header')
+  assert(sec.includes('### BREAKING'), 'breaking section')
+  assert(sec.includes('### Added') && sec.includes('native grid'), 'added section')
+  assert(!sec.includes('noise'), 'chore excluded from changelog')
+
+  const ah = renderAhChanges(p)
+  assert(ah.includes('kind: added') && ah.includes('kind: fixed'), 'ah kinds')
+  assert(!ah.includes('kind: chore'), 'ah excludes chore')
+
+  const chart = [
+    'version: 0.3.2',
+    'appVersion: "1.0.2"',
+    '  artifacthub.io/images: |',
+    '    - name: cerberus',
+    '      image: ghcr.io/tsouza/cerberus:v1.0.2',
+    '  artifacthub.io/changes: |',
+    '    - kind: changed',
+    '      description: "old"',
+  ].join('\n') + '\n'
+  const edited = editChart(chart, { chartVersion: '0.4.0', appVersion: '1.1.0', ahChanges: ah })
+  assert(/^version: 0\.4\.0$/m.test(edited), 'chart version bumped')
+  assert(/^appVersion: "1\.1\.0"$/m.test(edited), 'appVersion bumped')
+  assert(edited.includes('cerberus:v1.1.0'), 'image tag bumped')
+  assert(edited.includes('kind: added') && !edited.includes('"old"'), 'ah block replaced')
+
+  const cl = '# Changelog\n\n## [Unreleased]\n\n### Added\n\n- carried entry\n\n## [v1.0.0] — 2026-06-17\n\nfirst\n'
+  const ecl = editChangelog(cl, { version: '1.1.0', date: '2026-06-19', section: sec })
+  assert(ecl.indexOf('## [Unreleased]') < ecl.indexOf('## [v1.1.0]'), 'fresh unreleased on top')
+  assert(ecl.includes('carried entry'), 'carried entries preserved')
+  assert(!ecl.includes('### BREAKING'), 'generated section not duplicated when curated entries exist')
+  assert(ecl.indexOf('## [v1.1.0]') < ecl.indexOf('## [v1.0.0]'), 'new release above old')
+  assert((ecl.match(/## \[v1\.1\.0\]/g) || []).length === 1, 'single v1.1.0 header')
+
+  console.log('::notice::prepare-release --self-test: all assertions passed')
+}
+
+if (process.argv.includes('--self-test')) selfTest()
+else main()

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,80 @@
+name: prepare-release
+
+# Manually-triggered release staging. Bumps the chart `version` + `appVersion`,
+# refreshes the Artifact Hub `changes` annotation and the CHANGELOG, regenerates
+# the chart README, and opens a PR — all derived from the conventional commits
+# since the last `v*` tag. Merging that PR is the human gate; the `v<version>`
+# tag (cut separately) is what triggers `release.yml` to build the image and
+# publish the chart. The logic lives in `.github/scripts/prepare-release.mjs`
+# (Node ESM, no deps) so it is unit-testable; this file is just wiring.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Explicit target appVersion, e.g. 1.2.0 (overrides bump)'
+        type: string
+        required: false
+      bump:
+        description: 'Semver level to bump appVersion (used when version is empty)'
+        type: choice
+        options: [none, patch, minor, major]
+        default: none
+      chart_bump:
+        description: 'Semver level to bump the chart version'
+        type: choice
+        options: [patch, minor, major]
+        default: patch
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prepare:
+    name: prepare
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # need full history + tags for the commit summary
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      # Pin the deriver's own logic before it edits anything.
+      - name: prepare-release self-test
+        run: node .github/scripts/prepare-release.mjs --self-test
+
+      - name: stage release files
+        id: prep
+        env:
+          VERSION: ${{ inputs.version }}
+          BUMP: ${{ inputs.bump }}
+          CHART_BUMP: ${{ inputs.chart_bump }}
+          PR_BODY_FILE: release-pr-body.md
+        run: node .github/scripts/prepare-release.mjs
+
+      # Regenerate the chart README with the SAME helm-docs the chart-validate
+      # drift gate uses (jnorwood/helm-docs:v1.14.2), so the opened PR is green.
+      - name: regenerate chart README
+        uses: docker://jnorwood/helm-docs:v1.14.2
+        with:
+          args: --chart-search-root=deploy/helm --template-files=README.md.gotmpl
+
+      - name: create release PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.prep.outputs.new_version }}
+          CHART_VERSION: ${{ steps.prep.outputs.chart_version }}
+        run: |
+          branch="release/v${VERSION}-chart-${CHART_VERSION}"
+          title="chore(release): cerberus v${VERSION} / chart ${CHART_VERSION}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$branch"
+          git add deploy/helm/cerberus/Chart.yaml deploy/helm/cerberus/README.md CHANGELOG.md
+          git commit -m "$title"
+          git push -u origin "$branch"
+          gh pr create --base main --head "$branch" --title "$title" --body-file release-pr-body.md


### PR DESCRIPTION
Adds a manually-triggered `prepare-release.yml` that stages the next release PR the same way #1002 was assembled by hand — so future releases are one dispatch.

**Inputs**
- `version` — explicit target appVersion (e.g. `1.2.0`), overrides `bump`
- `bump` — `patch` / `minor` / `major` (the requested prepare-release-(patch/minor/major) behaviour, as one choice input rather than three workflows)
- `chart_bump` — chart `version:` bump level (default `patch`)

**What it does**
- bumps chart `version` + `appVersion` + image tag + the Artifact Hub `changes` annotation
- rewrites the CHANGELOG `[Unreleased]` block into a dated `## [vX.Y.Z]` section (curated entries preserved; commit-derived section is the fallback when empty)
- regenerates the chart README via the same `jnorwood/helm-docs:v1.14.2` the drift gate uses, so the opened PR is green
- opens the PR with a body **derived from the conventional commits since the last `v*` tag** (the "description generated with some tool" — a no-dep grouping in `prepare-release.mjs`, not git-cliff/python)

Logic is in `.github/scripts/prepare-release.mjs` (Node ESM, pure helpers + `--self-test`, run as the first workflow step) per the repo's CI-script convention. Merging the PR stays the human gate; the `v<version>` tag still triggers `release.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)