### PR TITLE
chore(release): cerberus v1.11.0 / chart 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to cerberus will be documented in this file. The format roug
 
 ## [Unreleased]
 
+## [v1.11.0] — 2026-07-16
+
+### Fixed
+
+- **prom:** don't re-shift native rate offset output (double-shift); sync docs/comments (#1217)
+- **promql:** report range-mode offset output on the unshifted grid, not t-offset (#1216)
+- **chsql:** push compare() root-lookup bound below GROUP BY, not above it (#1214)
+- **e2e:** reconcile the Traces-Drilldown undefined-groupBy init race (#1209)
+
+### Changed
+
+- **chsql:** dedupe SELECT-passthrough loops and offset-unshift frag (#1219)
+- **solver:** drop dead ScanFrom/spineReach; share offset-reanchor IR helper (#1218)
+
+### CI
+
+- auto-tidy test/oracle on dependabot go.mod bumps (#1212)
+
+### Documentation
+
+- remove goreportcard badge from README (#1210)
+
 ## [v1.10.0] — 2026-07-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to cerberus will be documented in this file. The format roug
 
 ## [v1.11.0] — 2026-07-16
 
+### Added
+
+- **solver:** register VectorJoin as slice-invariant so step-aligned ratio joins route through the sharded path; fail-close instant joins on route A (#1215)
+
 ### Fixed
 
 - **prom:** don't re-shift native rate offset output (double-shift); sync docs/comments (#1217)

--- a/deploy/helm/cerberus/Chart.yaml
+++ b/deploy/helm/cerberus/Chart.yaml
@@ -49,6 +49,8 @@ annotations:
   # Bump the `1.0.0` floor here when the chart raises its minimum supported
   # cerberus release; informational for Artifact Hub's compatibility hints.
   artifacthub.io/changes: |
+    - kind: added
+      description: "solver: register VectorJoin as slice-invariant so step-aligned ratio joins route through the sharded path; fail-close instant joins on route A (#1215)"
     - kind: fixed
       description: "prom: don't re-shift native rate offset output (double-shift); sync docs/comments (#1217)"
     - kind: fixed

--- a/deploy/helm/cerberus/Chart.yaml
+++ b/deploy/helm/cerberus/Chart.yaml
@@ -8,11 +8,11 @@ type: application
 # upgrade?" and is the publish trigger: a chart-only fix bumps this without an
 # app re-tag; an app-only release bumps appVersion + a PATCH here for the new
 # default image. Starts 0.x because the values contract is not yet frozen.
-version: 0.10.3
+version: 0.11.0
 
 # appVersion tracks the GA cerberus binary. Quoted so SemVer-shaped values
 # aren't coerced to floats. image.tag defaults from this when left empty.
-appVersion: "1.10.0"
+appVersion: "1.11.0"
 
 # autoscaling/v2 + policy/v1 (PDB) + networking/v1 (Ingress) are all GA from
 # 1.21+; 1.23 is the conservative floor matching the manifests this chart
@@ -45,23 +45,19 @@ annotations:
       url: https://github.com/tsouza/cerberus/blob/main/docs/operations.md
   artifacthub.io/images: |
     - name: cerberus
-      image: ghcr.io/tsouza/cerberus:v1.10.0
+      image: ghcr.io/tsouza/cerberus:v1.11.0
   # Bump the `1.0.0` floor here when the chart raises its minimum supported
   # cerberus release; informational for Artifact Hub's compatibility hints.
   artifacthub.io/changes: |
-    - kind: added
-      description: "tempo: extend the structural two-phase split to the gRPC Search path (#1201)"
-    - kind: added
-      description: "tempo: admit union `&>>`/`&<<` into the structural two-phase seam (#1198)"
-    - kind: added
-      description: "tempo: route `!>>` through two-phase + default-on structural-two-phase toggle (#1197)"
-    - kind: added
-      description: "tempo: route `>> | select(...)` through the structural two-phase seam (#1195)"
-    - kind: added
-      description: "autotune: expose loop state via /info/autotune + per-pod metrics (#1193)"
-    - kind: added
-      description: "solver: self-driving autotune loop lowering thresholds toward observed OOM line (#1190)"
     - kind: fixed
-      description: "tempo: bound the wide-projection drain with a fail-closed byte budget (#1200)"
+      description: "prom: don't re-shift native rate offset output (double-shift); sync docs/comments (#1217)"
     - kind: fixed
-      description: "e2e: warm the stack before compose-smoke's zero-tolerance sweep (#1196)"
+      description: "promql: report range-mode offset output on the unshifted grid, not t-offset (#1216)"
+    - kind: fixed
+      description: "chsql: push compare() root-lookup bound below GROUP BY, not above it (#1214)"
+    - kind: fixed
+      description: "e2e: reconcile the Traces-Drilldown undefined-groupBy init race (#1209)"
+    - kind: changed
+      description: "chsql: dedupe SELECT-passthrough loops and offset-unshift frag (#1219)"
+    - kind: changed
+      description: "solver: drop dead ScanFrom/spineReach; share offset-reanchor IR helper (#1218)"

--- a/deploy/helm/cerberus/README.md
+++ b/deploy/helm/cerberus/README.md
@@ -5,7 +5,7 @@
      pipe-aligned, and the version footer adds a trailing blank — both are
      owned by helm-docs; realigning would fight the chart-ci drift check. -->
 
-![Version: 0.10.3](https://img.shields.io/badge/Version-0.10.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.10.0](https://img.shields.io/badge/AppVersion-1.10.0-informational?style=flat-square)
+![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.11.0](https://img.shields.io/badge/AppVersion-1.11.0-informational?style=flat-square)
 
 Drop-in Prometheus / Loki / Tempo HTTP gateway for ClickHouse — a single stateless gateway that speaks three upstream query wire formats and lowers each to parameterised ClickHouse SQL.
 


### PR DESCRIPTION
Release-prep for **v1.11.0** (chart **0.11.0**), generated by `prepare-release.yml`.

- appVersion 1.10.0 -> 1.11.0, chart 0.10.3 -> 0.11.0

### Changes

### Added

- **solver:** register VectorJoin as slice-invariant so step-aligned ratio joins route through the sharded path; fail-close instant joins on route A (#1215)

### Fixed

- **prom:** don't re-shift native rate offset output (double-shift); sync docs/comments (#1217)
- **promql:** report range-mode offset output on the unshifted grid, not t-offset (#1216)
- **chsql:** push compare() root-lookup bound below GROUP BY, not above it (#1214)
- **e2e:** reconcile the Traces-Drilldown undefined-groupBy init race (#1209)

### Changed

- **chsql:** dedupe SELECT-passthrough loops and offset-unshift frag (#1219)
- **solver:** drop dead ScanFrom/spineReach; share offset-reanchor IR helper (#1218)

### CI

- auto-tidy test/oracle on dependabot go.mod bumps (#1212)

### Documentation

- remove goreportcard badge from README (#1210)

> Note: #1215 (feat) was squash-merged inside #1216's branch, so `main` carries no `feat(solver)` commit and prepare-release's subject-derived changelog missed it. The VectorJoin feature is the reason this is a minor bump; added here + in CHANGELOG + Chart.yaml artifacthub annotations.

Generated from the conventional commits since the last tag; VectorJoin (#1215) added manually.