### PR TITLE
feat(autotune): expose loop state via /info/autotune + per-pod metrics

### DIFF
--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -94,6 +94,11 @@ func newAdmitLimiters(cfg config.Config, logger *slog.Logger) (*admit.Limiter, *
 // skips the gRPC branch and shutdown skips GracefulStop).
 type apiHeads struct {
 	grpcServer *grpc.Server
+	// autotuneReporter exposes the self-driving solver's live decision state to
+	// the /info/autotune handler. Non-nil only when the prom head (hence the
+	// solver) is built; it reports "disabled"/"dormant" when the loop isn't
+	// running.
+	autotuneReporter *autotune.Reporter
 }
 
 // mountAPIHeads builds and mounts ONLY the query heads enabled by
@@ -123,6 +128,10 @@ func mountAPIHeads(
 	// observes only live heads (a disabled head has no engine to observe).
 	var engines []*engine.Engine
 
+	// autotuneReporter is populated when the prom head builds the solver; it
+	// backs GET /info/autotune. Nil when prom (and thus the solver) is disabled.
+	var autotuneReporter *autotune.Reporter
+
 	if cfg.HeadEnabled(config.HeadProm) {
 		// Per-head Client VIEW (#94): own breaker over the shared pool. Built
 		// only for the prom head — and the prom-only sharded-pushdown solver is
@@ -140,8 +149,9 @@ func mountAPIHeads(
 		// Self-driving threshold loop: when enabled (default) and the solver is
 		// in auto mode, periodically refit MinFanout / MinAnchorPairs from the
 		// router corpus and hot-swap changes into the live Planner. It runs on
-		// the server lifecycle ctx, so it exits on shutdown.
-		startAutotune(ctx, evalSolver, promClient, cfg, logger)
+		// the server lifecycle ctx, so it exits on shutdown. The returned reporter
+		// backs GET /info/autotune (populated even when the loop stays dormant).
+		autotuneReporter = startAutotune(ctx, evalSolver, promClient, cfg, logger)
 	}
 
 	if cfg.HeadEnabled(config.HeadLoki) {
@@ -176,7 +186,7 @@ func mountAPIHeads(
 	// hot path).
 	startOptCorpus(ctx, logger, client, cfg, engines...)
 
-	return apiHeads{grpcServer: grpcServer}, nil
+	return apiHeads{grpcServer: grpcServer, autotuneReporter: autotuneReporter}, nil
 }
 
 // enabledHeadNames returns the enabled heads in the canonical prom,loki,tempo
@@ -415,7 +425,7 @@ func run() error {
 	// readiness probe uses for its live reachability/breaker fields, and
 	// reuses the /readyz readiness condition for "ready". Like the health
 	// probes it bypasses otelhttp (low-frequency metadata scrape, no spans).
-	infoHandler := info.New(infoOptions(client, cfg, optRes, schemaReady, schemaPresent, startTime))
+	infoHandler := info.New(infoOptions(client, cfg, optRes, schemaReady, schemaPresent, startTime, heads.autotuneReporter))
 
 	rootMux := http.NewServeMux()
 	healthHandler.Mount(rootMux)
@@ -599,6 +609,7 @@ func infoOptions(
 	schemaReady health.SchemaReadyFunc,
 	schemaPresent health.SchemaPresentFunc,
 	startTime time.Time,
+	autotuneReporter *autotune.Reporter,
 ) info.Options {
 	probe := client.ForHead(chclient.HeadProbe)
 
@@ -640,6 +651,12 @@ func infoOptions(
 		SchemaReady: schemaReadyNow,
 		Ready: func(ctx context.Context) bool {
 			return probe.Ping(ctx) == nil && schemaPresentNow() && schemaReadyNow()
+		},
+		Autotune: func() (info.AutotuneStatus, bool) {
+			if autotuneReporter == nil {
+				return info.AutotuneStatus{}, false
+			}
+			return mapAutotuneStatus(autotuneReporter.Snapshot()), true
 		},
 	}
 }
@@ -969,10 +986,25 @@ const autotuneCorpusWindow = 7 * 24 * time.Hour
 // (default) and the solver is in auto mode — single / sharded carry no cost gate
 // to tune, so it no-ops there, and a fixed-threshold deployment
 // (CERBERUS_SOLVER_AUTOTUNE=false) pays nothing. The loop goroutine runs on the
-// server lifecycle ctx and exits when ctx is cancelled at shutdown.
-func startAutotune(ctx context.Context, s *solver.Solver, client *chclient.Client, cfg config.Config, logger *slog.Logger) {
+// server lifecycle ctx and exits when ctx is cancelled at shutdown. It always
+// returns a Reporter (backing GET /info/autotune) describing the state, even
+// when the loop stays dormant.
+func startAutotune(ctx context.Context, s *solver.Solver, client *chclient.Client, cfg config.Config, logger *slog.Logger) *autotune.Reporter {
+	configured := routerrules.Thresholds{MinFanout: s.Cfg.MinFanout, MinAnchorPairs: s.Cfg.MinAnchorPairs}
+	base := autotune.Status{
+		Enabled:             s.Cfg.Autotune,
+		Configured:          configured,
+		Live:                configured,
+		IntervalSeconds:     s.Cfg.AutotuneInterval.Seconds(),
+		CorpusWindowSeconds: autotuneCorpusWindow.Seconds(),
+	}
+
 	if !s.Cfg.Autotune || s.Cfg.Mode != solver.ModeAuto {
-		return
+		base.Reason = autotune.ReasonStatusDisabled
+		if s.Cfg.Autotune {
+			base.Reason = autotune.ReasonStatusNotAutoMode
+		}
+		return autotune.NewReporter(base)
 	}
 	// The fit reads the cerberus_router_corpus MergeTree, which is written ONLY
 	// when the query-log corpus reconciler runs with the chtable sink. Without it
@@ -986,8 +1018,13 @@ func startAutotune(ctx context.Context, s *solver.Solver, client *chclient.Clien
 			"corpus_enabled", cfg.CHOptCorpus.Enabled,
 			"corpus_sink_mode", cfg.CHOptCorpus.SinkMode,
 		)
-		return
+		base.Reason = autotune.ReasonStatusCorpusUnavailable
+		return autotune.NewReporter(base)
 	}
+
+	base.Active = true
+	base.Reason = autotune.ReasonStatusActive
+	reporter := autotune.NewReporter(base)
 
 	// Rebuild the source per tick with a freshly-computed window lower bound, so
 	// the fit reads a ROLLING window (recent data) rather than a window frozen at
@@ -997,7 +1034,7 @@ func startAutotune(ctx context.Context, s *solver.Solver, client *chclient.Clien
 		sinceUnix := float64(time.Now().Add(-autotuneCorpusWindow).Unix())
 		return routerrules.NewAutotuner(routerrules.NewCHOOMFloorSource(conn, sinceUnix))
 	}
-	loop := autotune.New(s.Planner, newTuner, s.Cfg.AutotuneInterval, logger.With("component", "autotune"))
+	loop := autotune.New(s.Planner, newTuner, s.Cfg.AutotuneInterval, logger.With("component", "autotune"), reporter)
 	go loop.Run(ctx)
 	logger.Info(
 		"solver autotune loop started",
@@ -1006,6 +1043,35 @@ func startAutotune(ctx context.Context, s *solver.Solver, client *chclient.Clien
 		"min_fanout", s.Cfg.MinFanout,
 		"min_anchor_pairs", s.Cfg.MinAnchorPairs,
 	)
+	return reporter
+}
+
+// mapAutotuneStatus projects the autotune snapshot into the info-layer JSON
+// shape, keeping the info package decoupled from the solver stack.
+func mapAutotuneStatus(s autotune.Status) info.AutotuneStatus {
+	out := info.AutotuneStatus{
+		Enabled:             s.Enabled,
+		Active:              s.Active,
+		Reason:              s.Reason,
+		IntervalSeconds:     s.IntervalSeconds,
+		CorpusWindowSeconds: s.CorpusWindowSeconds,
+		Configured:          info.ThresholdInfo{MinFanout: s.Configured.MinFanout, MinAnchorPairs: s.Configured.MinAnchorPairs},
+		Live:                info.ThresholdInfo{MinFanout: s.Live.MinFanout, MinAnchorPairs: s.Live.MinAnchorPairs},
+		Ticks:               s.Ticks,
+	}
+	if s.LastFit != nil {
+		out.LastFit = &info.AutotuneFit{
+			At:            s.LastFit.At.UTC().Format(time.RFC3339),
+			Reason:        s.LastFit.Reason,
+			Changed:       s.LastFit.Changed,
+			HasOOMSignal:  s.LastFit.HasOOMSignal,
+			OOMMinFanout:  s.LastFit.OOMMinFanout,
+			OOMMinAnchors: s.LastFit.OOMMinAnchors,
+			Candidate:     info.ThresholdInfo{MinFanout: s.LastFit.Candidate.MinFanout, MinAnchorPairs: s.LastFit.Candidate.MinAnchorPairs},
+			Error:         s.LastFit.Error,
+		}
+	}
+	return out
 }
 
 // warnIfClickHouseUnreachable performs the best-effort startup

--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -152,6 +152,9 @@ func mountAPIHeads(
 		// the server lifecycle ctx, so it exits on shutdown. The returned reporter
 		// backs GET /info/autotune (populated even when the loop stays dormant).
 		autotuneReporter = startAutotune(ctx, evalSolver, promClient, cfg, logger)
+		if err := autotune.RegisterMetrics(autotuneReporter); err != nil {
+			logger.Warn("autotune metrics registration failed; /info/autotune still serves this pod", "err", err)
+		}
 	}
 
 	if cfg.HeadEnabled(config.HeadLoki) {
@@ -1057,19 +1060,31 @@ func mapAutotuneStatus(s autotune.Status) info.AutotuneStatus {
 		CorpusWindowSeconds: s.CorpusWindowSeconds,
 		Configured:          info.ThresholdInfo{MinFanout: s.Configured.MinFanout, MinAnchorPairs: s.Configured.MinAnchorPairs},
 		Live:                info.ThresholdInfo{MinFanout: s.Live.MinFanout, MinAnchorPairs: s.Live.MinAnchorPairs},
-		Ticks:               s.Ticks,
+		Stats: info.AutotuneStats{
+			Ticks:            s.Stats.Ticks,
+			SignalTicks:      s.Stats.SignalTicks,
+			AppliedTicks:     s.Stats.AppliedTicks,
+			ErrorTicks:       s.Stats.ErrorTicks,
+			TicksSinceChange: s.Stats.TicksSinceChange,
+			LastError:        s.Stats.LastError,
+		},
+		Outcome: info.AutotuneOutcome{
+			HasSignal:        s.Outcome.HasSignal,
+			OOMMinFanout:     s.Outcome.OOMMinFanout,
+			OOMMinAnchors:    s.Outcome.OOMMinAnchors,
+			RouteAOoms:       s.Outcome.RouteAOomCount,
+			RouteBExecutions: s.Outcome.RouteBExecutions,
+			RouteBOoms:       s.Outcome.RouteBOomCount,
+		},
 	}
-	if s.LastFit != nil {
-		out.LastFit = &info.AutotuneFit{
-			At:            s.LastFit.At.UTC().Format(time.RFC3339),
-			Reason:        s.LastFit.Reason,
-			Changed:       s.LastFit.Changed,
-			HasOOMSignal:  s.LastFit.HasOOMSignal,
-			OOMMinFanout:  s.LastFit.OOMMinFanout,
-			OOMMinAnchors: s.LastFit.OOMMinAnchors,
-			Candidate:     info.ThresholdInfo{MinFanout: s.LastFit.Candidate.MinFanout, MinAnchorPairs: s.LastFit.Candidate.MinAnchorPairs},
-			Error:         s.LastFit.Error,
-		}
+	if !s.Stats.LastChangeAt.IsZero() {
+		out.Stats.LastChangeAt = s.Stats.LastChangeAt.UTC().Format(time.RFC3339)
+	}
+	if !s.Stats.LastErrorAt.IsZero() {
+		out.Stats.LastErrorAt = s.Stats.LastErrorAt.UTC().Format(time.RFC3339)
+	}
+	if !s.Outcome.At.IsZero() {
+		out.Outcome.At = s.Outcome.At.UTC().Format(time.RFC3339)
 	}
 	return out
 }

--- a/docs/health.md
+++ b/docs/health.md
@@ -163,6 +163,57 @@ Live fields, re-read on every request:
 - `ready` — the same condition `/readyz` uses (CH reachable AND schema
   present AND schema ready).
 
+## `/info/autotune` — self-driving solver state
+
+```text
+GET /info/autotune
+200 OK
+Content-Type: application/json
+
+{
+  "enabled": true,
+  "active": true,
+  "reason": "active",
+  "intervalSeconds": 900,
+  "corpusWindowSeconds": 604800,
+  "configured": { "minFanout": 16, "minAnchorPairs": 4000 },
+  "live":       { "minFanout": 8,  "minAnchorPairs": 1928 },
+  "ticks": 3,
+  "lastFit": {
+    "at": "2026-07-04T05:31:00Z",
+    "reason": "autotune-applied",
+    "changed": true,
+    "hasOomSignal": true,
+    "oomMinFanout": 8,
+    "oomMinAnchors": 241,
+    "candidate": { "minFanout": 8, "minAnchorPairs": 1928 },
+    "error": ""
+  }
+}
+```
+
+The live decision state of the [self-driving autotune loop](solver.md#stage-1--self-driving-thresholds-the-autotune-loop).
+Like `/info`, it is unauthenticated, read-only, and bypasses otelhttp; it is
+served from an in-memory snapshot the loop refreshes each tick (no ClickHouse
+read on the request path).
+
+- `enabled` — the `CERBERUS_SOLVER_AUTOTUNE` toggle.
+- `active` — whether the loop is actually running: enabled **and** auto mode
+  **and** the router-corpus CH table is being written.
+- `reason` — explains `active`: `"active"` | `"disabled"` |
+  `"not-auto-mode"` | `"corpus-unavailable"`.
+- `configured` — the gate the deployment shipped with (`CERBERUS_SHARD_MIN_FANOUT`
+  / `CERBERUS_SHARD_MIN_ANCHOR_PAIRS`).
+- `live` — the gate the Planner is routing with right now; equal to `configured`
+  until the loop lowers it.
+- `ticks` — completed fit cycles.
+- `lastFit` — the most recent fit (absent until the first tick): the observed
+  route-A OOM floor (`oomMinFanout` / `oomMinAnchors`), the `candidate` it
+  produced, whether it `changed` the live gate, and any `error` from that tick.
+
+Returns `404` when autotune introspection is not wired (the prom head, hence the
+solver, is disabled).
+
 ## Kubernetes probe configuration
 
 The shipped `test/e2e/k3s/cerberus-values.yaml` wires the probes as follows:

--- a/docs/health.md
+++ b/docs/health.md
@@ -178,41 +178,73 @@ Content-Type: application/json
   "corpusWindowSeconds": 604800,
   "configured": { "minFanout": 16, "minAnchorPairs": 4000 },
   "live":       { "minFanout": 8,  "minAnchorPairs": 1928 },
-  "ticks": 3,
-  "lastFit": {
-    "at": "2026-07-04T05:31:00Z",
-    "reason": "autotune-applied",
-    "changed": true,
-    "hasOomSignal": true,
+  "stats": {
+    "ticks": 42,
+    "signalTicks": 40,
+    "appliedTicks": 3,
+    "errorTicks": 0,
+    "ticksSinceChange": 12,
+    "lastChangeAt": "2026-07-04T05:31:00Z",
+    "lastError": ""
+  },
+  "outcome": {
+    "at": "2026-07-04T05:46:00Z",
+    "hasSignal": true,
     "oomMinFanout": 8,
     "oomMinAnchors": 241,
-    "candidate": { "minFanout": 8, "minAnchorPairs": 1928 },
-    "error": ""
+    "routeAOoms": 2,
+    "routeBExecutions": 1500,
+    "routeBOoms": 0
   }
 }
 ```
 
-The live decision state of the [self-driving autotune loop](solver.md#stage-1--self-driving-thresholds-the-autotune-loop).
+**This pod's** live decision state of the
+[self-driving autotune loop](solver.md#stage-1--self-driving-thresholds-the-autotune-loop).
 Like `/info`, it is unauthenticated, read-only, and bypasses otelhttp; it is
 served from an in-memory snapshot the loop refreshes each tick (no ClickHouse
-read on the request path).
+read on the request path). For the **fleet-wide + historical** view, see the
+metrics below — each pod also emits these as OTel gauges.
 
-- `enabled` — the `CERBERUS_SOLVER_AUTOTUNE` toggle.
-- `active` — whether the loop is actually running: enabled **and** auto mode
-  **and** the router-corpus CH table is being written.
-- `reason` — explains `active`: `"active"` | `"disabled"` |
-  `"not-auto-mode"` | `"corpus-unavailable"`.
-- `configured` — the gate the deployment shipped with (`CERBERUS_SHARD_MIN_FANOUT`
-  / `CERBERUS_SHARD_MIN_ANCHOR_PAIRS`).
-- `live` — the gate the Planner is routing with right now; equal to `configured`
-  until the loop lowers it.
-- `ticks` — completed fit cycles.
-- `lastFit` — the most recent fit (absent until the first tick): the observed
-  route-A OOM floor (`oomMinFanout` / `oomMinAnchors`), the `candidate` it
-  produced, whether it `changed` the live gate, and any `error` from that tick.
+- `enabled` / `active` / `reason` — is the loop running here, and why
+  (`"active"` | `"disabled"` | `"not-auto-mode"` | `"corpus-unavailable"`).
+- `configured` vs `live` — the shipped gate vs what the Planner routes with now;
+  the delta is exactly what the loop has done.
+- `stats` — this pod's loop health: `ticks`, `signalTicks`, `appliedTicks`
+  (gate lowerings), `errorTicks`, and `ticksSinceChange` (high = converged).
+- `outcome` — the rolling-window efficacy signal from the corpus (identical
+  across pods, since the corpus is shared). **Good:** `routeBOoms` is 0 (the safe
+  path isn't itself OOMing) and `routeAOoms` trends to 0 with `routeBExecutions`
+  > 0 (unprotected OOMs eliminated, volume protected). **Bad:** `routeBOoms` > 0,
+  or `routeAOoms` persistently high.
 
 Returns `404` when autotune introspection is not wired (the prom head, hence the
 solver, is disabled).
+
+### Fleet + historical view (metrics)
+
+Because cerberus runs multiple pods each with its own loop, the fleet-wide and
+historical view comes from metrics, not this per-pod endpoint. Every prom-head
+pod emits its autotune state as OTel observable gauges (via the standard OTLP →
+CH pipeline), stamped per-pod by `service.instance.id`:
+
+| Metric                                                      | Meaning                                 |
+| ----------------------------------------------------------- | --------------------------------------- |
+| `cerberus_solver_autotune_active`                           | 1 when the loop is running on the pod   |
+| `cerberus_solver_autotune_min_fanout` / `_min_anchor_pairs` | live gate                               |
+| `cerberus_solver_autotune_configured_min_fanout`            | shipped gate (for the delta)            |
+| `cerberus_solver_autotune_applied_total` / `_errors_total`  | per-pod tick counters                   |
+| `cerberus_solver_autotune_route_a_ooms`                     | remaining unprotected OOMs (→ 0 = good) |
+| `cerberus_solver_autotune_route_b_executions`               | volume routed to the safe path          |
+| `cerberus_solver_autotune_route_b_ooms`                     | route-B OOMs — should stay 0            |
+| `cerberus_solver_autotune_oom_min_fanout`                   | observed OOM floor being tracked        |
+
+Aggregate the **corpus-derived** series (`route_*`, `oom_min_fanout`, live gates)
+with `max`/`avg`, never `sum` — every pod reports the same shared-corpus value,
+so summing multiplies by pod count. The **per-pod** counters (`applied_total`,
+`errors_total`) may be summed or shown per `instance`. Autotune is prom-head
+scoped, so any pod emitting these also serves PromQL — the metrics are queryable
+wherever the loop runs.
 
 ## Kubernetes probe configuration
 

--- a/docs/solver.md
+++ b/docs/solver.md
@@ -351,7 +351,9 @@ the loop no-ops there; disabling it pins the thresholds at their configured
 values, byte-identical to a fixed-threshold build. The fit reads the
 `cerberus_router_corpus` MergeTree, so the loop stays **dormant** until the
 Stage-0 reconciler is writing that table (`CERBERUS_CH_OPT_CORPUS_ENABLED=true`
-with the `chtable` sink) rather than erroring against a missing table.
+with the `chtable` sink) rather than erroring against a missing table. Its live
+decision state — configured vs. live thresholds, the last fit, tick count — is
+exposed at [`GET /info/autotune`](health.md#infoautotune--self-driving-solver-state).
 
 The fit (`routerrules.Autotuner.Fit`) is deliberately narrow and **safe by
 construction, not by statistics**:

--- a/internal/api/info/autotune.go
+++ b/internal/api/info/autotune.go
@@ -22,14 +22,15 @@ type AutotuneStatus struct {
 	CorpusWindowSeconds float64 `json:"corpusWindowSeconds,omitempty"`
 
 	// Configured is the shipped gate; Live is what the Planner routes with right
-	// now (equal to Configured until the loop lowers it).
+	// now (equal to Configured until the loop lowers it). The delta shows exactly
+	// what the loop has done.
 	Configured ThresholdInfo `json:"configured"`
 	Live       ThresholdInfo `json:"live"`
 
-	// Ticks counts completed fit cycles; LastFit is the most recent one (absent
-	// until the first tick).
-	Ticks   int64        `json:"ticks"`
-	LastFit *AutotuneFit `json:"lastFit,omitempty"`
+	// Stats aggregates the loop's own behavior (process health); Outcome is the
+	// rolling-window efficacy signal from the corpus.
+	Stats   AutotuneStats   `json:"stats"`
+	Outcome AutotuneOutcome `json:"outcome"`
 }
 
 // ThresholdInfo is one (MinFanout, MinAnchorPairs) auto-gate pair.
@@ -38,16 +39,32 @@ type ThresholdInfo struct {
 	MinAnchorPairs int `json:"minAnchorPairs"`
 }
 
-// AutotuneFit is the outcome of one fit cycle.
-type AutotuneFit struct {
-	At            string        `json:"at"` // RFC 3339
-	Reason        string        `json:"reason"`
-	Changed       bool          `json:"changed"`
-	HasOOMSignal  bool          `json:"hasOomSignal"`
-	OOMMinFanout  int           `json:"oomMinFanout"`
-	OOMMinAnchors int           `json:"oomMinAnchors"`
-	Candidate     ThresholdInfo `json:"candidate"`
-	Error         string        `json:"error,omitempty"`
+// AutotuneStats aggregates the loop's behavior across ticks. Convergence reads as
+// a high ticksSinceChange with a small, stable appliedTicks; trouble reads as
+// climbing errorTicks, or signalTicks == 0 while route-A OOMs persist.
+type AutotuneStats struct {
+	Ticks            int64  `json:"ticks"`
+	SignalTicks      int64  `json:"signalTicks"`
+	AppliedTicks     int64  `json:"appliedTicks"`
+	ErrorTicks       int64  `json:"errorTicks"`
+	TicksSinceChange int64  `json:"ticksSinceChange"`
+	LastChangeAt     string `json:"lastChangeAt,omitempty"` // RFC 3339
+	LastError        string `json:"lastError,omitempty"`
+	LastErrorAt      string `json:"lastErrorAt,omitempty"` // RFC 3339
+}
+
+// AutotuneOutcome is the rolling-window efficacy signal (over corpusWindowSeconds).
+// Good: routeBOoms == 0 (the safe path isn't itself OOMing), routeAOoms trending
+// to 0 (unprotected OOMs eliminated) with routeBExecutions > 0 (volume protected).
+// Bad: routeBOoms > 0, or routeAOoms persistently high.
+type AutotuneOutcome struct {
+	At               string `json:"at,omitempty"` // RFC 3339, most recent tick
+	HasSignal        bool   `json:"hasSignal"`
+	OOMMinFanout     int    `json:"oomMinFanout"`
+	OOMMinAnchors    int    `json:"oomMinAnchors"`
+	RouteAOoms       int64  `json:"routeAOoms"`
+	RouteBExecutions int64  `json:"routeBExecutions"`
+	RouteBOoms       int64  `json:"routeBOoms"`
 }
 
 // handleAutotune serves GET /info/autotune. It is unauthenticated and read-only,

--- a/internal/api/info/autotune.go
+++ b/internal/api/info/autotune.go
@@ -1,0 +1,68 @@
+package info
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// AutotuneStatus is the JSON body of GET /info/autotune: the self-driving
+// solver's live decision state. It is defined here (rather than imported from
+// internal/autotune) so the info layer stays decoupled from the solver stack;
+// cmd/ maps the autotune snapshot into this shape.
+type AutotuneStatus struct {
+	// Enabled reflects the CERBERUS_SOLVER_AUTOTUNE toggle. Active is true only
+	// when the loop is actually running (enabled AND auto mode AND the corpus CH
+	// table is available). Reason explains Active: "active" | "disabled" |
+	// "not-auto-mode" | "corpus-unavailable".
+	Enabled bool   `json:"enabled"`
+	Active  bool   `json:"active"`
+	Reason  string `json:"reason"`
+
+	IntervalSeconds     float64 `json:"intervalSeconds,omitempty"`
+	CorpusWindowSeconds float64 `json:"corpusWindowSeconds,omitempty"`
+
+	// Configured is the shipped gate; Live is what the Planner routes with right
+	// now (equal to Configured until the loop lowers it).
+	Configured ThresholdInfo `json:"configured"`
+	Live       ThresholdInfo `json:"live"`
+
+	// Ticks counts completed fit cycles; LastFit is the most recent one (absent
+	// until the first tick).
+	Ticks   int64        `json:"ticks"`
+	LastFit *AutotuneFit `json:"lastFit,omitempty"`
+}
+
+// ThresholdInfo is one (MinFanout, MinAnchorPairs) auto-gate pair.
+type ThresholdInfo struct {
+	MinFanout      int `json:"minFanout"`
+	MinAnchorPairs int `json:"minAnchorPairs"`
+}
+
+// AutotuneFit is the outcome of one fit cycle.
+type AutotuneFit struct {
+	At            string        `json:"at"` // RFC 3339
+	Reason        string        `json:"reason"`
+	Changed       bool          `json:"changed"`
+	HasOOMSignal  bool          `json:"hasOomSignal"`
+	OOMMinFanout  int           `json:"oomMinFanout"`
+	OOMMinAnchors int           `json:"oomMinAnchors"`
+	Candidate     ThresholdInfo `json:"candidate"`
+	Error         string        `json:"error,omitempty"`
+}
+
+// handleAutotune serves GET /info/autotune. It is unauthenticated and read-only,
+// like GET /info. When autotune introspection is not wired (nil func) or reports
+// unavailable, it returns 404.
+func (h *Handler) handleAutotune(w http.ResponseWriter, _ *http.Request) {
+	if h.autotune == nil {
+		http.Error(w, "autotune introspection not configured", http.StatusNotFound)
+		return
+	}
+	st, ok := h.autotune()
+	if !ok {
+		http.Error(w, "autotune introspection unavailable", http.StatusNotFound)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(st)
+}

--- a/internal/api/info/autotune_test.go
+++ b/internal/api/info/autotune_test.go
@@ -23,8 +23,8 @@ func TestHandleAutotune_ServesStatus(t *testing.T) {
 		Reason:     "active",
 		Configured: ThresholdInfo{MinFanout: 16, MinAnchorPairs: 4000},
 		Live:       ThresholdInfo{MinFanout: 8, MinAnchorPairs: 1928},
-		Ticks:      3,
-		LastFit:    &AutotuneFit{Reason: "autotune-applied", Changed: true, HasOOMSignal: true, OOMMinFanout: 8},
+		Stats:      AutotuneStats{Ticks: 3, AppliedTicks: 1, TicksSinceChange: 2},
+		Outcome:    AutotuneOutcome{HasSignal: true, OOMMinFanout: 8, RouteAOoms: 2, RouteBExecutions: 1500, RouteBOoms: 0},
 	}
 	rec := getAutotune(t, Options{Autotune: func() (AutotuneStatus, bool) { return want, true }})
 
@@ -38,11 +38,14 @@ func TestHandleAutotune_ServesStatus(t *testing.T) {
 	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if !got.Active || got.Reason != "active" || got.Live.MinFanout != 8 || got.Ticks != 3 {
-		t.Errorf("got %+v", got)
+	if !got.Active || got.Reason != "active" || got.Live.MinFanout != 8 {
+		t.Errorf("status: got %+v", got)
 	}
-	if got.LastFit == nil || got.LastFit.OOMMinFanout != 8 {
-		t.Errorf("LastFit = %+v", got.LastFit)
+	if got.Stats.Ticks != 3 || got.Stats.AppliedTicks != 1 {
+		t.Errorf("stats: got %+v", got.Stats)
+	}
+	if !got.Outcome.HasSignal || got.Outcome.RouteBExecutions != 1500 || got.Outcome.RouteBOoms != 0 {
+		t.Errorf("outcome: got %+v", got.Outcome)
 	}
 }
 

--- a/internal/api/info/autotune_test.go
+++ b/internal/api/info/autotune_test.go
@@ -1,0 +1,63 @@
+package info
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func getAutotune(t *testing.T, opts Options) *httptest.ResponseRecorder {
+	t.Helper()
+	mux := http.NewServeMux()
+	New(opts).Mount(mux)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/info/autotune", nil))
+	return rec
+}
+
+func TestHandleAutotune_ServesStatus(t *testing.T) {
+	want := AutotuneStatus{
+		Enabled:    true,
+		Active:     true,
+		Reason:     "active",
+		Configured: ThresholdInfo{MinFanout: 16, MinAnchorPairs: 4000},
+		Live:       ThresholdInfo{MinFanout: 8, MinAnchorPairs: 1928},
+		Ticks:      3,
+		LastFit:    &AutotuneFit{Reason: "autotune-applied", Changed: true, HasOOMSignal: true, OOMMinFanout: 8},
+	}
+	rec := getAutotune(t, Options{Autotune: func() (AutotuneStatus, bool) { return want, true }})
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+	var got AutotuneStatus
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !got.Active || got.Reason != "active" || got.Live.MinFanout != 8 || got.Ticks != 3 {
+		t.Errorf("got %+v", got)
+	}
+	if got.LastFit == nil || got.LastFit.OOMMinFanout != 8 {
+		t.Errorf("LastFit = %+v", got.LastFit)
+	}
+}
+
+func TestHandleAutotune_NotConfigured(t *testing.T) {
+	// No Autotune func wired → 404.
+	rec := getAutotune(t, Options{})
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestHandleAutotune_Unavailable(t *testing.T) {
+	// Func present but reports unavailable → 404.
+	rec := getAutotune(t, Options{Autotune: func() (AutotuneStatus, bool) { return AutotuneStatus{}, false }})
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}

--- a/internal/api/info/info.go
+++ b/internal/api/info/info.go
@@ -103,6 +103,11 @@ type Options struct {
 	// compute uptimeSeconds. When zero, uptime is reported as 0.
 	StartTime time.Time
 
+	// Autotune reports the self-driving solver's live decision state for
+	// GET /info/autotune. The bool is false when autotune introspection is not
+	// available; when nil, GET /info/autotune returns 404.
+	Autotune func() (AutotuneStatus, bool)
+
 	// PingTimeout caps the per-request reachability/ready probes. Defaults to
 	// 1s, matching the health handler's ping budget.
 	PingTimeout time.Duration
@@ -117,6 +122,7 @@ type Handler struct {
 	ready       func(ctx context.Context) bool
 	start       time.Time
 	pingTimeout time.Duration
+	autotune    func() (AutotuneStatus, bool)
 }
 
 // defaultPingTimeout bounds the live reachability/ready probes per request.
@@ -134,6 +140,7 @@ func New(opts Options) *Handler {
 		ready:       opts.Ready,
 		start:       opts.StartTime,
 		pingTimeout: opts.PingTimeout,
+		autotune:    opts.Autotune,
 	}
 	if h.pingTimeout <= 0 {
 		h.pingTimeout = defaultPingTimeout
@@ -141,9 +148,10 @@ func New(opts Options) *Handler {
 	return h
 }
 
-// Mount registers GET /info on mux.
+// Mount registers GET /info and GET /info/autotune on mux.
 func (h *Handler) Mount(mux *http.ServeMux) {
 	mux.HandleFunc("GET /info", h.handleInfo)
+	mux.HandleFunc("GET /info/autotune", h.handleAutotune)
 }
 
 // clickHouseInfo is the nested "clickhouse" object of the /info body.

--- a/internal/autotune/loop.go
+++ b/internal/autotune/loop.go
@@ -107,30 +107,49 @@ func (l *Loop) tick(ctx context.Context) {
 
 // report updates the introspection Status after a tick, preserving the static
 // fields main/ seeded (enabled, reason, interval, window, configured) and
-// refreshing the dynamic ones (live thresholds, tick count, last fit). The loop
-// goroutine is the only writer after seeding, so the read-modify-write is safe.
+// refreshing the aggregate Stats + Outcome. The loop goroutine is the only writer
+// after seeding, so the read-modify-write is safe.
 func (l *Loop) report(res *routerrules.FitResult, fitErr error) {
 	if l.reporter == nil {
 		return
 	}
 	liveFanout, liveAnchorPairs := l.planner.CurrentThresholds()
-
-	fr := FitReport{
-		At:            time.Now(),
-		Reason:        res.Reason,
-		Changed:       res.Changed,
-		HasOOMSignal:  res.HasOOMSignal,
-		OOMMinFanout:  res.OOMMinFanout,
-		OOMMinAnchors: res.OOMMinAnchors,
-		Candidate:     res.Candidate,
-	}
-	if fitErr != nil {
-		fr.Error = fitErr.Error()
-	}
+	now := time.Now()
 
 	st := l.reporter.Snapshot()
 	st.Live = routerrules.Thresholds{MinFanout: liveFanout, MinAnchorPairs: liveAnchorPairs}
-	st.Ticks++
-	st.LastFit = &fr
+	st.Stats.Ticks++
+
+	if fitErr != nil {
+		// A failed corpus read: no fresh outcome counts, and no change to the
+		// gate — count it as a non-converging tick.
+		st.Stats.ErrorTicks++
+		st.Stats.LastError = fitErr.Error()
+		st.Stats.LastErrorAt = now
+		st.Stats.TicksSinceChange++
+		l.reporter.Set(st)
+		return
+	}
+
+	if res.HasOOMSignal {
+		st.Stats.SignalTicks++
+	}
+	if res.Changed {
+		st.Stats.AppliedTicks++
+		st.Stats.LastChangeAt = now
+		st.Stats.TicksSinceChange = 0
+	} else {
+		st.Stats.TicksSinceChange++
+	}
+
+	st.Outcome = Outcome{
+		At:               now,
+		HasSignal:        res.HasOOMSignal,
+		OOMMinFanout:     res.OOMMinFanout,
+		OOMMinAnchors:    res.OOMMinAnchors,
+		RouteAOomCount:   res.RouteAOomCount,
+		RouteBExecutions: res.RouteBExecutions,
+		RouteBOomCount:   res.RouteBOomCount,
+	}
 	l.reporter.Set(st)
 }

--- a/internal/autotune/loop.go
+++ b/internal/autotune/loop.go
@@ -29,15 +29,20 @@ type Loop struct {
 	newTuner func() *routerrules.Autotuner
 	interval time.Duration
 	logger   *slog.Logger
+
+	// reporter receives a Status update after every tick for /info introspection.
+	// May be nil (tests that don't care); the loop then reports nothing.
+	reporter *Reporter
 }
 
 // New builds a Loop. newTuner returns a fresh Autotuner per tick; cmd/ supplies
 // a closure that rebuilds the corpus source with a rolling window lower bound
 // (recomputed each call), so the fit reads recent data rather than an
 // ever-expanding window pinned at process start. interval must be > 0
-// (solver.Config.Validate enforces this whenever Autotune is set).
-func New(planner *solver.Planner, newTuner func() *routerrules.Autotuner, interval time.Duration, logger *slog.Logger) *Loop {
-	return &Loop{planner: planner, newTuner: newTuner, interval: interval, logger: logger}
+// (solver.Config.Validate enforces this whenever Autotune is set). reporter may
+// be nil.
+func New(planner *solver.Planner, newTuner func() *routerrules.Autotuner, interval time.Duration, logger *slog.Logger, reporter *Reporter) *Loop {
+	return &Loop{planner: planner, newTuner: newTuner, interval: interval, logger: logger, reporter: reporter}
 }
 
 // Run drives the loop until ctx is cancelled, then returns — leaving no
@@ -78,23 +83,54 @@ func (l *Loop) tick(ctx context.Context) {
 	res, err := l.newTuner().Fit(ctx, cur)
 	if err != nil {
 		l.logger.WarnContext(ctx, "autotune fit failed", "err", err)
+		l.report(&routerrules.FitResult{}, err)
 		return
 	}
-	if !res.Changed {
+	if res.Changed {
+		l.planner.SetThresholds(res.Candidate.MinFanout, res.Candidate.MinAnchorPairs)
+		l.logger.InfoContext(ctx, "autotune applied",
+			"reason", res.Reason,
+			"prev_min_fanout", cur.MinFanout,
+			"min_fanout", res.Candidate.MinFanout,
+			"prev_min_anchor_pairs", cur.MinAnchorPairs,
+			"min_anchor_pairs", res.Candidate.MinAnchorPairs,
+			"oom_min_fanout", res.OOMMinFanout,
+			"oom_min_anchors", res.OOMMinAnchors)
+	} else {
 		l.logger.DebugContext(ctx, "autotune no change",
 			"reason", res.Reason,
 			"min_fanout", cur.MinFanout,
 			"min_anchor_pairs", cur.MinAnchorPairs)
+	}
+	l.report(&res, nil)
+}
+
+// report updates the introspection Status after a tick, preserving the static
+// fields main/ seeded (enabled, reason, interval, window, configured) and
+// refreshing the dynamic ones (live thresholds, tick count, last fit). The loop
+// goroutine is the only writer after seeding, so the read-modify-write is safe.
+func (l *Loop) report(res *routerrules.FitResult, fitErr error) {
+	if l.reporter == nil {
 		return
 	}
+	liveFanout, liveAnchorPairs := l.planner.CurrentThresholds()
 
-	l.planner.SetThresholds(res.Candidate.MinFanout, res.Candidate.MinAnchorPairs)
-	l.logger.InfoContext(ctx, "autotune applied",
-		"reason", res.Reason,
-		"prev_min_fanout", cur.MinFanout,
-		"min_fanout", res.Candidate.MinFanout,
-		"prev_min_anchor_pairs", cur.MinAnchorPairs,
-		"min_anchor_pairs", res.Candidate.MinAnchorPairs,
-		"oom_min_fanout", res.OOMMinFanout,
-		"oom_min_anchors", res.OOMMinAnchors)
+	fr := FitReport{
+		At:            time.Now(),
+		Reason:        res.Reason,
+		Changed:       res.Changed,
+		HasOOMSignal:  res.HasOOMSignal,
+		OOMMinFanout:  res.OOMMinFanout,
+		OOMMinAnchors: res.OOMMinAnchors,
+		Candidate:     res.Candidate,
+	}
+	if fitErr != nil {
+		fr.Error = fitErr.Error()
+	}
+
+	st := l.reporter.Snapshot()
+	st.Live = routerrules.Thresholds{MinFanout: liveFanout, MinAnchorPairs: liveAnchorPairs}
+	st.Ticks++
+	st.LastFit = &fr
+	l.reporter.Set(st)
 }

--- a/internal/autotune/loop_test.go
+++ b/internal/autotune/loop_test.go
@@ -35,7 +35,7 @@ func newLoop(p *solver.Planner, floor routerrules.OOMFloor) *Loop {
 	newTuner := func() *routerrules.Autotuner {
 		return routerrules.NewAutotuner(fakeFloorSource{f: floor})
 	}
-	return New(p, newTuner, time.Hour, quietLogger())
+	return New(p, newTuner, time.Hour, quietLogger(), NewReporter(Status{}))
 }
 
 // TestLoop_Tick_Applies drives one tick with an OOM floor below the default
@@ -51,6 +51,39 @@ func TestLoop_Tick_Applies(t *testing.T) {
 
 	if gotF, gotP := p.CurrentThresholds(); gotF != 9 || gotP != 2169 {
 		t.Errorf("after tick: fanout=%d pairs=%d, want 9 / 2169", gotF, gotP)
+	}
+}
+
+// TestLoop_Tick_ReportsStatus asserts each tick publishes its outcome to the
+// Reporter for /info/autotune: live thresholds, tick count, and the last fit.
+func TestLoop_Tick_ReportsStatus(t *testing.T) {
+	p := newPlanner()
+	rep := NewReporter(Status{Enabled: true, Active: true, Reason: ReasonStatusActive})
+	newTuner := func() *routerrules.Autotuner {
+		return routerrules.NewAutotuner(fakeFloorSource{f: routerrules.OOMFloor{HasSignal: true, MinFanout: 9, MinAnchors: 241}})
+	}
+	l := New(p, newTuner, time.Hour, quietLogger(), rep)
+
+	l.tick(context.Background())
+
+	st := rep.Snapshot()
+	if st.Reason != ReasonStatusActive {
+		t.Errorf("static Reason clobbered: %q", st.Reason)
+	}
+	if st.Ticks != 1 {
+		t.Errorf("Ticks = %d, want 1", st.Ticks)
+	}
+	if st.Live.MinFanout != 9 || st.Live.MinAnchorPairs != 2169 {
+		t.Errorf("Live = %+v, want {9 2169}", st.Live)
+	}
+	if st.LastFit == nil {
+		t.Fatal("LastFit is nil after a tick")
+	}
+	if !st.LastFit.Changed || !st.LastFit.HasOOMSignal || st.LastFit.OOMMinFanout != 9 {
+		t.Errorf("LastFit = %+v, want changed+signal at OOM fanout 9", st.LastFit)
+	}
+	if st.LastFit.At.IsZero() {
+		t.Error("LastFit.At not stamped")
 	}
 }
 
@@ -75,7 +108,7 @@ func TestLoop_Run_StopsOnCancel(t *testing.T) {
 	newTuner := func() *routerrules.Autotuner {
 		return routerrules.NewAutotuner(fakeFloorSource{f: routerrules.OOMFloor{HasSignal: false}})
 	}
-	l := New(p, newTuner, time.Millisecond, quietLogger())
+	l := New(p, newTuner, time.Millisecond, quietLogger(), NewReporter(Status{}))
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})

--- a/internal/autotune/loop_test.go
+++ b/internal/autotune/loop_test.go
@@ -70,20 +70,25 @@ func TestLoop_Tick_ReportsStatus(t *testing.T) {
 	if st.Reason != ReasonStatusActive {
 		t.Errorf("static Reason clobbered: %q", st.Reason)
 	}
-	if st.Ticks != 1 {
-		t.Errorf("Ticks = %d, want 1", st.Ticks)
-	}
 	if st.Live.MinFanout != 9 || st.Live.MinAnchorPairs != 2169 {
 		t.Errorf("Live = %+v, want {9 2169}", st.Live)
 	}
-	if st.LastFit == nil {
-		t.Fatal("LastFit is nil after a tick")
+	// Process stats.
+	if st.Stats.Ticks != 1 || st.Stats.SignalTicks != 1 || st.Stats.AppliedTicks != 1 {
+		t.Errorf("Stats = %+v, want ticks/signal/applied = 1", st.Stats)
 	}
-	if !st.LastFit.Changed || !st.LastFit.HasOOMSignal || st.LastFit.OOMMinFanout != 9 {
-		t.Errorf("LastFit = %+v, want changed+signal at OOM fanout 9", st.LastFit)
+	if st.Stats.TicksSinceChange != 0 {
+		t.Errorf("TicksSinceChange = %d, want 0 (changed this tick)", st.Stats.TicksSinceChange)
 	}
-	if st.LastFit.At.IsZero() {
-		t.Error("LastFit.At not stamped")
+	if st.Stats.LastChangeAt.IsZero() {
+		t.Error("LastChangeAt not stamped after an applied change")
+	}
+	// Efficacy outcome.
+	if !st.Outcome.HasSignal || st.Outcome.OOMMinFanout != 9 {
+		t.Errorf("Outcome = %+v, want signal at OOM fanout 9", st.Outcome)
+	}
+	if st.Outcome.At.IsZero() {
+		t.Error("Outcome.At not stamped")
 	}
 }
 

--- a/internal/autotune/metrics.go
+++ b/internal/autotune/metrics.go
@@ -38,6 +38,14 @@ func RegisterMetrics(reporter *Reporter) error {
 	gauge := func(name, desc, unit string) (metric.Int64ObservableGauge, error) {
 		return meter.Int64ObservableGauge(name, metric.WithDescription(desc), metric.WithUnit(unit))
 	}
+	// The *_total series are MONOTONIC cumulative counts, so they must be
+	// observable COUNTERS (they land in the OTel-CH sum table). The prom head
+	// routes a `_total` name to the sum table by convention — an observable gauge
+	// named `_total` would write to the gauge table and then never resolve on a
+	// series query, which the compose-smoke metrics-explorer sweep enforces.
+	counter := func(name, desc, unit string) (metric.Int64ObservableCounter, error) {
+		return meter.Int64ObservableCounter(name, metric.WithDescription(desc), metric.WithUnit(unit))
+	}
 
 	active, err := gauge("cerberus_solver_autotune_active",
 		"1 when the self-driving loop is running on this pod (enabled, auto mode, corpus available), else 0.", "{state}")
@@ -59,12 +67,12 @@ func RegisterMetrics(reporter *Reporter) error {
 	if err != nil {
 		return err
 	}
-	appliedTicks, err := gauge("cerberus_solver_autotune_applied_total",
+	appliedTicks, err := counter("cerberus_solver_autotune_applied_total",
 		"Cumulative ticks that lowered the gate on this pod.", "{tick}")
 	if err != nil {
 		return err
 	}
-	errorTicks, err := gauge("cerberus_solver_autotune_errors_total",
+	errorTicks, err := counter("cerberus_solver_autotune_errors_total",
 		"Cumulative ticks whose corpus read failed on this pod.", "{tick}")
 	if err != nil {
 		return err

--- a/internal/autotune/metrics.go
+++ b/internal/autotune/metrics.go
@@ -1,0 +1,119 @@
+package autotune
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric"
+)
+
+// meterName is the instrumentation scope for the autotune gauges.
+const meterName = "github.com/tsouza/cerberus/internal/autotune"
+
+// RegisterMetrics registers observable gauges that publish the self-driving
+// loop's decision state on every collection interval, read from the Reporter.
+// Each series is stamped per-pod by the OTel resource's service.instance.id, so
+// the fleet + historical view is a CH/PromQL aggregation over pods.
+//
+// Aggregation note for dashboards: the corpus-derived series (route_a_ooms,
+// route_b_executions, route_b_ooms, oom_min_fanout, and the live thresholds) are
+// computed from the SHARED corpus, so every pod reports ~the same value — take
+// max/avg, never sum (summing N-inflates by pod count). The per-pod process
+// series (applied_total, errors_total) are genuinely per-pod and may be summed.
+//
+// Autotune is prom-head-scoped (the solver is built only for the prom head), so
+// wherever these gauges emit, that pod also serves PromQL — there is no pod that
+// tunes but cannot be queried. Emission itself rides the OTLP pipeline, so it is
+// independent of any head being enabled.
+//
+// A nil reporter is a no-op. It returns an error only on a misconfigured
+// MeterProvider; the caller logs and continues (introspection is best-effort and
+// never on the query path).
+func RegisterMetrics(reporter *Reporter) error {
+	if reporter == nil {
+		return nil
+	}
+	meter := otel.GetMeterProvider().Meter(meterName)
+
+	gauge := func(name, desc, unit string) (metric.Int64ObservableGauge, error) {
+		return meter.Int64ObservableGauge(name, metric.WithDescription(desc), metric.WithUnit(unit))
+	}
+
+	active, err := gauge("cerberus_solver_autotune_active",
+		"1 when the self-driving loop is running on this pod (enabled, auto mode, corpus available), else 0.", "{state}")
+	if err != nil {
+		return err
+	}
+	minFanout, err := gauge("cerberus_solver_autotune_min_fanout",
+		"Live MinFanout auto-gate the Planner is routing with right now.", "{anchor}")
+	if err != nil {
+		return err
+	}
+	minAnchorPairs, err := gauge("cerberus_solver_autotune_min_anchor_pairs",
+		"Live MinAnchorPairs auto-gate the Planner is routing with right now.", "{pair}")
+	if err != nil {
+		return err
+	}
+	configuredMinFanout, err := gauge("cerberus_solver_autotune_configured_min_fanout",
+		"Shipped (configured) MinFanout; live minus this is how far the loop has lowered the gate.", "{anchor}")
+	if err != nil {
+		return err
+	}
+	appliedTicks, err := gauge("cerberus_solver_autotune_applied_total",
+		"Cumulative ticks that lowered the gate on this pod.", "{tick}")
+	if err != nil {
+		return err
+	}
+	errorTicks, err := gauge("cerberus_solver_autotune_errors_total",
+		"Cumulative ticks whose corpus read failed on this pod.", "{tick}")
+	if err != nil {
+		return err
+	}
+	routeAOoms, err := gauge("cerberus_solver_autotune_route_a_ooms",
+		"Rolling-window route-A below-threshold OOMs (corpus-derived); good = trending to 0.", "{query}")
+	if err != nil {
+		return err
+	}
+	routeBExecs, err := gauge("cerberus_solver_autotune_route_b_executions",
+		"Rolling-window route-B executions — volume routed to the safe path (corpus-derived).", "{query}")
+	if err != nil {
+		return err
+	}
+	routeBOoms, err := gauge("cerberus_solver_autotune_route_b_ooms",
+		"Rolling-window route-B OOMs — the mitigation itself failing; should stay 0 (corpus-derived).", "{query}")
+	if err != nil {
+		return err
+	}
+	oomFloorFanout, err := gauge("cerberus_solver_autotune_oom_min_fanout",
+		"Observed route-A OOM floor fan-out the loop is tracking (corpus-derived).", "{anchor}")
+	if err != nil {
+		return err
+	}
+
+	_, err = meter.RegisterCallback(
+		func(_ context.Context, o metric.Observer) error {
+			s := reporter.Snapshot()
+			o.ObserveInt64(active, boolToInt64(s.Active))
+			o.ObserveInt64(minFanout, int64(s.Live.MinFanout))
+			o.ObserveInt64(minAnchorPairs, int64(s.Live.MinAnchorPairs))
+			o.ObserveInt64(configuredMinFanout, int64(s.Configured.MinFanout))
+			o.ObserveInt64(appliedTicks, s.Stats.AppliedTicks)
+			o.ObserveInt64(errorTicks, s.Stats.ErrorTicks)
+			o.ObserveInt64(routeAOoms, s.Outcome.RouteAOomCount)
+			o.ObserveInt64(routeBExecs, s.Outcome.RouteBExecutions)
+			o.ObserveInt64(routeBOoms, s.Outcome.RouteBOomCount)
+			o.ObserveInt64(oomFloorFanout, int64(s.Outcome.OOMMinFanout))
+			return nil
+		},
+		active, minFanout, minAnchorPairs, configuredMinFanout,
+		appliedTicks, errorTicks, routeAOoms, routeBExecs, routeBOoms, oomFloorFanout,
+	)
+	return err
+}
+
+func boolToInt64(b bool) int64 {
+	if b {
+		return 1
+	}
+	return 0
+}

--- a/internal/autotune/metrics_test.go
+++ b/internal/autotune/metrics_test.go
@@ -1,0 +1,76 @@
+package autotune
+
+import (
+	"context"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/tsouza/cerberus/internal/routerrules"
+)
+
+// gaugeValues collects one manual-reader snapshot into a name→value map over all
+// int64 observable gauges.
+func gaugeValues(t *testing.T, reader *metric.ManualReader) map[string]int64 {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+	out := map[string]int64{}
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			g, ok := m.Data.(metricdata.Gauge[int64])
+			if !ok || len(g.DataPoints) == 0 {
+				continue
+			}
+			out[m.Name] = g.DataPoints[0].Value
+		}
+	}
+	return out
+}
+
+func TestRegisterMetrics_PublishesReporterState(t *testing.T) {
+	reader := metric.NewManualReader()
+	mp := metric.NewMeterProvider(metric.WithReader(reader))
+	prev := otel.GetMeterProvider()
+	otel.SetMeterProvider(mp)
+	t.Cleanup(func() { otel.SetMeterProvider(prev) })
+
+	rep := NewReporter(Status{
+		Active:     true,
+		Configured: routerrules.Thresholds{MinFanout: 16, MinAnchorPairs: 4000},
+		Live:       routerrules.Thresholds{MinFanout: 8, MinAnchorPairs: 1928},
+		Stats:      Stats{AppliedTicks: 2, ErrorTicks: 1},
+		Outcome:    Outcome{OOMMinFanout: 8, RouteAOomCount: 3, RouteBExecutions: 100, RouteBOomCount: 0},
+	})
+	if err := RegisterMetrics(rep); err != nil {
+		t.Fatalf("RegisterMetrics: %v", err)
+	}
+
+	got := gaugeValues(t, reader)
+	want := map[string]int64{
+		"cerberus_solver_autotune_active":                1,
+		"cerberus_solver_autotune_min_fanout":            8,
+		"cerberus_solver_autotune_min_anchor_pairs":      1928,
+		"cerberus_solver_autotune_configured_min_fanout": 16,
+		"cerberus_solver_autotune_applied_total":         2,
+		"cerberus_solver_autotune_errors_total":          1,
+		"cerberus_solver_autotune_route_a_ooms":          3,
+		"cerberus_solver_autotune_route_b_executions":    100,
+		"cerberus_solver_autotune_route_b_ooms":          0,
+		"cerberus_solver_autotune_oom_min_fanout":        8,
+	}
+	for name, wv := range want {
+		if got[name] != wv {
+			t.Errorf("%s = %d, want %d", name, got[name], wv)
+		}
+	}
+
+	// A nil reporter must be a no-op, not a panic.
+	if err := RegisterMetrics(nil); err != nil {
+		t.Errorf("RegisterMetrics(nil) = %v, want nil", err)
+	}
+}

--- a/internal/autotune/metrics_test.go
+++ b/internal/autotune/metrics_test.go
@@ -22,11 +22,16 @@ func gaugeValues(t *testing.T, reader *metric.ManualReader) map[string]int64 {
 	out := map[string]int64{}
 	for _, sm := range rm.ScopeMetrics {
 		for _, m := range sm.Metrics {
-			g, ok := m.Data.(metricdata.Gauge[int64])
-			if !ok || len(g.DataPoints) == 0 {
-				continue
+			switch d := m.Data.(type) {
+			case metricdata.Gauge[int64]:
+				if len(d.DataPoints) > 0 {
+					out[m.Name] = d.DataPoints[0].Value
+				}
+			case metricdata.Sum[int64]: // the *_total observable counters
+				if len(d.DataPoints) > 0 {
+					out[m.Name] = d.DataPoints[0].Value
+				}
 			}
-			out[m.Name] = g.DataPoints[0].Value
 		}
 	}
 	return out

--- a/internal/autotune/reporter.go
+++ b/internal/autotune/reporter.go
@@ -27,22 +27,39 @@ type Status struct {
 	Configured routerrules.Thresholds
 	Live       routerrules.Thresholds
 
-	// Ticks counts completed fit cycles; LastFit is the most recent one (nil
-	// until the first tick).
-	Ticks   int64
-	LastFit *FitReport
+	// Stats aggregates the loop's own behavior; Outcome is the rolling-window
+	// efficacy signal from the corpus. Together they answer "is it doing good?".
+	Stats   Stats
+	Outcome Outcome
 }
 
-// FitReport is the outcome of one fit cycle.
-type FitReport struct {
-	At            time.Time
-	Reason        string
-	Changed       bool
-	HasOOMSignal  bool
-	OOMMinFanout  int
-	OOMMinAnchors int
-	Candidate     routerrules.Thresholds
-	Error         string
+// Stats aggregates the loop's behavior across ticks (process health): whether it
+// has converged (TicksSinceChange high, AppliedTicks small and stable), whether
+// it is finding signal, and whether it is erroring.
+type Stats struct {
+	Ticks            int64
+	SignalTicks      int64
+	AppliedTicks     int64
+	ErrorTicks       int64
+	TicksSinceChange int64
+	LastChangeAt     time.Time
+	LastError        string
+	LastErrorAt      time.Time
+}
+
+// Outcome is the rolling-window efficacy signal from the corpus, refreshed each
+// tick. RouteAOomCount is the eligible OOM population the loop targets (good =
+// trending to 0 as it protects them); RouteBExecutions is the volume it routes to
+// the safe path; RouteBOomCount is route-B OOMs — the mitigation itself failing,
+// which should stay 0 (nonzero = bad). OOMMin* is the last observed floor.
+type Outcome struct {
+	At               time.Time
+	HasSignal        bool
+	OOMMinFanout     int
+	OOMMinAnchors    int
+	RouteAOomCount   int64
+	RouteBExecutions int64
+	RouteBOomCount   int64
 }
 
 // Reason values for Status.Reason.

--- a/internal/autotune/reporter.go
+++ b/internal/autotune/reporter.go
@@ -1,0 +1,74 @@
+package autotune
+
+import (
+	"sync/atomic"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/routerrules"
+)
+
+// Status is a point-in-time snapshot of the self-driving loop's decision state,
+// exposed for introspection (e.g. the /info/autotune endpoint). It is a plain
+// value — the Reporter hands out copies, never a live pointer.
+type Status struct {
+	// Enabled reflects CERBERUS_SOLVER_AUTOTUNE. Active is true only when the
+	// loop is actually running (enabled AND auto mode AND the corpus CH table is
+	// available). Reason explains the Active state: "active" | "disabled" |
+	// "not-auto-mode" | "corpus-unavailable".
+	Enabled bool
+	Active  bool
+	Reason  string
+
+	IntervalSeconds     float64
+	CorpusWindowSeconds float64
+
+	// Configured is the gate the deployment shipped with; Live is what the
+	// Planner is using right now (Configured until the loop lowers it).
+	Configured routerrules.Thresholds
+	Live       routerrules.Thresholds
+
+	// Ticks counts completed fit cycles; LastFit is the most recent one (nil
+	// until the first tick).
+	Ticks   int64
+	LastFit *FitReport
+}
+
+// FitReport is the outcome of one fit cycle.
+type FitReport struct {
+	At            time.Time
+	Reason        string
+	Changed       bool
+	HasOOMSignal  bool
+	OOMMinFanout  int
+	OOMMinAnchors int
+	Candidate     routerrules.Thresholds
+	Error         string
+}
+
+// Reason values for Status.Reason.
+const (
+	ReasonStatusActive            = "active"
+	ReasonStatusDisabled          = "disabled"
+	ReasonStatusNotAutoMode       = "not-auto-mode"
+	ReasonStatusCorpusUnavailable = "corpus-unavailable"
+)
+
+// Reporter is a thread-safe holder of the latest Status. main/ seeds it with the
+// initial (pre-first-tick) status; the loop goroutine updates it after each tick
+// (single writer). The /info handler reads Snapshot concurrently.
+type Reporter struct {
+	v atomic.Pointer[Status]
+}
+
+// NewReporter builds a Reporter seeded with initial.
+func NewReporter(initial Status) *Reporter {
+	r := &Reporter{}
+	r.v.Store(&initial)
+	return r
+}
+
+// Set replaces the reported status.
+func (r *Reporter) Set(s Status) { r.v.Store(&s) }
+
+// Snapshot returns a copy of the current status.
+func (r *Reporter) Snapshot() Status { return *r.v.Load() }

--- a/internal/autotune/reporter_test.go
+++ b/internal/autotune/reporter_test.go
@@ -1,0 +1,23 @@
+package autotune
+
+import "testing"
+
+func TestReporter_SetSnapshot(t *testing.T) {
+	r := NewReporter(Status{Enabled: true, Reason: ReasonStatusActive})
+
+	if s := r.Snapshot(); !s.Enabled || s.Reason != ReasonStatusActive {
+		t.Fatalf("initial snapshot = %+v", s)
+	}
+
+	r.Set(Status{Ticks: 5})
+	if s := r.Snapshot(); s.Ticks != 5 || s.Enabled {
+		t.Fatalf("post-set snapshot = %+v", s)
+	}
+
+	// Snapshot returns a copy: mutating it must not affect the stored value.
+	s := r.Snapshot()
+	s.Ticks = 99
+	if got := r.Snapshot().Ticks; got != 5 {
+		t.Errorf("Snapshot leaked a live value: Ticks = %d, want 5", got)
+	}
+}

--- a/internal/autotune/reporter_test.go
+++ b/internal/autotune/reporter_test.go
@@ -9,15 +9,15 @@ func TestReporter_SetSnapshot(t *testing.T) {
 		t.Fatalf("initial snapshot = %+v", s)
 	}
 
-	r.Set(Status{Ticks: 5})
-	if s := r.Snapshot(); s.Ticks != 5 || s.Enabled {
+	r.Set(Status{Stats: Stats{Ticks: 5}})
+	if s := r.Snapshot(); s.Stats.Ticks != 5 || s.Enabled {
 		t.Fatalf("post-set snapshot = %+v", s)
 	}
 
 	// Snapshot returns a copy: mutating it must not affect the stored value.
 	s := r.Snapshot()
-	s.Ticks = 99
-	if got := r.Snapshot().Ticks; got != 5 {
+	s.Stats.Ticks = 99
+	if got := r.Snapshot().Stats.Ticks; got != 5 {
 		t.Errorf("Snapshot leaked a live value: Ticks = %d, want 5", got)
 	}
 }

--- a/internal/routerrules/autotune.go
+++ b/internal/routerrules/autotune.go
@@ -73,6 +73,12 @@ type FitResult struct {
 	OOMMinFanout  int
 	OOMMinAnchors int
 	HasOOMSignal  bool
+
+	// Rolling-window outcome counts over the corpus window, passed through from
+	// the OOM-floor read for introspection (they do not affect the fit).
+	RouteAOomCount   int64
+	RouteBExecutions int64
+	RouteBOomCount   int64
 }
 
 // Fit reads the corpus OOM floor and returns a threshold candidate relative to
@@ -83,15 +89,22 @@ func (a *Autotuner) Fit(ctx context.Context, current Thresholds) (FitResult, err
 	if err != nil {
 		return FitResult{}, err
 	}
-	if !floor.HasSignal {
-		return FitResult{Candidate: current, Reason: ReasonAutotuneNoSignal}, nil
-	}
 
+	// Outcome counts are carried on every result, signal or not (route-B volume
+	// is meaningful even when no route-A OOMs remain).
 	res := FitResult{
-		HasOOMSignal:  true,
-		OOMMinFanout:  floor.MinFanout,
-		OOMMinAnchors: floor.MinAnchors,
+		Candidate:        current,
+		RouteAOomCount:   floor.RouteAOomCount,
+		RouteBExecutions: floor.RouteBExecutions,
+		RouteBOomCount:   floor.RouteBOomCount,
 	}
+	if !floor.HasSignal {
+		res.Reason = ReasonAutotuneNoSignal
+		return res, nil
+	}
+	res.HasOOMSignal = true
+	res.OOMMinFanout = floor.MinFanout
+	res.OOMMinAnchors = floor.MinAnchors
 
 	// Candidate MinFanout: clamp the observed OOM fan-out floor into
 	// [floor, current] — only ever lowers, never above the OOM floor.

--- a/internal/routerrules/autotune_chdb_lane_test.go
+++ b/internal/routerrules/autotune_chdb_lane_test.go
@@ -118,6 +118,15 @@ func TestAutotune_CHFit_FlipsKnownOOMShapeToRouteB(t *testing.T) {
 	if res.OOMMinAnchors != autotuneGridAnchors {
 		t.Fatalf("OOMMinAnchors = %d, want %d", res.OOMMinAnchors, autotuneGridAnchors)
 	}
+	// Rolling-window outcome counts through the same real-CH conditional
+	// aggregates: two below-threshold route-A OOMs (fanout 8 + 12; the
+	// not-sliceable row is excluded), and no route-B rows were seeded.
+	if res.RouteAOomCount != 2 {
+		t.Fatalf("RouteAOomCount = %d, want 2 (below-threshold OOM rows, excluding not-sliceable)", res.RouteAOomCount)
+	}
+	if res.RouteBExecutions != 0 || res.RouteBOomCount != 0 {
+		t.Fatalf("route-B counts = %d / %d, want 0 / 0 (none seeded)", res.RouteBExecutions, res.RouteBOomCount)
+	}
 	if !res.Changed {
 		t.Fatalf("fit must lower the gate below the default; Changed=false, candidate=%+v", res.Candidate)
 	}

--- a/internal/routerrules/autotune_test.go
+++ b/internal/routerrules/autotune_test.go
@@ -10,6 +10,23 @@ type fakeFloorSource struct{ f OOMFloor }
 
 func (s fakeFloorSource) OOMFloor(_ context.Context) (OOMFloor, error) { return s.f, nil }
 
+// TestAutotuneFit_PassesOutcomeCounts asserts Fit forwards the rolling-window
+// outcome counts on every result — including the no-signal branch, where they
+// are still meaningful (route-B volume with zero remaining route-A OOMs).
+func TestAutotuneFit_PassesOutcomeCounts(t *testing.T) {
+	src := fakeFloorSource{f: OOMFloor{HasSignal: false, RouteBExecutions: 200, RouteBOomCount: 1}}
+	res, err := NewAutotuner(src).Fit(context.Background(), Thresholds{MinFanout: 16, MinAnchorPairs: 4000})
+	if err != nil {
+		t.Fatalf("Fit: %v", err)
+	}
+	if res.Reason != ReasonAutotuneNoSignal {
+		t.Errorf("Reason = %q, want no-signal", res.Reason)
+	}
+	if res.RouteBExecutions != 200 || res.RouteBOomCount != 1 {
+		t.Errorf("outcome counts not passed through: %+v", res)
+	}
+}
+
 func TestAutotuneFit(t *testing.T) {
 	cur := Thresholds{MinFanout: 16, MinAnchorPairs: 4000}
 

--- a/internal/routerrules/source.go
+++ b/internal/routerrules/source.go
@@ -71,10 +71,21 @@ type RuleQuery struct {
 // fanout > 0 AND n_anchors > 0 predicate is a guard against a gridless row
 // (e.g. an instant query, recorded with fanout = 0) slipping in and cratering
 // the min to 0. HasSignal is false when that population is empty (cold start).
+//
+// Alongside the floor, OOMFloor carries rolling-window outcome counts (over the
+// same corpus window) used to gauge whether the loop is doing good or bad:
+// RouteAOomCount is the eligible population the loop targets (should trend to 0
+// as it protects them), RouteBExecutions is the volume it routes to the safe
+// path, and RouteBOomCount is route-B OOMs — the mitigation itself failing, which
+// should stay 0.
 type OOMFloor struct {
 	MinFanout  int
 	MinAnchors int
 	HasSignal  bool
+
+	RouteAOomCount   int64
+	RouteBExecutions int64
+	RouteBOomCount   int64
 }
 
 // OOMFloorSource is the narrow read surface the autotune fit needs: the observed

--- a/internal/routerrules/source_ch.go
+++ b/internal/routerrules/source_ch.go
@@ -58,25 +58,36 @@ const reasonBelowThreshold = "below-threshold"
 // column, exactly like scalarAggregate — a 0 min is never mistaken for a real
 // "OOM at fan-out 0" (those rows are excluded by the fanout > 0 predicate).
 func (s *chCorpusSource) OOMFloor(ctx context.Context) (OOMFloor, error) {
-	fanoutMin := toFloat64Frag(chsql.Call("ifNull", chsql.Call("min", chsql.BareIdent("fanout")), chsql.InlineLit(int64(0))))
-	anchorMin := toFloat64Frag(chsql.Call("ifNull", chsql.Call("min", chsql.BareIdent("n_anchors")), chsql.InlineLit(int64(0))))
-	qb := chsql.NewQuery().
-		From(chsql.BareIdent(CorpusTableName)).
-		SelectAs(fanoutMin, "f").
-		SelectAs(anchorMin, "a").
-		SelectAs(toInt64Frag(chsql.Call("count")), "n")
-
-	conds := []chsql.Frag{
+	// floorPred selects the eligible population the cost gate protects: route-A
+	// OOMs rejected below-threshold, with a real grid. The floor is a conditional
+	// min over it; the outcome counts are conditional counts over the SAME window,
+	// so one query returns both. The WHERE narrows only the time window.
+	floorPred := chsql.And(
 		chsql.Eq(chsql.BareIdent("route"), chsql.InlineLit("A")),
 		chsql.Eq(chsql.BareIdent("exit_status"), chsql.InlineLit("oom")),
 		chsql.Eq(chsql.BareIdent("decision_reason"), chsql.InlineLit(reasonBelowThreshold)),
 		chsql.Gt(chsql.BareIdent("fanout"), chsql.InlineLit(int64(0))),
 		chsql.Gt(chsql.BareIdent("n_anchors"), chsql.InlineLit(int64(0))),
-	}
+	)
+	routeBPred := chsql.Eq(chsql.BareIdent("route"), chsql.InlineLit("B"))
+	routeBOomPred := chsql.And(
+		chsql.Eq(chsql.BareIdent("route"), chsql.InlineLit("B")),
+		chsql.Eq(chsql.BareIdent("exit_status"), chsql.InlineLit("oom")),
+	)
+
+	fanoutMin := toFloat64Frag(chsql.Call("ifNull", chsql.Call("minIf", chsql.BareIdent("fanout"), floorPred), chsql.InlineLit(int64(0))))
+	anchorMin := toFloat64Frag(chsql.Call("ifNull", chsql.Call("minIf", chsql.BareIdent("n_anchors"), floorPred), chsql.InlineLit(int64(0))))
+	qb := chsql.NewQuery().
+		From(chsql.BareIdent(CorpusTableName)).
+		SelectAs(fanoutMin, "f").
+		SelectAs(anchorMin, "a").
+		SelectAs(toInt64Frag(chsql.Call("countIf", floorPred)), "n").
+		SelectAs(toInt64Frag(chsql.Call("countIf", routeBPred)), "rb").
+		SelectAs(toInt64Frag(chsql.Call("countIf", routeBOomPred)), "rbo")
 	if sf := s.sinceFrag(); sf != nil {
-		conds = append(conds, sf)
+		qb = qb.Where(sf)
 	}
-	sql, args := qb.Where(chsql.And(conds...)).Build()
+	sql, args := qb.Build()
 
 	r, err := s.query(ctx, sql, args)
 	if err != nil {
@@ -85,21 +96,28 @@ func (s *chCorpusSource) OOMFloor(ctx context.Context) (OOMFloor, error) {
 	defer func() { _ = r.Close() }()
 
 	var (
-		fanout, anchors float64
-		n               int64
+		fanout, anchors               float64
+		floorCount, routeB, routeBOom int64
 	)
 	if r.Next() {
-		if err := r.Scan(&fanout, &anchors, &n); err != nil {
+		if err := r.Scan(&fanout, &anchors, &floorCount, &routeB, &routeBOom); err != nil {
 			return OOMFloor{}, fmt.Errorf("routerrules: scan oom floor: %w", err)
 		}
 	}
 	if err := r.Err(); err != nil {
 		return OOMFloor{}, err
 	}
-	if n == 0 {
-		return OOMFloor{}, nil
+	out := OOMFloor{
+		RouteAOomCount:   floorCount,
+		RouteBExecutions: routeB,
+		RouteBOomCount:   routeBOom,
 	}
-	return OOMFloor{MinFanout: int(fanout), MinAnchors: int(anchors), HasSignal: true}, nil
+	if floorCount > 0 {
+		out.HasSignal = true
+		out.MinFanout = int(fanout)
+		out.MinAnchors = int(anchors)
+	}
+	return out, nil
 }
 
 func (s *chCorpusSource) query(ctx context.Context, sql string, args []any) (rows, error) {

--- a/internal/routerrules/source_ch_test.go
+++ b/internal/routerrules/source_ch_test.go
@@ -115,9 +115,11 @@ func TestCHSourceBuildsTypedSQL(t *testing.T) {
 // predicate (route=A, oom, below-threshold, grid-bearing), the typed min/count
 // wrapping for the strict driver, and the scan into an OOMFloor.
 func TestCHSourceOOMFloor(t *testing.T) {
+	// Columns: f(minIf fanout), a(minIf n_anchors), n(floor countIf),
+	// rb(route-B countIf), rbo(route-B oom countIf).
 	conn := &recordingConn{
 		respond: []scriptedResponse{
-			{match: "FROM cerberus_router_corpus", rows: [][]any{{float64(9), float64(241), int64(5)}}},
+			{match: "FROM cerberus_router_corpus", rows: [][]any{{float64(9), float64(241), int64(5), int64(100), int64(2)}}},
 		},
 	}
 	src := NewCHOOMFloorSource(conn, 0).(*chCorpusSource)
@@ -127,16 +129,21 @@ func TestCHSourceOOMFloor(t *testing.T) {
 		t.Fatalf("OOMFloor: %v", err)
 	}
 	if !got.HasSignal || got.MinFanout != 9 || got.MinAnchors != 241 {
-		t.Fatalf("got %+v, want {MinFanout:9 MinAnchors:241 HasSignal:true}", got)
+		t.Fatalf("floor: got %+v, want {MinFanout:9 MinAnchors:241 HasSignal:true}", got)
+	}
+	if got.RouteAOomCount != 5 || got.RouteBExecutions != 100 || got.RouteBOomCount != 2 {
+		t.Fatalf("counts: got A=%d B=%d Boom=%d, want 5 / 100 / 2",
+			got.RouteAOomCount, got.RouteBExecutions, got.RouteBOomCount)
 	}
 
 	q := conn.queries[0]
 	for _, want := range []string{
-		"toFloat64(ifNull(min(fanout), 0))",
-		"toFloat64(ifNull(min(n_anchors), 0))",
-		"toInt64(count())",
+		"minIf(fanout,",
+		"minIf(n_anchors,",
+		"countIf(",
 		"FROM cerberus_router_corpus",
 		"route = 'A'",
+		"route = 'B'",
 		"exit_status = 'oom'",
 		"decision_reason = 'below-threshold'",
 		"fanout > 0",
@@ -148,12 +155,13 @@ func TestCHSourceOOMFloor(t *testing.T) {
 	}
 }
 
-// TestCHSourceOOMFloorNoSignal asserts an empty eligible population (count()=0)
-// resolves to HasSignal=false — cold start, never a spurious "OOM at fan-out 0".
+// TestCHSourceOOMFloorNoSignal asserts an empty eligible population (floor
+// countIf = 0) resolves to HasSignal=false — cold start, never a spurious "OOM
+// at fan-out 0" — while still reporting route-B outcome counts.
 func TestCHSourceOOMFloorNoSignal(t *testing.T) {
 	conn := &recordingConn{
 		respond: []scriptedResponse{
-			{match: "FROM cerberus_router_corpus", rows: [][]any{{float64(0), float64(0), int64(0)}}},
+			{match: "FROM cerberus_router_corpus", rows: [][]any{{float64(0), float64(0), int64(0), int64(50), int64(0)}}},
 		},
 	}
 	src := NewCHOOMFloorSource(conn, 0).(*chCorpusSource)
@@ -163,7 +171,10 @@ func TestCHSourceOOMFloorNoSignal(t *testing.T) {
 		t.Fatalf("OOMFloor: %v", err)
 	}
 	if got.HasSignal {
-		t.Fatalf("empty population must be no-signal, got %+v", got)
+		t.Fatalf("empty floor population must be no-signal, got %+v", got)
+	}
+	if got.RouteBExecutions != 50 {
+		t.Errorf("RouteBExecutions = %d, want 50 (counts reported even with no floor signal)", got.RouteBExecutions)
 	}
 }
 


### PR DESCRIPTION
Makes the self-driving autotune loop observable, correctly for a **multi-pod** deployment.

Two surfaces, by design:
- **`GET /info/autotune`** — *this pod's* live decision state, from an in-memory snapshot (no CH read on the request path). For debugging one pod.
- **Per-pod OTel gauges** → OTLP → CH — the **fleet + historical** view (each pod stamped by `service.instance.id`). Aggregate in Grafana/PromQL.

### `/info/autotune` shape
```json
{
  "enabled": true, "active": true, "reason": "active",
  "intervalSeconds": 900, "corpusWindowSeconds": 604800,
  "configured": { "minFanout": 16, "minAnchorPairs": 4000 },
  "live":       { "minFanout": 8,  "minAnchorPairs": 1928 },
  "stats":   { "ticks": 42, "signalTicks": 40, "appliedTicks": 3, "errorTicks": 0,
               "ticksSinceChange": 12, "lastChangeAt": "…", "lastError": "" },
  "outcome": { "at": "…", "hasSignal": true, "oomMinFanout": 8, "oomMinAnchors": 241,
               "routeAOoms": 2, "routeBExecutions": 1500, "routeBOoms": 0 }
}
```

- **`stats`** = loop process health (per-pod): converged = high `ticksSinceChange` + small stable `appliedTicks`; trouble = climbing `errorTicks`.
- **`outcome`** = the "good/bad" efficacy signal (rolling-window corpus counts, one `minIf`/`countIf` query, threaded through Fit). **Good:** `routeBOoms=0` (safe path not itself OOMing) + `routeAOoms→0` with `routeBExecutions>0`. **Bad:** `routeBOoms>0`, or `routeAOoms` persistently high.

### Metrics (fleet)
`cerberus_solver_autotune_{active,min_fanout,min_anchor_pairs,configured_min_fanout,applied_total,errors_total,route_a_ooms,route_b_executions,route_b_ooms,oom_min_fanout}`, observable gauges read from the Reporter each collection (mirrors `chclient/breaker_metrics`). **Aggregate corpus-derived series with max/avg, never sum** (every pod reports the same shared-corpus value); sum the per-pod process counters.

### Multi-pod / prom-head resolution
Autotune is **prom-head scoped** (the solver is built only for the prom head), so wherever these gauges emit, that pod also serves PromQL — no orphaned loop, and emission rides OTLP independent of any head.

### Design
- `internal/autotune.Reporter` — `atomic.Pointer[Status]`; single-writer loop RMW, concurrent HTTP + metric-callback reads (`-race` covered).
- Info layer stays decoupled: its own `AutotuneStatus` JSON type; cmd/ maps `autotune.Status` in.

### Tests
Reporter; loop publishes stats+outcome per tick; info handler 200/404×2; `RegisterMetrics` gauge values via ManualReader; CH `OOMFloor` conditional-aggregate SQL + counts; chDB lane extended to assert the counts against real chDB.

Docs: `health.md` gains the shape + a metrics table with the sum-vs-max guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)