### PR TITLE
test(e2e): add classic-histogram telemetrygen collector-write-path check

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -372,6 +372,21 @@ wrapper, plus `appendStepSummary` / `setOutput` for the runner files.
   - Env: `CERBERUS_URL` (default `http://localhost:8080`), `EXP_HIST_METRIC`
     (default `e2e_latency_exp_hist`), `POLL_SECONDS` (default `120`).
   - Exit: `0` the quantile returned a finite value, `1` if not within budget.
+- **`e2e-verify-classic-histogram.mjs`** — `e2e.yml`, the `compose-smoke-shard`
+  (required) + `compose-smoke-shard-info` (informational) jobs, run after
+  `docker compose up --wait`. Explicit-bucket sibling of
+  `e2e-verify-exp-histogram.mjs`: asserts the OTel collector's classic
+  (explicit-bucket) histogram write path is queryable end to end. A second
+  telemetrygen sidecar feeds OTLP classic `Histogram` points named
+  `e2e_latency_classic_hist` through the collector into the exporter-created
+  `otel_metrics_histogram` table, and this module polls cerberus's Prom API for
+  `histogram_quantile(0.9, rate(e2e_latency_classic_hist_bucket[5m]))` until it
+  returns a finite value. Proves collector-written classic-histogram data is
+  READABLE through cerberus's classic `_bucket`/`le` quantile path.
+  - Env: `CERBERUS_URL` (default `http://localhost:8080`),
+    `CLASSIC_HIST_METRIC` (default `e2e_latency_classic_hist`), `POLL_SECONDS`
+    (default `120`).
+  - Exit: `0` the quantile returned a finite value, `1` if not within budget.
 - **`e2e-cerberus-restart-gate.mjs`** — `e2e.yml`, the `Assert zero
   cerberus restarts` step on the k3d dashboard/crawl shards. Sums
   `restartCount` across the cerberus pods; on any restart dumps the

--- a/.github/scripts/e2e-verify-classic-histogram.mjs
+++ b/.github/scripts/e2e-verify-classic-histogram.mjs
@@ -1,0 +1,121 @@
+// e2e-verify-classic-histogram.mjs — assert the collector's classic
+// (explicit-bucket) histogram write path is queryable end to end through
+// cerberus, run by the compose-smoke job AFTER `docker compose up --wait`.
+//
+// The compose stack makes the OTel collector the SOLE schema authority: its
+// clickhouseexporter creates otel_metrics_histogram, and a telemetrygen sidecar
+// feeds OTLP classic Histogram points named `e2e_latency_classic_hist` through
+// the collector into that table. This module closes the loop cerberus's
+// readiness probe alone can't: readiness proves the table EXISTS with the right
+// shape, but not that data written by the collector is actually READABLE. It
+// drives cerberus's Prometheus HTTP API with the classic quantile idiom and
+// asserts a finite value comes back.
+//
+// The classic path reconstructs `<name>_bucket` series with `le` labels from
+// the exporter's BucketCounts / ExplicitBounds columns, so
+// `histogram_quantile(φ, rate(e2e_latency_classic_hist_bucket[…]))` proves:
+// collector -> otel_metrics_histogram -> cerberus classic `_bucket` quantile
+// all agree. This is the explicit-bucket sibling of e2e-verify-exp-histogram.mjs
+// (native exponential path); together they cover both histogram shapes the
+// collector's write path emits.
+//
+// Poll, don't sample once: telemetrygen's first batch, the collector's insert,
+// and CH visibility lag `up --wait` by a few seconds. We retry until a finite
+// value appears or the budget elapses, then fail with a clear annotation.
+//
+// Env contract:
+//   CERBERUS_URL         base URL of cerberus's HTTP API   (default http://localhost:8080)
+//   CLASSIC_HIST_METRIC  metric name telemetrygen emits    (default e2e_latency_classic_hist)
+//   POLL_SECONDS         total wait budget in seconds      (default 120)
+//
+// Exit 0 = the quantile returned a finite value; 1 = it did not within budget
+// (with a ::error:: annotation).
+
+import process from 'node:process';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { error, notice, log } from './lib/gh.mjs';
+
+const CERBERUS_URL = (process.env.CERBERUS_URL || 'http://localhost:8080').replace(/\/$/, '');
+const METRIC = process.env.CLASSIC_HIST_METRIC || 'e2e_latency_classic_hist';
+const POLL_SECONDS = Number(process.env.POLL_SECONDS || '120');
+
+// Gap between query attempts. Short enough that the step returns promptly once
+// the data is visible, long enough not to hammer the API during the boot race.
+const POLL_INTERVAL_MS = 3000;
+const QUANTILE = 0.9;
+// Rate window over the `_bucket` counters — wide enough that a continuously
+// emitting telemetrygen source retains at least two samples for `rate()`.
+const RATE_WINDOW = '5m';
+
+const query = `histogram_quantile(${QUANTILE}, rate(${METRIC}_bucket[${RATE_WINDOW}]))`;
+
+// queryValue runs one instant query and returns the first sample value as a
+// finite number, or null if the API errored, returned no series, or returned a
+// non-finite value (NaN/±Inf). It never throws on a transient network/HTTP
+// failure — those are expected during the boot race and drive a retry.
+async function queryValue() {
+  const url = `${CERBERUS_URL}/api/v1/query?query=${encodeURIComponent(query)}`;
+  let res;
+  try {
+    res = await fetch(url);
+  } catch (e) {
+    log(`query fetch failed (retrying): ${e.message}`);
+    return null;
+  }
+  if (!res.ok) {
+    log(`query HTTP ${res.status} (retrying)`);
+    return null;
+  }
+  let body;
+  try {
+    body = await res.json();
+  } catch (e) {
+    log(`query body not JSON (retrying): ${e.message}`);
+    return null;
+  }
+  if (body.status !== 'success') {
+    log(`query status=${body.status} error=${body.error || ''} (retrying)`);
+    return null;
+  }
+  const result = body.data && body.data.result;
+  if (!Array.isArray(result) || result.length === 0) {
+    return null;
+  }
+  // Instant vector: each series carries `value: [ts, "stringValue"]`.
+  const raw = result[0].value && result[0].value[1];
+  const num = Number(raw);
+  if (!Number.isFinite(num)) {
+    return null;
+  }
+  return num;
+}
+
+async function main() {
+  const deadline = Date.now() + POLL_SECONDS * 1000;
+  let attempts = 0;
+  for (;;) {
+    attempts += 1;
+    const value = await queryValue();
+    if (value !== null) {
+      notice(
+        `classic-histogram queryable through cerberus: ${query} = ${value} ` +
+          `(after ${attempts} attempt(s))`,
+      );
+      return 0;
+    }
+    if (Date.now() >= deadline) {
+      error(
+        `classic-histogram NOT queryable through cerberus after ${POLL_SECONDS}s: ` +
+          `${query} returned no finite value. The collector's clickhouseexporter ` +
+          `should have written telemetrygen's classic Histogram points to ` +
+          `otel_metrics_histogram, and cerberus's classic _bucket path should ` +
+          `read them back. Check the telemetrygen-classichist + otel-collector ` +
+          `logs and that cerberus's histogram table name matches the exporter's.`,
+      );
+      return 1;
+    }
+    await sleep(POLL_INTERVAL_MS);
+  }
+}
+
+process.exit(await main());

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -398,6 +398,15 @@ jobs:
         env:
           CERBERUS_URL: http://localhost:8080
 
+      # Same loop for the classic (explicit-bucket) histogram write path: a
+      # second telemetrygen sidecar feeds classic Histogram points into
+      # otel_metrics_histogram, and cerberus must resolve the classic `_bucket`
+      # quantile idiom over them. Explicit-bucket sibling of the check above.
+      - name: verify collector classic-histogram is queryable through cerberus
+        run: node .github/scripts/e2e-verify-classic-histogram.mjs
+        env:
+          CERBERUS_URL: http://localhost:8080
+
       - name: smoke Grafana /api/health
         run: |
           curl -fsS --max-time 5 http://localhost:3000/api/health \
@@ -604,6 +613,11 @@ jobs:
 
       - name: verify collector exp-histogram is queryable through cerberus
         run: node .github/scripts/e2e-verify-exp-histogram.mjs
+        env:
+          CERBERUS_URL: http://localhost:8080
+
+      - name: verify collector classic-histogram is queryable through cerberus
+        run: node .github/scripts/e2e-verify-classic-histogram.mjs
         env:
           CERBERUS_URL: http://localhost:8080
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -217,6 +217,44 @@ services:
       otel-collector:
         condition: service_started
 
+  telemetrygen-classichist:
+    # Classic-histogram data SOURCE, fed THROUGH the collector — the explicit-
+    # bucket sibling of telemetrygen-exphist. telemetrygen emits OTLP classic
+    # Histogram points to the collector, whose clickhouseexporter persists them
+    # into otel_metrics_histogram — the exporter-owned table cerberus reads back
+    # via the classic `_bucket` / `le` reconstruction. The metric name carries a
+    # distinct `_classic_hist` suffix so cerberus routes
+    # `histogram_quantile(φ, rate(e2e_latency_classic_hist_bucket[…]))` onto that
+    # table; the compose-smoke classic-histogram verifier
+    # (.github/scripts/e2e-verify-classic-histogram.mjs) asserts the query
+    # returns a value. Kept separate from the exponential source and from the
+    # deterministic showcase seed so this nondeterministic feed never collides
+    # with either. `--duration inf` at `--rate 20` emits continuously for the
+    # whole stack lifetime, so a fresh sample always sits inside the PromQL
+    # staleness window no matter how long the shard runs (`down -v` tears it
+    # down).
+    image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.152.0
+    networks: [cerberus-dev]
+    command:
+      - metrics
+      - --metric-type
+      - Histogram
+      - --otlp-endpoint
+      - otel-collector:4317
+      - --otlp-insecure
+      - --otlp-metric-name
+      - e2e_latency_classic_hist
+      - --duration
+      - inf
+      - --rate
+      - "20"
+    # telemetrygen FATALs if the collector's OTLP endpoint isn't accepting
+    # connections yet (k3d #82); on-failure restart retries until it is up.
+    restart: on-failure
+    depends_on:
+      otel-collector:
+        condition: service_started
+
   cerberus:
     image: cerberus:dev
     pull_policy: build


### PR DESCRIPTION
## What

Adds a `telemetrygen-classichist` sidecar to the compose E2E, the explicit-bucket sibling of the existing `telemetrygen-exphist` (exponential) source. This gives the compose-smoke lane symmetric coverage of the OTel collector's **classic (explicit-bucket) histogram write path**, end to end.

## Why

The exponential source validates that the collector's clickhouseexporter write path for `otel_metrics_exponential_histogram` is not just *shaped* right (readiness proves the table exists) but *readable* through cerberus's native quantile. The classic histogram shape — real OTLP `Histogram` → exporter writes `otel_metrics_histogram` → cerberus reconstructs `_bucket`/`le` series → `histogram_quantile` — had no equivalent live write-path check. This closes that gap so both histogram shapes the collector emits are exercised through the real exporter, not only the deterministic direct-INSERT seed.

## What it adds

- **`docker-compose.yml`** — `telemetrygen-classichist` service: same image/version, `depends_on`/`restart: on-failure` wait pattern as `telemetrygen-exphist`, but `--metric-type Histogram` emitting a distinct `e2e_latency_classic_hist` so it lands in `otel_metrics_histogram` and never collides with the deterministic showcase seed or the exponential source.
- **`.github/scripts/e2e-verify-classic-histogram.mjs`** — mirrors the exp verifier. Polls cerberus's Prom API for `histogram_quantile(0.9, rate(e2e_latency_classic_hist_bucket[5m]))` (the classic `_bucket`-rate idiom cerberus uses, matching the showcase classic panel) until it returns a **finite** value. Assertion-tolerant — telemetrygen data is nondeterministic, so it asserts *finite*, not an exact value. `node:` builtins only; `::error::`/`::notice::` + `process.exit`; reuses `lib/gh.mjs`. Quantile, poll interval, rate window are named consts (no magic constants).
- **`.github/workflows/e2e.yml`** — runs the new verifier in the same compose-smoke lanes as the exp one.
- **`.github/scripts/README.md`** — inventory entry with env contract.

## Constraints honoured

- Does **not** touch `test/e2e/seed` or the showcase/dashboard panels — those need exact seeded values; the nondeterministic telemetrygen feed lives only in this tolerant verifier lane.
- No `t.Skip`/soft-assert/tolerate; no magic constants; no `unsafe.Pointer`.

## Local validation

- `node --check` on the new `.mjs`; ran it against no server to confirm it enters the tolerant retry loop.
- `docker compose config` resolves; `docker compose config --services` shows both `telemetrygen-classichist` and `telemetrygen-exphist`.
- `actionlint .github/workflows/e2e.yml` clean.
- Pre-push gate (golangci-lint / markdownlint / discipline greps) passed on push.