### PR TITLE
fix(migration): keep tier-1 archetypes apart by identity, not by window

### DIFF
--- a/.github/scripts/migration-e2e.mjs
+++ b/.github/scripts/migration-e2e.mjs
@@ -109,13 +109,17 @@ export const TIER1_TIMEOUT_MIN = 45;
 // tier's dispatch option, job stanza and ceiling land with its first scenario.
 //
 // `matrixDriven` records WHICH job shape the tier's stanza has, because the
-// two are not interchangeable. migration-tier0 is one generic runner fanned
-// out by `strategy.matrix`, so its tiers must appear in the emitted matrix.
+// two are not interchangeable. The matrix job is one generic runner fanned out
+// by `strategy.matrix`, so its tiers must appear in the emitted matrix.
 // migration-tier1 is a fixed job — it brings a compose stack up, seeds it and
 // tears it down around the suite, steps a matrix shard cannot express — so it
-// must NOT appear there: a tier1 entry in the matrix would spawn a
-// `migration-tier0 (tier1)` shard that runs the tier-1 suite on a bare runner
-// with no stack behind it.
+// must NOT appear there.
+//
+// Getting this wrong is quiet rather than loud: a tier1 entry in the matrix
+// spawns a shard that runs the tier-1 suite on a bare runner with no stack
+// behind it. Both job shapes render as `migration-<tier>`, so that shard is
+// named exactly like the real fixed job — the run would show two
+// `migration-tier1` jobs, one of which never had a backend.
 export const TIER_JOBS = {
   tier0: { timeoutMinutes: TIER0_TIMEOUT_MIN, matrixDriven: true },
   tier1: { timeoutMinutes: TIER1_TIMEOUT_MIN, matrixDriven: false },
@@ -631,10 +635,13 @@ function runEmit() {
       '',
       '| tier | stories | timeout (min) | job |',
       '| --- | --- | --- | --- |',
+      // Both job shapes render as `migration-<tier>`: the matrix-driven job is
+      // named for the shard it is running, not for itself, so the summary
+      // names the job the reader will actually find in the run.
       ...running.map((tier) => {
         const stories = storiesForTier(scenarios, tier).join(', ');
-        const { timeoutMinutes, matrixDriven } = TIER_JOBS[tier];
-        return `| \`${tier}\` | ${stories} | ${timeoutMinutes} | ${matrixDriven ? `migration-tier0 (${tier})` : `migration-${tier}`} |`;
+        const { timeoutMinutes } = TIER_JOBS[tier];
+        return `| \`${tier}\` | ${stories} | ${timeoutMinutes} | migration-${tier} |`;
       }),
     ].join('\n'),
   );

--- a/.github/scripts/migration-e2e.test.mjs
+++ b/.github/scripts/migration-e2e.test.mjs
@@ -406,9 +406,10 @@ test('a tier with no job is refused before a matrix entry can be built for it', 
 test('a runnable tier whose job is not matrix-driven stays out of the matrix', () => {
   // tier1's job brings a compose stack up around the suite, so it is a fixed
   // stanza, not a matrix shard. Emitting a tier1 entry here would spawn a
-  // `migration-tier0 (tier1)` shard that runs the tier-1 suite on a bare
-  // runner with no stack behind it — green for the wrong reason, or red for a
-  // reason that has nothing to do with the scenarios.
+  // matrix shard running the tier-1 suite on a bare runner with no stack
+  // behind it — green for the wrong reason, or red for a reason that has
+  // nothing to do with the scenarios. It would also be named exactly like the
+  // real fixed job, since both shapes render as `migration-<tier>`.
   assert.equal(TIER_JOBS.tier1.matrixDriven, false);
   const { include } = buildMatrix(world().scenarios, { tiers: ['tier0', 'tier1'] });
   assert.deepEqual(include.map((e) => e.tier), ['tier0']);

--- a/.github/workflows/migration-e2e.yml
+++ b/.github/workflows/migration-e2e.yml
@@ -168,6 +168,35 @@ jobs:
         with:
           tool: just
 
+      # The stack pulls six images (ClickHouse, the collector, reference
+      # Prometheus/Loki/Tempo, golang) onto a runner whose default free space
+      # does not comfortably hold them. Same reclaim e2e.yml runs before its
+      # compose lanes.
+      - name: Disk free (before reclaim)
+        run: df -h
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main as of 2026-06-18
+        with:
+          docker-images: false
+          large-packages: false
+          tool-cache: false
+      - name: Disk free (after reclaim)
+        run: df -h
+
+      # Anonymous Docker Hub pulls are rate-limited hard enough to fail a
+      # cold runner mid-`compose up`; the other Docker-backed lanes log in
+      # first for exactly this reason. Gated on the secret being present so a
+      # fork PR degrades to anonymous rather than erroring on an empty
+      # password.
+      - name: Log in to Docker Hub
+        if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
+        env:
+          DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
+        uses: docker/login-action@v4
+        with:
+          username: tsouza
+          password: ${{ secrets.DOCKER_HUB_PAT }}
+
       # migration-tier1 runs on a separate runner with a fresh checkout, so
       # the enumerator output from migration-setup must travel as an
       # artifact — same reason migration-tier0 downloads it too.
@@ -195,9 +224,18 @@ jobs:
           MODE: run
           SCENARIOS_JSON: build/migration-scenarios.json
           TIER: tier1
+          STORY: ${{ inputs.story }}
 
       - name: Tier-1 substrate + parity assertions
         run: go test -tags=migration_tier1 -count=1 ./test/e2e/migration/
+
+      # A red tier-1 run is only diagnosable with the stack's own account of
+      # what it was doing. Without this, a failure that originates in the
+      # collector or a reference backend shows up here as an opaque assertion
+      # message and the evidence dies with the runner.
+      - name: dump the stack's logs
+        if: failure()
+        run: just migration-tier1-logs
 
       # Every seeded archetype's manifest is what its scenarios read their
       # window and cardinalities from, so a failing run is only diagnosable

--- a/.github/workflows/migration-e2e.yml
+++ b/.github/workflows/migration-e2e.yml
@@ -93,7 +93,10 @@ jobs:
           retention-days: 1
 
   migration-tier0:
-    name: migration-tier0 (${{ matrix.name }})
+    # Named for the tier the shard drives, not for the job. This is the one
+    # generic matrix-driven runner, so its id says `tier0` only because tier0
+    # is the only matrix-driven tier today; the shard name is the honest label.
+    name: migration-${{ matrix.name }}
     needs: migration-setup
     # An empty `include:` does not skip a matrix job — it still runs, with the
     # matrix context unset, so `TIER: ${{ matrix.tier }}` resolves to empty and

--- a/.github/workflows/migration-e2e.yml
+++ b/.github/workflows/migration-e2e.yml
@@ -95,6 +95,14 @@ jobs:
   migration-tier0:
     name: migration-tier0 (${{ matrix.name }})
     needs: migration-setup
+    # An empty `include:` does not skip a matrix job — it still runs, with the
+    # matrix context unset, so `TIER: ${{ matrix.tier }}` resolves to empty and
+    # the run fails on an unknown tier. A dispatch narrowed to tier1 therefore
+    # reported a tier0 FAILURE for a tier it never meant to run (the roll-up
+    # caught it: "tier0 ran (failure) but was not in the tier set this run
+    # selected"). Gate on the same `tiers` output the roll-up reads, exactly as
+    # migration-tier1 does, so selection is decided in one place.
+    if: contains(fromJSON(needs.migration-setup.outputs.tiers), 'tier0')
     runs-on: ubuntu-latest
     timeout-minutes: ${{ matrix.timeoutMinutes }}
     strategy:

--- a/Justfile
+++ b/Justfile
@@ -1273,17 +1273,27 @@ migration-tier1-up:
 # full rebuild + boot + healthcheck wait for no reason.
 MIGRATION_TIER1_ARCHETYPES := "three-signal kube-prometheus-stack"
 
-# Minutes each archetype's fixture window is pushed further into the past
-# than the previous archetype's (cmd/seed's --window-offset), so archetypes
-# seeded back-to-back into the same live stack land in disjoint windows even
-# when their fixtures share a label value. three-signal and
-# kube-prometheus-stack both declare a "checkout" trace service, and
-# reference Tempo's /api/search is window-scoped: an overlapping window let
-# one archetype's search see the other's "checkout" traces too. 45 minutes
-# clears the fixture window (seed.SeedWindow, 30 minutes) with margin for how
-# long seeding the prior archetype took, while staying under reference
-# Tempo's 1-hour ingestion slack (cmd/seed validates this at seed time).
-MIGRATION_TIER1_WINDOW_STEP_MIN := "45"
+# Lines per service kept when dumping the stack's logs after a failure. Enough
+# to cover a service's boot and its last work, short enough that the cause is
+# not buried under six boot logs.
+MIGRATION_TIER1_LOG_TAIL := "200"
+
+# Archetypes sharing one live stack are kept apart by their IDENTITIES, not by
+# their windows: every archetype in MIGRATION_TIER1_ARCHETYPES declares trace
+# service names, metric names and a log job that no other one declares, so all
+# of them can occupy the same fixture window without any search seeing another
+# archetype's data. test/regression/migration_tier1_test.go enforces that
+# pairwise disjointness, so adding a ninth archetype that reuses a name fails
+# the required `check` lane rather than a 45-minute Docker job.
+#
+# Pushing each archetype into its own earlier window (cmd/seed's
+# --window-offset) was the previous mechanism and is arithmetically impossible
+# for more than one archetype: disjoint windows need an offset of at least
+# seed.SeedWindow (30m), and reference Tempo's 1h wal.ingestion_time_range_slack
+# rejects any offset where offset + SeedWindow >= 1h. Every value satisfying one
+# constraint violates the other, so the second archetype could never seed. The
+# flag remains on cmd/seed — it is a real capability with a correct guard — but
+# nothing here uses it.
 
 # Load the deterministic all-signal fixture into the running stack: one
 # in-memory fixture per archetype, each written twice — directly into
@@ -1306,16 +1316,13 @@ MIGRATION_TIER1_WINDOW_STEP_MIN := "45"
 migration-tier1-seed archetype="":
     @archetypes="{{archetype}}"; \
     [ -n "$archetypes" ] || archetypes="{{MIGRATION_TIER1_ARCHETYPES}}"; \
-    offset=0; \
     for a in $archetypes; do \
         manifest="test/e2e/migration/.out/manifest.json"; \
         [ "$a" = "three-signal" ] || manifest="test/e2e/migration/.out/manifest-$a.json"; \
-        echo "==> migration tier-1 seed ($a, window offset ${offset}m, manifest $manifest)"; \
+        echo "==> migration tier-1 seed ($a, manifest $manifest)"; \
         go run ./test/e2e/migration/cmd/seed \
             --fixture test/e2e/migration/archetypes/$a/seed/fixture.json \
-            --manifest "$manifest" \
-            --window-offset "${offset}m"; \
-        offset=$((offset + {{MIGRATION_TIER1_WINDOW_STEP_MIN}})); \
+            --manifest "$manifest"; \
     done
 
 # Assert the Tier-1 substrate contract against the seeded stack: the collector
@@ -1338,6 +1345,15 @@ migration-tier1-run:
     go test -tags=migration_tier1 -count=1 ./test/e2e/migration/tiers/tier1-dual/...
     @echo "==> migration tier-1 substrate + parity assertions"
     go test -tags=migration_tier1 -count=1 ./test/e2e/migration/
+
+# Every service's log, for when an assertion fails and the reason is upstream
+# of the assertion — a collector that never provisioned the schema, a reference
+# backend that never became ready. CI runs this on failure only; the tail bound
+# keeps a red run readable instead of burying the cause under a boot log.
+migration-tier1-logs:
+    @echo "==> migration tier-1 stack logs"
+    docker compose -f test/e2e/migration/tiers/tier1-dual/docker-compose.dual.yml \
+        logs --no-color --tail {{MIGRATION_TIER1_LOG_TAIL}}
 
 # Tear the Tier-1 stack down. `-v` is mandatory, not cosmetic: the reference
 # images declare their own VOLUMEs, and a surviving volume would carry one

--- a/test/e2e/migration/archetypes/kube-prometheus-stack/seed/fixture.json
+++ b/test/e2e/migration/archetypes/kube-prometheus-stack/seed/fixture.json
@@ -1,5 +1,5 @@
 {
-  "services": ["frontend", "checkout", "recommendation"],
+  "services": ["frontend", "cart", "recommendation"],
   "http_status_codes": ["200", "404", "500", "503"],
   "log_formats": ["json", "logfmt"],
   "log_job": "cerberus-migration-kube-prometheus-stack",

--- a/test/e2e/migration/seed/drift.go
+++ b/test/e2e/migration/seed/drift.go
@@ -33,11 +33,27 @@ import (
 // values at all.
 const DriftFactor = 2.0
 
-// driftStatusCode is the label value the injected series carries. It is
-// deliberately outside the declared status-code list, so the injected series
-// is a NEW member of its group rather than a second copy of an existing
-// series — a duplicate row would leave the group sum ambiguous.
-const driftStatusCode = "503"
+// driftMarkerLabel / driftMarkerValue tag every injected row with a label no
+// archetype's data declaration can produce, which is what makes an injected
+// row identifiable as injected.
+//
+// This was previously an out-of-range `http_status_code` value (503). That only
+// held while ONE archetype was seeded: the value has to be absent from the
+// DECLARED status-code list, and the two archetypes the lane now seeds together
+// declare different lists — kube-prometheus-stack declares 503 legitimately.
+// The pristine guard then counted 363 perfectly ordinary fixture rows as a
+// previous run's injection and refused to run the parity lane at all. A
+// dedicated marker cannot collide with fixture data whatever an archetype
+// declares.
+//
+// The injected series still lands as a NEW member of its group rather than a
+// second copy of an existing one — the extra label makes its attribute set
+// distinct — so the group sum stays unambiguous, which is what the
+// out-of-range status code was for.
+const (
+	driftMarkerLabel = "cerberus_migration_injected_drift"
+	driftMarkerValue = "1"
+)
 
 // DriftRowCount reports how many injected drift rows ClickHouse currently
 // holds. The negative control deliberately corrupts the ClickHouse side, so a
@@ -48,7 +64,7 @@ const driftStatusCode = "503"
 func DriftRowCount(ctx context.Context, conn driver.Conn) (uint64, error) {
 	const countSQL = "SELECT count() FROM otel_metrics_gauge WHERE Attributes[?] = ?"
 	var n uint64
-	if err := conn.QueryRow(ctx, countSQL, statusCodeLabel, driftStatusCode).Scan(&n); err != nil {
+	if err := conn.QueryRow(ctx, countSQL, driftMarkerLabel, driftMarkerValue).Scan(&n); err != nil {
 		return 0, fmt.Errorf("count injected drift rows: %w", err)
 	}
 	return n, nil
@@ -86,7 +102,7 @@ func InjectGaugeDrift(ctx context.Context, conn driver.Conn, f Fixture, service 
 	resource := resourceAttributes(service)
 	driftAttributes := sortedAttrs(map[string]string{
 		serviceNameLabel: service,
-		statusCodeLabel:  driftStatusCode,
+		driftMarkerLabel: driftMarkerValue,
 	})
 	for _, t := range f.Window.SampleTimes() {
 		value := base[t.UnixMilli()] * DriftFactor

--- a/test/e2e/migration/steps/then_correlation.go
+++ b/test/e2e/migration/steps/then_correlation.go
@@ -62,7 +62,17 @@ type correlationProbe struct {
 	// real log record in this window actually carries. It seeds the LogQL
 	// query's time bound but is deliberately NOT what drives the trace-by-id
 	// fetch — see traceIDInLineRe.
-	wantTraceID   string
+	wantTraceID string
+	// wantRecordTime is the timestamp of the record wantTraceID was taken
+	// from. It is reported on failure so a mismatch says WHICH record the
+	// oracle pinned, without which "returned X, wanted Y" cannot be told
+	// apart from the query having simply started somewhere else.
+	wantRecordTime time.Time
+	// responseShape describes how many streams the live query matched and how
+	// its leading entries were ordered — the evidence that separates "the
+	// selector stopped pinning one stream" from "cerberus resolved the wrong
+	// trace".
+	responseShape string
 	wantSpanCount int
 
 	// Populated by the When step from what cerberus's own responses said.
@@ -140,11 +150,12 @@ func (w *World) givenCorrelationProbe() error {
 		// traced line the query returns need not be THIS record's stream at
 		// all. Pinning every label narrows the query to the exact stream the
 		// picked record belongs to.
-		logSelector:   logQLSelectorFor(stream.Labels),
-		logStart:      manifest.VerifyStart,
-		logEnd:        manifest.VerifyEnd,
-		wantTraceID:   record.TraceID,
-		wantSpanCount: spans,
+		logSelector:    logQLSelectorFor(stream.Labels),
+		logStart:       manifest.VerifyStart,
+		logEnd:         manifest.VerifyEnd,
+		wantTraceID:    record.TraceID,
+		wantRecordTime: record.Time,
+		wantSpanCount:  spans,
 	}
 	return nil
 }
@@ -231,10 +242,11 @@ func (w *World) whenResolveCorrelation() error {
 		return fmt.Errorf("no correlation probe established; the scenario must establish one first")
 	}
 
-	line, err := correlationQueryLogs(w.live.CerberusURL, w.correlation.logSelector, w.correlation.logStart, w.correlation.logEnd)
+	line, shape, err := correlationQueryLogs(w.live.CerberusURL, w.correlation.logSelector, w.correlation.logStart, w.correlation.logEnd)
 	if err != nil {
 		return fmt.Errorf("migration harness: query cerberus's log API: %w", err)
 	}
+	w.correlation.responseShape = shape
 	m := traceIDInLineRe.FindStringSubmatch(line)
 	if m == nil {
 		return fmt.Errorf("cerberus returned a log line carrying no recognisable trace_id: %q", line)
@@ -270,34 +282,85 @@ const correlationLogLimit = 500
 
 // correlationQueryLogs issues one LogQL query_range against base (cerberus's
 // own base URL) and returns the first returned line carrying any trace_id
-// token, failing when the query itself fails or returns nothing at all.
-func correlationQueryLogs(base, selector string, start, end time.Time) (string, error) {
+// token, together with a description of the shape the response came back in.
+//
+// The shape is returned rather than discarded because "the first traced line"
+// is only well-defined when the selector matched exactly ONE stream. The
+// selector pins every label of the picked stream precisely so that holds; if
+// it ever stops holding, "first" silently means "first of whichever stream the
+// backend happened to order first", and the mismatch that surfaces upstream is
+// indistinguishable from a genuine correlation bug. The caller reports this in
+// its failure message so one CI run tells the two apart.
+func correlationQueryLogs(base, selector string, start, end time.Time) (string, string, error) {
 	q := base + "/loki/api/v1/query_range?query=" + url.QueryEscape(selector) +
 		"&start=" + strconv.FormatInt(start.UnixNano(), 10) +
 		"&end=" + strconv.FormatInt(end.UnixNano(), 10) +
 		"&direction=forward&limit=" + strconv.Itoa(correlationLogLimit)
 	body, err := correlationGET(q)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	var resp lokiQueryRangeResponse
 	if err := json.Unmarshal(body, &resp); err != nil {
-		return "", fmt.Errorf("decode loki query_range response: %w", err)
+		return "", "", fmt.Errorf("decode loki query_range response: %w", err)
 	}
 	if resp.Status != "success" {
-		return "", fmt.Errorf("loki query_range status %q, want success", resp.Status)
+		return "", "", fmt.Errorf("loki query_range status %q, want success", resp.Status)
 	}
+
+	shape := describeLogResponse(resp)
 	for _, res := range resp.Data.Result {
 		for _, v := range res.Values {
 			if len(v) < 2 {
 				continue
 			}
 			if traceIDInLineRe.MatchString(v[1]) {
-				return v[1], nil
+				return v[1], shape, nil
 			}
 		}
 	}
-	return "", fmt.Errorf("cerberus returned no log line carrying a trace_id for selector %s", selector)
+	return "", shape, fmt.Errorf("cerberus returned no log line carrying a trace_id for selector %s (%s)",
+		selector, shape)
+}
+
+// correlationShapeStreams bounds how many streams describeLogResponse names
+// individually. One is the expected case; more than a handful means the
+// selector is not pinning a stream at all, which the count alone already says.
+const correlationShapeStreams = 4
+
+// correlationShapeEntries bounds how many leading entries of the first stream
+// are timestamped in the description. Enough to see whether the backend
+// ordered forward and where the first traced line sits, short enough that a
+// failure message stays readable.
+const correlationShapeEntries = 5
+
+// describeLogResponse renders the returned streams and the first few entries
+// of the first one, so a failing correlation assertion carries the evidence
+// needed to attribute it: how many streams matched, their labels, and the
+// leading timestamps in the order the backend returned them.
+func describeLogResponse(resp lokiQueryRangeResponse) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d stream(s) returned", len(resp.Data.Result))
+	for i, res := range resp.Data.Result {
+		if i >= correlationShapeStreams {
+			fmt.Fprintf(&b, "; +%d more", len(resp.Data.Result)-correlationShapeStreams)
+			break
+		}
+		fmt.Fprintf(&b, "; [%d] labels=%v entries=%d", i, res.Stream, len(res.Values))
+	}
+	if len(resp.Data.Result) > 0 {
+		b.WriteString("; first stream's leading entries:")
+		for i, v := range resp.Data.Result[0].Values {
+			if i >= correlationShapeEntries {
+				break
+			}
+			if len(v) < 2 {
+				continue
+			}
+			fmt.Fprintf(&b, " (ts=%s traced=%v)", v[0], traceIDInLineRe.MatchString(v[1]))
+		}
+	}
+	return b.String()
 }
 
 // tempoTraceByIDResponse is cerberus's trace-by-id JSON envelope: one
@@ -437,8 +500,14 @@ func (w *World) thenLogLineCarriesFixtureTraceID() error {
 		return err
 	}
 	if w.correlation.logLineTraceID != w.correlation.wantTraceID {
-		return fmt.Errorf("cerberus's log query returned trace_id %s, the fixture wrote %s for this record",
-			w.correlation.logLineTraceID, w.correlation.wantTraceID)
+		return fmt.Errorf("cerberus's log query returned trace_id %s, the fixture wrote %s for the record at %s "+
+			"(selector %s over [%s, %s]; %s)",
+			w.correlation.logLineTraceID, w.correlation.wantTraceID,
+			w.correlation.wantRecordTime.UTC().Format(time.RFC3339Nano),
+			w.correlation.logSelector,
+			w.correlation.logStart.UTC().Format(time.RFC3339Nano),
+			w.correlation.logEnd.UTC().Format(time.RFC3339Nano),
+			w.correlation.responseShape)
 	}
 	return nil
 }

--- a/test/e2e/migration/steps/then_correlation.go
+++ b/test/e2e/migration/steps/then_correlation.go
@@ -146,10 +146,13 @@ func (w *World) givenCorrelationProbe() error {
 		archetype:   a,
 		// Every label in the stream (not just job) — the fixture crosses
 		// every service with every log format under the SAME job label, so a
-		// job-only selector matches every stream at once and the first
-		// traced line the query returns need not be THIS record's stream at
-		// all. Pinning every label narrows the query to the exact stream the
-		// picked record belongs to.
+		// job-only selector would sweep in far more than this record's data.
+		//
+		// It still does not pin ONE live stream, and must not be relied on to:
+		// cerberus synthesizes `detected_level` the way Loki does, a label the
+		// fixture never declares, so this selector matches one live stream per
+		// detected level. The record is identified by its timestamp in
+		// correlationQueryLogs, not by its position in the response.
 		logSelector:    logQLSelectorFor(stream.Labels),
 		logStart:       manifest.VerifyStart,
 		logEnd:         manifest.VerifyEnd,
@@ -242,7 +245,8 @@ func (w *World) whenResolveCorrelation() error {
 		return fmt.Errorf("no correlation probe established; the scenario must establish one first")
 	}
 
-	line, shape, err := correlationQueryLogs(w.live.CerberusURL, w.correlation.logSelector, w.correlation.logStart, w.correlation.logEnd)
+	line, shape, err := correlationQueryLogs(w.live.CerberusURL, w.correlation.logSelector,
+		w.correlation.logStart, w.correlation.logEnd, w.correlation.wantRecordTime)
 	if err != nil {
 		return fmt.Errorf("migration harness: query cerberus's log API: %w", err)
 	}
@@ -291,7 +295,7 @@ const correlationLogLimit = 500
 // backend happened to order first", and the mismatch that surfaces upstream is
 // indistinguishable from a genuine correlation bug. The caller reports this in
 // its failure message so one CI run tells the two apart.
-func correlationQueryLogs(base, selector string, start, end time.Time) (string, string, error) {
+func correlationQueryLogs(base, selector string, start, end, at time.Time) (string, string, error) {
 	q := base + "/loki/api/v1/query_range?query=" + url.QueryEscape(selector) +
 		"&start=" + strconv.FormatInt(start.UnixNano(), 10) +
 		"&end=" + strconv.FormatInt(end.UnixNano(), 10) +
@@ -308,19 +312,52 @@ func correlationQueryLogs(base, selector string, start, end time.Time) (string, 
 		return "", "", fmt.Errorf("loki query_range status %q, want success", resp.Status)
 	}
 
+	// Find the entry at the ORACLE's own instant, across every returned
+	// stream — never "the first traced line of the first stream".
+	//
+	// The fixture's stream label set is not the live stream's: cerberus
+	// synthesizes `detected_level` the way Loki does, so a selector pinning
+	// every label the FIXTURE declares still matches one live stream per
+	// detected level (three, here). Position is then meaningless — which
+	// stream comes back first is not ordered by anything the probe controls,
+	// and the leading line of whichever arrived first belongs to a different
+	// record on different runs. That is a flake, and it read as a correlation
+	// mismatch.
+	//
+	// The timestamp is the identity the oracle actually pinned, so matching on
+	// it is both deterministic and a stronger claim than "some traced line
+	// came back": it holds cerberus to returning THIS record.
 	shape := describeLogResponse(resp)
+	wantNano := strconv.FormatInt(at.UnixNano(), 10)
+	var found []string
 	for _, res := range resp.Data.Result {
 		for _, v := range res.Values {
-			if len(v) < 2 {
+			if len(v) < 2 || v[0] != wantNano {
 				continue
 			}
-			if traceIDInLineRe.MatchString(v[1]) {
-				return v[1], shape, nil
-			}
+			found = append(found, v[1])
 		}
 	}
-	return "", shape, fmt.Errorf("cerberus returned no log line carrying a trace_id for selector %s (%s)",
-		selector, shape)
+	switch len(found) {
+	case 0:
+		return "", shape, fmt.Errorf(
+			"cerberus returned no log line at %s (the instant the fixture's picked record carries) for selector %s (%s)",
+			at.UTC().Format(time.RFC3339Nano), selector, shape,
+		)
+	case 1:
+		if !traceIDInLineRe.MatchString(found[0]) {
+			return "", shape, fmt.Errorf("cerberus's log line at %s carries no trace_id: %q (%s)",
+				at.UTC().Format(time.RFC3339Nano), found[0], shape)
+		}
+		return found[0], shape, nil
+	default:
+		// Two lines at one instant under one selector means the selector no
+		// longer identifies a single record, so "the" trace_id is undefined.
+		return "", shape, fmt.Errorf(
+			"cerberus returned %d log lines at %s for selector %s, so no single record is identified (%s)",
+			len(found), at.UTC().Format(time.RFC3339Nano), selector, shape,
+		)
+	}
 }
 
 // correlationShapeStreams bounds how many streams describeLogResponse names

--- a/test/regression/migration_tier1_test.go
+++ b/test/regression/migration_tier1_test.go
@@ -308,6 +308,82 @@ func TestMigrationTier1ReferencePrometheusIsWriteOnly(t *testing.T) {
 	}
 }
 
+// TestMigrationTier1ArchetypeIdentitiesAreDisjoint is the invariant that lets
+// every tier-1 archetype share ONE fixture window on ONE live stack.
+//
+// The seeder writes each archetype into the same reference backends over the
+// same interval, so nothing but the names keeps them apart. Reference Tempo's
+// /api/search is per-service and its settle gate demands EXACTLY the trace
+// count this run pushed, so two archetypes declaring the same service name
+// make the second seed fail — which is precisely how the previous mechanism
+// broke: three-signal and kube-prometheus-stack both declared "checkout".
+//
+// The alternative — pushing each archetype into its own earlier window via
+// cmd/seed's --window-offset — cannot work for more than one archetype:
+// disjoint windows need an offset >= seed.SeedWindow, while reference Tempo's
+// ingestion slack rejects offset+SeedWindow >= 1h. No value satisfies both.
+// Disjoint identities have no such ceiling, so this pin is what replaces it.
+//
+// It reads the archetype list out of the Justfile rather than restating it, so
+// a ninth archetype is covered the moment it is seeded.
+func TestMigrationTier1ArchetypeIdentitiesAreDisjoint(t *testing.T) {
+	t.Parallel()
+
+	buf, err := os.ReadFile("../../Justfile")
+	if err != nil {
+		t.Fatalf("read Justfile: %v", err)
+	}
+	archetypes := justVariableList(t, string(buf), "MIGRATION_TIER1_ARCHETYPES")
+	if len(archetypes) < 2 {
+		t.Fatalf("MIGRATION_TIER1_ARCHETYPES lists %d archetype(s) (%v); with fewer than two "+
+			"sharing a stack this invariant would assert nothing", len(archetypes), archetypes)
+	}
+
+	// owner maps each declared identity to the archetype that claimed it, so a
+	// collision names BOTH sides instead of only the second one.
+	owner := map[string]string{}
+	for _, a := range archetypes {
+		path := filepath.Join("..", "..", "test", "e2e", "migration", "archetypes", a, "seed", "fixture.json")
+		decl, err := seed.LoadDeclaration(path)
+		if err != nil {
+			t.Fatalf("archetype %s is seeded by the tier-1 lane but its data declaration does not load: %v", a, err)
+		}
+		// Every identity that reaches a shared backend as a queryable name.
+		// The kind prefix keeps a service named like a metric from reading as
+		// a collision when the two could never be searched the same way.
+		identities := []string{
+			"log-job/" + decl.LogJob,
+			"metric/" + decl.GaugeMetric,
+			"metric/" + decl.CounterMetric,
+			"metric/" + decl.HistogramMetric,
+		}
+		for _, svc := range decl.Services {
+			identities = append(identities, "service/"+svc)
+		}
+		for _, id := range identities {
+			if prev, taken := owner[id]; taken {
+				t.Fatalf("archetypes %s and %s both declare %s; they are seeded into one live stack over one "+
+					"window, so the shared name makes each one's queries see the other's data "+
+					"(reference Tempo's per-service settle gate fails outright). Rename it in "+
+					"test/e2e/migration/archetypes/%s/seed/fixture.json", prev, a, id, a)
+			}
+			owner[id] = a
+		}
+	}
+}
+
+// justVariableList reads a `NAME := "a b c"` Justfile assignment as a slice.
+func justVariableList(t *testing.T, justfile, name string) []string {
+	t.Helper()
+
+	re := regexp.MustCompile(`(?m)^` + regexp.QuoteMeta(name) + `\s*:=\s*"([^"]*)"`)
+	m := re.FindStringSubmatch(justfile)
+	if m == nil {
+		t.Fatalf("Justfile has no %s assignment; the tier-1 seed recipe reads its archetype list from it", name)
+	}
+	return strings.Fields(m[1])
+}
+
 // TestMigrationTier1JustfileRecipes pins the recipe shape the lane is driven
 // through: a `-run` recipe that actually passes the build tag (without it the
 // tagged assertions compile away to "no test files" and the lane reports green


### PR DESCRIPTION
## What

`just migration-tier1-seed` seeded the second archetype with
`--window-offset 45m`, which `cmd/seed` refuses: the offset pushes the fixture
window's start 1h15m before now, past reference Tempo's 1h
`wal.ingestion_time_range_slack`. The `migration-tier1` job died there on
every run — [run 30202532138](https://github.com/tsouza/cerberus/actions/runs/30202532138).

**No offset can work.** Disjoint windows need an offset of at least
`seed.SeedWindow` (30m); the slack guard rejects `offset + SeedWindow >= 1h`.
Every value satisfying one constraint violates the other, so the mechanism
could never seed more than one archetype.

## The fix

Keep archetypes apart by their **identities** instead — no ceiling. The only
collision was the `"checkout"` trace service, declared by both `three-signal`
and `kube-prometheus-stack`. Reference Tempo's `/api/search` is per-service and
its settle gate demands exactly the trace count this run pushed, so the shared
name is what made an overlapping window unusable in the first place.
`kube-prometheus-stack`'s becomes `"cart"`; every metric name and log job was
already distinct.

`TestMigrationTier1ArchetypeIdentitiesAreDisjoint` pins it, reading the
archetype list out of the Justfile rather than restating it, so a ninth
archetype that reuses a name fails the required `check` lane instead of a
45-minute Docker job.

**Verified in both directions** — green as committed, and red with `"checkout"`
put back:

```
[FAIL] TestMigrationTier1ArchetypeIdentitiesAreDisjoint
  archetypes three-signal and kube-prometheus-stack both declare service/checkout
```

`cmd/seed`'s `--window-offset` flag stays: it is a real capability with a
correct guard, and that guard's error message is what diagnosed this. Nothing
uses it now.

## Also — tier-1 CI hygiene

The `migration-tier1` job lacked what every other Docker-backed lane has:

- disk reclaim before six image pulls (`jlumbroso/free-disk-space`, same pin as `e2e.yml`)
- a secret-gated Docker Hub login, so a cold runner is not rate-limited mid-`compose up`
- `just migration-tier1-logs` on failure — a red run was previously undiagnosable
- the `story` dispatch input forwarded to the tier-1 suite (it reached only tier0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)