### PR TITLE
fix(traceql): push compare() time bound into the scan and seed the root leg

### DIFF
--- a/internal/chsql/metrics_compare.go
+++ b/internal/chsql/metrics_compare.go
@@ -58,11 +58,33 @@ const (
 	compareJoinRightAlias = "r"
 )
 
+// compareScanBound carries the (Start-range, End] Timestamp window the
+// matrix path pushes INTO each MergeTree scan of the compare join so
+// ClickHouse can partition/granule-prune both legs. lo / hi are the
+// strict-lower / inclusive-upper Frags from innerScanTsBoundsFrags; a
+// nil compareScanBound (the bare time-collapsed shape, which has no
+// anchor grid) leaves both scans unbounded — byte-stable against the
+// pinned bare fixtures.
+//
+// Why the bound must live inside the scans, not above the join: CH
+// 24.12 cannot push a predicate sitting on the SELECT that wraps
+// `s LEFT JOIN r` down into either MergeTree input, so a window filter
+// landed there scans the full span table on both legs (the prod
+// traces-drilldown OOM: a 15-min compare read ~731M rows before the
+// 2 GiB cap killed it; EXPLAIN showed ~130x fewer rows once the bound
+// pruned the scans). compareBaseQuery therefore attaches lo/hi to the
+// `s` subquery's own WHERE and seeds the root leg with a TraceId-IN
+// over the same bounded cohort.
+type compareScanBound struct {
+	lo, hi Frag
+}
+
 // compareBaseQuery builds the innermost SELECT — cohort flag +
 // arrayJoin'd attribute pairs (+ extraCols, used by the matrix path to
 // carry the timestamp column up to the fanout level) over Inner,
-// LEFT JOINed against RootLookup when present.
-func (e *emitter) compareBaseQuery(m *chplan.MetricsCompare, extraCols ...string) (*QueryBuilder, error) {
+// LEFT JOINed against RootLookup when present. When bound is non-nil the
+// Timestamp window is pushed into both join legs (see compareScanBound).
+func (e *emitter) compareBaseQuery(m *chplan.MetricsCompare, bound *compareScanBound, extraCols ...string) (*QueryBuilder, error) {
 	if m.Selection == nil {
 		return nil, fmt.Errorf("%w: MetricsCompare.Selection is nil", ErrUnsupported)
 	}
@@ -86,6 +108,15 @@ func (e *emitter) compareBaseQuery(m *chplan.MetricsCompare, extraCols ...string
 		return nil, err
 	}
 
+	// Left ('s') leg: wrap the inner spanset in a SELECT * that carries
+	// the Timestamp window in its own WHERE so the bound sits BELOW the
+	// join, inside the span scan, where CH can prune it. When unbounded
+	// the inner Frag is aliased directly (byte-stable bare shape).
+	sLeg := inner
+	if bound != nil {
+		sLeg = NewQuery().Select(Star()).From(inner).Where(bound.lo, bound.hi).Frag()
+	}
+
 	qb := NewQuery()
 	if m.RootLookup != nil {
 		if m.TraceIDColumn == "" {
@@ -95,7 +126,21 @@ func (e *emitter) compareBaseQuery(m *chplan.MetricsCompare, extraCols ...string
 		if rerr != nil {
 			return nil, rerr
 		}
-		qb.From(aliasedFrag(inner, compareJoinLeftAlias)).
+		// Right ('r') leg: bound the per-trace root lookup to the same
+		// windowed cohort the 's' leg scans via `TraceId IN (<bounded s
+		// trace-ids>)` — mirroring structuralSeedTraceFilter's seed
+		// pushdown. The predicate is on the root aggregate's GROUP BY key
+		// (TraceId), so CH pushes it through the aggregate into the root
+		// span scan, pruning it the same way the 's' leg is pruned. A
+		// plain Timestamp bound on the root leg would instead drop
+		// enrichment for traces whose root span straddles the window
+		// edge; seeding by the cohort's trace-id set keeps every root the
+		// LEFT JOIN can match (the join output is determined by
+		// s.TraceId, already windowed) while still scoping the scan.
+		if bound != nil {
+			root = e.boundedRootLeg(root, m.TraceIDColumn, inner, bound)
+		}
+		qb.From(aliasedFrag(sLeg, compareJoinLeftAlias)).
 			Join(
 				LeftJoin,
 				aliasedFrag(root, compareJoinRightAlias),
@@ -105,7 +150,7 @@ func (e *emitter) compareBaseQuery(m *chplan.MetricsCompare, extraCols ...string
 				),
 			)
 	} else {
-		qb.From(inner)
+		qb.From(sLeg)
 	}
 
 	sel := m.Selection
@@ -117,6 +162,26 @@ func (e *emitter) compareBaseQuery(m *chplan.MetricsCompare, extraCols ...string
 		qb.Select(func(b *Builder) { b.Ident(col) })
 	}
 	return qb, nil
+}
+
+// boundedRootLeg wraps the rendered root-lookup subquery so its scan is
+// pruned to the windowed cohort: it filters the root rows to
+// `<traceID> IN (SELECT <traceID> FROM (<bounded inner>) AS _cmp_seed)`,
+// where the bounded inner is the same windowed span scan the 's' leg
+// uses. Because <traceID> is the root aggregate's GROUP BY key, the
+// predicate pushes through the aggregate into the root span scan.
+// _cmp_seed aliases the seed subquery so CH's analyzer resolves the
+// projected trace-id column. See compareScanBound for the why.
+func (e *emitter) boundedRootLeg(root Frag, traceIDCol string, inner Frag, bound *compareScanBound) Frag {
+	boundedInner := NewQuery().Select(Star()).From(inner).Where(bound.lo, bound.hi)
+	seedIDs := NewQuery().
+		Select(Col(traceIDCol)).
+		From(aliasedFrag(boundedInner.Frag(), "_cmp_seed"))
+	return NewQuery().
+		Select(Star()).
+		From(root).
+		Where(In(Col(traceIDCol), Spliced(seedIDs))).
+		Frag()
 }
 
 // compareSelOut / compareAttrOut / compareValOut / compareValueOut
@@ -172,7 +237,7 @@ func compareCountValueFrag() Frag {
 
 // emitMetricsCompare renders the bare (time-collapsed) shape.
 func (e *emitter) emitMetricsCompare(m *chplan.MetricsCompare) error {
-	base, err := e.compareBaseQuery(m)
+	base, err := e.compareBaseQuery(m, nil)
 	if err != nil {
 		return err
 	}
@@ -226,11 +291,19 @@ func (e *emitter) emitRangeWindowCompare(r *chplan.RangeWindow, m *chplan.Metric
 	}
 
 	tsCol := r.TimestampColumn
-	base, err := e.compareBaseQuery(m, tsCol)
+	// Push the (Start-range, End] Timestamp window INTO each scan of the
+	// compare join (the 's' span scan + the seeded root leg) rather than
+	// above the join where CH 24.12 cannot prune it. Gated on both Start
+	// and End being set, matching maybePushInnerScanTimeBounds' contract.
+	var bound *compareScanBound
+	if !r.Start.IsZero() && !r.End.IsZero() {
+		lo, hi := innerScanTsBoundsFrags(tsCol, r.Start, r.End, r.Offset.Nanoseconds(), rangeNS)
+		bound = &compareScanBound{lo: lo, hi: hi}
+	}
+	base, err := e.compareBaseQuery(m, bound, tsCol)
 	if err != nil {
 		return err
 	}
-	maybePushInnerScanTimeBounds(base, r, tsCol, rangeNS)
 
 	selA, attrA, valA := compareSelOut(m), compareAttrOut(m), compareValOut(m)
 

--- a/internal/chsql/metrics_compare_test.go
+++ b/internal/chsql/metrics_compare_test.go
@@ -35,6 +35,94 @@ func compareNode() *chplan.MetricsCompare {
 	}
 }
 
+// compareNodeWithRoot extends compareNode with the per-trace root
+// lookup leg (the LEFT JOIN shape that the production traceql
+// drilldown compare emits). It mirrors internal/traceql's
+// compareRootLookup: an Aggregate over a Filter(ParentSpanId empty)
+// GROUP BY TraceId. The join shape is what makes scan-bound pushdown
+// non-trivial (a window filter above `s LEFT JOIN r` cannot prune
+// either MergeTree leg), so the matrix pushdown test below exercises
+// this node rather than the join-free compareNode.
+func compareNodeWithRoot() *chplan.MetricsCompare {
+	m := compareNode()
+	m.TraceIDColumn = "TraceId"
+	m.RootLookup = &chplan.Aggregate{
+		Input: &chplan.Filter{
+			Input: &chplan.Scan{Table: "otel_traces"},
+			Predicate: &chplan.Binary{
+				Op:    chplan.OpEq,
+				Left:  &chplan.ColumnRef{Name: "ParentSpanId"},
+				Right: &chplan.LitString{V: ""},
+			},
+		},
+		GroupBy: []chplan.Expr{&chplan.ColumnRef{Name: "TraceId"}},
+		AggFuncs: []chplan.AggFunc{
+			{Name: "any", Args: []chplan.Expr{&chplan.ColumnRef{Name: "SpanName"}}, Alias: "__root_name"},
+		},
+	}
+	return m
+}
+
+// TestEmitRangeWindowCompare_JoinScanPushdown pins the FIX-1 scan-
+// bounding pushdown for the join (RootLookup) shape — the prod
+// traces-drilldown OOM. The (Start - range, End] Timestamp window must
+// land INSIDE each MergeTree scan of `s LEFT JOIN r`, never on the
+// SELECT wrapping the join (CH 24.12 cannot push a join-level predicate
+// into either leg):
+//
+//   - the `s` span leg carries the bound in its own WHERE, immediately
+//     above the `AS s` alias;
+//   - the `r` root leg is seeded with `TraceId IN (<bounded cohort
+//     trace-ids>)` so the same window prunes the root scan through the
+//     GROUP BY TraceId aggregate, while preserving rootName enrichment
+//     for every trace the join can match.
+func TestEmitRangeWindowCompare_JoinScanPushdown(t *testing.T) {
+	t.Parallel()
+
+	rw := &chplan.RangeWindow{
+		Input:           compareNodeWithRoot(),
+		Range:           time.Minute,
+		Step:            time.Minute,
+		Start:           time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC),
+		End:             time.Date(2026, 5, 12, 10, 3, 0, 0, time.UTC),
+		TimestampColumn: "Timestamp",
+	}
+	sql, _, err := chsql.Emit(context.Background(), rw)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+
+	lo := "`Timestamp` > toDateTime64('2026-05-12 10:00:00.000000000', 9) - toIntervalNanosecond(60000000000)"
+	hi := "`Timestamp` <= toDateTime64('2026-05-12 10:03:00.000000000', 9)"
+
+	// The 's' span leg: bound sits in the WHERE immediately preceding the
+	// `AS s` alias — i.e. inside the scan, below the join.
+	sLeg := "WHERE " + lo + " AND " + hi + ") AS s"
+	if !strings.Contains(sql, sLeg) {
+		t.Errorf("matrix join SQL must bound the 's' scan inside the join (want %q):\n%s", sLeg, sql)
+	}
+
+	// The 'r' root leg: seeded by the bounded cohort's trace-id set so
+	// the root scan prunes the same way, with enrichment preserved.
+	rSeed := "WHERE `TraceId` IN (SELECT `TraceId` FROM (SELECT * FROM (SELECT * FROM `otel_traces`) " +
+		"WHERE " + lo + " AND " + hi + ") AS _cmp_seed)) AS r"
+	if !strings.Contains(sql, rSeed) {
+		t.Errorf("matrix join SQL must seed the 'r' root leg by bounded trace-ids (want %q):\n%s", rSeed, sql)
+	}
+
+	// Regression guard: the bound must NOT sit on the SELECT that wraps
+	// the whole `s LEFT JOIN r` (the original un-prunable placement). The
+	// join's ON clause is the last token before the wrapping SELECT's
+	// own scope; assert no Timestamp predicate trails the join's ON.
+	onIdx := strings.Index(sql, "ON s.`TraceId` = r.`TraceId`")
+	if onIdx < 0 {
+		t.Fatalf("expected the LEFT JOIN ON clause in:\n%s", sql)
+	}
+	if strings.Contains(sql[onIdx:], "`Timestamp` >") || strings.Contains(sql[onIdx:], "`Timestamp` <=") {
+		t.Errorf("Timestamp bound must not sit above the join (found after ON clause):\n%s", sql[onIdx:])
+	}
+}
+
 // TestEmitMetricsCompare_BareShape — bare emission groups by
 // (cohort, attr, val) with a deterministic ORDER BY and the Float64
 // count reducer.

--- a/test/perf/compare_window_prune_chdb_test.go
+++ b/test/perf/compare_window_prune_chdb_test.go
@@ -1,0 +1,349 @@
+//go:build chdb
+
+// Lever: push the TraceQL compare() matrix Timestamp window INTO both
+// MergeTree scans of the `s LEFT JOIN r` join (FIX-1 scan-bounding
+// pushdown), not above the join where ClickHouse 24.12 cannot prune it.
+//
+// The prod traces-drilldown OOM: a 15-min `compare()` over a busy
+// service read ~731M rows / tripped the 2 GiB cap because the
+// (Start-range, End] window sat on the SELECT wrapping the join, so
+// neither the span leg ('s') nor the per-trace root leg ('r') could be
+// scoped to the window — both fed the full multi-day span table into
+// the join.
+//
+// This guard pins two robust, version-independent signals of the fix on
+// a production-shaped spans table (PARTITION BY toDate(Timestamp), the
+// OTel-CH exporter's own layout) seeded across many day-partitions —
+// 250k traces total, 25k inside the one-day window:
+//
+//   - 's' span leg: the AFTER shape carries the bound in the scan's own
+//     WHERE, so EXPLAIN indexes=1 MinMax-Partition-prunes the leg to the
+//     window's day (Parts: 1/N), structurally — independent of whether
+//     the analyzer would also push it from above the join. (CH 24.12 in
+//     prod does NOT; that is the whole bug.)
+//   - 'r' root leg: the `TraceId IN (<bounded cohort>)` seed cuts the
+//     join's right side from every trace's root (250k) to only the
+//     window cohort's roots (25k) — the ~10x row reduction that keeps
+//     the join off the 2 GiB cap. Asserted as a strict row-count drop of
+//     the seeded root leg vs the unbounded one.
+//
+// Parity is asserted too: BEFORE and AFTER return an identical
+// (is_selection, attr, count) cohort — the window pushdown is
+// correctness-preserving for the in-window cohort.
+//
+// The pre-existing traceid_window_prune guard covers only the
+// SINGLE-scan trace-by-id shape; the compare join is a separate prune
+// surface (two scans, one seeded through a GROUP BY) that no other perf
+// guard exercised. Build-tagged `chdb`, same lane as the rest.
+package perf
+
+import (
+	"database/sql"
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/chdb-io/chdb-go/chdb/driver"
+)
+
+const (
+	// cmpTotalSpans / cmpSpansPerTrace / cmpNumDays seed a dense, multi-
+	// day-partition spans corpus so the MinMax/Partition stage has real
+	// parts to prune. Each trace's spans live within a single day; the
+	// compare window selects one day, so the fix must prune the other
+	// days' parts on the 's' leg and scope the 'r' leg to that day's
+	// traces.
+	cmpTotalSpans    = 2_000_000
+	cmpSpansPerTrace = 8
+	cmpNumDays       = 10
+	// cmpWindowDayIdx is the day-partition offset (from cmpSeedEpoch) the
+	// compare window targets; every span seeded into it falls in
+	// [cmpWindowLo, cmpWindowHi).
+	cmpWindowDayIdx = 4
+	// cmpSeedEpoch anchors the seed's day-0 partition; the seed adds
+	// `(trace % cmpNumDays)` days to it.
+	cmpSeedEpoch = "2026-01-01"
+)
+
+// cmpSpansDDL is the production OTel-CH spans table (the columns the
+// compare emitter reads + the partition/order the exporter writes),
+// trimmed to what this bench needs.
+const cmpSpansDDL = `CREATE OR REPLACE TABLE otel_traces (
+    Timestamp DateTime64(9) CODEC(Delta, ZSTD(1)),
+    TraceId String CODEC(ZSTD(1)),
+    SpanId String CODEC(ZSTD(1)),
+    ParentSpanId String CODEC(ZSTD(1)),
+    ServiceName LowCardinality(String) CODEC(ZSTD(1)),
+    SpanName LowCardinality(String) CODEC(ZSTD(1)),
+    StatusCode LowCardinality(String) CODEC(ZSTD(1))
+) ENGINE = MergeTree()
+PARTITION BY toDate(Timestamp)
+ORDER BY (ServiceName, SpanName, toDateTime(Timestamp))
+SETTINGS index_granularity = 8192;`
+
+// cmpSpansInsert seeds cmpTotalSpans rows scattered across cmpNumDays
+// day-partitions. Each trace (cmpSpansPerTrace consecutive rows) lands
+// in one day; span 0 of every trace has an empty ParentSpanId so it is a root
+// span (so the root leg has rows to aggregate).
+func cmpSpansInsert() string {
+	const subSecondStepNS = 110_000_000 // 0.11s per intra-trace span
+	return fmt.Sprintf(
+		`INSERT INTO otel_traces
+SELECT
+    toDateTime64('%s 00:00:00', 9)
+        + INTERVAL (intDiv(number, %d) %% %d) DAY
+        + INTERVAL (number %% %d) SECOND
+        + INTERVAL ((number %% %d) * %d) NANOSECOND AS Timestamp,
+    leftPad(lower(hex(intDiv(number, %d))), 32, '0') AS TraceId,
+    leftPad(lower(hex(number)), 16, '0') AS SpanId,
+    if(number %% %d = 0, '', leftPad(lower(hex(intDiv(number, %d) * %d)), 16, '0')) AS ParentSpanId,
+    concat('svc.', toString(number %% 50)) AS ServiceName,
+    concat('op.', toString(intDiv(number, %d) %% 300)) AS SpanName,
+    if(number %% 3 = 0, 'Error', 'Ok') AS StatusCode
+FROM numbers(%d);`,
+		cmpSeedEpoch,
+		cmpSpansPerTrace, cmpNumDays, // day partition (per trace)
+		cmpSecondsPerDay,                  // within-day second spread
+		cmpSpansPerTrace, subSecondStepNS, // sub-second offset
+		cmpSpansPerTrace,                   // TraceId hex
+		cmpSpansPerTrace,                   // root-span selector
+		cmpSpansPerTrace, cmpSpansPerTrace, // ParentSpanId = first span of trace
+		cmpSpansPerTrace, // SpanName bucket
+		cmpTotalSpans,
+	)
+}
+
+// cmpSecondsPerDay is the within-day second spread each trace's spans
+// fan across — under a day so every trace stays in one day-partition.
+const cmpSecondsPerDay = 80_000
+
+// cmpWindow returns the [lo, hi) DateTime64 literals bounding the target
+// day-partition (cmpWindowDayIdx days after cmpSeedEpoch) — the window
+// the compare query selects.
+func cmpWindow() (lo, hi string) {
+	epoch, _ := time.Parse("2006-01-02", cmpSeedEpoch)
+	day := epoch.AddDate(0, 0, cmpWindowDayIdx)
+	const dt64 = "2006-01-02 15:04:05.000000000"
+	return "'" + day.Format(dt64) + "'", "'" + day.AddDate(0, 0, 1).Format(dt64) + "'"
+}
+
+// cmpBeforeSQL renders the BUGGY shape: the Timestamp window sits on the
+// SELECT that wraps `s LEFT JOIN r`, so neither leg can MinMax-prune.
+func cmpBeforeSQL() string {
+	lo, hi := cmpWindow()
+	return `SELECT is_selection, attr, count() AS c FROM (
+  SELECT (StatusCode = 'Error') AS is_selection,
+         'svc' AS attr,
+         s.ServiceName AS sval
+  FROM (SELECT * FROM otel_traces) AS s
+  LEFT JOIN (
+    SELECT TraceId, any(SpanName) AS __root_name
+    FROM (SELECT * FROM otel_traces WHERE ParentSpanId = '') GROUP BY TraceId
+  ) AS r ON s.TraceId = r.TraceId
+  WHERE s.Timestamp > toDateTime64(` + lo + `, 9) - toIntervalNanosecond(60000000000)
+    AND s.Timestamp <= toDateTime64(` + hi + `, 9)
+) GROUP BY is_selection, attr, sval`
+}
+
+// cmpAfterSQL renders the FIXED shape: the window lives inside the 's'
+// scan and seeds the 'r' root scan via `TraceId IN (<bounded cohort>)`
+// — exactly the structure compareBaseQuery now emits.
+func cmpAfterSQL() string {
+	bound := cmpBound()
+	return `SELECT is_selection, attr, count() AS c FROM (
+  SELECT (StatusCode = 'Error') AS is_selection,
+         'svc' AS attr,
+         s.ServiceName AS sval
+  FROM (SELECT * FROM (SELECT * FROM otel_traces) WHERE ` + bound + `) AS s
+  LEFT JOIN (
+    SELECT * FROM (
+      SELECT TraceId, any(SpanName) AS __root_name
+      FROM (SELECT * FROM otel_traces WHERE ParentSpanId = '') GROUP BY TraceId
+    ) WHERE TraceId IN (
+      SELECT TraceId FROM (SELECT * FROM (SELECT * FROM otel_traces) WHERE ` + bound + `) AS _cmp_seed
+    )
+  ) AS r ON s.TraceId = r.TraceId
+) GROUP BY is_selection, attr, sval`
+}
+
+// cmpScanPartPrune returns (selected, total) parts for the FIRST
+// MinMax/Partition stage of a single-scan EXPLAIN indexes=1 plan — used
+// on the 's' span leg in isolation, where selected < total proves the
+// in-scan bound Partition-prunes to the window's day-partition(s).
+func cmpScanPartPrune(t *testing.T, db *sql.DB, query string) (selected, total int) {
+	t.Helper()
+	rows, err := db.Query("EXPLAIN indexes=1 " + query)
+	if err != nil {
+		t.Fatalf("EXPLAIN: %v\nquery: %s", err, query)
+	}
+	defer rows.Close()
+	seen := false
+	for rows.Next() {
+		var line string
+		if err := rows.Scan(&line); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		trim := trimSpace(line)
+		if hasPrefix(trim, "Parts:") && !seen {
+			selected, total = tsPartsFraction(trim)
+			seen = true
+		}
+	}
+	if !seen {
+		t.Fatalf("EXPLAIN produced no Parts line for:\n%s", query)
+	}
+	return selected, total
+}
+
+// cmpCount runs a scalar `SELECT count() ...` and returns the count.
+func cmpCount(t *testing.T, db *sql.DB, query string) int {
+	t.Helper()
+	var n int
+	if err := db.QueryRow(query).Scan(&n); err != nil {
+		t.Fatalf("count query: %v\nquery: %s", err, query)
+	}
+	return n
+}
+
+// cmpBound is the (Start-range, End] window predicate over a bare
+// Timestamp column — the exact bound the emitter pushes into each scan.
+func cmpBound() string {
+	lo, hi := cmpWindow()
+	return `Timestamp > toDateTime64(` + lo + `, 9) - toIntervalNanosecond(60000000000) ` +
+		`AND Timestamp <= toDateTime64(` + hi + `, 9)`
+}
+
+// cmpSLegSQL is the bounded 's' span leg in isolation (the scan the
+// emitter aliases `AS s`): a single MergeTree scan carrying the window
+// in its own WHERE.
+func cmpSLegSQL() string {
+	return `SELECT SpanId FROM (SELECT * FROM otel_traces) WHERE ` + cmpBound()
+}
+
+// cmpRootLegUnboundedSQL / cmpRootLegSeededSQL are the per-trace root
+// lookup WITHOUT and WITH the `TraceId IN (<bounded cohort>)` seed — the
+// join's right side before and after the fix. The seeded form returns
+// only the window cohort's roots.
+func cmpRootLegUnboundedSQL() string {
+	return `SELECT count() FROM (
+  SELECT TraceId, any(SpanName) AS __root_name
+  FROM (SELECT * FROM otel_traces WHERE ParentSpanId = '') GROUP BY TraceId
+)`
+}
+
+func cmpRootLegSeededSQL() string {
+	return `SELECT count() FROM (
+  SELECT TraceId, any(SpanName) AS __root_name
+  FROM (SELECT * FROM otel_traces WHERE ParentSpanId = '') GROUP BY TraceId
+) WHERE TraceId IN (
+  SELECT TraceId FROM (SELECT * FROM (SELECT * FROM otel_traces) WHERE ` + cmpBound() + `) AS _cmp_seed
+)`
+}
+
+// cmpCohort runs `query` and returns the sorted (is_selection, attr,
+// sval, count) rows flattened to strings — the parity fingerprint.
+func cmpCohort(t *testing.T, db *sql.DB, query string) []string {
+	t.Helper()
+	rows, err := db.Query(query)
+	if err != nil {
+		t.Fatalf("query: %v\nquery: %s", err, query)
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var sel uint8
+		var attr string
+		var c uint64
+		if err := rows.Scan(&sel, &attr, &c); err != nil {
+			t.Fatalf("scan cohort: %v", err)
+		}
+		out = append(out, strings.Join([]string{
+			itoa(int(sel)), attr, itoa(int(c)),
+		}, "|"))
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestCompareWindowPrune_JoinLegs pins FIX-1: the compare matrix window
+// must prune BOTH join legs' scans (AFTER strictly fewer parts than
+// BEFORE) while returning an identical cohort.
+func TestCompareWindowPrune_JoinLegs(t *testing.T) {
+	db, err := sql.Open("chdb", "")
+	if err != nil {
+		t.Fatalf("open chdb: %v", err)
+	}
+	defer db.Close()
+
+	for _, stmt := range []string{cmpSpansDDL, cmpSpansInsert()} {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("setup exec failed:\n%s\nerr: %v", stmt, err)
+		}
+	}
+	// One dense part per day-partition so the MinMax stage has real parts
+	// to prune (not inflated unmerged insert parts).
+	if _, err := db.Exec("OPTIMIZE TABLE otel_traces FINAL"); err != nil {
+		t.Fatalf("optimize: %v", err)
+	}
+
+	t.Logf("=== compare join window prune: %d spans, %d spans/trace, %d day-partitions ===",
+		cmpTotalSpans, cmpSpansPerTrace, cmpNumDays)
+
+	// --- PARITY: BEFORE and AFTER return the identical cohort -----------
+	beforeRows := cmpCohort(t, db, cmpBeforeSQL())
+	afterRows := cmpCohort(t, db, cmpAfterSQL())
+	if len(beforeRows) == 0 {
+		t.Fatalf("BEFORE returned no cohort rows — corpus seed degenerate")
+	}
+	if len(beforeRows) != len(afterRows) {
+		t.Fatalf("PARITY VIOLATION: BEFORE %d cohort rows, AFTER %d — window must be correctness-preserving\nBEFORE=%v\nAFTER=%v",
+			len(beforeRows), len(afterRows), beforeRows, afterRows)
+	}
+	for i := range beforeRows {
+		if beforeRows[i] != afterRows[i] {
+			t.Fatalf("PARITY VIOLATION at row %d: BEFORE=%q AFTER=%q", i, beforeRows[i], afterRows[i])
+		}
+	}
+
+	// --- 's' leg: in-scan bound MinMax-Partition-prunes the span scan ---
+	sSel, sTot := cmpScanPartPrune(t, db, cmpSLegSQL())
+	t.Logf("'s' span leg MinMax parts: %d/%d", sSel, sTot)
+	if sTot < cmpNumDays {
+		t.Fatalf("'s' leg saw %d parts total, want >= %d day-partitions — corpus not dense enough to prove pruning",
+			sTot, cmpNumDays)
+	}
+	if sSel >= sTot {
+		t.Fatalf("'s' span leg did NOT Partition-prune (selected %d of %d parts): the (Start-range, End] "+
+			"window must scope the span scan to the window's day-partition(s).", sSel, sTot)
+	}
+
+	// --- 'r' leg: trace-id seed cuts the root join-input to the cohort --
+	rootAll := cmpCount(t, db, cmpRootLegUnboundedSQL())
+	rootSeeded := cmpCount(t, db, cmpRootLegSeededSQL())
+	t.Logf("'r' root leg rows: unbounded=%d seeded=%d", rootAll, rootSeeded)
+	if rootAll == 0 {
+		t.Fatalf("unbounded root leg returned 0 rows — corpus seed degenerate")
+	}
+	if rootSeeded >= rootAll {
+		t.Fatalf("'r' root leg seed did NOT reduce the join input (seeded %d >= unbounded %d): "+
+			"`TraceId IN (<bounded cohort>)` must scope the root lookup to the window cohort's traces.",
+			rootSeeded, rootAll)
+	}
+}
+
+// tsPartsFraction parses an EXPLAIN `Parts: N/M` line into (N, M).
+func tsPartsFraction(s string) (selected, total int) {
+	s = stripPrefix(trimSpace(s), "Parts: ")
+	i := 0
+	for ; i < len(s) && s[i] >= '0' && s[i] <= '9'; i++ {
+		selected = selected*10 + int(s[i]-'0')
+	}
+	if i < len(s) && s[i] == '/' {
+		for i++; i < len(s) && s[i] >= '0' && s[i] <= '9'; i++ {
+			total = total*10 + int(s[i]-'0')
+		}
+	}
+	return selected, total
+}


### PR DESCRIPTION
## Problem
The traces-drilldown `compare()` (and matrix metrics) emitter placed the request `[start,end]` Timestamp filter **above** the `s LEFT JOIN r` (root-span lookup), so CH 24.12 couldn't push it into either MergeTree scan. Prod: a 15-min drilldown read **~731M rows** (~96% of `otel_traces`) and OOM'd at the 2 GiB per-query cap (Code 241). `EXPLAIN estimate`: **769M → 5.9M rows (~130×), 61 → 2 parts**.

## Fix
`compareBaseQuery` now pushes the window **inside the `s` scan** (`(SELECT * FROM otel_traces WHERE Timestamp > lo AND <= hi) AS s`) and seeds the root leg via **`TraceId IN (<bounded cohort>)`** (mirroring `structuralSeedTraceFilter`) rather than a raw Timestamp bound — which preserves `rootName`/`rootServiceName` enrichment for traces straddling the window edge. All typed Frags; no raw SQL.

## Audit
`structural_join.go` direct/sibling joins are **clean** — their legs already fold the window inside each scan; only the distinct-span rule sits above the join.

## Tests
- Emitter-shape unit test (`internal/chsql`) — **verified it FAILS on baseline** (bound above join), passes with the fix.
- chdb perf guard `TestCompareWindowPrune_JoinLegs` — `s` leg partition-prunes (1/10 parts), `r` seed cuts 250k→25k, BEFORE/AFTER cohort row-parity holds. Closes the perf-gate coverage hole (it only covered single-scan shapes).
- Portable to CH 24.12; spec goldens unchanged (zero churn).

Adversarial review: **APPROVE** (correctness + row-parity + hard rules all witnessed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)