### PR TITLE
ci(release): mirror release images to Docker Hub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,15 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Docker Hub mirror — goreleaser pushes the same per-arch images and
+      # manifests to docker.io/tsouza/cerberus in the same build. A login
+      # failure here aborts the whole release (atomic dual-registry push).
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: tsouza
+          password: ${{ secrets.DOCKER_HUB_PAT }}
+
       # Whether THIS tag is the highest stable release (so it may move the
       # rolling `:latest` images). A stable BACKPORT (e.g. v1.2.1 cut after
       # v1.3.0) is NOT the highest -> `:latest` stays on v1.3.0. goreleaser
@@ -122,6 +131,17 @@ jobs:
         run: gh release edit "${{ github.ref_name }}" --draft=false
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Mirror README.md to the Docker Hub repo overview. Non-fatal: a stale
+      # overview page must never turn an otherwise-published release red.
+      - name: Sync Docker Hub overview
+        uses: peter-evans/dockerhub-description@v4
+        continue-on-error: true
+        with:
+          username: tsouza
+          password: ${{ secrets.DOCKER_HUB_PAT }}
+          repository: tsouza/cerberus
+          readme-filepath: ./README.md
 
   # Publish the Helm chart to GHCR as an OCI artifact, cosign-sign it keyless,
   # attest provenance, and (idempotently) push the Artifact Hub metadata. Gated

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -55,6 +55,8 @@ dockers:
     image_templates:
       - "ghcr.io/tsouza/cerberus:{{ .Version }}-amd64"
       - "ghcr.io/tsouza/cerberus:v{{ .Version }}-amd64"
+      - "docker.io/tsouza/cerberus:{{ .Version }}-amd64"
+      - "docker.io/tsouza/cerberus:v{{ .Version }}-amd64"
     use: buildx
     goos: linux
     goarch: amd64
@@ -73,6 +75,8 @@ dockers:
     image_templates:
       - "ghcr.io/tsouza/cerberus:{{ .Version }}-arm64"
       - "ghcr.io/tsouza/cerberus:v{{ .Version }}-arm64"
+      - "docker.io/tsouza/cerberus:{{ .Version }}-arm64"
+      - "docker.io/tsouza/cerberus:v{{ .Version }}-arm64"
     use: buildx
     goos: linux
     goarch: arm64
@@ -94,6 +98,7 @@ dockers:
   - id: cerberus-amd64-latest
     image_templates:
       - "ghcr.io/tsouza/cerberus:latest-amd64"
+      - "docker.io/tsouza/cerberus:latest-amd64"
     skip_push: '{{ if and (not .Prerelease) (eq .Env.RELEASE_IS_LATEST "true") }}false{{ else }}true{{ end }}'
     use: buildx
     goos: linux
@@ -111,6 +116,7 @@ dockers:
   - id: cerberus-arm64-latest
     image_templates:
       - "ghcr.io/tsouza/cerberus:latest-arm64"
+      - "docker.io/tsouza/cerberus:latest-arm64"
     skip_push: '{{ if and (not .Prerelease) (eq .Env.RELEASE_IS_LATEST "true") }}false{{ else }}true{{ end }}'
     use: buildx
     goos: linux
@@ -142,6 +148,21 @@ docker_manifests:
     image_templates:
       - "ghcr.io/tsouza/cerberus:latest-amd64"
       - "ghcr.io/tsouza/cerberus:latest-arm64"
+  # Docker Hub mirrors of the same manifests (same per-arch images, pushed to
+  # both registries in one build) — identical tag set and `:latest` gating.
+  - name_template: "docker.io/tsouza/cerberus:{{ .Version }}"
+    image_templates:
+      - "docker.io/tsouza/cerberus:{{ .Version }}-amd64"
+      - "docker.io/tsouza/cerberus:{{ .Version }}-arm64"
+  - name_template: "docker.io/tsouza/cerberus:v{{ .Version }}"
+    image_templates:
+      - "docker.io/tsouza/cerberus:v{{ .Version }}-amd64"
+      - "docker.io/tsouza/cerberus:v{{ .Version }}-arm64"
+  - name_template: "docker.io/tsouza/cerberus:latest"
+    skip_push: '{{ if and (not .Prerelease) (eq .Env.RELEASE_IS_LATEST "true") }}false{{ else }}true{{ end }}'
+    image_templates:
+      - "docker.io/tsouza/cerberus:latest-amd64"
+      - "docker.io/tsouza/cerberus:latest-arm64"
 
 release:
   # draft:true so goreleaser creates the GitHub release as a DRAFT (mutable)


### PR DESCRIPTION
## What

Publishes cerberus container images to **Docker Hub** (`docker.io/tsouza/cerberus`) on every release tag, alongside the existing GHCR publish.

## How

- **goreleaser-native dual-registry.** Each per-arch image `dockers` build and each `docker_manifests` entry now carries `docker.io/tsouza/cerberus:…` templates beside the `ghcr.io` ones. goreleaser builds each arch **once** and pushes to both registries → identical digests, full tag parity (`{{.Version}}`, `v{{.Version}}`, per-arch, and prerelease-/RELEASE_IS_LATEST-gated `:latest`).
- **Docker Hub login** added before the goreleaser step (`tsouza` / `secrets.DOCKER_HUB_PAT`). A login/push failure aborts the whole release — the dual-registry push is atomic.
- **Overview sync** via `peter-evans/dockerhub-description` after the publish flip: pushes `README.md` to the Docker Hub repo overview. `continue-on-error: true` — a stale overview never reds an otherwise-good release. No short-description management.

## Activation / prereqs

- Dormant until the next `v*.*.*` tag.
- `DOCKER_HUB_PAT` repo secret — **already added.**
- Docker Hub auto-creates the public `tsouza/cerberus` repo on first push.

## Notes

- The overview-sync step authenticates with the PAT; if the PAT lacks description-write scope that step will fail softly (non-fatal) — images still publish fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)