### PR TITLE
chore(compose): bump dev/showcase ClickHouse 26.5 -> 26.6

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,9 +61,10 @@ services:
     #
     # Pinned to a recent ClickHouse so the demo exercises every cerberus
     # optimization (see the cerberus service env): condition_cache needs
-    # >= 25.3 and the native ts_grid rate path needs >= 25.6 — both
-    # comfortably satisfied here.
-    image: clickhouse/clickhouse-server:26.5
+    # >= 25.3, the native ts_grid rate path needs >= 25.6, and >= 26.6
+    # parallelizes the GROUP BY over the WITH RECURSIVE used by the TraceQL
+    # structural-join path — all comfortably satisfied here.
+    image: clickhouse/clickhouse-server:26.6
     networks: [cerberus-dev]
     environment:
       CLICKHOUSE_DB: otel

--- a/versions.yaml
+++ b/versions.yaml
@@ -39,7 +39,7 @@ min_native_rate: "25.9"
 # the quickstart enables via CERBERUS_CH_OPTIMIZATIONS (today:
 # aggregation_in_order, condition_cache, ts_grid_range -> highest floor 25.9).
 # The check asserts quickstart_clickhouse >= that derived highest floor.
-quickstart_clickhouse: "26.5"
+quickstart_clickhouse: "26.6"
 
 # chdb_substrate - the ClickHouse version of the test substrate: the in-process
 # chDB engine (libchdb / chdb-go) the parity + perf suites run on, and the tag


### PR DESCRIPTION
Follow-up to #1160. Bumps the **root dev/showcase** `docker-compose.yml` ClickHouse image 26.5 → 26.6 so the demo stack actually exercises the recursive-CTE parallelism #1160 recommends (the `WITH RECURSIVE` `GROUP BY` on the TraceQL structural-join path).

Scope is the dev/showcase stack only — the compat (`prometheus/loki/tempo`), e2e-k3s, and helm pins stay at **25.8** (matched to the chDB test substrate for golden parity), and the bwc test stays at **26.3** by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)