### PR TITLE
chore(release): cerberus v1.8.6 / chart 0.9.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to cerberus will be documented in this file. The format roug
 
 ## [Unreleased]
 
+## [v1.8.6] — 2026-07-03
+
+### Fixed
+
+- **chsql:** pass timeSeries*ToGrid family whole-second DateTime, not DateTime64 (#1185/#1187)
+- **schema:** widen proj_metric_metadata with IsMonotonic to keep routing (#1186/#1187)
+
 ## [chart-v0.9.4] — 2026-07-02
 
 Chart-only release (appVersion stays 1.8.5 — no binary/image change).

--- a/deploy/helm/cerberus/Chart.yaml
+++ b/deploy/helm/cerberus/Chart.yaml
@@ -8,11 +8,11 @@ type: application
 # upgrade?" and is the publish trigger: a chart-only fix bumps this without an
 # app re-tag; an app-only release bumps appVersion + a PATCH here for the new
 # default image. Starts 0.x because the values contract is not yet frozen.
-version: 0.9.4
+version: 0.9.5
 
 # appVersion tracks the GA cerberus binary. Quoted so SemVer-shaped values
 # aren't coerced to floats. image.tag defaults from this when left empty.
-appVersion: "1.8.5"
+appVersion: "1.8.6"
 
 # autoscaling/v2 + policy/v1 (PDB) + networking/v1 (Ingress) are all GA from
 # 1.21+; 1.23 is the conservative floor matching the manifests this chart
@@ -45,9 +45,11 @@ annotations:
       url: https://github.com/tsouza/cerberus/blob/main/docs/operations.md
   artifacthub.io/images: |
     - name: cerberus
-      image: ghcr.io/tsouza/cerberus:v1.8.5
+      image: ghcr.io/tsouza/cerberus:v1.8.6
   # Bump the `1.0.0` floor here when the chart raises its minimum supported
   # cerberus release; informational for Artifact Hub's compatibility hints.
   artifacthub.io/changes: |
     - kind: fixed
-      description: "chart: chMaxMemory reaches split heads + int64 all numeric emitters + guard split ingress (#1182) (#1183)"
+      description: "chsql: pass timeSeries*ToGrid family whole-second DateTime, not DateTime64 (#1185/#1187)"
+    - kind: fixed
+      description: "schema: widen proj_metric_metadata with IsMonotonic to keep routing (#1186/#1187)"

--- a/deploy/helm/cerberus/README.md
+++ b/deploy/helm/cerberus/README.md
@@ -5,7 +5,7 @@
      pipe-aligned, and the version footer adds a trailing blank — both are
      owned by helm-docs; realigning would fight the chart-ci drift check. -->
 
-![Version: 0.9.4](https://img.shields.io/badge/Version-0.9.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.5](https://img.shields.io/badge/AppVersion-1.8.5-informational?style=flat-square)
+![Version: 0.9.5](https://img.shields.io/badge/Version-0.9.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.6](https://img.shields.io/badge/AppVersion-1.8.6-informational?style=flat-square)
 
 Drop-in Prometheus / Loki / Tempo HTTP gateway for ClickHouse — a single stateless gateway that speaks three upstream query wire formats and lowers each to parameterised ClickHouse SQL.
 


### PR DESCRIPTION
Version bump for the #1187 backport (ts-grid Decimal overflow fix #1185 + metadata projection routing fix #1186), following the manual maintenance-line release process (`docs/operations.md` → "Maintenance lines (hotfix backports)").

- `appVersion`: 1.8.5 → 1.8.6
- chart `version`: 0.9.4 → 0.9.5 (app bump requires a chart patch for the new default image, per the chart's own version-field doc comment)
- `README.md` regenerated via the pinned `jnorwood/helm-docs:v1.14.2` (matches CI's chart-drift gate)
- `helm lint` + `helm template` both clean

Merging this (once green) triggers `release.yml`'s publish gate for this line: `v1.8.6` + `chart-v0.9.5` tags, images, and chart get published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)