### PR TITLE
fix(ci): run the tier a job was given, not the closure of what it needs

### DIFF
--- a/.github/scripts/migration-e2e.mjs
+++ b/.github/scripts/migration-e2e.mjs
@@ -1042,15 +1042,34 @@ const RUN_TIERS = {
   tier2: { pkg: TIER2_PACKAGE, buildTag: MIGRATION_TIER2_BUILD_TAG },
 };
 
+// tierToRun reads MODE=run's TIER as the ONE tier this job executes.
+//
+// Deliberately NOT [requestedTiers]: that answers a different question. It
+// resolves a DISPATCH input into the set of jobs to schedule, so it closes
+// over TIER_NEEDS — `tier2` selects tier1 too, because tier2's job needs
+// tier1's substrate stood up before it can prove firing parity. That closure
+// is right for scheduling and wrong here: migration-tier2 depending on
+// migration-tier1 does not mean migration-tier2 runs tier1's SCENARIOS.
+// Routing MODE=run through the scheduler's resolver made every tier2 job
+// abort with `TIER "tier2" resolved to [tier1, tier2]` before it ran a single
+// step — the tier could be dispatched but never executed (run 30216721405).
+//
+// A tier job's TIER is a literal in its YAML stanza, so the only valid input
+// is one RUN_TIERS key; `all` and an unknown name are both refused by the
+// table lookup.
+export function tierToRun(tierInput) {
+  const raw = (tierInput || '').trim().toLowerCase();
+  return Object.hasOwn(RUN_TIERS, raw) ? raw : null;
+}
+
 function runRun() {
   const scenarios = loadScenarios();
   const story = (process.env.STORY || '').trim();
-  const tiers = requestedTiers(process.env.TIER, scenarios);
-  const tier = tiers === null || tiers.length !== 1 ? null : tiers[0];
+  const tier = tierToRun(process.env.TIER);
   const run = tier === null ? undefined : RUN_TIERS[tier];
   if (run === undefined) {
     error(
-      `migration-e2e: MODE=run drives one tier at a time (${Object.keys(RUN_TIERS).join(', ')}); TIER "${process.env.TIER || 'all'}" resolved to ${tiers === null ? 'an unknown tier' : `[${tiers.join(', ')}]`}`,
+      `migration-e2e: MODE=run drives one tier at a time (${Object.keys(RUN_TIERS).join(', ')}); TIER "${process.env.TIER || ''}" names none of them`,
     );
     process.exit(1);
   }

--- a/.github/scripts/migration-e2e.test.mjs
+++ b/.github/scripts/migration-e2e.test.mjs
@@ -28,6 +28,7 @@ import {
   attestedCount,
   reportPathFor,
   requestedTiers,
+  tierToRun,
   nonRunnableTiers,
   tiersWithScenarios,
   storiesForTier,
@@ -529,6 +530,30 @@ test('narrowing to a tier also selects the tiers its job needs', () => {
   // operator asked for as failed (observed: run 30210906040). Selecting a tier
   // must select whatever makes it runnable.
   assert.deepEqual(requestedTiers('tier2', world().scenarios), ['tier1', 'tier2']);
+});
+
+test('the tier a job RUNS is its own, not the closure of what its job needs', () => {
+  // The two resolvers answer different questions and must not be swapped.
+  // requestedTiers schedules JOBS, so it closes over TIER_NEEDS; tierToRun
+  // names the ONE tier a job executes. Routing MODE=run through the scheduler
+  // aborted every tier2 job with `TIER "tier2" resolved to [tier1, tier2]`
+  // before its first step (run 30216721405): needing tier1's substrate is not
+  // running tier1's scenarios.
+  for (const tier of KNOWN_TIERS) assert.equal(tierToRun(tier), tier);
+  assert.equal(tierToRun('TIER2'), 'tier2');
+  assert.equal(tierToRun(' tier1 '), 'tier1');
+  // A runner drives one tier; `all`, empty and unknown names are all refused
+  // rather than silently widened.
+  assert.equal(tierToRun('all'), null);
+  assert.equal(tierToRun(''), null);
+  assert.equal(tierToRun(undefined), null);
+  assert.equal(tierToRun('nightly'), null);
+});
+
+test('every tier a job can be told to run has a runner behind that name', () => {
+  // tierToRun refuses anything outside RUN_TIERS, so a tier the tree declares
+  // but RUN_TIERS omits would be dispatchable, selectable — and unrunnable.
+  for (const tier of KNOWN_TIERS) assert.ok(tierToRun(tier) !== null, `${tier} has no runner`);
 });
 
 // --- 3. the PASS-assertion pin ----------------------------------------------


### PR DESCRIPTION
\`migration-tier2\` has never executed a scenario. Every run of it aborted before its first step:

\`\`\`
migration-e2e: MODE=run drives one tier at a time (tier0, tier1, tier2);
TIER "tier2" resolved to [tier1, tier2]
\`\`\`

(run [30216721405](https://github.com/tsouza/cerberus/actions/runs/30216721405/job/89832966964), where tier0 and tier1 both passed.)

## Two questions, one resolver

`MODE=run` read its `TIER` through `requestedTiers` — the **scheduler's** resolver. That function turns a dispatch input into the set of *jobs to schedule*, so it closes over `TIER_NEEDS` and selects `tier1` whenever `tier2` is asked for. That closure is correct for scheduling: `migration-tier2` `needs:` `migration-tier1`, because tier2 proves ruler firing parity against the substrate tier1 stands up, and selecting tier2 alone would gate tier1 off and skip tier2 through the needs-cascade (the bug fixed for dispatch in #1283).

It is the wrong answer for execution. Depending on `migration-tier1` does not mean running **tier1's scenarios**. The runner's single-tier guard then correctly refused the two-element list — so tier2 was dispatchable, selectable, and unrunnable.

`tierToRun` now answers the execution question directly: `TIER` is a literal in the job's YAML stanza, so the only valid input is one `RUN_TIERS` key, and `all` / empty / an unknown name are refused by the table lookup rather than silently widened. `requestedTiers` keeps the needs-closure and keeps its single caller, `runEmit`.

## Why the guard didn't catch it

The guard fired exactly as designed — it just fired on input that should never have reached it. Nothing tested the two resolvers against the same tier, so their divergence was invisible until tier2 first got far enough to try to run. Two tests close that:

- the resolvers are held apart on the precise input that broke — `tierToRun('tier2')` is `'tier2'` while `requestedTiers('tier2')` is still `['tier1','tier2']`, so swapping them back fails here;
- every tier the tree declares must have a runner behind its name, so a tier that is dispatchable but unrunnable fails in the unit tests rather than after a full compose stack has been stood up in CI.

57/57 green.

## What this does not yet prove

Tier-2's scenarios have now been **unblocked, not yet observed passing** — this is the first time they can execute at all, so their first real run is on this PR. If they surface genuine assertion failures, those are separate bugs to fix on top; I'll drive them from here rather than leave the tier half-proven.