### PR TITLE
docs: branded README hero (banner served from cerberus.foo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,34 @@
-# cerberus
+<div align="center">
 
-**Drop-in Prometheus / Loki / Tempo HTTP gateway for ClickHouse.**
-Keep Grafana, alerting, and your CLI tooling. Swap the backend.
+<img src="https://cerberus.foo/assets/brand/readme-banner-1280x640.png" alt="cerberus — three query languages, one backend" width="100%">
+
+<br>
+
+### Drop-in Prometheus / Loki / Tempo HTTP gateway for ClickHouse
+
+_Keep Grafana, alerting, and your CLI tooling. Swap the backend._
+
+<sub>
+<a href="#why-cerberus">Why cerberus</a> &nbsp;·&nbsp;
+<a href="#quick-start">Quick start</a> &nbsp;·&nbsp;
+<a href="#architecture">Architecture</a> &nbsp;·&nbsp;
+<a href="#compatibility">Compatibility</a> &nbsp;·&nbsp;
+<a href="#documentation">Docs</a>
+</sub>
+
+<br><br>
+
+[![CI](https://github.com/tsouza/cerberus/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/tsouza/cerberus/actions/workflows/ci.yml)
+[![Mutation](https://github.com/tsouza/cerberus/actions/workflows/mutation.yml/badge.svg?branch=main)](https://github.com/tsouza/cerberus/actions/workflows/mutation.yml)
+[![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
+[![Go Reference](https://pkg.go.dev/badge/github.com/tsouza/cerberus.svg)](https://pkg.go.dev/github.com/tsouza/cerberus)
+[![Go Report Card](https://goreportcard.com/badge/github.com/tsouza/cerberus)](https://goreportcard.com/report/github.com/tsouza/cerberus)
+
+[![PromQL compat](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Ftsouza%2Fcerberus%2Fcompat-scores%2Fbadges%2Fprometheus.json)](https://github.com/tsouza/cerberus/actions/workflows/compatibility.yml)
+[![LogQL compat](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Ftsouza%2Fcerberus%2Fcompat-scores%2Fbadges%2Floki.json)](https://github.com/tsouza/cerberus/actions/workflows/compatibility.yml)
+[![TraceQL compat](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Ftsouza%2Fcerberus%2Fcompat-scores%2Fbadges%2Ftempo.json)](https://github.com/tsouza/cerberus/actions/workflows/compatibility.yml)
+
+</div>
 
 > [!NOTE]
 > **1.0.0 — stable wire API, young project.** The Prometheus / Loki /
@@ -14,15 +41,6 @@ Keep Grafana, alerting, and your CLI tooling. Swap the backend.
 > the lightest conformance confidence of the three heads
 > ([details](#compatibility)). See [`CHANGELOG.md`](CHANGELOG.md) for what
 > has landed.
-
-[![CI](https://github.com/tsouza/cerberus/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/tsouza/cerberus/actions/workflows/ci.yml)
-[![Mutation](https://github.com/tsouza/cerberus/actions/workflows/mutation.yml/badge.svg?branch=main)](https://github.com/tsouza/cerberus/actions/workflows/mutation.yml)
-[![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
-[![Go Reference](https://pkg.go.dev/badge/github.com/tsouza/cerberus.svg)](https://pkg.go.dev/github.com/tsouza/cerberus)
-[![Go Report Card](https://goreportcard.com/badge/github.com/tsouza/cerberus)](https://goreportcard.com/report/github.com/tsouza/cerberus)
-[![PromQL compat](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Ftsouza%2Fcerberus%2Fcompat-scores%2Fbadges%2Fprometheus.json)](https://github.com/tsouza/cerberus/actions/workflows/compatibility.yml)
-[![LogQL compat](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Ftsouza%2Fcerberus%2Fcompat-scores%2Fbadges%2Floki.json)](https://github.com/tsouza/cerberus/actions/workflows/compatibility.yml)
-[![TraceQL compat](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Ftsouza%2Fcerberus%2Fcompat-scores%2Fbadges%2Ftempo.json)](https://github.com/tsouza/cerberus/actions/workflows/compatibility.yml)
 
 The three `*QL compat` badges are **differential parity scores** —
 `passed / total` cases where cerberus matched a reference Prometheus /

--- a/README.md
+++ b/README.md
@@ -199,8 +199,8 @@ see [`docs/performance.md`](docs/performance.md).
 
 Each query language has a **differential harness**: cerberus and a
 reference engine answer the same corpus against the same seeded data, and
-the responses are diffed case-for-case — pinning *observed semantics on
-real ClickHouse* against an upstream oracle, not just emitted SQL.
+the responses are diffed case-for-case — pinning _observed semantics on
+real ClickHouse_ against an upstream oracle, not just emitted SQL.
 
 The strongest leg is **PromQL**, which runs the third-party **PromQL
 Compliance Tester** (`prometheus/compliance`, the PromLabs / CNCF
@@ -229,7 +229,7 @@ won't boot, seed fails, report unparseable). Per-case **parity drift is
 report-only** by design ([#503](https://github.com/tsouza/cerberus/pull/503)):
 it is recorded in `report.json` and rendered into the live `compat-score.json`
 badge, but does not turn the required check red. The one lane that
-*hard-fails on any parity diff* is `compatibility/prometheus-forced-route`
+_hard-fails on any parity diff_ is `compatibility/prometheus-forced-route`
 (`FAIL_ON_DIFF=1`, proving the sharded solver route is byte-identical to
 reference Prometheus over the whole corpus) — that lane is informational,
 not a required check. The honest reading: the badges are a continuously


### PR DESCRIPTION
## Branded README hero

Adds a centered hero to the README — the cerberus brand banner, a one-line
section-nav row, and the existing status/compat badges regrouped beneath it.

**No prose changes.** Every section from **Why cerberus?** through **License**
is byte-for-byte identical to `main`; only the top header block changed (the
`# cerberus` heading + tagline + loose badge list become the centered hero).

### Resources served from the live site

The hero image is referenced from the production site rather than committed as
a binary into this repo:

```
https://cerberus.foo/assets/brand/readme-banner-1280x640.png
```

The full brand/logo asset kit (favicons, app-icon tiles, OG + GitHub social
cards) lives with the website source (`tsouza/cerberus-site`, deployed at
https://cerberus.foo) — keeping this Go repo free of binary assets.

### The mark

Three open strokes — PromQL (sky), LogQL (emerald), TraceQL (rose) — converging
on a single indigo node: **three query languages, one backend.**
