### PR TITLE
test(perf): record native_resample_offset fixture in cardinality baseline

### DIFF
--- a/test/perf/cardinality-baseline.json
+++ b/test/perf/cardinality-baseline.json
@@ -3750,6 +3750,16 @@
     "max_recursion_depth": 0
   },
   {
+    "fixture": "promql/native_resample_offset",
+    "fan_factor": 2,
+    "scan_rows": 2,
+    "peak_intermediate": 4,
+    "has_cross_join": false,
+    "has_array_join": true,
+    "has_recursive_cte": false,
+    "max_recursion_depth": 0
+  },
+  {
     "fixture": "promql/native_resample_range_step",
     "fan_factor": 2.5,
     "scan_rows": 2,


### PR DESCRIPTION
#1094 added the regression fixture `test/spec/promql/native_resample_offset.txtar` but didn't record it in `test/perf/cardinality-baseline.json`, so `TestCardinalityRatchet` (the chdb `perf-guards` lane) has been red on main since #1094 merged. 

The fixture's shape is **bounded** (`fan_factor=2.00, scan_rows=2, peak_intermediate=4, no cross-join, no recursive-CTE`) — a legitimate new-fixture baseline addition, not unbounded compute. Regenerated via `just update-cardinality-baseline`; the diff is **exactly one additive entry**, no other fixture drifted. Turns main's chdb lane green again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)