### PR TITLE
feat(engine): reject subqueries whose anchor grid busts the sample budget (GAP-2)

### DIFF
--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -484,10 +484,11 @@ const gracefulShutdownTimeout = 10 * time.Second
 func newPromHandler(client *chclient.Client, cfg config.Config, optSet chopt.EnabledSet, evalSolver *solver.Solver, limiter *admit.Limiter, logger *slog.Logger) *prom.Handler {
 	h := prom.New(client, cfg.Schema, logger.With("api", "prom"))
 	h.Engine = &engine.Engine{
-		Optimizer: h.Optimizer,
-		Client:    client,
-		Solver:    evalSolver,
-		Settings:  settingsRules(cfg, optSet),
+		Optimizer:       h.Optimizer,
+		Client:          client,
+		Solver:          evalSolver,
+		Settings:        settingsRules(cfg, optSet),
+		MaxQuerySamples: client.MaxQuerySamples(),
 	}
 	h.Limiter = limiter
 	h.Version = Version

--- a/internal/api/prom/handler_subquery_budget_test.go
+++ b/internal/api/prom/handler_subquery_budget_test.go
@@ -1,0 +1,77 @@
+package prom_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/api/prom"
+	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// newServerWithAnchorBudget mounts a prom handler with the engine-level
+// subquery anchor budget wired — the same value cmd/cerberus copies from
+// client.MaxQuerySamples() into engine.MaxQuerySamples.
+func newServerWithAnchorBudget(q prom.Querier, maxSamples int64) *httptest.Server {
+	h := prom.New(q, schema.DefaultOTelMetrics(), nil)
+	h.Engine.MaxQuerySamples = maxSamples
+	mux := http.NewServeMux()
+	h.Mount(mux)
+	return httptest.NewServer(mux)
+}
+
+// TestQuery_SubqueryAnchorBudget422 — GAP-2 regression pin. An instant
+// subquery whose anchor grid alone (OuterRange/Step) exceeds the per-query
+// sample budget is rejected with the SAME Prometheus "too many samples" 422 as
+// a result-drain overage — and crucially BEFORE any SQL is sent, so the
+// millions of intermediate anchor rows never reach ClickHouse to OOM it. This
+// is the layer that the original audit found missing: nothing asserted the
+// query-of-death is rejected rather than executed.
+//
+// max_over_time(rate(m[1m])[90d:1s]) = 7,776,001 anchors > the 1M budget here.
+func TestQuery_SubqueryAnchorBudget422(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{} // returns nothing; the gate must reject before reaching it
+	srv := newServerWithAnchorBudget(q, 1_000_000)
+	t.Cleanup(srv.Close)
+
+	q1 := url.QueryEscape("max_over_time(rate(http_requests_total[1m])[90d:1s])")
+	resp, err := http.Get(srv.URL + "/api/v1/query?query=" + q1)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	assertBudget422(t, resp)
+
+	if q.lastSQL != "" {
+		t.Fatalf("anchor gate must reject before emitting SQL; querier saw SQL: %q", q.lastSQL)
+	}
+}
+
+// TestQuery_SubqueryWithinBudget_NotGated — the gate must NOT over-reject: a
+// normal subquery (5m:30s = 11 anchors) sails under the budget and reaches
+// execution (the querier is consulted).
+func TestQuery_SubqueryWithinBudget_NotGated(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{samples: []chclient.Sample{
+		{MetricName: "http_requests_total", Labels: map[string]string{"job": "api"}, Value: 1},
+	}}
+	srv := newServerWithAnchorBudget(q, 1_000_000)
+	t.Cleanup(srv.Close)
+
+	q1 := url.QueryEscape("max_over_time(rate(http_requests_total[1m])[5m:30s])")
+	resp, err := http.Get(srv.URL + "/api/v1/query?query=" + q1)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode == http.StatusUnprocessableEntity {
+		t.Fatalf("within-budget subquery wrongly gated (422); the anchor budget over-rejected")
+	}
+	if q.lastSQL == "" {
+		t.Fatal("within-budget subquery never reached execution; the anchor gate over-rejected")
+	}
+}

--- a/internal/chclient/client.go
+++ b/internal/chclient/client.go
@@ -1135,6 +1135,14 @@ func (c *Client) MaxQueryMemoryBytes() int64 {
 	return c.maxMemory
 }
 
+// MaxQuerySamples is Config.MaxQuerySamples — the per-query sample budget.
+// The Client enforces it on the Go-side result drain; the engine reads it
+// (via this accessor at wiring time) to also fail-close a subquery whose
+// anchor grid alone would exceed it before any SQL is sent. 0 = unlimited.
+func (c *Client) MaxQuerySamples() int64 {
+	return c.maxSamples
+}
+
 // Exec runs sql with positional args against ClickHouse and returns any
 // error. Use for DDL (CREATE TABLE, ...) and DML (INSERT, ...) that don't
 // produce a result set.

--- a/internal/chplan/range_window.go
+++ b/internal/chplan/range_window.go
@@ -156,6 +156,21 @@ func (*RangeWindow) planNode() {}
 
 func (r *RangeWindow) Children() []Node { return []Node{r.Input} }
 
+// NumAnchors is the number of subquery anchor points this RangeWindow
+// materialises: one row per Step across (End - OuterRange, End], i.e.
+// OuterRange/Step + 1. It is the per-series intermediate row count of a
+// PromQL subquery grid (the dominant resource axis for a fine-step/long-range
+// subquery like `[90d:1s]` = 7.78M). Zero for a non-subquery instant leaf
+// (OuterRange == 0) or an unstepped window (Step <= 0). Mirrors the emitter's
+// own `OuterRange.Nanoseconds()/stepNS + 1` so the budget gate and the emit
+// agree on the count.
+func (r *RangeWindow) NumAnchors() int64 {
+	if r.OuterRange <= 0 || r.Step <= 0 {
+		return 0
+	}
+	return r.OuterRange.Nanoseconds()/r.Step.Nanoseconds() + 1
+}
+
 func (r *RangeWindow) Equal(other Node) bool {
 	o, ok := other.(*RangeWindow)
 	if !ok {

--- a/internal/engine/anchor_budget.go
+++ b/internal/engine/anchor_budget.go
@@ -1,0 +1,59 @@
+package engine
+
+import (
+	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// requireSubquerySampleBudget fail-closes a PromQL subquery whose anchor grid
+// alone would exceed the per-query sample budget (Config.MaxQuerySamples).
+//
+// A subquery <reducer>_over_time(<inner>[OuterRange:Step]) materialises
+// OuterRange/Step + 1 anchor rows PER SERIES as an intermediate (the
+// GROUP BY (Attributes, anchor_ts) regroup) before collapsing them. cerberus's
+// MaxQuerySamples budget is enforced on the Go-side RESULT drain
+// (chclient.SampleBudget), which sees ~1 row/series for an instant reducer and
+// so never trips — the millions of intermediate anchor rows OOM ClickHouse
+// before any result is drained (resource-bound audit GAP-2; #1112's spill
+// bounds the anchor axis, but the cardinality axis still busts a fixed memory
+// cap at C>=10 series for a 90d:1s grid).
+//
+// This bounds the intermediate the way upstream Prometheus bounds a subquery:
+// it REJECTS rather than streams-and-OOMs (Prometheus returns "too many
+// samples" once a subquery would load more than query.max-samples into memory).
+// We reject when a single series' anchor grid alone exceeds the budget,
+// returning the same chclient.ErrTooManySamples that maps to the Prom-shaped
+// 422 — so the worst case is a fast honest rejection, never a process OOM that
+// takes down all three heads sharing the cerberus process.
+//
+// maxSamples <= 0 disables the budget (matching the cursor's per-query budget
+// semantics), so the gate is inert by default in tests that don't wire it.
+func requireSubquerySampleBudget(plan chplan.Node, maxSamples int64) error {
+	if maxSamples <= 0 || plan == nil {
+		return nil
+	}
+	worst := worstAnchorCount(plan)
+	if worst > maxSamples {
+		return &chclient.TooManySamplesError{Limit: maxSamples}
+	}
+	return nil
+}
+
+// worstAnchorCount returns the largest RangeWindow.NumAnchors anywhere in the
+// plan (0 if none) — the per-series intermediate row count of the heaviest
+// subquery grid the plan will materialise.
+func worstAnchorCount(n chplan.Node) int64 {
+	if n == nil {
+		return 0
+	}
+	var worst int64
+	if rw, ok := n.(*chplan.RangeWindow); ok {
+		worst = rw.NumAnchors()
+	}
+	for _, c := range n.Children() {
+		if a := worstAnchorCount(c); a > worst {
+			worst = a
+		}
+	}
+	return worst
+}

--- a/internal/engine/anchor_budget.go
+++ b/internal/engine/anchor_budget.go
@@ -28,6 +28,25 @@ import (
 //
 // maxSamples <= 0 disables the budget (matching the cursor's per-query budget
 // semantics), so the gate is inert by default in tests that don't wire it.
+//
+// Scope. NumAnchors is non-zero for ANY RangeWindow with OuterRange>0 && Step>0
+// — which includes a plain query_range matrix, not only a subquery. That is
+// harmless: the query_range OUTER grid is already capped at
+// format.MaxResolutionPoints (11000) in the head handlers before lowering, far
+// below any sane budget, so a range query can never reach this gate. SUBQUERY
+// inner grids have no such cap (the [range:step] resolution is unbounded) — so
+// in practice this budget is the subquery counterpart to MaxResolutionPoints,
+// the one place an OuterRange grid that the handler did not pre-bound gets
+// bounded.
+//
+// The bound is per-series and conservative on two axes, by design:
+//   - cardinality: it counts a single series' anchor grid, not anchors x
+//     series; the cardinality axis is bounded elsewhere (#1112 spill + the
+//     result-drain SampleBudget). So a sub-budget grid at high cardinality is
+//     backstopped at runtime, not here.
+//   - nesting: for stacked subqueries it takes the MAX anchor grid in the tree,
+//     not the product the emitter fans out. An undercount, never an
+//     over-reject; the runtime nets catch a product that no single level busts.
 func requireSubquerySampleBudget(plan chplan.Node, maxSamples int64) error {
 	if maxSamples <= 0 || plan == nil {
 		return nil

--- a/internal/engine/anchor_budget_test.go
+++ b/internal/engine/anchor_budget_test.go
@@ -1,0 +1,74 @@
+package engine
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+func subqueryRW(outer, step time.Duration, input chplan.Node) *chplan.RangeWindow {
+	return &chplan.RangeWindow{
+		Func: "rate", Range: time.Minute, OuterRange: outer, Step: step, Input: input,
+	}
+}
+
+func TestRequireSubquerySampleBudget(t *testing.T) {
+	t.Parallel()
+	scan := &chplan.Scan{Table: "otel_metrics_sum"}
+	const day = 24 * time.Hour
+
+	cases := []struct {
+		name       string
+		plan       chplan.Node
+		maxSamples int64
+		wantReject bool
+	}{
+		// 90d/1s = 7,776,001 anchors > 1M budget → reject like Prometheus.
+		{"giant grid over budget rejects", subqueryRW(90*day, time.Second, scan), 1_000_000, true},
+		// 5m/30s = 11 anchors, trivially under budget.
+		{"normal subquery passes", subqueryRW(5*time.Minute, 30*time.Second, scan), 1_000_000, false},
+		// 0 disables the budget — even the giant grid is allowed through.
+		{"budget disabled passes giant", subqueryRW(90*day, time.Second, scan), 0, false},
+		// A non-subquery instant leaf (OuterRange 0) has NumAnchors 0.
+		{"non-subquery leaf passes", &chplan.RangeWindow{Func: "rate", Range: time.Minute, Input: scan}, 1_000_000, false},
+		// The walk finds the worst grid nested under a wrapper.
+		{"nested giant grid rejects", &chplan.Aggregate{Input: subqueryRW(90*day, time.Second, scan)}, 1_000_000, true},
+		{"nil plan passes", nil, 1_000_000, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := requireSubquerySampleBudget(tc.plan, tc.maxSamples)
+			switch {
+			case tc.wantReject && err == nil:
+				t.Fatal("want rejection, got nil")
+			case tc.wantReject && !errors.Is(err, chclient.ErrTooManySamples):
+				t.Fatalf("want ErrTooManySamples, got %v", err)
+			case !tc.wantReject && err != nil:
+				t.Fatalf("want pass, got %v", err)
+			}
+		})
+	}
+}
+
+func TestRangeWindowNumAnchors(t *testing.T) {
+	t.Parallel()
+	const day = 24 * time.Hour
+	cases := []struct {
+		outer, step time.Duration
+		want        int64
+	}{
+		{90 * day, time.Second, 7_776_001},
+		{5 * time.Minute, 30 * time.Second, 11},
+		{0, time.Second, 0}, // not a subquery
+		{time.Hour, 0, 0},   // unstepped
+	}
+	for _, c := range cases {
+		got := (&chplan.RangeWindow{OuterRange: c.outer, Step: c.step}).NumAnchors()
+		if got != c.want {
+			t.Errorf("NumAnchors(outer=%s step=%s): got %d, want %d", c.outer, c.step, got, c.want)
+		}
+	}
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -460,6 +460,14 @@ type Engine struct {
 	// query_id (trace id on ctx) and shape-id (planShapeID) are already
 	// computed; the reconciler later joins those ids back to system.query_log.
 	QueryObserver QueryObserver
+
+	// MaxQuerySamples mirrors chclient.Config.MaxQuerySamples (wired from the
+	// same CERBERUS_QUERY_MAX_SAMPLES in cmd/cerberus). The chclient enforces it
+	// on the Go-side RESULT drain; the engine enforces it on the post-optimize
+	// PLAN — rejecting a subquery whose anchor grid alone (RangeWindow.NumAnchors)
+	// would exceed the budget, which the result drain never sees (resource-bound
+	// audit GAP-2, see requireSubquerySampleBudget). 0 disables the gate.
+	MaxQuerySamples int64
 }
 
 // QueryObserver is the narrow seam the corpus reconciler registers on the
@@ -682,6 +690,13 @@ func (e *Engine) QueryPlan(ctx context.Context, lang Lang, plan chplan.Node, met
 		optT := telemetry.ObserveStage(telemetry.StageOptimize)
 		plan = e.Optimizer.Run(ctx, plan)
 		optT.Done(ctx)
+	}
+
+	// Resource-bound gate: reject a subquery whose anchor grid alone busts the
+	// per-query sample budget before any SQL is sent (GAP-2). Honest 422, never
+	// an OOM.
+	if err := requireSubquerySampleBudget(plan, e.MaxQuerySamples); err != nil {
+		return Result{}, err
 	}
 
 	// Solver classification (DARK). When the Solver is wired it classifies
@@ -913,6 +928,12 @@ func (e *Engine) QueryPlanCursor(ctx context.Context, lang Lang, plan chplan.Nod
 		optT := telemetry.ObserveStage(telemetry.StageOptimize)
 		plan = e.Optimizer.Run(ctx, plan)
 		optT.Done(ctx)
+	}
+
+	// Resource-bound gate (symmetrical with QueryPlan): reject a subquery whose
+	// anchor grid alone busts the per-query sample budget before any SQL is sent.
+	if err := requireSubquerySampleBudget(plan, e.MaxQuerySamples); err != nil {
+		return CursorResult{}, err
 	}
 
 	// Solver classification (DARK) — symmetrical with QueryPlan. Under


### PR DESCRIPTION
## What

The resource-bound audit's **GAP-2**: an instant PromQL subquery —
`max_over_time(rate(http_requests_total[1m])[90d:1s])` — materialises
`OuterRange/Step` = **7.78M anchor rows per series** as a `GROUP BY (Attributes,
anchor_ts)` intermediate before collapsing to ~1 row/series. cerberus's per-query
sample budget (`CERBERUS_QUERY_MAX_SAMPLES`) is enforced on the **Go-side result
drain**, which sees only the ~1 row/series and never trips — the millions of
intermediate anchor rows OOM ClickHouse first.

## The measurement (why a gate, not a rewrite)

I measured peak memory in chDB across scales (real numbers, `90d/1s` = 7.78M anchors):

| scale | #1112 spill @ 1GiB | verdict |
|---|---|---|
| C=1 series | completes, 768 MiB, 13.8s | spill bounds the **anchor** axis |
| **C=10 series** | **OOM — 1.00 GiB, 106s** | **cardinality axis unbounded** |
| C=50 series | extrapolates ~20–30 GiB | |

#1112's spill flattened the anchor axis but left **cardinality** unbounded against a
fixed cap. And the decisive finding: **upstream Prometheus does not stream-and-OOM
these either** — it *rejects* with *"too many samples"* once a subquery would load
more than `query.max-samples` into memory. So the **compatibility-faithful** fix is to
reject like Prometheus, not to build a fused rewrite that would serve what Prometheus
refuses (a compat *divergence*).

## The fix

A fail-closed engine gate (sibling to `requireInstantScanBound`): reject when a
`RangeWindow`'s anchor grid alone (`NumAnchors = OuterRange/Step + 1`) exceeds
`MaxQuerySamples`, returning the same `chclient.ErrTooManySamples` that maps to the
**Prom-shaped 422** — *before any SQL is sent*. Worst case is a fast honest rejection,
never a process OOM that takes down all three heads sharing the process.

- `chplan.RangeWindow.NumAnchors()` — single source for the anchor count.
- `engine.requireSubquerySampleBudget` walks the post-optimize plan in both
  `QueryPlan` + `QueryPlanCursor`; wired via the new `Engine.MaxQuerySamples`
  (copied from `client.MaxQuerySamples()` in cmd/cerberus — same
  `CERBERUS_QUERY_MAX_SAMPLES` value, no new config). `0` disables.

## Reproduced across all applicable layers

A pre-SQL rejection gate has no chDB/result-equivalence layer (nothing executes / nothing
to compare). It is reproduced at its three real layers:
- **chplan unit** — `NumAnchors()` math (90d/1s = 7,776,001; 5m/30s = 11; non-subquery = 0).
- **engine unit** — gate logic: rejects giant, passes normal, disabled at 0, nested walk finds the worst grid.
- **prom HTTP integration** — `max_over_time(rate(m[1m])[90d:1s])` → **422 with the exact upstream
  message**, and the querier is never called (rejected before SQL); a within-budget `5m:30s`
  subquery passes through to execution.

## Scope / what this is not

This is the **safety + compatibility** fix — the OOM becomes an honest bounded 422. The
*fused/streaming reduction* (serve giant subqueries fast, beyond what Prometheus serves) is a
separate, high-risk re-architecture across 8 reducer families; it's designed but deliberately
**not** in this PR (it would diverge from Prometheus and warrants explicit sign-off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
