### PR TITLE
feat(migrate): gate — fold migration artifacts into a go/no-go decision

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -166,6 +166,10 @@ components:
   # ranks the top-N metrics/labels by cardinality (the offline-invisible OOM
   # risk). Leaf, stdlib-only — no internal deps. Wired from cmd/migrate only.
   migrateinventory: { in: migrateinventory }
+  # Offline cutover go/no-go aggregator: reads the JSON artifacts the other
+  # migration blocks emit and folds them into one PASS/FAIL decision. Depends
+  # only on the blocks whose JSON contracts it reuses. Wired from cmd/migrate.
+  migrategate:    { in: migrategate }
   # Leaf yaml.v3 decode of Prometheus rule files (record/alert exprs). No
   # internal deps — deliberately avoids prometheus/rulefmt's ~112-package pull.
   promrules:      { in: promrules }
@@ -308,6 +312,16 @@ deps:
   migrateverify:
     mayDependOn:
       - migrate
+
+  # migrategate is the offline aggregator. It reads the JSON each block emits, so
+  # it reuses their contract types: migrate (classify + rulegraph), migrateverify
+  # (the parity report), and migrateinventory (the cardinality report). It runs no
+  # query and opens no connection — a pure JSON-in, decision-out fold.
+  migrategate:
+    mayDependOn:
+      - migrate
+      - migrateverify
+      - migrateinventory
 
   # config is wired from cmd/ to build chclient + schema at boot.
   config:

--- a/cmd/migrate/gate.go
+++ b/cmd/migrate/gate.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"io"
+
+	"github.com/tsouza/cerberus/internal/migrategate"
+)
+
+// gateExitFail is the process exit code when the cutover gate returns FAIL (a
+// blocking stage said no-go). It is distinct from the code Go uses for an
+// internal tool error, and from verify's own gate code, so a no-go reads as
+// "the gate did its job", not "the tool broke".
+const gateExitFail = 3
+
+// runGate folds the JSON artifacts the other migration blocks emit — verify,
+// classify, inventory, rulegraph — into a single cutover go/no-go decision. It
+// is a pure, offline aggregator: it reads the supplied artifact files, applies
+// the conservative gate rules, prints a per-stage checklist (text or --json),
+// and returns a gateFailedError (mapped to a non-zero exit) on any blocking
+// stage. Every artifact flag is optional, but a MISSING required artifact
+// blocks: the gate cannot prove safety for a stage it never saw.
+func runGate(args []string, stdout, stderr io.Writer) error {
+	fs := flag.NewFlagSet("migrate gate", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var (
+		verify    = fs.String("verify", "", "verify.json produced by `migrate verify --json`")
+		classify  = fs.String("classify", "", "classify.json produced by `migrate classify --json`")
+		inventory = fs.String("inventory", "", "inventory.json produced by `migrate inventory --json`")
+		rulegraph = fs.String("rulegraph", "", "rulegraph.json produced by `migrate rulegraph --json`")
+		out       = fs.String("out", "", "write the decision here (default: stdout)")
+		asJSON    = fs.Bool("json", false, "emit the decision as JSON instead of text")
+		highCard  = fs.Int64("high-card-series", migrategate.DefaultHighCardSeries,
+			"WARN when a metric's head series count reaches this threshold")
+		highCardLabels = fs.Int64("high-card-label-values", migrategate.DefaultHighCardLabelValues,
+			"WARN when a label's distinct-value count reaches this threshold")
+	)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	in := migrategate.Inputs{
+		Verify:    *verify,
+		Classify:  *classify,
+		Inventory: *inventory,
+		RuleGraph: *rulegraph,
+	}
+	opts := migrategate.Options{
+		HighCardSeries:      *highCard,
+		HighCardLabelValues: *highCardLabels,
+	}
+	dec, err := migrategate.Evaluate(in, opts)
+	if err != nil {
+		return err
+	}
+
+	if err := writeGate(stdout, *out, dec, *asJSON); err != nil {
+		return err
+	}
+	if !dec.Pass {
+		return gateFailedError{overall: dec.Overall}
+	}
+	return nil
+}
+
+// writeGate renders the decision (text or JSON) to --out, or stdout when out is
+// empty. When writing to a file it renders into a buffer first, then commits
+// with the checked writeOut, so a flush-at-close error surfaces rather than
+// truncating the decision silently.
+func writeGate(stdout io.Writer, out string, dec migrategate.Decision, asJSON bool) error {
+	render := func(w io.Writer) error {
+		if asJSON {
+			return dec.WriteJSON(w)
+		}
+		return dec.Write(w)
+	}
+	if out == "" {
+		return render(stdout)
+	}
+	var buf bytes.Buffer
+	if err := render(&buf); err != nil {
+		return err
+	}
+	return writeOut(stdout, out, buf.Bytes())
+}
+
+// gateFailedError signals a no-go cutover decision: the gate ran and the
+// checklist was written, but a blocking stage failed. main maps it to a
+// dedicated non-zero exit code so a no-go is distinguishable from a tool error.
+type gateFailedError struct {
+	overall string
+}
+
+func (e gateFailedError) Error() string {
+	return fmt.Sprintf("cutover gate failed: overall %s (a blocking stage said no-go)", e.overall)
+}

--- a/cmd/migrate/gate_test.go
+++ b/cmd/migrate/gate_test.go
@@ -1,0 +1,220 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/migrate"
+	"github.com/tsouza/cerberus/internal/migrateverify"
+)
+
+// writeJSONFile renders one block's JSON (via its real WriteJSON writer) to a
+// file in dir, so the gate CLI reads exactly what the sibling commands emit.
+func writeJSONFile(t *testing.T, dir, name string, wj func(io.Writer) error) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	f, err := os.Create(p)
+	if err != nil {
+		t.Fatalf("create %s: %v", name, err)
+	}
+	if err := wj(f); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close %s: %v", name, err)
+	}
+	return p
+}
+
+func cleanVerifyFile(t *testing.T, dir string) string {
+	rep := migrateverify.Report{Summary: migrateverify.Summary{Total: 1, Match: 1}}
+	return writeJSONFile(t, dir, "verify.json", rep.WriteJSON)
+}
+
+func cleanClassifyFile(t *testing.T, dir string) string {
+	cl := migrate.Classification{Counts: migrate.BucketCounts{Total: 1, Supported: 1}}
+	return writeJSONFile(t, dir, "classify.json", cl.WriteJSON)
+}
+
+func orphanRuleGraphFile(t *testing.T, dir string) string {
+	g := migrate.RuleGraph{
+		Counts:   migrate.RuleGraphCounts{Recorded: 1, Orphan: 1},
+		Recorded: []migrate.RecordedNode{{Name: "job:x", Source: "r", Status: migrate.StatusOrphan}},
+	}
+	return writeJSONFile(t, dir, "rulegraph.json", g.WriteJSON)
+}
+
+// TestRunGate_PassAllClean: clean required artifacts → runGate returns nil (the
+// gate passes) and prints an overall PASS.
+func TestRunGate_PassAllClean(t *testing.T) {
+	dir := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	err := runGate([]string{
+		"--verify", cleanVerifyFile(t, dir),
+		"--classify", cleanClassifyFile(t, dir),
+		"--rulegraph", orphanRuleGraphFile(t, dir),
+	}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("runGate returned error on clean artifacts: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "OVERALL: PASS") {
+		t.Errorf("want OVERALL: PASS in output, got:\n%s", stdout.String())
+	}
+}
+
+// TestRunGate_FailsOnConsumedSeries: a consumed recorded series → runGate returns
+// a gateFailedError (which main maps to a non-zero exit) and prints OVERALL: FAIL.
+func TestRunGate_FailsOnConsumedSeries(t *testing.T) {
+	dir := t.TempDir()
+	g := migrate.RuleGraph{
+		Counts:    migrate.RuleGraphCounts{Recorded: 1, Consumed: 1, Consumers: 1},
+		Recorded:  []migrate.RecordedNode{{Name: "job:x", Source: "r", Status: migrate.StatusConsumed, Consumers: []string{"dash.json"}}},
+		Consumers: []migrate.ConsumerNode{{Expr: "job:x", Source: "dash.json", Kind: "dashboard", References: []string{"job:x"}}},
+	}
+	var stdout, stderr bytes.Buffer
+	err := runGate([]string{
+		"--verify", cleanVerifyFile(t, dir),
+		"--classify", cleanClassifyFile(t, dir),
+		"--rulegraph", writeJSONFile(t, dir, "rulegraph.json", g.WriteJSON),
+	}, &stdout, &stderr)
+
+	var gate gateFailedError
+	if !errors.As(err, &gate) {
+		t.Fatalf("want gateFailedError, got %v", err)
+	}
+	if !strings.Contains(stdout.String(), "OVERALL: FAIL") {
+		t.Errorf("want OVERALL: FAIL in output, got:\n%s", stdout.String())
+	}
+}
+
+// TestRunGate_FailsOnMissingRequired: omitting a required artifact blocks the
+// gate — the CLI must not pass by omission.
+func TestRunGate_FailsOnMissingRequired(t *testing.T) {
+	dir := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	// rulegraph omitted (required) → BLOCK.
+	err := runGate([]string{
+		"--verify", cleanVerifyFile(t, dir),
+		"--classify", cleanClassifyFile(t, dir),
+	}, &stdout, &stderr)
+
+	var gate gateFailedError
+	if !errors.As(err, &gate) {
+		t.Fatalf("want gateFailedError on missing required artifact, got %v", err)
+	}
+	if !strings.Contains(stdout.String(), "missing artifacts") {
+		t.Errorf("want a missing-artifacts note in output, got:\n%s", stdout.String())
+	}
+}
+
+// TestRunGate_JSONOutput: --json emits a machine-readable decision that parses
+// and reflects the failing verdict.
+func TestRunGate_JSONOutput(t *testing.T) {
+	dir := t.TempDir()
+	rep := migrateverify.Report{Summary: migrateverify.Summary{Total: 1, Diverge: 1}}
+	var stdout, stderr bytes.Buffer
+	err := runGate([]string{
+		"--json",
+		"--verify", writeJSONFile(t, dir, "verify.json", rep.WriteJSON),
+		"--classify", cleanClassifyFile(t, dir),
+		"--rulegraph", orphanRuleGraphFile(t, dir),
+	}, &stdout, &stderr)
+
+	var gate gateFailedError
+	if !errors.As(err, &gate) {
+		t.Fatalf("want gateFailedError, got %v", err)
+	}
+	var dec struct {
+		Pass    bool `json:"pass"`
+		Overall string
+		Stages  []struct {
+			Stage    string
+			Verdict  string
+			Blocking bool
+		} `json:"stages"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &dec); err != nil {
+		t.Fatalf("gate --json output does not parse: %v\n%s", err, stdout.String())
+	}
+	if dec.Pass || dec.Overall != "FAIL" {
+		t.Errorf("want pass=false overall=FAIL, got %+v", dec)
+	}
+	var found bool
+	for _, s := range dec.Stages {
+		if s.Stage == "verify" {
+			found = true
+			if s.Verdict != "FAIL" || !s.Blocking {
+				t.Errorf("verify stage: want FAIL+blocking, got %+v", s)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("verify stage missing from JSON output")
+	}
+}
+
+// TestRunGate_OutFile: --out writes the decision to a file rather than stdout.
+func TestRunGate_OutFile(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "decision.txt")
+	var stdout, stderr bytes.Buffer
+	err := runGate([]string{
+		"--verify", cleanVerifyFile(t, dir),
+		"--classify", cleanClassifyFile(t, dir),
+		"--rulegraph", orphanRuleGraphFile(t, dir),
+		"--out", out,
+	}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("runGate --out: %v", err)
+	}
+	data, err := os.ReadFile(out) //nolint:gosec // test-controlled path.
+	if err != nil {
+		t.Fatalf("read out file: %v", err)
+	}
+	if !strings.Contains(string(data), "OVERALL: PASS") {
+		t.Errorf("out file should contain the decision, got:\n%s", data)
+	}
+}
+
+// TestRunGate_UnparseableArtifactIsError: a supplied-but-corrupt artifact is a
+// hard error, not a gate FAIL and not a silent skip.
+func TestRunGate_UnparseableArtifactIsError(t *testing.T) {
+	dir := t.TempDir()
+	bad := filepath.Join(dir, "verify.json")
+	if err := os.WriteFile(bad, []byte("{oops"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	err := runGate([]string{"--verify", bad, "--classify", cleanClassifyFile(t, dir)}, &stdout, &stderr)
+	if err == nil {
+		t.Fatal("want a hard error on a corrupt artifact")
+	}
+	var gate gateFailedError
+	if errors.As(err, &gate) {
+		t.Fatal("a corrupt artifact must be a tool error, not a gate FAIL verdict")
+	}
+}
+
+// TestRun_GateDispatch: the top-level dispatcher routes `gate` to runGate.
+func TestRun_GateDispatch(t *testing.T) {
+	dir := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	err := run([]string{
+		"gate",
+		"--verify", cleanVerifyFile(t, dir),
+		"--classify", cleanClassifyFile(t, dir),
+		"--rulegraph", orphanRuleGraphFile(t, dir),
+	}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("run gate dispatch: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "OVERALL: PASS") {
+		t.Errorf("want PASS via dispatcher, got:\n%s", stdout.String())
+	}
+}

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -16,6 +16,8 @@
 //	  --ref <prom-url> --cerberus <url>          #   Prometheus and cerberus and diff (parity gate)
 //	migrate inventory --source <prom-url>        # probe the LIVE source Prometheus for the
 //	  --top 50                                    #   cardinality that drives OOM risk
+//	migrate gate --verify verify.json \          # fold the migration artifacts into one
+//	  --classify classify.json ...                 #   cutover go/no-go (exit 0 only on PASS)
 //
 // --schema reads the SAME CERBERUS_* environment the server uses
 // (config.FromEnv), so the previewed schema is byte-identical to what the
@@ -65,6 +67,16 @@
 // (scrape config is not realized cardinality). The numbers RANK RISK; they do
 // not predict cerberus's exact memory. A source that 404s the status endpoint
 // exits non-zero.
+//
+// gate is the cutover decision aggregator: it reads the JSON artifacts the
+// other blocks emit (--verify / --classify / --inventory / --rulegraph, all
+// optional) and folds them into one PASS/FAIL go/no-go, reporting a per-stage
+// checklist and which artifacts were missing. It is pure and offline — reads
+// JSON, runs no query. It REFUSES (non-zero exit), never merely warns, on any
+// blocking input: a verify divergence/error, a classify unsupported, a
+// consumed recorded series that must stay materialized, or a missing required
+// artifact. High source cardinality WARNs but does not block. Exit 0 only on
+// overall PASS.
 package main
 
 import (
@@ -106,9 +118,15 @@ func main() {
 	fmt.Fprintln(os.Stderr, "migrate:", err)
 	// A failed parity gate is a real, expected outcome (cerberus diverged) — it
 	// gets its own exit code so callers can tell it apart from a tool error.
-	var gate verifyFailedError
-	if errors.As(err, &gate) {
+	var vgate verifyFailedError
+	if errors.As(err, &vgate) {
 		os.Exit(verifyExitFail)
+	}
+	// A failed cutover gate (a blocking stage said no-go) is likewise an expected
+	// outcome with its own exit code, distinct from a tool error.
+	var cgate gateFailedError
+	if errors.As(err, &cgate) {
+		os.Exit(gateExitFail)
 	}
 	os.Exit(1)
 }
@@ -155,6 +173,8 @@ func run(args []string, stdout, stderr io.Writer) error {
 			return runVerify(args[1:], stdout, stderr)
 		case "inventory":
 			return runInventory(args[1:], stdout, stderr)
+		case "gate":
+			return runGate(args[1:], stdout, stderr)
 		}
 	}
 

--- a/internal/migrategate/gate.go
+++ b/internal/migrategate/gate.go
@@ -1,0 +1,356 @@
+// Package migrategate folds the machine-readable artifacts the other migration
+// blocks emit — verify, classify, inventory, rulegraph — into a single
+// cutover go/no-go decision. It is a pure, offline aggregator: it reads the
+// JSON each block writes with its `--json` flag, applies a small set of
+// conservative rules, and reports a per-stage checklist plus one overall
+// PASS/FAIL verdict. It opens no network connection and runs no query.
+//
+// The gate REFUSES (a blocking stage → overall FAIL, non-zero exit), it never
+// merely warns, on any blocking input. The rules (v1, deliberately
+// conservative) are:
+//
+//   - verify   — BLOCK if any query diverged or errored (the parity gate found
+//     cerberus returning different numbers, or a backend failing).
+//   - classify — BLOCK if any corpus query is unsupported (no cerberus
+//     equivalent). A supported-but-risky query WARNs but does not block.
+//   - inventory — WARN (never block) when the source carries high-cardinality
+//     metrics or labels: an OOM candidate to review, not a correctness stop.
+//   - rulegraph — BLOCK if any recorded series is consumed: a dashboard or
+//     alert depends on it, so it MUST keep being materialized after cutover;
+//     dropping its materializer leaves a blank panel. Orphan recorded series
+//     (nobody reads them) are safe and never block.
+//
+// A required artifact that was not supplied is itself a BLOCK: the gate cannot
+// prove safety for a stage it never saw. verify, classify, and rulegraph are
+// required; inventory is advisory (its worst outcome is a WARN), so a missing
+// inventory artifact is reported but does not block.
+package migrategate
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+
+	"github.com/tsouza/cerberus/internal/migrate"
+	"github.com/tsouza/cerberus/internal/migrateinventory"
+	"github.com/tsouza/cerberus/internal/migrateverify"
+)
+
+// Stage names, stable across text and JSON output.
+const (
+	StageVerify    = "verify"
+	StageClassify  = "classify"
+	StageInventory = "inventory"
+	StageRuleGraph = "rulegraph"
+)
+
+// Verdicts a stage can carry. FAIL and a missing REQUIRED artifact block the
+// cutover; WARN and PASS do not; MISSING marks an artifact that was not
+// supplied (blocking only when the stage is required).
+const (
+	VerdictPass    = "PASS"
+	VerdictFail    = "FAIL"
+	VerdictWarn    = "WARN"
+	VerdictMissing = "MISSING"
+)
+
+// Overall decision strings.
+const (
+	OverallPass = "PASS"
+	OverallFail = "FAIL"
+)
+
+// DefaultHighCardSeries is the head series count at or above which a single
+// metric name is flagged as a high-cardinality OOM candidate (a WARN, never a
+// block). A metric with this many active series drives a large fan-out.
+const DefaultHighCardSeries int64 = 100_000
+
+// DefaultHighCardLabelValues is the distinct-value count at or above which a
+// single label name is flagged as high-cardinality: wide labels drive group-by
+// and join fan-out.
+const DefaultHighCardLabelValues int64 = 50_000
+
+// jsonIndent matches the two-space indent the other migration blocks emit, so
+// the gate's JSON reads the same as its inputs.
+const jsonIndent = "  "
+
+// Inputs holds the paths to the four artifact files. Every path is optional;
+// an empty path means that artifact was not supplied, which the gate reports
+// (and, for a required stage, blocks on).
+type Inputs struct {
+	Verify    string
+	Classify  string
+	Inventory string
+	RuleGraph string
+}
+
+// Options tunes the advisory thresholds. Zero values fall back to the package
+// defaults, so a caller can leave the struct empty for the standard gate.
+type Options struct {
+	HighCardSeries      int64
+	HighCardLabelValues int64
+}
+
+func (o Options) highCardSeries() int64 {
+	if o.HighCardSeries > 0 {
+		return o.HighCardSeries
+	}
+	return DefaultHighCardSeries
+}
+
+func (o Options) highCardLabelValues() int64 {
+	if o.HighCardLabelValues > 0 {
+		return o.HighCardLabelValues
+	}
+	return DefaultHighCardLabelValues
+}
+
+// StageResult is one stage's line in the go/no-go checklist. Present reports
+// whether the artifact was supplied; Blocking reports whether this stage
+// prevents the cutover (a FAIL, or a required artifact that is missing).
+// Reasons lists every rule that fired, in a deterministic order.
+type StageResult struct {
+	Stage    string   `json:"stage"`
+	Present  bool     `json:"present"`
+	Required bool     `json:"required"`
+	Verdict  string   `json:"verdict"`
+	Blocking bool     `json:"blocking"`
+	Reasons  []string `json:"reasons"`
+}
+
+// Decision is the full go/no-go result: one entry per stage, the names of the
+// artifacts that were missing, and the overall verdict. Pass is true — and the
+// CLI exits 0 — only when no stage blocks.
+type Decision struct {
+	Pass    bool          `json:"pass"`
+	Overall string        `json:"overall"`
+	Stages  []StageResult `json:"stages"`
+	Missing []string      `json:"missing"`
+}
+
+// Evaluate reads whichever artifacts were supplied, applies the gate rules, and
+// returns the decision. A supplied-but-unreadable or unparseable artifact is a
+// hard error (not a silent skip and not a gate FAIL): the operator handed the
+// gate a file it cannot trust, which is a misconfiguration to surface, not a
+// safety verdict to invent.
+func Evaluate(in Inputs, opts Options) (Decision, error) {
+	verify, err := evalVerify(in.Verify)
+	if err != nil {
+		return Decision{}, err
+	}
+	classify, err := evalClassify(in.Classify)
+	if err != nil {
+		return Decision{}, err
+	}
+	inventory, err := evalInventory(in.Inventory, opts)
+	if err != nil {
+		return Decision{}, err
+	}
+	rulegraph, err := evalRuleGraph(in.RuleGraph)
+	if err != nil {
+		return Decision{}, err
+	}
+
+	dec := Decision{Stages: []StageResult{verify, classify, inventory, rulegraph}}
+	dec.Pass = true
+	for _, s := range dec.Stages {
+		if s.Blocking {
+			dec.Pass = false
+		}
+		if !s.Present {
+			dec.Missing = append(dec.Missing, s.Stage)
+		}
+	}
+	if dec.Pass {
+		dec.Overall = OverallPass
+	} else {
+		dec.Overall = OverallFail
+	}
+	return dec, nil
+}
+
+// evalVerify blocks when the parity gate found any divergence or backend error.
+// verify is a required artifact: a cutover cannot be proven safe without it.
+func evalVerify(path string) (StageResult, error) {
+	res := StageResult{Stage: StageVerify, Required: true}
+	if path == "" {
+		return missingRequired(res, "--verify"), nil
+	}
+	var rep migrateverify.Report
+	if err := readArtifact(path, &rep); err != nil {
+		return StageResult{}, err
+	}
+	res.Present = true
+	if d, e := rep.Summary.Diverge, rep.Summary.Error; d > 0 || e > 0 {
+		res.Verdict = VerdictFail
+		res.Blocking = true
+		res.Reasons = append(res.Reasons,
+			fmt.Sprintf("parity gate failed: %d diverge, %d error (of %d queries)", d, e, rep.Summary.Total))
+		return res, nil
+	}
+	res.Verdict = VerdictPass
+	return res, nil
+}
+
+// evalClassify blocks when any corpus query is unsupported (no cerberus
+// equivalent). A supported-but-risky query WARNs but does not block. classify
+// is a required artifact.
+func evalClassify(path string) (StageResult, error) {
+	res := StageResult{Stage: StageClassify, Required: true}
+	if path == "" {
+		return missingRequired(res, "--classify"), nil
+	}
+	var cl migrate.Classification
+	if err := readArtifact(path, &cl); err != nil {
+		return StageResult{}, err
+	}
+	res.Present = true
+	if cl.Counts.Unsupported > 0 {
+		res.Verdict = VerdictFail
+		res.Blocking = true
+		res.Reasons = append(res.Reasons,
+			fmt.Sprintf("%d unsupported quer%s (no cerberus equivalent)",
+				cl.Counts.Unsupported, plural(cl.Counts.Unsupported, "y", "ies")))
+		for _, name := range unsupportedConstructs(cl) {
+			res.Reasons = append(res.Reasons, "  unsupported: "+name)
+		}
+		return res, nil
+	}
+	if cl.Counts.Risky > 0 {
+		res.Verdict = VerdictWarn
+		res.Reasons = append(res.Reasons,
+			fmt.Sprintf("%d supported quer%s carry an offline fan-out risk flag",
+				cl.Counts.Risky, plural(cl.Counts.Risky, "y", "ies")))
+		return res, nil
+	}
+	res.Verdict = VerdictPass
+	return res, nil
+}
+
+// evalInventory WARNs (never blocks) when the source carries a high-cardinality
+// metric or label. inventory is advisory: its worst outcome is a WARN, so a
+// missing inventory artifact is reported but does not block the cutover.
+func evalInventory(path string, opts Options) (StageResult, error) {
+	res := StageResult{Stage: StageInventory, Required: false}
+	if path == "" {
+		res.Verdict = VerdictMissing
+		res.Reasons = append(res.Reasons,
+			"artifact not provided (--inventory); source cardinality risk unchecked")
+		return res, nil
+	}
+	var inv migrateinventory.Inventory
+	if err := readArtifact(path, &inv); err != nil {
+		return StageResult{}, err
+	}
+	res.Present = true
+
+	seriesLimit := opts.highCardSeries()
+	for _, m := range inv.TopMetricsBySeries {
+		if m.Value >= seriesLimit {
+			res.Reasons = append(res.Reasons,
+				fmt.Sprintf("high-cardinality metric %q: %d series (>= %d)", m.Name, m.Value, seriesLimit))
+		}
+	}
+	labelLimit := opts.highCardLabelValues()
+	for _, l := range inv.TopLabelsByValues {
+		if l.Value >= labelLimit {
+			res.Reasons = append(res.Reasons,
+				fmt.Sprintf("high-cardinality label %q: %d values (>= %d)", l.Name, l.Value, labelLimit))
+		}
+	}
+
+	if len(res.Reasons) > 0 {
+		res.Verdict = VerdictWarn
+		return res, nil
+	}
+	res.Verdict = VerdictPass
+	return res, nil
+}
+
+// evalRuleGraph blocks when any recorded series is consumed: a dashboard or
+// alert reads it, so it MUST keep being materialized after cutover — dropping
+// its recording rule leaves a blank panel. Orphan recorded series (read by
+// nobody) are safe to drop and never block. rulegraph is a required artifact.
+func evalRuleGraph(path string) (StageResult, error) {
+	res := StageResult{Stage: StageRuleGraph, Required: true}
+	if path == "" {
+		return missingRequired(res, "--rulegraph"), nil
+	}
+	var g migrate.RuleGraph
+	if err := readArtifact(path, &g); err != nil {
+		return StageResult{}, err
+	}
+	res.Present = true
+
+	var consumed []migrate.RecordedNode
+	for _, n := range g.Recorded {
+		if n.Status == migrate.StatusConsumed {
+			consumed = append(consumed, n)
+		}
+	}
+	if len(consumed) > 0 {
+		res.Verdict = VerdictFail
+		res.Blocking = true
+		res.Reasons = append(res.Reasons,
+			fmt.Sprintf("%d consumed recorded series must stay materialized after cutover",
+				len(consumed)))
+		for _, n := range consumed {
+			res.Reasons = append(res.Reasons,
+				fmt.Sprintf("  %s <- %d consumer%s", n.Name, len(n.Consumers), plural(len(n.Consumers), "", "s")))
+		}
+		return res, nil
+	}
+	res.Verdict = VerdictPass
+	return res, nil
+}
+
+// missingRequired marks a required stage whose artifact was not supplied as a
+// blocking MISSING: the gate cannot prove that stage safe without seeing it.
+func missingRequired(res StageResult, flag string) StageResult {
+	res.Verdict = VerdictMissing
+	res.Blocking = true
+	res.Reasons = append(res.Reasons,
+		fmt.Sprintf("required artifact not provided (%s); cannot prove safety", flag))
+	return res
+}
+
+// unsupportedConstructs returns the sorted, deduplicated set of rejection
+// messages across the unsupported queries, so the gate names WHAT is
+// unsupported rather than only counting.
+func unsupportedConstructs(cl migrate.Classification) []string {
+	seen := map[string]struct{}{}
+	for _, q := range cl.Queries {
+		if q.Bucket == migrate.BucketUnsupported && q.Construct != "" {
+			seen[q.Construct] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for c := range seen {
+		out = append(out, c)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// plural picks the singular or plural suffix for n.
+func plural(n int, one, many string) string {
+	if n == 1 {
+		return one
+	}
+	return many
+}
+
+// readArtifact reads and JSON-decodes one artifact file into v. A read or
+// decode failure is wrapped with the path so the operator can tell which
+// artifact is at fault.
+func readArtifact(path string, v any) error {
+	data, err := os.ReadFile(path) //nolint:gosec // operator-supplied artifact path; offline CLI input.
+	if err != nil {
+		return fmt.Errorf("read artifact %q: %w", path, err)
+	}
+	if err := json.Unmarshal(data, v); err != nil {
+		return fmt.Errorf("parse artifact %q: %w", path, err)
+	}
+	return nil
+}

--- a/internal/migrategate/gate.go
+++ b/internal/migrategate/gate.go
@@ -10,20 +10,35 @@
 // conservative) are:
 //
 //   - verify   — BLOCK if any query diverged or errored (the parity gate found
-//     cerberus returning different numbers, or a backend failing).
+//     cerberus returning different numbers, or a backend failing). WARN when the
+//     report carries UNCHECKED entries — queries that emitted SQL but returned
+//     no comparable matrix live (Unsupported), harvest-skipped entries, or
+//     out-of-scope (non-PromQL) entries — so a green parity gate never hides an
+//     unexamined input.
 //   - classify — BLOCK if any corpus query is unsupported (no cerberus
-//     equivalent). A supported-but-risky query WARNs but does not block.
+//     equivalent). A supported-but-risky query WARNs but does not block; a
+//     harvest-skipped corpus entry (never classified) also WARNs.
 //   - inventory — WARN (never block) when the source carries high-cardinality
 //     metrics or labels: an OOM candidate to review, not a correctness stop.
+//     Also WARNs on every honesty caveat the probe recorded (an optional
+//     enrichment it could not fetch), so an enrichment failure never reads clean.
 //   - rulegraph — BLOCK if any recorded series is consumed: a dashboard or
 //     alert depends on it, so it MUST keep being materialized after cutover;
 //     dropping its materializer leaves a blank panel. Orphan recorded series
-//     (nobody reads them) are safe and never block.
+//     (nobody reads them) are safe and never block — BUT any SKIPPED input (an
+//     unparseable consumer expr, an unreadable rule file) also BLOCKS, because a
+//     dropped consumer that referenced a series would have marked it consumed;
+//     with a skip, "orphan ⇒ safe to drop" is unsound and the stage can no
+//     longer prove a panel won't go blank.
 //
 // A required artifact that was not supplied is itself a BLOCK: the gate cannot
 // prove safety for a stage it never saw. verify, classify, and rulegraph are
 // required; inventory is advisory (its worst outcome is a WARN), so a missing
 // inventory artifact is reported but does not block.
+//
+// Every count each upstream block deliberately preserves — the skip/unchecked/
+// caveat tallies — is threaded into a stage's Reasons here, never silently
+// re-dropped at the aggregation layer.
 package migrategate
 
 import (
@@ -182,20 +197,60 @@ func evalVerify(path string) (StageResult, error) {
 		return StageResult{}, err
 	}
 	res.Present = true
-	if d, e := rep.Summary.Diverge, rep.Summary.Error; d > 0 || e > 0 {
+	s := rep.Summary
+	caveats := verifyCaveats(s)
+	if s.Diverge > 0 || s.Error > 0 {
 		res.Verdict = VerdictFail
 		res.Blocking = true
 		res.Reasons = append(res.Reasons,
-			fmt.Sprintf("parity gate failed: %d diverge, %d error (of %d queries)", d, e, rep.Summary.Total))
+			fmt.Sprintf("parity gate failed: %d diverge, %d error (of %d queries)", s.Diverge, s.Error, s.Total))
+		res.Reasons = append(res.Reasons, caveats...)
+		return res, nil
+	}
+	if len(caveats) > 0 {
+		res.Verdict = VerdictWarn
+		res.Reasons = append(res.Reasons, caveats...)
 		return res, nil
 	}
 	res.Verdict = VerdictPass
 	return res, nil
 }
 
+// verifyCaveats surfaces the parity counts that Report.Failed() deliberately
+// does NOT block on but that each leave a query UNCHECKED against a reference
+// backend: a query cerberus emitted SQL for whose live response was not a
+// comparable matrix (Unsupported — e.g. a non-200 or non-matrix body), a corpus
+// entry that never became a replayable query (HarvestSkipped), and a non-PromQL
+// entry with no Prometheus baseline (OutOfScope). Each is an unexamined input
+// the operator must see before trusting a green parity gate — counted here,
+// never silently dropped.
+func verifyCaveats(s migrateverify.Summary) []string {
+	var out []string
+	if s.Unsupported > 0 {
+		out = append(out, fmt.Sprintf(
+			"%d quer%s emitted SQL but returned no comparable matrix live (unverified against the backend)",
+			s.Unsupported, plural(s.Unsupported, "y", "ies"),
+		))
+	}
+	if s.HarvestSkipped > 0 {
+		out = append(out, fmt.Sprintf(
+			"%d harvest-skipped corpus entr%s never became a replayable query (unchecked)",
+			s.HarvestSkipped, plural(s.HarvestSkipped, "y", "ies"),
+		))
+	}
+	if s.OutOfScope > 0 {
+		out = append(out, fmt.Sprintf(
+			"%d out-of-scope entr%s (not PromQL; no Prometheus baseline, unchecked)",
+			s.OutOfScope, plural(s.OutOfScope, "y", "ies"),
+		))
+	}
+	return out
+}
+
 // evalClassify blocks when any corpus query is unsupported (no cerberus
-// equivalent). A supported-but-risky query WARNs but does not block. classify
-// is a required artifact.
+// equivalent). A supported-but-risky query WARNs but does not block; a
+// harvest-skipped corpus entry (carried through but never classified) also
+// WARNs. classify is a required artifact.
 func evalClassify(path string) (StageResult, error) {
 	res := StageResult{Stage: StageClassify, Required: true}
 	if path == "" {
@@ -215,22 +270,53 @@ func evalClassify(path string) (StageResult, error) {
 		for _, name := range unsupportedConstructs(cl) {
 			res.Reasons = append(res.Reasons, "  unsupported: "+name)
 		}
+		res.Reasons = append(res.Reasons, classifyHarvestSkips(cl)...)
 		return res, nil
 	}
+	var warn []string
 	if cl.Counts.Risky > 0 {
+		warn = append(warn, fmt.Sprintf(
+			"%d supported quer%s carry an offline fan-out risk flag",
+			cl.Counts.Risky, plural(cl.Counts.Risky, "y", "ies"),
+		))
+	}
+	warn = append(warn, classifyHarvestSkips(cl)...)
+	if len(warn) > 0 {
 		res.Verdict = VerdictWarn
-		res.Reasons = append(res.Reasons,
-			fmt.Sprintf("%d supported quer%s carry an offline fan-out risk flag",
-				cl.Counts.Risky, plural(cl.Counts.Risky, "y", "ies")))
+		res.Reasons = append(res.Reasons, warn...)
 		return res, nil
 	}
 	res.Verdict = VerdictPass
 	return res, nil
 }
 
+// classifyHarvestSkips surfaces the corpus entries the harvester could not turn
+// into a query (an unreadable file, a YAML parse failure, a rule with no
+// expression). classify carries them through "so the skip count never gets
+// lost"; the gate must report them, because a skipped consumer is a query that
+// was NEVER classified — an unexamined input that would otherwise hide behind a
+// green classify.
+func classifyHarvestSkips(cl migrate.Classification) []string {
+	if len(cl.Skipped) == 0 {
+		return nil
+	}
+	return []string{fmt.Sprintf(
+		"%d harvest-skipped corpus entr%s never classified (unexamined)",
+		len(cl.Skipped), plural(len(cl.Skipped), "y", "ies"),
+	)}
+}
+
+// enrichmentUnavailable is the sentinel migrateinventory writes into a *Total
+// field when its optional enrichment probe could not be fetched: the count is
+// unknown, not zero. The gate surfaces it as a caveat so a probe that silently
+// failed an enrichment does not read as a clean inventory.
+const enrichmentUnavailable = -1
+
 // evalInventory WARNs (never blocks) when the source carries a high-cardinality
-// metric or label. inventory is advisory: its worst outcome is a WARN, so a
-// missing inventory artifact is reported but does not block the cutover.
+// metric or label, or when the probe recorded an honesty caveat (an optional
+// enrichment it could not fetch). inventory is advisory: its worst outcome is a
+// WARN, so a missing inventory artifact is reported but does not block the
+// cutover.
 func evalInventory(path string, opts Options) (StageResult, error) {
 	res := StageResult{Stage: StageInventory, Required: false}
 	if path == "" {
@@ -259,6 +345,7 @@ func evalInventory(path string, opts Options) (StageResult, error) {
 				fmt.Sprintf("high-cardinality label %q: %d values (>= %d)", l.Name, l.Value, labelLimit))
 		}
 	}
+	res.Reasons = append(res.Reasons, inventoryCaveats(inv)...)
 
 	if len(res.Reasons) > 0 {
 		res.Verdict = VerdictWarn
@@ -268,10 +355,38 @@ func evalInventory(path string, opts Options) (StageResult, error) {
 	return res, nil
 }
 
+// inventoryCaveats surfaces every honesty caveat the inventory carries: the
+// optional-enrichment failures the probe recorded in Notes (which the inventory
+// keeps "counted, never silently dropped"), plus an enrichment-not-obtained
+// signal (a -1 total) for a note-less artifact. The gate must not re-drop them:
+// an enrichment the probe could not fetch is an unchecked corner of the source,
+// not a clean bill of health.
+func inventoryCaveats(inv migrateinventory.Inventory) []string {
+	out := append([]string(nil), inv.Notes...)
+	if len(inv.Notes) > 0 {
+		// A recorded Note already explains each -1 total; the probe appends one
+		// per failed enrichment. Surfacing the notes covers the -1 case without
+		// double-reporting it.
+		return out
+	}
+	if inv.MetricNameTotal == enrichmentUnavailable {
+		out = append(out, "distinct metric-name total not obtained (enrichment unavailable)")
+	}
+	if inv.MetadataMetricTotal == enrichmentUnavailable {
+		out = append(out, "metric metadata total not obtained (enrichment unavailable)")
+	}
+	return out
+}
+
 // evalRuleGraph blocks when any recorded series is consumed: a dashboard or
 // alert reads it, so it MUST keep being materialized after cutover — dropping
 // its recording rule leaves a blank panel. Orphan recorded series (read by
-// nobody) are safe to drop and never block. rulegraph is a required artifact.
+// nobody) are safe to drop and never block — BUT any SKIPPED input also blocks:
+// the builder could not use it (an unparseable consumer expr, an unreadable rule
+// file), so a consumer that referenced a recorded series may have been dropped,
+// leaving that series wrongly classified orphan. With a skip, "orphan ⇒ safe to
+// drop" is unsound, so the gate refuses rather than green-light dropping a
+// materializer the skipped consumer needs. rulegraph is a required artifact.
 func evalRuleGraph(path string) (StageResult, error) {
 	res := StageResult{Stage: StageRuleGraph, Required: true}
 	if path == "" {
@@ -289,9 +404,17 @@ func evalRuleGraph(path string) (StageResult, error) {
 			consumed = append(consumed, n)
 		}
 	}
+	// A skip invalidates the orphan classification the whole stage rests on, so
+	// it blocks alongside any consumed series.
+	blockingSkip := g.Counts.Skipped > 0
+	if len(consumed) == 0 && !blockingSkip {
+		res.Verdict = VerdictPass
+		return res, nil
+	}
+
+	res.Verdict = VerdictFail
+	res.Blocking = true
 	if len(consumed) > 0 {
-		res.Verdict = VerdictFail
-		res.Blocking = true
 		res.Reasons = append(res.Reasons,
 			fmt.Sprintf("%d consumed recorded series must stay materialized after cutover",
 				len(consumed)))
@@ -299,9 +422,16 @@ func evalRuleGraph(path string) (StageResult, error) {
 			res.Reasons = append(res.Reasons,
 				fmt.Sprintf("  %s <- %d consumer%s", n.Name, len(n.Consumers), plural(len(n.Consumers), "", "s")))
 		}
-		return res, nil
 	}
-	res.Verdict = VerdictPass
+	if blockingSkip {
+		res.Reasons = append(res.Reasons,
+			fmt.Sprintf("%d skipped input%s make the orphan classification unsound (a dropped consumer may reference a series marked orphan)",
+				g.Counts.Skipped, plural(g.Counts.Skipped, "", "s")))
+		for _, sk := range g.Skipped {
+			res.Reasons = append(res.Reasons,
+				fmt.Sprintf("  skipped %s: %s", sk.Source, sk.Reason))
+		}
+	}
 	return res, nil
 }
 

--- a/internal/migrategate/gate_test.go
+++ b/internal/migrategate/gate_test.go
@@ -1,0 +1,410 @@
+package migrategate_test
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/migrate"
+	"github.com/tsouza/cerberus/internal/migrategate"
+	"github.com/tsouza/cerberus/internal/migrateinventory"
+	"github.com/tsouza/cerberus/internal/migrateverify"
+)
+
+// writeArtifact renders one block's JSON (via its real WriteJSON writer, so the
+// gate reads exactly what the CLI emits) into a temp file and returns its path.
+func writeArtifact(t *testing.T, name string, wj func(io.Writer) error) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), name)
+	f, err := os.Create(p)
+	if err != nil {
+		t.Fatalf("create %s: %v", name, err)
+	}
+	if err := wj(f); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close %s: %v", name, err)
+	}
+	return p
+}
+
+// cleanVerify is a parity report with no divergence and no error.
+func cleanVerify(t *testing.T) string {
+	rep := migrateverify.Report{Summary: migrateverify.Summary{Total: 3, Match: 3}}
+	return writeArtifact(t, "verify.json", rep.WriteJSON)
+}
+
+// cleanClassify is a classification with everything supported and nothing risky.
+func cleanClassify(t *testing.T) string {
+	cl := migrate.Classification{Counts: migrate.BucketCounts{Total: 2, Supported: 2}}
+	return writeArtifact(t, "classify.json", cl.WriteJSON)
+}
+
+// cleanInventory is an inventory whose top cardinalities are below the WARN
+// thresholds.
+func cleanInventory(t *testing.T) string {
+	inv := migrateinventory.Inventory{
+		Source: "http://src", Top: 5, MetricNameTotal: -1, MetadataMetricTotal: -1,
+		TopMetricsBySeries: []migrateinventory.NameValue{{Name: "up", Value: 12}},
+		TopLabelsByValues:  []migrateinventory.NameValue{{Name: "instance", Value: 30}},
+	}
+	return writeArtifact(t, "inventory.json", inv.WriteJSON)
+}
+
+// cleanRuleGraph is a rulegraph whose recorded series are all orphan (safe to
+// drop; nobody consumes them).
+func cleanRuleGraph(t *testing.T) string {
+	g := migrate.RuleGraph{
+		Counts:   migrate.RuleGraphCounts{Recorded: 1, Orphan: 1},
+		Recorded: []migrate.RecordedNode{{Name: "job:foo:rate", Source: "rules.yml", Status: migrate.StatusOrphan}},
+	}
+	return writeArtifact(t, "rulegraph.json", g.WriteJSON)
+}
+
+// stageByName finds a stage result in a decision.
+func stageByName(t *testing.T, d migrategate.Decision, name string) migrategate.StageResult {
+	t.Helper()
+	for _, s := range d.Stages {
+		if s.Stage == name {
+			return s
+		}
+	}
+	t.Fatalf("stage %q not found in decision", name)
+	return migrategate.StageResult{}
+}
+
+func TestEvaluatePassCleanArtifacts(t *testing.T) {
+	in := migrategate.Inputs{
+		Verify:    cleanVerify(t),
+		Classify:  cleanClassify(t),
+		Inventory: cleanInventory(t),
+		RuleGraph: cleanRuleGraph(t),
+	}
+	dec, err := migrategate.Evaluate(in, migrategate.Options{})
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if !dec.Pass || dec.Overall != migrategate.OverallPass {
+		t.Fatalf("want PASS, got pass=%v overall=%q stages=%+v", dec.Pass, dec.Overall, dec.Stages)
+	}
+	for _, s := range dec.Stages {
+		if s.Verdict != migrategate.VerdictPass {
+			t.Errorf("stage %q: want PASS, got %q (%v)", s.Stage, s.Verdict, s.Reasons)
+		}
+		if s.Blocking {
+			t.Errorf("stage %q blocked on clean input", s.Stage)
+		}
+	}
+	if len(dec.Missing) != 0 {
+		t.Errorf("clean run should report no missing artifacts, got %v", dec.Missing)
+	}
+}
+
+func TestEvaluateBlocksOnVerifyDiverge(t *testing.T) {
+	rep := migrateverify.Report{
+		Summary: migrateverify.Summary{Total: 3, Match: 2, Diverge: 1},
+		Results: []migrateverify.QueryResult{{Source: "r", Expr: "up", Verdict: migrateverify.VerdictDiverge}},
+	}
+	in := migrategate.Inputs{
+		Verify:    writeArtifact(t, "verify.json", rep.WriteJSON),
+		Classify:  cleanClassify(t),
+		Inventory: cleanInventory(t),
+		RuleGraph: cleanRuleGraph(t),
+	}
+	dec, err := migrategate.Evaluate(in, migrategate.Options{})
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if dec.Pass || dec.Overall != migrategate.OverallFail {
+		t.Fatalf("want FAIL, got pass=%v overall=%q", dec.Pass, dec.Overall)
+	}
+	v := stageByName(t, dec, migrategate.StageVerify)
+	if v.Verdict != migrategate.VerdictFail || !v.Blocking {
+		t.Fatalf("verify stage: want FAIL+blocking, got %q blocking=%v", v.Verdict, v.Blocking)
+	}
+	// Only verify should block; the other stages stay clean.
+	if s := stageByName(t, dec, migrategate.StageClassify); s.Blocking {
+		t.Errorf("classify blocked on a verify-only failure")
+	}
+}
+
+func TestEvaluateBlocksOnVerifyError(t *testing.T) {
+	rep := migrateverify.Report{Summary: migrateverify.Summary{Total: 2, Match: 1, Error: 1}}
+	in := migrategate.Inputs{
+		Verify:    writeArtifact(t, "verify.json", rep.WriteJSON),
+		Classify:  cleanClassify(t),
+		Inventory: cleanInventory(t),
+		RuleGraph: cleanRuleGraph(t),
+	}
+	dec, err := migrategate.Evaluate(in, migrategate.Options{})
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	v := stageByName(t, dec, migrategate.StageVerify)
+	if dec.Pass || v.Verdict != migrategate.VerdictFail || !v.Blocking {
+		t.Fatalf("want verify FAIL+blocking, got pass=%v verdict=%q", dec.Pass, v.Verdict)
+	}
+}
+
+func TestEvaluateBlocksOnClassifyUnsupported(t *testing.T) {
+	cl := migrate.Classification{
+		Counts: migrate.BucketCounts{Total: 2, Supported: 1, Unsupported: 1},
+		Queries: []migrate.ClassifiedQuery{
+			{Expr: "weird()", Source: "s", Kind: "rule", Bucket: migrate.BucketUnsupported, Construct: `unsupported function "weird"`},
+		},
+	}
+	in := migrategate.Inputs{
+		Verify:    cleanVerify(t),
+		Classify:  writeArtifact(t, "classify.json", cl.WriteJSON),
+		Inventory: cleanInventory(t),
+		RuleGraph: cleanRuleGraph(t),
+	}
+	dec, err := migrategate.Evaluate(in, migrategate.Options{})
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	c := stageByName(t, dec, migrategate.StageClassify)
+	if dec.Pass || c.Verdict != migrategate.VerdictFail || !c.Blocking {
+		t.Fatalf("want classify FAIL+blocking, got pass=%v verdict=%q", dec.Pass, c.Verdict)
+	}
+	if !containsSubstr(c.Reasons, "weird") {
+		t.Errorf("classify reasons should name the unsupported construct, got %v", c.Reasons)
+	}
+}
+
+func TestEvaluateBlocksOnConsumedRecordedSeries(t *testing.T) {
+	g := migrate.RuleGraph{
+		Counts: migrate.RuleGraphCounts{Recorded: 2, Consumed: 1, Orphan: 1, Consumers: 1},
+		Recorded: []migrate.RecordedNode{
+			{Name: "job:http:rate", Source: "rules.yml", Status: migrate.StatusConsumed, Consumers: []string{"dash.json"}},
+			{Name: "job:idle:rate", Source: "rules.yml", Status: migrate.StatusOrphan},
+		},
+		Consumers: []migrate.ConsumerNode{
+			{Expr: "job:http:rate", Source: "dash.json", Kind: "dashboard", References: []string{"job:http:rate"}},
+		},
+	}
+	in := migrategate.Inputs{
+		Verify:    cleanVerify(t),
+		Classify:  cleanClassify(t),
+		Inventory: cleanInventory(t),
+		RuleGraph: writeArtifact(t, "rulegraph.json", g.WriteJSON),
+	}
+	dec, err := migrategate.Evaluate(in, migrategate.Options{})
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	r := stageByName(t, dec, migrategate.StageRuleGraph)
+	if dec.Pass || r.Verdict != migrategate.VerdictFail || !r.Blocking {
+		t.Fatalf("want rulegraph FAIL+blocking, got pass=%v verdict=%q", dec.Pass, r.Verdict)
+	}
+	if !containsSubstr(r.Reasons, "job:http:rate") {
+		t.Errorf("rulegraph reasons should name the consumed series, got %v", r.Reasons)
+	}
+}
+
+func TestEvaluateBlocksOnMissingRequiredArtifact(t *testing.T) {
+	// Omit verify (a required artifact). The gate cannot prove parity safety, so
+	// it blocks on the missing input rather than passing by omission.
+	in := migrategate.Inputs{
+		Classify:  cleanClassify(t),
+		Inventory: cleanInventory(t),
+		RuleGraph: cleanRuleGraph(t),
+	}
+	dec, err := migrategate.Evaluate(in, migrategate.Options{})
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	v := stageByName(t, dec, migrategate.StageVerify)
+	if dec.Pass || v.Verdict != migrategate.VerdictMissing || !v.Blocking {
+		t.Fatalf("want verify MISSING+blocking, got pass=%v verdict=%q blocking=%v", dec.Pass, v.Verdict, v.Blocking)
+	}
+	if !containsExact(dec.Missing, migrategate.StageVerify) {
+		t.Errorf("verify should be reported as missing, got %v", dec.Missing)
+	}
+}
+
+func TestEvaluateWarnsButPassesOnHighCardinality(t *testing.T) {
+	inv := migrateinventory.Inventory{
+		Source: "http://src", Top: 5, MetricNameTotal: -1, MetadataMetricTotal: -1,
+		TopMetricsBySeries: []migrateinventory.NameValue{{Name: "http_requests_total", Value: 250_000}},
+		TopLabelsByValues:  []migrateinventory.NameValue{{Name: "user_id", Value: 80_000}},
+	}
+	in := migrategate.Inputs{
+		Verify:    cleanVerify(t),
+		Classify:  cleanClassify(t),
+		Inventory: writeArtifact(t, "inventory.json", inv.WriteJSON),
+		RuleGraph: cleanRuleGraph(t),
+	}
+	dec, err := migrategate.Evaluate(in, migrategate.Options{})
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	iv := stageByName(t, dec, migrategate.StageInventory)
+	if iv.Verdict != migrategate.VerdictWarn {
+		t.Fatalf("want inventory WARN, got %q", iv.Verdict)
+	}
+	if iv.Blocking {
+		t.Errorf("high cardinality must WARN, never block")
+	}
+	if !dec.Pass || dec.Overall != migrategate.OverallPass {
+		t.Fatalf("a WARN-only run should PASS overall, got pass=%v overall=%q", dec.Pass, dec.Overall)
+	}
+	if !containsSubstr(iv.Reasons, "http_requests_total") || !containsSubstr(iv.Reasons, "user_id") {
+		t.Errorf("inventory reasons should name both offenders, got %v", iv.Reasons)
+	}
+}
+
+func TestEvaluateMissingInventoryIsAdvisoryNotBlocking(t *testing.T) {
+	// Inventory is advisory: its worst outcome is a WARN, so a missing inventory
+	// artifact is reported but does not block a cutover.
+	in := migrategate.Inputs{
+		Verify:   cleanVerify(t),
+		Classify: cleanClassify(t),
+		// Inventory omitted.
+		RuleGraph: cleanRuleGraph(t),
+	}
+	dec, err := migrategate.Evaluate(in, migrategate.Options{})
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	iv := stageByName(t, dec, migrategate.StageInventory)
+	if iv.Verdict != migrategate.VerdictMissing || iv.Blocking {
+		t.Fatalf("want inventory MISSING+non-blocking, got verdict=%q blocking=%v", iv.Verdict, iv.Blocking)
+	}
+	if !dec.Pass || dec.Overall != migrategate.OverallPass {
+		t.Fatalf("a missing-inventory-only run should still PASS, got pass=%v overall=%q", dec.Pass, dec.Overall)
+	}
+	if !containsExact(dec.Missing, migrategate.StageInventory) {
+		t.Errorf("inventory should be reported as missing, got %v", dec.Missing)
+	}
+}
+
+func TestEvaluateClassifyRiskyWarnsNotBlocks(t *testing.T) {
+	cl := migrate.Classification{
+		Counts: migrate.BucketCounts{Total: 1, Supported: 1, Risky: 1},
+		Queries: []migrate.ClassifiedQuery{
+			{Expr: "a * b", Source: "s", Kind: "rule", Bucket: migrate.BucketSupported, Risky: true, Risks: []string{"vector-join fan-out"}},
+		},
+	}
+	in := migrategate.Inputs{
+		Verify:    cleanVerify(t),
+		Classify:  writeArtifact(t, "classify.json", cl.WriteJSON),
+		Inventory: cleanInventory(t),
+		RuleGraph: cleanRuleGraph(t),
+	}
+	dec, err := migrategate.Evaluate(in, migrategate.Options{})
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	c := stageByName(t, dec, migrategate.StageClassify)
+	if c.Verdict != migrategate.VerdictWarn || c.Blocking {
+		t.Fatalf("risky-but-supported must WARN not block, got verdict=%q blocking=%v", c.Verdict, c.Blocking)
+	}
+	if !dec.Pass {
+		t.Errorf("a risky-only classify should still PASS overall")
+	}
+}
+
+func TestEvaluateMultipleBlockersAllReported(t *testing.T) {
+	rep := migrateverify.Report{Summary: migrateverify.Summary{Total: 1, Diverge: 1}}
+	cl := migrate.Classification{
+		Counts:  migrate.BucketCounts{Total: 1, Unsupported: 1},
+		Queries: []migrate.ClassifiedQuery{{Bucket: migrate.BucketUnsupported, Construct: "x"}},
+	}
+	in := migrategate.Inputs{
+		Verify:   writeArtifact(t, "verify.json", rep.WriteJSON),
+		Classify: writeArtifact(t, "classify.json", cl.WriteJSON),
+		// inventory + rulegraph omitted: rulegraph is required (blocks), inventory advisory.
+	}
+	dec, err := migrategate.Evaluate(in, migrategate.Options{})
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if dec.Pass {
+		t.Fatalf("want FAIL with multiple blockers")
+	}
+	blocked := map[string]bool{}
+	for _, s := range dec.Stages {
+		if s.Blocking {
+			blocked[s.Stage] = true
+		}
+	}
+	for _, want := range []string{migrategate.StageVerify, migrategate.StageClassify, migrategate.StageRuleGraph} {
+		if !blocked[want] {
+			t.Errorf("stage %q should block, blocked=%v", want, blocked)
+		}
+	}
+	if blocked[migrategate.StageInventory] {
+		t.Errorf("missing inventory (advisory) must not block")
+	}
+}
+
+func TestEvaluateSuppliedButUnparseableArtifactIsHardError(t *testing.T) {
+	bad := filepath.Join(t.TempDir(), "verify.json")
+	if err := os.WriteFile(bad, []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	in := migrategate.Inputs{Verify: bad, Classify: cleanClassify(t), RuleGraph: cleanRuleGraph(t)}
+	if _, err := migrategate.Evaluate(in, migrategate.Options{}); err == nil {
+		t.Fatal("a supplied-but-unparseable artifact must be a hard error, not a silent skip")
+	}
+}
+
+func TestEvaluateMissingSuppliedFileIsHardError(t *testing.T) {
+	in := migrategate.Inputs{Verify: filepath.Join(t.TempDir(), "does-not-exist.json"), Classify: cleanClassify(t)}
+	if _, err := migrategate.Evaluate(in, migrategate.Options{}); err == nil {
+		t.Fatal("a supplied path that does not exist must be a hard error")
+	}
+}
+
+func TestDecisionWriteJSONRoundTrips(t *testing.T) {
+	in := migrategate.Inputs{
+		Verify:    cleanVerify(t),
+		Classify:  cleanClassify(t),
+		Inventory: cleanInventory(t),
+		RuleGraph: cleanRuleGraph(t),
+	}
+	dec, err := migrategate.Evaluate(in, migrategate.Options{})
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	p := writeArtifact(t, "decision.json", dec.WriteJSON)
+	data, err := os.ReadFile(p) //nolint:gosec // test-controlled path.
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got migrategate.Decision
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("decision JSON does not round-trip: %v", err)
+	}
+	if got.Overall != migrategate.OverallPass || !got.Pass {
+		t.Errorf("round-tripped decision mismatch: %+v", got)
+	}
+	if len(got.Stages) != 4 {
+		t.Errorf("want 4 stages in JSON, got %d", len(got.Stages))
+	}
+}
+
+// containsSubstr reports whether any element of ss contains sub.
+func containsSubstr(ss []string, sub string) bool {
+	for _, s := range ss {
+		if strings.Contains(s, sub) {
+			return true
+		}
+	}
+	return false
+}
+
+// containsExact reports whether ss contains want exactly.
+func containsExact(ss []string, want string) bool {
+	for _, s := range ss {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/migrategate/gate_test.go
+++ b/internal/migrategate/gate_test.go
@@ -45,10 +45,11 @@ func cleanClassify(t *testing.T) string {
 }
 
 // cleanInventory is an inventory whose top cardinalities are below the WARN
-// thresholds.
+// thresholds and whose optional enrichments were all obtained (non-negative
+// totals, no notes) — a genuinely clean bill of health.
 func cleanInventory(t *testing.T) string {
 	inv := migrateinventory.Inventory{
-		Source: "http://src", Top: 5, MetricNameTotal: -1, MetadataMetricTotal: -1,
+		Source: "http://src", Top: 5, MetricNameTotal: 42, MetadataMetricTotal: 40,
 		TopMetricsBySeries: []migrateinventory.NameValue{{Name: "up", Value: 12}},
 		TopLabelsByValues:  []migrateinventory.NameValue{{Name: "instance", Value: 30}},
 	}
@@ -229,7 +230,7 @@ func TestEvaluateBlocksOnMissingRequiredArtifact(t *testing.T) {
 
 func TestEvaluateWarnsButPassesOnHighCardinality(t *testing.T) {
 	inv := migrateinventory.Inventory{
-		Source: "http://src", Top: 5, MetricNameTotal: -1, MetadataMetricTotal: -1,
+		Source: "http://src", Top: 5, MetricNameTotal: 100, MetadataMetricTotal: 90,
 		TopMetricsBySeries: []migrateinventory.NameValue{{Name: "http_requests_total", Value: 250_000}},
 		TopLabelsByValues:  []migrateinventory.NameValue{{Name: "user_id", Value: 80_000}},
 	}
@@ -386,6 +387,166 @@ func TestDecisionWriteJSONRoundTrips(t *testing.T) {
 	}
 	if len(got.Stages) != 4 {
 		t.Errorf("want 4 stages in JSON, got %d", len(got.Stages))
+	}
+}
+
+func TestEvaluateWarnsOnVerifyUnsupportedButPasses(t *testing.T) {
+	// A query that emitted SQL offline but returned no comparable matrix live is
+	// counted only in Summary.Unsupported. Report.Failed() does not block on it,
+	// but the gate must surface it: it is a query UNVERIFIED against the backend,
+	// not a clean pass.
+	rep := migrateverify.Report{
+		Summary: migrateverify.Summary{Total: 3, Match: 2, Unsupported: 1, HarvestSkipped: 2, OutOfScope: 1},
+	}
+	in := migrategate.Inputs{
+		Verify:    writeArtifact(t, "verify.json", rep.WriteJSON),
+		Classify:  cleanClassify(t),
+		Inventory: cleanInventory(t),
+		RuleGraph: cleanRuleGraph(t),
+	}
+	dec, err := migrategate.Evaluate(in, migrategate.Options{})
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	v := stageByName(t, dec, migrategate.StageVerify)
+	if v.Verdict != migrategate.VerdictWarn || v.Blocking {
+		t.Fatalf("verify with unchecked entries must WARN not block, got verdict=%q blocking=%v", v.Verdict, v.Blocking)
+	}
+	if !containsSubstr(v.Reasons, "unverified") {
+		t.Errorf("verify reasons should surface the unverified query, got %v", v.Reasons)
+	}
+	if !containsSubstr(v.Reasons, "harvest-skipped") || !containsSubstr(v.Reasons, "out-of-scope") {
+		t.Errorf("verify reasons should surface harvest-skipped and out-of-scope entries, got %v", v.Reasons)
+	}
+	if !dec.Pass || dec.Overall != migrategate.OverallPass {
+		t.Fatalf("a WARN-only verify should PASS overall, got pass=%v overall=%q", dec.Pass, dec.Overall)
+	}
+}
+
+func TestEvaluateWarnsOnClassifySkippedButPasses(t *testing.T) {
+	// A corpus entry the harvester could not turn into a query is carried in
+	// Skipped but never classified. It must WARN — a green classify that hides an
+	// unexamined 40%-of-corpus is the exact "hollow green" the gate exists to
+	// prevent — yet it does not block (it is unexamined, not proven-unsupported).
+	cl := migrate.Classification{
+		Counts:  migrate.BucketCounts{Total: 2, Supported: 2},
+		Queries: []migrate.ClassifiedQuery{{Bucket: migrate.BucketSupported}, {Bucket: migrate.BucketSupported}},
+		Skipped: []migrate.SkippedEntry{
+			{Source: "rules-a.yml", Reason: "parse: unexpected token"},
+			{Source: "rules-b.yml", Reason: "read: permission denied"},
+		},
+	}
+	in := migrategate.Inputs{
+		Verify:    cleanVerify(t),
+		Classify:  writeArtifact(t, "classify.json", cl.WriteJSON),
+		Inventory: cleanInventory(t),
+		RuleGraph: cleanRuleGraph(t),
+	}
+	dec, err := migrategate.Evaluate(in, migrategate.Options{})
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	c := stageByName(t, dec, migrategate.StageClassify)
+	if c.Verdict != migrategate.VerdictWarn || c.Blocking {
+		t.Fatalf("classify with skips must WARN not block, got verdict=%q blocking=%v", c.Verdict, c.Blocking)
+	}
+	if !containsSubstr(c.Reasons, "2 harvest-skipped") {
+		t.Errorf("classify reasons should surface the skip count, got %v", c.Reasons)
+	}
+	if !dec.Pass || dec.Overall != migrategate.OverallPass {
+		t.Fatalf("a skip-only classify should PASS overall, got pass=%v overall=%q", dec.Pass, dec.Overall)
+	}
+}
+
+func TestEvaluateBlocksOnRuleGraphSkipped(t *testing.T) {
+	// Every recorded series is orphan (nobody consumes it) so the naive verdict
+	// is "safe to drop" — but the builder SKIPPED a consumer expr it could not
+	// parse. That skipped consumer might have referenced the orphan, which would
+	// then be needed after cutover. "orphan ⇒ safe to drop" is unsound with any
+	// skip, so the gate BLOCKS rather than green-light a possibly-blank panel.
+	g := migrate.RuleGraph{
+		Counts:   migrate.RuleGraphCounts{Recorded: 1, Orphan: 1, Skipped: 1},
+		Recorded: []migrate.RecordedNode{{Name: "job:foo:rate", Source: "rules.yml", Status: migrate.StatusOrphan}},
+		Skipped:  []migrate.SkippedEntry{{Source: "dash.json", Reason: "parse: unexpected token in consumer expr"}},
+	}
+	in := migrategate.Inputs{
+		Verify:    cleanVerify(t),
+		Classify:  cleanClassify(t),
+		Inventory: cleanInventory(t),
+		RuleGraph: writeArtifact(t, "rulegraph.json", g.WriteJSON),
+	}
+	dec, err := migrategate.Evaluate(in, migrategate.Options{})
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	r := stageByName(t, dec, migrategate.StageRuleGraph)
+	if dec.Pass || r.Verdict != migrategate.VerdictFail || !r.Blocking {
+		t.Fatalf("rulegraph with a skip must FAIL+block, got pass=%v verdict=%q blocking=%v", dec.Pass, r.Verdict, r.Blocking)
+	}
+	if !containsSubstr(r.Reasons, "unsound") || !containsSubstr(r.Reasons, "dash.json") {
+		t.Errorf("rulegraph reasons should surface the skip and its source, got %v", r.Reasons)
+	}
+}
+
+func TestEvaluateWarnsOnInventoryNotesButPasses(t *testing.T) {
+	// An enrichment the probe could not fetch lands in Notes. The gate must
+	// surface it: a probe that silently failed an enrichment is an unchecked
+	// corner of the source, not a clean inventory — but it stays advisory (WARN).
+	inv := migrateinventory.Inventory{
+		Source: "http://src", Top: 5, MetricNameTotal: -1, MetadataMetricTotal: 40,
+		TopMetricsBySeries: []migrateinventory.NameValue{{Name: "up", Value: 12}},
+		TopLabelsByValues:  []migrateinventory.NameValue{{Name: "instance", Value: 30}},
+		Notes:              []string{"metric-name total unavailable (/api/v1/label/__name__/values): 503"},
+	}
+	in := migrategate.Inputs{
+		Verify:    cleanVerify(t),
+		Classify:  cleanClassify(t),
+		Inventory: writeArtifact(t, "inventory.json", inv.WriteJSON),
+		RuleGraph: cleanRuleGraph(t),
+	}
+	dec, err := migrategate.Evaluate(in, migrategate.Options{})
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	iv := stageByName(t, dec, migrategate.StageInventory)
+	if iv.Verdict != migrategate.VerdictWarn || iv.Blocking {
+		t.Fatalf("inventory with a note must WARN not block, got verdict=%q blocking=%v", iv.Verdict, iv.Blocking)
+	}
+	if !containsSubstr(iv.Reasons, "metric-name total unavailable") {
+		t.Errorf("inventory reasons should surface the enrichment note, got %v", iv.Reasons)
+	}
+	if !dec.Pass || dec.Overall != migrategate.OverallPass {
+		t.Fatalf("a note-only inventory should PASS overall, got pass=%v overall=%q", dec.Pass, dec.Overall)
+	}
+}
+
+func TestEvaluateWarnsOnInventoryEnrichmentUnavailableWithoutNotes(t *testing.T) {
+	// A -1 total with no explaining note (an enrichment silently not obtained)
+	// must still surface a caveat, so the note-less path cannot read as clean.
+	inv := migrateinventory.Inventory{
+		Source: "http://src", Top: 5, MetricNameTotal: -1, MetadataMetricTotal: -1,
+		TopMetricsBySeries: []migrateinventory.NameValue{{Name: "up", Value: 12}},
+		TopLabelsByValues:  []migrateinventory.NameValue{{Name: "instance", Value: 30}},
+	}
+	in := migrategate.Inputs{
+		Verify:    cleanVerify(t),
+		Classify:  cleanClassify(t),
+		Inventory: writeArtifact(t, "inventory.json", inv.WriteJSON),
+		RuleGraph: cleanRuleGraph(t),
+	}
+	dec, err := migrategate.Evaluate(in, migrategate.Options{})
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	iv := stageByName(t, dec, migrategate.StageInventory)
+	if iv.Verdict != migrategate.VerdictWarn || iv.Blocking {
+		t.Fatalf("inventory with unobtained enrichment must WARN not block, got verdict=%q blocking=%v", iv.Verdict, iv.Blocking)
+	}
+	if !containsSubstr(iv.Reasons, "not obtained") {
+		t.Errorf("inventory reasons should surface the enrichment-not-obtained caveat, got %v", iv.Reasons)
+	}
+	if !dec.Pass {
+		t.Errorf("an enrichment-caveat-only inventory should still PASS overall")
 	}
 }
 

--- a/internal/migrategate/report.go
+++ b/internal/migrategate/report.go
@@ -1,0 +1,77 @@
+package migrategate
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// Write renders the decision as a scannable go/no-go checklist: one line per
+// stage with its verdict and whether it blocks, each stage's reasons indented
+// beneath it, then the overall PASS/FAIL verdict last.
+func (d Decision) Write(w io.Writer) error {
+	bw := &errWriter{w: w}
+	bw.printf("# cerberus migrate gate\n")
+	bw.printf("#\n")
+	bw.printf("# Folds the migration artifacts into one cutover go/no-go decision.\n")
+	bw.printf("# A blocking stage (FAIL, or a missing REQUIRED artifact) fails the gate;\n")
+	bw.printf("# a WARN is surfaced but does not block. Exit 0 only on overall PASS.\n")
+	bw.printf("#\n")
+
+	for _, s := range d.Stages {
+		if s.Blocking {
+			bw.printf("  %-9s %-7s BLOCKING\n", s.Stage, s.Verdict)
+		} else {
+			bw.printf("  %-9s %s\n", s.Stage, s.Verdict)
+		}
+		for _, r := range s.Reasons {
+			bw.printf("      %s\n", r)
+		}
+	}
+
+	if len(d.Missing) > 0 {
+		bw.printf("\n# missing artifacts: %v\n", d.Missing)
+	}
+	bw.printf("\nOVERALL: %s\n", d.Overall)
+	return bw.err
+}
+
+// WriteJSON renders the decision as deterministic, indented JSON with a
+// trailing newline. Nil slices become empty slices so the decision always
+// carries `[]` rather than `null`, matching the other blocks' JSON convention.
+func (d Decision) WriteJSON(w io.Writer) error {
+	if d.Stages == nil {
+		d.Stages = []StageResult{}
+	}
+	if d.Missing == nil {
+		d.Missing = []string{}
+	}
+	for i := range d.Stages {
+		if d.Stages[i].Reasons == nil {
+			d.Stages[i].Reasons = []string{}
+		}
+	}
+	data, err := json.MarshalIndent(d, "", jsonIndent)
+	if err != nil {
+		return fmt.Errorf("migrategate: marshal decision: %w", err)
+	}
+	if _, err := w.Write(append(data, '\n')); err != nil {
+		return fmt.Errorf("migrategate: write decision: %w", err)
+	}
+	return nil
+}
+
+// errWriter collapses the repeated Fprintf error checks in Write into a single
+// short-circuiting sink: once a write fails, later printf calls are no-ops and
+// the first error is returned.
+type errWriter struct {
+	w   io.Writer
+	err error
+}
+
+func (e *errWriter) printf(format string, args ...any) {
+	if e.err != nil {
+		return
+	}
+	_, e.err = fmt.Fprintf(e.w, format, args...)
+}


### PR DESCRIPTION
## What

Adds `migrate gate` — the cutover decision aggregator that folds the JSON artifacts the other migration blocks emit into a single go/no-go decision. Pure and offline: reads JSON, applies conservative rules, prints a per-stage checklist (human + `--json`) and one overall PASS/FAIL. Exit 0 only on PASS.

```
migrate gate --verify verify.json --classify classify.json \
             --inventory inventory.json --rulegraph rulegraph.json [--json] [--out f]
```

All four artifact flags are optional; the gate reports which are missing.

## Rules (v1 — conservative + honest)

| Stage | Rule | Verdict |
|-------|------|---------|
| verify | any diverge/error | **BLOCK** |
| classify | any unsupported | **BLOCK** |
| classify | supported-but-risky (fan-out) | WARN |
| inventory | high-cardinality metric/label | WARN (never blocks) |
| rulegraph | a **consumed** recorded series (must stay materialized post-cutover, else blank panel) | **BLOCK** |
| any required artifact | missing (can't prove safety) | **BLOCK** |

`verify` / `classify` / `rulegraph` are required (missing → BLOCK). `inventory` is advisory — its worst outcome is a WARN, so a missing inventory is reported but does not block. Orphan recorded series (nobody reads them) are safe and never block.

## Design

- The artifact contracts are the sibling blocks' own `--json` output types, reused directly — `migrate.Classification` / `migrate.RuleGraph`, `migrateverify.Report`, `migrateinventory.Inventory` — so the gate reads exactly what each CLI emits (the tests write fixtures through those blocks' real `WriteJSON` writers).
- A supplied-but-unreadable/unparseable artifact is a hard error, not a silent skip and not an invented verdict — the operator handed the gate a file it can't trust, which is a misconfiguration to surface.
- A no-go decision maps to a dedicated exit code (`3`), distinct from a tool error and from verify's own gate code (`2`).
- New `internal/migrategate` package declared in `.go-arch-lint.yml` (`mayDependOn: migrate, migrateverify, migrateinventory`); `go-arch-lint check` is green.

## Tests

`internal/migrategate` (pure logic) + `cmd/migrate` (CLI): the PASS case, a FAIL case per rule (diverge, error, unsupported, consumed series, missing required artifact), the WARN-not-block paths (high cardinality, risky classify, advisory-missing inventory), multiple-blockers-all-reported, the hard-error paths, and the CLI text / `--json` / `--out` surfaces + dispatcher routing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
