### PR TITLE
chore(release): cerberus v1.7.1 / chart 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to cerberus will be documented in this file. The format roug
 
 ## [Unreleased]
 
+## [v1.7.1] — 2026-06-26
+
+### Fixed
+
+- **tempo:** bound windowless tag/attribute discovery to recent window (#1089)
+- **prom:** push request window into no-match metadata discovery scans (#1088)
+
 ## [v1.7.0] — 2026-06-25
 
 ### Added

--- a/deploy/helm/cerberus/Chart.yaml
+++ b/deploy/helm/cerberus/Chart.yaml
@@ -8,11 +8,11 @@ type: application
 # upgrade?" and is the publish trigger: a chart-only fix bumps this without an
 # app re-tag; an app-only release bumps appVersion + a PATCH here for the new
 # default image. Starts 0.x because the values contract is not yet frozen.
-version: 0.7.0
+version: 0.7.1
 
 # appVersion tracks the GA cerberus binary. Quoted so SemVer-shaped values
 # aren't coerced to floats. image.tag defaults from this when left empty.
-appVersion: "1.7.0"
+appVersion: "1.7.1"
 
 # autoscaling/v2 + policy/v1 (PDB) + networking/v1 (Ingress) are all GA from
 # 1.21+; 1.23 is the conservative floor matching the manifests this chart
@@ -45,19 +45,11 @@ annotations:
       url: https://github.com/tsouza/cerberus/blob/main/docs/operations.md
   artifacthub.io/images: |
     - name: cerberus
-      image: ghcr.io/tsouza/cerberus:v1.7.0
+      image: ghcr.io/tsouza/cerberus:v1.7.1
   # Bump the `1.0.0` floor here when the chart raises its minimum supported
   # cerberus release; informational for Artifact Hub's compatibility hints.
   artifacthub.io/changes: |
-    - kind: added
-      description: "api: add /info metadata + optimization fingerprint endpoint (#1082)"
-    - kind: added
-      description: "schema: configurable storage_policy + MergeTree settings on auto-created tables (#1081)"
     - kind: fixed
-      description: "chclient: re-key query_id on columnar row-path fallback to avoid CH 216 (#1086)"
+      description: "tempo: bound windowless tag/attribute discovery to recent window (#1089)"
     - kind: fixed
-      description: "release: maintenance preflight waits for CI to finish instead of snapshotting (#1083)"
-    - kind: fixed
-      description: "traceql: push time bound into compare scan + root leg, not above the join (#1080)"
-    - kind: fixed
-      description: "chopt: probe CH version over the default connection so a missing otel DB no longer pins 24.8 (#1079)"
+      description: "prom: push request window into no-match metadata discovery scans (#1088)"

--- a/deploy/helm/cerberus/README.md
+++ b/deploy/helm/cerberus/README.md
@@ -5,7 +5,7 @@
      pipe-aligned, and the version footer adds a trailing blank — both are
      owned by helm-docs; realigning would fight the chart-ci drift check. -->
 
-![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.7.0](https://img.shields.io/badge/AppVersion-1.7.0-informational?style=flat-square)
+![Version: 0.7.1](https://img.shields.io/badge/Version-0.7.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.7.1](https://img.shields.io/badge/AppVersion-1.7.1-informational?style=flat-square)
 
 Drop-in Prometheus / Loki / Tempo HTTP gateway for ClickHouse — a single stateless gateway that speaks three upstream query wire formats and lowers each to parameterised ClickHouse SQL.
 


### PR DESCRIPTION
Release-prep for **v1.7.1** (chart **0.7.1**), generated by `prepare-release.yml`.

- appVersion 1.7.0 -> 1.7.1, chart 0.7.0 -> 0.7.1

### Changes

### Fixed

- **tempo:** bound windowless tag/attribute discovery to recent window (#1089)
- **prom:** push request window into no-match metadata discovery scans (#1088)

Generated from the conventional commits since the last tag. Review and edit before merging; the tag is cut once this lands.
