### PR TITLE
test(chsql): pin native regression sub-second membership gap; correct the whole-second-axis rationale

### DIFF
--- a/docs/native-clickhouse.md
+++ b/docs/native-clickhouse.md
@@ -35,27 +35,40 @@ the portable SQL path. What it currently exploits:
   whole-second timestamp axis (`toDateTime(ts)`) that matches the fan-out's
   `dateDiff('second', anchor, ts)` regression x-axis — without it
   `timeSeriesDerivToGrid` computes a per-nanosecond slope (1e9× too small) off
-  the raw `DateTime64(9)` column. (The whole-second axis is also the
-  numerically sound choice: a least-squares fit over absolute nanosecond
-  timestamps — ~10¹⁸, squared past float64's 2⁵³ exact range — loses precision,
-  and it keeps `predict_linear`'s whole-second horizon `t` unit-consistent.)
-  With the matching axis native == fan-out is **bit-identical for
-  whole-second-aligned samples**, proven directly on the chDB CI substrate by
-  the dual-emit parity tests (`range_window_deriv_chdb_test.go` /
+  the raw `DateTime64(9)` column. The whole-second axis is chosen so that native
+  stays **bit-identical to the fan-out**, whose own x-axis is that floored
+  `dateDiff('second', …)`. With the matching axis native == fan-out is
+  **bit-identical for whole-second-aligned samples**, proven directly on the chDB
+  CI substrate by the dual-emit parity tests (`range_window_deriv_chdb_test.go` /
   `range_window_predict_linear_chdb_test.go`): the substrate is ClickHouse 26.5,
   above the 25.9 floor, so it ships the aggregates and the native half genuinely
   fires in the `chdb` lane.
   - **Known limitation (why the native regression path stays experimental,
-    default-off behind `CERBERUS_EXPERIMENTAL_TS_GRID_RANGE`):** the
-    `toDateTime(ts)` argument feeds both the regression x-axis *and* the
-    aggregate's window-membership bucketing. On sub-second-offset samples that
-    straddle a window boundary, the native path buckets by the floored second
-    while the fan-out (and Prometheus) decide membership on the raw timestamp,
-    so a boundary sample can land in a different grid window between the two
-    paths. Bit-identical parity is therefore established only for
-    whole-second-aligned data; closing the sub-second membership gap (or pinning
-    the whole-second-only guarantee with a dedicated characterization seed) is
-    the gate before this path is promoted past experimental.
+    default-off behind `CERBERUS_EXPERIMENTAL_TS_GRID_RANGE`):** the aggregate
+    accepts only a `DateTime`/`DateTime64` timestamp (it rejects `Float64` /
+    `Decimal`), so its single ts argument drives both the regression x-axis *and*
+    the window-membership bucketing — there is no way to keep a whole-second
+    x-axis while bucketing membership on the raw timestamp. On sub-second-offset
+    samples that straddle a window boundary, the native path buckets by the
+    floored second while the fan-out (and Prometheus) decide membership on the raw
+    timestamp, so a boundary sample can land in a different grid window between the
+    two paths. This gap is characterised and pinned by
+    `range_window_regression_subsecond_chdb_test.go`. The per-function outlook:
+    - `deriv`: feeding the raw `DateTime64(9)` axis and scaling the slope by 1e9
+      is actually **more** correct (raw-ts membership + fractional-second x =
+      Prometheus's deriv) and is numerically sound at production ns magnitude —
+      the least-squares slope is a centered difference, not an absolute-magnitude
+      sum, so it does not overrun float64's exact range. It is kept on the
+      whole-second axis only to stay bit-identical to the (floored) fan-out;
+      moving it to raw-ns would improve correctness at the cost of that guard.
+    - `predict_linear`: raw-ns is genuinely broken — its result is an *absolute*
+      forecast (`intercept + slope*(anchor + offset)`) evaluated at ~10¹⁸ ns,
+      where catastrophic cancellation destroys all precision, and no scale trick
+      recovers it. It cannot be made sub-second-correct via the native aggregate.
+    Because the flag gates the whole family, that inherent `predict_linear`
+    limitation is what keeps the native regression path default-off; closing (or
+    formally accepting) the sub-second membership gap is the gate before it is
+    promoted.
 - **`timeSeriesResampleToGridWithStaleness`** — native instant-vector
   selection with Prometheus staleness, retiring the staleness fan-out.
 - **`condition_cache`** and **`aggregation_in_order`** — server-side

--- a/internal/chsql/range_window_deriv_chdb_test.go
+++ b/internal/chsql/range_window_deriv_chdb_test.go
@@ -33,9 +33,11 @@
 // regression axis AND the aggregate's window bucketing, so a boundary sample
 // buckets by its floored second here while the fan-out keeps raw-ts membership
 // (see nativeGridTsAxisFrag's LIMITATION note). This test therefore proves
-// bit-identity for whole-second-aligned data; the native regression path stays
-// experimental/default-off until the sub-second membership gap is closed or
-// pinned.
+// bit-identity for whole-second-aligned data; the sub-second membership gap it
+// deliberately does not exercise is characterised and pinned separately by
+// TestNativeTSGridDeriv_SubSecondMembershipPin
+// (range_window_regression_subsecond_chdb_test.go), and keeps the native
+// regression path experimental/default-off.
 //
 // Substrate: exercised on CI. timeSeriesDerivToGrid shipped in CH 25.8
 // (PR #84328) and is floor-pinned to 25.9 in internal/chopt (a uniform

--- a/internal/chsql/range_window_native.go
+++ b/internal/chsql/range_window_native.go
@@ -147,19 +147,46 @@ var nativeTSGridFn = map[string]string{
 //     native DateTime64(9) column untouched — no golden churn, no change to
 //     their sub-second sample-membership behaviour.
 //
-// LIMITATION (regression path only): the returned axis is the aggregate's ts
-// argument, which drives BOTH the least-squares x-axis AND the window-membership
-// bucketing. Truncating to whole seconds therefore also quantises membership: a
-// sub-second sample straddling a grid-window boundary buckets by its floored
-// second here, whereas the fan-out (and Prometheus) decide membership on the raw
-// timestamp, so such a boundary sample can land in a different window between the
-// two paths. Feeding the raw nanosecond column instead would match membership but
-// is numerically worse (a fit over ~10^18 timestamps overruns float64's exact
-// range) and breaks predict_linear's whole-second horizon unit — hence the
-// whole-second axis, with the sub-second membership gap left as the gate before
-// this experimental (CERBERUS_EXPERIMENTAL_TS_GRID_RANGE, default-off) path is
-// promoted. The dual-emit parity tests prove bit-identity on whole-second-aligned
-// seeds only.
+// LIMITATION (regression path only) — the sub-second membership gap. The
+// returned axis is the aggregate's ts argument, and the aggregate accepts only a
+// DateTime/DateTime64 timestamp (it rejects Float64/Decimal), so that ONE
+// argument drives BOTH the least-squares x-axis AND the window-membership
+// bucketing. There is therefore no way to keep a whole-second x-axis while
+// bucketing membership on the raw timestamp: whole-second (toDateTime) floors
+// both, and any sub-second type (DateTime64) makes both sub-second. Truncating to
+// whole seconds quantises membership — a sub-second sample straddling a
+// grid-window boundary buckets by its floored second here, whereas the fan-out
+// (and Prometheus) decide membership on the raw timestamp — so such a boundary
+// sample can land in a different window between the two paths. The gap is pinned
+// by TestNativeTSGrid{Deriv,PredictLinear}_SubSecondMembershipPin.
+//
+// Why whole-second is nonetheless the chosen axis, and why the family stays
+// experimental (CERBERUS_EXPERIMENTAL_TS_GRID_RANGE, default-off):
+//
+//   - deriv: feeding the raw DateTime64(9) axis and scaling the slope by 1e9
+//     (per-nanosecond -> per-second) actually yields the MORE correct answer —
+//     raw-ts membership + fractional-second x, i.e. exactly Prometheus's deriv —
+//     and it is numerically sound at production ns magnitude (~1.77e18), because
+//     the least-squares slope is a centered difference, not an absolute-magnitude
+//     sum, so it does NOT overrun float64's exact range (empirically raw-ns * 1e9
+//     equals the closed-form slope to full precision; see the sub-second pin).
+//     The whole-second axis is kept only because it stays BIT-IDENTICAL to the
+//     fan-out, whose own x-axis is the floored dateDiff('second', anchor, ts) —
+//     the raw-ns form diverges from that fan-out by ~2 ULP (the 1e9 multiply
+//     rounds). Switching deriv to raw-ns would thus improve correctness but
+//     require relaxing the bit-identical guard, and would not promote the family
+//     on its own (see predict_linear).
+//   - predict_linear: raw-ns is genuinely BROKEN, not merely a guard mismatch.
+//     Its result is an ABSOLUTE forecast (intercept + slope*(anchor + offset)),
+//     evaluated at ~1.77e18 ns, where catastrophic cancellation destroys all
+//     precision (empirically ~6.6e11 for a true value in the hundreds). There is
+//     no scale trick to recover it, so predict_linear cannot be made
+//     sub-second-correct via the native aggregate at all. Because the flag gates
+//     the whole regression family, this inherent predict_linear limitation is
+//     what keeps the family default-off.
+//
+// The dual-emit parity tests prove bit-identity on whole-second-aligned seeds
+// only; the sub-second pins characterise the divergence beyond that.
 func nativeGridTsAxisFrag(fn, tsColumn string) Frag {
 	if fn == "deriv" || fn == "predict_linear" {
 		return Call("toDateTime", Col(tsColumn))

--- a/internal/chsql/range_window_predict_linear_chdb_test.go
+++ b/internal/chsql/range_window_predict_linear_chdb_test.go
@@ -15,7 +15,12 @@
 // Prometheus-pinned funcPredictLinear value (the spec corpus is
 // reference-Prometheus-pinned), so native == fan-out transitively proves
 // native == Prometheus on the predict_linear shape FOR WHOLE-SECOND-ALIGNED
-// SAMPLES (see the scope note below). We compare the DECODED float64 (never a
+// SAMPLES; the sub-second membership gap this test does not exercise is pinned by
+// TestNativeTSGridPredictLinear_SubSecondMembershipPin
+// (range_window_regression_subsecond_chdb_test.go), and note that predict_linear
+// cannot be made sub-second-correct via the native aggregate at all (its absolute
+// forecast loses precision on a raw-ns axis — see nativeGridTsAxisFrag). We
+// compare the DECODED float64 (never a
 // string render) at full precision.
 //
 // Horizon literal, not computed. The native path only fires when the horizon t

--- a/internal/chsql/range_window_regression_subsecond_chdb_test.go
+++ b/internal/chsql/range_window_regression_subsecond_chdb_test.go
@@ -1,0 +1,308 @@
+//go:build chdb
+
+// chDB-backed CHARACTERIZATION PIN for the sub-second window-membership gap of
+// the experimental native regression path (timeSeriesDerivToGrid /
+// timeSeriesPredictLinearToGrid). This is the test that converts the documented
+// limitation into an enforced, self-describing fact.
+//
+// Why this test exists. The two dual-emit parity tests
+// (range_window_{deriv,predict_linear}_chdb_test.go) prove native == fan-out
+// bit-identically, but ONLY on whole-second-aligned seeds. The native path fits
+// the per-window regression on a WHOLE-SECOND timestamp axis (toDateTime(ts) —
+// see nativeGridTsAxisFrag), and that same argument also drives the aggregate's
+// window-MEMBERSHIP bucketing. So a sample whose sub-second offset straddles a
+// range-window boundary is bucketed by its FLOORED second in native, while the
+// fan-out (sampleAnchorFanoutFrag on raw srcTs) and real Prometheus decide
+// membership on the RAW timestamp. Whole-second seeds can't surface this — the
+// floor is a no-op there. This test seeds a boundary-straddling sample on
+// purpose and pins the resulting three-way split so it can neither regress
+// silently nor be "fixed" without the goldens noticing.
+//
+// The three answers this fixture produces (single series, a 30s-step grid; the
+// pin asserts on the anchor at 00:05:00 whose range-5m window (0s, 300s] has its
+// left edge exactly at the second the +0.5s sample straddles):
+//
+//   - native (whole-second axis, CURRENT SHIPPING): floors the +0.5s sample to
+//     second 0, which is OUTSIDE the left-open window (0,300], so the sample is
+//     DROPPED. Floored membership + floored x.
+//   - fan-out (portable, prod default): raw-ts membership KEEPS the +0.5s
+//     sample, but the SLR x-axis is dateDiff('second', anchor, ts) — also
+//     floored. Raw membership + floored x.
+//   - true Prometheus: raw-ts membership + FRACTIONAL-second x. This is what the
+//     native path computes if fed the raw DateTime64(9) axis and scaled to
+//     per-second (proven empirically: raw-ns deriv * 1e9 == the closed-form
+//     least-squares slope). NEITHER shipping path equals it on sub-second data.
+//
+// The pinned invariants (version-robust — relationships, not brittle float
+// constants):
+//
+//   - native != fan-out by more than float-order noise: the membership
+//     divergence is REAL, not a rounding artefact. This is the limitation, made
+//     a hard fact.
+//   - fan-out is STRICTLY CLOSER to true Prometheus than native is: fan-out only
+//     floors the x-axis, while native ALSO drops a whole sample, so the fan-out
+//     (the prod default) is the more-correct path here. This is the reassurance
+//     that the default-off native path is the one carrying the gap, not the
+//     shipping default.
+//
+// Substrate: exercised on CI. The native aggregates are present on the pinned
+// chdb-core v26.5.0 (CH 26.5.1.1) `chdb` lane; the feature-detect guard keeps
+// the fan-out half validating on an older local libchdb. The forbid-skip gate
+// bans the test-skip API, so the guard is a documented runtime conditional that
+// always executes.
+package chsql_test
+
+import (
+	"context"
+	"database/sql"
+	"math"
+	"testing"
+	"time"
+
+	promparser "github.com/prometheus/prometheus/promql/parser"
+
+	_ "github.com/chdb-io/chdb-go/chdb/driver"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// subSecondDerivSeed plants a single host series whose FIRST sample sits at
+// +0.5s past the window's left edge. Under raw-ts membership the sample is
+// inside (0s,300s]; under whole-second flooring it collapses to second 0 and
+// falls outside. The remaining samples are whole-second so the divergence is
+// attributable to exactly that one straddling point.
+const subSecondDerivSeed = `
+CREATE OR REPLACE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    ResourceAttributes Map(String, String) DEFAULT map(),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge (MetricName, Attributes, TimeUnix, Value) VALUES
+    ('load_state', map('host', 'a'), toDateTime64('2026-01-01 00:00:00.5', 9), 5.0),
+    ('load_state', map('host', 'a'), toDateTime64('2026-01-01 00:01:00', 9), 10.0),
+    ('load_state', map('host', 'a'), toDateTime64('2026-01-01 00:02:00', 9), 22.0),
+    ('load_state', map('host', 'a'), toDateTime64('2026-01-01 00:03:00', 9), 33.0),
+    ('load_state', map('host', 'a'), toDateTime64('2026-01-01 00:04:00', 9), 47.0),
+    ('load_state', map('host', 'a'), toDateTime64('2026-01-01 00:05:00', 9), 58.0);
+`
+
+// subSecondDerivQuery anchors a single grid point at 00:05:00 (Start==End) with
+// a 5-minute range, so the whole test reduces to one window (0s,300s] and one
+// regression slope per path — the cleanest possible frame for the membership
+// split.
+const subSecondDerivQuery = `sum by(host) (deriv(load_state[5m]))`
+
+// subSecondFloatCloseUlps bounds "float-order noise": two paths that compute the
+// SAME math via different float operations may differ by a few ULP. A membership
+// divergence is orders of magnitude larger, so this is the floor above which a
+// difference counts as a real (not rounding) divergence. Expressed as an
+// absolute epsilon on slopes of order ~0.2, a handful of ULP is ~1e-15.
+const subSecondFloatCloseEps = 1e-12
+
+func TestNativeTSGridDeriv_SubSecondMembershipPin(t *testing.T) {
+	db, err := sql.Open("chdb", "")
+	if err != nil {
+		t.Fatalf("open chdb: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := db.Ping(); err != nil {
+		t.Fatalf("ping chdb: %v", err)
+	}
+	if _, err := db.Exec("SET " + chclient.SettingExperimentalTSGridAggregate + " = 1"); err != nil {
+		t.Fatalf("enable experimental ts-grid: %v", err)
+	}
+	for _, stmt := range splitSeedStatements(subSecondDerivSeed) {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("seed: %v\n--- stmt ---\n%s", err, stmt)
+		}
+	}
+
+	fanout := runSubSecondRegressionEmit(t, db, subSecondDerivQuery, false)
+	if !derivFnPresent(t, db) {
+		t.Logf("NOTICE: timeSeriesDerivToGrid absent on this local chDB substrate " +
+			"(older libchdb than the pinned chdb-core v26.5.0) — native membership pin " +
+			"bypassed (fan-out half still computed). Run `just chdb-install` at the pinned " +
+			"version; the pin runs in the `chdb` CI lane on CH 26.5.")
+		return
+	}
+	native := runSubSecondRegressionEmit(t, db, subSecondDerivQuery, true)
+
+	// The grid spans several anchors; the straddle only bites at the anchor whose
+	// left window edge is second 0 — anchor 00:05:00, window (0s,300s], where the
+	// +0.5s sample floors across the boundary. Assert on exactly that cell.
+	cell := gridCell{ql: "a", anchor: "2026-01-01T00:05:00Z"}
+	fv, okF := fanout[cell]
+	nv, okN := native[cell]
+	if !okF || !okN {
+		t.Fatalf("straddle anchor cell %+v missing: fanout-present=%v native-present=%v", cell, okF, okN)
+	}
+	// true Prometheus = raw-ts membership + fractional-second x. Proven equal to
+	// the native aggregate fed the raw DateTime64(9) axis and scaled to
+	// per-second (per-nanosecond slope * 1e9). Computed directly so the reference
+	// is not a hand-copied constant.
+	truth := subSecondTrueDeriv(t, db)
+
+	t.Logf("sub-second deriv three-way split at %s:", cell.anchor)
+	t.Logf("  native (whole-second axis, floored membership) = %.20g", nv)
+	t.Logf("  fan-out (raw membership, floored x)            = %.20g", fv)
+	t.Logf("  true Prometheus (raw membership, fractional x) = %.20g", truth)
+
+	// Invariant 1: the membership divergence is REAL, not float-order noise.
+	if math.Abs(nv-fv) <= subSecondFloatCloseEps {
+		t.Fatalf("native (%.20g) and fan-out (%.20g) agree within float noise (%g) — the "+
+			"documented sub-second membership gap did NOT reproduce; either the fixture no "+
+			"longer straddles a boundary or the native path changed its membership rule",
+			nv, fv, subSecondFloatCloseEps)
+	}
+
+	// Invariant 2: the prod-default fan-out is STRICTLY closer to true Prometheus
+	// than the default-off native path — native carries the gap, not the default.
+	distNative := math.Abs(nv - truth)
+	distFanout := math.Abs(fv - truth)
+	if !(distFanout < distNative) {
+		t.Fatalf("fan-out is NOT closer to true Prometheus than native: "+
+			"|fanout-truth|=%.3g |native-truth|=%.3g — the pinned relationship (fan-out is "+
+			"the more-correct path on sub-second data) no longer holds", distFanout, distNative)
+	}
+}
+
+// subSecondPredictLinearQuery mirrors the deriv pin's frame for predict_linear
+// (horizon 3600s, a whole-second literal so the native path is eligible).
+const subSecondPredictLinearQuery = `sum by(host) (predict_linear(load_state[5m], 3600))`
+
+// TestNativeTSGridPredictLinear_SubSecondMembershipPin locks that predict_linear
+// carries the SAME whole-second membership gap as deriv. Unlike deriv there is
+// no raw-ns "true Prometheus" reference to compare against — feeding the
+// aggregate the raw nanosecond axis makes its ABSOLUTE forecast (intercept +
+// slope*(anchor+offset), evaluated at ~1.77e18 ns) lose all precision to
+// catastrophic cancellation (empirically ~6.6e11 for a true value near the
+// hundreds). So this pin asserts the membership divergence between the two
+// SHIPPING paths is real; the fan-out (raw membership) is the more-correct
+// default, and the native path stays experimental/default-off.
+func TestNativeTSGridPredictLinear_SubSecondMembershipPin(t *testing.T) {
+	db, err := sql.Open("chdb", "")
+	if err != nil {
+		t.Fatalf("open chdb: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := db.Ping(); err != nil {
+		t.Fatalf("ping chdb: %v", err)
+	}
+	if _, err := db.Exec("SET " + chclient.SettingExperimentalTSGridAggregate + " = 1"); err != nil {
+		t.Fatalf("enable experimental ts-grid: %v", err)
+	}
+	for _, stmt := range splitSeedStatements(subSecondDerivSeed) {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("seed: %v\n--- stmt ---\n%s", err, stmt)
+		}
+	}
+
+	fanout := runSubSecondRegressionEmit(t, db, subSecondPredictLinearQuery, false)
+	if !predictLinearFnPresent(t, db) {
+		t.Logf("NOTICE: timeSeriesPredictLinearToGrid absent on this local chDB substrate " +
+			"— native membership pin bypassed (fan-out half still computed). Run " +
+			"`just chdb-install` at the pinned version; the pin runs in the `chdb` CI lane.")
+		return
+	}
+	native := runSubSecondRegressionEmit(t, db, subSecondPredictLinearQuery, true)
+
+	cell := gridCell{ql: "a", anchor: "2026-01-01T00:05:00Z"}
+	fv, okF := fanout[cell]
+	nv, okN := native[cell]
+	if !okF || !okN {
+		t.Fatalf("straddle anchor cell %+v missing: fanout-present=%v native-present=%v", cell, okF, okN)
+	}
+	t.Logf("sub-second predict_linear at %s: native(floored membership)=%.20g fan-out(raw membership)=%.20g",
+		cell.anchor, nv, fv)
+	// The forecast projects 3600s ahead, so the dropped boundary sample moves the
+	// slope and the forecast by far more than float noise.
+	if math.Abs(nv-fv) <= subSecondFloatCloseEps {
+		t.Fatalf("native (%.20g) and fan-out (%.20g) agree within float noise (%g) — the "+
+			"predict_linear sub-second membership gap did NOT reproduce", nv, fv, subSecondFloatCloseEps)
+	}
+}
+
+// runSubSecondRegressionEmit lowers + emits a deriv/predict_linear query against
+// the sub-second seed over the 30s-step grid with the native strategy on/off and
+// returns the per-cell values. When native, BOTH regression lowerers are wired
+// (only the one matching the query's function fires), so one helper serves both
+// pins.
+func runSubSecondRegressionEmit(t *testing.T, db *sql.DB, query string, native bool) map[gridCell]float64 {
+	t.Helper()
+	p := promparser.NewParser(promparser.Options{EnableExperimentalFunctions: true})
+	expr, err := p.ParseExpr(query)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	rangeStart := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	rangeEnd := rangeStart.Add(5 * time.Minute)
+	var lowerers promql.RangeLowerers
+	if native {
+		lowerers.Deriv = promql.NativeDerivLowerer{Fallback: promql.FanoutDerivLowerer{}}
+		lowerers.PredictLinear = promql.NativePredictLinearLowerer{Fallback: promql.FanoutPredictLinearLowerer{}}
+	}
+	plan, err := promql.LowerAtRangeOpts(context.Background(), expr, schema.DefaultOTelMetrics(),
+		rangeStart, rangeEnd, 30*time.Second,
+		promql.LowerOpts{Lowerers: lowerers})
+	if err != nil {
+		t.Fatalf("lower (native=%v): %v", native, err)
+	}
+	sqlStr, args, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("emit (native=%v): %v", native, err)
+	}
+	wrapped := "SELECT toJSONString(`Attributes`) AS host_json, `TimeUnix`, `Value` FROM (" + sqlStr + ")"
+	rows, err := db.Query(wrapped, args...)
+	if err != nil {
+		t.Fatalf("query (native=%v): %v\nSQL: %s", native, err, wrapped)
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := make(map[gridCell]float64)
+	for rows.Next() {
+		var hostJSON string
+		var ts time.Time
+		var v float64
+		if err := rows.Scan(&hostJSON, &ts, &v); err != nil {
+			t.Fatalf("scan (native=%v): %v", native, err)
+		}
+		out[gridCell{ql: extractHostLabel(hostJSON), anchor: ts.UTC().Format(time.RFC3339)}] = v
+	}
+	if err := tolerantSentinel(rows.Err()); err != nil {
+		t.Fatalf("rows.Err (native=%v): %v", native, err)
+	}
+	if len(out) == 0 {
+		t.Fatalf("native=%v produced zero rows — the sub-second fixture must yield a populated grid", native)
+	}
+	return out
+}
+
+// subSecondTrueDeriv computes the reference Prometheus slope for the window
+// (0s,300s] directly from the aggregate on the RAW nanosecond axis, scaled to
+// per-second. Feeding raw DateTime64(9) makes the aggregate regress in
+// per-nanosecond units (1e9x too small); multiplying by 1e9 recovers the
+// per-second slope with FULL raw-ts membership and fractional-second x — i.e.
+// exactly Prometheus's deriv. (The scale survives production ns magnitude
+// ~1.77e18 because the least-squares slope is a centered difference, not an
+// absolute-magnitude sum.)
+func subSecondTrueDeriv(t *testing.T, db *sql.DB) float64 {
+	t.Helper()
+	const q = "SELECT arrayElement(" +
+		"arrayMap(x -> x * 1e9, " +
+		"timeSeriesDerivToGrid(toDateTime('2026-01-01 00:05:00'), toDateTime('2026-01-01 00:05:00'), 30, 300)" +
+		"(TimeUnix, Value)), 1) " +
+		"FROM otel_metrics_gauge WHERE MetricName = 'load_state'"
+	var v sql.NullFloat64
+	if err := db.QueryRow(q).Scan(&v); err != nil {
+		t.Fatalf("true-deriv reference: %v", err)
+	}
+	if !v.Valid {
+		t.Fatalf("true-deriv reference produced NULL — the window must contain >= 2 samples")
+	}
+	return v.Float64
+}

--- a/internal/migrateverify/report.go
+++ b/internal/migrateverify/report.go
@@ -75,8 +75,8 @@ const (
 		"membership: a sub-second-offset sample straddling a range-window boundary can " +
 		"land in a different window than real Prometheus, shifting the slope/forecast. " +
 		"This is a KNOWN limitation of that path (default-off, CERBERUS_EXPERIMENTAL_TS_GRID_RANGE); " +
-		"re-run with it disabled — the portable fan-out uses raw-ts membership and " +
-		"should match Prometheus — before reporting a bug."
+		"re-run with it disabled — the portable fan-out uses raw-ts membership and is the " +
+		"more-correct path here — before reporting a bug."
 	ingestArtifactNote = "a series present on only one backend may reflect an ingestion " +
 		"difference (relabeling, scrape timing) rather than a compute bug."
 	dataWindowGapNote = "a missing step or series may reflect a data-availability window " +


### PR DESCRIPTION
Follow-up to #1260 (merged). #1260 bumped the CI chDB substrate to 26.5 so the native `timeSeries{Deriv,PredictLinear}ToGrid` regression family is genuinely exercised numerically in the `chdb` lane. This PR pins the one remaining characterized behaviour of that path and corrects a factually-wrong rationale comment it left behind.

## Why

The native regression path fits the per-window least-squares on a **whole-second** timestamp axis (`toDateTime(ts)`), which also quantises the aggregate's **window membership**. On a sub-second-offset sample straddling a range-window boundary, native floors membership to the second while the portable fan-out (and real Prometheus) decide membership on the raw timestamp — so a boundary sample can land in a different grid window between the two paths.

While investigating whether that could be decoupled (whole-second x-axis + raw-ts membership), live chDB-26.5 probes settled it empirically:

- The aggregate accepts **only** `DateTime`/`DateTime64` timestamps (it rejects `Float64`/`Decimal` with `ILLEGAL_TYPE_OF_ARGUMENT`), so its single ts arg drives **both** the regression x-axis and membership bucketing — the decoupling is architecturally impossible.
- **deriv**: feeding the raw `DateTime64(9)` axis and scaling the slope by 1e9 is actually **more** correct (raw-ts membership + fractional-second x = Prometheus) and is numerically sound at production ns magnitude — the slope is a centered difference, not an absolute-magnitude sum. The prior comment claiming "raw-ns is numerically worse / overruns 2⁵³" was **false** for deriv. It's kept on the whole-second axis only to stay bit-identical to the (floored) fan-out.
- **predict_linear**: raw-ns is genuinely broken — its result is an *absolute* forecast (`intercept + slope*(anchor+offset)`) evaluated at ~10¹⁸ ns, where catastrophic cancellation destroys all precision. It cannot be made sub-second-correct via the native aggregate. Because the flag gates the whole family, that inherent limitation is what keeps the native regression path default-off.

## What

- **New pin** `range_window_regression_subsecond_chdb_test.go` (build-tagged `chdb`): a seeded sub-second straddle case that locks the three-way split — for deriv, asserts native ≠ fan-out beyond a noise floor **and** that the fan-out is strictly closer to true-Prometheus (closed-form least-squares) than native; for predict_linear, asserts native ≠ fan-out (no true-Prom reference since raw-ns is broken). Version-robust: asserts the *relationships*, not brittle float constants.
- **Corrected rationale** in `range_window_native.go` (the `nativeGridTsAxisFrag` limitation comment) and `docs/native-clickhouse.md`, with the accurate per-function outlook. Emit code is unchanged.
- Cross-links from the deriv/predict_linear parity tests to the new pin; softened `regressionMembershipNote` in `internal/migrateverify/report.go` ("the portable fan-out uses raw-ts membership and is the more-correct path here").

## Note on ordering

Branched off current `main`, so the `perf-guards` check will be red here until **#1261** (an unrelated `traceql_compare` scaling fix for the same 26.5 substrate bump) merges; I'll rebase/update-branch after. `perf-guards` is not a required check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)