### PR TITLE
chore(compat): silence perpetually-dirty compliance submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,8 @@
 [submodule "compatibility/prometheus/upstream"]
 	path = compatibility/prometheus/upstream
 	url = https://github.com/prometheus/compliance.git
+	# The harness builds promql-compliance-tester inside this tree; that binary
+	# is an untracked artifact git can't ignore from the superproject. We pin
+	# this submodule purely by gitlink commit, so suppress in-tree dirt and
+	# still surface an actual commit-pin change.
+	ignore = dirty


### PR DESCRIPTION
`compatibility/prometheus/upstream` (the `prometheus/compliance` submodule) always showed as dirty in `git status` because the harness builds `promql-compliance-tester` **inside** the submodule tree, and the superproject's `.gitignore` can't reach content inside a submodule. We manage this submodule purely by its pinned gitlink commit, so `ignore = dirty` is correct — it suppresses in-tree build dirt while still surfacing a real commit-pin bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)