### PR TITLE
ci(release): auto-retire the out-of-window release line on a new minor (active EOL)

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -232,21 +232,40 @@ wrapper, plus `appendStepSummary` / `setOutput` for the runner files.
   a push to a line 3+ minors behind the current minor (derived from the stable
   `v*` tag set, listed via the API so no fetch-depth is needed) is REFUSED
   before any artifact publishes, independent of how green the commit is. See
-  `docs/operations.md` "Release support window / EOL policy". Pure exported
-  `MAINTENANCE_BRANCH_RE` + `currentMinor(tags)` + `supportWindowProblem({branch,
-  tags, windowSize})` + `evaluate({branchHead, pushedSha, checkRuns, statuses,
-  selfJobs, branchLabel, tags})` (no network, no `process.exit`) + a
-  `--self-test`.
-  - Env: `GITHUB_TOKEN` (checks:read + statuses:read + contents:read),
-    `GITHUB_REPOSITORY`, `GITHUB_SHA` (pushed commit), `GITHUB_REF_NAME` (must
-    be `release/<major>.<minor>.x`), `GITHUB_API_URL` (default
-    `https://api.github.com`), `RELEASE_SELF_JOBS` (comma-separated self-job
-    names to exclude); argv `--self-test` runs the assertion suite.
-  - Exit: `0` when the line is in-window, the commit is the branch tip, and all
-    gated checks are green (or a green self-test); `1` on an end-of-life line,
-    any red/running gated check, a non-tip / unresolved commit, a
-    non-maintenance `GITHUB_REF_NAME` (a wiring error), or a missing required
-    env var.
+  `docs/operations.md` "Release support window / EOL policy". The SAME module
+  also drives the **active** half of the EOL policy via the `eol-retire-line`
+  command (the `eol-retire` job in `release.yml`): post-publish, it computes the
+  line that just fell out of the window with `retireLineForPublish` (the same
+  `SUPPORTED_MINOR_LINES` math — publishing `1.6.0` retires `release/1.3.x`) and
+  DELETES that `release/X.W.x` branch via the Git refs API iff it exists.
+  Conservative + fail-open: it retires at most one line, only on a minor open
+  (`X.Y.0`, `Y>0`) — patches / major bumps / backports / prereleases retire
+  nothing — deletes only a provably out-of-window branch that exists (idempotent
+  on a 404) with a `supportWindowProblem` cross-check, and ANY deletion failure
+  logs `::error::` and still exits 0 (the release already published). Pure
+  exported `MAINTENANCE_BRANCH_RE` + `currentMinor(tags)` +
+  `supportWindowProblem({branch, tags, windowSize})` +
+  `retireLineForPublish({version, tags, windowSize})` + `evaluate({branchHead,
+  pushedSha, checkRuns, statuses, selfJobs, branchLabel, tags})` (no network, no
+  `process.exit`) + a `--self-test`.
+  - Env (preflight, default command): `GITHUB_TOKEN` (checks:read +
+    statuses:read + contents:read), `GITHUB_REPOSITORY`, `GITHUB_SHA` (pushed
+    commit), `GITHUB_REF_NAME` (must be `release/<major>.<minor>.x`),
+    `GITHUB_API_URL` (default `https://api.github.com`), `RELEASE_SELF_JOBS`
+    (comma-separated self-job names to exclude).
+  - Env (`eol-retire-line` command): `GITHUB_TOKEN` (contents:write — the
+    workflow passes `RELEASE_PAT || github.token`), `GITHUB_REPOSITORY`,
+    `RELEASE_APP_VERSION` (the just-published `X.Y.Z`), `GITHUB_API_URL`.
+  - Args: argv `--self-test` runs the assertion suite; `eol-retire-line` runs
+    the active-EOL retirement; no command runs the maintenance preflight gate.
+  - Exit (preflight): `0` when the line is in-window, the commit is the branch
+    tip, and all gated checks are green (or a green self-test); `1` on an
+    end-of-life line, any red/running gated check, a non-tip / unresolved
+    commit, a non-maintenance `GITHUB_REF_NAME` (a wiring error), or a missing
+    required env var.
+  - Exit (`eol-retire-line`): `0` always (fail-open — a retirement failure must
+    never fail an already-published release); `1` only on a gross wiring error
+    (missing repo/token) before any publish-affecting work.
 - **`chart-kubeconform.mjs`** — `chart-ci.yml`, the `Render + kubeconform`
   step. Renders the chart for the default values and every `ci/*-values.yaml`
   fixture, schema-validates each manifest set with `kubeconform -strict`, and

--- a/.github/scripts/release-preflight.mjs
+++ b/.github/scripts/release-preflight.mjs
@@ -85,6 +85,11 @@ export const SUPPORTED_MINOR_LINES = 3;
 // suffix like `-rc.1` does NOT establish a new supported line).
 const APP_TAG_RE = /^v(\d+)\.(\d+)\.\d+$/;
 
+// A just-published app version, `<major>.<minor>.<patch>` (no `v`, stable). The
+// active-EOL retirement helper takes this shape (it is what the release gate
+// publishes — `release-version-gate.mjs` emits `version` without the `v`).
+const APP_VERSION_RE = /^(\d+)\.(\d+)\.(\d+)$/;
+
 // ---------------------------------------------------------------------------
 // pure core (exported for the self-test — no network, no process.exit)
 // ---------------------------------------------------------------------------
@@ -136,6 +141,57 @@ export function supportWindowProblem({ branch, tags, windowSize = SUPPORTED_MINO
     );
   }
   return null;
+}
+
+// retireLineForPublish — ACTIVE EOL. Given a just-published app version
+// `X.Y.Z` and the released `v*` tag set, return the maintenance branch name of
+// the line that just fell OUT of the support window (so the release job can
+// delete it), or null when nothing should be retired.
+//
+// The math is the SAME window as `supportWindowProblem` — `SUPPORTED_MINOR_LINES`
+// is the single source of truth. When a NEW minor opens (`Z == 0`), the window
+// slides forward by one and the line `SUPPORTED_MINOR_LINES` behind the new
+// minor drops off: publishing `X.Y.0` makes `X.(Y - SUPPORTED_MINOR_LINES).x`
+// end-of-life. With a 3-line window, shipping 1.6.0 retires release/1.3.x.
+//
+// Conservative by construction — retires AT MOST one line, and only when:
+//   - the version parses as a stable `X.Y.Z` (no prerelease suffix);
+//   - it is a MINOR open (`Z == 0`) AND not a major bump (`Y > 0`). A patch
+//     (`Z > 0`) leaves the window unchanged → null. A MAJOR bump (`Y == 0`)
+//     is deliberately scoped OUT: retiring a whole prior major's lines on a
+//     `X.0.0` is a bigger policy call, so this returns null and leaves those
+//     lines to the maintainer (the passive `supportWindowProblem` gate still
+//     refuses to PUBLISH on them). See docs/operations.md.
+//   - the computed minor index is >= 0 (early minors like 1.0/1.1/1.2 under a
+//     3-line window retire nothing — there is no line that far back yet);
+//   - the just-published minor is actually the (new) HIGHEST released minor.
+//     A stable BACKPORT cut after a newer minor — e.g. publishing 1.4.2 while
+//     1.6.0 is already out — must NOT slide the window or retire anything; the
+//     window is anchored to the current (highest) minor, not to whatever was
+//     just published. Guarded by comparing against `currentMinor(tags)`.
+//
+// Returns the branch NAME only (`release/X.W.x`); the caller checks existence
+// and performs the delete (idempotent when the branch is already gone).
+export function retireLineForPublish({ version, tags, windowSize = SUPPORTED_MINOR_LINES }) {
+  const m = APP_VERSION_RE.exec(version ?? '');
+  if (!m) return null; // not a stable X.Y.Z (e.g. prerelease / chart / junk)
+  const major = Number(m[1]);
+  const minor = Number(m[2]);
+  const patch = Number(m[3]);
+
+  if (patch !== 0) return null; // patch release — window unchanged
+  if (minor === 0) return null; // major bump (X.0.0) — out of scope, see note
+
+  // Anchor to the highest released minor. If a NEWER minor than the one just
+  // published already exists in the tag set, this publish is a backport and
+  // must not move the window.
+  const cur = currentMinor(tags);
+  if (cur && (cur[0] > major || (cur[0] === major && cur[1] > minor))) return null;
+
+  const retireMinor = minor - windowSize;
+  if (retireMinor < 0) return null; // no line that far back exists yet
+
+  return `release/${major}.${retireMinor}.x`;
 }
 
 // evaluate — given the branch tip sha, the pushed sha, the commit's raw
@@ -341,6 +397,40 @@ function selfTest() {
   });
   assert(r.problems.length === 0, 'in-window green line should pass: ' + r.problems.join('; '));
 
+  // --- active EOL: retireLineForPublish ------------------------------------
+  // The window math is shared with supportWindowProblem (SUPPORTED_MINOR_LINES),
+  // so a minor open retires the line exactly SUPPORTED_MINOR_LINES behind it.
+  const retire = (version, tags = []) => retireLineForPublish({ version, tags });
+
+  // Worked example from the brief: publish 1.6.0 -> retire release/1.3.x.
+  assert(retire('1.6.0', ['v1.6.0', 'v1.5.0', 'v1.4.0', 'v1.3.0']) === 'release/1.3.x', '1.6.0 retires release/1.3.x');
+  // 1.5.0 -> retire release/1.2.x (matches the docs worked example).
+  assert(retire('1.5.0', ['v1.5.0', 'v1.4.0', 'v1.3.0', 'v1.2.0']) === 'release/1.2.x', '1.5.0 retires release/1.2.x');
+  // A patch release retires nothing — window unchanged.
+  assert(retire('1.5.1', ['v1.5.1', 'v1.5.0', 'v1.4.0']) === null, '1.5.1 (patch) retires nothing');
+  // No prior line that far back yet (early minors under a 3-line window).
+  assert(retire('1.0.0', ['v1.0.0']) === null, '1.0.0 has no line 3 minors back -> noop');
+  assert(retire('1.2.0', ['v1.2.0', 'v1.1.0', 'v1.0.0']) === null, '1.2.0: would-be -1.x line does not exist -> noop');
+  // A MAJOR bump is out of scope — conservative, retires nothing here.
+  assert(retire('2.0.0', ['v2.0.0', 'v1.6.0', 'v1.5.0']) === null, 'major bump 2.0.0 retires nothing (scoped out)');
+  // A stable BACKPORT cut after a newer minor must NOT slide the window.
+  assert(retire('1.4.0', ['v1.6.0', 'v1.5.0', 'v1.4.0']) === null, 'backport 1.4.0 behind current 1.6 retires nothing');
+  // The retire-line is idempotent at the helper level: same inputs, same name
+  // (existence/deletion is the caller's job).
+  assert(retire('1.6.0', ['v1.6.0', 'v1.5.0']) === 'release/1.3.x', 'retire-line is deterministic regardless of branch presence');
+  // Non-stable / non-version inputs are ignored.
+  assert(retire('1.6.0-rc.1', ['v1.6.0-rc.1']) === null, 'prerelease publish retires nothing');
+  assert(retire('chart-v0.6.3', []) === null, 'chart version is not an app version -> noop');
+  assert(retire('', []) === null, 'empty version -> noop');
+  // The retired line is, by construction, the line supportWindowProblem now
+  // calls EOL — cross-check the two share the window.
+  {
+    const tags = ['v1.6.0', 'v1.5.0', 'v1.4.0', 'v1.3.0'];
+    const line = retireLineForPublish({ version: '1.6.0', tags });
+    assert(/end-of-life/.test(supportWindowProblem({ branch: line, tags })), 'the retired line is EOL per supportWindowProblem');
+    assert(supportWindowProblem({ branch: 'release/1.4.x', tags }) === null, 'the line kept (1.4.x) is still in-window');
+  }
+
   ghNotice('release-preflight --self-test: all assertions passed');
 }
 
@@ -459,12 +549,163 @@ async function main() {
   process.exit(0);
 }
 
+// ---------------------------------------------------------------------------
+// active-EOL driver — `eol-retire-line`
+// ---------------------------------------------------------------------------
+//
+// Runs POST-publish, after a NEW app version actually shipped. Computes the
+// line that just fell out of the support window via `retireLineForPublish`
+// (shared window math) and, if its `release/X.W.x` branch EXISTS, DELETES it.
+//
+// FAIL-OPEN by contract: the release already published before this runs, so a
+// deletion failure must NEVER fail the workflow. Every error path logs loudly
+// (`::error::` / `::notice::`) and still exits 0. The only non-zero exit is a
+// gross wiring error (missing repo/token) BEFORE any publish-affecting work —
+// but the workflow gates this step on a successful publish, so even that is
+// observability, not a release-failing condition (the step is `if:`-guarded and
+// could be marked continue-on-error too; we keep exit 0 to be safe regardless).
+//
+// Mechanism: deletes the ref via the Git refs API with the token in
+// GITHUB_TOKEN. The workflow passes RELEASE_PAT (fine-grained, contents:write)
+// when present, else the default github.token — both can delete an UNPROTECTED
+// `release/*.x` branch (verified: no ruleset / classic protection covers
+// `release/*`, only `main`). If a future ruleset protects `release/*`, wire a
+// bypass for the PAT identity; the fail-open contract means a 403 just logs.
+//
+// Env contract:
+//   GITHUB_TOKEN       token with contents:write (RELEASE_PAT or github.token).
+//   GITHUB_REPOSITORY  "owner/name".
+//   RELEASE_APP_VERSION the just-published app version, `X.Y.Z` (no `v`).
+//   GITHUB_API_URL     API base (default https://api.github.com).
+async function retireLine() {
+  const repo = process.env.GITHUB_REPOSITORY;
+  const token = process.env.GITHUB_TOKEN;
+  const version = process.env.RELEASE_APP_VERSION ?? '';
+  const apiBase = process.env.GITHUB_API_URL || 'https://api.github.com';
+
+  if (!repo || !token) {
+    ghError('eol-retire-line: GITHUB_REPOSITORY and GITHUB_TOKEN are required');
+    process.exit(1);
+  }
+
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+  };
+
+  // All tags — the window anchors to the highest released stable minor. Fetched
+  // via the API so the step needs no fetch-depth. Fail-open: if we cannot list
+  // tags we cannot safely compute the window, so we retire nothing and return.
+  async function allTags() {
+    const out = [];
+    let page = 1;
+    for (;;) {
+      const res = await fetch(`${apiBase}/repos/${repo}/tags?per_page=100&page=${page}`, { headers });
+      if (!res.ok) throw new Error(`GET tags -> ${res.status} ${res.statusText}`);
+      const data = await res.json();
+      const names = (data ?? []).map((t) => t.name);
+      out.push(...names);
+      if (names.length < 100) break;
+      page += 1;
+    }
+    return out;
+  }
+
+  let tags;
+  try {
+    tags = await allTags();
+  } catch (e) {
+    ghError(`eol-retire-line: could not list tags (${e.message}) — retiring nothing this run (fail-open)`);
+    process.exit(0);
+  }
+
+  const line = retireLineForPublish({ version, tags });
+  if (!line) {
+    ghNotice(
+      `eol-retire-line: publishing ${version || '(none)'} retires no line ` +
+        `(patch / major / early-minor / backport / non-stable — window unchanged).`,
+    );
+    process.exit(0);
+  }
+
+  const branch = line; // `release/X.W.x`
+  const ref = `heads/${branch}`;
+
+  // Does the branch exist? A 404 means it was already retired — idempotent noop.
+  let exists;
+  try {
+    const res = await fetch(`${apiBase}/repos/${repo}/git/ref/${ref}`, { headers });
+    if (res.status === 404) exists = false;
+    else if (res.ok) exists = true;
+    else throw new Error(`GET ref ${ref} -> ${res.status} ${res.statusText}`);
+  } catch (e) {
+    ghError(`eol-retire-line: could not check ${branch} existence (${e.message}) — skipping delete (fail-open)`);
+    process.exit(0);
+  }
+
+  if (!exists) {
+    ghNotice(`eol-retire-line: ${branch} is out-of-window but already absent — nothing to delete (idempotent).`);
+    process.exit(0);
+  }
+
+  // SAFETY BACKSTOP: never delete a line the support-window math considers
+  // in-window. `retireLineForPublish` already guarantees this, but cross-check
+  // against `supportWindowProblem` before the destructive call — a line that is
+  // NOT EOL must never be deleted, full stop.
+  if (!supportWindowProblem({ branch, tags })) {
+    ghError(
+      `eol-retire-line: refusing to delete ${branch} — supportWindowProblem says it is IN-WINDOW. ` +
+        `This is a logic contradiction; retiring nothing (fail-open).`,
+    );
+    process.exit(0);
+  }
+
+  // Delete the ref. Fail-open on any error (403 protected, 422, network …).
+  try {
+    const res = await fetch(`${apiBase}/repos/${repo}/git/refs/${ref}`, { method: 'DELETE', headers });
+    if (res.status === 204) {
+      ghNotice(
+        `eol-retire-line: deleted ${branch} — it fell out of the latest-${SUPPORTED_MINOR_LINES} support window ` +
+          `when ${version} shipped (active EOL). Tags / Releases for that line are retained.`,
+      );
+      process.exit(0);
+    }
+    const body = await res.text().catch(() => '');
+    ghError(
+      `eol-retire-line: DELETE ${branch} -> ${res.status} ${res.statusText} ${body} — ` +
+        `branch NOT deleted. Release already published; delete it manually: ` +
+        `git push origin --delete ${branch}. (fail-open)`,
+    );
+    process.exit(0);
+  } catch (e) {
+    ghError(
+      `eol-retire-line: DELETE ${branch} failed (${e.message}) — branch NOT deleted. ` +
+        `Release already published; delete it manually: git push origin --delete ${branch}. (fail-open)`,
+    );
+    process.exit(0);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// dispatcher
+// ---------------------------------------------------------------------------
+
 if (process.argv.includes('--self-test')) {
   selfTest();
   process.exit(0);
 }
 
-main().catch((e) => {
-  ghError(`release-preflight failed: ${e.message}`);
-  process.exit(1);
-});
+const cmd = process.argv[2];
+if (cmd === 'eol-retire-line') {
+  retireLine().catch((e) => {
+    // Even an unexpected throw is fail-open: the release already shipped.
+    ghError(`eol-retire-line: unexpected failure (${e.message}) — retiring nothing (fail-open)`);
+    process.exit(0);
+  });
+} else {
+  main().catch((e) => {
+    ghError(`release-preflight failed: ${e.message}`);
+    process.exit(1);
+  });
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -317,6 +317,61 @@ jobs:
           repository: tsouza/cerberus
           readme-filepath: ./README.md
 
+  # Active EOL — after a NEW app version actually publishes, retire the release
+  # line that just fell out of the latest-3-minor support window by DELETING its
+  # `release/<major>.<minor>.x` maintenance branch (e.g. publishing v1.6.0
+  # retires release/1.3.x). This is the ACTIVE half of the EOL policy; the
+  # PASSIVE half (refusing to PUBLISH on an out-of-window line) lives in the
+  # `preflight` gate. Both share `release-preflight.mjs`'s window math
+  # (SUPPORTED_MINOR_LINES) — single source of truth, no duplicated arithmetic.
+  #
+  # Guards (all in release-preflight.mjs `retireLineForPublish` + the
+  # `eol-retire-line` driver):
+  #   - runs ONLY after goreleaser SUCCEEDED (a real new-version publish);
+  #   - retires AT MOST one line, ONLY on a minor open (X.Y.0, Y>0). Patches +
+  #     major bumps + backports + prereleases retire nothing;
+  #   - deletes ONLY a provably out-of-window line that EXISTS (idempotent: a
+  #     404 / already-absent branch is a clean noop), with a cross-check against
+  #     `supportWindowProblem` before the destructive call;
+  #   - FAIL-OPEN: the release already published, so ANY deletion failure
+  #     (token perms, protection, network) logs loudly via `::error::` and the
+  #     step still exits 0 — a retirement hiccup never fails a shipped release.
+  #     `continue-on-error: true` is belt-and-braces on top of the in-script
+  #     fail-open.
+  #
+  # Token: RELEASE_PAT (fine-grained, contents:write) when present, else the
+  # default GITHUB_TOKEN — both can delete an UNPROTECTED `release/*.x` branch
+  # (no ruleset / classic branch protection covers `release/*`; only `main` is
+  # protected). See docs/operations.md "Release support window / EOL policy".
+  eol-retire:
+    name: eol-retire
+    needs: [gate, goreleaser]
+    # Only when a NEW app version actually published (goreleaser ran + succeeded).
+    # No `always()`: if goreleaser was skipped or failed, nothing shipped, so the
+    # window did not move and there is nothing to retire.
+    if: needs.gate.outputs.app_publish == 'true' && needs.goreleaser.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      # Deleting a branch ref needs contents:write. (The job uses RELEASE_PAT
+      # when present; this scope covers the github.token fallback.)
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: retire-line self-test
+        run: node .github/scripts/release-preflight.mjs --self-test
+
+      - name: Retire the out-of-window release line (active EOL)
+        continue-on-error: true
+        env:
+          # RELEASE_PAT (fine-grained contents:write) deletes the branch even if
+          # a future ruleset protects `release/*` and grants the PAT bypass;
+          # falls back to github.token, which suffices for today's unprotected
+          # `release/*.x` branches.
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
+          RELEASE_APP_VERSION: ${{ needs.gate.outputs.app_version }}
+        run: node .github/scripts/release-preflight.mjs eol-retire-line
+
   # Chart release — publish the Helm chart to GHCR as an OCI artifact, cosign-
   # sign it keyless, attest provenance, and (idempotently) push Artifact Hub
   # metadata. Runs ONLY when the chart gate says the chart `version:` is new.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -801,7 +801,8 @@ the two prior. When a new minor ships, the line that becomes **3 minors behind**
 the current minor reaches **end-of-life (EOL)**. An EOL line:
 
 - gets **no further hotfixes**;
-- has its `release/<major>.<minor>.x` maintenance branch **deleted**;
+- has its `release/<major>.<minor>.x` maintenance branch **deleted
+  automatically** when the new minor ships (the `eol-retire` job — see below);
 - has its maintenance-line **publish/CI disabled** (the `preflight` gate refuses
   to publish a push on an out-of-window line — see below).
 
@@ -814,14 +815,38 @@ charts, and binaries are never unpublished.
 `1.2.x` and older: `release/1.2.x` was deleted, `v1.2.*` tags and Releases stay
 up. `1.4.x` and `1.3.x` remain supported and keep taking backports.
 
-**Enforcement.** The support window is enforced in the maintenance-release
-`preflight` (`.github/scripts/release-preflight.mjs`, `supportWindowProblem` /
-`SUPPORTED_MINOR_LINES`): a push to a `release/<major>.<minor>.x` line that is
-3+ minors behind the current minor (derived from the stable `v*` tag set) is
-**refused** before any artifact publishes — independent of how green the commit
-is. Branch deletion itself is a manual maintainer step performed when the new
-minor ships (this gate is the publish-side backstop, not the branch-ops
-automation).
+**Enforcement.** The support window is enforced on both halves of the EOL
+policy, sharing one piece of window math
+(`.github/scripts/release-preflight.mjs`, `SUPPORTED_MINOR_LINES` — single
+source of truth):
+
+- **Passive (publish refusal).** The maintenance-release `preflight`
+  (`supportWindowProblem`) refuses a push to a `release/<major>.<minor>.x` line
+  that is 3+ minors behind the current minor (derived from the stable `v*` tag
+  set) — **before** any artifact publishes, independent of how green the commit
+  is. An out-of-window line takes no further hotfixes.
+- **Active (branch retirement).** When a NEW minor actually ships, the
+  `eol-retire` job in `release.yml` deletes the maintenance branch that just
+  fell out of the window **automatically** — no manual maintainer step. It runs
+  only after a successful new-version publish, computes the line via
+  `retireLineForPublish` (the same `SUPPORTED_MINOR_LINES` window: publishing
+  `1.6.0` retires `release/1.3.x`), and deletes that `release/X.W.x` branch iff
+  it exists. Guards: it retires **at most one** line and **only on a minor open**
+  (`X.Y.0`, `Y>0`) — patches, major bumps, stable backports, and prereleases
+  retire nothing; it deletes **only** a provably out-of-window branch that
+  exists (idempotent — an already-absent branch is a clean no-op), with a
+  `supportWindowProblem` cross-check before the destructive call; and it is
+  **fail-open** — the release has already published, so any deletion failure
+  (token, future protection, network) logs loudly and the step still succeeds,
+  leaving a one-line manual `git push origin --delete release/X.W.x` as the
+  fallback. The job uses `RELEASE_PAT` (fine-grained, `contents:write`) when
+  present and falls back to the default `GITHUB_TOKEN`; both can delete the
+  `release/*.x` branches, which carry no branch protection or ruleset (only
+  `main` is protected).
+
+EOL retirement never unpublishes anything: the `v<major>.<minor>.*` git tags and
+their GitHub Releases — and the already-pushed images, charts, and binaries —
+stay available; only the future-hotfix branch is removed.
 
 ## Dev / prod parity
 


### PR DESCRIPTION
## What this automates

Carves the **active** half of the EOL policy into the release pipeline. The **passive** half (#1068: `release-preflight.mjs` REFUSES to publish on a 3+-back line, via `SUPPORTED_MINOR_LINES` / `currentMinor` / `supportWindowProblem`) already existed. This adds the missing piece: when a **new minor actually ships**, the line that falls out of the latest-3-minor window is **deleted automatically** instead of via a manual maintainer step.

A new `eol-retire` job in `release.yml` runs post-publish — only after a successful new-app-version `goreleaser` run — computes the line that just fell out of the window, and deletes its `release/X.Y.x` maintenance branch.

## Single source of truth

The new pure helper `retireLineForPublish({version, tags})` lives **inside `release-preflight.mjs`** and reuses `SUPPORTED_MINOR_LINES` + `currentMinor()` — the **same window math** as #1068's `supportWindowProblem()`. No duplicated arithmetic. The two are cross-checked in the self-test (the line `retireLineForPublish` returns is exactly the line `supportWindowProblem` then calls EOL).

## Guards (load-bearing)

- **Minor-bump only** — `X.Y.0` with `Y>0`. Patches (`Z>0`), **MAJOR bumps** (`X.0.0`, deliberately scoped out — retiring a whole prior major is a bigger policy call left to the maintainer; the passive gate still refuses to publish on those lines), stable **backports** (anchored to the highest released minor, so publishing `1.4.0` while `1.6.0` exists retires nothing), and **prereleases** retire **nothing**.
- **Exists + out-of-window only** — deletes only a branch that EXISTS; **idempotent** (a 404 / already-absent branch is a clean no-op), with a `supportWindowProblem` cross-check immediately before the destructive call (never deletes an in-window line).
- **FAIL-OPEN** — the release already published before this runs, so ANY deletion failure (token, future protection, network) logs loudly via `::error::` and the step still exits 0 (plus `continue-on-error: true` belt-and-braces). A retirement hiccup never reds an already-shipped release; the fallback is a one-line manual `git push origin --delete`.

## Branch-protection / token finding + mechanism chosen

**Fully automated via the Git refs API** — no fallback needed:

- Repo **rulesets are empty** (`GET /repos/tsouza/cerberus/rulesets` → `[]`); only **`main`** carries classic branch protection. `release/1.3.x` and `release/1.4.x` are both `protected=false`. So `release/*.x` branches are deletable by a `contents:write` token.
- Token: **`RELEASE_PAT`** (fine-grained, `contents:write` — already a repo secret) when present, falling back to the default `GITHUB_TOKEN`. Both can delete an unprotected `release/*.x` branch today; the PAT path keeps working if a future ruleset protects `release/*` and grants the PAT a bypass.

## Worked example

`v1.5.0` current; supported = `1.5.x` / `1.4.x` / `1.3.x`. Shipping **`1.6.0`** retires **`release/1.3.x`** (kept: `1.5.x`, `1.4.x`, `1.3.x` → relative to `1.6`, kept are `1.4.x`/`1.3.x`... the helper deletes exactly the line `1.6 - 3 = 1.3`).

## Self-test cases (new)

`1.6.0→retire 1.3.x`, `1.5.1→nothing`, `1.5.0→retire 1.2.x`, `1.0.0/1.2.0→no-prior-line noop`, `2.0.0→major scoped-out noop`, `1.4.0 backport→noop`, prerelease/chart/empty→noop, idempotent (deterministic name regardless of branch presence), and the `supportWindowProblem` cross-check.

## Verification

- `node .github/scripts/release-preflight.mjs --self-test` ✅
- `actionlint .github/workflows/release.yml` ✅
- `markdownlint-cli2 docs/operations.md .github/scripts/README.md` ✅ (0 errors)
- No Go touched.

## Docs

- `docs/operations.md` "Release support window / EOL policy" — flipped "Branch deletion is a manual maintainer step" → the automated `eol-retire` job (passive/active split documented).
- `.github/scripts/README.md` — documented the `eol-retire-line` command + its env contract + fail-open exit semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)