### PR TITLE
docs: scrub non-production narrative + dead-code leftovers

### DIFF
--- a/docs/engine.md
+++ b/docs/engine.md
@@ -313,11 +313,11 @@ An instant windowed range aggregation (`rate` / `increase` /
 post-`groupArray` `arrayFilter` discards out-of-window samples. If that
 innermost read carries no time predicate, ClickHouse cannot prune
 granules and materialises the full per-series retention — tens of
-millions of rows on a prod instant query. The bound used to live only in
-the emitter, so it was repeatedly forgotten as new `groupArray` emitters
-landed.
+millions of rows on a prod instant query. A bound that lived only in the
+emitter would be easy to forget as new `groupArray` emitters land, so it
+is an IR-level property instead.
 
-It is now an IR-level property: an instant windowed-array **leaf**
+An instant windowed-array **leaf**
 RangeWindow (`OuterRange == 0`, and `Input` is **not** a
 `MetricsAggregate` / `MetricsHistogramOverTime` / `MetricsCompare`)
 carries `RangeWindow.InstantScanBounded`, established once by

--- a/docs/optimization-rules.md
+++ b/docs/optimization-rules.md
@@ -90,8 +90,8 @@ speedup, and a reflection or library clone that cannot preserve unexported and
 interface fields correctly is disqualified regardless of its speed.)
 
 The real lever is structural: clone LESS. On the slicer hot path,
-`chplan.ReanchorRange` used to deep-copy a byte-identical off-spine subtree K+1
-times; copy-on-write sharing of the immutable off-spine now collapses that to
+`chplan.ReanchorRange` shares the immutable off-spine subtree copy-on-write
+rather than deep-copying it K+1 times, collapsing the clone cost to
 O(spine-depth). On the committed reproducible `BenchmarkSlice` (the canonical
 `sum by (job)(rate(...))` shape) this measures ~2-2.5x faster with ~50-73% fewer
 allocations at K = 2..16. A wide off-spine subtree can push the win far higher

--- a/internal/api/loki/handler.go
+++ b/internal/api/loki/handler.go
@@ -368,10 +368,10 @@ func (h *Handler) handleQueryRange(w http.ResponseWriter, r *http.Request) {
 // langForRequest builds a per-request *logql.Lang carrying the request's
 // [start, end] window. The engine threads Start / End down through
 // logql.LowerAt so every Scan(LogsTable) gains a
-// `Timestamp BETWEEN start AND end` predicate at the SQL layer — the
-// fix for the wire-format contract violation where /query and
-// /query_range used to return every matching log row regardless of the
-// requested window.
+// `Timestamp BETWEEN start AND end` predicate at the SQL layer. Without
+// it, /query and /query_range would return every matching log row
+// regardless of the requested window, violating the wire-format
+// contract.
 func (h *Handler) langForRequest(start, end time.Time) *logql.Lang {
 	return &logql.Lang{Schema: h.Schema, Start: start, End: end}
 }

--- a/internal/api/prom/lang.go
+++ b/internal/api/prom/lang.go
@@ -118,11 +118,10 @@ func (l *lang) Parse(ctx context.Context, query string) (chplan.Node, engine.Met
 	return plan, engine.Meta{IsMetric: true}, nil
 }
 
-// ProjectSamples wraps plan with the Sample-shape Project the Prom
-// handler used to apply inline via wrapWithSampleProjection. The
-// per-handler derived-vs-canonical branch (RangeWindow / Aggregate /
-// Scan / Filter shapes) lives in wrapWithSampleProjection and is
-// re-used verbatim — moving the projection behind Lang keeps the
+// ProjectSamples wraps plan with the Sample-shape Project via
+// wrapWithSampleProjection. The per-handler derived-vs-canonical branch
+// (RangeWindow / Aggregate / Scan / Filter shapes) lives in
+// wrapWithSampleProjection — keeping the projection behind Lang keeps the
 // engine generic without forcing prom's per-shape switch into the
 // shared layer.
 func (l *lang) ProjectSamples(plan chplan.Node, _ engine.Meta) chplan.Node {

--- a/internal/api/prom/metadata.go
+++ b/internal/api/prom/metadata.go
@@ -1155,13 +1155,13 @@ func expandSeriesMatchers(parser promparser.Parser, matchers []string, histogram
 // Scan+Filter, UNION-ALLs the arms into ONE combined query, runs it as a
 // single CH round-trip, and dedupes the resulting label sets.
 //
-// Fan-in batching (task #71): the pre-#71 shape issued one `Client.Query`
-// per variant (V×H fan-out — up to 32 sequential round-trips for a
-// histogram-base request, ~330ms on the demo dataset). Each variant's
-// lowered Sample-shape SELECT is now a UNION-ALL arm of a single query;
-// the Go dedup below folds the combined row stream into distinct label
-// sets exactly as the per-arm loop did, so the returned series are
-// identical — only the round-trip count drops to 1.
+// Fan-in batching: issuing one `Client.Query` per variant would be a
+// V×H fan-out (up to 32 sequential round-trips for a histogram-base
+// request, ~330ms on the demo dataset). Instead each variant's lowered
+// Sample-shape SELECT is a UNION-ALL arm of a single query; the Go dedup
+// below folds the combined row stream into distinct label sets, so the
+// returned series are identical to the per-arm result — at one
+// round-trip instead of V×H.
 //
 // Bounded-batch-or-fallback: the variant set is arm-capped into ⌈N/K⌉
 // chunks (chunkMatcherVariants) and the rendered-size guard
@@ -1209,7 +1209,7 @@ func (h *Handler) fetchSeries(ctx context.Context, matchers []string, start, end
 func (h *Handler) fetchSeriesChunk(ctx context.Context, matchers []string, start, end time.Time) ([]chclient.Sample, error) {
 	// Single-matcher fast path: run the lowered Sample-shape SELECT
 	// directly as the top-level statement — byte-identical to the
-	// pre-#71 per-arm query (the engine ran this same SQL). Avoids
+	// per-arm query a single variant would produce. Avoids
 	// wrapping the Map-typed Attributes column in an extra `SELECT * FROM
 	// (…)` boundary, which some CH drivers (chdb) refuse to cast back to
 	// MAP.
@@ -1605,8 +1605,8 @@ func (h *Handler) unionLabelValuesSQL(name string, start, end time.Time, nowAnch
 // labelValueCandidates returns the candidate Attributes-map keys for a
 // /api/v1/label/<name>/values lookup. Names that don't carry any
 // rewritable underscore (`job`, `__name__`, ...) short-circuit to the
-// single-element list — preserves the pre-#663 byte-stable SQL for
-// keys that never needed dot↔underscore aliasing. Names with at least
+// single-element list — keeping the SQL byte-stable for keys that never
+// need dot↔underscore aliasing. Names with at least
 // one rewritable underscore (`cerberus_ql`, `http_request_method`)
 // expand via [format.PromLabelToOTelCandidates] so the lookup hits
 // both the underscored and dotted storage forms.

--- a/internal/api/tempo/handler.go
+++ b/internal/api/tempo/handler.go
@@ -309,8 +309,8 @@ func (h *Handler) handleSearch(w http.ResponseWriter, r *http.Request) {
 	// Tempo's /api/search honours `limit` (max trace summaries, default
 	// 20) and `spss` (max spans per spanset, default 3). Grafana's
 	// Traces Drilldown sends both (limit=200&spss=10 for the trace
-	// list); ignoring them used to return every matching trace
-	// (observed live: 4937 summaries / ~755KB body for limit=200).
+	// list); ignoring them returns every matching trace
+	// (e.g. 4937 summaries / ~755KB body for limit=200).
 	limit := positiveIntParam(r, "limit", DefaultSearchLimit)
 	if limit > MaxSearchLimit {
 		limit = MaxSearchLimit
@@ -400,9 +400,9 @@ func writeEngineHeaders(w http.ResponseWriter, hdr map[string]string) {
 	}
 }
 
-// classifySearchErr maps an engine.Query error to the HTTP status the
-// inline handler used to return: parse failures → 400, lower failures
-// → 422, emit failures → 500, execute failures → 502. The Lang
+// classifySearchErr maps an engine.Query error to its HTTP status:
+// parse failures → 400, lower failures → 422, emit failures → 500,
+// execute failures → 502. The Lang
 // adapter tags parse vs lower errors with errParseStage / errLowerStage
 // so errors.Is recovers the precise stage even though the engine
 // collapses both into its outer `engine: parse:` wrapper.

--- a/internal/api/tempo/lang.go
+++ b/internal/api/tempo/lang.go
@@ -17,8 +17,7 @@ import (
 // failures (HTTP 400) from lowering failures (HTTP 422). The engine
 // wraps Lang.Parse errors with `engine: parse:` which collapses both
 // into a single bucket; carrying the stage in the wrapped error chain
-// preserves the per-stage HTTP-status mapping the inlined handler
-// used to return.
+// preserves the per-stage HTTP-status mapping.
 //
 // ErrParseStage / ErrLowerStage are the exported aliases the sibling
 // gRPC handler (internal/api/tempo/grpc) chains via errors.Is to map

--- a/internal/api/tempo/metrics_query_range.go
+++ b/internal/api/tempo/metrics_query_range.go
@@ -98,9 +98,8 @@ func (l MetricsLabel) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON parses the tempopb KeyValue + AnyValue wire shape.
-// Also tolerates the legacy flat `{"key":"k","value":"v"}` shape that
-// cerberus used to emit (pre-EF #398), so handler tests + any consumer
-// that bound to the old shape keep round-tripping.
+// Also tolerates a flat `{"key":"k","value":"v"}` shape, so handler
+// tests + any consumer bound to that shape keep round-tripping.
 func (l *MetricsLabel) UnmarshalJSON(data []byte) error {
 	// Probe the raw `value` field first — its JSON shape decides which
 	// path to take. A flat-string value can't be decoded into the typed

--- a/internal/chclient/client.go
+++ b/internal/chclient/client.go
@@ -273,8 +273,8 @@ type Config struct {
 	// (within BreakerWindow) that trip the circuit breaker from CLOSED to
 	// OPEN. 0 falls back to the breaker default (5). cmd/cerberus wires it
 	// from CERBERUS_CH_BREAKER_THRESHOLD; see breaker.go for the state
-	// machine. Defaults reproduce the pre-#95 hardcoded constants exactly,
-	// so out-of-the-box breaker behaviour is byte-unchanged.
+	// machine. The defaults are the production-safe breaker constants, so
+	// out-of-the-box behaviour is sensible without any tuning.
 	BreakerThreshold int
 
 	// BreakerWindow is the rolling window over which BreakerThreshold
@@ -499,7 +499,7 @@ func buildBreakers(
 	// The default (unscoped) breaker fronts a bare *Client used without
 	// ForHead — schema preflight, tests, the startup ping. It carries no
 	// head label so it never pollutes a per-head series; direct callers see
-	// exactly the pre-#94 single-breaker behaviour. It is deliberately left
+	// a single unscoped breaker. It is deliberately left
 	// OUT of the observed set so the state gauge emits exactly one series per
 	// real head (no head="" sample).
 	def = mk("")
@@ -712,11 +712,11 @@ func buildOptions(cfg Config) *clickhouse.Options {
 // shared tail of New, factored out so option-building (buildOptions) and
 // breaker/Client assembly read as two distinct concerns.
 func assembleClientFromConn(cfg Config, conn driver.Conn) *Client {
-	// Per-head breaker registry (#94) sharing one telemetry set (#95 tuning
-	// + disable config flows to every head). Zero tuning fields resolve to
+	// Per-head breaker registry sharing one telemetry set (tuning +
+	// disable config flows to every head). Zero tuning fields resolve to
 	// the GA defaults inside each breaker (resolveThreshold / resolveWindow /
 	// resolveOpenInterval), so a bare Config — notably the ones tests build —
-	// keeps the pre-#95 hardcoded behaviour byte-for-byte. The telemetry set
+	// gets the production-safe defaults. The telemetry set
 	// is wired off the global MeterProvider and zero-initialised at
 	// construction for all four heads so a healthy replica exports a flat
 	// closed/0 series per head instead of "No data" — see breaker_metrics.go.

--- a/internal/chsql/histogram_quantile_native.go
+++ b/internal/chsql/histogram_quantile_native.go
@@ -14,7 +14,7 @@
 //     the original array) toward the least-negative, then through the
 //     zero bucket, then through PositiveBucketCounts in natural
 //     order. arrayReverse([]) = [], so distributions with no negative
-//     observations collapse to the Phase 1 walk
+//     observations collapse to the positive-only walk
 //     (`arrayConcat([ZeroCount], PositiveBucketCounts)`).
 //  3. total = cum[length(cum)]; target = phi * total.
 //  4. idx = arrayFirstIndex(c -> c >= target, cum) (1-based).
@@ -31,8 +31,8 @@
 //     - phi > 1 → +Inf (out of domain).
 //     - phi == 0 → lower edge of the lowest bucket (in domain):
 //     `-pow(base, NegativeOffset + length(Negative))` if any
-//     negative observations exist; otherwise 0 (matches Phase 1
-//     convention for non-negative distributions).
+//     negative observations exist; otherwise 0 (the convention for
+//     non-negative distributions).
 //     - phi == 1 → upper edge of the highest bucket (in domain):
 //     `pow(base, PositiveOffset + length(Positive))` when positive
 //     observations exist; else `ZeroThreshold` when zero bucket is
@@ -57,11 +57,11 @@
 //     covers `(base^idx, base^(idx+1)]`:
 //     `value = pow(base, PositiveOffset + (idx - nlen - 2) + fraction)`.
 //
-// Phase parity: distributions with empty NegativeBucketCounts and
-// ZeroCount = 0 produce the same numeric output as the original
-// positive-only emitter (idx = 1 only fires when target = 0, which
-// the phi<=0 / total=0 short-circuits already cover). The Phase 1
-// `idx = 1 → ZeroThreshold` branch is subsumed by the zero-bucket
+// Positive-only parity: distributions with empty NegativeBucketCounts
+// and ZeroCount = 0 reduce to the positive-only result (idx = 1 only
+// fires when target = 0, which the phi<=0 / total=0 short-circuits
+// already cover). The `idx = 1 → ZeroThreshold` branch is subsumed by
+// the zero-bucket
 // linear interpolation: with ZeroCount > 0 and target landing inside
 // the zero band, the interpolation returns a value in
 // `[-ZeroThreshold, +ZeroThreshold]` rather than the fixed upper edge.
@@ -263,7 +263,7 @@ func newHQNativeWriters(h *chplan.HistogramQuantileNative) hqNativeWriters {
 	//         [ZeroCount],
 	//         PositiveBucketCounts)).
 	// arrayReverse on an empty array yields [], so the walk collapses to
-	// the Phase 1 shape when NegativeBucketCounts is empty.
+	// the positive-only shape when NegativeBucketCounts is empty.
 	w.cum = func() Frag {
 		return Call(
 			"arrayCumSum",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1450,9 +1450,9 @@ type breakerConfig struct {
 }
 
 // breakerFromEnv reads the CERBERUS_CH_BREAKER_* knobs from the viper
-// loader. Unset values use the defaults above, which reproduce the
-// pre-#95 hardcoded breaker constants exactly (so defaults are
-// byte-unchanged). CERBERUS_CH_BREAKER_ENABLED=false disables the breaker
+// loader. Unset values use the defaults above — the production-safe
+// breaker constants — so an unconfigured deployment gets sensible
+// behaviour. CERBERUS_CH_BREAKER_ENABLED=false disables the breaker
 // entirely (always-allow, never trips); when disabled the threshold /
 // window / interval knobs are still validated so a typo doesn't pass
 // silently, but they have no runtime effect.

--- a/internal/config/envdocs.go
+++ b/internal/config/envdocs.go
@@ -193,11 +193,10 @@ var envDocGroups = []envDocGroup{
 
 // envDocs is the hand-authored metadata for every CERBERUS_* key the viper
 // loader resolves. There is exactly one entry per allEnvKeys member (enforced
-// by TestEnvDocsCoverAllKeys). The Type/Group/Desc are migrated from the
-// previously hand-written docs/configuration.md so the generated document
-// reads as well as the hand-maintained one did; the Default column and the
-// table structure are generated, so the documented default can never drift
-// from the runtime default.
+// by TestEnvDocsCoverAllKeys). The Type/Group/Desc are hand-authored so the
+// generated document reads well; the Default column and the table structure
+// are generated, so the documented default can never drift from the runtime
+// default.
 var envDocs = []EnvDoc{
 	// --- HTTP server ---
 	{envHTTPAddr, "string", "HTTP server", "HTTP listen address for the Prom / Loki / Tempo APIs and the `/healthz` / `/readyz` probes."},

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -3,27 +3,24 @@
 //	parse → lower (inside Lang.Parse) → wrap-projection → optimize →
 //	emit → execute
 //
-// The three per-API handlers (prom / loki / tempo) each used to inline
-// this loop with copy-pasted telemetry plumbing. Engine extracts the
-// loop so the handlers shrink to (a) HTTP routing, (b) per-language
+// Engine owns this loop so the per-API handlers (prom / loki / tempo)
+// stay thin: each handler is just (a) HTTP routing, (b) per-language
 // adapter wiring, and (c) the response-shape pivot.
 //
 // Per-language differences live behind the Lang interface: the parser
 // type stays inside the adapter, lowering happens inside Lang.Parse,
-// and the sample-row reshaping that used to live in each handler's
-// wrapWithSampleProjection helper moves behind Lang.ProjectSamples.
+// and the sample-row reshaping lives behind Lang.ProjectSamples.
 //
 // Execution strategy: route A (the default for the overwhelming majority
 // of traffic) emits one optimized plan into one ClickHouse statement and
-// pushes all reduction into CH. The maintainer relaxed the old "one CH
-// query per request — no scatter-gather" lock on 2026-06-12 for the narrow
-// memory-unbounded anchor-fan-out class: the sharded-pushdown solver
-// (internal/solver, docs/solver.md) re-anchors K copies of the
-// same optimized plan onto disjoint anchor slices, emits each via chsql.Emit,
-// and concatenates the streams — no new evaluator, no new SQL template, and
-// the all-or-nothing wire contract preserved. The solver hooks the seam
-// between Optimizer.Run and chsql.Emit (see QueryPlan / QueryPlanCursor) and
-// is off by default. The relaxed invariant set lives in docs/performance.md.
+// pushes all reduction into CH. For the narrow memory-unbounded
+// anchor-fan-out class, the sharded-pushdown solver (internal/solver,
+// docs/solver.md) re-anchors K copies of the same optimized plan onto
+// disjoint anchor slices, emits each via chsql.Emit, and concatenates the
+// streams — no new evaluator, no new SQL template, and the all-or-nothing
+// wire contract preserved. The solver hooks the seam between
+// Optimizer.Run and chsql.Emit (see QueryPlan / QueryPlanCursor) and is
+// off by default. The invariant set lives in docs/performance.md.
 package engine
 
 import (
@@ -72,7 +69,7 @@ const (
 	// Value grammar: "<strategy>;reason=<reason>". On a non-route the
 	// strategy is the route-A label "route-a" and reason is the solver's
 	// Reason vocabulary (instant / below-threshold / not-sliceable / ...);
-	// on a true route (phase-2, never under Mode=single) the strategy is the
+	// on a true route (never under Mode=single) the strategy is the
 	// decomposition name (sharded-timeslice) carrying ";k=<K>" before the
 	// reason. The header is OBSERVATIONAL — it never changes the X-Cerberus-
 	// Strategy value or the response body.
@@ -438,11 +435,11 @@ type Engine struct {
 	// classification branch, the shadow header, and the Executor are all
 	// dead code. When non-nil the engine classifies the optimized plan at
 	// the seam between Optimizer.Run and chsql.Emit and stamps the
-	// additive X-Cerberus-Route-Decision shadow header; under the phase-1
-	// default (Mode=single) the Planner never routes, so EXECUTION STAYS ON
+	// additive X-Cerberus-Route-Decision shadow header; under the default
+	// (Mode=single) the Planner never routes, so EXECUTION STAYS ON
 	// ROUTE A and the Executor is never invoked. The routed branch is wired
-	// (so the phase-2 flip is a config change) but dormant at the default
-	// config.
+	// (so flipping to routed mode is a config change) but dormant at the
+	// default config.
 	Solver *solver.Solver
 
 	// Settings carries the optional, DARK-by-default per-query ClickHouse
@@ -784,8 +781,8 @@ func (e *Engine) classify(plan chplan.Node, lang Lang) (*solver.Decision, bool) 
 // executeRouted runs the dormant route-B path: it dispatches the K shard
 // cursors through the Solver's Executor and drains the composed cursor into
 // the eager Result slice. It is NEVER reached under Mode=single (classify
-// returns routed=false there); it is wired so the phase-2 flip is a config
-// change. A nil Executor on a routed Decision is a wiring bug — fail closed
+// returns routed=false there); it is wired so flipping to routed mode is a
+// config change. A nil Executor on a routed Decision is a wiring bug — fail closed
 // to an error rather than panic.
 func (e *Engine) executeRouted(
 	ctx context.Context,
@@ -1041,7 +1038,7 @@ func (e *Engine) ObserveCapRejection(language string) {
 // dispatches the K shard cursors through the Solver's Executor and returns
 // the composed cursor directly (the caller drives the drain + Close, exactly
 // as route A's single cursor). NEVER reached under Mode=single; wired so the
-// phase-2 flip is a config change.
+// flip to routed mode is a config change.
 func (e *Engine) executeRoutedCursor(
 	ctx context.Context,
 	lang Lang,

--- a/internal/logql/binary.go
+++ b/internal/logql/binary.go
@@ -394,7 +394,7 @@ func isComparison(op chplan.BinaryOp) bool {
 // layer that re-projects an inner plan (vector-scalar binops, the
 // vector-join leg shaping, label_replace) and mirrored by
 // [Lang.ProjectSamples] — keeping the resolution in one place is what
-// stops the layers drifting (the pre-#757 drift surfaced as 502
+// stops the layers drifting (drift surfaces as a 502
 // `Unknown expression identifier 'anchor_ts' / 'ResourceAttributes'`
 // for every range-mode LogQL binop).
 //

--- a/internal/logql/duration.go
+++ b/internal/logql/duration.go
@@ -19,8 +19,8 @@ import (
 // `__error__` / `__error_details__` labels and flows on (label filters
 // keep the row; unwrap keeps the sample with value 0). ClickHouse's
 // `parseTimeDelta`, in contrast, throws (code 36) on the first value it
-// can't parse — one Go-shaped `291.792µs` in a single row used to abort
-// the whole query (crawl run 27327766381, Logs Drilldown fields tab).
+// can't parse — one Go-shaped `291.792µs` in a single row would abort
+// the whole query (e.g. the Logs Drilldown fields tab).
 //
 // CH `parseTimeDelta` unit gaps vs Go `time.ParseDuration` (verified
 // empirically against clickhouse-server 24.8.14 and chDB / server 25.8

--- a/internal/logql/lang.go
+++ b/internal/logql/lang.go
@@ -137,9 +137,8 @@ func (l *Lang) ProjectSamples(plan chplan.Node, meta engine.Meta) chplan.Node {
 		//
 		// The metric-value column is the canonical PascalCase `Value` (the
 		// alias the RangeWindow / Aggregate emitters project at every outer
-		// SELECT site since #310 collapsed the rename Project layer); mirror
-		// it here so the wire-wrap doesn't ColumnRef the pre-#310 lowercase
-		// alias.
+		// SELECT site); mirror it here so the wire-wrap doesn't ColumnRef a
+		// lowercase alias.
 		//
 		// Inner stream-identity column resolution: a bare range-aggregation
 		// (`rate({...}[5m])` / `count_over_time({...}[5m])` / …) leaves the

--- a/internal/logql/lower.go
+++ b/internal/logql/lower.go
@@ -1187,8 +1187,8 @@ func labelMatcherToExpr(m *labels.Matcher, s schema.Logs, labelsExpr chplan.Expr
 // underscored Loki label `key` against the live `labelsMap` (the
 // schema's ResourceAttributes column or a `mapConcat(...)` wrapping it
 // after a parser stage). For names with no rewritable underscore (e.g.
-// `job`, `__error__`) it returns a plain MapAccess — byte-stable with
-// the pre-#658 emit shape so the existing fixtures keep matching.
+// `job`, `__error__`) it returns a plain MapAccess — the byte-stable
+// emit shape the fixtures match.
 //
 // For names with at least one rewritable underscore (e.g.
 // `cerberus_ql`) it emits a left-associative `if(mapContains(m, k1),

--- a/internal/optimizer/filter_range_window_transpose.go
+++ b/internal/optimizer/filter_range_window_transpose.go
@@ -7,12 +7,9 @@ import "github.com/tsouza/cerberus/internal/chplan"
 // only the series-identifying columns the RangeWindow exposes
 // unchanged from X.
 //
-// ACTIVE: fires on the current test/spec corpus (measured with the
-// total optimizer walk from #812) — e.g. `max_over_time(topk(0, up)[5m:1m])`,
-// whose `topk(0, …)` lowers to a `Filter(false)` sitting directly above
-// a RangeWindow; this rule pushes that filter under the window. (The
-// Phase-1 perf audit recorded it as non-firing, but that was before
-// #812 made the optimizer walk reach the subquery RangeWindow shape.)
+// Fires on shapes like `max_over_time(topk(0, up)[5m:1m])`, whose
+// `topk(0, …)` lowers to a `Filter(false)` sitting directly above a
+// RangeWindow; this rule pushes that filter under the window.
 //
 // Lineage: VictoriaMetrics' `metricsql/optimizer.go` pushdown shape —
 // see https://github.com/VictoriaMetrics/metricsql/blob/master/optimizer.go.

--- a/internal/perf/fanout/lint.go
+++ b/internal/perf/fanout/lint.go
@@ -1,27 +1,26 @@
 // Package fanout is cerberus's static compute-fan-out linter — the
-// cheap, always-on tripwire from the Phase-1 perf assessment.
+// cheap, always-on tripwire that catches a query stage exploding
+// intermediate cardinality before the final aggregation collapses it.
 //
-// Every perf bug the assessment catalogued was a COMPUTE FAN-OUT: the
-// scan touched a normal number of rows, but an intermediate stage
-// exploded the cardinality before the final aggregation collapsed it —
-// a step-grid CROSS JOIN that paired every sample with every eval anchor
-// (the pre-#804 range_lwr / histogram shapes), an arrayJoin explosion
-// feeding a JOIN, or an unbounded WITH RECURSIVE structural closure (the
-// pre-#808/#809 nested-set / descendant walks). None of these change the
-// scanned-row count, so row-count- or EXPLAIN-based guards miss them.
+// A compute fan-out touches a normal number of scanned rows but blows up
+// the row count mid-plan: a step-grid CROSS JOIN that pairs every sample
+// with every eval anchor (the range_lwr / histogram shapes), an
+// arrayJoin explosion feeding a JOIN, or an unbounded WITH RECURSIVE
+// structural closure (nested-set / descendant walks). None of these
+// change the scanned-row count, so row-count- or EXPLAIN-based guards
+// miss them.
 //
 // [Lint] inspects the lowered [chplan] IR and the emitted ClickHouse SQL
 // statically — zero data, no execution — and returns a [Violation] for
 // each unbounded fan-out shape. It is wired into the always-on
 // (non-chDB) check gate by test/regression/fanout_lint_test.go, which
-// runs it over every test/spec/** fixture so a future PR that
-// reintroduces an unbounded fan-out fails at review time.
+// runs it over every test/spec/** fixture so a PR that reintroduces an
+// unbounded fan-out fails at review time.
 //
-// The API is deliberately representation-split so later perf-framework
-// components can reuse it: [Lint] takes both a plan tree and the SQL
-// string; callers that only have one pass the other as its zero value
-// (nil plan / empty SQL) and the rules keyed on the missing
-// representation simply do not fire.
+// The API is deliberately representation-split: [Lint] takes both a plan
+// tree and the SQL string; callers that only have one pass the other as
+// its zero value (nil plan / empty SQL) and the rules keyed on the
+// missing representation simply do not fire.
 package fanout
 
 import (
@@ -38,7 +37,7 @@ type Rule string
 const (
 	// RuleUnboundedCrossJoin flags a chplan.CrossJoin where NEITHER side
 	// is statically collapsed to a bounded row count — the range_lwr /
-	// histogram step-grid class (#804 / #805). A CROSS JOIN is safe only
+	// histogram step-grid class. A CROSS JOIN is safe only
 	// when at least one side is provably ≤1 row (OneRow, a no-GROUP-BY
 	// Aggregate, Limit 1, ...) or is already collapsed by an Aggregate
 	// (the unavoidable per-(series, step) broadcast shape — the right
@@ -53,7 +52,7 @@ const (
 
 	// RuleUncappedRecursion flags a `WITH RECURSIVE` CTE emitted WITHOUT
 	// a `_depth < <literal>` depth-cap bound — the nested-set /
-	// structural-recursion class (#808 / #809). Every recursive CTE must
+	// structural-recursion class. Every recursive CTE must
 	// carry an integer depth ceiling so a span-id cycle degrades to a
 	// partial closure instead of an unbounded walk.
 	RuleUncappedRecursion Rule = "uncapped-recursion"
@@ -107,7 +106,7 @@ func lintCrossJoins(plan chplan.Node) []Violation {
 			return true
 		}
 		// Safe iff at least one side is bounded-to-few-rows OR already
-		// collapsed by an aggregation. The dangerous shape — the pre-#804
+		// collapsed by an aggregation. The dangerous shape — the
 		// step-grid blowup — is `CrossJoin{StepGrid, Filter(Scan)}`: an
 		// N-anchor grid against RAW (un-collapsed) scan rows, yielding
 		// rows×anchors intermediate cardinality.

--- a/internal/promql/histogram_quantile_range.go
+++ b/internal/promql/histogram_quantile_range.go
@@ -273,8 +273,8 @@ func lowerHistogramQuantileNativeBareRange(
 
 	// LWR aggregation: latest exp-histogram fields per (series, anchor).
 	// argMax(<col>, TimeUnix) picks the value at the row with the highest
-	// TimeUnix in the (series, anchor) group, matching the Phase-1 instant-
-	// mode "newest sample" semantic with anchor swapped in for `now64(9)`.
+	// TimeUnix in the (series, anchor) group, matching the instant-mode
+	// "newest sample" semantic with anchor swapped in for `now64(9)`.
 	expHistAggs := []chplan.AggFunc{
 		{
 			Name: "argMax",

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -476,9 +476,9 @@ func lowerVectorSelector(v *parser.VectorSelector, s schema.Metrics, ctx lowerCt
 	// inflate Attributes with one synthesised key per such column so
 	// the downstream LWR / RangeWindow groups partition over the
 	// effective series identity. Without this, rows with distinct
-	// ServiceName collapse into a single Attributes bucket — the
-	// `sum by (service_name) (rate({__name__=~".+"}[5m]))` task-#232
-	// bug. The Project lands between the Scan/Filter and the per-mode
+	// ServiceName collapse into a single Attributes bucket, breaking
+	// `sum by (service_name) (rate({__name__=~".+"}[5m]))`.
+	// The Project lands between the Scan/Filter and the per-mode
 	// wraps so PREWHERE-eligible matchers stay on the raw Scan
 	// (the optimizer's promotion path is untouched).
 	//
@@ -487,13 +487,12 @@ func lowerVectorSelector(v *parser.VectorSelector, s schema.Metrics, ctx lowerCt
 	// (MetricName, Attributes, TimeUnix, Value) on its output side —
 	// any raw scan column the matcher predicate references
 	// (`ServiceName` in particular, via the `service_name` coalesce
-	// chain from PR #679 / task #232) goes out of scope above the
+	// chain) goes out of scope above the
 	// Project. The downstream LWR / range-vector wrappers would then
 	// apply the matcher Filter ON TOP of the augmented Project and CH
 	// rejects the query with `Unknown expression or function
-	// identifier 'ServiceName'` (HTTP 502, error 47 — caught by PR
-	// #681's Phase-3 filter-drill sweep on
-	// `topk(10, sum by (service_name) (rate({__name__=~".+",service_name="api"}[5m])))`).
+	// identifier 'ServiceName'` (HTTP 502, error 47) on shapes like
+	// `topk(10, sum by (service_name) (rate({__name__=~".+",service_name="api"}[5m])))`.
 	// The fix sinks `pred` to a Filter immediately above the raw
 	// scan-side input BEFORE augmenting — at that layer every raw
 	// column (including ServiceName) is still in scope and the
@@ -1603,8 +1602,7 @@ func metricNamePredicate(m *labels.Matcher, s schema.Metrics) chplan.Expr {
 // attributeLookup returns the chplan.Expr that resolves a Prom matcher
 // name `key` against the CH Map column `col`. For names with no
 // rewritable underscore (e.g. `job`, `__name__`) it returns a plain
-// MapAccess — byte-stable with the pre-#658 emit shape so the existing
-// fixtures keep matching.
+// MapAccess — the byte-stable emit shape the fixtures match.
 //
 // For names with at least one rewritable underscore (e.g. `cerberus_ql`)
 // it emits a left-associative `if(mapContains(col, k1), col[k1],

--- a/internal/promql/modifiers.go
+++ b/internal/promql/modifiers.go
@@ -68,8 +68,7 @@ type lowerCtx struct {
 	// (currently `service_name` → `ServiceName`) the outer aggregate
 	// needs. Empty (the default) means "no outer by-clause referencing
 	// a top-level column" — the augmenting Project is suppressed and
-	// the bare-selector / range-vector plan stays byte-identical with
-	// pre-#232 fixtures.
+	// the bare-selector / range-vector plan emits unchanged.
 	//
 	// Only `by(...)` propagates; `without(...)` exclusion semantics
 	// don't reference specific columns so the slot stays nil for the

--- a/internal/solver/config.go
+++ b/internal/solver/config.go
@@ -5,7 +5,7 @@
 // already-optimized chplan onto disjoint slices of the anchor grid so each
 // shard runs the same compat-gated SQL restricted to its anchor sub-grid.
 //
-// Phase 1 (this package's foundation) ships the policy half only:
+// The package is built from:
 //
 //   - Config — the tuning surface, with one DefaultConfig and a fail-fast
 //     Validate.
@@ -13,15 +13,14 @@
 //     post-optimize plan into a Decision (the shadow-header signal).
 //   - Slicer — the anchor-grid geometry that splits the eval grid into K
 //     disjoint, on-grid slices and re-anchors a deep copy per slice.
+//   - Executor — schedules the K shard queries (serial or bounded-parallel).
+//   - shardCursor — composes the K shard result streams into one cursor.
 //
-// The Executor (scheduling), shardCursor (composition), and the engine /
-// chclient wiring are LATER PRs and deliberately absent here.
-//
-// Import-cycle rule: internal/engine will later hold a *solver.Solver, so
-// this package must NOT import internal/engine. The request metadata the
-// Planner needs is carried by the package-local RequestMeta, populated by a
-// later engine adapter — never engine.Meta. This package imports only
-// internal/chplan and the standard library.
+// Import-cycle rule: internal/engine holds a *solver.Solver, so this package
+// must NOT import internal/engine. The request metadata the Planner needs is
+// carried by the package-local RequestMeta, populated by the engine adapter —
+// never engine.Meta. This package imports only internal/chplan, the executor
+// interfaces, and the standard library.
 package solver
 
 import (
@@ -39,7 +38,7 @@ const (
 
 	// ModeSingle disables the solver entirely: the Planner still computes a
 	// Decision (for the shadow header) but always returns routed=false, so
-	// every request stays on route A. The phase-1 ship-dark default.
+	// every request stays on route A. The library's ship-dark default.
 	ModeSingle = "single"
 
 	// ModeSharded drops the cost thresholds to the floor (K_min = 2) so
@@ -103,9 +102,9 @@ const (
 	defaultMaxOutputRows      = 2_000_000
 )
 
-// DefaultConfig returns the conservative phase-1 defaults. Mode defaults to
-// "single" — the solver ships dark — so DefaultConfig is safe to wire before
-// any parity lane has flipped the auto gate.
+// DefaultConfig returns the conservative library defaults. Mode defaults to
+// "single" — the solver ships dark — so DefaultConfig is safe to wire as the
+// in-process default without enabling routing.
 func DefaultConfig() Config {
 	return Config{
 		Mode:               ModeSingle,

--- a/internal/solver/config_env.go
+++ b/internal/solver/config_env.go
@@ -9,9 +9,9 @@ import (
 )
 
 // Env var names for the solver tuning surface. CERBERUS_EVAL_ROUTE is the
-// master switch (default "auto" — the phase-2 flip; operators pin "single" to
-// disable routing); the rest map 1:1 onto the Config fields and default to
-// DefaultConfig's conservative phase-1 values when unset.
+// master switch (default "auto"; operators pin "single" to disable routing);
+// the rest map 1:1 onto the Config fields and default to DefaultConfig's
+// conservative values when unset.
 const (
 	EnvRoute              = "CERBERUS_EVAL_ROUTE"
 	EnvMinFanout          = "CERBERUS_SHARD_MIN_FANOUT"
@@ -31,7 +31,7 @@ const (
 // A parse failure on any knob is returned so a typo never silently routes (or
 // never silently disables routing).
 //
-// PRODUCTION DEFAULT (phase-2 flip): when CERBERUS_EVAL_ROUTE is unset the
+// PRODUCTION DEFAULT: when CERBERUS_EVAL_ROUTE is unset the
 // solver routes in "auto" mode — eligible plans that clear the cost thresholds
 // take route B; everything else (ineligible / below-threshold / non-PromQL)
 // fails toward the byte-identical route A. Operators pin "single" to disable
@@ -40,8 +40,8 @@ const (
 // unaffected; only this env-driven prod path flips to auto.
 func ConfigFromEnv() (Config, error) {
 	cfg := DefaultConfig()
-	// Phase-2 flip: unset CERBERUS_EVAL_ROUTE means "auto" in production, not
-	// the library's dark "single" default.
+	// Unset CERBERUS_EVAL_ROUTE means "auto" in production, not the library's
+	// dark "single" default.
 	cfg.Mode = ModeAuto
 
 	if v := strings.TrimSpace(os.Getenv(EnvRoute)); v != "" {

--- a/internal/solver/decision.go
+++ b/internal/solver/decision.go
@@ -16,8 +16,8 @@ import (
 // as the @-modifier guard's oracle: a windowed node's bounds must match the
 // grid this Meta predicts at that spine depth.
 type RequestMeta struct {
-	// Lang is the head name ("promql" | "logql" | "traceql"). Phase 1 routes
-	// PromQL query_range only; the field lets the Planner reject the others
+	// Lang is the head name ("promql" | "logql" | "traceql"). Only PromQL
+	// query_range is routed; the field lets the Planner reject the others
 	// without importing the engine's Lang registry.
 	Lang string
 
@@ -29,7 +29,7 @@ type RequestMeta struct {
 	End   time.Time
 
 	// Step is the request resolution. Step == 0 is an instant query, never
-	// time-slice routed in phase 1.
+	// time-slice routed.
 	Step time.Duration
 }
 
@@ -37,7 +37,7 @@ type RequestMeta struct {
 // (composition order). A Decision is always produced — even when not routed —
 // so the shadow header X-Cerberus-Route-Decision can report the reason.
 type Decision struct {
-	// Strategy is the decomposition strategy name. Phase 1 emits exactly
+	// Strategy is the decomposition strategy name — exactly
 	// StrategyShardedTimeslice on a route, empty otherwise.
 	Strategy string
 
@@ -72,7 +72,7 @@ type Decision struct {
 	Step        time.Duration // the request grid step
 }
 
-// StrategyShardedTimeslice is the only decomposition strategy phase 1 emits:
+// StrategyShardedTimeslice is the only decomposition strategy emitted:
 // disjoint sub-grids of the primary (anchor) dimension.
 const StrategyShardedTimeslice = "sharded-timeslice"
 
@@ -93,7 +93,7 @@ const (
 	ReasonNotSliceable = "not-sliceable"
 
 	// ReasonInstant: an instant query (Step == 0 or OuterRange == 0) — no
-	// anchor grid to slice in phase 1.
+	// anchor grid to slice.
 	ReasonInstant = "instant"
 
 	// ReasonHighD: the K clamp floor (K <= OuterRange / max(D, Step)) drove

--- a/internal/solver/planner.go
+++ b/internal/solver/planner.go
@@ -29,7 +29,7 @@ type Planner struct {
 //   - "auto": route iff eligible AND F >= MinFanout AND N x F >= MinAnchorPairs
 //     AND K >= 2.
 func (p *Planner) Plan(plan chplan.Node, meta RequestMeta) (*Decision, bool) {
-	// (2)-prefix: instant queries are never time-slice routed in phase 1.
+	// (2)-prefix: instant queries are never time-slice routed.
 	// Step == 0 means an instant evaluation; there is no anchor grid. The
 	// analyze pass below derives the cost grid (N/F/D/OuterRange); it has not
 	// run yet here, so the only meaningful scalar is Step (zero on an instant
@@ -45,8 +45,8 @@ func (p *Planner) Plan(plan chplan.Node, meta RequestMeta) (*Decision, bool) {
 		return notRouted(ReasonNotSliceable).withGrid(sig, meta), false
 	}
 	// (1b) Routable-spine restriction: the routable spine families are the
-	// *RangeWindow matrix family (phase 1) and the *RangeLWR bare-selector
-	// last-with-respect-to family (phase 3) — ReanchorRange re-grids both. A
+	// *RangeWindow matrix family and the *RangeLWR bare-selector
+	// last-with-respect-to family — ReanchorRange re-grids both. A
 	// RangeBucketFanout / StepGrid spine bound-carrier is still left at
 	// zero/stale bounds (ReanchorRange CloneNode's their grid verbatim), so
 	// those fail closed to route A. Widening to those families extends
@@ -199,7 +199,7 @@ type signals struct {
 	// grid ReanchorRange does NOT re-anchor — a RangeBucketFanout or StepGrid,
 	// which ReanchorRange CloneNode's verbatim (every shard would emit
 	// stale bounds). The routable set is the *RangeWindow matrix family
-	// (phase 1) plus the *RangeLWR bare-selector family (phase 3): both are
+	// plus the *RangeLWR bare-selector family: both are
 	// re-gridded by ReanchorRange and zeroed/re-filled by unpinSpine, so
 	// neither sets this flag. RangeBucketFanout / StepGrid fail closed to
 	// route A until ReanchorRange learns their grids.
@@ -316,8 +316,8 @@ func (p *Planner) walkNode(n chplan.Node, predStart, predEnd time.Time, depth in
 		// StepGrid carries an eval grid (Start/End/Step) that ReanchorRange
 		// clones VERBATIM — the grid-prediction guard cannot see it and the
 		// slicer would leave every shard on the original full-grid bounds.
-		// Phase 1 routes the *RangeWindow matrix family only; a StepGrid
-		// spine carrier fails closed to route A.
+		// A StepGrid spine carrier is not in the routable set, so it
+		// fails closed to route A.
 		if v.Step > 0 {
 			sig.sawNonRangeWindowSpine = true
 		}
@@ -401,14 +401,14 @@ func (p *Planner) recordRangeWindow(v *chplan.RangeWindow, predStart, predEnd ti
 // recordRangeLWR gathers signals for a bare-selector last-with-respect-to
 // node — the leaf of the safe-set range family.
 func (p *Planner) recordRangeLWR(v *chplan.RangeLWR, predStart, predEnd time.Time, depth int, sig *signals) {
-	// Phase 3 widens the routable set to the RangeLWR matrix family: a
-	// grid-carrying RangeLWR (Step > 0) is now re-anchored by ReanchorRange
+	// The RangeLWR matrix family is in the routable set: a
+	// grid-carrying RangeLWR (Step > 0) is re-anchored by ReanchorRange
 	// (its Start/End re-gridded, the input spine widened by the offset-aware
 	// Offset+Lookback membership window) and zeroed/re-filled by the slicer's
-	// unpinSpine, so it no longer sets sawNonRangeWindowSpine. The deriv /
+	// unpinSpine, so it does not set sawNonRangeWindowSpine. The deriv /
 	// idelta / irate / instant-LWR / negative-offset families that lower to a
-	// bare RangeLWR spine now route B. RangeBucketFanout / StepGrid stay
-	// rejected — their grids are still CloneNode'd verbatim by ReanchorRange.
+	// bare RangeLWR spine route B. RangeBucketFanout / StepGrid stay
+	// rejected — their grids are CloneNode'd verbatim by ReanchorRange.
 	if v.Step <= 0 || (depth == 0 && v.End.Sub(v.Start) <= 0) {
 		sig.sawInstantWindow = true
 	}
@@ -561,10 +561,10 @@ func (p *Planner) scanExprForNow64(e chplan.Expr, sig *signals) {
 
 // checkScalarHeavy implements signal (6): a ScalarSubquery whose interior
 // scan-span × fan-out exceeds a configured fraction of the outer plan cannot
-// be cheaply replicated. In phase 1 the hoist (execute the scalar once,
-// bind the literal) is a later PR, so any scalar interior carrying its own
-// windowed spine is conservatively treated as heavy — replicating it K× is
-// the cost the hoist exists to avoid. A purely row-wise scalar (no windowed
+// be cheaply replicated. The scalar is not hoisted (executed once with the
+// literal bound), so any scalar interior carrying its own windowed spine is
+// conservatively treated as heavy — replicating it K× is the cost a hoist
+// would avoid. A purely row-wise scalar (no windowed
 // node inside) is cheap and admissible.
 func (p *Planner) checkScalarHeavy(inner chplan.Node, sig *signals) {
 	hasWindowedInterior := false

--- a/internal/solver/solver.go
+++ b/internal/solver/solver.go
@@ -15,10 +15,10 @@ import (
 // Decision (the shadow-header signal). A nil *Solver means the feature
 // is fully off and every existing call path is byte-unchanged.
 //
-// Under the phase-1 default (Config.Mode == ModeSingle) the Planner
+// Under the dark default (Config.Mode == ModeSingle) the Planner
 // classifies but NEVER routes, so Classify always returns routed=false
-// and the engine stays on route A. The Executor is wired (so the
-// phase-2 flip is a config change, not a code change) but dormant: the
+// and the engine stays on route A. The Executor is wired (so enabling
+// routing is a config change, not a code change) but dormant: the
 // engine only reaches Executor.Execute when Classify reports routed,
 // which never happens under ModeSingle.
 type Solver struct {
@@ -96,7 +96,7 @@ func (s *Solver) Classify(plan chplan.Node, meta RequestMeta) (*Decision, bool) 
 	return s.Planner.Plan(plan, meta)
 }
 
-// LangPromQL is the head name the solver classifies. Phase 1 routes the
+// LangPromQL is the head name the solver classifies. The solver routes the
 // PromQL query_range matrix family only; the other heads skip the solver
 // entirely (Classify returns not-classified for them). It mirrors the
 // engine's Lang.Name() string for the Prom head.

--- a/internal/traceql/metrics_pipeline.go
+++ b/internal/traceql/metrics_pipeline.go
@@ -121,8 +121,8 @@ func lowerMetricsAggregate(prev chplan.Node, agg *traceql.MetricsAggregate, s sc
 	// bucketizeDuration produces upstream — Log2Bucketize(d)
 	// in nanos, divided by 1e9 so the bucket reads in seconds. Only
 	// quantile_over_time consults IsDuration today; the rest of the
-	// matrix path emits the same SQL whether or not the operand was
-	// originally a duration intrinsic.
+	// matrix path emits the same SQL whether or not the operand is a
+	// duration intrinsic.
 	isDuration := op == traceql.MetricsAggregateQuantileOverTime && agg.Attribute().Intrinsic == traceql.IntrinsicDuration
 
 	return &chplan.MetricsAggregate{


### PR DESCRIPTION
## What

Audit for non-production-code leftovers across three classes. Only **Class 1** (research/evolution-narrative comments) had findings; the codebase is already clean of dead code and stale fork/AGPL references.

### Class 1 — research/evolution-narrative comments → timeless (the only changes)

Rewrote history/origin framing in production-facing comments and docs to timeless current-state per the "docs are timeless" rule. Stripped phase numbers, PR-archaeology (`pre-#NNN` / `pre-EF #398`), "the perf assessment", and `used to … now` before/after framing — while keeping the invariant rationale each comment carried. Touched **no** logic, imports, or goldens (comment/doc text only).

Notable files:
- `internal/perf/fanout/lint.go` — the seed example: package doc rewritten to describe what the linter catches (compute fan-out shapes that row-count/EXPLAIN guards miss) + how it's wired (`test/regression/fanout_lint_test.go` over `test/spec/**`) + the split-API behaviour, dropping the Phase-1-assessment / `pre-#804/#808/#809` narrative.
- `internal/engine/engine.go`, `internal/solver/{config,config_env,decision,planner,solver}.go` — dropped `phase-1`/`phase-2`/`phase-3` rollout framing; describe the current routable set + config-gated routing directly.
- `internal/solver/config.go` — **corrected a now-false claim**: the package doc said the Executor / shardCursor were "LATER PRs and deliberately absent"; both ship in the package today (`executor.go` / `cursor.go`), so the doc now describes the full Planner→Slicer→Executor→shardCursor build.
- `internal/chsql/histogram_quantile_native.go` — "Phase 1 walk" (an old positive-only emitter) → "positive-only walk".
- `internal/api/{loki,prom,tempo}/*`, `internal/{promql,logql,traceql,config,chclient}/*` — `pre-#NNN` / `used to return` framing → present-tense current behaviour, invariant kept.
- `docs/engine.md`, `docs/optimization-rules.md` — same treatment.

### Class 2 — dead / orphaned code: none found

All four internal packages outside the `cmd/cerberus` binary are live:
- `internal/chclienttest` — chdb-tagged test tooling, imported by many `*_chdb_test.go` + property tests.
- `internal/perf/fanout` — live via `test/regression/fanout_lint_test.go` (non-chDB check gate).
- `internal/routerrules` (+ `/catalog`) — consumed by the `cmd/route-rules` binary (wired in `.github/workflows/strict-scan.yml` + Justfile) and a data-validation test package.

Build tags (`chaos_sleep`, `chdb`, `agpl_oracle`, `chaos`) are all wired into CI/Justfile lanes. The `test/oracle` nested module builds clean (only quarantines the AGPL loki LogQL parser; TraceQL inventory uses the in-house `internal/traceql/ast`, no tempo dep). No orphaned files, no broken `_test.go`, no de-AGPL migration cruft.

### Class 3 — stale fork/AGPL references: none found

The earlier sweep (#1136) was thorough. Re-grep surfaced only accurate statements: the in-house parsers validated against the AGPL reference parsers as test-only oracles, the `tsouza/prometheus@cerberus-parser` fork (still extant), and CLAUDE.md correctly noting the `tsouza/loki`/`tsouza/tempo` forks were retired. No prod imports of `grafana/{loki,tempo}/pkg/{logql,traceql}`; binary stays AGPL-free.

## Verification

- `go build ./...` + `go vet ./...` green (also under `-tags 'chdb agpl_oracle'`).
- `go list -deps ./cmd/cerberus` AGPL-free.
- `test/oracle` nested module builds clean.
- gofmt-clean; comment-only edits, so goldens are unchanged.

## Kept (deliberately)

- Technical "phase 0" (epoch-alignment) in `range_window.go` / `subquery.go` — not project phases.
- CI lane names `phase1`…`phase5-*` and chaos `phase-1`/`phase-2` scenario tiers in `docs/test-strategy.md` — current operational identifiers, not origin stories.
- `test/oracle/go.mod` module doc — accurate, outside the Class-1 scope (internal/ + docs/ + README + CLAUDE).
- CHANGELOG.md, commit messages, and `_test.go` regression-pin rationale — out of scope by instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)