### PR TITLE
test(mutation): reclaim uncovered files and pin the leg partition

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -194,7 +194,7 @@ jobs:
             # Mutate only lower.go (~50 KB, the package's largest
             # source file). Excludes every other logql source plus the
             # lsyntax subtree (own dedicated legs below).
-            exclude_files: '^lsyntax/|(binary|detected_level|dotted_labels|literal|label_fns|top_level_columns|range_aggregation|vector_aggregation|lang)\.go$'
+            exclude_files: '^lsyntax/|(binary|detected_level|dotted_labels|literal|label_fns|top_level_columns|range_aggregation|vector_aggregation|lang)\.go$|^logpattern/|^(doc|duration|ip|jsonpath|numbytes|pattern_filter|variants)\.go$'
           - phase: phase4-logql-aggregation
             scope: ./internal/logql
             efficacy: 95
@@ -202,29 +202,32 @@ jobs:
             # Mutate range_aggregation.go + vector_aggregation.go +
             # lang.go (~54 KB total). Excludes everything else.
             # Bar at 93 (not 95) — see round-10 rationale above.
-            exclude_files: '^lsyntax/|(binary|detected_level|dotted_labels|literal|label_fns|top_level_columns|lower)\.go$'
+            exclude_files: '^lsyntax/|(binary|detected_level|dotted_labels|literal|label_fns|top_level_columns|lower)\.go$|^logpattern/|^(doc|duration|ip|jsonpath|numbytes|pattern_filter|variants)\.go$'
           - phase: phase4-logql-other-a
             scope: ./internal/logql
             efficacy: 95
             workers: 1
-            # Mutate binary.go + detected_level.go (~21 KB total).
-            # Round 8's `other-a` (which also included
-            # dotted_labels.go) ran cleanly through these two
-            # files in ~2.5 min before OOMing inside
-            # dotted_labels.go; this slice now stops there.
-            # dotted_labels.go is also excluded globally via
-            # `.gremlins.yaml` (round 10); kept in the per-phase
-            # regex too as belt-and-braces in case gremlins
-            # treats CLI `--exclude-files` as an override rather
-            # than an additional filter.
-            exclude_files: '^lsyntax/|(lower|range_aggregation|vector_aggregation|lang|literal|label_fns|top_level_columns|dotted_labels)\.go$'
+            # Mutate binary.go + detected_level.go + dotted_labels.go
+            # (~21 KB total). Round 8's `other-a` OOM-killed the runner
+            # inside dotted_labels.go, which is why later rounds carved
+            # it out. That was the runaway-mutant class — now bounded by
+            # --timeout-max — so the file is mutated here again rather
+            # than left uncovered.
+            exclude_files: '^lsyntax/|(lower|range_aggregation|vector_aggregation|lang|literal|label_fns|top_level_columns)\.go$|^logpattern/|^(doc|duration|ip|jsonpath|numbytes|pattern_filter|variants)\.go$'
           - phase: phase4-logql-other-b
             scope: ./internal/logql
             efficacy: 95
             workers: 1
-            # Mutate literal.go + label_fns.go +
-            # top_level_columns.go (~21 KB total). Unchanged from
-            # round 8.
+            # The catch-all leg: literal.go + label_fns.go +
+            # top_level_columns.go, plus every file no other leg claims
+            # (doc.go, duration.go, ip.go, jsonpath.go, numbytes.go,
+            # pattern_filter.go, variants.go, logpattern/). Those
+            # stragglers used to fall through all four ./internal/logql
+            # legs' regexes, so they were mutated four times over; they
+            # are now excluded from the other three and land here.
+            # A file newly added to internal/logql needs no edit — it is
+            # picked up here automatically, which is why this leg keeps
+            # no positive file list to fall out of sync.
             exclude_files: '^lsyntax/|(lower|range_aggregation|vector_aggregation|lang|binary|detected_level|dotted_labels)\.go$'
           - phase: phase4-logql-parser
             scope: ./internal/logql/lsyntax
@@ -233,19 +236,16 @@ jobs:
             # Mutate parser.go only (~27 KB, the recursive-descent
             # LogQL parser — the densest control-flow surface in the
             # package, same shape as phase4-traceql-parser below).
-            # dotted_labels.go stays excluded here too: it is
-            # structurally un-mutatable on ubuntu-latest regardless of
-            # which package it lives in (rounds 9-10 above).
-            exclude_files: '^dotted_labels\.go$|^(ast|binop|errors|labelfilter|lexer|ops|string)\.go$'
+            # dotted_labels.go belongs to the phase4-logql-lsyntax leg.
+            exclude_files: '^(ast|binop|dotted_labels|errors|labelfilter|lexer|ops|string)\.go$'
           - phase: phase4-logql-lsyntax
             scope: ./internal/logql/lsyntax
             efficacy: 95
             workers: 1
             # Mutate the rest of the lsyntax package (AST node defs,
-            # lexer, label-filter matching, operators); parser.go runs
-            # in its own leg above. dotted_labels.go excluded — see
-            # phase4-logql-parser.
-            exclude_files: '^dotted_labels\.go$|^parser\.go$'
+            # lexer, label-filter matching, operators, dotted-label
+            # normalisation); parser.go runs in its own leg above.
+            exclude_files: '^parser\.go$'
           # phase4-traceql historically OOM-killed the ubuntu-latest runner
           # (~7 GB RAM) after ~3 minutes. The original monolithic phase
           # contained ~109 timeout-inducing mutants in the recursive-descent

--- a/.gremlins.yaml
+++ b/.gremlins.yaml
@@ -24,44 +24,13 @@ mutants:
     enabled: true
 test:
   timeout-coefficient: 4
-excluded-files:
-  - "**/*_test.go"
-  - "internal/api/**"
-  - "cmd/**"
-  - "**/doc.go"
-  # `dotted_labels.go` is structurally un-mutatable on the
-  # ubuntu-latest runner (~7 GB RAM), regardless of which package it
-  # lives in. Rounds 4-9 of PR #664 walked the runner-budget knobs all
-  # the way down: workers=1, single-file `--exclude-files` slice (the
-  # file is only ~7 KB but the OTel dotted-label walker is the
-  # densest mutable surface in the package — ~40 mutants). Even the
-  # standalone single-file slice `phase4-logql-other-c` still
-  # received SIGTERM at ~3 min, having processed ~40 mutants of the
-  # file with every emitted mutant KILLED (0 LIVED). The bottleneck
-  # is cumulative gremlins-driver RSS plus each mutant's full
-  # `go test` cycle dragging the LogQL parser dep graph through the
-  # linker — not the file itself. Until either (a) gremlins exposes
-  # an incremental-test-binary mode that skips re-linking per mutant,
-  # or (b) the lane moves to a larger runner class, dotted_labels.go
-  # is excluded from gremlins runs. The file is still covered by
-  # Layer-2 TXTAR fixtures and the standalone unit tests alongside it.
-  #
-  # PR #1266 relocated the implementation from
-  # `internal/logql/dotted_labels.go` to
-  # `internal/logql/lsyntax/dotted_labels.go`; the entry below is kept
-  # as a filename match (gremlins' `--exclude-files` regexes are
-  # unanchored, so this matches the file at either path) so it stays
-  # correct across the move. NOTE: this top-level `excluded-files` key
-  # does not actually bind to gremlins' real config path
-  # (`unleash.exclude-files`, only reachable via nested `unleash:
-  # exclude-files:` or the `--exclude-files` CLI flag) — it has never
-  # been read by the gremlins binary. The exclusion that matters in
-  # practice is the per-leg `--exclude-files` CLI flag set in
-  # `.github/workflows/mutation.yml` for every phase4-logql-* /
-  # phase4-traceql-* leg, which is bound correctly. This entry is left
-  # here as documentation of intent pending a follow-up that fixes the
-  # key nesting; it has no effect today.
-  - "dotted_labels.go"
+# NOTE: there is deliberately no `excluded-files` key here. gremlins reads
+# exclusions from `unleash.exclude-files` (a single RE2 regex), so a
+# top-level `excluded-files:` list of globs is never read at all — this file
+# carried one for several rounds and it silently did nothing. Per-leg
+# exclusions live in `.github/workflows/mutation.yml` as the
+# `--exclude-files` CLI flag, which is bound correctly and is the only
+# mechanism that actually partitions files across legs.
 
 # Phased mutation-testing rollout. Each phase scopes gremlins to one
 # package with its own `--threshold-efficacy` bar enforced in

--- a/test/regression/mutation_leg_partition_test.go
+++ b/test/regression/mutation_leg_partition_test.go
@@ -1,0 +1,181 @@
+package regression
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// repoRoot locates the module root from this package's directory.
+const repoRoot = "../.."
+
+// testdataDir holds fixture inputs, not mutable production source.
+const testdataDir = "testdata"
+
+// mutationMatrixJob is the job whose matrix partitions packages across legs.
+const mutationMatrixJob = "mutate"
+
+// mutationWorkflow mirrors just enough of mutation.yml to read the leg matrix.
+// Everything else in the file is deliberately left untyped: this test pins the
+// file/leg partition, not the workflow's shape.
+type mutationWorkflow struct {
+	Jobs map[string]struct {
+		Strategy struct {
+			Matrix struct {
+				Include []mutationLeg `yaml:"include"`
+			} `yaml:"matrix"`
+		} `yaml:"strategy"`
+	} `yaml:"jobs"`
+}
+
+// mutationLeg is one matrix entry: a package scope plus the files it skips.
+type mutationLeg struct {
+	Phase        string `yaml:"phase"`
+	Scope        string `yaml:"scope"`
+	ExcludeFiles string `yaml:"exclude_files"`
+}
+
+// TestMutationLegsPartitionEveryScopedFile pins the invariant that every
+// mutable source file under a mutated package is claimed by exactly one leg.
+//
+// gremlins has no notion of "the set of files I am supposed to cover". Each leg
+// is an independent `--exclude-files` regex over its scope, so the partition is
+// only ever implied by the intersection of N hand-written regexes. Both ways of
+// getting that wrong are silent:
+//
+//   - A file excluded by every leg is mutated by nobody. Its efficacy is not
+//     reported as 0% — it is not reported at all, and the lane stays green while
+//     the file's tests go unmeasured. internal/logql/dotted_labels.go and
+//     internal/logql/lsyntax/dotted_labels.go sat in exactly this state, having
+//     been excluded round by round to stop an OOM that was really the runaway
+//     mutant class (see mutation_timeout_max_test.go).
+//   - A file excluded by no leg is mutated by all of them. Eight files under
+//     internal/logql were mutated four times over, quadrupling their share of
+//     the lane's runtime and folding their mutants into three efficacy bars that
+//     were never meant to own them.
+//
+// Neither shape can be seen by reading any single leg — which is why this is a
+// test and not a comment. A file added to a mutated package with no matching
+// leg is a real gap, so the fix is to claim it in a leg, never to widen an
+// exclusion until this passes.
+func TestMutationLegsPartitionEveryScopedFile(t *testing.T) {
+	t.Parallel()
+
+	raw, err := os.ReadFile(mutationWorkflowPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", mutationWorkflowPath, err)
+	}
+
+	var wf mutationWorkflow
+	if err := yaml.Unmarshal(raw, &wf); err != nil {
+		t.Fatalf("parse %s: %v", mutationWorkflowPath, err)
+	}
+
+	job, ok := wf.Jobs[mutationMatrixJob]
+	if !ok {
+		t.Fatalf("%s has no %q job; if the mutation matrix moved, re-point this test at it rather "+
+			"than deleting it — the partition it guards is still unenforced anywhere else.",
+			mutationWorkflowPath, mutationMatrixJob)
+	}
+
+	legs := job.Strategy.Matrix.Include
+	if len(legs) == 0 {
+		t.Fatalf("%s job %q declares no matrix legs; the partition check below would vacuously pass",
+			mutationWorkflowPath, mutationMatrixJob)
+	}
+
+	// claims[file] = the legs that mutate it.
+	claims := map[string][]string{}
+	scoped := map[string]bool{}
+
+	for _, leg := range legs {
+		if leg.Scope == "" {
+			t.Errorf("matrix leg %q has no scope", leg.Phase)
+
+			continue
+		}
+		dir := filepath.Join(repoRoot, filepath.FromSlash(strings.TrimPrefix(leg.Scope, "./")))
+
+		var exclude *regexp.Regexp
+		if leg.ExcludeFiles != "" {
+			exclude, err = regexp.Compile(leg.ExcludeFiles)
+			if err != nil {
+				t.Errorf("matrix leg %q has an uncompilable exclude_files %q: %v",
+					leg.Phase, leg.ExcludeFiles, err)
+
+				continue
+			}
+		}
+
+		for _, file := range mutableGoFiles(t, dir) {
+			rel, relErr := filepath.Rel(dir, file)
+			if relErr != nil {
+				t.Fatalf("relativise %s against %s: %v", file, dir, relErr)
+			}
+			scoped[file] = true
+			// gremlins matches exclude_files against the path relative to the
+			// scope argument, so match on that and not on the repo-relative path.
+			if exclude != nil && exclude.MatchString(filepath.ToSlash(rel)) {
+				continue
+			}
+			claims[file] = append(claims[file], leg.Phase)
+		}
+	}
+
+	if len(scoped) == 0 {
+		t.Fatalf("no mutable Go files found under any matrix scope in %s; the scopes are probably "+
+			"wrong, and every assertion below would vacuously pass", mutationWorkflowPath)
+	}
+
+	for file := range scoped {
+		shown := filepath.ToSlash(strings.TrimPrefix(file, repoRoot+string(filepath.Separator)))
+		switch owners := claims[file]; len(owners) {
+		case 1:
+		case 0:
+			t.Errorf("%s is mutated by no leg: every leg's exclude_files skips it, so its mutation "+
+				"efficacy is never measured and the lane stays green regardless of its tests. Claim "+
+				"it in exactly one leg.", shown)
+		default:
+			t.Errorf("%s is mutated by %d legs (%s): its mutants run once per leg, multiplying the "+
+				"lane's runtime and counting toward efficacy bars that were not meant to own it. "+
+				"Exclude it from all but one.", shown, len(owners), strings.Join(owners, ", "))
+		}
+	}
+}
+
+// mutableGoFiles returns the files gremlins can mutate under dir: non-test Go
+// sources, recursively. Test sources are excluded because gremlins mutates
+// production code only, and testdata because it holds fixtures rather than
+// compiled source.
+func mutableGoFiles(t *testing.T, dir string) []string {
+	t.Helper()
+
+	var out []string
+	err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if d.Name() == testdataDir {
+				return filepath.SkipDir
+			}
+
+			return nil
+		}
+		name := d.Name()
+		if strings.HasSuffix(name, ".go") && !strings.HasSuffix(name, "_test.go") {
+			out = append(out, path)
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", dir, err)
+	}
+
+	return out
+}


### PR DESCRIPTION
Follow-up to #1294. Now that `--timeout-max` bounds the runaway-mutant class,
the exclusions that were added to work around it can come back — and checking
the partition properly turned up a second, unrelated defect.

## 1. Files that no leg mutated

Both `dotted_labels.go` files — the `internal/logql` shim and the
`internal/logql/lsyntax` implementation — were excluded by **every** leg. Their
efficacy was not reported as 0%; it was not reported at all, and the lane stayed
green regardless of their tests.

Worth recording that the original diagnosis was wrong. `.gremlins.yaml` claimed
the file was *"structurally un-mutatable on the ubuntu-latest runner… the
bottleneck is cumulative gremlins-driver RSS plus each mutant's full `go test`
cycle dragging the LogQL parser dep graph through the linker — not the file
itself."* It is a 222-line byte-scanner with `out.WriteByte` inside its advance
loop: textbook runaway-mutant shape. It was the class #1294 fixes, misread as a
memory-ceiling problem, and each round of carving it out moved it closer to
invisible.

`lsyntax/dotted_labels.go` returns to `phase4-logql-lsyntax`; the shim returns to
`phase4-logql-other-a`, which owned it before round 8.

## 2. Files that four legs each mutated (pre-existing)

Eight files under `internal/logql` — `doc.go`, `duration.go`, `ip.go`,
`jsonpath.go`, `numbytes.go`, `pattern_filter.go`, `variants.go`, `logpattern/`
— matched no leg's exclusion alternation, so **all four** `./internal/logql`
legs mutated them. That quadrupled their share of the lane's runtime and folded
their mutants into three efficacy bars that were never meant to own them.
`phase4-logql-other-b`'s comment claimed it mutated three files; it was actually
mutating eleven.

This predates the PR (verified by re-running the check against `origin/main`:
`BURNED=2 DOUBLE=8` before, `BURNED=0 DOUBLE=0` after). It's the same file and
the same family, so it's fixed here rather than deferred.

## 3. `.gremlins.yaml`'s inert key

Dropped the top-level `excluded-files`. gremlins reads `unleash.exclude-files`, a
single RE2 regex — a top-level list of **globs** was never read on either count.
It had already been documented in-file as having "no effect today"; a config key
that has never once been consulted is worse than no key, because it reads as
intent.

## The pin

`TestMutationLegsPartitionEveryScopedFile` parses the matrix and asserts every
mutable file under a mutated scope is claimed by **exactly one** leg — catching
the zero-owner and the multi-owner shape in one invariant. Neither is visible
from reading any single leg, which is why it's a test and not a comment.

Verified failing in both directions against the pre-fix workflow:

- re-excluding `dotted_labels.go` everywhere → *"is mutated by no leg"* ×2
- restoring the straggler shape → *"is mutated by 4 legs (…)"* ×8

## Evidence

`mutation.yml`'s matrix is skipped on ordinary PRs, so this PR's own checks will
not exercise any of it. Dispatched
[run 30223035368](https://github.com/tsouza/cerberus/actions/runs/30223035368)
against the branch — that run puts `dotted_labels.go` back under mutation for the
first time since round 8, i.e. it is the real test of whether the `--timeout-max`
cap covers the case that OOM-killed the runner then. **Worth waiting for it
before merging**; if `phase4-logql-lsyntax` or `phase4-logql-other-a` dies the
same way, the cap is bounding something other than what killed those runs.
