### PR TITLE
fix(tempo): bound the wide-projection drain with a fail-closed byte budget

### DIFF
--- a/internal/api/tempo/export_test.go
+++ b/internal/api/tempo/export_test.go
@@ -27,7 +27,3 @@ var (
 	GroupBatchesForTest      = groupBatches
 	GroupBatchesProtoForTest = groupBatchesProto
 )
-
-// SetDrainBytesLimitForTest sets the wide-projection byte ceiling used by a
-// search drain, so a test can trip the fail-closed gate on a modest fixture.
-func (h *Handler) SetDrainBytesLimitForTest(n int64) { h.drainBytesLimit = n }

--- a/internal/api/tempo/export_test.go
+++ b/internal/api/tempo/export_test.go
@@ -27,3 +27,7 @@ var (
 	GroupBatchesForTest      = groupBatches
 	GroupBatchesProtoForTest = groupBatchesProto
 )
+
+// SetDrainBytesLimitForTest sets the wide-projection byte ceiling used by a
+// search drain, so a test can trip the fail-closed gate on a modest fixture.
+func (h *Handler) SetDrainBytesLimitForTest(n int64) { h.drainBytesLimit = n }

--- a/internal/api/tempo/grpc/export_test.go
+++ b/internal/api/tempo/grpc/export_test.go
@@ -1,0 +1,6 @@
+package grpc
+
+// MapEngineErrorForTest exposes mapEngineError to the external grpc_test package
+// so the resource-exhausted / invalid-argument classification can be pinned
+// without standing up a full streaming RPC.
+var MapEngineErrorForTest = mapEngineError

--- a/internal/api/tempo/grpc/map_engine_error_test.go
+++ b/internal/api/tempo/grpc/map_engine_error_test.go
@@ -1,0 +1,32 @@
+package grpc_test
+
+import (
+	"errors"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/tsouza/cerberus/internal/api/tempo/grpc"
+	"github.com/tsouza/cerberus/internal/chclient"
+)
+
+// TestMapEngineError_ResourceExhaustedFamily pins that the per-query resource
+// budgets map to codes.ResourceExhausted (the gRPC sibling of HTTP 422),
+// symmetric with the HTTP head's classifySearchErr — not a misleading Internal.
+func TestMapEngineError_ResourceExhaustedFamily(t *testing.T) {
+	t.Parallel()
+	for _, err := range []error{
+		&chclient.DrainByteBudgetError{Limit: 256 << 20},
+		&chclient.TooManySamplesError{Limit: 3},
+	} {
+		got := status.Code(grpc.MapEngineErrorForTest(err))
+		if got != codes.ResourceExhausted {
+			t.Errorf("mapEngineError(%v) code = %v, want ResourceExhausted", err, got)
+		}
+	}
+	// A generic error still maps to Internal.
+	if got := status.Code(grpc.MapEngineErrorForTest(errors.New("boom"))); got != codes.Internal {
+		t.Errorf("generic error code = %v, want Internal", got)
+	}
+}

--- a/internal/api/tempo/grpc/search.go
+++ b/internal/api/tempo/grpc/search.go
@@ -103,6 +103,12 @@ func (s *Service) Search(req *tempopb.SearchRequest, stream tempopb.StreamingQue
 		start = end.Add(-tempo.DefaultSearchLookback)
 	}
 	ctx = traceql.WithSearchWindow(ctx, start, end)
+	// Attach the wide-projection byte budget — the SAME fail-closed Go-heap cap
+	// the HTTP handler applies. Without it the gRPC Search path drained the wide
+	// ResourceAttributes+SpanAttributes maps unbounded (the recursive two-phase
+	// split only fires on HTTP), so a fat-map search OOM'd here even though the
+	// byte-identical HTTP query is bounded. Charged per-span during the drain.
+	ctx = chclient.WithDrainByteBudget(ctx, chclient.NewTempoSpanDrainBudget())
 
 	// Open the streaming cursor against the lowered TraceQL plan.
 	// cursor.Close is deferred so a client cancellation (ctx.Done()
@@ -205,6 +211,15 @@ func mapEngineError(err error) error {
 		return status.Errorf(codes.Unavailable, "%v", err)
 	case errors.Is(err, tempo.ErrParseStage), errors.Is(err, tempo.ErrLowerStage):
 		return status.Errorf(codes.InvalidArgument, "%v", err)
+	// Resource-exhausted family — the per-query budgets (row-count sample budget,
+	// wide-projection byte budget) and the CH memory-limit abort. All are
+	// "the query asked for too much", not an outage, so ResourceExhausted (the
+	// gRPC sibling of HTTP 422 — see classifySearchErr), symmetric with the HTTP
+	// head rather than a misleading Internal.
+	case errors.Is(err, chclient.ErrTooManySamples),
+		errors.Is(err, chclient.ErrDrainBytesExceeded),
+		errors.Is(err, chclient.ErrMemoryLimitExceeded):
+		return status.Errorf(codes.ResourceExhausted, "%v", err)
 	}
 	return status.Errorf(codes.Internal, "%v", err)
 }

--- a/internal/api/tempo/handler.go
+++ b/internal/api/tempo/handler.go
@@ -137,6 +137,12 @@ type Handler struct {
 	// false every search takes the traditional single wide query. New() defaults
 	// it true; cmd/ overrides from config.
 	StructuralTwoPhase bool
+
+	// drainBytesLimit overrides the wide-projection byte ceiling for a search
+	// drain. 0 (production) uses chclient's internal default const; tests set it
+	// small to trip the fail-closed gate on a modest fat-map fixture. Not wired
+	// to any env/config — deliberately not an operator knob.
+	drainBytesLimit int64
 }
 
 // New constructs a Handler with the seed optimizer wired in.
@@ -402,6 +408,20 @@ func (h *Handler) handleSearch(w http.ResponseWriter, r *http.Request) {
 	// Thread the request window so stampSearchTraceLimit folds it into the
 	// bounded plain-search scan. No-op when both bounds are absent.
 	ctx = traceql_lower.WithSearchWindow(ctx, start, end)
+	// Attach the wide-projection byte budget: a fail-closed cap on the cumulative
+	// ResourceAttributes+SpanAttributes bytes this search may drain into the Go
+	// heap. It is the byte axis every trace-count / time / row bound misses — a
+	// selective-but-fat-map search heaps gigabytes under all of them. Charged
+	// per-span during the drain (chclient cursor), so it aborts before the full
+	// wide set materialises. Scoped to the span-search path here; PromQL/LogQL
+	// drains never see it.
+	byteBudget := chclient.NewTempoSpanDrainBudget()
+	if h.drainBytesLimit > 0 {
+		// Test seam only (0 in production → the internal default const). Not an
+		// env/config knob: there is no per-deployment override to mis-set.
+		byteBudget = chclient.NewDrainByteBudget(h.drainBytesLimit)
+	}
+	ctx = chclient.WithDrainByteBudget(ctx, byteBudget)
 	// Parse + lower first so the handler can inspect the lowered plan and
 	// route the execution. h.lang.Parse runs the TraceQL parser + traceql.Lower
 	// (with the request window / trace-limit folds already applied via the ctx
@@ -519,6 +539,11 @@ func classifySearchErr(err error) int {
 	// instead of a breaker-adjacent 5xx. The error body carries the
 	// chclient budget message including the configured limit.
 	case errors.Is(err, chclient.ErrTooManySamples):
+		return http.StatusUnprocessableEntity
+	// Wide-projection byte budget: the byte-axis sibling of the sample budget —
+	// the search's cumulative attribute-map bytes crossed the Go-heap ceiling. A
+	// resource rejection, 422 like the row budget above.
+	case errors.Is(err, chclient.ErrDrainBytesExceeded):
 		return http.StatusUnprocessableEntity
 	// ClickHouse memory-limit abort (code 241) — the server-side
 	// sibling of the sample budget: a per-query resource rejection,

--- a/internal/api/tempo/handler.go
+++ b/internal/api/tempo/handler.go
@@ -137,12 +137,6 @@ type Handler struct {
 	// false every search takes the traditional single wide query. New() defaults
 	// it true; cmd/ overrides from config.
 	StructuralTwoPhase bool
-
-	// drainBytesLimit overrides the wide-projection byte ceiling for a search
-	// drain. 0 (production) uses chclient's internal default const; tests set it
-	// small to trip the fail-closed gate on a modest fat-map fixture. Not wired
-	// to any env/config — deliberately not an operator knob.
-	drainBytesLimit int64
 }
 
 // New constructs a Handler with the seed optimizer wired in.
@@ -360,6 +354,20 @@ func TruncateSummaries(summaries []TraceSummary, missing []string, limit int) ([
 	return summaries, filtered
 }
 
+// withSpanDrainBudget attaches the fail-closed wide-projection byte budget to
+// ctx — a cap on the cumulative ResourceAttributes+SpanAttributes bytes a span
+// drain may buffer into the Go heap before aborting. It is the byte axis every
+// trace-count / time / row bound misses (a selective-but-fat-map drain heaps
+// gigabytes under all of them); charged per unique span in the chclient cursor,
+// so the drain aborts before the full wide set materialises. EVERY Tempo drain
+// that projects the wide maps — /api/search, /api/search/recent, and
+// /api/traces/{id} — routes through this one helper so no wide-map drain is left
+// uncharged (trace-by-id folds the full per-span SpanAttributes and is the
+// fattest of them).
+func (h *Handler) withSpanDrainBudget(ctx context.Context) context.Context {
+	return chclient.WithDrainByteBudget(ctx, chclient.NewTempoSpanDrainBudget())
+}
+
 func (h *Handler) handleSearch(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query().Get("q")
 	if q == "" {
@@ -408,20 +416,7 @@ func (h *Handler) handleSearch(w http.ResponseWriter, r *http.Request) {
 	// Thread the request window so stampSearchTraceLimit folds it into the
 	// bounded plain-search scan. No-op when both bounds are absent.
 	ctx = traceql_lower.WithSearchWindow(ctx, start, end)
-	// Attach the wide-projection byte budget: a fail-closed cap on the cumulative
-	// ResourceAttributes+SpanAttributes bytes this search may drain into the Go
-	// heap. It is the byte axis every trace-count / time / row bound misses — a
-	// selective-but-fat-map search heaps gigabytes under all of them. Charged
-	// per-span during the drain (chclient cursor), so it aborts before the full
-	// wide set materialises. Scoped to the span-search path here; PromQL/LogQL
-	// drains never see it.
-	byteBudget := chclient.NewTempoSpanDrainBudget()
-	if h.drainBytesLimit > 0 {
-		// Test seam only (0 in production → the internal default const). Not an
-		// env/config knob: there is no per-deployment override to mis-set.
-		byteBudget = chclient.NewDrainByteBudget(h.drainBytesLimit)
-	}
-	ctx = chclient.WithDrainByteBudget(ctx, byteBudget)
+	ctx = h.withSpanDrainBudget(ctx)
 	// Parse + lower first so the handler can inspect the lowered plan and
 	// route the execution. h.lang.Parse runs the TraceQL parser + traceql.Lower
 	// (with the request window / trace-limit folds already applied via the ctx
@@ -679,7 +674,7 @@ func (h *Handler) handleSearchRecent(w http.ResponseWriter, r *http.Request) {
 	}
 	plan = &chplan.Limit{Input: plan, Count: limit}
 
-	ctx := r.Context()
+	ctx := h.withSpanDrainBudget(r.Context())
 	// /search/recent doesn't go through a parser, so use QueryPlan
 	// directly. IsTraceByID stays false: the OrderBy+Limit shape
 	// benefits from the seed optimizer's projection-pushdown pass.
@@ -768,7 +763,9 @@ func (h *Handler) serveTraceByID(w http.ResponseWriter, r *http.Request, v2 bool
 	// `if !meta.IsTraceByID` branch). The wrap-projection still runs
 	// via Lang.ProjectSamples so the chclient.Sample shape is
 	// canonical before emit.
-	ctx := r.Context()
+	// Trace-by-id folds the FULL per-span SpanAttributes map into the projection
+	// (the fattest wide drain), so it must carry the byte budget too.
+	ctx := h.withSpanDrainBudget(r.Context())
 	res, err := h.Engine.QueryPlan(ctx, h.lang, plan, engine.Meta{
 		IsTraceByID:   true,
 		ResponseShape: "tempo-trace",

--- a/internal/api/tempo/handler_drain_byte_budget_test.go
+++ b/internal/api/tempo/handler_drain_byte_budget_test.go
@@ -1,0 +1,33 @@
+package tempo_test
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+)
+
+// TestSearch_DrainByteBudget422 — when the wide-projection byte budget aborts the
+// span drain, the Tempo HTTP head must answer 422 (a resource rejection peer to
+// the sample budget), never a 5xx. The charge itself is proven on the production
+// rowsCursor in chclient; this pins the handler's error classification.
+func TestSearch_DrainByteBudget422(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{err: &chclient.DrainByteBudgetError{Limit: 256 << 20}}
+	srv := newServer(q, "v-test")
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/search/recent")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusUnprocessableEntity {
+		t.Fatalf("status: got %d (body %q), want 422", resp.StatusCode, body)
+	}
+	if !strings.Contains(body, "budget") {
+		t.Fatalf("body %q does not carry the byte-budget message", body)
+	}
+}

--- a/internal/api/tempo/handler_drain_byte_budget_test.go
+++ b/internal/api/tempo/handler_drain_byte_budget_test.go
@@ -2,11 +2,40 @@ package tempo_test
 
 import (
 	"net/http"
+	"net/url"
 	"strings"
 	"testing"
 
 	"github.com/tsouza/cerberus/internal/chclient"
 )
+
+// TestSearch_AttachesByteBudget_NoBypass is the no-bypass ratchet: EVERY Tempo
+// drain endpoint that projects the wide attribute maps must attach the drain
+// byte budget to its query context. A new endpoint that drains wide maps without
+// routing through withSpanDrainBudget would leave that path uncharged (exactly
+// how /api/traces/{id} was missed in review) — this fails if any listed
+// endpoint stops attaching it.
+func TestSearch_AttachesByteBudget_NoBypass(t *testing.T) {
+	t.Parallel()
+	for _, ep := range []string{
+		"/api/search?q=" + url.QueryEscape("{}"),
+		"/api/search/recent",
+		"/api/traces/0000000000000000000000000000000a",
+	} {
+		q := &stubQuerier{}
+		srv := newServer(q, "v-test")
+		resp, err := http.Get(srv.URL + ep)
+		if err != nil {
+			srv.Close()
+			t.Fatalf("GET %s: %v", ep, err)
+		}
+		resp.Body.Close()
+		srv.Close()
+		if !q.sawByteBudget {
+			t.Errorf("%s did not attach the wide-projection drain byte budget — a wide-map drain would run uncharged", ep)
+		}
+	}
+}
 
 // TestSearch_DrainByteBudget422 — when the wide-projection byte budget aborts the
 // span drain, the Tempo HTTP head must answer 422 (a resource rejection peer to

--- a/internal/api/tempo/handler_test.go
+++ b/internal/api/tempo/handler_test.go
@@ -39,12 +39,19 @@ type stubQuerier struct {
 	// arrival order. Lets tests assert that BOTH the matrix and the
 	// exemplars queries actually fired.
 	queriedSQLs []string
+	// sawByteBudget records whether the ctx passed to Query carried the
+	// wide-projection drain byte budget — lets the no-bypass ratchet test
+	// assert every wide-map drain endpoint attaches it.
+	sawByteBudget bool
 }
 
-func (s *stubQuerier) Query(_ context.Context, sql string, args ...any) ([]chclient.Sample, error) {
+func (s *stubQuerier) Query(ctx context.Context, sql string, args ...any) ([]chclient.Sample, error) {
 	s.lastSQL = sql
 	s.lastArgs = args
 	s.queriedSQLs = append(s.queriedSQLs, sql)
+	if chclient.DrainByteBudgetFromContext(ctx) != nil {
+		s.sawByteBudget = true
+	}
 	if s.err != nil {
 		return nil, s.err
 	}

--- a/internal/chclient/columnar.go
+++ b/internal/chclient/columnar.go
@@ -252,6 +252,7 @@ type columnarCursor struct {
 
 	budget         *SampleBudget
 	byteBudget     *DrainByteBudget
+	byteChargedSeq uint32
 	maxSamples     int64
 	maxMemoryBytes int64
 	queryTimeout   time.Duration
@@ -359,15 +360,17 @@ func (d *columnarCursor) decodeBlock(cols matrixCols, rows int) error {
 			curInterned, curID = d.interner.internLabels(curLabels)
 			prevStart, prevEnd = start, end
 			haveSeries = true
-			// Charge the newly-built unique attribute map against the Tempo
-			// wide-projection byte budget (nil off the span-search path, so
-			// PromQL/LogQL drains are untouched). Charging per UNIQUE interned
-			// map — not per row — measures the true Go-heap cost: aliased rows
-			// share the map. Fail-closed the instant the running total crosses
-			// the ceiling, before the full wide set materialises.
-			if d.byteBudget != nil && !d.byteBudget.consume(labelMapBytes(curInterned)) {
-				d.err = &DrainByteBudgetError{Limit: d.byteBudget.Limit()}
-				return errBudgetExceeded
+			// Charge the Tempo wide-projection byte budget once per UNIQUE series
+			// (nil off the span-search path). The sameSpan pre-check above
+			// rebuilds curLabels every row (Map offsets advance per row), so gate
+			// the charge on the monotonic series ordinal — NOT the rebuild — to
+			// match rowsCursor and avoid per-row over-counting of a shared map.
+			if d.byteBudget != nil && curID > d.byteChargedSeq {
+				d.byteChargedSeq = curID
+				if !d.byteBudget.consume(labelMapBytes(curInterned)) {
+					d.err = &DrainByteBudgetError{Limit: d.byteBudget.Limit()}
+					return errBudgetExceeded
+				}
 			}
 		}
 		d.samples = append(d.samples, Sample{

--- a/internal/chclient/columnar.go
+++ b/internal/chclient/columnar.go
@@ -168,6 +168,7 @@ func (d columnarDecoder) queryCursorColumnar(c *Client, ctx context.Context, sql
 
 	dec := &columnarCursor{
 		budget:         budgetFromContext(ctx),
+		byteBudget:     drainByteBudgetFromContext(ctx),
 		maxSamples:     c.maxSamples,
 		maxMemoryBytes: c.maxMemory,
 		queryTimeout:   c.effectiveQueryTimeout(ctx),
@@ -250,6 +251,7 @@ type columnarCursor struct {
 	interner rowsCursor
 
 	budget         *SampleBudget
+	byteBudget     *DrainByteBudget
 	maxSamples     int64
 	maxMemoryBytes int64
 	queryTimeout   time.Duration
@@ -357,6 +359,16 @@ func (d *columnarCursor) decodeBlock(cols matrixCols, rows int) error {
 			curInterned, curID = d.interner.internLabels(curLabels)
 			prevStart, prevEnd = start, end
 			haveSeries = true
+			// Charge the newly-built unique attribute map against the Tempo
+			// wide-projection byte budget (nil off the span-search path, so
+			// PromQL/LogQL drains are untouched). Charging per UNIQUE interned
+			// map — not per row — measures the true Go-heap cost: aliased rows
+			// share the map. Fail-closed the instant the running total crosses
+			// the ceiling, before the full wide set materialises.
+			if d.byteBudget != nil && !d.byteBudget.consume(labelMapBytes(curInterned)) {
+				d.err = &DrainByteBudgetError{Limit: d.byteBudget.Limit()}
+				return errBudgetExceeded
+			}
 		}
 		d.samples = append(d.samples, Sample{
 			MetricName: cols.name.Row(r),

--- a/internal/chclient/cursor.go
+++ b/internal/chclient/cursor.go
@@ -126,6 +126,15 @@ type rowsCursor struct {
 	// A crossing yields the IDENTICAL *TooManySamplesError (errors.Is
 	// ErrTooManySamples) the per-cursor limit produces.
 	budget *SampleBudget
+	// byteBudget is the wide-projection byte budget (nil off the Tempo
+	// span-search path, so PromQL/LogQL drains are untouched). Charged once
+	// per UNIQUE interned series — the true Go-heap cost, since aliased rows
+	// share one map. A crossing yields a *DrainByteBudgetError.
+	byteBudget *DrainByteBudget
+	// byteChargedSeq is the highest series ordinal already charged against
+	// byteBudget. A new series' SeriesID exceeds it (internSeq is monotonic);
+	// a repeat returns a lower ordinal and is not re-charged.
+	byteChargedSeq uint32
 	// seen counts rows successfully decoded so far, compared against
 	// maxSamples after each scan.
 	seen int64
@@ -258,6 +267,19 @@ func (c *rowsCursor) Next() bool {
 		return false
 	}
 	s.Labels, s.SeriesID = c.internLabels(labels)
+	// Charge the wide-projection byte budget once per UNIQUE series: a new
+	// SeriesID exceeds every ordinal charged so far, while a repeat aliases an
+	// already-charged map (charging repeats would over-count the shared heap and
+	// wrongly reject a legitimate many-identical-spans result). Fail-closed the
+	// instant cumulative attribute-map bytes cross the ceiling — before the full
+	// wide set buffers into the Go heap.
+	if c.byteBudget != nil && s.SeriesID > c.byteChargedSeq {
+		c.byteChargedSeq = s.SeriesID
+		if !c.byteBudget.consume(labelMapBytes(s.Labels)) {
+			c.err = &DrainByteBudgetError{Limit: c.byteBudget.Limit()}
+			return false
+		}
+	}
 	// Per-row structured metadata is genuinely distinct per log line
 	// (durations, byte counts, query ids), so it is NOT interned — unlike
 	// the series-identity Labels map. The fifth column arrives as a JSON

--- a/internal/chclient/decoder.go
+++ b/internal/chclient/decoder.go
@@ -121,6 +121,7 @@ func (rowDecoder) decode(c *Client, ctx context.Context, sql string, args ...any
 		maxMemoryBytes: c.maxMemory,
 		queryTimeout:   c.effectiveQueryTimeout(ctx),
 		budget:         budgetFromContext(ctx),
+		byteBudget:     drainByteBudgetFromContext(ctx),
 	}, nil
 }
 

--- a/internal/chclient/drain_byte_budget.go
+++ b/internal/chclient/drain_byte_budget.go
@@ -22,11 +22,14 @@ import (
 // drain, so the Go-heap high-water is bounded to the ceiling plus one CH block
 // — the full wide set never materialises first.
 //
-// 256 MiB matches maxLogPeekBytes (the Loki line-peek sibling). It is a byte
-// count of attribute-map key+value lengths, so a legitimate result would need a
-// genuinely enormous matched-span × map-width product to approach it; the
-// compatibility/tempo corpus pass confirms no valid Matched set does before this
-// ceiling ships.
+// 256 MiB matches maxLogPeekBytes (the Loki line-peek sibling). The ceiling sits
+// at the OOM-adjacent point, not a query-restrictive one — TestDrainByteBudget_
+// CeilingHeadroom measures the real charge: a 1000-trace / 20-service search
+// charges ~16 KB (17,000× margin, because resource attrs intern and share), and
+// a realistic 10k-distinct-attr-span trace-by-id charges ~12 MiB (21× margin).
+// To reach 256 MiB a trace needs ~200k+ spans or genuinely fat attrs — i.e. it
+// already holds 256+ MiB of attribute maps on the heap, the OOM itself. So a
+// crossing 422s only an OOM-scale query, never a servable one.
 const maxTempoSpanDrainBytes = 256 << 20
 
 // ErrDrainBytesExceeded is the sentinel matched (via errors.Is) when a Tempo
@@ -61,6 +64,11 @@ type DrainByteBudget struct {
 	// limit is the original ceiling, carried so a *DrainByteBudgetError can
 	// report the configured cap rather than the residual.
 	limit int64
+	// peak is the high-water of cumulative charged bytes over the request's
+	// lifetime — the actual Go-heap the wide projection reached. Readable after
+	// a drain (Peak) so an observe-only rollout / e2e can report the real charge
+	// distribution and confirm the ceiling is never legitimately approached.
+	peak atomic.Int64
 }
 
 // NewDrainByteBudget returns a budget admitting up to max wide-projection bytes
@@ -89,7 +97,27 @@ func (b *DrainByteBudget) consume(n int64) bool {
 	if b == nil || b.limit <= 0 {
 		return true
 	}
-	return b.remaining.Add(-n) >= 0
+	rem := b.remaining.Add(-n)
+	// Record the high-water (best-effort monotonic CAS) even on the crossing
+	// draw, so Peak reflects how far over the ceiling the request reached.
+	charged := b.limit - rem
+	for {
+		p := b.peak.Load()
+		if charged <= p || b.peak.CompareAndSwap(p, charged) {
+			break
+		}
+	}
+	return rem >= 0
+}
+
+// Peak returns the high-water of cumulative charged bytes over the request — the
+// actual Go-heap the wide projection reached, for observability. 0 on a nil or
+// inert budget.
+func (b *DrainByteBudget) Peak() int64 {
+	if b == nil {
+		return 0
+	}
+	return b.peak.Load()
 }
 
 // Limit returns the configured ceiling (0 on a nil budget), carried so the

--- a/internal/chclient/drain_byte_budget.go
+++ b/internal/chclient/drain_byte_budget.go
@@ -130,14 +130,31 @@ func drainByteBudgetFromContext(ctx context.Context) *DrainByteBudget {
 	return b
 }
 
-// labelMapBytes returns the on-heap byte width of a decoded attribute map: the
-// sum of every key and value string length. It is the per-span wide-projection
-// cost the byte budget charges — the same Map(String,String) key/value bytes
-// ClickHouse materialised and streamed, which the Go heap then holds.
+// perMapEntryHeapBytes approximates the Go-runtime heap the cursor RETAINS per
+// attribute-map entry beyond the raw string content: two ~16-byte string headers
+// (key + value) plus amortised map-bucket overhead. Included so the byte ceiling
+// tracks the real Go-heap high-water rather than just the wire content — a
+// content-only count under-charges the retained heap several-fold and would fire
+// the gate well past the memory it is meant to bound.
+const perMapEntryHeapBytes = 48
+
+// DrainByteBudgetFromContext returns the *DrainByteBudget attached to ctx by
+// WithDrainByteBudget, or nil. Exported so the Tempo handler tests can confirm
+// every wide-map drain endpoint attaches the budget (the no-bypass ratchet).
+func DrainByteBudgetFromContext(ctx context.Context) *DrainByteBudget {
+	return drainByteBudgetFromContext(ctx)
+}
+
+// labelMapBytes returns the on-heap byte width the cursor RETAINS for one unique
+// interned attribute map. That is NOT just the key/value content: internLabels
+// also retains a canonicalLabelKey string of the same content per unique series,
+// and each entry carries Go map-header + string-header overhead. So the charge
+// is ~2× the content (map + canonical-key duplicate) plus per-entry overhead —
+// a deliberately conservative estimate of the true retained heap.
 func labelMapBytes(m map[string]string) int64 {
-	var n int64
+	var content int64
 	for k, v := range m {
-		n += int64(len(k)) + int64(len(v))
+		content += int64(len(k)) + int64(len(v))
 	}
-	return n
+	return content*2 + int64(len(m))*perMapEntryHeapBytes
 }

--- a/internal/chclient/drain_byte_budget.go
+++ b/internal/chclient/drain_byte_budget.go
@@ -1,0 +1,143 @@
+package chclient
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+)
+
+// maxTempoSpanDrainBytes hard-caps the cumulative wide-projection bytes — the
+// ResourceAttributes + SpanAttributes maps, folded into Sample.Labels — that a
+// single Tempo /api/search (or gRPC Search) drain may buffer into the Go heap
+// before the cursor aborts fail-closed.
+//
+// It is the byte axis that every other Tempo bound structurally misses: the
+// two-phase split and the trace-limit pushdown cap the TRACE count, the
+// resource-bound gate caps TIME (partition prune), and MaxQuerySamples caps
+// ROWS — but the OOM cost is BYTES = matched-span-count × per-span-map-width. A
+// selective-but-fat-map search (a few thousand error spans each carrying a
+// ~60 KB stacktrace/body map) sails under every row/trace/time threshold and
+// heaps gigabytes. This budget is charged INCREMENTALLY during the streaming
+// drain, so the Go-heap high-water is bounded to the ceiling plus one CH block
+// — the full wide set never materialises first.
+//
+// 256 MiB matches maxLogPeekBytes (the Loki line-peek sibling). It is a byte
+// count of attribute-map key+value lengths, so a legitimate result would need a
+// genuinely enormous matched-span × map-width product to approach it; the
+// compatibility/tempo corpus pass confirms no valid Matched set does before this
+// ceiling ships.
+const maxTempoSpanDrainBytes = 256 << 20
+
+// ErrDrainBytesExceeded is the sentinel matched (via errors.Is) when a Tempo
+// span drain crosses its cumulative wide-projection byte budget. It maps to the
+// same resource-exhausted rejection (Tempo 422) as ErrTooManySamples — the
+// byte-axis sibling of the row-axis sample budget, and the Go-heap sibling of
+// the CH-side max_memory_usage cap.
+var ErrDrainBytesExceeded = errors.New("tempo span drain byte budget exceeded")
+
+// DrainByteBudgetError wraps ErrDrainBytesExceeded and names the configured
+// ceiling, mirroring *TooManySamplesError so the handler + gRPC error mappers
+// classify it in the same resource-exhausted branch.
+type DrainByteBudgetError struct{ Limit int64 }
+
+func (e *DrainByteBudgetError) Error() string {
+	return fmt.Sprintf("tempo span drain exceeded the %d-byte wide-projection budget", e.Limit)
+}
+
+func (e *DrainByteBudgetError) Unwrap() error { return ErrDrainBytesExceeded }
+
+// DrainByteBudget is a per-REQUEST cap on the cumulative wide-projection bytes a
+// Tempo span search may drain across all its cursors — the byte-axis sibling of
+// SampleBudget. It is attached to the request context by the Tempo read path
+// ONLY (WithDrainByteBudget), so the cursor charges bytes for span searches and
+// leaves every PromQL / LogQL drain untouched (no budget on the context → no
+// charge). Lifecycle: born and dies with one request, no cross-request state.
+type DrainByteBudget struct {
+	// remaining is the wide-projection bytes the request may still drain
+	// across all its cursors. Decremented atomically as each unique decoded
+	// attribute map is charged; the limit is crossed when it would go negative.
+	remaining atomic.Int64
+	// limit is the original ceiling, carried so a *DrainByteBudgetError can
+	// report the configured cap rather than the residual.
+	limit int64
+}
+
+// NewDrainByteBudget returns a budget admitting up to max wide-projection bytes
+// across every cursor of one request. A non-positive max is inert (never
+// consulted) — see drainByteBudgetFromContext.
+func NewDrainByteBudget(max int64) *DrainByteBudget {
+	b := &DrainByteBudget{limit: max}
+	b.remaining.Store(max)
+	return b
+}
+
+// NewTempoSpanDrainBudget returns the default-on wide-projection byte budget for
+// a Tempo span search, sized to maxTempoSpanDrainBytes. The Tempo read path
+// attaches it to every span-search request context so the const stays internal
+// to chclient (no exported knob, no per-request override — the fixed default-on
+// ratchet).
+func NewTempoSpanDrainBudget() *DrainByteBudget { return NewDrainByteBudget(maxTempoSpanDrainBytes) }
+
+// consume draws n wide-projection bytes against the shared budget. Returns true
+// when the draw fits and false when it would cross the ceiling — at which point
+// the caller aborts iteration with a *DrainByteBudgetError{Limit: b.Limit()}.
+// A non-positive limit is "unlimited". The decrement is atomic so concurrent
+// shard cursors share the counter without a lock; once negative it stays
+// tripped for every later consume.
+func (b *DrainByteBudget) consume(n int64) bool {
+	if b == nil || b.limit <= 0 {
+		return true
+	}
+	return b.remaining.Add(-n) >= 0
+}
+
+// Limit returns the configured ceiling (0 on a nil budget), carried so the
+// over-budget error names the cap rather than the residual.
+func (b *DrainByteBudget) Limit() int64 {
+	if b == nil {
+		return 0
+	}
+	return b.limit
+}
+
+// active reports whether the budget carries a positive limit and should be
+// consulted. A non-positive limit is inert.
+func (b *DrainByteBudget) active() bool { return b != nil && b.limit > 0 }
+
+// drainByteBudgetKey is the unexported context key under which a
+// *DrainByteBudget travels.
+type drainByteBudgetKey struct{}
+
+// WithDrainByteBudget attaches b to ctx so every cursor the Tempo span request
+// opens shares b's counter. Cursors opened from a context WITHOUT a budget (the
+// PromQL / LogQL paths) never charge bytes.
+func WithDrainByteBudget(ctx context.Context, b *DrainByteBudget) context.Context {
+	return context.WithValue(ctx, drainByteBudgetKey{}, b)
+}
+
+// drainByteBudgetFromContext returns the *DrainByteBudget attached to ctx, or
+// nil when none is present or the attached one is inert. A nil result means
+// "do not charge bytes on this drain".
+func drainByteBudgetFromContext(ctx context.Context) *DrainByteBudget {
+	if ctx == nil {
+		return nil
+	}
+	b, _ := ctx.Value(drainByteBudgetKey{}).(*DrainByteBudget)
+	if !b.active() {
+		return nil
+	}
+	return b
+}
+
+// labelMapBytes returns the on-heap byte width of a decoded attribute map: the
+// sum of every key and value string length. It is the per-span wide-projection
+// cost the byte budget charges — the same Map(String,String) key/value bytes
+// ClickHouse materialised and streamed, which the Go heap then holds.
+func labelMapBytes(m map[string]string) int64 {
+	var n int64
+	for k, v := range m {
+		n += int64(len(k)) + int64(len(v))
+	}
+	return n
+}

--- a/internal/chclient/drain_byte_budget_ceiling_test.go
+++ b/internal/chclient/drain_byte_budget_ceiling_test.go
@@ -1,0 +1,68 @@
+package chclient
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestDrainByteBudget_CeilingHeadroom is the corpus-floor validation: it measures
+// the ACTUAL charge (via Peak) for realistic search and trace-by-id workloads
+// through the production rowsCursor, grounding the 256 MiB ceiling. Search stays
+// KB-scale (resource attrs intern/share); a large 10k-distinct-attr-span trace
+// stays comfortably under the ceiling. So the ceiling 422s only genuinely
+// OOM-scale traces (100k+ fat spans) — never a servable query.
+func TestDrainByteBudget_CeilingHeadroom(t *testing.T) {
+	t.Parallel()
+	measure := func(rows []Sample) int64 {
+		b := NewDrainByteBudget(1 << 40) // effectively unlimited: measure, don't trip
+		cur := &rowsCursor{rows: &freshLabelRows{rows: rows}, byteBudget: b}
+		for cur.Next() {
+		}
+		if err := cur.Err(); err != nil {
+			t.Fatalf("measure drain: %v", err)
+		}
+		return b.Peak()
+	}
+	const ceiling = maxTempoSpanDrainBytes
+
+	// SEARCH scale: 1000 result traces but only ~20 distinct services — resource
+	// attrs are shared and interned, so unique-series count is the service count,
+	// not the trace count.
+	resAttrs := func(svc int) map[string]string {
+		return map[string]string{
+			"service.name": fmt.Sprintf("svc-%d", svc), "service.namespace": "prod",
+			"k8s.pod.name": fmt.Sprintf("pod-%d-7f9c8b", svc), "k8s.namespace.name": "default",
+			"host.name": fmt.Sprintf("node-%d.internal", svc), "telemetry.sdk.language": "go",
+			"telemetry.sdk.name": "opentelemetry", "deployment.environment": "production",
+		}
+	}
+	searchRows := make([]Sample, 1000)
+	for i := range searchRows {
+		searchRows[i] = Sample{MetricName: "s", Labels: resAttrs(i % 20), Timestamp: time.Unix(int64(i), 0), Value: 1}
+	}
+	searchPeak := measure(searchRows)
+	t.Logf("SEARCH  (1000 traces / 20 services): peak=%d B (%.4f MiB) — ceiling %d MiB, margin %.0fx",
+		searchPeak, float64(searchPeak)/(1<<20), ceiling>>20, float64(ceiling)/float64(searchPeak))
+	if searchPeak > ceiling/100 {
+		t.Errorf("search peak %d B exceeds 1%% of ceiling — expected a huge margin", searchPeak)
+	}
+
+	// TRACE-BY-ID scale: one large trace, 10k spans each with a DISTINCT ~450 B
+	// span-attr map (http/db attrs, not interned).
+	spanRows := make([]Sample, 10000)
+	for i := range spanRows {
+		spanRows[i] = Sample{MetricName: "s", Timestamp: time.Unix(int64(i), 0), Value: 1, Labels: map[string]string{
+			"span.kind": "server", "http.method": "GET", "http.status_code": "200",
+			"http.route":   fmt.Sprintf("/api/v1/resource/%d/detail", i),
+			"db.statement": fmt.Sprintf("SELECT * FROM t WHERE id=%d AND %s", i, strings.Repeat("x", 380)),
+		}}
+	}
+	tracePeak := measure(spanRows)
+	t.Logf("TRACE   (10k distinct-attr spans):   peak=%d B (%.1f MiB) — ceiling %d MiB, margin %.1fx",
+		tracePeak, float64(tracePeak)/(1<<20), ceiling>>20, float64(ceiling)/float64(tracePeak))
+	if tracePeak > ceiling {
+		t.Errorf("realistic 10k-span trace peak %d B exceeds the ceiling — a legitimate trace would be 422'd", tracePeak)
+	}
+}

--- a/internal/chclient/drain_byte_budget_cursor_test.go
+++ b/internal/chclient/drain_byte_budget_cursor_test.go
@@ -1,0 +1,134 @@
+package chclient
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fatSample builds a Sample whose Labels map carries a distinct ~valueBytes
+// payload (distinct so each interns to a unique series and is charged once).
+func fatSample(i, valueBytes int) Sample {
+	return Sample{
+		MetricName: "s",
+		Labels:     map[string]string{"payload": fmt.Sprintf("%d-%s", i, strings.Repeat("x", valueBytes))},
+		Timestamp:  time.Unix(0, 0),
+		Value:      1,
+	}
+}
+
+// TestRowsCursor_DrainByteBudget_TripsMidStream proves the wide-projection byte
+// charge fires on the PRODUCTION rowsCursor drain and aborts fail-closed BEFORE
+// buffering the full result — the core of the OOM class fix. Non-vacuity is the
+// paired control: the same rows under a huge ceiling drain fully with no error.
+func TestRowsCursor_DrainByteBudget_TripsMidStream(t *testing.T) {
+	t.Parallel()
+	const valueBytes = 1000
+	mkRows := func() *freshLabelRows {
+		return &freshLabelRows{rows: []Sample{
+			fatSample(1, valueBytes), fatSample(2, valueBytes),
+			fatSample(3, valueBytes), fatSample(4, valueBytes),
+		}}
+	}
+
+	// Control: a ceiling far above the cumulative bytes → full drain, no error.
+	full := &rowsCursor{rows: mkRows(), byteBudget: NewDrainByteBudget(1 << 20)}
+	defer func() { _ = full.Close() }()
+	var drained int
+	for full.Next() {
+		drained++
+	}
+	if err := full.Err(); err != nil {
+		t.Fatalf("control drain errored: %v", err)
+	}
+	if drained != 4 {
+		t.Fatalf("control drained %d rows, want 4 — fixture did not fully drain under a huge ceiling", drained)
+	}
+
+	// Trip: a ceiling below the cumulative (~4×1007) but above a single map
+	// (~1007) → the drain crosses it mid-stream.
+	trip := &rowsCursor{rows: mkRows(), byteBudget: NewDrainByteBudget(2500)}
+	defer func() { _ = trip.Close() }()
+	var got int
+	for trip.Next() {
+		got++
+	}
+	err := trip.Err()
+	if !errors.Is(err, ErrDrainBytesExceeded) {
+		t.Fatalf("Err = %v, want ErrDrainBytesExceeded", err)
+	}
+	var be *DrainByteBudgetError
+	if !errors.As(err, &be) || be.Limit != 2500 {
+		t.Fatalf("want *DrainByteBudgetError{Limit:2500}, got %+v", err)
+	}
+	if got >= 4 {
+		t.Errorf("drained %d rows before aborting, want < 4 (must abort before full materialisation)", got)
+	}
+}
+
+// TestRowsCursor_DrainByteBudget_PerUniqueSeries proves the charge is per UNIQUE
+// interned series, not per row: many rows aliasing ONE fat map cost one map on
+// the heap and must NOT trip a ceiling just above that single map. Charging
+// per-row would wrongly reject this legitimate many-identical-spans result.
+func TestRowsCursor_DrainByteBudget_PerUniqueSeries(t *testing.T) {
+	t.Parallel()
+	shared := map[string]string{"payload": strings.Repeat("x", 1000)}
+	rows := make([]Sample, 100)
+	for i := range rows {
+		// Same map CONTENTS every row → interns to one series after the first.
+		rows[i] = Sample{MetricName: "s", Labels: shared, Timestamp: time.Unix(int64(i), 0), Value: 1}
+	}
+	// Ceiling just above one map (~1007) but far below 100×1007: per-row charging
+	// would trip; per-unique must not.
+	cur := &rowsCursor{rows: &freshLabelRows{rows: rows}, byteBudget: NewDrainByteBudget(2000)}
+	defer func() { _ = cur.Close() }()
+	var drained int
+	for cur.Next() {
+		drained++
+	}
+	if err := cur.Err(); err != nil {
+		t.Fatalf("per-unique drain errored (%v) — the charge over-counted aliased rows", err)
+	}
+	if drained != 100 {
+		t.Fatalf("drained %d rows, want 100 — aliased rows should share one charge", drained)
+	}
+}
+
+func TestDrainByteBudget_ConsumeAndContext(t *testing.T) {
+	t.Parallel()
+	b := NewDrainByteBudget(100)
+	if !b.consume(60) || !b.consume(40) {
+		t.Fatal("consume within limit returned false")
+	}
+	if b.consume(1) {
+		t.Fatal("consume past limit returned true")
+	}
+	// Inert (non-positive) budget is never consulted.
+	if inert := NewDrainByteBudget(0); !inert.consume(1_000_000) {
+		t.Fatal("inert budget consumed")
+	}
+	// Context round-trip: attached active budget comes back; inert one reads nil.
+	ctx := WithDrainByteBudget(context.Background(), NewDrainByteBudget(5))
+	if drainByteBudgetFromContext(ctx) == nil {
+		t.Fatal("active budget not retrieved from context")
+	}
+	if drainByteBudgetFromContext(WithDrainByteBudget(context.Background(), NewDrainByteBudget(0))) != nil {
+		t.Fatal("inert budget must read back nil")
+	}
+	if drainByteBudgetFromContext(context.Background()) != nil {
+		t.Fatal("no budget must read back nil")
+	}
+}
+
+func TestLabelMapBytes(t *testing.T) {
+	t.Parallel()
+	if got := labelMapBytes(map[string]string{"ab": "cde", "f": "g"}); got != 2+3+1+1 {
+		t.Fatalf("labelMapBytes = %d, want 7", got)
+	}
+	if got := labelMapBytes(nil); got != 0 {
+		t.Fatalf("labelMapBytes(nil) = %d, want 0", got)
+	}
+}

--- a/internal/chclient/drain_byte_budget_cursor_test.go
+++ b/internal/chclient/drain_byte_budget_cursor_test.go
@@ -83,7 +83,7 @@ func TestRowsCursor_DrainByteBudget_PerUniqueSeries(t *testing.T) {
 	}
 	// Ceiling just above one map (~1007) but far below 100×1007: per-row charging
 	// would trip; per-unique must not.
-	cur := &rowsCursor{rows: &freshLabelRows{rows: rows}, byteBudget: NewDrainByteBudget(2000)}
+	cur := &rowsCursor{rows: &freshLabelRows{rows: rows}, byteBudget: NewDrainByteBudget(5000)}
 	defer func() { _ = cur.Close() }()
 	var drained int
 	for cur.Next() {
@@ -125,8 +125,8 @@ func TestDrainByteBudget_ConsumeAndContext(t *testing.T) {
 
 func TestLabelMapBytes(t *testing.T) {
 	t.Parallel()
-	if got := labelMapBytes(map[string]string{"ab": "cde", "f": "g"}); got != 2+3+1+1 {
-		t.Fatalf("labelMapBytes = %d, want 7", got)
+	if got := labelMapBytes(map[string]string{"ab": "cde", "f": "g"}); got != 7*2+2*48 {
+		t.Fatalf("labelMapBytes = %d, want 110", got)
 	}
 	if got := labelMapBytes(nil); got != 0 {
 		t.Fatalf("labelMapBytes(nil) = %d, want 0", got)


### PR DESCRIPTION
**The class fix for the TraceQL wide-projection OOM.** A multi-agent audit found Phase 1's two-phase split closed only a slice: **25 shapes across both transports** still materialize the wide `ResourceAttributes`+`SpanAttributes` projection unbounded — direct/negated/union structural joins (ineligible for the recursive two-phase), `| select` (strips the trace-limit pushdown), multi-`select`/Filter-wrapped recursive, set operations, the **fat-single-trace `{}`** (trace-limit caps traces, never spans-per-trace), and the **entire gRPC Search path** (never two-phased — asymmetric with HTTP).

### Root cause
Every existing bound caps the wrong axis: trace count (two-phase, trace-limit), time (resource-bound gate), or rows (the prod-unset sample budget). The OOM cost is **bytes** = matched-span-count × per-span-map-width, and nothing measured bytes at the one chokepoint every shape funnels through — the `[]chclient.Sample` cursor drain.

### The fix (one gate)
A cumulative wide-projection **byte budget** charged incrementally on the cursor drain — the byte-axis sibling of the row-count `SampleBudget`, the Go-heap sibling of CH's `max_memory_usage`. Charged **once per unique interned map** (aliased rows share the heap; per-row charging would false-fire a legitimate many-identical-spans result). Fail-closes with **422 / ResourceExhausted** the instant cumulative map bytes cross a fixed **256 MiB** ceiling — *before* the full wide set buffers. Indifferent to plan shape and transport: both `handler.go` and `grpc/search.go` attach it and drain the same cursor. Default-on, **no operator knob** (no prod-unset footgun). Also fixes a latent gap — gRPC `mapEngineError` mapped budget errors to `Internal`, now `ResourceExhausted`, symmetric with HTTP.

### Tests
The charge is proven on the **production `rowsCursor`**: trips mid-stream, control drains fully, per-unique-series avoids false-firing (non-vacuous), plus budget arithmetic/context and both error mappings. Honest limitation: the chdb harness uses an in-memory `sliceCursor` that bypasses `rowsCursor` (same reason the existing sample-budget tests stub their error), so the end-to-end trip is proven at the cursor level; the handler→cursor threading rides the exact same context plumbing as the shipped `SampleBudget`.

### Follow-up (PR-2)
Per-shape integration fixtures (direct/`select`/set-op/fat-trace/gRPC) on the Docker lane, the fail-closed ratchet meta-test (both drains route through the byte-charged cursor), and the compatibility/tempo corpus pass to confirm no legitimate Matched set approaches 256 MiB.

Holding for adversarial review before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)