### PR TITLE
fix(loki): tail drops overflow rows when a poll window exceeds the limit

### DIFF
--- a/internal/api/loki/tail.go
+++ b/internal/api/loki/tail.go
@@ -27,10 +27,6 @@ const (
 	defaultTailLimit    = 100
 	maxTailDelayFor     = 5 * time.Second
 
-	// tailPollInterval is how often the handler queries ClickHouse for
-	// new rows. Upstream Loki streams chunks every ~1s; we match that.
-	tailPollInterval = 1 * time.Second
-
 	// defaultTailWriteTimeout caps how long a single WebSocket write may
 	// block before we tear the connection down. Catches slow / dead clients
 	// without leaking the polling goroutine. Operators override it via
@@ -38,6 +34,11 @@ const (
 	// the fallback when the handler field is zero (bare-Handler tests).
 	defaultTailWriteTimeout = 10 * time.Second
 )
+
+// tailPollInterval is how often the handler queries ClickHouse for new rows.
+// Upstream Loki streams chunks every ~1s; we match that. A var (not const) so
+// tests can shorten it; never reassigned in production.
+var tailPollInterval = 1 * time.Second
 
 // tailWriteTimeout resolves the effective per-write deadline: the handler's
 // configured TailWriteTimeout when positive, else the package default.
@@ -251,17 +252,23 @@ func (h *Handler) runTailLoop(ctx context.Context, conn *websocket.Conn, cfg tai
 		// Grafana's tail client doesn't negotiate `categorize-labels` over
 		// the socket, so per-line structured metadata is not surfaced here.
 		streams := toStreamsWithTransform(samples, cfg.tx, false)
-		// Advance the cursor past the latest row we just sent so the
-		// next poll picks up only newer data. If the batch was empty we
-		// still advance to `end` to avoid re-querying the same window.
+		// Advance the cursor. The batch is ordered ascending and capped at
+		// cfg.limit, so when it comes back FULL it may be truncated — more
+		// rows can exist in (lastSent, end]. In that case advance only PAST
+		// the last row we actually sent, so the overflow is re-queried on
+		// the next poll instead of being skipped. Otherwise (a short or
+		// empty batch) the window is fully drained, so advance to `end` to
+		// avoid re-querying it. The previous code seeded nextCursor at `end`
+		// and only bumped it UP — but every row is bounded `<= end`, so the
+		// bump never fired and a truncated window silently dropped its tail.
 		nextCursor := end
-		for _, s := range samples {
-			if s.Timestamp.After(nextCursor) {
-				nextCursor = s.Timestamp
-			}
+		if len(samples) > 0 && len(samples) == cfg.limit {
+			nextCursor = samples[len(samples)-1].Timestamp // latest sent (ASC order)
 		}
 		// Tick forward by 1ns so the inclusive `>=` lower bound doesn't
-		// duplicate the just-sent latest row on the next poll.
+		// re-send the boundary row next poll. (A rare exact-nanosecond tie
+		// straddling a truncation boundary is dropped — acceptable for a
+		// best-effort live tail; distinct-timestamp overflow is preserved.)
 		cursor = nextCursor.Add(time.Nanosecond)
 
 		// Skip the wire write on empty chunks — both upstream Loki and

--- a/internal/api/loki/tail_overflow_internal_test.go
+++ b/internal/api/loki/tail_overflow_internal_test.go
@@ -1,0 +1,220 @@
+package loki
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"regexp"
+	"sort"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// cursorAwareQuerier faithfully emulates ClickHouse for the /tail polling
+// query. Unlike tailStubQuerier (which returns canned chunks and ignores the
+// cursor), this fake parses the inlined time bounds and LIMIT out of the SQL
+// string and returns exactly the rows a real CH would for that window:
+//
+//	rows WHERE cursor <= Timestamp <= end, ORDER BY Timestamp ASC, LIMIT n
+//
+// The time bounds are rendered inline as `toDateTime64('YYYY-MM-DD
+// HH:MM:SS.fffffffff', 9)` literals (lower = cursor `>=`, upper = end `<=`);
+// the limit is rendered as `LIMIT n` (NOT positional args). This is what lets
+// the test catch the overflow-drop bug: when a window holds more than `limit`
+// matching rows, a correct cursor-advance must re-query the truncated tail on
+// the next poll instead of skipping past `end`.
+type cursorAwareQuerier struct {
+	master []chclient.Sample // seeded, sorted ASC by Timestamp
+}
+
+var (
+	dt64Re  = regexp.MustCompile(`toDateTime64\('([^']+)', 9\)`)
+	limitRe = regexp.MustCompile(`LIMIT (\d+)`)
+)
+
+const dt64Layout = "2006-01-02 15:04:05.000000000"
+
+func (q *cursorAwareQuerier) Query(_ context.Context, sql string, _ ...any) ([]chclient.Sample, error) {
+	bounds := dt64Re.FindAllStringSubmatch(sql, -1)
+	if len(bounds) != 2 {
+		// Not the tail polling query (or shape changed); return nothing
+		// rather than guess.
+		return nil, nil
+	}
+	lower, err := time.Parse(dt64Layout, bounds[0][1])
+	if err != nil {
+		return nil, err
+	}
+	upper, err := time.Parse(dt64Layout, bounds[1][1])
+	if err != nil {
+		return nil, err
+	}
+
+	limit := -1
+	if m := limitRe.FindStringSubmatch(sql); m != nil {
+		n, err := strconv.Atoi(m[1])
+		if err != nil {
+			return nil, err
+		}
+		limit = n
+	}
+
+	out := make([]chclient.Sample, 0, len(q.master))
+	for _, s := range q.master {
+		ts := s.Timestamp.UTC()
+		if (ts.Equal(lower) || ts.After(lower)) && (ts.Equal(upper) || ts.Before(upper)) {
+			out = append(out, s)
+			if limit > 0 && len(out) == limit {
+				break
+			}
+		}
+	}
+	return out, nil
+}
+
+// The remaining Querier methods are unused by /tail; satisfy the interface.
+func (q *cursorAwareQuerier) QueryIndexStats(context.Context, string, ...any) (chclient.IndexStatsRow, error) {
+	return chclient.IndexStatsRow{}, nil
+}
+
+func (q *cursorAwareQuerier) QueryIndexVolume(context.Context, string, ...any) ([]chclient.IndexVolumeRow, error) {
+	return nil, nil
+}
+
+func (q *cursorAwareQuerier) QueryStrings(context.Context, string, ...any) ([]string, error) {
+	return nil, nil
+}
+
+func (q *cursorAwareQuerier) QueryDetectedFieldRows(context.Context, string, ...any) ([]chclient.DetectedFieldRow, error) {
+	return nil, nil
+}
+
+func (q *cursorAwareQuerier) QueryTimestampedLines(context.Context, string, ...any) ([]chclient.TimestampedLine, error) {
+	return nil, nil
+}
+
+func (q *cursorAwareQuerier) QueryLabelSets(context.Context, string, ...any) ([]map[string]string, error) {
+	return nil, nil
+}
+
+// TestTail_OverflowRowsNotDropped is the regression guard for the
+// poll-window-exceeds-limit data-loss bug. Five rows share ONE poll window
+// (all timestamps in the past, so the very first poll's [cursor, now] covers
+// them all) but the tail is opened with limit=2. A correct cursor-advance
+// must drain the truncated overflow across subsequent polls and deliver all
+// five lines exactly once, in order. The pre-fix code seeded the cursor at
+// `end` and jumped past the whole window, delivering only the first 2 of 5.
+//
+// This test lives in package loki (internal) so it can shorten the unexported
+// tailPollInterval; it must NOT t.Parallel() because it mutates that package
+// global.
+func TestTail_OverflowRowsNotDropped(t *testing.T) {
+	// Speed up polling so the five rows drain quickly across ticks.
+	prev := tailPollInterval
+	tailPollInterval = 10 * time.Millisecond
+	t.Cleanup(func() { tailPollInterval = prev })
+
+	// Seed five rows with DISTINCT timestamps clustered just after "now".
+	// The tail's default lower bound (`start`) is the dial moment, so the
+	// rows must sit at/after it; they're packed into a tight 4ms span a few
+	// ms in the future so that within a couple of 10ms polls a single
+	// window's upper bound (`end = now`) covers ALL of them at once — the
+	// over-limit window the bug drops. 1ms spacing keeps them unambiguous
+	// after the nanosecond cursor bump.
+	base := time.Now().UTC().Add(20 * time.Millisecond)
+	want := []string{"line-1", "line-2", "line-3", "line-4", "line-5"}
+	master := make([]chclient.Sample, len(want))
+	for i, line := range want {
+		master[i] = chclient.Sample{
+			MetricName: line,
+			Labels:     map[string]string{"job": "api"},
+			Timestamp:  base.Add(time.Duration(i) * time.Millisecond),
+		}
+	}
+	q := &cursorAwareQuerier{master: master}
+
+	h := New(q, schema.DefaultOTelLogs(), nil)
+	mux := http.NewServeMux()
+	h.Mount(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	conn := dialTailLimit(t, srv, `{job="api"}`, 2)
+
+	// Collect lines until all five arrive or a short deadline elapses. Assert
+	// each is received exactly once and in ascending order.
+	var got []string
+	seen := map[string]int{}
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) && len(got) < len(want) {
+		_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+		_, payload, err := conn.ReadMessage()
+		if err != nil {
+			break
+		}
+		var chunk struct {
+			Streams []struct {
+				Values [][]any `json:"values"`
+			} `json:"streams"`
+		}
+		if err := json.Unmarshal(payload, &chunk); err != nil {
+			t.Fatalf("unmarshal: %v (payload=%s)", err, payload)
+		}
+		for _, st := range chunk.Streams {
+			for _, pair := range st.Values {
+				if len(pair) == 2 {
+					if line, ok := pair[1].(string); ok {
+						seen[line]++
+						got = append(got, line)
+					}
+				}
+			}
+		}
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("overflow rows dropped: received %d of %d lines (got=%v); pre-fix code delivers only the first 2", len(got), len(want), got)
+	}
+	for _, line := range want {
+		if seen[line] != 1 {
+			t.Errorf("line %q received %d times, want exactly 1 (got=%v)", line, seen[line], got)
+		}
+	}
+	if !sort.StringsAreSorted(got) {
+		t.Errorf("lines not received in ascending order: %v", got)
+	}
+}
+
+// dialTailLimit is dialTail with an explicit ?limit=. Kept local to the
+// internal test so it can set the limit param the overflow case needs.
+func dialTailLimit(t *testing.T, srv *httptest.Server, query string, limit int) *websocket.Conn {
+	t.Helper()
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+	u.Scheme = "ws"
+	u.Path = "/loki/api/v1/tail"
+	qv := url.Values{}
+	qv.Set("query", query)
+	qv.Set("limit", strconv.Itoa(limit))
+	u.RawQuery = qv.Encode()
+
+	conn, resp, err := websocket.DefaultDialer.Dial(u.String(), nil)
+	if err != nil {
+		if resp != nil {
+			t.Fatalf("dial: %v (status=%d)", err, resp.StatusCode)
+		}
+		t.Fatalf("dial: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	return conn
+}


### PR DESCRIPTION
## The bug

`/loki/api/v1/tail` (`internal/api/loki/tail.go`, `handleTail` -> `runTailLoop`) polls ClickHouse every `tailPollInterval` with:

```sql
... WHERE Timestamp >= cursor AND Timestamp <= end ORDER BY Timestamp ASC LIMIT cfg.limit
```

The old cursor-advance seeded `nextCursor := end` and only bumped it UP for samples `After(end)`. But every returned row is bounded `<= end`, so the bump never fired and the cursor always jumped to `end + 1ns`. When a poll window matched MORE than `cfg.limit` rows, the `LIMIT`-truncated overflow in `(lastSent, end]` was silently skipped — data loss on busy tails.

## The fix

When the batch comes back FULL (`len(samples) == cfg.limit`) the window may be truncated, so advance only past the last row actually sent (`samples[len-1].Timestamp + 1ns`, rows are ASC) — the overflow is re-queried next poll. Otherwise (short/empty batch) the window is fully drained, so advance to `end`.

## Regression test

`internal/api/loki/tail_overflow_internal_test.go` (internal `package loki` so it can shorten the unexported `tailPollInterval`) drives the real `/tail` WebSocket against a **cursor-aware** fake `Querier`. The fake parses the inlined `toDateTime64('...', 9)` lower/upper bounds and `LIMIT n` out of the emitted SQL and returns rows for `cursor <= ts <= end` ASC capped at the limit — faithfully emulating ClickHouse (the existing `tailStubQuerier` ignores the cursor and cannot catch this).

Five distinct-timestamp rows land in one over-limit (`limit=2`) poll window; the test asserts every line is received exactly once, in order.

- **Pre-fix:** delivers only the first rows of the truncated window (verified: 3 of 5, consistently across 5 runs) — FAILS.
- **Post-fix:** all 5 stream across polls — PASSES (5/5 runs).

The test is non-parallel (it mutates the `tailPollInterval` package global, restored via `t.Cleanup`).

A `//go:build chdb` integration variant was deferred as follow-up: the existing chDB harness is non-trivial to reuse and the tail loop's wall-clock-relative poll windows make a real-CH seed timing-sensitive. The cursor-aware unit test is the required deliverable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)