### PR TITLE
chore(release): cerberus v1.8.2 / chart 0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to cerberus will be documented in this file. The format roug
 
 ## [Unreleased]
 
+## [v1.8.2] — 2026-06-27
+
+### Fixed
+
+- **prom:** bound metadata enumeration to retention + cover always-unbounded metricMetaSQL (#1104)
+
+### Performance
+
+- **prom:** per-series projection (proj_series) retires the metrics enumeration tier + curated projection registry (#1107)
+- **prom:** serve windowless metric-name enumeration from an aggregating projection (#1105)
+
 ## [v1.8.1] — 2026-06-26
 
 ### Added

--- a/deploy/helm/cerberus/Chart.yaml
+++ b/deploy/helm/cerberus/Chart.yaml
@@ -8,11 +8,11 @@ type: application
 # upgrade?" and is the publish trigger: a chart-only fix bumps this without an
 # app re-tag; an app-only release bumps appVersion + a PATCH here for the new
 # default image. Starts 0.x because the values contract is not yet frozen.
-version: 0.8.1
+version: 0.8.2
 
 # appVersion tracks the GA cerberus binary. Quoted so SemVer-shaped values
 # aren't coerced to floats. image.tag defaults from this when left empty.
-appVersion: "1.8.1"
+appVersion: "1.8.2"
 
 # autoscaling/v2 + policy/v1 (PDB) + networking/v1 (Ingress) are all GA from
 # 1.21+; 1.23 is the conservative floor matching the manifests this chart
@@ -45,13 +45,13 @@ annotations:
       url: https://github.com/tsouza/cerberus/blob/main/docs/operations.md
   artifacthub.io/images: |
     - name: cerberus
-      image: ghcr.io/tsouza/cerberus:v1.8.1
+      image: ghcr.io/tsouza/cerberus:v1.8.2
   # Bump the `1.0.0` floor here when the chart raises its minimum supported
   # cerberus release; informational for Artifact Hub's compatibility hints.
   artifacthub.io/changes: |
-    - kind: added
-      description: "optimizer: fail-closed scan-time-bound invariant for instant windowed scans (#1100)"
     - kind: fixed
-      description: "release: preflight ignores empty check-suites (e.g. GitGuardian) in the CI wait (#1097)"
+      description: "prom: bound metadata enumeration to retention + cover always-unbounded metricMetaSQL (#1104)"
     - kind: changed
-      description: "chsql: bound instant windowed-array scans to the eval window (#1098)"
+      description: "prom: per-series projection (proj_series) retires the metrics enumeration tier + curated projection registry (#1107)"
+    - kind: changed
+      description: "prom: serve windowless metric-name enumeration from an aggregating projection (#1105)"

--- a/deploy/helm/cerberus/README.md
+++ b/deploy/helm/cerberus/README.md
@@ -5,7 +5,7 @@
      pipe-aligned, and the version footer adds a trailing blank — both are
      owned by helm-docs; realigning would fight the chart-ci drift check. -->
 
-![Version: 0.8.1](https://img.shields.io/badge/Version-0.8.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.1](https://img.shields.io/badge/AppVersion-1.8.1-informational?style=flat-square)
+![Version: 0.8.2](https://img.shields.io/badge/Version-0.8.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.2](https://img.shields.io/badge/AppVersion-1.8.2-informational?style=flat-square)
 
 Drop-in Prometheus / Loki / Tempo HTTP gateway for ClickHouse — a single stateless gateway that speaks three upstream query wire formats and lowers each to parameterised ClickHouse SQL.
 


### PR DESCRIPTION
Release-prep for **v1.8.2** (chart **0.8.2**), generated by `prepare-release.yml`.

- appVersion 1.8.1 -> 1.8.2, chart 0.8.1 -> 0.8.2

### Changes

### Fixed

- **prom:** bound metadata enumeration to retention + cover always-unbounded metricMetaSQL (#1104)

### Performance

- **prom:** per-series projection (proj_series) retires the metrics enumeration tier + curated projection registry (#1107)
- **prom:** serve windowless metric-name enumeration from an aggregating projection (#1105)

Generated from the conventional commits since the last tag. Review and edit before merging; the tag is cut once this lands.
