### PR TITLE
chore(release): cerberus v1.3.0 / chart 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to cerberus will be documented in this file. The format roug
 
 ## [Unreleased]
 
+## [v1.3.0] — 2026-06-19
+
+### Added
+
+- **config:** accept humanized byte sizes (2Gi) for memory caps, BWC-preserving (#1017)
+
+### Fixed
+
+- **telemetry:** apply CERBERUS_LOG_LEVEL to the OTLP slog bridge (stop debug leaking to otel_logs) (#1018)
+
+### CI
+
+- **release:** make release tooling backport-aware (maintenance lines + :latest guard) (#1019)
+
 ## [v1.2.0] — 2026-06-19
 
 ### Added

--- a/deploy/helm/cerberus/Chart.yaml
+++ b/deploy/helm/cerberus/Chart.yaml
@@ -8,11 +8,11 @@ type: application
 # upgrade?" and is the publish trigger: a chart-only fix bumps this without an
 # app re-tag; an app-only release bumps appVersion + a PATCH here for the new
 # default image. Starts 0.x because the values contract is not yet frozen.
-version: 0.5.0
+version: 0.5.1
 
 # appVersion tracks the GA cerberus binary. Quoted so SemVer-shaped values
 # aren't coerced to floats. image.tag defaults from this when left empty.
-appVersion: "1.2.0"
+appVersion: "1.3.0"
 
 # autoscaling/v2 + policy/v1 (PDB) + networking/v1 (Ingress) are all GA from
 # 1.21+; 1.23 is the conservative floor matching the manifests this chart
@@ -45,13 +45,11 @@ annotations:
       url: https://github.com/tsouza/cerberus/blob/main/docs/operations.md
   artifacthub.io/images: |
     - name: cerberus
-      image: ghcr.io/tsouza/cerberus:v1.2.0
+      image: ghcr.io/tsouza/cerberus:v1.3.0
   # Bump the `1.0.0` floor here when the chart raises its minimum supported
   # cerberus release; informational for Artifact Hub's compatibility hints.
   artifacthub.io/changes: |
     - kind: added
-      description: "chclient: surface ch-go telemetry on cerberus's own telemetry (#1007)"
+      description: "config: accept humanized byte sizes (2Gi) for memory caps, BWC-preserving (#1017)"
     - kind: fixed
-      description: "loki: tail drops overflow rows when a poll window exceeds the limit (#1011)"
-    - kind: fixed
-      description: "release: gate strictly on main HEAD fully settled green (#1008)"
+      description: "telemetry: apply CERBERUS_LOG_LEVEL to the OTLP slog bridge (stop debug leaking to otel_logs) (#1018)"

--- a/deploy/helm/cerberus/README.md
+++ b/deploy/helm/cerberus/README.md
@@ -5,7 +5,7 @@
      pipe-aligned, and the version footer adds a trailing blank — both are
      owned by helm-docs; realigning would fight the chart-ci drift check. -->
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
+![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.0](https://img.shields.io/badge/AppVersion-1.3.0-informational?style=flat-square)
 
 Drop-in Prometheus / Loki / Tempo HTTP gateway for ClickHouse — a single stateless gateway that speaks three upstream query wire formats and lowers each to parameterised ClickHouse SQL.
 


### PR DESCRIPTION
Stages the **v1.3.0** feature release (chart **0.5.1**). The `prepare-release` workflow generated and pushed this branch but couldn't open its own PR (Actions can't create PRs); opening it manually.

## What ships in v1.3.0

- **Added — `config`:** humanized byte sizes (`2Gi`) for memory caps, BWC-preserving (#1017)
- **Fixed — `telemetry`:** apply `CERBERUS_LOG_LEVEL` to the OTLP slog bridge, stopping debug records leaking into `otel_logs`/Loki (#1018)
- **CI — `release`:** backport-aware release tooling (maintenance-line preflight + `:latest` guard) (#1019)

## Versions

- `appVersion` 1.2.0 → **1.3.0** (minor: carries a feature)
- chart `version` 0.5.0 → **0.5.1** (0.5.0 was bumped by #1017 but never published — registry has 0.4.1; 0.5.1 carries the same humanized-values change)

Diff is the generated Chart.yaml + CHANGELOG + helm-docs README only. After merge, `v1.3.0` is tagged on the new main HEAD (once main CI is settled green) to trigger the release build; goreleaser sets `:latest` = 1.3.0.