### PR TITLE
fix(telemetry): apply CERBERUS_LOG_LEVEL to the OTLP slog bridge (stop debug leaking to otel_logs)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1406,7 +1406,7 @@ func NewTelemetryLogger(w io.Writer, cfg LogConfig, provider any) *slog.Logger {
 		// caller's import wiring is broken; fall back to stderr.
 		return slog.New(local)
 	}
-	return slog.New(telemetry.NewSlogHandler(local, lp))
+	return slog.New(telemetry.NewSlogHandler(local, cfg.Level, lp))
 }
 
 func newLocalHandler(w io.Writer, cfg LogConfig) slog.Handler {

--- a/internal/config/log_test.go
+++ b/internal/config/log_test.go
@@ -6,6 +6,8 @@ import (
 	"log/slog"
 	"strings"
 	"testing"
+
+	"go.opentelemetry.io/otel/log/logtest"
 )
 
 // TestFromEnv_Log_Defaults confirms the slog format/level defaults match
@@ -148,6 +150,53 @@ func TestNewLogger_LevelFilter(t *testing.T) {
 	}
 	if !strings.Contains(out, "kept") {
 		t.Errorf("warn record missing under warn level: %q", out)
+	}
+}
+
+// TestNewTelemetryLogger_LevelGatesBothSinks is the integration guard at
+// the production seam (the same NewTelemetryLogger cmd/cerberus installs):
+// CERBERUS_LOG_LEVEL must filter the OTLP-log bridge symmetrically with
+// stderr, so a sub-level record is exported to NEITHER. Regression for
+// the debug-leak bug, where the level was never threaded into the bridge
+// and Debug records leaked into otel_logs/Loki at info.
+//
+// It drives the real construction path with a logtest.Recorder standing
+// in for the SDK LoggerProvider, so it exercises the actual config ->
+// telemetry wiring (NewTelemetryLogger -> NewSlogHandler -> leveled
+// bridge), not a hand-rolled fanout.
+func TestNewTelemetryLogger_LevelGatesBothSinks(t *testing.T) {
+	cases := []struct {
+		name     string
+		level    slog.Level
+		emit     func(*slog.Logger)
+		wantBoth bool // true: kept by stderr AND OTLP; false: dropped by both
+	}{
+		{name: "info/debug-dropped", level: slog.LevelInfo, emit: func(l *slog.Logger) { l.Debug("ev") }, wantBoth: false},
+		{name: "info/info-kept", level: slog.LevelInfo, emit: func(l *slog.Logger) { l.Info("ev") }, wantBoth: true},
+		{name: "debug/debug-kept", level: slog.LevelDebug, emit: func(l *slog.Logger) { l.Debug("ev") }, wantBoth: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			recorder := logtest.NewRecorder()
+			logger := NewTelemetryLogger(&buf, LogConfig{Format: "text", Level: tc.level}, recorder)
+
+			tc.emit(logger)
+
+			gotLocal := strings.Contains(buf.String(), "ev")
+			var otlpCount int
+			for _, scoped := range recorder.Result() {
+				otlpCount += len(scoped)
+			}
+			gotOTLP := otlpCount > 0
+
+			if gotLocal != tc.wantBoth {
+				t.Errorf("stderr sink kept=%v, want %v (buf=%q)", gotLocal, tc.wantBoth, buf.String())
+			}
+			if gotOTLP != tc.wantBoth {
+				t.Errorf("OTLP sink kept=%v (count=%d), want %v", gotOTLP, otlpCount, tc.wantBoth)
+			}
+		})
 	}
 }
 

--- a/internal/telemetry/slog_handler.go
+++ b/internal/telemetry/slog_handler.go
@@ -9,7 +9,10 @@
 //  2. An OTel slog bridge backed by the provided LoggerProvider —
 //     ships the same record via OTLP gRPC to the collector, which
 //     writes it to ClickHouse `otel_logs` alongside the metrics and
-//     traces this binary emits.
+//     traces this binary emits. The bridge is gated on the SAME
+//     `LogConfig.Level` as the local sink (via leveledHandler), so the
+//     level filter is symmetric: a record dropped at stderr is never
+//     exported to `otel_logs`/Loki either.
 //
 // Without (2), cerberus would rely on the k8s container-log path
 // (stderr → kubelet → filelog receiver → OTLP → CH) which requires a
@@ -38,17 +41,26 @@ const slogScope = "github.com/tsouza/cerberus/internal/telemetry"
 
 // NewSlogHandler returns the slog.Handler cerberus installs as the
 // process default. `local` is the handler that writes to stderr (text
-// or JSON, level-filtered per LogConfig). `provider` is the OTel
-// LoggerProvider built by telemetry.New — pass the no-op provider if
-// you only want the local handler.
+// or JSON, level-filtered per LogConfig). `level` is the minimum level
+// (`LogConfig.Level`) the OTLP bridge is gated on, applied symmetrically
+// with the local sink. `provider` is the OTel LoggerProvider built by
+// telemetry.New — pass the no-op provider if you only want the local
+// handler.
 //
-// The returned handler runs both sinks unconditionally; level filter
-// happens inside each sink, so a record that the local handler drops
-// (e.g. below `info`) still reaches the OTLP bridge if it accepts the
-// level. Callers who want symmetric filtering should set the same
-// level on both sinks — config.NewLogger already does this via
-// `LogConfig.Level`.
-func NewSlogHandler(local slog.Handler, provider otellog.LoggerProvider) slog.Handler {
+// The level filter is applied to BOTH sinks: the local handler enforces
+// it via slog.HandlerOptions.Level, and the OTLP bridge is wrapped in a
+// leveledHandler that gates on the same `level`. Without this wrapper the
+// raw otelslog bridge delegates Enabled to the SDK LoggerProvider, which
+// accepts EVERY severity — so a record the local handler drops (e.g.
+// Debug below `info`) would still be exported to `otel_logs`/Loki. With
+// it, at `info` both sinks reject Debug (the fanout never even creates
+// the record); at `debug` both accept and the record reaches stderr AND
+// the bridge.
+//
+// `level` is a slog.Leveler (LogConfig.Level is a slog.Level, which
+// satisfies it). A nil level defaults to slog.LevelInfo so the bridge is
+// never accidentally left ungated.
+func NewSlogHandler(local slog.Handler, level slog.Leveler, provider otellog.LoggerProvider) slog.Handler {
 	if local == nil {
 		// Defensive: a nil local handler would crash slog.New; install
 		// a discard fallback so callers can pass `nil` to mean
@@ -58,8 +70,39 @@ func NewSlogHandler(local slog.Handler, provider otellog.LoggerProvider) slog.Ha
 	if provider == nil {
 		return local
 	}
+	if level == nil {
+		level = slog.LevelInfo
+	}
 	bridge := otelslog.NewHandler(slogScope, otelslog.WithLoggerProvider(provider))
-	return fanoutHandler{handlers: []slog.Handler{local, bridge}}
+	return fanoutHandler{handlers: []slog.Handler{local, leveledHandler{Handler: bridge, level: level}}}
+}
+
+// leveledHandler gates an inner slog.Handler on a minimum level. The
+// otelslog bridge has no built-in min-severity option (otelslog v0.19.0)
+// — its Enabled delegates to the SDK LoggerProvider, which accepts every
+// severity. Wrapping it here threads `LogConfig.Level` into the OTLP path
+// so the bridge filters symmetrically with the stderr sink.
+//
+// The embedded slog.Handler forwards Handle and (via the explicit
+// WithAttrs/WithGroup below) keeps the leveled gate across slog's
+// handler-chain rebuilds: a bare embed would have those methods return
+// the UNWRAPPED inner handler, silently losing the level gate after the
+// first `logger.With(...)`.
+type leveledHandler struct {
+	slog.Handler
+	level slog.Leveler
+}
+
+func (h leveledHandler) Enabled(ctx context.Context, l slog.Level) bool {
+	return l >= h.level.Level() && h.Handler.Enabled(ctx, l)
+}
+
+func (h leveledHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return leveledHandler{Handler: h.Handler.WithAttrs(attrs), level: h.level}
+}
+
+func (h leveledHandler) WithGroup(name string) slog.Handler {
+	return leveledHandler{Handler: h.Handler.WithGroup(name), level: h.level}
 }
 
 // fanoutHandler dispatches every record to each wrapped handler in

--- a/internal/telemetry/slog_handler_test.go
+++ b/internal/telemetry/slog_handler_test.go
@@ -22,7 +22,7 @@ func TestNewSlogHandler_NilProvider(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer
 	local := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})
-	h := NewSlogHandler(local, nil)
+	h := NewSlogHandler(local, slog.LevelInfo, nil)
 	if h != local {
 		t.Errorf("nil provider should return local handler unchanged; got %T", h)
 	}
@@ -39,7 +39,7 @@ func TestNewSlogHandler_FansOutToBoth(t *testing.T) {
 	localHandler := slog.NewTextHandler(&localBuf, &slog.HandlerOptions{Level: slog.LevelInfo})
 
 	recorder := logtest.NewRecorder()
-	handler := NewSlogHandler(localHandler, recorder)
+	handler := NewSlogHandler(localHandler, slog.LevelInfo, recorder)
 	logger := slog.New(handler)
 	logger.Info(
 		"test event",
@@ -83,7 +83,7 @@ func TestNewSlogHandler_NoopProviderIsStderrOnly(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer
 	local := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})
-	h := NewSlogHandler(local, lognoop.NewLoggerProvider())
+	h := NewSlogHandler(local, slog.LevelInfo, lognoop.NewLoggerProvider())
 	slog.New(h).Info("hello noop")
 	if !strings.Contains(buf.String(), "hello noop") {
 		t.Errorf("noop provider should still write stderr; got %q", buf.String())
@@ -99,7 +99,7 @@ func TestNewSlogHandler_PreservesAttrs(t *testing.T) {
 	local := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})
 	recorder := logtest.NewRecorder()
 
-	handler := NewSlogHandler(local, recorder)
+	handler := NewSlogHandler(local, slog.LevelInfo, recorder)
 	logger := slog.New(handler).With("api", "loki")
 	logger.Info("dispatched", "sql", "SELECT 1")
 
@@ -117,6 +117,90 @@ func TestNewSlogHandler_PreservesAttrs(t *testing.T) {
 	}
 	if got["sql"] != "SELECT 1" {
 		t.Errorf("bridge: sql attr lost; got %+v", got)
+	}
+}
+
+// TestNewSlogHandler_LevelGatesOTLPBridge is the regression for the
+// debug-leak bug: at level=info a Debug record must reach NEITHER the
+// local sink NOR the OTLP bridge, and at level=debug it must reach BOTH.
+// Before the fix the bridge delegated Enabled to the SDK provider, which
+// accepts every severity, so Debug leaked into otel_logs/Loki at info.
+//
+// The test drives the real public construction path (NewSlogHandler, the
+// same seam config.NewTelemetryLogger uses) with a logtest.Recorder as
+// the OTLP sink, so it exercises the actual wiring, not a hand-rolled
+// fanout.
+func TestNewSlogHandler_LevelGatesOTLPBridge(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		level     slog.Level
+		logDebug  bool
+		wantLocal bool
+		wantOTLP  bool
+	}{
+		{name: "info/debug-dropped-both", level: slog.LevelInfo, logDebug: true, wantLocal: false, wantOTLP: false},
+		{name: "info/info-kept-both", level: slog.LevelInfo, logDebug: false, wantLocal: true, wantOTLP: true},
+		{name: "debug/debug-kept-both", level: slog.LevelDebug, logDebug: true, wantLocal: true, wantOTLP: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var localBuf bytes.Buffer
+			local := slog.NewTextHandler(&localBuf, &slog.HandlerOptions{Level: tc.level})
+			recorder := logtest.NewRecorder()
+
+			logger := slog.New(NewSlogHandler(local, tc.level, recorder))
+			if tc.logDebug {
+				logger.Debug("debug event")
+			} else {
+				logger.Info("info event")
+			}
+
+			localCount := strings.Count(localBuf.String(), "event")
+			otlpCount := len(flattenRecorder(recorder))
+
+			wantLocalCount := 0
+			if tc.wantLocal {
+				wantLocalCount = 1
+			}
+			wantOTLPCount := 0
+			if tc.wantOTLP {
+				wantOTLPCount = 1
+			}
+			if localCount != wantLocalCount {
+				t.Errorf("local sink: got %d records, want %d (buf=%q)", localCount, wantLocalCount, localBuf.String())
+			}
+			if otlpCount != wantOTLPCount {
+				t.Errorf("OTLP sink: got %d records, want %d", otlpCount, wantOTLPCount)
+			}
+		})
+	}
+}
+
+// TestNewSlogHandler_LevelGateSurvivesWithAttrs confirms the leveled
+// gate on the OTLP bridge is NOT lost after slog rebuilds the handler
+// chain via With(...). A bare embed of slog.Handler would have WithAttrs
+// return the unwrapped bridge, re-opening the debug leak after the first
+// structured-logger derivation.
+func TestNewSlogHandler_LevelGateSurvivesWithAttrs(t *testing.T) {
+	t.Parallel()
+
+	var localBuf bytes.Buffer
+	local := slog.NewTextHandler(&localBuf, &slog.HandlerOptions{Level: slog.LevelInfo})
+	recorder := logtest.NewRecorder()
+
+	logger := slog.New(NewSlogHandler(local, slog.LevelInfo, recorder)).With("api", "loki")
+	logger.Debug("debug after with")
+
+	if got := len(flattenRecorder(recorder)); got != 0 {
+		t.Errorf("OTLP sink: debug leaked through WithAttrs; got %d records, want 0", got)
+	}
+	if strings.Contains(localBuf.String(), "debug after with") {
+		t.Errorf("local sink: debug leaked through WithAttrs; got %q", localBuf.String())
 	}
 }
 


### PR DESCRIPTION
## Symptom

At `CERBERUS_LOG_LEVEL=info`, `debug` records still landed in ClickHouse `otel_logs` (and therefore Loki), even though the stderr stream correctly dropped them. Operators who set `info` to silence debug in prod were silently polluting their o11y storage with debug logs over OTLP.

## Root cause

`telemetry.NewSlogHandler` built the OTel slog bridge with **no level option**:

```go
bridge := otelslog.NewHandler(slogScope, otelslog.WithLoggerProvider(provider))
```

`otelslog` v0.19.0 has no built-in min-severity knob, so the bridge's `Enabled` delegates to the SDK `LoggerProvider`, which **accepts every severity**. The local sink applied `cfg.Level` via `slog.HandlerOptions{Level: cfg.Level}`, but the level was **never threaded to the bridge**.

`fanoutHandler.Enabled` is an **OR** across its sinks:

```go
func (h fanoutHandler) Enabled(ctx, level) bool {
    for _, sub := range h.handlers { if sub.Enabled(ctx, level) { return true } }
    return false
}
```

So at `info`: the bridge accepts `Debug` -> top-level `Enabled(Debug)=true` -> slog creates the record -> `fanoutHandler.Handle` re-checks each sub and lets the bridge export it -> collector -> `otel_logs`/Loki. stderr correctly dropped it (asymmetric filtering).

Two doc comments (package-level and on `NewSlogHandler`) **falsely** claimed the filtering was already symmetric — they have been corrected.

## Fix

Thread `cfg.Level` (a `slog.Leveler`) into `NewSlogHandler` and wrap the bridge in a `leveledHandler` whose `Enabled` requires **both** `l >= level` AND the inner handler's `Enabled`:

```go
type leveledHandler struct { slog.Handler; level slog.Leveler }
func (h leveledHandler) Enabled(ctx, l) bool {
    return l >= h.level.Level() && h.Handler.Enabled(ctx, l)
}
```

`WithAttrs`/`WithGroup` are explicitly overridden to **re-wrap** the inner handler — a bare embed would return the unwrapped bridge after the first `logger.With(...)`, silently re-opening the leak. The seam chosen is `NewSlogHandler` (keeps handler construction in `telemetry`); the only production caller, `config.NewTelemetryLogger`, passes `cfg.Level`.

After the fix: at `info` both sinks reject `Debug` (the fanout never even creates the record — more efficient); at `debug` both accept and the record reaches stderr **and** `otel_logs`.

## Tests

- `internal/telemetry/slog_handler_test.go`: drives the real `NewSlogHandler` path with a `logtest.Recorder` OTLP sink. Asserts **0 local + 0 OTLP** for `Debug` at `info`, **1 + 1** for `Info` at `info`, **1 + 1** for `Debug` at `debug`, plus a `WithAttrs`-survival case proving the gate holds across `logger.With(...)`.
- `internal/config/log_test.go`: a `NewTelemetryLogger` integration guard exercising the **production construction path** end-to-end (config -> telemetry wiring) for the same level symmetry — catching any future regression of this class (a telemetry sink ignoring `CERBERUS_LOG_LEVEL`) at the integration boundary.

All existing tests updated for the new signature and pass.

## Validation

- `go build ./...` — clean
- `go test ./internal/telemetry/... ./internal/config/...` — pass
- `golangci-lint run ./internal/telemetry/... ./internal/config/...` — no issues
- `gofmt -l` — clean

No chart/values change, so no `Chart.yaml` bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)