### PR TITLE
fix(e2e): move the k3d ClickHouse substrate off the defective 26.5 line

### DIFF
--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -1267,6 +1267,12 @@ func runRequirementsCheck(
 		Traces:            cfg.Traces,
 	}
 	res := preflight.RunIfEnabled(ctx, cfg.RequirementsCheck, client, req)
+	// Logged BEFORE the fatal check: a warning describes the server cerberus is
+	// pointed at, and an operator debugging a failed boot needs it just as much
+	// as one whose boot succeeds.
+	for _, w := range res.Warnings {
+		logger.Warn(w)
+	}
 	if res.Fatal != nil {
 		// Wrong-shape / too-old / unreadable — never self-heals. Exit even if
 		// some tables are also absent: a too-old server won't fix itself by
@@ -1397,6 +1403,11 @@ func reprobeSchema(
 ) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
+	// A boot that started ahead of ClickHouse (or ahead of its database) never
+	// got to read version(), so the re-probe is the FIRST place a server-level
+	// warning can surface. Log each distinct warning once — the loop ticks every
+	// few seconds and the findings are stable, so re-logging would be noise.
+	warned := map[string]bool{}
 	for {
 		select {
 		case <-ctx.Done():
@@ -1404,6 +1415,12 @@ func reprobeSchema(
 		case <-ticker.C:
 		}
 		res := preflight.Run(ctx, client, req)
+		for _, w := range res.Warnings {
+			if !warned[w] {
+				warned[w] = true
+				logger.Warn(w)
+			}
+		}
 		if res.Fatal != nil {
 			logger.Warn("schema re-probe found a fatal requirement; staying unready and retrying", "err", res.Fatal)
 			continue

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -270,6 +270,39 @@ no correctness floor here (the SQL is 24.8-safe), so it stays a **recommendation
 not a requirement**: trace-heavy deployments leaning on the structure tab should
 prefer 26.6+, everyone else is unaffected.
 
+### ClickHouse 26.5 — known-defective line
+
+**Do not run cerberus on ClickHouse 26.5.x.** The 26.5 line (reproduced on
+26.5.1 through 26.5.6, and on the chDB build of the same line) carries an
+upstream query-execution regression in the top-K prefilter that backs
+`ORDER BY <sorting-key column> … LIMIT n`: when the same attribute map appears
+in both the `WHERE` predicate and the projection, the prefilter is handed the
+map column where it expects the sort key and the server aborts the query with
+
+```text
+Code: 53. Type mismatch in IN or VALUES section. Expected: DateTime64(9).
+Got: Map: while executing 'FUNCTION __topKFilter(Timestamp) …'
+```
+
+26.4 and earlier are unaffected (the optimisation does not exist), and
+**26.6 fixes it**. The defect is gated on `LIMIT n` with
+`n <= query_plan_max_limit_for_top_k_optimization` (default 1000).
+
+For cerberus the blast radius is the Loki **`/loki/api/v1/detected_fields`**
+endpoint — its peek projects `Body` + both attribute maps while the stream
+selector filters on `ResourceAttributes`, and its default `line_limit` is
+exactly 1000 — so Grafana's Logs Drilldown renders "Fields: 0" and the endpoint
+returns 502 on every request. Sibling surfaces are clear: `/patterns` projects
+the timestamp alongside the body (which sidesteps the prefilter), and the log
+query path filters inside a subquery, so both keep working. Nothing is silently
+wrong — the defect always aborts the query rather than returning bad rows.
+
+Cerberus does not work around this in emitted SQL: the shapes that avoid it do
+so incidentally, so pinning a golden to one would encode an upstream bug as a
+cerberus invariant. The boot-time requirements check instead **warns** when it
+sees a 26.5 server (it does not refuse to start — the rest of the gateway is
+healthy), and the k3d e2e substrate is pinned to 26.6.
+
 ### Prometheus resource-attribute labels
 
 The Prometheus head projects each metric row's OTel `ResourceAttributes` map as

--- a/internal/preflight/preflight.go
+++ b/internal/preflight/preflight.go
@@ -93,6 +93,35 @@ var minCHBase = chopt.Version{Major: 24, Minor: 8}
 // above the base raises the requirement, and the base wins otherwise.
 var minCHNativeRate = chopt.Version{Major: 25, Minor: 9}
 
+// defectiveCHLines maps a ClickHouse minor line to the symptom an operator
+// running it will see. These are versions ABOVE the floor whose SQL cerberus
+// emits correctly but whose SERVER mis-executes it — an upstream regression,
+// not a cerberus requirement — so they are reported as WARNINGS: the rest of
+// the gateway is healthy and refusing to boot would cost far more than the
+// degraded surface. The version gate is the only place that already reads
+// version(), so the check rides along with it rather than re-probing.
+//
+// Keyed by major.minor because that is the granularity a regression lands and
+// is fixed at (the whole line is affected until the next minor). Each entry is
+// removed once no supported deployment can still be on it.
+var defectiveCHLines = map[chopt.Version]string{
+	{Major: 26, Minor: 5}: "the top-K prefilter behind `ORDER BY … LIMIT n` mis-types its input " +
+		"(`__topKFilter` / server error 53) when an attribute map is both filtered on and projected, " +
+		"which fails every /loki/api/v1/detected_fields request (Logs Drilldown renders \"Fields: 0\"); " +
+		"fixed in ClickHouse 26.6 — 26.4 and earlier are unaffected",
+}
+
+// defectNote renders the operator-facing warning for a known-defective server
+// line, naming the version actually connected to (not just the line) so the
+// log line is self-contained. Returns "" when got sits on no defective line.
+func defectNote(raw string, got chopt.Version) string {
+	symptom, bad := defectiveCHLines[got]
+	if !bad {
+		return ""
+	}
+	return fmt.Sprintf("clickhouse %s is a known-defective line for cerberus: %s", raw, symptom)
+}
+
 // attrMapType is the ClickHouse type the OTel-CH attribute-map columns
 // (Attributes / ResourceAttributes / ScopeAttributes) must carry. Stored
 // canonical (no spaces); the deployed type read from system.columns is
@@ -161,6 +190,11 @@ type Querier interface {
 //     is the "boot ahead of ClickHouse" race: the caller boots NOT READY and
 //     re-probes rather than exiting. UnreachableErr carries the underlying
 //     transport error for the /readyz reason + logs.
+//   - Warnings carries non-fatal findings the operator should act on but that
+//     must not stop the gateway — today, a connected server sitting on a
+//     known-defective ClickHouse line (see defectiveCHLines). A warning never
+//     gates readiness and never coexists exclusively: a Result can carry both
+//     Warnings and a Fatal, and the caller logs the warnings either way.
 //   - DatabaseAbsent is set when ClickHouse is reachable but the configured
 //     database does not exist yet (UNKNOWN_DATABASE / code 81). Because the
 //     connection carries the database as its session default, even SELECT
@@ -179,6 +213,7 @@ type Querier interface {
 // introspected) so neither ever coexists with a Fatal wrong-shape finding.
 type Result struct {
 	Fatal             error
+	Warnings          []string
 	AbsentTables      []string
 	Unreachable       bool
 	UnreachableErr    error
@@ -266,7 +301,7 @@ func Run(ctx context.Context, q Querier, req Requirements) Result {
 	// database does not exist yet (the connection carries it as the session
 	// default, so even version() fails) — equally transient, so short-circuit to
 	// a DatabaseAbsent Result rather than mislabelling it a fatal version-read.
-	versionProblems, unreachable, dbAbsent := checkVersion(ctx, q, req)
+	versionProblems, warnings, unreachable, dbAbsent := checkVersion(ctx, q, req)
 	if unreachable != nil {
 		return Result{Unreachable: true, UnreachableErr: unreachable}
 	}
@@ -281,7 +316,7 @@ func Run(ctx context.Context, q Querier, req Requirements) Result {
 
 	problems := append(versionProblems, schemaProblems...)
 
-	res := Result{AbsentTables: absent}
+	res := Result{Warnings: warnings, AbsentTables: absent}
 	if len(problems) == 0 {
 		return res
 	}
@@ -393,7 +428,11 @@ func matchesTransportPhrase(err error) bool {
 // dbAbsent. An unreadable-but-reachable response against an existing database
 // (other server-side query error, empty result, or unparseable / too-old
 // version) is a fatal problem (never a silent pass).
-func checkVersion(ctx context.Context, q Querier, req Requirements) (problems []string, unreachable, dbAbsent error) {
+//
+// A server that clears the floor but sits on a known-defective line (an
+// upstream regression cerberus cannot emit around) yields no problem and a
+// warning instead — the gateway boots, degraded on the named surface only.
+func checkVersion(ctx context.Context, q Querier, req Requirements) (problems, warnings []string, unreachable, dbAbsent error) {
 	min := req.minVersion()
 	rateNote := "native rate disabled"
 	if req.NativeRateEnabled {
@@ -404,25 +443,28 @@ func checkVersion(ctx context.Context, q Querier, req Requirements) (problems []
 	rows, err := q.QueryStrings(ctx, sql, args...)
 	if err != nil {
 		if isUnreachable(err) {
-			return nil, err, nil
+			return nil, nil, err, nil
 		}
 		if isDatabaseAbsent(err) {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
-		return []string{fmt.Sprintf("could not read clickhouse version: %v", err)}, nil, nil
+		return []string{fmt.Sprintf("could not read clickhouse version: %v", err)}, nil, nil, nil
 	}
 	if len(rows) == 0 {
-		return []string{"clickhouse version query returned no rows"}, nil, nil
+		return []string{"clickhouse version query returned no rows"}, nil, nil, nil
 	}
 	raw := strings.TrimSpace(rows[0])
 	got, ok := chopt.ParseVersion(raw)
 	if !ok {
-		return []string{fmt.Sprintf("clickhouse version %q is unparseable; required minimum %s (%s)", raw, min, rateNote)}, nil, nil
+		return []string{fmt.Sprintf("clickhouse version %q is unparseable; required minimum %s (%s)", raw, min, rateNote)}, nil, nil, nil
 	}
 	if !got.AtLeast(min) {
-		return []string{fmt.Sprintf("clickhouse version %s is below the required minimum %s (%s)", raw, min, rateNote)}, nil, nil
+		return []string{fmt.Sprintf("clickhouse version %s is below the required minimum %s (%s)", raw, min, rateNote)}, nil, nil, nil
 	}
-	return nil, nil, nil
+	if note := defectNote(raw, got); note != "" {
+		return nil, []string{note}, nil, nil
+	}
+	return nil, nil, nil, nil
 }
 
 // tableReq describes the shape required of one configured table: its

--- a/internal/preflight/preflight_test.go
+++ b/internal/preflight/preflight_test.go
@@ -225,6 +225,87 @@ func TestRunVersionOKAllPass(t *testing.T) {
 	}
 }
 
+// A known-defective ClickHouse line WARNS but never blocks: the server clears
+// the floor, the schema is healthy, and the defect degrades one endpoint rather
+// than the gateway. The pins below are the contract the boot log and
+// docs/operations.md both rest on — a defective server must not be fatal, and a
+// healthy one must not warn.
+func TestRunDefectiveLineWarnsButPasses(t *testing.T) {
+	t.Parallel()
+	q := &stubQuerier{Version: "26.5.6.64", Columns: healthyColumns()}
+	res := Run(context.Background(), q, defaultReq())
+	if res.Fatal != nil {
+		t.Fatalf("a defective-line server must still boot, got fatal: %v", res.Fatal)
+	}
+	if len(res.Warnings) != 1 {
+		t.Fatalf("want exactly 1 warning, got %d: %v", len(res.Warnings), res.Warnings)
+	}
+	w := res.Warnings[0]
+	// The raw server string (not just the line) so the log is self-contained,
+	// the affected endpoint so the operator can match it to what they see, and
+	// the fixed version so the message says where to go.
+	for _, want := range []string{"26.5.6.64", "detected_fields", "26.6"} {
+		if !strings.Contains(w, want) {
+			t.Errorf("warning missing %q: %s", want, w)
+		}
+	}
+}
+
+// The adjacent lines on both sides of the defect are clean — the regression
+// does not exist below 26.5 and is fixed above it — so neither may warn.
+func TestRunAdjacentLinesDoNotWarn(t *testing.T) {
+	t.Parallel()
+	for _, v := range []string{"26.4.5.143", "26.6.2.81", "25.8.2.1-lts"} {
+		q := &stubQuerier{Version: v, Columns: healthyColumns()}
+		res := Run(context.Background(), q, defaultReq())
+		if len(res.Warnings) != 0 {
+			t.Errorf("version %s must not warn, got: %v", v, res.Warnings)
+		}
+	}
+}
+
+// A too-old server is rejected on the floor gate and never reaches the
+// defect lookup, so it carries the fatal alone — no warning noise on a boot
+// that is already failing for a different reason.
+func TestRunTooOldCarriesNoWarning(t *testing.T) {
+	t.Parallel()
+	q := &stubQuerier{Version: "24.3.1.2557-stable", Columns: healthyColumns()}
+	res := Run(context.Background(), q, defaultReq())
+	if res.Fatal == nil {
+		t.Fatal("expected fatal for too-old version")
+	}
+	if len(res.Warnings) != 0 {
+		t.Errorf("too-old version must not also warn, got: %v", res.Warnings)
+	}
+}
+
+// A defective server with a wrong-shape schema must report BOTH: the fatal
+// stops the boot, and the warning still explains the server the operator is
+// pointed at. Warnings are not swallowed by an unrelated fatal.
+func TestRunDefectiveLineWarnsAlongsideFatal(t *testing.T) {
+	t.Parallel()
+	cols := healthyColumns()
+	// Drop Body from otel_logs so the shape gate has something fatal to say.
+	l := schema.DefaultOTelLogs()
+	pruned := cols[l.LogsTable][:0:0]
+	for _, c := range cols[l.LogsTable] {
+		if c.Name == l.BodyColumn {
+			continue
+		}
+		pruned = append(pruned, c)
+	}
+	cols[l.LogsTable] = pruned
+
+	q := &stubQuerier{Version: "26.5.6.64", Columns: cols}
+	res := Run(context.Background(), q, defaultReq())
+	if res.Fatal == nil {
+		t.Fatal("expected fatal for the missing body column")
+	}
+	if len(res.Warnings) != 1 {
+		t.Fatalf("want the defect warning alongside the fatal, got %d: %v", len(res.Warnings), res.Warnings)
+	}
+}
+
 func TestRunVersionExactlyAtFloor(t *testing.T) {
 	t.Parallel()
 	q := &stubQuerier{Version: "24.8.0.0", Columns: healthyColumns()}

--- a/test/e2e/k3s/clickhouse.yaml
+++ b/test/e2e/k3s/clickhouse.yaml
@@ -75,7 +75,11 @@ spec:
             claimName: clickhouse-data
       containers:
         - name: clickhouse
-          image: clickhouse/clickhouse-server:26.5-alpine
+          # 26.6, not 26.5: the 26.5 line carries an upstream query-execution
+          # regression (`__topKFilter` type mismatch) that fails the Loki
+          # /detected_fields peek. See docs/operations.md, "ClickHouse 26.5 —
+          # known-defective line".
+          image: clickhouse/clickhouse-server:26.6-alpine
           ports:
             - name: native
               containerPort: 9000

--- a/test/e2e/k3s/otel-collector.yaml
+++ b/test/e2e/k3s/otel-collector.yaml
@@ -471,7 +471,8 @@ spec:
         # the exporter's `create database` takes — so a green probe proves the
         # exporter's first Start() will succeed.
         - name: wait-for-clickhouse
-          image: clickhouse/clickhouse-server:26.5-alpine
+          # Kept in lock-step with the server image in clickhouse.yaml.
+          image: clickhouse/clickhouse-server:26.6-alpine
           command:
             - sh
             - -c


### PR DESCRIPTION
## What broke

The `dashboard` e2e job went red on push-to-main [`d4bcd0f0`](https://github.com/tsouza/cerberus/actions/runs/30047606867). `loki_explore_columns.spec.ts` → *detected_fields advertises the useful structured-metadata keys* got **502 on all three attempts** (not a flake):

```text
Code: 53. DB::Exception: Type mismatch in IN or VALUES section.
Expected: DateTime64(9). Got: Map: while executing
'FUNCTION __topKFilter(Timestamp : 0) -> __topKFilter(Timestamp) UInt8 : 1'
```

## Root cause — upstream ClickHouse, not a cerberus change

The 26.5 line added a top-K prefilter behind `ORDER BY <sorting-key column> … LIMIT n`, gated on `n <= query_plan_max_limit_for_top_k_optimization` (default **1000**). When the same attribute map appears in **both** the `WHERE` predicate and the projection, the prefilter is handed the map column where it expects the sort key and the server aborts.

Reproduced deterministically against the real OTel-CH logs DDL (skip indexes + `ORDER BY (toStartOfFiveMinutes(Timestamp), ServiceName, Timestamp)`):

| ClickHouse | detected_fields peek |
|------------|----------------------|
| 25.8.28.1  | ✅ pass (no such optimisation) |
| 26.3.17.56 | ✅ pass |
| 26.4.5.143 | ✅ pass |
| **26.5.1.1 (chDB)** | ❌ **Code 53** |
| **26.5.6.64** | ❌ **Code 53** |
| 26.6.2.81  | ✅ pass (fixed upstream) |

`LIMIT 1001` passes where `LIMIT 1000` fails — the threshold confirms the gate. #1260 had just moved the k3d substrate onto 26.5, which is why it surfaced now.

## Blast radius

`/loki/api/v1/detected_fields` only. Its peek projects `Body` + both attribute maps while the stream selector filters on `ResourceAttributes`, and its default `line_limit` is exactly 1000 — so every request 502s and Logs Drilldown renders "Fields: 0".

Sibling surfaces verified clean on 26.5: `/patterns` projects the timestamp alongside the body (which sidesteps the prefilter), and the log query path filters inside a subquery. The defect always **aborts** the query — it never returns wrong rows.

## Changes

- **k3d substrate 26.5 → 26.6** (`clickhouse.yaml` + the `wait-for-clickhouse` init image), matching the compose stack and the existing *"prefer 26.6+"* recommendation in `docs/operations.md`.
- **Preflight warns on a known-defective line** rather than refusing to start. The server clears the version floor and the rest of the gateway is healthy, so an operator pinned to 26.5 keeps serving with one endpoint degraded plus a log line naming the symptom and the fix version. The background re-probe logs it once too — a boot that started ahead of ClickHouse never reads `version()` on the first pass. New `Result.Warnings`; four tests pin defective-warns-but-passes, adjacent-lines-stay-quiet, too-old-carries-no-warning, and warning-survives-an-unrelated-fatal.
- **`docs/operations.md`** documents the line, the blast radius, and why cerberus does **not** work around it in emitted SQL: the shapes that avoid it (projecting the sort column, filtering in a subquery) do so incidentally, so pinning a golden to one would encode an upstream bug as a cerberus invariant.

## Not fixed here

`compose-smoke-shard-info (shard-crawl)` also failed in that run — Traces Drilldown getting a repeated **400** from `/api/search` on the `cerberus-tempo` datasource. Independent of this defect (the compose stack runs 26.6) and being investigated separately; that job is not a required check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
