### PR TITLE
ci: auto-tidy test/oracle on dependabot go.mod bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,13 @@ version: 2
 updates:
   # Go modules — parsers get their own daily group so cerberus stays
   # within a release of upstream. Everything else still bumps weekly.
+  # Root module only — deliberately no second `directory: /test/oracle`
+  # entry. test/oracle carries `replace github.com/tsouza/cerberus =>
+  # ../..`, so its module graph is entangled with the root's; a second
+  # Dependabot directory there would just open a SEPARATE, unsynced PR for
+  # the same bump, not fix the drift. `dependabot-tidy-nested-modules.yml`
+  # re-tidies test/oracle inside each root-module PR instead. See PR #1211
+  # and that workflow's header comment.
   - package-ecosystem: gomod
     directory: /
     schedule:

--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -451,6 +451,20 @@ wrapper, plus `appendStepSummary` / `setOutput` for the runner files.
     written to).
   - Exit: `0` clean / matrix emitted, `1` on any coverage violation or bad
     `MODE`.
+- **`dependabot-tidy-nested-modules.mjs`** — `dependabot-tidy-nested-modules.yml`,
+  the `tidy` job. `test/oracle` is a nested Go module carrying
+  `replace github.com/tsouza/cerberus => ../..`, so its module graph is
+  entangled with the root's; a root-only Dependabot bump routinely leaves
+  `test/oracle/go.mod`/`go.sum` stale and fails `ci.yml`'s "test oracle
+  module" step. Runs `go mod tidy` in each nested module dir and, only if
+  that produced a diff, commits and pushes a fixup straight to the
+  Dependabot PR branch — closing the loop without a human re-running it by
+  hand (see PR #1211).
+  - Env: `NESTED_MODULE_DIRS` (space-separated, default `test/oracle`),
+    `BRANCH` (required — the branch to push the fixup to), `GIT_USER_NAME` /
+    `GIT_USER_EMAIL` (default `github-actions[bot]` identity).
+  - Exit: `0` nothing to do or fixup pushed; `1` on a `go mod tidy` or git
+    failure.
 
 ## Notes
 

--- a/.github/scripts/dependabot-tidy-nested-modules.mjs
+++ b/.github/scripts/dependabot-tidy-nested-modules.mjs
@@ -1,0 +1,78 @@
+// dependabot-tidy-nested-modules.mjs — .github/workflows/dependabot-tidy-nested-modules.yml,
+// the "tidy" step.
+//
+// test/oracle is a nested Go module (its own go.mod) that carries
+// `replace github.com/tsouza/cerberus => ../..` so its AGPL-quarantined
+// oracle tests can import cerberus's internal/** packages (see the module
+// doc-comment in test/oracle/go.mod and docs re: the agpl-clean gate). That
+// local-path replace entangles its module graph with the root's: almost
+// every dependency Dependabot bumps in the root go.mod is also an indirect
+// require in test/oracle/go.mod, so a root-only bump leaves the nested
+// module's go.mod/go.sum stale. `.github/dependabot.yml` only watches
+// `directory: /` (by design — a second Dependabot directory would open a
+// SEPARATE, unsynced PR, not fix this), so nothing ever tidies test/oracle
+// on its own. Left alone, `ci.yml`'s "test oracle module" step fails on
+// nearly every Dependabot PR with "go: updates to go.mod needed; to update
+// it: go mod tidy" (see PR #1211) and a human has to notice, run
+// `go mod tidy` locally, and push a fixup commit.
+//
+// This script closes that loop: run inside a Dependabot PR's checkout
+// (after Dependabot's own go.mod/go.sum edits are already on disk), it runs
+// `go mod tidy` in each nested module, and — only if that produced a diff —
+// commits and pushes a fixup straight to the PR branch. bench/histogram is
+// a second nested module but deliberately does NOT depend on the root
+// module (see its go.mod doc-comment), so it never needs this and is not
+// included by default.
+//
+// Env contract:
+//   NESTED_MODULE_DIRS  space-separated dirs, each containing a go.mod that
+//                        must be re-tidied (default: "test/oracle")
+//   BRANCH               branch to push the fixup commit to (required)
+//   GIT_USER_NAME         commit author name (default: "github-actions[bot]")
+//   GIT_USER_EMAIL        commit author email
+//                        (default: "github-actions[bot]@users.noreply.github.com")
+//
+// Exit codes: 0 = nothing to do, or fixup committed + pushed; 1 = `go mod
+// tidy` or a git command failed.
+
+import process from 'node:process';
+import { error, exec, git, notice } from './lib/gh.mjs';
+
+const dirs = (process.env.NESTED_MODULE_DIRS || 'test/oracle').split(/\s+/).filter(Boolean);
+const branch = process.env.BRANCH;
+const gitUserName = process.env.GIT_USER_NAME || 'github-actions[bot]';
+const gitUserEmail =
+  process.env.GIT_USER_EMAIL || 'github-actions[bot]@users.noreply.github.com';
+
+if (!branch) {
+  error('dependabot-tidy-nested-modules.mjs: BRANCH env var is required');
+  process.exit(1);
+}
+
+for (const dir of dirs) {
+  notice(`go mod tidy in ${dir}`);
+  exec('go', ['mod', 'tidy'], { cwd: dir });
+}
+
+const status = git(['status', '--porcelain', '--', ...dirs]);
+if (status.status !== 0) {
+  error(`git status failed: ${status.stderr.trim()}`);
+  process.exit(1);
+}
+
+if (status.stdout.trim() === '') {
+  notice(`nested module(s) already tidy: ${dirs.join(', ')}`);
+  process.exit(0);
+}
+
+exec('git', ['config', 'user.name', gitUserName]);
+exec('git', ['config', 'user.email', gitUserEmail]);
+exec('git', ['add', '--', ...dirs]);
+exec('git', [
+  'commit',
+  '-m',
+  `chore: go mod tidy nested modules\n\nDependabot bumped a dependency shared with test/oracle's module\ngraph (entangled via its local-path replace on the root module);\nre-tidying keeps its go.mod/go.sum consistent.`,
+]);
+exec('git', ['push', 'origin', `HEAD:${branch}`]);
+
+notice(`pushed go mod tidy fixup for ${dirs.join(', ')} to ${branch}`);

--- a/.github/workflows/dependabot-tidy-nested-modules.yml
+++ b/.github/workflows/dependabot-tidy-nested-modules.yml
@@ -1,0 +1,67 @@
+name: dependabot-tidy-nested-modules
+# test/oracle is a nested Go module (its own go.mod) that carries
+# `replace github.com/tsouza/cerberus => ../..`, so its module graph is
+# entangled with the root's. `.github/dependabot.yml` only watches
+# `directory: /` — on purpose, a second Dependabot directory for
+# test/oracle would just open a second, unsynced PR, not fix this — so a
+# root-only Dependabot bump routinely leaves test/oracle/go.mod stale and
+# `ci.yml`'s "test oracle module" step fails with "go: updates to go.mod
+# needed; to update it: go mod tidy" (see PR #1211). This workflow closes
+# the loop: re-tidy the nested module(s) inside the Dependabot PR itself
+# and push a fixup commit straight to its branch, so the required checks
+# go green without a human (or agent) noticing and doing it by hand.
+# bench/histogram is a second nested module but deliberately does NOT
+# depend on the root module, so it's excluded by the script's default.
+#
+# Gated the same way as auto-merge-deps.yml: job-level actor guard plus
+# dependabot/fetch-metadata's ecosystem output, since only `go_modules`
+# bumps can desync test/oracle.
+#
+# Token: RELEASE_PAT (fine-grained, contents:write) when present, else
+# github.token. A push made with the plain GITHUB_TOKEN does not trigger
+# downstream `pull_request` workflow runs (GitHub's recursion guard), so
+# without RELEASE_PAT the fixup lands but the PR's checks need a manual
+# re-run; see prepare-release.yml / release.yml for the same fallback.
+on:
+  pull_request:
+    paths:
+      - go.mod
+      - go.sum
+
+permissions:
+  contents: write
+
+concurrency:
+  group: dependabot-tidy-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  tidy:
+    name: tidy nested modules
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: checkout PR branch
+        if: steps.meta.outputs.package-ecosystem == 'go_modules'
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.RELEASE_PAT || github.token }}
+
+      - uses: actions/setup-go@v6
+        if: steps.meta.outputs.package-ecosystem == 'go_modules'
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: go mod tidy nested modules + push fixup if needed
+        if: steps.meta.outputs.package-ecosystem == 'go_modules'
+        env:
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+        run: node .github/scripts/dependabot-tidy-nested-modules.mjs


### PR DESCRIPTION
## Summary

- `test/oracle` is a nested Go module carrying `replace github.com/tsouza/cerberus => ../..`, entangling its dependency graph with the root module's. `.github/dependabot.yml` only watches `directory: /`, so a root-only Dependabot bump routinely leaves `test/oracle/go.mod`/`go.sum` stale and `ci.yml`'s "test oracle module" step fails with `go: updates to go.mod needed; to update it: go mod tidy` — requiring a human to notice and push a manual fixup every time (most recently PR #1211).
- Adds `dependabot-tidy-nested-modules.yml`, gated to `dependabot[bot]` PRs touching `go.mod`/`go.sum` (same actor-guard + `dependabot/fetch-metadata` pattern as `auto-merge-deps.yml`). It re-tidies `test/oracle` (nested-module list is configurable) and, only if that produces a diff, commits and pushes a fixup straight to the PR branch — closing the loop without manual intervention.
- Uses the `secrets.RELEASE_PAT || github.token` fallback already established in `prepare-release.yml`/`release.yml`, since a push made with the plain `GITHUB_TOKEN` doesn't retrigger downstream `pull_request` checks.
- `bench/histogram` is a second nested module but deliberately does not depend on the root module, so it's excluded from the default tidy list.
- Documents the rationale inline in `.github/dependabot.yml` (why there's no second `directory: /test/oracle` entry) and adds the new script to `.github/scripts/README.md`'s module inventory per the repo's non-inline-CI-logic convention.

## Validation

Locally reproduced PR #1211's failure in an isolated worktree checked out at its branch tip: `go mod tidy` inside `test/oracle` produces exactly the expected one-line fix (`google.golang.org/grpc v1.82.0` → `v1.82.1`), and `go build ./...` then succeeds.

## Test plan

- [ ] CI green on this PR (workflow itself doesn't run here — no Dependabot actor — but `check`/`lint` validate the new files)
- [ ] Next Dependabot `go_modules` PR that touches `test/oracle`'s indirect deps exercises `dependabot-tidy-nested-modules.yml` for real and confirms the fixup push + green `check / test oracle module`

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>