### PR TITLE
test(engine): de-flake solver byte-identical assertion (timing header)

### DIFF
--- a/internal/engine/solver_wiring_test.go
+++ b/internal/engine/solver_wiring_test.go
@@ -132,8 +132,14 @@ func TestSolver_SingleMode_ByteIdenticalToNilSolver(t *testing.T) {
 	}
 
 	// Headers must match for EVERY pre-existing key; the shadow header is
-	// the only addition.
+	// the only addition. HeaderCHMillis is excluded: it's a measured CH
+	// wall-clock duration, so base vs sol differ run-to-run (e.g. "0" vs
+	// "1") — that's latency, not a divergence in the byte-identical OUTPUT
+	// invariant this test guards.
 	for k, bv := range baseRes.Headers {
+		if k == engine.HeaderCHMillis {
+			continue
+		}
 		if sv, ok := solRes.Headers[k]; !ok || sv != bv {
 			t.Errorf("header %q: base=%q sol=%q (present=%v)", k, bv, sv, ok)
 		}


### PR DESCRIPTION
TestSolver_SingleMode_ByteIdenticalToNilSolver asserted byte-identity on X-Cerberus-CH-Millis (measured CH wall-clock) — inherently nondeterministic (CI: base="0" sol="1"). Excluded from the comparison; output-correctness headers still asserted. Blocks the chart-v0.6.3 release PR (#1042).

🤖 Generated with [Claude Code](https://claude.com/claude-code)