### PR TITLE
chore(release): cerberus v1.8.2 / chart 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to cerberus will be documented in this file. The format roug
 
 ## [Unreleased]
 
-## [v1.8.2] — 2026-06-27
+## [chart-v0.9.0] — 2026-06-27
+
+Chart-only release (appVersion stays 1.8.2 — no binary/image change).
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to cerberus will be documented in this file. The format roug
 
 ## [v1.8.2] — 2026-06-27
 
+### Added
+
+- **chart:** bwc mode — bundled production ClickHouse on object storage (S3/GCS/Azure), no operator (#1106)
+
+## [v1.8.2] — 2026-06-27
+
 ### Fixed
 
 - **prom:** bound metadata enumeration to retention + cover always-unbounded metricMetaSQL (#1104)

--- a/deploy/helm/cerberus/Chart.yaml
+++ b/deploy/helm/cerberus/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # upgrade?" and is the publish trigger: a chart-only fix bumps this without an
 # app re-tag; an app-only release bumps appVersion + a PATCH here for the new
 # default image. Starts 0.x because the values contract is not yet frozen.
-version: 0.8.2
+version: 0.9.0
 
 # appVersion tracks the GA cerberus binary. Quoted so SemVer-shaped values
 # aren't coerced to floats. image.tag defaults from this when left empty.
@@ -49,9 +49,5 @@ annotations:
   # Bump the `1.0.0` floor here when the chart raises its minimum supported
   # cerberus release; informational for Artifact Hub's compatibility hints.
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "prom: bound metadata enumeration to retention + cover always-unbounded metricMetaSQL (#1104)"
-    - kind: changed
-      description: "prom: per-series projection (proj_series) retires the metrics enumeration tier + curated projection registry (#1107)"
-    - kind: changed
-      description: "prom: serve windowless metric-name enumeration from an aggregating projection (#1105)"
+    - kind: added
+      description: "chart: bwc mode — bundled production ClickHouse on object storage (S3/GCS/Azure), no operator (#1106)"

--- a/deploy/helm/cerberus/README.md
+++ b/deploy/helm/cerberus/README.md
@@ -5,7 +5,7 @@
      pipe-aligned, and the version footer adds a trailing blank — both are
      owned by helm-docs; realigning would fight the chart-ci drift check. -->
 
-![Version: 0.8.2](https://img.shields.io/badge/Version-0.8.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.2](https://img.shields.io/badge/AppVersion-1.8.2-informational?style=flat-square)
+![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.2](https://img.shields.io/badge/AppVersion-1.8.2-informational?style=flat-square)
 
 Drop-in Prometheus / Loki / Tempo HTTP gateway for ClickHouse — a single stateless gateway that speaks three upstream query wire formats and lowers each to parameterised ClickHouse SQL.
 


### PR DESCRIPTION
Release-prep for **v1.8.2** (chart **0.9.0**), generated by `prepare-release.yml`.

- appVersion 1.8.2 -> 1.8.2, chart 0.8.2 -> 0.9.0

### Changes

### Added

- **chart:** bwc mode — bundled production ClickHouse on object storage (S3/GCS/Azure), no operator (#1106)

Generated from the conventional commits since the last tag. Review and edit before merging; the tag is cut once this lands.
