### PR TITLE
fix(mutation): scope internal/logql/lsyntax out of the four logql legs

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -161,13 +161,40 @@ jobs:
           #     byte-identical no-op.
           # With the killable set covered the bar is RAISED BACK TO 95; the
           # equivalents sit comfortably under it (~97.7%).
+          # Round 13 (2026-07-25, this incident): all four phase4-logql-*
+          # legs below started dying with the same "runner received a
+          # shutdown signal" OOM signature ~20-25 min into every push-to-main
+          # run, 100% reproducible, starting exactly at the commit that
+          # moved internal/logql/dotted_labels.go's implementation AND its
+          # large table-driven test suite into internal/logql/lsyntax
+          # (dotted_labels_test.go went from package logql to package
+          # lsyntax). `scope: ./internal/logql` recurses into every
+          # subdirectory (gremlins walks the whole scope tree), so
+          # internal/logql/lsyntax/*.go was ALREADY being swept into these
+          # four legs — none of the exclude_files regexes below ever
+          # covered lsyntax's own files (ast.go, lexer.go, parser.go, …),
+          # only dotted_labels.go itself (matched by filename regardless of
+          # directory). Once dotted_labels_test.go relocated into package
+          # lsyntax, every covered mutant found anywhere in lsyntax now
+          # forces `go test .../internal/logql/lsyntax` to link and run
+          # that heavier test binary, on every one of the four legs, and
+          # cumulative runner RSS crossed the ubuntu-latest ceiling before
+          # the run finished — the same root cause documented for
+          # dotted_labels.go itself in rounds 4-10 above, just reached via
+          # a different file. Fix: exclude the whole lsyntax subtree
+          # (scope-relative '^lsyntax/', mirroring the phase4-traceql-lower
+          # '^ast/' precedent below) from all four legs, and give lsyntax
+          # its own dedicated phase4-logql-parser / phase4-logql-lsyntax
+          # legs (see below phase4-traceql-parser/-ast) so the package
+          # keeps its mutation coverage instead of losing it.
           - phase: phase4-logql-lower
             scope: ./internal/logql
             efficacy: 95
             workers: 1
             # Mutate only lower.go (~50 KB, the package's largest
-            # source file). Excludes every other logql source.
-            exclude_files: '(binary|detected_level|dotted_labels|literal|label_fns|top_level_columns|range_aggregation|vector_aggregation|lang)\.go$'
+            # source file). Excludes every other logql source plus the
+            # lsyntax subtree (own dedicated legs below).
+            exclude_files: '^lsyntax/|(binary|detected_level|dotted_labels|literal|label_fns|top_level_columns|range_aggregation|vector_aggregation|lang)\.go$'
           - phase: phase4-logql-aggregation
             scope: ./internal/logql
             efficacy: 95
@@ -175,7 +202,7 @@ jobs:
             # Mutate range_aggregation.go + vector_aggregation.go +
             # lang.go (~54 KB total). Excludes everything else.
             # Bar at 93 (not 95) — see round-10 rationale above.
-            exclude_files: '(binary|detected_level|dotted_labels|literal|label_fns|top_level_columns|lower)\.go$'
+            exclude_files: '^lsyntax/|(binary|detected_level|dotted_labels|literal|label_fns|top_level_columns|lower)\.go$'
           - phase: phase4-logql-other-a
             scope: ./internal/logql
             efficacy: 95
@@ -190,7 +217,7 @@ jobs:
             # regex too as belt-and-braces in case gremlins
             # treats CLI `--exclude-files` as an override rather
             # than an additional filter.
-            exclude_files: '(lower|range_aggregation|vector_aggregation|lang|literal|label_fns|top_level_columns|dotted_labels)\.go$'
+            exclude_files: '^lsyntax/|(lower|range_aggregation|vector_aggregation|lang|literal|label_fns|top_level_columns|dotted_labels)\.go$'
           - phase: phase4-logql-other-b
             scope: ./internal/logql
             efficacy: 95
@@ -198,7 +225,27 @@ jobs:
             # Mutate literal.go + label_fns.go +
             # top_level_columns.go (~21 KB total). Unchanged from
             # round 8.
-            exclude_files: '(lower|range_aggregation|vector_aggregation|lang|binary|detected_level|dotted_labels)\.go$'
+            exclude_files: '^lsyntax/|(lower|range_aggregation|vector_aggregation|lang|binary|detected_level|dotted_labels)\.go$'
+          - phase: phase4-logql-parser
+            scope: ./internal/logql/lsyntax
+            efficacy: 95
+            workers: 1
+            # Mutate parser.go only (~27 KB, the recursive-descent
+            # LogQL parser — the densest control-flow surface in the
+            # package, same shape as phase4-traceql-parser below).
+            # dotted_labels.go stays excluded here too: it is
+            # structurally un-mutatable on ubuntu-latest regardless of
+            # which package it lives in (rounds 9-10 above).
+            exclude_files: '^dotted_labels\.go$|^(ast|binop|errors|labelfilter|lexer|ops|string)\.go$'
+          - phase: phase4-logql-lsyntax
+            scope: ./internal/logql/lsyntax
+            efficacy: 95
+            workers: 1
+            # Mutate the rest of the lsyntax package (AST node defs,
+            # lexer, label-filter matching, operators); parser.go runs
+            # in its own leg above. dotted_labels.go excluded — see
+            # phase4-logql-parser.
+            exclude_files: '^dotted_labels\.go$|^parser\.go$'
           # phase4-traceql historically OOM-killed the ubuntu-latest runner
           # (~7 GB RAM) after ~3 minutes. The original monolithic phase
           # contained ~109 timeout-inducing mutants in the recursive-descent

--- a/.gremlins.yaml
+++ b/.gremlins.yaml
@@ -29,24 +29,39 @@ excluded-files:
   - "internal/api/**"
   - "cmd/**"
   - "**/doc.go"
-  # `internal/logql/dotted_labels.go` is structurally un-mutatable on
-  # the ubuntu-latest runner (~7 GB RAM). Rounds 4-9 of PR #664 walked
-  # the runner-budget knobs all the way down: workers=1, single-file
-  # `--exclude-files` slice (the file is only ~7 KB but the OTel
-  # dotted-label walker is the densest mutable surface in the
-  # package — ~40 mutants). Even the standalone single-file slice
-  # `phase4-logql-other-c` still received SIGTERM at ~3 min, having
-  # processed ~40 mutants of the file with every emitted mutant
-  # KILLED (0 LIVED). The bottleneck is cumulative gremlins-driver
-  # RSS plus each mutant's full `go test ./internal/logql` cycle
-  # dragging the loki + prometheus + dskit + memberlist parser dep
-  # graph through the linker — not the file itself. Until either
-  # (a) gremlins exposes an incremental-test-binary mode that
-  # skips re-linking per mutant, or (b) the lane moves to a larger
-  # runner class, dotted_labels.go is excluded from gremlins runs.
-  # The file is still covered by Layer-2 TXTAR fixtures and the
-  # standalone unit tests in `dotted_labels_test.go`.
-  - "internal/logql/dotted_labels.go"
+  # `dotted_labels.go` is structurally un-mutatable on the
+  # ubuntu-latest runner (~7 GB RAM), regardless of which package it
+  # lives in. Rounds 4-9 of PR #664 walked the runner-budget knobs all
+  # the way down: workers=1, single-file `--exclude-files` slice (the
+  # file is only ~7 KB but the OTel dotted-label walker is the
+  # densest mutable surface in the package — ~40 mutants). Even the
+  # standalone single-file slice `phase4-logql-other-c` still
+  # received SIGTERM at ~3 min, having processed ~40 mutants of the
+  # file with every emitted mutant KILLED (0 LIVED). The bottleneck
+  # is cumulative gremlins-driver RSS plus each mutant's full
+  # `go test` cycle dragging the LogQL parser dep graph through the
+  # linker — not the file itself. Until either (a) gremlins exposes
+  # an incremental-test-binary mode that skips re-linking per mutant,
+  # or (b) the lane moves to a larger runner class, dotted_labels.go
+  # is excluded from gremlins runs. The file is still covered by
+  # Layer-2 TXTAR fixtures and the standalone unit tests alongside it.
+  #
+  # PR #1266 relocated the implementation from
+  # `internal/logql/dotted_labels.go` to
+  # `internal/logql/lsyntax/dotted_labels.go`; the entry below is kept
+  # as a filename match (gremlins' `--exclude-files` regexes are
+  # unanchored, so this matches the file at either path) so it stays
+  # correct across the move. NOTE: this top-level `excluded-files` key
+  # does not actually bind to gremlins' real config path
+  # (`unleash.exclude-files`, only reachable via nested `unleash:
+  # exclude-files:` or the `--exclude-files` CLI flag) — it has never
+  # been read by the gremlins binary. The exclusion that matters in
+  # practice is the per-leg `--exclude-files` CLI flag set in
+  # `.github/workflows/mutation.yml` for every phase4-logql-* /
+  # phase4-traceql-* leg, which is bound correctly. This entry is left
+  # here as documentation of intent pending a follow-up that fixes the
+  # key nesting; it has no effect today.
+  - "dotted_labels.go"
 
 # Phased mutation-testing rollout. Each phase scopes gremlins to one
 # package with its own `--threshold-efficacy` bar enforced in

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -435,25 +435,33 @@ runs as its own matrix entry in `.github/workflows/mutation.yml`. The
 gate is informational on push-to-main; flipped to required when a
 phase has held the 95% efficacy floor for a stable streak.
 
-| Phase                       | Package              | Efficacy floor |
-| --------------------------- | -------------------- | -------------- |
-| `phase1`                    | `internal/chplan`    | 95%            |
-| `phase2`                    | `internal/chsql`     | 95%            |
-| `phase3-optimizer`          | `internal/optimizer` | 95%            |
-| `phase4-promql`             | `internal/promql`    | 95%            |
-| `phase4-logql-lower`        | `internal/logql`     | 95%            |
-| `phase4-logql-aggregation`  | `internal/logql`     | 93%            |
-| `phase4-logql-other-a`      | `internal/logql`     | 95%            |
-| `phase4-logql-other-b`      | `internal/logql`     | 95%            |
-| `phase4-traceql`            | `internal/traceql`   | 95%            |
-| `phase5-qlcommon`           | `internal/qlcommon`  | 95%            |
+| Phase                       | Package                  | Efficacy floor |
+| --------------------------- | ------------------------ | -------------- |
+| `phase1`                    | `internal/chplan`        | 95%            |
+| `phase2`                    | `internal/chsql`         | 95%            |
+| `phase3-optimizer`          | `internal/optimizer`     | 95%            |
+| `phase4-promql`             | `internal/promql`        | 95%            |
+| `phase4-logql-lower`        | `internal/logql`         | 95%            |
+| `phase4-logql-aggregation`  | `internal/logql`         | 93%            |
+| `phase4-logql-other-a`      | `internal/logql`         | 95%            |
+| `phase4-logql-other-b`      | `internal/logql`         | 95%            |
+| `phase4-logql-parser`       | `internal/logql/lsyntax` | 95%            |
+| `phase4-logql-lsyntax`      | `internal/logql/lsyntax` | 95%            |
+| `phase4-traceql`            | `internal/traceql`       | 95%            |
+| `phase5-qlcommon`           | `internal/qlcommon`      | 95%            |
 
 `internal/logql` is split into four sibling matrix entries (each scoped
 to `./internal/logql` but with disjoint `--exclude-files` regexes) to
 keep the `go test ./internal/logql` cycle under the ubuntu-latest memory
 ceiling; `phase4-logql-aggregation` sits one point lower at 93% to absorb
-a documented equivalent mutant. See `.github/workflows/mutation.yml` for
-the per-phase exclude sets.
+a documented equivalent mutant. Its `internal/logql/lsyntax` parser
+subpackage gets its own pair of dedicated legs (`phase4-logql-parser` /
+`phase4-logql-lsyntax`, mirroring the `internal/traceql/ast` split
+below) rather than being swept into the four `internal/logql` legs —
+gremlins recurses into every subdirectory of a scope, so leaving
+`lsyntax` unexcluded there let a relocated, heavier test file bloat
+every one of those legs' `go test` cycles (2026-07-25 incident). See
+`.github/workflows/mutation.yml` for the per-phase exclude sets.
 
 A surviving mutant is either (a) a legitimately weak assertion that
 needs strengthening, (b) a functionally-equivalent mutation (`<` vs


### PR DESCRIPTION
## Summary

Fixes the `mutation` workflow failure from run [30175604520](https://github.com/tsouza/cerberus/actions/runs/30175604520) (and every push-to-main run since ~08:46 UTC today — 10/10 consecutive failures, 100% reproducible), where all four `phase4-logql-*` legs (`lower`, `aggregation`, `other-a`, `other-b`) die with the runner's OOM "shutdown signal" ~20-25 min into the run.

## Root cause

- `gremlins`' scope resolution (`fs.WalkDir(mu.fs, ".", …)` in the `tsouza/gremlins` fork) recurses into **every subdirectory** of the given scope. `scope: ./internal/logql` therefore already recursed into `internal/logql/lsyntax` — the LogQL parser subpackage — even though none of the four legs' `--exclude-files` regexes ever excluded lsyntax's own files (`ast.go`, `lexer.go`, `parser.go`, etc.). Only `dotted_labels.go` was excluded, by filename match regardless of directory.
- PR #1266 (`3056b471`, merged today ~08:31 UTC) relocated `NormalizeDottedLabels`'s implementation from `internal/logql/dotted_labels.go` into `internal/logql/lsyntax/dotted_labels.go`, and moved its large table-driven test suite (`dotted_labels_test.go`, ~440 lines, several `t.Parallel()` subtests) from package `logql` into package `lsyntax` along with it.
- Since gremlins runs `go test <package-of-mutated-file>` per mutant, every covered mutant anywhere in `lsyntax` (which was already being generated by all four `internal/logql`-scoped legs) now forces `go test .../internal/logql/lsyntax` to build and run against a **heavier** test binary that includes the newly-relocated `dotted_labels_test.go` suite. That happens on **every** mutant, on **all four** legs — not just mutants inside `dotted_labels.go` itself (which stays properly excluded).
- Job logs confirm coverage-gathering is fast (~1 min); the runner instead dies ~22 minutes into mutant execution with the exact "Shutting down gracefully..." → "The runner has received a shutdown signal" signature that `.github/workflows/mutation.yml`'s own history documents as the ubuntu-latest (~7 GB RAM) OOM-kill pattern for this package (rounds 4-10 of PR #664, walked at length in the existing comments).

Confirmed via `gh run list`/`gh run view` across the last ~10 push-to-main `mutation` runs: every run failed identically starting at the exact commit that landed the relocation; the immediately preceding run (last green, ~06:34 UTC) succeeded with comparable (~21-27 min) durations for these same legs. Unrelated, heavier legs in the same runs (e.g. `phase2` at 38m46s, all four `phase4-traceql-*` legs) were unaffected — ruling out generic GitHub-hosted-runner fleet flakiness as the explanation. This is a real, actionable, code-correlated bug, not infra noise.

## Fix

Mirrors the existing precedent already established in this same file for `internal/traceql/ast` (see `phase4-traceql-parser` / `phase4-traceql-ast` / the `^ast/` exclude on `phase4-traceql-lower`/`-other`):

- Exclude the whole `lsyntax` subtree (`^lsyntax/`) from all four `internal/logql`-scoped legs, restoring the isolation their doc comments already claimed to have.
- Add two new dedicated legs, `phase4-logql-parser` (mutates `lsyntax/parser.go` only — the recursive-descent parser, the densest control-flow surface) and `phase4-logql-lsyntax` (the rest of the package), both excluding `dotted_labels.go` per the existing rounds 9-10 precedent (that file is structurally un-mutatable on ubuntu-latest regardless of which package it lives in). This *preserves* lsyntax's mutation coverage rather than dropping it — `internal/logql/lsyntax` (minus `dotted_labels.go`) is ~3,400 lines, smaller than `internal/traceql/ast`'s ~5,500 lines, which already runs successfully split the same way.
- Updated `.gremlins.yaml`'s `dotted_labels.go` exclusion comment to reference the new file location and note this exclusion is enforced by filename match (works at either path).
- Also documented (but did not fix, to keep this PR minimal) a separate, pre-existing, currently-harmless finding: `.gremlins.yaml`'s top-level `excluded-files:` key has never actually bound to gremlins' real config path (`unleash.exclude-files`, reachable only via nested `unleash: exclude-files:` or the `--exclude-files` CLI flag) — it has silently been a no-op. This doesn't affect today's incident because the workflow's own per-leg `--exclude-files` CLI flags (which *do* bind correctly) are what actually enforces every exclusion in the matrix.
- Synced `docs/test-strategy.md`'s gremlins phase table with the two new legs.

## Test plan

- [ ] CI `mutation` workflow (push-to-main gate, this run) — the four `phase4-logql-*` legs should complete within budget again, and the two new `phase4-logql-parser`/`phase4-logql-lsyntax` legs should run green.
- [ ] `check`, `lint`, `forbid-skip`, `compatibility/*`, `probe`, `roundtrip (*)`, `compose-smoke` — unaffected by this change (workflow/config only), expected to pass as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)