### PR TITLE
chore(release): cerberus v1.9.0 / chart 0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to cerberus will be documented in this file. The format roug
 
 ## [v1.9.0] — 2026-07-02
 
+### Fixed
+
+- **chart:** chMaxMemory reaches split heads + int64 all numeric emitters + guard split ingress (#1182)
+
+## [v1.9.0] — 2026-07-02
+
 ### Added
 
 - **traceql:** two-phase structural search to bound the wide projection (#1166)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to cerberus will be documented in this file. The format roug
 
 ## [Unreleased]
 
-## [v1.9.0] — 2026-07-02
+## [chart 0.10.1] — 2026-07-02
 
 ### Fixed
 

--- a/deploy/helm/cerberus/Chart.yaml
+++ b/deploy/helm/cerberus/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # upgrade?" and is the publish trigger: a chart-only fix bumps this without an
 # app re-tag; an app-only release bumps appVersion + a PATCH here for the new
 # default image. Starts 0.x because the values contract is not yet frozen.
-version: 0.10.0
+version: 0.10.1
 
 # appVersion tracks the GA cerberus binary. Quoted so SemVer-shaped values
 # aren't coerced to floats. image.tag defaults from this when left empty.
@@ -49,11 +49,5 @@ annotations:
   # Bump the `1.0.0` floor here when the chart raises its minimum supported
   # cerberus release; informational for Artifact Hub's compatibility hints.
   artifacthub.io/changes: |
-    - kind: added
-      description: "traceql: two-phase structural search to bound the wide projection (#1166)"
     - kind: fixed
-      description: "prom: exp-histogram support on the real OTel-CH exporter schema (#1171)"
-    - kind: fixed
-      description: "traces: window-bound every otel_traces scan + memory-bound compare and structural (#1163)"
-    - kind: changed
-      description: "split phase4-traceql into three memory-balanced matrix entries"
+      description: "chart: chMaxMemory reaches split heads + int64 all numeric emitters + guard split ingress (#1182)"

--- a/deploy/helm/cerberus/README.md
+++ b/deploy/helm/cerberus/README.md
@@ -5,7 +5,7 @@
      pipe-aligned, and the version footer adds a trailing blank — both are
      owned by helm-docs; realigning would fight the chart-ci drift check. -->
 
-![Version: 0.10.0](https://img.shields.io/badge/Version-0.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.9.0](https://img.shields.io/badge/AppVersion-1.9.0-informational?style=flat-square)
+![Version: 0.10.1](https://img.shields.io/badge/Version-0.10.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.9.0](https://img.shields.io/badge/AppVersion-1.9.0-informational?style=flat-square)
 
 Drop-in Prometheus / Loki / Tempo HTTP gateway for ClickHouse — a single stateless gateway that speaks three upstream query wire formats and lowers each to parameterised ClickHouse SQL.
 


### PR DESCRIPTION
Release-prep for **v1.9.0** (chart **0.10.1**), generated by `prepare-release.yml`.

- appVersion 1.9.0 -> 1.9.0, chart 0.10.0 -> 0.10.1

### Changes

### Fixed

- **chart:** chMaxMemory reaches split heads + int64 all numeric emitters + guard split ingress (#1182)

Generated from the conventional commits since the last tag. Review and edit before merging; the tag is cut once this lands.
