### PR TITLE
docs(tempo): record the deliberate no-density-gate decision + pin phase-A narrowness

### DIFF
--- a/internal/api/tempo/handler.go
+++ b/internal/api/tempo/handler.go
@@ -424,6 +424,22 @@ func (h *Handler) handleSearch(w http.ResponseWriter, r *http.Request) {
 	// (CERBERUS_TEMPO_STRUCTURAL_TWO_PHASE=false) to fall back to the traditional
 	// single wide query — an escape hatch if a workload ever prefers the
 	// single-pass shape, or to bisect a regression to the two-phase path.
+	//
+	// Deliberately UNCONDITIONAL for every eligible shape — there is no density
+	// cost-gate that would run the single wide query when the descendant side
+	// "looks sparse". A gate was designed and rejected: the OOM variable is
+	// BYTES (matched-span-count × per-span attribute-map width), and every cheap
+	// signal available before the wide fetch (EXPLAIN ESTIMATE rows, system.parts
+	// row counts, count(), window×rate) measures ROWS, blind to fat maps. A
+	// selective-but-fat-map search — e.g. a few thousand error spans each
+	// carrying a ~60 KB stacktrace/body map — passes every row threshold and
+	// OOMs on the single query, reintroducing the exact crash this split fixed.
+	// Meanwhile phase A is already narrow + optimizer-bypassed + window-pruned +
+	// LIMIT-pushed (sub-second on a sparse side, with an empty-result
+	// short-circuit skipping phase B), so a gate would save little for a large
+	// safety risk. A future gate must key off a BYTE-cost signal (column
+	// statistics), not row counts — see TestPhaseAStaysNarrow, which pins the
+	// narrowness this "no gate needed" reasoning rests on.
 	var res engine.Result
 	if sj, ok := structuralTwoPhaseTarget(plan); ok && h.StructuralTwoPhase {
 		res, err = h.runStructuralTwoPhase(ctx, sj, plan, meta, limit)

--- a/internal/api/tempo/phase_a_narrow_test.go
+++ b/internal/api/tempo/phase_a_narrow_test.go
@@ -1,0 +1,61 @@
+package tempo
+
+import (
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestPhaseAStaysNarrow pins the invariant the two-phase cost model — and the
+// deliberate decision NOT to add a density cost-gate (see the handler decision
+// point) — depends on: buildStructuralPhaseAPlan strips the wide attribute-map
+// columns from EVERY structural join (the root AND the inner closures of a
+// chain) and preserves the request window, so phase A stays a narrow,
+// window-pruned rank. If a future change widens phase A's projection or drops
+// its window, the always-paid phase-A overhead inflates and the "phase A is
+// already cheap, no gate needed" reasoning silently breaks — this pin fails
+// first.
+func TestPhaseAStaysNarrow(t *testing.T) {
+	s := schema.DefaultOTelTraces()
+	const wStart, wEnd = int64(1_000), int64(2_000)
+
+	// The wide projection every join starts with — exactly the fat maps the OOM
+	// came from; phase A must drop them down to Timestamp only.
+	wide := []string{"ResourceAttributes", "SpanAttributes"}
+	scan := func() chplan.Node { return &chplan.Scan{Table: s.SpansTable} }
+	mkJoin := func(l, r chplan.Node) *chplan.StructuralJoin {
+		return &chplan.StructuralJoin{
+			Left: l, Right: r, Op: chplan.StructuralDescendant,
+			TraceIDColumn:          s.TraceIDColumn,
+			SpanIDColumn:           s.SpanIDColumn,
+			ParentSpanIDColumn:     s.ParentSpanIDColumn,
+			TimestampColumn:        s.TimestampColumn,
+			WindowStartNano:        wStart,
+			WindowEndNano:          wEnd,
+			ExtraProjectionColumns: wide,
+		}
+	}
+	// `A >> B >> C` is left-associative: root.Left is itself a StructuralJoin, so
+	// eachStructuralJoin must narrow the inner closure, not only the root.
+	inner := mkJoin(scan(), scan())
+	root := mkJoin(inner, scan())
+
+	phaseA := buildStructuralPhaseAPlan(root, s, 5)
+
+	joins := 0
+	eachStructuralJoin(phaseA, func(j *chplan.StructuralJoin) {
+		joins++
+		if len(j.ExtraProjectionColumns) != 1 || j.ExtraProjectionColumns[0] != s.TimestampColumn {
+			t.Errorf("phase-A join projects %v, want narrow [%q] only — wide attribute maps leaked into the rank",
+				j.ExtraProjectionColumns, s.TimestampColumn)
+		}
+		if j.WindowStartNano != wStart || j.WindowEndNano != wEnd {
+			t.Errorf("phase-A join lost its window: got [%d,%d], want [%d,%d] — phase A must stay partition-pruned",
+				j.WindowStartNano, j.WindowEndNano, wStart, wEnd)
+		}
+	})
+	if joins != 2 {
+		t.Fatalf("expected buildStructuralPhaseAPlan to narrow 2 structural joins (root + inner closure), walked %d", joins)
+	}
+}


### PR DESCRIPTION
**Phase 2 outcome: don't build the density cost-gate.** A multi-agent design pass (6 approaches, adversarially scored on OOM-safety) reached a clear verdict, and this lands its two durable artifacts.

### Why no gate
The gate's job would be to single-query when the descendant side "looks sparse" and skip the extra phase-A round-trip. But the OOM variable is **bytes** (matched-span-count × per-span attribute-map width), and every cheap pre-fetch signal — `EXPLAIN ESTIMATE` rows, `system.parts` row counts, `count()`, window×rate — measures **rows**, blind to fat maps. A selective-but-fat-map search (a few thousand error spans each carrying a ~60 KB stacktrace/body map) passes every row threshold and **OOMs on the single query**, reintroducing the exact crash the split fixed.

Adversarial scores (safety / latency / simplicity):

| approach | safety | verdict |
|---|---|---|
| explain-estimate | 2 | reject (rows≠bytes) |
| metadata-probe | 2 | reject |
| window-heuristic | 2 | reject |
| learned-autotune | 2 | reject (danger direction reversed vs PromQL autotune) |
| count-aware phase-A | 4 | safe but inert (never skips → saves nothing) |
| **no-gate** | **5** | **recommend** |

The safe designs all save ~nothing precisely because they never take the skip. Meanwhile phase A is already narrow + optimizer-bypassed + window-pruned + LIMIT-pushed (sub-second on a sparse side). Small uncertain win vs. a wrong-direction that is an OOM → loses on safety-first.

### What lands
- **Doc comment** at the routing point recording the rows-vs-bytes rationale, so the missing gate isn't "fixed" later. A real gate must key off a byte-cost signal (column statistics), not row counts.
- **`TestPhaseAStaysNarrow`** — pins that `buildStructuralPhaseAPlan` strips the wide maps from every structural join (root + inner closures) and keeps the window: the "phase A is cheap" premise the deferral rests on. Proven non-vacuous (fails when a wide column leaks).

No routing change — Phase-1's unconditional A≡B + trace-restriction bound holds verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)