### PR TITLE
ci(release): make opening a release PR label-triggered

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -133,8 +133,27 @@ wrapper, plus `appendStepSummary` / `setOutput` for the runner files.
     `preflight,goreleaser,chart-release`).
   - Exit: `0` when the tag is main HEAD and every non-self check is settled
     green, `1` otherwise (with one `::error::` per running/red lane).
-- **`prepare-release.mjs`** — `prepare-release.yml`, the manual release-staging
-    workflow. Bumps the chart `version:` + `appVersion:`, the image tag, and the
+- **`resolve-release-trigger.mjs`** — `prepare-release.yml`, the `resolve
+    trigger` step. Normalises the workflow's two entrypoints — a manual
+    `workflow_dispatch` and an `issues: labeled` event — into the
+    `version`/`bump`/`chart_bump` outputs the `stage release files` step
+    (`prepare-release.mjs`) consumes. On dispatch it passes the three inputs
+    through verbatim; on a label it parses `github.event.label.name`:
+    `release:patch|minor|major` -> `bump=<that>`, `chart_bump=patch`;
+    `release:<semver>` (e.g. `release:1.4.2`) -> `version=<semver>` (v-prefix
+    stripped), `chart_bump=patch`; anything else under `release:` is an error.
+    `prepare-release.mjs` still owns the value semantics (explicit VERSION
+    overrides BUMP, BUMP=none is its no-op placeholder); this resolver only
+    decides which event shape supplied them. Pure exported `resolve(env)` + a
+    `--self-test` the workflow runs before it stages anything.
+  - Env: `EVENT_NAME` (`workflow_dispatch` | `issues`); dispatch path reads
+    `VERSION` / `BUMP` / `CHART_BUMP`; issues path reads `LABEL_NAME`;
+    `GITHUB_OUTPUT` (runner-provided; sets `version` / `bump` / `chart_bump`).
+  - Exit: `0` after writing the outputs (or a green self-test), `1` on an
+    unrecognised `release:` label or an unsupported event.
+- **`prepare-release.mjs`** — `prepare-release.yml`, the release-staging
+    workflow (`workflow_dispatch` or an `issues: labeled` `release:*` trigger;
+    see `resolve-release-trigger.mjs`). Bumps the chart `version:` + `appVersion:`, the image tag, and the
     Artifact Hub `changes` annotation, and rewrites the CHANGELOG `[Unreleased]`
     section into a dated `## [vX.Y.Z]` one — deriving the change summary and the
     PR body from the conventional commits since the last `v*` tag. The commit

--- a/.github/scripts/resolve-release-trigger.mjs
+++ b/.github/scripts/resolve-release-trigger.mjs
@@ -1,0 +1,158 @@
+// Command resolve-release-trigger normalises the two entrypoints into
+// `prepare-release.yml` — a manual `workflow_dispatch` and an `issues:
+// labeled` event — into the three values the downstream `stage release files`
+// step (prepare-release.mjs) consumes: `version`, `bump`, `chart_bump`.
+//
+// It writes those three keys to $GITHUB_OUTPUT (and echoes them) so the
+// workflow can feed `steps.<id>.outputs.{version,bump,chart_bump}` into the
+// staging step's env regardless of which trigger fired. prepare-release.mjs
+// owns the semantics of the values (explicit VERSION overrides BUMP, BUMP=none
+// is its no-op placeholder, CHART_BUMP defaults to patch); this resolver only
+// decides which of the two event shapes supplied them.
+//
+// Env:
+//   EVENT_NAME  GitHub event name: "workflow_dispatch" or "issues".
+//
+//   workflow_dispatch path (reads the three dispatch inputs verbatim):
+//     VERSION     explicit target appVersion (e.g. "1.2.0"); may be empty
+//     BUMP        none | patch | minor | major
+//     CHART_BUMP  patch | minor | major (default patch when empty)
+//
+//   issues path (parses the just-applied label):
+//     LABEL_NAME  the github.event.label.name, e.g. "release:minor" or
+//                 "release:1.4.2". The contract:
+//                   release:patch|minor|major  -> bump=<that>, chart_bump=patch
+//                   release:<semver>           -> version=<semver>, chart_bump=patch
+//                 anything else under `release:` is an error.
+//
+//   GITHUB_OUTPUT  runner file for step outputs (optional; echoed when absent).
+//
+// argv `--self-test` runs the in-process assertion suite and exits.
+import process from 'node:process';
+import { error, setOutput, log } from './lib/gh.mjs';
+
+const LABEL_PREFIX = 'release:';
+const LEVELS = new Set(['patch', 'minor', 'major']);
+const SEMVER = /^v?\d+\.\d+\.\d+$/;
+const DEFAULT_CHART_BUMP = 'patch';
+
+// resolve() returns { version, bump, chart_bump } from a plain env object, or
+// throws Error on bad input. Pure (no I/O) so the self-test can drive it.
+export function resolve(env) {
+  const eventName = (env.EVENT_NAME || '').trim();
+
+  if (eventName === 'workflow_dispatch') {
+    // Pass the dispatch inputs through untouched; prepare-release.mjs owns
+    // the VERSION-overrides-BUMP and BUMP=none placeholder semantics.
+    return {
+      version: (env.VERSION || '').trim(),
+      bump: (env.BUMP || '').trim(),
+      chart_bump: (env.CHART_BUMP || '').trim() || DEFAULT_CHART_BUMP,
+    };
+  }
+
+  if (eventName === 'issues') {
+    const label = (env.LABEL_NAME || '').trim();
+    if (!label.startsWith(LABEL_PREFIX)) {
+      throw new Error(`label "${label}" is not a release: label`);
+    }
+    const arg = label.slice(LABEL_PREFIX.length).trim();
+    if (LEVELS.has(arg)) {
+      return { version: '', bump: arg, chart_bump: DEFAULT_CHART_BUMP };
+    }
+    if (SEMVER.test(arg)) {
+      return { version: arg.replace(/^v/, ''), bump: '', chart_bump: DEFAULT_CHART_BUMP };
+    }
+    throw new Error(
+      `unrecognised release label "${label}": expected ` +
+        `release:patch|minor|major or release:<semver> (e.g. release:1.4.2)`,
+    );
+  }
+
+  throw new Error(`unsupported EVENT_NAME "${eventName}" (want workflow_dispatch or issues)`);
+}
+
+function main() {
+  let out;
+  try {
+    out = resolve(process.env);
+  } catch (e) {
+    error(`resolve-release-trigger: ${e.message}`);
+    process.exit(1);
+  }
+  setOutput('version', out.version);
+  setOutput('bump', out.bump);
+  setOutput('chart_bump', out.chart_bump);
+}
+
+// --- self-test --------------------------------------------------------------
+
+function selfTest() {
+  const assert = (c, m) => {
+    if (!c) throw new Error('self-test: ' + m);
+  };
+  const eq = (got, want, m) =>
+    assert(JSON.stringify(got) === JSON.stringify(want), `${m}: got ${JSON.stringify(got)} want ${JSON.stringify(want)}`);
+  const throws = (env, m) => {
+    let threw = false;
+    try {
+      resolve(env);
+    } catch {
+      threw = true;
+    }
+    assert(threw, m);
+  };
+
+  // workflow_dispatch: inputs pass through; empty chart_bump defaults to patch.
+  eq(
+    resolve({ EVENT_NAME: 'workflow_dispatch', VERSION: '1.2.0', BUMP: 'none', CHART_BUMP: 'minor' }),
+    { version: '1.2.0', bump: 'none', chart_bump: 'minor' },
+    'dispatch explicit version',
+  );
+  eq(
+    resolve({ EVENT_NAME: 'workflow_dispatch', VERSION: '', BUMP: 'minor', CHART_BUMP: '' }),
+    { version: '', bump: 'minor', chart_bump: 'patch' },
+    'dispatch bump, default chart_bump',
+  );
+  eq(
+    resolve({ EVENT_NAME: 'workflow_dispatch' }),
+    { version: '', bump: '', chart_bump: 'patch' },
+    'dispatch all-empty (validation deferred to prepare-release.mjs)',
+  );
+
+  // issues: release:<level> -> bump=<level>, chart_bump=patch.
+  for (const lvl of ['patch', 'minor', 'major']) {
+    eq(
+      resolve({ EVENT_NAME: 'issues', LABEL_NAME: `release:${lvl}` }),
+      { version: '', bump: lvl, chart_bump: 'patch' },
+      `issues release:${lvl}`,
+    );
+  }
+
+  // issues: release:<semver> -> version=<semver> (v-prefix stripped), bump empty.
+  eq(
+    resolve({ EVENT_NAME: 'issues', LABEL_NAME: 'release:1.4.2' }),
+    { version: '1.4.2', bump: '', chart_bump: 'patch' },
+    'issues release:<semver>',
+  );
+  eq(
+    resolve({ EVENT_NAME: 'issues', LABEL_NAME: 'release:v2.0.0' }),
+    { version: '2.0.0', bump: '', chart_bump: 'patch' },
+    'issues release:v<semver> strips v',
+  );
+
+  // issues: bad labels error.
+  throws({ EVENT_NAME: 'issues', LABEL_NAME: 'release:lol' }, 'issues garbage suffix errors');
+  throws({ EVENT_NAME: 'issues', LABEL_NAME: 'release:1.2' }, 'issues non-3-part semver errors');
+  throws({ EVENT_NAME: 'issues', LABEL_NAME: 'bug' }, 'issues non-release label errors');
+  throws({ EVENT_NAME: 'issues', LABEL_NAME: 'release:' }, 'issues bare release: errors');
+
+  // unknown event name errors.
+  throws({ EVENT_NAME: 'push' }, 'unknown event errors');
+  throws({}, 'missing event errors');
+
+  log('::notice::resolve-release-trigger --self-test: all assertions passed');
+}
+
+if (process.argv.includes('--self-test')) selfTest();
+else main();

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,12 +1,29 @@
 name: prepare-release
 
-# Manually-triggered release staging. Bumps the chart `version` + `appVersion`,
-# refreshes the Artifact Hub `changes` annotation and the CHANGELOG, regenerates
-# the chart README, and opens a PR — all derived from the conventional commits
-# since the last `v*` tag. Merging that PR is the human gate; the `v<version>`
-# tag (cut separately) is what triggers `release.yml` to build the image and
-# publish the chart. The logic lives in `.github/scripts/prepare-release.mjs`
-# (Node ESM, no deps) so it is unit-testable; this file is just wiring.
+# Release staging. Bumps chart `version` + `appVersion`, refreshes the Artifact
+# Hub `changes` annotation + CHANGELOG, regenerates the chart README, and opens
+# a PR — all derived from the conventional commits since the last `v*` tag.
+# Merging the PR is the human gate; the `v<version>` tag (cut separately)
+# triggers `release.yml` to build the image and publish the chart. The staging
+# logic lives in `.github/scripts/prepare-release.mjs` (Node ESM, no deps) so it
+# is unit-testable; this file is just wiring.
+#
+# Two ways to start a release:
+#   1. workflow_dispatch — pick version/bump/chart_bump from the Actions UI.
+#   2. Apply a `release:*` label to ANY issue:
+#        release:patch | release:minor | release:major  -> bump appVersion
+#        release:1.4.2 (a 3-part semver)                 -> explicit appVersion
+#      The label is consumed (removed) and the new PR's URL is posted back to
+#      the triggering issue. Re-apply the label to re-trigger.
+#
+# IMPORTANT — RELEASE_PAT secret. A PR opened with the default `GITHUB_TOKEN`
+# does NOT trigger `pull_request` workflows (GitHub's recursion guard), so the
+# release PR would run NONE of its required checks (incl. the full e2e matrix
+# release PRs run, and which release-preflight requires green). To make the
+# label/dispatch-created PR run CI, add a fine-grained PAT as the `RELEASE_PAT`
+# repo secret (contents: write + pull-requests: write, ideally actions too).
+# Without it the PR is still created but won't run CI and must be nudged
+# manually (close+reopen, or push an empty commit).
 
 on:
   workflow_dispatch:
@@ -21,19 +38,26 @@ on:
         options: [none, patch, minor, major]
         default: none
       chart_bump:
-        description: 'Semver level to bump the chart version'
+        description: 'Semver level to bump chart version'
         type: choice
         options: [patch, minor, major]
         default: patch
+  issues:
+    types: [labeled]
 
 permissions:
   contents: write
   pull-requests: write
+  issues: write
 
 jobs:
   prepare:
     name: prepare
     runs-on: ubuntu-latest
+    # Run on a manual dispatch, or when a `release:*` label is applied to an issue.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issues' && startsWith(github.event.label.name, 'release:'))
     steps:
       - uses: actions/checkout@v7
         with:
@@ -43,29 +67,48 @@ jobs:
         with:
           node-version: '20'
 
-      # Pin the deriver's own logic before it edits anything.
+      # Pin the resolver's + deriver's own logic before either edits anything.
+      - name: resolve-release-trigger self-test
+        run: node .github/scripts/resolve-release-trigger.mjs --self-test
+
       - name: prepare-release self-test
         run: node .github/scripts/prepare-release.mjs --self-test
+
+      # Normalise the two triggers (dispatch inputs / issue label) into the
+      # version/bump/chart_bump the staging step consumes.
+      - name: resolve trigger
+        id: trigger
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          VERSION: ${{ inputs.version }}
+          BUMP: ${{ inputs.bump }}
+          CHART_BUMP: ${{ inputs.chart_bump }}
+          LABEL_NAME: ${{ github.event.label.name }}
+        run: node .github/scripts/resolve-release-trigger.mjs
 
       - name: stage release files
         id: prep
         env:
-          VERSION: ${{ inputs.version }}
-          BUMP: ${{ inputs.bump }}
-          CHART_BUMP: ${{ inputs.chart_bump }}
+          VERSION: ${{ steps.trigger.outputs.version }}
+          BUMP: ${{ steps.trigger.outputs.bump }}
+          CHART_BUMP: ${{ steps.trigger.outputs.chart_bump }}
           PR_BODY_FILE: release-pr-body.md
         run: node .github/scripts/prepare-release.mjs
 
-      # Regenerate the chart README with the SAME helm-docs the chart-validate
-      # drift gate uses (jnorwood/helm-docs:v1.14.2), so the opened PR is green.
+      # Keep the chart README in sync; the chart-ci drift gate uses the same
+      # helm-docs version (jnorwood/helm-docs:v1.14.2) so the opened PR is green.
       - name: regenerate chart README
         uses: docker://jnorwood/helm-docs:v1.14.2
         with:
           args: --chart-search-root=deploy/helm --template-files=README.md.gotmpl
 
       - name: create release PR
+        id: pr
+        # Prefer RELEASE_PAT so the created PR triggers pull_request CI; fall
+        # back to github.token (PR created, but its checks won't run — see the
+        # header note). gh reads GH_TOKEN.
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.RELEASE_PAT || github.token }}
           VERSION: ${{ steps.prep.outputs.new_version }}
           CHART_VERSION: ${{ steps.prep.outputs.chart_version }}
         run: |
@@ -77,4 +120,20 @@ jobs:
           git add deploy/helm/cerberus/Chart.yaml deploy/helm/cerberus/README.md CHANGELOG.md
           git commit -m "$title"
           git push -u origin "$branch"
-          gh pr create --base main --head "$branch" --title "$title" --body-file release-pr-body.md
+          url="$(gh pr create --base main --head "$branch" --title "$title" --body-file release-pr-body.md)"
+          echo "url=$url" >>"$GITHUB_OUTPUT"
+          echo "PR: $url"
+
+      # issues trigger only: report the PR back on the issue, then consume the
+      # label so it can be cleanly re-applied to re-trigger (and doesn't re-fire
+      # on an unrelated edit). Uses github.token (issue write only).
+      - name: comment + remove label on issue
+        if: github.event_name == 'issues'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE: ${{ github.event.issue.number }}
+          LABEL: ${{ github.event.label.name }}
+          PR_URL: ${{ steps.pr.outputs.url }}
+        run: |
+          gh issue comment "$ISSUE" --body "Release PR opened: ${PR_URL}"
+          gh api -X DELETE "repos/${GITHUB_REPOSITORY}/issues/${ISSUE}/labels/${LABEL}" || true


### PR DESCRIPTION
## What

Make opening a release PR **label-triggered**, in addition to the existing manual `workflow_dispatch`, by extending `.github/workflows/prepare-release.yml`.

## The label contract

Apply one of these labels to **any issue** and the `prepare` job opens a release PR:

| Label | Effect |
| --- | --- |
| `release:patch` | bump appVersion patch, chart_bump=patch |
| `release:minor` | bump appVersion minor, chart_bump=patch |
| `release:major` | bump appVersion major, chart_bump=patch |
| `release:1.4.2` (a 3-part semver) | explicit appVersion `1.4.2`, chart_bump=patch |

Anything else under `release:` (e.g. `release:lol`, `release:1.2`) is rejected with an `::error::`. The three `release:{patch,minor,major}` labels were created in the repo.

After the PR opens, the workflow comments the PR URL back on the triggering issue and **removes the `release:*` label** so it can be cleanly re-applied to re-trigger (and doesn't silently re-fire on an unrelated issue edit).

`workflow_dispatch` still works exactly as before (version / bump / chart_bump inputs from the Actions UI).

## How

Per the repo rule *"non-trivial CI step logic lives in `.github/scripts/*.mjs`"*, a new env-driven Node ESM module `.github/scripts/resolve-release-trigger.mjs` (node: builtins only, documented env contract, `--self-test` with assert-based cases, `::error::` + `process.exit(1)` on bad input) normalises **both** triggers into `version=`/`bump=`/`chart_bump=` `$GITHUB_OUTPUT` keys. Those feed the existing `stage release files` step (`prepare-release.mjs`) unchanged — `prepare-release.mjs` still owns the value semantics (explicit VERSION overrides BUMP, BUMP=none placeholder). Added to `.github/scripts/README.md`.

Workflow wiring:
- `on:` adds `issues: types: [labeled]` (keeps `workflow_dispatch`); `permissions:` adds `issues: write`.
- Job `if:` runs on `workflow_dispatch` OR (`issues` AND `startsWith(github.event.label.name, 'release:')`).

## The RELEASE_PAT requirement (load-bearing — please read)

The `create release PR` step token is now `${{ secrets.RELEASE_PAT || github.token }}`.

**Why:** a PR created with the default `GITHUB_TOKEN` does **not** trigger `pull_request` workflows (GitHub's recursion guard). Since #1036 made release PRs (head `release/*`) run the **full e2e matrix** (split + crawl), and `release-preflight` requires every check on the release commit green, a release PR with **no CI is stuck/useless**.

So for the label/dispatch-created PR to run its required checks, a fine-grained **`RELEASE_PAT`** must be added as a repo secret:
- **contents: write** + **pull-requests: write** (and ideally **actions: read/write**).

Without it the PR is still created but won't run CI and must be nudged manually (close+reopen, or push an empty commit). This is documented in the workflow header comment and the README.

## Verification

- `node .github/scripts/resolve-release-trigger.mjs --self-test` — all assertions pass (dispatch passthrough, all 3 levels, semver + v-prefix strip, every bad-label/bad-event error path).
- `actionlint .github/workflows/prepare-release.yml` — clean.
- `release:{patch,minor,major}` labels created in `tsouza/cerberus`.
- No release was actually triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
