### PR TITLE
feat(migrate): explain — preview the ClickHouse SQL for your PromQL

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -154,6 +154,13 @@ components:
   # it depends only on chsql for typed SQL composition.
   routerrules:    { in: routerrules }
   autotune:       { in: autotune }
+  # Offline migration preview support: harvests a PromQL corpus from rule files
+  # (promrules) and assembles the explain report over the chplan IR. Wired from
+  # cmd/migrate only.
+  migrate:        { in: migrate }
+  # Leaf yaml.v3 decode of Prometheus rule files (record/alert exprs). No
+  # internal deps — deliberately avoids prometheus/rulefmt's ~112-package pull.
+  promrules:      { in: promrules }
 
 # commonComponents are importable from every layer without an explicit
 # `mayDependOn` entry. These are the cross-cutting utility packages
@@ -276,6 +283,15 @@ deps:
     mayDependOn:
       - solver
       - routerrules
+
+  # migrate builds the offline explain report. It walks the chplan IR (Tables /
+  # Lint) and harvests its corpus via promrules. Explanation is delegated to an
+  # Explainer interface — the engine/DryRunSQL wiring lives in cmd/migrate
+  # (arch-lint-exempt), so migrate itself takes only chplan + promrules.
+  migrate:
+    mayDependOn:
+      - chplan
+      - promrules
 
   # config is wired from cmd/ to build chclient + schema at boot.
   config:

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -1,29 +1,49 @@
-// Command migrate is cerberus's pre-cutover migration preview tool. It renders
-// the ClickHouse schema cerberus expects — offline, without a database
-// connection — so an operator can review exactly what cerberus will create
-// before provisioning anything.
+// Command migrate is cerberus's pre-cutover migration preview tool. It runs
+// offline — without a ClickHouse connection — so an operator can review exactly
+// what cerberus will do before provisioning anything.
 //
 // Usage:
 //
-//	migrate --schema      # print the CREATE statements cerberus expects, to stdout
+//	migrate --schema             # print the CREATE statements cerberus expects
+//	migrate --rules <path/glob>  # explain the ClickHouse SQL for each PromQL
+//	                             # query in the given Prometheus rule files
 //
-// Configuration is read from the SAME CERBERUS_* environment the server uses
+// --schema reads the SAME CERBERUS_* environment the server uses
 // (config.FromEnv), so the previewed schema is byte-identical to what the
-// server would apply on startup. The rendered DDL is directly pipeable into
-// clickhouse-client.
+// server would apply on startup, and pipes straight into clickhouse-client.
+//
+// --rules harvests every recording/alerting rule's PromQL, dry-runs it through
+// the exact read-side pipeline the server runs (parse → project → optimize →
+// emit, via engine.DryRunSQL — the ClickHouse client is never touched), and
+// prints the emitted SQL, the physical tables each query scans, and
+// conservative offline risk flags, or marks the query UNSUPPORTED. Row
+// cardinality is data-dependent and is deliberately NOT estimated offline.
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"io"
 	"os"
 	"strings"
+	"time"
 
+	"github.com/tsouza/cerberus/internal/api/prom"
 	"github.com/tsouza/cerberus/internal/config"
+	"github.com/tsouza/cerberus/internal/engine"
+	"github.com/tsouza/cerberus/internal/migrate"
+	"github.com/tsouza/cerberus/internal/optimizer"
+	"github.com/tsouza/cerberus/internal/schema"
 	"github.com/tsouza/cerberus/internal/schema/ddl"
 	"github.com/tsouza/cerberus/internal/schemaboot"
 )
+
+// explainEvalUnix pins the offline explain's instant-evaluation anchor to a
+// fixed wall-clock (Unix seconds) so the emitted SQL — and any goldens over it
+// — are deterministic regardless of when the tool runs. The exact instant is
+// arbitrary; only its stability matters.
+const explainEvalUnix = 1_700_000_000
 
 func main() {
 	if err := run(os.Args[1:], os.Stdout, os.Stderr); err != nil {
@@ -32,10 +52,26 @@ func main() {
 	}
 }
 
-// options holds the parsed flags. It grows as the tool gains subcommands
-// (explain, verify); for now --schema is the only capability.
+// stringList is a repeatable + comma-separated flag value. `--rules a,b --rules
+// c` accumulates ["a", "b", "c"].
+type stringList []string
+
+func (l *stringList) String() string { return strings.Join(*l, ",") }
+
+func (l *stringList) Set(v string) error {
+	for _, part := range strings.Split(v, ",") {
+		if p := strings.TrimSpace(part); p != "" {
+			*l = append(*l, p)
+		}
+	}
+	return nil
+}
+
+// options holds the parsed flags. --schema renders the expected ClickHouse
+// schema; --rules switches to the offline PromQL explain over rule files.
 type options struct {
 	schema bool
+	rules  stringList
 }
 
 // run is the testable entrypoint: it parses args, then dispatches. Splitting it
@@ -47,20 +83,58 @@ func run(args []string, stdout, stderr io.Writer) error {
 	var opts options
 	fs.BoolVar(&opts.schema, "schema", false,
 		"print the ClickHouse schema (CREATE statements) cerberus expects, then exit")
+	fs.Var(&opts.rules, "rules",
+		"explain the ClickHouse SQL for each PromQL query in these Prometheus rule "+
+			"files (repeatable or comma-separated paths/globs)")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 
-	if !opts.schema {
+	switch {
+	case len(opts.rules) > 0:
+		return runExplain(stdout, opts.rules)
+	case opts.schema:
+		cfg, err := config.FromEnv()
+		if err != nil {
+			return fmt.Errorf("load config from environment: %w", err)
+		}
+		return writeSchema(stdout, cfg)
+	default:
 		fs.Usage()
-		return fmt.Errorf("nothing to do: pass --schema to print the expected ClickHouse schema")
+		return fmt.Errorf("nothing to do: pass --schema to print the expected schema, " +
+			"or --rules <path> to explain PromQL rule files")
 	}
+}
 
-	cfg, err := config.FromEnv()
+// runExplain harvests PromQL from the given rule files, dry-runs each query
+// through the read-side pipeline, and writes the explain report to w. It is
+// fully offline: the engine has no Client and DryRunSQL never executes.
+func runExplain(w io.Writer, rulePaths []string) error {
+	metrics := schema.DefaultOTelMetricsFromEnv()
+	eng := &engine.Engine{Optimizer: optimizer.Default()}
+	lang := prom.NewExplainLang(metrics, time.Unix(explainEvalUnix, 0).UTC())
+
+	src := migrate.FileSource{RulePaths: rulePaths}
+	ex := dryRunExplainer{eng: eng, lang: lang}
+	rep, err := migrate.BuildReport(context.Background(), src, ex)
 	if err != nil {
-		return fmt.Errorf("load config from environment: %w", err)
+		return fmt.Errorf("build explain report: %w", err)
 	}
-	return writeSchema(stdout, cfg)
+	return rep.Write(w)
+}
+
+// dryRunExplainer adapts engine.DryRunSQL to migrate.Explainer. The SQL it
+// reports is byte-identical to what the server would send to ClickHouse for the
+// same query — DryRunSQL runs the identical parse → project → optimize → emit
+// stages, minus Execute.
+type dryRunExplainer struct {
+	eng  *engine.Engine
+	lang engine.Lang
+}
+
+func (d dryRunExplainer) Explain(ctx context.Context, query string) migrate.Explanation {
+	dr, err := d.eng.DryRunSQL(ctx, d.lang, query)
+	return migrate.Explanation{SQL: dr.SQL, Plan: dr.Plan, Err: err}
 }
 
 // writeSchema renders the schema cerberus expects for cfg and writes it to w.

--- a/cmd/migrate/main_test.go
+++ b/cmd/migrate/main_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -27,6 +29,58 @@ func TestRun_UnknownFlagIsError(t *testing.T) {
 	var out, errOut bytes.Buffer
 	if err := run([]string{"--nope"}, &out, &errOut); err == nil {
 		t.Fatal("run with an unknown flag should error")
+	}
+}
+
+// TestStringListFlag pins that --rules accumulates both repeated flags and
+// comma-separated values, trimming blanks.
+func TestStringListFlag(t *testing.T) {
+	var l stringList
+	if err := l.Set("a.yml, b.yml"); err != nil {
+		t.Fatal(err)
+	}
+	if err := l.Set(" c.yml "); err != nil {
+		t.Fatal(err)
+	}
+	got := strings.Join([]string(l), "|")
+	if got != "a.yml|b.yml|c.yml" {
+		t.Errorf("stringList = %q, want a.yml|b.yml|c.yml", got)
+	}
+}
+
+// TestRunExplainEndToEnd runs the explain mode offline over a temp rules file:
+// a valid recording rule must produce emitted SQL, and a deliberately-broken
+// expr must be marked UNSUPPORTED — the build keeps going past the bad one.
+func TestRunExplainEndToEnd(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "rules.yml")
+	const rules = `
+groups:
+  - name: probe
+    rules:
+      - record: job:up
+        expr: up
+      - alert: BrokenExpr
+        expr: "!!! not valid promql"
+`
+	if err := os.WriteFile(file, []byte(rules), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var out, errOut bytes.Buffer
+	if err := run([]string{"--rules", file}, &out, &errOut); err != nil {
+		t.Fatalf("run --rules: %v (stderr: %s)", err, errOut.String())
+	}
+	got := out.String()
+
+	if !strings.Contains(got, "SELECT") {
+		t.Errorf("explain report should contain the emitted SQL for `up`, got:\n%s", got)
+	}
+	if !strings.Contains(got, "UNSUPPORTED") {
+		t.Errorf("explain report should mark the broken expr UNSUPPORTED, got:\n%s", got)
+	}
+	if !strings.Contains(got, "cardinality is NOT knowable offline") {
+		t.Errorf("explain report should carry the offline-cardinality honesty note, got:\n%s", got)
 	}
 }
 

--- a/internal/api/prom/explain.go
+++ b/internal/api/prom/explain.go
@@ -1,0 +1,29 @@
+package prom
+
+import (
+	"time"
+
+	promparser "github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/engine"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// NewExplainLang builds an engine.Lang for offline instant explain — the
+// migration preview's read-only "what SQL would cerberus run for this PromQL"
+// path. It reuses the exact unexported lang adapter the HTTP handler drives, so
+// ProjectSamples and Parse (parser options, dotted-name rewrite, lowering) are
+// byte-identical to production.
+//
+// evalTime is pinned to both Start and End with Step left at 0, so the query
+// lowers as an instant evaluation at a single anchor. Lowerers is left at its
+// zero value (the all-fan-out default), matching an instant query on the
+// handler where the native timeSeries*ToGrid table is not threaded.
+func NewExplainLang(s schema.Metrics, evalTime time.Time) engine.Lang {
+	return &lang{
+		Parser: promparser.NewParser(promparser.Options{EnableExperimentalFunctions: true}),
+		Schema: s,
+		Start:  evalTime,
+		End:    evalTime, // Step stays 0 => instant evaluation
+	}
+}

--- a/internal/migrate/migrate.go
+++ b/internal/migrate/migrate.go
@@ -1,0 +1,311 @@
+// Package migrate builds the offline "explain" report for cerberus's migration
+// preview: for each PromQL query harvested from Prometheus rule files, it shows
+// the exact ClickHouse SQL cerberus would run, the physical tables the query
+// touches, and conservative offline risk flags — or marks the query
+// UNSUPPORTED when the engine cannot emit it.
+//
+// The whole flow is read-only and offline. Corpus harvesting reads rule files;
+// explanation is delegated to an Explainer (wired in cmd/migrate over
+// engine.DryRunSQL, which never touches a ClickHouse connection). Nothing here
+// estimates cardinality — row counts are data-dependent and cannot be known
+// without a database, so the report says so explicitly rather than guessing.
+package migrate
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/promrules"
+)
+
+// Kind classifies a harvested query by the rule that produced it.
+const (
+	KindRecord = "record"
+	KindAlert  = "alert"
+)
+
+// HarvestedQuery is one PromQL expression pulled from a corpus source, tagged
+// with where it came from and whether it backs a recording or alerting rule.
+type HarvestedQuery struct {
+	Expr   string
+	Source string // e.g. "rule:<file>/<group>/<name>"
+	Kind   string // KindRecord | KindAlert
+}
+
+// SkippedEntry records a corpus entry the harvester could not turn into a query —
+// an unreadable file, a YAML parse failure, a rule with no expression. Every
+// dropped entry is reported here; the harvester never silently discards input.
+type SkippedEntry struct {
+	Source string
+	Reason string
+}
+
+// CorpusSource yields the PromQL queries to explain, plus the entries it had to
+// skip. Harvest is offline and side-effect-free beyond reading its inputs.
+type CorpusSource interface {
+	Harvest(ctx context.Context) ([]HarvestedQuery, []SkippedEntry, error)
+}
+
+// FileSource harvests queries from Prometheus rule files. RulePaths holds file
+// paths or globs; each match is read and parsed as a rule file, and one
+// HarvestedQuery is emitted per recording/alerting rule.
+type FileSource struct {
+	RulePaths []string
+}
+
+// Harvest expands every RulePaths entry, reads and parses each matched rule
+// file, and emits one HarvestedQuery per rule. Anything it cannot use — a glob
+// that matches nothing, an unreadable file, a YAML parse failure, a rule with
+// no expression or no name — is recorded as a SkippedEntry rather than dropped.
+func (s FileSource) Harvest(_ context.Context) ([]HarvestedQuery, []SkippedEntry, error) {
+	var (
+		queries []HarvestedQuery
+		skipped []SkippedEntry
+	)
+	for _, pattern := range s.RulePaths {
+		matches, err := filepath.Glob(pattern)
+		if err != nil {
+			skipped = append(skipped, SkippedEntry{Source: pattern, Reason: fmt.Sprintf("bad path pattern: %v", err)})
+			continue
+		}
+		if len(matches) == 0 {
+			skipped = append(skipped, SkippedEntry{Source: pattern, Reason: "no files matched"})
+			continue
+		}
+		for _, file := range matches {
+			data, err := os.ReadFile(file)
+			if err != nil {
+				skipped = append(skipped, SkippedEntry{Source: file, Reason: fmt.Sprintf("read: %v", err)})
+				continue
+			}
+			rg, err := promrules.Parse(data)
+			if err != nil {
+				skipped = append(skipped, SkippedEntry{Source: file, Reason: err.Error()})
+				continue
+			}
+			q, sk := harvestFile(file, rg)
+			queries = append(queries, q...)
+			skipped = append(skipped, sk...)
+		}
+	}
+	return queries, skipped, nil
+}
+
+// harvestFile flattens one parsed rule file's groups into HarvestedQuery /
+// SkippedEntry entries. A rule with no name or no expression is skipped (counted),
+// never emitted as an empty query.
+func harvestFile(file string, rg promrules.RuleGroups) ([]HarvestedQuery, []SkippedEntry) {
+	var (
+		queries []HarvestedQuery
+		skipped []SkippedEntry
+	)
+	for _, g := range rg.Groups {
+		for _, r := range g.Rules {
+			name, kind := r.Record, KindRecord
+			if r.Alert != "" {
+				name, kind = r.Alert, KindAlert
+			}
+			source := fmt.Sprintf("rule:%s/%s/%s", file, g.Name, name)
+			if name == "" {
+				skipped = append(skipped, SkippedEntry{Source: source, Reason: "rule has neither record nor alert name"})
+				continue
+			}
+			if strings.TrimSpace(r.Expr) == "" {
+				skipped = append(skipped, SkippedEntry{Source: source, Reason: "rule has an empty expr"})
+				continue
+			}
+			queries = append(queries, HarvestedQuery{Expr: r.Expr, Source: source, Kind: kind})
+		}
+	}
+	return queries, skipped
+}
+
+// Explanation is the offline result of dry-running one query through the engine:
+// the parameterised ClickHouse SQL, the optimized plan, and any error. On error
+// SQL is empty and Err is set; Plan may still be populated (the engine records
+// the optimized plan even when the emit chokepoint rejects it).
+type Explanation struct {
+	SQL  string
+	Plan chplan.Node
+	Err  error
+}
+
+// Explainer turns a PromQL query into an Explanation, offline. The cmd/migrate
+// adapter implements it over engine.DryRunSQL so the SQL is byte-identical to
+// what the server would send to ClickHouse.
+type Explainer interface {
+	Explain(ctx context.Context, query string) Explanation
+}
+
+// Tables walks plan and returns the physical ClickHouse tables it scans —
+// every *chplan.Scan's Table plus its UnionTables, qualified with the scan's
+// Database when set — deduplicated and sorted for a stable report.
+func Tables(plan chplan.Node) []string {
+	seen := map[string]struct{}{}
+	chplan.Walk(plan, func(n chplan.Node) bool {
+		scan, ok := n.(*chplan.Scan)
+		if !ok {
+			return true
+		}
+		if scan.Table != "" {
+			seen[qualify(scan.Database, scan.Table)] = struct{}{}
+		}
+		for _, t := range scan.UnionTables {
+			seen[qualify(scan.Database, t)] = struct{}{}
+		}
+		return true
+	})
+	out := make([]string, 0, len(seen))
+	for t := range seen {
+		out = append(out, t)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// qualify renders a table reference as "database.table" when a database is set,
+// otherwise the bare table name.
+func qualify(db, table string) string {
+	if db == "" {
+		return table
+	}
+	return db + "." + table
+}
+
+// Lint returns conservative, offline risk flags read straight off the IR. It
+// deliberately does NOT estimate cardinality — row counts depend on data the
+// preview cannot see. It flags only structural fan-out that is a fact of the
+// plan shape: a PromQL subquery RangeWindow evaluates its inner expression at
+// many anchors per series, a work multiplier worth surfacing before cutover.
+func Lint(plan chplan.Node) []string {
+	seen := map[string]struct{}{}
+	var risks []string
+	add := func(msg string) {
+		if _, ok := seen[msg]; ok {
+			return
+		}
+		seen[msg] = struct{}{}
+		risks = append(risks, msg)
+	}
+	chplan.Walk(plan, func(n chplan.Node) bool {
+		rw, ok := n.(*chplan.RangeWindow)
+		if !ok {
+			return true
+		}
+		if rw.OuterRange > 0 && rw.Step > 0 {
+			// anchors = OuterRange/Step + 1 (end-inclusive grid). This is a
+			// structural fan-out factor from the plan, not a data estimate.
+			anchors := int64(rw.OuterRange/rw.Step) + 1
+			add(fmt.Sprintf("subquery fan-out: inner expression evaluated at %d anchors per series", anchors))
+		}
+		return true
+	})
+	return risks
+}
+
+// QueryReport is the per-query section of the report.
+type QueryReport struct {
+	Query       HarvestedQuery
+	SQL         string
+	Tables      []string
+	Risks       []string
+	Unsupported string // non-empty when the engine could not emit the query
+}
+
+// Report is the full offline explain result: one QueryReport per harvested
+// query plus the entries the harvester skipped.
+type Report struct {
+	Queries []QueryReport
+	Skipped []SkippedEntry
+}
+
+// BuildReport harvests the corpus, dry-runs every query through ex, and
+// assembles the report. A query the engine cannot emit is marked Unsupported
+// (with the engine's error) and the build keeps going — one unsupported query
+// never aborts the preview.
+func BuildReport(ctx context.Context, src CorpusSource, ex Explainer) (Report, error) {
+	queries, skipped, err := src.Harvest(ctx)
+	if err != nil {
+		return Report{}, fmt.Errorf("migrate: harvest corpus: %w", err)
+	}
+	rep := Report{Skipped: skipped}
+	for _, q := range queries {
+		qr := QueryReport{Query: q}
+		ex := ex.Explain(ctx, q.Expr)
+		if ex.Err != nil {
+			qr.Unsupported = ex.Err.Error()
+		} else {
+			qr.SQL = ex.SQL
+			qr.Tables = Tables(ex.Plan)
+			qr.Risks = Lint(ex.Plan)
+		}
+		rep.Queries = append(rep.Queries, qr)
+	}
+	return rep, nil
+}
+
+// Write renders the report as scannable, human-readable text. It leads with the
+// honesty note that cardinality is unknown offline, then one block per query,
+// then the skipped entries with their reasons.
+func (r Report) Write(w io.Writer) error {
+	bw := &errWriter{w: w}
+	bw.printf("# cerberus migrate explain\n")
+	bw.printf("#\n")
+	bw.printf("# Offline preview: the exact ClickHouse SQL cerberus will run for each\n")
+	bw.printf("# PromQL query, the physical tables it touches, and conservative IR risk\n")
+	bw.printf("# flags. Row COUNT / cardinality is NOT knowable offline (it depends on\n")
+	bw.printf("# data this tool never reads) — it is deliberately not estimated here.\n")
+	bw.printf("#\n")
+	bw.printf("# %d queries, %d skipped\n\n", len(r.Queries), len(r.Skipped))
+
+	for _, q := range r.Queries {
+		bw.printf("== [%s] %s\n", q.Query.Kind, q.Query.Source)
+		bw.printf("   expr:  %s\n", q.Query.Expr)
+		if q.Unsupported != "" {
+			bw.printf("   UNSUPPORTED: %s\n", q.Unsupported)
+			bw.printf("\n")
+			continue
+		}
+		bw.printf("   sql:   %s\n", q.SQL)
+		if len(q.Tables) > 0 {
+			bw.printf("   tables: %s\n", strings.Join(q.Tables, ", "))
+		}
+		if len(q.Risks) > 0 {
+			for _, risk := range q.Risks {
+				bw.printf("   risk:  %s\n", risk)
+			}
+		} else {
+			bw.printf("   risk:  none flagged offline (cardinality unknown)\n")
+		}
+		bw.printf("\n")
+	}
+
+	if len(r.Skipped) > 0 {
+		bw.printf("== skipped (%d)\n", len(r.Skipped))
+		for _, s := range r.Skipped {
+			bw.printf("   %s: %s\n", s.Source, s.Reason)
+		}
+	}
+	return bw.err
+}
+
+// errWriter collapses the repeated Fprintf error checks in Write into a single
+// short-circuiting sink: once a write fails, later printf calls are no-ops and
+// the first error is returned.
+type errWriter struct {
+	w   io.Writer
+	err error
+}
+
+func (e *errWriter) printf(format string, args ...any) {
+	if e.err != nil {
+		return
+	}
+	_, e.err = fmt.Fprintf(e.w, format, args...)
+}

--- a/internal/migrate/migrate.go
+++ b/internal/migrate/migrate.go
@@ -79,7 +79,7 @@ func (s FileSource) Harvest(_ context.Context) ([]HarvestedQuery, []SkippedEntry
 			continue
 		}
 		for _, file := range matches {
-			data, err := os.ReadFile(file)
+			data, err := os.ReadFile(file) //nolint:gosec // operator-supplied rule-file path; offline CLI.
 			if err != nil {
 				skipped = append(skipped, SkippedEntry{Source: file, Reason: fmt.Sprintf("read: %v", err)})
 				continue

--- a/internal/migrate/migrate_test.go
+++ b/internal/migrate/migrate_test.go
@@ -1,0 +1,182 @@
+package migrate
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// fakeExplainer returns a canned Explanation per query string, so BuildReport /
+// Write can be exercised offline without the engine.
+type fakeExplainer struct {
+	byQuery map[string]Explanation
+}
+
+func (f fakeExplainer) Explain(_ context.Context, query string) Explanation {
+	if ex, ok := f.byQuery[query]; ok {
+		return ex
+	}
+	return Explanation{Err: errors.New("no canned explanation")}
+}
+
+// TestFileSourceHarvest writes a small rule file and asserts both a recording
+// and an alerting rule are harvested with the right kind + source, and that an
+// unmatched path is counted as a skip rather than dropped.
+func TestFileSourceHarvest(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "rules.yml")
+	const rules = `
+groups:
+  - name: cpu
+    rules:
+      - record: job:cpu:rate5m
+        expr: sum(rate(cpu_seconds_total[5m])) by (job)
+      - alert: HighErrorRate
+        expr: rate(errors_total[5m]) > 0.5
+      - record: empty:rule
+        expr: "   "
+`
+	if err := os.WriteFile(file, []byte(rules), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	missing := filepath.Join(dir, "nope-*.yml")
+	src := FileSource{RulePaths: []string{file, missing}}
+	queries, skipped, err := src.Harvest(context.Background())
+	if err != nil {
+		t.Fatalf("Harvest: %v", err)
+	}
+
+	if len(queries) != 2 {
+		t.Fatalf("expected 2 harvested queries, got %d: %+v", len(queries), queries)
+	}
+	if queries[0].Kind != KindRecord || !strings.Contains(queries[0].Source, "/cpu/job:cpu:rate5m") {
+		t.Errorf("recording rule harvested wrong: %+v", queries[0])
+	}
+	if queries[1].Kind != KindAlert || !strings.Contains(queries[1].Source, "/cpu/HighErrorRate") {
+		t.Errorf("alerting rule harvested wrong: %+v", queries[1])
+	}
+
+	// One skip for the empty-expr rule, one for the unmatched glob.
+	if len(skipped) != 2 {
+		t.Fatalf("expected 2 skips, got %d: %+v", len(skipped), skipped)
+	}
+	var sawEmpty, sawNoMatch bool
+	for _, s := range skipped {
+		if strings.Contains(s.Source, "empty:rule") && strings.Contains(s.Reason, "empty expr") {
+			sawEmpty = true
+		}
+		if s.Source == missing && strings.Contains(s.Reason, "no files matched") {
+			sawNoMatch = true
+		}
+	}
+	if !sawEmpty {
+		t.Error("empty-expr rule should be counted as a skip")
+	}
+	if !sawNoMatch {
+		t.Error("unmatched glob should be counted as a skip")
+	}
+}
+
+// TestTables pins that Tables collects Table + UnionTables across scans,
+// qualifies with Database, and returns a deduplicated, sorted list.
+func TestTables(t *testing.T) {
+	plan := &chplan.Filter{
+		Input: &chplan.Scan{
+			Database:    "otel",
+			UnionTables: []string{"otel_metrics_sum", "otel_metrics_gauge"},
+		},
+		Predicate: &chplan.ColumnRef{Name: "x"},
+	}
+	got := Tables(plan)
+	want := []string{"otel.otel_metrics_gauge", "otel.otel_metrics_sum"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("Tables = %v, want %v", got, want)
+	}
+}
+
+// TestLintSubqueryFanout pins that a subquery RangeWindow is flagged with its
+// anchor count, and that a plain range window is not flagged.
+func TestLintSubqueryFanout(t *testing.T) {
+	subquery := &chplan.RangeWindow{
+		Input:      &chplan.Scan{Table: "otel_metrics_gauge"},
+		Func:       "rate",
+		OuterRange: 10 * time.Minute,
+		Step:       time.Minute,
+	}
+	risks := Lint(subquery)
+	if len(risks) != 1 || !strings.Contains(risks[0], "11 anchors") {
+		t.Fatalf("expected a subquery fan-out risk with 11 anchors, got %v", risks)
+	}
+
+	plain := &chplan.RangeWindow{Input: &chplan.Scan{Table: "t"}, Func: "rate"}
+	if risks := Lint(plain); len(risks) != 0 {
+		t.Errorf("plain range window should carry no offline risk, got %v", risks)
+	}
+}
+
+// TestBuildReportAndWrite exercises the full assembly: a supported query gets
+// SQL + tables, a broken query is marked UNSUPPORTED (build keeps going), and
+// the rendered report carries the honesty note plus both outcomes.
+func TestBuildReportAndWrite(t *testing.T) {
+	src := staticSource{queries: []HarvestedQuery{
+		{Expr: "up", Source: "rule:f/g/up_rec", Kind: KindRecord},
+		{Expr: "!!!", Source: "rule:f/g/broken", Kind: KindAlert},
+	}}
+	ex := fakeExplainer{byQuery: map[string]Explanation{
+		"up": {
+			SQL:  "SELECT * FROM otel_metrics_gauge",
+			Plan: &chplan.Scan{Table: "otel_metrics_gauge"},
+		},
+		"!!!": {Err: errors.New("parse: unexpected token")},
+	}}
+
+	rep, err := BuildReport(context.Background(), src, ex)
+	if err != nil {
+		t.Fatalf("BuildReport: %v", err)
+	}
+	if len(rep.Queries) != 2 {
+		t.Fatalf("expected 2 query reports, got %d", len(rep.Queries))
+	}
+	if rep.Queries[0].SQL != "SELECT * FROM otel_metrics_gauge" {
+		t.Errorf("supported query SQL wrong: %q", rep.Queries[0].SQL)
+	}
+	if got := rep.Queries[0].Tables; len(got) != 1 || got[0] != "otel_metrics_gauge" {
+		t.Errorf("supported query tables wrong: %v", got)
+	}
+	if rep.Queries[1].Unsupported == "" {
+		t.Error("broken query should be marked unsupported")
+	}
+
+	var sb strings.Builder
+	if err := rep.Write(&sb); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	out := sb.String()
+	for _, want := range []string{
+		"cardinality is NOT knowable offline",
+		"SELECT * FROM otel_metrics_gauge",
+		"otel_metrics_gauge",
+		"UNSUPPORTED: parse: unexpected token",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("report missing %q\n---\n%s", want, out)
+		}
+	}
+}
+
+// staticSource is a CorpusSource that returns a fixed query list.
+type staticSource struct {
+	queries []HarvestedQuery
+	skipped []SkippedEntry
+}
+
+func (s staticSource) Harvest(context.Context) ([]HarvestedQuery, []SkippedEntry, error) {
+	return s.queries, s.skipped, nil
+}

--- a/internal/promrules/promrules.go
+++ b/internal/promrules/promrules.go
@@ -1,0 +1,48 @@
+// Package promrules parses Prometheus recording/alerting rule files into the
+// minimal shape cerberus's migration preview needs: the PromQL expression of
+// each rule plus its record/alert name.
+//
+// It deliberately does NOT import prometheus/rulefmt. That package drags in
+// ~112 transitive packages (k8s apimachinery among them) for validation the
+// preview does not need — the preview only harvests the `expr` of every rule so
+// it can be dry-run through the engine. A leaf yaml.v3 decode over the
+// documented rule-group schema is the whole dependency surface.
+package promrules
+
+import (
+	"fmt"
+
+	yaml "gopkg.in/yaml.v3"
+)
+
+// RuleGroups is the top-level shape of a Prometheus rule file: a list of named
+// groups, each holding recording and/or alerting rules.
+type RuleGroups struct {
+	Groups []RuleGroup `yaml:"groups"`
+}
+
+// RuleGroup is one named group of rules.
+type RuleGroup struct {
+	Name  string `yaml:"name"`
+	Rules []Rule `yaml:"rules"`
+}
+
+// Rule is a single recording or alerting rule. A recording rule sets Record
+// (the series name it produces); an alerting rule sets Alert (the alert name).
+// Both carry Expr — the PromQL the preview dry-runs.
+type Rule struct {
+	Record string `yaml:"record"`
+	Alert  string `yaml:"alert"`
+	Expr   string `yaml:"expr"`
+}
+
+// Parse decodes a Prometheus rule file's YAML into RuleGroups. It wraps decode
+// errors so the caller (the migration harvester) can attribute a parse failure
+// to the file it read.
+func Parse(data []byte) (RuleGroups, error) {
+	var rg RuleGroups
+	if err := yaml.Unmarshal(data, &rg); err != nil {
+		return RuleGroups{}, fmt.Errorf("promrules: parse rule file: %w", err)
+	}
+	return rg, nil
+}

--- a/internal/promrules/promrules_test.go
+++ b/internal/promrules/promrules_test.go
@@ -1,0 +1,62 @@
+package promrules
+
+import "testing"
+
+// TestParse pins that a rule file with both a recording rule and an alerting
+// rule decodes into the right group/name/expr shape.
+func TestParse(t *testing.T) {
+	const rules = `
+groups:
+  - name: cpu
+    rules:
+      - record: job:cpu:rate5m
+        expr: sum(rate(cpu_seconds_total[5m])) by (job)
+      - alert: HighErrorRate
+        expr: rate(errors_total[5m]) > 0.5
+        for: 10m
+`
+	rg, err := Parse([]byte(rules))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(rg.Groups) != 1 {
+		t.Fatalf("expected 1 group, got %d", len(rg.Groups))
+	}
+	g := rg.Groups[0]
+	if g.Name != "cpu" {
+		t.Errorf("group name = %q, want cpu", g.Name)
+	}
+	if len(g.Rules) != 2 {
+		t.Fatalf("expected 2 rules, got %d", len(g.Rules))
+	}
+
+	rec := g.Rules[0]
+	if rec.Record != "job:cpu:rate5m" {
+		t.Errorf("record name = %q", rec.Record)
+	}
+	if rec.Alert != "" {
+		t.Errorf("recording rule should have no alert name, got %q", rec.Alert)
+	}
+	if rec.Expr != "sum(rate(cpu_seconds_total[5m])) by (job)" {
+		t.Errorf("record expr = %q", rec.Expr)
+	}
+
+	alert := g.Rules[1]
+	if alert.Alert != "HighErrorRate" {
+		t.Errorf("alert name = %q", alert.Alert)
+	}
+	if alert.Record != "" {
+		t.Errorf("alerting rule should have no record name, got %q", alert.Record)
+	}
+	if alert.Expr != "rate(errors_total[5m]) > 0.5" {
+		t.Errorf("alert expr = %q", alert.Expr)
+	}
+}
+
+// TestParseInvalidYAML pins that a malformed rule file surfaces a wrapped error
+// rather than a zero-value success.
+func TestParseInvalidYAML(t *testing.T) {
+	if _, err := Parse([]byte("groups: [::: not yaml")); err == nil {
+		t.Fatal("expected a parse error for malformed YAML")
+	}
+}


### PR DESCRIPTION
## What this does

Adds an offline `migrate explain` capability. For every PromQL query harvested from Prometheus rule files, it prints:

- the **exact ClickHouse SQL** cerberus will run,
- the **physical tables** the query scans,
- a conservative **offline risk flag** (structural fan-out), or
- **UNSUPPORTED** when the engine cannot emit the query.

It is fully read-only and offline — the engine is built with **no ClickHouse client**, and `engine.DryRunSQL` never executes.

```
migrate --rules ./rules/*.yml
```

## Pieces

- **`internal/api/prom/explain.go`** — `NewExplainLang` reuses the unexported `lang` adapter the HTTP handler drives, so `Parse` / `ProjectSamples` (parser options, dotted-name rewrite, all-fan-out lowerers) are byte-identical to production. Pinned to an instant eval (Start == End, Step 0).
- **`internal/promrules/`** — leaf `yaml.v3` decode of rule files (record/alert `expr`), deliberately avoiding `prometheus/rulefmt` (which drags in ~112 packages incl. k8s apimachinery).
- **`internal/migrate/`** — corpus harvest + report:
  - `FileSource.Harvest` emits one query per rule; **every** unreadable/unparseable/empty entry is **counted as a skip and reported**, never silently dropped.
  - `Tables` walks `chplan.Walk`, collecting each `*chplan.Scan`'s Database/Table + UnionTables (deduped, sorted).
  - `Lint` returns conservative IR risk flags (subquery fan-out anchor count). It does **not** estimate cardinality — that is data-dependent and unknowable offline, and the report says so explicitly.
  - `BuildReport` marks an un-emittable query UNSUPPORTED and keeps going; `Write` renders a scannable report led by the offline-cardinality honesty note.
- **`cmd/migrate/`** — `--rules` mode wires `engine.DryRunSQL` through a small `Explainer` adapter at a fixed, deterministic eval time. `--schema` is unchanged.
- **`.go-arch-lint.yml`** — declares the `migrate` (→ chplan, promrules) and leaf `promrules` components.

## Byte-identical SQL

The SQL shown is byte-identical to what the server sends to ClickHouse: `DryRunSQL` runs the same parse → project → optimize → emit stages, minus `Execute`.

## Honesty

Row count / cardinality is **not** estimated. It depends on data this tool never reads; the report states that up front rather than guessing.

## Test coverage

- `promrules`: parse a record+alert file; malformed YAML errors.
- `migrate`: harvest (record/alert + counted skips), `Tables`, `Lint` (subquery fan-out + plain-window no-flag), `BuildReport`/`Write` (SQL + tables + UNSUPPORTED + honesty note).
- `cmd/migrate`: `--rules` flag parsing (repeat + comma-sep); end-to-end explain over a temp rules file asserting emitted SQL + an UNSUPPORTED broken expr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
