### PR TITLE
fix(prom): don't re-shift native rate offset output (double-shift); sync docs/comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ real ClickHouse against an upstream oracle, not just the emitted SQL.
 The strongest leg is **PromQL**, which runs the third-party **PromQL
 Compliance Tester** (`prometheus/compliance`, the PromLabs / CNCF
 Prometheus Conformance Program tooling) against a real `prom/prometheus`,
-seeded identically on both sides via remote-write. **574/574 cases pass,
+seeded identically on both sides via remote-write. **718/718 cases pass,
 no allow-list.** LogQL diffs against a real Loki on Grafana's own
 `pkg/logql/bench` corpus — solid, but a Grafana bench corpus rather than a
 standardised conformance suite. TraceQL is the lighter leg: there is **no

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -55,10 +55,10 @@ branch as shields.io badge JSON; the README shows them live. On
   data).
 - **Corpus**: vendored
   [`prometheus/compliance/promql/promql-test-queries.yml`](https://github.com/prometheus/compliance),
-  template-expanded to 574 concrete cases.
-- **Today**: **574/574** cases pass; no allow-list exists. This is the
+  template-expanded to 718 concrete cases.
+- **Today**: **718/718** cases pass; no allow-list exists. This is the
   highest-confidence leg — an industry-standard conformance suite against
-  a real reference. (Parity drift is report-only in CI; the 574/574 is a
+  a real reference. (Parity drift is report-only in CI; the 718/718 is a
   measured score, not a merge gate — see the note at the top of this
   page.)
 
@@ -102,7 +102,7 @@ they are:
 
 | Head    | Reference          | Corpus origin                                  | Numerical confidence                                                                        |
 | ------- | ------------------ | ---------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| PromQL  | real Prometheus    | third-party `prometheus/compliance` (CNCF)     | **Highest** — industry-standard conformance suite, 574/574, no allow-list                   |
+| PromQL  | real Prometheus    | third-party `prometheus/compliance` (CNCF)     | **Highest** — industry-standard conformance suite, 718/718, no allow-list                   |
 | LogQL   | real Loki          | Grafana's own `pkg/logql/bench` corpus         | **Solid** — real backend + real corpus, but a Grafana bench set, not a conformance standard |
 | TraceQL | real Tempo         | cerberus-owned author-written TXTAR            | **Lowest** — real backend, but no third-party suite; corpus breadth is author-bounded       |
 
@@ -313,7 +313,7 @@ The floors today (`heads.<name>.{passed,total}`):
 
 | head       | passed/total |
 | ---------- | ------------ |
-| prometheus | 574 / 574    |
+| prometheus | 718 / 718    |
 | loki       | 116 / 116    |
 | tempo      | 48 / 48      |
 
@@ -324,7 +324,7 @@ below it. It cannot flake because the differs compare with
 absolute + relative epsilon tolerance over canonical-key-sorted result
 sets against a deterministic seed, so `passed`/`total` are stable run to
 run (verified: three consecutive green main runs produced byte-identical
-574/574, 116/116, 48/48); the ratchet then compares **integers**, with
+718/718, 116/116, 48/48); the ratchet then compares **integers**, with
 no float/timing/ordering surface left to jitter.
 
 When the harness legitimately gains passing cases or the corpus grows,

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -230,7 +230,7 @@ the SQL array machinery leaves at high cardinality. See
 - **The fan-out remains byte-for-byte available.** Pinning `ts_grid_range` off
   (an explicit list omitting it, or the legacy `=false`) restores the
   established fan-out exactly; on a < 25.9 server it is the only path. Every
-  existing golden, the compat 574/574 corpus, and the compose / e2e lanes are
+  existing golden, the compat 718/718 corpus, and the compose / e2e lanes are
   structurally the fan-out shape.
 
 **Parity.** Validated on the chDB substrate (25.8) by a dual-emit test

--- a/internal/api/prom/handler.go
+++ b/internal/api/prom/handler.go
@@ -997,7 +997,15 @@ func matrixWindowOffset(plan chplan.Node) (offset time.Duration, relabel bool) {
 	case *chplan.RangeWindow:
 		return v.Offset, v.Offset != 0 && !v.Identity
 	case *chplan.RangeWindowNative:
-		return v.Offset, v.Offset != 0
+		// Native (timeSeriesRateToGrid) already reports on the UNSHIFTED request
+		// grid: its anchor axis is built with nativeGridTimeBoundFrag(_, 0) and
+		// Offset is folded ONLY into the aggregate's membership window
+		// (range_window_native.go — "Offset must NOT move the reported
+		// timestamps"). So its bare anchor_ts is the grid value already, unlike
+		// the fan-out RangeWindow whose bare anchor_ts is offset-SHIFTED.
+		// Re-shifting it here would double-shift a native `rate(m[r] offset o)`
+		// by +o. Never relabel native.
+		return 0, false
 	case *chplan.Project:
 		return matrixWindowOffset(v.Input)
 	case *chplan.Filter:

--- a/internal/api/prom/native_projection_test.go
+++ b/internal/api/prom/native_projection_test.go
@@ -80,3 +80,45 @@ func TestWrapSampleProjection_NativeRangeWindowIsDerivedMatrix(t *testing.T) {
 		t.Fatalf("TimeUnix projection = %#v, want ColumnRef{anchor_ts}", ts.Expr)
 	}
 }
+
+// TestWrapSampleProjection_NativeRangeWindowOffsetNotReshifted pins that a
+// native RangeWindow carrying a PromQL `offset` is NOT re-shifted by the sample
+// projection. Native (timeSeriesRateToGrid) already reports on the UNSHIFTED
+// request grid — its bare anchor_ts IS the grid value — so
+// wrapWithSampleProjection must project TimeUnix as a plain
+// ColumnRef{anchor_ts}, never anchor_ts + Offset. The fan-out RangeWindow keeps
+// its bare anchor_ts offset-shifted (and IS relabeled), so the two must not
+// share the relabel: a relabel here double-shifts every native
+// `rate(m[r] offset o)` by +o. This is invisible to the SQL goldens (which test
+// chsql.Emit only, never this projection).
+func TestWrapSampleProjection_NativeRangeWindowOffsetNotReshifted(t *testing.T) {
+	s := schema.DefaultOTelMetrics()
+
+	native := &chplan.RangeWindowNative{
+		Input:           &chplan.Scan{Table: "otel_metrics_gauge"},
+		Func:            "rate",
+		Range:           5 * time.Minute,
+		Step:            time.Minute,
+		Offset:          time.Hour, // the modifier the fan-out RangeWindow re-shifts
+		Start:           time.Unix(1000, 0).UTC(),
+		End:             time.Unix(4600, 0).UTC(),
+		TimestampColumn: s.TimestampColumn,
+		ValueColumn:     s.ValueColumn,
+		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: s.AttributesColumn}},
+	}
+
+	wrapped, ok := wrapWithSampleProjection(native, s).(*chplan.Project)
+	if !ok {
+		t.Fatalf("wrapWithSampleProjection returned %T, want *chplan.Project", wrapped)
+	}
+	ts := wrapped.Projections[2]
+	if ts.Alias != s.TimestampColumn {
+		t.Fatalf("projection[2] alias = %q, want %q", ts.Alias, s.TimestampColumn)
+	}
+	col, ok := ts.Expr.(*chplan.ColumnRef)
+	if !ok || col.Name != chplan.RangeWindowAnchorColumn {
+		t.Fatalf("native offset TimeUnix projection = %#v, want bare ColumnRef{%s} — "+
+			"native already reports the unshifted grid; re-shifting double-shifts by +Offset",
+			ts.Expr, chplan.RangeWindowAnchorColumn)
+	}
+}

--- a/internal/solver/config.go
+++ b/internal/solver/config.go
@@ -48,9 +48,10 @@ const (
 	ModeSharded = "sharded"
 )
 
-// Config tunes the solver. Every field maps to a CERBERUS_* env var wired by
-// internal/config in a later PR; this package owns only the defaults and the
-// invariants. The defaults are deliberately conservative against the
+// Config tunes the solver. Every field maps to a CERBERUS_* env var parsed by
+// ConfigFromEnv (config_env.go) — kept in this package rather than
+// internal/config to avoid an import cycle; this package owns the defaults and
+// the invariants. The defaults are deliberately conservative against the
 // over-routing attack (docs §Routing): Grafana's auto-step makes the dominant
 // production shape rate[5m] @ 15s hit F=20, N>=241, which must NOT route at
 // these thresholds unless the total expansion is spike-class.

--- a/internal/solver/decision.go
+++ b/internal/solver/decision.go
@@ -10,7 +10,8 @@ import (
 // classify a plan. It is the package-local stand-in for engine.Meta: the
 // import-cycle rule (internal/engine imports internal/solver, never the
 // reverse) forbids referencing engine.Meta here, so the engine adapter
-// (a later PR) populates this small struct from its own Meta + Lang.
+// (internal/engine, engine.go) populates this small struct from its own
+// Meta + Lang.
 //
 // The Planner uses it both as the cost-signal source (Step / OuterRange) and
 // as the @-modifier guard's oracle: a windowed node's bounds must match the


### PR DESCRIPTION
Post-merge audit follow-up to #1216. Fixes one real (latent) correctness regression plus two doc/comment drifts. Bundles audit items #1 + #2 + #6.

## #1 — Native rate `offset` double-shift (the real bug)

`matrixWindowOffset` (in `wrapWithSampleProjection`) relabeled `RangeWindowNative` the same way as the fan-out `RangeWindow` — `anchor_ts + Offset`. But the two emitters use **opposite** conventions for the bare `anchor_ts` column:

- **Fan-out** (`gridAnchorFrag`): bare `anchor_ts` is offset-**shifted**, so adding `Offset` back is correct.
- **Native** (`range_window_native.go`): the anchor axis is built with `nativeGridTimeBoundFrag(_, 0)` — the **unshifted** grid; its own comment says *"Offset must NOT move the reported timestamps."* `Offset` is folded only into the membership window.

So for native, `anchor_ts` is already the grid value, and adding `Offset` again shifted a native `rate(m[5m] offset 1h)` **+1h into the future**. Scope: only the **bare-selector** native path (aggregate-wrapped native reads the correct `TimeUnix` grid via the non-matrix branch). It's **invisible to the SQL goldens** (they test `chsql.Emit`, never `wrapWithSampleProjection`) and **latent in prod** only where the native path is enabled (CH ≥ 25.9); current squid-prod (CH 25.7.5) is unaffected. Introduced by #1216, caught by a post-merge audit.

**Fix:** `matrixWindowOffset` returns `(0, false)` for `RangeWindowNative` — never relabel native. New non-chDB shape test `TestWrapSampleProjection_NativeRangeWindowOffsetNotReshifted` pins a bare `ColumnRef{anchor_ts}` for a native window with a non-zero offset; it fails as a `Binary{+}` without the fix (verified). The fan-out offset tests still pass.

## #2 — Stale PromQL parity count `574` → `718`

`compatibility/parity-baseline.json` is `718/718` after the range-offset corpus additions, but the docs still said `574` in 8 spots: `README.md:226`, `docs/compatibility.md` (58/59/61/105/316/327), `docs/operations.md:233`. It shipped CI-green because `doc-counts.mjs` never derives this number from the baseline. Corrected all 8 (Loki 116/116 + Tempo 48/48 untouched).

## #6 — Two "a later PR" comments describing landed work

- `internal/solver/decision.go` — the engine adapter that populates `solver.RequestMeta` already exists (`engine.go:793`).
- `internal/solver/config.go` — env parsing is done by `ConfigFromEnv` (`config_env.go`), deliberately kept in-package to avoid an import cycle, not a future `internal/config` merge.

(The third stale comment the audit flagged — `slicer.go`'s `ScanFrom` note — is tied to the dead `ScanFrom` field and will be removed with it in a separate cleanup PR.)

## Verification
`go build ./...`, `golangci-lint` (0 issues), and the full `internal/api/prom` + `internal/solver` suites pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)