### PR TITLE
fix(test): thread a time window into the TraceQL property harness

### DIFF
--- a/test/property/gen/traceql.go
+++ b/test/property/gen/traceql.go
@@ -325,9 +325,11 @@ func deterministicSpanID(seed, salt int) string {
 // draws across the pool uniformly, and the dataset's spans cover only
 // a subset of TraceQLServicePool on any iteration.
 //
-// EvalTs is irrelevant for TraceQL search (no time range threading)
-// so it's stamped at TraceQLAnchorTime() + 1h purely for log
-// completeness.
+// EvalTs is stamped at TraceQLAnchorTime() + 1h for log completeness.
+// /api/search DOES thread a time range now (the harness sends an explicit
+// window bracketing the anchor — see runCerberusTraceQL — so the
+// DefaultSearchLookback clamp doesn't filter this historically-anchored
+// dataset out), but the query value itself doesn't carry it.
 func TraceQLQuery(d property.Dataset) *rapid.Generator[property.Query] {
 	return rapid.Custom(func(t *rapid.T) property.Query {
 		// Draw service value — always from the global pool so half the

--- a/test/property/traceql_test.go
+++ b/test/property/traceql_test.go
@@ -151,8 +151,24 @@ func TestTraceQL_Property(t *testing.T) {
 // (SpanName, Timestamp) — the generator already avoids that collapse
 // by stamping unique suffixes, but reading from InspectedTraces makes
 // the comparator robust against a future generator widening.
+// propertyWindowMarginSec brackets the dataset anchor by ~a year on each
+// side — wide enough that the /api/search window can never clip a generated
+// span, while still being a real (non-windowless) request that skips the
+// DefaultSearchLookback clamp.
+const propertyWindowMarginSec int64 = 366 * 24 * 60 * 60
+
 func runCerberusTraceQL(ctx context.Context, baseURL string, q property.Query) property.Outcome {
-	u := fmt.Sprintf("%s/api/search?q=%s", baseURL, urlEscape(q.String))
+	// Thread an explicit time window bracketing the dataset anchor. A
+	// windowless /api/search clamps to [now-1h, now] (DefaultSearchLookback,
+	// added with the trace-limit/window pushdown); this dataset is stamped at
+	// a fixed historical anchor (gen.TraceQLAnchorTime), so a windowless
+	// request would filter every span out and drift from the window-less
+	// oracle. Both bounds present skips the clamp; the wide margin can't clip
+	// any generated span (the oracle has no window concept, so over-wide is
+	// safe). Tests what Grafana's Traces Drilldown actually sends — a window.
+	anchorSec := gen.TraceQLAnchorTime().Unix()
+	startSec, endSec := anchorSec-propertyWindowMarginSec, anchorSec+propertyWindowMarginSec
+	u := fmt.Sprintf("%s/api/search?q=%s&start=%d&end=%d", baseURL, urlEscape(q.String), startSec, endSec)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
 	if err != nil {
 		return property.Outcome{Err: fmt.Errorf("property: build request: %w", err)}


### PR DESCRIPTION
Fixes the `property` workflow, red on main since #1027. The windowless-search lookback clamp filtered the historically-anchored property dataset out; the harness now sends an explicit window bracketing the anchor (mirrors Grafana). `TestTraceQL_Property` verified green locally (chdb).

🤖 Generated with [Claude Code](https://claude.com/claude-code)