### PR TITLE
docs(readme): center architecture diagram as a convergent hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,18 +41,19 @@ cerberus translates it into ClickHouse SQL, runs it, and hands back the
 normal Prometheus / Loki / Tempo response. Grafana can't tell the
 difference, so your existing dashboards and alerts keep working unchanged.
 
-```text
-      WRITE SIDE                     READ SIDE
-                            (PromQL · LogQL · TraceQL)
+<div align="center">
+<table><tr><td><pre>
+      WRITE SIDE                      READ SIDE
+                             (PromQL · LogQL · TraceQL)
   ┌────────────────┐         ┌──────────┐    ┌─────────┐
   │ OTel Collector │         │ cerberus │◀───│ Grafana │
   └───────┬────────┘         └────┬─────┘    └─────────┘
           │ writes                │ reads
-          ▼                       ▼
-     ┌───────────────────────────────────┐
-     │            ClickHouse             │
-     └───────────────────────────────────┘
-```
+          │    ┌─────────────┐    │
+          └───▶│ ClickHouse  │◀───┘
+               └─────────────┘
+</pre></td></tr></table>
+</div>
 
 **Cerberus does not ingest or store anything.** Your OpenTelemetry
 Collector already writes telemetry into ClickHouse through its ClickHouse


### PR DESCRIPTION
Follow-up to #1227. Two refinements over the diagram now on `main`:

**1. Convergent-hub layout** — both flows now turn *inward* toward a centered ClickHouse box, instead of dropping straight down into a left-shifted wide box:

```
      WRITE SIDE                      READ SIDE
                             (PromQL · LogQL · TraceQL)
  ┌────────────────┐         ┌──────────┐    ┌─────────┐
  │ OTel Collector │         │ cerberus │◀───│ Grafana │
  └───────┬────────┘         └────┬─────┘    └─────────┘
          │ writes                │ reads
          │    ┌─────────────┐    │
          └───▶│ ClickHouse  │◀───┘
               └─────────────┘
```

**2. Centering** — a fenced ` ```text ` block can't be centered on GitHub, so the diagram is wrapped in a shrink-to-fit `<table><pre>` centered via `<div align="center">`, matching the centered banner/badges at the top of the README. The `<pre>` keeps the box-art columns rigidly aligned — a plain `align="center"` on preformatted text would center each line independently and shear the columns apart.

Renders as a centered, lightly-framed box (GitHub's default table-cell border + grey `pre` background — the cost of centering rigid ASCII).

Docs-only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)