### PR TITLE
chore(release): cerberus v1.9.0 / chart 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to cerberus will be documented in this file. The format roug
 
 ## [Unreleased]
 
+## [v1.9.0] — 2026-07-02
+
+### Added
+
+- **traceql:** two-phase structural search to bound the wide projection (#1166)
+
+### Fixed
+
+- **prom:** exp-histogram support on the real OTel-CH exporter schema (#1171)
+- **traces:** window-bound every otel_traces scan + memory-bound compare and structural (#1163)
+
+### Changed
+
+- split phase4-traceql into three memory-balanced matrix entries
+
+### CI
+
+- **mutation:** rebalance traceql split into four RE2-safe package-scoped legs (#1178)
+- **mutation:** run phase4-traceql at workers=1 to fit the runner budget (#1177)
+
+### Documentation
+
+- rewrite README to be human-first (plain intro, lighter 1.0 disclaimer, progressive depth) (#1162)
+- **operations:** recommend ClickHouse 26.6+ for parallel recursive CTEs on structural-join (#1160)
+
 ## [v1.8.4] — 2026-06-29
 
 ### Fixed

--- a/deploy/helm/cerberus/Chart.yaml
+++ b/deploy/helm/cerberus/Chart.yaml
@@ -8,11 +8,11 @@ type: application
 # upgrade?" and is the publish trigger: a chart-only fix bumps this without an
 # app re-tag; an app-only release bumps appVersion + a PATCH here for the new
 # default image. Starts 0.x because the values contract is not yet frozen.
-version: 0.9.2
+version: 0.10.0
 
 # appVersion tracks the GA cerberus binary. Quoted so SemVer-shaped values
 # aren't coerced to floats. image.tag defaults from this when left empty.
-appVersion: "1.8.4"
+appVersion: "1.9.0"
 
 # autoscaling/v2 + policy/v1 (PDB) + networking/v1 (Ingress) are all GA from
 # 1.21+; 1.23 is the conservative floor matching the manifests this chart
@@ -45,9 +45,15 @@ annotations:
       url: https://github.com/tsouza/cerberus/blob/main/docs/operations.md
   artifacthub.io/images: |
     - name: cerberus
-      image: ghcr.io/tsouza/cerberus:v1.8.4
+      image: ghcr.io/tsouza/cerberus:v1.9.0
   # Bump the `1.0.0` floor here when the chart raises its minimum supported
   # cerberus release; informational for Artifact Hub's compatibility hints.
   artifacthub.io/changes: |
+    - kind: added
+      description: "traceql: two-phase structural search to bound the wide projection (#1166)"
     - kind: fixed
-      description: "traceql: enforce resource-bound invariant on every spans scan (traces drilldown OOM) (#1154)"
+      description: "prom: exp-histogram support on the real OTel-CH exporter schema (#1171)"
+    - kind: fixed
+      description: "traces: window-bound every otel_traces scan + memory-bound compare and structural (#1163)"
+    - kind: changed
+      description: "split phase4-traceql into three memory-balanced matrix entries"

--- a/deploy/helm/cerberus/README.md
+++ b/deploy/helm/cerberus/README.md
@@ -5,7 +5,7 @@
      pipe-aligned, and the version footer adds a trailing blank — both are
      owned by helm-docs; realigning would fight the chart-ci drift check. -->
 
-![Version: 0.9.2](https://img.shields.io/badge/Version-0.9.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.4](https://img.shields.io/badge/AppVersion-1.8.4-informational?style=flat-square)
+![Version: 0.10.0](https://img.shields.io/badge/Version-0.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.9.0](https://img.shields.io/badge/AppVersion-1.9.0-informational?style=flat-square)
 
 Drop-in Prometheus / Loki / Tempo HTTP gateway for ClickHouse — a single stateless gateway that speaks three upstream query wire formats and lowers each to parameterised ClickHouse SQL.
 


### PR DESCRIPTION
Release-prep for **v1.9.0** (chart **0.10.0**), generated by `prepare-release.yml`.

- appVersion 1.8.4 -> 1.9.0, chart 0.9.2 -> 0.10.0

### Changes

### Added

- **traceql:** two-phase structural search to bound the wide projection (#1166)

### Fixed

- **prom:** exp-histogram support on the real OTel-CH exporter schema (#1171)
- **traces:** window-bound every otel_traces scan + memory-bound compare and structural (#1163)

### Changed

- split phase4-traceql into three memory-balanced matrix entries

### CI

- **mutation:** rebalance traceql split into four RE2-safe package-scoped legs (#1178)
- **mutation:** run phase4-traceql at workers=1 to fit the runner budget (#1177)

### Documentation

- rewrite README to be human-first (plain intro, lighter 1.0 disclaimer, progressive depth) (#1162)
- **operations:** recommend ClickHouse 26.6+ for parallel recursive CTEs on structural-join (#1160)

Generated from the conventional commits since the last tag. Review and edit before merging; the tag is cut once this lands.
