### PR TITLE
feat(chopt): native deriv/predict_linear via timeSeries*ToGrid (25.9)

### DIFF
--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -539,12 +539,15 @@ func newPromHandler(client *chclient.Client, cfg config.Config, optSet chopt.Ena
 //	staleness = enabled ? NativeStalenessLowerer{Fallback: FanoutStalenessLowerer{}} : FanoutStalenessLowerer{}
 //	changes   = enabled ? NativeChangesLowerer{Fallback: FanoutChangesLowerer{}} : FanoutChangesLowerer{}
 //	resets    = enabled ? NativeResetsLowerer{Fallback: FanoutResetsLowerer{}} : FanoutResetsLowerer{}
+//	deriv     = enabled ? NativeDerivLowerer{Fallback: FanoutDerivLowerer{}} : FanoutDerivLowerer{}
+//	predict   = enabled ? NativePredictLinearLowerer{Fallback: FanoutPredictLinearLowerer{}} : FanoutPredictLinearLowerer{}
 //
 // The fan-out impl is the concrete DEFAULT (never nil), and the native impl
 // embeds it as the fallback for shapes it cannot handle. The features are
 // independent, so the table composes per-function — native rate can be on while
-// native staleness / changes / resets are off, and vice versa (changes/resets
-// also carry a higher 25.9 floor than rate/resample's 25.6). The per-query
+// native staleness / changes / resets / deriv / predict_linear are off, and vice
+// versa (changes/resets/deriv/predict_linear also carry a higher 25.9 floor than
+// rate/resample's 25.6). The per-query
 // lowering then
 // dispatches through this table as a plain interface method call: NO
 // feature/version read, NO nil/presence check.
@@ -569,6 +572,16 @@ func nativeRangeLowerers(optSet chopt.EnabledSet) promql.RangeLowerers {
 		l.Resets = promql.NativeResetsLowerer{Fallback: promql.FanoutResetsLowerer{}}
 	} else {
 		l.Resets = promql.FanoutResetsLowerer{}
+	}
+	if optSet.Has(chopt.FeatureTSGridDeriv) {
+		l.Deriv = promql.NativeDerivLowerer{Fallback: promql.FanoutDerivLowerer{}}
+	} else {
+		l.Deriv = promql.FanoutDerivLowerer{}
+	}
+	if optSet.Has(chopt.FeatureTSGridPredictLinear) {
+		l.PredictLinear = promql.NativePredictLinearLowerer{Fallback: promql.FanoutPredictLinearLowerer{}}
+	} else {
+		l.PredictLinear = promql.FanoutPredictLinearLowerer{}
 	}
 	return l
 }

--- a/docs/clickhouse-optimizations.md
+++ b/docs/clickhouse-optimizations.md
@@ -123,6 +123,8 @@ table.
 | `columnar_result_decode` | none       | experimental | no         |
 | `ts_grid_changes`        | 25.9       | experimental | yes        |
 | `ts_grid_resets`         | 25.9       | experimental | yes        |
+| `ts_grid_deriv`          | 25.9       | experimental | yes        |
+| `ts_grid_predict_linear` | 25.9       | experimental | yes        |
 <!-- END GENERATED: chopt-feature-table -->
 
 The rich, hand-authored columns below stay OUTSIDE the generated block: they
@@ -135,15 +137,17 @@ the feature was reached via `auto` or by explicit listing. `columnar_result_deco
 is the lone `autoSelect: no` opt-in feature whose perf-tradeoff framing is
 described as "opt-in" in the effect prose.
 
-| id                       | experimental setting                                 | effect                                                                                                                                                                                                 |
-| ------------------------ | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `aggregation_in_order`   | (none)                                               | stamps `optimize_aggregation_in_order=1` when the plan's Aggregate GROUP BY is a bare-column prefix of the scanned table's sorting key. Result-equivalent.                                             |
-| `condition_cache`        | (none)                                               | stamps `use_query_condition_cache=1` (+`enable_analyzer=1`, analyzer-gated) on predicate-stable read paths. Result-equivalent (a cache).                                                               |
-| `ts_grid_range`          | `allow_experimental_time_series_aggregate_functions` | opts eligible `rate(<counter>[<range>])` query_range shapes onto the native `timeSeriesRateToGrid` aggregate. Auto-enabled on server >= 25.9 (experimental maturity).                                  |
-| `ts_grid_resample`       | `allow_experimental_time_series_aggregate_functions` | opts the range-mode instant-vector staleness shape onto the native `timeSeriesResampleToGridWithStaleness` aggregate, retiring the argMax fan-out. Auto-enabled on server >= 25.9.                     |
-| `columnar_result_decode` | (none)                                               | client-side: decodes the `query_range` matrix shape via the ch-go columnar path (label map built once per run, not per row). No server setting, no version floor. Opt-in only (never auto).            |
-| `ts_grid_changes`        | `allow_experimental_time_series_aggregate_functions` | opts eligible `changes(<v>[<range>])` query_range shapes onto the native `timeSeriesChangesToGrid` aggregate, retiring the `arrayPopBack`/`arrayPopFront` fan-out. Auto-enabled on server >= 25.9.     |
-| `ts_grid_resets`         | `allow_experimental_time_series_aggregate_functions` | opts eligible `resets(<counter>[<range>])` query_range shapes onto the native `timeSeriesResetsToGrid` aggregate, retiring the `arrayPopBack`/`arrayPopFront` fan-out. Auto-enabled on server >= 25.9. |
+| id                       | experimental setting                                 | effect                                                                                                                                                                                                                                                                                               |
+| ------------------------ | ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `aggregation_in_order`   | (none)                                               | stamps `optimize_aggregation_in_order=1` when the plan's Aggregate GROUP BY is a bare-column prefix of the scanned table's sorting key. Result-equivalent.                                                                                                                                           |
+| `condition_cache`        | (none)                                               | stamps `use_query_condition_cache=1` (+`enable_analyzer=1`, analyzer-gated) on predicate-stable read paths. Result-equivalent (a cache).                                                                                                                                                             |
+| `ts_grid_range`          | `allow_experimental_time_series_aggregate_functions` | opts eligible `rate(<counter>[<range>])` query_range shapes onto the native `timeSeriesRateToGrid` aggregate. Auto-enabled on server >= 25.9 (experimental maturity).                                                                                                                                |
+| `ts_grid_resample`       | `allow_experimental_time_series_aggregate_functions` | opts the range-mode instant-vector staleness shape onto the native `timeSeriesResampleToGridWithStaleness` aggregate, retiring the argMax fan-out. Auto-enabled on server >= 25.9.                                                                                                                   |
+| `columnar_result_decode` | (none)                                               | client-side: decodes the `query_range` matrix shape via the ch-go columnar path (label map built once per run, not per row). No server setting, no version floor. Opt-in only (never auto).                                                                                                          |
+| `ts_grid_changes`        | `allow_experimental_time_series_aggregate_functions` | opts eligible `changes(<v>[<range>])` query_range shapes onto the native `timeSeriesChangesToGrid` aggregate, retiring the `arrayPopBack`/`arrayPopFront` fan-out. Auto-enabled on server >= 25.9.                                                                                                   |
+| `ts_grid_resets`         | `allow_experimental_time_series_aggregate_functions` | opts eligible `resets(<counter>[<range>])` query_range shapes onto the native `timeSeriesResetsToGrid` aggregate, retiring the `arrayPopBack`/`arrayPopFront` fan-out. Auto-enabled on server >= 25.9.                                                                                               |
+| `ts_grid_deriv`          | `allow_experimental_time_series_aggregate_functions` | opts eligible `deriv(<gauge>[<range>])` query_range shapes onto the native `timeSeriesDerivToGrid` aggregate (per-window least-squares slope), retiring the `simpleLinearRegression`/`arrayReduce` fan-out. Auto-enabled on server >= 25.9.                                                          |
+| `ts_grid_predict_linear` | `allow_experimental_time_series_aggregate_functions` | opts eligible `predict_linear(<gauge>[<range>], t)` query_range shapes (whole-second literal `t`) onto the native `timeSeriesPredictLinearToGrid` aggregate (per-window slope\*t + intercept forecast), retiring the `simpleLinearRegression`/`arrayReduce` fan-out. Auto-enabled on server >= 25.9. |
 
 Notes:
 
@@ -198,6 +202,26 @@ Notes:
   It opts eligible `resets(<counter>[<range>])` shapes onto the native
   `timeSeriesResetsToGrid` aggregate, retiring the per-window counter-reset
   fan-out.
+- **`ts_grid_deriv`** and **`ts_grid_predict_linear`** are the LAST members of
+  the `timeSeries*ToGrid` family to adopt the native path: experimental
+  maturity, auto-enabled on a capable server, same experimental setting. Their
+  aggregates (`timeSeriesDerivToGrid` / `timeSeriesPredictLinearToGrid`) shipped
+  in ClickHouse **25.8** (PR #84328) — a quarter EARLIER than changes/resets —
+  but the registry pins them to the family's shared **25.9** floor (the
+  left-open-window fix, PR #86588) so one probed capability verdict governs
+  every member. `deriv` is the per-window least-squares slope; `predict_linear`
+  projects that fit `t` seconds past the anchor. Both retire the
+  `simpleLinearRegression`/`arrayReduce` fan-out; both NULL a window with < 2
+  samples (filtered to absent rows), mirroring the fan-out's drop-series
+  semantics. `predict_linear` threads its horizon `t` as the aggregate's 5th
+  parametric arg, so ONLY a single whole-second literal `t` is native-eligible —
+  a computed horizon (`predict_linear(v[r], scalar(x))`) or a fractional `t`
+  stays on the exact fan-out arithmetic. The native == fan-out numeric
+  differential (a Float64 fit, so ULP-close rather than bit-identical) is proven
+  on a `>= 25.9` server in the prod/e2e lane, not on the sub-25.9 chDB CI
+  substrate, where the version gate keeps both on the fan-out; the always-on
+  SQL-shape goldens (`native_deriv_range_step.txtar`,
+  `native_predict_linear_range_step.txtar`) pin the native emit unconditionally.
 
 ## Runtime version probe
 
@@ -217,7 +241,8 @@ This is the documented v1 behaviour.
 ## Boot capability probe (experimental ts_grid setting)
 
 The native `timeSeries*ToGrid` features (`ts_grid_range`, `ts_grid_resample`,
-`ts_grid_changes`, `ts_grid_resets`) need the server to run with
+`ts_grid_changes`, `ts_grid_resets`, `ts_grid_deriv`, `ts_grid_predict_linear`)
+need the server to run with
 `allow_experimental_time_series_aggregate_functions=1`, which cerberus
 co-stamps on exactly the queries that emit the native node. A server can be
 **new enough** for the version floor yet still **forbid** that setting — a

--- a/docs/native-clickhouse.md
+++ b/docs/native-clickhouse.md
@@ -24,6 +24,18 @@ the portable SQL path. What it currently exploits:
 - **`timeSeriesChangesToGrid` / `timeSeriesResetsToGrid`**
   (`changes` / `resets`, ClickHouse 25.9) — same one-pass shape for the
   adjacent-pair counters.
+- **`timeSeriesDerivToGrid` / `timeSeriesPredictLinearToGrid`**
+  (`deriv` / `predict_linear`, ClickHouse 25.8, registry-pinned to the family's
+  25.9 floor) — the last members of the family to adopt the native path: a
+  per-window least-squares fit whose slope is `deriv` and whose `slope*t +
+  intercept` projection is `predict_linear`, retiring the
+  `simpleLinearRegression`/`arrayReduce` fan-out. `predict_linear` threads its
+  whole-second horizon `t` as the aggregate's 5th parametric arg; a computed or
+  fractional `t` stays on the fan-out. The native == fan-out numeric parity is a
+  Float64 fit (ULP-close, not bit-identical), proven on a `>= 25.9` server in
+  the prod/e2e differential lane — the sub-25.9 chDB CI substrate lacks the
+  aggregates, so it runs the fan-out and the always-on SQL-shape goldens pin the
+  native emit.
 - **`timeSeriesResampleToGridWithStaleness`** — native instant-vector
   selection with Prometheus staleness, retiring the staleness fan-out.
 - **`condition_cache`** and **`aggregation_in_order`** — server-side

--- a/internal/chopt/registry.go
+++ b/internal/chopt/registry.go
@@ -96,6 +96,33 @@ const (
 	// AUTO-SELECTED on capable servers, same 25.9 floor and same experimental
 	// gate as FeatureTSGridChanges (the two are siblings from PR #86010).
 	FeatureTSGridResets = "ts_grid_resets"
+
+	// FeatureTSGridDeriv opts eligible deriv(<gauge>[<range>]) query_range
+	// shapes onto the native timeSeriesDerivToGrid aggregate (the per-window
+	// simple-linear-regression slope), retiring the
+	// simpleLinearRegression/arrayReduce fan-out
+	// (internal/chsql.emitRangeWindowDeriv). Experimental maturity but
+	// AUTO-SELECTED on capable servers, same experimental gate and the same
+	// 25.9 floor as the rest of the family.
+	//
+	// IMPORTANT — the floor is 25.9, shared with the family. The deriv/
+	// predict_linear ToGrid aggregates first shipped in ClickHouse 25.8
+	// (PR #84328); the registry pins them to the family's 25.9 floor for
+	// consistency (the shared left-open-window fix, PR #86588), so a single
+	// probed capability verdict governs every timeSeries*ToGrid member.
+	FeatureTSGridDeriv = "ts_grid_deriv"
+
+	// FeatureTSGridPredictLinear opts eligible predict_linear(<gauge>[<range>], t)
+	// query_range shapes onto the native timeSeriesPredictLinearToGrid aggregate
+	// (the per-window slope*t + intercept forecast), retiring the
+	// simpleLinearRegression/arrayReduce fan-out
+	// (internal/chsql.emitRangeWindowPredictLinear). The native path only fires
+	// for a single whole-second literal horizon t (the aggregate's 5th
+	// parametric arg); computed/fractional horizons stay on the fan-out.
+	// Experimental maturity, AUTO-SELECTED on capable servers, same 25.9 floor
+	// and same experimental gate as FeatureTSGridDeriv (the two are siblings
+	// from PR #84328).
+	FeatureTSGridPredictLinear = "ts_grid_predict_linear"
 )
 
 // AlwaysAvailable is the zero version floor for a feature that depends on no
@@ -224,11 +251,28 @@ var registry = []Feature{
 		RequiresExperimentalTSGrid: true,
 		Doc:                        "opt eligible resets(<counter>[<range>]) shapes onto native timeSeriesResetsToGrid (experimental maturity, auto-enabled on server >= 25.9)",
 	},
+	{
+		ID:                         FeatureTSGridDeriv,
+		MinVersion:                 Version{Major: 25, Minor: 9},
+		Stability:                  Experimental,
+		AutoSelect:                 true,
+		RequiresExperimentalTSGrid: true,
+		Doc:                        "opt eligible deriv(<gauge>[<range>]) shapes onto native timeSeriesDerivToGrid (experimental maturity, auto-enabled on server >= 25.9)",
+	},
+	{
+		ID:                         FeatureTSGridPredictLinear,
+		MinVersion:                 Version{Major: 25, Minor: 9},
+		Stability:                  Experimental,
+		AutoSelect:                 true,
+		RequiresExperimentalTSGrid: true,
+		Doc:                        "opt eligible predict_linear(<gauge>[<range>], t) shapes (whole-second literal t) onto native timeSeriesPredictLinearToGrid (experimental maturity, auto-enabled on server >= 25.9)",
+	},
 }
 
 // Registry returns a copy of the seeded feature registry
 // (aggregation_in_order, condition_cache, ts_grid_range, ts_grid_resample,
-// columnar_result_decode, ts_grid_changes, ts_grid_resets). The copy keeps the
+// columnar_result_decode, ts_grid_changes, ts_grid_resets, ts_grid_deriv,
+// ts_grid_predict_linear). The copy keeps the
 // canonical entries immutable from the caller's side. Exposed so tests can
 // enumerate the gates and the docs generator can render the table.
 func Registry() []Feature {

--- a/internal/chopt/resolve_test.go
+++ b/internal/chopt/resolve_test.go
@@ -108,11 +108,13 @@ func TestResolve_Off_LegacyFalse_StaysEmpty(t *testing.T) {
 
 func TestResolve_Auto_EnablesAutoSelectByVersion(t *testing.T) {
 	// On 25.9 the stable features (aggregation_in_order 24.8, condition_cache
-	// 25.3) plus ALL FOUR 25.9-floored native aggregates (ts_grid_range,
-	// ts_grid_resample, ts_grid_changes, ts_grid_resets) are AutoSelect=true and
-	// supported; columnar_result_decode is AutoSelect=false so auto never picks
-	// it. 25.9 is the first release whose timeSeries*ToGrid window is left-open
-	// (PR #86588), so it is the native floor for the whole family.
+	// 25.3) plus ALL SIX 25.9-floored native aggregates (ts_grid_range,
+	// ts_grid_resample, ts_grid_changes, ts_grid_resets, ts_grid_deriv,
+	// ts_grid_predict_linear) are AutoSelect=true and supported;
+	// columnar_result_decode is AutoSelect=false so auto never picks it. 25.9 is
+	// the first release whose timeSeries*ToGrid window is left-open (PR #86588),
+	// so it is the native floor for the whole family (deriv/predict_linear
+	// shipped at 25.8 but are registry-pinned to the shared 25.9 floor).
 	// Capability=Available is the happy-path boot verdict (the server permits
 	// the experimental setting).
 	set, _, err := Resolve(Config{Optimizations: "auto", Capability: CapabilityAvailable}, v(25, 9))
@@ -120,7 +122,8 @@ func TestResolve_Auto_EnablesAutoSelectByVersion(t *testing.T) {
 		t.Fatalf("Resolve: %v", err)
 	}
 	assertSet(t, set, FeatureAggregationInOrder, FeatureConditionCache,
-		FeatureTSGridRange, FeatureTSGridResample, FeatureTSGridChanges, FeatureTSGridResets)
+		FeatureTSGridRange, FeatureTSGridResample, FeatureTSGridChanges, FeatureTSGridResets,
+		FeatureTSGridDeriv, FeatureTSGridPredictLinear)
 	if set.Has(FeatureColumnarResultDecode) {
 		t.Errorf("auto on 25.9 enabled %q; want it off (opt-in only)", FeatureColumnarResultDecode)
 	}
@@ -135,7 +138,10 @@ func TestResolve_Auto_NativeAggregatesOffBelow259(t *testing.T) {
 		t.Fatalf("Resolve: %v", err)
 	}
 	assertSet(t, set, FeatureAggregationInOrder, FeatureConditionCache)
-	for _, off := range []string{FeatureTSGridRange, FeatureTSGridResample, FeatureTSGridChanges, FeatureTSGridResets} {
+	for _, off := range []string{
+		FeatureTSGridRange, FeatureTSGridResample, FeatureTSGridChanges, FeatureTSGridResets,
+		FeatureTSGridDeriv, FeatureTSGridPredictLinear,
+	} {
 		if set.Has(off) {
 			t.Errorf("auto on 25.8 enabled %q; want it off (native floor is 25.9)", off)
 		}
@@ -148,7 +154,8 @@ func TestResolve_Auto_EmptySelectionDefaultsToAuto(t *testing.T) {
 		t.Fatalf("Resolve: %v", err)
 	}
 	assertSet(t, set, FeatureAggregationInOrder, FeatureConditionCache,
-		FeatureTSGridRange, FeatureTSGridResample, FeatureTSGridChanges, FeatureTSGridResets)
+		FeatureTSGridRange, FeatureTSGridResample, FeatureTSGridChanges, FeatureTSGridResets,
+		FeatureTSGridDeriv, FeatureTSGridPredictLinear)
 }
 
 func TestResolve_Auto_VersionBoundaries(t *testing.T) {
@@ -183,11 +190,12 @@ func TestResolve_Auto_VersionBoundaries(t *testing.T) {
 			want:   []string{FeatureAggregationInOrder, FeatureConditionCache},
 		},
 		{
-			name:   "25.9 adds all four native aggregates (left-open window)",
+			name:   "25.9 adds all six native aggregates (left-open window)",
 			server: v(25, 9),
 			want: []string{
 				FeatureAggregationInOrder, FeatureConditionCache,
 				FeatureTSGridRange, FeatureTSGridResample, FeatureTSGridChanges, FeatureTSGridResets,
+				FeatureTSGridDeriv, FeatureTSGridPredictLinear,
 			},
 		},
 	}
@@ -317,7 +325,7 @@ func TestResolve_ColumnarResultDecode_NoVersionFloor(t *testing.T) {
 func TestResolve_AutoPlusOptIn_UnionsBoth(t *testing.T) {
 	// The headline case: "auto,columnar_result_decode" = the version-gated auto
 	// set PLUS the opt-in feature, without bailing out of auto. On 25.9 the auto
-	// half includes all four 25.9-floored native aggregates.
+	// half includes all six 25.9-floored native aggregates.
 	set, _, err := Resolve(Config{Optimizations: "auto,columnar_result_decode", Capability: CapabilityAvailable}, v(25, 9))
 	if err != nil {
 		t.Fatalf("Resolve(auto,columnar_result_decode): %v", err)
@@ -325,6 +333,7 @@ func TestResolve_AutoPlusOptIn_UnionsBoth(t *testing.T) {
 	assertSet(t, set,
 		FeatureAggregationInOrder, FeatureConditionCache,
 		FeatureTSGridRange, FeatureTSGridResample, FeatureTSGridChanges, FeatureTSGridResets,
+		FeatureTSGridDeriv, FeatureTSGridPredictLinear,
 		FeatureColumnarResultDecode)
 }
 
@@ -480,7 +489,8 @@ func TestResolve_LegacyUnset_NoEffect(t *testing.T) {
 		t.Fatalf("Resolve: %v", err)
 	}
 	assertSet(t, set, FeatureAggregationInOrder, FeatureConditionCache,
-		FeatureTSGridRange, FeatureTSGridResample, FeatureTSGridChanges, FeatureTSGridResets)
+		FeatureTSGridRange, FeatureTSGridResample, FeatureTSGridChanges, FeatureTSGridResets,
+		FeatureTSGridDeriv, FeatureTSGridPredictLinear)
 	if hasDeprecation(warns) {
 		t.Errorf("unset legacy must not emit deprecation; warns = %v", warns)
 	}
@@ -492,7 +502,7 @@ func TestRegistry_SeededEntries(t *testing.T) {
 	// aggregates are Experimental maturity yet AutoSelect=true (auto picks them
 	// by version), while columnar_result_decode is the lone AutoSelect=false
 	// opt-in perf tradeoff.
-	// RequiresExperimentalTSGrid marks the four native timeSeries*ToGrid
+	// RequiresExperimentalTSGrid marks the six native timeSeries*ToGrid
 	// aggregates (the experimental-setting family); the stable/client-side
 	// features leave it false.
 	want := map[string]Feature{
@@ -503,6 +513,8 @@ func TestRegistry_SeededEntries(t *testing.T) {
 		FeatureColumnarResultDecode: {ID: FeatureColumnarResultDecode, MinVersion: AlwaysAvailable, Stability: Experimental, AutoSelect: false, RequiresExperimentalTSGrid: false},
 		FeatureTSGridChanges:        {ID: FeatureTSGridChanges, MinVersion: v(25, 9), Stability: Experimental, AutoSelect: true, RequiresExperimentalTSGrid: true},
 		FeatureTSGridResets:         {ID: FeatureTSGridResets, MinVersion: v(25, 9), Stability: Experimental, AutoSelect: true, RequiresExperimentalTSGrid: true},
+		FeatureTSGridDeriv:          {ID: FeatureTSGridDeriv, MinVersion: v(25, 9), Stability: Experimental, AutoSelect: true, RequiresExperimentalTSGrid: true},
+		FeatureTSGridPredictLinear:  {ID: FeatureTSGridPredictLinear, MinVersion: v(25, 9), Stability: Experimental, AutoSelect: true, RequiresExperimentalTSGrid: true},
 	}
 	if len(reg) != len(want) {
 		t.Fatalf("registry has %d entries; want %d", len(reg), len(want))
@@ -521,7 +533,7 @@ func TestRegistry_SeededEntries(t *testing.T) {
 
 func TestResolve_Auto_CapabilityForbidden_DropsNativeKeepsStable(t *testing.T) {
 	// A 25.9 server (every native floor met) whose boot verdict is FORBIDDEN:
-	// auto drops ALL FOUR native ts_grid_* features and keeps the non-experimental
+	// auto drops ALL SIX native ts_grid_* features and keeps the non-experimental
 	// stable ones (aggregation_in_order, condition_cache). Each dropped native
 	// feature emits a boot WARN naming the experimental setting + the fan-out
 	// fallback (auto is silent on version skips, but NOT on a capability block —
@@ -531,13 +543,16 @@ func TestResolve_Auto_CapabilityForbidden_DropsNativeKeepsStable(t *testing.T) {
 		t.Fatalf("Resolve: %v", err)
 	}
 	assertSet(t, set, FeatureAggregationInOrder, FeatureConditionCache)
-	for _, native := range []string{FeatureTSGridRange, FeatureTSGridResample, FeatureTSGridChanges, FeatureTSGridResets} {
+	for _, native := range []string{
+		FeatureTSGridRange, FeatureTSGridResample, FeatureTSGridChanges, FeatureTSGridResets,
+		FeatureTSGridDeriv, FeatureTSGridPredictLinear,
+	} {
 		if set.Has(native) {
 			t.Errorf("auto enabled %q on a capability-forbidden server; want it dropped to fan-out", native)
 		}
 	}
-	if len(warns) != 4 {
-		t.Fatalf("want one WARN per dropped native feature (4); got %d: %v", len(warns), warns)
+	if len(warns) != 6 {
+		t.Fatalf("want one WARN per dropped native feature (6); got %d: %v", len(warns), warns)
 	}
 	for _, w := range warns {
 		if !strings.Contains(w, "allow_experimental_time_series_aggregate_functions") || !strings.Contains(w, "fan-out") {

--- a/internal/chplan/clone.go
+++ b/internal/chplan/clone.go
@@ -60,6 +60,7 @@ func CloneNode(n Node) Node {
 		c := *v
 		c.Input = CloneNode(v.Input)
 		c.GroupBy = cloneExprs(v.GroupBy)
+		c.Scalars = cloneFloats(v.Scalars)
 		return &c
 	case *RangeLWR:
 		c := *v

--- a/internal/chplan/range_window_native.go
+++ b/internal/chplan/range_window_native.go
@@ -90,6 +90,16 @@ type RangeWindowNative struct {
 	// `[ColumnRef("Attributes")]` for OTel-CH). May be empty, in which
 	// case all rows form one series. Same semantics as RangeWindow.GroupBy.
 	GroupBy []Expr
+
+	// Scalars carries the literal scalar arguments the native aggregate takes
+	// beyond the shared (start, end, step, window) parametric prefix. Only
+	// predict_linear uses it today: a single whole-second horizon t threaded
+	// into timeSeriesPredictLinearToGrid's 5th parametric arg. Empty for
+	// rate / changes / resets / deriv, which take no extra parameter. Mirrors
+	// RangeWindow.Scalars; the PromQL lowering gates predict_linear to a
+	// whole-second literal before populating it (computed / fractional horizons
+	// stay on the fan-out RangeWindow).
+	Scalars []float64
 }
 
 func (*RangeWindowNative) planNode() {}
@@ -109,6 +119,14 @@ func (r *RangeWindowNative) Equal(other Node) bool {
 	}
 	if r.TimestampColumn != o.TimestampColumn || r.ValueColumn != o.ValueColumn {
 		return false
+	}
+	if len(r.Scalars) != len(o.Scalars) {
+		return false
+	}
+	for i := range r.Scalars {
+		if r.Scalars[i] != o.Scalars[i] {
+			return false
+		}
 	}
 	if len(r.GroupBy) != len(o.GroupBy) {
 		return false

--- a/internal/chsql/range_window_native.go
+++ b/internal/chsql/range_window_native.go
@@ -29,31 +29,40 @@ const (
 
 // nativeTSGridFn maps a PromQL range function to its ClickHouse-native
 // timeSeries*ToGrid aggregate. The map is the single extension point for the
-// rest of the family (timeSeriesDeltaToGrid, timeSeriesDerivToGrid, …) once
-// each is differentially proven equivalent to its PromQL counterpart.
+// rest of the family (timeSeriesDeltaToGrid, …) once each is differentially
+// proven equivalent to its PromQL counterpart.
 //
 // Every entry renders through the IDENTICAL emitRangeWindowNative shape — the
-// `(start, end, step_s, Range_s)(ts, value)` parametric aggregate paired with a
-// lockstep timeSeriesRange axis — because the whole family shares one paren/arg
-// signature. The per-func difference is purely the aggregate NAME and the
-// ClickHouse version floor at which it first shipped:
+// `(start, end, step_s, Range_s[, predict_offset_s])(ts, value)` parametric
+// aggregate paired with a lockstep timeSeriesRange axis — because the whole
+// family shares one paren/arg signature. The per-func difference is the
+// aggregate NAME, the ClickHouse version floor at which it first shipped, and
+// (predict_linear only) one extra trailing parametric arg:
 //
-//   - rate    -> timeSeriesRateToGrid    (shipped v25.6, >= 2 samples/window)
-//   - changes -> timeSeriesChangesToGrid (v25.9 — PR #86010, >= 1 sample/window)
-//   - resets  -> timeSeriesResetsToGrid  (v25.9 — PR #86010, >= 1 sample/window)
+//   - rate           -> timeSeriesRateToGrid          (shipped v25.6, >= 2 samples/window)
+//   - changes        -> timeSeriesChangesToGrid       (v25.9 — PR #86010, >= 1 sample/window)
+//   - resets         -> timeSeriesResetsToGrid        (v25.9 — PR #86010, >= 1 sample/window)
+//   - deriv          -> timeSeriesDerivToGrid         (v25.8 — PR #84328, >= 2 samples/window)
+//   - predict_linear -> timeSeriesPredictLinearToGrid (v25.8 — PR #84328, >= 2 samples/window, +predict_offset)
 //
 // changes/resets are COUNT functions (Array(Nullable(Float64)) one count per
-// grid point, NULL where no in-window sample), so the same
+// grid point, NULL where no in-window sample); rate/deriv/predict_linear return
+// one Nullable(Float64) value per grid point (NULL where the window has < 2
+// samples, mirroring PromQL's drop-series). Either way the same
 // `WHERE grid_val IS NOT NULL` filter and `toFloat64` cast apply verbatim. The
 // whole family is gated to a 25.9 floor by the chopt registry: changes/resets
 // because the aggregates only ship at 25.9, rate because its membership window
 // was CLOSED until 25.9 (PR #86588 made it left-open / right-closed to match
-// PromQL — see internal/chopt FeatureTSGridRange). The emitter is
-// version-agnostic and only needs the name.
+// PromQL — see internal/chopt FeatureTSGridRange), and deriv/predict_linear
+// (which shipped a quarter earlier at 25.8) pinned to the same 25.9 floor for
+// one uniform capability verdict. The emitter is version-agnostic and only
+// needs the name (plus predict_linear's offset scalar).
 var nativeTSGridFn = map[string]string{
-	"rate":    "timeSeriesRateToGrid",
-	"changes": "timeSeriesChangesToGrid",
-	"resets":  "timeSeriesResetsToGrid",
+	"rate":           "timeSeriesRateToGrid",
+	"changes":        "timeSeriesChangesToGrid",
+	"resets":         "timeSeriesResetsToGrid",
+	"deriv":          "timeSeriesDerivToGrid",
+	"predict_linear": "timeSeriesPredictLinearToGrid",
 }
 
 // emitRangeWindowNative renders a chplan.RangeWindowNative — the
@@ -124,7 +133,19 @@ func (e *emitter) emitRangeWindowNative(r *chplan.RangeWindowNative) error {
 	}
 	fnName, ok := nativeTSGridFn[r.Func]
 	if !ok {
-		return fmt.Errorf("%w: RangeWindowNative func %q (supported: rate, changes, resets)", ErrUnsupported, r.Func)
+		return fmt.Errorf("%w: RangeWindowNative func %q (supported: rate, changes, resets, deriv, predict_linear)", ErrUnsupported, r.Func)
+	}
+	// predict_linear threads its future-offset horizon t (whole seconds) as the
+	// 5th parametric arg of timeSeriesPredictLinearToGrid. The PromQL lowering
+	// only wires the native path for a single whole-second literal t (computed /
+	// fractional horizons stay on the fan-out), so a predict_linear node must
+	// carry exactly one Scalar; any other func must carry none.
+	if r.Func == "predict_linear" {
+		if len(r.Scalars) != 1 {
+			return fmt.Errorf("%w: RangeWindowNative predict_linear requires exactly 1 scalar (t), got %d", ErrUnsupported, len(r.Scalars))
+		}
+	} else if len(r.Scalars) != 0 {
+		return fmt.Errorf("%w: RangeWindowNative func %q takes no scalar, got %d", ErrUnsupported, r.Func, len(r.Scalars))
 	}
 
 	groupFrags, err := e.collectGroupByFrags(r.GroupBy)
@@ -146,12 +167,18 @@ func (e *emitter) emitRangeWindowNative(r *chplan.RangeWindowNative) error {
 	windowSeconds := int64(r.Range.Seconds())
 
 	// timeSeriesRateToGrid(start, end, step_s, window_s)(ts, value) — the
-	// compiled C++ aggregate that returns the per-grid-point
-	// extrapolatedRate as Array(Nullable(Float64)). Note the TWO paren
-	// groups (params then args), rendered by Parametric.
+	// compiled C++ aggregate that returns the per-grid-point value as
+	// Array(Nullable(Float64)). Note the TWO paren groups (params then args),
+	// rendered by Parametric. predict_linear appends its whole-second horizon t
+	// as a 5th param: timeSeriesPredictLinearToGrid(start, end, step_s,
+	// window_s, predict_offset_s)(ts, value).
+	gridParams := []Frag{startFrag, endFrag, InlineLit(stepSeconds), InlineLit(windowSeconds)}
+	if r.Func == "predict_linear" {
+		gridParams = append(gridParams, InlineLit(int64(r.Scalars[0])))
+	}
 	gridAgg := Parametric(
 		fnName,
-		[]Frag{startFrag, endFrag, InlineLit(stepSeconds), InlineLit(windowSeconds)},
+		gridParams,
 		Col(r.TimestampColumn),
 		Col(r.ValueColumn),
 	)

--- a/internal/chsql/range_window_native_deriv_predict_test.go
+++ b/internal/chsql/range_window_native_deriv_predict_test.go
@@ -169,6 +169,38 @@ func TestNativePredictLinearFractionalFallsBack(t *testing.T) {
 	}
 }
 
+// TestNativePredictLinearNegativeHorizonFallsBack pins the eligibility carve-out
+// for a NEGATIVE horizon t (-3600s, a legal PromQL backward projection). Even
+// with the native feature ENABLED the lowering delegates to the fan-out: the
+// aggregate's 5th parametric (predict_offset) arg is not verified to accept a
+// signed offset on the >= 25.9 substrate, so a negative literal would be a
+// silent query-time rejection the sub-25.9 CI cannot catch. The fan-out's
+// `intercept + slope*t` evaluates negative t byte-exactly, so the fallback is
+// the correct home for it.
+func TestNativePredictLinearNegativeHorizonFallsBack(t *testing.T) {
+	t.Parallel()
+
+	lowerers := promql.RangeLowerers{
+		PredictLinear: promql.NativePredictLinearLowerer{Fallback: promql.FanoutPredictLinearLowerer{}},
+	}
+	plan := lowerRangeNative(t, "sum by(host) (predict_linear(disk_used_bytes[10m], -3600))", lowerers)
+
+	if native := findNativeNode(plan); native != nil {
+		t.Fatalf("negative-horizon predict_linear MUST stay on the fan-out, but got a RangeWindowNative (Func=%q, Scalars=%v)",
+			native.Func, native.Scalars)
+	}
+	sqlStr, _, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	if !strings.Contains(sqlStr, "simpleLinearRegression") {
+		t.Errorf("negative-horizon predict_linear fan-out missing simpleLinearRegression:\n%s", sqlStr)
+	}
+	if strings.Contains(sqlStr, "timeSeriesPredictLinearToGrid(") {
+		t.Errorf("negative-horizon predict_linear must NOT emit the native aggregate:\n%s", sqlStr)
+	}
+}
+
 // TestNativeDerivPredictFeatureDisabledStaysFanout pins the default (feature
 // OFF) path: with the all-fan-out table, neither deriv nor predict_linear
 // produces a RangeWindowNative — the byte-identical fallback the < 25.9

--- a/internal/chsql/range_window_native_deriv_predict_test.go
+++ b/internal/chsql/range_window_native_deriv_predict_test.go
@@ -1,0 +1,225 @@
+package chsql_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	promparser "github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// This is the HOLLOW-GREEN GUARD for the native deriv / predict_linear
+// timeSeries*ToGrid lowerings. The CI chDB substrate is < 25.9, so the native
+// aggregates are ABSENT and every version-gated fixture falls back to the
+// fan-out — a broken native path would therefore stay invisible on chDB. These
+// tests force the feature ENABLED via the chopt EnabledSet's boot-wired
+// strategy (NOT a live server) and assert the feature ACTIVATES: the plan
+// carries a chplan.RangeWindowNative node and chsql.Emit renders the exact
+// native aggregate call with the correct parametric args. The native==fan-out
+// numeric differential is a prod/e2e concern above the chDB floor (documented
+// in docs/native-clickhouse.md), so it is deliberately NOT asserted here.
+//
+// The engine stamps allow_experimental_time_series_aggregate_functions=1 on any
+// plan carrying a RangeWindowNative node (internal/engine.planHasTSGridNative,
+// which is generic over the node TYPE, not the Func) — the companion assertion
+// that deriv / predict_linear ride that gate lives in
+// internal/engine/ts_grid_native_deriv_predict_test.go.
+
+const nativeDerivPredictRangeStep = 30 * time.Second
+
+// lowerRangeNative parses q, lowers it over the default OTel-CH schema in range
+// mode ([2026-01-01T00:00:00Z, +5m] step 30s) with the supplied boot-wired
+// strategy table, and returns the plan.
+func lowerRangeNative(t *testing.T, q string, lowerers promql.RangeLowerers) chplan.Node {
+	t.Helper()
+	p := promparser.NewParser(promparser.Options{EnableExperimentalFunctions: true})
+	expr, err := p.ParseExpr(q)
+	if err != nil {
+		t.Fatalf("parse %q: %v", q, err)
+	}
+	rangeStart := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	rangeEnd := rangeStart.Add(5 * time.Minute)
+	plan, err := promql.LowerAtRangeOpts(context.Background(), expr, schema.DefaultOTelMetrics(),
+		rangeStart, rangeEnd, nativeDerivPredictRangeStep, promql.LowerOpts{Lowerers: lowerers})
+	if err != nil {
+		t.Fatalf("lower %q: %v", q, err)
+	}
+	return plan
+}
+
+// findNativeNode returns the first chplan.RangeWindowNative in plan, or nil.
+func findNativeNode(plan chplan.Node) *chplan.RangeWindowNative {
+	var found *chplan.RangeWindowNative
+	chplan.Walk(plan, func(n chplan.Node) bool {
+		if found != nil {
+			return false
+		}
+		if rw, ok := n.(*chplan.RangeWindowNative); ok {
+			found = rw
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+func TestNativeDerivActivatesAndEmits(t *testing.T) {
+	t.Parallel()
+
+	lowerers := promql.RangeLowerers{
+		Deriv: promql.NativeDerivLowerer{Fallback: promql.FanoutDerivLowerer{}},
+	}
+	plan := lowerRangeNative(t, "sum by(host) (deriv(disk_used_bytes[5m]))", lowerers)
+
+	native := findNativeNode(plan)
+	if native == nil {
+		t.Fatalf("native deriv feature ENABLED but plan carries no RangeWindowNative — the feature is inert (hollow green): %s",
+			spineOfTypes(plan))
+	}
+	if native.Func != "deriv" {
+		t.Errorf("RangeWindowNative.Func = %q, want %q", native.Func, "deriv")
+	}
+	if len(native.Scalars) != 0 {
+		t.Errorf("deriv RangeWindowNative.Scalars = %v, want empty (deriv takes no scalar)", native.Scalars)
+	}
+
+	sqlStr, _, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	if !strings.Contains(sqlStr, "timeSeriesDerivToGrid(") {
+		t.Errorf("emitted SQL missing timeSeriesDerivToGrid( call — native emit is broken:\n%s", sqlStr)
+	}
+	// The shared (start, end, step_s, window_s) parametric prefix: step 30s,
+	// window 5m = 300s. deriv adds NO trailing param.
+	if !strings.Contains(sqlStr, "timeSeriesDerivToGrid(toDateTime(") {
+		t.Errorf("emitted SQL deriv call missing whole-second DateTime start bound:\n%s", sqlStr)
+	}
+	if !strings.Contains(sqlStr, ", 30, 300)(") {
+		t.Errorf("emitted SQL deriv call missing (step_s=30, window_s=300) params:\n%s", sqlStr)
+	}
+}
+
+func TestNativePredictLinearActivatesAndEmits(t *testing.T) {
+	t.Parallel()
+
+	lowerers := promql.RangeLowerers{
+		PredictLinear: promql.NativePredictLinearLowerer{Fallback: promql.FanoutPredictLinearLowerer{}},
+	}
+	plan := lowerRangeNative(t, "sum by(host) (predict_linear(disk_used_bytes[10m], 3600))", lowerers)
+
+	native := findNativeNode(plan)
+	if native == nil {
+		t.Fatalf("native predict_linear feature ENABLED but plan carries no RangeWindowNative — the feature is inert (hollow green): %s",
+			spineOfTypes(plan))
+	}
+	if native.Func != "predict_linear" {
+		t.Errorf("RangeWindowNative.Func = %q, want %q", native.Func, "predict_linear")
+	}
+	if len(native.Scalars) != 1 || native.Scalars[0] != 3600 {
+		t.Errorf("predict_linear RangeWindowNative.Scalars = %v, want [3600] (the whole-second horizon t)", native.Scalars)
+	}
+
+	sqlStr, _, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	if !strings.Contains(sqlStr, "timeSeriesPredictLinearToGrid(") {
+		t.Errorf("emitted SQL missing timeSeriesPredictLinearToGrid( call — native emit is broken:\n%s", sqlStr)
+	}
+	// The (start, end, step_s=30, window_s=600) prefix + the horizon t=3600 as
+	// the 5th parametric arg.
+	if !strings.Contains(sqlStr, ", 30, 600, 3600)(") {
+		t.Errorf("emitted SQL predict_linear call missing (step_s=30, window_s=600, predict_offset_s=3600) params:\n%s", sqlStr)
+	}
+}
+
+// TestNativePredictLinearFractionalFallsBack pins the eligibility carve-out: a
+// FRACTIONAL horizon t cannot ride timeSeriesPredictLinearToGrid's integer 5th
+// parametric arg, so even with the native feature ENABLED the lowering
+// delegates to the fan-out (exact `intercept + slope*t` Float64 arithmetic).
+func TestNativePredictLinearFractionalFallsBack(t *testing.T) {
+	t.Parallel()
+
+	lowerers := promql.RangeLowerers{
+		PredictLinear: promql.NativePredictLinearLowerer{Fallback: promql.FanoutPredictLinearLowerer{}},
+	}
+	plan := lowerRangeNative(t, "sum by(host) (predict_linear(disk_used_bytes[10m], 1.5))", lowerers)
+
+	if native := findNativeNode(plan); native != nil {
+		t.Fatalf("fractional-horizon predict_linear MUST stay on the fan-out, but got a RangeWindowNative (Func=%q, Scalars=%v)",
+			native.Func, native.Scalars)
+	}
+	sqlStr, _, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	if !strings.Contains(sqlStr, "simpleLinearRegression") {
+		t.Errorf("fractional-horizon predict_linear fan-out missing simpleLinearRegression:\n%s", sqlStr)
+	}
+	if strings.Contains(sqlStr, "timeSeriesPredictLinearToGrid(") {
+		t.Errorf("fractional-horizon predict_linear must NOT emit the native aggregate:\n%s", sqlStr)
+	}
+}
+
+// TestNativeDerivPredictFeatureDisabledStaysFanout pins the default (feature
+// OFF) path: with the all-fan-out table, neither deriv nor predict_linear
+// produces a RangeWindowNative — the byte-identical fallback the < 25.9
+// substrate runs.
+func TestNativeDerivPredictFeatureDisabledStaysFanout(t *testing.T) {
+	t.Parallel()
+
+	for _, q := range []string{
+		"sum by(host) (deriv(disk_used_bytes[5m]))",
+		"sum by(host) (predict_linear(disk_used_bytes[10m], 3600))",
+	} {
+		q := q
+		t.Run(q, func(t *testing.T) {
+			t.Parallel()
+			// Zero-value RangeLowerers => withDefaults => all fan-out.
+			plan := lowerRangeNative(t, q, promql.RangeLowerers{})
+			if native := findNativeNode(plan); native != nil {
+				t.Fatalf("feature OFF but %q produced a RangeWindowNative (Func=%q) — the default path must stay fan-out",
+					q, native.Func)
+			}
+			sqlStr, _, err := chsql.Emit(context.Background(), plan)
+			if err != nil {
+				t.Fatalf("emit: %v", err)
+			}
+			if !strings.Contains(sqlStr, "simpleLinearRegression") {
+				t.Errorf("feature-OFF %q fan-out missing simpleLinearRegression:\n%s", q, sqlStr)
+			}
+			if strings.Contains(sqlStr, "ToGrid(") {
+				t.Errorf("feature-OFF %q must NOT emit any native *ToGrid aggregate:\n%s", q, sqlStr)
+			}
+		})
+	}
+}
+
+// spineOfTypes renders a compact node-type spine of plan for failure messages
+// so a hollow-green failure shows WHAT shape leaked through instead of the
+// native node.
+func spineOfTypes(n chplan.Node) string {
+	var b strings.Builder
+	var walk func(chplan.Node, int)
+	walk = func(n chplan.Node, depth int) {
+		if n == nil {
+			return
+		}
+		b.WriteString(strings.Repeat("  ", depth))
+		fmt.Fprintf(&b, "%T", n)
+		b.WriteByte('\n')
+		for _, c := range n.Children() {
+			walk(c, depth+1)
+		}
+	}
+	walk(n, 0)
+	return b.String()
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -381,12 +381,13 @@ func clampU8(v int64) uint8 {
 // experimental timeSeries*ToGrid family anywhere in the tree — either a
 // chplan.RangeWindowNative (timeSeriesRateToGrid for Func="rate",
 // timeSeriesChangesToGrid for Func="changes", timeSeriesResetsToGrid for
-// Func="resets") or a chplan.RangeWindowResample
-// (timeSeriesResampleToGridWithStaleness). All share the
-// allow_experimental_time_series_aggregate_functions gate, so the engine stamps
-// the experimental setting on a query carrying ANY such node — the changes /
-// resets matrix functions ride the RangeWindowNative match with no engine
-// change.
+// Func="resets", timeSeriesDerivToGrid for Func="deriv",
+// timeSeriesPredictLinearToGrid for Func="predict_linear") or a
+// chplan.RangeWindowResample (timeSeriesResampleToGridWithStaleness). All share
+// the allow_experimental_time_series_aggregate_functions gate, so the engine
+// stamps the experimental setting on a query carrying ANY such node — the
+// changes / resets / deriv / predict_linear matrix functions ride the
+// RangeWindowNative match with no engine change.
 func planHasTSGridNative(plan chplan.Node) bool {
 	found := false
 	chplan.Walk(plan, func(n chplan.Node) bool {

--- a/internal/engine/ts_grid_native_deriv_predict_test.go
+++ b/internal/engine/ts_grid_native_deriv_predict_test.go
@@ -1,0 +1,61 @@
+package engine
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// TestPlanHasTSGridNativeDerivPredictLinear pins that a plan carrying a native
+// deriv / predict_linear RangeWindowNative trips the experimental-setting gate,
+// so the engine stamps allow_experimental_time_series_aggregate_functions=1 on
+// exactly those queries — the same gate the rate / changes / resets members
+// ride. The detector is generic over the node TYPE (not the Func), so this is
+// the companion to the promql/chsql hollow-green guard
+// (internal/chsql/range_window_native_deriv_predict_test.go): together they
+// prove the feature ACTIVATES end-to-end (native node emitted AND the setting
+// stamped), which the < 25.9 chDB substrate cannot show.
+func TestPlanHasTSGridNativeDerivPredictLinear(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(5 * time.Minute)
+
+	for _, fn := range []string{"deriv", "predict_linear"} {
+		fn := fn
+		t.Run(fn, func(t *testing.T) {
+			t.Parallel()
+			node := &chplan.RangeWindowNative{
+				Input:           &chplan.Scan{Table: "otel_metrics_gauge"},
+				Func:            fn,
+				Range:           5 * time.Minute,
+				Step:            30 * time.Second,
+				Start:           start,
+				End:             end,
+				TimestampColumn: "TimeUnix",
+				ValueColumn:     "Value",
+			}
+			if fn == "predict_linear" {
+				node.Scalars = []float64{3600}
+			}
+			// Wrap it the way the real plan does (a Project over the native node)
+			// to prove the walk finds it below the root, not just at the root.
+			plan := &chplan.Project{Input: node}
+
+			if !planHasTSGridNative(plan) {
+				t.Fatalf("planHasTSGridNative == false for a native %s plan — the experimental setting would NOT be stamped", fn)
+			}
+
+			// The setting the gate stamps must be the canonical experimental one.
+			ctx := chclient.WithTSGridSetting(context.Background())
+			settings := chclient.QuerySettingsFromContext(ctx)
+			if v, ok := settings[chclient.SettingExperimentalTSGridAggregate]; !ok || v != 1 {
+				t.Fatalf("expected %s=1 stamped, got %v (present=%v)",
+					chclient.SettingExperimentalTSGridAggregate, v, ok)
+			}
+		})
+	}
+}

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -1954,6 +1954,8 @@ func lowerRangeVectorCall(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chpla
 			node = ctx.lowerers.Changes.LowerChanges(rw, s)
 		case "resets":
 			node = ctx.lowerers.Resets.LowerResets(rw, s)
+		case "deriv":
+			node = ctx.lowerers.Deriv.LowerDeriv(rw, s)
 		default:
 			node = ctx.lowerers.Rate.LowerRate(rw, s)
 		}
@@ -2077,6 +2079,12 @@ func nativeTSGridMatrixNode(rw *chplan.RangeWindow, wantFunc string, s schema.Me
 		TimestampColumn: rw.TimestampColumn,
 		ValueColumn:     rw.ValueColumn,
 		GroupBy:         rw.GroupBy,
+		// Scalars carries predict_linear's literal horizon t (empty for
+		// rate/changes/resets/deriv). The native emitter threads it into
+		// timeSeriesPredictLinearToGrid's 5th parametric arg; the caller
+		// (NativePredictLinearLowerer) gates eligibility to a whole-second
+		// literal before reaching here, so any element present is native-safe.
+		Scalars: rw.Scalars,
 	}
 }
 

--- a/internal/promql/lower_strategy.go
+++ b/internal/promql/lower_strategy.go
@@ -1,6 +1,7 @@
 package promql
 
 import (
+	"math"
 	"time"
 
 	"github.com/tsouza/cerberus/internal/chplan"
@@ -109,6 +110,33 @@ type ResetsLowerer interface {
 	LowerResets(rw *chplan.RangeWindow, s schema.Metrics) chplan.Node
 }
 
+// DerivLowerer lowers a range-mode deriv(<gauge>[range]) RangeWindow to a
+// chplan node, mirroring [ChangesLowerer]: the native impl emits a
+// RangeWindowNative (Func="deriv" -> timeSeriesDerivToGrid, the per-window
+// simple-linear-regression slope) for an eligible window, the fan-out fallback
+// otherwise. It never returns nil.
+type DerivLowerer interface {
+	// LowerDeriv returns the chplan node for rw — the native RangeWindowNative
+	// for a shape the impl handles, or the fan-out lowering otherwise. It never
+	// returns nil.
+	LowerDeriv(rw *chplan.RangeWindow, s schema.Metrics) chplan.Node
+}
+
+// PredictLinearLowerer lowers a range-mode predict_linear(<gauge>[range], t)
+// RangeWindow to a chplan node, mirroring [ChangesLowerer]: the native impl
+// emits a RangeWindowNative (Func="predict_linear" ->
+// timeSeriesPredictLinearToGrid, the per-window slope*t + intercept forecast)
+// for an eligible window, the fan-out fallback otherwise. Only a single
+// whole-second literal horizon t is native-eligible — the aggregate's 5th
+// parametric arg is a constant, so computed / fractional horizons delegate to
+// the fan-out. It never returns nil.
+type PredictLinearLowerer interface {
+	// LowerPredictLinear returns the chplan node for rw — the native
+	// RangeWindowNative for a shape the impl handles, or the fan-out lowering
+	// otherwise. It never returns nil.
+	LowerPredictLinear(rw *chplan.RangeWindow, s schema.Metrics) chplan.Node
+}
+
 // RangeLowerers is the boot-wired dispatch table the lowering reads. Each field
 // is the CONCRETE strategy for one promql function family, decided once at
 // boot. Every field is ALWAYS non-nil on the lowering path — a fan-out-only
@@ -133,6 +161,14 @@ type RangeLowerers struct {
 	// timeSeriesResetsToGrid, server >= 25.9). Concrete fan-out impl when the
 	// native path is off; never nil on the lowering path.
 	Resets ResetsLowerer
+	// Deriv handles range-mode deriv(...) shapes (native timeSeriesDerivToGrid,
+	// server >= 25.9). Concrete fan-out impl when the native path is off; never
+	// nil on the lowering path.
+	Deriv DerivLowerer
+	// PredictLinear handles range-mode predict_linear(..., t) shapes (native
+	// timeSeriesPredictLinearToGrid, server >= 25.9). Concrete fan-out impl when
+	// the native path is off; never nil on the lowering path.
+	PredictLinear PredictLinearLowerer
 }
 
 // withDefaults returns a copy of l with any nil strategy field filled with its
@@ -153,6 +189,12 @@ func (l RangeLowerers) withDefaults() RangeLowerers {
 	}
 	if l.Resets == nil {
 		l.Resets = FanoutResetsLowerer{}
+	}
+	if l.Deriv == nil {
+		l.Deriv = FanoutDerivLowerer{}
+	}
+	if l.PredictLinear == nil {
+		l.PredictLinear = FanoutPredictLinearLowerer{}
 	}
 	return l
 }
@@ -312,4 +354,91 @@ func (n NativeResetsLowerer) LowerResets(rw *chplan.RangeWindow, s schema.Metric
 		return native
 	}
 	return n.Fallback.LowerResets(rw, s)
+}
+
+// FanoutDerivLowerer is the concrete DEFAULT DerivLowerer: it returns the
+// generic fan-out RangeWindow (the simpleLinearRegression slope) unchanged. It
+// is the fallback the native impl embeds AND the strategy a fan-out-only
+// deployment wires directly.
+type FanoutDerivLowerer struct{}
+
+// LowerDeriv returns the fan-out RangeWindow rw unchanged.
+func (FanoutDerivLowerer) LowerDeriv(rw *chplan.RangeWindow, _ schema.Metrics) chplan.Node {
+	return rw
+}
+
+// NativeDerivLowerer is the boot-wired DerivLowerer that emits the native
+// timeSeriesDerivToGrid lowering (a chplan.RangeWindowNative with Func="deriv")
+// for shape-eligible deriv range-windows. cmd/cerberus wires it ONLY when the
+// chopt resolved the ts_grid_deriv feature (server >= 25.9) at boot. It embeds
+// a concrete Fallback for shapes it cannot handle, so the interface method
+// always yields a valid lowering and the dispatch site stays branch-free.
+type NativeDerivLowerer struct {
+	// Fallback is the concrete lowerer for shapes the native path cannot
+	// handle. Boot wires it to FanoutDerivLowerer{}.
+	Fallback DerivLowerer
+}
+
+// LowerDeriv returns a RangeWindowNative for an eligible range-mode deriv
+// shape, or delegates to the embedded Fallback otherwise. Same intrinsic SHAPE
+// check as changes/resets (deriv func, materialised grid, plain Scan/Filter
+// input) — deriv takes no scalar, so no extra parameter gate applies.
+func (n NativeDerivLowerer) LowerDeriv(rw *chplan.RangeWindow, s schema.Metrics) chplan.Node {
+	if native := nativeTSGridMatrixNode(rw, "deriv", s); native != nil {
+		return native
+	}
+	return n.Fallback.LowerDeriv(rw, s)
+}
+
+// FanoutPredictLinearLowerer is the concrete DEFAULT PredictLinearLowerer: it
+// returns the generic fan-out RangeWindow (the simpleLinearRegression
+// intercept + slope*t forecast) unchanged. It is the fallback the native impl
+// embeds AND the strategy a fan-out-only deployment wires directly.
+type FanoutPredictLinearLowerer struct{}
+
+// LowerPredictLinear returns the fan-out RangeWindow rw unchanged.
+func (FanoutPredictLinearLowerer) LowerPredictLinear(rw *chplan.RangeWindow, _ schema.Metrics) chplan.Node {
+	return rw
+}
+
+// NativePredictLinearLowerer is the boot-wired PredictLinearLowerer that emits
+// the native timeSeriesPredictLinearToGrid lowering (a chplan.RangeWindowNative
+// with Func="predict_linear") for shape-eligible predict_linear range-windows.
+// cmd/cerberus wires it ONLY when the chopt resolved the ts_grid_predict_linear
+// feature (server >= 25.9) at boot. It embeds a concrete Fallback for shapes it
+// cannot handle, so the interface method always yields a valid lowering and the
+// dispatch site stays branch-free.
+type NativePredictLinearLowerer struct {
+	// Fallback is the concrete lowerer for shapes the native path cannot
+	// handle. Boot wires it to FanoutPredictLinearLowerer{}.
+	Fallback PredictLinearLowerer
+}
+
+// LowerPredictLinear returns a RangeWindowNative for an eligible range-mode
+// predict_linear shape, or delegates to the embedded Fallback otherwise. On top
+// of the shared shape check (predict_linear func, materialised grid, plain
+// Scan/Filter input) the horizon t must be a single whole-second literal:
+// timeSeriesPredictLinearToGrid takes the offset as its 5th parametric arg (a
+// constant), so a computed horizon (ScalarExprs) or a fractional t cannot ride
+// the native aggregate and stays on the exact fan-out arithmetic.
+func (n NativePredictLinearLowerer) LowerPredictLinear(rw *chplan.RangeWindow, s schema.Metrics) chplan.Node {
+	if nativePredictLinearHorizonEligible(rw) {
+		if native := nativeTSGridMatrixNode(rw, "predict_linear", s); native != nil {
+			return native
+		}
+	}
+	return n.Fallback.LowerPredictLinear(rw, s)
+}
+
+// nativePredictLinearHorizonEligible reports whether rw's predict_linear
+// horizon t can be threaded into timeSeriesPredictLinearToGrid's 5th parametric
+// arg: exactly one literal scalar (no computed ScalarExprs) whose value is a
+// whole number of seconds. A fractional or computed horizon is byte-exact only
+// on the fan-out's `intercept + slope*t` Float64 arithmetic, so it delegates.
+func nativePredictLinearHorizonEligible(rw *chplan.RangeWindow) bool {
+	if len(rw.ScalarExprs) != 0 || len(rw.Scalars) != 1 {
+		return false
+	}
+	t := rw.Scalars[0]
+	return t == math.Trunc(t)
 }

--- a/internal/promql/lower_strategy.go
+++ b/internal/promql/lower_strategy.go
@@ -433,12 +433,17 @@ func (n NativePredictLinearLowerer) LowerPredictLinear(rw *chplan.RangeWindow, s
 // nativePredictLinearHorizonEligible reports whether rw's predict_linear
 // horizon t can be threaded into timeSeriesPredictLinearToGrid's 5th parametric
 // arg: exactly one literal scalar (no computed ScalarExprs) whose value is a
-// whole number of seconds. A fractional or computed horizon is byte-exact only
-// on the fan-out's `intercept + slope*t` Float64 arithmetic, so it delegates.
+// non-negative whole number of seconds. A fractional or computed horizon is
+// byte-exact only on the fan-out's `intercept + slope*t` Float64 arithmetic, so
+// it delegates. A negative t (legal PromQL backward projection) also delegates:
+// the aggregate's predict_offset parameter is not verified to accept a signed
+// offset on the >= 25.9 substrate, and the fan-out's `intercept + slope*t`
+// evaluates negative t exactly, so the native path stays inside the verified
+// non-negative domain rather than risk a signed-literal rejection at query time.
 func nativePredictLinearHorizonEligible(rw *chplan.RangeWindow) bool {
 	if len(rw.ScalarExprs) != 0 || len(rw.Scalars) != 1 {
 		return false
 	}
 	t := rw.Scalars[0]
-	return t == math.Trunc(t)
+	return t >= 0 && t == math.Trunc(t)
 }

--- a/internal/promql/lower_test.go
+++ b/internal/promql/lower_test.go
@@ -109,9 +109,12 @@ func TestLower(t *testing.T) {
 				// native-staleness strategy (timeSeriesResampleToGridWithStaleness);
 				// `experimental_ts_grid_changes:` wires NativeChangesLowerer
 				// (timeSeriesChangesToGrid); `experimental_ts_grid_resets:` wires
-				// NativeResetsLowerer (timeSeriesResetsToGrid). Without any of
-				// these sections the default all-fan-out table is used, so every
-				// existing fixture stays byte-identical.
+				// NativeResetsLowerer (timeSeriesResetsToGrid);
+				// `experimental_ts_grid_deriv:` wires NativeDerivLowerer
+				// (timeSeriesDerivToGrid); `experimental_ts_grid_predict_linear:`
+				// wires NativePredictLinearLowerer (timeSeriesPredictLinearToGrid).
+				// Without any of these sections the default all-fan-out table is
+				// used, so every existing fixture stays byte-identical.
 				var lowerers promql.RangeLowerers
 				if _, native := c.Section("experimental_ts_grid_range"); native {
 					lowerers.Rate = promql.NativeRateLowerer{Fallback: promql.FanoutRateLowerer{}}
@@ -124,6 +127,12 @@ func TestLower(t *testing.T) {
 				}
 				if _, resets := c.Section("experimental_ts_grid_resets"); resets {
 					lowerers.Resets = promql.NativeResetsLowerer{Fallback: promql.FanoutResetsLowerer{}}
+				}
+				if _, deriv := c.Section("experimental_ts_grid_deriv"); deriv {
+					lowerers.Deriv = promql.NativeDerivLowerer{Fallback: promql.FanoutDerivLowerer{}}
+				}
+				if _, predict := c.Section("experimental_ts_grid_predict_linear"); predict {
+					lowerers.PredictLinear = promql.NativePredictLinearLowerer{Fallback: promql.FanoutPredictLinearLowerer{}}
 				}
 				plan, err = promql.LowerAtRangeOpts(context.Background(), expr, s, rangeStart, rangeEnd, stepDur,
 					promql.LowerOpts{Lowerers: lowerers})

--- a/internal/promql/range_fns.go
+++ b/internal/promql/range_fns.go
@@ -85,7 +85,14 @@ func lowerPredictLinear(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.
 		rw.Step = ctx.step
 		rw.OuterRange = ctx.end.Sub(ctx.start)
 	}
-	return rw, nil
+	// Route through the boot-wired PredictLinear strategy: the native impl
+	// emits a RangeWindowNative (timeSeriesPredictLinearToGrid) for an eligible
+	// range-mode window with a whole-second literal horizon, the fan-out impl
+	// returns rw unchanged. The feature/version decision lives in WHICH strategy
+	// cmd/cerberus wired — there is NO feature-flag / version read here, and the
+	// strategy always returns a valid lowering (never nil). Mirrors the
+	// rate/changes/resets dispatch in lowerRangeVectorCall.
+	return ctx.lowerers.PredictLinear.LowerPredictLinear(rw, s), nil
 }
 
 // lowerHoltWinters handles `holt_winters(v range-vector, sf scalar, tf

--- a/test/perf/cardinality-baseline.json
+++ b/test/perf/cardinality-baseline.json
@@ -3750,6 +3750,16 @@
     "max_recursion_depth": 0
   },
   {
+    "fixture": "promql/native_predict_linear_negative_horizon_fanout",
+    "fan_factor": 9,
+    "scan_rows": 5,
+    "peak_intermediate": 45,
+    "has_cross_join": false,
+    "has_array_join": true,
+    "has_recursive_cte": false,
+    "max_recursion_depth": 0
+  },
+  {
     "fixture": "promql/native_rate_range_step",
     "fan_factor": 1.5,
     "scan_rows": 12,

--- a/test/perf/solver-decision-baseline.json
+++ b/test/perf/solver-decision-baseline.json
@@ -1332,6 +1332,18 @@
     "reason": "routed"
   },
   {
+    "query": "native_deriv_range_step",
+    "routed": true,
+    "k": 8,
+    "reason": "routed"
+  },
+  {
+    "query": "native_predict_linear_range_step",
+    "routed": true,
+    "k": 6,
+    "reason": "routed"
+  },
+  {
     "query": "native_rate_range_step",
     "routed": true,
     "k": 8,

--- a/test/perf/solver-decision-baseline.json
+++ b/test/perf/solver-decision-baseline.json
@@ -1338,6 +1338,12 @@
     "reason": "routed"
   },
   {
+    "query": "native_predict_linear_negative_horizon_fanout",
+    "routed": true,
+    "k": 6,
+    "reason": "routed"
+  },
+  {
     "query": "native_predict_linear_range_step",
     "routed": true,
     "k": 6,

--- a/test/spec/promql/native_deriv_range_step.txtar
+++ b/test/spec/promql/native_deriv_range_step.txtar
@@ -1,0 +1,69 @@
+# Experimental: ClickHouse-native timeSeriesDerivToGrid lowering for
+# `sum by (X) (deriv(gauge[range]))` in range mode (Step > 0). This is the
+# always-on SQL-shape coverage floor for the `ts_grid_deriv` feature: the
+# `experimental_ts_grid_deriv` section opts the fixture into
+# RangeLowerers.Deriv = NativeDerivLowerer, so the lowering emits a
+# chplan.RangeWindowNative (Func=deriv -> timeSeriesDerivToGrid parametric
+# aggregate + parallel timeSeriesRange axis + ARRAY JOIN + IS NOT NULL filter)
+# instead of the simpleLinearRegression/arrayReduce fan-out. The wrapping
+# outer-sum Aggregate is byte-identical to the fan-out; only the windowed
+# per-grid-point subquery differs.
+#
+# VERSION FLOOR 25.9 (registry-pinned). timeSeriesDerivToGrid shipped in
+# PR #84328 (ClickHouse 25.8), one quarter before changes/resets, but the chopt
+# registry pins the whole family to a single 25.9 capability verdict — the
+# shared left-open-window fix (PR #86588) — so a sub-25.9 substrate stays on the
+# fan-out. The native SQL below is a SHAPE golden pinned unconditionally; the
+# native==fan-out numeric differential is proven on a >= 25.9 server (prod/e2e
+# lane), not on the current chDB substrate.
+#
+# deriv() is the per-second slope of a least-squares linear fit over the samples
+# in the window. Native timeSeriesDerivToGrid returns NULL for a window with
+# < 2 samples, filtered to ABSENT rows by `WHERE grid_val IS NOT NULL`,
+# mirroring the fan-out's `length(window_pairs) >= 2` + NaN-drop guard.
+
+-- query.promql --
+sum by(host) (deriv(disk_used_bytes[5m]))
+-- range_step --
+30s
+-- experimental_ts_grid_deriv --
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+  MetricName String,
+  Attributes Map(String, String),
+  ResourceAttributes Map(String, String) DEFAULT map(),
+  TimeUnix DateTime64(9),
+  Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+-- ramp: value increases 100 every 30 seconds -> slope 10/3 per second.
+INSERT INTO otel_metrics_gauge (MetricName, Attributes, TimeUnix, Value) VALUES
+  ('disk_used_bytes', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 100.0),
+  ('disk_used_bytes', map('host', 'a'), toDateTime64('2026-01-01 00:00:30', 9), 200.0),
+  ('disk_used_bytes', map('host', 'a'), toDateTime64('2026-01-01 00:01:00', 9), 300.0),
+  ('disk_used_bytes', map('host', 'a'), toDateTime64('2026-01-01 00:01:30', 9), 400.0),
+  ('disk_used_bytes', map('host', 'a'), toDateTime64('2026-01-01 00:02:00', 9), 500.0);
+-- args --
+[0] string = ""
+[1] string = "host"
+[2] string = "host"
+[3] string = "service.name"
+[4] string = "service_name"
+[5] string = "service.name"
+[6] string = "service_name"
+[7] string = "disk_used_bytes"
+[8] string = "disk.used.bytes"
+[9] string = "disk.used/bytes"
+[10] string = "disk.used_bytes"
+[11] string = "disk/used/bytes"
+[12] string = "disk/used_bytes"
+[13] string = "disk_used.bytes"
+[14] string = "host"
+-- chplan --
+Project ["" AS MetricName, mapWithoutEmpty(map("host", gkey_0)) AS Attributes, bucket_ts AS TimeUnix, Value AS Value]
+  Aggregate groupBy=[Attributes["host"] AS gkey_0, TimeUnix AS bucket_ts] funcs=[sum(Value) AS Value]
+    RangeWindowNative func=deriv range=5m0s step=30s ts=TimeUnix value=Value groupBy=[Attributes] start=2026-01-01T00:00:00Z end=2026-01-01T00:05:00Z
+      Project [MetricName AS MetricName, mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))) AS Attributes, TimeUnix AS TimeUnix, Value AS Value]
+        Filter predicate=(MetricName IN ("disk_used_bytes", "disk.used.bytes", "disk.used/bytes", "disk.used_bytes", "disk/used/bytes", "disk/used_bytes", "disk_used.bytes"))
+          Scan(merge(otel_metrics_gauge|otel_metrics_sum))
+-- sql --
+SELECT ? AS `MetricName`, mapFilter((k, v) -> v != '', map(?, `gkey_0`)) AS `Attributes`, `bucket_ts` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Attributes`[?] AS `gkey_0`, `TimeUnix` AS `bucket_ts`, sum(`Value`) AS `Value` FROM (SELECT `Attributes`, toDateTime64(`anchor_ts`, 9) AS `anchor_ts`, toDateTime64(`anchor_ts`, 9) AS `TimeUnix`, toFloat64(assumeNotNull(`grid_val`)) AS `Value` FROM (SELECT `Attributes`, timeSeriesDerivToGrid(toDateTime(1767225600, 'UTC'), toDateTime(1767225900, 'UTC'), 30, 300)(`TimeUnix`, `Value`) AS `grid`, timeSeriesRange(toDateTime(1767225600, 'UTC'), toDateTime(1767225900, 'UTC'), 30) AS `grid_ts` FROM (SELECT `MetricName` AS `MetricName`, mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') WHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?)))) WHERE `TimeUnix` > toDateTime64('2026-01-01 00:00:00.000000000', 9) - toIntervalNanosecond(300000000000) AND `TimeUnix` <= toDateTime64('2026-01-01 00:05:00.000000000', 9) GROUP BY `Attributes`) ARRAY JOIN `grid` AS `grid_val`, `grid_ts` AS `anchor_ts` WHERE `grid_val` IS NOT NULL) GROUP BY `Attributes`[?], `TimeUnix`)

--- a/test/spec/promql/native_predict_linear_negative_horizon_fanout.txtar
+++ b/test/spec/promql/native_predict_linear_negative_horizon_fanout.txtar
@@ -1,0 +1,80 @@
+# Negative-horizon guard for the ClickHouse-native timeSeriesPredictLinearToGrid
+# lowering. This fixture opts INTO the feature (the
+# `experimental_ts_grid_predict_linear` section installs
+# RangeLowerers.PredictLinear = NativePredictLinearLowerer), yet the query uses a
+# NEGATIVE horizon t (-3600s, a legal PromQL backward projection), so lowering
+# MUST fall back to the simpleLinearRegression/arrayReduce fan-out (a plain
+# chplan.RangeWindow, NOT a RangeWindowNative).
+#
+# Why the fallback: timeSeriesPredictLinearToGrid threads t as its 5th parametric
+# (predict_offset) arg, and that parameter is not verified to accept a signed
+# offset on the >= 25.9 substrate. A negative literal spliced into the aggregate
+# would be a silent query-time rejection the sub-25.9 chDB CI cannot catch, so
+# nativePredictLinearHorizonEligible pins the native path to the non-negative
+# whole-second domain. The fan-out's `intercept + slope*t` evaluates negative t
+# byte-exactly, so the result is correct — this fixture roundtrips it on chDB to
+# prove the backward projection still computes.
+#
+# Sibling of native_predict_linear_range_step.txtar (which exercises the native
+# path with a non-negative t) and predict_linear_scalar_horizon.txtar (the
+# computed-horizon fan-out shape).
+
+-- query.promql --
+sum by(host) (predict_linear(disk_used_bytes[10m], -3600))
+-- range_step --
+30s
+-- experimental_ts_grid_predict_linear --
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+  MetricName String,
+  Attributes Map(String, String),
+  ResourceAttributes Map(String, String) DEFAULT map(),
+  TimeUnix DateTime64(9),
+  Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+-- ramp: value increases 100 every 30 seconds -> slope 10/3 per second.
+INSERT INTO otel_metrics_gauge (MetricName, Attributes, TimeUnix, Value) VALUES
+  ('disk_used_bytes', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 100.0),
+  ('disk_used_bytes', map('host', 'a'), toDateTime64('2026-01-01 00:00:30', 9), 200.0),
+  ('disk_used_bytes', map('host', 'a'), toDateTime64('2026-01-01 00:01:00', 9), 300.0),
+  ('disk_used_bytes', map('host', 'a'), toDateTime64('2026-01-01 00:01:30', 9), 400.0),
+  ('disk_used_bytes', map('host', 'a'), toDateTime64('2026-01-01 00:02:00', 9), 500.0);
+-- expected_rows --
+[
+  ["", {"host": "a"}, "2026-01-01T00:00:30Z", -11800],
+  ["", {"host": "a"}, "2026-01-01T00:01:00Z", -11700],
+  ["", {"host": "a"}, "2026-01-01T00:01:30Z", -11600],
+  ["", {"host": "a"}, "2026-01-01T00:02:00Z", -11500],
+  ["", {"host": "a"}, "2026-01-01T00:02:30Z", -11400],
+  ["", {"host": "a"}, "2026-01-01T00:03:00Z", -11300],
+  ["", {"host": "a"}, "2026-01-01T00:03:30Z", -11200],
+  ["", {"host": "a"}, "2026-01-01T00:04:00Z", -11100],
+  ["", {"host": "a"}, "2026-01-01T00:04:30Z", -11000],
+  ["", {"host": "a"}, "2026-01-01T00:05:00Z", -10900]
+]
+-- args --
+[0] string = ""
+[1] string = "host"
+[2] string = "host"
+[3] float64 = -3600
+[4] string = "service.name"
+[5] string = "service_name"
+[6] string = "service.name"
+[7] string = "service_name"
+[8] string = "disk_used_bytes"
+[9] string = "disk.used.bytes"
+[10] string = "disk.used/bytes"
+[11] string = "disk.used_bytes"
+[12] string = "disk/used/bytes"
+[13] string = "disk/used_bytes"
+[14] string = "disk_used.bytes"
+[15] string = "host"
+-- chplan --
+Project ["" AS MetricName, mapWithoutEmpty(map("host", gkey_0)) AS Attributes, bucket_ts AS TimeUnix, Value AS Value]
+  Aggregate groupBy=[Attributes["host"] AS gkey_0, TimeUnix AS bucket_ts] funcs=[sum(Value) AS Value]
+    RangeWindow func=predict_linear range=10m0s step=30s outerRange=5m0s ts=TimeUnix value=Value groupBy=[Attributes] scalars=[-3600] start=2026-01-01T00:00:00Z end=2026-01-01T00:05:00Z
+      Project [MetricName AS MetricName, mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))) AS Attributes, TimeUnix AS TimeUnix, Value AS Value]
+        Filter predicate=(MetricName IN ("disk_used_bytes", "disk.used.bytes", "disk.used/bytes", "disk.used_bytes", "disk/used/bytes", "disk/used_bytes", "disk_used.bytes"))
+          Scan(merge(otel_metrics_gauge|otel_metrics_sum))
+-- sql --
+SELECT ? AS `MetricName`, mapFilter((k, v) -> v != '', map(?, `gkey_0`)) AS `Attributes`, `bucket_ts` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Attributes`[?] AS `gkey_0`, `TimeUnix` AS `bucket_ts`, sum(`Value`) AS `Value` FROM (SELECT `Attributes`, `anchor_ts`, anchor_ts AS `TimeUnix`, if(length(window_pairs) > 1, tupleElement(arrayReduce('simpleLinearRegression', arrayMap(p -> dateDiff('second', anchor_ts, tupleElement(p, 1)), window_pairs), arrayMap(p -> tupleElement(p, 2), window_pairs)), 2) + tupleElement(arrayReduce('simpleLinearRegression', arrayMap(p -> dateDiff('second', anchor_ts, tupleElement(p, 1)), window_pairs), arrayMap(p -> tupleElement(p, 2), window_pairs)), 1) * ?, nan) AS Value FROM (SELECT `Attributes`, `anchor_ts`, arraySort(groupArray((`TimeUnix`, `Value`))) AS window_pairs FROM (SELECT `Attributes`, `TimeUnix`, `Value`, arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:05:00.000000000', 9) - toIntervalNanosecond(i * 30000000000), range(greatest(0, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 600000000000, toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 600000000000, toInt64(30000000000)) < 0) + 1), least(11, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)), toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)), toInt64(30000000000)) < 0) + 1)))) AS anchor_ts FROM (SELECT `MetricName` AS `MetricName`, mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') WHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?)))) WHERE `TimeUnix` > toDateTime64('2026-01-01 00:00:00.000000000', 9) - toIntervalNanosecond(600000000000) AND `TimeUnix` <= toDateTime64('2026-01-01 00:05:00.000000000', 9)) GROUP BY `Attributes`, `anchor_ts`) WHERE length(`window_pairs`) >= 2) GROUP BY `Attributes`[?], `TimeUnix`)

--- a/test/spec/promql/native_predict_linear_range_step.txtar
+++ b/test/spec/promql/native_predict_linear_range_step.txtar
@@ -1,0 +1,79 @@
+# Experimental: ClickHouse-native timeSeriesPredictLinearToGrid lowering for
+# `sum by (X) (predict_linear(gauge[range], t))` in range mode (Step > 0). This
+# is the always-on SQL-shape coverage floor for the `ts_grid_predict_linear`
+# feature: the `experimental_ts_grid_predict_linear` section opts the fixture
+# into RangeLowerers.PredictLinear = NativePredictLinearLowerer, so the lowering
+# emits a chplan.RangeWindowNative (Func=predict_linear ->
+# timeSeriesPredictLinearToGrid parametric aggregate + parallel timeSeriesRange
+# axis + ARRAY JOIN + IS NOT NULL filter) instead of the
+# simpleLinearRegression/arrayReduce fan-out. The wrapping outer-sum Aggregate
+# is byte-identical to the fan-out; only the windowed per-grid-point subquery
+# differs.
+#
+# The horizon t (3600s here) is threaded as the aggregate's 5th parametric arg:
+# timeSeriesPredictLinearToGrid(start, end, step_s, window_s, predict_offset_s).
+# ONLY a single whole-second literal t is native-eligible — the parametric arg
+# is a constant, so a computed horizon (`predict_linear(v[r], scalar(x))`) or a
+# fractional t delegates to the fan-out's exact `intercept + slope*t` Float64
+# arithmetic (see predict_linear_scalar_horizon.txtar for the computed shape,
+# which stays fan-out even with the feature on).
+#
+# VERSION FLOOR 25.9 (registry-pinned). timeSeriesPredictLinearToGrid shipped in
+# PR #84328 (ClickHouse 25.8), sibling of timeSeriesDerivToGrid, but the chopt
+# registry pins the whole family to a single 25.9 capability verdict — the
+# shared left-open-window fix (PR #86588) — so a sub-25.9 substrate stays on the
+# fan-out. The native SQL below is a SHAPE golden pinned unconditionally; the
+# native==fan-out numeric differential is proven on a >= 25.9 server (prod/e2e
+# lane), not on the current chDB substrate.
+#
+# predict_linear() fits a least-squares line over the window and projects it t
+# seconds past the anchor (slope*t + intercept). Native
+# timeSeriesPredictLinearToGrid returns NULL for a window with < 2 samples,
+# filtered to ABSENT rows by `WHERE grid_val IS NOT NULL`, mirroring the
+# fan-out's `length(window_pairs) >= 2` + NaN-drop guard.
+
+-- query.promql --
+sum by(host) (predict_linear(disk_used_bytes[10m], 3600))
+-- range_step --
+30s
+-- experimental_ts_grid_predict_linear --
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+  MetricName String,
+  Attributes Map(String, String),
+  ResourceAttributes Map(String, String) DEFAULT map(),
+  TimeUnix DateTime64(9),
+  Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+-- ramp: value increases 100 every 30 seconds -> slope 10/3 per second.
+INSERT INTO otel_metrics_gauge (MetricName, Attributes, TimeUnix, Value) VALUES
+  ('disk_used_bytes', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 100.0),
+  ('disk_used_bytes', map('host', 'a'), toDateTime64('2026-01-01 00:00:30', 9), 200.0),
+  ('disk_used_bytes', map('host', 'a'), toDateTime64('2026-01-01 00:01:00', 9), 300.0),
+  ('disk_used_bytes', map('host', 'a'), toDateTime64('2026-01-01 00:01:30', 9), 400.0),
+  ('disk_used_bytes', map('host', 'a'), toDateTime64('2026-01-01 00:02:00', 9), 500.0);
+-- args --
+[0] string = ""
+[1] string = "host"
+[2] string = "host"
+[3] string = "service.name"
+[4] string = "service_name"
+[5] string = "service.name"
+[6] string = "service_name"
+[7] string = "disk_used_bytes"
+[8] string = "disk.used.bytes"
+[9] string = "disk.used/bytes"
+[10] string = "disk.used_bytes"
+[11] string = "disk/used/bytes"
+[12] string = "disk/used_bytes"
+[13] string = "disk_used.bytes"
+[14] string = "host"
+-- chplan --
+Project ["" AS MetricName, mapWithoutEmpty(map("host", gkey_0)) AS Attributes, bucket_ts AS TimeUnix, Value AS Value]
+  Aggregate groupBy=[Attributes["host"] AS gkey_0, TimeUnix AS bucket_ts] funcs=[sum(Value) AS Value]
+    RangeWindowNative func=predict_linear range=10m0s step=30s ts=TimeUnix value=Value groupBy=[Attributes] start=2026-01-01T00:00:00Z end=2026-01-01T00:05:00Z
+      Project [MetricName AS MetricName, mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))) AS Attributes, TimeUnix AS TimeUnix, Value AS Value]
+        Filter predicate=(MetricName IN ("disk_used_bytes", "disk.used.bytes", "disk.used/bytes", "disk.used_bytes", "disk/used/bytes", "disk/used_bytes", "disk_used.bytes"))
+          Scan(merge(otel_metrics_gauge|otel_metrics_sum))
+-- sql --
+SELECT ? AS `MetricName`, mapFilter((k, v) -> v != '', map(?, `gkey_0`)) AS `Attributes`, `bucket_ts` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Attributes`[?] AS `gkey_0`, `TimeUnix` AS `bucket_ts`, sum(`Value`) AS `Value` FROM (SELECT `Attributes`, toDateTime64(`anchor_ts`, 9) AS `anchor_ts`, toDateTime64(`anchor_ts`, 9) AS `TimeUnix`, toFloat64(assumeNotNull(`grid_val`)) AS `Value` FROM (SELECT `Attributes`, timeSeriesPredictLinearToGrid(toDateTime(1767225600, 'UTC'), toDateTime(1767225900, 'UTC'), 30, 600, 3600)(`TimeUnix`, `Value`) AS `grid`, timeSeriesRange(toDateTime(1767225600, 'UTC'), toDateTime(1767225900, 'UTC'), 30) AS `grid_ts` FROM (SELECT `MetricName` AS `MetricName`, mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') WHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?)))) WHERE `TimeUnix` > toDateTime64('2026-01-01 00:00:00.000000000', 9) - toIntervalNanosecond(600000000000) AND `TimeUnix` <= toDateTime64('2026-01-01 00:05:00.000000000', 9) GROUP BY `Attributes`) ARRAY JOIN `grid` AS `grid_val`, `grid_ts` AS `anchor_ts` WHERE `grid_val` IS NOT NULL) GROUP BY `Attributes`[?], `TimeUnix`)


### PR DESCRIPTION
## What

Adopts the **last two unadopted members** of the `timeSeries*ToGrid` family as boot-resolved chopt features:

- `deriv(<gauge>[<range>])` → native **`timeSeriesDerivToGrid`** (per-window least-squares slope)
- `predict_linear(<gauge>[<range>], t)` → native **`timeSeriesPredictLinearToGrid`** (per-window `slope*t + intercept` forecast)

This completes the family alongside the existing `rate` / `changes` / `resets` / staleness-resample lowerings.

## Architecture invariant (zero per-query version branching)

The CH version is probed **once at boot**; the chopt resolver computes the enabled feature set; `cmd/cerberus` wires the native-vs-fanout lowerer into the boot dispatch table (`promql.RangeLowerers`). There is **no** runtime `if CH >= 25.9` check anywhere on the query path — the feature/version decision lives entirely in *which* concrete strategy boot wired into each field.

- **registry**: `FeatureTSGridDeriv` + `FeatureTSGridPredictLinear`, same shape/floor/gate/Doc as `changes`/`resets` (`MinVersion{25,9}`, `Stability: Experimental`, `AutoSelect: true`, `RequiresExperimentalTSGrid: true`). The resolver iterates the registry generically, so both are picked up with **zero** new resolve code.
- **promql**: new `DerivLowerer` / `PredictLinearLowerer` strategies with `Fanout*`/`Native*` impls; `deriv` routes through the `lowerRangeVectorCall` dispatch switch, `predict_linear` through its own lowering. Both mirror `rate`/`changes`/`resets`.
- **chplan/chsql**: `RangeWindowNative` gains a `Scalars` field (predict_linear's horizon); both aggregates emit as **typed Frags** (`Parametric` / `Call` / `InlineLit`) — no raw SQL. The engine's node-type gate stamps `allow_experimental_time_series_aggregate_functions=1` unchanged (generic over the node type).
- The `simpleLinearRegression`/`arrayReduce` **fan-out stays the feature-disabled fallback**.

### predict_linear horizon `t`

`timeSeriesPredictLinearToGrid` takes the horizon as its 5th **parametric** (constant) arg, so **only a single whole-second literal `t`** is native-eligible. A computed horizon (`predict_linear(v[r], scalar(x))`) or a fractional `t` delegates to the exact fan-out `intercept + slope*t` Float64 arithmetic.

## Version floor

`timeSeriesDerivToGrid` / `timeSeriesPredictLinearToGrid` shipped in ClickHouse **25.8** (PR #84328), a quarter *earlier* than changes/resets — but the registry pins them to the family's shared **25.9** floor (the left-open-window fix, PR #86588) so a single probed capability verdict governs every member.

## Hollow-green guard

The CI chDB substrate is **< 25.9**, so the native aggregates are absent, the version gate keeps both on the fan-out, and a broken native path would be invisible on chDB. To prevent that:

- `internal/chsql/range_window_native_deriv_predict_test.go` forces the feature **ENABLED via the strategy table** (not a live server) and asserts (a) the plan carries a `RangeWindowNative` node for deriv/predict_linear and (b) `chsql.Emit` renders `timeSeriesDerivToGrid(` / `timeSeriesPredictLinearToGrid(` with the correct parametric args (incl. the `predict_offset` 5th arg). It also pins the fan-out fallback for a fractional `t` and for the feature-OFF default.
- `internal/engine/ts_grid_native_deriv_predict_test.go` asserts the experimental setting is stamped for these funcs.
- `test/spec/promql/native_{deriv,predict_linear}_range_step.txtar` pin the native emit shape unconditionally (version-gated like the rest of the family).

The **native == fan-out numeric differential** (a Float64 fit → ULP-close, not bit-identical) is a `>= 25.9` prod/e2e concern, documented in `docs/native-clickhouse.md` + `docs/clickhouse-optimizations.md` exactly as the existing family does — **not** faked on chDB.

## Correctness

`deriv` = least-squares slope over the range; `predict_linear` = `slope*t + intercept`. Both mirror the fan-out's `simpleLinearRegression` computation by construction and both NULL a window with `< 2` samples (filtered to absent rows via `WHERE grid_val IS NOT NULL`), matching Prometheus's drop-series semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
