### PR TITLE
feat(migrate): harvest all three heads (LogQL + TraceQL) into one corpus

### DIFF
--- a/cmd/cerberus/cmd_migrate.go
+++ b/cmd/cerberus/cmd_migrate.go
@@ -206,34 +206,40 @@ func newMigrateSchemaCmd() *cobra.Command {
 func newMigrateHarvestCmd() *cobra.Command {
 	var (
 		rules      []string
+		lokiRules  []string
 		dashboards string
 		out        string
 	)
 	cmd := &cobra.Command{
 		Use:   "harvest",
-		Short: "Build a machine-readable PromQL query corpus from rule files + dashboards",
-		Long: "Scan Prometheus rule files (--rules) and exported Grafana dashboard JSON\n" +
-			"(--dashboards) and emit a versioned, deterministic corpus.json of the\n" +
-			"operator's real PromQL. Every dropped item (unreadable file, non-Prometheus\n" +
-			"panel, empty expr) is counted, never silently discarded.",
-		Example:       "  cerberus migrate harvest --rules 'rules/*.yml' --dashboards dashboards/ --out corpus.json",
+		Short: "Build a machine-readable three-headed query corpus from rule files + dashboards",
+		Long: "Scan Prometheus rule files (--rules), Loki rule files (--loki-rules), and\n" +
+			"exported Grafana dashboard JSON (--dashboards) and emit a versioned,\n" +
+			"deterministic corpus.json of the operator's real PromQL, LogQL, and TraceQL —\n" +
+			"each query tagged with its language and provenance. Dashboard Prometheus\n" +
+			"panels (PromQL), Loki panels (LogQL), and Tempo panels (TraceQL, read from the\n" +
+			"panel's `query` field) are all harvested. Every dropped item (unreadable file,\n" +
+			"unsupported datasource, empty expr) is counted, never silently discarded.",
+		Example:       "  cerberus migrate harvest --rules 'rules/*.yml' --loki-rules 'loki/*.yml' --dashboards dashboards/ --out corpus.json",
 		Args:          cobra.NoArgs,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runHarvestCommand(cmd, normalizeList(rules), dashboards, out)
+			return runHarvestCommand(cmd, normalizeList(rules), normalizeList(lokiRules), dashboards, out)
 		},
 	}
 	cmd.Flags().StringSliceVar(&rules, "rules", nil,
 		"harvest PromQL from these Prometheus rule files (repeatable or comma-separated paths/globs)")
+	cmd.Flags().StringSliceVar(&lokiRules, "loki-rules", nil,
+		"harvest LogQL from these Loki rule files, which share the Prometheus rule-file YAML shape (repeatable or comma-separated paths/globs)")
 	cmd.Flags().StringVar(&dashboards, "dashboards", "",
-		"harvest PromQL from exported Grafana dashboard JSON under this directory (walked recursively)")
+		"harvest PromQL/LogQL/TraceQL from exported Grafana dashboard JSON under this directory (walked recursively)")
 	cmd.Flags().StringVar(&out, "out", "", "write the corpus JSON here (default: stdout)")
 	return cmd
 }
 
-func runHarvestCommand(cmd *cobra.Command, rules []string, dashboards, out string) error {
-	src, err := harvestSources("", rules, dashboards)
+func runHarvestCommand(cmd *cobra.Command, rules, lokiRules []string, dashboards, out string) error {
+	src, err := harvestSources("", rules, lokiRules, dashboards)
 	if err != nil {
 		if errors.Is(err, errNothingToHarvest) {
 			printUsageToStderr(cmd)
@@ -258,6 +264,7 @@ func runHarvestCommand(cmd *cobra.Command, rules []string, dashboards, out strin
 func newMigrateExplainCmd() *cobra.Command {
 	var (
 		rules      []string
+		lokiRules  []string
 		dashboards string
 		corpus     string
 		out        string
@@ -278,21 +285,23 @@ func newMigrateExplainCmd() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runExplainCommand(cmd, normalizeList(rules), dashboards, corpus, out)
+			return runExplainCommand(cmd, normalizeList(rules), normalizeList(lokiRules), dashboards, corpus, out)
 		},
 	}
 	cmd.Flags().StringSliceVar(&rules, "rules", nil,
 		"explain PromQL from these Prometheus rule files (repeatable or comma-separated paths/globs)")
+	cmd.Flags().StringSliceVar(&lokiRules, "loki-rules", nil,
+		"explain LogQL from these Loki rule files, which share the Prometheus rule-file YAML shape (repeatable or comma-separated paths/globs)")
 	cmd.Flags().StringVar(&dashboards, "dashboards", "",
-		"explain PromQL from exported Grafana dashboard JSON under this directory (walked recursively)")
+		"explain PromQL/LogQL/TraceQL from exported Grafana dashboard JSON under this directory (walked recursively)")
 	cmd.Flags().StringVar(&corpus, "corpus", "",
 		"explain a corpus.json previously written by `cerberus migrate harvest`")
 	cmd.Flags().StringVar(&out, "out", "", "write the explain report here (default: stdout)")
 	return cmd
 }
 
-func runExplainCommand(cmd *cobra.Command, rules []string, dashboards, corpus, out string) error {
-	src, err := harvestSources(corpus, rules, dashboards)
+func runExplainCommand(cmd *cobra.Command, rules, lokiRules []string, dashboards, corpus, out string) error {
+	src, err := harvestSources(corpus, rules, lokiRules, dashboards)
 	if err != nil {
 		if errors.Is(err, errNothingToHarvest) {
 			printUsageToStderr(cmd)
@@ -318,6 +327,7 @@ func runExplainCommand(cmd *cobra.Command, rules []string, dashboards, corpus, o
 func newMigrateClassifyCmd() *cobra.Command {
 	var (
 		rules      []string
+		lokiRules  []string
 		dashboards string
 		corpus     string
 		out        string
@@ -336,13 +346,15 @@ func newMigrateClassifyCmd() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runClassifyCommand(cmd, normalizeList(rules), dashboards, corpus, out, asJSON)
+			return runClassifyCommand(cmd, normalizeList(rules), normalizeList(lokiRules), dashboards, corpus, out, asJSON)
 		},
 	}
 	cmd.Flags().StringSliceVar(&rules, "rules", nil,
 		"classify PromQL in Prometheus rule files (repeatable or comma-separated paths/globs)")
+	cmd.Flags().StringSliceVar(&lokiRules, "loki-rules", nil,
+		"classify LogQL in Loki rule files, which share the Prometheus rule-file YAML shape (repeatable or comma-separated paths/globs)")
 	cmd.Flags().StringVar(&dashboards, "dashboards", "",
-		"classify PromQL in exported Grafana dashboard JSON under a directory (walked recursively)")
+		"classify PromQL/LogQL/TraceQL in exported Grafana dashboard JSON under a directory (walked recursively)")
 	cmd.Flags().StringVar(&corpus, "corpus", "",
 		"classify a corpus.json previously written by `cerberus migrate harvest`")
 	cmd.Flags().StringVar(&out, "out", "", "write the classification here (default: stdout)")
@@ -350,8 +362,8 @@ func newMigrateClassifyCmd() *cobra.Command {
 	return cmd
 }
 
-func runClassifyCommand(cmd *cobra.Command, rules []string, dashboards, corpus, out string, asJSON bool) error {
-	src, err := harvestSources(corpus, rules, dashboards)
+func runClassifyCommand(cmd *cobra.Command, rules, lokiRules []string, dashboards, corpus, out string, asJSON bool) error {
+	src, err := harvestSources(corpus, rules, lokiRules, dashboards)
 	if err != nil {
 		if errors.Is(err, errNothingToHarvest) {
 			printUsageToStderr(cmd)
@@ -671,15 +683,21 @@ func newMigrateGateCmd() *cobra.Command {
 }
 
 // harvestSources assembles the corpus sources from the provided inputs. Order is
-// stable (corpus, then rules, then dashboards) but the corpus itself is sorted
-// deterministically, and the explain report renders in that same stable order.
-func harvestSources(corpus string, rules []string, dashboards string) (migrate.CorpusSource, error) {
+// stable (corpus, then Prometheus rules, then Loki rules, then dashboards) but the
+// corpus itself is sorted deterministically, and the explain report renders in
+// that same stable order. Prometheus rules harvest as PromQL; Loki rules share
+// the identical YAML shape and harvest as LogQL; dashboards harvest all three
+// heads from their panel datasource types.
+func harvestSources(corpus string, rules, lokiRules []string, dashboards string) (migrate.CorpusSource, error) {
 	var src migrate.MultiSource
 	if corpus != "" {
 		src = append(src, migrate.CorpusFileSource{Path: corpus})
 	}
 	if len(rules) > 0 {
-		src = append(src, migrate.FileSource{RulePaths: rules})
+		src = append(src, migrate.FileSource{RulePaths: rules, Lang: migrate.LangPromQL})
+	}
+	if len(lokiRules) > 0 {
+		src = append(src, migrate.FileSource{RulePaths: lokiRules, Lang: migrate.LangLogQL})
 	}
 	if dashboards != "" {
 		src = append(src, migrate.DashboardSource{Dir: dashboards})
@@ -693,7 +711,7 @@ func harvestSources(corpus string, rules []string, dashboards string) (migrate.C
 // errNothingToHarvest is returned by harvestSources when no corpus-input flag was
 // supplied. The corpus subcommands treat it as a usage error — print the flag
 // help before returning — so every corpus command is consistent.
-var errNothingToHarvest = errors.New("nothing to harvest: pass --rules, --dashboards, and/or --corpus")
+var errNothingToHarvest = errors.New("nothing to harvest: pass --rules, --loki-rules, --dashboards, and/or --corpus")
 
 // runExplainReport dry-runs every query from src through the read-side pipeline
 // and writes the explain report to w. It is fully offline: the engine has no
@@ -832,11 +850,20 @@ type dryRunExplainer struct {
 }
 
 func (d dryRunExplainer) Explain(ctx context.Context, q migrate.HarvestedQuery) migrate.Explanation {
-	lang := d.instantLang
-	if q.Kind == migrate.KindPanel {
-		lang = d.rangeLang
+	// The offline SQL preview models the PromQL read pipeline. LogQL and TraceQL
+	// queries are still harvested into the corpus (so the report accounts for
+	// them), but their SQL is not previewed offline in this wave — report that
+	// honestly rather than parsing a LogQL/TraceQL string as PromQL and surfacing a
+	// mislabelled parse error. An empty Lang is treated as PromQL for corpora
+	// written before the corpus went three-headed.
+	if q.Lang != "" && q.Lang != migrate.LangPromQL {
+		return migrate.Explanation{Err: fmt.Errorf("offline SQL preview covers PromQL only; %s query harvested but not previewed here", q.Lang)}
 	}
-	dr, err := d.eng.DryRunSQL(ctx, lang, q.Expr)
+	evalLang := d.instantLang
+	if q.Kind == migrate.KindPanel {
+		evalLang = d.rangeLang
+	}
+	dr, err := d.eng.DryRunSQL(ctx, evalLang, q.Expr)
 	return migrate.Explanation{SQL: dr.SQL, Plan: dr.Plan, Err: err}
 }
 

--- a/cmd/cerberus/cmd_migrate_main_test.go
+++ b/cmd/cerberus/cmd_migrate_main_test.go
@@ -168,8 +168,9 @@ groups:
 
 // TestHarvestThenExplainCorpus drives the composed flow end to end: harvest a
 // corpus from a rules file plus a dashboard (with a Prometheus panel, a nested
-// row, and a Loki panel that is dropped-with-count) to a file, then explain that
-// corpus file. The corpus is deterministic and the explain reads it back.
+// row, and a Loki panel harvested as LogQL) to a file, then explain that corpus
+// file. The corpus is deterministic and the explain reads it back; the LogQL
+// query is carried into the corpus but reported as not-previewed-offline.
 func TestHarvestThenExplainCorpus(t *testing.T) {
 	dir := t.TempDir()
 
@@ -224,18 +225,23 @@ groups:
 	if corpus.Version != migrate.CorpusVersion {
 		t.Errorf("corpus version = %d, want %d", corpus.Version, migrate.CorpusVersion)
 	}
-	// 1 rule + 2 prometheus panel targets (top-level + nested row) = 3 queries.
-	if len(corpus.Queries) != 3 {
-		t.Fatalf("corpus queries = %d, want 3: %+v", len(corpus.Queries), corpus.Queries)
+	// 1 rule + 2 prometheus panel targets (top-level + nested row) + 1 Loki panel
+	// = 4 queries; nothing dropped now that the corpus is three-headed.
+	if len(corpus.Queries) != 4 {
+		t.Fatalf("corpus queries = %d, want 4: %+v", len(corpus.Queries), corpus.Queries)
 	}
-	// The Loki panel target is dropped-with-count.
-	if len(corpus.Skipped) != 1 || !strings.Contains(corpus.Skipped[0].Reason, "loki") {
-		t.Fatalf("expected 1 Loki skip, got %+v", corpus.Skipped)
+	if len(corpus.Skipped) != 0 {
+		t.Fatalf("expected 0 skips (Loki panel harvested as LogQL), got %+v", corpus.Skipped)
 	}
+	langs := map[string]int{}
 	for _, q := range corpus.Queries {
-		if q.Lang != migrate.LangPromQL {
-			t.Errorf("query %q lang = %q, want %q", q.Expr, q.Lang, migrate.LangPromQL)
+		if q.Lang == "" {
+			t.Errorf("query %q carries no lang tag", q.Expr)
 		}
+		langs[q.Lang]++
+	}
+	if langs[migrate.LangPromQL] != 3 || langs[migrate.LangLogQL] != 1 {
+		t.Errorf("unexpected lang distribution: %+v", langs)
 	}
 
 	// Harvest is deterministic: a second harvest to a fresh file is byte-identical.
@@ -264,9 +270,14 @@ groups:
 	if !strings.Contains(report, "node_load1") {
 		t.Errorf("explain report should include the nested-row panel query, got:\n%s", report)
 	}
-	// The harvest-time Loki skip is carried into the explain report's skip count.
-	if !strings.Contains(report, "1 skipped") {
-		t.Errorf("explain report should carry the 1 harvest-time skip, got:\n%s", report)
+	// The LogQL query is carried into the corpus (4 queries, 0 skips) but the
+	// offline SQL preview covers PromQL only, so it is reported UNSUPPORTED with an
+	// honest reason rather than parsed as PromQL.
+	if !strings.Contains(report, "4 queries, 0 skipped") {
+		t.Errorf("explain report should report 4 queries and 0 skips, got:\n%s", report)
+	}
+	if !strings.Contains(report, "offline SQL preview covers PromQL only") {
+		t.Errorf("explain report should flag the LogQL query as not previewed offline, got:\n%s", report)
 	}
 }
 

--- a/cmd/cerberus/cmd_migrate_threehead_test.go
+++ b/cmd/cerberus/cmd_migrate_threehead_test.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/migrate"
+)
+
+// TestHarvestThreeHeadedCorpus pins the three-headed harvest end to end through
+// the real `harvest` flags: a dashboard with one Prometheus panel (PromQL), one
+// Loki panel (LogQL), one Tempo panel (TraceQL, read from the `query` field), and
+// one unknown-datasource panel that is counted as a skip — plus a `--loki-rules`
+// file that harvests as LogQL. The corpus carries all three languages with the
+// right provenance, and the single unusable panel is counted, never dropped.
+func TestHarvestThreeHeadedCorpus(t *testing.T) {
+	dir := t.TempDir()
+
+	lokiRulesFile := filepath.Join(dir, "loki-rules.yml")
+	const lokiRules = `
+groups:
+  - name: logs
+    rules:
+      - record: job:errors:rate5m
+        expr: sum(rate({app="svc"} |= "error" [5m]))
+`
+	if err := os.WriteFile(lokiRulesFile, []byte(lokiRules), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	dashDir := filepath.Join(dir, "dash")
+	if err := os.MkdirAll(dashDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	// One panel per head plus an unknown (Elasticsearch) datasource. The Tempo
+	// panel deliberately carries its TraceQL in `query`, not `expr`.
+	const dashboard = `{
+  "title": "svc",
+  "panels": [
+    {"id": 1, "title": "reqs", "datasource": {"type": "prometheus"},
+     "targets": [{"refId": "A", "expr": "sum(rate(http_requests_total[5m]))"}]},
+    {"id": 2, "title": "logs", "datasource": {"type": "loki"},
+     "targets": [{"refId": "A", "expr": "{app=\"svc\"} |= \"error\""}]},
+    {"id": 3, "title": "traces", "datasource": {"type": "tempo"},
+     "targets": [{"refId": "A", "query": "{ span.http.status_code >= 500 }"}]},
+    {"id": 4, "title": "docs", "datasource": {"type": "elasticsearch"},
+     "targets": [{"refId": "A", "expr": "whatever"}]}
+  ]
+}`
+	if err := os.WriteFile(filepath.Join(dashDir, "board.json"), []byte(dashboard), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	corpusFile := filepath.Join(dir, "corpus.json")
+	var out, errOut bytes.Buffer
+	if err := runMigrate([]string{
+		"harvest",
+		"--loki-rules", lokiRulesFile,
+		"--dashboards", dashDir,
+		"--out", corpusFile,
+	}, &out, &errOut); err != nil {
+		t.Fatalf("harvest: %v (stderr: %s)", err, errOut.String())
+	}
+
+	data, err := os.ReadFile(corpusFile) //nolint:gosec // test-controlled temp path.
+	if err != nil {
+		t.Fatalf("read corpus: %v", err)
+	}
+	var corpus migrate.Corpus
+	if err := json.Unmarshal(data, &corpus); err != nil {
+		t.Fatalf("corpus is not valid JSON: %v\n%s", err, data)
+	}
+
+	// Three heads harvested: one LogQL rule + one PromQL panel + one LogQL panel +
+	// one TraceQL panel = 4 queries.
+	if len(corpus.Queries) != 4 {
+		t.Fatalf("corpus queries = %d, want 4: %+v", len(corpus.Queries), corpus.Queries)
+	}
+
+	// Provenance: each language present with the right expr and kind.
+	byLang := map[string]migrate.CorpusQuery{}
+	for _, q := range corpus.Queries {
+		byLang[q.Lang] = q
+	}
+	if q := byLang[migrate.LangPromQL]; q.Kind != migrate.KindPanel ||
+		!strings.Contains(q.Expr, "http_requests_total") {
+		t.Errorf("PromQL provenance wrong: %+v", q)
+	}
+	if q := byLang[migrate.LangTraceQL]; q.Kind != migrate.KindPanel ||
+		q.Expr != "{ span.http.status_code >= 500 }" {
+		t.Errorf("TraceQL provenance wrong (must read the panel `query` field): %+v", q)
+	}
+	// LogQL appears twice (rule + panel); assert both provenances exist.
+	var sawLogQLRule, sawLogQLPanel bool
+	for _, q := range corpus.Queries {
+		if q.Lang != migrate.LangLogQL {
+			continue
+		}
+		switch q.Kind {
+		case migrate.KindRecord:
+			sawLogQLRule = strings.Contains(q.Source, "job:errors:rate5m")
+		case migrate.KindPanel:
+			sawLogQLPanel = strings.Contains(q.Expr, `|= "error"`)
+		}
+	}
+	if !sawLogQLRule {
+		t.Errorf("expected a LogQL recording rule from --loki-rules, got: %+v", corpus.Queries)
+	}
+	if !sawLogQLPanel {
+		t.Errorf("expected a LogQL dashboard panel, got: %+v", corpus.Queries)
+	}
+
+	// The Elasticsearch panel is the one unusable target: counted, never dropped.
+	if len(corpus.Skipped) != 1 {
+		t.Fatalf("expected exactly 1 skip (the unknown datasource), got %+v", corpus.Skipped)
+	}
+	if !strings.Contains(corpus.Skipped[0].Reason, "elasticsearch") ||
+		!strings.Contains(corpus.Skipped[0].Reason, "unsupported datasource type") {
+		t.Errorf("unknown-datasource skip should name the type honestly, got: %+v", corpus.Skipped[0])
+	}
+
+	// Deterministic: a second harvest to a fresh file is byte-identical.
+	corpusFile2 := filepath.Join(dir, "corpus2.json")
+	var out2, errOut2 bytes.Buffer
+	if err := runMigrate([]string{
+		"harvest",
+		"--loki-rules", lokiRulesFile,
+		"--dashboards", dashDir,
+		"--out", corpusFile2,
+	}, &out2, &errOut2); err != nil {
+		t.Fatalf("harvest (2): %v (stderr: %s)", err, errOut2.String())
+	}
+	data2, err := os.ReadFile(corpusFile2) //nolint:gosec // test-controlled temp path.
+	if err != nil {
+		t.Fatalf("read corpus2: %v", err)
+	}
+	if !bytes.Equal(data, data2) {
+		t.Errorf("three-headed harvest is not deterministic:\n--- run 1 ---\n%s\n--- run 2 ---\n%s", data, data2)
+	}
+}

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -53,16 +53,16 @@ You need three things in place:
 `migrate` is a command group of the single `cerberus` binary, with eight
 subcommands.
 
-| Command                      | What it does                                                            | Key flags                                                                                                                                        | Network             |
-| ---------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------- |
-| `cerberus migrate schema`    | Print the `CREATE` statements cerberus expects, from `CERBERUS_*` env   | *(no flags; reads `CERBERUS_*`)*                                                                                                                 | offline             |
-| `cerberus migrate harvest`   | Build a machine-readable PromQL corpus from your files                  | `--rules`, `--dashboards`, `--out`                                                                                                               | offline             |
-| `cerberus migrate explain`   | Dry-run each corpus query through the read pipeline, print the SQL      | `--corpus` (or `--rules`/`--dashboards`), `--out`                                                                                                | offline             |
-| `cerberus migrate classify`  | Bucket each query as supported / unsupported / risky                    | `--corpus` (or `--rules`/`--dashboards`), `--json`, `--out`                                                                                      | offline             |
-| `cerberus migrate rulegraph` | Map recording-rule outputs to the consumers that must stay materialized | `--rules`, `--corpus`, `--json`, `--out`                                                                                                         | offline             |
-| `cerberus migrate verify`    | Replay the corpus against **both** backends and diff (parity gate)      | `--corpus`, `--ref`, `--cerberus`, `--ref-token`, `--cerberus-token`, `--start`, `--end`, `--step`, `--tolerance`, `--json`, `--report`, `--out` | live (two backends) |
-| `cerberus migrate inventory` | Probe a **live** Prometheus for the cardinality that drives OOM risk    | `--source`, `--top`, `--window`, `--json`, `--out`                                                                                               | live (one backend)  |
-| `cerberus migrate gate`      | Fold the artifacts into one cutover go/no-go decision                   | `--verify`, `--classify`, `--rulegraph`, `--inventory`, `--high-card-series`, `--high-card-label-values`, `--json`, `--out`                      | offline             |
+| Command                      | What it does                                                             | Key flags                                                                                                                                        | Network             |
+| ---------------------------- | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------- |
+| `cerberus migrate schema`    | Print the `CREATE` statements cerberus expects, from `CERBERUS_*` env    | *(no flags; reads `CERBERUS_*`)*                                                                                                                 | offline             |
+| `cerberus migrate harvest`   | Build a machine-readable PromQL + LogQL + TraceQL corpus from your files | `--rules`, `--loki-rules`, `--dashboards`, `--out`                                                                                               | offline             |
+| `cerberus migrate explain`   | Dry-run each corpus query through the read pipeline, print the SQL       | `--corpus` (or `--rules`/`--loki-rules`/`--dashboards`), `--out`                                                                                 | offline             |
+| `cerberus migrate classify`  | Bucket each query as supported / unsupported / risky                     | `--corpus` (or `--rules`/`--loki-rules`/`--dashboards`), `--json`, `--out`                                                                       | offline             |
+| `cerberus migrate rulegraph` | Map recording-rule outputs to the consumers that must stay materialized  | `--rules`, `--corpus`, `--json`, `--out`                                                                                                         | offline             |
+| `cerberus migrate verify`    | Replay the corpus against **both** backends and diff (parity gate)       | `--corpus`, `--ref`, `--cerberus`, `--ref-token`, `--cerberus-token`, `--start`, `--end`, `--step`, `--tolerance`, `--json`, `--report`, `--out` | live (two backends) |
+| `cerberus migrate inventory` | Probe a **live** Prometheus for the cardinality that drives OOM risk     | `--source`, `--top`, `--window`, `--json`, `--out`                                                                                               | live (one backend)  |
+| `cerberus migrate gate`      | Fold the artifacts into one cutover go/no-go decision                    | `--verify`, `--classify`, `--rulegraph`, `--inventory`, `--high-card-series`, `--high-card-label-values`, `--json`, `--out`                      | offline             |
 
 The legacy `migrate --schema` root flag is now the `schema` subcommand, and the
 legacy `migrate --rules` root shorthand folded into `explain --rules`.
@@ -104,8 +104,13 @@ stops at the go/no-go and hands you the flip.
 ### Assess: harvest, inventory, classify, rulegraph
 
 **Harvest** collapses every rule file and exported dashboard into one
-deterministic `corpus.json`. Every dropped item (unreadable file, non-Prometheus
-panel) is counted and reported — nothing is silently discarded.
+deterministic `corpus.json` spanning all three heads: Prometheus rules
+(`--rules`) and Prometheus dashboard panels harvest as PromQL, Loki rules
+(`--loki-rules`, same YAML shape) and Loki panels as LogQL, and Tempo panels
+(TraceQL read from the panel's `query` field) as TraceQL — each query tagged
+with its language and provenance. Every dropped item (unreadable file,
+unsupported datasource, empty expr) is counted and reported — nothing is
+silently discarded.
 
 **Inventory** probes the **live** source Prometheus's
 `/api/v1/status/tsdb` endpoint and ranks the top head-block series and label
@@ -211,9 +216,10 @@ The commands pipe together into one assess → verify → gate flow:
 
 ```bash
 # ── ASSESS ────────────────────────────────────────────────────────────
-# Harvest every real query into one deterministic corpus.
+# Harvest every real query (PromQL + LogQL + TraceQL) into one deterministic corpus.
 cerberus migrate harvest \
   --rules './prometheus/rules/*.yml' \
+  --loki-rules './loki/rules/*.yml' \
   --dashboards ./grafana/dashboards \
   --out corpus.json
 
@@ -278,8 +284,9 @@ pretends to know these:
 - **Experimental ClickHouse paths may deviate.** Verify against the exact
   configuration you will run in production (see the note under *Verify*).
 
-Anything the tool cannot resolve — an unreadable file, a non-Prometheus panel,
-an unparseable expression — is **counted and reported**, never silently skipped.
+Anything the tool cannot resolve — an unreadable file, an unsupported-datasource
+panel, an unparseable expression — is **counted and reported**, never silently
+skipped.
 
 ## Continuous verification
 

--- a/internal/migrate/corpus.go
+++ b/internal/migrate/corpus.go
@@ -45,12 +45,10 @@ type Corpus struct {
 func BuildCorpus(queries []HarvestedQuery, skipped []SkippedEntry) Corpus {
 	cqs := make([]CorpusQuery, 0, len(queries))
 	for _, q := range queries {
-		cqs = append(cqs, CorpusQuery{
-			Expr:   q.Expr,
-			Source: q.Source,
-			Kind:   q.Kind,
-			Lang:   LangPromQL,
-		})
+		// HarvestedQuery and CorpusQuery share the same fields (the latter adds
+		// only json tags), so a struct conversion carries every field — including
+		// Lang — without a field-by-field copy that could silently drop one.
+		cqs = append(cqs, CorpusQuery(q))
 	}
 	sort.SliceStable(cqs, func(i, j int) bool {
 		if cqs[i].Source != cqs[j].Source {
@@ -108,7 +106,8 @@ func (s CorpusFileSource) Harvest(_ context.Context) ([]HarvestedQuery, []Skippe
 	}
 	queries := make([]HarvestedQuery, 0, len(c.Queries))
 	for _, q := range c.Queries {
-		queries = append(queries, HarvestedQuery{Expr: q.Expr, Source: q.Source, Kind: q.Kind})
+		// Struct conversion (identical fields) carries Kind + Lang back out intact.
+		queries = append(queries, HarvestedQuery(q))
 	}
 	return queries, c.Skipped, nil
 }

--- a/internal/migrate/corpus_test.go
+++ b/internal/migrate/corpus_test.go
@@ -11,8 +11,8 @@ import (
 
 // TestHarvestRulesAndDashboardsIntoCorpus drives the full harvest → corpus flow
 // over a temp rules file and a temp Grafana dashboard: a Prometheus panel and a
-// Prometheus target inside a nested collapsed row are kept, a Loki panel is
-// dropped-with-count, and the corpus marshals deterministically.
+// Prometheus target inside a nested collapsed row are harvested as PromQL, a Loki
+// panel is harvested as LogQL, and the corpus marshals deterministically.
 func TestHarvestRulesAndDashboardsIntoCorpus(t *testing.T) {
 	dir := t.TempDir()
 
@@ -87,16 +87,13 @@ groups:
 		t.Fatalf("Harvest: %v", err)
 	}
 
-	// Two rules + two Prometheus panel targets (top-level + nested row).
-	if len(queries) != 4 {
-		t.Fatalf("expected 4 harvested queries, got %d: %+v", len(queries), queries)
+	// Two rules + two Prometheus panel targets + one Loki panel target, all
+	// harvested now that the corpus is three-headed — nothing dropped.
+	if len(queries) != 5 {
+		t.Fatalf("expected 5 harvested queries, got %d: %+v", len(queries), queries)
 	}
-	// Exactly one drop: the Loki panel target.
-	if len(skipped) != 1 {
-		t.Fatalf("expected 1 skip (the Loki panel), got %d: %+v", len(skipped), skipped)
-	}
-	if !strings.Contains(skipped[0].Reason, "non-prometheus datasource: loki") {
-		t.Errorf("Loki panel should be dropped with a datasource reason, got: %+v", skipped[0])
+	if len(skipped) != 0 {
+		t.Fatalf("expected 0 skips (Loki panel is now harvested as LogQL), got %d: %+v", len(skipped), skipped)
 	}
 
 	corpus := BuildCorpus(queries, skipped)
@@ -104,16 +101,28 @@ groups:
 		t.Errorf("corpus version = %d, want %d", corpus.Version, CorpusVersion)
 	}
 
-	// Every query is PromQL-tagged; kinds cover record, alert, and panel.
+	// Kinds cover record, alert, and panel; langs cover PromQL (rules + prom
+	// panels) and LogQL (the Loki panel).
 	kinds := map[string]int{}
+	langs := map[string]int{}
 	for _, q := range corpus.Queries {
-		if q.Lang != LangPromQL {
-			t.Errorf("query %q lang = %q, want %q", q.Expr, q.Lang, LangPromQL)
+		if q.Lang == "" {
+			t.Errorf("query %q carries no lang tag", q.Expr)
 		}
 		kinds[q.Kind]++
+		langs[q.Lang]++
 	}
-	if kinds[KindRecord] != 1 || kinds[KindAlert] != 1 || kinds[KindPanel] != 2 {
+	if kinds[KindRecord] != 1 || kinds[KindAlert] != 1 || kinds[KindPanel] != 3 {
 		t.Errorf("unexpected kind distribution: %+v", kinds)
+	}
+	if langs[LangPromQL] != 4 || langs[LangLogQL] != 1 {
+		t.Errorf("unexpected lang distribution: %+v", langs)
+	}
+	// The Loki panel query is LogQL-tagged with panel provenance.
+	for _, q := range corpus.Queries {
+		if strings.Contains(q.Expr, `|= "error"`) && q.Lang != LangLogQL {
+			t.Errorf("Loki panel query should be LogQL-tagged, got: %+v", q)
+		}
 	}
 
 	// The nested-row Prometheus target must be present with panel provenance.
@@ -162,11 +171,12 @@ groups:
 // `harvest --out` composes with `explain --corpus`.
 func TestCorpusRoundTripThroughFileSource(t *testing.T) {
 	queries := []HarvestedQuery{
-		{Expr: "up", Source: "rule:f/g/up_rec", Kind: KindRecord},
-		{Expr: "rate(x[5m])", Source: "dashboard:d/p/A", Kind: KindPanel},
+		{Expr: "up", Source: "rule:f/g/up_rec", Kind: KindRecord, Lang: LangPromQL},
+		{Expr: `{app="x"}`, Source: "dashboard:d/logs/A", Kind: KindPanel, Lang: LangLogQL},
+		{Expr: "rate(x[5m])", Source: "dashboard:d/p/A", Kind: KindPanel, Lang: LangPromQL},
 	}
 	skipped := []SkippedEntry{
-		{Source: "dashboard:d/logs/A", Reason: "non-prometheus datasource: loki"},
+		{Source: "dashboard:d/traces/A", Reason: `unsupported datasource type "elasticsearch" (not prometheus/loki/tempo)`},
 	}
 
 	data, err := BuildCorpus(queries, skipped).Marshal()
@@ -183,19 +193,22 @@ func TestCorpusRoundTripThroughFileSource(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CorpusFileSource.Harvest: %v", err)
 	}
-	if len(gotQueries) != 2 {
-		t.Fatalf("round-trip queries = %d, want 2: %+v", len(gotQueries), gotQueries)
+	if len(gotQueries) != 3 {
+		t.Fatalf("round-trip queries = %d, want 3: %+v", len(gotQueries), gotQueries)
 	}
 	if len(gotSkipped) != 1 {
 		t.Fatalf("round-trip skips = %d, want 1: %+v", len(gotSkipped), gotSkipped)
 	}
-	// Kinds are preserved; sort order is by source, so up_rec comes before the
-	// dashboard entry.
-	if gotQueries[0].Kind != KindPanel {
-		// dashboard:d/p/A sorts before rule:f/g/up_rec ("d" < "r").
-		t.Errorf("first round-tripped query kind = %q, want %q", gotQueries[0].Kind, KindPanel)
+	// Sort order is by source: dashboard:d/logs/A ("logs") < dashboard:d/p/A
+	// ("p") < rule:f/g/up_rec ("r"). Kind AND lang round-trip intact — the LogQL
+	// panel keeps its language.
+	if gotQueries[0].Kind != KindPanel || gotQueries[0].Lang != LangLogQL {
+		t.Errorf("first round-tripped query = %+v, want a LogQL panel", gotQueries[0])
 	}
-	if gotSkipped[0].Reason != "non-prometheus datasource: loki" {
+	if gotQueries[1].Lang != LangPromQL || gotQueries[2].Lang != LangPromQL {
+		t.Errorf("PromQL queries lost their lang tag on round-trip: %+v", gotQueries)
+	}
+	if !strings.Contains(gotSkipped[0].Reason, "unsupported datasource type") {
 		t.Errorf("round-tripped skip reason = %q", gotSkipped[0].Reason)
 	}
 }

--- a/internal/migrate/dashboards.go
+++ b/internal/migrate/dashboards.go
@@ -10,24 +10,47 @@ import (
 	"strings"
 )
 
-// datasourceTypePrometheus is the Grafana datasource `type` that marks a panel
-// target as PromQL. Only targets resolving to this type are harvested; targets
-// on any other datasource (Loki, Tempo, mixed, …) are dropped with a count.
-const datasourceTypePrometheus = "prometheus"
+// The Grafana datasource `type` strings for the three gateway heads. Each maps
+// to the query language its panel targets are written in — Prometheus→PromQL,
+// Loki→LogQL, Tempo→TraceQL. A target on any other datasource type (a table/logs
+// plugin, an unknown backend, a mixed source) is dropped-with-count.
+const (
+	datasourceTypePrometheus = "prometheus"
+	datasourceTypeLoki       = "loki"
+	datasourceTypeTempo      = "tempo"
+)
 
 // dashboardFileExt is the extension of an exported Grafana dashboard file. The
 // dashboard source walks a directory tree and considers only these files.
 const dashboardFileExt = ".json"
 
-// DashboardSource harvests PromQL from a directory tree of exported Grafana
-// dashboard JSON files. It walks every panel's targets — targets on top-level
-// panels[], targets on panels nested inside collapsed rows (panels[].panels[]),
-// and targets on panels under the legacy pre-v16 rows[].panels[] schema — and
-// keeps only the targets whose datasource resolves to the Prometheus type.
-// Everything else — an unreadable or unparseable file, a target with an empty
-// expression, a target on a non-Prometheus datasource, or a legacy name-form
-// datasource that cannot be type-resolved offline — is recorded as a counted
-// SkippedEntry, never silently dropped.
+// langForDatasourceType maps a resolved Grafana datasource `type` to the query
+// language its panel targets carry. The three heads — Prometheus (PromQL), Loki
+// (LogQL), Tempo (TraceQL) — are the only types the harvest keeps; any other type
+// yields ok=false and the target is dropped-with-count.
+func langForDatasourceType(typ string) (lang string, ok bool) {
+	switch typ {
+	case datasourceTypePrometheus:
+		return LangPromQL, true
+	case datasourceTypeLoki:
+		return LangLogQL, true
+	case datasourceTypeTempo:
+		return LangTraceQL, true
+	default:
+		return "", false
+	}
+}
+
+// DashboardSource harvests queries from a directory tree of exported Grafana
+// dashboard JSON files across all three heads. It walks every panel's targets —
+// targets on top-level panels[], targets on panels nested inside collapsed rows
+// (panels[].panels[]), and targets on panels under the legacy pre-v16
+// rows[].panels[] schema — and keeps every target whose datasource resolves to a
+// Prometheus (PromQL), Loki (LogQL), or Tempo (TraceQL) type, tagged with its
+// language. Everything else — an unreadable or unparseable file, a target with an
+// empty expression, a target on an unsupported datasource type, or a legacy
+// name-form datasource that cannot be type-resolved offline — is recorded as a
+// counted SkippedEntry, never silently dropped.
 type DashboardSource struct {
 	Dir string
 }
@@ -61,17 +84,21 @@ type dashboardPanel struct {
 }
 
 // dashboardTarget is one query target on a panel. `datasource` overrides the
-// panel default when present.
+// panel default when present. Prometheus and Loki targets carry their query in
+// `expr`; Tempo targets carry TraceQL in `query` instead — both are decoded and
+// the right one is read per the resolved datasource language.
 type dashboardTarget struct {
 	RefID      string          `json:"refId"`
 	Expr       string          `json:"expr"`
+	Query      string          `json:"query"`
 	Datasource json.RawMessage `json:"datasource"`
 }
 
 // Harvest walks the dashboard directory, decoding each JSON file and flattening
-// its Prometheus panel targets into HarvestedQuery entries. It never returns a
-// per-item hard error: a missing directory, an unreadable file, a parse
-// failure, an empty expr, or a non-Prometheus target all become counted skips.
+// its Prometheus / Loki / Tempo panel targets into lang-tagged HarvestedQuery
+// entries. It never returns a per-item hard error: a missing directory, an
+// unreadable file, a parse failure, an empty expr/query, or an
+// unsupported-datasource target all become counted skips.
 func (s DashboardSource) Harvest(_ context.Context) ([]HarvestedQuery, []SkippedEntry, error) {
 	var (
 		queries []HarvestedQuery
@@ -137,15 +164,22 @@ func walkPanels(file string, panels []dashboardPanel, inherited datasourceRef, q
 			if !ds.set() {
 				ds = panelDS
 			}
-			if ds.typ != datasourceTypePrometheus {
+			lang, ok := langForDatasourceType(ds.typ)
+			if !ok {
 				*skipped = append(*skipped, SkippedEntry{Source: source, Reason: ds.dropReason()})
 				continue
 			}
-			if strings.TrimSpace(t.Expr) == "" {
-				*skipped = append(*skipped, SkippedEntry{Source: source, Reason: "target has an empty expr"})
+			// Tempo panels carry TraceQL in `query`; Prometheus/Loki panels carry
+			// their query in `expr`. Read the field that matches the resolved head.
+			expr, field := t.Expr, "expr"
+			if lang == LangTraceQL {
+				expr, field = t.Query, "query"
+			}
+			if strings.TrimSpace(expr) == "" {
+				*skipped = append(*skipped, SkippedEntry{Source: source, Reason: "target has an empty " + field})
 				continue
 			}
-			*queries = append(*queries, HarvestedQuery{Expr: t.Expr, Source: source, Kind: KindPanel})
+			*queries = append(*queries, HarvestedQuery{Expr: expr, Source: source, Kind: KindPanel, Lang: lang})
 		}
 		// Recurse into collapsed-row child panels, inheriting this panel's ds.
 		walkPanels(file, p.Panels, panelDS, queries, skipped)
@@ -156,11 +190,11 @@ func walkPanels(file string, panels []dashboardPanel, inherited datasourceRef, q
 // / name is populated; both empty means the field was absent and the datasource
 // is inherited from the enclosing panel/row. The object form
 // ({"type":"prometheus","uid":...}) yields a concrete typ. The legacy bare
-// string form is a datasource NAME, not a type — a name that case-folds to
-// "prometheus" is the one name safely resolvable to the prometheus type offline;
-// any other name (Loki, Mimir, Cortex, a custom name, a "${var}" template)
-// cannot be mapped to a type without querying Grafana, so it is carried as name
-// and dropped-with-count rather than silently miscategorised as a type.
+// string form is a datasource NAME, not a type — a name that case-folds to one of
+// the head type names ("prometheus" / "loki" / "tempo") is safely resolvable to
+// that type offline; any other name (Mimir, Cortex, a custom name, a "${var}"
+// template) cannot be mapped to a type without querying Grafana, so it is carried
+// as name and dropped-with-count rather than silently miscategorised as a type.
 type datasourceRef struct {
 	typ  string
 	name string
@@ -170,17 +204,17 @@ type datasourceRef struct {
 // the enclosing panel/row default.
 func (r datasourceRef) set() bool { return r.typ != "" || r.name != "" }
 
-// dropReason explains why a non-Prometheus target was dropped: a concrete
-// non-Prometheus type, a name-form datasource that cannot be type-resolved
-// offline, or a datasource that resolved to no type at all.
+// dropReason explains why a target was dropped: a name-form datasource that
+// cannot be type-resolved offline, a datasource that resolved to no type at all,
+// or a concrete type that is none of the three supported heads.
 func (r datasourceRef) dropReason() string {
 	switch {
 	case r.name != "":
 		return fmt.Sprintf("legacy name-form datasource %q cannot be type-resolved offline", r.name)
 	case r.typ == "":
-		return "target datasource is unresolved (not Prometheus-typed)"
+		return "target datasource is unresolved (no prometheus/loki/tempo type)"
 	default:
-		return fmt.Sprintf("non-prometheus datasource: %s", r.typ)
+		return fmt.Sprintf("unsupported datasource type %q (not prometheus/loki/tempo)", r.typ)
 	}
 }
 
@@ -199,18 +233,34 @@ func resolveDatasource(raw json.RawMessage) datasourceRef {
 	}
 	var str string
 	if err := json.Unmarshal(raw, &str); err == nil {
-		switch s := strings.TrimSpace(str); {
-		case s == "":
+		s := strings.TrimSpace(str)
+		if s == "" {
 			return datasourceRef{}
-		case strings.EqualFold(s, datasourceTypePrometheus):
-			// The only datasource NAME safely resolvable to a type offline: the
-			// conventional default Prometheus datasource name ("Prometheus").
-			return datasourceRef{typ: datasourceTypePrometheus}
-		default:
-			return datasourceRef{name: s}
 		}
+		if typ, ok := resolveDatasourceName(s); ok {
+			return datasourceRef{typ: typ}
+		}
+		return datasourceRef{name: s}
 	}
 	return datasourceRef{}
+}
+
+// resolveDatasourceName resolves a legacy bare-string datasource NAME to a head
+// type when the name is one of the conventional default datasource names
+// ("Prometheus" / "Loki" / "Tempo", any case) — the only names safely mapped to a
+// type offline. Any other name needs a live Grafana lookup, so it is left
+// unresolved and dropped-with-count.
+func resolveDatasourceName(name string) (typ string, ok bool) {
+	switch strings.ToLower(name) {
+	case datasourceTypePrometheus:
+		return datasourceTypePrometheus, true
+	case datasourceTypeLoki:
+		return datasourceTypeLoki, true
+	case datasourceTypeTempo:
+		return datasourceTypeTempo, true
+	default:
+		return "", false
+	}
 }
 
 // panelIdent names a panel for provenance: its title when set, else panel-<id>.

--- a/internal/migrate/dashboards_test.go
+++ b/internal/migrate/dashboards_test.go
@@ -10,10 +10,10 @@ import (
 
 // TestDashboardLegacyNameFormDatasource pins the legacy bare-string datasource
 // form, where the string is a datasource NAME (not a type). The conventional
-// default "Prometheus" name (any case) is resolved to the prometheus type and
-// harvested; any other name (Loki, Mimir, …) cannot be mapped to a type offline
-// and is dropped-with-count with a distinct, honest reason — never silently
-// discarded and never miscategorised as a type.
+// default head names — "Prometheus" / "Loki" / "Tempo", any case — resolve to
+// their type and harvest with the right language; any other name (Mimir, …)
+// cannot be mapped to a type offline and is dropped-with-count with a distinct,
+// honest reason — never silently discarded and never miscategorised as a type.
 func TestDashboardLegacyNameFormDatasource(t *testing.T) {
 	dir := t.TempDir()
 	const dashboard = `{
@@ -23,7 +23,9 @@ func TestDashboardLegacyNameFormDatasource(t *testing.T) {
      "targets": [{"refId": "A", "expr": "up"}]},
     {"id": 2, "title": "logs", "datasource": "Loki",
      "targets": [{"refId": "A", "expr": "{app=\"x\"}"}]},
-    {"id": 3, "title": "via mimir", "datasource": "Mimir",
+    {"id": 3, "title": "traces", "datasource": "Tempo",
+     "targets": [{"refId": "A", "query": "{ duration > 1s }"}]},
+    {"id": 4, "title": "via mimir", "datasource": "Mimir",
      "targets": [{"refId": "A", "expr": "rate(x[5m])"}]}
   ]
 }`
@@ -36,35 +38,39 @@ func TestDashboardLegacyNameFormDatasource(t *testing.T) {
 		t.Fatalf("Harvest: %v", err)
 	}
 
-	// The "Prometheus"-named panel resolves to the prometheus type and is kept.
-	if len(queries) != 1 || queries[0].Expr != "up" {
-		t.Fatalf("name-form \"Prometheus\" should resolve and harvest `up`, got %+v", queries)
+	// The Prometheus / Loki / Tempo name-form panels each resolve and harvest with
+	// the right language.
+	byLang := map[string]HarvestedQuery{}
+	for _, q := range queries {
+		byLang[q.Lang] = q
+	}
+	if len(queries) != 3 {
+		t.Fatalf("expected 3 name-form harvests (Prometheus, Loki, Tempo), got %d: %+v", len(queries), queries)
+	}
+	if byLang[LangPromQL].Expr != "up" {
+		t.Errorf("name-form \"Prometheus\" should harvest `up` as PromQL, got %+v", byLang[LangPromQL])
+	}
+	if byLang[LangLogQL].Expr != `{app="x"}` {
+		t.Errorf("name-form \"Loki\" should harvest the LogQL selector, got %+v", byLang[LangLogQL])
+	}
+	if byLang[LangTraceQL].Expr != "{ duration > 1s }" {
+		t.Errorf("name-form \"Tempo\" should harvest the TraceQL `query` field, got %+v", byLang[LangTraceQL])
 	}
 
-	// Loki + Mimir name-form panels are each dropped with a name-form reason.
-	if len(skipped) != 2 {
-		t.Fatalf("expected 2 name-form drops (Loki, Mimir), got %d: %+v", len(skipped), skipped)
+	// The Mimir name-form panel is dropped-with-count: no offline type mapping.
+	if len(skipped) != 1 {
+		t.Fatalf("expected 1 name-form drop (Mimir), got %d: %+v", len(skipped), skipped)
 	}
-	var sawLoki, sawMimir bool
-	for _, s := range skipped {
-		if !strings.Contains(s.Reason, "cannot be type-resolved offline") {
-			t.Errorf("name-form drop should carry the offline-unresolvable reason, got: %+v", s)
-		}
-		if strings.Contains(s.Reason, `"Loki"`) {
-			sawLoki = true
-		}
-		if strings.Contains(s.Reason, `"Mimir"`) {
-			sawMimir = true
-		}
-	}
-	if !sawLoki || !sawMimir {
-		t.Errorf("both name-form datasources should be named in the drop reasons: %+v", skipped)
+	if !strings.Contains(skipped[0].Reason, "cannot be type-resolved offline") ||
+		!strings.Contains(skipped[0].Reason, `"Mimir"`) {
+		t.Errorf("Mimir should be dropped with the offline-unresolvable name-form reason, got: %+v", skipped[0])
 	}
 }
 
 // TestDashboardLegacyRowsSchema pins that the pre-v16 (Grafana v4) rows[].panels[]
-// schema is walked, not silently dropped: a Prometheus panel nested under rows[]
-// is harvested with panel provenance.
+// schema is walked, not silently dropped: a Prometheus panel (PromQL) and a Loki
+// panel (LogQL) nested under rows[] are both harvested with panel provenance and
+// the right language.
 func TestDashboardLegacyRowsSchema(t *testing.T) {
 	dir := t.TempDir()
 	const dashboard = `{
@@ -86,15 +92,21 @@ func TestDashboardLegacyRowsSchema(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Harvest: %v", err)
 	}
-	if len(queries) != 1 || queries[0].Expr != "node_load1" {
-		t.Fatalf("rows[] Prometheus panel should be harvested, got %+v", queries)
+	if len(skipped) != 0 {
+		t.Fatalf("rows[] Prometheus + Loki panels should both harvest, got skips: %+v", skipped)
 	}
-	if queries[0].Kind != KindPanel {
-		t.Errorf("rows[] harvest should be a panel kind, got %q", queries[0].Kind)
+	byLang := map[string]HarvestedQuery{}
+	for _, q := range queries {
+		if q.Kind != KindPanel {
+			t.Errorf("rows[] harvest should be a panel kind, got %q for %q", q.Kind, q.Expr)
+		}
+		byLang[q.Lang] = q
 	}
-	// The Loki panel under the same row is dropped-with-count.
-	if len(skipped) != 1 || !strings.Contains(skipped[0].Reason, "non-prometheus datasource: loki") {
-		t.Fatalf("rows[] Loki panel should be dropped-with-count, got %+v", skipped)
+	if byLang[LangPromQL].Expr != "node_load1" {
+		t.Errorf("rows[] Prometheus panel should harvest node_load1 as PromQL, got %+v", byLang[LangPromQL])
+	}
+	if byLang[LangLogQL].Expr != `{app="x"}` {
+		t.Errorf("rows[] Loki panel should harvest the LogQL selector, got %+v", byLang[LangLogQL])
 	}
 }
 

--- a/internal/migrate/migrate.go
+++ b/internal/migrate/migrate.go
@@ -32,17 +32,24 @@ const (
 	KindPanel  = "panel"
 )
 
-// LangPromQL tags every harvested query's source language. The corpus is
-// PromQL-only today; the field is carried explicitly so a future LogQL/TraceQL
-// corpus can share the same schema without a version bump breaking readers.
-const LangPromQL = "promql"
+// Lang tags every harvested query's source query language. The corpus is
+// three-headed: a query resolves to PromQL, LogQL, or TraceQL from the
+// datasource / rule-file it was harvested from, and the tag rides through the
+// corpus so downstream readers route each query to the right engine.
+const (
+	LangPromQL  = "promql"
+	LangLogQL   = "logql"
+	LangTraceQL = "traceql"
+)
 
-// HarvestedQuery is one PromQL expression pulled from a corpus source, tagged
-// with where it came from and whether it backs a recording or alerting rule.
+// HarvestedQuery is one query expression pulled from a corpus source, tagged
+// with where it came from, whether it backs a recording/alerting rule or a
+// dashboard panel, and its source query language.
 type HarvestedQuery struct {
 	Expr   string
 	Source string // e.g. "rule:<file>/<group>/<name>"
-	Kind   string // KindRecord | KindAlert
+	Kind   string // KindRecord | KindAlert | KindPanel
+	Lang   string // LangPromQL | LangLogQL | LangTraceQL
 }
 
 // SkippedEntry records a corpus entry the harvester could not turn into a query —
@@ -59,11 +66,24 @@ type CorpusSource interface {
 	Harvest(ctx context.Context) ([]HarvestedQuery, []SkippedEntry, error)
 }
 
-// FileSource harvests queries from Prometheus rule files. RulePaths holds file
-// paths or globs; each match is read and parsed as a rule file, and one
-// HarvestedQuery is emitted per recording/alerting rule.
+// FileSource harvests queries from Prometheus-shaped rule files. RulePaths holds
+// file paths or globs; each match is read and parsed as a rule file, and one
+// HarvestedQuery is emitted per recording/alerting rule. Loki recording/alerting
+// rule files use the identical YAML shape, so the same parser harvests them —
+// Lang selects the tag every emitted query carries (PromQL for Prometheus rules,
+// LogQL for Loki rules). An empty Lang defaults to PromQL.
 type FileSource struct {
 	RulePaths []string
+	Lang      string
+}
+
+// lang returns the source's query-language tag, defaulting an unset Lang to
+// PromQL so the zero-value FileSource keeps harvesting Prometheus rules.
+func (s FileSource) lang() string {
+	if s.Lang == "" {
+		return LangPromQL
+	}
+	return s.Lang
 }
 
 // Harvest expands every RulePaths entry, reads and parses each matched rule
@@ -96,7 +116,7 @@ func (s FileSource) Harvest(_ context.Context) ([]HarvestedQuery, []SkippedEntry
 				skipped = append(skipped, SkippedEntry{Source: file, Reason: err.Error()})
 				continue
 			}
-			q, sk := harvestFile(file, rg)
+			q, sk := harvestFile(file, rg, s.lang())
 			queries = append(queries, q...)
 			skipped = append(skipped, sk...)
 		}
@@ -105,9 +125,9 @@ func (s FileSource) Harvest(_ context.Context) ([]HarvestedQuery, []SkippedEntry
 }
 
 // harvestFile flattens one parsed rule file's groups into HarvestedQuery /
-// SkippedEntry entries. A rule with no name or no expression is skipped (counted),
-// never emitted as an empty query.
-func harvestFile(file string, rg promrules.RuleGroups) ([]HarvestedQuery, []SkippedEntry) {
+// SkippedEntry entries, tagging each emitted query with lang. A rule with no name
+// or no expression is skipped (counted), never emitted as an empty query.
+func harvestFile(file string, rg promrules.RuleGroups, lang string) ([]HarvestedQuery, []SkippedEntry) {
 	var (
 		queries []HarvestedQuery
 		skipped []SkippedEntry
@@ -127,7 +147,7 @@ func harvestFile(file string, rg promrules.RuleGroups) ([]HarvestedQuery, []Skip
 				skipped = append(skipped, SkippedEntry{Source: source, Reason: "rule has an empty expr"})
 				continue
 			}
-			queries = append(queries, HarvestedQuery{Expr: r.Expr, Source: source, Kind: kind})
+			queries = append(queries, HarvestedQuery{Expr: r.Expr, Source: source, Kind: kind, Lang: lang})
 		}
 	}
 	return queries, skipped

--- a/internal/migrate/rulegraph.go
+++ b/internal/migrate/rulegraph.go
@@ -382,14 +382,14 @@ func splitRuleGroups(file string, rg promrules.RuleGroups) (recorded []RecordedS
 					skipped = append(skipped, SkippedEntry{Source: source, Reason: "recording rule has empty expr"})
 					continue
 				}
-				consumers = append(consumers, HarvestedQuery{Expr: r.Expr, Source: source, Kind: KindRecord})
+				consumers = append(consumers, HarvestedQuery{Expr: r.Expr, Source: source, Kind: KindRecord, Lang: LangPromQL})
 			case r.Alert != "":
 				source := fmt.Sprintf("rule:%s/%s/%s", file, g.Name, r.Alert)
 				if strings.TrimSpace(r.Expr) == "" {
 					skipped = append(skipped, SkippedEntry{Source: source, Reason: "alerting rule has empty expr"})
 					continue
 				}
-				consumers = append(consumers, HarvestedQuery{Expr: r.Expr, Source: source, Kind: KindAlert})
+				consumers = append(consumers, HarvestedQuery{Expr: r.Expr, Source: source, Kind: KindAlert, Lang: LangPromQL})
 			default:
 				source := fmt.Sprintf("rule:%s/%s/?", file, g.Name)
 				skipped = append(skipped, SkippedEntry{Source: source, Reason: "rule is neither a record nor an alert"})


### PR DESCRIPTION
## What

`cerberus migrate harvest` was PromQL-only: it decoded only Prometheus rule
files and Prometheus dashboard panels, dropping every Loki and Tempo panel with
a count. This opens the harvest to **all three gateway heads** so the corpus
carries **PromQL, LogQL, and TraceQL**, each query tagged with its language and
provenance.

## Changes

- **`internal/migrate`** — add `LangLogQL` / `LangTraceQL` consts. `HarvestedQuery`
  now carries a `Lang`, threaded into `CorpusQuery.Lang` (and back out through
  `CorpusFileSource` on round-trip). `FileSource` gains a `Lang` (defaulting to
  PromQL) so Loki rule files — identical YAML shape, parsed unchanged by
  `promrules.Parse` — harvest as LogQL.
- **`dashboards.go`** — open the datasource type-gate to `loki` (→ LogQL) and
  `tempo` (→ TraceQL) alongside `prometheus` (→ PromQL). Tempo panels carry their
  TraceQL in the `query` field, not `expr` — both are decoded and the field
  matching the resolved head is read. Legacy bare-string datasource **names**
  resolve offline only for the literal `prometheus`/`loki`/`tempo` names; any
  other name (Mimir, Cortex, …) is still dropped-with-count.
- **`cmd/cerberus`** — add a `--loki-rules <glob>` flag (on `harvest`, `explain`,
  `classify`) that harvests rule exprs tagged LogQL; `--rules` stays PromQL. The
  offline explainer routes by lang: PromQL previews its SQL; LogQL/TraceQL are
  carried into the corpus but reported honestly as *not previewed offline this
  wave* rather than mis-parsed as PromQL and mislabelled with a parse error.
- Everything genuinely unusable (empty expr/query, unreadable file, unsupported
  or unresolvable datasource) stays **counted as a skip, never silently dropped**.

## Scope

Tooling + tests only, version-gated — nothing releases. This wave stays within
offline `harvest`/`explain`/`classify`; building full offline LogQL/TraceQL SQL
preview engines is out of scope (those queries are harvested and accounted for,
their SQL preview is a follow-up).

## Tests

- New end-to-end cmd test (`TestHarvestThreeHeadedCorpus`) harvests a dashboard
  with one Prometheus, one Loki, and one Tempo panel (Tempo via `query`) plus a
  `--loki-rules` file, and asserts the corpus carries all three langs with
  correct provenance and one counted skip for an unknown (Elasticsearch)
  datasource. Deterministic (fixed inputs, byte-identical re-harvest).
- Existing dashboard/corpus/main tests updated for the now-harvested Loki/Tempo
  panels and lang round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
