### PR TITLE
chore(release): cerberus v1.8.1 / chart 0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to cerberus will be documented in this file. The format roug
 
 ## [Unreleased]
 
+## [v1.8.1] — 2026-06-26
+
+### Added
+
+- **optimizer:** fail-closed scan-time-bound invariant for instant windowed scans (#1100)
+
+### Fixed
+
+- **release:** preflight ignores empty check-suites (e.g. GitGuardian) in the CI wait (#1097)
+
+### Performance
+
+- **chsql:** bound instant windowed-array scans to the eval window (#1098)
+
+### Documentation
+
+- swap CI/mutation badges for Ask DeepWiki in README (#1099)
+
 ## [v1.8.0] — 2026-06-26
 
 ### Added

--- a/deploy/helm/cerberus/Chart.yaml
+++ b/deploy/helm/cerberus/Chart.yaml
@@ -8,11 +8,11 @@ type: application
 # upgrade?" and is the publish trigger: a chart-only fix bumps this without an
 # app re-tag; an app-only release bumps appVersion + a PATCH here for the new
 # default image. Starts 0.x because the values contract is not yet frozen.
-version: 0.8.0
+version: 0.8.1
 
 # appVersion tracks the GA cerberus binary. Quoted so SemVer-shaped values
 # aren't coerced to floats. image.tag defaults from this when left empty.
-appVersion: "1.8.0"
+appVersion: "1.8.1"
 
 # autoscaling/v2 + policy/v1 (PDB) + networking/v1 (Ingress) are all GA from
 # 1.21+; 1.23 is the conservative floor matching the manifests this chart
@@ -45,13 +45,13 @@ annotations:
       url: https://github.com/tsouza/cerberus/blob/main/docs/operations.md
   artifacthub.io/images: |
     - name: cerberus
-      image: ghcr.io/tsouza/cerberus:v1.8.0
+      image: ghcr.io/tsouza/cerberus:v1.8.1
   # Bump the `1.0.0` floor here when the chart raises its minimum supported
   # cerberus release; informational for Artifact Hub's compatibility hints.
   artifacthub.io/changes: |
     - kind: added
-      description: "chopt: auto-enable native time-series aggregates on capable servers (#1091)"
+      description: "optimizer: fail-closed scan-time-bound invariant for instant windowed scans (#1100)"
     - kind: fixed
-      description: "chsql: dedup duplicate-timestamp samples in row-path rate/increase/delta (#1092)"
-    - kind: fixed
-      description: "chopt: ts_grid capability probe falsely disabled native aggregates on healthy servers (#1094)"
+      description: "release: preflight ignores empty check-suites (e.g. GitGuardian) in the CI wait (#1097)"
+    - kind: changed
+      description: "chsql: bound instant windowed-array scans to the eval window (#1098)"

--- a/deploy/helm/cerberus/README.md
+++ b/deploy/helm/cerberus/README.md
@@ -5,7 +5,7 @@
      pipe-aligned, and the version footer adds a trailing blank — both are
      owned by helm-docs; realigning would fight the chart-ci drift check. -->
 
-![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.0](https://img.shields.io/badge/AppVersion-1.8.0-informational?style=flat-square)
+![Version: 0.8.1](https://img.shields.io/badge/Version-0.8.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.1](https://img.shields.io/badge/AppVersion-1.8.1-informational?style=flat-square)
 
 Drop-in Prometheus / Loki / Tempo HTTP gateway for ClickHouse — a single stateless gateway that speaks three upstream query wire formats and lowers each to parameterised ClickHouse SQL.
 


### PR DESCRIPTION
Release-prep for **v1.8.1** (chart **0.8.1**), generated by `prepare-release.yml`.

- appVersion 1.8.0 -> 1.8.1, chart 0.8.0 -> 0.8.1

### Changes

### Added

- **optimizer:** fail-closed scan-time-bound invariant for instant windowed scans (#1100)

### Fixed

- **release:** preflight ignores empty check-suites (e.g. GitGuardian) in the CI wait (#1097)

### Performance

- **chsql:** bound instant windowed-array scans to the eval window (#1098)

### Documentation

- swap CI/mutation badges for Ask DeepWiki in README (#1099)

Generated from the conventional commits since the last tag. Review and edit before merging; the tag is cut once this lands.
