### PR TITLE
feat(migrate): verify — failure verdict, --report json, bug-report repro, experimental-CH attribution

### DIFF
--- a/cmd/migrate/verify.go
+++ b/cmd/migrate/verify.go
@@ -7,7 +7,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime/debug"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/tsouza/cerberus/internal/migrateverify"
@@ -22,6 +24,15 @@ const defaultVerifyTolerance = migrateverify.DefaultTolerance
 // diverges or errors). It is distinct from the code Go uses for an internal
 // error so a divergence reads as "the gate did its job", not "the tool broke".
 const verifyExitFail = 2
+
+// reportFileMode is the permission for the --report JSON diagnostic: operator-
+// readable, not world-writable.
+const reportFileMode = 0o600
+
+// unknownToolVersion is the tool_version stamped into the diagnostic when the
+// binary carries no VCS/module build stamp (e.g. a `go test` binary or a
+// -buildvcs=false build).
+const unknownToolVersion = "unknown"
 
 // runVerify replays a harvested PromQL corpus against a reference Prometheus and
 // cerberus over one query_range window and diffs the results. It is the cutover
@@ -44,6 +55,7 @@ func runVerify(args []string, stdout, stderr io.Writer) error {
 		stepStr   = fs.String("step", envOr("CERBERUS_VERIFY_STEP", "60s"), "range step (e.g. 60s)")
 		tolerance = fs.Float64("tolerance", tolDefault, "absolute value tolerance for a match")
 		asJSON    = fs.Bool("json", false, "emit the machine-readable JSON report instead of the text report")
+		report    = fs.String("report", envOr("CERBERUS_VERIFY_REPORT", ""), "write the full JSON diagnostics to this file (additive; the text report still prints)")
 	)
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -71,7 +83,27 @@ func runVerify(args []string, stdout, stderr io.Writer) error {
 	cerBackend := migrateverify.NewHTTPBackend(*cerberus)
 	rep := migrateverify.Verify(context.Background(), c, refBackend, cerBackend, params)
 
-	if err := writeReport(stdout, rep, *asJSON); err != nil {
+	// The resolved run params drive both the JSON diagnostic and the copy-pasteable
+	// repro command, so the two always describe the exact same window.
+	reportParams := migrateverify.VerifyReportParams{
+		RefURL:      *ref,
+		CerberusURL: *cerberus,
+		Start:       params.Start.UTC().Format(time.RFC3339),
+		End:         params.End.UTC().Format(time.RFC3339),
+		Step:        params.Step.String(),
+		Tolerance:   params.Tolerance,
+		Corpus:      *corpus,
+	}
+	repro := reproCommand(reportParams)
+
+	if *report != "" {
+		diag := migrateverify.NewVerifyReport(rep, reportParams, toolVersion(), time.Now().UTC())
+		if err := writeReportFile(*report, diag); err != nil {
+			return err
+		}
+	}
+
+	if err := writeReport(stdout, rep, *asJSON, repro); err != nil {
 		return err
 	}
 	if rep.Failed() {
@@ -80,12 +112,90 @@ func runVerify(args []string, stdout, stderr io.Writer) error {
 	return nil
 }
 
-// writeReport renders the report in the requested form.
-func writeReport(w io.Writer, rep migrateverify.Report, asJSON bool) error {
+// writeReport renders the report in the requested form. The text report is guided
+// by the repro command so a failing run ends with a copy-pasteable reproduction.
+func writeReport(w io.Writer, rep migrateverify.Report, asJSON bool, repro string) error {
 	if asJSON {
 		return rep.WriteJSON(w)
 	}
-	return rep.WriteText(w)
+	return rep.WriteTextGuided(w, migrateverify.TextGuidance{ReproCommand: repro})
+}
+
+// writeReportFile marshals the full JSON diagnostic to path, buffering first so a
+// marshal failure never leaves a half-written file behind.
+func writeReportFile(path string, diag migrateverify.VerifyReport) error {
+	var buf strings.Builder
+	if err := diag.WriteJSON(&buf); err != nil {
+		return err
+	}
+	if err := os.WriteFile(path, []byte(buf.String()), reportFileMode); err != nil {
+		return fmt.Errorf("write report file %q: %w", path, err)
+	}
+	return nil
+}
+
+// reproCommand reconstructs the exact, copy-pasteable `migrate verify …`
+// invocation that regenerates this diagnostic, using the RESOLVED window (so a
+// relative -1h/now input reproduces the same instants) and suggesting --report so
+// the operator captures the JSON to attach to a bug report.
+func reproCommand(p migrateverify.VerifyReportParams) string {
+	return strings.Join([]string{
+		"migrate verify",
+		"--corpus", shellQuote(p.Corpus),
+		"--ref", shellQuote(p.RefURL),
+		"--cerberus", shellQuote(p.CerberusURL),
+		"--start", shellQuote(p.Start),
+		"--end", shellQuote(p.End),
+		"--step", shellQuote(p.Step),
+		"--tolerance", strconv.FormatFloat(p.Tolerance, 'g', -1, 64),
+		"--report", "verify-report.json",
+	}, " ")
+}
+
+// shellQuote renders s as a single copy-pasteable shell word: bare when it holds
+// only safe characters, single-quoted otherwise (with embedded single quotes
+// escaped), so a URL or path with special characters survives a paste.
+func shellQuote(s string) string {
+	if s == "" {
+		return "''"
+	}
+	safe := true
+	for i := 0; i < len(s); i++ {
+		if !isShellSafe(s[i]) {
+			safe = false
+			break
+		}
+	}
+	if safe {
+		return s
+	}
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// isShellSafe reports whether c can appear unquoted in a shell word.
+func isShellSafe(c byte) bool {
+	switch {
+	case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c >= '0' && c <= '9':
+		return true
+	case c == '_' || c == '-' || c == '.' || c == '/' || c == ':' || c == '=' || c == '@' || c == '%' || c == '+':
+		return true
+	default:
+		return false
+	}
+}
+
+// toolVersion returns the migrate binary's version for the diagnostic, read from
+// the embedded module build info. It is "unknown" when the build carries no such
+// stamp (e.g. a `go test` binary).
+func toolVersion() string {
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return unknownToolVersion
+	}
+	if v := bi.Main.Version; v != "" && v != "(devel)" {
+		return v
+	}
+	return unknownToolVersion
 }
 
 // verifyFailedError signals a failed parity gate: the run completed and the

--- a/cmd/migrate/verify_test.go
+++ b/cmd/migrate/verify_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -9,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/tsouza/cerberus/internal/migrateverify"
 )
 
 // promServer answers /api/v1/query_range with a fixed matrix for known queries
@@ -70,8 +73,6 @@ func TestRunVerify_MatchPasses(t *testing.T) {
 func TestRunVerify_DivergeFails(t *testing.T) {
 	dir := t.TempDir()
 	corpus := writeCorpus(t, dir)
-	const cerMatrix = `{"status":"success","data":{"resultType":"matrix","result":[` +
-		`{"metric":{"__name__":"up","job":"api"},"values":[[1700000000,"1"],[1700000060,"0"]]}]}}`
 	ref := promServer(t, map[string]string{"up": upMatrix})
 	cer := promServer(t, map[string]string{"up": cerMatrix})
 
@@ -105,6 +106,133 @@ func TestRunVerify_JSON(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), `"verdict": "match"`) {
 		t.Errorf("expected JSON report with a match verdict, got:\n%s", out.String())
+	}
+}
+
+// cerMatrix is a divergent up matrix (second point differs from upMatrix), used
+// by the failure-path tests.
+const cerMatrix = `{"status":"success","data":{"resultType":"matrix","result":[` +
+	`{"metric":{"__name__":"up","job":"api"},"values":[[1700000000,"1"],[1700000060,"0"]]}]}}`
+
+// TestRunVerify_DivergeStdoutGuidance: a diverging run's stdout leads with the
+// FAILED verdict and ends with the bug-report guidance — the issues URL and a
+// copy-pasteable repro command.
+func TestRunVerify_DivergeStdoutGuidance(t *testing.T) {
+	dir := t.TempDir()
+	corpus := writeCorpus(t, dir)
+	ref := promServer(t, map[string]string{"up": upMatrix})
+	cer := promServer(t, map[string]string{"up": cerMatrix})
+
+	var out, errOut bytes.Buffer
+	err := runVerify([]string{
+		"--corpus", corpus, "--ref", ref.URL, "--cerberus", cer.URL,
+		"--start", "1700000000", "--end", "1700000600", "--step", "60s",
+	}, &out, &errOut)
+	var gate verifyFailedError
+	if !errors.As(err, &gate) {
+		t.Fatalf("runVerify should fail the gate on divergence, got: %v", err)
+	}
+	s := out.String()
+	if !strings.HasPrefix(s, "VERIFICATION FAILED") {
+		t.Errorf("stdout must lead with VERIFICATION FAILED, got:\n%s", s)
+	}
+	if !strings.Contains(s, "https://github.com/tsouza/cerberus/issues") {
+		t.Errorf("stdout must carry the cerberus issues URL, got:\n%s", s)
+	}
+	if !strings.Contains(s, "migrate verify --corpus") || !strings.Contains(s, "--report verify-report.json") {
+		t.Errorf("stdout must carry a copy-pasteable repro command with --report, got:\n%s", s)
+	}
+}
+
+// TestRunVerify_ReportFile: --report writes valid, parseable JSON carrying the
+// schema version, tool version, run params, summary, and per-query verdicts.
+func TestRunVerify_ReportFile(t *testing.T) {
+	dir := t.TempDir()
+	corpus := writeCorpus(t, dir)
+	ref := promServer(t, map[string]string{"up": upMatrix})
+	cer := promServer(t, map[string]string{"up": cerMatrix})
+	reportPath := filepath.Join(dir, "verify-report.json")
+
+	var out, errOut bytes.Buffer
+	err := runVerify([]string{
+		"--corpus", corpus, "--ref", ref.URL, "--cerberus", cer.URL,
+		"--start", "1700000000", "--end", "1700000600", "--step", "60s",
+		"--report", reportPath,
+	}, &out, &errOut)
+	var gate verifyFailedError
+	if !errors.As(err, &gate) {
+		t.Fatalf("runVerify should fail the gate on divergence, got: %v", err)
+	}
+
+	data, readErr := os.ReadFile(reportPath) //nolint:gosec // test-controlled temp path.
+	if readErr != nil {
+		t.Fatalf("--report file was not written: %v", readErr)
+	}
+	var diag struct {
+		SchemaVersion int    `json:"schema_version"`
+		ToolVersion   string `json:"tool_version"`
+		GeneratedAt   string `json:"generated_at"`
+		Note          string `json:"note"`
+		Params        struct {
+			RefURL      string  `json:"ref_url"`
+			CerberusURL string  `json:"cerberus_url"`
+			Start       string  `json:"start"`
+			End         string  `json:"end"`
+			Step        string  `json:"step"`
+			Tolerance   float64 `json:"tolerance"`
+			Corpus      string  `json:"corpus"`
+		} `json:"params"`
+		Summary struct {
+			Total   int `json:"total"`
+			Diverge int `json:"diverge"`
+		} `json:"summary"`
+		Results []struct {
+			Expr    string `json:"expr"`
+			Verdict string `json:"verdict"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal(data, &diag); err != nil {
+		t.Fatalf("--report must be valid JSON: %v\n%s", err, string(data))
+	}
+	if diag.SchemaVersion != 1 {
+		t.Errorf("schema_version = %d, want 1", diag.SchemaVersion)
+	}
+	if diag.ToolVersion == "" {
+		t.Error("tool_version must be populated")
+	}
+	if diag.GeneratedAt == "" || diag.Note == "" {
+		t.Errorf("generated_at and note must be populated, got %q / %q", diag.GeneratedAt, diag.Note)
+	}
+	if diag.Params.RefURL != ref.URL || diag.Params.CerberusURL != cer.URL || diag.Params.Corpus != corpus {
+		t.Errorf("params did not capture the run inputs: %+v", diag.Params)
+	}
+	if diag.Params.Step != "1m0s" || diag.Params.Tolerance == 0 {
+		t.Errorf("params step/tolerance not captured: step=%q tol=%v", diag.Params.Step, diag.Params.Tolerance)
+	}
+	if diag.Summary.Total != 1 || diag.Summary.Diverge != 1 {
+		t.Errorf("summary = %+v, want total 1 / diverge 1", diag.Summary)
+	}
+	if len(diag.Results) != 1 || diag.Results[0].Verdict != "diverge" {
+		t.Errorf("results = %+v, want one diverge result", diag.Results)
+	}
+}
+
+// TestReproCommand_ShellQuoting: a URL with special characters is single-quoted so
+// the repro command stays copy-pasteable.
+func TestReproCommand_ShellQuoting(t *testing.T) {
+	cmd := reproCommand(migrateverify.VerifyReportParams{
+		RefURL: "http://ref:9090", CerberusURL: "http://cer/path?x=1&y=2",
+		Start: "2023-11-14T22:13:20Z", End: "2023-11-14T22:23:20Z",
+		Step: "1m0s", Tolerance: migrateverify.DefaultTolerance, Corpus: "corpus.json",
+	})
+	if !strings.Contains(cmd, "'http://cer/path?x=1&y=2'") {
+		t.Errorf("URL with shell-special chars must be single-quoted, got:\n%s", cmd)
+	}
+	if !strings.Contains(cmd, "http://ref:9090") {
+		t.Errorf("safe URL should appear bare, got:\n%s", cmd)
+	}
+	if !strings.HasPrefix(cmd, "migrate verify ") || !strings.Contains(cmd, "--report verify-report.json") {
+		t.Errorf("repro must be a full migrate verify invocation ending in --report, got:\n%s", cmd)
 	}
 }
 

--- a/internal/migrateverify/report.go
+++ b/internal/migrateverify/report.go
@@ -1,0 +1,222 @@
+package migrateverify
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+)
+
+// IssuesURL is where an operator reports a divergence that looks like a cerberus
+// bug. It is surfaced in the failing text report's bug-report guidance and is a
+// named constant so the report and any docs stay in lock-step.
+const IssuesURL = "https://github.com/tsouza/cerberus/issues"
+
+// VerifyReportVersion is the schema version stamped into every --report JSON
+// diagnostic. Bump it when the on-disk shape changes so a consumer can refuse a
+// diagnostic it does not understand.
+const VerifyReportVersion = 1
+
+// hotspotFuncs are the PromQL functions whose cerberus results are most likely to
+// be computed via an EXPERIMENTAL ClickHouse path (native timeSeries*ToGrid /
+// experimental time-series aggregates, exponential-histogram quantiles) that can
+// deviate from real Prometheus. A divergence on one of these is not proof of an
+// experimental path — verify sees only two HTTP backends and cannot introspect
+// cerberus config — so it is surfaced as a CANDIDATE cause, never a detection.
+var hotspotFuncs = []string{"rate", "irate", "increase", "histogram_quantile"}
+
+// Attribution candidate categories. Each is a HINT about what MIGHT explain a
+// divergence, never a claim that verify detected the cause: verify only compares
+// two HTTP responses and cannot see either backend's internals.
+const (
+	// AttribCerberusBug: the divergence may be a genuine cerberus defect. Always a
+	// candidate on any divergence — the honest default.
+	AttribCerberusBug = "cerberus-bug"
+	// AttribExperimentalCHFeature: cerberus may have computed a hotspot function via
+	// an experimental ClickHouse path that deviates from Prometheus.
+	AttribExperimentalCHFeature = "experimental-ch-feature"
+	// AttribIngestArtifact: a series/point present on only one side may reflect an
+	// ingestion difference between the two backends, not a compute bug.
+	AttribIngestArtifact = "ingest-artifact"
+	// AttribDataWindowGap: a coverage gap (a step or series present on one side
+	// only) may reflect a data-availability window difference, not a compute bug.
+	AttribDataWindowGap = "data-window-gap"
+	// AttribDialectSemantics: a value difference may stem from a query-language
+	// semantic difference between the reference and cerberus, not a bug.
+	AttribDialectSemantics = "dialect-semantics"
+)
+
+// Per-candidate operator notes. Kept as consts so the text and JSON reports carry
+// identical wording and the honesty framing ("candidate", "may") is not lost in a
+// hand-edit.
+const (
+	cerberusBugNote = "a divergence may indicate a genuine cerberus bug; " +
+		"if the other candidates below are ruled out, report it."
+	experimentalCHNote = "cerberus may compute this via an experimental CH path; " +
+		"re-run cerberus with experimental features disabled to isolate a cerberus bug " +
+		"from an experimental-feature deviation."
+	ingestArtifactNote = "a series present on only one backend may reflect an ingestion " +
+		"difference (relabeling, scrape timing) rather than a compute bug."
+	dataWindowGapNote = "a missing step or series may reflect a data-availability window " +
+		"difference between the two backends rather than a compute bug."
+	dialectSemanticsNote = "a value difference may stem from a query-language semantic " +
+		"difference between the reference and cerberus rather than a bug."
+)
+
+// ExperimentalNote is the one-time general framing printed in the report header
+// and stamped into the JSON diagnostic. It states plainly that verify cannot
+// introspect cerberus config, so any experimental-feature attribution is a
+// candidate hint, not a detection.
+const ExperimentalNote = "cerberus may use EXPERIMENTAL ClickHouse features " +
+	"(native timeSeries*ToGrid / experimental time-series aggregates, exponential " +
+	"histograms) that can deviate calculations from real Prometheus. verify sees only " +
+	"two HTTP backends and CANNOT introspect cerberus config, so every attribution " +
+	"below is a CANDIDATE-CAUSE HINT, never a claim of detection."
+
+// AttributionCandidate is one candidate explanation for a divergence: a category
+// plus an operator-facing note. It is a hint, not a detection (see ExperimentalNote).
+type AttributionCandidate struct {
+	Category string `json:"category"`
+	Note     string `json:"note"`
+}
+
+// isIdentChar reports whether c can appear inside a PromQL identifier (metric,
+// label, or function name, plus ':' for recording-rule names). Used to enforce
+// call-token boundaries so "irate" is not matched as "rate" and "foo:rate" is not
+// matched as the rate() function.
+func isIdentChar(c byte) bool {
+	switch {
+	case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c >= '0' && c <= '9':
+		return true
+	case c == '_' || c == ':':
+		return true
+	default:
+		return false
+	}
+}
+
+// isHotspotExpr reports whether expr invokes any hotspot function. It is a robust
+// token check (not a substring match): the function name must sit on an
+// identifier boundary and be followed — modulo whitespace — by '(', so it matches
+// a genuine call and not a metric named "rate_total" or a "foo:rate" recording
+// rule.
+func isHotspotExpr(expr string) bool {
+	for _, fn := range hotspotFuncs {
+		if containsCall(expr, fn) {
+			return true
+		}
+	}
+	return false
+}
+
+// containsCall reports whether fn appears in expr as a function call: bounded on
+// the left by a non-identifier char (or start of string) and followed on the
+// right — after optional whitespace — by '('.
+func containsCall(expr, fn string) bool {
+	for from := 0; ; {
+		i := strings.Index(expr[from:], fn)
+		if i < 0 {
+			return false
+		}
+		i += from
+		from = i + len(fn)
+		if i > 0 && isIdentChar(expr[i-1]) {
+			continue // part of a longer identifier, e.g. "irate" for "rate"
+		}
+		j := from
+		for j < len(expr) && (expr[j] == ' ' || expr[j] == '\t') {
+			j++
+		}
+		if j < len(expr) && expr[j] == '(' {
+			return true
+		}
+	}
+}
+
+// attributeDivergence builds the candidate-cause list for a diverging query. It
+// always lists cerberus-bug (the honest default), adds experimental-ch-feature
+// for hotspot exprs, and splits the remaining hint by the divergence shape: a
+// coverage gap points at data-window / ingest differences, a value difference at
+// a dialect-semantics difference. Every entry is a candidate, never a detection.
+func attributeDivergence(expr string, fd *FirstDiff) []AttributionCandidate {
+	cands := []AttributionCandidate{{Category: AttribCerberusBug, Note: cerberusBugNote}}
+	if isHotspotExpr(expr) {
+		cands = append(cands, AttributionCandidate{Category: AttribExperimentalCHFeature, Note: experimentalCHNote})
+	}
+	if fd != nil && isCoverageGap(fd.Reason) {
+		cands = append(cands,
+			AttributionCandidate{Category: AttribDataWindowGap, Note: dataWindowGapNote},
+			AttributionCandidate{Category: AttribIngestArtifact, Note: ingestArtifactNote})
+	} else {
+		cands = append(cands, AttributionCandidate{Category: AttribDialectSemantics, Note: dialectSemanticsNote})
+	}
+	return cands
+}
+
+// isCoverageGap reports whether a first-diff reason describes a series/step that
+// exists on only one backend (a coverage gap), as opposed to a value that differs
+// where both backends have data.
+func isCoverageGap(reason string) bool {
+	return strings.Contains(reason, "present in") || strings.Contains(reason, "no sample")
+}
+
+// VerifyReportParams is the resolved run context stamped into the JSON diagnostic:
+// the two backend URLs, the exact query_range window (resolved to RFC3339 so a
+// relative -1h/now input is captured as the concrete instant that was queried),
+// the step, the tolerance, and the corpus path.
+type VerifyReportParams struct {
+	RefURL      string  `json:"ref_url"`
+	CerberusURL string  `json:"cerberus_url"`
+	Start       string  `json:"start"`
+	End         string  `json:"end"`
+	Step        string  `json:"step"`
+	Tolerance   float64 `json:"tolerance"`
+	Corpus      string  `json:"corpus"`
+}
+
+// VerifyReport is the versioned, self-describing --report diagnostic: the full
+// parity result plus the context needed to reproduce and triage it. It is a
+// superset of the in-memory Report, adding the schema/tool version, the generation
+// timestamp, the resolved run params, and the general experimental-feature note.
+type VerifyReport struct {
+	SchemaVersion  int                   `json:"schema_version"`
+	ToolVersion    string                `json:"tool_version"`
+	GeneratedAt    string                `json:"generated_at"`
+	Note           string                `json:"note"`
+	Params         VerifyReportParams    `json:"params"`
+	Summary        Summary               `json:"summary"`
+	Results        []QueryResult         `json:"results"`
+	OutOfScope     []OutOfScopeEntry     `json:"out_of_scope,omitempty"`
+	HarvestSkipped []HarvestSkippedEntry `json:"harvest_skipped,omitempty"`
+}
+
+// NewVerifyReport assembles the JSON diagnostic from a completed parity run.
+// generatedAt is passed in (not read from the clock) so the marshaling is
+// deterministic and testable; the caller pins it to the run's wall-clock.
+func NewVerifyReport(rep Report, params VerifyReportParams, toolVersion string, generatedAt time.Time) VerifyReport {
+	return VerifyReport{
+		SchemaVersion:  VerifyReportVersion,
+		ToolVersion:    toolVersion,
+		GeneratedAt:    generatedAt.UTC().Format(time.RFC3339),
+		Note:           ExperimentalNote,
+		Params:         params,
+		Summary:        rep.Summary,
+		Results:        rep.Results,
+		OutOfScope:     rep.OutOfScope,
+		HarvestSkipped: rep.HarvestSkipped,
+	}
+}
+
+// WriteJSON renders the diagnostic as deterministically-marshaled, indented JSON
+// with a trailing newline. Field order is fixed by the struct definition and the
+// per-query results are in corpus order, so re-running verify on the same inputs
+// produces byte-identical diagnostics (modulo the generation timestamp).
+func (vr VerifyReport) WriteJSON(w io.Writer) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(vr); err != nil {
+		return fmt.Errorf("encode verify report: %w", err)
+	}
+	return nil
+}

--- a/internal/migrateverify/report_test.go
+++ b/internal/migrateverify/report_test.go
@@ -1,0 +1,254 @@
+package migrateverify
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+// hasAttrib reports whether a candidate of the given category is present.
+func hasAttrib(cands []AttributionCandidate, category string) bool {
+	for _, c := range cands {
+		if c.Category == category {
+			return true
+		}
+	}
+	return false
+}
+
+// TestIsHotspotExpr covers the robust call-token boundary check: real hotspot
+// calls match, while longer identifiers and recording-rule names that merely
+// contain a hotspot name do not.
+func TestIsHotspotExpr(t *testing.T) {
+	cases := []struct {
+		expr string
+		want bool
+	}{
+		{"rate(x[1m])", true},
+		{"irate(x[1m])", true},
+		{"increase(x[5m])", true},
+		{"histogram_quantile(0.9, sum(x))", true},
+		{"sum(rate(http_requests_total[1m]))", true},
+		{"rate (x[1m])", true}, // whitespace before '(' still a call
+		{"up", false},
+		{"rate_total", false},         // longer identifier, not a call
+		{"job:rate:sum", false},       // recording-rule name, no call
+		{"my_irate_helper(x)", false}, // 'irate' inside a longer identifier
+		{"sum(node_increase)", false}, // 'increase' inside a longer identifier
+		{"histogram_quantiles(x)", false},
+	}
+	for _, c := range cases {
+		if got := isHotspotExpr(c.expr); got != c.want {
+			t.Errorf("isHotspotExpr(%q) = %v, want %v", c.expr, got, c.want)
+		}
+	}
+}
+
+// TestAttribution_HotspotVsNonHotspot: a diverging hotspot query carries the
+// experimental-ch-feature candidate; a non-hotspot divergence does not. Both
+// always carry cerberus-bug (the honest default).
+func TestAttribution_HotspotVsNonHotspot(t *testing.T) {
+	mk := func(v string) map[string]string {
+		return map[string]string{
+			"rate(x[1m])": matrix(seriesSpec{labels: map[string]string{"job": "a"}, points: []pointSpec{{1_700_000_000, v}}}),
+			"up":          matrix(seriesSpec{labels: map[string]string{"job": "a"}, points: []pointSpec{{1_700_000_000, v}}}),
+		}
+	}
+	refBody, cerBody := mk("1"), mk("2")
+
+	hotspot := runVerifyOne(t, refBody, cerBody, Query{Expr: "rate(x[1m])", Source: "rule:r"})
+	if hotspot.Verdict != VerdictDiverge {
+		t.Fatalf("hotspot verdict = %q, want diverge", hotspot.Verdict)
+	}
+	if !hasAttrib(hotspot.Attribution, AttribExperimentalCHFeature) {
+		t.Errorf("hotspot divergence must carry the experimental-ch-feature candidate, got %+v", hotspot.Attribution)
+	}
+	if !hasAttrib(hotspot.Attribution, AttribCerberusBug) {
+		t.Errorf("every divergence must carry the cerberus-bug candidate, got %+v", hotspot.Attribution)
+	}
+
+	plain := runVerifyOne(t, refBody, cerBody, Query{Expr: "up", Source: "rule:u"})
+	if plain.Verdict != VerdictDiverge {
+		t.Fatalf("non-hotspot verdict = %q, want diverge", plain.Verdict)
+	}
+	if hasAttrib(plain.Attribution, AttribExperimentalCHFeature) {
+		t.Errorf("non-hotspot divergence must NOT carry the experimental-ch-feature candidate, got %+v", plain.Attribution)
+	}
+	if !hasAttrib(plain.Attribution, AttribCerberusBug) {
+		t.Errorf("every divergence must carry the cerberus-bug candidate, got %+v", plain.Attribution)
+	}
+}
+
+// TestAttribution_HistogramQuantileHotspot: histogram_quantile is a hotspot too.
+func TestAttribution_HistogramQuantileHotspot(t *testing.T) {
+	const expr = "histogram_quantile(0.9, x)"
+	refBody := map[string]string{expr: matrix(seriesSpec{labels: map[string]string{"le": "1"}, points: []pointSpec{{1_700_000_000, "1"}}})}
+	cerBody := map[string]string{expr: matrix(seriesSpec{labels: map[string]string{"le": "1"}, points: []pointSpec{{1_700_000_000, "2"}}})}
+	res := runVerifyOne(t, refBody, cerBody, Query{Expr: expr, Source: "panel:p"})
+	if !hasAttrib(res.Attribution, AttribExperimentalCHFeature) {
+		t.Errorf("histogram_quantile divergence must carry the experimental-ch-feature candidate, got %+v", res.Attribution)
+	}
+}
+
+// TestAttribution_CoverageGap: a series present on only one backend surfaces the
+// data-window-gap + ingest-artifact candidates rather than dialect-semantics.
+func TestAttribution_CoverageGap(t *testing.T) {
+	refBody := map[string]string{"up": matrix(
+		seriesSpec{labels: map[string]string{"job": "a"}, points: []pointSpec{{1_700_000_000, "1"}}},
+		seriesSpec{labels: map[string]string{"job": "b"}, points: []pointSpec{{1_700_000_000, "1"}}},
+	)}
+	cerBody := map[string]string{"up": matrix(
+		seriesSpec{labels: map[string]string{"job": "a"}, points: []pointSpec{{1_700_000_000, "1"}}},
+	)}
+	res := runVerifyOne(t, refBody, cerBody, Query{Expr: "up", Source: "s"})
+	if !hasAttrib(res.Attribution, AttribDataWindowGap) || !hasAttrib(res.Attribution, AttribIngestArtifact) {
+		t.Errorf("coverage-gap divergence must carry data-window-gap + ingest-artifact, got %+v", res.Attribution)
+	}
+	if hasAttrib(res.Attribution, AttribDialectSemantics) {
+		t.Errorf("coverage-gap divergence should not carry dialect-semantics, got %+v", res.Attribution)
+	}
+}
+
+// TestWriteText_VerdictBanner: the text report LEADS with an unmistakable verdict
+// banner — FAILED on a diverging run, PASSED on a clean one.
+func TestWriteText_VerdictBanner(t *testing.T) {
+	failing := Report{Summary: Summary{Total: 3, Match: 1, Diverge: 1, Error: 1}}
+	var fb strings.Builder
+	if err := failing.WriteText(&fb); err != nil {
+		t.Fatalf("WriteText: %v", err)
+	}
+	first := strings.SplitN(fb.String(), "\n", 2)[0]
+	if !strings.HasPrefix(first, "VERIFICATION FAILED") {
+		t.Errorf("failing report must lead with VERIFICATION FAILED, got first line: %q", first)
+	}
+	if !strings.Contains(first, "1 diverged") || !strings.Contains(first, "1 errored") ||
+		!strings.Contains(first, "1 matched") || !strings.Contains(first, "of 3") {
+		t.Errorf("failure banner must carry the counts, got: %q", first)
+	}
+
+	passing := Report{Summary: Summary{Total: 5, Match: 5}}
+	var pb strings.Builder
+	if err := passing.WriteText(&pb); err != nil {
+		t.Fatalf("WriteText: %v", err)
+	}
+	firstPass := strings.SplitN(pb.String(), "\n", 2)[0]
+	if !strings.HasPrefix(firstPass, "VERIFICATION PASSED") || !strings.Contains(firstPass, "all 5") {
+		t.Errorf("passing report must lead with VERIFICATION PASSED — all 5, got: %q", firstPass)
+	}
+}
+
+// TestWriteTextGuided_BugReport: a failing report ends with the "Report this to
+// cerberus" section carrying the issues URL and the supplied repro command.
+func TestWriteTextGuided_BugReport(t *testing.T) {
+	rep := Report{
+		Summary: Summary{Total: 1, Diverge: 1},
+		Results: []QueryResult{{
+			Source: "rule:r", Expr: "rate(x[1m])", Verdict: VerdictDiverge,
+			Attribution: attributeDivergence("rate(x[1m])", &FirstDiff{Reason: "value differs beyond tolerance"}),
+		}},
+	}
+	const repro = "migrate verify --corpus c.json --ref http://ref --cerberus http://cer --report verify-report.json"
+	var b strings.Builder
+	if err := rep.WriteTextGuided(&b, TextGuidance{ReproCommand: repro}); err != nil {
+		t.Fatalf("WriteTextGuided: %v", err)
+	}
+	out := b.String()
+	if !strings.Contains(out, "Report this to cerberus") {
+		t.Errorf("failing report must carry the bug-report section, got:\n%s", out)
+	}
+	if !strings.Contains(out, IssuesURL) {
+		t.Errorf("bug-report section must carry the issues URL %q, got:\n%s", IssuesURL, out)
+	}
+	if !strings.Contains(out, repro) {
+		t.Errorf("bug-report section must carry the repro command, got:\n%s", out)
+	}
+	if !strings.Contains(out, "candidate-cause [experimental-ch-feature]") {
+		t.Errorf("failing report must print the per-divergence candidate causes, got:\n%s", out)
+	}
+	if !strings.Contains(out, ExperimentalNote) {
+		t.Errorf("report header must carry the one-time experimental-feature note, got:\n%s", out)
+	}
+}
+
+// TestVerifyReport_JSON: the --report diagnostic marshals to valid, parseable
+// JSON carrying the schema version, tool version, timestamp, run params, summary,
+// and per-query verdicts (with attribution on a divergence).
+func TestVerifyReport_JSON(t *testing.T) {
+	refBody := map[string]string{
+		"up":          matrix(seriesSpec{labels: map[string]string{"j": "a"}, points: []pointSpec{{1_700_000_000, "1"}}}),
+		"rate(x[1m])": matrix(seriesSpec{labels: map[string]string{"j": "a"}, points: []pointSpec{{1_700_000_000, "1"}}}),
+	}
+	cerBody := map[string]string{
+		"up":          matrix(seriesSpec{labels: map[string]string{"j": "a"}, points: []pointSpec{{1_700_000_000, "1"}}}),
+		"rate(x[1m])": matrix(seriesSpec{labels: map[string]string{"j": "a"}, points: []pointSpec{{1_700_000_000, "9"}}}),
+	}
+	ref := NewHTTPBackend(matrixServer(t, refBody).URL)
+	cer := NewHTTPBackend(matrixServer(t, cerBody).URL)
+	corpus := Corpus{PromQL: []Query{{Expr: "up", Source: "s1"}, {Expr: "rate(x[1m])", Source: "s2"}}}
+	rep := Verify(context.Background(), corpus, ref, cer, testParams())
+
+	params := VerifyReportParams{
+		RefURL: "http://ref", CerberusURL: "http://cer",
+		Start: "2023-11-14T22:13:20Z", End: "2023-11-14T22:23:20Z",
+		Step: "1m0s", Tolerance: DefaultTolerance, Corpus: "corpus.json",
+	}
+	genAt := time.Unix(1_700_000_600, 0).UTC()
+	diag := NewVerifyReport(rep, params, "v1.2.3", genAt)
+
+	var buf strings.Builder
+	if err := diag.WriteJSON(&buf); err != nil {
+		t.Fatalf("WriteJSON: %v", err)
+	}
+
+	// It must be valid, parseable JSON.
+	var back VerifyReport
+	if err := json.Unmarshal([]byte(buf.String()), &back); err != nil {
+		t.Fatalf("diagnostic must be parseable JSON: %v\n%s", err, buf.String())
+	}
+	if back.SchemaVersion != VerifyReportVersion {
+		t.Errorf("schema_version = %d, want %d", back.SchemaVersion, VerifyReportVersion)
+	}
+	if back.ToolVersion != "v1.2.3" {
+		t.Errorf("tool_version = %q, want v1.2.3", back.ToolVersion)
+	}
+	if back.GeneratedAt != genAt.Format(time.RFC3339) {
+		t.Errorf("generated_at = %q, want %q", back.GeneratedAt, genAt.Format(time.RFC3339))
+	}
+	if back.Note != ExperimentalNote {
+		t.Errorf("note = %q, want the experimental-feature note", back.Note)
+	}
+	if back.Params != params {
+		t.Errorf("params = %+v, want %+v", back.Params, params)
+	}
+	if back.Summary != rep.Summary {
+		t.Errorf("summary = %+v, want %+v", back.Summary, rep.Summary)
+	}
+	if len(back.Results) != 2 {
+		t.Fatalf("results = %d, want 2", len(back.Results))
+	}
+
+	// The diverging result must carry its attribution through the JSON round-trip.
+	var diverged QueryResult
+	for _, r := range back.Results {
+		if r.Verdict == VerdictDiverge {
+			diverged = r
+		}
+	}
+	if diverged.Source == "" {
+		t.Fatal("expected a diverged result in the diagnostic")
+	}
+	if !hasAttrib(diverged.Attribution, AttribExperimentalCHFeature) {
+		t.Errorf("diverged rate() result must carry experimental-ch-feature attribution, got %+v", diverged.Attribution)
+	}
+
+	// Deterministic marshaling: the same inputs produce byte-identical JSON.
+	var buf2 strings.Builder
+	if err := NewVerifyReport(rep, params, "v1.2.3", genAt).WriteJSON(&buf2); err != nil {
+		t.Fatalf("WriteJSON (second): %v", err)
+	}
+	if buf.String() != buf2.String() {
+		t.Errorf("diagnostic marshaling must be deterministic; got two different encodings")
+	}
+}

--- a/internal/migrateverify/report_test.go
+++ b/internal/migrateverify/report_test.go
@@ -137,6 +137,40 @@ func TestWriteText_VerdictBanner(t *testing.T) {
 	if !strings.HasPrefix(firstPass, "VERIFICATION PASSED") || !strings.Contains(firstPass, "all 5") {
 		t.Errorf("passing report must lead with VERIFICATION PASSED — all 5, got: %q", firstPass)
 	}
+
+	// Unsupported queries pass the gate but are NOT matches: the banner must not
+	// claim "all N matched" when only some agreed (mixed pass) or none did.
+	mixed := Report{Summary: Summary{Total: 5, Match: 3, Unsupported: 2}}
+	var mb strings.Builder
+	if err := mixed.WriteText(&mb); err != nil {
+		t.Fatalf("WriteText: %v", err)
+	}
+	firstMixed := strings.SplitN(mb.String(), "\n", 2)[0]
+	if !strings.HasPrefix(firstMixed, "VERIFICATION PASSED") {
+		t.Errorf("mixed-unsupported report must still lead with VERIFICATION PASSED, got: %q", firstMixed)
+	}
+	if strings.Contains(firstMixed, "all 5 queries matched") {
+		t.Errorf("mixed-unsupported banner must NOT claim all 5 matched, got: %q", firstMixed)
+	}
+	if !strings.Contains(firstMixed, "3 matched") || !strings.Contains(firstMixed, "2 unsupported") ||
+		!strings.Contains(firstMixed, "of 5") {
+		t.Errorf("mixed-unsupported banner must split match/unsupported/total, got: %q", firstMixed)
+	}
+
+	// All-unsupported: zero matched, yet the gate passes — the banner must not
+	// claim every query matched.
+	allUnsup := Report{Summary: Summary{Total: 5, Unsupported: 5}}
+	var ab strings.Builder
+	if err := allUnsup.WriteText(&ab); err != nil {
+		t.Fatalf("WriteText: %v", err)
+	}
+	firstAll := strings.SplitN(ab.String(), "\n", 2)[0]
+	if strings.Contains(firstAll, "all 5 queries matched") {
+		t.Errorf("all-unsupported banner must NOT claim all 5 matched, got: %q", firstAll)
+	}
+	if !strings.Contains(firstAll, "0 matched") || !strings.Contains(firstAll, "5 unsupported") {
+		t.Errorf("all-unsupported banner must report 0 matched / 5 unsupported, got: %q", firstAll)
+	}
 }
 
 // TestWriteTextGuided_BugReport: a failing report ends with the "Report this to

--- a/internal/migrateverify/verify.go
+++ b/internal/migrateverify/verify.go
@@ -417,6 +417,11 @@ func (r Report) writeText(w io.Writer, g *TextGuidance) error {
 	if r.Failed() {
 		bw.printf("VERIFICATION FAILED — %d diverged, %d errored, %d matched (of %d)\n\n",
 			r.Summary.Diverge, r.Summary.Error, r.Summary.Match, r.Summary.Total)
+	} else if r.Summary.Unsupported > 0 {
+		// Unsupported queries pass the gate but are NOT matches; the banner must
+		// not equate Total with matched or it overstates what agreed.
+		bw.printf("VERIFICATION PASSED — %d matched, %d unsupported, 0 diverged (of %d)\n\n",
+			r.Summary.Match, r.Summary.Unsupported, r.Summary.Total)
 	} else {
 		bw.printf("VERIFICATION PASSED — all %d queries matched\n\n", r.Summary.Total)
 	}

--- a/internal/migrateverify/verify.go
+++ b/internal/migrateverify/verify.go
@@ -269,13 +269,16 @@ type Corpus struct {
 	HarvestSkipped []HarvestSkippedEntry
 }
 
-// QueryResult is the parity verdict for a single replayed query.
+// QueryResult is the parity verdict for a single replayed query. On a divergence
+// it also carries Attribution: a list of CANDIDATE causes (never a detection —
+// verify cannot introspect either backend) to steer triage.
 type QueryResult struct {
-	Source    string     `json:"source"`
-	Expr      string     `json:"expr"`
-	Verdict   Verdict    `json:"verdict"`
-	FirstDiff *FirstDiff `json:"first_diff,omitempty"`
-	Detail    string     `json:"detail,omitempty"`
+	Source      string                 `json:"source"`
+	Expr        string                 `json:"expr"`
+	Verdict     Verdict                `json:"verdict"`
+	FirstDiff   *FirstDiff             `json:"first_diff,omitempty"`
+	Detail      string                 `json:"detail,omitempty"`
+	Attribution []AttributionCandidate `json:"attribution,omitempty"`
 }
 
 // Summary counts verdicts across the whole run.
@@ -375,22 +378,57 @@ func verifyOne(ctx context.Context, q Query, ref, cerberus Backend, p Params) Qu
 	default:
 		verdict, fd := Compare(refRes.Series, cerRes.Series, p.Tolerance)
 		out.Verdict, out.FirstDiff = verdict, fd
+		if verdict == VerdictDiverge {
+			out.Attribution = attributeDivergence(out.Expr, fd)
+		}
 	}
 	return out
 }
 
-// WriteText renders the report as a scannable, human-readable gate report: a
-// header, one block per non-matching query (matches are summarised, not listed,
-// so a diverging result is not buried), the out-of-scope accounting, and the
-// roll-up counts. It ends with an explicit PASS / FAIL line.
+// TextGuidance carries the CLI context the internal report cannot know on its
+// own — the exact, copy-pasteable command that regenerates this diagnostic — so
+// the failing text report can tell an operator precisely how to file a bug.
+type TextGuidance struct {
+	ReproCommand string
+}
+
+// WriteText renders the human report with no CLI-derived bug-report guidance. It
+// is the entrypoint for callers (and tests) that only have the Report in hand.
 func (r Report) WriteText(w io.Writer) error {
+	return r.writeText(w, nil)
+}
+
+// WriteTextGuided renders the human report and, on failure, a bug-report section
+// built from the CLI context in g (the repro command). The CLI uses this so a
+// failing run ends with a copy-pasteable reproduction.
+func (r Report) WriteTextGuided(w io.Writer, g TextGuidance) error {
+	return r.writeText(w, &g)
+}
+
+// writeText renders the report as a scannable, human-readable gate report. It
+// LEADS with an unmistakable PASSED / FAILED verdict banner, then a header (with
+// the one-time experimental-feature note), one block per non-matching query (with
+// its candidate-cause attribution), the out-of-scope accounting, the roll-up
+// counts, and — on failure — a "Report this to cerberus" bug-report section.
+func (r Report) writeText(w io.Writer, g *TextGuidance) error {
 	bw := &errWriter{w: w}
+
+	// R1: lead with a prominent, unmistakable verdict line.
+	if r.Failed() {
+		bw.printf("VERIFICATION FAILED — %d diverged, %d errored, %d matched (of %d)\n\n",
+			r.Summary.Diverge, r.Summary.Error, r.Summary.Match, r.Summary.Total)
+	} else {
+		bw.printf("VERIFICATION PASSED — all %d queries matched\n\n", r.Summary.Total)
+	}
+
 	bw.printf("# cerberus migrate verify\n")
 	bw.printf("#\n")
 	bw.printf("# Parity gate: each corpus query replayed against the reference Prometheus\n")
 	bw.printf("# and cerberus over one query_range window, results diffed series-by-series.\n")
 	bw.printf("# A divergence is never allow-listed — the gate fails if any query diverges\n")
 	bw.printf("# or errors.\n")
+	bw.printf("#\n")
+	bw.printf("# Note: %s\n", ExperimentalNote)
 	bw.printf("#\n")
 	bw.printf("# %d queries: %d match, %d diverge, %d unsupported, %d error (+%d out of scope, +%d harvest-skipped)\n\n",
 		r.Summary.Total, r.Summary.Match, r.Summary.Diverge, r.Summary.Unsupported, r.Summary.Error, r.Summary.OutOfScope, r.Summary.HarvestSkipped)
@@ -408,6 +446,9 @@ func (r Report) WriteText(w io.Writer) error {
 			fd := res.FirstDiff
 			bw.printf("   first-diff: series=%s ts=%s ref=%s cerberus=%s (%s)\n",
 				fd.Series, formatValue(fd.Timestamp), fd.RefValue, fd.CerberusValue, fd.Reason)
+		}
+		for _, a := range res.Attribution {
+			bw.printf("   candidate-cause [%s]: %s\n", a.Category, a.Note)
 		}
 		bw.printf("\n")
 	}
@@ -430,10 +471,32 @@ func (r Report) WriteText(w io.Writer) error {
 
 	if r.Failed() {
 		bw.printf("FAIL: %d diverge, %d error\n", r.Summary.Diverge, r.Summary.Error)
+		r.writeBugReport(bw, g)
 	} else {
 		bw.printf("PASS: %d match, %d unsupported (no divergence)\n", r.Summary.Match, r.Summary.Unsupported)
 	}
 	return bw.err
+}
+
+// writeBugReport prints the "Report this to cerberus" section shown after a
+// failing run: it frames a divergence as a possible cerberus bug, points at the
+// issues tracker, prints the exact copy-pasteable command to regenerate the
+// diagnostic (when the CLI supplied it), and asks the operator to attach the JSON.
+func (r Report) writeBugReport(bw *errWriter, g *TextGuidance) {
+	bw.printf("\n")
+	bw.printf("== Report this to cerberus\n")
+	bw.printf("   A divergence may indicate a cerberus bug. If the candidate causes above\n")
+	bw.printf("   (especially experimental-CH-feature deviations) are ruled out, please\n")
+	bw.printf("   open an issue so it can be fixed at the source:\n")
+	bw.printf("     %s\n", IssuesURL)
+	if g != nil && g.ReproCommand != "" {
+		bw.printf("   Regenerate the full JSON diagnostic with this exact command:\n")
+		bw.printf("     %s\n", g.ReproCommand)
+		bw.printf("   Then attach the resulting verify-report.json to the issue.\n")
+	} else {
+		bw.printf("   Re-run with --report verify-report.json to capture the full JSON\n")
+		bw.printf("   diagnostic, and attach it to the issue.\n")
+	}
 }
 
 // errWriter collapses the repeated Fprintf error checks into a single


### PR DESCRIPTION
## What

Extends the existing `migrate verify` parity gate (`internal/migrateverify` comparator + `cmd/migrate verify` wiring) with four operator-facing diagnostics. All additive — the gate's non-zero exit on any diverge/error is unchanged.

### R1 — Failure verdict in output
The text report now **leads** with an unmistakable verdict banner:

- `VERIFICATION FAILED — <D> diverged, <E> errored, <M> matched (of <T>)`
- `VERIFICATION PASSED — all <T> queries matched`

The trailing `PASS:` / `FAIL:` line is retained.

### R2 — `--report <file>` JSON diagnostics
New `--report <path>` flag (also `CERBERUS_VERIFY_REPORT`) writes the full diagnostics as a versioned, deterministically-marshaled `VerifyReport`: `schema_version`, `tool_version` (from build info), `generated_at`, the one-time experimental note, resolved run `params` (ref/cerberus URL, start/end/step, tolerance, corpus), summary counts, and per-query `{expr, source, verdict, first_diff, attribution}`. Additive — the human report still prints to stdout. Marshaling is stable (fixed field order, corpus-order results, indented).

### R3 — Bug-report guidance with repro steps
On failure the report ends with a **"Report this to cerberus"** section: it frames a divergence as a possible cerberus bug, gives the issues URL `https://github.com/tsouza/cerberus/issues`, prints the **exact copy-pasteable** `migrate verify …` command reconstructed from the resolved flag values (with `--report verify-report.json` suggested), and asks the operator to attach the JSON. URLs/paths with shell-special characters are single-quoted.

### R4 — Experimental-CH attribution
Each divergence carries a candidate-cause list. Hotspot exprs — `rate(` / `irate(` / `increase(` / `histogram_quantile(`, detected via a robust call-token check (identifier boundary + `(`, so `rate_total` and `job:rate` don't match) — add the `experimental-ch-feature` candidate with a note to re-run cerberus with experimental features disabled to isolate a real bug from an experimental-feature deviation. A one-time general note in the header/JSON explains the framing. **Honesty:** verify only sees two HTTP backends and cannot introspect cerberus config, so every attribution is worded as a *candidate-cause hint*, never a detection. The five categories (`cerberus-bug`, `experimental-ch-feature`, `ingest-artifact`, `data-window-gap`, `dialect-semantics`) are surfaced where relevant: `cerberus-bug` always, `experimental-ch-feature` on hotspots, `data-window-gap`+`ingest-artifact` on coverage gaps, `dialect-semantics` on plain value diffs.

## Notes
- Issues URL + hotspot function set lifted to named consts; no magic numbers.
- No raw SQL (touches no query SQL). No `t.Skip`/soft-assert. Operator-file reads annotated `//nolint:gosec`.
- Tests (real `httptest`, fixed timestamps): banner verdicts, hotspot vs non-hotspot attribution, coverage-gap attribution, hotspot token boundaries, deterministic parseable `VerifyReport` JSON, and cmd-level `--report` file + diverging-run stdout guidance (FAILED + issues URL + repro command).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
