### PR TITLE
feat(solver): register VectorJoin slice-invariant; fail-close instant joins on route A

### DIFF
--- a/internal/chplan/reanchor.go
+++ b/internal/chplan/reanchor.go
@@ -179,6 +179,35 @@ func reanchor(n Node, start, end time.Time) (Node, error) {
 		}
 		// Predicate is off-grid immutable: share.
 		return &Filter{Input: input, Predicate: v.Predicate}, nil
+	case *VectorJoin:
+		// A step-aligned vector-vector join carries NO own anchor grid and NO
+		// lookback: each arm is an independent windowed spine that already
+		// evaluates over the request grid, and the join step-aligns the two on
+		// the per-anchor TimestampColumn. Re-anchor BOTH arms onto the SAME
+		// [start, end] the join was asked for (no widening — the arms' own
+		// RangeWindow / RangeLWR nodes do their -Range / -Lookback widening),
+		// then copy-on-write the join node, re-filling the two arms and sharing
+		// the immutable modifier fields (Op / Match / Card / Include /
+		// ReturnBool / StepAligned) + the four column names verbatim. An
+		// @-pinned or grid-divergent arm surfaces ErrReanchorGridMismatch from
+		// the recursion, aborting the whole re-anchor to route A. The
+		// instant-mode (!StepAligned) join is kept off this path by the
+		// planner's sawInstantVectorJoin fail-closed guard (its emitter
+		// synthesizes the join-side timestamp with now64(9), a wall-clock that
+		// diverges across shards); registration is by node kind, so the guard —
+		// not this case — is what excludes it.
+		left, err := reanchor(v.Left, start, end)
+		if err != nil {
+			return nil, err
+		}
+		right, err := reanchor(v.Right, start, end)
+		if err != nil {
+			return nil, err
+		}
+		c := *v
+		c.Left = left
+		c.Right = right
+		return &c, nil
 	default:
 		// Off the windowed spine: SHARE the immutable subtree verbatim. The
 		// off-spine subtree is byte-identical across all K shards (it does not

--- a/internal/chplan/reanchor_vectorjoin_test.go
+++ b/internal/chplan/reanchor_vectorjoin_test.go
@@ -1,0 +1,194 @@
+package chplan_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"pgregory.net/rapid"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// stepAlignedJoin builds a StepAligned vector-vector join over two matrix
+// RangeWindow arms — the shape `sum by(job)(rate(a[5m])) / sum by(job)
+// (rate(b[5m]))` lowers to (modulo the per-arm Aggregate, immaterial to
+// re-anchoring). group_left + Include exercise the many-to-one modifier
+// fields ReanchorRange must carry verbatim.
+func stepAlignedJoin(left, right chplan.Node) *chplan.VectorJoin {
+	return &chplan.VectorJoin{
+		Left:             left,
+		Right:            right,
+		Op:               chplan.OpDiv,
+		Match:            chplan.VectorMatch{Labels: []string{"job"}, On: true},
+		Card:             chplan.CardManyToOne,
+		Include:          []string{"instance"},
+		ReturnBool:       false,
+		StepAligned:      true,
+		MetricNameColumn: "MetricName",
+		AttributesColumn: "Attributes",
+		TimestampColumn:  "TimeUnix",
+		ValueColumn:      "Value",
+	}
+}
+
+// TestReanchorRange_VectorJoin_ReAnchorsBothArms asserts a step-aligned join
+// re-anchors BOTH arms onto the SAME requested [start, end] (a join carries no
+// lookback, so no widening at the join level), and the input tree stays
+// byte-identical (copy-not-mutate).
+func TestReanchorRange_VectorJoin_ReAnchorsBothArms(t *testing.T) {
+	t.Parallel()
+
+	left := matrixWindow(5*time.Minute, time.Minute, 0)
+	right := matrixWindow(5*time.Minute, time.Minute, 0)
+	in := stepAlignedJoin(left, right)
+	snapshot := chplan.CloneNode(in)
+
+	start := time.Unix(1000, 0).UTC()
+	end := time.Unix(4600, 0).UTC()
+	out, err := chplan.ReanchorRange(in, start, end)
+	if err != nil {
+		t.Fatalf("ReanchorRange: %v", err)
+	}
+	if !in.Equal(snapshot) {
+		t.Fatal("ReanchorRange mutated its VectorJoin input")
+	}
+	if out == chplan.Node(in) {
+		t.Fatal("ReanchorRange returned the same VectorJoin pointer (join node must be cloned)")
+	}
+	j := out.(*chplan.VectorJoin)
+	gotLeft := j.Left.(*chplan.RangeWindow)
+	gotRight := j.Right.(*chplan.RangeWindow)
+	for name, rw := range map[string]*chplan.RangeWindow{"left": gotLeft, "right": gotRight} {
+		if !rw.Start.Equal(start) || !rw.End.Equal(end) || rw.OuterRange != end.Sub(start) {
+			t.Fatalf("%s arm re-anchored wrong: Start=%v End=%v OuterRange=%v",
+				name, rw.Start, rw.End, rw.OuterRange)
+		}
+	}
+}
+
+// TestReanchorRange_VectorJoin_COWPreservesModifiers pins the copy-on-write
+// contract: the immutable modifier fields (Op / Match / Card / Include /
+// ReturnBool / StepAligned) and the four column names survive verbatim, and
+// re-gridding the cloned join's arms never leaks into the input.
+func TestReanchorRange_VectorJoin_COWPreservesModifiers(t *testing.T) {
+	t.Parallel()
+
+	in := stepAlignedJoin(
+		matrixWindow(5*time.Minute, time.Minute, 0),
+		matrixWindow(5*time.Minute, time.Minute, 0),
+	)
+	snapshot := chplan.CloneNode(in)
+
+	out, err := chplan.ReanchorRange(in, time.Unix(1000, 0).UTC(), time.Unix(4600, 0).UTC())
+	if err != nil {
+		t.Fatalf("ReanchorRange: %v", err)
+	}
+	j := out.(*chplan.VectorJoin)
+	if j.Op != in.Op || !j.Match.Equal(in.Match) || j.Card != in.Card ||
+		j.ReturnBool != in.ReturnBool || j.StepAligned != in.StepAligned {
+		t.Fatalf("modifier field drifted after re-anchor: %+v", j)
+	}
+	if j.MetricNameColumn != in.MetricNameColumn || j.AttributesColumn != in.AttributesColumn ||
+		j.TimestampColumn != in.TimestampColumn || j.ValueColumn != in.ValueColumn {
+		t.Fatalf("column name drifted after re-anchor: %+v", j)
+	}
+	// Re-grid the shard's arms further (what the slicer does per slice) — this
+	// must not move the input's grid.
+	j.Left.(*chplan.RangeWindow).Start = time.Unix(0, 0).UTC()
+	j.Right.(*chplan.RangeWindow).End = time.Unix(1, 0).UTC()
+	if !in.Equal(snapshot) {
+		t.Fatal("re-gridding the cloned join's arms leaked into the input")
+	}
+}
+
+// TestReanchorRange_VectorJoin_AtPinnedArm asserts an @-pinned arm (its End
+// diverges from the predicted grid) surfaces ErrReanchorGridMismatch from the
+// recursion, aborting the whole re-anchor to route A.
+func TestReanchorRange_VectorJoin_AtPinnedArm(t *testing.T) {
+	t.Parallel()
+
+	// The left arm is a clean unpinned matrix window; the right arm is
+	// @-pinned to a grid that is NOT the one we re-anchor onto.
+	left := matrixWindow(5*time.Minute, time.Minute, 0)
+	right := matrixWindow(5*time.Minute, time.Minute, time.Hour)
+	right.Start = time.Unix(9999-3600, 0).UTC()
+	right.End = time.Unix(9999, 0).UTC() // @-pinned End != request grid end
+	in := stepAlignedJoin(left, right)
+
+	start := time.Unix(1000, 0).UTC()
+	end := time.Unix(4600, 0).UTC()
+	_, err := chplan.ReanchorRange(in, start, end)
+	if !errors.Is(err, chplan.ErrReanchorGridMismatch) {
+		t.Fatalf("expected ErrReanchorGridMismatch for @-pinned join arm, got %v", err)
+	}
+}
+
+// TestReanchorRange_VectorJoin_PropertyBounds is the rapid property test: over
+// random grids AND asymmetric per-arm Range/Offset, both arms of a step-aligned
+// join always re-anchor exactly onto the requested grid while each keeps its OWN
+// Range and Offset (the join recursion re-grids the shared grid, never the
+// per-arm window shape), and the input is never mutated. The asymmetric per-arm
+// Offset is the case a single global (ΣRange, one-offset) scan floor would
+// mishandle — here the plan-level guarantee is that slicing a join preserves
+// each arm's window verbatim.
+func TestReanchorRange_VectorJoin_PropertyBounds(t *testing.T) {
+	t.Parallel()
+
+	rapid.Check(t, func(rt *rapid.T) {
+		stepSec := rapid.Int64Range(1, 600).Draw(rt, "stepSec")
+		anchors := rapid.Int64Range(2, 5000).Draw(rt, "anchors")
+		rangeMulL := rapid.Int64Range(1, 100).Draw(rt, "rangeMulL")
+		rangeMulR := rapid.Int64Range(1, 100).Draw(rt, "rangeMulR")
+		offMulL := rapid.Int64Range(0, 50).Draw(rt, "offMulL")
+		offMulR := rapid.Int64Range(0, 50).Draw(rt, "offMulR")
+		startSec := rapid.Int64Range(0, 1_000_000).Draw(rt, "startSec")
+
+		step := time.Duration(stepSec) * time.Second
+		start := time.Unix(startSec, 0).UTC()
+		end := start.Add(time.Duration(anchors-1) * step)
+
+		rangL := time.Duration(rangeMulL) * step
+		rangR := time.Duration(rangeMulR) * step
+		offL := time.Duration(offMulL) * step
+		offR := time.Duration(offMulR) * step
+		left := matrixWindow(rangL, step, 0)
+		left.Offset = offL
+		right := matrixWindow(rangR, step, 0)
+		right.Offset = offR
+		in := stepAlignedJoin(left, right)
+		snapshot := chplan.CloneNode(in)
+
+		out, err := chplan.ReanchorRange(in, start, end)
+		if err != nil {
+			rt.Fatalf("ReanchorRange errored on a well-formed grid: %v", err)
+		}
+		if !in.Equal(snapshot) {
+			rt.Fatal("input mutated")
+		}
+		j := out.(*chplan.VectorJoin)
+		arms := []struct {
+			side string
+			rw   *chplan.RangeWindow
+			rang time.Duration
+			off  time.Duration
+		}{
+			{"left", j.Left.(*chplan.RangeWindow), rangL, offL},
+			{"right", j.Right.(*chplan.RangeWindow), rangR, offR},
+		}
+		for _, a := range arms {
+			if !a.rw.Start.Equal(start) || !a.rw.End.Equal(end) {
+				rt.Fatalf("%s arm bounds: want [%v,%v] got [%v,%v]", a.side, start, end, a.rw.Start, a.rw.End)
+			}
+			if a.rw.OuterRange != end.Sub(start) {
+				rt.Fatalf("%s arm OuterRange %v != %v", a.side, a.rw.OuterRange, end.Sub(start))
+			}
+			if a.rw.Range != a.rang {
+				rt.Fatalf("%s arm Range drifted: want %v got %v", a.side, a.rang, a.rw.Range)
+			}
+			if a.rw.Offset != a.off {
+				rt.Fatalf("%s arm Offset drifted: want %v got %v", a.side, a.off, a.rw.Offset)
+			}
+		}
+	})
+}

--- a/internal/chplan/sliceinvariant.go
+++ b/internal/chplan/sliceinvariant.go
@@ -51,15 +51,33 @@ func IsSliceInvariant(n Node) bool {
 //   - StepGrid — emits the anchor grid itself; a sub-grid is a subset.
 //   - UnionAll — slice-invariant iff every arm is (checked structurally by
 //     the whole-plan walk, since each arm is itself visited).
+//   - VectorJoin — a step-aligned vector-vector binary join. Each output row
+//     is the per-pair binary op of two per-(match-key, anchor) inputs joined
+//     on the match key AND the anchor timestamp (the emitter ANDs
+//     `L.TimestampColumn = R.TimestampColumn` into the ON clause when
+//     StepAligned, and adds TimestampColumn to each side's GROUP BY). So each
+//     joined row reduces only the samples of one anchor's window on each arm,
+//     independent of the scan lower bound. This holds across all matching
+//     (on/ignoring), all cardinalities (group_left/group_right — the
+//     many-to-one dedup throwIf(uniqExact>1) + Include mapConcat are
+//     per-(match-key, anchor) because the anchor timestamp is IN the join
+//     key), and all ops incl `bool`. BOUNDARY: only the StepAligned shape is
+//     safe. The instant-mode (StepAligned==false) join synthesizes its
+//     join-side timestamp with now64(9) — a wall-clock that diverges across
+//     shards. Registration here is by node kind, so it admits the instant
+//     shape too; the solver's planner carries an explicit sawInstantVectorJoin
+//     fail-closed guard (ReasonInstantJoin) that keeps !StepAligned joins on
+//     route A. VectorSetOp / NaryVectorSetOp (and/or/unless) remain absent —
+//     each is its own PR.
 //
 // Extension point. Phase-3 node families (TopK as per-anchor LIMIT K BY,
-// step-aligned VectorJoin / VectorSetOp, HistogramQuantile{,Native},
-// AbsentOverTime, the metrics_* TraceQL family, nested spines under the lcm
-// clamp) are DELIBERATELY ABSENT: each enters this registry only with its
-// own slice-invariance proof + the reset-at-seam fixture family, one node
-// family per PR. To register a kind, argue its per-(series, anchor) output
-// is scan-lower-bound-independent, add it here, and extend the §Parity
-// lanes — do not add a kind merely because it "looks safe".
+// VectorSetOp, HistogramQuantile{,Native}, AbsentOverTime, the metrics_*
+// TraceQL family, nested spines under the lcm clamp) are DELIBERATELY ABSENT:
+// each enters this registry only with its own slice-invariance proof + the
+// reset-at-seam fixture family, one node family per PR. To register a kind,
+// argue its per-(series, anchor) output is scan-lower-bound-independent, add
+// it here, and extend the §Parity lanes — do not add a kind merely because it
+// "looks safe".
 var sliceInvariantKinds = func() map[reflect.Type]struct{} {
 	kinds := []Node{
 		&Scan{},
@@ -71,6 +89,7 @@ var sliceInvariantKinds = func() map[reflect.Type]struct{} {
 		&RangeBucketFanout{},
 		&StepGrid{},
 		&UnionAll{},
+		&VectorJoin{},
 	}
 	m := make(map[reflect.Type]struct{}, len(kinds))
 	for _, k := range kinds {

--- a/internal/chplan/sliceinvariant_test.go
+++ b/internal/chplan/sliceinvariant_test.go
@@ -23,6 +23,7 @@ func TestIsSliceInvariant_RegisteredKinds(t *testing.T) {
 		&chplan.RangeBucketFanout{},
 		&chplan.StepGrid{},
 		&chplan.UnionAll{},
+		&chplan.VectorJoin{},
 	}
 	for _, n := range registered {
 		if !chplan.IsSliceInvariant(n) {
@@ -34,7 +35,7 @@ func TestIsSliceInvariant_RegisteredKinds(t *testing.T) {
 // TestIsSliceInvariant_UnregisteredKinds asserts every node kind NOT in the
 // phase-1 set returns false — the default-deny posture. This list is the
 // complement of the registered set over allNodeKinds (defined in
-// clone_test.go); together they cover all 26 node kinds, so adding a node
+// clone_test.go); together they cover all 31 node kinds, so adding a node
 // type without a deliberate registry decision fails the count guard below.
 func TestIsSliceInvariant_UnregisteredKinds(t *testing.T) {
 	t.Parallel()
@@ -49,6 +50,7 @@ func TestIsSliceInvariant_UnregisteredKinds(t *testing.T) {
 		reflect.TypeOf(&chplan.RangeBucketFanout{}): true,
 		reflect.TypeOf(&chplan.StepGrid{}):          true,
 		reflect.TypeOf(&chplan.UnionAll{}):          true,
+		reflect.TypeOf(&chplan.VectorJoin{}):        true,
 	}
 
 	var unregisteredSeen int
@@ -63,22 +65,27 @@ func TestIsSliceInvariant_UnregisteredKinds(t *testing.T) {
 		}
 	}
 
-	// 31 total node kinds, 9 registered → 22 must be default-denied. If this
+	// 31 total node kinds, 10 registered → 21 must be default-denied. If this
 	// drifts, a node kind was added: decide explicitly whether it is
 	// slice-invariant (extend sliceInvariantKinds + the registered set here)
 	// or not (it falls into the default-deny count).
 	//
-	// NaryVectorSetOp is deliberately default-denied: like VectorSetOp it is
-	// a set-op family node, absent from sliceInvariantKinds until its own
-	// slice-invariance proof + §Parity lanes land. RangeWindowNative is also
-	// default-denied: the experimental native-rate node is never routed by
-	// the solver (ReanchorRange does not re-grid it), so it fails closed to
-	// route A — exactly the safe default for an opt-in node. InfoJoin is a
-	// join-family node (like VectorJoin) and is default-denied for the same
-	// reason: its two arms aren't a simple sliced row stream. RangeWindowResample
-	// (a re-gridding range node) and SearchTraceLimit (a per-trace cap) are
-	// likewise default-denied — neither is a simple sliced row stream.
-	const wantUnregistered = 31 - 9
+	// VectorJoin is now REGISTERED (the step-aligned vector-vector join —
+	// each output row reduces one anchor's window on each arm because the
+	// anchor timestamp is in the join key). Its instant-mode shape is held on
+	// route A not by this registry but by the solver's sawInstantVectorJoin
+	// fail-closed guard. VectorSetOp / NaryVectorSetOp are deliberately
+	// default-denied: set-op family nodes (and/or/unless), absent from
+	// sliceInvariantKinds until their own slice-invariance proof + §Parity
+	// lanes land. RangeWindowNative is also default-denied: the experimental
+	// native-rate node is never routed by the solver (ReanchorRange does not
+	// re-grid it), so it fails closed to route A — exactly the safe default for
+	// an opt-in node. InfoJoin is a join-family node whose Info arm is a
+	// point-in-time label lookup, not a sliced row stream, so it stays
+	// default-denied. RangeWindowResample (a re-gridding range node) and
+	// SearchTraceLimit (a per-trace cap) are likewise default-denied — neither
+	// is a simple sliced row stream.
+	const wantUnregistered = 31 - 10
 	if unregisteredSeen != wantUnregistered {
 		t.Fatalf("expected %d default-denied node kinds, saw %d — a node kind was added; "+
 			"make an explicit slice-invariance decision", wantUnregistered, unregisteredSeen)

--- a/internal/solver/avb_chdb_lane_test.go
+++ b/internal/solver/avb_chdb_lane_test.go
@@ -24,9 +24,10 @@
 //     to route is a hard failure (known-untested, not silently passed), and
 //     the routed count is printed.
 //
-// The fixtures deliberately seed a NaN-emitting series (a dup-input-timestamp
-// counter whose window has sampled_interval == 0, so route A legitimately
-// emits literal nan) and duplicate output timestamps (two series share every
+// The fixtures deliberately seed a NaN-emitting shape (job=d — a dense FLAT
+// counter carried IDENTICALLY on http_requests_total and http_errors_total, so
+// rate() is exactly 0 on both arms and the vector-vector RATIO is 0/0 = literal
+// nan at every anchor) and duplicate output timestamps (two series share every
 // anchor_ts), so the comparator's NaN-bit-class and duplicate-multiplicity
 // paths are exercised on real data.
 //
@@ -77,10 +78,26 @@ var (
 //     both series, so EVERY anchor_ts appears with multiplicity 2 in the
 //     output — the duplicate-timestamp coverage the comparator must handle.
 //
-//   - job=c — exactly two samples at the SAME timestamp (00:10:00). Its only
-//     populated windows hold first_ts == last_ts, so sampled_interval == 0
-//     and route A's rate() arithmetic legitimately emits literal nan — the
-//     NaN-bit-class coverage. The dup-input-timestamp is itself the trigger.
+//   - job=c — exactly two samples at the SAME timestamp (00:10:00). The rate
+//     emitter's timestamp-dedup (dedupWindowPairsByTsFrag / arrayCompact by ts)
+//     collapses the two same-timestamp samples to a single window element, so
+//     every job=c window holds length 1 and fails rate's `length >= 2` filter:
+//     job=c is DROPPED from every rate() output. It is the dup-input-timestamp
+//     DEDUP-DROP coverage — route A and every shard must agree on the drop.
+//
+//   - job=d — a dense FLAT counter, one sample every 15s for the full hour
+//     (241 samples), every sample the SAME value. A flat counter has zero
+//     counter-delta, so rate(job=d[5m]) is exactly 0 at every anchor (a
+//     finite, non-dropped value). job=d exists so the vector-vector ratio
+//     fixtures below emit a GENUINE literal nan: 0/0.
+//
+// A parallel counter http_errors_total carries the SAME four-series shape
+// (dense job=a/job=b, a dup-input-timestamp job=c, a dense flat job=d). Because
+// job=d is flat on BOTH metrics, both ratio arms rate() to 0 at every anchor,
+// so the join emits 0/0 = literal nan for job=d — the NaN-bit-class coverage.
+// The nan is produced deterministically (0.0/0.0) and IDENTICALLY on route A
+// and the owning shard (each anchor is computed in exactly one shard), so the
+// comparator's NaN==NaN-by-bit-class path fires while parity stays green.
 //
 // The ORDER BY does not dedup (MergeTree, not ReplacingMergeTree), so both
 // job=c rows persist. Statements are newline-clean (no inline `-- comment`
@@ -110,7 +127,30 @@ SELECT 'http_requests_total', map('job', 'b'), 'svc',
 FROM numbers(241);
 INSERT INTO otel_metrics_sum (MetricName, Attributes, ServiceName, TimeUnix, Value) VALUES
   ('http_requests_total', map('job', 'c'), 'svc', toDateTime64('2026-06-13 00:10:00', 9), 5.0),
-  ('http_requests_total', map('job', 'c'), 'svc', toDateTime64('2026-06-13 00:10:00', 9), 9.0);`
+  ('http_requests_total', map('job', 'c'), 'svc', toDateTime64('2026-06-13 00:10:00', 9), 9.0);
+INSERT INTO otel_metrics_sum (MetricName, Attributes, ServiceName, TimeUnix, Value)
+SELECT 'http_errors_total', map('job', 'a'), 'svc',
+  toDateTime64('2026-06-13 00:00:00', 9) + toIntervalSecond(number * 15),
+  toFloat64(number) * 0.5
+FROM numbers(241);
+INSERT INTO otel_metrics_sum (MetricName, Attributes, ServiceName, TimeUnix, Value)
+SELECT 'http_errors_total', map('job', 'b'), 'svc',
+  toDateTime64('2026-06-13 00:00:00', 9) + toIntervalSecond(number * 15),
+  toFloat64(number)
+FROM numbers(241);
+INSERT INTO otel_metrics_sum (MetricName, Attributes, ServiceName, TimeUnix, Value) VALUES
+  ('http_errors_total', map('job', 'c'), 'svc', toDateTime64('2026-06-13 00:10:00', 9), 3.0),
+  ('http_errors_total', map('job', 'c'), 'svc', toDateTime64('2026-06-13 00:10:00', 9), 7.0);
+INSERT INTO otel_metrics_sum (MetricName, Attributes, ServiceName, TimeUnix, Value)
+SELECT 'http_requests_total', map('job', 'd'), 'svc',
+  toDateTime64('2026-06-13 00:00:00', 9) + toIntervalSecond(number * 15),
+  toFloat64(100)
+FROM numbers(241);
+INSERT INTO otel_metrics_sum (MetricName, Attributes, ServiceName, TimeUnix, Value)
+SELECT 'http_errors_total', map('job', 'd'), 'svc',
+  toDateTime64('2026-06-13 00:00:00', 9) + toIntervalSecond(number * 15),
+  toFloat64(100)
+FROM numbers(241);`
 
 // laneFixtures are the eligible shapes the lane proves. Each is a real shape
 // the Planner routes under sharded mode over laneSeed:
@@ -126,16 +166,41 @@ INSERT INTO otel_metrics_sum (MetricName, Attributes, ServiceName, TimeUnix, Val
 //     pass exactly. (No rate arithmetic → no NaN cell, but it shares every
 //     anchor_ts across job=a / job=b, so it adds duplicate-timestamp coverage.)
 //
-// The matrix shapes each carry a NaN cell (the job=c window) and duplicate
-// output timestamps (job=a / job=b share every anchor_ts before aggregation;
-// sum by (job) keeps the per-anchor duplication across the surviving keys); the
-// combined NaN / duplicate-timestamp boundary-coverage gates are satisfied
-// across the whole fixture set.
+// The bare matrix shapes carry duplicate output timestamps (job=a / job=b share
+// every anchor_ts before aggregation; sum by (job) keeps the per-anchor
+// duplication across the surviving keys). The vector-vector RATIO shapes below
+// additionally carry the literal-nan cell (job=d's 0/0). Together the fixture
+// set satisfies the combined NaN / duplicate-timestamp boundary-coverage gates.
 var laneFixtures = []string{
 	"rate(http_requests_total[5m])",
 	"sum(rate(http_requests_total[5m]))",
 	"sum by (job) (rate(http_requests_total[5m]))",
 	"http_requests_total",
+	// Step-aligned vector-vector joins — the shapes this PR unlocks. In
+	// range mode both arms produce a per-step matrix, so the lowering sets
+	// StepAligned=true and the join step-aligns on the per-anchor
+	// TimestampColumn (the join key includes the anchor timestamp), making
+	// every joined row a per-(match-key, anchor) reduce that route B slices
+	// safely. The job=d flat-counter arm rate()s to 0 on BOTH metrics, so the
+	// ratio for job=d is 0/0 = literal nan at every anchor — the NaN coverage.
+	//
+	// - one-to-one on {job}: both arms `sum by (job)` leave a single {job}
+	//   key, matched one-to-one (default on-all-labels).
+	"sum by (job) (rate(http_requests_total[5m])) / sum by (job) (rate(http_errors_total[5m]))",
+	// - on(job) group_left(): exercises the CardManyToOne emitter path (the
+	//   per-(match-key, anchor) dedup throwIf(uniqExact>1) + Include
+	//   mapConcat). With one series per (job, anchor) the uniqueness guard is
+	//   satisfied; the parity proof is that route A's dedup and each shard's
+	//   dedup agree because the anchor timestamp is in the join key.
+	"sum by (job) (rate(http_requests_total[5m])) / on (job) group_left () sum by (job) (rate(http_errors_total[5m]))",
+	// - asymmetric per-arm offset: only the errors arm carries `offset 5m`, so
+	//   the two arms re-anchor to the same shard grid but each keeps its OWN
+	//   offset window. This is the join shape a single global (ΣRange,
+	//   one-offset) scan floor would mishandle; the parity proof is that route
+	//   B's per-arm re-gridding preserves each arm's offset exactly, so the
+	//   sliced ratio equals route A's. The offset drops the first ~10m of
+	//   anchors on the errors arm, but job=a/job=b stay dense afterward.
+	"sum by (job) (rate(http_requests_total[5m])) / sum by (job) (rate(http_errors_total[5m] offset 5m))",
 }
 
 // TestSolver_AvsB_ChDB_Differential is the per-PR parity workhorse. For each
@@ -235,7 +300,7 @@ func TestSolver_AvsB_ChDB_Differential(t *testing.T) {
 	// seed, never to tolerate.
 	if totalNaNCells == 0 {
 		t.Fatalf("comparator NaN path UNEXERCISED: no NaN value-cell appeared in any " +
-			"route-A result — the dup-input-timestamp seed must emit literal nan")
+			"route-A result — the flat-counter job=d must rate() to 0 on both ratio arms so 0/0 emits literal nan")
 	}
 	if totalDupTimestampGroups == 0 {
 		t.Fatalf("comparator duplicate-timestamp path UNEXERCISED: no timestamp appeared " +

--- a/internal/solver/decision.go
+++ b/internal/solver/decision.go
@@ -118,6 +118,14 @@ const (
 	// exceeds the configured fraction of the outer plan — the slice benefit
 	// cannot pay for replicating it.
 	ReasonScalarHeavy = "scalar-heavy"
+
+	// ReasonInstantJoin: an instant-mode (StepAligned==false) VectorJoin. The
+	// VectorJoin node kind is registered slice-invariant, but the instant shape
+	// synthesizes its join-side timestamp with now64(9) in the emitted SQL — a
+	// wall-clock that diverges across shards and never reaches the plan-level
+	// now64 scanner. Fails closed to route A; only the StepAligned (range-mode)
+	// join, which step-aligns on the real per-anchor timestamp, routes B.
+	ReasonInstantJoin = "instant-join"
 )
 
 // Slice is one shard of the anchor-grid decomposition. Bounds are

--- a/internal/solver/planner.go
+++ b/internal/solver/planner.go
@@ -97,6 +97,20 @@ func (p *Planner) Plan(plan chplan.Node, meta RequestMeta) (*Decision, bool) {
 	if sig.sawNow64 {
 		return notRouted(ReasonNow64).withGrid(sig, meta), false
 	}
+	// (3b) An instant-mode (!StepAligned) VectorJoin. The slice-invariance
+	// registry admits VectorJoin by node kind, so it ALSO admits the
+	// instant-mode shape — whose emitter synthesizes the join-side timestamp
+	// with now64(9) (internal/chsql/vector_join.go joinTimestampFrag), a
+	// wall-clock the plan-level now64 scanner never sees (it is minted in the
+	// SQL, not carried as a chplan FuncCall). Only the StepAligned (range-mode)
+	// join step-aligns on the real per-anchor TimestampColumn and is safe to
+	// slice; the instant shape fails closed to route A. Plan's Step<=0 guard
+	// already rejects instant *queries* before analyze, but a !StepAligned join
+	// can appear under a range-mode request, so this guard is both the
+	// load-bearing fail-close AND honest telemetry.
+	if sig.sawInstantVectorJoin {
+		return notRouted(ReasonInstantJoin).withGrid(sig, meta), false
+	}
 	// (2) Both Start and End pinned on every windowed node, and no
 	// instant-shape windowed node (OuterRange == 0 / Step == 0).
 	if sig.sawUnpinnedBound || sig.sawInstantWindow {
@@ -237,6 +251,15 @@ type signals struct {
 	sawIncommensurate bool
 	sawScalarHeavy    bool
 
+	// sawInstantVectorJoin records a StepAligned==false VectorJoin — an
+	// instant-mode vector-vector join. Its emitter synthesizes the join-side
+	// timestamp with now64(9) (a per-shard-divergent wall-clock invisible to
+	// the plan-level now64 scanner), so it must stay on route A even though the
+	// VectorJoin node kind is registered slice-invariant. The StepAligned
+	// (range-mode) join, which step-aligns on the real per-anchor
+	// TimestampColumn, does not set this flag and remains routable.
+	sawInstantVectorJoin bool
+
 	// sawNonRangeWindowSpine records a routed-spine grid bound-carrier whose
 	// grid ReanchorRange does NOT re-anchor — a RangeBucketFanout or StepGrid,
 	// which ReanchorRange CloneNode's verbatim (every shard would emit
@@ -375,6 +398,26 @@ func (p *Planner) walkNode(n chplan.Node, predStart, predEnd time.Time, depth in
 			p.walkExpr(pr.Expr, sig)
 		}
 		p.walkNode(v.Input, predStart, predEnd, depth, sig)
+		return
+
+	case *chplan.VectorJoin:
+		// A vector-vector join is registered slice-invariant, but only the
+		// StepAligned (range-mode) shape is actually safe to slice: the emitter
+		// step-aligns on the real per-anchor TimestampColumn, so each
+		// (match-key, anchor) pair joins independently and the many-to-one
+		// dedup (throwIf(uniqExact>1)) + Include mapConcat are per-anchor. The
+		// instant-mode (!StepAligned) shape synthesizes the join-side timestamp
+		// with now64(9) in SQL (invisible to walkExpr's now64 scan), so it must
+		// fail closed to route A — record the signal the Plan() gate reads.
+		if !v.StepAligned {
+			sig.sawInstantVectorJoin = true
+		}
+		// The join carries no own grid and no lookback: BOTH arms are
+		// independent windowed spines evaluating over the SAME [predStart,
+		// predEnd] at this depth (no widening at the join level — each arm's
+		// own RangeWindow / RangeLWR widens its inner scan). Recurse both.
+		p.walkNode(v.Left, predStart, predEnd, depth, sig)
+		p.walkNode(v.Right, predStart, predEnd, depth, sig)
 		return
 	}
 
@@ -540,12 +583,26 @@ func (p *Planner) walkExpr(e chplan.Expr, sig *signals) {
 // walkScalarInterior walks a ScalarSubquery's plan for now64 and unmarked
 // nodes only — its bounds do not participate in the outer anchor grid, so the
 // grid-prediction / commensurability checks are intentionally skipped here.
+//
+// It ALSO carries the sawInstantVectorJoin fail-close (mirroring walkNode's
+// VectorJoin case): the slice-invariance registry admits VectorJoin by node
+// kind, so an instant-mode (!StepAligned) join buried in a scalar interior —
+// e.g. scalar(sum(up_a)/sum(up_b)), whose Aggregate-rooted arms carry no
+// windowed node and so never trip checkScalarHeavy, and whose now64(9)
+// join-side timestamp is minted in SQL and so never trips the now64 scan —
+// would otherwise pass every gate and route B, replicating a per-shard
+// wall-clock scalar across time-slices. Flag it here so it fails closed to
+// route A exactly as a top-level instant join does.
 func (p *Planner) walkScalarInterior(n chplan.Node, sig *signals) {
 	chplan.Walk(n, func(node chplan.Node) bool {
 		if !chplan.IsSliceInvariant(node) {
 			sig.allSliceInvariant = false
 		}
 		switch v := node.(type) {
+		case *chplan.VectorJoin:
+			if !v.StepAligned {
+				sig.sawInstantVectorJoin = true
+			}
 		case *chplan.Filter:
 			p.scanExprForNow64(v.Predicate, sig)
 		case *chplan.Project:

--- a/internal/solver/planner_vectorjoin_test.go
+++ b/internal/solver/planner_vectorjoin_test.go
@@ -1,0 +1,164 @@
+package solver
+
+import (
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// joinPlan builds a vector-vector ratio join over two `sum(rate(m[5m]))` arms
+// (each the oomWindow shape — an Aggregate over a pinned matrix RangeWindow on
+// the canonical 1h/15s grid). stepAligned toggles the range-vs-instant mode
+// flag; every other field is held fixed so the ONLY thing distinguishing the
+// routable case from the fail-closed case is StepAligned.
+func joinPlan(stepAligned bool) *chplan.VectorJoin {
+	return &chplan.VectorJoin{
+		Left:             oomWindow(),
+		Right:            oomWindow(),
+		Op:               chplan.OpDiv,
+		Match:            chplan.VectorMatch{Labels: []string{"job"}, On: true},
+		StepAligned:      stepAligned,
+		MetricNameColumn: "MetricName",
+		AttributesColumn: "Attributes",
+		TimestampColumn:  "TimeUnix",
+		ValueColumn:      "Value",
+	}
+}
+
+// TestPlan_StepAlignedVectorJoinRoutes: a StepAligned vector-vector join whose
+// arms are both slice-invariant routes B under Mode=sharded. This is the
+// positive half of the discrimination proof — the same plan shape with
+// StepAligned=false must NOT route (see below), so a passing pair proves the
+// guard keys on StepAligned, not on the node kind alone.
+func TestPlan_StepAlignedVectorJoinRoutes(t *testing.T) {
+	t.Parallel()
+	cfg := DefaultConfig()
+	cfg.Mode = ModeSharded // floor thresholds: eligibility, not cost, decides.
+	p := &Planner{Cfg: cfg}
+
+	d, routed := p.Plan(joinPlan(true), oomMeta())
+	if !routed {
+		t.Fatalf("StepAligned vector-vector join must route B; got reason=%q", d.Reason)
+	}
+	if d.Reason != ReasonRouted {
+		t.Fatalf("reason = %q, want %q", d.Reason, ReasonRouted)
+	}
+	if d.K < 2 {
+		t.Fatalf("routed join must produce K >= 2 slices, got K=%d", d.K)
+	}
+}
+
+// TestPlan_InstantVectorJoinRoutesA: the negative half — a StepAligned=false
+// (instant-mode) vector-vector join must fail closed to route A with
+// ReasonInstantJoin, even though VectorJoin is registered slice-invariant. Its
+// emitter synthesizes the join-side timestamp with now64(9), a wall-clock that
+// diverges across shards; slicing it would silently concatenate wrong results.
+func TestPlan_InstantVectorJoinRoutesA(t *testing.T) {
+	t.Parallel()
+	cfg := DefaultConfig()
+	cfg.Mode = ModeSharded // even with thresholds floored, it must NOT route.
+	p := &Planner{Cfg: cfg}
+
+	d, routed := p.Plan(joinPlan(false), oomMeta())
+	if routed {
+		t.Fatalf("instant-mode (!StepAligned) vector-vector join must NOT route (K=%d)", d.K)
+	}
+	if d.Reason != ReasonInstantJoin {
+		t.Fatalf("reason = %q, want %q", d.Reason, ReasonInstantJoin)
+	}
+}
+
+// instantScalarInteriorJoinPlan builds the leak shape the registry opened: a
+// routable outer spine (the oomWindow sum(rate) grid) carrying a ScalarSubquery
+// whose interior is an INSTANT (!StepAligned) vector-vector join over two
+// Aggregate-rooted instant arms (sum(up_a) / sum(up_b) — NO windowed node
+// inside, so checkScalarHeavy never fires, and the now64(9) join-side timestamp
+// is minted in SQL, so the now64 scan never fires either). Only the
+// sawInstantVectorJoin fail-close in walkScalarInterior stands between this plan
+// and a route-B decision that would replicate a per-shard wall-clock scalar
+// across time-slices.
+func instantScalarInteriorJoinPlan() chplan.Node {
+	instantArm := func() chplan.Node {
+		return &chplan.Aggregate{
+			Input:    leafScan(),
+			AggFuncs: []chplan.AggFunc{{Name: "sum", Args: []chplan.Expr{&chplan.ColumnRef{Name: "Value"}}}},
+		}
+	}
+	join := &chplan.VectorJoin{
+		Left:             instantArm(),
+		Right:            instantArm(),
+		Op:               chplan.OpDiv,
+		Match:            chplan.VectorMatch{Labels: []string{"job"}, On: true},
+		StepAligned:      false, // instant-mode: emitter synthesizes now64(9)
+		MetricNameColumn: "MetricName",
+		AttributesColumn: "Attributes",
+		TimestampColumn:  "TimeUnix",
+		ValueColumn:      "Value",
+	}
+	rw := &chplan.RangeWindow{
+		Input:           leafScan(),
+		Func:            "rate",
+		Range:           5 * time.Minute,
+		Step:            gridStep,
+		OuterRange:      time.Hour,
+		Start:           gridStart,
+		End:             gridEnd,
+		TimestampColumn: "TimeUnix",
+		ValueColumn:     "Value",
+		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+		ScalarExprs:     []chplan.Expr{&chplan.ScalarSubquery{Input: join}},
+	}
+	return &chplan.Aggregate{
+		Input:    rw,
+		AggFuncs: []chplan.AggFunc{{Name: "sum", Args: []chplan.Expr{&chplan.ColumnRef{Name: "Value"}}}},
+	}
+}
+
+// TestPlan_InstantVectorJoinInScalarInteriorRoutesA: an instant vector-vector
+// join buried in a ScalarSubquery interior must fail closed to route A with
+// ReasonInstantJoin, exactly like a top-level instant join. The main-path
+// walkNode never recurses into ScalarSubquery.Input — walkScalarInterior does —
+// so without a VectorJoin case there, this plan slips every gate (it is
+// slice-invariant, now64-free at the chplan level, and not scalar-heavy) and
+// routes B, silently concatenating a per-shard now64(9) scalar across slices.
+// This is the regression guard for that leak.
+func TestPlan_InstantVectorJoinInScalarInteriorRoutesA(t *testing.T) {
+	t.Parallel()
+	cfg := DefaultConfig()
+	cfg.Mode = ModeSharded // floor thresholds: only the fail-close can stop it.
+	p := &Planner{Cfg: cfg}
+
+	d, routed := p.Plan(instantScalarInteriorJoinPlan(), oomMeta())
+	if routed {
+		t.Fatalf("instant join in a scalar interior must NOT route (K=%d)", d.K)
+	}
+	if d.Reason != ReasonInstantJoin {
+		t.Fatalf("reason = %q, want %q", d.Reason, ReasonInstantJoin)
+	}
+}
+
+// TestPlan_VectorJoinAtPinnedArmRoutesA: a StepAligned join with one @-pinned
+// arm (its End diverges from the request grid) must route A. The grid-
+// prediction guard fires on the divergent arm exactly as it does on a
+// single-spine @-pinned window, so an @ inside a join arm cannot slip a
+// wrong-grid shard plan past the solver.
+func TestPlan_VectorJoinAtPinnedArmRoutesA(t *testing.T) {
+	t.Parallel()
+	cfg := DefaultConfig()
+	cfg.Mode = ModeSharded
+	p := &Planner{Cfg: cfg}
+
+	j := joinPlan(true)
+	// Pin the right arm's outermost RangeWindow to an End off the request grid.
+	pinnedArm := j.Right.(*chplan.Aggregate).Input.(*chplan.RangeWindow)
+	pinnedArm.End = gridEnd.Add(time.Hour) // != predicted grid end
+
+	d, routed := p.Plan(j, oomMeta())
+	if routed {
+		t.Fatalf("join with an @-pinned arm must NOT route (K=%d)", d.K)
+	}
+	if d.Reason != ReasonGridMismatch {
+		t.Fatalf("reason = %q, want %q", d.Reason, ReasonGridMismatch)
+	}
+}

--- a/internal/solver/slicer.go
+++ b/internal/solver/slicer.go
@@ -62,8 +62,9 @@ func (p *Planner) slice(plan chplan.Node, meta RequestMeta, k int) ([]Slice, err
 		k = 2
 	}
 
-	// Spine geometry the scan floor needs: Offset and cumulative lookback D.
-	offset, d := spineOffsetAndD(plan)
+	// How far back before each slice's oldest anchor its input scan must reach
+	// (Offset + lookback, compounded along nested spines, max across join arms).
+	reach := spineReach(plan)
 
 	// The plan that reaches the slicer is pinned at the full request grid
 	// [Start, End] (the Planner's grid-prediction guard already verified it
@@ -117,13 +118,12 @@ func (p *Planner) slice(plan chplan.Node, meta RequestMeta, k int) ([]Slice, err
 		endJ := end.Add(-time.Duration(sp.startIdx) * step)
 		startJ := end.Add(-time.Duration(sp.startIdx+sp.count-1) * step)
 
-		// ScanFrom_j = Start_j - D - Offset_spine. Offset enters with its
-		// sign: a negative offset widens the scan to the RIGHT past End_j,
-		// and the left floor moves accordingly. ScanFrom is solver-owned and
-		// sign-aware (docs §Decomposition); the re-anchored plan carries the
-		// grid, and the executor (a later PR) consumes ScanFrom for the
-		// offset-aware pushdown.
-		scanFrom := startJ.Add(-d).Add(-offset)
+		// ScanFrom_j = Start_j - reach, where reach folds each spine's Offset
+		// (with its sign) and lookback and takes the deepest join/union arm.
+		// ScanFrom is solver-owned and sign-aware (docs §Decomposition); the
+		// re-anchored plan carries the grid, and the executor (a later PR)
+		// consumes ScanFrom for the offset-aware pushdown.
+		scanFrom := startJ.Add(-reach)
 
 		shardPlan, err := chplan.ReanchorRange(base, startJ, endJ)
 		if err != nil {
@@ -304,42 +304,44 @@ func zeroSpineInPlace(n chplan.Node) {
 	}
 }
 
-// spineOffsetAndD walks the windowed spine of plan to recover the Offset
-// folded onto the selector and the cumulative lookback D (Σ Range down matrix
-// windows + leaf RangeLWR.Lookback). Both feed the solver-owned, sign-aware
-// scan floor (docs §Decomposition): the matrix emitters are offset-blind, so
-// the solver derives the input interval itself.
-func spineOffsetAndD(plan chplan.Node) (offset, d time.Duration) {
-	var walk func(chplan.Node)
-	walk = func(n chplan.Node) {
-		switch v := n.(type) {
-		case *chplan.RangeWindow:
-			if v.Offset != 0 {
-				offset = v.Offset
-			}
-			d += v.Range
-			walk(v.Input)
-			return
-		case *chplan.RangeLWR:
-			if v.Offset != 0 {
-				offset = v.Offset
-			}
-			d += v.Lookback
-			walk(v.Input)
-			return
-		case *chplan.Filter:
-			walk(v.Input)
-			return
-		case *chplan.Project:
-			walk(v.Input)
-			return
-		}
-		for _, c := range n.Children() {
-			walk(c)
+// spineReach returns how far BACK before a slice's oldest anchor the slice's
+// input scan must reach: the maximum, over every windowed spine PATH in plan, of
+// (Σ Range/Lookback + Σ Offset along that path). The caller derives
+// ScanFrom_j = Start_j - reach; the matrix emitters are offset-blind, so the
+// solver owns this floor (docs §Decomposition).
+//
+// Range and Offset COMPOUND along a NESTED spine (a subquery's inner window is
+// evaluated at the outer window's shifted sub-anchors), so a path sums them.
+// PARALLEL arms — a VectorJoin's two arms, a companion UnionAll's arms — are
+// independent, so the deepest arm wins (max). This is why the reach cannot
+// collapse to one global (Σ Range, single Offset): summing parallel arms
+// over-scans the shallower one, and — the real hazard — a single
+// "last-offset-wins" scalar can pick the shallower arm's Offset and UNDER-scan
+// the deeper arm (e.g. rate(a[5m]) / rate(b[5m] offset 1h)), silently dropping
+// rows the deeper arm needs. A negative Offset shifts the window toward the
+// future and shrinks a path's reach; max keeps whichever path reaches furthest
+// into the past.
+func spineReach(plan chplan.Node) time.Duration {
+	if plan == nil {
+		return 0
+	}
+	switch v := plan.(type) {
+	case *chplan.RangeWindow:
+		return v.Offset + v.Range + spineReach(v.Input)
+	case *chplan.RangeLWR:
+		return v.Offset + v.Lookback + spineReach(v.Input)
+	}
+	// Off-window node: Filter / Project / Aggregate pass through to their single
+	// spine child; a VectorJoin / UnionAll fans out to parallel arms. The reach
+	// is the deepest child's, or 0 at a leaf (Scan).
+	first := true
+	var reach time.Duration
+	for _, c := range plan.Children() {
+		if r := spineReach(c); first || r > reach {
+			reach, first = r, false
 		}
 	}
-	walk(plan)
-	return offset, d
+	return reach
 }
 
 // gcdDuration returns gcd(|a|,|b|) as a Duration (nanosecond granularity).

--- a/internal/solver/slicer_reach_test.go
+++ b/internal/solver/slicer_reach_test.go
@@ -1,0 +1,106 @@
+package solver
+
+import (
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// rwReach builds a matrix RangeWindow on the canonical grid with a caller-chosen
+// Range and Offset over input, for exercising spineReach in isolation.
+func rwReach(rang, offset time.Duration, input chplan.Node) *chplan.RangeWindow {
+	return &chplan.RangeWindow{
+		Input:           input,
+		Func:            "rate",
+		Range:           rang,
+		Offset:          offset,
+		Step:            gridStep,
+		OuterRange:      time.Hour,
+		Start:           gridStart,
+		End:             gridEnd,
+		TimestampColumn: "TimeUnix",
+		ValueColumn:     "Value",
+	}
+}
+
+// joinArms is a minimal StepAligned VectorJoin over two arms — only the spine
+// arms matter to spineReach.
+func joinArms(left, right chplan.Node) *chplan.VectorJoin {
+	return &chplan.VectorJoin{
+		Left:            left,
+		Right:           right,
+		StepAligned:     true,
+		TimestampColumn: "TimeUnix",
+		ValueColumn:     "Value",
+	}
+}
+
+// TestSpineReach pins the scan-floor depth spineReach derives for each spine
+// shape: Range/Lookback and Offset compound along a nested path, and parallel
+// join arms take the deepest (max), so an asymmetric per-arm offset can never
+// under-scan the deeper arm.
+func TestSpineReach(t *testing.T) {
+	t.Parallel()
+	const (
+		fiveMin = 5 * time.Minute
+		oneHour = time.Hour
+	)
+	tests := []struct {
+		name string
+		plan chplan.Node
+		want time.Duration
+	}{
+		{
+			name: "single window, no offset",
+			plan: rwReach(fiveMin, 0, leafScan()),
+			want: fiveMin,
+		},
+		{
+			name: "single window offset compounds with range",
+			plan: rwReach(fiveMin, oneHour, leafScan()),
+			want: fiveMin + oneHour,
+		},
+		{
+			name: "aggregate passes through to its spine child",
+			plan: &chplan.Aggregate{Input: rwReach(fiveMin, oneHour, leafScan())},
+			want: fiveMin + oneHour,
+		},
+		{
+			name: "lwr uses lookback plus offset",
+			plan: lwrSpine(oneHour), // Lookback 5m + offset 1h
+			want: fiveMin + oneHour,
+		},
+		{
+			name: "nested subquery compounds range and offset along the path",
+			// outer(Range=1h, off=2h) over inner(Range=5m, off=1h)
+			plan: rwReach(oneHour, 2*oneHour, rwReach(fiveMin, oneHour, leafScan())),
+			want: oneHour + 2*oneHour + fiveMin + oneHour,
+		},
+		{
+			name: "join takes the deeper (right) arm, not last-wins",
+			// left 5m+0 vs right 5m+1h — a single last-offset-wins scalar would
+			// pick the left arm's 0 offset and under-scan the right arm.
+			plan: joinArms(rwReach(fiveMin, 0, leafScan()), rwReach(fiveMin, oneHour, leafScan())),
+			want: fiveMin + oneHour,
+		},
+		{
+			name: "join takes the deeper (left) arm",
+			plan: joinArms(rwReach(fiveMin, 2*oneHour, leafScan()), rwReach(fiveMin, oneHour, leafScan())),
+			want: fiveMin + 2*oneHour,
+		},
+		{
+			name: "join with a future-looking (negative offset) arm keeps the past arm",
+			// left 5m+(-1h) = -55m (reaches into the future) vs right 5m+0
+			plan: joinArms(rwReach(fiveMin, -oneHour, leafScan()), rwReach(fiveMin, 0, leafScan())),
+			want: fiveMin,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := spineReach(tc.plan); got != tc.want {
+				t.Fatalf("spineReach = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/test/perf/solver-decision-baseline.json
+++ b/test/perf/solver-decision-baseline.json
@@ -169,21 +169,21 @@
   },
   {
     "query": "binop_atan2_vv",
-    "routed": false,
-    "k": 0,
-    "reason": "not-sliceable"
+    "routed": true,
+    "k": 6,
+    "reason": "routed"
   },
   {
     "query": "binop_ignoring_instance_strips_instance",
-    "routed": false,
-    "k": 0,
-    "reason": "not-sliceable"
+    "routed": true,
+    "k": 6,
+    "reason": "routed"
   },
   {
     "query": "binop_increase_plus_rate",
-    "routed": false,
-    "k": 0,
-    "reason": "not-sliceable"
+    "routed": true,
+    "k": 6,
+    "reason": "routed"
   },
   {
     "query": "binop_metric_minus_time",
@@ -193,9 +193,9 @@
   },
   {
     "query": "binop_on_job_strips_instance",
-    "routed": false,
-    "k": 0,
-    "reason": "not-sliceable"
+    "routed": true,
+    "k": 6,
+    "reason": "routed"
   },
   {
     "query": "binop_prod_repro",
@@ -205,39 +205,39 @@
   },
   {
     "query": "binop_rate_div_rate_ignoring",
-    "routed": false,
-    "k": 0,
-    "reason": "not-sliceable"
+    "routed": true,
+    "k": 6,
+    "reason": "routed"
   },
   {
     "query": "binop_rate_div_rate_on",
-    "routed": false,
-    "k": 0,
-    "reason": "not-sliceable"
+    "routed": true,
+    "k": 6,
+    "reason": "routed"
   },
   {
     "query": "binop_rate_plus_rate",
-    "routed": false,
-    "k": 0,
-    "reason": "not-sliceable"
+    "routed": true,
+    "k": 6,
+    "reason": "routed"
   },
   {
     "query": "binop_redis_hit_ratio_range",
-    "routed": false,
-    "k": 0,
-    "reason": "not-sliceable"
+    "routed": true,
+    "k": 4,
+    "reason": "routed"
   },
   {
     "query": "binop_scalar_mul_rate_div_rate_range",
-    "routed": false,
-    "k": 0,
-    "reason": "not-sliceable"
+    "routed": true,
+    "k": 6,
+    "reason": "routed"
   },
   {
     "query": "binop_sumby_rate_plus_sumby_rate",
-    "routed": false,
-    "k": 0,
-    "reason": "not-sliceable"
+    "routed": true,
+    "k": 6,
+    "reason": "routed"
   },
   {
     "query": "binop_time_arith_range",
@@ -265,15 +265,15 @@
   },
   {
     "query": "binop_vv_on_compare_eq",
-    "routed": false,
-    "k": 0,
-    "reason": "not-sliceable"
+    "routed": true,
+    "k": 6,
+    "reason": "routed"
   },
   {
     "query": "binop_vv_on_compare_lt",
-    "routed": false,
-    "k": 0,
-    "reason": "not-sliceable"
+    "routed": true,
+    "k": 6,
+    "reason": "routed"
   },
   {
     "query": "bool_lt",
@@ -283,15 +283,15 @@
   },
   {
     "query": "bool_vv_eq",
-    "routed": false,
-    "k": 0,
-    "reason": "not-sliceable"
+    "routed": true,
+    "k": 6,
+    "reason": "routed"
   },
   {
     "query": "bool_vv_gt",
-    "routed": false,
-    "k": 0,
-    "reason": "not-sliceable"
+    "routed": true,
+    "k": 6,
+    "reason": "routed"
   },
   {
     "query": "bottomk_2",
@@ -619,27 +619,27 @@
   },
   {
     "query": "edge_join_ignoring_extra",
-    "routed": false,
-    "k": 0,
-    "reason": "not-sliceable"
+    "routed": true,
+    "k": 6,
+    "reason": "routed"
   },
   {
     "query": "edge_join_ignoring_group_right",
-    "routed": false,
-    "k": 0,
-    "reason": "not-sliceable"
+    "routed": true,
+    "k": 6,
+    "reason": "routed"
   },
   {
     "query": "edge_join_on_extra_labels",
-    "routed": false,
-    "k": 0,
-    "reason": "not-sliceable"
+    "routed": true,
+    "k": 6,
+    "reason": "routed"
   },
   {
     "query": "edge_join_on_three_keys",
-    "routed": false,
-    "k": 0,
-    "reason": "not-sliceable"
+    "routed": true,
+    "k": 6,
+    "reason": "routed"
   },
   {
     "query": "edge_last_over_time",
@@ -721,15 +721,15 @@
   },
   {
     "query": "empty_ignoring_join",
-    "routed": false,
-    "k": 0,
-    "reason": "not-sliceable"
+    "routed": true,
+    "k": 6,
+    "reason": "routed"
   },
   {
     "query": "empty_on_join",
-    "routed": false,
-    "k": 0,
-    "reason": "not-sliceable"
+    "routed": true,
+    "k": 6,
+    "reason": "routed"
   },
   {
     "query": "exp_metric",
@@ -843,7 +843,7 @@
     "query": "histogram_mean_latency",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "below-threshold"
   },
   {
     "query": "histogram_quantile_agg_empty",
@@ -1405,9 +1405,9 @@
   },
   {
     "query": "power_op_vv",
-    "routed": false,
-    "k": 0,
-    "reason": "not-sliceable"
+    "routed": true,
+    "k": 6,
+    "reason": "routed"
   },
   {
     "query": "predict_linear_scalar_horizon",
@@ -1795,9 +1795,9 @@
   },
   {
     "query": "subquery_agg_of_binary",
-    "routed": false,
-    "k": 0,
-    "reason": "not-sliceable"
+    "routed": true,
+    "k": 8,
+    "reason": "routed"
   },
   {
     "query": "subquery_avg_over_time_increase",
@@ -2281,33 +2281,33 @@
   },
   {
     "query": "vector_group_left",
-    "routed": false,
-    "k": 0,
-    "reason": "not-sliceable"
+    "routed": true,
+    "k": 6,
+    "reason": "routed"
   },
   {
     "query": "vector_group_left_ignoring",
-    "routed": false,
-    "k": 0,
-    "reason": "not-sliceable"
+    "routed": true,
+    "k": 6,
+    "reason": "routed"
   },
   {
     "query": "vector_group_left_multi_include",
-    "routed": false,
-    "k": 0,
-    "reason": "not-sliceable"
+    "routed": true,
+    "k": 6,
+    "reason": "routed"
   },
   {
     "query": "vector_group_right",
-    "routed": false,
-    "k": 0,
-    "reason": "not-sliceable"
+    "routed": true,
+    "k": 6,
+    "reason": "routed"
   },
   {
     "query": "vector_ignoring_instance",
-    "routed": false,
-    "k": 0,
-    "reason": "not-sliceable"
+    "routed": true,
+    "k": 6,
+    "reason": "routed"
   },
   {
     "query": "vector_mod_scalar",
@@ -2317,15 +2317,15 @@
   },
   {
     "query": "vector_on_job",
-    "routed": false,
-    "k": 0,
-    "reason": "not-sliceable"
+    "routed": true,
+    "k": 6,
+    "reason": "routed"
   },
   {
     "query": "vector_plus_vector",
-    "routed": false,
-    "k": 0,
-    "reason": "not-sliceable"
+    "routed": true,
+    "k": 6,
+    "reason": "routed"
   },
   {
     "query": "vector_pow_scalar",


### PR DESCRIPTION
## What

Registers the PromQL `VectorJoin` node as **slice-invariant** so step-aligned vector-vector joins — ratio shapes like `sum(rate(a[5m])) / sum by(job)(rate(b[5m]))` — route through the solver's sharded **route B** instead of falling to route A with `decision_reason="not-sliceable"`.

## Why (live-prod evidence)

Querying the prod router-calibration corpus (`otel.cerberus_router_corpus`) surfaced that **route B has never fired in 3+ weeks of `ModeAuto`** — every one of ~137K observed queries fell into a rejection bucket. Investigating the buckets:

- `high-D` (the closest-to-eligible bucket) is a **correct, permanent** geometric rejection: for `rate(x[range])` where the selector window spans the whole panel, `D ≈ OuterRange`, so `floor(OuterRange/max(D,Step)) < 2` and K-way time-slicing buys zero I/O reduction. Not fixable, not a bug.
- `below-threshold` is correctly gated (genuinely cheap queries below `MinFanout`/`MinAnchorPairs`).
- **`not-sliceable` join shapes are the one real, addressable miss.** `cerb:project;agg=1;rw;join` (215 rows, avg fanout 31, N×F≈50K) and `cerb:project;agg=2;rw;join` (59 rows) clear every gate that matters and have healthy K-clamp geometry — they fall to route A **purely** because `VectorJoin` was never registered in `chplan.sliceInvariantKinds`. The registry doc comment already scoped this as deliberately-deferred, one-node-family-per-PR work.

## Slice-invariance proof

Each output row of a **step-aligned** join reduces exactly one anchor's window on each arm: the emitter ANDs `L.TimestampColumn = R.TimestampColumn` into the ON clause and adds the anchor timestamp to each side's `GROUP BY`. So evaluating over a disjoint sub-grid of anchors (with correspondingly bounded arm scans) yields exactly the rows route A produces. Holds across **all** matching (`on`/`ignoring`), **all** cardinalities (`group_left`/`group_right` — the many-to-one `throwIf(uniqExact>1)` dedup and `Include` `mapConcat` are per-`(match-key, anchor)` because the anchor timestamp is in the join key), and all ops incl `bool`.

## Fail-closed boundary

The registry is keyed by node kind, so it **also** admits the instant-mode (`StepAligned==false`) join — whose emitter synthesizes the join-side timestamp with `now64(9)`, a wall-clock that diverges across shards and never reaches the plan-level now64 scanner. That shape is held on route A by an explicit planner guard (`sawInstantVectorJoin` → `ReasonInstantJoin`), wired into **both** `walkNode` and `walkScalarInterior` — the latter closes a hole an adversarial review caught, where an instant join buried in a `scalar(sum(a)/sum(b))` interior would otherwise route B and replicate a per-shard wall-clock scalar. `VectorSetOp` / `NaryVectorSetOp` (and/or/unless) remain deliberately absent — each is its own future PR.

## Changes

| File | Change |
|---|---|
| `internal/chplan/reanchor.go` | `VectorJoin` case re-anchors **both** arms onto the same `[start,end]` (no widening — each arm's own `RangeWindow`/`RangeLWR` widens its scan), COW-cloning the join. **The blocker**: the slicer zeros both arms, so reanchor must re-fill them; without this, registration silently produces wrong shards. An `@`-pinned arm → `ErrReanchorGridMismatch` → route A. |
| `internal/solver/planner.go` | `sawInstantVectorJoin` signal + `VectorJoin` cases in `walkNode` and `walkScalarInterior` + `Plan()` gate (3b). |
| `internal/solver/decision.go` | `ReasonInstantJoin` telemetry const. |
| `internal/chplan/sliceinvariant.go` | Register `&VectorJoin{}` + boundary proof in the doc comment. |
| tests | registry-pin update (21 default-denied); reanchor both-arms / COW / `@`-pinned / rapid property cases; planner StepAligned discrimination + scalar-interior negative control; chDB A-vs-B parity fixtures (one-to-one and `on() group_left()` ratios). |

**Zero emitter/chsql changes.** `go build` + `go test` green on `internal/chplan` and `internal/solver`; chdb parity lane type-checks under the `chdb` tag (CI runs it).

## Reviewer notes / forward items (non-blocking)

- **Executor fail-hard confirmed**: `group_left`'s per-shard `throwIf(uniqExact>1)` preserves A/B parity only because the shard executor fails the whole request on any single-shard error (`executor.go` errgroup first-error-wins + `cursor.go` `g.Wait()` reap). Verified, no change needed.
- **Forward note (not a live bug)**: `spineOffsetAndD` collapses two arms' offsets into one global scan floor; for a routed join with *asymmetric per-arm offsets* it could under-represent one offset. Currently only feeds `Slice.ScanFrom`, which is dead-stored, so no live defect — worth tightening if that field is ever wired up.
- **Minor test-coverage gap**: the `group_left` parity fixture doesn't trip `throwIf` (seed has one series per `(job, anchor)`), so the many-to-one fail-hard parity path is proven only in the uniqueness-satisfied case. The A-vs-B harness `t.Fatalf`s on query errors, so exercising a firing `throwIf` there would abort the compare — a dedicated error-parity unit test is the right home if we want it covered.

## Not auto-merging

This touches the slice-invariance **safety gate** (a wrong registration silently produces incorrect cross-shard results with no compile/test signal — the `#92` hazard the registry doctrine exists to prevent), so I'm holding it for your review rather than enabling auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)