### PR TITLE
feat(migrate): classify — bucket each corpus query as PromQL-pure / rewritable / no-equivalent

### DIFF
--- a/cmd/migrate/classify.go
+++ b/cmd/migrate/classify.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/api/prom"
+	"github.com/tsouza/cerberus/internal/engine"
+	"github.com/tsouza/cerberus/internal/migrate"
+	"github.com/tsouza/cerberus/internal/optimizer"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// runClassifyCmd harvests a corpus (from --corpus, --rules and/or --dashboards),
+// dry-runs every query through the exact offline explain pipeline, and buckets
+// each one as supported (parses/lowers/emits clean) or unsupported (rejected,
+// with the offending construct named), flagging supported-but-risky queries.
+// Fully offline: DryRunSQL never opens a ClickHouse connection. Writes the
+// ledger to --out (or stdout), as text or --json.
+func runClassifyCmd(args []string, stdout, stderr io.Writer) error {
+	fs := flag.NewFlagSet("migrate classify", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var (
+		rules      stringList
+		dashboards string
+		corpus     string
+		out        string
+		asJSON     bool
+	)
+	fs.Var(&rules, "rules",
+		"classify PromQL in Prometheus rule files (repeatable comma-separated paths/globs)")
+	fs.StringVar(&dashboards, "dashboards", "",
+		"classify PromQL in exported Grafana dashboard JSON under a directory (walked recursively)")
+	fs.StringVar(&corpus, "corpus", "",
+		"classify a corpus.json previously written by `migrate harvest`")
+	fs.StringVar(&out, "out", "", "write the classification here (default: stdout)")
+	fs.BoolVar(&asJSON, "json", false, "emit the classification ledger as JSON instead of text")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	src, err := harvestSources(corpus, rules, dashboards)
+	if err != nil {
+		return err
+	}
+	if out == "" {
+		return runClassifyReport(stdout, src, asJSON)
+	}
+	// Render into a buffer, then commit with a checked os.WriteFile (via
+	// writeOut). A streaming os.Create with an unchecked Close would swallow a
+	// flush-at-close error and truncate the ledger silently.
+	var buf bytes.Buffer
+	if err := runClassifyReport(&buf, src, asJSON); err != nil {
+		return err
+	}
+	return writeOut(stdout, out, buf.Bytes())
+}
+
+// runClassifyReport dry-runs every query in src through the read-side pipeline,
+// buckets the resulting explain report, and writes it to w. It is fully offline:
+// the engine has no Client and DryRunSQL never executes.
+func runClassifyReport(w io.Writer, src migrate.CorpusSource, asJSON bool) error {
+	metrics := schema.DefaultOTelMetricsFromEnv()
+	eng := &engine.Engine{Optimizer: optimizer.Default()}
+	lang := prom.NewExplainLang(metrics, time.Unix(explainEvalUnix, 0).UTC())
+
+	ex := dryRunExplainer{eng: eng, lang: lang}
+	rep, err := migrate.BuildReport(context.Background(), src, ex)
+	if err != nil {
+		return fmt.Errorf("build classify report: %w", err)
+	}
+	cl := migrate.Classify(rep)
+	if asJSON {
+		return cl.WriteJSON(w)
+	}
+	return cl.Write(w)
+}

--- a/cmd/migrate/classify_test.go
+++ b/cmd/migrate/classify_test.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/migrate"
+)
+
+// TestClassifyEndToEnd runs `migrate classify` over a small rule file through the
+// REAL offline pipeline (parse -> lower -> emit via engine.DryRunSQL, no
+// ClickHouse). One clean query buckets as supported, one syntactically broken
+// query buckets as unsupported with its construct named, and the honesty header
+// warns that "supported" is translation, not result parity.
+func TestClassifyEndToEnd(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "rules.yml")
+	// `up` lowers + emits cleanly; `up{` is a real PromQL parse error, so the
+	// engine rejects it and it must land in the unsupported bucket, not vanish.
+	const rules = `
+groups:
+  - name: mix
+    rules:
+      - record: job:up
+        expr: up
+      - alert: Broken
+        expr: "up{"
+`
+	if err := os.WriteFile(file, []byte(rules), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var out, errOut bytes.Buffer
+	if err := run([]string{"classify", "--rules", file}, &out, &errOut); err != nil {
+		t.Fatalf("classify: %v (stderr: %s)", err, errOut.String())
+	}
+	report := out.String()
+
+	// Two rules -> two queries: `up` supported, `up{` unsupported.
+	for _, want := range []string{
+		"2 queries: 1 supported (0 risky), 1 unsupported; 0 skipped",
+		"job:up",
+		"only `migrate verify` proves parity",
+		// The unsupported query must NAME its offending construct (the engine
+		// error), under the unsupported bucket — never silently dropped.
+		"construct:",
+	} {
+		if !strings.Contains(report, want) {
+			t.Errorf("classify report missing %q\n---\n%s", want, report)
+		}
+	}
+}
+
+// TestClassifyJSONEndToEnd pins the --json path over the real pipeline: the
+// ledger unmarshals, the counts split 1 supported / 1 unsupported, and the
+// unsupported entry carries a non-empty construct.
+func TestClassifyJSONEndToEnd(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "rules.yml")
+	const rules = `
+groups:
+  - name: mix
+    rules:
+      - record: job:up
+        expr: up
+      - alert: Broken
+        expr: "up{"
+`
+	if err := os.WriteFile(file, []byte(rules), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var out, errOut bytes.Buffer
+	if err := run([]string{"classify", "--rules", file, "--json"}, &out, &errOut); err != nil {
+		t.Fatalf("classify --json: %v (stderr: %s)", err, errOut.String())
+	}
+
+	var cl migrate.Classification
+	if err := json.Unmarshal(out.Bytes(), &cl); err != nil {
+		t.Fatalf("unmarshal classify JSON: %v\n%s", err, out.String())
+	}
+	if cl.Counts.Total != 2 || cl.Counts.Supported != 1 || cl.Counts.Unsupported != 1 {
+		t.Fatalf("counts = %+v, want total 2 / supported 1 / unsupported 1", cl.Counts)
+	}
+	var sawNamedConstruct bool
+	for _, q := range cl.Queries {
+		if q.Bucket == migrate.BucketUnsupported {
+			if q.Construct == "" {
+				t.Errorf("unsupported query %q has an empty construct", q.Expr)
+			} else {
+				sawNamedConstruct = true
+			}
+		}
+	}
+	if !sawNamedConstruct {
+		t.Error("expected at least one unsupported query with a named construct")
+	}
+}
+
+// TestClassifyToOutFile pins that `classify --out <file>` writes the ledger to
+// the named file (checked write) and nothing to stdout.
+func TestClassifyToOutFile(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "rules.yml")
+	const rules = `
+groups:
+  - name: probe
+    rules:
+      - record: job:up
+        expr: up
+`
+	if err := os.WriteFile(file, []byte(rules), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ledger := filepath.Join(dir, "classify.txt")
+
+	var out, errOut bytes.Buffer
+	if err := run([]string{"classify", "--rules", file, "--out", ledger}, &out, &errOut); err != nil {
+		t.Fatalf("classify --out: %v (stderr: %s)", err, errOut.String())
+	}
+	if out.Len() != 0 {
+		t.Errorf("classify --out should not write to stdout, got: %q", out.String())
+	}
+	data, err := os.ReadFile(ledger) //nolint:gosec // test-controlled temp path.
+	if err != nil {
+		t.Fatalf("read ledger file: %v", err)
+	}
+	if !strings.Contains(string(data), "1 queries: 1 supported") {
+		t.Errorf("ledger file should carry the counts line, got:\n%s", string(data))
+	}
+}

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -9,6 +9,7 @@
 //	migrate harvest --rules <glob> \           # build a machine-readable query corpus from
 //	  --dashboards <dir> --out corpus.json     #   rule files + exported Grafana dashboards
 //	migrate explain --corpus corpus.json       # explain a previously-harvested corpus
+//	migrate classify --corpus corpus.json      # bucket each corpus query by PromQL support
 //	migrate verify --corpus corpus.json \       # replay the corpus against a reference
 //	  --ref <prom-url> --cerberus <url>          #   Prometheus and cerberus and diff (parity gate)
 //	migrate inventory --source <prom-url>        # probe the LIVE source Prometheus for the
@@ -30,6 +31,14 @@
 // emitted SQL, the physical tables each query scans, and conservative offline
 // risk flags, or marks the query UNSUPPORTED. Row cardinality is data-dependent
 // and is deliberately NOT estimated offline.
+//
+// classify is a re-view of that same explain data specialised into a
+// classification ledger: it buckets each corpus query as supported (PromQL-pure
+// / rewritable — parses, lowers, and emits SQL cleanly) or unsupported
+// (no-equivalent — a parse/lower/emit error, with the offending construct
+// named), flags supported-but-risky queries, and prints per-bucket counts as
+// text or --json. "supported" means the query TRANSLATES, not that cerberus
+// returns the same numbers as Prometheus — only verify proves parity.
 //
 // verify is the online cutover parity gate: it replays each PromQL query in a
 // harvested corpus against a reference Prometheus AND cerberus over one
@@ -126,6 +135,8 @@ func run(args []string, stdout, stderr io.Writer) error {
 			return runHarvest(args[1:], stdout, stderr)
 		case "explain":
 			return runExplainCmd(args[1:], stdout, stderr)
+		case "classify":
+			return runClassifyCmd(args[1:], stdout, stderr)
 		case "verify":
 			return runVerify(args[1:], stdout, stderr)
 		case "inventory":

--- a/internal/migrate/classify.go
+++ b/internal/migrate/classify.go
@@ -1,0 +1,169 @@
+package migrate
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// Bucket names for `migrate classify`. Classification is a re-view of the exact
+// offline explain pipeline (parse → lower → emit via engine.DryRunSQL),
+// specialised into a ledger of how cleanly each corpus query maps onto
+// cerberus's PromQL support:
+//
+//   - BucketSupported   — the query PARSES, LOWERS, and EMITS ClickHouse SQL
+//     cleanly. This is the "PromQL-pure / rewritable" bucket: cerberus has a
+//     translation for it. It does NOT assert result parity (see the honesty
+//     note in Write): only `migrate verify` proves the numbers match.
+//   - BucketUnsupported — the offline pipeline rejected the query (a parse,
+//     lower, or emit error). This is the "no-equivalent" bucket; the offending
+//     construct/error is captured verbatim in ClassifiedQuery.Construct so the
+//     operator knows exactly what to rewrite before cutover.
+//
+// "risky" is not a third bucket — it is a flag on a SUPPORTED query that also
+// carries at least one offline Lint fan-out risk. It is counted separately so a
+// clean-but-expensive query is visible without being demoted out of supported.
+const (
+	BucketSupported   = "supported"
+	BucketUnsupported = "unsupported"
+)
+
+// ClassifiedQuery is one corpus query placed in a bucket. Expr/Source/Kind are
+// carried from the harvested query so the JSON ledger is self-contained.
+// Construct is the engine's rejection message — the offending construct — when
+// Bucket is unsupported, and empty otherwise. Risky is set on a supported query
+// that carries at least one offline Lint risk flag; Risks lists them.
+type ClassifiedQuery struct {
+	Expr      string   `json:"expr"`
+	Source    string   `json:"source"`
+	Kind      string   `json:"kind"`
+	Bucket    string   `json:"bucket"`
+	Construct string   `json:"construct,omitempty"`
+	Risky     bool     `json:"risky"`
+	Risks     []string `json:"risks,omitempty"`
+}
+
+// BucketCounts is the per-bucket tally. Total is every classified query;
+// Supported + Unsupported == Total. Risky is a subset of Supported (a supported
+// query that also carries an offline fan-out risk), so it is NOT added to Total.
+type BucketCounts struct {
+	Total       int `json:"total"`
+	Supported   int `json:"supported"`
+	Unsupported int `json:"unsupported"`
+	Risky       int `json:"risky"`
+}
+
+// Classification is the full classify ledger: per-bucket counts, one
+// ClassifiedQuery per harvested query, and the entries the harvester skipped
+// (carried straight through from the report so the skip count never gets lost).
+type Classification struct {
+	Counts  BucketCounts      `json:"counts"`
+	Queries []ClassifiedQuery `json:"queries"`
+	Skipped []SkippedEntry    `json:"skipped"`
+}
+
+// Classify turns an already-built explain Report into a bucketed ledger. It does
+// not re-run the engine — it reads the outcome the report already recorded: a
+// query with a non-empty Unsupported field lands in the unsupported bucket
+// (construct = the engine error), everything else is supported, and a supported
+// query carrying offline Lint risks is additionally flagged risky.
+func Classify(rep Report) Classification {
+	cl := Classification{
+		Queries: make([]ClassifiedQuery, 0, len(rep.Queries)),
+		Skipped: rep.Skipped,
+	}
+	for _, q := range rep.Queries {
+		cq := ClassifiedQuery{
+			Expr:   q.Query.Expr,
+			Source: q.Query.Source,
+			Kind:   q.Query.Kind,
+		}
+		if q.Unsupported != "" {
+			cq.Bucket = BucketUnsupported
+			cq.Construct = q.Unsupported
+			cl.Counts.Unsupported++
+		} else {
+			cq.Bucket = BucketSupported
+			cl.Counts.Supported++
+			if len(q.Risks) > 0 {
+				cq.Risky = true
+				cq.Risks = q.Risks
+				cl.Counts.Risky++
+			}
+		}
+		cl.Queries = append(cl.Queries, cq)
+	}
+	cl.Counts.Total = len(rep.Queries)
+	return cl
+}
+
+// Write renders the classification as scannable text. It leads with the honesty
+// note — "supported" means the query TRANSLATES, not that cerberus returns the
+// same numbers as Prometheus — then the per-bucket counts, then one block per
+// bucket, then the skipped entries with their reasons.
+func (c Classification) Write(w io.Writer) error {
+	bw := &errWriter{w: w}
+	bw.printf("# cerberus migrate classify\n")
+	bw.printf("#\n")
+	bw.printf("# Buckets each corpus query by how cleanly it maps onto cerberus's PromQL\n")
+	bw.printf("# support, using the exact offline explain pipeline (parse -> lower -> emit):\n")
+	bw.printf("#   supported   — parses, lowers, and EMITS ClickHouse SQL (PromQL-pure / rewritable)\n")
+	bw.printf("#   unsupported — the offline pipeline rejected it (no-equivalent; construct named)\n")
+	bw.printf("#   risky       — a SUPPORTED query that also carries an offline fan-out risk flag\n")
+	bw.printf("#\n")
+	bw.printf("# HONESTY: \"supported\" means the query TRANSLATES to SQL, NOT that cerberus\n")
+	bw.printf("# returns the same numbers as Prometheus — only `migrate verify` proves parity.\n")
+	bw.printf("#\n")
+	bw.printf("# %d queries: %d supported (%d risky), %d unsupported; %d skipped\n\n",
+		c.Counts.Total, c.Counts.Supported, c.Counts.Risky, c.Counts.Unsupported, len(c.Skipped))
+
+	bw.printf("== supported (%d)\n", c.Counts.Supported)
+	for _, q := range c.Queries {
+		if q.Bucket != BucketSupported {
+			continue
+		}
+		bw.printf("   [%s] %s\n", q.Kind, q.Source)
+		bw.printf("     expr: %s\n", q.Expr)
+		for _, risk := range q.Risks {
+			bw.printf("     RISKY: %s\n", risk)
+		}
+	}
+
+	bw.printf("\n== unsupported (%d)\n", c.Counts.Unsupported)
+	for _, q := range c.Queries {
+		if q.Bucket != BucketUnsupported {
+			continue
+		}
+		bw.printf("   [%s] %s\n", q.Kind, q.Source)
+		bw.printf("     expr:      %s\n", q.Expr)
+		bw.printf("     construct: %s\n", q.Construct)
+	}
+
+	if len(c.Skipped) > 0 {
+		bw.printf("\n== skipped (%d)\n", len(c.Skipped))
+		for _, s := range c.Skipped {
+			bw.printf("   %s: %s\n", s.Source, s.Reason)
+		}
+	}
+	return bw.err
+}
+
+// WriteJSON renders the classification as deterministic, indented JSON with a
+// trailing newline. Nil slices become empty slices so the ledger always carries
+// `[]` rather than `null`, matching the corpus JSON convention.
+func (c Classification) WriteJSON(w io.Writer) error {
+	if c.Queries == nil {
+		c.Queries = []ClassifiedQuery{}
+	}
+	if c.Skipped == nil {
+		c.Skipped = []SkippedEntry{}
+	}
+	data, err := json.MarshalIndent(c, "", jsonIndent)
+	if err != nil {
+		return fmt.Errorf("migrate: marshal classification: %w", err)
+	}
+	if _, err := w.Write(append(data, '\n')); err != nil {
+		return fmt.Errorf("migrate: write classification: %w", err)
+	}
+	return nil
+}

--- a/internal/migrate/classify_test.go
+++ b/internal/migrate/classify_test.go
@@ -1,0 +1,141 @@
+package migrate
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// TestClassifyBuckets exercises the full classify ledger over a mixed corpus: a
+// clean query lands in supported, a broken query in unsupported with its
+// offending construct captured, and a clean-but-fan-out query is supported AND
+// flagged risky. Counts and the rendered text are both asserted.
+func TestClassifyBuckets(t *testing.T) {
+	src := staticSource{
+		queries: []HarvestedQuery{
+			{Expr: "up", Source: "rule:f/g/up_rec", Kind: KindRecord},
+			{Expr: "sum_over_time(up[10m:1m])", Source: "rule:f/g/subq", Kind: KindRecord},
+			{Expr: "!!!", Source: "rule:f/g/broken", Kind: KindAlert},
+		},
+		skipped: []SkippedEntry{{Source: "rule:f/g/empty", Reason: "rule has an empty expr"}},
+	}
+	ex := fakeExplainer{byQuery: map[string]Explanation{
+		"up": {
+			SQL:  "SELECT * FROM otel_metrics_gauge",
+			Plan: &chplan.Scan{Table: "otel_metrics_gauge"},
+		},
+		"sum_over_time(up[10m:1m])": {
+			SQL: "SELECT * FROM otel_metrics_gauge",
+			Plan: &chplan.RangeWindow{
+				Input:      &chplan.Scan{Table: "otel_metrics_gauge"},
+				Func:       "sum_over_time",
+				OuterRange: 10 * time.Minute,
+				Step:       time.Minute,
+			},
+		},
+		"!!!": {Err: errors.New("parse error: unexpected character inside braces")},
+	}}
+
+	rep, err := BuildReport(context.Background(), src, ex)
+	if err != nil {
+		t.Fatalf("BuildReport: %v", err)
+	}
+	cl := Classify(rep)
+
+	if cl.Counts.Total != 3 {
+		t.Errorf("Total = %d, want 3", cl.Counts.Total)
+	}
+	if cl.Counts.Supported != 2 {
+		t.Errorf("Supported = %d, want 2", cl.Counts.Supported)
+	}
+	if cl.Counts.Unsupported != 1 {
+		t.Errorf("Unsupported = %d, want 1", cl.Counts.Unsupported)
+	}
+	if cl.Counts.Risky != 1 {
+		t.Errorf("Risky = %d, want 1", cl.Counts.Risky)
+	}
+
+	byExpr := map[string]ClassifiedQuery{}
+	for _, q := range cl.Queries {
+		byExpr[q.Expr] = q
+	}
+	if got := byExpr["up"]; got.Bucket != BucketSupported || got.Risky {
+		t.Errorf("`up` should be supported and not risky, got %+v", got)
+	}
+	if got := byExpr["sum_over_time(up[10m:1m])"]; got.Bucket != BucketSupported || !got.Risky {
+		t.Errorf("subquery should be supported AND risky, got %+v", got)
+	}
+	broken := byExpr["!!!"]
+	if broken.Bucket != BucketUnsupported {
+		t.Fatalf("`!!!` should be unsupported, got %+v", broken)
+	}
+	// The offending construct must be NAMED, not silently dropped.
+	if !strings.Contains(broken.Construct, "unexpected character inside braces") {
+		t.Errorf("unsupported query must name the offending construct, got %q", broken.Construct)
+	}
+
+	var sb strings.Builder
+	if err := cl.Write(&sb); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	out := sb.String()
+	for _, want := range []string{
+		"3 queries: 2 supported (1 risky), 1 unsupported; 1 skipped",
+		"only `migrate verify` proves parity",
+		"unexpected character inside braces",
+		"RISKY:",
+		"rule has an empty expr",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("classify text missing %q\n---\n%s", want, out)
+		}
+	}
+}
+
+// TestClassifyJSON pins the machine-readable ledger: the bucket, construct, and
+// counts round-trip through JSON, and nil query/skip slices render as [] not
+// null so downstream readers never choke on a null.
+func TestClassifyJSON(t *testing.T) {
+	src := staticSource{queries: []HarvestedQuery{
+		{Expr: "up", Source: "rule:f/g/up", Kind: KindRecord},
+		{Expr: "!!!", Source: "rule:f/g/broken", Kind: KindAlert},
+	}}
+	ex := fakeExplainer{byQuery: map[string]Explanation{
+		"up":  {SQL: "SELECT 1", Plan: &chplan.Scan{Table: "otel_metrics_gauge"}},
+		"!!!": {Err: errors.New("parse error: bad token")},
+	}}
+	rep, err := BuildReport(context.Background(), src, ex)
+	if err != nil {
+		t.Fatalf("BuildReport: %v", err)
+	}
+
+	var sb strings.Builder
+	if err := Classify(rep).WriteJSON(&sb); err != nil {
+		t.Fatalf("WriteJSON: %v", err)
+	}
+
+	var got Classification
+	if err := json.Unmarshal([]byte(sb.String()), &got); err != nil {
+		t.Fatalf("unmarshal classify JSON: %v\n%s", err, sb.String())
+	}
+	if got.Counts.Supported != 1 || got.Counts.Unsupported != 1 {
+		t.Errorf("JSON counts wrong: %+v", got.Counts)
+	}
+	if len(got.Queries) != 2 {
+		t.Fatalf("expected 2 queries in JSON, got %d", len(got.Queries))
+	}
+
+	// Empty-corpus classify must emit [] for queries/skipped, never null.
+	var empty strings.Builder
+	if err := (Classification{}).WriteJSON(&empty); err != nil {
+		t.Fatalf("WriteJSON empty: %v", err)
+	}
+	if s := empty.String(); strings.Contains(s, "null") {
+		t.Errorf("empty classification must render [] not null, got:\n%s", s)
+	}
+}


### PR DESCRIPTION
## What

Adds `migrate classify`: read a harvested corpus (or `--rules` / `--dashboards`) and bucket each PromQL query by how cleanly it maps onto cerberus's PromQL support, **naming the offending construct** when it doesn't.

It is a re-view of `explain`'s data specialised into a classification ledger. Each query runs through the exact offline pipeline `explain` uses — parse → lower → emit via `engine.DryRunSQL` through `prom.NewExplainLang`; the ClickHouse client is never touched (fully offline).

### Buckets

- **supported** — parses, lowers, and EMITS ClickHouse SQL cleanly (the *PromQL-pure / rewritable* bucket).
- **unsupported** — the offline pipeline rejected it (the *no-equivalent* bucket). The engine error is captured verbatim as the offending construct, **never silently dropped**.
- **risky** — not a third bucket, but a *flag* on a SUPPORTED query that also carries an offline `Lint` fan-out risk (e.g. subquery anchor fan-out), counted separately so a clean-but-expensive query stays visible without being demoted.

Output is per-bucket counts plus one block per bucket, as scannable **text** or **`--json`**, with **`--out`** to write a file.

### Honesty contract (stated in the report header)

> "supported" means the query **TRANSLATES** to SQL, **NOT** that cerberus returns the same numbers as Prometheus — only `migrate verify` proves parity.

## Where

- `Classify` / `Classification` live in `internal/migrate`, reusing `BuildReport` and touching only `chplan` + `promrules` — **no new package, no `.go-arch-lint.yml` change**.
- The `DryRunSQL` / explainer wiring is the `classify` subcommand in `cmd/migrate`, mirroring `explain`.

## Tests

- **Unit** (`internal/migrate`): a mixed corpus (clean + subquery-risky + broken) asserting bucket counts, the named construct, the risky flag, and JSON rendering `[]` not `null`.
- **End to end** (`cmd/migrate`): through the real engine over a rule file with one clean (`up`) and one broken (`up{`) expr — bucket counts, the named construct, `--json`, and `--out` all asserted.

## Example

```text
# 3 queries: 2 supported (1 risky), 1 unsupported; 0 skipped

== supported (2)
   [record] rule:.../job:up
     expr: up
   [record] rule:.../subq
     expr: sum_over_time(rate(http_requests_total[1m])[10m:1m])
     RISKY: subquery fan-out: inner expression evaluated at 11 anchors per series

== unsupported (1)
   [alert] rule:.../Broken
     expr:      up{
     construct: engine: parse: 1:4: parse error: unexpected end of input inside braces
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
