### PR TITLE
fix(migrate): final audit batch — gate soundness, creds leak, preview fidelity, polish

### DIFF
--- a/cmd/migrate/classify.go
+++ b/cmd/migrate/classify.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -41,6 +42,9 @@ func runClassifyCmd(args []string, stdout, stderr io.Writer) error {
 
 	src, err := harvestSources(corpus, rules, dashboards)
 	if err != nil {
+		if errors.Is(err, errNothingToHarvest) {
+			fs.Usage()
+		}
 		return err
 	}
 	if out == "" {

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -311,6 +311,9 @@ func runHarvest(args []string, stdout, stderr io.Writer) error {
 
 	src, err := harvestSources("", rules, dashboards)
 	if err != nil {
+		if errors.Is(err, errNothingToHarvest) {
+			fs.Usage()
+		}
 		return err
 	}
 	queries, skipped, err := src.Harvest(context.Background())
@@ -349,6 +352,9 @@ func runExplainCmd(args []string, stdout, stderr io.Writer) error {
 
 	src, err := harvestSources(corpus, rules, dashboards)
 	if err != nil {
+		if errors.Is(err, errNothingToHarvest) {
+			fs.Usage()
+		}
 		return err
 	}
 	if out == "" {
@@ -379,10 +385,16 @@ func harvestSources(corpus string, rules []string, dashboards string) (migrate.C
 		src = append(src, migrate.DashboardSource{Dir: dashboards})
 	}
 	if len(src) == 0 {
-		return nil, errors.New("nothing to harvest: pass --rules, --dashboards, and/or --corpus")
+		return nil, errNothingToHarvest
 	}
 	return src, nil
 }
+
+// errNothingToHarvest is returned by harvestSources when no corpus-input flag was
+// supplied. The corpus subcommands (harvest / explain / classify) treat it as a
+// usage error — print the flag help before returning — mirroring how rulegraph
+// handles its own missing-input case, so every corpus command is consistent.
+var errNothingToHarvest = errors.New("nothing to harvest: pass --rules, --dashboards, and/or --corpus")
 
 // runExplainReport dry-runs every query from src through the read-side pipeline
 // and writes the explain report to w. It is fully offline: the engine has no

--- a/cmd/migrate/main_test.go
+++ b/cmd/migrate/main_test.go
@@ -103,6 +103,22 @@ func TestRootUsageListsSubcommands(t *testing.T) {
 	}
 }
 
+// TestCorpusCommandsPrintUsageOnMissingInput pins that the corpus subcommands
+// (harvest / explain / classify), like rulegraph, print flag usage on stderr
+// when no corpus-input flag is supplied — a consistent usage-error UX rather than
+// a bare error line.
+func TestCorpusCommandsPrintUsageOnMissingInput(t *testing.T) {
+	for _, sc := range []string{"harvest", "explain", "classify"} {
+		var out, errOut bytes.Buffer
+		if err := run([]string{sc}, &out, &errOut); err == nil {
+			t.Errorf("%s with no inputs should error", sc)
+		}
+		if !strings.Contains(errOut.String(), "Usage of migrate "+sc) {
+			t.Errorf("%s with no inputs should print usage on stderr, got: %q", sc, errOut.String())
+		}
+	}
+}
+
 // TestStringListFlag pins that --rules accumulates both repeated flags and
 // comma-separated values, trimming blanks.
 func TestStringListFlag(t *testing.T) {

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -49,26 +49,39 @@ You need three things in place:
 
 ## The `migrate` tool
 
-There are eight capabilities: seven subcommands plus one root flag.
+There are nine capabilities: seven subcommands plus two root flags (`--schema`
+and `--rules`).
 
-| Command             | What it does                                                            | Key flags                                                                                                                                        | Network             |
-| ------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------- |
-| `migrate --schema`  | Print the `CREATE` statements cerberus expects, from `CERBERUS_*` env   | *(root flag; reads `CERBERUS_*`)*                                                                                                                | offline             |
-| `migrate harvest`   | Build a machine-readable PromQL corpus from your files                  | `--rules`, `--dashboards`, `--out`                                                                                                               | offline             |
-| `migrate explain`   | Dry-run each corpus query through the read pipeline, print the SQL      | `--corpus` (or `--rules`/`--dashboards`), `--out`                                                                                                | offline             |
-| `migrate classify`  | Bucket each query as supported / unsupported / risky                    | `--corpus` (or `--rules`/`--dashboards`), `--json`, `--out`                                                                                      | offline             |
-| `migrate rulegraph` | Map recording-rule outputs to the consumers that must stay materialized | `--rules`, `--corpus`, `--json`, `--out`                                                                                                         | offline             |
-| `migrate verify`    | Replay the corpus against **both** backends and diff (parity gate)      | `--corpus`, `--ref`, `--cerberus`, `--ref-token`, `--cerberus-token`, `--start`, `--end`, `--step`, `--tolerance`, `--json`, `--report`, `--out` | live (two backends) |
-| `migrate inventory` | Probe a **live** Prometheus for the cardinality that drives OOM risk    | `--source`, `--top`, `--window`, `--json`, `--out`                                                                                               | live (one backend)  |
-| `migrate gate`      | Fold the artifacts into one cutover go/no-go decision                   | `--verify`, `--classify`, `--rulegraph`, `--inventory`, `--high-card-series`, `--high-card-label-values`, `--json`, `--out`                      | offline             |
+| Command             | What it does                                                                          | Key flags                                                                                                                                        | Network             |
+| ------------------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------- |
+| `migrate --schema`  | Print the `CREATE` statements cerberus expects, from `CERBERUS_*` env                 | *(root flag; reads `CERBERUS_*`)*                                                                                                                | offline             |
+| `migrate --rules`   | Explain the SQL for each PromQL query in rule files (shorthand for `explain --rules`) | `--rules` *(root flag)*                                                                                                                          | offline             |
+| `migrate harvest`   | Build a machine-readable PromQL corpus from your files                                | `--rules`, `--dashboards`, `--out`                                                                                                               | offline             |
+| `migrate explain`   | Dry-run each corpus query through the read pipeline, print the SQL                    | `--corpus` (or `--rules`/`--dashboards`), `--out`                                                                                                | offline             |
+| `migrate classify`  | Bucket each query as supported / unsupported / risky                                  | `--corpus` (or `--rules`/`--dashboards`), `--json`, `--out`                                                                                      | offline             |
+| `migrate rulegraph` | Map recording-rule outputs to the consumers that must stay materialized               | `--rules`, `--corpus`, `--json`, `--out`                                                                                                         | offline             |
+| `migrate verify`    | Replay the corpus against **both** backends and diff (parity gate)                    | `--corpus`, `--ref`, `--cerberus`, `--ref-token`, `--cerberus-token`, `--start`, `--end`, `--step`, `--tolerance`, `--json`, `--report`, `--out` | live (two backends) |
+| `migrate inventory` | Probe a **live** Prometheus for the cardinality that drives OOM risk                  | `--source`, `--top`, `--window`, `--json`, `--out`                                                                                               | live (one backend)  |
+| `migrate gate`      | Fold the artifacts into one cutover go/no-go decision                                 | `--verify`, `--classify`, `--rulegraph`, `--inventory`, `--high-card-series`, `--high-card-label-values`, `--json`, `--out`                      | offline             |
 
 The offline preview commands (`explain`, `classify`) load `config.FromEnv()`
 so the preview runs with the **same per-query sample budget** the production
 server enforces — a query that would trip a runtime guard is not previewed as
 clean. `verify` and `inventory` also read `CERBERUS_VERIFY_*` /
-`CERBERUS_INVENTORY_*` environment fallbacks for their connection, window, and
-credential flags — not the output flags (`--json` / `--out`, and for inventory
-not `--top`) — so the same run can be driven from flags or env.
+`CERBERUS_INVENTORY_*` environment fallbacks for their connection, window,
+credential, and (for `verify`) `--report` flags — `--report` has a
+`CERBERUS_VERIFY_REPORT` fallback too — but not the stdout output flags (`--json`
+/ `--out`, and for inventory not `--top`), so the same run can be driven from
+flags or env.
+
+`explain` previews the SQL for a query as an *instant* evaluation for rules and a
+*range* (`query_range`) evaluation for panels. The instant/rule SQL matches what
+the server runs. The range/panel SQL uses the **fan-out** lowering for the
+range-window operators (`rate` / `changes` / `resets` / `*_over_time`, staleness);
+a live deployment with the experimental native `timeSeries*ToGrid` aggregates
+enabled (auto-selected on CH 25.9+) lowers those differently, so the previewed
+range SQL **may differ** from what such a deployment runs. The tool is offline and
+cannot know the target's ClickHouse version.
 
 ## The migration lifecycle
 

--- a/internal/api/prom/explain.go
+++ b/internal/api/prom/explain.go
@@ -32,9 +32,20 @@ func NewExplainLang(s schema.Metrics, evalTime time.Time) engine.Lang {
 // preview path for dashboard-panel queries, which the server runs as a
 // query_range (a non-zero Step lowers the outer step grid), not as the instant
 // evaluation NewExplainLang models for rules. It reuses the same lang adapter, so
-// Parse and ProjectSamples stay byte-identical to production; only the [start,
-// end, step] window differs. Callers pin a fixed, representative window so the
-// emitted SQL — and any goldens over it — stay deterministic.
+// Parse and ProjectSamples stay identical to production for the shared pipeline
+// stages. Callers pin a fixed, representative window so the emitted SQL — and any
+// goldens over it — stay deterministic.
+//
+// HONESTY — a range preview is NOT guaranteed byte-identical to what a live
+// deployment runs. Lowerers is left at its zero value (the all-fan-out default),
+// but the production query_range path AUTO-ENABLES the native timeSeries*ToGrid
+// lowerers on ClickHouse >= 25.9 (the default "auto" mode). This tool is offline
+// and cannot know the target's CH version, so for the range-window operators
+// (rate / changes / resets / *_over_time and staleness panels) the previewed SQL
+// uses fan-out lowering and MAY DIFFER from a deployment with native
+// timeSeries*ToGrid enabled. Unlike the instant/rule preview — where the handler
+// likewise threads no native lowerers, so NewExplainLang stays faithful — the
+// range preview trades that fidelity for offline determinism.
 func NewExplainLangRange(s schema.Metrics, start, end time.Time, step time.Duration) engine.Lang {
 	return &lang{
 		Parser: promparser.NewParser(promparser.Options{EnableExperimentalFunctions: true}),

--- a/internal/migrate/rulegraph.go
+++ b/internal/migrate/rulegraph.go
@@ -91,8 +91,10 @@ const RuleGraphVersion = 1
 //
 // HONESTY: this is a NAME-LEVEL dependency approximation. A consumer is linked
 // to a recorded series when it references that series' metric NAME (via a vector
-// selector); label matchers, value equality, and rule-to-rule chains are not
-// analysed. A name collision (an unrelated metric that happens to share a
+// selector); label matchers and value equality are not analysed. Rule-to-rule
+// chains ARE analysed: each recording rule's own expr is fed in as a consumer, so
+// a recorded series read by another recording rule is linked, not left orphan. A
+// name collision (an unrelated metric that happens to share a
 // recorded name) would over-link; that is the safe direction (it keeps a series
 // marked "must materialize" rather than dropping one that is needed). A consumer
 // whose matched name set CANNOT be statically reduced — a regex or negated
@@ -319,12 +321,14 @@ func sortedUnique(in []string) []string {
 }
 
 // HarvestRuleFiles reads the recording/alerting rule files matched by rulePaths
-// and splits them into the two things the graph needs: the recording-rule OUTPUT
-// series (RecordedSeries) and the alerting-rule exprs (as consumer queries). Any
-// input it cannot use — a bad glob, an unreadable file, a YAML parse failure, a
-// rule that is neither a record nor an alert — is returned as a counted skip
-// rather than dropped. Recording-rule exprs themselves are NOT returned as
-// consumers: v1 scans corpus queries + alerting exprs, not rule-to-rule chains.
+// and splits them into what the graph needs: the recording-rule OUTPUT series
+// (RecordedSeries), and every rule expr — both alerting exprs AND recording-rule
+// exprs — as consumer queries. Feeding recording-rule exprs as consumers links
+// rule-to-rule chains (a recorded series consumed by another recording rule),
+// keeping the over-link-never-under-link invariant honest. Any input it cannot
+// use — a bad glob, an unreadable file, a YAML parse failure, a rule that is
+// neither a record nor an alert, a rule with an empty expr — is returned as a
+// counted skip rather than dropped.
 func HarvestRuleFiles(rulePaths []string) (recorded []RecordedSeries, consumers []HarvestedQuery, skipped []SkippedEntry) {
 	for _, pattern := range rulePaths {
 		matches, err := filepath.Glob(pattern)
@@ -357,9 +361,16 @@ func HarvestRuleFiles(rulePaths []string) (recorded []RecordedSeries, consumers 
 }
 
 // splitRuleGroups walks one parsed rule file: a rule with a `record:` name is a
-// recorded output series; a rule with an `alert:` name and a non-empty expr is a
-// consumer query; a rule that is neither is a counted skip. An alerting rule with
-// an empty expr is a skip (there is nothing to scan for references).
+// recorded output series AND a consumer (its own expr reads whatever series it
+// aggregates — a rule-to-rule chain); a rule with an `alert:` name and a
+// non-empty expr is a consumer query; a rule that is neither is a counted skip.
+// A rule with an empty expr is a skip (there is nothing to scan for references).
+//
+// Feeding the recording rule's expr into the consumer set is what keeps a
+// rule-to-rule chain honest: for `record: top / expr: sum(inter)`, the recorded
+// series `inter` is referenced by `top`'s expr, so without this it would be
+// misclassified orphan ("safe to drop") while a live chain still depends on it —
+// an UNDER-link that violates the over-link-never-under-link invariant.
 func splitRuleGroups(file string, rg promrules.RuleGroups) (recorded []RecordedSeries, consumers []HarvestedQuery, skipped []SkippedEntry) {
 	for _, g := range rg.Groups {
 		for _, r := range g.Rules {
@@ -367,6 +378,11 @@ func splitRuleGroups(file string, rg promrules.RuleGroups) (recorded []RecordedS
 			case r.Record != "":
 				source := fmt.Sprintf("rule:%s/%s/%s", file, g.Name, r.Record)
 				recorded = append(recorded, RecordedSeries{Name: r.Record, Source: source})
+				if strings.TrimSpace(r.Expr) == "" {
+					skipped = append(skipped, SkippedEntry{Source: source, Reason: "recording rule has empty expr"})
+					continue
+				}
+				consumers = append(consumers, HarvestedQuery{Expr: r.Expr, Source: source, Kind: KindRecord})
 			case r.Alert != "":
 				source := fmt.Sprintf("rule:%s/%s/%s", file, g.Name, r.Alert)
 				if strings.TrimSpace(r.Expr) == "" {
@@ -398,8 +414,9 @@ func (g RuleGraph) Write(w io.Writer) error {
 	bw.printf("# blank. This graph links each recorded series to the queries that consume it.\n")
 	bw.printf("#\n")
 	bw.printf("# HONESTY: this is a NAME-LEVEL dependency approximation — a consumer links to\n")
-	bw.printf("# a recorded series when it references that series' metric NAME. Label matchers,\n")
-	bw.printf("# value equality, and rule-to-rule chains are not analysed. Unparseable consumer\n")
+	bw.printf("# a recorded series when it references that series' metric NAME. Label matchers\n")
+	bw.printf("# and value equality are not analysed; rule-to-rule chains ARE (a recording\n")
+	bw.printf("# rule's own expr is scanned as a consumer). Unparseable consumer\n")
 	bw.printf("# exprs — and consumers whose __name__ set can't be statically reduced (a regex or\n")
 	bw.printf("# negated __name__ matcher, or no name constraint) — are counted as skips below\n")
 	bw.printf("# (never under-linked to nothing), so the over-link direction stays honest.\n")

--- a/internal/migrate/rulegraph_test.go
+++ b/internal/migrate/rulegraph_test.go
@@ -177,8 +177,9 @@ func TestBuildRuleGraphDeterministicJSON(t *testing.T) {
 }
 
 // TestHarvestRuleFilesSplitsRecordAndAlert pins the file harvester: a recording
-// rule becomes a recorded series, an alerting rule becomes a consumer, an empty
-// alert expr is a counted skip, and a no-name rule is a counted skip.
+// rule becomes a recorded series AND a KindRecord consumer (its own expr — so
+// rule-to-rule chains link), an alerting rule becomes a KindAlert consumer, an
+// empty expr is a counted skip, and a no-name rule is a counted skip.
 func TestHarvestRuleFilesSplitsRecordAndAlert(t *testing.T) {
 	dir := t.TempDir()
 	file := filepath.Join(dir, "rules.yml")
@@ -203,12 +204,72 @@ groups:
 	if len(recorded) != 1 || recorded[0].Name != "job:up:rate5m" {
 		t.Fatalf("recorded = %+v, want one job:up:rate5m", recorded)
 	}
-	if len(consumers) != 1 || consumers[0].Kind != KindAlert {
-		t.Fatalf("consumers = %+v, want one alert consumer", consumers)
+	// The recording rule's own expr is now a consumer too (KindRecord), so a
+	// rule-to-rule chain can be detected — two consumers: the record expr and the
+	// alert expr.
+	kinds := map[string]int{}
+	for _, c := range consumers {
+		kinds[c.Kind]++
+	}
+	if len(consumers) != 2 || kinds[KindRecord] != 1 || kinds[KindAlert] != 1 {
+		t.Fatalf("consumers = %+v, want one KindRecord + one KindAlert", consumers)
 	}
 	// One empty-expr alert + one no-name rule = two skips.
 	if len(skipped) != 2 {
 		t.Fatalf("skipped = %+v, want 2 (empty-expr alert + no-name rule)", skipped)
+	}
+}
+
+// TestHarvestRuleFilesRecordToRecordChain pins the honesty fix: when one
+// recording rule's expr reads ANOTHER recording rule's output (a rule-to-rule
+// chain), the intermediate recorded series is linked as CONSUMED — never left
+// wrongly orphan ("safe to drop") while a live chain still depends on it. The
+// empty-expr recording rule is a counted skip, not a silent false orphan.
+func TestHarvestRuleFilesRecordToRecordChain(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "rules.yml")
+	const rules = `
+groups:
+  - name: chain
+    rules:
+      - record: job:top:sum
+        expr: sum(job:inter:rate5m)
+      - record: job:inter:rate5m
+        expr: rate(http_requests_total[5m])
+      - record: job:broken:noexpr
+        expr: ""
+`
+	if err := os.WriteFile(file, []byte(rules), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	recorded, consumers, skipped := HarvestRuleFiles([]string{file})
+	g := BuildRuleGraph(recorded, consumers, PromQLMetricNames, skipped)
+
+	byName := map[string]RecordedNode{}
+	for _, n := range g.Recorded {
+		byName[n.Name] = n
+	}
+
+	inter, ok := byName["job:inter:rate5m"]
+	if !ok {
+		t.Fatalf("job:inter:rate5m missing from recorded set %+v", g.Recorded)
+	}
+	if inter.Status != StatusConsumed {
+		t.Errorf("intermediate recorded series job:inter:rate5m status = %q, want consumed (read by job:top:sum)", inter.Status)
+	}
+
+	top, ok := byName["job:top:sum"]
+	if !ok {
+		t.Fatalf("job:top:sum missing from recorded set %+v", g.Recorded)
+	}
+	if top.Status != StatusOrphan {
+		t.Errorf("top-of-chain job:top:sum status = %q, want orphan (nobody reads it)", top.Status)
+	}
+
+	// The empty-expr recording rule is a counted skip, never a silent false orphan.
+	if g.Counts.Skipped != 1 {
+		t.Errorf("skipped = %d, want 1 (the empty-expr recording rule)", g.Counts.Skipped)
 	}
 }
 

--- a/internal/migrategate/gate.go
+++ b/internal/migrategate/gate.go
@@ -11,8 +11,10 @@
 //
 //   - verify   — BLOCK if any query diverged or errored (the parity gate found
 //     cerberus returning different numbers, or a backend failing), or if the run
-//     verified ZERO queries (an empty harvest proves nothing and must not
-//     green-light a cutover). WARN when the report carries UNCHECKED entries —
+//     COMPARED ZERO queries (Match+Diverge+Error==0): an empty harvest (Total==0)
+//     or an all-unsupported run (Total>0 but nothing returned a comparable matrix
+//     live) proves nothing and must not green-light a cutover. WARN when the run
+//     did compare something but the report also carries UNCHECKED entries —
 //     queries that emitted SQL but returned no comparable matrix live
 //     (Unsupported), harvest-skipped entries, or out-of-scope (non-PromQL)
 //     entries — so a green parity gate never hides an unexamined input.
@@ -210,12 +212,25 @@ func evalVerify(path string) (StageResult, error) {
 	res.Present = true
 	s := rep.Summary
 	caveats := verifyCaveats(s)
-	if s.Total == 0 {
-		// A parity run that replayed zero queries proves nothing — an empty
-		// harvest must never green-light a cutover with nothing verified.
+	// A run proves parity only if at least one query was actually COMPARED against
+	// the reference backend — matched, diverged, or errored. Unsupported replays
+	// (emitted SQL but returned no comparable matrix live) and out-of-scope /
+	// harvest-skipped entries inflate Total without comparing anything, so keying
+	// the "nothing verified" guard on Total alone lets an ALL-UNSUPPORTED run
+	// (Match+Diverge+Error==0, Total>0) fall through to a WARN and a green gate,
+	// proving nothing. Block whenever nothing was compared: the empty corpus
+	// (Total==0) is one subcase; an all-unsupported run (Total>0) is the other.
+	if compared := s.Match + s.Diverge + s.Error; compared == 0 {
 		res.Verdict = VerdictFail
 		res.Blocking = true
-		res.Reasons = append(res.Reasons, "nothing verified: the parity run replayed 0 queries (an empty corpus cannot prove parity)")
+		if s.Total == 0 {
+			res.Reasons = append(res.Reasons, "nothing verified: the parity run replayed 0 queries (an empty corpus cannot prove parity)")
+		} else {
+			res.Reasons = append(res.Reasons, fmt.Sprintf(
+				"nothing actually compared: 0 of %d queries returned a comparable matrix live (all unsupported/unchecked); the parity gate compared nothing",
+				s.Total,
+			))
+		}
 		res.Reasons = append(res.Reasons, caveats...)
 		return res, nil
 	}

--- a/internal/migrategate/gate_test.go
+++ b/internal/migrategate/gate_test.go
@@ -631,6 +631,31 @@ func TestEvaluateBlocksOnZeroQueryVerify(t *testing.T) {
 	}
 }
 
+// TestEvaluateBlocksOnAllUnsupportedVerify pins that a run that replayed queries
+// but COMPARED none — every query unsupported (Match+Diverge+Error==0, Total>0) —
+// blocks. Keying "nothing verified" on Total alone would let an all-unsupported
+// run WARN through to a green gate, proving nothing.
+func TestEvaluateBlocksOnAllUnsupportedVerify(t *testing.T) {
+	rep := migrateverify.Report{Summary: migrateverify.Summary{Total: 4, Unsupported: 4}}
+	in := migrategate.Inputs{
+		Verify:    writeArtifact(t, "verify.json", rep.WriteJSON),
+		Classify:  cleanClassify(t),
+		Inventory: cleanInventory(t),
+		RuleGraph: cleanRuleGraph(t),
+	}
+	dec, err := migrategate.Evaluate(in, migrategate.Options{})
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	v := stageByName(t, dec, migrategate.StageVerify)
+	if dec.Pass || v.Verdict != migrategate.VerdictFail || !v.Blocking {
+		t.Fatalf("all-unsupported verify must FAIL+block, got pass=%v verdict=%q blocking=%v", dec.Pass, v.Verdict, v.Blocking)
+	}
+	if !containsSubstr(v.Reasons, "nothing actually compared") {
+		t.Errorf("verify reasons should say nothing actually compared, got %v", v.Reasons)
+	}
+}
+
 // TestEvaluateBlocksOnZeroQueryClassify pins the same for classify: bucketing
 // zero queries proves no support coverage and must block.
 func TestEvaluateBlocksOnZeroQueryClassify(t *testing.T) {

--- a/internal/migrateinventory/inventory.go
+++ b/internal/migrateinventory/inventory.go
@@ -40,6 +40,12 @@ const DefaultTop = 50
 // stall the whole inventory.
 const defaultHTTPTimeout = 30 * time.Second
 
+// maxResponseBytes caps how much of a probe response body the inventory will
+// buffer. The TSDB-status and enrichment responses are bounded in practice, so a
+// body beyond this cap signals a misbehaving or wrong endpoint, not a valid
+// reply; failing loudly beats letting an unbounded stream OOM the process.
+const maxResponseBytes = 256 << 20 // 256 MiB
+
 // Prometheus HTTP API paths the probe talks to. status/tsdb is the mandatory
 // cardinality source; the label-names and metadata endpoints are optional
 // enrichment.
@@ -288,12 +294,28 @@ func (c *Client) getOK(ctx context.Context, path string) ([]byte, error) {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := readCappedBody(resp.Body, maxResponseBytes)
 	if err != nil {
 		return nil, fmt.Errorf("read %s body: %w", path, err)
 	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("GET %s: HTTP %d", path, resp.StatusCode)
+	}
+	return body, nil
+}
+
+// readCappedBody reads r fully but no further than limit bytes, erroring rather
+// than buffering an unbounded stream (it reads one byte past limit so an
+// over-limit body is detected, never silently truncated into a mis-parse). This
+// bounds the inventory-process memory against a misbehaving or wrong source —
+// the same capped-read discipline the verify client applies to backend bodies.
+func readCappedBody(r io.Reader, limit int64) ([]byte, error) {
+	body, err := io.ReadAll(io.LimitReader(r, limit+1))
+	if err != nil {
+		return nil, fmt.Errorf("read body: %w", err)
+	}
+	if int64(len(body)) > limit {
+		return nil, fmt.Errorf("response body exceeds %d-byte cap", limit)
 	}
 	return body, nil
 }

--- a/internal/migrateinventory/inventory_test.go
+++ b/internal/migrateinventory/inventory_test.go
@@ -3,6 +3,7 @@ package migrateinventory
 import (
 	"context"
 	"encoding/json"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -253,5 +254,54 @@ func TestWriteText(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Errorf("text report missing %q, got:\n%s", want, out)
 		}
+	}
+}
+
+// TestWriteText_EmptyHeadNoGarbageSpan pins the empty-head guard: an empty TSDB
+// head reports sentinel bounds (MinTime = math.MaxInt64, MaxTime = math.MinInt64,
+// so MinTime > MaxTime). The head-span line must be OMITTED rather than printing
+// garbage year-292-billion timestamps. A populated head still prints its span.
+func TestWriteText_EmptyHeadNoGarbageSpan(t *testing.T) {
+	empty := Inventory{
+		Source: "http://src", Top: 5, MetricNameTotal: -1, MetadataMetricTotal: -1,
+		Head: HeadStats{NumSeries: 0, MinTime: math.MaxInt64, MaxTime: math.MinInt64},
+	}
+	var eb strings.Builder
+	if err := empty.WriteText(&eb); err != nil {
+		t.Fatalf("WriteText: %v", err)
+	}
+	if strings.Contains(eb.String(), "head span:") {
+		t.Errorf("empty head must not print a head-span line, got:\n%s", eb.String())
+	}
+
+	populated := Inventory{
+		Source: "http://src", Top: 5, MetricNameTotal: -1, MetadataMetricTotal: -1,
+		Head: HeadStats{NumSeries: 10, MinTime: 1_700_000_000_000, MaxTime: 1_700_003_600_000},
+	}
+	var pb strings.Builder
+	if err := populated.WriteText(&pb); err != nil {
+		t.Fatalf("WriteText: %v", err)
+	}
+	if !strings.Contains(pb.String(), "head span:") {
+		t.Errorf("populated head must print a head-span line, got:\n%s", pb.String())
+	}
+}
+
+// TestReadCappedBody pins the response-body cap: a body within the limit is
+// returned whole, and a body past the limit errors rather than buffering an
+// unbounded stream into memory.
+func TestReadCappedBody(t *testing.T) {
+	const limit = 16
+	got, err := readCappedBody(strings.NewReader("small"), limit)
+	if err != nil {
+		t.Fatalf("under-limit read errored: %v", err)
+	}
+	if string(got) != "small" {
+		t.Errorf("under-limit body = %q, want %q", got, "small")
+	}
+
+	oversize := strings.Repeat("x", limit+1)
+	if _, err := readCappedBody(strings.NewReader(oversize), limit); err == nil {
+		t.Errorf("over-limit read should error, got nil for a %d-byte body (cap %d)", len(oversize), limit)
 	}
 }

--- a/internal/migrateinventory/report.go
+++ b/internal/migrateinventory/report.go
@@ -43,7 +43,7 @@ func (inv Inventory) WriteText(w io.Writer) error {
 	bw.printf("  series:      %d\n", inv.Head.NumSeries)
 	bw.printf("  label pairs: %d\n", inv.Head.NumLabelPairs)
 	bw.printf("  chunks:      %d\n", inv.Head.ChunkCount)
-	if inv.Head.MinTime != 0 || inv.Head.MaxTime != 0 {
+	if hasHeadSpan(inv.Head) {
 		bw.printf("  head span:   %s .. %s\n", formatMillis(inv.Head.MinTime), formatMillis(inv.Head.MaxTime))
 	}
 	if inv.MetricNameTotal >= 0 {
@@ -87,6 +87,15 @@ func writeRanked(bw *errWriter, title string, rows []NameValue, unit string) {
 // rankNameWidth pads the name column so the value column lines up in the ranked
 // tables. It is a cosmetic alignment width, not a data limit.
 const rankNameWidth = 48
+
+// hasHeadSpan reports whether the head block carries a real time span worth
+// printing. An EMPTY head is not all-zero: Prometheus reports it with sentinel
+// bounds (MinTime = math.MaxInt64, MaxTime = math.MinInt64), so MinTime > MaxTime.
+// Printing those verbatim yields garbage year-292-billion timestamps, so a span
+// is shown only when MaxTime >= MinTime and at least one bound is non-zero.
+func hasHeadSpan(h HeadStats) bool {
+	return h.MaxTime >= h.MinTime && (h.MinTime != 0 || h.MaxTime != 0)
+}
 
 // formatMillis renders a Prometheus millisecond epoch as an RFC3339 UTC instant.
 func formatMillis(ms int64) string {

--- a/internal/migrateverify/client.go
+++ b/internal/migrateverify/client.go
@@ -3,6 +3,7 @@ package migrateverify
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -93,6 +94,23 @@ func RedactURL(raw string) string {
 	return u.String()
 }
 
+// redactTransportErr strips any basic-auth userinfo from a backend transport
+// error before it can reach an artifact. Go's http client wraps a request
+// failure in a *url.Error whose URL keeps the USERNAME (only the password is
+// masked by stripPassword), so a token-as-username embedded in --ref / --cerberus
+// would leak in full into the error string — which lands in the gate-consumed
+// verify.json AND the --report file operators attach to bug reports. Rebuilding
+// the *url.Error with a RedactURL'd URL removes it; a non-url.Error carries no
+// URL and is returned unchanged. Redacting here, at the client boundary, means
+// every error string a verdict Detail can quote is already clean.
+func redactTransportErr(err error) error {
+	var uerr *url.Error
+	if errors.As(err, &uerr) {
+		return &url.Error{Op: uerr.Op, URL: RedactURL(uerr.URL), Err: uerr.Err}
+	}
+	return err
+}
+
 // promRangeResponse is the standard Prometheus range-query JSON envelope.
 type promRangeResponse struct {
 	Status string `json:"status"`
@@ -124,14 +142,14 @@ func (b *HTTPBackend) QueryRange(ctx context.Context, expr string, p Params) (Ra
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
 	if err != nil {
-		return RangeResult{}, fmt.Errorf("build request: %w", err)
+		return RangeResult{}, fmt.Errorf("build request: %w", redactTransportErr(err))
 	}
 	if b.bearerToken != "" {
 		req.Header.Set("Authorization", "Bearer "+b.bearerToken)
 	}
 	resp, err := b.HTTP.Do(req)
 	if err != nil {
-		return RangeResult{}, fmt.Errorf("do request: %w", err)
+		return RangeResult{}, fmt.Errorf("do request: %w", redactTransportErr(err))
 	}
 	defer func() { _ = resp.Body.Close() }()
 

--- a/internal/migrateverify/report_test.go
+++ b/internal/migrateverify/report_test.go
@@ -111,6 +111,30 @@ func TestAttribution_CoverageGap(t *testing.T) {
 	}
 }
 
+// TestAttribution_ValueDivergenceDialect is the positive counterpart to the
+// coverage-gap case: a same-series value difference (not a missing series) IS a
+// dialect-semantics candidate — the two engines evaluated the same shape to
+// different numbers. Non-hotspot, so it must NOT also carry the experimental-CH
+// candidate.
+func TestAttribution_ValueDivergenceDialect(t *testing.T) {
+	refBody := map[string]string{"up": matrix(
+		seriesSpec{labels: map[string]string{"job": "a"}, points: []pointSpec{{1_700_000_000, "1"}}},
+	)}
+	cerBody := map[string]string{"up": matrix(
+		seriesSpec{labels: map[string]string{"job": "a"}, points: []pointSpec{{1_700_000_000, "2"}}},
+	)}
+	res := runVerifyOne(t, refBody, cerBody, Query{Expr: "up", Source: "s"})
+	if res.Verdict != VerdictDiverge {
+		t.Fatalf("verdict = %q, want diverge", res.Verdict)
+	}
+	if !hasAttrib(res.Attribution, AttribDialectSemantics) {
+		t.Errorf("a same-series value divergence must carry the dialect-semantics candidate, got %+v", res.Attribution)
+	}
+	if hasAttrib(res.Attribution, AttribDataWindowGap) {
+		t.Errorf("a value divergence (not a coverage gap) should not carry data-window-gap, got %+v", res.Attribution)
+	}
+}
+
 // TestWriteText_VerdictBanner: the text report LEADS with an unmistakable verdict
 // banner — FAILED on a diverging run, PASSED on a clean one.
 func TestWriteText_VerdictBanner(t *testing.T) {

--- a/internal/migrateverify/verify.go
+++ b/internal/migrateverify/verify.go
@@ -482,8 +482,15 @@ type TextGuidance struct {
 	ReproCommand string
 }
 
-// WriteText renders the human report with no CLI-derived bug-report guidance. It
-// is the entrypoint for callers (and tests) that only have the Report in hand.
+// WriteText renders the human report with no CLI-derived bug-report guidance.
+//
+// It is output-identical to WriteTextGuided with an empty TextGuidance, but it is
+// deliberately KEPT (not dead): it is the Report-only entrypoint used by callers
+// and tests that hold a Report without the CLI's repro-command context — the
+// verify unit tests and the guided/unguided writeText parity checks drive it
+// directly. The production CLI always calls WriteTextGuided so a failing run ends
+// with a copy-pasteable reproduction; this variant keeps the guidance-free path
+// exercised so the two never silently diverge.
 func (r Report) WriteText(w io.Writer) error {
 	return r.writeText(w, nil)
 }

--- a/internal/migrateverify/verify_test.go
+++ b/internal/migrateverify/verify_test.go
@@ -318,3 +318,137 @@ func TestVerify_SummaryAndJSON(t *testing.T) {
 		t.Errorf("text report must account for harvest-skipped entries, got:\n%s", text.String())
 	}
 }
+
+// nonMatrixServer answers every /api/v1/query_range with a 200 body whose
+// resultType is NOT "matrix" (a scalar/vector reply cerberus cannot serve as a
+// range). The backend parses it fine but carries the non-matrix resultType
+// through for the caller to classify.
+func nonMatrixServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector"}}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// deadBackendURL returns the URL of an httptest server that has already been
+// closed, so any request against it fails at the transport layer (connection
+// refused) — a deterministic way to exercise the transport-error branches.
+func deadBackendURL(t *testing.T) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	u := srv.URL
+	srv.Close()
+	return u
+}
+
+// TestVerify_Cerberus200NonMatrix: cerberus answers 200 but with a non-matrix
+// resultType — it cannot serve the query as a range. That is a non-blocking
+// coverage gap (unsupported), not a gate failure.
+func TestVerify_Cerberus200NonMatrix(t *testing.T) {
+	refBody := map[string]string{
+		"scalar(up)": matrix(seriesSpec{labels: map[string]string{"job": "a"}, points: []pointSpec{{1_700_000_000, "1"}}}),
+	}
+	ref := NewHTTPBackend(matrixServer(t, refBody).URL)
+	cer := NewHTTPBackend(nonMatrixServer(t).URL)
+	rep := Verify(context.Background(), Corpus{PromQL: []Query{{Expr: "scalar(up)", Source: "panel:s"}}}, ref, cer, testParams())
+	res := rep.Results[0]
+	if res.Verdict != VerdictUnsupported {
+		t.Fatalf("verdict = %q, want unsupported (cerberus 200 non-matrix)", res.Verdict)
+	}
+	if !strings.Contains(res.Detail, `resultType="vector"`) {
+		t.Errorf("unsupported detail should name the non-matrix resultType, got %q", res.Detail)
+	}
+	if (Report{Summary: Summary{Total: 1, Unsupported: 1}}).Failed() {
+		t.Error("a lone unsupported query must not fail the gate")
+	}
+}
+
+// TestVerify_Reference200NonMatrix: the reference answers 200 with a non-matrix
+// resultType, so there is no baseline to compare — an error verdict that DOES
+// fail the gate (never silently passed).
+func TestVerify_Reference200NonMatrix(t *testing.T) {
+	cerBody := map[string]string{
+		"q": matrix(seriesSpec{labels: map[string]string{"job": "a"}, points: []pointSpec{{1_700_000_000, "1"}}}),
+	}
+	ref := NewHTTPBackend(nonMatrixServer(t).URL)
+	cer := NewHTTPBackend(matrixServer(t, cerBody).URL)
+	rep := Verify(context.Background(), Corpus{PromQL: []Query{{Expr: "q", Source: "s"}}}, ref, cer, testParams())
+	res := rep.Results[0]
+	if res.Verdict != VerdictError {
+		t.Fatalf("verdict = %q, want error (reference 200 non-matrix)", res.Verdict)
+	}
+	if !(Report{Summary: Summary{Total: 1, Error: 1}}).Failed() {
+		t.Error("a reference-error verdict must fail the gate")
+	}
+}
+
+// TestVerify_ReferenceTransportError: the reference is unreachable (transport
+// error, refErr branch) → error verdict, gate fails.
+func TestVerify_ReferenceTransportError(t *testing.T) {
+	cerBody := map[string]string{
+		"q": matrix(seriesSpec{labels: map[string]string{"job": "a"}, points: []pointSpec{{1_700_000_000, "1"}}}),
+	}
+	ref := NewHTTPBackend(deadBackendURL(t))
+	cer := NewHTTPBackend(matrixServer(t, cerBody).URL)
+	rep := Verify(context.Background(), Corpus{PromQL: []Query{{Expr: "q", Source: "s"}}}, ref, cer, testParams())
+	res := rep.Results[0]
+	if res.Verdict != VerdictError {
+		t.Fatalf("verdict = %q, want error (reference transport failure)", res.Verdict)
+	}
+	if !strings.Contains(res.Detail, "reference request failed") {
+		t.Errorf("detail should name the reference transport failure, got %q", res.Detail)
+	}
+}
+
+// TestVerify_CerberusTransportError: cerberus is unreachable (transport error,
+// cerErr branch) → error verdict, gate fails. The reference is healthy, proving
+// the cerErr branch is what fires.
+func TestVerify_CerberusTransportError(t *testing.T) {
+	refBody := map[string]string{
+		"q": matrix(seriesSpec{labels: map[string]string{"job": "a"}, points: []pointSpec{{1_700_000_000, "1"}}}),
+	}
+	ref := NewHTTPBackend(matrixServer(t, refBody).URL)
+	cer := NewHTTPBackend(deadBackendURL(t))
+	rep := Verify(context.Background(), Corpus{PromQL: []Query{{Expr: "q", Source: "s"}}}, ref, cer, testParams())
+	res := rep.Results[0]
+	if res.Verdict != VerdictError {
+		t.Fatalf("verdict = %q, want error (cerberus transport failure)", res.Verdict)
+	}
+	if !strings.Contains(res.Detail, "cerberus request failed") {
+		t.Errorf("detail should name the cerberus transport failure, got %q", res.Detail)
+	}
+}
+
+// TestVerify_TransportErrorRedactsCredentials pins the security fix: a transport
+// error against a user:pass@ backend URL must NOT leak the basic-auth userinfo
+// (Go's *url.Error keeps the username, so a token-as-username would leak in full)
+// into the verdict Detail — which lands in gate-consumed verify.json and the
+// --report file operators attach to bug reports.
+func TestVerify_TransportErrorRedactsCredentials(t *testing.T) {
+	const (
+		user = "s3cr3t-token"
+		pass = "hunter2-pw"
+	)
+	addr := strings.TrimPrefix(deadBackendURL(t), "http://")
+	badURL := "http://" + user + ":" + pass + "@" + addr
+
+	cerBody := map[string]string{
+		"up": matrix(seriesSpec{labels: map[string]string{"job": "a"}, points: []pointSpec{{1_700_000_000, "1"}}}),
+	}
+	ref := NewHTTPBackend(badURL)
+	cer := NewHTTPBackend(matrixServer(t, cerBody).URL)
+	rep := Verify(context.Background(), Corpus{PromQL: []Query{{Expr: "up", Source: "s"}}}, ref, cer, testParams())
+	res := rep.Results[0]
+	if res.Verdict != VerdictError {
+		t.Fatalf("verdict = %q, want error", res.Verdict)
+	}
+	if strings.Contains(res.Detail, user) || strings.Contains(res.Detail, pass) {
+		t.Fatalf("verdict Detail leaked credentials: %q", res.Detail)
+	}
+	if !strings.Contains(res.Detail, redactedUserinfo) {
+		t.Errorf("verdict Detail should show the userinfo was redacted (%q), got %q", redactedUserinfo, res.Detail)
+	}
+}


### PR DESCRIPTION
Final batch of CONFIRMED audit findings across the `migrate` CLI. Each finding gets a root fix plus a regression test (the MED tests fail without the fix).

## MED

- **Gate soundness** (`internal/migrategate/gate.go`) — the "nothing verified" guard keyed on `Total`, but `Total` counts `Unsupported` replays. An all-unsupported run (`Match+Diverge+Error==0`, `Total>0`) WARNed → overall PASS, proving nothing. Now blocks whenever `Match+Diverge+Error==0` ("nothing actually compared"); `Total==0` stays the empty-corpus subcase (also blocking).
- **Rulegraph honesty** (`internal/migrate/rulegraph.go`) — recording-rule expr bodies were dropped from consumer analysis, so a rule-to-rule chain (`record: top / expr: sum(inter)`) mislabelled the intermediate recorded series `inter` as orphan ("safe to drop"), violating over-link-never-under-link. Each recording rule's own expr is now fed into the consumer set as `KindRecord`; an empty-expr recording rule becomes a counted skip.
- **Preview fidelity + honesty** (`internal/api/prom/explain.go` + `docs/migration.md`) — the production RANGE path auto-wires native `timeSeries*ToGrid` lowerers (CH >= 25.9, default auto), but `NewExplainLangRange` leaves Lowerers zero (all-fan-out), so range/panel preview SQL can diverge for rate/changes/resets/staleness. The offline tool cannot know the CH version. Corrected the doc-comment and scoped the docs "byte-identical" claim to instant (rule) previews, caveating range (panel) previews.
- **Security — credential leak** (`internal/migrateverify/client.go`) — a transport error embedded the raw `*url.Error` string; Go's `stripPassword` keeps the username, so a token-as-username leaked fully into gate-consumed `verify.json` and the `--report` file. Backend transport errors are now redacted at the client boundary (`RedactURL` on the `*url.Error` URL), so every quoted error string is clean.

## LOW

- Empty-head TSDB span guard (sentinel `MinTime > MaxTime`) no longer prints garbage timestamps (`internal/migrateinventory/report.go`).
- Inventory HTTP probe body is now capped with an `io.LimitReader` (named const), reusing the verify client's capped-read pattern (`internal/migrateinventory/inventory.go`).
- Added the missing verify tests: cerberus 200-non-matrix (unsupported), reference 200-non-matrix (error), and both transport-error branches (`refErr`/`cerErr`).
- Positive dialect-semantics attribution assertion (`report_test.go`).
- `harvest`/`explain`/`classify` now print usage on a missing-required-input error, consistent with `rulegraph`.
- Docs: env-fallback prose now includes `--report` (`CERBERUS_VERIFY_REPORT`); capability count reconciled to nine (seven subcommands + two root flags `--schema`/`--rules`).
- Documented why `Report.WriteText` is kept (Report-only test entrypoint, not dead).

## Tests

Regression tests added for every finding, all deterministic (httptest, fixed timestamps, closed-server transport errors): gate all-unsupported block, rule-to-rule chain linking + empty-expr skip, transport-error credential redaction, 200-non-matrix + transport-error verdict branches, positive dialect-semantics, empty-head span guard, capped-read cap, usage-on-missing-input.

Generated with Claude Code
