### PR TITLE
fix(e2e): reconcile the Traces-Drilldown undefined-groupBy init race

### DIFF
--- a/test/e2e/playwright/crawl/reconcile.spec.ts
+++ b/test/e2e/playwright/crawl/reconcile.spec.ts
@@ -257,6 +257,20 @@ test.describe('isTransientMalformedTraceQLFailure', () => {
     }
   });
 
+  // The groupBy-init race (run 29392064642, reproduced locally 2026-07-15):
+  // before the click handler's effect commits the clicked facet name, the
+  // breakdown view forwards the JS `undefined` value string-interpolated in
+  // as the group-by attribute / a nil-comparison operand.
+  test('reconciles the undefined-groupBy breakdown-view race', () => {
+    for (const q of [
+      '{nestedSetParent<0 && true && undefined != nil} | rate() by(undefined)',
+      '{nestedSetParent<0 && true} | rate() by(undefined)',
+      '{true && undefined != nil} | rate()',
+    ]) {
+      expect(isTransientMalformedTraceQLFailure(dsqTempo(q, 400))).toBe(true);
+    }
+  });
+
   test('does NOT reconcile when one query in the request is well-formed', () => {
     const mixed: DsResponseView = {
       url: '/api/ds/query?ds_type=tempo&requestId=SQR1',
@@ -324,6 +338,21 @@ test.describe('isTransientMalformedTraceQLFailure', () => {
         }),
       ).toBe(true);
     }
+  });
+
+  // Response-side fallback for the undefined-groupBy shape. Live-captured
+  // body (compose stack, 2026-07-15):
+  //   {"results":{"A":{"error":"failed to execute TraceQL query: {nestedSetParent<0 && true && undefined != nil} | rate() by(undefined) Status: 400 Bad Request Body: {\"traceID\":\"\",\"spanID\":\"\",\"error\":true,\"message\":\"parse error at line 1, col 31: unknown identifier: undefined\"}\n","errorSource":"plugin","status":500}}}
+  test('reconciles the undefined-groupBy race via the cerberus 400 body', () => {
+    expect(
+      isTransientMalformedTraceQLFailure({
+        url: '/api/ds/query?ds_type=tempo&requestId=SQR108',
+        status: 400,
+        requestBody: '<streamed>',
+        responseBody:
+          '{"results":{"A":{"error":"failed to execute TraceQL query: {nestedSetParent<0 && true && undefined != nil} | rate() by(undefined) Status: 400 Bad Request Body: {\\"traceID\\":\\"\\",\\"spanID\\":\\"\\",\\"error\\":true,\\"message\\":\\"parse error at line 1, col 31: unknown identifier: undefined\\"}\\n","errorSource":"plugin","status":500}}}',
+      }),
+    ).toBe(true);
   });
 
   test('does NOT reconcile a DIFFERENT syntax error via the response body', () => {

--- a/test/e2e/playwright/helpers/reconcile.ts
+++ b/test/e2e/playwright/helpers/reconcile.ts
@@ -114,6 +114,32 @@ export const DANGLING_TRACEQL_REJECTION =
   /unexpected\s+(?:&&|\\u0026\\u0026|\|\|)/;
 
 /**
+ * Matches a TraceQL query carrying the literal JS token `undefined` as an
+ * identifier — e.g. `by(undefined)` or `undefined != nil`. Same
+ * primarySignal-init race family as DANGLING_TRACEQL_OPERAND, but the
+ * unresolved React state here is the Traces Drilldown app's `groupBy`
+ * variable rather than `primarySignal`: mid-drill, before the click handler's
+ * effect commits the clicked facet name, the app re-renders its breakdown
+ * query with the JS `undefined` value string-interpolated in as the group-by
+ * attribute. `undefined` is not a valid TraceQL identifier, so cerberus (and
+ * reference Tempo's identical grammar) rejects it with `unknown identifier:
+ * undefined`; the app re-fires a well-formed query once the state settles.
+ * `undefined` never appears in a well-formed TraceQL query (it isn't a
+ * keyword or a real attribute name), so the match stays narrow.
+ */
+export const UNDEFINED_GROUPBY_TRACEQL = /\bundefined\b/;
+
+/**
+ * Matches cerberus's HTTP-400 body for the undefined-groupBy TraceQL shape —
+ * the RESPONSE-side signature of the race UNDEFINED_GROUPBY_TRACEQL matches
+ * request-side. cerberus's parser reports the exact unresolved identifier
+ * name, so this is as specific as the dangling-operand response matcher: a
+ * genuine wrong-rejection of a different malformed query names a different
+ * identifier and still fails loudly.
+ */
+export const UNDEFINED_GROUPBY_REJECTION = /unknown identifier: undefined/;
+
+/**
  * True iff a captured console message is a browser `TypeError: Failed to fetch`
  * — the network-abort class. This is NOT how cerberus signals an error: a
  * cerberus 4xx/5xx arrives as an HTTP response with a JSON body (the fetch
@@ -151,16 +177,17 @@ export function isResourceStatusTwin(consoleMessage: string): boolean {
 
 /**
  * True iff `resp` is a non-2xx Tempo ds/query whose EVERY forwarded TraceQL
- * query carries a dangling-operand spanset (see DANGLING_TRACEQL_OPERAND) —
- * the Traces Drilldown app's primarySignal-init-race shape. cerberus correctly
- * 400s these (reference Tempo rejects the identical syntax-error), so they are
- * a transient app-side artifact, not a cerberus fault.
+ * query carries a known Traces-Drilldown init-race shape: a dangling-operand
+ * spanset (see DANGLING_TRACEQL_OPERAND, the primarySignal-init race) or the
+ * literal `undefined` identifier (see UNDEFINED_GROUPBY_TRACEQL, the
+ * groupBy-init race). cerberus correctly 400s these (reference Tempo rejects
+ * the identical syntax errors), so they are a transient app-side artifact,
+ * not a cerberus fault.
  *
  * It is NOT a blanket 400 suppressor — a non-2xx carrying any well-formed
- * query still fails loudly; only the specific dangling-`&&`/`||` syntax shape
- * the app's known init race emits is reconciled, and ALL queries in the
- * request must exhibit it (a mixed request with one well-formed query is a
- * genuine failure).
+ * query still fails loudly; only the specific known-race syntax shapes are
+ * reconciled, and ALL queries in the request must exhibit one of them (a
+ * mixed request with one well-formed query is a genuine failure).
  */
 export function isTransientMalformedTraceQLFailure(
   resp: DsResponseView,
@@ -171,16 +198,21 @@ export function isTransientMalformedTraceQLFailure(
   if (dsType !== 'tempo') return false;
   const exprs = [...refIdToExpr(resp.requestBody).values()];
   if (exprs.length > 0) {
-    // Request-side: EVERY forwarded query must carry the dangling shape (a
+    // Request-side: EVERY forwarded query must carry a known-race shape (a
     // mixed request with one well-formed query is a genuine failure).
-    return exprs.every((expr) => DANGLING_TRACEQL_OPERAND.test(expr));
+    return exprs.every(
+      (expr) =>
+        DANGLING_TRACEQL_OPERAND.test(expr) ||
+        UNDEFINED_GROUPBY_TRACEQL.test(expr),
+    );
   }
   // Request body uncapturable (a torn-down request left postData empty). Fall
-  // back to cerberus's 400 body, which names the dangling-operand syntax error
-  // verbatim — the same proven shape, observed response-side.
+  // back to cerberus's 400 body, which names the known-race syntax error
+  // verbatim — the same proven shapes, observed response-side.
   if (
     resp.responseBody !== undefined &&
-    DANGLING_TRACEQL_REJECTION.test(resp.responseBody)
+    (DANGLING_TRACEQL_REJECTION.test(resp.responseBody) ||
+      UNDEFINED_GROUPBY_REJECTION.test(resp.responseBody))
   ) {
     return true;
   }
@@ -206,20 +238,21 @@ export function isTransientMalformedTraceQLFailure(
 }
 
 /**
- * Resolve the browser-side twins of the reconciled primarySignal-init-race
- * 400s and return the console errors that remain REPORTABLE.
+ * Resolve the browser-side twins of the reconciled init-race 400s and return
+ * the console errors that remain REPORTABLE.
  *
- * When an interactive drill drives the Traces Drilldown app through its
- * primarySignal-init race, each dangling-operand TraceQL 400 that
- * isTransientMalformedTraceQLFailure reconciled on the wire ALSO surfaces to
- * the browser as a single EMPTY-text console error — Grafana logs the failed
- * background fetch, and the captured `msg.text()` is empty. Given
- * `reconciledInitRace` such reconciled 400s, up to that many empty-text console
- * errors are those twins and are resolved away; EVERY substantive (non-empty)
- * console error is kept (mask nothing of value), and any empty-text error
- * BEYOND the reconciled-400 count is kept too (placeholder text), so a
- * genuinely-broken app — which produces either a non-reconciled wire failure or
- * more console noise than the init race explains — still reports.
+ * When an interactive drill drives the Traces Drilldown app through one of
+ * its known init races (primarySignal or groupBy — see
+ * isTransientMalformedTraceQLFailure), each TraceQL 400 that function
+ * reconciled on the wire ALSO surfaces to the browser as a single EMPTY-text
+ * console error — Grafana logs the failed background fetch, and the captured
+ * `msg.text()` is empty. Given `reconciledInitRace` such reconciled 400s, up
+ * to that many empty-text console errors are those twins and are resolved
+ * away; EVERY substantive (non-empty) console error is kept (mask nothing of
+ * value), and any empty-text error BEYOND the reconciled-400 count is kept
+ * too (placeholder text), so a genuinely-broken app — which produces either a
+ * non-reconciled wire failure or more console noise than the init races
+ * explain — still reports.
  */
 export function reportableConsoleErrors(
   consoleErrors: ReadonlyArray<string>,

--- a/test/e2e/playwright/iterate-drilldown-apps.spec.ts
+++ b/test/e2e/playwright/iterate-drilldown-apps.spec.ts
@@ -340,19 +340,23 @@ async function sweepDrilldownApp(
   await Promise.all(captureBodies);
 
   // 1. Wire-status sweep over every captured response — zero
-  //    tolerance for 4xx/5xx, EXCEPT the Traces Drilldown app's
-  //    primarySignal-init race. That app applies its primarySignal
-  //    default inside a React useEffect, so during the initial-load /
-  //    rapid-drill window it transiently forwards a dangling-operand
-  //    TraceQL (`{ && …} | rate()`) that cerberus correctly 400s
-  //    (reference Tempo rejects the identical syntax error). It is a
-  //    third-party app artifact, not a cerberus fault — and racy: the
-  //    400 fires on every run but only lands inside the capture window
-  //    intermittently, which is what makes this spec flaky. The
-  //    reconciler is narrow (every query in the request must carry the
-  //    dangling shape); a well-formed-query non-2xx still fails loudly.
-  //    Mirrors the crawl lane (#934). Count the reconciled races so the
-  //    console sweep below can resolve their browser-side twin.
+  //    tolerance for 4xx/5xx, EXCEPT the Traces Drilldown app's known
+  //    init races. That app applies several pieces of state (notably
+  //    primarySignal and groupBy) inside React useEffects, so during the
+  //    initial-load / rapid-drill window it transiently forwards either a
+  //    dangling-operand TraceQL (`{ && …} | rate()`, the primarySignal
+  //    race) or one carrying the literal JS `undefined` as an identifier
+  //    (`{… && undefined != nil} | rate() by(undefined)`, the groupBy
+  //    race — reproduced locally 2026-07-15, run 29392064642). cerberus
+  //    correctly 400s both (reference Tempo rejects the identical syntax
+  //    errors). Both are third-party app artifacts, not a cerberus fault —
+  //    and racy: the 400 fires on every run but only lands inside the
+  //    capture window intermittently, which is what makes this spec
+  //    flaky. The reconciler is narrow (every query in the request must
+  //    carry one of the known shapes); a well-formed-query non-2xx still
+  //    fails loudly. Mirrors the crawl lane (#934). Count the reconciled
+  //    races so the console sweep below can resolve their browser-side
+  //    twin.
   let reconciledInitRace = 0;
   for (const resp of captured) {
     if (resp.status >= 200 && resp.status <= 299) continue;


### PR DESCRIPTION
## Summary

- Fixes the flaky `iterate-drilldown-apps.spec.ts` that failed both dashboard-shard jobs in run 29392064642 (`failOnFlakyTests` is intentional in `playwright.config.ts`, so a pass-on-retry still reds the job).
- Root cause (reproduced locally against the compose stack, ~1-in-4 to 1-in-5 runs): mid-drill, before the Traces Drilldown app's click handler commits the clicked facet name into its `groupBy` state, the breakdown view fires a TraceQL query with the JS `undefined` value string-interpolated in as the group-by attribute — `{nestedSetParent<0 && true && undefined != nil} | rate() by(undefined)`. `undefined` isn't a valid TraceQL identifier, so cerberus correctly 400s it (`unknown identifier: undefined`) — same class of third-party-app init-race artifact as the existing primarySignal-init race (dangling-operand spansets), just a different unresolved-state shape.
- Widened `isTransientMalformedTraceQLFailure` (`test/e2e/playwright/helpers/reconcile.ts`, shared by the drilldown-apps spec and the crawl lane) to recognize this shape too, both request-side (`UNDEFINED_GROUPBY_TRACEQL`) and via cerberus's 400 body as a response-side fallback (`UNDEFINED_GROUPBY_REJECTION`). Not a blanket suppressor — every query in the request must still exhibit a known-race shape, and a genuinely well-formed query still fails loudly.
- Added unit coverage in `crawl/reconcile.spec.ts` for the new shape (request-side and response-body-fallback), and updated doc comments describing both known init-race shapes.

## Test plan

- [x] Reproduced the flake locally against the compose stack (`docker compose up` with CH host-ports unpublished) — captured the exact 400 body via a temporary `page.route` intercept (not committed).
- [x] `npx playwright test crawl/reconcile.spec.ts` — 40/40 pass, including the 2 new cases.
- [x] `npx playwright test iterate-drilldown-apps.spec.ts` — 20/20 pass locally with the fix (previously failed ~1-in-4 to 1-in-5).
- [x] `golangci-lint run ./...` — 0 issues (repo-wide, clean cache).

🤖 Generated with [Claude Code](https://claude.com/claude-code)