### PR TITLE
docs(readme): redraw architecture diagram as a hub around ClickHouse

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,16 @@ normal Prometheus / Loki / Tempo response. Grafana can't tell the
 difference, so your existing dashboards and alerts keep working unchanged.
 
 ```text
-  OpenTelemetry Collector ──writes──▶ ClickHouse ◀──reads── cerberus ◀──queries── Grafana
-                                                            (PromQL / LogQL / TraceQL)
+      WRITE SIDE                     READ SIDE
+                            (PromQL · LogQL · TraceQL)
+  ┌────────────────┐         ┌──────────┐    ┌─────────┐
+  │ OTel Collector │         │ cerberus │◀───│ Grafana │
+  └───────┬────────┘         └────┬─────┘    └─────────┘
+          │ writes                │ reads
+          ▼                       ▼
+     ┌───────────────────────────────────┐
+     │            ClickHouse             │
+     └───────────────────────────────────┘
 ```
 
 **Cerberus does not ingest or store anything.** Your OpenTelemetry


### PR DESCRIPTION
## What

Redraws the README architecture diagram. The old version was a single dense line; the new version draws **ClickHouse as the shared hub** both sides meet at:

```
      WRITE SIDE                     READ SIDE
                            (PromQL · LogQL · TraceQL)
  ┌────────────────┐         ┌──────────┐    ┌─────────┐
  │ OTel Collector │         │ cerberus │◀───│ Grafana │
  └───────┬────────┘         └────┬─────┘    └─────────┘
          │ writes                │ reads
          ▼                       ▼
     ┌───────────────────────────────────┐
     │            ClickHouse             │
     └───────────────────────────────────┘
```

## Why

- Makes the **read-only invariant** ("cerberus only reads, never writes") *visual* rather than prose-only — writers feed ClickHouse from one side, cerberus reads from the other.
- The **WRITE SIDE / READ SIDE** split maps directly onto the paragraph right below the diagram.
- Query languages sit with the **read side**, where the PromQL/LogQL/TraceQL → SQL translation actually happens.

Docs-only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)