### PR TITLE
chore(release): cerberus v1.11.1 / chart 0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to cerberus will be documented in this file. The format roug
 
 ## [Unreleased]
 
+## [v1.11.1] — 2026-07-17
+
+### Fixed
+
+- **chsql:** window-prune the compare root-lookup scan for root-scoped selections (#1223)
+
 ## [v1.11.0] — 2026-07-16
 
 ### Added

--- a/deploy/helm/cerberus/Chart.yaml
+++ b/deploy/helm/cerberus/Chart.yaml
@@ -8,11 +8,11 @@ type: application
 # upgrade?" and is the publish trigger: a chart-only fix bumps this without an
 # app re-tag; an app-only release bumps appVersion + a PATCH here for the new
 # default image. Starts 0.x because the values contract is not yet frozen.
-version: 0.11.0
+version: 0.11.1
 
 # appVersion tracks the GA cerberus binary. Quoted so SemVer-shaped values
 # aren't coerced to floats. image.tag defaults from this when left empty.
-appVersion: "1.11.0"
+appVersion: "1.11.1"
 
 # autoscaling/v2 + policy/v1 (PDB) + networking/v1 (Ingress) are all GA from
 # 1.21+; 1.23 is the conservative floor matching the manifests this chart
@@ -45,21 +45,9 @@ annotations:
       url: https://github.com/tsouza/cerberus/blob/main/docs/operations.md
   artifacthub.io/images: |
     - name: cerberus
-      image: ghcr.io/tsouza/cerberus:v1.11.0
+      image: ghcr.io/tsouza/cerberus:v1.11.1
   # Bump the `1.0.0` floor here when the chart raises its minimum supported
   # cerberus release; informational for Artifact Hub's compatibility hints.
   artifacthub.io/changes: |
-    - kind: added
-      description: "solver: register VectorJoin as slice-invariant so step-aligned ratio joins route through the sharded path; fail-close instant joins on route A (#1215)"
     - kind: fixed
-      description: "prom: don't re-shift native rate offset output (double-shift); sync docs/comments (#1217)"
-    - kind: fixed
-      description: "promql: report range-mode offset output on the unshifted grid, not t-offset (#1216)"
-    - kind: fixed
-      description: "chsql: push compare() root-lookup bound below GROUP BY, not above it (#1214)"
-    - kind: fixed
-      description: "e2e: reconcile the Traces-Drilldown undefined-groupBy init race (#1209)"
-    - kind: changed
-      description: "chsql: dedupe SELECT-passthrough loops and offset-unshift frag (#1219)"
-    - kind: changed
-      description: "solver: drop dead ScanFrom/spineReach; share offset-reanchor IR helper (#1218)"
+      description: "chsql: window-prune the compare root-lookup scan for root-scoped selections (#1223)"

--- a/deploy/helm/cerberus/README.md
+++ b/deploy/helm/cerberus/README.md
@@ -5,7 +5,7 @@
      pipe-aligned, and the version footer adds a trailing blank — both are
      owned by helm-docs; realigning would fight the chart-ci drift check. -->
 
-![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.11.0](https://img.shields.io/badge/AppVersion-1.11.0-informational?style=flat-square)
+![Version: 0.11.1](https://img.shields.io/badge/Version-0.11.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.11.1](https://img.shields.io/badge/AppVersion-1.11.1-informational?style=flat-square)
 
 Drop-in Prometheus / Loki / Tempo HTTP gateway for ClickHouse — a single stateless gateway that speaks three upstream query wire formats and lowers each to parameterised ClickHouse SQL.
 


### PR DESCRIPTION
Release-prep for **v1.11.1** (chart **0.11.1**), generated by `prepare-release.yml`.

- appVersion 1.11.0 -> 1.11.1, chart 0.11.0 -> 0.11.1

### Changes

### Fixed

- **chsql:** window-prune the compare root-lookup scan for root-scoped selections (#1223)

Generated from the conventional commits since the last tag. Review and edit before merging; the tag is cut once this lands.
