### PR TITLE
fix(e2e): re-provision Grafana after split-mode datasource rewrite

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -518,9 +518,25 @@ e2e-up: e2e-down
     kubectl apply -k test/e2e/k3s/
     @# In split mode the chart-managed datasource hostnames change (each head
     @# gets its own bare-named Service), so rewrite the Grafana datasource
-    @# ConfigMap to point each datasource type at its head Service BEFORE
-    @# Grafana provisions. In monolith mode the kustomize-applied ConfigMap
-    @# (url: http://cerberus:8080) is already correct.
+    @# ConfigMap to point each datasource type at its head Service. In monolith
+    @# mode the kustomize-applied ConfigMap (url: http://cerberus:8080) is
+    @# already correct.
+    @#
+    @# Grafana provisions datasources into its DB ONCE, at boot, from the
+    @# mounted ConfigMap file — and the kubelet's ConfigMap→volume sync lags a
+    @# pod's startup by tens of seconds. So updating the ConfigMap object after
+    @# `apply -k` has already created the Grafana Deployment does NOT change what
+    @# Grafana provisioned: it boots from the original `http://cerberus:8080`
+    @# and never re-reads. In split that URL resolves to the NodePort-alias
+    @# Service, which selects ONLY the prometheus head, so loki/tempo datasource
+    @# queries hit the prometheus process (no /loki/* or /api/* routes) and 404
+    @# — the v1.4.0 split-mode dashboard-lane breakage.
+    @#
+    @# Fix: after updating the ConfigMap, BLOCK until the kubelet has synced the
+    @# per-head URLs into the running Grafana pod's mounted file, THEN restart
+    @# Grafana so it re-provisions from the corrected file. Polling the mounted
+    @# file (not a fixed sleep) makes the restart race-free: Grafana only
+    @# re-reads once the new content is actually on disk.
     @if [ "{{E2E_MODE}}" = "split" ]; then \
         echo "==> [split] rewriting Grafana datasource URLs to per-head Services"; \
         kubectl -n cerberus get configmap grafana-datasources -o jsonpath='{.data.datasources\.yaml}' \
@@ -529,6 +545,19 @@ e2e-up: e2e-down
         kubectl -n cerberus create configmap grafana-datasources \
             --from-file=datasources.yaml=/tmp/cerberus-e2e-ds-split.yaml \
             --dry-run=client -o yaml | kubectl apply -f -; \
+        echo "==> [split] waiting for the per-head datasource URLs to sync into the Grafana pod"; \
+        kubectl -n cerberus rollout status deployment/grafana --timeout=120s; \
+        synced=0; \
+        for attempt in $(seq 1 60); do \
+            if kubectl -n cerberus exec deploy/grafana -- grep -q 'url: http://loki:8080' /etc/grafana/provisioning/datasources/datasources.yaml 2>/dev/null; then \
+                synced=1; break; \
+            fi; \
+            sleep 2; \
+        done; \
+        [ "$synced" = "1" ] || { echo "ERROR: per-head datasource URLs never synced into the Grafana pod after 120s" >&2; exit 1; }; \
+        echo "==> [split] restarting Grafana so it re-provisions datasources from the corrected file"; \
+        kubectl -n cerberus rollout restart deployment/grafana; \
+        kubectl -n cerberus rollout status deployment/grafana --timeout=120s; \
     fi
     @# cerberus is deployed via its OWN Helm chart so the e2e cluster dogfoods
     @# the published chart (deploy/helm/cerberus) — a chart bug now fails the


### PR DESCRIPTION
## Problem

The v1.4.0 `mode: split` chart (per-head k8s Deployments, opt-in) is **broken at runtime in the dashboard e2e lane**. The nightly e2e (run 28002642584, job 82878022060, `dashboard-shard (shard-smoke-b-split)`) failed with 35 Tempo + Loki spec failures. `split_isolation.spec.ts` failed at its **pre-kill** check:

```
loki serves before kill: expected true received false
```

i.e. Loki (and Tempo) were already not-serving *before any head was scaled down*. This is a real bug, not flakiness.

## Root cause — a Grafana provisioning race in `just e2e-up E2E_MODE=split`, not the chart

The chart itself is correct. `helm template … --values cerberus-values.yaml --values cerberus-values-split.yaml` renders three bare-named ClusterIP Services (prometheus / loki / tempo), each selecting its own head Deployment, each Deployment getting the right `CERBERUS_ENABLED_HEADS` token. `go test ./cmd/cerberus/ -run TestMountAPIHeads` confirms each head mounts only its own routes. The head pods are healthy — **direct in-cluster curls to every head returned 200**:

| target (direct, in-cluster) | result |
|---|---|
| `prometheus:8080/api/v1/query?query=up` | `HTTP 200` |
| `loki:8080/loki/api/v1/labels` | `HTTP 200`, `status:success` + 12 labels |
| `tempo:8080/api/echo` | `HTTP 200`, `echo` |
| each head's `/readyz` | `{"clickhouse":"ok","schema":"ready"}` 200 |

The break is purely in the **Grafana datasource-proxy path**, and only for the two non-prometheus heads:

| through Grafana proxy (the path the specs use) | before fix |
|---|---|
| `proxy/uid/cerberus-prometheus/api/v1/query?query=up` | `HTTP 200` |
| `proxy/uid/cerberus-loki/loki/api/v1/labels` | **`HTTP 404`** |
| `proxy/uid/cerberus-tempo/api/echo` | **`HTTP 404`** |

Grafana's loaded datasources all still pointed at `url: http://cerberus:8080` — **not** the rewritten per-head URLs.

In split mode `e2e-up` rewrites the Grafana datasource ConfigMap from `http://cerberus:8080` to per-head URLs (`http://{prometheus,loki,tempo}:8080`). But that rewrite ran **after** `kubectl apply -k` had already created the Grafana Deployment. **Grafana provisions datasources into its DB once, at boot, from the mounted ConfigMap file** — and the kubelet's ConfigMap→volume sync lags pod startup by tens of seconds (measured **~52s** on k3d). So Grafana booted, provisioned the stale `http://cerberus:8080`, and never re-read the corrected file.

`http://cerberus:8080` resolves to the split **NodePort-alias Service**, whose selector targets **only the prometheus head**. So Prometheus queries worked through the proxy, but Loki/Tempo queries hit the prometheus process — which mounts neither `/loki/*` nor the Tempo `/api/*` routes — and got 404. That is exactly the pre-kill failure shape.

## Fix

After updating the ConfigMap, **block until the kubelet has synced the per-head URLs into the running Grafana pod's mounted file, then `rollout restart` Grafana** so it re-provisions from the corrected file. Polling the mounted file (not a fixed sleep) makes the restart race-free — Grafana only re-reads once the new content is on disk. One-line change in scope: split-only, monolith path untouched.

## Verification (local k3d split cluster)

1. Reproduced: stale Grafana → `loki`/`tempo` proxy = `HTTP 404`, prom = 200.
2. Applied the new `e2e-up` split logic against the stale state → poll reported `synced=1 after 26 attempts` (~52s), restart re-provisioned.
3. Post-fix proxy curls: prom / loki / tempo all `HTTP 200` (loki `status:success`, tempo `echo`).
4. Playwright in split mode (`CERBERUS_MODE=split`):
   - `split_isolation.spec.ts` — **1 passed** (the exact nightly failure).
   - `datasource_health.spec.ts` + `tempo_traces.spec.ts` + `loki_logs.spec.ts` — **12/12 passed**.

## v1.4.1 recommendation

**This does NOT need a v1.4.1 patch.** The bug is entirely in the e2e harness (`just e2e-up`), not in the shipped chart or binary. `helm template` renders the split topology correctly and the head pods serve correctly in-cluster — a real operator pointing Grafana at the per-head Services from the start is unaffected. No chart/binary artifact changed, so there is nothing to re-release. (If a follow-up wants belt-and-braces, the chart could optionally ship per-head datasource provisioning, but that is enhancement, not a regression fix.)

## Follow-up: split_isolation deserves its own shard

`split_isolation.spec.ts` currently lives on `shard-smoke-b` (`.github/scripts/dashboard-matrix.mjs`) alongside `tempo_*` / `service_graph` specs. It scales the **shared** Tempo head to zero and relies on an `afterAll` restore. Even with serving fixed, co-sharding a head-killing test with other specs of that same head is risky under Playwright retries (a retried tempo spec could overlap the window where tempo is scaled down). Recommend moving `split_isolation.spec.ts` to a dedicated split shard that carries no other tempo/loki specs. Left as a separate change to keep this fix focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)