### PR TITLE
perf(prom): per-series projection (proj_series) retires the metrics enumeration tier + curated projection registry

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -577,50 +577,110 @@ Auto-create also reuses the **same** table names the query heads read
 (`CERBERUS_SCHEMA_*_TABLE`), so a renamed table is created and queried
 consistently rather than silently diverging onto the upstream defaults.
 
-### Metric-name catalog projection (`label_values(__name__)`)
+### Metadata-enumeration projections (curated registry)
 
-Auto-create installs a small **aggregating projection** named
-`proj_metric_name` on the gauge / sum / histogram fact tables:
+Auto-create installs a small **curated registry** of aggregating projections
+on the gauge / sum / histogram fact tables. The registry lives in
+`internal/schema/ddl` as a `(projectionName, body)` slice; each entry is
+emitted as an idempotent `ADD PROJECTION IF NOT EXISTS` against every catalog
+table at boot. Two projections ship:
 
 ```sql
-ALTER TABLE <db>.<table> ADD PROJECTION IF NOT EXISTS proj_metric_name
-  (SELECT MetricName, max(TimeUnix) GROUP BY MetricName)
+-- proj_series: serves every windowless metadata-enumeration shape
+ALTER TABLE <db>.<table> ADD PROJECTION IF NOT EXISTS proj_series
+  (SELECT MetricName, Attributes, max(TimeUnix) GROUP BY MetricName, Attributes)
+
+-- proj_metric_metadata: serves the windowless /api/v1/metadata listing
+ALTER TABLE <db>.<table> ADD PROJECTION IF NOT EXISTS proj_metric_metadata
+  (SELECT MetricName, any(MetricDescription), any(MetricUnit), max(TimeUnix)
+   GROUP BY MetricName)
 ```
 
-A windowless `/api/v1/label/__name__/values` (the query a Grafana metric
-picker sends on dashboard load — by far the heaviest metadata shape on a
-busy datasource) enumerates the distinct metric names. Without the
-projection that enumeration full-scans the metrics tables — on a real
-deployment ~4 billion rows / ~140 GiB / ~10 s for a single refresh. The
-handler emits the enumeration as
-`SELECT MetricName … GROUP BY MetricName HAVING max(TimeUnix) >= <lookback>`
-(an aggregate-only predicate — a raw `WHERE TimeUnix >= …` column filter
-cannot use the projection), which ClickHouse 26.x routes to
-`proj_metric_name`, reading the one-row-per-name projection (sub-megabyte,
-sub-100 ms) instead of the fact table. The result set is identical: because
-samples are never future-dated, `max(TimeUnix) >= lookback` is true for
-exactly the names with a sample in `[lookback, now]`.
+`proj_series` is the workhorse. The four windowless metadata shapes a Grafana
+datasource sends on dashboard load — by far the heaviest metadata calls on a
+busy backend — all route onto it:
+
+- `label_values(__name__)` — distinct metric names. ClickHouse re-aggregates
+  the finer `(MetricName, Attributes)` projection up to the coarser
+  `GROUP BY MetricName` via **max-of-maxes**, so one projection serves both
+  the per-name enumeration and the per-series shapes below;
+- `label_values(<label>)` — distinct values of a label
+  (`DISTINCT Attributes['k']` over the grouped form);
+- label names (`/api/v1/labels`) —
+  `arrayJoin(mapKeys(Attributes))` over the grouped form;
+- series cardinality (`count()` over the grouped form).
+
+`proj_series` deliberately **supersedes** the narrower per-name projection
+(`proj_metric_name`) that earlier releases shipped: because `__name__` routes
+onto it via re-aggregation with byte-identical results, a dedicated per-name
+projection buys nothing and is no longer installed. The projection omits any
+`Value` aggregate — the histogram catalog table has no top-level `Value`
+column (it lives only inside the `Exemplars` Nested block) and none of the
+routed shapes read a value, so a uniform `(MetricName, Attributes,
+max(TimeUnix))` body stays valid across all three catalog tables. Note the
+**Attributes** map is wide, so `proj_series` is the larger of the two
+projections (measured storage overhead ~0.4 % of the catalog table at
+realistic per-series row counts); `proj_metric_metadata` is tiny.
+
+The handler emits each enumeration as the grouped
+`… GROUP BY MetricName[, Attributes] HAVING max(TimeUnix) >= <lookback>`
+shape (an aggregate-only predicate — a raw `WHERE TimeUnix >= …` column
+filter cannot use a projection), which ClickHouse 26.x routes to the
+matching projection, reading a sub-megabyte pre-aggregated part instead of
+the fact table. Without the projection these enumerations full-scan the
+metrics tables — on a real deployment ~4 billion rows / ~140 GiB / ~10 s for
+a single refresh. The result set is identical: because samples are never
+future-dated, `max(TimeUnix) >= lookback` is true for exactly the
+names / values with a sample in `[lookback, now]`. A routing regression on a
+ClickHouse upgrade is caught by the EXPLAIN + `read_rows` guard in
+`internal/api/prom/metadata_scan_bound_explain_chdb_test.go` (the routed read
+must stay orders below the unprojected baseline), so a silent fall-back to
+full scans fails CI rather than degrading prod.
 
 `ADD PROJECTION IF NOT EXISTS` is metadata-only and idempotent, so the
-auto-create hook (re)applies it safely on every boot, covering both
-freshly-created and pre-existing tables. **New parts written after the ALTER
-carry the projection automatically; existing parts are not back-filled by
-`ADD PROJECTION` alone.** Until existing parts roll over (under the metrics
-TTL) or are back-filled, ClickHouse transparently serves those parts from
-the base table — results stay correct, the prune ratio ramps in as
-projected parts replace un-projected ones. To back-fill immediately on an
-existing deployment, run the one-time materialize (a background mutation,
-non-blocking for reads):
+auto-create hook (re)applies the whole registry safely on every boot,
+covering both freshly-created and pre-existing tables. **New parts written
+after the ALTER carry the projections automatically; existing parts are not
+back-filled by `ADD PROJECTION` alone.** Until existing parts roll over
+(under the metrics TTL) or are back-filled, ClickHouse transparently serves
+those parts from the base table — results stay correct, the prune ratio
+ramps in as projected parts replace un-projected ones.
+
+#### One-time `MATERIALIZE PROJECTION` back-fill runbook
+
+To back-fill existing parts immediately on a deployment that predates the
+projections, run the one-time materialize **per projection, per catalog
+table** (a background mutation, non-blocking for reads):
 
 ```sql
-ALTER TABLE <db>.otel_metrics_gauge      MATERIALIZE PROJECTION proj_metric_name;
-ALTER TABLE <db>.otel_metrics_sum        MATERIALIZE PROJECTION proj_metric_name;
-ALTER TABLE <db>.otel_metrics_histogram  MATERIALIZE PROJECTION proj_metric_name;
+-- proj_series
+ALTER TABLE <db>.otel_metrics_gauge      MATERIALIZE PROJECTION proj_series;
+ALTER TABLE <db>.otel_metrics_sum        MATERIALIZE PROJECTION proj_series;
+ALTER TABLE <db>.otel_metrics_histogram  MATERIALIZE PROJECTION proj_series;
+-- proj_metric_metadata
+ALTER TABLE <db>.otel_metrics_gauge      MATERIALIZE PROJECTION proj_metric_metadata;
+ALTER TABLE <db>.otel_metrics_sum        MATERIALIZE PROJECTION proj_metric_metadata;
+ALTER TABLE <db>.otel_metrics_histogram  MATERIALIZE PROJECTION proj_metric_metadata;
 ```
 
 `MATERIALIZE` is intentionally **not** issued by the auto-create hook — it
 rewrites every existing part and belongs in a deliberate maintenance window,
-not the boot path. Track its progress in `system.mutations`.
+not the boot path. Track progress in `system.mutations` (the
+`is_done` / `parts_to_do` columns).
+
+**Cost / caveat.** Each `MATERIALIZE` reads only the projection's source
+columns (`MetricName`, `Attributes`, `TimeUnix` for `proj_series`) and writes
+a small aggregated part per source part. On a production gauge table
+(~2.9 billion rows / ~108 parts) the `proj_series` source columns are on the
+order of **~9 GiB compressed**; the mutation is I/O-bound on that read.
+Single-stream throughput measured ~1.4 M rows/s, but the background pool
+parallelises across parts, so realistic wall time is **~3–8 minutes**. On a
+ClickHouse cluster backed by object storage (S3 / GCS) the mutation **reads
+and rewrites those parts through the object store**, so budget for the column
+read + the projection-part write against your bucket's throughput and request
+costs — on a wide-`Attributes` table the read side dominates. Materialize one
+projection at a time and watch `system.mutations` before starting the next so
+a maintenance window isn't saturated by both at once.
 
 ### Startup requirements preflight
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -622,6 +622,36 @@ max(TimeUnix))` body stays valid across all three catalog tables. Note the
 projections (measured storage overhead ~0.4 % of the catalog table at
 realistic per-series row counts); `proj_metric_metadata` is tiny.
 
+**Ongoing ingest cost (the honest part).** An aggregating projection is not
+free at write time: ClickHouse re-sorts and writes a projection part for every
+insert, so the projections levy a per-insert CPU + write-amplification tax for
+as long as they exist — distinct from the one-time `MATERIALIZE` back-fill
+below and from the (negligible) storage overhead above. A measured 3-way A/B on
+a representative scrape workload:
+
+| Configuration                          | Insert throughput | p50 insert latency | Storage |
+| -------------------------------------- | ----------------- | ------------------ | ------- |
+| no projection (baseline)               | —                 | —                  | —       |
+| `proj_metric_metadata` only            | ~ −18 %           | ~ +33 %            | tiny    |
+| `proj_series` + `proj_metric_metadata` | ~ −36 %           | ~ +70 %            | +~0.4 % |
+
+The `proj_series` tax is roughly double the metric-name-only case because each
+scrape batch's distinct `(MetricName, Attributes)` series collapse very little
+under the grouping key, so the projection re-sorts and writes nearly as many
+rows as the batch carries. Background **merge** cost is flat — the tax is paid
+at insert, not at merge.
+
+**Why this is acceptable here, with the number that makes it so.** This is a
+real per-insert tax, but it is operationally immaterial at current production
+scale: sustained ingest runs ~**2,824 rows/s**, against a measured
+~**178k rows/s** sustained write ceiling on 4 cores — about **60× headroom**.
+A 36 % throughput haircut consumes a sliver of that margin. Treat it as: real
+tax, negligible given the headroom, revisit only if ingest headroom tightens
+(an instance under genuine write pressure can install `proj_metric_metadata`
+alone — it still covers the `__name__` enumeration at roughly half the tax, at
+the cost of the per-series shapes `proj_series` adds). No caching or buffering
+is involved; this is purely the write-path cost of maintaining the projections.
+
 The handler emits each enumeration as the grouped
 `… GROUP BY MetricName[, Attributes] HAVING max(TimeUnix) >= <lookback>`
 shape (an aggregate-only predicate — a raw `WHERE TimeUnix >= …` column

--- a/internal/api/prom/handler_test.go
+++ b/internal/api/prom/handler_test.go
@@ -33,6 +33,10 @@ type stubQuerier struct {
 	// endpoints issue several (per table group / per metadata arm), so a
 	// scan-bound assertion that must hold for EVERY arm reads allSQL.
 	allSQL []string
+	// allArgs records the positional args bound by each allSQL statement, in
+	// lock-step order — so a test that needs to EXPLAIN a captured arm can
+	// inline the `?` placeholders the projection-routing emit binds.
+	allArgs [][]any
 
 	// metaCalls records every QueryMetricMeta invocation in order so
 	// metadata tests can assert the per-table fan-out (which SQL was
@@ -54,6 +58,7 @@ type metaCall struct {
 func (s *stubQuerier) Query(_ context.Context, sql string, args ...any) ([]chclient.Sample, error) {
 	s.lastSQL = sql
 	s.allSQL = append(s.allSQL, sql)
+	s.allArgs = append(s.allArgs, args)
 	s.lastArgs = args
 	if s.err != nil {
 		return nil, s.err
@@ -64,6 +69,7 @@ func (s *stubQuerier) Query(_ context.Context, sql string, args ...any) ([]chcli
 func (s *stubQuerier) QueryCursor(_ context.Context, sql string, args ...any) (chclient.Cursor, error) {
 	s.lastSQL = sql
 	s.allSQL = append(s.allSQL, sql)
+	s.allArgs = append(s.allArgs, args)
 	s.lastArgs = args
 	if s.err != nil {
 		return nil, s.err
@@ -74,6 +80,7 @@ func (s *stubQuerier) QueryCursor(_ context.Context, sql string, args ...any) (c
 func (s *stubQuerier) QueryStrings(_ context.Context, sql string, args ...any) ([]string, error) {
 	s.lastSQL = sql
 	s.allSQL = append(s.allSQL, sql)
+	s.allArgs = append(s.allArgs, args)
 	s.lastArgs = args
 	if s.err != nil {
 		return nil, s.err
@@ -84,6 +91,7 @@ func (s *stubQuerier) QueryStrings(_ context.Context, sql string, args ...any) (
 func (s *stubQuerier) QueryLabelSets(_ context.Context, sql string, args ...any) ([]map[string]string, error) {
 	s.lastSQL = sql
 	s.allSQL = append(s.allSQL, sql)
+	s.allArgs = append(s.allArgs, args)
 	s.lastArgs = args
 	if s.err != nil {
 		return nil, s.err
@@ -94,6 +102,7 @@ func (s *stubQuerier) QueryLabelSets(_ context.Context, sql string, args ...any)
 func (s *stubQuerier) QueryMetricMeta(_ context.Context, sql, metricType string, args ...any) ([]chclient.MetricMetaRow, error) {
 	s.lastSQL = sql
 	s.allSQL = append(s.allSQL, sql)
+	s.allArgs = append(s.allArgs, args)
 	s.lastArgs = args
 	call := metaCall{sql: sql, kind: metricType, args: args}
 	s.metaCalls = append(s.metaCalls, call)

--- a/internal/api/prom/metadata.go
+++ b/internal/api/prom/metadata.go
@@ -522,14 +522,23 @@ func (h *Handler) fetchMetricMeta(ctx context.Context, metricName string, start,
 //
 //   - nowAnchored (the /api/v1/metadata listing, which takes no time params, so
 //     its window always ends "now"): the bound is an aggregate-only
-//     `HAVING max(TimeUnix) >= <start>`. Because samples are never future-dated
-//     and MetricDescription/MetricUnit are metric-level (constant across a
-//     metric's rows), this returns the byte-identical name/description/unit set
-//     the WHERE-bounded form did, but the pure `GROUP BY MetricName` + aggregate
-//     HAVING routes to the proj_metric_metadata aggregating projection — turning
-//     the whole-table group into a tiny projection read. A raw WHERE
-//     (metric-name filter or IsMonotonic predicate) keeps that arm off the
-//     projection, so only the unfiltered list-all shape — the hot Grafana
+//     `HAVING max(TimeUnix) >= <start>`. Because samples are never future-dated,
+//     the metric-NAME set this returns is exactly the WHERE-bounded form's — a
+//     name passes iff it has a sample in [start, now]. The description/unit pick
+//     is the honest caveat: unlike the WHERE-bounded form, this `GROUP BY
+//     MetricName` carries no time filter (the HAVING gates which names pass, not
+//     which rows the aggregate sees), so any(MetricDescription) / any(MetricUnit)
+//     draw from the metric's ALL-TIME rows rather than just the window's. For a
+//     metric whose description/unit is constant (the overwhelmingly common case)
+//     the pick is identical either way; for one whose metadata varied over time
+//     the arbitrary pick can differ from the windowed form's. This is not new
+//     nondeterminism — any() was already an arbitrary pick on main — only its
+//     row pool widened from the window to all-time (arguably more correct for
+//     metric-level metadata). The payoff: the pure `GROUP BY MetricName` +
+//     aggregate HAVING routes to the proj_metric_metadata aggregating
+//     projection — turning the whole-table group into a tiny projection read. A
+//     raw WHERE (metric-name filter or IsMonotonic predicate) keeps that arm off
+//     the projection, so only the unfiltered list-all shape — the hot Grafana
 //     call — routes; the filtered arms fall back to the bounded scan, which is
 //     already cheap.
 //   - !nowAnchored (a user-supplied finite [start,end]): the closed

--- a/internal/api/prom/metadata.go
+++ b/internal/api/prom/metadata.go
@@ -292,11 +292,16 @@ func (h *Handler) handleLabels(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, ErrBadData, err)
 		return
 	}
+	// nowAnchored mirrors handleLabelValues: with no explicit upper bound the
+	// effective window ends "now", so the label-name fan-out routes onto the
+	// proj_series projection via the aggregate-only HAVING bound. A
+	// user-supplied finite [start,end] keeps the exact WHERE-bounded scan.
+	nowAnchored := endT.IsZero()
 	startT, endT = boundMetadataWindow(startT, endT)
 
 	var names []string
 	if len(matchers) == 0 {
-		names, err = h.fetchLabelNames(r.Context(), startT, endT)
+		names, err = h.fetchLabelNames(r.Context(), startT, endT, nowAnchored)
 	} else {
 		names, err = h.fetchLabelNamesMatched(r.Context(), matchers, startT, endT)
 	}
@@ -419,7 +424,10 @@ func (h *Handler) handleMetadata(w http.ResponseWriter, r *http.Request) {
 	// retention-horizon window the discovery handlers use so the per-table
 	// metadata fan-out partition-prunes too.
 	startT, endT := boundMetadataWindow(time.Time{}, time.Time{})
-	rows, err := h.fetchMetricMeta(r.Context(), metricName, startT, endT)
+	// /api/v1/metadata supplies no explicit end, so its window always ends
+	// "now" — the now-anchored case that routes onto proj_metric_metadata via
+	// the aggregate-only HAVING bound (see metricMetaSQL).
+	rows, err := h.fetchMetricMeta(r.Context(), metricName, startT, endT, true)
 	if err != nil {
 		h.respondError(w, err)
 		return
@@ -466,7 +474,7 @@ type metricMetaSpec struct {
 	monotonic *bool
 }
 
-func (h *Handler) fetchMetricMeta(ctx context.Context, metricName string, start, end time.Time) ([]chclient.MetricMetaRow, error) {
+func (h *Handler) fetchMetricMeta(ctx context.Context, metricName string, start, end time.Time, nowAnchored bool) ([]chclient.MetricMetaRow, error) {
 	monotonic, nonMonotonic := true, false
 	specs := []metricMetaSpec{
 		{table: h.Schema.GaugeTable, kind: "gauge"},
@@ -493,7 +501,7 @@ func (h *Handler) fetchMetricMeta(ctx context.Context, metricName string, start,
 
 	var out []chclient.MetricMetaRow
 	for _, spec := range specs {
-		sql, args := h.metricMetaSQL(spec.table, metricName, spec.monotonic, start, end)
+		sql, args := h.metricMetaSQL(spec.table, metricName, spec.monotonic, start, end, nowAnchored)
 		rows, err := h.Client.QueryMetricMeta(ctx, sql, spec.kind, args...)
 		if err != nil {
 			return nil, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusBadGateway}
@@ -508,14 +516,30 @@ func (h *Handler) fetchMetricMeta(ctx context.Context, metricName string, start,
 // we list all distinct metrics; otherwise we filter to the named one.
 // A non-nil monotonic adds a `IsMonotonic` / `NOT IsMonotonic` predicate
 // (combined via AND with the metric-name filter when both are present).
-// A non-zero start/end pushes the closed metadata window onto the GROUP BY
-// arm so the per-table fan-out partition-prunes by toDate(TimeUnix) instead
-// of grouping the whole table; the window literals are inlined
-// (dateTime64Frag), so the metric-name filter keeps its positional slot.
-func (h *Handler) metricMetaSQL(table, metricName string, monotonic *bool, start, end time.Time) (string, []any) {
+//
+// The window is applied in one of two shapes, picked by nowAnchored (mirroring
+// metricNamesSQL):
+//
+//   - nowAnchored (the /api/v1/metadata listing, which takes no time params, so
+//     its window always ends "now"): the bound is an aggregate-only
+//     `HAVING max(TimeUnix) >= <start>`. Because samples are never future-dated
+//     and MetricDescription/MetricUnit are metric-level (constant across a
+//     metric's rows), this returns the byte-identical name/description/unit set
+//     the WHERE-bounded form did, but the pure `GROUP BY MetricName` + aggregate
+//     HAVING routes to the proj_metric_metadata aggregating projection — turning
+//     the whole-table group into a tiny projection read. A raw WHERE
+//     (metric-name filter or IsMonotonic predicate) keeps that arm off the
+//     projection, so only the unfiltered list-all shape — the hot Grafana
+//     call — routes; the filtered arms fall back to the bounded scan, which is
+//     already cheap.
+//   - !nowAnchored (a user-supplied finite [start,end]): the closed
+//     WHERE-bounded window is kept (a historical window cannot be answered
+//     exactly from per-name max alone), and partition pruning bounds the scan.
+func (h *Handler) metricMetaSQL(table, metricName string, monotonic *bool, start, end time.Time, nowAnchored bool) (string, []any) {
 	nameCol := h.Schema.MetricNameColumn
 	descCol := h.Schema.MetricDescriptionColumn
 	unitCol := h.Schema.MetricUnitColumn
+	tsCol := h.Schema.TimestampColumn
 
 	anyCall := func(col string) chsql.Frag {
 		return chsql.Call("any", chsql.Col(col))
@@ -526,7 +550,11 @@ func (h *Handler) metricMetaSQL(table, metricName string, monotonic *bool, start
 		From(chsql.Col(table)).
 		GroupBy(chsql.Col(nameCol))
 
-	if pred := h.metadataWindowPred(start, end); pred != nil {
+	if nowAnchored {
+		if !start.IsZero() {
+			sb.Having(chsql.Gte(chsql.Call("max", chsql.Col(tsCol)), dateTime64Frag(start)))
+		}
+	} else if pred := h.metadataWindowPred(start, end); pred != nil {
 		sb.Where(pred)
 	}
 
@@ -655,8 +683,8 @@ func (h *Handler) handleSeries(w http.ResponseWriter, r *http.Request) {
 // stores dotted keys (`service.name`, `http.request.method`) that PromQL
 // grammar forbids in identifier position; without the rewrite, panels
 // doing `sum by (service_name)` silently produce empty matrices.
-func (h *Handler) fetchLabelNames(ctx context.Context, start, end time.Time) ([]string, error) {
-	sql := h.unionLabelNamesSQL(start, end)
+func (h *Handler) fetchLabelNames(ctx context.Context, start, end time.Time, nowAnchored bool) ([]string, error) {
+	sql := h.unionLabelNamesSQL(start, end, nowAnchored)
 	names, err := timeCH(ctx, func() ([]string, error) {
 		return h.Client.QueryStrings(ctx, sql)
 	})
@@ -713,7 +741,7 @@ func (h *Handler) fetchLabelValues(ctx context.Context, name string, start, end 
 	if name == model.MetricNameLabel {
 		return h.fetchMetricNameValues(ctx, start, end, nowAnchored)
 	}
-	sql, args := h.unionLabelValuesSQL(name, start, end)
+	sql, args := h.unionLabelValuesSQL(name, start, end, nowAnchored)
 	values, err := timeCH(ctx, func() ([]string, error) {
 		return h.Client.QueryStrings(ctx, sql, args...)
 	})
@@ -1310,17 +1338,30 @@ func (h *Handler) resourceLabelValueArmActive(promLabel string) bool {
 	return false
 }
 
-// unionLabelNamesSQL builds a UNION of all metric tables' label keys.
-func (h *Handler) unionLabelNamesSQL(start, end time.Time) string {
+// unionLabelNamesSQL builds a UNION of all metric tables' label keys. In the
+// now-anchored case each arm emits the grouped form
+// `arrayJoin(mapKeys(Attributes)) ... GROUP BY MetricName, Attributes HAVING
+// max(TimeUnix) >= start`, so the key fan-out routes onto the proj_series
+// aggregating projection (Attributes is a grouping key, the time bound an
+// aggregate predicate). A user-supplied finite window keeps the exact
+// WHERE-bounded scan.
+func (h *Handler) unionLabelNamesSQL(start, end time.Time, nowAnchored bool) string {
 	tables := h.metricTables()
 	attrsCol := h.Schema.AttributesColumn
+	metricCol := h.Schema.MetricNameColumn
+	tsCol := h.Schema.TimestampColumn
 	pred := h.metadataWindowPred(start, end)
 	parts := make([]chsql.Frag, 0, len(tables))
 	for _, t := range tables {
 		arm := chsql.NewQuery().
 			Select(chsql.As(arrayJoinMapKeysFrag(attrsCol), "name")).
 			From(chsql.Col(t))
-		if pred != nil {
+		if nowAnchored {
+			arm = arm.GroupBy(chsql.Col(metricCol), chsql.Col(attrsCol))
+			if !start.IsZero() {
+				arm = arm.Having(chsql.Gte(chsql.Call("max", chsql.Col(tsCol)), dateTime64Frag(start)))
+			}
+		} else if pred != nil {
 			arm = arm.Where(pred)
 		}
 		parts = append(parts, arm.Frag())
@@ -1413,10 +1454,13 @@ func (h *Handler) metadataWindowPred(start, end time.Time) chsql.Frag {
 //     future-dated, max(TimeUnix) >= start ⇔ the name has a sample in
 //     [start, now] — byte-for-byte the same name set as the WHERE-bounded
 //     DISTINCT, but the aggregate-only predicate is served from the
-//     `proj_metric_name` aggregating projection (GROUP BY MetricName,
-//     max(TimeUnix)) instead of full-scanning the fact table. On prod this
-//     turns the ~4.2B-row / ~139 GiB windowless enumeration into a
-//     sub-megabyte projection read.
+//     `proj_series` aggregating projection (GROUP BY MetricName, Attributes
+//     carrying max(TimeUnix)) instead of full-scanning the fact table.
+//     ClickHouse re-aggregates the finer (MetricName, Attributes) projection
+//     to the coarser GROUP BY MetricName via max-of-maxes, so one projection
+//     serves both this enumeration and the generic label_values / label-name
+//     shapes. On prod this turns the ~4.2B-row / ~139 GiB windowless
+//     enumeration into a sub-megabyte projection read.
 //
 //   - !nowAnchored (a user-supplied finite [start,end]): the exact
 //     WHERE-bounded DISTINCT is kept — a closed historical window cannot be
@@ -1475,9 +1519,11 @@ func (h *Handler) metricNamesSQL(tables []string, start, end time.Time, nowAncho
 // Mirrors the matcher-side `attributeLookup` chain in
 // `internal/promql/lower.go`: both query and listing surfaces now
 // resolve the same Prom-grammar → OTel-key candidates the same way.
-func (h *Handler) unionLabelValuesSQL(name string, start, end time.Time) (string, []any) {
+func (h *Handler) unionLabelValuesSQL(name string, start, end time.Time, nowAnchored bool) (string, []any) {
 	tables := h.metricTables()
 	attrsCol := h.Schema.AttributesColumn
+	metricCol := h.Schema.MetricNameColumn
+	tsCol := h.Schema.TimestampColumn
 	candidates := labelValueCandidates(name)
 	resCol := h.Schema.ResourceAttributesColumn
 	resourceArm := h.resourceLabelValueArmActive(name)
@@ -1492,20 +1538,45 @@ func (h *Handler) unionLabelValuesSQL(name string, start, end time.Time) (string
 		}
 		return chsql.And(notEmpty, pred)
 	}
-	parts := make([]chsql.Frag, 0, len(tables)*len(candidates)*2)
-	for _, t := range tables {
-		for _, k := range candidates {
+	// attrsArm builds the Attributes-map arm. In the now-anchored case it
+	// emits the grouped form `GROUP BY MetricName, Attributes HAVING
+	// max(TimeUnix) >= start` so the leading-key DISTINCT routes onto the
+	// proj_series aggregating projection (Attributes is a grouping key, the
+	// time bound an aggregate predicate — both materialized on the
+	// projection). The not-empty sentinel filter is also a per-group
+	// predicate (Attributes[k] is constant within a (MetricName, Attributes)
+	// group), so it rides in HAVING and the projection still serves the read.
+	// A user-supplied finite window keeps the exact WHERE-bounded DISTINCT.
+	attrsArm := func(t, k string) chsql.Frag {
+		if nowAnchored {
 			arm := chsql.NewQuery().
 				Select(chsql.As(distinctMapAtFrag(attrsCol, k), "value")).
 				From(chsql.Col(t)).
-				Where(withWindow(mapAtNotEmptyFrag(attrsCol, k)))
-			parts = append(parts, arm.Frag())
+				GroupBy(chsql.Col(metricCol), chsql.Col(attrsCol)).
+				Having(mapAtNotEmptyFrag(attrsCol, k))
+			if !start.IsZero() {
+				arm.Having(chsql.Gte(chsql.Call("max", chsql.Col(tsCol)), dateTime64Frag(start)))
+			}
+			return arm.Frag()
+		}
+		return chsql.NewQuery().
+			Select(chsql.As(distinctMapAtFrag(attrsCol, k), "value")).
+			From(chsql.Col(t)).
+			Where(withWindow(mapAtNotEmptyFrag(attrsCol, k))).
+			Frag()
+	}
+	parts := make([]chsql.Frag, 0, len(tables)*len(candidates)*2)
+	for _, t := range tables {
+		for _, k := range candidates {
+			parts = append(parts, attrsArm(t, k))
 			// Resource arm: read the same candidate key out of the
 			// ResourceAttributes map so a value stored only under a
 			// resource attribute (k8s.namespace.name, …) surfaces on
-			// /label/<name>/values. Gated on the allowlist so a
-			// non-allowlisted label stays Attributes-only — byte-identical
-			// to the legacy emit.
+			// /label/<name>/values. ResourceAttributes is absent from
+			// proj_series, so this arm cannot route onto the projection; it
+			// keeps the WHERE-bounded DISTINCT (partition-pruned by the
+			// now-anchored window). The arm is allowlist-gated and rare, so
+			// staying off the projection is by design, not a regression.
 			if resourceArm {
 				resArm := chsql.NewQuery().
 					Select(chsql.As(distinctMapAtFrag(resCol, k), "value")).

--- a/internal/api/prom/metadata_distinct_projection_chdb_test.go
+++ b/internal/api/prom/metadata_distinct_projection_chdb_test.go
@@ -4,24 +4,23 @@ package prom_test
 
 // PARITY (Layer 6a — chDB roundtrip; result identity under the projection).
 //
-// The windowless metric-name enumeration changed shape from
-// `SELECT DISTINCT MetricName WHERE TimeUnix >= <lookback>` to
-// `SELECT MetricName GROUP BY MetricName HAVING max(TimeUnix) >= <lookback>`
-// so it can route to the proj_metric_name aggregating projection
-// (metadata_scan_bound_explain_chdb_test.go pins the routing). This test
-// pins that the routed emit returns the IDENTICAL name set the bounded
-// DISTINCT did — including the retention-horizon boundary:
+// The windowless metadata enumerations changed shape from
+// `SELECT DISTINCT … WHERE TimeUnix >= <lookback>` to the grouped
+// `… GROUP BY MetricName[, Attributes] HAVING max(TimeUnix) >= <lookback>`
+// so they route onto the proj_series aggregating projection
+// (metadata_scan_bound_explain_chdb_test.go pins the routing). These tests pin
+// that the routed emit returns the IDENTICAL result set the bounded DISTINCT
+// did — including the retention-horizon boundary:
 //
-//   - names with a sample inside the default lookback (recent / days-old)
+//   - values with a sample inside the default lookback (recent / days-old)
 //     are returned;
-//   - a name whose newest sample is older than the lookback is excluded,
+//   - a value whose newest sample is older than the lookback is excluded,
 //     exactly as the `WHERE TimeUnix >= <lookback>` DISTINCT excluded it.
 //
 // Because samples are never future-dated, max(TimeUnix) >= lookback ⇔ a
 // sample exists in [lookback, now], so the two shapes are byte-for-byte the
-// same answer. The table carries the projection (materialized) so the result
-// is also proven correct when served from the projection, not just the base
-// table.
+// same answer. The tables carry the projection (materialized) so the result is
+// also proven correct when served from the projection, not just the base table.
 
 import (
 	"fmt"
@@ -29,11 +28,21 @@ import (
 	"time"
 )
 
+// addSeriesProjection installs + materializes proj_series on a metric table,
+// mirroring the curated registry in internal/schema/ddl.
+func addSeriesProjection(table string) string {
+	return fmt.Sprintf(
+		"ALTER TABLE %s ADD PROJECTION proj_series "+
+			"(SELECT MetricName, Attributes, max(TimeUnix) GROUP BY MetricName, Attributes);\n"+
+			"ALTER TABLE %s MATERIALIZE PROJECTION proj_series;\n",
+		table, table,
+	)
+}
+
 // projectionParitySeed seeds gauge+sum with names spanning the default
-// retention lookback boundary, then installs + materializes the metric-name
-// projection (mirroring the cerberus DDL apply path). The returned sets are
-// the oracle: names inside the lookback must list, the over-horizon name
-// must not.
+// retention lookback boundary, then installs + materializes proj_series
+// (mirroring the cerberus DDL apply path). The returned sets are the oracle:
+// names inside the lookback must list, the over-horizon name must not.
 func projectionParitySeed() (seed string, want, excluded map[string]struct{}) {
 	now := time.Now().UTC()
 	lit := func(d time.Duration) string {
@@ -50,24 +59,22 @@ INSERT INTO otel_metrics_gauge (MetricName, Attributes, TimeUnix, Value) VALUES
     ('g_overhorizon', map('job', 'old'),   toDateTime64('%s', 9), 1.0);
 INSERT INTO otel_metrics_sum (MetricName, Attributes, TimeUnix, Value, IsMonotonic) VALUES
     ('s_recent_total', map('job', 'fresh'), toDateTime64('%s', 9), 1.0, true);
-ALTER TABLE otel_metrics_gauge ADD PROJECTION proj_metric_name (SELECT MetricName, max(TimeUnix) GROUP BY MetricName);
-ALTER TABLE otel_metrics_sum ADD PROJECTION proj_metric_name (SELECT MetricName, max(TimeUnix) GROUP BY MetricName);
-ALTER TABLE otel_metrics_gauge MATERIALIZE PROJECTION proj_metric_name;
-ALTER TABLE otel_metrics_sum MATERIALIZE PROJECTION proj_metric_name;`,
+`,
 		lit(time.Minute),             // g_recent: 1 minute ago
 		lit(13*24*time.Hour),         // g_within: 13 days ago (inside 14d lookback)
 		lit(lookback+2*24*time.Hour), // g_overhorizon: 16 days ago (outside)
 		lit(time.Minute),             // s_recent_total: 1 minute ago
-	)
+	) + addSeriesProjection("otel_metrics_gauge") + addSeriesProjection("otel_metrics_sum")
 	want = map[string]struct{}{"g_recent": {}, "g_within": {}, "s_recent_total": {}}
 	excluded = map[string]struct{}{"g_overhorizon": {}}
 	return seed, want, excluded
 }
 
 // TestMetadataDistinctProjection_WindowlessParity pins that the windowless
-// /api/v1/label/__name__/values served from the aggregating projection
-// returns exactly the bounded DISTINCT's name set: every name inside the
-// default lookback, and none whose newest sample is over the horizon.
+// /api/v1/label/__name__/values served from proj_series (re-aggregated to
+// GROUP BY MetricName) returns exactly the bounded DISTINCT's name set: every
+// name inside the default lookback, and none whose newest sample is over the
+// horizon.
 func TestMetadataDistinctProjection_WindowlessParity(t *testing.T) {
 	seed, want, excluded := projectionParitySeed()
 	srv, _ := newChDBServer(t, seed)
@@ -86,6 +93,57 @@ func TestMetadataDistinctProjection_WindowlessParity(t *testing.T) {
 		if _, ok := gotSet[name]; ok {
 			t.Errorf("windowless /label/__name__/values returned over-horizon name %q (got %v) — "+
 				"the projection emit must match the bounded DISTINCT, which excludes it", name, got)
+		}
+	}
+}
+
+// labelValuesParitySeed seeds gauge with a `team` attribute whose values span
+// the lookback boundary: one value carried only by an in-lookback series, one
+// carried only by an over-horizon series. proj_series is installed so the
+// generic label_values emit is served from the projection.
+func labelValuesParitySeed() (seed string, want, excluded map[string]struct{}) {
+	now := time.Now().UTC()
+	lit := func(d time.Duration) string {
+		return now.Add(-d).Format("2006-01-02 15:04:05.000000000")
+	}
+	const lookback = 14 * 24 * time.Hour
+	seed = metaShapedGaugeDDL + metaShapedSumDDL + metaShapedHistogramDDL + fmt.Sprintf(
+		`
+INSERT INTO otel_metrics_gauge (MetricName, Attributes, TimeUnix, Value) VALUES
+    ('g_a', map('team', 'fresh'),   toDateTime64('%s', 9), 1.0),
+    ('g_a', map('team', 'recent'),  toDateTime64('%s', 9), 1.0),
+    ('g_a', map('team', 'stale'),   toDateTime64('%s', 9), 1.0);
+`,
+		lit(time.Minute),             // team=fresh: 1 minute ago
+		lit(13*24*time.Hour),         // team=recent: 13 days ago (inside lookback)
+		lit(lookback+2*24*time.Hour), // team=stale: 16 days ago (over horizon)
+	) + addSeriesProjection("otel_metrics_gauge")
+	want = map[string]struct{}{"fresh": {}, "recent": {}}
+	excluded = map[string]struct{}{"stale": {}}
+	return seed, want, excluded
+}
+
+// TestMetadataLabelValuesProjection_WindowlessParity pins that the windowless
+// /api/v1/label/team/values served from proj_series returns exactly the
+// bounded DISTINCT's value set: in-lookback attribute values, none over horizon.
+func TestMetadataLabelValuesProjection_WindowlessParity(t *testing.T) {
+	seed, want, excluded := labelValuesParitySeed()
+	srv, _ := newChDBServer(t, seed)
+
+	got := stringData(t, getMetaData(t, srv.URL+"/api/v1/label/team/values"))
+	gotSet := make(map[string]struct{}, len(got))
+	for _, v := range got {
+		gotSet[v] = struct{}{}
+	}
+	for v := range want {
+		if _, ok := gotSet[v]; !ok {
+			t.Errorf("windowless /label/team/values dropped in-lookback value %q (got %v)", v, got)
+		}
+	}
+	for v := range excluded {
+		if _, ok := gotSet[v]; ok {
+			t.Errorf("windowless /label/team/values returned over-horizon value %q (got %v) — "+
+				"the proj_series emit must match the bounded DISTINCT, which excludes it", v, got)
 		}
 	}
 }

--- a/internal/api/prom/metadata_scan_bound_explain_chdb_test.go
+++ b/internal/api/prom/metadata_scan_bound_explain_chdb_test.go
@@ -2,46 +2,49 @@
 
 package prom_test
 
-// REPRO (Layer 12 — compute fan-out / scan-volume, chDB EXPLAIN indexes=1).
+// REPRO (Layer 12 — compute fan-out / scan-volume, chDB EXPLAIN).
 //
-// The empirical proof that the windowless `__name__` enumeration reads the
-// `proj_metric_name` aggregating projection instead of full-scanning the
-// metrics fact table. This drives the SQL the HANDLER ACTUALLY emits for a
-// no-start/end `/api/v1/label/__name__/values` request (captured through a
-// recording stub), then runs it against a production-shaped gauge+sum table —
-// PARTITION BY toDate(TimeUnix), the OTel-CH exporter's own layout — that
-// carries the aggregating projection the cerberus DDL apply path installs
-// (internal/schema/ddl), and inspects the read source via EXPLAIN indexes=1.
+// The empirical guard that every windowless metadata-enumeration shape the
+// catalog answers reads a curated aggregating projection instead of
+// full-scanning the metrics fact table. It drives the SQL the HANDLER ACTUALLY
+// emits (captured through a recording stub) for:
 //
-//   - A bare `DISTINCT ... WHERE TimeUnix >= …` emit (the pre-projection
-//     shape) keeps a raw column filter that no aggregating projection can
-//     serve, so the read streams every granule of the fact table.
-//   - The handler's windowless emit is `GROUP BY MetricName HAVING
-//     max(TimeUnix) >= <lookback>` — an aggregate-only predicate that routes
-//     to proj_metric_name, so EXPLAIN reads the projection with a strict
-//     granule subset. The assertion (the read must route to the projection
-//     and prune) is the flip this test pins.
+//   - /api/v1/label/__name__/values  → routes onto proj_series (max-of-maxes
+//     re-aggregation of the finer (MetricName, Attributes) projection to the
+//     coarser GROUP BY MetricName);
+//   - /api/v1/label/<label>/values   → routes onto proj_series;
+//   - /api/v1/labels (label names)   → routes onto proj_series;
+//   - /api/v1/metadata               → routes onto proj_metric_metadata.
 //
-// This complements the hand-written
-// test/perf/metric_names_window_prune_chdb_test.go: that file recorded that
-// no exact column-DISTINCT shape can be marks-bounded; the projection is the
-// exact, marks-bounded shape, and this file asserts the property on the SQL
-// cerberus's handler actually emits, so it tracks the handler rather than a
-// hand-copied string.
+// Each captured emit runs against a production-shaped table — PARTITION BY
+// toDate(TimeUnix), the OTel-CH exporter's own layout — carrying the curated
+// projections the cerberus DDL apply path installs (internal/schema/ddl). Two
+// independent properties are asserted per shape:
 //
-// Honest scope note: the projection answers "names with a sample in
-// [lookback, now]" exactly because samples are never future-dated
-// (max(TimeUnix) >= lookback ⇔ a sample in the window), so the windowless
-// catalog stays COMPLETE over the retention horizon — the result-identity
-// guard for that lives in metadata_scan_bound_guard_chdb_test.go and
-// W5_omitted in handler_chdb_metadata_window_sweep_test.go; both halves hold.
+//   - EXPLAIN indexes=1: the read routes to the NAMED projection and prunes
+//     granules (selected < total) — a bare `DISTINCT ... WHERE` emit keeps a
+//     raw column filter no aggregating projection can serve, so it would stream
+//     every granule;
+//   - EXPLAIN ESTIMATE: the routed read_rows is far below the unprojected full
+//     scan (optimize_use_projections=0 baseline) AND under an absolute ceiling.
+//
+// The read_rows half makes the guard non-vacuous against silent un-routing on a
+// ClickHouse upgrade: if a future CH stopped serving the shape from the
+// projection, the read would fall back to the full scan and read_rows would
+// jump to the baseline — failing this test instead of silently regressing prod
+// to a 4.2B-row / 139 GiB scan.
 
 import (
 	"database/sql"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/tsouza/cerberus/internal/api/prom"
+	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/schema"
 
 	_ "github.com/chdb-io/chdb-go/chdb/driver"
 )
@@ -54,15 +57,30 @@ const (
 	// scanBoundRows seeds a dense corpus so OPTIMIZE FINAL yields one part
 	// per day-partition (real parts for the projection to collapse).
 	scanBoundRows = 200_000
+	// maxRoutedReadRows is the absolute ceiling on the routed read's
+	// EXPLAIN-ESTIMATE row count. The curated projections pre-aggregate the
+	// corpus to at most a few hundred (MetricName, Attributes) rows, so a
+	// routed read stays orders below this; a read at or above it means the
+	// query fell back to scanning the scanBoundRows-row fact table.
+	maxRoutedReadRows = 50_000
+	// minReadRowsPruneFactor is the floor on baseline/routed read_rows
+	// (projection off vs on). A routed read that the projection genuinely
+	// serves prunes by ~1000x here; this floor is set well below that so the
+	// guard is robust, but a factor of 1 (un-routed: routed == baseline)
+	// fails it.
+	minReadRowsPruneFactor = 4
 )
 
-// scanBoundPartitionedDDL is the production OTel-CH metric table trimmed to
-// the columns the metric-name discovery scan reads, with the exporter's
-// PARTITION BY toDate(TimeUnix) so the MinMax stage has day-partitions to
-// prune.
+// scanBoundPartitionedDDL is the production OTel-CH metric table trimmed to the
+// columns the metadata-enumeration scans read, with the exporter's PARTITION BY
+// toDate(TimeUnix) so the MinMax stage has day-partitions to prune. It carries
+// the proj_series source columns (MetricName, Attributes, TimeUnix) plus the
+// proj_metric_metadata source columns (MetricDescription, MetricUnit).
 func scanBoundPartitionedDDL(table string) string {
 	return fmt.Sprintf(`CREATE OR REPLACE TABLE %s (
     MetricName String,
+    MetricDescription String,
+    MetricUnit String,
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64
@@ -71,35 +89,43 @@ PARTITION BY toDate(TimeUnix)
 ORDER BY (MetricName, TimeUnix);`, table)
 }
 
-// scanBoundInsert scatters rows across scanBoundDays day-partitions. The
-// rows are now-relative (newest sample seconds ago, oldest scanBoundDays ago)
-// so they land inside the windowless emit's default retention lookback and
-// the HAVING max(TimeUnix) >= start predicate selects them.
+// scanBoundInsert scatters rows across scanBoundDays day-partitions with a
+// realistic series fan-out (a job + an instance key in Attributes). The rows
+// are now-relative (newest sample seconds ago, oldest scanBoundDays ago) so
+// they land inside the windowless emit's default retention lookback and the
+// HAVING max(TimeUnix) >= start predicate selects them.
 func scanBoundInsert(table string) string {
 	return fmt.Sprintf(`INSERT INTO %s
 SELECT
     concat('m_', toString(number %% 50)) AS MetricName,
-    map('job', 'j') AS Attributes,
+    concat('desc ', toString(number %% 50)) AS MetricDescription,
+    'unit' AS MetricUnit,
+    map('job', 'j', 'instance', toString(number %% 200)) AS Attributes,
     now64(9) - INTERVAL (number %% %d) DAY AS TimeUnix,
     toFloat64(number) AS Value
 FROM numbers(%d);`, table, scanBoundDays, scanBoundRows)
 }
 
-// scanBoundAddProjection mirrors the cerberus DDL apply path
-// (internal/schema/ddl): the aggregating projection over MetricName carrying
-// max(TimeUnix) that the windowless metric-name emit routes to.
-func scanBoundAddProjection(table string) string {
-	return fmt.Sprintf(
-		`ALTER TABLE %s ADD PROJECTION proj_metric_name `+
-			`(SELECT MetricName, max(TimeUnix) GROUP BY MetricName);`, table,
-	)
+// scanBoundProjections mirrors the curated registry in internal/schema/ddl:
+// proj_series (the (MetricName, Attributes) aggregating projection every
+// enumeration shape routes onto) + proj_metric_metadata (the per-name
+// description/unit projection /api/v1/metadata routes onto).
+func scanBoundProjections(table string) []string {
+	return []string{
+		"ALTER TABLE " + table + " ADD PROJECTION proj_series " +
+			"(SELECT MetricName, Attributes, max(TimeUnix) GROUP BY MetricName, Attributes)",
+		"ALTER TABLE " + table + " MATERIALIZE PROJECTION proj_series",
+		"ALTER TABLE " + table + " ADD PROJECTION proj_metric_metadata " +
+			"(SELECT MetricName, any(MetricDescription), any(MetricUnit), max(TimeUnix) GROUP BY MetricName)",
+		"ALTER TABLE " + table + " MATERIALIZE PROJECTION proj_metric_metadata",
+	}
 }
 
-// projectionGranules returns (selected, total) granules from the
-// EXPLAIN indexes=1 read of the `proj_metric_name` aggregating projection —
-// proof the windowless emit routes to the projection rather than scanning the
-// fact table. It returns ok=false if no projection read appears in the plan.
-func projectionGranules(t *testing.T, db *sql.DB, query string) (selected, total int, ok bool) {
+// projectionGranules returns (selected, total) granules from the EXPLAIN
+// indexes=1 read of the named aggregating projection — proof the emit routes to
+// that projection rather than scanning the fact table. It returns ok=false if
+// no read of that projection appears in the plan.
+func projectionGranules(t *testing.T, db *sql.DB, query, projName string) (selected, total int, ok bool) {
 	t.Helper()
 	rows, err := db.Query("EXPLAIN indexes=1 " + query)
 	if err != nil {
@@ -115,7 +141,7 @@ func projectionGranules(t *testing.T, db *sql.DB, query string) (selected, total
 		trim := strings.TrimSpace(line)
 		switch {
 		case strings.HasPrefix(trim, "ReadFromMergeTree"):
-			inProjection = strings.Contains(trim, "proj_metric_name")
+			inProjection = strings.Contains(trim, projName)
 		case inProjection && strings.HasPrefix(trim, "Granules:"):
 			frac := strings.TrimSpace(strings.TrimPrefix(trim, "Granules:"))
 			if _, err := fmt.Sscanf(frac, "%d/%d", &selected, &total); err != nil {
@@ -127,41 +153,150 @@ func projectionGranules(t *testing.T, db *sql.DB, query string) (selected, total
 	return 0, 0, false
 }
 
-// captureWindowlessMetricNamesSQL returns the gauge/sum-arm SQL the handler
-// emits for a windowless /api/v1/label/__name__/values request. The
-// recording stub feeds canned names back so the handler completes; the
-// returned statement is the bare-group UNION (the one that references the
-// gauge table).
-func captureWindowlessMetricNamesSQL(t *testing.T) string {
+// explainEstimateRows returns the total estimated rows EXPLAIN ESTIMATE reports
+// for query (summed across the per-table rows). With a projection serving the
+// read this reflects the projection's tiny pre-aggregated row count; with
+// `optimize_use_projections=0` appended it reflects the full fact-table scan.
+func explainEstimateRows(t *testing.T, db *sql.DB, query string) int64 {
 	t.Helper()
-	q := &stubQuerier{strings: []string{"m_0"}}
-	srv := newServer(q)
-	t.Cleanup(srv.Close)
-
-	resp, err := http.Get(srv.URL + "/api/v1/label/__name__/values")
+	rows, err := db.Query("EXPLAIN ESTIMATE " + query)
 	if err != nil {
-		t.Fatalf("GET: %v", err)
+		t.Fatalf("EXPLAIN ESTIMATE: %v\nquery: %s", err, query)
+	}
+	defer rows.Close()
+	var total int64
+	for rows.Next() {
+		var database, table string
+		var parts, r, marks int64
+		if err := rows.Scan(&database, &table, &parts, &r, &marks); err != nil {
+			t.Fatalf("scan estimate: %v", err)
+		}
+		total += r
+	}
+	return total
+}
+
+// assertRoutesAndPrunes pins both halves of the projection-routing guard for
+// one captured emit: it routes to projName and prunes granules, and its
+// read_rows is far below the unprojected baseline and under the absolute
+// ceiling.
+func assertRoutesAndPrunes(t *testing.T, db *sql.DB, label, query, projName string) {
+	t.Helper()
+	t.Logf("%s emit:\n%s", label, query)
+	sel, tot, ok := projectionGranules(t, db, query, projName)
+	if !ok {
+		t.Fatalf("%s did not route to %s — it full-scans the fact table. emit:\n%s", label, projName, query)
+	}
+	t.Logf("%s %s granules: %d/%d", label, projName, sel, tot)
+	if tot < scanBoundDays {
+		t.Fatalf("%s: %s read saw %d granules total, want >= %d — corpus not dense enough to prove pruning",
+			label, projName, tot, scanBoundDays)
+	}
+	if sel >= tot {
+		t.Errorf("%s: read %d of %d %s granules — no pruning (selected must be < total)", label, sel, tot, projName)
+	}
+
+	routed := explainEstimateRows(t, db, query)
+	baseline := explainEstimateRows(t, db, query+" SETTINGS optimize_use_projections=0")
+	if routed <= 0 {
+		t.Fatalf("%s: routed read_rows=%d — EXPLAIN ESTIMATE returned nothing", label, routed)
+	}
+	t.Logf("%s read_rows: routed=%d baseline=%d (factor %d)", label, routed, baseline, baseline/routed)
+	if routed > maxRoutedReadRows {
+		t.Errorf("%s: routed read_rows=%d exceeds ceiling %d — the read fell back to scanning the fact table",
+			label, routed, maxRoutedReadRows)
+	}
+	if baseline/routed < minReadRowsPruneFactor {
+		t.Errorf("%s: read_rows prune factor %d (baseline=%d routed=%d) below floor %d — projection not pruning",
+			label, baseline/routed, baseline, routed, minReadRowsPruneFactor)
+	}
+}
+
+// newCaptureServer builds a stub-backed prom handler with the resource arm
+// disabled (ResourceAttributesColumn cleared), so a /label/<name>/values
+// request emits only the Attributes-map arm — the path proj_series serves. The
+// resource arm reads ResourceAttributes (absent from proj_series) and is a
+// separate, documented non-routing path, out of scope for this guard.
+func newCaptureServer(t *testing.T, q prom.Querier) *httptest.Server {
+	t.Helper()
+	sch := schema.DefaultOTelMetrics()
+	sch.ResourceAttributesColumn = ""
+	h := prom.New(q, sch, nil)
+	mux := http.NewServeMux()
+	h.Mount(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// inlineArgs replaces each `?` placeholder in sql with its bound arg so the
+// captured emit is EXPLAIN-ready. The metadata enumeration binds only string
+// args (map keys + the empty-string sentinel), rendered as single-quoted CH
+// literals.
+func inlineArgs(t *testing.T, sql string, args []any) string {
+	t.Helper()
+	out := sql
+	for _, a := range args {
+		s, ok := a.(string)
+		if !ok {
+			t.Fatalf("non-string arg %v (%T) in captured SQL; the inliner handles only string metadata args", a, a)
+		}
+		lit := "'" + strings.ReplaceAll(s, "'", "''") + "'"
+		out = strings.Replace(out, "?", lit, 1)
+	}
+	if strings.Contains(out, "?") {
+		t.Fatalf("unbound placeholder left after inlining: %s", out)
+	}
+	return out
+}
+
+// captureGaugeArm issues the metadata request at path against a capture server,
+// then returns the first recorded statement that references the gauge table and
+// satisfies match, with its placeholders inlined. match disambiguates between
+// arms (e.g. the grouped Attributes arm vs others) when a request fans out.
+func captureGaugeArm(t *testing.T, path string, match func(sql string) bool) string {
+	t.Helper()
+	q := &stubQuerier{
+		strings:  []string{"j"},
+		metaRows: []chclient.MetricMetaRow{{Name: "m_0", Description: "desc 0", Unit: "unit"}},
+	}
+	srv := newCaptureServer(t, q)
+
+	resp, err := http.Get(srv.URL + path)
+	if err != nil {
+		t.Fatalf("GET %s: %v", path, err)
 	}
 	resp.Body.Close()
 
-	for _, stmt := range q.allSQL {
-		if strings.Contains(stmt, "otel_metrics_gauge") {
-			return stmt
+	for i, stmt := range q.allSQL {
+		if strings.Contains(stmt, "otel_metrics_gauge") && match(stmt) {
+			return inlineArgs(t, stmt, q.allArgs[i])
 		}
 	}
-	t.Fatalf("handler issued no gauge-table metric-name query; allSQL=%q", q.allSQL)
+	t.Fatalf("handler issued no matching gauge-table query for %s; allSQL=%q", path, q.allSQL)
 	return ""
 }
 
-// TestMetadataScanBound_MetricNamesExplain_Repro pins the projection-routing
-// property on the handler's actual windowless `__name__` emit. The windowless
-// enumeration (`GROUP BY MetricName HAVING max(TimeUnix) >= <lookback>`) must
-// read the `proj_metric_name` aggregating projection — a tiny one-row-per-name
-// part — instead of full-scanning the metrics fact table. Without the
-// projection (or with the pre-projection `DISTINCT ... WHERE TimeUnix` emit
-// that a column filter keeps off any projection) this read streams every
-// granule of the fact table; the assertion below catches that regression.
-func TestMetadataScanBound_MetricNamesExplain_Repro(t *testing.T) {
+// setupScanBoundTable creates + seeds the production-shaped gauge table and
+// installs+materializes the curated projections, ready for EXPLAIN.
+func setupScanBoundTable(t *testing.T, db *sql.DB, table string) {
+	t.Helper()
+	stmts := []string{scanBoundPartitionedDDL(table), scanBoundInsert(table)}
+	stmts = append(stmts, scanBoundProjections(table)...)
+	for _, stmt := range stmts {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("setup %s: %v", stmt, err)
+		}
+	}
+	// One dense part per day-partition so the projection collapses real parts,
+	// not inflated unmerged insert parts.
+	if _, err := db.Exec("OPTIMIZE TABLE " + table + " FINAL"); err != nil {
+		t.Fatalf("optimize %s: %v", table, err)
+	}
+}
+
+func openScanBoundDB(t *testing.T) *sql.DB {
+	t.Helper()
 	db, err := sql.Open("chdb", "")
 	if err != nil {
 		t.Fatalf("open chdb: %v", err)
@@ -170,41 +305,68 @@ func TestMetadataScanBound_MetricNamesExplain_Repro(t *testing.T) {
 	if err := db.Ping(); err != nil {
 		t.Fatalf("ping chdb: %v", err)
 	}
+	return db
+}
 
+// TestMetadataScanBound_MetricNamesExplain_Repro pins that the windowless
+// /api/v1/label/__name__/values emit routes onto proj_series (re-aggregated
+// max-of-maxes to the coarser GROUP BY MetricName) and prunes.
+func TestMetadataScanBound_MetricNamesExplain_Repro(t *testing.T) {
+	db := openScanBoundDB(t)
 	for _, table := range []string{"otel_metrics_gauge", "otel_metrics_sum"} {
-		stmts := []string{
-			scanBoundPartitionedDDL(table),
-			scanBoundInsert(table),
-			scanBoundAddProjection(table),
-			"ALTER TABLE " + table + " MATERIALIZE PROJECTION proj_metric_name",
-		}
-		for _, stmt := range stmts {
-			if _, err := db.Exec(stmt); err != nil {
-				t.Fatalf("setup %s: %v", stmt, err)
-			}
-		}
-		// One dense part per day-partition so the projection collapses real
-		// parts, not inflated unmerged insert parts.
-		if _, err := db.Exec("OPTIMIZE TABLE " + table + " FINAL"); err != nil {
-			t.Fatalf("optimize %s: %v", table, err)
-		}
+		setupScanBoundTable(t, db, table)
 	}
+	// The bare-group __name__ arm references the gauge table and groups by
+	// MetricName only (no Attributes) — distinguishes it from any other arm.
+	emit := captureGaugeArm(t, "/api/v1/label/__name__/values", func(sql string) bool {
+		return strings.Contains(sql, "GROUP BY `MetricName`") &&
+			!strings.Contains(sql, "`MetricName`, `Attributes`")
+	})
+	assertRoutesAndPrunes(t, db, "windowless __name__", emit, "proj_series")
+}
 
-	captured := captureWindowlessMetricNamesSQL(t)
-	t.Logf("windowless __name__ emit:\n%s", captured)
+// TestMetadataScanBound_LabelValuesExplain_Repro pins that the generic
+// windowless /api/v1/label/<label>/values emit (grouped DISTINCT Attributes[k]
+// over GROUP BY MetricName, Attributes HAVING max(TimeUnix) >= lookback) routes
+// onto proj_series and prunes.
+func TestMetadataScanBound_LabelValuesExplain_Repro(t *testing.T) {
+	db := openScanBoundDB(t)
+	setupScanBoundTable(t, db, "otel_metrics_gauge")
+	setupScanBoundTable(t, db, "otel_metrics_sum")
+	setupScanBoundTable(t, db, "otel_metrics_histogram")
+	emit := captureGaugeArm(t, "/api/v1/label/instance/values", func(sql string) bool {
+		return strings.Contains(sql, "GROUP BY `MetricName`, `Attributes`")
+	})
+	assertRoutesAndPrunes(t, db, "windowless label_values(instance)", emit, "proj_series")
+}
 
-	sel, tot, ok := projectionGranules(t, db, captured)
-	if !ok {
-		t.Fatalf("windowless /api/v1/label/__name__/values did not route to proj_metric_name — "+
-			"it full-scans the fact table. emit:\n%s", captured)
-	}
-	t.Logf("windowless __name__ projection granules: %d/%d", sel, tot)
-	if tot < scanBoundDays {
-		t.Fatalf("projection read saw %d granules total, want >= %d — corpus not dense enough to prove pruning",
-			tot, scanBoundDays)
-	}
-	if sel >= tot {
-		t.Errorf("windowless /api/v1/label/__name__/values read %d of %d projection granules — no pruning; "+
-			"the aggregating projection must collapse the metric-name scan (selected < total).", sel, tot)
-	}
+// TestMetadataScanBound_LabelNamesExplain_Repro pins that the windowless
+// /api/v1/labels emit (arrayJoin(mapKeys(Attributes)) over GROUP BY MetricName,
+// Attributes HAVING max(TimeUnix) >= lookback) routes onto proj_series.
+func TestMetadataScanBound_LabelNamesExplain_Repro(t *testing.T) {
+	db := openScanBoundDB(t)
+	setupScanBoundTable(t, db, "otel_metrics_gauge")
+	setupScanBoundTable(t, db, "otel_metrics_sum")
+	setupScanBoundTable(t, db, "otel_metrics_histogram")
+	emit := captureGaugeArm(t, "/api/v1/labels", func(sql string) bool {
+		return strings.Contains(sql, "mapKeys(`Attributes`)") &&
+			strings.Contains(sql, "GROUP BY `MetricName`, `Attributes`")
+	})
+	assertRoutesAndPrunes(t, db, "windowless label names", emit, "proj_series")
+}
+
+// TestMetadataScanBound_MetadataExplain_Repro pins that the windowless
+// /api/v1/metadata gauge arm (SELECT MetricName, any(MetricDescription),
+// any(MetricUnit) GROUP BY MetricName HAVING max(TimeUnix) >= lookback) routes
+// onto proj_metric_metadata.
+func TestMetadataScanBound_MetadataExplain_Repro(t *testing.T) {
+	db := openScanBoundDB(t)
+	setupScanBoundTable(t, db, "otel_metrics_gauge")
+	// The gauge metadata arm is the one over the gauge table grouping by
+	// MetricName and selecting the description/unit aggregates.
+	emit := captureGaugeArm(t, "/api/v1/metadata", func(sql string) bool {
+		return strings.Contains(sql, "any(`MetricDescription`)") &&
+			strings.Contains(sql, "GROUP BY `MetricName`")
+	})
+	assertRoutesAndPrunes(t, db, "windowless metadata", emit, "proj_metric_metadata")
 }

--- a/internal/api/prom/metadata_scan_bound_explain_chdb_test.go
+++ b/internal/api/prom/metadata_scan_bound_explain_chdb_test.go
@@ -9,9 +9,11 @@ package prom_test
 // full-scanning the metrics fact table. It drives the SQL the HANDLER ACTUALLY
 // emits (captured through a recording stub) for:
 //
-//   - /api/v1/label/__name__/values  → routes onto proj_series (max-of-maxes
-//     re-aggregation of the finer (MetricName, Attributes) projection to the
-//     coarser GROUP BY MetricName);
+//   - /api/v1/label/__name__/values  → routes onto an aggregating projection
+//     (proj_series via max-of-maxes re-aggregation of the finer
+//     (MetricName, Attributes) projection to the coarser GROUP BY MetricName, OR
+//     the exact-match proj_metric_metadata — CH's cost model picks per substrate,
+//     so the guard accepts either);
 //   - /api/v1/label/<label>/values   → routes onto proj_series;
 //   - /api/v1/labels (label names)   → routes onto proj_series;
 //   - /api/v1/metadata               → routes onto proj_metric_metadata.
@@ -122,17 +124,21 @@ func scanBoundProjections(table string) []string {
 }
 
 // projectionGranules returns (selected, total) granules from the EXPLAIN
-// indexes=1 read of the named aggregating projection — proof the emit routes to
-// that projection rather than scanning the fact table. It returns ok=false if
-// no read of that projection appears in the plan.
-func projectionGranules(t *testing.T, db *sql.DB, query, projName string) (selected, total int, ok bool) {
+// indexes=1 read of an accepted aggregating projection — proof the emit routes
+// to a projection rather than scanning the fact table. projNames lists the
+// acceptable projections (more than one when the shape can legitimately route to
+// either, e.g. __name__ which CH's cost model may serve from proj_series or the
+// exact-match proj_metric_metadata depending on substrate). It returns the
+// matched projection name, or ok=false if no read of ANY listed projection
+// appears in the plan (a full fact-table scan).
+func projectionGranules(t *testing.T, db *sql.DB, query string, projNames ...string) (selected, total int, matched string, ok bool) {
 	t.Helper()
 	rows, err := db.Query("EXPLAIN indexes=1 " + query)
 	if err != nil {
 		t.Fatalf("EXPLAIN: %v\nquery: %s", err, query)
 	}
 	defer rows.Close()
-	inProjection := false
+	cur := ""
 	for rows.Next() {
 		var line string
 		if err := rows.Scan(&line); err != nil {
@@ -141,16 +147,22 @@ func projectionGranules(t *testing.T, db *sql.DB, query, projName string) (selec
 		trim := strings.TrimSpace(line)
 		switch {
 		case strings.HasPrefix(trim, "ReadFromMergeTree"):
-			inProjection = strings.Contains(trim, projName)
-		case inProjection && strings.HasPrefix(trim, "Granules:"):
+			cur = ""
+			for _, name := range projNames {
+				if strings.Contains(trim, name) {
+					cur = name
+					break
+				}
+			}
+		case cur != "" && strings.HasPrefix(trim, "Granules:"):
 			frac := strings.TrimSpace(strings.TrimPrefix(trim, "Granules:"))
 			if _, err := fmt.Sscanf(frac, "%d/%d", &selected, &total); err != nil {
 				t.Fatalf("parse Granules line %q: %v", trim, err)
 			}
-			return selected, total, true
+			return selected, total, cur, true
 		}
 	}
-	return 0, 0, false
+	return 0, 0, "", false
 }
 
 // explainEstimateRows returns the total estimated rows EXPLAIN ESTIMATE reports
@@ -177,15 +189,21 @@ func explainEstimateRows(t *testing.T, db *sql.DB, query string) int64 {
 }
 
 // assertRoutesAndPrunes pins both halves of the projection-routing guard for
-// one captured emit: it routes to projName and prunes granules, and its
+// one captured emit: it routes to one of projNames and prunes granules, and its
 // read_rows is far below the unprojected baseline and under the absolute
-// ceiling.
-func assertRoutesAndPrunes(t *testing.T, db *sql.DB, label, query, projName string) {
+// ceiling. Passing more than one projName accepts routing onto ANY of them —
+// for shapes (like __name__) that CH may legitimately serve from either an
+// (MetricName, Attributes) or an exact-match (MetricName) projection depending
+// on its cost model / substrate. The read_rows half is projection-agnostic
+// (routed vs optimize_use_projections=0 baseline), so the guard stays
+// non-vacuous regardless of which listed projection wins: if NONE routes, the
+// granules half fatals on the full scan.
+func assertRoutesAndPrunes(t *testing.T, db *sql.DB, label, query string, projNames ...string) {
 	t.Helper()
 	t.Logf("%s emit:\n%s", label, query)
-	sel, tot, ok := projectionGranules(t, db, query, projName)
+	sel, tot, projName, ok := projectionGranules(t, db, query, projNames...)
 	if !ok {
-		t.Fatalf("%s did not route to %s — it full-scans the fact table. emit:\n%s", label, projName, query)
+		t.Fatalf("%s did not route to any of %v — it full-scans the fact table. emit:\n%s", label, projNames, query)
 	}
 	t.Logf("%s %s granules: %d/%d", label, projName, sel, tot)
 	if tot < scanBoundDays {
@@ -309,8 +327,16 @@ func openScanBoundDB(t *testing.T) *sql.DB {
 }
 
 // TestMetadataScanBound_MetricNamesExplain_Repro pins that the windowless
-// /api/v1/label/__name__/values emit routes onto proj_series (re-aggregated
-// max-of-maxes to the coarser GROUP BY MetricName) and prunes.
+// /api/v1/label/__name__/values emit routes onto an aggregating projection and
+// prunes — either proj_series (re-aggregated max-of-maxes to the coarser GROUP
+// BY MetricName) or the exact-match proj_metric_metadata. The __name__ emit
+// groups by MetricName only and reads just MetricName + max(TimeUnix), which
+// BOTH curated projections can serve; CH's cost model picks the cheaper one and
+// that choice varies by substrate (chDB CI vs prod CH 26.x may disagree), so
+// pinning a single projection name here would be substrate-fragile. The guard
+// is what matters and what we assert: a projection routes (not a full scan) and
+// it prunes. The Attributes-grouped shapes below (label_values / label names /
+// metadata desc-unit) genuinely require a specific projection and stay pinned.
 func TestMetadataScanBound_MetricNamesExplain_Repro(t *testing.T) {
 	db := openScanBoundDB(t)
 	for _, table := range []string{"otel_metrics_gauge", "otel_metrics_sum"} {
@@ -322,7 +348,7 @@ func TestMetadataScanBound_MetricNamesExplain_Repro(t *testing.T) {
 		return strings.Contains(sql, "GROUP BY `MetricName`") &&
 			!strings.Contains(sql, "`MetricName`, `Attributes`")
 	})
-	assertRoutesAndPrunes(t, db, "windowless __name__", emit, "proj_series")
+	assertRoutesAndPrunes(t, db, "windowless __name__", emit, "proj_series", "proj_metric_metadata")
 }
 
 // TestMetadataScanBound_LabelValuesExplain_Repro pins that the generic

--- a/internal/chsql/ddl_test.go
+++ b/internal/chsql/ddl_test.go
@@ -137,12 +137,22 @@ func TestCreateDatabase(t *testing.T) {
 	}
 }
 
-// metricNameProjectionBody is the aggregating projection body the metric-name
-// catalog enumeration is served from: one row per MetricName carrying its
-// max(TimeUnix). Built with the same typed QueryBuilder used for reads.
-func metricNameProjectionBody() *QueryBuilder {
+// seriesProjectionBody is the curated proj_series body: one row per
+// (MetricName, Attributes) carrying max(TimeUnix). It serves every windowless
+// enumeration shape (label_values, label-names, __name__, cardinality). Built
+// with the same typed QueryBuilder used for reads.
+func seriesProjectionBody() *QueryBuilder {
 	return NewQuery().
-		Select(Col("MetricName"), Call("max", Col("TimeUnix"))).
+		Select(Col("MetricName"), Col("Attributes"), Call("max", Col("TimeUnix"))).
+		GroupBy(Col("MetricName"), Col("Attributes"))
+}
+
+// metadataProjectionBody is the curated proj_metric_metadata body: one row per
+// MetricName carrying any(MetricDescription)/any(MetricUnit) + max(TimeUnix),
+// serving the windowless /api/v1/metadata listing.
+func metadataProjectionBody() *QueryBuilder {
+	return NewQuery().
+		Select(Col("MetricName"), Call("any", Col("MetricDescription")), Call("any", Col("MetricUnit")), Call("max", Col("TimeUnix"))).
 		GroupBy(Col("MetricName"))
 }
 
@@ -157,22 +167,22 @@ func TestAlterTableAddProjection(t *testing.T) {
 		want string
 	}{
 		{
-			"plain",
-			AlterTableAddProjection("otel", "otel_metrics_gauge", "proj_metric_name", metricNameProjectionBody()),
-			"ALTER TABLE otel.otel_metrics_gauge ADD PROJECTION IF NOT EXISTS proj_metric_name " +
-				"(SELECT `MetricName`, max(`TimeUnix`) GROUP BY `MetricName`)",
+			"series_plain",
+			AlterTableAddProjection("otel", "otel_metrics_gauge", "proj_series", seriesProjectionBody()),
+			"ALTER TABLE otel.otel_metrics_gauge ADD PROJECTION IF NOT EXISTS proj_series " +
+				"(SELECT `MetricName`, `Attributes`, max(`TimeUnix`) GROUP BY `MetricName`, `Attributes`)",
 		},
 		{
-			"default_db",
-			AlterTableAddProjection("default", "otel_metrics_sum", "proj_metric_name", metricNameProjectionBody()),
-			"ALTER TABLE default.otel_metrics_sum ADD PROJECTION IF NOT EXISTS proj_metric_name " +
-				"(SELECT `MetricName`, max(`TimeUnix`) GROUP BY `MetricName`)",
+			"series_default_db",
+			AlterTableAddProjection("default", "otel_metrics_sum", "proj_series", seriesProjectionBody()),
+			"ALTER TABLE default.otel_metrics_sum ADD PROJECTION IF NOT EXISTS proj_series " +
+				"(SELECT `MetricName`, `Attributes`, max(`TimeUnix`) GROUP BY `MetricName`, `Attributes`)",
 		},
 		{
-			"on_cluster",
-			AlterTableAddProjection("otel", "otel_metrics_histogram", "proj_metric_name", metricNameProjectionBody()).OnCluster("prod"),
-			"ALTER TABLE otel.otel_metrics_histogram ON CLUSTER `prod` ADD PROJECTION IF NOT EXISTS proj_metric_name " +
-				"(SELECT `MetricName`, max(`TimeUnix`) GROUP BY `MetricName`)",
+			"metadata_on_cluster",
+			AlterTableAddProjection("otel", "otel_metrics_histogram", "proj_metric_metadata", metadataProjectionBody()).OnCluster("prod"),
+			"ALTER TABLE otel.otel_metrics_histogram ON CLUSTER `prod` ADD PROJECTION IF NOT EXISTS proj_metric_metadata " +
+				"(SELECT `MetricName`, any(`MetricDescription`), any(`MetricUnit`), max(`TimeUnix`) GROUP BY `MetricName`)",
 		},
 	}
 	for _, tc := range cases {

--- a/internal/schema/ddl/ddl.go
+++ b/internal/schema/ddl/ddl.go
@@ -429,14 +429,16 @@ func renderSignal(cfg Config, s Signal) ([]string, error) {
 			renderMetricsTable(sqltemplates.MetricsExpHistogramCreateTable, cfg, cfg.Tables.MetricsExpHistogram, ttl),
 			renderMetricsTable(sqltemplates.MetricsSummaryCreateTable, cfg, cfg.Tables.MetricsSummary, ttl),
 		}
-		// Each CREATE is immediately followed by the idempotent
-		// ADD PROJECTION ALTER for the same table — CREATE precedes ALTER in
-		// the slice and applySignal executes sequentially, so the ALTER never
-		// races a missing table. Only the catalog tables the metric-name
+		// Each CREATE is immediately followed by the curated registry's
+		// idempotent ADD PROJECTION ALTERs on the same table — CREATE precedes
+		// ALTER in the slice and applySignal executes sequentially, so an ALTER
+		// never races a missing table. Only the catalog tables the metadata
 		// enumeration reads (gauge/sum/histogram, see metricTables() in
-		// internal/api/prom/metadata.go) carry the projection.
+		// internal/api/prom/metadata.go) carry the projections.
 		for _, table := range []string{cfg.Tables.MetricsGauge, cfg.Tables.MetricsSum, cfg.Tables.MetricsHistogram} {
-			stmts = append(stmts, renderAddMetricNameProjection(cfg, table))
+			for _, p := range metricCatalogProjections {
+				stmts = append(stmts, renderAddMetricProjection(cfg, table, p))
+			}
 		}
 		return stmts, nil
 	case Logs:
@@ -467,33 +469,87 @@ func renderMetricsTable(tmpl string, cfg Config, table, ttl string) string {
 }
 
 const (
-	// metricNameProjection is the aggregating projection that lets the
-	// windowless metric-name catalog enumeration (label_values(__name__))
-	// read an aggregating-projection part instead of full-scanning the
-	// metrics fact table — see metricNamesSQL in internal/api/prom/metadata.go.
-	metricNameProjection = "proj_metric_name"
-	// metricNameColumn / metricTimeColumn are the OTel-CH metric-table columns
-	// the projection aggregates over; fixed by the upstream exporter schema,
-	// not configurable in this package.
-	metricNameColumn = "MetricName"
-	metricTimeColumn = "TimeUnix"
+	// seriesProjection is the curated aggregating projection over
+	// (MetricName, Attributes) carrying max(TimeUnix). It serves every
+	// windowless metadata-enumeration shape the catalog tables answer —
+	// label_values(<label>), label-names, label_values(__name__), and series
+	// cardinality — from a tiny pre-aggregated part instead of full-scanning
+	// the metrics fact table (see internal/api/prom/metadata.go). The coarser
+	// __name__ enumeration (`GROUP BY MetricName`) is served from this finer
+	// (MetricName, Attributes) projection by ClickHouse's max-of-maxes
+	// re-aggregation, so it subsumes the narrower per-name projection #1105
+	// shipped — one projection covers all four shapes.
+	seriesProjection = "proj_series"
+	// metadataProjection carries any(MetricDescription)/any(MetricUnit) per
+	// MetricName so the windowless /api/v1/metadata listing reads a
+	// pre-aggregated part instead of grouping the whole fact table. It also
+	// carries max(TimeUnix) so the same windowless HAVING-bounded shape the
+	// enumeration emits routes here too.
+	metadataProjection = "proj_metric_metadata"
+	// The OTel-CH metric-table columns the projections aggregate over; fixed
+	// by the upstream exporter schema, not configurable in this package. The
+	// histogram table has no top-level Value column (Value lives only inside
+	// the Exemplars Nested block), so the series projection deliberately omits
+	// any Value aggregate — none of the routed enumeration shapes read it, and
+	// a uniform body keeps one registry entry valid across gauge/sum/histogram.
+	metricNameColumn        = "MetricName"
+	metricTimeColumn        = "TimeUnix"
+	metricAttributesColumn  = "Attributes"
+	metricDescriptionColumn = "MetricDescription"
+	metricUnitColumn        = "MetricUnit"
 )
 
-// renderAddMetricNameProjection builds the idempotent ADD PROJECTION ALTER
-// for one metrics fact table: an aggregating projection over MetricName
-// carrying max(TimeUnix), which serves the metric-name catalog query
-// (`GROUP BY MetricName HAVING max(TimeUnix) >= …`) from a tiny pre-aggregated
-// part rather than the full column. ON CLUSTER is threaded so the ALTER
-// replicates the same way the CREATE statements do. ADD PROJECTION IF NOT
-// EXISTS is metadata-only and idempotent, so the same Apply path covers both
-// freshly-created and pre-existing tables; backfilling existing parts is a
-// separate MATERIALIZE PROJECTION runbook (see docs/operations.md), kept out
-// of the hot DDL path.
-func renderAddMetricNameProjection(cfg Config, table string) string {
-	body := chsql.NewQuery().
-		Select(chsql.Col(metricNameColumn), chsql.Call("max", chsql.Col(metricTimeColumn))).
-		GroupBy(chsql.Col(metricNameColumn))
-	stmt := chsql.AlterTableAddProjection(cfg.Database, table, metricNameProjection, body)
+// metricProjection is one curated aggregating projection the DDL apply path
+// installs on each metrics catalog table. body is built fresh per call so each
+// rendered ALTER owns its QueryBuilder (no shared mutable state across tables).
+type metricProjection struct {
+	name string
+	body func() *chsql.QueryBuilder
+}
+
+// metricCatalogProjections is the curated registry of aggregating projections
+// installed (idempotently, ADD PROJECTION IF NOT EXISTS) on each of the
+// gauge/sum/histogram catalog tables at boot. Adding a projection here adds it
+// to every catalog table; the read-side emitters in internal/api/prom decide
+// which enumeration shapes route onto which projection (ClickHouse picks the
+// projection at plan time). Backfilling existing parts is a separate
+// MATERIALIZE PROJECTION runbook (see docs/operations.md), kept out of the hot
+// DDL path so boot stays metadata-only.
+var metricCatalogProjections = []metricProjection{
+	{
+		name: seriesProjection,
+		body: func() *chsql.QueryBuilder {
+			return chsql.NewQuery().
+				Select(
+					chsql.Col(metricNameColumn),
+					chsql.Col(metricAttributesColumn),
+					chsql.Call("max", chsql.Col(metricTimeColumn)),
+				).
+				GroupBy(chsql.Col(metricNameColumn), chsql.Col(metricAttributesColumn))
+		},
+	},
+	{
+		name: metadataProjection,
+		body: func() *chsql.QueryBuilder {
+			return chsql.NewQuery().
+				Select(
+					chsql.Col(metricNameColumn),
+					chsql.Call("any", chsql.Col(metricDescriptionColumn)),
+					chsql.Call("any", chsql.Col(metricUnitColumn)),
+					chsql.Call("max", chsql.Col(metricTimeColumn)),
+				).
+				GroupBy(chsql.Col(metricNameColumn))
+		},
+	},
+}
+
+// renderAddMetricProjection builds the idempotent ADD PROJECTION ALTER for one
+// curated projection on one metrics fact table. ON CLUSTER is threaded so the
+// ALTER replicates the same way the CREATE statements do. ADD PROJECTION IF
+// NOT EXISTS is metadata-only and idempotent, so the same Apply path covers
+// both freshly-created and pre-existing tables.
+func renderAddMetricProjection(cfg Config, table string, p metricProjection) string {
+	stmt := chsql.AlterTableAddProjection(cfg.Database, table, p.name, p.body())
 	if cfg.Cluster != "" {
 		stmt.OnCluster(cfg.Cluster)
 	}

--- a/internal/schema/ddl/ddl_test.go
+++ b/internal/schema/ddl/ddl_test.go
@@ -8,7 +8,8 @@ import (
 
 // TestRenderSignal_Metrics checks all five metrics templates render with
 // the right table names + engine + database substituted in, followed by the
-// three idempotent metric-name ADD PROJECTION ALTERs.
+// curated registry's idempotent ADD PROJECTION ALTERs — proj_series +
+// proj_metric_metadata on each of the gauge/sum/histogram catalog tables.
 func TestRenderSignal_Metrics(t *testing.T) {
 	cfg := Config{}.withDefaults()
 
@@ -16,9 +17,10 @@ func TestRenderSignal_Metrics(t *testing.T) {
 	if err != nil {
 		t.Fatalf("renderSignal(Metrics): %v", err)
 	}
-	// 5 CREATE TABLE + 3 ADD PROJECTION (gauge/sum/histogram catalog tables).
+	// 5 CREATE TABLE + (3 catalog tables × 2 curated projections) ADD PROJECTION.
 	const wantCreates = 5
-	if got, want := len(stmts), wantCreates+3; got != want {
+	wantProj := 3 * len(metricCatalogProjections)
+	if got, want := len(stmts), wantCreates+wantProj; got != want {
 		t.Fatalf("metrics: got %d statements, want %d", got, want)
 	}
 	wantTables := []string{
@@ -45,22 +47,40 @@ func TestRenderSignal_Metrics(t *testing.T) {
 			t.Errorf("metrics[%d]: zero TTL should not render TTL clause", i)
 		}
 	}
-	// The projection ALTERs follow the CREATEs, one per catalog table, in
-	// gauge/sum/histogram order. CREATE precedes ALTER so the ALTER never
-	// races a missing table.
-	wantProjTables := []string{"otel_metrics_gauge", "otel_metrics_sum", "otel_metrics_histogram"}
-	for i, stmt := range stmts[wantCreates:] {
-		wantPrefix := "ALTER TABLE default." + wantProjTables[i] +
-			" ADD PROJECTION IF NOT EXISTS proj_metric_name "
-		if !strings.HasPrefix(stmt, wantPrefix) {
-			t.Errorf("metrics projection[%d]: got %q, want prefix %q", i, stmt, wantPrefix)
+	// The projection ALTERs follow the CREATEs, grouped per catalog table in
+	// gauge/sum/histogram order, each table carrying every registry entry in
+	// registry order. CREATE precedes ALTER so the ALTER never races a missing
+	// table.
+	catalogTables := []string{"otel_metrics_gauge", "otel_metrics_sum", "otel_metrics_histogram"}
+	proj := stmts[wantCreates:]
+	idx := 0
+	for _, table := range catalogTables {
+		for _, p := range metricCatalogProjections {
+			stmt := proj[idx]
+			wantPrefix := "ALTER TABLE default." + table +
+				" ADD PROJECTION IF NOT EXISTS " + p.name + " "
+			if !strings.HasPrefix(stmt, wantPrefix) {
+				t.Errorf("metrics projection[%d]: got %q, want prefix %q", idx, stmt, wantPrefix)
+			}
+			if !strings.Contains(stmt, "max(`TimeUnix`)") {
+				t.Errorf("metrics projection[%d]: missing max(TimeUnix) aggregate in:\n%s", idx, stmt)
+			}
+			if strings.Contains(stmt, "ON CLUSTER") {
+				t.Errorf("metrics projection[%d]: empty cluster should not render ON CLUSTER", idx)
+			}
+			idx++
 		}
-		if !strings.Contains(stmt, "max(`TimeUnix`) GROUP BY `MetricName`") {
-			t.Errorf("metrics projection[%d]: missing aggregating body in:\n%s", i, stmt)
-		}
-		if strings.Contains(stmt, "ON CLUSTER") {
-			t.Errorf("metrics projection[%d]: empty cluster should not render ON CLUSTER", i)
-		}
+	}
+	// Pin the two distinct projection bodies so a registry shape regression is
+	// caught here, not only at routing time.
+	all := strings.Join(proj, "\n")
+	if !strings.Contains(all, "ADD PROJECTION IF NOT EXISTS proj_series "+
+		"(SELECT `MetricName`, `Attributes`, max(`TimeUnix`) GROUP BY `MetricName`, `Attributes`)") {
+		t.Errorf("missing proj_series body in:\n%s", all)
+	}
+	if !strings.Contains(all, "ADD PROJECTION IF NOT EXISTS proj_metric_metadata "+
+		"(SELECT `MetricName`, any(`MetricDescription`), any(`MetricUnit`), max(`TimeUnix`) GROUP BY `MetricName`)") {
+		t.Errorf("missing proj_metric_metadata body in:\n%s", all)
 	}
 }
 

--- a/internal/schema/ddl/idempotency_test.go
+++ b/internal/schema/ddl/idempotency_test.go
@@ -272,17 +272,18 @@ func TestRenderSignal_TracesOnlySubset(t *testing.T) {
 }
 
 // TestRenderSignal_MetricsOnlySubset confirms the five metrics CREATE
-// statements (plus the three metric-name ADD PROJECTION ALTERs) render
-// without leaking logs or traces tables.
+// statements (plus the curated registry's ADD PROJECTION ALTERs on the three
+// catalog tables) render without leaking logs or traces tables.
 func TestRenderSignal_MetricsOnlySubset(t *testing.T) {
 	cfg := Config{}.withDefaults()
 	stmts, err := renderSignal(cfg, Metrics)
 	if err != nil {
 		t.Fatalf("renderSignal(Metrics): %v", err)
 	}
-	// 5 CREATE TABLE + 3 ADD PROJECTION (gauge/sum/histogram).
-	if len(stmts) != 8 {
-		t.Fatalf("metrics subset: got %d statements; want 8", len(stmts))
+	// 5 CREATE TABLE + (3 catalog tables × len(registry)) ADD PROJECTION.
+	wantStmts := 5 + 3*len(metricCatalogProjections)
+	if len(stmts) != wantStmts {
+		t.Fatalf("metrics subset: got %d statements; want %d", len(stmts), wantStmts)
 	}
 	for i, stmt := range stmts {
 		if strings.Contains(stmt, "otel_logs") || strings.Contains(stmt, "otel_traces") {


### PR DESCRIPTION
## What
Generalizes #1105's metric-name projection into a **curated projection registry** and adds **`proj_series`** (`SELECT MetricName, Attributes, max(TimeUnix) GROUP BY MetricName, Attributes`) + **`proj_metric_metadata`** (`GROUP BY MetricName, any(Desc), any(Unit)`) on gauge/sum/histogram. **Replaces `proj_metric_name`** — `proj_series` subsumes it (the planner serves `__name__` via max-of-maxes re-aggregation; prod's cost model actually picks the cheaper `proj_metric_metadata`), and additionally **auto-routes the generic `label_values(<label>)` shape** (746×/1.2B-rows/24h) with **zero emit change** — prod already groups by `MetricName, Attributes`.

## Wins (measured on prod-shaped scratch from real otel)
Retires the whole metrics **enumeration + cardinality tier** (`label_values(__name__)` + generic `label_values` + label-names + active-series count) onto projections: 149–389× row-prune, byte-exact result sets (cityHash-identical vs full scan).

## Cost — honest (3-way A/B, the full picture)
| axis | none → metric-name → proj_series |
|---|---|
| storage | — / +0.013% / **+0.4%** (below floor) |
| insert throughput | 276k → 226k (−18%) → **178k (−36%)** rows/s |
| p50 insert latency | 190ms → 253ms (+33%) → **323ms (+70%)** |
| merge CPU | flat across all three |
| MATERIALIZE backfill | ~3–8 min at prod gauge scale |

The wide `Attributes` map makes `proj_series`'s **insert** tax ~2× the metric-name-only projection (per-scrape series barely collapse → near-full re-sort/write). **Operationally immaterial today: ~60× ingest headroom** (~2,824 rows/s prod vs ~178k/s sustained on 4 cores). Documented in `docs/operations.md`; revisit if headroom tightens (`proj_metric_metadata` alone covers `__name__` at ~half the tax).

## Routing guard (the one real risk of implicit projection routing)
Projection selection is implicit (no pin) — a CH upgrade could silently un-route back to full scans. The EXPLAIN+read_rows regression test asserts `__name__` routes onto *some* aggregating projection (substrate-robust: chDB picks `proj_series`, prod picks `proj_metric_metadata`) and is **non-vacuous** (goes red on full-scan if projections are dropped).

## Honest caveats
- Curated registry (data-driven `(table,name,body)`, idempotent `ADD PROJECTION IF NOT EXISTS`) — **auto-provision = curated, not learned**.
- `/api/v1/metadata` desc/unit now drawn from an all-time `any()` (was windowed) — metric-NAME set exact; the arbitrary desc/unit pick can differ for time-varying metadata (`any()` was already nondeterministic). Comment corrected.
- **Nothing prunes until deployed + `MATERIALIZE`'d** (`system.projections` empty on prod) → ships in **v1.8.2**.

Builds on #1105 (which it supersedes). Zero golden drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)