### PR TITLE
chore(test): scrub customer name from schema test comment

### DIFF
--- a/internal/schema/ddl/idempotency_test.go
+++ b/internal/schema/ddl/idempotency_test.go
@@ -82,7 +82,7 @@ func TestRenderCreateDatabase(t *testing.T) {
 // engine path: the CREATE DATABASE statement carries
 // `ENGINE = Replicated(<path>, <shard>, <replica>)`, the shard/replica
 // default to the server macros when unset, and an explicit override is
-// honoured. This is the squid-style clustered shape where the Replicated
+// honoured. This is a replicated clustered shape where the Replicated
 // database auto-replicates DDL (the tables themselves get an explicit
 // ReplicatedMergeTree engine to replicate their DATA).
 func TestRenderCreateDatabase_ReplicatedEngine(t *testing.T) {


### PR DESCRIPTION
Scrubs a customer name that leaked into a test comment on main.

`internal/schema/ddl/idempotency_test.go` described the Replicated database
shape using a customer-specific name. Replaced with a generic description
("a replicated clustered shape ...") — no behavior change, comment only.

Verified `go test ./internal/schema/...` still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)