### PR TITLE
feat(migrate): explain + classify LogQL queries

### DIFF
--- a/cmd/cerberus/cmd_migrate.go
+++ b/cmd/cerberus/cmd_migrate.go
@@ -17,6 +17,7 @@ import (
 	"github.com/tsouza/cerberus/internal/api/prom"
 	"github.com/tsouza/cerberus/internal/config"
 	"github.com/tsouza/cerberus/internal/engine"
+	"github.com/tsouza/cerberus/internal/logql"
 	"github.com/tsouza/cerberus/internal/migrate"
 	"github.com/tsouza/cerberus/internal/migrategate"
 	"github.com/tsouza/cerberus/internal/migrateinventory"
@@ -827,44 +828,70 @@ func newExplainEngine(cfg config.Config) *engine.Engine {
 }
 
 // newDryRunExplainer wires the offline explainer: one engine (with the prod
-// sample budget) plus an instant lang for rules and a range lang for dashboard
-// panels, so each query previews in the evaluation mode the server would run it in.
+// sample budget) plus a per-head pair of langs — an instant lang for rules and a
+// range lang for dashboard panels — so each query previews in the evaluation mode
+// the server would run it in. Both the PromQL head (metrics schema) and the LogQL
+// head (logs schema) are wired; the corpus is three-headed and each query routes
+// to the lang matching its Lang tag. Every lang shares the same fixed evalTime and
+// window so the emitted SQL stays deterministic.
 func newDryRunExplainer(cfg config.Config) dryRunExplainer {
 	metrics := schema.DefaultOTelMetricsFromEnv()
+	logs := schema.DefaultOTelLogsFromEnv()
 	evalTime := time.Unix(explainEvalUnix, 0).UTC()
+	rangeStart := evalTime.Add(-explainRangeWindow)
 	return dryRunExplainer{
-		eng:         newExplainEngine(cfg),
-		instantLang: prom.NewExplainLang(metrics, evalTime),
-		rangeLang:   prom.NewExplainLangRange(metrics, evalTime.Add(-explainRangeWindow), evalTime, explainRangeStep),
+		eng:          newExplainEngine(cfg),
+		promInstant:  prom.NewExplainLang(metrics, evalTime),
+		promRange:    prom.NewExplainLangRange(metrics, rangeStart, evalTime, explainRangeStep),
+		logqlInstant: &logql.Lang{Schema: logs, Start: evalTime, End: evalTime},
+		logqlRange:   &logql.Lang{Schema: logs, Start: rangeStart, End: evalTime, Step: explainRangeStep},
 	}
 }
 
 // dryRunExplainer adapts engine.DryRunSQL to migrate.Explainer. The SQL it
 // reports is byte-identical to what the server would send to ClickHouse for the
-// same query. It picks the lang matching the query's evaluation mode: a panel
-// previews as a range query, a rule as an instant query.
+// same query. It picks the lang matching the query's source language (PromQL vs
+// LogQL) AND its evaluation mode: a panel previews as a range query, a rule as an
+// instant query. TraceQL corpus entries have no offline SQL preview yet, so they
+// are reported UNSUPPORTED with the language named rather than mis-parsed.
 type dryRunExplainer struct {
-	eng         *engine.Engine
-	instantLang engine.Lang
-	rangeLang   engine.Lang
+	eng          *engine.Engine
+	promInstant  engine.Lang
+	promRange    engine.Lang
+	logqlInstant engine.Lang
+	logqlRange   engine.Lang
 }
 
 func (d dryRunExplainer) Explain(ctx context.Context, q migrate.HarvestedQuery) migrate.Explanation {
-	// The offline SQL preview models the PromQL read pipeline. LogQL and TraceQL
-	// queries are still harvested into the corpus (so the report accounts for
-	// them), but their SQL is not previewed offline in this wave — report that
-	// honestly rather than parsing a LogQL/TraceQL string as PromQL and surfacing a
-	// mislabelled parse error. An empty Lang is treated as PromQL for corpora
-	// written before the corpus went three-headed.
-	if q.Lang != "" && q.Lang != migrate.LangPromQL {
-		return migrate.Explanation{Err: fmt.Errorf("offline SQL preview covers PromQL only; %s query harvested but not previewed here", q.Lang)}
+	instant, rangeLang, ok := d.langsFor(q.Lang)
+	if !ok {
+		// The offline SQL preview models the PromQL and LogQL read pipelines. A
+		// TraceQL query is still harvested into the corpus (so the report accounts
+		// for it), but its SQL is not previewed offline in this wave — report that
+		// honestly rather than parsing a TraceQL string as PromQL and surfacing a
+		// mislabelled parse error.
+		return migrate.Explanation{Err: fmt.Errorf("offline SQL preview covers PromQL and LogQL only; %s query harvested but not previewed here", q.Lang)}
 	}
-	evalLang := d.instantLang
+	evalLang := instant
 	if q.Kind == migrate.KindPanel {
-		evalLang = d.rangeLang
+		evalLang = rangeLang
 	}
 	dr, err := d.eng.DryRunSQL(ctx, evalLang, q.Expr)
 	return migrate.Explanation{SQL: dr.SQL, Plan: dr.Plan, Err: err}
+}
+
+// langsFor returns the (instant, range) lang pair for a harvested query's source
+// language and whether that language has an offline SQL preview. An empty Lang is
+// treated as PromQL for corpora written before the corpus went three-headed.
+func (d dryRunExplainer) langsFor(lang string) (instant, rangeLang engine.Lang, ok bool) {
+	switch lang {
+	case "", migrate.LangPromQL:
+		return d.promInstant, d.promRange, true
+	case migrate.LangLogQL:
+		return d.logqlInstant, d.logqlRange, true
+	default:
+		return nil, nil, false
+	}
 }
 
 // writeSchema renders the schema cerberus expects for cfg and writes it to w. It

--- a/cmd/cerberus/cmd_migrate_logql_test.go
+++ b/cmd/cerberus/cmd_migrate_logql_test.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/migrate"
+)
+
+// writeLogQLCorpus writes a deterministic corpus.json carrying LogQL queries and
+// returns its path. The corpus format is exactly what `migrate harvest` emits, so
+// driving `explain --corpus` / `classify --corpus` over it exercises the real
+// three-headed offline pipeline (parse -> lower -> emit via engine.DryRunSQL) for
+// the LogQL head without a ClickHouse connection.
+func writeLogQLCorpus(t *testing.T, queries []migrate.CorpusQuery) string {
+	t.Helper()
+	c := migrate.Corpus{Version: migrate.CorpusVersion, Queries: queries, Skipped: []migrate.SkippedEntry{}}
+	data, err := c.Marshal()
+	if err != nil {
+		t.Fatalf("marshal corpus: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "corpus.json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write corpus: %v", err)
+	}
+	return path
+}
+
+// TestExplainLogQLCorpus drives `migrate explain --corpus` over a LogQL corpus
+// through the real offline pipeline. A LogQL metric query and a LogQL log-stream
+// query must both preview REAL ClickHouse SQL against the logs table (otel_logs),
+// never UNSUPPORTED — the offline explainer now routes LogQL to the logs schema.
+func TestExplainLogQLCorpus(t *testing.T) {
+	corpus := writeLogQLCorpus(t, []migrate.CorpusQuery{
+		{Expr: `sum(rate({job="x"}[5m]))`, Source: "corpus:metric", Kind: migrate.KindRecord, Lang: migrate.LangLogQL},
+		{Expr: `{job="x"} |= "err"`, Source: "corpus:logstream", Kind: migrate.KindRecord, Lang: migrate.LangLogQL},
+	})
+
+	var out, errOut bytes.Buffer
+	if err := runMigrate([]string{"explain", "--corpus", corpus}, &out, &errOut); err != nil {
+		t.Fatalf("explain: %v (stderr: %s)", err, errOut.String())
+	}
+	report := out.String()
+
+	if strings.Contains(report, "UNSUPPORTED") {
+		t.Fatalf("LogQL corpus must preview real SQL, got an UNSUPPORTED entry:\n%s", report)
+	}
+	// Both queries scan the OTel logs table — the emitted SQL must reference it,
+	// which only happens if the query lowered against the logs schema.
+	if got := strings.Count(report, "otel_logs"); got < 2 {
+		t.Errorf("expected both LogQL queries to emit SQL over otel_logs (>=2 occurrences), got %d\n%s", got, report)
+	}
+	for _, want := range []string{
+		`sum(rate({job="x"}[5m]))`,
+		`{job="x"} |= "err"`,
+		"sql:",
+	} {
+		if !strings.Contains(report, want) {
+			t.Errorf("explain report missing %q\n---\n%s", want, report)
+		}
+	}
+}
+
+// TestClassifyLogQLCorpus drives `migrate classify --corpus --json` over the same
+// LogQL corpus: both a metric and a log-stream query lower + emit cleanly, so both
+// bucket as supported through the identical DryRunSQL path used by PromQL.
+func TestClassifyLogQLCorpus(t *testing.T) {
+	corpus := writeLogQLCorpus(t, []migrate.CorpusQuery{
+		{Expr: `sum(rate({job="x"}[5m]))`, Source: "corpus:metric", Kind: migrate.KindRecord, Lang: migrate.LangLogQL},
+		{Expr: `{job="x"} |= "err"`, Source: "corpus:logstream", Kind: migrate.KindRecord, Lang: migrate.LangLogQL},
+	})
+
+	var out, errOut bytes.Buffer
+	if err := runMigrate([]string{"classify", "--corpus", corpus, "--json"}, &out, &errOut); err != nil {
+		t.Fatalf("classify --json: %v (stderr: %s)", err, errOut.String())
+	}
+
+	var cl migrate.Classification
+	if err := json.Unmarshal(out.Bytes(), &cl); err != nil {
+		t.Fatalf("unmarshal classify JSON: %v\n%s", err, out.String())
+	}
+	if cl.Counts.Total != 2 || cl.Counts.Supported != 2 || cl.Counts.Unsupported != 0 {
+		t.Fatalf("counts = %+v, want total 2 / supported 2 / unsupported 0\n%s", cl.Counts, out.String())
+	}
+	for _, q := range cl.Queries {
+		if q.Bucket != migrate.BucketSupported {
+			t.Errorf("LogQL query %q bucketed as %q, want supported (construct: %q)", q.Expr, q.Bucket, q.Construct)
+		}
+	}
+}
+
+// TestClassifyLogQLUnsupported pins that a genuinely broken LogQL query still
+// lands in the unsupported bucket with its construct named — the honest failure
+// path, not a silent drop or a mislabelled success.
+func TestClassifyLogQLUnsupported(t *testing.T) {
+	corpus := writeLogQLCorpus(t, []migrate.CorpusQuery{
+		// Unterminated stream selector: a real LogQL parse error.
+		{Expr: `{job="x"`, Source: "corpus:broken", Kind: migrate.KindRecord, Lang: migrate.LangLogQL},
+	})
+
+	var out, errOut bytes.Buffer
+	if err := runMigrate([]string{"classify", "--corpus", corpus, "--json"}, &out, &errOut); err != nil {
+		t.Fatalf("classify --json: %v (stderr: %s)", err, errOut.String())
+	}
+
+	var cl migrate.Classification
+	if err := json.Unmarshal(out.Bytes(), &cl); err != nil {
+		t.Fatalf("unmarshal classify JSON: %v\n%s", err, out.String())
+	}
+	if cl.Counts.Total != 1 || cl.Counts.Unsupported != 1 {
+		t.Fatalf("counts = %+v, want total 1 / unsupported 1\n%s", cl.Counts, out.String())
+	}
+	if cl.Queries[0].Bucket != migrate.BucketUnsupported {
+		t.Errorf("broken LogQL query bucketed as %q, want unsupported", cl.Queries[0].Bucket)
+	}
+	if cl.Queries[0].Construct == "" {
+		t.Error("unsupported LogQL query must name its offending construct, got empty")
+	}
+}
+
+// TestExplainTraceQLCorpusHonestlyUnsupported pins that a TraceQL corpus entry —
+// which has no offline SQL preview in this wave — is reported UNSUPPORTED with the
+// language named, rather than mis-parsed as PromQL/LogQL and surfaced as a
+// confusing parse error.
+func TestExplainTraceQLCorpusHonestlyUnsupported(t *testing.T) {
+	corpus := writeLogQLCorpus(t, []migrate.CorpusQuery{
+		{Expr: `{ span.http.status_code = 500 }`, Source: "corpus:trace", Kind: migrate.KindPanel, Lang: migrate.LangTraceQL},
+	})
+
+	var out, errOut bytes.Buffer
+	if err := runMigrate([]string{"explain", "--corpus", corpus}, &out, &errOut); err != nil {
+		t.Fatalf("explain: %v (stderr: %s)", err, errOut.String())
+	}
+	report := out.String()
+	if !strings.Contains(report, "UNSUPPORTED") {
+		t.Fatalf("TraceQL corpus entry must report UNSUPPORTED, got:\n%s", report)
+	}
+	if !strings.Contains(report, migrate.LangTraceQL) {
+		t.Errorf("UNSUPPORTED reason must name the traceql language, got:\n%s", report)
+	}
+}

--- a/cmd/cerberus/cmd_migrate_main_test.go
+++ b/cmd/cerberus/cmd_migrate_main_test.go
@@ -170,7 +170,7 @@ groups:
 // corpus from a rules file plus a dashboard (with a Prometheus panel, a nested
 // row, and a Loki panel harvested as LogQL) to a file, then explain that corpus
 // file. The corpus is deterministic and the explain reads it back; the LogQL
-// query is carried into the corpus but reported as not-previewed-offline.
+// query is carried into the corpus and previewed as real SQL over the logs table.
 func TestHarvestThenExplainCorpus(t *testing.T) {
 	dir := t.TempDir()
 
@@ -270,14 +270,18 @@ groups:
 	if !strings.Contains(report, "node_load1") {
 		t.Errorf("explain report should include the nested-row panel query, got:\n%s", report)
 	}
-	// The LogQL query is carried into the corpus (4 queries, 0 skips) but the
-	// offline SQL preview covers PromQL only, so it is reported UNSUPPORTED with an
-	// honest reason rather than parsed as PromQL.
+	// The LogQL panel query (`{app="x"}`) is carried into the corpus (4 queries, 0
+	// skips) and now previews REAL ClickHouse SQL over the logs table — the offline
+	// explainer routes LogQL to the logs schema, so it is no longer reported as
+	// unsupported.
 	if !strings.Contains(report, "4 queries, 0 skipped") {
 		t.Errorf("explain report should report 4 queries and 0 skips, got:\n%s", report)
 	}
-	if !strings.Contains(report, "offline SQL preview covers PromQL only") {
-		t.Errorf("explain report should flag the LogQL query as not previewed offline, got:\n%s", report)
+	if strings.Contains(report, "UNSUPPORTED") {
+		t.Errorf("explain report should not mark any query UNSUPPORTED now that LogQL is previewed, got:\n%s", report)
+	}
+	if !strings.Contains(report, "otel_logs") {
+		t.Errorf("explain report should preview the LogQL panel query over otel_logs, got:\n%s", report)
 	}
 }
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -86,6 +86,14 @@ enabled (auto-selected on CH 25.9+) lowers those differently, so the previewed
 range SQL **may differ** from what such a deployment runs. The tool is offline and
 cannot know the target's ClickHouse version.
 
+The SQL preview covers the **PromQL and LogQL** heads: a PromQL corpus query
+lowers against the metrics schema and a LogQL query against the logs schema
+(`otel_logs`), each emitting real ClickHouse SQL. TraceQL corpus entries are
+still harvested (so the report and classify counts account for them), but they
+have no offline SQL preview yet — `explain` reports them `UNSUPPORTED` with the
+language named, and `classify` buckets them unsupported, rather than mis-parsing
+a TraceQL string against another head.
+
 ## The migration lifecycle
 
 ```text


### PR DESCRIPTION
## What

`cerberus migrate explain` and `classify` now handle **LogQL** corpus queries (`lang=logql`), building on the three-headed harvest (#1256). Previously any non-PromQL corpus entry was reported "offline SQL preview covers PromQL only"; LogQL entries are now dry-run through the real read pipeline and preview real ClickHouse SQL.

## How

- **Explainer dispatch is now Lang-aware.** `dryRunExplainer` carries a per-head pair of `engine.Lang`s: the existing PromQL metrics-schema langs (`prom.NewExplainLang` / `NewExplainLangRange`, unchanged) plus a new LogQL logs-schema pair — `&logql.Lang{Schema: schema.DefaultOTelLogsFromEnv(), Start, End, Step}` (instant for rules, range for panels). `langsFor(q.Lang)` routes each query; both heads run through the head-agnostic `engine.DryRunSQL`.
- **No new SQL.** LogQL lowering + emission is entirely reused via `DryRunSQL`; this change emits none of its own SQL (typed chsql only, by construction).
- **classify** flows through the same explain `Report`, so LogQL queries bucket supported / unsupported / risky automatically. `unsupported` = a real parse/lower/emit error with the construct named. The existing head-agnostic structural `Lint` (RangeWindow anchor fan-out) already flags risky LogQL metric queries — no over-claimed bespoke heuristic added.
- **TraceQL** corpus entries stay honestly `UNSUPPORTED` with the language named (no offline preview in this wave) rather than mis-parsed against another head.

## Tests (real + deterministic, fixed eval time)

- `explain --corpus` over a LogQL metric query `sum(rate({job="x"}[5m]))` and a log-stream query `{job="x"} |= "err"` -> both preview real SQL over `otel_logs`, never UNSUPPORTED.
- `classify --corpus --json` over the same corpus -> both `supported` (total 2 / supported 2 / unsupported 0).
- A broken LogQL selector `{job="x"` -> `unsupported` with a named construct.
- A TraceQL entry -> `UNSUPPORTED` with `traceql` named.
- Updated the existing three-headed harvest+explain test whose Loki panel now previews real SQL instead of the old PromQL-only rejection.

## Scope

Tooling + tests only — version-gated, nothing releases. Docs: added an honesty note to `docs/migration.md` that the SQL preview covers PromQL + LogQL, TraceQL harvested-but-not-previewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
