### PR TITLE
ci(property): correct job name to include TraceQL

### DIFF
--- a/.github/workflows/property.yml
+++ b/.github/workflows/property.yml
@@ -69,7 +69,7 @@ concurrency:
 
 jobs:
   property:
-    name: property (PromQL + LogQL, rapid N=500)
+    name: property (PromQL + LogQL + TraceQL, rapid N=500)
     runs-on: ubuntu-latest
     timeout-minutes: 30
     # RUN_HEAVY gates the real work: true on push / schedule / dispatch, and on


### PR DESCRIPTION
## What
Renames the property job: `property (PromQL + LogQL, rapid N=500)` → `property (PromQL + LogQL + TraceQL, rapid N=500)`.

## Why
The job runs `go test -tags chdb ./test/property/...`, which **already includes** `TestTraceQL_Property` — random TraceQL dataset+query generators (`gen/traceql.go`, 359 LOC) diffed against a from-scratch oracle (`oracle/traceql/evaluator.go`, 265 LOC) through the live Tempo HTTP handler via `property.Run`. The label said only two heads, making real TraceQL property coverage look absent. Label-only fix; no test behavior changes.

## ⚠️ Required-check coordination
`property (PromQL + LogQL, rapid N=500)` is a **required status check** on `main`. After this merges, that exact context never reports again. Branch protection must swap the required context to the new name (and in-flight PRs `update-branch` to pick up the renamed job), or PRs stall on a check that never posts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)