### PR TITLE
feat(chclient): surface ch-go telemetry on cerberus's own telemetry

### DIFF
--- a/internal/chclient/columnar.go
+++ b/internal/chclient/columnar.go
@@ -108,6 +108,13 @@ func chPoolOptions(cfg Config) chpool.Options {
 		User:     cfg.Username,
 		Password: cfg.Password,
 		TLS:      cfg.TLS,
+		// Route ch-go's own client instrumentation (per-query spans carrying
+		// Rows/Bytes/Blocks, and its meter) through cerberus's telemetry: ch-go
+		// defaults TracerProvider/MeterProvider to the OTel globals, which
+		// cerberus configures for OTLP export. When no exporter is configured
+		// the globals are no-ops, so this stays free. ch-go's query span nests
+		// under cerberus's execute span as added transport-level detail.
+		OpenTelemetryInstrumentation: true,
 	}
 	if cfg.DialTimeout > 0 {
 		opts.DialTimeout = cfg.DialTimeout
@@ -167,12 +174,14 @@ func (d columnarDecoder) queryCursorColumnar(c *Client, ctx context.Context, sql
 	}
 	rec := recorderFromContext(ctx)
 
+	pe := &profileEventAccumulator{}
 	q := ch.Query{
-		Body:     body,
-		QueryID:  queryID,
-		Result:   dec.results.Auto(),
-		Settings: chSettings(c.querySettings(ctx)),
-		OnResult: dec.onResult,
+		Body:            body,
+		QueryID:         queryID,
+		Result:          dec.results.Auto(),
+		Settings:        chSettings(c.querySettings(ctx)),
+		OnResult:        dec.onResult,
+		OnProfileEvents: pe.observe,
 	}
 	if rec != nil {
 		q.OnProgress = progressBridge(rec)
@@ -186,6 +195,10 @@ func (d columnarDecoder) queryCursorColumnar(c *Client, ctx context.Context, sql
 		span.End()
 		return nil, false, nil
 	}
+	// Surface the accumulated ProfileEvents inline on the execute span (both the
+	// error and success paths below keep the span). A shape-mismatch returns
+	// above before this, since it carried no real result.
+	pe.stamp(span)
 	breakerErr := runErr
 	if isBudgetErr(runErr) {
 		breakerErr = nil // budget rejection is the caller asking for too much, not an outage

--- a/internal/chclient/columnar_support.go
+++ b/internal/chclient/columnar_support.go
@@ -9,6 +9,8 @@ import (
 	"github.com/ClickHouse/ch-go"
 	chproto "github.com/ClickHouse/ch-go/proto"
 	"github.com/ClickHouse/clickhouse-go/v2"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // columnar_support.go — the conn-agnostic glue the ch-go matrix path needs:
@@ -65,6 +67,62 @@ func progressBridge(rec *progressRecorder) func(context.Context, chproto.Progres
 		rec.onProgress(&clickhouse.Progress{Rows: rows, Bytes: bytes})
 		return nil
 	}
+}
+
+// chProfileEventAttrPrefix namespaces the per-query ClickHouse ProfileEvent
+// counters stamped onto the execute span.
+const chProfileEventAttrPrefix = "ch.profile_event."
+
+// profileEventAccumulator collects ch-go's per-block ProfileEvents — the SAME
+// server-side counters (SelectedRows, RowsReadByPrewhereReaders,
+// QueryConditionCacheHits, …) that later land in `system.query_log`. ch-go
+// streams them in batches, so we sum by name and, at query end, stamp the
+// non-zero totals onto the execute span. This surfaces the cost data the
+// optcorpus reconciler scrapes asynchronously from `system.query_log` INLINE on
+// the trace, with no reconcile latency and no second server round-trip — for
+// columnar-matrix queries (the only path that runs through ch-go).
+type profileEventAccumulator struct {
+	totals map[string]int64
+}
+
+// observe is the ch-go OnProfileEvents handler: it sums each event batch's
+// values by name. ch-go calls it once per event batch over the query's life.
+func (a *profileEventAccumulator) observe(_ context.Context, events []chproto.ProfileEvent) error {
+	if a.totals == nil {
+		a.totals = make(map[string]int64, len(events))
+	}
+	for i := range events {
+		a.totals[events[i].Name] += events[i].Value
+	}
+	return nil
+}
+
+// stamp writes each accumulated non-zero ProfileEvent onto span as a
+// `ch.profile_event.<Name>` integer attribute. No-op when nothing was observed
+// or the span is not recording. ponytail: OTel's default 128-attribute span cap
+// silently drops the tail if a query emits an unusually large event set; raise
+// the span attribute limit in the tracer config if that ever bites.
+func (a *profileEventAccumulator) stamp(span trace.Span) {
+	if len(a.totals) == 0 || span == nil || !span.IsRecording() {
+		return
+	}
+	if attrs := a.attrs(); len(attrs) > 0 {
+		span.SetAttributes(attrs...)
+	}
+}
+
+// attrs renders the accumulated non-zero totals as `ch.profile_event.<Name>`
+// integer attributes. Split out from stamp so the name/value/non-zero handling
+// is unit-testable without an OTel span.
+func (a *profileEventAccumulator) attrs() []attribute.KeyValue {
+	attrs := make([]attribute.KeyValue, 0, len(a.totals))
+	for name, v := range a.totals {
+		if v == 0 {
+			continue
+		}
+		attrs = append(attrs, attribute.Int64(chProfileEventAttrPrefix+name, v))
+	}
+	return attrs
 }
 
 // bindArgs splices the positional `?` arguments into sql to produce the raw

--- a/internal/chclient/columnar_support_test.go
+++ b/internal/chclient/columnar_support_test.go
@@ -1,0 +1,65 @@
+package chclient
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	chproto "github.com/ClickHouse/ch-go/proto"
+)
+
+// TestProfileEventAccumulator pins the ProfileEvents bridge: ch-go streams
+// events in batches, so observe must SUM by name across batches, and attrs
+// must render only non-zero totals as `ch.profile_event.<Name>` integers.
+func TestProfileEventAccumulator(t *testing.T) {
+	t.Parallel()
+
+	var a profileEventAccumulator
+	// Two batches, same names accumulate; a zero-valued event is dropped.
+	_ = a.observe(context.Background(), []chproto.ProfileEvent{
+		{Name: "SelectedRows", Value: 100},
+		{Name: "RowsReadByPrewhereReaders", Value: 40},
+		{Name: "QueryConditionCacheHits", Value: 0},
+	})
+	_ = a.observe(context.Background(), []chproto.ProfileEvent{
+		{Name: "SelectedRows", Value: 50}, // accumulates to 150
+	})
+
+	got := map[string]int64{}
+	for _, kv := range a.attrs() {
+		got[string(kv.Key)] = kv.Value.AsInt64()
+	}
+
+	want := map[string]int64{
+		"ch.profile_event.SelectedRows":              150,
+		"ch.profile_event.RowsReadByPrewhereReaders": 40,
+	}
+	if len(got) != len(want) {
+		keys := make([]string, 0, len(got))
+		for k := range got {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		t.Fatalf("attr count = %d (%v), want %d", len(got), keys, len(want))
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("%s = %d, want %d", k, got[k], v)
+		}
+	}
+	if _, ok := got["ch.profile_event.QueryConditionCacheHits"]; ok {
+		t.Error("zero-valued ProfileEvent should be dropped, not stamped")
+	}
+}
+
+// TestProfileEventAccumulator_Empty: no events observed -> no attrs, and stamp
+// on a nil span is a no-op (does not panic).
+func TestProfileEventAccumulator_Empty(t *testing.T) {
+	t.Parallel()
+
+	var a profileEventAccumulator
+	if got := a.attrs(); len(got) != 0 {
+		t.Fatalf("attrs() on empty accumulator = %v, want none", got)
+	}
+	a.stamp(nil) // must not panic
+}


### PR DESCRIPTION
Leverages ch-go's observability surface on the columnar matrix path (the only path that runs through ch-go), per the investigation into ch-go PR #1135.

**1. Inline ProfileEvents (the headline win).** Wires ch-go's `OnProfileEvents` to accumulate the per-query server-side counters (`SelectedRows`, `RowsReadByPrewhereReaders`, `QueryConditionCacheHits`, …) and stamps the non-zero totals onto the execute span as `ch.profile_event.<Name>`. This is the **same cost data the optcorpus reconciler scrapes asynchronously from `system.query_log`**, delivered **inline on the trace** — no reconcile latency, no second round-trip, no `query_id` correlation window.

**2. ch-go's own OTel instrumentation** (`OpenTelemetryInstrumentation: true` on the columnar pool). ch-go defaults its Tracer/Meter providers to the OTel globals cerberus already configures for OTLP export, so ch-go's per-query spans (Rows/Bytes/Blocks) and meter flow out **cerberus's own telemetry**; no-op when no exporter is set. Its span nests under cerberus's execute span as transport detail.

Complements (does not replace) the optcorpus reconciler — only columnar queries take ch-go; the clickhouse-go/v2 row path still needs the async join.

Tests: `TestProfileEventAccumulator{,_Empty}` pin the batch summation + non-zero filter. Build + `golangci-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)