### PR TITLE
fix(perf): delegate traceql_compare scaling to the cardinality axis

### DIFF
--- a/test/perf/scaling/construct_traceql_compare_test.go
+++ b/test/perf/scaling/construct_traceql_compare_test.go
@@ -13,10 +13,21 @@
 //
 // On current main the conjunction lowers to a SINGLE flat WHERE — K map
 // lookups on one scan, no fan-out — so the intermediate equals the scan
-// rows (a Filter only reduces) and the wall stays sub-linear in K (K cheap
-// map probes per row). Param = K, swept 2 -> 8 -> 32. The bound pins that
-// the path STAYS scan-bound: peak intermediate <= ~1x scan_rows,
+// rows (a Filter only reduces). Param = K, swept 2 -> 8 -> 32. The bound
+// pins that the path STAYS scan-bound: peak intermediate <= ~1x scan_rows,
 // independent of K.
+//
+// The WALL axis is deliberately NOT gated for this construct
+// (WallAxisLinearByDesign): evaluating K conjunctive map-probes per row is
+// inherently O(rows x K) CPU, so wall grows ~linearly in K even on the
+// flat, non-fan-out shape — and a per-attribute JOIN/arrayJoin fan-out is
+// ALSO O(rows x K), so the wall axis cannot separate the two by
+// construction. (The old 25.8 CI substrate was scan-dominated enough to
+// mask the per-probe cost, so wall looked sub-linear; the 26.5 substrate
+// surfaces the true linearity.) The discriminator is the CARDINALITY axis
+// (b): the flat filter keeps the peak intermediate at ~scan_rows, flat in
+// K, while a fan-out inflates it to rows x K — plus the emitted-SQL-shape
+// precondition below that rejects a JOIN/arrayJoin outright.
 package scaling
 
 import (
@@ -43,7 +54,13 @@ func init() {
 		// arrayJoin regression (rows x K) blows straight past, while the
 		// scan-bound shape sits at <=1x.
 		CardinalityBound: 1.1,
-		SubLinearSlack:   0.9,
+		SubLinearSlack:   0.9, // informational only — the wall axis is delegated (see below)
+		// K conjunctive map-probes per row is inherently O(rows x K), and so
+		// is a per-attribute fan-out; the wall axis cannot tell them apart, so
+		// fan-out detection is delegated to the cardinality bound (b) + the
+		// emitted-SQL-shape precondition. See the file header for the full why.
+		WallAxisLinearByDesign: "flat K-probe filter and a per-attribute fan-out are both O(rows x K); " +
+			"wall cannot separate them — the cardinality bound (b) is the fan-out gate",
 		Seed: func() string {
 			ddl := `DROP TABLE IF EXISTS otel_traces;
 			CREATE TABLE otel_traces (

--- a/test/perf/scaling/harness_test.go
+++ b/test/perf/scaling/harness_test.go
@@ -55,7 +55,11 @@
 //
 // It MUST pass on current main: every registered shape is bounded there.
 // If a registered shape is NOT sub-linear on main, that is a real finding
-// — the assertion is not weakened to make it pass.
+// — the wall assertion is not weakened to make it pass. The one exception
+// is a shape whose bounded AND fan-out forms are BOTH linear in the
+// parameter (so the wall axis cannot separate them by construction); such a
+// construct sets [Construct.WallAxisLinearByDesign] and is gated solely by
+// the deterministic cardinality invariant (b), never by a slack fudge.
 //
 // Build-tagged `chdb`; runs in the `perf-chdb` lane (./test/perf/...).
 package scaling
@@ -182,6 +186,27 @@ type Construct struct {
 	// REMOVE this flag (flip the wall axis back to a hard gate) once the
 	// tracked bug is fixed.
 	KnownSuperlinear string
+
+	// WallAxisLinearByDesign delegates this construct's fan-out detection
+	// ENTIRELY to the cardinality invariant (b), because the wall-time axis
+	// (a) cannot discriminate its bounded shape from its fan-out shape — BOTH
+	// are linear in the parameter, so no wall gate (at any slack) separates
+	// them. The canonical case is traceql_compare: a flat WHERE evaluating K
+	// conjunctive map-probes per row is inherently O(rows x K) CPU, and a
+	// per-attribute JOIN/arrayJoin fan-out is ALSO O(rows x K) (rows is fixed,
+	// K varies), so wall tracks K ~1:1 EITHER WAY. The discriminator is
+	// cardinality: the flat filter keeps the peak intermediate at ~scan_rows
+	// (flat in K) while a fan-out inflates it to rows x K. The driver still
+	// MEASURES and LOGS wall every run (the data stays visible) but does not
+	// gate on it; invariant (b) and the construct's own emitted-SQL-shape
+	// precondition are the hard fan-out gates. A non-empty reason is required.
+	//
+	// This is NOT KnownSuperlinear. KnownSuperlinear quarantines a REAL,
+	// separately-tracked super-linear BUG pending a fix (remove the flag when
+	// fixed). WallAxisLinearByDesign records a PERMANENT property of the shape
+	// — the wall axis is uninformative by construction; there is no bug and
+	// nothing to un-flag. Mutually exclusive with KnownSuperlinear.
+	WallAxisLinearByDesign string
 }
 
 // register adds c to the package registry. Called from each construct

--- a/test/perf/scaling/scaling_test.go
+++ b/test/perf/scaling/scaling_test.go
@@ -43,6 +43,12 @@ func runConstruct(t *testing.T, c Construct) {
 		t.Fatalf("construct %q: set exactly one of Seed / Reseed", c.Name)
 	}
 
+	if c.KnownSuperlinear != "" && c.WallAxisLinearByDesign != "" {
+		t.Fatalf("construct %q: set at most one of KnownSuperlinear / WallAxisLinearByDesign — "+
+			"the first quarantines a tracked super-linear bug, the second records a permanently "+
+			"uninformative wall axis; a construct is one or the other, not both.", c.Name)
+	}
+
 	// Each construct gets its own connection / session so a seed or DROP in
 	// one never bleeds into another's row set.
 	db := openChDB(t)
@@ -151,7 +157,18 @@ func runConstruct(t *testing.T, c Construct) {
 		t.Fatalf("construct %q: parameter did not grow across the sweep (%.2fx) — the sweep is mis-built; "+
 			"a sub-linearity assertion is meaningless without a growing parameter.", c.Name, paramGrowth)
 	}
-	if wallGrowth >= gate {
+	switch {
+	case c.WallAxisLinearByDesign != "":
+		// The wall axis is uninformative for this construct by construction:
+		// its bounded shape and its fan-out shape are BOTH linear in the
+		// parameter (see WallAxisLinearByDesign), so no wall gate separates
+		// them. Measure and log for visibility, but delegate the fan-out gate
+		// entirely to the deterministic cardinality invariant (b) below.
+		t.Logf("WALL-AXIS-DELEGATED %s: wall grew %.2fx while %s grew %.2fx (reference gate %.2fx) — "+
+			"wall cannot discriminate the bounded shape from a fan-out here; the cardinality axis (b) is the gate.",
+			c.Name, wallGrowth, c.Param, paramGrowth, gate)
+		t.Logf("  reason: %s", c.WallAxisLinearByDesign)
+	case wallGrowth >= gate:
 		msg := func(verb string) string {
 			return verb + ": compute-scaling violation in " + c.Name + " (" + c.Why + "): wall-time grew " +
 				ftoa(wallGrowth) + "x while " + c.Param + " grew only " + ftoa(paramGrowth) + "x (slack=" +
@@ -169,7 +186,7 @@ func runConstruct(t *testing.T, c Construct) {
 			t.Errorf("%s The %s fan-out regressed back in. first: %s=%d wall=%v   last: %s=%d wall=%v",
 				msg("regression"), c.Why, c.Param, first.param, first.wall, c.Param, last.param, last.wall)
 		}
-	} else if c.KnownSuperlinear != "" {
+	case c.KnownSuperlinear != "":
 		// The quarantined construct is now sub-linear — the tracked bug may
 		// be FIXED. Surface it so the flag gets removed (flip back to a hard
 		// gate) rather than lingering as dead quarantine.


### PR DESCRIPTION
## What broke

`perf-guards` (`TestScaling_ChDB/traceql_compare`) failed on the **push-to-main run after #1260 merged** ([run 30038284774](https://github.com/tsouza/cerberus/actions/runs/30038284774/job/89311649068)) — i.e. as a direct consequence of the CI chDB substrate bumping **25.8 → 26.5**:

```
attrs/span K=2   wall=45.414ms   peak_intermediate=60000  (0.50x scan_rows=120000)
attrs/span K=8   wall=176.198ms  peak_intermediate=60000  (0.50x scan_rows=120000)
attrs/span K=32  wall=684.425ms  peak_intermediate=60000  (0.50x scan_rows=120000)
regression: wall grew 15.07x while K grew 16.00x (gate 14.65x)
```

Note the two axes disagree: the **wall axis** tripped, but the **cardinality axis** (the primary, deterministic, no-margin anti-fan-out invariant) stayed **flat at 0.50x scan_rows for every K**, and the emitted-SQL-shape precondition (no `JOIN`/`ARRAYJOIN`/`WITH RECURSIVE`) passed. The SQL cerberus emits is unchanged — a flat single scan with K conjunctive `WHERE` map-probes.

## Root cause — a construct modeling error, not a cerberus regression

`traceql_compare` asserted its wall grows **sub-linearly** in K. That was never structurally true — it was an artifact of the old 25.8 substrate being scan-dominated enough to hide the per-probe cost:

- Evaluating **K conjunctive map-probes per row** is inherently **O(rows × K)** CPU → wall grows ~linearly in K on the *flat, non-fan-out* shape.
- A per-attribute `JOIN`/`arrayJoin` fan-out is **also O(rows × K)** (rows fixed, K varies) → wall tracks K ~1:1 there too.

So for this construct the **wall axis cannot separate the bounded shape from a fan-out by construction** — and no `SubLinearSlack` value fixes that. Bumping slack would just be papering over a fragile timing proxy. The 26.5 substrate simply surfaces the linearity that was always there (locally the same sweep measured anywhere from 8.4x to 15x depending on the runner — pure timing noise, while `peak_intermediate` is deterministically flat).

## The fix

Delegate this construct's fan-out detection to the axis that **actually discriminates**: the **cardinality bound** (flat `scan_rows` vs `rows × K`) + the emitted-SQL-shape precondition — both deterministic, both already green.

- New first-class `Construct.WallAxisLinearByDesign` field, **distinct from `KnownSuperlinear`**: `KnownSuperlinear` quarantines a *real tracked super-linear bug pending a fix*; `WallAxisLinearByDesign` records a *permanent* property of the shape (the wall axis is uninformative by construction — no bug, nothing to un-flag). Mutually exclusive; validated in the driver.
- The driver still **measures and logs** wall every run (`WALL-AXIS-DELEGATED …`) so the data stays visible; it just doesn't gate on it. Invariant (b) stays a hard, no-margin gate.
- The `traceql_compare` header comment is corrected (the "wall stays sub-linear in K" claim was false) and the harness package doc notes the delegation exception.

This is the no-cat-and-mouse / no-tolerance-fudge path: the real anti-fan-out guarantee (cardinality + SQL shape) is untouched and still hard-asserted.

## Verification

`go test -tags chdb -run TestScaling_ChDB ./test/perf/scaling/` — full suite green on the local 26.5 substrate; `traceql_compare` now logs `WALL-AXIS-DELEGATED` and passes on the cardinality axis; the other constructs (incl. the `KnownSuperlinear` path) are unaffected by the switch restructure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)