### PR TITLE
chore(release): cerberus v1.8.0 / chart 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to cerberus will be documented in this file. The format roug
 
 ## [Unreleased]
 
+## [v1.8.0] — 2026-06-26
+
+### Added
+
+- **chopt:** auto-enable native time-series aggregates on capable servers (#1091)
+
+### Fixed
+
+- **chsql:** dedup duplicate-timestamp samples in row-path rate/increase/delta (#1092)
+- **chopt:** ts_grid capability probe falsely disabled native aggregates on healthy servers (#1094)
+
 ## [v1.7.1] — 2026-06-26
 
 ### Fixed

--- a/deploy/helm/cerberus/Chart.yaml
+++ b/deploy/helm/cerberus/Chart.yaml
@@ -8,11 +8,11 @@ type: application
 # upgrade?" and is the publish trigger: a chart-only fix bumps this without an
 # app re-tag; an app-only release bumps appVersion + a PATCH here for the new
 # default image. Starts 0.x because the values contract is not yet frozen.
-version: 0.7.1
+version: 0.8.0
 
 # appVersion tracks the GA cerberus binary. Quoted so SemVer-shaped values
 # aren't coerced to floats. image.tag defaults from this when left empty.
-appVersion: "1.7.1"
+appVersion: "1.8.0"
 
 # autoscaling/v2 + policy/v1 (PDB) + networking/v1 (Ingress) are all GA from
 # 1.21+; 1.23 is the conservative floor matching the manifests this chart
@@ -45,11 +45,13 @@ annotations:
       url: https://github.com/tsouza/cerberus/blob/main/docs/operations.md
   artifacthub.io/images: |
     - name: cerberus
-      image: ghcr.io/tsouza/cerberus:v1.7.1
+      image: ghcr.io/tsouza/cerberus:v1.8.0
   # Bump the `1.0.0` floor here when the chart raises its minimum supported
   # cerberus release; informational for Artifact Hub's compatibility hints.
   artifacthub.io/changes: |
+    - kind: added
+      description: "chopt: auto-enable native time-series aggregates on capable servers (#1091)"
     - kind: fixed
-      description: "tempo: bound windowless tag/attribute discovery to recent window (#1089)"
+      description: "chsql: dedup duplicate-timestamp samples in row-path rate/increase/delta (#1092)"
     - kind: fixed
-      description: "prom: push request window into no-match metadata discovery scans (#1088)"
+      description: "chopt: ts_grid capability probe falsely disabled native aggregates on healthy servers (#1094)"

--- a/deploy/helm/cerberus/README.md
+++ b/deploy/helm/cerberus/README.md
@@ -5,7 +5,7 @@
      pipe-aligned, and the version footer adds a trailing blank — both are
      owned by helm-docs; realigning would fight the chart-ci drift check. -->
 
-![Version: 0.7.1](https://img.shields.io/badge/Version-0.7.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.7.1](https://img.shields.io/badge/AppVersion-1.7.1-informational?style=flat-square)
+![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.0](https://img.shields.io/badge/AppVersion-1.8.0-informational?style=flat-square)
 
 Drop-in Prometheus / Loki / Tempo HTTP gateway for ClickHouse — a single stateless gateway that speaks three upstream query wire formats and lowers each to parameterised ClickHouse SQL.
 


### PR DESCRIPTION
Release-prep for **v1.8.0** (chart **0.8.0**), generated by `prepare-release.yml`.

- appVersion 1.7.1 -> 1.8.0, chart 0.7.1 -> 0.8.0

### Changes

### Added

- **chopt:** auto-enable native time-series aggregates on capable servers (#1091)

### Fixed

- **chsql:** dedup duplicate-timestamp samples in row-path rate/increase/delta (#1092)
- **chopt:** ts_grid capability probe falsely disabled native aggregates on healthy servers (#1094)

Generated from the conventional commits since the last tag. Review and edit before merging; the tag is cut once this lands.
