### PR TITLE
ci(release): make release tooling backport-aware (maintenance lines + :latest guard)

### DIFF
--- a/.github/scripts/release-preflight.mjs
+++ b/.github/scripts/release-preflight.mjs
@@ -45,16 +45,16 @@ export const GREEN_CONCLUSIONS = new Set(['success', 'skipped', 'neutral']);
 // list of blocking problems (empty == release may proceed) and the count of
 // gated checks. No network, no exclusions beyond self-jobs — exported so the
 // self-test pins the exact pass/fail boundary.
-export function evaluate({ mainHead, taggedSha, checkRuns, statuses, selfJobs }) {
+export function evaluate({ mainHead, taggedSha, checkRuns, statuses, selfJobs, baseLabel = 'main' }) {
   const problems = [];
   if (!mainHead) {
-    problems.push('could not resolve the default-branch (main) HEAD commit');
+    problems.push(`could not resolve the ${baseLabel} HEAD commit`);
     return { problems, gated: 0 };
   }
   if (taggedSha !== mainHead) {
     problems.push(
-      `tagged commit ${taggedSha.slice(0, 8)} is NOT main HEAD ${mainHead.slice(0, 8)} — ` +
-        `a release may only be cut from the tip of main`,
+      `tagged commit ${taggedSha.slice(0, 8)} is NOT ${baseLabel} HEAD ${mainHead.slice(0, 8)} — ` +
+        `a release may only be cut from the tip of its release line (${baseLabel})`,
     );
     return { problems, gated: 0 };
   }
@@ -205,12 +205,27 @@ async function getJSON(url) {
   return res.json();
 }
 
-// HEAD commit of the repo's default branch (main).
-async function mainHeadSha() {
+// HEAD of the release line this tag belongs to: the `release/X.Y.x`
+// maintenance branch when one exists (a backport / hotfix cut off an older
+// minor), else the repo's default branch (a normal tip-of-main release). The
+// gate stays equally strict either way — the tag must be the TIP of whichever
+// line it is cut from. X.Y come from the tag name (GITHUB_REF_NAME), stripping
+// an optional `chart-` prefix and the leading `v`.
+async function expectedHead() {
+  const tag = (process.env.GITHUB_REF_NAME ?? '').replace(/^chart-/, '').replace(/^v/, '');
+  const m = tag.match(/^(\d+)\.(\d+)\./);
+  if (m) {
+    const series = `release/${m[1]}.${m[2]}.x`;
+    const res = await fetch(`${apiBase}/repos/${repo}/branches/${series}`, { headers });
+    if (res.ok) {
+      const b = await res.json();
+      return { sha: b.commit?.sha ?? null, label: series };
+    }
+  }
   const repoInfo = await getJSON(`${apiBase}/repos/${repo}`);
   const branch = repoInfo.default_branch || 'main';
   const b = await getJSON(`${apiBase}/repos/${repo}/branches/${branch}`);
-  return b.commit?.sha ?? null;
+  return { sha: b.commit?.sha ?? null, label: branch };
 }
 
 async function allCheckRuns() {
@@ -232,14 +247,15 @@ async function combinedStatus() {
   return getJSON(`${apiBase}/repos/${repo}/commits/${sha}/status?per_page=100`);
 }
 
-const [mainHead, checkRuns, status] = await Promise.all([
-  mainHeadSha(),
+const [base, checkRuns, status] = await Promise.all([
+  expectedHead(),
   allCheckRuns(),
   combinedStatus(),
 ]);
 
 const { problems, gated } = evaluate({
-  mainHead,
+  mainHead: base.sha,
+  baseLabel: base.label,
   taggedSha: sha,
   checkRuns,
   statuses: status.statuses ?? [],
@@ -248,16 +264,16 @@ const { problems, gated } = evaluate({
 
 if (problems.length > 0) {
   error(
-    `release-preflight: refusing to publish — main is NOT fully complete + green on the ` +
-      `tagged commit ${sha.slice(0, 8)}. Every CI lane on main must be settled green; then re-tag the tip.`,
+    `release-preflight: refusing to publish — ${base.label} is NOT fully complete + green on the ` +
+      `tagged commit ${sha.slice(0, 8)}. Every CI lane must be settled green; then re-tag the tip of ${base.label}.`,
   );
   for (const p of problems.sort()) error(`  - ${p}`);
   process.exit(1);
 }
 
 notice(
-  `release-preflight: tagged commit ${sha.slice(0, 8)} is main HEAD and all ${gated} CI checks ` +
+  `release-preflight: tagged commit ${sha.slice(0, 8)} is ${base.label} HEAD and all ${gated} CI checks ` +
     `are settled green — proceeding with the release.`,
 );
-log(`release-preflight: ${gated} checks verified settled-green on main HEAD ${sha}`);
+log(`release-preflight: ${gated} checks verified settled-green on ${base.label} HEAD ${sha}`);
 process.exit(0);

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,22 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Whether THIS tag is the highest stable release (so it may move the
+      # rolling `:latest` images). A stable BACKPORT (e.g. v1.2.1 cut after
+      # v1.3.0) is NOT the highest -> `:latest` stays on v1.3.0. goreleaser
+      # reads this via `.Env.RELEASE_IS_LATEST` in the `latest-*` skip_push.
+      # Needs fetch-depth: 0 above so all tags are present.
+      - name: Determine if this tag is the latest stable release
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          highest=$(git tag -l 'v*.*.*' | awk '!/-/' | sed 's/^v//' | sort -V | tail -1)
+          if [ "$tag" = "$highest" ]; then
+            echo "RELEASE_IS_LATEST=true" >> "$GITHUB_ENV"
+          else
+            echo "RELEASE_IS_LATEST=false" >> "$GITHUB_ENV"
+          fi
+          echo "tag=$tag highest_stable=$highest RELEASE_IS_LATEST set accordingly"
+
       - id: goreleaser
         uses: goreleaser/goreleaser-action@v7
         with:
@@ -83,6 +99,7 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_IS_LATEST: ${{ env.RELEASE_IS_LATEST }}
 
       # SLSA build provenance for the release binaries. Lets downstream
       # consumers verify each artifact was built from this repo at this

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -87,13 +87,14 @@ dockers:
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.licenses=Apache-2.0"
 
-  # `latest-*` tags published ONLY for stable (non-prerelease) tags.
-  # Otherwise an RC / alpha / beta tag would advance `:latest` and
-  # silently break consumers that pin to the tag.
+  # `latest-*` tags published ONLY for the HIGHEST stable release
+  # (RELEASE_IS_LATEST, computed in release.yml: tag == highest stable
+  # semver). A prerelease never advances `:latest`, AND a stable BACKPORT
+  # (e.g. v1.2.1 cut after v1.3.0) must not drag `:latest` backwards either.
   - id: cerberus-amd64-latest
     image_templates:
       - "ghcr.io/tsouza/cerberus:latest-amd64"
-    skip_push: "{{ if .Prerelease }}true{{ else }}false{{ end }}"
+    skip_push: '{{ if and (not .Prerelease) (eq .Env.RELEASE_IS_LATEST "true") }}false{{ else }}true{{ end }}'
     use: buildx
     goos: linux
     goarch: amd64
@@ -110,7 +111,7 @@ dockers:
   - id: cerberus-arm64-latest
     image_templates:
       - "ghcr.io/tsouza/cerberus:latest-arm64"
-    skip_push: "{{ if .Prerelease }}true{{ else }}false{{ end }}"
+    skip_push: '{{ if and (not .Prerelease) (eq .Env.RELEASE_IS_LATEST "true") }}false{{ else }}true{{ end }}'
     use: buildx
     goos: linux
     goarch: arm64
@@ -134,10 +135,10 @@ docker_manifests:
     image_templates:
       - "ghcr.io/tsouza/cerberus:v{{ .Version }}-amd64"
       - "ghcr.io/tsouza/cerberus:v{{ .Version }}-arm64"
-  # `:latest` manifest — only for stable tags, so RC / alpha / beta
-  # never advance the rolling `:latest`.
+  # `:latest` manifest — only the HIGHEST stable release (RELEASE_IS_LATEST):
+  # neither a prerelease nor a stable backport advances the rolling `:latest`.
   - name_template: "ghcr.io/tsouza/cerberus:latest"
-    skip_push: "{{ if .Prerelease }}true{{ else }}false{{ end }}"
+    skip_push: '{{ if and (not .Prerelease) (eq .Env.RELEASE_IS_LATEST "true") }}false{{ else }}true{{ end }}'
     image_templates:
       - "ghcr.io/tsouza/cerberus:latest-amd64"
       - "ghcr.io/tsouza/cerberus:latest-arm64"


### PR DESCRIPTION
## Why

We need to ship the next feature release (**v1.3.0**, off main) *and* backport the OTLP debug-leak fix (#1018) as a hotfix **v1.2.1** off `v1.2.0`. Two pieces of the release machinery currently make a safe backport impossible. This PR closes both gaps **before** we cut anything. v1.3.0 itself needs none of this (it's tip-of-main); this is purely to unblock the backport lane.

## Gap A — the preflight gate rejects any non-main tag

`release-preflight.mjs` required `taggedSha === <default-branch HEAD>`. A backport tag lives on a `release/1.2.x` maintenance branch, **not** main HEAD, so the gate would abort with *"is NOT main HEAD"* — there was no way to release off an older line at all.

**Fix:** the driver now resolves the head of the release *line* the tag belongs to — a `release/X.Y.x` branch (X.Y parsed from the tag, `chart-`/`v` stripped) when it exists, otherwise the default branch. The gate is **equally strict** either way: the tag must still be the fully-settled-green **tip** of its line. The pure `evaluate()` is untouched (its self-test stays green); only head resolution and the message label generalize from "main" to the resolved line.

## Gap B — a stable backport would corrupt `:latest`

The `latest-*` images / `:latest` manifest were skipped only on **prerelease** (`{{ if .Prerelease }}`). A *stable* backport `v1.2.1` cut **after** `v1.3.0` is not a prerelease, so goreleaser would happily move `:latest` **backwards** to the older 1.2.1 build — silently breaking everyone who pins `:latest`.

**Fix:** `release.yml` computes `RELEASE_IS_LATEST` = (this tag == highest stable semver across all tags) and goreleaser gates the three `latest` push points on it. Now neither a prerelease nor a backport advances `:latest`; only the genuine highest release does. Needs the goreleaser job's existing `fetch-depth: 0` (all tags present) — confirmed.

## Verification

- `release-preflight.mjs --self-test` — green (evaluate logic unchanged).
- `node --check` on the script — parses.
- Highest-stable computation dry-run against real tags: `v1.3.0 -> true`, and `v1.2.1` (with `v1.3.0` present) resolves `-> false` via `sort -V`.
- Both YAML files parse.

## Not changed

`prepare-release.mjs` is already branch-agnostic (no main assumption) — it bumps/changelogs whatever tree it runs in, so it works on a release branch as-is.