### PR TITLE
chore(just): update-golden records the cardinality + solver-decision baselines

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -222,9 +222,28 @@ coverage:
 # under that build tag. Requires libchdb.so (`just chdb-install`) — the
 # recipe fails fast without it rather than leaving stale expected_rows
 # behind (the PR #758 failure mode).
-# Review `git diff test/spec/` before committing.
-update-golden:
-    @test -f "{{CHDB_INSTALL_PATH}}" || { echo "error: {{CHDB_INSTALL_PATH}} not found — run 'just chdb-install' first; without it the chdb-tagged -- expected_rows -- sections cannot regenerate and go stale" >&2; exit 1; }
+#
+# It first runs the two perf-assessment ratchet baselines as PRIOR
+# dependencies so a SINGLE `just update-golden` records every fixture-derived
+# artefact in one shot: the solver routing-DECISION baseline, the cardinality
+# fan-factor baseline, and the text/expected_rows goldens (this body). This
+# closes the recurring miss where a new TXTAR fixture regenerated its goldens
+# but left `cardinality-baseline.json` unrecorded, turning the non-required
+# `perf-guards` TestCardinalityRatchet red on main after merge (hit by #1096
+# native_resample_offset and #1098 increase_left_edge_scan_bound).
+#
+# Why PRIOR deps, not subsequent (`&&`): the body's default-tag
+# `GOLDEN_UPDATE=1 go test ./...` lane runs TestSolverDecisionRatchet in
+# ASSERT mode, which fails on a brand-new fixture not yet in the routing
+# baseline — aborting before any subsequent dependency could record it.
+# Recording both baselines FIRST means the body's asserting lanes pass for
+# the new fixture. The baselines re-derive from each fixture's input query
+# (not the regenerated `-- sql --` / `-- expected_rows --` cells), so running
+# them before the golden rewrite is order-safe; all three are no-ops on a
+# corpus already in sync (zero diff).
+# Review `git diff test/spec/ test/perf/*-baseline.json` before committing.
+update-golden: update-solver-decision-baseline update-cardinality-baseline
+    @test -f "{{CHDB_INSTALL_PATH}}" || { echo "error: {{CHDB_INSTALL_PATH}} not found — run 'just chdb-install' first; without it the chdb-tagged -- expected_rows -- sections (and the cardinality baseline) cannot regenerate and go stale" >&2; exit 1; }
     GOLDEN_UPDATE=1 go test ./...
     GOLDEN_UPDATE=1 go test -tags chdb -count=1 ./test/spec/...
     @echo

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -311,7 +311,10 @@ for the strategy):
   `cardinality-baseline.json` / `scale-wall-baseline.json` and fail on an
   upward regression, a new unbounded shape, or a deeper recursion. A
   decrease never blocks; the ceiling tightens only on a deliberate
-  `just update-cardinality-baseline`.
+  `just update-cardinality-baseline` — which `just update-golden` now
+  chains automatically, so adding a TXTAR fixture records its ratchet
+  entry in the same pass that fills the goldens (closing the recurring
+  "unrecorded fixture → red `perf-guards` on main" miss).
 - **Solver-decision ratchet** (`test/perf/solver_decision_ratchet_test.go`,
   chDB-free, in `check`) — pins the per-fixture route A/B classification
   against `solver-decision-baseline.json` so a routing-heuristic change

--- a/test/perf/cardinality-baseline.json
+++ b/test/perf/cardinality-baseline.json
@@ -3410,6 +3410,16 @@
     "max_recursion_depth": 0
   },
   {
+    "fixture": "promql/increase_left_edge_scan_bound",
+    "fan_factor": 1,
+    "scan_rows": 5,
+    "peak_intermediate": 5,
+    "has_cross_join": false,
+    "has_array_join": false,
+    "has_recursive_cte": false,
+    "max_recursion_depth": 0
+  },
+  {
     "fixture": "promql/info_target_info_enrichment",
     "fan_factor": 1,
     "scan_rows": 2,


### PR DESCRIPTION
Closes the recurring 'unrecorded fixture → red perf-guards on main' miss (#1096, #1101): `just update-golden` now chains `update-cardinality-baseline` + `update-solver-decision-baseline` as **prior** deps, so adding a TXTAR fixture auto-records all three baselines in one invocation. Makes 'record the baseline' enforced by the tool, not remembered.

Prior (not `&&`) deps because the recipe body runs TestSolverDecisionRatchet in assert mode, which would abort on a new fixture before a subsequent dep could record it. DRY — reuses the existing standalone recipes. Idempotent (zero diff on clean tree); proven via a throwaway fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)