### PR TITLE
test(chsql): kill range-scan time-bound mutants (restore ≥95% efficacy)

### DIFF
--- a/internal/chsql/range_window_pushdown_test.go
+++ b/internal/chsql/range_window_pushdown_test.go
@@ -480,3 +480,643 @@ func TestRangeBucketFanoutInnerScanTimeBound_BothSet(t *testing.T) {
 		t.Errorf("expected RangeBucketFanout inner-scan upper bound %q in SQL=%s", lwrPushdownUpperSubstr, sql)
 	}
 }
+
+// The range-query lowerings (RangeLWR / RangeBucketFanout / native
+// resample / native rate) route their inner-scan pruning through the
+// shared maybePushRangeScanTimeBound helper:
+//
+//	func maybePushRangeScanTimeBound(sb *QueryBuilder, tsCol string, start, end time.Time, offsetNS, spanNS int64) {
+//		if start.IsZero() || end.IsZero() {  // <- gate
+//			return
+//		}
+//		lo, hi := innerScanTsBoundsFrags(tsCol, start, end, offsetNS, spanNS)
+//		sb.Where(lo, hi)
+//	}
+//
+// The `||` short-circuit is load-bearing: when EITHER edge is zero the
+// bound must be suppressed (the now64()/@-pinned/zero-grid fixture shapes
+// rely on it to stay byte-stable). Two earlier tests
+// (TestRangeLWRInnerScanTimeBound_BothSet / _ZeroGridSuppressed) pin the
+// both-set and both-zero corners — but neither distinguishes the `||`
+// gate from an `&&` gate, because both predicates agree when Start and
+// End are EITHER both set OR both zero. The exactly-one-set cases below
+// are the discriminating shapes: with `||` the bound is suppressed, with
+// the `&&` mutant it leaks a half-zero `now64(9)` bound. They kill the
+// INVERT_LOGICAL mutant on the gate (range_lwr.go) for both fan-out node
+// types, and the offset/span edge assertions kill the ARITHMETIC /
+// CONDITIONALS_BOUNDARY mutants on the inner-scan bound math.
+
+// rangeScanOffsetShift is the offset interval (2m) the bound subtracts
+// from both edges; rangeScanSpanShift is the lower-edge span widening
+// (5m Lookback / Range). Both render as toIntervalNanosecond(<ns>) and
+// are load-bearing — an ARITHMETIC mutant on either term changes the
+// emitted ns literal, and a CONDITIONALS_BOUNDARY / sign flip on the
+// offset shift moves the whole interval.
+const (
+	rangeScanOffsetShift = "toIntervalNanosecond(120000000000)" // 2m offset
+	rangeScanSpanShift   = "toIntervalNanosecond(300000000000)" // 5m Lookback/Range
+)
+
+// TestRangeLWRInnerScanTimeBound_OnlyOneSet pins the gate's `||`
+// short-circuit for the RangeLWR fan-out: with exactly one of Start/End
+// set the inner-scan bound MUST be suppressed. Under the INVERT_LOGICAL
+// mutant (`||` -> `&&`) a single-edge grid would NOT suppress and would
+// leak a half-zero `now64(9)` bound, so this case kills it.
+func TestRangeLWRInnerScanTimeBound_OnlyOneSet(t *testing.T) {
+	t.Parallel()
+
+	nonZero := time.Date(2026, 5, 13, 12, 5, 0, 0, time.UTC)
+
+	cases := []struct {
+		name  string
+		start time.Time
+		end   time.Time
+	}{
+		{name: "start_only", start: nonZero, end: time.Time{}},
+		{name: "end_only", start: time.Time{}, end: nonZero},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			plan := &chplan.RangeLWR{
+				Input:         &chplan.Scan{Table: "otel_metrics_gauge"},
+				Start:         c.start,
+				End:           c.end,
+				Step:          30 * time.Second,
+				Lookback:      5 * time.Minute,
+				MetricNameCol: "MetricName",
+				AttributesCol: "Attributes",
+				TimestampCol:  "TimeUnix",
+				ValueCol:      "Value",
+			}
+			sql, _, err := chsql.Emit(context.Background(), plan)
+			if err != nil {
+				t.Fatalf("Emit: %v", err)
+			}
+			if strings.Contains(sql, lwrPushdownLowerSubstr) {
+				t.Errorf("RangeLWR inner-scan lower bound leaked with only %s set; SQL=%s", c.name, sql)
+			}
+			if strings.Contains(sql, lwrPushdownUpperSubstr) {
+				t.Errorf("RangeLWR inner-scan upper bound leaked with only %s set; SQL=%s", c.name, sql)
+			}
+		})
+	}
+}
+
+// TestRangeLWRInnerScanTimeBound_OffsetAndSpanEdges pins the exact
+// offset-shift + lower-span-widening terms the RangeLWR bound subtracts.
+// The lower bound is
+//
+//	`TimeUnix` > (<Start> - toIntervalNanosecond(<offset>)) - toIntervalNanosecond(<lookback>)
+//
+// and the upper bound is `(<End> - toIntervalNanosecond(<offset>))`. An
+// ARITHMETIC mutant on the offset or span term changes the emitted ns
+// literal; a sign flip / boundary mutant moves the interval. Asserting
+// both literals appear (offset on BOTH edges, span ONLY on the lower)
+// kills those mutants on the inner-scan math.
+func TestRangeLWRInnerScanTimeBound_OffsetAndSpanEdges(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 5, 13, 12, 5, 0, 0, time.UTC)
+
+	plan := &chplan.RangeLWR{
+		Input:         &chplan.Scan{Table: "otel_metrics_gauge"},
+		Start:         start,
+		End:           end,
+		Step:          30 * time.Second,
+		Lookback:      5 * time.Minute,
+		Offset:        2 * time.Minute,
+		MetricNameCol: "MetricName",
+		AttributesCol: "Attributes",
+		TimestampCol:  "TimeUnix",
+		ValueCol:      "Value",
+	}
+	sql, _, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	// The full lower-bound expression: offset shift then span widening.
+	wantLower := "`TimeUnix` > (toDateTime64('2026-05-13 12:00:00.000000000', 9) - " +
+		rangeScanOffsetShift + ") - " + rangeScanSpanShift
+	if !strings.Contains(sql, wantLower) {
+		t.Errorf("expected RangeLWR offset+span lower bound %q in SQL=%s", wantLower, sql)
+	}
+	// The upper bound carries the offset shift but NO span term.
+	wantUpper := "`TimeUnix` <= (toDateTime64('2026-05-13 12:05:00.000000000', 9) - " +
+		rangeScanOffsetShift + ")"
+	if !strings.Contains(sql, wantUpper) {
+		t.Errorf("expected RangeLWR offset-only upper bound %q in SQL=%s", wantUpper, sql)
+	}
+}
+
+// TestRangeLWRRejectsBadInput pins the RangeLWR emitter's pre-flight
+// guards (Step <= 0, nil Input, the 4-way column-name OR, and Start >
+// End). Under a mutated guard the bad-input plan would emit SQL instead
+// of erroring, killing the CONDITIONALS_BOUNDARY / CONDITIONALS_NEGATION
+// / INVERT_LOGICAL mutants on those guards and the span-sign boundary.
+func TestRangeLWRRejectsBadInput(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 5, 13, 12, 5, 0, 0, time.UTC)
+	mkBase := func() chplan.RangeLWR {
+		return chplan.RangeLWR{
+			Input:         &chplan.Scan{Table: "otel_metrics_gauge"},
+			Start:         start,
+			End:           end,
+			Step:          30 * time.Second,
+			Lookback:      5 * time.Minute,
+			MetricNameCol: "MetricName",
+			AttributesCol: "Attributes",
+			TimestampCol:  "TimeUnix",
+			ValueCol:      "Value",
+		}
+	}
+
+	cases := []struct {
+		name  string
+		mutfn func(p *chplan.RangeLWR)
+	}{
+		{name: "zero_step", mutfn: func(p *chplan.RangeLWR) { p.Step = 0 }},
+		{name: "neg_step", mutfn: func(p *chplan.RangeLWR) { p.Step = -time.Second }},
+		{name: "nil_input", mutfn: func(p *chplan.RangeLWR) { p.Input = nil }},
+		{name: "no_timestamp_col", mutfn: func(p *chplan.RangeLWR) { p.TimestampCol = "" }},
+		{name: "no_value_col", mutfn: func(p *chplan.RangeLWR) { p.ValueCol = "" }},
+		{name: "no_metric_name_col", mutfn: func(p *chplan.RangeLWR) { p.MetricNameCol = "" }},
+		{name: "no_attributes_col", mutfn: func(p *chplan.RangeLWR) { p.AttributesCol = "" }},
+		{name: "start_after_end", mutfn: func(p *chplan.RangeLWR) { p.Start, p.End = end, start }},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			p := mkBase()
+			c.mutfn(&p)
+			if _, _, err := chsql.Emit(context.Background(), &p); err == nil {
+				t.Errorf("expected RangeLWR to reject %s, got nil error", c.name)
+			}
+		})
+	}
+}
+
+// TestRangeBucketFanoutRejectsBadAggExpr pins the per-AggFunc pre-flight
+// that synchronously surfaces chplan Expr errors from BOTH the Params and
+// the Args lists (the `(&Builder{}).Expr(...)` loops). A nil Expr element
+// hits Builder.Expr's default branch (ErrUnsupported), so a fan-out whose
+// AggFunc carries a nil Param / nil Arg must error — covering and killing
+// the mutants on those two pre-flight loops.
+func TestRangeBucketFanoutRejectsBadAggExpr(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 5, 13, 12, 5, 0, 0, time.UTC)
+	mkBase := func() chplan.RangeBucketFanout {
+		return chplan.RangeBucketFanout{
+			Input:        &chplan.Scan{Table: "otel_metrics_exponential_histogram"},
+			Start:        start,
+			End:          end,
+			Step:         30 * time.Second,
+			Lookback:     5 * time.Minute,
+			GroupBy:      []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+			AnchorAlias:  "anchor_ts",
+			TimestampCol: "TimeUnix",
+		}
+	}
+
+	cases := []struct {
+		name string
+		agg  chplan.AggFunc
+	}{
+		{
+			name: "bad_param",
+			agg: chplan.AggFunc{
+				Name:   "quantilesTDigest",
+				Alias:  "BucketCounts",
+				Params: []chplan.Expr{nil},
+				Args:   []chplan.Expr{&chplan.ColumnRef{Name: "BucketCounts"}},
+			},
+		},
+		{
+			name: "bad_arg",
+			agg: chplan.AggFunc{
+				Name:  "argMax",
+				Alias: "BucketCounts",
+				Args:  []chplan.Expr{nil},
+			},
+		},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			p := mkBase()
+			p.AggFuncs = []chplan.AggFunc{c.agg}
+			if _, _, err := chsql.Emit(context.Background(), &p); err == nil {
+				t.Errorf("expected RangeBucketFanout to reject %s, got nil error", c.name)
+			}
+		})
+	}
+}
+
+// TestRangeBucketFanoutInnerScanTimeBound_OnlyOneSet mirrors the LWR
+// gate test for the histogram-over-range fan-out: with exactly one of
+// Start/End set the bound MUST be suppressed (kills the INVERT_LOGICAL
+// gate mutant on this node's call site too).
+func TestRangeBucketFanoutInnerScanTimeBound_OnlyOneSet(t *testing.T) {
+	t.Parallel()
+
+	nonZero := time.Date(2026, 5, 13, 12, 5, 0, 0, time.UTC)
+
+	cases := []struct {
+		name  string
+		start time.Time
+		end   time.Time
+	}{
+		{name: "start_only", start: nonZero, end: time.Time{}},
+		{name: "end_only", start: time.Time{}, end: nonZero},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			plan := &chplan.RangeBucketFanout{
+				Input:        &chplan.Scan{Table: "otel_metrics_exponential_histogram"},
+				Start:        c.start,
+				End:          c.end,
+				Step:         30 * time.Second,
+				Lookback:     5 * time.Minute,
+				GroupBy:      []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+				AnchorAlias:  "anchor_ts",
+				TimestampCol: "TimeUnix",
+				AggFuncs: []chplan.AggFunc{
+					{
+						Name:  "argMax",
+						Alias: "BucketCounts",
+						Args: []chplan.Expr{
+							&chplan.ColumnRef{Name: "BucketCounts"},
+							&chplan.ColumnRef{Name: "TimeUnix"},
+						},
+					},
+				},
+			}
+			sql, _, err := chsql.Emit(context.Background(), plan)
+			if err != nil {
+				t.Fatalf("Emit: %v", err)
+			}
+			if strings.Contains(sql, lwrPushdownLowerSubstr) {
+				t.Errorf("RangeBucketFanout lower bound leaked with only %s set; SQL=%s", c.name, sql)
+			}
+			if strings.Contains(sql, lwrPushdownUpperSubstr) {
+				t.Errorf("RangeBucketFanout upper bound leaked with only %s set; SQL=%s", c.name, sql)
+			}
+		})
+	}
+}
+
+// TestRangeBucketFanoutInnerScanTimeBound_OffsetAndSpanEdges pins the
+// exact offset-shift + span-widening terms for the histogram-over-range
+// fan-out's inner-scan bound (same contract as RangeLWR above).
+func TestRangeBucketFanoutInnerScanTimeBound_OffsetAndSpanEdges(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 5, 13, 12, 5, 0, 0, time.UTC)
+
+	plan := &chplan.RangeBucketFanout{
+		Input:        &chplan.Scan{Table: "otel_metrics_exponential_histogram"},
+		Start:        start,
+		End:          end,
+		Step:         30 * time.Second,
+		Lookback:     5 * time.Minute,
+		Offset:       2 * time.Minute,
+		GroupBy:      []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+		AnchorAlias:  "anchor_ts",
+		TimestampCol: "TimeUnix",
+		AggFuncs: []chplan.AggFunc{
+			{
+				Name:  "argMax",
+				Alias: "BucketCounts",
+				Args: []chplan.Expr{
+					&chplan.ColumnRef{Name: "BucketCounts"},
+					&chplan.ColumnRef{Name: "TimeUnix"},
+				},
+			},
+		},
+	}
+	sql, _, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	wantLower := "`TimeUnix` > (toDateTime64('2026-05-13 12:00:00.000000000', 9) - " +
+		rangeScanOffsetShift + ") - " + rangeScanSpanShift
+	if !strings.Contains(sql, wantLower) {
+		t.Errorf("expected RangeBucketFanout offset+span lower bound %q in SQL=%s", wantLower, sql)
+	}
+	wantUpper := "`TimeUnix` <= (toDateTime64('2026-05-13 12:05:00.000000000', 9) - " +
+		rangeScanOffsetShift + ")"
+	if !strings.Contains(sql, wantUpper) {
+		t.Errorf("expected RangeBucketFanout offset-only upper bound %q in SQL=%s", wantUpper, sql)
+	}
+	// numAnchors = (End-Start)/Step + 1 = 5m/30s + 1 = 11. It renders as
+	// the `least(11, …)` upper index cap of the anchor-fanout range. An
+	// ARITHMETIC mutant on the `/Step` or `+1` term shifts the count
+	// (e.g. `+1`->`-1` yields least(9,…)), so pinning the literal kills
+	// both numAnchors arithmetic mutants. (The RangeLWR sibling is pinned
+	// by range_lwr_test.go's TestEmitRangeLWR_SinglePassShape.)
+	if !strings.Contains(sql, "least(11,") {
+		t.Errorf("expected RangeBucketFanout numAnchors cap least(11, in SQL=%s", sql)
+	}
+}
+
+// TestRangeBucketFanoutZeroSpanGridAccepted pins the `span < 0` reject
+// boundary: a single-point grid (Start == End, span == 0) is VALID and
+// must emit one anchor (least(1, …)), not error. The earlier
+// start_after_end case only exercises span < 0 (rejected by both `< 0`
+// and the `<= 0` boundary mutant); this span == 0 success case is the
+// discriminating shape that kills the CONDITIONALS_BOUNDARY mutant on the
+// `if span < 0` guard.
+func TestRangeBucketFanoutZeroSpanGridAccepted(t *testing.T) {
+	t.Parallel()
+
+	at := time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC)
+
+	plan := &chplan.RangeBucketFanout{
+		Input:        &chplan.Scan{Table: "otel_metrics_exponential_histogram"},
+		Start:        at,
+		End:          at, // span == 0
+		Step:         30 * time.Second,
+		Lookback:     5 * time.Minute,
+		GroupBy:      []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+		AnchorAlias:  "anchor_ts",
+		TimestampCol: "TimeUnix",
+		AggFuncs: []chplan.AggFunc{
+			{
+				Name:  "argMax",
+				Alias: "BucketCounts",
+				Args: []chplan.Expr{
+					&chplan.ColumnRef{Name: "BucketCounts"},
+					&chplan.ColumnRef{Name: "TimeUnix"},
+				},
+			},
+		},
+	}
+	sql, _, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("expected zero-span grid to be accepted, got error: %v", err)
+	}
+	if !strings.Contains(sql, "least(1,") {
+		t.Errorf("expected zero-span grid to emit a single anchor (least(1,) in SQL=%s", sql)
+	}
+}
+
+// TestRangeWindowNativeInnerScanTimeBound pins the inner-scan prune the
+// ClickHouse-native rate lowering (RangeWindowNative, the
+// timeSeriesRateToGrid path) pushes onto the per-series SELECT BEFORE the
+// GROUP BY. This shape was previously only exercised through the
+// test/spec TXTAR goldens, which the package-scoped mutation lane does
+// NOT run — so every guard + the maybePushRangeScanTimeBound call here
+// was an uncovered mutation surface. The exact-bound assertions cover and
+// kill the CONDITIONALS_NEGATION / CONDITIONALS_BOUNDARY mutants on the
+// emitter's guards and the inner-scan bound math.
+func TestRangeWindowNativeInnerScanTimeBound(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 5, 13, 12, 5, 0, 0, time.UTC)
+
+	plan := &chplan.RangeWindowNative{
+		Input:           &chplan.Scan{Table: "otel_metrics_sum"},
+		Func:            "rate",
+		Start:           start,
+		End:             end,
+		Step:            30 * time.Second,
+		Range:           5 * time.Minute,
+		Offset:          2 * time.Minute,
+		TimestampColumn: "TimeUnix",
+		ValueColumn:     "Value",
+	}
+	sql, _, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	// Lower bound: offset shift then Range (5m) widening; upper bound:
+	// offset shift only. The Range term (300000000000) reuses the same
+	// 5m literal as Lookback above.
+	wantLower := "`TimeUnix` > (toDateTime64('2026-05-13 12:00:00.000000000', 9) - " +
+		rangeScanOffsetShift + ") - " + rangeScanSpanShift
+	if !strings.Contains(sql, wantLower) {
+		t.Errorf("expected RangeWindowNative offset+Range lower bound %q in SQL=%s", wantLower, sql)
+	}
+	wantUpper := "`TimeUnix` <= (toDateTime64('2026-05-13 12:05:00.000000000', 9) - " +
+		rangeScanOffsetShift + ")"
+	if !strings.Contains(sql, wantUpper) {
+		t.Errorf("expected RangeWindowNative offset-only upper bound %q in SQL=%s", wantUpper, sql)
+	}
+	// When the schema TimestampColumn differs from the bare anchor alias
+	// (the common case — here "TimeUnix" != "anchor_ts"), the outer SELECT
+	// surfaces the anchor BOTH bare and re-aliased to the schema column so
+	// the wrapping Aggregate's per-step GROUP BY(ColumnRef{TimestampColumn})
+	// resolves. The `r.TimestampColumn != RangeWindowAnchorAlias` guard
+	// gates that extra projection; a CONDITIONALS_NEGATION mutant (`!=` ->
+	// `==`) drops the re-alias for a differently-named column, so pinning
+	// the `anchor_ts` -> `TimeUnix` projection kills it.
+	if !strings.Contains(sql, "`anchor_ts` AS `TimeUnix`") {
+		t.Errorf("expected RangeWindowNative anchor re-alias `anchor_ts` AS `TimeUnix` in SQL=%s", sql)
+	}
+}
+
+// TestRangeWindowNativeRejectsBadInput pins the emitter's pre-flight
+// guards (TimestampColumn / ValueColumn unset, Step <= 0, unknown Func)
+// so the CONDITIONALS_NEGATION / CONDITIONALS_BOUNDARY mutants on each
+// guard are killed: under a mutated guard the bad-input plan would emit
+// SQL instead of erroring.
+func TestRangeWindowNativeRejectsBadInput(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 5, 13, 12, 5, 0, 0, time.UTC)
+	base := chplan.RangeWindowNative{
+		Input:           &chplan.Scan{Table: "otel_metrics_sum"},
+		Func:            "rate",
+		Start:           start,
+		End:             end,
+		Step:            30 * time.Second,
+		Range:           5 * time.Minute,
+		TimestampColumn: "TimeUnix",
+		ValueColumn:     "Value",
+	}
+
+	cases := []struct {
+		name  string
+		mutfn func(p *chplan.RangeWindowNative)
+	}{
+		{name: "no_timestamp_col", mutfn: func(p *chplan.RangeWindowNative) { p.TimestampColumn = "" }},
+		{name: "no_value_col", mutfn: func(p *chplan.RangeWindowNative) { p.ValueColumn = "" }},
+		{name: "zero_step", mutfn: func(p *chplan.RangeWindowNative) { p.Step = 0 }},
+		{name: "neg_step", mutfn: func(p *chplan.RangeWindowNative) { p.Step = -time.Second }},
+		{name: "unknown_func", mutfn: func(p *chplan.RangeWindowNative) { p.Func = "nope" }},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			p := base
+			c.mutfn(&p)
+			if _, _, err := chsql.Emit(context.Background(), &p); err == nil {
+				t.Errorf("expected RangeWindowNative to reject %s, got nil error", c.name)
+			}
+		})
+	}
+}
+
+// TestRangeWindowResampleInnerScanTimeBound pins the inner-scan prune the
+// native-staleness resample lowering (RangeWindowResample,
+// timeSeriesResampleToGridWithStaleness) pushes onto the per-series
+// SELECT. Same coverage rationale as the native-rate test above — this
+// shape only reached the spec goldens before, so its guards + bound were
+// an uncovered mutation surface.
+func TestRangeWindowResampleInnerScanTimeBound(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 5, 13, 12, 5, 0, 0, time.UTC)
+
+	plan := &chplan.RangeWindowResample{
+		Input:         &chplan.Scan{Table: "otel_metrics_gauge"},
+		Start:         start,
+		End:           end,
+		Step:          30 * time.Second,
+		Lookback:      5 * time.Minute,
+		Offset:        2 * time.Minute,
+		MetricNameCol: "MetricName",
+		AttributesCol: "Attributes",
+		TimestampCol:  "TimeUnix",
+		ValueCol:      "Value",
+	}
+	sql, _, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	wantLower := "`TimeUnix` > (toDateTime64('2026-05-13 12:00:00.000000000', 9) - " +
+		rangeScanOffsetShift + ") - " + rangeScanSpanShift
+	if !strings.Contains(sql, wantLower) {
+		t.Errorf("expected RangeWindowResample offset+Lookback lower bound %q in SQL=%s", wantLower, sql)
+	}
+	wantUpper := "`TimeUnix` <= (toDateTime64('2026-05-13 12:05:00.000000000', 9) - " +
+		rangeScanOffsetShift + ")"
+	if !strings.Contains(sql, wantUpper) {
+		t.Errorf("expected RangeWindowResample offset-only upper bound %q in SQL=%s", wantUpper, sql)
+	}
+}
+
+// TestRangeWindowResampleRejectsBadInput pins the resample emitter's
+// pre-flight guards: the 4-way column-name OR, Step <= 0, and the
+// pinned-Start/End requirement. Under a mutated guard the bad-input plan
+// would emit SQL instead of erroring, so each case kills the
+// CONDITIONALS_NEGATION / INVERT_LOGICAL / CONDITIONALS_BOUNDARY mutants
+// on those guards.
+func TestRangeWindowResampleRejectsBadInput(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 5, 13, 12, 5, 0, 0, time.UTC)
+	base := chplan.RangeWindowResample{
+		Input:         &chplan.Scan{Table: "otel_metrics_gauge"},
+		Start:         start,
+		End:           end,
+		Step:          30 * time.Second,
+		Lookback:      5 * time.Minute,
+		MetricNameCol: "MetricName",
+		AttributesCol: "Attributes",
+		TimestampCol:  "TimeUnix",
+		ValueCol:      "Value",
+	}
+
+	cases := []struct {
+		name  string
+		mutfn func(p *chplan.RangeWindowResample)
+	}{
+		{name: "no_timestamp_col", mutfn: func(p *chplan.RangeWindowResample) { p.TimestampCol = "" }},
+		{name: "no_value_col", mutfn: func(p *chplan.RangeWindowResample) { p.ValueCol = "" }},
+		{name: "no_metric_name_col", mutfn: func(p *chplan.RangeWindowResample) { p.MetricNameCol = "" }},
+		{name: "no_attributes_col", mutfn: func(p *chplan.RangeWindowResample) { p.AttributesCol = "" }},
+		{name: "zero_step", mutfn: func(p *chplan.RangeWindowResample) { p.Step = 0 }},
+		{name: "neg_step", mutfn: func(p *chplan.RangeWindowResample) { p.Step = -time.Second }},
+		{name: "zero_start", mutfn: func(p *chplan.RangeWindowResample) { p.Start = time.Time{} }},
+		{name: "zero_end", mutfn: func(p *chplan.RangeWindowResample) { p.End = time.Time{} }},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			p := base
+			c.mutfn(&p)
+			if _, _, err := chsql.Emit(context.Background(), &p); err == nil {
+				t.Errorf("expected RangeWindowResample to reject %s, got nil error", c.name)
+			}
+		})
+	}
+}
+
+// TestRangeBucketFanoutRejectsBadInput pins the fan-out emitter's
+// pre-flight guards (Step <= 0, nil Input, empty TimestampCol/AnchorAlias,
+// no AggFunc, and Start > End). The Step <= 0 case in particular kills the
+// CONDITIONALS_BOUNDARY mutant at the `r.Step <= 0` guard; the Start > End
+// case kills the span-sign boundary mutant.
+func TestRangeBucketFanoutRejectsBadInput(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 5, 13, 12, 5, 0, 0, time.UTC)
+	mkAgg := func() []chplan.AggFunc {
+		return []chplan.AggFunc{
+			{
+				Name:  "argMax",
+				Alias: "BucketCounts",
+				Args: []chplan.Expr{
+					&chplan.ColumnRef{Name: "BucketCounts"},
+					&chplan.ColumnRef{Name: "TimeUnix"},
+				},
+			},
+		}
+	}
+	mkBase := func() chplan.RangeBucketFanout {
+		return chplan.RangeBucketFanout{
+			Input:        &chplan.Scan{Table: "otel_metrics_exponential_histogram"},
+			Start:        start,
+			End:          end,
+			Step:         30 * time.Second,
+			Lookback:     5 * time.Minute,
+			GroupBy:      []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+			AnchorAlias:  "anchor_ts",
+			TimestampCol: "TimeUnix",
+			AggFuncs:     mkAgg(),
+		}
+	}
+
+	cases := []struct {
+		name  string
+		mutfn func(p *chplan.RangeBucketFanout)
+	}{
+		{name: "zero_step", mutfn: func(p *chplan.RangeBucketFanout) { p.Step = 0 }},
+		{name: "neg_step", mutfn: func(p *chplan.RangeBucketFanout) { p.Step = -time.Second }},
+		{name: "nil_input", mutfn: func(p *chplan.RangeBucketFanout) { p.Input = nil }},
+		{name: "no_timestamp_col", mutfn: func(p *chplan.RangeBucketFanout) { p.TimestampCol = "" }},
+		{name: "no_anchor_alias", mutfn: func(p *chplan.RangeBucketFanout) { p.AnchorAlias = "" }},
+		{name: "no_agg_func", mutfn: func(p *chplan.RangeBucketFanout) { p.AggFuncs = nil }},
+		{name: "start_after_end", mutfn: func(p *chplan.RangeBucketFanout) { p.Start, p.End = end, start }},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			p := mkBase()
+			c.mutfn(&p)
+			if _, _, err := chsql.Emit(context.Background(), &p); err == nil {
+				t.Errorf("expected RangeBucketFanout to reject %s, got nil error", c.name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Why

The `mutation` required check fails on `main` via `gremlins phase2 (./internal/chsql @ 95%)` — efficacy **94.80% < 95%**. It regressed in #1048 ("perf(chsql): push inner-scan time bound on range query lowerings", `1c65b168`), which added new conditional / logical / arithmetic branches in the four range emitters (`range_lwr.go`, `range_bucket_fanout.go`, `range_window_native.go`, `range_window_resample.go`) and the shared `maybePushRangeScanTimeBound` helper. No package-level test killed the new mutants — the spec TXTAR goldens exercise these shapes, but the gremlins lane only runs `go test ./internal/chsql`, so the spec goldens don't count. Last green was 95.63%. This blocks the v1.5.0 release (#1055).

## What

Test-only additions to `internal/chsql/range_window_pushdown_test.go` (no emitter or golden changes). Each test distinguishes the mutated behaviour from the original:

- **Gate `start.IsZero() || end.IsZero()`** — exactly-one-set suppression cases for RangeLWR / RangeBucketFanout. The prior `_ZeroGridSuppressed` test set BOTH edges zero, so `||` and `&&` agree; the discriminating shape is *one* edge zero. Kills `INVERT_LOGICAL at range_lwr.go:240`.
- **Inner-scan bound math** — exact offset-shift (`toIntervalNanosecond(120000000000)`) + span-widening (`toIntervalNanosecond(300000000000)`) literal assertions across all four nodes. Kills the ARITHMETIC / boundary mutants on the `(Start - Offset - span, End - Offset]` bound.
- **numAnchors** — assert `least(11, …)` for RangeBucketFanout (mirrors the existing RangeLWR pin in `range_lwr_test.go`), killing the `/Step` and `+1` arithmetic mutants; a Start==End zero-span success case (`least(1,`) kills the `span < 0` boundary mutant at `range_bucket_fanout.go:99`.
- **Coverage** — RangeWindowNative / RangeWindowResample had **zero** package tests (entire emit path NOT_COVERED). New emit + bad-input + anchor-re-alias tests close that surface, including the `!= RangeWindowAnchorAlias` branch at `range_window_native.go:185`.
- **Bad-input guards** — empty-column / `Step<=0` / nil-Input / bad-AggFunc-Expr rejection tests for all four emitters.

## LIVED mutants killed (scoped gremlins on the four #1048 files)

| file:line | type |
|---|---|
| `range_lwr.go:240:20` | INVERT_LOGICAL (gate `\|\|`) |
| `range_bucket_fanout.go:99:11` | CONDITIONALS_BOUNDARY (`span < 0`) |
| `range_bucket_fanout.go:102:20` | ARITHMETIC_BASE (numAnchors `/`) |
| `range_bucket_fanout.go:102:28` | ARITHMETIC_BASE (numAnchors `+1`) |
| `range_window_native.go:185:23` | CONDITIONALS_NEGATION (`!=` anchor alias) |

Plus the previously NOT_COVERED native/resample guard + bound surface, all now KILLED.

## Result

Scoped gremlins on the four #1048 files: **60 killed / 1 lived / 0 not-covered, efficacy 98.36%**. The single survivor is `range_bucket_fanout.go:160:46 ARITHMETIC_BASE` — a `make([]Frag, 0, len(r.GroupBy)+1)` slice-capacity hint, an equivalent mutant (capacity doesn't change output; the exact pattern `mutation.yml` documents as unkillable).

This PR is non-release, so its own `mutation` check is **skipped** (per #1052) — verification is the local gremlins run. Once merged, the v1.5.0 release PR #1055 (full mutation matrix) clears the 95% phase2 floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)