### PR TITLE
test(perf): record increase_left_edge_scan_bound in cardinality baseline

### DIFF
--- a/test/perf/cardinality-baseline.json
+++ b/test/perf/cardinality-baseline.json
@@ -3410,6 +3410,16 @@
     "max_recursion_depth": 0
   },
   {
+    "fixture": "promql/increase_left_edge_scan_bound",
+    "fan_factor": 1,
+    "scan_rows": 5,
+    "peak_intermediate": 5,
+    "has_cross_join": false,
+    "has_array_join": false,
+    "has_recursive_cte": false,
+    "max_recursion_depth": 0
+  },
+  {
     "fixture": "promql/info_target_info_enrichment",
     "fan_factor": 1,
     "scan_rows": 2,


### PR DESCRIPTION
Fixes the RED chdb `perf-guards` lane on main. #1098 added `test/spec/promql/increase_left_edge_scan_bound.txtar` and updated `solver-decision-baseline.json` but missed `cardinality-baseline.json`, so `TestCardinalityRatchet` fails on main (perf-guards is non-required → it merged red). Additive, bounded entry (`fan_factor=1, scan_rows=5, no cross-join/array-join/recursive-cte`); single +10 -0 baseline diff, nothing else drifted. No threshold/allowlist change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)