### PR TITLE
fix(prom): push request time window into metric-name + label-values discovery

### DIFF
--- a/internal/api/prom/metadata.go
+++ b/internal/api/prom/metadata.go
@@ -253,7 +253,7 @@ func (h *Handler) handleLabels(w http.ResponseWriter, r *http.Request) {
 
 	var names []string
 	if len(matchers) == 0 {
-		names, err = h.fetchLabelNames(r.Context())
+		names, err = h.fetchLabelNames(r.Context(), startT, endT)
 	} else {
 		names, err = h.fetchLabelNamesMatched(r.Context(), matchers, startT, endT)
 	}
@@ -317,7 +317,7 @@ func (h *Handler) handleLabelValues(w http.ResponseWriter, r *http.Request) {
 
 	var values []string
 	if len(matchers) == 0 {
-		values, err = h.fetchLabelValues(r.Context(), name)
+		values, err = h.fetchLabelValues(r.Context(), name, startT, endT)
 	} else {
 		values, err = h.fetchLabelValuesMatched(r.Context(), name, matchers, startT, endT)
 	}
@@ -589,8 +589,8 @@ func (h *Handler) handleSeries(w http.ResponseWriter, r *http.Request) {
 // stores dotted keys (`service.name`, `http.request.method`) that PromQL
 // grammar forbids in identifier position; without the rewrite, panels
 // doing `sum by (service_name)` silently produce empty matrices.
-func (h *Handler) fetchLabelNames(ctx context.Context) ([]string, error) {
-	sql := h.unionLabelNamesSQL()
+func (h *Handler) fetchLabelNames(ctx context.Context, start, end time.Time) ([]string, error) {
+	sql := h.unionLabelNamesSQL(start, end)
 	names, err := timeCH(ctx, func() ([]string, error) {
 		return h.Client.QueryStrings(ctx, sql)
 	})
@@ -599,7 +599,7 @@ func (h *Handler) fetchLabelNames(ctx context.Context) ([]string, error) {
 	}
 	collected := append([]string{model.MetricNameLabel}, names...)
 	if h.resourceArmActive() {
-		resNames, err := h.fetchResourceLabelNames(ctx)
+		resNames, err := h.fetchResourceLabelNames(ctx, start, end)
 		if err != nil {
 			return nil, err
 		}
@@ -616,9 +616,9 @@ func (h *Handler) fetchLabelNames(ctx context.Context) ([]string, error) {
 // allowlist = every key) and emitted in its dot->underscore sanitized form
 // (the wire spelling operators see in Grafana). The caller folds these into
 // the /labels listing alongside the Attributes keys + __name__.
-func (h *Handler) fetchResourceLabelNames(ctx context.Context) ([]string, error) {
+func (h *Handler) fetchResourceLabelNames(ctx context.Context, start, end time.Time) ([]string, error) {
 	resNames, err := timeCH(ctx, func() ([]string, error) {
-		return h.Client.QueryStrings(ctx, h.unionResourceLabelNamesSQL())
+		return h.Client.QueryStrings(ctx, h.unionResourceLabelNamesSQL(start, end))
 	})
 	if err != nil {
 		return nil, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusBadGateway}
@@ -643,11 +643,11 @@ func (h *Handler) fetchResourceLabelNames(ctx context.Context) ([]string, error)
 	return out, nil
 }
 
-func (h *Handler) fetchLabelValues(ctx context.Context, name string) ([]string, error) {
+func (h *Handler) fetchLabelValues(ctx context.Context, name string, start, end time.Time) ([]string, error) {
 	if name == model.MetricNameLabel {
-		return h.fetchMetricNameValues(ctx)
+		return h.fetchMetricNameValues(ctx, start, end)
 	}
-	sql, args := h.unionLabelValuesSQL(name)
+	sql, args := h.unionLabelValuesSQL(name, start, end)
 	values, err := timeCH(ctx, func() ([]string, error) {
 		return h.Client.QueryStrings(ctx, sql, args...)
 	})
@@ -691,11 +691,11 @@ func (h *Handler) fetchLabelValues(ctx context.Context, name string) ([]string, 
 // the summary table has no lowering at all), and advertising names the
 // query surface can't serve is exactly the bug this function's split
 // shape exists to prevent.
-func (h *Handler) fetchMetricNameValues(ctx context.Context) ([]string, error) {
+func (h *Handler) fetchMetricNameValues(ctx context.Context, start, end time.Time) ([]string, error) {
 	bareTables, histogramTable := h.catalogNameTables()
 	var values []string
 	if len(bareTables) > 0 {
-		sql := h.metricNamesSQL(bareTables)
+		sql := h.metricNamesSQL(bareTables, start, end)
 		bare, err := timeCH(ctx, func() ([]string, error) {
 			return h.Client.QueryStrings(ctx, sql)
 		})
@@ -709,7 +709,7 @@ func (h *Handler) fetchMetricNameValues(ctx context.Context) ([]string, error) {
 		values = normalizeMetricValues(bare)
 	}
 	if histogramTable != "" {
-		sql := h.metricNamesSQL([]string{histogramTable})
+		sql := h.metricNamesSQL([]string{histogramTable}, start, end)
 		hist, err := timeCH(ctx, func() ([]string, error) {
 			return h.Client.QueryStrings(ctx, sql)
 		})
@@ -1245,14 +1245,18 @@ func (h *Handler) resourceLabelValueArmActive(promLabel string) bool {
 }
 
 // unionLabelNamesSQL builds a UNION of all metric tables' label keys.
-func (h *Handler) unionLabelNamesSQL() string {
+func (h *Handler) unionLabelNamesSQL(start, end time.Time) string {
 	tables := h.metricTables()
 	attrsCol := h.Schema.AttributesColumn
+	pred := h.metadataWindowPred(start, end)
 	parts := make([]chsql.Frag, 0, len(tables))
 	for _, t := range tables {
 		arm := chsql.NewQuery().
 			Select(chsql.As(arrayJoinMapKeysFrag(attrsCol), "name")).
 			From(chsql.Col(t))
+		if pred != nil {
+			arm = arm.Where(pred)
+		}
 		parts = append(parts, arm.Frag())
 	}
 	outer := chsql.NewQuery().
@@ -1269,14 +1273,18 @@ func (h *Handler) unionLabelNamesSQL() string {
 // sanitizes + allowlist-filters in Go (cheaper than an N-key SQL IN over
 // every row's map, and it keeps the Attributes union byte-identical so the
 // promote-all default adds no churn to existing fixtures).
-func (h *Handler) unionResourceLabelNamesSQL() string {
+func (h *Handler) unionResourceLabelNamesSQL(start, end time.Time) string {
 	tables := h.metricTables()
 	resCol := h.Schema.ResourceAttributesColumn
+	pred := h.metadataWindowPred(start, end)
 	parts := make([]chsql.Frag, 0, len(tables))
 	for _, t := range tables {
 		arm := chsql.NewQuery().
 			Select(chsql.As(arrayJoinMapKeysFrag(resCol), "name")).
 			From(chsql.Col(t))
+		if pred != nil {
+			arm = arm.Where(pred)
+		}
 		parts = append(parts, arm.Frag())
 	}
 	outer := chsql.NewQuery().
@@ -1287,17 +1295,61 @@ func (h *Handler) unionResourceLabelNamesSQL() string {
 	return sql
 }
 
+// dateTime64Frag renders the `toDateTime64('<ts>', 9)` literal used to
+// bound the metadata-discovery window. It mirrors the matched-path bound
+// emitted by promql.metadataBoundExpr so the unmatched (no-`match[]`)
+// discovery arms carry byte-identical time semantics.
+func dateTime64Frag(t time.Time) chsql.Frag {
+	return chsql.Frag(func(b *chsql.Builder) { b.DateTime64Lit(t) })
+}
+
+// metadataWindowPred builds the closed `[start,end]` TimeUnix bound the
+// no-`match[]` discovery arms push so a request that carries a window
+// (Grafana's metric/label picker forwards the dashboard range) prunes by
+// the `toDate(TimeUnix)` partition instead of streaming the whole table —
+// turning the leading-key DISTINCT from an O(rows) full-column scan into
+// an O(window) partition-bounded scan. Each bound is omitted when zero, so
+// a no-bound side scans the whole table, matching reference Prometheus's
+// min/max-retention default and the matched-path semantics in
+// promql.wrapMetadataFullRange. Returns nil when both bounds are zero
+// (no WHERE emitted — byte-identical to the prior unbounded form, which is
+// the inherent exact answer when the caller supplies no window).
+func (h *Handler) metadataWindowPred(start, end time.Time) chsql.Frag {
+	tsCol := h.Schema.TimestampColumn
+	var bounds []chsql.Frag
+	if !start.IsZero() {
+		bounds = append(bounds, chsql.Gte(chsql.Col(tsCol), dateTime64Frag(start)))
+	}
+	if !end.IsZero() {
+		bounds = append(bounds, chsql.Lte(chsql.Col(tsCol), dateTime64Frag(end)))
+	}
+	switch len(bounds) {
+	case 0:
+		return nil
+	case 1:
+		return bounds[0]
+	default:
+		return chsql.And(bounds...)
+	}
+}
+
 // metricNamesSQL returns the distinct MetricName values across the
 // given tables. Callers group tables by how their names surface in the
 // catalog (see fetchMetricNameValues) — the SQL shape itself is the
-// same UNION-of-DISTINCT-arms for any group size.
-func (h *Handler) metricNamesSQL(tables []string) string {
+// same UNION-of-DISTINCT-arms for any group size. A non-zero start/end
+// pushes the closed metadata window onto each arm so the leading-key
+// DISTINCT prunes by partition instead of scanning the whole table.
+func (h *Handler) metricNamesSQL(tables []string, start, end time.Time) string {
 	metricCol := h.Schema.MetricNameColumn
+	pred := h.metadataWindowPred(start, end)
 	parts := make([]chsql.Frag, 0, len(tables))
 	for _, t := range tables {
 		arm := chsql.NewQuery().
 			Select(chsql.As(distinctIdent(metricCol), "value")).
 			From(chsql.Col(t))
+		if pred != nil {
+			arm = arm.Where(pred)
+		}
 		parts = append(parts, arm.Frag())
 	}
 	outer := chsql.NewQuery().
@@ -1324,19 +1376,30 @@ func (h *Handler) metricNamesSQL(tables []string) string {
 // Mirrors the matcher-side `attributeLookup` chain in
 // `internal/promql/lower.go`: both query and listing surfaces now
 // resolve the same Prom-grammar → OTel-key candidates the same way.
-func (h *Handler) unionLabelValuesSQL(name string) (string, []any) {
+func (h *Handler) unionLabelValuesSQL(name string, start, end time.Time) (string, []any) {
 	tables := h.metricTables()
 	attrsCol := h.Schema.AttributesColumn
 	candidates := labelValueCandidates(name)
 	resCol := h.Schema.ResourceAttributesColumn
 	resourceArm := h.resourceLabelValueArmActive(name)
+	pred := h.metadataWindowPred(start, end)
+	// withWindow ANDs the closed metadata window onto an arm's not-empty
+	// predicate so the per-table scan prunes by partition when a window is
+	// present; with no window it returns the not-empty predicate unchanged
+	// (byte-identical to the prior emit).
+	withWindow := func(notEmpty chsql.Frag) chsql.Frag {
+		if pred == nil {
+			return notEmpty
+		}
+		return chsql.And(notEmpty, pred)
+	}
 	parts := make([]chsql.Frag, 0, len(tables)*len(candidates)*2)
 	for _, t := range tables {
 		for _, k := range candidates {
 			arm := chsql.NewQuery().
 				Select(chsql.As(distinctMapAtFrag(attrsCol, k), "value")).
 				From(chsql.Col(t)).
-				Where(mapAtNotEmptyFrag(attrsCol, k))
+				Where(withWindow(mapAtNotEmptyFrag(attrsCol, k)))
 			parts = append(parts, arm.Frag())
 			// Resource arm: read the same candidate key out of the
 			// ResourceAttributes map so a value stored only under a
@@ -1348,7 +1411,7 @@ func (h *Handler) unionLabelValuesSQL(name string) (string, []any) {
 				resArm := chsql.NewQuery().
 					Select(chsql.As(distinctMapAtFrag(resCol, k), "value")).
 					From(chsql.Col(t)).
-					Where(mapAtNotEmptyFrag(resCol, k))
+					Where(withWindow(mapAtNotEmptyFrag(resCol, k)))
 				parts = append(parts, resArm.Frag())
 			}
 		}

--- a/internal/api/prom/metadata_test.go
+++ b/internal/api/prom/metadata_test.go
@@ -188,6 +188,63 @@ func TestLabelValues_MetricNameLabel(t *testing.T) {
 	}
 }
 
+// TestMetadataDiscovery_WindowPrune pins the index/partition-bounding fix:
+// the no-`match[]` discovery endpoints (`/label/__name__/values`,
+// `/labels`, `/label/<name>/values`) must push the request `start`/`end`
+// window onto each per-table arm so ClickHouse prunes by the
+// `toDate(TimeUnix)` partition instead of streaming the full leading-key
+// column (the unbounded `SELECT DISTINCT MetricName` that scanned ~2.6B
+// rows in prod). When no window is sent the SQL stays unbounded — that is
+// the inherent exact answer for Prometheus's no-bound metadata semantics.
+func TestMetadataDiscovery_WindowPrune(t *testing.T) {
+	t.Parallel()
+
+	const window = "start=1700000000&end=1700003600"
+	cases := []struct {
+		name string
+		path string
+	}{
+		{"metric_names", "/api/v1/label/__name__/values"},
+		{"label_names", "/api/v1/labels"},
+		{"label_values", "/api/v1/label/job/values"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// With a window: every arm must carry the TimeUnix bound.
+			qw := &stubQuerier{strings: []string{"up"}}
+			srvW := newServer(qw)
+			t.Cleanup(srvW.Close)
+			resp, err := http.Get(srvW.URL + tc.path + "?" + window)
+			if err != nil {
+				t.Fatalf("GET windowed: %v", err)
+			}
+			resp.Body.Close()
+			if !strings.Contains(qw.lastSQL, "toDateTime64(") ||
+				!strings.Contains(qw.lastSQL, "TimeUnix") {
+				t.Errorf("windowed %s must push a TimeUnix partition bound; got %q",
+					tc.path, qw.lastSQL)
+			}
+
+			// Without a window: SQL stays unbounded (no time predicate),
+			// byte-for-byte the prior emit.
+			qn := &stubQuerier{strings: []string{"up"}}
+			srvN := newServer(qn)
+			t.Cleanup(srvN.Close)
+			resp, err = http.Get(srvN.URL + tc.path)
+			if err != nil {
+				t.Fatalf("GET unbounded: %v", err)
+			}
+			resp.Body.Close()
+			if strings.Contains(qn.lastSQL, "TimeUnix") {
+				t.Errorf("unbounded %s must not emit a TimeUnix bound; got %q",
+					tc.path, qn.lastSQL)
+			}
+		})
+	}
+}
+
 func TestLabelValues_InvalidName(t *testing.T) {
 	t.Parallel()
 

--- a/test/perf/metric_names_window_prune_chdb_test.go
+++ b/test/perf/metric_names_window_prune_chdb_test.go
@@ -1,0 +1,239 @@
+//go:build chdb
+
+// Lever: the no-`match[]` metric-name discovery endpoint
+// (`/api/v1/label/__name__/values`) must push the request [start,end]
+// window INTO each per-table scan so ClickHouse MinMax/Partition-prunes
+// by `toDate(TimeUnix)` — instead of streaming the full leading-key
+// column.
+//
+// The prod incident: `SELECT DISTINCT MetricName FROM otel_metrics_gauge`
+// (the unbounded arm cerberus emitted) read ~2.6B rows / 8-18s to return
+// ~2027 distinct names, timing out Grafana's 30s datasource limit. The
+// `optimize_distinct_in_order` path does NOT reduce read_rows — it removes
+// the hash table, not the full-column read — so the leading-key DISTINCT
+// is O(rows), not O(marks). There is no exact, marks-bounded shape for the
+// unbounded case (CH has no skip-scan for an exact distinct, and a
+// correlated-recursive loose-index-scan is unsupported), so the lever is
+// the request window: a bounded picker request must prune to its
+// day-partition(s).
+//
+// This guard pins two version-independent signals on a production-shaped
+// gauge table (PARTITION BY toDate(TimeUnix), the OTel-CH exporter's own
+// layout) seeded across many day-partitions, each day carrying its own
+// disjoint set of metric names:
+//
+//   - UNBOUNDED `SELECT DISTINCT MetricName` selects EVERY part
+//     (Parts: N/N) — the full-column scan that is the bug.
+//   - WINDOWED `... WHERE TimeUnix >= lo AND TimeUnix <= hi`
+//     MinMax-Partition-prunes to the window's day(s) (Parts: k/N, k < N)
+//     — the fix.
+//
+// Exactness is asserted too: the windowed distinct set equals exactly the
+// names whose samples fall in [lo,hi] (a strict subset of the full
+// catalog), so the prune is correctness-preserving — a discovery catalog
+// must stay exact. Build-tagged `chdb`, same lane as the rest.
+package perf
+
+import (
+	"database/sql"
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/chdb-io/chdb-go/chdb/driver"
+)
+
+const (
+	// mnwTotalRows / mnwNumDays / mnwNamesPerDay seed a dense, multi-day
+	// gauge corpus. Each row's MetricName is namespaced by its day, so the
+	// full catalog is mnwNumDays*mnwNamesPerDay names and any single-day
+	// window selects exactly mnwNamesPerDay of them — making the prune both
+	// measurable (other days' parts drop) and exactness-checkable (the
+	// other days' names must NOT appear).
+	mnwTotalRows     = 2_000_000
+	mnwNumDays       = 10
+	mnwNamesPerDay   = 20
+	mnwSecondsPerDay = 80_000
+	// mnwWindowDayIdx is the day-partition offset (from mnwSeedEpoch) the
+	// discovery window targets.
+	mnwWindowDayIdx = 4
+	mnwSeedEpoch    = "2026-01-01"
+)
+
+// mnwGaugeDDL is the production OTel-CH gauge table trimmed to the columns
+// this bench reads, with the exporter's partition + order key (MetricName
+// leads the sort, TimeUnix drives the partition).
+const mnwGaugeDDL = `CREATE OR REPLACE TABLE otel_metrics_gauge (
+    MetricName String CODEC(ZSTD(1)),
+    Attributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    ServiceName LowCardinality(String) CODEC(ZSTD(1)),
+    TimeUnix DateTime64(9) CODEC(Delta, ZSTD(1)),
+    Value Float64 CODEC(ZSTD(1))
+) ENGINE = MergeTree()
+PARTITION BY toDate(TimeUnix)
+ORDER BY (MetricName, Attributes, ServiceName, toUnixTimestamp64Nano(TimeUnix))
+SETTINGS index_granularity = 8192;`
+
+// mnwGaugeInsert scatters mnwTotalRows across mnwNumDays day-partitions
+// (dayIdx = number % mnwNumDays); each row's MetricName is
+// `m_<dayIdx>_<k>` so day W owns names `m_W_0 .. m_W_(mnwNamesPerDay-1)`
+// and no name crosses a day boundary.
+func mnwGaugeInsert() string {
+	return fmt.Sprintf(
+		`INSERT INTO otel_metrics_gauge
+SELECT
+    concat('m_', toString(number %% %d), '_', toString(intDiv(number, %d) %% %d)) AS MetricName,
+    map('job', concat('j', toString(number %% 5))) AS Attributes,
+    concat('svc.', toString(number %% 50)) AS ServiceName,
+    toDateTime64('%s 00:00:00', 9)
+        + INTERVAL (number %% %d) DAY
+        + INTERVAL (number %% %d) SECOND AS TimeUnix,
+    toFloat64(number %% 1000) AS Value
+FROM numbers(%d);`,
+		mnwNumDays, mnwNumDays, mnwNamesPerDay, // MetricName = m_<day>_<k>, k decorrelated from day via intDiv
+		mnwSeedEpoch,
+		mnwNumDays,       // day partition
+		mnwSecondsPerDay, // within-day second spread
+		mnwTotalRows,
+	)
+}
+
+// mnwWindow returns the [lo, hi] DateTime64 literals bounding the target
+// day-partition — the closed window the discovery request carries.
+func mnwWindow() (lo, hi string) {
+	epoch, _ := time.Parse("2006-01-02", mnwSeedEpoch)
+	day := epoch.AddDate(0, 0, mnwWindowDayIdx)
+	const dt64 = "2006-01-02 15:04:05.000000000"
+	return "'" + day.Format(dt64) + "'", "'" + day.AddDate(0, 0, 1).Format(dt64) + "'"
+}
+
+// mnwUnboundedSQL is the arm cerberus emitted before the fix: an unbounded
+// leading-key DISTINCT over the whole table.
+func mnwUnboundedSQL() string {
+	return `SELECT DISTINCT MetricName AS value FROM otel_metrics_gauge`
+}
+
+// mnwWindowedSQL is the arm cerberus emits after the fix: the same DISTINCT
+// with the closed [start,end] TimeUnix bound pushed into the scan.
+func mnwWindowedSQL() string {
+	lo, hi := mnwWindow()
+	return `SELECT DISTINCT MetricName AS value FROM otel_metrics_gauge ` +
+		`WHERE TimeUnix >= toDateTime64(` + lo + `, 9) AND TimeUnix <= toDateTime64(` + hi + `, 9)`
+}
+
+// mnwFirstPartsFraction returns (selected, total) parts from the FIRST
+// `Parts:` line of an `EXPLAIN indexes=1` plan — the MinMax/Partition
+// stage of the MergeTree scan.
+func mnwFirstPartsFraction(t *testing.T, db *sql.DB, query string) (selected, total int) {
+	t.Helper()
+	rows, err := db.Query("EXPLAIN indexes=1 " + query)
+	if err != nil {
+		t.Fatalf("EXPLAIN: %v\nquery: %s", err, query)
+	}
+	defer rows.Close()
+	seen := false
+	for rows.Next() {
+		var line string
+		if err := rows.Scan(&line); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		trim := trimSpace(line)
+		if hasPrefix(trim, "Parts:") && !seen {
+			selected, total = tsPartsFraction(trim)
+			seen = true
+		}
+	}
+	if !seen {
+		t.Fatalf("EXPLAIN produced no Parts line for:\n%s", query)
+	}
+	return selected, total
+}
+
+// mnwDistinctNames runs `query` and returns the sorted distinct names.
+func mnwDistinctNames(t *testing.T, db *sql.DB, query string) []string {
+	t.Helper()
+	rows, err := db.Query(query)
+	if err != nil {
+		t.Fatalf("query: %v\nquery: %s", err, query)
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var v string
+		if err := rows.Scan(&v); err != nil {
+			t.Fatalf("scan name: %v", err)
+		}
+		out = append(out, v)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestMetricNamesWindowPrune pins the discovery fix: the windowed
+// `__name__` arm must MinMax-Partition-prune to its day (strictly fewer
+// parts than the unbounded full scan) while returning EXACTLY the names in
+// the window — a strict, exact subset of the full catalog.
+func TestMetricNamesWindowPrune(t *testing.T) {
+	db := openChDB(t)
+	defer db.Close()
+
+	for _, stmt := range []string{mnwGaugeDDL, mnwGaugeInsert()} {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("setup exec failed:\n%s\nerr: %v", stmt, err)
+		}
+	}
+	// One dense part per day-partition so the MinMax stage has real parts
+	// to prune (not inflated unmerged insert parts).
+	if _, err := db.Exec("OPTIMIZE TABLE otel_metrics_gauge FINAL"); err != nil {
+		t.Fatalf("optimize: %v", err)
+	}
+
+	t.Logf("=== metric-name discovery window prune: %d rows, %d day-partitions, %d names/day ===",
+		mnwTotalRows, mnwNumDays, mnwNamesPerDay)
+
+	// --- UNBOUNDED: leading-key DISTINCT selects every part (the bug) ----
+	uSel, uTot := mnwFirstPartsFraction(t, db, mnwUnboundedSQL())
+	t.Logf("unbounded DISTINCT MinMax parts: %d/%d", uSel, uTot)
+	if uTot < mnwNumDays {
+		t.Fatalf("unbounded scan saw %d parts total, want >= %d day-partitions — corpus not dense enough to prove pruning",
+			uTot, mnwNumDays)
+	}
+	if uSel != uTot {
+		t.Fatalf("unbounded DISTINCT pruned parts (selected %d of %d) — expected the full-column scan that motivates the fix",
+			uSel, uTot)
+	}
+
+	// --- WINDOWED: in-scan bound Partition-prunes to the window day ------
+	wSel, wTot := mnwFirstPartsFraction(t, db, mnwWindowedSQL())
+	t.Logf("windowed DISTINCT MinMax parts: %d/%d", wSel, wTot)
+	if wSel >= wTot {
+		t.Fatalf("windowed DISTINCT did NOT Partition-prune (selected %d of %d parts): the [start,end] "+
+			"window must scope the metric-name scan to the window's day-partition(s).", wSel, wTot)
+	}
+
+	// --- EXACTNESS: windowed names == in-window names, ⊊ full catalog ----
+	full := mnwDistinctNames(t, db, mnwUnboundedSQL())
+	windowed := mnwDistinctNames(t, db, mnwWindowedSQL())
+	oracle := mnwDistinctNames(t, db, mnwWindowedSQL()+" SETTINGS optimize_distinct_in_order=0")
+	if len(full) != mnwNumDays*mnwNamesPerDay {
+		t.Fatalf("full catalog = %d names, want %d — seed degenerate", len(full), mnwNumDays*mnwNamesPerDay)
+	}
+	if strings.Join(windowed, ",") != strings.Join(oracle, ",") {
+		t.Fatalf("windowed distinct not setting-independent:\nwindowed=%v\noracle=%v", windowed, oracle)
+	}
+	if len(windowed) != mnwNamesPerDay {
+		t.Fatalf("windowed catalog = %d names, want %d (one day's namespace)\n%v", len(windowed), mnwNamesPerDay, windowed)
+	}
+	if len(windowed) >= len(full) {
+		t.Fatalf("windowed catalog (%d) must be a strict subset of full (%d)", len(windowed), len(full))
+	}
+	wantPrefix := fmt.Sprintf("m_%d_", mnwWindowDayIdx)
+	for _, n := range windowed {
+		if !hasPrefix(n, wantPrefix) {
+			t.Fatalf("windowed name %q outside window day (want prefix %q) — prune dropped a real name or leaked another day's",
+				n, wantPrefix)
+		}
+	}
+}


### PR DESCRIPTION
## Problem
cerberus answers Grafana's metric-name picker (`/api/v1/label/__name__/values`) and label-values discovery with an **unbounded full-table DISTINCT** — on a 2.6B-row `otel_metrics_gauge` it reads ~3.9B rows (~11s) to return ~2027 names, timing out Grafana's 30s limit.

## Root cause (measured on prod, not assumed)
The intuition that a DISTINCT over the leading ORDER BY key (`MetricName`) is marks-bounded is **falsified by measurement**: `optimize_distinct_in_order`/`optimize_aggregation_in_order` only drop the hash/sort buffer — they do **not** reduce reads. So the distinct is O(rows). The alias / UNION nesting are not the cause (all variants read ~2.6B). The only real lever is **partition pruning via the request window** (`PARTITION BY toDate(TimeUnix)`):

| shape | read_rows | time |
|---|---|---|
| current (unbounded, gauge+sum) | 3.9B | 11s |
| **windowed (1h)** | **25.7M** | **0.7s** |

## The gap
`internal/api/prom/metadata.go` parses `start`/`end` but **drops them on the no-`match[]` discovery path** — `fetchMetricNameValues`/`fetchLabelNames`/`fetchLabelValues` and the `union*SQL` builders never received a window. Only the *matched* path threaded it.

## Fix
Thread `start,end` through the four no-matcher discovery builders and push `TimeUnix >= … AND <= …` onto each per-table arm (typed chsql Frags, mirroring `promql.metadataBoundExpr`). `metadataWindowPred` returns nil when both bounds are zero ⇒ **byte-identical** no-window DDL. Exact (Prometheus `[start,end]` semantics, same as the matched path), portable (partition pruning predates 24.8). **label-values fixed too**, not deferred.

Honest scope: a literal no-window request still full-scans — that's the *correct* exact answer for Prometheus no-bound semantics; inventing a default window would drop metrics vs reference. The common Grafana case sends a range, so it's the one that mattered.

## Tests
- `TestMetadataDiscovery_WindowPrune` — bound emitted when windowed, absent when not (`__name__`, `/labels`, `/label/<n>/values`).
- `test/perf/metric_names_window_prune_chdb_test.go` — `EXPLAIN indexes=1`: unbounded 10/10 parts (bug) vs windowed 1/10 (fix), exact in-window parity.

Prod runs 1.7.x → **backport candidate to release/1.7.x**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)