### PR TITLE
docs(coverage): reframe PromQL start()/end() rejection as permanent parity

### DIFF
--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -1755,6 +1755,15 @@ func lowerCall(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, err
 		// path, not here. Lowering bare `start()` / `end()` as scalar
 		// calls would accept a shape stock reference Prometheus rejects.
 		return lowerQueryContextFold(c, s, ctx)
+	case "start", "end":
+		// `start()` / `end()` are query-context time anchors, not
+		// standalone callable functions. Upstream's parser admits them
+		// only inside an `@` modifier (`up @ start()`, `up @ end()` —
+		// both supported, lowered via the at-modifier path); the bare
+		// top-level call is invalid PromQL that stock reference
+		// Prometheus rejects. Cerberus rejects it identically — a
+		// permanent parity decision, not a coverage gap.
+		return nil, fmt.Errorf("promql: function %s() is only valid inside an @ modifier (e.g. up @ %s()), not as a standalone call", c.Func.Name, c.Func.Name)
 	case "pi":
 		// Bare top-level `pi()` (or any scalar-foldable call the parser
 		// admits as a top-level expression). The /api/v1/query handler
@@ -1769,7 +1778,7 @@ func lowerCall(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, err
 	if chFn, ok := instantFnCH[c.Func.Name]; ok {
 		return lowerInstantFn(c, s, chFn, ctx)
 	}
-	return nil, fmt.Errorf("promql: function %s is not yet supported", c.Func.Name)
+	return nil, fmt.Errorf("promql: function %s is not a recognized lowering target", c.Func.Name)
 }
 
 // lowerRangeVectorCall handles range-vector functions: rate, increase,

--- a/test/rejection-parity/catalogue.json
+++ b/test/rejection-parity/catalogue.json
@@ -556,8 +556,15 @@
     },
     {
       "head": "promql",
-      "site": "internal/promql/lower.go:lowerCall#ab321c46",
-      "message": "promql: function %s is not yet supported",
+      "site": "internal/promql/lower.go:lowerCall#682975f8",
+      "message": "promql: function %s is not a recognized lowering target",
+      "class": "internal",
+      "rationale": "Every PromQL function the reference parser produces is dispatched by an explicit case in lowerCall or by the instantFnCH table; start()/end() have their own dedicated parity-reject case. This generic fall-through guards against a parser-accepted function with no lowering, of which there are currently none, so no wire query reaches it."
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/lower.go:lowerCall#87f33f63",
+      "message": "promql: function %s() is only valid inside an @ modifier (e.g. up @ %s()), not as a standalone call",
       "class": "rejection",
       "trigger_query": "start()"
     },

--- a/test/surface-parity/inventory.json
+++ b/test/surface-parity/inventory.json
@@ -369,7 +369,7 @@
       "cerberus": "reject",
       "reference": "reject",
       "class": "parity-reject",
-      "cerberus_error": "promql: function end is not yet supported"
+      "cerberus_error": "promql: function end() is only valid inside an @ modifier (e.g. up @ end()), not as a standalone call"
     },
     {
       "head": "promql",
@@ -784,7 +784,7 @@
       "cerberus": "reject",
       "reference": "reject",
       "class": "parity-reject",
-      "cerberus_error": "promql: function start is not yet supported"
+      "cerberus_error": "promql: function start() is only valid inside an @ modifier (e.g. up @ start()), not as a standalone call"
     },
     {
       "head": "promql",


### PR DESCRIPTION
## What

The bare top-level PromQL grammar functions `start()` / `end()` are a **permanent parity rejection**, not a temporary gap. Upstream Prometheus's parser only admits them inside an `@` modifier (`up @ start()`, `up @ end()` — both Supported); the standalone top-level call is invalid PromQL that the reference parser itself rejects, and cerberus rejects it identically.

The rejection error string mislabelled this permanent decision as temporary (`is not yet supported`), which (a) is inaccurate, (b) brushes the project's no-"not yet"/deferred/not-implemented tone rule, and (c) was generic enough to be misread as the HTTP `start`/`end` query params rather than the grammar functions.

**No behaviour change** — start()/end() are still rejected, with parity to the reference. Only the error wording and its pinned ledger records change.

## Changes

- `internal/promql/lower.go:1758` — add a dedicated `case "start", "end":` in `lowerCall` returning an accurate, permanent-framed, self-disambiguating message: `promql: function %s() is only valid inside an @ modifier (e.g. up @ %s()), not as a standalone call`. Previously these fell through to the generic catch-all; they now have their own parity-reject site.
- `internal/promql/lower.go:1781` (generic fall-through) — reworded from `promql: function %s is not yet supported` → `promql: function %s is not a recognized lowering target`. Every parser-accepted PromQL function is dispatched by an explicit case or the `instantFnCH` table, so this site is unreachable by any wire query; the change drops the temporary "not yet" framing for neutral, honest phrasing.
- `test/surface-parity/inventory.json` — regenerated `cerberus_error` for `fn:start` / `fn:end` to the new message (`CERBERUS_UPDATE_INVENTORY=1`). `cerberus`/`reference`/`class` (parity-reject) unchanged — behaviour identical, so the doc's "Rejected (parity with reference)" status and the 121/119/2/0 counts still hold.
- `test/rejection-parity/catalogue.json` — regenerated. The start/end site is now `class: rejection` with `trigger_query: "start()"`; the orphaned generic fall-through site is `class: internal` with a rationale documenting why no wire query reaches it (site key hash = sha256(message)[:8], so both changed).

## docs/coverage.md audit (PART 2)

Read the full doc and audited for the three issue classes (mislabeled-permanence wording, scoping ambiguities, stale claims-vs-code). **No edits needed:**

- The `start()`/`end()` prose (lines 58-63) is already correctly scoped to "the bare `start()` / `end()` query-context calls" / "standalone expressions" and frames the rejection as permanent parity vs the Supported `@ start()`/`@ end()` modifiers — no ambiguity, no mislabel.
- At-a-glance counts (PromQL 121 probed / 119 supported / 2 parity-reject / 0 not-yet) verified against the regenerated `inventory.json` — exact match.
- The `--enable-feature=promql-experimental-functions` claim (line 22) verified against the production parser (`internal/api/prom/handler.go:140` sets `EnableExperimentalFunctions: true`).
- The doc tables embed only the Status, never the error string, so they need no regen for this change.

### Judgment call left for the maintainer

The **"Not yet supported"** status *category* (coverage.md lines 25 / 43) still uses future-framed wording. I left it deliberately: it honestly describes a genuine-future category (a real wrong-rejection that the reference accepts but cerberus doesn't), which the doc says is currently empty (zero). Per the tone rule, honest descriptions of genuinely-future work are fine; this isn't a mislabel of a permanent decision. Flagging in case you'd prefer a permanent-neutral label (e.g. "Unsupported gap") regardless.

## Verification

- `go build ./...` clean
- `go test ./internal/promql/ ./internal/api/prom/ ./test/surface-parity/ ./test/rejection-parity/` — 1222 passed
- rejection-parity catalogue regen is byte-stable (curation survives re-regen unchanged)
- `gofumpt -extra` no churn; scoped `golangci-lint run ./internal/promql/` clean; `markdownlint-cli2 docs/coverage.md` 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)