### PR TITLE
chore(release): cerberus v1.2.1 (backport debug-leak fix) / chart 0.4.2

### DIFF
--- a/.github/scripts/release-preflight.mjs
+++ b/.github/scripts/release-preflight.mjs
@@ -45,16 +45,16 @@ export const GREEN_CONCLUSIONS = new Set(['success', 'skipped', 'neutral']);
 // list of blocking problems (empty == release may proceed) and the count of
 // gated checks. No network, no exclusions beyond self-jobs — exported so the
 // self-test pins the exact pass/fail boundary.
-export function evaluate({ mainHead, taggedSha, checkRuns, statuses, selfJobs }) {
+export function evaluate({ mainHead, taggedSha, checkRuns, statuses, selfJobs, baseLabel = 'main' }) {
   const problems = [];
   if (!mainHead) {
-    problems.push('could not resolve the default-branch (main) HEAD commit');
+    problems.push(`could not resolve the ${baseLabel} HEAD commit`);
     return { problems, gated: 0 };
   }
   if (taggedSha !== mainHead) {
     problems.push(
-      `tagged commit ${taggedSha.slice(0, 8)} is NOT main HEAD ${mainHead.slice(0, 8)} — ` +
-        `a release may only be cut from the tip of main`,
+      `tagged commit ${taggedSha.slice(0, 8)} is NOT ${baseLabel} HEAD ${mainHead.slice(0, 8)} — ` +
+        `a release may only be cut from the tip of its release line (${baseLabel})`,
     );
     return { problems, gated: 0 };
   }
@@ -205,12 +205,27 @@ async function getJSON(url) {
   return res.json();
 }
 
-// HEAD commit of the repo's default branch (main).
-async function mainHeadSha() {
+// HEAD of the release line this tag belongs to: the `release/X.Y.x`
+// maintenance branch when one exists (a backport / hotfix cut off an older
+// minor), else the repo's default branch (a normal tip-of-main release). The
+// gate stays equally strict either way — the tag must be the TIP of whichever
+// line it is cut from. X.Y come from the tag name (GITHUB_REF_NAME), stripping
+// an optional `chart-` prefix and the leading `v`.
+async function expectedHead() {
+  const tag = (process.env.GITHUB_REF_NAME ?? '').replace(/^chart-/, '').replace(/^v/, '');
+  const m = tag.match(/^(\d+)\.(\d+)\./);
+  if (m) {
+    const series = `release/${m[1]}.${m[2]}.x`;
+    const res = await fetch(`${apiBase}/repos/${repo}/branches/${series}`, { headers });
+    if (res.ok) {
+      const b = await res.json();
+      return { sha: b.commit?.sha ?? null, label: series };
+    }
+  }
   const repoInfo = await getJSON(`${apiBase}/repos/${repo}`);
   const branch = repoInfo.default_branch || 'main';
   const b = await getJSON(`${apiBase}/repos/${repo}/branches/${branch}`);
-  return b.commit?.sha ?? null;
+  return { sha: b.commit?.sha ?? null, label: branch };
 }
 
 async function allCheckRuns() {
@@ -232,14 +247,15 @@ async function combinedStatus() {
   return getJSON(`${apiBase}/repos/${repo}/commits/${sha}/status?per_page=100`);
 }
 
-const [mainHead, checkRuns, status] = await Promise.all([
-  mainHeadSha(),
+const [base, checkRuns, status] = await Promise.all([
+  expectedHead(),
   allCheckRuns(),
   combinedStatus(),
 ]);
 
 const { problems, gated } = evaluate({
-  mainHead,
+  mainHead: base.sha,
+  baseLabel: base.label,
   taggedSha: sha,
   checkRuns,
   statuses: status.statuses ?? [],
@@ -248,16 +264,16 @@ const { problems, gated } = evaluate({
 
 if (problems.length > 0) {
   error(
-    `release-preflight: refusing to publish — main is NOT fully complete + green on the ` +
-      `tagged commit ${sha.slice(0, 8)}. Every CI lane on main must be settled green; then re-tag the tip.`,
+    `release-preflight: refusing to publish — ${base.label} is NOT fully complete + green on the ` +
+      `tagged commit ${sha.slice(0, 8)}. Every CI lane must be settled green; then re-tag the tip of ${base.label}.`,
   );
   for (const p of problems.sort()) error(`  - ${p}`);
   process.exit(1);
 }
 
 notice(
-  `release-preflight: tagged commit ${sha.slice(0, 8)} is main HEAD and all ${gated} CI checks ` +
+  `release-preflight: tagged commit ${sha.slice(0, 8)} is ${base.label} HEAD and all ${gated} CI checks ` +
     `are settled green — proceeding with the release.`,
 );
-log(`release-preflight: ${gated} checks verified settled-green on main HEAD ${sha}`);
+log(`release-preflight: ${gated} checks verified settled-green on ${base.label} HEAD ${sha}`);
 process.exit(0);

--- a/.github/workflows/chart-ci.yml
+++ b/.github/workflows/chart-ci.yml
@@ -92,6 +92,11 @@ jobs:
       # Chart.yaml `version:`. (No `ct install` / kind step: cerberus needs a
       # live ClickHouse to pass readiness, which a bare kind cluster lacks —
       # helm template + kubeconform already validate rendering.)
+      # Compare against the PR's BASE branch (github.base_ref), not always the
+      # default branch: a backport PR onto a `release/X.Y.x` line legitimately
+      # carries a LOWER chart version than main (e.g. 0.4.2 < main's 0.5.x), and
+      # ct's bump check would otherwise read that as a downgrade. Falls back to
+      # the default branch for push events (base_ref is empty there).
       - name: ct lint — enforce the version bump on real chart changes
         if: steps.changes.outputs.chart == 'true'
-        run: ct lint --chart-dirs deploy/helm --target-branch "${{ github.event.repository.default_branch }}" --validate-maintainers=false
+        run: ct lint --chart-dirs deploy/helm --target-branch "${{ github.base_ref || github.event.repository.default_branch }}" --validate-maintainers=false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,22 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Whether THIS tag is the highest stable release (so it may move the
+      # rolling `:latest` images). A stable BACKPORT (e.g. v1.2.1 cut after
+      # v1.3.0) is NOT the highest -> `:latest` stays on v1.3.0. goreleaser
+      # reads this via `.Env.RELEASE_IS_LATEST` in the `latest-*` skip_push.
+      # Needs fetch-depth: 0 above so all tags are present.
+      - name: Determine if this tag is the latest stable release
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          highest=$(git tag -l 'v*.*.*' | awk '!/-/' | sed 's/^v//' | sort -V | tail -1)
+          if [ "$tag" = "$highest" ]; then
+            echo "RELEASE_IS_LATEST=true" >> "$GITHUB_ENV"
+          else
+            echo "RELEASE_IS_LATEST=false" >> "$GITHUB_ENV"
+          fi
+          echo "tag=$tag highest_stable=$highest RELEASE_IS_LATEST set accordingly"
+
       - id: goreleaser
         uses: goreleaser/goreleaser-action@v7
         with:
@@ -83,6 +99,7 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_IS_LATEST: ${{ env.RELEASE_IS_LATEST }}
 
       # SLSA build provenance for the release binaries. Lets downstream
       # consumers verify each artifact was built from this repo at this

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -87,13 +87,14 @@ dockers:
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.licenses=Apache-2.0"
 
-  # `latest-*` tags published ONLY for stable (non-prerelease) tags.
-  # Otherwise an RC / alpha / beta tag would advance `:latest` and
-  # silently break consumers that pin to the tag.
+  # `latest-*` tags published ONLY for the HIGHEST stable release
+  # (RELEASE_IS_LATEST, computed in release.yml: tag == highest stable
+  # semver). A prerelease never advances `:latest`, AND a stable BACKPORT
+  # (e.g. v1.2.1 cut after v1.3.0) must not drag `:latest` backwards either.
   - id: cerberus-amd64-latest
     image_templates:
       - "ghcr.io/tsouza/cerberus:latest-amd64"
-    skip_push: "{{ if .Prerelease }}true{{ else }}false{{ end }}"
+    skip_push: '{{ if and (not .Prerelease) (eq .Env.RELEASE_IS_LATEST "true") }}false{{ else }}true{{ end }}'
     use: buildx
     goos: linux
     goarch: amd64
@@ -110,7 +111,7 @@ dockers:
   - id: cerberus-arm64-latest
     image_templates:
       - "ghcr.io/tsouza/cerberus:latest-arm64"
-    skip_push: "{{ if .Prerelease }}true{{ else }}false{{ end }}"
+    skip_push: '{{ if and (not .Prerelease) (eq .Env.RELEASE_IS_LATEST "true") }}false{{ else }}true{{ end }}'
     use: buildx
     goos: linux
     goarch: arm64
@@ -134,10 +135,10 @@ docker_manifests:
     image_templates:
       - "ghcr.io/tsouza/cerberus:v{{ .Version }}-amd64"
       - "ghcr.io/tsouza/cerberus:v{{ .Version }}-arm64"
-  # `:latest` manifest — only for stable tags, so RC / alpha / beta
-  # never advance the rolling `:latest`.
+  # `:latest` manifest — only the HIGHEST stable release (RELEASE_IS_LATEST):
+  # neither a prerelease nor a stable backport advances the rolling `:latest`.
   - name_template: "ghcr.io/tsouza/cerberus:latest"
-    skip_push: "{{ if .Prerelease }}true{{ else }}false{{ end }}"
+    skip_push: '{{ if and (not .Prerelease) (eq .Env.RELEASE_IS_LATEST "true") }}false{{ else }}true{{ end }}'
     image_templates:
       - "ghcr.io/tsouza/cerberus:latest-amd64"
       - "ghcr.io/tsouza/cerberus:latest-arm64"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to cerberus will be documented in this file. The format roug
 
 ## [Unreleased]
 
+## [v1.2.1] — 2026-06-19
+
+### Fixed
+
+- **telemetry:** apply CERBERUS_LOG_LEVEL to the OTLP slog bridge (stop debug leaking to otel_logs) (#1018)
+
+### CI
+
+- **release:** make release tooling backport-aware (maintenance lines + :latest guard) (#1019)
+
 ## [v1.2.0] — 2026-06-19
 
 ### Added

--- a/deploy/helm/cerberus/Chart.yaml
+++ b/deploy/helm/cerberus/Chart.yaml
@@ -8,11 +8,11 @@ type: application
 # upgrade?" and is the publish trigger: a chart-only fix bumps this without an
 # app re-tag; an app-only release bumps appVersion + a PATCH here for the new
 # default image. Starts 0.x because the values contract is not yet frozen.
-version: 0.4.1
+version: 0.4.2
 
 # appVersion tracks the GA cerberus binary. Quoted so SemVer-shaped values
 # aren't coerced to floats. image.tag defaults from this when left empty.
-appVersion: "1.2.0"
+appVersion: "1.2.1"
 
 # autoscaling/v2 + policy/v1 (PDB) + networking/v1 (Ingress) are all GA from
 # 1.21+; 1.23 is the conservative floor matching the manifests this chart
@@ -45,13 +45,9 @@ annotations:
       url: https://github.com/tsouza/cerberus/blob/main/docs/operations.md
   artifacthub.io/images: |
     - name: cerberus
-      image: ghcr.io/tsouza/cerberus:v1.2.0
+      image: ghcr.io/tsouza/cerberus:v1.2.1
   # Bump the `1.0.0` floor here when the chart raises its minimum supported
   # cerberus release; informational for Artifact Hub's compatibility hints.
   artifacthub.io/changes: |
-    - kind: added
-      description: "chclient: surface ch-go telemetry on cerberus's own telemetry (#1007)"
     - kind: fixed
-      description: "loki: tail drops overflow rows when a poll window exceeds the limit (#1011)"
-    - kind: fixed
-      description: "release: gate strictly on main HEAD fully settled green (#1008)"
+      description: "telemetry: apply CERBERUS_LOG_LEVEL to the OTLP slog bridge (stop debug leaking to otel_logs) (#1018)"

--- a/deploy/helm/cerberus/README.md
+++ b/deploy/helm/cerberus/README.md
@@ -5,7 +5,7 @@
      pipe-aligned, and the version footer adds a trailing blank — both are
      owned by helm-docs; realigning would fight the chart-ci drift check. -->
 
-![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
+![Version: 0.4.2](https://img.shields.io/badge/Version-0.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.1](https://img.shields.io/badge/AppVersion-1.2.1-informational?style=flat-square)
 
 Drop-in Prometheus / Loki / Tempo HTTP gateway for ClickHouse — a single stateless gateway that speaks three upstream query wire formats and lowers each to parameterised ClickHouse SQL.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1405,7 +1405,7 @@ func NewTelemetryLogger(w io.Writer, cfg LogConfig, provider any) *slog.Logger {
 		// caller's import wiring is broken; fall back to stderr.
 		return slog.New(local)
 	}
-	return slog.New(telemetry.NewSlogHandler(local, lp))
+	return slog.New(telemetry.NewSlogHandler(local, cfg.Level, lp))
 }
 
 func newLocalHandler(w io.Writer, cfg LogConfig) slog.Handler {

--- a/internal/config/log_test.go
+++ b/internal/config/log_test.go
@@ -6,6 +6,8 @@ import (
 	"log/slog"
 	"strings"
 	"testing"
+
+	"go.opentelemetry.io/otel/log/logtest"
 )
 
 // TestFromEnv_Log_Defaults confirms the slog format/level defaults match
@@ -148,6 +150,53 @@ func TestNewLogger_LevelFilter(t *testing.T) {
 	}
 	if !strings.Contains(out, "kept") {
 		t.Errorf("warn record missing under warn level: %q", out)
+	}
+}
+
+// TestNewTelemetryLogger_LevelGatesBothSinks is the integration guard at
+// the production seam (the same NewTelemetryLogger cmd/cerberus installs):
+// CERBERUS_LOG_LEVEL must filter the OTLP-log bridge symmetrically with
+// stderr, so a sub-level record is exported to NEITHER. Regression for
+// the debug-leak bug, where the level was never threaded into the bridge
+// and Debug records leaked into otel_logs/Loki at info.
+//
+// It drives the real construction path with a logtest.Recorder standing
+// in for the SDK LoggerProvider, so it exercises the actual config ->
+// telemetry wiring (NewTelemetryLogger -> NewSlogHandler -> leveled
+// bridge), not a hand-rolled fanout.
+func TestNewTelemetryLogger_LevelGatesBothSinks(t *testing.T) {
+	cases := []struct {
+		name     string
+		level    slog.Level
+		emit     func(*slog.Logger)
+		wantBoth bool // true: kept by stderr AND OTLP; false: dropped by both
+	}{
+		{name: "info/debug-dropped", level: slog.LevelInfo, emit: func(l *slog.Logger) { l.Debug("ev") }, wantBoth: false},
+		{name: "info/info-kept", level: slog.LevelInfo, emit: func(l *slog.Logger) { l.Info("ev") }, wantBoth: true},
+		{name: "debug/debug-kept", level: slog.LevelDebug, emit: func(l *slog.Logger) { l.Debug("ev") }, wantBoth: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			recorder := logtest.NewRecorder()
+			logger := NewTelemetryLogger(&buf, LogConfig{Format: "text", Level: tc.level}, recorder)
+
+			tc.emit(logger)
+
+			gotLocal := strings.Contains(buf.String(), "ev")
+			var otlpCount int
+			for _, scoped := range recorder.Result() {
+				otlpCount += len(scoped)
+			}
+			gotOTLP := otlpCount > 0
+
+			if gotLocal != tc.wantBoth {
+				t.Errorf("stderr sink kept=%v, want %v (buf=%q)", gotLocal, tc.wantBoth, buf.String())
+			}
+			if gotOTLP != tc.wantBoth {
+				t.Errorf("OTLP sink kept=%v (count=%d), want %v", gotOTLP, otlpCount, tc.wantBoth)
+			}
+		})
 	}
 }
 

--- a/internal/telemetry/slog_handler.go
+++ b/internal/telemetry/slog_handler.go
@@ -9,7 +9,10 @@
 //  2. An OTel slog bridge backed by the provided LoggerProvider —
 //     ships the same record via OTLP gRPC to the collector, which
 //     writes it to ClickHouse `otel_logs` alongside the metrics and
-//     traces this binary emits.
+//     traces this binary emits. The bridge is gated on the SAME
+//     `LogConfig.Level` as the local sink (via leveledHandler), so the
+//     level filter is symmetric: a record dropped at stderr is never
+//     exported to `otel_logs`/Loki either.
 //
 // Without (2), cerberus would rely on the k8s container-log path
 // (stderr → kubelet → filelog receiver → OTLP → CH) which requires a
@@ -38,17 +41,26 @@ const slogScope = "github.com/tsouza/cerberus/internal/telemetry"
 
 // NewSlogHandler returns the slog.Handler cerberus installs as the
 // process default. `local` is the handler that writes to stderr (text
-// or JSON, level-filtered per LogConfig). `provider` is the OTel
-// LoggerProvider built by telemetry.New — pass the no-op provider if
-// you only want the local handler.
+// or JSON, level-filtered per LogConfig). `level` is the minimum level
+// (`LogConfig.Level`) the OTLP bridge is gated on, applied symmetrically
+// with the local sink. `provider` is the OTel LoggerProvider built by
+// telemetry.New — pass the no-op provider if you only want the local
+// handler.
 //
-// The returned handler runs both sinks unconditionally; level filter
-// happens inside each sink, so a record that the local handler drops
-// (e.g. below `info`) still reaches the OTLP bridge if it accepts the
-// level. Callers who want symmetric filtering should set the same
-// level on both sinks — config.NewLogger already does this via
-// `LogConfig.Level`.
-func NewSlogHandler(local slog.Handler, provider otellog.LoggerProvider) slog.Handler {
+// The level filter is applied to BOTH sinks: the local handler enforces
+// it via slog.HandlerOptions.Level, and the OTLP bridge is wrapped in a
+// leveledHandler that gates on the same `level`. Without this wrapper the
+// raw otelslog bridge delegates Enabled to the SDK LoggerProvider, which
+// accepts EVERY severity — so a record the local handler drops (e.g.
+// Debug below `info`) would still be exported to `otel_logs`/Loki. With
+// it, at `info` both sinks reject Debug (the fanout never even creates
+// the record); at `debug` both accept and the record reaches stderr AND
+// the bridge.
+//
+// `level` is a slog.Leveler (LogConfig.Level is a slog.Level, which
+// satisfies it). A nil level defaults to slog.LevelInfo so the bridge is
+// never accidentally left ungated.
+func NewSlogHandler(local slog.Handler, level slog.Leveler, provider otellog.LoggerProvider) slog.Handler {
 	if local == nil {
 		// Defensive: a nil local handler would crash slog.New; install
 		// a discard fallback so callers can pass `nil` to mean
@@ -58,8 +70,39 @@ func NewSlogHandler(local slog.Handler, provider otellog.LoggerProvider) slog.Ha
 	if provider == nil {
 		return local
 	}
+	if level == nil {
+		level = slog.LevelInfo
+	}
 	bridge := otelslog.NewHandler(slogScope, otelslog.WithLoggerProvider(provider))
-	return fanoutHandler{handlers: []slog.Handler{local, bridge}}
+	return fanoutHandler{handlers: []slog.Handler{local, leveledHandler{Handler: bridge, level: level}}}
+}
+
+// leveledHandler gates an inner slog.Handler on a minimum level. The
+// otelslog bridge has no built-in min-severity option (otelslog v0.19.0)
+// — its Enabled delegates to the SDK LoggerProvider, which accepts every
+// severity. Wrapping it here threads `LogConfig.Level` into the OTLP path
+// so the bridge filters symmetrically with the stderr sink.
+//
+// The embedded slog.Handler forwards Handle and (via the explicit
+// WithAttrs/WithGroup below) keeps the leveled gate across slog's
+// handler-chain rebuilds: a bare embed would have those methods return
+// the UNWRAPPED inner handler, silently losing the level gate after the
+// first `logger.With(...)`.
+type leveledHandler struct {
+	slog.Handler
+	level slog.Leveler
+}
+
+func (h leveledHandler) Enabled(ctx context.Context, l slog.Level) bool {
+	return l >= h.level.Level() && h.Handler.Enabled(ctx, l)
+}
+
+func (h leveledHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return leveledHandler{Handler: h.Handler.WithAttrs(attrs), level: h.level}
+}
+
+func (h leveledHandler) WithGroup(name string) slog.Handler {
+	return leveledHandler{Handler: h.Handler.WithGroup(name), level: h.level}
 }
 
 // fanoutHandler dispatches every record to each wrapped handler in

--- a/internal/telemetry/slog_handler_test.go
+++ b/internal/telemetry/slog_handler_test.go
@@ -22,7 +22,7 @@ func TestNewSlogHandler_NilProvider(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer
 	local := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})
-	h := NewSlogHandler(local, nil)
+	h := NewSlogHandler(local, slog.LevelInfo, nil)
 	if h != local {
 		t.Errorf("nil provider should return local handler unchanged; got %T", h)
 	}
@@ -39,7 +39,7 @@ func TestNewSlogHandler_FansOutToBoth(t *testing.T) {
 	localHandler := slog.NewTextHandler(&localBuf, &slog.HandlerOptions{Level: slog.LevelInfo})
 
 	recorder := logtest.NewRecorder()
-	handler := NewSlogHandler(localHandler, recorder)
+	handler := NewSlogHandler(localHandler, slog.LevelInfo, recorder)
 	logger := slog.New(handler)
 	logger.Info(
 		"test event",
@@ -83,7 +83,7 @@ func TestNewSlogHandler_NoopProviderIsStderrOnly(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer
 	local := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})
-	h := NewSlogHandler(local, lognoop.NewLoggerProvider())
+	h := NewSlogHandler(local, slog.LevelInfo, lognoop.NewLoggerProvider())
 	slog.New(h).Info("hello noop")
 	if !strings.Contains(buf.String(), "hello noop") {
 		t.Errorf("noop provider should still write stderr; got %q", buf.String())
@@ -99,7 +99,7 @@ func TestNewSlogHandler_PreservesAttrs(t *testing.T) {
 	local := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})
 	recorder := logtest.NewRecorder()
 
-	handler := NewSlogHandler(local, recorder)
+	handler := NewSlogHandler(local, slog.LevelInfo, recorder)
 	logger := slog.New(handler).With("api", "loki")
 	logger.Info("dispatched", "sql", "SELECT 1")
 
@@ -117,6 +117,90 @@ func TestNewSlogHandler_PreservesAttrs(t *testing.T) {
 	}
 	if got["sql"] != "SELECT 1" {
 		t.Errorf("bridge: sql attr lost; got %+v", got)
+	}
+}
+
+// TestNewSlogHandler_LevelGatesOTLPBridge is the regression for the
+// debug-leak bug: at level=info a Debug record must reach NEITHER the
+// local sink NOR the OTLP bridge, and at level=debug it must reach BOTH.
+// Before the fix the bridge delegated Enabled to the SDK provider, which
+// accepts every severity, so Debug leaked into otel_logs/Loki at info.
+//
+// The test drives the real public construction path (NewSlogHandler, the
+// same seam config.NewTelemetryLogger uses) with a logtest.Recorder as
+// the OTLP sink, so it exercises the actual wiring, not a hand-rolled
+// fanout.
+func TestNewSlogHandler_LevelGatesOTLPBridge(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		level     slog.Level
+		logDebug  bool
+		wantLocal bool
+		wantOTLP  bool
+	}{
+		{name: "info/debug-dropped-both", level: slog.LevelInfo, logDebug: true, wantLocal: false, wantOTLP: false},
+		{name: "info/info-kept-both", level: slog.LevelInfo, logDebug: false, wantLocal: true, wantOTLP: true},
+		{name: "debug/debug-kept-both", level: slog.LevelDebug, logDebug: true, wantLocal: true, wantOTLP: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var localBuf bytes.Buffer
+			local := slog.NewTextHandler(&localBuf, &slog.HandlerOptions{Level: tc.level})
+			recorder := logtest.NewRecorder()
+
+			logger := slog.New(NewSlogHandler(local, tc.level, recorder))
+			if tc.logDebug {
+				logger.Debug("debug event")
+			} else {
+				logger.Info("info event")
+			}
+
+			localCount := strings.Count(localBuf.String(), "event")
+			otlpCount := len(flattenRecorder(recorder))
+
+			wantLocalCount := 0
+			if tc.wantLocal {
+				wantLocalCount = 1
+			}
+			wantOTLPCount := 0
+			if tc.wantOTLP {
+				wantOTLPCount = 1
+			}
+			if localCount != wantLocalCount {
+				t.Errorf("local sink: got %d records, want %d (buf=%q)", localCount, wantLocalCount, localBuf.String())
+			}
+			if otlpCount != wantOTLPCount {
+				t.Errorf("OTLP sink: got %d records, want %d", otlpCount, wantOTLPCount)
+			}
+		})
+	}
+}
+
+// TestNewSlogHandler_LevelGateSurvivesWithAttrs confirms the leveled
+// gate on the OTLP bridge is NOT lost after slog rebuilds the handler
+// chain via With(...). A bare embed of slog.Handler would have WithAttrs
+// return the unwrapped bridge, re-opening the debug leak after the first
+// structured-logger derivation.
+func TestNewSlogHandler_LevelGateSurvivesWithAttrs(t *testing.T) {
+	t.Parallel()
+
+	var localBuf bytes.Buffer
+	local := slog.NewTextHandler(&localBuf, &slog.HandlerOptions{Level: slog.LevelInfo})
+	recorder := logtest.NewRecorder()
+
+	logger := slog.New(NewSlogHandler(local, slog.LevelInfo, recorder)).With("api", "loki")
+	logger.Debug("debug after with")
+
+	if got := len(flattenRecorder(recorder)); got != 0 {
+		t.Errorf("OTLP sink: debug leaked through WithAttrs; got %d records, want 0", got)
+	}
+	if strings.Contains(localBuf.String(), "debug after with") {
+		t.Errorf("local sink: debug leaked through WithAttrs; got %q", localBuf.String())
 	}
 }
 


### PR DESCRIPTION
**Hotfix backport off `v1.2.0`** onto the new `release/1.2.x` maintenance line. Ships the OTLP debug-leak fix to v1.2.0 consumers without waiting for the v1.3.0 feature release.

## What's backported

- **fix(telemetry) (#1018):** apply `CERBERUS_LOG_LEVEL` to the OTLP slog bridge. At `info` level, debug records were still exported to `otel_logs`/Loki (the level filter only reached the stderr sink), flooding production o11y storage. Cherry-picked clean.
- **ci(release) (#1019):** the backport-aware release tooling (maintenance-line preflight + `:latest` guard). Required on this branch so the `v1.2.1` tag can actually release: preflight now matches `release/1.2.x` HEAD instead of main, and goreleaser leaves `:latest` on the higher v1.3.0 (`RELEASE_IS_LATEST=false`) rather than dragging it back to 1.2.1.

## Versions

- `appVersion` 1.2.0 → **1.2.1**; chart `version` 0.4.1 → **0.4.2** (new default image).

## Release mechanics

Merged by **fast-forwarding** `release/1.2.x` to this PR's validated head SHA (not a squash/merge-commit), so the tagged commit keeps its green CI — then `v1.2.1` is tagged on `release/1.2.x` HEAD **after** `v1.3.0` is tagged (so `:latest` stays on 1.3.0). `1.2.1` deliberately excludes the v1.3.0 feature (#1017) — patch = fix only.