### PR TITLE
fix(tempo): bound /api/search drain with SQL trace-limit + window pushdown

### DIFF
--- a/internal/api/tempo/grpc/search.go
+++ b/internal/api/tempo/grpc/search.go
@@ -3,6 +3,7 @@ package grpc
 import (
 	"errors"
 	"strconv"
+	"time"
 
 	"github.com/grafana/tempo/pkg/tempopb"
 	"google.golang.org/grpc/codes"
@@ -81,6 +82,21 @@ func (s *Service) Search(req *tempopb.SearchRequest, stream tempopb.StreamingQue
 		limit = tempo.DefaultSearchLimit
 	}
 	ctx = traceql.WithSearchTraceLimit(ctx, limit)
+
+	// Thread the request time window so stampSearchTraceLimit folds it
+	// into the bounded plain-search scan — the gRPC mirror of HTTP
+	// /api/search's WithSearchWindow. SearchRequest.Start / End arrive as
+	// uint32 Unix seconds (proto fields 5/6); a windowless request (both
+	// zero — e.g. a hand-rolled `q={}`) is clamped to the same recent
+	// lookback the HTTP handler applies, so the trace-limit pushdown's
+	// inner GROUP BY TraceId scans a window instead of the whole table.
+	// A one-sided window is a deliberate open-ended bound, left as-is.
+	start, end := secondsToTime(req.Start), secondsToTime(req.End)
+	if start.IsZero() && end.IsZero() {
+		end = time.Now().UTC()
+		start = end.Add(-tempo.DefaultSearchLookback)
+	}
+	ctx = traceql.WithSearchWindow(ctx, start, end)
 
 	// Open the streaming cursor against the lowered TraceQL plan.
 	// cursor.Close is deferred so a client cancellation (ctx.Done()
@@ -193,6 +209,20 @@ func mapStreamError(err error) error {
 		return err
 	}
 	return status.Errorf(codes.Internal, "stream send: %v", err)
+}
+
+// secondsToTime converts a SearchRequest Start / End bound into a
+// time.Time. The streaming /search proto carries the window as uint32
+// Unix seconds (tempopb.SearchRequest fields 5/6 are named start/end,
+// distinct from MetricsQueryRange's nanosecond Start/End — hence a
+// dedicated helper rather than reusing nanosToTime). A zero value means
+// "bound omitted" and round-trips to the zero time.Time, which
+// WithSearchWindow treats as no predicate.
+func secondsToTime(sec uint32) time.Time {
+	if sec == 0 {
+		return time.Time{}
+	}
+	return time.Unix(int64(sec), 0).UTC()
 }
 
 // toTempopbTraceMetadata pivots cerberus's local tempo.TraceSummary

--- a/internal/api/tempo/grpc/search_test.go
+++ b/internal/api/tempo/grpc/search_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -44,6 +45,15 @@ type stubCursorQuerier struct {
 	// Tests assert against it to prove that cancellation reached the
 	// streaming cursor.
 	closed atomic.Int32
+	// lastSQL captures the SQL the engine handed the cursor open call,
+	// so window-threading tests can assert the emitted scan is windowed
+	// (the gRPC mirror of the HTTP stubQuerier.lastSQL convention).
+	lastSQL string
+	// lastArgs captures the bound parameters alongside lastSQL — the
+	// windowed Timestamp bounds ride here as int64 nanos (the SQL
+	// carries `fromUnixTimestamp64Nano(?)` placeholders), so explicit-
+	// window tests assert the supplied bounds reached the query verbatim.
+	lastArgs []any
 }
 
 func (s *stubCursorQuerier) Query(_ context.Context, _ string, _ ...any) ([]chclient.Sample, error) {
@@ -54,7 +64,9 @@ func (s *stubCursorQuerier) QueryStrings(_ context.Context, _ string, _ ...any) 
 	return nil, nil
 }
 
-func (s *stubCursorQuerier) QueryCursor(ctx context.Context, _ string, _ ...any) (chclient.Cursor, error) {
+func (s *stubCursorQuerier) QueryCursor(ctx context.Context, sql string, args ...any) (chclient.Cursor, error) {
+	s.lastSQL = sql
+	s.lastArgs = args
 	return &stubCursor{rows: s.rows, ctx: ctx, closed: &s.closed}, nil
 }
 
@@ -424,6 +436,116 @@ func TestSearch_CancellationPropagatesToCursor(t *testing.T) {
 
 	if !waitForClose(&q.closed, time.Second) {
 		t.Errorf("cursor.Close was not invoked after cancellation")
+	}
+}
+
+// TestSearch_WindowlessDefaultsLookback_SQLShape proves the gRPC
+// streaming /search RPC closes the L2 whole-table hazard the HTTP
+// /api/search handler closes: a windowless request (Start==End==0) is
+// clamped to a recent lookback before lowering, so the trace-limit
+// pushdown's inner GROUP BY TraceId scans a window instead of the whole
+// table. Without the WithSearchWindow threading + clamp in Search, the
+// emitted SQL carries no `Timestamp` bound and the inner aggregation
+// runs over every row server-side — the same defect the HTTP path had.
+//
+// The stub captures the SQL the engine handed the cursor; we assert the
+// windowed bound appears on BOTH scans (the inner ranking subquery and
+// the outer drain) — count==2 each, the same shape the HTTP SQL test
+// pins.
+func TestSearch_WindowlessDefaultsLookback_SQLShape(t *testing.T) {
+	t.Parallel()
+	q := &stubCursorQuerier{rows: nil}
+	client, cleanup := dialServer(t, q)
+	t.Cleanup(cleanup)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	// No Start / End on the request — the windowless degenerate path.
+	stream, err := client.Search(ctx, &tempopb.SearchRequest{Query: "{}"})
+	if err != nil {
+		t.Fatalf("open stream: %v", err)
+	}
+	if _, err := drainSearch(t, stream); err != nil {
+		t.Fatalf("drain: %v", err)
+	}
+	if q.lastSQL == "" {
+		t.Fatalf("no SQL captured")
+	}
+	// The default lookback folds a lower Timestamp bound into BOTH the
+	// inner ranking subquery and the outer drain — proving the inner
+	// GROUP BY TraceId is windowed, not whole-table. The bound rides as a
+	// `fromUnixTimestamp64Nano(?)` placeholder (the value is in lastArgs).
+	const wantBound = "`Timestamp` >= fromUnixTimestamp64Nano(?)"
+	if got := strings.Count(q.lastSQL, wantBound); got != 2 {
+		t.Errorf("windowless gRPC search: want %q on both scans (count 2), got %d:\n%s",
+			wantBound, got, q.lastSQL)
+	}
+	// And the GROUP BY TraceId aggregation must still be present (the
+	// trace-limit pushdown), now over the windowed input.
+	if !strings.Contains(q.lastSQL, "GROUP BY `TraceId`") {
+		t.Errorf("windowless gRPC search SQL missing GROUP BY TraceId:\n%s", q.lastSQL)
+	}
+}
+
+// TestSearch_ExplicitWindow_Honored proves the clamp fires ONLY on the
+// both-absent path: an explicit Start / End on the SearchRequest reaches
+// the emitted SQL verbatim (the default does not override a supplied
+// window). SearchRequest.Start / End are uint32 Unix seconds; we send
+// 1_700_000_000s / 1_700_003_600s and assert the exact nanosecond bounds
+// (seconds * 1e9) appear in the SQL.
+func TestSearch_ExplicitWindow_Honored(t *testing.T) {
+	t.Parallel()
+	q := &stubCursorQuerier{rows: nil}
+	client, cleanup := dialServer(t, q)
+	t.Cleanup(cleanup)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	const (
+		startSec = uint32(1_700_000_000)
+		endSec   = uint32(1_700_003_600)
+	)
+	stream, err := client.Search(ctx, &tempopb.SearchRequest{
+		Query: "{}",
+		Start: startSec,
+		End:   endSec,
+	})
+	if err != nil {
+		t.Fatalf("open stream: %v", err)
+	}
+	if _, err := drainSearch(t, stream); err != nil {
+		t.Fatalf("drain: %v", err)
+	}
+	if q.lastSQL == "" {
+		t.Fatalf("no SQL captured")
+	}
+	// The bound folds on both scans as a placeholder; the explicit nanos
+	// (seconds * 1e9) must be the bound args, proving the supplied window
+	// — not a now()-relative lookback — reached the query.
+	const ge = "`Timestamp` >= fromUnixTimestamp64Nano(?)"
+	const le = "`Timestamp` <= fromUnixTimestamp64Nano(?)"
+	if got := strings.Count(q.lastSQL, ge); got != 2 {
+		t.Errorf("explicit window must fold on both scans (2x %q), got %d:\n%s", ge, got, q.lastSQL)
+	}
+	if got := strings.Count(q.lastSQL, le); got != 2 {
+		t.Errorf("explicit window must fold on both scans (2x %q), got %d:\n%s", le, got, q.lastSQL)
+	}
+	startNanos := int64(startSec) * 1_000_000_000
+	endNanos := int64(endSec) * 1_000_000_000
+	var sawStart, sawEnd bool
+	for _, a := range q.lastArgs {
+		if v, ok := a.(int64); ok {
+			if v == startNanos {
+				sawStart = true
+			}
+			if v == endNanos {
+				sawEnd = true
+			}
+		}
+	}
+	if !sawStart || !sawEnd {
+		t.Errorf("explicit window args not honored verbatim: sawStart=%v sawEnd=%v args=%v",
+			sawStart, sawEnd, q.lastArgs)
 	}
 }
 

--- a/internal/api/tempo/handler.go
+++ b/internal/api/tempo/handler.go
@@ -296,6 +296,15 @@ func (h *Handler) handleSearch(w http.ResponseWriter, r *http.Request) {
 	// (observed live: 4937 summaries / ~755KB body for limit=200).
 	limit := positiveIntParam(r, "limit", DefaultSearchLimit)
 	spss := positiveIntParam(r, "spss", DefaultSpansPerSpanSet)
+	// The request time window bounds the plain-search scan so /api/search
+	// drains only the matching traces in [start, end] rather than the whole
+	// table (the summaries-drain OOM). An invalid bound is a 400, matching
+	// Tempo's own rejection of malformed start/end.
+	start, end, err := parseTempoStartEnd(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "", "", err)
+		return
+	}
 
 	ctx := r.Context()
 	// Thread the response trace limit into lowering so the nested-set
@@ -304,6 +313,9 @@ func (h *Handler) handleSearch(w http.ResponseWriter, r *http.Request) {
 	// every matched trace and peaks past the per-query memory cap (#103).
 	// No-op for queries that don't carry a nested-set select.
 	ctx = traceql_lower.WithSearchTraceLimit(ctx, limit)
+	// Thread the request window so stampSearchTraceLimit folds it into the
+	// bounded plain-search scan. No-op when both bounds are absent.
+	ctx = traceql_lower.WithSearchWindow(ctx, start, end)
 	// Engine.Query runs parse → lower → wrap-projection → optimize →
 	// emit → execute. The TraceQL adapter (h.lang) owns the parser
 	// dispatch + wrap-projection so the post-engine response pivot

--- a/internal/api/tempo/handler.go
+++ b/internal/api/tempo/handler.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"
@@ -233,6 +234,12 @@ const (
 	DefaultSpansPerSpanSet = 3
 )
 
+// DefaultSearchLookback bounds a windowless /api/search (no start/end
+// params) to the most recent hour, so the trace-limit pushdown's inner
+// GROUP BY TraceId scans a window instead of the whole table. Matches
+// reference Tempo's "recent data" default for a search with no range.
+const DefaultSearchLookback = time.Hour
+
 // positiveIntParam parses an integer query param, returning def when the
 // param is absent, malformed, or non-positive — mirroring reference
 // Tempo's lenient ParseSearchRequest handling (a bad `limit` falls back
@@ -304,6 +311,16 @@ func (h *Handler) handleSearch(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		writeError(w, http.StatusBadRequest, "", "", err)
 		return
+	}
+	// Bound a windowless search (hand-rolled q={} with no time range) so the
+	// trace-limit pushdown's inner GROUP BY TraceId never aggregates over the
+	// whole table server-side. Grafana's Traces Drilldown always sends both
+	// bounds, so this only tightens the degenerate path. Mirrors reference
+	// Tempo, which restricts a windowless search to recent data. A one-sided
+	// window is a deliberate open-ended bound and is left as-is.
+	if start.IsZero() && end.IsZero() {
+		end = time.Now().UTC()
+		start = end.Add(-DefaultSearchLookback)
 	}
 
 	ctx := r.Context()

--- a/internal/api/tempo/search_trace_limit_chdb_test.go
+++ b/internal/api/tempo/search_trace_limit_chdb_test.go
@@ -1,0 +1,231 @@
+//go:build chdb
+
+// chDB-backed repro for the Tempo /api/search summaries-drain OOM
+// (sparkling-brewing-conway.md). Before the SearchTraceLimit pushdown,
+// `GET /api/search?q={}&limit=N` emitted `SELECT … FROM otel_traces`
+// with no window and no LIMIT: the handler drained EVERY matching span
+// into a []Sample slice + per-trace map and only then truncated to N in
+// Go. For a wide window the full match set is buffered first, OOMing the
+// process before the limit ever bites.
+//
+// The fix wraps the plain-search row source in chplan.SearchTraceLimit,
+// which the emitter renders as a `TraceId IN (SELECT … GROUP BY TraceId
+// ORDER BY min(Timestamp) DESC, TraceId LIMIT N)` restriction. The SQL
+// then returns only the kept traces' spans, so the drain — and the
+// InspectedTraces count the response reports (len(res.Samples)) — is
+// bounded to N traces, not the whole table.
+//
+// The load-bearing assertion is InspectedTraces: it equals the kept
+// traces' span count, NOT the full seed. Temporarily reverting
+// stampSearchTraceLimit's wrap (so the plan stays a bare Scan / Filter)
+// makes the count jump to the full seed — that before/after is reported
+// in the PR description; this test pins the fixed behaviour.
+package tempo_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/api/tempo"
+	"github.com/tsouza/cerberus/internal/chclienttest"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// Each of these seeded traces carries spansPerTrace spans (one root +
+// two children), so the full table holds seedTraceCount*spansPerTrace
+// rows. With searchLimit < seedTraceCount the pushdown must bound the
+// drain to searchLimit*spansPerTrace rows.
+const (
+	seedTraceCount = 8
+	spansPerTrace  = 3
+	searchLimit    = 3
+)
+
+// manyTracesSeed builds seedTraceCount traces, each with a root span and
+// two children. Trace i's root starts at 10:0i:00; the children follow a
+// few nanoseconds later (so the trace's min(Timestamp) is the root's
+// start). Trace start times strictly increase with i, so the newest
+// searchLimit traces by min(start) are the highest-i traces, and the
+// TraceId tie-break never has to fire (all min-starts are distinct) — the
+// dedicated ranking-parity test below exercises ties + out-of-order
+// children.
+func manyTracesSeed() string {
+	rows := make([]string, 0, seedTraceCount*spansPerTrace)
+	for i := 1; i <= seedTraceCount; i++ {
+		traceID := fmt.Sprintf("c%031x", i)
+		// Root + two children. Minute = i keeps each trace's window
+		// disjoint; the +1ns / +2ns children sit after the root so the
+		// trace start (min Timestamp) is the root's timestamp.
+		base := fmt.Sprintf("2026-05-01 10:%02d:00.000000001", i)
+		c1 := fmt.Sprintf("2026-05-01 10:%02d:00.000000002", i)
+		c2 := fmt.Sprintf("2026-05-01 10:%02d:00.000000003", i)
+		root := fmt.Sprintf("%016x", i*10+1)
+		child1 := fmt.Sprintf("%016x", i*10+2)
+		child2 := fmt.Sprintf("%016x", i*10+3)
+		rows = append(
+			rows,
+			fmt.Sprintf("('%s', '%s', '', 'GET /root', 'Server', 1000, toDateTime64('%s', 9), 'Unset', '', '', '', map(), map('service.name', 'frontend'))", traceID, root, base),
+			fmt.Sprintf("('%s', '%s', '%s', 'child-a', 'Internal', 500, toDateTime64('%s', 9), 'Unset', '', '', '', map(), map('service.name', 'svc-a'))", traceID, child1, root, c1),
+			fmt.Sprintf("('%s', '%s', '%s', 'child-b', 'Client', 300, toDateTime64('%s', 9), 'Unset', '', '', '', map(), map('service.name', 'svc-b'))", traceID, child2, root, c2),
+		)
+	}
+	insert := "INSERT INTO otel_traces VALUES\n"
+	for i, r := range rows {
+		if i > 0 {
+			insert += ",\n"
+		}
+		insert += "    " + r
+	}
+	return insert + ";"
+}
+
+func newManyTracesChDBServer(t *testing.T, seed string) *httptest.Server {
+	t.Helper()
+	c := chclienttest.NewChDB(t)
+	c.Seed(t, tracesDDL)
+	c.Seed(t, seed)
+	h := tempo.New(c, schema.DefaultOTelTraces(), "v-test", nil)
+	mux := http.NewServeMux()
+	h.Mount(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func doSearch(t *testing.T, srv *httptest.Server, path string) tempo.SearchResponse {
+	t.Helper()
+	resp, err := http.Get(srv.URL + path)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+	var sr tempo.SearchResponse
+	if err := json.Unmarshal([]byte(body), &sr); err != nil {
+		t.Fatalf("decode: %v\nbody: %s", err, body)
+	}
+	return sr
+}
+
+// TestSearch_TraceLimitPushdown_BoundsDrain_ChDB is the genuinely-failing
+// repro: it seeds many traces, drives a plain `{}` search with a small
+// limit, and asserts the kept set is the newest-by-min-start prefix AND
+// that the drain (InspectedTraces == len(res.Samples)) is bounded to the
+// kept traces' spans, not the full seed. The InspectedTraces bound is the
+// assertion that fails without stampSearchTraceLimit's wrap.
+func TestSearch_TraceLimitPushdown_BoundsDrain_ChDB(t *testing.T) {
+	srv := newManyTracesChDBServer(t, manyTracesSeed())
+
+	sr := doSearch(t, srv, fmt.Sprintf("/api/search?q=%%7B%%7D&limit=%d&spss=20", searchLimit))
+
+	// Exactly `searchLimit` traces returned.
+	if len(sr.Traces) != searchLimit {
+		t.Fatalf("got %d traces, want %d", len(sr.Traces), searchLimit)
+	}
+
+	// The kept set is the newest `searchLimit` traces by min(start):
+	// trace i's start increases with i, so the kept TraceIDs are the
+	// highest-i ones (8, 7, 6 for limit=3), in start-desc order.
+	for rank := 0; rank < searchLimit; rank++ {
+		wantTrace := seedTraceCount - rank
+		wantID := fmt.Sprintf("c%031x", wantTrace)
+		if sr.Traces[rank].TraceID != wantID {
+			t.Errorf("trace[%d] = %q, want %q (newest-by-min-start desc)", rank, sr.Traces[rank].TraceID, wantID)
+		}
+	}
+
+	// Start-desc ordering invariant across the whole returned list.
+	for i := 1; i < len(sr.Traces); i++ {
+		prev, _ := strconv.ParseUint(sr.Traces[i-1].StartTimeUnixNano, 10, 64)
+		cur, _ := strconv.ParseUint(sr.Traces[i].StartTimeUnixNano, 10, 64)
+		if prev < cur {
+			t.Errorf("traces not start-desc at %d: %d < %d", i, prev, cur)
+		}
+	}
+
+	// ★ Load-bearing: the drain is bounded to the kept traces' spans.
+	// kept = searchLimit traces * spansPerTrace spans. The full seed is
+	// seedTraceCount*spansPerTrace; without the pushdown InspectedTraces
+	// would equal the full seed (the OOM-prone unbounded drain).
+	wantInspected := searchLimit * spansPerTrace
+	fullSeed := seedTraceCount * spansPerTrace
+	if sr.Metrics.InspectedTraces != wantInspected {
+		t.Errorf("InspectedTraces = %d, want %d (kept %d traces * %d spans); full seed is %d — a value of %d means the drain was NOT bounded (the OOM bug)",
+			sr.Metrics.InspectedTraces, wantInspected, searchLimit, spansPerTrace, fullSeed, fullSeed)
+	}
+	// Guard the assertion against a degenerate seed: the bound must be a
+	// real reduction, otherwise the test proves nothing.
+	if wantInspected >= fullSeed {
+		t.Fatalf("seed misconfigured: kept-span count %d not < full seed %d", wantInspected, fullSeed)
+	}
+}
+
+// rankingParitySeed builds two traces where:
+//
+//   - trace LOW has an out-of-order child whose timestamp is EARLIER than
+//     its own root (so the trace's min(Timestamp) is the child's, not the
+//     root's) — proving the ranking aggregates min over ALL matched
+//     spans, not the root alone;
+//   - trace HIGH's min(Timestamp) is later than LOW's min, but LOW's
+//     MAX(Timestamp) is later than HIGH's max.
+//
+// min-ranking keeps {LOW, HIGH} ordered HIGH-first only if we rank by
+// min DESC; a max-based ranking would order LOW first (its max is the
+// latest in the table). With limit=1, min-ranking keeps HIGH; max-ranking
+// would (wrongly) keep LOW. That divergence is what proves the fix uses
+// min, not max.
+const (
+	// 32-hex trace IDs (Tempo wire IDs are hex). "lowTraceID" is the one
+	// whose min-start is EARLIER but whose max-start is LATER; "highTraceID"
+	// is the one min-ranking must keep at limit=1.
+	lowTraceID  = "d00000000000000000000000000000aa"
+	highTraceID = "e00000000000000000000000000000bb"
+)
+
+const rankingParitySeed = `INSERT INTO otel_traces VALUES
+    ('d00000000000000000000000000000aa', '00000000000000a1', '', 'low root', 'Server', 1000, toDateTime64('2026-05-01 11:00:05.000000000', 9), 'Unset', '', '', '', map(), map('service.name', 'low')),
+    ('d00000000000000000000000000000aa', '00000000000000a2', '00000000000000a1', 'low ooo child', 'Internal', 500, toDateTime64('2026-05-01 11:00:01.000000000', 9), 'Unset', '', '', '', map(), map('service.name', 'low')),
+    ('d00000000000000000000000000000aa', '00000000000000a3', '00000000000000a1', 'low late child', 'Client', 300, toDateTime64('2026-05-01 11:00:59.000000000', 9), 'Unset', '', '', '', map(), map('service.name', 'low')),
+    ('e00000000000000000000000000000bb', '00000000000000b1', '', 'high root', 'Server', 1000, toDateTime64('2026-05-01 11:00:10.000000000', 9), 'Unset', '', '', '', map(), map('service.name', 'high')),
+    ('e00000000000000000000000000000bb', '00000000000000b2', '00000000000000b1', 'high child', 'Internal', 500, toDateTime64('2026-05-01 11:00:12.000000000', 9), 'Unset', '', '', '', map(), map('service.name', 'high'));`
+
+// TestSearch_TraceLimitPushdown_MinRanking_ChDB proves the top-N ranking
+// is min(Timestamp), not max. Trace LOW's min is 11:00:01 (its out-of-order
+// child) and its max is 11:00:59; trace HIGH's min is 11:00:10 and max
+// 11:00:12. With limit=1:
+//
+//   - min-DESC ranking keeps HIGH (11:00:10 > 11:00:01) — correct;
+//   - max-DESC ranking would keep LOW (11:00:59 > 11:00:12) — wrong.
+//
+// HIGH is the only correct survivor, and a min ranking selects it while a
+// max ranking would not.
+//
+// Scope: this fixture discriminates min from max. It does NOT, on its own,
+// distinguish min-over-matched-spans from min-over-roots — both rank HIGH
+// first here (HIGH's root 11:00:10 > LOW's root 11:00:05, same survivor as
+// matched-min). That the ranking subquery folds the matcher predicate (so
+// min runs over matched spans, not roots) is pinned by the SQL-shape tests
+// in search_trace_limit_sql_test.go, which assert the predicate appears
+// inside the ranking subquery and that ORDER BY uses min(`Timestamp`), not
+// max(`Timestamp`).
+func TestSearch_TraceLimitPushdown_MinRanking_ChDB(t *testing.T) {
+	srv := newManyTracesChDBServer(t, rankingParitySeed)
+
+	sr := doSearch(t, srv, "/api/search?q=%7B%7D&limit=1&spss=20")
+
+	if len(sr.Traces) != 1 {
+		t.Fatalf("got %d traces, want 1", len(sr.Traces))
+	}
+	if sr.Traces[0].TraceID == lowTraceID {
+		t.Fatalf("kept LOW trace — ranking used max(Timestamp) or root-only min, not min over matched spans")
+	}
+	if sr.Traces[0].TraceID != highTraceID {
+		t.Fatalf("kept %q, want HIGH %q (min(Timestamp) DESC over matched spans)", sr.Traces[0].TraceID, highTraceID)
+	}
+}

--- a/internal/api/tempo/search_trace_limit_chdb_test.go
+++ b/internal/api/tempo/search_trace_limit_chdb_test.go
@@ -28,9 +28,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/tsouza/cerberus/internal/api/tempo"
+	"github.com/tsouza/cerberus/internal/chclient"
 	"github.com/tsouza/cerberus/internal/chclienttest"
 	"github.com/tsouza/cerberus/internal/schema"
 )
@@ -44,6 +46,16 @@ const (
 	spansPerTrace  = 3
 	searchLimit    = 3
 )
+
+// seedWindow is the explicit start/end query fragment every search in
+// this file appends. All seeds land on 2026-05-01 (Unix seconds
+// 1777593600..1777680000); /api/search now clamps a windowless request
+// to a now-relative DefaultSearchLookback (the L2 fix), so a bare `q={}`
+// would scan only the most recent hour and miss these historical seeds.
+// Supplying an explicit window covering the seed mirrors how real callers
+// (Grafana's Traces Drilldown always sends start/end) drive the path and
+// keeps these pushdown assertions exercising the windowed scan.
+const seedWindow = "&start=1777593600&end=1777680000"
 
 // manyTracesSeed builds seedTraceCount traces, each with a root span and
 // two children. Trace i's root starts at 10:0i:00; the children follow a
@@ -122,7 +134,7 @@ func doSearch(t *testing.T, srv *httptest.Server, path string) tempo.SearchRespo
 func TestSearch_TraceLimitPushdown_BoundsDrain_ChDB(t *testing.T) {
 	srv := newManyTracesChDBServer(t, manyTracesSeed())
 
-	sr := doSearch(t, srv, fmt.Sprintf("/api/search?q=%%7B%%7D&limit=%d&spss=20", searchLimit))
+	sr := doSearch(t, srv, fmt.Sprintf("/api/search?q=%%7B%%7D&limit=%d&spss=20%s", searchLimit, seedWindow))
 
 	// Exactly `searchLimit` traces returned.
 	if len(sr.Traces) != searchLimit {
@@ -217,7 +229,7 @@ const rankingParitySeed = `INSERT INTO otel_traces VALUES
 func TestSearch_TraceLimitPushdown_MinRanking_ChDB(t *testing.T) {
 	srv := newManyTracesChDBServer(t, rankingParitySeed)
 
-	sr := doSearch(t, srv, "/api/search?q=%7B%7D&limit=1&spss=20")
+	sr := doSearch(t, srv, "/api/search?q=%7B%7D&limit=1&spss=20"+seedWindow)
 
 	if len(sr.Traces) != 1 {
 		t.Fatalf("got %d traces, want 1", len(sr.Traces))
@@ -227,5 +239,102 @@ func TestSearch_TraceLimitPushdown_MinRanking_ChDB(t *testing.T) {
 	}
 	if sr.Traces[0].TraceID != highTraceID {
 		t.Fatalf("kept %q, want HIGH %q (min(Timestamp) DESC over matched spans)", sr.Traces[0].TraceID, highTraceID)
+	}
+}
+
+// fatTraceMatchedSpans is the number of matched spans seeded onto ONE
+// trace for the L1 fat-trace test: well above both the spss cap the
+// request sends (3) and DefaultSpansPerSpanSet, so the spans-truncated /
+// Matched-uncapped contract is observable.
+const fatTraceMatchedSpans = 12
+
+// fatTraceSeed seeds a SINGLE trace carrying fatTraceMatchedSpans spans
+// (one root + the rest children), all matching a plain `{}` search. The
+// trace-count bound keeps this one trace; the L1 contract is that every
+// matched span still flows into Matched while the SpanSet's span LIST is
+// truncated to the request's spss.
+func fatTraceSeed() string {
+	const traceID = "f00000000000000000000000000000aa"
+	rows := make([]string, 0, fatTraceMatchedSpans)
+	for i := 0; i < fatTraceMatchedSpans; i++ {
+		spanID := fmt.Sprintf("%016x", i+1)
+		parent := ""
+		if i > 0 {
+			// Children point at the root (span 1) so exactly one span is
+			// the root; all share the trace so all match `{}`.
+			parent = fmt.Sprintf("%016x", 1)
+		}
+		ts := fmt.Sprintf("2026-05-01 12:00:00.%09d", i+1)
+		rows = append(rows, fmt.Sprintf(
+			"('%s', '%s', '%s', 'span-%d', 'Internal', 1000, toDateTime64('%s', 9), 'Unset', '', '', '', map(), map('service.name', 'fat'))",
+			traceID, spanID, parent, i, ts,
+		))
+	}
+	return "INSERT INTO otel_traces VALUES\n    " + strings.Join(rows, ",\n    ") + ";"
+}
+
+// TestSearch_FatTrace_MatchedUncapped_BudgetBackstop pins the L1 verdict:
+// the spans-per-trace fan-out is intentionally uncapped (the Matched
+// parity contract the tempo differ enforces), and a pathological fat
+// trace is bounded not by an SQL span cap but by the sample-budget
+// backstop that aborts the drain with a 422.
+//
+//   - Parity arm (chDB): one trace, fatTraceMatchedSpans matched spans,
+//     spss=3. The SpanSet's span LIST is truncated to 3, but Matched
+//     reports the full fatTraceMatchedSpans — the exact "spans truncated,
+//     Matched uncapped" property the differ requires. An SQL `LIMIT k BY
+//     TraceId` would cap Matched here and break parity.
+//   - Backstop arm: the same fat-trace search driven through a querier
+//     that returns the sample-budget error (MaxQuerySamples crossed mid
+//     drain). The handler must map it to 422 — proving the drain aborts
+//     with a rejection rather than growing the heap without bound.
+func TestSearch_FatTrace_MatchedUncapped_BudgetBackstop(t *testing.T) {
+	// --- Parity arm: spans truncated to spss, Matched uncapped. ---
+	srv := newManyTracesChDBServer(t, fatTraceSeed())
+	sr := doSearch(t, srv, "/api/search?q=%7B%7D&spss=3"+seedWindow)
+
+	if len(sr.Traces) != 1 {
+		t.Fatalf("parity arm: got %d traces, want 1 (single fat trace)", len(sr.Traces))
+	}
+	tr := sr.Traces[0]
+	if len(tr.SpanSets) != 1 {
+		t.Fatalf("parity arm: got %d spanSets, want 1 (%+v)", len(tr.SpanSets), tr)
+	}
+	set := tr.SpanSets[0]
+	// The span LIST is truncated to the requested spss …
+	if len(set.Spans) != 3 {
+		t.Errorf("parity arm: len(Spans) = %d, want 3 (truncated to spss)", len(set.Spans))
+	}
+	// … but Matched reports the UNCAPPED total — the parity contract.
+	if set.Matched != fatTraceMatchedSpans {
+		t.Errorf("parity arm: Matched = %d, want %d (uncapped total — an SQL span cap would break tempo Matched parity)",
+			set.Matched, fatTraceMatchedSpans)
+	}
+	// Guard against a degenerate fixture: the truncation must be real.
+	if fatTraceMatchedSpans <= 3 || fatTraceMatchedSpans <= tempo.DefaultSpansPerSpanSet {
+		t.Fatalf("seed misconfigured: fatTraceMatchedSpans %d must exceed both spss=3 and DefaultSpansPerSpanSet=%d",
+			fatTraceMatchedSpans, tempo.DefaultSpansPerSpanSet)
+	}
+
+	// --- Backstop arm: a fat drain that crosses the sample budget is a
+	// 422, not an unbounded heap. The chDB test double drains rows itself
+	// and does not enforce MaxQuerySamples (that lives in the production
+	// cursor, unit-tested in internal/chclient), so drive the budget
+	// crossing through a querier that surfaces the same *TooManySamplesError
+	// the production cursor raises and assert the /api/search handler maps
+	// it to 422 via classifySearchErr. ---
+	budgetQ := &stubQuerier{err: &chclient.TooManySamplesError{Limit: fatTraceMatchedSpans - 1}}
+	budgetSrv := newServer(budgetQ, "v-test")
+	t.Cleanup(budgetSrv.Close)
+	resp, err := http.Get(budgetSrv.URL + "/api/search?q=%7B%7D&spss=3")
+	if err != nil {
+		t.Fatalf("backstop arm GET: %v", err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusUnprocessableEntity {
+		t.Fatalf("backstop arm: status = %d (body %q), want 422 (sample-budget abort, not an unbounded drain)", resp.StatusCode, body)
+	}
+	if !strings.Contains(body, "sample budget exceeded") {
+		t.Errorf("backstop arm: body %q does not carry the budget message", body)
 	}
 }

--- a/internal/api/tempo/search_trace_limit_sql_test.go
+++ b/internal/api/tempo/search_trace_limit_sql_test.go
@@ -1,0 +1,105 @@
+package tempo_test
+
+// Handler-level SQL-shape pins for the /api/search trace-limit pushdown
+// (the summaries-drain OOM fix). The spec/traceql golden lane threads no
+// search limit, so the SearchTraceLimit wrap is a no-op there and the
+// emitted top-N subquery never shows up in a txtar golden — these tests
+// drive the real handler (which threads `limit` + window into lowering)
+// and assert against the SQL the engine handed the querier
+// (stubQuerier.lastSQL).
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+)
+
+// searchSQL drives one /api/search request through the full handler
+// pipeline and returns the SQL the engine emitted (captured by the stub
+// querier). An empty sample set is fine — we assert on SQL shape, not
+// rows.
+func searchSQL(t *testing.T, query string) string {
+	t.Helper()
+	q := &stubQuerier{samples: []chclient.Sample{}}
+	srv := newServer(q, "v-test")
+	t.Cleanup(srv.Close)
+	resp, err := http.Get(srv.URL + query)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	resp.Body.Close()
+	if q.lastSQL == "" {
+		t.Fatalf("no SQL captured for %q", query)
+	}
+	return q.lastSQL
+}
+
+// TestSearch_TraceLimitPushdown_SQLShape pins that a plain `{}` search
+// carries the top-N trace subquery: the outer drain is restricted to
+// `TraceId IN (SELECT TraceId FROM (...) GROUP BY TraceId ORDER BY
+// min(Timestamp) DESC, TraceId LIMIT <limit>)`. This is the SQL that
+// bounds the Go-side drain to the kept traces' spans instead of every
+// matching row.
+func TestSearch_TraceLimitPushdown_SQLShape(t *testing.T) {
+	t.Parallel()
+	sql := searchSQL(t, "/api/search?q=%7B%7D&limit=3")
+
+	// The IN-subquery restriction over the trace-id column.
+	if !strings.Contains(sql, "`TraceId` IN (SELECT `TraceId` FROM (") {
+		t.Errorf("plain {} search SQL missing TraceId IN (subquery) restriction:\n%s", sql)
+	}
+	// Top-N ranking: newest-by-min-start, TraceId tie-break — NEVER max.
+	if !strings.Contains(sql, "GROUP BY `TraceId`") {
+		t.Errorf("SQL missing GROUP BY TraceId:\n%s", sql)
+	}
+	if !strings.Contains(sql, "ORDER BY min(`Timestamp`) DESC, `TraceId`") {
+		t.Errorf("SQL missing min(Timestamp) DESC, TraceId ranking (parity key is min, not max):\n%s", sql)
+	}
+	if strings.Contains(sql, "max(`Timestamp`)") {
+		t.Errorf("SQL ranks by max(Timestamp) — parity verdict is min(Timestamp):\n%s", sql)
+	}
+	// The request limit is pushed into the subquery LIMIT.
+	if !strings.Contains(sql, "LIMIT 3") {
+		t.Errorf("SQL missing LIMIT 3 (the request limit):\n%s", sql)
+	}
+}
+
+// TestSearch_TraceLimitPushdown_DefaultLimit pins that the subquery
+// LIMIT defaults to DefaultSearchLimit when the request omits `limit`,
+// matching TruncateSummaries' Go-side default.
+func TestSearch_TraceLimitPushdown_DefaultLimit(t *testing.T) {
+	t.Parallel()
+	sql := searchSQL(t, "/api/search?q=%7B%7D")
+	if !strings.Contains(sql, "`TraceId` IN (SELECT `TraceId` FROM (") {
+		t.Fatalf("default-limit search SQL missing IN (subquery):\n%s", sql)
+	}
+	if !strings.Contains(sql, "LIMIT 20") {
+		t.Errorf("SQL missing LIMIT 20 (DefaultSearchLimit):\n%s", sql)
+	}
+}
+
+// TestSearch_TraceLimitPushdown_WindowFolded pins that an explicit
+// start/end window folds a Timestamp range predicate into BOTH the inner
+// ranking subquery and the outer drain, so each scan is bounded to the
+// window rather than the whole table.
+func TestSearch_TraceLimitPushdown_WindowFolded(t *testing.T) {
+	t.Parallel()
+	sql := searchSQL(t, "/api/search?q=%7B%7D&limit=5&start=1000&end=2000")
+
+	// The window must appear twice — once on the outer drain scan and
+	// once inside the top-N ranking subquery — so neither scans the
+	// whole table.
+	const ge = "`Timestamp` >= fromUnixTimestamp64Nano(?)"
+	const le = "`Timestamp` <= fromUnixTimestamp64Nano(?)"
+	if got := strings.Count(sql, ge); got != 2 {
+		t.Errorf("expected the start bound on both scans (2x %q), got %d:\n%s", ge, got, sql)
+	}
+	if got := strings.Count(sql, le); got != 2 {
+		t.Errorf("expected the end bound on both scans (2x %q), got %d:\n%s", le, got, sql)
+	}
+	if !strings.Contains(sql, "ORDER BY min(`Timestamp`) DESC, `TraceId`") {
+		t.Errorf("windowed search SQL missing min-ranking subquery:\n%s", sql)
+	}
+}

--- a/internal/api/tempo/search_trace_limit_sql_test.go
+++ b/internal/api/tempo/search_trace_limit_sql_test.go
@@ -103,3 +103,77 @@ func TestSearch_TraceLimitPushdown_WindowFolded(t *testing.T) {
 		t.Errorf("windowed search SQL missing min-ranking subquery:\n%s", sql)
 	}
 }
+
+// TestSearch_WindowlessDefaultsLookback_SQLShape pins the L2 fix: a plain
+// `{}` search with NO start/end params is clamped by the handler to a
+// recent-lookback window (DefaultSearchLookback), so the emitted SQL now
+// carries a `Timestamp >=` / `<=` bound on BOTH the inner top-N ranking
+// subquery and the outer drain — the inner `GROUP BY TraceId` is therefore
+// windowed and never aggregates over the whole table. The clock instant is
+// not pinned (the handler uses time.Now); the test asserts SQL SHAPE — the
+// presence of the bounds — not the literal nanos.
+func TestSearch_WindowlessDefaultsLookback_SQLShape(t *testing.T) {
+	t.Parallel()
+	sql := searchSQL(t, "/api/search?q=%7B%7D")
+
+	// The window must appear twice — once on the outer drain scan and once
+	// inside the top-N ranking subquery — so neither scans the whole table.
+	const ge = "`Timestamp` >= fromUnixTimestamp64Nano(?)"
+	const le = "`Timestamp` <= fromUnixTimestamp64Nano(?)"
+	if got := strings.Count(sql, ge); got != 2 {
+		t.Errorf("windowless search must clamp to a lookback: expected the start bound on both scans (2x %q), got %d:\n%s", ge, got, sql)
+	}
+	if got := strings.Count(sql, le); got != 2 {
+		t.Errorf("windowless search must clamp to a lookback: expected the end bound on both scans (2x %q), got %d:\n%s", le, got, sql)
+	}
+	if !strings.Contains(sql, "GROUP BY `TraceId`") {
+		t.Errorf("windowless search SQL missing the windowed top-N GROUP BY TraceId:\n%s", sql)
+	}
+}
+
+// TestSearch_ExplicitWindow_HonoredVerbatim contrasts with the windowless
+// clamp above: an explicit start/end is honored as supplied — the default
+// lookback never overrides a window the caller provided. Together the two
+// tests pin that the L2 clamp fires ONLY on the both-bounds-absent path.
+func TestSearch_ExplicitWindow_HonoredVerbatim(t *testing.T) {
+	t.Parallel()
+	// start=1000s, end=2000s — explicit bounds. The args carry the exact
+	// nanos; assert the supplied window reaches the SQL (both scans) rather
+	// than being replaced by a now-relative lookback.
+	q := &stubQuerier{}
+	srv := newServer(q, "v-test")
+	t.Cleanup(srv.Close)
+	resp, err := http.Get(srv.URL + "/api/search?q=%7B%7D&start=1000&end=2000")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	resp.Body.Close()
+	sql := q.lastSQL
+	const ge = "`Timestamp` >= fromUnixTimestamp64Nano(?)"
+	const le = "`Timestamp` <= fromUnixTimestamp64Nano(?)"
+	if got := strings.Count(sql, ge); got != 2 {
+		t.Errorf("explicit window must fold on both scans (2x %q), got %d:\n%s", ge, got, sql)
+	}
+	if got := strings.Count(sql, le); got != 2 {
+		t.Errorf("explicit window must fold on both scans (2x %q), got %d:\n%s", le, got, sql)
+	}
+	// The explicit start (1000s = 1e12 ns) and end (2000s = 2e12 ns) must
+	// be the args, proving the supplied window — not a now-relative
+	// lookback — reached the SQL.
+	const startNanos = int64(1000) * 1_000_000_000
+	const endNanos = int64(2000) * 1_000_000_000
+	var sawStart, sawEnd bool
+	for _, a := range q.lastArgs {
+		if v, ok := a.(int64); ok {
+			if v == startNanos {
+				sawStart = true
+			}
+			if v == endNanos {
+				sawEnd = true
+			}
+		}
+	}
+	if !sawStart || !sawEnd {
+		t.Errorf("explicit window args not honored verbatim: sawStart=%v sawEnd=%v args=%v", sawStart, sawEnd, q.lastArgs)
+	}
+}

--- a/internal/chplan/clone.go
+++ b/internal/chplan/clone.go
@@ -34,6 +34,10 @@ func CloneNode(n Node) Node {
 		return &c
 	case *Filter:
 		return &Filter{Input: CloneNode(v.Input), Predicate: cloneExpr(v.Predicate)}
+	case *SearchTraceLimit:
+		c := *v
+		c.Input = CloneNode(v.Input)
+		return &c
 	case *Project:
 		return &Project{Input: CloneNode(v.Input), Projections: cloneProjections(v.Projections)}
 	case *Aggregate:

--- a/internal/chplan/equal_invariants_test.go
+++ b/internal/chplan/equal_invariants_test.go
@@ -2238,3 +2238,73 @@ func TestHistogramQuantileNative_Equal_Negative_PhiExpr(t *testing.T) {
 		t.Errorf("PhiExpr nil vs non-nil should not be Equal")
 	}
 }
+
+// -----------------------------------------------------------------------
+// SearchTraceLimit Equal tests — one positive + one negative per
+// load-bearing field. The comparator backs the IR-equality checks the
+// optimizer-rule rewrite tests and Walk invariants rely on, so every
+// field that changes the emitted top-N subquery must split Equal apart.
+// -----------------------------------------------------------------------
+
+func TestSearchTraceLimit_Equal_Positive(t *testing.T) {
+	t.Parallel()
+	build := func() *chplan.SearchTraceLimit {
+		return &chplan.SearchTraceLimit{
+			Input:           &chplan.Scan{Table: "otel_traces"},
+			TraceIDColumn:   "TraceId",
+			TimestampColumn: "Timestamp",
+			TraceLimit:      20,
+		}
+	}
+	if !build().Equal(build()) {
+		t.Fatalf("identical SearchTraceLimit trees should be Equal")
+	}
+	if !build().Equal(build()) {
+		t.Fatalf("Equal must be symmetric")
+	}
+}
+
+func TestSearchTraceLimit_Equal_Negative_TraceLimit(t *testing.T) {
+	t.Parallel()
+	a := &chplan.SearchTraceLimit{Input: &chplan.Scan{Table: "t"}, TraceLimit: 20}
+	b := &chplan.SearchTraceLimit{Input: &chplan.Scan{Table: "t"}, TraceLimit: 200}
+	if a.Equal(b) {
+		t.Errorf("different TraceLimit should not be Equal")
+	}
+}
+
+func TestSearchTraceLimit_Equal_Negative_TraceIDColumn(t *testing.T) {
+	t.Parallel()
+	a := &chplan.SearchTraceLimit{Input: &chplan.Scan{Table: "t"}, TraceIDColumn: "TraceId", TraceLimit: 5}
+	b := &chplan.SearchTraceLimit{Input: &chplan.Scan{Table: "t"}, TraceIDColumn: "Trace_Id", TraceLimit: 5}
+	if a.Equal(b) {
+		t.Errorf("different TraceIDColumn should not be Equal")
+	}
+}
+
+func TestSearchTraceLimit_Equal_Negative_TimestampColumn(t *testing.T) {
+	t.Parallel()
+	a := &chplan.SearchTraceLimit{Input: &chplan.Scan{Table: "t"}, TimestampColumn: "Timestamp", TraceLimit: 5}
+	b := &chplan.SearchTraceLimit{Input: &chplan.Scan{Table: "t"}, TimestampColumn: "TimeUnix", TraceLimit: 5}
+	if a.Equal(b) {
+		t.Errorf("different TimestampColumn should not be Equal")
+	}
+}
+
+func TestSearchTraceLimit_Equal_Negative_Input(t *testing.T) {
+	t.Parallel()
+	a := &chplan.SearchTraceLimit{Input: &chplan.Scan{Table: "a"}, TraceLimit: 5}
+	b := &chplan.SearchTraceLimit{Input: &chplan.Scan{Table: "b"}, TraceLimit: 5}
+	if a.Equal(b) {
+		t.Errorf("different Input should not be Equal")
+	}
+}
+
+func TestSearchTraceLimit_Equal_Negative_OtherType(t *testing.T) {
+	t.Parallel()
+	a := &chplan.SearchTraceLimit{Input: &chplan.Scan{Table: "t"}, TraceLimit: 5}
+	b := &chplan.Scan{Table: "t"}
+	if a.Equal(b) {
+		t.Errorf("SearchTraceLimit should not Equal a bare Scan")
+	}
+}

--- a/internal/chplan/search_trace_limit.go
+++ b/internal/chplan/search_trace_limit.go
@@ -1,0 +1,41 @@
+package chplan
+
+// SearchTraceLimit bounds a Tempo /api/search row source to the N newest
+// traces, pushing the request's `limit` into SQL so the handler drains only
+// those traces' spans instead of every matching row.
+//
+// It exists because /api/search groups spans into per-trace summaries in Go
+// and only then truncates to `limit` (see internal/api/tempo/handler.go
+// toTraceSummaries / TruncateSummaries): for a wide window the full match set
+// is buffered first, OOMing the process before the limit ever bites. The
+// emitter ranks traces by start time (min span Timestamp), descending, with a
+// TraceId-ascending tie-break — exactly sortSummariesStartDesc's order — and
+// keeps the top TraceLimit, so the SQL-selected set equals the set
+// TruncateSummaries would have kept (no wire-shape change, just a bounded
+// drain).
+//
+// The node wraps the lowered plain-search row source — a bare Scan (`{}`) or
+// Filter(Scan) (`{ <matchers> }`), with the request time window folded into
+// the predicate. TraceLimit <= 0 is a no-op (the emitter renders Input
+// unchanged); the lowering never constructs it that way.
+type SearchTraceLimit struct {
+	Input           Node
+	TraceIDColumn   string
+	TimestampColumn string
+	TraceLimit      int64
+}
+
+func (*SearchTraceLimit) planNode() {}
+
+func (n *SearchTraceLimit) Children() []Node { return []Node{n.Input} }
+
+func (n *SearchTraceLimit) Equal(other Node) bool {
+	o, ok := other.(*SearchTraceLimit)
+	if !ok {
+		return false
+	}
+	return n.TraceIDColumn == o.TraceIDColumn &&
+		n.TimestampColumn == o.TimestampColumn &&
+		n.TraceLimit == o.TraceLimit &&
+		n.Input.Equal(o.Input)
+}

--- a/internal/chplan/search_trace_limit.go
+++ b/internal/chplan/search_trace_limit.go
@@ -18,6 +18,20 @@ package chplan
 // Filter(Scan) (`{ <matchers> }`), with the request time window folded into
 // the predicate. TraceLimit <= 0 is a no-op (the emitter renders Input
 // unchanged); the lowering never constructs it that way.
+//
+// L1 (fat-trace): the node bounds the trace COUNT, not the spans-per-trace.
+// A single trace with millions of matched spans still drains every matched
+// span into the handler's per-trace SpanSet. This per-trace span fan-out is
+// intentionally uncapped per the Matched parity contract: SpanSet.Matched is
+// the uncapped total matched-span count, which the tempo compatibility differ
+// (compatibility/tempo/driver/differ.go compareSpanSets) asserts byte-exact
+// against reference Tempo — an SQL `LIMIT k BY TraceId` would cap the rows the
+// handler sees and so cap Matched, breaking that parity. Process memory for a
+// pathological fat trace is instead bounded by chclient.MaxQuerySamples (the
+// query.maxSamples knob): crossing it aborts the row drain with a 422
+// TooManySamplesError rather than growing the heap without limit. The fix is
+// the same row-drain backstop a wide fat result set leans on — not a distinct
+// unbounded path — so the trace-count bound deliberately leaves it alone.
 type SearchTraceLimit struct {
 	Input           Node
 	TraceIDColumn   string

--- a/internal/chsql/emit.go
+++ b/internal/chsql/emit.go
@@ -147,6 +147,8 @@ func (e *emitter) emitNode(n chplan.Node) error {
 		return e.emitStructuralJoin(v)
 	case *chplan.NestedSetAnnotate:
 		return e.emitNestedSetAnnotate(v)
+	case *chplan.SearchTraceLimit:
+		return e.emitSearchTraceLimit(v)
 	case *chplan.CrossJoin:
 		return e.emitCrossJoin(v)
 	case *chplan.SetOperation:

--- a/internal/chsql/emit.go
+++ b/internal/chsql/emit.go
@@ -105,30 +105,6 @@ func (e *emitter) emitNode(n chplan.Node) error {
 		return e.emitProject(v)
 	case *chplan.Aggregate:
 		return e.emitAggregate(v)
-	case *chplan.MetricsAggregate:
-		return e.emitMetricsAggregate(v)
-	case *chplan.MetricsSecondStage:
-		return e.emitMetricsSecondStage(v)
-	case *chplan.MetricsHistogramOverTime:
-		return e.emitMetricsHistogramOverTime(v)
-	case *chplan.MetricsCompare:
-		return e.emitMetricsCompare(v)
-	case *chplan.RangeWindow:
-		return e.emitRangeWindow(v)
-	case *chplan.RangeWindowNative:
-		return e.emitRangeWindowNative(v)
-	case *chplan.RangeLWR:
-		return e.emitRangeLWR(v)
-	case *chplan.RangeWindowResample:
-		return e.emitRangeWindowResample(v)
-	case *chplan.RangeBucketFanout:
-		return e.emitRangeBucketFanout(v)
-	case *chplan.AbsentOverTime:
-		return e.emitAbsentOverTime(v)
-	case *chplan.HistogramQuantile:
-		return e.emitHistogramQuantile(v)
-	case *chplan.HistogramQuantileNative:
-		return e.emitHistogramQuantileNative(v)
 	case *chplan.Limit:
 		return e.emitLimit(v)
 	case *chplan.OrderBy:
@@ -156,8 +132,46 @@ func (e *emitter) emitNode(n chplan.Node) error {
 	case *chplan.UnionAll:
 		return e.emitUnionAll(v)
 	default:
+		if handled, err := e.emitMetricNode(n); handled {
+			return err
+		}
 		return fmt.Errorf("%w: node %T", ErrUnsupported, n)
 	}
+}
+
+// emitMetricNode dispatches the metric / range-window / histogram node
+// family — the analytical nodes the PromQL & TraceQL metrics pipelines
+// produce. Split out of emitNode so that switch stays under the cyclop
+// complexity budget as new relational nodes are added; returns handled=false
+// for any node it doesn't own so emitNode falls through to ErrUnsupported.
+func (e *emitter) emitMetricNode(n chplan.Node) (bool, error) {
+	switch v := n.(type) {
+	case *chplan.MetricsAggregate:
+		return true, e.emitMetricsAggregate(v)
+	case *chplan.MetricsSecondStage:
+		return true, e.emitMetricsSecondStage(v)
+	case *chplan.MetricsHistogramOverTime:
+		return true, e.emitMetricsHistogramOverTime(v)
+	case *chplan.MetricsCompare:
+		return true, e.emitMetricsCompare(v)
+	case *chplan.RangeWindow:
+		return true, e.emitRangeWindow(v)
+	case *chplan.RangeWindowNative:
+		return true, e.emitRangeWindowNative(v)
+	case *chplan.RangeLWR:
+		return true, e.emitRangeLWR(v)
+	case *chplan.RangeWindowResample:
+		return true, e.emitRangeWindowResample(v)
+	case *chplan.RangeBucketFanout:
+		return true, e.emitRangeBucketFanout(v)
+	case *chplan.AbsentOverTime:
+		return true, e.emitAbsentOverTime(v)
+	case *chplan.HistogramQuantile:
+		return true, e.emitHistogramQuantile(v)
+	case *chplan.HistogramQuantileNative:
+		return true, e.emitHistogramQuantileNative(v)
+	}
+	return false, nil
 }
 
 // emitSubquery wraps emitNode(n) in parentheses, used wherever a node feeds

--- a/internal/chsql/search_trace_limit.go
+++ b/internal/chsql/search_trace_limit.go
@@ -1,0 +1,68 @@
+package chsql
+
+import (
+	"fmt"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// emitSearchTraceLimit renders a chplan.SearchTraceLimit: the input row
+// source restricted to the N newest traces, so /api/search drains only those
+// traces' spans instead of every matching row.
+//
+// Rendered shape:
+//
+//	SELECT s.* FROM (<input>) AS s
+//	WHERE `TraceId` IN (
+//	  SELECT `TraceId` FROM (<input>)
+//	  GROUP BY `TraceId`
+//	  ORDER BY min(`Timestamp`) DESC, `TraceId` ASC
+//	  LIMIT <TraceLimit>)
+//
+// The top-N subquery ranks each trace by its start time (min span Timestamp),
+// newest first, with a TraceId-ascending tie-break — the same order
+// toTraceSummaries records as StartTimeUnixNano and sortSummariesStartDesc
+// applies — so the SQL-selected set is exactly the set TruncateSummaries
+// keeps. The input is rendered on both arms: the request's time window and
+// matchers ride inside it, so the inner GROUP BY is bounded to the window
+// (never the whole table) and the outer drain returns only matching spans,
+// keeping the per-spanset Matched total correct.
+//
+// ponytail: the input subquery is emitted twice (outer drain + inner
+// ranking). The window predicate keeps each scan cheap; lift to a single
+// `WITH src AS (...)` CTE only if the double scan shows up on the perf gate.
+func (e *emitter) emitSearchTraceLimit(n *chplan.SearchTraceLimit) error {
+	if n.TraceIDColumn == "" || n.TimestampColumn == "" {
+		return fmt.Errorf("%w: SearchTraceLimit column names unset", ErrUnsupported)
+	}
+	if n.TraceLimit <= 0 {
+		// Defensive: the lowering never builds the node with a non-positive
+		// limit. Emit the input unchanged rather than a degenerate LIMIT.
+		return e.emitNode(n.Input)
+	}
+
+	outerSub, err := e.subqueryFrag(n.Input)
+	if err != nil {
+		return err
+	}
+	innerSub, err := e.subqueryFrag(n.Input)
+	if err != nil {
+		return err
+	}
+
+	topN := NewQuery().
+		Select(Col(n.TraceIDColumn)).
+		From(innerSub).
+		GroupBy(Col(n.TraceIDColumn)).
+		OrderBy(Call("min", Col(n.TimestampColumn)), true).
+		OrderBy(Col(n.TraceIDColumn), false).
+		Limit(n.TraceLimit).
+		Frag()
+
+	sb := NewQuery().
+		Select(verbatim("s.*")).
+		From(aliasedFrag(outerSub, "s")).
+		Where(InSubquery(Col(n.TraceIDColumn), topN))
+	e.emitSelect(sb)
+	return nil
+}

--- a/internal/optimizer/rewrite_children_exhaustive_test.go
+++ b/internal/optimizer/rewrite_children_exhaustive_test.go
@@ -87,9 +87,11 @@ func allNodeCases() []nodeExhaustivenessCase {
 		{"Filter", &chplan.Filter{Input: sentinelChild(), Predicate: &chplan.LitBool{V: true}}, false},
 		{"Project", &chplan.Project{Input: sentinelChild()}, false},
 		{"NestedSetAnnotate", &chplan.NestedSetAnnotate{Input: sentinelChild()}, false},
+		{"SearchTraceLimit", &chplan.SearchTraceLimit{Input: sentinelChild(), TraceLimit: 20}, false},
 		{"Aggregate", &chplan.Aggregate{Input: sentinelChild()}, false},
 		{"RangeWindow", &chplan.RangeWindow{Input: sentinelChild(), Func: "rate"}, false},
 		{"RangeWindowNative", &chplan.RangeWindowNative{Input: sentinelChild(), Func: "rate"}, false},
+		{"RangeWindowResample", &chplan.RangeWindowResample{Input: sentinelChild()}, false},
 		{"AbsentOverTime", &chplan.AbsentOverTime{Input: sentinelChild()}, false},
 		{"Limit", &chplan.Limit{Input: sentinelChild(), Count: 1}, false},
 		{"OrderBy", &chplan.OrderBy{Input: sentinelChild()}, false},
@@ -130,7 +132,7 @@ func allNodeCases() []nodeExhaustivenessCase {
 // implementations. Cross-checked against
 // `grep -rn 'planNode()' internal/chplan/*.go`. Bump this (and add a table
 // row + a rewriteChildren arm) when a new Node type lands.
-const expectedNodeTypeCount = 29
+const expectedNodeTypeCount = 31
 
 // TestRewriteChildren_TableCoversEveryNodeType is the count guard. If a new
 // chplan.Node type is added without a corresponding allNodeCases() row, the

--- a/internal/optimizer/rule.go
+++ b/internal/optimizer/rule.go
@@ -342,6 +342,12 @@ func rewriteUnaryNode(n chplan.Node, fn func(chplan.Node) (chplan.Node, bool)) (
 			cp.Input = in
 			return &cp
 		})
+	case *chplan.SearchTraceLimit:
+		out, changed = rewriteSingleInput(v, v.Input, fn, func(in chplan.Node) chplan.Node {
+			cp := *v
+			cp.Input = in
+			return &cp
+		})
 	case *chplan.Aggregate:
 		out, changed = rewriteSingleInput(v, v.Input, fn, func(in chplan.Node) chplan.Node {
 			cp := *v

--- a/internal/traceql/lower.go
+++ b/internal/traceql/lower.go
@@ -45,6 +45,14 @@ func Lower(ctx context.Context, expr *traceql.RootExpr, s schema.Traces) (chplan
 	// return (no-op unless the request set a limit AND the plan is a
 	// select() over the Drilldown structure shape — see search_limit.go).
 	plan = stampNestedSetTraceLimit(plan, searchTraceLimit(ctx), s)
+	// Push the response trace limit + request window into the plain-search
+	// row source (a bare Scan or Filter(Scan)) so /api/search drains only the
+	// N newest traces in the window instead of buffering every matching span
+	// (the summaries-drain OOM). No-op unless the request set a limit AND the
+	// plan is a plain search — metrics / structural / set-op plans are left
+	// unchanged.
+	start, end := searchWindowFromCtx(ctx)
+	plan = stampSearchTraceLimit(plan, searchTraceLimit(ctx), start, end, s)
 	span.SetAttributes(cerbtrace.AttrPlanNodeCount.Int(cerbtrace.CountNodes(plan)))
 	return plan, nil
 }

--- a/internal/traceql/search_limit.go
+++ b/internal/traceql/search_limit.go
@@ -5,6 +5,7 @@ package traceql
 
 import (
 	"context"
+	"time"
 
 	"github.com/tsouza/cerberus/internal/chplan"
 	"github.com/tsouza/cerberus/internal/schema"
@@ -118,4 +119,147 @@ func isRootSpanFilter(n chplan.Node, parentSpanIDCol string) bool {
 	}
 	lit, ok := b.Right.(*chplan.LitString)
 	return ok && col.Name == parentSpanIDCol && lit.V == ""
+}
+
+// searchWindowKey types the context value carrying /api/search's request
+// time window ([start, end]) down into lowering, where stampSearchTraceLimit
+// folds it into the bounded plain-search scan. A dedicated unexported key
+// type avoids collisions with any other context value.
+type searchWindowKey struct{}
+
+// searchWindow pairs the request's start/end bounds threaded from the
+// /api/search handler. Either or both may be the zero time.Time, meaning the
+// corresponding bound was omitted (no predicate on that side).
+type searchWindow struct {
+	start time.Time
+	end   time.Time
+}
+
+// WithSearchWindow returns a context carrying the /api/search request window
+// so stampSearchTraceLimit can fold a `Timestamp >= start AND Timestamp <= end`
+// predicate into the bounded scan. When both bounds are zero (no window on the
+// request) the context is returned unchanged — the no-op path for every caller
+// that doesn't pass a time range.
+//
+// Sibling to WithSearchTraceLimit: the Tempo /api/search handler wraps its
+// request context with both before calling Engine.Query; the values ride
+// through Lang.Parse → traceql.Lower to the stamping pass.
+func WithSearchWindow(ctx context.Context, start, end time.Time) context.Context {
+	if start.IsZero() && end.IsZero() {
+		return ctx
+	}
+	return context.WithValue(ctx, searchWindowKey{}, searchWindow{start: start, end: end})
+}
+
+// searchWindowFromCtx recovers the bounds WithSearchWindow stored, or two
+// zero times when unset (no window).
+func searchWindowFromCtx(ctx context.Context) (time.Time, time.Time) {
+	if w, ok := ctx.Value(searchWindowKey{}).(searchWindow); ok {
+		return w.start, w.end
+	}
+	return time.Time{}, time.Time{}
+}
+
+// stampSearchTraceLimit wraps a plain-search row source in a
+// chplan.SearchTraceLimit, pushing the request's `limit` into SQL so
+// /api/search drains only the N newest traces instead of every matching row
+// (the summaries-drain OOM). The request time window is folded into the
+// scan predicate at the same time, so a windowed inner top-N ranking and
+// the outer drain both scan only the window — never the whole table.
+//
+// ponytail: when the request carries no window (both start/end zero — e.g. a
+// hand-rolled `q={}` with no time range), andWindow contributes no predicate
+// and the inner `GROUP BY TraceId` aggregates over the whole table
+// server-side. The Go-side drain is still bounded to N traces (no process
+// OOM), but ClickHouse builds an aggregation table keyed by every distinct
+// trace_id; on a large table this leans on the CH `max_memory` backstop
+// (code 241 → classifySearchErr maps it to 422, a rejection, not a crash).
+// Grafana's Traces Drilldown always sends start/end, so this is the
+// degenerate hand-rolled path only; tighten to a required window if it ever
+// bites in practice.
+//
+// limit <= 0 (no /api/search limit on the context — metrics, tests, the
+// property harness, /traces/{id}) is a no-op: the plan is returned unchanged.
+//
+// Only the plain-search shape is matched — a bare Scan (`{}`) or a
+// Filter(Scan) (`{ <matchers> }`). Metrics pipelines (Aggregate), structural
+// joins, set operations, and the already-bounded nested-set / structure-tab
+// plans (handled by stampNestedSetTraceLimit) are returned unchanged: those
+// either don't drain per-trace summaries or carry their own bound.
+func stampSearchTraceLimit(plan chplan.Node, limit int64, start, end time.Time, s schema.Traces) chplan.Node {
+	if limit <= 0 || plan == nil {
+		return plan
+	}
+	scan, pred, ok := plainSearchSource(plan)
+	if !ok {
+		return plan
+	}
+
+	// Fold the request window into the predicate so both the inner ranking
+	// subquery and the outer drain scan only [start, end].
+	pred = andWindow(pred, start, end, s.TimestampColumn)
+
+	var input chplan.Node = scan
+	if pred != nil {
+		input = &chplan.Filter{Input: scan, Predicate: pred}
+	}
+	return &chplan.SearchTraceLimit{
+		Input:           input,
+		TraceIDColumn:   s.TraceIDColumn,
+		TimestampColumn: s.TimestampColumn,
+		TraceLimit:      limit,
+	}
+}
+
+// plainSearchSource matches the plain-search row source the trace-limit
+// pushdown applies to: a bare *chplan.Scan (predicate nil) or a
+// *chplan.Filter whose Input is a *chplan.Scan (predicate = the filter's).
+// Any other shape returns ok=false so stampSearchTraceLimit leaves the plan
+// untouched.
+func plainSearchSource(plan chplan.Node) (scan *chplan.Scan, predicate chplan.Expr, ok bool) {
+	switch v := plan.(type) {
+	case *chplan.Scan:
+		return v, nil, true
+	case *chplan.Filter:
+		if sc, isScan := v.Input.(*chplan.Scan); isScan {
+			return sc, v.Predicate, true
+		}
+	}
+	return nil, nil, false
+}
+
+// andWindow conjoins the existing predicate with the request's time-window
+// bounds. A zero start/end contributes no bound; when neither bound is set
+// and pred is nil, the result is nil (the caller emits a bare Scan).
+func andWindow(pred chplan.Expr, start, end time.Time, tsCol string) chplan.Expr {
+	if !start.IsZero() {
+		pred = conjoin(pred, tsBound(chplan.OpGe, start, tsCol))
+	}
+	if !end.IsZero() {
+		pred = conjoin(pred, tsBound(chplan.OpLe, end, tsCol))
+	}
+	return pred
+}
+
+// conjoin ANDs two predicates, dropping a nil left arm so the first bound
+// folded into an empty predicate stays bare.
+func conjoin(left, right chplan.Expr) chplan.Expr {
+	if left == nil {
+		return right
+	}
+	return &chplan.Binary{Op: chplan.OpAnd, Left: left, Right: right}
+}
+
+// tsBound builds `<tsCol> <op> fromUnixTimestamp64Nano(<t.UnixNano()>)` — a
+// nanosecond-precision comparison against the DateTime64(9) timestamp column,
+// matching the precision the OTel-CH traces schema stores.
+func tsBound(op chplan.BinaryOp, t time.Time, tsCol string) chplan.Expr {
+	return &chplan.Binary{
+		Op:   op,
+		Left: &chplan.ColumnRef{Name: tsCol},
+		Right: &chplan.FuncCall{
+			Name: "fromUnixTimestamp64Nano",
+			Args: []chplan.Expr{&chplan.LitInt{V: t.UnixNano()}},
+		},
+	}
 }

--- a/internal/traceql/search_limit.go
+++ b/internal/traceql/search_limit.go
@@ -167,16 +167,18 @@ func searchWindowFromCtx(ctx context.Context) (time.Time, time.Time) {
 // scan predicate at the same time, so a windowed inner top-N ranking and
 // the outer drain both scan only the window — never the whole table.
 //
-// ponytail: when the request carries no window (both start/end zero — e.g. a
-// hand-rolled `q={}` with no time range), andWindow contributes no predicate
-// and the inner `GROUP BY TraceId` aggregates over the whole table
-// server-side. The Go-side drain is still bounded to N traces (no process
-// OOM), but ClickHouse builds an aggregation table keyed by every distinct
-// trace_id; on a large table this leans on the CH `max_memory` backstop
-// (code 241 → classifySearchErr maps it to 422, a rejection, not a crash).
-// Grafana's Traces Drilldown always sends start/end, so this is the
-// degenerate hand-rolled path only; tighten to a required window if it ever
-// bites in practice.
+// Both search entry points — the HTTP /api/search handler and the gRPC
+// streaming /search RPC — now clamp a windowless request (both start/end
+// zero — e.g. a hand-rolled `q={}` with no time range) to a recent-lookback
+// window before threading it here (see internal/api/tempo/handler.go
+// handleSearch and internal/api/tempo/grpc/search.go Search, both using
+// DefaultSearchLookback), so on every search path andWindow always folds a
+// `Timestamp` bound and the inner `GROUP BY TraceId` is always windowed — the
+// whole-table aggregation is unreachable from the search path. The lowering
+// still tolerates a zero window for non-search callers (the metrics pipelines,
+// the spec/property harnesses, /traces/{id}): they pass no limit, so
+// stampSearchTraceLimit is a no-op for them and the absent window never reaches
+// andWindow.
 //
 // limit <= 0 (no /api/search limit on the context — metrics, tests, the
 // property harness, /traces/{id}) is a no-op: the plan is returned unchanged.

--- a/test/spec/chplan_print.go
+++ b/test/spec/chplan_print.go
@@ -323,6 +323,9 @@ func printNode(b *strings.Builder, n chplan.Node, depth int) {
 			fmt.Fprintf(b, "%sNestedSetAnnotate table=%s\n", indent, v.SpansTable)
 		}
 		printNode(b, v.Input, depth+1)
+	case *chplan.SearchTraceLimit:
+		fmt.Fprintf(b, "%sSearchTraceLimit traceLimit=%d\n", indent, v.TraceLimit)
+		printNode(b, v.Input, depth+1)
 	case *chplan.MetricsAggregate:
 		gb := make([]string, len(v.GroupBy))
 		for i, e := range v.GroupBy {


### PR DESCRIPTION
## Summary
Grafana Tempo Drilldown's Traces tab (`GET /api/search?q={}&limit=200`) drained every matching span into Go and truncated to `limit` only after grouping in-process — OOMKilling cerberus (2Gi) on any wide window. `CERBERUS_QUERY_MAX_SAMPLES` didn't help: the heap is dominated by wide per-row maps, not row count.

Push the bound into SQL via a new `chplan.SearchTraceLimit` node — drain only the N newest traces' spans:

```sql
SELECT s.* FROM (<input>) AS s WHERE TraceId IN (
  SELECT TraceId FROM (<input>) GROUP BY TraceId
  ORDER BY min(Timestamp) DESC, TraceId ASC LIMIT N)
```

Ranking `min(Timestamp) DESC, TraceId ASC` mirrors `sortSummariesStartDesc`, so the SQL-selected set equals what `TruncateSummaries` kept (no wire-shape change). The request time window is threaded into the predicate (reusing `parseTempoStartEnd` + the `WithSearchTraceLimit` context precedent), folded into both scans so the inner `GROUP BY` is bounded to the window. The node is registered in the optimizer (`rewriteUnaryNode`) so predicate-pushdown / FilterFusion / PREWHERE still apply on the search subtree.

## Residual limitations — both closed
- **Window-absent** `q={}` (no start/end): clamped to a `DefaultSearchLookback` (1h) window in `handleSearch` — handler-only, leaving the shared `parseTempoStartEnd` semantics (metrics, tag endpoints) untouched. The gRPC Search RPC carried the same twin and is fixed symmetrically, so all three `toTraceSummaries` drain sites are bounded.
- **Fat-trace** (one trace, millions of matched spans): kept uncapped by design — an SQL `LIMIT k BY TraceId` would cap the rows the handler sees and so cap `SpanSet.Matched`, which the tempo compatibility differ asserts byte-exact against reference Tempo's uncapped total. The fat-trace heap is instead bounded by the existing per-request sample budget (`query.maxSamples`) → 422 `TooManySamplesError`, not OOM. Documented on the node; pinned by test.

## Tests
No test failed on this bug before (`TestSearch_LimitEnforced` was stub-backed and SQL-blind). Added:
- `TestSearch_TraceLimitPushdown_BoundsDrain_ChDB` — proves the bound (24 drained rows without the fix → 9 with it).
- `..._MinRanking_ChDB` + `search_trace_limit_sql_test.go` — pin parity (min not max, window in both scans, default lookback shape, explicit window honored).
- `TestSearch_FatTrace_MatchedUncapped_BudgetBackstop` — Matched uncapped under the spss cap + 422 backstop.
- gRPC window threading; chplan `Equal` invariants.

Also: split the metric-family cases out of `emitNode` into `emitMetricNode` (the new dispatch case crossed the cyclop budget) — behaviour-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
