### PR TITLE
feat(migrate): extend inventory + rulegraph to Loki, fold into gate

### DIFF
--- a/cmd/cerberus/cmd_migrate.go
+++ b/cmd/cerberus/cmd_migrate.go
@@ -384,33 +384,46 @@ func runClassifyCommand(cmd *cobra.Command, rules, lokiRules []string, dashboard
 
 // newMigrateRuleGraphCmd builds the recording-rule-output → consumer dependency
 // graph and lists the consumers that MUST keep being materialized post-cutover.
-// Needs --rules and/or --corpus.
+// Needs --rules, --loki-rules, and/or --corpus. Tempo has no rule-file concept
+// in this sense — its metrics-generator is a fixed-shape, config-driven metric
+// emitter with no user-authored record:/expr: rule file to point a glob at —
+// so there is deliberately no --tempo-rules flag; offering one with nothing
+// behind it would itself be the silent-ignore anti-pattern this tool avoids.
 func newMigrateRuleGraphCmd() *cobra.Command {
 	var (
-		rules  []string
-		corpus string
-		out    string
-		asJSON bool
+		rules     []string
+		lokiRules []string
+		corpus    string
+		out       string
+		asJSON    bool
 	)
 	cmd := &cobra.Command{
 		Use:   "rulegraph",
 		Short: "Map recording-rule outputs to the consumers that must stay materialized",
 		Long: "Link each recording rule's recorded OUTPUT series (its record: name, from\n" +
-			"--rules) to the corpus queries and alerting exprs that reference it\n" +
-			"(--rules alerts + --corpus), classify every recorded series as consumed or\n" +
-			"orphan, and list the consumers that MUST keep being materialized after\n" +
-			"cutover (cerberus has no ruler). Fully offline; anything unparseable is a\n" +
-			"counted skip, never silently dropped.",
-		Example:       "  cerberus migrate rulegraph --rules 'rules/*.yml' --corpus corpus.json",
+			"--rules and/or --loki-rules) to the corpus queries and alerting exprs that\n" +
+			"reference it (--rules alerts + --corpus), classify every recorded series as\n" +
+			"consumed or orphan, and list the consumers that MUST keep being\n" +
+			"materialized after cutover (cerberus has no ruler). --loki-rules harvests\n" +
+			"only Loki ruler record: output series: a LogQL alerting or recording expr\n" +
+			"is a log-stream selector, not a metric reference, so it can never itself\n" +
+			"consume a recorded series and is never fed into the consumer pipeline.\n" +
+			"Tempo has no rule concept in this sense (its metrics-generator has no\n" +
+			"user-authored rule file), so there is no --tempo-rules flag. Fully\n" +
+			"offline; anything unparseable is a counted skip, never silently dropped.",
+		Example:       "  cerberus migrate rulegraph --rules 'rules/*.yml' --loki-rules 'loki/*.yml' --corpus corpus.json",
 		Args:          cobra.NoArgs,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runRuleGraphCommand(cmd, normalizeList(rules), corpus, out, asJSON)
+			return runRuleGraphCommand(cmd, normalizeList(rules), normalizeList(lokiRules), corpus, out, asJSON)
 		},
 	}
 	cmd.Flags().StringSliceVar(&rules, "rules", nil,
-		"recording/alerting rule files: record: names are the recorded series, alerting exprs are consumers "+
+		"Prometheus recording/alerting rule files: record: names are the recorded series, alerting exprs are consumers "+
+			"(repeatable or comma-separated paths/globs)")
+	cmd.Flags().StringSliceVar(&lokiRules, "loki-rules", nil,
+		"Loki ruler rule files: only record: names are harvested, as recorded series "+
 			"(repeatable or comma-separated paths/globs)")
 	cmd.Flags().StringVar(&corpus, "corpus", "",
 		"harvested corpus.json (from `cerberus migrate harvest`) whose queries are scanned as consumers")
@@ -419,12 +432,12 @@ func newMigrateRuleGraphCmd() *cobra.Command {
 	return cmd
 }
 
-func runRuleGraphCommand(cmd *cobra.Command, rules []string, corpus, out string, asJSON bool) error {
-	if len(rules) == 0 && corpus == "" {
+func runRuleGraphCommand(cmd *cobra.Command, rules, lokiRules []string, corpus, out string, asJSON bool) error {
+	if len(rules) == 0 && len(lokiRules) == 0 && corpus == "" {
 		_ = cmd.Usage()
-		return fmt.Errorf("rulegraph needs --rules (for recorded series) and/or --corpus (for consumers)")
+		return fmt.Errorf("rulegraph needs --rules and/or --loki-rules (for recorded series) and/or --corpus (for consumers)")
 	}
-	g, err := buildRuleGraph(rules, corpus)
+	g, err := buildRuleGraph(rules, lokiRules, corpus)
 	if err != nil {
 		return err
 	}
@@ -998,11 +1011,21 @@ func runClassifyReport(w io.Writer, src migrate.CorpusSource, asJSON bool) error
 }
 
 // buildRuleGraph assembles the graph inputs: recorded series + alerting
-// consumers from the rule files, plus every corpus query as an additional
+// consumers from the Prometheus rule files, recorded series (record: only)
+// from the Loki rule files, plus every corpus query as an additional
 // consumer. Rule-file and corpus skips are threaded through so the graph's skip
-// count accounts for every dropped input.
-func buildRuleGraph(rules []string, corpus string) (migrate.RuleGraph, error) {
+// count accounts for every dropped input. When lokiRules is empty this runs
+// the exact same code path as before it existed — no HarvestLokiRuleFiles
+// call, no output-shape change — which is what keeps MIG-04's committed
+// golden byte-identical for the existing --rules/--corpus invocation.
+func buildRuleGraph(rules, lokiRules []string, corpus string) (migrate.RuleGraph, error) {
 	recorded, consumers, skipped := migrate.HarvestRuleFiles(rules)
+
+	if len(lokiRules) > 0 {
+		lokiRecorded, lokiSkipped := migrate.HarvestLokiRuleFiles(lokiRules)
+		recorded = append(recorded, lokiRecorded...)
+		skipped = append(skipped, lokiSkipped...)
+	}
 
 	if corpus != "" {
 		cq, csk, err := migrate.CorpusFileSource{Path: corpus}.Harvest(context.Background())

--- a/cmd/cerberus/cmd_migrate.go
+++ b/cmd/cerberus/cmd_migrate.go
@@ -769,27 +769,42 @@ func runVerifyCommand(cmd *cobra.Command, in verifyInputs) error {
 	return nil
 }
 
-// newMigrateInventoryCmd probes a LIVE source Prometheus for the runtime
-// cardinality facts config can't reveal offline — the head-block series/label
-// cardinality that drives OOM risk — ranks the top-N candidates, and writes the
-// report. Flags fall back to CERBERUS_INVENTORY_*.
+// newMigrateInventoryCmd probes LIVE migration sources for the runtime
+// cardinality facts config can't reveal offline. The source Prometheus is
+// always probed (its head-block series/label cardinality drives OOM risk,
+// ranked to the top-N candidates); a Loki source is probed only when
+// --loki-source is supplied (its per-selector stream cardinality/volume,
+// ranked across the operator-supplied --loki-selector set — Loki has no
+// whole-tenant top-N call to rank without one); a Tempo source, supplied via
+// --tempo-source, records a fixed out-of-scope entry rather than a fabricated
+// cardinality number, since Tempo's span/block storage exposes nothing
+// analogous. Flags fall back to CERBERUS_INVENTORY_*.
 func newMigrateInventoryCmd() *cobra.Command {
 	var (
-		source string
-		top    int
-		window string
-		asJSON bool
-		out    string
+		source        string
+		top           int
+		window        string
+		asJSON        bool
+		out           string
+		lokiSource    string
+		lokiSelectors []string
+		tempoSource   string
 	)
 	cmd := &cobra.Command{
 		Use:   "inventory",
-		Short: "Probe a live source Prometheus for cardinality / OOM-risk facts",
+		Short: "Probe live migration sources for cardinality / OOM-risk facts",
 		Long: "Probe the LIVE source Prometheus for the runtime cardinality facts config\n" +
 			"can't reveal offline: /api/v1/status/tsdb (plus optional label-values and\n" +
 			"metadata) ranked as the top-N metrics by series count and labels by\n" +
 			"cardinality — the OOM candidates cerberus can't see before cutover. It\n" +
 			"refuses to infer from prometheus.yml. The numbers RANK RISK; they do not\n" +
-			"predict cerberus's exact memory.",
+			"predict cerberus's exact memory.\n\n" +
+			"--loki-source additionally probes a Loki instance's per-selector\n" +
+			"/loki/api/v1/index/stats endpoint, ranking the --loki-selector set the\n" +
+			"operator supplies (Loki has no whole-tenant top-N call to rank without\n" +
+			"one). --tempo-source records a fixed, specifically-reasoned out-of-scope\n" +
+			"entry: Tempo's span/block storage exposes no cardinality-ranking API\n" +
+			"analogous to Prometheus's or Loki's, so no proxy number is fabricated.",
 		Example:       "  cerberus migrate inventory --source http://prometheus:9090 --top 50 --json",
 		Args:          cobra.NoArgs,
 		SilenceUsage:  true,
@@ -798,6 +813,16 @@ func newMigrateInventoryCmd() *cobra.Command {
 			if source == "" {
 				return errors.New("missing --source (or CERBERUS_INVENTORY_SOURCE): the source Prometheus base URL to probe")
 			}
+			selectors := normalizeList(lokiSelectors)
+			if len(selectors) > 0 && lokiSource == "" {
+				return errors.New("--loki-selector supplied without --loki-source: " +
+					"point --loki-source at a Loki base URL or drop --loki-selector")
+			}
+			if lokiSource != "" && len(selectors) == 0 {
+				return errors.New("--loki-source requires at least one --loki-selector: " +
+					"Loki has no whole-tenant top-N cardinality endpoint, so name what to rank")
+			}
+
 			opts := migrateinventory.Options{Top: top, Window: window}
 			if err := opts.Validate(); err != nil {
 				return err
@@ -806,16 +831,39 @@ func newMigrateInventoryCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+
+			if lokiSource != "" {
+				lokiInv, err := migrateinventory.NewLokiClient(lokiSource).Probe(context.Background(), selectors, window, top)
+				if err != nil {
+					return err
+				}
+				inv.Loki = &lokiInv
+			}
+			if tempoSource != "" {
+				tempoInv := migrateinventory.NewTempoInventory(tempoSource)
+				inv.Tempo = &tempoInv
+			}
+
 			return writeInventory(cmd.OutOrStdout(), out, inv, asJSON)
 		},
 	}
 	cmd.Flags().StringVar(&source, "source", envOr("CERBERUS_INVENTORY_SOURCE", ""),
 		"source Prometheus base URL to probe for live cardinality (env: CERBERUS_INVENTORY_SOURCE)")
-	cmd.Flags().IntVar(&top, "top", migrateinventory.DefaultTop, "rank the top N metrics/labels by cardinality")
+	cmd.Flags().IntVar(&top, "top", migrateinventory.DefaultTop, "rank the top N metrics/labels/selectors by cardinality")
 	cmd.Flags().StringVar(&window, "window", envOr("CERBERUS_INVENTORY_WINDOW", ""),
-		"optional observation window (duration like 1h) recorded as report context (env: CERBERUS_INVENTORY_WINDOW)")
+		"optional observation window (duration like 1h); recorded as report context for Prometheus, "+
+			"and applied as the real query range for Loki's index/stats (env: CERBERUS_INVENTORY_WINDOW)")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "emit the machine-readable JSON report instead of text")
 	cmd.Flags().StringVar(&out, "out", "", "write the inventory here (default: stdout)")
+	cmd.Flags().StringVar(&lokiSource, "loki-source", envOr("CERBERUS_INVENTORY_LOKI_SOURCE", ""),
+		"optional Loki base URL to probe per-selector stream cardinality/volume (requires --loki-selector; "+
+			"env: CERBERUS_INVENTORY_LOKI_SOURCE)")
+	cmd.Flags().StringArrayVar(&lokiSelectors, "loki-selector", envOrList("CERBERUS_INVENTORY_LOKI_SELECTORS"),
+		"Loki stream selector to rank via /loki/api/v1/index/stats (repeatable; required with --loki-source; "+
+			"env: CERBERUS_INVENTORY_LOKI_SELECTORS, comma-separated)")
+	cmd.Flags().StringVar(&tempoSource, "tempo-source", envOr("CERBERUS_INVENTORY_TEMPO_SOURCE", ""),
+		"optional Tempo base URL; presence alone records a fixed out-of-scope inventory entry, no probe is made "+
+			"(env: CERBERUS_INVENTORY_TEMPO_SOURCE)")
 	return cmd
 }
 
@@ -1303,6 +1351,18 @@ func envOr(key, def string) string {
 		return v
 	}
 	return def
+}
+
+// envOrList parses a comma-separated environment fallback for a repeatable
+// flag, applying normalizeList's trim-and-drop-blanks semantics. It returns
+// nil (not an empty non-nil slice) when the variable is unset, so cobra's
+// flag default stays indistinguishable from "never set."
+func envOrList(key string) []string {
+	v := os.Getenv(key)
+	if v == "" {
+		return nil
+	}
+	return normalizeList(strings.Split(v, ","))
 }
 
 // envFloat returns the float parsed from the environment value for key, or def

--- a/cmd/cerberus/cmd_migrate.go
+++ b/cmd/cerberus/cmd_migrate.go
@@ -871,9 +871,9 @@ func newMigrateInventoryCmd() *cobra.Command {
 	cmd.Flags().StringVar(&lokiSource, "loki-source", envOr("CERBERUS_INVENTORY_LOKI_SOURCE", ""),
 		"optional Loki base URL to probe per-selector stream cardinality/volume (requires --loki-selector; "+
 			"env: CERBERUS_INVENTORY_LOKI_SOURCE)")
-	cmd.Flags().StringArrayVar(&lokiSelectors, "loki-selector", envOrList("CERBERUS_INVENTORY_LOKI_SELECTORS"),
+	cmd.Flags().StringArrayVar(&lokiSelectors, "loki-selector", envOrLokiSelectors("CERBERUS_INVENTORY_LOKI_SELECTORS"),
 		"Loki stream selector to rank via /loki/api/v1/index/stats (repeatable; required with --loki-source; "+
-			"env: CERBERUS_INVENTORY_LOKI_SELECTORS, comma-separated)")
+			"env: CERBERUS_INVENTORY_LOKI_SELECTORS, one selector per line — a selector may itself contain a comma)")
 	cmd.Flags().StringVar(&tempoSource, "tempo-source", envOr("CERBERUS_INVENTORY_TEMPO_SOURCE", ""),
 		"optional Tempo base URL; presence alone records a fixed out-of-scope inventory entry, no probe is made "+
 			"(env: CERBERUS_INVENTORY_TEMPO_SOURCE)")
@@ -1376,16 +1376,22 @@ func envOr(key, def string) string {
 	return def
 }
 
-// envOrList parses a comma-separated environment fallback for a repeatable
-// flag, applying normalizeList's trim-and-drop-blanks semantics. It returns
-// nil (not an empty non-nil slice) when the variable is unset, so cobra's
-// flag default stays indistinguishable from "never set."
-func envOrList(key string) []string {
+// envOrLokiSelectors parses the environment fallback for the repeatable
+// --loki-selector flag. It deliberately does NOT comma-split the way a
+// generic repeatable-flag env fallback would: a LogQL stream selector
+// routinely contains a comma itself (e.g. the ordinary multi-label selector
+// `{app="checkout", env="prod"}`), and comma-splitting would corrupt it into
+// two malformed fragments. Each selector is instead one line, matching
+// --loki-selector's StringArrayVar CLI semantics where every occurrence of
+// the flag is one whole, unsplit selector. It returns nil (not an empty
+// non-nil slice) when the variable is unset, so cobra's flag default stays
+// indistinguishable from "never set."
+func envOrLokiSelectors(key string) []string {
 	v := os.Getenv(key)
 	if v == "" {
 		return nil
 	}
-	return normalizeList(strings.Split(v, ","))
+	return normalizeList(strings.Split(v, "\n"))
 }
 
 // envFloat returns the float parsed from the environment value for key, or def

--- a/cmd/cerberus/cmd_migrate_inventory_test.go
+++ b/cmd/cerberus/cmd_migrate_inventory_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -58,8 +59,9 @@ func TestRunInventory_JSON(t *testing.T) {
 		t.Fatalf("runInventory --json: %v (stderr: %s)", err, errOut.String())
 	}
 	got := out.String()
-	if !strings.Contains(got, `"schema_version": 1`) {
-		t.Errorf("JSON inventory should stamp schema_version, got:\n%s", got)
+	wantVer := fmt.Sprintf(`"schema_version": %d`, migrateinventory.InventoryVersion)
+	if !strings.Contains(got, wantVer) {
+		t.Errorf("JSON inventory should stamp %s, got:\n%s", wantVer, got)
 	}
 	if !strings.Contains(got, "http_requests_total") {
 		t.Errorf("JSON inventory should rank the high-cardinality metric, got:\n%s", got)
@@ -159,5 +161,136 @@ func TestRunInventory_OutFile(t *testing.T) {
 	wantVer := fmt.Sprintf(`"schema_version": %d`, migrateinventory.InventoryVersion)
 	if !strings.Contains(string(data), wantVer) {
 		t.Errorf("out file should stamp %s for the gate, got:\n%s", wantVer, data)
+	}
+}
+
+// TestRunInventory_LegacyInvocationHasNoHeadSections: a bare --source/--top/
+// --window/--json invocation (no --loki-source, no --tempo-source) must not
+// grow "loki" or "tempo" JSON keys — the per-head sections are additive, and
+// their absence must be visible absence, not an empty object.
+func TestRunInventory_LegacyInvocationHasNoHeadSections(t *testing.T) {
+	clearInventoryEnv(t)
+	t.Setenv("CERBERUS_INVENTORY_LOKI_SOURCE", "")
+	t.Setenv("CERBERUS_INVENTORY_LOKI_SELECTORS", "")
+	t.Setenv("CERBERUS_INVENTORY_TEMPO_SOURCE", "")
+	srv := tsdbServer(t)
+
+	var out, errOut bytes.Buffer
+	if err := runInventory([]string{"--source", srv.URL, "--top", "10", "--window", "1h", "--json"}, &out, &errOut); err != nil {
+		t.Fatalf("runInventory: %v (stderr: %s)", err, errOut.String())
+	}
+	got := out.String()
+	if strings.Contains(got, `"loki"`) {
+		t.Errorf("legacy invocation should carry no \"loki\" key, got:\n%s", got)
+	}
+	if strings.Contains(got, `"tempo"`) {
+		t.Errorf("legacy invocation should carry no \"tempo\" key, got:\n%s", got)
+	}
+}
+
+// lokiIndexStatsServer answers /loki/api/v1/index/stats with a fixed
+// {streams, chunks, entries, bytes} body per selector (keyed by the "query"
+// param), so the cmd-level test drives the Loki wiring over real HTTP.
+func lokiIndexStatsServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	byQuery := map[string]string{
+		`{app="checkout"}`: `{"streams":500,"chunks":900,"entries":40000,"bytes":8000000}`,
+		`{app="frontend"}`: `{"streams":50,"chunks":90,"entries":4000,"bytes":800000}`,
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/loki/api/v1/index/stats" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		body, ok := byQuery[r.URL.Query().Get("query")]
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestRunInventory_LokiAndTempoSections: --loki-source/--loki-selector and
+// --tempo-source wire through the CLI into the Loki-ranked section and the
+// fixed Tempo out-of-scope section, ranked highest-streams-first.
+func TestRunInventory_LokiAndTempoSections(t *testing.T) {
+	clearInventoryEnv(t)
+	promSrv := tsdbServer(t)
+	lokiSrv := lokiIndexStatsServer(t)
+
+	var out, errOut bytes.Buffer
+	err := runInventory([]string{
+		"--source", promSrv.URL, "--json",
+		"--loki-source", lokiSrv.URL,
+		"--loki-selector", `{app="frontend"}`,
+		"--loki-selector", `{app="checkout"}`,
+		"--tempo-source", "http://tempo.example:3200",
+	}, &out, &errOut)
+	if err != nil {
+		t.Fatalf("runInventory (loki+tempo): %v (stderr: %s)", err, errOut.String())
+	}
+
+	var inv migrateinventory.Inventory
+	if unmarshalErr := json.Unmarshal(out.Bytes(), &inv); unmarshalErr != nil {
+		t.Fatalf("decode inventory JSON: %v\n%s", unmarshalErr, out.String())
+	}
+
+	if inv.Loki == nil {
+		t.Fatalf("inventory should carry a Loki section, got:\n%s", out.String())
+	}
+	if len(inv.Loki.Selectors) != 2 {
+		t.Fatalf("loki selectors = %d, want 2, got: %+v", len(inv.Loki.Selectors), inv.Loki.Selectors)
+	}
+	if inv.Loki.Selectors[0].Selector != `{app="checkout"}` || inv.Loki.Selectors[0].Streams != 500 {
+		t.Errorf("rank #1 loki selector = %+v, want checkout (500 streams) first", inv.Loki.Selectors[0])
+	}
+	if inv.Loki.Selectors[1].Selector != `{app="frontend"}` || inv.Loki.Selectors[1].Streams != 50 {
+		t.Errorf("rank #2 loki selector = %+v, want frontend (50 streams) second", inv.Loki.Selectors[1])
+	}
+
+	if inv.Tempo == nil {
+		t.Fatalf("inventory should carry a Tempo section, got:\n%s", out.String())
+	}
+	if inv.Tempo.Source != "http://tempo.example:3200" {
+		t.Errorf("tempo source = %q, want the supplied --tempo-source", inv.Tempo.Source)
+	}
+	if inv.Tempo.OutOfScope != migrateinventory.TempoInventoryOutOfScopeReason {
+		t.Errorf("tempo out-of-scope reason = %q, want the specific reason constant", inv.Tempo.OutOfScope)
+	}
+}
+
+// TestRunInventory_LokiSelectorWithoutSourceIsValidationError: --loki-selector
+// with no --loki-source is rejected before any HTTP call, naming both flags.
+func TestRunInventory_LokiSelectorWithoutSourceIsValidationError(t *testing.T) {
+	clearInventoryEnv(t)
+	srv := tsdbServer(t)
+
+	var out, errOut bytes.Buffer
+	err := runInventory([]string{"--source", srv.URL, "--loki-selector", `{app="x"}`}, &out, &errOut)
+	if err == nil {
+		t.Fatal("runInventory should reject --loki-selector without --loki-source")
+	}
+	if !strings.Contains(err.Error(), "--loki-selector") || !strings.Contains(err.Error(), "--loki-source") {
+		t.Errorf("error should name both flags, got: %v", err)
+	}
+}
+
+// TestRunInventory_LokiSourceWithoutSelectorIsValidationError: --loki-source
+// with zero --loki-selector entries is rejected before any HTTP call — Loki
+// has no whole-tenant top-N call to rank without an operator-named selector.
+func TestRunInventory_LokiSourceWithoutSelectorIsValidationError(t *testing.T) {
+	clearInventoryEnv(t)
+	srv := tsdbServer(t)
+
+	var out, errOut bytes.Buffer
+	err := runInventory([]string{"--source", srv.URL, "--loki-source", "http://loki.example:3100"}, &out, &errOut)
+	if err == nil {
+		t.Fatal("runInventory should reject --loki-source without any --loki-selector")
+	}
+	if !strings.Contains(err.Error(), "--loki-selector") {
+		t.Errorf("error should name --loki-selector, got: %v", err)
 	}
 }

--- a/cmd/cerberus/cmd_migrate_inventory_test.go
+++ b/cmd/cerberus/cmd_migrate_inventory_test.go
@@ -262,6 +262,115 @@ func TestRunInventory_LokiAndTempoSections(t *testing.T) {
 	}
 }
 
+// TestRunInventory_LokiSelectorsEnvPreservesCommaBearingSelector pins that the
+// CERBERUS_INVENTORY_LOKI_SELECTORS env fallback treats one line as one whole
+// selector, never comma-splitting it — an ordinary multi-label LogQL stream
+// selector like `{app="checkout", env="prod"}` contains a comma of its own,
+// and the documented env-var form must round-trip it exactly like the
+// equivalent repeated --loki-selector flag does (StringArrayVar, no split).
+func TestRunInventory_LokiSelectorsEnvPreservesCommaBearingSelector(t *testing.T) {
+	clearInventoryEnv(t)
+	promSrv := tsdbServer(t)
+
+	const multiLabelSelector = `{app="checkout", env="prod"}`
+	var gotQueries []string
+	lokiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQueries = append(gotQueries, r.URL.Query().Get("query"))
+		_, _ = w.Write([]byte(`{"streams":10,"chunks":20,"entries":100,"bytes":1000}`))
+	}))
+	defer lokiSrv.Close()
+
+	t.Setenv("CERBERUS_INVENTORY_LOKI_SELECTORS", multiLabelSelector)
+
+	var out, errOut bytes.Buffer
+	err := runInventory([]string{
+		"--source", promSrv.URL, "--json",
+		"--loki-source", lokiSrv.URL,
+	}, &out, &errOut)
+	if err != nil {
+		t.Fatalf("runInventory: %v (stderr: %s)", err, errOut.String())
+	}
+
+	if len(gotQueries) != 1 || gotQueries[0] != multiLabelSelector {
+		t.Fatalf("loki index/stats queries = %+v, want exactly one query %q "+
+			"(the env selector must not be split on its internal comma)", gotQueries, multiLabelSelector)
+	}
+}
+
+// TestRunInventory_LokiProbeAllSelectorsFail pins the CLI-level enforcement of
+// the honesty contract LokiClient.Probe documents: if every --loki-selector's
+// index/stats call fails, runInventory must return a hard error and must NOT
+// write an inventory.json — a failed probe must never read as a clean, empty
+// top-N.
+func TestRunInventory_LokiProbeAllSelectorsFail(t *testing.T) {
+	clearInventoryEnv(t)
+	promSrv := tsdbServer(t)
+	lokiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer lokiSrv.Close()
+
+	outPath := filepath.Join(t.TempDir(), "inventory.json")
+	var out, errOut bytes.Buffer
+	err := runInventory([]string{
+		"--source", promSrv.URL, "--json", "--out", outPath,
+		"--loki-source", lokiSrv.URL,
+		"--loki-selector", `{app="checkout"}`,
+		"--loki-selector", `{app="frontend"}`,
+	}, &out, &errOut)
+	if err == nil {
+		t.Fatal("runInventory should hard-fail when every --loki-selector's probe call fails")
+	}
+	if !strings.Contains(err.Error(), `{app="checkout"}`) || !strings.Contains(err.Error(), `{app="frontend"}`) {
+		t.Errorf("error should name both failed selectors, got: %v", err)
+	}
+	if _, statErr := os.Stat(outPath); !os.IsNotExist(statErr) {
+		t.Errorf("--out file should not be written on a hard probe failure, stat err: %v", statErr)
+	}
+}
+
+// TestRunInventory_LokiProbePartialFailureRecordsNotes pins that a PARTIAL
+// Loki probe failure (some selectors succeed, one fails) is not an error at
+// the CLI layer: runInventory succeeds and the emitted JSON carries the
+// failed selector in inv.Loki.Notes rather than silently dropping it.
+func TestRunInventory_LokiProbePartialFailureRecordsNotes(t *testing.T) {
+	clearInventoryEnv(t)
+	promSrv := tsdbServer(t)
+	lokiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("query") == `{app="checkout"}` {
+			_, _ = w.Write([]byte(`{"streams":500,"chunks":900,"entries":40000,"bytes":8000000}`))
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer lokiSrv.Close()
+
+	var out, errOut bytes.Buffer
+	err := runInventory([]string{
+		"--source", promSrv.URL, "--json",
+		"--loki-source", lokiSrv.URL,
+		"--loki-selector", `{app="checkout"}`,
+		"--loki-selector", `{app="broken"}`,
+	}, &out, &errOut)
+	if err != nil {
+		t.Fatalf("runInventory (partial loki failure): %v (stderr: %s)", err, errOut.String())
+	}
+
+	var inv migrateinventory.Inventory
+	if unmarshalErr := json.Unmarshal(out.Bytes(), &inv); unmarshalErr != nil {
+		t.Fatalf("decode inventory JSON: %v\n%s", unmarshalErr, out.String())
+	}
+	if inv.Loki == nil {
+		t.Fatalf("inventory should still carry a Loki section, got:\n%s", out.String())
+	}
+	if len(inv.Loki.Selectors) != 1 || inv.Loki.Selectors[0].Selector != `{app="checkout"}` {
+		t.Fatalf("loki selectors = %+v, want exactly the surviving checkout selector", inv.Loki.Selectors)
+	}
+	if len(inv.Loki.Notes) != 1 || !strings.Contains(inv.Loki.Notes[0], `{app="broken"}`) {
+		t.Fatalf("loki notes = %+v, want one note naming the failed broken selector", inv.Loki.Notes)
+	}
+}
+
 // TestRunInventory_LokiSelectorWithoutSourceIsValidationError: --loki-selector
 // with no --loki-source is rejected before any HTTP call, naming both flags.
 func TestRunInventory_LokiSelectorWithoutSourceIsValidationError(t *testing.T) {

--- a/cmd/cerberus/cmd_migrate_rulegraph_test.go
+++ b/cmd/cerberus/cmd_migrate_rulegraph_test.go
@@ -170,3 +170,131 @@ groups:
 		t.Errorf("graph file should carry the counts line, got:\n%s", string(data))
 	}
 }
+
+// TestRuleGraphLegacyInvocationUnaffectedWithoutLokiRules pins that the
+// --loki-rules flag's mere existence on the command changes nothing: the
+// output for an invocation that never passes it is byte-identical to the
+// output before the flag was added. This is what makes MIG-04's committed
+// golden safe without regeneration.
+func TestRuleGraphLegacyInvocationUnaffectedWithoutLokiRules(t *testing.T) {
+	dir := t.TempDir()
+	ruleFile := filepath.Join(dir, "rules.yml")
+	const rules = `
+groups:
+  - name: api
+    rules:
+      - record: job:http_requests:rate5m
+        expr: rate(http_requests_total[5m])
+      - record: job:errors:rate5m
+        expr: rate(http_errors_total[5m])
+`
+	if err := os.WriteFile(ruleFile, []byte(rules), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	corpusFile := filepath.Join(dir, "corpus.json")
+	writeRuleGraphCorpus(t, corpusFile, migrate.HarvestedQuery{
+		Expr:   `sum(job:http_requests:rate5m{env="prod"})`,
+		Source: "dash:overview/reqs",
+		Kind:   migrate.KindPanel,
+	})
+
+	var out, errOut bytes.Buffer
+	if err := runMigrate([]string{"rulegraph", "--rules", ruleFile, "--corpus", corpusFile, "--json"}, &out, &errOut); err != nil {
+		t.Fatalf("rulegraph --json: %v (stderr: %s)", err, errOut.String())
+	}
+
+	var withoutFlag, withEmptyFlag bytes.Buffer
+	if err := runMigrate([]string{"rulegraph", "--rules", ruleFile, "--corpus", corpusFile, "--json"}, &withoutFlag, &errOut); err != nil {
+		t.Fatalf("rulegraph --json (rerun): %v (stderr: %s)", err, errOut.String())
+	}
+	if err := runMigrate([]string{"rulegraph", "--rules", ruleFile, "--loki-rules", "", "--corpus", corpusFile, "--json"}, &withEmptyFlag, &errOut); err != nil {
+		t.Fatalf("rulegraph --json --loki-rules '': %v (stderr: %s)", err, errOut.String())
+	}
+
+	if out.String() != withoutFlag.String() {
+		t.Fatalf("rulegraph output is not even reproducible across two runs with identical flags:\n%s\n---\n%s", out.String(), withoutFlag.String())
+	}
+	if out.String() != withEmptyFlag.String() {
+		t.Fatalf("rulegraph output changed by the mere presence of an empty --loki-rules flag:\n%s\n---\n%s", out.String(), withEmptyFlag.String())
+	}
+}
+
+// TestRuleGraphLokiRulesHarvestsRecordedSeries pins the CLI wiring: a
+// --loki-rules file's record: output is folded into the graph's recorded
+// series, tagged with the loki-rule: source prefix, and linked by a corpus
+// consumer exactly like a Prometheus-recorded series.
+func TestRuleGraphLokiRulesHarvestsRecordedSeries(t *testing.T) {
+	dir := t.TempDir()
+	lokiRuleFile := filepath.Join(dir, "loki-rules.yml")
+	const lokiRules = `
+groups:
+  - name: g
+    rules:
+      - record: job:error_lines:rate5m
+        expr: sum(rate({app="api"} |= "ERROR" [5m]))
+      - alert: HighErrorLines
+        expr: '{app="api"} |= "ERROR"'
+`
+	if err := os.WriteFile(lokiRuleFile, []byte(lokiRules), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	corpusFile := filepath.Join(dir, "corpus.json")
+	writeRuleGraphCorpus(t, corpusFile, migrate.HarvestedQuery{
+		Expr:   `sum(job:error_lines:rate5m{env="prod"})`,
+		Source: "dash:overview/errlines",
+		Kind:   migrate.KindPanel,
+	})
+
+	var out, errOut bytes.Buffer
+	if err := runMigrate([]string{"rulegraph", "--loki-rules", lokiRuleFile, "--corpus", corpusFile, "--json"}, &out, &errOut); err != nil {
+		t.Fatalf("rulegraph --loki-rules: %v (stderr: %s)", err, errOut.String())
+	}
+
+	var g migrate.RuleGraph
+	if err := json.Unmarshal(out.Bytes(), &g); err != nil {
+		t.Fatalf("unmarshal rulegraph JSON: %v\n%s", err, out.String())
+	}
+	if g.Counts.Recorded != 1 || g.Counts.Consumed != 1 || g.Counts.Orphan != 0 {
+		t.Fatalf("counts = %+v, want recorded 1 / consumed 1 / orphan 0", g.Counts)
+	}
+	if len(g.Recorded) != 1 {
+		t.Fatalf("recorded = %+v, want exactly 1 (the alert: rule is not harvested)", g.Recorded)
+	}
+	n := g.Recorded[0]
+	if n.Name != "job:error_lines:rate5m" {
+		t.Errorf("recorded[0].Name = %q, want job:error_lines:rate5m", n.Name)
+	}
+	if !strings.HasPrefix(n.Source, "loki-rule:") {
+		t.Errorf("recorded[0].Source = %q, want loki-rule: prefix", n.Source)
+	}
+	if n.Status != migrate.StatusConsumed {
+		t.Errorf("recorded[0].Status = %q, want %q", n.Status, migrate.StatusConsumed)
+	}
+	if len(n.Consumers) != 1 || n.Consumers[0] != "dash:overview/errlines" {
+		t.Errorf("recorded[0].Consumers = %v, want [dash:overview/errlines]", n.Consumers)
+	}
+}
+
+// TestRuleGraphLokiRulesNoFilesMatchedBlocks pins that a --loki-rules glob
+// matching zero files surfaces as a counted skip, not a silent empty graph —
+// the same posture --rules already has for a missed glob.
+func TestRuleGraphLokiRulesNoFilesMatchedBlocks(t *testing.T) {
+	dir := t.TempDir()
+	pattern := filepath.Join(dir, "does-not-exist-*.yml")
+
+	var out, errOut bytes.Buffer
+	if err := runMigrate([]string{"rulegraph", "--loki-rules", pattern, "--json"}, &out, &errOut); err != nil {
+		t.Fatalf("rulegraph --loki-rules (missing glob): %v (stderr: %s)", err, errOut.String())
+	}
+
+	var g migrate.RuleGraph
+	if err := json.Unmarshal(out.Bytes(), &g); err != nil {
+		t.Fatalf("unmarshal rulegraph JSON: %v\n%s", err, out.String())
+	}
+	if g.Counts.Skipped != 1 {
+		t.Fatalf("counts.Skipped = %d, want 1", g.Counts.Skipped)
+	}
+	if len(g.Skipped) != 1 || g.Skipped[0].Source != pattern || g.Skipped[0].Reason != "no files matched" {
+		t.Fatalf("skipped = %+v, want one entry naming %q with reason %q", g.Skipped, pattern, "no files matched")
+	}
+}

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -61,7 +61,7 @@ subcommands.
 | `cerberus migrate classify`  | Bucket each query as supported / unsupported / risky                           | `--corpus` (or `--rules`/`--loki-rules`/`--dashboards`), `--json`, `--out`                                                                       | offline                                 |
 | `cerberus migrate rulegraph` | Map recording-rule outputs to the consumers that must stay materialized        | `--rules`, `--corpus`, `--json`, `--out`                                                                                                         | offline                                 |
 | `cerberus migrate verify`    | Replay the corpus against each head's reference backend and diff (parity gate) | `--corpus`, per-head `--ref*`/`--cerberus*` pairs (see below), `--start`, `--end`, `--step`, `--tolerance`, `--json`, `--report`, `--out`        | live (two backends per configured head) |
-| `cerberus migrate inventory` | Probe a **live** Prometheus for the cardinality that drives OOM risk           | `--source`, `--top`, `--window`, `--json`, `--out`                                                                                               | live (one backend)                      |
+| `cerberus migrate inventory` | Probe live sources for the cardinality that drives OOM risk                    | `--source`, `--top`, `--window`, `--loki-source`, `--loki-selector`, `--tempo-source`, `--json`, `--out`                                         | live (Prometheus always; Loki optional) |
 | `cerberus migrate gate`      | Fold the artifacts into one cutover go/no-go decision                          | `--verify`, `--classify`, `--rulegraph`, `--inventory`, `--high-card-series`, `--high-card-label-values`, `--json`, `--out`                      | offline                                 |
 
 The legacy `migrate --schema` root flag is now the `schema` subcommand, and the
@@ -151,6 +151,14 @@ silently discarded.
 cardinality. This is the number that drives OOM risk, and it exists **only** at
 runtime — it is not in any config or dashboard. Inventory refuses to infer it
 from `prometheus.yml`. A source that 404s the status endpoint is a hard error.
+`--loki-source` optionally adds a per-selector section, ranking the
+`--loki-selector` set the operator supplies by streams matched via Loki's
+`/loki/api/v1/index/stats` endpoint — Loki exposes no whole-tenant top-N
+cardinality call the way Prometheus's TSDB status does, so the operator names
+what to rank instead of the tool guessing. `--tempo-source` records a fixed,
+specifically-reasoned out-of-scope entry rather than a fabricated number:
+Tempo's span/block storage has no head-block or ranked-cardinality-stats API
+analogous to either of the other two heads, so no such proxy is computed.
 
 **Classify** buckets each corpus query: *supported* (parses, lowers, and emits
 SQL cleanly), *unsupported* (the offending construct is named), or

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -393,7 +393,19 @@ them into **one** PASS/FAIL verdict with a per-stage checklist. It **refuses**
   **zero queries** also blocks (an empty corpus proves no support coverage).
 - **rulegraph** — any *consumed* recorded series blocks (it must stay
   materialized); an unparseable consumer expression also blocks, because
-  "orphan ⇒ safe to drop" is unsound once a consumer was dropped.
+  "orphan ⇒ safe to drop" is unsound once a consumer was dropped. A
+  Loki-ruler-sourced recorded series (from `--loki-rules`) is the identical
+  `RecordedNode` shape as a Prometheus one, distinguished only by its
+  `loki-rule:` source prefix, and blocks through this exact same rule — the
+  reported reason names the source, so the two are never visually
+  indistinguishable.
+- **inventory** — advisory everywhere: high cardinality WARNs and never
+  blocks, uniformly across every head the operator asked about. A
+  high-cardinality Loki stream selector (from `--loki-source`) WARNs exactly
+  like a high-cardinality Prometheus metric; a present Tempo section (from
+  `--tempo-source`) always WARNs with its fixed out-of-scope reason. A head
+  the operator never asked about is simply absent from the decision — never
+  presented as "checked, nothing found."
 - A **missing required artifact** blocks — `verify`, `classify`, and
   `rulegraph` are required; `inventory` is advisory (high cardinality WARNs,
   never blocks).

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -59,7 +59,7 @@ subcommands.
 | `cerberus migrate harvest`   | Build a machine-readable PromQL + LogQL + TraceQL corpus from your files       | `--rules`, `--loki-rules`, `--dashboards`, `--out`                                                                                               | offline                                 |
 | `cerberus migrate explain`   | Dry-run each corpus query through the read pipeline, print the SQL             | `--corpus` (or `--rules`/`--loki-rules`/`--dashboards`), `--out`                                                                                 | offline                                 |
 | `cerberus migrate classify`  | Bucket each query as supported / unsupported / risky                           | `--corpus` (or `--rules`/`--loki-rules`/`--dashboards`), `--json`, `--out`                                                                       | offline                                 |
-| `cerberus migrate rulegraph` | Map recording-rule outputs to the consumers that must stay materialized        | `--rules`, `--corpus`, `--json`, `--out`                                                                                                         | offline                                 |
+| `cerberus migrate rulegraph` | Map recording-rule outputs to the consumers that must stay materialized        | `--rules`, `--loki-rules`, `--corpus`, `--json`, `--out`                                                                                         | offline                                 |
 | `cerberus migrate verify`    | Replay the corpus against each head's reference backend and diff (parity gate) | `--corpus`, per-head `--ref*`/`--cerberus*` pairs (see below), `--start`, `--end`, `--step`, `--tolerance`, `--json`, `--report`, `--out`        | live (two backends per configured head) |
 | `cerberus migrate inventory` | Probe live sources for the cardinality that drives OOM risk                    | `--source`, `--top`, `--window`, `--loki-source`, `--loki-selector`, `--tempo-source`, `--json`, `--out`                                         | live (Prometheus always; Loki optional) |
 | `cerberus migrate gate`      | Fold the artifacts into one cutover go/no-go decision                          | `--verify`, `--classify`, `--rulegraph`, `--inventory`, `--high-card-series`, `--high-card-label-values`, `--json`, `--out`                      | offline                                 |
@@ -170,7 +170,19 @@ proves that.
 dashboard/alert consumers that read it. Because cerberus has no ruler, any
 **consumed** recorded series must keep being materialized after cutover, or the
 panel that reads it goes silently blank. Rulegraph tells you exactly which ones;
-materializing them elsewhere is a manual operator step.
+materializing them elsewhere is a manual operator step. `--loki-rules` extends
+this to Loki's ruler, which has a real recording/alerting rule format of its
+own: only `record:` output series are harvested from it, tagged with a
+`loki-rule:` source so they're distinguishable from Prometheus-sourced ones,
+and linked by the same PromQL-shaped consumers (a dashboard panel or a
+Prometheus rule reading the remote-written metric by name) rulegraph already
+scans. Loki `alert:` rules are never harvested for this graph — a LogQL
+alerting expr is a log-stream selector, not a metric-name reference, so it can
+never itself consume a recorded series, and feeding it through the PromQL
+extractor would only manufacture spurious unparseable-consumer skips. Tempo
+has no rule concept in this sense: its metrics-generator is a fixed-shape,
+config-driven span-metric emitter with no user-authored recording/alerting
+rule file for a `--tempo-rules` flag to point at, so no such flag exists.
 
 ### Validate: render the schema
 
@@ -424,6 +436,7 @@ cerberus migrate classify --corpus corpus.json --json --out classify.json
 # Which recording-rule outputs must stay materialized after cutover?
 cerberus migrate rulegraph \
   --rules './prometheus/rules/*.yml' \
+  --loki-rules './loki/rules/*.yml' \
   --corpus corpus.json \
   --json --out rulegraph.json
 

--- a/internal/migrate/rulegraph.go
+++ b/internal/migrate/rulegraph.go
@@ -399,6 +399,89 @@ func splitRuleGroups(file string, rg promrules.RuleGroups) (recorded []RecordedS
 	return recorded, consumers, skipped
 }
 
+// lokiRuleSourcePrefix tags a RecordedSeries harvested from a Loki ruler rule
+// file, distinguishing it from a Prometheus "rule:" source using the same
+// free-form Source string the schema already carries — no new JSON field, so
+// a --rules-only invocation is byte-for-byte unchanged.
+const lokiRuleSourcePrefix = "loki-rule:"
+
+// HarvestLokiRuleFiles reads Loki ruler rule files matched by rulePaths and
+// extracts ONLY their recording-rule OUTPUT series (record: names). Loki
+// alerting- and recording-rule EXPRESSIONS are LogQL over log streams; LogQL
+// has no operator that re-selects a previously remote-written metric name, so
+// a Loki rule's own expr can never reference another recorded series the way
+// a Prometheus rule's expr can — it is therefore never fed into the
+// PromQL-based consumer/extractor pipeline. The only consumers a
+// Loki-recorded series can have are the PromQL-shaped queries already
+// harvested from --rules/--corpus (a dashboard panel or Prometheus rule
+// reading the remote-written metric by name); BuildRuleGraph links them
+// unmodified.
+//
+// Any input this cannot use — bad glob, unreadable file, YAML parse failure,
+// a rule with an empty record name — is returned as a SkippedEntry, never
+// silently dropped: a --loki-rules glob that matches zero files BLOCKS the
+// gate exactly like an equivalent --rules miss does today, so "nothing
+// configured" is never read as "no rules, all clear."
+func HarvestLokiRuleFiles(rulePaths []string) (recorded []RecordedSeries, skipped []SkippedEntry) {
+	for _, pattern := range rulePaths {
+		matches, err := filepath.Glob(pattern)
+		if err != nil {
+			skipped = append(skipped, SkippedEntry{Source: pattern, Reason: fmt.Sprintf("bad path pattern: %v", err)})
+			continue
+		}
+		if len(matches) == 0 {
+			skipped = append(skipped, SkippedEntry{Source: pattern, Reason: "no files matched"})
+			continue
+		}
+		for _, file := range matches {
+			data, err := os.ReadFile(file) //nolint:gosec // operator-supplied rule-file path; offline CLI.
+			if err != nil {
+				skipped = append(skipped, SkippedEntry{Source: file, Reason: fmt.Sprintf("read: %v", err)})
+				continue
+			}
+			rg, err := promrules.Parse(data)
+			if err != nil {
+				skipped = append(skipped, SkippedEntry{Source: file, Reason: fmt.Sprintf("parse: %v", err)})
+				continue
+			}
+			rec, sk := splitLokiRuleGroups(file, rg)
+			recorded = append(recorded, rec...)
+			skipped = append(skipped, sk...)
+		}
+	}
+	return recorded, skipped
+}
+
+// splitLokiRuleGroups walks one parsed Loki rule file: a rule with a `record:`
+// name and a non-empty expr becomes a RecordedSeries tagged with
+// lokiRuleSourcePrefix; a rule with an `alert:` name is deliberately not
+// harvested at all (see HarvestLokiRuleFiles — a Loki alerting expr is LogQL
+// over log streams and structurally cannot reference a recorded metric
+// series, so feeding it into the consumer pipeline would only manufacture
+// spurious unparseable-consumer skips); a rule with an empty expr, or neither
+// a record nor an alert name, is a counted skip.
+func splitLokiRuleGroups(file string, rg promrules.RuleGroups) (recorded []RecordedSeries, skipped []SkippedEntry) {
+	for _, g := range rg.Groups {
+		for _, r := range g.Rules {
+			switch {
+			case r.Record != "":
+				source := fmt.Sprintf("%s%s/%s/%s", lokiRuleSourcePrefix, file, g.Name, r.Record)
+				if strings.TrimSpace(r.Expr) == "" {
+					skipped = append(skipped, SkippedEntry{Source: source, Reason: "recording rule has empty expr"})
+					continue
+				}
+				recorded = append(recorded, RecordedSeries{Name: r.Record, Source: source})
+			case r.Alert != "":
+				// Deliberately not harvested as a consumer: see HarvestLokiRuleFiles.
+			default:
+				source := fmt.Sprintf("%s%s/%s/?", lokiRuleSourcePrefix, file, g.Name)
+				skipped = append(skipped, SkippedEntry{Source: source, Reason: "rule is neither a record nor an alert"})
+			}
+		}
+	}
+	return recorded, skipped
+}
+
 // Write renders the graph as scannable, human-readable text. It leads with the
 // name-level-approximation honesty note, then the headline counts, then the
 // orphan recorded series (the ones nothing reads — drop candidates), then the

--- a/internal/migrate/rulegraph_test.go
+++ b/internal/migrate/rulegraph_test.go
@@ -416,6 +416,83 @@ groups:
 	}
 }
 
+// TestHarvestLokiRuleFilesBadGlobPatternIsSkip pins that a syntactically
+// invalid --loki-rules glob pattern (an unterminated character class) is a
+// counted skip naming the bad pattern, never a silent empty result — the same
+// discipline HarvestRuleFiles applies to a bad Prometheus --rules pattern.
+func TestHarvestLokiRuleFilesBadGlobPatternIsSkip(t *testing.T) {
+	pattern := filepath.Join(t.TempDir(), "invalid[")
+
+	recorded, skipped := HarvestLokiRuleFiles([]string{pattern})
+
+	if len(recorded) != 0 {
+		t.Fatalf("recorded = %+v, want none", recorded)
+	}
+	if len(skipped) != 1 {
+		t.Fatalf("skipped = %+v, want exactly 1", skipped)
+	}
+	if skipped[0].Source != pattern {
+		t.Errorf("skipped[0].Source = %q, want %q", skipped[0].Source, pattern)
+	}
+	if !strings.Contains(skipped[0].Reason, "bad path pattern") {
+		t.Errorf("skipped[0].Reason = %q, want it to name a bad path pattern", skipped[0].Reason)
+	}
+}
+
+// TestHarvestLokiRuleFilesUnreadableFileIsSkip pins that a matched path
+// os.ReadFile cannot read (here, a directory matched by the glob rather than
+// a plain file) is a counted skip naming the read failure, not a silently
+// dropped input.
+func TestHarvestLokiRuleFilesUnreadableFileIsSkip(t *testing.T) {
+	dir := t.TempDir()
+	unreadable := filepath.Join(dir, "loki-rules.yml")
+	if err := os.Mkdir(unreadable, 0o755); err != nil { //nolint:gosec // test-controlled temp path.
+		t.Fatal(err)
+	}
+
+	recorded, skipped := HarvestLokiRuleFiles([]string{unreadable})
+
+	if len(recorded) != 0 {
+		t.Fatalf("recorded = %+v, want none", recorded)
+	}
+	if len(skipped) != 1 {
+		t.Fatalf("skipped = %+v, want exactly 1", skipped)
+	}
+	if skipped[0].Source != unreadable {
+		t.Errorf("skipped[0].Source = %q, want %q", skipped[0].Source, unreadable)
+	}
+	if !strings.Contains(skipped[0].Reason, "read:") {
+		t.Errorf("skipped[0].Reason = %q, want it to name the read failure", skipped[0].Reason)
+	}
+}
+
+// TestHarvestLokiRuleFilesParseErrorIsSkip pins that a matched file whose
+// contents are not valid YAML is a counted skip naming the parse failure —
+// never silently dropped, and never surfaced as a spurious empty rule file.
+func TestHarvestLokiRuleFilesParseErrorIsSkip(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "loki-rules.yml")
+	const malformed = "groups: [\n  - name: unterminated\n"
+	if err := os.WriteFile(file, []byte(malformed), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	recorded, skipped := HarvestLokiRuleFiles([]string{file})
+
+	if len(recorded) != 0 {
+		t.Fatalf("recorded = %+v, want none", recorded)
+	}
+	if len(skipped) != 1 {
+		t.Fatalf("skipped = %+v, want exactly 1", skipped)
+	}
+	if skipped[0].Source != file {
+		t.Errorf("skipped[0].Source = %q, want %q", skipped[0].Source, file)
+	}
+	if !strings.Contains(skipped[0].Reason, "parse:") {
+		t.Errorf("skipped[0].Reason = %q, want it to name the parse failure", skipped[0].Reason)
+	}
+}
+
 // TestBuildRuleGraphLokiRecordedSeriesLinkedByExistingConsumers pins that a
 // Loki-recorded series is linked by the SAME PromQL-based consumer pipeline a
 // Prometheus-recorded series uses — a dashboard panel or Prometheus rule

--- a/internal/migrate/rulegraph_test.go
+++ b/internal/migrate/rulegraph_test.go
@@ -327,3 +327,152 @@ func TestBuildRuleGraphRegexConsumerCountsAsSkip(t *testing.T) {
 		t.Errorf("skip reason should explain the non-reducible __name__ selection, got %q", g.Skipped[0].Reason)
 	}
 }
+
+// TestHarvestLokiRuleFilesRecordOnlyExtraction pins the core Loki-rulegraph
+// design decision: a Loki rule file's `record:` rules become RecordedSeries
+// tagged with the loki-rule: source prefix, but `alert:` rules are NOT
+// extracted as consumers at all — LogQL alerting exprs are log-stream
+// selectors, not metric-name references, so feeding them through the
+// PromQL-based extractor would only manufacture spurious skips.
+func TestHarvestLokiRuleFilesRecordOnlyExtraction(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "loki-rules.yml")
+	const rules = `
+groups:
+  - name: g
+    rules:
+      - record: job:error_lines:rate5m
+        expr: sum(rate({app="api"} |= "ERROR" [5m]))
+      - alert: HighErrorLines
+        expr: '{app="api"} |= "ERROR"'
+`
+	if err := os.WriteFile(file, []byte(rules), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	recorded, skipped := HarvestLokiRuleFiles([]string{file})
+
+	if len(recorded) != 1 {
+		t.Fatalf("recorded = %+v, want exactly 1 (the record: rule only)", recorded)
+	}
+	if recorded[0].Name != "job:error_lines:rate5m" {
+		t.Errorf("recorded[0].Name = %q, want job:error_lines:rate5m", recorded[0].Name)
+	}
+	if !strings.HasPrefix(recorded[0].Source, lokiRuleSourcePrefix) {
+		t.Errorf("recorded[0].Source = %q, want prefix %q", recorded[0].Source, lokiRuleSourcePrefix)
+	}
+	if len(skipped) != 0 {
+		t.Fatalf("skipped = %+v, want none (the alert rule is intentionally excluded, not a failure)", skipped)
+	}
+}
+
+// TestHarvestLokiRuleFilesNoFilesMatchedIsSkip pins that a --loki-rules glob
+// matching zero files is a counted skip (which trips the gate's blockingSkip
+// rule), never a silent empty result that would read as "no rules, all clear."
+func TestHarvestLokiRuleFilesNoFilesMatchedIsSkip(t *testing.T) {
+	dir := t.TempDir()
+	pattern := filepath.Join(dir, "does-not-exist-*.yml")
+
+	recorded, skipped := HarvestLokiRuleFiles([]string{pattern})
+
+	if len(recorded) != 0 {
+		t.Fatalf("recorded = %+v, want none", recorded)
+	}
+	if len(skipped) != 1 {
+		t.Fatalf("skipped = %+v, want exactly 1", skipped)
+	}
+	if skipped[0].Source != pattern {
+		t.Errorf("skipped[0].Source = %q, want %q", skipped[0].Source, pattern)
+	}
+	if skipped[0].Reason != "no files matched" {
+		t.Errorf("skipped[0].Reason = %q, want %q", skipped[0].Reason, "no files matched")
+	}
+}
+
+// TestHarvestLokiRuleFilesEmptyExprRecordIsSkip pins that a record: rule with
+// an empty expr is a counted skip, not silently listed as a recorded series
+// that will never actually be materialized by Loki's ruler.
+func TestHarvestLokiRuleFilesEmptyExprRecordIsSkip(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "loki-rules.yml")
+	const rules = `
+groups:
+  - name: g
+    rules:
+      - record: job:broken:noexpr
+        expr: ""
+`
+	if err := os.WriteFile(file, []byte(rules), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	recorded, skipped := HarvestLokiRuleFiles([]string{file})
+
+	if len(recorded) != 0 {
+		t.Fatalf("recorded = %+v, want none (empty expr is a skip, not a recorded series)", recorded)
+	}
+	if len(skipped) != 1 || skipped[0].Reason != "recording rule has empty expr" {
+		t.Fatalf("skipped = %+v, want one entry reasoning empty expr", skipped)
+	}
+}
+
+// TestBuildRuleGraphLokiRecordedSeriesLinkedByExistingConsumers pins that a
+// Loki-recorded series is linked by the SAME PromQL-based consumer pipeline a
+// Prometheus-recorded series uses — a dashboard panel or Prometheus rule
+// referencing the remote-written metric by name classifies it StatusConsumed,
+// with zero changes to BuildRuleGraph's signature or logic.
+func TestBuildRuleGraphLokiRecordedSeriesLinkedByExistingConsumers(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "loki-rules.yml")
+	const rules = `
+groups:
+  - name: g
+    rules:
+      - record: job:error_lines:rate5m
+        expr: sum(rate({app="api"} |= "ERROR" [5m]))
+      - record: job:warn_lines:rate5m
+        expr: sum(rate({app="api"} |= "WARN" [5m]))
+`
+	if err := os.WriteFile(file, []byte(rules), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	recorded, skipped := HarvestLokiRuleFiles([]string{file})
+	if len(skipped) != 0 {
+		t.Fatalf("skipped = %+v, want none", skipped)
+	}
+
+	consumers := []HarvestedQuery{
+		// A Grafana dashboard panel — PromQL, reading the Loki-remote-written
+		// metric by name — is harvested exactly like any other panel consumer.
+		{Expr: `sum(job:error_lines:rate5m{env="prod"})`, Source: "dash:overview/panel-1", Kind: KindPanel},
+	}
+
+	g := BuildRuleGraph(recorded, consumers, PromQLMetricNames, nil)
+
+	byName := map[string]RecordedNode{}
+	for _, n := range g.Recorded {
+		byName[n.Name] = n
+	}
+
+	consumed, ok := byName["job:error_lines:rate5m"]
+	if !ok {
+		t.Fatal("job:error_lines:rate5m missing from graph")
+	}
+	if consumed.Status != StatusConsumed {
+		t.Errorf("job:error_lines:rate5m status = %q, want %q", consumed.Status, StatusConsumed)
+	}
+	if !strings.HasPrefix(consumed.Source, lokiRuleSourcePrefix) {
+		t.Errorf("job:error_lines:rate5m source = %q, want loki-rule: prefix preserved", consumed.Source)
+	}
+	if len(consumed.Consumers) != 1 || consumed.Consumers[0] != "dash:overview/panel-1" {
+		t.Errorf("consumed edges = %v, want [dash:overview/panel-1]", consumed.Consumers)
+	}
+
+	orphan, ok := byName["job:warn_lines:rate5m"]
+	if !ok {
+		t.Fatal("job:warn_lines:rate5m missing from graph")
+	}
+	if orphan.Status != StatusOrphan {
+		t.Errorf("job:warn_lines:rate5m status = %q, want %q (nothing references it)", orphan.Status, StatusOrphan)
+	}
+}

--- a/internal/migrategate/gate.go
+++ b/internal/migrategate/gate.go
@@ -23,18 +23,34 @@
 //     equivalent), or if ZERO queries were classified (an empty harvest cannot
 //     prove support). A supported-but-risky query WARNs but does not block; a
 //     harvest-skipped corpus entry (never classified) also WARNs.
-//   - inventory — WARN (never block) when the source carries high-cardinality
-//     metrics or labels: an OOM candidate to review, not a correctness stop.
+//   - inventory — WARN (never block), uniformly across every head the operator
+//     asked about, when the source carries high-cardinality metrics, labels, or
+//     Loki stream selectors: an OOM candidate to review, not a correctness stop.
 //     Also WARNs on every honesty caveat the probe recorded (an optional
-//     enrichment it could not fetch), so an enrichment failure never reads clean.
+//     enrichment or Loki selector it could not fetch) and on a Tempo section's
+//     fixed out-of-scope note, so none of that ever reads clean. Inventory's own
+//     rule — a cardinality signal never proves or disproves cutover correctness,
+//     only how well-informed it is — is head-agnostic by construction, so no
+//     head gets a WARN-vs-BLOCK carve-out; a head the operator never asked
+//     about (no --loki-source / --tempo-source) is simply absent, never
+//     silently treated as "checked, nothing found."
 //   - rulegraph — BLOCK if any recorded series is consumed: a dashboard or
 //     alert depends on it, so it MUST keep being materialized after cutover;
-//     dropping its materializer leaves a blank panel. Orphan recorded series
-//     (nobody reads them) are safe and never block — BUT any SKIPPED input (an
-//     unparseable consumer expr, an unreadable rule file) also BLOCKS, because a
-//     dropped consumer that referenced a series would have marked it consumed;
-//     with a skip, "orphan ⇒ safe to drop" is unsound and the stage can no
-//     longer prove a panel won't go blank.
+//     dropping its materializer leaves a blank panel. This applies identically
+//     to a Prometheus-sourced and a Loki-ruler-sourced recorded series — both
+//     are the same RecordedNode shape, discriminated only by a "rule:" vs.
+//     "loki-rule:" Source prefix, so the existing rule covers both with no
+//     per-head branch; the blocking reason names the Source so the two are
+//     never visually indistinguishable. Orphan recorded series (nobody reads
+//     them) are safe and never block — BUT any SKIPPED input (an unparseable
+//     consumer expr, an unreadable rule file, a --loki-rules glob that matched
+//     zero files) also BLOCKS, because a dropped consumer that referenced a
+//     series would have marked it consumed; with a skip, "orphan ⇒ safe to
+//     drop" is unsound and the stage can no longer prove a panel won't go
+//     blank. Loki has no rule-consumer side to fold in here: a Loki ruler
+//     expression is LogQL over log streams, which cannot itself reference a
+//     recorded metric series, so only Loki's recorded (record:) side ever
+//     reaches this stage — never a new consumer shape.
 //
 // A required artifact that was not supplied is itself a BLOCK: the gate cannot
 // prove safety for a stage it never saw. verify, classify, and rulegraph are
@@ -475,10 +491,13 @@ func classifyHarvestSkips(cl migrate.Classification) []string {
 const enrichmentUnavailable = -1
 
 // evalInventory WARNs (never blocks) when the source carries a high-cardinality
-// metric or label, or when the probe recorded an honesty caveat (an optional
-// enrichment it could not fetch). inventory is advisory: its worst outcome is a
-// WARN, so a missing inventory artifact is reported but does not block the
-// cutover.
+// metric, label, or Loki stream selector, or when the probe recorded an
+// honesty caveat (an optional enrichment or Loki selector it could not fetch,
+// or a Tempo out-of-scope note). Every head folds into this single stage the
+// same way — inventory is advisory everywhere, its worst outcome is a WARN —
+// so a missing inventory artifact is reported but does not block the cutover,
+// and a head the operator never asked about (Loki/Tempo both nil) contributes
+// nothing at all.
 func evalInventory(path string, opts Options) (StageResult, error) {
 	res := StageResult{Stage: StageInventory, Required: false}
 	if path == "" {
@@ -511,6 +530,8 @@ func evalInventory(path string, opts Options) (StageResult, error) {
 		}
 	}
 	res.Reasons = append(res.Reasons, inventoryCaveats(inv)...)
+	res.Reasons = append(res.Reasons, lokiInventoryReasons(inv.Loki, seriesLimit)...)
+	res.Reasons = append(res.Reasons, tempoInventoryReasons(inv.Tempo)...)
 
 	if len(res.Reasons) > 0 {
 		res.Verdict = VerdictWarn
@@ -543,12 +564,54 @@ func inventoryCaveats(inv migrateinventory.Inventory) []string {
 	return out
 }
 
+// lokiInventoryReasons flags every Loki selector at or above seriesLimit
+// streams and surfaces every per-selector probe failure the Loki section
+// recorded in Notes. A nil section (the operator never supplied --loki-source)
+// yields nothing: "never asked" is not "asked and found nothing." This never
+// blocks — WARN is inventory's only outcome, uniformly across every head.
+func lokiInventoryReasons(loki *migrateinventory.LokiInventory, seriesLimit int64) []string {
+	if loki == nil {
+		return nil
+	}
+	var out []string
+	// highCardSeries() always returns a positive default or override, but the
+	// guard is restated on this same variable so gosec G115 and CodeQL's
+	// go/incorrect-integer-conversion can prove the uint64 conversion locally
+	// (neither follows the bound across the Options.highCardSeries call).
+	if seriesLimit > 0 {
+		limit := uint64(seriesLimit)
+		for _, s := range loki.Selectors {
+			if s.Streams >= limit {
+				out = append(out, fmt.Sprintf("high-cardinality loki selector %q: %d streams (>= %d)",
+					s.Selector, s.Streams, seriesLimit))
+			}
+		}
+	}
+	out = append(out, loki.Notes...)
+	return out
+}
+
+// tempoInventoryReasons surfaces the Tempo section's fixed, specifically-
+// reasoned out-of-scope note as a caveat. A nil section (the operator never
+// supplied --tempo-source) yields nothing. This never blocks: it documents why
+// no cardinality signal exists for Tempo, it does not itself signal risk.
+func tempoInventoryReasons(tempo *migrateinventory.TempoInventory) []string {
+	if tempo == nil {
+		return nil
+	}
+	return []string{fmt.Sprintf("tempo inventory intentionally out of scope: %s", tempo.OutOfScope)}
+}
+
 // evalRuleGraph blocks when any recorded series is consumed: a dashboard or
 // alert reads it, so it MUST keep being materialized after cutover — dropping
-// its recording rule leaves a blank panel. Orphan recorded series (read by
-// nobody) are safe to drop and never block — BUT any SKIPPED input also blocks:
-// the builder could not use it (an unparseable consumer expr, an unreadable rule
-// file), so a consumer that referenced a recorded series may have been dropped,
+// its recording rule leaves a blank panel. This rule is unmodified by source:
+// a Loki-ruler-sourced RecordedNode (Source prefixed "loki-rule:") is the exact
+// same shape as a Prometheus one and blocks identically — the reason line names
+// the Source so the two are never visually indistinguishable. Orphan recorded
+// series (read by nobody) are safe to drop and never block — BUT any SKIPPED
+// input also blocks: the builder could not use it (an unparseable consumer
+// expr, an unreadable rule file, a --loki-rules glob that matched zero files),
+// so a consumer that referenced a recorded series may have been dropped,
 // leaving that series wrongly classified orphan. With a skip, "orphan ⇒ safe to
 // drop" is unsound, so the gate refuses rather than green-light dropping a
 // materializer the skipped consumer needs. rulegraph is a required artifact.
@@ -588,7 +651,7 @@ func evalRuleGraph(path string) (StageResult, error) {
 				len(consumed)))
 		for _, n := range consumed {
 			res.Reasons = append(res.Reasons,
-				fmt.Sprintf("  %s <- %d consumer%s", n.Name, len(n.Consumers), plural(len(n.Consumers), "", "s")))
+				fmt.Sprintf("  %s (%s) <- %d consumer%s", n.Name, n.Source, len(n.Consumers), plural(len(n.Consumers), "", "s")))
 		}
 	}
 	if blockingSkip {

--- a/internal/migrategate/gate_test.go
+++ b/internal/migrategate/gate_test.go
@@ -501,6 +501,227 @@ func TestEvaluateBlocksOnRuleGraphSkipped(t *testing.T) {
 	}
 }
 
+// TestEvaluateBlocksOnLokiConsumedRecordedSeries pins that a Loki-ruler-sourced
+// recorded series (Source prefixed "loki-rule:") blocks through the exact same,
+// unmodified rule a Prometheus-sourced one does — RecordedNode carries no
+// per-head field, only the Source prefix — and that the blocking reason names
+// the Loki source, not just the series name, so the two are never visually
+// indistinguishable in the decision output.
+func TestEvaluateBlocksOnLokiConsumedRecordedSeries(t *testing.T) {
+	g := migrate.RuleGraph{
+		Counts: migrate.RuleGraphCounts{Recorded: 1, Consumed: 1, Consumers: 1},
+		Recorded: []migrate.RecordedNode{
+			{
+				Name: "job:logs:error_rate", Source: "loki-rule:loki/rules.yml/logs/job:logs:error_rate",
+				Status: migrate.StatusConsumed, Consumers: []string{"dash.json"},
+			},
+		},
+		Consumers: []migrate.ConsumerNode{
+			{Expr: "job:logs:error_rate", Source: "dash.json", Kind: "dashboard", References: []string{"job:logs:error_rate"}},
+		},
+	}
+	in := migrategate.Inputs{
+		Verify:    cleanVerify(t),
+		Classify:  cleanClassify(t),
+		Inventory: cleanInventory(t),
+		RuleGraph: writeArtifact(t, "rulegraph.json", g.WriteJSON),
+	}
+	dec, err := migrategate.Evaluate(in, migrategate.Options{})
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	r := stageByName(t, dec, migrategate.StageRuleGraph)
+	if dec.Pass || r.Verdict != migrategate.VerdictFail || !r.Blocking {
+		t.Fatalf("want rulegraph FAIL+blocking on a Loki-sourced consumed series, got pass=%v verdict=%q", dec.Pass, r.Verdict)
+	}
+	if !containsSubstr(r.Reasons, "job:logs:error_rate") {
+		t.Errorf("rulegraph reasons should name the consumed series, got %v", r.Reasons)
+	}
+	if !containsSubstr(r.Reasons, "loki-rule:") {
+		t.Errorf("rulegraph reasons should attribute the block to its loki-rule: source, got %v", r.Reasons)
+	}
+}
+
+// TestEvaluateBlocksOnLokiRulegraphSkip mirrors TestEvaluateBlocksOnRuleGraphSkipped
+// for a Loki-sourced skip (a --loki-rules glob that matched zero files, or an
+// unreadable/unparseable Loki rule file): it trips the same blockingSkip rule,
+// unmodified, because Counts.Skipped carries no per-head distinction.
+func TestEvaluateBlocksOnLokiRulegraphSkip(t *testing.T) {
+	g := migrate.RuleGraph{
+		Counts:   migrate.RuleGraphCounts{Recorded: 1, Orphan: 1, Skipped: 1},
+		Recorded: []migrate.RecordedNode{{Name: "job:foo:rate", Source: "rules.yml", Status: migrate.StatusOrphan}},
+		Skipped:  []migrate.SkippedEntry{{Source: "loki-rule:loki/missing-*.yml", Reason: "no files matched"}},
+	}
+	in := migrategate.Inputs{
+		Verify:    cleanVerify(t),
+		Classify:  cleanClassify(t),
+		Inventory: cleanInventory(t),
+		RuleGraph: writeArtifact(t, "rulegraph.json", g.WriteJSON),
+	}
+	dec, err := migrategate.Evaluate(in, migrategate.Options{})
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	r := stageByName(t, dec, migrategate.StageRuleGraph)
+	if dec.Pass || r.Verdict != migrategate.VerdictFail || !r.Blocking {
+		t.Fatalf("rulegraph with a loki-sourced skip must FAIL+block, got pass=%v verdict=%q blocking=%v", dec.Pass, r.Verdict, r.Blocking)
+	}
+	if !containsSubstr(r.Reasons, "unsound") || !containsSubstr(r.Reasons, "loki-rule:") {
+		t.Errorf("rulegraph reasons should surface the loki-sourced skip, got %v", r.Reasons)
+	}
+}
+
+// TestEvaluateWarnsOnLokiHighCardinalitySelector pins that a Loki selector at or
+// above the same DefaultHighCardSeries threshold used for Prometheus metrics
+// WARNs — never blocks — and that a low-cardinality selector is not flagged.
+func TestEvaluateWarnsOnLokiHighCardinalitySelector(t *testing.T) {
+	inv := migrateinventory.Inventory{
+		Source: "http://src", Top: 5,
+		Loki: &migrateinventory.LokiInventory{
+			Source: "http://loki",
+			Selectors: []migrateinventory.LokiSelectorStats{
+				{Selector: "checkout-app-stream", Streams: 250_000},
+				{Selector: "quiet-app-stream", Streams: 3},
+			},
+		},
+	}
+	in := migrategate.Inputs{
+		Verify:    cleanVerify(t),
+		Classify:  cleanClassify(t),
+		Inventory: writeArtifact(t, "inventory.json", inv.WriteJSON),
+		RuleGraph: cleanRuleGraph(t),
+	}
+	dec, err := migrategate.Evaluate(in, migrategate.Options{})
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	iv := stageByName(t, dec, migrategate.StageInventory)
+	if iv.Verdict != migrategate.VerdictWarn {
+		t.Fatalf("want inventory WARN on a high-cardinality loki selector, got %q", iv.Verdict)
+	}
+	if iv.Blocking {
+		t.Errorf("a high-cardinality loki selector must WARN, never block")
+	}
+	if !dec.Pass || dec.Overall != migrategate.OverallPass {
+		t.Fatalf("a WARN-only run should PASS overall, got pass=%v overall=%q", dec.Pass, dec.Overall)
+	}
+	if !containsSubstr(iv.Reasons, "checkout-app-stream") {
+		t.Errorf("inventory reasons should name the high-cardinality selector, got %v", iv.Reasons)
+	}
+	if containsSubstr(iv.Reasons, "quiet-app-stream") {
+		t.Errorf("a low-cardinality selector must not be flagged, got %v", iv.Reasons)
+	}
+}
+
+// TestEvaluateWarnsOnLokiInventoryNotes pins that a Loki selector probe failure
+// (recorded in the Loki section's own Notes, e.g. a partial-failure case) is
+// surfaced as an inventory caveat, never silently dropped.
+func TestEvaluateWarnsOnLokiInventoryNotes(t *testing.T) {
+	inv := migrateinventory.Inventory{
+		Source: "http://src", Top: 5,
+		Loki: &migrateinventory.LokiInventory{
+			Source:    "http://loki",
+			Selectors: []migrateinventory.LokiSelectorStats{{Selector: `{app="checkout"}`, Streams: 10}},
+			Notes:     []string{`selector {app="down"}: /loki/api/v1/index/stats unavailable: HTTP 503`},
+		},
+	}
+	in := migrategate.Inputs{
+		Verify:    cleanVerify(t),
+		Classify:  cleanClassify(t),
+		Inventory: writeArtifact(t, "inventory.json", inv.WriteJSON),
+		RuleGraph: cleanRuleGraph(t),
+	}
+	dec, err := migrategate.Evaluate(in, migrategate.Options{})
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	iv := stageByName(t, dec, migrategate.StageInventory)
+	if iv.Verdict != migrategate.VerdictWarn || iv.Blocking {
+		t.Fatalf("loki inventory notes must WARN not block, got verdict=%q blocking=%v", iv.Verdict, iv.Blocking)
+	}
+	if !containsSubstr(iv.Reasons, "unavailable") {
+		t.Errorf("inventory reasons should surface the loki selector failure note, got %v", iv.Reasons)
+	}
+}
+
+// TestEvaluateWarnsOnTempoInventoryOutOfScope pins that a present Tempo section
+// (the operator supplied --tempo-source) always yields exactly one WARN
+// reason naming the fixed, specific out-of-scope text — never a block, and
+// never a silently dropped section.
+func TestEvaluateWarnsOnTempoInventoryOutOfScope(t *testing.T) {
+	tempoInv := migrateinventory.NewTempoInventory("http://tempo")
+	inv := migrateinventory.Inventory{
+		Source: "http://src", Top: 5,
+		Tempo: &tempoInv,
+	}
+	in := migrategate.Inputs{
+		Verify:    cleanVerify(t),
+		Classify:  cleanClassify(t),
+		Inventory: writeArtifact(t, "inventory.json", inv.WriteJSON),
+		RuleGraph: cleanRuleGraph(t),
+	}
+	dec, err := migrategate.Evaluate(in, migrategate.Options{})
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	iv := stageByName(t, dec, migrategate.StageInventory)
+	if iv.Verdict != migrategate.VerdictWarn || iv.Blocking {
+		t.Fatalf("a present tempo section must WARN not block, got verdict=%q blocking=%v", iv.Verdict, iv.Blocking)
+	}
+	if !dec.Pass || dec.Overall != migrategate.OverallPass {
+		t.Fatalf("a tempo-out-of-scope-only run should PASS overall, got pass=%v overall=%q", dec.Pass, dec.Overall)
+	}
+	if !containsSubstr(iv.Reasons, migrateinventory.TempoInventoryOutOfScopeReason) {
+		t.Errorf("inventory reasons should carry the specific tempo out-of-scope reason, got %v", iv.Reasons)
+	}
+}
+
+// TestEvaluateInventoryAbsentHeadsAreSilent pins the "never asked ⇒ never
+// mentioned" half of the fold: an inventory with neither Loki nor Tempo
+// sections must not mention either head anywhere in its reasons.
+func TestEvaluateInventoryAbsentHeadsAreSilent(t *testing.T) {
+	in := migrategate.Inputs{
+		Verify:    cleanVerify(t),
+		Classify:  cleanClassify(t),
+		Inventory: cleanInventory(t),
+		RuleGraph: cleanRuleGraph(t),
+	}
+	dec, err := migrategate.Evaluate(in, migrategate.Options{})
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	iv := stageByName(t, dec, migrategate.StageInventory)
+	if containsSubstr(iv.Reasons, "loki") || containsSubstr(iv.Reasons, "tempo") {
+		t.Errorf("an inventory with no loki/tempo section must not mention either head, got %v", iv.Reasons)
+	}
+}
+
+// TestEvaluateRejectsLegacyV1InventoryArtifact pins §5's exact-match schema
+// version policy: InventoryVersion bumped 1→2 when the optional Loki/Tempo
+// sections were added, and the gate's requireSchemaVersion check is exact
+// equality, not "at least" — so a schema_version:1 artifact from before this
+// wave (which predates the Loki/Tempo fields entirely) is a hard error, never
+// a silent decode into a struct whose new pointer fields simply zero to nil.
+// This is the same posture TestEvaluateBlocksOnV2Artifact already pins for
+// verify: the operator must regenerate the artifact with the new binary
+// (inventory is a read-only, non-destructive probe, so this costs one re-run).
+func TestEvaluateRejectsLegacyV1InventoryArtifact(t *testing.T) {
+	legacy := rawArtifact(t, "inventory.json",
+		`{"schema_version":1,"source":"http://src","top":5,"head":{"numSeries":0,"numLabelPairs":0,`+
+			`"chunkCount":0,"minTime":0,"maxTime":0},"topMetricsBySeriesCount":[],`+
+			`"topLabelsByValueCardinality":[],"topLabelsByMemoryBytes":[],"metricNameTotal":-1,`+
+			`"metadataMetricTotal":-1}`)
+	in := migrategate.Inputs{
+		Verify:    cleanVerify(t),
+		Classify:  cleanClassify(t),
+		Inventory: legacy,
+		RuleGraph: cleanRuleGraph(t),
+	}
+	if _, err := migrategate.Evaluate(in, migrategate.Options{}); err == nil {
+		t.Fatal("a schema_version:1 inventory artifact predates the Loki/Tempo sections and must hard error, not silently decode")
+	}
+}
+
 func TestEvaluateWarnsOnInventoryNotesButPasses(t *testing.T) {
 	// An enrichment the probe could not fetch lands in Notes. The gate must
 	// surface it: a probe that silently failed an enrichment is an unchecked

--- a/internal/migrateinventory/inventory.go
+++ b/internal/migrateinventory/inventory.go
@@ -1,21 +1,34 @@
-// Package migrateinventory probes a LIVE source Prometheus for the runtime
+// Package migrateinventory probes LIVE migration sources for the runtime
 // cardinality facts that a migration preview cannot learn offline. Cerberus's
 // offline `migrate explain` can show the SQL and physical tables a query
 // touches, but the one thing that actually drives ClickHouse memory risk —
-// how many series a metric fans out to, how wide a label is — is data, not
-// config, and it lives only in the running TSDB.
+// how many series a metric fans out to, how wide a label is, how much a log
+// stream churns — is data, not config; it lives only in the running source.
 //
-// This package deliberately REFUSES to infer cardinality from prometheus.yml:
-// scrape config lists targets and relabel rules, not the realized series count
-// after those rules run against real endpoints. The only honest source is the
-// TSDB itself, so `inventory` calls the source Prometheus HTTP API
-// (/api/v1/status/tsdb) and ranks the head-block cardinality.
+// Each head's client REFUSES to infer cardinality from static config —
+// Prometheus's scrape config lists targets and relabel rules, not the
+// realized series count after those rules run against real endpoints; Loki's
+// config says nothing about how many streams a tenant actually writes. The
+// only honest source is the running system itself:
 //
-// Honesty contract: everything here is a SOURCE-Prometheus runtime fact. It
-// ranks OOM RISK — a high-cardinality metric is a candidate that cerberus can't
-// see offline — it does NOT predict cerberus's exact memory. The report says so
-// in its own words. Optional enrichment endpoints that fail are COUNTED and
-// surfaced as notes, never silently dropped.
+//   - Client probes the source Prometheus's /api/v1/status/tsdb, which ranks
+//     head-block cardinality — a point-in-time TSDB snapshot.
+//   - LokiClient probes a Loki source's per-selector /loki/api/v1/index/stats
+//     endpoint. Loki exposes no whole-tenant top-N cardinality call, so the
+//     operator supplies the stream selectors to rank; the ranking covers
+//     exactly that supplied set, by streams matched.
+//   - Tempo has no client in this package. Its span/block storage exposes
+//     neither a TSDB-style head snapshot (Prometheus) nor a per-selector
+//     stats endpoint (Loki); its Inventory section is always the fixed,
+//     specifically-reasoned out-of-scope entry in TempoInventory rather than
+//     a fabricated cardinality number Tempo cannot honestly back.
+//
+// Honesty contract: everything here is a source runtime fact. It ranks OOM
+// RISK — a high-cardinality metric, label, or selector is a candidate worth
+// reviewing, never a prediction of cerberus's exact memory — and it never
+// silently drops a caveat: enrichment and per-selector failures land in
+// Notes, and a head the operator never asked about is simply absent from the
+// report, never presented as "checked, nothing found."
 package migrateinventory
 
 import (
@@ -115,12 +128,18 @@ type tsdbStatusResponse struct {
 // WriteJSON stamps it and the cutover gate refuses an inventory whose version it
 // does not understand, so a schema-drifted or wrong-type artifact blocks rather
 // than zero-filling to a silent PASS. Bump it on any breaking change to the JSON
-// shape.
-const InventoryVersion = 1
+// shape — the optional Loki and Tempo sections are exactly that kind of change,
+// since DisallowUnknownFields decoding of an old artifact against a newer struct
+// (or vice versa) is the class of drift this version exists to catch.
+const InventoryVersion = 2
 
-// Inventory is the ranked risk picture of the source Prometheus head block.
-// Every field is a source-Prometheus runtime fact; none predicts cerberus's
-// memory. It ranks candidates worth reviewing before cutover.
+// Inventory is the ranked risk picture assembled from every source the
+// operator pointed the probe at. The Prometheus fields (Head/TopMetrics*/
+// TopLabels*) are always present — Inventory always probes a live Prometheus.
+// Loki and Tempo are present only when the operator supplied the matching
+// source flag; a nil section means "never asked," never "asked and found
+// nothing." Every field is a source runtime fact; none predicts cerberus's
+// own memory. It ranks candidates worth reviewing before cutover.
 type Inventory struct {
 	SchemaVersion int    `json:"schema_version"`
 	Source        string `json:"source"`
@@ -150,6 +169,13 @@ type Inventory struct {
 	// enrichment that could not be fetched is recorded here — counted, never
 	// silently dropped.
 	Notes []string `json:"notes,omitempty"`
+
+	// Loki is the optional per-selector stream cardinality/volume section,
+	// present only when the operator supplied a Loki source to probe.
+	Loki *LokiInventory `json:"loki,omitempty"`
+	// Tempo is the optional out-of-scope section, present only when the
+	// operator supplied a Tempo source.
+	Tempo *TempoInventory `json:"tempo,omitempty"`
 }
 
 // Client probes a Prometheus-compatible HTTP API for TSDB cardinality.

--- a/internal/migrateinventory/inventory_test.go
+++ b/internal/migrateinventory/inventory_test.go
@@ -287,6 +287,54 @@ func TestWriteText_EmptyHeadNoGarbageSpan(t *testing.T) {
 	}
 }
 
+// TestWriteText_NoHeadSectionsWhenAbsent pins that a bare Inventory (nil
+// Loki, nil Tempo) renders no "loki:"/"tempo:" section headers at all —
+// absence must read as visibly absent, not as an empty ranked table.
+func TestWriteText_NoHeadSectionsWhenAbsent(t *testing.T) {
+	inv := Inventory{Source: "http://src", Top: 5, MetricNameTotal: -1, MetadataMetricTotal: -1}
+	var buf strings.Builder
+	if err := inv.WriteText(&buf); err != nil {
+		t.Fatalf("WriteText: %v", err)
+	}
+	out := buf.String()
+	if strings.Contains(out, "== loki:") || strings.Contains(out, "== tempo:") {
+		t.Errorf("a bare inventory must carry no per-head sections, got:\n%s", out)
+	}
+}
+
+// TestWriteText_LokiAndTempoSections pins that populated Loki/Tempo sections
+// render their ranked selectors and the fixed out-of-scope reason.
+func TestWriteText_LokiAndTempoSections(t *testing.T) {
+	inv := Inventory{
+		Source: "http://src", Top: 5, MetricNameTotal: -1, MetadataMetricTotal: -1,
+		Loki: &LokiInventory{
+			Source: "http://loki:3100",
+			Selectors: []LokiSelectorStats{
+				{Selector: `{app="checkout"}`, Streams: 500, Chunks: 10, Entries: 1000, Bytes: 2000},
+			},
+			Notes: []string{`selector {app="broken"}: /loki/api/v1/index/stats unavailable: GET: HTTP 500`},
+		},
+		Tempo: &TempoInventory{Source: "http://tempo:3200", OutOfScope: TempoInventoryOutOfScopeReason},
+	}
+	var buf strings.Builder
+	if err := inv.WriteText(&buf); err != nil {
+		t.Fatalf("WriteText: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{
+		"== loki: http://loki:3100",
+		`{app="checkout"}`,
+		"500",
+		`selector {app="broken"}`,
+		"== tempo: http://tempo:3200",
+		TempoInventoryOutOfScopeReason,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("text report missing %q, got:\n%s", want, out)
+		}
+	}
+}
+
 // TestReadCappedBody pins the response-body cap: a body within the limit is
 // returned whole, and a body past the limit errors rather than buffering an
 // unbounded stream into memory.

--- a/internal/migrateinventory/loki.go
+++ b/internal/migrateinventory/loki.go
@@ -1,0 +1,212 @@
+package migrateinventory
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// lokiIndexStatsPath is Loki's real, bounded per-selector cardinality/volume
+// endpoint. Loki exposes no single ranked top-N call analogous to
+// Prometheus's /api/v1/status/tsdb; index/stats answers "how much does THIS
+// stream selector match," so an operator-supplied selector set is what gets
+// ranked, never a whole-tenant scan.
+const lokiIndexStatsPath = "/loki/api/v1/index/stats"
+
+// LokiInventory is the optional per-selector cardinality/volume section for a
+// Loki source. Unlike Prometheus's ranked whole-TSDB status/tsdb call, Loki
+// exposes no global top-N cardinality endpoint — its index/stats API answers
+// "how much does THIS stream selector match" — so the operator supplies the
+// selectors to probe and this section ranks only across that supplied set.
+// Loki's label/series enumeration endpoints (/loki/api/v1/labels,
+// /label/<name>/values, /series) are deliberately not probed here: they
+// return raw sets with no built-in count, so ranking them would require
+// unbounded client-side enumeration with no natural top-N boundary.
+type LokiInventory struct {
+	Source    string              `json:"source"`
+	Window    string              `json:"window"`
+	Selectors []LokiSelectorStats `json:"selectors"` // sorted by Streams desc
+	Notes     []string            `json:"notes"`
+}
+
+// LokiSelectorStats is one operator-supplied selector's index/stats result.
+type LokiSelectorStats struct {
+	Selector string `json:"selector"`
+	Streams  uint64 `json:"streams"`
+	Chunks   uint64 `json:"chunks"`
+	Entries  uint64 `json:"entries"`
+	Bytes    uint64 `json:"bytes"`
+}
+
+// lokiIndexStatsResponse is /loki/api/v1/index/stats's JSON envelope: a flat
+// object with no "status" wrapper, matching Loki's documented shape (unlike
+// the Prometheus HTTP API's {status, data} envelope).
+type lokiIndexStatsResponse struct {
+	Streams uint64 `json:"streams"`
+	Chunks  uint64 `json:"chunks"`
+	Entries uint64 `json:"entries"`
+	Bytes   uint64 `json:"bytes"`
+}
+
+// LokiClient probes a Loki-compatible HTTP API for per-selector stream
+// cardinality/volume.
+type LokiClient struct {
+	BaseURL string
+	HTTP    *http.Client
+}
+
+// NewLokiClient builds a probe client for baseURL, with the same bounded
+// default HTTP client the Prometheus Client uses.
+func NewLokiClient(baseURL string) *LokiClient {
+	return &LokiClient{
+		BaseURL: strings.TrimRight(baseURL, "/"),
+		HTTP:    &http.Client{Timeout: defaultHTTPTimeout},
+	}
+}
+
+// Probe ranks selectors by streams matched, issuing one independent
+// /loki/api/v1/index/stats call per selector. window, if non-empty, is a
+// duration parsed once and applied as the real [now-window, now) query range
+// for every selector's call — unlike the Prometheus Client's Window (recorded
+// verbatim, cosmetic only against a point-in-time snapshot), Loki's
+// index/stats endpoint takes a real start/end range, so window here actually
+// bounds the query. An empty window omits start/end, letting the server apply
+// its own default range.
+//
+// Zero selectors is a validation error raised before any HTTP call — an
+// operator who points --loki-source at a Loki instance must also name at
+// least one --loki-selector, since there is no way to drive this API without
+// one; returning an empty section here would misrepresent "nothing
+// configured" as "checked, nothing found." If every selector's call fails,
+// that is a hard error for the same reason: real work was attempted and
+// nothing came back, which must not read as a clean, empty top-N. A PARTIAL
+// failure (some selectors succeed, others don't) instead appends the failures
+// to Notes and still ranks and truncates the selectors that did succeed.
+func (c *LokiClient) Probe(ctx context.Context, selectors []string, window string, top int) (LokiInventory, error) {
+	if len(selectors) == 0 {
+		return LokiInventory{}, errors.New(
+			"loki inventory requires at least one --loki-selector (or CERBERUS_INVENTORY_LOKI_SELECTORS entry)",
+		)
+	}
+	if top <= 0 {
+		return LokiInventory{}, fmt.Errorf("top must be positive, got %d", top)
+	}
+
+	startParam, endParam, err := lokiWindowParams(window)
+	if err != nil {
+		return LokiInventory{}, err
+	}
+
+	inv := LokiInventory{Source: c.BaseURL, Window: window}
+
+	var failed []string
+	for _, sel := range selectors {
+		stats, err := c.fetchIndexStats(ctx, sel, startParam, endParam)
+		if err != nil {
+			failed = append(failed, sel)
+			inv.Notes = append(inv.Notes, fmt.Sprintf("selector %s: %s unavailable: %v", sel, lokiIndexStatsPath, err))
+			continue
+		}
+		inv.Selectors = append(inv.Selectors, LokiSelectorStats{
+			Selector: sel,
+			Streams:  stats.Streams,
+			Chunks:   stats.Chunks,
+			Entries:  stats.Entries,
+			Bytes:    stats.Bytes,
+		})
+	}
+
+	if len(failed) == len(selectors) {
+		return LokiInventory{}, fmt.Errorf("all %d loki selector(s) failed %s: %s",
+			len(selectors), lokiIndexStatsPath, strings.Join(failed, ", "))
+	}
+
+	rankSelectorsByStreams(inv.Selectors)
+	if len(inv.Selectors) > top {
+		inv.Selectors = inv.Selectors[:top]
+	}
+
+	return inv, nil
+}
+
+// lokiWindowParams parses window (if non-empty) into the [start, end) epoch
+// nanosecond strings index/stats expects, anchored to a single "now" so every
+// selector in one Probe call is compared over the identical range. An empty
+// window yields empty params, letting the server apply its own default.
+func lokiWindowParams(window string) (startParam, endParam string, err error) {
+	if window == "" {
+		return "", "", nil
+	}
+	dur, err := time.ParseDuration(window)
+	if err != nil {
+		return "", "", fmt.Errorf("window %q is not a valid duration: %w", window, err)
+	}
+	end := time.Now().UTC()
+	start := end.Add(-dur)
+	return strconv.FormatInt(start.UnixNano(), 10), strconv.FormatInt(end.UnixNano(), 10), nil
+}
+
+// rankSelectorsByStreams sorts stats descending by Streams (ties broken by
+// Selector ascending for determinism), matching rankTopN's discipline for the
+// Prometheus ranked tables: never trust the server's ordering, always re-rank.
+func rankSelectorsByStreams(stats []LokiSelectorStats) {
+	sort.Slice(stats, func(i, j int) bool {
+		if stats[i].Streams != stats[j].Streams {
+			return stats[i].Streams > stats[j].Streams
+		}
+		return stats[i].Selector < stats[j].Selector
+	})
+}
+
+// fetchIndexStats issues GET {base}/loki/api/v1/index/stats?query=<selector>
+// (plus start/end when startParam is set) and decodes the flat
+// {streams, chunks, entries, bytes} response.
+func (c *LokiClient) fetchIndexStats(ctx context.Context, selector, startParam, endParam string) (lokiIndexStatsResponse, error) {
+	q := url.Values{}
+	q.Set("query", selector)
+	if startParam != "" {
+		q.Set("start", startParam)
+		q.Set("end", endParam)
+	}
+
+	body, err := c.getOK(ctx, lokiIndexStatsPath+"?"+q.Encode())
+	if err != nil {
+		return lokiIndexStatsResponse{}, err
+	}
+	var raw lokiIndexStatsResponse
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return lokiIndexStatsResponse{}, fmt.Errorf("decode %s response: %w", lokiIndexStatsPath, err)
+	}
+	return raw, nil
+}
+
+// getOK issues GET {base}{path} and returns the body only on HTTP 200,
+// mirroring the Prometheus Client's capped-read, non-200-is-error discipline.
+func (c *LokiClient) getOK(ctx context.Context, path string) ([]byte, error) {
+	reqURL := c.BaseURL + path
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request %s: %w", path, err)
+	}
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("GET %s: %w", path, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := readCappedBody(resp.Body, maxResponseBytes)
+	if err != nil {
+		return nil, fmt.Errorf("read %s body: %w", path, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GET %s: HTTP %d", path, resp.StatusCode)
+	}
+	return body, nil
+}

--- a/internal/migrateinventory/loki_test.go
+++ b/internal/migrateinventory/loki_test.go
@@ -1,0 +1,188 @@
+package migrateinventory
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// lokiStatsHandler returns an httptest handler answering /loki/api/v1/index/stats
+// with a fixed body for each recognized selector, and a 404 for anything else
+// — closing over a mutable failSet so tests can flip individual selectors
+// between "answers" and "fails" without spinning up a second server.
+func lokiStatsHandler(t *testing.T, bodies map[string]string, failSet map[string]bool) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != lokiIndexStatsPath {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		sel := r.URL.Query().Get("query")
+		if failSet[sel] {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		body, ok := bodies[sel]
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		_, _ = w.Write([]byte(body))
+	}
+}
+
+// TestLokiProbe_RanksSelectorsByStreams: three selectors answer out of
+// stream-count order; Probe re-ranks them descending by Streams (never
+// trusting call order) and truncates to top.
+func TestLokiProbe_RanksSelectorsByStreams(t *testing.T) {
+	bodies := map[string]string{
+		`{app="a"}`: `{"streams":10,"chunks":1,"entries":100,"bytes":1000}`,
+		`{app="b"}`: `{"streams":900,"chunks":2,"entries":200,"bytes":2000}`,
+		`{app="c"}`: `{"streams":450,"chunks":3,"entries":300,"bytes":3000}`,
+	}
+	srv := httptest.NewServer(lokiStatsHandler(t, bodies, nil))
+	t.Cleanup(srv.Close)
+
+	inv, err := NewLokiClient(srv.URL).Probe(context.Background(),
+		[]string{`{app="a"}`, `{app="b"}`, `{app="c"}`}, "", 2)
+	if err != nil {
+		t.Fatalf("Probe: %v", err)
+	}
+	if len(inv.Selectors) != 2 {
+		t.Fatalf("selectors = %d, want 2 (truncated to top)", len(inv.Selectors))
+	}
+	if inv.Selectors[0].Selector != `{app="b"}` || inv.Selectors[0].Streams != 900 {
+		t.Errorf("rank #1 = %+v, want {app=\"b\"} with 900 streams", inv.Selectors[0])
+	}
+	if inv.Selectors[1].Selector != `{app="c"}` || inv.Selectors[1].Streams != 450 {
+		t.Errorf("rank #2 = %+v, want {app=\"c\"} with 450 streams", inv.Selectors[1])
+	}
+	if inv.Selectors[0].Chunks != 2 || inv.Selectors[0].Entries != 200 || inv.Selectors[0].Bytes != 2000 {
+		t.Errorf("rank #1 should carry through chunks/entries/bytes, got %+v", inv.Selectors[0])
+	}
+}
+
+// TestLokiProbe_ZeroSelectorsIsValidationError: an empty selector list is
+// rejected before any HTTP call — Probe must not even need a live server.
+func TestLokiProbe_ZeroSelectorsIsValidationError(t *testing.T) {
+	client := NewLokiClient("http://unreachable.invalid:1")
+	_, err := client.Probe(context.Background(), nil, "", 10)
+	if err == nil {
+		t.Fatal("Probe should reject zero selectors")
+	}
+	if !strings.Contains(err.Error(), "at least one") {
+		t.Errorf("error should explain the requirement, got: %v", err)
+	}
+}
+
+// TestLokiProbe_AllSelectorsFailIsHardError: every selector's index/stats
+// call failing must surface a non-nil error, never an empty-but-successful
+// Selectors slice (that would misrepresent "nothing configured" as "checked,
+// nothing found").
+func TestLokiProbe_AllSelectorsFailIsHardError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	inv, err := NewLokiClient(srv.URL).Probe(context.Background(), []string{`{app="a"}`, `{app="b"}`}, "", 10)
+	if err == nil {
+		t.Fatalf("Probe should hard-error when every selector fails, got inv: %+v", inv)
+	}
+	if !strings.Contains(err.Error(), `{app="a"}`) || !strings.Contains(err.Error(), `{app="b"}`) {
+		t.Errorf("error should name both failed selectors, got: %v", err)
+	}
+}
+
+// TestLokiProbe_PartialFailureAppendsNotes: one of three selectors failing
+// yields two ranked results plus a Notes entry naming the failed selector —
+// the failure is counted, never silently swallowed.
+func TestLokiProbe_PartialFailureAppendsNotes(t *testing.T) {
+	bodies := map[string]string{
+		`{app="ok1"}`: `{"streams":10,"chunks":1,"entries":100,"bytes":1000}`,
+		`{app="ok2"}`: `{"streams":20,"chunks":1,"entries":100,"bytes":1000}`,
+	}
+	failSet := map[string]bool{`{app="bad"}`: true}
+	srv := httptest.NewServer(lokiStatsHandler(t, bodies, failSet))
+	t.Cleanup(srv.Close)
+
+	inv, err := NewLokiClient(srv.URL).Probe(context.Background(),
+		[]string{`{app="ok1"}`, `{app="bad"}`, `{app="ok2"}`}, "", 10)
+	if err != nil {
+		t.Fatalf("Probe: %v", err)
+	}
+	if len(inv.Selectors) != 2 {
+		t.Fatalf("selectors = %d, want 2 (the two that succeeded), got %+v", len(inv.Selectors), inv.Selectors)
+	}
+	if len(inv.Notes) != 1 {
+		t.Fatalf("notes = %d, want 1, got %+v", len(inv.Notes), inv.Notes)
+	}
+	if !strings.Contains(inv.Notes[0], `{app="bad"}`) {
+		t.Errorf("note should name the failed selector, got: %q", inv.Notes[0])
+	}
+}
+
+// TestLokiProbe_WindowAppliesRealQueryRange pins that a non-empty window is
+// actually threaded through as start/end params, unlike the Prometheus
+// Client's cosmetic-only Window.
+func TestLokiProbe_WindowAppliesRealQueryRange(t *testing.T) {
+	var gotStart, gotEnd string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotStart = r.URL.Query().Get("start")
+		gotEnd = r.URL.Query().Get("end")
+		_, _ = w.Write([]byte(`{"streams":1,"chunks":1,"entries":1,"bytes":1}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	if _, err := NewLokiClient(srv.URL).Probe(context.Background(), []string{`{app="a"}`}, "1h", 10); err != nil {
+		t.Fatalf("Probe: %v", err)
+	}
+	if gotStart == "" || gotEnd == "" {
+		t.Fatalf("a non-empty window should set start/end query params, got start=%q end=%q", gotStart, gotEnd)
+	}
+}
+
+// TestLokiProbe_EmptyWindowOmitsRange pins that an empty window sends no
+// start/end params at all, letting the server apply its own default range.
+func TestLokiProbe_EmptyWindowOmitsRange(t *testing.T) {
+	sawStart, sawEnd := false, false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, sawStart = r.URL.Query()["start"]
+		_, sawEnd = r.URL.Query()["end"]
+		_, _ = w.Write([]byte(`{"streams":1,"chunks":1,"entries":1,"bytes":1}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	if _, err := NewLokiClient(srv.URL).Probe(context.Background(), []string{`{app="a"}`}, "", 10); err != nil {
+		t.Fatalf("Probe: %v", err)
+	}
+	if sawStart || sawEnd {
+		t.Errorf("an empty window should omit start/end params, got start present=%v end present=%v", sawStart, sawEnd)
+	}
+}
+
+// TestLokiProbe_InvalidWindowIsValidationError: an unparseable window is
+// rejected before any HTTP call, matching the Prometheus Options.Validate
+// discipline for the same kind of input.
+func TestLokiProbe_InvalidWindowIsValidationError(t *testing.T) {
+	client := NewLokiClient("http://unreachable.invalid:1")
+	_, err := client.Probe(context.Background(), []string{`{app="a"}`}, "banana", 10)
+	if err == nil {
+		t.Fatal("Probe should reject an unparseable window")
+	}
+	if !strings.Contains(err.Error(), "banana") {
+		t.Errorf("error should name the bad window value, got: %v", err)
+	}
+}
+
+// TestLokiProbe_InvalidTopIsValidationError: a non-positive top is rejected
+// before any HTTP call, mirroring the Prometheus Options.Validate guard.
+func TestLokiProbe_InvalidTopIsValidationError(t *testing.T) {
+	client := NewLokiClient("http://unreachable.invalid:1")
+	_, err := client.Probe(context.Background(), []string{`{app="a"}`}, "", 0)
+	if err == nil {
+		t.Fatal("Probe should reject top <= 0")
+	}
+}

--- a/internal/migrateinventory/report.go
+++ b/internal/migrateinventory/report.go
@@ -67,7 +67,48 @@ func (inv Inventory) WriteText(w io.Writer) error {
 			bw.printf("  %s\n", n)
 		}
 	}
+
+	writeLokiSection(bw, inv.Loki)
+	writeTempoSection(bw, inv.Tempo)
+
 	return bw.err
+}
+
+// writeLokiSection prints the optional per-selector Loki section, or nothing
+// at all when the operator never supplied a Loki source — a nil section is
+// simply absent from the report, never rendered as an empty ranked table.
+func writeLokiSection(bw *errWriter, loki *LokiInventory) {
+	if loki == nil {
+		return
+	}
+	bw.printf("\n== loki: %s\n", loki.Source)
+	if loki.Window != "" {
+		bw.printf("  window: %s\n", loki.Window)
+	}
+	if len(loki.Selectors) == 0 {
+		bw.printf("  none reported by the source\n")
+	}
+	for i, s := range loki.Selectors {
+		bw.printf("  %3d. %-*s %d streams %d chunks %d entries %d bytes\n",
+			i+1, rankNameWidth, s.Selector, s.Streams, s.Chunks, s.Entries, s.Bytes)
+	}
+	if len(loki.Notes) > 0 {
+		bw.printf("  notes (%d):\n", len(loki.Notes))
+		for _, n := range loki.Notes {
+			bw.printf("    %s\n", n)
+		}
+	}
+}
+
+// writeTempoSection prints the optional, always-fixed Tempo out-of-scope
+// section, or nothing at all when the operator never supplied a Tempo
+// source.
+func writeTempoSection(bw *errWriter, tempo *TempoInventory) {
+	if tempo == nil {
+		return
+	}
+	bw.printf("\n== tempo: %s\n", tempo.Source)
+	bw.printf("  out of scope: %s\n", tempo.OutOfScope)
 }
 
 // writeRanked prints one ranked table, or an explicit "none reported" line so an

--- a/internal/migrateinventory/tempo.go
+++ b/internal/migrateinventory/tempo.go
@@ -1,0 +1,26 @@
+package migrateinventory
+
+// TempoInventory is always exactly this: an honest statement that Tempo has
+// no TSDB-head-block or ranked cardinality-stats analog to probe. Tempo's
+// storage is block-based spans with no in-memory series-cardinality surface
+// exposed over HTTP; a distinct-span-name or service-name count would not
+// measure OOM risk the way head-series cardinality does, so no such proxy is
+// computed. Present only when the operator supplied --tempo-source.
+type TempoInventory struct {
+	Source     string `json:"source"`
+	OutOfScope string `json:"out_of_scope"`
+}
+
+// TempoInventoryOutOfScopeReason is the fixed, specific reason recorded for
+// every TempoInventory — a statement of Tempo's storage model, not a
+// placeholder for a missing feature.
+const TempoInventoryOutOfScopeReason = "tempo storage is block-based spans with no TSDB-head-block or " +
+	"ranked cardinality-stats API analogous to Prometheus's status/tsdb or Loki's index/stats; no " +
+	"cardinality proxy is computed because a span/service-name count would not measure OOM risk"
+
+// NewTempoInventory builds the fixed out-of-scope entry for a Tempo source.
+// No HTTP round-trip is made: there is nothing to call, so pretending to
+// probe would itself be dishonest theater.
+func NewTempoInventory(source string) TempoInventory {
+	return TempoInventory{Source: source, OutOfScope: TempoInventoryOutOfScopeReason}
+}

--- a/internal/migrateinventory/tempo_test.go
+++ b/internal/migrateinventory/tempo_test.go
@@ -1,0 +1,29 @@
+package migrateinventory
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestTempoInventory_OutOfScopeReasonIsSpecific pins that the recorded reason
+// names the actual mechanism (block-based spans, no head-block/ranked-stats
+// API) rather than a generic "not supported" placeholder — a specific reason
+// is the honesty contract this section exists to satisfy.
+func TestTempoInventory_OutOfScopeReasonIsSpecific(t *testing.T) {
+	inv := NewTempoInventory("http://tempo.example:3200")
+
+	if inv.Source != "http://tempo.example:3200" {
+		t.Errorf("source = %q, want the supplied base URL", inv.Source)
+	}
+	if inv.OutOfScope != TempoInventoryOutOfScopeReason {
+		t.Errorf("out-of-scope reason = %q, want the package constant", inv.OutOfScope)
+	}
+	for _, mustContain := range []string{"block-based spans", "TSDB-head-block", "cardinality-stats"} {
+		if !strings.Contains(inv.OutOfScope, mustContain) {
+			t.Errorf("out-of-scope reason should name %q, got: %q", mustContain, inv.OutOfScope)
+		}
+	}
+	if inv.OutOfScope == "not supported" || inv.OutOfScope == "" {
+		t.Errorf("out-of-scope reason must not be a generic placeholder, got: %q", inv.OutOfScope)
+	}
+}

--- a/test/e2e/migration/archetypes/already-otel/expected/gate.json
+++ b/test/e2e/migration/archetypes/already-otel/expected/gate.json
@@ -40,7 +40,7 @@
       "blocking": true,
       "reasons": [
         "1 consumed recorded series must stay materialized after cutover",
-        "  otel:http_server_request_duration:p95 \u003c- 1 consumer"
+        "  otel:http_server_request_duration:p95 (rule:test/e2e/migration/archetypes/already-otel/rules/otel-recording.yaml/otel.rules/otel:http_server_request_duration:p95) \u003c- 1 consumer"
       ]
     }
   ],

--- a/test/e2e/migration/archetypes/kube-prometheus-stack/expected/gate.json
+++ b/test/e2e/migration/archetypes/kube-prometheus-stack/expected/gate.json
@@ -38,9 +38,9 @@
       "blocking": true,
       "reasons": [
         "3 consumed recorded series must stay materialized after cutover",
-        "  cluster:node_cpu:ratio \u003c- 1 consumer",
-        "  node:node_cpu_utilisation:avg1m \u003c- 2 consumers",
-        "  node:node_memory_utilisation:ratio \u003c- 1 consumer",
+        "  cluster:node_cpu:ratio (rule:test/e2e/migration/archetypes/kube-prometheus-stack/rules/node-recording.yaml/node.rules/cluster:node_cpu:ratio) \u003c- 1 consumer",
+        "  node:node_cpu_utilisation:avg1m (rule:test/e2e/migration/archetypes/kube-prometheus-stack/rules/node-recording.yaml/node.rules/node:node_cpu_utilisation:avg1m) \u003c- 2 consumers",
+        "  node:node_memory_utilisation:ratio (rule:test/e2e/migration/archetypes/kube-prometheus-stack/rules/node-recording.yaml/node.rules/node:node_memory_utilisation:ratio) \u003c- 1 consumer",
         "1 skipped input make the orphan classification unsound (a dropped consumer may reference a series marked orphan)",
         "  skipped dashboard:test/e2e/migration/archetypes/kube-prometheus-stack/dashboards/node-exporter.json/Byte counters by name pattern/A: unparseable consumer expr: consumer selects __name__ non-statically (regex/negated matcher or no name constraint): {__name__=~\"node_.*_bytes_total\"}"
       ]

--- a/test/e2e/migration/archetypes/mimir-cortex/expected/gate.json
+++ b/test/e2e/migration/archetypes/mimir-cortex/expected/gate.json
@@ -40,8 +40,8 @@
       "blocking": true,
       "reasons": [
         "2 consumed recorded series must stay materialized after cutover",
-        "  tenant:cortex_ingester_active_series:sum \u003c- 2 consumers",
-        "  tenant:cortex_request_duration_seconds:p99 \u003c- 1 consumer"
+        "  tenant:cortex_ingester_active_series:sum (rule:test/e2e/migration/archetypes/mimir-cortex/rules/tenant-recording.yaml/mimir.tenant/tenant:cortex_ingester_active_series:sum) \u003c- 2 consumers",
+        "  tenant:cortex_request_duration_seconds:p99 (rule:test/e2e/migration/archetypes/mimir-cortex/rules/tenant-recording.yaml/mimir.tenant/tenant:cortex_request_duration_seconds:p99) \u003c- 1 consumer"
       ]
     }
   ],

--- a/test/e2e/migration/archetypes/prometheus-thanos/expected/gate.json
+++ b/test/e2e/migration/archetypes/prometheus-thanos/expected/gate.json
@@ -40,8 +40,8 @@
       "blocking": true,
       "reasons": [
         "2 consumed recorded series must stay materialized after cutover",
-        "  slo:http_error_budget:burnrate7d \u003c- 1 consumer",
-        "  slo:http_request_availability:ratio30d \u003c- 1 consumer"
+        "  slo:http_error_budget:burnrate7d (rule:test/e2e/migration/archetypes/prometheus-thanos/rules/thanos-slo.yaml/thanos.slo/slo:http_error_budget:burnrate7d) \u003c- 1 consumer",
+        "  slo:http_request_availability:ratio30d (rule:test/e2e/migration/archetypes/prometheus-thanos/rules/thanos-slo.yaml/thanos.slo/slo:http_request_availability:ratio30d) \u003c- 1 consumer"
       ]
     }
   ],

--- a/test/e2e/migration/archetypes/three-signal/expected/gate.json
+++ b/test/e2e/migration/archetypes/three-signal/expected/gate.json
@@ -41,7 +41,7 @@
       "blocking": true,
       "reasons": [
         "1 consumed recorded series must stay materialized after cutover",
-        "  svc:http_requests:rate5m \u003c- 2 consumers",
+        "  svc:http_requests:rate5m (rule:test/e2e/migration/archetypes/three-signal/rules/service-recording.yaml/three-signal/svc:http_requests:rate5m) \u003c- 2 consumers",
         "3 skipped inputs make the orphan classification unsound (a dropped consumer may reference a series marked orphan)",
         "  skipped dashboard:test/e2e/migration/archetypes/three-signal/dashboards/checkout-signals.json/Error log rate/A: unparseable consumer expr: 1:55: parse error: unexpected character: '|'",
         "  skipped dashboard:test/e2e/migration/archetypes/three-signal/dashboards/checkout-signals.json/Left on the old search backend/A: unsupported datasource type \"elasticsearch\" (not prometheus/loki/tempo)",


### PR DESCRIPTION
Wave 4: extends `cerberus migrate inventory` and `cerberus migrate rulegraph` to Loki where a genuine equivalent exists, honestly out-of-scope for Tempo where it doesn't, and folds the new per-head evidence into `cerberus migrate gate`'s go/no-go decision using the same honesty discipline Wave 2/3 established for `verify` (ComparedSeries-style evidence counters — a lane that produced no evidence must be visibly absent from the decision, never silently clean).

**Scope honesty note:** `MIG-04` (rulegraph's canonical story, already shipped in Harness Phase 1) is Prometheus-rules-only per `docs/migration-testing.md` §6 — this PR extends beyond MIG-04's mandate, and does not claim to close or extend that story. `MIG-02` (inventory) is Tier-1 and has no Gherkin scenario yet by design (Harness Phase 1 was Tier-0 only); this PR is tool capability only and does not attempt Tier-1 Gherkin authorship, which belongs to Harness Phase 2 (not yet chartered).

**Draft — build in progress.** Stage A (multi-head inventory) is pushed; rulegraph and gate-fold stages, then an adversarial review pass and its fixes, land before this leaves draft. Opened early so CI runs against each stage rather than only at the end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)