### PR TITLE
feat(migrate): explain + classify TraceQL queries

### DIFF
--- a/cmd/cerberus/cmd_migrate.go
+++ b/cmd/cerberus/cmd_migrate.go
@@ -15,6 +15,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/tsouza/cerberus/internal/api/prom"
+	"github.com/tsouza/cerberus/internal/api/tempo"
 	"github.com/tsouza/cerberus/internal/config"
 	"github.com/tsouza/cerberus/internal/engine"
 	"github.com/tsouza/cerberus/internal/logql"
@@ -830,13 +831,17 @@ func newExplainEngine(cfg config.Config) *engine.Engine {
 // newDryRunExplainer wires the offline explainer: one engine (with the prod
 // sample budget) plus a per-head pair of langs — an instant lang for rules and a
 // range lang for dashboard panels — so each query previews in the evaluation mode
-// the server would run it in. Both the PromQL head (metrics schema) and the LogQL
-// head (logs schema) are wired; the corpus is three-headed and each query routes
-// to the lang matching its Lang tag. Every lang shares the same fixed evalTime and
-// window so the emitted SQL stays deterministic.
+// the server would run it in. All three heads are wired — PromQL (metrics
+// schema), LogQL (logs schema), and TraceQL (traces schema) — and the
+// three-headed corpus routes each query to the lang matching its Lang tag. Every
+// lang shares the same fixed evalTime and window so the emitted SQL stays
+// deterministic. The TraceQL head has a single lang: a search query and a
+// metrics-pipeline query are distinguished by the query shape, not by rule-vs-
+// panel kind, so its Parse routes internally.
 func newDryRunExplainer(cfg config.Config) dryRunExplainer {
 	metrics := schema.DefaultOTelMetricsFromEnv()
 	logs := schema.DefaultOTelLogsFromEnv()
+	traces := schema.DefaultOTelTracesFromEnv()
 	evalTime := time.Unix(explainEvalUnix, 0).UTC()
 	rangeStart := evalTime.Add(-explainRangeWindow)
 	return dryRunExplainer{
@@ -845,32 +850,45 @@ func newDryRunExplainer(cfg config.Config) dryRunExplainer {
 		promRange:    prom.NewExplainLangRange(metrics, rangeStart, evalTime, explainRangeStep),
 		logqlInstant: &logql.Lang{Schema: logs, Start: evalTime, End: evalTime},
 		logqlRange:   &logql.Lang{Schema: logs, Start: rangeStart, End: evalTime, Step: explainRangeStep},
+		traceqlLang:  tempo.NewExplainLang(traces, explainRangeStep),
+		traceStart:   rangeStart,
+		traceEnd:     evalTime,
 	}
 }
 
 // dryRunExplainer adapts engine.DryRunSQL to migrate.Explainer. The SQL it
 // reports is byte-identical to what the server would send to ClickHouse for the
-// same query. It picks the lang matching the query's source language (PromQL vs
-// LogQL) AND its evaluation mode: a panel previews as a range query, a rule as an
-// instant query. TraceQL corpus entries have no offline SQL preview yet, so they
-// are reported UNSUPPORTED with the language named rather than mis-parsed.
+// same query. It picks the lang matching the query's source language (PromQL /
+// LogQL / TraceQL) AND, for the metrics heads, its evaluation mode: a panel
+// previews as a range query, a rule as an instant query.
 type dryRunExplainer struct {
 	eng          *engine.Engine
 	promInstant  engine.Lang
 	promRange    engine.Lang
 	logqlInstant engine.Lang
 	logqlRange   engine.Lang
+	// traceqlLang previews both TraceQL modes (search + metrics-range); the
+	// window it bounds each scan to is threaded onto ctx from traceStart/traceEnd.
+	traceqlLang engine.Lang
+	traceStart  time.Time
+	traceEnd    time.Time
 }
 
 func (d dryRunExplainer) Explain(ctx context.Context, q migrate.HarvestedQuery) migrate.Explanation {
+	if q.Lang == migrate.LangTraceQL {
+		// TraceQL lowering reads its search window + trace limit off the ctx; without
+		// the thread the plan lowers to an unbounded otel_traces scan the emit gate
+		// rejects (a bogus UNSUPPORTED). Thread the fixed explain window so the
+		// preview bounds every spans scan deterministically.
+		ctx = tempo.ExplainContext(ctx, d.traceStart, d.traceEnd, tempo.DefaultSearchLimit)
+		dr, err := d.eng.DryRunSQL(ctx, d.traceqlLang, q.Expr)
+		return migrate.Explanation{SQL: dr.SQL, Plan: dr.Plan, Err: err}
+	}
 	instant, rangeLang, ok := d.langsFor(q.Lang)
 	if !ok {
-		// The offline SQL preview models the PromQL and LogQL read pipelines. A
-		// TraceQL query is still harvested into the corpus (so the report accounts
-		// for it), but its SQL is not previewed offline in this wave — report that
-		// honestly rather than parsing a TraceQL string as PromQL and surfacing a
-		// mislabelled parse error.
-		return migrate.Explanation{Err: fmt.Errorf("offline SQL preview covers PromQL and LogQL only; %s query harvested but not previewed here", q.Lang)}
+		// Defensive: every harvested Lang is covered above. An unknown tag is
+		// reported honestly rather than parsed against the wrong head.
+		return migrate.Explanation{Err: fmt.Errorf("offline SQL preview does not cover %s queries", q.Lang)}
 	}
 	evalLang := instant
 	if q.Kind == migrate.KindPanel {
@@ -880,9 +898,11 @@ func (d dryRunExplainer) Explain(ctx context.Context, q migrate.HarvestedQuery) 
 	return migrate.Explanation{SQL: dr.SQL, Plan: dr.Plan, Err: err}
 }
 
-// langsFor returns the (instant, range) lang pair for a harvested query's source
-// language and whether that language has an offline SQL preview. An empty Lang is
-// treated as PromQL for corpora written before the corpus went three-headed.
+// langsFor returns the (instant, range) lang pair for a metrics-head query's
+// source language and whether that language has an instant/range lang pair. An
+// empty Lang is treated as PromQL for corpora written before the corpus went
+// three-headed. TraceQL is handled directly in Explain (single lang, shape-
+// routed) and never reaches here.
 func (d dryRunExplainer) langsFor(lang string) (instant, rangeLang engine.Lang, ok bool) {
 	switch lang {
 	case "", migrate.LangPromQL:

--- a/cmd/cerberus/cmd_migrate_logql_test.go
+++ b/cmd/cerberus/cmd_migrate_logql_test.go
@@ -121,25 +121,3 @@ func TestClassifyLogQLUnsupported(t *testing.T) {
 		t.Error("unsupported LogQL query must name its offending construct, got empty")
 	}
 }
-
-// TestExplainTraceQLCorpusHonestlyUnsupported pins that a TraceQL corpus entry —
-// which has no offline SQL preview in this wave — is reported UNSUPPORTED with the
-// language named, rather than mis-parsed as PromQL/LogQL and surfaced as a
-// confusing parse error.
-func TestExplainTraceQLCorpusHonestlyUnsupported(t *testing.T) {
-	corpus := writeLogQLCorpus(t, []migrate.CorpusQuery{
-		{Expr: `{ span.http.status_code = 500 }`, Source: "corpus:trace", Kind: migrate.KindPanel, Lang: migrate.LangTraceQL},
-	})
-
-	var out, errOut bytes.Buffer
-	if err := runMigrate([]string{"explain", "--corpus", corpus}, &out, &errOut); err != nil {
-		t.Fatalf("explain: %v (stderr: %s)", err, errOut.String())
-	}
-	report := out.String()
-	if !strings.Contains(report, "UNSUPPORTED") {
-		t.Fatalf("TraceQL corpus entry must report UNSUPPORTED, got:\n%s", report)
-	}
-	if !strings.Contains(report, migrate.LangTraceQL) {
-		t.Errorf("UNSUPPORTED reason must name the traceql language, got:\n%s", report)
-	}
-}

--- a/cmd/cerberus/cmd_migrate_traceql_test.go
+++ b/cmd/cerberus/cmd_migrate_traceql_test.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/migrate"
+)
+
+// writeTraceQLCorpus writes a deterministic corpus.json carrying TraceQL queries
+// and returns its path. The corpus format is exactly what `migrate harvest`
+// emits, so driving `explain --corpus` / `classify --corpus` over it exercises
+// the real three-headed offline pipeline (parse -> lower -> emit via
+// engine.DryRunSQL) for the TraceQL head without a ClickHouse connection.
+func writeTraceQLCorpus(t *testing.T, queries []migrate.CorpusQuery) string {
+	t.Helper()
+	c := migrate.Corpus{Version: migrate.CorpusVersion, Queries: queries, Skipped: []migrate.SkippedEntry{}}
+	data, err := c.Marshal()
+	if err != nil {
+		t.Fatalf("marshal corpus: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "corpus.json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write corpus: %v", err)
+	}
+	return path
+}
+
+// TestExplainTraceQLCorpusBounded is the load-bearing pin for this wave: a real
+// TraceQL SEARCH query and a TraceQL METRICS query must BOTH preview real,
+// BOUNDED ClickHouse SQL over the traces table (otel_traces), never UNSUPPORTED.
+//
+// Boundedness is the whole point. TraceQL lowering reads its search window +
+// trace limit off the ctx (WithSearchWindow / WithSearchTraceLimit); if the
+// offline dispatcher forgets to thread them, lowering emits an unbounded spans
+// scan that chsql.Emit's RequireSpansScansBounded chokepoint REJECTS — which
+// would surface here as an UNSUPPORTED entry. So a non-UNSUPPORTED preview that
+// scans otel_traces proves the ctx window/limit were threaded end to end.
+func TestExplainTraceQLCorpusBounded(t *testing.T) {
+	corpus := writeTraceQLCorpus(t, []migrate.CorpusQuery{
+		{Expr: `{ span.http.status_code = 500 }`, Source: "corpus:search", Kind: migrate.KindPanel, Lang: migrate.LangTraceQL},
+		{Expr: `{ } | rate()`, Source: "corpus:metrics", Kind: migrate.KindPanel, Lang: migrate.LangTraceQL},
+	})
+
+	var out, errOut bytes.Buffer
+	if err := runMigrate([]string{"explain", "--corpus", corpus}, &out, &errOut); err != nil {
+		t.Fatalf("explain: %v (stderr: %s)", err, errOut.String())
+	}
+	report := out.String()
+
+	if strings.Contains(report, "UNSUPPORTED") {
+		t.Fatalf("TraceQL corpus must preview real bounded SQL, got an UNSUPPORTED entry:\n%s", report)
+	}
+	// Both queries scan the OTel traces table — the emitted SQL must reference it,
+	// which only happens if the query lowered against the traces schema.
+	if got := strings.Count(report, "otel_traces"); got < 2 {
+		t.Errorf("expected both TraceQL queries to emit SQL over otel_traces (>=2 occurrences), got %d\n%s", got, report)
+	}
+	// The bound itself must be present: the search window lowers to a Timestamp
+	// partition-prune predicate (fromUnixTimestamp64Nano(...)). Its presence is
+	// the observable proof the ctx window threaded through to emit.
+	if !strings.Contains(report, "fromUnixTimestamp64Nano") {
+		t.Errorf("expected a bounded (windowed) scan predicate in the emitted SQL, got:\n%s", report)
+	}
+	for _, want := range []string{
+		`{ span.http.status_code = 500 }`,
+		`{ } | rate()`,
+		"sql:",
+	} {
+		if !strings.Contains(report, want) {
+			t.Errorf("explain report missing %q\n---\n%s", want, report)
+		}
+	}
+}
+
+// TestClassifyTraceQLCorpus drives `migrate classify --corpus --json` over the
+// same TraceQL corpus: both the search and the metrics query lower + emit
+// cleanly, so both bucket as supported through the identical DryRunSQL path used
+// by the other two heads.
+func TestClassifyTraceQLCorpus(t *testing.T) {
+	corpus := writeTraceQLCorpus(t, []migrate.CorpusQuery{
+		{Expr: `{ span.http.status_code = 500 }`, Source: "corpus:search", Kind: migrate.KindPanel, Lang: migrate.LangTraceQL},
+		{Expr: `{ } | rate()`, Source: "corpus:metrics", Kind: migrate.KindPanel, Lang: migrate.LangTraceQL},
+	})
+
+	var out, errOut bytes.Buffer
+	if err := runMigrate([]string{"classify", "--corpus", corpus, "--json"}, &out, &errOut); err != nil {
+		t.Fatalf("classify --json: %v (stderr: %s)", err, errOut.String())
+	}
+
+	var cl migrate.Classification
+	if err := json.Unmarshal(out.Bytes(), &cl); err != nil {
+		t.Fatalf("unmarshal classify JSON: %v\n%s", err, out.String())
+	}
+	if cl.Counts.Total != 2 || cl.Counts.Supported != 2 || cl.Counts.Unsupported != 0 {
+		t.Fatalf("counts = %+v, want total 2 / supported 2 / unsupported 0\n%s", cl.Counts, out.String())
+	}
+	for _, q := range cl.Queries {
+		if q.Bucket != migrate.BucketSupported {
+			t.Errorf("TraceQL query %q bucketed as %q, want supported (construct: %q)", q.Expr, q.Bucket, q.Construct)
+		}
+	}
+}
+
+// TestClassifyTraceQLStructuralRisky pins the "risky" flag for the TraceQL head:
+// a structural-join query (`{...} >> {...}`) lowers + emits cleanly (so it is
+// SUPPORTED) but carries the per-trace recursive-closure fan-out risk, so it must
+// also be flagged risky — the honest "clean but expensive" signal, not a demoted
+// bucket.
+func TestClassifyTraceQLStructuralRisky(t *testing.T) {
+	corpus := writeTraceQLCorpus(t, []migrate.CorpusQuery{
+		{Expr: `{ span.http.status_code = 500 } >> { name = "db.query" }`, Source: "corpus:structural", Kind: migrate.KindPanel, Lang: migrate.LangTraceQL},
+	})
+
+	var out, errOut bytes.Buffer
+	if err := runMigrate([]string{"classify", "--corpus", corpus, "--json"}, &out, &errOut); err != nil {
+		t.Fatalf("classify --json: %v (stderr: %s)", err, errOut.String())
+	}
+
+	var cl migrate.Classification
+	if err := json.Unmarshal(out.Bytes(), &cl); err != nil {
+		t.Fatalf("unmarshal classify JSON: %v\n%s", err, out.String())
+	}
+	if cl.Counts.Supported != 1 || cl.Counts.Risky != 1 {
+		t.Fatalf("counts = %+v, want supported 1 / risky 1\n%s", cl.Counts, out.String())
+	}
+	q := cl.Queries[0]
+	if q.Bucket != migrate.BucketSupported || !q.Risky {
+		t.Fatalf("structural-join query must be supported AND risky, got %+v", q)
+	}
+	joined := strings.Join(q.Risks, " ")
+	if !strings.Contains(joined, "structural-join fan-out") {
+		t.Errorf("risk flags must name the structural-join fan-out, got %v", q.Risks)
+	}
+}

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -86,13 +86,17 @@ enabled (auto-selected on CH 25.9+) lowers those differently, so the previewed
 range SQL **may differ** from what such a deployment runs. The tool is offline and
 cannot know the target's ClickHouse version.
 
-The SQL preview covers the **PromQL and LogQL** heads: a PromQL corpus query
-lowers against the metrics schema and a LogQL query against the logs schema
-(`otel_logs`), each emitting real ClickHouse SQL. TraceQL corpus entries are
-still harvested (so the report and classify counts account for them), but they
-have no offline SQL preview yet — `explain` reports them `UNSUPPORTED` with the
-language named, and `classify` buckets them unsupported, rather than mis-parsing
-a TraceQL string against another head.
+The SQL preview covers all **three heads**: a PromQL corpus query lowers against
+the metrics schema, a LogQL query against the logs schema (`otel_logs`), and a
+TraceQL query against the traces schema (`otel_traces`) — each emitting real
+ClickHouse SQL. A TraceQL search query (`{ span.http.status_code = 500 }`)
+previews as the bounded `/api/search` scan; a TraceQL metrics query
+(`{ } | rate()`) previews as the `/api/metrics/query_range` matrix. Both are
+bounded to a fixed lookback window so the emitted scan is partition-pruned, the
+same shape the server runs. `classify` additionally flags a TraceQL
+structural-join query (`{...} >> {...}`) **risky**: it lowers cleanly (so it is
+supported) but runs a per-trace recursive closure — the fan-out worth reviewing
+before cutover.
 
 ## The migration lifecycle
 

--- a/internal/api/tempo/explain.go
+++ b/internal/api/tempo/explain.go
@@ -1,0 +1,142 @@
+package tempo
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	traceql "github.com/tsouza/cerberus/internal/traceql/ast"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/engine"
+	"github.com/tsouza/cerberus/internal/schema"
+	traceql_lower "github.com/tsouza/cerberus/internal/traceql"
+)
+
+// NewExplainLang builds an engine.Lang for cerberus's offline TraceQL explain —
+// the migration preview's read-only "what SQL would cerberus run for this
+// TraceQL query" path. It wraps the same unexported traceqlLang the /api/search
+// handler drives, so a plain SEARCH query lowers through the identical parse +
+// lower + wrap-projection pipeline; a METRICS-pipeline query (`{...} | rate()`,
+// `{...} | count_over_time()`, …) additionally gets the range-window matrix wrap
+// the /api/metrics/query_range handler applies, so it previews in the same
+// evaluation mode the server would run it in.
+//
+// Both modes lower to a BOUNDED otel_traces scan: the search window + trace
+// limit ride in on the context (thread them with ExplainContext before calling
+// engine.DryRunSQL), and the metrics wrap reads that same window to build its
+// RangeWindow. Without the bound, lowering would emit an unbounded spans scan
+// that chsql.Emit's RequireSpansScansBounded chokepoint rejects — surfacing as a
+// bogus UNSUPPORTED rather than a real preview. `step` sizes the metrics matrix
+// buckets; it must be > 0.
+//
+// Trace-by-id (/traces/{id}) is the third TraceQL mode; it has no TraceQL
+// expression to explain (the handler hand-rolls a lookup plan from a raw id), so
+// the offline explainer covers SEARCH + metrics-range only.
+func NewExplainLang(s schema.Traces, step time.Duration) engine.Lang {
+	return &explainLang{traceqlLang: traceqlLang{schema: s}, step: step}
+}
+
+// ExplainContext pre-threads the offline explain window + trace limit onto ctx
+// so a TraceQL query lowers to a BOUNDED spans scan under engine.DryRunSQL. A
+// windowless request (both bounds zero) is clamped to the most recent
+// DefaultSearchLookback ending at `end` — the same recent-data default
+// /api/search applies — so the preview never emits an unbounded otel_traces
+// scan; a one-sided window has its missing start clamped the same way. A
+// non-positive limit falls back to DefaultSearchLimit.
+func ExplainContext(ctx context.Context, start, end time.Time, limit int) context.Context {
+	if limit <= 0 {
+		limit = DefaultSearchLimit
+	}
+	// Clamp a windowless / one-sided request to a bounded lookback so the search
+	// stamps and the metrics RangeWindow both have a real [start, end] to prune
+	// on. When end is also absent there is nothing deterministic to anchor to, so
+	// leave the (zero) window untouched and let the caller's explicit bound win.
+	if start.IsZero() && !end.IsZero() {
+		start = end.Add(-DefaultSearchLookback)
+	}
+	ctx = traceql_lower.WithSearchTraceLimit(ctx, limit)
+	ctx = traceql_lower.WithSearchWindow(ctx, start, end)
+	return ctx
+}
+
+// explainLang adapts the TraceQL head to engine.Lang for offline explain. It
+// embeds traceqlLang so Name / ProjectSamples (search path) / SpansTable are
+// inherited unchanged, and overrides Parse to route a metrics-pipeline query
+// through the range-window matrix wrap.
+type explainLang struct {
+	traceqlLang
+	step time.Duration
+}
+
+// Parse routes on the parsed query shape: a metrics-pipeline query builds the
+// range matrix plan, everything else falls through to the shared search
+// lowering (which reads the window + trace limit already threaded onto ctx).
+func (l *explainLang) Parse(ctx context.Context, query string) (chplan.Node, engine.Meta, error) {
+	expr, err := parseExpr(ctx, query)
+	if err != nil {
+		return nil, engine.Meta{}, fmt.Errorf("%w: %w", errParseStage, err)
+	}
+	if expr.MetricsPipeline != nil || expr.MetricsSecondStage != nil {
+		return l.parseMetrics(ctx, expr)
+	}
+	return l.traceqlLang.Parse(ctx, query)
+}
+
+// parseMetrics mirrors handleMetricsQueryRange's plan construction (minus the
+// HTTP / exemplar / execution machinery): lower the metrics pipeline, wrap the
+// aggregate with a step-sized chplan.RangeWindow bounded to the explain window,
+// then project into the Sample matrix shape. The RangeWindow is what bounds the
+// metrics inner spans scan (the top-level RequireSpansScansBounded chokepoint
+// skips the metrics-emitter subtree, deferring to the emitter's own per-site
+// bound), so a windowless preview would otherwise emit an unbounded scan.
+func (l *explainLang) parseMetrics(ctx context.Context, expr *traceql.RootExpr) (chplan.Node, engine.Meta, error) {
+	if l.step <= 0 {
+		return nil, engine.Meta{}, fmt.Errorf("%w: metrics explain needs a positive step", errLowerStage)
+	}
+	start, end := traceql_lower.SearchWindow(ctx)
+	start, end = alignMetricsWindow(start, end, l.step)
+	// Thread the aligned window so the universal recursive-arm stamp bounds a
+	// metrics-over-structural source (`{ } >> { } | rate()`) the RangeWindow wrap
+	// cannot reach below.
+	ctx = traceql_lower.WithSearchWindow(ctx, start, end)
+	plan, err := traceql_lower.Lower(ctx, expr, l.schema)
+	if err != nil {
+		return nil, engine.Meta{}, fmt.Errorf("%w: %w", errLowerStage, err)
+	}
+	stages, inner := peelMetricsSecondStages(plan)
+	metrics, ok := unwrapMetricsAggregate(inner)
+	if !ok {
+		// histogram_over_time / compare() lower to their own matrix node shapes
+		// (the handler's serveMetricsQueryRangeNonScalar path). The offline
+		// preview covers the scalar-aggregate metrics families; name the gap
+		// honestly rather than mis-wrapping a non-scalar plan.
+		return nil, engine.Meta{}, fmt.Errorf(
+			"%w: offline metrics preview covers scalar aggregates (rate / count_over_time / *_over_time / quantile_over_time); %q previews a non-scalar metrics shape", errLowerStage, expr.String(),
+		)
+	}
+	rw := &chplan.RangeWindow{
+		Input:           inner,
+		Range:           l.step,
+		Step:            l.step,
+		Start:           start,
+		End:             end,
+		TimestampColumn: l.schema.TimestampColumn,
+	}
+	wrapped := wrapMetricsForSample(
+		applyMetricsSecondStages(rw, stages, []string{chsql.RangeWindowAnchorAlias}),
+		metrics,
+	)
+	return wrapped, engine.Meta{IsMetric: true, ResponseShape: "tempo-metrics-matrix"}, nil
+}
+
+// ProjectSamples keeps the matrix wrap parseMetrics already applied (a metrics
+// plan is Sample-shaped on emit) and defers to the embedded search projection
+// for plain search plans.
+func (l *explainLang) ProjectSamples(plan chplan.Node, meta engine.Meta) chplan.Node {
+	if meta.IsMetric {
+		return plan
+	}
+	return l.traceqlLang.ProjectSamples(plan, meta)
+}

--- a/internal/migrate/migrate.go
+++ b/internal/migrate/migrate.go
@@ -212,8 +212,16 @@ func qualify(db, table string) string {
 // Lint returns conservative, offline risk flags read straight off the IR. It
 // deliberately does NOT estimate cardinality — row counts depend on data the
 // preview cannot see. It flags only structural fan-out that is a fact of the
-// plan shape: a PromQL subquery RangeWindow evaluates its inner expression at
-// many anchors per series, a work multiplier worth surfacing before cutover.
+// plan shape, the same across all three heads:
+//
+//   - a PromQL subquery RangeWindow evaluates its inner expression at many
+//     anchors per series, a work multiplier worth surfacing before cutover;
+//   - a TraceQL structural join (`>>` / `<<` / `>` / `<` / `~`) runs a
+//     per-trace parent/child/descendant closure over the matched span set —
+//     the recursive-CTE fan-out that dominates a structure-tab query's cost.
+//
+// Neither is a cardinality estimate: both are multipliers the plan shape makes
+// certain regardless of the data.
 func Lint(plan chplan.Node) []string {
 	seen := map[string]struct{}{}
 	var risks []string
@@ -225,15 +233,16 @@ func Lint(plan chplan.Node) []string {
 		risks = append(risks, msg)
 	}
 	chplan.Walk(plan, func(n chplan.Node) bool {
-		rw, ok := n.(*chplan.RangeWindow)
-		if !ok {
-			return true
-		}
-		if rw.OuterRange > 0 && rw.Step > 0 {
-			// anchors = OuterRange/Step + 1 (end-inclusive grid). This is a
-			// structural fan-out factor from the plan, not a data estimate.
-			anchors := int64(rw.OuterRange/rw.Step) + 1
-			add(fmt.Sprintf("subquery fan-out: inner expression evaluated at %d anchors per series", anchors))
+		switch v := n.(type) {
+		case *chplan.RangeWindow:
+			if v.OuterRange > 0 && v.Step > 0 {
+				// anchors = OuterRange/Step + 1 (end-inclusive grid). This is a
+				// structural fan-out factor from the plan, not a data estimate.
+				anchors := int64(v.OuterRange/v.Step) + 1
+				add(fmt.Sprintf("subquery fan-out: inner expression evaluated at %d anchors per series", anchors))
+			}
+		case *chplan.StructuralJoin:
+			add(fmt.Sprintf("structural-join fan-out: %s closure evaluated per matched trace", v.Op))
 		}
 		return true
 	})

--- a/internal/traceql/search_limit.go
+++ b/internal/traceql/search_limit.go
@@ -53,6 +53,12 @@ func searchTraceLimit(ctx context.Context) int64 {
 // node plain search already gets. 0 = unbounded.
 func SearchTraceLimit(ctx context.Context) int64 { return searchTraceLimit(ctx) }
 
+// SearchWindow exposes the /api/search request window (WithSearchWindow) to
+// adapters that build the plan outside this package — the offline explain Lang
+// reads it to bound a metrics-range preview's RangeWindow to the same window a
+// plain search scan gets. Two zero times = no window threaded.
+func SearchWindow(ctx context.Context) (time.Time, time.Time) { return searchWindowFromCtx(ctx) }
+
 // stampNestedSetTraceLimit walks the lowered plan and sets TraceLimit on
 // every NestedSetAnnotate whose input plan guarantees each returned trace's
 // root span is in the result set — the precondition under which ranking the


### PR DESCRIPTION
## What

Route each harvested corpus query tagged `lang=traceql` through a new offline TraceQL explain `engine.Lang` (`tempo.NewExplainLang`) instead of reporting it `UNSUPPORTED`. `explain --corpus` / `classify --corpus` now preview real, **bounded** ClickHouse SQL over `otel_traces` for the TraceQL head, via the same head-agnostic `engine.DryRunSQL` PromQL and LogQL already use — completing the three-headed offline preview.

- A **search** query (`{ span.http.status_code = 500 }`) previews as the bounded `/api/search` scan.
- A **metrics** query (`{ } | rate()`) previews as the `/api/metrics/query_range` matrix (a step-sized `RangeWindow` wrap mirroring the handler).
- Trace-by-id is the third TraceQL mode; it has no TraceQL expression to explain (the handler hand-rolls a lookup plan from a raw id), so the offline explainer covers search + metrics-range.

## The bound is the whole point

TraceQL lowering reads its search window + trace limit off the **context** (`WithSearchWindow` / `WithSearchTraceLimit`), not struct fields. The dispatcher threads a fixed, deterministic explain window via the new `tempo.ExplainContext` (clamping a windowless request to `DefaultSearchLookback`) before `DryRunSQL`. Without that thread, lowering emits an unbounded `otel_traces` scan that `chsql.Emit`'s `RequireSpansScansBounded` chokepoint rejects — which would surface as a bogus `UNSUPPORTED`. The metrics wrap reads that same window (newly exposed via `traceql.SearchWindow`) to build its `RangeWindow`, so its inner spans scan is partition-pruned too (the top-level chokepoint defers the metrics subtree to the emitter's own per-site bound).

## classify

Both search and metrics bucket **supported** through the identical `DryRunSQL` path. `Lint` gains a head-agnostic **structural-join fan-out** risk flag, so a `{...} >> {...}` query is supported *and* flagged **risky** (the per-trace recursive-closure fan-out) — the honest "clean but expensive" signal, not a demoted bucket. No cardinality is estimated (the preview has no data); only structural fan-out that is a fact of the plan shape is flagged.

## Tests (real + deterministic, fixed eval time)

- `TestExplainTraceQLCorpusBounded` — a real search query **and** a metrics query both explain to bounded SQL over `otel_traces` (asserts non-`UNSUPPORTED`, `otel_traces` present, and the `fromUnixTimestamp64Nano(...)` window predicate present). This pins that the ctx window/limit were threaded end to end.
- `TestClassifyTraceQLCorpus` — both bucket supported via `classify --json`.
- `TestClassifyTraceQLStructuralRisky` — a structural-join query is supported AND risky, with the fan-out named.

Removed the now-obsolete `TestExplainTraceQLCorpusHonestlyUnsupported` (it pinned the old "no TraceQL preview" behavior this PR replaces).

Tooling + tests only; nothing releases (version-gated, no tags). No raw SQL (reuses `DryRunSQL`). No new internal package (lives in `internal/api/tempo`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)