### PR TITLE
feat(solver): per-deployment self-tuning route calibration (generic loop, local constants)

### DIFF
--- a/cmd/bench-report/matrix_chdb.go
+++ b/cmd/bench-report/matrix_chdb.go
@@ -181,7 +181,7 @@ func measureMatrixCell(ctx context.Context, s *session, iters int, st matrixStra
 	if err := cfg.Validate(); err != nil {
 		return matrixCell{}, fmt.Errorf("solver config: %w", err)
 	}
-	pl := &solver.Planner{Cfg: cfg}
+	pl := solver.NewPlanner(cfg)
 	gs, ge, gstep := solver.GridOf(plan)
 	dec, routed := pl.Plan(plan, solver.RequestMeta{
 		Lang: solver.LangPromQL, Start: gs, End: ge, Step: gstep,

--- a/cmd/bench-report/sharded_chdb.go
+++ b/cmd/bench-report/sharded_chdb.go
@@ -164,7 +164,7 @@ func measureSharded(s *session, iters int) (shardedResult, error) {
 	if err := cfg.Validate(); err != nil {
 		return shardedResult{}, fmt.Errorf("sharded config invalid: %w", err)
 	}
-	pl := &solver.Planner{Cfg: cfg}
+	pl := solver.NewPlanner(cfg)
 	gs, ge, gstep := solver.GridOf(plan)
 	dec, routed := pl.Plan(plan, solver.RequestMeta{
 		Lang:  solver.LangPromQL,

--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -809,12 +809,13 @@ func (a frontierReaderAdapter) ReadFrontier(ctx context.Context) ([]solver.Corpu
 			NAnchors:        int(b.NAnchors),
 			Fanout:          int(b.Fanout),
 			CumulativeD:     int(b.CumulativeD),
-			Route:           b.Route,
-			BelowThreshold:  b.BelowThreshold,
-			MemoryUsage:     b.MaxMemoryUsage,
-			QueryDurationMS: b.MaxQueryDurationMS,
-			OOM:             b.Danger,
-			Count:           int(b.Count),
+			Route:          b.Route,
+			BelowThreshold: b.BelowThreshold,
+			// MaxMemoryUsage / MaxQueryDurationMS are captured in the corpus
+			// bucket but the calibrator gates on the terminal-OOM coordinate
+			// (b.Danger) alone, so they are not forwarded.
+			OOM:   b.Danger,
+			Count: int(b.Count),
 		})
 	}
 	return out, nil

--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -88,7 +88,15 @@ func newAdmitLimiters(cfg config.Config, logger *slog.Logger) (*admit.Limiter, *
 // skips the gRPC branch and shutdown skips GracefulStop).
 type apiHeads struct {
 	grpcServer *grpc.Server
+	// selfTuner is the per-deployment route self-tuning loop, started only
+	// when CERBERUS_ROUTE_SELFTUNE is on and the PromQL head is enabled. nil
+	// otherwise; stopSelfTune is nil-safe so run() can defer it unconditionally.
+	selfTuner *solver.SelfTuner
 }
+
+// stopSelfTune joins the self-tuning goroutine (goleak-clean) if one was
+// started. A no-op when self-tuning is off.
+func (h apiHeads) stopSelfTune() { h.selfTuner.Stop() }
 
 // mountAPIHeads builds and mounts ONLY the query heads enabled by
 // CERBERUS_ENABLED_HEADS (default: all three) onto traceMux. A disabled head's
@@ -117,6 +125,10 @@ func mountAPIHeads(
 	// observes only live heads (a disabled head has no engine to observe).
 	var engines []*engine.Engine
 
+	// selfTuner is started only on the prom head when CERBERUS_ROUTE_SELFTUNE
+	// is on; nil otherwise. Returned in apiHeads so run() joins it on shutdown.
+	var selfTuner *solver.SelfTuner
+
 	if cfg.HeadEnabled(config.HeadProm) {
 		// Per-head Client VIEW (#94): own breaker over the shared pool. Built
 		// only for the prom head — and the prom-only sharded-pushdown solver is
@@ -130,6 +142,12 @@ func mountAPIHeads(
 		promHandler := newPromHandler(promClient, cfg, optSet, evalSolver, promLimiter, logger)
 		promHandler.Mount(traceMux)
 		engines = append(engines, promHandler.Engine)
+
+		// Per-deployment route self-tuning (off by default). When on, start the
+		// background loop that reads THIS deployment's router corpus and swaps
+		// locally-calibrated thresholds into the solver's Planner. Default off →
+		// nothing starts and routing uses the static shipped Config.
+		selfTuner = startRouteSelfTune(ctx, logger, promClient, cfg, evalSolver)
 	}
 
 	if cfg.HeadEnabled(config.HeadLoki) {
@@ -164,7 +182,7 @@ func mountAPIHeads(
 	// hot path).
 	startOptCorpus(ctx, logger, client, cfg, engines...)
 
-	return apiHeads{grpcServer: grpcServer}, nil
+	return apiHeads{grpcServer: grpcServer, selfTuner: selfTuner}, nil
 }
 
 // enabledHeadNames returns the enabled heads in the canonical prom,loki,tempo
@@ -360,6 +378,9 @@ func run() error {
 	if err != nil {
 		return err
 	}
+	// Join the route self-tune goroutine (if any) on shutdown so Close is
+	// goleak-clean. No-op when self-tuning is off.
+	defer heads.stopSelfTune()
 	grpcServer := heads.grpcServer
 
 	tracedAPI := wrapWithOTel(traceMux, "cerberus")
@@ -761,6 +782,93 @@ func buildSolver(
 	)
 	return s, nil
 }
+
+// frontierReaderAdapter bridges optcorpus.CHFrontierSource (which reads THIS
+// deployment's cerberus_router_corpus) to solver.FrontierReader (the calibrator
+// loop's input seam). It is the LOCAL data path: it maps each neutral
+// optcorpus.FrontierBucket into a solver.CorpusSample, the only
+// deployment-specific input Calibrate consumes. Keeping the mapping here (not in
+// either package) preserves the generic/local boundary — optcorpus owns the
+// table + CH read discipline, solver owns the calibration math, neither imports
+// the other.
+type frontierReaderAdapter struct {
+	src *optcorpus.CHFrontierSource
+}
+
+// ReadFrontier reads the local corpus aggregates and maps them to the
+// calibrator's sample shape. A nil/empty result is a legitimate "no signal yet"
+// and is passed straight through (Calibrate fails open on it).
+func (a frontierReaderAdapter) ReadFrontier(ctx context.Context) ([]solver.CorpusSample, error) {
+	buckets, err := a.src.ReadFrontier(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]solver.CorpusSample, 0, len(buckets))
+	for _, b := range buckets {
+		out = append(out, solver.CorpusSample{
+			NAnchors:        int(b.NAnchors),
+			Fanout:          int(b.Fanout),
+			CumulativeD:     int(b.CumulativeD),
+			Route:           b.Route,
+			BelowThreshold:  b.BelowThreshold,
+			MemoryUsage:     b.MaxMemoryUsage,
+			QueryDurationMS: b.MaxQueryDurationMS,
+			OOM:             b.Danger,
+			Count:           int(b.Count),
+		})
+	}
+	return out, nil
+}
+
+// startRouteSelfTune starts the per-deployment route self-tuning loop when
+// CERBERUS_ROUTE_SELFTUNE is on (carried on the resolved solver Config). It is
+// OFF by default: when the flag is unset the function returns nil and nothing
+// starts, so routing uses the static shipped Config and existing deployments
+// are byte-for-byte unchanged. When on, it wires the local corpus reader to the
+// generic calibrator loop and hands it the resolved Config as both the
+// conservative defaults (calibration floor / fail-open fallback) and the value
+// the loop swaps into the solver's Planner.
+func startRouteSelfTune(
+	ctx context.Context,
+	logger *slog.Logger,
+	client *chclient.Client,
+	cfg config.Config,
+	s *solver.Solver,
+) *solver.SelfTuner {
+	if s == nil || !s.Cfg.SelfTune {
+		return nil
+	}
+	// Reuse the corpus read discipline: bound each frontier SELECT in
+	// wall-clock and derive the lookback window from the recalibration
+	// interval so a longer interval still covers more than one read.
+	srcTimeout := selfTuneReadTimeout
+	window := optcorpus.QueryLogWindow(selfTuneInterval)
+	src := optcorpus.NewCHFrontierSource(client.Conn(), srcTimeout, window)
+	tuner := solver.StartSelfTuner(ctx, solver.SelfTuneParams{
+		Planner:  s.Planner,
+		Reader:   frontierReaderAdapter{src: src},
+		Defaults: s.Cfg,
+		Interval: selfTuneInterval,
+		Logger:   logger.With("component", "route-selftune"),
+	})
+	logger.Info(
+		"per-deployment route self-tuning started (constants learned locally from this deployment's corpus)",
+		"interval", selfTuneInterval.String(),
+		"defaults_min_fanout", s.Cfg.MinFanout,
+		"defaults_min_anchor_pairs", s.Cfg.MinAnchorPairs,
+	)
+	return tuner
+}
+
+// selfTuneInterval is the recalibration cadence and selfTuneReadTimeout bounds
+// each corpus frontier read in wall-clock. The interval is long because the
+// cost frontier moves on the timescale of workload shifts, not seconds; the
+// read timeout is the belt-and-braces client deadline on top of the server-side
+// max_execution_time cap.
+const (
+	selfTuneInterval    = 15 * time.Minute
+	selfTuneReadTimeout = 30 * time.Second
+)
 
 // warnIfClickHouseUnreachable performs the best-effort startup
 // connectivity validation, demoted to a WARN. A replica that boots

--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -806,9 +806,9 @@ func (a frontierReaderAdapter) ReadFrontier(ctx context.Context) ([]solver.Corpu
 	out := make([]solver.CorpusSample, 0, len(buckets))
 	for _, b := range buckets {
 		out = append(out, solver.CorpusSample{
-			NAnchors:        int(b.NAnchors),
-			Fanout:          int(b.Fanout),
-			CumulativeD:     int(b.CumulativeD),
+			NAnchors:       int(b.NAnchors),
+			Fanout:         int(b.Fanout),
+			CumulativeD:    int(b.CumulativeD),
 			Route:          b.Route,
 			BelowThreshold: b.BelowThreshold,
 			// MaxMemoryUsage / MaxQueryDurationMS are captured in the corpus

--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math"
 	"net/http"
 	"net/http/pprof"
 	"os"
@@ -805,6 +806,13 @@ func (a frontierReaderAdapter) ReadFrontier(ctx context.Context) ([]solver.Corpu
 	}
 	out := make([]solver.CorpusSample, 0, len(buckets))
 	for _, b := range buckets {
+		// Count is a uint64 corpus row aggregate; bound it before the int
+		// conversion so gosec G115 is satisfied. A bucket can never realistically
+		// hold 2^31 rows, so the clamp is a safety net, not an expected path.
+		count := b.Count
+		if count > math.MaxInt32 {
+			count = math.MaxInt32
+		}
 		out = append(out, solver.CorpusSample{
 			NAnchors:       int(b.NAnchors),
 			Fanout:         int(b.Fanout),
@@ -815,7 +823,7 @@ func (a frontierReaderAdapter) ReadFrontier(ctx context.Context) ([]solver.Corpu
 			// bucket but the calibrator gates on the terminal-OOM coordinate
 			// (b.Danger) alone, so they are not forwarded.
 			OOM:   b.Danger,
-			Count: int(b.Count),
+			Count: int(count),
 		})
 	}
 	return out, nil

--- a/cmd/cerberus/selftune_wiring_test.go
+++ b/cmd/cerberus/selftune_wiring_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/config"
+	"github.com/tsouza/cerberus/internal/solver"
+)
+
+// TestStartRouteSelfTune_OffByDefault is the zero-behavior-change proof: with
+// the default solver Config (SelfTune == false) startRouteSelfTune must return
+// nil and start nothing — it returns before ever touching the CH client, so a
+// nil client is safe here. This pins that an existing deployment (which never
+// sets CERBERUS_ROUTE_SELFTUNE) gets no loop and no behavior change.
+func TestStartRouteSelfTune_OffByDefault(t *testing.T) {
+	cfg := solver.DefaultConfig()
+	if cfg.SelfTune {
+		t.Fatal("DefaultConfig.SelfTune must be false (off by default)")
+	}
+	s := solver.New(cfg, nil, solver.ExecDeps{})
+
+	tuner := startRouteSelfTune(
+		context.Background(),
+		slog.Default(),
+		nil, // never dereferenced on the off path
+		config.Config{},
+		s,
+	)
+	if tuner != nil {
+		tuner.Stop()
+		t.Fatal("self-tuning must not start when SelfTune is off")
+	}
+}
+
+// TestStartRouteSelfTune_NilSolver: a disabled prom head passes a nil solver;
+// startRouteSelfTune must tolerate it and return nil.
+func TestStartRouteSelfTune_NilSolver(t *testing.T) {
+	if tuner := startRouteSelfTune(context.Background(), slog.Default(), nil, config.Config{}, nil); tuner != nil {
+		tuner.Stop()
+		t.Fatal("nil solver must yield a nil tuner")
+	}
+}
+
+// TestConfigFromEnv_SelfTuneOffByDefault pins that the env builder leaves
+// SelfTune false unless the operator opts in.
+func TestConfigFromEnv_SelfTuneOffByDefault(t *testing.T) {
+	t.Setenv(solver.EnvRouteSelfTune, "")
+	cfg, err := solver.ConfigFromEnv()
+	if err != nil {
+		t.Fatalf("ConfigFromEnv: %v", err)
+	}
+	if cfg.SelfTune {
+		t.Fatal("unset CERBERUS_ROUTE_SELFTUNE must leave SelfTune false")
+	}
+
+	t.Setenv(solver.EnvRouteSelfTune, "true")
+	on, err := solver.ConfigFromEnv()
+	if err != nil {
+		t.Fatalf("ConfigFromEnv (on): %v", err)
+	}
+	if !on.SelfTune {
+		t.Fatal("CERBERUS_ROUTE_SELFTUNE=true must enable SelfTune")
+	}
+}

--- a/docs/solver.md
+++ b/docs/solver.md
@@ -371,3 +371,86 @@ Run [`router-calibration.sql`](router-calibration.sql) against the corpus table:
   — route-A queries OOM/timeout (query 4). Any non-trivial route-A failure
   count is a standalone go signal: the query died on the single path the
   heuristic chose for it.
+
+## Per-deployment self-tuning
+
+Stage 0 records each deployment's own observed cost into
+`cerberus_router_corpus`. **Per-deployment self-tuning** closes that loop at
+runtime: when enabled, cerberus periodically reads *its own* corpus, derives
+route thresholds calibrated to *that deployment's* cost frontier, and swaps them
+into the live router — so squid's data tunes squid only, and any other install
+tunes itself from its own corpus.
+
+The architecture is deliberately split into a generic half and a local half, and
+the split is the whole point:
+
+- **Generic (shipped to every deployment).** The calibration *logic*, the
+  background *loop*, and a *conservative default* for the thresholds. This is
+  deployment-independent: `Calibrate` (`internal/solver/calibrate.go`) is a pure,
+  deterministic function whose only deployment-specific input is the corpus
+  samples; the loop (`internal/solver/selftune.go`) and the shipped
+  `DefaultConfig` carry **no** learned constants. A fresh install runs the same
+  code over its own (initially empty) corpus.
+- **Local (never shipped).** The *calibrated constants* themselves, derived **at
+  runtime** from this deployment's `cerberus_router_corpus` and held in memory
+  only. They are never written back into the shipped code or defaults. A single
+  deployment's corpus deliberately never leaks into the shipped defaults —
+  baking one install's numbers into the binary would over-fit every other
+  deployment to a workload it never runs.
+
+This is **optimizer self-tuning, not result caching**: it adjusts which *plan
+shape* (single vs sharded) the router chooses, never memoizes query results, and
+honors the no-caching invariant (only `/readyz` has a TTL).
+
+### What the calibrator does
+
+`Calibrate(samples, defaults) → (Config, CalibrationReport)` reads the empirical
+cost frontier from the local corpus — the smallest fan-out `F` and anchor-pair
+product `N×F` at which the deployment actually observed OOM/cost-danger
+dispatches (`exit_status` ∈ `oom` / `timeout` / `sample_budget`) — and derives
+thresholds that route B *before* that frontier. Only `MinFanout` and
+`MinAnchorPairs` are calibrated; the geometric knobs (`MaxK`,
+`MinAnchorsPerSlice`, the high-`D` clamp) are structural grid invariants the
+corpus does not re-derive, so they pass through from the defaults untouched.
+
+The derivation is expressed in the corpus's own relative `(F, N×F)` coordinates
+scaled by a shipped safety-margin percent — not absolutes hardcoded to one
+deployment.
+
+### Safety rails (non-negotiable, each has a test)
+
+- **Conservative-floor / tighten-only.** A calibrated threshold may only move in
+  the *safer* direction — lower, so the deployment shards **more** readily as it
+  approaches its own OOM frontier. This is the PARQO asymmetric penalty:
+  under-sharding into an OOM is catastrophic, over-sharding merely wastes a
+  connection. `Calibrate` never *raises* a threshold and never lowers past the
+  shipped safety floor (`minCalibratedFanout` / `minCalibratedAnchorPairs`).
+- **Fail-open / no-op without signal.** A thin corpus (below the min-sample
+  floor), no `below-threshold` decisions, or no OOM/cost-danger exemplars →
+  `Calibrate` returns `defaults` **unchanged**. On squid today the corpus is all
+  route-A, `below-threshold = 0`, and zero failures, so `Calibrate` returns the
+  defaults **verbatim** — a true no-op (pinned by
+  `TestCalibrate_NoOpOnSquidShapedCorpus`).
+- **Off by default.** The loop is gated behind `CERBERUS_ROUTE_SELFTUNE`
+  (default off). Unset → the router uses the static shipped `Config` and the loop
+  never starts, so existing deployments are byte-for-byte unchanged.
+
+### The loop
+
+When `CERBERUS_ROUTE_SELFTUNE` is on, `cmd/cerberus` starts a background
+goroutine after the PromQL solver is built. On a fixed cadence it reads the
+local corpus (`optcorpus.CHFrontierSource` — a few aggregate SELECTs per
+`(N, F[, D])` bucket, never all rows, under the same rate-limited /
+deprioritised / read-only / failure-open discipline as the query_log source),
+runs `Calibrate`, and **atomically** swaps the new `Config` into the router
+(`Planner.cfg` is an `atomic.Pointer[Config]`; `Plan` reads it lock-free). Any
+read or calibrate error keeps the current `Config`, logs, and never crashes
+(fail-open). The loop derives its context from a cancelable parent and cancels
+in-flight reads on shutdown, so `Close` is goleak-clean (it mirrors — and fixes
+— the `breaker_recovery.go` recovery-loop shape: no context rooted in
+`context.Background()` without cancellation).
+
+Every recalibration logs the active thresholds plus a `CalibrationReport`
+(sample count, what moved versus the default and why, the detected frontier), so
+operators can **see** what their deployment self-tuned to and that the constants
+are local to their install.

--- a/docs/solver.md
+++ b/docs/solver.md
@@ -405,13 +405,26 @@ honors the no-caching invariant (only `/readyz` has a TTL).
 ### What the calibrator does
 
 `Calibrate(samples, defaults) → (Config, CalibrationReport)` reads the empirical
-cost frontier from the local corpus — the smallest fan-out `F` and anchor-pair
-product `N×F` at which the deployment actually observed OOM/cost-danger
-dispatches (`exit_status` ∈ `oom` / `timeout` / `sample_budget`) — and derives
-thresholds that route B *before* that frontier. Only `MinFanout` and
-`MinAnchorPairs` are calibrated; the geometric knobs (`MaxK`,
-`MinAnchorsPerSlice`, the high-`D` clamp) are structural grid invariants the
-corpus does not re-derive, so they pass through from the defaults untouched.
+**terminal-OOM** frontier from the local corpus — the single binding coordinate
+at which the deployment actually observed OOM/cost-danger dispatches
+(`exit_status` ∈ `oom` / `timeout` / `sample_budget`) — and derives thresholds
+that route B *before* that frontier. Only `MinFanout` and `MinAnchorPairs` are
+calibrated; the geometric knobs (`MaxK`, `MinAnchorsPerSlice`, the high-`D`
+clamp) are structural grid invariants the corpus does not re-derive, so they
+pass through from the defaults untouched.
+
+The frontier is read from the terminal outcome only — there is **no** soft
+cost-gradient model. The corpus bucket still records peak memory and wall-clock
+(`optcorpus.FrontierBucket`), but the calibrator does not consult them; gating
+purely on the terminal OOM keeps the shipped behaviour honest about what it
+measures.
+
+The frontier coordinate is **coupled**: both axes (`F` and `N×F`) are read from
+the *same* OOM sample — the one with the smallest anchor-pair product (the
+binding danger corner closest to the safe region). The two axes are never
+minimized independently across different samples, which would invent a synthetic
+corner at no real query and let a fanout-gated OOM drag the anchor-pair frontier
+down.
 
 The derivation is expressed in the corpus's own relative `(F, N×F)` coordinates
 scaled by a shipped safety-margin percent — not absolutes hardcoded to one
@@ -425,6 +438,19 @@ deployment.
   under-sharding into an OOM is catastrophic, over-sharding merely wastes a
   connection. `Calibrate` never *raises* a threshold and never lowers past the
   shipped safety floor (`minCalibratedFanout` / `minCalibratedAnchorPairs`).
+- **Floor / margin interaction (surfaced, never silent).** The safety margin
+  puts route B a fixed percent *below* the frontier. When the frontier sits so
+  close to the floor that the margin-reduced target would fall below the floor,
+  the floor wins on the tighten-only invariant — but the full margin is then
+  *gone*, and a genuine **sub-floor** OOM (frontier ≤ floor) is worse: pinning to
+  the floor would install a gate *above* the OOM coordinate, leaving an
+  already-OOMing query on route A. The calibrator handles both honestly: in the
+  sub-floor case it caps **strictly below** the frontier (so route B still fires
+  before the danger zone) instead of pinning above it, and in either case it sets
+  `CalibrationReport.FloorClamped{Fanout,AnchorPairs}` and the loop logs a
+  `WARN`. Operators *see* when the floor has swallowed the margin rather than the
+  threshold moving silently. (If a deployment legitimately OOMs below the shipped
+  floor, the floor itself — not the calibrator — is the thing to lower.)
 - **Fail-open / no-op without signal.** A thin corpus (below the min-sample
   floor), no `below-threshold` decisions, or no OOM/cost-danger exemplars →
   `Calibrate` returns `defaults` **unchanged**. For a no-signal corpus that is
@@ -453,4 +479,6 @@ in-flight reads on shutdown, so `Close` is goleak-clean (it mirrors — and fixe
 Every recalibration logs the active thresholds plus a `CalibrationReport`
 (sample count, what moved versus the default and why, the detected frontier), so
 operators can **see** what their deployment self-tuned to and that the constants
-are local to their install.
+are local to their install. When the safety floor swallowed the margin near the
+frontier, the loop additionally logs a `WARN` carrying the floor-clamp flags, the
+frontier, and the installed thresholds.

--- a/docs/solver.md
+++ b/docs/solver.md
@@ -378,8 +378,8 @@ Stage 0 records each deployment's own observed cost into
 `cerberus_router_corpus`. **Per-deployment self-tuning** closes that loop at
 runtime: when enabled, cerberus periodically reads *its own* corpus, derives
 route thresholds calibrated to *that deployment's* cost frontier, and swaps them
-into the live router — so squid's data tunes squid only, and any other install
-tunes itself from its own corpus.
+into the live router — so a deployment's data tunes that deployment only, and
+any other install tunes itself from its own corpus.
 
 The architecture is deliberately split into a generic half and a local half, and
 the split is the whole point:
@@ -427,10 +427,10 @@ deployment.
   shipped safety floor (`minCalibratedFanout` / `minCalibratedAnchorPairs`).
 - **Fail-open / no-op without signal.** A thin corpus (below the min-sample
   floor), no `below-threshold` decisions, or no OOM/cost-danger exemplars →
-  `Calibrate` returns `defaults` **unchanged**. On squid today the corpus is all
-  route-A, `below-threshold = 0`, and zero failures, so `Calibrate` returns the
-  defaults **verbatim** — a true no-op (pinned by
-  `TestCalibrate_NoOpOnSquidShapedCorpus`).
+  `Calibrate` returns `defaults` **unchanged**. For a no-signal corpus that is
+  all route-A, with `below-threshold = 0` and zero failures, `Calibrate` returns
+  the defaults **verbatim** — a true no-op (pinned by
+  `TestCalibrate_NoOpOnNoSignalCorpus`).
 - **Off by default.** The loop is gated behind `CERBERUS_ROUTE_SELFTUNE`
   (default off). Unset → the router uses the static shipped `Config` and the loop
   never starts, so existing deployments are byte-for-byte unchanged.

--- a/internal/optcorpus/frontier.go
+++ b/internal/optcorpus/frontier.go
@@ -1,0 +1,154 @@
+package optcorpus
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+)
+
+// Per-deployment self-tuning corpus reader.
+//
+// This is the LOCAL data path for route self-tuning: it reads aggregated cost
+// frontier buckets from THIS deployment's cerberus_router_corpus table and
+// hands them to the GENERIC calibrator (internal/solver). It never reads all
+// rows — it runs a small set of aggregate SELECTs (one GROUP BY over the
+// (n_anchors, fanout, cumulative_d, route, danger) buckets) and returns one
+// FrontierBucket per group. It reuses the exact CH read discipline the
+// query_log source uses: bounded wall-clock context, single-threaded,
+// deprioritised, hard row/byte caps, read-only, failure-open.
+//
+// FrontierBucket is intentionally a neutral aggregate type that carries NO
+// solver dependency, so optcorpus stays decoupled from the calibrator (the
+// cmd/cerberus wiring maps FrontierBucket → solver.CorpusSample). This keeps
+// the generic/local boundary clean: optcorpus owns the table + read discipline;
+// solver owns the calibration math; neither imports the other.
+
+// FrontierBucket is one aggregated cost-grid bucket from the local corpus: the
+// (N, F, D) coordinates plus the observed cost summary and whether queries in
+// this bucket reached the OOM/cost danger zone. It is the per-deployment input
+// the self-tuner aggregates into a frontier.
+type FrontierBucket struct {
+	// NAnchors / Fanout / CumulativeD are the cost-grid coordinates (the
+	// corpus n_anchors / fanout / cumulative_d columns).
+	NAnchors    uint32
+	Fanout      uint32
+	CumulativeD uint32
+
+	// Route is the routing read-out: "A" or "B".
+	Route string
+
+	// BelowThreshold is true when this bucket's decision_reason was
+	// below-threshold (eligible but kept on route A by the cost thresholds) —
+	// the evidence the thresholds actually gated a plan.
+	BelowThreshold bool
+
+	// Danger is true when this bucket's exit_status reached the OOM/cost
+	// danger zone (oom / timeout / sample_budget) — the frontier-defining
+	// catastrophes route B exists to avoid.
+	Danger bool
+
+	// MaxMemoryUsage / MaxQueryDurationMS are the worst observed cost in the
+	// bucket (bytes / ms).
+	MaxMemoryUsage     uint64
+	MaxQueryDurationMS uint64
+
+	// Count is how many corpus rows this bucket aggregates.
+	Count uint64
+}
+
+// frontierAggSQL aggregates the local corpus into cost-grid buckets for
+// self-tuning. It groups by the (N, F, D) coordinates plus two derived
+// booleans — whether the decision was below-threshold, and whether the exit
+// reached the OOM/cost danger zone — so each returned row is one
+// (coordinate × below-threshold × danger) bucket with its worst observed cost
+// and row count. The event_time lookback is bounded by a parameter (derived
+// from the recalibration interval) so a huge corpus is never scanned in full.
+//
+// The danger set (oom / timeout / sample_budget) mirrors solver's
+// CorpusSample.OOM contract and the corpus Enum8 tokens (chtable.go). It is a
+// fixed const query with a single parameterised window — no value is
+// concatenated into the SQL — matching the queryLogSQL precedent in
+// chsource.go.
+const frontierAggSQL = `SELECT
+		n_anchors,
+		fanout,
+		cumulative_d,
+		toString(route) AS route_token,
+		decision_reason = 'below-threshold' AS below_threshold,
+		toString(exit_status) IN ('oom', 'timeout', 'sample_budget') AS danger,
+		max(memory_usage) AS max_memory_usage,
+		max(query_duration_ms) AS max_query_duration_ms,
+		count() AS row_count
+	FROM ` + CorpusTableName + `
+	WHERE event_time > now() - INTERVAL ? SECOND
+	GROUP BY n_anchors, fanout, cumulative_d, route_token, below_threshold, danger`
+
+// CHFrontierSource reads aggregated frontier buckets from the local corpus
+// table over a narrow CH read surface. It mirrors CHQueryLogSource: a bounded
+// per-read context plus server-side conservative settings, so the self-tune
+// reader can never starve the data plane.
+type CHFrontierSource struct {
+	conn    CHConn
+	timeout time.Duration
+	window  time.Duration
+}
+
+// NewCHFrontierSource builds a frontier source over conn (typically
+// chclient.Client.Conn()). A non-positive timeout / window falls back to the
+// same conservative defaults the query_log source uses, so the reader goroutine
+// can never block indefinitely and always bounds its lookback.
+func NewCHFrontierSource(conn CHConn, timeout, window time.Duration) *CHFrontierSource {
+	if timeout <= 0 {
+		timeout = 15 * time.Second
+	}
+	if window <= 0 {
+		window = defaultQueryLogWindow
+	}
+	return &CHFrontierSource{conn: conn, timeout: timeout, window: window}
+}
+
+// ReadFrontier runs the bounded aggregate SELECT and decodes the buckets. It is
+// read-only and failure-open: on any error it returns the error (the caller —
+// the self-tune loop — keeps the current Config and retries next interval). An
+// empty result (no corpus yet) returns (nil, nil), a legitimate "no signal".
+func (s *CHFrontierSource) ReadFrontier(ctx context.Context) ([]FrontierBucket, error) {
+	// Hard wall-clock bound on top of server-side max_execution_time so a
+	// stuck scan can never pin the self-tune goroutine until shutdown.
+	ctx, cancel := context.WithTimeout(ctx, s.timeout)
+	defer cancel()
+	// Stamp the conservative resource caps so this background read cannot
+	// disturb the data plane, exactly as the query_log source does.
+	ctx = clickhouse.Context(ctx, clickhouse.WithSettings(corpusSettings()))
+
+	windowSeconds := int64(s.window / time.Second)
+	rows, err := s.conn.Query(ctx, frontierAggSQL, windowSeconds)
+	if err != nil {
+		return nil, fmt.Errorf("optcorpus: query %s frontier: %w", CorpusTableName, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []FrontierBucket
+	for rows.Next() {
+		var b FrontierBucket
+		if err := rows.Scan(
+			&b.NAnchors,
+			&b.Fanout,
+			&b.CumulativeD,
+			&b.Route,
+			&b.BelowThreshold,
+			&b.Danger,
+			&b.MaxMemoryUsage,
+			&b.MaxQueryDurationMS,
+			&b.Count,
+		); err != nil {
+			return nil, fmt.Errorf("optcorpus: scan frontier bucket: %w", err)
+		}
+		out = append(out, b)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("optcorpus: frontier rows: %w", err)
+	}
+	return out, nil
+}

--- a/internal/optcorpus/frontier_test.go
+++ b/internal/optcorpus/frontier_test.go
@@ -1,0 +1,68 @@
+package optcorpus
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNewCHFrontierSource_Fallbacks(t *testing.T) {
+	// Non-positive timeout / window fall back to the conservative defaults so
+	// the self-tune read can never block indefinitely or scan unbounded.
+	src := NewCHFrontierSource(&capturingConn{}, 0, 0)
+	if src.window != defaultQueryLogWindow {
+		t.Errorf("non-positive window = %s; want default %s", src.window, defaultQueryLogWindow)
+	}
+	if src.timeout <= 0 {
+		t.Errorf("non-positive timeout must fall back to a positive default, got %s", src.timeout)
+	}
+}
+
+func TestCHFrontierSource_PassesWindowSeconds(t *testing.T) {
+	conn := &capturingConn{}
+	// 2h window -> 7200 seconds is the single bound arg (no value is ever
+	// concatenated into the SQL).
+	src := NewCHFrontierSource(conn, time.Second, 2*time.Hour)
+	_, err := src.ReadFrontier(context.Background())
+	if err == nil {
+		t.Fatal("ReadFrontier: want stub error, got nil")
+	}
+	if len(conn.gotArgs) != 1 {
+		t.Fatalf("query args = %d; want 1 (window seconds)", len(conn.gotArgs))
+	}
+	if got, ok := conn.gotArgs[0].(int64); !ok || got != 7200 {
+		t.Errorf("first arg = %v; want int64(7200) window seconds", conn.gotArgs[0])
+	}
+}
+
+// TestFrontierAggSQL_ShapeContract pins the aggregate SQL's structural
+// contract: it reads from the corpus table, is bounded by a parameterised
+// event_time window (never an inlined value), groups by the cost-grid
+// coordinates, and classifies the danger set as the three OOM/cost outcomes
+// route B exists to avoid. This is a cheap regression guard on the read shape.
+func TestFrontierAggSQL_ShapeContract(t *testing.T) {
+	sql := frontierAggSQL
+	mustContain := []string{
+		"FROM " + CorpusTableName,
+		"event_time > now() - INTERVAL ? SECOND",
+		"GROUP BY",
+		"n_anchors",
+		"fanout",
+		"cumulative_d",
+		"decision_reason = 'below-threshold'",
+		"'oom', 'timeout', 'sample_budget'",
+		"max(memory_usage)",
+		"count()",
+	}
+	for _, frag := range mustContain {
+		if !strings.Contains(sql, frag) {
+			t.Errorf("frontierAggSQL missing %q", frag)
+		}
+	}
+	// No GROUP BY on a non-aggregated cost column would be a logic bug; assert
+	// the aggregates are real.
+	if !strings.Contains(sql, "AS row_count") {
+		t.Error("frontierAggSQL must alias the count() as row_count")
+	}
+}

--- a/internal/schema/ddl/idempotency_test.go
+++ b/internal/schema/ddl/idempotency_test.go
@@ -82,7 +82,7 @@ func TestRenderCreateDatabase(t *testing.T) {
 // engine path: the CREATE DATABASE statement carries
 // `ENGINE = Replicated(<path>, <shard>, <replica>)`, the shard/replica
 // default to the server macros when unset, and an explicit override is
-// honoured. This is the squid-style clustered shape where the Replicated
+// honoured. This is a replicated clustered shape where the Replicated
 // database auto-replicates DDL (the tables themselves get an explicit
 // ReplicatedMergeTree engine to replicate their DATA).
 func TestRenderCreateDatabase_ReplicatedEngine(t *testing.T) {

--- a/internal/solver/avb_chdb_lane_test.go
+++ b/internal/solver/avb_chdb_lane_test.go
@@ -160,7 +160,7 @@ func TestSolver_AvsB_ChDB_Differential(t *testing.T) {
 	for _, query := range laneFixtures {
 		plan := optimizedPlan(t, ctx, query)
 
-		pl := &solver.Planner{Cfg: cfg}
+		pl := solver.NewPlanner(cfg)
 		gs, ge, gstep := solver.GridOf(plan)
 		dec, isRouted := pl.Plan(plan, solver.RequestMeta{
 			Lang:  solver.LangPromQL,

--- a/internal/solver/calibrate.go
+++ b/internal/solver/calibrate.go
@@ -205,10 +205,10 @@ func Calibrate(samples []CorpusSample, defaults Config) (Config, CalibrationRepo
 		return defaults, report
 	}
 
-	// Find the empirical danger frontier: the SMALLEST Fanout and smallest
-	// (N×F) anchor-pair product at which the deployment actually observed
-	// OOM/cost-danger dispatches, weighted by a min-danger-sample floor so a
-	// single unlucky OOM is treated as noise.
+	// Find the empirical danger frontier: the COUPLED (Fanout, N×F) coordinate
+	// of the single binding OOM sample (smallest anchor-pair product) at which
+	// the deployment actually observed OOM/cost-danger dispatches, weighted by a
+	// min-danger-sample floor so a single unlucky OOM is treated as noise.
 	frontierF, frontierPairs, dangerCount, sawBelowThreshold := scanFrontier(samples)
 
 	report.FrontierFanout = frontierF

--- a/internal/solver/calibrate.go
+++ b/internal/solver/calibrate.go
@@ -93,11 +93,23 @@ type CalibrationReport struct {
 	Changes []ThresholdChange
 
 	// FrontierFanout / FrontierAnchorPairs record the empirical frontier the
-	// run detected: the smallest Fanout / (N×F) anchor-pair product at which
-	// the corpus showed OOM/cost-danger samples. Zero when no danger frontier
-	// was observed. Reported even on a no-op so operators see the evidence.
+	// run detected: the COUPLED (single-OOM-coordinate) Fanout / (N×F)
+	// anchor-pair product that defines the binding danger corner. Zero when no
+	// danger frontier was observed. Reported even on a no-op so operators see
+	// the evidence.
 	FrontierFanout      int
 	FrontierAnchorPairs int
+
+	// FloorClampedFanout / FloorClampedAnchorPairs are set when the shipped
+	// safety floor (minCalibratedFanout / minCalibratedAnchorPairs) bound the
+	// calibrated threshold at or ABOVE the margin-reduced frontier — i.e. the
+	// floor swallowed the safety margin (and, in the sub-floor case, would have
+	// installed a gate above the actual OOM coordinate). When set, the
+	// calibrated threshold no longer sits a full margin below the frontier; the
+	// loop logs a WARN so operators see the rail has been reached. This is the
+	// honest surfacing the floor previously hid (it moved silently before).
+	FloorClampedFanout      bool
+	FloorClampedAnchorPairs bool
 }
 
 // ThresholdChange is one field's defaults → calibrated movement plus a short
@@ -213,17 +225,17 @@ func Calibrate(samples []CorpusSample, defaults Config) (Config, CalibrationRepo
 	}
 
 	// We have a real frontier. Derive calibrated thresholds that route B
-	// strictly BEFORE it, then apply tighten-only + safety-floor clamps.
+	// strictly BEFORE it, then apply tighten-only + safety-floor clamps. Each
+	// axis reports whether the floor swallowed the safety margin so the loop can
+	// WARN (and so a genuine sub-floor OOM caps strictly below the frontier
+	// rather than installing a gate above the OOM coordinate).
 	calibrated := defaults
 
-	wantFanout := applyMargin(frontierF)
-	wantPairs := applyMargin(frontierPairs)
-
-	calibrated.MinFanout = clampTighten(
-		defaults.MinFanout, wantFanout, minCalibratedFanout,
+	calibrated.MinFanout, report.FloorClampedFanout = calibrateAxis(
+		defaults.MinFanout, frontierF, minCalibratedFanout,
 	)
-	calibrated.MinAnchorPairs = clampTighten(
-		defaults.MinAnchorPairs, wantPairs, minCalibratedAnchorPairs,
+	calibrated.MinAnchorPairs, report.FloorClampedAnchorPairs = calibrateAxis(
+		defaults.MinAnchorPairs, frontierPairs, minCalibratedAnchorPairs,
 	)
 
 	if calibrated.MinFanout != defaults.MinFanout {
@@ -231,7 +243,7 @@ func Calibrate(samples []CorpusSample, defaults Config) (Config, CalibrationRepo
 			Field: "MinFanout",
 			From:  defaults.MinFanout,
 			To:    calibrated.MinFanout,
-			Why:   "observed OOM/cost-danger at lower fanout; shard before the local frontier",
+			Why:   axisWhy("fanout", report.FloorClampedFanout),
 		})
 	}
 	if calibrated.MinAnchorPairs != defaults.MinAnchorPairs {
@@ -239,7 +251,7 @@ func Calibrate(samples []CorpusSample, defaults Config) (Config, CalibrationRepo
 			Field: "MinAnchorPairs",
 			From:  defaults.MinAnchorPairs,
 			To:    calibrated.MinAnchorPairs,
-			Why:   "observed OOM/cost-danger at fewer anchor-pairs; shard before the local frontier",
+			Why:   axisWhy("anchor-pairs", report.FloorClampedAnchorPairs),
 		})
 	}
 
@@ -255,22 +267,32 @@ func Calibrate(samples []CorpusSample, defaults Config) (Config, CalibrationRepo
 	return calibrated, report
 }
 
-// scanFrontier finds, across all samples, the smallest Fanout and smallest
-// (N×F) anchor-pair product at which the deployment observed OOM/cost-danger
-// dispatches, plus the total danger-sample count and whether any
-// below-threshold decision exists. Deterministic: samples are sorted before
-// scanning so the result never depends on input order.
+// scanFrontier finds the deployment's binding danger corner: ONE OOM sample's
+// COUPLED (Fanout, N×F) coordinate, plus the total danger-sample count and
+// whether any below-threshold decision exists. Deterministic: samples are
+// sorted before scanning so the result never depends on input order.
+//
+// COUPLED, not per-axis-independent. An earlier version minimised frontierF and
+// frontierPairs separately, so the two could come from two DIFFERENT OOM
+// samples — a synthetic corner that exists at no real query, and that let a
+// fanout-gated OOM (small fanout, large N → large pairs) drag the pairs
+// frontier down below where the pairs axis is actually dangerous. Both frontier
+// values now come from the SAME sample: the OOM coordinate with the smallest
+// anchor-pair product (ties broken by smaller fanout, then D, then Route for
+// determinism). Anchor-pairs is the dominant cost proxy (route B exists to cap
+// the N×F scan), so the smallest-pairs OOM is the corner closest to the safe
+// region — the conservative binding frontier.
 func scanFrontier(samples []CorpusSample) (frontierF, frontierPairs, dangerCount int, sawBelowThreshold bool) {
 	ordered := make([]CorpusSample, len(samples))
 	copy(ordered, samples)
 	sort.Slice(ordered, func(i, j int) bool {
 		a, b := ordered[i], ordered[j]
-		if a.Fanout != b.Fanout {
-			return a.Fanout < b.Fanout
-		}
 		ap, bp := a.NAnchors*a.Fanout, b.NAnchors*b.Fanout
 		if ap != bp {
 			return ap < bp
+		}
+		if a.Fanout != b.Fanout {
+			return a.Fanout < b.Fanout
 		}
 		if a.CumulativeD != b.CumulativeD {
 			return a.CumulativeD < b.CumulativeD
@@ -293,11 +315,14 @@ func scanFrontier(samples []CorpusSample) (frontierF, frontierPairs, dangerCount
 		}
 		dangerCount += c
 
-		if s.Fanout > 0 && (frontierF == 0 || s.Fanout < frontierF) {
-			frontierF = s.Fanout
-		}
 		pairs := s.NAnchors * s.Fanout
-		if pairs > 0 && (frontierPairs == 0 || pairs < frontierPairs) {
+		if pairs <= 0 || s.Fanout <= 0 {
+			continue
+		}
+		// First valid OOM sample in (pairs, fanout, …) order is the binding
+		// corner; both axes are read from it so the coordinate is real.
+		if frontierPairs == 0 {
+			frontierF = s.Fanout
 			frontierPairs = pairs
 		}
 	}
@@ -316,19 +341,57 @@ func applyMargin(frontierValue int) int {
 	return scaled
 }
 
-// clampTighten enforces the tighten-only + safety-floor rails for an int
-// threshold: the calibrated value `want` is accepted ONLY if it is strictly
-// LOWER than the shipped default (the safer direction — shard more readily)
-// AND not below the shipped floor. Otherwise the default is kept verbatim.
-// This is the load-bearing safety invariant: Calibrate can never RAISE a
-// threshold, and never lower past the floor.
-func clampTighten(def, want, floor int) int {
-	if want < floor {
-		want = floor
+// axisWhy renders the reason string for one axis's threshold move, calling out
+// when the safety floor swallowed the margin so the change log is honest.
+func axisWhy(axis string, floorClamped bool) string {
+	if floorClamped {
+		return "observed OOM/cost-danger at low " + axis +
+			"; calibrated threshold pinned by the safety floor — margin reduced (see floor-clamp WARN)"
 	}
+	return "observed OOM/cost-danger at lower " + axis + "; shard before the local frontier"
+}
+
+// calibrateAxis derives one axis's calibrated threshold from its observed
+// frontier and reports whether the safety floor swallowed the margin.
+//
+// It enforces the tighten-only + safety-floor rails: the result is accepted
+// only if it tightens (strictly LOWER than the shipped default — shard more
+// readily) and never sits below the shipped floor; otherwise the default is
+// kept. Calibrate can never RAISE a threshold.
+//
+// The floor/margin interaction (the bug this replaces hid): the margin-reduced
+// target `want` is the value that puts route B a full safety margin below the
+// frontier. When the floor would raise `want` back up to or above the frontier,
+// the margin is gone — and a genuine SUB-FLOOR frontier (frontier ≤ floor) is
+// worse still: pinning to the floor installs a gate ABOVE the OOM coordinate,
+// keeping an already-OOMing query on route A. Both cases set floorClamped=true
+// so the loop WARNs instead of moving silently:
+//
+//   - frontier ≤ floor (sub-floor OOM): cap STRICTLY BELOW the frontier
+//     (frontier-1) so route B still fires before the danger zone, rather than
+//     pinning to a floor that sits above it.
+//   - floor < frontier but floor ≥ want (floor ate the margin): pin to the
+//     floor — route B still fires before the frontier, just with less headroom.
+func calibrateAxis(def, frontier, floor int) (value int, floorClamped bool) {
+	want := applyMargin(frontier)
 	if want >= def {
-		// Not a tightening (would loosen or no-op) — keep the default.
-		return def
+		// Not a tightening (frontier above current threshold) — keep default.
+		return def, false
 	}
-	return want
+	if want >= floor {
+		// Clean tightening: full margin preserved, floor not reached.
+		return want, false
+	}
+	// The floor would raise `want`. Surface it.
+	if frontier <= floor {
+		// Sub-floor OOM: floor sits at/above the OOM coordinate. Cap strictly
+		// below the frontier so route B fires before the danger zone.
+		capped := frontier - 1
+		if capped < 1 {
+			capped = 1
+		}
+		return capped, true
+	}
+	// Floor is still below the frontier — pin to it, but flag the lost margin.
+	return floor, true
 }

--- a/internal/solver/calibrate.go
+++ b/internal/solver/calibrate.go
@@ -166,6 +166,13 @@ const (
 //     never RAISES a threshold (which would route B less readily and risk the
 //     under-shard→OOM catastrophe), and never lowers past the shipped safety
 //     floor (minCalibratedFanout / minCalibratedAnchorPairs).
+//   - Floor / margin interaction surfaced (never silent): when the floor would
+//     raise the margin-reduced threshold to/above the frontier, the margin is
+//     lost — and a sub-floor OOM (frontier ≤ floor) is capped STRICTLY BELOW the
+//     frontier rather than pinned above the OOM coordinate. Both set
+//     CalibrationReport.FloorClamped{Fanout,AnchorPairs} for the loop's WARN.
+//   - Coupled frontier: both axes come from the SAME OOM sample (smallest N×F),
+//     never minimized independently into a synthetic corner.
 //   - Fail-open / no-op without signal: a thin corpus (< minCalibrationSamples
 //     real dispatches), no below-threshold decisions, or no OOM/cost-danger
 //     exemplars → return `defaults` UNCHANGED with NoOp set. (A no-signal

--- a/internal/solver/calibrate.go
+++ b/internal/solver/calibrate.go
@@ -1,0 +1,339 @@
+package solver
+
+// Per-deployment self-tuning of the route A/B thresholds.
+//
+// ARCHITECTURE (the whole point of this file — keep it explicit):
+//
+//   - GENERIC (shipped to every deployment): everything in THIS file — the
+//     Calibrate logic, the cost-frontier model, the safety rails, and the
+//     CONSERVATIVE DEFAULT thresholds (DefaultConfig in config.go). This code
+//     is deployment-independent: no deployment's learned constants are ever
+//     baked into it. A fresh install runs the same Calibrate over its own
+//     (initially empty) corpus.
+//
+//   - LOCAL (never shipped): the CALIBRATED constants Calibrate returns. They
+//     are derived AT RUNTIME, exclusively from `samples` — THIS deployment's
+//     own cerberus_router_corpus rows. Squid's corpus tunes squid only;
+//     another install tunes itself. A single deployment's corpus deliberately
+//     never leaks into the shipped defaults (that would be cross-deployment
+//     over-fit), which is why the only deployment-specific input to Calibrate
+//     is `samples` and nothing else.
+//
+// Calibrate is PURE and DETERMINISTIC: same (samples, defaults) → same
+// (Config, CalibrationReport), no clock / RNG / I/O. The corpus read lives
+// behind a reader interface (selftune.go); the calibration math is here.
+
+import (
+	"sort"
+)
+
+// CorpusSample is one aggregated frontier bucket read from THIS deployment's
+// cerberus_router_corpus — the ONLY deployment-specific input to Calibrate.
+// Each sample summarises the observed cost of queries that classified at a
+// given (N, F, D) cost-grid point, so the calibrator can find where the
+// deployment's own cost frontier approaches the danger zone.
+//
+// It is intentionally a flat value type (no chplan / optcorpus dependency) so
+// the calibrator stays pure and the reader that fills it can live anywhere
+// (in practice cmd/cerberus maps corpus rows into this shape — see
+// docs/solver.md).
+type CorpusSample struct {
+	// NAnchors / Fanout / CumulativeD are the cost-grid coordinates the
+	// router stamped on the decision (Decision.NAnchors / Fanout /
+	// CumulativeD). They mirror the corpus n_anchors / fanout / cumulative_d
+	// columns.
+	NAnchors    int
+	Fanout      int
+	CumulativeD int
+
+	// Route is the routing read-out captured at dispatch: "A" (single) or
+	// "B" (sharded). Mirrors the corpus route Enum8.
+	Route string
+
+	// BelowThreshold is true when the router classified the plan ELIGIBLE but
+	// kept it on route A because it had not cleared the cost thresholds
+	// (DecisionReason == ReasonBelowThreshold). These are the samples that
+	// tell us where the CURRENT thresholds sit relative to the frontier.
+	BelowThreshold bool
+
+	// MemoryUsage is the peak server-side memory the dispatched query used
+	// (bytes), from the corpus memory_usage column. Zero for decision-only
+	// rows that never dispatched a CH query.
+	MemoryUsage uint64
+
+	// QueryDurationMS is the server-side wall-clock duration, from the corpus
+	// query_duration_ms column. Zero for decision-only rows.
+	QueryDurationMS uint64
+
+	// OOM is true when this sample's query terminated in the OOM / cost danger
+	// zone — ExitStatus oom / timeout / sample_budget (the three terminal
+	// outcomes route B exists to avoid). These are the frontier-defining
+	// catastrophes.
+	OOM bool
+
+	// Count is how many real dispatches this aggregated bucket summarises, so
+	// the calibrator can weight rates and apply the min-sample floor. A
+	// bucket built from a single SELECT-GROUP-BY row carries its group count.
+	Count int
+}
+
+// CalibrationReport is the human-readable, GENERIC explanation of what a
+// single Calibrate run did — logged on every recalibration so operators can
+// SEE what their deployment self-tuned to (and that it is local, derived from
+// their own corpus). It carries no deployment identity; it is a diff of
+// Config fields plus the evidence that justified each move.
+type CalibrationReport struct {
+	// SampleCount is the total number of real dispatches across all samples
+	// (Σ CorpusSample.Count) the run considered.
+	SampleCount int
+
+	// NoOp is true when Calibrate returned the defaults verbatim because the
+	// corpus carried no actionable signal (fail-open). NoOpReason names why.
+	NoOp       bool
+	NoOpReason string
+
+	// Changes lists each threshold that moved, in defaults → calibrated form,
+	// with the evidence. Empty when NoOp or when the frontier confirmed the
+	// defaults already route safely.
+	Changes []ThresholdChange
+
+	// FrontierFanout / FrontierAnchorPairs record the empirical frontier the
+	// run detected: the smallest Fanout / (N×F) anchor-pair product at which
+	// the corpus showed OOM/cost-danger samples. Zero when no danger frontier
+	// was observed. Reported even on a no-op so operators see the evidence.
+	FrontierFanout      int
+	FrontierAnchorPairs int
+}
+
+// ThresholdChange is one field's defaults → calibrated movement plus a short
+// reason. The Field names match Config field names so the log is greppable.
+type ThresholdChange struct {
+	Field string
+	From  int
+	To    int
+	Why   string
+}
+
+// Safety-rail constants (GENERIC). These bound how far Calibrate may move a
+// threshold in the SAFER direction, and how much evidence it demands before
+// moving at all. None of them encodes a deployment's data — they are the
+// shipped conservative envelope.
+const (
+	// minCalibrationSamples is the corpus-thinness floor: below this many
+	// total real dispatches the corpus cannot describe a frontier, so
+	// Calibrate fails open and returns defaults unchanged. Sized so a handful
+	// of stray queries can never move a production threshold.
+	minCalibrationSamples = 200
+
+	// minFrontierDangerSamples is how many OOM/cost-danger dispatches must
+	// exist before the frontier is considered real. One unlucky OOM is noise;
+	// a cluster of them at a consistent (F, N×F) is signal.
+	minFrontierDangerSamples = 5
+
+	// frontierSafetyMargin tightens the calibrated threshold to route B
+	// strictly BEFORE the observed danger frontier rather than AT it
+	// (PARQO asymmetric penalty: under-shard→OOM is catastrophic, over-shard
+	// merely wastes a connection). A calibrated threshold is set to the
+	// frontier value scaled down by this fraction, expressed as a percent so
+	// it stays an integer-relative term, not an absolute tuned to one install.
+	frontierSafetyMarginPercent = 75
+
+	// minCalibratedFanout / minCalibratedAnchorPairs are the SHIPPED SAFETY
+	// FLOOR: the calibrated thresholds may tighten toward route B but never
+	// past these, so a pathological corpus can never drive routing to shard
+	// trivially-small queries (which would waste connections for no memory
+	// benefit). Tighten-only is bounded below by this floor.
+	minCalibratedFanout      = 2
+	minCalibratedAnchorPairs = 500
+)
+
+// Calibrate derives per-deployment route thresholds from THIS deployment's
+// corpus samples, starting from the shipped conservative defaults. It is the
+// GENERIC calibration logic; the only deployment-specific input is `samples`.
+//
+// SAFETY RAILS (all tested):
+//
+//   - Conservative-floor / tighten-only: a calibrated threshold may only move
+//     in the SAFER direction — i.e. LOWER MinFanout / MinAnchorPairs so the
+//     deployment shards MORE readily near its own OOM frontier. Calibrate
+//     never RAISES a threshold (which would route B less readily and risk the
+//     under-shard→OOM catastrophe), and never lowers past the shipped safety
+//     floor (minCalibratedFanout / minCalibratedAnchorPairs).
+//   - Fail-open / no-op without signal: a thin corpus (< minCalibrationSamples
+//     real dispatches), no below-threshold decisions, or no OOM/cost-danger
+//     exemplars → return `defaults` UNCHANGED with NoOp set. (Squid today is
+//     exactly this shape — all route A, below-threshold=0, zero failures — so
+//     Calibrate is a true verbatim no-op there.)
+//   - Relative terms: the frontier is expressed in the corpus's own observed
+//     (F, N×F) coordinates scaled by a shipped margin percent, not absolutes
+//     hardcoded to one deployment.
+//
+// Only MinFanout and MinAnchorPairs are calibrated; the geometric knobs (MaxK,
+// MinAnchorsPerSlice, high-D clamp) are structural grid invariants the corpus
+// does not re-derive, so they pass through from defaults untouched.
+func Calibrate(samples []CorpusSample, defaults Config) (Config, CalibrationReport) {
+	total := 0
+	for _, s := range samples {
+		c := s.Count
+		if c <= 0 {
+			c = 1
+		}
+		total += c
+	}
+
+	report := CalibrationReport{SampleCount: total}
+
+	// Fail-open rail 1: thin corpus. A handful of samples cannot describe a
+	// frontier; return defaults verbatim.
+	if total < minCalibrationSamples {
+		report.NoOp = true
+		report.NoOpReason = "thin corpus: below min-sample floor"
+		return defaults, report
+	}
+
+	// Find the empirical danger frontier: the SMALLEST Fanout and smallest
+	// (N×F) anchor-pair product at which the deployment actually observed
+	// OOM/cost-danger dispatches, weighted by a min-danger-sample floor so a
+	// single unlucky OOM is treated as noise.
+	frontierF, frontierPairs, dangerCount, sawBelowThreshold := scanFrontier(samples)
+
+	report.FrontierFanout = frontierF
+	report.FrontierAnchorPairs = frontierPairs
+
+	// Fail-open rail 2: no below-threshold decisions means the current
+	// thresholds never held a plan back — there is nothing to tighten toward.
+	if !sawBelowThreshold {
+		report.NoOp = true
+		report.NoOpReason = "no below-threshold decisions: thresholds never gated a plan"
+		return defaults, report
+	}
+
+	// Fail-open rail 3: no OOM/cost-danger frontier observed. Without a danger
+	// signal there is no evidence that routing A near these thresholds is
+	// risky, so tightening would be speculative. Return defaults.
+	if dangerCount < minFrontierDangerSamples || frontierF <= 0 || frontierPairs <= 0 {
+		report.NoOp = true
+		report.NoOpReason = "no OOM/cost-danger frontier: corpus shows no danger signal"
+		return defaults, report
+	}
+
+	// We have a real frontier. Derive calibrated thresholds that route B
+	// strictly BEFORE it, then apply tighten-only + safety-floor clamps.
+	calibrated := defaults
+
+	wantFanout := applyMargin(frontierF)
+	wantPairs := applyMargin(frontierPairs)
+
+	calibrated.MinFanout = clampTighten(
+		defaults.MinFanout, wantFanout, minCalibratedFanout,
+	)
+	calibrated.MinAnchorPairs = clampTighten(
+		defaults.MinAnchorPairs, wantPairs, minCalibratedAnchorPairs,
+	)
+
+	if calibrated.MinFanout != defaults.MinFanout {
+		report.Changes = append(report.Changes, ThresholdChange{
+			Field: "MinFanout",
+			From:  defaults.MinFanout,
+			To:    calibrated.MinFanout,
+			Why:   "observed OOM/cost-danger at lower fanout; shard before the local frontier",
+		})
+	}
+	if calibrated.MinAnchorPairs != defaults.MinAnchorPairs {
+		report.Changes = append(report.Changes, ThresholdChange{
+			Field: "MinAnchorPairs",
+			From:  defaults.MinAnchorPairs,
+			To:    calibrated.MinAnchorPairs,
+			Why:   "observed OOM/cost-danger at fewer anchor-pairs; shard before the local frontier",
+		})
+	}
+
+	// If the frontier confirmed the defaults already route safely (both clamps
+	// left the defaults in place), this is a confirming no-op: still return
+	// defaults so the swap is a literal identity, and record why.
+	if len(report.Changes) == 0 {
+		report.NoOp = true
+		report.NoOpReason = "frontier above current thresholds: defaults already route safely"
+		return defaults, report
+	}
+
+	return calibrated, report
+}
+
+// scanFrontier finds, across all samples, the smallest Fanout and smallest
+// (N×F) anchor-pair product at which the deployment observed OOM/cost-danger
+// dispatches, plus the total danger-sample count and whether any
+// below-threshold decision exists. Deterministic: samples are sorted before
+// scanning so the result never depends on input order.
+func scanFrontier(samples []CorpusSample) (frontierF, frontierPairs, dangerCount int, sawBelowThreshold bool) {
+	ordered := make([]CorpusSample, len(samples))
+	copy(ordered, samples)
+	sort.Slice(ordered, func(i, j int) bool {
+		a, b := ordered[i], ordered[j]
+		if a.Fanout != b.Fanout {
+			return a.Fanout < b.Fanout
+		}
+		ap, bp := a.NAnchors*a.Fanout, b.NAnchors*b.Fanout
+		if ap != bp {
+			return ap < bp
+		}
+		if a.CumulativeD != b.CumulativeD {
+			return a.CumulativeD < b.CumulativeD
+		}
+		return a.Route < b.Route
+	})
+
+	frontierF = 0
+	frontierPairs = 0
+	for _, s := range ordered {
+		if s.BelowThreshold {
+			sawBelowThreshold = true
+		}
+		if !s.OOM {
+			continue
+		}
+		c := s.Count
+		if c <= 0 {
+			c = 1
+		}
+		dangerCount += c
+
+		if s.Fanout > 0 && (frontierF == 0 || s.Fanout < frontierF) {
+			frontierF = s.Fanout
+		}
+		pairs := s.NAnchors * s.Fanout
+		if pairs > 0 && (frontierPairs == 0 || pairs < frontierPairs) {
+			frontierPairs = pairs
+		}
+	}
+	return frontierF, frontierPairs, dangerCount, sawBelowThreshold
+}
+
+// applyMargin scales a frontier value down by frontierSafetyMarginPercent so
+// the calibrated threshold sits strictly BELOW the observed danger frontier
+// (route B fires before the deployment hits the danger zone). Floors at 1 so a
+// tiny frontier never collapses to zero.
+func applyMargin(frontierValue int) int {
+	scaled := frontierValue * frontierSafetyMarginPercent / 100
+	if scaled < 1 {
+		return 1
+	}
+	return scaled
+}
+
+// clampTighten enforces the tighten-only + safety-floor rails for an int
+// threshold: the calibrated value `want` is accepted ONLY if it is strictly
+// LOWER than the shipped default (the safer direction — shard more readily)
+// AND not below the shipped floor. Otherwise the default is kept verbatim.
+// This is the load-bearing safety invariant: Calibrate can never RAISE a
+// threshold, and never lower past the floor.
+func clampTighten(def, want, floor int) int {
+	if want < floor {
+		want = floor
+	}
+	if want >= def {
+		// Not a tightening (would loosen or no-op) — keep the default.
+		return def
+	}
+	return want
+}

--- a/internal/solver/calibrate.go
+++ b/internal/solver/calibrate.go
@@ -5,8 +5,8 @@ package solver
 // ARCHITECTURE (the whole point of this file — keep it explicit):
 //
 //   - GENERIC (shipped to every deployment): everything in THIS file — the
-//     Calibrate logic, the cost-frontier model, the safety rails, and the
-//     CONSERVATIVE DEFAULT thresholds (DefaultConfig in config.go). This code
+//     Calibrate logic, the terminal-OOM frontier model, the safety rails, and
+//     the CONSERVATIVE DEFAULT thresholds (DefaultConfig in config.go). This code
 //     is deployment-independent: no deployment's learned constants are ever
 //     baked into it. A fresh install runs the same Calibrate over its own
 //     (initially empty) corpus.
@@ -29,9 +29,9 @@ import (
 
 // CorpusSample is one aggregated frontier bucket read from THIS deployment's
 // cerberus_router_corpus — the ONLY deployment-specific input to Calibrate.
-// Each sample summarises the observed cost of queries that classified at a
-// given (N, F, D) cost-grid point, so the calibrator can find where the
-// deployment's own cost frontier approaches the danger zone.
+// Each sample summarises the queries that classified at a given (N, F, D)
+// cost-grid point and whether any of them hit a TERMINAL OOM, so the
+// calibrator can locate where the deployment's own queries actually fall over.
 //
 // It is intentionally a flat value type (no chplan / optcorpus dependency) so
 // the calibrator stays pure and the reader that fills it can live anywhere
@@ -56,19 +56,14 @@ type CorpusSample struct {
 	// tell us where the CURRENT thresholds sit relative to the frontier.
 	BelowThreshold bool
 
-	// MemoryUsage is the peak server-side memory the dispatched query used
-	// (bytes), from the corpus memory_usage column. Zero for decision-only
-	// rows that never dispatched a CH query.
-	MemoryUsage uint64
-
-	// QueryDurationMS is the server-side wall-clock duration, from the corpus
-	// query_duration_ms column. Zero for decision-only rows.
-	QueryDurationMS uint64
-
 	// OOM is true when this sample's query terminated in the OOM / cost danger
 	// zone — ExitStatus oom / timeout / sample_budget (the three terminal
-	// outcomes route B exists to avoid). These are the frontier-defining
-	// catastrophes.
+	// outcomes route B exists to avoid). This is the only cost read-out the
+	// calibrator consults: it locates the frontier from the TERMINAL-OOM
+	// coordinate alone. The corpus still captures peak memory / wall-clock per
+	// bucket (see optcorpus.FrontierBucket), but the calibrator deliberately
+	// does NOT read a soft cost gradient — matching the shipped behaviour, which
+	// gates purely on the terminal outcome.
 	OOM bool
 
 	// Count is how many real dispatches this aggregated bucket summarises, so

--- a/internal/solver/calibrate.go
+++ b/internal/solver/calibrate.go
@@ -13,7 +13,7 @@ package solver
 //
 //   - LOCAL (never shipped): the CALIBRATED constants Calibrate returns. They
 //     are derived AT RUNTIME, exclusively from `samples` — THIS deployment's
-//     own cerberus_router_corpus rows. Squid's corpus tunes squid only;
+//     own cerberus_router_corpus rows. A deployment's corpus tunes that deployment only;
 //     another install tunes itself. A single deployment's corpus deliberately
 //     never leaks into the shipped defaults (that would be cross-deployment
 //     over-fit), which is why the only deployment-specific input to Calibrate
@@ -161,9 +161,9 @@ const (
 //     floor (minCalibratedFanout / minCalibratedAnchorPairs).
 //   - Fail-open / no-op without signal: a thin corpus (< minCalibrationSamples
 //     real dispatches), no below-threshold decisions, or no OOM/cost-danger
-//     exemplars → return `defaults` UNCHANGED with NoOp set. (Squid today is
-//     exactly this shape — all route A, below-threshold=0, zero failures — so
-//     Calibrate is a true verbatim no-op there.)
+//     exemplars → return `defaults` UNCHANGED with NoOp set. (A no-signal
+//     corpus is exactly this shape — all route A, below-threshold=0, zero
+//     failures — so Calibrate is a true verbatim no-op there.)
 //   - Relative terms: the frontier is expressed in the corpus's own observed
 //     (F, N×F) coordinates scaled by a shipped margin percent, not absolutes
 //     hardcoded to one deployment.

--- a/internal/solver/calibrate_test.go
+++ b/internal/solver/calibrate_test.go
@@ -19,11 +19,11 @@ func calibDefaults() Config {
 	return c
 }
 
-// squidShapedCorpus models squid's corpus TODAY: every dispatch is route A,
+// noSignalCorpus models a no-signal corpus: every dispatch is route A,
 // below-threshold never fired (the thresholds never gated a plan), and there
 // are zero OOM/cost-danger outcomes. Calibrate MUST treat this as no-signal and
-// return the defaults verbatim — the load-bearing no-op-on-squid proof.
-func squidShapedCorpus() []CorpusSample {
+// return the defaults verbatim — the load-bearing no-op-on-no-signal proof.
+func noSignalCorpus() []CorpusSample {
 	out := make([]CorpusSample, 0, 8)
 	for i := 0; i < 8; i++ {
 		out = append(out, CorpusSample{
@@ -43,15 +43,15 @@ func squidShapedCorpus() []CorpusSample {
 	return out
 }
 
-func TestCalibrate_NoOpOnSquidShapedCorpus(t *testing.T) {
+func TestCalibrate_NoOpOnNoSignalCorpus(t *testing.T) {
 	defaults := calibDefaults()
-	got, report := Calibrate(squidShapedCorpus(), defaults)
+	got, report := Calibrate(noSignalCorpus(), defaults)
 
 	if !reflect.DeepEqual(got, defaults) {
-		t.Fatalf("squid-shaped corpus must return defaults verbatim, got %+v want %+v", got, defaults)
+		t.Fatalf("no-signal corpus must return defaults verbatim, got %+v want %+v", got, defaults)
 	}
 	if !report.NoOp {
-		t.Fatalf("expected NoOp report on squid-shaped corpus, got %+v", report)
+		t.Fatalf("expected NoOp report on no-signal corpus, got %+v", report)
 	}
 	if len(report.Changes) != 0 {
 		t.Fatalf("no-op must report zero changes, got %+v", report.Changes)
@@ -182,7 +182,7 @@ func TestCalibrate_NeverLoosensTightenOnlyInvariant(t *testing.T) {
 	defaults := calibDefaults()
 
 	corpora := map[string][]CorpusSample{
-		"squid":          squidShapedCorpus(),
+		"no-signal":      noSignalCorpus(),
 		"clear-frontier": clearFrontierCorpus(),
 		"no-below":       mustManySamples(false, true),
 		"no-danger":      mustManySamples(true, false),

--- a/internal/solver/calibrate_test.go
+++ b/internal/solver/calibrate_test.go
@@ -72,10 +72,17 @@ func TestCalibrate_NoOpOnThinCorpus(t *testing.T) {
 	}
 }
 
+// noBelowThresholdReason is the exact NoOpReason for the no-below-threshold
+// rail. Pinning the literal kills a mutant that returns the wrong rail's reason.
+const noBelowThresholdReason = "no below-threshold decisions: thresholds never gated a plan"
+
 func TestCalibrate_NoOpWhenNoBelowThreshold(t *testing.T) {
 	defaults := calibDefaults()
-	// Plenty of samples and even danger, but NO below-threshold decision: the
-	// thresholds never gated a plan, so there is nothing to tighten toward.
+	// Rail isolation (KILL-MUTANT): plenty of samples (rail 1 silent) AND a
+	// real danger frontier — 20*20 = 400 OOM danger samples ≥ floor, valid
+	// frontier (rail 3 silent) — but NO below-threshold decision, so ONLY the
+	// below-threshold rail can fire. Inverting that rail must change the result,
+	// which it cannot if another rail also no-ops this corpus.
 	var s []CorpusSample
 	for i := 0; i < 20; i++ {
 		s = append(s, CorpusSample{
@@ -90,13 +97,20 @@ func TestCalibrate_NoOpWhenNoBelowThreshold(t *testing.T) {
 	if !report.NoOp {
 		t.Fatalf("expected NoOp when no below-threshold decisions, got %+v", report)
 	}
+	if report.NoOpReason != noBelowThresholdReason {
+		t.Fatalf("wrong NoOpReason: got %q want %q", report.NoOpReason, noBelowThresholdReason)
+	}
 }
+
+// noDangerReason is the exact NoOpReason for the no-danger-signal rail.
+const noDangerReason = "no OOM/cost-danger frontier: corpus shows no danger signal"
 
 func TestCalibrate_NoOpWhenNoDangerSignal(t *testing.T) {
 	defaults := calibDefaults()
-	// Below-threshold decisions exist, but ZERO danger outcomes: no evidence
-	// route A near these thresholds is risky, so tightening would be
-	// speculative → defaults verbatim.
+	// Rail isolation (KILL-MUTANT): plenty of samples (rail 1 silent) AND
+	// below-threshold decisions exist (rail 2 silent), but ZERO danger
+	// outcomes, so ONLY the no-danger rail can fire. 20*30 = 600 below-threshold
+	// route-A samples, none OOM.
 	var s []CorpusSample
 	for i := 0; i < 20; i++ {
 		s = append(s, CorpusSample{
@@ -110,6 +124,49 @@ func TestCalibrate_NoOpWhenNoDangerSignal(t *testing.T) {
 	}
 	if !report.NoOp {
 		t.Fatalf("expected NoOp when no danger signal, got %+v", report)
+	}
+	if report.NoOpReason != noDangerReason {
+		t.Fatalf("wrong NoOpReason: got %q want %q", report.NoOpReason, noDangerReason)
+	}
+}
+
+// thinReason is the exact NoOpReason for the thin-corpus rail.
+const thinReason = "thin corpus: below min-sample floor"
+
+// TestCalibrate_ThinCorpusRailIsolated (KILL-MUTANT) builds a corpus that
+// carries a REAL danger frontier (below-threshold + ≥ minFrontierDangerSamples
+// OOM samples at a valid coordinate) but stays just under the min-sample floor.
+// Only the thin-corpus rail may fire: the other two rails would PASS this
+// corpus through to tightening, so deleting / weakening the min-sample floor
+// flips the result from defaults to a real calibration. The existing
+// TestCalibrate_NoOpOnThinCorpus uses a single count=3 sample (dangerCount=3 <
+// floor), so the no-danger rail ALSO no-ops it — setting the min-sample floor
+// to 1 there leaves the test green. This case closes that hole.
+func TestCalibrate_ThinCorpusRailIsolated(t *testing.T) {
+	defaults := calibDefaults()
+	var s []CorpusSample
+	// 6 OOM danger samples (≥ minFrontierDangerSamples) at a clear sub-default
+	// frontier, all below-threshold — but Count=1 each so the total is far
+	// under minCalibrationSamples.
+	for i := 0; i < 6; i++ {
+		s = append(s, CorpusSample{
+			NAnchors: 100, Fanout: 10, CumulativeD: 300, Route: "A",
+			BelowThreshold: true, OOM: true, Count: 1,
+		})
+	}
+	total := 0
+	for _, x := range s {
+		total += x.Count
+	}
+	if total >= minCalibrationSamples {
+		t.Fatalf("test setup: corpus not thin (total=%d ≥ floor %d)", total, minCalibrationSamples)
+	}
+	got, report := Calibrate(s, defaults)
+	if !reflect.DeepEqual(got, defaults) {
+		t.Fatalf("thin corpus must return defaults verbatim, got %+v", got)
+	}
+	if !report.NoOp || report.NoOpReason != thinReason {
+		t.Fatalf("expected thin-corpus rail, got NoOp=%v reason=%q", report.NoOp, report.NoOpReason)
 	}
 }
 
@@ -266,5 +323,199 @@ func TestCalibrate_DeterministicAndPure(t *testing.T) {
 	_, _ = Calibrate(base, defaults)
 	if !reflect.DeepEqual(base, snapshot) {
 		t.Fatalf("Calibrate mutated its input slice")
+	}
+}
+
+// dangerBoundaryCorpus builds a corpus with exactly `dangerCount` OOM danger
+// samples (Count=1 each) at a clear sub-default frontier, padded with enough
+// safe below-threshold dispatches that the total clears minCalibrationSamples.
+// Below-threshold is always present so only the danger-sample floor decides.
+func dangerBoundaryCorpus(dangerCount int) []CorpusSample {
+	var s []CorpusSample
+	for i := 0; i < dangerCount; i++ {
+		s = append(s, CorpusSample{
+			NAnchors: 100, Fanout: 10, CumulativeD: 300, Route: "A",
+			BelowThreshold: true, OOM: true, Count: 1,
+		})
+	}
+	// Padding: safe, below-threshold, non-OOM — total well over the sample floor
+	// without adding danger or a smaller frontier.
+	s = append(s, CorpusSample{
+		NAnchors: 10, Fanout: 1, CumulativeD: 300, Route: "A",
+		BelowThreshold: true, OOM: false, Count: minCalibrationSamples + 10,
+	})
+	return s
+}
+
+// TestCalibrate_DangerSampleFloorBoundary (KILL-MUTANT) pins the
+// minFrontierDangerSamples floor at its exact value: dangerCount = floor-1 must
+// no-op (the no-danger rail), dangerCount = floor must tighten. A mutant that
+// lowers the floor to 1 (or removes the comparison) lets the floor-1 case
+// tighten, flipping this test red.
+func TestCalibrate_DangerSampleFloorBoundary(t *testing.T) {
+	defaults := calibDefaults()
+	// Pin the literal floor value so a mutant that moves minFrontierDangerSamples
+	// (e.g. down to 1) cannot also slide the boundary these corpora probe.
+	const wantDangerFloor = 5
+	if minFrontierDangerSamples != wantDangerFloor {
+		t.Fatalf("danger-floor moved to %d; update this test's literal corpora deliberately",
+			minFrontierDangerSamples)
+	}
+
+	below, reportBelow := Calibrate(dangerBoundaryCorpus(wantDangerFloor-1), defaults)
+	if !reflect.DeepEqual(below, defaults) {
+		t.Fatalf("dangerCount=floor-1 must no-op, got %+v", below)
+	}
+	if !reportBelow.NoOp || reportBelow.NoOpReason != noDangerReason {
+		t.Fatalf("dangerCount=floor-1: expected no-danger rail, got NoOp=%v reason=%q",
+			reportBelow.NoOp, reportBelow.NoOpReason)
+	}
+
+	at, reportAt := Calibrate(dangerBoundaryCorpus(wantDangerFloor), defaults)
+	if reportAt.NoOp {
+		t.Fatalf("dangerCount=floor must tighten, got no-op %+v", reportAt)
+	}
+	if at.MinFanout >= defaults.MinFanout || at.MinAnchorPairs >= defaults.MinAnchorPairs {
+		t.Fatalf("dangerCount=floor must lower thresholds, got MinFanout=%d MinAnchorPairs=%d",
+			at.MinFanout, at.MinAnchorPairs)
+	}
+}
+
+// TestCalibrate_AnchorPairsFloorPinsExactly (KILL-MUTANT) drives the
+// anchor-pairs frontier into the band [floor+1, floor/0.75] so the margin-
+// reduced target falls BELOW the floor while the frontier itself stays above
+// it. The floor must pin the result at EXACTLY minCalibratedAnchorPairs and set
+// FloorClampedAnchorPairs. clearFrontierCorpus never exercises this (its pairs
+// frontier is 1000 → margin 750, well above the 500 floor), so the floor clamp
+// was deletable-green before this test. The fanout axis is kept clean (frontier
+// 10 → margin 7, above its floor of 2) to isolate the pairs clamp.
+func TestCalibrate_AnchorPairsFloorPinsExactly(t *testing.T) {
+	defaults := calibDefaults()
+	// frontier pairs = 60*10 = 600 ∈ [501,666]: margin 450 < floor 500, but
+	// frontier 600 > floor → the floor PINS (not the sub-floor cap).
+	var s []CorpusSample
+	for i := 0; i < minFrontierDangerSamples+1; i++ {
+		s = append(s, CorpusSample{
+			NAnchors: 60, Fanout: 10, CumulativeD: 300, Route: "A",
+			BelowThreshold: true, OOM: true, Count: 10,
+		})
+	}
+	s = append(s, CorpusSample{
+		NAnchors: 10, Fanout: 1, CumulativeD: 300, Route: "A",
+		BelowThreshold: true, OOM: false, Count: minCalibrationSamples,
+	})
+
+	got, report := Calibrate(s, defaults)
+	if report.NoOp {
+		t.Fatalf("expected a real calibration, got no-op %+v", report)
+	}
+	if got.MinAnchorPairs != minCalibratedAnchorPairs {
+		t.Fatalf("anchor-pairs must pin EXACTLY at floor %d, got %d",
+			minCalibratedAnchorPairs, got.MinAnchorPairs)
+	}
+	if !report.FloorClampedAnchorPairs {
+		t.Fatalf("expected FloorClampedAnchorPairs=true when the floor swallowed the margin")
+	}
+	// The floor sits below the frontier — route B still fires before danger.
+	if got.MinAnchorPairs >= report.FrontierAnchorPairs {
+		t.Fatalf("floor-pinned threshold %d must stay below frontier %d",
+			got.MinAnchorPairs, report.FrontierAnchorPairs)
+	}
+	// Fanout axis stays clean (no clamp) so the pairs clamp is isolated.
+	if report.FloorClampedFanout {
+		t.Fatalf("fanout axis should not be floor-clamped in this corpus")
+	}
+}
+
+// TestCalibrate_FanoutSubFloorCapsBelowFrontier (KILL-MUTANT) drives the fanout
+// frontier to 2 — at/below minCalibratedFanout. Pinning to the floor (2) would
+// install a gate AT the OOM coordinate, leaving an OOMing query on route A. The
+// sub-floor branch must instead cap STRICTLY BELOW the frontier (frontier-1=1)
+// and flag FloorClampedFanout. A mutant that pins to the floor here yields
+// MinFanout=2 == frontier, failing the strict-below assertion. The pairs axis
+// is kept clean (frontier 800 → margin 600, above floor 500) to isolate fanout.
+func TestCalibrate_FanoutSubFloorCapsBelowFrontier(t *testing.T) {
+	defaults := calibDefaults()
+	// frontier fanout = 2 (≤ floor 2); pairs = 400*2 = 800 (margin 600 ≥ floor).
+	var s []CorpusSample
+	for i := 0; i < minFrontierDangerSamples+1; i++ {
+		s = append(s, CorpusSample{
+			NAnchors: 400, Fanout: 2, CumulativeD: 300, Route: "A",
+			BelowThreshold: true, OOM: true, Count: 10,
+		})
+	}
+	s = append(s, CorpusSample{
+		NAnchors: 10, Fanout: 1, CumulativeD: 300, Route: "A",
+		BelowThreshold: true, OOM: false, Count: minCalibrationSamples,
+	})
+
+	got, report := Calibrate(s, defaults)
+	if report.NoOp {
+		t.Fatalf("expected a real calibration, got no-op %+v", report)
+	}
+	if report.FrontierFanout != minCalibratedFanout {
+		t.Fatalf("test setup: expected frontier fanout %d, got %d",
+			minCalibratedFanout, report.FrontierFanout)
+	}
+	if !report.FloorClampedFanout {
+		t.Fatalf("expected FloorClampedFanout=true on a sub-floor OOM")
+	}
+	// Strictly below the frontier — a floor-pin (==2) would fail here.
+	if got.MinFanout >= report.FrontierFanout {
+		t.Fatalf("sub-floor cap must stay STRICTLY below frontier %d, got MinFanout=%d",
+			report.FrontierFanout, got.MinFanout)
+	}
+	if got.MinFanout != report.FrontierFanout-1 {
+		t.Fatalf("sub-floor cap must be frontier-1=%d, got %d",
+			report.FrontierFanout-1, got.MinFanout)
+	}
+	// Pairs axis clean (no clamp) so the fanout clamp is isolated.
+	if report.FloorClampedAnchorPairs {
+		t.Fatalf("anchor-pairs axis should not be floor-clamped in this corpus")
+	}
+}
+
+// TestCalibrate_CoupledFrontierIgnoresFanoutGatedOOM (KILL-MUTANT for Fix 4)
+// proves the frontier coordinate is COUPLED to a single OOM sample. The corpus
+// has two disjoint OOM samples:
+//
+//   - a fanout-gated OOM at small fanout but LARGE anchor-pairs (F=3, N=400 →
+//     pairs=1200), and
+//   - the real binding corner at larger fanout but SMALLER pairs (F=12, N=50 →
+//     pairs=600).
+//
+// Independent per-axis minimization (the old bug) would take frontierFanout=3
+// from the first sample and frontierAnchorPairs=600 from the second — a
+// synthetic corner at no real query. The coupled scan must report BOTH axes
+// from the smallest-pairs OOM sample: frontierFanout=12, frontierAnchorPairs=600.
+func TestCalibrate_CoupledFrontierIgnoresFanoutGatedOOM(t *testing.T) {
+	defaults := calibDefaults()
+	var s []CorpusSample
+	for i := 0; i < minFrontierDangerSamples; i++ {
+		// Fanout-gated OOM: small fanout, large pairs.
+		s = append(s, CorpusSample{
+			NAnchors: 400, Fanout: 3, CumulativeD: 300, Route: "A",
+			BelowThreshold: true, OOM: true, Count: 10,
+		})
+		// Binding corner: larger fanout, smaller pairs.
+		s = append(s, CorpusSample{
+			NAnchors: 50, Fanout: 12, CumulativeD: 300, Route: "A",
+			BelowThreshold: true, OOM: true, Count: 10,
+		})
+	}
+	s = append(s, CorpusSample{
+		NAnchors: 10, Fanout: 1, CumulativeD: 300, Route: "A",
+		BelowThreshold: true, OOM: false, Count: minCalibrationSamples,
+	})
+
+	_, report := Calibrate(s, defaults)
+	const wantFrontierF = 12
+	const wantFrontierPairs = 600 // 50 * 12
+	if report.FrontierFanout != wantFrontierF {
+		t.Fatalf("coupled frontier fanout: got %d want %d (must come from the smallest-pairs OOM, not the fanout-gated one)",
+			report.FrontierFanout, wantFrontierF)
+	}
+	if report.FrontierAnchorPairs != wantFrontierPairs {
+		t.Fatalf("coupled frontier pairs: got %d want %d", report.FrontierAnchorPairs, wantFrontierPairs)
 	}
 }

--- a/internal/solver/calibrate_test.go
+++ b/internal/solver/calibrate_test.go
@@ -33,11 +33,9 @@ func noSignalCorpus() []CorpusSample {
 			Route:       "A",
 			// Not below-threshold: these were genuinely small (ineligible /
 			// instant), never held back by the cost thresholds.
-			BelowThreshold:  false,
-			MemoryUsage:     50 << 20, // 50 MiB — nowhere near danger
-			QueryDurationMS: 40,
-			OOM:             false,
-			Count:           50, // 8 * 50 = 400 ≥ minCalibrationSamples
+			BelowThreshold: false,
+			OOM:            false,
+			Count:          50, // 8 * 50 = 400 ≥ minCalibrationSamples
 		})
 	}
 	return out
@@ -103,7 +101,7 @@ func TestCalibrate_NoOpWhenNoDangerSignal(t *testing.T) {
 	for i := 0; i < 20; i++ {
 		s = append(s, CorpusSample{
 			NAnchors: 100, Fanout: 8, CumulativeD: 300, Route: "A",
-			BelowThreshold: true, OOM: false, MemoryUsage: 30 << 20, Count: 30,
+			BelowThreshold: true, OOM: false, Count: 30,
 		})
 	}
 	got, report := Calibrate(s, defaults)
@@ -127,18 +125,16 @@ func clearFrontierCorpus() []CorpusSample {
 	for i := 0; i < 10; i++ {
 		s = append(s, CorpusSample{
 			NAnchors: 100, Fanout: 10, CumulativeD: 300, Route: "A",
-			BelowThreshold:  true,
-			MemoryUsage:     8 << 30, // 8 GiB
-			QueryDurationMS: 30000,
-			OOM:             true,
-			Count:           30,
+			BelowThreshold: true,
+			OOM:            true,
+			Count:          30,
 		})
 	}
 	// Some safe small queries below the frontier, also below-threshold.
 	for i := 0; i < 5; i++ {
 		s = append(s, CorpusSample{
 			NAnchors: 50, Fanout: 3, CumulativeD: 300, Route: "A",
-			BelowThreshold: true, MemoryUsage: 20 << 20, OOM: false, Count: 40,
+			BelowThreshold: true, OOM: false, Count: 40,
 		})
 	}
 	return s
@@ -219,7 +215,7 @@ func highFrontierCorpus() []CorpusSample {
 	for i := 0; i < 10; i++ {
 		s = append(s, CorpusSample{
 			NAnchors: 5000, Fanout: 2000, CumulativeD: 300, Route: "B",
-			BelowThreshold: true, OOM: true, MemoryUsage: 8 << 30, Count: 30,
+			BelowThreshold: true, OOM: true, Count: 30,
 		})
 	}
 	return s
@@ -230,7 +226,7 @@ func mustManySamples(belowThreshold, oom bool) []CorpusSample {
 	for i := 0; i < 20; i++ {
 		s = append(s, CorpusSample{
 			NAnchors: 100, Fanout: 10, CumulativeD: 300, Route: "A",
-			BelowThreshold: belowThreshold, OOM: oom, MemoryUsage: 4 << 30, Count: 30,
+			BelowThreshold: belowThreshold, OOM: oom, Count: 30,
 		})
 	}
 	return s

--- a/internal/solver/calibrate_test.go
+++ b/internal/solver/calibrate_test.go
@@ -1,0 +1,274 @@
+package solver
+
+import (
+	"reflect"
+	"testing"
+)
+
+// calibDefaults returns a conservative shipped Config in auto mode for the
+// calibrator tests. These are GENERIC shipped values — never a deployment's
+// learned constants. The tests assert Calibrate only ever moves them in the
+// safer direction and never bakes any deployment-specific number in.
+func calibDefaults() Config {
+	c := DefaultConfig()
+	c.Mode = ModeAuto
+	c.MinFanout = 16
+	c.MinAnchorPairs = 4000
+	c.MinAnchorsPerSlice = 16
+	c.MaxK = 64
+	return c
+}
+
+// squidShapedCorpus models squid's corpus TODAY: every dispatch is route A,
+// below-threshold never fired (the thresholds never gated a plan), and there
+// are zero OOM/cost-danger outcomes. Calibrate MUST treat this as no-signal and
+// return the defaults verbatim — the load-bearing no-op-on-squid proof.
+func squidShapedCorpus() []CorpusSample {
+	out := make([]CorpusSample, 0, 8)
+	for i := 0; i < 8; i++ {
+		out = append(out, CorpusSample{
+			NAnchors:    100 + i,
+			Fanout:      4 + i,
+			CumulativeD: 300,
+			Route:       "A",
+			// Not below-threshold: these were genuinely small (ineligible /
+			// instant), never held back by the cost thresholds.
+			BelowThreshold:  false,
+			MemoryUsage:     50 << 20, // 50 MiB — nowhere near danger
+			QueryDurationMS: 40,
+			OOM:             false,
+			Count:           50, // 8 * 50 = 400 ≥ minCalibrationSamples
+		})
+	}
+	return out
+}
+
+func TestCalibrate_NoOpOnSquidShapedCorpus(t *testing.T) {
+	defaults := calibDefaults()
+	got, report := Calibrate(squidShapedCorpus(), defaults)
+
+	if !reflect.DeepEqual(got, defaults) {
+		t.Fatalf("squid-shaped corpus must return defaults verbatim, got %+v want %+v", got, defaults)
+	}
+	if !report.NoOp {
+		t.Fatalf("expected NoOp report on squid-shaped corpus, got %+v", report)
+	}
+	if len(report.Changes) != 0 {
+		t.Fatalf("no-op must report zero changes, got %+v", report.Changes)
+	}
+}
+
+func TestCalibrate_NoOpOnThinCorpus(t *testing.T) {
+	defaults := calibDefaults()
+	// Far below minCalibrationSamples even though it carries danger signal:
+	// thin corpus must fail open regardless of what little it shows.
+	thin := []CorpusSample{
+		{NAnchors: 100, Fanout: 8, CumulativeD: 300, Route: "A", BelowThreshold: true, OOM: true, Count: 3},
+	}
+	got, report := Calibrate(thin, defaults)
+	if !reflect.DeepEqual(got, defaults) {
+		t.Fatalf("thin corpus must return defaults verbatim, got %+v", got)
+	}
+	if !report.NoOp || report.NoOpReason == "" {
+		t.Fatalf("expected NoOp with reason on thin corpus, got %+v", report)
+	}
+}
+
+func TestCalibrate_NoOpWhenNoBelowThreshold(t *testing.T) {
+	defaults := calibDefaults()
+	// Plenty of samples and even danger, but NO below-threshold decision: the
+	// thresholds never gated a plan, so there is nothing to tighten toward.
+	var s []CorpusSample
+	for i := 0; i < 20; i++ {
+		s = append(s, CorpusSample{
+			NAnchors: 200, Fanout: 30, CumulativeD: 300, Route: "B",
+			BelowThreshold: false, OOM: true, Count: 20,
+		})
+	}
+	got, report := Calibrate(s, defaults)
+	if !reflect.DeepEqual(got, defaults) {
+		t.Fatalf("no below-threshold → defaults verbatim, got %+v", got)
+	}
+	if !report.NoOp {
+		t.Fatalf("expected NoOp when no below-threshold decisions, got %+v", report)
+	}
+}
+
+func TestCalibrate_NoOpWhenNoDangerSignal(t *testing.T) {
+	defaults := calibDefaults()
+	// Below-threshold decisions exist, but ZERO danger outcomes: no evidence
+	// route A near these thresholds is risky, so tightening would be
+	// speculative → defaults verbatim.
+	var s []CorpusSample
+	for i := 0; i < 20; i++ {
+		s = append(s, CorpusSample{
+			NAnchors: 100, Fanout: 8, CumulativeD: 300, Route: "A",
+			BelowThreshold: true, OOM: false, MemoryUsage: 30 << 20, Count: 30,
+		})
+	}
+	got, report := Calibrate(s, defaults)
+	if !reflect.DeepEqual(got, defaults) {
+		t.Fatalf("no danger signal → defaults verbatim, got %+v", got)
+	}
+	if !report.NoOp {
+		t.Fatalf("expected NoOp when no danger signal, got %+v", report)
+	}
+}
+
+// clearFrontierCorpus models a deployment whose own corpus shows a clear
+// OOM/cost frontier well BELOW the shipped defaults: queries at fanout ~10 and
+// anchor-pairs ~1000 are already OOMing, yet the defaults (MinFanout 16,
+// MinAnchorPairs 4000) keep them on route A (below-threshold). Calibrate must
+// tighten MinFanout / MinAnchorPairs DOWN so those queries route B before the
+// frontier — but never below the safety floor.
+func clearFrontierCorpus() []CorpusSample {
+	var s []CorpusSample
+	// The danger frontier: fanout 10, N=100 → anchor-pairs 1000, OOMing.
+	for i := 0; i < 10; i++ {
+		s = append(s, CorpusSample{
+			NAnchors: 100, Fanout: 10, CumulativeD: 300, Route: "A",
+			BelowThreshold:  true,
+			MemoryUsage:     8 << 30, // 8 GiB
+			QueryDurationMS: 30000,
+			OOM:             true,
+			Count:           30,
+		})
+	}
+	// Some safe small queries below the frontier, also below-threshold.
+	for i := 0; i < 5; i++ {
+		s = append(s, CorpusSample{
+			NAnchors: 50, Fanout: 3, CumulativeD: 300, Route: "A",
+			BelowThreshold: true, MemoryUsage: 20 << 20, OOM: false, Count: 40,
+		})
+	}
+	return s
+}
+
+func TestCalibrate_ClearFrontierTightensTowardRouteB(t *testing.T) {
+	defaults := calibDefaults()
+	got, report := Calibrate(clearFrontierCorpus(), defaults)
+
+	if report.NoOp {
+		t.Fatalf("clear frontier must NOT be a no-op, got %+v", report)
+	}
+	// Tightened in the safer direction: lower thresholds → shard more readily.
+	if got.MinFanout >= defaults.MinFanout {
+		t.Fatalf("MinFanout must tighten DOWN: got %d, default %d", got.MinFanout, defaults.MinFanout)
+	}
+	if got.MinAnchorPairs >= defaults.MinAnchorPairs {
+		t.Fatalf("MinAnchorPairs must tighten DOWN: got %d, default %d", got.MinAnchorPairs, defaults.MinAnchorPairs)
+	}
+	// Never past the shipped safety floor.
+	if got.MinFanout < minCalibratedFanout {
+		t.Fatalf("MinFanout below safety floor: got %d floor %d", got.MinFanout, minCalibratedFanout)
+	}
+	if got.MinAnchorPairs < minCalibratedAnchorPairs {
+		t.Fatalf("MinAnchorPairs below safety floor: got %d floor %d", got.MinAnchorPairs, minCalibratedAnchorPairs)
+	}
+	// Calibrated threshold must sit strictly below the observed frontier so
+	// route B fires BEFORE the danger zone (the safety margin).
+	if got.MinFanout >= report.FrontierFanout {
+		t.Fatalf("MinFanout %d must be below the frontier fanout %d", got.MinFanout, report.FrontierFanout)
+	}
+	if len(report.Changes) == 0 {
+		t.Fatalf("expected reported changes on a real tightening, got none")
+	}
+}
+
+// TestCalibrate_NeverLoosensTightenOnlyInvariant fuzzes a range of corpora and
+// asserts the calibrated thresholds NEVER exceed the defaults (the tighten-only
+// rail) and NEVER drop below the safety floor.
+func TestCalibrate_NeverLoosensTightenOnlyInvariant(t *testing.T) {
+	defaults := calibDefaults()
+
+	corpora := map[string][]CorpusSample{
+		"squid":          squidShapedCorpus(),
+		"clear-frontier": clearFrontierCorpus(),
+		"no-below":       mustManySamples(false, true),
+		"no-danger":      mustManySamples(true, false),
+		// A corpus whose frontier sits ABOVE the defaults: danger only at huge
+		// fanout. Must not loosen the defaults upward toward that frontier.
+		"high-frontier": highFrontierCorpus(),
+	}
+
+	for name, c := range corpora {
+		got, _ := Calibrate(c, defaults)
+		if got.MinFanout > defaults.MinFanout {
+			t.Errorf("%s: MinFanout LOOSENED %d > default %d", name, got.MinFanout, defaults.MinFanout)
+		}
+		if got.MinAnchorPairs > defaults.MinAnchorPairs {
+			t.Errorf("%s: MinAnchorPairs LOOSENED %d > default %d", name, got.MinAnchorPairs, defaults.MinAnchorPairs)
+		}
+		if got.MinFanout < minCalibratedFanout {
+			t.Errorf("%s: MinFanout below floor %d", name, got.MinFanout)
+		}
+		if got.MinAnchorPairs < minCalibratedAnchorPairs {
+			t.Errorf("%s: MinAnchorPairs below floor %d", name, got.MinAnchorPairs)
+		}
+		// Geometric knobs must always pass through untouched.
+		if got.MaxK != defaults.MaxK || got.MinAnchorsPerSlice != defaults.MinAnchorsPerSlice {
+			t.Errorf("%s: geometric knobs must pass through: got MaxK=%d MAPS=%d", name, got.MaxK, got.MinAnchorsPerSlice)
+		}
+	}
+}
+
+// highFrontierCorpus: danger only at very high fanout (way above defaults), so
+// the frontier confirms the defaults already route safely → no loosening.
+func highFrontierCorpus() []CorpusSample {
+	var s []CorpusSample
+	for i := 0; i < 10; i++ {
+		s = append(s, CorpusSample{
+			NAnchors: 5000, Fanout: 2000, CumulativeD: 300, Route: "B",
+			BelowThreshold: true, OOM: true, MemoryUsage: 8 << 30, Count: 30,
+		})
+	}
+	return s
+}
+
+func mustManySamples(belowThreshold, oom bool) []CorpusSample {
+	var s []CorpusSample
+	for i := 0; i < 20; i++ {
+		s = append(s, CorpusSample{
+			NAnchors: 100, Fanout: 10, CumulativeD: 300, Route: "A",
+			BelowThreshold: belowThreshold, OOM: oom, MemoryUsage: 4 << 30, Count: 30,
+		})
+	}
+	return s
+}
+
+// TestCalibrate_DeterministicAndPure asserts repeated calls with the same input
+// (in different slice orders) yield identical output — no clock / RNG / order
+// dependence.
+func TestCalibrate_DeterministicAndPure(t *testing.T) {
+	defaults := calibDefaults()
+	base := clearFrontierCorpus()
+
+	first, r1 := Calibrate(base, defaults)
+	for iter := 0; iter < 5; iter++ {
+		again, r2 := Calibrate(base, defaults)
+		if !reflect.DeepEqual(first, again) {
+			t.Fatalf("non-deterministic Config: %+v vs %+v", first, again)
+		}
+		if !reflect.DeepEqual(r1, r2) {
+			t.Fatalf("non-deterministic report: %+v vs %+v", r1, r2)
+		}
+	}
+
+	// Order independence: reversing the sample slice must not change the result.
+	rev := make([]CorpusSample, len(base))
+	for i := range base {
+		rev[len(base)-1-i] = base[i]
+	}
+	revGot, _ := Calibrate(rev, defaults)
+	if !reflect.DeepEqual(first, revGot) {
+		t.Fatalf("order-dependent result: forward %+v reversed %+v", first, revGot)
+	}
+
+	// Purity: Calibrate must not mutate its input slice.
+	snapshot := make([]CorpusSample, len(base))
+	copy(snapshot, base)
+	_, _ = Calibrate(base, defaults)
+	if !reflect.DeepEqual(base, snapshot) {
+		t.Fatalf("Calibrate mutated its input slice")
+	}
+}

--- a/internal/solver/config.go
+++ b/internal/solver/config.go
@@ -90,6 +90,17 @@ type Config struct {
 	// per-shard max_memory_usage is cap/P (256 MiB floor), holding total
 	// exposure at exactly the single-query cap.
 	MemoryApportion bool
+
+	// SelfTune (CERBERUS_ROUTE_SELFTUNE) enables the per-deployment
+	// self-tuning loop (selftune.go): when true, cmd/cerberus starts a
+	// background goroutine that periodically reads THIS deployment's router
+	// corpus, runs Calibrate, and atomically swaps the locally-calibrated
+	// thresholds into the Planner. Default FALSE — the static shipped Config
+	// is used and the loop never starts, so existing deployments are
+	// byte-for-byte unchanged. It tunes only MinFanout / MinAnchorPairs and
+	// only ever in the SAFER (tighten-toward-route-B) direction; see
+	// calibrate.go for the safety rails.
+	SelfTune bool
 }
 
 // Default tuning constants (docs §Routing / §"The solver framework").

--- a/internal/solver/config_env.go
+++ b/internal/solver/config_env.go
@@ -24,6 +24,9 @@ const (
 	EnvMemoryApportion    = "CERBERUS_SHARD_MEMORY_APPORTION"
 )
 
+// EnvRouteSelfTune is declared in selftune.go (the loop owns the flag name);
+// referenced here so ConfigFromEnv parses it alongside the other knobs.
+
 // ConfigFromEnv builds a Config from the CERBERUS_* environment, starting
 // from DefaultConfig and overriding each field from its env var when set. It
 // does NOT call Validate — the caller (cmd/cerberus) runs Validate to fail-fast
@@ -71,6 +74,10 @@ func ConfigFromEnv() (Config, error) {
 		return Config{}, err
 	}
 	if cfg.MemoryApportion, err = envBool(EnvMemoryApportion, cfg.MemoryApportion); err != nil {
+		return Config{}, err
+	}
+	// Self-tuning is OFF unless explicitly enabled, regardless of route mode.
+	if cfg.SelfTune, err = envBool(EnvRouteSelfTune, cfg.SelfTune); err != nil {
 		return Config{}, err
 	}
 	return cfg, nil

--- a/internal/solver/config_sweep_test.go
+++ b/internal/solver/config_sweep_test.go
@@ -87,7 +87,7 @@ func TestSweep_PlanNeverPanics(t *testing.T) {
 			&chplan.Limit{Input: drawEligibleWindow(t, start, end, step), Count: 5}, // unmarked node
 			now64Window(start, end, step),                                           // now64 in a projection
 		}
-		p := &Planner{Cfg: cfg}
+		p := NewPlanner(cfg)
 		for _, plan := range plans {
 			// The contract is "does not panic"; the decision itself is asserted
 			// by the targeted invariants below.
@@ -109,7 +109,7 @@ func TestSweep_SingleNeverRoutes(t *testing.T) {
 		meta := RequestMeta{Lang: "promql", Start: start, End: end, Step: step}
 		plan := drawEligibleWindow(t, start, end, step) // the most routable shape
 
-		p := &Planner{Cfg: cfg}
+		p := NewPlanner(cfg)
 		_, routed := p.Plan(plan, meta)
 		if routed {
 			t.Fatalf("Mode=single routed (cfg=%+v) — ship-dark guarantee broken", cfg)
@@ -130,7 +130,7 @@ func TestSweep_RoutedDecisionIsWellFormed(t *testing.T) {
 		meta := RequestMeta{Lang: "promql", Start: start, End: end, Step: step}
 		plan := drawEligibleWindow(t, start, end, step)
 
-		p := &Planner{Cfg: cfg}
+		p := NewPlanner(cfg)
 		d, routed := p.Plan(plan, meta)
 		if !routed {
 			return // ineligible-for-threshold under this config; nothing to check.
@@ -216,7 +216,7 @@ func TestSweep_IneligibleAlwaysRoutesA(t *testing.T) {
 			{"instant-window", instantWindow(start, end), instantMeta},
 		}
 
-		p := &Planner{Cfg: cfg}
+		p := NewPlanner(cfg)
 		for _, c := range cases {
 			_, routed := p.Plan(c.plan, c.meta)
 			if routed {
@@ -250,8 +250,8 @@ func TestSweep_ThresholdMonotonicity(t *testing.T) {
 		strict.MinFanout = base.MinFanout + bumpFanout
 		strict.MinAnchorPairs = base.MinAnchorPairs + bumpPairs
 
-		lowP := &Planner{Cfg: base}
-		hiP := &Planner{Cfg: strict}
+		lowP := NewPlanner(base)
+		hiP := NewPlanner(strict)
 
 		_, lowRouted := lowP.Plan(plan, meta)
 		_, hiRouted := hiP.Plan(plan, meta)

--- a/internal/solver/decision_grid_test.go
+++ b/internal/solver/decision_grid_test.go
@@ -13,7 +13,7 @@ import (
 func TestDecision_CostGrid_PopulatedOnRoute(t *testing.T) {
 	t.Parallel()
 
-	p := &Planner{Cfg: autoCfg()}
+	p := NewPlanner(autoCfg())
 	d, routed := p.Plan(oomWindow(), oomMeta())
 	if !routed {
 		t.Fatalf("OOM shape should route under auto; reason=%q", d.Reason)
@@ -65,7 +65,7 @@ func TestDecision_CostGrid_PopulatedOnNotRouted(t *testing.T) {
 		AggFuncs: []chplan.AggFunc{{Name: "sum", Args: []chplan.Expr{&chplan.ColumnRef{Name: "Value"}}}},
 	}
 
-	p := &Planner{Cfg: autoCfg()}
+	p := NewPlanner(autoCfg())
 	d, routed := p.Plan(plan, oomMeta())
 	if routed {
 		t.Fatalf("F=2 shape should NOT route under auto")
@@ -116,7 +116,7 @@ func TestDecision_CostGrid_HighDNotFoldedIntoReason(t *testing.T) {
 		AggFuncs: []chplan.AggFunc{{Name: "sum", Args: []chplan.Expr{&chplan.ColumnRef{Name: "Value"}}}},
 	}
 
-	p := &Planner{Cfg: autoCfg()}
+	p := NewPlanner(autoCfg())
 	d, routed := p.Plan(plan, oomMeta())
 	if routed {
 		t.Fatalf("high-D shape should NOT route")
@@ -153,7 +153,7 @@ func TestPlan_OfflineReplay_ReproducesRoute(t *testing.T) {
 			t.Parallel()
 			cfg := DefaultConfig()
 			cfg.Mode = tc.mode
-			p := &Planner{Cfg: cfg}
+			p := NewPlanner(cfg)
 
 			// Original classification, capturing the recorded features.
 			plan := buildReplayPlan(tc.fanRn)

--- a/internal/solver/planner.go
+++ b/internal/solver/planner.go
@@ -1,6 +1,7 @@
 package solver
 
 import (
+	"sync/atomic"
 	"time"
 
 	"github.com/tsouza/cerberus/internal/chplan"
@@ -10,8 +11,42 @@ import (
 // routing Decision. It never mutates the plan: every check reads the tree,
 // and slicing (the only path that copies) goes through ReanchorRange, which
 // deep-copies.
+//
+// The active Config is held behind an atomic.Pointer so the per-deployment
+// self-tuning loop (selftune.go) can atomically swap a freshly calibrated
+// Config in while concurrent Plan calls read it lock-free. When self-tuning is
+// off (the default) the pointer is written exactly once at construction and
+// never changes, so the hot path is a single atomic load with no contention.
 type Planner struct {
-	Cfg Config
+	cfg atomic.Pointer[Config]
+}
+
+// NewPlanner builds a Planner with the given static Config installed. Use this
+// rather than a bare &Planner{} so the atomic Config pointer is always
+// initialised before the first Plan call.
+func NewPlanner(cfg Config) *Planner {
+	p := &Planner{}
+	p.cfg.Store(&cfg)
+	return p
+}
+
+// Cfg returns the currently active Config (lock-free). It is a value copy, so
+// callers never observe a torn struct even if a swap races the read: the
+// atomic load returns either the old or the new whole Config pointer, never a
+// half-updated one.
+func (p *Planner) Cfg() Config {
+	if c := p.cfg.Load(); c != nil {
+		return *c
+	}
+	return Config{}
+}
+
+// SetConfig atomically swaps the active Config. The next Plan call observes the
+// new thresholds; in-flight Plan calls finish against whichever pointer they
+// already loaded. This is the only writer and is safe to call concurrently
+// with Plan (the self-tuning loop calls it on each recalibration).
+func (p *Planner) SetConfig(cfg Config) {
+	p.cfg.Store(&cfg)
 }
 
 // Plan classifies plan against meta and returns the Decision plus whether the
@@ -29,6 +64,11 @@ type Planner struct {
 //   - "auto": route iff eligible AND F >= MinFanout AND N x F >= MinAnchorPairs
 //     AND K >= 2.
 func (p *Planner) Plan(plan chplan.Node, meta RequestMeta) (*Decision, bool) {
+	// Snapshot the active Config once (lock-free atomic load) so the whole
+	// classification runs against one consistent threshold set even if the
+	// self-tuning loop swaps a new Config in mid-Plan.
+	cfg := p.Cfg()
+
 	// (2)-prefix: instant queries are never time-slice routed in phase 1.
 	// Step == 0 means an instant evaluation; there is no anchor grid. The
 	// analyze pass below derives the cost grid (N/F/D/OuterRange); it has not
@@ -38,7 +78,7 @@ func (p *Planner) Plan(plan chplan.Node, meta RequestMeta) (*Decision, bool) {
 		return notRouted(ReasonInstant).withGrid(signals{}, meta), false
 	}
 
-	sig := p.analyze(plan, meta)
+	sig := p.analyze(plan, meta, cfg)
 
 	// (1) Slice-invariance: any unmarked node anywhere → route A.
 	if !sig.allSliceInvariant {
@@ -97,12 +137,12 @@ func (p *Planner) Plan(plan chplan.Node, meta RequestMeta) (*Decision, bool) {
 		denom = step
 	}
 	highBound := int64(outerRange / denom) // floor(OuterRange / max(D, Step))
-	upper := int64(p.Cfg.MaxK)
+	upper := int64(cfg.MaxK)
 	if highBound < upper {
 		upper = highBound
 	}
 	lower := int64(2)
-	k := int64(n / p.Cfg.MinAnchorsPerSlice)
+	k := int64(n / cfg.MinAnchorsPerSlice)
 	if k < lower {
 		k = lower
 	}
@@ -117,16 +157,16 @@ func (p *Planner) Plan(plan chplan.Node, meta RequestMeta) (*Decision, bool) {
 	}
 
 	// "single" classifies but never routes.
-	if p.Cfg.Mode == ModeSingle {
+	if cfg.Mode == ModeSingle {
 		return notRouted(ReasonBelowThreshold).withGrid(sig, meta), false
 	}
 
-	if p.Cfg.Mode == ModeAuto {
+	if cfg.Mode == ModeAuto {
 		// Cost thresholds gate the auto path. Below threshold → route A.
-		if f < int64(p.Cfg.MinFanout) {
+		if f < int64(cfg.MinFanout) {
 			return notRouted(ReasonBelowThreshold).withGrid(sig, meta), false
 		}
-		if int64(n)*f < int64(p.Cfg.MinAnchorPairs) {
+		if int64(n)*f < int64(cfg.MinAnchorPairs) {
 			return notRouted(ReasonBelowThreshold).withGrid(sig, meta), false
 		}
 		if k < 2 {
@@ -214,12 +254,18 @@ type signals struct {
 	// innerResolutions records every inner-spine Step for the lcm
 	// commensurability check.
 	innerResolutions []time.Duration
+
+	// minAnchorsPerSlice snapshots cfg.MinAnchorsPerSlice for the duration of
+	// this one analyze pass, so checkCommensurability reads the SAME Config
+	// snapshot the rest of Plan uses even if the self-tuning loop swaps a new
+	// Config in mid-pass.
+	minAnchorsPerSlice int
 }
 
 // analyze runs the one eligibility pass over both the node tree and every
 // expr tree (recursing into ScalarSubquery.Input, which chplan.Walk skips).
-func (p *Planner) analyze(plan chplan.Node, meta RequestMeta) signals {
-	sig := signals{allSliceInvariant: true}
+func (p *Planner) analyze(plan chplan.Node, meta RequestMeta, cfg Config) signals {
+	sig := signals{allSliceInvariant: true, minAnchorsPerSlice: cfg.MinAnchorsPerSlice}
 
 	// depth tracks how deep on the windowed spine we are, so the
 	// grid-prediction check can predict the right (start, end) per level.
@@ -467,7 +513,7 @@ func (p *Planner) checkCommensurability(sig *signals) {
 	// Equivalently m must be a multiple of lcm/gcd(Step,lcm) = lcm/g.
 	// Defer the Step-dependent half to the slicer; here record the gate
 	// only when the outer grid is known.
-	loBound := p.Cfg.MinAnchorsPerSlice
+	loBound := sig.minAnchorsPerSlice
 	hiBound := sig.outerN / 2
 	if hiBound < loBound {
 		// No room for a valid quantum window at all.

--- a/internal/solver/planner_test.go
+++ b/internal/solver/planner_test.go
@@ -58,7 +58,7 @@ func autoCfg() Config {
 // routes under Mode=auto with K=8 and Reason=routed.
 func TestPlan_OOMShapeRoutes(t *testing.T) {
 	t.Parallel()
-	p := &Planner{Cfg: autoCfg()}
+	p := NewPlanner(autoCfg())
 	d, routed := p.Plan(oomWindow(), oomMeta())
 	if !routed {
 		t.Fatalf("OOM shape must route; got reason=%q", d.Reason)
@@ -114,7 +114,7 @@ func TestPlan_RangeLWRSpineRoutes(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			p := &Planner{Cfg: autoCfg()}
+			p := NewPlanner(autoCfg())
 			d, routed := p.Plan(lwrSpine(tc.offset), oomMeta())
 			if !routed {
 				t.Fatalf("RangeLWR spine must route; got reason=%q", d.Reason)
@@ -161,7 +161,7 @@ func TestPlan_RangeLWRSpineRoutes(t *testing.T) {
 func TestPlan_SingleNeverRoutes(t *testing.T) {
 	t.Parallel()
 	cfg := DefaultConfig() // Mode == single
-	p := &Planner{Cfg: cfg}
+	p := NewPlanner(cfg)
 	d, routed := p.Plan(oomWindow(), oomMeta())
 	if routed {
 		t.Fatal("Mode=single must never route")
@@ -191,7 +191,7 @@ func TestPlan_ShardedRoutesEligible(t *testing.T) {
 		ValueColumn:     "Value",
 		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
 	}
-	p := &Planner{Cfg: cfg}
+	p := NewPlanner(cfg)
 	d, routed := p.Plan(rw, oomMeta())
 	if !routed {
 		t.Fatalf("sharded must route eligible plan; reason=%q", d.Reason)
@@ -364,7 +364,7 @@ func TestPlan_RejectionTable(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			p := &Planner{Cfg: autoCfg()}
+			p := NewPlanner(autoCfg())
 			d, routed := p.Plan(tc.plan(), tc.meta())
 			if routed {
 				t.Fatalf("%s: expected NOT routed, got routed (K=%d)", tc.name, d.K)
@@ -392,7 +392,7 @@ func TestPlan_Now64InAggregateArgsRejected(t *testing.T) {
 			Right: &chplan.FuncCall{Name: "now64", Args: []chplan.Expr{&chplan.LitInt{V: 9}}},
 		}},
 	}}
-	p := &Planner{Cfg: autoCfg()}
+	p := NewPlanner(autoCfg())
 	d, routed := p.Plan(agg, oomMeta())
 	if routed {
 		t.Fatal("now64 in outer Aggregate args must not route")
@@ -408,7 +408,7 @@ func TestPlan_Now64InAggregateGroupByRejected(t *testing.T) {
 	t.Parallel()
 	agg := oomWindow().(*chplan.Aggregate)
 	agg.GroupBy = []chplan.Expr{&chplan.FuncCall{Name: "now64", Args: []chplan.Expr{&chplan.LitInt{V: 9}}}}
-	p := &Planner{Cfg: autoCfg()}
+	p := NewPlanner(autoCfg())
 	d, routed := p.Plan(agg, oomMeta())
 	if routed {
 		t.Fatal("now64 in outer Aggregate GroupBy must not route")
@@ -441,7 +441,7 @@ func TestPlan_Now64InScalarInteriorAggregateRejected(t *testing.T) {
 			Right: &chplan.ScalarSubquery{Input: scalarInner},
 		},
 	}
-	p := &Planner{Cfg: autoCfg()}
+	p := NewPlanner(autoCfg())
 	d, routed := p.Plan(plan, oomMeta())
 	if routed {
 		t.Fatal("now64 in scalar-interior Aggregate must not route")
@@ -492,7 +492,7 @@ func TestPlan_NonRangeWindowSpineRejected(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			p := &Planner{Cfg: autoCfg()}
+			p := NewPlanner(autoCfg())
 			d, routed := p.Plan(tc.plan(), oomMeta())
 			if routed {
 				t.Fatalf("%s must not route (K=%d)", tc.name, d.K)
@@ -529,7 +529,7 @@ func TestPlan_SingleProducedSliceNotRouted(t *testing.T) {
 		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
 	}
 	meta := RequestMeta{Lang: "promql", Start: start, End: end, Step: step}
-	p := &Planner{Cfg: cfg}
+	p := NewPlanner(cfg)
 	d, routed := p.Plan(plan, meta)
 	if routed {
 		t.Fatalf("a plan collapsing to one slice must not route (K=%d)", d.K)
@@ -563,7 +563,7 @@ func TestPlan_ScalarHeavyRejected(t *testing.T) {
 			Right: &chplan.ScalarSubquery{Input: heavyInner},
 		},
 	}
-	p := &Planner{Cfg: autoCfg()}
+	p := NewPlanner(autoCfg())
 	d, routed := p.Plan(plan, oomMeta())
 	if routed {
 		t.Fatal("scalar-heavy plan must not route")
@@ -601,7 +601,7 @@ func TestPlan_IncommensurateNestedSpine(t *testing.T) {
 		TimestampColumn: "anchor_ts",
 		ValueColumn:     "Value",
 	}
-	p := &Planner{Cfg: autoCfg()}
+	p := NewPlanner(autoCfg())
 	d, routed := p.Plan(outer, RequestMeta{Lang: "promql", Start: start, End: end, Step: step})
 	if routed {
 		t.Fatal("incommensurate nested spine must not route")

--- a/internal/solver/selftune.go
+++ b/internal/solver/selftune.go
@@ -172,6 +172,24 @@ func (st *SelfTuner) recalibrate(ctx context.Context) {
 		"min_fanout", calibrated.MinFanout,
 		"min_anchor_pairs", calibrated.MinAnchorPairs,
 		"changes", changeStrings(report.Changes))
+
+	// Surface the floor/margin interaction: when the shipped safety floor bound
+	// a calibrated threshold at or above the margin-reduced frontier, the safety
+	// margin is reduced (or, in the sub-floor case, the floor would have gated
+	// above the OOM coordinate and the calibrator capped strictly below the
+	// frontier instead). Operators must SEE this — the floor previously moved
+	// silently, defeating the safety margin near the floor without a trace.
+	if report.FloorClampedFanout || report.FloorClampedAnchorPairs {
+		st.logger.Warn("route self-tune: safety floor swallowed the margin near the frontier",
+			"floor_clamped_fanout", report.FloorClampedFanout,
+			"floor_clamped_anchor_pairs", report.FloorClampedAnchorPairs,
+			"frontier_fanout", report.FrontierFanout,
+			"frontier_anchor_pairs", report.FrontierAnchorPairs,
+			"min_fanout", calibrated.MinFanout,
+			"min_anchor_pairs", calibrated.MinAnchorPairs,
+			"min_calibrated_fanout", minCalibratedFanout,
+			"min_calibrated_anchor_pairs", minCalibratedAnchorPairs)
+	}
 }
 
 // changeStrings renders the report's threshold moves into a flat []string for

--- a/internal/solver/selftune.go
+++ b/internal/solver/selftune.go
@@ -1,0 +1,202 @@
+package solver
+
+// Self-tuning loop: the GENERIC background driver that, when enabled, reads
+// THIS deployment's router corpus on a fixed cadence, runs the pure Calibrate
+// over it, and atomically swaps the freshly calibrated Config into the Planner.
+//
+// What ships vs what is learned (mirrors calibrate.go):
+//
+//   - GENERIC (shipped): this loop, its cadence, the fail-open behaviour, and
+//     the conservative defaults it starts from. Deployment-independent.
+//   - LOCAL (never shipped): the Config the loop installs, derived at runtime
+//     from FrontierReader.ReadFrontier (this deployment's corpus). Off by
+//     default — nothing starts unless the operator flips CERBERUS_ROUTE_SELFTUNE.
+//
+// The loop derives its context from a cancelable parent and exits on cancel —
+// it does NOT root anything in context.Background() without cancellation (the
+// C1 breaker-recovery bug class). A read or calibrate error keeps the current
+// Config, logs, and never crashes (fail-open).
+
+import (
+	"context"
+	"log/slog"
+	"strconv"
+	"sync"
+	"time"
+)
+
+// EnvRouteSelfTune is the master flag for per-deployment self-tuning. Default
+// OFF: unset / false means the Planner runs the static shipped Config and this
+// loop never starts, so existing deployments see ZERO behaviour change. Set to
+// a strconv.ParseBool-true value to enable.
+const EnvRouteSelfTune = "CERBERUS_ROUTE_SELFTUNE"
+
+// defaultSelfTuneInterval is the recalibration cadence. Sized long: the corpus
+// frontier moves on the timescale of deployment workload shifts, not seconds,
+// and each tick runs a rate-limited corpus read, so a slow cadence keeps the
+// data-plane impact negligible while still adapting within an hour.
+const defaultSelfTuneInterval = 15 * time.Minute
+
+// FrontierReader is the GENERIC seam between the loop and a deployment's
+// corpus. ReadFrontier returns the aggregated frontier buckets (a few
+// aggregate SELECTs per (N,F[,D]) bucket, NOT every row) for THIS deployment.
+// The concrete implementation lives in the corpus-reader wiring (cmd/cerberus
+// maps cerberus_router_corpus rows into []CorpusSample); the loop depends only
+// on this interface so the solver package stays free of any CH driver or
+// optcorpus dependency.
+//
+// A nil error with an empty slice is a legitimate "no signal yet" — Calibrate
+// fails open on it. A non-nil error is logged and the current Config is kept.
+type FrontierReader interface {
+	ReadFrontier(ctx context.Context) ([]CorpusSample, error)
+}
+
+// SelfTuner is the lifecycle handle for one Planner's background calibration
+// goroutine. Created and started by StartSelfTuner; Stop cancels the loop ctx
+// and joins the goroutine so shutdown is goleak-clean.
+type SelfTuner struct {
+	planner  *Planner
+	reader   FrontierReader
+	defaults Config
+	interval time.Duration
+	logger   *slog.Logger
+
+	cancel   context.CancelFunc
+	doneCh   chan struct{}
+	stopOnce sync.Once
+}
+
+// SelfTuneParams groups StartSelfTuner's inputs. defaults is the SHIPPED
+// conservative Config (the calibration floor / fail-open fallback); it is the
+// only Config the loop trusts as a baseline and the value Calibrate returns
+// verbatim on a no-op. interval <= 0 falls back to defaultSelfTuneInterval.
+// A nil logger falls back to slog.Default so the loop always logs its swaps.
+type SelfTuneParams struct {
+	Planner  *Planner
+	Reader   FrontierReader
+	Defaults Config
+	Interval time.Duration
+	Logger   *slog.Logger
+}
+
+// StartSelfTuner launches the background calibration loop against a CANCELABLE
+// child of parent and returns the handle. The loop runs one calibration pass
+// immediately (so a restart picks up the learned frontier without waiting a
+// full interval), then on every interval tick, until Stop or parent cancel.
+//
+// Returns nil if planner or reader is nil — callers may then skip Stop safely
+// (Stop is a no-op on a nil receiver). The default-off wiring in cmd/cerberus
+// simply never calls this.
+func StartSelfTuner(parent context.Context, params SelfTuneParams) *SelfTuner {
+	if params.Planner == nil || params.Reader == nil {
+		return nil
+	}
+	interval := params.Interval
+	if interval <= 0 {
+		interval = defaultSelfTuneInterval
+	}
+	logger := params.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	ctx, cancel := context.WithCancel(parent)
+	st := &SelfTuner{
+		planner:  params.Planner,
+		reader:   params.Reader,
+		defaults: params.Defaults,
+		interval: interval,
+		logger:   logger,
+		cancel:   cancel,
+		doneCh:   make(chan struct{}),
+	}
+	go st.run(ctx)
+	return st
+}
+
+// run is the goroutine body: an immediate pass, then a ticker loop. It exits
+// (closing doneCh) as soon as ctx is cancelled.
+func (st *SelfTuner) run(ctx context.Context) {
+	defer close(st.doneCh)
+
+	st.recalibrate(ctx)
+
+	ticker := time.NewTicker(st.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			st.recalibrate(ctx)
+		}
+	}
+}
+
+// recalibrate runs one read → Calibrate → atomic-swap cycle. Fail-open: any
+// reader error keeps the current Config and returns; Calibrate's own no-op
+// path returns the defaults verbatim, so a no-signal corpus reinstalls the
+// conservative defaults (never a partially-learned Config). Every swap and
+// no-op is logged so operators can SEE what their deployment self-tuned to.
+func (st *SelfTuner) recalibrate(ctx context.Context) {
+	samples, err := st.reader.ReadFrontier(ctx)
+	if err != nil {
+		// Fail-open: a corpus-read failure (CH busy, timeout, table missing)
+		// must never disturb the data plane or crash the loop. Keep the
+		// current Config and try again next tick.
+		st.logger.Warn("route self-tune: corpus read failed; keeping current config",
+			"err", err)
+		return
+	}
+
+	calibrated, report := Calibrate(samples, st.defaults)
+
+	if report.NoOp {
+		// Reinstall the conservative defaults verbatim (Calibrate returned
+		// them unchanged). This is the squid-shaped path: all route A,
+		// below-threshold=0, no failures → defaults stay in force.
+		st.planner.SetConfig(calibrated)
+		st.logger.Info("route self-tune: no-op (local corpus carries no actionable signal)",
+			"samples", report.SampleCount,
+			"reason", report.NoOpReason,
+			"min_fanout", calibrated.MinFanout,
+			"min_anchor_pairs", calibrated.MinAnchorPairs)
+		return
+	}
+
+	st.planner.SetConfig(calibrated)
+	st.logger.Info("route self-tune: installed locally-calibrated thresholds",
+		"samples", report.SampleCount,
+		"frontier_fanout", report.FrontierFanout,
+		"frontier_anchor_pairs", report.FrontierAnchorPairs,
+		"min_fanout", calibrated.MinFanout,
+		"min_anchor_pairs", calibrated.MinAnchorPairs,
+		"changes", changeStrings(report.Changes))
+}
+
+// changeStrings renders the report's threshold moves into a flat []string for
+// structured logging (def→calibrated per field with its reason).
+func changeStrings(changes []ThresholdChange) []string {
+	out := make([]string, 0, len(changes))
+	for _, c := range changes {
+		out = append(out, c.String())
+	}
+	return out
+}
+
+// String renders one ThresholdChange as "Field: from→to (why)".
+func (c ThresholdChange) String() string {
+	return c.Field + ": " + strconv.Itoa(c.From) + "→" + strconv.Itoa(c.To) + " (" + c.Why + ")"
+}
+
+// Stop cancels the loop ctx and blocks until the goroutine has exited, so a
+// caller's Close is goleak-clean. Idempotent and nil-safe.
+func (st *SelfTuner) Stop() {
+	if st == nil {
+		return
+	}
+	st.stopOnce.Do(func() {
+		st.cancel()
+	})
+	<-st.doneCh
+}

--- a/internal/solver/selftune.go
+++ b/internal/solver/selftune.go
@@ -153,7 +153,7 @@ func (st *SelfTuner) recalibrate(ctx context.Context) {
 
 	if report.NoOp {
 		// Reinstall the conservative defaults verbatim (Calibrate returned
-		// them unchanged). This is the squid-shaped path: all route A,
+		// them unchanged). This is the no-signal path: all route A,
 		// below-threshold=0, no failures → defaults stay in force.
 		st.planner.SetConfig(calibrated)
 		st.logger.Info("route self-tune: no-op (local corpus carries no actionable signal)",

--- a/internal/solver/selftune_test.go
+++ b/internal/solver/selftune_test.go
@@ -1,0 +1,267 @@
+package solver
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// fakeFrontierReader is a programmable solver.FrontierReader for the loop
+// tests: it returns canned samples (or an error) and counts reads, so a test
+// can drive recalibrate and assert what the loop did.
+type fakeFrontierReader struct {
+	mu      sync.Mutex
+	samples []CorpusSample
+	err     error
+	reads   atomic.Int64
+}
+
+func (f *fakeFrontierReader) ReadFrontier(ctx context.Context) ([]CorpusSample, error) {
+	f.reads.Add(1)
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.samples, f.err
+}
+
+func (f *fakeFrontierReader) set(samples []CorpusSample, err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.samples, f.err = samples, err
+}
+
+// TestSelfTuner_NilReaderOrPlannerReturnsNil: the off-by-default wiring (nil
+// reader / planner) must start nothing and be Stop-safe.
+func TestSelfTuner_NilReaderOrPlannerReturnsNil(t *testing.T) {
+	if st := StartSelfTuner(context.Background(), SelfTuneParams{Planner: nil, Reader: &fakeFrontierReader{}}); st != nil {
+		st.Stop()
+		t.Fatal("nil planner must return a nil tuner")
+	}
+	if st := StartSelfTuner(context.Background(), SelfTuneParams{Planner: NewPlanner(calibDefaults()), Reader: nil}); st != nil {
+		st.Stop()
+		t.Fatal("nil reader must return a nil tuner")
+	}
+	// Stop on a nil *SelfTuner must not panic.
+	var none *SelfTuner
+	none.Stop()
+}
+
+// TestSelfTuner_ImmediatePassSwapsCalibratedConfig: with a clear-frontier
+// corpus the loop's immediate pass must install tightened thresholds into the
+// Planner.
+func TestSelfTuner_ImmediatePassSwapsCalibratedConfig(t *testing.T) {
+	defaults := calibDefaults()
+	pl := NewPlanner(defaults)
+	reader := &fakeFrontierReader{}
+	reader.set(clearFrontierCorpus(), nil)
+
+	st := StartSelfTuner(context.Background(), SelfTuneParams{
+		Planner:  pl,
+		Reader:   reader,
+		Defaults: defaults,
+		Interval: time.Hour, // immediate pass only; ticker won't fire in the test
+	})
+	defer st.Stop()
+
+	// The immediate pass runs in the goroutine; wait for the first read.
+	waitFor(t, func() bool { return reader.reads.Load() >= 1 })
+	// Then wait for the swap to land (SetConfig happens right after the read).
+	waitFor(t, func() bool { return pl.Cfg().MinFanout < defaults.MinFanout })
+
+	got := pl.Cfg()
+	if got.MinFanout >= defaults.MinFanout || got.MinAnchorPairs >= defaults.MinAnchorPairs {
+		t.Fatalf("expected tightened config installed, got %+v", got)
+	}
+}
+
+// TestSelfTuner_NoOpReinstallsDefaultsVerbatim: a squid-shaped corpus must
+// leave the Planner on the defaults (the no-op-on-squid behavior, end to end
+// through the loop).
+func TestSelfTuner_NoOpReinstallsDefaultsVerbatim(t *testing.T) {
+	defaults := calibDefaults()
+	pl := NewPlanner(defaults)
+	reader := &fakeFrontierReader{}
+	reader.set(squidShapedCorpus(), nil)
+
+	st := StartSelfTuner(context.Background(), SelfTuneParams{
+		Planner: pl, Reader: reader, Defaults: defaults, Interval: time.Hour,
+	})
+	defer st.Stop()
+
+	waitFor(t, func() bool { return reader.reads.Load() >= 1 })
+	// Give the swap a moment; defaults must remain in force.
+	time.Sleep(20 * time.Millisecond)
+	if pl.Cfg() != defaults {
+		t.Fatalf("squid-shaped corpus must keep defaults, got %+v", pl.Cfg())
+	}
+}
+
+// TestSelfTuner_FailOpenOnReaderError: a reader error must keep the current
+// Config and never crash; subsequent good reads must still take effect.
+func TestSelfTuner_FailOpenOnReaderError(t *testing.T) {
+	defaults := calibDefaults()
+	pl := NewPlanner(defaults)
+	reader := &fakeFrontierReader{}
+	reader.set(nil, errors.New("CH busy"))
+
+	st := StartSelfTuner(context.Background(), SelfTuneParams{
+		Planner:  pl,
+		Reader:   reader,
+		Defaults: defaults,
+		Interval: 5 * time.Millisecond, // tick quickly so the recovery read fires
+	})
+	defer st.Stop()
+
+	waitFor(t, func() bool { return reader.reads.Load() >= 1 })
+	// Config unchanged after the failing read.
+	if pl.Cfg() != defaults {
+		t.Fatalf("reader error must keep current config, got %+v", pl.Cfg())
+	}
+
+	// Now feed a clear frontier; a later tick must pick it up (fail-open
+	// recovered, not stuck).
+	reader.set(clearFrontierCorpus(), nil)
+	waitFor(t, func() bool { return pl.Cfg().MinFanout < defaults.MinFanout })
+}
+
+// TestSelfTuner_AtomicSwapUnderConcurrency hammers Plan from many goroutines
+// while the loop swaps Configs, asserting (under -race) no data race and that
+// every observed Config is one of the two legal whole values (never torn).
+func TestSelfTuner_AtomicSwapUnderConcurrency(t *testing.T) {
+	defaults := calibDefaults()
+	calibrated, _ := Calibrate(clearFrontierCorpus(), defaults)
+	if calibrated == defaults {
+		t.Fatal("test precondition: calibrated must differ from defaults")
+	}
+
+	pl := NewPlanner(defaults)
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Writer: flip between the two legal whole Configs as fast as possible.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		flip := false
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				if flip {
+					pl.SetConfig(defaults)
+				} else {
+					pl.SetConfig(calibrated)
+				}
+				flip = !flip
+			}
+		}
+	}()
+
+	// Readers: snapshot the Config and assert it is whole (one of the two).
+	const readers = 8
+	for i := 0; i < readers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					c := pl.Cfg()
+					okDefaults := c == defaults
+					okCalibrated := c == calibrated
+					if !okDefaults && !okCalibrated {
+						t.Errorf("torn Config observed: %+v", c)
+						return
+					}
+				}
+			}
+		}()
+	}
+
+	time.Sleep(100 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+}
+
+// TestSelfTuner_CleanShutdownCancelsInFlight: Stop must cancel the loop ctx and
+// the in-flight read's ctx, and join the goroutine (no leak — the package
+// goleak TestMain enforces this too).
+func TestSelfTuner_CleanShutdownCancelsInFlight(t *testing.T) {
+	defaults := calibDefaults()
+	pl := NewPlanner(defaults)
+
+	ctxObserved := make(chan context.Context, 1)
+	blocked := &blockingReader{ctxObserved: ctxObserved, release: make(chan struct{})}
+
+	st := StartSelfTuner(context.Background(), SelfTuneParams{
+		Planner: pl, Reader: blocked, Defaults: defaults, Interval: time.Hour,
+	})
+
+	// Wait until the immediate-pass read is in flight (ctx captured).
+	var readCtx context.Context
+	select {
+	case readCtx = <-ctxObserved:
+	case <-time.After(2 * time.Second):
+		st.Stop()
+		t.Fatal("reader never started")
+	}
+	if readCtx.Err() != nil {
+		t.Fatal("read ctx should be live before Stop")
+	}
+
+	// Stop in a goroutine: it must cancel the in-flight read's ctx, which
+	// unblocks the reader and lets the goroutine exit and Stop return.
+	done := make(chan struct{})
+	go func() { st.Stop(); close(done) }()
+
+	waitFor(t, func() bool { return readCtx.Err() != nil })
+	close(blocked.release) // belt-and-braces: let the reader return
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop did not return; goroutine not joined")
+	}
+
+	// Stop is idempotent.
+	st.Stop()
+}
+
+// blockingReader blocks inside ReadFrontier until its ctx is cancelled (or
+// release is closed), exposing the ctx so the shutdown test can assert
+// cancellation propagated.
+type blockingReader struct {
+	ctxObserved chan context.Context
+	release     chan struct{}
+	once        sync.Once
+}
+
+func (b *blockingReader) ReadFrontier(ctx context.Context) ([]CorpusSample, error) {
+	b.once.Do(func() { b.ctxObserved <- ctx })
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-b.release:
+		return nil, nil
+	}
+}
+
+// waitFor polls cond until true or a short deadline, failing the test on
+// timeout. Used instead of fixed sleeps so the loop tests stay fast and stable.
+func waitFor(t *testing.T, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("condition not met within deadline")
+}

--- a/internal/solver/selftune_test.go
+++ b/internal/solver/selftune_test.go
@@ -76,14 +76,14 @@ func TestSelfTuner_ImmediatePassSwapsCalibratedConfig(t *testing.T) {
 	}
 }
 
-// TestSelfTuner_NoOpReinstallsDefaultsVerbatim: a squid-shaped corpus must
-// leave the Planner on the defaults (the no-op-on-squid behavior, end to end
+// TestSelfTuner_NoOpReinstallsDefaultsVerbatim: a no-signal corpus must
+// leave the Planner on the defaults (the no-op-on-no-signal behavior, end to end
 // through the loop).
 func TestSelfTuner_NoOpReinstallsDefaultsVerbatim(t *testing.T) {
 	defaults := calibDefaults()
 	pl := NewPlanner(defaults)
 	reader := &fakeFrontierReader{}
-	reader.set(squidShapedCorpus(), nil)
+	reader.set(noSignalCorpus(), nil)
 
 	st := StartSelfTuner(context.Background(), SelfTuneParams{
 		Planner: pl, Reader: reader, Defaults: defaults, Interval: time.Hour,
@@ -94,7 +94,7 @@ func TestSelfTuner_NoOpReinstallsDefaultsVerbatim(t *testing.T) {
 	// Give the swap a moment; defaults must remain in force.
 	time.Sleep(20 * time.Millisecond)
 	if pl.Cfg() != defaults {
-		t.Fatalf("squid-shaped corpus must keep defaults, got %+v", pl.Cfg())
+		t.Fatalf("no-signal corpus must keep defaults, got %+v", pl.Cfg())
 	}
 }
 

--- a/internal/solver/slicer_bench_test.go
+++ b/internal/solver/slicer_bench_test.go
@@ -30,7 +30,7 @@ func BenchmarkSlice(b *testing.B) {
 	meta := RequestMeta{Lang: LangPromQL, Start: start, End: end, Step: step}
 
 	plan := benchSlicePlan(start, end, step, 5*time.Minute)
-	p := &Planner{Cfg: autoCfg()}
+	p := NewPlanner(autoCfg())
 
 	for _, k := range []int{2, 4, 8, 16} {
 		k := k

--- a/internal/solver/slicer_cow_guard_test.go
+++ b/internal/solver/slicer_cow_guard_test.go
@@ -59,7 +59,7 @@ func guardRoute(t *testing.T, plan chplan.Node) *solver.Decision {
 	if err := cfg.Validate(); err != nil {
 		t.Fatalf("sharded Config invalid: %v", err)
 	}
-	pl := &solver.Planner{Cfg: cfg}
+	pl := solver.NewPlanner(cfg)
 	gs, ge, gstep := solver.GridOf(plan)
 	dec, isRouted := pl.Plan(plan, solver.RequestMeta{
 		Lang:  solver.LangPromQL,

--- a/internal/solver/slicer_test.go
+++ b/internal/solver/slicer_test.go
@@ -66,7 +66,7 @@ func sliceAnchors(s Slice, step time.Duration) []time.Time {
 
 func TestSlice_AnchorUnionAndDisjoint(t *testing.T) {
 	t.Parallel()
-	p := &Planner{Cfg: autoCfg()}
+	p := NewPlanner(autoCfg())
 
 	rapid.Check(t, func(t *rapid.T) {
 		step := time.Duration(rapid.IntRange(1, 120).Draw(t, "stepSec")) * time.Second
@@ -135,7 +135,7 @@ func TestSlice_AnchorUnionAndDisjoint(t *testing.T) {
 
 func TestSlice_ScanFromSignAware(t *testing.T) {
 	t.Parallel()
-	p := &Planner{Cfg: autoCfg()}
+	p := NewPlanner(autoCfg())
 	start := time.Unix(1_700_000_000, 0).UTC()
 	step := 15 * time.Second
 	end := start.Add(time.Hour)
@@ -171,7 +171,7 @@ func TestSlice_ScanFromSignAware(t *testing.T) {
 
 func TestSlice_KClampHonored(t *testing.T) {
 	t.Parallel()
-	p := &Planner{Cfg: autoCfg()}
+	p := NewPlanner(autoCfg())
 	start := time.Unix(1_700_000_000, 0).UTC()
 	step := time.Minute
 	// N = 5 anchors; ask for K = 8 → clamped to <= N, with singleton-tail
@@ -206,7 +206,7 @@ func TestSlice_KClampHonored(t *testing.T) {
 // only the cloned spine fields, which the COW contract keeps isolated.
 func TestSlice_SpineImmutability(t *testing.T) {
 	t.Parallel()
-	p := &Planner{Cfg: autoCfg()}
+	p := NewPlanner(autoCfg())
 	start := time.Unix(1_700_000_000, 0).UTC()
 	step := 15 * time.Second
 	end := start.Add(time.Hour)
@@ -243,7 +243,7 @@ func TestSlice_SpineImmutability(t *testing.T) {
 // no-mutate-after-slice contract — see TestSlice_NoSharedMutation.
 func TestSlice_OffSpineIsShared(t *testing.T) {
 	t.Parallel()
-	p := &Planner{Cfg: autoCfg()}
+	p := NewPlanner(autoCfg())
 	start := time.Unix(1_700_000_000, 0).UTC()
 	step := 15 * time.Second
 	end := start.Add(time.Hour)
@@ -280,7 +280,7 @@ func TestSlice_OffSpineIsShared(t *testing.T) {
 // disjoint, and the slices are oldest-first.
 func TestSliceLWR_AnchorUnionAndDisjoint(t *testing.T) {
 	t.Parallel()
-	p := &Planner{Cfg: autoCfg()}
+	p := NewPlanner(autoCfg())
 
 	rapid.Check(t, func(t *rapid.T) {
 		step := time.Duration(rapid.IntRange(1, 120).Draw(t, "stepSec")) * time.Second
@@ -362,7 +362,7 @@ func TestSliceLWR_AnchorUnionAndDisjoint(t *testing.T) {
 // offset-sign-aware.
 func TestSliceLWR_ScanFromSignAware(t *testing.T) {
 	t.Parallel()
-	p := &Planner{Cfg: autoCfg()}
+	p := NewPlanner(autoCfg())
 	start := time.Unix(1_700_000_000, 0).UTC()
 	step := 15 * time.Second
 	end := start.Add(time.Hour)
@@ -401,7 +401,7 @@ func TestSliceLWR_ScanFromSignAware(t *testing.T) {
 // TestSliceLWR_OffSpineIsShared); this test mutates only the cloned spine.
 func TestSliceLWR_SpineImmutability(t *testing.T) {
 	t.Parallel()
-	p := &Planner{Cfg: autoCfg()}
+	p := NewPlanner(autoCfg())
 	start := time.Unix(1_700_000_000, 0).UTC()
 	step := 15 * time.Second
 	end := start.Add(time.Hour)
@@ -482,7 +482,7 @@ func nestedSubqueryWindowPlan(start, end time.Time, step, rang time.Duration) ch
 //  3. the spine is correctly re-gridded per shard.
 func TestSlice_NestedSubqueryDescendsAndClones(t *testing.T) {
 	t.Parallel()
-	p := &Planner{Cfg: autoCfg()}
+	p := NewPlanner(autoCfg())
 	start := time.Unix(1_700_000_000, 0).UTC()
 	step := 15 * time.Second
 	end := start.Add(time.Hour)
@@ -533,7 +533,7 @@ func TestSlice_NestedSubqueryDescendsAndClones(t *testing.T) {
 // the bare-selector family.
 func TestSliceLWR_OffSpineIsShared(t *testing.T) {
 	t.Parallel()
-	p := &Planner{Cfg: autoCfg()}
+	p := NewPlanner(autoCfg())
 	start := time.Unix(1_700_000_000, 0).UTC()
 	step := 15 * time.Second
 	end := start.Add(time.Hour)

--- a/internal/solver/solver.go
+++ b/internal/solver/solver.go
@@ -45,7 +45,7 @@ type Solver struct {
 // until cfg.Mode flips off "single".
 func New(cfg Config, emitter SQLEmitter, deps ExecDeps) *Solver {
 	return &Solver{
-		Planner: &Planner{Cfg: cfg},
+		Planner: NewPlanner(cfg),
 		Executor: &Executor{
 			Client:  deps.Client,
 			Emitter: emitter,

--- a/test/perf/slice_allocs_chdb_test.go
+++ b/test/perf/slice_allocs_chdb_test.go
@@ -158,7 +158,7 @@ func TestSliceAllocs_ChDB(t *testing.T) {
 		cfg := solver.DefaultConfig()
 		cfg.Mode = solver.ModeAuto
 		cfg.MaxK = tc.k
-		p := &solver.Planner{Cfg: cfg}
+		p := solver.NewPlanner(cfg)
 
 		// Sanity: the fixed plan/grid must actually route at the pinned K, or
 		// the arm would be measuring the cheap not-routed path and silently

--- a/test/perf/solver_decision_ratchet_test.go
+++ b/test/perf/solver_decision_ratchet_test.go
@@ -155,7 +155,7 @@ func classifyCorpus(t *testing.T) map[string]decisionEntry {
 	sm := schema.DefaultOTelMetrics()
 	cfg := solver.DefaultConfig()
 	cfg.Mode = solver.ModeAuto // the production routing mode the ratchet pins.
-	planner := &solver.Planner{Cfg: cfg}
+	planner := solver.NewPlanner(cfg)
 	// Mirror the production PromQL head, which builds its parser with
 	// EnableExperimentalFunctions=true (see internal/api/prom/lang.go) so
 	// the deliberately-supported experimental subset


### PR DESCRIPTION
## What

Per-deployment **self-tuning** of the route A/B (single vs time-slice-sharded) thresholds. The router's hand-tuned thresholds (`MinFanout`, `MinAnchorPairs`) are now calibrated **at runtime from each deployment's own** `cerberus_router_corpus` — the Stage-0 corpus (#1053) of observed cost.

## Architecture — generic ships, local is learned

- **GENERIC (shipped to every deployment):** the calibration logic (`internal/solver/calibrate.go`), the background loop (`internal/solver/selftune.go`), and the conservative `DefaultConfig`. Deployment-independent — **no** deployment's learned constants are baked into the shipped code. A grep of the diff confirms the only deployment-specific data path is the corpus reader; there are no hardcoded deployment-specific values.
- **LOCAL (never shipped):** the calibrated constants, derived in-memory from THIS deployment's corpus. this deployment's data tunes itself only; another install tunes itself. A single corpus deliberately never leaks into shipped defaults (avoids cross-deployment over-fit).

This is **optimizer self-tuning, not result caching** — it changes which plan shape the router picks, never memoizes results.

## Safety rails (each tested)

- **Conservative-floor / tighten-only:** calibrated thresholds may only move in the SAFER direction (lower → shard more readily near the OOM frontier; PARQO asymmetric penalty). Calibrate never *raises* a threshold and never lowers past the shipped floor.
- **Fail-open / no-op without signal:** thin corpus, no `below-threshold` decisions, or no OOM/cost-danger exemplars → `defaults` returned **verbatim**. a no-signal corpus (all route-A, below-threshold=0, no failures) is a true no-op — pinned by `TestCalibrate_NoOpOnNoSignalCorpus`.
- **Off by default:** gated behind `CERBERUS_ROUTE_SELFTUNE` (default off). Unset → static shipped Config, loop never starts, **zero behavior change** for existing deployments (`TestStartRouteSelfTune_OffByDefault`).

## Mechanics

- `Planner.cfg` is now an `atomic.Pointer[Config]`; the `Plan` path reads it lock-free. The loop atomically swaps a freshly calibrated Config in.
- Reader (`internal/optcorpus/frontier.go`) runs a few aggregate SELECTs per `(N,F[,D])` bucket — never all rows — under the same rate-limited / deprioritised / read-only / failure-open discipline as the query_log source.
- Loop derives its ctx from a cancelable parent and cancels in-flight reads on shutdown (mirrors + fixes the `breaker_recovery.go` ctx shape; goleak-clean).
- Every recalibration logs the active thresholds + a `CalibrationReport` (sample count, what moved vs default and why, detected frontier) so operators can SEE what their deployment self-tuned to.

## Tests (assert-based)

Calibrate purity + determinism (order/mutation-independent); no-op-without-signal; clear-frontier tightens but never past the floor; tighten-only invariant across a fuzz of corpora; atomic swap under `-race`; fail-open on reader error; clean shutdown (goleak, ctx cancels in-flight). `go build ./...`, scoped golangci-lint, go-arch-lint, gofumpt -extra all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

