### PR TITLE
ci(chart): lint version bump against PR base branch, not always main

### DIFF
--- a/.github/workflows/chart-ci.yml
+++ b/.github/workflows/chart-ci.yml
@@ -92,6 +92,11 @@ jobs:
       # Chart.yaml `version:`. (No `ct install` / kind step: cerberus needs a
       # live ClickHouse to pass readiness, which a bare kind cluster lacks —
       # helm template + kubeconform already validate rendering.)
+      # Compare against the PR's BASE branch (github.base_ref), not always the
+      # default branch: a backport PR onto a `release/X.Y.x` line legitimately
+      # carries a LOWER chart version than main (e.g. 0.4.2 < main's 0.5.x), and
+      # ct's bump check would otherwise read that as a downgrade. Falls back to
+      # the default branch for push events (base_ref is empty there).
       - name: ct lint — enforce the version bump on real chart changes
         if: steps.changes.outputs.chart == 'true'
-        run: ct lint --chart-dirs deploy/helm --target-branch "${{ github.event.repository.default_branch }}" --validate-maintainers=false
+        run: ct lint --chart-dirs deploy/helm --target-branch "${{ github.base_ref || github.event.repository.default_branch }}" --validate-maintainers=false


### PR DESCRIPTION
Completes the backport-ready release tooling on `main`.

During the v1.2.1 backport, `chart-validate` rejected the maintenance-line chart (`0.4.2`) because `ct lint --target-branch` was hardcoded to the default branch (`main`, at `0.5.x`) and read the lower version as a downgrade. The fix shipped on `release/1.2.x` to unblock that release; this lands the identical one-liner on `main` so the **next** backport doesn't re-hit it.

`--target-branch "${{ github.base_ref || github.event.repository.default_branch }}"` — compares against the PR's actual base (the maintenance line for a backport, `main` for normal PRs), falling back to the default branch for push events. No behavior change for PRs targeting `main`.