### PR TITLE
fix(chsql): push compare() root-lookup bound below GROUP BY, not above it

### DIFF
--- a/internal/chplan/clone.go
+++ b/internal/chplan/clone.go
@@ -328,6 +328,11 @@ func cloneExpr(e Expr) Expr {
 		// Expr, not a Node child), so a node-only copy walk would miss the
 		// embedded plan subtree entirely. Copy it explicitly here.
 		return &ScalarSubquery{Input: CloneNode(v.Input)}
+	case *InSubquery:
+		// Same rationale as ScalarSubquery above: Subquery is an embedded
+		// Node reachable only through this Expr, so it needs an explicit
+		// CloneNode rather than a shallow field copy.
+		return &InSubquery{Left: cloneExpr(v.Left), Subquery: CloneNode(v.Subquery)}
 	case *BoundedTraceScope:
 		// Pure leaf (column names + limit, no embedded Node) — a flat value
 		// copy, like the literals above.

--- a/internal/chplan/in_subquery.go
+++ b/internal/chplan/in_subquery.go
@@ -1,0 +1,46 @@
+package chplan
+
+// InSubquery is a set-membership predicate: `<Left> IN (<Subquery>)`, where
+// Subquery is a full plan subtree rather than a literal list (see InList for
+// the flat-literal sibling). It exists so a lowering or emitter can inject an
+// exact membership predicate — e.g. "TraceId IN (<the already-filtered span
+// cohort>)" — directly into a Filter that sits BELOW an Aggregate's GROUP BY,
+// so ClickHouse can push the predicate all the way down into the underlying
+// MergeTree scan. Wrapping a `WHERE <col> IN (...)` around an ALREADY
+// aggregated relation (i.e. wrapping the Aggregate's output) does not get
+// that pushdown — CH does not push a predicate back down through GROUP BY —
+// so it prunes nothing at the scan; see metrics_compare.go's RootLookup
+// TraceId-membership rewrite in internal/chsql for the motivating case.
+//
+// Optimizer note: InSubquery is an Expr, so chplan.Walk does NOT recurse
+// into Subquery — Walk only traverses Node.Children, and an Expr field
+// (including any Node embedded inside one) is invisible to it by
+// construction. This mirrors ScalarSubquery's exclusion from optimizer
+// visibility; see scalar_subquery.go for the full rationale. InspectExpr /
+// InspectExprNodes still reach it explicitly, exactly like ScalarSubquery.
+type InSubquery struct {
+	Left     Expr
+	Subquery Node
+}
+
+func (*InSubquery) exprNode() {}
+
+func (i *InSubquery) Equal(other Expr) bool {
+	o, ok := other.(*InSubquery)
+	if !ok {
+		return false
+	}
+	if (i.Left == nil) != (o.Left == nil) {
+		return false
+	}
+	if i.Left != nil && !i.Left.Equal(o.Left) {
+		return false
+	}
+	if (i.Subquery == nil) != (o.Subquery == nil) {
+		return false
+	}
+	if i.Subquery == nil {
+		return true
+	}
+	return i.Subquery.Equal(o.Subquery)
+}

--- a/internal/chplan/in_subquery_test.go
+++ b/internal/chplan/in_subquery_test.go
@@ -1,0 +1,100 @@
+package chplan_test
+
+import (
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// Equal-invariant coverage for chplan.InSubquery, mirroring the
+// positive/negative pattern in in_list_test.go: structurally identical
+// values compare Equal; values differing in exactly one load-bearing field
+// do not, symmetrically.
+
+func inSubqueryFixture() *chplan.InSubquery {
+	return &chplan.InSubquery{
+		Left: &chplan.ColumnRef{Name: "TraceId"},
+		Subquery: &chplan.Project{
+			Input:       &chplan.Scan{Table: "spans"},
+			Projections: []chplan.Projection{{Expr: &chplan.ColumnRef{Name: "TraceId"}}},
+		},
+	}
+}
+
+func TestInSubquery_Equal_Positive(t *testing.T) {
+	t.Parallel()
+	a, b := inSubqueryFixture(), inSubqueryFixture()
+	if !a.Equal(b) || !b.Equal(a) {
+		t.Errorf("structurally identical InSubquery values must compare Equal (both directions)")
+	}
+}
+
+func TestInSubquery_Equal_Negative(t *testing.T) {
+	t.Parallel()
+	cases := map[string]chplan.Expr{
+		"different left": &chplan.InSubquery{
+			Left: &chplan.ColumnRef{Name: "SpanId"},
+			Subquery: &chplan.Project{
+				Input:       &chplan.Scan{Table: "spans"},
+				Projections: []chplan.Projection{{Expr: &chplan.ColumnRef{Name: "TraceId"}}},
+			},
+		},
+		"nil left": &chplan.InSubquery{
+			Subquery: &chplan.Project{
+				Input:       &chplan.Scan{Table: "spans"},
+				Projections: []chplan.Projection{{Expr: &chplan.ColumnRef{Name: "TraceId"}}},
+			},
+		},
+		"different subquery": &chplan.InSubquery{
+			Left: &chplan.ColumnRef{Name: "TraceId"},
+			Subquery: &chplan.Project{
+				Input:       &chplan.Scan{Table: "other_spans"},
+				Projections: []chplan.Projection{{Expr: &chplan.ColumnRef{Name: "TraceId"}}},
+			},
+		},
+		"nil subquery": &chplan.InSubquery{
+			Left: &chplan.ColumnRef{Name: "TraceId"},
+		},
+		"other type": &chplan.LitString{V: "a"},
+	}
+	base := inSubqueryFixture()
+	for name, other := range cases {
+		if base.Equal(other) {
+			t.Errorf("%s: Equal must be false", name)
+		}
+		if other.Equal(base) {
+			t.Errorf("%s: Equal must be false symmetrically", name)
+		}
+	}
+}
+
+// TestInSubquery_CloneNode_IsolatesSubquery proves CloneNode deep-copies the
+// embedded Subquery Node rather than aliasing it — mirroring
+// ScalarSubquery's clone contract (see clone.go's InSubquery case).
+func TestInSubquery_CloneNode_IsolatesSubquery(t *testing.T) {
+	t.Parallel()
+
+	orig := &chplan.Filter{
+		Input:     &chplan.Scan{Table: "roots"},
+		Predicate: inSubqueryFixture(),
+	}
+	clone := chplan.CloneNode(orig).(*chplan.Filter)
+
+	origPred := orig.Predicate.(*chplan.InSubquery)
+	clonePred := clone.Predicate.(*chplan.InSubquery)
+
+	if origPred == clonePred {
+		t.Fatal("CloneNode must not alias the InSubquery expression itself")
+	}
+	if !origPred.Equal(clonePred) {
+		t.Fatal("cloned InSubquery must be structurally Equal to the original")
+	}
+
+	cloneSub := clonePred.Subquery.(*chplan.Project)
+	cloneSub.Projections[0].Expr = &chplan.ColumnRef{Name: "SpanId"}
+
+	origSub := origPred.Subquery.(*chplan.Project)
+	if origSub.Projections[0].Expr.(*chplan.ColumnRef).Name != "TraceId" {
+		t.Fatal("mutating the clone's embedded Subquery leaked back into the original")
+	}
+}

--- a/internal/chplan/walk_expr.go
+++ b/internal/chplan/walk_expr.go
@@ -75,5 +75,10 @@ func inspectExpr(e Expr, visit func(Expr) bool, nodeVisit func(Node)) {
 		if nodeVisit != nil && v.Input != nil {
 			nodeVisit(v.Input)
 		}
+	case *InSubquery:
+		inspectExpr(v.Left, visit, nodeVisit)
+		if nodeVisit != nil && v.Subquery != nil {
+			nodeVisit(v.Subquery)
+		}
 	}
 }

--- a/internal/chplan/walk_expr_test.go
+++ b/internal/chplan/walk_expr_test.go
@@ -41,6 +41,7 @@ func TestInspectExprExhaustive(t *testing.T) {
 		&NestedArrayExists{},
 		&ScalarSubquery{},
 		&BoundedTraceScope{},
+		&InSubquery{},
 	}
 
 	// Each listed type must be reached as a root visit without panicking,
@@ -70,7 +71,7 @@ func TestInspectExprExhaustive(t *testing.T) {
 	// switch has no default-panic), so this count forces the author to
 	// revisit both the switch AND this list. Keep it in lock-step with the
 	// number of exprNode() implementers under internal/chplan.
-	const wantExprTypes = 22
+	const wantExprTypes = 23
 	if len(all) != wantExprTypes {
 		t.Fatalf("expected %d Expr types in the exhaustiveness set, listed %d — "+
 			"a new Expr type was added: extend inspectExpr's switch in walk_expr.go AND this list",
@@ -111,8 +112,9 @@ func TestCloneExprExhaustive(t *testing.T) {
 		&NestedArrayExists{},
 		&ScalarSubquery{},
 		&BoundedTraceScope{},
+		&InSubquery{},
 	}
-	const wantExprTypes = 22
+	const wantExprTypes = 23
 	if len(all) != wantExprTypes {
 		t.Fatalf("expected %d Expr types, listed %d — a new Expr type was added: "+
 			"extend cloneExpr's switch in clone.go AND this list", wantExprTypes, len(all))

--- a/internal/chsql/builder.go
+++ b/internal/chsql/builder.go
@@ -374,6 +374,8 @@ func (b *Builder) Expr(x chplan.Expr) error {
 		return b.exprSubscript(v)
 	case *chplan.ScalarSubquery:
 		return b.exprScalarSubquery(v)
+	case *chplan.InSubquery:
+		return b.exprInSubquery(v)
 	case *chplan.BoundedTraceScope:
 		return b.exprBoundedTraceScope(v)
 	default:
@@ -414,6 +416,41 @@ func (b *Builder) exprScalarSubquery(s *chplan.ScalarSubquery) error {
 	b.sb.WriteString(e.b.String())
 	b.args = append(b.args, e.args...)
 	return nil
+}
+
+// exprInSubquery renders chplan.InSubquery as `<Left> IN (<SELECT ...>)`.
+// The embedded plan subtree is rendered through a fresh in-package emitter
+// exactly like exprScalarSubquery above, so its args splice into this
+// Builder's stream at the position the IN predicate is written; the operator
+// itself reuses the top-level InSubquery Frag constructor so the shape
+// matches every other `<col> IN (<SELECT ...>)` predicate cerberus emits
+// (chplan.BoundedTraceScope, the nested-set anchor/step scope, …).
+func (b *Builder) exprInSubquery(v *chplan.InSubquery) error {
+	if v.Left == nil {
+		return fmt.Errorf("%w: chplan.InSubquery has nil Left", ErrUnsupported)
+	}
+	if v.Subquery == nil {
+		return fmt.Errorf("%w: chplan.InSubquery has nil Subquery", ErrUnsupported)
+	}
+	e := &emitter{}
+	if err := e.emitSubquery(v.Subquery); err != nil {
+		return err
+	}
+	sql, args := e.b.String(), e.args
+
+	var leftErr error
+	InSubquery(
+		func(lb *Builder) {
+			if err := lb.Expr(v.Left); err != nil {
+				leftErr = err
+			}
+		},
+		func(sb *Builder) {
+			sb.sb.WriteString(sql)
+			sb.args = append(sb.args, args...)
+		},
+	)(b)
+	return leftErr
 }
 
 // exprLambda renders chplan.Lambda. Single-parameter shapes render as

--- a/internal/chsql/metrics_compare.go
+++ b/internal/chsql/metrics_compare.go
@@ -71,12 +71,22 @@ const (
 // `s LEFT JOIN r` down into either MergeTree input, so a window filter
 // landed there scans the full span table on both legs (the prod
 // traces-drilldown OOM: a 15-min compare read ~731M rows before the
-// 2 GiB cap killed it; EXPLAIN showed ~130x fewer rows once the bound
-// pruned the scans). compareBaseQuery therefore attaches lo/hi to the
-// `s` subquery's own WHERE and seeds the root leg with a TraceId-IN
-// over the same bounded cohort.
+// 2 GiB cap killed it). compareBaseQuery therefore attaches lo/hi to
+// the `s` subquery's own WHERE. The same is true one level deeper for
+// the `r` (root) leg: a `TraceId IN (...)` filter sitting ABOVE
+// RootLookup's own GROUP BY (boundedRootLeg's wrap, below) restricts
+// only the aggregate's OUTPUT — CH still has to materialize the whole
+// aggregate over the unpruned scan first, which is what actually kept
+// OOMing in prod despite that wrap already existing. The real fix is
+// windowRootLookupTraceIDSeed, which pushes the same TraceId-IN
+// predicate into the Filter directly beneath RootLookup's own Scan (see
+// emitRangeWindowCompare) so CH prunes the scan itself, below the
+// GROUP BY. rootSeeded records when that pushdown already succeeded, so
+// compareBaseQuery can skip boundedRootLeg's now-redundant wrap instead
+// of re-filtering an already-pruned result by the same trace-id set.
 type compareScanBound struct {
-	lo, hi Frag
+	lo, hi     Frag
+	rootSeeded bool
 }
 
 // compareBaseQuery builds the innermost SELECT — cohort flag +
@@ -127,17 +137,21 @@ func (e *emitter) compareBaseQuery(m *chplan.MetricsCompare, bound *compareScanB
 			return nil, rerr
 		}
 		// Right ('r') leg: bound the per-trace root lookup to the same
-		// windowed cohort the 's' leg scans via `TraceId IN (<bounded s
-		// trace-ids>)` — mirroring structuralSeedTraceFilter's seed
-		// pushdown. The predicate is on the root aggregate's GROUP BY key
-		// (TraceId), so CH pushes it through the aggregate into the root
-		// span scan, pruning it the same way the 's' leg is pruned. A
-		// plain Timestamp bound on the root leg would instead drop
-		// enrichment for traces whose root span straddles the window
-		// edge; seeding by the cohort's trace-id set keeps every root the
-		// LEFT JOIN can match (the join output is determined by
-		// s.TraceId, already windowed) while still scoping the scan.
-		if bound != nil {
+		// windowed cohort the 's' leg scans, restricting root rows to
+		// `TraceId IN (<bounded s trace-ids>)`. When emitRangeWindowCompare
+		// has already pushed that same predicate into RootLookup's own
+		// scan-level Filter (bound.rootSeeded — see
+		// windowRootLookupTraceIDSeed), boundedRootLeg's wrap here would
+		// only re-filter an already-pruned result by the identical
+		// trace-id set, so it's skipped. It stays as the correctness
+		// fallback for the rare RootLookup shape the scan-level pushdown
+		// can't reach (rootLookupSpansTable finds no matching Scan): a
+		// plain Timestamp bound on the root leg would drop enrichment for
+		// traces whose root span straddles the window edge, so seeding by
+		// the cohort's trace-id set is what keeps every root the LEFT
+		// JOIN can match (the join output is determined by s.TraceId,
+		// already windowed) while still scoping the leg to the cohort.
+		if bound != nil && !bound.rootSeeded {
 			root = e.boundedRootLeg(root, m.TraceIDColumn, inner, bound)
 		}
 		qb.From(aliasedFrag(sLeg, compareJoinLeftAlias)).
@@ -164,14 +178,19 @@ func (e *emitter) compareBaseQuery(m *chplan.MetricsCompare, bound *compareScanB
 	return qb, nil
 }
 
-// boundedRootLeg wraps the rendered root-lookup subquery so its scan is
-// pruned to the windowed cohort: it filters the root rows to
+// boundedRootLeg wraps the RENDERED (post-aggregate) root-lookup subquery,
+// restricting its output rows to
 // `<traceID> IN (SELECT <traceID> FROM (<bounded inner>) AS _cmp_seed)`,
-// where the bounded inner is the same windowed span scan the 's' leg
-// uses. Because <traceID> is the root aggregate's GROUP BY key, the
-// predicate pushes through the aggregate into the root span scan.
-// _cmp_seed aliases the seed subquery so CH's analyzer resolves the
-// projected trace-id column. See compareScanBound for the why.
+// where the bounded inner is the same windowed span scan the 's' leg uses.
+// This does NOT prune RootLookup's underlying MergeTree scan — the
+// predicate sits above the GROUP BY it wraps, and CH does not push a
+// filter on an aggregate's output back down through the GROUP BY into the
+// scan beneath it. It only narrows which already-aggregated rows the join
+// sees, which is necessary for correctness (e.g. when the scan-level
+// pushdown below can't reach RootLookup's shape) but does nothing for the
+// scan-level OOM windowRootLookupTraceIDSeed exists to fix. _cmp_seed
+// aliases the seed subquery so CH's analyzer resolves the projected
+// trace-id column. See compareScanBound for the why.
 func (e *emitter) boundedRootLeg(root Frag, traceIDCol string, inner Frag, bound *compareScanBound) Frag {
 	boundedInner := NewQuery().Select(Star()).From(inner).Where(bound.lo, bound.hi)
 	seedIDs := NewQuery().
@@ -184,32 +203,104 @@ func (e *emitter) boundedRootLeg(root Frag, traceIDCol string, inner Frag, bound
 		Frag()
 }
 
-// windowRootLookupScan returns a clone of the root-lookup relation with the
-// request window AND-ed into the Filter that sits directly on the spans Scan,
-// so the per-trace root aggregate prunes partitions below its GROUP BY (a
-// Timestamp predicate above the GROUP BY would reference an ungrouped column and
-// could not push down). startNano / endNano are the request window's unix
-// nanoseconds; each bound is omitted when its value is 0. The rewrite only
-// touches a Scan whose Table is the context-threaded spans table, leaving any
-// other shape untouched (defensive — the compare lowering always produces the
-// Aggregate→Filter→Scan root lookup, but a future schema may not). Returns the
-// input unchanged when no matching spans scan is found.
-func windowRootLookupScan(root chplan.Node, tsCol string, startNano, endNano int64, spansTable string) chplan.Node {
-	lo, hi := tsBoundExprs(tsCol, startNano, endNano)
-	if lo == nil && hi == nil {
-		return root
+// compareSeedNode builds `SELECT <traceIDCol> FROM (<inner>)` [with
+// <inner> additionally filtered to (lo, hi] on tsCol when either bound is
+// set] — the EXACT same relation compareBaseQuery uses for the "s"/cohort
+// leg (see compareBaseQuery's sLeg and boundedRootLeg's seedIDs), expressed
+// as a chplan.Node rather than a rendered Frag so it can be embedded as a
+// chplan.InSubquery.Subquery inside RootLookup's own Filter.Predicate (a
+// chplan.Expr slot the emitted "s" leg's Frag-level bound cannot reach).
+//
+// FIDELITY: inner must be the fully-filtered spanset the query's `{...}`
+// pipeline already resolved to (whatever resource/service/attribute
+// filters compareBaseQuery's "s" leg applies) — not a bare Scan plus only
+// a time range — otherwise the seed set would be wider than the query
+// actually intends and would silently change which traces receive
+// root-name/root-service enrichment. The SAME fidelity requirement applies
+// to lo/hi: they must be the caller's actual scan-bound values (matching
+// innerScanTsBoundsFrags' (Start-Offset-range, End-Offset] window, not the
+// raw [Start, End] request window) — a narrower bound here silently
+// excludes traces the "s" leg's own scan still includes.
+func compareSeedNode(inner chplan.Node, traceIDCol string, lo, hi chplan.Expr) chplan.Node {
+	windowed := chplan.CloneNode(inner)
+	if pred := conjoinExpr(lo, hi); pred != nil {
+		windowed = &chplan.Filter{Input: windowed, Predicate: pred}
+	}
+	return &chplan.Project{
+		Input:       windowed,
+		Projections: []chplan.Projection{{Expr: &chplan.ColumnRef{Name: traceIDCol}}},
+	}
+}
+
+// rootLookupSpansTable returns the table name of the Scan embedded inside
+// root (RootLookup's own Aggregate→Filter→Scan chain — see
+// traceql.compareRootLookup), or "" if none is reachable. Deriving the
+// table name from RootLookup itself, rather than threading it in from the
+// emit context, means windowRootLookupTraceIDSeed below fires on every
+// emit path — the bare shape, the RangeWindow/matrix shape, and the
+// TXTAR spec/chdb golden lane — not only "real" Tempo requests that
+// happen to thread WithSpansTable.
+func rootLookupSpansTable(root chplan.Node) string {
+	var table string
+	chplan.Walk(root, func(n chplan.Node) bool {
+		if sc, ok := n.(*chplan.Scan); ok {
+			if table == "" {
+				table = sc.Table
+			}
+			return false
+		}
+		return true
+	})
+	return table
+}
+
+// windowRootLookupTraceIDSeed returns a clone of the root-lookup relation
+// with `<traceIDCol> IN (<seed>)` AND-ed — as a chplan.InSubquery — into the
+// Filter that sits directly on the spans Scan, so the per-trace root
+// aggregate prunes the scan itself, below its own GROUP BY (a predicate
+// sitting above the GROUP BY, like the old post-aggregate wrap in
+// boundedRootLeg, does not get pushed back down through it by ClickHouse).
+//
+// This replaces the previous Timestamp-only push: TraceId is the bare,
+// unaliased GROUP BY key of RootLookup's own Aggregate, with no HAVING
+// clause or window function between the scan and the GROUP BY, so a
+// predicate that only references TraceId membership commutes freely across
+// GROUP BY — filtering by TraceId before vs. after GROUP BY produces
+// IDENTICAL groups. A Timestamp bound on the root span's own Timestamp is
+// instead LOSSY: it silently drops the enrichment for any trace whose root
+// span started before the request window (a normal case for a long-lived
+// trace whose matched span is late) — see internal/chsql's
+// compareRootLookup / TestEmitRangeWindowCompare_JoinScanPushdown history
+// for the full incident writeup.
+//
+// The rewrite only touches a Scan whose Table matches the one
+// rootLookupSpansTable derives from root itself, leaving any other shape
+// untouched (defensive — the compare lowering always produces the
+// Aggregate→Filter→Scan root lookup, but a future schema may not). Returns
+// the input unchanged and seeded=false when seed is nil or no matching
+// spans scan is found — the caller (emitRangeWindowCompare) uses seeded to
+// decide whether boundedRootLeg's post-aggregate wrap is still needed as a
+// correctness fallback.
+func windowRootLookupTraceIDSeed(root chplan.Node, traceIDCol string, seed chplan.Node) (windowed chplan.Node, seeded bool) {
+	if seed == nil {
+		return root, false
+	}
+	spansTable := rootLookupSpansTable(root)
+	if spansTable == "" {
+		return root, false
 	}
 	clone := chplan.CloneNode(root)
-	if pushWindowToSpansScanFilter(clone, spansTable, lo, hi) {
-		return clone
+	pred := &chplan.InSubquery{Left: &chplan.ColumnRef{Name: traceIDCol}, Subquery: seed}
+	if pushPredicateToSpansScanFilter(clone, spansTable, pred) {
+		return clone, true
 	}
-	return root
+	return root, false
 }
 
 // tsBoundExprs builds the lower (`>= fromUnixTimestamp64Nano(startNano)`) and
 // upper (`<= fromUnixTimestamp64Nano(endNano)`) request-window comparison
 // expressions for tsCol, mirroring the search lowering's tsBound shape so the
-// root-leg window matches the rest of the search path. Either side is nil when
+// seed's window matches the rest of the search path. Either side is nil when
 // its nanosecond value is 0.
 func tsBoundExprs(tsCol string, startNano, endNano int64) (lo, hi chplan.Expr) {
 	fromNano := func(nano int64) chplan.Expr {
@@ -227,22 +318,23 @@ func tsBoundExprs(tsCol string, startNano, endNano int64) (lo, hi chplan.Expr) {
 	return lo, hi
 }
 
-// pushWindowToSpansScanFilter walks n in place looking for the Filter that sits
-// directly on a Scan of spansTable (or a bare such Scan) and conjoins lo/hi into
-// its predicate. n must be a solely-owned clone. Returns true once it has
-// folded the window, false if no matching spans scan is reachable.
-func pushWindowToSpansScanFilter(n chplan.Node, spansTable string, lo, hi chplan.Expr) bool {
+// pushPredicateToSpansScanFilter walks n in place looking for the Filter
+// that sits directly on a Scan of spansTable (or a bare such Scan) and
+// conjoins pred into its predicate. n must be a solely-owned clone. Returns
+// true once it has folded pred, false if no matching spans scan is
+// reachable.
+func pushPredicateToSpansScanFilter(n chplan.Node, spansTable string, pred chplan.Expr) bool {
 	switch v := n.(type) {
 	case *chplan.Filter:
 		if sc, ok := v.Input.(*chplan.Scan); ok && sc.Table == spansTable {
-			v.Predicate = conjoinExpr(conjoinExpr(v.Predicate, lo), hi)
+			v.Predicate = conjoinExpr(v.Predicate, pred)
 			return true
 		}
-		return pushWindowToSpansScanFilter(v.Input, spansTable, lo, hi)
+		return pushPredicateToSpansScanFilter(v.Input, spansTable, pred)
 	case *chplan.Aggregate:
-		return pushWindowToSpansScanFilter(v.Input, spansTable, lo, hi)
+		return pushPredicateToSpansScanFilter(v.Input, spansTable, pred)
 	case *chplan.Project:
-		return pushWindowToSpansScanFilter(v.Input, spansTable, lo, hi)
+		return pushPredicateToSpansScanFilter(v.Input, spansTable, pred)
 	}
 	return false
 }
@@ -384,31 +476,42 @@ func (e *emitter) emitRangeWindowCompare(r *chplan.RangeWindow, m *chplan.Metric
 		lo, hi := innerScanTsBoundsFrags(tsCol, r.Start, r.End, r.Offset.Nanoseconds(), rangeNS)
 		bound = &compareScanBound{lo: lo, hi: hi}
 	}
-	// Push the request window directly onto the root-lookup's physical scan
-	// (below its GROUP BY), so CH partition-prunes it. boundedRootLeg's
-	// `TraceId IN (<bounded cohort>)` seed sits ABOVE the GROUP BY and so prunes
-	// nothing — it stays as the cohort scope, but a direct Timestamp predicate
-	// on the root scan is what actually prunes the toDate(Timestamp) partitions.
-	// Gated on the context-threaded spans table so it only fires for a real
-	// Tempo request (the spec/golden lane never threads it, staying
-	// byte-identical). The window edge residual — a root whose start straddles
-	// out of [start,end] is dropped — is the same approximation
-	// boundedRootScopeFrag already accepts.
-	if bound != nil && e.ctxSpansTable != "" && m.RootLookup != nil {
-		// A zero time.Time's UnixNano() is a huge negative number, not 0, which
-		// would emit a bogus fromUnixTimestamp64Nano(<negative>) bound instead of
-		// omitting the side. Mirror the `!r.Start.IsZero() && !r.End.IsZero()`
-		// guard above (and handler.go scanTimestampWindow) so an absent bound
-		// passes 0 and windowRootLookupScan omits it.
-		var startN, endN int64
-		if !r.Start.IsZero() {
-			startN = r.Start.UnixNano()
-		}
-		if !r.End.IsZero() {
-			endN = r.End.UnixNano()
-		}
+	// Push a `TraceId IN (<windowed cohort>)` seed directly onto the
+	// root-lookup's physical scan (below its own GROUP BY), so CH can
+	// partition-prune the scan before the aggregate runs. TraceId is
+	// RootLookup's bare, unaliased GROUP BY key with no HAVING/window
+	// function in between, so a TraceId-membership predicate commutes freely
+	// across the GROUP BY — pushing it into the scan's Filter produces the
+	// same groups as filtering after. This is unlike boundedRootLeg's
+	// post-aggregate `TraceId IN (...)` wrap (kept as a correctness fallback
+	// in compareBaseQuery, skipped via bound.rootSeeded whenever this
+	// pushdown succeeds): that wrap sits ABOVE the GROUP BY, so CH must
+	// materialize the full aggregate before it can apply it — the actual OOM
+	// cause. A direct Timestamp bound on the root span's own Timestamp was
+	// rejected instead of this: it is LOSSY, silently dropping root-name /
+	// root-service enrichment for any trace whose root span started before
+	// the request window. windowRootLookupTraceIDSeed derives the spans
+	// table from RootLookup itself (rootLookupSpansTable), not from
+	// e.ctxSpansTable, so this fires uniformly on every emit path — no
+	// context-threading gate needed here.
+	if bound != nil && m.RootLookup != nil {
+		// The seed must bound Inner by the SAME (Start-Offset-range, End-Offset]
+		// window the 's' leg's own scan uses (innerScanTsBoundsFrags above) —
+		// not the raw [Start, End] request window. Otherwise a trace whose only
+		// matching span falls in the anchor lookback slice (Start-range, Start)
+		// — the normal case for every anchor before the last — would satisfy
+		// the 's' leg's bound but miss the seed's, silently dropping its
+		// root-name/root-service enrichment. offsetNS's sign convention matches
+		// offsetShiftedTimeFrag: shiftedNano = wallNano - offsetNS.
+		offsetNS := r.Offset.Nanoseconds()
+		lo, hi := tsBoundExprs(tsCol, r.Start.UnixNano()-offsetNS-rangeNS, r.End.UnixNano()-offsetNS)
+		seed := compareSeedNode(m.Inner, m.TraceIDColumn, lo, hi)
 		windowed := *m
-		windowed.RootLookup = windowRootLookupScan(m.RootLookup, tsCol, startN, endN, e.ctxSpansTable)
+		rootLookup, seeded := windowRootLookupTraceIDSeed(m.RootLookup, m.TraceIDColumn, seed)
+		windowed.RootLookup = rootLookup
+		boundCopy := *bound
+		boundCopy.rootSeeded = seeded
+		bound = &boundCopy
 		m = &windowed
 	}
 	base, err := e.compareBaseQuery(m, bound, tsCol)

--- a/internal/chsql/metrics_compare_test.go
+++ b/internal/chsql/metrics_compare_test.go
@@ -10,6 +10,19 @@ import (
 	"github.com/tsouza/cerberus/internal/chsql"
 )
 
+// containsInt64Arg reports whether want appears among args as an int64 —
+// used to check a parameterized bound's actual VALUE, since a substring
+// match against the SQL text only proves a `fromUnixTimestamp64Nano(?)`
+// placeholder is present, not which value it was bound to.
+func containsInt64Arg(args []any, want int64) bool {
+	for _, a := range args {
+		if v, ok := a.(int64); ok && v == want {
+			return true
+		}
+	}
+	return false
+}
+
 // compareNode builds a minimal valid MetricsCompare (no root lookup —
 // the join shape is covered by the lowering-level tests + TXTAR
 // fixtures; this file pins the emitter's own contract).
@@ -63,19 +76,23 @@ func compareNodeWithRoot() *chplan.MetricsCompare {
 	return m
 }
 
-// TestEmitRangeWindowCompare_JoinScanPushdown pins the FIX-1 scan-
-// bounding pushdown for the join (RootLookup) shape — the prod
-// traces-drilldown OOM. The (Start - range, End] Timestamp window must
-// land INSIDE each MergeTree scan of `s LEFT JOIN r`, never on the
-// SELECT wrapping the join (CH 24.12 cannot push a join-level predicate
-// into either leg):
+// TestEmitRangeWindowCompare_JoinScanPushdown pins the scan-bounding
+// pushdown for the join (RootLookup) shape — the prod traces-drilldown
+// OOM. The (Start - range, End] Timestamp window must land INSIDE each
+// MergeTree scan of `s LEFT JOIN r`, never on the SELECT wrapping the
+// join (CH 24.12 cannot push a join-level predicate into either leg):
 //
 //   - the `s` span leg carries the bound in its own WHERE, immediately
 //     above the `AS s` alias;
 //   - the `r` root leg is seeded with `TraceId IN (<bounded cohort
-//     trace-ids>)` so the same window prunes the root scan through the
-//     GROUP BY TraceId aggregate, while preserving rootName enrichment
-//     for every trace the join can match.
+//     trace-ids>)` pushed directly into the Filter beneath RootLookup's
+//     own physical Scan — i.e. BELOW its GROUP BY TraceId aggregate, not
+//     as a wrap around the aggregate's output — so CH partition-prunes
+//     the scan itself instead of materializing the full aggregate first.
+//     A `TraceId IN (...)` filter sitting ABOVE the GROUP BY (the earlier
+//     boundedRootLeg-only shape) restricts only the aggregate's output
+//     and does not prune the scan; that's what kept OOMing in prod
+//     despite the wrap already existing (see windowRootLookupTraceIDSeed).
 func TestEmitRangeWindowCompare_JoinScanPushdown(t *testing.T) {
 	t.Parallel()
 
@@ -87,7 +104,7 @@ func TestEmitRangeWindowCompare_JoinScanPushdown(t *testing.T) {
 		End:             time.Date(2026, 5, 12, 10, 3, 0, 0, time.UTC),
 		TimestampColumn: "Timestamp",
 	}
-	sql, _, err := chsql.Emit(context.Background(), rw)
+	sql, args, err := chsql.Emit(context.Background(), rw)
 	if err != nil {
 		t.Fatalf("Emit: %v", err)
 	}
@@ -102,12 +119,55 @@ func TestEmitRangeWindowCompare_JoinScanPushdown(t *testing.T) {
 		t.Errorf("matrix join SQL must bound the 's' scan inside the join (want %q):\n%s", sLeg, sql)
 	}
 
-	// The 'r' root leg: seeded by the bounded cohort's trace-id set so
-	// the root scan prunes the same way, with enrichment preserved.
-	rSeed := "WHERE `TraceId` IN (SELECT `TraceId` FROM (SELECT * FROM (SELECT * FROM `otel_traces`) " +
-		"WHERE " + lo + " AND " + hi + ") AS _cmp_seed)) AS r"
-	if !strings.Contains(sql, rSeed) {
-		t.Errorf("matrix join SQL must seed the 'r' root leg by bounded trace-ids (want %q):\n%s", rSeed, sql)
+	// The 'r' root leg: RootLookup's own Filter(ParentSpanId = '') gains a
+	// `TraceId IN (<bounded cohort>)` conjunct, seeding the scan directly
+	// — BELOW the GROUP BY that follows it — so CH prunes the scan before
+	// aggregating, not after. PREWHERE promotion (internal/optimizer)
+	// splits the two conjuncts of the Filter across PREWHERE/WHERE rather
+	// than AND-ing them into one clause; either placement still lands the
+	// seed inside the scan, below the GROUP BY. The seed's own bound
+	// (tsBoundExprs) renders as fromUnixTimestamp64Nano(?) — the same
+	// parameterized shape the search lowering's tsBound uses — not the
+	// inlined toDateTime64(...) literal the 's' leg's lo/hi above use.
+	rSeededScan := "PREWHERE (`ParentSpanId` = ?) WHERE `TraceId` IN (SELECT `TraceId` FROM (SELECT * FROM `otel_traces` " +
+		"WHERE (`Timestamp` >= fromUnixTimestamp64Nano(?)) AND (`Timestamp` <= fromUnixTimestamp64Nano(?)))))"
+	if !strings.Contains(sql, rSeededScan) {
+		t.Errorf("matrix join SQL must seed the 'r' root leg's own scan by bounded trace-ids (want %q):\n%s", rSeededScan, sql)
+	}
+	if !strings.Contains(sql, rSeededScan+" GROUP BY `TraceId`") {
+		t.Errorf("the trace-id seed must sit BELOW RootLookup's GROUP BY, not wrap its output:\n%s", sql)
+	}
+
+	// The seed's own bound is parameterized (fromUnixTimestamp64Nano(?)), so
+	// the shape assertion above passes regardless of the actual bound VALUE —
+	// it must independently be checked against args. The seed has to mirror
+	// the 's' leg's own (Start-range, End] window (see innerScanTsBoundsFrags
+	// in range_window.go), not the raw [Start, End] request window: a trace
+	// whose only matching span falls in the anchor lookback slice
+	// (Start-range, Start) — the normal case for every anchor before the
+	// last — satisfies the 's' leg's bound but would miss a seed bounded to
+	// raw Start, silently dropping that trace's root-name/root-service
+	// enrichment. This is the same shape as prior window-anchor bugs in this
+	// codebase (mismatched request-window bound vs. actual scan bound).
+	wantSeedLoNano := rw.Start.UnixNano() - rw.Range.Nanoseconds()
+	wantSeedHiNano := rw.End.UnixNano()
+	if !containsInt64Arg(args, wantSeedLoNano) {
+		t.Errorf("seed lower bound arg %d (Start - range) not found in emitted args %v", wantSeedLoNano, args)
+	}
+	if !containsInt64Arg(args, wantSeedHiNano) {
+		t.Errorf("seed upper bound arg %d (End) not found in emitted args %v", wantSeedHiNano, args)
+	}
+	if containsInt64Arg(args, rw.Start.UnixNano()) {
+		t.Errorf("seed lower bound must be Start-range, not raw Start (found raw Start.UnixNano()=%d in args %v)", rw.Start.UnixNano(), args)
+	}
+
+	// Regression guard: once the scan-level seed lands, boundedRootLeg's
+	// redundant post-aggregate wrap (`) AS r` immediately preceded by a
+	// bare `WHERE TraceId IN (...)`, with no intervening Filter/Scan) must
+	// not also appear — that shape re-filters an already-pruned result by
+	// the identical trace-id set for no benefit.
+	if strings.Contains(sql, "_cmp_seed") {
+		t.Errorf("boundedRootLeg's post-aggregate wrap must be skipped once the scan-level seed succeeds (unexpected _cmp_seed):\n%s", sql)
 	}
 
 	// Regression guard: the bound must NOT sit on the SELECT that wraps

--- a/internal/chsql/scan_window_emit_test.go
+++ b/internal/chsql/scan_window_emit_test.go
@@ -167,7 +167,7 @@ func TestEmitNestedSetAnchorStepWindowed(t *testing.T) {
 // RangeWindow the /api/metrics/query_range handler builds, and emits — with or
 // without the spans table on the context. start/end may be zero to exercise the
 // fail-closed gate.
-func emitCompareInRangeWindow(t *testing.T, start, end time.Time, spansScoped bool) (string, error) {
+func emitCompareInRangeWindow(t *testing.T, start, end time.Time, spansScoped bool) (string, []any, error) {
 	t.Helper()
 	s := schema.DefaultOTelTraces()
 	expr, err := ast.Parse(`{ } | compare({ status = error })`)
@@ -190,44 +190,79 @@ func emitCompareInRangeWindow(t *testing.T, start, end time.Time, spansScoped bo
 	if spansScoped {
 		ctx = chsql.WithSpansTable(ctx, s.SpansTable)
 	}
-	sql, _, err := chsql.Emit(ctx, chplan.Node(rw))
-	return sql, err
+	sql, args, err := chsql.Emit(ctx, chplan.Node(rw))
+	return sql, args, err
 }
 
-// TestEmitCompareRootLookupWindowed pins the compare() root-lookup window push:
-// under the spans scope the per-trace root aggregate gains two direct
-// `fromUnixTimestamp64Nano(...)` Timestamp bounds (below its GROUP BY, where they
-// can partition-prune); without the spans scope the golden/metrics lane stays
-// byte-identical (no push). A zero window under the spans scope fails closed.
+// TestEmitCompareRootLookupWindowed pins the compare() root-lookup window
+// push: the per-trace root aggregate's own scan gains a `TraceId IN
+// (<bounded cohort>)` seed (below its GROUP BY, where CH can
+// partition-prune it), whose own bound renders as two direct
+// `fromUnixTimestamp64Nano(...)` Timestamp calls. windowRootLookupTraceIDSeed
+// derives the spans table straight from RootLookup's own Scan
+// (rootLookupSpansTable), not from the emit context, so this push fires
+// identically whether or not the context threads WithSpansTable — unlike
+// requireSpansScanWindow's fail-closed gate below, which is deliberately
+// scoped to the real Tempo path. A zero window under the spans scope fails
+// closed regardless.
 func TestEmitCompareRootLookupWindowed(t *testing.T) {
 	t.Parallel()
 	start, end := scanWindowEmitBounds()
 
-	withScope, err := emitCompareInRangeWindow(t, start, end, true)
+	withScope, withScopeArgs, err := emitCompareInRangeWindow(t, start, end, true)
 	if err != nil {
 		t.Fatalf("windowed compare emit (spans-scoped): %v", err)
 	}
-	withoutScope, err := emitCompareInRangeWindow(t, start, end, false)
+	withoutScope, withoutScopeArgs, err := emitCompareInRangeWindow(t, start, end, false)
 	if err != nil {
 		t.Fatalf("windowed compare emit (unscoped): %v", err)
 	}
 
-	// The base compare window renders its bounds as positional `?` args, so the
-	// only `fromUnixTimestamp64Nano` calls come from the root-lookup push: two
-	// (lo + hi) under the spans scope, zero without it.
+	// The base compare window renders its bounds as positional `?` args, so
+	// the only `fromUnixTimestamp64Nano` calls come from the root-lookup
+	// seed's own bound: two (lo + hi), present identically with or without
+	// the spans scope threaded on the context.
+	const wantRootSeedBoundCalls = 2
 	countWith := strings.Count(withScope, fromUnixNanoCall)
 	countWithout := strings.Count(withoutScope, fromUnixNanoCall)
-	if countWith != countWithout+2 {
-		t.Errorf("compare root-lookup window push = %d extra %s calls; want exactly 2 (lo+hi on the root scan)\n--- with scope ---\n%s",
-			countWith-countWithout, fromUnixNanoCall, withScope)
+	if countWith != wantRootSeedBoundCalls {
+		t.Errorf("spans-scoped compare root-lookup seed = %d %s calls, want %d:\n%s", countWith, fromUnixNanoCall, wantRootSeedBoundCalls, withScope)
 	}
-	if countWith < 2 {
-		t.Errorf("spans-scoped compare carries no root-lookup Timestamp prune (%s count=%d):\n%s", fromUnixNanoCall, countWith, withScope)
+	if countWithout != wantRootSeedBoundCalls {
+		t.Errorf("unscoped compare root-lookup seed = %d %s calls, want %d (the seed derives its spans table from RootLookup itself, not the emit context):\n%s",
+			countWithout, fromUnixNanoCall, wantRootSeedBoundCalls, withoutScope)
+	}
+
+	// The `?` shape assertion above passes regardless of the bound's actual
+	// VALUE — checked here against args. The seed must mirror the 's' leg's
+	// own (Start-range, End] window, not the raw [Start, End] request
+	// window: a trace whose only matching span falls in the anchor lookback
+	// slice (Start-range, Start) satisfies the 's' leg's bound but would be
+	// silently dropped from root-name/root-service enrichment if the seed
+	// used raw Start.
+	wantSeedLoNano := scanWindowEmitStartNano - scanWindowEmitStep.Nanoseconds()
+	wantSeedHiNano := scanWindowEmitEndNano
+	for _, tc := range []struct {
+		name string
+		args []any
+	}{
+		{"spans-scoped", withScopeArgs},
+		{"unscoped", withoutScopeArgs},
+	} {
+		if !containsInt64Arg(tc.args, wantSeedLoNano) {
+			t.Errorf("%s: seed lower bound arg %d (Start - range) not found in emitted args %v", tc.name, wantSeedLoNano, tc.args)
+		}
+		if !containsInt64Arg(tc.args, wantSeedHiNano) {
+			t.Errorf("%s: seed upper bound arg %d (End) not found in emitted args %v", tc.name, wantSeedHiNano, tc.args)
+		}
+		if containsInt64Arg(tc.args, scanWindowEmitStartNano) {
+			t.Errorf("%s: seed lower bound must be Start-range, not raw Start (found raw Start=%d in args %v)", tc.name, scanWindowEmitStartNano, tc.args)
+		}
 	}
 
 	// Fail closed: a zero request window under the spans scope must be rejected
 	// rather than scanning full retention.
-	if _, err := emitCompareInRangeWindow(t, time.Time{}, time.Time{}, true); !errors.Is(err, chsql.ErrUnboundedSpansScan) {
+	if _, _, err := emitCompareInRangeWindow(t, time.Time{}, time.Time{}, true); !errors.Is(err, chsql.ErrUnboundedSpansScan) {
 		t.Fatalf("zero-window compare under WithSpansTable must fail closed, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes a production ClickHouse OOM in TraceQL's `compare()` when wrapped in a RangeWindow (the `/api/metrics/query_range` matrix path).

- `compare()`'s per-trace `RootLookup` aggregate was bounded by wrapping the **aggregate's output** with `WHERE TraceId IN (<bounded cohort>)`. ClickHouse does not push a predicate on an aggregate's output back down through `GROUP BY` into the underlying scan, so this wrap pruned nothing — the root-span scan still read full retention. That's what OOM'd production (~731M rows read before hitting the 2 GiB cap).
- Fix: push `TraceId IN (<seed>)` into the `Filter` directly beneath `RootLookup`'s own `Scan`, i.e. **below** its `GROUP BY TraceId`, so ClickHouse partition-prunes the scan itself before aggregating. `TraceId` is `RootLookup`'s own bare `GROUP BY` key with no `HAVING`/window function in between, so the predicate commutes freely across that particular `GROUP BY`.
- Adds `chplan.InSubquery` — a set-membership `Expr` whose right-hand side is a full plan subtree (not a literal list) — to carry the seed subquery through the plan IR into emission, mirroring `ScalarSubquery`'s optimizer-visibility precedent.
- The old post-aggregate wrap (`boundedRootLeg`) is retained as a correctness-only fallback for any non-standard `RootLookup` shape the pushdown can't reach.
- **Caught in adversarial review before merge**: the seed's own time bound must mirror the `s` (span) leg's actual scan window — `(Start-Offset-range, End-Offset]`, not the raw `[Start, End]` request window — or a trace whose only matching span falls in the anchor lookback slice would silently lose its root-name/root-service enrichment (trading OOM for silently-wrong output). Fixed and covered with value-level (not just SQL-shape-level) test assertions.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — 6459 tests pass, 0 failures
- [x] `gofumpt -extra -l` clean on all touched/new files
- [x] `golangci-lint run` clean on `internal/chplan/...` and `internal/chsql/...`
- [x] Verified emitted SQL directly (dump test) — `TraceId IN (seed)` correctly sits below `RootLookup`'s `GROUP BY`, no redundant double-filtering with the old wrap
- [x] `TestEmitRangeWindowCompare_JoinScanPushdown` and `TestEmitCompareRootLookupWindowed` strengthened to assert the seed's actual bound *value* (via emitted args), not just SQL shape — regression-proof against the anchor-lookback-window bug caught in review
- [x] Adversarial review pass completed; the one correctness finding it raised is fixed in this same PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)