### PR TITLE
fix(ci): log in to Docker Hub before k3d pulls in dashboard/chaos/bwc-minio

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -914,13 +914,13 @@ jobs:
       # login is what actually raises the pull-rate ceiling for k3d jobs,
       # exactly like the compose-smoke jobs above.
       - name: Log in to Docker Hub
-        if: ${{ env.RUN_SHARD == 'true' && env.DOCKERHUB_TOKEN_SET == 'true' }}
+        if: ${{ env.RUN_SHARD == 'true' && env.DOCKER_HUB_PAT_SET == 'true' }}
         env:
-          DOCKERHUB_TOKEN_SET: ${{ secrets.DOCKERHUB_TOKEN != '' }}
+          DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
         uses: docker/login-action@v4
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: tsouza
+          password: ${{ secrets.DOCKER_HUB_PAT }}
 
       - name: Bring up k3d stack
         if: env.RUN_SHARD == 'true'
@@ -1353,13 +1353,13 @@ jobs:
       # login is what actually raises the pull-rate ceiling for k3d jobs,
       # exactly like the compose-smoke jobs above.
       - name: Log in to Docker Hub
-        if: ${{ env.DOCKERHUB_TOKEN_SET == 'true' }}
+        if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
         env:
-          DOCKERHUB_TOKEN_SET: ${{ secrets.DOCKERHUB_TOKEN != '' }}
+          DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
         uses: docker/login-action@v4
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: tsouza
+          password: ${{ secrets.DOCKER_HUB_PAT }}
 
       # Reuse the e2e k3d bring-up (same first steps as the dashboard job):
       # cluster, cerberus:e2e image, manifests, host port maps
@@ -1538,13 +1538,13 @@ jobs:
       # this login is what actually raises the pull-rate ceiling here,
       # exactly like the compose-smoke jobs above.
       - name: Log in to Docker Hub
-        if: ${{ env.DOCKERHUB_TOKEN_SET == 'true' }}
+        if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
         env:
-          DOCKERHUB_TOKEN_SET: ${{ secrets.DOCKERHUB_TOKEN != '' }}
+          DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
         uses: docker/login-action@v4
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: tsouza
+          password: ${{ secrets.DOCKER_HUB_PAT }}
 
       - name: Bring up k3d + MinIO + bundled-ClickHouse stack
         run: just e2e-bwc-up

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -908,6 +908,20 @@ jobs:
         run: |
           curl -sSfL https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=v5.8.3 bash
 
+      # `just e2e-up` pulls the k3s node image + every external image on
+      # the HOST docker daemon (then `k3d image import`s them into the
+      # cluster's containerd — see Justfile's e2e-up/_pull-retry), so this
+      # login is what actually raises the pull-rate ceiling for k3d jobs,
+      # exactly like the compose-smoke jobs above.
+      - name: Log in to Docker Hub
+        if: ${{ env.RUN_SHARD == 'true' && env.DOCKERHUB_TOKEN_SET == 'true' }}
+        env:
+          DOCKERHUB_TOKEN_SET: ${{ secrets.DOCKERHUB_TOKEN != '' }}
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Bring up k3d stack
         if: env.RUN_SHARD == 'true'
         # E2E_MODE drives the chart deployment topology `just e2e-up` installs:
@@ -1333,6 +1347,20 @@ jobs:
         run: |
           curl -sSfL https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=v5.8.3 bash
 
+      # `just e2e-up` pulls the k3s node image + every external image on
+      # the HOST docker daemon (then `k3d image import`s them into the
+      # cluster's containerd — see Justfile's e2e-up/_pull-retry), so this
+      # login is what actually raises the pull-rate ceiling for k3d jobs,
+      # exactly like the compose-smoke jobs above.
+      - name: Log in to Docker Hub
+        if: ${{ env.DOCKERHUB_TOKEN_SET == 'true' }}
+        env:
+          DOCKERHUB_TOKEN_SET: ${{ secrets.DOCKERHUB_TOKEN != '' }}
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       # Reuse the e2e k3d bring-up (same first steps as the dashboard job):
       # cluster, cerberus:e2e image, manifests, host port maps
       # (localhost:8080 cerberus), and live OTel data. The ONE difference
@@ -1503,6 +1531,20 @@ jobs:
       - name: Install k3d
         run: |
           curl -sSfL https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=v5.8.3 bash
+
+      # `just e2e-bwc-up` pulls the k3s node image + every external/bwc image
+      # on the HOST docker daemon (then `k3d image import`s them into the
+      # cluster's containerd — see Justfile's e2e-bwc-up/_pull-retry), so
+      # this login is what actually raises the pull-rate ceiling here,
+      # exactly like the compose-smoke jobs above.
+      - name: Log in to Docker Hub
+        if: ${{ env.DOCKERHUB_TOKEN_SET == 'true' }}
+        env:
+          DOCKERHUB_TOKEN_SET: ${{ secrets.DOCKERHUB_TOKEN != '' }}
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Bring up k3d + MinIO + bundled-ClickHouse stack
         run: just e2e-bwc-up


### PR DESCRIPTION
## Summary

- `dashboard-shard`, `chaos`, and `bwc-minio` each build a k3d cluster via `just e2e-up`/`e2e-bwc-up`, which pulls the k3s node image plus every external image on the **host** docker daemon (then `k3d image import`s them into the cluster's containerd — see `Justfile`'s `_pull-retry`).
- The Docker Hub login fix (`DOCKERHUB_TOKEN` via `docker/login-action@v4`) only ever landed on `compose-smoke-setup`/`compose-smoke-shard`. These three k3d-based jobs never got it, so their host-side pulls stay unauthenticated and hit Docker Hub's anonymous rate limit under load.
- Concretely: https://github.com/tsouza/cerberus/actions/runs/30190696899/job/89763331906 died with `context deadline exceeded` pulling `rancher/k3s:v1.31.5-k3s1` — a symptom of the same unauthenticated-pull gap, not a new bug.
- Fix mirrors the exact `docker/login-action@v4` step already proven in the compose-smoke jobs, added to all three remaining k3d-based jobs (gated on `secrets.DOCKERHUB_TOKEN != ''`, so it's a no-op if the secret is ever unset).

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — valid YAML
- [x] `actionlint` — 0 findings (also ran clean as part of the pre-push hook)
- [x] `golangci-lint` / other pre-push hooks — all green
- [ ] Next scheduled/dispatched `e2e.yml` run on `main` — confirms the k3d jobs actually authenticate and no longer hit the anonymous rate limit (can't be exercised locally; this workflow only triggers on push-to-main/schedule/dispatch)