### PR TITLE
chore(release): chart 0.6.2 (split-mode HA hardening)

### DIFF
--- a/deploy/helm/cerberus/Chart.yaml
+++ b/deploy/helm/cerberus/Chart.yaml
@@ -60,6 +60,8 @@ annotations:
     - kind: added
       description: "config: add CERBERUS_ENABLED_HEADS per-head toggle (#1029)"
     - kind: fixed
+      description: "chart: allow integer admit.{prom,loki,tempo} concurrency caps in values.schema.json (#1040)"
+    - kind: fixed
       description: "test: thread a time window into the TraceQL property harness (#1032)"
     - kind: fixed
       description: "config: default-on per-query sample budget at 5M (#1028)"


### PR DESCRIPTION
Release PR for **chart 0.6.2** (appVersion stays 1.4.0). Head branch `release/*` so #1036 runs the FULL e2e matrix (split + crawl) — validating the split-mode chart (per-head PDB, GOMEMLIMIT) before the `chart-v0.6.2` tag publishes.

Carries the missing changelog annotation for the admit-cap schema fix. The 0.6.2 chart content (PDB, GOMEMLIMIT, admit schema) already merged via #1040; this PR is the validated release gate.

On merge: tag `chart-v0.6.2` at the merge commit → release.yml chart-release publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)