### PR TITLE
build(release): ship the migrate CLI binary + in the Docker image

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,9 +23,47 @@ builds:
       - amd64
       - arm64
 
+  # migrate — the offline pre-cutover migration preview CLI (./cmd/migrate).
+  # Shipped as its own released binary + tar.gz archive alongside cerberus,
+  # with an identical build profile (static CGO-off, -trimpath, stripped).
+  - id: migrate
+    main: ./cmd/migrate
+    binary: migrate
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w -X main.Version={{.Version}}
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+
 archives:
   - id: cerberus
+    ids:
+      - cerberus
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    formats:
+      - tar.gz
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+    files:
+      - LICENSE
+      - README.md
+      - CHANGELOG.md
+
+  # migrate CLI archive — same tar.gz shape + doc set as the cerberus archive,
+  # scoped to the migrate build so each archive carries exactly one binary.
+  - id: migrate
+    ids:
+      - migrate
+    name_template: "migrate_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     formats:
       - tar.gz
     format_overrides:

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,10 @@ LABEL org.opencontainers.image.source="https://github.com/tsouza/cerberus"
 LABEL org.opencontainers.image.licenses="MIT"
 
 COPY cerberus /usr/local/bin/cerberus
+# migrate — the offline pre-cutover migration preview CLI. goreleaser's docker
+# build context includes every binary built for the platform, so the migrate
+# binary is present here without any `dockers:` ids change.
+COPY migrate /usr/local/bin/migrate
 
 EXPOSE 8080
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -950,7 +950,11 @@ data already persisted.
   container images) from a Git tag. Source code is compiled, the binary
   is statically linked (`CGO_ENABLED=0` in release builds), and the
   version string is injected via `-ldflags` so `Version` in
-  `cmd/cerberus/main.go` reflects the tag.
+  `cmd/cerberus/main.go` reflects the tag. Two binaries ship per release:
+  the `cerberus` gateway and the `migrate` offline migration-preview CLI
+  (`./cmd/migrate`), each as its own `tar.gz` archive
+  (`cerberus_<ver>_<os>_<arch>.tar.gz` / `migrate_<ver>_<os>_<arch>.tar.gz`)
+  and both baked into the container image under `/usr/local/bin/`.
 - **Release** — the build output is combined with the deployment
   configuration. In Kubernetes that means a specific image tag/SHA in the
   Helm values (`test/e2e/k3s/cerberus-values.yaml` for the e2e stack) plus
@@ -1002,6 +1006,17 @@ toggle) ships by bumping `version:` alone, and an app-only release bumps
 publish gates handle either or both. The `:latest` image tag advances only for
 the highest stable `v*` release (a prerelease or a stable backport never drags
 it backwards) — `RELEASE_IS_LATEST` is computed in `release.yml`.
+
+#### Homebrew tap (future)
+
+The release currently ships raw `tar.gz` archives + container images. A Homebrew
+formula can be added later by giving goreleaser a `brews:` block that points at a
+`tsouza/homebrew-tap` repo (the tap must exist first, and the release token must
+be able to push to it). It was deliberately left out of the initial `migrate` +
+`cerberus` binary release: a `brews:` block whose tap repo does not yet exist
+fails the goreleaser release step, so wiring it up is gated on creating that
+repo. Add the block — one entry per binary that should be `brew install`-able —
+in a follow-up once `tsouza/homebrew-tap` exists.
 
 #### Maintenance lines (hotfix backports)
 


### PR DESCRIPTION
## What

Package `cmd/migrate` (the offline pre-cutover migration-preview CLI) as a released artifact alongside `cerberus`. The maintainer chose "released binary".

## Changes

- **`.goreleaser.yml`** — second `builds` entry `migrate` with the *same* build profile as `cerberus` (`CGO_ENABLED=0`, `-trimpath`, `-s -w`, `goos: linux/darwin`, `goarch: amd64/arm64`). Matching `archives` entry `migrate` → `migrate_{{.Version}}_{{.Os}}_{{.Arch}}.tar.gz` with `LICENSE` + `README.md` + `CHANGELOG.md`. Both archive entries now carry `ids:` so each `tar.gz` ships exactly one binary.
- **`Dockerfile`** — `COPY migrate /usr/local/bin/migrate` so the container image ships both binaries. goreleaser's docker build context already includes every per-platform binary, and the `dockers:` section pins no `ids:`, so no `dockers:` change is needed.
- **`docs/operations.md`** — documents the two-binary release and notes a Homebrew tap can be added later via a `brews:` block pointing at a `tsouza/homebrew-tap` repo (deliberately left out here so a missing tap repo can't break the release).

## Homebrew — deliberately deferred

No `brews:` block is added in this PR. A `brews:` block whose tap repo doesn't yet exist fails the goreleaser release step, so it's gated on first creating `tsouza/homebrew-tap`. Documented as a follow-up in `docs/operations.md`.

## Validation

- `goreleaser check` — config valid.
- `goreleaser build --single-target --snapshot --clean` — builds both `cerberus` and `migrate`; the produced `migrate` binary runs (`migrate --help` / `--schema` / `--rules`).

## Safety

Releases are **tag-triggered**, not merge-triggered, so this only affects the next tagged release — safe to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
