### PR TITLE
fix(license): de-AGPL audit cleanup

### DIFF
--- a/.github/scripts/agpl-clean.mjs
+++ b/.github/scripts/agpl-clean.mjs
@@ -1,9 +1,11 @@
 // agpl-clean.mjs — the provably-clean-build licence gate.
 //
 // Cerberus ships under Apache-2.0. Its LogQL and TraceQL parsers are
-// in-house clean-room Apache reimplementations (internal/logql/lsyntax,
-// internal/logql/logpattern, internal/drain, internal/traceql/ast); PromQL
-// uses the upstream Apache prometheus parser. The AGPLv3 grafana/loki and
+// in-house, independent Apache reimplementations (internal/logql/lsyntax,
+// internal/logql/logpattern, internal/drain, internal/traceql/ast); a small
+// set of error-message strings is deliberately matched to upstream for wire
+// compatibility (documented at each site). PromQL uses the upstream Apache
+// prometheus parser. The AGPLv3 grafana/loki and
 // grafana/tempo parsers survive only as test-only oracles (the agpl_oracle-
 // tagged tests and the compatibility harnesses), never in the shipped binary.
 // Linking AGPL code into the Apache binary distributed as `cmd/cerberus`

--- a/NOTICE
+++ b/NOTICE
@@ -12,10 +12,12 @@ In-house clean-room parsers (LogQL, TraceQL)
 
 Cerberus's LogQL parser (internal/logql/lsyntax, internal/logql/logpattern,
 internal/drain) and TraceQL parser (internal/traceql/ast) are original,
-clean-room implementations written by the Cerberus authors from the published
-LogQL and TraceQL language grammars and HTTP API documentation. They are NOT
-derived from, and contain no source code copied from, Grafana Loki or Grafana
-Tempo.
+independent reimplementations written by the Cerberus authors from the
+published LogQL and TraceQL language grammars and HTTP API documentation. They
+are not derived from, and do not copy source code from, Grafana Loki or Grafana
+Tempo, with one narrow exception: a small set of error-message strings is
+deliberately reproduced verbatim so that Cerberus returns wire-compatible error
+text to clients (each such string is documented at its definition site).
 
 These parsers are API-compatible with Grafana Loki and Grafana Tempo so that
 Cerberus can act as a drop-in datasource. "Loki", "Tempo", "Grafana",

--- a/compatibility/loki/README.md
+++ b/compatibility/loki/README.md
@@ -55,9 +55,10 @@ compatibility/loki/
 
 ## Upstream corpus
 
-The snapshot pins `grafana/loki` directly: the `tsouza/loki` fork
-tracks `pkg/logql/syntax/`, `pkg/logql/log/`, and `pkg/logqlmodel/`,
-so `pkg/logql/bench/` is outside the fork's watch boundary.
+The snapshot pins `grafana/loki` directly. This vendored
+`pkg/logql/bench/` corpus is reference test material only — it is never
+linked into `cmd/cerberus`; the shipped LogQL parser is cerberus's own
+in-house reimplementation (`internal/logql/lsyntax`).
 
 Vendored paths (the authoritative inventory is in
 `upstream/loki-bench/VERSION`):
@@ -307,6 +308,6 @@ $EDITOR compatibility/loki/upstream/loki-bench/VERSION
 ## Related docs
 
 - [`docs/compatibility.md`](../../docs/compatibility.md) — cross-head playbook
-- [`docs/upstream-forks.md`](../../docs/upstream-forks.md) — how the `tsouza/loki` fork is wired (and why the bench corpus is outside it)
+- [`docs/upstream-forks.md`](../../docs/upstream-forks.md) — the in-house LogQL parser and the remaining watch-boundary forks
 - [`compatibility/prometheus/`](../prometheus/) — sibling Prom harness
 - [`compatibility/tempo/`](../tempo/) — sibling Tempo harness

--- a/compatibility/loki/upstream/loki-bench/VERSION
+++ b/compatibility/loki/upstream/loki-bench/VERSION
@@ -4,10 +4,10 @@
 # this directory. See ../../README.md and ../../../docs/loki-compliance-plan.md
 # for the bump procedure.
 #
-# Cerberus's `tsouza/loki` fork (replace directive in go.mod) only
-# tracks `pkg/logql/syntax/`, `pkg/logql/log/`, and `pkg/logqlmodel`;
-# `pkg/logql/bench/` is OUT of that watch boundary. The snapshot here
-# therefore pins grafana/loki directly rather than the fork tag.
+# This `pkg/logql/bench/` corpus is reference test material only — it is
+# never linked into cmd/cerberus (the shipped LogQL parser is cerberus's
+# own in-house reimplementation, internal/logql/lsyntax). The snapshot
+# here pins grafana/loki directly.
 
 upstream_repo:     github.com/grafana/loki
 upstream_tag:      v3.7.0

--- a/compatibility/tempo/README.md
+++ b/compatibility/tempo/README.md
@@ -11,7 +11,7 @@ PromQL parity, but the Tempo / TraceQL surface has **no upstream
 "tempo-compliance" repo**. The closest analogue is
 `cmd/tempo-vulture`, Grafana's deterministic seed + read-back canary.
 This harness vendors `cmd/tempo-vulture/` and `pkg/httpclient/` from
-the `tsouza/tempo` fork as reference material under `upstream/`,
+`grafana/tempo` as reference material under `upstream/`,
 drives both backends from a cerberus-owned driver
 (`driver/`), and writes JSON + markdown reports whose envelope matches
 the Prom harness's so one downstream analyser handles both.
@@ -113,28 +113,25 @@ The tag endpoints pin three classes of subset assertion:
 ## What's in `upstream/`
 
 A pure, unmodified snapshot of two paths from
-`github.com/grafana/tempo`, brought in via the `github.com/tsouza/tempo`
-fork that already gates cerberus's tempo dependency (see
-[`docs/upstream-forks.md`](../../docs/upstream-forks.md)). The
-`cerberus-accessors` branch only patches `pkg/traceql/`; the two paths
-vendored here (`cmd/tempo-vulture/` and `pkg/httpclient/`) are
-byte-identical between the fork tag and the upstream commit it tracks.
+`github.com/grafana/tempo` (`cmd/tempo-vulture/` and `pkg/httpclient/`),
+taken directly from the upstream commit `go.mod` pins for the Apache
+`pkg/tempopb` wire types.
 
 Exact coordinates live in [`upstream/VERSION`](upstream/VERSION).
 
 ### Why vendor, not import via `go.mod`
 
-`github.com/grafana/tempo` is already in `go.mod` via the replace
-directive that points at `github.com/tsouza/tempo`, so we **could**
-just import `pkg/httpclient` directly. We vendor instead because:
+`github.com/grafana/tempo` is already a direct require in `go.mod` (for
+the Apache `pkg/tempopb` wire types), so we **could** just import
+`pkg/httpclient` directly. We vendor instead because:
 
 1. **Reference material, not a build dependency.** The driver imports
    only a narrow subset of this code; vendoring lets reviewers read
    the seeder pattern in the diff without grepping `~/go/pkg/mod/`.
 2. **`cmd/tempo-vulture` is a `package main`**, not importable.
    Vendoring it keeps the source visible for the driver to adapt.
-3. **Snapshot stability.** A future bump of the tsouza/tempo replace
-   tag won't silently move the seeder pattern under our feet; the
+3. **Snapshot stability.** A future bump of the grafana/tempo version
+   in go.mod won't silently move the seeder pattern under our feet; the
    snapshot here is pinned and explicit.
 
 ### Why the vendor isn't compiled
@@ -159,8 +156,8 @@ With it in place:
 ## Bump procedure
 
 The vendor is **not** automatically refreshed when `go.mod`'s
-`tsouza/tempo` tag bumps — the cerberus-accessors branch only patches
-`pkg/traceql/`, so a fork-tag bump rarely touches vendored paths. Do a
+`grafana/tempo` version bumps — a version bump rarely touches the
+vendored `cmd/tempo-vulture/` and `pkg/httpclient/` paths. Do a
 manual re-snapshot only when:
 
 1. Upstream Grafana adds a meaningful capability to `cmd/tempo-vulture`
@@ -171,12 +168,13 @@ manual re-snapshot only when:
 To re-snapshot:
 
 ```sh
-# 1. Read the current replace target in go.mod.
-grep '^replace github.com/grafana/tempo' go.mod
-#    => replace github.com/grafana/tempo => github.com/tsouza/tempo vX.Y.Z
+# 1. Read the current grafana/tempo version in go.mod.
+grep '^\s*github.com/grafana/tempo ' go.mod
+#    => github.com/grafana/tempo vX.Y.Z-0.<timestamp>-<commit>
 
-# 2. Clone the fork at that tag.
-git clone --depth=1 -b vX.Y.Z https://github.com/tsouza/tempo /tmp/tempo-upstream
+# 2. Clone grafana/tempo at that commit.
+git clone --depth=1 https://github.com/grafana/tempo /tmp/tempo-upstream
+git -C /tmp/tempo-upstream fetch --depth=1 origin <commit> && git -C /tmp/tempo-upstream checkout <commit>
 
 # 3. Wipe the existing snapshot and re-copy.
 rm -rf compatibility/tempo/upstream/{cmd,pkg,LICENSE}
@@ -185,8 +183,8 @@ cp -r /tmp/tempo-upstream/cmd/tempo-vulture  compatibility/tempo/upstream/cmd/
 cp -r /tmp/tempo-upstream/pkg/httpclient     compatibility/tempo/upstream/pkg/
 cp    /tmp/tempo-upstream/LICENSE            compatibility/tempo/upstream/LICENSE
 
-# 4. Update upstream/VERSION with the new fork tag + commit SHA and
-#    the matching upstream/main base commit.
+# 4. Update upstream/VERSION with the new grafana/tempo commit SHA and
+#    describe.
 $EDITOR compatibility/tempo/upstream/VERSION
 
 # 5. PR the diff. Reviewer checks the bump procedure was followed
@@ -208,6 +206,6 @@ lives OUTSIDE `upstream/` and is cerberus-licensed.
 ## Related docs
 
 - [`docs/compatibility.md`](../../docs/compatibility.md) — cross-head playbook
-- [`docs/upstream-forks.md`](../../docs/upstream-forks.md) — how the `tsouza/tempo` fork is wired
+- [`docs/upstream-forks.md`](../../docs/upstream-forks.md) — the in-house TraceQL parser and the remaining watch-boundary forks
 - [`compatibility/prometheus/`](../prometheus/) — sibling Prom harness
 - [`compatibility/loki/`](../loki/) — sibling Loki harness

--- a/compatibility/tempo/docker-compose.yml
+++ b/compatibility/tempo/docker-compose.yml
@@ -7,8 +7,8 @@
 #                        the alpine variant regression.
 #   tempo                Reference grafana/tempo single-binary, listens on
 #                        :3200 (HTTP) and :4317 (OTLP gRPC). Pinned to the
-#                        commit-hash tag that matches the tsouza/tempo
-#                        replace target in go.mod — see the inline note
+#                        commit-hash tag that matches the grafana/tempo
+#                        version pinned in go.mod — see the inline note
 #                        on the version pin.
 #   cerberus-tempo       cerberus under test, listens on :29092. Same
 #                        Dockerfile.local image as the prom harness; the
@@ -58,22 +58,21 @@ services:
       - "28124:8123"
 
   tempo:
-    # Pin to the commit-hash tag that matches the tsouza/tempo replace
-    # target in go.mod. Reasoning:
+    # Pin to the commit-hash tag that matches the grafana/tempo version
+    # in go.mod. Reasoning:
     #
-    #   go.mod replace: github.com/grafana/tempo =>
-    #       github.com/tsouza/tempo v0.0.1-cerberus-accessors
+    #   go.mod: github.com/grafana/tempo
+    #       v1.5.1-0.20260508211128-2f74ea818de1
+    #   (pseudo-version of grafana/tempo commit
+    #   2f74ea818de1377e6ac9dd15117fa284c9c6ba36
+    #   = `v3.0.0-rc.1-7-g2f74ea818`, see harness/.../upstream/VERSION).
     #
-    #   tsouza/tempo cerberus-accessors branches from grafana/tempo
-    #   commit 2f74ea818de1377e6ac9dd15117fa284c9c6ba36
-    #   (= `v3.0.0-rc.1-7-g2f74ea818`, see harness/.../upstream/VERSION).
-    #
-    # Tempo's pkg/traceql parser ships in the server binary, so a Docker
-    # image that lags or leads the fork's branch point will diff against
+    # Tempo's pkg/traceql parser ships in the reference server binary, so a
+    # Docker image that lags or leads that commit will diff against
     # cerberus for purely-parser reasons. `grafana/tempo:main-2f74ea8`
-    # is built from the exact upstream commit the tsouza/tempo fork
-    # branches from. Bump the tag here in lock-step when the tsouza/tempo
-    # replace tag moves (procedure in compatibility/tempo/README.md).
+    # is built from the exact upstream commit go.mod pins. Bump the tag
+    # here in lock-step when the grafana/tempo version in go.mod moves
+    # (procedure in compatibility/tempo/README.md).
     image: grafana/tempo:main-2f74ea8
     command: ["-config.file=/etc/tempo.yaml"]
     volumes:

--- a/compatibility/tempo/tempo-config.yaml
+++ b/compatibility/tempo/tempo-config.yaml
@@ -25,7 +25,7 @@
 #       harness's read paths.
 #
 # When the tempo image pin in docker-compose.yml bumps (in lock-step
-# with the tsouza/tempo go.mod replace), revisit this config: Tempo's
+# with the grafana/tempo go.mod version), revisit this config: Tempo's
 # config schema occasionally renames fields between minor versions.
 
 stream_over_http_enabled: true

--- a/compatibility/tempo/upstream/VERSION
+++ b/compatibility/tempo/upstream/VERSION
@@ -1,17 +1,12 @@
-# Vendored from github.com/tsouza/tempo (fork of grafana/tempo).
+# Vendored from github.com/grafana/tempo.
 #
 # This file records the EXACT upstream coordinates of the snapshot under
 # this directory. See ./README.md and ../../docs/tempo-compliance-plan.md
 # for the bump procedure.
 
-fork_repo:        github.com/tsouza/tempo
-fork_tag:         v0.0.1-cerberus-accessors
-fork_commit:      5e75744c3b21a850c7ac374591ef3ef2e857fc6d
-
-# Upstream commit on grafana/tempo:main that cerberus-accessors was
-# branched from. The cerberus-accessors branch only patches pkg/traceql/;
-# cmd/tempo-vulture/ and pkg/httpclient/ are byte-identical between the
-# fork tag and this upstream base (verified via `git diff`).
+# Snapshot taken from the grafana/tempo commit that go.mod pins for the
+# Apache pkg/tempopb wire types. cmd/tempo-vulture/ and pkg/httpclient/
+# are vendored verbatim from this commit.
 upstream_repo:    github.com/grafana/tempo
 upstream_commit:  2f74ea818de1377e6ac9dd15117fa284c9c6ba36
 upstream_describe: v3.0.0-rc.1-7-g2f74ea818

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -8,10 +8,13 @@ intrinsic / metrics-op — with an honest support status.
 
 ## How to read this
 
-Cerberus parses each head with its **reference upstream parser**
-(`prometheus/promql/parser`, `grafana/loki/v3/pkg/logql/syntax`,
-`grafana/tempo/pkg/traceql`), so anything those parsers accept, cerberus
-parses. The status below reflects whether cerberus's full
+Cerberus parses PromQL with the upstream Apache `prometheus/promql/parser`,
+and parses LogQL and TraceQL with its own in-house clean-room Apache
+reimplementations (`internal/logql/lsyntax`, `internal/traceql/ast`),
+validated against the upstream AGPL `grafana/loki/v3/pkg/logql/syntax` and
+`grafana/tempo/pkg/traceql` parsers as test-only differential oracles. So
+anything those reference parsers accept, cerberus parses. The status below
+reflects whether cerberus's full
 `parse → fold → lower → optimize → emit` pipeline turns a symbol into
 ClickHouse SQL, measured against what the reference backend does with the
 same query.

--- a/internal/api/loki/detected_extract.go
+++ b/internal/api/loki/detected_extract.go
@@ -83,7 +83,7 @@ func (j *jsonExtractor) labelValue(key, value []byte, dataType jsonparser.ValueT
 		// Top-level scalar: sanitise the bare key. The JSON path is the
 		// single RAW key (matching upstream, which records the unsanitised
 		// key under the sanitised label name).
-		sk := sanitizeLabelKey(string(key), true)
+		sk := sanitizeLabelKey(string(key))
 		if sk == "" {
 			return
 		}
@@ -124,7 +124,7 @@ func extractLogfmt(line []byte, stream map[string]string) map[string]string {
 		if !dec.scanKeyval() {
 			continue
 		}
-		key := sanitizeLabelKey(string(dec.Key()), true)
+		key := sanitizeLabelKey(string(dec.Key()))
 		if key == "" {
 			continue
 		}
@@ -176,14 +176,14 @@ func unescapeJSONString(b []byte) string {
 }
 
 // sanitizeLabelKey replaces every non-`[A-Za-z0-9_]` byte with `_`,
-// trims surrounding space, and (for the prefix form) prepends `_` when
-// the key starts with a digit. Matches upstream sanitizeLabelKey.
-func sanitizeLabelKey(key string, isPrefix bool) string {
+// trims surrounding space, and prepends `_` when the key starts with a
+// digit. Matches upstream sanitizeLabelKey.
+func sanitizeLabelKey(key string) string {
 	key = strings.TrimSpace(key)
 	if len(key) == 0 {
 		return key
 	}
-	if isPrefix && key[0] >= '0' && key[0] <= '9' {
+	if key[0] >= '0' && key[0] <= '9' {
 		key = "_" + key
 	}
 	return strings.Map(func(r rune) rune {

--- a/internal/api/tempo/grpc/service.go
+++ b/internal/api/tempo/grpc/service.go
@@ -7,8 +7,8 @@
 // stream incrementally over this surface.
 //
 // Wire-format generated stubs live in github.com/grafana/tempo/pkg/
-// tempopb (routed through the tsouza/tempo:cerberus-accessors fork —
-// see go.mod). This package only depends on the generated server
+// tempopb — the plain Apache-2.0 upstream wire types, a direct require
+// in go.mod (no fork). This package only depends on the generated server
 // interface + the cerberus query pipeline (Engine, schema, admit
 // limiter); no protoc plumbing is needed in tree.
 //

--- a/internal/api/tempo/metrics_query_range.go
+++ b/internal/api/tempo/metrics_query_range.go
@@ -711,20 +711,18 @@ func formatPhi(v float64) string {
 // anchor) wire shape Tempo's HistogramAggregator emits.
 //
 // For each (group_labels_minus_bucket, anchor) pair, the per-bucket
-// counts feed `pkg/traceql.Log2QuantileWithBucket(phi, buckets)` from
-// the cerberus-accessors Tempo fork — the same power-of-two
-// bucket-interpolation routine `HistogramAggregator.Results` runs
-// upstream. The post-processor then emits one `chclient.Sample` per
-// (group_labels_minus_bucket, phi, anchor) with a synthetic
-// `p="<phi>"` label.
+// counts feed the in-house `log2QuantileWithBucket(phi, buckets)`
+// (metrics_histogram.go) — cerberus's own clean-room reimplementation
+// of the same power-of-two bucket-interpolation routine
+// `HistogramAggregator.Results` runs upstream. The post-processor then
+// emits one `chclient.Sample` per (group_labels_minus_bucket, phi,
+// anchor) with a synthetic `p="<phi>"` label.
 //
 // Why a post-processor rather than rendering the algorithm as CH SQL:
-// the upstream algorithm is non-trivial (boundary handling for
-// p100, exponential interpolation between bucket maxima, plus an
-// edge-case sample-count rounding rule) and is being tweaked over
-// time in Tempo upstream. Reusing the upstream function via the
-// cerberus-accessors fork keeps the two backends bit-for-bit aligned
-// even as Tempo refines the algorithm.
+// the algorithm is non-trivial (boundary handling for p100, exponential
+// interpolation between bucket maxima, plus an edge-case sample-count
+// rounding rule). Keeping it as a small Go reimplementation keeps the
+// two backends aligned while staying independent of the AGPL upstream.
 //
 // Returns a fresh `[]chclient.Sample`; the input slice is read-only.
 func postProcessQuantileBuckets(samples []chclient.Sample, m *chplan.MetricsAggregate) []chclient.Sample {

--- a/internal/chplan/metrics_compare.go
+++ b/internal/chplan/metrics_compare.go
@@ -5,7 +5,8 @@ package chplan
 // operator (Grafana Traces Drilldown's "Comparison" tab).
 //
 // Reference semantics (grafana/tempo pkg/traceql/engine_metrics_compare.go,
-// consumed via the tsouza/tempo cerberus-accessors fork): every span
+// the AGPL upstream cerberus reimplements clean-room — consulted only as a
+// test-only oracle, never linked): every span
 // produced by the query's pipeline is split into two cohorts —
 // "selection" (spans matching the compare() filter, optionally further
 // restricted to a unix-nanosecond start/end window) and "baseline"

--- a/internal/logql/doc.go
+++ b/internal/logql/doc.go
@@ -2,6 +2,7 @@
 // clean-room parser in internal/logql/lsyntax, keeps a thin high-level IR
 // wrapping the parser AST, and lowers expressions into the shared
 // internal/chplan IR. Runtime evaluation helpers (line/label filter
-// execution, templating, pattern/drain extraction) are still consumed
-// from grafana/loki/pkg/logql/log.
+// execution, templating, pattern/drain extraction) are cerberus's own
+// implementations in internal/api/loki, internal/drain, and
+// internal/logql/logpattern — no AGPL grafana/loki code is linked.
 package logql

--- a/internal/logql/lang.go
+++ b/internal/logql/lang.go
@@ -363,11 +363,11 @@ func parseExprTraced(ctx context.Context, query string) (syntax.Expr, error) {
 // during parsing itself, so the permissive path still surfaces them
 // downstream when cerberus's lowering walks the AST.
 //
-// Detection is by error-message substring because the upstream
-// errAtleastOneEqualityMatcherRequired constant is unexported.
-// `empty-compatible` is unique to that single rejection path in
-// vendored Loki v3.0.0-cerberus-parser, so the substring is stable
-// across the corpus the cerberus-forks-monitor rebases.
+// Detection is by error-message substring because the in-house
+// lsyntax errEmptyCompatibleMatcherRejected constant is unexported.
+// This is a cerberus-internal substring contract between lsyntax's
+// validator and this permissive path: `empty-compatible` is unique to
+// that single rejection message, so the substring is stable.
 //
 // Exported so handlers outside the logql package
 // (internal/api/loki/index_stats.go's selectorMatchers,

--- a/internal/logql/lsyntax/binop.go
+++ b/internal/logql/lsyntax/binop.go
@@ -3,8 +3,6 @@ package lsyntax
 import (
 	"fmt"
 	"math"
-
-	"github.com/prometheus/prometheus/promql"
 )
 
 // IsLogicalBinOp reports whether op is one of the logical/set binary
@@ -18,131 +16,62 @@ func IsLogicalBinOp(op string) bool {
 	return false
 }
 
-// MergeBinOp evaluates a binary operation between two scalar samples.
-// It mirrors the upstream LogQL scalar merge semantics and backs the
-// parse-time constant folding of literal-only binary expressions.
-func MergeBinOp(op string, left, right *promql.Sample, swap, filter, isVectorComparison bool) (*promql.Sample, error) {
-	var merger func(left, right *promql.Sample) *promql.Sample
-
+// foldScalarBinOp evaluates a binary operation between two scalar values,
+// mirroring the upstream LogQL scalar-merge semantics. It backs the
+// parse-time constant folding of literal-only binary expressions, where
+// both legs are always concrete scalars (no vector comparison, no filter
+// semantics).
+func foldScalarBinOp(op string, left, right float64) (float64, error) {
 	switch op {
 	case OpTypeAdd:
-		merger = func(l, r *promql.Sample) *promql.Sample {
-			if l == nil || r == nil {
-				return nil
-			}
-			res := *l
-			res.F += r.F
-			return &res
-		}
+		return left + right, nil
 	case OpTypeSub:
-		merger = func(l, r *promql.Sample) *promql.Sample {
-			if l == nil || r == nil {
-				return nil
-			}
-			res := *l
-			res.F -= r.F
-			return &res
-		}
+		return left - right, nil
 	case OpTypeMul:
-		merger = func(l, r *promql.Sample) *promql.Sample {
-			if l == nil || r == nil {
-				return nil
-			}
-			res := *l
-			res.F *= r.F
-			return &res
-		}
+		return left * right, nil
 	case OpTypeDiv:
-		merger = func(l, r *promql.Sample) *promql.Sample {
-			if l == nil || r == nil {
-				return nil
-			}
-			res := *l
-			if r.F == 0 {
-				res.F = math.NaN()
-			} else {
-				res.F /= r.F
-			}
-			return &res
+		if right == 0 {
+			return math.NaN(), nil
 		}
+		return left / right, nil
 	case OpTypeMod:
-		merger = func(l, r *promql.Sample) *promql.Sample {
-			if l == nil || r == nil {
-				return nil
-			}
-			res := *l
-			if r.F == 0 {
-				res.F = math.NaN()
-			} else {
-				res.F = math.Mod(res.F, r.F)
-			}
-			return &res
+		if right == 0 {
+			return math.NaN(), nil
 		}
+		return math.Mod(left, right), nil
 	case OpTypePow:
-		merger = func(l, r *promql.Sample) *promql.Sample {
-			if l == nil || r == nil {
-				return nil
-			}
-			res := *l
-			res.F = math.Pow(l.F, r.F)
-			return &res
-		}
+		return math.Pow(left, right), nil
 	case OpTypeCmpEQ:
-		merger = comparator(func(l, r float64) bool { return l == r }, filter)
+		return boolToFloat(left == right), nil
 	case OpTypeNEQ:
-		merger = comparator(func(l, r float64) bool { return l != r }, filter)
+		return boolToFloat(left != right), nil
 	case OpTypeGT:
-		merger = comparator(func(l, r float64) bool { return l > r }, filter)
+		return boolToFloat(left > right), nil
 	case OpTypeGTE:
-		merger = comparator(func(l, r float64) bool { return l >= r }, filter)
+		return boolToFloat(left >= right), nil
 	case OpTypeLT:
-		merger = comparator(func(l, r float64) bool { return l < r }, filter)
+		return boolToFloat(left < right), nil
 	case OpTypeLTE:
-		merger = comparator(func(l, r float64) bool { return l <= r }, filter)
+		return boolToFloat(left <= right), nil
 	default:
-		return nil, fmt.Errorf("should never happen: unexpected operation: (%s)", op)
+		return 0, fmt.Errorf("should never happen: unexpected operation: (%s)", op)
 	}
-
-	res := merger(left, right)
-	if !isVectorComparison {
-		return res, nil
-	}
-	if filter {
-		retSample := left
-		if swap {
-			retSample = right
-		}
-		if res != nil {
-			return retSample, nil
-		}
-	}
-	return res, nil
 }
 
-func comparator(pred func(l, r float64) bool, filter bool) func(l, r *promql.Sample) *promql.Sample {
-	return func(l, r *promql.Sample) *promql.Sample {
-		if l == nil || r == nil {
-			return nil
-		}
-		res := *l
-		val := 0.0
-		if pred(l.F, r.F) {
-			val = 1.0
-		} else if filter {
-			return nil
-		}
-		res.F = val
-		return &res
+func boolToFloat(b bool) float64 {
+	if b {
+		return 1.0
 	}
+	return 0.0
 }
 
 // reduceBinOp folds a binary operation between two literal floats into a
 // single literal, maintaining the invariant that a BinOpExpr never has
 // two literal legs.
 func reduceBinOp(op string, left, right float64) *LiteralExpr {
-	merged, err := MergeBinOp(op, &promql.Sample{F: left}, &promql.Sample{F: right}, false, false, false)
+	val, err := foldScalarBinOp(op, left, right)
 	if err != nil {
 		return &LiteralExpr{err: err}
 	}
-	return &LiteralExpr{Val: merged.F}
+	return &LiteralExpr{Val: val}
 }

--- a/internal/logql/lsyntax/parser.go
+++ b/internal/logql/lsyntax/parser.go
@@ -93,11 +93,13 @@ func ParseLogSelector(input string, validate bool) (LogSelectorExpr, error) {
 // validation
 // ------------------------------------------------------------------
 
-// errAtLeastOneEqualityMatcherRequired is the message the upstream LogQL
-// parser produces when a selector has no matcher that constrains a
-// non-empty value. cerberus's permissive parse path keys its retry on
-// the "empty-compatible" substring, so the wording is preserved.
-const errAtLeastOneEqualityMatcherRequired = "queries require at least one regexp or equality matcher that does not have an empty-compatible value. For instance, app=~\".*\" does not meet this requirement, but app=~\".+\" will"
+// errEmptyCompatibleMatcherRejected is returned when a selector has no
+// matcher that constrains a non-empty value. The error text is
+// deliberately matched to upstream Loki for wire compatibility: it is
+// returned verbatim to clients, and cerberus's permissive parse path
+// (logql.ParseExprPermissive) keys its retry on the "empty-compatible"
+// substring, so the wording must not drift.
+const errEmptyCompatibleMatcherRejected = "queries require at least one regexp or equality matcher that does not have an empty-compatible value. For instance, app=~\".*\" does not meet this requirement, but app=~\".+\" will"
 
 func validateExpr(expr Expr) error {
 	switch e := expr.(type) {
@@ -172,7 +174,7 @@ func validateMatchers(matchers []*labels.Matcher) error {
 			return nil
 		}
 	}
-	return NewParseError(errAtLeastOneEqualityMatcherRequired, 0, 0)
+	return NewParseError(errEmptyCompatibleMatcherRejected, 0, 0)
 }
 
 // matcherEmptyCompatible reports whether a matcher also matches the empty

--- a/internal/traceql/aggregate.go
+++ b/internal/traceql/aggregate.go
@@ -1,6 +1,6 @@
 // This file (and select.go) read parser AST nodes exclusively via the
-// upstream-fork-exposed accessors on github.com/tsouza/tempo:cerberus-accessors
-// — no reflection, no pointer aliasing tricks. See docs/upstream-forks.md.
+// typed accessors on cerberus's in-house TraceQL AST
+// (internal/traceql/ast) — no reflection, no pointer aliasing tricks.
 
 package traceql
 
@@ -54,9 +54,8 @@ const (
 // lowerAggregate handles `| count()`, `| sum(...)`, `| avg(...)`,
 // `| max(...)`, `| min(...)`. count() has no inner expression — we
 // aggregate the constant 1 per row. The other four read the inner
-// FieldExpression via the upstream-fork-exposed Aggregate.InnerExpr()
-// accessor (github.com/tsouza/tempo:cerberus-accessors) — see
-// docs/upstream-forks.md.
+// FieldExpression via the in-house Aggregate.InnerExpr() accessor
+// (internal/traceql/ast).
 //
 // Per-trace identity is preserved by grouping on TraceId and
 // piggybacking representative envelope columns (SpanName,

--- a/internal/traceql/ast/attribute.go
+++ b/internal/traceql/ast/attribute.go
@@ -2,8 +2,6 @@ package ast
 
 import (
 	"strings"
-	"text/scanner"
-	"unicode"
 )
 
 // Attribute is a reference to a span/resource/trace field or an intrinsic.
@@ -95,15 +93,12 @@ func (a Attribute) String() string {
 }
 
 // containsNonAttributeRune reports whether s holds any rune that cannot
-// appear in a bare attribute name and therefore forces quoting. The
-// disallowed set is the lexer's structural punctuation plus whitespace.
+// appear in a bare attribute name and therefore forces quoting. It is the
+// exact inverse of the lexer's isAttributeRune, so the disallowed set (the
+// structural punctuation plus whitespace) is defined in one place only.
 func containsNonAttributeRune(s string) bool {
 	for _, r := range s {
-		if unicode.IsSpace(r) {
-			return true
-		}
-		switch r {
-		case scanner.EOF, '{', '}', '(', ')', '=', '~', '!', '<', '>', '&', '|', '^', ',':
+		if !isAttributeRune(r) {
 			return true
 		}
 	}

--- a/internal/traceql/ast/parser.go
+++ b/internal/traceql/ast/parser.go
@@ -246,7 +246,7 @@ func scalarFilterOp(k tokenKind) Operator {
 // =====================================================================
 
 func (c *cursor) parseRoot() *RootExpr {
-	first := c.parsePipelineStage(true)
+	first := c.parsePipelineStage()
 	elems := []PipelineElement{first}
 
 	var m1 FirstStageElement
@@ -260,7 +260,7 @@ func (c *cursor) parseRoot() *RootExpr {
 			break
 		}
 		c.advance() // consume PIPE
-		elems = append(elems, c.parsePipelineStage(false))
+		elems = append(elems, c.parsePipelineStage())
 	}
 
 	var lead PipelineElement
@@ -315,10 +315,11 @@ func asPipeline(e PipelineElement) Pipeline {
 // Pipeline stages
 // =====================================================================
 
-// parsePipelineStage parses one stage of a spanset pipeline. The first stage
-// permits the same forms as later ones (the grammar's only difference is that
-// coalesce may not lead; accepting it here is harmless over-acceptance).
-func (c *cursor) parsePipelineStage(_ bool) PipelineElement {
+// parsePipelineStage parses one stage of a spanset pipeline. Every stage
+// permits the same forms (the grammar's only difference is that coalesce may
+// not lead; accepting it everywhere is harmless over-acceptance, so the
+// position of the stage does not affect parsing).
+func (c *cursor) parsePipelineStage() PipelineElement {
 	switch c.kind() {
 	case tokBy:
 		return c.parseGroupOperation()
@@ -415,7 +416,7 @@ func (c *cursor) parseSpansetPrimary() SpansetExpression {
 // parseParenPipeline parses the contents of a parenthesised spanset, which may
 // itself be a `|`-chained pipeline or a spanset operator expression.
 func (c *cursor) parseParenPipeline() SpansetExpression {
-	first := c.parsePipelineStage(true)
+	first := c.parsePipelineStage()
 	if c.kind() != tokPipe {
 		if se, ok := first.(SpansetExpression); ok {
 			return se
@@ -425,7 +426,7 @@ func (c *cursor) parseParenPipeline() SpansetExpression {
 	elems := []PipelineElement{first}
 	for c.kind() == tokPipe {
 		c.advance()
-		elems = append(elems, c.parsePipelineStage(false))
+		elems = append(elems, c.parsePipelineStage())
 	}
 	return Pipeline{Elements: elems}
 }

--- a/internal/traceql/ast/pipeline.go
+++ b/internal/traceql/ast/pipeline.go
@@ -10,7 +10,6 @@ type RootExpr struct {
 	MetricsPipeline    FirstStageElement
 	MetricsSecondStage SecondStageElement
 	Hints              *Hints
-	OptimizationCount  int
 }
 
 func (r RootExpr) String() string {

--- a/internal/traceql/ast/rewrite.go
+++ b/internal/traceql/ast/rewrite.go
@@ -32,9 +32,6 @@ func rewritePipeline(p *Pipeline) {
 		switch e := elem.(type) {
 		case *SpansetFilter:
 			e.Expression = rewriteFieldExpr(e.Expression)
-		case SpansetFilter:
-			e.Expression = rewriteFieldExpr(e.Expression)
-			p.Elements[i] = e
 		case GroupOperation:
 			e.Expression = rewriteFieldExpr(e.Expression)
 			p.Elements[i] = e
@@ -72,9 +69,6 @@ func rewriteFieldExpr(fe FieldExpression) FieldExpression {
 		if folded, ok := foldArrayComparison(e); ok {
 			return folded
 		}
-		return e
-	case *UnaryOperation:
-		e.Expression = rewriteFieldExpr(e.Expression)
 		return e
 	case UnaryOperation:
 		e.Expression = rewriteFieldExpr(e.Expression)

--- a/internal/traceql/lower.go
+++ b/internal/traceql/lower.go
@@ -137,11 +137,10 @@ func lowerPipeline(p traceql.Pipeline, s schema.Traces) (chplan.Node, error) {
 // outermost chplan node (which matches the chsql emitter's
 // inside-out subquery wrap).
 //
-// The IR + chsql emit foundation landed in PR #437. This lowering
-// became wireable once tsouza/tempo v0.0.3-cerberus-accessors
-// exposed Op() / Limit() / Value() / Elements() / Separators()
-// accessors on the upstream-unexported SecondStageElement variants
-// (mirrors the MetricsAggregate accessor pattern from #143).
+// The IR + chsql emit foundation landed in PR #437. The in-house ast
+// (internal/traceql/ast) exposes Op() / Limit() / Value() / Elements() /
+// Separators() accessors on its SecondStageElement variants, which this
+// lowering reads to build the load-bearing shapes.
 func lowerMetricsSecondStage(inner chplan.Node, ss traceql.SecondStageElement) (chplan.Node, error) {
 	switch v := ss.(type) {
 	case *traceql.TopKBottomK:
@@ -694,7 +693,8 @@ func lowerFieldExpr(e traceql.FieldExpression, s schema.Traces) (chplan.Expr, er
 // so both the attribute and the intrinsic existence forms are
 // load-bearing shapes.
 //
-// Reference semantics (tsouza/tempo fork, pkg/traceql):
+// Reference semantics (grafana/tempo pkg/traceql, the AGPL upstream
+// cerberus reimplements clean-room — test-only oracle, never linked):
 //
 //   - `x != nil` (OpExists) evaluates to `static.Type != TypeNil`
 //     after executing x against the span (ast_execute.go). Intrinsic
@@ -759,8 +759,9 @@ func lowerUnaryOperation(u traceql.UnaryOperation, s schema.Traces) (chplan.Expr
 // (UnaryOperation{OpSub}) — e.g. `{ -span.foo > 0 }`,
 // `{ -(span.a + span.b) = -5 }`, `{ -span.duration < 0ns }`.
 //
-// Reference semantics (tsouza/tempo fork, ast_execute.go
-// UnaryOperation.execute, OpSub branch): the operand executes to a
+// Reference semantics (grafana/tempo pkg/traceql ast_execute.go
+// UnaryOperation.execute, OpSub branch — the AGPL upstream cerberus
+// reimplements clean-room, test-only oracle, never linked): the operand executes to a
 // Static; if its type is not numeric (int / float / duration) the
 // reference returns an error, otherwise it returns `-1 * n` preserving
 // the operand's numeric type (NewStaticInt / NewStaticFloat /

--- a/internal/traceql/metrics_compare.go
+++ b/internal/traceql/metrics_compare.go
@@ -14,7 +14,8 @@ import (
 // tab) into a chplan.MetricsCompare node.
 //
 // Reference semantics — grafana/tempo pkg/traceql/engine_metrics_compare.go
-// (consumed via the tsouza/tempo cerberus-accessors fork):
+// (the AGPL upstream cerberus reimplements clean-room; consulted only as a
+// test-only oracle, never linked into the binary):
 //
 //   - Every span the pipeline produces is assigned to one of two
 //     cohorts: "selection" (the span matches the compare() filter and,

--- a/internal/traceql/metrics_pipeline.go
+++ b/internal/traceql/metrics_pipeline.go
@@ -103,8 +103,8 @@ func lowerMetricsAggregate(prev chplan.Node, agg *traceql.MetricsAggregate, s sc
 		if len(qs) == 0 {
 			return nil, fmt.Errorf("traceql: quantile_over_time requires at least one quantile")
 		}
-		// Multi-quantile is accepted at the lowering layer (v0.0.3
-		// fork accessors expose the full slice via Quantiles()); the
+		// Multi-quantile is accepted at the lowering layer (the in-house
+		// ast exposes the full slice via Quantiles()); the
 		// emitted plan carries all phi values on
 		// chplan.MetricsAggregate.Quantiles. The chsql emitter
 		// (internal/chsql/range_window.go::metricsAggregateCH plus
@@ -117,8 +117,8 @@ func lowerMetricsAggregate(prev chplan.Node, agg *traceql.MetricsAggregate, s sc
 	// IsDuration drives the bucketise divisor in the chsql matrix-path
 	// quantile emitter (and the post-processor in
 	// internal/api/tempo/metrics_query_range.go) so the bucket edges fed
-	// into Tempo's Log2QuantileWithBucket match what
-	// pkg/traceql.bucketizeDuration produces upstream — Log2Bucketize(d)
+	// into the in-house log2QuantileWithBucket match what Tempo's
+	// bucketizeDuration produces upstream — Log2Bucketize(d)
 	// in nanos, divided by 1e9 so the bucket reads in seconds. Only
 	// quantile_over_time consults IsDuration today; the rest of the
 	// matrix path emits the same SQL whether or not the operand was
@@ -138,11 +138,10 @@ func lowerMetricsAggregate(prev chplan.Node, agg *traceql.MetricsAggregate, s sc
 	}, nil
 }
 
-// lowerAverageOverTime lowers Tempo's dedicated
-// *traceql.AverageOverTimeAggregator (the unexported
-// averageOverTimeAggregator surfaced via the exported type alias in the
-// cerberus-accessors fork) into a chplan.MetricsAggregate with
-// Op=MetricsOpAvgOverTime.
+// lowerAverageOverTime lowers the dedicated
+// *traceql.AverageOverTimeAggregator node (cerberus's in-house ast type,
+// modelled on Tempo's separate averageOverTimeAggregator) into a
+// chplan.MetricsAggregate with Op=MetricsOpAvgOverTime.
 //
 // Tempo parses `| avg_over_time(attr)` into
 // *averageOverTimeAggregator rather than *MetricsAggregate because

--- a/internal/traceql/select.go
+++ b/internal/traceql/select.go
@@ -13,10 +13,8 @@ import (
 )
 
 // lowerSelect handles `| select(.attr1, .attr2, ...)` projection.
-// The attribute list is read via the upstream-fork-exposed
-// SelectOperation.Attrs() accessor
-// (github.com/tsouza/tempo:cerberus-accessors) — see
-// docs/upstream-forks.md.
+// The attribute list is read via the in-house
+// SelectOperation.Attrs() accessor (internal/traceql/ast).
 //
 // Output: a chplan.Project that emits the standard span-identity
 // columns (TraceId, SpanId, Timestamp) plus the selected attribute

--- a/test/agpl_oracle/oracle_test.go
+++ b/test/agpl_oracle/oracle_test.go
@@ -1,0 +1,434 @@
+//go:build agpl_oracle
+
+// Package agpl_oracle holds the differential A/B check that pins the in-house
+// clean-room TraceQL parser (internal/traceql/ast) against the AGPL reference
+// parser (grafana/tempo/pkg/traceql). It is guarded by the `agpl_oracle` build
+// tag so the reference parser is NEVER linked into cmd/cerberus or any normal
+// `go test` run — it exists purely as a fidelity oracle you opt into with
+//
+//	go test -tags agpl_oracle ./test/agpl_oracle/...
+//
+// Two tiers run over the corpus:
+//
+//   - TestParserAcceptReject_AB asserts both parsers accept/reject every query
+//     identically, across the full grammar (spanset filters, field
+//     expressions, pipelines, and the metrics first/second stages).
+//   - TestParserStructural_AB additionally asserts a neutral S-expression of the
+//     parsed AST is byte-equal. Each AST is serialized over the *exported*
+//     surface of upstream tempo only — every enum (Operator, StaticType,
+//     AttributeScope, Intrinsic, …) is cast to its integer iota value rather
+//     than calling String(), so the comparison checks structure, not the two
+//     independently authored printers' cosmetics (pipe spacing, `IN` vs `in`,
+//     `1m` vs `1m0s`, parenthesization). It incidentally validates that the two
+//     packages' enum orderings match.
+//
+// Upstream tempo keeps the metrics/aggregate scalars (op, attr, quantiles,
+// limit, …) unexported with no accessors, so the structural tier covers the
+// spanset-filter / field-expression / scalar-filter / set-operation universe —
+// where the parser's real ambiguity (operator precedence, or→IN folding, scope
+// and intrinsic resolution, static typing) lives. The two nodes whose internals
+// upstream hides yet appear in that universe — Aggregate and SelectOperation —
+// are pinned via each parser's own local String(); the metrics first/second
+// stages are exercised by the accept/reject tier only.
+package agpl_oracle
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	tempo "github.com/grafana/tempo/pkg/traceql"
+
+	ast "github.com/tsouza/cerberus/internal/traceql/ast"
+)
+
+// structuralCorpus is the subset both parsers expose structurally: spanset
+// filters, field expressions, scalar filters, set/structural spanset
+// operations, group/select/coalesce pipeline elements, and aggregates compared
+// over scalars. It excludes the two transforms the in-house parser
+// intentionally defers (general two-static binary constant folding such as
+// `{ 1 + 1 = 2 }`, and parenthesized top-level scalar pipelines) — documented
+// gaps, not fidelity bugs, that diverge by design.
+var structuralCorpus = []string{
+	// Spanset filters: attribute matchers, scopes, intrinsics.
+	`{ resource.service.name = "frontend" }`,
+	`{ .http.status_code = 200 }`,
+	`{ span.http.method != "GET" }`,
+	`{ name =~ "foo.*" }`,
+	`{ name !~ "bar.*" }`,
+	`{ duration > 100ms }`,
+	`{ duration >= 1s && duration < 2s }`,
+	`{ status = error }`,
+	`{ status = ok }`,
+	`{ kind = server }`,
+	`{ kind = client }`,
+	`{ true }`,
+	`{ }`,
+	`{ .a = -100 }`,
+	`{ .x > 1 && .y < 2 }`,
+	`{ .x = 1 || .y = 2 }`,
+	`{ parent.span.http.method = "GET" }`,
+	`{ parent.resource.service.name = "x" }`,
+	`{ span:duration > 1s }`,
+	`{ trace:duration > 1s }`,
+	`{ span:name = "GET" }`,
+	`{ .ok = true }`,
+	`{ .ratio = 1.5 }`,
+
+	// Array-fold rewrites (or_to_in family).
+	`{ .x = "a" || .x = "b" }`,
+	`{ .x = "a" || .x = "b" || .x = "c" }`,
+	`{ .n = 1 || .n = 2 }`,
+	`{ .a != "x" && .a != "y" }`,
+	`{ name =~ "a.*" || name =~ "b.*" }`,
+	`{ name !~ "a.*" && name !~ "b.*" }`,
+
+	// Pipelines (aggregates pinned via local String()).
+	`{ .a = 1 } | count() > 2`,
+	`{ .a = 1 } | avg(duration) > 1s`,
+	`{ .a = 1 } | by(.b)`,
+	`{ .a = 1 } | select(.b, .c)`,
+	`{ .a = 1 } | coalesce()`,
+	`{ .a = 1 } | max(duration) > 500ms`,
+	`{ .a = 1 } | min(duration) < 1s`,
+	`{ .a = 1 } | sum(duration) > 1s`,
+
+	// Structural / set spanset operations.
+	`{ .a = 1 } >> { .b = 2 }`,
+	`{ .a = 1 } << { .b = 2 }`,
+	`{ .a = 1 } > { .b = 2 }`,
+	`{ .a = 1 } && { .b = 2 }`,
+	`{ .a = 1 } || { .b = 2 }`,
+	`{ .a = 1 } ~ { .b = 2 }`,
+	`{ .a = 1 } !> { .b = 2 }`,
+}
+
+// metricsCorpus exercises the metrics first/second stages, whose scalars
+// upstream tempo keeps unexported. These run through the accept/reject tier
+// only — there is no exported-surface structural view of them.
+var metricsCorpus = []string{
+	`{ .a = 1 } | rate()`,
+	`{ .a = 1 } | count_over_time()`,
+	`{ .a = 1 } | rate() by (resource.service.name)`,
+	`{ .a = 1 } | sum_over_time(duration)`,
+	`{ .a = 1 } | quantile_over_time(duration, 0.9, 0.99)`,
+	`{ .a = 1 } | histogram_over_time(duration)`,
+	`{ .a = 1 } | avg_over_time(duration)`,
+	`{ .a = 1 } | min_over_time(duration) by (.b)`,
+	`{ .a = 1 } | rate() | topk(5)`,
+	`{ .a = 1 } | rate() | bottomk(3)`,
+}
+
+// TestParserAcceptReject_AB pins accept/reject parity across the full grammar.
+func TestParserAcceptReject_AB(t *testing.T) {
+	for _, q := range append(append([]string{}, structuralCorpus...), metricsCorpus...) {
+		q := q
+		t.Run(q, func(t *testing.T) {
+			_, refErr := tempo.Parse(q)
+			_, gotErr := ast.Parse(q)
+			if (refErr == nil) != (gotErr == nil) {
+				t.Fatalf("accept/reject divergence: tempo err=%v, in-house err=%v", refErr, gotErr)
+			}
+		})
+	}
+}
+
+// TestParserStructural_AB pins structural equality over the exported-surface
+// subset.
+func TestParserStructural_AB(t *testing.T) {
+	for _, q := range structuralCorpus {
+		q := q
+		t.Run(q, func(t *testing.T) {
+			ref, refErr := tempo.Parse(q)
+			got, gotErr := ast.Parse(q)
+
+			if (refErr == nil) != (gotErr == nil) {
+				t.Fatalf("accept/reject divergence: tempo err=%v, in-house err=%v", refErr, gotErr)
+			}
+			if refErr != nil {
+				return // both rejected — agreement is enough.
+			}
+
+			want := tqRoot(ref)
+			have := astRoot(got)
+			if want != have {
+				t.Fatalf("structural divergence for %q\n tempo: %s\n  ours: %s", q, want, have)
+			}
+		})
+	}
+}
+
+// normStr canonicalizes the only cross-parser cosmetic divergence that reaches
+// the structural tier: the in-house printer lowercases the `in` / `not in`
+// set-membership tokens, upstream uppercases them. (Set-membership inside an
+// Aggregate's inner field expression is the sole place a node compared via
+// String() can carry one.)
+func normStr(s string) string {
+	s = strings.ReplaceAll(s, " NOT IN ", " not in ")
+	s = strings.ReplaceAll(s, " IN ", " in ")
+	return s
+}
+
+// ---- in-house (ast) serializer ----
+
+func astRoot(r *ast.RootExpr) string {
+	var b strings.Builder
+	b.WriteString("(root ")
+	b.WriteString(astPipeline(r.Pipeline))
+	b.WriteString(")")
+	return b.String()
+}
+
+func astPipeline(p ast.Pipeline) string {
+	parts := make([]string, len(p.Elements))
+	for i, e := range p.Elements {
+		parts[i] = astElement(e)
+	}
+	return "(pipe " + strings.Join(parts, " ") + ")"
+}
+
+func astElement(e ast.PipelineElement) string {
+	switch v := e.(type) {
+	case *ast.SpansetFilter:
+		return "(filter " + astField(v.Expression) + ")"
+	case ast.SpansetFilter:
+		return "(filter " + astField(v.Expression) + ")"
+	case ast.SpansetOperation:
+		return fmt.Sprintf("(sop %d %s %s)", int(v.Op), astSpanset(v.LHS), astSpanset(v.RHS))
+	case ast.ScalarFilter:
+		return fmt.Sprintf("(scf %d %s %s)", int(v.Op), astScalar(v.LHS), astScalar(v.RHS))
+	case ast.GroupOperation:
+		return "(by " + astField(v.Expression) + ")"
+	case ast.CoalesceOperation:
+		return "(coalesce)"
+	case ast.SelectOperation:
+		return "(select-str " + strconv.Quote(normStr(v.String())) + ")"
+	case ast.Aggregate:
+		return "(agg-str " + strconv.Quote(normStr(v.String())) + ")"
+	case ast.Pipeline:
+		return astPipeline(v)
+	default:
+		panic(fmt.Sprintf("ast: unhandled pipeline element %T", e))
+	}
+}
+
+func astSpanset(se ast.SpansetExpression) string {
+	switch v := se.(type) {
+	case *ast.SpansetFilter:
+		return "(filter " + astField(v.Expression) + ")"
+	case ast.SpansetFilter:
+		return "(filter " + astField(v.Expression) + ")"
+	case ast.SpansetOperation:
+		return fmt.Sprintf("(sop %d %s %s)", int(v.Op), astSpanset(v.LHS), astSpanset(v.RHS))
+	case ast.ScalarFilter:
+		return fmt.Sprintf("(scf %d %s %s)", int(v.Op), astScalar(v.LHS), astScalar(v.RHS))
+	case ast.Pipeline:
+		return astPipeline(v)
+	default:
+		panic(fmt.Sprintf("ast: unhandled spanset expr %T", se))
+	}
+}
+
+func astScalar(se ast.ScalarExpression) string {
+	switch v := se.(type) {
+	case ast.Aggregate:
+		return "(agg-str " + strconv.Quote(normStr(v.String())) + ")"
+	case ast.Static:
+		return astStatic(v)
+	case ast.Pipeline:
+		return astPipeline(v)
+	default:
+		panic(fmt.Sprintf("ast: unhandled scalar expr %T", se))
+	}
+}
+
+func astField(fe ast.FieldExpression) string {
+	switch v := fe.(type) {
+	case *ast.BinaryOperation:
+		return fmt.Sprintf("(b %d %s %s)", int(v.Op), astField(v.LHS), astField(v.RHS))
+	case *ast.UnaryOperation:
+		return fmt.Sprintf("(u %d %s)", int(v.Op), astField(v.Expression))
+	case ast.UnaryOperation:
+		return fmt.Sprintf("(u %d %s)", int(v.Op), astField(v.Expression))
+	case ast.Attribute:
+		return astAttr(v)
+	case ast.Static:
+		return astStatic(v)
+	default:
+		panic(fmt.Sprintf("ast: unhandled field expr %T", fe))
+	}
+}
+
+func astAttr(a ast.Attribute) string {
+	return fmt.Sprintf("(attr %d %t %d %q)", int(a.Scope), a.Parent, int(a.Intrinsic), a.Name)
+}
+
+func astStatic(s ast.Static) string {
+	return "(s " + strconv.Itoa(int(s.Type)) + ":" + astStaticValue(s) + ")"
+}
+
+func astStaticValue(s ast.Static) string {
+	switch s.Type {
+	case ast.TypeNil:
+		return "nil"
+	case ast.TypeInt:
+		n, _ := s.Int()
+		return strconv.Itoa(n)
+	case ast.TypeFloat:
+		return strconv.FormatFloat(s.Float(), 'g', -1, 64)
+	case ast.TypeString:
+		return strconv.Quote(s.EncodeToString(false))
+	case ast.TypeBoolean:
+		b, _ := s.Bool()
+		return strconv.FormatBool(b)
+	case ast.TypeDuration:
+		d, _ := s.Duration()
+		return strconv.FormatInt(int64(d), 10)
+	case ast.TypeStatus:
+		st, _ := s.Status()
+		return strconv.Itoa(int(st))
+	case ast.TypeKind:
+		k, _ := s.Kind()
+		return strconv.Itoa(int(k))
+	case ast.TypeIntArray, ast.TypeFloatArray, ast.TypeStringArray, ast.TypeBooleanArray:
+		var parts []string
+		for _, el := range s.Elements() {
+			parts = append(parts, astStaticValue(el))
+		}
+		return "[" + strings.Join(parts, ",") + "]"
+	default:
+		panic(fmt.Sprintf("ast: unhandled static type %d", int(s.Type)))
+	}
+}
+
+// ---- reference (tempo) serializer — structurally identical to the above,
+// over upstream's exported surface only ----
+
+func tqRoot(r *tempo.RootExpr) string {
+	var b strings.Builder
+	b.WriteString("(root ")
+	b.WriteString(tqPipeline(r.Pipeline))
+	b.WriteString(")")
+	return b.String()
+}
+
+func tqPipeline(p tempo.Pipeline) string {
+	parts := make([]string, len(p.Elements))
+	for i, e := range p.Elements {
+		parts[i] = tqElement(e)
+	}
+	return "(pipe " + strings.Join(parts, " ") + ")"
+}
+
+func tqElement(e tempo.Element) string {
+	switch v := e.(type) {
+	case *tempo.SpansetFilter:
+		return "(filter " + tqField(v.Expression) + ")"
+	case tempo.SpansetFilter:
+		return "(filter " + tqField(v.Expression) + ")"
+	case tempo.SpansetOperation:
+		return fmt.Sprintf("(sop %d %s %s)", int(v.Op), tqSpanset(v.LHS), tqSpanset(v.RHS))
+	case tempo.ScalarFilter:
+		return fmt.Sprintf("(scf %d %s %s)", int(v.Op), tqScalar(v.LHS), tqScalar(v.RHS))
+	case tempo.GroupOperation:
+		return "(by " + tqField(v.Expression) + ")"
+	case tempo.CoalesceOperation:
+		return "(coalesce)"
+	case tempo.SelectOperation:
+		return "(select-str " + strconv.Quote(normStr(v.String())) + ")"
+	case tempo.Aggregate:
+		return "(agg-str " + strconv.Quote(normStr(v.String())) + ")"
+	case tempo.Pipeline:
+		return tqPipeline(v)
+	default:
+		panic(fmt.Sprintf("tempo: unhandled pipeline element %T", e))
+	}
+}
+
+func tqSpanset(se tempo.SpansetExpression) string {
+	switch v := se.(type) {
+	case *tempo.SpansetFilter:
+		return "(filter " + tqField(v.Expression) + ")"
+	case tempo.SpansetOperation:
+		return fmt.Sprintf("(sop %d %s %s)", int(v.Op), tqSpanset(v.LHS), tqSpanset(v.RHS))
+	case tempo.ScalarFilter:
+		return fmt.Sprintf("(scf %d %s %s)", int(v.Op), tqScalar(v.LHS), tqScalar(v.RHS))
+	case tempo.Pipeline:
+		return tqPipeline(v)
+	default:
+		panic(fmt.Sprintf("tempo: unhandled spanset expr %T", se))
+	}
+}
+
+func tqScalar(se tempo.ScalarExpression) string {
+	switch v := se.(type) {
+	case tempo.Aggregate:
+		return "(agg-str " + strconv.Quote(normStr(v.String())) + ")"
+	case tempo.Static:
+		return tqStatic(v)
+	case tempo.Pipeline:
+		return tqPipeline(v)
+	default:
+		panic(fmt.Sprintf("tempo: unhandled scalar expr %T", se))
+	}
+}
+
+func tqField(fe tempo.FieldExpression) string {
+	switch v := fe.(type) {
+	case *tempo.BinaryOperation:
+		return fmt.Sprintf("(b %d %s %s)", int(v.Op), tqField(v.LHS), tqField(v.RHS))
+	case *tempo.UnaryOperation:
+		return fmt.Sprintf("(u %d %s)", int(v.Op), tqField(v.Expression))
+	case tempo.UnaryOperation:
+		return fmt.Sprintf("(u %d %s)", int(v.Op), tqField(v.Expression))
+	case tempo.Attribute:
+		return tqAttr(v)
+	case tempo.Static:
+		return tqStatic(v)
+	default:
+		panic(fmt.Sprintf("tempo: unhandled field expr %T", fe))
+	}
+}
+
+func tqAttr(a tempo.Attribute) string {
+	return fmt.Sprintf("(attr %d %t %d %q)", int(a.Scope), a.Parent, int(a.Intrinsic), a.Name)
+}
+
+func tqStatic(s tempo.Static) string {
+	return "(s " + strconv.Itoa(int(s.Type)) + ":" + tqStaticValue(s) + ")"
+}
+
+func tqStaticValue(s tempo.Static) string {
+	switch s.Type {
+	case tempo.TypeNil:
+		return "nil"
+	case tempo.TypeInt:
+		n, _ := s.Int()
+		return strconv.Itoa(n)
+	case tempo.TypeFloat:
+		return strconv.FormatFloat(s.Float(), 'g', -1, 64)
+	case tempo.TypeString:
+		return strconv.Quote(s.EncodeToString(false))
+	case tempo.TypeBoolean:
+		b, _ := s.Bool()
+		return strconv.FormatBool(b)
+	case tempo.TypeDuration:
+		d, _ := s.Duration()
+		return strconv.FormatInt(int64(d), 10)
+	case tempo.TypeStatus:
+		st, _ := s.Status()
+		return strconv.Itoa(int(st))
+	case tempo.TypeKind:
+		k, _ := s.Kind()
+		return strconv.Itoa(int(k))
+	case tempo.TypeIntArray, tempo.TypeFloatArray, tempo.TypeStringArray, tempo.TypeBooleanArray:
+		var parts []string
+		for _, el := range s.Elements() {
+			parts = append(parts, tqStaticValue(el))
+		}
+		return "[" + strings.Join(parts, ",") + "]"
+	default:
+		panic(fmt.Sprintf("tempo: unhandled static type %d", int(s.Type)))
+	}
+}


### PR DESCRIPTION
## Summary

Claim/coverage/hygiene fixes from the de-AGPL audit. The binary is already AGPL-clean (the `agpl-clean` gate is enforcing — `go list -deps ./cmd/cerberus` links 0 AGPL packages); these are defects left by the fast multi-agent rewrite. Five logical commits:

1. **fix(license): correct false AGPL-linkage comments** — two doc comments claimed the binary still consumes AGPL grafana/loki/tempo code it no longer links (`internal/logql/doc.go`; the quantile post-processor in `internal/api/tempo/metrics_query_range.go`). Both contradicted the enforcing gate. Reworded to the in-house implementations.
2. **docs(license): sweep retired tsouza/loki+tempo fork references** — the `tsouza/loki` + `tsouza/tempo` parser forks are gone from `go.mod`; comments/docs/harness files that named them or described them as the wiring boundary are reframed to the in-house `internal/traceql/ast` (and, for the compatibility harnesses, plain upstream grafana/loki + grafana/tempo as test-only oracles / vendored reference). Touches `internal/traceql/*`, `internal/chplan/metrics_compare.go`, `internal/api/tempo/grpc/service.go`, `docs/coverage.md`, and `compatibility/{loki,tempo}/*`.
3. **refactor(license): rename upstream-matched error const, soften provenance claims** — rename the lsyntax error const to the cerberus-authored `errEmptyCompatibleMatcherRejected`; **keep the message TEXT verbatim** (returned to clients + grepped by `logql.ParseExprPermissive`'s "empty-compatible" substring contract) with a one-line wire-compat note at the const site. Soften the global "clean-room, contains no upstream code" claim in `NOTICE` + the `agpl-clean.mjs` header to "independent reimplementation; a small set of error-message strings is deliberately matched to upstream for wire compatibility (documented at each site)."
4. **test(license): restore TraceQL A/B differential oracle** — restore the `agpl_oracle`-tagged TraceQL differential deleted as merge collateral by #1130. Reworked for the post-fork world: in-house `ast.Parse` vs the AGPL `grafana/tempo/pkg/traceql` reference (resolvable because grafana/tempo is still required for Apache `pkg/tempopb`); reference parser never linked into the binary. Two tiers — whole-corpus accept/reject parity + structural S-expr equality over the exported-surface subset (upstream now hides the metrics/aggregate scalars the fork used to expose). Runs green (100 cases) and the agpl-clean gate stays at 0 AGPL deps.
5. **refactor: remove dead code surfaced by de-AGPL audit** — `MergeBinOp` → `foldScalarBinOp` (dead swap/filter/vector-comparison params), unreachable pointer/value switch arms in `rewrite.go`, `RootExpr.OptimizationCount`, `parsePipelineStage`'s ignored bool, `sanitizeLabelKey`'s always-true `isPrefix`, and DRY of the duplicated attribute rune-set.

## ⚠️ Maintainer / counsel sign-off needed

The softened **NOTICE wording** in commit 3 is a legal-axis change. It now acknowledges that a small set of error-message strings are deliberately reproduced verbatim for wire compatibility (documented at each definition site), rather than claiming the parsers contain *no* upstream-matching text. Please confirm this wording with counsel before the release tag.

## Audit items kept (turned out live — documented at each site)

- **Intrinsic enum consts** (`Structural*`/`ServiceStats`/`SpanStartTime`, the `ScopedIntrinsic*` family): the audit flagged them as deletable, but they preserve iota parity with upstream tempo's `Intrinsic` enum — which the restored oracle's `int(Intrinsic)` structural comparison depends on (deleting mid-block consts shifts the iota values and breaks `span:duration`/`trace:duration` parity) — and several `ScopedIntrinsic*` are read by `lower.go`/the inventory. Kept.
- **`logpattern.Matcher.Test`**: only the oracle calls it, but it is the in-house reference implementation the pattern A/B oracle differentials against upstream. Removing it would delete a real Test-parity assertion (contradicting item 4). Kept.
- **lsyntax helpers `reduceBinOp`/`mustNewMatcher`/`validateMatchers`**: left un-renamed — they are generic, independently-descriptive Go idioms (not verbatim-distinctive upstream identifiers), and several cross-package comments deliberately reference the upstream equivalents for reader context, so renaming isn't clearly "cheap" and would degrade those cross-references. The provenance-sensitive identifier (the error const) was renamed.

## Validation

- `go build ./...`, `go vet ./internal/...` green.
- Scoped unit tests green (logql, traceql, api/loki, api/tempo, chplan); spec lowering goldens unchanged (zero churn); `test/oracle` nested module builds.
- `go test -tags agpl_oracle ./test/agpl_oracle/...` green (100 cases).
- `node .github/scripts/agpl-clean.mjs` exit 0 — `./cmd/cerberus` links 0 AGPL packages.
- gofumpt -extra + goimports clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)