### PR TITLE
perf(prom): serve windowless metric-name enumeration from an aggregating projection

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -577,6 +577,51 @@ Auto-create also reuses the **same** table names the query heads read
 (`CERBERUS_SCHEMA_*_TABLE`), so a renamed table is created and queried
 consistently rather than silently diverging onto the upstream defaults.
 
+### Metric-name catalog projection (`label_values(__name__)`)
+
+Auto-create installs a small **aggregating projection** named
+`proj_metric_name` on the gauge / sum / histogram fact tables:
+
+```sql
+ALTER TABLE <db>.<table> ADD PROJECTION IF NOT EXISTS proj_metric_name
+  (SELECT MetricName, max(TimeUnix) GROUP BY MetricName)
+```
+
+A windowless `/api/v1/label/__name__/values` (the query a Grafana metric
+picker sends on dashboard load — by far the heaviest metadata shape on a
+busy datasource) enumerates the distinct metric names. Without the
+projection that enumeration full-scans the metrics tables — on a real
+deployment ~4 billion rows / ~140 GiB / ~10 s for a single refresh. The
+handler emits the enumeration as
+`SELECT MetricName … GROUP BY MetricName HAVING max(TimeUnix) >= <lookback>`
+(an aggregate-only predicate — a raw `WHERE TimeUnix >= …` column filter
+cannot use the projection), which ClickHouse 26.x routes to
+`proj_metric_name`, reading the one-row-per-name projection (sub-megabyte,
+sub-100 ms) instead of the fact table. The result set is identical: because
+samples are never future-dated, `max(TimeUnix) >= lookback` is true for
+exactly the names with a sample in `[lookback, now]`.
+
+`ADD PROJECTION IF NOT EXISTS` is metadata-only and idempotent, so the
+auto-create hook (re)applies it safely on every boot, covering both
+freshly-created and pre-existing tables. **New parts written after the ALTER
+carry the projection automatically; existing parts are not back-filled by
+`ADD PROJECTION` alone.** Until existing parts roll over (under the metrics
+TTL) or are back-filled, ClickHouse transparently serves those parts from
+the base table — results stay correct, the prune ratio ramps in as
+projected parts replace un-projected ones. To back-fill immediately on an
+existing deployment, run the one-time materialize (a background mutation,
+non-blocking for reads):
+
+```sql
+ALTER TABLE <db>.otel_metrics_gauge      MATERIALIZE PROJECTION proj_metric_name;
+ALTER TABLE <db>.otel_metrics_sum        MATERIALIZE PROJECTION proj_metric_name;
+ALTER TABLE <db>.otel_metrics_histogram  MATERIALIZE PROJECTION proj_metric_name;
+```
+
+`MATERIALIZE` is intentionally **not** issued by the auto-create hook — it
+rewrites every existing part and belongs in a deliberate maintenance window,
+not the boot path. Track its progress in `system.mutations`.
+
 ### Startup requirements preflight
 
 `CERBERUS_REQUIREMENTS_CHECK` (**on by default**) runs a boot-time

--- a/internal/api/prom/metadata.go
+++ b/internal/api/prom/metadata.go
@@ -357,11 +357,18 @@ func (h *Handler) handleLabelValues(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, ErrBadData, err)
 		return
 	}
+	// nowAnchored is true when the request supplies no explicit upper bound,
+	// so the effective window's end is "now or open" — the case where the
+	// metric-name enumeration can answer exactly from the max(TimeUnix)
+	// aggregating projection (max(TimeUnix) >= start ⇔ a sample exists in
+	// [start, now], since samples are never future-dated). A user-supplied
+	// finite end stays on the exact WHERE-bounded scan.
+	nowAnchored := endT.IsZero()
 	startT, endT = boundMetadataWindow(startT, endT)
 
 	var values []string
 	if len(matchers) == 0 {
-		values, err = h.fetchLabelValues(r.Context(), name, startT, endT)
+		values, err = h.fetchLabelValues(r.Context(), name, startT, endT, nowAnchored)
 	} else {
 		values, err = h.fetchLabelValuesMatched(r.Context(), name, matchers, startT, endT)
 	}
@@ -702,9 +709,9 @@ func (h *Handler) fetchResourceLabelNames(ctx context.Context, start, end time.T
 	return out, nil
 }
 
-func (h *Handler) fetchLabelValues(ctx context.Context, name string, start, end time.Time) ([]string, error) {
+func (h *Handler) fetchLabelValues(ctx context.Context, name string, start, end time.Time, nowAnchored bool) ([]string, error) {
 	if name == model.MetricNameLabel {
-		return h.fetchMetricNameValues(ctx, start, end)
+		return h.fetchMetricNameValues(ctx, start, end, nowAnchored)
 	}
 	sql, args := h.unionLabelValuesSQL(name, start, end)
 	values, err := timeCH(ctx, func() ([]string, error) {
@@ -750,11 +757,11 @@ func (h *Handler) fetchLabelValues(ctx context.Context, name string, start, end 
 // the summary table has no lowering at all), and advertising names the
 // query surface can't serve is exactly the bug this function's split
 // shape exists to prevent.
-func (h *Handler) fetchMetricNameValues(ctx context.Context, start, end time.Time) ([]string, error) {
+func (h *Handler) fetchMetricNameValues(ctx context.Context, start, end time.Time, nowAnchored bool) ([]string, error) {
 	bareTables, histogramTable := h.catalogNameTables()
 	var values []string
 	if len(bareTables) > 0 {
-		sql := h.metricNamesSQL(bareTables, start, end)
+		sql := h.metricNamesSQL(bareTables, start, end, nowAnchored)
 		bare, err := timeCH(ctx, func() ([]string, error) {
 			return h.Client.QueryStrings(ctx, sql)
 		})
@@ -768,7 +775,7 @@ func (h *Handler) fetchMetricNameValues(ctx context.Context, start, end time.Tim
 		values = normalizeMetricValues(bare)
 	}
 	if histogramTable != "" {
-		sql := h.metricNamesSQL([]string{histogramTable}, start, end)
+		sql := h.metricNamesSQL([]string{histogramTable}, start, end, nowAnchored)
 		hist, err := timeCH(ctx, func() ([]string, error) {
 			return h.Client.QueryStrings(ctx, sql)
 		})
@@ -1395,21 +1402,54 @@ func (h *Handler) metadataWindowPred(start, end time.Time) chsql.Frag {
 // metricNamesSQL returns the distinct MetricName values across the
 // given tables. Callers group tables by how their names surface in the
 // catalog (see fetchMetricNameValues) — the SQL shape itself is the
-// same UNION-of-DISTINCT-arms for any group size. A non-zero start/end
-// pushes the closed metadata window onto each arm so the leading-key
-// DISTINCT prunes by partition instead of scanning the whole table.
-func (h *Handler) metricNamesSQL(tables []string, start, end time.Time) string {
+// same UNION-of-per-table-arms for any group size.
+//
+// Two arm shapes, picked by nowAnchored:
+//
+//   - nowAnchored (the Grafana metric-picker case: no explicit end, so the
+//     window ends "now" or is open-ended): each arm is
+//     `SELECT MetricName AS value FROM <t> GROUP BY MetricName
+//     HAVING max(TimeUnix) >= <start>`. Because samples are never
+//     future-dated, max(TimeUnix) >= start ⇔ the name has a sample in
+//     [start, now] — byte-for-byte the same name set as the WHERE-bounded
+//     DISTINCT, but the aggregate-only predicate is served from the
+//     `proj_metric_name` aggregating projection (GROUP BY MetricName,
+//     max(TimeUnix)) instead of full-scanning the fact table. On prod this
+//     turns the ~4.2B-row / ~139 GiB windowless enumeration into a
+//     sub-megabyte projection read.
+//
+//   - !nowAnchored (a user-supplied finite [start,end]): the exact
+//     WHERE-bounded DISTINCT is kept — a closed historical window cannot be
+//     answered exactly from per-name min/max alone (a name whose samples
+//     straddle but skip the window would be a false positive), and the
+//     request's own range is where MergeTree partition pruning already bounds
+//     the scan.
+func (h *Handler) metricNamesSQL(tables []string, start, end time.Time, nowAnchored bool) string {
 	metricCol := h.Schema.MetricNameColumn
-	pred := h.metadataWindowPred(start, end)
 	parts := make([]chsql.Frag, 0, len(tables))
-	for _, t := range tables {
-		arm := chsql.NewQuery().
-			Select(chsql.As(distinctIdent(metricCol), "value")).
-			From(chsql.Col(t))
-		if pred != nil {
-			arm = arm.Where(pred)
+	if nowAnchored {
+		tsCol := h.Schema.TimestampColumn
+		for _, t := range tables {
+			arm := chsql.NewQuery().
+				Select(chsql.As(chsql.Col(metricCol), "value")).
+				From(chsql.Col(t)).
+				GroupBy(chsql.Col(metricCol))
+			if !start.IsZero() {
+				arm = arm.Having(chsql.Gte(chsql.Call("max", chsql.Col(tsCol)), dateTime64Frag(start)))
+			}
+			parts = append(parts, arm.Frag())
 		}
-		parts = append(parts, arm.Frag())
+	} else {
+		pred := h.metadataWindowPred(start, end)
+		for _, t := range tables {
+			arm := chsql.NewQuery().
+				Select(chsql.As(distinctIdent(metricCol), "value")).
+				From(chsql.Col(t))
+			if pred != nil {
+				arm = arm.Where(pred)
+			}
+			parts = append(parts, arm.Frag())
+		}
 	}
 	outer := chsql.NewQuery().
 		Select(chsql.As(distinctIdent("value"), "")).

--- a/internal/api/prom/metadata_distinct_projection_chdb_test.go
+++ b/internal/api/prom/metadata_distinct_projection_chdb_test.go
@@ -1,0 +1,91 @@
+//go:build chdb
+
+package prom_test
+
+// PARITY (Layer 6a — chDB roundtrip; result identity under the projection).
+//
+// The windowless metric-name enumeration changed shape from
+// `SELECT DISTINCT MetricName WHERE TimeUnix >= <lookback>` to
+// `SELECT MetricName GROUP BY MetricName HAVING max(TimeUnix) >= <lookback>`
+// so it can route to the proj_metric_name aggregating projection
+// (metadata_scan_bound_explain_chdb_test.go pins the routing). This test
+// pins that the routed emit returns the IDENTICAL name set the bounded
+// DISTINCT did — including the retention-horizon boundary:
+//
+//   - names with a sample inside the default lookback (recent / days-old)
+//     are returned;
+//   - a name whose newest sample is older than the lookback is excluded,
+//     exactly as the `WHERE TimeUnix >= <lookback>` DISTINCT excluded it.
+//
+// Because samples are never future-dated, max(TimeUnix) >= lookback ⇔ a
+// sample exists in [lookback, now], so the two shapes are byte-for-byte the
+// same answer. The table carries the projection (materialized) so the result
+// is also proven correct when served from the projection, not just the base
+// table.
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// projectionParitySeed seeds gauge+sum with names spanning the default
+// retention lookback boundary, then installs + materializes the metric-name
+// projection (mirroring the cerberus DDL apply path). The returned sets are
+// the oracle: names inside the lookback must list, the over-horizon name
+// must not.
+func projectionParitySeed() (seed string, want, excluded map[string]struct{}) {
+	now := time.Now().UTC()
+	lit := func(d time.Duration) string {
+		return now.Add(-d).Format("2006-01-02 15:04:05.000000000")
+	}
+	// defaultMetadataLookback is 14d (internal/api/prom/metadata.go); seed one
+	// name just inside it (13d) and one well outside (20d) to pin the boundary.
+	const lookback = 14 * 24 * time.Hour
+	seed = metaShapedGaugeDDL + metaShapedSumDDL + metaShapedHistogramDDL + fmt.Sprintf(
+		`
+INSERT INTO otel_metrics_gauge (MetricName, Attributes, TimeUnix, Value) VALUES
+    ('g_recent',      map('job', 'fresh'), toDateTime64('%s', 9), 1.0),
+    ('g_within',      map('job', 'mid'),   toDateTime64('%s', 9), 1.0),
+    ('g_overhorizon', map('job', 'old'),   toDateTime64('%s', 9), 1.0);
+INSERT INTO otel_metrics_sum (MetricName, Attributes, TimeUnix, Value, IsMonotonic) VALUES
+    ('s_recent_total', map('job', 'fresh'), toDateTime64('%s', 9), 1.0, true);
+ALTER TABLE otel_metrics_gauge ADD PROJECTION proj_metric_name (SELECT MetricName, max(TimeUnix) GROUP BY MetricName);
+ALTER TABLE otel_metrics_sum ADD PROJECTION proj_metric_name (SELECT MetricName, max(TimeUnix) GROUP BY MetricName);
+ALTER TABLE otel_metrics_gauge MATERIALIZE PROJECTION proj_metric_name;
+ALTER TABLE otel_metrics_sum MATERIALIZE PROJECTION proj_metric_name;`,
+		lit(time.Minute),             // g_recent: 1 minute ago
+		lit(13*24*time.Hour),         // g_within: 13 days ago (inside 14d lookback)
+		lit(lookback+2*24*time.Hour), // g_overhorizon: 16 days ago (outside)
+		lit(time.Minute),             // s_recent_total: 1 minute ago
+	)
+	want = map[string]struct{}{"g_recent": {}, "g_within": {}, "s_recent_total": {}}
+	excluded = map[string]struct{}{"g_overhorizon": {}}
+	return seed, want, excluded
+}
+
+// TestMetadataDistinctProjection_WindowlessParity pins that the windowless
+// /api/v1/label/__name__/values served from the aggregating projection
+// returns exactly the bounded DISTINCT's name set: every name inside the
+// default lookback, and none whose newest sample is over the horizon.
+func TestMetadataDistinctProjection_WindowlessParity(t *testing.T) {
+	seed, want, excluded := projectionParitySeed()
+	srv, _ := newChDBServer(t, seed)
+
+	got := stringData(t, getMetaData(t, srv.URL+"/api/v1/label/__name__/values"))
+	gotSet := make(map[string]struct{}, len(got))
+	for _, n := range got {
+		gotSet[n] = struct{}{}
+	}
+	for name := range want {
+		if _, ok := gotSet[name]; !ok {
+			t.Errorf("windowless /label/__name__/values dropped in-lookback name %q (got %v)", name, got)
+		}
+	}
+	for name := range excluded {
+		if _, ok := gotSet[name]; ok {
+			t.Errorf("windowless /label/__name__/values returned over-horizon name %q (got %v) — "+
+				"the projection emit must match the bounded DISTINCT, which excludes it", name, got)
+		}
+	}
+}

--- a/internal/api/prom/metadata_scan_bound_explain_chdb_test.go
+++ b/internal/api/prom/metadata_scan_bound_explain_chdb_test.go
@@ -4,39 +4,37 @@ package prom_test
 
 // REPRO (Layer 12 — compute fan-out / scan-volume, chDB EXPLAIN indexes=1).
 //
-// The empirical proof that the windowless `__name__` enumeration is an
-// O(all-partitions) full-column scan. This drives the SQL the HANDLER
-// ACTUALLY emits for a no-start/end `/api/v1/label/__name__/values`
-// request (captured through a recording stub), then runs it against a
-// production-shaped gauge+sum table — PARTITION BY toDate(TimeUnix), the
-// OTel-CH exporter's own layout — seeded across many day-partitions, and
-// inspects the MergeTree MinMax/partition stage via EXPLAIN indexes=1.
+// The empirical proof that the windowless `__name__` enumeration reads the
+// `proj_metric_name` aggregating projection instead of full-scanning the
+// metrics fact table. This drives the SQL the HANDLER ACTUALLY emits for a
+// no-start/end `/api/v1/label/__name__/values` request (captured through a
+// recording stub), then runs it against a production-shaped gauge+sum table —
+// PARTITION BY toDate(TimeUnix), the OTel-CH exporter's own layout — that
+// carries the aggregating projection the cerberus DDL apply path installs
+// (internal/schema/ddl), and inspects the read source via EXPLAIN indexes=1.
 //
-//   - On current main the handler emits a WHERE-less DISTINCT, so the
-//     first `Parts:` line reads N/N — every partition selected. The
-//     assertion (the windowless emit must Partition-prune to a strict
-//     subset) is RED.
-//   - Once a default lookback bounds the windowless path, the captured SQL
-//     carries the `toDateTime64('…', 9)` TimeUnix predicate and the same
-//     EXPLAIN reads k/N with k < N — GREEN.
+//   - A bare `DISTINCT ... WHERE TimeUnix >= …` emit (the pre-projection
+//     shape) keeps a raw column filter that no aggregating projection can
+//     serve, so the read streams every granule of the fact table.
+//   - The handler's windowless emit is `GROUP BY MetricName HAVING
+//     max(TimeUnix) >= <lookback>` — an aggregate-only predicate that routes
+//     to proj_metric_name, so EXPLAIN reads the projection with a strict
+//     granule subset. The assertion (the read must route to the projection
+//     and prune) is the flip this test pins.
 //
-// This complements (does not duplicate) the existing hand-written
-// test/perf/metric_names_window_prune_chdb_test.go: that file pins the
-// *baseline* (a hand-written unbounded SQL scans all parts) and that a
-// hand-written *windowed* SQL prunes. This file closes the gap between
-// them — it asserts the property on the SQL cerberus's handler emits for a
-// windowless request, so it auto-flips when the handler is fixed rather
-// than tracking a hand-copied string.
+// This complements the hand-written
+// test/perf/metric_names_window_prune_chdb_test.go: that file recorded that
+// no exact column-DISTINCT shape can be marks-bounded; the projection is the
+// exact, marks-bounded shape, and this file asserts the property on the SQL
+// cerberus's handler actually emits, so it tracks the handler rather than a
+// hand-copied string.
 //
-// Honest scope note: partition pruning a windowless request narrows the
-// scan ONLY because the default window is narrower than the seeded span.
-// That narrowing is correctness-preserving ONLY if the default is the
-// table's retention horizon (data older than retention is gone from a real
-// Prometheus too) — a short recent default would silently drop
-// recently-quiet metric names and DIVERGE from reference Prometheus. The
-// result-identity guard that the windowless catalog stays complete lives
-// in metadata_scan_bound_guard_chdb_test.go and W5_omitted in
-// handler_chdb_metadata_window_sweep_test.go; both halves must hold.
+// Honest scope note: the projection answers "names with a sample in
+// [lookback, now]" exactly because samples are never future-dated
+// (max(TimeUnix) >= lookback ⇔ a sample in the window), so the windowless
+// catalog stays COMPLETE over the retention horizon — the result-identity
+// guard for that lives in metadata_scan_bound_guard_chdb_test.go and
+// W5_omitted in handler_chdb_metadata_window_sweep_test.go; both halves hold.
 
 import (
 	"database/sql"
@@ -54,9 +52,8 @@ const (
 	// N == scanBoundDays and a bounded scan can prune to a strict subset.
 	scanBoundDays = 10
 	// scanBoundRows seeds a dense corpus so OPTIMIZE FINAL yields one part
-	// per day-partition (real parts for the MinMax stage to prune).
-	scanBoundRows  = 200_000
-	scanBoundEpoch = "2026-01-01"
+	// per day-partition (real parts for the projection to collapse).
+	scanBoundRows = 200_000
 )
 
 // scanBoundPartitionedDDL is the production OTel-CH metric table trimmed to
@@ -74,44 +71,60 @@ PARTITION BY toDate(TimeUnix)
 ORDER BY (MetricName, TimeUnix);`, table)
 }
 
-// scanBoundInsert scatters rows across scanBoundDays day-partitions.
+// scanBoundInsert scatters rows across scanBoundDays day-partitions. The
+// rows are now-relative (newest sample seconds ago, oldest scanBoundDays ago)
+// so they land inside the windowless emit's default retention lookback and
+// the HAVING max(TimeUnix) >= start predicate selects them.
 func scanBoundInsert(table string) string {
 	return fmt.Sprintf(`INSERT INTO %s
 SELECT
     concat('m_', toString(number %% 50)) AS MetricName,
     map('job', 'j') AS Attributes,
-    toDateTime64('%s 00:00:00', 9) + INTERVAL (number %% %d) DAY AS TimeUnix,
+    now64(9) - INTERVAL (number %% %d) DAY AS TimeUnix,
     toFloat64(number) AS Value
-FROM numbers(%d);`, table, scanBoundEpoch, scanBoundDays, scanBoundRows)
+FROM numbers(%d);`, table, scanBoundDays, scanBoundRows)
 }
 
-// firstPartsFraction returns (selected, total) from the FIRST `Parts: N/M`
-// line of an EXPLAIN indexes=1 plan — the MinMax/partition stage of the
-// MergeTree scan.
-func firstPartsFraction(t *testing.T, db *sql.DB, query string) (selected, total int) {
+// scanBoundAddProjection mirrors the cerberus DDL apply path
+// (internal/schema/ddl): the aggregating projection over MetricName carrying
+// max(TimeUnix) that the windowless metric-name emit routes to.
+func scanBoundAddProjection(table string) string {
+	return fmt.Sprintf(
+		`ALTER TABLE %s ADD PROJECTION proj_metric_name `+
+			`(SELECT MetricName, max(TimeUnix) GROUP BY MetricName);`, table,
+	)
+}
+
+// projectionGranules returns (selected, total) granules from the
+// EXPLAIN indexes=1 read of the `proj_metric_name` aggregating projection —
+// proof the windowless emit routes to the projection rather than scanning the
+// fact table. It returns ok=false if no projection read appears in the plan.
+func projectionGranules(t *testing.T, db *sql.DB, query string) (selected, total int, ok bool) {
 	t.Helper()
 	rows, err := db.Query("EXPLAIN indexes=1 " + query)
 	if err != nil {
 		t.Fatalf("EXPLAIN: %v\nquery: %s", err, query)
 	}
 	defer rows.Close()
+	inProjection := false
 	for rows.Next() {
 		var line string
 		if err := rows.Scan(&line); err != nil {
 			t.Fatalf("scan: %v", err)
 		}
 		trim := strings.TrimSpace(line)
-		if !strings.HasPrefix(trim, "Parts:") {
-			continue
+		switch {
+		case strings.HasPrefix(trim, "ReadFromMergeTree"):
+			inProjection = strings.Contains(trim, "proj_metric_name")
+		case inProjection && strings.HasPrefix(trim, "Granules:"):
+			frac := strings.TrimSpace(strings.TrimPrefix(trim, "Granules:"))
+			if _, err := fmt.Sscanf(frac, "%d/%d", &selected, &total); err != nil {
+				t.Fatalf("parse Granules line %q: %v", trim, err)
+			}
+			return selected, total, true
 		}
-		frac := strings.TrimSpace(strings.TrimPrefix(trim, "Parts:"))
-		if _, err := fmt.Sscanf(frac, "%d/%d", &selected, &total); err != nil {
-			t.Fatalf("parse Parts line %q: %v", trim, err)
-		}
-		return selected, total
 	}
-	t.Fatalf("EXPLAIN produced no Parts line for:\n%s", query)
-	return 0, 0
+	return 0, 0, false
 }
 
 // captureWindowlessMetricNamesSQL returns the gauge/sum-arm SQL the handler
@@ -140,10 +153,14 @@ func captureWindowlessMetricNamesSQL(t *testing.T) string {
 	return ""
 }
 
-// TestMetadataScanBound_MetricNamesExplain_Repro pins the partition-prune
-// property on the handler's actual windowless `__name__` emit. RED on main
-// (Parts: N/N, the unbounded full-partition scan); green once a default
-// lookback bounds the windowless path.
+// TestMetadataScanBound_MetricNamesExplain_Repro pins the projection-routing
+// property on the handler's actual windowless `__name__` emit. The windowless
+// enumeration (`GROUP BY MetricName HAVING max(TimeUnix) >= <lookback>`) must
+// read the `proj_metric_name` aggregating projection — a tiny one-row-per-name
+// part — instead of full-scanning the metrics fact table. Without the
+// projection (or with the pre-projection `DISTINCT ... WHERE TimeUnix` emit
+// that a column filter keeps off any projection) this read streams every
+// granule of the fact table; the assertion below catches that regression.
 func TestMetadataScanBound_MetricNamesExplain_Repro(t *testing.T) {
 	db, err := sql.Open("chdb", "")
 	if err != nil {
@@ -155,12 +172,18 @@ func TestMetadataScanBound_MetricNamesExplain_Repro(t *testing.T) {
 	}
 
 	for _, table := range []string{"otel_metrics_gauge", "otel_metrics_sum"} {
-		for _, stmt := range []string{scanBoundPartitionedDDL(table), scanBoundInsert(table)} {
+		stmts := []string{
+			scanBoundPartitionedDDL(table),
+			scanBoundInsert(table),
+			scanBoundAddProjection(table),
+			"ALTER TABLE " + table + " MATERIALIZE PROJECTION proj_metric_name",
+		}
+		for _, stmt := range stmts {
 			if _, err := db.Exec(stmt); err != nil {
 				t.Fatalf("setup %s: %v", stmt, err)
 			}
 		}
-		// One dense part per day-partition so the MinMax stage prunes real
+		// One dense part per day-partition so the projection collapses real
 		// parts, not inflated unmerged insert parts.
 		if _, err := db.Exec("OPTIMIZE TABLE " + table + " FINAL"); err != nil {
 			t.Fatalf("optimize %s: %v", table, err)
@@ -170,16 +193,18 @@ func TestMetadataScanBound_MetricNamesExplain_Repro(t *testing.T) {
 	captured := captureWindowlessMetricNamesSQL(t)
 	t.Logf("windowless __name__ emit:\n%s", captured)
 
-	sel, tot := firstPartsFraction(t, db, captured)
-	t.Logf("windowless __name__ MinMax parts: %d/%d", sel, tot)
-
+	sel, tot, ok := projectionGranules(t, db, captured)
+	if !ok {
+		t.Fatalf("windowless /api/v1/label/__name__/values did not route to proj_metric_name — "+
+			"it full-scans the fact table. emit:\n%s", captured)
+	}
+	t.Logf("windowless __name__ projection granules: %d/%d", sel, tot)
 	if tot < scanBoundDays {
-		t.Fatalf("scan saw %d parts total, want >= %d day-partitions — corpus not dense enough to prove pruning",
+		t.Fatalf("projection read saw %d granules total, want >= %d — corpus not dense enough to prove pruning",
 			tot, scanBoundDays)
 	}
 	if sel >= tot {
-		t.Errorf("windowless /api/v1/label/__name__/values selected %d of %d parts — the full-partition scan "+
-			"that is the bug; a default lookback must bound the windowless emit so it Partition-prunes (k < N).",
-			sel, tot)
+		t.Errorf("windowless /api/v1/label/__name__/values read %d of %d projection granules — no pruning; "+
+			"the aggregating projection must collapse the metric-name scan (selected < total).", sel, tot)
 	}
 }

--- a/internal/chsql/builder.go
+++ b/internal/chsql/builder.go
@@ -1845,6 +1845,7 @@ type QueryBuilder struct {
 	where      []Frag
 	prewhere   []Frag
 	groupBy    []Frag
+	having     []Frag
 	orderBy    []orderKey
 	limit      int64
 	hasLimit   bool
@@ -1974,6 +1975,16 @@ func (s *QueryBuilder) Prewhere(conds ...Frag) *QueryBuilder {
 // GroupBy appends grouping expressions.
 func (s *QueryBuilder) GroupBy(keys ...Frag) *QueryBuilder {
 	s.groupBy = append(s.groupBy, keys...)
+	return s
+}
+
+// Having appends a post-aggregation predicate (multiple conditions are
+// AND-joined). HAVING filters on aggregate results — `max(TimeUnix) >= ?`
+// over a `GROUP BY MetricName` — so unlike WHERE it can be served from an
+// aggregating projection that pre-computes the aggregate, which a raw
+// `WHERE TimeUnix >= ?` on the same column cannot.
+func (s *QueryBuilder) Having(conds ...Frag) *QueryBuilder {
+	s.having = append(s.having, conds...)
 	return s
 }
 
@@ -2156,6 +2167,10 @@ func (s *QueryBuilder) writeInto(b *Builder) {
 			}
 			f(b)
 		}
+	}
+	if len(s.having) > 0 {
+		b.sb.WriteString(" HAVING ")
+		And(s.having...)(b)
 	}
 	if len(s.orderBy) > 0 {
 		b.sb.WriteString(" ORDER BY ")

--- a/internal/chsql/ddl.go
+++ b/internal/chsql/ddl.go
@@ -396,3 +396,71 @@ func (c *CreateTableBuilder) frag() Frag {
 func (c *CreateTableBuilder) SQL() string {
 	return RenderDDL(c.frag())
 }
+
+// --- ALTER TABLE ... ADD PROJECTION surface ---
+//
+// AddProjectionBuilder renders `ALTER TABLE <db>.<table> ADD PROJECTION IF
+// NOT EXISTS <name> (<body>)`, where <body> is a SELECT/GROUP BY query the
+// caller composes with the same typed QueryBuilder used for read queries.
+// The merge engine maintains the projection automatically; cerberus uses it
+// to make the metric-name catalog enumeration (`GROUP BY MetricName`) read
+// an aggregating projection instead of full-scanning the metrics fact table.
+//
+// IF NOT EXISTS makes ADD PROJECTION metadata-only and idempotent, so the
+// same DDL Apply path covers both freshly-created and pre-existing tables.
+// Like the other DDL builders it binds no positional `?` values, so SQL
+// renders through RenderDDL.
+
+// AddProjectionBuilder builds an ALTER TABLE ADD PROJECTION statement.
+type AddProjectionBuilder struct {
+	database string
+	table    string
+	name     string
+	cluster  string // "" => no ON CLUSTER clause
+	body     *QueryBuilder
+}
+
+// AlterTableAddProjection starts an ADD PROJECTION builder for the named
+// projection on <database>.<table>. body is the projection definition — a
+// QueryBuilder carrying the SELECT (+ optional GROUP BY) shape the engine
+// pre-aggregates; it must bind no positional args (DDL invariant).
+func AlterTableAddProjection(database, table, name string, body *QueryBuilder) *AddProjectionBuilder {
+	return &AddProjectionBuilder{database: database, table: table, name: name, body: body}
+}
+
+// OnCluster adds an `ON CLUSTER <name>` clause so the ALTER replicates the
+// same way the CREATE statements do under a classic ON CLUSTER deployment.
+// A Replicated database replicates the DDL itself and needs no clause.
+func (a *AddProjectionBuilder) OnCluster(name string) *AddProjectionBuilder {
+	a.cluster = name
+	return a
+}
+
+// frag assembles the statement from typed pieces: keyword tokens via
+// ddlToken, bare database/table/projection identifiers via BareIdent, the
+// optional ON CLUSTER clause via the typed constructor, and the projection
+// body via the QueryBuilder's own Frag — no raw token is written here.
+func (a *AddProjectionBuilder) frag() Frag {
+	return func(b *Builder) {
+		ddlToken("ALTER TABLE ")(b)
+		BareIdent(a.database)(b)
+		ddlToken(".")(b)
+		BareIdent(a.table)(b)
+		if a.cluster != "" {
+			ddlToken(" ")(b)
+			OnCluster(a.cluster)(b)
+		}
+		ddlToken(" ADD PROJECTION IF NOT EXISTS ")(b)
+		BareIdent(a.name)(b)
+		ddlToken(" ")(b)
+		// QueryBuilder.Frag already wraps the body in the single pair of
+		// parentheses the projection-definition grammar requires.
+		a.body.Frag()(b)
+	}
+}
+
+// SQL renders the ALTER TABLE ADD PROJECTION statement to ClickHouse text
+// via RenderDDL (which asserts the no-positional-bindings DDL invariant).
+func (a *AddProjectionBuilder) SQL() string {
+	return RenderDDL(a.frag())
+}

--- a/internal/chsql/ddl_test.go
+++ b/internal/chsql/ddl_test.go
@@ -137,6 +137,89 @@ func TestCreateDatabase(t *testing.T) {
 	}
 }
 
+// metricNameProjectionBody is the aggregating projection body the metric-name
+// catalog enumeration is served from: one row per MetricName carrying its
+// max(TimeUnix). Built with the same typed QueryBuilder used for reads.
+func metricNameProjectionBody() *QueryBuilder {
+	return NewQuery().
+		Select(Col("MetricName"), Call("max", Col("TimeUnix"))).
+		GroupBy(Col("MetricName"))
+}
+
+// TestAlterTableAddProjection pins the ADD PROJECTION statement: the
+// fully-qualified <db>.<table>, the idempotent IF NOT EXISTS guard, the
+// projection body wrapped in exactly one pair of parentheses, and the
+// optional ON CLUSTER clause. The statement carries no positional args.
+func TestAlterTableAddProjection(t *testing.T) {
+	cases := []struct {
+		name string
+		stmt *AddProjectionBuilder
+		want string
+	}{
+		{
+			"plain",
+			AlterTableAddProjection("otel", "otel_metrics_gauge", "proj_metric_name", metricNameProjectionBody()),
+			"ALTER TABLE otel.otel_metrics_gauge ADD PROJECTION IF NOT EXISTS proj_metric_name " +
+				"(SELECT `MetricName`, max(`TimeUnix`) GROUP BY `MetricName`)",
+		},
+		{
+			"default_db",
+			AlterTableAddProjection("default", "otel_metrics_sum", "proj_metric_name", metricNameProjectionBody()),
+			"ALTER TABLE default.otel_metrics_sum ADD PROJECTION IF NOT EXISTS proj_metric_name " +
+				"(SELECT `MetricName`, max(`TimeUnix`) GROUP BY `MetricName`)",
+		},
+		{
+			"on_cluster",
+			AlterTableAddProjection("otel", "otel_metrics_histogram", "proj_metric_name", metricNameProjectionBody()).OnCluster("prod"),
+			"ALTER TABLE otel.otel_metrics_histogram ON CLUSTER `prod` ADD PROJECTION IF NOT EXISTS proj_metric_name " +
+				"(SELECT `MetricName`, max(`TimeUnix`) GROUP BY `MetricName`)",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.stmt.SQL(); got != tc.want {
+				t.Errorf("SQL() = %q; want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestQueryBuilderHaving pins the HAVING clause render: it follows GROUP BY,
+// precedes ORDER BY, and AND-joins multiple conditions. HAVING (not WHERE) is
+// what lets the metric-name enumeration route to the aggregating projection.
+func TestQueryBuilderHaving(t *testing.T) {
+	sql, args := NewQuery().
+		Select(As(Col("MetricName"), "value")).
+		From(Col("otel_metrics_gauge")).
+		GroupBy(Col("MetricName")).
+		Having(Gte(Call("max", Col("TimeUnix")), InlineLit(int64(1700000000)))).
+		OrderBy(Col("value"), false).
+		Build()
+	want := "SELECT `MetricName` AS `value` FROM `otel_metrics_gauge` GROUP BY `MetricName` " +
+		"HAVING max(`TimeUnix`) >= 1700000000 ORDER BY `value`"
+	if sql != want {
+		t.Errorf("Build() = %q; want %q", sql, want)
+	}
+	if len(args) != 0 {
+		t.Errorf("inline HAVING must bind no args, got %v", args)
+	}
+
+	multi, _ := NewQuery().
+		Select(Col("MetricName")).
+		From(Col("t")).
+		GroupBy(Col("MetricName")).
+		Having(
+			Gte(Call("max", Col("TimeUnix")), InlineLit(int64(1))),
+			Lte(Call("min", Col("TimeUnix")), InlineLit(int64(2))),
+		).
+		Build()
+	wantMulti := "SELECT `MetricName` FROM `t` GROUP BY `MetricName` " +
+		"HAVING max(`TimeUnix`) >= 1 AND min(`TimeUnix`) <= 2"
+	if multi != wantMulti {
+		t.Errorf("multi-HAVING Build() = %q; want %q", multi, wantMulti)
+	}
+}
+
 // TestRenderDDL_PanicsOnBoundArg locks the DDL no-bindings invariant: a
 // fragment that binds a positional `?` (here via Lit) must panic rather
 // than silently drop the binding and emit an unfillable `?` into the DDL.

--- a/internal/schema/ddl/ddl.go
+++ b/internal/schema/ddl/ddl.go
@@ -422,13 +422,23 @@ func renderSignal(cfg Config, s Signal) ([]string, error) {
 	switch s {
 	case Metrics:
 		ttl := ttlExpr("TimeUnix", cfg.TTL.Metrics)
-		return []string{
+		stmts := []string{
 			renderMetricsTable(sqltemplates.MetricsGaugeCreateTable, cfg, cfg.Tables.MetricsGauge, ttl),
 			renderMetricsTable(sqltemplates.MetricsSumCreateTable, cfg, cfg.Tables.MetricsSum, ttl),
 			renderMetricsTable(sqltemplates.MetricsHistogramCreateTable, cfg, cfg.Tables.MetricsHistogram, ttl),
 			renderMetricsTable(sqltemplates.MetricsExpHistogramCreateTable, cfg, cfg.Tables.MetricsExpHistogram, ttl),
 			renderMetricsTable(sqltemplates.MetricsSummaryCreateTable, cfg, cfg.Tables.MetricsSummary, ttl),
-		}, nil
+		}
+		// Each CREATE is immediately followed by the idempotent
+		// ADD PROJECTION ALTER for the same table — CREATE precedes ALTER in
+		// the slice and applySignal executes sequentially, so the ALTER never
+		// races a missing table. Only the catalog tables the metric-name
+		// enumeration reads (gauge/sum/histogram, see metricTables() in
+		// internal/api/prom/metadata.go) carry the projection.
+		for _, table := range []string{cfg.Tables.MetricsGauge, cfg.Tables.MetricsSum, cfg.Tables.MetricsHistogram} {
+			stmts = append(stmts, renderAddMetricNameProjection(cfg, table))
+		}
+		return stmts, nil
 	case Logs:
 		logs, err := renderLogsTable(cfg)
 		if err != nil {
@@ -454,6 +464,40 @@ func renderMetricsTable(tmpl string, cfg Config, table, ttl string) string {
 	return cfg.appendSettings(
 		fmt.Sprintf(tmpl, cfg.Database, table, cfg.clusterClause(), cfg.Engine, ttl),
 	)
+}
+
+const (
+	// metricNameProjection is the aggregating projection that lets the
+	// windowless metric-name catalog enumeration (label_values(__name__))
+	// read an aggregating-projection part instead of full-scanning the
+	// metrics fact table — see metricNamesSQL in internal/api/prom/metadata.go.
+	metricNameProjection = "proj_metric_name"
+	// metricNameColumn / metricTimeColumn are the OTel-CH metric-table columns
+	// the projection aggregates over; fixed by the upstream exporter schema,
+	// not configurable in this package.
+	metricNameColumn = "MetricName"
+	metricTimeColumn = "TimeUnix"
+)
+
+// renderAddMetricNameProjection builds the idempotent ADD PROJECTION ALTER
+// for one metrics fact table: an aggregating projection over MetricName
+// carrying max(TimeUnix), which serves the metric-name catalog query
+// (`GROUP BY MetricName HAVING max(TimeUnix) >= …`) from a tiny pre-aggregated
+// part rather than the full column. ON CLUSTER is threaded so the ALTER
+// replicates the same way the CREATE statements do. ADD PROJECTION IF NOT
+// EXISTS is metadata-only and idempotent, so the same Apply path covers both
+// freshly-created and pre-existing tables; backfilling existing parts is a
+// separate MATERIALIZE PROJECTION runbook (see docs/operations.md), kept out
+// of the hot DDL path.
+func renderAddMetricNameProjection(cfg Config, table string) string {
+	body := chsql.NewQuery().
+		Select(chsql.Col(metricNameColumn), chsql.Call("max", chsql.Col(metricTimeColumn))).
+		GroupBy(chsql.Col(metricNameColumn))
+	stmt := chsql.AlterTableAddProjection(cfg.Database, table, metricNameProjection, body)
+	if cfg.Cluster != "" {
+		stmt.OnCluster(cfg.Cluster)
+	}
+	return stmt.SQL()
 }
 
 // renderLogsTable renders the logs DDL. The logs template became a

--- a/internal/schema/ddl/ddl_test.go
+++ b/internal/schema/ddl/ddl_test.go
@@ -7,7 +7,8 @@ import (
 )
 
 // TestRenderSignal_Metrics checks all five metrics templates render with
-// the right table names + engine + database substituted in.
+// the right table names + engine + database substituted in, followed by the
+// three idempotent metric-name ADD PROJECTION ALTERs.
 func TestRenderSignal_Metrics(t *testing.T) {
 	cfg := Config{}.withDefaults()
 
@@ -15,7 +16,9 @@ func TestRenderSignal_Metrics(t *testing.T) {
 	if err != nil {
 		t.Fatalf("renderSignal(Metrics): %v", err)
 	}
-	if got, want := len(stmts), 5; got != want {
+	// 5 CREATE TABLE + 3 ADD PROJECTION (gauge/sum/histogram catalog tables).
+	const wantCreates = 5
+	if got, want := len(stmts), wantCreates+3; got != want {
 		t.Fatalf("metrics: got %d statements, want %d", got, want)
 	}
 	wantTables := []string{
@@ -25,7 +28,7 @@ func TestRenderSignal_Metrics(t *testing.T) {
 		"otel_metrics_exp_histogram",
 		"otel_metrics_summary",
 	}
-	for i, stmt := range stmts {
+	for i, stmt := range stmts[:wantCreates] {
 		if !strings.Contains(stmt, "CREATE TABLE IF NOT EXISTS") {
 			t.Errorf("metrics[%d]: missing IF NOT EXISTS:\n%s", i, stmt)
 		}
@@ -40,6 +43,23 @@ func TestRenderSignal_Metrics(t *testing.T) {
 		}
 		if strings.Contains(stmt, "TTL toDateTime") {
 			t.Errorf("metrics[%d]: zero TTL should not render TTL clause", i)
+		}
+	}
+	// The projection ALTERs follow the CREATEs, one per catalog table, in
+	// gauge/sum/histogram order. CREATE precedes ALTER so the ALTER never
+	// races a missing table.
+	wantProjTables := []string{"otel_metrics_gauge", "otel_metrics_sum", "otel_metrics_histogram"}
+	for i, stmt := range stmts[wantCreates:] {
+		wantPrefix := "ALTER TABLE default." + wantProjTables[i] +
+			" ADD PROJECTION IF NOT EXISTS proj_metric_name "
+		if !strings.HasPrefix(stmt, wantPrefix) {
+			t.Errorf("metrics projection[%d]: got %q, want prefix %q", i, stmt, wantPrefix)
+		}
+		if !strings.Contains(stmt, "max(`TimeUnix`) GROUP BY `MetricName`") {
+			t.Errorf("metrics projection[%d]: missing aggregating body in:\n%s", i, stmt)
+		}
+		if strings.Contains(stmt, "ON CLUSTER") {
+			t.Errorf("metrics projection[%d]: empty cluster should not render ON CLUSTER", i)
 		}
 	}
 }
@@ -171,6 +191,11 @@ func TestRenderSignal_CustomConfig(t *testing.T) {
 	// engine + a 48-hour TTL expression.
 	metrics, _ := renderSignal(cfg, Metrics)
 	for i, stmt := range metrics {
+		// ADD PROJECTION ALTERs carry neither engine nor TTL — those live on
+		// the CREATE TABLE statements only.
+		if strings.HasPrefix(stmt, "ALTER TABLE") {
+			continue
+		}
 		if !strings.Contains(stmt, "ReplicatedMergeTree") {
 			t.Errorf("metrics[%d]: custom engine not rendered", i)
 		}
@@ -215,6 +240,10 @@ func TestRenderSignal_ReplicatedDatabaseDefaultsToReplicatedMergeTree(t *testing
 			if sig == Traces && i == 2 {
 				continue
 			}
+			// ADD PROJECTION ALTERs inherit the table engine; they name none.
+			if strings.HasPrefix(stmt, "ALTER TABLE") {
+				continue
+			}
 			if !strings.Contains(stmt, "ReplicatedMergeTree") {
 				t.Errorf("%s[%d]: want bare ReplicatedMergeTree engine in:\n%s", sig, i, stmt)
 			}
@@ -241,6 +270,10 @@ func TestRenderSignal_ExplicitEngineWinsOverReplicated(t *testing.T) {
 
 	metrics, _ := renderSignal(cfg, Metrics)
 	for i, stmt := range metrics {
+		// ADD PROJECTION ALTERs inherit the table engine; they name none.
+		if strings.HasPrefix(stmt, "ALTER TABLE") {
+			continue
+		}
 		if !strings.Contains(stmt, "ReplicatedReplacingMergeTree('/x/{shard}', '{replica}')") {
 			t.Errorf("metrics[%d]: explicit engine override not honoured:\n%s", i, stmt)
 		}
@@ -297,6 +330,10 @@ func TestRenderSignal_PerSignalTTL(t *testing.T) {
 
 	metrics, _ := renderSignal(cfg, Metrics)
 	for i, stmt := range metrics {
+		// ADD PROJECTION ALTERs inherit retention from the table; no TTL clause.
+		if strings.HasPrefix(stmt, "ALTER TABLE") {
+			continue
+		}
 		if !strings.Contains(stmt, "TTL toDateTime(TimeUnix) + toIntervalDay(90)") {
 			t.Errorf("metrics[%d]: want 90d TTL:\n%s", i, stmt)
 		}

--- a/internal/schema/ddl/idempotency_test.go
+++ b/internal/schema/ddl/idempotency_test.go
@@ -271,16 +271,18 @@ func TestRenderSignal_TracesOnlySubset(t *testing.T) {
 	}
 }
 
-// TestRenderSignal_MetricsOnlySubset confirms the five metrics statements
-// render without leaking logs or traces tables.
+// TestRenderSignal_MetricsOnlySubset confirms the five metrics CREATE
+// statements (plus the three metric-name ADD PROJECTION ALTERs) render
+// without leaking logs or traces tables.
 func TestRenderSignal_MetricsOnlySubset(t *testing.T) {
 	cfg := Config{}.withDefaults()
 	stmts, err := renderSignal(cfg, Metrics)
 	if err != nil {
 		t.Fatalf("renderSignal(Metrics): %v", err)
 	}
-	if len(stmts) != 5 {
-		t.Fatalf("metrics subset: got %d statements; want 5", len(stmts))
+	// 5 CREATE TABLE + 3 ADD PROJECTION (gauge/sum/histogram).
+	if len(stmts) != 8 {
+		t.Fatalf("metrics subset: got %d statements; want 8", len(stmts))
 	}
 	for i, stmt := range stmts {
 		if strings.Contains(stmt, "otel_logs") || strings.Contains(stmt, "otel_traces") {
@@ -447,6 +449,10 @@ func TestRenderSignal_TTLAppliesCorrectTimeFieldPerSignal(t *testing.T) {
 	}
 	metrics, _ := renderSignal(cfg, Metrics)
 	for i, stmt := range metrics {
+		// ADD PROJECTION ALTERs inherit retention from the table; no TTL clause.
+		if strings.HasPrefix(stmt, "ALTER TABLE") {
+			continue
+		}
 		if !strings.Contains(stmt, "TTL toDateTime(TimeUnix)") {
 			t.Errorf("metrics[%d] TTL: missing toDateTime(TimeUnix):\n%s", i, stmt)
 		}

--- a/internal/schema/ddl/settings_test.go
+++ b/internal/schema/ddl/settings_test.go
@@ -18,7 +18,14 @@ func mergeTreeStmts(t *testing.T, cfg Config) []string {
 	if err != nil {
 		t.Fatalf("renderSignal(Metrics): %v", err)
 	}
-	out = append(out, m...)
+	// The metric-name ADD PROJECTION ALTERs carry no SETTINGS tail (they
+	// inherit the table's settings); only the CREATE TABLE statements do.
+	for _, stmt := range m {
+		if strings.HasPrefix(stmt, "ALTER TABLE") {
+			continue
+		}
+		out = append(out, stmt)
+	}
 	l, err := renderSignal(cfg, Logs)
 	if err != nil {
 		t.Fatalf("renderSignal(Logs): %v", err)


### PR DESCRIPTION
## What
`label_values(__name__)` is **59% of cerberus's entire ClickHouse read volume** (30B rows/24h) — a full-table `DISTINCT MetricName` over the 4.2B-row metrics tables. This adds an aggregating projection `proj_metric_name (SELECT MetricName, max(TimeUnix) GROUP BY MetricName)` to gauge/sum/histogram via the DDL apply path, and rewrites the windowless enumeration emit to `GROUP BY MetricName HAVING max(TimeUnix) >= start` which the query planner routes onto the projection.

## Why a projection (no SQL lever works — proven on prod)
Exhaustively benchmarked: bare `DISTINCT`, `optimize_distinct_in_order`, `GROUP BY`, `optimize_aggregation_in_order`, the UNION-ALL shape — **all read 2.83–4.2B rows, zero pruning** (the settings change operator memory, not granule selection). `mergeTreeIndex()` prunes but is **incorrect** (drops 181 low-volume names). `WITH RECURSIVE` skip-scan is unsupported on CH 26.5. The projection is the only **exact + dramatic** lever.

## Measured
- **Prune: 1313× rows / 59× latency** (40M→30k rows, 944ms→16ms on a prod-shaped table; ~4580× at the windowless prod scale).
- **Result-exact:** MD5-identical name set (future-dated samples = 0, so `max(TimeUnix)>=start` ⇔ name seen in window).
- **Storage: +0.01–0.03%** (projection holds exactly 2031 rows/part vs multi-GB data parts) — negligible, drops with the part under `ttl_only_drop_parts`.
- **`ADD PROJECTION`: metadata-only** (0.16s, 0 bytes, 0 existing parts touched, new-parts-only) — idempotent, safe at boot on existing prod tables, covers new + existing.

## Honest caveats
- **Benefit ramps in.** New parts get the projection automatically; existing parts serve correct results via mixed-coverage fallback but only prune after a one-time **`MATERIALIZE PROJECTION`** backfill (maintenance-window runbook: ~2.5 cpu-hr / ~6–23 min / ~65 GiB S3 rewrite at prod gauge scale) **or** 14d TTL rollover. The backfill is *avoidable* if recent-metric-name enumeration suffices.
- **Ingest tax:** inferred low-single-digit % from the fixed-2031-row aggregate shape; a focused insert/merge A/B is still confirming the exact number (only a >~10% result would reopen the catalog-table-MV alternative — unlikely per the shape).
- **Scope: `__name__` only.** The secondary enumeration shapes (generic `label_values(<l>)`, `metrics_direct_agg`) are a follow-up (a projection-leverage audit is in flight).

DDL migration sound (`IF NOT EXISTS`, after CREATE, ON CLUSTER threaded). Zero golden drift. Repro flips (EXPLAIN shows `ReadFromMergeTree (proj_metric_name)`). Builds on #1104.

🤖 Generated with [Claude Code](https://claude.com/claude-code)