### PR TITLE
fix(chclient): unique query_id for the columnar row-fallback to avoid CH code 216

### DIFF
--- a/internal/chclient/client.go
+++ b/internal/chclient/client.go
@@ -921,6 +921,28 @@ func queryIDFromContext(ctx context.Context) string {
 	return id
 }
 
+// freshQueryID mints a NEW per-dispatch query_id for ctx and re-stamps it onto
+// the returned context, OVERWRITING any id ensureQueryID previously cached. It
+// exists for the one case where a single logical query drives a SECOND physical
+// ClickHouse execution under the same ctx: the columnar matrix decode's row-path
+// fallback. The columnar attempt already dispatched the cached id to the server;
+// reusing that same id for the fallback collides with the still-running columnar
+// query on a slow backend and ClickHouse rejects the fallback with code 216
+// (QUERY_WITH_SAME_ID_IS_ALREADY_RUNNING). A fresh counter value keeps the
+// fallback's id unique while preserving the "<traceID>-<spanID>-<counter>" shape
+// (the trace id stays a greppable prefix). When no valid trace is present the id
+// is "" (the driver self-generates one) and ctx is returned unchanged, matching
+// ensureQueryID's no-trace contract.
+func freshQueryID(ctx context.Context) (string, context.Context) {
+	sc := trace.SpanContextFromContext(ctx)
+	if !sc.HasTraceID() {
+		return "", ctx
+	}
+	id := sc.TraceID().String() + "-" + sc.SpanID().String() + "-" +
+		strconv.FormatUint(queryIDCounter.Add(1), 10)
+	return id, context.WithValue(ctx, queryIDKey, id)
+}
+
 // EnsureQueryID is the exported single-source-of-truth seam for the
 // per-dispatch ClickHouse query_id. It returns the id for ctx (generating and
 // caching it on the returned context if absent) so the engine can fix ONE id

--- a/internal/chclient/decoder.go
+++ b/internal/chclient/decoder.go
@@ -145,6 +145,16 @@ type columnarDecoder struct {
 // bindable): a false with nil err means "not the matrix shape" — delegate to
 // the embedded row path, byte-unchanged from the flag-off behaviour. A non-nil
 // err is a real, already-classified-and-recorded failure and surfaces as-is.
+//
+// The columnar attempt already dispatched the cached per-dispatch query_id to
+// ClickHouse. On a slow backend that query can still be running when the row
+// fallback fires, so the fallback MUST run under a FRESH query_id — reusing the
+// cached one collides with the in-flight columnar query and ClickHouse rejects
+// the fallback with code 216 (QUERY_WITH_SAME_ID_IS_ALREADY_RUNNING). The
+// columnar attempt keeps the original (optcorpus-recorded) id; only this second
+// physical execution re-keys, so the corpus reconciler's join key still matches
+// the primary attempt's terminal query_log row, and cancellation (ctx-based)
+// is unaffected by the id string.
 func (d columnarDecoder) decode(c *Client, ctx context.Context, sql string, args ...any) (Cursor, error) {
 	cur, ok, err := d.queryCursorColumnar(c, ctx, sql, args...)
 	if err != nil {
@@ -153,6 +163,7 @@ func (d columnarDecoder) decode(c *Client, ctx context.Context, sql string, args
 	if ok {
 		return cur, nil
 	}
+	_, ctx = freshQueryID(ctx)
 	return d.fallback.decode(c, ctx, sql, args...)
 }
 

--- a/internal/chclient/query_settings_test.go
+++ b/internal/chclient/query_settings_test.go
@@ -184,3 +184,98 @@ func TestQueryContext_StampsAndCachesQueryID(t *testing.T) {
 		t.Errorf("cached query_id %q is not prefixed by the trace id", got)
 	}
 }
+
+// TestFreshQueryID_DistinctFromCached — freshQueryID mints a NEW id even when
+// ctx already carries a cached one (the columnar attempt's id), overwriting the
+// cache so a SECOND physical execution under the same ctx never reuses the
+// in-flight id. This is the code-216 guard: the columnar matrix attempt and its
+// row-path fallback are two physical CH executions under one request ctx, and
+// they MUST carry distinct query_ids or the slow-backend fallback collides with
+// the still-running columnar query.
+func TestFreshQueryID_DistinctFromCached(t *testing.T) {
+	t.Parallel()
+
+	tid := trace.TraceID{
+		0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00, 0x11,
+		0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99,
+	}
+	sid := trace.SpanID{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00, 0x11}
+	prefix := tid.String() + "-"
+
+	// The columnar attempt fixes its id (the engine's EnsureQueryID seam).
+	columnarID, ctx := ensureQueryID(tracedCtx(tid, sid))
+	if columnarID == "" {
+		t.Fatal("ensureQueryID returned empty under a valid trace")
+	}
+
+	// The fallback re-keys: a fresh, DISTINCT id that overwrites the cache.
+	fallbackID, ctx := freshQueryID(ctx)
+	if fallbackID == "" {
+		t.Fatal("freshQueryID returned empty under a valid trace")
+	}
+	if fallbackID == columnarID {
+		t.Fatalf("fallback reused the columnar query_id %q; ClickHouse would reject it with code 216", columnarID)
+	}
+	if !strings.HasPrefix(fallbackID, prefix) {
+		t.Errorf("fallback query_id %q lost the trace prefix %q", fallbackID, prefix)
+	}
+
+	// The cache now reads back the FRESH id — the row fallback's queryContext
+	// (which reads queryIDFromContext) stamps the distinct id, not the columnar
+	// one.
+	if got := queryIDFromContext(ctx); got != fallbackID {
+		t.Errorf("queryIDFromContext after freshQueryID = %q; want the re-keyed %q", got, fallbackID)
+	}
+}
+
+// TestFreshQueryID_NoTrace — with no valid trace, freshQueryID yields "" and
+// leaves ctx unchanged (the driver self-generates an id), mirroring
+// ensureQueryID's no-trace contract so an un-instrumented fallback is never an
+// error path.
+func TestFreshQueryID_NoTrace(t *testing.T) {
+	t.Parallel()
+
+	id, out := freshQueryID(context.Background())
+	if id != "" {
+		t.Errorf("freshQueryID(plain) = %q; want empty", id)
+	}
+	if out != context.Background() {
+		t.Error("freshQueryID(plain) re-keyed the ctx; want it unchanged when no trace is present")
+	}
+}
+
+// TestColumnarFallback_DistinctQueryIDFromColumnar — drives the columnar
+// decoder's fallback path the way a non-matrix shape (the Loki log-stream
+// projection) does in production: the columnar attempt caches its id, then the
+// row fallback re-keys via freshQueryID before queryContext stamps it. Asserts
+// the two physical executions resolve to DISTINCT ids end-to-end through
+// queryContext (the WithQueryID stamp), which is the exact pairing ClickHouse
+// rejected with code 216 before the fix.
+func TestColumnarFallback_DistinctQueryIDFromColumnar(t *testing.T) {
+	t.Parallel()
+
+	tid := trace.TraceID{
+		0x2b, 0x58, 0x00, 0x71, 0x90, 0xa6, 0x32, 0xed,
+		0x79, 0xd3, 0x3b, 0xb7, 0xc4, 0xd2, 0x4b, 0x1e,
+	}
+	sid := trace.SpanID{0x1f, 0xb3, 0xec, 0x1e, 0x9b, 0x59, 0xe6, 0x14}
+	c := &Client{}
+
+	// Columnar attempt: queryContext caches + stamps the id queryCursorColumnar
+	// sends to ch-go.
+	columnarCtx := c.queryContext(tracedCtx(tid, sid))
+	columnarID := queryIDFromContext(columnarCtx)
+
+	// Fallback: columnarDecoder.decode re-keys with freshQueryID, then the row
+	// path's queryContext reads back the re-keyed id.
+	_, fallbackBaseCtx := freshQueryID(columnarCtx)
+	fallbackCtx := c.queryContext(fallbackBaseCtx)
+	fallbackID := queryIDFromContext(fallbackCtx)
+
+	if columnarID == "" || fallbackID == "" {
+		t.Fatalf("expected non-empty ids; got columnar=%q fallback=%q", columnarID, fallbackID)
+	}
+	if columnarID == fallbackID {
+		t.Fatalf("columnar and fallback share query_id %q; this is the code-216 collision the fix prevents", columnarID)
+	}
+}


### PR DESCRIPTION
## Problem
Prod (logs drilldown, S3-backed CH) fails ~everywhere with **CH code 216 `QUERY_WITH_SAME_ID_IS_ALREADY_RUNNING`**.

**Proven mechanism (prod `system.query_log` + code):** `EnsureQueryID` mints `<traceID>-<spanID>-<counter>` once per logical query and **caches it on ctx**. The `columnar_result_decode` path dispatches the matrix query with that cached id; for a Loki log-stream projection (5 cols, not the 4-col matrix) it hits `errMatrixMismatch` and **falls back to the row path with the SAME cached id** while the columnar query is **still running** on the slow S3 backend → 216.

Prod evidence for the failing id: columnar `QueryStart` (never finishes) → row `ExceptionBeforeStart` code 216 **32 ms later**, identical SQL (`normalizeQuery` distinct=1), same replica; the abandoned columnar query later resets (code 210). 17 such 216s in a day.

## Fix
`freshQueryID(ctx)` mints a new id and overwrites the cached `queryIDKey`; `columnarDecoder.decode` calls it **before** delegating to the row fallback, so the two physical executions never collide.

**Preserves:** cancellation (ctx-based — no `KILL QUERY … WHERE query_id` anywhere), optcorpus (the columnar/common path keeps the originally-recorded id so the `system.query_log` join key still matches), observability (id format unchanged, trace prefix intact).

Tests: distinct-id unit tests + an end-to-end columnar→fallback test asserting distinct stamped ids (the exact pairing CH rejected). Build + chclient/engine/optcorpus tests green.

Targets v1.7.x; **backported to 1.6.x as v1.6.3** (prod runs 1.6.x).

🤖 Generated with [Claude Code](https://claude.com/claude-code)