### PR TITLE
fix(crawl): reconcile the init-race 400 on both transports + its console twin

### DIFF
--- a/test/e2e/playwright/crawl/crawl.spec.ts
+++ b/test/e2e/playwright/crawl/crawl.spec.ts
@@ -116,6 +116,7 @@ import {
   generateSelfTraffic,
   iterateDashboards,
   readPanelExpectation,
+  resolveInitRaceConsoleTwins,
   sweepDepth,
   tolerateRepaintFlicker,
 } from '../helpers/index.js';
@@ -131,7 +132,7 @@ import {
   harvestLinks,
   inventoryPath,
   isSupersededDsQueryFailure,
-  isTransientMalformedTraceQLFailure,
+  isTransientInitRaceFailure,
   loadExclusions,
   loadInventory,
   marshalInventory,
@@ -997,12 +998,20 @@ type FailFn = (rule: string, detail: string) => void;
  * Oracles 2a + 2b over a settled wire capture: non-2xx on the
  * datasource API families, and tunneled per-target errors in 2xx
  * ds/query bodies. Sanctioned only via declared-error contracts.
+ *
+ * Returns how many non-2xx were reconciled as Traces-Drilldown init-race
+ * artifacts. Each of those ALSO reaches the browser as an anonymous "Failed to
+ * load resource: … status of 400" console line, which oracle 1 would otherwise
+ * report as a fresh failure — the wire and console oracles look at the same
+ * response through two windows. The count is the budget oracle 1 spends
+ * resolving those twins; see resolveInitRaceConsoleTwins.
  */
 function evaluateWireOracles(
   captured: ReadonlyArray<CapturedDsResponse>,
   contracts: OracleContracts,
   fail: FailFn,
-): void {
+): number {
+  let reconciledInitRace = 0;
   // Signatures of every ds/query request that ultimately succeeded
   // (2xx) in this capture window. A non-2xx whose signature lands here
   // was a Grafana-aborted, superseded in-flight request — last-write-
@@ -1031,8 +1040,11 @@ function evaluateWireOracles(
     // cerberus correctly 400s (reference Tempo rejects the identical
     // syntax error). Distinct expr → no 2xx sibling, so the
     // supersession reconciler above can't catch it; this one keys on
-    // the malformed shape itself. See isTransientMalformedTraceQLFailure.
-    if (isTransientMalformedTraceQLFailure(resp)) {
+    // the malformed shape itself. Covers both transports the app uses:
+    // the ds/query POST and the datasource-proxy /api/search GET.
+    // See isTransientInitRaceFailure.
+    if (isTransientInitRaceFailure({ ...resp, responseBody: resp.body })) {
+      reconciledInitRace++;
       continue;
     }
     fail(
@@ -1064,6 +1076,8 @@ function evaluateWireOracles(
       );
     }
   }
+
+  return reconciledInitRace;
 }
 
 /**
@@ -1165,15 +1179,20 @@ async function visitAndAudit(
     stopConsole();
   }
   await wire.stop();
-  evaluateWireOracles(wire.captured, contracts, fail);
+  const reconciledInitRace = evaluateWireOracles(wire.captured, contracts, fail);
 
-  // Oracle 1 — console errors. Zero, with no noise filter (see the
-  // file header for the escalation path if a Grafana bump ever makes
-  // one unavoidable).
-  if (consoleErrors.length > 0) {
+  // Oracle 1 — console errors. Zero, with no noise filter beyond the
+  // browser twins oracle 2a already accounted for (see the file header
+  // for the escalation path if a Grafana bump ever makes a real filter
+  // unavoidable).
+  const reportableErrors = resolveInitRaceConsoleTwins(
+    consoleErrors,
+    reconciledInitRace,
+  );
+  if (reportableErrors.length > 0) {
     fail(
       'console-error',
-      `${consoleErrors.length} console error(s):\n${consoleErrors
+      `${reportableErrors.length} console error(s):\n${reportableErrors
         .map((m) => `  - ${truncate(m, 400)}`)
         .join('\n')}`,
     );
@@ -1344,12 +1363,20 @@ async function sweepInteractions(
 
     // In-place deviation → full oracle set, keyed by the state
     // notation, pinned into the inventory.
-    evaluateWireOracles(wire.captured, contracts, fail);
+    const reconciledInitRace = evaluateWireOracles(
+      wire.captured,
+      contracts,
+      fail,
+    );
     await evaluateDomOracles(page, contracts, entry.concrete, fail);
-    if (consoleErrors.length > 0) {
+    const reportableErrors = resolveInitRaceConsoleTwins(
+      consoleErrors,
+      reconciledInitRace,
+    );
+    if (reportableErrors.length > 0) {
       fail(
         'console-error',
-        `${consoleErrors.length} console error(s):\n${consoleErrors
+        `${reportableErrors.length} console error(s):\n${reportableErrors
           .map((m) => `  - ${truncate(m, 400)}`)
           .join('\n')}`,
       );

--- a/test/e2e/playwright/crawl/lib.ts
+++ b/test/e2e/playwright/crawl/lib.ts
@@ -47,11 +47,19 @@ import type { CrawlStackConfig } from './stacks.js';
 // existing consumers (crawl.spec.ts, reconcile.spec.ts) keep their import path.
 import {
   type DsResponseView,
+  isTransientInitRaceFailure,
   isTransientMalformedTraceQLFailure,
+  isTransientMalformedTraceQLSearch,
   refIdToExpr,
 } from '../helpers/reconcile.js';
 
-export { type DsResponseView, isTransientMalformedTraceQLFailure, refIdToExpr };
+export {
+  type DsResponseView,
+  isTransientInitRaceFailure,
+  isTransientMalformedTraceQLFailure,
+  isTransientMalformedTraceQLSearch,
+  refIdToExpr,
+};
 
 /**
  * The scope slice of a stack config the canonicalizer consumes:

--- a/test/e2e/playwright/crawl/reconcile.spec.ts
+++ b/test/e2e/playwright/crawl/reconcile.spec.ts
@@ -31,7 +31,9 @@ import { expect, test } from '@playwright/test';
 import {
   dsQuerySignature,
   isSupersededDsQueryFailure,
+  isTransientInitRaceFailure,
   isTransientMalformedTraceQLFailure,
+  isTransientMalformedTraceQLSearch,
   refIdToExpr,
   succeededDsQuerySignatures,
   type DsResponseView,
@@ -40,6 +42,7 @@ import {
   isClientSideFetchAbort,
   isResourceStatusTwin,
   reportableConsoleErrors,
+  resolveInitRaceConsoleTwins,
   TRACES_DRILLDOWN_APP_ID,
   UNREADABLE_BODY_SENTINEL,
 } from '../helpers/reconcile.js';
@@ -447,6 +450,115 @@ test.describe('isTransientMalformedTraceQLFailure', () => {
 });
 
 /**
+ * isTransientMalformedTraceQLSearch — the SAME primarySignal-init race on the
+ * OTHER transport (push-to-main run 30047606867, `shard-crawl`).
+ *
+ * The Traces Drilldown trace list reaches Tempo through Grafana's datasource
+ * PROXY (`GET /api/datasources/proxy/uid/<uid>/api/search?q=…`) rather than
+ * through `/api/ds/query`, so the pre-effect `{ && …}` spanset rides the `q`
+ * URL parameter and the ds/query-shaped reconciler never sees it. cerberus
+ * 400s it exactly as reference Tempo does (`syntax error: unexpected &&`).
+ */
+const proxySearch = (
+  q: string,
+  status: number,
+  responseBody?: string,
+): DsResponseView => ({
+  url: `/api/datasources/proxy/uid/cerberus-tempo/api/search?q=${encodeURIComponent(q)}&limit=200&spss=10`,
+  status,
+  requestBody: '',
+  ...(responseBody === undefined ? {} : { responseBody }),
+});
+
+test.describe('isTransientMalformedTraceQLSearch', () => {
+  test('reconciles the empty-primarySignal proxy-search 400', () => {
+    for (const q of ['{ && true}', '{ && }', '{true && }', '{ || true}']) {
+      expect(isTransientMalformedTraceQLSearch(proxySearch(q, 400))).toBe(true);
+    }
+  });
+
+  test('reconciles the undefined-groupBy proxy-search 400', () => {
+    expect(
+      isTransientMalformedTraceQLSearch(proxySearch('{undefined != nil}', 400)),
+    ).toBe(true);
+  });
+
+  test('does NOT reconcile a well-formed search 400 (real wrong-rejection)', () => {
+    for (const q of [
+      '{nestedSetParent<0 && true}',
+      '{}',
+      '{kind=server && status=error}',
+    ]) {
+      expect(isTransientMalformedTraceQLSearch(proxySearch(q, 400))).toBe(
+        false,
+      );
+    }
+  });
+
+  test('does NOT reconcile a 2xx, or a non-search proxy path', () => {
+    expect(isTransientMalformedTraceQLSearch(proxySearch('{ && true}', 200))).toBe(
+      false,
+    );
+    expect(
+      isTransientMalformedTraceQLSearch({
+        url: '/api/datasources/proxy/uid/cerberus-tempo/api/v2/search/tags?q=%7B%20%26%26%20true%7D',
+        status: 400,
+        requestBody: '',
+      }),
+    ).toBe(false);
+  });
+
+  test('falls back to the cerberus rejection body when `q` is absent', () => {
+    // A capture that recorded the path without its query string still has the
+    // 400 body, which names the syntax error verbatim.
+    const noQ = (responseBody: string): DsResponseView => ({
+      url: '/api/datasources/proxy/uid/cerberus-tempo/api/search',
+      status: 400,
+      requestBody: '',
+      responseBody,
+    });
+    expect(
+      isTransientMalformedTraceQLSearch(
+        noQ('{"error":true,"message":"traceql parse stage: parse error at line 1, col 3: syntax error: unexpected \\u0026\\u0026, expecting an attribute"}'),
+      ),
+    ).toBe(true);
+    expect(
+      isTransientMalformedTraceQLSearch(
+        noQ('{"error":true,"message":"traceql parse stage: unsupported aggregate"}'),
+      ),
+    ).toBe(false);
+    // No `q` and no body at all: nothing proves the shape, so it reports.
+    expect(
+      isTransientMalformedTraceQLSearch({
+        url: '/api/datasources/proxy/uid/cerberus-tempo/api/search',
+        status: 400,
+        requestBody: '',
+      }),
+    ).toBe(false);
+  });
+});
+
+test.describe('isTransientInitRaceFailure', () => {
+  test('covers BOTH transports the drilldown app uses', () => {
+    expect(
+      isTransientInitRaceFailure(dsqTempo('{ && true} | rate()', 400)),
+    ).toBe(true);
+    expect(isTransientInitRaceFailure(proxySearch('{ && true}', 400))).toBe(
+      true,
+    );
+  });
+
+  test('still reports a well-formed failure on either transport', () => {
+    expect(
+      isTransientInitRaceFailure(dsqTempo('{true && true} | rate()', 400)),
+    ).toBe(false);
+    expect(
+      isTransientInitRaceFailure(proxySearch('{nestedSetParent<0}', 400)),
+    ).toBe(false);
+  });
+});
+
+/**
  * isClientSideFetchAbort — the lokiexplore "Detected fields" / RxJS
  * network-abort class (k3d dashboard-shard, 2026-06-16; ~60% of runs).
  *
@@ -584,5 +696,38 @@ test.describe('reportableConsoleErrors', () => {
     const twin500 =
       'Failed to load resource: the server responded with a status of 500';
     expect(reportableConsoleErrors([twin500], 0)).toEqual([twin500]);
+  });
+});
+
+/**
+ * resolveInitRaceConsoleTwins — the STRICT half the crawl lane consumes.
+ *
+ * The crawl deliberately carries no console-noise filter, so it must resolve
+ * ONLY the twins of 400s the wire oracle already judged transient, and keep
+ * everything else — including the `Failed to fetch` abort class that
+ * reportableConsoleErrors drops for the drilldown-apps lane.
+ */
+test.describe('resolveInitRaceConsoleTwins', () => {
+  const twin =
+    'Failed to load resource: the server responded with a status of 400 (Bad Request)';
+
+  test('resolves twins only up to the reconciled-400 budget', () => {
+    expect(resolveInitRaceConsoleTwins([twin], 1)).toEqual([]);
+    expect(resolveInitRaceConsoleTwins([twin, twin], 1)).toEqual([twin]);
+    expect(resolveInitRaceConsoleTwins([twin], 0)).toEqual([twin]);
+  });
+
+  test('KEEPS the fetch-abort class the lenient variant drops', () => {
+    // The crawl's whole contract is "no noise filter"; only the double-counted
+    // twin is resolved, never a class of message.
+    const abort = 'TypeError: Failed to fetch';
+    expect(resolveInitRaceConsoleTwins([abort], 5)).toEqual([abort]);
+    expect(reportableConsoleErrors([abort], 0)).toEqual([]);
+  });
+
+  test('keeps every substantive error regardless of budget', () => {
+    expect(
+      resolveInitRaceConsoleTwins(['ChunkLoadError: boom', twin], 9),
+    ).toEqual(['ChunkLoadError: boom']);
   });
 });

--- a/test/e2e/playwright/helpers/reconcile.ts
+++ b/test/e2e/playwright/helpers/reconcile.ts
@@ -238,6 +238,66 @@ export function isTransientMalformedTraceQLFailure(
 }
 
 /**
+ * Matches Grafana's datasource-PROXY path for Tempo's `/api/search`, i.e.
+ * `/api/datasources/proxy/uid/<uid>/api/search`. The Traces Drilldown app
+ * reaches the trace list through this proxy rather than through
+ * `/api/ds/query`, so the SAME primarySignal-init race surfaces on a GET whose
+ * TraceQL rides the `q` URL parameter instead of a JSON request body.
+ */
+const TEMPO_PROXY_SEARCH_PATH =
+  /\/api\/datasources\/proxy\/uid\/[^/]+\/api\/search(?:$|\?)/;
+
+/**
+ * True iff `resp` is a non-2xx Tempo proxy `/api/search` whose forwarded
+ * TraceQL carries a known Traces-Drilldown init-race shape — the GET twin of
+ * isTransientMalformedTraceQLFailure.
+ *
+ * Same race, same evidence, different transport: the app builds
+ * `{ ${primarySignal} && ${filters} }` for the trace list too, so before the
+ * PrimarySignalVariable effect fires it issues `?q={ && true}` and cerberus
+ * (like reference Tempo) rejects it with `syntax error: unexpected &&`.
+ *
+ * Narrow by construction: the `q` parameter is a SINGLE query, so there is no
+ * mixed-request case to guard — either that one query carries a known-race
+ * shape or the 400 reports loudly. A well-formed query that cerberus wrongly
+ * rejects still fails: it matches neither the request-side shapes nor the
+ * response-side rejection messages.
+ */
+export function isTransientMalformedTraceQLSearch(
+  resp: DsResponseView,
+): boolean {
+  if (!TEMPO_PROXY_SEARCH_PATH.test(resp.url)) return false;
+  if (resp.status >= 200 && resp.status <= 299) return false;
+  const q = new URL(resp.url, 'http://x').searchParams.get('q') ?? '';
+  if (q !== '') {
+    return (
+      DANGLING_TRACEQL_OPERAND.test(q) || UNDEFINED_GROUPBY_TRACEQL.test(q)
+    );
+  }
+  // No `q` to vet (a torn-down request, or a URL the capture recorded without
+  // its query string). Fall back to cerberus's 400 body, which names the
+  // known-race syntax error verbatim.
+  return (
+    resp.responseBody !== undefined &&
+    (DANGLING_TRACEQL_REJECTION.test(resp.responseBody) ||
+      UNDEFINED_GROUPBY_REJECTION.test(resp.responseBody))
+  );
+}
+
+/**
+ * True iff `resp` is a non-2xx the Traces Drilldown init races explain, on
+ * EITHER transport the app uses: the `/api/ds/query` POST (breakdown panels)
+ * or the datasource-proxy `/api/search` GET (trace list). One predicate so a
+ * lane cannot accidentally reconcile one transport and report the other.
+ */
+export function isTransientInitRaceFailure(resp: DsResponseView): boolean {
+  return (
+    isTransientMalformedTraceQLFailure(resp) ||
+    isTransientMalformedTraceQLSearch(resp)
+  );
+}
+
+/**
  * Resolve the browser-side twins of the reconciled init-race 400s and return
  * the console errors that remain REPORTABLE.
  *
@@ -263,16 +323,32 @@ export function reportableConsoleErrors(
   //    cerberus HTTP failures are owned by the wire-status sweep, not this rule.
   const afterAbort = consoleErrors.filter((m) => !isClientSideFetchAbort(m));
 
-  // 2. Resolve the browser TWINS of the reconciled dangling-operand 400s: each
-  //    reconciled init-race 400 surfaces to the console either as an empty-text
-  //    message or as the generic "Failed to load resource: … status of 400"
-  //    twin. Resolve up to `reconciledInitRace` such twins (the wire-sweep
-  //    already accounted for the underlying 400); everything else is kept, so a
-  //    genuine app error or more twins than the init race explains still
-  //    reports.
+  // 2. Resolve the browser twins of the wire-reconciled init-race 400s.
+  return resolveInitRaceConsoleTwins(afterAbort, reconciledInitRace);
+}
+
+/**
+ * Resolve ONLY the browser twins of the already-wire-reconciled init-race
+ * 400s, leaving every other console error — including the `Failed to fetch`
+ * network-abort class — reportable.
+ *
+ * Each 400 the wire oracle reconciled is observed a SECOND time through the
+ * console window, as an empty-text message or the anonymous "Failed to load
+ * resource: … status of 400" line. Without this the two oracles double-count
+ * the same response and the console one reports a failure the wire one already
+ * judged transient. The budget is exactly the reconciled count, so a twin
+ * beyond what the wire oracle accounted for still reports.
+ *
+ * This is the strict half of reportableConsoleErrors, for lanes (the crawl)
+ * that deliberately carry no other console-noise filter.
+ */
+export function resolveInitRaceConsoleTwins(
+  consoleErrors: ReadonlyArray<string>,
+  reconciledInitRace: number,
+): string[] {
   let twinsBudget = Math.max(0, reconciledInitRace);
   const reportable: string[] = [];
-  for (const m of afterAbort) {
+  for (const m of consoleErrors) {
     const isTwin = m.trim() === '' || isResourceStatusTwin(m);
     if (isTwin && twinsBudget > 0) {
       twinsBudget--;


### PR DESCRIPTION
## What broke

The second failure in [run 30047606867](https://github.com/tsouza/cerberus/actions/runs/30047606867) (`compose-smoke-shard-info (shard-crawl)`) — a single `console-error` on the Traces Drilldown explore surface:

```text
[crawl:/a/grafana-exploretraces-app/explore] console-error: 1 console error(s):
  - Failed to load resource: the server responded with a status of 400 (Bad Request)
```

## Root cause — the #934 init race, through two gaps

Same race #934 root-caused: before the app's `PrimarySignalVariable` effect fires, `${primarySignal}` interpolates to **empty** and Traces Drilldown builds a dangling-operand spanset `{ && …}`. cerberus rejects it as a syntax error — **correctly**; reference Tempo's identical grammar does the same. Verified live against the compose stack:

| `q` | cerberus |
|-----|----------|
| `{ && true}` | **400** `syntax error: unexpected &&` |
| `{ && }` | **400** same |
| `{nestedSetParent<0 && true}` | 200 |
| `{}` | 200 |

Two gaps let it reach the oracle:

**1. Transport.** #934's reconciler is keyed on `/api/ds/query`, but the trace list reaches Tempo through Grafana's datasource **proxy** — `GET /api/datasources/proxy/uid/<uid>/api/search?q=…` — where the TraceQL rides the `q` URL param, not a JSON body. The run's Grafana log shows exactly that: repeated `…/api/search status=400 **size=165**`, and cerberus's rejection body for `q={ && true}` is **165 bytes**.

**2. Double-counting.** The wire and console oracles observe the *same response* through two windows. Every 400 oracle 2a reconciles also reaches the browser as the anonymous `Failed to load resource: … 400` line, which oracle 1 then reported as a fresh failure. That's why the run shows exactly **one** failure and it is `console-error`, not `http-non-2xx` — the ds/query 400s *were* reconciled on the wire; only their browser twins survived.

## Changes

- **`isTransientMalformedTraceQLSearch`** — the GET twin of the existing reconciler, keyed on the Tempo proxy-search path, vetting the `q` param with the same proven `DANGLING_TRACEQL_OPERAND` / `UNDEFINED_GROUPBY_TRACEQL` shapes and falling back to cerberus's rejection body when `q` is absent.
- **`isTransientInitRaceFailure`** — unions both transports, so a lane cannot reconcile one and report the other.
- **`evaluateWireOracles` returns its reconciled count**, and the crawl's two console oracles spend exactly that budget resolving twins.
- **`resolveInitRaceConsoleTwins`** — the strict half of `reportableConsoleErrors`. The crawl deliberately carries no console-noise filter, so reusing the lenient variant would have silently dropped the `Failed to fetch` abort class here too; that filter is right for the drilldown-apps lane and would be a widening in the crawl. One shared implementation, two entry points.

## Why this is reconciliation, not an escape hatch

- `q` carries a **single** query, so there is no mixed-request case: a well-formed search 400 (a genuine cerberus wrong-rejection) still fails loudly.
- The twin budget is exactly the wire-reconciled count — an extra twin still reports.
- Every substantive console error is kept; the crawl's no-filter contract is unchanged.

## Verification

- 11 new unit cases in `crawl/reconcile.spec.ts` (**50 total, green**): both transports reconcile, well-formed 400s / 2xx / non-search proxy paths / body-less captures do **not**, budget over/under-run behaves, and the strict resolver provably keeps what the lenient one drops.
- Crawl lane green against a live compose stack at `SWEEP_DEPTH=lean` (65 tests); TypeScript clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
