### PR TITLE
feat(tempo): extend the structural two-phase split to the gRPC Search path

### DIFF
--- a/internal/api/tempo/grpc/map_engine_error_test.go
+++ b/internal/api/tempo/grpc/map_engine_error_test.go
@@ -44,8 +44,12 @@ func TestMapEngineError_ContextErrors(t *testing.T) {
 		want codes.Code
 	}{
 		{context.Canceled, codes.Canceled},
-		{context.DeadlineExceeded, codes.DeadlineExceeded},
+		// Deadline + CH wall-clock timeout both map to Unavailable (the gRPC 503),
+		// symmetric with HTTP classifySearchErr which maps both to 503.
+		{context.DeadlineExceeded, codes.Unavailable},
+		{chclient.ErrQueryTimeout, codes.Unavailable},
 		{fmt.Errorf("engine: execute: %w", context.Canceled), codes.Canceled},
+		{fmt.Errorf("engine: execute: %w", chclient.ErrQueryTimeout), codes.Unavailable},
 	}
 	for _, tc := range cases {
 		if got := status.Code(grpc.MapEngineErrorForTest(tc.err)); got != tc.want {

--- a/internal/api/tempo/grpc/map_engine_error_test.go
+++ b/internal/api/tempo/grpc/map_engine_error_test.go
@@ -1,7 +1,9 @@
 package grpc_test
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"google.golang.org/grpc/codes"
@@ -28,5 +30,26 @@ func TestMapEngineError_ResourceExhaustedFamily(t *testing.T) {
 	// A generic error still maps to Internal.
 	if got := status.Code(grpc.MapEngineErrorForTest(errors.New("boom"))); got != codes.Internal {
 		t.Errorf("generic error code = %v, want Internal", got)
+	}
+}
+
+// TestMapEngineError_ContextErrors pins that cancellation / deadline — now
+// surfaced at the eager SearchResult boundary (the old streaming path caught it
+// per-row) — maps to the proper gRPC status, including through the engine's
+// `execute: %w` wrap, not a misleading Internal.
+func TestMapEngineError_ContextErrors(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		err  error
+		want codes.Code
+	}{
+		{context.Canceled, codes.Canceled},
+		{context.DeadlineExceeded, codes.DeadlineExceeded},
+		{fmt.Errorf("engine: execute: %w", context.Canceled), codes.Canceled},
+	}
+	for _, tc := range cases {
+		if got := status.Code(grpc.MapEngineErrorForTest(tc.err)); got != tc.want {
+			t.Errorf("mapEngineError(%v) code = %v, want %v", tc.err, got, tc.want)
+		}
 	}
 }

--- a/internal/api/tempo/grpc/search.go
+++ b/internal/api/tempo/grpc/search.go
@@ -1,6 +1,7 @@
 package grpc
 
 import (
+	"context"
 	"errors"
 	"strconv"
 	"time"
@@ -110,40 +111,19 @@ func (s *Service) Search(req *tempopb.SearchRequest, stream tempopb.StreamingQue
 	// byte-identical HTTP query is bounded. Charged per-span during the drain.
 	ctx = chclient.WithDrainByteBudget(ctx, chclient.NewTempoSpanDrainBudget())
 
-	// Open the streaming cursor against the lowered TraceQL plan.
-	// cursor.Close is deferred so a client cancellation (ctx.Done()
-	// fires through QueryCursor's progress-context) propagates into
-	// the CH driver — same pattern as Loki's /tail and Prom's
-	// /query_range chunked path.
-	res, err := s.Handler.Engine.QueryCursor(ctx, s.Handler.Lang(), req.Query)
+	// Route through the SAME two-phase-aware entry point the HTTP head uses, so a
+	// recursive structural query is bounded to the top-N traces here too — it used
+	// to drain in FULL because the two-phase split was HTTP-only (the byte budget
+	// above only fail-closed it). Eager, not streaming: the shaper below already
+	// needs the full sample set to group spans by TraceID, so gRPC never streamed
+	// on the Go heap anyway; the byte budget still charges the drain, and the
+	// two-phase split shrinks it to the response traces. Cancellation now surfaces
+	// at the query boundary (mapEngineError maps ctx errors below).
+	res, err := s.Handler.SearchResult(ctx, req.Query, limit)
 	if err != nil {
 		return mapEngineError(err)
 	}
-	defer func() { _ = res.Cursor.Close() }()
-
-	// Drain the cursor into a samples slice. The toTraceSummaries
-	// shaper requires the full result set to group spans by TraceID;
-	// the gRPC frame batching kicks in on the post-shaped summary
-	// list (so frames carry whole-trace summaries, not partial spans).
-	// Cancellation through ctx surfaces as cursor.Next returning false
-	// + cursor.Err returning the wrapped context error.
-	samples := make([]chclient.Sample, 0, 64)
-	for res.Cursor.Next() {
-		samples = append(samples, res.Cursor.Sample())
-		// Honour context cancellation between rows so a client
-		// disconnect mid-drain doesn't block on CH back-pressure.
-		if err := ctx.Err(); err != nil {
-			return status.FromContextError(err).Err()
-		}
-	}
-	if err := res.Cursor.Err(); err != nil {
-		// A cerberus-side outcome surfacing during the drain: a sample-budget 422
-		// (the CH query finished cleanly, cost retained + exit overridden) or a
-		// memory-cap abort (recorded terminally so the corpus does not depend on
-		// the query_log join). Stamp it onto the corpus record for this dispatch.
-		s.Handler.Engine.ObserveDrainOutcome(res.QueryID, "traceql", err)
-		return mapEngineError(err)
-	}
+	samples := res.Samples
 
 	// Honour the request's SpansPerSpanSet + Limit the same way the
 	// HTTP handler honours `spss` + `limit` (zero values fall back to
@@ -207,6 +187,11 @@ func mapEngineError(err error) error {
 		return nil
 	}
 	switch {
+	// Client cancellation / deadline: the eager SearchResult surfaces it at the
+	// query boundary (the old streaming path caught it per-row via ctx.Err). Map
+	// to the proper gRPC status, not a misleading Internal.
+	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+		return status.FromContextError(err).Err()
 	case errors.Is(err, chclient.ErrCircuitOpen):
 		return status.Errorf(codes.Unavailable, "%v", err)
 	case errors.Is(err, tempo.ErrParseStage), errors.Is(err, tempo.ErrLowerStage):

--- a/internal/api/tempo/grpc/search.go
+++ b/internal/api/tempo/grpc/search.go
@@ -187,11 +187,16 @@ func mapEngineError(err error) error {
 		return nil
 	}
 	switch {
-	// Client cancellation / deadline: the eager SearchResult surfaces it at the
-	// query boundary (the old streaming path caught it per-row via ctx.Err). Map
-	// to the proper gRPC status, not a misleading Internal.
-	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+	// Client cancellation: the eager SearchResult surfaces it at the query
+	// boundary (the old streaming path caught it per-row via ctx.Err).
+	case errors.Is(err, context.Canceled):
 		return status.FromContextError(err).Err()
+	// Timeout family — a CH wall-clock cap (ErrQueryTimeout, code 159) or a ctx
+	// deadline. HTTP classifySearchErr maps BOTH to 503; codes.Unavailable is the
+	// gRPC 503 (transient, retryable), so the two heads stay symmetric. Without
+	// the ErrQueryTimeout case it fell through to a misleading Internal.
+	case errors.Is(err, chclient.ErrQueryTimeout), errors.Is(err, context.DeadlineExceeded):
+		return status.Errorf(codes.Unavailable, "%v", err)
 	case errors.Is(err, chclient.ErrCircuitOpen):
 		return status.Errorf(codes.Unavailable, "%v", err)
 	case errors.Is(err, tempo.ErrParseStage), errors.Is(err, tempo.ErrLowerStage):

--- a/internal/api/tempo/grpc/search_test.go
+++ b/internal/api/tempo/grpc/search_test.go
@@ -41,31 +41,31 @@ type stubCursorQuerier struct {
 	// real root span. Empty / nil here means "no roots to patch",
 	// matching the steady-state happy path.
 	rootSamples []chclient.Sample
-	// closed flips to 1 once the cursor's Close has been invoked.
-	// Tests assert against it to prove that cancellation reached the
-	// streaming cursor.
-	closed atomic.Int32
-	// lastSQL captures the SQL the engine handed the cursor open call,
-	// so window-threading tests can assert the emitted scan is windowed
-	// (the gRPC mirror of the HTTP stubQuerier.lastSQL convention).
-	lastSQL string
-	// lastArgs captures the bound parameters alongside lastSQL — the
-	// windowed Timestamp bounds ride here as int64 nanos (the SQL
-	// carries `fromUnixTimestamp64Nano(?)` placeholders), so explicit-
-	// window tests assert the supplied bounds reached the query verbatim.
+	// lastSQL / lastArgs capture what the eager search Query received, so
+	// window-threading tests can assert the emitted scan is windowed.
+	lastSQL  string
 	lastArgs []any
-	// phaseAStrings records QueryStrings calls — phase A of the structural
-	// two-phase emits its top-N ranking via QueryStrings, so a non-empty slice
-	// proves a gRPC structural search ROUTED through the two-phase split.
+	// phaseAStrings records QueryStrings calls; phaseAIDs is what it returns.
+	// A non-empty phaseAStrings proves a gRPC structural search ROUTED through
+	// the two-phase split; setting phaseAIDs lets phase B run end-to-end.
 	phaseAStrings []string
+	phaseAIDs     []string
+	// block makes Query wait for ctx cancellation then return ctx.Err(); released
+	// records it observed the cancellation — so a cancellation test proves the
+	// client cancel propagated through SearchResult -> QueryPlan -> Query.
+	block    bool
+	released atomic.Bool
 }
 
-func (s *stubCursorQuerier) Query(_ context.Context, sql string, args ...any) ([]chclient.Sample, error) {
-	// Search now routes through the eager SearchResult -> Engine.QueryPlan ->
-	// Query (the streaming QueryCursor path is gone), so this method serves the
-	// main search rows. The follow-up root lookup (resolveTraceRoots) emits
-	// argMinIf(...); serve rootSamples for it and capture lastSQL only for the
-	// main query, matching what QueryCursor used to record.
+func (s *stubCursorQuerier) Query(ctx context.Context, sql string, args ...any) ([]chclient.Sample, error) {
+	if s.block {
+		<-ctx.Done()
+		s.released.Store(true)
+		return nil, ctx.Err()
+	}
+	// The eager search routes here (the streaming QueryCursor path is gone). The
+	// follow-up root lookup (resolveTraceRoots) emits argMinIf(...); serve
+	// rootSamples for it and the main search rows otherwise.
 	if strings.Contains(sql, "argMinIf") {
 		return s.rootSamples, nil
 	}
@@ -76,50 +76,8 @@ func (s *stubCursorQuerier) Query(_ context.Context, sql string, args ...any) ([
 
 func (s *stubCursorQuerier) QueryStrings(_ context.Context, sql string, _ ...any) ([]string, error) {
 	s.phaseAStrings = append(s.phaseAStrings, sql)
-	return nil, nil
+	return s.phaseAIDs, nil
 }
-
-func (s *stubCursorQuerier) QueryCursor(ctx context.Context, sql string, args ...any) (chclient.Cursor, error) {
-	s.lastSQL = sql
-	s.lastArgs = args
-	return &stubCursor{rows: s.rows, ctx: ctx, closed: &s.closed}, nil
-}
-
-// stubCursor walks rowsByQuery one Sample at a time. Honours ctx
-// cancellation so the gRPC Search RPC can prove that a client
-// disconnect mid-stream surfaces as a cursor termination.
-type stubCursor struct {
-	rows   []chclient.Sample
-	i      int
-	cur    chclient.Sample
-	err    error
-	ctx    context.Context
-	closed *atomic.Int32
-}
-
-func (c *stubCursor) Next() bool {
-	// Mid-iteration context cancellation: shortcut Next to surface the
-	// ctx error via Err(). Matches the rowsCursor production shape
-	// where a cancelled driver.Rows reports its cause through Err.
-	if err := c.ctx.Err(); err != nil {
-		c.err = err
-		return false
-	}
-	if c.i >= len(c.rows) {
-		return false
-	}
-	c.cur = c.rows[c.i]
-	c.i++
-	return true
-}
-
-func (c *stubCursor) Sample() chclient.Sample { return c.cur }
-func (c *stubCursor) Err() error              { return c.err }
-func (c *stubCursor) Close() error {
-	c.closed.Store(1)
-	return nil
-}
-func (c *stubCursor) Inspected() int64 { return int64(c.i) }
 
 // makeSearchRow returns one synthetic chclient.Sample shaped like the
 // canonical wrap-projection output: MetricName carries SpanName, the
@@ -396,33 +354,16 @@ func TestSearch_TraceMetadataPivot(t *testing.T) {
 	}
 }
 
-// TestSearch_CancellationPropagatesToCursor wires a slow synthetic
-// cursor (1 row every 50ms), cancels the client context mid-stream,
-// and asserts that cursor.Close was invoked. This is the proof that
-// gRPC stream context cancellation flows through to the CH cursor's
-// resource-release path — the property the design-doc §4 calls out
-// as "Cancellation: stream.Context() cancels on client disconnect;
-// pass into Engine.QueryPlanCursor."
-func TestSearch_CancellationTerminatesStream(t *testing.T) {
+// TestSearch_CancellationReachesQuery proves a client cancellation propagates
+// through the eager SearchResult -> Engine.QueryPlan -> Query drain (the
+// coverage the removed gRPC-owned cursor used to give). The stub Query BLOCKS
+// until its ctx is cancelled, so the test asserts BOTH that the stream
+// terminates promptly AND that the server's Query observed the cancellation
+// (released): a broken cancellation path would hang and leave released false.
+func TestSearch_CancellationReachesQuery(t *testing.T) {
 	t.Parallel()
-	// Enough rows that no realistic in-flight drain ends before the test
-	// cancels — we want the cancel to be observable, not a race with the
-	// natural end-of-stream. Search now routes through the shared eager
-	// SearchResult (not a gRPC-owned cursor), so cancellation propagates
-	// through the ctx to the CH driver inside the engine; the gRPC-observable
-	// contract is that the stream TERMINATES PROMPTLY on cancel (no hang), which
-	// this asserts. The ctx-error → gRPC-status mapping is pinned separately in
-	// TestMapEngineError_ContextErrors.
-	rows := make([]chclient.Sample, 0, 1000)
-	ts := time.Now()
-	for i := 0; i < 1000; i++ {
-		rows = append(rows, makeSearchRow(padHexTraceID(i), "GET /api", "svc", ts, 1))
-	}
-	q := &slowCursorQuerier{
-		stubCursorQuerier: stubCursorQuerier{rows: rows},
-		rowDelay:          20 * time.Millisecond,
-	}
-	client, cleanup := dialServer(t, &q.stubCursorQuerier)
+	q := &stubCursorQuerier{block: true}
+	client, cleanup := dialServer(t, q)
 	t.Cleanup(cleanup)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -430,7 +371,6 @@ func TestSearch_CancellationTerminatesStream(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open stream: %v", err)
 	}
-
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
@@ -449,6 +389,21 @@ func TestSearch_CancellationTerminatesStream(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatalf("stream did not terminate after cancel")
 	}
+	if !waitForBool(&q.released, time.Second) {
+		t.Error("server Query never observed ctx cancellation — not propagated to the eager drain")
+	}
+}
+
+// waitForBool polls an atomic.Bool until true or the deadline elapses.
+func waitForBool(b *atomic.Bool, deadline time.Duration) bool {
+	end := time.Now().Add(deadline)
+	for time.Now().Before(end) {
+		if b.Load() {
+			return true
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return b.Load()
 }
 
 // TestSearch_WindowlessDefaultsLookback_SQLShape proves the gRPC
@@ -560,46 +515,6 @@ func TestSearch_ExplicitWindow_Honored(t *testing.T) {
 			sawStart, sawEnd, q.lastArgs)
 	}
 }
-
-// slowCursorQuerier is stubCursorQuerier with a delay between
-// Next() calls so the CancellationPropagatesToCursor test has
-// enough wall-clock to interrupt mid-stream. The embedded
-// stubCursorQuerier carries the rows + closed-counter; the delay
-// is layered on by wrapping QueryCursor's returned cursor.
-type slowCursorQuerier struct {
-	stubCursorQuerier
-	rowDelay time.Duration
-}
-
-func (s *slowCursorQuerier) QueryCursor(ctx context.Context, _ string, _ ...any) (chclient.Cursor, error) {
-	return &slowCursor{
-		stubCursor: stubCursor{rows: s.rows, ctx: ctx, closed: &s.closed},
-		delay:      s.rowDelay,
-	}, nil
-}
-
-type slowCursor struct {
-	stubCursor
-	delay time.Duration
-}
-
-func (c *slowCursor) Next() bool {
-	if c.i > 0 {
-		// Honour ctx cancellation while sleeping so the cancel
-		// propagates promptly (a naked time.Sleep wouldn't return).
-		select {
-		case <-time.After(c.delay):
-		case <-c.ctx.Done():
-			c.err = c.ctx.Err()
-			return false
-		}
-	}
-	return c.stubCursor.Next()
-}
-
-func (c *slowCursor) Sample() chclient.Sample { return c.stubCursor.Sample() }
-func (c *slowCursor) Err() error              { return c.stubCursor.Err() }
-func (c *slowCursor) Close() error            { return c.stubCursor.Close() }
 
 // TestSearch_ParseErrorMapsToInvalidArgument confirms the gRPC error-
 // mapping table from the design doc §3: a TraceQL parser failure
@@ -738,7 +653,17 @@ func TestSearch_SpanSetsLimitAndSpss(t *testing.T) {
 // the result is empty — we assert the ROUTING, not the rows.)
 func TestSearch_StructuralRoutesTwoPhase(t *testing.T) {
 	t.Parallel()
-	q := &stubCursorQuerier{}
+	ts := time.Now()
+	// phaseAIDs = the top-N ranking phase A returns (non-empty so phase B runs);
+	// rows = the wide phase-B hydrate for those traces. Proves the split runs
+	// END-TO-END over gRPC, not just that phase A fires.
+	q := &stubCursorQuerier{
+		phaseAIDs: []string{padHexTraceID(1), padHexTraceID(2)},
+		rows: []chclient.Sample{
+			makeSearchRow(padHexTraceID(1), "op", "a", ts, 1),
+			makeSearchRow(padHexTraceID(2), "op", "a", ts, 1),
+		},
+	}
 	client, cleanup := dialServer(t, q)
 	t.Cleanup(cleanup)
 	stream, err := client.Search(context.Background(), &tempopb.SearchRequest{
@@ -748,10 +673,20 @@ func TestSearch_StructuralRoutesTwoPhase(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open stream: %v", err)
 	}
-	if _, err := drainSearch(t, stream); err != nil {
+	frames, err := drainSearch(t, stream)
+	if err != nil {
 		t.Fatalf("drain: %v", err)
 	}
+	// Phase A fired — routed through the two-phase split, not a single wide query.
 	if len(q.phaseAStrings) == 0 {
-		t.Error("gRPC structural search did not route through the two-phase split (phase A / QueryStrings never fired)")
+		t.Fatal("gRPC structural search did not route through the two-phase split (phase A never fired)")
+	}
+	// Phase B hydrated + shaped end-to-end into trace summaries over the stream.
+	traces := 0
+	for _, f := range frames {
+		traces += len(f.Traces)
+	}
+	if traces != 2 {
+		t.Errorf("gRPC structural two-phase returned %d traces, want 2 (phase B did not hydrate+shape end-to-end)", traces)
 	}
 }

--- a/internal/api/tempo/grpc/search_test.go
+++ b/internal/api/tempo/grpc/search_test.go
@@ -54,13 +54,28 @@ type stubCursorQuerier struct {
 	// carries `fromUnixTimestamp64Nano(?)` placeholders), so explicit-
 	// window tests assert the supplied bounds reached the query verbatim.
 	lastArgs []any
+	// phaseAStrings records QueryStrings calls — phase A of the structural
+	// two-phase emits its top-N ranking via QueryStrings, so a non-empty slice
+	// proves a gRPC structural search ROUTED through the two-phase split.
+	phaseAStrings []string
 }
 
-func (s *stubCursorQuerier) Query(_ context.Context, _ string, _ ...any) ([]chclient.Sample, error) {
-	return s.rootSamples, nil
+func (s *stubCursorQuerier) Query(_ context.Context, sql string, args ...any) ([]chclient.Sample, error) {
+	// Search now routes through the eager SearchResult -> Engine.QueryPlan ->
+	// Query (the streaming QueryCursor path is gone), so this method serves the
+	// main search rows. The follow-up root lookup (resolveTraceRoots) emits
+	// argMinIf(...); serve rootSamples for it and capture lastSQL only for the
+	// main query, matching what QueryCursor used to record.
+	if strings.Contains(sql, "argMinIf") {
+		return s.rootSamples, nil
+	}
+	s.lastSQL = sql
+	s.lastArgs = args
+	return s.rows, nil
 }
 
-func (s *stubCursorQuerier) QueryStrings(_ context.Context, _ string, _ ...any) ([]string, error) {
+func (s *stubCursorQuerier) QueryStrings(_ context.Context, sql string, _ ...any) ([]string, error) {
+	s.phaseAStrings = append(s.phaseAStrings, sql)
 	return nil, nil
 }
 
@@ -259,13 +274,11 @@ func TestSearch_FrameBatching(t *testing.T) {
 		t.Errorf("traces across frames: got %d, want %d", sum, total)
 	}
 
-	// Cursor.Close MUST be called by the Search handler so CH
-	// resources don't leak. Cancel the context first so any
-	// in-flight goroutine drains, then check.
+	// Release the stream ctx. Search now routes through the eager SearchResult
+	// (no gRPC-owned cursor to Close — CH resources are released inside the engine
+	// when Query returns); the wire contract this test pins is the frame batching
+	// above.
 	cancel()
-	if !waitForClose(&q.closed, time.Second) {
-		t.Errorf("cursor.Close was not invoked")
-	}
 }
 
 // TestSearch_EmptyResultSet asserts the zero-row happy path: a search
@@ -390,11 +403,16 @@ func TestSearch_TraceMetadataPivot(t *testing.T) {
 // resource-release path — the property the design-doc §4 calls out
 // as "Cancellation: stream.Context() cancels on client disconnect;
 // pass into Engine.QueryPlanCursor."
-func TestSearch_CancellationPropagatesToCursor(t *testing.T) {
+func TestSearch_CancellationTerminatesStream(t *testing.T) {
 	t.Parallel()
-	// Enough rows that no realistic in-flight drain ever exhausts the
-	// cursor before the test cancels — we want the cancel to be
-	// observable, not a race with the natural end-of-stream.
+	// Enough rows that no realistic in-flight drain ends before the test
+	// cancels — we want the cancel to be observable, not a race with the
+	// natural end-of-stream. Search now routes through the shared eager
+	// SearchResult (not a gRPC-owned cursor), so cancellation propagates
+	// through the ctx to the CH driver inside the engine; the gRPC-observable
+	// contract is that the stream TERMINATES PROMPTLY on cancel (no hang), which
+	// this asserts. The ctx-error → gRPC-status mapping is pinned separately in
+	// TestMapEngineError_ContextErrors.
 	rows := make([]chclient.Sample, 0, 1000)
 	ts := time.Now()
 	for i := 0; i < 1000; i++ {
@@ -413,8 +431,6 @@ func TestSearch_CancellationPropagatesToCursor(t *testing.T) {
 		t.Fatalf("open stream: %v", err)
 	}
 
-	// Pump the stream in a goroutine so we can cancel mid-drain and
-	// observe Close from the test thread.
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
@@ -425,7 +441,6 @@ func TestSearch_CancellationPropagatesToCursor(t *testing.T) {
 		}
 	}()
 
-	// Give the server a moment to start draining, then cancel.
 	time.Sleep(50 * time.Millisecond)
 	cancel()
 
@@ -433,10 +448,6 @@ func TestSearch_CancellationPropagatesToCursor(t *testing.T) {
 	case <-done:
 	case <-time.After(2 * time.Second):
 		t.Fatalf("stream did not terminate after cancel")
-	}
-
-	if !waitForClose(&q.closed, time.Second) {
-		t.Errorf("cursor.Close was not invoked after cancellation")
 	}
 }
 
@@ -590,20 +601,6 @@ func (c *slowCursor) Sample() chclient.Sample { return c.stubCursor.Sample() }
 func (c *slowCursor) Err() error              { return c.stubCursor.Err() }
 func (c *slowCursor) Close() error            { return c.stubCursor.Close() }
 
-// waitForClose polls the closed counter for up to deadline so the
-// test doesn't race the goroutine that owns the cursor. Returns true
-// once Close has been observed; false when the deadline expires.
-func waitForClose(c *atomic.Int32, deadline time.Duration) bool {
-	end := time.Now().Add(deadline)
-	for time.Now().Before(end) {
-		if c.Load() == 1 {
-			return true
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	return c.Load() == 1
-}
-
 // TestSearch_ParseErrorMapsToInvalidArgument confirms the gRPC error-
 // mapping table from the design doc §3: a TraceQL parser failure
 // surfaces as codes.InvalidArgument (user-facing query error), not
@@ -730,5 +727,31 @@ func TestSearch_SpanSetsLimitAndSpss(t *testing.T) {
 	// Legacy single-set field mirrors SpanSets[0].
 	if tr.SpanSet == nil || len(tr.SpanSet.Spans) != 1 || tr.SpanSet.Spans[0].SpanID != sp.SpanID {
 		t.Errorf("legacy SpanSet must mirror SpanSets[0]; got %+v", tr.SpanSet)
+	}
+}
+
+// TestSearch_StructuralRoutesTwoPhase is the non-vacuity pin: a recursive
+// structural query over gRPC must ROUTE through the same two-phase split as HTTP
+// (phase A ranks via QueryStrings), not silently fall through to a single wide
+// drain. Without the shared SearchResult wiring this passes vacuously; with it,
+// phase A fires. (Phase A returns no ids from the stub, so phase B is skipped and
+// the result is empty — we assert the ROUTING, not the rows.)
+func TestSearch_StructuralRoutesTwoPhase(t *testing.T) {
+	t.Parallel()
+	q := &stubCursorQuerier{}
+	client, cleanup := dialServer(t, q)
+	t.Cleanup(cleanup)
+	stream, err := client.Search(context.Background(), &tempopb.SearchRequest{
+		Query: `{ resource.service.name = "a" } >> { resource.service.name = "b" }`,
+		Limit: 5,
+	})
+	if err != nil {
+		t.Fatalf("open stream: %v", err)
+	}
+	if _, err := drainSearch(t, stream); err != nil {
+		t.Fatalf("drain: %v", err)
+	}
+	if len(q.phaseAStrings) == 0 {
+		t.Error("gRPC structural search did not route through the two-phase split (phase A / QueryStrings never fired)")
 	}
 }

--- a/internal/api/tempo/handler.go
+++ b/internal/api/tempo/handler.go
@@ -421,46 +421,10 @@ func (h *Handler) handleSearch(w http.ResponseWriter, r *http.Request) {
 	// route the execution. h.lang.Parse runs the TraceQL parser + traceql.Lower
 	// (with the request window / trace-limit folds already applied via the ctx
 	// above), so the returned plan is the same one Engine.Query would run — the
-	// split below is a routing decision, not a re-parse.
-	plan, meta, err := h.lang.Parse(ctx, q)
-	if err != nil {
-		writeError(w, classifySearchErr(err), "", "", err)
-		return
-	}
-	// A positive recursive structural search (`A >> B` / `A << B`) lowers to a
-	// WITH RECURSIVE closure INNER JOINed to the WIDE R projection; on a dense
-	// descendant side that projection materialises every matched span (hundreds
-	// of thousands) only to return the top-N traces — the prod OOM. Split it:
-	// phase A ranks narrowly to the top-N TraceIds, phase B re-runs the closure
-	// projecting wide but restricted to just those traces, bounding the wide
-	// projection to the response set. Every other search shape stays on the
-	// single-query path — byte-identical to today.
-	// The two-phase split is default-on but switchable off
-	// (CERBERUS_TEMPO_STRUCTURAL_TWO_PHASE=false) to fall back to the traditional
-	// single wide query — an escape hatch if a workload ever prefers the
-	// single-pass shape, or to bisect a regression to the two-phase path.
-	//
-	// Deliberately UNCONDITIONAL for every eligible shape — there is no density
-	// cost-gate that would run the single wide query when the descendant side
-	// "looks sparse". A gate was designed and rejected: the OOM variable is
-	// BYTES (matched-span-count × per-span attribute-map width), and every cheap
-	// signal available before the wide fetch (EXPLAIN ESTIMATE rows, system.parts
-	// row counts, count(), window×rate) measures ROWS, blind to fat maps. A
-	// selective-but-fat-map search — e.g. a few thousand error spans each
-	// carrying a ~60 KB stacktrace/body map — passes every row threshold and
-	// OOMs on the single query, reintroducing the exact crash this split fixed.
-	// Meanwhile phase A is already narrow + optimizer-bypassed + window-pruned +
-	// LIMIT-pushed (sub-second on a sparse side, with an empty-result
-	// short-circuit skipping phase B), so a gate would save little for a large
-	// safety risk. A future gate must key off a BYTE-cost signal (column
-	// statistics), not row counts — see TestPhaseAStaysNarrow, which pins the
-	// narrowness this "no gate needed" reasoning rests on.
-	var res engine.Result
-	if sj, ok := structuralTwoPhaseTarget(plan); ok && h.StructuralTwoPhase {
-		res, err = h.runStructuralTwoPhase(ctx, sj, plan, meta, limit)
-	} else {
-		res, err = h.Engine.QueryPlan(ctx, h.lang, plan, meta)
-	}
+	// One shared entry point (SearchResult) parses, routes the two-phase
+	// split, and executes — the SAME method the gRPC Search head calls, so the
+	// two transports cannot diverge on eligibility.
+	res, err := h.SearchResult(ctx, q, limit)
 	if err != nil {
 		writeError(w, classifySearchErr(err), "", "", err)
 		return

--- a/internal/api/tempo/structural_two_phase.go
+++ b/internal/api/tempo/structural_two_phase.go
@@ -77,6 +77,39 @@ func isPureSelectProjection(p *chplan.Project) bool {
 	return ok
 }
 
+// SearchResult parses, routes, and executes a /api/search query and returns the
+// eager engine.Result both Search transports shape into trace summaries. It is
+// the SINGLE place the structural two-phase split decision lives, so the HTTP and
+// gRPC heads physically cannot diverge — the HTTP-only two-phase gap this closes.
+// Callers apply toTraceSummaries / TruncateSummaries / spss over res.Samples.
+//
+// A positive recursive structural search (`A >> B` / `A << B`, plus negated
+// `!>>` / union `&>>`) lowers to a WITH RECURSIVE closure INNER JOINed to the
+// WIDE R projection; on a dense descendant side that projection materialises
+// every matched span only to return the top-N traces — the prod OOM. Split it:
+// phase A ranks narrowly to the top-N TraceIds, phase B re-runs the closure
+// projecting wide but restricted to just those traces. Every other shape stays
+// on the single-query path — byte-identical to today.
+//
+// Default-on, switchable off (CERBERUS_TEMPO_STRUCTURAL_TWO_PHASE=false).
+// Deliberately UNCONDITIONAL for every eligible shape — no density cost-gate:
+// the OOM variable is BYTES (matched-span-count × per-span map width), and every
+// cheap pre-fetch signal measures ROWS, blind to fat maps, so a selective-but-
+// fat-map search would slip a gate and reintroduce the crash. The Go-heap bytes
+// are instead bounded at the drain by the wide-projection byte budget
+// (withSpanDrainBudget); a future upfront gate would need a byte-cost signal, not
+// row counts — see TestPhaseAStaysNarrow.
+func (h *Handler) SearchResult(ctx context.Context, query string, limit int) (engine.Result, error) {
+	plan, meta, err := h.lang.Parse(ctx, query)
+	if err != nil {
+		return engine.Result{}, err
+	}
+	if sj, ok := structuralTwoPhaseTarget(plan); ok && h.StructuralTwoPhase {
+		return h.runStructuralTwoPhase(ctx, sj, plan, meta, limit)
+	}
+	return h.Engine.QueryPlan(ctx, h.lang, plan, meta)
+}
+
 // runStructuralTwoPhase executes a positive recursive structural search in two
 // phases and returns the same engine.Result the single wide query would have
 // produced — the identical ordered top-N traces with identical per-trace


### PR DESCRIPTION
Closes the last two-phase asymmetry: the split was **HTTP-only**, so a recursive structural query HTTP bounds to top-N traces drained in *full* over gRPC (the byte budget fail-closed it with `ResourceExhausted` rather than OOMing — but gRPC still rejected queries HTTP serves).

### The fix: one shared entry point
Collapses HTTP's inline parse→gate→execute into **`Handler.SearchResult(ctx, query, limit)`** — `lang.Parse` → `structuralTwoPhaseTarget` → `runStructuralTwoPhase`-or-`QueryPlan`. **Both transports call it**, so the two-phase eligibility decision lives in exactly one place and the transports **physically cannot diverge again** — which is the whole bug.

### Why eager is a drop-in (no memory regression)
gRPC already fully buffered into a `[]Sample` before shaping (`toTraceSummaries` groups spans by TraceID), so it never streamed on the Go heap. Dropping `QueryCursor`/the drain loop/`cursor.Close` for `res.Samples` keeps the same memory profile — and two-phase *shrinks* it to the response traces. The byte budget still charges the eager drain.

### A≡B across transports, by construction
The ctx folds (`WithSearchTraceLimit`/`Window`/`DrainByteBudget`) are already identical on both heads, so the same plan flows through the same gate. Parity is structural, not empirical: there's no second copy of the gate to drift.

### Also
- Cancellation now surfaces at the query boundary (not per-row); `mapEngineError` maps `context.Canceled`/`DeadlineExceeded` to the proper gRPC status instead of `Internal`.
- Tests: cross-transport routing non-vacuity (a gRPC structural query fires phase A), ctx-error mapping, and the cancellation test rewritten to clean stream termination (the gRPC-owned cursor is gone).

Holding for adversarial review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)