### PR TITLE
test(e2e): make the OTel collector the sole compose schema authority + ship exp-histogram data

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -358,6 +358,20 @@ wrapper, plus `appendStepSummary` / `setOutput` for the runner files.
     `cerberus-bwc`), `STORAGE_POLICY` (default `bwc_object_store`), `MC_IMAGE`
     (default the pinned `minio/mc` RELEASE), `POLL_SECONDS` (default `30`).
   - Exit: `0` all assertions passed, `1` on any placement-assertion failure.
+- **`e2e-verify-exp-histogram.mjs`** — `e2e.yml`, the `compose-smoke-shard`
+  (required) + `compose-smoke-shard-info` (informational) jobs, run after
+  `docker compose up --wait`. Asserts the OTel collector's
+  exponential-histogram write path is queryable end to end: a telemetrygen
+  sidecar feeds OTLP `ExponentialHistogram` points named `e2e_latency_exp_hist`
+  through the collector into the exporter-created
+  `otel_metrics_exponential_histogram` table, and this module polls cerberus's
+  Prom API for `histogram_quantile(0.9, e2e_latency_exp_hist)` until it returns
+  a finite value. Complements the readiness probe (which proves the table
+  exists) by proving collector-written data is READABLE through cerberus's
+  native quantile path.
+  - Env: `CERBERUS_URL` (default `http://localhost:8080`), `EXP_HIST_METRIC`
+    (default `e2e_latency_exp_hist`), `POLL_SECONDS` (default `120`).
+  - Exit: `0` the quantile returned a finite value, `1` if not within budget.
 - **`e2e-cerberus-restart-gate.mjs`** — `e2e.yml`, the `Assert zero
   cerberus restarts` step on the k3d dashboard/crawl shards. Sums
   `restartCount` across the cerberus pods; on any restart dumps the

--- a/.github/scripts/e2e-verify-exp-histogram.mjs
+++ b/.github/scripts/e2e-verify-exp-histogram.mjs
@@ -1,0 +1,116 @@
+// e2e-verify-exp-histogram.mjs — assert the collector's exponential-histogram
+// write path is queryable end to end through cerberus, run by the compose-smoke
+// job AFTER `docker compose up --wait`.
+//
+// The compose stack makes the OTel collector the SOLE schema authority: its
+// clickhouseexporter creates otel_metrics_exponential_histogram, and a
+// telemetrygen sidecar feeds OTLP ExponentialHistogram points named
+// `e2e_latency_exp_hist` through the collector into that table. This module
+// closes the loop cerberus's readiness probe alone can't: readiness proves the
+// table EXISTS with the right shape, but not that data written by the collector
+// is actually READABLE. It drives cerberus's Prometheus HTTP API with a native
+// exponential-histogram quantile and asserts a finite value comes back.
+//
+// The `_exp_hist` suffix on the metric name routes
+// `histogram_quantile(φ, e2e_latency_exp_hist)` onto cerberus's native
+// exponential-histogram lowering (schema.ExpHistogramSuffix), so a non-empty,
+// finite result proves: collector -> exponential_histogram table -> cerberus
+// native quantile all agree.
+//
+// Poll, don't sample once: telemetrygen's first batch, the collector's insert,
+// and CH visibility lag `up --wait` by a few seconds. We retry until a finite
+// value appears or the budget elapses, then fail with a clear annotation.
+//
+// Env contract:
+//   CERBERUS_URL       base URL of cerberus's HTTP API   (default http://localhost:8080)
+//   EXP_HIST_METRIC    metric name telemetrygen emits    (default e2e_latency_exp_hist)
+//   POLL_SECONDS       total wait budget in seconds      (default 120)
+//
+// Exit 0 = the quantile returned a finite value; 1 = it did not within budget
+// (with a ::error:: annotation).
+
+import process from 'node:process';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { error, notice, log } from './lib/gh.mjs';
+
+const CERBERUS_URL = (process.env.CERBERUS_URL || 'http://localhost:8080').replace(/\/$/, '');
+const METRIC = process.env.EXP_HIST_METRIC || 'e2e_latency_exp_hist';
+const POLL_SECONDS = Number(process.env.POLL_SECONDS || '120');
+
+// Gap between query attempts. Short enough that the step returns promptly once
+// the data is visible, long enough not to hammer the API during the boot race.
+const POLL_INTERVAL_MS = 3000;
+const QUANTILE = 0.9;
+
+const query = `histogram_quantile(${QUANTILE}, ${METRIC})`;
+
+// queryValue runs one instant query and returns the first sample value as a
+// finite number, or null if the API errored, returned no series, or returned a
+// non-finite value (NaN/±Inf). It never throws on a transient network/HTTP
+// failure — those are expected during the boot race and drive a retry.
+async function queryValue() {
+  const url = `${CERBERUS_URL}/api/v1/query?query=${encodeURIComponent(query)}`;
+  let res;
+  try {
+    res = await fetch(url);
+  } catch (e) {
+    log(`query fetch failed (retrying): ${e.message}`);
+    return null;
+  }
+  if (!res.ok) {
+    log(`query HTTP ${res.status} (retrying)`);
+    return null;
+  }
+  let body;
+  try {
+    body = await res.json();
+  } catch (e) {
+    log(`query body not JSON (retrying): ${e.message}`);
+    return null;
+  }
+  if (body.status !== 'success') {
+    log(`query status=${body.status} error=${body.error || ''} (retrying)`);
+    return null;
+  }
+  const result = body.data && body.data.result;
+  if (!Array.isArray(result) || result.length === 0) {
+    return null;
+  }
+  // Instant vector: each series carries `value: [ts, "stringValue"]`.
+  const raw = result[0].value && result[0].value[1];
+  const num = Number(raw);
+  if (!Number.isFinite(num)) {
+    return null;
+  }
+  return num;
+}
+
+async function main() {
+  const deadline = Date.now() + POLL_SECONDS * 1000;
+  let attempts = 0;
+  for (;;) {
+    attempts += 1;
+    const value = await queryValue();
+    if (value !== null) {
+      notice(
+        `exp-histogram queryable through cerberus: ${query} = ${value} ` +
+          `(after ${attempts} attempt(s))`,
+      );
+      return 0;
+    }
+    if (Date.now() >= deadline) {
+      error(
+        `exp-histogram NOT queryable through cerberus after ${POLL_SECONDS}s: ` +
+          `${query} returned no finite value. The collector's clickhouseexporter ` +
+          `should have written telemetrygen's ExponentialHistogram points to ` +
+          `otel_metrics_exponential_histogram, and cerberus's native path should ` +
+          `read them back. Check the telemetrygen-exphist + otel-collector logs ` +
+          `and that cerberus's exp-histogram table name matches the exporter's.`,
+      );
+      return 1;
+    }
+    await sleep(POLL_INTERVAL_MS);
+  }
+}
+
+process.exit(await main());

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -378,7 +378,25 @@ jobs:
       - name: smoke cerberus /healthz + /readyz
         run: |
           curl -fsS --max-time 5 http://localhost:8080/healthz
-          curl -fsS --max-time 5 http://localhost:8080/readyz
+          # /readyz is the live schema-drift gate. The collector's
+          # clickhouseexporter is the SOLE schema authority (cerberus
+          # auto-create is off), so cerberus serves 503 until the exporter's
+          # start() provisions the tables — a beat behind the liveness
+          # healthcheck that satisfies `up --wait`. --retry-all-errors makes
+          # curl retry the 503 until the schema lands; a genuine table-name
+          # drift never resolves and the step fails, which is the catch.
+          curl -fsS --max-time 5 --retry 30 --retry-delay 2 --retry-all-errors \
+            http://localhost:8080/readyz
+
+      # The collector-created otel_metrics_exponential_histogram table must be
+      # queryable end to end: telemetrygen feeds ExponentialHistogram points
+      # through the collector, and cerberus must resolve a native quantile over
+      # them. Polls cerberus's Prom API until the query returns a finite value
+      # (ingestion lags the insert by a beat) or the budget elapses.
+      - name: verify collector exp-histogram is queryable through cerberus
+        run: node .github/scripts/e2e-verify-exp-histogram.mjs
+        env:
+          CERBERUS_URL: http://localhost:8080
 
       - name: smoke Grafana /api/health
         run: |
@@ -577,7 +595,17 @@ jobs:
       - name: smoke cerberus /healthz + /readyz
         run: |
           curl -fsS --max-time 5 http://localhost:8080/healthz
-          curl -fsS --max-time 5 http://localhost:8080/readyz
+          # Poll /readyz: the collector (sole schema authority) provisions the
+          # tables a beat after the liveness healthcheck satisfies `up --wait`,
+          # so retry the 503 until the schema lands. A real table-name drift
+          # never resolves and the step fails.
+          curl -fsS --max-time 5 --retry 30 --retry-delay 2 --retry-all-errors \
+            http://localhost:8080/readyz
+
+      - name: verify collector exp-histogram is queryable through cerberus
+        run: node .github/scripts/e2e-verify-exp-histogram.mjs
+        env:
+          CERBERUS_URL: http://localhost:8080
 
       - name: smoke Grafana /api/health
         run: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,11 +14,20 @@
 #                   Closes the dogfood loop: cerberus emits self-telemetry
 #                   over OTLP -> collector writes to ClickHouse -> cerberus
 #                   queries it back through its own Prom/Loki/Tempo APIs.
+#                   Its clickhouseexporter (create_schema: true) is the SOLE
+#                   schema authority for this stack — cerberus auto-create is
+#                   off and the seeder never creates tables — so cerberus's
+#                   readiness probe doubles as a live schema-drift detector.
 #                   Config: test/e2e/otel-collector/compose-config.yaml.
+#   telemetrygen    one exponential-histogram metric source (e2e_latency_exp_hist)
+#                   fed through the collector, so the exporter-created
+#                   otel_metrics_exponential_histogram table carries data a
+#                   native histogram_quantile query can read back.
 #   cerberus        built from the repo-root `Dockerfile.local` (same image
-#                   the k3d E2E uses). Auto-creates the OTel-CH schema on
-#                   startup via CERBERUS_AUTO_CREATE_SCHEMA=true, so no
-#                   separate init job. Exports OTLP to `otel-collector:4317`.
+#                   the k3d E2E uses). Does NOT auto-create the schema
+#                   (CERBERUS_AUTO_CREATE_SCHEMA=false); it serves unready
+#                   until the collector provisions the tables, then reads
+#                   them. Exports OTLP to `otel-collector:4317`.
 #                   Cerberus's own self-telemetry (metrics + logs + traces)
 #                   is the sole data source for the quickstart: it flows
 #                   cerberus -> otel-collector -> ClickHouse -> back into
@@ -144,9 +153,10 @@ services:
     # self-telemetry can't guarantee deterministically: counter resets
     # (`resets()`), flapping gauges (`changes()`), multi-key label sets
     # (`label_join` / `count_values`), and exponential histograms
-    # (native `histogram_quantile`). The seeder's ddl.Apply is the same
-    # CREATE IF NOT EXISTS set cerberus's CERBERUS_AUTO_CREATE_SCHEMA
-    # applies, so the startup race between the two is idempotent.
+    # (native `histogram_quantile`). The seeder does NOT create tables — the
+    # collector's clickhouseexporter is the sole schema authority — so it
+    # WAITS for the exporter-created tables to appear, then INSERTs its rows
+    # into them (see test/e2e/seed/cmd/seed/main.go waitForTables).
     image: cerberus-seed:dev
     pull_policy: build
     build:
@@ -163,6 +173,49 @@ services:
     depends_on:
       clickhouse:
         condition: service_healthy
+      # Gate the seeder behind the collector process so its table-existence
+      # wait starts once the sole schema writer is live (service_started only —
+      # the FROM-scratch contrib image has no healthcheck binary; the seeder's
+      # own bounded waitForTables poll absorbs the create-schema latency).
+      otel-collector:
+        condition: service_started
+
+  telemetrygen-exphist:
+    # Exponential-histogram data SOURCE, fed THROUGH the collector. Every other
+    # metric shape in this stack reaches CH either via cerberus's own OTLP
+    # self-telemetry or the seeder's direct INSERT; none exercises the
+    # collector's exponential-histogram WRITE path. telemetrygen emits OTLP
+    # ExponentialHistogram points to the collector, whose clickhouseexporter
+    # persists them into otel_metrics_exponential_histogram — the exporter-owned
+    # table cerberus must read back. The metric name carries the `_exp_hist`
+    # suffix so cerberus's native path routes
+    # `histogram_quantile(φ, e2e_latency_exp_hist)` onto that table
+    # (schema.ExpHistogramSuffix); the compose-smoke exp-histogram verifier
+    # (.github/scripts/e2e-verify-exp-histogram.mjs) asserts the query returns a
+    # value. `--duration inf` at `--rate 20` emits continuously for the whole
+    # stack lifetime, so a fresh sample always sits inside the PromQL staleness
+    # window no matter how long the shard runs (`down -v` tears it down).
+    image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.152.0
+    networks: [cerberus-dev]
+    command:
+      - metrics
+      - --metric-type
+      - ExponentialHistogram
+      - --otlp-endpoint
+      - otel-collector:4317
+      - --otlp-insecure
+      - --otlp-metric-name
+      - e2e_latency_exp_hist
+      - --duration
+      - inf
+      - --rate
+      - "20"
+    # telemetrygen FATALs if the collector's OTLP endpoint isn't accepting
+    # connections yet (k3d #82); on-failure restart retries until it is up.
+    restart: on-failure
+    depends_on:
+      otel-collector:
+        condition: service_started
 
   cerberus:
     image: cerberus:dev
@@ -180,9 +233,15 @@ services:
       CERBERUS_CH_USERNAME: "cerberus"
       CERBERUS_CH_PASSWORD: "cerberus"
       CERBERUS_CH_DIAL_TIMEOUT: "10s"
-      # CERBERUS_AUTO_CREATE_SCHEMA   apply the OTel-CH DDL on startup so a
-      # fresh CH volume is queryable without a separate migration step.
-      CERBERUS_AUTO_CREATE_SCHEMA: "true"
+      # CERBERUS_AUTO_CREATE_SCHEMA   OFF by design. The collector's
+      # clickhouseexporter (create_schema: true) is the SOLE schema authority
+      # for this stack, so cerberus never mints its own tables. That makes the
+      # readiness probe a live drift detector: if cerberus's read-side table
+      # names ever diverge from the exporter's real names, the expected tables
+      # are absent, /readyz stays 503, and compose-smoke fails instead of
+      # silently querying an empty table.
+      # cerberus serves unready until the exporter provisions the schema.
+      CERBERUS_AUTO_CREATE_SCHEMA: "false"
       # CERBERUS_OTLP_*       export self-telemetry (metrics + logs +
       # traces) to the in-stack OTel Collector over OTLP/gRPC. Closes
       # the dogfood loop: cerberus emits -> collector writes to CH ->

--- a/test/e2e/k3s/README.md
+++ b/test/e2e/k3s/README.md
@@ -43,11 +43,12 @@ Cerberus's E2E stack populates ClickHouse from **two independent
 sources** that write to the same `otel.*` tables:
 
 1. **Synthetic seed (`just e2e-seed`).** Runs the Go program at
-   `test/e2e/seed/cmd/seed/`. It applies the upstream OTel-CH DDL via
-   `internal/schema/ddl.Apply` and inserts a small set of deterministic
-   rows (the canonical `up` metric, a couple of log lines, a span pair,
-   etc.). This is what spec-style E2E tests assert on — they need
-   known values at known timestamps with known labels.
+   `test/e2e/seed/cmd/seed/`. It does NOT create tables — it waits for an
+   external writer (the collector's clickhouseexporter, and here also
+   cerberus's own auto-create hook) to provision the schema, then inserts a
+   small set of deterministic rows (the canonical `up` metric, a couple of
+   log lines, a span pair, etc.). This is what spec-style E2E tests assert
+   on — they need known values at known timestamps with known labels.
 
 2. **Real OTel pipeline (`test/e2e/k3s/otel-collector.yaml`).** Boots
    alongside cerberus and continuously writes real telemetry:

--- a/test/e2e/seed/cmd/seed/main.go
+++ b/test/e2e/seed/cmd/seed/main.go
@@ -2,11 +2,23 @@
 // fixture rows that the e2e test suite + Grafana Playwright smoke depend on.
 //
 // It is the Go replacement for the three pre-existing
-// `test/e2e/seed/{otel_metrics,otel_logs,otel_traces}.sql` scripts. The DDL
-// half now lives in [internal/schema/ddl] (PR C of the schema-source-of-truth
-// sequence) which wraps the upstream OTel ClickHouse Exporter templates. The
-// INSERT statements below are preserved verbatim from the old .sql files so
-// the row set the regression tests + e2e tests see is unchanged.
+// `test/e2e/seed/{otel_metrics,otel_logs,otel_traces}.sql` scripts. The INSERT
+// statements below are preserved verbatim from the old .sql files so the row
+// set the regression tests + e2e tests see is unchanged.
+//
+// # Schema authority (the seeder never creates tables)
+//
+// The seeder does NOT create the schema. In every stack it runs against an
+// external writer owns table creation: the OTel Collector's clickhouseexporter
+// (create_schema: true) in the compose quickstart, plus cerberus's own
+// auto-create hook in the k3d lane. Making the collector the SOLE schema
+// authority in compose turns cerberus's readiness probe into a live drift
+// detector — if cerberus's read-side table-name defaults ever diverge from the
+// exporter's real names again, cerberus can't find its expected tables, /readyz
+// stays 503, and compose-smoke fails. A cerberus-DDL create path here would
+// re-mask that drift by minting the cerberus-named tables the seeder inserts
+// into, so it is deliberately absent: the seeder WAITS for the external
+// writer's tables to appear (see waitForTables) before it inserts.
 //
 // Connection inputs (all env-driven; the Justfile sets them via
 // `kubectl port-forward`):
@@ -62,8 +74,6 @@ import (
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
-
-	"github.com/tsouza/cerberus/internal/schema/ddl"
 )
 
 func main() {
@@ -115,9 +125,14 @@ func run(ctx context.Context, reSeedInterval time.Duration) error {
 		return fmt.Errorf("ping %s: %w", addr, err)
 	}
 
-	log.Printf("seed: applying upstream OTel-CH DDL to %s (database=%s)", addr, database) //nolint:gosec // G706: addr+database are CI/dev env config, not user input
-	if err := ddl.ApplyWithConfig(ctx, conn, ddl.Config{Database: database}, ddl.All); err != nil {
-		return fmt.Errorf("apply ddl: %w", err)
+	// The seeder never creates the schema (see the package doc comment): the
+	// OTel collector's clickhouseexporter owns table creation. Wait for every
+	// table the INSERTs below target to exist before inserting, so the seeder
+	// tolerates the collector-creates-first ordering rather than failing with
+	// UNKNOWN_TABLE on a cold stack.
+	log.Printf("seed: waiting for the external writer's tables on %s (database=%s)", addr, database) //nolint:gosec // G706: addr+database are CI/dev env config, not user input
+	if err := waitForTables(ctx, conn, database, seededTables, tableWaitTimeout); err != nil {
+		return fmt.Errorf("wait for tables: %w", err)
 	}
 
 	if err := seedAll(ctx, conn); err != nil {
@@ -157,6 +172,83 @@ func run(ctx context.Context, reSeedInterval time.Duration) error {
 			log.Printf("seed: re-seed tick at %s ok", t.Format(time.RFC3339))
 		}
 	}
+}
+
+// Table-wait tuning. The collector's clickhouseexporter creates every OTel
+// table eagerly at exporter start(), so on a warm stack the tables are already
+// present and the first poll returns immediately; the budget only has to absorb
+// a cold boot where the seeder races ahead of the collector's start().
+const (
+	// tableWaitTimeout bounds the wait for the external writer's tables before
+	// the seeder gives up with a clear error rather than hanging a shard.
+	tableWaitTimeout = 3 * time.Minute
+	// tableWaitPoll is the gap between table-existence polls.
+	tableWaitPoll = 2 * time.Second
+)
+
+// seededTables are the tables every seed INSERT targets — the set the external
+// schema writer (the OTel collector) must have created before the seeder can
+// insert. Kept in lockstep with the INSERT statements below; a table added to
+// an INSERT without being added here would surface as an UNKNOWN_TABLE on a
+// cold stack instead of a bounded, explained wait.
+var seededTables = []string{
+	"otel_metrics_gauge",
+	"otel_metrics_sum",
+	"otel_metrics_histogram",
+	"otel_metrics_exponential_histogram",
+	"otel_logs",
+	"otel_traces",
+}
+
+// waitForTables blocks until every table in tables exists in database, or the
+// timeout elapses (or ctx is cancelled). It is the seeder's tolerance for the
+// collector-creates-first ordering: on a cold stack the seeder can start before
+// the collector's start() has run the schema DDL, so rather than failing with
+// UNKNOWN_TABLE it polls system.tables until the writer has provisioned every
+// table the INSERTs target. On timeout it names the tables still missing so a
+// CI failure points straight at the stuck creator.
+func waitForTables(ctx context.Context, conn driver.Conn, database string, tables []string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	ticker := time.NewTicker(tableWaitPoll)
+	defer ticker.Stop()
+	for {
+		missing, err := missingTables(ctx, conn, database, tables)
+		if err != nil {
+			return err
+		}
+		if len(missing) == 0 {
+			log.Printf("seed: all %d tables present", len(tables))
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out after %s waiting for tables to be created by the external writer: %v", timeout, missing)
+		}
+		log.Printf("seed: %d table(s) not yet created, waiting: %v", len(missing), missing)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+// missingTables returns the members of tables that do not yet exist in
+// database. The query is static with the name bound as a parameter — no
+// SQL string interpolation, same discipline as the INSERTs.
+func missingTables(ctx context.Context, conn driver.Conn, database string, tables []string) ([]string, error) {
+	const existsSQL = "SELECT count() FROM system.tables WHERE database = ? AND name = ?"
+	var missing []string
+	for _, t := range tables {
+		var n uint64
+		row := conn.QueryRow(ctx, existsSQL, database, t)
+		if err := row.Scan(&n); err != nil {
+			return nil, fmt.Errorf("introspect table %s: %w", t, err)
+		}
+		if n == 0 {
+			missing = append(missing, t)
+		}
+	}
+	return missing, nil
 }
 
 // seedAll runs every INSERT once against the live connection. The

--- a/test/regression/seed_test.go
+++ b/test/regression/seed_test.go
@@ -115,20 +115,20 @@ func TestLogsSeedUsesUnderscoredServiceName(t *testing.T) {
 // seed, every metadata query fails with `Table doesn't exist` and
 // cerberus returns 502.
 //
-// Schema creation is now delegated to internal/schema/ddl which always
-// creates all 5 metrics tables (gauge, sum, histogram, exp_histogram,
-// summary) as a single Metrics signal. So the table is guaranteed to
-// exist as long as the seeder calls `ddl.Apply(ctx, conn, ddl.All)` —
-// that's what this test now asserts.
+// The compose stack's OTel-CH schema is provisioned by the external OTel
+// collector, so the seeder blocks (waitForTables) until every table it inserts
+// into — otel_metrics_histogram included — has been created before it writes.
+// The histogram table is therefore guaranteed present as long as the seeder
+// keeps otel_metrics_histogram in its wait set; that's what this test asserts.
 func TestMetricsSeedHasHistogramTable(t *testing.T) {
 	t.Parallel()
 
 	content := readSeedSource(t)
-	if !strings.Contains(content, "ddl.ApplyWithConfig") && !strings.Contains(content, "ddl.Apply") {
-		t.Errorf("%s: expected the seeder to call ddl.Apply / ddl.ApplyWithConfig to create the OTel-CH schema (incl. otel_metrics_histogram)", seedSource)
+	if !strings.Contains(content, "waitForTables") {
+		t.Errorf("%s: expected the seeder to waitForTables until the external writer provisions the OTel-CH schema (incl. otel_metrics_histogram)", seedSource)
 	}
-	if !strings.Contains(content, "ddl.All") {
-		t.Errorf("%s: expected the seeder to pass ddl.All — without the Metrics signal, otel_metrics_histogram is missing and Prom /labels + /label/.../values + /metadata fail with 502", seedSource)
+	if !strings.Contains(content, `"otel_metrics_histogram"`) {
+		t.Errorf("%s: expected the seeder to require otel_metrics_histogram (in its wait set) — without it, Prom /labels + /label/.../values + /metadata fail with 502", seedSource)
 	}
 }
 


### PR DESCRIPTION
## What this delivers

The compose E2E had three schema creators — the seed's `ddl.Apply`, cerberus auto-create, and the OTel collector's `clickhouseexporter` — so the collector's authoritative (exporter-named) schema was never load-bearing, and a read-side table-name drift from the exporter's names could pass unseen while every lane stayed green.

This makes the collector the **sole** schema authority in compose, so cerberus's existing readiness gate becomes a live drift detector on every `compose-smoke` run:

- `docker-compose.yml`: `CERBERUS_AUTO_CREATE_SCHEMA=false`; the seed no longer creates tables and gates behind the collector process.
- seed (`test/e2e/seed`): drop `ddl.Apply`; bounded-poll `system.tables` for the collector-created tables before inserting, so no cerberus-DDL create path can mask drift. cerberus serves unready until the collector provisions the schema — safe by design.
- `e2e.yml`: the `/readyz` smoke retries the collector-creates-first 503; a genuine read-side drift never resolves and the step fails.
- A `telemetrygen` sidecar emits OTLP `ExponentialHistogram` points (`e2e_latency_exp_hist`) into the exporter-created `otel_metrics_exponential_histogram`, and a new verifier asserts cerberus resolves a native `histogram_quantile` over them.

**Net:** if cerberus's read-side default table names ever drift from the exporter's real names, `/readyz` stays 503 and `compose-smoke` fails.

## Local validation

- `/readyz` = 200, reading tables the **collector** authored (`Attributes` = `Map(LowCardinality(String), String)`, the exporter's shape — not cerberus's plain-map DDL).
- telemetrygen wrote exp-histogram rows; the verifier resolved a native `histogram_quantile` and exited 0.
- **Drift-catch proof:** pointing cerberus's exp-histogram table at a name the exporter does not create held `/readyz` at 503 — exactly the failure the gate now surfaces.

## Ordering

Stacked on **#1171** — the read-side default lives there. The earlier commits drop out of this diff once #1171 merges to `main`. **Merge #1171 first.** References #1168.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
