### PR TITLE
feat(engine): nested-subquery anchor product (GAP-C) + plan-node bound registry (Step 5)

### DIFF
--- a/internal/engine/anchor_budget.go
+++ b/internal/engine/anchor_budget.go
@@ -1,6 +1,8 @@
 package engine
 
 import (
+	"math"
+
 	"github.com/tsouza/cerberus/internal/chclient"
 	"github.com/tsouza/cerberus/internal/chplan"
 )
@@ -30,49 +32,79 @@ import (
 // semantics), so the gate is inert by default in tests that don't wire it.
 //
 // Scope. NumAnchors is non-zero for ANY RangeWindow with OuterRange>0 && Step>0
-// — which includes a plain query_range matrix, not only a subquery. That is
-// harmless: the query_range OUTER grid is already capped at
-// format.MaxResolutionPoints (11000) in the head handlers before lowering, far
-// below any sane budget, so a range query can never reach this gate. SUBQUERY
-// inner grids have no such cap (the [range:step] resolution is unbounded) — so
-// in practice this budget is the subquery counterpart to MaxResolutionPoints,
-// the one place an OuterRange grid that the handler did not pre-bound gets
-// bounded.
+// — a subquery [range:step] grid, OR a plain query_range matrix's outer step
+// grid. A plain query_range alone is already capped at format.MaxResolutionPoints
+// (11000) in the head handlers, far below any sane budget; SUBQUERY inner grids
+// have no such cap, so this budget is the subquery counterpart to
+// MaxResolutionPoints. The two compose: a query_range OVER a subquery stacks the
+// 11000-point outer grid above the subquery grid, and subqueryAnchorLoad
+// MULTIPLIES them — so the gate can be reached by a range query whose subquery
+// inner grid pushes the product past the budget (the intermediate it materialises
+// really is that product).
 //
-// The bound is per-series and conservative on two axes, by design:
-//   - cardinality: it counts a single series' anchor grid, not anchors x
-//     series; the cardinality axis is bounded elsewhere (#1112 spill + the
-//     result-drain SampleBudget). So a sub-budget grid at high cardinality is
-//     backstopped at runtime, not here.
-//   - nesting: for stacked subqueries it takes the MAX anchor grid in the tree,
-//     not the product the emitter fans out. An undercount, never an
-//     over-reject; the runtime nets catch a product that no single level busts.
+// The bound is per-series and conservative on the cardinality axis by design: it
+// counts a single series' anchor grid, not anchors x series; the cardinality
+// axis is bounded elsewhere (#1112 spill + the result-drain SampleBudget). So a
+// sub-budget grid at high cardinality is backstopped at runtime, not here.
+//
+// Nesting IS counted (GAP-C): subqueryAnchorLoad takes the PRODUCT of stacked
+// OuterRange>0 grids — each outer anchor re-evaluates the inner grid — not the
+// max, which under-rejected nested subqueries.
 func requireSubquerySampleBudget(plan chplan.Node, maxSamples int64) error {
 	if maxSamples <= 0 || plan == nil {
 		return nil
 	}
-	worst := worstAnchorCount(plan)
+	worst := subqueryAnchorLoad(plan)
 	if worst > maxSamples {
 		return &chclient.TooManySamplesError{Limit: maxSamples}
 	}
 	return nil
 }
 
-// worstAnchorCount returns the largest RangeWindow.NumAnchors anywhere in the
-// plan (0 if none) — the per-series intermediate row count of the heaviest
-// subquery grid the plan will materialise.
-func worstAnchorCount(n chplan.Node) int64 {
+// subqueryAnchorLoad returns the largest per-series intermediate anchor-row
+// count the plan will materialise. A single subquery RangeWindow contributes
+// its NumAnchors; NESTED subqueries multiply, because each outer anchor
+// re-evaluates the inner grid — `max_over_time(max_over_time(rate(m[1m])
+// [5m:30s])[1h:5m])` materialises (1h/5m)·(5m/30s) anchor rows, not the larger
+// of the two. (The earlier max-only count under-rejected this product shape —
+// GAP-C.) Sibling subqueries (e.g. the two arms of a binary op) do NOT multiply;
+// only a RangeWindow stacked over another OuterRange>0 RangeWindow in its own
+// input subtree does. Saturates at math.MaxInt64 so a deeply nested product can
+// never wrap negative and slip under the budget.
+func subqueryAnchorLoad(n chplan.Node) int64 {
 	if n == nil {
 		return 0
 	}
-	var worst int64
+	var self int64
 	if rw, ok := n.(*chplan.RangeWindow); ok {
-		worst = rw.NumAnchors()
+		self = rw.NumAnchors()
 	}
+	// The heaviest nested load among the input subtree(s).
+	var childLoad int64
 	for _, c := range n.Children() {
-		if a := worstAnchorCount(c); a > worst {
-			worst = a
+		if l := subqueryAnchorLoad(c); l > childLoad {
+			childLoad = l
 		}
 	}
-	return worst
+	// A subquery grid (self>0) stacked over a nested grid (childLoad>0)
+	// multiplies; otherwise the load is whichever side carries it.
+	if self > 0 && childLoad > 0 {
+		return satMulInt64(self, childLoad)
+	}
+	if self > childLoad {
+		return self
+	}
+	return childLoad
+}
+
+// satMulInt64 multiplies two non-negative int64s, saturating at math.MaxInt64
+// instead of overflowing (a nested anchor product can exceed 1e18).
+func satMulInt64(a, b int64) int64 {
+	if a == 0 || b == 0 {
+		return 0
+	}
+	if a > math.MaxInt64/b {
+		return math.MaxInt64
+	}
+	return a * b
 }

--- a/internal/engine/anchor_budget_test.go
+++ b/internal/engine/anchor_budget_test.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"errors"
+	"math"
 	"testing"
 	"time"
 
@@ -70,5 +71,64 @@ func TestRangeWindowNumAnchors(t *testing.T) {
 		if got != c.want {
 			t.Errorf("NumAnchors(outer=%s step=%s): got %d, want %d", c.outer, c.step, got, c.want)
 		}
+	}
+}
+
+// TestSubqueryAnchorLoad_NestedProduct pins GAP-C: nested subquery grids
+// multiply (each outer anchor re-evaluates the inner grid), siblings don't, and
+// the product saturates rather than overflowing.
+func TestSubqueryAnchorLoad_NestedProduct(t *testing.T) {
+	t.Parallel()
+	scan := &chplan.Scan{Table: "otel_metrics_sum"}
+	// 1h/1m + 1 = 61 anchors per grid.
+	grid := func(in chplan.Node) *chplan.RangeWindow {
+		return &chplan.RangeWindow{Func: "rate", Range: time.Minute, OuterRange: time.Hour, Step: time.Minute, Input: in}
+	}
+	single := grid(scan)
+	nested := &chplan.RangeWindow{Func: "max_over_time", Range: time.Hour, OuterRange: time.Hour, Step: time.Minute, Input: grid(scan)}
+
+	if got := subqueryAnchorLoad(single); got != 61 {
+		t.Fatalf("single: got %d, want 61", got)
+	}
+	// Nested multiplies: 61 * 61 = 3721 — the max-only count would have seen 61.
+	if got := subqueryAnchorLoad(nested); got != 61*61 {
+		t.Fatalf("nested product: got %d, want %d", got, 61*61)
+	}
+	// Siblings (two arms of a join) do NOT multiply — only the deepest chain.
+	siblings := &chplan.CrossJoin{Left: grid(scan), Right: grid(scan)}
+	if got := subqueryAnchorLoad(siblings); got != 61 {
+		t.Fatalf("siblings: got %d, want 61 (max, not product)", got)
+	}
+	// The product propagates THROUGH a wrapper (Project) between the two grids —
+	// the real lowered shape, where the outer reducer sits over a Project over
+	// the inner subquery matrix.
+	throughWrapper := &chplan.RangeWindow{
+		Func: "max_over_time", Range: time.Hour, OuterRange: time.Hour, Step: time.Minute,
+		Input: &chplan.Project{Input: grid(scan)},
+	}
+	if got := subqueryAnchorLoad(throughWrapper); got != 61*61 {
+		t.Fatalf("product through wrapper: got %d, want %d", got, 61*61)
+	}
+	// The budget rejects the nested product but passes either level alone.
+	if err := requireSubquerySampleBudget(nested, 1000); !errors.Is(err, chclient.ErrTooManySamples) {
+		t.Fatalf("nested over budget 1000: want reject, got %v", err)
+	}
+	if err := requireSubquerySampleBudget(single, 1000); err != nil {
+		t.Fatalf("single under budget 1000: want pass, got %v", err)
+	}
+}
+
+func TestSatMulInt64_Saturates(t *testing.T) {
+	t.Parallel()
+	if got := satMulInt64(0, 1<<40); got != 0 {
+		t.Fatalf("0*x: got %d, want 0", got)
+	}
+	if got := satMulInt64(3, 4); got != 12 {
+		t.Fatalf("3*4: got %d, want 12", got)
+	}
+	// 7.78M ^ 3 overflows int64 — must saturate, never wrap negative.
+	big := int64(7_776_001)
+	if got := satMulInt64(satMulInt64(big, big), big); got != math.MaxInt64 {
+		t.Fatalf("triple-nested product: got %d, want MaxInt64", got)
 	}
 }

--- a/internal/engine/resource_bound_classification_test.go
+++ b/internal/engine/resource_bound_classification_test.go
@@ -1,0 +1,128 @@
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// boundClass records HOW a chplan plan-node's worst-case resource consumption
+// is bounded. This is the resource-bound audit's Step-5 enumeration made
+// executable: every plan node must declare a class, so a newly-added node type
+// FAILS TestResourceBoundClassification_Exhaustive until its author has thought
+// about (and recorded) how it is bounded — the "can't ship an unbounded
+// operator" guarantee.
+type boundClass int
+
+const (
+	// boundStructural: the bound is intrinsic to the node's own IR/SQL shape
+	// (a LIMIT, a 1:1 projection, a single row, a top-N) — it cannot run away.
+	boundStructural boundClass = iota
+	// boundGated: an axis that CAN be unbounded, caught by a fail-closed
+	// plan-time gate that rejects (422) when the bound is absent.
+	boundGated
+	// boundRuntimeNet: bounded only at execution time by ClickHouse
+	// (max_memory_usage / external-spill) and/or the Go-side result drain
+	// (SampleBudget). No plan-time gate; a runaway is a graceful resource
+	// rejection, never a process crash. Declared, not silently omitted.
+	boundRuntimeNet
+)
+
+// resourceBoundClassification classifies every chplan plan node (every type
+// with a planNode() marker). Keep it in sync with internal/chplan — the
+// exhaustiveness test below fails if a plan node is missing here.
+var resourceBoundClassification = map[string]struct {
+	class boundClass
+	note  string
+}{
+	// Leaf + structurally-bounded shapes.
+	"Scan":             {boundGated, "axis 1: leaf scan bounded by the request time window; instant windowed leaves fail-close via requireInstantScanBound"},
+	"Filter":           {boundStructural, "≤ input rows; the scan-time predicate it carries bounds the leaf below"},
+	"Project":          {boundStructural, "1:1 row map"},
+	"OneRow":           {boundStructural, "exactly one row"},
+	"Limit":            {boundStructural, "explicit LIMIT N"},
+	"TopK":             {boundStructural, "LIMIT N over the ordered input"},
+	"SearchTraceLimit": {boundStructural, "axis 2: top-N traces (the structural row-source bound)"},
+	"OrderBy":          {boundRuntimeNet, "axis 4: sort buffer; spill + max_memory_usage"},
+
+	// Subquery / windowed grids — axis 5, the anchor budget.
+	"RangeWindow":         {boundGated, "axis 5: subquery anchor grid (incl. nested product) gated by requireSubquerySampleBudget; axis 1 instant leaf by requireInstantScanBound"},
+	"RangeWindowNative":   {boundGated, "axis 5: native timeSeries*ToGrid variant of RangeWindow; same anchor-grid bound"},
+	"RangeWindowResample": {boundGated, "axis 5: native-staleness resample variant; same anchor-grid bound"},
+	"StepGrid":            {boundStructural, "axis 5: query_range step grid capped at format.MaxResolutionPoints in the head handler"},
+	"RangeBucketFanout":   {boundRuntimeNet, "axis 4/7: histogram bucket fan-out over the scan-bounded window; spill + max_memory_usage"},
+	"RangeLWR":            {boundRuntimeNet, "axis 7: linear-regression-window compute over the scan-bounded window"},
+	"AbsentOverTime":      {boundStructural, "one synthesized row per absent series over the bounded window"},
+
+	// Recursive / structural-join walks — axis 3, depth caps.
+	"StructuralJoin":    {boundGated, "axis 3: recursive CTE depth-capped at defaultStructuralRecursionDepth"},
+	"NestedSetAnnotate": {boundGated, "axis 3: recursive numbering walk depth-capped; row source bounded by BoundedTraceScope"},
+
+	// Aggregations + joins — axis 4 cardinality, runtime net.
+	"Aggregate":                {boundRuntimeNet, "axis 4: GROUP BY cardinality; external-aggregation spill + max_memory_usage; output bounded by the result drain SampleBudget"},
+	"MetricsAggregate":         {boundRuntimeNet, "axis 4: TraceQL metrics GROUP BY; spill + max_memory_usage"},
+	"MetricsSecondStage":       {boundRuntimeNet, "axis 4/7: second-stage metrics reduction over the bounded first stage"},
+	"MetricsCompare":           {boundRuntimeNet, "axis 7: compare() arithmetic over the scan-bounded input"},
+	"MetricsHistogramOverTime": {boundRuntimeNet, "axis 4/7: per-bucket histogram over the bounded window"},
+	"CrossJoin":                {boundRuntimeNet, "axis 4: row product; current callers (absent lowering) feed it a single-row side; max_memory_usage"},
+	"InfoJoin":                 {boundRuntimeNet, "axis 4: info-metric enrichment join; spill + max_memory_usage"},
+	"SetOperation":             {boundStructural, "≤ sum of the two bounded inputs"},
+	"NaryVectorSetOp":          {boundStructural, "≤ sum of the bounded operand vectors"},
+
+	// Per-row compute — axis 7, runtime net.
+	"HistogramQuantile":       {boundRuntimeNet, "axis 7: per-row quantile over the bounded bucket set"},
+	"HistogramQuantileNative": {boundRuntimeNet, "axis 7: native per-row histogram quantile over the bounded input"},
+
+	// Binary / set vector ops over two already-bounded operand vectors.
+	"VectorJoin":  {boundRuntimeNet, "axis 4: on()/ignoring() match join over two bounded vectors; max_memory_usage"},
+	"VectorSetOp": {boundStructural, "and/or/unless — ≤ the union of the two bounded operand vectors"},
+	"UnionAll":    {boundStructural, "≤ the sum of its bounded inputs"},
+}
+
+// TestResourceBoundClassification_Exhaustive discovers every chplan plan-node
+// type (the planNode() marker) from source and asserts each is classified
+// above. A new node type fails this until its resource bound is declared.
+func TestResourceBoundClassification_Exhaustive(t *testing.T) {
+	t.Parallel()
+	files, err := filepath.Glob("../chplan/*.go")
+	if err != nil {
+		t.Fatalf("glob chplan: %v", err)
+	}
+	if len(files) == 0 {
+		t.Fatal("no chplan source files found — adjust the relative path")
+	}
+	// Matches `func (*Foo) planNode() {` and `func (f *Foo) planNode() {`.
+	re := regexp.MustCompile(`func \([a-z]* ?\*?(\w+)\) planNode\(\)`)
+	found := map[string]bool{}
+	for _, f := range files {
+		if filepath.Base(f) == "node.go" || strings.HasSuffix(f, "_test.go") {
+			continue
+		}
+		src, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("read %s: %v", f, err)
+		}
+		for _, m := range re.FindAllStringSubmatch(string(src), -1) {
+			found[m[1]] = true
+		}
+	}
+	if len(found) < 20 {
+		t.Fatalf("discovered only %d plan-node types — the marker regex likely drifted", len(found))
+	}
+	for name := range found {
+		if _, ok := resourceBoundClassification[name]; !ok {
+			t.Errorf("chplan.%s is a plan node with no resource-bound classification — "+
+				"add it to resourceBoundClassification (declare how its worst-case resource "+
+				"use is bounded: structural / gated / runtime-net) per the Step-5 audit", name)
+		}
+	}
+	// Also flag stale entries (a classification for a removed node).
+	for name := range resourceBoundClassification {
+		if !found[name] {
+			t.Errorf("resourceBoundClassification has %q but no chplan plan node by that "+
+				"name exists — remove the stale entry", name)
+		}
+	}
+}


### PR DESCRIPTION
Two Step-5 (`RequireResourceBound`) pieces — the systematic side of the resource-bound audit. (Independent of the GAP-A metadata-drain budget #1119.)

## GAP-C — nested-subquery anchor product
The anchor budget (#1115) counted the **MAX** `RangeWindow.NumAnchors` in the plan, which **under-rejects nested subqueries**: `max_over_time(max_over_time(rate(m[1m])[5m:30s])[1h:5m])` materialises (1h/5m)·(5m/30s) anchor rows — each outer anchor re-evaluates the inner grid — not the larger of the two. `subqueryAnchorLoad` now **multiplies** stacked `OuterRange>0` RangeWindows down a chain (siblings, e.g. the arms of a join, do **not** multiply), saturating at `math.MaxInt64` so a deep product can't wrap negative and slip under the budget.

## Registry exhaustiveness test — the "can't ship unbounded" guarantee
The audit's thesis (the unbounded-operator set is finite + enumerable) made executable: `resourceBoundClassification` declares, for **every** chplan plan node, how its worst-case resource use is bounded — **structural** / **gated** / **runtime-net** + a one-line note. `TestResourceBoundClassification_Exhaustive` discovers every `planNode()` type from source and **fails if one is unclassified** — so a newly-added node can't ship without its author declaring its bound. It immediately caught 3 unclassified nodes (`VectorJoin`, `VectorSetOp`, `UnionAll`).

The honest classification: **5 gated families** carry fail-closed plan-time gates (scan-time, anchor budget, recursion depth); high-cardinality GROUP BY / sort / per-row compute are **runtime-net** (spill + `max_memory_usage` + the drain budget) — *declared, not omitted*. A sweeping gate over them would reject legitimate `sum by()`, which is why Step 5 is a registry + test, not one gate.

## On GAP-D (deliberately not a static gate)
A static range-selector magnitude cap (reject `[365d]`) would reject queries Prometheus *serves* at low cardinality — the same over-rejection trap as the original GAP-2. The range magnitude is classified runtime-net (scan-time bound + `max_memory_usage`), not a new fail-closed rule.

## Tests
GAP-C: nested product = 61², siblings = 61 (max not product), `satMulInt64` overflow saturation, budget rejects nested but passes either level alone. Plus the exhaustiveness test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)