### PR TITLE
feat(engine): add DryRunSQL to emit query SQL without executing

### DIFF
--- a/internal/engine/dryrun_test.go
+++ b/internal/engine/dryrun_test.go
@@ -1,0 +1,67 @@
+package engine_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/engine"
+)
+
+// TestDryRunSQL_MatchesQuery is the core contract: DryRunSQL must return the
+// exact SQL that Query executes, and must NOT touch the querier. It runs the
+// live path (capturing the SQL sent to the fake ClickHouse), then the dry run,
+// and asserts the SQL matches and the querier saw no extra call.
+func TestDryRunSQL_MatchesQuery(t *testing.T) {
+	q := &fakeQuerier{}
+	eng := newEngine(q)
+	lang := &fakeLang{name: "promql"}
+	ctx := context.Background()
+
+	if _, err := eng.Query(ctx, lang, "up"); err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if q.calls != 1 {
+		t.Fatalf("setup: expected exactly one querier call from Query, got %d", q.calls)
+	}
+	executedSQL := q.gotSQL
+
+	dr, err := eng.DryRunSQL(ctx, lang, "up")
+	if err != nil {
+		t.Fatalf("DryRunSQL: %v", err)
+	}
+	if dr.SQL != executedSQL {
+		t.Errorf("dry-run SQL differs from executed SQL:\n dry:  %s\n exec: %s", dr.SQL, executedSQL)
+	}
+	if len(dr.Args) != len(q.gotArgs) {
+		t.Errorf("dry-run args count %d != executed args count %d", len(dr.Args), len(q.gotArgs))
+	}
+	if q.calls != 1 {
+		t.Errorf("DryRunSQL must not execute: querier calls went from 1 to %d", q.calls)
+	}
+	if dr.Plan == nil {
+		t.Error("dry-run should expose the optimized plan for offline inspection")
+	}
+}
+
+// TestDryRunSQL_ParseError pins that a parse failure is surfaced (wrapped) and
+// the querier is never touched.
+func TestDryRunSQL_ParseError(t *testing.T) {
+	sentinel := errors.New("boom")
+	q := &fakeQuerier{}
+	eng := newEngine(q)
+	lang := &fakeLang{
+		name: "promql",
+		parseFn: func(context.Context, string) (chplan.Node, engine.Meta, error) {
+			return nil, engine.Meta{}, sentinel
+		},
+	}
+
+	if _, err := eng.DryRunSQL(context.Background(), lang, "!!!"); err == nil {
+		t.Fatal("expected a parse error from DryRunSQL")
+	}
+	if q.calls != 0 {
+		t.Errorf("a parse failure must not reach the querier, got %d calls", q.calls)
+	}
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -672,6 +672,66 @@ func (e *Engine) Query(ctx context.Context, lang Lang, query string) (Result, er
 	return e.QueryPlan(ctx, lang, plan, meta)
 }
 
+// DryRun is the offline result of DryRunSQL: the parameterised ClickHouse SQL
+// the pipeline would execute for a query, plus the optimized plan and Meta,
+// WITHOUT running it.
+type DryRun struct {
+	// SQL is the parameterised ClickHouse SQL that Query would execute. It is
+	// empty when emit failed (see the error DryRunSQL returned alongside it).
+	SQL string
+	// Args is the positional bind list for SQL's `?` placeholders.
+	Args []any
+	// Plan is the optimized plan the SQL was emitted from. It is populated even
+	// when emit fails, so a caller can still inspect WHY (e.g. an unbounded
+	// scan that the emit-time chokepoint rejected).
+	Plan chplan.Node
+	// Meta is the per-language semantic flags the adapter returned from Parse.
+	Meta Meta
+}
+
+// DryRunSQL runs the read-side of the pipeline — parse, project, optimize,
+// emit — and returns the ClickHouse SQL WITHOUT executing it. It reuses the
+// exact stages QueryPlan runs before Execute, so the SQL is byte-identical to
+// what Query would send to ClickHouse. The optimizer pass, the subquery
+// sample-budget gate, and the emit-time chokepoints all fire here just as they
+// do on a live run, so an unbounded query returns their error rather than a
+// misleadingly-clean preview.
+//
+// It exists so offline tooling (the migration preview) can show operators the
+// SQL cerberus will run for a query without a ClickHouse connection — the
+// Engine's Client is never touched. Solver routing is intentionally skipped:
+// the dry run reports the standard emit, which is what executes under the
+// default single-route mode.
+func (e *Engine) DryRunSQL(ctx context.Context, lang Lang, query string) (DryRun, error) {
+	if lang == nil {
+		return DryRun{}, fmt.Errorf("engine: nil Lang")
+	}
+	plan, meta, err := lang.Parse(ctx, query)
+	if err != nil {
+		return DryRun{}, fmt.Errorf("engine: parse: %w", err)
+	}
+	dr := DryRun{Meta: meta}
+
+	plan = lang.ProjectSamples(plan, meta)
+	if !meta.IsTraceByID {
+		plan = e.Optimizer.Run(ctx, plan)
+	}
+	// Record the optimized plan before the gate + emit, which may return early:
+	// the plan is useful for offline inspection even when emit rejects it.
+	dr.Plan = plan
+
+	if err := requireSubquerySampleBudget(plan, e.MaxQuerySamples); err != nil {
+		return dr, err
+	}
+
+	sql, args, err := emitForHead(ctx, lang, plan)
+	if err != nil {
+		return dr, fmt.Errorf("engine: emit: %w", err)
+	}
+	dr.SQL, dr.Args = sql, args
+	return dr, nil
+}
+
 // QueryPlan runs the post-parse half of the pipeline for a plan the
 // adapter built directly. The Tempo /traces/{id} path is the canonical
 // caller: it hand-rolls a plan instead of running a TraceQL parser, so


### PR DESCRIPTION
## What

Adds `Engine.DryRunSQL(ctx, lang, query) (DryRun, error)` — it runs the read-side of the pipeline (**parse → project → optimize → emit**) and returns the parameterised ClickHouse SQL + the optimized plan, **without executing it**.

## Why byte-parity matters

It reuses the *exact* stages `QueryPlan` runs before Execute — the optimizer pass, the subquery sample-budget gate, and the emit-time chokepoints all fire. So:
- the SQL is byte-identical to what `Query` sends to ClickHouse, and
- an unbounded query returns an honest error instead of a misleadingly-clean preview.

The Engine's `Client` is never touched. Solver routing is intentionally skipped — the dry run reports the standard emit, which is what executes under the default single-route mode.

## Consumer

This is the seam the migration preview tool's `explain` uses to show operators the SQL cerberus will run for each of their queries — offline, no database connection. (That harvest/explain layer lands in the next PR.)

## Tests

- `TestDryRunSQL_MatchesQuery` — runs the live path (capturing the executed SQL via a fake querier), then the dry run, and asserts the SQL matches **and** the querier is never called.
- `TestDryRunSQL_ParseError` — parse failures are surfaced (wrapped) and never reach the querier.

Independent of the other migration-tool PRs (pure `internal/engine` addition). Part of the pre-cutover migration tool series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)