### PR TITLE
fix(migrate): gate + rulegraph honesty, CLI UX, inventory tests

### DIFF
--- a/cmd/migrate/classify.go
+++ b/cmd/migrate/classify.go
@@ -35,7 +35,7 @@ func runClassifyCmd(args []string, stdout, stderr io.Writer) error {
 		"classify a corpus.json previously written by `migrate harvest`")
 	fs.StringVar(&out, "out", "", "write the classification here (default: stdout)")
 	fs.BoolVar(&asJSON, "json", false, "emit the classification ledger as JSON instead of text")
-	if err := fs.Parse(args); err != nil {
+	if handled, err := parseFlags(fs, args, stdout, stderr); err != nil || handled {
 		return err
 	}
 

--- a/cmd/migrate/gate.go
+++ b/cmd/migrate/gate.go
@@ -37,7 +37,7 @@ func runGate(args []string, stdout, stderr io.Writer) error {
 		highCardLabels = fs.Int64("high-card-label-values", migrategate.DefaultHighCardLabelValues,
 			"WARN when a label's distinct-value count reaches this threshold")
 	)
-	if err := fs.Parse(args); err != nil {
+	if handled, err := parseFlags(fs, args, stdout, stderr); err != nil || handled {
 		return err
 	}
 

--- a/cmd/migrate/inventory.go
+++ b/cmd/migrate/inventory.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"flag"
@@ -27,8 +28,9 @@ func runInventory(args []string, stdout, stderr io.Writer) error {
 		window = fs.String("window", envOr("CERBERUS_INVENTORY_WINDOW", ""),
 			"optional observation window (duration like 1h) recorded as report context")
 		asJSON = fs.Bool("json", false, "emit the machine-readable JSON report instead of text")
+		out    = fs.String("out", "", "write the inventory here (default: stdout)")
 	)
-	if err := fs.Parse(args); err != nil {
+	if handled, err := parseFlags(fs, args, stdout, stderr); err != nil || handled {
 		return err
 	}
 	if *source == "" {
@@ -44,8 +46,27 @@ func runInventory(args []string, stdout, stderr io.Writer) error {
 	if err != nil {
 		return err
 	}
-	if *asJSON {
-		return inv.WriteJSON(stdout)
+	return writeInventory(stdout, *out, inv, *asJSON)
+}
+
+// writeInventory renders the inventory (text or JSON) to --out, or stdout when
+// out is empty. When writing to a file it renders into a buffer first, then
+// commits with the checked writeOut, so a flush-at-close error surfaces rather
+// than truncating the report silently — the same file-output convention every
+// other gate-input producer follows.
+func writeInventory(stdout io.Writer, out string, inv migrateinventory.Inventory, asJSON bool) error {
+	render := func(w io.Writer) error {
+		if asJSON {
+			return inv.WriteJSON(w)
+		}
+		return inv.WriteText(w)
 	}
-	return inv.WriteText(stdout)
+	if out == "" {
+		return render(stdout)
+	}
+	var buf bytes.Buffer
+	if err := render(&buf); err != nil {
+		return err
+	}
+	return writeOut(stdout, out, buf.Bytes())
 }

--- a/cmd/migrate/inventory_test.go
+++ b/cmd/migrate/inventory_test.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/migrateinventory"
+)
+
+// tsdbServer answers the source-Prometheus endpoints the inventory probe calls:
+// the mandatory /api/v1/status/tsdb cardinality source plus the two optional
+// enrichments, all with fixed bodies, so the cmd-level test drives runInventory
+// end to end over real HTTP without a live Prometheus.
+func tsdbServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	const tsdb = `{"status":"success","data":{` +
+		`"headStats":{"numSeries":100,"numLabelPairs":200,"chunkCount":50,"minTime":1700000000000,"maxTime":1700000600000},` +
+		`"seriesCountByMetricName":[{"name":"http_requests_total","value":250000},{"name":"up","value":12}],` +
+		`"labelValueCountByLabelName":[{"name":"instance","value":30}],` +
+		`"memoryInBytesByLabelName":[{"name":"instance","value":4096}]}}`
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/status/tsdb", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(tsdb))
+	})
+	mux.HandleFunc("/api/v1/label/__name__/values", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"status":"success","data":["http_requests_total","up"]}`))
+	})
+	mux.HandleFunc("/api/v1/metadata", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"status":"success","data":{"up":[{"type":"gauge","help":"x","unit":""}]}}`))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// clearInventoryEnv unsets the CERBERUS_INVENTORY_* fallbacks so a test drives the
+// probe purely through explicit flags (or, for the env-fallback test, sets them).
+func clearInventoryEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("CERBERUS_INVENTORY_SOURCE", "")
+	t.Setenv("CERBERUS_INVENTORY_WINDOW", "")
+}
+
+// TestRunInventory_JSON: --json emits the machine-readable inventory, carrying the
+// stamped schema version and the ranked high-cardinality metric.
+func TestRunInventory_JSON(t *testing.T) {
+	clearInventoryEnv(t)
+	srv := tsdbServer(t)
+
+	var out, errOut bytes.Buffer
+	if err := runInventory([]string{"--source", srv.URL, "--json"}, &out, &errOut); err != nil {
+		t.Fatalf("runInventory --json: %v (stderr: %s)", err, errOut.String())
+	}
+	got := out.String()
+	if !strings.Contains(got, `"schema_version": 1`) {
+		t.Errorf("JSON inventory should stamp schema_version, got:\n%s", got)
+	}
+	if !strings.Contains(got, "http_requests_total") {
+		t.Errorf("JSON inventory should rank the high-cardinality metric, got:\n%s", got)
+	}
+}
+
+// TestRunInventory_Text: the default (non-JSON) form renders the scannable text
+// report with the head-block section and the ranked metric.
+func TestRunInventory_Text(t *testing.T) {
+	clearInventoryEnv(t)
+	srv := tsdbServer(t)
+
+	var out, errOut bytes.Buffer
+	if err := runInventory([]string{"--source", srv.URL}, &out, &errOut); err != nil {
+		t.Fatalf("runInventory: %v (stderr: %s)", err, errOut.String())
+	}
+	got := out.String()
+	if !strings.Contains(got, "head block") {
+		t.Errorf("text inventory should carry the head-block section, got:\n%s", got)
+	}
+	if !strings.Contains(got, "http_requests_total") {
+		t.Errorf("text inventory should rank the high-cardinality metric, got:\n%s", got)
+	}
+}
+
+// TestRunInventory_MissingSource: with neither --source nor CERBERUS_INVENTORY_SOURCE
+// set, runInventory reports a clear error naming the source flag rather than
+// panicking or silently probing nothing.
+func TestRunInventory_MissingSource(t *testing.T) {
+	clearInventoryEnv(t)
+
+	var out, errOut bytes.Buffer
+	err := runInventory(nil, &out, &errOut)
+	if err == nil {
+		t.Fatal("runInventory should reject a missing --source")
+	}
+	if !strings.Contains(err.Error(), "--source") {
+		t.Errorf("error should name the source flag, got: %v", err)
+	}
+}
+
+// TestRunInventory_InvalidTop: a non-positive --top fails Options.Validate, and
+// runInventory propagates that error (rather than probing with a bad rank size).
+func TestRunInventory_InvalidTop(t *testing.T) {
+	clearInventoryEnv(t)
+	srv := tsdbServer(t)
+
+	var out, errOut bytes.Buffer
+	err := runInventory([]string{"--source", srv.URL, "--top", "0"}, &out, &errOut)
+	if err == nil {
+		t.Fatal("runInventory should reject --top 0 via Options.Validate")
+	}
+	if !strings.Contains(err.Error(), "top must be positive") {
+		t.Errorf("error should come from Options.Validate, got: %v", err)
+	}
+}
+
+// TestRunInventory_SourceFromEnv: the source falls back to CERBERUS_INVENTORY_SOURCE
+// when --source is absent, so a run can be driven by env alone.
+func TestRunInventory_SourceFromEnv(t *testing.T) {
+	srv := tsdbServer(t)
+	t.Setenv("CERBERUS_INVENTORY_SOURCE", srv.URL)
+	t.Setenv("CERBERUS_INVENTORY_WINDOW", "")
+
+	var out, errOut bytes.Buffer
+	if err := runInventory([]string{"--json"}, &out, &errOut); err != nil {
+		t.Fatalf("runInventory (env source): %v (stderr: %s)", err, errOut.String())
+	}
+	if !strings.Contains(out.String(), "http_requests_total") {
+		t.Errorf("env-sourced inventory should rank the metric, got:\n%s", out.String())
+	}
+}
+
+// TestRunInventory_OutFile: --out writes the inventory to the named file (checked,
+// via writeOut) rather than stdout, following the file-output convention.
+func TestRunInventory_OutFile(t *testing.T) {
+	clearInventoryEnv(t)
+	srv := tsdbServer(t)
+	outPath := filepath.Join(t.TempDir(), "inventory.json")
+
+	var out, errOut bytes.Buffer
+	if err := runInventory([]string{"--source", srv.URL, "--json", "--out", outPath}, &out, &errOut); err != nil {
+		t.Fatalf("runInventory --out: %v (stderr: %s)", err, errOut.String())
+	}
+	if out.Len() != 0 {
+		t.Errorf("inventory --out should not write to stdout, got: %q", out.String())
+	}
+	data, err := os.ReadFile(outPath) //nolint:gosec // test-controlled temp path.
+	if err != nil {
+		t.Fatalf("read out file: %v", err)
+	}
+	if !strings.Contains(string(data), "http_requests_total") {
+		t.Errorf("out file should carry the inventory JSON, got:\n%s", data)
+	}
+	// The gate consumes this file: it must carry the schema version so the gate's
+	// version check accepts it. Tie the expectation to the source-of-truth const.
+	wantVer := fmt.Sprintf(`"schema_version": %d`, migrateinventory.InventoryVersion)
+	if !strings.Contains(string(data), wantVer) {
+		t.Errorf("out file should stamp %s for the gate, got:\n%s", wantVer, data)
+	}
+}

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -165,13 +165,89 @@ type options struct {
 	rules  stringList
 }
 
+// subcommand is one dispatchable `migrate` verb: its name and a one-line
+// description for the root usage listing.
+type subcommand struct {
+	name string
+	desc string
+}
+
+// subcommands is the full, ordered list the root usage prints. schema is invoked
+// as the `--schema` root flag rather than a verb, but it is listed here so the
+// operator sees every capability in one place.
+var subcommands = []subcommand{
+	{"schema", "print the ClickHouse schema cerberus expects (invoke as: migrate --schema)"},
+	{"harvest", "build a machine-readable PromQL query corpus from rule files + dashboards"},
+	{"explain", "dry-run corpus queries through the read pipeline (offline emitted SQL)"},
+	{"classify", "bucket each corpus query by how cleanly it maps onto cerberus PromQL support"},
+	{"rulegraph", "map recording-rule outputs to the consumers that must stay materialized"},
+	{"verify", "replay the corpus against reference Prometheus + cerberus (parity gate)"},
+	{"inventory", "probe a live source Prometheus for cardinality / OOM-risk facts"},
+	{"gate", "fold the artifacts into one cutover go/no-go decision"},
+}
+
+// writeRootUsage prints the root help: what the tool is, how to invoke it, the
+// full subcommand listing, and the root flag defaults. It sets the flagset output
+// to w so PrintDefaults lands on the same writer as the rest of the usage.
+func writeRootUsage(w io.Writer, fs *flag.FlagSet) {
+	fmt.Fprintln(w, "migrate — cerberus pre-cutover migration preview tool (offline)")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Usage:")
+	fmt.Fprintln(w, "  migrate <subcommand> [flags]")
+	fmt.Fprintln(w, "  migrate --schema | --rules <path/glob>")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Subcommands:")
+	for _, sc := range subcommands {
+		fmt.Fprintf(w, "  %-10s %s\n", sc.name, sc.desc)
+	}
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Root flags (no subcommand):")
+	fs.SetOutput(w)
+	fs.PrintDefaults()
+}
+
+// parseFlags parses fs, routing a -h/--help request cleanly to stdout (exit 0, no
+// error line) and a genuine flag error to stderr (non-zero). It buffers the
+// flagset's own output so the destination is chosen AFTER the parse outcome is
+// known. handled is true only for a help request, telling the caller to return
+// without running the command.
+func parseFlags(fs *flag.FlagSet, args []string, stdout, stderr io.Writer) (handled bool, err error) {
+	var buf bytes.Buffer
+	fs.SetOutput(&buf)
+	switch parseErr := fs.Parse(args); {
+	case errors.Is(parseErr, flag.ErrHelp):
+		_, _ = io.Copy(stdout, &buf)
+		return true, nil
+	case parseErr != nil:
+		_, _ = io.Copy(stderr, &buf)
+		return false, parseErr
+	default:
+		// Restore stderr so any post-parse validation usage (fs.Usage) a
+		// subcommand prints lands on stderr, not the now-discarded buffer.
+		fs.SetOutput(stderr)
+		return false, nil
+	}
+}
+
 // run is the testable entrypoint: it parses args, then dispatches. Splitting it
 // from main() (mirroring cmd/route-rules) keeps flag parsing and dispatch unit
-// -testable without spawning a process. The first arg selects a subcommand
-// (harvest / explain); anything else falls back to the legacy top-level
-// --schema / --rules flags so existing invocations keep working.
+// -testable without spawning a process. A non-flag first arg selects a subcommand
+// (an unrecognized one is a clear error, never a silent fall-through); otherwise
+// the top-level --schema / --rules flags run.
 func run(args []string, stdout, stderr io.Writer) error {
-	if len(args) > 0 {
+	fs := flag.NewFlagSet("migrate", flag.ContinueOnError)
+	var opts options
+	fs.BoolVar(&opts.schema, "schema", false,
+		"print the ClickHouse schema (CREATE statements) cerberus expects, then exit")
+	fs.Var(&opts.rules, "rules",
+		"explain the ClickHouse SQL for each PromQL query in these Prometheus rule "+
+			"files (repeatable or comma-separated paths/globs)")
+	fs.Usage = func() { writeRootUsage(fs.Output(), fs) }
+
+	// A first arg that is not a flag is a subcommand selector: dispatch a known
+	// one, and fail a mistyped one loudly rather than letting it fall through to
+	// the root flags and print a misleading "nothing to do".
+	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
 		switch args[0] {
 		case "harvest":
 			return runHarvest(args[1:], stdout, stderr)
@@ -187,18 +263,13 @@ func run(args []string, stdout, stderr io.Writer) error {
 			return runInventory(args[1:], stdout, stderr)
 		case "gate":
 			return runGate(args[1:], stdout, stderr)
+		default:
+			writeRootUsage(stderr, fs)
+			return fmt.Errorf("unknown subcommand %q", args[0])
 		}
 	}
 
-	fs := flag.NewFlagSet("migrate", flag.ContinueOnError)
-	fs.SetOutput(stderr)
-	var opts options
-	fs.BoolVar(&opts.schema, "schema", false,
-		"print the ClickHouse schema (CREATE statements) cerberus expects, then exit")
-	fs.Var(&opts.rules, "rules",
-		"explain the ClickHouse SQL for each PromQL query in these Prometheus rule "+
-			"files (repeatable or comma-separated paths/globs)")
-	if err := fs.Parse(args); err != nil {
+	if handled, err := parseFlags(fs, args, stdout, stderr); err != nil || handled {
 		return err
 	}
 
@@ -213,9 +284,9 @@ func run(args []string, stdout, stderr io.Writer) error {
 		}
 		return writeSchema(stdout, cfg)
 	default:
-		fs.Usage()
-		return fmt.Errorf("nothing to do: pass --schema to print the expected schema, " +
-			"--rules <path> to explain PromQL rule files, or the harvest/explain subcommand")
+		writeRootUsage(stderr, fs)
+		return errors.New("nothing to do: pass a subcommand, --schema to print the expected " +
+			"schema, or --rules <path> to explain PromQL rule files")
 	}
 }
 
@@ -234,7 +305,7 @@ func runHarvest(args []string, stdout, stderr io.Writer) error {
 	fs.StringVar(&dashboards, "dashboards", "",
 		"harvest PromQL from exported Grafana dashboard JSON under this directory (walked recursively)")
 	fs.StringVar(&out, "out", "", "write the corpus JSON here (default: stdout)")
-	if err := fs.Parse(args); err != nil {
+	if handled, err := parseFlags(fs, args, stdout, stderr); err != nil || handled {
 		return err
 	}
 
@@ -272,7 +343,7 @@ func runExplainCmd(args []string, stdout, stderr io.Writer) error {
 	fs.StringVar(&corpus, "corpus", "",
 		"explain a corpus.json previously written by `migrate harvest`")
 	fs.StringVar(&out, "out", "", "write the explain report here (default: stdout)")
-	if err := fs.Parse(args); err != nil {
+	if handled, err := parseFlags(fs, args, stdout, stderr); err != nil || handled {
 		return err
 	}
 

--- a/cmd/migrate/main_test.go
+++ b/cmd/migrate/main_test.go
@@ -34,6 +34,75 @@ func TestRun_UnknownFlagIsError(t *testing.T) {
 	}
 }
 
+// TestRunHelpExitsCleanToStdout pins that -h/--help prints usage to stdout and
+// returns no error (exit 0), with no spurious "flag: help requested" error line
+// on stderr.
+func TestRunHelpExitsCleanToStdout(t *testing.T) {
+	for _, flagArg := range []string{"-h", "--help"} {
+		var out, errOut bytes.Buffer
+		if err := run([]string{flagArg}, &out, &errOut); err != nil {
+			t.Fatalf("run %s should exit cleanly, got error: %v", flagArg, err)
+		}
+		if out.Len() == 0 {
+			t.Errorf("run %s should print usage to stdout", flagArg)
+		}
+		if errOut.Len() != 0 {
+			t.Errorf("run %s should write nothing to stderr, got: %q", flagArg, errOut.String())
+		}
+	}
+}
+
+// TestSubcommandHelpExitsClean pins that every subcommand's -h likewise exits 0
+// with usage on stdout and nothing on stderr — the fix applies to every flagset.
+func TestSubcommandHelpExitsClean(t *testing.T) {
+	for _, sc := range []string{"harvest", "explain", "classify", "rulegraph", "verify", "inventory", "gate"} {
+		var out, errOut bytes.Buffer
+		if err := run([]string{sc, "-h"}, &out, &errOut); err != nil {
+			t.Errorf("run %s -h should exit cleanly, got: %v", sc, err)
+		}
+		if out.Len() == 0 {
+			t.Errorf("run %s -h should print usage to stdout", sc)
+		}
+		if errOut.Len() != 0 {
+			t.Errorf("run %s -h should write nothing to stderr, got: %q", sc, errOut.String())
+		}
+	}
+}
+
+// TestRunUnknownSubcommand pins that a mistyped subcommand is a clear error (not a
+// silent fall-through to the root flags that prints "nothing to do").
+func TestRunUnknownSubcommand(t *testing.T) {
+	var out, errOut bytes.Buffer
+	err := run([]string{"verifyy"}, &out, &errOut)
+	if err == nil {
+		t.Fatal("an unknown subcommand should error")
+	}
+	if !strings.Contains(err.Error(), "unknown subcommand") || !strings.Contains(err.Error(), "verifyy") {
+		t.Errorf("error should name the unknown subcommand, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "nothing to do") {
+		t.Errorf("unknown subcommand must not fall through to the root 'nothing to do', got: %v", err)
+	}
+	if out.Len() != 0 {
+		t.Errorf("unknown subcommand should write nothing to stdout, got: %q", out.String())
+	}
+}
+
+// TestRootUsageListsSubcommands pins that the root usage names every subcommand so
+// an operator can discover them.
+func TestRootUsageListsSubcommands(t *testing.T) {
+	var out, errOut bytes.Buffer
+	if err := run([]string{"-h"}, &out, &errOut); err != nil {
+		t.Fatalf("run -h: %v", err)
+	}
+	usage := out.String()
+	for _, name := range []string{"schema", "harvest", "explain", "classify", "rulegraph", "verify", "inventory", "gate"} {
+		if !strings.Contains(usage, name) {
+			t.Errorf("root usage should list subcommand %q, got:\n%s", name, usage)
+		}
+	}
+}
+
 // TestStringListFlag pins that --rules accumulates both repeated flags and
 // comma-separated values, trimming blanks.
 func TestStringListFlag(t *testing.T) {

--- a/cmd/migrate/rulegraph.go
+++ b/cmd/migrate/rulegraph.go
@@ -35,7 +35,7 @@ func runRuleGraphCmd(args []string, stdout, stderr io.Writer) error {
 		"harvested corpus.json (from `migrate harvest`) whose queries are scanned as consumers")
 	fs.StringVar(&out, "out", "", "write graph here (default: stdout)")
 	fs.BoolVar(&asJSON, "json", false, "emit the graph as JSON instead of text")
-	if err := fs.Parse(args); err != nil {
+	if handled, err := parseFlags(fs, args, stdout, stderr); err != nil || handled {
 		return err
 	}
 	if len(rules) == 0 && corpus == "" {

--- a/cmd/migrate/verify.go
+++ b/cmd/migrate/verify.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"flag"
@@ -58,8 +59,9 @@ func runVerify(args []string, stdout, stderr io.Writer) error {
 		tolerance = fs.Float64("tolerance", tolDefault, "absolute value tolerance for a match")
 		asJSON    = fs.Bool("json", false, "emit the machine-readable JSON report instead of the text report")
 		report    = fs.String("report", envOr("CERBERUS_VERIFY_REPORT", ""), "write the full JSON diagnostics to this file (additive; the text report still prints)")
+		out       = fs.String("out", "", "write the report here (default: stdout); same content (text or --json) as stdout")
 	)
-	if err := fs.Parse(args); err != nil {
+	if handled, err := parseFlags(fs, args, stdout, stderr); err != nil || handled {
 		return err
 	}
 
@@ -109,7 +111,15 @@ func runVerify(args []string, stdout, stderr io.Writer) error {
 		}
 	}
 
-	if err := writeReport(stdout, rep, *asJSON, repro); err != nil {
+	// Render into a buffer, then commit via the checked writeOut so a flush error
+	// surfaces rather than truncating the report. --out follows the file-output
+	// convention (file when set, stdout when empty); the parity-gate exit verdict
+	// below fires regardless of where the report landed.
+	var buf bytes.Buffer
+	if err := writeReport(&buf, rep, *asJSON, repro); err != nil {
+		return err
+	}
+	if err := writeOut(stdout, *out, buf.Bytes()); err != nil {
 		return err
 	}
 	if rep.Failed() {

--- a/cmd/migrate/verify_test.go
+++ b/cmd/migrate/verify_test.go
@@ -217,6 +217,36 @@ func TestRunVerify_ReportFile(t *testing.T) {
 	}
 }
 
+// TestRunVerify_OutFile: --out writes the report to a file (checked, via
+// writeOut) instead of stdout, following the file-output convention every other
+// gate-input producer uses.
+func TestRunVerify_OutFile(t *testing.T) {
+	dir := t.TempDir()
+	corpus := writeCorpus(t, dir)
+	ref := promServer(t, map[string]string{"up": upMatrix})
+	cer := promServer(t, map[string]string{"up": upMatrix})
+	outPath := filepath.Join(dir, "verify.json")
+
+	var out, errOut bytes.Buffer
+	if err := runVerify([]string{
+		"--corpus", corpus, "--ref", ref.URL, "--cerberus", cer.URL,
+		"--start", "1700000000", "--end", "1700000600", "--step", "60s",
+		"--json", "--out", outPath,
+	}, &out, &errOut); err != nil {
+		t.Fatalf("runVerify --out: %v", err)
+	}
+	if out.Len() != 0 {
+		t.Errorf("verify --out should not write the report to stdout, got: %q", out.String())
+	}
+	data, err := os.ReadFile(outPath) //nolint:gosec // test-controlled temp path.
+	if err != nil {
+		t.Fatalf("read out file: %v", err)
+	}
+	if !strings.Contains(string(data), `"verdict": "match"`) {
+		t.Errorf("out file should carry the JSON report, got:\n%s", data)
+	}
+}
+
 // TestReproCommand_ShellQuoting: a URL with special characters is single-quoted so
 // the repro command stays copy-pasteable.
 func TestReproCommand_ShellQuoting(t *testing.T) {

--- a/internal/migrate/classify.go
+++ b/internal/migrate/classify.go
@@ -53,13 +53,22 @@ type BucketCounts struct {
 	Risky       int `json:"risky"`
 }
 
-// Classification is the full classify ledger: per-bucket counts, one
-// ClassifiedQuery per harvested query, and the entries the harvester skipped
-// (carried straight through from the report so the skip count never gets lost).
+// ClassificationVersion is the schema version stamped into every emitted
+// Classification. WriteJSON stamps it and the cutover gate refuses a ledger whose
+// version it does not understand, so a schema-drifted or wrong-type artifact
+// blocks rather than zero-filling to a silent PASS. Bump it on any breaking
+// change to the JSON shape.
+const ClassificationVersion = 1
+
+// Classification is the full classify ledger: the schema version, per-bucket
+// counts, one ClassifiedQuery per harvested query, and the entries the harvester
+// skipped (carried straight through from the report so the skip count never gets
+// lost).
 type Classification struct {
-	Counts  BucketCounts      `json:"counts"`
-	Queries []ClassifiedQuery `json:"queries"`
-	Skipped []SkippedEntry    `json:"skipped"`
+	SchemaVersion int               `json:"schema_version"`
+	Counts        BucketCounts      `json:"counts"`
+	Queries       []ClassifiedQuery `json:"queries"`
+	Skipped       []SkippedEntry    `json:"skipped"`
 }
 
 // Classify turns an already-built explain Report into a bucketed ledger. It does
@@ -69,8 +78,9 @@ type Classification struct {
 // query carrying offline Lint risks is additionally flagged risky.
 func Classify(rep Report) Classification {
 	cl := Classification{
-		Queries: make([]ClassifiedQuery, 0, len(rep.Queries)),
-		Skipped: rep.Skipped,
+		SchemaVersion: ClassificationVersion,
+		Queries:       make([]ClassifiedQuery, 0, len(rep.Queries)),
+		Skipped:       rep.Skipped,
 	}
 	for _, q := range rep.Queries {
 		cq := ClassifiedQuery{
@@ -152,6 +162,7 @@ func (c Classification) Write(w io.Writer) error {
 // trailing newline. Nil slices become empty slices so the ledger always carries
 // `[]` rather than `null`, matching the corpus JSON convention.
 func (c Classification) WriteJSON(w io.Writer) error {
+	c.SchemaVersion = ClassificationVersion
 	if c.Queries == nil {
 		c.Queries = []ClassifiedQuery{}
 	}

--- a/internal/migrate/rulegraph.go
+++ b/internal/migrate/rulegraph.go
@@ -77,23 +77,36 @@ type RuleGraphCounts struct {
 	Skipped   int `json:"skipped"`
 }
 
+// RuleGraphVersion is the schema version stamped into every emitted RuleGraph.
+// WriteJSON stamps it and the cutover gate refuses a graph whose version it does
+// not understand, so a schema-drifted or wrong-type artifact blocks rather than
+// zero-filling to a silent PASS. Bump it on any breaking change to the JSON shape.
+const RuleGraphVersion = 1
+
 // RuleGraph is the full recording-rule-output → consumer dependency graph:
-// per-recorded-series consumed/orphan classification with edges, the flat list
-// of consumers that reference a recorded series, and everything the builder had
-// to skip. It marshals deterministically so the same inputs always produce
-// byte-identical output.
+// the schema version, the per-recorded-series consumed/orphan classification with
+// edges, the flat list of consumers that reference a recorded series, and
+// everything the builder had to skip. It marshals deterministically so the same
+// inputs always produce byte-identical output.
 //
 // HONESTY: this is a NAME-LEVEL dependency approximation. A consumer is linked
 // to a recorded series when it references that series' metric NAME (via a vector
 // selector); label matchers, value equality, and rule-to-rule chains are not
 // analysed. A name collision (an unrelated metric that happens to share a
 // recorded name) would over-link; that is the safe direction (it keeps a series
-// marked "must materialize" rather than dropping one that is needed).
+// marked "must materialize" rather than dropping one that is needed). A consumer
+// whose matched name set CANNOT be statically reduced — a regex or negated
+// `__name__` matcher, or a selector with no name constraint at all — is NOT
+// under-linked to "references nothing" (which would be the UNSAFE direction: it
+// could hide a real consumer and leave a needed series wrongly orphan). It is
+// counted as a skip instead, which blocks the gate, keeping the over-link (never
+// under-link) invariant honest.
 type RuleGraph struct {
-	Counts    RuleGraphCounts `json:"counts"`
-	Recorded  []RecordedNode  `json:"recorded"`
-	Consumers []ConsumerNode  `json:"consumers"`
-	Skipped   []SkippedEntry  `json:"skipped"`
+	SchemaVersion int             `json:"schema_version"`
+	Counts        RuleGraphCounts `json:"counts"`
+	Recorded      []RecordedNode  `json:"recorded"`
+	Consumers     []ConsumerNode  `json:"consumers"`
+	Skipped       []SkippedEntry  `json:"skipped"`
 }
 
 // MetricNameExtractor pulls the set of metric-name references out of one query
@@ -114,22 +127,39 @@ var ruleGraphParser = promparser.NewParser(promparser.Options{EnableExperimental
 // selector, collecting the metric name each one reads (from an explicit
 // `__name__` equality matcher, or the selector's bare name). An expression that
 // does not parse is returned as an error so BuildRuleGraph records it as a skip.
+//
+// A selector whose matched name set cannot be statically reduced to concrete
+// names — a regex or negated `__name__` matcher, or a selector with no name
+// constraint at all — also returns an error: linking it to "references nothing"
+// would UNDER-link (the unsafe direction, potentially leaving a truly-consumed
+// recorded series marked orphan), so the whole consumer is recorded as a skip
+// instead, which blocks the gate.
 func PromQLMetricNames(expr string) ([]string, error) {
 	ast, err := ruleGraphParser.ParseExpr(expr)
 	if err != nil {
 		return nil, err
 	}
 	seen := map[string]struct{}{}
+	var unreducible error
 	promparser.Inspect(ast, func(node promparser.Node, _ []promparser.Node) error {
 		vs, ok := node.(*promparser.VectorSelector)
 		if !ok {
 			return nil
 		}
-		if name := metricNameOf(vs); name != "" {
-			seen[name] = struct{}{}
+		name, reducible := metricNameOf(vs)
+		if !reducible {
+			unreducible = fmt.Errorf(
+				"consumer selects __name__ non-statically (regex/negated matcher or no name constraint): %s",
+				vs.String(),
+			)
+			return unreducible // stop the walk; the whole consumer is a skip
 		}
+		seen[name] = struct{}{}
 		return nil
 	})
+	if unreducible != nil {
+		return nil, unreducible
+	}
 	names := make([]string, 0, len(seen))
 	for n := range seen {
 		names = append(names, n)
@@ -138,17 +168,29 @@ func PromQLMetricNames(expr string) ([]string, error) {
 	return names, nil
 }
 
-// metricNameOf returns the metric name a vector selector reads: the value of its
-// `__name__` equality matcher when present, else the selector's bare Name. A
-// selector with only a regex `__name__` matcher (no single concrete name) yields
-// "" — it names no single recorded series to link.
-func metricNameOf(vs *promparser.VectorSelector) string {
+// metricNameOf returns the single recorded-series name a vector selector reads
+// and whether that name is statically reducible. A `__name__` equality matcher
+// (or the selector's bare Name) yields a concrete name and reducible=true. A
+// regex or negated `__name__` matcher, or a selector with no name constraint at
+// all (e.g. `{job="x"}`, which matches every metric), yields reducible=false: its
+// matched name set is not a single concrete name, so the caller must count it as a
+// skip rather than under-link it to nothing.
+func metricNameOf(vs *promparser.VectorSelector) (name string, reducible bool) {
 	for _, m := range vs.LabelMatchers {
-		if m.Name == model.MetricNameLabel && m.Type == labels.MatchEqual {
-			return m.Value
+		if m.Name != model.MetricNameLabel {
+			continue
 		}
+		if m.Type == labels.MatchEqual {
+			return m.Value, true
+		}
+		// A regex/negated __name__ matcher selects a name SET, not one name.
+		return "", false
 	}
-	return vs.Name
+	if vs.Name != "" {
+		return vs.Name, true
+	}
+	// No name constraint: the selector matches every metric name.
+	return "", false
 }
 
 // BuildRuleGraph is the pure, offline core: given the recording-rule outputs and
@@ -358,7 +400,9 @@ func (g RuleGraph) Write(w io.Writer) error {
 	bw.printf("# HONESTY: this is a NAME-LEVEL dependency approximation — a consumer links to\n")
 	bw.printf("# a recorded series when it references that series' metric NAME. Label matchers,\n")
 	bw.printf("# value equality, and rule-to-rule chains are not analysed. Unparseable consumer\n")
-	bw.printf("# exprs are counted as skips below, never silently ignored.\n")
+	bw.printf("# exprs — and consumers whose __name__ set can't be statically reduced (a regex or\n")
+	bw.printf("# negated __name__ matcher, or no name constraint) — are counted as skips below\n")
+	bw.printf("# (never under-linked to nothing), so the over-link direction stays honest.\n")
 	bw.printf("#\n")
 	bw.printf("# %d recorded series: %d consumed, %d orphan; %d consumers; %d skipped\n\n",
 		g.Counts.Recorded, g.Counts.Consumed, g.Counts.Orphan, g.Counts.Consumers, g.Counts.Skipped)
@@ -402,6 +446,7 @@ func (g RuleGraph) Write(w io.Writer) error {
 // newline. Nil slices become empty slices so the graph always carries `[]` rather
 // than `null`, matching the corpus/classify JSON convention.
 func (g RuleGraph) WriteJSON(w io.Writer) error {
+	g.SchemaVersion = RuleGraphVersion
 	if g.Recorded == nil {
 		g.Recorded = []RecordedNode{}
 	}

--- a/internal/migrate/rulegraph_test.go
+++ b/internal/migrate/rulegraph_test.go
@@ -211,3 +211,58 @@ groups:
 		t.Fatalf("skipped = %+v, want 2 (empty-expr alert + no-name rule)", skipped)
 	}
 }
+
+// TestPromQLMetricNamesRegexNameIsSkip pins that a consumer selecting __name__ by
+// regex (a name set that cannot be statically reduced) is returned as an error, so
+// BuildRuleGraph records it as a skip rather than under-linking it to nothing.
+func TestPromQLMetricNamesRegexNameIsSkip(t *testing.T) {
+	cases := []string{
+		`sum({__name__=~"job:.*"})`, // regex __name__ matcher
+		`{__name__!="up"}`,          // negated __name__ matcher
+		`sum({job="api"})`,          // no name constraint at all (matches every metric)
+	}
+	for _, expr := range cases {
+		if _, err := PromQLMetricNames(expr); err == nil {
+			t.Errorf("PromQLMetricNames(%q) should error (name set not statically reducible), got nil", expr)
+		}
+	}
+
+	// A concrete-name selector (even with label matchers) stays reducible.
+	names, err := PromQLMetricNames(`sum(job:http:rate5m{env="prod"})`)
+	if err != nil {
+		t.Fatalf("concrete-name selector should reduce, got error: %v", err)
+	}
+	if len(names) != 1 || names[0] != "job:http:rate5m" {
+		t.Errorf("names = %v, want [job:http:rate5m]", names)
+	}
+}
+
+// TestBuildRuleGraphRegexConsumerCountsAsSkip pins the honesty invariant: a regex
+// __name__ consumer that WOULD match a recorded series is counted as a skip
+// (blocking the gate), never silently under-linked so that a truly-consumed
+// recorded series is left wrongly orphan.
+func TestBuildRuleGraphRegexConsumerCountsAsSkip(t *testing.T) {
+	recorded := []RecordedSeries{
+		{Name: "job:http_requests:rate5m", Source: "rule:a.yml/api/job:http_requests:rate5m"},
+	}
+	consumers := []HarvestedQuery{
+		// This regex would match the recorded series by name, but the match set is
+		// not statically reducible — it must become a skip, not a silent non-link.
+		{Expr: `sum({__name__=~"job:http_requests:.*"})`, Source: "dash:overview/panel-1", Kind: KindPanel},
+	}
+
+	g := BuildRuleGraph(recorded, consumers, PromQLMetricNames, nil)
+
+	if g.Counts.Skipped != 1 {
+		t.Fatalf("skipped = %d, want 1 (the regex consumer)", g.Counts.Skipped)
+	}
+	if g.Counts.Consumers != 0 {
+		t.Errorf("consumers = %d, want 0 (regex consumer is a skip, not a link)", g.Counts.Consumers)
+	}
+	if len(g.Skipped) != 1 || g.Skipped[0].Source != "dash:overview/panel-1" {
+		t.Fatalf("skipped entry = %+v, want the regex consumer source", g.Skipped)
+	}
+	if !strings.Contains(g.Skipped[0].Reason, "__name__") {
+		t.Errorf("skip reason should explain the non-reducible __name__ selection, got %q", g.Skipped[0].Reason)
+	}
+}

--- a/internal/migrategate/gate.go
+++ b/internal/migrategate/gate.go
@@ -10,13 +10,15 @@
 // conservative) are:
 //
 //   - verify   — BLOCK if any query diverged or errored (the parity gate found
-//     cerberus returning different numbers, or a backend failing). WARN when the
-//     report carries UNCHECKED entries — queries that emitted SQL but returned
-//     no comparable matrix live (Unsupported), harvest-skipped entries, or
-//     out-of-scope (non-PromQL) entries — so a green parity gate never hides an
-//     unexamined input.
+//     cerberus returning different numbers, or a backend failing), or if the run
+//     verified ZERO queries (an empty harvest proves nothing and must not
+//     green-light a cutover). WARN when the report carries UNCHECKED entries —
+//     queries that emitted SQL but returned no comparable matrix live
+//     (Unsupported), harvest-skipped entries, or out-of-scope (non-PromQL)
+//     entries — so a green parity gate never hides an unexamined input.
 //   - classify — BLOCK if any corpus query is unsupported (no cerberus
-//     equivalent). A supported-but-risky query WARNs but does not block; a
+//     equivalent), or if ZERO queries were classified (an empty harvest cannot
+//     prove support). A supported-but-risky query WARNs but does not block; a
 //     harvest-skipped corpus entry (never classified) also WARNs.
 //   - inventory — WARN (never block) when the source carries high-cardinality
 //     metrics or labels: an OOM candidate to review, not a correctness stop.
@@ -36,12 +38,18 @@
 // required; inventory is advisory (its worst outcome is a WARN), so a missing
 // inventory artifact is reported but does not block.
 //
+// Every artifact is decoded strictly (unknown fields rejected) and its stamped
+// schema_version is checked against the version this gate build understands. A
+// schema-drifted, wrong-type, or version-mismatched artifact is a hard error, not
+// a struct that zero-fills its counts to a silent PASS.
+//
 // Every count each upstream block deliberately preserves — the skip/unchecked/
 // caveat tallies — is threaded into a stage's Reasons here, never silently
 // re-dropped at the aggregation layer.
 package migrategate
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -196,9 +204,21 @@ func evalVerify(path string) (StageResult, error) {
 	if err := readArtifact(path, &rep); err != nil {
 		return StageResult{}, err
 	}
+	if err := requireSchemaVersion(path, rep.SchemaVersion, migrateverify.ReportVersion); err != nil {
+		return StageResult{}, err
+	}
 	res.Present = true
 	s := rep.Summary
 	caveats := verifyCaveats(s)
+	if s.Total == 0 {
+		// A parity run that replayed zero queries proves nothing — an empty
+		// harvest must never green-light a cutover with nothing verified.
+		res.Verdict = VerdictFail
+		res.Blocking = true
+		res.Reasons = append(res.Reasons, "nothing verified: the parity run replayed 0 queries (an empty corpus cannot prove parity)")
+		res.Reasons = append(res.Reasons, caveats...)
+		return res, nil
+	}
 	if s.Diverge > 0 || s.Error > 0 {
 		res.Verdict = VerdictFail
 		res.Blocking = true
@@ -260,7 +280,19 @@ func evalClassify(path string) (StageResult, error) {
 	if err := readArtifact(path, &cl); err != nil {
 		return StageResult{}, err
 	}
+	if err := requireSchemaVersion(path, cl.SchemaVersion, migrate.ClassificationVersion); err != nil {
+		return StageResult{}, err
+	}
 	res.Present = true
+	if cl.Counts.Total == 0 {
+		// Classifying zero queries proves no cerberus-support coverage — an empty
+		// harvest must never green-light a cutover with nothing classified.
+		res.Verdict = VerdictFail
+		res.Blocking = true
+		res.Reasons = append(res.Reasons, "nothing classified: 0 corpus queries were bucketed (an empty corpus cannot prove support)")
+		res.Reasons = append(res.Reasons, classifyHarvestSkips(cl)...)
+		return res, nil
+	}
 	if cl.Counts.Unsupported > 0 {
 		res.Verdict = VerdictFail
 		res.Blocking = true
@@ -329,6 +361,9 @@ func evalInventory(path string, opts Options) (StageResult, error) {
 	if err := readArtifact(path, &inv); err != nil {
 		return StageResult{}, err
 	}
+	if err := requireSchemaVersion(path, inv.SchemaVersion, migrateinventory.InventoryVersion); err != nil {
+		return StageResult{}, err
+	}
 	res.Present = true
 
 	seriesLimit := opts.highCardSeries()
@@ -394,6 +429,9 @@ func evalRuleGraph(path string) (StageResult, error) {
 	}
 	var g migrate.RuleGraph
 	if err := readArtifact(path, &g); err != nil {
+		return StageResult{}, err
+	}
+	if err := requireSchemaVersion(path, g.SchemaVersion, migrate.RuleGraphVersion); err != nil {
 		return StageResult{}, err
 	}
 	res.Present = true
@@ -471,16 +509,36 @@ func plural(n int, one, many string) string {
 	return many
 }
 
-// readArtifact reads and JSON-decodes one artifact file into v. A read or
-// decode failure is wrapped with the path so the operator can tell which
-// artifact is at fault.
+// readArtifact reads and strictly JSON-decodes one artifact file into v. A read
+// or decode failure is wrapped with the path so the operator can tell which
+// artifact is at fault. Decoding uses DisallowUnknownFields so a schema-drifted
+// or wrong-type artifact (e.g. a classify.json handed to --verify) is a hard
+// error the operator must fix, never a struct that silently zero-fills its
+// counts to a bogus PASS.
 func readArtifact(path string, v any) error {
 	data, err := os.ReadFile(path) //nolint:gosec // operator-supplied artifact path; offline CLI input.
 	if err != nil {
 		return fmt.Errorf("read artifact %q: %w", path, err)
 	}
-	if err := json.Unmarshal(data, v); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(v); err != nil {
 		return fmt.Errorf("parse artifact %q: %w", path, err)
+	}
+	return nil
+}
+
+// requireSchemaVersion rejects an artifact whose stamped schema_version is not the
+// one this gate build understands. A missing version zero-fills to 0 and a drifted
+// producer stamps a different number; either way the gate cannot trust the file's
+// shape, so it is a hard error (a block, never a silent PASS on a misread
+// artifact), consistent with the unreadable/unparseable contract.
+func requireSchemaVersion(path string, got, want int) error {
+	if got != want {
+		return fmt.Errorf(
+			"artifact %q: unsupported schema_version %d (this gate understands %d); regenerate it with a matching `migrate` build",
+			path, got, want,
+		)
 	}
 	return nil
 }

--- a/internal/migrategate/gate_test.go
+++ b/internal/migrategate/gate_test.go
@@ -550,6 +550,110 @@ func TestEvaluateWarnsOnInventoryEnrichmentUnavailableWithoutNotes(t *testing.T)
 	}
 }
 
+// rawArtifact writes verbatim bytes to a temp file and returns its path, for the
+// artifact shapes a producer's WriteJSON would never emit — a version-less,
+// version-mismatched, or field-drifted file — so the gate's strict decode +
+// schema-version check can be exercised against them.
+func rawArtifact(t *testing.T, name, content string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	return p
+}
+
+// TestEvaluateBlocksOnVersionMismatch pins that a verify.json stamped with a
+// schema_version this gate build does not understand is a hard error (a block),
+// never a zero-filled struct that reads as a silent PASS.
+func TestEvaluateBlocksOnVersionMismatch(t *testing.T) {
+	verify := rawArtifact(t, "verify.json",
+		`{"schema_version":999,"params":{"tolerance":1e-9},"summary":{"total":3,"match":3},"results":[]}`)
+	in := migrategate.Inputs{Verify: verify, Classify: cleanClassify(t), RuleGraph: cleanRuleGraph(t)}
+	if _, err := migrategate.Evaluate(in, migrategate.Options{}); err == nil {
+		t.Fatal("a version-mismatched verify artifact must hard error, not silently PASS")
+	}
+}
+
+// TestEvaluateBlocksOnMissingVersion pins that a version-less artifact (which
+// zero-fills schema_version to 0) is rejected, not trusted.
+func TestEvaluateBlocksOnMissingVersion(t *testing.T) {
+	verify := rawArtifact(t, "verify.json",
+		`{"params":{"tolerance":1e-9},"summary":{"total":3,"match":3},"results":[]}`)
+	in := migrategate.Inputs{Verify: verify, Classify: cleanClassify(t), RuleGraph: cleanRuleGraph(t)}
+	if _, err := migrategate.Evaluate(in, migrategate.Options{}); err == nil {
+		t.Fatal("a version-less verify artifact must hard error")
+	}
+}
+
+// TestEvaluateBlocksOnDriftedUnknownField pins that the strict decoder rejects an
+// unknown field (schema drift) rather than ignoring it — a drifted producer
+// cannot slip a zero-filled struct past the gate.
+func TestEvaluateBlocksOnDriftedUnknownField(t *testing.T) {
+	verify := rawArtifact(t, "verify.json",
+		`{"schema_version":1,"summary":{"total":3,"match":3},"bogus_new_field":42}`)
+	in := migrategate.Inputs{Verify: verify, Classify: cleanClassify(t), RuleGraph: cleanRuleGraph(t)}
+	if _, err := migrategate.Evaluate(in, migrategate.Options{}); err == nil {
+		t.Fatal("a drifted verify artifact with an unknown field must hard error")
+	}
+}
+
+// TestEvaluateBlocksOnWrongTypeArtifact pins that a classify.json handed to
+// --verify is rejected: its fields are unknown to the verify Report, so the
+// strict decoder blocks rather than zero-filling verify's counts to a bogus PASS.
+func TestEvaluateBlocksOnWrongTypeArtifact(t *testing.T) {
+	in := migrategate.Inputs{Verify: cleanClassify(t), Classify: cleanClassify(t), RuleGraph: cleanRuleGraph(t)}
+	if _, err := migrategate.Evaluate(in, migrategate.Options{}); err == nil {
+		t.Fatal("a classify artifact fed to --verify must hard error (wrong type), not PASS")
+	}
+}
+
+// TestEvaluateBlocksOnZeroQueryVerify pins that a parity run that replayed zero
+// queries blocks: an empty harvest proves nothing and must not green-light cutover.
+func TestEvaluateBlocksOnZeroQueryVerify(t *testing.T) {
+	rep := migrateverify.Report{Summary: migrateverify.Summary{Total: 0}}
+	in := migrategate.Inputs{
+		Verify:    writeArtifact(t, "verify.json", rep.WriteJSON),
+		Classify:  cleanClassify(t),
+		Inventory: cleanInventory(t),
+		RuleGraph: cleanRuleGraph(t),
+	}
+	dec, err := migrategate.Evaluate(in, migrategate.Options{})
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	v := stageByName(t, dec, migrategate.StageVerify)
+	if dec.Pass || v.Verdict != migrategate.VerdictFail || !v.Blocking {
+		t.Fatalf("zero-query verify must FAIL+block, got pass=%v verdict=%q blocking=%v", dec.Pass, v.Verdict, v.Blocking)
+	}
+	if !containsSubstr(v.Reasons, "nothing verified") {
+		t.Errorf("verify reasons should say nothing verified, got %v", v.Reasons)
+	}
+}
+
+// TestEvaluateBlocksOnZeroQueryClassify pins the same for classify: bucketing
+// zero queries proves no support coverage and must block.
+func TestEvaluateBlocksOnZeroQueryClassify(t *testing.T) {
+	cl := migrate.Classification{Counts: migrate.BucketCounts{Total: 0}}
+	in := migrategate.Inputs{
+		Verify:    cleanVerify(t),
+		Classify:  writeArtifact(t, "classify.json", cl.WriteJSON),
+		Inventory: cleanInventory(t),
+		RuleGraph: cleanRuleGraph(t),
+	}
+	dec, err := migrategate.Evaluate(in, migrategate.Options{})
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	c := stageByName(t, dec, migrategate.StageClassify)
+	if dec.Pass || c.Verdict != migrategate.VerdictFail || !c.Blocking {
+		t.Fatalf("zero-query classify must FAIL+block, got pass=%v verdict=%q blocking=%v", dec.Pass, c.Verdict, c.Blocking)
+	}
+	if !containsSubstr(c.Reasons, "nothing classified") {
+		t.Errorf("classify reasons should say nothing classified, got %v", c.Reasons)
+	}
+}
+
 // containsSubstr reports whether any element of ss contains sub.
 func containsSubstr(ss []string, sub string) bool {
 	for _, s := range ss {

--- a/internal/migrateinventory/inventory.go
+++ b/internal/migrateinventory/inventory.go
@@ -105,13 +105,21 @@ type tsdbStatusResponse struct {
 	Error     string `json:"error"`
 }
 
+// InventoryVersion is the schema version stamped into every emitted Inventory.
+// WriteJSON stamps it and the cutover gate refuses an inventory whose version it
+// does not understand, so a schema-drifted or wrong-type artifact blocks rather
+// than zero-filling to a silent PASS. Bump it on any breaking change to the JSON
+// shape.
+const InventoryVersion = 1
+
 // Inventory is the ranked risk picture of the source Prometheus head block.
 // Every field is a source-Prometheus runtime fact; none predicts cerberus's
 // memory. It ranks candidates worth reviewing before cutover.
 type Inventory struct {
-	Source string `json:"source"`
-	Window string `json:"window,omitempty"`
-	Top    int    `json:"top"`
+	SchemaVersion int    `json:"schema_version"`
+	Source        string `json:"source"`
+	Window        string `json:"window,omitempty"`
+	Top           int    `json:"top"`
 
 	Head HeadStats `json:"head"`
 
@@ -168,6 +176,7 @@ func (c *Client) Probe(ctx context.Context, opts Options) (Inventory, error) {
 	}
 
 	inv := Inventory{
+		SchemaVersion:       InventoryVersion,
 		Source:              c.BaseURL,
 		Window:              opts.Window,
 		Top:                 opts.Top,

--- a/internal/migrateinventory/report.go
+++ b/internal/migrateinventory/report.go
@@ -8,8 +8,10 @@ import (
 )
 
 // WriteJSON renders the inventory as machine-readable JSON with a trailing
-// newline.
+// newline. It stamps the current schema version so the artifact is self-describing
+// and the cutover gate can refuse an inventory shape it does not understand.
 func (inv Inventory) WriteJSON(w io.Writer) error {
+	inv.SchemaVersion = InventoryVersion
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
 	if err := enc.Encode(inv); err != nil {

--- a/internal/migrateverify/client.go
+++ b/internal/migrateverify/client.go
@@ -332,7 +332,10 @@ func LoadCorpus(path string) (Corpus, error) {
 }
 
 // WriteJSON renders the report as machine-readable JSON with a trailing newline.
+// It stamps the current schema version so every artifact on disk is self-describing
+// and the cutover gate can refuse a report shape it does not understand.
 func (r Report) WriteJSON(w io.Writer) error {
+	r.SchemaVersion = ReportVersion
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
 	if err := enc.Encode(r); err != nil {

--- a/internal/migrateverify/verify.go
+++ b/internal/migrateverify/verify.go
@@ -355,10 +355,19 @@ type ReportParams struct {
 	Tolerance float64 `json:"tolerance"`
 }
 
-// Report is the full parity result: the resolved comparison params, per-query
-// verdicts, the out-of-scope accounting, the harvest-time skips, and the roll-up
-// summary.
+// ReportVersion is the schema version stamped into the gate-consumed `--json`
+// report (the plain Report, distinct from the richer `--report` VerifyReport
+// diagnostic). WriteJSON stamps it and the cutover gate refuses a report whose
+// version it does not understand, so a schema-drifted or wrong-type artifact
+// blocks rather than zero-filling to a silent PASS. Bump it on any breaking
+// change to the on-disk Report shape.
+const ReportVersion = 1
+
+// Report is the full parity result: the schema version, the resolved comparison
+// params, per-query verdicts, the out-of-scope accounting, the harvest-time
+// skips, and the roll-up summary.
 type Report struct {
+	SchemaVersion  int                   `json:"schema_version"`
 	Params         ReportParams          `json:"params"`
 	Summary        Summary               `json:"summary"`
 	Results        []QueryResult         `json:"results"`
@@ -403,6 +412,7 @@ type RangeResult struct {
 //   - otherwise → the comparator's match/diverge verdict.
 func Verify(ctx context.Context, corpus Corpus, ref, cerberus Backend, p Params) Report {
 	rep := Report{
+		SchemaVersion:  ReportVersion,
 		Params:         ReportParams{Tolerance: p.Tolerance},
 		OutOfScope:     corpus.OutOfScope,
 		HarvestSkipped: corpus.HarvestSkipped,


### PR DESCRIPTION
Bundle of CONFIRMED audit findings in cerberus's migration CLI. Each finding gets a root-cause fix plus a regression test.

## Findings fixed

### MED — gate contract: version-less artifacts silently PASS
`internal/migrategate/gate.go` decoded its four inputs via plain `json.Unmarshal` into version-less structs, so a wrong-type or schema-drifted artifact zero-filled to `Diverge:0` ⇒ silent PASS.

- Added a stamped `schema_version` to each gate-consumed artifact type: `migrateverify.Report` (`ReportVersion`), `migrate.Classification` (`ClassificationVersion`), `migrateinventory.Inventory` (`InventoryVersion`), `migrate.RuleGraph` (`RuleGraphVersion`) — following the existing `corpus.json` `Version` pattern. Each producer stamps it in its constructor and (belt-and-suspenders) in `WriteJSON`.
- `readArtifact` now uses `json.Decoder` with `DisallowUnknownFields`; the gate rejects a missing/mismatched version. A wrong-type / drifted / version-mismatched artifact is a hard error (block), never a silent PASS.
- Tests: version-mismatch, missing-version, drifted-unknown-field, and wrong-type (classify JSON fed to `--verify`) all block.

### LOW — gate correctness: zero-query run reads as PASS
A verify/classify artifact with `Total==0` green-lit cutover with nothing verified. Now `Total==0` BLOCKS with an explicit "nothing verified" / "nothing classified" reason. Tests added.

### MED — rulegraph honesty: regex/label-only `__name__` consumers under-link
A consumer selecting `__name__` by regex/negation (or with no name constraint at all) was silently treated as referencing nothing, so a truly-consumed recorded series could be marked Orphan — contradicting the package's "over-link is the safe direction" note and risking an operator dropping a live materializer (blank panel). Such a consumer is now counted as a SKIP (which blocks the gate). Honesty notes corrected in the type doc and the text report. Tests with `{__name__=~"..."}`, `{__name__!="up"}`, and `{job="api"}` consumers.

### LOW — CLI UX: `-h`/`--help` exits 1 with a spurious error line
`flag.ErrHelp` is now handled cleanly: exit 0, usage to stdout, no `migrate: flag: help requested` line — for the root flagset and every subcommand (shared `parseFlags` helper). Tested for root and all subcommands.

### LOW — CLI UX: unknown subcommand silently falls through
A mistyped first arg fell through to the root flags and printed a misleading "nothing to do". Now an unrecognized non-flag first arg is a clear `unknown subcommand %q` error + usage, non-zero exit. Tested.

### LOW — CLI UX: root usage never listed the subcommands
The root usage now lists all subcommands (schema/harvest/explain/classify/rulegraph/verify/inventory/gate) with one-line descriptions. Tested.

### LOW — convention: inventory (and verify) had no `--out`
`inventory` and `verify` now take `--out <file>`, writing the same content that goes to stdout via the shared checked-write helper (`writeOut`) — matching every other gate-input producer. Tested.

### MED — test: `runInventory` had zero coverage
New `cmd/migrate/inventory_test.go` mirrors `verify_test.go` with an `httptest` source Prometheus (`/api/v1/status/tsdb` + enrichment endpoints), covering the missing-source guard, json + text output, the env fallback, `Options.Validate` propagation (`--top 0`), and `--out`.

## Notes
- No new packages; no `.go-arch-lint.yml` change needed.
- No raw SQL; no skip/soft-assert tokens; named consts only.
- Tests are real + deterministic (httptest, fixed timestamps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
