### PR TITLE
fix: backport compare window-prune to 1.10.x (v1.10.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to cerberus will be documented in this file. The format roug
 
 ## [Unreleased]
 
+## [v1.10.2] — 2026-07-17
+
+### Fixed
+
+- **chsql:** window-prune the compare root-lookup scan for root-scoped selections — the traces-drilldown Comparison scan read full retention (~3B rows) and timed out; now ~80× fewer rows, lossless when root-scoped (backport of #1223)
+
 ## [v1.10.1] — 2026-07-16
 
 ### Fixed

--- a/deploy/helm/cerberus/Chart.yaml
+++ b/deploy/helm/cerberus/Chart.yaml
@@ -8,11 +8,11 @@ type: application
 # upgrade?" and is the publish trigger: a chart-only fix bumps this without an
 # app re-tag; an app-only release bumps appVersion + a PATCH here for the new
 # default image. Starts 0.x because the values contract is not yet frozen.
-version: 0.10.4
+version: 0.10.6
 
 # appVersion tracks the GA cerberus binary. Quoted so SemVer-shaped values
 # aren't coerced to floats. image.tag defaults from this when left empty.
-appVersion: "1.10.1"
+appVersion: "1.10.2"
 
 # autoscaling/v2 + policy/v1 (PDB) + networking/v1 (Ingress) are all GA from
 # 1.21+; 1.23 is the conservative floor matching the manifests this chart
@@ -45,11 +45,9 @@ annotations:
       url: https://github.com/tsouza/cerberus/blob/main/docs/operations.md
   artifacthub.io/images: |
     - name: cerberus
-      image: ghcr.io/tsouza/cerberus:v1.10.1
+      image: ghcr.io/tsouza/cerberus:v1.10.2
   # Bump the `1.0.0` floor here when the chart raises its minimum supported
   # cerberus release; informational for Artifact Hub's compatibility hints.
   artifacthub.io/changes: |
     - kind: fixed
-      description: "promql: report range-mode offset output on the unshifted grid, not t-offset (backport #1216/#1217)"
-    - kind: fixed
-      description: "chsql: push compare() root-lookup bound below GROUP BY, not above it (backport #1214)"
+      description: "chsql: window-prune the compare root-lookup scan for root-scoped selections — fixes the traces-drilldown Comparison OOM/timeout (backport #1223)"

--- a/deploy/helm/cerberus/README.md
+++ b/deploy/helm/cerberus/README.md
@@ -5,7 +5,7 @@
      pipe-aligned, and the version footer adds a trailing blank — both are
      owned by helm-docs; realigning would fight the chart-ci drift check. -->
 
-![Version: 0.10.4](https://img.shields.io/badge/Version-0.10.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.10.1](https://img.shields.io/badge/AppVersion-1.10.1-informational?style=flat-square)
+![Version: 0.10.6](https://img.shields.io/badge/Version-0.10.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.10.2](https://img.shields.io/badge/AppVersion-1.10.2-informational?style=flat-square)
 
 Drop-in Prometheus / Loki / Tempo HTTP gateway for ClickHouse — a single stateless gateway that speaks three upstream query wire formats and lowers each to parameterised ClickHouse SQL.
 

--- a/internal/chplan/metrics_compare.go
+++ b/internal/chplan/metrics_compare.go
@@ -88,6 +88,11 @@ type MetricsCompare struct {
 	ValAlias         string
 	ValueAlias       string
 	Inner            Node
+	// InnerRootScoped is set by lowering when Inner is confined to root spans
+	// (ParentSpanId = ''). It lets the emitter prune the root-lookup scan by the
+	// request-window Timestamp losslessly — the seed's roots are then in-window
+	// by construction. Only meaningful when RootLookup != nil.
+	InnerRootScoped bool
 }
 
 func (*MetricsCompare) planNode() {}

--- a/internal/chsql/metrics_compare.go
+++ b/internal/chsql/metrics_compare.go
@@ -64,7 +64,10 @@ const (
 // strict-lower / inclusive-upper Frags from innerScanTsBoundsFrags; a
 // nil compareScanBound (the bare time-collapsed shape, which has no
 // anchor grid) leaves both scans unbounded — byte-stable against the
-// pinned bare fixtures.
+// pinned bare fixtures. That bare path is reached only by the golden /
+// chdb test lanes; every prod compare() enters through a RangeWindow
+// (/api/metrics/query_range), so the unbounded bare root leg is not a
+// live OOM surface.
 //
 // Why the bound must live inside the scans, not above the join: CH
 // 24.12 cannot push a predicate sitting on the SELECT that wraps
@@ -77,13 +80,20 @@ const (
 // RootLookup's own GROUP BY (boundedRootLeg's wrap, below) restricts
 // only the aggregate's OUTPUT — CH still has to materialize the whole
 // aggregate over the unpruned scan first, which is what actually kept
-// OOMing in prod despite that wrap already existing. The real fix is
-// windowRootLookupTraceIDSeed, which pushes the same TraceId-IN
-// predicate into the Filter directly beneath RootLookup's own Scan (see
-// emitRangeWindowCompare) so CH prunes the scan itself, below the
-// GROUP BY. rootSeeded records when that pushdown already succeeded, so
+// OOMing in prod despite that wrap already existing.
+// windowRootLookupTraceIDSeed pushes the same TraceId-IN predicate into
+// the Filter directly beneath RootLookup's own Scan (see
+// emitRangeWindowCompare), below the GROUP BY. That push alone does NOT
+// prune the scan, though: TraceId is not the spans table's MergeTree
+// sort key, so CH still reads every root span across retention to test
+// IN-membership (the residual prod OOM — ~1.4B rows). The scan is pruned
+// only by a DIRECT Timestamp predicate, which the seed additionally
+// conjoins onto the same Filter when the selection is root-scoped
+// (m.InnerRootScoped) — where the seed's roots are all in-window so the
+// bound is lossless; a non-root selection keeps TraceId-IN alone,
+// unpruned but lossless. rootSeeded records when the push succeeded, so
 // compareBaseQuery can skip boundedRootLeg's now-redundant wrap instead
-// of re-filtering an already-pruned result by the same trace-id set.
+// of re-filtering an already-seeded result by the same trace-id set.
 type compareScanBound struct {
 	lo, hi     Frag
 	rootSeeded bool
@@ -142,7 +152,7 @@ func (e *emitter) compareBaseQuery(m *chplan.MetricsCompare, bound *compareScanB
 		// has already pushed that same predicate into RootLookup's own
 		// scan-level Filter (bound.rootSeeded — see
 		// windowRootLookupTraceIDSeed), boundedRootLeg's wrap here would
-		// only re-filter an already-pruned result by the identical
+		// only re-filter an already-seeded result by the identical
 		// trace-id set, so it's skipped. It stays as the correctness
 		// fallback for the rare RootLookup shape the scan-level pushdown
 		// can't reach (rootLookupSpansTable finds no matching Scan): a
@@ -256,10 +266,12 @@ func rootLookupSpansTable(root chplan.Node) string {
 
 // windowRootLookupTraceIDSeed returns a clone of the root-lookup relation
 // with `<traceIDCol> IN (<seed>)` AND-ed — as a chplan.InSubquery — into the
-// Filter that sits directly on the spans Scan, so the per-trace root
-// aggregate prunes the scan itself, below its own GROUP BY (a predicate
+// Filter that sits directly on the spans Scan, so the membership predicate
+// lands below the per-trace root aggregate's own GROUP BY (a predicate
 // sitting above the GROUP BY, like the old post-aggregate wrap in
 // boundedRootLeg, does not get pushed back down through it by ClickHouse).
+// That placement scopes the aggregate's inputs to the cohort but does NOT
+// prune the scan (TraceId is not the sort key — see the tsLo/tsHi note below).
 //
 // This replaces the previous Timestamp-only push: TraceId is the bare,
 // unaliased GROUP BY key of RootLookup's own Aggregate, with no HAVING
@@ -281,7 +293,18 @@ func rootLookupSpansTable(root chplan.Node) string {
 // spans scan is found — the caller (emitRangeWindowCompare) uses seeded to
 // decide whether boundedRootLeg's post-aggregate wrap is still needed as a
 // correctness fallback.
-func windowRootLookupTraceIDSeed(root chplan.Node, traceIDCol string, seed chplan.Node) (windowed chplan.Node, seeded bool) {
+//
+// tsLo/tsHi, when non-nil, additionally conjoin the request-window Timestamp
+// bound onto the same scan Filter. The TraceId-IN seed alone bounds the cohort
+// but cannot PRUNE the scan: TraceId is not the spans table's MergeTree sort
+// key, so CH reads every root span across full retention to test membership
+// (the compare OOM/timeout — read_rows ~1.4B in prod). A direct Timestamp bound
+// prunes by partition/PK, but it is only LOSSLESS to add when the caller has
+// established the seed's roots all fall inside the window (root-scoped
+// selection — gated on m.InnerRootScoped in emitRangeWindowCompare);
+// for a non-root selection the caller passes nil tsLo/tsHi and this keeps the
+// unbounded-but-lossless behavior #1214 chose.
+func windowRootLookupTraceIDSeed(root chplan.Node, traceIDCol string, seed chplan.Node, tsLo, tsHi chplan.Expr) (windowed chplan.Node, seeded bool) {
 	if seed == nil {
 		return root, false
 	}
@@ -290,7 +313,8 @@ func windowRootLookupTraceIDSeed(root chplan.Node, traceIDCol string, seed chpla
 		return root, false
 	}
 	clone := chplan.CloneNode(root)
-	pred := &chplan.InSubquery{Left: &chplan.ColumnRef{Name: traceIDCol}, Subquery: seed}
+	in := &chplan.InSubquery{Left: &chplan.ColumnRef{Name: traceIDCol}, Subquery: seed}
+	pred := conjoinExpr(conjoinExpr(tsLo, tsHi), in)
 	if pushPredicateToSpansScanFilter(clone, spansTable, pred) {
 		return clone, true
 	}
@@ -477,8 +501,10 @@ func (e *emitter) emitRangeWindowCompare(r *chplan.RangeWindow, m *chplan.Metric
 		bound = &compareScanBound{lo: lo, hi: hi}
 	}
 	// Push a `TraceId IN (<windowed cohort>)` seed directly onto the
-	// root-lookup's physical scan (below its own GROUP BY), so CH can
-	// partition-prune the scan before the aggregate runs. TraceId is
+	// root-lookup's physical scan (below its own GROUP BY), so the membership
+	// predicate applies to the aggregate's inputs rather than being stuck above
+	// the GROUP BY like boundedRootLeg's wrap (it does not prune the scan on its
+	// own — the root-scoped Timestamp bound below does that). TraceId is
 	// RootLookup's bare, unaliased GROUP BY key with no HAVING/window
 	// function in between, so a TraceId-membership predicate commutes freely
 	// across the GROUP BY — pushing it into the scan's Filter produces the
@@ -487,10 +513,16 @@ func (e *emitter) emitRangeWindowCompare(r *chplan.RangeWindow, m *chplan.Metric
 	// in compareBaseQuery, skipped via bound.rootSeeded whenever this
 	// pushdown succeeds): that wrap sits ABOVE the GROUP BY, so CH must
 	// materialize the full aggregate before it can apply it — the actual OOM
-	// cause. A direct Timestamp bound on the root span's own Timestamp was
-	// rejected instead of this: it is LOSSY, silently dropping root-name /
-	// root-service enrichment for any trace whose root span started before
-	// the request window. windowRootLookupTraceIDSeed derives the spans
+	// cause. A direct Timestamp bound on the root span's own Timestamp is
+	// LOSSY for a non-root selection — it silently drops root-name/root-service
+	// enrichment for any trace whose root started before the window — so it is
+	// conjoined onto the scan ONLY when the selection is root-scoped
+	// (m.InnerRootScoped, set by lowering), where the seed's roots are in-window
+	// by construction and the bound is lossless while letting CH partition/PK-
+	// prune (TraceId-IN alone cannot: TraceId is not the sort key). That
+	// root-scoped shape is exactly the traces-drilldown "Comparison" whose
+	// unpruned root scan reads full retention and OOMs.
+	// windowRootLookupTraceIDSeed derives the spans
 	// table from RootLookup itself (rootLookupSpansTable), not from
 	// e.ctxSpansTable, so this fires uniformly on every emit path — no
 	// context-threading gate needed here.
@@ -507,7 +539,13 @@ func (e *emitter) emitRangeWindowCompare(r *chplan.RangeWindow, m *chplan.Metric
 		lo, hi := tsBoundExprs(tsCol, r.Start.UnixNano()-offsetNS-rangeNS, r.End.UnixNano()-offsetNS)
 		seed := compareSeedNode(m.Inner, m.TraceIDColumn, lo, hi)
 		windowed := *m
-		rootLookup, seeded := windowRootLookupTraceIDSeed(m.RootLookup, m.TraceIDColumn, seed)
+		// Prune the root-lookup scan by Timestamp only when lossless
+		// (root-scoped selection); otherwise keep it unbounded.
+		var rootLo, rootHi chplan.Expr
+		if m.InnerRootScoped {
+			rootLo, rootHi = lo, hi
+		}
+		rootLookup, seeded := windowRootLookupTraceIDSeed(m.RootLookup, m.TraceIDColumn, seed, rootLo, rootHi)
 		windowed.RootLookup = rootLookup
 		boundCopy := *bound
 		boundCopy.rootSeeded = seeded

--- a/internal/chsql/metrics_compare_test.go
+++ b/internal/chsql/metrics_compare_test.go
@@ -87,8 +87,9 @@ func compareNodeWithRoot() *chplan.MetricsCompare {
 //   - the `r` root leg is seeded with `TraceId IN (<bounded cohort
 //     trace-ids>)` pushed directly into the Filter beneath RootLookup's
 //     own physical Scan — i.e. BELOW its GROUP BY TraceId aggregate, not
-//     as a wrap around the aggregate's output — so CH partition-prunes
-//     the scan itself instead of materializing the full aggregate first.
+//     as a wrap around the aggregate's output — so the membership predicate
+//     scopes the aggregate's inputs instead of filtering its output (the
+//     scan itself is pruned only in the root-scoped arm's Timestamp bound).
 //     A `TraceId IN (...)` filter sitting ABOVE the GROUP BY (the earlier
 //     boundedRootLeg-only shape) restricts only the aggregate's output
 //     and does not prune the scan; that's what kept OOMing in prod
@@ -121,8 +122,11 @@ func TestEmitRangeWindowCompare_JoinScanPushdown(t *testing.T) {
 
 	// The 'r' root leg: RootLookup's own Filter(ParentSpanId = '') gains a
 	// `TraceId IN (<bounded cohort>)` conjunct, seeding the scan directly
-	// — BELOW the GROUP BY that follows it — so CH prunes the scan before
-	// aggregating, not after. PREWHERE promotion (internal/optimizer)
+	// — BELOW the GROUP BY that follows it — so the predicate scopes the
+	// aggregate's inputs rather than filtering its output. This non-root shape
+	// has no direct Timestamp bound, so the scan itself is NOT pruned (that is
+	// #1214's lossless tradeoff; only the root-scoped arm prunes).
+	// PREWHERE promotion (internal/optimizer)
 	// splits the two conjuncts of the Filter across PREWHERE/WHERE rather
 	// than AND-ing them into one clause; either placement still lands the
 	// seed inside the scan, below the GROUP BY. The seed's own bound
@@ -164,7 +168,7 @@ func TestEmitRangeWindowCompare_JoinScanPushdown(t *testing.T) {
 	// Regression guard: once the scan-level seed lands, boundedRootLeg's
 	// redundant post-aggregate wrap (`) AS r` immediately preceded by a
 	// bare `WHERE TraceId IN (...)`, with no intervening Filter/Scan) must
-	// not also appear — that shape re-filters an already-pruned result by
+	// not also appear — that shape re-filters an already-seeded result by
 	// the identical trace-id set for no benefit.
 	if strings.Contains(sql, "_cmp_seed") {
 		t.Errorf("boundedRootLeg's post-aggregate wrap must be skipped once the scan-level seed succeeds (unexpected _cmp_seed):\n%s", sql)
@@ -180,6 +184,70 @@ func TestEmitRangeWindowCompare_JoinScanPushdown(t *testing.T) {
 	}
 	if strings.Contains(sql[onIdx:], "`Timestamp` >") || strings.Contains(sql[onIdx:], "`Timestamp` <=") {
 		t.Errorf("Timestamp bound must not sit above the join (found after ON clause):\n%s", sql[onIdx:])
+	}
+}
+
+// TestEmitRangeWindowCompare_RootScopedEnrichmentTimestampBound pins the
+// prod fix for the traces-drilldown "Comparison" OOM: when the selection is
+// root-scoped (InnerRootScoped), the enrichment ('r') root-lookup scan gains a
+// DIRECT request-window Timestamp bound conjoined onto its own Filter, so CH
+// partition/PK-prunes it. #1214's TraceId-IN seed alone cannot prune (TraceId
+// is not the sort key). The bound is lossless here because the seed's roots are
+// all in-window; a non-root selection (InnerRootScoped == false, the
+// JoinScanPushdown test above) keeps the scan unbounded to preserve #1214's
+// no-drop guarantee.
+func TestEmitRangeWindowCompare_RootScopedEnrichmentTimestampBound(t *testing.T) {
+	t.Parallel()
+
+	// The discriminating signal is the DIRECT Timestamp bound conjoined onto the
+	// root scan's own Filter, which renders BEFORE the `TraceId IN (…)` seed.
+	// The seed subquery already carries its OWN nested Timestamp bound (#1214),
+	// so a test that only greps the whole filter region for a Timestamp bound is
+	// hollow — it passes on the non-root shape too. Slicing at the seed opener
+	// pins the prefix that differs between the two arms.
+	prefixBeforeSeed := func(t *testing.T, innerRootScoped bool) string {
+		t.Helper()
+		m := compareNodeWithRoot()
+		m.InnerRootScoped = innerRootScoped
+		rw := &chplan.RangeWindow{
+			Input:           m,
+			Range:           time.Minute,
+			Step:            time.Minute,
+			Start:           time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC),
+			End:             time.Date(2026, 5, 12, 10, 3, 0, 0, time.UTC),
+			TimestampColumn: "Timestamp",
+		}
+		sql, _, err := chsql.Emit(context.Background(), rw)
+		if err != nil {
+			t.Fatalf("Emit: %v", err)
+		}
+		onIdx := strings.Index(sql, "ON s.`TraceId` = r.`TraceId`")
+		if onIdx < 0 {
+			t.Fatalf("expected LEFT JOIN ON clause:\n%s", sql)
+		}
+		rLeg := sql[:onIdx]
+		start := strings.LastIndex(rLeg, "`ParentSpanId` = ?")
+		seed := strings.Index(rLeg, "`TraceId` IN (SELECT `TraceId`")
+		if start < 0 || seed < 0 || seed <= start {
+			t.Fatalf("expected root leg ParentSpanId filter then TraceId-IN seed:\n%s", rLeg)
+		}
+		return rLeg[start:seed] // the scan filter BEFORE the seed subquery
+	}
+
+	// Root-scoped: the direct request-window Timestamp bound is conjoined onto
+	// the scan filter, ahead of the (retained) TraceId-IN seed.
+	rootPrefix := prefixBeforeSeed(t, true)
+	if !strings.Contains(rootPrefix, "`Timestamp` >= fromUnixTimestamp64Nano(?)") ||
+		!strings.Contains(rootPrefix, "`Timestamp` <= fromUnixTimestamp64Nano(?)") {
+		t.Errorf("root-scoped: direct Timestamp bound must precede the TraceId-IN seed, got prefix:\n%s", rootPrefix)
+	}
+
+	// Negative arm (regression discriminator): a non-root selection must NOT gain
+	// the direct bound — the prefix before the seed is only the ParentSpanId
+	// filter. This is what makes the test fail if the emitter half is reverted.
+	nonRootPrefix := prefixBeforeSeed(t, false)
+	if strings.Contains(nonRootPrefix, "fromUnixTimestamp64Nano") {
+		t.Errorf("non-root: root scan must stay unbounded (no direct Timestamp bound before the seed), got prefix:\n%s", nonRootPrefix)
 	}
 }
 

--- a/internal/traceql/metrics_compare.go
+++ b/internal/traceql/metrics_compare.go
@@ -156,6 +156,12 @@ func lowerMetricsCompare(prev chplan.Node, mc *traceql.MetricsCompare, s schema.
 		node.TraceIDColumn = s.TraceIDColumn
 		node.RootNameAlias = rootNameAlias
 		node.RootServiceAlias = rootServiceAlias
+		// A root-scoped selection (`{ nestedSetParent < 0 }` → Filter(ParentSpanId
+		// = '') over Scan — the traces-drilldown "Comparison" shape) only seeds
+		// TraceIds whose root span is in the request window, so the emitter can
+		// prune the root-lookup scan by Timestamp losslessly. isRootSpanFilter is
+		// the same root-shape predicate the search-limit bound uses.
+		node.InnerRootScoped = isRootSpanFilter(prev, s.ParentSpanIDColumn)
 	}
 
 	return node, nil

--- a/internal/traceql/metrics_compare_rootscope_test.go
+++ b/internal/traceql/metrics_compare_rootscope_test.go
@@ -1,0 +1,63 @@
+package traceql_test
+
+import (
+	"context"
+	"testing"
+
+	tempo "github.com/tsouza/cerberus/internal/traceql/ast"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/traceql"
+)
+
+// TestLowerCompareInnerRootScoped pins the end-to-end gate that decides
+// whether the emitter may window-prune the compare root-lookup scan: lowering
+// must set MetricsCompare.InnerRootScoped iff the selection is confined to root
+// spans. The emitter-side effect (the Timestamp bound) is pinned separately in
+// chsql's TestEmitRangeWindowCompare_RootScopedEnrichmentTimestampBound; this
+// test guards the reachability half — that the real traces-drilldown
+// "Comparison" shape (`{ nestedSetParent < 0 }`) actually trips the gate, and
+// that non-root selections do not (which would silently drop enrichment).
+func TestLowerCompareInnerRootScoped(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelTraces()
+	cases := []struct {
+		query string
+		want  bool
+	}{
+		{"{ nestedSetParent < 0 } | compare({ status = error })", true},          // drilldown Comparison shape
+		{"{ } | compare({ status = error })", false},                             // all spans (root not guaranteed)
+		{"{ span.http.status_code = 500 } | compare({ status = error })", false}, // non-root selection
+	}
+	for _, tc := range cases {
+		expr, err := tempo.Parse(tc.query)
+		if err != nil {
+			t.Fatalf("Parse(%q): %v", tc.query, err)
+		}
+		plan, err := traceql.Lower(context.Background(), expr, s)
+		if err != nil {
+			t.Fatalf("Lower(%q): %v", tc.query, err)
+		}
+		mc := findMetricsCompare(plan)
+		if mc == nil {
+			t.Fatalf("%q: no MetricsCompare in plan", tc.query)
+		}
+		if mc.InnerRootScoped != tc.want {
+			t.Errorf("%q: InnerRootScoped=%v, want %v", tc.query, mc.InnerRootScoped, tc.want)
+		}
+	}
+}
+
+func findMetricsCompare(n chplan.Node) *chplan.MetricsCompare {
+	var found *chplan.MetricsCompare
+	chplan.Walk(n, func(x chplan.Node) bool {
+		if mc, ok := x.(*chplan.MetricsCompare); ok {
+			found = mc
+			return false
+		}
+		return true
+	})
+	return found
+}


### PR DESCRIPTION
Backports the compare root-lookup window-prune fix (#1223) to the 1.10 line. Publishes v1.10.2 / chart 0.10.6. Clean cherry-pick; build + unit + revert-guard tests pass. Fixes the traces-drilldown Comparison OOM/timeout (prod-proven: ~80x fewer rows, no memory regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)