### PR TITLE
fix(tempo): push /api/search limit into spanset-aggregation as server-side ORDER BY+LIMIT

### DIFF
--- a/internal/api/tempo/handler.go
+++ b/internal/api/tempo/handler.go
@@ -1012,8 +1012,13 @@ func wrapWithSampleProjection(plan chplan.Node, s schema.Traces, meta engine.Met
 		// `min(Timestamp) AS TimeUnix`) so the wrap projection just
 		// reads them out + merges the TraceId into Attributes via
 		// mapConcat (same `__cerberus_traceID` reserved-key pattern as
-		// canonicalSampleProjections).
-		return &chplan.Project{Input: plan, Projections: spansetAggregateSampleProjections()}
+		// canonicalSampleProjections). boundNewestTraces caps the result to
+		// the newest `limit` qualifying traces server-side, below the
+		// projection so the TraceStartNs sort key is still in scope.
+		return &chplan.Project{
+			Input:       boundNewestTraces(plan, searchLimitFromMeta(meta)),
+			Projections: spansetAggregateSampleProjections(),
+		}
 	case isAggregateShape(plan):
 		// MetricsAggregate / MetricsSecondStage output is just
 		// (group-keys, agg-func-aliases). SpanName / Timestamp /
@@ -1314,6 +1319,52 @@ func isProjectShape(plan chplan.Node) bool {
 	return ok
 }
 
+// metaKeySearchTraceLimit keys the /api/search trace limit the TraceQL Lang
+// stashes in engine.Meta.Extra (set in lang.go from traceql.SearchTraceLimit)
+// so the wrap projection can bound a spanset-aggregation result.
+const metaKeySearchTraceLimit = "searchTraceLimit"
+
+// searchLimitFromMeta reads the /api/search trace limit threaded through
+// engine.Meta.Extra, or 0 (unbounded) when absent.
+func searchLimitFromMeta(meta engine.Meta) int64 {
+	if v, ok := meta.Extra[metaKeySearchTraceLimit].(int64); ok {
+		return v
+	}
+	return 0
+}
+
+// boundNewestTraces caps a spanset-aggregation search (`| count() > N`,
+// `| by(name)`, `| avg(...) > X`) to the newest `limit` qualifying traces
+// server-side as ORDER BY TraceStartNs DESC LIMIT N — the parity counterpart to
+// the SQL LIMIT plain search gets via its SearchTraceLimit node, mirroring the
+// Go-side sortSummariesStartDesc + TruncateSummaries this path also runs. The
+// aggregate is untouched: ORDER+LIMIT only select WHICH finished per-trace
+// groups are emitted, so count()/avg()/by() still compute over every trace in
+// the window. Without it a busy window drains every qualifying group and can
+// trip the per-query sample budget — a spurious 422 where Tempo returns the
+// newest N. The ORDER BY is load-bearing: a bare LIMIT on a GROUP BY is
+// non-deterministic. No-op unless limit > 0.
+func boundNewestTraces(plan chplan.Node, limit int64) chplan.Node {
+	if limit <= 0 {
+		return plan
+	}
+	return &chplan.Limit{
+		Count: limit,
+		Input: &chplan.OrderBy{
+			Input: plan,
+			// TraceStartNs DESC, TraceId ASC — byte-parity with the Go-side
+			// sortSummariesStartDesc tie-break (start DESC, then TraceId ASC),
+			// so which trace lands inside vs outside the LIMIT at an exact
+			// start-ns collision is deterministic and matches the old drain-all
+			// path. Both are Aggregate output columns.
+			Keys: []chplan.OrderKey{
+				{Expr: &chplan.ColumnRef{Name: "TraceStartNs"}, Desc: true},
+				{Expr: &chplan.ColumnRef{Name: "TraceId"}, Desc: false},
+			},
+		},
+	}
+}
+
 // isAggregateShape reports whether the plan's output schema is just
 // the Aggregate's projected columns (group-keys + agg-func aliases),
 // i.e. the otel_traces canonical columns aren't available. Covers
@@ -1373,6 +1424,11 @@ func aggregateCarriesSpansetEnvelope(a *chplan.Aggregate) bool {
 		"MetricName":    false,
 		"ResourceAttrs": false,
 		"TimeUnix":      false,
+		// boundNewestTraces sorts the result by TraceStartNs; require it here
+		// too so the shape-matcher and the ORDER BY key stay in lockstep — a
+		// future envelope without TraceStartNs must not match (the ORDER BY
+		// would reference a non-existent alias).
+		"TraceStartNs": false,
 	}
 	for _, af := range a.AggFuncs {
 		if _, ok := wanted[af.Alias]; ok {

--- a/internal/api/tempo/handler_test.go
+++ b/internal/api/tempo/handler_test.go
@@ -1559,3 +1559,37 @@ func TestResponseHeaders_EngineInstrumentation(t *testing.T) {
 		}
 	})
 }
+
+// TestSearch_SpansetAggregate_ResultLimitPushedToSQL — the /api/search limit is
+// now pushed server-side as ORDER BY TraceStartNs DESC LIMIT N for a spanset
+// aggregation, instead of draining every qualifying group and truncating in Go
+// (which trips the per-query sample budget → spurious 422 on busy windows). The
+// aggregate is untouched (the SpansetAggregate_* correctness tests still pass);
+// only the emitted output set is bounded to the newest N traces.
+func TestSearch_SpansetAggregate_ResultLimitPushedToSQL(t *testing.T) {
+	t.Parallel()
+	q := &stubQuerier{}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	// `{ resource.service.name = "frontend" } | count() > 0` with limit=7.
+	resp, err := http.Get(srv.URL + "/api/search?limit=7&q=%7B%20resource.service.name%20%3D%20%22frontend%22%20%7D%20%7C%20count%28%29%20%3E%200")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	if !strings.Contains(q.lastSQL, "TraceStartNs` DESC") {
+		t.Errorf("aggregate search SQL must ORDER BY TraceStartNs DESC; got %s", q.lastSQL)
+	}
+	// Secondary TraceId key — the deterministic tie-break matching the Go-side
+	// sortSummariesStartDesc (start DESC, then TraceId ASC).
+	if !strings.Contains(q.lastSQL, "DESC, `TraceId`") {
+		t.Errorf("aggregate search SQL must tie-break on TraceId; got %s", q.lastSQL)
+	}
+	if !strings.Contains(q.lastSQL, "LIMIT 7") {
+		t.Errorf("aggregate search SQL must push the request LIMIT 7 server-side; got %s", q.lastSQL)
+	}
+}

--- a/internal/api/tempo/lang.go
+++ b/internal/api/tempo/lang.go
@@ -82,6 +82,10 @@ func (l *traceqlLang) Parse(ctx context.Context, query string) (chplan.Node, eng
 		IsMetric:      false,
 		IsTraceByID:   false,
 		ResponseShape: "tempo-trace",
+		// Carry the /api/search trace limit so ProjectSamples can cap a
+		// spanset-aggregation search to the newest N traces server-side
+		// (the parity counterpart to plain search's SearchTraceLimit node).
+		Extra: map[string]any{metaKeySearchTraceLimit: traceql_lower.SearchTraceLimit(ctx)},
 	}, nil
 }
 

--- a/internal/traceql/search_limit.go
+++ b/internal/traceql/search_limit.go
@@ -44,6 +44,13 @@ func searchTraceLimit(ctx context.Context) int64 {
 	return 0
 }
 
+// SearchTraceLimit exposes the /api/search trace limit (WithSearchTraceLimit)
+// to adapters that finalise the plan outside this package — the Tempo Lang's
+// ProjectSamples wrap reads it to cap a spanset-aggregation search to the
+// newest N traces server-side, the parity counterpart to the SearchTraceLimit
+// node plain search already gets. 0 = unbounded.
+func SearchTraceLimit(ctx context.Context) int64 { return searchTraceLimit(ctx) }
+
 // stampNestedSetTraceLimit walks the lowered plan and sets TraceLimit on
 // every NestedSetAnnotate whose input plan guarantees each returned trace's
 // root span is in the result set — the precondition under which ranking the


### PR DESCRIPTION
Follow-up to GAP-3 (#1121). A TraceQL aggregation search — `{svc} | count() > N`, `| by(name)`, `| avg(duration) > X` — is window-bounded but the `/api/search` `limit` was applied **only Go-side**: the handler drained **every** qualifying group then `TruncateSummaries[:limit]`. On a busy window that drains more groups than the per-query sample budget allows → a **spurious 422**, where the equivalent plain search (SQL `LIMIT` via its `SearchTraceLimit` node) and Tempo both return the newest N.

## Fix
Push the limit server-side as `ORDER BY TraceStartNs DESC LIMIT N`, **below** the envelope `Project` so the `TraceStartNs` sort key is still in scope. This mirrors the Go-side `sortSummariesStartDesc + TruncateSummaries` byte-for-byte in *selection* — `count()/avg()/by()` are **unchanged** (ORDER+LIMIT only pick which finished per-trace groups are emitted; the aggregate still runs over every trace in the window). The `ORDER BY` is load-bearing: a bare `LIMIT` on a `GROUP BY` is non-deterministic.

Plumbing: handler→ctx (`WithSearchTraceLimit`) → `engine.Meta.Extra` → `wrapWithSampleProjection`, via the new exported `traceql.SearchTraceLimit` accessor. The Tempo Lang already owns the wrap projection, so the bound lives next to it.

## Explicitly NOT an OOM fix
A 4-agent understand pass confirmed that path is **already bounded** (GAP-3 window + unconditional GROUP BY spill + 5M sample budget). An input trace-gate would be redundant **and** semantically wrong (counting over N traces, not all). This is a **Tempo-parity + transfer-cost** fix.

## Tests
- `TestSearch_SpansetAggregate_ResultLimitPushedToSQL`: SQL now carries `ORDER BY TraceStartNs DESC … LIMIT 7`.
- Existing `TestSearch_SpansetAggregate_*` (per-trace count, multi-span duration replay) still pass → aggregate semantics unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)