### PR TITLE
test: satisfy staticcheck SA5011 nil-deref after golangci 2.12.2 bump

### DIFF
--- a/internal/api/loki/patterns_test.go
+++ b/internal/api/loki/patterns_test.go
@@ -105,6 +105,7 @@ func TestPatterns_DrainExtractsCommonTemplate(t *testing.T) {
 	}
 	if hit == nil {
 		t.Fatalf("no cluster contained both GET and 200; data=%+v", out.Data)
+		return
 	}
 	if !strings.Contains(hit.Pattern, "<_>") {
 		t.Errorf("expected variable placeholder <_> in pattern; got %q", hit.Pattern)

--- a/internal/api/prom/label_memo_bucketing_test.go
+++ b/internal/api/prom/label_memo_bucketing_test.go
@@ -113,6 +113,7 @@ func TestMatrixFromCursor_MemoPreservesBucketing(t *testing.T) {
 		r := refBy[k]
 		if r == nil {
 			t.Fatalf("series %v not in reference", ms.Metric)
+			return
 		}
 		if len(ms.Values) != len(r.vals) {
 			t.Fatalf("series %v: got %d values, want %d", ms.Metric, len(ms.Values), len(r.vals))

--- a/internal/api/tempo/metrics_query_range_histogram_test.go
+++ b/internal/api/tempo/metrics_query_range_histogram_test.go
@@ -73,6 +73,7 @@ func TestMetricsQueryRangeHistogram_Ungrouped(t *testing.T) {
 	}
 	if b025 == nil {
 		t.Fatalf("no series for __bucket=0.25: %+v", body.Series)
+		return
 	}
 	if len(b025.Samples) != 2 || b025.Samples[0].Value != 1 || b025.Samples[1].Value != 3 {
 		t.Errorf("bucket 0.25 samples wrong (want ascending [1 3]): %+v", b025.Samples)

--- a/internal/api/tempo/metrics_query_range_test.go
+++ b/internal/api/tempo/metrics_query_range_test.go
@@ -615,6 +615,7 @@ func TestMetricsQueryRange_DurationAggInSeconds(t *testing.T) {
 			}
 			if observed == nil {
 				t.Fatalf("no sample matches stubbed timestamp %d: %+v", midMs, body.Series[0].Samples)
+				return
 			}
 			if observed.Value != 0.5 {
 				t.Errorf("expected sub-second value 0.5 to pass through unchanged, got %v", observed.Value)

--- a/internal/config/ch_connection_test.go
+++ b/internal/config/ch_connection_test.go
@@ -206,6 +206,7 @@ func TestFromEnv_CHTLS_mTLS(t *testing.T) {
 	tlsCfg := cfg.ClickHouse.TLS
 	if tlsCfg == nil {
 		t.Fatal("TLS = nil; want non-nil when enabled")
+		return
 	}
 	if tlsCfg.ServerName != "clickhouse.internal" {
 		t.Errorf("ServerName = %q; want clickhouse.internal", tlsCfg.ServerName)

--- a/internal/optimizer/scan_resource_bound_test.go
+++ b/internal/optimizer/scan_resource_bound_test.go
@@ -83,6 +83,7 @@ func TestRequireScanResourceBound_PanicsWhenGateStripped(t *testing.T) {
 	})
 	if v == nil {
 		t.Fatalf("TraceLimit>0 NestedSetAnnotate without a BoundedTraceScope leaf must panic ScanResourceBoundViolation")
+		return
 	}
 	if v.Table != "otel_traces" {
 		t.Errorf("violation Table = %q, want otel_traces", v.Table)

--- a/internal/optimizer/scan_time_bound_test.go
+++ b/internal/optimizer/scan_time_bound_test.go
@@ -69,6 +69,7 @@ func TestRequireScanTimeBound_RejectsUnboundedInstantLeaf(t *testing.T) {
 	})
 	if v == nil {
 		t.Fatal("RequireScanTimeBound must reject an unbounded instant windowed-array leaf")
+		return
 	}
 	if v.Func != "rate" {
 		t.Errorf("violation Func = %q, want %q", v.Func, "rate")

--- a/internal/promql/parser_shape_test.go
+++ b/internal/promql/parser_shape_test.go
@@ -61,6 +61,7 @@ func TestParserShape_InstantSelector(t *testing.T) {
 	}
 	if nameMatcher == nil {
 		t.Fatal("no __name__ matcher in LabelMatchers")
+		return
 	}
 	if nameMatcher.Type != labels.MatchEqual {
 		t.Errorf("__name__ matcher Type = %v; want MatchEqual", nameMatcher.Type)
@@ -180,6 +181,7 @@ func TestParserShape_MatcherAndOffset(t *testing.T) {
 	}
 	if jobMatcher == nil {
 		t.Fatal("no job matcher in LabelMatchers")
+		return
 	}
 	if jobMatcher.Type != labels.MatchEqual {
 		t.Errorf("job matcher Type = %v; want MatchEqual", jobMatcher.Type)

--- a/internal/telemetry/contract_test.go
+++ b/internal/telemetry/contract_test.go
@@ -194,6 +194,7 @@ func TestGet_NoopMeterProviderProducesNonNilInstruments(t *testing.T) {
 	inst := telemetry.Get()
 	if inst == nil {
 		t.Fatal("Get = nil under noop provider")
+		return
 	}
 	if inst.QueriesTotal == nil || inst.QueryDuration == nil ||
 		inst.StageDuration == nil || inst.RulesApplied == nil ||

--- a/internal/traceql/metrics_compare_rootscope_test.go
+++ b/internal/traceql/metrics_compare_rootscope_test.go
@@ -43,6 +43,7 @@ func TestLowerCompareInnerRootScoped(t *testing.T) {
 		mc := findMetricsCompare(plan)
 		if mc == nil {
 			t.Fatalf("%q: no MetricsCompare in plan", tc.query)
+			return
 		}
 		if mc.InnerRootScoped != tc.want {
 			t.Errorf("%q: InnerRootScoped=%v, want %v", tc.query, mc.InnerRootScoped, tc.want)


### PR DESCRIPTION
## Why

golangci-lint **2.12.2** (now installed by the CI lint action) ships a staticcheck that no longer treats `testing.T.Fatal`/`Fatalf` as unconditionally terminating in these contexts. The common idiom

```go
if p == nil { t.Fatalf(...) }
// ... p.Field
```

is now flagged **SA5011 (possible nil pointer dereference)** across ~10 test files. This currently fails the `lint` gate on **every open PR** (it fails on `main`'s tree, not on anything a PR changed).

## Fix

Add an explicit `return` after the fatal in each nil-guard so control flow is unambiguous for the analyzer. Behaviour is unchanged — `t.Fatal` already aborts the test; the `return` is only reached in the analyzer's model. Verified clean under golangci-lint 2.12.2 locally (`./...`).

## Files

10 test files: loki/patterns, prom/label_memo_bucketing, tempo/metrics_query_range{,_histogram}, config/ch_connection, optimizer/scan_{resource,time}_bound, promql/parser_shape (×2), telemetry/contract, traceql/metrics_compare_rootscope.

This is the shared unblocker — merging it first lets the migration-tool PRs (#1231–#1233) go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)