### PR TITLE
chore(release): v1.5.0 + chart 0.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to cerberus will be documented in this file. The format roug
 
 ## [Unreleased]
 
+## [v1.5.0] — 2026-06-24
+
+### Added
+
+- **optcorpus:** record routing decision + cost-grid for route A/B calibration (stage 0) (#1053)
+
+### Fixed
+
+- remediate verified audit findings (#1046)
+- **promql:** pass TimeUnix through scalar-wrapped rate arm in range joins (#1045)
+- **api:** harden Loki/Tempo HTTP surface against POST + DoS vectors (#1049)
+- **chart:** per-head PDB + auto-derived GOMEMLIMIT for split mode (#1040)
+- **e2e:** re-provision Grafana after split-mode datasource rewrite (#1037)
+
+### Performance
+
+- **chsql:** push inner-scan time bound on range query lowerings (#1048)
+
+### CI
+
+- **release:** support maintenance-line (release/X.Y.x) hotfix publishing (#1054)
+- **pr-label:** self-healing backfill + shared mapping (#1051)
+- **mutation:** skip gremlins matrix on non-release PRs (aggregator passes through) (#1052)
+- **release:** publish on merge of a validated release PR, not on raw tag (#1044)
+- **release:** make opening a release PR label-triggered (#1039)
+- **e2e:** isolate split_isolation in its own dashboard shard (#1038)
+- **e2e:** run the FULL matrix (split + crawl) on release PRs (#1036)
+
 ## [v1.4.0] — 2026-06-22
 
 ### Added

--- a/deploy/helm/cerberus/Chart.yaml
+++ b/deploy/helm/cerberus/Chart.yaml
@@ -8,11 +8,11 @@ type: application
 # upgrade?" and is the publish trigger: a chart-only fix bumps this without an
 # app re-tag; an app-only release bumps appVersion + a PATCH here for the new
 # default image. Starts 0.x because the values contract is not yet frozen.
-version: 0.6.3
+version: 0.6.4
 
 # appVersion tracks the GA cerberus binary. Quoted so SemVer-shaped values
 # aren't coerced to floats. image.tag defaults from this when left empty.
-appVersion: "1.4.0"
+appVersion: "1.5.0"
 
 # autoscaling/v2 + policy/v1 (PDB) + networking/v1 (Ingress) are all GA from
 # 1.21+; 1.23 is the conservative floor matching the manifests this chart
@@ -45,25 +45,21 @@ annotations:
       url: https://github.com/tsouza/cerberus/blob/main/docs/operations.md
   artifacthub.io/images: |
     - name: cerberus
-      image: ghcr.io/tsouza/cerberus:v1.4.0
+      image: ghcr.io/tsouza/cerberus:v1.5.0
   # Bump the `1.0.0` floor here when the chart raises its minimum supported
   # cerberus release; informational for Artifact Hub's compatibility hints.
   artifacthub.io/changes: |
     - kind: added
-      description: "chart: per-head PodDisruptionBudget in split mode (#1040)"
-    - kind: added
-      description: "chart: auto-derive per-container GOMEMLIMIT from limits.memory (#1040)"
-    - kind: added
-      description: "chart: split mode — isolated per-head deployments (no proxy) (#1031)"
-    - kind: added
-      description: "api: O(output) drain counter + falsifiable bounds-drain regression harness (#1030)"
-    - kind: added
-      description: "config: add CERBERUS_ENABLED_HEADS per-head toggle (#1029)"
+      description: "optcorpus: record routing decision + cost-grid for route A/B calibration (stage 0) (#1053)"
     - kind: fixed
-      description: "chart: allow integer admit.{prom,loki,tempo} concurrency caps in values.schema.json (#1040)"
+      description: "remediate verified audit findings (#1046)"
     - kind: fixed
-      description: "test: thread a time window into the TraceQL property harness (#1032)"
+      description: "promql: pass TimeUnix through scalar-wrapped rate arm in range joins (#1045)"
     - kind: fixed
-      description: "config: default-on per-query sample budget at 5M (#1028)"
+      description: "api: harden Loki/Tempo HTTP surface against POST + DoS vectors (#1049)"
     - kind: fixed
-      description: "tempo: bound /api/search drain with SQL trace-limit + window pushdown (#1027)"
+      description: "chart: per-head PDB + auto-derived GOMEMLIMIT for split mode (#1040)"
+    - kind: fixed
+      description: "e2e: re-provision Grafana after split-mode datasource rewrite (#1037)"
+    - kind: changed
+      description: "chsql: push inner-scan time bound on range query lowerings (#1048)"

--- a/deploy/helm/cerberus/README.md
+++ b/deploy/helm/cerberus/README.md
@@ -5,7 +5,7 @@
      pipe-aligned, and the version footer adds a trailing blank — both are
      owned by helm-docs; realigning would fight the chart-ci drift check. -->
 
-![Version: 0.6.3](https://img.shields.io/badge/Version-0.6.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.4.0](https://img.shields.io/badge/AppVersion-1.4.0-informational?style=flat-square)
+![Version: 0.6.4](https://img.shields.io/badge/Version-0.6.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
 
 Drop-in Prometheus / Loki / Tempo HTTP gateway for ClickHouse — a single stateless gateway that speaks three upstream query wire formats and lowers each to parameterised ClickHouse SQL.
 


### PR DESCRIPTION
Release-prep **v1.5.0** (chart **0.6.4**) — cuts the minor release for everything developed this cycle, via the publish-on-merge flow.

- appVersion `1.4.0` -> `1.5.0` (minor: this cycle added features)
- chart `0.6.3` -> `0.6.4` (patch: new default image tag)

A minor app bump is correct for this cycle: it shipped new features (Stage-0 optcorpus routing instrumentation, per-head config/HA, API hardening, range-scan perf) alongside bug fixes (scalar-op 502, audit remediation, Loki/Tempo POST/DoS hardening).

### Notable changes since v1.4.0

**Added**
- **optcorpus:** record routing decision + cost-grid for route A/B calibration (stage 0) (#1053)

**Fixed**
- remediate verified audit findings (#1046)
- **promql:** pass TimeUnix through scalar-wrapped rate arm in range joins (#1045)
- **api:** harden Loki/Tempo HTTP surface against POST + DoS vectors (#1049)
- **chart:** per-head PDB + auto-derived GOMEMLIMIT for split mode (#1040)
- **e2e:** re-provision Grafana after split-mode datasource rewrite (#1037)

**Performance**
- **chsql:** push inner-scan time bound on range query lowerings (#1048)

**CI**
- **release:** support maintenance-line (release/X.Y.x) hotfix publishing (#1054); publish on merge of a validated release PR (#1044); full split+crawl matrix on release PRs (#1036)

### Mechanics

This is a `release/*` head, so chart-ci enforces the version-increment check (satisfied by 0.6.3 -> 0.6.4) and #1036 runs the FULL split+crawl matrix plus the four parity lanes. On merge, publish-on-merge (`release.yml`) detects appVersion `1.5.0` (tag absent) and goreleaser publishes **v1.5.0** (binary / image / GHCR + DockerHub / provenance) and creates the `v1.5.0` tag; chart `0.6.4` (tag absent) triggers chart-release to publish **chart-v0.6.4**.

Local verification before opening:
- `helm lint` (default + `ci/split-values.yaml`) — 0 failures
- `node .github/scripts/chart-render-assert.mjs` — all PASS
- helm-docs v1.14.2 README drift — zero (badges show 1.5.0 / 0.6.4)
- `ct lint --chart-dirs deploy/helm --target-branch main --validate-maintainers=false` — version bump 0.6.3 -> 0.6.4 detected, "Chart version ok"

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
