### PR TITLE
chore(release): cerberus v1.1.0 / chart 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,51 +4,46 @@ All notable changes to cerberus will be documented in this file. The format roug
 
 ## [Unreleased]
 
+## [v1.1.0] — 2026-06-19
+
 ### Added
 
-- **Native ClickHouse 25.9 grid aggregates for `changes()` / `resets()`.**
-  `ts_grid_changes` / `ts_grid_resets` lower eligible `changes(<v>[range])` /
-  `resets(<counter>[range])` query_range shapes onto `timeSeriesChangesToGrid` /
-  `timeSeriesResetsToGrid`, retiring the `arrayPopBack`/`arrayPopFront` fan-out
-  (experimental, explicit-only). (#990)
-- **`ts_grid_resample`** — native instant-vector staleness via
-  `timeSeriesResampleToGridWithStaleness`, retiring the argMax fan-out
-  (experimental, explicit-only).
-- **`columnar_result_decode`** — client-side `query_range` matrix decode via the
-  ch-go columnar path (label map built once per run, not per row); no server
-  setting, no version floor; explicit-only. (#983)
-- **Generated, drift-gated docs.** `docs/configuration.md` is generated from the
-  viper config and the `docs/clickhouse-optimizations.md` feature table from the
-  chopt registry, each with a CI gate that fails on drift. (#998, #1000)
-- **CI documentation gates** keeping prose in lock-step with code: internal
-  link + anchor checks, doc-to-code reference checks, and assert-from-source
-  doc-count checks. (#997, #999)
-- **Central `versions.yaml`** as the single source of truth for the supported
-  ClickHouse version, with a version-sync gate across the quickstart,
-  compatibility images, preflight floor, and per-optimization floors. (#995)
-
-### Changed
-
-- **Every version/feature-gated optimization is boot-wired.** Each optimization
-  resolves once at startup into an immutable enabled-set and a concrete
-  pure-polymorphic strategy — no per-query flag, version branch, or nil-check on
-  any data-plane path. PromQL range-lowering and native-grid dispatch were
-  migrated to this model; columnar decode became a `CH_OPTIMIZATIONS` feature. (#986)
-
-### Performance
-
-- **Copy-on-write plan slicing.** The slicer shares immutable off-spine subtrees
-  instead of deep-cloning them — ~2-2.5x fewer allocations on representative
-  slices, up to ~37x on wide off-spine plans. (#988)
+- **ci:** manual prepare-release workflow + generator (#1003)
+- **chopt:** generate opt feature table from registry + drift gate (#998)
+- **config:** generate docs/configuration.md from viper config + CI drift gate (#1000)
+- **promql:** adopt native timeSeriesChangesToGrid/ResetsToGrid (25.9) (#990)
+- **chclient:** columnar query_range matrix decode via ch-go (flag-gated) (#983)
 
 ### Fixed
 
-- Serialize chDB engine access to stop a process-global SIGABRT in
-  `result.Free` under parallel tests. (#984)
-- E2E stability: kill the unless-panel seed-race, the false-positive
-  DiskPressure breadcrumb mislabelling (#992), and DiskPressure evictions by
-  freeing runner disk before the stack (#981).
-- Cache Playwright chromium across e2e shards. (#994)
+- **e2e:** gate showcase probes on seed-fixture signal to kill unless-panel flake (#993)
+- **e2e:** stop the false-positive DiskPressure breadcrumb mislabelling (#992)
+- **test:** serialize chDB engine access to stop SIGABRT in result.Free (#984)
+
+### Performance
+
+- **solver:** share immutable off-spine in plan slicing (copy-on-write) (#988)
+
+### Changed
+
+- **chopt:** adopt columnar decode as a CH_OPTIMIZATIONS feature, drop standalone env (#989)
+- **promql:** pure polymorphic range-lowering dispatch (no nil-check) (#986)
+
+### CI
+
+- **forbid-skip:** assert-from-source doc-count gate; fix forbid-skip 6->5 + layer 12->13 drift (#997)
+- add internal/external link + doc-to-code reference gates (#999)
+- **clickhouse:** central versions.yaml SoT + version-sync gate (#995)
+- **e2e:** cache Playwright chromium across e2e shards (#994)
+- **forbid-skip:** drop the wording-tests vocabulary scan, keep the five behavioural checks (#991)
+- **e2e:** free runner disk before the stack to stop DiskPressure evictions (#981)
+
+### Documentation
+
+- **changelog:** restructure pre-1.1.0 — backfill v1.0.1/v1.0.2, stage [Unreleased] (#1004)
+- fix configuration.md anchor links broken by generator (#1000) (#1001)
+- sync docs to code ahead of v1.1.0 (feature table, COW, dead links, counts) (#996)
+- native-ClickHouse roadmap + staged timeSeriesIncreaseToGrid contribution (#982)
 
 ## [v1.0.2] — 2026-06-18
 

--- a/deploy/helm/cerberus/Chart.yaml
+++ b/deploy/helm/cerberus/Chart.yaml
@@ -8,11 +8,11 @@ type: application
 # upgrade?" and is the publish trigger: a chart-only fix bumps this without an
 # app re-tag; an app-only release bumps appVersion + a PATCH here for the new
 # default image. Starts 0.x because the values contract is not yet frozen.
-version: 0.3.2
+version: 0.4.0
 
 # appVersion tracks the GA cerberus binary. Quoted so SemVer-shaped values
 # aren't coerced to floats. image.tag defaults from this when left empty.
-appVersion: "1.0.2"
+appVersion: "1.1.0"
 
 # autoscaling/v2 + policy/v1 (PDB) + networking/v1 (Ingress) are all GA from
 # 1.21+; 1.23 is the conservative floor matching the manifests this chart
@@ -45,11 +45,27 @@ annotations:
       url: https://github.com/tsouza/cerberus/blob/main/docs/operations.md
   artifacthub.io/images: |
     - name: cerberus
-      image: ghcr.io/tsouza/cerberus:v1.0.2
+      image: ghcr.io/tsouza/cerberus:v1.1.0
   # Bump the `1.0.0` floor here when the chart raises its minimum supported
   # cerberus release; informational for Artifact Hub's compatibility hints.
   artifacthub.io/changes: |
+    - kind: added
+      description: "ci: manual prepare-release workflow + generator (#1003)"
+    - kind: added
+      description: "chopt: generate opt feature table from registry + drift gate (#998)"
+    - kind: added
+      description: "config: generate docs/configuration.md from viper config + CI drift gate (#1000)"
+    - kind: added
+      description: "promql: adopt native timeSeriesChangesToGrid/ResetsToGrid (25.9) (#990)"
+    - kind: added
+      description: "chclient: columnar query_range matrix decode via ch-go (flag-gated) (#983)"
+    - kind: fixed
+      description: "e2e: gate showcase probes on seed-fixture signal to kill unless-panel flake (#993)"
+    - kind: fixed
+      description: "e2e: stop the false-positive DiskPressure breadcrumb mislabelling (#992)"
+    - kind: fixed
+      description: "test: serialize chDB engine access to stop SIGABRT in result.Free (#984)"
     - kind: changed
-      description: "appVersion -> 1.0.2: histogram_quantile phi-domain (+/-Inf out of range) + vector(scalar) vector-typing fixes, plus dependency updates"
+      description: "solver: share immutable off-spine in plan slicing (copy-on-write) (#988)"
     - kind: changed
-      description: "admit.{prom,loki,tempo} documented as integer per-head concurrency caps with true/false aliases (matches the binary's restored integer admission caps)"
+      description: "chopt: adopt columnar decode as a CH_OPTIMIZATIONS feature, drop standalone env (#989)"

--- a/deploy/helm/cerberus/README.md
+++ b/deploy/helm/cerberus/README.md
@@ -5,7 +5,7 @@
      pipe-aligned, and the version footer adds a trailing blank — both are
      owned by helm-docs; realigning would fight the chart-ci drift check. -->
 
-![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.2](https://img.shields.io/badge/AppVersion-1.0.2-informational?style=flat-square)
+![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
 
 Drop-in Prometheus / Loki / Tempo HTTP gateway for ClickHouse — a single stateless gateway that speaks three upstream query wire formats and lowers each to parameterised ClickHouse SQL.
 


### PR DESCRIPTION
Staged by the new `prepare-release` pipeline (dispatched `prepare-release.yml -f version=1.1.0 -f chart_bump=minor`, run [27811136726](https://github.com/tsouza/cerberus/actions/runs/27811136726)). Opened with a user token because GitHub blocks Actions' `GITHUB_TOKEN` from creating PRs (and such PRs don't trigger CI anyway).

**Generated, all from the commit history since `v1.0.2`:**
- Chart.yaml: version 0.3.2 → 0.4.0, appVersion 1.0.2 → 1.1.0, image tag v1.1.0, `artifacthub.io/changes` regenerated
- chart README badge regenerated (helm-docs v1.14.2)
- CHANGELOG `[v1.1.0]` section grouped by type (Added/Fixed/Performance/Changed/CI/Documentation), `[Unreleased]` reset empty

Version references are consistent everywhere (Chart.yaml/README/CHANGELOG); zero stale `1.0.2`. Tag `v1.1.0` is cut once this lands → `release.yml` builds the image + publishes chart 0.4.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)