### PR TITLE
ci: reject empty / stub PR descriptions (pr-body gate)

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -95,6 +95,18 @@ wrapper, plus `appendStepSummary` / `setOutput` for the runner files.
   - Env: none (paths are repo-relative to the script).
   - Exit: `0` when every doc count matches source (or every self-test
     meta-assertion passes), `1` on any drift / undetected mutation.
+- **`pr-body-check.mjs`** — `pr-hygiene.yml`, the `pr-body` job. Rejects a
+  pull request with an empty or stub description (the `gh pr create … --body
+  'cat'` incident, where a malformed heredoc shipped a PR whose entire body was
+  the word `cat`). Strips boilerplate that carries no description (the AI footer,
+  `Co-authored-by:` trailers, HTML/template comments, image-only lines), then
+  requires the remainder to be substantive: at least `MIN_CHARS` (20) of
+  meaningful text and not a lone placeholder token (`cat`/`wip`/`todo`/…). Runs
+  on `pull_request` (incl. `edited`, so fixing the body re-runs the gate). The
+  body is read from the `PR_BODY` env var — never interpolated into a shell line.
+  - Env: `PR_BODY` (the pull request body); argv `--self-test`.
+  - Exit: `0` when the description is substantive (or self-test passes), `1` on
+    an empty / stub body (with one `::error::` explaining what to write).
 - **`gremlins-threshold.mjs`** — `mutation.yml`, the
   `enforce efficacy threshold` step.
   - Env: `REPORT` (default `gremlins.json`), `THRESHOLD` (a number).

--- a/.github/scripts/pr-body-check.mjs
+++ b/.github/scripts/pr-body-check.mjs
@@ -27,8 +27,14 @@ const PLACEHOLDER = /^(cat|dog|todo|to-?do|wip|test|tests?|placeholder|tbd|t\.?b
 // description: the Claude footer, Co-authored-by trailers, HTML comments, and
 // markdown image-only lines, then collapses whitespace.
 export function meaningfulBody(raw) {
-  return String(raw ?? '')
-    .replace(/<!--[\s\S]*?-->/g, '') // HTML / template comments
+  // Strip HTML / template comments to a FIXPOINT: a single non-greedy pass can
+  // leave a residual `<!--` on crafted nested markers, so repeat until stable.
+  let s = String(raw ?? '');
+  for (let prev; prev !== s; ) {
+    prev = s;
+    s = s.replace(/<!--[\s\S]*?-->/g, '');
+  }
+  return s
     .replace(/^.*🤖.*$/gm, '') // the AI-generated footer line
     .replace(/^\s*Generated with \[?Claude Code.*$/gim, '')
     .replace(/^\s*Co-authored-by:.*$/gim, '')

--- a/.github/scripts/pr-body-check.mjs
+++ b/.github/scripts/pr-body-check.mjs
@@ -1,0 +1,94 @@
+// pr-body-check.mjs — fail a pull request whose description is empty or a
+// stub. A real "gh pr create … --body 'cat'" once shipped a PR whose entire
+// body was the word `cat` (a malformed heredoc dropped the real text); this
+// gate makes that un-mergeable: the agent or human must write an actual
+// description before the PR can go green.
+//
+// The check strips boilerplate that carries no description (the AI-generated
+// footer, Co-authored-by trailers, HTML comments / template comments) and then
+// requires what remains to be a genuine description: at least MIN_CHARS of
+// meaningful text and not a lone placeholder token.
+//
+// Env:
+//   PR_BODY   the pull request body (pass via env, NEVER interpolated into a
+//             shell `run:` line — bodies are attacker-controlled).
+//
+// argv `--self-test` runs the in-process assertion suite and exits.
+
+import { error, notice } from './lib/gh.mjs';
+
+export const MIN_CHARS = 20;
+
+// Lone-token placeholders that clear length checks only by accident. Matched
+// against the whole stripped body (case-insensitive), not substrings.
+const PLACEHOLDER = /^(cat|dog|todo|to-?do|wip|test|tests?|placeholder|tbd|t\.?b\.?d\.?|n\/?a|none|asdf|\.+|x+|foo|bar|stub|wip+|change|changes|update|updates|fix|fixes)$/i;
+
+// meaningfulBody strips the parts of a body that are boilerplate / not a
+// description: the Claude footer, Co-authored-by trailers, HTML comments, and
+// markdown image-only lines, then collapses whitespace.
+export function meaningfulBody(raw) {
+  return String(raw ?? '')
+    .replace(/<!--[\s\S]*?-->/g, '') // HTML / template comments
+    .replace(/^.*🤖.*$/gm, '') // the AI-generated footer line
+    .replace(/^\s*Generated with \[?Claude Code.*$/gim, '')
+    .replace(/^\s*Co-authored-by:.*$/gim, '')
+    .replace(/^\s*!\[[^\]]*\]\([^)]*\)\s*$/gm, '') // image-only lines
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+// classify returns { stub: bool, reason?: string } for a raw body.
+export function classify(raw) {
+  const body = meaningfulBody(raw);
+  if (body.length === 0) {
+    return { stub: true, reason: 'the description is empty (after stripping the AI footer / comments / trailers)' };
+  }
+  if (PLACEHOLDER.test(body)) {
+    return { stub: true, reason: `the description is a placeholder token: "${body}"` };
+  }
+  if (body.length < MIN_CHARS) {
+    return { stub: true, reason: `the description has only ${body.length} meaningful characters (minimum ${MIN_CHARS})` };
+  }
+  return { stub: false };
+}
+
+function selfTest() {
+  const assert = (c, m) => {
+    if (!c) throw new Error('self-test: ' + m);
+  };
+  const stub = (b, why) => assert(classify(b).stub, why);
+  const ok = (b, why) => assert(!classify(b).stub, why);
+
+  stub('', 'empty body');
+  stub('   \n  ', 'whitespace-only');
+  stub('cat', 'the literal #1012 case');
+  stub('TODO', 'placeholder TODO');
+  stub('wip', 'placeholder wip');
+  stub('update', 'one-word filler');
+  stub('🤖 Generated with [Claude Code](https://claude.com/claude-code)', 'footer-only');
+  stub('<!-- describe your change -->', 'comment-only template');
+  stub('Fixes it.', 'too short (< 20 meaningful chars)');
+  ok('Fixes the Loki tail overflow by advancing the cursor past the last sent row.', 'real one-liner');
+  ok('Adds a guardrail.\n\nDetails: rejects empty PR bodies.\n\n🤖 Generated with [Claude Code](x)', 'real body + footer');
+  // footer/trailers must not rescue an otherwise-empty body
+  stub('Co-authored-by: Someone <x@y.z>\n🤖 Generated with [Claude Code](x)', 'only trailers + footer');
+
+  notice('pr-body-check --self-test: all assertions passed');
+}
+
+if (process.argv.includes('--self-test')) {
+  selfTest();
+  process.exit(0);
+}
+
+const { stub, reason } = classify(process.env.PR_BODY);
+if (stub) {
+  error(
+    `pr-body-check: this PR has no real description — ${reason}. ` +
+      `Write a description of WHAT changed and WHY (the gate strips the AI footer, ` +
+      `Co-authored-by trailers, and comments before measuring), then the check re-runs on edit.`,
+  );
+  process.exit(1);
+}
+notice('pr-body-check: PR description is non-empty and substantive.');
+process.exit(0);

--- a/.github/scripts/pr-body-check.mjs
+++ b/.github/scripts/pr-body-check.mjs
@@ -23,18 +23,51 @@ export const MIN_CHARS = 20;
 // against the whole stripped body (case-insensitive), not substrings.
 const PLACEHOLDER = /^(cat|dog|todo|to-?do|wip|test|tests?|placeholder|tbd|t\.?b\.?d\.?|n\/?a|none|asdf|\.+|x+|foo|bar|stub|wip+|change|changes|update|updates|fix|fixes)$/i;
 
+// stripHtmlComments removes every `<!-- ... -->` HTML/template comment with a
+// linear `indexOf` scan, repeated to a FIXPOINT. The fixpoint matters for
+// security: a single pass can re-expose a `<!--` on crafted nested markers
+// (e.g. `<!<!-- -->-- x -->`), which CodeQL flags as
+// js/incomplete-multi-character-sanitization. Looping until the string stops
+// changing guarantees the output cannot contain `<!--` followed by a `-->`.
+//
+// This uses indexOf rather than a regex on purpose: the lazy regex
+// `/<!--[\s\S]*?-->/` is O(n^2) on an unterminated run of `<!--` (it rescans to
+// end-of-string from every open marker), which is a ReDoS on the
+// attacker-controlled PR body. The indexOf scan is strictly linear, and the
+// fixpoint loop stays linear overall because every pass that changes the string
+// removes at least one full comment, so the string strictly shrinks.
+function stripHtmlComments(input) {
+  let s = String(input ?? '');
+  for (let prev; prev !== s; ) {
+    prev = s;
+    let out = '';
+    let i = 0;
+    for (;;) {
+      const open = s.indexOf('<!--', i);
+      if (open === -1) {
+        out += s.slice(i);
+        break;
+      }
+      const close = s.indexOf('-->', open + 4);
+      if (close === -1) {
+        // Unterminated comment: leave the remainder untouched (it carries no
+        // closing marker, so it cannot reintroduce a complete comment).
+        out += s.slice(i);
+        break;
+      }
+      out += s.slice(i, open);
+      i = close + 3;
+    }
+    s = out;
+  }
+  return s;
+}
+
 // meaningfulBody strips the parts of a body that are boilerplate / not a
 // description: the Claude footer, Co-authored-by trailers, HTML comments, and
 // markdown image-only lines, then collapses whitespace.
 export function meaningfulBody(raw) {
-  // Strip HTML / template comments to a FIXPOINT: a single non-greedy pass can
-  // leave a residual `<!--` on crafted nested markers, so repeat until stable.
-  let s = String(raw ?? '');
-  for (let prev; prev !== s; ) {
-    prev = s;
-    s = s.replace(/<!--[\s\S]*?-->/g, '');
-  }
-  return s
+  return stripHtmlComments(raw)
     .replace(/^.*🤖.*$/gm, '') // the AI-generated footer line
     .replace(/^\s*Generated with \[?Claude Code.*$/gim, '')
     .replace(/^\s*Co-authored-by:.*$/gim, '')
@@ -73,6 +106,8 @@ function selfTest() {
   stub('update', 'one-word filler');
   stub('🤖 Generated with [Claude Code](https://claude.com/claude-code)', 'footer-only');
   stub('<!-- describe your change -->', 'comment-only template');
+  stub('<!<!-- -->-- evil -->', 'nested markers must not re-expose a comment'); // CodeQL: incomplete-multi-character-sanitization
+  assert(!meaningfulBody('<!<!-- -->-- evil -->').includes('<!--'), 'stripped body must not contain a residual <!-- marker');
   stub('Fixes it.', 'too short (< 20 meaningful chars)');
   ok('Fixes the Loki tail overflow by advancing the cursor past the last sent row.', 'real one-liner');
   ok('Adds a guardrail.\n\nDetails: rejects empty PR bodies.\n\n🤖 Generated with [Claude Code](x)', 'real body + footer');

--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -1,0 +1,31 @@
+name: pr-hygiene
+
+# Cheap, fast PR-metadata gates that the heavy ci.yml jobs don't cover.
+# Runs only on pull_request (the body lives in the event payload, not the
+# tree). `edited` is included so fixing the description re-runs the gate and
+# clears it without a new commit.
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  pr-body:
+    name: pr-body
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Pin the gate logic
+        run: node .github/scripts/pr-body-check.mjs --self-test
+
+      # Reject an empty / stub PR description (the `--body 'cat'` incident).
+      # PR_BODY is attacker-controlled, so it is passed via env and read by the
+      # script — never interpolated into a shell `run:` line.
+      - name: Reject empty / stub PR descriptions
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: node .github/scripts/pr-body-check.mjs


### PR DESCRIPTION
Adds a guardrail so a stub PR description can never ship again — the `gh pr create … --body 'cat'` incident on #1012, where a malformed heredoc collided with the `--body` flag and gh used the literal word `cat` as the body, dropping the real description on the floor.

**The gate:** a new lightweight `pr-hygiene.yml` workflow runs `.github/scripts/pr-body-check.mjs` on every `pull_request` (including `edited`, so fixing the body re-runs and clears the check without a new commit). The script strips boilerplate that isn't a description — the 🤖 AI footer, `Co-authored-by:` trailers, HTML/template comments, image-only lines — then fails when what remains is empty, a lone placeholder token (`cat`/`wip`/`todo`/…), or under 20 meaningful characters.

Pure Node ESM (no deps) + a `--self-test` (run as the first workflow step) that pins the empty/footer-only/placeholder/too-short cases — including the exact `cat` case. Documented in `.github/scripts/README.md`.

**Follow-up:** to make this strictly enforcing (so auto-merge waits on it), add `pr-body` to the branch's required status checks — happy to do that once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)