### PR TITLE
chore(release): cerberus v1.8.4 / chart 0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to cerberus will be documented in this file. The format roug
 
 ## [Unreleased]
 
+## [v1.8.4] — 2026-06-29
+
+### Fixed
+
+- **traceql:** enforce resource-bound invariant on every spans scan (traces drilldown OOM) (#1154)
+
 ## [v1.8.3] — 2026-06-29
 
 ### Added

--- a/deploy/helm/cerberus/Chart.yaml
+++ b/deploy/helm/cerberus/Chart.yaml
@@ -8,11 +8,11 @@ type: application
 # upgrade?" and is the publish trigger: a chart-only fix bumps this without an
 # app re-tag; an app-only release bumps appVersion + a PATCH here for the new
 # default image. Starts 0.x because the values contract is not yet frozen.
-version: 0.9.1
+version: 0.9.2
 
 # appVersion tracks the GA cerberus binary. Quoted so SemVer-shaped values
 # aren't coerced to floats. image.tag defaults from this when left empty.
-appVersion: "1.8.3"
+appVersion: "1.8.4"
 
 # autoscaling/v2 + policy/v1 (PDB) + networking/v1 (Ingress) are all GA from
 # 1.21+; 1.23 is the conservative floor matching the manifests this chart
@@ -45,27 +45,9 @@ annotations:
       url: https://github.com/tsouza/cerberus/blob/main/docs/operations.md
   artifacthub.io/images: |
     - name: cerberus
-      image: ghcr.io/tsouza/cerberus:v1.8.3
+      image: ghcr.io/tsouza/cerberus:v1.8.4
   # Bump the `1.0.0` floor here when the chart raises its minimum supported
   # cerberus release; informational for Artifact Hub's compatibility hints.
   artifacthub.io/changes: |
-    - kind: added
-      description: "engine: nested-subquery anchor product (GAP-C) + plan-node bound registry (#1120)"
-    - kind: added
-      description: "engine: reject subqueries whose anchor grid busts the sample budget (GAP-2) (#1115)"
-    - kind: added
-      description: "chart: bwc mode — bundled production ClickHouse on object storage (S3/GCS/Azure), no operator (#1106)"
     - kind: fixed
-      description: "license: de-AGPL audit cleanup (#1136)"
-    - kind: fixed
-      description: "logql: clean-room Apache LogQL parser (remove AGPL pkg/logql/syntax) (#1130)"
-    - kind: fixed
-      description: "traceql: clean-room Apache TraceQL parser (remove AGPL pkg/traceql) (#1131)"
-    - kind: fixed
-      description: "traceql: numeric-coerce attribute-vs-attribute ordering comparisons (#1127)"
-    - kind: fixed
-      description: "chclient: enforce the drain budget — 0 no longer disables it + cap line-peek bytes (#1123)"
-    - kind: fixed
-      description: "tempo: push /api/search limit into spanset-aggregation as server-side ORDER BY+LIMIT (#1122)"
-    - kind: fixed
-      description: "traceql: window spanset-aggregation searches (GAP-3) via generic leaf recurse (#1121)"
+      description: "traceql: enforce resource-bound invariant on every spans scan (traces drilldown OOM) (#1154)"

--- a/deploy/helm/cerberus/README.md
+++ b/deploy/helm/cerberus/README.md
@@ -5,7 +5,7 @@
      pipe-aligned, and the version footer adds a trailing blank — both are
      owned by helm-docs; realigning would fight the chart-ci drift check. -->
 
-![Version: 0.9.1](https://img.shields.io/badge/Version-0.9.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.3](https://img.shields.io/badge/AppVersion-1.8.3-informational?style=flat-square)
+![Version: 0.9.2](https://img.shields.io/badge/Version-0.9.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.4](https://img.shields.io/badge/AppVersion-1.8.4-informational?style=flat-square)
 
 Drop-in Prometheus / Loki / Tempo HTTP gateway for ClickHouse — a single stateless gateway that speaks three upstream query wire formats and lowers each to parameterised ClickHouse SQL.
 


### PR DESCRIPTION
Release-prep for **v1.8.4** (chart **0.9.2**), generated by `prepare-release.yml`.

- appVersion 1.8.3 -> 1.8.4, chart 0.9.1 -> 0.9.2

### Changes

### Fixed

- **traceql:** enforce resource-bound invariant on every spans scan (traces drilldown OOM) (#1154)

Generated from the conventional commits since the last tag. Review and edit before merging; the tag is cut once this lands.
