### PR TITLE
chore(release): cerberus v1.2.0 / chart 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to cerberus will be documented in this file. The format roug
 
 ## [Unreleased]
 
+## [v1.2.0] — 2026-06-19
+
+### Added
+
+- **chclient:** surface ch-go telemetry on cerberus's own telemetry (#1007)
+
+### Fixed
+
+- **loki:** tail drops overflow rows when a poll window exceeds the limit (#1011)
+- **release:** gate strictly on main HEAD fully settled green (#1008)
+
+### Documentation
+
+- collapse native-upstream roadmap into a single note (uses-today + positioning) (#1014)
+- **roadmap:** mark 5A external-table push DEFERRED — no qualifying call-site (#1010)
+- native-CH roadmap execution addendum (code-now + ambitious chase) (#1009)
+
 ## [v1.1.0] — 2026-06-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ All notable changes to cerberus will be documented in this file. The format roug
 - **roadmap:** mark 5A external-table push DEFERRED — no qualifying call-site (#1010)
 - native-CH roadmap execution addendum (code-now + ambitious chase) (#1009)
 
+### Dependencies
+
+- bump `github.com/ClickHouse/ch-go` 0.71 → 0.72, which exposes the client-side query telemetry surfaced in #1007 (#1005)
+
 ## [v1.1.0] — 2026-06-19
 
 ### Added

--- a/deploy/helm/cerberus/Chart.yaml
+++ b/deploy/helm/cerberus/Chart.yaml
@@ -8,11 +8,11 @@ type: application
 # upgrade?" and is the publish trigger: a chart-only fix bumps this without an
 # app re-tag; an app-only release bumps appVersion + a PATCH here for the new
 # default image. Starts 0.x because the values contract is not yet frozen.
-version: 0.4.0
+version: 0.4.1
 
 # appVersion tracks the GA cerberus binary. Quoted so SemVer-shaped values
 # aren't coerced to floats. image.tag defaults from this when left empty.
-appVersion: "1.1.0"
+appVersion: "1.2.0"
 
 # autoscaling/v2 + policy/v1 (PDB) + networking/v1 (Ingress) are all GA from
 # 1.21+; 1.23 is the conservative floor matching the manifests this chart
@@ -45,27 +45,13 @@ annotations:
       url: https://github.com/tsouza/cerberus/blob/main/docs/operations.md
   artifacthub.io/images: |
     - name: cerberus
-      image: ghcr.io/tsouza/cerberus:v1.1.0
+      image: ghcr.io/tsouza/cerberus:v1.2.0
   # Bump the `1.0.0` floor here when the chart raises its minimum supported
   # cerberus release; informational for Artifact Hub's compatibility hints.
   artifacthub.io/changes: |
     - kind: added
-      description: "ci: manual prepare-release workflow + generator (#1003)"
-    - kind: added
-      description: "chopt: generate opt feature table from registry + drift gate (#998)"
-    - kind: added
-      description: "config: generate docs/configuration.md from viper config + CI drift gate (#1000)"
-    - kind: added
-      description: "promql: adopt native timeSeriesChangesToGrid/ResetsToGrid (25.9) (#990)"
-    - kind: added
-      description: "chclient: columnar query_range matrix decode via ch-go (flag-gated) (#983)"
+      description: "chclient: surface ch-go telemetry on cerberus's own telemetry (#1007)"
     - kind: fixed
-      description: "e2e: gate showcase probes on seed-fixture signal to kill unless-panel flake (#993)"
+      description: "loki: tail drops overflow rows when a poll window exceeds the limit (#1011)"
     - kind: fixed
-      description: "e2e: stop the false-positive DiskPressure breadcrumb mislabelling (#992)"
-    - kind: fixed
-      description: "test: serialize chDB engine access to stop SIGABRT in result.Free (#984)"
-    - kind: changed
-      description: "solver: share immutable off-spine in plan slicing (copy-on-write) (#988)"
-    - kind: changed
-      description: "chopt: adopt columnar decode as a CH_OPTIMIZATIONS feature, drop standalone env (#989)"
+      description: "release: gate strictly on main HEAD fully settled green (#1008)"

--- a/deploy/helm/cerberus/README.md
+++ b/deploy/helm/cerberus/README.md
@@ -5,7 +5,7 @@
      pipe-aligned, and the version footer adds a trailing blank — both are
      owned by helm-docs; realigning would fight the chart-ci drift check. -->
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
+![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
 
 Drop-in Prometheus / Loki / Tempo HTTP gateway for ClickHouse — a single stateless gateway that speaks three upstream query wire formats and lowers each to parameterised ClickHouse SQL.
 


### PR DESCRIPTION
## chore(release): cerberus v1.2.0 / chart 0.4.1

Staged by `prepare-release.yml` (run 27822510745) from the conventional commits since `v1.1.0` (`221d13b97`), with a light manual enrichment of the CHANGELOG (ch-go bump note).

### Why a MINOR app bump (1.1.0 -> 1.2.0)
Since v1.1.0, main shipped a new feature — **#1007 `feat(chclient)`: surface ch-go telemetry on cerberus's own telemetry** — which mandates a minor bump under SemVer. Alongside it: **#1011 `fix(loki)`** tail overflow, **#1008 `fix(release)`** strict green gate, **#1005** ch-go 0.71 -> 0.72 (the dependency that exposes the telemetry surface), plus docs/test internals.

### Why a PATCH chart bump (0.4.0 -> 0.4.1)
This is an **app-only** release: there is **no change to the chart templates or `values.yaml`** since v1.1.0 (verified `git log v1.1.0..HEAD -- deploy/helm/cerberus`). Per the Chart.yaml convention, an app-only release bumps `appVersion` + a PATCH to `version` for the new default image tag. The values contract is unchanged, so existing `values.yaml` files survive the upgrade.

### What this PR changes
- **`deploy/helm/cerberus/Chart.yaml`** — `version: 0.4.1`, `appVersion: "1.2.0"`, default image `ghcr.io/tsouza/cerberus:v1.2.0`, refreshed `artifacthub.io/changes`. Zero stale `1.1.0` remain.
- **`deploy/helm/cerberus/README.md`** — regenerated by helm-docs (v1.14.2, same as the chart-validate drift gate); Version/AppVersion badges now read 0.4.1 / 1.2.0.
- **`CHANGELOG.md`** — dated `## [v1.2.0]` section grouped Added / Fixed / Documentation / Dependencies; `[Unreleased]` reset empty.

### Release mechanics
Merging this PR is the human gate. The `v1.2.0` tag is cut separately (git-refs API) against the fully-green main HEAD, which triggers `release.yml` (preflight -> goreleaser -> chart-release) to publish the GH release, image, and chart.
