### PR TITLE
perf(traceql): bound structure-tab row source to the search trace limit (#1109)

### DIFF
--- a/internal/chplan/bounded_trace_scope.go
+++ b/internal/chplan/bounded_trace_scope.go
@@ -1,0 +1,44 @@
+package chplan
+
+// BoundedTraceScope is a predicate-position expression that renders
+//
+//	<TraceIDColumn> IN (<top-N newest root-bearing traces>)
+//
+// where the right-hand subquery ranks every root span (ParentSpanId == "")
+// in the spans table by start time (min Timestamp) descending, TraceId
+// ascending, and keeps the top TraceLimit. It is the SAME set the sibling
+// NestedSetAnnotate.TraceLimit numbers (boundedRootScopeFrag emits both), so
+// the numbering and the gated row source see an identical trace universe.
+//
+// The traceql stamping pass (stampNestedSetTraceLimit) ANDs one shared
+// BoundedTraceScope into every LEAF Filter of a structure-tab row source so
+// the structural recursive closures — seeded via the #77 seed re-render of
+// those leaves — scan only the top-N traces instead of the whole window. See
+// internal/traceql/search_limit.go (pushBoundedTraceGate) and
+// internal/chsql/nested_set_annotate.go (boundedRootScopeFrag).
+//
+// It is a PURE LEAF: it carries no embedded Node (only the column names + the
+// limit needed to re-derive the self-contained subquery at emit time), so
+// InspectExpr has nothing to recurse into and the optimizer's predicate
+// classifier treats it as an opaque, non-cheap conjunct that always stays in
+// WHERE (never promoted to PREWHERE, which cannot wrap a subquery). TraceLimit
+// is always > 0 when a BoundedTraceScope is present.
+type BoundedTraceScope struct {
+	SpansTable         string
+	TraceIDColumn      string
+	ParentSpanIDColumn string
+	TimestampColumn    string
+	TraceLimit         int64
+}
+
+func (*BoundedTraceScope) exprNode() {}
+
+func (b *BoundedTraceScope) Equal(other Expr) bool {
+	o, ok := other.(*BoundedTraceScope)
+	return ok &&
+		b.SpansTable == o.SpansTable &&
+		b.TraceIDColumn == o.TraceIDColumn &&
+		b.ParentSpanIDColumn == o.ParentSpanIDColumn &&
+		b.TimestampColumn == o.TimestampColumn &&
+		b.TraceLimit == o.TraceLimit
+}

--- a/internal/chplan/clone.go
+++ b/internal/chplan/clone.go
@@ -327,6 +327,11 @@ func cloneExpr(e Expr) Expr {
 		// Expr, not a Node child), so a node-only copy walk would miss the
 		// embedded plan subtree entirely. Copy it explicitly here.
 		return &ScalarSubquery{Input: CloneNode(v.Input)}
+	case *BoundedTraceScope:
+		// Pure leaf (column names + limit, no embedded Node) — a flat value
+		// copy, like the literals above.
+		c := *v
+		return &c
 	default:
 		panic(fmt.Sprintf("chplan.cloneExpr: unhandled Expr type %T — extend the switch in clone.go", e))
 	}

--- a/internal/chplan/walk_expr.go
+++ b/internal/chplan/walk_expr.go
@@ -33,8 +33,10 @@ func inspectExpr(e Expr, visit func(Expr) bool, nodeVisit func(Node)) {
 		return
 	}
 	switch v := e.(type) {
-	case *ColumnRef, *LitString, *InlineString, *LitInt, *LitFloat, *LitBool, *BareIdent:
-		// Leaf expressions: no sub-expressions.
+	case *ColumnRef, *LitString, *InlineString, *LitInt, *LitFloat, *LitBool, *BareIdent, *BoundedTraceScope:
+		// Leaf expressions: no sub-expressions. BoundedTraceScope carries
+		// only column names + a limit (the top-N subquery is re-derived at
+		// emit time), so it has nothing to descend into.
 	case *Binary:
 		inspectExpr(v.Left, visit, nodeVisit)
 		inspectExpr(v.Right, visit, nodeVisit)

--- a/internal/chplan/walk_expr_test.go
+++ b/internal/chplan/walk_expr_test.go
@@ -40,6 +40,7 @@ func TestInspectExprExhaustive(t *testing.T) {
 		&MapWithoutEmptyValues{},
 		&NestedArrayExists{},
 		&ScalarSubquery{},
+		&BoundedTraceScope{},
 	}
 
 	// Each listed type must be reached as a root visit without panicking,
@@ -69,11 +70,69 @@ func TestInspectExprExhaustive(t *testing.T) {
 	// switch has no default-panic), so this count forces the author to
 	// revisit both the switch AND this list. Keep it in lock-step with the
 	// number of exprNode() implementers under internal/chplan.
-	const wantExprTypes = 21
+	const wantExprTypes = 22
 	if len(all) != wantExprTypes {
 		t.Fatalf("expected %d Expr types in the exhaustiveness set, listed %d — "+
 			"a new Expr type was added: extend inspectExpr's switch in walk_expr.go AND this list",
 			wantExprTypes, len(all))
+	}
+}
+
+// TestCloneExprExhaustive guards cloneExpr's exhaustive switch (which has a
+// default-panic) against a new Expr type silently aliasing into a re-anchored
+// shard plan. Every concrete Expr type must clone without panicking and the
+// clone must be Equal to the original. The hardcoded count is in lock-step
+// with TestInspectExprExhaustive's set — both mirror the exprNode()
+// implementers, so a new type forces the author to extend BOTH switches
+// (inspectExpr AND cloneExpr).
+func TestCloneExprExhaustive(t *testing.T) {
+	t.Parallel()
+
+	all := []Expr{
+		&ColumnRef{},
+		&LitString{},
+		&InlineString{},
+		&LitInt{},
+		&LitFloat{},
+		&LitBool{},
+		&BareIdent{},
+		&Binary{},
+		&FuncCall{},
+		&InList{},
+		&FieldAccess{},
+		&MapAccess{},
+		&Subscript{},
+		&LineContent{},
+		&LabelJoin{},
+		&LabelReplace{},
+		&Lambda{},
+		&MapWithoutKeys{},
+		&MapWithoutEmptyValues{},
+		&NestedArrayExists{},
+		&ScalarSubquery{},
+		&BoundedTraceScope{},
+	}
+	const wantExprTypes = 22
+	if len(all) != wantExprTypes {
+		t.Fatalf("expected %d Expr types, listed %d — a new Expr type was added: "+
+			"extend cloneExpr's switch in clone.go AND this list", wantExprTypes, len(all))
+	}
+	// Zero-value Exprs (nil children) are fine for this check: we only assert
+	// cloneExpr handles each concrete type (no default-panic) and returns the
+	// same concrete type — NOT structural equality, which would deref the nil
+	// children. Deep-copy isolation is covered by clone_test.go's Node tests.
+	for _, e := range all {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("cloneExpr(%T) panicked: %v — extend cloneExpr's switch in clone.go", e, r)
+				}
+			}()
+			got := cloneExpr(e)
+			if reflect.TypeOf(got) != reflect.TypeOf(e) {
+				t.Errorf("cloneExpr(%T) returned %T — type not preserved", e, got)
+			}
+		}()
 	}
 }
 

--- a/internal/chsql/builder.go
+++ b/internal/chsql/builder.go
@@ -374,9 +374,25 @@ func (b *Builder) Expr(x chplan.Expr) error {
 		return b.exprSubscript(v)
 	case *chplan.ScalarSubquery:
 		return b.exprScalarSubquery(v)
+	case *chplan.BoundedTraceScope:
+		return b.exprBoundedTraceScope(v)
 	default:
 		return fmt.Errorf("%w: expr %T", ErrUnsupported, x)
 	}
+}
+
+// exprBoundedTraceScope renders `<TraceId> IN (<top-N newest root traces>)` by
+// reusing boundedRootScopeFrag — the SAME self-contained top-N subquery the
+// NestedSetAnnotate numbering anchor uses (nested_set_annotate.go), so a
+// leaf-scan gate and the numbering scope see a byte-identical trace set. The
+// subquery self-parenthesises (QueryBuilder.Frag) and InSubquery adds none, so
+// the result is the CH-idiomatic `<TraceId> IN (SELECT …)` with one paren pair.
+func (b *Builder) exprBoundedTraceScope(s *chplan.BoundedTraceScope) error {
+	InSubquery(
+		Col(s.TraceIDColumn),
+		boundedRootScopeFrag(s.SpansTable, s.TraceIDColumn, s.ParentSpanIDColumn, s.TimestampColumn, s.TraceLimit),
+	)(b)
+	return nil
 }
 
 // exprScalarSubquery renders chplan.ScalarSubquery as `(<SELECT ...>)`

--- a/internal/chsql/nested_set_annotate.go
+++ b/internal/chsql/nested_set_annotate.go
@@ -121,20 +121,34 @@ func (e *emitter) emitNestedSetAnnotate(n *chplan.NestedSetAnnotate) error {
 	if err != nil {
 		return err
 	}
-	scope, err := e.traceScopeFrag(n.Input, n.TraceIDColumn)
-	if err != nil {
-		return err
-	}
 	// When the search returns only the N newest traces, bound the numbering
-	// walk to exactly those N: rank the root spans of the scope's trace
-	// universe by Timestamp (descending, ties by TraceId ascending — the
-	// order /api/search's TruncateSummaries keeps) and keep the top N. The
-	// lowering only sets TraceLimit when the plan guarantees each returned
-	// trace's root is in the result, so this root-Timestamp ranking equals
-	// the result-min-Timestamp ranking the handler applies — the kept
-	// traces are numbered byte-identically; the excess is dropped.
+	// walk to exactly those N: rank the root spans by Timestamp (descending,
+	// ties by TraceId ascending — the order /api/search's TruncateSummaries
+	// keeps) and keep the top N. The lowering only sets TraceLimit when the
+	// plan guarantees each returned trace's root is in the result, so this
+	// root-Timestamp ranking equals the result-min-Timestamp ranking the
+	// handler applies — the kept traces are numbered byte-identically; the
+	// excess is dropped.
+	//
+	// In the bounded case the numbering scope is the SELF-CONTAINED top-N
+	// frag (boundedRootScopeFrag), NOT traceScopeFrag(n.Input): the same
+	// lowering that sets TraceLimit also pushes a BoundedTraceScope gate into
+	// every leaf of n.Input (the structural-union row source), so deriving the
+	// scope from n.Input here would (a) re-render the gate it embeds — an
+	// emit cycle — and (b) be redundant. The leaf gate emits this exact same
+	// frag, so the numbering and the row source see a byte-identical trace
+	// set, which is load-bearing: a mismatch would strand kept rows at the
+	// 0/0/0 LEFT-JOIN default. Under the gating precondition the dropped
+	// `IN traceScopeFrag(input)` conjunct was a no-op anyway (the bare-root
+	// union arm puts every root trace in that scope).
+	var scope Frag
 	if n.TraceLimit > 0 {
-		scope = boundedTraceScopeFrag(n, scope)
+		scope = boundedRootScopeFrag(n.SpansTable, n.TraceIDColumn, n.ParentSpanIDColumn, n.TimestampColumn, n.TraceLimit)
+	} else {
+		scope, err = e.traceScopeFrag(n.Input, n.TraceIDColumn)
+		if err != nil {
+			return err
+		}
 	}
 
 	numbering := buildNestedSetNumbering(n, scope)
@@ -374,39 +388,55 @@ func (e *emitter) traceScopeFrag(n chplan.Node, traceIDCol string) (Frag, error)
 	return NewQuery().Select(Col(traceIDCol)).From(sub).Frag(), nil
 }
 
-// boundedTraceScopeFrag narrows scope to the N newest traces the numbering
-// walk needs — exactly the set /api/search returns. It ranks the root spans
-// (ParentSpanId = ”) of the traces in scope by start time and keeps the top
-// n.TraceLimit:
+// boundedRootScopeFrag renders the N newest root-bearing traces directly from
+// the spans table — the set /api/search returns when it keeps the top N:
 //
 //	(SELECT `TraceId`
 //	   FROM `otel_traces`
-//	  WHERE `ParentSpanId` = '' AND `TraceId` IN <scope>
+//	  WHERE `ParentSpanId` = ''
 //	  GROUP BY `TraceId`
 //	  ORDER BY min(`Timestamp`) DESC, `TraceId` ASC
-//	  LIMIT <n.TraceLimit>)
+//	  LIMIT <limit>)
 //
-// `min(Timestamp)` per trace is the trace's start time — the same value
-// toTraceSummaries records as StartTimeUnixNano — and the DESC / TraceId-ASC
-// order matches sortSummariesStartDesc, so the n.TraceLimit traces kept here
-// are precisely the ones TruncateSummaries keeps (root-Timestamp == result-
-// min-Timestamp under lowerSelect's root-in-result gate). The GROUP BY +
-// LIMIT over the narrow root scan is linear in trace count and tiny next to
-// the numbering it bounds. QueryBuilder.Frag already parenthesises the SELECT,
-// so the anchor's `TraceId IN (...)` stays a single subquery, matching the
-// unbounded form.
-func boundedTraceScopeFrag(n *chplan.NestedSetAnnotate, scope Frag) Frag {
+// `min(Timestamp)` over a trace's ROOT spans is the root's start time, and
+// the DESC / TraceId-ASC order matches sortSummariesStartDesc. This
+// APPROXIMATES the set TruncateSummaries keeps, which ranks by
+// StartTimeUnixNano = min(Timestamp) over ALL matched result rows (root +
+// matched descendants; toTraceSummaries). The two ranking keys coincide when
+// the root is each trace's earliest matched span — true absent intra-trace
+// clock skew — so for the common case the kept set is exactly
+// TruncateSummaries'. Under skew (a matched descendant timestamped before its
+// root) the N-th boundary trace may differ; that residual is accepted to keep
+// the gate cheap — ranking by the true result-min would require materialising
+// the full result, i.e. the OOM this bound exists to prevent. The GROUP BY +
+// LIMIT over the narrow root scan keeps bounded memory (a partial top-N sort),
+// and the recursive closures it gates only ever process those N traces.
+//
+// It is SELF-CONTAINED — no `TraceId IN <input scope>` conjunct — for two
+// reasons. (1) It is referenced from two places that must agree byte-for-byte:
+// the NestedSetAnnotate numbering anchor scope AND every leaf-scan gate
+// (chplan.BoundedTraceScope) pushed into the row source; a self-contained frag
+// makes those references identical by construction, so numbering and row
+// source see the same trace set with no chance of drift stranding rows at the
+// 0/0/0 LEFT-JOIN default. (2) Referencing the input scope from a gate pushed
+// INTO that input's leaves would be an emit cycle. Dropping the conjunct is a
+// no-op under the gating precondition (inputGuaranteesRootInResult): the
+// bare-root union arm puts every root-bearing trace in the input scope, so
+// `ParentSpanId=” AND TraceId IN <input scope>` selected exactly the same
+// roots as `ParentSpanId=”` alone. Determinism (the `TraceId ASC` tie-break
+// makes the order total) is load-bearing: both references are evaluated
+// independently by ClickHouse and must yield the same N-boundary. QueryBuilder.Frag
+// already parenthesises the SELECT, so each `TraceId IN (...)` stays a single
+// subquery.
+func boundedRootScopeFrag(spansTable, traceIDCol, parentCol, tsCol string, limit int64) Frag {
 	return NewQuery().
-		Select(Col(n.TraceIDColumn)).
-		From(Col(n.SpansTable)).
-		Where(
-			Eq(Col(n.ParentSpanIDColumn), InlineLit("")),
-			InSubquery(Col(n.TraceIDColumn), scope),
-		).
-		GroupBy(Col(n.TraceIDColumn)).
-		OrderBy(Call("min", Col(n.TimestampColumn)), true).
-		OrderBy(Col(n.TraceIDColumn), false).
-		Limit(n.TraceLimit).
+		Select(Col(traceIDCol)).
+		From(Col(spansTable)).
+		Where(Eq(Col(parentCol), InlineLit(""))).
+		GroupBy(Col(traceIDCol)).
+		OrderBy(Call("min", Col(tsCol)), true).
+		OrderBy(Col(traceIDCol), false).
+		Limit(limit).
 		Frag()
 }
 

--- a/internal/chsql/nested_set_annotate_test.go
+++ b/internal/chsql/nested_set_annotate_test.go
@@ -170,12 +170,15 @@ func drilldownUnionInput() *chplan.SetOperation {
 }
 
 // TestNestedSetAnnotate_TraceLimit_BoundsAnchorScope pins the bounded
-// numbering: a non-zero TraceLimit wraps the anchor's trace-id IN scope
-// in a `GROUP BY TraceId ORDER BY min(Timestamp) DESC, TraceId LIMIT N`
-// subquery that keeps only the N newest traces — exactly the set
-// /api/search's TruncateSummaries keeps (newest by start time, ties by
-// TraceId). The rest of the numbering (recursive walk, ARRAY JOIN, window
-// passes) is unchanged; only the trace universe narrows.
+// numbering: a non-zero TraceLimit narrows the anchor's trace-id IN scope to
+// the SELF-CONTAINED top-N root subquery (`SELECT TraceId FROM otel_traces
+// WHERE ParentSpanId=” GROUP BY TraceId ORDER BY min(Timestamp) DESC,
+// TraceId ASC LIMIT N`) — exactly the set /api/search's TruncateSummaries
+// keeps (newest by start time, ties by TraceId). It is self-contained (no
+// `IN <input scope>` conjunct) so the SAME frag can gate the row-source
+// leaves (chplan.BoundedTraceScope) without an emit cycle; the
+// numbering==gate identity is pinned in
+// TestNestedSetAnnotate_TraceLimit_NumberingMatchesLeafGate.
 func TestNestedSetAnnotate_TraceLimit_BoundsAnchorScope(t *testing.T) {
 	t.Parallel()
 	n := nsAnnotateOver(drilldownUnionInput())
@@ -184,10 +187,10 @@ func TestNestedSetAnnotate_TraceLimit_BoundsAnchorScope(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Emit: %v", err)
 	}
-	// The anchor scope is wrapped in the newest-N selection. The ordering
-	// (DESC, TraceId ASC) and the GROUP BY min(Timestamp) match
+	// The anchor scope is the self-contained newest-N root selection. The
+	// ordering (DESC, TraceId ASC) and the GROUP BY min(Timestamp) match
 	// sortSummariesStartDesc / toTraceSummaries' StartTimeUnixNano.
-	wantBound := "WHERE `ParentSpanId` = '' AND `TraceId` IN (((SELECT `TraceId` FROM (SELECT * FROM `otel_traces` WHERE (`ParentSpanId` = ?))) UNION ALL (SELECT `TraceId` FROM (SELECT * FROM `otel_traces` WHERE (`SpanKind` = ?)))) UNION ALL (SELECT `TraceId` FROM (SELECT * FROM `otel_traces` WHERE (`ParentSpanId` = ?)))) GROUP BY `TraceId` ORDER BY min(`Timestamp`) DESC, `TraceId` LIMIT 200"
+	wantBound := "WHERE `ParentSpanId` = '' AND `TraceId` IN (SELECT `TraceId` FROM `otel_traces` WHERE `ParentSpanId` = '' GROUP BY `TraceId` ORDER BY min(`Timestamp`) DESC, `TraceId` LIMIT 200)"
 	if !strings.Contains(sql, wantBound) {
 		t.Errorf("bounded anchor scope missing;\nwant substring: %s\ngot:\n%s", wantBound, sql)
 	}
@@ -195,6 +198,46 @@ func TestNestedSetAnnotate_TraceLimit_BoundsAnchorScope(t *testing.T) {
 	// recursive numbering CTE still renders exactly once.
 	if got := strings.Count(sql, "WITH RECURSIVE _cerberus_ns_paths"); got != 1 {
 		t.Errorf("numbering CTE must render exactly once, got %d:\n%s", got, sql)
+	}
+}
+
+// TestNestedSetAnnotate_TraceLimit_NumberingMatchesLeafGate pins the
+// load-bearing identity: the top-N subquery the numbering anchor scope emits
+// is BYTE-IDENTICAL to the one a leaf-scan BoundedTraceScope gate emits. If
+// they ever drift, the numbering would number a different trace set than the
+// row source produces, stranding kept rows at the 0/0/0 LEFT-JOIN default.
+func TestNestedSetAnnotate_TraceLimit_NumberingMatchesLeafGate(t *testing.T) {
+	t.Parallel()
+	const topN = "(SELECT `TraceId` FROM `otel_traces` WHERE `ParentSpanId` = '' GROUP BY `TraceId` ORDER BY min(`Timestamp`) DESC, `TraceId` LIMIT 200)"
+
+	// Numbering side: a bounded NestedSetAnnotate's anchor scope.
+	n := nsAnnotateOver(drilldownUnionInput())
+	n.TraceLimit = 200
+	nsSQL, _, err := chsql.Emit(context.Background(), n)
+	if err != nil {
+		t.Fatalf("Emit numbering: %v", err)
+	}
+	if !strings.Contains(nsSQL, "`TraceId` IN "+topN) {
+		t.Errorf("numbering anchor scope does not emit the expected top-N subquery %s\ngot:\n%s", topN, nsSQL)
+	}
+
+	// Gate side: a leaf Filter carrying a BoundedTraceScope, emitted directly.
+	gated := &chplan.Filter{
+		Input: &chplan.Scan{Table: "otel_traces"},
+		Predicate: &chplan.BoundedTraceScope{
+			SpansTable:         "otel_traces",
+			TraceIDColumn:      "TraceId",
+			ParentSpanIDColumn: "ParentSpanId",
+			TimestampColumn:    "Timestamp",
+			TraceLimit:         200,
+		},
+	}
+	gateSQL, _, err := chsql.Emit(context.Background(), gated)
+	if err != nil {
+		t.Fatalf("Emit gate: %v", err)
+	}
+	if !strings.Contains(gateSQL, "`TraceId` IN "+topN) {
+		t.Errorf("leaf gate does not emit the expected top-N subquery %s\ngot:\n%s", topN, gateSQL)
 	}
 }
 

--- a/internal/optimizer/projection_pushdown.go
+++ b/internal/optimizer/projection_pushdown.go
@@ -341,10 +341,14 @@ func predicateColumns(e chplan.Expr) []string {
 }
 
 // collectColumn returns a walkExpr visitor that records every column
-// name an expression node reads into seen. Two node kinds carry one:
-// ColumnRef (by definition) and NestedArrayExists, whose Column field
+// name an expression node reads into seen. Three node kinds carry one:
+// ColumnRef (by definition), NestedArrayExists, whose Column field
 // names the Nested carrier (e.g. `Events`) as a plain string rather
-// than a child ColumnRef.
+// than a child ColumnRef, and BoundedTraceScope, whose TraceIDColumn is
+// read as the LHS of its `<TraceId> IN (...)` predicate (a bare
+// outer-scope column, not a child ColumnRef) — omitting it would let
+// ProjectionPushdown prune TraceId off the Scan beneath a gated leaf and
+// emit an UNKNOWN_IDENTIFIER (the failure mode walkExpr's own doc names).
 func collectColumn(seen map[string]struct{}) func(chplan.Expr) {
 	return func(sub chplan.Expr) {
 		switch v := sub.(type) {
@@ -352,6 +356,8 @@ func collectColumn(seen map[string]struct{}) func(chplan.Expr) {
 			seen[v.Name] = struct{}{}
 		case *chplan.NestedArrayExists:
 			seen[v.Column] = struct{}{}
+		case *chplan.BoundedTraceScope:
+			seen[v.TraceIDColumn] = struct{}{}
 		}
 	}
 }

--- a/internal/traceql/search_limit.go
+++ b/internal/traceql/search_limit.go
@@ -70,9 +70,72 @@ func stampNestedSetTraceLimit(plan chplan.Node, limit int64, s schema.Traces) ch
 	case *chplan.NestedSetAnnotate:
 		if inputGuaranteesRootInResult(v.Input, s.ParentSpanIDColumn) {
 			v.TraceLimit = limit
+			// Bound the row source too, not just the numbering. The numbering
+			// walk is bounded by TraceLimit (boundedRootScopeFrag), but the
+			// structural-union row source (v.Input) is otherwise computed over
+			// every trace in the window — two recursive closures + a wide-row
+			// UNION DISTINCT — and only truncated to N afterward, peaking past
+			// the per-query memory cap (#1109 prod OOM). Push one shared
+			// BoundedTraceScope gate into every leaf so the closures (seeded
+			// via the #77 seed re-render of those leaves) scan only the top-N
+			// traces — the IDENTICAL set the numbering uses, so no kept row is
+			// stranded at the 0/0/0 LEFT-JOIN default. Gating here, inside the
+			// same precondition that sets TraceLimit, keeps the two bounds in
+			// lock-step (they can never fire on different shapes).
+			gate := &chplan.BoundedTraceScope{
+				SpansTable:         v.SpansTable,
+				TraceIDColumn:      v.TraceIDColumn,
+				ParentSpanIDColumn: v.ParentSpanIDColumn,
+				TimestampColumn:    v.TimestampColumn,
+				TraceLimit:         limit,
+			}
+			v.Input = pushBoundedTraceGate(v.Input, gate)
 		}
 	}
 	return plan
+}
+
+// pushBoundedTraceGate ANDs gate into every leaf Filter/Scan of a
+// NestedSetAnnotate row source. The bare-root union arm and both structural
+// arms (whose recursive closures are seeded by the #77 seed re-render of their
+// leaf subtree) each become `... AND TraceId IN (topN)`, bounding the closures
+// to the top-N traces instead of the whole window. The same immutable gate
+// pointer is shared across all leaves, so every leaf emits identical SQL.
+//
+// The recursion mirrors the node families a select()-with-nested-set row
+// source can produce (the union/structural/project/limit spine over
+// Filter(Scan) / Scan leaves); isRootSpanFilter looks through a passthrough
+// Project, so recursing Project.Input here gates the re-projected bare-root arm
+// too. Any other node is left untouched (the gate only needs to reach the
+// scans that seed the closures).
+func pushBoundedTraceGate(n chplan.Node, gate chplan.Expr) chplan.Node {
+	switch v := n.(type) {
+	case *chplan.Filter:
+		if _, ok := v.Input.(*chplan.Scan); ok {
+			v.Predicate = conjoin(v.Predicate, gate)
+			return v
+		}
+		v.Input = pushBoundedTraceGate(v.Input, gate)
+		return v
+	case *chplan.Scan:
+		return &chplan.Filter{Input: v, Predicate: gate}
+	case *chplan.StructuralJoin:
+		v.Left = pushBoundedTraceGate(v.Left, gate)
+		v.Right = pushBoundedTraceGate(v.Right, gate)
+		return v
+	case *chplan.SetOperation:
+		v.Left = pushBoundedTraceGate(v.Left, gate)
+		v.Right = pushBoundedTraceGate(v.Right, gate)
+		return v
+	case *chplan.Project:
+		v.Input = pushBoundedTraceGate(v.Input, gate)
+		return v
+	case *chplan.Limit:
+		v.Input = pushBoundedTraceGate(v.Input, gate)
+		return v
+	default:
+		return n
+	}
 }
 
 // inputGuaranteesRootInResult reports whether every trace n emits is
@@ -80,18 +143,64 @@ func stampNestedSetTraceLimit(plan chplan.Node, limit int64, s schema.Traces) ch
 // the precondition for bounding the numbering walk by root-span Timestamp.
 //
 // The recognised shape is the Grafana Traces Drilldown structure-tab input:
-// a `||` SetOperation one of whose arms is a bare root-span filter
+// a `||` SetOperation where (1) one arm is a bare root-span filter
 // (`{ nestedSetParent < 0 }`, lowered to Filter(ParentSpanId = "") over a
-// Scan, optionally re-projected). The union re-adds every matched trace's
-// root, so result-min(Timestamp) per trace == root.Timestamp. This is the
-// only OOM-prone shape; gating on it keeps the bound exact-parity-safe by
-// construction and leaves all other selects unbounded.
+// Scan, optionally re-projected) — which re-adds every trace's root — and
+// (2) BOTH arms emit only spans belonging to root-bearing traces, so every
+// trace in the result carries its root.
+//
+// Requirement (2) is load-bearing for the bound's correctness, not just its
+// optimality: the bound (numbering scope + the BoundedTraceScope row-source
+// gate) ranks/keeps traces by their ROOT span, so any trace admitted to the
+// result WITHOUT a root span (e.g. a `{ kind = server }` arm matching a
+// rootless trace under sampling / ingest lag) would be silently dropped by
+// the gate — a wrong result, not a boundary reorder. Gating on (2) keeps the
+// result set faithful: every admitted trace has a root, and the only residual
+// approximation is the start-time RANKING (root-span vs result-min Timestamp;
+// see boundedRootScopeFrag), which only shuffles the kept set at the N-th
+// boundary under intra-trace clock skew.
+//
+// A non-bare-root arm is root-bearing-only when it is a POSITIVE
+// descendant/child structural join seeded from a root filter
+// (`{ root } &>> { x }` / `>>` / `&>` / `>`): every span it emits descends
+// from a root, so its trace is root-bearing. Negated / ancestor / parent /
+// sibling arms make no such guarantee and leave the select unbounded.
 func inputGuaranteesRootInResult(n chplan.Node, parentSpanIDCol string) bool {
 	set, ok := n.(*chplan.SetOperation)
 	if !ok || set.Op != chplan.SetUnion {
 		return false
 	}
-	return isRootSpanFilter(set.Left, parentSpanIDCol) || isRootSpanFilter(set.Right, parentSpanIDCol)
+	leftRoot := isRootSpanFilter(set.Left, parentSpanIDCol)
+	rightRoot := isRootSpanFilter(set.Right, parentSpanIDCol)
+	if !leftRoot && !rightRoot {
+		return false // no arm re-adds the roots
+	}
+	return armEmitsOnlyRootBearingTraces(set.Left, parentSpanIDCol) &&
+		armEmitsOnlyRootBearingTraces(set.Right, parentSpanIDCol)
+}
+
+// armEmitsOnlyRootBearingTraces reports whether every span n emits belongs to
+// a trace that carries a root span (ParentSpanId = "") — the per-arm half of
+// inputGuaranteesRootInResult. Two shapes qualify: a bare root-span filter
+// (it emits roots), and a positive descendant/child structural join whose
+// ANCESTOR side (Left) is a root filter (every emitted span descends from a
+// root, and union forms also re-emit those roots). Any other shape — a bare
+// non-root filter, a negated/ancestor/parent/sibling structural join, a
+// nested set-op — is conservatively rejected.
+func armEmitsOnlyRootBearingTraces(n chplan.Node, parentSpanIDCol string) bool {
+	if isRootSpanFilter(n, parentSpanIDCol) {
+		return true
+	}
+	sj, ok := n.(*chplan.StructuralJoin)
+	if !ok || sj.Op.IsNegated() {
+		return false
+	}
+	switch sj.Op.Positive() {
+	case chplan.StructuralDescendant, chplan.StructuralChild:
+		return isRootSpanFilter(sj.Left, parentSpanIDCol)
+	default:
+		return false
+	}
 }
 
 // isRootSpanFilter reports whether n is a root-span filter

--- a/internal/traceql/search_limit_test.go
+++ b/internal/traceql/search_limit_test.go
@@ -46,6 +46,33 @@ func findNestedSetAnnotate(t *testing.T, n chplan.Node) *chplan.NestedSetAnnotat
 
 const drilldownStructureQuery = `({ nestedSetParent < 0 } &>> { kind = server }) || ({ nestedSetParent < 0 }) | select(status, name, nestedSetParent, nestedSetLeft, nestedSetRight)`
 
+// boundedTraceGates collects every chplan.BoundedTraceScope conjunct reachable
+// from the leaf Filter predicates of n (walking the row-source spine + the
+// conjunction tree of each Filter). Used to assert the row-source bound is
+// stamped (or declined) in lock-step with NestedSetAnnotate.TraceLimit.
+func boundedTraceGates(n chplan.Node) []*chplan.BoundedTraceScope {
+	var out []*chplan.BoundedTraceScope
+	var walkNode func(chplan.Node)
+	walkNode = func(n chplan.Node) {
+		if n == nil {
+			return
+		}
+		if f, ok := n.(*chplan.Filter); ok {
+			chplan.InspectExpr(f.Predicate, func(e chplan.Expr) bool {
+				if g, ok := e.(*chplan.BoundedTraceScope); ok {
+					out = append(out, g)
+				}
+				return true
+			})
+		}
+		for _, c := range n.Children() {
+			walkNode(c)
+		}
+	}
+	walkNode(n)
+	return out
+}
+
 // TestSearchLimit_StampsDrilldownShape verifies the Drilldown structure
 // query (union with a root-filter arm) gets its NestedSetAnnotate bounded
 // to the search limit, so the numbering walk only numbers the returned N.
@@ -54,6 +81,27 @@ func TestSearchLimit_StampsDrilldownShape(t *testing.T) {
 	ns := findNestedSetAnnotate(t, lowerSearch(t, drilldownStructureQuery, 200))
 	if ns.TraceLimit != 200 {
 		t.Fatalf("TraceLimit = %d, want 200 (Drilldown shape must be bounded)", ns.TraceLimit)
+	}
+	// The row source must be bounded too: one BoundedTraceScope gate per leaf
+	// scan. The structure shape has three leaves (the `&>>` arm's two scans +
+	// the bare-root `||` arm), so the numbering bound AND the closure bound
+	// both fire. Every gate must carry the SAME params as the annotate node,
+	// so the leaf gate and the numbering scope emit the identical top-N set.
+	gates := boundedTraceGates(ns.Input)
+	if len(gates) != 3 {
+		t.Fatalf("got %d BoundedTraceScope leaf gates, want 3 (one per row-source leaf scan)", len(gates))
+	}
+	want := &chplan.BoundedTraceScope{
+		SpansTable:         ns.SpansTable,
+		TraceIDColumn:      ns.TraceIDColumn,
+		ParentSpanIDColumn: ns.ParentSpanIDColumn,
+		TimestampColumn:    ns.TimestampColumn,
+		TraceLimit:         ns.TraceLimit,
+	}
+	for i, g := range gates {
+		if !g.Equal(want) {
+			t.Errorf("gate[%d] = %+v, want %+v (must match the annotate node so numbering==row-source set)", i, g, want)
+		}
 	}
 }
 
@@ -65,6 +113,11 @@ func TestSearchLimit_UnboundedWithoutLimit(t *testing.T) {
 	ns := findNestedSetAnnotate(t, lowerSearch(t, drilldownStructureQuery, 0))
 	if ns.TraceLimit != 0 {
 		t.Fatalf("TraceLimit = %d, want 0 (no ctx limit ⇒ unbounded)", ns.TraceLimit)
+	}
+	// No limit ⇒ no row-source gate either; the two bounds are stamped in
+	// lock-step inside the same precondition branch.
+	if gates := boundedTraceGates(ns.Input); len(gates) != 0 {
+		t.Fatalf("got %d BoundedTraceScope gates, want 0 (no ctx limit ⇒ unbounded row source)", len(gates))
 	}
 }
 
@@ -81,6 +134,31 @@ func TestSearchLimit_NonGuaranteedRootStaysUnbounded(t *testing.T) {
 	ns := findNestedSetAnnotate(t, lowerSearch(t, q, 200))
 	if ns.TraceLimit != 0 {
 		t.Fatalf("TraceLimit = %d, want 0 (non-root-guaranteed shape must stay unbounded)", ns.TraceLimit)
+	}
+	// The gate must decline on the SAME precondition as TraceLimit — the two
+	// can never fire on different shapes (a bounded row source under an
+	// unbounded numbering would strand rows at 0/0/0).
+	if gates := boundedTraceGates(ns.Input); len(gates) != 0 {
+		t.Fatalf("got %d BoundedTraceScope gates, want 0 (non-root-guaranteed shape must stay unbounded)", len(gates))
+	}
+}
+
+// TestSearchLimit_RootlessAdmittingUnionStaysUnbounded pins the D4b
+// correctness gate: a `||` union whose non-bare-root arm is a plain
+// `{ kind = server }` filter (NOT a root-seeded structural join) can admit
+// rootless traces to the result via that arm. Bounding such a shape would let
+// the root-keyed gate silently DROP those rootless traces — a wrong result,
+// not a boundary reorder. inputGuaranteesRootInResult must therefore decline
+// it: neither TraceLimit nor any BoundedTraceScope gate may be stamped.
+func TestSearchLimit_RootlessAdmittingUnionStaysUnbounded(t *testing.T) {
+	t.Parallel()
+	const q = `({ nestedSetParent < 0 }) || ({ kind = server }) | select(status, nestedSetParent, nestedSetLeft, nestedSetRight)`
+	ns := findNestedSetAnnotate(t, lowerSearch(t, q, 200))
+	if ns.TraceLimit != 0 {
+		t.Fatalf("TraceLimit = %d, want 0 (root || server admits rootless traces — must stay unbounded)", ns.TraceLimit)
+	}
+	if gates := boundedTraceGates(ns.Input); len(gates) != 0 {
+		t.Fatalf("got %d BoundedTraceScope gates, want 0 (rootless-admitting union must not be gated)", len(gates))
 	}
 }
 

--- a/test/perf/cardinality-baseline.json
+++ b/test/perf/cardinality-baseline.json
@@ -6702,12 +6702,12 @@
   {
     "fixture": "traceql/select_nested_set_drilldown_limited",
     "fan_factor": 1,
-    "scan_rows": 12,
-    "peak_intermediate": 12,
+    "scan_rows": 6,
+    "peak_intermediate": 6,
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": true,
-    "max_recursion_depth": 8
+    "max_recursion_depth": 4
   },
   {
     "fixture": "traceql/select_nested_set_drilldown_structure",
@@ -6718,6 +6718,16 @@
     "has_array_join": true,
     "has_recursive_cte": true,
     "max_recursion_depth": 2
+  },
+  {
+    "fixture": "traceql/select_nested_set_drilldown_unbounded_noop",
+    "fan_factor": 1,
+    "scan_rows": 12,
+    "peak_intermediate": 12,
+    "has_cross_join": false,
+    "has_array_join": true,
+    "has_recursive_cte": true,
+    "max_recursion_depth": 8
   },
   {
     "fixture": "traceql/select_nested_set_structural",

--- a/test/spec/chplan_print.go
+++ b/test/spec/chplan_print.go
@@ -613,6 +613,11 @@ func printExpr(e chplan.Expr) string {
 		flat := strings.TrimRight(sb.String(), "\n")
 		flat = strings.Join(strings.Fields(strings.ReplaceAll(flat, "\n", " ; ")), " ")
 		return fmt.Sprintf("scalarSubquery{%s}", flat)
+	case *chplan.BoundedTraceScope:
+		// One-line greppable form: the gate shows on each leaf Filter of a
+		// bounded structure-tab row source so the IR snapshot proves the
+		// closures are seeded from the top-N set, not the whole window.
+		return fmt.Sprintf("(%s IN topNewestRootTraces(%d))", v.TraceIDColumn, v.TraceLimit)
 	default:
 		return fmt.Sprintf("<unknown:%T>", e)
 	}

--- a/test/spec/traceql/select_nested_set_drilldown_limited.txtar
+++ b/test/spec/traceql/select_nested_set_drilldown_limited.txtar
@@ -1,23 +1,28 @@
-The #103 memory bound: the Grafana Traces Drilldown structure-tab query
-numbers EVERY span of EVERY matched trace, peaking past the per-query
-memory cap when `{nestedSetParent<0}` matches all roots. But /api/search
-only RETURNS the newest N traces (TruncateSummaries, default 20, Drilldown
-sends 200), so numbering all of them is wasted work.
+The #1109 memory bound: the Grafana Traces Drilldown structure-tab query
+builds its row source (two recursive structural closures + a wide-row
+UNION DISTINCT) over EVERY matched trace, peaking past the per-query memory
+cap when `{nestedSetParent<0}` matches all roots. But /api/search only
+RETURNS the newest N traces (TruncateSummaries, default 20, Drilldown sends
+200), so processing all of them is wasted work — and the prod OOM.
 
-This fixture pins the bound: with `search_limit: 2`, the NestedSetAnnotate
-carries TraceLimit=2, and the numbering anchor scope is narrowed to the 2
-newest traces by root-span Timestamp (DESC, TraceId ASC — exactly
-TruncateSummaries' selection). Spans of the 2 OLDER traces still appear in
-the result (the `m` arm is unbounded) but with nested-set columns 0/0/0
-(LEFT JOIN miss) — and the search response discards those traces anyway.
+This fixture pins BOTH halves of the bound. With `search_limit: 2`, the
+NestedSetAnnotate carries TraceLimit=2: (1) the numbering anchor scope is
+narrowed to the 2 newest traces by root-span Timestamp (DESC, TraceId ASC),
+which approximates TruncateSummaries' selection — exact absent intra-trace
+clock skew, as in this skew-free seed — and (2) a BoundedTraceScope gate
+(`TraceId IN topNewestRootTraces(2)`) is pushed into every LEAF scan of the
+row source, so the structural closures — seeded via the #77 seed re-render
+of those leaves — only ever process those 2 traces. The gate and the
+numbering scope emit the byte-identical top-N subquery, so they see the same
+trace set: no kept row is stranded at the 0/0/0 LEFT-JOIN default.
 
-Seed: four single-root traces, each root (Server) with one Server child,
-at increasing root timestamps a < b < c < d. The query returns each
-trace's root (via the `||{nestedSetParent<0}` arm) plus its Server
-descendant (via the `&>> {kind=server}` arm). The 2 newest (c, d) get
-numbered (root 1,4,-1; child 2,3,1); the 2 oldest (a, b) come back 0/0/0.
-This proves the bound drops older traces from numbering AND the kept
-traces are numbered byte-identically to the unbounded shape.
+Seed: four single-root traces, each root (Server) with one Server child, at
+increasing root timestamps a < b < c < d. The query returns each trace's
+root (via the `||{nestedSetParent<0}` arm) plus its Server descendant (via
+the `&>> {kind=server}` arm). Only the 2 newest (c, d) appear AT ALL, each
+fully numbered (root -1,1,4; child 1,2,3); the 2 oldest (a, b) are dropped
+entirely from the row source — proving the bound caps the closures, not just
+the numbering. (Before the gate, a, b leaked into the result at 0/0/0.)
 
 -- search_limit --
 2
@@ -38,7 +43,7 @@ CREATE TABLE otel_traces (
     ScopeVersion String,
     SpanAttributes Map(String, String),
     ResourceAttributes Map(String, String)
-) ENGINE = Memory;
+) ENGINE = MergeTree ORDER BY (Timestamp, SpanId);
 INSERT INTO otel_traces VALUES
     ('a0000000000000000000000000000001', '1000000000000001', '', 'root', 'Server', 100, toDateTime64('2026-01-01 00:00:00.000000001', 9), 'Unset', '', '', '', map(), map()),
     ('a0000000000000000000000000000001', '1000000000000002', '1000000000000001', 'child', 'Server', 50, toDateTime64('2026-01-01 00:00:00.000000002', 9), 'Unset', '', '', '', map(), map()),
@@ -50,10 +55,6 @@ INSERT INTO otel_traces VALUES
     ('d0000000000000000000000000000001', '4000000000000002', '4000000000000001', 'child', 'Server', 50, toDateTime64('2026-01-01 00:00:03.000000002', 9), 'Unset', '', '', '', map(), map());
 -- expected_rows --
 [
-  ["a0000000000000000000000000000001", "1000000000000001", "2026-01-01T00:00:00.000000001Z", 0, 0, 0],
-  ["a0000000000000000000000000000001", "1000000000000002", "2026-01-01T00:00:00.000000002Z", 0, 0, 0],
-  ["b0000000000000000000000000000001", "2000000000000001", "2026-01-01T00:00:01.000000001Z", 0, 0, 0],
-  ["b0000000000000000000000000000001", "2000000000000002", "2026-01-01T00:00:01.000000002Z", 0, 0, 0],
   ["c0000000000000000000000000000001", "3000000000000001", "2026-01-01T00:00:02.000000001Z", -1, 1, 4],
   ["c0000000000000000000000000000001", "3000000000000002", "2026-01-01T00:00:02.000000002Z", 1, 2, 3],
   ["d0000000000000000000000000000001", "4000000000000001", "2026-01-01T00:00:03.000000001Z", -1, 1, 4],
@@ -67,20 +68,17 @@ INSERT INTO otel_traces VALUES
 [4] string = "Server"
 [5] string = "Server"
 [6] string = ""
-[7] string = ""
-[8] string = "Server"
-[9] string = ""
 -- chplan --
 Project [TraceId, SpanId, Timestamp, __cerberus_ns_parent AS nestedSetParent, __cerberus_ns_left AS nestedSetLeft, __cerberus_ns_right AS nestedSetRight]
   NestedSetAnnotate table=otel_traces traceLimit=2
     SetOperation op=||
       StructuralJoin op=&>> maxDepth=128
-        Filter predicate=(ParentSpanId = "")
+        Filter predicate=((ParentSpanId = "") AND (TraceId IN topNewestRootTraces(2)))
           Scan(otel_traces)
-        Filter predicate=(SpanKind = "Server")
+        Filter predicate=((SpanKind = "Server") AND (TraceId IN topNewestRootTraces(2)))
           Scan(otel_traces)
       Project [TraceId, SpanId, ParentSpanId, SpanName, Duration, Timestamp, ResourceAttributes, SpanAttributes, StatusCode, StatusMessage, SpanKind, ScopeName, ScopeVersion]
-        Filter predicate=(ParentSpanId = "")
+        Filter predicate=((ParentSpanId = "") AND (TraceId IN topNewestRootTraces(2)))
           Scan(otel_traces)
 -- sql --
-SELECT `TraceId`, `SpanId`, `Timestamp`, `__cerberus_ns_parent` AS `nestedSetParent`, `__cerberus_ns_left` AS `nestedSetLeft`, `__cerberus_ns_right` AS `nestedSetRight` FROM (SELECT m.*, ifNull(`ns`.`_ns_left`, 0) AS `__cerberus_ns_left`, ifNull(`ns`.`_ns_right`, 0) AS `__cerberus_ns_right`, ifNull(`ns`.`_ns_parent`, 0) AS `__cerberus_ns_parent` FROM (SELECT * FROM (((SELECT R.`TraceId` AS `TraceId`, R.`SpanId` AS `SpanId`, R.`ParentSpanId` AS `ParentSpanId`, R.`SpanName` AS `SpanName`, R.`Duration` AS `Duration`, R.`Timestamp` AS `Timestamp`, R.`ResourceAttributes` AS `ResourceAttributes`, R.`SpanAttributes` AS `SpanAttributes`, R.`StatusCode` AS `StatusCode`, R.`StatusMessage` AS `StatusMessage`, R.`SpanKind` AS `SpanKind`, R.`ScopeName` AS `ScopeName`, R.`ScopeVersion` AS `ScopeVersion` FROM (WITH RECURSIVE _struct_closure_1 AS (SELECT DISTINCT `TraceId`, `SpanId`, `ParentSpanId`, 0 AS _depth FROM (SELECT * FROM `otel_traces` WHERE (`ParentSpanId` = ?)) AS _seed UNION ALL SELECT DISTINCT t.`TraceId`, t.`SpanId`, t.`ParentSpanId`, c._depth + 1 FROM `otel_traces` AS t INNER JOIN _struct_closure_1 AS c ON t.`TraceId` = c.`TraceId` AND t.`ParentSpanId` = c.`SpanId` WHERE c._depth < 128 AND t.`TraceId` IN (SELECT `TraceId` FROM (SELECT * FROM `otel_traces` WHERE (`ParentSpanId` = ?)) AS _seed_ids)) SELECT DISTINCT `TraceId`, `SpanId` FROM _struct_closure_1 WHERE _depth > 0) AS L INNER JOIN (SELECT * FROM `otel_traces` WHERE (`SpanKind` = ?)) AS R ON L.`TraceId` = R.`TraceId` AND L.`SpanId` = R.`SpanId`) UNION DISTINCT (SELECT L.`TraceId` AS `TraceId`, L.`SpanId` AS `SpanId`, L.`ParentSpanId` AS `ParentSpanId`, L.`SpanName` AS `SpanName`, L.`Duration` AS `Duration`, L.`Timestamp` AS `Timestamp`, L.`ResourceAttributes` AS `ResourceAttributes`, L.`SpanAttributes` AS `SpanAttributes`, L.`StatusCode` AS `StatusCode`, L.`StatusMessage` AS `StatusMessage`, L.`SpanKind` AS `SpanKind`, L.`ScopeName` AS `ScopeName`, L.`ScopeVersion` AS `ScopeVersion` FROM (SELECT * FROM `otel_traces` WHERE (`ParentSpanId` = ?)) AS L INNER JOIN (WITH RECURSIVE _struct_closure_inv_2 AS (SELECT DISTINCT `TraceId`, `SpanId`, `ParentSpanId`, 0 AS _depth FROM (SELECT * FROM `otel_traces` WHERE (`SpanKind` = ?)) AS _seed UNION ALL SELECT DISTINCT t.`TraceId`, t.`SpanId`, t.`ParentSpanId`, c._depth + 1 FROM `otel_traces` AS t INNER JOIN _struct_closure_inv_2 AS c ON t.`TraceId` = c.`TraceId` AND t.`SpanId` = c.`ParentSpanId` WHERE c._depth < 128 AND t.`TraceId` IN (SELECT `TraceId` FROM (SELECT * FROM `otel_traces` WHERE (`SpanKind` = ?)) AS _seed_ids)) SELECT DISTINCT `TraceId`, `SpanId` FROM _struct_closure_inv_2 WHERE _depth > 0) AS R ON L.`TraceId` = R.`TraceId` AND L.`SpanId` = R.`SpanId`)) UNION ALL (SELECT `TraceId`, `SpanId`, `ParentSpanId`, `SpanName`, `Duration`, `Timestamp`, `ResourceAttributes`, `SpanAttributes`, `StatusCode`, `StatusMessage`, `SpanKind`, `ScopeName`, `ScopeVersion` FROM (SELECT * FROM `otel_traces` WHERE (`ParentSpanId` = ?)))) LIMIT 1 BY `TraceId`, `SpanId`) AS m LEFT JOIN (WITH RECURSIVE _cerberus_ns_paths AS (SELECT `TraceId`, `SpanId`, `ParentSpanId`, concat(leftPad(toString(toUnixTimestamp64Nano(`Timestamp`)), 20, '0'), leftPad(toString(sipHash64(`SpanId`)), 20, '0')) AS `_path`, 0 AS `_depth` FROM `otel_traces` WHERE `ParentSpanId` = '' AND `TraceId` IN (SELECT `TraceId` FROM `otel_traces` WHERE `ParentSpanId` = '' AND `TraceId` IN (((SELECT `TraceId` FROM (SELECT * FROM `otel_traces` WHERE (`ParentSpanId` = ?))) UNION ALL (SELECT `TraceId` FROM (SELECT * FROM `otel_traces` WHERE (`SpanKind` = ?)))) UNION ALL (SELECT `TraceId` FROM (SELECT * FROM `otel_traces` WHERE (`ParentSpanId` = ?)))) GROUP BY `TraceId` ORDER BY min(`Timestamp`) DESC, `TraceId` LIMIT 2) UNION ALL SELECT t.`TraceId`, t.`SpanId`, t.`ParentSpanId`, concat(c.`_path`, concat(leftPad(toString(toUnixTimestamp64Nano(`t`.`Timestamp`)), 20, '0'), leftPad(toString(sipHash64(`t`.`SpanId`)), 20, '0'))), c.`_depth` + 1 AS `_depth` FROM `otel_traces` AS t INNER JOIN `_cerberus_ns_paths` AS c ON t.`TraceId` = c.`TraceId` AND t.`ParentSpanId` = c.`SpanId` WHERE c._depth < 128) SELECT `TraceId`, `SpanId`, toInt64(maxIf(`_erank`, `_etype` = 0)) AS `_ns_left`, toInt64(maxIf(`_erank`, `_etype` = 2)) AS `_ns_right`, if(countIf(`_etype` = 1) = 0, toInt64(-1), toInt64(maxIf(`_keyrank`, `_etype` = 1))) AS `_ns_parent` FROM (SELECT `TraceId`, `SpanId`, `_etype`, `_erank`, first_value(`_erank`) OVER (PARTITION BY `TraceId`, `_ekey` ORDER BY `_etype` ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS `_keyrank` FROM (SELECT `TraceId`, `SpanId`, `_ekey`, `_etype`, sum(`_etype` != 1) OVER (PARTITION BY `TraceId` ORDER BY `_ekey` ASC, `_etype` ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS `_erank` FROM (SELECT `TraceId`, `SpanId`, `_ev`.1 AS `_ekey`, `_ev`.2 AS `_etype` FROM `_cerberus_ns_paths` ARRAY JOIN arrayFilter(e -> NOT (e.2 = 1 AND e.1 = ''), [(`_path`, 0), (concat(`_path`, '~'), 2), (substring(`_path`, 1, length(`_path`) - 40), 1)]) AS `_ev`))) GROUP BY `TraceId`, `SpanId`) AS ns ON m.`TraceId` = ns.`TraceId` AND m.`SpanId` = ns.`SpanId`)
+SELECT `TraceId`, `SpanId`, `Timestamp`, `__cerberus_ns_parent` AS `nestedSetParent`, `__cerberus_ns_left` AS `nestedSetLeft`, `__cerberus_ns_right` AS `nestedSetRight` FROM (SELECT m.*, ifNull(`ns`.`_ns_left`, 0) AS `__cerberus_ns_left`, ifNull(`ns`.`_ns_right`, 0) AS `__cerberus_ns_right`, ifNull(`ns`.`_ns_parent`, 0) AS `__cerberus_ns_parent` FROM (SELECT * FROM (((SELECT R.`TraceId` AS `TraceId`, R.`SpanId` AS `SpanId`, R.`ParentSpanId` AS `ParentSpanId`, R.`SpanName` AS `SpanName`, R.`Duration` AS `Duration`, R.`Timestamp` AS `Timestamp`, R.`ResourceAttributes` AS `ResourceAttributes`, R.`SpanAttributes` AS `SpanAttributes`, R.`StatusCode` AS `StatusCode`, R.`StatusMessage` AS `StatusMessage`, R.`SpanKind` AS `SpanKind`, R.`ScopeName` AS `ScopeName`, R.`ScopeVersion` AS `ScopeVersion` FROM (WITH RECURSIVE _struct_closure_1 AS (SELECT DISTINCT `TraceId`, `SpanId`, `ParentSpanId`, 0 AS _depth FROM (SELECT * FROM `otel_traces` PREWHERE (`ParentSpanId` = ?) WHERE `TraceId` IN (SELECT `TraceId` FROM `otel_traces` WHERE `ParentSpanId` = '' GROUP BY `TraceId` ORDER BY min(`Timestamp`) DESC, `TraceId` LIMIT 2)) AS _seed UNION ALL SELECT DISTINCT t.`TraceId`, t.`SpanId`, t.`ParentSpanId`, c._depth + 1 FROM `otel_traces` AS t INNER JOIN _struct_closure_1 AS c ON t.`TraceId` = c.`TraceId` AND t.`ParentSpanId` = c.`SpanId` WHERE c._depth < 128 AND t.`TraceId` IN (SELECT `TraceId` FROM (SELECT * FROM `otel_traces` PREWHERE (`ParentSpanId` = ?) WHERE `TraceId` IN (SELECT `TraceId` FROM `otel_traces` WHERE `ParentSpanId` = '' GROUP BY `TraceId` ORDER BY min(`Timestamp`) DESC, `TraceId` LIMIT 2)) AS _seed_ids)) SELECT DISTINCT `TraceId`, `SpanId` FROM _struct_closure_1 WHERE _depth > 0) AS L INNER JOIN (SELECT * FROM `otel_traces` PREWHERE (`SpanKind` = ?) WHERE `TraceId` IN (SELECT `TraceId` FROM `otel_traces` WHERE `ParentSpanId` = '' GROUP BY `TraceId` ORDER BY min(`Timestamp`) DESC, `TraceId` LIMIT 2)) AS R ON L.`TraceId` = R.`TraceId` AND L.`SpanId` = R.`SpanId`) UNION DISTINCT (SELECT L.`TraceId` AS `TraceId`, L.`SpanId` AS `SpanId`, L.`ParentSpanId` AS `ParentSpanId`, L.`SpanName` AS `SpanName`, L.`Duration` AS `Duration`, L.`Timestamp` AS `Timestamp`, L.`ResourceAttributes` AS `ResourceAttributes`, L.`SpanAttributes` AS `SpanAttributes`, L.`StatusCode` AS `StatusCode`, L.`StatusMessage` AS `StatusMessage`, L.`SpanKind` AS `SpanKind`, L.`ScopeName` AS `ScopeName`, L.`ScopeVersion` AS `ScopeVersion` FROM (SELECT * FROM `otel_traces` PREWHERE (`ParentSpanId` = ?) WHERE `TraceId` IN (SELECT `TraceId` FROM `otel_traces` WHERE `ParentSpanId` = '' GROUP BY `TraceId` ORDER BY min(`Timestamp`) DESC, `TraceId` LIMIT 2)) AS L INNER JOIN (WITH RECURSIVE _struct_closure_inv_2 AS (SELECT DISTINCT `TraceId`, `SpanId`, `ParentSpanId`, 0 AS _depth FROM (SELECT * FROM `otel_traces` PREWHERE (`SpanKind` = ?) WHERE `TraceId` IN (SELECT `TraceId` FROM `otel_traces` WHERE `ParentSpanId` = '' GROUP BY `TraceId` ORDER BY min(`Timestamp`) DESC, `TraceId` LIMIT 2)) AS _seed UNION ALL SELECT DISTINCT t.`TraceId`, t.`SpanId`, t.`ParentSpanId`, c._depth + 1 FROM `otel_traces` AS t INNER JOIN _struct_closure_inv_2 AS c ON t.`TraceId` = c.`TraceId` AND t.`SpanId` = c.`ParentSpanId` WHERE c._depth < 128 AND t.`TraceId` IN (SELECT `TraceId` FROM (SELECT * FROM `otel_traces` PREWHERE (`SpanKind` = ?) WHERE `TraceId` IN (SELECT `TraceId` FROM `otel_traces` WHERE `ParentSpanId` = '' GROUP BY `TraceId` ORDER BY min(`Timestamp`) DESC, `TraceId` LIMIT 2)) AS _seed_ids)) SELECT DISTINCT `TraceId`, `SpanId` FROM _struct_closure_inv_2 WHERE _depth > 0) AS R ON L.`TraceId` = R.`TraceId` AND L.`SpanId` = R.`SpanId`)) UNION ALL (SELECT `TraceId`, `SpanId`, `ParentSpanId`, `SpanName`, `Duration`, `Timestamp`, `ResourceAttributes`, `SpanAttributes`, `StatusCode`, `StatusMessage`, `SpanKind`, `ScopeName`, `ScopeVersion` FROM (SELECT * FROM `otel_traces` PREWHERE (`ParentSpanId` = ?) WHERE `TraceId` IN (SELECT `TraceId` FROM `otel_traces` WHERE `ParentSpanId` = '' GROUP BY `TraceId` ORDER BY min(`Timestamp`) DESC, `TraceId` LIMIT 2)))) LIMIT 1 BY `TraceId`, `SpanId`) AS m LEFT JOIN (WITH RECURSIVE _cerberus_ns_paths AS (SELECT `TraceId`, `SpanId`, `ParentSpanId`, concat(leftPad(toString(toUnixTimestamp64Nano(`Timestamp`)), 20, '0'), leftPad(toString(sipHash64(`SpanId`)), 20, '0')) AS `_path`, 0 AS `_depth` FROM `otel_traces` WHERE `ParentSpanId` = '' AND `TraceId` IN (SELECT `TraceId` FROM `otel_traces` WHERE `ParentSpanId` = '' GROUP BY `TraceId` ORDER BY min(`Timestamp`) DESC, `TraceId` LIMIT 2) UNION ALL SELECT t.`TraceId`, t.`SpanId`, t.`ParentSpanId`, concat(c.`_path`, concat(leftPad(toString(toUnixTimestamp64Nano(`t`.`Timestamp`)), 20, '0'), leftPad(toString(sipHash64(`t`.`SpanId`)), 20, '0'))), c.`_depth` + 1 AS `_depth` FROM `otel_traces` AS t INNER JOIN `_cerberus_ns_paths` AS c ON t.`TraceId` = c.`TraceId` AND t.`ParentSpanId` = c.`SpanId` WHERE c._depth < 128) SELECT `TraceId`, `SpanId`, toInt64(maxIf(`_erank`, `_etype` = 0)) AS `_ns_left`, toInt64(maxIf(`_erank`, `_etype` = 2)) AS `_ns_right`, if(countIf(`_etype` = 1) = 0, toInt64(-1), toInt64(maxIf(`_keyrank`, `_etype` = 1))) AS `_ns_parent` FROM (SELECT `TraceId`, `SpanId`, `_etype`, `_erank`, first_value(`_erank`) OVER (PARTITION BY `TraceId`, `_ekey` ORDER BY `_etype` ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS `_keyrank` FROM (SELECT `TraceId`, `SpanId`, `_ekey`, `_etype`, sum(`_etype` != 1) OVER (PARTITION BY `TraceId` ORDER BY `_ekey` ASC, `_etype` ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS `_erank` FROM (SELECT `TraceId`, `SpanId`, `_ev`.1 AS `_ekey`, `_ev`.2 AS `_etype` FROM `_cerberus_ns_paths` ARRAY JOIN arrayFilter(e -> NOT (e.2 = 1 AND e.1 = ''), [(`_path`, 0), (concat(`_path`, '~'), 2), (substring(`_path`, 1, length(`_path`) - 40), 1)]) AS `_ev`))) GROUP BY `TraceId`, `SpanId`) AS ns ON m.`TraceId` = ns.`TraceId` AND m.`SpanId` = ns.`SpanId`)

--- a/test/spec/traceql/select_nested_set_drilldown_unbounded_noop.txtar
+++ b/test/spec/traceql/select_nested_set_drilldown_unbounded_noop.txtar
@@ -1,0 +1,79 @@
+The no-drop companion to select_nested_set_drilldown_limited: the SAME bounded
+structure-tab plan, but with search_limit (10) ABOVE the trace count (4), so
+the top-N gate keeps every trace and drops nothing. This pins the
+semantics-preserving half of the #1109 bound: when the result already fits the
+limit, the BoundedTraceScope gate (`TraceId IN topNewestRootTraces(10)`) is a
+provable no-op — all four traces appear, every span fully numbered, none
+stranded at 0/0/0.
+
+It is the structural complement of the _limited fixture (which exercises the
+DROP path): together they catch both a too-tight bound (rows wrongly dropped
+here) and a too-loose bound (older traces wrongly kept there), plus any
+off-by-one in the LIMIT.
+
+Seed: four single-root traces a < b < c < d, each root (Server) with one Server
+child (identical to _limited). With search_limit=10 ≥ 4 traces, all 8 spans
+return, each numbered (root -1,1,4; child 1,2,3).
+
+-- search_limit --
+10
+-- query.traceql --
+({ nestedSetParent < 0 } &>> { kind = server }) || ({ nestedSetParent < 0 }) | select(nestedSetParent, nestedSetLeft, nestedSetRight)
+-- seed --
+CREATE TABLE otel_traces (
+    TraceId String,
+    SpanId String,
+    ParentSpanId String,
+    SpanName String,
+    SpanKind String,
+    Duration Int64,
+    Timestamp DateTime64(9),
+    StatusCode String,
+    StatusMessage String,
+    ScopeName String,
+    ScopeVersion String,
+    SpanAttributes Map(String, String),
+    ResourceAttributes Map(String, String)
+) ENGINE = MergeTree ORDER BY (Timestamp, SpanId);
+INSERT INTO otel_traces VALUES
+    ('a0000000000000000000000000000001', '1000000000000001', '', 'root', 'Server', 100, toDateTime64('2026-01-01 00:00:00.000000001', 9), 'Unset', '', '', '', map(), map()),
+    ('a0000000000000000000000000000001', '1000000000000002', '1000000000000001', 'child', 'Server', 50, toDateTime64('2026-01-01 00:00:00.000000002', 9), 'Unset', '', '', '', map(), map()),
+    ('b0000000000000000000000000000001', '2000000000000001', '', 'root', 'Server', 100, toDateTime64('2026-01-01 00:00:01.000000001', 9), 'Unset', '', '', '', map(), map()),
+    ('b0000000000000000000000000000001', '2000000000000002', '2000000000000001', 'child', 'Server', 50, toDateTime64('2026-01-01 00:00:01.000000002', 9), 'Unset', '', '', '', map(), map()),
+    ('c0000000000000000000000000000001', '3000000000000001', '', 'root', 'Server', 100, toDateTime64('2026-01-01 00:00:02.000000001', 9), 'Unset', '', '', '', map(), map()),
+    ('c0000000000000000000000000000001', '3000000000000002', '3000000000000001', 'child', 'Server', 50, toDateTime64('2026-01-01 00:00:02.000000002', 9), 'Unset', '', '', '', map(), map()),
+    ('d0000000000000000000000000000001', '4000000000000001', '', 'root', 'Server', 100, toDateTime64('2026-01-01 00:00:03.000000001', 9), 'Unset', '', '', '', map(), map()),
+    ('d0000000000000000000000000000001', '4000000000000002', '4000000000000001', 'child', 'Server', 50, toDateTime64('2026-01-01 00:00:03.000000002', 9), 'Unset', '', '', '', map(), map());
+-- expected_rows --
+[
+  ["a0000000000000000000000000000001", "1000000000000001", "2026-01-01T00:00:00.000000001Z", -1, 1, 4],
+  ["a0000000000000000000000000000001", "1000000000000002", "2026-01-01T00:00:00.000000002Z", 1, 2, 3],
+  ["b0000000000000000000000000000001", "2000000000000001", "2026-01-01T00:00:01.000000001Z", -1, 1, 4],
+  ["b0000000000000000000000000000001", "2000000000000002", "2026-01-01T00:00:01.000000002Z", 1, 2, 3],
+  ["c0000000000000000000000000000001", "3000000000000001", "2026-01-01T00:00:02.000000001Z", -1, 1, 4],
+  ["c0000000000000000000000000000001", "3000000000000002", "2026-01-01T00:00:02.000000002Z", 1, 2, 3],
+  ["d0000000000000000000000000000001", "4000000000000001", "2026-01-01T00:00:03.000000001Z", -1, 1, 4],
+  ["d0000000000000000000000000000001", "4000000000000002", "2026-01-01T00:00:03.000000002Z", 1, 2, 3]
+]
+-- args --
+[0] string = ""
+[1] string = ""
+[2] string = "Server"
+[3] string = ""
+[4] string = "Server"
+[5] string = "Server"
+[6] string = ""
+-- chplan --
+Project [TraceId, SpanId, Timestamp, __cerberus_ns_parent AS nestedSetParent, __cerberus_ns_left AS nestedSetLeft, __cerberus_ns_right AS nestedSetRight]
+  NestedSetAnnotate table=otel_traces traceLimit=10
+    SetOperation op=||
+      StructuralJoin op=&>> maxDepth=128
+        Filter predicate=((ParentSpanId = "") AND (TraceId IN topNewestRootTraces(10)))
+          Scan(otel_traces)
+        Filter predicate=((SpanKind = "Server") AND (TraceId IN topNewestRootTraces(10)))
+          Scan(otel_traces)
+      Project [TraceId, SpanId, ParentSpanId, SpanName, Duration, Timestamp, ResourceAttributes, SpanAttributes, StatusCode, StatusMessage, SpanKind, ScopeName, ScopeVersion]
+        Filter predicate=((ParentSpanId = "") AND (TraceId IN topNewestRootTraces(10)))
+          Scan(otel_traces)
+-- sql --
+SELECT `TraceId`, `SpanId`, `Timestamp`, `__cerberus_ns_parent` AS `nestedSetParent`, `__cerberus_ns_left` AS `nestedSetLeft`, `__cerberus_ns_right` AS `nestedSetRight` FROM (SELECT m.*, ifNull(`ns`.`_ns_left`, 0) AS `__cerberus_ns_left`, ifNull(`ns`.`_ns_right`, 0) AS `__cerberus_ns_right`, ifNull(`ns`.`_ns_parent`, 0) AS `__cerberus_ns_parent` FROM (SELECT * FROM (((SELECT R.`TraceId` AS `TraceId`, R.`SpanId` AS `SpanId`, R.`ParentSpanId` AS `ParentSpanId`, R.`SpanName` AS `SpanName`, R.`Duration` AS `Duration`, R.`Timestamp` AS `Timestamp`, R.`ResourceAttributes` AS `ResourceAttributes`, R.`SpanAttributes` AS `SpanAttributes`, R.`StatusCode` AS `StatusCode`, R.`StatusMessage` AS `StatusMessage`, R.`SpanKind` AS `SpanKind`, R.`ScopeName` AS `ScopeName`, R.`ScopeVersion` AS `ScopeVersion` FROM (WITH RECURSIVE _struct_closure_1 AS (SELECT DISTINCT `TraceId`, `SpanId`, `ParentSpanId`, 0 AS _depth FROM (SELECT * FROM `otel_traces` PREWHERE (`ParentSpanId` = ?) WHERE `TraceId` IN (SELECT `TraceId` FROM `otel_traces` WHERE `ParentSpanId` = '' GROUP BY `TraceId` ORDER BY min(`Timestamp`) DESC, `TraceId` LIMIT 10)) AS _seed UNION ALL SELECT DISTINCT t.`TraceId`, t.`SpanId`, t.`ParentSpanId`, c._depth + 1 FROM `otel_traces` AS t INNER JOIN _struct_closure_1 AS c ON t.`TraceId` = c.`TraceId` AND t.`ParentSpanId` = c.`SpanId` WHERE c._depth < 128 AND t.`TraceId` IN (SELECT `TraceId` FROM (SELECT * FROM `otel_traces` PREWHERE (`ParentSpanId` = ?) WHERE `TraceId` IN (SELECT `TraceId` FROM `otel_traces` WHERE `ParentSpanId` = '' GROUP BY `TraceId` ORDER BY min(`Timestamp`) DESC, `TraceId` LIMIT 10)) AS _seed_ids)) SELECT DISTINCT `TraceId`, `SpanId` FROM _struct_closure_1 WHERE _depth > 0) AS L INNER JOIN (SELECT * FROM `otel_traces` PREWHERE (`SpanKind` = ?) WHERE `TraceId` IN (SELECT `TraceId` FROM `otel_traces` WHERE `ParentSpanId` = '' GROUP BY `TraceId` ORDER BY min(`Timestamp`) DESC, `TraceId` LIMIT 10)) AS R ON L.`TraceId` = R.`TraceId` AND L.`SpanId` = R.`SpanId`) UNION DISTINCT (SELECT L.`TraceId` AS `TraceId`, L.`SpanId` AS `SpanId`, L.`ParentSpanId` AS `ParentSpanId`, L.`SpanName` AS `SpanName`, L.`Duration` AS `Duration`, L.`Timestamp` AS `Timestamp`, L.`ResourceAttributes` AS `ResourceAttributes`, L.`SpanAttributes` AS `SpanAttributes`, L.`StatusCode` AS `StatusCode`, L.`StatusMessage` AS `StatusMessage`, L.`SpanKind` AS `SpanKind`, L.`ScopeName` AS `ScopeName`, L.`ScopeVersion` AS `ScopeVersion` FROM (SELECT * FROM `otel_traces` PREWHERE (`ParentSpanId` = ?) WHERE `TraceId` IN (SELECT `TraceId` FROM `otel_traces` WHERE `ParentSpanId` = '' GROUP BY `TraceId` ORDER BY min(`Timestamp`) DESC, `TraceId` LIMIT 10)) AS L INNER JOIN (WITH RECURSIVE _struct_closure_inv_2 AS (SELECT DISTINCT `TraceId`, `SpanId`, `ParentSpanId`, 0 AS _depth FROM (SELECT * FROM `otel_traces` PREWHERE (`SpanKind` = ?) WHERE `TraceId` IN (SELECT `TraceId` FROM `otel_traces` WHERE `ParentSpanId` = '' GROUP BY `TraceId` ORDER BY min(`Timestamp`) DESC, `TraceId` LIMIT 10)) AS _seed UNION ALL SELECT DISTINCT t.`TraceId`, t.`SpanId`, t.`ParentSpanId`, c._depth + 1 FROM `otel_traces` AS t INNER JOIN _struct_closure_inv_2 AS c ON t.`TraceId` = c.`TraceId` AND t.`SpanId` = c.`ParentSpanId` WHERE c._depth < 128 AND t.`TraceId` IN (SELECT `TraceId` FROM (SELECT * FROM `otel_traces` PREWHERE (`SpanKind` = ?) WHERE `TraceId` IN (SELECT `TraceId` FROM `otel_traces` WHERE `ParentSpanId` = '' GROUP BY `TraceId` ORDER BY min(`Timestamp`) DESC, `TraceId` LIMIT 10)) AS _seed_ids)) SELECT DISTINCT `TraceId`, `SpanId` FROM _struct_closure_inv_2 WHERE _depth > 0) AS R ON L.`TraceId` = R.`TraceId` AND L.`SpanId` = R.`SpanId`)) UNION ALL (SELECT `TraceId`, `SpanId`, `ParentSpanId`, `SpanName`, `Duration`, `Timestamp`, `ResourceAttributes`, `SpanAttributes`, `StatusCode`, `StatusMessage`, `SpanKind`, `ScopeName`, `ScopeVersion` FROM (SELECT * FROM `otel_traces` PREWHERE (`ParentSpanId` = ?) WHERE `TraceId` IN (SELECT `TraceId` FROM `otel_traces` WHERE `ParentSpanId` = '' GROUP BY `TraceId` ORDER BY min(`Timestamp`) DESC, `TraceId` LIMIT 10)))) LIMIT 1 BY `TraceId`, `SpanId`) AS m LEFT JOIN (WITH RECURSIVE _cerberus_ns_paths AS (SELECT `TraceId`, `SpanId`, `ParentSpanId`, concat(leftPad(toString(toUnixTimestamp64Nano(`Timestamp`)), 20, '0'), leftPad(toString(sipHash64(`SpanId`)), 20, '0')) AS `_path`, 0 AS `_depth` FROM `otel_traces` WHERE `ParentSpanId` = '' AND `TraceId` IN (SELECT `TraceId` FROM `otel_traces` WHERE `ParentSpanId` = '' GROUP BY `TraceId` ORDER BY min(`Timestamp`) DESC, `TraceId` LIMIT 10) UNION ALL SELECT t.`TraceId`, t.`SpanId`, t.`ParentSpanId`, concat(c.`_path`, concat(leftPad(toString(toUnixTimestamp64Nano(`t`.`Timestamp`)), 20, '0'), leftPad(toString(sipHash64(`t`.`SpanId`)), 20, '0'))), c.`_depth` + 1 AS `_depth` FROM `otel_traces` AS t INNER JOIN `_cerberus_ns_paths` AS c ON t.`TraceId` = c.`TraceId` AND t.`ParentSpanId` = c.`SpanId` WHERE c._depth < 128) SELECT `TraceId`, `SpanId`, toInt64(maxIf(`_erank`, `_etype` = 0)) AS `_ns_left`, toInt64(maxIf(`_erank`, `_etype` = 2)) AS `_ns_right`, if(countIf(`_etype` = 1) = 0, toInt64(-1), toInt64(maxIf(`_keyrank`, `_etype` = 1))) AS `_ns_parent` FROM (SELECT `TraceId`, `SpanId`, `_etype`, `_erank`, first_value(`_erank`) OVER (PARTITION BY `TraceId`, `_ekey` ORDER BY `_etype` ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS `_keyrank` FROM (SELECT `TraceId`, `SpanId`, `_ekey`, `_etype`, sum(`_etype` != 1) OVER (PARTITION BY `TraceId` ORDER BY `_ekey` ASC, `_etype` ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS `_erank` FROM (SELECT `TraceId`, `SpanId`, `_ev`.1 AS `_ekey`, `_ev`.2 AS `_etype` FROM `_cerberus_ns_paths` ARRAY JOIN arrayFilter(e -> NOT (e.2 = 1 AND e.1 = ''), [(`_path`, 0), (concat(`_path`, '~'), 2), (substring(`_path`, 1, length(`_path`) - 40), 1)]) AS `_ev`))) GROUP BY `TraceId`, `SpanId`) AS ns ON m.`TraceId` = ns.`TraceId` AND m.`SpanId` = ns.`SpanId`)


### PR DESCRIPTION
## Problem

The Grafana Traces Drilldown **service structure** query

```traceql
({nestedSetParent<0} &>> {kind=server}) || ({nestedSetParent<0})
  | select(status, resource.service.name, name, nestedSetParent, nestedSetLeft, nestedSetRight)
```

OOM-crashed prod ClickHouse at the per-query memory cap (`query memory limit exceeded (2147483648 bytes)`).

**Root cause:** the `NestedSetAnnotate` numbering walk was already bounded to the N newest traces (`TraceLimit` → `boundedRootScopeFrag`), but the **row source** feeding it — a `||` over a `&>>` structural join — built **two recursive CTE closures + a wide-row `UNION DISTINCT`** (incl. the heavy `ResourceAttributes`/`SpanAttributes` Map columns) over **every trace in the window**, only truncated to N *afterward* by the handler's `TruncateSummaries`.

## Fix

When `stampNestedSetTraceLimit` sets `TraceLimit`, push one shared `chplan.BoundedTraceScope` gate into **every leaf scan** of the row source. The gate emits `TraceId IN (<top-N newest root traces>)` — the self-contained subquery the numbering anchor now also uses, **byte-identical by construction** — and the structural emitter's #77 seed re-render carries it into each closure seed, so the closures scan only the top-N traces instead of the whole window. The bound lands in `WHERE` (never PREWHERE) and survives the optimizer.

**Semantics-preserving** vs today's handler: same N-newest-by-root-start-time set (exact absent intra-trace clock skew — the ranking residual is documented, not claimed as exact). The precondition was **tightened** so it only fires on genuinely root-guaranteed unions (both arms emit root-bearing traces); a rootless-admitting `root || server` shape stays unbounded rather than dropping rootless traces.

## Reproduction (falsifiable, across layers)

- **chDB roundtrip** `select_nested_set_drilldown_limited` (`search_limit=2`): **8 → 4 rows** — older traces `a`,`b` no longer leak in at `0/0/0`; only the 2 newest `c`,`d`, fully numbered.
- **New** `select_nested_set_drilldown_unbounded_noop` (`search_limit=10` > 4 traces): all **8 rows** kept — gate is a provable no-op (pins the no-drop path).

## Test coverage

| Layer | Coverage |
|---|---|
| 2a IR + SQL goldens | gate visible in each leaf + closure seed |
| 6c chDB roundtrip | drop path (8→4) + no-drop path (8) |
| chsql unit | numbering scope == leaf-gate **byte-identity** |
| traceql unit | gate stamped/declined in lock-step with `TraceLimit`; `root \|\| server` stays unbounded |
| chplan | `cloneExpr` exhaustiveness + `BoundedTraceScope` clone case |
| optimizer | `collectColumn` records gate's `TraceId` (no pushdown prune); gate stays in WHERE |
| Layer 12 | cardinality ratchet tightened (`peak_intermediate` 12→6) |

## Review

Designed and adversarially reviewed via multi-agent workflows; the review caught 6 issues (clone panic, projection-pushdown prune, stale ratchet baseline, over-claimed parity docs, over-broad precondition, missing no-drop fixture) — all fixed in this PR.

## Out of scope (follow-ups)

- The structure-tab query emits **no time-window predicate** today (pre-existing) — the bound is "top-N newest-ever roots", faithful to current handler behavior. Window-folding is a separate change.
- A breadth-fan-out lint (recursive closure seeded from an unbounded trace scope under `TraceLimit>0`) would catch this class structurally pre-prod — worth a fast-follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)