### PR TITLE
fix(chart): per-head PDB + auto-derived GOMEMLIMIT for split mode

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -175,6 +175,16 @@ wrapper, plus `appendStepSummary` / `setOutput` for the runner files.
     `1.28.0`), `SKIP_IMAGE_CHECK` (set `1` to skip the registry probe).
   - Exit: `0` when all fixtures validate + images present; `1` on any
     kubeconform failure or a missing image.
+- **`chart-render-assert.mjs`** — `chart-ci.yml`, the `Render assertions`
+  step. Behavioural render checks kubeconform's schema validation cannot make:
+  split mode renders one PodDisruptionBudget per enabled head (each with its
+  `app.kubernetes.io/component` selector), the monolith PDB render is unchanged,
+  and each container gets a `GOMEMLIMIT` env sized to ~80% of its own
+  `resources.limits.memory` (per-head in split, per-pod in monolith) — with an
+  explicit `extraEnv` `GOMEMLIMIT` always winning and an unset limit emitting
+  nothing.
+  - Env: `CHART_DIR` (default `deploy/helm/cerberus`).
+  - Exit: `0` when every assertion holds; `1` on the first failure.
 - **`compat-step-summary.mjs`** — `compatibility.yml`, the three
   `Append score to step summary` steps.
   - Env: `HEAD` (`prometheus`, `tempo`, or `loki`), `SCORE` (path to that

--- a/.github/scripts/chart-render-assert.mjs
+++ b/.github/scripts/chart-render-assert.mjs
@@ -116,4 +116,28 @@ function count(haystack, needle) {
   check(!out.includes('name: GOMEMLIMIT'), 'no memory limit set -> GOMEMLIMIT skipped silently')
 }
 
+// --- 7. admit.{prom,loki,tempo} accept an integer concurrency cap -------------
+// Schema was boolean-only, which rejected an integer cap client-side even though
+// the binary + template both honor it. Guard against a revert to boolean-only.
+{
+  const out = tpl(['--set', 'admit.prom=128', '-s', 'templates/configmap-env.yaml'])
+  check(out.includes('CERBERUS_ADMIT_PROM: "128"'), 'admit.prom integer cap renders as CERBERUS_ADMIT_PROM="128"')
+
+  let boolOk = true
+  try {
+    tpl(['--set', 'admit.loki=false', '-s', 'templates/configmap-env.yaml'])
+  } catch {
+    boolOk = false
+  }
+  check(boolOk, 'admit.loki boolean still accepted (toggle preserved)')
+
+  let negRejected = false
+  try {
+    tpl(['--set', 'admit.tempo=-1', '-s', 'templates/configmap-env.yaml'])
+  } catch {
+    negRejected = true
+  }
+  check(negRejected, 'admit.tempo negative rejected (minimum:0 enforced)')
+}
+
 process.exit(ok ? 0 : 1)

--- a/.github/scripts/chart-render-assert.mjs
+++ b/.github/scripts/chart-render-assert.mjs
@@ -1,0 +1,119 @@
+// chart-render-assert.mjs — behavioural render assertions for the cerberus Helm
+// chart's HA-hardening paths that kubeconform (schema-only) cannot check:
+//
+//   1. Split-mode PodDisruptionBudget: `mode: split` + podDisruptionBudget
+//      enabled renders ONE PDB per enabled head, each selecting only that head's
+//      pods via app.kubernetes.io/component=<svc>. Disabling a head drops its
+//      PDB. The monolith PDB render is unchanged (single aggregate PDB).
+//   2. Derived GOMEMLIMIT: each container gets a GOMEMLIMIT env sized to ~80% of
+//      THAT container's resources.limits.memory (per-head in split, per-pod in
+//      monolith); an explicit extraEnv GOMEMLIMIT always wins; an unset limit
+//      emits nothing.
+//
+// Env contract:
+//   CHART_DIR   chart directory (default: deploy/helm/cerberus)
+//
+// Deps: node: builtins only. Requires `helm` on PATH.
+// Exit 1 on any failed assertion, 0 when all pass.
+
+import { execFileSync } from 'node:child_process'
+import { error as ghError, notice as ghNotice } from './lib/gh.mjs'
+
+const CHART_DIR = process.env.CHART_DIR || 'deploy/helm/cerberus'
+
+// ~80% headroom factor mirrored from cerberus.gomemlimitEnv (_helpers.tpl); the
+// derived byte budget below the cgroup limit leaves room for off-heap memory.
+const GOMEMLIMIT_HEADROOM = 0.8
+const MiB = 1048576
+const GiB = 1073741824
+
+function tpl(args) {
+  return execFileSync('helm', ['template', 'rn', CHART_DIR, ...args], {
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+  })
+}
+
+let ok = true
+function check(cond, msg) {
+  if (cond) {
+    ghNotice(`PASS: ${msg}`)
+  } else {
+    ghError(`FAIL: ${msg}`)
+    ok = false
+  }
+}
+
+// Count occurrences of a literal substring.
+function count(haystack, needle) {
+  return haystack.split(needle).length - 1
+}
+
+// --- 1. Split-mode per-head PDBs ----------------------------------------------
+{
+  const out = tpl(['-f', `${CHART_DIR}/ci/split-pdb-values.yaml`, '-s', 'templates/poddisruptionbudget.yaml'])
+  check(count(out, 'kind: PodDisruptionBudget') === 3, 'split mode renders 3 PodDisruptionBudgets (one per enabled head)')
+  for (const svc of ['prometheus', 'loki', 'tempo']) {
+    check(out.includes(`name: rn-cerberus-${svc}`), `split PDB exists for head ${svc}`)
+    check(
+      count(out, `app.kubernetes.io/component: ${svc}`) === 2,
+      `split PDB ${svc} carries its component selector (metadata label + matchLabels)`,
+    )
+  }
+
+  // Disabling a head drops its PDB.
+  const out2 = tpl([
+    '-f', `${CHART_DIR}/ci/split-pdb-values.yaml`,
+    '--set', 'split.loki.enabled=false',
+    '-s', 'templates/poddisruptionbudget.yaml',
+  ])
+  check(count(out2, 'kind: PodDisruptionBudget') === 2, 'disabling a head drops its PDB (2 remain)')
+  check(!out2.includes('name: rn-cerberus-loki'), 'disabled head loki has no PDB')
+}
+
+// --- 2. Monolith PDB unchanged (single aggregate PDB, no component selector) ---
+{
+  const out = tpl(['--set', 'podDisruptionBudget.enabled=true', '-s', 'templates/poddisruptionbudget.yaml'])
+  check(count(out, 'kind: PodDisruptionBudget') === 1, 'monolith renders exactly 1 PDB')
+  check(out.includes('name: rn-cerberus\n'), 'monolith PDB keeps the aggregate name')
+  check(!/component: (prometheus|loki|tempo)/.test(out), 'monolith PDB has no per-head component selector')
+}
+
+// --- 3. Derived GOMEMLIMIT, monolith -----------------------------------------
+{
+  const out = tpl(['-s', 'templates/deployment.yaml'])
+  const want = Math.floor(1536 * MiB * GOMEMLIMIT_HEADROOM)
+  check(out.includes(`value: "${want}B"`), `monolith GOMEMLIMIT is ~80% of default 1536Mi limit (${want}B)`)
+  check(count(out, 'name: GOMEMLIMIT') === 1, 'monolith emits exactly one GOMEMLIMIT')
+}
+
+// --- 4. Derived GOMEMLIMIT, per-head in split --------------------------------
+{
+  const out = tpl(['-f', `${CHART_DIR}/ci/split-pdb-values.yaml`, '-s', 'templates/split.yaml'])
+  const lean = Math.floor(1 * GiB * GOMEMLIMIT_HEADROOM)
+  const fat = Math.floor(4 * GiB * GOMEMLIMIT_HEADROOM)
+  check(count(out, `value: "${lean}B"`) === 2, `prom + loki heads get 80%-of-1Gi GOMEMLIMIT (${lean}B x2)`)
+  check(out.includes(`value: "${fat}B"`), `tempo head gets 80%-of-4Gi GOMEMLIMIT (${fat}B)`)
+  check(count(out, 'name: GOMEMLIMIT') === 3, 'split emits one GOMEMLIMIT per head')
+}
+
+// --- 5. Explicit extraEnv GOMEMLIMIT wins (derived suppressed) ----------------
+{
+  const overrideArgs = ['--set-string', 'extraEnv[0].name=GOMEMLIMIT', '--set-string', 'extraEnv[0].value=2GiB']
+
+  const mono = tpl([...overrideArgs, '-s', 'templates/deployment.yaml'])
+  check(count(mono, 'name: GOMEMLIMIT') === 1, 'monolith: explicit GOMEMLIMIT is the only one (derived suppressed)')
+  check(mono.includes('value: 2GiB'), 'monolith: explicit GOMEMLIMIT value wins')
+
+  const split = tpl(['-f', `${CHART_DIR}/ci/split-pdb-values.yaml`, ...overrideArgs, '-s', 'templates/split.yaml'])
+  check(count(split, 'name: GOMEMLIMIT') === 3, 'split: one explicit GOMEMLIMIT per head, no derived duplicate')
+  check(count(split, 'value: 2GiB') === 3, 'split: explicit GOMEMLIMIT value wins on every head')
+}
+
+// --- 6. Unset memory limit emits no GOMEMLIMIT --------------------------------
+{
+  const out = tpl(['--set', 'resources=null', '-s', 'templates/deployment.yaml'])
+  check(!out.includes('name: GOMEMLIMIT'), 'no memory limit set -> GOMEMLIMIT skipped silently')
+}
+
+process.exit(ok ? 0 : 1)

--- a/.github/workflows/chart-ci.yml
+++ b/.github/workflows/chart-ci.yml
@@ -82,6 +82,10 @@ jobs:
           KUBE_VERSION: '1.33.0'
         run: node .github/scripts/chart-kubeconform.mjs
 
+      - name: Render assertions (split PDBs + derived GOMEMLIMIT)
+        if: steps.changes.outputs.chart == 'true'
+        run: node .github/scripts/chart-render-assert.mjs
+
       - name: chart-testing (ct) lint
         if: steps.changes.outputs.chart == 'true'
         uses: helm/chart-testing-action@v2

--- a/deploy/helm/cerberus/Chart.yaml
+++ b/deploy/helm/cerberus/Chart.yaml
@@ -50,9 +50,9 @@ annotations:
   # cerberus release; informational for Artifact Hub's compatibility hints.
   artifacthub.io/changes: |
     - kind: added
-      description: "chart: per-head PodDisruptionBudget in split mode (#PRNUM)"
+      description: "chart: per-head PodDisruptionBudget in split mode (#1040)"
     - kind: added
-      description: "chart: auto-derive per-container GOMEMLIMIT from limits.memory (#PRNUM)"
+      description: "chart: auto-derive per-container GOMEMLIMIT from limits.memory (#1040)"
     - kind: added
       description: "chart: split mode — isolated per-head deployments (no proxy) (#1031)"
     - kind: added

--- a/deploy/helm/cerberus/Chart.yaml
+++ b/deploy/helm/cerberus/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # upgrade?" and is the publish trigger: a chart-only fix bumps this without an
 # app re-tag; an app-only release bumps appVersion + a PATCH here for the new
 # default image. Starts 0.x because the values contract is not yet frozen.
-version: 0.6.1
+version: 0.6.2
 
 # appVersion tracks the GA cerberus binary. Quoted so SemVer-shaped values
 # aren't coerced to floats. image.tag defaults from this when left empty.
@@ -49,6 +49,10 @@ annotations:
   # Bump the `1.0.0` floor here when the chart raises its minimum supported
   # cerberus release; informational for Artifact Hub's compatibility hints.
   artifacthub.io/changes: |
+    - kind: added
+      description: "chart: per-head PodDisruptionBudget in split mode (#PRNUM)"
+    - kind: added
+      description: "chart: auto-derive per-container GOMEMLIMIT from limits.memory (#PRNUM)"
     - kind: added
       description: "chart: split mode — isolated per-head deployments (no proxy) (#1031)"
     - kind: added

--- a/deploy/helm/cerberus/README.md
+++ b/deploy/helm/cerberus/README.md
@@ -5,7 +5,7 @@
      pipe-aligned, and the version footer adds a trailing blank — both are
      owned by helm-docs; realigning would fight the chart-ci drift check. -->
 
-![Version: 0.6.1](https://img.shields.io/badge/Version-0.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.4.0](https://img.shields.io/badge/AppVersion-1.4.0-informational?style=flat-square)
+![Version: 0.6.2](https://img.shields.io/badge/Version-0.6.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.4.0](https://img.shields.io/badge/AppVersion-1.4.0-informational?style=flat-square)
 
 Drop-in Prometheus / Loki / Tempo HTTP gateway for ClickHouse — a single stateless gateway that speaks three upstream query wire formats and lowers each to parameterised ClickHouse SQL.
 

--- a/deploy/helm/cerberus/ci/split-pdb-values.yaml
+++ b/deploy/helm/cerberus/ci/split-pdb-values.yaml
@@ -1,0 +1,39 @@
+# ct / helm-template fixture: split topology WITH PodDisruptionBudget enabled.
+# Exercises the per-head PDB path (one PDB per enabled head, each carrying the
+# head's component selector) that the default split-values fixture leaves off,
+# so kubeconform schema-validates the rendered policy/v1 PodDisruptionBudgets.
+mode: split
+
+clickhouse:
+  addr:
+    - clickhouse:9000
+  database: otel
+  username: default
+
+autoCreate:
+  schema: false
+  database: false
+
+otlp:
+  endpoint: ""
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+
+split:
+  prometheus:
+    replicaCount: 2
+    resources:
+      limits:
+        memory: 1Gi
+  loki:
+    replicaCount: 2
+    resources:
+      limits:
+        memory: 1Gi
+  tempo:
+    replicaCount: 1
+    resources:
+      limits:
+        memory: 4Gi

--- a/deploy/helm/cerberus/templates/NOTES.txt
+++ b/deploy/helm/cerberus/templates/NOTES.txt
@@ -69,9 +69,12 @@ cerberus endpoint below — it speaks all three wire formats on one port.
 {{- end }}
 
 5. Memory sizing note:
-   resources.limits.memory is {{ .Values.resources.limits.memory }}. cerberus's
-   Go heap does not see the cgroup limit on its own — if you change the memory
-   limit, set GOMEMLIMIT (~80% of the limit) via extraEnv, e.g.:
+   cerberus's Go heap does not see the cgroup limit on its own, so the chart
+   auto-derives GOMEMLIMIT (~80% of each container's resources.limits.memory) and
+   injects it per-container — correct per-head in split mode, per-pod in monolith.
+   No action needed when you set a memory limit; it is skipped when no limit is
+   set. To override (or pin an exact value), set GOMEMLIMIT in extraEnv — an
+   explicit entry always wins over the derived one:
      extraEnv:
        - name: GOMEMLIMIT
          value: "1228MiB"

--- a/deploy/helm/cerberus/templates/_helpers.tpl
+++ b/deploy/helm/cerberus/templates/_helpers.tpl
@@ -352,6 +352,65 @@ ConfigMap and reach the container via envFrom.
 {{- end }}
 
 {{/*
+cerberus.memBytes — parse a Kubernetes memory quantity string into an integer
+number of bytes. Handles the binary suffixes (Ki/Mi/Gi/Ti), the decimal SI
+suffixes (k/K/M/G/T), and a bare integer (already bytes). Returns the byte
+count as a string; an unparseable/empty input returns "" (callers skip on
+empty). Input is the raw quantity (e.g. "1536Mi", "4Gi", "2G").
+*/}}
+{{- define "cerberus.memBytes" -}}
+{{- $q := . | toString | trim -}}
+{{- if hasSuffix "Ki" $q -}}{{ mulf (trimSuffix "Ki" $q) 1024 | int64 }}
+{{- else if hasSuffix "Mi" $q -}}{{ mulf (trimSuffix "Mi" $q) 1048576 | int64 }}
+{{- else if hasSuffix "Gi" $q -}}{{ mulf (trimSuffix "Gi" $q) 1073741824 | int64 }}
+{{- else if hasSuffix "Ti" $q -}}{{ mulf (trimSuffix "Ti" $q) 1099511627776 | int64 }}
+{{- else if hasSuffix "k" $q -}}{{ mulf (trimSuffix "k" $q) 1000 | int64 }}
+{{- else if hasSuffix "K" $q -}}{{ mulf (trimSuffix "K" $q) 1000 | int64 }}
+{{- else if hasSuffix "M" $q -}}{{ mulf (trimSuffix "M" $q) 1000000 | int64 }}
+{{- else if hasSuffix "G" $q -}}{{ mulf (trimSuffix "G" $q) 1000000000 | int64 }}
+{{- else if hasSuffix "T" $q -}}{{ mulf (trimSuffix "T" $q) 1000000000000 | int64 }}
+{{- else if regexMatch "^[0-9]+$" $q -}}{{ $q | int64 }}
+{{- end -}}
+{{- end }}
+
+{{/*
+cerberus.gomemlimitEnv — emit a derived `GOMEMLIMIT` container env entry sized to
+a fraction of THIS container's memory limit, so the Go runtime's soft heap limit
+tracks the cgroup limit per-container (correct per-head in split, per-pod in
+monolith) instead of forcing operators to hand-set one global value via extraEnv.
+
+The byte budget is the limit times gomemlimitHeadroomFactor — headroom below
+100% for off-heap allocations (the ClickHouse driver's buffers, goroutine
+stacks, cgo) that GOMEMLIMIT does NOT bound. Emitted as a literal byte count
+with Go's `B` suffix.
+
+Args: dict "ctx" $ "resources" <resolved per-container resources>.
+Renders nothing (so the caller emits no env entry) when:
+  - limits.memory is unset (default OFF — no derivation to make), or
+  - the operator already set GOMEMLIMIT in .Values.extraEnv (explicit wins).
+*/}}
+{{- define "cerberus.gomemlimitEnv" -}}
+{{- /* gomemlimitHeadroomFactor: fraction of the memory limit handed to the Go
+       soft heap limit; the remainder is headroom for off-heap memory GOMEMLIMIT
+       cannot bound (CH driver buffers, goroutine stacks, cgo). */ -}}
+{{- $gomemlimitHeadroomFactor := 0.8 -}}
+{{- $ctx := .ctx -}}
+{{- $res := .resources -}}
+{{- $userSet := false -}}
+{{- range (default (list) $ctx.Values.extraEnv) -}}
+{{- if eq (default "" .name) "GOMEMLIMIT" -}}{{ $userSet = true }}{{- end -}}
+{{- end -}}
+{{- $limit := dig "limits" "memory" "" (default (dict) $res) -}}
+{{- if and (not $userSet) $limit -}}
+{{- $bytes := include "cerberus.memBytes" $limit -}}
+{{- if $bytes -}}
+- name: GOMEMLIMIT
+  value: {{ printf "%dB" (mulf $bytes $gomemlimitHeadroomFactor | floor | int64) | quote }}
+{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 cerberus.affinity — composes the optional colocateWithClickHouse podAffinity
 preset over the operator-supplied .Values.affinity. The preset only INJECTS a
 pod-affinity term (preferred/soft by default, required/hard opt-in) targeting

--- a/deploy/helm/cerberus/templates/deployment.yaml
+++ b/deploy/helm/cerberus/templates/deployment.yaml
@@ -88,10 +88,16 @@ spec:
             - name: http
               containerPort: {{ .Values.service.targetPort }}
               protocol: TCP
+          {{- $gomem := include "cerberus.gomemlimitEnv" (dict "ctx" $ "resources" .Values.resources) | trim }}
           {{- $env := include "cerberus.env" . | trim }}
-          {{- if $env }}
+          {{- if or $gomem $env }}
           env:
-            {{- $env | nindent 12 }}
+            {{- with $gomem }}
+            {{- . | nindent 12 }}
+            {{- end }}
+            {{- with $env }}
+            {{- . | nindent 12 }}
+            {{- end }}
           {{- end }}
           {{- $hasEnvCM := include "cerberus.nonSecretEnv" . | trim }}
           {{- if or $hasEnvCM .Values.extraEnvFrom }}

--- a/deploy/helm/cerberus/templates/poddisruptionbudget.yaml
+++ b/deploy/helm/cerberus/templates/poddisruptionbudget.yaml
@@ -1,6 +1,36 @@
-{{- /* PDB is monolith-only: it selects the single aggregate Deployment's pods,
-       which don't exist in split mode (each head is its own Deployment). */ -}}
-{{- if and .Values.podDisruptionBudget.enabled (ne .Values.mode "split") }}
+{{- if .Values.podDisruptionBudget.enabled }}
+{{- if eq .Values.mode "split" }}
+{{- /* Split mode: one PDB per ENABLED head. Each head Deployment is its own
+       workload with a stable per-head selector (the base selector +
+       app.kubernetes.io/component=<svc>), so a PDB CAN target it — the old
+       monolith-only gate wrongly assumed those selectors don't exist in split.
+       minAvailable/maxUnavailable semantics are identical to the monolith
+       branch; a single global podDisruptionBudget is applied to each head. */ -}}
+{{- $root := . }}
+{{- range (include "cerberus.heads" . | fromYamlArray) }}
+{{- $svc := .svc }}
+{{- $hv := include "cerberus.headValues" (dict "ctx" $root "svc" $svc) | fromYaml }}
+{{- if $hv.enabled }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "cerberus.headFullname" (dict "ctx" $root "svc" $svc) }}
+  namespace: {{ $root.Release.Namespace }}
+  labels:
+    {{- include "cerberus.headLabels" (dict "ctx" $root "svc" $svc) | nindent 4 }}
+spec:
+  {{- if $root.Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ $root.Values.podDisruptionBudget.maxUnavailable }}
+  {{- else }}
+  minAvailable: {{ $root.Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "cerberus.headSelectorLabels" (dict "ctx" $root "svc" $svc) | nindent 6 }}
+{{- end }}
+{{- end }}
+{{- else }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -17,4 +47,5 @@ spec:
   selector:
     matchLabels:
       {{- include "cerberus.selectorLabels" . | nindent 6 }}
+{{- end }}
 {{- end }}

--- a/deploy/helm/cerberus/templates/split.yaml
+++ b/deploy/helm/cerberus/templates/split.yaml
@@ -136,6 +136,13 @@ spec:
                      the binary's integer parser rejects. */}}
               value: {{ $hv.maxSamples | int64 | quote }}
             {{- end }}
+            {{- /* GOMEMLIMIT derived from THIS head's own memory limit, so each
+                   head's Go soft heap limit tracks its own (possibly distinct)
+                   cgroup limit — a single global extraEnv value cannot. */}}
+            {{- $gomem := include "cerberus.gomemlimitEnv" (dict "ctx" $ctx "resources" $hv.resources) | trim }}
+            {{- with $gomem }}
+            {{- . | nindent 12 }}
+            {{- end }}
             {{- $env := include "cerberus.env" $ctx | trim }}
             {{- with $env }}
             {{- . | nindent 12 }}

--- a/deploy/helm/cerberus/values.schema.json
+++ b/deploy/helm/cerberus/values.schema.json
@@ -90,9 +90,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "prom": { "type": "boolean" },
-        "loki": { "type": "boolean" },
-        "tempo": { "type": "boolean" },
+        "prom": { "type": ["boolean", "integer"], "minimum": 0 },
+        "loki": { "type": ["boolean", "integer"], "minimum": 0 },
+        "tempo": { "type": ["boolean", "integer"], "minimum": 0 },
         "disabled": { "type": "boolean" }
       }
     },


### PR DESCRIPTION
## What

Two chart-only HA-hardening fixes for `mode: split` in `deploy/helm/cerberus`. **Chart-only — version 0.6.1 → 0.6.2, `appVersion` unchanged at `1.4.0`.** Intended for the next patch release.

### Patch 1 — Per-head PodDisruptionBudget in split mode

`templates/poddisruptionbudget.yaml` previously hard-gated the PDB **off** in split mode (`ne .Values.mode "split"`) on the wrong assumption that selector labels don't exist there. They do — each head Deployment carries a stable `app.kubernetes.io/component: {prometheus,loki,tempo}` selector.

Split now renders **one PDB per ENABLED head** (disabled heads are skipped), each scoped to its own head via the existing `cerberus.headFullname` / `cerberus.headSelectorLabels` / `cerberus.headLabels` helpers. `minAvailable`/`maxUnavailable` semantics are identical to the monolith branch, and a single global `podDisruptionBudget` is applied to each head (per-head override under `split.<head>` can come later). **The monolith branch renders byte-identical** (verified by diffing against the pre-change render — only the chart-version label changes, which is expected from the version bump).

### Patch 2 — Auto-derive per-container GOMEMLIMIT from `limits.memory`

A new `cerberus.gomemlimitEnv` helper parses a container's `resources.limits.memory` (Mi/Gi/M/G/Ki/k/Ti/T → bytes), multiplies by a **named ~80% headroom factor** (no bare magic constant; headroom for off-heap CH-driver buffers / goroutine stacks / cgo that `GOMEMLIMIT` does not bound), and emits a literal-byte `GOMEMLIMIT` env **per container, derived from THAT container's own limit**.

This fixes the split-mode gap where `extraEnv` is global: a single value can't give a 1Gi Prom/Loki head and a 4Gi Tempo head correct `GOMEMLIMIT`s simultaneously. Now each head/pod gets the right value automatically. An explicit `extraEnv` `GOMEMLIMIT` **always wins** (the derived one is suppressed, no duplicate key); an unset limit emits nothing (default-on when a limit is set). `NOTES.txt` updated to describe the auto-derivation + override.

## Validation

- `helm lint` clean for default, `ci/split-values.yaml`, and `ci/ha-values.yaml`.
- New `.github/scripts/chart-render-assert.mjs` (wired into `chart-ci.yml`) makes 22 behavioural render assertions kubeconform can't: split PDB count (3) + per-head component selectors, head-disable drops its PDB, monolith parity (1 PDB, no component selector), `~80%` GOMEMLIMIT math per head (1Gi→858993459B, 4Gi→3435973836B) and per monolith pod (1536Mi→1288490188B), `extraEnv` override wins on every container, unset-limit skip.
- New `ci/split-pdb-values.yaml` fixture so the existing `chart-kubeconform.mjs` schema-validates the rendered per-head PDBs (11 resources, all valid).
- README regenerated with **helm-docs v1.14.2** (only the version badge changed → drift gate clean).
- `ct lint` version-bump gate satisfied by 0.6.1 → 0.6.2.

> The split-mode change will be **split-e2e-validated** when the chart release PR runs the full matrix (#1036 makes release PRs exercise it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)