### PR TITLE
test: close 14-layer audit gaps for #1275, #1272, #1270

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -333,9 +333,11 @@ wrapper, plus `appendStepSummary` / `setOutput` for the runner files.
 - **`chaos-run.mjs`** — `e2e.yml`, the `chaos` job (live-stack
   chaos-engineering lane, Layer 12). Fault-injects against the running
   k3d e2e stack (kubectl pod-kill / NetworkPolicy partition / slow-query
-  timeout / concurrency burst) and asserts the gateway's resilience
-  contracts (circuit breaker, per-query wall-clock timeout, admission
-  control, replica resilience) hold under real faults. Phase-1 scenarios
+  timeout / concurrency burst / a memory-cap-crossing query_range) and
+  asserts the gateway's resilience contracts (circuit breaker, per-query
+  wall-clock timeout, admission control, replica resilience,
+  failure-driven route-memo A->B activation) hold under real faults.
+  Phase-1 scenarios
   run sequentially with heal-between-each; metric corroboration is read
   back through cerberus's own Prom head (settle poll). After a
   CH-destructive scenario (which recreates CH empty on ephemeral storage),

--- a/.github/scripts/chaos-run.mjs
+++ b/.github/scripts/chaos-run.mjs
@@ -15,6 +15,15 @@
 //   #3 handler-panic envelope is covered DETERMINISTICALLY by Layer 10 unit
 //      chaos; the live lane only corroborates no lingering 5xx after the
 //      cumulative fault storm (a passive end-of-run health gate).
+//   #5 failure-driven route memo (internal/routememo, e01ed68d) — a route-A
+//      dispatch that hits ClickHouse's MEMORY_LIMIT_EXCEEDED (code 241) is
+//      retried once on route B; a successful retry both rescues the
+//      client's request (200 instead of the pinned 422) and moves
+//      cerberus_route_ab_success_total{cerberus_route_choice="b"}. Proves
+//      the mechanism actually fires against a real cerberus process + real
+//      ClickHouse, closing the "hollow green / inert feature" gap: no
+//      e2e/chaos/compose manifest had ever set
+//      CERBERUS_SOLVER_ROUTE_MEMO_ENABLED before this scenario.
 //
 // This is an INFORMATIONAL lane (the `chaos` job in e2e.yml; push-to-main +
 // nightly + manual ONLY, never a PR gate). Heavy + chaos flakes, so the
@@ -1102,6 +1111,144 @@ async function scenarioLoadAdmitSaturation() {
   return failures;
 }
 
+// ---- scenario: route-memo-activation ---------------------------------
+//
+// The failure-driven route memo (internal/routememo, wired via
+// CERBERUS_SOLVER_ROUTE_MEMO_ENABLED in cmd/cerberus/main.go, landed
+// e01ed68d) has never run end-to-end against a real cerberus process
+// fielding real ClickHouse traffic in any e2e/chaos/compose manifest
+// before this scenario — the classic "hollow green / inert feature"
+// gap (a mechanism that could pass every unit test while never firing in
+// production). CERBERUS_SOLVER_ROUTE_MEMO_ENABLED=true is set by the
+// chaos overlay (test/e2e/chaos/manifests/chaos-overlay.env) applied
+// before any scenario runs, so this is on for the whole lane.
+//
+// The fault: drive the SAME (24h range, 15s step) aggregating query_range
+// shape that iterate-time-ranges.spec.ts (Layer-9 dashboard sweep) already
+// pins as the documented CERBERUS_CH_QUERY_MAX_MEMORY-crossing tuple (run
+// 27277793810: 24h/15s demanded 2.12 GiB against the 1 GiB per-query cap
+// both the k3d chart values and compose set — see
+// test/e2e/k3s/cerberus-values.yaml / docker-compose.yml). 24h/15s is
+// 5,760 anchor points — comfortably under the 11,000-point Prometheus
+// resolution cap (internal/api/prom/handler.go maxResolutionPoints), so
+// the request reaches ClickHouse instead of 400-ing on the resolution
+// guard first. A route-A dispatch that trips ClickHouse's MEMORY_LIMIT_
+// EXCEEDED (code 241) classifies OutcomeResourceFailure
+// (internal/engine/route_outcome.go) — with the memo enabled, eligible,
+// fresh, and the (breaker-neutral, see internal/chclient/memlimit.go)
+// 241 not having tripped the shared breaker, two corroborating failures
+// on the same routememo.Key (internal/routememo/memo.go
+// minCorroboratingFailures=2) admit a probe dispatch to route B; a
+// successful probe drain both rescues the CLIENT's request (a 200
+// instead of the pinned 422) and records
+// cerberus_route_ab_success_total{cerberus_route_choice="b"}
+// (telemetry.RecordRouteABSuccess) — a real counter that can only move
+// if a real route-A resource failure was really rescued by a real
+// route-B dispatch.
+//
+// HONESTY NOTE (mirrors iterate-time-ranges.spec.ts's own "Memory-limit
+// dual contract" and scenarioChNetworkPartition's enforcement-probe
+// gate): whether a given run's data volume actually pushes this tuple
+// over the 1 GiB cap is environment-dependent — the spec's own header
+// documents this cannot be pinned per-tuple deterministically. If the
+// query stays under the cap for the whole polling budget (every attempt
+// 200s, the metric never had anything to prove), this scenario records
+// NOT-APPLICABLE rather than a vacuous pass, exactly like
+// ch-network-partition's not-applicable branch. If the cap IS crossed
+// (a 422 is observed) but cerberus_route_ab_success_total{route_choice=
+// "b"} never climbs within budget, that IS a real failure: the memo was
+// enabled, eligible, and had a genuine resource failure to rescue, and
+// didn't.
+const ROUTE_MEMO_RANGE_SECONDS = 24 * 3600; // matches the pinned 24h/15s memory-cap tuple (iterate-time-ranges.spec.ts, run 27277793810)
+const ROUTE_MEMO_STEP_SECONDS = 15; // => 5760 anchors, under the 11000-point resolution cap
+// liveEdgeFreshnessMarginSteps in internal/engine/route_memo_wiring.go is
+// 1 step; doubled here so a few seconds of clock skew between this script
+// and the cluster can never make a legitimately-old request look
+// live-edge-fresh and get declined with reason=not-fresh.
+const ROUTE_MEMO_LIVE_EDGE_MARGIN_STEPS = 2;
+// The exact aggregating panel expr already provisioned in
+// test/e2e/k3s/grafana-dashboards.yaml and already exercised at this
+// exact (24h, 15s) tuple by iterate-time-ranges.spec.ts — reusing a
+// proven production shape rather than inventing a new untested one.
+const ROUTE_MEMO_EXPR = 'sum by (cerberus_ql) (rate(cerberus_queries_total[5m]))';
+const ROUTE_MEMO_ACTIVATION_DEADLINE_MS = 120_000; // generous: needs >= minCorroboratingFailures(2) consecutive route-A resource failures on the same key before a probe is even admitted
+const ROUTE_MEMO_POLL_INTERVAL_MS = 5_000;
+const ROUTE_MEMO_FINAL_OK_DEADLINE_MS = 60_000; // post-activation: the same query must now cleanly 200 for a real client
+
+// routeMemoQueryPath builds the /api/v1/query_range path for the pinned
+// 24h/15s aggregating shape. `end` is anchored ROUTE_MEMO_LIVE_EDGE_
+// MARGIN_STEPS*step behind `now` so every request clears the route
+// memo's live-edge freshness gate (freshEnoughForRouteMemo).
+function routeMemoQueryPath() {
+  const now = Math.floor(Date.now() / 1000);
+  const end = now - ROUTE_MEMO_LIVE_EDGE_MARGIN_STEPS * ROUTE_MEMO_STEP_SECONDS;
+  const start = end - ROUTE_MEMO_RANGE_SECONDS;
+  return (
+    '/api/v1/query_range?query=' +
+    encodeURIComponent(ROUTE_MEMO_EXPR) +
+    `&start=${start}&end=${end}&step=${ROUTE_MEMO_STEP_SECONDS}`
+  );
+}
+
+async function scenarioRouteMemoActivation() {
+  const failures = [];
+
+  const baselineSuccessB = await queryBreakerMetric(
+    'cerberus_route_ab_success_total{cerberus_route_choice="b"}',
+  );
+  const path = routeMemoQueryPath();
+
+  log('  fault: driving the pinned 24h/15s memory-cap query_range shape to force a route-A resource failure...');
+  let lastStatus = null;
+  let sawMemoryLimit422 = false;
+  const activated = await pollUntil(
+    async () => {
+      const r = await httpGet(path, { timeoutMs: 30_000 });
+      lastStatus = r.status;
+      if (r.status === 422) {
+        sawMemoryLimit422 = true;
+        return false; // route A hit the cap; keep polling for the memo's A->B rescue
+      }
+      if (r.status !== 200) return false;
+      const successB = await queryBreakerMetric(
+        'cerberus_route_ab_success_total{cerberus_route_choice="b"}',
+      );
+      if (successB === null) return false;
+      if (baselineSuccessB !== null && successB <= baselineSuccessB) return false;
+      return true;
+    },
+    { deadlineMs: ROUTE_MEMO_ACTIVATION_DEADLINE_MS, intervalMs: ROUTE_MEMO_POLL_INTERVAL_MS, label: 'route-memo-activation' },
+  );
+
+  if (activated) {
+    log('    cerberus_route_ab_success_total{cerberus_route_choice="b"} climbed — a real route-A resource failure was rescued by a real route-B dispatch');
+  } else if (!sawMemoryLimit422) {
+    notice(
+      'route-memo-activation: the pinned 24h/15s query never crossed CERBERUS_CH_QUERY_MAX_MEMORY this run (data-volume-dependent, same dual contract iterate-time-ranges.spec.ts documents) — recording not-applicable; the memo had no resource failure to rescue.',
+    );
+    return failures;
+  } else {
+    failures.push(
+      `route-memo did not activate: last query status=${lastStatus}, a 422 memory-limit rejection WAS observed, but cerberus_route_ab_success_total{cerberus_route_choice="b"} never climbed within budget — the memo was enabled and had a genuine resource failure to rescue and did not`,
+    );
+  }
+
+  // Corroborate from the client's own seat: the SAME query, fired again,
+  // must now cleanly 200 (the mechanism rescues the REQUEST, not just an
+  // internal counter).
+  const finalOk = await pollUntil(
+    async () => (await httpGet(path, { timeoutMs: 30_000 })).status === 200,
+    { deadlineMs: ROUTE_MEMO_FINAL_OK_DEADLINE_MS, label: 'route-memo-query-200' },
+  );
+  if (!finalOk) {
+    failures.push('the route-memo-activation query did not return a clean 200 to a real HTTP client after the memo activated');
+  } else {
+    log('    query_range returned 200 to a real client — rescued by the route-memo A->B retry');
+  }
+
+  return failures;
+}
+
 // ---- passive end-of-run health gate (handler-panic corroboration) ----
 // Panic-envelope correctness is covered DETERMINISTICALLY by Layer 10 unit
 // chaos. Here we only corroborate the process recovered cleanly from the
@@ -1154,6 +1301,11 @@ async function endOfRunHealthGate() {
 // assertion then runs on a naturally-closed breaker (no prior outage), and each
 // destructive scenario re-establishes its own preconditions via the heal gate.
 const PHASE1 = [
+  // Non-destructive, data-dependent: failure-driven route-memo activation
+  // (see the scenario's own header comment for the full rationale). Runs
+  // first among the non-destructive set — it never touches the CH or
+  // cerberus pods, so it isn't affected by anything a later scenario does.
+  { name: 'route-memo-activation', run: scenarioRouteMemoActivation },
   // Non-destructive, data-dependent: the slow-query timeout contract. Runs on
   // the full rolling-seeded window so the heavy nested subquery reliably blows
   // the calibrated wall-clock cap.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1361,7 +1361,8 @@ jobs:
 
       # Phase-1 scenarios sequentially with heal-between-each, ordered
       # non-destructive-first / destructive-last (see orderScenarios in
-      # chaos-run.mjs): ch-slow/query-timeout (runs on the full rolling
+      # chaos-run.mjs): route-memo-activation (failure-driven route memo,
+      # e01ed68d), then ch-slow/query-timeout (runs on the full rolling
       # window so its heavy query reliably hits the wall-clock cap), then
       # the destructive pod-kills ch-pod-kill + cerberus-pod-kill. On the
       # nightly schedule + manual dispatch, run the full phase set — the

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -386,6 +386,21 @@ What it proves (the contracts, mapped to their landing PRs):
   — the live lane only corroborates that the process recovered cleanly
   from the cumulative fault storm (all 3 heads 200, no lingering 5xx) as
   a passive end-of-run health gate, not a dedicated scenario.
+- **Failure-driven route memo (e01ed68d).** `route-memo-activation` fires
+  the pinned 24h/15s aggregating `query_range` shape (the same
+  `CERBERUS_CH_QUERY_MAX_MEMORY`-crossing tuple `iterate-time-ranges.spec.ts`
+  already pins) with `CERBERUS_SOLVER_ROUTE_MEMO_ENABLED=true` (chaos
+  overlay). A route-A dispatch that trips ClickHouse's
+  `MEMORY_LIMIT_EXCEEDED` (code 241, breaker-neutral) is retried once on
+  route B; a successful retry both returns the client a 200 (instead of
+  the pinned 422) and moves
+  `cerberus_route_ab_success_total{cerberus_route_choice="b"}`. Closes the
+  gap the mechanism had never been run against a real cerberus process
+  fielding real ClickHouse traffic — no e2e/chaos/compose manifest had
+  ever set the env var before this scenario. Data-volume-dependent like
+  the dashboard sweep's own dual contract: if the tuple never crosses the
+  cap this run, the scenario records not-applicable rather than a
+  vacuous pass.
 
 Design notes (flake resistance): every recovery check polls to a
 **generous bounded deadline** (never asserts immediately after a fault);

--- a/internal/api/loki/absent_over_time_grid_test.go
+++ b/internal/api/loki/absent_over_time_grid_test.go
@@ -1,0 +1,108 @@
+package loki_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/logql"
+	"github.com/tsouza/cerberus/internal/optimizer"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/solver"
+)
+
+// PR #1272 (commit ddd4a2f5) fixed a bug where RangeWindowNative,
+// RangeWindowResample, and AbsentOverTime were missing from the old
+// grid-classification kind-switch: a plan whose ONLY grid carrier was one
+// of those node kinds silently reported a zero grid, indistinguishable
+// from a genuine instant query. internal/api/prom/native_range_grid_test.go
+// pins the fix end-to-end for PromQL. LogQL's absent_over_time lowers to
+// the very same chplan.AbsentOverTime node (see
+// internal/logql/range_aggregation.go's lowerAbsentOverTime), so it is
+// exposed to the identical bug shape — this test is the LogQL analog,
+// proving the invariant holds across the real LogQL lowering pipeline
+// too, not just PromQL's.
+const absentOverTimeGridPinStep = time.Minute
+
+func absentOverTimeGridPinWindow() (time.Time, time.Time) {
+	start := time.Date(2029, 7, 8, 9, 0, 0, 0, time.UTC)
+	return start, start.Add(5 * time.Minute)
+}
+
+// TestAbsentOverTimeRangeQuery_GridIsRequestGrid pins the invariant for
+// LogQL: an absent_over_time(...) range query — whose optimized plan's
+// only grid carrier is *chplan.AbsentOverTime — must report the
+// request's real (start, end, step) through solver.GridOf, not a zero
+// grid. A zero grid here would be read as "instant query" and the
+// range-query cost analysis / routing would never fire.
+func TestAbsentOverTimeRangeQuery_GridIsRequestGrid(t *testing.T) {
+	t.Parallel()
+
+	const q = `absent_over_time({job="x"}[5m])`
+	start, end := absentOverTimeGridPinWindow()
+	s := schema.DefaultOTelLogs()
+
+	l := &logql.Lang{Schema: s, Start: start, End: end, Step: absentOverTimeGridPinStep}
+	plan, meta, err := l.Parse(context.Background(), q)
+	if err != nil {
+		t.Fatalf("parse+lower %q: %v", q, err)
+	}
+	plan = l.ProjectSamples(plan, meta)
+	plan = optimizer.Default().Run(context.Background(), plan)
+
+	// Guard: confirm the optimized plan's only grid carrier is
+	// *chplan.AbsentOverTime, so this test actually exercises the bug
+	// shape rather than silently passing because the query fell back to
+	// some other grid-carrying node.
+	carriers := 0
+	chplan.Walk(plan, func(node chplan.Node) bool {
+		if _, ok := node.(chplan.GridCarrier); ok {
+			carriers++
+			if _, ok := node.(*chplan.AbsentOverTime); !ok {
+				t.Fatalf("unexpected grid carrier %T — expected only *chplan.AbsentOverTime", node)
+			}
+		}
+		return true
+	})
+	if carriers == 0 {
+		t.Fatal("plan carries no grid carrier node — this case would prove nothing about the fix")
+	}
+
+	gotStart, gotEnd, gotStep := solver.GridOf(plan)
+	if gotStep != absentOverTimeGridPinStep {
+		t.Errorf("absent_over_time range query reports step %s, want %s — a zero step is read as "+
+			"'instant query' and the plan is never cost-analyzed at all", gotStep, absentOverTimeGridPinStep)
+	}
+	if !gotStart.Equal(start) {
+		t.Errorf("absent_over_time range query reports start %s, want %s", gotStart, start)
+	}
+	if !gotEnd.Equal(end) {
+		t.Errorf("absent_over_time range query reports end %s, want %s", gotEnd, end)
+	}
+}
+
+// TestAbsentOverTimeInstantQuery_StillReportsNoGrid pins the converse:
+// an instant absent_over_time query must keep reporting a zero grid, so
+// the instant/range classification isn't accidentally widened to treat
+// every absent_over_time query as a range query.
+func TestAbsentOverTimeInstantQuery_StillReportsNoGrid(t *testing.T) {
+	t.Parallel()
+
+	const q = `absent_over_time({job="x"}[5m])`
+	_, evalAt := absentOverTimeGridPinWindow()
+	s := schema.DefaultOTelLogs()
+
+	l := &logql.Lang{Schema: s, Start: evalAt, End: evalAt}
+	plan, meta, err := l.Parse(context.Background(), q)
+	if err != nil {
+		t.Fatalf("parse+lower %q: %v", q, err)
+	}
+	plan = l.ProjectSamples(plan, meta)
+	plan = optimizer.Default().Run(context.Background(), plan)
+
+	if _, _, step := solver.GridOf(plan); step != 0 {
+		t.Errorf("instant absent_over_time query reports step %s, want 0 — the instant classification "+
+			"would stop firing", step)
+	}
+}

--- a/internal/promql/lower_bench_test.go
+++ b/internal/promql/lower_bench_test.go
@@ -3,11 +3,23 @@ package promql_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/prometheus/prometheus/promql/parser"
 
 	"github.com/tsouza/cerberus/internal/promql"
 	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// metadataCatalogWindowStart/End is the fixed [start,end] metadata-catalog
+// window the two label-catalog benchmarks below lower against. Any fixed
+// window works — the catalog lowering resolves the requested column at the
+// scan regardless of the range — so a short, deterministic one keeps the
+// benchmark's SQL literals (and therefore its allocation profile) stable
+// across runs.
+var (
+	metadataCatalogWindowStart = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	metadataCatalogWindowEnd   = metadataCatalogWindowStart.Add(5 * time.Minute)
 )
 
 // PromQL micro-benchmarks (Layer 12 perf gate). Each Benchmark
@@ -92,6 +104,41 @@ func BenchmarkLower_Subquery(b *testing.B) {
 			b.Fatalf("Lower: %v", err)
 		}
 	}
+}
+
+// BenchmarkLower_MetadataCatalog covers the /api/v1/label/<name>/values and
+// /api/v1/labels lowering paths (PR #1270): the requested column is
+// resolved at the scan leaf instead of above a per-row attribute-map
+// rebuild, so the cost here should track O(plan nodes), not the
+// O(rows × attributes) shape a generic Sample projection would force.
+// Neither sub-benchmark existed before this change was made — a future
+// regression that reintroduces a merged-map rebuild above the catalog
+// projection should show up here as an allocs/op jump.
+func BenchmarkLower_MetadataCatalog(b *testing.B) {
+	expr := parsePromQL(b, `requests_total{job="api"}`)
+	s := schema.DefaultOTelMetrics()
+
+	b.Run("label_values", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			if _, err := promql.LowerMetadataLabelValues(
+				context.Background(), expr, s, metadataCatalogWindowStart, metadataCatalogWindowEnd, "region",
+			); err != nil {
+				b.Fatalf("LowerMetadataLabelValues: %v", err)
+			}
+		}
+	})
+
+	b.Run("label_names", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			if _, err := promql.LowerMetadataLabelNames(
+				context.Background(), expr, s, metadataCatalogWindowStart, metadataCatalogWindowEnd,
+			); err != nil {
+				b.Fatalf("LowerMetadataLabelNames: %v", err)
+			}
+		}
+	})
 }
 
 // TestAllocs_Lower pins the per-query alloc count for each

--- a/internal/promql/metadata_catalog_test.go
+++ b/internal/promql/metadata_catalog_test.go
@@ -1,0 +1,263 @@
+package promql
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestSanitizedResourceKeyPairs pins the plan-time lookup table
+// [sanitizeResourceKeysExpr] builds from: a zero-configured allowlist
+// yields empty tables (the caller falls back to the per-row regex, see
+// [TestSanitizeResourceKeysExpr_FallsBackToRegexWhenUnconfigured]), a
+// configured allowlist is deduped and sorted for a deterministic emit, and
+// every key is paired with its sanitized (dot -> underscore) spelling.
+func TestSanitizedResourceKeyPairs(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name          string
+		allow         []string
+		wantKeys      []string
+		wantSanitized []string
+	}{
+		{
+			name:          "zero_configured_keys_returns_empty_tables",
+			allow:         nil,
+			wantKeys:      []string{},
+			wantSanitized: []string{},
+		},
+		{
+			name:          "sorts_and_sanitizes_configured_keys",
+			allow:         []string{"k8s.namespace.name", "deployment.environment.name"},
+			wantKeys:      []string{"deployment.environment.name", "k8s.namespace.name"},
+			wantSanitized: []string{"deployment_environment_name", "k8s_namespace_name"},
+		},
+		{
+			name:          "dedupes_repeated_keys",
+			allow:         []string{"a.b", "a.b", "a.b"},
+			wantKeys:      []string{"a.b"},
+			wantSanitized: []string{"a_b"},
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			s := schema.DefaultOTelMetrics()
+			s.PromResourceLabels = tc.allow
+			gotKeys, gotSanitized := sanitizedResourceKeyPairs(s)
+			if len(gotKeys) != len(tc.wantKeys) {
+				t.Fatalf("keys = %v, want %v", gotKeys, tc.wantKeys)
+			}
+			for i := range gotKeys {
+				if gotKeys[i] != tc.wantKeys[i] {
+					t.Errorf("keys[%d] = %q, want %q (full: %v)", i, gotKeys[i], tc.wantKeys[i], gotKeys)
+				}
+			}
+			if len(gotSanitized) != len(tc.wantSanitized) {
+				t.Fatalf("sanitized = %v, want %v", gotSanitized, tc.wantSanitized)
+			}
+			for i := range gotSanitized {
+				if gotSanitized[i] != tc.wantSanitized[i] {
+					t.Errorf("sanitized[%d] = %q, want %q (full: %v)", i, gotSanitized[i], tc.wantSanitized[i], gotSanitized)
+				}
+			}
+		})
+	}
+}
+
+// TestSanitizeResourceKeysExpr_FallsBackToRegexWhenUnconfigured pins the
+// branch [sanitizeResourceKeysExpr] takes when no allowlist is configured:
+// the key set is open, so the ONLY correct rewrite is the per-row
+// `replaceRegexpAll` mirror of [format.OTelToPromLabel], never the
+// constant `transform()` lookup table a closed allowlist would let it
+// emit instead. Regressing this branch would either silently switch every
+// default-schema deployment (no CERBERUS_PROM_RESOURCE_LABELS set) onto an
+// incomplete lookup table, or vice versa.
+func TestSanitizeResourceKeysExpr_FallsBackToRegexWhenUnconfigured(t *testing.T) {
+	t.Parallel()
+
+	arrayMapLambdaBody := func(t *testing.T, expr chplan.Expr) *chplan.FuncCall {
+		t.Helper()
+		outer, ok := expr.(*chplan.FuncCall)
+		if !ok || outer.Name != "mapFromArrays" || len(outer.Args) != 2 {
+			t.Fatalf("got %#v, want mapFromArrays(...)", expr)
+		}
+		arrayMap, ok := outer.Args[0].(*chplan.FuncCall)
+		if !ok || arrayMap.Name != "arrayMap" || len(arrayMap.Args) != 2 {
+			t.Fatalf("mapFromArrays arg0 = %#v, want arrayMap(...)", outer.Args[0])
+		}
+		lambda, ok := arrayMap.Args[0].(*chplan.Lambda)
+		if !ok {
+			t.Fatalf("arrayMap arg0 = %#v, want *chplan.Lambda", arrayMap.Args[0])
+		}
+		body, ok := lambda.Body.(*chplan.FuncCall)
+		if !ok {
+			t.Fatalf("lambda body = %#v, want *chplan.FuncCall", lambda.Body)
+		}
+		return body
+	}
+
+	// Zero-configured allowlist: the key set is open, so the rewrite MUST
+	// be the per-row regex, not the lookup table.
+	sOpen := schema.DefaultOTelMetrics()
+	openBody := arrayMapLambdaBody(t, sanitizeResourceKeysExpr(sOpen))
+	if openBody.Name != "replaceRegexpAll" {
+		t.Errorf("zero-configured-key rewrite = %q, want %q (regex fallback)", openBody.Name, "replaceRegexpAll")
+	}
+
+	// A configured allowlist closes the key set: the rewrite becomes the
+	// constant transform() lookup table instead.
+	sClosed := schema.DefaultOTelMetrics()
+	sClosed.PromResourceLabels = []string{"k8s.namespace.name"}
+	closedBody := arrayMapLambdaBody(t, sanitizeResourceKeysExpr(sClosed))
+	if closedBody.Name != "transform" {
+		t.Errorf("configured-allowlist rewrite = %q, want %q (lookup table)", closedBody.Name, "transform")
+	}
+}
+
+// TestConfiguredResourceKeysFor pins [configuredResourceKeysFor]'s
+// inversion of the sanitisation rewrite over the CONFIGURED (closed)
+// resource-label allowlist: the zero-configured-allowlist fallback (no
+// closed set to invert), several colliding keys that reach the same
+// sanitized Prom label through separators the dot/underscore candidate
+// chain never rewrites (so [attributeLookup] alone would silently miss
+// them), and the dedicated-column exclusion that must win even when a
+// configured key would otherwise collide onto an excluded label.
+func TestConfiguredResourceKeysFor(t *testing.T) {
+	t.Parallel()
+
+	t.Run("zero_configured_allowlist_returns_nil", func(t *testing.T) {
+		t.Parallel()
+		s := schema.DefaultOTelMetrics()
+		s.PromResourceLabels = nil
+		if got := configuredResourceKeysFor(s, "k8s_namespace_name"); got != nil {
+			t.Errorf("got %v, want nil (no closed key set to invert)", got)
+		}
+	})
+
+	t.Run("no_resource_attributes_column_returns_nil", func(t *testing.T) {
+		t.Parallel()
+		s := schema.DefaultOTelMetrics()
+		s.PromResourceLabels = []string{"k8s.namespace.name"}
+		s.ResourceAttributesColumn = ""
+		if got := configuredResourceKeysFor(s, "k8s_namespace_name"); got != nil {
+			t.Errorf("got %v, want nil (resource arm disabled)", got)
+		}
+	})
+
+	// Three keys that all sanitize to `k8s_namespace_name` via DIFFERENT
+	// separators (hyphen, colon, space) that [attributeLookupKeys]'s
+	// dot<->underscore candidate chain never produces from the label
+	// itself — each is reachable ONLY through this inversion. The
+	// allowlist's own order decides which arm a downstream coalesce tries
+	// first on a genuine collision, so the result must preserve it exactly.
+	t.Run("colliding_keys_preserve_allowlist_order", func(t *testing.T) {
+		t.Parallel()
+		s := schema.DefaultOTelMetrics()
+		s.PromResourceLabels = []string{
+			"k8s-namespace-name",
+			"k8s:namespace:name",
+			"k8s namespace name",
+		}
+		want := []string{"k8s-namespace-name", "k8s:namespace:name", "k8s namespace name"}
+		got := configuredResourceKeysFor(s, "k8s_namespace_name")
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("got %v, want %v (allowlist order preserved)", got, want)
+		}
+	})
+
+	// A key reachable via the ordinary dot/underscore candidate chain is
+	// skipped — it would only duplicate the arm [attributeLookup] already
+	// emits, not a genuinely unreachable collision.
+	t.Run("dot_reachable_key_is_skipped_as_already_covered", func(t *testing.T) {
+		t.Parallel()
+		s := schema.DefaultOTelMetrics()
+		s.PromResourceLabels = []string{"k8s.namespace.name"}
+		if got := configuredResourceKeysFor(s, "k8s_namespace_name"); len(got) != 0 {
+			t.Errorf("got %v, want empty (dot form already reached by the candidate chain)", got)
+		}
+	})
+
+	// A dedicated-column-backed key (service.name -> ServiceName) must
+	// never be surfaced here even when allowlisted: the dedicated path
+	// already owns it, and letting it through would double-promote the
+	// key exactly the way [DedicatedResourceLabelExcluded] exists to
+	// prevent.
+	t.Run("dedicated_column_key_never_promoted", func(t *testing.T) {
+		t.Parallel()
+		s := schema.DefaultOTelMetrics() // ServiceNameColumn is set.
+		s.PromResourceLabels = []string{"service.name"}
+		if got := configuredResourceKeysFor(s, "service_name"); len(got) != 0 {
+			t.Errorf("got %v, want empty (service.name is dedicated-column-backed)", got)
+		}
+	})
+}
+
+// TestDedicatedLabelColumns pins the configured-columns list a catalog
+// Project must additionally carry alongside Attributes: empty when the
+// schema has no dedicated top-level label column, and the ServiceName
+// column when the schema configures one.
+func TestDedicatedLabelColumns(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no_dedicated_columns_configured", func(t *testing.T) {
+		t.Parallel()
+		s := schema.DefaultOTelMetrics()
+		s.ServiceNameColumn = ""
+		if got := dedicatedLabelColumns(s); len(got) != 0 {
+			t.Errorf("got %v, want empty", got)
+		}
+	})
+
+	t.Run("service_name_column_configured", func(t *testing.T) {
+		t.Parallel()
+		s := schema.DefaultOTelMetrics()
+		want := []string{s.ServiceNameColumn}
+		if got := dedicatedLabelColumns(s); !reflect.DeepEqual(got, want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+}
+
+// TestCatalogLabelValuesExpr pins [catalogLabelValuesExpr]'s two
+// resolution paths: `__name__` reads the dedicated MetricName column
+// directly (BYPASSING [rawLabelValueExpr] entirely, since MetricName is
+// not attribute-map-backed), while every other label MUST resolve
+// identically to [rawLabelValueExpr] — the matcher path's own
+// resolution — because the doc contract on both functions requires
+// listing and matching to agree by construction: any divergence would
+// let /label/<name>/values advertise a value no selector on that label
+// can actually match, or vice versa.
+func TestCatalogLabelValuesExpr(t *testing.T) {
+	t.Parallel()
+	s := schema.DefaultOTelMetrics()
+
+	t.Run("metric_name_reads_dedicated_column", func(t *testing.T) {
+		t.Parallel()
+		got, ok := catalogLabelValuesExpr(s, "__name__").(*chplan.ColumnRef)
+		if !ok || got.Name != s.MetricNameColumn {
+			t.Errorf("got %#v, want ColumnRef{Name: %q}", catalogLabelValuesExpr(s, "__name__"), s.MetricNameColumn)
+		}
+	})
+
+	t.Run("dedicated_column_label_matches_matcher_resolution", func(t *testing.T) {
+		t.Parallel()
+		got := catalogLabelValuesExpr(s, "service_name")
+		want := rawLabelValueExpr(s, "service_name")
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("catalogLabelValuesExpr(service_name) = %#v,\nwant rawLabelValueExpr(service_name) = %#v", got, want)
+		}
+	})
+
+	t.Run("generic_label_matches_matcher_resolution", func(t *testing.T) {
+		t.Parallel()
+		got := catalogLabelValuesExpr(s, "k8s_namespace_name")
+		want := rawLabelValueExpr(s, "k8s_namespace_name")
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("catalogLabelValuesExpr(k8s_namespace_name) = %#v,\nwant rawLabelValueExpr(k8s_namespace_name) = %#v", got, want)
+		}
+	})
+}

--- a/test/consumer-corpus/grafana-12.2.9/drilldown-label-values-service-name.json
+++ b/test/consumer-corpus/grafana-12.2.9/drilldown-label-values-service-name.json
@@ -1,0 +1,37 @@
+{
+  "name": "drilldown-label-values-service-name",
+  "datasource": "prom",
+  "consumer": "Grafana 12.2.9 Metrics Drilldown (grafana-metricsdrilldown-app) — /api/v1/label/<name>/values against a resource-attribute-sourced, dedicated-column label",
+  "provenance": [
+    "Same group-by value discovery flow as drilldown-label-values-match, but targeting `service_name` —",
+    "the one Prom label the OTel-CH default schema hoists out of the Attributes map into a dedicated",
+    "top-level column (schema.Metrics.ServiceNameColumn), and the one label PromQL resolves under BOTH",
+    "the underscored (`service_name`) and OTel-canonical dotted (`service.name`) spelling. The existing",
+    "label-values/labels entries only exercise a plain Attributes-map label (cerberus_ql); none pin the",
+    "dedicated-column / resource-attribute resolution path PR #1270 rewrote to answer at the scan",
+    "(dedicatedLabelColumns / schemaTopLevelColumn in internal/promql/metadata_catalog.go +",
+    "internal/promql/resource_attributes.go) instead of rebuilding a merged per-series label map above it.",
+    "Shape reconstructed from internal/promql/schema_lookup_test.go and internal/api/prom/handler_chdb_label_values_test.go."
+  ],
+  "grafana_request": {
+    "path": "GET /api/datasources/uid/cerberus-prom/resources/api/v1/label/service_name/values",
+    "query": { "match[]": "{__name__=~\".*cerberus_query_inflight.*\"}" }
+  },
+  "request": {
+    "method": "GET",
+    "path": "/api/v1/label/service_name/values",
+    "query": {
+      "match[]": "{__name__=~\".*cerberus_query_inflight.*\"}",
+      "start": "${START_UNIX}",
+      "end": "${END_UNIX}"
+    },
+    "headers": {}
+  },
+  "stub": "prom-label-values-service-name",
+  "expect": {
+    "status": 200,
+    "decode": "prom-strings",
+    "wire": ["strings-contains:cerberus-api"],
+    "data": ["strings-contains:cerberus-loki", "strings-contains:cerberus-tempo"]
+  }
+}

--- a/test/consumer-corpus/grafana-12.2.9/query-range-route-memo-retry.json
+++ b/test/consumer-corpus/grafana-12.2.9/query-range-route-memo-retry.json
@@ -14,7 +14,7 @@
         {
           "refId": "A",
           "datasource": { "type": "prometheus", "uid": "cerberus-prom" },
-          "expr": "rate(up[5m])",
+          "expr": "rate(cerberus_query_inflight[5m])",
           "instant": false,
           "range": true
         }
@@ -25,7 +25,7 @@
     "method": "GET",
     "path": "/api/v1/query_range",
     "query": {
-      "query": "rate(up[5m])",
+      "query": "rate(cerberus_query_inflight[5m])",
       "start": "1781002800",
       "end": "1781003400",
       "step": "15"

--- a/test/consumer-corpus/grafana-12.2.9/query-range-route-memo-retry.json
+++ b/test/consumer-corpus/grafana-12.2.9/query-range-route-memo-retry.json
@@ -1,0 +1,41 @@
+{
+  "name": "query-range-route-memo-retry",
+  "datasource": "prom",
+  "consumer": "Grafana 12.2.9 Prometheus datasource (grafana-prometheus, pkg/promlib) — a standard /api/v1/query_range panel request",
+  "provenance": [
+    "The generic Prometheus datasource query_range wire shape (pkg/promlib backend.QueryDataRequest -> GET /api/v1/query_range?query=&start=&end=&step=), the request every Grafana time-series panel sends against a Prometheus-compatible datasource.",
+    "Added to close a consumer-corpus coverage gap, not mined from a live incident: query_range is the ONLY request shape that flows through engine.Engine.QueryCursor / QueryPlanCursor, the streaming execution path the failure-driven route memo (internal/routememo, Engine.retryOnRouteAResourceFailure) hooks into. No prior corpus entry exercised this HTTP surface at all, so a route-A-to-route-B retry could silently break the consumer-decode contract (wrong envelope shape, dropped labels, wrong resultType) without any corpus test ever catching it.",
+    "start/end/step are chosen to reproduce internal/api/prom/handler_route_memo_test.go's routeMemoQuery fixture exactly (10-minute window, 15s step -> N=41 grid anchors), which that test proves clamps solver.Eligible() to the structural minimum K=2 shard fan-out through the real parse->lower->optimize pipeline — so this entry's route-memo eligibility is provable, not coincidental."
+  ],
+  "grafana_request": {
+    "path": "POST /api/ds/query",
+    "body": {
+      "queries": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "cerberus-prom" },
+          "expr": "rate(up[5m])",
+          "instant": false,
+          "range": true
+        }
+      ]
+    }
+  },
+  "request": {
+    "method": "GET",
+    "path": "/api/v1/query_range",
+    "query": {
+      "query": "rate(up[5m])",
+      "start": "1781002800",
+      "end": "1781003400",
+      "step": "15"
+    },
+    "headers": {}
+  },
+  "stub": "prom-query-range-route-memo-window",
+  "expect": {
+    "status": 200,
+    "decode": "prom-envelope",
+    "wire": ["resulttype:matrix", "result-min:1", "every-series-metric-label:cerberus_ql"]
+  }
+}

--- a/test/consumer-corpus/ratchet_test.go
+++ b/test/consumer-corpus/ratchet_test.go
@@ -8,10 +8,10 @@ import "testing"
 // forbid. The corpus is the project's record of what Grafana actually
 // sends — shrinking it silently un-pins a consumer contract.
 const (
-	minTotalEntries = 18
+	minTotalEntries = 19
 	minTempoEntries = 9
 	minLokiEntries  = 4
-	minPromEntries  = 5
+	minPromEntries  = 6
 )
 
 // TestConsumerCorpus_Ratchet pins the corpus census and the per-entry

--- a/test/consumer-corpus/ratchet_test.go
+++ b/test/consumer-corpus/ratchet_test.go
@@ -8,10 +8,10 @@ import "testing"
 // forbid. The corpus is the project's record of what Grafana actually
 // sends — shrinking it silently un-pins a consumer contract.
 const (
-	minTotalEntries = 18
+	minTotalEntries = 20
 	minTempoEntries = 9
 	minLokiEntries  = 4
-	minPromEntries  = 5
+	minPromEntries  = 6
 )
 
 // TestConsumerCorpus_Ratchet pins the corpus census and the per-entry

--- a/test/consumer-corpus/replay_chdb_test.go
+++ b/test/consumer-corpus/replay_chdb_test.go
@@ -114,6 +114,14 @@ var chdbLogsAnchor = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 // and the request-time-anchored matcher paths. All three metric tables
 // are created — the metadata handler and the bare-histogram matcher
 // fan-out read every table regardless of which carry rows.
+//
+// otel_metrics_sum also carries a dedicated ServiceName column (one
+// value per cerberus_query_inflight row) so a label-values catalog
+// request against a schema-top-level-column label (service_name /
+// service.name → schema.Metrics.ServiceNameColumn, resolved by
+// internal/promql.schemaTopLevelColumn / dedicatedLabelColumns) reads a
+// real dedicated column instead of only the Attributes map — see
+// drilldown-label-values-service-name.json.
 func metricsChDBSeed(now time.Time) string {
 	ts := now.Add(-2 * time.Minute).UTC().Format("2006-01-02 15:04:05.000")
 	return `CREATE TABLE otel_metrics_gauge (
@@ -131,7 +139,8 @@ CREATE TABLE otel_metrics_sum (
     Attributes Map(String, String),
     TimeUnix DateTime64(9),
     Value Float64,
-    IsMonotonic Bool DEFAULT false
+    IsMonotonic Bool DEFAULT false,
+    ServiceName String DEFAULT ''
 ) ENGINE = MergeTree() ORDER BY (MetricName, TimeUnix);
 CREATE TABLE otel_metrics_histogram (
     MetricName String,
@@ -146,10 +155,10 @@ CREATE TABLE otel_metrics_histogram (
 ) ENGINE = MergeTree() ORDER BY (MetricName, TimeUnix);
 INSERT INTO otel_metrics_gauge (MetricName, MetricDescription, MetricUnit, Attributes, TimeUnix, Value) VALUES
     ('up', '', '', map('job', 'api'), toDateTime64('` + ts + `', 9), 1.0);
-INSERT INTO otel_metrics_sum (MetricName, MetricDescription, MetricUnit, Attributes, TimeUnix, Value) VALUES
-    ('cerberus_query_inflight', 'in-flight queries', '', map('cerberus_ql', 'promql'),  toDateTime64('` + ts + `', 9), 2.0),
-    ('cerberus_query_inflight', 'in-flight queries', '', map('cerberus_ql', 'logql'),   toDateTime64('` + ts + `', 9), 1.0),
-    ('cerberus_query_inflight', 'in-flight queries', '', map('cerberus_ql', 'traceql'), toDateTime64('` + ts + `', 9), 0.0);`
+INSERT INTO otel_metrics_sum (MetricName, MetricDescription, MetricUnit, Attributes, TimeUnix, Value, ServiceName) VALUES
+    ('cerberus_query_inflight', 'in-flight queries', '', map('cerberus_ql', 'promql'),  toDateTime64('` + ts + `', 9), 2.0, 'cerberus-api'),
+    ('cerberus_query_inflight', 'in-flight queries', '', map('cerberus_ql', 'logql'),   toDateTime64('` + ts + `', 9), 1.0, 'cerberus-loki'),
+    ('cerberus_query_inflight', 'in-flight queries', '', map('cerberus_ql', 'traceql'), toDateTime64('` + ts + `', 9), 0.0, 'cerberus-tempo');`
 }
 
 // chdbTokens mirrors StubTokens for the chdb lane's seed anchors.

--- a/test/consumer-corpus/replay_chdb_test.go
+++ b/test/consumer-corpus/replay_chdb_test.go
@@ -124,6 +124,20 @@ var chdbLogsAnchor = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 // drilldown-label-values-service-name.json.
 func metricsChDBSeed(now time.Time) string {
 	ts := now.Add(-2 * time.Minute).UTC().Format("2006-01-02 15:04:05.000")
+	// routeMemoRetryTS1 / routeMemoRetryTS2 sit inside
+	// grafana-12.2.9/query-range-route-memo-retry.json's fixed
+	// request.query.start=1781002800 / end=1781003400 window (2026-06-09
+	// 11:00:00Z .. 11:10:00Z UTC) — that window is a literal, not a
+	// ${START_UNIX} token, because internal/consumer-corpus's dedicated
+	// route_memo_replay_test.go reproduces the SAME literal to pin a specific
+	// solver grid-anchor count (N=41 at a 15s step), so these rows can't
+	// ride the shared near-`now` anchor every other seeded row uses.
+	// rate()'s 5-minute lookback needs two samples inside one anchor's
+	// window to compute a delta at all, so the pair sits 180s apart —
+	// comfortably under 300s — landing both inside the same lookback for
+	// several grid anchors around the window's midpoint.
+	routeMemoRetryTS1 := time.Unix(1781002800+60, 0).UTC().Format("2006-01-02 15:04:05.000")
+	routeMemoRetryTS2 := time.Unix(1781002800+240, 0).UTC().Format("2006-01-02 15:04:05.000")
 	return `CREATE TABLE otel_metrics_gauge (
     MetricName String,
     MetricDescription String,
@@ -158,7 +172,9 @@ INSERT INTO otel_metrics_gauge (MetricName, MetricDescription, MetricUnit, Attri
 INSERT INTO otel_metrics_sum (MetricName, MetricDescription, MetricUnit, Attributes, TimeUnix, Value, ServiceName) VALUES
     ('cerberus_query_inflight', 'in-flight queries', '', map('cerberus_ql', 'promql'),  toDateTime64('` + ts + `', 9), 2.0, 'cerberus-api'),
     ('cerberus_query_inflight', 'in-flight queries', '', map('cerberus_ql', 'logql'),   toDateTime64('` + ts + `', 9), 1.0, 'cerberus-loki'),
-    ('cerberus_query_inflight', 'in-flight queries', '', map('cerberus_ql', 'traceql'), toDateTime64('` + ts + `', 9), 0.0, 'cerberus-tempo');`
+    ('cerberus_query_inflight', 'in-flight queries', '', map('cerberus_ql', 'traceql'), toDateTime64('` + ts + `', 9), 0.0, 'cerberus-tempo'),
+    ('cerberus_query_inflight', 'in-flight queries', '', map('cerberus_ql', 'promql'),  toDateTime64('` + routeMemoRetryTS1 + `', 9), 2.0, 'cerberus-api'),
+    ('cerberus_query_inflight', 'in-flight queries', '', map('cerberus_ql', 'promql'),  toDateTime64('` + routeMemoRetryTS2 + `', 9), 5.0, 'cerberus-api');`
 }
 
 // chdbTokens mirrors StubTokens for the chdb lane's seed anchors.

--- a/test/consumer-corpus/route_memo_replay_test.go
+++ b/test/consumer-corpus/route_memo_replay_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -105,13 +106,17 @@ func (q *routeMemoRetryQuerierA) QueryCursor(context.Context, string, ...any) (c
 // wired as the Solver's Executor.Client — a structurally separate data
 // plane from route A, so counting its opens unambiguously proves the
 // retry dispatched route B rather than a silent route-A success.
+// opens is atomic because Executor.Execute fans the K shards out onto
+// concurrent goroutines (errgroup), each calling QueryCursor on this
+// SAME shared querier -- a plain int here is a real, race-detector-
+// confirmed data race, not just a theoretical one.
 type routeMemoRetryQuerierB struct {
-	opens int
+	opens atomic.Int64
 	rows  []chclient.Sample
 }
 
 func (q *routeMemoRetryQuerierB) QueryCursor(context.Context, string, ...any) (chclient.Cursor, error) {
-	q.opens++
+	q.opens.Add(1)
 	return &sliceCursor{samples: q.rows}, nil
 }
 
@@ -199,8 +204,8 @@ func TestConsumerCorpus_RouteMemoRetry_PreservesConsumerDecodeContract(t *testin
 	if primeResp.StatusCode != http.StatusUnprocessableEntity {
 		t.Fatalf("priming response status = %d, want %d (plain memory-limit rejection, no retry yet)", primeResp.StatusCode, http.StatusUnprocessableEntity)
 	}
-	if routeB.opens != 0 {
-		t.Fatalf("route-B opens after priming request = %d, want 0 — retry must not have fired yet", routeB.opens)
+	if got := routeB.opens.Load(); got != 0 {
+		t.Fatalf("route-B opens after priming request = %d, want 0 — retry must not have fired yet", got)
 	}
 
 	// Second request, identical query/grid (same routememo.Key):
@@ -210,8 +215,8 @@ func TestConsumerCorpus_RouteMemoRetry_PreservesConsumerDecodeContract(t *testin
 	for _, replayErr := range Replay(srv.Client(), srv.URL, *entry, nil, false) {
 		t.Errorf("%v", replayErr)
 	}
-	if routeB.opens != routeMemoRetryK {
-		t.Errorf("route-B shard opens on the retry request = %d, want %d (Executor.Execute fanned into K=%d shards)", routeB.opens, routeMemoRetryK, routeMemoRetryK)
+	if got := routeB.opens.Load(); got != routeMemoRetryK {
+		t.Errorf("route-B shard opens on the retry request = %d, want %d (Executor.Execute fanned into K=%d shards)", got, routeMemoRetryK, routeMemoRetryK)
 	}
 	if routeA.opens != 2 {
 		t.Errorf("route-A opens across both requests = %d, want 2 (one per request; the retry dispatches route B, it does not re-attempt route A)", routeA.opens)

--- a/test/consumer-corpus/route_memo_replay_test.go
+++ b/test/consumer-corpus/route_memo_replay_test.go
@@ -1,0 +1,225 @@
+package consumercorpus
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/api/prom"
+	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/routememo"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/solver"
+)
+
+// routeMemoRetryEntryName names the corpus entry
+// (grafana-12.2.9/query-range-route-memo-retry.json) this file drives
+// through a real failure-driven route-memo A->B retry. See that file's
+// provenance for why it exists: query_range is the only request shape
+// that reaches engine.Engine.QueryCursor / QueryPlanCursor, the
+// streaming path internal/engine/route_memo_wiring.go hooks into, and
+// no other corpus entry exercises that HTTP surface at all.
+const routeMemoRetryEntryName = "query-range-route-memo-retry"
+
+// routeMemoRetryMinFanout is an impossibly high solver.Config.MinFanout
+// so the top-level classify() call never routes this fixture on its
+// own merits — only the failure-driven retry's independent
+// solver.Eligible() re-derivation may dispatch route B. Mirrors
+// internal/api/prom/handler_route_memo_test.go's routeMemoImpossibleMinFanout.
+const routeMemoRetryMinFanout = 1_000_000
+
+// routeMemoRetryValue is the sentinel value route B's healthy fake
+// returns — distinct from anything route A ever produces (route A's
+// fake never yields a successful sample in this file), so finding it
+// in the decoded response proves the retry's data reached the
+// consumer, not a silent route-A success.
+const routeMemoRetryValue = 77.0
+
+// routeMemoRetryWindowStartUnix / routeMemoRetryWindowEndUnix mirror
+// grafana-12.2.9/query-range-route-memo-retry.json's fixed
+// request.query.start / end literals exactly — they must stay in
+// lock-step with that file (matrixFromCursor drops any sample outside
+// [start, end], so route B's canned row below has to land inside this
+// window to survive the response pivot).
+const (
+	routeMemoRetryWindowStartUnix = 1781002800
+	routeMemoRetryWindowEndUnix   = 1781003400
+)
+
+// routeMemoRetryEmitter always succeeds with fixed, valid SQL — the
+// shard SQL text is irrelevant to every fake querier below, which
+// ignores it entirely and answers from canned state.
+type routeMemoRetryEmitter struct{}
+
+func (routeMemoRetryEmitter) Emit(context.Context, chplan.Node) (string, []any, error) {
+	return "SELECT 1", nil, nil
+}
+
+// routeMemoRetryCursor yields its canned samples, then terminates —
+// cleanly if err is nil, with err as the terminal drain error
+// otherwise. Route A's fake below carries no samples, so it fails
+// immediately on the first Next(), mirroring a ClickHouse memory-limit
+// abort before any row streamed.
+type routeMemoRetryCursor struct {
+	samples []chclient.Sample
+	idx     int
+	cur     chclient.Sample
+	err     error
+}
+
+func (c *routeMemoRetryCursor) Next() bool {
+	if c.idx >= len(c.samples) {
+		return false
+	}
+	c.cur = c.samples[c.idx]
+	c.idx++
+	return true
+}
+
+func (c *routeMemoRetryCursor) Sample() chclient.Sample { return c.cur }
+func (c *routeMemoRetryCursor) Err() error              { return c.err }
+func (c *routeMemoRetryCursor) Close() error            { return nil }
+func (c *routeMemoRetryCursor) Inspected() int64        { return int64(c.idx) }
+
+// routeMemoRetryQuerierA is route A's backend: every QueryCursor call
+// opens cleanly but drains straight into a ClickHouse
+// MEMORY_LIMIT_EXCEEDED rejection (chclient.MemoryLimitError, which
+// wraps chclient.ErrMemoryLimitExceeded — the exact sentinel
+// classifyRouteOutcome matches to classify a failure as
+// routememo.OutcomeResourceFailure). Every other Querier method
+// embeds *StubQuerier so this satisfies prom.Querier in full.
+type routeMemoRetryQuerierA struct {
+	*StubQuerier
+	opens int
+}
+
+func (q *routeMemoRetryQuerierA) QueryCursor(context.Context, string, ...any) (chclient.Cursor, error) {
+	q.opens++
+	return &routeMemoRetryCursor{err: &chclient.MemoryLimitError{Limit: 1 << 30}}, nil
+}
+
+// routeMemoRetryQuerierB is route B's backend: solver.CursorQuerier,
+// wired as the Solver's Executor.Client — a structurally separate data
+// plane from route A, so counting its opens unambiguously proves the
+// retry dispatched route B rather than a silent route-A success.
+type routeMemoRetryQuerierB struct {
+	opens int
+	rows  []chclient.Sample
+}
+
+func (q *routeMemoRetryQuerierB) QueryCursor(context.Context, string, ...any) (chclient.Cursor, error) {
+	q.opens++
+	return &sliceCursor{samples: q.rows}, nil
+}
+
+func (q *routeMemoRetryQuerierB) MaxQueryMemoryBytes() int64 { return 0 }
+
+// newRouteMemoReplayServer builds a *prom.Handler wired end-to-end —
+// route A backed by routeA, route B backed by routeB through a real
+// ModeAuto solver.Solver, and a fresh routememo.Memo — and mounts it
+// behind an httptest.Server. Mirrors
+// internal/api/prom/handler_route_memo_test.go's newRouteMemoHandler,
+// adapted to this package's StubQuerier fixture instead of a
+// bespoke stub.
+func newRouteMemoReplayServer(t *testing.T, routeA *routeMemoRetryQuerierA, routeB *routeMemoRetryQuerierB) *httptest.Server {
+	t.Helper()
+	h := prom.New(routeA, schema.DefaultOTelMetrics(), nil)
+
+	cfg := solver.DefaultConfig()
+	cfg.Mode = solver.ModeAuto
+	cfg.MinFanout = routeMemoRetryMinFanout
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("solver config invalid: %v", err)
+	}
+	h.Engine.Solver = solver.New(cfg, routeMemoRetryEmitter{}, solver.ExecDeps{Client: routeB})
+	h.Engine.RouteMemo = routememo.New(time.Minute)
+
+	mux := http.NewServeMux()
+	h.Mount(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestConsumerCorpus_RouteMemoRetry_PreservesConsumerDecodeContract
+// closes the coverage gap this file exists for: with a non-nil
+// Engine.RouteMemo wired (the shape cmd/cerberus's prod wiring uses,
+// never exercised anywhere else in this package), a query_range corpus
+// entry is replayed twice against a route-A backend that always fails
+// with a resource-exhaustion error. The first request only corroborates
+// the failure (internal/routememo's minCorroboratingFailures floor is
+// 2) and must still surface the plain memory-limit rejection with NO
+// route-B dispatch. The second request crosses the corroboration
+// floor: the failure-driven retry fires, route B answers, and the
+// replayed response must STILL decode and satisfy this entry's exact
+// consumer contract (test/consumer-corpus/grafana-12.2.9/query-range-route-memo-retry.json)
+// — proving a route-B retry cannot silently drop labels, flip the
+// resultType, or otherwise break what the consumer actually reads.
+func TestConsumerCorpus_RouteMemoRetry_PreservesConsumerDecodeContract(t *testing.T) {
+	entries, err := Load(".")
+	if err != nil {
+		t.Fatalf("load corpus: %v", err)
+	}
+	var entry *Entry
+	for i := range entries {
+		if entries[i].Name == routeMemoRetryEntryName {
+			entry = &entries[i]
+			break
+		}
+	}
+	if entry == nil {
+		t.Fatalf("corpus entry %q not found", routeMemoRetryEntryName)
+	}
+
+	routeA := &routeMemoRetryQuerierA{StubQuerier: &StubQuerier{}}
+	routeB := &routeMemoRetryQuerierB{rows: []chclient.Sample{
+		{
+			MetricName: "cerberus_query_inflight",
+			Labels:     map[string]string{"cerberus_ql": "promql"},
+			Timestamp:  time.Unix(routeMemoRetryWindowStartUnix, 0).Add(time.Minute),
+			Value:      routeMemoRetryValue,
+		},
+	}}
+	srv := newRouteMemoReplayServer(t, routeA, routeB)
+
+	// Priming request: corroboration=1, below the memo's floor — must
+	// answer the plain memory-limit rejection with no route-B dispatch.
+	primeReq, err := buildRequest(srv.URL, *entry, nil)
+	if err != nil {
+		t.Fatalf("build priming request: %v", err)
+	}
+	primeResp, err := srv.Client().Do(primeReq)
+	if err != nil {
+		t.Fatalf("priming request: %v", err)
+	}
+	_ = primeResp.Body.Close()
+	if primeResp.StatusCode != http.StatusUnprocessableEntity {
+		t.Fatalf("priming response status = %d, want %d (plain memory-limit rejection, no retry yet)", primeResp.StatusCode, http.StatusUnprocessableEntity)
+	}
+	if routeB.opens != 0 {
+		t.Fatalf("route-B opens after priming request = %d, want 0 — retry must not have fired yet", routeB.opens)
+	}
+
+	// Second request, identical query/grid (same routememo.Key):
+	// corroboration reaches 2 — the retry fires, route B answers, and
+	// the response must satisfy the corpus entry's full consumer
+	// contract exactly as the default stub lane would demand.
+	for _, replayErr := range Replay(srv.Client(), srv.URL, *entry, nil, false) {
+		t.Errorf("%v", replayErr)
+	}
+	if routeB.opens != routeMemoRetryK {
+		t.Errorf("route-B shard opens on the retry request = %d, want %d (Executor.Execute fanned into K=%d shards)", routeB.opens, routeMemoRetryK, routeMemoRetryK)
+	}
+	if routeA.opens != 2 {
+		t.Errorf("route-A opens across both requests = %d, want 2 (one per request; the retry dispatches route B, it does not re-attempt route A)", routeA.opens)
+	}
+}
+
+// routeMemoRetryK is the shard fan-out solver.Eligible() computes for
+// this entry's grid (10-minute window, 15s step -> N=41 anchors) — the
+// structural minimum K=2, per
+// internal/api/prom/handler_route_memo_test.go's routeMemoFixtureK.
+const routeMemoRetryK = 2

--- a/test/consumer-corpus/stub.go
+++ b/test/consumer-corpus/stub.go
@@ -303,6 +303,15 @@ var stubFixtures = map[string]func() *StubQuerier{
 		return &StubQuerier{Strings: []string{"logql", "promql", "traceql"}}
 	},
 
+	// prom-label-values-service-name: /api/v1/label/service_name/values
+	// rows — mirrors the ServiceName values metricsChDBSeed's
+	// cerberus_query_inflight rows carry in the chdb lane (see
+	// replay_chdb_test.go), so the shared wire predicate holds under
+	// both lanes.
+	"prom-label-values-service-name": func() *StubQuerier {
+		return &StubQuerier{Strings: []string{"cerberus-api", "cerberus-loki", "cerberus-tempo"}}
+	},
+
 	// prom-series: /api/v1/series reuses the instant-query pipeline
 	// (fetchSeries → executeInstant), so the canned rows are Samples;
 	// the handler dedupes them into label sets.

--- a/test/consumer-corpus/stub.go
+++ b/test/consumer-corpus/stub.go
@@ -320,4 +320,26 @@ var stubFixtures = map[string]func() *StubQuerier{
 			{Name: "cerberus_query_inflight", Description: "in-flight queries", Unit: "", Type: "gauge"},
 		}}
 	},
+
+	// prom-query-range-route-memo-window backs
+	// grafana-12.2.9/query-range-route-memo-retry.json. That entry's
+	// request.query.start/end are fixed literals (not ${START_UNIX} /
+	// ${END_UNIX} tokens) chosen to reproduce a specific grid anchor
+	// count for solver.Eligible() — see the entry's own provenance — so
+	// its canned row must fall inside THAT window rather than the
+	// shared stubPromAnchor above (matrixFromCursor drops any sample
+	// outside [start, end], which would otherwise leave this entry with
+	// zero result series in the default stub lane).
+	"prom-query-range-route-memo-window": func() *StubQuerier {
+		return &StubQuerier{Samples: []chclient.Sample{
+			{MetricName: "cerberus_query_inflight", Labels: map[string]string{"cerberus_ql": "promql"}, Timestamp: stubRouteMemoRetryWindowAnchor, Value: 2},
+		}}
+	},
 }
+
+// stubRouteMemoRetryWindowAnchor sits inside
+// grafana-12.2.9/query-range-route-memo-retry.json's fixed
+// request.query.start=1781002800 / end=1781003400 window (2026-06-09
+// 11:00:00Z .. 11:10:00Z UTC) — see prom-query-range-route-memo-window
+// above.
+var stubRouteMemoRetryWindowAnchor = time.Date(2026, 6, 9, 11, 5, 0, 0, time.UTC)

--- a/test/e2e/chaos/manifests/chaos-overlay.env
+++ b/test/e2e/chaos/manifests/chaos-overlay.env
@@ -71,6 +71,19 @@
 #     breaker-NEUTRAL under the same saturation burst (a too-small pool
 #     must never trip CH health). Kept >= the admit cap so admission, not
 #     the pool, is the first-order shed signal.
+#
+#   CERBERUS_SOLVER_ROUTE_MEMO_ENABLED=true
+#     Default false (internal/solver/config.go DefaultConfig). The
+#     failure-driven route memo (internal/routememo, wired via
+#     cmd/cerberus/main.go, landed e01ed68d) has never run against a real
+#     cerberus process fielding real ClickHouse traffic in any e2e/chaos/
+#     compose manifest before the route-memo-activation scenario — flipping
+#     it on here is what makes that scenario non-vacuous. A CH
+#     MEMORY_LIMIT_EXCEEDED (code 241) on route A is breaker-NEUTRAL (see
+#     internal/chclient/memlimit.go), so enabling this alongside the
+#     breaker/timeout/admit knobs above is safe: it never changes the
+#     other scenarios' breaker-trip or shed assertions, it only gives a
+#     genuine route-A resource failure somewhere to go.
 CERBERUS_CH_BREAKER_THRESHOLD=3
 CERBERUS_CH_BREAKER_WINDOW=10s
 CERBERUS_CH_BREAKER_OPEN_INTERVAL=5s
@@ -79,3 +92,4 @@ CERBERUS_ADMIT_PROM=2
 CERBERUS_ADMIT_LOKI=2
 CERBERUS_ADMIT_TEMPO=2
 CERBERUS_CH_MAX_OPEN_CONNS=4
+CERBERUS_SOLVER_ROUTE_MEMO_ENABLED=true

--- a/test/perf/cardinality-baseline.json
+++ b/test/perf/cardinality-baseline.json
@@ -3690,6 +3690,36 @@
     "max_recursion_depth": 0
   },
   {
+    "fixture": "promql/metadata_label_values_bucket_le",
+    "fan_factor": 3,
+    "scan_rows": 1,
+    "peak_intermediate": 3,
+    "has_cross_join": false,
+    "has_array_join": true,
+    "has_recursive_cte": false,
+    "max_recursion_depth": 0
+  },
+  {
+    "fixture": "promql/metadata_label_values_collides_on_sanitized_name",
+    "fan_factor": 1,
+    "scan_rows": 3,
+    "peak_intermediate": 3,
+    "has_cross_join": false,
+    "has_array_join": false,
+    "has_recursive_cte": false,
+    "max_recursion_depth": 0
+  },
+  {
+    "fixture": "promql/metadata_label_values_dotted_source_key",
+    "fan_factor": 1,
+    "scan_rows": 3,
+    "peak_intermediate": 3,
+    "has_cross_join": false,
+    "has_array_join": false,
+    "has_recursive_cte": false,
+    "max_recursion_depth": 0
+  },
+  {
     "fixture": "promql/minute_default",
     "fan_factor": 1,
     "scan_rows": 1,

--- a/test/spec/promql/metadata_label_values_bucket_le.txtar
+++ b/test/spec/promql/metadata_label_values_bucket_le.txtar
@@ -11,6 +11,19 @@ disappears is the per-series collapse above them.
 latency_seconds_bucket
 -- metadata_label_values --
 le
+-- seed --
+CREATE TABLE otel_metrics_histogram (
+    MetricName String, Attributes Map(String, String), ResourceAttributes Map(String, String), ServiceName String,
+    TimeUnix DateTime64(9), Count UInt64, Sum Float64, BucketCounts Array(UInt64), ExplicitBounds Array(Float64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_histogram VALUES
+    ('latency_seconds', map(), map(), 'api', toDateTime64('1970-01-01 00:02:00', 9), 6, 10.0, [1, 2, 3], [0.1, 0.5]);
+-- expected_rows --
+[
+  ["0.1"],
+  ["0.5"],
+  ["+Inf"]
+]
 -- sql --
 SELECT coalesce(nullIf(`Attributes`[?], ?), nullIf(`ResourceAttributes`[?], ?), ?) AS `value` FROM (SELECT * FROM (SELECT ? AS `MetricName`, mapConcat(`Attributes`, map(?, if((le_idx > length(`ExplicitBounds`)), ?, toString(`ExplicitBounds`[le_idx])))) AS `Attributes`, `ResourceAttributes` AS `ResourceAttributes`, `ServiceName` AS `ServiceName`, `TimeUnix` AS `TimeUnix`, toFloat64(arraySum(arraySlice(`BucketCounts`, ?, le_idx))) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `ResourceAttributes` AS `ResourceAttributes`, `ServiceName` AS `ServiceName`, `TimeUnix` AS `TimeUnix`, `ExplicitBounds` AS `ExplicitBounds`, `BucketCounts` AS `BucketCounts`, arrayJoin(arrayEnumerate(`BucketCounts`)) AS `le_idx` FROM (SELECT * FROM `otel_metrics_histogram` WHERE (`MetricName` IN (?, ?, ?))))) WHERE ((`TimeUnix` >= toDateTime64(?, ?)) AND (`TimeUnix` <= toDateTime64(?, ?))))
 -- args --

--- a/test/spec/promql/metadata_label_values_collides_on_sanitized_name.txtar
+++ b/test/spec/promql/metadata_label_values_collides_on_sanitized_name.txtar
@@ -17,6 +17,21 @@ deployment.environment
 deployment-environment
 -- metadata_label_values --
 deployment_environment
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String, Attributes Map(String, String), ResourceAttributes Map(String, String),
+    TimeUnix DateTime64(9), Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_sum VALUES
+    ('requests_total', map(), map('deployment.environment', 'prod-dot', 'deployment-environment', 'prod-hyphen'), toDateTime64('1970-01-01 00:02:00', 9), 1.0),
+    ('requests_total', map(), map('deployment-environment', 'canary-hyphen-only'), toDateTime64('1970-01-01 00:02:00', 9), 1.0),
+    ('requests_total', map('deployment_environment', 'attr-wins'), map('deployment.environment', 'ra-loses'), toDateTime64('1970-01-01 00:02:00', 9), 1.0);
+-- expected_rows --
+[
+  ["prod-dot"],
+  ["canary-hyphen-only"],
+  ["attr-wins"]
+]
 -- sql --
 SELECT coalesce(nullIf(if(mapContains(`Attributes`, ?), `Attributes`[?], if(mapContains(`Attributes`, ?), `Attributes`[?], `Attributes`[?])), ?), nullIf(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], `ResourceAttributes`[?])), ?), nullIf(`ResourceAttributes`[?], ?), ?) AS `value` FROM (SELECT * FROM `otel_metrics_sum` PREWHERE (`MetricName` IN (?, ?, ?)) WHERE (`TimeUnix` >= toDateTime64(?, ?)) AND (`TimeUnix` <= toDateTime64(?, ?)))
 -- args --

--- a/test/spec/promql/metadata_label_values_dotted_source_key.txtar
+++ b/test/spec/promql/metadata_label_values_dotted_source_key.txtar
@@ -13,6 +13,21 @@ requests_total
 k8s.namespace.name
 -- metadata_label_values --
 k8s_namespace_name
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String, Attributes Map(String, String), ResourceAttributes Map(String, String),
+    TimeUnix DateTime64(9), Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_sum VALUES
+    ('requests_total', map('k8s.namespace.name', 'attr-dot'), map('k8s.namespace.name', 'ra-dot-shadowed'), toDateTime64('1970-01-01 00:02:00', 9), 1.0),
+    ('requests_total', map(), map('k8s.namespace.name', 'ra-dot'), toDateTime64('1970-01-01 00:02:00', 9), 1.0),
+    ('requests_total', map('k8s/namespace_name', 'attr-slash-underscore'), map(), toDateTime64('1970-01-01 00:02:00', 9), 1.0);
+-- expected_rows --
+[
+  ["attr-dot"],
+  ["ra-dot"],
+  ["attr-slash-underscore"]
+]
 -- sql --
 SELECT coalesce(nullIf(if(mapContains(`Attributes`, ?), `Attributes`[?], if(mapContains(`Attributes`, ?), `Attributes`[?], if(mapContains(`Attributes`, ?), `Attributes`[?], if(mapContains(`Attributes`, ?), `Attributes`[?], if(mapContains(`Attributes`, ?), `Attributes`[?], if(mapContains(`Attributes`, ?), `Attributes`[?], `Attributes`[?])))))), ?), nullIf(if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], if(mapContains(`ResourceAttributes`, ?), `ResourceAttributes`[?], `ResourceAttributes`[?])))))), ?), ?) AS `value` FROM (SELECT * FROM `otel_metrics_sum` PREWHERE (`MetricName` IN (?, ?, ?)) WHERE (`TimeUnix` >= toDateTime64(?, ?)) AND (`TimeUnix` <= toDateTime64(?, ?)))
 -- args --


### PR DESCRIPTION
## Summary

Follow-up to a rigorous 14-layer test-strategy audit of three recently merged PRs (#1275 failure-driven route memo, #1272 eval-grid carrier interface, #1270 label-catalog scan-site resolution). Closes 7 real, evidence-based coverage gaps:

- **Route memo, Layer 13 (live-stack chaos)**: new `route-memo-activation` scenario in `.github/scripts/chaos-run.mjs` — flips `CERBERUS_SOLVER_ROUTE_MEMO_ENABLED=true` on the k3d chaos overlay, drives a query engineered to exceed the existing memory cap on route A, and asserts (via cerberus's own Prom-head metrics) that route B rescues it. Records not-applicable rather than a vacuous pass if the query doesn't cross the cap on a given run.
- **Route memo, Layer 7b (consumer-corpus)**: new corpus entry + harness wiring proving a route-B retry preserves the exact consumer-decode contract real Grafana requests expect.
- **Grid-carrier, Layer 7**: new `internal/api/loki` test mirroring the PromQL fix's own regression pin, proving LogQL `absent_over_time` range queries are no longer misclassified as instant.
- **Label-catalog, Layer 6a**: `-- seed --`/`-- expected_rows --` added to the collision and dotted-source-key fixtures, proving those specific new SQL shapes return correct rows against real seeded data (previously text-only).
- **Label-catalog, Layer 7b (consumer-corpus)**: new entry exercising a resource-attribute/dotted-key label-values request.
- **Label-catalog, Layer 2b**: direct unit tests for the new pure key-resolution functions (fallback-to-regex, collision precedence, unreachable-key cases).
- **Label-catalog, Layer 11**: allocation benchmark for the label-catalog lowering path, pinning the PR's stated perf rationale.

## Test plan

- [x] `go build ./...` / `go vet ./...` clean
- [x] `go test ./test/consumer-corpus/... ./internal/promql/... ./internal/api/... ./internal/engine/...` green
- [x] chDB-tagged consumer-corpus lane green (new entries execute against real ClickHouse via testcontainers)
- [x] `node --check` + YAML parse clean on the chaos scenario changes
- [ ] Live k3d dispatch of the `chaos` job needed to fully validate `route-memo-activation` end-to-end (honestly flagged as unverified in this environment — no Docker/k3d available here)