### PR TITLE
docs(autotune): correct stale certify/off-policy language and OOM-population wording

### DIFF
--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -139,8 +139,8 @@ func mountAPIHeads(
 
 		// Self-driving threshold loop: when enabled (default) and the solver is
 		// in auto mode, periodically refit MinFanout / MinAnchorPairs from the
-		// router corpus and hot-swap certified changes into the live Planner. It
-		// runs on the server lifecycle ctx, so it exits on shutdown.
+		// router corpus and hot-swap changes into the live Planner. It runs on
+		// the server lifecycle ctx, so it exits on shutdown.
 		startAutotune(ctx, evalSolver, promClient, cfg, logger)
 	}
 

--- a/docs/solver.md
+++ b/docs/solver.md
@@ -358,11 +358,12 @@ construction, not by statistics**:
 
 - It reads only the observed **route-A OOM floor** over the population the cost
   gate can actually protect: rows where route A OOM'd *after being gated below
-  the thresholds* (`decision_reason = below-threshold`) with a real grid
-  (`fanout > 0 AND n_anchors > 0`), via the narrow `OOMFloorSource` seam. Instant
-  / not-sliceable / high-D route-A OOMs are excluded — they were rejected for
-  eligibility, not by the cost gate, so lowering it cannot help them, and their
-  zero grid would otherwise crater the floor to 0.
+  the thresholds* (`decision_reason = below-threshold`), via the narrow
+  `OOMFloorSource` seam. That predicate excludes the OOMs lowering the gate cannot
+  help — instant / not-sliceable / high-D route-A OOMs were rejected for
+  eligibility, not by the cost gate. An added `fanout > 0 AND n_anchors > 0` guard
+  stops a gridless row (an instant query, recorded with `fanout = 0`) from
+  cratering the floor to 0.
 - It only ever **lowers** a threshold toward that floor, never raises it, and
   applies whatever it computes (no hysteresis) — so the guarantee below holds for
   the **live** gate, not a notional candidate. Because route A and route B are

--- a/internal/autotune/loop.go
+++ b/internal/autotune/loop.go
@@ -1,7 +1,7 @@
 // Package autotune is the solver's self-driving threshold controller. On a fixed
 // cadence it refits the auto-mode cost thresholds (MinFanout, MinAnchorPairs)
-// from the router corpus via routerrules.Autotuner and hot-swaps any certified
-// change into the running solver.Planner.
+// from the router corpus via routerrules.Autotuner and hot-swaps any change into
+// the running solver.Planner.
 //
 // It is the composition of the corpus-fit "brain" (routerrules) with the policy
 // half (solver): it depends on both and is imported by nothing but cmd/, which
@@ -22,8 +22,8 @@ import (
 	"github.com/tsouza/cerberus/internal/solver"
 )
 
-// Loop drives periodic corpus-fit → certify → hot-reload of the Planner's
-// auto-mode thresholds.
+// Loop drives periodic corpus-fit → hot-reload of the Planner's auto-mode
+// thresholds.
 type Loop struct {
 	planner  *solver.Planner
 	newTuner func() *routerrules.Autotuner

--- a/internal/routerrules/source.go
+++ b/internal/routerrules/source.go
@@ -63,14 +63,14 @@ type RuleQuery struct {
 }
 
 // OOMFloor is the observed route-A OOM cost floor: the minimum fan-out and
-// minimum anchor count over the eligible, grid-bearing corpus population that
-// the cost gate can actually protect — route-A queries that OOM'd AFTER being
-// gated below the cost thresholds (decision_reason = below-threshold), with a
-// real grid (fanout > 0 AND n_anchors > 0). Instant / not-sliceable / high-D
-// route-A OOMs are excluded: they were rejected for eligibility, not by the cost
-// gate, so lowering the gate cannot move them to route B, and their zero grid
-// would otherwise crater the min to 0. HasSignal is false when that population
-// is empty (cold start).
+// minimum anchor count over the eligible corpus population the cost gate can
+// actually protect — route-A queries that OOM'd AFTER being gated below the cost
+// thresholds (decision_reason = below-threshold). That predicate excludes the
+// OOMs lowering the gate cannot move to route B (instant / not-sliceable / high-D
+// were rejected for eligibility, not by the cost gate). The additional
+// fanout > 0 AND n_anchors > 0 predicate is a guard against a gridless row
+// (e.g. an instant query, recorded with fanout = 0) slipping in and cratering
+// the min to 0. HasSignal is false when that population is empty (cold start).
 type OOMFloor struct {
 	MinFanout  int
 	MinAnchors int

--- a/internal/solver/config.go
+++ b/internal/solver/config.go
@@ -93,11 +93,12 @@ type Config struct {
 	// Autotune enables the self-driving threshold loop
 	// (CERBERUS_SOLVER_AUTOTUNE, default true). When true AND Mode == ModeAuto,
 	// a background loop periodically refits MinFanout / MinAnchorPairs from the
-	// router corpus, certifies the candidate off-policy against the OOM floor,
-	// and hot-reloads it into the Planner (Planner.SetThresholds). Disabled pins
-	// the thresholds at their configured values — byte-identical to a
-	// fixed-threshold build. It has no effect outside ModeAuto: single and
-	// sharded carry no cost gate to tune.
+	// router corpus toward the observed route-A OOM floor — only ever lowering
+	// them — and hot-reloads the result into the Planner (Planner.SetThresholds).
+	// Disabled pins the thresholds at their configured values — byte-identical to
+	// a fixed-threshold build. It has no effect outside ModeAuto (single and
+	// sharded carry no cost gate to tune), and stays dormant until the router
+	// corpus CH table is being written (see startAutotune in cmd/).
 	Autotune bool
 
 	// AutotuneInterval is the cadence of the self-driving loop

--- a/internal/solver/planner.go
+++ b/internal/solver/planner.go
@@ -42,8 +42,7 @@ func (p *Planner) thresholds() (minFanout, minAnchorPairs int) {
 }
 
 // SetThresholds atomically hot-swaps the auto-gate thresholds. Called only by
-// the autotune loop after it certifies a candidate; safe to call concurrently
-// with Plan.
+// the autotune loop after a fit; safe to call concurrently with Plan.
 func (p *Planner) SetThresholds(minFanout, minAnchorPairs int) {
 	p.tuned.Store(&tunedThresholds{MinFanout: minFanout, MinAnchorPairs: minAnchorPairs})
 }


### PR DESCRIPTION
Post-merge comment/doc audit of the autotune feature (#1190). **No logic change** — comments and docs only.

- The OPE off-policy **certification** pass was replaced by the structural clamp during review, but "certify" / "certified" / "certifies the candidate off-policy" survived in `loop.go`, `config.go`, `planner.go`, and `main.go`. The fit just computes and applies; safety is structural. Dropped the certification framing.
- `OOMFloor` doc (`source.go`) and `solver.md` Stage-1 described instant / not-sliceable / high-D OOMs as excluded by "their zero grid" — only instant is gridless. Clarified: the `decision_reason=below-threshold` predicate excludes them (rejected for eligibility, not by the cost gate); `fanout>0` is the separate guard against a gridless row cratering the min.
- Noted the corpus-availability dormancy in the `Config.Autotune` field doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)