### PR TITLE
feat(api): O(output) drain counter + falsifiable bounds-drain regression harness

### DIFF
--- a/internal/api/prom/chaos_test.go
+++ b/internal/api/prom/chaos_test.go
@@ -164,6 +164,7 @@ func (c *chaosCursor) Next() bool {
 func (c *chaosCursor) Sample() chclient.Sample { return c.cur }
 func (c *chaosCursor) Err() error              { return c.err }
 func (c *chaosCursor) Close() error            { c.closed = true; return nil }
+func (c *chaosCursor) Inspected() int64        { return int64(c.idx) }
 
 // TestCH_UpstreamError_Returns502 — an upstream CH error must map to
 // a 502 Bad Gateway with the Prom error envelope.

--- a/internal/api/prom/export_test.go
+++ b/internal/api/prom/export_test.go
@@ -1,0 +1,23 @@
+package prom
+
+// SetOnRangeDrain installs the test-observable streaming-drain hook on the
+// handler. The hook fires once per /api/v1/query_range request with the
+// number of rows the handler pulled off the streaming cursor
+// (cursor.Inspected() after matrixFromCursor drains it) — the buffer that
+// OOMed the gateway (OOM #2: matrixFromCursor buffering O(series × scanned)
+// before truncating).
+//
+// This is the only entry point external (prom_test) tests have to read the
+// streaming-path drain count, because onRangeDrain is unexported (production
+// never installs a hook, keeping the hot path byte-unchanged). It mirrors the
+// eager path's Result.Inspected and Tempo's SearchMetrics.InspectedTraces:
+// the boundsdrain harness reads it to assert the range matrix pivot stays
+// O(output) = O(series × step) rather than O(rows scanned) as the dataset /
+// window / cardinality axis grows.
+//
+// Exposed via export_test.go so the field stays unexported in production code
+// while remaining settable from the chdb-tagged regression tests, which live
+// in package prom_test.
+func (h *Handler) SetOnRangeDrain(fn func(int64)) {
+	h.onRangeDrain = fn
+}

--- a/internal/api/prom/handler.go
+++ b/internal/api/prom/handler.go
@@ -109,6 +109,17 @@ type Handler struct {
 	// identity. The invariant is pinned by
 	// TestHandlerLang_ParserOptionsAligned.
 	parser promparser.Parser
+
+	// onRangeDrain, when non-nil, is invoked once per /api/v1/query_range
+	// request with the number of rows the handler pulled off the streaming
+	// cursor (cursor.Inspected() after matrixFromCursor drains it) — the
+	// streaming-path drain count, the buffer that OOMed the gateway. It is
+	// the test-observable hook the boundsdrain harness reads to assert the
+	// range matrix pivot stays O(output) = O(series × step) rather than
+	// O(rows scanned) as the dataset / window / cardinality axis grows.
+	// Production leaves it nil (the range handler skips the call), so the
+	// hot path is byte-unchanged; only tests install it.
+	onRangeDrain func(int64)
 }
 
 // New constructs a Handler with the seed optimizer wired in plus a
@@ -488,6 +499,13 @@ func (h *Handler) handleQueryRange(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		h.respondError(w, classifyDrainError(err))
 		return
+	}
+	// Surface the streaming-path drain count (rows pulled off the cursor =
+	// the buffer matrixFromCursor accumulated) to the test-observable hook
+	// when one is installed. Mirrors the eager path's Result.Inspected /
+	// Tempo's SearchMetrics.InspectedTraces; nil in production.
+	if h.onRangeDrain != nil {
+		h.onRangeDrain(cursor.Inspected())
 	}
 	writeEngineHeaders(w, hdr)
 	writeJSON(w, http.StatusOK, Response{

--- a/internal/api/prom/handler_bench_test.go
+++ b/internal/api/prom/handler_bench_test.go
@@ -68,6 +68,7 @@ func (c *fakeCountingCursor) Close() error {
 	c.closed = true
 	return nil
 }
+func (c *fakeCountingCursor) Inspected() int64 { return int64(c.emitted) }
 
 // cursorQuerier returns a fresh counting cursor on each QueryCursor.
 // stubQuerier (in handler_test.go) returns a sliceCursor over its

--- a/internal/api/prom/handler_chdb_boundsdrain_test.go
+++ b/internal/api/prom/handler_chdb_boundsdrain_test.go
@@ -1,0 +1,177 @@
+//go:build chdb
+
+// chDB-backed regression coverage for OOM #2: PromQL /api/v1/query_range
+// buffering O(input) instead of O(output) before truncating in Go.
+//
+// matrixFromCursor (internal/api/prom/handler.go) drains the streaming
+// cursor row-by-row into per-series buffers, then pivots to a Matrix. The
+// memory it holds is therefore exactly the row count the cursor yields. The
+// gateway OOMed because, for a wide window with dense raw samples, an
+// un-collapsed scan returned one row per RAW SAMPLE — O(series × samples) —
+// and matrixFromCursor buffered all of it before the matrix shape (and any
+// truncation) bit. The Pool-AK range-mode rework fixed this by collapsing
+// the per-step LWR on the SQL side: the scan now returns one row per
+// (series, step anchor) — O(series × step) — so the drain is bounded by the
+// OUTPUT matrix size, independent of how many raw samples each window holds.
+//
+// The blind spot that let OOM #2 through: every prior range-mode test used a
+// FIXED tiny seed (one raw sample per step), so "drain everything" and
+// "drain one-per-anchor" produced identical counts — the input axis was
+// never varied, so the drain never had room to diverge from the output. This
+// test varies the input axis (raw sample DENSITY per window) while holding
+// the output bound (series × step) fixed, and asserts the drain tracks
+// output, not input. It is wired through the shared boundsdrain harness so
+// the Tempo /api/search trace-limit pushdown (OOM #1) rides as the proven
+// reference row.
+
+package prom_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/api/prom"
+	"github.com/tsouza/cerberus/internal/chclienttest"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// Bounds-drain seed scale for the PromQL range path. The point is to make
+// the INPUT axis (raw samples) dwarf the OUTPUT axis (series × step) so a
+// bounded drain (O(output)) and an unbounded one (O(input)) produce wildly
+// different counts:
+//
+//   - drainSeriesCount distinct series (the cardinality axis),
+//   - drainStepCount step anchors across the request window (the output axis),
+//   - drainSamplesPerWindow raw samples seeded inside EACH per-step staleness
+//     window (the input-density axis the prior fixed-seed tests never varied).
+//
+// Output bound: drainSeriesCount × drainStepCount — one row per
+// (series, anchor) after the per-step LWR collapse.
+// Full seed: drainSeriesCount × drainStepCount × drainSamplesPerWindow —
+// what an un-collapsed scan would drain (the OOM count).
+//
+// With drainSamplesPerWindow = 6 the full seed is 6× the bound, comfortably
+// past boundsDrainFudge (2×): a bounded drain passes, an O(input) drain fails.
+const (
+	drainSeriesCount      = 25
+	drainStepCount        = 13
+	drainSamplesPerWindow = 6
+)
+
+// drainStep is the query_range step. The staleness window is 5m, so a step
+// of 1m keeps every step anchor's (anchor-5m, anchor] window overlapping the
+// prior anchors' samples — but the per-step argMax collapse still yields
+// exactly one row per (series, anchor), which is the property under test.
+const drainStep = time.Minute
+
+// boundsDrainPromServer builds a chDB-backed prom handler + httptest server
+// and returns both, so the caller can install the streaming-drain hook on
+// the handler before driving /api/v1/query_range. The plain newChDBServer
+// helper does not expose the handler, and the drain hook is the only way an
+// external test reads the streaming-path drain count.
+func boundsDrainPromServer(t *testing.T, seed string) (*prom.Handler, *httptest.Server) {
+	t.Helper()
+	c := chclienttest.NewChDB(t)
+	c.Seed(t, seed)
+	h := prom.New(c, schema.DefaultOTelMetrics(), nil)
+	mux := http.NewServeMux()
+	h.Mount(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return h, srv
+}
+
+// seedManySeriesDenseWindows plants drainSeriesCount series, each carrying
+// drainSamplesPerWindow distinct raw samples inside every per-step window
+// across drainStepCount anchors. The raw row count is therefore
+// drainSeriesCount × drainStepCount × drainSamplesPerWindow — the input axis
+// — while the bare-selector range query collapses to one row per
+// (series, anchor) on the SQL side — the output axis.
+func seedManySeriesDenseWindows(start time.Time) (seed string, fullSeed int64) {
+	rows := make([]string, 0, drainSeriesCount*drainStepCount*drainSamplesPerWindow)
+	for s := 0; s < drainSeriesCount; s++ {
+		inst := fmt.Sprintf("inst-%03d", s)
+		for step := 0; step < drainStepCount; step++ {
+			anchor := start.Add(time.Duration(step) * drainStep)
+			// Spread drainSamplesPerWindow raw samples through the seconds
+			// leading up to (and including) the anchor, all inside the 5m
+			// staleness window so the per-step LWR sees every one of them and
+			// must collapse them to a single argMax(Value, TimeUnix) row.
+			for k := 0; k < drainSamplesPerWindow; k++ {
+				ts := anchor.Add(-time.Duration(k) * time.Second).
+					Format("2006-01-02 15:04:05.000000000")
+				rows = append(rows, fmt.Sprintf(
+					`('demo_memory_usage_bytes', map('instance', '%s'), toDateTime64('%s', 9), %d.0)`,
+					inst, ts, s*1000+step*10+k,
+				))
+			}
+		}
+	}
+	seed = gaugeDDL + "\nINSERT INTO otel_metrics_gauge VALUES\n  " +
+		strings.Join(rows, ",\n  ") + ";"
+	return seed, int64(len(rows))
+}
+
+// promRangeDrainCase builds the PromQL /api/v1/query_range bounds-drain row.
+// It seeds many series with dense per-window samples, installs the drain
+// hook, drives a bare-selector range query at a fixed step, and returns the
+// streaming-drain count plus the full seed for the harness's two assertions.
+func promRangeDrainCase() chclienttest.BoundsDrainCase {
+	return chclienttest.BoundsDrainCase{
+		Name:        "promql/query_range/bare_selector",
+		OutputBound: int64(drainSeriesCount * drainStepCount),
+		Run: func(t *testing.T) (drain, fullSeed int64) {
+			start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+			end := start.Add(time.Duration(drainStepCount-1) * drainStep)
+
+			seed, full := seedManySeriesDenseWindows(start)
+			h, srv := boundsDrainPromServer(t, seed)
+
+			var got int64
+			h.SetOnRangeDrain(func(n int64) { got = n })
+
+			matrix := runRangeModeQueryRange(t, srv.URL,
+				"demo_memory_usage_bytes", start, end, drainStep)
+
+			// Sanity: the output really is the (series × step) matrix the
+			// bound is named for — every series present, every step anchor
+			// populated. (If the SQL returned nothing the drain would be a
+			// vacuous 0 and the bound would pass for the wrong reason.)
+			if len(matrix) != drainSeriesCount {
+				t.Fatalf("got %d series, want %d — the output matrix is not the (series × step) shape the bound names",
+					len(matrix), drainSeriesCount)
+			}
+			for _, ser := range matrix {
+				if len(ser.Values) != drainStepCount {
+					t.Fatalf("series %v: %d samples, want %d (one per step anchor)",
+						ser.Metric, len(ser.Values), drainStepCount)
+				}
+			}
+			return got, full
+		},
+	}
+}
+
+// TestBoundsDrain_ResultBufferingHandlers is the shared bounds-drain gate:
+// each row seeds at scale, drives a result-buffering handler, and the harness
+// asserts the drain is O(output) (≤ OutputBound × fudge) AND a real reduction
+// below the full seed. The PromQL row is the new high-value regression for
+// OOM #2; the Tempo row is the proven reference for OOM #1.
+// The behavioural falsifiability of this row is proven by
+// TestBoundsDrain_ResultBufferingHandlers itself: it runs matrixFromCursor end
+// to end against a real chDB drain, so neutering the SQL-side per-step argMax
+// collapse (see internal/chsql/range_lwr.go) turns the measured drain from
+// drainSeriesCount × drainStepCount into the full seed (× drainSamplesPerWindow),
+// failing the bound assertion. The PR records the measured before/after
+// (325 → 8250). The predicate that does the rejecting is unit-tested directly in
+// internal/chclienttest/boundsdrain_test.go — no separate, literal-only test
+// here, which would assert nothing about the handler.
+func TestBoundsDrain_ResultBufferingHandlers(t *testing.T) {
+	chclienttest.RunBoundsDrain(t, []chclienttest.BoundsDrainCase{
+		promRangeDrainCase(),
+	})
+}

--- a/internal/api/prom/handler_memory_limit_test.go
+++ b/internal/api/prom/handler_memory_limit_test.go
@@ -65,6 +65,7 @@ func (c *memLimitCursor) Next() bool {
 func (c *memLimitCursor) Sample() chclient.Sample { return c.cur }
 func (c *memLimitCursor) Err() error              { return c.err }
 func (c *memLimitCursor) Close() error            { return nil }
+func (c *memLimitCursor) Inspected() int64        { return int64(c.idx) }
 
 // memLimitQuerier reuses stubQuerier for every endpoint except
 // QueryCursor, which fails the drain mid-stream with the

--- a/internal/api/prom/handler_query_timeout_test.go
+++ b/internal/api/prom/handler_query_timeout_test.go
@@ -137,6 +137,7 @@ func (c *timeoutCursor) Next() bool {
 func (c *timeoutCursor) Sample() chclient.Sample { return c.cur }
 func (c *timeoutCursor) Err() error              { return c.err }
 func (c *timeoutCursor) Close() error            { return nil }
+func (c *timeoutCursor) Inspected() int64        { return int64(c.idx) }
 
 type timeoutCursorQuerier struct {
 	stubQuerier

--- a/internal/api/prom/handler_sample_budget_test.go
+++ b/internal/api/prom/handler_sample_budget_test.go
@@ -45,6 +45,7 @@ func (c *budgetCursor) Next() bool {
 func (c *budgetCursor) Sample() chclient.Sample { return c.cur }
 func (c *budgetCursor) Err() error              { return c.err }
 func (c *budgetCursor) Close() error            { return nil }
+func (c *budgetCursor) Inspected() int64        { return int64(c.idx) }
 
 // budgetQuerier reuses stubQuerier for every endpoint except
 // QueryCursor, which returns a cursor that fails the drain with the

--- a/internal/api/prom/handler_test.go
+++ b/internal/api/prom/handler_test.go
@@ -676,6 +676,16 @@ func (c *sliceCursor) Close() error {
 	return nil
 }
 
+// Inspected returns the count of Next() calls that returned true (idx
+// clamped to the slice length, since idx overshoots by one once Next
+// returns false). Mirrors the production cursor's drain count.
+func (c *sliceCursor) Inspected() int64 {
+	if c.idx > len(c.samples) {
+		return int64(len(c.samples))
+	}
+	return int64(c.idx)
+}
+
 func readBody(t *testing.T, resp *http.Response) string {
 	t.Helper()
 	defer resp.Body.Close()

--- a/internal/api/prom/label_memo_bench_test.go
+++ b/internal/api/prom/label_memo_bench_test.go
@@ -69,6 +69,12 @@ func (c *benchSliceCursor) Sample() chclient.Sample {
 }
 func (c *benchSliceCursor) Err() error   { return nil }
 func (c *benchSliceCursor) Close() error { return nil }
+func (c *benchSliceCursor) Inspected() int64 {
+	if c.idx > len(c.samples) {
+		return int64(len(c.samples))
+	}
+	return int64(c.idx)
+}
 
 func BenchmarkMatrixFromCursor_Memoised(b *testing.B) {
 	samples := benchInternedMatrixSamples(50, 60)

--- a/internal/api/prom/label_memo_bucketing_test.go
+++ b/internal/api/prom/label_memo_bucketing_test.go
@@ -49,8 +49,9 @@ func (c *seriesIDCursor) Sample() chclient.Sample {
 	return s
 }
 
-func (c *seriesIDCursor) Err() error   { return nil }
-func (c *seriesIDCursor) Close() error { return nil }
+func (c *seriesIDCursor) Err() error       { return nil }
+func (c *seriesIDCursor) Close() error     { return nil }
+func (c *seriesIDCursor) Inspected() int64 { return int64(c.idx) }
 
 // TestMatrixFromCursor_MemoPreservesBucketing pins that matrixFromCursor with
 // the label memo produces exactly the matrix the un-memoised

--- a/internal/api/prom/matrix_order_test.go
+++ b/internal/api/prom/matrix_order_test.go
@@ -98,3 +98,9 @@ func (c *orderTestCursor) Next() bool {
 func (c *orderTestCursor) Sample() chclient.Sample { return c.samples[c.idx] }
 func (c *orderTestCursor) Err() error              { return nil }
 func (c *orderTestCursor) Close() error            { return nil }
+func (c *orderTestCursor) Inspected() int64 {
+	if c.idx > len(c.samples) {
+		return int64(len(c.samples))
+	}
+	return int64(c.idx)
+}

--- a/internal/api/tempo/grpc/search_test.go
+++ b/internal/api/tempo/grpc/search_test.go
@@ -104,6 +104,7 @@ func (c *stubCursor) Close() error {
 	c.closed.Store(1)
 	return nil
 }
+func (c *stubCursor) Inspected() int64 { return int64(c.i) }
 
 // makeSearchRow returns one synthetic chclient.Sample shaped like the
 // canonical wrap-projection output: MetricName carries SpanName, the

--- a/internal/api/tempo/search_trace_limit_chdb_test.go
+++ b/internal/api/tempo/search_trace_limit_chdb_test.go
@@ -178,6 +178,31 @@ func TestSearch_TraceLimitPushdown_BoundsDrain_ChDB(t *testing.T) {
 	}
 }
 
+// TestBoundsDrain_TempoSearch_ChDB folds the trace-limit pushdown (OOM #1)
+// into the shared bounds-drain harness as the proven reference row: the same
+// seed-many / request-few / assert-O(output) shape as the PromQL range
+// regression (OOM #2), expressed once through chclienttest.RunBoundsDrain.
+// The drain count is Tempo's SearchMetrics.InspectedTraces (== len(samples)
+// the handler buffered); the output bound is searchLimit traces × spansPerTrace
+// spans; the full seed is the whole table an unbounded /api/search would drain.
+//
+// This rides alongside TestSearch_TraceLimitPushdown_BoundsDrain_ChDB above:
+// that test pins the Tempo-specific ranking/ordering invariants, this one
+// pins the drain bound via the same predicate the PromQL row uses, so both
+// OOMs are guarded by one shared, falsifiable rule.
+func TestBoundsDrain_TempoSearch_ChDB(t *testing.T) {
+	chclienttest.RunBoundsDrain(t, []chclienttest.BoundsDrainCase{{
+		Name:        "tempo/api_search/trace_limit_pushdown",
+		OutputBound: int64(searchLimit * spansPerTrace),
+		Run: func(t *testing.T) (drain, fullSeed int64) {
+			srv := newManyTracesChDBServer(t, manyTracesSeed())
+			sr := doSearch(t, srv,
+				fmt.Sprintf("/api/search?q=%%7B%%7D&limit=%d&spss=20%s", searchLimit, seedWindow))
+			return int64(sr.Metrics.InspectedTraces), int64(seedTraceCount * spansPerTrace)
+		},
+	}})
+}
+
 // rankingParitySeed builds two traces where:
 //
 //   - trace LOW has an out-of-order child whose timestamp is EARLIER than

--- a/internal/chclient/columnar.go
+++ b/internal/chclient/columnar.go
@@ -439,6 +439,12 @@ func (d *columnarCursor) Sample() Sample {
 // surfaced from QueryCursor's open call, not here, matching the row path.
 func (d *columnarCursor) Err() error { return d.err }
 
+// Inspected returns the number of rows the consumer has pulled — the count of
+// Next() calls that returned true, which is d.idx (advanced once per consumed
+// row). It matches the row path's seen-based count: the per-request drain
+// count a streaming handler buffers.
+func (d *columnarCursor) Inspected() int64 { return int64(d.idx) }
+
 // Close ends the execute span exactly once. The ch-go pool itself is owned by
 // the Client (closed on Client.Close), not the cursor — the per-query
 // connection was already released when pool.Do returned.

--- a/internal/chclient/cursor.go
+++ b/internal/chclient/cursor.go
@@ -56,11 +56,24 @@ func (e *TooManySamplesError) Unwrap() error { return ErrTooManySamples }
 // transport error rather than end-of-stream. Close() releases the
 // underlying CH resources and MUST be called exactly once, typically via
 // `defer cursor.Close()` immediately after a successful QueryCursor.
+//
+// Inspected reports the number of rows the consumer has pulled off the
+// cursor so far (the count of Next() calls that returned true). This is
+// the size of the buffer a result-buffering handler accumulates as it
+// drains — the quantity that OOMed the gateway twice (Tempo /api/search
+// and PromQL /api/v1/query_range). A handler whose memory must be O(output)
+// rather than O(input) proves it by asserting Inspected stays bounded by
+// the output limit as the input axis (dataset / window / cardinality)
+// scales; see test/chdb/boundsdrain. It mirrors the eager path's
+// len(Result.Samples) semantics — the rows that crossed from ClickHouse
+// into the process — so a streaming handler can report a drain count the
+// same way Tempo's SearchMetrics.InspectedTraces does on the eager path.
 type Cursor interface {
 	Next() bool
 	Sample() Sample
 	Err() error
 	Close() error
+	Inspected() int64
 }
 
 // rowsCursor wraps a driver.Rows and decodes each row positionally into a
@@ -316,6 +329,18 @@ func (c *rowsCursor) Sample() Sample { return c.cur }
 // Err returns any non-EOF error that terminated iteration. It is safe to
 // call after Close.
 func (c *rowsCursor) Err() error { return c.err }
+
+// Inspected returns the number of rows decoded off the wire so far: seen is
+// incremented once per row scanned, before the per-request budget / per-cursor
+// maxSamples check. On a clean drain that equals the count of Next() calls that
+// returned true — the per-request drain count a streaming handler buffers (the
+// matrix the prom /query_range pivot accumulates), the streaming-path analogue
+// of the eager path's len(Result.Samples). On a budget / maxSamples trip the
+// tripping row is included though its Next() returned false, so Inspected is
+// one higher than the buffered count; that case always sets Err(), and every
+// reader (matrixFromCursor, Client.Query) reports Inspected only after a
+// nil-error full drain, so the off-by-one is never observed.
+func (c *rowsCursor) Inspected() int64 { return c.seen }
 
 // Close releases the underlying driver.Rows. Safe to call multiple
 // times AND from multiple goroutines concurrently; the underlying

--- a/internal/chclienttest/boundsdrain.go
+++ b/internal/chclienttest/boundsdrain.go
@@ -1,0 +1,103 @@
+//go:build chdb
+
+package chclienttest
+
+import (
+	"fmt"
+	"testing"
+)
+
+// boundsDrainFudge is the slack the bound assertion allows above the
+// declared output bound. A result-buffering handler is O(output), not
+// O(input) — but "O(output)" admits a small constant factor: the matrix
+// pivot may pull a handful of rows that round to empty windows, the
+// trace-limit pushdown keeps `limit` traces but each carries a few spans,
+// etc. The harness asserts drain <= outputBound * boundsDrainFudge so a
+// genuinely-bounded handler passes while an O(input) drain (which scales
+// with the seed, far past any constant factor) fails. Keep it small: a
+// large fudge would let an unbounded drain slip through on a small seed.
+const boundsDrainFudge = 2
+
+// BoundsDrainCase is one row of the bounds-drain harness. It encodes the
+// principle the two production OOMs violated: a result-buffering handler
+// must drain O(output), not O(input). A case proves that by VARYING the
+// axis the input scales on (dataset size / window / cardinality) while
+// holding the output bound (limit / step-count) fixed, then asserting the
+// drained-row count tracks output, not input.
+//
+// Run performs the head-specific work — seed the table at scale, drive the
+// handler, and return the two numbers the harness reasons over:
+//
+//   - drain: the rows the handler pulled into its in-process buffer (the
+//     quantity that OOMed twice). Read it from the uniform drain counter:
+//     Tempo's SearchMetrics.InspectedTraces, the eager engine.Result.Inspected,
+//     or the PromQL streaming hook (cursor.Inspected() via SetOnRangeDrain).
+//   - fullSeed: the total rows the unbounded handler WOULD have drained —
+//     i.e. the full match set the seed planted. This is the degeneracy
+//     guard: without asserting drain < fullSeed, a too-small seed lets a
+//     broken (unbounded) handler pass vacuously, because on a tiny table
+//     "drain everything" and "drain the bound" coincide.
+//
+// OutputBound is the handler's declared output ceiling — the trace limit,
+// the (series × step) matrix cell count, etc. The harness asserts
+// drain <= OutputBound * boundsDrainFudge.
+type BoundsDrainCase struct {
+	Name        string
+	OutputBound int64
+	Run         func(t *testing.T) (drain, fullSeed int64)
+}
+
+// BoundsDrainViolation is the pure predicate the harness applies to one
+// case's measured numbers. It encodes the two checks that make the
+// O(output)-not-O(input) principle falsifiable:
+//
+//  1. Degeneracy guard: fullSeed must exceed outputBound, else a bounded and
+//     an unbounded handler drain the same count and the bound check is
+//     vacuous — the blind spot that shipped both OOMs (fixed tiny seeds never
+//     varied the input axis). A misconfigured seed is itself a violation.
+//  2. Bound: drain <= outputBound * boundsDrainFudge AND drain < fullSeed.
+//     The handler buffered only (a small constant factor of) its output, and
+//     that buffer is a REAL reduction below what an unbounded drain would
+//     have pulled.
+//
+// It returns ok=false with a human-readable reason on any violation. Keeping
+// it pure (no *testing.T) lets the falsifiability test assert directly that a
+// bounded count passes and an unbounded count fails, without spinning a
+// nested test runner.
+func BoundsDrainViolation(drain, outputBound, fullSeed int64) (ok bool, reason string) {
+	if fullSeed <= outputBound {
+		return false, fmt.Sprintf("seed misconfigured: fullSeed=%d must exceed outputBound=%d, "+
+			"otherwise a bounded and an unbounded handler are indistinguishable "+
+			"(the blind spot that shipped both OOMs)", fullSeed, outputBound)
+	}
+	maxDrain := outputBound * boundsDrainFudge
+	if drain > maxDrain {
+		return false, fmt.Sprintf("drain=%d exceeds bound %d (outputBound=%d × fudge=%d): "+
+			"the handler buffered O(input), not O(output) — on a seed of %d this is the "+
+			"unbounded drain that OOMs", drain, maxDrain, outputBound, boundsDrainFudge, fullSeed)
+	}
+	if drain >= fullSeed {
+		return false, fmt.Sprintf("drain=%d did not reduce below full seed %d: the handler "+
+			"drained the whole match set (the OOM bug); a bound that keeps everything is no bound",
+			drain, fullSeed)
+	}
+	return true, ""
+}
+
+// RunBoundsDrain executes a table of BoundsDrainCase rows, applying
+// BoundsDrainViolation to each case's measured (drain, fullSeed) against its
+// declared OutputBound. Every case must scale its seed so fullSeed
+// comfortably exceeds OutputBound; the degeneracy guard fails the row loudly
+// if it does not, so a future edit that shrinks a seed below the bound cannot
+// silently defang it.
+func RunBoundsDrain(t *testing.T, cases []BoundsDrainCase) {
+	t.Helper()
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			drain, fullSeed := tc.Run(t)
+			if ok, reason := BoundsDrainViolation(drain, tc.OutputBound, fullSeed); !ok {
+				t.Errorf("%s: %s", tc.Name, reason)
+			}
+		})
+	}
+}

--- a/internal/chclienttest/boundsdrain_test.go
+++ b/internal/chclienttest/boundsdrain_test.go
@@ -1,0 +1,102 @@
+//go:build chdb
+
+package chclienttest
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestBoundsDrainViolation_Predicate pins the three rejections that make the
+// O(output)-not-O(input) principle falsifiable, exercising the pure predicate
+// every RunBoundsDrain row reasons over. This is a UNIT test of the predicate,
+// not a stand-in for a handler test: it proves the gate's arithmetic rejects an
+// unbounded drain (so a real behavioural row — e.g. the PromQL query_range row
+// in api/prom — cannot pass on the OOM bug it guards) and accepts a bounded
+// one. The behavioural proof that a handler's measured drain actually feeds
+// these numbers lives in the harness rows themselves.
+func TestBoundsDrainViolation_Predicate(t *testing.T) {
+	// Shared scale: a bound well below the full match set, so the degeneracy
+	// guard is satisfied and bounded vs unbounded are distinguishable — the
+	// exact configuration the two production OOMs lacked.
+	const (
+		outputBound = 100
+		fullSeed    = 600 // 6× the bound, mirroring the PromQL row's density axis
+	)
+
+	cases := []struct {
+		name     string
+		drain    int64
+		bound    int64
+		fullSeed int64
+		wantOK   bool
+		wantWhy  string // substring the rejection reason must contain
+	}{
+		{
+			// The fixed handler: drains exactly its output bound.
+			name:  "bounded drain accepted",
+			drain: outputBound,
+			bound: outputBound, fullSeed: fullSeed,
+			wantOK: true,
+		},
+		{
+			// Falsifiability: the neutered handler drains the full match set.
+			// The predicate MUST reject it, or the gate cannot fail on the bug.
+			name:  "unbounded drain rejected",
+			drain: fullSeed,
+			bound: outputBound, fullSeed: fullSeed,
+			wantOK:  false,
+			wantWhy: "buffered O(input)",
+		},
+		{
+			// A drain at the fudge ceiling passes; one row past it fails — the
+			// fudge admits a small constant factor, not an O(input) blow-up.
+			name:  "drain at fudge ceiling accepted",
+			drain: outputBound * boundsDrainFudge,
+			bound: outputBound, fullSeed: fullSeed,
+			wantOK: true,
+		},
+		{
+			name:  "drain past fudge ceiling rejected",
+			drain: outputBound*boundsDrainFudge + 1,
+			bound: outputBound, fullSeed: fullSeed,
+			wantOK:  false,
+			wantWhy: "exceeds bound",
+		},
+		{
+			// Degeneracy guard: a seed that does not exceed the bound makes a
+			// bounded and an unbounded handler indistinguishable — itself a
+			// violation, regardless of the drain count.
+			name:  "degenerate seed rejected",
+			drain: outputBound,
+			bound: outputBound, fullSeed: outputBound,
+			wantOK:  false,
+			wantWhy: "fullSeed",
+		},
+		{
+			// A "bound" that keeps the whole match set is no bound: a drain
+			// within the fudge ceiling but not below fullSeed must still fail.
+			// Requires fullSeed > bound (pass the degeneracy guard) and
+			// drain in [fullSeed, bound*fudge], so the drain>=fullSeed branch is
+			// the one that fires: bound=100, fullSeed=150, drain=150 (≤ 200).
+			name:  "no reduction below full seed rejected",
+			drain: outputBound + outputBound/2,                        // 150
+			bound: outputBound, fullSeed: outputBound + outputBound/2, // fullSeed 150 > bound 100
+			wantOK:  false,
+			wantWhy: "did not reduce below full seed",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ok, reason := BoundsDrainViolation(tc.drain, tc.bound, tc.fullSeed)
+			if ok != tc.wantOK {
+				t.Fatalf("BoundsDrainViolation(drain=%d, bound=%d, fullSeed=%d) ok=%v, want %v (reason=%q)",
+					tc.drain, tc.bound, tc.fullSeed, ok, tc.wantOK, reason)
+			}
+			if !tc.wantOK && !strings.Contains(reason, tc.wantWhy) {
+				t.Fatalf("rejection reason %q does not mention %q", reason, tc.wantWhy)
+			}
+		})
+	}
+}

--- a/internal/chclienttest/cursor.go
+++ b/internal/chclienttest/cursor.go
@@ -12,6 +12,11 @@ type sliceCursor struct {
 	samples []chclient.Sample
 	idx     int
 	cur     chclient.Sample
+	// drained counts Next() calls that returned true — the rows the consumer
+	// pulled off the cursor. Mirrors the production rowsCursor.seen counter so
+	// the boundsdrain harness can read a drain count from the chdb test cursor
+	// exactly as it does from the prod cursor.
+	drained int64
 }
 
 func newSliceCursor(samples []chclient.Sample) *sliceCursor {
@@ -24,9 +29,15 @@ func (c *sliceCursor) Next() bool {
 		return false
 	}
 	c.cur = c.samples[c.idx]
+	c.drained++
 	return true
 }
 
 func (c *sliceCursor) Sample() chclient.Sample { return c.cur }
 func (c *sliceCursor) Err() error              { return nil }
 func (c *sliceCursor) Close() error            { return nil }
+
+// Inspected returns the number of rows the consumer pulled — the count of
+// Next() calls that returned true. Matches the production cursor's seen-based
+// drain count so a streaming-path test reads the buffer size identically.
+func (c *sliceCursor) Inspected() int64 { return c.drained }

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -347,6 +347,17 @@ type Result struct {
 	// Parse (or that QueryPlan was called with), threaded through
 	// so the handler-side response pivot can switch on it.
 	Meta Meta
+	// Inspected is the number of rows the engine pulled from ClickHouse
+	// for this request — the size of the buffer a result-buffering
+	// handler accumulates before it truncates / reshapes in Go. On the
+	// eager path it equals len(Samples) (Client.Query drains the whole
+	// result into the slice), the same quantity Tempo already reports as
+	// SearchMetrics.InspectedTraces. It is the uniform per-response drain
+	// counter the boundsdrain harness asserts stays O(output) as the
+	// input axis scales; the streaming sibling lives on the cursor as
+	// chclient.Cursor.Inspected (CursorResult carries the cursor, so the
+	// caller reads the count off it after the drain).
+	Inspected int64
 }
 
 // Query runs the full pipeline for an upstream query string: it asks
@@ -455,6 +466,9 @@ func (e *Engine) QueryPlan(ctx context.Context, lang Lang, plan chplan.Node, met
 		PlanNodeCount: nodes,
 		Headers:       headers,
 		Meta:          meta,
+		// Eager path: Client.Query drained the whole result into samples,
+		// so the slice length IS the rows-from-CH drain count.
+		Inspected: int64(len(samples)),
 	}, nil
 }
 
@@ -536,6 +550,10 @@ func (e *Engine) executeRouted(
 		PlanNodeCount: nodes,
 		Headers:       headers,
 		Meta:          meta,
+		// Routed eager path drained the composed shard cursor into samples,
+		// so the slice length is the rows-from-CH drain count (equal to the
+		// cursor's Inspected/emitted).
+		Inspected: int64(len(samples)),
 	}, nil
 }
 

--- a/internal/solver/cursor.go
+++ b/internal/solver/cursor.go
@@ -210,6 +210,12 @@ func (sc *shardCursor) reintern(labels map[string]string) (map[string]string, ui
 // Sample returns the row the most recent successful Next landed on.
 func (sc *shardCursor) Sample() chclient.Sample { return sc.cur }
 
+// Inspected returns the number of composed rows handed out via Next — the
+// emitted counter the output-row cap is enforced against. It is the routed
+// path's drain count, the same per-request quantity the single-cursor row
+// path reports via seen.
+func (sc *shardCursor) Inspected() int64 { return sc.emitted }
+
 // Err returns the terminal error that stopped iteration, or nil at a clean
 // end-of-stream. First-error-wins, cause-threaded: a sibling's induced
 // cancel never masks the deterministic shard error.

--- a/internal/solver/exec_fakes_test.go
+++ b/internal/solver/exec_fakes_test.go
@@ -163,6 +163,7 @@ func (c *fakeCursor) Next() bool {
 
 func (c *fakeCursor) Sample() chclient.Sample { return c.cur }
 func (c *fakeCursor) Err() error              { return c.err }
+func (c *fakeCursor) Inspected() int64        { return int64(c.i) }
 
 func (c *fakeCursor) Close() error {
 	c.closeOnce.Do(func() {

--- a/test/consumer-corpus/stub.go
+++ b/test/consumer-corpus/stub.go
@@ -92,6 +92,7 @@ func (c *sliceCursor) Next() bool {
 func (c *sliceCursor) Sample() chclient.Sample { return c.samples[c.i-1] }
 func (c *sliceCursor) Err() error              { return nil }
 func (c *sliceCursor) Close() error            { return nil }
+func (c *sliceCursor) Inspected() int64        { return int64(c.i) }
 
 // Stub-lane time anchors. Every canned fixture timestamps its rows
 // against these, and StubTokens derives the request windows from the

--- a/test/regression/goleak_test.go
+++ b/test/regression/goleak_test.go
@@ -97,6 +97,12 @@ func (c *goleakSliceCursor) Next() bool {
 func (c *goleakSliceCursor) Sample() chclient.Sample { return c.cur }
 func (c *goleakSliceCursor) Err() error              { return nil }
 func (c *goleakSliceCursor) Close() error            { return nil }
+func (c *goleakSliceCursor) Inspected() int64 {
+	if c.idx > len(c.samples) {
+		return int64(len(c.samples))
+	}
+	return int64(c.idx)
+}
 
 func TestNoGoroutineLeak_PromQuery(t *testing.T) {
 	defer goleak.VerifyNone(t, goleakOpts()...)


### PR DESCRIPTION
feat(api): O(output) drain counter + falsifiable bounds-drain regression harness

Closes the test-framework blind spot that let two production OOMs ship —
both the same bug: a handler buffering O(input) rows instead of O(output)
before truncating in Go. Every test layer was blind because it either
stubbed the querier (drain invisible) or used a fixed tiny seed (the axis
the bug scales on was never varied).

- D1 — uniform drain counter. engine.Result.Inspected (eager paths:
  len(samples), on Prom/Loki/Tempo-HTTP) and chclient.Cursor.Inspected()
  (streaming: rows pulled from CH), aligned with Tempo's InspectedTraces
  vocabulary. A test-observable onRangeDrain hook on the prom handler
  exposes the matrixFromCursor drain (nil in production; hot path
  byte-unchanged).
- boundsdrain harness (internal/chclienttest, build-tag chdb): table-driven
  seed-many / request-few / assert-O(output). The pure predicate
  BoundsDrainViolation asserts drain <= outputBound*fudge AND
  drain < fullSeed AND fullSeed > outputBound (the degeneracy guard that
  rejects the too-small seed which shipped both OOMs).
- PromQL /api/v1/query_range regression — the catch for OOM #2
  (matrixFromCursor). Falsifiability proven empirically: fixed code
  drains 325 (= series*step = the O(output) bound); neutering the
  per-(series,anchor) LWR collapse drains 8250 → FAIL.
- Tempo /api/search folded in as the proven reference row.

Known follow-ups (documented, not blockers): Loki has the counter plumbed
but no harness row yet; PromQL instant + Tempo gRPC search are uncovered
(now one-line fixes given Cursor.Inspected exists). A static drain gate was
deliberately NOT shipped: the drain-into-slice shape is syntactically
identical for bounded vs unbounded handlers (the bound lives in the
plan/SQL, invisible at cursor.Next()), so a grep gate would fire on every
correct streaming handler — the behavioral harness is the sound layer.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
