### PR TITLE
feat(migrate): cmd/migrate binary with offline --schema preview

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -108,6 +108,10 @@ components:
   # Cross-cutting utility packages — see commonComponents below.
   schema:         { in: schema }
   schema-ddl:     { in: schema/ddl }
+  # Maps runtime config → typed ddl.Config. The single place that translation
+  # lives, shared by the server's auto-create hook and cmd/migrate's offline
+  # schema preview, so the previewed schema matches what the server applies.
+  schemaboot:     { in: schemaboot }
   cerbtrace:      { in: cerbtrace }
   telemetry:      { in: telemetry }
   httperr:        { in: api/httperr }
@@ -348,3 +352,12 @@ deps:
   schema-ddl:
     mayDependOn:
       - chsql
+
+  # schemaboot is the wiring layer that maps runtime config into ddl.Config, so
+  # it sits above both config and schema-ddl (and reads schema.KV). One-way
+  # deps only — config/schema/schema-ddl never import schemaboot back.
+  schemaboot:
+    mayDependOn:
+      - config
+      - schema
+      - schema-ddl

--- a/Justfile
+++ b/Justfile
@@ -68,6 +68,13 @@ gen-opt-docs:
 route-rules *ARGS:
     go run ./cmd/route-rules {{ARGS}}
 
+# Pre-cutover migration preview. Renders the ClickHouse schema cerberus expects
+# from the current CERBERUS_* environment — offline, no database connection —
+# so you can review it before provisioning. Pipeable into clickhouse-client:
+#   just migrate --schema | clickhouse-client -h ...
+migrate *ARGS:
+    go run ./cmd/migrate {{ARGS}}
+
 # === Test ===
 
 # Run unit + spec tests with race detector.

--- a/cmd/cerberus/bootstrap_config_test.go
+++ b/cmd/cerberus/bootstrap_config_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+)
+
+// TestBootstrapClickHouseConfig pins that the bootstrap connection rebinds to
+// ClickHouse's always-present `default` database (so CREATE DATABASE works
+// even when the configured target database doesn't exist yet) while leaving
+// the rest of the connection config untouched.
+//
+// The runtime-config → ddl.Config mapping that used to live here moved to
+// internal/schemaboot (shared with cmd/migrate); its tests live there now.
+func TestBootstrapClickHouseConfig(t *testing.T) {
+	in := chclient.Config{Addr: "ch:9000", Database: "otel", Username: "u", Password: "p"}
+	got := bootstrapClickHouseConfig(in)
+	if got.Database != "default" {
+		t.Errorf("bootstrap Database = %q; want default", got.Database)
+	}
+	if got.Addr != "ch:9000" || got.Username != "u" || got.Password != "p" {
+		t.Errorf("bootstrap config changed non-database fields: %+v", got)
+	}
+	if in.Database != "otel" {
+		t.Errorf("input config mutated: %+v", in)
+	}
+}

--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -38,8 +38,8 @@ import (
 	"github.com/tsouza/cerberus/internal/preflight"
 	"github.com/tsouza/cerberus/internal/promql"
 	"github.com/tsouza/cerberus/internal/routerrules"
-	"github.com/tsouza/cerberus/internal/schema"
 	"github.com/tsouza/cerberus/internal/schema/ddl"
+	"github.com/tsouza/cerberus/internal/schemaboot"
 	"github.com/tsouza/cerberus/internal/solver"
 	"github.com/tsouza/cerberus/internal/telemetry"
 )
@@ -290,7 +290,7 @@ func run() error {
 
 	// schemaReady reports whether the auto-create-schema startup hook
 	// has finished at least once; /readyz consults it on every probe.
-	applyCfg, err := schemaApplyConfig(cfg)
+	applyCfg, err := schemaboot.DDLConfig(cfg)
 	if err != nil {
 		return err
 	}
@@ -1113,85 +1113,6 @@ func warnIfClickHouseUnreachable(ctx context.Context, logger *slog.Logger, clien
 			"err", err,
 		)
 	}
-}
-
-// schemaApplyConfig maps the runtime config into the typed internal/schema/ddl
-// Config the auto-create hook applies. The database name comes from the
-// ClickHouse connection config; the cluster / table-engine / TTL / Replicated
-// database-engine knobs come from CERBERUS_SCHEMA_* (SchemaProvisioning); and
-// the per-signal TABLE NAMES are threaded from the SAME resolved schema structs
-// the query heads read (cfg.Schema / cfg.Logs / cfg.Traces), so a
-// CERBERUS_SCHEMA_*_TABLE override creates and queries the same table instead of
-// silently diverging.
-func schemaApplyConfig(cfg config.Config) (ddl.Config, error) {
-	p := cfg.SchemaProvisioning
-	// Per-signal TTL: a non-zero per-signal override wins; otherwise the
-	// signal inherits the global CERBERUS_SCHEMA_TTL default (which is itself
-	// 0 = no retention unless the operator sets it).
-	signalTTL := func(override time.Duration) time.Duration {
-		if override > 0 {
-			return override
-		}
-		return p.TTL
-	}
-	settings, err := schemaSettings(p)
-	if err != nil {
-		return ddl.Config{}, err
-	}
-	return ddl.Config{
-		Database: cfg.ClickHouse.Database,
-		Cluster:  p.Cluster,
-		Engine:   p.TableEngine,
-		TTL: ddl.TTL{
-			Metrics: signalTTL(p.TTLMetrics),
-			Logs:    signalTTL(p.TTLLogs),
-			Traces:  signalTTL(p.TTLTraces),
-		},
-		DatabaseEngine: ddl.DatabaseEngine{
-			Replicated:        p.DatabaseReplicated,
-			ReplicatedZooPath: p.DatabaseReplicatedPath,
-			ReplicatedShard:   p.DatabaseReplicatedShard,
-			ReplicatedReplica: p.DatabaseReplicatedReplica,
-		},
-		Tables: ddl.Tables{
-			Logs:                cfg.Logs.LogsTable,
-			Traces:              cfg.Traces.SpansTable,
-			MetricsGauge:        cfg.Schema.GaugeTable,
-			MetricsSum:          cfg.Schema.SumTable,
-			MetricsHistogram:    cfg.Schema.HistogramTable,
-			MetricsExpHistogram: cfg.Schema.ExpHistogramTable,
-			MetricsSummary:      cfg.Schema.SummaryTable,
-		},
-		Settings: settings,
-	}, nil
-}
-
-// storagePolicySetting is the MergeTree setting key the StoragePolicy shorthand
-// folds into the SETTINGS tail. Pinned first so the emitted DDL is
-// deterministic regardless of any further Settings entries.
-const storagePolicySetting = "storage_policy"
-
-// schemaSettings resolves the auto-create-table SETTINGS tail from the
-// provisioning config: the StoragePolicy shorthand (when set) is folded in
-// PINNED FIRST, ahead of the generic Settings list, so `storage_policy` always
-// precedes the long-tail settings deterministically. Setting StoragePolicy AND
-// also carrying a `storage_policy` key in Settings is a fail-fast startup error
-// — there is one way to set it.
-func schemaSettings(p config.SchemaProvisioning) ([]schema.KV, error) {
-	if p.StoragePolicy == "" {
-		return p.Settings, nil
-	}
-	for _, kv := range p.Settings {
-		if kv.Key == storagePolicySetting {
-			return nil, fmt.Errorf(
-				"schema: storage_policy set via both CERBERUS_SCHEMA_STORAGE_POLICY and CERBERUS_SCHEMA_SETTINGS — set it in exactly one",
-			)
-		}
-	}
-	out := make([]schema.KV, 0, len(p.Settings)+1)
-	out = append(out, schema.KV{Key: storagePolicySetting, Value: p.StoragePolicy})
-	out = append(out, p.Settings...)
-	return out, nil
 }
 
 // setupSchema runs the auto-create-schema startup hook (when enabled)

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -1,0 +1,87 @@
+// Command migrate is cerberus's pre-cutover migration preview tool. It renders
+// the ClickHouse schema cerberus expects — offline, without a database
+// connection — so an operator can review exactly what cerberus will create
+// before provisioning anything.
+//
+// Usage:
+//
+//	migrate --schema      # print the CREATE statements cerberus expects, to stdout
+//
+// Configuration is read from the SAME CERBERUS_* environment the server uses
+// (config.FromEnv), so the previewed schema is byte-identical to what the
+// server would apply on startup. The rendered DDL is directly pipeable into
+// clickhouse-client.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/tsouza/cerberus/internal/config"
+	"github.com/tsouza/cerberus/internal/schema/ddl"
+	"github.com/tsouza/cerberus/internal/schemaboot"
+)
+
+func main() {
+	if err := run(os.Args[1:], os.Stdout, os.Stderr); err != nil {
+		fmt.Fprintln(os.Stderr, "migrate:", err)
+		os.Exit(1)
+	}
+}
+
+// options holds the parsed flags. It grows as the tool gains subcommands
+// (explain, verify); for now --schema is the only capability.
+type options struct {
+	schema bool
+}
+
+// run is the testable entrypoint: it parses args, then dispatches. Splitting it
+// from main() (mirroring cmd/route-rules) keeps flag parsing and dispatch unit
+// -testable without spawning a process.
+func run(args []string, stdout, stderr io.Writer) error {
+	fs := flag.NewFlagSet("migrate", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var opts options
+	fs.BoolVar(&opts.schema, "schema", false,
+		"print the ClickHouse schema (CREATE statements) cerberus expects, then exit")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if !opts.schema {
+		fs.Usage()
+		return fmt.Errorf("nothing to do: pass --schema to print the expected ClickHouse schema")
+	}
+
+	cfg, err := config.FromEnv()
+	if err != nil {
+		return fmt.Errorf("load config from environment: %w", err)
+	}
+	return writeSchema(stdout, cfg)
+}
+
+// writeSchema renders the schema cerberus expects for cfg and writes it to w.
+// It takes an already-loaded config so it is unit-testable without touching the
+// process environment.
+func writeSchema(w io.Writer, cfg config.Config) error {
+	ddlCfg, err := schemaboot.DDLConfig(cfg)
+	if err != nil {
+		return fmt.Errorf("build schema config: %w", err)
+	}
+	stmts, err := ddl.RenderAll(ddlCfg, ddl.All)
+	if err != nil {
+		return fmt.Errorf("render schema: %w", err)
+	}
+	if len(stmts) == 0 {
+		return fmt.Errorf("no schema to render (no signals configured)")
+	}
+	// Terminate every statement with ';' so the output pipes straight into
+	// clickhouse-client; blank lines between statements keep it readable.
+	if _, err := fmt.Fprintln(w, strings.Join(stmts, ";\n\n")+";"); err != nil {
+		return fmt.Errorf("write schema: %w", err)
+	}
+	return nil
+}

--- a/cmd/migrate/main_test.go
+++ b/cmd/migrate/main_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/config"
+)
+
+// TestRun_NoFlagsIsError pins that invoking the tool with nothing to do reports
+// an error (and prints usage) rather than silently succeeding.
+func TestRun_NoFlagsIsError(t *testing.T) {
+	var out, errOut bytes.Buffer
+	if err := run(nil, &out, &errOut); err == nil {
+		t.Fatal("run with no flags should error")
+	}
+	if out.Len() != 0 {
+		t.Errorf("no schema should be written to stdout on error, got: %q", out.String())
+	}
+}
+
+// TestRun_UnknownFlagIsError pins that an unknown flag surfaces the flag
+// package's parse error instead of proceeding.
+func TestRun_UnknownFlagIsError(t *testing.T) {
+	var out, errOut bytes.Buffer
+	if err := run([]string{"--nope"}, &out, &errOut); err == nil {
+		t.Fatal("run with an unknown flag should error")
+	}
+}
+
+// TestWriteSchema pins the render path end to end (offline): a config with a
+// database + table overrides produces pipeable DDL that creates the database
+// first and the overridden tables after, each statement ';'-terminated.
+func TestWriteSchema(t *testing.T) {
+	cfg := config.Config{
+		ClickHouse: chclient.Config{Database: "otel"},
+	}
+
+	var out bytes.Buffer
+	if err := writeSchema(&out, cfg); err != nil {
+		t.Fatalf("writeSchema: %v", err)
+	}
+	got := out.String()
+
+	if !strings.Contains(got, "CREATE DATABASE IF NOT EXISTS otel") {
+		t.Errorf("expected CREATE DATABASE for the configured database, got:\n%s", got)
+	}
+	if !strings.Contains(got, "CREATE TABLE IF NOT EXISTS") {
+		t.Errorf("expected CREATE TABLE statements, got:\n%s", got)
+	}
+	// The database must be created before any table references it.
+	if db, tbl := strings.Index(got, "CREATE DATABASE"), strings.Index(got, "CREATE TABLE"); db > tbl {
+		t.Errorf("CREATE DATABASE must precede CREATE TABLE (db@%d, table@%d)", db, tbl)
+	}
+	if !strings.HasSuffix(strings.TrimRight(got, "\n"), ";") {
+		t.Errorf("rendered schema must be ';'-terminated for clickhouse-client, got tail: %q",
+			got[max(0, len(got)-40):])
+	}
+}

--- a/internal/schemaboot/ddlconfig.go
+++ b/internal/schemaboot/ddlconfig.go
@@ -1,0 +1,94 @@
+// Package schemaboot maps cerberus's runtime config into the typed
+// internal/schema/ddl Config used to create ClickHouse tables. It is the single
+// place that translation lives, shared by the server's auto-create startup hook
+// (cmd/cerberus) and the offline migration preview tool (cmd/migrate), so the
+// schema the tool previews is byte-identical to the schema the server applies.
+package schemaboot
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/config"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/schema/ddl"
+)
+
+// storagePolicySetting is the MergeTree setting key the StoragePolicy shorthand
+// folds into the SETTINGS tail. Pinned first so the emitted DDL is
+// deterministic regardless of any further Settings entries.
+const storagePolicySetting = "storage_policy"
+
+// DDLConfig maps the runtime config into the typed internal/schema/ddl Config
+// the auto-create hook applies. The database name comes from the ClickHouse
+// connection config; the cluster / table-engine / TTL / Replicated
+// database-engine knobs come from CERBERUS_SCHEMA_* (SchemaProvisioning); and
+// the per-signal TABLE NAMES are threaded from the SAME resolved schema structs
+// the query heads read (cfg.Schema / cfg.Logs / cfg.Traces), so a
+// CERBERUS_SCHEMA_*_TABLE override creates and queries the same table instead of
+// silently diverging.
+func DDLConfig(cfg config.Config) (ddl.Config, error) {
+	p := cfg.SchemaProvisioning
+	// Per-signal TTL: a non-zero per-signal override wins; otherwise the signal
+	// inherits the global CERBERUS_SCHEMA_TTL default (which is itself 0 = no
+	// retention unless the operator sets it).
+	signalTTL := func(override time.Duration) time.Duration {
+		if override > 0 {
+			return override
+		}
+		return p.TTL
+	}
+	settings, err := schemaSettings(p)
+	if err != nil {
+		return ddl.Config{}, err
+	}
+	return ddl.Config{
+		Database: cfg.ClickHouse.Database,
+		Cluster:  p.Cluster,
+		Engine:   p.TableEngine,
+		TTL: ddl.TTL{
+			Metrics: signalTTL(p.TTLMetrics),
+			Logs:    signalTTL(p.TTLLogs),
+			Traces:  signalTTL(p.TTLTraces),
+		},
+		DatabaseEngine: ddl.DatabaseEngine{
+			Replicated:        p.DatabaseReplicated,
+			ReplicatedZooPath: p.DatabaseReplicatedPath,
+			ReplicatedShard:   p.DatabaseReplicatedShard,
+			ReplicatedReplica: p.DatabaseReplicatedReplica,
+		},
+		Tables: ddl.Tables{
+			Logs:                cfg.Logs.LogsTable,
+			Traces:              cfg.Traces.SpansTable,
+			MetricsGauge:        cfg.Schema.GaugeTable,
+			MetricsSum:          cfg.Schema.SumTable,
+			MetricsHistogram:    cfg.Schema.HistogramTable,
+			MetricsExpHistogram: cfg.Schema.ExpHistogramTable,
+			MetricsSummary:      cfg.Schema.SummaryTable,
+		},
+		Settings: settings,
+	}, nil
+}
+
+// schemaSettings resolves the auto-create-table SETTINGS tail from the
+// provisioning config: the StoragePolicy shorthand (when set) is folded in
+// PINNED FIRST, ahead of the generic Settings list, so `storage_policy` always
+// precedes the long-tail settings deterministically. Setting StoragePolicy AND
+// also carrying a `storage_policy` key in Settings is a fail-fast error — there
+// is exactly one way to set it.
+func schemaSettings(p config.SchemaProvisioning) ([]schema.KV, error) {
+	if p.StoragePolicy == "" {
+		return p.Settings, nil
+	}
+	for _, kv := range p.Settings {
+		if kv.Key == storagePolicySetting {
+			return nil, fmt.Errorf(
+				"schema: storage_policy set via both CERBERUS_SCHEMA_STORAGE_POLICY and CERBERUS_SCHEMA_SETTINGS — set it in exactly one",
+			)
+		}
+	}
+	out := make([]schema.KV, 0, len(p.Settings)+1)
+	out = append(out, schema.KV{Key: storagePolicySetting, Value: p.StoragePolicy})
+	out = append(out, p.Settings...)
+	return out, nil
+}

--- a/internal/schemaboot/ddlconfig_test.go
+++ b/internal/schemaboot/ddlconfig_test.go
@@ -1,36 +1,18 @@
-package main
+package schemaboot_test
 
 import (
 	"testing"
 	"time"
 
-	"github.com/tsouza/cerberus/internal/chclient"
 	"github.com/tsouza/cerberus/internal/config"
 	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/schemaboot"
 )
 
-// TestBootstrapClickHouseConfig pins that the bootstrap connection rebinds to
-// ClickHouse's always-present `default` database (so CREATE DATABASE works
-// even when the configured target database doesn't exist yet) while leaving
-// the rest of the connection config untouched.
-func TestBootstrapClickHouseConfig(t *testing.T) {
-	in := chclient.Config{Addr: "ch:9000", Database: "otel", Username: "u", Password: "p"}
-	got := bootstrapClickHouseConfig(in)
-	if got.Database != "default" {
-		t.Errorf("bootstrap Database = %q; want default", got.Database)
-	}
-	if got.Addr != "ch:9000" || got.Username != "u" || got.Password != "p" {
-		t.Errorf("bootstrap config changed non-database fields: %+v", got)
-	}
-	if in.Database != "otel" {
-		t.Errorf("input config mutated: %+v", in)
-	}
-}
-
-// TestSchemaApplyConfig_PerSignalTTLFallback pins the per-signal TTL
-// resolution schemaApplyConfig performs: a non-zero per-signal override
-// wins, and a zero per-signal value inherits the global CERBERUS_SCHEMA_TTL.
-func TestSchemaApplyConfig_PerSignalTTLFallback(t *testing.T) {
+// TestDDLConfig_PerSignalTTLFallback pins the per-signal TTL resolution: a
+// non-zero per-signal override wins, and a zero per-signal value inherits the
+// global CERBERUS_SCHEMA_TTL.
+func TestDDLConfig_PerSignalTTLFallback(t *testing.T) {
 	cfg := config.Config{
 		SchemaProvisioning: config.SchemaProvisioning{
 			TTL:        90 * 24 * time.Hour, // global default
@@ -39,9 +21,9 @@ func TestSchemaApplyConfig_PerSignalTTLFallback(t *testing.T) {
 			TTLMetrics: 0,                   // metrics inherit the global
 		},
 	}
-	got, err := schemaApplyConfig(cfg)
+	got, err := schemaboot.DDLConfig(cfg)
 	if err != nil {
-		t.Fatalf("schemaApplyConfig: %v", err)
+		t.Fatalf("DDLConfig: %v", err)
 	}
 	if got.TTL.Metrics != 90*24*time.Hour {
 		t.Errorf("metrics TTL = %v; want global 90d (inherited)", got.TTL.Metrics)
@@ -54,11 +36,11 @@ func TestSchemaApplyConfig_PerSignalTTLFallback(t *testing.T) {
 	}
 }
 
-// TestSchemaApplyConfig_TableNamesThreaded pins that auto-create uses the
-// SAME resolved table names the query heads read (cfg.Schema / Logs /
-// Traces), so a CERBERUS_SCHEMA_*_TABLE override creates and queries the
-// same table rather than silently diverging onto the upstream defaults.
-func TestSchemaApplyConfig_TableNamesThreaded(t *testing.T) {
+// TestDDLConfig_TableNamesThreaded pins that auto-create uses the SAME resolved
+// table names the query heads read (cfg.Schema / Logs / Traces), so a
+// CERBERUS_SCHEMA_*_TABLE override creates and queries the same table rather
+// than silently diverging onto the upstream defaults.
+func TestDDLConfig_TableNamesThreaded(t *testing.T) {
 	cfg := config.Config{
 		Schema: schema.Metrics{
 			GaugeTable:        "m_gauge",
@@ -70,9 +52,9 @@ func TestSchemaApplyConfig_TableNamesThreaded(t *testing.T) {
 		Logs:   schema.Logs{LogsTable: "my_logs"},
 		Traces: schema.Traces{SpansTable: "my_spans"},
 	}
-	got, err := schemaApplyConfig(cfg)
+	got, err := schemaboot.DDLConfig(cfg)
 	if err != nil {
-		t.Fatalf("schemaApplyConfig: %v", err)
+		t.Fatalf("DDLConfig: %v", err)
 	}
 	if got.Tables.MetricsGauge != "m_gauge" || got.Tables.MetricsSum != "m_sum" ||
 		got.Tables.MetricsHistogram != "m_hist" || got.Tables.MetricsExpHistogram != "m_exp" ||
@@ -87,9 +69,9 @@ func TestSchemaApplyConfig_TableNamesThreaded(t *testing.T) {
 	}
 }
 
-// TestSchemaApplyConfig_ReplicatedThreaded pins the Replicated database
-// engine knobs flow through to the ddl Config.
-func TestSchemaApplyConfig_ReplicatedThreaded(t *testing.T) {
+// TestDDLConfig_ReplicatedThreaded pins the Replicated database engine knobs
+// flow through to the ddl Config.
+func TestDDLConfig_ReplicatedThreaded(t *testing.T) {
 	cfg := config.Config{
 		SchemaProvisioning: config.SchemaProvisioning{
 			Cluster:                   "", // mutually exclusive with replicated
@@ -99,9 +81,9 @@ func TestSchemaApplyConfig_ReplicatedThreaded(t *testing.T) {
 			DatabaseReplicatedReplica: "replica0",
 		},
 	}
-	got, err := schemaApplyConfig(cfg)
+	got, err := schemaboot.DDLConfig(cfg)
 	if err != nil {
-		t.Fatalf("schemaApplyConfig: %v", err)
+		t.Fatalf("DDLConfig: %v", err)
 	}
 	if !got.DatabaseEngine.Replicated ||
 		got.DatabaseEngine.ReplicatedZooPath != "/clickhouse/databases/otel" ||
@@ -111,11 +93,10 @@ func TestSchemaApplyConfig_ReplicatedThreaded(t *testing.T) {
 	}
 }
 
-// TestSchemaApplyConfig_StoragePolicyPinnedFirst pins the StoragePolicy
-// shorthand: it folds into Settings ahead of the generic settings list, so
-// `storage_policy` always precedes any CERBERUS_SCHEMA_SETTINGS entries
-// deterministically.
-func TestSchemaApplyConfig_StoragePolicyPinnedFirst(t *testing.T) {
+// TestDDLConfig_StoragePolicyPinnedFirst pins the StoragePolicy shorthand: it
+// folds into Settings ahead of the generic settings list, so `storage_policy`
+// always precedes any CERBERUS_SCHEMA_SETTINGS entries deterministically.
+func TestDDLConfig_StoragePolicyPinnedFirst(t *testing.T) {
 	cfg := config.Config{
 		SchemaProvisioning: config.SchemaProvisioning{
 			StoragePolicy: "s3_tiered",
@@ -124,9 +105,9 @@ func TestSchemaApplyConfig_StoragePolicyPinnedFirst(t *testing.T) {
 			},
 		},
 	}
-	got, err := schemaApplyConfig(cfg)
+	got, err := schemaboot.DDLConfig(cfg)
 	if err != nil {
-		t.Fatalf("schemaApplyConfig: %v", err)
+		t.Fatalf("DDLConfig: %v", err)
 	}
 	if len(got.Settings) != 2 {
 		t.Fatalf("want 2 settings, got %d: %+v", len(got.Settings), got.Settings)
@@ -139,10 +120,10 @@ func TestSchemaApplyConfig_StoragePolicyPinnedFirst(t *testing.T) {
 	}
 }
 
-// TestSchemaApplyConfig_StoragePolicyDualSourceRejected pins the fail-fast:
-// setting storage_policy via BOTH the shorthand and a Settings key is a
-// startup error — there is exactly one way to set it.
-func TestSchemaApplyConfig_StoragePolicyDualSourceRejected(t *testing.T) {
+// TestDDLConfig_StoragePolicyDualSourceRejected pins the fail-fast: setting
+// storage_policy via BOTH the shorthand and a Settings key is an error — there
+// is exactly one way to set it.
+func TestDDLConfig_StoragePolicyDualSourceRejected(t *testing.T) {
 	cfg := config.Config{
 		SchemaProvisioning: config.SchemaProvisioning{
 			StoragePolicy: "s3_tiered",
@@ -151,14 +132,14 @@ func TestSchemaApplyConfig_StoragePolicyDualSourceRejected(t *testing.T) {
 			},
 		},
 	}
-	if _, err := schemaApplyConfig(cfg); err == nil {
+	if _, err := schemaboot.DDLConfig(cfg); err == nil {
 		t.Fatal("want error for storage_policy set via both shorthand and Settings, got nil")
 	}
 }
 
-// TestSchemaApplyConfig_SettingsOnlyNoStoragePolicy pins that a bare Settings
-// list (no shorthand) threads through unchanged — no spurious storage_policy.
-func TestSchemaApplyConfig_SettingsOnlyNoStoragePolicy(t *testing.T) {
+// TestDDLConfig_SettingsOnlyNoStoragePolicy pins that a bare Settings list (no
+// shorthand) threads through unchanged — no spurious storage_policy.
+func TestDDLConfig_SettingsOnlyNoStoragePolicy(t *testing.T) {
 	cfg := config.Config{
 		SchemaProvisioning: config.SchemaProvisioning{
 			Settings: []schema.KV{
@@ -166,9 +147,9 @@ func TestSchemaApplyConfig_SettingsOnlyNoStoragePolicy(t *testing.T) {
 			},
 		},
 	}
-	got, err := schemaApplyConfig(cfg)
+	got, err := schemaboot.DDLConfig(cfg)
 	if err != nil {
-		t.Fatalf("schemaApplyConfig: %v", err)
+		t.Fatalf("DDLConfig: %v", err)
 	}
 	if len(got.Settings) != 1 || got.Settings[0].Key != "min_bytes_for_wide_part" {
 		t.Errorf("settings not threaded as-is: %+v", got.Settings)


### PR DESCRIPTION
> Stacked on #1231 (`feat/ddl-render-all`). GitHub will auto-retarget this to `main` once #1231 merges; I'll rebase to drop the shared commit.

## What

Adds the **`migrate` tool** as a standalone `cmd/` binary (matching the repo's one-binary-per-tool idiom — `bench-report`, `route-rules`, …). First capability:

```
migrate --schema   # print the exact ClickHouse CREATE statements cerberus expects
```

Offline, no database connection. Reads the **same `CERBERUS_*` environment the server does**, so the preview is byte-identical to what the server applies on startup. Output is pipeable straight into `clickhouse-client`.

## Clean-architecture change: shared `schemaboot` package

To guarantee the preview matches the server, the runtime-config → `ddl.Config` mapping is **lifted out of `cmd/cerberus`** into a new `internal/schemaboot` package, now consumed by both:
- the server's auto-create startup hook, and
- `cmd/migrate`.

No duplication. The five mapping tests move to `schemaboot`; the server keeps only its bootstrap-connection test. Behavior is unchanged (pure move + delegate).

## Wiring

- `.go-arch-lint.yml`: `schemaboot` declared with one-way deps (`config`, `schema`, `schema-ddl`).
- `just migrate` recipe added.
- `cmd/` is arch-lint-exempt, so the new binary needs no arch declaration.

## Tests

- `internal/schemaboot`: the 5 config→DDL mapping tests (TTL fallback, table-name threading, Replicated, storage_policy pinning + dual-source rejection).
- `cmd/migrate`: flag dispatch (no-flags / unknown-flag error) + an end-to-end `writeSchema` render test (database-before-tables, `;`-terminated).

## Not in this PR

Release packaging (goreleaser build + Docker image) lands as its own PR so the release-infra change can be validated on its own. Until then the tool runs via `just migrate` / `go run ./cmd/migrate`.

Part of the pre-cutover migration tool series (step 2 of 6). Next: `migrate explain` over local files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)