### PR TITLE
fix(chopt): probe ClickHouse version over the default connection so a missing otel DB no longer pins the 24.8 floor

### DIFF
--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -239,15 +239,19 @@ func run() error {
 	warnIfClickHouseUnreachable(ctx, logger, client, cfg.ClickHouse)
 
 	// Resolve the ClickHouse-optimization auto-picker ONCE, here, after the
-	// client is built and the runtime version is probed. The probe needs a
-	// live connection (which config.FromEnv does not have), so FromEnv carried
-	// only the raw CERBERUS_CH_OPTIMIZATIONS selection + parsed mode + the
-	// tri-state legacy alias; this is where they become the immutable
-	// EnabledSet every consumer reads. A fatal resolve (unknown feature id in
-	// any mode, or an unsupported explicit id under enforcing) aborts startup.
-	// The resolved set then back-fills cfg.ExperimentalTSGridRange (the single
-	// source of truth for the legacy ts-grid consumers) and drives the
-	// per-query SettingsRules built below.
+	// client is built and the runtime version is probed. The version probe runs
+	// over a short-lived connection bound to ClickHouse's always-present
+	// `default` database (NOT the configured otel one), because this runs before
+	// setupSchema creates otel and a session whose default database is absent
+	// rejects every statement, version() included (code 81). config.FromEnv has
+	// no live connection, so it carried only the raw CERBERUS_CH_OPTIMIZATIONS
+	// selection + parsed mode + the tri-state legacy alias; this is where they
+	// become the immutable EnabledSet every consumer reads. A fatal resolve
+	// (unknown feature id in any mode, or an unsupported explicit id under
+	// enforcing) aborts startup. The resolved set then back-fills
+	// cfg.ExperimentalTSGridRange (the single source of truth for the legacy
+	// ts-grid consumers), drives the per-query SettingsRules built below, and
+	// the main client (passed here) gets the one boot-time columnar-decode swap.
 	optSet, err := resolveCHOptimizations(ctx, logger, client, &cfg)
 	if err != nil {
 		return err
@@ -568,7 +572,7 @@ func settingsRules(cfg config.Config, set chopt.EnabledSet) engine.SettingsRules
 // (unknown feature id, or an unsupported explicit id under enforcing) is still
 // fatal — that is a typo/operator error, independent of connectivity.
 func resolveCHOptimizations(ctx context.Context, logger *slog.Logger, client *chclient.Client, cfg *config.Config) (chopt.EnabledSet, error) {
-	resolvedVersion, err := client.ProbeVersion(ctx)
+	resolvedVersion, err := probeVersionOverBootstrap(ctx, cfg.ClickHouse)
 	if err != nil {
 		// Connectivity fallback: assume the supported floor so 24.8-safe
 		// stable features still resolve under auto; newer features stay off
@@ -614,6 +618,30 @@ func resolveCHOptimizations(ctx context.Context, logger *slog.Logger, client *ch
 		"enabled", strings.Join(set.IDs(), ","),
 	)
 	return set, nil
+}
+
+// probeVersionOverBootstrap issues the SELECT version() probe over a
+// short-lived client bound to ClickHouse's always-present `default` database,
+// not the configured (otel) one. The version probe must succeed on a fresh or
+// freshly-upgraded server whose configured database does not exist yet: it runs
+// at boot BEFORE setupSchema creates the target database, and ClickHouse rejects
+// EVERY statement — version() included — on a session whose default database is
+// absent (code 81, UNKNOWN_DATABASE). Binding the probe to `default` (which is
+// always present, the same database the auto-create DDL targets) makes the probe
+// independent of whether the configured database exists, so a CH upgrade takes
+// effect on the next boot instead of being masked as a probe failure that pins
+// the supported floor. The client is opened, probed, and closed here — it never
+// outlives the probe; the breaker-guarded read surface still makes a genuinely
+// unreachable server fail (not hang), preserving the connectivity fallback.
+func probeVersionOverBootstrap(ctx context.Context, chCfg chclient.Config) (chopt.Version, error) {
+	bootClient, err := chclient.New(bootstrapClickHouseConfig(chCfg))
+	if err != nil {
+		return chopt.Version{}, fmt.Errorf("open bootstrap client for version probe: %w", err)
+	}
+	defer func() {
+		_ = bootClient.Close()
+	}()
+	return bootClient.ProbeVersion(ctx)
 }
 
 // startOptCorpus starts the async system.query_log performance-corpus

--- a/internal/chclient/version_probe_integration_test.go
+++ b/internal/chclient/version_probe_integration_test.go
@@ -1,0 +1,123 @@
+//go:build integration
+
+package chclient_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	tcclickhouse "github.com/testcontainers/testcontainers-go/modules/clickhouse"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+)
+
+// TestProbeVersion_DatabaseAbsent is the regression test for the boot-order bug
+// where cerberus pinned the optimization auto-picker to the 24.8 supported floor
+// on a fresh/upgraded ClickHouse. The version probe runs BEFORE the schema
+// auto-create step, so on a fresh server the configured `otel` database does not
+// exist yet. ClickHouse rejects EVERY statement — SELECT version() included — on
+// a session whose default database is absent (code 81, UNKNOWN_DATABASE), during
+// session default-DB resolution before execution. The probe therefore failed and
+// the picker fell back to the 24.8 floor for the pod's lifetime, defeating the
+// upgrade until a manual restart.
+//
+// The fix re-scopes the probe to ClickHouse's always-present `default` database
+// (the same one the auto-create DDL bootstraps over). This test stands up a real
+// server whose ONLY database is `default` and proves both halves:
+//
+//  1. a client bound to the absent `otel` database fails the probe (the bug), and
+//  2. a client bound to `default` succeeds and parses the REAL server version
+//     (the fix) — independent of whether `otel` exists.
+//
+// Gated by the `integration` build tag (requires Docker); the E2E workflow runs
+// it, regular CI doesn't.
+func TestProbeVersion_DatabaseAbsent(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	// Start a plain ClickHouse with only the built-in `default` database —
+	// deliberately NOT pre-creating `otel`, so we reproduce the real
+	// cold-cluster bootstrap path a fresh k8s/compose deployment hits.
+	container, err := tcclickhouse.Run(
+		ctx,
+		"clickhouse/clickhouse-server:25.8-alpine",
+		tcclickhouse.WithUsername("cerberus"),
+		tcclickhouse.WithPassword("cerberus"),
+	)
+	if err != nil {
+		t.Fatalf("start clickhouse: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = container.Terminate(ctx)
+	})
+
+	host, err := container.Host(ctx)
+	if err != nil {
+		t.Fatalf("host: %v", err)
+	}
+	port, err := container.MappedPort(ctx, "9000/tcp")
+	if err != nil {
+		t.Fatalf("port: %v", err)
+	}
+	addr := host + ":" + port.Port()
+
+	base := chclient.Config{
+		Addr:     addr,
+		Username: "cerberus",
+		Password: "cerberus",
+	}
+
+	// Half 1 — bind to the ABSENT otel database. This is the pre-fix wiring:
+	// the probe ran over cerberus's main client whose session default DB is the
+	// configured otel, so version() is rejected with code 81 before it executes.
+	t.Run("otel_absent_probe_fails", func(t *testing.T) {
+		otelCfg := base
+		otelCfg.Database = "otel"
+		client, err := chclient.New(otelCfg)
+		if err != nil {
+			t.Fatalf("new otel-bound client: %v", err)
+		}
+		t.Cleanup(func() { _ = client.Close() })
+
+		_, err = client.ProbeVersion(ctx)
+		if err == nil {
+			t.Fatal("expected ProbeVersion to fail against the absent otel database, got nil " +
+				"(the bug only reproduces while otel does not exist)")
+		}
+		// The server-side rejection is code 81 / "Database otel does not exist".
+		// Assert on the substring rather than the numeric code to stay robust to
+		// driver error-wrapping; the point is the probe fails because the bound
+		// DB is missing, which is exactly what the default-bound probe avoids.
+		if !strings.Contains(err.Error(), "otel") {
+			t.Fatalf("expected probe error to mention the absent otel database, got: %v", err)
+		}
+	})
+
+	// Half 2 — bind to the always-present `default` database (the fix). The
+	// probe must now succeed and parse the REAL server version regardless of
+	// whether otel exists.
+	t.Run("default_bound_probe_succeeds", func(t *testing.T) {
+		defCfg := base
+		defCfg.Database = "default"
+		client, err := chclient.New(defCfg)
+		if err != nil {
+			t.Fatalf("new default-bound client: %v", err)
+		}
+		t.Cleanup(func() { _ = client.Close() })
+
+		v, err := client.ProbeVersion(ctx)
+		if err != nil {
+			t.Fatalf("ProbeVersion over default-bound connection (otel absent): %v", err)
+		}
+		// The testcontainers image is the 25.8 line; the probe must resolve a
+		// real, non-zero version rather than fall through to the 24.8 floor.
+		if v.Major == 0 {
+			t.Fatalf("probe resolved a zero version: %+v", v)
+		}
+		if v.Major != 25 || v.Minor != 8 {
+			t.Errorf("probe version mismatch: got %s, want 25.8 (server image line)", v.String())
+		}
+	})
+}


### PR DESCRIPTION
## Problem

On a fresh / upgraded ClickHouse (e.g. moving prod to 26.5), cerberus pins the optimization auto-picker to the **24.8 supported-floor fallback** and silently never enables `condition_cache` (≥25.3) or the native aggregates (≥25.6) — defeating the entire point of the CH upgrade until a manual pod restart.

**Root cause (not a parse bug, not a dial race):** the boot-time version probe runs *before* schema auto-create (`main.go:251` before `:258`) and issues `SELECT version()` over cerberus's main client, whose session **default database is the configured `otel`**. On a fresh server `otel` doesn't exist yet, so the server rejects the query with **code 81 "Database otel does not exist"** during default-DB resolution — *before* execution, so it never even appears in `system.query_log`. The probe errors → `main.go:576` falls back to `{24,8}` (with a WARN) → the optimization set is resolved once and never re-evaluated.

Verbatim prod evidence:
```
WARN "clickhouse version probe failed; resolving optimizations against the supported floor"
     err="probe clickhouse version: code: 81, message: Database otel does not exist" assumed_version="24.8"
```

## Fix

Probe `version()` over the **`default` bootstrap connection** cerberus already uses for `CREATE DATABASE` (`bootstrapClickHouseConfig` → `Database="default"`, CH's always-present DB). A new `probeVersionOverBootstrap` opens/probes/closes a short-lived `default`-bound client, so `version()` succeeds regardless of whether `otel` exists. The genuine-unreachable-server fallback is untouched (still 24.8 + WARN, non-fatal).

## Test

New integration test `TestProbeVersion_DatabaseAbsent` (testcontainers, `integration` tag): on a real CH with only `default`, asserts the `otel`-bound probe **fails** (reproduces the bug) and the `default`-bound probe **succeeds and parses the real version**.

## Deliberately deferred (follow-up)

A *runtime* re-resolve of optimizations when a background re-probe finds the DB present (so a live rolling CH upgrade crossing a feature floor takes effect without restart). Assessed and left out: the resolved `EnabledSet` is consumed by-value into immutable hot-path structures (prom lowering dispatch table, engine settings rules, the columnar-decode client mutation), so a runtime swap is a multi-package refactor. With this fix the fresh-server pinning is fully resolved at boot; the live-upgrade case remains documented v1 restart-to-reprobe behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)