### PR TITLE
feat(migrate): verify — replay the corpus against Prometheus and cerberus and diff (parity gate)

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -158,6 +158,10 @@ components:
   # (promrules) and assembles the explain report over the chplan IR. Wired from
   # cmd/migrate only.
   migrate:        { in: migrate }
+  # Online cutover parity gate: replays a harvested corpus against a reference
+  # Prometheus + cerberus and diffs the query_range results. Reuses the migrate
+  # corpus format to read the harvested corpus.json. Wired from cmd/migrate only.
+  migrateverify:  { in: migrateverify }
   # Leaf yaml.v3 decode of Prometheus rule files (record/alert exprs). No
   # internal deps — deliberately avoids prometheus/rulefmt's ~112-package pull.
   promrules:      { in: promrules }
@@ -292,6 +296,14 @@ deps:
     mayDependOn:
       - chplan
       - promrules
+
+  # migrateverify is the online parity gate. It only needs the migrate corpus
+  # format (Corpus / CorpusQuery / LangPromQL) to read a harvested corpus.json;
+  # the comparator and HTTP client are net-new and stdlib-only. It must NOT reach
+  # into the engine / chsql / handler layers — it talks to both backends over HTTP.
+  migrateverify:
+    mayDependOn:
+      - migrate
 
   # config is wired from cmd/ to build chclient + schema at boot.
   config:

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -9,6 +9,8 @@
 //	migrate harvest --rules <glob> \           # build a machine-readable query corpus from
 //	  --dashboards <dir> --out corpus.json     #   rule files + exported Grafana dashboards
 //	migrate explain --corpus corpus.json       # explain a previously-harvested corpus
+//	migrate verify --corpus corpus.json \       # replay the corpus against a reference
+//	  --ref <prom-url> --cerberus <url>          #   Prometheus and cerberus and diff (parity gate)
 //
 // --schema reads the SAME CERBERUS_* environment the server uses
 // (config.FromEnv), so the previewed schema is byte-identical to what the
@@ -26,6 +28,11 @@
 // emitted SQL, the physical tables each query scans, and conservative offline
 // risk flags, or marks the query UNSUPPORTED. Row cardinality is data-dependent
 // and is deliberately NOT estimated offline.
+//
+// verify is the online cutover parity gate: it replays each PromQL query in a
+// harvested corpus against a reference Prometheus AND cerberus over one
+// query_range window and diffs the results series-by-series. It exits non-zero
+// if any query diverges or errors — a divergence is never allow-listed.
 package main
 
 import (
@@ -60,10 +67,18 @@ const explainEvalUnix = 1_700_000_000
 const outFileMode = 0o600
 
 func main() {
-	if err := run(os.Args[1:], os.Stdout, os.Stderr); err != nil {
-		fmt.Fprintln(os.Stderr, "migrate:", err)
-		os.Exit(1)
+	err := run(os.Args[1:], os.Stdout, os.Stderr)
+	if err == nil {
+		return
 	}
+	fmt.Fprintln(os.Stderr, "migrate:", err)
+	// A failed parity gate is a real, expected outcome (cerberus diverged) — it
+	// gets its own exit code so callers can tell it apart from a tool error.
+	var gate verifyFailedError
+	if errors.As(err, &gate) {
+		os.Exit(verifyExitFail)
+	}
+	os.Exit(1)
 }
 
 // stringList is a repeatable + comma-separated flag value. `--rules a,b --rules
@@ -100,6 +115,8 @@ func run(args []string, stdout, stderr io.Writer) error {
 			return runHarvest(args[1:], stdout, stderr)
 		case "explain":
 			return runExplainCmd(args[1:], stdout, stderr)
+		case "verify":
+			return runVerify(args[1:], stdout, stderr)
 		}
 	}
 

--- a/cmd/migrate/verify.go
+++ b/cmd/migrate/verify.go
@@ -31,6 +31,10 @@ const verifyExitFail = 2
 func runVerify(args []string, stdout, stderr io.Writer) error {
 	fs := flag.NewFlagSet("migrate verify", flag.ContinueOnError)
 	fs.SetOutput(stderr)
+	tolDefault, err := envFloat("CERBERUS_VERIFY_TOLERANCE", defaultVerifyTolerance)
+	if err != nil {
+		return err
+	}
 	var (
 		corpus    = fs.String("corpus", envOr("CERBERUS_VERIFY_CORPUS", ""), "corpus.json produced by `migrate harvest`")
 		ref       = fs.String("ref", envOr("CERBERUS_VERIFY_REF", ""), "reference Prometheus base URL")
@@ -38,7 +42,7 @@ func runVerify(args []string, stdout, stderr io.Writer) error {
 		startStr  = fs.String("start", envOr("CERBERUS_VERIFY_START", "-1h"), "range start (RFC3339, Unix seconds, or relative like -1h/now)")
 		endStr    = fs.String("end", envOr("CERBERUS_VERIFY_END", "now"), "range end (RFC3339, Unix seconds, or relative like -1h/now)")
 		stepStr   = fs.String("step", envOr("CERBERUS_VERIFY_STEP", "60s"), "range step (e.g. 60s)")
-		tolerance = fs.Float64("tolerance", envFloat("CERBERUS_VERIFY_TOLERANCE", defaultVerifyTolerance), "absolute value tolerance for a match")
+		tolerance = fs.Float64("tolerance", tolDefault, "absolute value tolerance for a match")
 		asJSON    = fs.Bool("json", false, "emit the machine-readable JSON report instead of the text report")
 	)
 	if err := fs.Parse(args); err != nil {
@@ -105,15 +109,18 @@ func envOr(key, def string) string {
 }
 
 // envFloat returns the float parsed from the environment value for key, or def
-// when unset or unparseable.
-func envFloat(key string, def float64) float64 {
+// when the variable is unset. A set-but-unparseable value is an error, not a
+// silent fallback to def: because the tolerance default is deliberately tiny, a
+// fat-fingered value would otherwise silently tighten the gate into spurious
+// divergences instead of surfacing the misconfiguration.
+func envFloat(key string, def float64) (float64, error) {
 	v := os.Getenv(key)
 	if v == "" {
-		return def
+		return def, nil
 	}
 	f, err := strconv.ParseFloat(v, 64)
 	if err != nil {
-		return def
+		return 0, fmt.Errorf("%s=%q is not a valid float: %w", key, v, err)
 	}
-	return f
+	return f, nil
 }

--- a/cmd/migrate/verify.go
+++ b/cmd/migrate/verify.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/migrateverify"
+)
+
+// defaultVerifyTolerance is the epsilon used when neither --tolerance nor
+// CERBERUS_VERIFY_TOLERANCE is supplied. It reuses the package default so the
+// CLI and the comparator agree on what "the same number" means.
+const defaultVerifyTolerance = migrateverify.DefaultTolerance
+
+// verifyExitFail is the process exit code when the parity gate fails (any query
+// diverges or errors). It is distinct from the code Go uses for an internal
+// error so a divergence reads as "the gate did its job", not "the tool broke".
+const verifyExitFail = 2
+
+// runVerify replays a harvested PromQL corpus against a reference Prometheus and
+// cerberus over one query_range window and diffs the results. It is the cutover
+// parity gate: on any divergence or error it returns a verifyFailedError so
+// main can exit non-zero. Flags fall back to CERBERUS_VERIFY_* environment
+// variables, so the same run can be driven by flags or env.
+func runVerify(args []string, stdout, stderr io.Writer) error {
+	fs := flag.NewFlagSet("migrate verify", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var (
+		corpus    = fs.String("corpus", envOr("CERBERUS_VERIFY_CORPUS", ""), "corpus.json produced by `migrate harvest`")
+		ref       = fs.String("ref", envOr("CERBERUS_VERIFY_REF", ""), "reference Prometheus base URL")
+		cerberus  = fs.String("cerberus", envOr("CERBERUS_VERIFY_CERBERUS", ""), "cerberus base URL")
+		startStr  = fs.String("start", envOr("CERBERUS_VERIFY_START", "-1h"), "range start (RFC3339, Unix seconds, or relative like -1h/now)")
+		endStr    = fs.String("end", envOr("CERBERUS_VERIFY_END", "now"), "range end (RFC3339, Unix seconds, or relative like -1h/now)")
+		stepStr   = fs.String("step", envOr("CERBERUS_VERIFY_STEP", "60s"), "range step (e.g. 60s)")
+		tolerance = fs.Float64("tolerance", envFloat("CERBERUS_VERIFY_TOLERANCE", defaultVerifyTolerance), "absolute value tolerance for a match")
+		asJSON    = fs.Bool("json", false, "emit the machine-readable JSON report instead of the text report")
+	)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	switch {
+	case *corpus == "":
+		return errors.New("missing --corpus (or CERBERUS_VERIFY_CORPUS): the harvested corpus.json to replay")
+	case *ref == "":
+		return errors.New("missing --ref (or CERBERUS_VERIFY_REF): the reference Prometheus base URL")
+	case *cerberus == "":
+		return errors.New("missing --cerberus (or CERBERUS_VERIFY_CERBERUS): the cerberus base URL")
+	}
+
+	c, err := migrateverify.LoadCorpus(*corpus)
+	if err != nil {
+		return err
+	}
+	params, err := migrateverify.BuildParams(*startStr, *endStr, *stepStr, *tolerance, time.Now().UTC())
+	if err != nil {
+		return err
+	}
+
+	refBackend := migrateverify.NewHTTPBackend(*ref)
+	cerBackend := migrateverify.NewHTTPBackend(*cerberus)
+	rep := migrateverify.Verify(context.Background(), c, refBackend, cerBackend, params)
+
+	if err := writeReport(stdout, rep, *asJSON); err != nil {
+		return err
+	}
+	if rep.Failed() {
+		return verifyFailedError{summary: rep.Summary}
+	}
+	return nil
+}
+
+// writeReport renders the report in the requested form.
+func writeReport(w io.Writer, rep migrateverify.Report, asJSON bool) error {
+	if asJSON {
+		return rep.WriteJSON(w)
+	}
+	return rep.WriteText(w)
+}
+
+// verifyFailedError signals a failed parity gate: the run completed and the
+// report was written, but cerberus diverged from the reference (or a backend
+// errored). main maps it to a dedicated non-zero exit code.
+type verifyFailedError struct {
+	summary migrateverify.Summary
+}
+
+func (e verifyFailedError) Error() string {
+	return fmt.Sprintf("parity gate failed: %d diverge, %d error (of %d queries)",
+		e.summary.Diverge, e.summary.Error, e.summary.Total)
+}
+
+// envOr returns the environment value for key, or def when unset/empty.
+func envOr(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+// envFloat returns the float parsed from the environment value for key, or def
+// when unset or unparseable.
+func envFloat(key string, def float64) float64 {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	f, err := strconv.ParseFloat(v, 64)
+	if err != nil {
+		return def
+	}
+	return f
+}

--- a/cmd/migrate/verify_test.go
+++ b/cmd/migrate/verify_test.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// promServer answers /api/v1/query_range with a fixed matrix for known queries
+// and a 400 otherwise, so the cmd-level test can drive runVerify end to end
+// against real HTTP without a live Prometheus or cerberus.
+func promServer(t *testing.T, byQuery map[string]string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, ok := byQuery[r.URL.Query().Get("query")]
+		if !ok {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"status":"error","error":"unknown"}`))
+			return
+		}
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+const upMatrix = `{"status":"success","data":{"resultType":"matrix","result":[` +
+	`{"metric":{"__name__":"up","job":"api"},"values":[[1700000000,"1"],[1700000060,"1"]]}]}}`
+
+func writeCorpus(t *testing.T, dir string) string {
+	t.Helper()
+	path := filepath.Join(dir, "corpus.json")
+	const body = `{"version":1,"queries":[` +
+		`{"expr":"up","source":"rule:up","kind":"record","lang":"promql"}` +
+		`],"skipped":[]}`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// TestRunVerify_MatchPasses: identical backends → runVerify returns nil (gate
+// passes) and prints a PASS report.
+func TestRunVerify_MatchPasses(t *testing.T) {
+	dir := t.TempDir()
+	corpus := writeCorpus(t, dir)
+	ref := promServer(t, map[string]string{"up": upMatrix})
+	cer := promServer(t, map[string]string{"up": upMatrix})
+
+	var out, errOut bytes.Buffer
+	err := runVerify([]string{
+		"--corpus", corpus, "--ref", ref.URL, "--cerberus", cer.URL,
+		"--start", "1700000000", "--end", "1700000600", "--step", "60s",
+	}, &out, &errOut)
+	if err != nil {
+		t.Fatalf("runVerify should pass on identical backends, got: %v (stderr %s)", err, errOut.String())
+	}
+	if !strings.Contains(out.String(), "PASS:") {
+		t.Errorf("expected a PASS report, got:\n%s", out.String())
+	}
+}
+
+// TestRunVerify_DivergeFails: a value difference makes runVerify return a
+// verifyFailedError (mapped to a non-zero exit) and print FAIL.
+func TestRunVerify_DivergeFails(t *testing.T) {
+	dir := t.TempDir()
+	corpus := writeCorpus(t, dir)
+	const cerMatrix = `{"status":"success","data":{"resultType":"matrix","result":[` +
+		`{"metric":{"__name__":"up","job":"api"},"values":[[1700000000,"1"],[1700000060,"0"]]}]}}`
+	ref := promServer(t, map[string]string{"up": upMatrix})
+	cer := promServer(t, map[string]string{"up": cerMatrix})
+
+	var out, errOut bytes.Buffer
+	err := runVerify([]string{
+		"--corpus", corpus, "--ref", ref.URL, "--cerberus", cer.URL,
+		"--start", "1700000000", "--end", "1700000600", "--step", "60s",
+	}, &out, &errOut)
+	var gate verifyFailedError
+	if !errors.As(err, &gate) {
+		t.Fatalf("runVerify should return verifyFailedError on divergence, got: %v", err)
+	}
+	if !strings.Contains(out.String(), "FAIL:") {
+		t.Errorf("expected a FAIL report, got:\n%s", out.String())
+	}
+}
+
+// TestRunVerify_JSON: --json emits the machine report.
+func TestRunVerify_JSON(t *testing.T) {
+	dir := t.TempDir()
+	corpus := writeCorpus(t, dir)
+	ref := promServer(t, map[string]string{"up": upMatrix})
+	cer := promServer(t, map[string]string{"up": upMatrix})
+
+	var out, errOut bytes.Buffer
+	if err := runVerify([]string{
+		"--corpus", corpus, "--ref", ref.URL, "--cerberus", cer.URL,
+		"--start", "1700000000", "--end", "1700000600", "--step", "60s", "--json",
+	}, &out, &errOut); err != nil {
+		t.Fatalf("runVerify --json: %v", err)
+	}
+	if !strings.Contains(out.String(), `"verdict": "match"`) {
+		t.Errorf("expected JSON report with a match verdict, got:\n%s", out.String())
+	}
+}
+
+// TestRunVerify_MissingFlags: absent required inputs are a clear error, not a
+// panic or a silent no-op.
+func TestRunVerify_MissingFlags(t *testing.T) {
+	t.Setenv("CERBERUS_VERIFY_CORPUS", "")
+	t.Setenv("CERBERUS_VERIFY_REF", "")
+	t.Setenv("CERBERUS_VERIFY_CERBERUS", "")
+	var out, errOut bytes.Buffer
+	if err := runVerify(nil, &out, &errOut); err == nil {
+		t.Fatal("runVerify with no corpus/ref/cerberus should error")
+	}
+}
+
+// TestRunVerify_EnvFallback: CERBERUS_VERIFY_* supply the inputs when flags are
+// omitted.
+func TestRunVerify_EnvFallback(t *testing.T) {
+	dir := t.TempDir()
+	corpus := writeCorpus(t, dir)
+	ref := promServer(t, map[string]string{"up": upMatrix})
+	cer := promServer(t, map[string]string{"up": upMatrix})
+	t.Setenv("CERBERUS_VERIFY_CORPUS", corpus)
+	t.Setenv("CERBERUS_VERIFY_REF", ref.URL)
+	t.Setenv("CERBERUS_VERIFY_CERBERUS", cer.URL)
+	t.Setenv("CERBERUS_VERIFY_START", "1700000000")
+	t.Setenv("CERBERUS_VERIFY_END", "1700000600")
+	t.Setenv("CERBERUS_VERIFY_STEP", "60s")
+
+	var out, errOut bytes.Buffer
+	if err := runVerify(nil, &out, &errOut); err != nil {
+		t.Fatalf("runVerify via env: %v (stderr %s)", err, errOut.String())
+	}
+	if !strings.Contains(out.String(), "PASS:") {
+		t.Errorf("expected PASS via env-driven run, got:\n%s", out.String())
+	}
+}

--- a/cmd/migrate/verify_test.go
+++ b/cmd/migrate/verify_test.go
@@ -142,3 +142,46 @@ func TestRunVerify_EnvFallback(t *testing.T) {
 		t.Errorf("expected PASS via env-driven run, got:\n%s", out.String())
 	}
 }
+
+// TestRunVerify_BadToleranceEnv: a set-but-unparseable CERBERUS_VERIFY_TOLERANCE
+// is a loud error, not a silent fallback to the tiny default that would tighten
+// the gate into spurious divergences.
+func TestRunVerify_BadToleranceEnv(t *testing.T) {
+	dir := t.TempDir()
+	corpus := writeCorpus(t, dir)
+	ref := promServer(t, map[string]string{"up": upMatrix})
+	cer := promServer(t, map[string]string{"up": upMatrix})
+	t.Setenv("CERBERUS_VERIFY_CORPUS", corpus)
+	t.Setenv("CERBERUS_VERIFY_REF", ref.URL)
+	t.Setenv("CERBERUS_VERIFY_CERBERUS", cer.URL)
+	t.Setenv("CERBERUS_VERIFY_TOLERANCE", "not-a-float")
+
+	var out, errOut bytes.Buffer
+	err := runVerify(nil, &out, &errOut)
+	if err == nil {
+		t.Fatal("runVerify should reject an unparseable CERBERUS_VERIFY_TOLERANCE")
+	}
+	if !strings.Contains(err.Error(), "CERBERUS_VERIFY_TOLERANCE") {
+		t.Errorf("error should name the offending variable, got: %v", err)
+	}
+}
+
+// TestEnvFloat covers the unset / valid / unparseable branches directly.
+func TestEnvFloat(t *testing.T) {
+	const key = "CERBERUS_VERIFY_TOLERANCE_TESTKEY"
+
+	t.Setenv(key, "")
+	if got, err := envFloat(key, 1e-9); err != nil || got != 1e-9 {
+		t.Errorf("unset: got %v, %v; want 1e-9, nil", got, err)
+	}
+
+	t.Setenv(key, "0.25")
+	if got, err := envFloat(key, 1e-9); err != nil || got != 0.25 {
+		t.Errorf("valid: got %v, %v; want 0.25, nil", got, err)
+	}
+
+	t.Setenv(key, "banana")
+	if _, err := envFloat(key, 1e-9); err == nil {
+		t.Error("unparseable: envFloat should error, not fall back to the default")
+	}
+}

--- a/internal/migrateverify/client.go
+++ b/internal/migrateverify/client.go
@@ -1,0 +1,242 @@
+package migrateverify
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/migrate"
+)
+
+// queryRangePath is the Prometheus HTTP API range-query endpoint, appended to
+// each backend's base URL.
+const queryRangePath = "/api/v1/query_range"
+
+// defaultHTTPTimeout bounds a single backend request so one hung query can't
+// stall the whole gate.
+const defaultHTTPTimeout = 30 * time.Second
+
+// Params are the shared query_range parameters replayed identically against both
+// backends, plus the comparison tolerance.
+type Params struct {
+	Start     time.Time
+	End       time.Time
+	Step      time.Duration
+	Tolerance float64
+}
+
+// HTTPBackend issues range queries against a Prometheus-compatible HTTP API.
+type HTTPBackend struct {
+	BaseURL string
+	HTTP    *http.Client
+}
+
+// NewHTTPBackend builds a backend for baseURL with a bounded default client.
+func NewHTTPBackend(baseURL string) *HTTPBackend {
+	return &HTTPBackend{
+		BaseURL: strings.TrimRight(baseURL, "/"),
+		HTTP:    &http.Client{Timeout: defaultHTTPTimeout},
+	}
+}
+
+// promRangeResponse is the standard Prometheus range-query JSON envelope.
+type promRangeResponse struct {
+	Status string `json:"status"`
+	Data   struct {
+		ResultType string          `json:"resultType"`
+		Result     []promRawSeries `json:"result"`
+	} `json:"data"`
+	ErrorType string `json:"errorType"`
+	Error     string `json:"error"`
+}
+
+// promRawSeries is one series: a label set plus [ [ts, "value"], ... ].
+type promRawSeries struct {
+	Metric map[string]string    `json:"metric"`
+	Values [][2]json.RawMessage `json:"values"`
+}
+
+// QueryRange issues GET {base}/api/v1/query_range with the shared params and
+// parses the response. An HTTP non-200 is returned as RangeResult{Status: code}
+// (no series) rather than an error, so the caller can classify it as unsupported
+// vs error; only transport and decode failures are returned as err.
+func (b *HTTPBackend) QueryRange(ctx context.Context, expr string, p Params) (RangeResult, error) {
+	q := url.Values{}
+	q.Set("query", expr)
+	q.Set("start", formatTimestamp(p.Start))
+	q.Set("end", formatTimestamp(p.End))
+	q.Set("step", strconv.FormatInt(int64(p.Step.Seconds()), 10))
+	reqURL := b.BaseURL + queryRangePath + "?" + q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return RangeResult{}, fmt.Errorf("build request: %w", err)
+	}
+	resp, err := b.HTTP.Do(req)
+	if err != nil {
+		return RangeResult{}, fmt.Errorf("do request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return RangeResult{}, fmt.Errorf("read body: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return RangeResult{Status: resp.StatusCode}, nil
+	}
+	return parseRangeBody(resp.StatusCode, body)
+}
+
+// parseRangeBody decodes a 200 range body into a RangeResult. A body that is not
+// valid JSON is a decode error; a valid body with a non-matrix resultType is
+// carried through (Status + ResultType) for the caller to classify.
+func parseRangeBody(status int, body []byte) (RangeResult, error) {
+	var raw promRangeResponse
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return RangeResult{}, fmt.Errorf("decode range response: %w", err)
+	}
+	res := RangeResult{Status: status, ResultType: raw.Data.ResultType}
+	if raw.Data.ResultType != resultTypeMatrix {
+		return res, nil
+	}
+	for _, rs := range raw.Data.Result {
+		s := Series{Labels: rs.Metric, Samples: make([]Sample, 0, len(rs.Values))}
+		for _, pair := range rs.Values {
+			ts, val, err := parseSamplePair(pair)
+			if err != nil {
+				return RangeResult{}, err
+			}
+			s.Samples = append(s.Samples, Sample{T: ts, V: val})
+		}
+		res.Series = append(res.Series, s)
+	}
+	return res, nil
+}
+
+// parseSamplePair decodes one [ts, "value"] point. The timestamp is a JSON
+// number; the value is a JSON string (Prometheus encodes values as strings so
+// NaN / Inf round-trip).
+func parseSamplePair(pair [2]json.RawMessage) (float64, float64, error) {
+	var ts float64
+	if err := json.Unmarshal(pair[0], &ts); err != nil {
+		return 0, 0, fmt.Errorf("decode sample timestamp: %w", err)
+	}
+	var valStr string
+	if err := json.Unmarshal(pair[1], &valStr); err != nil {
+		return 0, 0, fmt.Errorf("decode sample value: %w", err)
+	}
+	val, err := strconv.ParseFloat(valStr, 64)
+	if err != nil {
+		return 0, 0, fmt.Errorf("parse sample value %q: %w", valStr, err)
+	}
+	return ts, val, nil
+}
+
+// formatTimestamp renders an instant as Unix seconds for the query_range API.
+func formatTimestamp(t time.Time) string {
+	return strconv.FormatInt(t.Unix(), 10)
+}
+
+// ParseTime resolves a start/end value that may be RFC3339, a Unix-seconds
+// integer, the literal "now", or a relative offset ("-1h", "+30m", "now-15m").
+// Relative values are resolved against now, which the caller pins for
+// determinism.
+func ParseTime(s string, now time.Time) (time.Time, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return time.Time{}, fmt.Errorf("empty time value")
+	}
+	if s == "now" {
+		return now, nil
+	}
+	if rest, ok := strings.CutPrefix(s, "now"); ok {
+		d, err := time.ParseDuration(rest)
+		if err != nil {
+			return time.Time{}, fmt.Errorf("relative time %q: %w", s, err)
+		}
+		return now.Add(d), nil
+	}
+	if strings.HasPrefix(s, "+") || strings.HasPrefix(s, "-") {
+		d, err := time.ParseDuration(s)
+		if err != nil {
+			return time.Time{}, fmt.Errorf("relative time %q: %w", s, err)
+		}
+		return now.Add(d), nil
+	}
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t, nil
+	}
+	if secs, err := strconv.ParseInt(s, 10, 64); err == nil {
+		return time.Unix(secs, 0).UTC(), nil
+	}
+	return time.Time{}, fmt.Errorf("time %q: not RFC3339, a Unix timestamp, or a relative offset", s)
+}
+
+// BuildParams resolves the raw string inputs into validated Params. now pins the
+// resolution of any relative start/end so the result is reproducible.
+func BuildParams(startStr, endStr, stepStr string, tolerance float64, now time.Time) (Params, error) {
+	start, err := ParseTime(startStr, now)
+	if err != nil {
+		return Params{}, fmt.Errorf("start: %w", err)
+	}
+	end, err := ParseTime(endStr, now)
+	if err != nil {
+		return Params{}, fmt.Errorf("end: %w", err)
+	}
+	if !end.After(start) {
+		return Params{}, fmt.Errorf("end (%s) must be after start (%s)", end.Format(time.RFC3339), start.Format(time.RFC3339))
+	}
+	step, err := time.ParseDuration(stepStr)
+	if err != nil {
+		return Params{}, fmt.Errorf("step %q: %w", stepStr, err)
+	}
+	if step <= 0 {
+		return Params{}, fmt.Errorf("step must be positive, got %s", step)
+	}
+	return Params{Start: start, End: end, Step: step, Tolerance: tolerance}, nil
+}
+
+// LoadCorpus reads a corpus.json produced by `migrate harvest`, splits it into
+// the PromQL queries to replay and the non-PromQL entries carried through for
+// honest accounting, and rejects a corpus whose version this build does not
+// understand. Every query is accounted for — none is silently dropped.
+func LoadCorpus(path string) (Corpus, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // operator-supplied corpus path; offline CLI input.
+	if err != nil {
+		return Corpus{}, fmt.Errorf("read corpus %q: %w", path, err)
+	}
+	var c migrate.Corpus
+	if err := json.Unmarshal(data, &c); err != nil {
+		return Corpus{}, fmt.Errorf("decode corpus %q: %w", path, err)
+	}
+	if c.Version != migrate.CorpusVersion {
+		return Corpus{}, fmt.Errorf("corpus %q has version %d, this build understands version %d", path, c.Version, migrate.CorpusVersion)
+	}
+	out := Corpus{}
+	for _, q := range c.Queries {
+		if q.Lang == migrate.LangPromQL {
+			out.PromQL = append(out.PromQL, Query{Expr: q.Expr, Source: q.Source})
+			continue
+		}
+		out.OutOfScope = append(out.OutOfScope, OutOfScopeEntry{Source: q.Source, Lang: q.Lang})
+	}
+	return out, nil
+}
+
+// WriteJSON renders the report as machine-readable JSON with a trailing newline.
+func (r Report) WriteJSON(w io.Writer) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(r); err != nil {
+		return fmt.Errorf("encode report: %w", err)
+	}
+	return nil
+}

--- a/internal/migrateverify/client.go
+++ b/internal/migrateverify/client.go
@@ -72,7 +72,7 @@ func (b *HTTPBackend) QueryRange(ctx context.Context, expr string, p Params) (Ra
 	q.Set("query", expr)
 	q.Set("start", formatTimestamp(p.Start))
 	q.Set("end", formatTimestamp(p.End))
-	q.Set("step", strconv.FormatInt(int64(p.Step.Seconds()), 10))
+	q.Set("step", formatStep(p.Step))
 	reqURL := b.BaseURL + queryRangePath + "?" + q.Encode()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
@@ -145,6 +145,14 @@ func formatTimestamp(t time.Time) string {
 	return strconv.FormatInt(t.Unix(), 10)
 }
 
+// formatStep renders the range step as Prometheus-style float seconds, keeping
+// sub-second precision (e.g. 1500ms → "1.5", 500ms → "0.5") so the replayed
+// window matches the operator's requested step exactly instead of truncating to
+// whole seconds.
+func formatStep(step time.Duration) string {
+	return strconv.FormatFloat(step.Seconds(), 'f', -1, 64)
+}
+
 // ParseTime resolves a start/end value that may be RFC3339, a Unix-seconds
 // integer, the literal "now", or a relative offset ("-1h", "+30m", "now-15m").
 // Relative values are resolved against now, which the caller pins for
@@ -206,8 +214,11 @@ func BuildParams(startStr, endStr, stepStr string, tolerance float64, now time.T
 
 // LoadCorpus reads a corpus.json produced by `migrate harvest`, splits it into
 // the PromQL queries to replay and the non-PromQL entries carried through for
-// honest accounting, and rejects a corpus whose version this build does not
-// understand. Every query is accounted for — none is silently dropped.
+// honest accounting, carries through the harvest-time skips the corpus recorded,
+// and rejects a corpus whose version this build does not understand. Every entry
+// is accounted for — none is silently dropped: PromQL queries are replayed,
+// non-PromQL queries are counted out of scope, and the harvester's own skips are
+// surfaced so the operator sees queries that never became replayable at all.
 func LoadCorpus(path string) (Corpus, error) {
 	data, err := os.ReadFile(path) //nolint:gosec // operator-supplied corpus path; offline CLI input.
 	if err != nil {
@@ -227,6 +238,9 @@ func LoadCorpus(path string) (Corpus, error) {
 			continue
 		}
 		out.OutOfScope = append(out.OutOfScope, OutOfScopeEntry{Source: q.Source, Lang: q.Lang})
+	}
+	for _, s := range c.Skipped {
+		out.HarvestSkipped = append(out.HarvestSkipped, HarvestSkippedEntry{Source: s.Source, Reason: s.Reason})
 	}
 	return out, nil
 }

--- a/internal/migrateverify/client_test.go
+++ b/internal/migrateverify/client_test.go
@@ -64,9 +64,10 @@ func TestBuildParams(t *testing.T) {
 	}
 }
 
-// TestLoadCorpus writes a v1 corpus with a PromQL query and a LogQL panel, then
-// checks that verify picks up the PromQL query and carries the LogQL one through
-// as out-of-scope (never silently dropped).
+// TestLoadCorpus writes a v1 corpus with a PromQL query, a LogQL panel, and a
+// harvest-time skip, then checks that verify picks up the PromQL query, carries
+// the LogQL one through as out-of-scope, and surfaces the harvest skip — every
+// entry accounted for, none silently dropped.
 func TestLoadCorpus(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "corpus.json")
@@ -76,7 +77,9 @@ func TestLoadCorpus(t *testing.T) {
     {"expr": "up", "source": "rule:a", "kind": "record", "lang": "promql"},
     {"expr": "{app=\"x\"}", "source": "panel:logs", "kind": "panel", "lang": "logql"}
   ],
-  "skipped": []
+  "skipped": [
+    {"source": "rule:broken.yml", "reason": "rule has an empty expr"}
+  ]
 }`
 	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
 		t.Fatal(err)
@@ -90,6 +93,29 @@ func TestLoadCorpus(t *testing.T) {
 	}
 	if len(c.OutOfScope) != 1 || c.OutOfScope[0].Lang != "logql" {
 		t.Errorf("OutOfScope = %+v, want the one logql panel", c.OutOfScope)
+	}
+	if len(c.HarvestSkipped) != 1 || c.HarvestSkipped[0].Source != "rule:broken.yml" ||
+		c.HarvestSkipped[0].Reason != "rule has an empty expr" {
+		t.Errorf("HarvestSkipped = %+v, want the one broken-rule skip", c.HarvestSkipped)
+	}
+}
+
+// TestFormatStep pins that the step is sent with sub-second precision instead of
+// being truncated to whole seconds — a 1500ms step must replay as "1.5", not "1".
+func TestFormatStep(t *testing.T) {
+	cases := []struct {
+		in   time.Duration
+		want string
+	}{
+		{60 * time.Second, "60"},
+		{1500 * time.Millisecond, "1.5"},
+		{500 * time.Millisecond, "0.5"},
+		{90 * time.Second, "90"},
+	}
+	for _, c := range cases {
+		if got := formatStep(c.in); got != c.want {
+			t.Errorf("formatStep(%s) = %q, want %q", c.in, got, c.want)
+		}
 	}
 }
 

--- a/internal/migrateverify/client_test.go
+++ b/internal/migrateverify/client_test.go
@@ -1,0 +1,130 @@
+package migrateverify
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestParseTime(t *testing.T) {
+	now := time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		in   string
+		want time.Time
+	}{
+		{"now", now},
+		{"-1h", now.Add(-time.Hour)},
+		{"now-15m", now.Add(-15 * time.Minute)},
+		{"+30m", now.Add(30 * time.Minute)},
+		{"2026-07-22T11:00:00Z", time.Date(2026, 7, 22, 11, 0, 0, 0, time.UTC)},
+		{"1700000000", time.Unix(1_700_000_000, 0).UTC()},
+	}
+	for _, c := range cases {
+		got, err := ParseTime(c.in, now)
+		if err != nil {
+			t.Errorf("ParseTime(%q): %v", c.in, err)
+			continue
+		}
+		if !got.Equal(c.want) {
+			t.Errorf("ParseTime(%q) = %s, want %s", c.in, got, c.want)
+		}
+	}
+
+	for _, bad := range []string{"", "yesterday", "-1potato"} {
+		if _, err := ParseTime(bad, now); err == nil {
+			t.Errorf("ParseTime(%q) should error", bad)
+		}
+	}
+}
+
+func TestBuildParams(t *testing.T) {
+	now := time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC)
+	p, err := BuildParams("-1h", "now", "60s", 0.5, now)
+	if err != nil {
+		t.Fatalf("BuildParams: %v", err)
+	}
+	if !p.Start.Equal(now.Add(-time.Hour)) || !p.End.Equal(now) {
+		t.Errorf("window = [%s, %s], want [-1h, now]", p.Start, p.End)
+	}
+	if p.Step != 60*time.Second || p.Tolerance != 0.5 {
+		t.Errorf("step/tol = %s / %v, want 60s / 0.5", p.Step, p.Tolerance)
+	}
+
+	// end must be after start.
+	if _, err := BuildParams("now", "-1h", "60s", 0, now); err == nil {
+		t.Error("BuildParams should reject end before start")
+	}
+	// step must be positive and parseable.
+	if _, err := BuildParams("-1h", "now", "0s", 0, now); err == nil {
+		t.Error("BuildParams should reject a zero step")
+	}
+	if _, err := BuildParams("-1h", "now", "banana", 0, now); err == nil {
+		t.Error("BuildParams should reject an unparseable step")
+	}
+}
+
+// TestLoadCorpus writes a v1 corpus with a PromQL query and a LogQL panel, then
+// checks that verify picks up the PromQL query and carries the LogQL one through
+// as out-of-scope (never silently dropped).
+func TestLoadCorpus(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "corpus.json")
+	const body = `{
+  "version": 1,
+  "queries": [
+    {"expr": "up", "source": "rule:a", "kind": "record", "lang": "promql"},
+    {"expr": "{app=\"x\"}", "source": "panel:logs", "kind": "panel", "lang": "logql"}
+  ],
+  "skipped": []
+}`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	c, err := LoadCorpus(path)
+	if err != nil {
+		t.Fatalf("LoadCorpus: %v", err)
+	}
+	if len(c.PromQL) != 1 || c.PromQL[0].Expr != "up" {
+		t.Errorf("PromQL = %+v, want the single `up` query", c.PromQL)
+	}
+	if len(c.OutOfScope) != 1 || c.OutOfScope[0].Lang != "logql" {
+		t.Errorf("OutOfScope = %+v, want the one logql panel", c.OutOfScope)
+	}
+}
+
+func TestLoadCorpus_Errors(t *testing.T) {
+	dir := t.TempDir()
+
+	if _, err := LoadCorpus(filepath.Join(dir, "nope.json")); err == nil {
+		t.Error("LoadCorpus should error on a missing file")
+	}
+
+	bad := filepath.Join(dir, "bad.json")
+	if err := os.WriteFile(bad, []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadCorpus(bad); err == nil {
+		t.Error("LoadCorpus should error on malformed JSON")
+	}
+
+	wrongVer := filepath.Join(dir, "v99.json")
+	if err := os.WriteFile(wrongVer, []byte(`{"version":99,"queries":[],"skipped":[]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadCorpus(wrongVer); err == nil {
+		t.Error("LoadCorpus should reject an unknown corpus version")
+	}
+}
+
+// TestCanonicalLabels pins that label-map order does not affect the match key.
+func TestCanonicalLabels(t *testing.T) {
+	a := canonicalLabels(map[string]string{"b": "2", "a": "1"})
+	b := canonicalLabels(map[string]string{"a": "1", "b": "2"})
+	if a != b {
+		t.Errorf("canonical labels must be order-independent: %q vs %q", a, b)
+	}
+	if a != `{a="1",b="2"}` {
+		t.Errorf("canonical form = %q, want {a=\"1\",b=\"2\"}", a)
+	}
+}

--- a/internal/migrateverify/verify.go
+++ b/internal/migrateverify/verify.go
@@ -1,0 +1,427 @@
+// Package migrateverify is cerberus's cutover parity gate. It replays a
+// harvested PromQL corpus against a reference Prometheus AND cerberus over one
+// query_range window and diffs the results, so an operator can prove — before
+// flipping a datasource — that cerberus returns the same numbers Prometheus
+// does for the queries they actually run.
+//
+// The flow is read-only against both backends: for each query it issues an
+// identical GET /api/v1/query_range to the reference and to cerberus, parses the
+// standard Prometheus matrix response, matches series by their canonical label
+// set, step-aligns the samples, and compares values within a tolerance (with
+// NaN==NaN treated as equal). Every query lands in exactly one verdict — match,
+// diverge, unsupported, or error — and a divergence is never allow-listed: the
+// gate exits non-zero if any query diverges or errors.
+//
+// Honesty is the whole point: the comparator only claims a match where both
+// backends returned data that agrees. A series present in one backend but not
+// the other is itself a divergence (reported with its first differing point),
+// not a silent omission.
+package migrateverify
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"math"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// DefaultTolerance is the absolute epsilon two sample values may differ by and
+// still count as equal. It is deliberately tiny — parity means the same number,
+// and this only absorbs float round-trips through JSON string encoding, not real
+// numeric drift.
+const DefaultTolerance = 1e-9
+
+// resultTypeMatrix is the only Prometheus resultType a range query can return;
+// anything else from cerberus means it could not serve the query as a range.
+const resultTypeMatrix = "matrix"
+
+// Verdict is the classification of a single query's parity check.
+type Verdict string
+
+const (
+	// VerdictMatch: both backends returned matrix data that agrees within tolerance.
+	VerdictMatch Verdict = "match"
+	// VerdictDiverge: both backends returned matrix data, but the results differ.
+	VerdictDiverge Verdict = "diverge"
+	// VerdictUnsupported: cerberus returned a non-200 status or a non-matrix
+	// result — it could not serve the query as a range at all.
+	VerdictUnsupported Verdict = "unsupported"
+	// VerdictError: the reference failed, or a transport/parse error prevented a
+	// comparison. Distinct from unsupported: the fault is not cerberus rejecting
+	// the query, so there is nothing to compare.
+	VerdictError Verdict = "error"
+)
+
+// Sample is one point of a range result: a Unix-seconds timestamp and its value.
+type Sample struct {
+	T float64
+	V float64
+}
+
+// Series is one labelled time series from a matrix response.
+type Series struct {
+	Labels  map[string]string
+	Samples []Sample
+}
+
+// FirstDiff captures the first point at which two backends disagree for a query.
+// Values are formatted strings (Prometheus renders values as strings) so NaN /
+// +Inf survive both the human report and JSON encoding, where a float NaN would
+// otherwise be unrepresentable.
+type FirstDiff struct {
+	Series        string  `json:"series"`
+	Timestamp     float64 `json:"timestamp"`
+	RefValue      string  `json:"ref_value"`
+	CerberusValue string  `json:"cerberus_value"`
+	Reason        string  `json:"reason"`
+}
+
+// canonicalLabels renders a label set as a stable, order-independent key so the
+// same series from two backends matches regardless of map iteration order.
+func canonicalLabels(labels map[string]string) string {
+	keys := make([]string, 0, len(labels))
+	for k := range labels {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	b.WriteByte('{')
+	for i, k := range keys {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(k)
+		b.WriteByte('=')
+		b.WriteString(strconv.Quote(labels[k]))
+	}
+	b.WriteByte('}')
+	return b.String()
+}
+
+// formatValue renders a sample value the way Prometheus does, so NaN / Inf are
+// human- and JSON-safe.
+func formatValue(v float64) string {
+	return strconv.FormatFloat(v, 'g', -1, 64)
+}
+
+// valuesEqual reports whether two sample values agree within tol, treating two
+// NaNs as equal (both backends declaring "no value here" is agreement, not a
+// divergence).
+func valuesEqual(a, b, tol float64) bool {
+	aNaN, bNaN := math.IsNaN(a), math.IsNaN(b)
+	if aNaN || bNaN {
+		return aNaN && bNaN
+	}
+	return math.Abs(a-b) <= tol
+}
+
+// Compare matches ref and cerberus series by canonical label set and returns the
+// verdict plus, on divergence, the first differing point. It is deterministic:
+// series are visited in sorted canonical-label order and, within a series,
+// samples in sorted timestamp order, so the "first" diff is stable across runs.
+// A series present in only one backend is a divergence, not a skip.
+func Compare(ref, cerberus []Series, tol float64) (Verdict, *FirstDiff) {
+	refByKey := indexSeries(ref)
+	cerByKey := indexSeries(cerberus)
+
+	keys := make([]string, 0, len(refByKey)+len(cerByKey))
+	seen := map[string]struct{}{}
+	for k := range refByKey {
+		if _, ok := seen[k]; !ok {
+			seen[k] = struct{}{}
+			keys = append(keys, k)
+		}
+	}
+	for k := range cerByKey {
+		if _, ok := seen[k]; !ok {
+			seen[k] = struct{}{}
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		r, rok := refByKey[k]
+		c, cok := cerByKey[k]
+		switch {
+		case !cok:
+			return VerdictDiverge, missingSeriesDiff(k, r, "present in reference only")
+		case !rok:
+			return VerdictDiverge, missingSeriesDiff(k, c, "present in cerberus only")
+		default:
+			if fd := compareSeries(k, r, c, tol); fd != nil {
+				return VerdictDiverge, fd
+			}
+		}
+	}
+	return VerdictMatch, nil
+}
+
+// indexSeries keys series by canonical label set. If a backend repeats a label
+// set (it should not), the last one wins — a benign, deterministic choice.
+func indexSeries(series []Series) map[string]Series {
+	out := make(map[string]Series, len(series))
+	for _, s := range series {
+		out[canonicalLabels(s.Labels)] = s
+	}
+	return out
+}
+
+// missingSeriesDiff builds a FirstDiff for a series that exists in only one
+// backend, anchored at the present side's first sample.
+func missingSeriesDiff(key string, present Series, reason string) *FirstDiff {
+	fd := &FirstDiff{Series: key, Reason: reason}
+	presentVal := "<none>"
+	if len(present.Samples) > 0 {
+		fd.Timestamp = present.Samples[0].T
+		presentVal = formatValue(present.Samples[0].V)
+	}
+	if strings.Contains(reason, "reference only") {
+		fd.RefValue, fd.CerberusValue = presentVal, "<missing series>"
+	} else {
+		fd.RefValue, fd.CerberusValue = "<missing series>", presentVal
+	}
+	return fd
+}
+
+// compareSeries step-aligns two matched series by timestamp and returns the
+// first differing point, or nil if they agree everywhere within tol. A timestamp
+// present in only one side is a divergence (coverage gap) at that point.
+func compareSeries(key string, ref, cerberus Series, tol float64) *FirstDiff {
+	refAt := samplesByTS(ref.Samples)
+	cerAt := samplesByTS(cerberus.Samples)
+
+	timestamps := make([]float64, 0, len(refAt)+len(cerAt))
+	seen := map[float64]struct{}{}
+	for _, s := range ref.Samples {
+		if _, ok := seen[s.T]; !ok {
+			seen[s.T] = struct{}{}
+			timestamps = append(timestamps, s.T)
+		}
+	}
+	for _, s := range cerberus.Samples {
+		if _, ok := seen[s.T]; !ok {
+			seen[s.T] = struct{}{}
+			timestamps = append(timestamps, s.T)
+		}
+	}
+	sort.Float64s(timestamps)
+
+	for _, ts := range timestamps {
+		rv, rok := refAt[ts]
+		cv, cok := cerAt[ts]
+		switch {
+		case !cok:
+			return &FirstDiff{Series: key, Timestamp: ts, RefValue: formatValue(rv), CerberusValue: "<no sample>", Reason: "cerberus has no sample at this step"}
+		case !rok:
+			return &FirstDiff{Series: key, Timestamp: ts, RefValue: "<no sample>", CerberusValue: formatValue(cv), Reason: "reference has no sample at this step"}
+		case !valuesEqual(rv, cv, tol):
+			return &FirstDiff{Series: key, Timestamp: ts, RefValue: formatValue(rv), CerberusValue: formatValue(cv), Reason: "value differs beyond tolerance"}
+		}
+	}
+	return nil
+}
+
+// samplesByTS indexes samples by timestamp for O(1) step alignment.
+func samplesByTS(samples []Sample) map[float64]float64 {
+	out := make(map[float64]float64, len(samples))
+	for _, s := range samples {
+		out[s.T] = s.V
+	}
+	return out
+}
+
+// Query is one PromQL expression from the corpus to replay.
+type Query struct {
+	Expr   string `json:"expr"`
+	Source string `json:"source"`
+}
+
+// OutOfScopeEntry records a corpus entry that is not PromQL (e.g. a LogQL
+// dashboard panel). A Prometheus parity gate cannot judge it, so it is reported
+// and counted here rather than dropped — its parity belongs to a different head's
+// gate, and pretending otherwise would be a silent omission.
+type OutOfScopeEntry struct {
+	Source string `json:"source"`
+	Lang   string `json:"lang"`
+}
+
+// Corpus is the verify input: the PromQL queries to replay plus the non-PromQL
+// entries carried through for honest accounting.
+type Corpus struct {
+	PromQL     []Query
+	OutOfScope []OutOfScopeEntry
+}
+
+// QueryResult is the parity verdict for a single replayed query.
+type QueryResult struct {
+	Source    string     `json:"source"`
+	Expr      string     `json:"expr"`
+	Verdict   Verdict    `json:"verdict"`
+	FirstDiff *FirstDiff `json:"first_diff,omitempty"`
+	Detail    string     `json:"detail,omitempty"`
+}
+
+// Summary counts verdicts across the whole run.
+type Summary struct {
+	Total       int `json:"total"`
+	Match       int `json:"match"`
+	Diverge     int `json:"diverge"`
+	Unsupported int `json:"unsupported"`
+	Error       int `json:"error"`
+	OutOfScope  int `json:"out_of_scope"`
+}
+
+// Report is the full parity result: per-query verdicts, the out-of-scope
+// accounting, and the roll-up summary.
+type Report struct {
+	Summary    Summary           `json:"summary"`
+	Results    []QueryResult     `json:"results"`
+	OutOfScope []OutOfScopeEntry `json:"out_of_scope,omitempty"`
+}
+
+// Failed reports whether the gate should exit non-zero: any diverging or erroring
+// query fails it. Unsupported queries are reported but do not fail the gate — an
+// unsupported query is a coverage gap surfaced for the operator, not a wrong
+// answer. Out-of-scope entries never affect the gate.
+func (r Report) Failed() bool {
+	return r.Summary.Diverge > 0 || r.Summary.Error > 0
+}
+
+// Backend issues a range query against one backend and returns the parsed
+// result. Transport / decode failures are returned as err; an HTTP non-200 or a
+// non-matrix body is carried in RangeResult (Status / ResultType) so the caller
+// can classify unsupported-vs-error itself.
+type Backend interface {
+	QueryRange(ctx context.Context, expr string, p Params) (RangeResult, error)
+}
+
+// RangeResult is a parsed range response from one backend.
+type RangeResult struct {
+	Status     int
+	ResultType string
+	Series     []Series
+}
+
+// Verify replays every PromQL query in the corpus against both backends and
+// assembles the parity report. Queries are processed in corpus order for
+// deterministic output. Each query is issued to the reference and to cerberus
+// with identical parameters; the verdict is derived as:
+//
+//   - transport/decode failure on either backend, or a reference that did not
+//     return a 200 matrix → error (nothing to compare against);
+//   - cerberus non-200 or non-matrix → unsupported;
+//   - otherwise → the comparator's match/diverge verdict.
+func Verify(ctx context.Context, corpus Corpus, ref, cerberus Backend, p Params) Report {
+	rep := Report{OutOfScope: corpus.OutOfScope}
+	rep.Summary.OutOfScope = len(corpus.OutOfScope)
+
+	for _, q := range corpus.PromQL {
+		res := verifyOne(ctx, q, ref, cerberus, p)
+		rep.Results = append(rep.Results, res)
+		rep.Summary.Total++
+		switch res.Verdict {
+		case VerdictMatch:
+			rep.Summary.Match++
+		case VerdictDiverge:
+			rep.Summary.Diverge++
+		case VerdictUnsupported:
+			rep.Summary.Unsupported++
+		case VerdictError:
+			rep.Summary.Error++
+		}
+	}
+	return rep
+}
+
+// verifyOne runs the parity check for a single query.
+func verifyOne(ctx context.Context, q Query, ref, cerberus Backend, p Params) QueryResult {
+	out := QueryResult{Source: q.Source, Expr: q.Expr}
+
+	refRes, refErr := ref.QueryRange(ctx, q.Expr, p)
+	cerRes, cerErr := cerberus.QueryRange(ctx, q.Expr, p)
+
+	switch {
+	case refErr != nil:
+		out.Verdict, out.Detail = VerdictError, fmt.Sprintf("reference request failed: %v", refErr)
+	case cerErr != nil:
+		out.Verdict, out.Detail = VerdictError, fmt.Sprintf("cerberus request failed: %v", cerErr)
+	case cerRes.Status != 200 || cerRes.ResultType != resultTypeMatrix:
+		out.Verdict = VerdictUnsupported
+		out.Detail = fmt.Sprintf("cerberus returned status=%d resultType=%q", cerRes.Status, cerRes.ResultType)
+	case refRes.Status != 200 || refRes.ResultType != resultTypeMatrix:
+		out.Verdict = VerdictError
+		out.Detail = fmt.Sprintf("reference returned status=%d resultType=%q (no baseline to compare)", refRes.Status, refRes.ResultType)
+	default:
+		verdict, fd := Compare(refRes.Series, cerRes.Series, p.Tolerance)
+		out.Verdict, out.FirstDiff = verdict, fd
+	}
+	return out
+}
+
+// WriteText renders the report as a scannable, human-readable gate report: a
+// header, one block per non-matching query (matches are summarised, not listed,
+// so a diverging result is not buried), the out-of-scope accounting, and the
+// roll-up counts. It ends with an explicit PASS / FAIL line.
+func (r Report) WriteText(w io.Writer) error {
+	bw := &errWriter{w: w}
+	bw.printf("# cerberus migrate verify\n")
+	bw.printf("#\n")
+	bw.printf("# Parity gate: each corpus query replayed against the reference Prometheus\n")
+	bw.printf("# and cerberus over one query_range window, results diffed series-by-series.\n")
+	bw.printf("# A divergence is never allow-listed — the gate fails if any query diverges\n")
+	bw.printf("# or errors.\n")
+	bw.printf("#\n")
+	bw.printf("# %d queries: %d match, %d diverge, %d unsupported, %d error (+%d out of scope)\n\n",
+		r.Summary.Total, r.Summary.Match, r.Summary.Diverge, r.Summary.Unsupported, r.Summary.Error, r.Summary.OutOfScope)
+
+	for _, res := range r.Results {
+		if res.Verdict == VerdictMatch {
+			continue
+		}
+		bw.printf("== [%s] %s\n", res.Verdict, res.Source)
+		bw.printf("   expr:   %s\n", res.Expr)
+		if res.Detail != "" {
+			bw.printf("   detail: %s\n", res.Detail)
+		}
+		if res.FirstDiff != nil {
+			fd := res.FirstDiff
+			bw.printf("   first-diff: series=%s ts=%s ref=%s cerberus=%s (%s)\n",
+				fd.Series, formatValue(fd.Timestamp), fd.RefValue, fd.CerberusValue, fd.Reason)
+		}
+		bw.printf("\n")
+	}
+
+	if len(r.OutOfScope) > 0 {
+		bw.printf("== out of scope (%d) — not PromQL, no Prometheus baseline\n", len(r.OutOfScope))
+		for _, e := range r.OutOfScope {
+			bw.printf("   %s: lang=%s\n", e.Source, e.Lang)
+		}
+		bw.printf("\n")
+	}
+
+	if r.Failed() {
+		bw.printf("FAIL: %d diverge, %d error\n", r.Summary.Diverge, r.Summary.Error)
+	} else {
+		bw.printf("PASS: %d match, %d unsupported (no divergence)\n", r.Summary.Match, r.Summary.Unsupported)
+	}
+	return bw.err
+}
+
+// errWriter collapses the repeated Fprintf error checks into a single
+// short-circuiting sink: once a write fails, later printf calls are no-ops and
+// the first error is returned.
+type errWriter struct {
+	w   io.Writer
+	err error
+}
+
+func (e *errWriter) printf(format string, args ...any) {
+	if e.err != nil {
+		return
+	}
+	_, e.err = fmt.Fprintf(e.w, format, args...)
+}

--- a/internal/migrateverify/verify.go
+++ b/internal/migrateverify/verify.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"net/http"
 	"sort"
 	"strconv"
 	"strings"
@@ -249,11 +250,23 @@ type OutOfScopeEntry struct {
 	Lang   string `json:"lang"`
 }
 
-// Corpus is the verify input: the PromQL queries to replay plus the non-PromQL
-// entries carried through for honest accounting.
+// HarvestSkippedEntry records a corpus entry that `migrate harvest` could not
+// turn into a replayable query (an unreadable file, a YAML parse failure, a rule
+// with no expression). It carries no PromQL to replay, so verify cannot check its
+// parity — but it is reported and counted here rather than dropped, because the
+// operator needs to know these queries never entered the gate at all.
+type HarvestSkippedEntry struct {
+	Source string `json:"source"`
+	Reason string `json:"reason"`
+}
+
+// Corpus is the verify input: the PromQL queries to replay, the non-PromQL
+// entries carried through for honest accounting, and the harvest-time skips the
+// corpus recorded (queries that never became replayable at all).
 type Corpus struct {
-	PromQL     []Query
-	OutOfScope []OutOfScopeEntry
+	PromQL         []Query
+	OutOfScope     []OutOfScopeEntry
+	HarvestSkipped []HarvestSkippedEntry
 }
 
 // QueryResult is the parity verdict for a single replayed query.
@@ -267,26 +280,29 @@ type QueryResult struct {
 
 // Summary counts verdicts across the whole run.
 type Summary struct {
-	Total       int `json:"total"`
-	Match       int `json:"match"`
-	Diverge     int `json:"diverge"`
-	Unsupported int `json:"unsupported"`
-	Error       int `json:"error"`
-	OutOfScope  int `json:"out_of_scope"`
+	Total          int `json:"total"`
+	Match          int `json:"match"`
+	Diverge        int `json:"diverge"`
+	Unsupported    int `json:"unsupported"`
+	Error          int `json:"error"`
+	OutOfScope     int `json:"out_of_scope"`
+	HarvestSkipped int `json:"harvest_skipped"`
 }
 
 // Report is the full parity result: per-query verdicts, the out-of-scope
-// accounting, and the roll-up summary.
+// accounting, the harvest-time skips, and the roll-up summary.
 type Report struct {
-	Summary    Summary           `json:"summary"`
-	Results    []QueryResult     `json:"results"`
-	OutOfScope []OutOfScopeEntry `json:"out_of_scope,omitempty"`
+	Summary        Summary               `json:"summary"`
+	Results        []QueryResult         `json:"results"`
+	OutOfScope     []OutOfScopeEntry     `json:"out_of_scope,omitempty"`
+	HarvestSkipped []HarvestSkippedEntry `json:"harvest_skipped,omitempty"`
 }
 
 // Failed reports whether the gate should exit non-zero: any diverging or erroring
 // query fails it. Unsupported queries are reported but do not fail the gate — an
 // unsupported query is a coverage gap surfaced for the operator, not a wrong
-// answer. Out-of-scope entries never affect the gate.
+// answer. Out-of-scope and harvest-skipped entries never affect the gate: they
+// carry no replayable query, so there is nothing for the comparator to judge.
 func (r Report) Failed() bool {
 	return r.Summary.Diverge > 0 || r.Summary.Error > 0
 }
@@ -316,8 +332,9 @@ type RangeResult struct {
 //   - cerberus non-200 or non-matrix → unsupported;
 //   - otherwise → the comparator's match/diverge verdict.
 func Verify(ctx context.Context, corpus Corpus, ref, cerberus Backend, p Params) Report {
-	rep := Report{OutOfScope: corpus.OutOfScope}
+	rep := Report{OutOfScope: corpus.OutOfScope, HarvestSkipped: corpus.HarvestSkipped}
 	rep.Summary.OutOfScope = len(corpus.OutOfScope)
+	rep.Summary.HarvestSkipped = len(corpus.HarvestSkipped)
 
 	for _, q := range corpus.PromQL {
 		res := verifyOne(ctx, q, ref, cerberus, p)
@@ -349,10 +366,10 @@ func verifyOne(ctx context.Context, q Query, ref, cerberus Backend, p Params) Qu
 		out.Verdict, out.Detail = VerdictError, fmt.Sprintf("reference request failed: %v", refErr)
 	case cerErr != nil:
 		out.Verdict, out.Detail = VerdictError, fmt.Sprintf("cerberus request failed: %v", cerErr)
-	case cerRes.Status != 200 || cerRes.ResultType != resultTypeMatrix:
+	case cerRes.Status != http.StatusOK || cerRes.ResultType != resultTypeMatrix:
 		out.Verdict = VerdictUnsupported
 		out.Detail = fmt.Sprintf("cerberus returned status=%d resultType=%q", cerRes.Status, cerRes.ResultType)
-	case refRes.Status != 200 || refRes.ResultType != resultTypeMatrix:
+	case refRes.Status != http.StatusOK || refRes.ResultType != resultTypeMatrix:
 		out.Verdict = VerdictError
 		out.Detail = fmt.Sprintf("reference returned status=%d resultType=%q (no baseline to compare)", refRes.Status, refRes.ResultType)
 	default:
@@ -375,8 +392,8 @@ func (r Report) WriteText(w io.Writer) error {
 	bw.printf("# A divergence is never allow-listed — the gate fails if any query diverges\n")
 	bw.printf("# or errors.\n")
 	bw.printf("#\n")
-	bw.printf("# %d queries: %d match, %d diverge, %d unsupported, %d error (+%d out of scope)\n\n",
-		r.Summary.Total, r.Summary.Match, r.Summary.Diverge, r.Summary.Unsupported, r.Summary.Error, r.Summary.OutOfScope)
+	bw.printf("# %d queries: %d match, %d diverge, %d unsupported, %d error (+%d out of scope, +%d harvest-skipped)\n\n",
+		r.Summary.Total, r.Summary.Match, r.Summary.Diverge, r.Summary.Unsupported, r.Summary.Error, r.Summary.OutOfScope, r.Summary.HarvestSkipped)
 
 	for _, res := range r.Results {
 		if res.Verdict == VerdictMatch {
@@ -399,6 +416,14 @@ func (r Report) WriteText(w io.Writer) error {
 		bw.printf("== out of scope (%d) — not PromQL, no Prometheus baseline\n", len(r.OutOfScope))
 		for _, e := range r.OutOfScope {
 			bw.printf("   %s: lang=%s\n", e.Source, e.Lang)
+		}
+		bw.printf("\n")
+	}
+
+	if len(r.HarvestSkipped) > 0 {
+		bw.printf("== harvest-skipped (%d) — never became a replayable query, not checked\n", len(r.HarvestSkipped))
+		for _, e := range r.HarvestSkipped {
+			bw.printf("   %s: %s\n", e.Source, e.Reason)
 		}
 		bw.printf("\n")
 	}

--- a/internal/migrateverify/verify_test.go
+++ b/internal/migrateverify/verify_test.go
@@ -135,6 +135,7 @@ func TestVerify_ValueDivergence(t *testing.T) {
 	fd := res.FirstDiff
 	if fd == nil {
 		t.Fatal("diverge must carry a first-diff")
+		return
 	}
 	if fd.Timestamp != 1_700_000_060 {
 		t.Errorf("first-diff ts = %v, want 1700000060 (the first mismatching step)", fd.Timestamp)

--- a/internal/migrateverify/verify_test.go
+++ b/internal/migrateverify/verify_test.go
@@ -273,13 +273,15 @@ func TestVerify_SummaryAndJSON(t *testing.T) {
 	ref := NewHTTPBackend(matrixServer(t, refBody).URL)
 	cer := NewHTTPBackend(matrixServer(t, cerBody).URL)
 	corpus := Corpus{
-		PromQL:     []Query{{Expr: "good", Source: "s1"}, {Expr: "bad", Source: "s2"}},
-		OutOfScope: []OutOfScopeEntry{{Source: "panel:logs", Lang: "logql"}},
+		PromQL:         []Query{{Expr: "good", Source: "s1"}, {Expr: "bad", Source: "s2"}},
+		OutOfScope:     []OutOfScopeEntry{{Source: "panel:logs", Lang: "logql"}},
+		HarvestSkipped: []HarvestSkippedEntry{{Source: "rule:broken.yml", Reason: "rule has an empty expr"}},
 	}
 	rep := Verify(context.Background(), corpus, ref, cer, testParams())
 
-	if rep.Summary.Total != 2 || rep.Summary.Match != 1 || rep.Summary.Diverge != 1 || rep.Summary.OutOfScope != 1 {
-		t.Fatalf("summary = %+v, want total 2 / match 1 / diverge 1 / oos 1", rep.Summary)
+	if rep.Summary.Total != 2 || rep.Summary.Match != 1 || rep.Summary.Diverge != 1 ||
+		rep.Summary.OutOfScope != 1 || rep.Summary.HarvestSkipped != 1 {
+		t.Fatalf("summary = %+v, want total 2 / match 1 / diverge 1 / oos 1 / harvest-skipped 1", rep.Summary)
 	}
 	if !rep.Failed() {
 		t.Error("a run with a divergence must fail the gate")
@@ -296,6 +298,9 @@ func TestVerify_SummaryAndJSON(t *testing.T) {
 	if back.Summary != rep.Summary {
 		t.Errorf("round-tripped summary = %+v, want %+v", back.Summary, rep.Summary)
 	}
+	if len(back.HarvestSkipped) != 1 || back.HarvestSkipped[0].Source != "rule:broken.yml" {
+		t.Errorf("round-tripped harvest-skipped = %+v, want the one broken-rule skip", back.HarvestSkipped)
+	}
 
 	var text strings.Builder
 	if err := rep.WriteText(&text); err != nil {
@@ -306,5 +311,9 @@ func TestVerify_SummaryAndJSON(t *testing.T) {
 	}
 	if !strings.Contains(text.String(), "out of scope") {
 		t.Errorf("text report must account for out-of-scope entries, got:\n%s", text.String())
+	}
+	if !strings.Contains(text.String(), "harvest-skipped") ||
+		!strings.Contains(text.String(), "rule:broken.yml") {
+		t.Errorf("text report must account for harvest-skipped entries, got:\n%s", text.String())
 	}
 }

--- a/internal/migrateverify/verify_test.go
+++ b/internal/migrateverify/verify_test.go
@@ -1,0 +1,310 @@
+package migrateverify
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// matrixServer returns an httptest server that answers /api/v1/query_range with
+// the supplied per-query matrix JSON. A query with no entry gets a 400 with a
+// non-matrix body, so a test can exercise the cerberus-unsupported path.
+func matrixServer(t *testing.T, byQuery map[string]string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Path; got != queryRangePath {
+			t.Errorf("unexpected path %q, want %q", got, queryRangePath)
+		}
+		q := r.URL.Query().Get("query")
+		body, ok := byQuery[q]
+		if !ok {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"status":"error","errorType":"bad_data","error":"unknown query"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// matrix builds a Prometheus matrix response body from a small spec. Each series
+// is a label set plus [ts,"value"] points.
+func matrix(series ...seriesSpec) string {
+	type point [2]any
+	type rawSeries struct {
+		Metric map[string]string `json:"metric"`
+		Values []point           `json:"values"`
+	}
+	out := struct {
+		Status string `json:"status"`
+		Data   struct {
+			ResultType string      `json:"resultType"`
+			Result     []rawSeries `json:"result"`
+		} `json:"data"`
+	}{Status: "success"}
+	out.Data.ResultType = "matrix"
+	for _, s := range series {
+		rs := rawSeries{Metric: s.labels}
+		for _, p := range s.points {
+			rs.Values = append(rs.Values, point{p.ts, p.val})
+		}
+		out.Data.Result = append(out.Data.Result, rs)
+	}
+	b, err := json.Marshal(out)
+	if err != nil {
+		panic(err)
+	}
+	return string(b)
+}
+
+type seriesSpec struct {
+	labels map[string]string
+	points []pointSpec
+}
+
+type pointSpec struct {
+	ts  float64
+	val string
+}
+
+// testParams is a fixed, deterministic window (relative parsing is exercised
+// separately).
+func testParams() Params {
+	return Params{
+		Start:     time.Unix(1_700_000_000, 0).UTC(),
+		End:       time.Unix(1_700_000_600, 0).UTC(),
+		Step:      60 * time.Second,
+		Tolerance: DefaultTolerance,
+	}
+}
+
+func runVerifyOne(t *testing.T, refBody, cerBody map[string]string, q Query) QueryResult {
+	t.Helper()
+	ref := NewHTTPBackend(matrixServer(t, refBody).URL)
+	cer := NewHTTPBackend(matrixServer(t, cerBody).URL)
+	rep := Verify(context.Background(), Corpus{PromQL: []Query{q}}, ref, cer, testParams())
+	if len(rep.Results) != 1 {
+		t.Fatalf("want 1 result, got %d", len(rep.Results))
+	}
+	return rep.Results[0]
+}
+
+// TestVerify_Match: identical matrices from both backends → match, no first-diff,
+// gate passes.
+func TestVerify_Match(t *testing.T) {
+	body := map[string]string{
+		"up": matrix(seriesSpec{
+			labels: map[string]string{"__name__": "up", "job": "api"},
+			points: []pointSpec{{1_700_000_000, "1"}, {1_700_000_060, "1"}},
+		}),
+	}
+	res := runVerifyOne(t, body, body, Query{Expr: "up", Source: "rule:up"})
+	if res.Verdict != VerdictMatch {
+		t.Fatalf("verdict = %q, want match (detail: %s)", res.Verdict, res.Detail)
+	}
+	if res.FirstDiff != nil {
+		t.Fatalf("match must have no first-diff, got %+v", res.FirstDiff)
+	}
+}
+
+// TestVerify_ValueDivergence: same series, one differing value → diverge, with
+// the first differing point captured exactly, and the gate fails.
+func TestVerify_ValueDivergence(t *testing.T) {
+	refBody := map[string]string{
+		"rate(x[1m])": matrix(seriesSpec{
+			labels: map[string]string{"job": "api"},
+			points: []pointSpec{{1_700_000_000, "1"}, {1_700_000_060, "2"}, {1_700_000_120, "3"}},
+		}),
+	}
+	cerBody := map[string]string{
+		"rate(x[1m])": matrix(seriesSpec{
+			labels: map[string]string{"job": "api"},
+			points: []pointSpec{{1_700_000_000, "1"}, {1_700_000_060, "2.5"}, {1_700_000_120, "3"}},
+		}),
+	}
+	res := runVerifyOne(t, refBody, cerBody, Query{Expr: "rate(x[1m])", Source: "rule:r"})
+	if res.Verdict != VerdictDiverge {
+		t.Fatalf("verdict = %q, want diverge", res.Verdict)
+	}
+	fd := res.FirstDiff
+	if fd == nil {
+		t.Fatal("diverge must carry a first-diff")
+	}
+	if fd.Timestamp != 1_700_000_060 {
+		t.Errorf("first-diff ts = %v, want 1700000060 (the first mismatching step)", fd.Timestamp)
+	}
+	if fd.RefValue != "2" || fd.CerberusValue != "2.5" {
+		t.Errorf("first-diff values = ref %q / cerberus %q, want 2 / 2.5", fd.RefValue, fd.CerberusValue)
+	}
+	rep := Report{Summary: Summary{Diverge: 1}}
+	if !rep.Failed() {
+		t.Error("a divergence must fail the gate")
+	}
+}
+
+// TestVerify_MissingSeries: cerberus omits a series the reference returned → that
+// is itself a divergence (never a silent skip).
+func TestVerify_MissingSeries(t *testing.T) {
+	refBody := map[string]string{
+		"q": matrix(
+			seriesSpec{labels: map[string]string{"job": "a"}, points: []pointSpec{{1_700_000_000, "1"}}},
+			seriesSpec{labels: map[string]string{"job": "b"}, points: []pointSpec{{1_700_000_000, "2"}}},
+		),
+	}
+	cerBody := map[string]string{
+		"q": matrix(
+			seriesSpec{labels: map[string]string{"job": "a"}, points: []pointSpec{{1_700_000_000, "1"}}},
+		),
+	}
+	res := runVerifyOne(t, refBody, cerBody, Query{Expr: "q", Source: "rule:q"})
+	if res.Verdict != VerdictDiverge {
+		t.Fatalf("verdict = %q, want diverge", res.Verdict)
+	}
+	if res.FirstDiff == nil || !strings.Contains(res.FirstDiff.Reason, "reference only") {
+		t.Fatalf("first-diff should flag the missing series as reference-only, got %+v", res.FirstDiff)
+	}
+	if res.FirstDiff.CerberusValue != "<missing series>" {
+		t.Errorf("missing-series diff should mark cerberus side missing, got %q", res.FirstDiff.CerberusValue)
+	}
+}
+
+// TestVerify_EpsilonBoundary: a diff exactly at tolerance matches; a diff just
+// beyond it diverges.
+func TestVerify_EpsilonBoundary(t *testing.T) {
+	// tol and the sample values are exactly representable in float64 (halves), so
+	// the boundary comparison is not clouded by decimal-to-binary rounding.
+	const tol = 0.5
+	mk := func(v string) map[string]string {
+		return map[string]string{"q": matrix(seriesSpec{
+			labels: map[string]string{"job": "a"},
+			points: []pointSpec{{1_700_000_000, v}},
+		})}
+	}
+	p := testParams()
+	p.Tolerance = tol
+
+	// Exactly at the boundary: |0 - 0.5| == tol → within tolerance → match.
+	ref := NewHTTPBackend(matrixServer(t, mk("0")).URL)
+	cerAtBoundary := NewHTTPBackend(matrixServer(t, mk("0.5")).URL)
+	rep := Verify(context.Background(), Corpus{PromQL: []Query{{Expr: "q", Source: "s"}}}, ref, cerAtBoundary, p)
+	if rep.Results[0].Verdict != VerdictMatch {
+		t.Errorf("diff exactly at tolerance should match, got %q", rep.Results[0].Verdict)
+	}
+
+	// Just beyond the boundary: |0 - 0.75| > tol → diverge.
+	cerBeyond := NewHTTPBackend(matrixServer(t, mk("0.75")).URL)
+	rep = Verify(context.Background(), Corpus{PromQL: []Query{{Expr: "q", Source: "s"}}}, ref, cerBeyond, p)
+	if rep.Results[0].Verdict != VerdictDiverge {
+		t.Errorf("diff beyond tolerance should diverge, got %q", rep.Results[0].Verdict)
+	}
+}
+
+// TestVerify_NaNEqual: both backends report NaN at the same step → equal, match.
+func TestVerify_NaNEqual(t *testing.T) {
+	body := map[string]string{
+		"q": matrix(seriesSpec{
+			labels: map[string]string{"job": "a"},
+			points: []pointSpec{{1_700_000_000, "NaN"}, {1_700_000_060, "5"}},
+		}),
+	}
+	res := runVerifyOne(t, body, body, Query{Expr: "q", Source: "s"})
+	if res.Verdict != VerdictMatch {
+		t.Fatalf("NaN==NaN should be treated as equal, got %q (diff %+v)", res.Verdict, res.FirstDiff)
+	}
+}
+
+// TestVerify_CerberusUnsupported: cerberus returns a 400 (non-matrix) → the query
+// is classified unsupported, the reference is untouched, and the gate does NOT
+// fail on an unsupported query alone.
+func TestVerify_CerberusUnsupported(t *testing.T) {
+	refBody := map[string]string{
+		"histogram_quantile(0.9, x)": matrix(seriesSpec{
+			labels: map[string]string{"job": "a"},
+			points: []pointSpec{{1_700_000_000, "1"}},
+		}),
+	}
+	// cerBody has no entry for the query → matrixServer answers 400.
+	res := runVerifyOne(t, refBody, map[string]string{}, Query{Expr: "histogram_quantile(0.9, x)", Source: "panel:x"})
+	if res.Verdict != VerdictUnsupported {
+		t.Fatalf("verdict = %q, want unsupported", res.Verdict)
+	}
+	if !strings.Contains(res.Detail, "status=400") {
+		t.Errorf("unsupported detail should name the cerberus status, got %q", res.Detail)
+	}
+	rep := Report{Summary: Summary{Unsupported: 1}}
+	if rep.Failed() {
+		t.Error("an unsupported query alone must not fail the gate")
+	}
+}
+
+// TestVerify_ReferenceError: the reference returns non-200 → error verdict (no
+// baseline to compare), which DOES fail the gate.
+func TestVerify_ReferenceError(t *testing.T) {
+	cerBody := map[string]string{
+		"q": matrix(seriesSpec{labels: map[string]string{"job": "a"}, points: []pointSpec{{1_700_000_000, "1"}}}),
+	}
+	res := runVerifyOne(t, map[string]string{}, cerBody, Query{Expr: "q", Source: "s"})
+	if res.Verdict != VerdictError {
+		t.Fatalf("verdict = %q, want error", res.Verdict)
+	}
+	rep := Report{Summary: Summary{Error: 1}}
+	if !rep.Failed() {
+		t.Error("an error verdict must fail the gate")
+	}
+}
+
+// TestVerify_SummaryAndJSON: a mixed run rolls up the right counts and the JSON
+// report round-trips.
+func TestVerify_SummaryAndJSON(t *testing.T) {
+	refBody := map[string]string{
+		"good": matrix(seriesSpec{labels: map[string]string{"j": "a"}, points: []pointSpec{{1_700_000_000, "1"}}}),
+		"bad":  matrix(seriesSpec{labels: map[string]string{"j": "a"}, points: []pointSpec{{1_700_000_000, "1"}}}),
+	}
+	cerBody := map[string]string{
+		"good": matrix(seriesSpec{labels: map[string]string{"j": "a"}, points: []pointSpec{{1_700_000_000, "1"}}}),
+		"bad":  matrix(seriesSpec{labels: map[string]string{"j": "a"}, points: []pointSpec{{1_700_000_000, "9"}}}),
+	}
+	ref := NewHTTPBackend(matrixServer(t, refBody).URL)
+	cer := NewHTTPBackend(matrixServer(t, cerBody).URL)
+	corpus := Corpus{
+		PromQL:     []Query{{Expr: "good", Source: "s1"}, {Expr: "bad", Source: "s2"}},
+		OutOfScope: []OutOfScopeEntry{{Source: "panel:logs", Lang: "logql"}},
+	}
+	rep := Verify(context.Background(), corpus, ref, cer, testParams())
+
+	if rep.Summary.Total != 2 || rep.Summary.Match != 1 || rep.Summary.Diverge != 1 || rep.Summary.OutOfScope != 1 {
+		t.Fatalf("summary = %+v, want total 2 / match 1 / diverge 1 / oos 1", rep.Summary)
+	}
+	if !rep.Failed() {
+		t.Error("a run with a divergence must fail the gate")
+	}
+
+	var buf strings.Builder
+	if err := rep.WriteJSON(&buf); err != nil {
+		t.Fatalf("WriteJSON: %v", err)
+	}
+	var back Report
+	if err := json.Unmarshal([]byte(buf.String()), &back); err != nil {
+		t.Fatalf("JSON report should round-trip: %v", err)
+	}
+	if back.Summary != rep.Summary {
+		t.Errorf("round-tripped summary = %+v, want %+v", back.Summary, rep.Summary)
+	}
+
+	var text strings.Builder
+	if err := rep.WriteText(&text); err != nil {
+		t.Fatalf("WriteText: %v", err)
+	}
+	if !strings.Contains(text.String(), "FAIL:") {
+		t.Errorf("text report of a failing run must announce FAIL, got:\n%s", text.String())
+	}
+	if !strings.Contains(text.String(), "out of scope") {
+		t.Errorf("text report must account for out-of-scope entries, got:\n%s", text.String())
+	}
+}


### PR DESCRIPTION
## What

Adds `migrate verify` — the online cutover **parity gate**. It replays each PromQL query from a harvested `corpus.json` against a **reference Prometheus** AND **cerberus** over one `query_range` window and diffs the results series-by-series, so an operator can prove — before flipping a datasource — that cerberus returns the same numbers Prometheus does for the queries they actually run.

```
migrate verify --corpus corpus.json \
  --ref http://prometheus:9090 --cerberus http://cerberus:9090 \
  --start -1h --end now --step 60s [--tolerance 1e-9] [--json]
```

Flags fall back to `CERBERUS_VERIFY_*` env (`_CORPUS`, `_REF`, `_CERBERUS`, `_START`, `_END`, `_STEP`, `_TOLERANCE`).

## How

New `internal/migrateverify` package:

- **HTTP client** — issues identical `GET /api/v1/query_range` to each backend and parses the standard Prometheus matrix envelope (`status`, `data.resultType`, `data.result[].metric` + `.values [[ts,"val"],...]`). A non-200 is carried as a *status* (not a transport error) so the caller can tell unsupported from error.
- **Net-new Go comparator** — the compat harness's differ is an external Docker binary, not reusable Go, so this is genuinely from-scratch: match series by canonical label set, step-align samples by timestamp, compare values within an absolute tolerance with **NaN==NaN treated as equal**. First-diff is deterministic (sorted series, then sorted timestamps). A series present in **only one** backend is itself a divergence — reported, never a silent skip.
- **Verdicts** — every query lands in exactly one of: `match` / `diverge` / `unsupported` (cerberus non-200 or non-matrix) / `error` (reference failed, or a transport/decode fault — nothing to compare). Values render as strings so `NaN`/`Inf` survive both the human and `--json` report.

`cmd/migrate verify` loads the corpus (PromQL replayed; non-PromQL dashboard entries carried through as *out-of-scope*, **counted not dropped**) and **exits non-zero if any query diverges or errors** (dedicated exit code 2). A divergence is **never allow-listed**.

## Honesty

- Only claims a match where **both** backends returned matrix data that agrees.
- A series in one backend only → divergence with its first-diff.
- Non-PromQL corpus entries are reported as out-of-scope (a Prometheus gate can't judge LogQL), never silently omitted.

## Arch-lint

`migrateverify` declared in `.go-arch-lint.yml`, depending only on `migrate` (for the corpus format `Corpus` / `CorpusQuery` / `LangPromQL`). The comparator + HTTP client are stdlib-only. It does not reach into engine / chsql / handler layers — it talks to both backends over HTTP.

## Tests

Comparator + client driven by `httptest` servers returning crafted matrices, all deterministic (fixed window/timestamps):

- match (identical matrices)
- value-divergence with the exact first-diff point captured
- missing-series divergence (reference-only series)
- epsilon boundary (exactly-representable halves: at-tolerance matches, beyond diverges)
- NaN==NaN equality
- cerberus-side unsupported (400 → does **not** fail the gate on its own)
- reference error (non-200 → **does** fail the gate)
- summary roll-up + JSON round-trip + text PASS/FAIL
- cmd end-to-end via httptest: match passes, diverge returns `verifyFailedError`, `--json`, missing-flags error, `CERBERUS_VERIFY_*` env fallback
- time/params parsing (RFC3339, Unix, `now`, `-1h`, `now-15m`, `+30m`; rejects bad input, end-before-start, non-positive/unparseable step)
- corpus load (version check, PromQL vs out-of-scope split, malformed/missing-file/wrong-version errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
