### PR TITLE
chore(release): chart 0.6.3 (split-mode HA hardening)

### DIFF
--- a/deploy/helm/cerberus/Chart.yaml
+++ b/deploy/helm/cerberus/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # upgrade?" and is the publish trigger: a chart-only fix bumps this without an
 # app re-tag; an app-only release bumps appVersion + a PATCH here for the new
 # default image. Starts 0.x because the values contract is not yet frozen.
-version: 0.6.2
+version: 0.6.3
 
 # appVersion tracks the GA cerberus binary. Quoted so SemVer-shaped values
 # aren't coerced to floats. image.tag defaults from this when left empty.
@@ -59,6 +59,8 @@ annotations:
       description: "api: O(output) drain counter + falsifiable bounds-drain regression harness (#1030)"
     - kind: added
       description: "config: add CERBERUS_ENABLED_HEADS per-head toggle (#1029)"
+    - kind: fixed
+      description: "chart: allow integer admit.{prom,loki,tempo} concurrency caps in values.schema.json (#1040)"
     - kind: fixed
       description: "test: thread a time window into the TraceQL property harness (#1032)"
     - kind: fixed

--- a/deploy/helm/cerberus/README.md
+++ b/deploy/helm/cerberus/README.md
@@ -5,7 +5,7 @@
      pipe-aligned, and the version footer adds a trailing blank — both are
      owned by helm-docs; realigning would fight the chart-ci drift check. -->
 
-![Version: 0.6.2](https://img.shields.io/badge/Version-0.6.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.4.0](https://img.shields.io/badge/AppVersion-1.4.0-informational?style=flat-square)
+![Version: 0.6.3](https://img.shields.io/badge/Version-0.6.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.4.0](https://img.shields.io/badge/AppVersion-1.4.0-informational?style=flat-square)
 
 Drop-in Prometheus / Loki / Tempo HTTP gateway for ClickHouse — a single stateless gateway that speaks three upstream query wire formats and lowers each to parameterised ClickHouse SQL.
 


### PR DESCRIPTION
Release PR for **chart 0.6.3** (appVersion stays 1.4.0).

**Why 0.6.3 not 0.6.2:** ct-lint requires the version bump to live in the release PR vs base `main`. The 0.6.2 bump already leaked into #1040, so main is at 0.6.2 and a PR at 0.6.2 fails the gate. 0.6.2 was never published (no chart artifact), so this releases 0.6.3.

Head branch `release/*` → #1036 runs the FULL e2e matrix (split + crawl + dedicated split_isolation shard), validating the split-mode chart (per-head PDB, GOMEMLIMIT, integer admit caps) before publish.

On merge: tag `chart-v0.6.3` at the merge commit → release.yml chart-release publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)