### PR TITLE
fix(prom): bound metadata enumeration to retention + cover always-unbounded metricMetaSQL

### DIFF
--- a/internal/api/prom/handler_chdb_catalog_queryable_test.go
+++ b/internal/api/prom/handler_chdb_catalog_queryable_test.go
@@ -92,7 +92,11 @@ const catalogSummaryDDL = `CREATE TABLE otel_metrics_summary (
 ) ENGINE = MergeTree() ORDER BY (MetricName, TimeUnix);`
 
 func TestCatalog_AdvertisedNamesAreQueryable_ChDB(t *testing.T) {
-	seedTime := time.Date(2026, 5, 11, 12, 0, 0, 0, time.UTC)
+	// Step 1 enumerates __name__ windowless; seed within the default-lookback
+	// retention horizon (boundMetadataWindow) so the bounded discovery scan
+	// still advertises every name. Step 2's instant queries anchor at
+	// seedTime, whose 5m staleness window covers these rows.
+	seedTime := time.Now().UTC().Truncate(time.Second).Add(-time.Hour)
 	ts := seedTime.Format("2006-01-02 15:04:05.000")
 
 	seed := catalogGaugeDDL + catalogSumDDL + catalogHistogramDDL +

--- a/internal/api/prom/handler_chdb_label_values_test.go
+++ b/internal/api/prom/handler_chdb_label_values_test.go
@@ -320,7 +320,10 @@ INSERT INTO otel_metrics_gauge (MetricName, MetricDescription, MetricUnit, Attri
 // metric typed "counter", which made Grafana's Metrics Drilldown wrap
 // UpDownCounters in rate() and render a flat-0 preview.
 func TestMetadata_NonMonotonicSumIsGauge_ChDB(t *testing.T) {
-	seedTime := time.Date(2026, 5, 11, 12, 0, 0, 0, time.UTC)
+	// /api/v1/metadata is windowless; seed inside the default-lookback
+	// retention horizon (boundMetadataWindow) so the bounded metadata scan
+	// still lists the metric — beyond-horizon data is TTL-gone in prod too.
+	seedTime := time.Now().UTC().Truncate(time.Second).Add(-time.Hour)
 	ts := seedTime.Format("2006-01-02 15:04:05.000")
 	seed := metaShapedGaugeDDL + metaShapedSumDDL + metaShapedHistogramDDL + fmt.Sprintf(`
 INSERT INTO otel_metrics_sum (MetricName, MetricDescription, MetricUnit, Attributes, TimeUnix, Value, IsMonotonic) VALUES
@@ -391,7 +394,8 @@ INSERT INTO otel_metrics_sum (MetricName, MetricDescription, MetricUnit, Attribu
 // found check). The seed creates all three; only the gauge table
 // carries rows.
 func TestMetadata_TruncateAtLimit_ChDB(t *testing.T) {
-	seedTime := time.Date(2026, 5, 11, 12, 0, 0, 0, time.UTC)
+	// Windowless /api/v1/metadata — seed within the default-lookback horizon.
+	seedTime := time.Now().UTC().Truncate(time.Second).Add(-time.Hour)
 	ts := seedTime.Format("2006-01-02 15:04:05.000")
 	seed := metaShapedGaugeDDL + metaShapedSumDDL + metaShapedHistogramDDL + fmt.Sprintf(`
 INSERT INTO otel_metrics_gauge (MetricName, MetricDescription, MetricUnit, Attributes, TimeUnix, Value) VALUES
@@ -448,7 +452,8 @@ INSERT INTO otel_metrics_gauge (MetricName, MetricDescription, MetricUnit, Attri
 // in truncateMetadata against chDB: limit exceeds the seeded count, so
 // the handler must return every row untouched.
 func TestMetadata_LimitAboveCount_ChDB(t *testing.T) {
-	seedTime := time.Date(2026, 5, 11, 12, 0, 0, 0, time.UTC)
+	// Windowless /api/v1/metadata — seed within the default-lookback horizon.
+	seedTime := time.Now().UTC().Truncate(time.Second).Add(-time.Hour)
 	ts := seedTime.Format("2006-01-02 15:04:05.000")
 	seed := metaShapedGaugeDDL + metaShapedSumDDL + metaShapedHistogramDDL + fmt.Sprintf(`
 INSERT INTO otel_metrics_gauge (MetricName, MetricDescription, MetricUnit, Attributes, TimeUnix, Value) VALUES
@@ -515,7 +520,10 @@ func keysOf(m map[string][]prom.MetricMetaEntry) []string {
 // for the unrelated sanity check (`route` carries no internal
 // underscore so it hits the byte-stable single-arm path).
 func TestLabelValues_DottedSource_ChDB(t *testing.T) {
-	seedTime := time.Date(2026, 5, 11, 12, 0, 0, 0, time.UTC)
+	// Pin 1 is windowless; seed within the default-lookback retention
+	// horizon (boundMetadataWindow) so the bounded scan still lists the
+	// dotted-source values. Pin 2 derives its window from seedTime.
+	seedTime := time.Now().UTC().Truncate(time.Second).Add(-time.Hour)
 	ts := seedTime.Format("2006-01-02 15:04:05.000")
 	// Seed into otel_metrics_sum: `cerberus_queries_total` carries the
 	// `_total` suffix so Metrics.TableFor routes the matched-listing

--- a/internal/api/prom/handler_chdb_metadata_window_sweep_test.go
+++ b/internal/api/prom/handler_chdb_metadata_window_sweep_test.go
@@ -3,8 +3,8 @@
 // Exploratory window-vs-freshness sweep for the Prometheus metadata
 // endpoints (/series, /labels, /label/<name>/values). This is the
 // metadata analogue of the rc.9 eval-instant sweep
-// (test/spec/eval_instant_sweep.go): it seeds series at FIXED sample
-// times anchored well in the past, then varies the REQUEST window
+// (test/spec/eval_instant_sweep.go): it seeds series at sample times
+// anchored a couple of hours in the past, then varies the REQUEST window
 // [start,end] independently of wall-clock and asserts each endpoint
 // returns exactly the series/labels/values whose sample falls in the
 // window.
@@ -15,10 +15,12 @@
 // window (/series, /labels pre-fix) or clamping to an instant window at
 // `end` (/label_values pre-fix) — still passed. Those exact defects are
 // the rc.9 /series empty-window bug and its /labels + /label/<name>/values
-// siblings. Anchoring the seed ~37 days before wall-clock means a
-// now()-anchored handler returns EMPTY for every window here, so the
-// sweep is red pre-fix and green only once all three endpoints honour the
-// full closed [start,end] window (promql.LowerMetadataRange).
+// siblings. Anchoring every sample older than the 5m staleness window (but
+// within the windowless metadata default-lookback retention horizon, so the
+// no-bounds W5 case still returns the full catalog) means a now()-anchored
+// handler returns EMPTY for every windowed case here, so the sweep is red
+// pre-fix and green only once all three endpoints honour the full closed
+// [start,end] window (promql.LowerMetadataRange).
 
 package prom_test
 
@@ -32,12 +34,16 @@ import (
 	"time"
 )
 
-// metaWindowSeedBase anchors the sweep's sample times. It is deliberately
-// weeks before any plausible test wall-clock so a handler that evaluates a
-// metadata request at `now` (the pre-fix /series + /labels behaviour)
-// returns empty for EVERY window below — making the window-drop bug fail
-// the sweep instead of hiding behind a now-aligned seed.
-var metaWindowSeedBase = time.Date(2026, 5, 11, 12, 0, 0, 0, time.UTC)
+// metaWindowSeedBase anchors the sweep's sample times in the recent past:
+// far enough back (2h) that every sample is older than the 5m instant
+// staleness window — so a handler that evaluates a metadata request at
+// `now` (the pre-fix /series + /labels behaviour) STILL returns empty for
+// the windowed cases, making the window-drop bug fail the sweep — yet
+// inside the windowless metadata default-lookback retention horizon
+// (boundMetadataWindow) so the W5_omitted whole-catalog case returns every
+// series. A fixed calendar anchor would fall outside that horizon as the
+// wall clock advances and spuriously empty the windowless case.
+var metaWindowSeedBase = time.Now().UTC().Truncate(time.Second).Add(-2 * time.Hour)
 
 // metaWindowSeed builds the gauge/sum/histogram tables plus four `m`
 // series (one per `job`), each with a single sample at a distinct time

--- a/internal/api/prom/handler_test.go
+++ b/internal/api/prom/handler_test.go
@@ -28,6 +28,11 @@ type stubQuerier struct {
 	exemplarsErr error
 	lastSQL      string
 	lastArgs     []any
+	// allSQL records every SQL statement issued through this stub, in
+	// order. lastSQL only keeps the final statement; the batched metadata
+	// endpoints issue several (per table group / per metadata arm), so a
+	// scan-bound assertion that must hold for EVERY arm reads allSQL.
+	allSQL []string
 
 	// metaCalls records every QueryMetricMeta invocation in order so
 	// metadata tests can assert the per-table fan-out (which SQL was
@@ -48,6 +53,7 @@ type metaCall struct {
 
 func (s *stubQuerier) Query(_ context.Context, sql string, args ...any) ([]chclient.Sample, error) {
 	s.lastSQL = sql
+	s.allSQL = append(s.allSQL, sql)
 	s.lastArgs = args
 	if s.err != nil {
 		return nil, s.err
@@ -57,6 +63,7 @@ func (s *stubQuerier) Query(_ context.Context, sql string, args ...any) ([]chcli
 
 func (s *stubQuerier) QueryCursor(_ context.Context, sql string, args ...any) (chclient.Cursor, error) {
 	s.lastSQL = sql
+	s.allSQL = append(s.allSQL, sql)
 	s.lastArgs = args
 	if s.err != nil {
 		return nil, s.err
@@ -66,6 +73,7 @@ func (s *stubQuerier) QueryCursor(_ context.Context, sql string, args ...any) (c
 
 func (s *stubQuerier) QueryStrings(_ context.Context, sql string, args ...any) ([]string, error) {
 	s.lastSQL = sql
+	s.allSQL = append(s.allSQL, sql)
 	s.lastArgs = args
 	if s.err != nil {
 		return nil, s.err
@@ -75,6 +83,7 @@ func (s *stubQuerier) QueryStrings(_ context.Context, sql string, args ...any) (
 
 func (s *stubQuerier) QueryLabelSets(_ context.Context, sql string, args ...any) ([]map[string]string, error) {
 	s.lastSQL = sql
+	s.allSQL = append(s.allSQL, sql)
 	s.lastArgs = args
 	if s.err != nil {
 		return nil, s.err
@@ -84,6 +93,7 @@ func (s *stubQuerier) QueryLabelSets(_ context.Context, sql string, args ...any)
 
 func (s *stubQuerier) QueryMetricMeta(_ context.Context, sql, metricType string, args ...any) ([]chclient.MetricMetaRow, error) {
 	s.lastSQL = sql
+	s.allSQL = append(s.allSQL, sql)
 	s.lastArgs = args
 	call := metaCall{sql: sql, kind: metricType, args: args}
 	s.metaCalls = append(s.metaCalls, call)

--- a/internal/api/prom/metadata.go
+++ b/internal/api/prom/metadata.go
@@ -238,6 +238,48 @@ func parseMetadataWindow(r *http.Request) (start, end time.Time, err error) {
 	return start, end, nil
 }
 
+// defaultMetadataLookback bounds the absent-window metadata-discovery scan
+// to the data-retention horizon rather than to a short recent window.
+//
+// Reference Prometheus answers a windowless /api/v1/label/<l>/values,
+// /labels and /series over the ENTIRE queryable range (web/api/v1/api.go
+// defaults start to MinTime and end to MaxTime) — every name / value /
+// series still inside retention. Grafana's metric / label pickers send no
+// start/end under the common "On dashboard load" variable refresh, so
+// without a default the discovery arms emit a WHERE-less scan over every
+// toDate(TimeUnix) partition (the prod full-column scan this fix targets).
+//
+// Defaulting the absent window to the retention horizon — the OTel-CH
+// metric tables' TTL, two weeks — keeps the answer byte-identical to
+// Prometheus's: anything older than the TTL has already been
+// ttl_only_drop_parts-dropped and is absent from both backends, so no
+// name/value/series that Prometheus would return is dropped. It still
+// emits a closed TimeUnix bound, so ClickHouse partition-prunes whenever
+// the table physically spans more than the horizon (a request-supplied
+// narrower range, honored verbatim, is where the real pruning comes from).
+//
+// A SHORTER default (1h/6h/24h) prunes harder but silently drops metrics
+// that went quiet within retention — the no-silent-drop divergence the
+// windowless-completeness guards forbid.
+const defaultMetadataLookback = 14 * 24 * time.Hour
+
+// boundMetadataWindow applies the default retention-horizon lookback when a
+// metadata request carries NO window (both bounds zero) — the Grafana
+// variable-query case. A request that supplies either bound is honored
+// verbatim: a one-sided window stays deliberately open-ended, matching
+// reference Prometheus's MinTime/MaxTime default and the matched-path
+// semantics in promql.wrapMetadataFullRange. Both the no-match arms
+// (metadataWindowPred) and the matched path (promql.LowerMetadataRange)
+// consume the returned [start,end], so wiring this once at the handler
+// covers every discovery shape.
+func boundMetadataWindow(start, end time.Time) (time.Time, time.Time) {
+	if start.IsZero() && end.IsZero() {
+		end = time.Now().UTC()
+		start = end.Add(-defaultMetadataLookback)
+	}
+	return start, end
+}
+
 func (h *Handler) handleLabels(w http.ResponseWriter, r *http.Request) {
 	if err := r.ParseForm(); err != nil {
 		writeError(w, http.StatusBadRequest, ErrBadData, err)
@@ -250,6 +292,7 @@ func (h *Handler) handleLabels(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, ErrBadData, err)
 		return
 	}
+	startT, endT = boundMetadataWindow(startT, endT)
 
 	var names []string
 	if len(matchers) == 0 {
@@ -314,6 +357,7 @@ func (h *Handler) handleLabelValues(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, ErrBadData, err)
 		return
 	}
+	startT, endT = boundMetadataWindow(startT, endT)
 
 	var values []string
 	if len(matchers) == 0 {
@@ -362,7 +406,13 @@ func (h *Handler) handleMetadata(w http.ResponseWriter, r *http.Request) {
 	metricName := r.URL.Query().Get("metric")
 	limitStr := r.URL.Query().Get("limit")
 
-	rows, err := h.fetchMetricMeta(r.Context(), metricName)
+	// /api/v1/metadata takes no time params (upstream Prometheus accepts
+	// only `metric` + `limit`), so it would otherwise GROUP BY MetricName
+	// over every partition on every call. Bound it to the same default
+	// retention-horizon window the discovery handlers use so the per-table
+	// metadata fan-out partition-prunes too.
+	startT, endT := boundMetadataWindow(time.Time{}, time.Time{})
+	rows, err := h.fetchMetricMeta(r.Context(), metricName, startT, endT)
 	if err != nil {
 		h.respondError(w, err)
 		return
@@ -409,7 +459,7 @@ type metricMetaSpec struct {
 	monotonic *bool
 }
 
-func (h *Handler) fetchMetricMeta(ctx context.Context, metricName string) ([]chclient.MetricMetaRow, error) {
+func (h *Handler) fetchMetricMeta(ctx context.Context, metricName string, start, end time.Time) ([]chclient.MetricMetaRow, error) {
 	monotonic, nonMonotonic := true, false
 	specs := []metricMetaSpec{
 		{table: h.Schema.GaugeTable, kind: "gauge"},
@@ -436,7 +486,7 @@ func (h *Handler) fetchMetricMeta(ctx context.Context, metricName string) ([]chc
 
 	var out []chclient.MetricMetaRow
 	for _, spec := range specs {
-		sql, args := h.metricMetaSQL(spec.table, metricName, spec.monotonic)
+		sql, args := h.metricMetaSQL(spec.table, metricName, spec.monotonic, start, end)
 		rows, err := h.Client.QueryMetricMeta(ctx, sql, spec.kind, args...)
 		if err != nil {
 			return nil, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusBadGateway}
@@ -451,7 +501,11 @@ func (h *Handler) fetchMetricMeta(ctx context.Context, metricName string) ([]chc
 // we list all distinct metrics; otherwise we filter to the named one.
 // A non-nil monotonic adds a `IsMonotonic` / `NOT IsMonotonic` predicate
 // (combined via AND with the metric-name filter when both are present).
-func (h *Handler) metricMetaSQL(table, metricName string, monotonic *bool) (string, []any) {
+// A non-zero start/end pushes the closed metadata window onto the GROUP BY
+// arm so the per-table fan-out partition-prunes by toDate(TimeUnix) instead
+// of grouping the whole table; the window literals are inlined
+// (dateTime64Frag), so the metric-name filter keeps its positional slot.
+func (h *Handler) metricMetaSQL(table, metricName string, monotonic *bool, start, end time.Time) (string, []any) {
 	nameCol := h.Schema.MetricNameColumn
 	descCol := h.Schema.MetricDescriptionColumn
 	unitCol := h.Schema.MetricUnitColumn
@@ -464,6 +518,10 @@ func (h *Handler) metricMetaSQL(table, metricName string, monotonic *bool) (stri
 		Select(chsql.Col(nameCol), anyCall(descCol), anyCall(unitCol)).
 		From(chsql.Col(table)).
 		GroupBy(chsql.Col(nameCol))
+
+	if pred := h.metadataWindowPred(start, end); pred != nil {
+		sb.Where(pred)
+	}
 
 	if monotonic != nil {
 		// Bare boolean-column predicate (`IsMonotonic` / `NOT
@@ -539,6 +597,7 @@ func (h *Handler) handleSeries(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, ErrBadData, err)
 		return
 	}
+	startT, endT = boundMetadataWindow(startT, endT)
 
 	// Two-layer matcher fan-out — `expandUnderscoredMetricNameMatcher`
 	// (dotted-storage candidates) nested inside `expandBareHistogramMatcher`

--- a/internal/api/prom/metadata_scan_bound_explain_chdb_test.go
+++ b/internal/api/prom/metadata_scan_bound_explain_chdb_test.go
@@ -1,0 +1,185 @@
+//go:build chdb
+
+package prom_test
+
+// REPRO (Layer 12 — compute fan-out / scan-volume, chDB EXPLAIN indexes=1).
+//
+// The empirical proof that the windowless `__name__` enumeration is an
+// O(all-partitions) full-column scan. This drives the SQL the HANDLER
+// ACTUALLY emits for a no-start/end `/api/v1/label/__name__/values`
+// request (captured through a recording stub), then runs it against a
+// production-shaped gauge+sum table — PARTITION BY toDate(TimeUnix), the
+// OTel-CH exporter's own layout — seeded across many day-partitions, and
+// inspects the MergeTree MinMax/partition stage via EXPLAIN indexes=1.
+//
+//   - On current main the handler emits a WHERE-less DISTINCT, so the
+//     first `Parts:` line reads N/N — every partition selected. The
+//     assertion (the windowless emit must Partition-prune to a strict
+//     subset) is RED.
+//   - Once a default lookback bounds the windowless path, the captured SQL
+//     carries the `toDateTime64('…', 9)` TimeUnix predicate and the same
+//     EXPLAIN reads k/N with k < N — GREEN.
+//
+// This complements (does not duplicate) the existing hand-written
+// test/perf/metric_names_window_prune_chdb_test.go: that file pins the
+// *baseline* (a hand-written unbounded SQL scans all parts) and that a
+// hand-written *windowed* SQL prunes. This file closes the gap between
+// them — it asserts the property on the SQL cerberus's handler emits for a
+// windowless request, so it auto-flips when the handler is fixed rather
+// than tracking a hand-copied string.
+//
+// Honest scope note: partition pruning a windowless request narrows the
+// scan ONLY because the default window is narrower than the seeded span.
+// That narrowing is correctness-preserving ONLY if the default is the
+// table's retention horizon (data older than retention is gone from a real
+// Prometheus too) — a short recent default would silently drop
+// recently-quiet metric names and DIVERGE from reference Prometheus. The
+// result-identity guard that the windowless catalog stays complete lives
+// in metadata_scan_bound_guard_chdb_test.go and W5_omitted in
+// handler_chdb_metadata_window_sweep_test.go; both halves must hold.
+
+import (
+	"database/sql"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	_ "github.com/chdb-io/chdb-go/chdb/driver"
+)
+
+const (
+	// scanBoundDays is the number of day-partitions the EXPLAIN corpus
+	// scatters rows across, so an unbounded scan shows Parts: N/N with
+	// N == scanBoundDays and a bounded scan can prune to a strict subset.
+	scanBoundDays = 10
+	// scanBoundRows seeds a dense corpus so OPTIMIZE FINAL yields one part
+	// per day-partition (real parts for the MinMax stage to prune).
+	scanBoundRows  = 200_000
+	scanBoundEpoch = "2026-01-01"
+)
+
+// scanBoundPartitionedDDL is the production OTel-CH metric table trimmed to
+// the columns the metric-name discovery scan reads, with the exporter's
+// PARTITION BY toDate(TimeUnix) so the MinMax stage has day-partitions to
+// prune.
+func scanBoundPartitionedDDL(table string) string {
+	return fmt.Sprintf(`CREATE OR REPLACE TABLE %s (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree()
+PARTITION BY toDate(TimeUnix)
+ORDER BY (MetricName, TimeUnix);`, table)
+}
+
+// scanBoundInsert scatters rows across scanBoundDays day-partitions.
+func scanBoundInsert(table string) string {
+	return fmt.Sprintf(`INSERT INTO %s
+SELECT
+    concat('m_', toString(number %% 50)) AS MetricName,
+    map('job', 'j') AS Attributes,
+    toDateTime64('%s 00:00:00', 9) + INTERVAL (number %% %d) DAY AS TimeUnix,
+    toFloat64(number) AS Value
+FROM numbers(%d);`, table, scanBoundEpoch, scanBoundDays, scanBoundRows)
+}
+
+// firstPartsFraction returns (selected, total) from the FIRST `Parts: N/M`
+// line of an EXPLAIN indexes=1 plan — the MinMax/partition stage of the
+// MergeTree scan.
+func firstPartsFraction(t *testing.T, db *sql.DB, query string) (selected, total int) {
+	t.Helper()
+	rows, err := db.Query("EXPLAIN indexes=1 " + query)
+	if err != nil {
+		t.Fatalf("EXPLAIN: %v\nquery: %s", err, query)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var line string
+		if err := rows.Scan(&line); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		trim := strings.TrimSpace(line)
+		if !strings.HasPrefix(trim, "Parts:") {
+			continue
+		}
+		frac := strings.TrimSpace(strings.TrimPrefix(trim, "Parts:"))
+		if _, err := fmt.Sscanf(frac, "%d/%d", &selected, &total); err != nil {
+			t.Fatalf("parse Parts line %q: %v", trim, err)
+		}
+		return selected, total
+	}
+	t.Fatalf("EXPLAIN produced no Parts line for:\n%s", query)
+	return 0, 0
+}
+
+// captureWindowlessMetricNamesSQL returns the gauge/sum-arm SQL the handler
+// emits for a windowless /api/v1/label/__name__/values request. The
+// recording stub feeds canned names back so the handler completes; the
+// returned statement is the bare-group UNION (the one that references the
+// gauge table).
+func captureWindowlessMetricNamesSQL(t *testing.T) string {
+	t.Helper()
+	q := &stubQuerier{strings: []string{"m_0"}}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v1/label/__name__/values")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	resp.Body.Close()
+
+	for _, stmt := range q.allSQL {
+		if strings.Contains(stmt, "otel_metrics_gauge") {
+			return stmt
+		}
+	}
+	t.Fatalf("handler issued no gauge-table metric-name query; allSQL=%q", q.allSQL)
+	return ""
+}
+
+// TestMetadataScanBound_MetricNamesExplain_Repro pins the partition-prune
+// property on the handler's actual windowless `__name__` emit. RED on main
+// (Parts: N/N, the unbounded full-partition scan); green once a default
+// lookback bounds the windowless path.
+func TestMetadataScanBound_MetricNamesExplain_Repro(t *testing.T) {
+	db, err := sql.Open("chdb", "")
+	if err != nil {
+		t.Fatalf("open chdb: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := db.Ping(); err != nil {
+		t.Fatalf("ping chdb: %v", err)
+	}
+
+	for _, table := range []string{"otel_metrics_gauge", "otel_metrics_sum"} {
+		for _, stmt := range []string{scanBoundPartitionedDDL(table), scanBoundInsert(table)} {
+			if _, err := db.Exec(stmt); err != nil {
+				t.Fatalf("setup %s: %v", stmt, err)
+			}
+		}
+		// One dense part per day-partition so the MinMax stage prunes real
+		// parts, not inflated unmerged insert parts.
+		if _, err := db.Exec("OPTIMIZE TABLE " + table + " FINAL"); err != nil {
+			t.Fatalf("optimize %s: %v", table, err)
+		}
+	}
+
+	captured := captureWindowlessMetricNamesSQL(t)
+	t.Logf("windowless __name__ emit:\n%s", captured)
+
+	sel, tot := firstPartsFraction(t, db, captured)
+	t.Logf("windowless __name__ MinMax parts: %d/%d", sel, tot)
+
+	if tot < scanBoundDays {
+		t.Fatalf("scan saw %d parts total, want >= %d day-partitions — corpus not dense enough to prove pruning",
+			tot, scanBoundDays)
+	}
+	if sel >= tot {
+		t.Errorf("windowless /api/v1/label/__name__/values selected %d of %d parts — the full-partition scan "+
+			"that is the bug; a default lookback must bound the windowless emit so it Partition-prunes (k < N).",
+			sel, tot)
+	}
+}

--- a/internal/api/prom/metadata_scan_bound_guard_chdb_test.go
+++ b/internal/api/prom/metadata_scan_bound_guard_chdb_test.go
@@ -1,0 +1,111 @@
+//go:build chdb
+
+package prom_test
+
+// GUARD (Layer 6a — chDB roundtrip; result identity the fix MUST preserve).
+//
+// The repro side (metadata_scan_bound_repro_test.go +
+// metadata_scan_bound_explain_chdb_test.go) demands the windowless
+// metadata scan be BOUNDED. This guard pins the other, equally-binding
+// half: a windowless discovery query must still return the COMPLETE
+// catalog — every metric name / label / value present in the data, however
+// long ago its newest sample landed.
+//
+// Why this matters: reference Prometheus answers a windowless
+// /api/v1/label/__name__/values (and /labels, /label/<l>/values) over the
+// ENTIRE TSDB retention — every name/value still inside the retention
+// horizon, head + all persistent blocks. A "fix" that bounds the
+// windowless scan to a short recent window (1h/6h/24h) prunes well but
+// silently drops metrics that went quiet within retention — the
+// no-allowlists / no-silent-drop failure mode. So the only correct bound
+// is the retention horizon (data older than which is gone from a real
+// Prometheus too); this guard seeds names whose only sample is days old
+// (well inside any plausible retention) and asserts they are STILL
+// returned. It is GREEN on main (the scan is unbounded today) and stays
+// green only for a retention-scale default — it goes RED for a
+// short-recent default, catching that divergence.
+//
+// The matched-path windowless completeness is covered by W5_omitted in
+// handler_chdb_metadata_window_sweep_test.go; this file covers the
+// no-`match[]` discovery arms (metricNamesSQL / unionLabelNamesSQL /
+// unionLabelValuesSQL).
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// scanGuardSeed seeds gauge+sum with names whose newest sample spans from
+// days-old to seconds-ago, all inside a plausible retention horizon. The
+// returned map is the oracle: every distinct `__name__` the windowless
+// catalog must list.
+func scanGuardSeed() (string, map[string]struct{}) {
+	now := time.Now().UTC()
+	lit := func(d time.Duration) string {
+		return now.Add(-d).Format("2006-01-02 15:04:05.000000000")
+	}
+	seed := metaShapedGaugeDDL + metaShapedSumDDL + metaShapedHistogramDDL + fmt.Sprintf(
+		`
+INSERT INTO otel_metrics_gauge (MetricName, Attributes, TimeUnix, Value) VALUES
+    ('g_ancient', map('job', 'old'),    toDateTime64('%s', 9), 1.0),
+    ('g_recent',  map('job', 'fresh'),  toDateTime64('%s', 9), 1.0);
+INSERT INTO otel_metrics_sum (MetricName, Attributes, TimeUnix, Value, IsMonotonic) VALUES
+    ('s_stale_total', map('job', 'mid'), toDateTime64('%s', 9), 1.0, true);`,
+		lit(10*24*time.Hour), // g_ancient: newest sample 10 days ago
+		lit(time.Minute),     // g_recent: newest sample 1 minute ago
+		lit(7*24*time.Hour),  // s_stale_total: newest sample 7 days ago
+	)
+	want := map[string]struct{}{
+		"g_ancient":     {},
+		"g_recent":      {},
+		"s_stale_total": {},
+	}
+	return seed, want
+}
+
+// TestMetadataScanBound_WindowlessCatalogComplete_Guard pins that a
+// windowless /api/v1/label/__name__/values returns the FULL name catalog,
+// including names whose only sample is days old. GREEN on main; a
+// short-recent default lookback would drop g_ancient (10d) / s_stale_total
+// (7d) and turn this RED — exactly the divergence the guard exists to
+// catch.
+func TestMetadataScanBound_WindowlessCatalogComplete_Guard(t *testing.T) {
+	seed, want := scanGuardSeed()
+	srv, _ := newChDBServer(t, seed)
+
+	got := stringData(t, getMetaData(t, srv.URL+"/api/v1/label/__name__/values"))
+	gotSet := make(map[string]struct{}, len(got))
+	for _, n := range got {
+		gotSet[n] = struct{}{}
+	}
+	for name := range want {
+		if _, ok := gotSet[name]; !ok {
+			t.Errorf("windowless /label/__name__/values dropped %q (got %v) — a windowless catalog must "+
+				"list every retained name, not just recently-active ones", name, got)
+		}
+	}
+}
+
+// TestMetadataScanBound_WindowlessLabelsComplete_Guard pins the label-name
+// and label-value discovery arms (unionLabelNamesSQL / unionLabelValuesSQL)
+// over the same days-old corpus: a windowless /labels must surface `job`,
+// and windowless /label/job/values must surface every job value, including
+// those carried only by days-old series.
+func TestMetadataScanBound_WindowlessLabelsComplete_Guard(t *testing.T) {
+	seed, _ := scanGuardSeed()
+	srv, _ := newChDBServer(t, seed)
+
+	labels := stringData(t, getMetaData(t, srv.URL+"/api/v1/labels"))
+	if !contains(labels, "__name__") || !contains(labels, "job") {
+		t.Errorf("windowless /labels = %v, want at least [__name__ job]", labels)
+	}
+
+	jobs := stringData(t, getMetaData(t, srv.URL+"/api/v1/label/job/values"))
+	for _, want := range []string{"old", "fresh", "mid"} {
+		if !contains(jobs, want) {
+			t.Errorf("windowless /label/job/values dropped %q (got %v) — every retained value must list",
+				want, jobs)
+		}
+	}
+}

--- a/internal/api/prom/metadata_scan_bound_repro_test.go
+++ b/internal/api/prom/metadata_scan_bound_repro_test.go
@@ -1,0 +1,155 @@
+package prom_test
+
+// REPRO (Layer 7/8 — HTTP-handler SQL-shape, default tag, no chDB).
+//
+// Pins the unbounded metadata-scan bug: a Grafana variable/metric-picker
+// query (`label_values(__name__)`, `label_values(<l>)`, `/labels`,
+// `/series`, `/api/v1/metadata`) that carries NO `start`/`end` lowers to
+// SQL with NO time predicate at all, so ClickHouse reads every
+// `toDate(TimeUnix)` partition — the ~30B-row / 59GB full-column scan seen
+// on prod.
+//
+// The honest knob that makes this visible without chDB: the metadata
+// emitters bound the scan with a `toDateTime64('…', 9)` TimeUnix literal
+// (dateTime64Frag for the no-`match[]` arms, metadataBoundExpr for the
+// matched path) ONLY when a window is present. metadataWindowPred returns
+// nil for the zero/zero case, so every windowless arm emits a WHERE-less
+// (or, for /api/v1/metadata, GROUP-BY-only) full-table scan. This test
+// asserts the inverse — that EVERY windowless arm carries the
+// `toDateTime64(` bound — so it is RED on current main and turns green
+// once a default lookback is bounded onto the windowless path.
+//
+// These assertions are the SQL-shape side of the bug. The result-identity
+// side (a bounded windowless scan must still return the SAME catalog it
+// does today — no silently-dropped recently-quiet metric) is pinned
+// separately by the chDB completeness guard in
+// metadata_scan_bound_guard_chdb_test.go and the existing W5_omitted
+// case in handler_chdb_metadata_window_sweep_test.go. Both halves must
+// hold: the fix bounds the scan AND preserves the answer.
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// dt64Bound is the inline TimeUnix window literal both metadata emit paths
+// render — present in the SQL iff a partition-pruning bound was pushed.
+const dt64Bound = "toDateTime64("
+
+// anyContains reports whether any recorded statement contains sub.
+func anyContains(stmts []string, sub string) bool {
+	for _, s := range stmts {
+		if strings.Contains(s, sub) {
+			return true
+		}
+	}
+	return false
+}
+
+// getDiscard GETs u and discards the body; the assertion is on the SQL the
+// stub recorded, not the response.
+func getDiscard(t *testing.T, u string) {
+	t.Helper()
+	resp, err := http.Get(u)
+	if err != nil {
+		t.Fatalf("GET %s: %v", u, err)
+	}
+	resp.Body.Close()
+}
+
+// TestMetadataScanBound_NoMatchWindowless_Repro covers the no-`match[]`
+// discovery arms — the exact shapes a Grafana variable query with default
+// "On dashboard load" refresh sends (no start/end):
+//
+//   - /label/__name__/values  -> metricNamesSQL        (the 59% prod shape)
+//   - /labels                 -> unionLabelNamesSQL
+//   - /label/<l>/values       -> unionLabelValuesSQL
+//
+// On main each emits a WHERE-less DISTINCT/mapKeys scan; the assertion
+// that the bound is present fails.
+func TestMetadataScanBound_NoMatchWindowless_Repro(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		path string
+	}{
+		{"metric_names", "/api/v1/label/__name__/values"},
+		{"label_names", "/api/v1/labels"},
+		{"label_values", "/api/v1/label/job/values"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			q := &stubQuerier{strings: []string{"up"}}
+			srv := newServer(q)
+			t.Cleanup(srv.Close)
+
+			getDiscard(t, srv.URL+tc.path)
+
+			if !anyContains(q.allSQL, dt64Bound) {
+				t.Errorf("windowless %s emitted no %s TimeUnix bound — full-partition scan; arms=%q",
+					tc.path, dt64Bound, q.allSQL)
+			}
+		})
+	}
+}
+
+// TestMetadataScanBound_MatchedWindowless_Repro covers the matched path —
+// `match[]` present but no start/end — which lowers through
+// promql.LowerMetadataRange -> wrapMetadataFullRange. With both bounds
+// zero the Filter node is omitted entirely, so the GROUP BY
+// (MetricName, Attributes) collapse runs over the whole table.
+func TestMetadataScanBound_MatchedWindowless_Repro(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		path string
+	}{
+		{"series", "/api/v1/series?match%5B%5D=up"},
+		{"label_values_matched", "/api/v1/label/job/values?match%5B%5D=up"},
+		{"labels_matched", "/api/v1/labels?match%5B%5D=up"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			q := &stubQuerier{
+				strings:   []string{"api"},
+				labelSets: []map[string]string{{"__name__": "up", "job": "api"}},
+			}
+			srv := newServer(q)
+			t.Cleanup(srv.Close)
+
+			getDiscard(t, srv.URL+tc.path)
+
+			if !anyContains(q.allSQL, dt64Bound) {
+				t.Errorf("windowless matched %s emitted no %s TimeUnix bound — whole-table GROUP BY; arms=%q",
+					tc.path, dt64Bound, q.allSQL)
+			}
+		})
+	}
+}
+
+// TestMetadataScanBound_MetricMeta_Repro covers /api/v1/metadata
+// (metricMetaSQL). This arm is UNCONDITIONALLY unbounded today: it accepts
+// no time input at all, so `SELECT MetricName, any(desc), any(unit) FROM
+// <table> GROUP BY MetricName` runs a whole-table GROUP BY on every call.
+// Unlike the others it cannot be fixed by threading the request window
+// alone — a default bound must be injected here too. The assertion that
+// the emit carries a TimeUnix bound fails on main.
+func TestMetadataScanBound_MetricMeta_Repro(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	getDiscard(t, srv.URL+"/api/v1/metadata")
+
+	if !anyContains(q.allSQL, dt64Bound) {
+		t.Errorf("/api/v1/metadata emitted no %s TimeUnix bound — unconditional whole-table GROUP BY; arms=%q",
+			dt64Bound, q.allSQL)
+	}
+}

--- a/internal/api/prom/metadata_test.go
+++ b/internal/api/prom/metadata_test.go
@@ -227,8 +227,15 @@ func TestMetadataDiscovery_WindowPrune(t *testing.T) {
 					tc.path, qw.lastSQL)
 			}
 
-			// Without a window: SQL stays unbounded (no time predicate),
-			// byte-for-byte the prior emit.
+			// Without a window: the scan must STILL be bounded by a default
+			// lookback so a Grafana variable query that sends no start/end
+			// (the common "On dashboard load" refresh) does not stream every
+			// toDate(TimeUnix) partition — the ~30B-row prod scan. REPRO:
+			// metadataWindowPred returns nil for the zero/zero case, so on
+			// current main this arm emits a WHERE-less full scan and the
+			// assertion below is RED. The companion result-identity guard
+			// (the windowless scan must still return the full catalog) lives
+			// in metadata_scan_bound_guard_chdb_test.go.
 			qn := &stubQuerier{strings: []string{"up"}}
 			srvN := newServer(qn)
 			t.Cleanup(srvN.Close)
@@ -237,8 +244,9 @@ func TestMetadataDiscovery_WindowPrune(t *testing.T) {
 				t.Fatalf("GET unbounded: %v", err)
 			}
 			resp.Body.Close()
-			if strings.Contains(qn.lastSQL, "TimeUnix") {
-				t.Errorf("unbounded %s must not emit a TimeUnix bound; got %q",
+			if !strings.Contains(qn.lastSQL, "toDateTime64(") ||
+				!strings.Contains(qn.lastSQL, "TimeUnix") {
+				t.Errorf("windowless %s must push a default TimeUnix partition bound; got %q",
 					tc.path, qn.lastSQL)
 			}
 		})


### PR DESCRIPTION
## What
Metadata enumeration emitters (`label_values(__name__)`, generic `label_values`, `/labels`, `series`, and **`/api/v1/metadata`**) emitted WHERE-less full-table `DISTINCT`/`GROUP BY` over `otel_metrics_*` when the request had no start/end. `metadataWindowPred` returned nil for zero-time bounds; `metricMetaSQL` had **no time parameter at all** (unbounded even when a window was known). This bounds the absent-window case to the **retention horizon** and threads the window through `metricMetaSQL`.

## Semantics (the important part — verified, not assumed)
Reference Prometheus answers windowless metadata over the **full queryable range** (`MinTime`/`MaxTime`), so a short-recent default would **under-return** vs Prometheus. The only parity-faithful default is `now - retention`. `const defaultMetadataLookback = 14*24*time.Hour` = the OTel-CH 2-week TTL. **Prod parity proven byte-identical**: windowless `DISTINCT MetricName` = 4316 names, identical cityHash64, unbounded vs 14d-bounded. Request-supplied ranges are honored verbatim (that's where real partition pruning comes from).

## Honest scope — this is correctness + coverage, NOT the windowless perf win
On current prod all data is within the 14d retention, so the retention-bound default **caps but does not reduce** the windowless scan (93/93 parts). The windowless `label_values(__name__)` 59%-of-reads cost needs a **separate `DISTINCT`-in-order pushdown on the `MetricName` sort key** (defeated today by the `DISTINCT`-over-`UNION ALL` wrapper) — a follow-up this PR's repro suite is built to validate. What this PR *does* fix: parity-safe bounding, honoring ranges (dashboard panels prune now), and the always-unbounded `/api/v1/metadata`.

## Repro at every applicable layer (repro-first)
4 fail-on-main repros: HTTP-handler SQL-shape (no-match + matched + `metricMetaSQL`), inverted windowless unit pin, and a **chDB EXPLAIN partition-prune gate** (10/10 parts on main → pruned on fix). 4 correctness guards (chDB multi-partition windowless completeness — must keep returning days-old names). 9 layers documented not-applicable (the bug is a CH-side scan-volume property invisible to parser/IR/optimizer/alloc layers). Named const, typed Frags, zero golden churn.

Latent caveat: if the table TTL is ever lengthened beyond 14d without bumping `defaultMetadataLookback`, the bound would silently drop names — a const-pinned-to-TTL test is recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)