### PR TITLE
feat(routerrules): detection-fidelity benchmark (precision/recall/F1 + degradation sweep)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ go.work.sum
 # Local build outputs
 bin/
 dist/
+# route-rules CLI build output (never commit the compiled binary)
+/route-rules
+/cmd/route-rules/route-rules
 
 # direnv local override
 .direnv/

--- a/cmd/route-rules/main.go
+++ b/cmd/route-rules/main.go
@@ -34,6 +34,15 @@ func main() {
 	}
 }
 
+// benchmarkSubcommand is the offline detection-fidelity benchmark: it scores the
+// catalog against a fabricated, seed-deterministic labeled corpus and prints the
+// per-rule precision/recall/F1 table. It takes no corpus path — the corpus is
+// generated — so an operator (or CI) can quantify how consistently the rules
+// detect their planted pathologies (and guard against regressions) with nothing
+// to set up. The labels share provenance with the rules' thresholds, so this
+// measures detection consistency, not real-world rule effectiveness.
+const benchmarkSubcommand = "benchmark"
+
 type options struct {
 	catalogPath  string
 	source       string
@@ -59,6 +68,10 @@ func (p paramFlags) Set(v string) error {
 }
 
 func run(args []string, stdout, stderr *os.File) error {
+	if len(args) > 0 && args[0] == benchmarkSubcommand {
+		return runBenchmark(args[1:], stdout, stderr)
+	}
+
 	opts := options{params: paramFlags{}}
 	fs := flag.NewFlagSet("route-rules", flag.ContinueOnError)
 	fs.SetOutput(stderr)
@@ -105,6 +118,56 @@ func run(args []string, stdout, stderr *os.File) error {
 	default:
 		return fmt.Errorf("unknown --format %q (want table|json)", opts.format)
 	}
+}
+
+// benchDefaultConfig is the nominal operating point the benchmark scores at: a
+// p95 watermark on both percentile knobs and a min_rows_per_class of 5. These
+// are benchmark settings, not catalog thresholds (the shipped catalog stays
+// number-free); an operator can override any of them with --param.
+var benchDefaultConfig = map[string]string{
+	"router_rules.watermark_percentile":    "0.95",
+	"router_rules.cumulative_d_percentile": "0.95",
+	"router_rules.min_rows_per_class":      "5",
+	"query.max_memory_bytes":               "1073741824",
+	"query.max_samples":                    "50000000",
+}
+
+func runBenchmark(args []string, stdout, stderr *os.File) error {
+	params := paramFlags{}
+	fs := flag.NewFlagSet("route-rules benchmark", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	catalogPath := fs.String("catalog", "", "path to a router-rules catalog YAML (default: embedded)")
+	seed := fs.Int64("seed", 1, "PRNG seed for the fabricated labeled corpus (deterministic)")
+	minSupport := fs.Int("min-support", 5, "min_rows_per_class the corpus is sized and scored at")
+	fs.Var(params, "param", "config-kind param override KEY=VALUE (repeatable)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	cat, err := loadCatalog(*catalogPath)
+	if err != nil {
+		return err
+	}
+
+	cfg := routerrules.BenchConfig{}
+	for k, v := range benchDefaultConfig {
+		cfg[k] = v
+	}
+	cfg["router_rules.min_rows_per_class"] = strconv.Itoa(*minSupport)
+	for k, v := range params {
+		cfg[k] = v
+	}
+
+	corpus := routerrules.GenerateBenchCorpus(routerrules.BenchParams{Seed: *seed, MinSupport: *minSupport})
+	metrics, err := routerrules.ScoreCatalog(context.Background(), cat, cfg, corpus)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(stdout, "router-rules detection-fidelity benchmark (seed=%d, rows=%d, labeled classes=%d):\n\n",
+		*seed, len(corpus.Rows), len(corpus.Classes))
+	fmt.Fprint(stdout, routerrules.FormatMetricsTable(metrics))
+	return nil
 }
 
 func loadCatalog(path string) (*routerrules.Catalog, error) {

--- a/cmd/route-rules/main_test.go
+++ b/cmd/route-rules/main_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// runCapture invokes run with temp files for stdout/stderr and returns their
+// contents plus the error, so a test can assert on the CLI's real output the way
+// an operator would see it.
+func runCapture(t *testing.T, args ...string) (stdout, stderr string, err error) {
+	t.Helper()
+	outF, e := os.CreateTemp(t.TempDir(), "out")
+	if e != nil {
+		t.Fatalf("temp out: %v", e)
+	}
+	errF, e := os.CreateTemp(t.TempDir(), "err")
+	if e != nil {
+		t.Fatalf("temp err: %v", e)
+	}
+	err = run(args, outF, errF)
+	_ = outF.Close()
+	_ = errF.Close()
+	ob, _ := os.ReadFile(outF.Name())
+	eb, _ := os.ReadFile(errF.Name())
+	return string(ob), string(eb), err
+}
+
+// TestBenchmarkSubcommandE2E is the CLI end-to-end proof: `route-rules benchmark`
+// runs the embedded catalog over the generated labeled corpus and prints the
+// per-rule precision/recall/F1 table with an OVERALL row. It exercises the same
+// path an operator or CI invokes, no corpus file required.
+func TestBenchmarkSubcommandE2E(t *testing.T) {
+	stdout, stderr, err := runCapture(t, "benchmark", "--seed", "1")
+	if err != nil {
+		t.Fatalf("benchmark subcommand failed: %v (stderr=%s)", err, stderr)
+	}
+	for _, want := range []string{
+		"detection-fidelity benchmark",
+		"RULE", "PRECISION", "RECALL", "F1",
+		"oom_on_route_a",
+		"cerberus_side_rejection_pressure",
+		"OVERALL (micro)",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("benchmark output missing %q:\n%s", want, stdout)
+		}
+	}
+}
+
+// TestBenchmarkSubcommandDeterministic confirms the benchmark is reproducible:
+// the same seed yields byte-identical output across runs.
+func TestBenchmarkSubcommandDeterministic(t *testing.T) {
+	a, _, err := runCapture(t, "benchmark", "--seed", "5")
+	if err != nil {
+		t.Fatalf("run a: %v", err)
+	}
+	b, _, err := runCapture(t, "benchmark", "--seed", "5")
+	if err != nil {
+		t.Fatalf("run b: %v", err)
+	}
+	if a != b {
+		t.Errorf("benchmark output is not deterministic for a fixed seed:\n--- a ---\n%s\n--- b ---\n%s", a, b)
+	}
+}
+
+// TestBenchmarkSubcommandParamOverride confirms --min-support flows into the
+// scored config: a tiny floor admits thin classes (more findings counted), a
+// realistic floor does not, so the two runs differ.
+func TestBenchmarkSubcommandParamOverride(t *testing.T) {
+	tiny, _, err := runCapture(t, "benchmark", "--seed", "1", "--min-support", "1")
+	if err != nil {
+		t.Fatalf("tiny floor: %v", err)
+	}
+	nominal, _, err := runCapture(t, "benchmark", "--seed", "1", "--min-support", "5")
+	if err != nil {
+		t.Fatalf("nominal floor: %v", err)
+	}
+	if tiny == nominal {
+		t.Error("min-support override had no effect on the benchmark output")
+	}
+}

--- a/docs/router-rules.md
+++ b/docs/router-rules.md
@@ -310,6 +310,62 @@ action; the `effectiveness_no_route_b.jsonl` variant exercises the
 empty-population no-signal skip. Both backends run the fixture under the parity
 test, so the JSONL and CH paths must agree finding-for-finding.
 
+### The detection-fidelity benchmark
+
+The effectiveness fixture answers "does every rule fire on its planted
+pathology?" as a binary. The benchmark answers a graded version of the same
+question — **how consistently does each rule detect its planted pathologies,
+measured as precision / recall / F1 against a synthetic labeled corpus, and how
+does that detection degrade as the deployment is tuned off-nominal?**
+
+This is a *detection-fidelity / regression* gate, not a real-world
+effectiveness measurement. The corpus labels share provenance with the rules'
+p95-watermark thresholds — the same model decides both what counts as a planted
+pathology and what each rule fires on — so a perfect score proves the rules
+detect what the model says they should and pins that against regressions. It
+does **not** prove the rules catch real production incidents; that would require
+labels grounded in real incident outcomes, which this corpus does not have.
+
+- `benchmark.go` generates a fabricated, seed-deterministic corpus (no
+  production-identifying values) shaped like a real deployment — a healthy,
+  PromQL-dominant, range-heavy majority on route A plus a planted failure
+  surface — where every class carries a ground-truth label: the rule ids that
+  *should* fire on it, and a pathology severity (`severe` far past the watermark,
+  `marginal` just past it). The in-memory source folds these rows through the
+  same matcher + `quantileExact` path the JSONL/CH backends use.
+- `metrics.go` scores the catalog against the labels at the CLASS granularity
+  (TP = labeled class the rule fired on; FP = unlabeled class it fired on; FN =
+  labeled class it stayed silent on) and reports per-rule precision / recall / F1
+  plus a micro-averaged overall. At the nominal p95 / min-support-5 operating
+  point the catalog scores **precision 1.000 / recall 1.000 / F1 1.000** over the
+  12 rules — every planted pathology detected, zero false positives on the healthy
+  majority. (A perfect score here is a self-consistency result, by construction —
+  see the provenance caveat above.)
+- `sweep.go` turns that single point into a sensitivity surface: it sweeps
+  `watermark_percentile`, `min_rows_per_class`, and pathology prevalence around
+  the nominal and reports how recall/precision (and severe-vs-marginal recall)
+  hold up. The shape is the design's stated tradeoff made measurable: loosening
+  the watermark or the support floor floods false positives (precision falls
+  toward ~0.33 at p50); over-tightening sheds marginal recall first; a rare
+  deployment (low prevalence) starves its *marginal* pathologies below the support
+  floor and loses their detection, while *severe* pathologies are detected at
+  every operating point. A guard test fails if any swept axis is inert (its whole
+  grid collapses to one identical score), so the sweep can't silently grow a dead
+  knob.
+- The regression-floor tests pin numeric recall/precision/F1 minimums at the
+  nominal point and across the operationally sane tuning range (the only place
+  numbers belong — the shipped catalog stays number-free; the floors live in
+  test code). The overall recall/precision floors hold at nominal prevalence;
+  severe-recall is floored at 1.0 across the whole grid including off-nominal
+  prevalence. Adversarial corpora (monochrome-healthy, distribution-shifted
+  across seeds) and a multi-rule-interaction test guard the edges.
+- `route-rules benchmark` runs the whole thing from the CLI: it scores the
+  embedded catalog over the generated corpus and prints the metric table, no
+  corpus file required (`--seed`, `--min-support`, and `--param` tune it). The
+  `chdb`-tagged parity test re-runs the benchmark through the CH SQL backend and
+  asserts identical findings and identical metrics, so the numbers are not an
+  artefact of the in-memory source.
+
 All ClickHouse SQL is composed via the typed `internal/chsql` Frag API
 (`Call` / `Parametric` / `Eq` / `Gt` / `And` / `In` / `BareIdent` / …) — no raw
 SQL strings.

--- a/internal/routerrules/benchmark.go
+++ b/internal/routerrules/benchmark.go
@@ -1,0 +1,687 @@
+package routerrules
+
+import (
+	"math"
+	"math/rand"
+	"sort"
+)
+
+// This file builds a SYNTHETIC, LABELED ground-truth benchmark corpus for
+// measuring the router-rules catalog's DETECTION FIDELITY — quantitatively, with
+// precision / recall / F1 per rule, rather than the binary fire/no-fire
+// assertions of the effectiveness fixture. The corpus labels are derived from the
+// same p95-watermark model the rules' thresholds resolve against, so the score
+// measures how consistently the rules detect what the model says they should (and
+// pins that against regressions); it is NOT a measurement of real-world rule
+// effectiveness against production incidents.
+//
+// Every value here is FABRICATED. No production-identifying number, shape id,
+// or deployment name appears: the corpus is synthesised from a seeded PRNG over
+// a deliberately shaped distribution (a healthy, PromQL-dominant, range-heavy
+// majority on route A plus a planted failure surface), so the benchmark is
+// fully reproducible and carries zero prod grounding.
+//
+// The catalog ships number-free; this generator and the metrics harness are
+// (test-adjacent) tooling, where concrete numbers are not only allowed but
+// necessary — you cannot measure detection on a corpus that has no numbers.
+//
+// Ground truth is expressed at the CLASS level, because the rules fire per
+// group_by class after the min_support floor. Each generated class is either a
+// planted pathology (it is the textbook positive for one or more rules) or a
+// healthy class (negative for every rule). benchClass.expect names the rule ids
+// that SHOULD fire on the class under the benchmark's nominal config; the
+// metrics harness compares that ground truth against the rules that actually
+// fired.
+
+// PathologySeverity grades how far a planted pathology sits past the detection
+// boundary, so the degradation sweep can ask "do we still catch the marginal
+// cases as the watermark tightens, or only the egregious ones?".
+type PathologySeverity uint8
+
+const (
+	// SevHealthy is a negative class: no rule should fire on it.
+	SevHealthy PathologySeverity = iota
+	// SevMarginal sits just past the firing boundary — the hardest true
+	// positive to keep catching as thresholds tighten.
+	SevMarginal
+	// SevSevere sits far past the boundary — the easy, unambiguous positive.
+	SevSevere
+)
+
+func (s PathologySeverity) String() string {
+	switch s {
+	case SevSevere:
+		return "severe"
+	case SevMarginal:
+		return "marginal"
+	default:
+		return "healthy"
+	}
+}
+
+// BenchRow is one synthetic corpus row. It mirrors jsonlRow's columns exactly so
+// it folds through the same corpusRow path both backends consume, with no new
+// decode surface.
+type BenchRow struct {
+	ShapeID             string
+	Language            string
+	NormalizedQueryHash uint64
+	NAnchors            float64
+	Fanout              float64
+	CumulativeD         float64
+	OuterRange          float64
+	Step                float64
+	Route               string
+	KShards             float64
+	DecisionReason      string
+	ReadRows            float64
+	ReadBytes           float64
+	QueryDurationMS     float64
+	MemoryUsage         float64
+	ExitStatus          string
+}
+
+func (r BenchRow) toCorpusRow() corpusRow {
+	return corpusRow{
+		numeric: map[string]float64{
+			"n_anchors":             r.NAnchors,
+			"fanout":                r.Fanout,
+			"cumulative_d":          r.CumulativeD,
+			"outer_range":           r.OuterRange,
+			"step":                  r.Step,
+			"k_shards":              r.KShards,
+			"read_rows":             r.ReadRows,
+			"read_bytes":            r.ReadBytes,
+			"query_duration_ms":     r.QueryDurationMS,
+			"memory_usage":          r.MemoryUsage,
+			"normalized_query_hash": float64(r.NormalizedQueryHash),
+		},
+		str: map[string]string{
+			"shape_id":              r.ShapeID,
+			"language":              r.Language,
+			"route":                 r.Route,
+			"decision_reason":       r.DecisionReason,
+			"exit_status":           r.ExitStatus,
+			"normalized_query_hash": formatNumeric(float64(r.NormalizedQueryHash)),
+		},
+	}
+}
+
+// LabeledClass is one ground-truth class: its identifying group-key dimensions,
+// the rule ids that SHOULD fire on it, and its planted severity.
+type LabeledClass struct {
+	ShapeID        string
+	Language       string
+	DecisionReason string
+	// QueryHash distinguishes the slow-shape classes, which group_by
+	// normalized_query_hash rather than shape_id.
+	QueryHash uint64
+	Expect    []string
+	Severity  PathologySeverity
+}
+
+// BenchCorpus is a generated corpus plus its class-level ground truth.
+type BenchCorpus struct {
+	Rows    []BenchRow
+	Classes []LabeledClass
+}
+
+// AsCorpusSource exposes the in-memory rows through the CorpusSource seam the
+// evaluator consumes, with no JSONL round-trip.
+func (c *BenchCorpus) AsCorpusSource() CorpusSource {
+	return &memCorpusSource{rows: c.Rows}
+}
+
+// BenchParams tunes the generated distribution. Zero values fall back to the
+// nominal benchmark shape via withDefaults.
+type BenchParams struct {
+	Seed int64
+	// HealthyClassesPerLang is how many healthy (negative) classes to plant per
+	// language, sized so the healthy bulk dominates a realistic deployment.
+	HealthyClassesPerLang int
+	// HealthyClassSize is the row count per healthy class.
+	HealthyClassSize int
+	// PathologyPrevalence scales the row count of every planted pathology class
+	// (1.0 = nominal). Below 1.0 starves marginal classes toward the
+	// min_support floor, modelling a rare-pathology deployment.
+	PathologyPrevalence float64
+	// MinSupport is the min_rows_per_class the benchmark resolves the catalog
+	// at; it must match the harness config so the ground-truth row counts are
+	// sized correctly relative to the floor.
+	MinSupport int
+}
+
+const (
+	// benchNominalHealthyPerLang / benchNominalHealthyClassSize shape a healthy
+	// majority broad enough that a per-language watermark is learned from a real
+	// distribution rather than a handful of rows.
+	benchNominalHealthyPerLang   = 6
+	benchNominalHealthyClassSize = 30
+	// benchNominalMinSupport is the firing floor the nominal benchmark uses; it
+	// matches benchConfig in the harness.
+	benchNominalMinSupport = 5
+	// benchSeverePathologySize / benchMarginalPathologySize size planted
+	// pathology classes comfortably and barely above the min-support floor.
+	benchSeverePathologySize   = 10
+	benchMarginalPathologySize = benchNominalMinSupport + 1
+	// minPathologyClassRows is the existence floor for a marginal class. At low
+	// prevalence a marginal pathology is deliberately starved below the support
+	// floor (so it stops firing and the prevalence axis can move marginal recall),
+	// but it must keep at least one row so the class is still present in the corpus
+	// to be scored as a false negative rather than vanishing entirely.
+	minPathologyClassRows = 1
+)
+
+func (p BenchParams) withDefaults() BenchParams {
+	if p.HealthyClassesPerLang == 0 {
+		p.HealthyClassesPerLang = benchNominalHealthyPerLang
+	}
+	if p.HealthyClassSize == 0 {
+		p.HealthyClassSize = benchNominalHealthyClassSize
+	}
+	if p.PathologyPrevalence == 0 {
+		p.PathologyPrevalence = 1
+	}
+	if p.MinSupport == 0 {
+		p.MinSupport = benchNominalMinSupport
+	}
+	return p
+}
+
+// Healthy-distribution magnitude anchors. These set the BODY of each healthy
+// per-language distribution; planted pathologies are placed deliberately above
+// (or, for the overshard/regret cases, below) the watermark these bodies imply.
+// They are ordinary corpus data values, not catalog thresholds.
+const (
+	healthyMemBase    = 20_000_000.0 // ~20 MB healthy peak memory
+	healthyMemSpread  = 60_000_000.0
+	healthyDurBase    = 40.0 // ms
+	healthyDurSpread  = 200.0
+	healthyReadBase   = 50_000.0 // rows scanned
+	healthyReadSpread = 400_000.0
+	healthyDBase      = 30.0 // cumulative_d spine lookback
+	healthyDSpread    = 90.0
+	healthyFanBase    = 4.0
+	healthyFanSpread  = 8.0
+
+	// Pathology magnitudes, placed past the p95 tail the healthy body implies.
+	// Severe sits far past; marginal sits just past.
+	sevMemSevere  = 950_000_000.0
+	sevMemMarg    = 130_000_000.0
+	sevDurSevere  = 9_000.0
+	sevDurMarg    = 280.0
+	sevReadSevere = 8_000_000.0
+	sevReadMarg   = 520_000.0
+	sevDSevere    = 400.0
+	sevDMarg      = 130.0
+	// Fan-out positives must clear the route-B fanout floor (= routeBFloorFanout,
+	// the p95 of the constant-fan-out route-B seed). Severe is far past; marginal
+	// is just past, to probe retention as the floor moves.
+	sevFanSevere = 120.0
+	sevFanMarg   = 72.0
+
+	// Route-B regret class: finishes fast and low-fanout on route B, so it sits
+	// BELOW both the slow watermark and the route-B fanout floor.
+	regretFanout = 2.0
+	regretDur    = 30.0
+	regretShards = 6.0
+
+	// Route-B floor seed: route-B healthy rows establish the fan-out floor the
+	// shard rules gate on. Their fan-out is a single high constant (route B is
+	// where big, properly-sharded fan-outs land), so it defines the p95 floor AND
+	// every seed row sits AT it — and the overshard rule's strict `fanout < floor`
+	// is false for them, so a well-sharded route-B class is not mistaken for
+	// regret. The genuine overshard class plants its own far-lower fan-out.
+	routeBFloorFanout    = 70.0
+	routeBFloorDurBase   = 600.0
+	routeBFloorDurSpread = 400.0
+)
+
+// languages are the three heads, weighted PromQL-dominant to match a realistic
+// query mix (the healthy generator plants more promql classes).
+var benchLanguages = []string{"promql", "logql", "traceql"}
+
+// GenerateBenchCorpus builds a deterministic labeled corpus from p. The same
+// seed yields byte-identical rows, so the metrics are reproducible.
+func GenerateBenchCorpus(p BenchParams) *BenchCorpus {
+	p = p.withDefaults()
+	rng := rand.New(rand.NewSource(p.Seed)) //nolint:gosec // deterministic fixture PRNG, not security.
+	bc := &BenchCorpus{}
+
+	plantHealthy(bc, rng, p)
+	plantRouteBFloor(bc, rng, p)
+	plantPathologies(bc, rng, p)
+
+	// Deterministic ordering so a chdb re-insert and the in-Go scan see the same
+	// row sequence (quantileExact is order-independent, but stability avoids
+	// surprises in any order-sensitive downstream).
+	sortBenchRows(bc.Rows)
+	sort.Slice(bc.Classes, func(i, j int) bool {
+		return classID(bc.Classes[i]) < classID(bc.Classes[j])
+	})
+	return bc
+}
+
+// plantHealthy fills the negative majority: route-A, exit ok, every numeric
+// feature drawn from the body of its per-language distribution (strictly below
+// the p95 tail). No rule should fire on any of these.
+func plantHealthy(bc *BenchCorpus, rng *rand.Rand, p BenchParams) {
+	for _, lang := range benchLanguages {
+		n := p.HealthyClassesPerLang
+		if lang != "promql" {
+			n = max(1, n/2) // promql-dominant mix
+		}
+		for c := 0; c < n; c++ {
+			shape := lang + ":healthy_" + itoaLocal(c)
+			hash := uint64(1000 + len(bc.Classes))
+			for i := 0; i < p.HealthyClassSize; i++ {
+				bc.Rows = append(bc.Rows, BenchRow{
+					ShapeID:             shape,
+					Language:            lang,
+					NormalizedQueryHash: hash,
+					NAnchors:            jitter(rng, 1, 5),
+					Fanout:              jitter(rng, healthyFanBase, healthyFanSpread),
+					CumulativeD:         jitter(rng, healthyDBase, healthyDSpread),
+					OuterRange:          jitter(rng, 300, 3600),
+					Step:                jitter(rng, 15, 60),
+					Route:               "A",
+					KShards:             0,
+					DecisionReason:      "below-threshold",
+					ReadRows:            jitter(rng, healthyReadBase, healthyReadSpread),
+					ReadBytes:           jitter(rng, 1_000_000, 40_000_000),
+					QueryDurationMS:     jitter(rng, healthyDurBase, healthyDurSpread),
+					MemoryUsage:         jitter(rng, healthyMemBase, healthyMemSpread),
+					ExitStatus:          "ok",
+				})
+			}
+			bc.Classes = append(bc.Classes, LabeledClass{
+				ShapeID: shape, Language: lang, DecisionReason: "below-threshold",
+				QueryHash: hash, Expect: nil, Severity: SevHealthy,
+			})
+		}
+	}
+}
+
+// plantRouteBFloor seeds healthy route-B classes whose high fan-out establishes
+// the route-B fanout floor the shard rules learn. These are negative classes
+// (exit ok, finishing reasonably), but with fan-out characteristic of route B.
+func plantRouteBFloor(bc *BenchCorpus, rng *rand.Rand, p BenchParams) {
+	for _, lang := range []string{"promql", "logql"} {
+		shape := lang + ":routeb_healthy"
+		hash := uint64(2000 + len(bc.Classes))
+		for i := 0; i < p.HealthyClassSize; i++ {
+			bc.Rows = append(bc.Rows, BenchRow{
+				ShapeID:             shape,
+				Language:            lang,
+				NormalizedQueryHash: hash,
+				Fanout:              routeBFloorFanout,
+				CumulativeD:         jitter(rng, healthyDBase, healthyDSpread),
+				Route:               "B",
+				KShards:             jitter(rng, 4, 8),
+				DecisionReason:      "sliceable",
+				ReadRows:            jitter(rng, healthyReadBase, healthyReadSpread),
+				ReadBytes:           jitter(rng, 1_000_000, 40_000_000),
+				QueryDurationMS:     jitter(rng, routeBFloorDurBase, routeBFloorDurSpread),
+				MemoryUsage:         jitter(rng, healthyMemBase, healthyMemSpread),
+				ExitStatus:          "ok",
+			})
+		}
+		bc.Classes = append(bc.Classes, LabeledClass{
+			ShapeID: shape, Language: lang, DecisionReason: "sliceable",
+			QueryHash: hash, Expect: nil, Severity: SevHealthy,
+		})
+	}
+}
+
+// pathologySpec declares one planted-pathology class: how to fill a row, and
+// which rules should fire on it. Each spec is emitted at both severe and
+// marginal magnitudes (where a magnitude axis exists) so the sweep can measure
+// marginal-case retention separately.
+func plantPathologies(bc *BenchCorpus, rng *rand.Rand, p BenchParams) {
+	specs := pathologySpecs()
+	for _, sp := range specs {
+		for _, sev := range sp.severities {
+			size := pathologySize(sev, p)
+			if size <= 0 {
+				continue
+			}
+			shape := sp.shape
+			if len(sp.severities) > 1 {
+				shape = sp.shape + "_" + sev.String()
+			}
+			hash := sp.hashBase + uint64(sev)
+			for i := 0; i < size; i++ {
+				row := sp.fill(rng, sev)
+				row.ShapeID = shape
+				row.Language = sp.lang
+				row.NormalizedQueryHash = hash
+				bc.Rows = append(bc.Rows, row)
+			}
+			bc.Classes = append(bc.Classes, LabeledClass{
+				ShapeID:        shape,
+				Language:       sp.lang,
+				DecisionReason: sp.fill(rng, sev).DecisionReason,
+				QueryHash:      hash,
+				Expect:         sp.expect(sev),
+				Severity:       sev,
+			})
+		}
+	}
+}
+
+// pathologySize scales a planted class by prevalence and severity. The two
+// severities are clamped differently ON PURPOSE so the prevalence axis can
+// actually move a metric:
+//
+//   - SEVERE classes keep a floor of min_support+1, so a severe pathology always
+//     clears the firing floor at every prevalence. That is what makes the
+//     SevereRecall=1.0 contract hold across the whole sweep grid (a severe class
+//     is, by construction, never lost merely because the deployment is rare).
+//   - MARGINAL classes get only a one-row existence floor, so prevalence < 1
+//     genuinely starves them below the support floor and they stop firing. That
+//     is the modelled behaviour — a rare marginal pathology has too few rows to
+//     learn from — and it is what gives the prevalence curve a metric to degrade
+//     (marginal recall), instead of the old clamp that pinned every prevalence
+//     to an identical, inert corpus.
+func pathologySize(sev PathologySeverity, p BenchParams) int {
+	base := benchSeverePathologySize
+	floor := p.MinSupport + 1
+	if sev == SevMarginal {
+		base = p.MinSupport + 1
+		floor = minPathologyClassRows
+	}
+	scaled := int(math.Round(float64(base) * p.PathologyPrevalence))
+	if scaled < floor {
+		scaled = floor
+	}
+	return scaled
+}
+
+// pathologySpec is the declarative shape of one planted pathology family. The
+// expected-rule set is a function of severity, because a self-relative tail
+// detector (geometry, fan-out) fires on a class only when THAT class crosses
+// its own watermark: a marginal-on-memory OOM is not necessarily in the
+// geometry tail, so its label must not claim the geometry rule.
+type pathologySpec struct {
+	shape      string
+	lang       string
+	hashBase   uint64
+	expect     func(sev PathologySeverity) []string
+	severities []PathologySeverity
+	fill       func(rng *rand.Rand, sev PathologySeverity) BenchRow
+}
+
+// always returns an expect-func that yields the same rule set at every severity.
+func always(rules ...string) func(PathologySeverity) []string {
+	return func(PathologySeverity) []string { return rules }
+}
+
+// pathologySpecs enumerates one planted family per detectable signal, each
+// labeled with exactly the rules that should fire on it. The expected rule sets
+// encode the catalog's intended semantics (e.g. an OOM on route A fires the
+// route-A OOM rule AND the route-agnostic failure-cluster + heavy-geometry
+// generalizers when its geometry is in the tail). It is split into the
+// hard-failure / rejection families and the self-relative tail detectors so each
+// half stays readable.
+func pathologySpecs() []pathologySpec {
+	return append(pathologyFailureSpecs(), pathologyTailSpecs()...)
+}
+
+// pathologyFailureSpecs are the families driven by a non-ok exit_status (OOM,
+// timeout, sample-budget, breaker, rejected) plus the route-B-still-failing
+// guardrail.
+func pathologyFailureSpecs() []pathologySpec {
+	return []pathologySpec{
+		// Route-A OOM. oom_on_route_a + failure_cluster_by_reason fire on any
+		// route-A OOM regardless of geometry; heavy_shape_geometry_failing fires
+		// only when cumulative_d is in the per-language tail, so it is expected at
+		// SEVERE (d in tail) but NOT at MARGINAL (d in the healthy body).
+		{
+			shape: "prom:oom_heavy", lang: "promql", hashBase: 30000,
+			expect: func(sev PathologySeverity) []string {
+				base := []string{"oom_on_route_a", "failure_cluster_by_reason"}
+				if sev == SevSevere {
+					return append(base, "heavy_shape_geometry_failing")
+				}
+				return base
+			},
+			severities: []PathologySeverity{SevSevere, SevMarginal},
+			fill: func(rng *rand.Rand, sev PathologySeverity) BenchRow {
+				return BenchRow{
+					Route: "A", ExitStatus: "oom", DecisionReason: "high-cardinality",
+					MemoryUsage: pick(sev, sevMemSevere, sevMemMarg),
+					CumulativeD: pick(sev, sevDSevere, sevDMarg),
+					NAnchors:    jitter(rng, 5, 20), Fanout: jitter(rng, 20, 40),
+					ReadRows: jitter(rng, 1_000_000, 4_000_000),
+				}
+			},
+		},
+		// Route-A timeout. route_a_timeout_should_shard + failure_cluster_by_reason
+		// fire on any route-A timeout. The SEVERE variant is also in the geometry
+		// tail (heavy_shape_geometry_failing) AND in the duration tail at 9s
+		// (route_a_slow_hot_shape, which gates only on route-A duration). The
+		// MARGINAL variant clears neither tail, so it expects only the two
+		// status-driven rules.
+		{
+			shape: "log:timeout_heavy", lang: "logql", hashBase: 31000,
+			expect: func(sev PathologySeverity) []string {
+				base := []string{"route_a_timeout_should_shard", "failure_cluster_by_reason"}
+				if sev == SevSevere {
+					return append(base, "heavy_shape_geometry_failing", "route_a_slow_hot_shape")
+				}
+				return base
+			},
+			severities: []PathologySeverity{SevSevere, SevMarginal},
+			fill: func(rng *rand.Rand, sev PathologySeverity) BenchRow {
+				return BenchRow{
+					Route: "A", ExitStatus: "timeout", DecisionReason: "high-cardinality",
+					QueryDurationMS: pick(sev, sevDurSevere, sevDurMarg),
+					CumulativeD:     pick(sev, sevDSevere, sevDMarg),
+					NAnchors:        jitter(rng, 5, 20), Fanout: jitter(rng, 20, 40),
+					MemoryUsage: jitter(rng, healthyMemBase, healthyMemSpread),
+				}
+			},
+		},
+		// Route-A sample-budget: route_a_hit_sample_budget +
+		// cerberus_side_rejection_pressure.
+		{
+			shape: "prom:topk_budget", lang: "promql", hashBase: 32000,
+			expect:     always("route_a_hit_sample_budget", "cerberus_side_rejection_pressure"),
+			severities: []PathologySeverity{SevSevere},
+			fill: func(rng *rand.Rand, _ PathologySeverity) BenchRow {
+				return BenchRow{
+					Route: "A", ExitStatus: "sample_budget", DecisionReason: "scalar-heavy",
+					ReadRows: jitter(rng, 2_000_000, 6_000_000), Fanout: jitter(rng, 10, 30),
+				}
+			},
+		},
+		// Cerberus-side breaker: cerberus_side_rejection_pressure only.
+		{
+			shape: "trc:breaker", lang: "traceql", hashBase: 33000,
+			expect:     always("cerberus_side_rejection_pressure"),
+			severities: []PathologySeverity{SevSevere},
+			fill: func(rng *rand.Rand, _ PathologySeverity) BenchRow {
+				return BenchRow{
+					Route: "A", ExitStatus: "breaker", DecisionReason: "scalar-heavy",
+					ReadRows: jitter(rng, 100_000, 500_000),
+				}
+			},
+		},
+		// Explicit rejected: cerberus_side_rejection_pressure only.
+		{
+			shape: "prom:rejected", lang: "promql", hashBase: 34000,
+			expect:     always("cerberus_side_rejection_pressure"),
+			severities: []PathologySeverity{SevSevere},
+			fill: func(rng *rand.Rand, _ PathologySeverity) BenchRow {
+				return BenchRow{
+					Route: "A", ExitStatus: "rejected", DecisionReason: "scalar-heavy",
+					ReadRows: jitter(rng, 100_000, 500_000),
+				}
+			},
+		},
+		// Route-B still failing: route_b_still_failing +
+		// failure_cluster_by_reason + heavy_shape_geometry_failing.
+		{
+			shape: "prom:routeb_fail", lang: "promql", hashBase: 35000,
+			expect:     always("route_b_still_failing", "failure_cluster_by_reason", "heavy_shape_geometry_failing"),
+			severities: []PathologySeverity{SevSevere},
+			fill: func(rng *rand.Rand, _ PathologySeverity) BenchRow {
+				return BenchRow{
+					Route: "B", ExitStatus: "oom", DecisionReason: "not-sliceable",
+					KShards: jitter(rng, 8, 32), CumulativeD: sevDSevere,
+					MemoryUsage: pick(SevSevere, sevMemSevere, sevMemMarg),
+					NAnchors:    jitter(rng, 5, 20), Fanout: jitter(rng, 20, 40),
+				}
+			},
+		},
+	}
+}
+
+// pathologyTailSpecs are the self-relative tail detectors: a class flagged for
+// sitting in the top (or, for overshard regret, the bottom) of its own
+// distribution rather than for a hard failure.
+func pathologyTailSpecs() []pathologySpec {
+	return []pathologySpec{
+		// Route-B overshard regret: route_b_overshard_low_fanout only.
+		{
+			shape: "prom:overshard", lang: "promql", hashBase: 36000,
+			expect:     always("route_b_overshard_low_fanout"),
+			severities: []PathologySeverity{SevSevere},
+			fill: func(rng *rand.Rand, _ PathologySeverity) BenchRow {
+				return BenchRow{
+					Route: "B", ExitStatus: "ok", DecisionReason: "sliceable",
+					Fanout: regretFanout, QueryDurationMS: regretDur, KShards: regretShards,
+					CumulativeD: jitter(rng, healthyDBase, healthyDSpread),
+					MemoryUsage: jitter(rng, healthyMemBase, healthyMemSpread),
+					ReadRows:    jitter(rng, healthyReadBase, healthyReadSpread),
+				}
+			},
+		},
+		// High-fanout route-A: route_a_high_fanout_should_shard only.
+		{
+			shape: "prom:hot_fanout", lang: "promql", hashBase: 37000,
+			expect:     always("route_a_high_fanout_should_shard"),
+			severities: []PathologySeverity{SevSevere, SevMarginal},
+			fill: func(rng *rand.Rand, sev PathologySeverity) BenchRow {
+				return BenchRow{
+					Route: "A", ExitStatus: "ok", DecisionReason: "below-threshold",
+					Fanout:          pick(sev, sevFanSevere, sevFanMarg),
+					CumulativeD:     jitter(rng, healthyDBase, healthyDSpread),
+					MemoryUsage:     jitter(rng, healthyMemBase, healthyMemSpread),
+					QueryDurationMS: jitter(rng, healthyDurBase, healthyDurSpread),
+					ReadRows:        jitter(rng, healthyReadBase, healthyReadSpread),
+				}
+			},
+		},
+		// Memory near cap (healthy but in the per-language memory tail):
+		// route_a_memory_near_cap only.
+		{
+			shape: "prom:mem_near_cap", lang: "promql", hashBase: 38000,
+			expect:     always("route_a_memory_near_cap"),
+			severities: []PathologySeverity{SevSevere, SevMarginal},
+			fill: func(rng *rand.Rand, sev PathologySeverity) BenchRow {
+				return BenchRow{
+					Route: "A", ExitStatus: "ok", DecisionReason: "below-threshold",
+					MemoryUsage:     pick(sev, sevMemSevere, sevMemMarg),
+					Fanout:          jitter(rng, healthyFanBase, healthyFanSpread),
+					CumulativeD:     jitter(rng, healthyDBase, healthyDSpread),
+					QueryDurationMS: jitter(rng, healthyDurBase, healthyDurSpread),
+					ReadRows:        jitter(rng, healthyReadBase, healthyReadSpread),
+				}
+			},
+		},
+		// Slow hot shape (route A, in the per-language duration tail):
+		// route_a_slow_hot_shape only. Grouped by normalized_query_hash.
+		{
+			shape: "prom:slow_hot", lang: "promql", hashBase: 39000,
+			expect:     always("route_a_slow_hot_shape"),
+			severities: []PathologySeverity{SevSevere},
+			fill: func(rng *rand.Rand, _ PathologySeverity) BenchRow {
+				return BenchRow{
+					Route: "A", ExitStatus: "ok", DecisionReason: "below-threshold",
+					QueryDurationMS: sevDurSevere,
+					MemoryUsage:     jitter(rng, healthyMemBase, healthyMemSpread),
+					Fanout:          jitter(rng, healthyFanBase, healthyFanSpread),
+					CumulativeD:     jitter(rng, healthyDBase, healthyDSpread),
+					ReadRows:        jitter(rng, healthyReadBase, healthyReadSpread),
+				}
+			},
+		},
+		// Read-amplification (experimental rule): read_amplification_hot_shape.
+		{
+			shape: "prom:read_amp", lang: "promql", hashBase: 40000,
+			expect:     always("read_amplification_hot_shape"),
+			severities: []PathologySeverity{SevSevere},
+			fill: func(rng *rand.Rand, _ PathologySeverity) BenchRow {
+				return BenchRow{
+					Route: "A", ExitStatus: "ok", DecisionReason: "below-threshold",
+					ReadRows:        sevReadSevere,
+					ReadBytes:       jitter(rng, 100_000_000, 400_000_000),
+					MemoryUsage:     jitter(rng, healthyMemBase, healthyMemSpread),
+					Fanout:          jitter(rng, healthyFanBase, healthyFanSpread),
+					CumulativeD:     jitter(rng, healthyDBase, healthyDSpread),
+					QueryDurationMS: jitter(rng, healthyDurBase, healthyDurSpread),
+				}
+			},
+		},
+	}
+}
+
+// pick chooses the severe or marginal magnitude for a severity.
+func pick(sev PathologySeverity, severe, marginal float64) float64 {
+	if sev == SevMarginal {
+		return marginal
+	}
+	return severe
+}
+
+// jitter draws a value in [base, base+spread) deterministically from rng,
+// rounded to an integer (corpus columns are integer-typed in the CH DDL).
+func jitter(rng *rand.Rand, base, spread float64) float64 {
+	return math.Round(base + rng.Float64()*spread)
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+// classID is a stable identifier for a labeled class across its group_by
+// dimensions, used to order classes and to look one up from a fired finding.
+func classID(c LabeledClass) string {
+	return c.Language + "|" + c.ShapeID + "|" + c.DecisionReason + "|" + formatNumeric(float64(c.QueryHash))
+}
+
+func sortBenchRows(rows []BenchRow) {
+	sort.SliceStable(rows, func(i, j int) bool {
+		a, b := rows[i], rows[j]
+		if a.ShapeID != b.ShapeID {
+			return a.ShapeID < b.ShapeID
+		}
+		return a.NormalizedQueryHash < b.NormalizedQueryHash
+	})
+}
+
+func itoaLocal(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var b [20]byte
+	pos := len(b)
+	neg := i < 0
+	if neg {
+		i = -i
+	}
+	for i > 0 {
+		pos--
+		b[pos] = byte('0' + i%10)
+		i /= 10
+	}
+	if neg {
+		pos--
+		b[pos] = '-'
+	}
+	return string(b[pos:])
+}

--- a/internal/routerrules/benchmark_coverage_test.go
+++ b/internal/routerrules/benchmark_coverage_test.go
@@ -1,0 +1,274 @@
+package routerrules
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// This file closes the high-value coverage gaps the benchmark exposed:
+//   - resolver-kind coverage: corpus_agg (max/avg/min/stddevPop) is a live
+//     resolver kind with no catalog param exercising it on a realistic corpus,
+//     and the in-memory source is a second backend that must agree with the
+//     JSONL one;
+//   - multi-rule interaction: a single class that is the textbook positive for
+//     several rules must fire EXACTLY those rules and no others;
+//   - adversarial corpora: monochrome, all-failure, and shifted distributions
+//     that try to drive the rules into false positives or false negatives.
+
+// TestResolverKindCorpusAggOnBenchmark exercises every corpus_agg function over
+// the realistic benchmark corpus, partitioned and scalar, through the in-memory
+// source. The catalog ships no corpus_agg param today, so without this the
+// resolver kind is only unit-tested on tiny fixtures; here it must resolve to a
+// non-degenerate value on a real distribution.
+func TestResolverKindCorpusAggOnBenchmark(t *testing.T) {
+	corpus := GenerateBenchCorpus(nominalBenchParams())
+	src := corpus.AsCorpusSource()
+	ctx := context.Background()
+
+	// Scalar aggregates over the whole corpus.
+	for _, fn := range []AggFunc{AggMax, AggAvg, AggMin, AggStdDev} {
+		v, err := src.Aggregate(ctx, AggSpec{Agg: fn, Column: "memory_usage"})
+		if err != nil {
+			t.Fatalf("agg %s: %v", fn, err)
+		}
+		if v.IsPartitioned() || v.NoSignal {
+			t.Errorf("agg %s should be a scalar with signal, got partitioned=%v nosignal=%v", fn, v.IsPartitioned(), v.NoSignal)
+		}
+		if fn != AggMin && v.Scalar <= 0 {
+			t.Errorf("agg %s memory_usage = %v, want positive", fn, v.Scalar)
+		}
+	}
+
+	// Ordering invariant on a real distribution: min <= avg <= max.
+	mn := mustScalar(t, src, AggSpec{Agg: AggMin, Column: "memory_usage"})
+	av := mustScalar(t, src, AggSpec{Agg: AggAvg, Column: "memory_usage"})
+	mx := mustScalar(t, src, AggSpec{Agg: AggMax, Column: "memory_usage"})
+	if !(mn <= av && av <= mx) {
+		t.Errorf("agg ordering violated: min=%v avg=%v max=%v", mn, av, mx)
+	}
+
+	// Partitioned corpus_agg: one max per language, every bucket positive.
+	part, err := src.Aggregate(ctx, AggSpec{Agg: AggMax, Column: "query_duration_ms", PartitionBy: []string{"language"}})
+	if err != nil {
+		t.Fatalf("partitioned agg: %v", err)
+	}
+	if !part.IsPartitioned() || len(part.Partition) == 0 {
+		t.Fatalf("partitioned agg should yield per-language buckets, got %+v", part)
+	}
+	for lang, v := range part.Partition {
+		if v <= 0 {
+			t.Errorf("partitioned agg query_duration_ms[%q] = %v, want positive", lang, v)
+		}
+	}
+}
+
+func mustScalar(t *testing.T, src CorpusSource, spec AggSpec) float64 {
+	t.Helper()
+	v, err := src.Aggregate(context.Background(), spec)
+	if err != nil {
+		t.Fatalf("aggregate: %v", err)
+	}
+	return v.Scalar
+}
+
+// TestMemSourceMatchesJSONLOnAgg pins the in-memory benchmark source against the
+// JSONL source: written to the same rows, every corpus_agg resolves identically.
+// This is the parity guarantee that the benchmark measures the production
+// matcher, not a divergent re-implementation.
+func TestMemSourceMatchesJSONLOnAgg(t *testing.T) {
+	corpus := GenerateBenchCorpus(nominalBenchParams())
+	mem := corpus.AsCorpusSource()
+	jsonl := jsonlFromBenchRows(t, corpus.Rows)
+	ctx := context.Background()
+
+	specs := []AggSpec{
+		{Agg: AggMax, Column: "memory_usage"},
+		{Agg: AggStdDev, Column: "read_rows"},
+		{Agg: AggAvg, Column: "fanout", PartitionBy: []string{"language"}},
+		{CountRatio: true, NumScope: Scope{"exit_status": "oom"}, DenScope: Scope{"route": "A"}},
+	}
+	for _, spec := range specs {
+		mv, err := mem.Aggregate(ctx, spec)
+		if err != nil {
+			t.Fatalf("mem aggregate: %v", err)
+		}
+		jv, err := jsonl.Aggregate(ctx, spec)
+		if err != nil {
+			t.Fatalf("jsonl aggregate: %v", err)
+		}
+		if mv.NoSignal != jv.NoSignal || mv.Scalar != jv.Scalar {
+			t.Errorf("scalar parity broke for %+v: mem={%v,%v} jsonl={%v,%v}", spec, mv.Scalar, mv.NoSignal, jv.Scalar, jv.NoSignal)
+		}
+		if len(mv.Partition) != len(jv.Partition) {
+			t.Errorf("partition parity broke for %+v: mem=%d jsonl=%d buckets", spec, len(mv.Partition), len(jv.Partition))
+		}
+		for k, mscal := range mv.Partition {
+			if jscal, ok := jv.Partition[k]; !ok || jscal != mscal {
+				t.Errorf("partition[%q] parity broke for %+v: mem=%v jsonl=%v", k, spec, mscal, jscal)
+			}
+		}
+	}
+}
+
+// TestMultiRuleInteraction asserts that a class which is the textbook positive
+// for several rules fires EXACTLY its labeled rule set — no rule bleeds onto a
+// class outside its territory, and no labeled rule is silently dropped. The
+// route-A heavy OOM class is the canonical multi-rule class (oom_on_route_a +
+// failure_cluster_by_reason + heavy_shape_geometry_failing).
+func TestMultiRuleInteraction(t *testing.T) {
+	cat := loadCatalogT(t)
+	corpus := GenerateBenchCorpus(nominalBenchParams())
+	rep, err := NewEvaluator(cat, staticConfigLookup(benchConfig()), corpus.AsCorpusSource()).
+		Evaluate(context.Background(), EvalOptions{IncludeExperimental: true})
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+
+	// firedByClass[classID] = set of rule ids fired on it.
+	firedByClass := map[string]map[string]struct{}{}
+	for _, f := range rep.Findings {
+		id := matchClassID(f, corpus)
+		if id == "" {
+			t.Errorf("finding for rule %q matched no labeled class: %s", f.RuleID, classOfFinding(f))
+			continue
+		}
+		set := firedByClass[id]
+		if set == nil {
+			set = map[string]struct{}{}
+			firedByClass[id] = set
+		}
+		set[f.RuleID] = struct{}{}
+	}
+
+	for i := range corpus.Classes {
+		c := &corpus.Classes[i]
+		want := map[string]struct{}{}
+		for _, r := range c.Expect {
+			want[r] = struct{}{}
+		}
+		got := firedByClass[classID(*c)]
+		if !setsEqual(want, got) {
+			t.Errorf("class %s/%s fired %v, expected exactly %v",
+				c.Language, c.ShapeID, sortedKeys(got), sortedKeys(want))
+		}
+	}
+}
+
+// TestAdversarialMonochrome is the zero-false-positive proof on a HEALTHY-ONLY
+// corpus: a deployment whose every query is route-A and ok (the real-world
+// monochrome-healthy shape) must produce no findings at all — the failure rules
+// have nothing to gate on, and the self-relative tail detectors must not invent
+// a pathology out of a uniform healthy body.
+func TestAdversarialMonochrome(t *testing.T) {
+	cat := loadCatalogT(t)
+	corpus := GenerateBenchCorpus(BenchParams{Seed: 7, MinSupport: 5})
+	// Strip every planted pathology row + class, keeping only the healthy bulk.
+	healthyOnly := &BenchCorpus{}
+	keep := map[string]struct{}{}
+	for _, c := range corpus.Classes {
+		if c.Severity == SevHealthy {
+			healthyOnly.Classes = append(healthyOnly.Classes, c)
+			keep[c.ShapeID] = struct{}{}
+		}
+	}
+	for _, r := range corpus.Rows {
+		if _, ok := keep[r.ShapeID]; ok {
+			healthyOnly.Rows = append(healthyOnly.Rows, r)
+		}
+	}
+
+	rep, err := NewEvaluator(cat, staticConfigLookup(benchConfig()), healthyOnly.AsCorpusSource()).
+		Evaluate(context.Background(), EvalOptions{IncludeExperimental: true})
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if len(rep.Findings) != 0 {
+		t.Errorf("monochrome-healthy corpus must yield zero findings, got %d:\n%s",
+			len(rep.Findings), dumpFindings(rep.Findings))
+	}
+}
+
+// TestAdversarialDistributionShift stress-tests robustness to a non-stationary
+// corpus: the same labeled pathologies but with the healthy body shifted to a
+// different seed (a different deployment's cost surface). Detection must remain
+// effective — the self-relative watermarks adapt to the new body, so recall
+// stays at the floor and precision does not collapse.
+func TestAdversarialDistributionShift(t *testing.T) {
+	cat := loadCatalogT(t)
+	for _, seed := range []int64{2, 13, 99, 12345} {
+		corpus := GenerateBenchCorpus(BenchParams{Seed: seed, MinSupport: 5})
+		m, err := ScoreCatalog(context.Background(), cat, benchConfig(), corpus)
+		if err != nil {
+			t.Fatalf("seed %d: score: %v", seed, err)
+		}
+		if m.Overall.Recall < saneRangeRecallFloor {
+			t.Errorf("seed %d: recall %.3f below floor %.3f (self-relative watermarks should adapt)\n%s",
+				seed, m.Overall.Recall, saneRangeRecallFloor, FormatMetricsTable(m))
+		}
+		if m.Overall.Precision < saneRangePrecisionFloor {
+			t.Errorf("seed %d: precision %.3f below floor %.3f\n%s",
+				seed, m.Overall.Precision, saneRangePrecisionFloor, FormatMetricsTable(m))
+		}
+	}
+}
+
+// jsonlFromBenchRows writes bench rows to a temp JSONL file and returns a JSONL
+// source over them, so the in-memory and JSONL backends can be compared on
+// byte-identical data.
+func jsonlFromBenchRows(t *testing.T, rows []BenchRow) CorpusSource {
+	t.Helper()
+	dir := t.TempDir()
+	path := dir + "/bench.jsonl"
+	writeBenchJSONL(t, path, rows)
+	return NewJSONLCorpusSource(path, 0)
+}
+
+// writeBenchJSONL serialises bench rows as JSONL matching jsonlRow's tags, so a
+// JSONL source reads them byte-for-byte as the in-memory source folds them.
+func writeBenchJSONL(t *testing.T, path string, rows []BenchRow) {
+	t.Helper()
+	var sb strings.Builder
+	for _, r := range rows {
+		jr := jsonlRow{
+			ShapeID: r.ShapeID, Language: r.Language, NormalizedQueryHash: r.NormalizedQueryHash,
+			NAnchors: r.NAnchors, Fanout: r.Fanout, CumulativeD: r.CumulativeD,
+			OuterRange: r.OuterRange, Step: r.Step, Route: r.Route, KShards: r.KShards,
+			DecisionReason: r.DecisionReason, ReadRows: r.ReadRows, ReadBytes: r.ReadBytes,
+			QueryDurationMS: r.QueryDurationMS, MemoryUsage: r.MemoryUsage, ExitStatus: r.ExitStatus,
+		}
+		b, err := json.Marshal(jr)
+		if err != nil {
+			t.Fatalf("marshal bench row: %v", err)
+		}
+		sb.Write(b)
+		sb.WriteByte('\n')
+	}
+	if err := os.WriteFile(path, []byte(sb.String()), 0o600); err != nil {
+		t.Fatalf("write bench jsonl: %v", err)
+	}
+}
+
+func setsEqual(a, b map[string]struct{}) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k := range a {
+		if _, ok := b[k]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func sortedKeys(m map[string]struct{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/routerrules/benchmark_test.go
+++ b/internal/routerrules/benchmark_test.go
@@ -1,0 +1,61 @@
+package routerrules
+
+import (
+	"context"
+	"testing"
+)
+
+// benchConfig is the nominal config the benchmark scores the catalog at: a p95
+// watermark on both percentile knobs and a min_rows_per_class matching the
+// generator's benchNominalMinSupport, so the planted marginal classes sit one
+// row above the firing floor.
+func benchConfig() BenchConfig {
+	return BenchConfig{
+		"router_rules.watermark_percentile":    "0.95",
+		"router_rules.cumulative_d_percentile": "0.95",
+		"router_rules.min_rows_per_class":      "5",
+		"query.max_memory_bytes":               "1073741824",
+		"query.max_samples":                    "50000000",
+	}
+}
+
+// nominalBenchParams is the benchmark's reference distribution: a fixed seed for
+// reproducibility and the nominal class sizes.
+func nominalBenchParams() BenchParams {
+	return BenchParams{Seed: 1, MinSupport: 5}
+}
+
+func loadCatalogT(t *testing.T) *Catalog {
+	t.Helper()
+	cat, err := LoadEmbeddedCatalog()
+	if err != nil {
+		t.Fatalf("load catalog: %v", err)
+	}
+	return cat
+}
+
+// TestBenchmarkScorecard runs the catalog over the nominal labeled corpus and
+// prints the full precision/recall/F1 table. It measures DETECTION FIDELITY — how
+// consistently each rule fires on the pathologies a synthetic, self-labeled
+// corpus plants for it — not real-world rule effectiveness. The corpus labels are
+// derived from the same p95-watermark model the rules' thresholds resolve against,
+// so a perfect score proves the rules detect what the model says they should and
+// guards against detection regressions; it does NOT prove the rules catch real
+// production incidents. It is the source of the numbers reported in the PR.
+func TestBenchmarkScorecard(t *testing.T) {
+	cat := loadCatalogT(t)
+	corpus := GenerateBenchCorpus(nominalBenchParams())
+	m, err := ScoreCatalog(context.Background(), cat, benchConfig(), corpus)
+	if err != nil {
+		t.Fatalf("score catalog: %v", err)
+	}
+	t.Logf("router-rules detection fidelity on %d rows / %d labeled classes (seed=%d):\n%s",
+		len(corpus.Rows), len(corpus.Classes), nominalBenchParams().Seed, FormatMetricsTable(m))
+
+	// Sanity: every rule that is labeled in the corpus must appear in the
+	// scorecard, and the overall must have measured at least one true positive
+	// (a catalog that detects nothing is a broken benchmark, not a passing one).
+	if m.Overall.TP == 0 {
+		t.Fatalf("overall TP is 0 — the benchmark detected nothing:\n%s", FormatMetricsTable(m))
+	}
+}

--- a/internal/routerrules/metrics.go
+++ b/internal/routerrules/metrics.go
@@ -1,0 +1,253 @@
+package routerrules
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// This file is the quantified detection-fidelity measure for the router-rules
+// catalog: it runs the catalog over a SYNTHETIC LABELED benchmark corpus and
+// scores each rule's detection as precision / recall / F1 against the class-level
+// ground truth, plus a micro-averaged overall. The corpus labels share provenance
+// with the rules' p95-watermark thresholds, so the score measures detection
+// CONSISTENCY and guards against regressions — it is not a claim about real-world
+// rule effectiveness. It turns the binary fire/no-fire of the effectiveness
+// fixture into a graded, regression-pinnable number.
+//
+// Ground truth is per CLASS (a group_by group), because that is the granularity
+// a rule fires at after the min_support floor:
+//   - true positive  (TP): a class labeled with rule R, on which R fired.
+//   - false positive (FP): a class NOT labeled with R, on which R fired.
+//   - false negative (FN): a class labeled with R, on which R did not fire.
+// True negatives are not scored (precision/recall don't use them); the healthy
+// majority's contribution shows up as the absence of false positives.
+
+// RuleMetrics is one rule's confusion counts and derived scores over a corpus.
+type RuleMetrics struct {
+	Rule      string
+	TP        int
+	FP        int
+	FN        int
+	Precision float64
+	Recall    float64
+	F1        float64
+}
+
+// BenchmarkMetrics is the full scorecard: per-rule rows plus a micro-averaged
+// overall (TP/FP/FN summed across rules, then scored once).
+type BenchmarkMetrics struct {
+	PerRule []RuleMetrics
+	Overall RuleMetrics
+}
+
+// BenchConfig is the resolved config the benchmark scores the catalog at. It is
+// a plain map so the harness and the CLI subcommand share one shape; numbers
+// here are benchmark settings, not catalog thresholds.
+type BenchConfig map[string]string
+
+// ScoreCatalog runs the catalog over the corpus and scores every rule. It folds
+// in experimental rules (the read-amplification detector is labeled in the
+// corpus, so excluding it would understate recall) and returns the per-rule +
+// overall metrics, sorted by rule id for a deterministic table.
+func ScoreCatalog(ctx context.Context, cat *Catalog, cfg BenchConfig, corpus *BenchCorpus) (*BenchmarkMetrics, error) {
+	src := corpus.AsCorpusSource()
+	rep, err := NewEvaluator(cat, staticConfigLookup(cfg), src).
+		Evaluate(ctx, EvalOptions{IncludeExperimental: true})
+	if err != nil {
+		return nil, err
+	}
+	return scoreReport(rep, corpus), nil
+}
+
+// scoreReport scores a finished report against the corpus ground truth. It is
+// split out so the degradation sweep can score reports it already has without
+// re-evaluating.
+func scoreReport(rep *Report, corpus *BenchCorpus) *BenchmarkMetrics {
+	// fired[rule] = set of class ids the rule fired on.
+	fired := map[string]map[string]struct{}{}
+	for _, f := range rep.Findings {
+		id := matchClassID(f, corpus)
+		if id == "" {
+			// A finding that matches no labeled class is a false positive against
+			// a synthetic class id, so it still counts: bucket it under a unique
+			// key so it is never silently a true positive.
+			id = "unlabeled:" + f.RuleID + ":" + classOfFinding(f)
+		}
+		set := fired[f.RuleID]
+		if set == nil {
+			set = map[string]struct{}{}
+			fired[f.RuleID] = set
+		}
+		set[id] = struct{}{}
+	}
+
+	// labeled[rule] = set of class ids labeled positive for the rule.
+	labeled := map[string]map[string]struct{}{}
+	allLabeledIDs := map[string]struct{}{}
+	for _, c := range corpus.Classes {
+		cid := classID(c)
+		allLabeledIDs[cid] = struct{}{}
+		for _, r := range c.Expect {
+			set := labeled[r]
+			if set == nil {
+				set = map[string]struct{}{}
+				labeled[r] = set
+			}
+			set[cid] = struct{}{}
+		}
+	}
+
+	rules := ruleUniverse(fired, labeled)
+	out := &BenchmarkMetrics{}
+	var sumTP, sumFP, sumFN int
+	for _, rule := range rules {
+		m := scoreRule(rule, fired[rule], labeled[rule], allLabeledIDs)
+		out.PerRule = append(out.PerRule, m)
+		sumTP += m.TP
+		sumFP += m.FP
+		sumFN += m.FN
+	}
+	out.Overall = finalize(RuleMetrics{Rule: "OVERALL (micro)", TP: sumTP, FP: sumFP, FN: sumFN})
+	return out
+}
+
+// scoreRule computes one rule's confusion counts. A fired class id that is not a
+// real labeled class id (an "unlabeled:" bucket) is always a false positive.
+func scoreRule(rule string, fired, labeled, allLabeledIDs map[string]struct{}) RuleMetrics {
+	m := RuleMetrics{Rule: rule}
+	for id := range fired {
+		if _, real := allLabeledIDs[id]; !real {
+			m.FP++ // fired on a class that does not exist in ground truth
+			continue
+		}
+		if _, want := labeled[id]; want {
+			m.TP++
+		} else {
+			m.FP++ // fired on a real class that is not labeled for this rule
+		}
+	}
+	for id := range labeled {
+		if _, ok := fired[id]; !ok {
+			m.FN++ // labeled positive but the rule stayed silent
+		}
+	}
+	return finalize(m)
+}
+
+func finalize(m RuleMetrics) RuleMetrics {
+	if m.TP+m.FP > 0 {
+		m.Precision = float64(m.TP) / float64(m.TP+m.FP)
+	}
+	if m.TP+m.FN > 0 {
+		m.Recall = float64(m.TP) / float64(m.TP+m.FN)
+	}
+	if m.Precision+m.Recall > 0 {
+		m.F1 = 2 * m.Precision * m.Recall / (m.Precision + m.Recall)
+	}
+	return m
+}
+
+// matchClassID resolves the labeled class a finding fired on by matching the
+// finding's group-key values against each class's dimensions. A rule only
+// group_bys a subset of dimensions, so the match uses exactly the keys present
+// in the finding: shape_id (or normalized_query_hash for the slow rule) plus
+// language uniquely identify a planted class.
+func matchClassID(f Finding, corpus *BenchCorpus) string {
+	for i := range corpus.Classes {
+		c := &corpus.Classes[i]
+		if classMatchesFinding(c, f.GroupKey) {
+			return classID(*c)
+		}
+	}
+	return ""
+}
+
+// classMatchesFinding reports whether every dimension the finding keys on agrees
+// with the class. Keys the finding does not carry are not constrained.
+func classMatchesFinding(c *LabeledClass, gk map[string]string) bool {
+	if v, ok := gk["language"]; ok && v != c.Language {
+		return false
+	}
+	if v, ok := gk["shape_id"]; ok && v != c.ShapeID {
+		return false
+	}
+	if v, ok := gk["decision_reason"]; ok && v != c.DecisionReason {
+		return false
+	}
+	if v, ok := gk["normalized_query_hash"]; ok && v != formatNumeric(float64(c.QueryHash)) {
+		return false
+	}
+	// At least one identifying dimension (shape_id or query hash) must be present
+	// and have matched, or the match is vacuous.
+	_, hasShape := gk["shape_id"]
+	_, hasHash := gk["normalized_query_hash"]
+	return hasShape || hasHash
+}
+
+// ruleUniverse is the sorted union of rules that fired or are labeled, so a rule
+// that never fires (all FN) and a rule that only false-positives both appear.
+func ruleUniverse(fired, labeled map[string]map[string]struct{}) []string {
+	seen := map[string]struct{}{}
+	for r := range fired {
+		seen[r] = struct{}{}
+	}
+	for r := range labeled {
+		seen[r] = struct{}{}
+	}
+	out := make([]string, 0, len(seen))
+	for r := range seen {
+		// Drop the synthetic unlabeled bucket keys: they are class ids, not rule
+		// ids, and never appear as map keys here, but guard anyway.
+		if strings.HasPrefix(r, "unlabeled:") {
+			continue
+		}
+		out = append(out, r)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func classOfFinding(f Finding) string {
+	keys := make([]string, 0, len(f.GroupKey))
+	for k := range f.GroupKey {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, len(keys))
+	for i, k := range keys {
+		parts[i] = k + "=" + f.GroupKey[k]
+	}
+	return strings.Join(parts, ",")
+}
+
+// staticConfigLookup adapts a BenchConfig map to the ConfigLookup the resolver
+// consumes.
+func staticConfigLookup(cfg BenchConfig) ConfigLookup {
+	return func(key string) (string, bool) {
+		v, ok := cfg[key]
+		return v, ok
+	}
+}
+
+// FormatMetricsTable renders the scorecard as an aligned text table. It is the
+// human-facing output of both the go-test harness and the CLI subcommand.
+func FormatMetricsTable(m *BenchmarkMetrics) string {
+	var sb strings.Builder
+	header := fmt.Sprintf("%-36s %5s %5s %5s %9s %9s %9s\n",
+		"RULE", "TP", "FP", "FN", "PRECISION", "RECALL", "F1")
+	sb.WriteString(header)
+	sb.WriteString(strings.Repeat("-", len(header)) + "\n")
+	for _, r := range m.PerRule {
+		sb.WriteString(formatMetricRow(r))
+	}
+	sb.WriteString(strings.Repeat("-", len(header)) + "\n")
+	sb.WriteString(formatMetricRow(m.Overall))
+	return sb.String()
+}
+
+func formatMetricRow(r RuleMetrics) string {
+	return fmt.Sprintf("%-36s %5d %5d %5d %9.3f %9.3f %9.3f\n",
+		r.Rule, r.TP, r.FP, r.FN, r.Precision, r.Recall, r.F1)
+}

--- a/internal/routerrules/parity_chdb_test.go
+++ b/internal/routerrules/parity_chdb_test.go
@@ -159,6 +159,74 @@ func TestCrossBackendParityEffectiveness(t *testing.T) {
 	}
 }
 
+// TestCrossBackendParityBenchmark runs the LABELED benchmark corpus through both
+// backends and asserts identical findings. This proves the precision/recall/F1
+// the benchmark reports is the same whether measured on the in-Go matcher (the
+// default-lane benchmark harness) or the production CH SQL path — so the
+// effectiveness numbers are not an artefact of the in-memory source.
+func TestCrossBackendParityBenchmark(t *testing.T) {
+	corpus := GenerateBenchCorpus(nominalBenchParams())
+
+	db := openParityChDB(t)
+	seedParityTableFromBench(t, db, corpus.Rows)
+
+	cat, err := LoadEmbeddedCatalog()
+	if err != nil {
+		t.Fatalf("load catalog: %v", err)
+	}
+	cfg := staticConfigLookup(benchConfig())
+	opts := EvalOptions{IncludeExperimental: true}
+
+	chReport, err := NewEvaluator(cat, cfg, NewCHCorpusSource(&sqlDBConn{db: db}, 0)).Evaluate(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("ch evaluate: %v", err)
+	}
+	memReport, err := NewEvaluator(cat, cfg, corpus.AsCorpusSource()).Evaluate(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("mem evaluate: %v", err)
+	}
+
+	chKeys := findingKeys(chReport)
+	memKeys := findingKeys(memReport)
+	if len(chKeys) != len(memKeys) {
+		t.Fatalf("finding count differs: ch=%d mem=%d\nch=%v\nmem=%v", len(chKeys), len(memKeys), chKeys, memKeys)
+	}
+	for k, chSup := range chKeys {
+		mSup, ok := memKeys[k]
+		if !ok {
+			t.Errorf("ch finding %q absent from mem", k)
+			continue
+		}
+		if chSup != mSup {
+			t.Errorf("support differs for %q: ch=%d mem=%d", k, chSup, mSup)
+		}
+	}
+
+	// And the scored metrics must be identical across backends.
+	chMetrics := scoreReport(chReport, corpus)
+	memMetrics := scoreReport(memReport, corpus)
+	if chMetrics.Overall != memMetrics.Overall {
+		t.Errorf("overall metrics differ across backends:\nch=%+v\nmem=%+v", chMetrics.Overall, memMetrics.Overall)
+	}
+}
+
+// seedParityTableFromBench creates the corpus table in chdb and loads benchmark
+// rows directly (no JSONL round-trip), mirroring seedParityTableFrom's DDL.
+func seedParityTableFromBench(t *testing.T, db *sql.DB, rows []BenchRow) {
+	t.Helper()
+	jr := make([]jsonlRow, len(rows))
+	for i, r := range rows {
+		jr[i] = jsonlRow{
+			ShapeID: r.ShapeID, Language: r.Language, NormalizedQueryHash: r.NormalizedQueryHash,
+			NAnchors: r.NAnchors, Fanout: r.Fanout, CumulativeD: r.CumulativeD,
+			OuterRange: r.OuterRange, Step: r.Step, Route: r.Route, KShards: r.KShards,
+			DecisionReason: r.DecisionReason, ReadRows: r.ReadRows, ReadBytes: r.ReadBytes,
+			QueryDurationMS: r.QueryDurationMS, MemoryUsage: r.MemoryUsage, ExitStatus: r.ExitStatus,
+		}
+	}
+	seedParityTableFromRows(t, db, jr)
+}
+
 // assertEnvParity fails if the two resolved Envs differ in key set, NoSignal
 // flags, scalar values (NaN/Inf is never tolerated), or partition contents.
 func assertEnvParity(t *testing.T, a, b Env) {
@@ -228,6 +296,14 @@ func seedParityTable(t *testing.T, db *sql.DB) {
 // queries behave as they would against the real table.
 func seedParityTableFrom(t *testing.T, db *sql.DB, fixture string) {
 	t.Helper()
+	seedParityTableFromRows(t, db, readSeedRows(t, fixture))
+}
+
+// seedParityTableFromRows creates the corpus table in chdb and loads the given
+// decoded rows. The column types mirror the optcorpus MergeTree DDL so the CH
+// source's queries behave as they would against the real table.
+func seedParityTableFromRows(t *testing.T, db *sql.DB, rows []jsonlRow) {
+	t.Helper()
 	ddl := "CREATE OR REPLACE TABLE " + CorpusTableName + ` (
 		event_time DateTime,
 		shape_id LowCardinality(String),
@@ -246,7 +322,6 @@ func seedParityTableFrom(t *testing.T, db *sql.DB, fixture string) {
 		t.Fatalf("create table: %v", err)
 	}
 
-	rows := readSeedRows(t, fixture)
 	var vals []string
 	for _, r := range rows {
 		vals = append(vals, fmt.Sprintf(

--- a/internal/routerrules/regression_floor_test.go
+++ b/internal/routerrules/regression_floor_test.go
@@ -1,0 +1,117 @@
+package routerrules
+
+import (
+	"context"
+	"testing"
+)
+
+// Regression floors for router-rules detection. These NUMERIC thresholds live in
+// test code by design (the no-numbers invariant governs only the shipped
+// catalog YAML). They are the contract that a future catalog or generator change
+// must not silently erode: if a rule is weakened, a watermark formula drifts, or
+// the corpus stops exercising a rule, one of these floors trips.
+//
+// The floors are deliberately set BELOW the measured nominal (precision/recall
+// 1.0) so normal run-to-run determinism has headroom, while still catching a
+// real regression (a rule that stops firing, or starts over-firing on healthy
+// classes).
+const (
+	// nominalF1Floor: at the nominal operating point the catalog must score at
+	// least this overall F1. Measured nominal is 1.0; the floor leaves margin.
+	nominalF1Floor = 0.95
+	// nominalPrecisionFloor / nominalRecallFloor: nominal per-axis floors.
+	nominalPrecisionFloor = 0.95
+	nominalRecallFloor    = 0.95
+	// saneRangeRecallFloor: across the operationally sane tuning range (watermark
+	// 0.90–0.99, min_support 3–8, prevalence 0.5–2.0) recall must stay at least
+	// this high — detection must not collapse just because a deployment tunes a
+	// little off-nominal.
+	saneRangeRecallFloor = 0.90
+	// saneRangePrecisionFloor: across the SAME sane range precision must stay at
+	// least this high — the rules must not flood an operator with false positives
+	// under reasonable tuning. (Loosening the watermark to 0.50 deliberately
+	// breaks this; the sane range starts at 0.90, where the healthy body no
+	// longer crosses the watermark.)
+	saneRangePrecisionFloor = 0.80
+	// severeRecallFloor: severe pathologies must be caught at every sane point.
+	severeRecallFloor = 1.0
+)
+
+// TestRegressionFloorNominal pins the nominal scorecard above the stated floors.
+func TestRegressionFloorNominal(t *testing.T) {
+	cat := loadCatalogT(t)
+	corpus := GenerateBenchCorpus(nominalBenchParams())
+	m, err := ScoreCatalog(context.Background(), cat, benchConfig(), corpus)
+	if err != nil {
+		t.Fatalf("score catalog: %v", err)
+	}
+	if m.Overall.F1 < nominalF1Floor {
+		t.Errorf("nominal overall F1 %.3f below floor %.3f:\n%s", m.Overall.F1, nominalF1Floor, FormatMetricsTable(m))
+	}
+	if m.Overall.Precision < nominalPrecisionFloor {
+		t.Errorf("nominal overall precision %.3f below floor %.3f", m.Overall.Precision, nominalPrecisionFloor)
+	}
+	if m.Overall.Recall < nominalRecallFloor {
+		t.Errorf("nominal overall recall %.3f below floor %.3f", m.Overall.Recall, nominalRecallFloor)
+	}
+
+	// Every rule that is labeled in the corpus must score a positive F1 — a rule
+	// that scores 0 is one that never fired on its planted pathology (a silenced
+	// rule), the single most important regression to catch per-rule.
+	for _, r := range m.PerRule {
+		if r.TP+r.FN == 0 {
+			continue // rule has no labeled positives in the corpus
+		}
+		if r.F1 == 0 {
+			t.Errorf("rule %q has labeled positives but F1=0 — it detected none of them", r.Rule)
+		}
+	}
+}
+
+// TestRegressionFloorSaneRange pins recall + precision floors across the
+// operationally sane TUNING range (watermark + min_support, at nominal
+// prevalence), and severe-recall at 1.0 everywhere including off-nominal
+// prevalence.
+//
+// Prevalence is held at nominal for the overall recall/precision floors on
+// purpose: a rare deployment legitimately starves its marginal pathologies below
+// the support floor (that is the modelled behaviour the prevalence axis now
+// exercises — see pathologySize), so a prevalence-driven drop in overall recall
+// is expected degradation, not a regression. SevereRecall, by contrast, must
+// stay perfect at every prevalence — a severe pathology is never lost merely
+// because the deployment is rare.
+func TestRegressionFloorSaneRange(t *testing.T) {
+	cat := loadCatalogT(t)
+	ax := SweepAxes{
+		Watermarks:        []float64{0.90, 0.95, 0.99},
+		MinSupports:       []int{3, 5, 8},
+		Prevalences:       []float64{0.5, 1.0, 2.0},
+		NominalWatermark:  0.95,
+		NominalMinSupport: 5,
+		NominalPrevalence: 1.0,
+		Seed:              1,
+	}
+	pts, err := RunSweep(context.Background(), cat, ax)
+	if err != nil {
+		t.Fatalf("run sweep: %v", err)
+	}
+	for _, p := range pts {
+		// Overall recall/precision floors apply across the tuning knobs at nominal
+		// prevalence; off-nominal prevalence is allowed to degrade overall recall.
+		if p.Prevalence == ax.NominalPrevalence {
+			if p.Overall.Recall < saneRangeRecallFloor {
+				t.Errorf("recall %.3f below sane-range floor %.3f at wm=%.2f msup=%d prev=%.2f",
+					p.Overall.Recall, saneRangeRecallFloor, p.WatermarkPctile, p.MinSupport, p.Prevalence)
+			}
+			if p.Overall.Precision < saneRangePrecisionFloor {
+				t.Errorf("precision %.3f below sane-range floor %.3f at wm=%.2f msup=%d prev=%.2f",
+					p.Overall.Precision, saneRangePrecisionFloor, p.WatermarkPctile, p.MinSupport, p.Prevalence)
+			}
+		}
+		// Severe recall stays perfect everywhere, including off-nominal prevalence.
+		if p.SevereRecall < severeRecallFloor {
+			t.Errorf("severe recall %.3f below floor %.3f at wm=%.2f msup=%d prev=%.2f",
+				p.SevereRecall, severeRecallFloor, p.WatermarkPctile, p.MinSupport, p.Prevalence)
+		}
+	}
+}

--- a/internal/routerrules/resolve.go
+++ b/internal/routerrules/resolve.go
@@ -45,10 +45,21 @@ type Env map[string]Value
 type ConfigLookup func(key string) (string, bool)
 
 // ParamResolver resolves the catalog's named-parameter registry against a
-// deployment's config and corpus. It topo-sorts the parameter dependency DAG,
-// resolves leaves first, memoizes, and batches corpus aggregates that share a
-// (scope, partition_by) group into one scan so a whole catalog costs
-// O(distinct scope-groups) scans, not O(params).
+// deployment's config and corpus. It topo-sorts the parameter dependency DAG and
+// resolves leaves first (a percentile param's fraction ref is resolved before the
+// percentile itself).
+//
+// Cost: it resolves one param at a time, and every corpus-kind param triggers a
+// full corpus pass (CorpusSource.Aggregate streams the whole corpus once), so a
+// catalog costs ~O(corpus-params) scans, not O(distinct scope-groups). The corpus
+// is small (per-pod JSONL, or a single CH GROUP BY) and resolution is offline, so
+// this has never mattered in practice.
+//
+// ponytail: batching corpus aggregates that share an AggSpec (scope, partition_by,
+// fraction) into one scan would cut this to O(distinct scope-groups) passes. It is
+// left unimplemented because the corpus is small and the win is unmeasured — do it
+// only if a large corpus ever makes resolution a hotspot. TestResolveScanCount
+// pins the actual scan count so this doc can't drift from the code again.
 type ParamResolver struct {
 	cfg ConfigLookup
 	src CorpusSource
@@ -73,11 +84,11 @@ func (r *ParamResolver) Resolve(ctx context.Context, cat *Catalog) (Env, error) 
 		return nil, err
 	}
 
-	// Batch corpus aggregates that share an identical AggSpec group so the
-	// percentile-fraction differences (which are inputs, resolved first as
-	// config leaves) collapse to one scan per distinct (column, scope,
-	// partition, fraction) shape. Config leaves and ratios are resolved
-	// inline; percentile/agg params are grouped by their resolved AggSpec.
+	// Resolve in dependency order, one param at a time: config leaves and ratios
+	// resolve inline, and each corpus-kind param drives its own full corpus pass
+	// via resolveOne -> resolveCorpus -> CorpusSource.Aggregate. No cross-param
+	// batching today (see the type doc's ponytail note); the corpus is small and
+	// resolution is offline.
 	env := make(Env, len(order))
 	for _, name := range order {
 		spec := specs[name]

--- a/internal/routerrules/resolve_scan_test.go
+++ b/internal/routerrules/resolve_scan_test.go
@@ -1,0 +1,60 @@
+package routerrules
+
+import (
+	"context"
+	"testing"
+)
+
+// countingCorpusSource wraps a CorpusSource and counts how many times Aggregate
+// is invoked. Each Aggregate call is exactly one full corpus pass in both real
+// backends (jsonlCorpusSource streams the file per call; source_ch issues one
+// SELECT per call), so the count is the resolver's corpus-scan count.
+type countingCorpusSource struct {
+	inner      CorpusSource
+	aggregates int
+}
+
+func (c *countingCorpusSource) Aggregate(ctx context.Context, spec AggSpec) (Value, error) {
+	c.aggregates++
+	return c.inner.Aggregate(ctx, spec)
+}
+
+func (c *countingCorpusSource) EvalRule(ctx context.Context, q RuleQuery) ([]GroupResult, error) {
+	return c.inner.EvalRule(ctx, q)
+}
+
+// TestResolveScanCount pins the resolver's actual cost model: it performs one
+// corpus scan per corpus-kind param (~O(corpus-params)), NOT one scan per
+// distinct scope-group. It exists so the ParamResolver doc — which used to claim
+// a batching optimization the code never had — cannot silently drift from the
+// implementation again. If batching is ever added (the ponytail note on
+// ParamResolver), this test is where the new, lower count gets re-pinned.
+func TestResolveScanCount(t *testing.T) {
+	cat := loadCatalogT(t)
+	corpus := GenerateBenchCorpus(nominalBenchParams())
+	counter := &countingCorpusSource{inner: NewMemCorpusSource(corpus.Rows)}
+
+	r := NewParamResolver(staticConfigLookup(benchConfig()), counter)
+	if _, err := r.Resolve(context.Background(), cat); err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+
+	wantCorpusParams := 0
+	for _, p := range cat.Params {
+		switch p.Kind {
+		case ParamCorpusPercentile, ParamCorpusAgg, ParamCorpusCountRatio:
+			wantCorpusParams++
+		case ParamConfig:
+			// config leaves resolve inline, no corpus scan.
+		}
+	}
+
+	if wantCorpusParams == 0 {
+		t.Fatal("catalog has no corpus-kind params; scan-count test would be vacuous")
+	}
+	if counter.aggregates != wantCorpusParams {
+		t.Errorf("resolver did %d corpus scans for %d corpus-kind params; expected one scan per corpus param (no batching). "+
+			"If the resolver gained AggSpec batching, update this expectation and the ParamResolver doc together.",
+			counter.aggregates, wantCorpusParams)
+	}
+}

--- a/internal/routerrules/source_jsonl.go
+++ b/internal/routerrules/source_jsonl.go
@@ -154,22 +154,35 @@ func (s *jsonlCorpusSource) files() ([]string, error) {
 
 // Aggregate resolves a corpus param in-Go.
 func (s *jsonlCorpusSource) Aggregate(_ context.Context, spec AggSpec) (Value, error) {
+	return inGoAggregate(s.stream, spec)
+}
+
+// EvalRule folds the corpus in-Go.
+func (s *jsonlCorpusSource) EvalRule(_ context.Context, q RuleQuery) ([]GroupResult, error) {
+	return inGoEvalRule(s.stream, q)
+}
+
+// inGoAggregate resolves a corpus param by streaming rows through stream and
+// folding them in-Go. It is shared by the JSONL source and the in-memory
+// benchmark source so both take the identical aggregation path (and therefore
+// the identical quantile formula) the catalog is validated against.
+func inGoAggregate(stream func(func(corpusRow) error) error, spec AggSpec) (Value, error) {
 	switch {
 	case spec.CountRatio:
-		return s.countRatio(spec)
+		return inGoCountRatio(stream, spec)
 	case spec.Percentile != nil:
-		return s.percentile(spec)
+		return inGoPercentile(stream, spec)
 	case spec.Agg != "":
-		return s.agg(spec)
+		return inGoAgg(stream, spec)
 	default:
-		return Value{}, fmt.Errorf("routerrules: jsonl aggregate: empty AggSpec for column %q", spec.Column)
+		return Value{}, fmt.Errorf("routerrules: in-go aggregate: empty AggSpec for column %q", spec.Column)
 	}
 }
 
-func (s *jsonlCorpusSource) percentile(spec AggSpec) (Value, error) {
+func inGoPercentile(stream func(func(corpusRow) error) error, spec AggSpec) (Value, error) {
 	buckets := map[string][]float64{}
 	all := []float64{}
-	err := s.stream(func(r corpusRow) error {
+	err := stream(func(r corpusRow) error {
 		if !matchScope(r, spec.Scope) {
 			return nil
 		}
@@ -198,10 +211,10 @@ func (s *jsonlCorpusSource) percentile(spec AggSpec) (Value, error) {
 	return Value{Scalar: quantileExact(all, *spec.Percentile)}, nil
 }
 
-func (s *jsonlCorpusSource) agg(spec AggSpec) (Value, error) {
+func inGoAgg(stream func(func(corpusRow) error) error, spec AggSpec) (Value, error) {
 	buckets := map[string][]float64{}
 	all := []float64{}
-	err := s.stream(func(r corpusRow) error {
+	err := stream(func(r corpusRow) error {
 		if !matchScope(r, spec.Scope) {
 			return nil
 		}
@@ -230,9 +243,9 @@ func (s *jsonlCorpusSource) agg(spec AggSpec) (Value, error) {
 	return Value{Scalar: aggregate(spec.Agg, all)}, nil
 }
 
-func (s *jsonlCorpusSource) countRatio(spec AggSpec) (Value, error) {
+func inGoCountRatio(stream func(func(corpusRow) error) error, spec AggSpec) (Value, error) {
 	var num, den float64
-	err := s.stream(func(r corpusRow) error {
+	err := stream(func(r corpusRow) error {
 		if matchScope(r, spec.NumScope) {
 			num++
 		}
@@ -250,9 +263,9 @@ func (s *jsonlCorpusSource) countRatio(spec AggSpec) (Value, error) {
 	return Value{Scalar: num / den}, nil
 }
 
-// EvalRule folds the corpus in-Go: it groups matched rows by the rule's
+// inGoEvalRule folds the corpus in-Go: it groups matched rows by the rule's
 // group_by columns, counting support and accumulating evidence aggregates.
-func (s *jsonlCorpusSource) EvalRule(_ context.Context, q RuleQuery) ([]GroupResult, error) {
+func inGoEvalRule(stream func(func(corpusRow) error) error, q RuleQuery) ([]GroupResult, error) {
 	type acc struct {
 		key      []string
 		support  int64
@@ -261,7 +274,7 @@ func (s *jsonlCorpusSource) EvalRule(_ context.Context, q RuleQuery) ([]GroupRes
 	groups := map[string]*acc{}
 	var order []string
 
-	err := s.stream(func(r corpusRow) error {
+	err := stream(func(r corpusRow) error {
 		ok, err := q.Condition.match(r, q.Env)
 		if err != nil {
 			return err

--- a/internal/routerrules/source_mem.go
+++ b/internal/routerrules/source_mem.go
@@ -1,0 +1,38 @@
+package routerrules
+
+import "context"
+
+// memCorpusSource is an in-memory CorpusSource over a slice of benchmark rows.
+// It exists so the effectiveness benchmark can resolve params and evaluate rules
+// against a generated labeled corpus with no JSONL round-trip, while taking the
+// EXACT same in-Go aggregation + evaluation path the JSONL source uses (the
+// shared inGoAggregate / inGoEvalRule helpers). That shared path is what keeps
+// the benchmark honest: it measures the same matcher and the same quantileExact
+// formula the production JSONL backend runs, not a parallel re-implementation.
+type memCorpusSource struct {
+	rows []BenchRow
+}
+
+// NewMemCorpusSource builds an in-memory source over benchmark rows.
+func NewMemCorpusSource(rows []BenchRow) CorpusSource {
+	return &memCorpusSource{rows: rows}
+}
+
+// stream feeds every row through fn as a decoded corpusRow, the shape both
+// in-Go aggregation helpers consume.
+func (s *memCorpusSource) stream(fn func(corpusRow) error) error {
+	for _, r := range s.rows {
+		if err := fn(r.toCorpusRow()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *memCorpusSource) Aggregate(_ context.Context, spec AggSpec) (Value, error) {
+	return inGoAggregate(s.stream, spec)
+}
+
+func (s *memCorpusSource) EvalRule(_ context.Context, q RuleQuery) ([]GroupResult, error) {
+	return inGoEvalRule(s.stream, q)
+}

--- a/internal/routerrules/sweep.go
+++ b/internal/routerrules/sweep.go
@@ -1,0 +1,157 @@
+package routerrules
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// This file is the degradation sweep: it scores the catalog over a grid of
+// operating points (watermark percentile, min_support, pathology prevalence)
+// and reports how detection holds up as each knob moves away from the nominal.
+// It turns the single nominal scorecard into a sensitivity surface — the answer
+// to "how robust is detection when the deployment is tuned differently or the
+// pathology is rare?".
+
+// SweepPoint is one operating point and its measured overall + marginal scores.
+type SweepPoint struct {
+	WatermarkPctile float64
+	MinSupport      int
+	Prevalence      float64
+
+	Overall RuleMetrics
+	// MarginalRecall is recall restricted to classes planted at SevMarginal — the
+	// hardest true positives, the first to be lost as a knob tightens.
+	MarginalRecall float64
+	// SevereRecall is recall over SevSevere classes — these should stay caught
+	// far longer than marginal ones.
+	SevereRecall float64
+}
+
+// SweepAxes declares the grid to sweep. Each axis is varied independently
+// around the nominal (the other two held at their nominal value), so the table
+// reads as three one-dimensional sensitivity curves rather than a full product.
+type SweepAxes struct {
+	Watermarks  []float64
+	MinSupports []int
+	Prevalences []float64
+
+	NominalWatermark  float64
+	NominalMinSupport int
+	NominalPrevalence float64
+	Seed              int64
+}
+
+// RunSweep scores every operating point on the three one-dimensional axes and
+// returns the points in a deterministic order (watermark curve, then
+// min_support curve, then prevalence curve).
+func RunSweep(ctx context.Context, cat *Catalog, ax SweepAxes) ([]SweepPoint, error) {
+	var out []SweepPoint
+	add := func(wm float64, ms int, prev float64) error {
+		pt, err := scorePoint(ctx, cat, ax.Seed, wm, ms, prev)
+		if err != nil {
+			return err
+		}
+		out = append(out, pt)
+		return nil
+	}
+	for _, wm := range ax.Watermarks {
+		if err := add(wm, ax.NominalMinSupport, ax.NominalPrevalence); err != nil {
+			return nil, err
+		}
+	}
+	for _, ms := range ax.MinSupports {
+		if err := add(ax.NominalWatermark, ms, ax.NominalPrevalence); err != nil {
+			return nil, err
+		}
+	}
+	for _, prev := range ax.Prevalences {
+		if err := add(ax.NominalWatermark, ax.NominalMinSupport, prev); err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+
+// scorePoint generates a corpus and scores the catalog at one operating point.
+// The min_support knob is threaded into BOTH the generator (so marginal class
+// sizes track the floor) and the catalog config (so the rule applies the floor).
+func scorePoint(ctx context.Context, cat *Catalog, seed int64, wm float64, ms int, prev float64) (SweepPoint, error) {
+	params := BenchParams{Seed: seed, MinSupport: ms, PathologyPrevalence: prev}
+	corpus := GenerateBenchCorpus(params)
+	cfg := BenchConfig{
+		"router_rules.watermark_percentile":    formatNumeric(wm),
+		"router_rules.cumulative_d_percentile": formatNumeric(wm),
+		"router_rules.min_rows_per_class":      fmt.Sprintf("%d", ms),
+		"query.max_memory_bytes":               "1073741824",
+		"query.max_samples":                    "50000000",
+	}
+	src := corpus.AsCorpusSource()
+	rep, err := NewEvaluator(cat, staticConfigLookup(cfg), src).
+		Evaluate(ctx, EvalOptions{IncludeExperimental: true})
+	if err != nil {
+		return SweepPoint{}, err
+	}
+	m := scoreReport(rep, corpus)
+	pt := SweepPoint{
+		WatermarkPctile: wm, MinSupport: ms, Prevalence: prev,
+		Overall:        m.Overall,
+		MarginalRecall: severityRecall(rep, corpus, SevMarginal),
+		SevereRecall:   severityRecall(rep, corpus, SevSevere),
+	}
+	return pt, nil
+}
+
+// severityRecall computes recall restricted to classes of one planted severity:
+// of all (class, expected-rule) positive pairs at that severity, the fraction
+// the catalog actually fired.
+func severityRecall(rep *Report, corpus *BenchCorpus, sev PathologySeverity) float64 {
+	fired := map[string]map[string]struct{}{}
+	for _, f := range rep.Findings {
+		id := matchClassID(f, corpus)
+		if id == "" {
+			continue
+		}
+		set := fired[id]
+		if set == nil {
+			set = map[string]struct{}{}
+			fired[id] = set
+		}
+		set[f.RuleID] = struct{}{}
+	}
+	var want, got int
+	for i := range corpus.Classes {
+		c := &corpus.Classes[i]
+		if c.Severity != sev {
+			continue
+		}
+		for _, rule := range c.Expect {
+			want++
+			if set, ok := fired[classID(*c)]; ok {
+				if _, hit := set[rule]; hit {
+					got++
+				}
+			}
+		}
+	}
+	if want == 0 {
+		return 1 // no positives at this severity: vacuously perfect.
+	}
+	return float64(got) / float64(want)
+}
+
+// FormatSweepTable renders the sensitivity grid as an aligned text table.
+func FormatSweepTable(points []SweepPoint) string {
+	var sb strings.Builder
+	header := fmt.Sprintf("%8s %4s %6s %5s %5s %5s %9s %9s %9s %9s\n",
+		"WMARK", "MSUP", "PREV", "TP", "FP", "FN", "PRECISION", "RECALL", "REC.MARG", "REC.SEV")
+	sb.WriteString(header)
+	sb.WriteString(strings.Repeat("-", len(header)) + "\n")
+	for _, p := range points {
+		fmt.Fprintf(&sb, "%8.2f %4d %6.2f %5d %5d %5d %9.3f %9.3f %9.3f %9.3f\n",
+			p.WatermarkPctile, p.MinSupport, p.Prevalence,
+			p.Overall.TP, p.Overall.FP, p.Overall.FN,
+			p.Overall.Precision, p.Overall.Recall, p.MarginalRecall, p.SevereRecall)
+	}
+	return sb.String()
+}

--- a/internal/routerrules/sweep_test.go
+++ b/internal/routerrules/sweep_test.go
@@ -1,0 +1,173 @@
+package routerrules
+
+import (
+	"context"
+	"testing"
+)
+
+// nominalSweepAxes is the reference grid: each knob swept independently around
+// the p95 / min-support-5 / nominal-prevalence operating point, on a fixed seed.
+func nominalSweepAxes() SweepAxes {
+	return SweepAxes{
+		Watermarks:        []float64{0.50, 0.75, 0.90, 0.95, 0.99},
+		MinSupports:       []int{1, 3, 5, 8, 12},
+		Prevalences:       []float64{0.5, 1.0, 2.0},
+		NominalWatermark:  0.95,
+		NominalMinSupport: 5,
+		NominalPrevalence: 1.0,
+		Seed:              1,
+	}
+}
+
+// TestDegradationSweep prints the sensitivity surface and asserts its qualitative
+// shape: detection degrades the way the design predicts as each knob moves off
+// the nominal, and severe pathologies are NEVER lost anywhere on the grid.
+func TestDegradationSweep(t *testing.T) {
+	cat := loadCatalogT(t)
+	ax := nominalSweepAxes()
+	pts, err := RunSweep(context.Background(), cat, ax)
+	if err != nil {
+		t.Fatalf("run sweep: %v", err)
+	}
+	t.Logf("router-rules degradation sweep (seed=%d):\n%s", ax.Seed, FormatSweepTable(pts))
+
+	// 1) Severe pathologies are caught at EVERY operating point. A severe class
+	//    sits far past its watermark, so no reasonable tuning should miss it; if
+	//    this breaks, a rule has genuinely regressed, not merely become
+	//    conservative.
+	for _, p := range pts {
+		if p.SevereRecall < 1.0 {
+			t.Errorf("severe pathology missed at wm=%.2f msup=%d prev=%.2f: severe recall=%.3f",
+				p.WatermarkPctile, p.MinSupport, p.Prevalence, p.SevereRecall)
+		}
+	}
+
+	// 2) The watermark precision/recall tradeoff is monotone in the expected
+	//    direction: loosening the watermark cannot IMPROVE precision (it admits
+	//    more of the healthy body as false positives). Compare the loosest and
+	//    nominal watermark points.
+	loose := pointAt(t, pts, 0.50, 5, 1.0)
+	nominal := pointAt(t, pts, 0.95, 5, 1.0)
+	if loose.Overall.Precision >= nominal.Overall.Precision {
+		t.Errorf("loosening the watermark to 0.50 should hurt precision vs nominal 0.95: loose=%.3f nominal=%.3f",
+			loose.Overall.Precision, nominal.Overall.Precision)
+	}
+
+	// 3) The min_support floor trades recall for precision: a tiny floor (1)
+	//    admits thin false-positive classes, so its precision is strictly worse
+	//    than the nominal floor.
+	tinyFloor := pointAt(t, pts, 0.95, 1, 1.0)
+	if tinyFloor.Overall.Precision >= nominal.Overall.Precision {
+		t.Errorf("a min_support floor of 1 should admit thin false positives vs nominal floor 5: floor1=%.3f nominal=%.3f",
+			tinyFloor.Overall.Precision, nominal.Overall.Precision)
+	}
+
+	// 4) An over-tight watermark (0.99) starts losing the marginal class set —
+	//    the design's stated tradeoff (precision over recall as you tighten). It
+	//    must lose SOME marginal recall relative to nominal but keep severe
+	//    recall perfect (already asserted in 1).
+	tight := pointAt(t, pts, 0.99, 5, 1.0)
+	if tight.MarginalRecall >= nominal.MarginalRecall {
+		t.Errorf("over-tight watermark 0.99 should lose marginal recall vs nominal 0.95: tight=%.3f nominal=%.3f",
+			tight.MarginalRecall, nominal.MarginalRecall)
+	}
+
+	// 5) At nominal, precision and recall are both perfect — the corpus is
+	//    well-separated, so the catalog should make no errors there. This pins the
+	//    sweet spot the other axes degrade away from.
+	if nominal.Overall.Precision != 1.0 || nominal.Overall.Recall != 1.0 {
+		t.Errorf("nominal operating point should be perfect, got precision=%.3f recall=%.3f",
+			nominal.Overall.Precision, nominal.Overall.Recall)
+	}
+
+	// 6) A rare deployment (prevalence < nominal) starves its marginal pathologies
+	//    below the support floor, so marginal recall drops while severe recall
+	//    stays perfect. This proves the prevalence axis actually moves a metric —
+	//    the old size clamp pinned every prevalence to an identical corpus, leaving
+	//    the axis inert.
+	rare := pointAt(t, pts, 0.95, 5, 0.5)
+	if rare.MarginalRecall >= nominal.MarginalRecall {
+		t.Errorf("rare prevalence 0.50 should lose marginal recall vs nominal 1.00: rare=%.3f nominal=%.3f",
+			rare.MarginalRecall, nominal.MarginalRecall)
+	}
+	if rare.SevereRecall != 1.0 {
+		t.Errorf("severe recall must stay perfect even at rare prevalence 0.50: got %.3f", rare.SevereRecall)
+	}
+
+	// 7) Inert-axis guard: every swept axis must move SOME metric. If an axis's
+	//    entire grid collapses to one identical score, the axis is dead weight
+	//    (the prevalence regression that triggered this redo). This guard fails
+	//    loudly so a future clamp/grid change can't silently neuter an axis.
+	assertAxisNotInert(t, "watermark", pts, ax, func(p SweepPoint) (float64, bool) {
+		return p.WatermarkPctile, p.MinSupport == ax.NominalMinSupport && p.Prevalence == ax.NominalPrevalence
+	})
+	assertAxisNotInert(t, "min_support", pts, ax, func(p SweepPoint) (float64, bool) {
+		return float64(p.MinSupport), p.WatermarkPctile == ax.NominalWatermark && p.Prevalence == ax.NominalPrevalence
+	})
+	assertAxisNotInert(t, "prevalence", pts, ax, func(p SweepPoint) (float64, bool) {
+		return p.Prevalence, p.WatermarkPctile == ax.NominalWatermark && p.MinSupport == ax.NominalMinSupport
+	})
+}
+
+// scoreFingerprint is the tuple of measured scores at one operating point. Two
+// grid points sharing a fingerprint are indistinguishable — the mark of an inert
+// axis when they sit on the same swept axis at different knob values.
+type scoreFingerprint struct {
+	tp, fp, fn                   int
+	marginalRecall, severeRecall float64
+	precision, recall            float64
+}
+
+func fingerprint(p SweepPoint) scoreFingerprint {
+	return scoreFingerprint{
+		tp: p.Overall.TP, fp: p.Overall.FP, fn: p.Overall.FN,
+		marginalRecall: p.MarginalRecall, severeRecall: p.SevereRecall,
+		precision: p.Overall.Precision, recall: p.Overall.Recall,
+	}
+}
+
+// assertAxisNotInert fails if EVERY point on the named axis (selected by sel,
+// which returns the axis knob value and whether the point lies on that axis with
+// the other knobs nominal) shares one identical score fingerprint. An axis whose
+// whole grid collapses to a single score moves no metric and is dead weight —
+// the prevalence regression this guard exists to catch. (A saturated plateau
+// where SOME but not all points match is fine; the axis still bends elsewhere.)
+func assertAxisNotInert(t *testing.T, axis string, pts []SweepPoint, _ SweepAxes, sel func(SweepPoint) (float64, bool)) {
+	t.Helper()
+	type knobPoint struct {
+		knob float64
+		fp   scoreFingerprint
+	}
+	var axisPts []knobPoint
+	for _, p := range pts {
+		if knob, on := sel(p); on {
+			axisPts = append(axisPts, knobPoint{knob: knob, fp: fingerprint(p)})
+		}
+	}
+	if len(axisPts) < 2 {
+		t.Fatalf("inert-axis guard: %s axis has %d grid points, need at least 2 to detect inertness", axis, len(axisPts))
+	}
+	allSame := true
+	for _, kp := range axisPts[1:] {
+		if kp.fp != axisPts[0].fp {
+			allSame = false
+			break
+		}
+	}
+	if allSame {
+		t.Errorf("inert %s axis: all %d grid points produce identical scores %+v — the axis moves no metric across its entire range",
+			axis, len(axisPts), axisPts[0].fp)
+	}
+}
+
+// pointAt returns the swept point matching the three knobs, failing if absent.
+func pointAt(t *testing.T, pts []SweepPoint, wm float64, ms int, prev float64) SweepPoint {
+	t.Helper()
+	for _, p := range pts {
+		if p.WatermarkPctile == wm && p.MinSupport == ms && p.Prevalence == prev {
+			return p
+		}
+	}
+	t.Fatalf("no swept point at wm=%.2f msup=%d prev=%.2f", wm, ms, prev)
+	return SweepPoint{}
+}


### PR DESCRIPTION
Offline benchmark that scores the router-rules catalog over a **synthetic, self-labeled** corpus as precision / recall / F1 per rule, plus a three-axis degradation sweep and numeric regression floors. Re-done on a clean branch off `main` (the earlier history committed a 36 MB compiled `route-rules` binary at repo root; this branch carries only the source, and the binary is gitignored).

## Honest framing (what this is, and isn't)

This is a **detection-fidelity / regression** gate, **not** a real-world rule-effectiveness measurement. The corpus labels share provenance with the rules' p95-watermark thresholds — the same model decides both what counts as a planted pathology and what each rule fires on — so a perfect score proves the rules detect what the model says they should and pins that against regressions. It does **not** prove the rules catch real production incidents (that would need labels grounded in real incident outcomes, which this corpus does not have). The wording is consistent across `benchmark.go`, `metrics.go`, `benchmark_test.go`, `cmd/route-rules`, and `docs/router-rules.md`.

## What's here

- `benchmark.go` — fabricated, seed-deterministic labeled corpus (no production-identifying values); every class carries the rule ids that *should* fire plus a severity (`severe` / `marginal`). Folded through the same matcher + `quantileExact` path the JSONL/CH backends use.
- `metrics.go` — class-granularity precision / recall / F1 per rule + micro-averaged overall.
- `sweep.go` + `sweep_test.go` — sweeps `watermark_percentile`, `min_rows_per_class`, and **pathology prevalence** around nominal.
- `regression_floor_test.go` — numeric floors (the only place numbers belong; the shipped catalog stays number-free).
- `route-rules benchmark` CLI subcommand; `chdb`-tagged parity test re-runs through the CH SQL backend and asserts identical findings + metrics.

## Prevalence axis fixed (was inert)

The old size clamp (`min_support+1`) pinned every prevalence to a byte-identical corpus, so the axis moved no metric. Now **severe** classes keep the firing floor (so `SevereRecall=1.0` holds across the whole grid), while **marginal** classes get only a one-row existence floor — so a rare deployment genuinely starves them below support and loses their detection: marginal recall `0.5→0.76`, `1.0→1.0`, `2.0→0.96`. Added an explicit prevalence-degradation assertion **and** a general **inert-axis guard** that fails if any swept axis collapses to a single identical score, so a future clamp/grid change can't silently neuter an axis.

## Floors kept (they bite)

Severe-recall floored at `1.0` everywhere (including off-nominal prevalence); cross-seed sane-range `R≥0.90` / `P≥0.80` floors retained. Overall recall/precision floors apply at nominal prevalence — prevalence-driven marginal loss is *expected* degradation, not a regression.

## resolve.go doc/perf correction

`ParamResolver`'s doc claimed an AggSpec-batching optimization (`O(distinct scope-groups) scans, not O(params)`) the code never had — `Resolve` loops one full corpus pass per corpus-kind param. Corrected the doc to match reality (`~O(corpus-params)` passes), left a `ponytail:` note naming batching as the upgrade path, and added `TestResolveScanCount` pinning the actual scan count so the doc can't drift again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)