### PR TITLE
test(logql): close lsyntax mutation-coverage gap surfaced by #1280

### DIFF
--- a/internal/logql/lsyntax/errors_test.go
+++ b/internal/logql/lsyntax/errors_test.go
@@ -1,0 +1,54 @@
+package lsyntax
+
+import (
+	"errors"
+	"testing"
+)
+
+// ParseError.Error() switches its rendering on whether BOTH line and col
+// are zero. Each of the two fields must be checked independently: these
+// cases pin "only line is zero" and "only col is zero" so a mutation on
+// either half of the `&&`, or a flip to `||`, changes which format gets
+// picked.
+func TestParseErrorFormatting(t *testing.T) {
+	cases := []struct {
+		name string
+		err  ParseError
+		want string
+	}{
+		{
+			name: "both zero: no positional prefix",
+			err:  ParseError{msg: "z"},
+			want: "parse error : z",
+		},
+		{
+			name: "col zero, line set: positional prefix",
+			err:  ParseError{msg: "x", line: 5, col: 0},
+			want: "parse error at line 5, col 0: x",
+		},
+		{
+			name: "line zero, col set: positional prefix",
+			err:  ParseError{msg: "y", line: 0, col: 7},
+			want: "parse error at line 0, col 7: y",
+		},
+		{
+			name: "both set: positional prefix",
+			err:  ParseError{msg: "w", line: 2, col: 3},
+			want: "parse error at line 2, col 3: w",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.err.Error(); got != tc.want {
+				t.Errorf("Error() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseErrorIs(t *testing.T) {
+	var err error = ParseError{msg: "boom"}
+	if !errors.Is(err, ErrParse) {
+		t.Error("ParseError should satisfy errors.Is(err, ErrParse)")
+	}
+}

--- a/internal/logql/lsyntax/lexer_test.go
+++ b/internal/logql/lsyntax/lexer_test.go
@@ -1,0 +1,481 @@
+package lsyntax
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// See parser_test.go's file comment: internal/logql/lsyntax has no
+// default-tag unit tests of its own lexer, so these boundary-exact tests
+// close the mutation-coverage gap gremlins' phase4-logql-lsyntax leg
+// surfaced (65.4% efficacy, below the repo's 95% bar).
+
+// --- byte/rune classification boundaries -----------------------------------
+
+func TestIsDigit(t *testing.T) {
+	for _, b := range []byte{'0', '9'} {
+		if !isDigit(b) {
+			t.Errorf("isDigit(%q) = false, want true", b)
+		}
+	}
+	for _, b := range []byte{'/', ':'} { // one below '0', one above '9'
+		if isDigit(b) {
+			t.Errorf("isDigit(%q) = true, want false", b)
+		}
+	}
+}
+
+func TestIsHexDigit(t *testing.T) {
+	for _, b := range []byte{'0', '9', 'a', 'f', 'A', 'F'} {
+		if !isHexDigit(b) {
+			t.Errorf("isHexDigit(%q) = false, want true", b)
+		}
+	}
+	// One below/above each range: '`'/'g' bracket 'a'-'f' extended to
+	// 'a'-'z' isn't accepted; '@'/'G' bracket 'A'-'F'.
+	for _, b := range []byte{'`', 'g', '@', 'G'} {
+		if isHexDigit(b) {
+			t.Errorf("isHexDigit(%q) = true, want false", b)
+		}
+	}
+}
+
+func TestIsLetter(t *testing.T) {
+	for _, b := range []byte{'a', 'z', 'A', 'Z', 'm', 'M'} {
+		if !isLetter(b) {
+			t.Errorf("isLetter(%q) = false, want true", b)
+		}
+	}
+	// One below 'a', one above 'z', one below 'A', one above 'Z'.
+	for _, b := range []byte{'`', '{', '@', '['} {
+		if isLetter(b) {
+			t.Errorf("isLetter(%q) = true, want false", b)
+		}
+	}
+}
+
+func TestIsIdentStart(t *testing.T) {
+	if !isIdentStart('_') {
+		t.Error("isIdentStart('_') = false, want true")
+	}
+	if !isIdentStart('a') {
+		t.Error("isIdentStart('a') = false, want true")
+	}
+	if isIdentStart('0') {
+		t.Error("isIdentStart('0') = true, want false (digits can't start an identifier)")
+	}
+	if isIdentStart('-') {
+		t.Error("isIdentStart('-') = true, want false")
+	}
+}
+
+// --- isFunction: whitespace-skipping + by/without keyword detection -------
+
+func TestLexerIsFunction(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		want bool
+	}{
+		{"direct paren", "(", true},
+		{"whitespace then paren", "  (", true},
+		{"bare identifier", "x", false},
+		{"all whitespace, no paren", "   ", false},
+		{"by immediately followed by paren", "by(x)", true},
+		{"by, single space, paren", "by (x)", true},
+		{"by, multiple spaces, paren", "by  (x)", true},
+		{"by is a prefix of a longer identifier", "bytes", false},
+		{"by is a prefix, followed directly by paren", "byte(", false},
+		{"by at the exact end of input", "by", false},
+		{"without immediately followed by paren", "without(x)", true},
+		{"without, multiple spaces, paren", "without  (x)", true},
+		{"without followed by another identifier", "without foo", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			l := &lexer{src: tc.src, pos: 0}
+			if got := l.isFunction(); got != tc.want {
+				t.Errorf("isFunction(%q) = %v, want %v", tc.src, got, tc.want)
+			}
+		})
+	}
+}
+
+// --- scanRange / scanString: unterminated-input error paths ---------------
+
+func TestLexScanRangeUnterminated(t *testing.T) {
+	_, err := lex("[5m")
+	if err == nil {
+		t.Fatal("expected an error for an unterminated range")
+	}
+	if !strings.Contains(err.Error(), "missing closing ']'") {
+		t.Errorf("expected a missing-closing-bracket error, got: %v", err)
+	}
+}
+
+func TestLexScanRangeTerminated(t *testing.T) {
+	toks, err := lex("[5m]")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(toks) != 2 || toks[0].kind != tkRange {
+		t.Fatalf("lex(\"[5m]\") = %+v, want a single tkRange token + EOF", toks)
+	}
+}
+
+func TestLexScanStringUnterminated(t *testing.T) {
+	cases := []string{`"abc`, "`abc"}
+	for _, src := range cases {
+		_, err := lex(src)
+		if err == nil {
+			t.Fatalf("lex(%q): expected an error for an unterminated string literal", src)
+		}
+		if !strings.Contains(err.Error(), "literal not terminated") {
+			t.Errorf("lex(%q): expected a not-terminated error, got: %v", src, err)
+		}
+	}
+}
+
+func TestLexScanStringTerminated(t *testing.T) {
+	cases := []string{`"abc"`, "`abc`"}
+	for _, src := range cases {
+		toks, err := lex(src)
+		if err != nil {
+			t.Fatalf("lex(%q): unexpected error: %v", src, err)
+		}
+		if len(toks) != 2 || toks[0].kind != tkString {
+			t.Fatalf("lex(%q) = %+v, want a single tkString token + EOF", src, toks)
+		}
+	}
+}
+
+// --- scanFrom1: two-character operators with a one-character fallback -----
+
+func TestLexScanFrom1(t *testing.T) {
+	cases := []struct {
+		src      string
+		wantKind tokenKind
+	}{
+		{">=", tkGte},
+		{">", tkGt},
+		{"<=", tkLte},
+		{"<", tkLt},
+	}
+	for _, tc := range cases {
+		toks, err := lex(tc.src)
+		if err != nil {
+			t.Fatalf("lex(%q): unexpected error: %v", tc.src, err)
+		}
+		if len(toks) != 2 || toks[0].kind != tc.wantKind {
+			t.Errorf("lex(%q) = %+v, want a single token of kind %v + EOF", tc.src, toks, tc.wantKind)
+		}
+	}
+}
+
+// --- scanMinus: `--flag`, negative durations, and plain subtraction -------
+
+func TestLexScanMinus(t *testing.T) {
+	t.Run("recognized function flags", func(t *testing.T) {
+		for _, src := range []string{"--strict", "--keep-empty"} {
+			toks, err := lex(src)
+			if err != nil {
+				t.Fatalf("lex(%q): unexpected error: %v", src, err)
+			}
+			if len(toks) != 2 || toks[0].kind != tkFunctionFlag || toks[0].str != src {
+				t.Errorf("lex(%q) = %+v, want a single tkFunctionFlag(%q) + EOF", src, toks, src)
+			}
+		}
+	})
+
+	t.Run("unrecognized double-dash falls back to two minus tokens", func(t *testing.T) {
+		toks, err := lex("--bogus")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(toks) < 2 || toks[0].kind != tkSub || toks[1].kind != tkSub {
+			t.Fatalf("lex(\"--bogus\") = %+v, want two leading tkSub tokens", toks)
+		}
+	})
+
+	t.Run("negative duration, single unit", func(t *testing.T) {
+		toks, err := lex("-5m")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(toks) != 2 || toks[0].kind != tkDuration || toks[0].dur != -5*time.Minute {
+			t.Errorf("lex(\"-5m\") = %+v, want a single tkDuration(-5m) + EOF", toks)
+		}
+	})
+
+	t.Run("negative duration, fractional unit", func(t *testing.T) {
+		toks, err := lex("-5.5h")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := -time.Duration(5.5 * float64(time.Hour))
+		if len(toks) != 2 || toks[0].kind != tkDuration || toks[0].dur != want {
+			t.Errorf("lex(\"-5.5h\") = %+v, want a single tkDuration(%v) + EOF", toks, want)
+		}
+	})
+
+	t.Run("minus followed by a digit but no valid unit falls back to tkSub", func(t *testing.T) {
+		toks, err := lex("-5x")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(toks) < 3 || toks[0].kind != tkSub || toks[1].kind != tkNumber || toks[1].str != "5" {
+			t.Fatalf("lex(\"-5x\") = %+v, want tkSub, tkNumber(5), ...", toks)
+		}
+	})
+}
+
+// --- scanNumber: hex literals, decimals, and exponents ---------------------
+
+func TestLexScanNumber(t *testing.T) {
+	cases := []struct {
+		src  string
+		want string
+	}{
+		{"0x1A", "0x1A"},
+		{"0X1A", "0X1A"},
+		{"0", "0"},
+		{"01", "01"},
+		{"1e5", "1e5"},
+		{"1E-3", "1E-3"},
+		{"5.25", "5.25"},
+	}
+	for _, tc := range cases {
+		toks, err := lex(tc.src)
+		if err != nil {
+			t.Fatalf("lex(%q): unexpected error: %v", tc.src, err)
+		}
+		if len(toks) != 2 || toks[0].kind != tkNumber || toks[0].str != tc.want {
+			t.Errorf("lex(%q) = %+v, want a single tkNumber(%q) + EOF", tc.src, toks, tc.want)
+		}
+	}
+}
+
+// --- scanHexRun: hex-digit run starting at an arbitrary offset -------------
+
+func TestLexerScanHexRun(t *testing.T) {
+	// The starting offset is NOT zero, so a mutation that discards the
+	// input `j` and hard-codes the post-prefix offset (e.g. `j = 2`
+	// instead of `j += 2`) is only detectable when the run doesn't start
+	// at position 0. "0x" sits at [2:4); the hex digits "1A" follow.
+	l := &lexer{src: ".." + "0x1A" + "z"}
+	got := l.scanHexRun(2)
+	const want = 6 // just past "0x1A", before 'z'
+	if got != want {
+		t.Errorf("scanHexRun(2) = %d, want %d", got, want)
+	}
+}
+
+// --- scanExponent: `e`/`E` exponent boundary handling ----------------------
+
+func TestLexScanExponentBoundaries(t *testing.T) {
+	cases := []struct {
+		name       string
+		src        string
+		wantKinds  []tokenKind
+		wantFirst  string
+		commentary string
+	}{
+		{
+			name:      "bare 'e' at end of input is not an exponent",
+			src:       "1e",
+			wantKinds: []tokenKind{tkNumber, tkIdentifier, tkEOF},
+			wantFirst: "1",
+		},
+		{
+			name:      "'e' with a sign but no digits, at end of input",
+			src:       "1e+",
+			wantKinds: []tokenKind{tkNumber, tkIdentifier, tkAdd, tkEOF},
+			wantFirst: "1",
+		},
+		{
+			name:      "'e' with a sign followed by a non-digit",
+			src:       "1e+x",
+			wantKinds: []tokenKind{tkNumber, tkIdentifier, tkAdd, tkIdentifier, tkEOF},
+			wantFirst: "1",
+		},
+		{
+			name:      "a genuine exponent is consumed whole",
+			src:       "1e5",
+			wantKinds: []tokenKind{tkNumber, tkEOF},
+			wantFirst: "1e5",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			toks, err := lex(tc.src)
+			if err != nil {
+				t.Fatalf("lex(%q): unexpected error: %v", tc.src, err)
+			}
+			if len(toks) != len(tc.wantKinds) {
+				t.Fatalf("lex(%q) = %+v, want %d tokens of kind %v", tc.src, toks, len(tc.wantKinds), tc.wantKinds)
+			}
+			for i, k := range tc.wantKinds {
+				if toks[i].kind != k {
+					t.Errorf("lex(%q): token[%d].kind = %v, want %v", tc.src, i, toks[i].kind, k)
+				}
+			}
+			if toks[0].str != tc.wantFirst {
+				t.Errorf("lex(%q): token[0].str = %q, want %q", tc.src, toks[0].str, tc.wantFirst)
+			}
+		})
+	}
+}
+
+// --- trySuffix: multi-component durations can embed digits/dots in the ----
+// --- middle of the unit run (e.g. "1h30m", "1h30.5m") ----------------------
+
+func TestLexDurationSuffixMultiComponent(t *testing.T) {
+	cases := []struct {
+		src  string
+		want time.Duration
+	}{
+		{"1h30m", time.Hour + 30*time.Minute},
+		{"1h30.5m", time.Hour + 30*time.Minute + 30*time.Second},
+	}
+	for _, tc := range cases {
+		toks, err := lex(tc.src)
+		if err != nil {
+			t.Fatalf("lex(%q): unexpected error: %v", tc.src, err)
+		}
+		if len(toks) != 2 || toks[0].kind != tkDuration || toks[0].dur != tc.want {
+			t.Errorf("lex(%q) = %+v, want a single tkDuration(%v) + EOF", tc.src, toks, tc.want)
+		}
+	}
+}
+
+// --- tryBytesSuffix: an embedded '.' inside the suffix scan (white-box) ---
+
+func TestLexerTryBytesSuffixEmbeddedDot(t *testing.T) {
+	l := &lexer{src: "1.5MB"}
+	v, consumed, ok := l.tryBytesSuffix("0")
+	if !ok {
+		t.Fatal("tryBytesSuffix: expected ok=true")
+	}
+	if consumed != len(l.src) {
+		t.Errorf("consumed = %d, want %d (the whole suffix run)", consumed, len(l.src))
+	}
+	const want = 1500000 // "01.5MB" parsed as decimal megabytes
+	if v != want {
+		t.Errorf("value = %d, want %d", v, want)
+	}
+}
+
+// --- trySuffix / tryBytesSuffix: duration and byte-size unit scanning -----
+
+func TestLexDurationSuffix(t *testing.T) {
+	cases := []struct {
+		src  string
+		want time.Duration
+	}{
+		// ASCII duration unit.
+		{"5m", 5 * time.Minute},
+		// Multi-byte (UTF-8) duration unit: exercises the >= utf8.RuneSelf
+		// branch of trySuffix's scan loop.
+		{"5µs", 5 * time.Microsecond},
+	}
+	for _, tc := range cases {
+		toks, err := lex(tc.src)
+		if err != nil {
+			t.Fatalf("lex(%q): unexpected error: %v", tc.src, err)
+		}
+		if len(toks) != 2 || toks[0].kind != tkDuration || toks[0].dur != tc.want {
+			t.Errorf("lex(%q) = %+v, want a single tkDuration(%v) + EOF", tc.src, toks, tc.want)
+		}
+	}
+}
+
+func TestLexBytesSuffix(t *testing.T) {
+	cases := []struct {
+		src  string
+		want uint64
+	}{
+		{"5KB", 5000},
+		{"1.5GiB", 1610612736},
+		{"10Mi", 10485760},
+	}
+	for _, tc := range cases {
+		toks, err := lex(tc.src)
+		if err != nil {
+			t.Fatalf("lex(%q): unexpected error: %v", tc.src, err)
+		}
+		if len(toks) != 2 || toks[0].kind != tkBytes || toks[0].bytes != tc.want {
+			t.Errorf("lex(%q) = %+v, want a single tkBytes(%d) + EOF", tc.src, toks, tc.want)
+		}
+	}
+}
+
+// --- lineCol: byte-offset-to-line/col conversion for error reporting ------
+
+func TestLexerLineCol(t *testing.T) {
+	const src = "ab\ncd"
+	cases := []struct {
+		name     string
+		pos      int
+		wantLine int
+		wantCol  int
+	}{
+		// Exactly at the newline: the newline itself is NOT yet counted.
+		{"before the newline", 2, 1, 3},
+		// One past: the newline IS counted, resetting the column.
+		{"just after the newline", 3, 2, 1},
+		// Far past the end of the source: must clamp to scanning the
+		// whole string exactly once, not read out of bounds.
+		{"past end of input", 100, 2, 3},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			l := &lexer{src: src, pos: tc.pos}
+			line, col := l.lineCol()
+			if line != tc.wantLine || col != tc.wantCol {
+				t.Errorf("lineCol() at pos=%d = (%d,%d), want (%d,%d)", tc.pos, line, col, tc.wantLine, tc.wantCol)
+			}
+		})
+	}
+}
+
+// --- peekByte / peekByteAt: bounds-safe lookahead --------------------------
+
+func TestLexerPeekByte(t *testing.T) {
+	l := &lexer{src: "a", pos: 0}
+	if got := l.peekByte(); got != 'a' {
+		t.Errorf("peekByte() at pos=0 = %q, want 'a'", got)
+	}
+	l.pos = 1 // exactly at len(src)
+	if got := l.peekByte(); got != 0 {
+		t.Errorf("peekByte() at pos=len(src) = %q, want 0", got)
+	}
+}
+
+func TestLexerPeekByteAt(t *testing.T) {
+	l := &lexer{src: "ab", pos: 1}
+	if got := l.peekByteAt(0); got != 'b' {
+		t.Errorf("peekByteAt(0) at pos=1 = %q, want 'b'", got)
+	}
+	// pos+off == len(src) exactly: must clamp to 0, not read (and not
+	// read l.src[pos-off] either, which an ARITHMETIC_BASE mutant on
+	// `pos+off` would wrongly do).
+	if got := l.peekByteAt(1); got != 0 {
+		t.Errorf("peekByteAt(1) at pos=1 (== len(src)) = %q, want 0", got)
+	}
+}
+
+// --- scanIdent: identifier running to end of input -------------------------
+
+func TestLexScanIdentToEOF(t *testing.T) {
+	toks, err := lex("abc")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(toks) != 2 || toks[0].kind != tkIdentifier || toks[0].str != "abc" {
+		t.Fatalf("lex(\"abc\") = %+v, want a single tkIdentifier(\"abc\") + EOF", toks)
+	}
+	if toks[1].kind != tkEOF {
+		t.Errorf("final token kind = %v, want tkEOF", toks[1].kind)
+	}
+}

--- a/internal/logql/lsyntax/parser_test.go
+++ b/internal/logql/lsyntax/parser_test.go
@@ -1,0 +1,626 @@
+package lsyntax
+
+import (
+	"strings"
+	"testing"
+)
+
+// This file exists because internal/logql/lsyntax's parser.go had ZERO
+// direct unit-test coverage of its own: the package's only default-tag
+// test file (dotted_labels_test.go) covers the OTel dotted-label
+// rewrite, and the only file that exercises parser.go/lexer.go against
+// real LogQL text is oracle_agpl_test.go, which is gated behind the
+// `agpl_oracle` build tag and never runs in `go test ./...`. Splitting
+// `internal/logql/lsyntax` into its own gremlins legs (phase4-logql-parser
+// / phase4-logql-lsyntax, see .github/workflows/mutation.yml) surfaced
+// this: 51.2%/65.4% efficacy, far below the 95% bar every other phase
+// clears. These tests close the gap by exercising parser.go directly
+// through the public ParseExpr/ParseSampleExpr/ParseLogSelector API,
+// plus a few white-box tests against parser-internal bounds-checking
+// helpers that aren't reachable any other way.
+
+// --- ParseExprWithoutValidation input-size guard (parser.go) --------------
+
+func TestParseExpr_InputSizeGuard(t *testing.T) {
+	// Exactly at the boundary: must be rejected by the explicit
+	// "input size too long" guard, not merely fail later in lexing.
+	atLimit := strings.Repeat("a", maxInputSize)
+	_, err := ParseExpr(atLimit)
+	if err == nil {
+		t.Fatalf("input of length %d (== maxInputSize) should be rejected", maxInputSize)
+	}
+	if !strings.Contains(err.Error(), "input size too long") {
+		t.Errorf("expected the size-guard error, got: %v", err)
+	}
+
+	// One under the boundary: a valid, otherwise-parseable query padded
+	// with trailing whitespace out to maxInputSize-1 bytes must NOT be
+	// rejected by the size guard.
+	padded := `{app="x"}` + strings.Repeat(" ", maxInputSize-1-len(`{app="x"}`))
+	if len(padded) != maxInputSize-1 {
+		t.Fatalf("test construction bug: len(padded)=%d want %d", len(padded), maxInputSize-1)
+	}
+	_, err = ParseExpr(padded)
+	if err != nil {
+		t.Errorf("input of length maxInputSize-1 should parse (bare selector + trailing whitespace), got: %v", err)
+	}
+}
+
+// --- validateExpr / validateSampleExpr error propagation ------------------
+
+func TestParseExpr_VectorAggregationErrorPropagates(t *testing.T) {
+	// mustNewVectorAggregationExpr stashes a construction error (invalid
+	// topk parameter) on the node itself; validateSampleExpr's
+	// *VectorAggregationExpr case must surface it via e.err, not silently
+	// swallow it and recurse into e.Left (which is nil for an errored
+	// node, and would panic).
+	_, err := ParseExpr(`topk(0, sum(rate({app="x"}[5m])))`)
+	if err == nil {
+		t.Fatal("expected an error for topk with a non-positive parameter")
+	}
+	if !strings.Contains(err.Error(), "invalid parameter") {
+		t.Errorf("expected an invalid-parameter error, got: %v", err)
+	}
+}
+
+func TestParseExpr_RangeAggregationValidateErrorPropagates(t *testing.T) {
+	// newRangeAggregationExpr's validate() rejects grouping on operations
+	// that don't support it (count_over_time); that error must surface
+	// all the way through ParseExpr's default-case Selector() path in
+	// validateSampleExpr, not be dropped.
+	_, err := ParseExpr(`count_over_time({app="x"}[5m]) by (host)`)
+	if err == nil {
+		t.Fatal("expected an error: grouping is not allowed on count_over_time")
+	}
+	if !strings.Contains(err.Error(), "grouping not allowed") {
+		t.Errorf("expected a grouping-not-allowed error, got: %v", err)
+	}
+}
+
+func TestParseExpr_UnwrapRequirement(t *testing.T) {
+	cases := []struct {
+		name    string
+		query   string
+		wantErr string // substring; empty means "must succeed"
+	}{
+		{
+			name:  "count_over_time without unwrap succeeds",
+			query: `count_over_time({app="x"}[5m])`,
+		},
+		{
+			name:    "count_over_time with unwrap is rejected",
+			query:   `count_over_time({app="x"} | unwrap bytes [5m])`,
+			wantErr: "invalid aggregation count_over_time with unwrap",
+		},
+		{
+			name:  "avg_over_time with unwrap succeeds",
+			query: `avg_over_time({app="x"} | unwrap bytes [5m])`,
+		},
+		{
+			name:    "avg_over_time without unwrap is rejected",
+			query:   `avg_over_time({app="x"}[5m])`,
+			wantErr: "invalid aggregation avg_over_time without unwrap",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParseExpr(tc.query)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected success, got error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got success", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("expected error containing %q, got: %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+// --- parseUnary: signed numeric literals -----------------------------------
+
+func TestParseExpr_SignedLiteral(t *testing.T) {
+	cases := []struct {
+		query string
+		want  float64
+	}{
+		{"-5", -5},
+		{"+5", 5},
+	}
+	for _, tc := range cases {
+		e, err := ParseExpr(tc.query)
+		if err != nil {
+			t.Fatalf("ParseExpr(%q): unexpected error: %v", tc.query, err)
+		}
+		lit, ok := e.(*LiteralExpr)
+		if !ok {
+			t.Fatalf("ParseExpr(%q): got %T, want *LiteralExpr", tc.query, e)
+		}
+		got, err := lit.Value()
+		if err != nil {
+			t.Fatalf("ParseExpr(%q): Value(): %v", tc.query, err)
+		}
+		if got != tc.want {
+			t.Errorf("ParseExpr(%q) = %v, want %v", tc.query, got, tc.want)
+		}
+	}
+}
+
+// --- parseExpr: operator precedence and associativity ----------------------
+
+func TestParseExpr_PrecedenceAndAssociativity(t *testing.T) {
+	// All-literal binary expressions constant-fold to a single
+	// LiteralExpr (mustNewBinOpExpr reduces two literal legs), so the
+	// resulting numeric value pins both precedence and associativity
+	// unambiguously: a wrong precedence table or a left/right-assoc bug
+	// changes the computed number.
+	cases := []struct {
+		query string
+		want  float64
+	}{
+		// '*' binds tighter than '+': 2 + (3*4), not (2+3)*4.
+		{"2 + 3 * 4", 14},
+		// '-' is left-associative: (1-2)-3 = -4, not 1-(2-3) = 2.
+		{"1 - 2 - 3", -4},
+		// '^' is right-associative: 2^(3^2) = 2^9 = 512, not (2^3)^2 = 64.
+		{"2 ^ 3 ^ 2", 512},
+	}
+	for _, tc := range cases {
+		e, err := ParseExpr(tc.query)
+		if err != nil {
+			t.Fatalf("ParseExpr(%q): unexpected error: %v", tc.query, err)
+		}
+		lit, ok := e.(*LiteralExpr)
+		if !ok {
+			t.Fatalf("ParseExpr(%q): got %T, want a constant-folded *LiteralExpr", tc.query, e)
+		}
+		got, err := lit.Value()
+		if err != nil {
+			t.Fatalf("ParseExpr(%q): Value(): %v", tc.query, err)
+		}
+		if got != tc.want {
+			t.Errorf("ParseExpr(%q) = %v, want %v", tc.query, got, tc.want)
+		}
+	}
+}
+
+// --- parseRangeAggregation / parseVectorAggregation: optional leading ------
+// --- numeric parameter must not be confused with an arbitrary token --------
+
+func TestParseExpr_RangeAggregationRejectsNonNumericParam(t *testing.T) {
+	// The `<number> ','` lookahead in parseRangeAggregation must require
+	// BOTH a number token AND a following comma; a lone identifier
+	// sitting where the comma-separated parameter goes must not be
+	// silently consumed as the parameter, swallowing the comma with it.
+	// If it were, parsing would incorrectly proceed straight into the log
+	// range and fail later with an "invalid parameter" error instead of
+	// the correct syntax error over the malformed selector.
+	_, err := ParseExpr(`quantile_over_time(x, {app="y"}[5m])`)
+	if err == nil {
+		t.Fatal("expected a syntax error for a non-numeric range-aggregation parameter")
+	}
+	if !strings.Contains(err.Error(), "expected '{'") {
+		t.Errorf("expected a syntax error about the missing selector, got: %v", err)
+	}
+}
+
+func TestParseExpr_VectorAggregationRejectsNonNumericParam(t *testing.T) {
+	// Same lookahead, mirrored in parseVectorAggregation.
+	_, err := ParseExpr(`topk(x, sum(rate({app="y"}[5m])))`)
+	if err == nil {
+		t.Fatal("expected a syntax error for a non-numeric vector-aggregation parameter")
+	}
+	if !strings.Contains(err.Error(), "unexpected") {
+		t.Errorf("expected a syntax error about the unexpected token, got: %v", err)
+	}
+}
+
+// --- parseVectorAggregation: grouping may appear before OR after the -------
+// --- argument list, but never both -----------------------------------------
+
+func TestParseExpr_VectorAggregationGrouping(t *testing.T) {
+	// Grouping before the parens.
+	e, err := ParseExpr(`sum by (a) (rate({app="x"}[5m]))`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	va, ok := e.(*VectorAggregationExpr)
+	if !ok {
+		t.Fatalf("got %T, want *VectorAggregationExpr", e)
+	}
+	if va.Grouping == nil || len(va.Grouping.Groups) != 1 || va.Grouping.Groups[0] != "a" {
+		t.Errorf("grouping before parens: got %+v, want Groups=[a]", va.Grouping)
+	}
+
+	// Grouping after the parens (the alternative, equally valid form).
+	e, err = ParseExpr(`sum(rate({app="x"}[5m])) by (host)`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	va, ok = e.(*VectorAggregationExpr)
+	if !ok {
+		t.Fatalf("got %T, want *VectorAggregationExpr", e)
+	}
+	if va.Grouping == nil || len(va.Grouping.Groups) != 1 || va.Grouping.Groups[0] != "host" {
+		t.Errorf("grouping after parens: got %+v, want Groups=[host]", va.Grouping)
+	}
+
+	// No grouping at all: mustNewVectorAggregationExpr must default
+	// Grouping to a non-nil, empty *Grouping (never leave it nil).
+	e, err = ParseExpr(`sum(rate({app="x"}[5m]))`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	va, ok = e.(*VectorAggregationExpr)
+	if !ok {
+		t.Fatalf("got %T, want *VectorAggregationExpr", e)
+	}
+	if va.Grouping == nil {
+		t.Fatal("expected a default (non-nil) Grouping when none is specified")
+	}
+	if len(va.Grouping.Groups) != 0 {
+		t.Errorf("expected an empty default Grouping, got %+v", va.Grouping)
+	}
+
+	// Grouping BOTH before and after the parens is not valid grammar:
+	// once the before-parens grouping is set, the after-parens clause
+	// must be left unconsumed, producing a trailing-tokens error. The
+	// error text must name the actual offending token ("by"), which
+	// pins parser.tokenText's `t.str != ""` branch (a keyword token
+	// always carries its text in .str; tokenKindName's fallback ("token")
+	// is only reached for tokens that don't).
+	_, err = ParseExpr(`sum by (a) (rate({app="x"}[5m])) by (b)`)
+	if err == nil {
+		t.Fatal("expected an error: grouping specified both before and after the parens")
+	}
+	if !strings.Contains(err.Error(), `trailing tokens near "by"`) {
+		t.Errorf(`expected an error naming the trailing "by" token, got: %v`, err)
+	}
+}
+
+// --- parseRangeAggregation: a genuine numeric parameter must be ------------
+// --- recognized (not just a malformed one rejected) ------------------------
+
+func TestParseExpr_RangeAggregationAcceptsNumericParam(t *testing.T) {
+	// Complements TestParseExpr_RangeAggregationRejectsNonNumericParam:
+	// that test pins the `&&` in the `at(tkNumber) && peek(1)==tkComma`
+	// lookahead; this one pins the `==` itself, which only diverges from
+	// `!=` when a real, well-formed "<number>," prefix is present.
+	e, err := ParseExpr(`quantile_over_time(0.95, {app="x"} | unwrap bytes [5m])`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ra, ok := e.(*RangeAggregationExpr)
+	if !ok {
+		t.Fatalf("got %T, want *RangeAggregationExpr", e)
+	}
+	if ra.Params == nil || *ra.Params != 0.95 {
+		t.Errorf("Params = %v, want 0.95", ra.Params)
+	}
+}
+
+// --- parseBinOpModifier: on(...) / ignoring(...) / bool ---------------------
+
+func TestParseExpr_BinOpModifier(t *testing.T) {
+	cases := []struct {
+		name       string
+		query      string
+		wantOn     bool
+		wantBool   bool
+		wantLabels []string
+	}{
+		{
+			name:       "on",
+			query:      `count_over_time({app="x"}[5m]) + on(host) count_over_time({app="y"}[5m])`,
+			wantOn:     true,
+			wantLabels: []string{"host"},
+		},
+		{
+			name:       "ignoring",
+			query:      `count_over_time({app="x"}[5m]) + ignoring(host) count_over_time({app="y"}[5m])`,
+			wantOn:     false,
+			wantLabels: []string{"host"},
+		},
+		{
+			name:       "bool on",
+			query:      `count_over_time({app="x"}[5m]) + bool on(host) count_over_time({app="y"}[5m])`,
+			wantOn:     true,
+			wantBool:   true,
+			wantLabels: []string{"host"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e, err := ParseExpr(tc.query)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			bo, ok := e.(*BinOpExpr)
+			if !ok {
+				t.Fatalf("got %T, want *BinOpExpr", e)
+			}
+			if bo.Opts.ReturnBool != tc.wantBool {
+				t.Errorf("ReturnBool = %v, want %v", bo.Opts.ReturnBool, tc.wantBool)
+			}
+			if bo.Opts.VectorMatching.On != tc.wantOn {
+				t.Errorf("VectorMatching.On = %v, want %v", bo.Opts.VectorMatching.On, tc.wantOn)
+			}
+			if strings.Join(bo.Opts.VectorMatching.MatchingLabels, ",") != strings.Join(tc.wantLabels, ",") {
+				t.Errorf("MatchingLabels = %v, want %v", bo.Opts.VectorMatching.MatchingLabels, tc.wantLabels)
+			}
+		})
+	}
+}
+
+// --- parseUnwrap: trailing `| <labelFilter>` post-filters (white-box) ------
+
+func TestParseExpr_UnwrapPostFilters(t *testing.T) {
+	// Both accepted lookahead shapes (`| <identifier>...` and
+	// `| (...)`) must be recognized and folded into PostFilters.
+	cases := []struct {
+		name  string
+		query string
+	}{
+		{"identifier-led filter", `avg_over_time({app="x"} | unwrap bytes | foo > 5 [5m])`},
+		{"paren-led filter", `avg_over_time({app="x"} | unwrap bytes | (foo > 5) [5m])`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e, err := ParseExpr(tc.query)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			ra, ok := e.(*RangeAggregationExpr)
+			if !ok {
+				t.Fatalf("got %T, want *RangeAggregationExpr", e)
+			}
+			if got := len(ra.Left.Unwrap.PostFilters); got != 1 {
+				t.Errorf("PostFilters = %d, want 1", got)
+			}
+		})
+	}
+}
+
+// --- parseSignedFloat: signed numeric values inside label filters ---------
+
+func TestParseExpr_SignedLabelFilterValue(t *testing.T) {
+	cases := []struct {
+		query string
+		want  float64
+	}{
+		{`avg_over_time({app="x"} | unwrap bytes | foo > -5 [5m])`, -5},
+		{`avg_over_time({app="x"} | unwrap bytes | foo > +5 [5m])`, 5},
+	}
+	for _, tc := range cases {
+		e, err := ParseExpr(tc.query)
+		if err != nil {
+			t.Fatalf("ParseExpr(%q): unexpected error: %v", tc.query, err)
+		}
+		ra, ok := e.(*RangeAggregationExpr)
+		if !ok {
+			t.Fatalf("ParseExpr(%q): got %T, want *RangeAggregationExpr", tc.query, e)
+		}
+		if len(ra.Left.Unwrap.PostFilters) != 1 {
+			t.Fatalf("ParseExpr(%q): PostFilters = %d, want 1", tc.query, len(ra.Left.Unwrap.PostFilters))
+		}
+		nf, ok := ra.Left.Unwrap.PostFilters[0].(*NumericLabelFilter)
+		if !ok {
+			t.Fatalf("ParseExpr(%q): PostFilter is %T, want *NumericLabelFilter", tc.query, ra.Left.Unwrap.PostFilters[0])
+		}
+		if nf.Value != tc.want {
+			t.Errorf("ParseExpr(%q): Value = %v, want %v", tc.query, nf.Value, tc.want)
+		}
+	}
+}
+
+// --- parseGroupModifier: group_left(...) / group_right(...) ---------------
+
+func TestParseExpr_GroupModifier(t *testing.T) {
+	cases := []struct {
+		name       string
+		query      string
+		wantCard   VectorMatchCardinality
+		wantLabels []string
+	}{
+		{
+			name:       "group_left with include list",
+			query:      `count_over_time({app="x"}[5m]) + on(host) group_left(extra) count_over_time({app="y"}[5m])`,
+			wantCard:   CardManyToOne,
+			wantLabels: []string{"extra"},
+		},
+		{
+			name:       "group_right with include list",
+			query:      `count_over_time({app="x"}[5m]) + on(host) group_right(extra) count_over_time({app="y"}[5m])`,
+			wantCard:   CardOneToMany,
+			wantLabels: []string{"extra"},
+		},
+		{
+			name:     "no group modifier at all",
+			query:    `count_over_time({app="x"}[5m]) + on(host) count_over_time({app="y"}[5m])`,
+			wantCard: CardOneToOne,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e, err := ParseExpr(tc.query)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			bo, ok := e.(*BinOpExpr)
+			if !ok {
+				t.Fatalf("got %T, want *BinOpExpr", e)
+			}
+			vm := bo.Opts.VectorMatching
+			if vm.Card != tc.wantCard {
+				t.Errorf("Card = %v, want %v", vm.Card, tc.wantCard)
+			}
+			if strings.Join(vm.Include, ",") != strings.Join(tc.wantLabels, ",") {
+				t.Errorf("Include = %v, want %v", vm.Include, tc.wantLabels)
+			}
+		})
+	}
+}
+
+// --- validateSampleExpr: *BinOpExpr error propagation ----------------------
+
+func TestParseExpr_BinOpErrorPropagates(t *testing.T) {
+	// mustNewBinOpExpr rejects a literal leg on a logical/set operator
+	// ("and"/"or"/"unless") by stashing the error directly on the
+	// resulting BinOpExpr; validateSampleExpr's *BinOpExpr case must
+	// surface it via e.err rather than recursing into the (nil) legs.
+	_, err := ParseExpr(`1 and count_over_time({app="x"}[5m])`)
+	if err == nil {
+		t.Fatal("expected an error: literal leg on a logical/set binary operator")
+	}
+	if !strings.Contains(err.Error(), "unexpected literal") {
+		t.Errorf("expected an unexpected-literal error, got: %v", err)
+	}
+}
+
+func TestParseExpr_BinOpLeftLegErrorPropagates(t *testing.T) {
+	// When the BinOpExpr node itself constructs cleanly but its LEFT leg
+	// carries a validation error (e.g. an invalid grouping on a nested
+	// range aggregation), validateSampleExpr must recurse into
+	// e.SampleExpr and surface that error, not silently return success
+	// (or fall through to validating e.RHS instead).
+	_, err := ParseExpr(`count_over_time({app="x"}[5m]) by (host) + count_over_time({app="y"}[5m])`)
+	if err == nil {
+		t.Fatal("expected an error: grouping is not allowed on count_over_time")
+	}
+	if !strings.Contains(err.Error(), "grouping not allowed") {
+		t.Errorf("expected a grouping-not-allowed error, got: %v", err)
+	}
+}
+
+// --- mustNewVectorAggregationExpr: non-integer topk/bottomk parameter -----
+
+func TestParseExpr_VectorAggregationNonIntegerParam(t *testing.T) {
+	// "0.5" lexes as a single tkNumber, so it passes the
+	// at(tkNumber)+comma lookahead and reaches strconv.Atoi, which
+	// rejects it for not being an integer. That must surface as its own
+	// "invalid parameter" error, not fall through to the (unrelated)
+	// "must be greater than 0" check using Atoi's zero-value result.
+	_, err := ParseExpr(`topk(0.5, sum(rate({app="x"}[5m])))`)
+	if err == nil {
+		t.Fatal("expected an error for a non-integer topk parameter")
+	}
+	if !strings.Contains(err.Error(), "invalid parameter topk(0.5") {
+		t.Errorf("expected an invalid-parameter error naming the value, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "must be greater than 0") {
+		t.Errorf("got the wrong error variant (should not have reached the >0 check): %v", err)
+	}
+}
+
+// --- mustNewBinOpExpr: constant folding requires BOTH legs to be ----------
+// --- literals, not just one -------------------------------------------------
+
+func TestParseExpr_BinOpFoldsOnlyWhenBothLegsAreLiterals(t *testing.T) {
+	// The right leg here is a literal (5) but the left is not
+	// (a RangeAggregationExpr); the result must stay a *BinOpExpr, never
+	// get folded into a *LiteralExpr using the non-literal leg's
+	// (zero-value) numeric value.
+	e, err := ParseExpr(`count_over_time({app="x"}[5m]) + 5`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := e.(*BinOpExpr); !ok {
+		t.Errorf("got %T, want *BinOpExpr (must not constant-fold with a non-literal leg)", e)
+	}
+}
+
+func TestParserUnwrapPostFilterLookaheadBoundary(t *testing.T) {
+	// White-box: parseUnwrap's trailing-filter loop requires the token
+	// after '|' to be an identifier or '(' before consuming the pipe. A
+	// pipe followed by anything else (here, a bare number) must be left
+	// entirely unconsumed for the caller to deal with, not swallowed.
+	toks, err := lex(`| unwrap bytes | 5`)
+	if err != nil {
+		t.Fatalf("lex: %v", err)
+	}
+	p := &parser{toks: toks}
+	u := p.parseUnwrap()
+	if len(u.PostFilters) != 0 {
+		t.Errorf("PostFilters = %d, want 0 (lookahead token is neither identifier nor '(')", len(u.PostFilters))
+	}
+	if p.cur().kind != tkPipe {
+		t.Errorf("parseUnwrap consumed the trailing '|' it should have left for the caller; cur=%v", p.cur().kind)
+	}
+}
+
+// --- parseLogRange: bare selector vs. selector-with-pipeline shape ---------
+
+func TestParseExpr_LogRangeLeftShape(t *testing.T) {
+	// No pipeline stages: Left must stay the bare *MatchersExpr the
+	// selector parsed into, not get wrapped in an (empty) *PipelineExpr.
+	e, err := ParseExpr(`count_over_time({app="x"}[5m])`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ra, ok := e.(*RangeAggregationExpr)
+	if !ok {
+		t.Fatalf("got %T, want *RangeAggregationExpr", e)
+	}
+	if _, ok := ra.Left.Left.(*MatchersExpr); !ok {
+		t.Errorf("no pipeline stages: got %T, want *MatchersExpr", ra.Left.Left)
+	}
+
+	// With a pipeline stage: Left must be wrapped in a *PipelineExpr.
+	e, err = ParseExpr(`count_over_time({app="x"} | json [5m])`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ra, ok = e.(*RangeAggregationExpr)
+	if !ok {
+		t.Fatalf("got %T, want *RangeAggregationExpr", e)
+	}
+	if _, ok := ra.Left.Left.(*PipelineExpr); !ok {
+		t.Errorf("with a pipeline stage: got %T, want *PipelineExpr", ra.Left.Left)
+	}
+}
+
+// --- parser.peek / parser.advance bounds checking (white-box) --------------
+
+func TestParserPeekAdvanceBounds(t *testing.T) {
+	toks, err := lex("a b")
+	if err != nil {
+		t.Fatalf("lex: %v", err)
+	}
+	// "a", "b", EOF.
+	if len(toks) != 3 {
+		t.Fatalf("test construction bug: len(toks)=%d, want 3", len(toks))
+	}
+	lastKind := toks[len(toks)-1].kind
+
+	p := &parser{toks: toks}
+	if got := p.peek(0); got.kind != toks[0].kind {
+		t.Errorf("peek(0) = %v, want %v", got.kind, toks[0].kind)
+	}
+	if got := p.peek(1); got.kind != toks[1].kind {
+		t.Errorf("peek(1) = %v, want %v", got.kind, toks[1].kind)
+	}
+	// Exactly at the token-count boundary: must clamp to the last token.
+	if got := p.peek(len(toks)); got.kind != lastKind {
+		t.Errorf("peek(len(toks)) = %v, want clamp to %v", got.kind, lastKind)
+	}
+	// Well past the boundary: must still clamp, not index out of range.
+	if got := p.peek(len(toks) + 5); got.kind != lastKind {
+		t.Errorf("peek(len(toks)+5) = %v, want clamp to %v", got.kind, lastKind)
+	}
+
+	// advance() must never move pos past the last valid token index, no
+	// matter how many times it's called.
+	for i := 0; i < len(toks)+3; i++ {
+		p.advance()
+	}
+	if want := len(toks) - 1; p.pos != want {
+		t.Errorf("pos after over-advancing = %d, want clamp to %d", p.pos, want)
+	}
+	if p.cur().kind != lastKind {
+		t.Errorf("cur() after over-advancing = %v, want %v", p.cur().kind, lastKind)
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #1280. That PR fixed a real bug (gremlins' `--exclude-files` scoping accidentally swept `internal/logql/lsyntax` into all four `phase4-logql-*` legs, causing repeated OOMs) by giving `lsyntax` its own two dedicated gremlins legs, `phase4-logql-parser` and `phase4-logql-lsyntax`. That isolation was mechanically correct but surfaced a second, pre-existing problem: `lsyntax`'s *real* mutation-kill coverage was always weak — it had just been hidden by dilution inside `internal/logql`'s much larger, better-tested aggregate.

Root cause: `internal/logql/lsyntax` had **zero default-tag unit tests of its own**. The package's only test files are:
- `dotted_labels_test.go` — covers only the OTel dotted-label rewrite, not the general parser/lexer.
- `oracle_agpl_test.go` — the only file that exercises `parser.go`/`lexer.go` against real LogQL text, but it's gated behind the `agpl_oracle` build tag and **never runs** in `go test ./...` (by design — it imports the AGPL upstream Loki parser as a differential oracle).

So `parser.go` and most of `lexer.go`/`ast.go`/`errors.go` were only ever exercised *indirectly*, through `internal/logql`'s tests calling through the public API from a different package — which doesn't count as coverage for `go test ./internal/logql/lsyntax`'s own gremlins run.

Confirmed live before starting: a fresh push-to-main run showed the same numbers documented in #1280's investigation — `phase4-logql-parser` at 51.2% and `phase4-logql-lsyntax` at 65.4%, both far below the repo's 95% bar.

## What was added

Three new test files, all exercising `parser.go`/`lexer.go`/`errors.go` directly — mostly black-box through the public `ParseExpr`/`ParseSampleExpr`/`ParseLogSelector` API, plus white-box tests against a handful of parser/lexer-internal bounds-checking helpers (`peek`/`advance`, `lineCol`, `peekByte(At)`, `scanHexRun`, `tryBytesSuffix`) that aren't reachable any other way:

- `internal/logql/lsyntax/parser_test.go` — input-size boundary, validate()/Selector() error propagation (range + vector aggregation, binop legs), unwrap requirement rules, unary-sign literals, operator precedence/associativity (via constant-folding to a single literal, which pins the exact numeric result), the range/vector-aggregation optional-parameter lookahead, grouping (before/after/duplicate/default), binop `on`/`ignoring`/`bool`/`group_left`/`group_right` modifiers, unwrap post-filters, log-range `MatchersExpr` vs `PipelineExpr` shape, and `parser.peek`/`parser.advance` bounds.
- `internal/logql/lsyntax/lexer_test.go` — byte/rune classification boundaries (`isDigit`/`isHexDigit`/`isLetter`/`isIdentStart`), `isFunction`'s whitespace-skip + `by`/`without` keyword detection, `scanRange`/`scanString` unterminated-input paths, `scanIdent`, two-char operators (`scanFrom1`), `scanMinus` (`--flag`, negative durations, plain subtraction), `scanNumber` (hex/decimal/exponent), `scanExponent` boundaries, multi-component duration suffixes (`1h30m`), byte-size suffixes, `lineCol`, `peekByte`/`peekByteAt`.
- `internal/logql/lsyntax/errors_test.go` — `ParseError.Error()`'s positional-vs-bare rendering, `errors.Is(err, ErrParse)`.

Every test was validated by hand-tracing (and in a few cases hand-mutating the source locally, running the test, then reverting) to confirm it actually distinguishes the mutant it targets before it went in — not just "covers the line."

## Result (verified locally with the pinned gremlins fork, `v0.6.0-cerberus-sigterm-consume`, matching `mutation.yml`'s exact `gremlins unleash --on-shutdown-status=not-run` invocation and each leg's `--exclude-files`)

- `phase4-logql-parser` (`./internal/logql/lsyntax`, parser.go only): **51.2% → 100%** (0 LIVED, stable across 2 consecutive local runs).
- `phase4-logql-lsyntax` (`./internal/logql/lsyntax`, everything but parser.go/dotted_labels.go): **65.4% → 98%** (5 LIVED, stable across 2 consecutive local runs), all 5 individually root-caused as **genuinely equivalent mutants** — see below.

## The 5 remaining LIVED mutants (equivalence argument, not left uninvestigated)

All 5 sit in defensive bounds/lookahead checks where the "wrong" branch and the "right" branch provably converge on the same output for every possible input — not because I couldn't construct a distinguishing test, but because none exists:

1. **`lexer.go:691:11`** (`CONDITIONALS_BOUNDARY` and `CONDITIONALS_NEGATION`) and **`lexer.go:694:6`** (`INVERT_LOOPCTRL`) — `isFunction`'s "is this a whole word, not just a prefix" check for the `by`/`without` keywords. The check only *matters* (changes which branch runs) when the character right after the keyword prefix is itself an identifier-continuation rune (letter/digit/`_`). But in exactly that case, that same rune is categorically not `(` and not whitespace — so whichever branch runs, the subsequent character-by-character scan independently arrives at `return false`. There is no input where skipping/mis-bounding this check changes the final answer.
2. **`lexer.go:598:8`** (`CONDITIONALS_BOUNDARY`) — `scanIdent`'s "keep scanning identifier runes" loop, boundary at `j == len(src)`. `utf8.DecodeRuneInString` on the empty string (`src[len(src):]`) safely returns `(RuneError, 0)`, and `isIdentPart(RuneError)` is `false` — so the boundary mutant's one extra "iteration" always immediately breaks with the same `id`/`j` the original code produced. Same safety net as #1, just via `DecodeRuneInString`'s empty-string contract instead of a second character comparison.
3. **`lexer.go:551:8`** (`CONDITIONALS_BOUNDARY`) — `trySuffix`'s ASCII-vs-multi-byte dispatch, boundary at `b == utf8.RuneSelf` (0x80). A byte with value exactly 0x80 is *never* a valid UTF-8 leading byte (0x80–0xBF are exclusively continuation bytes), so `utf8.DecodeRuneInString` on that position always yields `(RuneError, 1)` regardless of which branch is taken, and `RuneError` fails every `runeOK`/`isDigit`/`b=='.'` check either way — both branches `break` identically.

I did not treat "equivalent" as a shortcut: each of these took a full trace (and for #2/#3, a check of the exact stdlib contract for decoding past a string's end / decoding a bare continuation byte) before I concluded no test could split them. Given the "no allow-lists, no tolerance" repo policy, I want to flag this explicitly rather than bury it: **no bar was lowered** — both legs already clear 95% for real (100% and 98%), so this isn't a request to relax anything, just documentation of why the last few points aren't 100/100.

## Verification

- `go build ./...`, `go vet ./internal/logql/...`, `go test -race ./internal/logql/lsyntax/...` all green.
- `gofumpt -extra` / `goimports` clean on all three new files.
- Triggered `gremlins unleash` locally against `./internal/logql/lsyntax` with each leg's exact CLI flags from `mutation.yml` (`--exclude-files`, `--workers 1`, `--on-shutdown-status=not-run`), pinned to the same `tsouza/gremlins@v0.6.0-cerberus-sigterm-consume` fork CI uses — not just `go test`.
- Will also trigger `gh workflow run mutation.yml --ref fix/logql-lsyntax-mutation-coverage` and watch the two touched legs to confirm the same numbers hold on the actual CI runner (per the task's live-verification requirement), before this is considered done.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/logql/...`
- [x] `go test -race ./internal/logql/lsyntax/...`
- [x] Local `gremlins unleash` on both legs, 2x each for stability
- [ ] `workflow_dispatch` of `mutation.yml` on this branch, confirm `phase4-logql-parser` and `phase4-logql-lsyntax` clear 95% on the real CI runner