### PR TITLE
ci(lint): exclude .claude worktrees from golangci-lint scan

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -132,15 +132,22 @@ linters:
     lll:
       line-length: 280
   exclusions:
-    # Drop sibling agent worktrees from discovery. Lefthook pre-push runs
-    # `golangci-lint run ./...` from the active worktree root; without this
-    # exclusion any file under `.claude/worktrees/<other-agent>/...` (a
-    # parallel worktree's tree) gets reachable via explicit path / IDE
-    # integration and surfaces lint findings unrelated to the committer's
-    # change. The pattern is anchored on the literal segment so it matches
-    # both `.claude/worktrees/agent-…/…` and any nested re-entry.
+    # Drop sibling-worktree leakage. Lefthook pre-push runs
+    # `golangci-lint run ./...` from a worktree root under
+    # `.claude/worktrees/<name>/`; the golangci cache is shared (keyed
+    # by the single module path), so a run can surface OTHER agents'
+    # worktrees — reported relative to cwd as either a `.claude/...`
+    # segment (this tree's own nested re-entry) or `../<name>/...` (a
+    # collapsed sibling, where the shared `.claude/worktrees/` prefix
+    # is elided). Cerberus is one module rooted at go.mod, so `go list
+    # ./...` never yields a parent-relative package — any reported path
+    # that escapes upward via `..` is foreign-worktree noise, never the
+    # committer's change. Match both shapes. (`exclusions.paths` is the
+    # only directory-skip key the golangci-lint v2 schema accepts;
+    # `run.exclude-dirs` / `issues.exclude-dirs` are rejected.)
     paths:
-      - \.claude/worktrees
+      - (^|/)\.claude($|/)
+      - (^|/)\.\.($|/)
     rules:
       - path: _test\.go
         linters:


### PR DESCRIPTION
## Problem

Lefthook's `pre-push` hook runs `golangci-lint run ./...` from each agent's per-task worktree (rooted under `.claude/worktrees/<name>/`). Because the golangci-lint cache is shared across worktrees (keyed by the single module path `github.com/tsouza/cerberus`), a run intermittently surfaces **other concurrent agents' worktrees**, reported relative to cwd as `../<name>/...` (a collapsed sibling) or a `.claude/...` segment. Those foreign findings (gosec/ineffassign/etc. from unrelated branches) produced **false pre-push failures on changes that are themselves clean**.

## Why the existing exclusion didn't work

The committed `exclusions.paths: [\.claude/worktrees]` never matched the leaked form. Sibling worktrees collapse to `../agent-…/…` with the shared `.claude/worktrees/` prefix **elided**, so the literal `.claude` segment is absent from the reported path.

## Fix

Broaden `exclusions.paths` to two regexes covering both reported shapes:

```yaml
paths:
  - (^|/)\.claude($|/)   # this tree's own nested re-entry, any abs .claude
  - (^|/)\.\.($|/)       # any parent-escape — foreign-worktree noise
```

Cerberus is a single module rooted at `go.mod`, so `go list ./...` never yields a parent-relative package; any reported path that escapes upward via `..` is, by construction, a foreign worktree, never the committer's change.

`exclusions.paths` is the **only** directory-skip key the golangci-lint **v2** schema accepts — `run.exclude-dirs` and `issues.exclude-dirs` are both rejected by the schema (verified with `golangci-lint config verify` against v2.12.2).

## Verification

- `golangci-lint config verify` → valid (exit 0).
- A throwaway lint-dirty file under `.claude/worktrees/x/` fires under `--no-config` but is excluded under the project config (both the `.claude/...` and `../...` reported forms). Throwaway removed, not committed.
- `golangci-lint run ./...` on the real change → 0 issues, 0 loader warnings.

## Scope

No-op for CI: CI checks out a clean repo with no `.claude/worktrees`, so this only fixes the **local** pre-push false-failure. `lefthook.yml` left untouched — the central `.golangci.yml` exclusion is the durable fix and is sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)