### PR TITLE
feat(migrate): rulegraph — recording-rule output → consumer dependency graph

### DIFF
--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -10,6 +10,8 @@
 //	  --dashboards <dir> --out corpus.json     #   rule files + exported Grafana dashboards
 //	migrate explain --corpus corpus.json       # explain a previously-harvested corpus
 //	migrate classify --corpus corpus.json      # bucket each corpus query by PromQL support
+//	migrate rulegraph --rules <glob> \          # recording-rule output -> consumer dependency
+//	  --corpus corpus.json                       #   graph (what MUST stay materialized)
 //	migrate verify --corpus corpus.json \       # replay the corpus against a reference
 //	  --ref <prom-url> --cerberus <url>          #   Prometheus and cerberus and diff (parity gate)
 //	migrate inventory --source <prom-url>        # probe the LIVE source Prometheus for the
@@ -39,6 +41,16 @@
 // named), flags supported-but-risky queries, and prints per-bucket counts as
 // text or --json. "supported" means the query TRANSLATES, not that cerberus
 // returns the same numbers as Prometheus — only verify proves parity.
+//
+// rulegraph builds the recording-rule-output -> consumer dependency graph.
+// Because cerberus has NO ruler, a recording rule's OUTPUT series (its record:
+// name) is not produced by cerberus — every dashboard panel or alert that reads
+// it must be re-materialized elsewhere post-cutover or the panel goes silently
+// blank. rulegraph takes the recorded names from --rules and scans every corpus
+// query (--corpus) and alerting-rule expr for references to them (a name-level
+// approximation via the PromQL parser), then marks each recorded series consumed
+// or orphan and lists the consumers that MUST keep being materialized. Text or
+// --json; anything unparseable is a counted skip, never silently dropped.
 //
 // verify is the online cutover parity gate: it replays each PromQL query in a
 // harvested corpus against a reference Prometheus AND cerberus over one
@@ -137,6 +149,8 @@ func run(args []string, stdout, stderr io.Writer) error {
 			return runExplainCmd(args[1:], stdout, stderr)
 		case "classify":
 			return runClassifyCmd(args[1:], stdout, stderr)
+		case "rulegraph":
+			return runRuleGraphCmd(args[1:], stdout, stderr)
 		case "verify":
 			return runVerify(args[1:], stdout, stderr)
 		case "inventory":

--- a/cmd/migrate/rulegraph.go
+++ b/cmd/migrate/rulegraph.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"fmt"
+	"io"
+
+	"github.com/tsouza/cerberus/internal/migrate"
+)
+
+// runRuleGraphCmd builds the recording-rule-output → consumer dependency graph.
+// It harvests recording/alerting rules from --rules (record: names become the
+// recorded OUTPUT series; alerting exprs become consumers) and the harvested
+// dashboard/alert queries from --corpus (also consumers), then links each
+// consumer to the recorded series it references by metric name. It classifies
+// every recorded series as consumed or orphan and lists the consumers that MUST
+// keep being materialized post-cutover. Fully offline: the only parsing is the
+// PromQL name extraction; no ClickHouse connection is opened. Writes the graph to
+// --out (or stdout), text or --json.
+func runRuleGraphCmd(args []string, stdout, stderr io.Writer) error {
+	fs := flag.NewFlagSet("migrate rulegraph", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var (
+		rules  stringList
+		corpus string
+		out    string
+		asJSON bool
+	)
+	fs.Var(&rules, "rules",
+		"recording/alerting rule files: record: names are the recorded series, "+
+			"alerting exprs are consumers (repeatable comma-separated paths/globs)")
+	fs.StringVar(&corpus, "corpus", "",
+		"harvested corpus.json (from `migrate harvest`) whose queries are scanned as consumers")
+	fs.StringVar(&out, "out", "", "write graph here (default: stdout)")
+	fs.BoolVar(&asJSON, "json", false, "emit the graph as JSON instead of text")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if len(rules) == 0 && corpus == "" {
+		fs.Usage()
+		return fmt.Errorf("rulegraph needs --rules (for recorded series) and/or --corpus (for consumers)")
+	}
+
+	g, err := buildRuleGraph(rules, corpus)
+	if err != nil {
+		return err
+	}
+	if out == "" {
+		return writeRuleGraph(stdout, g, asJSON)
+	}
+	// Render into a buffer, then commit with a checked writeOut. A streaming
+	// os.Create with an unchecked Close would swallow a flush-at-close error
+	// and truncate the graph silently.
+	var buf bytes.Buffer
+	if err := writeRuleGraph(&buf, g, asJSON); err != nil {
+		return err
+	}
+	return writeOut(stdout, out, buf.Bytes())
+}
+
+// buildRuleGraph assembles the graph inputs: recorded series + alerting
+// consumers from the rule files, plus every corpus query as an additional
+// consumer. Rule-file and corpus skips are threaded through so the graph's skip
+// count accounts for every dropped input. The PromQL name extractor is the only
+// thing that parses; a corpus/alert expr that will not parse becomes a skip.
+func buildRuleGraph(rules []string, corpus string) (migrate.RuleGraph, error) {
+	recorded, consumers, skipped := migrate.HarvestRuleFiles(rules)
+
+	if corpus != "" {
+		cq, csk, err := migrate.CorpusFileSource{Path: corpus}.Harvest(context.Background())
+		if err != nil {
+			return migrate.RuleGraph{}, fmt.Errorf("read corpus: %w", err)
+		}
+		consumers = append(consumers, cq...)
+		skipped = append(skipped, csk...)
+	}
+
+	return migrate.BuildRuleGraph(recorded, consumers, migrate.PromQLMetricNames, skipped), nil
+}
+
+// writeRuleGraph renders the graph as text or JSON.
+func writeRuleGraph(w io.Writer, g migrate.RuleGraph, asJSON bool) error {
+	if asJSON {
+		return g.WriteJSON(w)
+	}
+	return g.Write(w)
+}

--- a/cmd/migrate/rulegraph_test.go
+++ b/cmd/migrate/rulegraph_test.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/migrate"
+)
+
+// writeRuleGraphCorpus writes a minimal harvested corpus.json for the rulegraph tests: a
+// single panel query that references the recorded series, so the graph has a real
+// dashboard consumer to link. It uses migrate.BuildCorpus so the version stamp
+// and shape match what `migrate harvest` produces.
+func writeRuleGraphCorpus(t *testing.T, path string, queries ...migrate.HarvestedQuery) {
+	t.Helper()
+	c := migrate.BuildCorpus(queries, nil)
+	data, err := c.Marshal()
+	if err != nil {
+		t.Fatalf("marshal corpus: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestRuleGraphEndToEnd runs `migrate rulegraph` over a rule file (one recording
+// rule consumed by a dashboard query, one orphan recording rule) plus a corpus
+// through the REAL name extractor, asserting the consumed/orphan classification,
+// the edge back to the dashboard consumer, and the honesty header.
+func TestRuleGraphEndToEnd(t *testing.T) {
+	dir := t.TempDir()
+	ruleFile := filepath.Join(dir, "rules.yml")
+	const rules = `
+groups:
+  - name: api
+    rules:
+      - record: job:http_requests:rate5m
+        expr: rate(http_requests_total[5m])
+      - record: job:errors:rate5m
+        expr: rate(http_errors_total[5m])
+`
+	if err := os.WriteFile(ruleFile, []byte(rules), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	corpusFile := filepath.Join(dir, "corpus.json")
+	writeRuleGraphCorpus(t, corpusFile, migrate.HarvestedQuery{
+		Expr:   `sum(job:http_requests:rate5m{env="prod"})`,
+		Source: "dash:overview/reqs",
+		Kind:   migrate.KindPanel,
+	})
+
+	var out, errOut bytes.Buffer
+	if err := run([]string{"rulegraph", "--rules", ruleFile, "--corpus", corpusFile}, &out, &errOut); err != nil {
+		t.Fatalf("rulegraph: %v (stderr: %s)", err, errOut.String())
+	}
+	report := out.String()
+
+	for _, want := range []string{
+		"2 recorded series: 1 consumed, 1 orphan; 1 consumers; 0 skipped",
+		"NAME-LEVEL dependency approximation",
+		// the consumed series names its consumer edge
+		"job:http_requests:rate5m",
+		"<- dash:overview/reqs",
+		// the orphan series is listed under orphans
+		"job:errors:rate5m",
+	} {
+		if !strings.Contains(report, want) {
+			t.Errorf("rulegraph report missing %q\n---\n%s", want, report)
+		}
+	}
+}
+
+// TestRuleGraphJSONEndToEnd pins the --json path: the graph unmarshals, the
+// counts split 1 consumed / 1 orphan, and the consumed node carries its
+// consumer edge.
+func TestRuleGraphJSONEndToEnd(t *testing.T) {
+	dir := t.TempDir()
+	ruleFile := filepath.Join(dir, "rules.yml")
+	const rules = `
+groups:
+  - name: api
+    rules:
+      - record: job:http_requests:rate5m
+        expr: rate(http_requests_total[5m])
+      - record: job:errors:rate5m
+        expr: rate(http_errors_total[5m])
+`
+	if err := os.WriteFile(ruleFile, []byte(rules), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	corpusFile := filepath.Join(dir, "corpus.json")
+	writeRuleGraphCorpus(t, corpusFile, migrate.HarvestedQuery{
+		Expr:   "job:http_requests:rate5m",
+		Source: "dash:overview/reqs",
+		Kind:   migrate.KindPanel,
+	})
+
+	var out, errOut bytes.Buffer
+	if err := run([]string{"rulegraph", "--rules", ruleFile, "--corpus", corpusFile, "--json"}, &out, &errOut); err != nil {
+		t.Fatalf("rulegraph --json: %v (stderr: %s)", err, errOut.String())
+	}
+
+	var g migrate.RuleGraph
+	if err := json.Unmarshal(out.Bytes(), &g); err != nil {
+		t.Fatalf("unmarshal rulegraph JSON: %v\n%s", err, out.String())
+	}
+	if g.Counts.Recorded != 2 || g.Counts.Consumed != 1 || g.Counts.Orphan != 1 {
+		t.Fatalf("counts = %+v, want recorded 2 / consumed 1 / orphan 1", g.Counts)
+	}
+	var sawEdge bool
+	for _, n := range g.Recorded {
+		if n.Name == "job:http_requests:rate5m" {
+			if n.Status != migrate.StatusConsumed {
+				t.Errorf("job:http_requests:rate5m status = %q, want consumed", n.Status)
+			}
+			for _, c := range n.Consumers {
+				if c == "dash:overview/reqs" {
+					sawEdge = true
+				}
+			}
+		}
+	}
+	if !sawEdge {
+		t.Error("expected consumed node to carry an edge back to dash:overview/reqs")
+	}
+}
+
+// TestRuleGraphNoInputs pins that rulegraph refuses to run with neither --rules
+// nor --corpus rather than emitting an empty graph.
+func TestRuleGraphNoInputs(t *testing.T) {
+	var out, errOut bytes.Buffer
+	if err := run([]string{"rulegraph"}, &out, &errOut); err == nil {
+		t.Fatal("rulegraph with no inputs should error")
+	}
+}
+
+// TestRuleGraphToOutFile pins that `rulegraph --out <file>` writes to the named
+// file and nothing to stdout.
+func TestRuleGraphToOutFile(t *testing.T) {
+	dir := t.TempDir()
+	ruleFile := filepath.Join(dir, "rules.yml")
+	const rules = `
+groups:
+  - name: g
+    rules:
+      - record: job:up
+        expr: up
+`
+	if err := os.WriteFile(ruleFile, []byte(rules), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	graphFile := filepath.Join(dir, "graph.txt")
+
+	var out, errOut bytes.Buffer
+	if err := run([]string{"rulegraph", "--rules", ruleFile, "--out", graphFile}, &out, &errOut); err != nil {
+		t.Fatalf("rulegraph --out: %v (stderr: %s)", err, errOut.String())
+	}
+	if out.Len() != 0 {
+		t.Errorf("rulegraph --out should not write to stdout, got: %q", out.String())
+	}
+	data, err := os.ReadFile(graphFile) //nolint:gosec // test-controlled temp path.
+	if err != nil {
+		t.Fatalf("read graph file: %v", err)
+	}
+	if !strings.Contains(string(data), "1 recorded series") {
+		t.Errorf("graph file should carry the counts line, got:\n%s", string(data))
+	}
+}

--- a/internal/migrate/rulegraph.go
+++ b/internal/migrate/rulegraph.go
@@ -1,0 +1,415 @@
+package migrate
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	promparser "github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/promrules"
+)
+
+// Status values for a recorded series in the dependency graph. Because cerberus
+// has NO ruler, a recording rule's OUTPUT series is not materialized by cerberus
+// itself — it must be produced elsewhere (a materialized view, an external
+// recording engine, …) or every dashboard panel and alert that reads it goes
+// silently blank. The graph classifies each recorded series by whether anything
+// in the corpus still reads it:
+//
+//   - StatusConsumed — at least one corpus query or alerting-rule expr
+//     references the recorded series name. It MUST keep being materialized
+//     post-cutover or its consumers break.
+//   - StatusOrphan   — nothing in the scanned inputs references it. It is a
+//     candidate to drop (no consumer would notice), but the operator should
+//     confirm the corpus is complete before deleting anything.
+const (
+	StatusConsumed = "consumed"
+	StatusOrphan   = "orphan"
+)
+
+// RecordedSeries is one recording rule's OUTPUT: the series name it produces
+// (`record:`), tagged with the rule source it came from. Two recording rules may
+// declare the same output name; each is kept as its own entry so the operator
+// sees every site that must be re-materialized.
+type RecordedSeries struct {
+	Name   string `json:"name"`
+	Source string `json:"source"`
+}
+
+// RecordedNode is one recorded series in the emitted graph: its output name, the
+// rule that declares it, its consumed/orphan status, and the sorted, deduplicated
+// list of consumer sources that reference it.
+type RecordedNode struct {
+	Name      string   `json:"name"`
+	Source    string   `json:"source"`
+	Status    string   `json:"status"`
+	Consumers []string `json:"consumers"`
+}
+
+// ConsumerNode is one query (a corpus query or an alerting-rule expr) that
+// references at least one recorded series. References is the sorted, deduplicated
+// list of recorded series names it reads — exactly the set that MUST keep being
+// materialized for this consumer to keep working after cutover.
+type ConsumerNode struct {
+	Expr       string   `json:"expr"`
+	Source     string   `json:"source"`
+	Kind       string   `json:"kind"`
+	References []string `json:"references"`
+}
+
+// RuleGraphCounts is the headline tally. Recorded is every recording-rule output;
+// Consumed + Orphan == Recorded. Consumers is the number of scanned queries that
+// reference at least one recorded series. Skipped is every input the builder
+// could not use (an unparseable consumer expr, an unreadable rule file, …) —
+// counted, never silently dropped.
+type RuleGraphCounts struct {
+	Recorded  int `json:"recorded"`
+	Consumed  int `json:"consumed"`
+	Orphan    int `json:"orphan"`
+	Consumers int `json:"consumers"`
+	Skipped   int `json:"skipped"`
+}
+
+// RuleGraph is the full recording-rule-output → consumer dependency graph:
+// per-recorded-series consumed/orphan classification with edges, the flat list
+// of consumers that reference a recorded series, and everything the builder had
+// to skip. It marshals deterministically so the same inputs always produce
+// byte-identical output.
+//
+// HONESTY: this is a NAME-LEVEL dependency approximation. A consumer is linked
+// to a recorded series when it references that series' metric NAME (via a vector
+// selector); label matchers, value equality, and rule-to-rule chains are not
+// analysed. A name collision (an unrelated metric that happens to share a
+// recorded name) would over-link; that is the safe direction (it keeps a series
+// marked "must materialize" rather than dropping one that is needed).
+type RuleGraph struct {
+	Counts    RuleGraphCounts `json:"counts"`
+	Recorded  []RecordedNode  `json:"recorded"`
+	Consumers []ConsumerNode  `json:"consumers"`
+	Skipped   []SkippedEntry  `json:"skipped"`
+}
+
+// MetricNameExtractor pulls the set of metric-name references out of one query
+// expression. It returns an error when the expression cannot be parsed at all,
+// so the caller can count it as a reported skip rather than silently treating it
+// as referencing nothing. Injected into BuildRuleGraph so the pure graph logic
+// is testable without a full engine.
+type MetricNameExtractor func(expr string) ([]string, error)
+
+// ruleGraphParser is the PromQL parser used for name extraction. It matches the
+// options the explain/handler paths use (EnableExperimentalFunctions) so a rule
+// or corpus expr that parses for the engine also parses here — the graph never
+// skips an expr the rest of the tool accepts.
+var ruleGraphParser = promparser.NewParser(promparser.Options{EnableExperimentalFunctions: true})
+
+// PromQLMetricNames is the production MetricNameExtractor: it parses the
+// expression with the upstream Prometheus PromQL parser and walks every vector
+// selector, collecting the metric name each one reads (from an explicit
+// `__name__` equality matcher, or the selector's bare name). An expression that
+// does not parse is returned as an error so BuildRuleGraph records it as a skip.
+func PromQLMetricNames(expr string) ([]string, error) {
+	ast, err := ruleGraphParser.ParseExpr(expr)
+	if err != nil {
+		return nil, err
+	}
+	seen := map[string]struct{}{}
+	promparser.Inspect(ast, func(node promparser.Node, _ []promparser.Node) error {
+		vs, ok := node.(*promparser.VectorSelector)
+		if !ok {
+			return nil
+		}
+		if name := metricNameOf(vs); name != "" {
+			seen[name] = struct{}{}
+		}
+		return nil
+	})
+	names := make([]string, 0, len(seen))
+	for n := range seen {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+// metricNameOf returns the metric name a vector selector reads: the value of its
+// `__name__` equality matcher when present, else the selector's bare Name. A
+// selector with only a regex `__name__` matcher (no single concrete name) yields
+// "" — it names no single recorded series to link.
+func metricNameOf(vs *promparser.VectorSelector) string {
+	for _, m := range vs.LabelMatchers {
+		if m.Name == model.MetricNameLabel && m.Type == labels.MatchEqual {
+			return m.Value
+		}
+	}
+	return vs.Name
+}
+
+// BuildRuleGraph is the pure, offline core: given the recording-rule outputs and
+// the consumer queries (corpus queries + alerting-rule exprs), it links each
+// consumer to the recorded series it references (by extracted metric name) and
+// classifies each recorded series as consumed or orphan. A consumer whose expr
+// the extractor cannot parse is appended to skipped (never silently dropped).
+// The result is fully sorted so it is deterministic regardless of input order.
+func BuildRuleGraph(recorded []RecordedSeries, consumers []HarvestedQuery, extract MetricNameExtractor, skipped []SkippedEntry) RuleGraph {
+	nodes := make([]*RecordedNode, 0, len(recorded))
+	byName := map[string][]*RecordedNode{}
+	for _, r := range recorded {
+		n := &RecordedNode{Name: r.Name, Source: r.Source, Status: StatusOrphan}
+		nodes = append(nodes, n)
+		byName[r.Name] = append(byName[r.Name], n)
+	}
+
+	sk := make([]SkippedEntry, len(skipped))
+	copy(sk, skipped)
+
+	consumerNodes := make([]ConsumerNode, 0, len(consumers))
+	for _, c := range consumers {
+		names, err := extract(c.Expr)
+		if err != nil {
+			sk = append(sk, SkippedEntry{
+				Source: c.Source,
+				Reason: fmt.Sprintf("unparseable consumer expr: %v", err),
+			})
+			continue
+		}
+		refSeen := map[string]struct{}{}
+		for _, name := range names {
+			targets, ok := byName[name]
+			if !ok {
+				continue
+			}
+			refSeen[name] = struct{}{}
+			for _, t := range targets {
+				t.Consumers = append(t.Consumers, c.Source)
+			}
+		}
+		if len(refSeen) == 0 {
+			continue
+		}
+		refs := make([]string, 0, len(refSeen))
+		for name := range refSeen {
+			refs = append(refs, name)
+		}
+		sort.Strings(refs)
+		consumerNodes = append(consumerNodes, ConsumerNode{
+			Expr:       c.Expr,
+			Source:     c.Source,
+			Kind:       c.Kind,
+			References: refs,
+		})
+	}
+
+	counts := RuleGraphCounts{Recorded: len(nodes)}
+	out := make([]RecordedNode, 0, len(nodes))
+	for _, n := range nodes {
+		n.Consumers = sortedUnique(n.Consumers)
+		if len(n.Consumers) > 0 {
+			n.Status = StatusConsumed
+			counts.Consumed++
+		} else {
+			counts.Orphan++
+		}
+		out = append(out, *n)
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Name != out[j].Name {
+			return out[i].Name < out[j].Name
+		}
+		return out[i].Source < out[j].Source
+	})
+
+	sort.SliceStable(consumerNodes, func(i, j int) bool {
+		if consumerNodes[i].Source != consumerNodes[j].Source {
+			return consumerNodes[i].Source < consumerNodes[j].Source
+		}
+		return consumerNodes[i].Expr < consumerNodes[j].Expr
+	})
+	counts.Consumers = len(consumerNodes)
+
+	sort.SliceStable(sk, func(i, j int) bool {
+		if sk[i].Source != sk[j].Source {
+			return sk[i].Source < sk[j].Source
+		}
+		return sk[i].Reason < sk[j].Reason
+	})
+	counts.Skipped = len(sk)
+
+	return RuleGraph{Counts: counts, Recorded: out, Consumers: consumerNodes, Skipped: sk}
+}
+
+// sortedUnique returns a sorted copy of in with duplicates removed. Used to
+// dedupe the consumer-source list on a recorded node (the same corpus query can
+// reference a recorded name more than once) so edges are stable and counted once.
+func sortedUnique(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// HarvestRuleFiles reads the recording/alerting rule files matched by rulePaths
+// and splits them into the two things the graph needs: the recording-rule OUTPUT
+// series (RecordedSeries) and the alerting-rule exprs (as consumer queries). Any
+// input it cannot use — a bad glob, an unreadable file, a YAML parse failure, a
+// rule that is neither a record nor an alert — is returned as a counted skip
+// rather than dropped. Recording-rule exprs themselves are NOT returned as
+// consumers: v1 scans corpus queries + alerting exprs, not rule-to-rule chains.
+func HarvestRuleFiles(rulePaths []string) (recorded []RecordedSeries, consumers []HarvestedQuery, skipped []SkippedEntry) {
+	for _, pattern := range rulePaths {
+		matches, err := filepath.Glob(pattern)
+		if err != nil {
+			skipped = append(skipped, SkippedEntry{Source: pattern, Reason: fmt.Sprintf("bad path pattern: %v", err)})
+			continue
+		}
+		if len(matches) == 0 {
+			skipped = append(skipped, SkippedEntry{Source: pattern, Reason: "no files matched"})
+			continue
+		}
+		for _, file := range matches {
+			data, err := os.ReadFile(file) //nolint:gosec // operator-supplied rule-file path; offline CLI.
+			if err != nil {
+				skipped = append(skipped, SkippedEntry{Source: file, Reason: fmt.Sprintf("read: %v", err)})
+				continue
+			}
+			rg, err := promrules.Parse(data)
+			if err != nil {
+				skipped = append(skipped, SkippedEntry{Source: file, Reason: fmt.Sprintf("parse: %v", err)})
+				continue
+			}
+			rec, cons, sk := splitRuleGroups(file, rg)
+			recorded = append(recorded, rec...)
+			consumers = append(consumers, cons...)
+			skipped = append(skipped, sk...)
+		}
+	}
+	return recorded, consumers, skipped
+}
+
+// splitRuleGroups walks one parsed rule file: a rule with a `record:` name is a
+// recorded output series; a rule with an `alert:` name and a non-empty expr is a
+// consumer query; a rule that is neither is a counted skip. An alerting rule with
+// an empty expr is a skip (there is nothing to scan for references).
+func splitRuleGroups(file string, rg promrules.RuleGroups) (recorded []RecordedSeries, consumers []HarvestedQuery, skipped []SkippedEntry) {
+	for _, g := range rg.Groups {
+		for _, r := range g.Rules {
+			switch {
+			case r.Record != "":
+				source := fmt.Sprintf("rule:%s/%s/%s", file, g.Name, r.Record)
+				recorded = append(recorded, RecordedSeries{Name: r.Record, Source: source})
+			case r.Alert != "":
+				source := fmt.Sprintf("rule:%s/%s/%s", file, g.Name, r.Alert)
+				if strings.TrimSpace(r.Expr) == "" {
+					skipped = append(skipped, SkippedEntry{Source: source, Reason: "alerting rule has empty expr"})
+					continue
+				}
+				consumers = append(consumers, HarvestedQuery{Expr: r.Expr, Source: source, Kind: KindAlert})
+			default:
+				source := fmt.Sprintf("rule:%s/%s/?", file, g.Name)
+				skipped = append(skipped, SkippedEntry{Source: source, Reason: "rule is neither a record nor an alert"})
+			}
+		}
+	}
+	return recorded, consumers, skipped
+}
+
+// Write renders the graph as scannable, human-readable text. It leads with the
+// name-level-approximation honesty note, then the headline counts, then the
+// orphan recorded series (the ones nothing reads — drop candidates), then the
+// consumed recorded series with their consumer edges (what MUST keep being
+// materialized), then the skipped inputs with their reasons.
+func (g RuleGraph) Write(w io.Writer) error {
+	bw := &errWriter{w: w}
+	bw.printf("# cerberus migrate rulegraph\n")
+	bw.printf("#\n")
+	bw.printf("# cerberus has NO ruler: a recording rule's OUTPUT series is not produced\n")
+	bw.printf("# by cerberus. Every recorded series a dashboard panel or alert still reads\n")
+	bw.printf("# MUST be materialized elsewhere post-cutover, or the panel goes silently\n")
+	bw.printf("# blank. This graph links each recorded series to the queries that consume it.\n")
+	bw.printf("#\n")
+	bw.printf("# HONESTY: this is a NAME-LEVEL dependency approximation — a consumer links to\n")
+	bw.printf("# a recorded series when it references that series' metric NAME. Label matchers,\n")
+	bw.printf("# value equality, and rule-to-rule chains are not analysed. Unparseable consumer\n")
+	bw.printf("# exprs are counted as skips below, never silently ignored.\n")
+	bw.printf("#\n")
+	bw.printf("# %d recorded series: %d consumed, %d orphan; %d consumers; %d skipped\n\n",
+		g.Counts.Recorded, g.Counts.Consumed, g.Counts.Orphan, g.Counts.Consumers, g.Counts.Skipped)
+
+	bw.printf("== orphan recorded series (%d) — nothing scanned reads these\n", g.Counts.Orphan)
+	for _, n := range g.Recorded {
+		if n.Status != StatusOrphan {
+			continue
+		}
+		bw.printf("   %s (%s)\n", n.Name, n.Source)
+	}
+
+	bw.printf("\n== consumed recorded series (%d) — MUST keep being materialized\n", g.Counts.Consumed)
+	for _, n := range g.Recorded {
+		if n.Status != StatusConsumed {
+			continue
+		}
+		bw.printf("   %s (%s)\n", n.Name, n.Source)
+		for _, c := range n.Consumers {
+			bw.printf("     <- %s\n", c)
+		}
+	}
+
+	bw.printf("\n== consumers referencing recorded series (%d)\n", g.Counts.Consumers)
+	for _, c := range g.Consumers {
+		bw.printf("   [%s] %s\n", c.Kind, c.Source)
+		bw.printf("     expr: %s\n", c.Expr)
+		bw.printf("     refs: %s\n", strings.Join(c.References, ", "))
+	}
+
+	if len(g.Skipped) > 0 {
+		bw.printf("\n== skipped (%d)\n", len(g.Skipped))
+		for _, s := range g.Skipped {
+			bw.printf("   %s: %s\n", s.Source, s.Reason)
+		}
+	}
+	return bw.err
+}
+
+// WriteJSON renders the graph as deterministic, indented JSON with a trailing
+// newline. Nil slices become empty slices so the graph always carries `[]` rather
+// than `null`, matching the corpus/classify JSON convention.
+func (g RuleGraph) WriteJSON(w io.Writer) error {
+	if g.Recorded == nil {
+		g.Recorded = []RecordedNode{}
+	}
+	if g.Consumers == nil {
+		g.Consumers = []ConsumerNode{}
+	}
+	if g.Skipped == nil {
+		g.Skipped = []SkippedEntry{}
+	}
+	for i := range g.Recorded {
+		if g.Recorded[i].Consumers == nil {
+			g.Recorded[i].Consumers = []string{}
+		}
+	}
+	data, err := json.MarshalIndent(g, "", jsonIndent)
+	if err != nil {
+		return fmt.Errorf("migrate: marshal rulegraph: %w", err)
+	}
+	if _, err := w.Write(append(data, '\n')); err != nil {
+		return fmt.Errorf("migrate: write rulegraph: %w", err)
+	}
+	return nil
+}

--- a/internal/migrate/rulegraph.go
+++ b/internal/migrate/rulegraph.go
@@ -170,7 +170,19 @@ func BuildRuleGraph(recorded []RecordedSeries, consumers []HarvestedQuery, extra
 	copy(sk, skipped)
 
 	consumerNodes := make([]ConsumerNode, 0, len(consumers))
+	seenConsumer := map[string]struct{}{}
 	for _, c := range consumers {
+		// Collapse exact-duplicate consumer entries (same source+expr+kind):
+		// overlapping --rules / --corpus inputs (e.g. a corpus harvested from
+		// the same rule files) scan an identical consumer twice. Deduping here
+		// keeps counts.Consumers and the Consumers list honest, mirroring the
+		// sortedUnique edge-dedup on recorded nodes. Distinct consumers that
+		// merely share a source (different expr) are preserved.
+		ck := c.Source + "\x00" + c.Expr + "\x00" + c.Kind
+		if _, dup := seenConsumer[ck]; dup {
+			continue
+		}
+		seenConsumer[ck] = struct{}{}
 		names, err := extract(c.Expr)
 		if err != nil {
 			sk = append(sk, SkippedEntry{

--- a/internal/migrate/rulegraph_test.go
+++ b/internal/migrate/rulegraph_test.go
@@ -118,6 +118,41 @@ func TestBuildRuleGraphAlertingConsumer(t *testing.T) {
 	}
 }
 
+// TestBuildRuleGraphDedupsExactDuplicateConsumers pins that an identical consumer
+// entry (same source+expr+kind) scanned twice — as happens when --corpus is
+// harvested from the same rule files as --rules, so an alerting expr arrives via
+// both HarvestRuleFiles and the corpus — is collapsed to a single consumer node.
+// counts.Consumers and the recorded node's edge count stay honest instead of
+// double-counting the same consumer.
+func TestBuildRuleGraphDedupsExactDuplicateConsumers(t *testing.T) {
+	recorded := []RecordedSeries{{Name: "job:latency:p99", Source: "rule:a.yml/g/job:latency:p99"}}
+	dup := HarvestedQuery{Expr: "job:latency:p99 > 0.5", Source: "rule:a.yml/g/HighLatency", Kind: KindAlert}
+	consumers := []HarvestedQuery{dup, dup} // same consumer arriving via two overlapping inputs
+
+	g := BuildRuleGraph(recorded, consumers, PromQLMetricNames, nil)
+
+	if g.Counts.Consumers != 1 || len(g.Consumers) != 1 {
+		t.Fatalf("consumers = %d / nodes %d, want 1 (exact duplicate collapsed)", g.Counts.Consumers, len(g.Consumers))
+	}
+	if g.Counts.Consumed != 1 {
+		t.Fatalf("consumed = %d, want 1", g.Counts.Consumed)
+	}
+	if len(g.Recorded[0].Consumers) != 1 {
+		t.Errorf("recorded edges = %v, want a single de-duplicated edge", g.Recorded[0].Consumers)
+	}
+
+	// A genuinely distinct consumer that merely SHARES a source (different expr)
+	// is preserved, not folded away.
+	consumers2 := []HarvestedQuery{
+		{Expr: "job:latency:p99 > 0.5", Source: "rule:a.yml/g/HighLatency", Kind: KindAlert},
+		{Expr: "job:latency:p99 > 0.9", Source: "rule:a.yml/g/HighLatency", Kind: KindAlert},
+	}
+	g2 := BuildRuleGraph(recorded, consumers2, PromQLMetricNames, nil)
+	if g2.Counts.Consumers != 2 || len(g2.Consumers) != 2 {
+		t.Fatalf("distinct-expr consumers = %d, want 2 (not deduped)", g2.Counts.Consumers)
+	}
+}
+
 // TestBuildRuleGraphDeterministicJSON pins that the JSON output is stable and
 // carries empty slices (never null) for a graph with no consumers or skips.
 func TestBuildRuleGraphDeterministicJSON(t *testing.T) {

--- a/internal/migrate/rulegraph_test.go
+++ b/internal/migrate/rulegraph_test.go
@@ -1,0 +1,178 @@
+package migrate
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestBuildRuleGraphConsumedAndOrphan is the core case: one recording rule whose
+// output IS referenced by a dashboard query (consumed, with an edge back to that
+// query) and one recording rule whose output NOTHING references (orphan). It runs
+// the REAL PromQL name extractor, so the edge is proven by actual selector
+// parsing, not a stub.
+func TestBuildRuleGraphConsumedAndOrphan(t *testing.T) {
+	recorded := []RecordedSeries{
+		{Name: "job:http_requests:rate5m", Source: "rule:a.yml/api/job:http_requests:rate5m"},
+		{Name: "job:errors:rate5m", Source: "rule:a.yml/api/job:errors:rate5m"},
+	}
+	consumers := []HarvestedQuery{
+		// A dashboard panel that reads the first recorded series (inside a
+		// selector with a label matcher — the name still matches).
+		{Expr: `sum(job:http_requests:rate5m{env="prod"})`, Source: "dash:overview/panel-1", Kind: KindPanel},
+		// A panel that reads only a raw, non-recorded metric — references nothing.
+		{Expr: `rate(http_requests_total[5m])`, Source: "dash:overview/panel-2", Kind: KindPanel},
+	}
+
+	g := BuildRuleGraph(recorded, consumers, PromQLMetricNames, nil)
+
+	if g.Counts.Recorded != 2 || g.Counts.Consumed != 1 || g.Counts.Orphan != 1 {
+		t.Fatalf("counts = %+v, want recorded 2 / consumed 1 / orphan 1", g.Counts)
+	}
+	if g.Counts.Consumers != 1 {
+		t.Fatalf("consumers = %d, want 1", g.Counts.Consumers)
+	}
+
+	byName := map[string]RecordedNode{}
+	for _, n := range g.Recorded {
+		byName[n.Name] = n
+	}
+
+	consumed, ok := byName["job:http_requests:rate5m"]
+	if !ok {
+		t.Fatal("recorded series job:http_requests:rate5m missing from graph")
+	}
+	if consumed.Status != StatusConsumed {
+		t.Errorf("job:http_requests:rate5m status = %q, want %q", consumed.Status, StatusConsumed)
+	}
+	if len(consumed.Consumers) != 1 || consumed.Consumers[0] != "dash:overview/panel-1" {
+		t.Errorf("consumed edges = %v, want [dash:overview/panel-1]", consumed.Consumers)
+	}
+
+	orphan, ok := byName["job:errors:rate5m"]
+	if !ok {
+		t.Fatal("recorded series job:errors:rate5m missing from graph")
+	}
+	if orphan.Status != StatusOrphan {
+		t.Errorf("job:errors:rate5m status = %q, want %q", orphan.Status, StatusOrphan)
+	}
+	if len(orphan.Consumers) != 0 {
+		t.Errorf("orphan should have no consumers, got %v", orphan.Consumers)
+	}
+
+	if len(g.Consumers) != 1 {
+		t.Fatalf("consumer nodes = %d, want 1", len(g.Consumers))
+	}
+	cn := g.Consumers[0]
+	if cn.Source != "dash:overview/panel-1" || len(cn.References) != 1 ||
+		cn.References[0] != "job:http_requests:rate5m" {
+		t.Errorf("consumer node = %+v, want panel-1 referencing job:http_requests:rate5m", cn)
+	}
+}
+
+// TestBuildRuleGraphUnparseableIsSkipped pins that a consumer expr the extractor
+// cannot parse is COUNTED as a skip, never silently treated as referencing
+// nothing.
+func TestBuildRuleGraphUnparseableIsSkipped(t *testing.T) {
+	recorded := []RecordedSeries{{Name: "job:up", Source: "rule:a.yml/g/job:up"}}
+	consumers := []HarvestedQuery{
+		{Expr: "job:up", Source: "dash:d/ok", Kind: KindPanel},
+		{Expr: "sum(job:up{", Source: "dash:d/broken", Kind: KindPanel},
+	}
+
+	g := BuildRuleGraph(recorded, consumers, PromQLMetricNames, nil)
+
+	if g.Counts.Skipped != 1 || len(g.Skipped) != 1 {
+		t.Fatalf("skipped = %d, want 1", g.Counts.Skipped)
+	}
+	if g.Skipped[0].Source != "dash:d/broken" ||
+		!strings.Contains(g.Skipped[0].Reason, "unparseable") {
+		t.Errorf("skip entry = %+v, want dash:d/broken / unparseable", g.Skipped[0])
+	}
+	// The parseable consumer still links the recorded series.
+	if g.Counts.Consumed != 1 {
+		t.Errorf("consumed = %d, want 1 (the ok consumer)", g.Counts.Consumed)
+	}
+}
+
+// TestBuildRuleGraphAlertingConsumer proves an alerting-rule expr is scanned as a
+// consumer just like a corpus query.
+func TestBuildRuleGraphAlertingConsumer(t *testing.T) {
+	recorded := []RecordedSeries{{Name: "job:latency:p99", Source: "rule:a.yml/g/job:latency:p99"}}
+	consumers := []HarvestedQuery{
+		{Expr: "job:latency:p99 > 0.5", Source: "rule:a.yml/g/HighLatency", Kind: KindAlert},
+	}
+
+	g := BuildRuleGraph(recorded, consumers, PromQLMetricNames, nil)
+
+	if g.Counts.Consumed != 1 || g.Counts.Consumers != 1 {
+		t.Fatalf("counts = %+v, want consumed 1 / consumers 1", g.Counts)
+	}
+	if g.Recorded[0].Status != StatusConsumed ||
+		len(g.Recorded[0].Consumers) != 1 ||
+		g.Recorded[0].Consumers[0] != "rule:a.yml/g/HighLatency" {
+		t.Errorf("recorded node = %+v, want consumed by the alerting rule", g.Recorded[0])
+	}
+}
+
+// TestBuildRuleGraphDeterministicJSON pins that the JSON output is stable and
+// carries empty slices (never null) for a graph with no consumers or skips.
+func TestBuildRuleGraphDeterministicJSON(t *testing.T) {
+	recorded := []RecordedSeries{{Name: "job:up", Source: "rule:a.yml/g/job:up"}}
+	g := BuildRuleGraph(recorded, nil, PromQLMetricNames, nil)
+
+	var buf bytes.Buffer
+	if err := g.WriteJSON(&buf); err != nil {
+		t.Fatalf("WriteJSON: %v", err)
+	}
+	// Round-trips and the recorded node's consumers is [] not null.
+	var back RuleGraph
+	if err := json.Unmarshal(buf.Bytes(), &back); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, buf.String())
+	}
+	if back.Counts.Orphan != 1 {
+		t.Errorf("orphan count round-trip = %d, want 1", back.Counts.Orphan)
+	}
+	if !strings.Contains(buf.String(), `"consumers": []`) {
+		t.Errorf("empty consumers should marshal as [], got:\n%s", buf.String())
+	}
+}
+
+// TestHarvestRuleFilesSplitsRecordAndAlert pins the file harvester: a recording
+// rule becomes a recorded series, an alerting rule becomes a consumer, an empty
+// alert expr is a counted skip, and a no-name rule is a counted skip.
+func TestHarvestRuleFilesSplitsRecordAndAlert(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "rules.yml")
+	const rules = `
+groups:
+  - name: g
+    rules:
+      - record: job:up:rate5m
+        expr: rate(up[5m])
+      - alert: HighErr
+        expr: job:up:rate5m > 1
+      - alert: Empty
+        expr: ""
+      - expr: something
+`
+	if err := os.WriteFile(file, []byte(rules), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	recorded, consumers, skipped := HarvestRuleFiles([]string{file})
+
+	if len(recorded) != 1 || recorded[0].Name != "job:up:rate5m" {
+		t.Fatalf("recorded = %+v, want one job:up:rate5m", recorded)
+	}
+	if len(consumers) != 1 || consumers[0].Kind != KindAlert {
+		t.Fatalf("consumers = %+v, want one alert consumer", consumers)
+	}
+	// One empty-expr alert + one no-name rule = two skips.
+	if len(skipped) != 2 {
+		t.Fatalf("skipped = %+v, want 2 (empty-expr alert + no-name rule)", skipped)
+	}
+}


### PR DESCRIPTION
## What

Adds `migrate rulegraph` — the recording-rule-output → consumer dependency graph.

Cerberus has **no ruler**, so a recording rule's OUTPUT series (its `record:` name) is never produced by cerberus. Every dashboard panel or alert that reads a recorded series must be re-materialized elsewhere post-cutover (a materialized view, an external recording engine, …) or the panel goes **silently blank**. This command builds the DAG so the operator knows exactly which recorded series must keep being materialized.

## How

- **Inputs**: `--rules <glob>` (recording+alerting rule files, via `promrules`) and `--corpus <file>` (harvested dashboard/alert queries from `migrate harvest`). At least one is required.
- For each recording rule, its OUTPUT is the `record:` series name. Every corpus query and every alerting-rule expr is scanned for references to those recorded names.
- **Matching** is a name-level approximation: the consumer expr is parsed with the PromQL parser and every vector selector's metric name is collected (`__name__` equality matcher, or the bare selector name). Label matchers, value equality, and rule-to-rule chains are **not** analysed.
- **Output** (human text + `--json`):
  - `recorded-series -> [consumers]` edges,
  - each recorded series classified **consumed** or **orphan**,
  - the flat list of consumers that reference a recorded series (what MUST keep being materialized).

## Honesty

- The header states plainly this is a **name-level dependency approximation**. A name collision would over-link — the safe direction (keeps a series marked "must materialize" rather than dropping one that is needed).
- Anything unparseable (a corpus/alert expr that will not parse, an unreadable/mal-YAML rule file, a rule that is neither record nor alert) is a **counted skip**, surfaced in the report — never silently dropped.

## Where

- `internal/migrate/rulegraph.go` — pure/offline builder (`BuildRuleGraph`), rule-file harvest (`HarvestRuleFiles`), and the PromQL name extractor (`PromQLMetricNames`). No ClickHouse connection; the only parsing is name extraction.
- `cmd/migrate/rulegraph.go` — subcommand wiring (`--rules` / `--corpus` / `--out` / `--json`), reusing the existing corpus reader.
- `cmd/migrate/main.go` — dispatch + usage docs.

## Tests

- `internal/migrate/rulegraph_test.go` — the core case (one recording rule consumed by a dashboard query + one orphan recording rule → asserts consumed/orphan classification **and** the edge), plus unparseable-consumer-is-skipped, alerting-rule-as-consumer, deterministic JSON (`[]` not `null`), and the rule-file split harvester. Uses the **real** PromQL extractor, not a stub.
- `cmd/migrate/rulegraph_test.go` — end-to-end through `run()`: text + `--json` over a rule file plus a real harvested corpus, no-inputs error, and `--out` file write.

Fully offline and deterministic (fixed inputs, sorted output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
