### PR TITLE
fix(ci): pass migration-e2e's enumerator output to migration-tier0 as an artifact

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -259,13 +259,13 @@ jobs:
       # silently when the secrets are absent (forks). Mirroring the
       # upstream images to GHCR is the stronger long-term fix.
       - name: Log in to Docker Hub
-        if: ${{ env.DOCKERHUB_TOKEN_SET == 'true' }}
+        if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
         env:
-          DOCKERHUB_TOKEN_SET: ${{ secrets.DOCKERHUB_TOKEN != '' }}
+          DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
         uses: docker/login-action@v4
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: tsouza
+          password: ${{ secrets.DOCKER_HUB_PAT }}
 
       - name: Run compatibility harness
         id: compat
@@ -507,13 +507,13 @@ jobs:
           tool: just
 
       - name: Log in to Docker Hub
-        if: ${{ env.DOCKERHUB_TOKEN_SET == 'true' }}
+        if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
         env:
-          DOCKERHUB_TOKEN_SET: ${{ secrets.DOCKERHUB_TOKEN != '' }}
+          DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
         uses: docker/login-action@v4
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: tsouza
+          password: ${{ secrets.DOCKER_HUB_PAT }}
 
       - name: Run forced-route compatibility harness
         id: compat
@@ -631,13 +631,13 @@ jobs:
       # See the prometheus job: authed Docker Hub pulls dodge the anonymous
       # rate limit shared across runner IPs; skips silently on forks.
       - name: Log in to Docker Hub
-        if: ${{ env.DOCKERHUB_TOKEN_SET == 'true' }}
+        if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
         env:
-          DOCKERHUB_TOKEN_SET: ${{ secrets.DOCKERHUB_TOKEN != '' }}
+          DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
         uses: docker/login-action@v4
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: tsouza
+          password: ${{ secrets.DOCKER_HUB_PAT }}
 
       - name: Run PromQL surface-completeness gate
         id: gate
@@ -681,13 +681,13 @@ jobs:
       # anonymous rate limit shared across runner IPs; skips silently
       # on forks without the secrets.
       - name: Log in to Docker Hub
-        if: ${{ env.DOCKERHUB_TOKEN_SET == 'true' }}
+        if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
         env:
-          DOCKERHUB_TOKEN_SET: ${{ secrets.DOCKERHUB_TOKEN != '' }}
+          DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
         uses: docker/login-action@v4
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: tsouza
+          password: ${{ secrets.DOCKER_HUB_PAT }}
 
       - name: Run tempo-compatibility harness
         id: harness
@@ -857,13 +857,13 @@ jobs:
       # anonymous rate limit shared across runner IPs; skips silently
       # on forks without the secrets.
       - name: Log in to Docker Hub
-        if: ${{ env.DOCKERHUB_TOKEN_SET == 'true' }}
+        if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
         env:
-          DOCKERHUB_TOKEN_SET: ${{ secrets.DOCKERHUB_TOKEN != '' }}
+          DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
         uses: docker/login-action@v4
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: tsouza
+          password: ${{ secrets.DOCKER_HUB_PAT }}
 
       - name: Run loki-compatibility harness
         id: harness

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -364,13 +364,13 @@ jobs:
       # secrets are absent (forks); GHCR mirroring is the stronger
       # long-term fix.
       - name: Log in to Docker Hub
-        if: ${{ env.DOCKERHUB_TOKEN_SET == 'true' }}
+        if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
         env:
-          DOCKERHUB_TOKEN_SET: ${{ secrets.DOCKERHUB_TOKEN != '' }}
+          DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
         uses: docker/login-action@v4
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: tsouza
+          password: ${{ secrets.DOCKER_HUB_PAT }}
 
       - name: docker compose up --wait
         run: |
@@ -575,13 +575,13 @@ jobs:
       - uses: docker/setup-buildx-action@v4
 
       - name: Log in to Docker Hub
-        if: ${{ env.DOCKERHUB_TOKEN_SET == 'true' }}
+        if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
         env:
-          DOCKERHUB_TOKEN_SET: ${{ secrets.DOCKERHUB_TOKEN != '' }}
+          DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
         uses: docker/login-action@v4
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: tsouza
+          password: ${{ secrets.DOCKER_HUB_PAT }}
 
       - name: docker compose up --wait
         run: docker compose up --wait --wait-timeout 300

--- a/.github/workflows/migration-e2e.yml
+++ b/.github/workflows/migration-e2e.yml
@@ -74,6 +74,16 @@ jobs:
           SCENARIOS_JSON: build/migration-scenarios.json
           TIER: ${{ inputs.tier || 'all' }}
 
+      # migration-tier0 runs on a separate runner with a fresh checkout, so
+      # the enumerator output above must travel as an artifact — the job
+      # `matrix` output only carries the small tier-list JSON, not this file.
+      - name: upload migration scenarios enumeration
+        uses: actions/upload-artifact@v7
+        with:
+          name: migration-scenarios
+          path: build/migration-scenarios.json
+          retention-days: 1
+
   migration-tier0:
     name: migration-tier0 (${{ matrix.name }})
     needs: migration-setup
@@ -92,6 +102,12 @@ jobs:
         with:
           go-version-file: 'go.mod'
           cache: true
+
+      - name: download migration scenarios enumeration
+        uses: actions/download-artifact@v7
+        with:
+          name: migration-scenarios
+          path: build
 
       # The scenarios exec a real `cerberus migrate`. Building it here and
       # handing it over via CERBERUS_BIN keeps the build failure separate


### PR DESCRIPTION
Two small, related CI-infra fixes found while validating this exact PR.

## 1. migration-tier0 never received the enumerator's output

Every push-to-main run of `migration-e2e.yml` has failed since Harness Phase 1 (#1268) merged, unnoticed because that workflow deliberately has no `pull_request` trigger (push-to-main + nightly + manual dispatch only) — so this cross-job wiring bug was never exercised in CI before merge. Caught by investigating https://github.com/tsouza/cerberus/actions/runs/30175604534.

`migration-setup` and `migration-tier0` run on separate runners. `migration-setup` generates `build/migration-scenarios.json` and uses it successfully for its own coverage-ratchet and tier-matrix steps (same runner). `migration-tier0` does a fresh checkout on a different runner and expects that same file — it never existed there, since only the small tier-matrix JSON crosses via the job `outputs`. Fixed by uploading the file as an artifact at the end of `migration-setup` and downloading it at the start of `migration-tier0`, matching this repo's existing `actions/upload-artifact@v7` convention. **Verified live**, not just linted: manually triggered `workflow_dispatch` on this branch (run 30176257981) — `migration-setup` uploads the artifact, `migration-tier0` downloads it, all 7 Tier-0 scenarios pass.

## 2. Docker Hub login has been silently unauthenticated everywhere

Found investigating a `compatibility/promql-surface` flake on this PR's own CI (https://github.com/tsouza/cerberus/actions/runs/30176249670/job/89725551397 — `failed to start reference container: ... context deadline exceeded` pulling `prom/prometheus`).

Every "Log in to Docker Hub" step across `compatibility.yml` and `e2e.yml` checked `secrets.DOCKERHUB_TOKEN` / `secrets.DOCKERHUB_USERNAME` — neither secret exists. The actual configured secret is `DOCKER_HUB_PAT`, and the username is a public constant (`tsouza`), exactly as `release.yml` already has it correct. So the login step's guard has always been false, and every Docker-pulling CI job in this repo has been running fully unauthenticated against Docker Hub since the mitigation was added, hitting Docker Hub's anonymous per-IP rate limit shared across the whole GitHub Actions runner pool at the frequency several recent runs have shown. Fixed all 7 occurrences (5 in `compatibility.yml`, 2 in `e2e.yml`) to use the real secret name and the constant username.

🤖 Generated with [Claude Code](https://claude.com/claude-code)