### PR TITLE
feat(migrate): inventory — cardinality + churn from the source Prometheus

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -162,6 +162,10 @@ components:
   # Prometheus + cerberus and diffs the query_range results. Reuses the migrate
   # corpus format to read the harvested corpus.json. Wired from cmd/migrate only.
   migrateverify:  { in: migrateverify }
+  # Live cardinality probe: reads the source Prometheus TSDB status over HTTP and
+  # ranks the top-N metrics/labels by cardinality (the offline-invisible OOM
+  # risk). Leaf, stdlib-only — no internal deps. Wired from cmd/migrate only.
+  migrateinventory: { in: migrateinventory }
   # Leaf yaml.v3 decode of Prometheus rule files (record/alert exprs). No
   # internal deps — deliberately avoids prometheus/rulefmt's ~112-package pull.
   promrules:      { in: promrules }

--- a/cmd/migrate/inventory.go
+++ b/cmd/migrate/inventory.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"io"
+
+	"github.com/tsouza/cerberus/internal/migrateinventory"
+)
+
+// runInventory probes a LIVE source Prometheus for the runtime cardinality
+// facts config can't reveal offline — the head-block series/label cardinality
+// that drives OOM risk — ranks the top-N candidates, and writes the report.
+// It deliberately refuses to infer from prometheus.yml: the only honest source
+// of realized cardinality is the running TSDB. Flags fall back to
+// CERBERUS_INVENTORY_* environment variables. A source that 404s the mandatory
+// /api/v1/status/tsdb endpoint is a hard error mapped to a non-zero exit.
+func runInventory(args []string, stdout, stderr io.Writer) error {
+	fs := flag.NewFlagSet("migrate inventory", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var (
+		source = fs.String("source", envOr("CERBERUS_INVENTORY_SOURCE", ""),
+			"source Prometheus base URL to probe for live cardinality")
+		top = fs.Int("top", migrateinventory.DefaultTop,
+			"rank the top N metrics/labels by cardinality")
+		window = fs.String("window", envOr("CERBERUS_INVENTORY_WINDOW", ""),
+			"optional observation window (duration like 1h) recorded as report context")
+		asJSON = fs.Bool("json", false, "emit the machine-readable JSON report instead of text")
+	)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *source == "" {
+		return errors.New("missing --source (or CERBERUS_INVENTORY_SOURCE): the source Prometheus base URL to probe")
+	}
+
+	opts := migrateinventory.Options{Top: *top, Window: *window}
+	if err := opts.Validate(); err != nil {
+		return err
+	}
+
+	inv, err := migrateinventory.NewClient(*source).Probe(context.Background(), opts)
+	if err != nil {
+		return err
+	}
+	if *asJSON {
+		return inv.WriteJSON(stdout)
+	}
+	return inv.WriteText(stdout)
+}

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -11,6 +11,8 @@
 //	migrate explain --corpus corpus.json       # explain a previously-harvested corpus
 //	migrate verify --corpus corpus.json \       # replay the corpus against a reference
 //	  --ref <prom-url> --cerberus <url>          #   Prometheus and cerberus and diff (parity gate)
+//	migrate inventory --source <prom-url>        # probe the LIVE source Prometheus for the
+//	  --top 50                                    #   cardinality that drives OOM risk
 //
 // --schema reads the SAME CERBERUS_* environment the server uses
 // (config.FromEnv), so the previewed schema is byte-identical to what the
@@ -33,6 +35,15 @@
 // harvested corpus against a reference Prometheus AND cerberus over one
 // query_range window and diffs the results series-by-series. It exits non-zero
 // if any query diverges or errors — a divergence is never allow-listed.
+//
+// inventory probes the LIVE source Prometheus for the runtime cardinality facts
+// config can't reveal offline: it calls /api/v1/status/tsdb (plus optional
+// /api/v1/label/__name__/values and /api/v1/metadata) and ranks the top-N
+// metrics by series count and labels by cardinality — the OOM candidates
+// cerberus can't see before cutover. It refuses to infer from prometheus.yml
+// (scrape config is not realized cardinality). The numbers RANK RISK; they do
+// not predict cerberus's exact memory. A source that 404s the status endpoint
+// exits non-zero.
 package main
 
 import (
@@ -117,6 +128,8 @@ func run(args []string, stdout, stderr io.Writer) error {
 			return runExplainCmd(args[1:], stdout, stderr)
 		case "verify":
 			return runVerify(args[1:], stdout, stderr)
+		case "inventory":
+			return runInventory(args[1:], stdout, stderr)
 		}
 	}
 

--- a/internal/migrateinventory/inventory.go
+++ b/internal/migrateinventory/inventory.go
@@ -1,0 +1,309 @@
+// Package migrateinventory probes a LIVE source Prometheus for the runtime
+// cardinality facts that a migration preview cannot learn offline. Cerberus's
+// offline `migrate explain` can show the SQL and physical tables a query
+// touches, but the one thing that actually drives ClickHouse memory risk —
+// how many series a metric fans out to, how wide a label is — is data, not
+// config, and it lives only in the running TSDB.
+//
+// This package deliberately REFUSES to infer cardinality from prometheus.yml:
+// scrape config lists targets and relabel rules, not the realized series count
+// after those rules run against real endpoints. The only honest source is the
+// TSDB itself, so `inventory` calls the source Prometheus HTTP API
+// (/api/v1/status/tsdb) and ranks the head-block cardinality.
+//
+// Honesty contract: everything here is a SOURCE-Prometheus runtime fact. It
+// ranks OOM RISK — a high-cardinality metric is a candidate that cerberus can't
+// see offline — it does NOT predict cerberus's exact memory. The report says so
+// in its own words. Optional enrichment endpoints that fail are COUNTED and
+// surfaced as notes, never silently dropped.
+package migrateinventory
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// DefaultTop is the number of highest-cardinality metrics and labels ranked
+// when --top is not supplied. It is a readable slice of the risk surface — big
+// enough to catch the fat tail, small enough to scan by eye.
+const DefaultTop = 50
+
+// defaultHTTPTimeout bounds a single probe request so one hung source can't
+// stall the whole inventory.
+const defaultHTTPTimeout = 30 * time.Second
+
+// Prometheus HTTP API paths the probe talks to. status/tsdb is the mandatory
+// cardinality source; the label-names and metadata endpoints are optional
+// enrichment.
+const (
+	statusTSDBPath       = "/api/v1/status/tsdb"
+	metricNamesPath      = "/api/v1/label/__name__/values"
+	metadataPath         = "/api/v1/metadata"
+	promStatusSuccessful = "success"
+)
+
+// Options controls a probe: how many entries to rank and an optional
+// operator-declared observation window recorded as report context.
+type Options struct {
+	// Top ranks the highest-cardinality N metrics and labels. Must be > 0.
+	Top int
+	// Window, when set, is a duration string recorded verbatim in the report
+	// as the operator's churn-reasoning context. TSDB status is a point-in-time
+	// head snapshot, so this frames the numbers; it is not a server-side filter.
+	Window string
+}
+
+// Validate checks the options are usable before any request is issued.
+func (o Options) Validate() error {
+	if o.Top <= 0 {
+		return fmt.Errorf("top must be positive, got %d", o.Top)
+	}
+	if o.Window != "" {
+		if _, err := time.ParseDuration(o.Window); err != nil {
+			return fmt.Errorf("window %q is not a valid duration: %w", o.Window, err)
+		}
+	}
+	return nil
+}
+
+// NameValue is one {name, value} cardinality pair from a TSDB status array —
+// a metric name to its series count, or a label name to its value cardinality
+// or memory footprint.
+type NameValue struct {
+	Name  string `json:"name"`
+	Value int64  `json:"value"`
+}
+
+// HeadStats mirrors Prometheus TSDB headStats: the size of the in-memory head
+// block that every query reads from.
+type HeadStats struct {
+	NumSeries     int64 `json:"numSeries"`
+	NumLabelPairs int64 `json:"numLabelPairs"`
+	ChunkCount    int64 `json:"chunkCount"`
+	MinTime       int64 `json:"minTime"`
+	MaxTime       int64 `json:"maxTime"`
+}
+
+// tsdbStatusResponse is the /api/v1/status/tsdb JSON envelope.
+type tsdbStatusResponse struct {
+	Status string `json:"status"`
+	Data   struct {
+		HeadStats                  HeadStats   `json:"headStats"`
+		SeriesCountByMetricName    []NameValue `json:"seriesCountByMetricName"`
+		LabelValueCountByLabelName []NameValue `json:"labelValueCountByLabelName"`
+		MemoryInBytesByLabelName   []NameValue `json:"memoryInBytesByLabelName"`
+	} `json:"data"`
+	ErrorType string `json:"errorType"`
+	Error     string `json:"error"`
+}
+
+// Inventory is the ranked risk picture of the source Prometheus head block.
+// Every field is a source-Prometheus runtime fact; none predicts cerberus's
+// memory. It ranks candidates worth reviewing before cutover.
+type Inventory struct {
+	Source string `json:"source"`
+	Window string `json:"window,omitempty"`
+	Top    int    `json:"top"`
+
+	Head HeadStats `json:"head"`
+
+	// TopMetricsBySeries ranks the metrics whose head series count is highest —
+	// the OOM candidates a fan-out query would materialize.
+	TopMetricsBySeries []NameValue `json:"topMetricsBySeriesCount"`
+	// TopLabelsByValues ranks label names by distinct value cardinality — wide
+	// labels drive group-by and join fan-out.
+	TopLabelsByValues []NameValue `json:"topLabelsByValueCardinality"`
+	// TopLabelsByMemory ranks label names by head memory footprint (bytes).
+	TopLabelsByMemory []NameValue `json:"topLabelsByMemoryBytes"`
+
+	// MetricNameTotal is the total distinct metric-name count from the optional
+	// /label/__name__/values enrichment. -1 means the enrichment was not
+	// obtained (see Notes for why).
+	MetricNameTotal int `json:"metricNameTotal"`
+	// MetadataMetricTotal is the count of metrics carrying metadata from the
+	// optional /metadata enrichment. -1 means it was not obtained.
+	MetadataMetricTotal int `json:"metadataMetricTotal"`
+
+	// Notes surfaces every optional-enrichment failure and honesty caveat. An
+	// enrichment that could not be fetched is recorded here — counted, never
+	// silently dropped.
+	Notes []string `json:"notes,omitempty"`
+}
+
+// Client probes a Prometheus-compatible HTTP API for TSDB cardinality.
+type Client struct {
+	BaseURL string
+	HTTP    *http.Client
+}
+
+// NewClient builds a probe client for baseURL with a bounded default client.
+func NewClient(baseURL string) *Client {
+	return &Client{
+		BaseURL: strings.TrimRight(baseURL, "/"),
+		HTTP:    &http.Client{Timeout: defaultHTTPTimeout},
+	}
+}
+
+// Probe fetches and ranks the source Prometheus TSDB cardinality. The mandatory
+// /api/v1/status/tsdb call drives the result: a transport failure, a non-200
+// (a source that 404s the endpoint), or an unparseable body is a hard error the
+// caller surfaces and exits non-zero on. The optional metric-name and metadata
+// enrichments never abort the probe — their failures land in Notes.
+func (c *Client) Probe(ctx context.Context, opts Options) (Inventory, error) {
+	if err := opts.Validate(); err != nil {
+		return Inventory{}, err
+	}
+
+	status, err := c.fetchTSDBStatus(ctx, opts.Top)
+	if err != nil {
+		return Inventory{}, err
+	}
+
+	inv := Inventory{
+		Source:              c.BaseURL,
+		Window:              opts.Window,
+		Top:                 opts.Top,
+		Head:                status.Data.HeadStats,
+		TopMetricsBySeries:  rankTopN(status.Data.SeriesCountByMetricName, opts.Top),
+		TopLabelsByValues:   rankTopN(status.Data.LabelValueCountByLabelName, opts.Top),
+		TopLabelsByMemory:   rankTopN(status.Data.MemoryInBytesByLabelName, opts.Top),
+		MetricNameTotal:     -1,
+		MetadataMetricTotal: -1,
+	}
+
+	// Optional enrichment: a total distinct metric-name count. A failure here is
+	// recorded, not fatal — the ranked head cardinality already stands on its own.
+	if total, err := c.fetchMetricNameTotal(ctx); err != nil {
+		inv.Notes = append(inv.Notes, fmt.Sprintf("metric-name total unavailable (%s): %v", metricNamesPath, err))
+	} else {
+		inv.MetricNameTotal = total
+	}
+
+	// Optional enrichment: how many metrics publish metadata (help/type).
+	if total, err := c.fetchMetadataTotal(ctx); err != nil {
+		inv.Notes = append(inv.Notes, fmt.Sprintf("metadata total unavailable (%s): %v", metadataPath, err))
+	} else {
+		inv.MetadataMetricTotal = total
+	}
+
+	return inv, nil
+}
+
+// fetchTSDBStatus issues GET {base}/api/v1/status/tsdb?limit=top and decodes it.
+// The limit param asks Prometheus for at least `top` entries per array so the
+// local ranking has enough to rank; older servers that ignore it are fine
+// because rankTopN re-sorts and truncates whatever it receives.
+func (c *Client) fetchTSDBStatus(ctx context.Context, top int) (tsdbStatusResponse, error) {
+	q := url.Values{}
+	q.Set("limit", strconv.Itoa(top))
+	body, err := c.getOK(ctx, statusTSDBPath+"?"+q.Encode())
+	if err != nil {
+		return tsdbStatusResponse{}, err
+	}
+	var raw tsdbStatusResponse
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return tsdbStatusResponse{}, fmt.Errorf("decode %s response: %w", statusTSDBPath, err)
+	}
+	if raw.Status != promStatusSuccessful {
+		return tsdbStatusResponse{}, fmt.Errorf("%s returned status %q: %s: %s",
+			statusTSDBPath, raw.Status, raw.ErrorType, raw.Error)
+	}
+	return raw, nil
+}
+
+// metricNamesResponse is the /api/v1/label/__name__/values envelope.
+type metricNamesResponse struct {
+	Status string   `json:"status"`
+	Data   []string `json:"data"`
+}
+
+// fetchMetricNameTotal returns the count of distinct metric names.
+func (c *Client) fetchMetricNameTotal(ctx context.Context) (int, error) {
+	body, err := c.getOK(ctx, metricNamesPath)
+	if err != nil {
+		return 0, err
+	}
+	var raw metricNamesResponse
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return 0, fmt.Errorf("decode response: %w", err)
+	}
+	if raw.Status != promStatusSuccessful {
+		return 0, fmt.Errorf("status %q", raw.Status)
+	}
+	return len(raw.Data), nil
+}
+
+// metadataResponse is the /api/v1/metadata envelope: a map of metric name to
+// its metadata entries.
+type metadataResponse struct {
+	Status string                       `json:"status"`
+	Data   map[string][]json.RawMessage `json:"data"`
+}
+
+// fetchMetadataTotal returns the count of metrics that publish metadata.
+func (c *Client) fetchMetadataTotal(ctx context.Context) (int, error) {
+	body, err := c.getOK(ctx, metadataPath)
+	if err != nil {
+		return 0, err
+	}
+	var raw metadataResponse
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return 0, fmt.Errorf("decode response: %w", err)
+	}
+	if raw.Status != promStatusSuccessful {
+		return 0, fmt.Errorf("status %q", raw.Status)
+	}
+	return len(raw.Data), nil
+}
+
+// getOK issues GET {base}{path} and returns the body only on a 200. A non-200
+// (including a 404 of an endpoint an old Prometheus lacks) is an error carrying
+// the status, so the caller can surface it and exit non-zero.
+func (c *Client) getOK(ctx context.Context, path string) ([]byte, error) {
+	reqURL := c.BaseURL + path
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request %s: %w", path, err)
+	}
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("GET %s: %w", path, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read %s body: %w", path, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GET %s: HTTP %d", path, resp.StatusCode)
+	}
+	return body, nil
+}
+
+// rankTopN sorts a cardinality array by value descending (ties broken by name
+// ascending for determinism) and truncates to top. It does not trust the
+// server's ordering or truncation — it re-ranks whatever it received so the
+// report is stable regardless of the source Prometheus version.
+func rankTopN(in []NameValue, top int) []NameValue {
+	out := make([]NameValue, len(in))
+	copy(out, in)
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Value != out[j].Value {
+			return out[i].Value > out[j].Value
+		}
+		return out[i].Name < out[j].Name
+	})
+	if len(out) > top {
+		out = out[:top]
+	}
+	return out
+}

--- a/internal/migrateinventory/inventory_test.go
+++ b/internal/migrateinventory/inventory_test.go
@@ -1,0 +1,257 @@
+package migrateinventory
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// syntheticTSDB is a fixed /api/v1/status/tsdb payload whose arrays are
+// deliberately out of value order, so the test proves the client re-ranks
+// rather than trusting the server's ordering.
+const syntheticTSDB = `{
+  "status": "success",
+  "data": {
+    "headStats": {
+      "numSeries": 508,
+      "numLabelPairs": 1234,
+      "chunkCount": 937,
+      "minTime": 1700000000000,
+      "maxTime": 1700003600000
+    },
+    "seriesCountByMetricName": [
+      {"name": "http_requests_total", "value": 300},
+      {"name": "node_cpu_seconds_total", "value": 900},
+      {"name": "go_gc_duration_seconds", "value": 120}
+    ],
+    "labelValueCountByLabelName": [
+      {"name": "instance", "value": 40},
+      {"name": "__name__", "value": 210},
+      {"name": "job", "value": 12}
+    ],
+    "memoryInBytesByLabelName": [
+      {"name": "__name__", "value": 24000},
+      {"name": "instance", "value": 8000}
+    ]
+  }
+}`
+
+// tsdbServer answers /api/v1/status/tsdb with the synthetic payload and the
+// optional enrichment endpoints, so the probe can be driven over real HTTP.
+func tsdbServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case statusTSDBPath:
+			_, _ = w.Write([]byte(syntheticTSDB))
+		case metricNamesPath:
+			_, _ = w.Write([]byte(`{"status":"success","data":["http_requests_total","node_cpu_seconds_total","go_gc_duration_seconds"]}`))
+		case metadataPath:
+			_, _ = w.Write([]byte(`{"status":"success","data":{"http_requests_total":[{"type":"counter"}],"node_cpu_seconds_total":[{"type":"counter"}]}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestProbe_RanksTopN drives the full probe over httptest and asserts the
+// ranking (highest series/value/memory first), the head stats, and the
+// enrichment totals.
+func TestProbe_RanksTopN(t *testing.T) {
+	srv := tsdbServer(t)
+	inv, err := NewClient(srv.URL).Probe(context.Background(), Options{Top: 2})
+	if err != nil {
+		t.Fatalf("Probe: %v", err)
+	}
+
+	if inv.Head.NumSeries != 508 || inv.Head.ChunkCount != 937 {
+		t.Errorf("head = %+v, want numSeries 508 / chunks 937", inv.Head)
+	}
+
+	// Top 2 metrics by series, ranked descending: node_cpu (900) then http (300).
+	if len(inv.TopMetricsBySeries) != 2 {
+		t.Fatalf("top metrics = %d, want 2 (truncated to --top)", len(inv.TopMetricsBySeries))
+	}
+	if inv.TopMetricsBySeries[0].Name != "node_cpu_seconds_total" || inv.TopMetricsBySeries[0].Value != 900 {
+		t.Errorf("rank #1 metric = %+v, want node_cpu_seconds_total=900", inv.TopMetricsBySeries[0])
+	}
+	if inv.TopMetricsBySeries[1].Name != "http_requests_total" {
+		t.Errorf("rank #2 metric = %+v, want http_requests_total", inv.TopMetricsBySeries[1])
+	}
+
+	// Top 2 labels by value cardinality: __name__ (210) then instance (40).
+	if inv.TopLabelsByValues[0].Name != "__name__" || inv.TopLabelsByValues[0].Value != 210 {
+		t.Errorf("rank #1 label = %+v, want __name__=210", inv.TopLabelsByValues[0])
+	}
+
+	// Memory ranking: __name__ (24000) first.
+	if inv.TopLabelsByMemory[0].Name != "__name__" || inv.TopLabelsByMemory[0].Value != 24000 {
+		t.Errorf("rank #1 label-memory = %+v, want __name__=24000", inv.TopLabelsByMemory[0])
+	}
+
+	if inv.MetricNameTotal != 3 {
+		t.Errorf("metric-name total = %d, want 3", inv.MetricNameTotal)
+	}
+	if inv.MetadataMetricTotal != 2 {
+		t.Errorf("metadata total = %d, want 2", inv.MetadataMetricTotal)
+	}
+	if len(inv.Notes) != 0 {
+		t.Errorf("expected no notes when all endpoints answer, got %v", inv.Notes)
+	}
+}
+
+// TestProbe_404OnStatusIsError: a source that 404s /status/tsdb is a hard error
+// (the caller exits non-zero), not a silently empty inventory.
+func TestProbe_404OnStatusIsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := NewClient(srv.URL).Probe(context.Background(), Options{Top: 10})
+	if err == nil {
+		t.Fatal("Probe should error when /status/tsdb 404s")
+	}
+	if !strings.Contains(err.Error(), "404") {
+		t.Errorf("error should name the 404 status, got: %v", err)
+	}
+}
+
+// TestProbe_EnrichmentFailuresAreCounted: when the mandatory status endpoint
+// answers but the optional enrichments 404, the probe still succeeds and every
+// missing enrichment is COUNTED as a note (never silently dropped) with its
+// total left at the -1 "not obtained" sentinel.
+func TestProbe_EnrichmentFailuresAreCounted(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == statusTSDBPath {
+			_, _ = w.Write([]byte(syntheticTSDB))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+
+	inv, err := NewClient(srv.URL).Probe(context.Background(), Options{Top: 10})
+	if err != nil {
+		t.Fatalf("Probe should succeed on status alone, got: %v", err)
+	}
+	if inv.MetricNameTotal != -1 || inv.MetadataMetricTotal != -1 {
+		t.Errorf("failed enrichments should stay at -1, got names=%d metadata=%d",
+			inv.MetricNameTotal, inv.MetadataMetricTotal)
+	}
+	if len(inv.Notes) != 2 {
+		t.Errorf("both enrichment failures should be counted as notes, got %d: %v", len(inv.Notes), inv.Notes)
+	}
+}
+
+// TestProbe_StatusErrorBodyIsError: a 200 whose JSON status is "error" is
+// surfaced, not treated as an empty-but-valid inventory.
+func TestProbe_StatusErrorBodyIsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == statusTSDBPath {
+			_, _ = w.Write([]byte(`{"status":"error","errorType":"bad_data","error":"limit too high"}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := NewClient(srv.URL).Probe(context.Background(), Options{Top: 10})
+	if err == nil || !strings.Contains(err.Error(), "limit too high") {
+		t.Errorf("Probe should surface the source error body, got: %v", err)
+	}
+}
+
+// TestOptionsValidate pins the input guards: top must be positive; a set window
+// must be a valid duration.
+func TestOptionsValidate(t *testing.T) {
+	if err := (Options{Top: 0}).Validate(); err == nil {
+		t.Error("Top=0 should be rejected")
+	}
+	if err := (Options{Top: 10, Window: "banana"}).Validate(); err == nil {
+		t.Error("an unparseable window should be rejected")
+	}
+	if err := (Options{Top: 10, Window: "1h"}).Validate(); err != nil {
+		t.Errorf("Top=10, Window=1h should be valid, got: %v", err)
+	}
+}
+
+// TestProbe_SendsLimit asserts the probe passes --top through as the TSDB
+// `limit` query param so the server returns enough entries to rank.
+func TestProbe_SendsLimit(t *testing.T) {
+	var gotLimit string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == statusTSDBPath {
+			gotLimit = r.URL.Query().Get("limit")
+			_, _ = w.Write([]byte(syntheticTSDB))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+
+	if _, err := NewClient(srv.URL).Probe(context.Background(), Options{Top: 25}); err != nil {
+		t.Fatalf("Probe: %v", err)
+	}
+	if gotLimit != "25" {
+		t.Errorf("limit query param = %q, want 25", gotLimit)
+	}
+}
+
+// TestWriteJSON pins the JSON shape callers depend on: the ranked arrays and the
+// enrichment sentinels round-trip.
+func TestWriteJSON(t *testing.T) {
+	inv := Inventory{
+		Source:              "http://prom:9090",
+		Top:                 2,
+		Head:                HeadStats{NumSeries: 508},
+		TopMetricsBySeries:  []NameValue{{Name: "node_cpu_seconds_total", Value: 900}},
+		MetricNameTotal:     3,
+		MetadataMetricTotal: -1,
+		Notes:               []string{"metadata total unavailable"},
+	}
+	var buf strings.Builder
+	if err := inv.WriteJSON(&buf); err != nil {
+		t.Fatalf("WriteJSON: %v", err)
+	}
+	var back Inventory
+	if err := json.Unmarshal([]byte(buf.String()), &back); err != nil {
+		t.Fatalf("round-trip: %v", err)
+	}
+	if back.Head.NumSeries != 508 || len(back.TopMetricsBySeries) != 1 ||
+		back.MetricNameTotal != 3 || back.MetadataMetricTotal != -1 || len(back.Notes) != 1 {
+		t.Errorf("round-tripped inventory lost fields: %+v", back)
+	}
+}
+
+// TestWriteText pins the honesty framing and the ranked tables appear in the
+// human report.
+func TestWriteText(t *testing.T) {
+	srv := tsdbServer(t)
+	inv, err := NewClient(srv.URL).Probe(context.Background(), Options{Top: 50, Window: "1h"})
+	if err != nil {
+		t.Fatalf("Probe: %v", err)
+	}
+	var buf strings.Builder
+	if err := inv.WriteText(&buf); err != nil {
+		t.Fatalf("WriteText: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{
+		"RANK RISK",                           // honesty framing
+		"NOT predict cerberus's exact memory", // does not predict cerberus memory
+		"node_cpu_seconds_total",
+		"top 50 metrics by series count",
+		"head block",
+		"Observation window (operator context): 1h",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("text report missing %q, got:\n%s", want, out)
+		}
+	}
+}

--- a/internal/migrateinventory/report.go
+++ b/internal/migrateinventory/report.go
@@ -1,0 +1,107 @@
+package migrateinventory
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+)
+
+// WriteJSON renders the inventory as machine-readable JSON with a trailing
+// newline.
+func (inv Inventory) WriteJSON(w io.Writer) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(inv); err != nil {
+		return fmt.Errorf("encode inventory: %w", err)
+	}
+	return nil
+}
+
+// WriteText renders the inventory as scannable human-readable text. It leads
+// with the honesty framing (these are source-Prometheus runtime facts that rank
+// OOM risk, not a cerberus memory prediction), then the head-block size, then
+// the ranked risk tables, then any enrichment notes.
+func (inv Inventory) WriteText(w io.Writer) error {
+	bw := &errWriter{w: w}
+	bw.printf("# cerberus migrate inventory\n")
+	bw.printf("#\n")
+	bw.printf("# Live cardinality probed from the SOURCE Prometheus TSDB (%s).\n", inv.Source)
+	bw.printf("# These are source-Prometheus runtime facts — the realized series counts\n")
+	bw.printf("# config can't reveal offline. High-cardinality metrics are the OOM\n")
+	bw.printf("# CANDIDATES cerberus can't see before cutover. They RANK RISK; they do\n")
+	bw.printf("# NOT predict cerberus's exact memory (that depends on the query + engine).\n")
+	if inv.Window != "" {
+		bw.printf("# Observation window (operator context): %s. TSDB status is a\n", inv.Window)
+		bw.printf("# point-in-time head snapshot, so the window frames the numbers.\n")
+	}
+	bw.printf("#\n\n")
+
+	bw.printf("== head block\n")
+	bw.printf("  series:      %d\n", inv.Head.NumSeries)
+	bw.printf("  label pairs: %d\n", inv.Head.NumLabelPairs)
+	bw.printf("  chunks:      %d\n", inv.Head.ChunkCount)
+	if inv.Head.MinTime != 0 || inv.Head.MaxTime != 0 {
+		bw.printf("  head span:   %s .. %s\n", formatMillis(inv.Head.MinTime), formatMillis(inv.Head.MaxTime))
+	}
+	if inv.MetricNameTotal >= 0 {
+		bw.printf("  distinct metric names: %d\n", inv.MetricNameTotal)
+	}
+	if inv.MetadataMetricTotal >= 0 {
+		bw.printf("  metrics with metadata: %d\n", inv.MetadataMetricTotal)
+	}
+	bw.printf("\n")
+
+	writeRanked(bw, fmt.Sprintf("top %d metrics by series count (OOM candidates)", inv.Top),
+		inv.TopMetricsBySeries, "series")
+	writeRanked(bw, fmt.Sprintf("top %d labels by value cardinality (fan-out drivers)", inv.Top),
+		inv.TopLabelsByValues, "values")
+	writeRanked(bw, fmt.Sprintf("top %d labels by head memory", inv.Top),
+		inv.TopLabelsByMemory, "bytes")
+
+	if len(inv.Notes) > 0 {
+		bw.printf("== notes (%d)\n", len(inv.Notes))
+		for _, n := range inv.Notes {
+			bw.printf("  %s\n", n)
+		}
+	}
+	return bw.err
+}
+
+// writeRanked prints one ranked table, or an explicit "none reported" line so an
+// empty array is visible rather than a silent gap.
+func writeRanked(bw *errWriter, title string, rows []NameValue, unit string) {
+	bw.printf("== %s\n", title)
+	if len(rows) == 0 {
+		bw.printf("  none reported by the source\n\n")
+		return
+	}
+	for i, r := range rows {
+		bw.printf("  %3d. %-*s %d %s\n", i+1, rankNameWidth, r.Name, r.Value, unit)
+	}
+	bw.printf("\n")
+}
+
+// rankNameWidth pads the name column so the value column lines up in the ranked
+// tables. It is a cosmetic alignment width, not a data limit.
+const rankNameWidth = 48
+
+// formatMillis renders a Prometheus millisecond epoch as an RFC3339 UTC instant.
+func formatMillis(ms int64) string {
+	return time.UnixMilli(ms).UTC().Format(time.RFC3339)
+}
+
+// errWriter collapses the Fprintf error checks in the text writers into a single
+// short-circuiting sink: once a write fails, later printf calls no-op and the
+// first error is returned.
+type errWriter struct {
+	w   io.Writer
+	err error
+}
+
+func (e *errWriter) printf(format string, args ...any) {
+	if e.err != nil {
+		return
+	}
+	_, e.err = fmt.Fprintf(e.w, format, args...)
+}


### PR DESCRIPTION
## What

Adds `migrate inventory` — probe the **live source Prometheus** for the runtime cardinality facts that config can't reveal offline. Cerberus's offline `migrate explain` shows the SQL and physical tables a query touches, but the one thing that actually drives ClickHouse memory risk — how many series a metric fans out to, how wide a label is — is data, not config, and lives only in the running TSDB.

It **refuses to infer from `prometheus.yml`**: scrape config lists targets and relabel rules, not the realized series count after those rules run against real endpoints.

## How

- Calls `GET /api/v1/status/tsdb` (`headStats` + `seriesCountByMetricName` + `labelValueCountByLabelName` + `memoryInBytesByLabelName`), passing `--top` through as the `limit` query param.
- Ranks **top-N metrics by series count**, **top labels by value cardinality**, **top labels by head memory**, plus the head series/chunk stats — re-sorting locally so the output is stable across Prometheus versions rather than trusting the server's ordering.
- Optional enrichment: `/api/v1/label/__name__/values` (distinct metric-name total) and `/api/v1/metadata` (metrics-with-metadata total). A failure there is **counted as a note**, never silently dropped; its total stays at the `-1` "not obtained" sentinel.
- A source that **404s the mandatory status endpoint is a hard error → non-zero exit**.
- Human report (`WriteText`) and `--json` (`WriteJSON`).

## Honesty framing

Stated in the report itself: these are **SOURCE-Prometheus runtime facts** that **rank OOM risk** — high-cardinality metrics are the candidates cerberus can't see offline — they do **not** predict cerberus's exact memory (that depends on the query + engine).

## Layout

- New **leaf** package `internal/migrateinventory` (HTTP only, stdlib, no internal deps), declared in `.go-arch-lint.yml`.
- Wired as the `inventory` subcommand in `cmd/migrate` (flags fall back to `CERBERUS_INVENTORY_*`).

## Tests

End-to-end with `httptest` stub servers: top-N ranking + truncation, head stats, JSON round-trip, the honesty framing in the text report, `--top`→`limit` passthrough, a 404-on-status hard error, a `status:"error"` body surfaced, and both optional enrichment failures **counted** as notes (`-1` sentinels).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
