### PR TITLE
fix(e2e): warm the stack before compose-smoke's zero-tolerance sweep

### DIFF
--- a/test/e2e/playwright/compose_grafana_smoke.spec.ts
+++ b/test/e2e/playwright/compose_grafana_smoke.spec.ts
@@ -5,6 +5,11 @@ import {
   type Page,
   type APIRequestContext,
 } from '@playwright/test';
+import {
+  generateSelfTraffic,
+  awaitSelfTelemetryRangeSignal,
+  awaitSeedFixtureSignal,
+} from './helpers/index.js';
 
 /**
  * Compose-stack Grafana catch-net.
@@ -63,6 +68,32 @@ type DSQueryError = {
   status: number;
   error: string;
 };
+
+// --- Shared warmup: gate BOTH tests on a warm, seeded stack -----------------
+//
+// Both tests below assert against a freshly-booted compose stack with ZERO
+// tolerance for datasource errors. On a cold start the cerberus->CH circuit
+// breaker can still be OPEN (or CH still settling) when the sweep fires, so a
+// panel query intermittently caught `503 circuit breaker open`, and the traceql
+// probe found no self-telemetry trace within its budget — a recovered-on-retry
+// flake that CI's failOnFlakyTests turns into a red shard. The sweep runs before
+// this spec's own seed (driveCerberusQLPartition), so nothing guaranteed the
+// stack was warm first. Seeding self-traffic and WAITING until it (and the seed
+// fixture) are queryable proves cerberus is warm — breaker closed, CH reachable,
+// schema present — before any assertion. Mirrors iterate-all-dashboards.spec.ts.
+const SEED_TRAFFIC_SECONDS = 30;
+const WARMUP_SIGNAL_DEADLINE_SECONDS = 120;
+const WARMUP_BOUNDED_WAITS = 3; // 2 self-telemetry exprs + 1 seed-fixture wait
+const WARMUP_BEFOREALL_TIMEOUT_MS =
+  (SEED_TRAFFIC_SECONDS + WARMUP_BOUNDED_WAITS * WARMUP_SIGNAL_DEADLINE_SECONDS) *
+  1000;
+
+test.beforeAll(async ({ request }) => {
+  test.setTimeout(WARMUP_BEFOREALL_TIMEOUT_MS);
+  await generateSelfTraffic(request, SEED_TRAFFIC_SECONDS);
+  await awaitSelfTelemetryRangeSignal(request);
+  await awaitSeedFixtureSignal(request);
+});
 
 test('compose: home, drilldown app, and every provisioned dashboard load without datasource errors', async ({
   page,


### PR DESCRIPTION
De-flakes `compose_grafana_smoke.spec.ts` — the `1 flaky` that intermittently reds the `dashboard`/`compose-smoke` shards.

### Root cause (reproduced locally)
The spec's two zero-tolerance tests — the "every dashboard loads without datasource errors" sweep and a traceql self-telemetry probe — run their assertions **before** any readiness/seed step (this spec seeds *after* the sweep, in `driveCerberusQLPartition`). On a cold start the cerberus→CH **circuit breaker can still be open** (or CH still settling) when the sweep fires, so a panel query intermittently catches `503 circuit breaker open`, and the traceql probe finds no self-telemetry trace in its budget. Both recover on the whole-test retry (warm stack) → `failOnFlakyTests` reports a red shard.

### Fix
Add a shared `beforeAll` warmup: seed self-traffic, then **wait until it and the seed fixture are queryable** (`awaitSelfTelemetryRangeSignal` / `awaitSeedFixtureSignal`). If cerberus can answer those, it's warm — breaker closed, CH reachable, schema present — before any assertion. This mirrors `iterate-all-dashboards.spec.ts`, which already has this gate and doesn't flake.

### How I diagnosed / verified
Ran the stack locally (alongside a pre-existing ClickHouse, via a CH-ports-unpublished compose override). Confirmed the exact failure mode is `503 breaker-open` in the sweep + missing self-telemetry trace, and confirmed the structural gap (sweep before seed). With the fix, the warmup runs cleanly and both tests pass (2.8m vs a 2.0m warm baseline — the delta is the warmup). The flake is CI-cold-start/contention-specific and does **not** reproduce on a fast local host, so this is validated by mechanism + CI, honestly not by a local red→green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)