### PR TITLE
docs: theme-aware README hero via <picture>

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 <div align="center">
 
-<img src="https://cerberus.foo/assets/brand/readme-banner-1280x640.png" alt="cerberus — three query languages, one backend" width="100%">
+<picture>
+  <source media="(prefers-color-scheme: light)" srcset="https://cerberus.foo/assets/brand/readme-banner-light-1280x640.png">
+  <img src="https://cerberus.foo/assets/brand/readme-banner-1280x640.png" alt="cerberus — three query languages, one backend" width="100%">
+</picture>
 
 <br>
 


### PR DESCRIPTION
## Problem

The README hero is a single dark PNG — on GitHub's **light** theme it floats as a dark slab on white instead of blending.

## Fix

Swap the hero by `prefers-color-scheme` with `<picture>`:

```html
<picture>
  <source media="(prefers-color-scheme: light)" srcset=".../readme-banner-light-1280x640.png">
  <img src=".../readme-banner-1280x640.png" ...>   <!-- dark = default / fallback -->
</picture>
```

- **Light theme** → new light banner.
- **Dark theme** (and any renderer that ignores `<picture>`) → existing dark PNG via the `<img>` fallback.

## Companion

Assets + generator land in **tsouza/cerberus-site#1** (merged, live on cerberus.foo). The light asset is already serving 200, so `link-check` is green from the first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)