### PR TITLE
fix(logql): clean-room Drain miner, drop AGPL drain+logproto from /patterns

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -118,6 +118,10 @@ components:
   api-info:       { in: api/info }
   chclienttest:   { in: chclienttest }
   qlcommon:       { in: qlcommon }
+  # Clean-room in-house Drain log-template miner (replaces the AGPL
+  # grafana/loki pkg/pattern/drain). Stdlib-only leaf; the loki `/patterns`
+  # handler trains it over a peek window.
+  drain:          { in: drain }
   # Static fan-out perf linter — reads the chplan IR; leaf utility.
   perf-fanout:    { in: perf/fanout }
   # Boot-time requirements preflight — reads CH version + system.columns
@@ -258,6 +262,7 @@ deps:
       - optimizer
       - logql
       - lsyntax
+      - drain
   api-prom:
     mayDependOn:
       - chplan

--- a/internal/api/loki/patterns.go
+++ b/internal/api/loki/patterns.go
@@ -6,12 +6,11 @@ import (
 	"sort"
 	"time"
 
-	"github.com/grafana/loki/v3/pkg/logproto"
-	drainpkg "github.com/grafana/loki/v3/pkg/pattern/drain"
 	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/tsouza/cerberus/internal/chclient"
 	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/drain"
 	"github.com/tsouza/cerberus/internal/logql"
 	"github.com/tsouza/cerberus/internal/schema"
 )
@@ -37,15 +36,6 @@ type Pattern struct {
 	Level   string     `json:"level"`
 	Samples [][2]int64 `json:"samples"`
 }
-
-// nilLimits satisfies drain.Limits with no per-tenant JSON tokenisation
-// hints. Cerberus is single-tenant; the upstream pattern ingester uses
-// this hook to tokenise specific JSON fields differently, but the
-// format passed to drain.New ignores it for FormatUnknown (the generic
-// punctuation tokeniser).
-type nilLimits struct{}
-
-func (nilLimits) PatternIngesterTokenizableJSONFields(string) []string { return nil }
 
 // handlePatterns implements GET /loki/api/v1/patterns.
 //
@@ -158,15 +148,12 @@ func buildPatternsSQL(s schema.Logs, matchers []*labels.Matcher, start, end time
 // shape. Returns an empty (non-nil) slice when no lines hit any cluster
 // — the JSON envelope encodes that as `data:[]`, matching upstream Loki.
 //
-// drain.New(FormatUnknown) uses the punctuation tokeniser, which is the
-// most generic of the three (JSON / logfmt / unknown) and works on
-// arbitrary log lines. Cerberus does not run DetectLogFormat on the
-// first line because that gates the tokeniser for all subsequent lines
-// — a single non-JSON / non-logfmt row in a mostly-JSON stream would
-// then break tokenisation for the rest. The punctuation tokeniser is
-// equally happy with all three shapes.
+// The miner is the in-house clean-room Drain implementation
+// (internal/drain), which tokenises on whitespace and treats
+// digit-bearing tokens as variables — generic enough for arbitrary log
+// lines without a per-format tokeniser gate.
 func minePatterns(lines []chclient.TimestampedLine) []Pattern {
-	d := drainpkg.New("", drainpkg.DefaultConfig(), nilLimits{}, drainpkg.FormatUnknown, nil)
+	d := drain.New(drain.DefaultConfig())
 	for _, line := range lines {
 		d.Train(line.Body, line.Timestamp.UnixNano())
 	}
@@ -195,22 +182,16 @@ func minePatterns(lines []chclient.TimestampedLine) []Pattern {
 	return out
 }
 
-// projectSamples converts drain's per-cluster []*logproto.PatternSample
-// (Timestamp model.Time = millisecond, Value int64 = count) onto the
-// upstream wire shape `[][unix_seconds, count]`. Samples are sorted by
-// timestamp ascending so the response is stable across runs.
-//
-// model.Time is milliseconds-since-epoch typed as int64; its .Unix()
-// returns seconds. Upstream's WriteQueryPatternsResponseJSON calls
-// `sample.Timestamp.Unix()`, which strips the millisecond component —
-// cerberus matches that exactly.
-func projectSamples(samples []*logproto.PatternSample) [][2]int64 {
+// projectSamples converts the in-house drain cluster samples
+// (TimestampUnixSec, Count) onto the upstream wire shape
+// `[][unix_seconds, count]`. Samples already arrive ascending by
+// timestamp (drain.Cluster.Samples sorts), and the resolution is whole
+// seconds, matching upstream's `WriteQueryPatternsResponseJSON`, which
+// emits `sample.Timestamp.Unix()`.
+func projectSamples(samples []drain.Sample) [][2]int64 {
 	out := make([][2]int64, 0, len(samples))
 	for _, s := range samples {
-		if s == nil {
-			continue
-		}
-		out = append(out, [2]int64{s.Timestamp.Unix(), s.Value})
+		out = append(out, [2]int64{s.TimestampUnixSec, s.Count})
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i][0] < out[j][0] })
 	return out

--- a/internal/drain/drain.go
+++ b/internal/drain/drain.go
@@ -1,0 +1,338 @@
+// Package drain mines log-line templates from a stream of log records
+// using the Drain algorithm — Pinjia He, Jieming Zhu, Zibin Zheng and
+// Michael R. Lyu, "Drain: An Online Log Parsing Approach with Fixed
+// Depth Tree", ICWS 2017.
+//
+// This is a clean-room in-house implementation written from the
+// published algorithm, NOT ported from any existing source. It exists
+// so the cerberus binary can serve Loki's `/loki/api/v1/patterns`
+// endpoint without linking the AGPLv3 `github.com/grafana/loki/v3/pkg/
+// pattern/drain` package (and its transitive `pkg/logproto` →
+// `pkg/logql/syntax` AGPL closure).
+//
+// Algorithm recap (paper §3):
+//
+//   - Preprocessing: each log message is split into tokens on
+//     whitespace.
+//   - Step 1 — search by length: the first tree layer buckets messages
+//     by their token count, on the premise that messages from the same
+//     template usually share a length.
+//   - Step 2 — search by preceding tokens: a fixed-depth tree is walked
+//     using the leading tokens. A token that contains a digit is treated
+//     as a wildcard during the walk (numeric tokens are almost always
+//     variables), which keeps the tree from exploding. A per-node child
+//     cap routes overflow to the wildcard branch.
+//   - Step 3 — search by token similarity: at the leaf, the message is
+//     compared against each candidate log group's template token by
+//     token; similarity is the fraction of non-wildcard positions that
+//     match. The closest group above a threshold wins; otherwise a new
+//     group is created.
+//   - Update: on a match, every template position whose token differs
+//     from the message becomes a wildcard, generalising the template.
+package drain
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+)
+
+// wildcard is the placeholder token Drain stores for variable
+// positions, both in the parse tree and in a cluster's template. It is
+// rendered to the Loki wire form by [Cluster.String].
+const wildcard = "<*>"
+
+// wireWildcard is how a variable position is rendered in the
+// `/patterns` response, matching Loki's pattern template format
+// (`<_>`).
+const wireWildcard = "<_>"
+
+// Default tuning, from the paper's evaluation (depth 4, similarity
+// threshold 0.4) plus a conventional 100-child cap to bound tree fan-out.
+const (
+	defaultDepth        = 4
+	defaultSimThreshold = 0.4
+	defaultMaxChildren  = 100
+	// defaultSampleResolution buckets per-cluster sample counts onto a
+	// coarse time grid for the `/patterns` time series, mirroring the
+	// resolution Loki's pattern endpoint reports.
+	defaultSampleResolution = 10 * time.Second
+)
+
+// Config tunes the miner. The zero value is not usable; build one with
+// [DefaultConfig].
+type Config struct {
+	// Depth is the fixed tree depth (number of leading-token layers
+	// walked before reaching the leaf log groups). Must be >= 2.
+	Depth int
+	// SimThreshold is the minimum token-similarity (in [0,1]) for a
+	// message to join an existing cluster rather than spawn a new one.
+	SimThreshold float64
+	// MaxChildren caps the children of any internal tree node; overflow
+	// is folded into the wildcard branch.
+	MaxChildren int
+	// SampleResolution is the time-bucket granularity for per-cluster
+	// sample counts.
+	SampleResolution time.Duration
+}
+
+// DefaultConfig returns the paper's recommended parameters.
+func DefaultConfig() Config {
+	return Config{
+		Depth:            defaultDepth,
+		SimThreshold:     defaultSimThreshold,
+		MaxChildren:      defaultMaxChildren,
+		SampleResolution: defaultSampleResolution,
+	}
+}
+
+// Sample is one time-bucketed observation count for a cluster.
+type Sample struct {
+	// TimestampUnixSec is the bucket's start, in whole seconds since the
+	// Unix epoch.
+	TimestampUnixSec int64
+	// Count is the number of log lines that landed in this bucket.
+	Count int64
+}
+
+// Cluster is a discovered log template plus its observation counts.
+type Cluster struct {
+	tokens  []string
+	count   int64
+	samples map[int64]int64
+	res     time.Duration
+}
+
+// String renders the template in Loki's wire form: tokens joined by a
+// single space, with variable positions shown as `<_>`.
+func (c *Cluster) String() string {
+	if len(c.tokens) == 0 {
+		return ""
+	}
+	out := make([]string, len(c.tokens))
+	for i, tok := range c.tokens {
+		if tok == wildcard {
+			out[i] = wireWildcard
+			continue
+		}
+		out[i] = tok
+	}
+	return strings.Join(out, " ")
+}
+
+// Count is the total number of log lines folded into this cluster.
+func (c *Cluster) Count() int64 { return c.count }
+
+// Samples returns the per-bucket observation counts, ascending by
+// timestamp.
+func (c *Cluster) Samples() []Sample {
+	out := make([]Sample, 0, len(c.samples))
+	for ts, n := range c.samples {
+		out = append(out, Sample{TimestampUnixSec: ts, Count: n})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].TimestampUnixSec < out[j].TimestampUnixSec })
+	return out
+}
+
+// observe records one log line at tsNano against this cluster.
+func (c *Cluster) observe(tsNano int64) {
+	c.count++
+	bucket := time.Unix(0, tsNano).Truncate(c.res).Unix()
+	if c.samples == nil {
+		c.samples = map[int64]int64{}
+	}
+	c.samples[bucket]++
+}
+
+// node is one parse-tree node. Internal nodes route by token via
+// children; leaf nodes carry the log groups in clusters.
+type node struct {
+	children map[string]*node
+	clusters []*Cluster
+}
+
+func newNode() *node { return &node{children: map[string]*node{}} }
+
+// Miner is a Drain parse tree. It is not safe for concurrent use; the
+// cerberus `/patterns` handler builds a fresh miner per request.
+type Miner struct {
+	cfg  Config
+	root *node
+	all  []*Cluster
+}
+
+// New builds an empty miner with cfg.
+func New(cfg Config) *Miner {
+	if cfg.Depth < 2 {
+		cfg.Depth = defaultDepth
+	}
+	if cfg.MaxChildren < 1 {
+		cfg.MaxChildren = defaultMaxChildren
+	}
+	if cfg.SampleResolution <= 0 {
+		cfg.SampleResolution = defaultSampleResolution
+	}
+	return &Miner{cfg: cfg, root: newNode()}
+}
+
+// Train folds one log line (observed at tsNano nanoseconds since the
+// epoch) into the tree, creating or updating a cluster. Empty lines are
+// ignored.
+func (m *Miner) Train(line string, tsNano int64) {
+	tokens := strings.Fields(line)
+	if len(tokens) == 0 {
+		return
+	}
+	if cl := m.treeSearch(tokens); cl != nil {
+		m.updateTemplate(cl, tokens)
+		cl.observe(tsNano)
+		return
+	}
+	cl := &Cluster{tokens: append([]string(nil), tokens...), res: m.cfg.SampleResolution}
+	m.addCluster(cl)
+	cl.observe(tsNano)
+	m.all = append(m.all, cl)
+}
+
+// Clusters returns every discovered cluster in creation order. The
+// caller is responsible for any wire-shape sorting.
+func (m *Miner) Clusters() []*Cluster { return m.all }
+
+// treeSearch walks the fixed-depth tree for tokens and returns the
+// best-matching cluster at the leaf, or nil if no path or no group
+// clears the similarity threshold.
+func (m *Miner) treeSearch(tokens []string) *Cluster {
+	lenNode, ok := m.root.children[strconv.Itoa(len(tokens))]
+	if !ok {
+		return nil
+	}
+	parent := lenNode
+	depth := 1
+	for _, tok := range tokens {
+		if depth >= m.cfg.Depth || depth > len(tokens) {
+			break
+		}
+		if child, ok := parent.children[tok]; ok {
+			parent = child
+		} else if child, ok := parent.children[wildcard]; ok {
+			parent = child
+		} else {
+			return nil
+		}
+		depth++
+	}
+	return m.fastMatch(parent.clusters, tokens)
+}
+
+// addCluster inserts cl into the tree, creating the length and
+// leading-token nodes along the way. Numeric leading tokens collapse to
+// the wildcard branch, as does any node that exceeds the child cap.
+func (m *Miner) addCluster(cl *Cluster) {
+	tokens := cl.tokens
+	lenKey := strconv.Itoa(len(tokens))
+	lenNode, ok := m.root.children[lenKey]
+	if !ok {
+		lenNode = newNode()
+		m.root.children[lenKey] = lenNode
+	}
+	parent := lenNode
+	depth := 1
+	for _, tok := range tokens {
+		if depth >= m.cfg.Depth || depth > len(tokens) {
+			break
+		}
+		parent = m.descendForInsert(parent, tok)
+		depth++
+	}
+	parent.clusters = append(parent.clusters, cl)
+}
+
+// descendForInsert returns the child of parent that tok routes to when
+// inserting, creating it if necessary.
+func (m *Miner) descendForInsert(parent *node, tok string) *node {
+	if hasNumber(tok) {
+		return getOrCreate(parent, wildcard)
+	}
+	if child, ok := parent.children[tok]; ok {
+		return child
+	}
+	// New literal child only if there is room; otherwise overflow into
+	// the wildcard branch to bound fan-out.
+	if len(parent.children) >= m.cfg.MaxChildren {
+		return getOrCreate(parent, wildcard)
+	}
+	return getOrCreate(parent, tok)
+}
+
+func getOrCreate(parent *node, key string) *node {
+	if child, ok := parent.children[key]; ok {
+		return child
+	}
+	child := newNode()
+	parent.children[key] = child
+	return child
+}
+
+// fastMatch picks the candidate cluster with the highest token
+// similarity (tie-broken by wildcard count) that clears the threshold.
+func (m *Miner) fastMatch(candidates []*Cluster, tokens []string) *Cluster {
+	var best *Cluster
+	bestSim := -1.0
+	bestParams := -1
+	for _, cl := range candidates {
+		sim, params := seqSimilarity(cl.tokens, tokens)
+		if sim > bestSim || (sim == bestSim && params > bestParams) {
+			bestSim, bestParams, best = sim, params, cl
+		}
+	}
+	if best != nil && bestSim >= m.cfg.SimThreshold {
+		return best
+	}
+	return nil
+}
+
+// updateTemplate generalises cl's template against a newly matched line:
+// any non-wildcard position whose token differs becomes a wildcard.
+func (m *Miner) updateTemplate(cl *Cluster, tokens []string) {
+	for i := range cl.tokens {
+		if i >= len(tokens) {
+			break
+		}
+		if cl.tokens[i] != wildcard && cl.tokens[i] != tokens[i] {
+			cl.tokens[i] = wildcard
+		}
+	}
+}
+
+// seqSimilarity returns the fraction of non-wildcard template positions
+// that equal the message token, and the number of wildcard positions.
+// template and tokens are assumed equal length (same length-node leaf).
+func seqSimilarity(template, tokens []string) (sim float64, params int) {
+	if len(template) == 0 {
+		return 1, 0
+	}
+	matched := 0
+	for i, tmpl := range template {
+		if tmpl == wildcard {
+			params++
+			continue
+		}
+		if i < len(tokens) && tmpl == tokens[i] {
+			matched++
+		}
+	}
+	return float64(matched) / float64(len(template)), params
+}
+
+// hasNumber reports whether tok contains a decimal digit — Drain's
+// heuristic for "this token is probably a variable".
+func hasNumber(tok string) bool {
+	for _, r := range tok {
+		if unicode.IsDigit(r) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/drain/drain_test.go
+++ b/internal/drain/drain_test.go
@@ -1,0 +1,185 @@
+package drain_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/drain"
+)
+
+// findCluster returns the first cluster whose template contains every
+// given substring, or nil.
+func findCluster(clusters []*drain.Cluster, subs ...string) *drain.Cluster {
+	for _, c := range clusters {
+		s := c.String()
+		ok := true
+		for _, sub := range subs {
+			if !contains(s, sub) {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			return c
+		}
+	}
+	return nil
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}
+
+// TestDrain_FoldsVariableTokens — structurally identical lines that
+// differ only in numeric IDs collapse into one cluster, with the
+// varying positions generalised to `<_>` and the constant positions
+// preserved verbatim.
+func TestDrain_FoldsVariableTokens(t *testing.T) {
+	t.Parallel()
+	d := drain.New(drain.DefaultConfig())
+	base := time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC)
+	lines := []string{
+		"GET /api/users/1 status=200 latency=5ms",
+		"GET /api/users/2 status=200 latency=7ms",
+		"GET /api/users/42 status=200 latency=4ms",
+		"GET /api/users/1337 status=200 latency=11ms",
+	}
+	for i, l := range lines {
+		d.Train(l, base.Add(time.Duration(i)*time.Second).UnixNano())
+	}
+
+	clusters := d.Clusters()
+	if len(clusters) != 1 {
+		t.Fatalf("expected 1 cluster, got %d: %+v", len(clusters), clusters)
+	}
+	got := clusters[0].String()
+	const want = "GET <_> status=200 <_>"
+	if got != want {
+		t.Fatalf("template = %q, want %q", got, want)
+	}
+	if clusters[0].Count() != 4 {
+		t.Fatalf("count = %d, want 4", clusters[0].Count())
+	}
+	var sum int64
+	for _, s := range clusters[0].Samples() {
+		sum += s.Count
+	}
+	if sum != 4 {
+		t.Fatalf("sample count sum = %d, want 4", sum)
+	}
+}
+
+// TestDrain_SeparatesDistinctShapes — lines whose constant (non-numeric)
+// leading tokens differ land in distinct clusters; the variable-only
+// positions still generalise within each.
+func TestDrain_SeparatesDistinctShapes(t *testing.T) {
+	t.Parallel()
+	d := drain.New(drain.DefaultConfig())
+	ts := time.Now().UnixNano()
+	for _, l := range []string{
+		"GET /api/foo/1 status=200 latency=5ms",
+		"GET /api/foo/2 status=200 latency=7ms",
+		"POST /bar status=500 latency=22ms",
+		"POST /bar status=500 latency=18ms",
+	} {
+		d.Train(l, ts)
+	}
+
+	clusters := d.Clusters()
+	if len(clusters) != 2 {
+		t.Fatalf("expected 2 clusters, got %d: %+v", len(clusters), clusters)
+	}
+	get := findCluster(clusters, "GET", "200", "<_>")
+	if get == nil {
+		t.Fatalf("no GET/200 cluster: %+v", clusters)
+	}
+	post := findCluster(clusters, "POST", "/bar", "500")
+	if post == nil {
+		t.Fatalf("no POST/bar/500 cluster: %+v", clusters)
+	}
+	// The POST cluster keeps the constant `/bar` literal (no digit, never
+	// varied) and generalises only the latency suffix.
+	if post.String() != "POST /bar status=500 <_>" {
+		t.Fatalf("POST template = %q, want %q", post.String(), "POST /bar status=500 <_>")
+	}
+}
+
+// TestDrain_EmptyLinesIgnored — blank / whitespace-only lines never
+// create a cluster.
+func TestDrain_EmptyLinesIgnored(t *testing.T) {
+	t.Parallel()
+	d := drain.New(drain.DefaultConfig())
+	ts := time.Now().UnixNano()
+	d.Train("", ts)
+	d.Train("   \t  ", ts)
+	if n := len(d.Clusters()); n != 0 {
+		t.Fatalf("expected 0 clusters from empty input, got %d", n)
+	}
+}
+
+// TestDrain_SampleBucketing — observations bucket onto the configured
+// resolution grid: four lines within one bucket window collapse to a
+// single sample whose count is the total, timestamped at the bucket
+// start in whole seconds.
+func TestDrain_SampleBucketing(t *testing.T) {
+	t.Parallel()
+	cfg := drain.DefaultConfig()
+	cfg.SampleResolution = 10 * time.Second
+	d := drain.New(cfg)
+	// Bucket-aligned base (multiple of 10s) so the truncated timestamp is
+	// the base itself.
+	base := time.Unix(1778760000, 0).UTC()
+	for i := 0; i < 4; i++ {
+		d.Train("GET /x/1 ok done", base.Add(time.Duration(i)*time.Second).UnixNano())
+	}
+	clusters := d.Clusters()
+	if len(clusters) != 1 {
+		t.Fatalf("expected 1 cluster, got %d", len(clusters))
+	}
+	samples := clusters[0].Samples()
+	if len(samples) != 1 {
+		t.Fatalf("expected 1 bucket, got %d: %+v", len(samples), samples)
+	}
+	if samples[0].TimestampUnixSec != 1778760000 {
+		t.Fatalf("bucket ts = %d, want 1778760000", samples[0].TimestampUnixSec)
+	}
+	if samples[0].Count != 4 {
+		t.Fatalf("bucket count = %d, want 4", samples[0].Count)
+	}
+}
+
+// TestDrain_SplitsAcrossBuckets — observations far apart in time land in
+// separate buckets while still folding into one cluster, and the bucket
+// counts still sum to the line count.
+func TestDrain_SplitsAcrossBuckets(t *testing.T) {
+	t.Parallel()
+	cfg := drain.DefaultConfig()
+	cfg.SampleResolution = 10 * time.Second
+	d := drain.New(cfg)
+	base := time.Unix(1778760000, 0).UTC()
+	d.Train("GET /x/1 ok done", base.UnixNano())
+	d.Train("GET /x/2 ok done", base.Add(time.Minute).UnixNano())
+	clusters := d.Clusters()
+	if len(clusters) != 1 {
+		t.Fatalf("expected 1 cluster, got %d", len(clusters))
+	}
+	samples := clusters[0].Samples()
+	if len(samples) != 2 {
+		t.Fatalf("expected 2 buckets, got %d: %+v", len(samples), samples)
+	}
+	if samples[0].TimestampUnixSec >= samples[1].TimestampUnixSec {
+		t.Fatalf("samples not ascending: %+v", samples)
+	}
+	var sum int64
+	for _, s := range samples {
+		sum += s.Count
+	}
+	if sum != 2 {
+		t.Fatalf("sample sum = %d, want 2", sum)
+	}
+}


### PR DESCRIPTION
## What

Replaces the AGPLv3 `grafana/loki/v3/pkg/pattern/drain` miner and `pkg/logproto.PatternSample` wire struct — used only by `/loki/api/v1/patterns` — with **`internal/drain`**, a clean-room in-house implementation written from the published Drain algorithm (He et al., *"Drain: An Online Log Parsing Approach with Fixed Depth Tree"*, ICWS 2017). No loki source was consulted — paper algorithm only.

## Why this is the keystone

`pkg/logproto` directly imports `pkg/logql/syntax`, so this one endpoint transitively linked the **entire** loki AGPL closure into the Apache-licensed `cmd/cerberus` binary — `pkg/logql/log`, `pkg/logql/syntax`, `logqlmodel`, `querier/plan`, `tsdb/index`, the `iter/v2` subtree, etc. No other de-AGPL work could reduce the binary footprint while `/patterns` kept these imports.

```
go list -deps ./cmd/cerberus | grep grafana/loki :  24 → 17
```
Removed: `pattern/drain`, `logproto`, `logql/syntax`, `querier/plan`, `iter/v2`, `util/encoding`, `util/labelpool`, `tsdb/index`. The remaining 17 are the `pkg/logql/log` eval-surface closure, removed in the stacked follow-up PR.

## Algorithm

Fixed-depth parse tree keyed by token count + leading tokens; digit-bearing tokens treated as wildcards during the walk (per-node child cap routes overflow to the wildcard branch); per-leaf log groups merged by token-sequence similarity (threshold 0.4); template generalisation on match. Samples are time-bucketed to whole seconds for the `/patterns` wire shape.

## Tests / no golden churn

The existing `/patterns` tests assert **structurally** (cluster membership, `<_>` placeholders, sample-count sums, unix-second timestamps), not against a frozen loki-drain string, so a from-paper miner passes with zero golden churn:

- `internal/drain` unit tests (folding, shape separation, empty-line skip, sample bucketing) — 5 pass
- `internal/api/loki` patterns + conformance — 16 pass
- full `internal/api/loki` suite — 325 pass
- chDB roundtrip (`-tags chdb`, `TestPatterns_ChDB_*`) — 2 pass
- `go-arch-lint` + scoped `golangci-lint` clean (`drain` declared as a leaf component)

No `agpl_oracle` A/B for drain: a from-paper miner deliberately differs from loki's tuned tokeniser, so reference equality is not the contract here. Byte-equality A/B oracles land with the eval-surface parsers (json/logfmt/jsonexpr/pattern) in the follow-up.

Part of the loki de-AGPL track. Stacked on #1130 (clean-room LogQL parser).

🤖 Generated with [Claude Code](https://claude.com/claude-code)