### PR TITLE
chore(deps): pin grafana/loki oracle reference

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -54,6 +54,14 @@ updates:
           - minor
     # Major bumps stay one-per-PR — they almost always need code
     # changes and benefit from individual review.
+    ignore:
+      # grafana/loki is a TEST-ONLY A/B oracle reference (build-tag
+      # agpl_oracle), never in the shipped binary — the agpl-clean gate
+      # enforces 0 AGPL in cmd/cerberus. Pin it at a known-good baseline:
+      # chasing upstream parser releases can only break the equivalence
+      # oracle, never improve the product (the in-house parser is what
+      # ships; compatibility/loki is the real parity source-of-truth).
+      - dependency-name: "github.com/grafana/loki/*"
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
Adds a Dependabot `ignore` for `github.com/grafana/loki/*`.

**Why:** loki is a *test-only* A/B oracle reference (build-tag `agpl_oracle`), never in the shipped binary — `agpl-clean` enforces 0 AGPL in `cmd/cerberus`. The oracle proves the in-house LogQL parser matches a *pinned* upstream baseline byte-for-byte; chasing loki point releases (#1139 = 3.7.1→3.7.3) can only break the oracle when upstream changes its parser, with no upside. `compatibility/loki` remains the real parity source-of-truth.

Supersedes and closes #1139. Reversible — drop the ignore to resume tracking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)