### PR TITLE
chore(release): cerberus v1.4.0 / chart 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to cerberus will be documented in this file. The format roug
 
 ## [Unreleased]
 
+## [v1.4.0] — 2026-06-22
+
+### Added
+
+- **chart:** split mode — isolated per-head deployments (no proxy) (#1031)
+- **api:** O(output) drain counter + falsifiable bounds-drain regression harness (#1030)
+- **config:** add CERBERUS_ENABLED_HEADS per-head toggle (#1029)
+
+### Fixed
+
+- **test:** thread a time window into the TraceQL property harness (#1032)
+- **config:** default-on per-query sample budget at 5M (#1028)
+- **tempo:** bound /api/search drain with SQL trace-limit + window pushdown (#1027)
+
 ## [v1.3.0] — 2026-06-19
 
 ### Added

--- a/deploy/helm/cerberus/Chart.yaml
+++ b/deploy/helm/cerberus/Chart.yaml
@@ -8,11 +8,11 @@ type: application
 # upgrade?" and is the publish trigger: a chart-only fix bumps this without an
 # app re-tag; an app-only release bumps appVersion + a PATCH here for the new
 # default image. Starts 0.x because the values contract is not yet frozen.
-version: 0.6.0
+version: 0.6.1
 
 # appVersion tracks the GA cerberus binary. Quoted so SemVer-shaped values
 # aren't coerced to floats. image.tag defaults from this when left empty.
-appVersion: "1.3.0"
+appVersion: "1.4.0"
 
 # autoscaling/v2 + policy/v1 (PDB) + networking/v1 (Ingress) are all GA from
 # 1.21+; 1.23 is the conservative floor matching the manifests this chart
@@ -45,11 +45,19 @@ annotations:
       url: https://github.com/tsouza/cerberus/blob/main/docs/operations.md
   artifacthub.io/images: |
     - name: cerberus
-      image: ghcr.io/tsouza/cerberus:v1.3.0
+      image: ghcr.io/tsouza/cerberus:v1.4.0
   # Bump the `1.0.0` floor here when the chart raises its minimum supported
   # cerberus release; informational for Artifact Hub's compatibility hints.
   artifacthub.io/changes: |
     - kind: added
-      description: "config: accept humanized byte sizes (2Gi) for memory caps, BWC-preserving (#1017)"
+      description: "chart: split mode — isolated per-head deployments (no proxy) (#1031)"
+    - kind: added
+      description: "api: O(output) drain counter + falsifiable bounds-drain regression harness (#1030)"
+    - kind: added
+      description: "config: add CERBERUS_ENABLED_HEADS per-head toggle (#1029)"
     - kind: fixed
-      description: "telemetry: apply CERBERUS_LOG_LEVEL to the OTLP slog bridge (stop debug leaking to otel_logs) (#1018)"
+      description: "test: thread a time window into the TraceQL property harness (#1032)"
+    - kind: fixed
+      description: "config: default-on per-query sample budget at 5M (#1028)"
+    - kind: fixed
+      description: "tempo: bound /api/search drain with SQL trace-limit + window pushdown (#1027)"

--- a/deploy/helm/cerberus/README.md
+++ b/deploy/helm/cerberus/README.md
@@ -5,7 +5,7 @@
      pipe-aligned, and the version footer adds a trailing blank — both are
      owned by helm-docs; realigning would fight the chart-ci drift check. -->
 
-![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.0](https://img.shields.io/badge/AppVersion-1.3.0-informational?style=flat-square)
+![Version: 0.6.1](https://img.shields.io/badge/Version-0.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.4.0](https://img.shields.io/badge/AppVersion-1.4.0-informational?style=flat-square)
 
 Drop-in Prometheus / Loki / Tempo HTTP gateway for ClickHouse — a single stateless gateway that speaks three upstream query wire formats and lowers each to parameterised ClickHouse SQL.
 


### PR DESCRIPTION
Release-prep for **v1.3.2** (chart **0.5.3**), generated by `prepare-release.yml`.

- appVersion 1.3.0 -> 1.3.2, chart 0.5.2 -> 0.5.3

### Changes

### Fixed

- **test:** thread a time window into the TraceQL property harness (#1032)
- **config:** default-on per-query sample budget at 5M (#1028)
- **tempo:** bound /api/search drain with SQL trace-limit + window pushdown (#1027)

Generated from the conventional commits since the last tag. Review and edit before merging; the tag is cut once this lands.
