### PR TITLE
chore(release): cerberus v1.6.0 / chart 0.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to cerberus will be documented in this file. The format roug
 
 ## [Unreleased]
 
+## [v1.6.0] — 2026-06-25
+
+### Added
+
+- **optcorpus:** capture cerberus-side rejections in the router corpus (#1065)
+- **routerrules:** detection-fidelity benchmark + degradation sweep (#1063)
+- **routerrules:** concrete 5-rule ruleset + harness + chDB-parity CI fix (#1062)
+- **routerrules:** generic router-rules catalog + offline analysis engine (#1060)
+
+### Fixed
+
+- **routerrules:** gate route_a_memory_near_cap on the configured cap, not the corpus p95 (#1066)
+- **e2e:** reconcile Traces-Drilldown init-race 400 when both bodies are lost (#1070)
+- **routerrules:** wrap integer CH columns to match Go scan types (strict clickhouse-go) (#1064)
+- **traceql:** bound compare() query memory to avoid 2GiB ClickHouse OOM (#1059)
+
+### CI
+
+- **lint:** exclude .claude worktrees from golangci-lint scan (#1071)
+- **release:** auto-retire the out-of-window release line on a new minor (active EOL) (#1072)
+
+### Documentation
+
+- theme-aware README hero via <picture> (#1074)
+- **readme:** branded hero banner + regrouped badges (#1073)
+- forbid "pre-existing" as an escape hatch for leaving bugs unfixed (#1069)
+- **release:** define the maintenance support-window / EOL policy (latest 3 minor lines) (#1068)
+- **coverage:** reframe PromQL start()/end() rejection as permanent parity (#1061)
+
 ## [v1.5.0] — 2026-06-24
 
 ### Added

--- a/deploy/helm/cerberus/Chart.yaml
+++ b/deploy/helm/cerberus/Chart.yaml
@@ -8,11 +8,11 @@ type: application
 # upgrade?" and is the publish trigger: a chart-only fix bumps this without an
 # app re-tag; an app-only release bumps appVersion + a PATCH here for the new
 # default image. Starts 0.x because the values contract is not yet frozen.
-version: 0.6.4
+version: 0.6.5
 
 # appVersion tracks the GA cerberus binary. Quoted so SemVer-shaped values
 # aren't coerced to floats. image.tag defaults from this when left empty.
-appVersion: "1.5.0"
+appVersion: "1.6.0"
 
 # autoscaling/v2 + policy/v1 (PDB) + networking/v1 (Ingress) are all GA from
 # 1.21+; 1.23 is the conservative floor matching the manifests this chart
@@ -45,21 +45,23 @@ annotations:
       url: https://github.com/tsouza/cerberus/blob/main/docs/operations.md
   artifacthub.io/images: |
     - name: cerberus
-      image: ghcr.io/tsouza/cerberus:v1.5.0
+      image: ghcr.io/tsouza/cerberus:v1.6.0
   # Bump the `1.0.0` floor here when the chart raises its minimum supported
   # cerberus release; informational for Artifact Hub's compatibility hints.
   artifacthub.io/changes: |
     - kind: added
-      description: "optcorpus: record routing decision + cost-grid for route A/B calibration (stage 0) (#1053)"
+      description: "optcorpus: capture cerberus-side rejections in the router corpus (#1065)"
+    - kind: added
+      description: "routerrules: detection-fidelity benchmark + degradation sweep (#1063)"
+    - kind: added
+      description: "routerrules: concrete 5-rule ruleset + harness + chDB-parity CI fix (#1062)"
+    - kind: added
+      description: "routerrules: generic router-rules catalog + offline analysis engine (#1060)"
     - kind: fixed
-      description: "remediate verified audit findings (#1046)"
+      description: "routerrules: gate route_a_memory_near_cap on the configured cap, not the corpus p95 (#1066)"
     - kind: fixed
-      description: "promql: pass TimeUnix through scalar-wrapped rate arm in range joins (#1045)"
+      description: "e2e: reconcile Traces-Drilldown init-race 400 when both bodies are lost (#1070)"
     - kind: fixed
-      description: "api: harden Loki/Tempo HTTP surface against POST + DoS vectors (#1049)"
+      description: "routerrules: wrap integer CH columns to match Go scan types (strict clickhouse-go) (#1064)"
     - kind: fixed
-      description: "chart: per-head PDB + auto-derived GOMEMLIMIT for split mode (#1040)"
-    - kind: fixed
-      description: "e2e: re-provision Grafana after split-mode datasource rewrite (#1037)"
-    - kind: changed
-      description: "chsql: push inner-scan time bound on range query lowerings (#1048)"
+      description: "traceql: bound compare() query memory to avoid 2GiB ClickHouse OOM (#1059)"

--- a/deploy/helm/cerberus/README.md
+++ b/deploy/helm/cerberus/README.md
@@ -5,7 +5,7 @@
      pipe-aligned, and the version footer adds a trailing blank — both are
      owned by helm-docs; realigning would fight the chart-ci drift check. -->
 
-![Version: 0.6.4](https://img.shields.io/badge/Version-0.6.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
+![Version: 0.6.5](https://img.shields.io/badge/Version-0.6.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.0](https://img.shields.io/badge/AppVersion-1.6.0-informational?style=flat-square)
 
 Drop-in Prometheus / Loki / Tempo HTTP gateway for ClickHouse — a single stateless gateway that speaks three upstream query wire formats and lowers each to parameterised ClickHouse SQL.
 


### PR DESCRIPTION
Release-prep for **v1.6.0** (chart **0.6.5**), generated by `prepare-release.yml`.

- appVersion 1.5.0 -> 1.6.0, chart 0.6.4 -> 0.6.5

### Changes

### Added

- **optcorpus:** capture cerberus-side rejections in the router corpus (#1065)
- **routerrules:** detection-fidelity benchmark + degradation sweep (#1063)
- **routerrules:** concrete 5-rule ruleset + harness + chDB-parity CI fix (#1062)
- **routerrules:** generic router-rules catalog + offline analysis engine (#1060)

### Fixed

- **routerrules:** gate route_a_memory_near_cap on the configured cap, not the corpus p95 (#1066)
- **e2e:** reconcile Traces-Drilldown init-race 400 when both bodies are lost (#1070)
- **routerrules:** wrap integer CH columns to match Go scan types (strict clickhouse-go) (#1064)
- **traceql:** bound compare() query memory to avoid 2GiB ClickHouse OOM (#1059)

### CI

- **lint:** exclude .claude worktrees from golangci-lint scan (#1071)
- **release:** auto-retire the out-of-window release line on a new minor (active EOL) (#1072)

### Documentation

- theme-aware README hero via <picture> (#1074)
- **readme:** branded hero banner + regrouped badges (#1073)
- forbid "pre-existing" as an escape hatch for leaving bugs unfixed (#1069)
- **release:** define the maintenance support-window / EOL policy (latest 3 minor lines) (#1068)
- **coverage:** reframe PromQL start()/end() rejection as permanent parity (#1061)

Generated from the conventional commits since the last tag. Review and edit before merging; the tag is cut once this lands.
