### PR TITLE
feat(release): gate publish on migration-e2e and smoke the released artifact

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -228,26 +228,39 @@ wrapper, plus `appendStepSummary` / `setOutput` for the runner files.
     version-gate cannot definitively determine existence (fails closed, with one
     `::error::`).
 - **`release-preflight.mjs`** — `release.yml`, the `preflight` job. The
-  green-check guard for the MAINTENANCE-line release path ONLY (a push to a
-  `release/<major>.<minor>.x` hotfix branch). A push to `main` is implicitly
-  green (branch protection won't merge a red/behind PR), so the main path runs
-  no preflight; a `release/*.x` push has no PR gate, so before the publish jobs
-  run this re-reads the pushed commit's check-runs + legacy statuses via the
-  GitHub API and FAILS the release unless the commit is the branch tip AND every
-  non-self check is settled green (success / skipped / neutral). Because
-  `release.yml` fires on the SAME push as the CI workflows, the driver first
-  WAITS — polling the commit's check-SUITES (`allSuitesSettled`) until every
-  suite except this release run's own (resolved via `GITHUB_RUN_ID` ->
-  `check_suite_id`) is `completed` — THEN runs the one-shot green evaluation.
-  The wait is bounded (`maxWaitMs` ~50 min / `pollIntervalMs` ~30 s); on timeout
-  it ABORTS naming the still-running suites (fail-safe — never publish on an
-  incomplete state). The release
-  run's own jobs (`gate` / `preflight` / `goreleaser` / `chart-release`) are
-  excluded via `RELEASE_SELF_JOBS` (gating on in-flight self-jobs would
-  deadlock). Latest-per-name dedup means a green re-run supersedes an earlier
-  red. The publish jobs guard `needs.preflight.result == 'success' ||
-  == 'skipped'`, so the main path (preflight skipped) stays preflight-free while
-  a failed/cancelled maintenance preflight blocks the publish. It ALSO enforces
+  green-check guard for BOTH release paths, gated on the publish decision rather
+  than on the branch: it runs whenever `app_publish` or `chart_publish` is true,
+  in `mainline` mode on `main` and in `maintenance` mode on a
+  `release/<major>.<minor>.x` push. Before the publish jobs run it reads the
+  pushed commit's check-runs + legacy statuses via the GitHub API and FAILS the
+  release unless every check it gates is settled green (success / skipped /
+  neutral). Branch protection is not sufficient on either path: it can only
+  cover lanes eligible to BE a branch-protection check, and the heavyweight
+  push/schedule-only lanes (`migration-e2e`) are not.
+  **ABSENCE IS A FAILURE.** The gate is not derived from what the API returned —
+  `RELEASE_REQUIRED_CHECKS` is an EXPECTED SET, and a required lane that posted
+  no check-run on the commit is a blocking problem, not a silence. Three
+  degradations are themselves blocking problems: an EMPTY required set (the gate
+  would collapse back into an observational deny-list), a required name also
+  listed in `RELEASE_SELF_JOBS`, and a required name swallowed by a
+  `RELEASE_INFORMATIONAL_CHECKS` prefix. Because `release.yml` fires on the SAME
+  push as the CI workflows, the driver first WAITS — polling the commit's
+  check-SUITES (`allSuitesSettled`) until every suite except this release run's
+  own (resolved via `GITHUB_RUN_ID` -> `check_suite_id`) is `completed`, AND
+  polling `requiredChecksPending` until every required lane is present and
+  completed, so a lane that never starts times out loudly instead of reading as
+  settled. The wait is bounded (`releaseWaitMinutes` / `pollIntervalMs` ~30 s);
+  on timeout it ABORTS naming the missing lanes and the still-running suites
+  (fail-safe — never publish on an incomplete state). The release run's own jobs
+  (`gate` / `preflight` / `goreleaser` / `release-artifact-migration` /
+  `publish` / `brew-smoke` / `chart-release`) are excluded via
+  `RELEASE_SELF_JOBS`, along with their reusable-workflow children (`<self-job>
+  / <child>`, split on `REUSABLE_JOB_SEPARATOR`) — gating on in-flight self-jobs
+  would deadlock. Latest-per-name dedup means a green re-run supersedes an
+  earlier red. The branch-tip rule is `maintenance`-only: `main` legitimately
+  moves while a release waits on CI. The publish jobs guard
+  `needs.preflight.result == 'success'` with no `|| skipped` disjunction, since
+  the preflight now fires on every publishing run. It ALSO enforces
   the **release support-window / EOL policy** (`SUPPORTED_MINOR_LINES = 3`): the
   pushed line must be within the latest 3 minor lines (current + the two prior);
   a push to a line 3+ minors behind the current minor (derived from the stable
@@ -267,26 +280,68 @@ wrapper, plus `appendStepSummary` / `setOutput` for the runner files.
   exported `MAINTENANCE_BRANCH_RE` + `currentMinor(tags)` +
   `supportWindowProblem({branch, tags, windowSize})` +
   `retireLineForPublish({version, tags, windowSize})` + `evaluate({branchHead,
-  pushedSha, checkRuns, statuses, selfJobs, branchLabel, tags})` (no network, no
-  `process.exit`) + a `--self-test`.
+  pushedSha, checkRuns, statuses, selfJobs, branchLabel, tags, informational,
+  required, mode})` + `requiredChecksPending(checkRuns, required)` (no network,
+  no `process.exit`) + a `--self-test`. `release-preflight.test.mjs` is the
+  `node --test` sibling wired into the required `lint` lane — `release.yml` has
+  no `pull_request:` trigger, so without it every edit to the gate would be
+  unverified until a release is cut. Its headline case is an absent required
+  lane blocking the publish, paired with the negative control that the same
+  world is green once the name leaves `required`.
   - Env (preflight, default command): `GITHUB_TOKEN` (checks:read +
     statuses:read + contents:read), `GITHUB_REPOSITORY`, `GITHUB_SHA` (pushed
-    commit), `GITHUB_REF_NAME` (must be `release/<major>.<minor>.x`),
-    `GITHUB_API_URL` (default `https://api.github.com`), `RELEASE_SELF_JOBS`
-    (comma-separated self-job names to exclude).
+    commit), `GITHUB_REF_NAME` (`main` -> `mainline` mode,
+    `release/<major>.<minor>.x` -> `maintenance` mode), `GITHUB_API_URL`
+    (default `https://api.github.com`), `RELEASE_SELF_JOBS` (comma-separated
+    self-job names to exclude), `RELEASE_REQUIRED_CHECKS` (comma-separated
+    EXPECTED set — every name must have posted a green check-run; empty is a
+    hard failure), `RELEASE_INFORMATIONAL_CHECKS` (comma-separated name
+    PREFIXES to observe but not gate on).
   - Env (`eol-retire-line` command): `GITHUB_TOKEN` (contents:write — the
     workflow passes `RELEASE_PAT || github.token`), `GITHUB_REPOSITORY`,
     `RELEASE_APP_VERSION` (the just-published `X.Y.Z`), `GITHUB_API_URL`.
   - Args: argv `--self-test` runs the assertion suite; `eol-retire-line` runs
-    the active-EOL retirement; no command runs the maintenance preflight gate.
-  - Exit (preflight): `0` when the line is in-window, the commit is the branch
-    tip, and all gated checks are green (or a green self-test); `1` on an
-    end-of-life line, any red/running gated check, a non-tip / unresolved
-    commit, a non-maintenance `GITHUB_REF_NAME` (a wiring error), or a missing
-    required env var.
+    the active-EOL retirement; no command runs the preflight gate.
+  - Exit (preflight): `0` when every required lane ran green and all other gated
+    checks are green (plus, in `maintenance` mode, the line is in-window and the
+    commit is the branch tip) — or a green self-test; `1` on a required lane
+    that never ran, an empty / self-colliding / informational-swallowed required
+    set, any red/running gated check, an end-of-life line, a non-tip /
+    unresolved commit, or a missing required env var.
   - Exit (`eol-retire-line`): `0` always (fail-open — a retirement failure must
     never fail an already-published release); `1` only on a gross wiring error
     (missing repo/token) before any publish-affecting work.
+- **`brew-smoke.mjs`** — `release.yml`, the `brew-smoke` job (post-`publish`).
+  Proves the Homebrew tap actually serves the version that just shipped. Reads
+  `Formula/cerberus.rb` from `tsouza/homebrew-tap` through the API FIRST: that
+  is the anti-vacuous check, because a deleted `brews:` block or an expired
+  `HOMEBREW_TAP_GITHUB_TOKEN` leaves a STALE formula that a warm `brew install`
+  would install happily. Then it branches EXPLICITLY on the release kind rather
+  than skipping: a stable `X.Y.Z` requires the formula to declare exactly that
+  version, then installs it and asserts the binary lands under `brew --prefix`,
+  that `cerberus --version` EQUALS the bare release version (string equality, so
+  an off-by-`v` or a stale ldflag cannot pass a substring test), and that two
+  OFFLINE payload verbs work — `migrate schema` (emits `CREATE` DDL) and
+  `config-docs -check` against `REPO_ROOT`'s `docs/configuration.md`. A
+  prerelease takes the negative branch: `.goreleaser.yml` sets
+  `skip_upload: auto`, so an `rc.*` must NOT have written a formula, and a
+  formula declaring the prerelease version is a reported regression. `migrate
+  gate` / `migrate verify` are deliberately unused — they exit non-zero on a
+  legitimate no-go, so they cannot distinguish a broken binary from a correct
+  verdict. Pure exports `isStableRelease(version)`, `formulaVersion(rbSource)`
+  (declaration, then archive-name fallback, then THROWS — an unparseable formula
+  never degrades into a pass) and `verdict({version, formulaSource})`, covered
+  by `brew-smoke.test.mjs` on the required `lint` lane and as the job's own
+  first step.
+  - Env: `RELEASE_VERSION` (the BARE `X.Y.Z[-rc.N]`, i.e.
+    `needs.gate.outputs.app_version`, never the `v`-prefixed tag),
+    `GITHUB_TOKEN` (contents:read on the tap), `GITHUB_API_URL` (default
+    `https://api.github.com`), `REPO_ROOT` (checkout root, for the
+    `config-docs -check` payload).
+  - Exit: `0` when the formula state matches the release kind and (stable only)
+    the installed binary passes every assertion; `1` on a stale / missing /
+    unparseable formula, a prerelease formula that should not exist, a failed
+    install, a version mismatch, or a failing payload verb.
 - **`chart-kubeconform.mjs`** — `chart-ci.yml`, the `Render + kubeconform`
   step. Renders the chart for the default values and every `ci/*-values.yaml`
   fixture, schema-validates each manifest set with `kubeconform -strict`, and
@@ -492,6 +547,46 @@ wrapper, plus `appendStepSummary` / `setOutput` for the runner files.
   - Exit: `0` clean, `1` on any coverage violation, an unattested scenario, a
     PASS-cell pin mismatch, an unknown `MODE`, a missing/malformed input, a
     requested tier the workflow has no job for, or a failed suite run.
+
+- **`migration-artifact.mjs`** — `migration-e2e.yml`, the first step of every
+  tier job (`migration-tier0` / `migration-tier1` / `migration-tier2`). The
+  single decision point for *which cerberus the lane proves*, and the reason the
+  lane can be pointed at a released artifact at all. Two inputs travel together
+  and are the whole contract: supply both `cerberus_image` + `expect_version`
+  (`release.yml` calls the lane this way, naming the image goreleaser just
+  built) and the module pulls that image, `docker cp`s
+  `/usr/local/bin/cerberus` out of it, and exports it as `CERBERUS_BIN`;
+  supply neither (every PR / dispatch / push run) and it `go build`s the CLI
+  from the tree instead. Supplying exactly one is an error, not a default — a
+  half pair would run a source build under an artifact-shaped job name, which
+  is the exact hollow green the module exists to prevent. The CLI is extracted
+  FROM the image rather than from a release tarball so the binary the scenarios
+  exec and the server the stack runs are the same bytes. Whichever binary it
+  produced is then held to its expected version: the module runs `--version`,
+  requires exit 0 and exactly one non-empty line, and string-compares it — a
+  build that is not the build this run claims to drive fails here, before a
+  single scenario runs, instead of passing thirty of them against the wrong
+  artifact. The two paths carry different stamps by construction (`dev` for a
+  bare `go build`, `e2e` for `Dockerfile.local`, `<version>` for a goreleaser
+  build), which is what makes the probe a real discriminator; the same
+  constants live in `test/e2e/migration/lib/provenance.go` for the Go side, and
+  `test/regression/migration_tier1_test.go` holds every copy equal. The
+  exported `CERBERUS_IMAGE` is what the tier-1/tier-2 compose stacks
+  interpolate (`image: ${CERBERUS_IMAGE:-cerberus:migration-tier1}`,
+  `pull_policy: never`), and `CERBERUS_EXPECT_VERSION` is exported only on the
+  image path — on the source path the CLI and the compose image are two
+  different builds, so each is held to its own stamp rather than to a shared
+  one. `migration-artifact.test.mjs` is a `node --test` guard on the required
+  `lint` lane covering the plan resolver, including the mutation control that a
+  half pair never yields a plan in either direction.
+  - Env: `CERBERUS_IMAGE_INPUT` / `CERBERUS_EXPECT_VERSION_INPUT` (the two
+    workflow inputs; both empty = build from source, both set = test that
+    image, exactly one set = error), `BUILD_DIR` (default `build`),
+    `GITHUB_ENV` (the runner file `CERBERUS_BIN` / `CERBERUS_IMAGE` /
+    `CERBERUS_EXPECT_VERSION` are appended to).
+  - Exit: `0` once a binary exists and its `--version` matches, `1` on a half
+    pair, a failed build / pull / extract, a `--version` that errors, prints
+    nothing, prints more than one line, or prints the wrong stamp.
 
 - **`dashboard-matrix.mjs`** — `e2e.yml`, the `dashboard-setup` job. The k3d
   twin of `compose-smoke-matrix.mjs`: single source of truth for how the

--- a/.github/scripts/brew-smoke.mjs
+++ b/.github/scripts/brew-smoke.mjs
@@ -1,0 +1,316 @@
+// brew-smoke.mjs — post-publish Homebrew install smoke for `release.yml`'s
+// `brew-smoke` job.
+//
+// What it is for: goreleaser's `brews:` block pushes a formula to a DIFFERENT
+// repository (tsouza/homebrew-tap) with a PAT. Nothing in this repo observes
+// that push. If the block is deleted, if HOMEBREW_TAP_GITHUB_TOKEN expires, or
+// if the cross-repo write silently fails, the release still goes green here and
+// `brew install tsouza/tap/cerberus` is discovered broken by a user.
+//
+// Ordering: it MUST run after the draft -> published flip. `brew install`
+// downloads the release tarball, and a draft release's assets 404 for anyone
+// but the token that created them. The fix for that is ordering
+// (`needs: publish`), never a retry loop and never `continue-on-error` — a
+// tolerated failure here is decoration, not a gate.
+//
+// PRERELEASES ARE NOT SKIPPED. `skip_upload: auto` in .goreleaser.yml means an
+// `rc.*` release writes NO formula, so the honest assertion for a prerelease is
+// the NEGATIVE one: the formula must still exist AND must NOT declare this
+// version. Bailing out on a "not applicable" flag would be `t.Skip` in workflow
+// clothing, and would wave through a `skip_upload` regression that started
+// publishing prerelease formulas to the stable tap.
+//
+// ANTI-VACUOUS: the formula's declared version is compared to the release
+// version BEFORE `brew install` runs. That reads the tap's git state through
+// the API, so a warm brew cache, a mirror, or a previously-installed cerberus
+// cannot make a stale/never-pushed formula look healthy. The installed
+// binary's `--version` is then compared with string EQUALITY against the
+// de-`v`'d release version — `grep -q "$TAG"` can never match (the tag carries
+// the `v`), and `grep -q "${TAG#v}"` passes on any superstring.
+//
+// Payload verbs (proving the SHIPPED bytes work, not just that a file landed):
+//   - `cerberus migrate schema` — offline DDL render; must exit 0 and emit
+//     CREATE statements.
+//   - `cerberus config-docs -check` — the binary's config registry rendered and
+//     compared against THIS commit's docs/configuration.md. A released binary
+//     built from other source goes red here.
+// `migrate gate` / `migrate verify` are deliberately NOT used: they carry
+// dedicated non-zero exit codes for a legitimate no-go verdict, so a healthy
+// binary would red the job.
+//
+// Env contract:
+//   RELEASE_VERSION   the published app version, BARE (`1.11.2` /
+//                     `1.11.2-rc.1`) — release.yml passes
+//                     `needs.gate.outputs.app_version`, which is the de-`v`'d
+//                     form the binary itself reports.
+//   GITHUB_TOKEN      token used to read the tap's formula via the contents API.
+//   GITHUB_API_URL    API base (default https://api.github.com).
+//   REPO_ROOT         checkout of the release commit — the working directory for
+//                     the `config-docs -check` payload run.
+//
+// Exit: 0 when every assertion for the branch taken holds; 1 on any missing env
+// var, an unreadable/unparseable formula, a formula-version mismatch (stable) or
+// match (prerelease), a failed install, a binary resolved outside the brew
+// prefix, a `--version` mismatch, or a failing payload verb.
+//
+// Imports only node: builtins. Run with `node .github/scripts/brew-smoke.mjs`.
+
+import process from 'node:process';
+import { spawnSync } from 'node:child_process';
+
+// The tap goreleaser's `brews:` block writes to, and the formula path inside it.
+const TAP_REPO = 'tsouza/homebrew-tap';
+const TAP_FORMULA_PATH = 'Formula/cerberus.rb';
+
+// How an operator names the formula: `brew install tsouza/tap/cerberus`.
+const FORMULA_REF = 'tsouza/tap/cerberus';
+
+// A STABLE release is exactly `<major>.<minor>.<patch>`. Anything with a
+// prerelease suffix (`-rc.1`, `-RC1`) is a prerelease, which `skip_upload: auto`
+// keeps out of the tap.
+const STABLE_VERSION_RE = /^\d+\.\d+\.\d+$/;
+
+// goreleaser's formula template declares `version "1.11.2"`.
+const FORMULA_VERSION_RE = /^\s*version\s+"([^"]+)"/m;
+
+// Fallback when the template stops emitting a bare `version` line: the archive
+// name goreleaser builds, `cerberus_<version>_<os>_<arch>.tar.gz` (the
+// `name_template` in .goreleaser.yml `archives:`).
+const FORMULA_ARCHIVE_RE = /cerberus_([^_]+)_(?:linux|darwin)_(?:amd64|arm64)\.tar\.gz/;
+
+// The install command's timeout. A brew install that hangs must fail the job
+// rather than burn the whole runner allowance.
+const INSTALL_TIMEOUT_MS = 15 * 60 * 1000;
+
+// ---------------------------------------------------------------------------
+// pure core (exported for brew-smoke.test.mjs — no network, no process.exit)
+// ---------------------------------------------------------------------------
+
+// isStableRelease — true iff the bare version is a stable `X.Y.Z`. This is the
+// SAME predicate goreleaser's `skip_upload: auto` applies, so the two branches
+// below mirror what the tap actually receives.
+export function isStableRelease(version) {
+  return STABLE_VERSION_RE.test(String(version ?? '').trim());
+}
+
+// formulaVersion — the version the tap formula declares. Tries the explicit
+// `version "..."` line, falls back to the archive filename, and THROWS when
+// neither parses. An unparseable formula is a failure, never a pass: silently
+// returning null would let the stable branch's equality check degrade into
+// "well, we couldn't tell".
+export function formulaVersion(rbSource) {
+  const src = String(rbSource ?? '');
+  const declared = FORMULA_VERSION_RE.exec(src);
+  if (declared) return declared[1];
+  const archive = FORMULA_ARCHIVE_RE.exec(src);
+  if (archive) return archive[1];
+  throw new Error(
+    `could not determine the version of ${TAP_REPO}:${TAP_FORMULA_PATH} — neither a \`version "…"\` ` +
+      `declaration nor a cerberus_<version>_<os>_<arch>.tar.gz archive name is present. ` +
+      `An unreadable formula is a release failure, not a pass.`,
+  );
+}
+
+// verdict — the pure decision both branches share. Returns:
+//   mustInstall — true for a stable release (the formula is expected to declare
+//                 this version and `brew install` must work), false for a
+//                 prerelease (no formula is published for it).
+//   problems    — blocking problem strings; empty == the tap is in the state
+//                 this release requires.
+export function verdict({ version, formulaSource }) {
+  const v = String(version ?? '').trim();
+  const declared = formulaVersion(formulaSource);
+  const stable = isStableRelease(v);
+  const problems = [];
+
+  if (stable) {
+    if (declared !== v) {
+      problems.push(
+        `${TAP_REPO}:${TAP_FORMULA_PATH} declares version "${declared}" but this release is "${v}". ` +
+          `The formula was never pushed, or the push landed stale — goreleaser's brews block, ` +
+          `HOMEBREW_TAP_GITHUB_TOKEN, or the cross-repo write is broken. ` +
+          `\`brew install ${FORMULA_REF}\` would install the wrong version.`,
+      );
+    }
+  } else if (declared === v) {
+    problems.push(
+      `${TAP_REPO}:${TAP_FORMULA_PATH} declares prerelease version "${v}". ` +
+        `.goreleaser.yml sets \`skip_upload: auto\`, so a prerelease must write NO formula — ` +
+        `the stable tap is now pointing operators at a prerelease.`,
+    );
+  }
+
+  return { mustInstall: stable, problems };
+}
+
+// ---------------------------------------------------------------------------
+// driver
+// ---------------------------------------------------------------------------
+
+function ghNotice(msg) {
+  process.stdout.write(`::notice::${String(msg).replace(/\r?\n/g, '%0A')}\n`);
+}
+
+function ghError(msg) {
+  process.stdout.write(`::error::${String(msg).replace(/\r?\n/g, '%0A')}\n`);
+}
+
+function fail(msg) {
+  ghError(`brew-smoke: ${msg}`);
+  process.exit(1);
+}
+
+// sh — run a command, capture stdout/stderr/status. No shell unless `shell` is
+// set (only the PATH resolution probe needs one).
+function sh(cmd, args, { cwd, shell = false, timeout } = {}) {
+  const res = spawnSync(cmd, args, {
+    cwd,
+    shell,
+    encoding: 'utf8',
+    timeout,
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  return {
+    status: res.status,
+    stdout: res.stdout ?? '',
+    stderr: res.stderr ?? '',
+    error: res.error,
+  };
+}
+
+function describe(res) {
+  return `exit=${res.status}${res.error ? ` error=${res.error.message}` : ''}\n${res.stdout}\n${res.stderr}`.trim();
+}
+
+async function main() {
+  const version = (process.env.RELEASE_VERSION ?? '').trim();
+  const token = process.env.GITHUB_TOKEN;
+  const apiBase = process.env.GITHUB_API_URL || 'https://api.github.com';
+  const repoRoot = process.env.REPO_ROOT;
+
+  if (!version) fail('RELEASE_VERSION is required (the BARE published version, e.g. 1.11.2)');
+  if (!token) fail('GITHUB_TOKEN is required to read the tap formula');
+  if (!repoRoot) fail('REPO_ROOT is required — the `config-docs -check` payload runs against this commit\'s docs');
+
+  // --- read the tap's formula through the API --------------------------------
+  // Both branches need it, and a 404 is a hard failure on both: a tap that has
+  // no cerberus formula at all is broken regardless of what we just published.
+  const url = `${apiBase}/repos/${TAP_REPO}/contents/${TAP_FORMULA_PATH}`;
+  const res = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github.raw+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+  });
+  if (!res.ok) {
+    fail(
+      `GET ${url} -> ${res.status} ${res.statusText}. ${TAP_REPO} has no readable ${TAP_FORMULA_PATH}: ` +
+        `\`brew install ${FORMULA_REF}\` is broken for every operator, whatever this release published.`,
+    );
+  }
+  const formulaSource = await res.text();
+
+  let decision;
+  try {
+    decision = verdict({ version, formulaSource });
+  } catch (e) {
+    fail(e.message);
+  }
+
+  for (const p of decision.problems) ghError(`brew-smoke: ${p}`);
+  if (decision.problems.length > 0) process.exit(1);
+
+  if (!decision.mustInstall) {
+    // PRERELEASE branch — asserted, not skipped. The formula exists and does NOT
+    // declare this version, which is exactly what `skip_upload: auto` promises.
+    ghNotice(
+      `brew-smoke: prerelease ${version}: the tap correctly still declares ` +
+        `"${formulaVersion(formulaSource)}"; no formula is published for prereleases (skip_upload: auto).`,
+    );
+    process.exit(0);
+  }
+
+  // --- STABLE branch: install from the tap and smoke the published binary -----
+  const prefixRes = sh('brew', ['--prefix']);
+  if (prefixRes.status !== 0) {
+    fail(
+      `\`brew --prefix\` did not resolve — Homebrew is not available on this runner. ${describe(prefixRes)}`,
+    );
+  }
+  const brewPrefix = prefixRes.stdout.trim();
+
+  const install = sh('brew', ['install', '--formula', FORMULA_REF], { timeout: INSTALL_TIMEOUT_MS });
+  if (install.status !== 0) {
+    fail(`\`brew install --formula ${FORMULA_REF}\` failed. ${describe(install)}`);
+  }
+
+  // The binary under test must be the one brew just installed — a cerberus
+  // already on PATH (a build artifact, a leftover) would otherwise satisfy every
+  // assertion below without the tap being involved at all.
+  const which = sh('command -v cerberus', [], { shell: true });
+  if (which.status !== 0) {
+    fail(`cerberus is not on PATH after \`brew install ${FORMULA_REF}\`. ${describe(which)}`);
+  }
+  const resolved = which.stdout.trim();
+  if (!resolved.startsWith(brewPrefix)) {
+    fail(
+      `cerberus resolved to ${resolved}, which is OUTSIDE the brew prefix ${brewPrefix} — ` +
+        `the smoke would be testing some other binary, not the published formula.`,
+    );
+  }
+
+  const versionRes = sh(resolved, ['--version']);
+  if (versionRes.status !== 0) {
+    fail(`\`${resolved} --version\` failed. ${describe(versionRes)}`);
+  }
+  const reported = versionRes.stdout.trim();
+  if (reported !== version) {
+    fail(
+      `the installed binary reports version "${reported}", expected exactly "${version}". ` +
+        `(The comparison is against the BARE app version, not the \`v\`-prefixed tag: comparing to the ` +
+        `tag is a guaranteed off-by-\`v\` mismatch.) ${resolved}`,
+    );
+  }
+
+  // Payload 1: the offline DDL render must produce real CREATE statements.
+  const schema = sh(resolved, ['migrate', 'schema'], { cwd: repoRoot });
+  if (schema.status !== 0) {
+    fail(`\`cerberus migrate schema\` failed on the published binary. ${describe(schema)}`);
+  }
+  if (!schema.stdout.includes('CREATE')) {
+    fail(
+      `\`cerberus migrate schema\` produced no CREATE statement (${schema.stdout.length} bytes) — ` +
+        `an empty render would satisfy a naive non-empty check while shipping nothing usable.`,
+    );
+  }
+
+  // Payload 2: the shipped binary's config registry must match THIS commit's
+  // docs/configuration.md. A binary built from other source goes red here.
+  const docs = sh(resolved, ['config-docs', '-check'], { cwd: repoRoot });
+  if (docs.status !== 0) {
+    fail(
+      `\`cerberus config-docs -check\` failed against ${repoRoot}/docs/configuration.md — ` +
+        `the published binary's config registry does not match the source this release was cut from. ` +
+        `${describe(docs)}`,
+    );
+  }
+
+  ghNotice(
+    `brew-smoke: ${FORMULA_REF} installed ${reported} at ${resolved} (tap formula declares ` +
+      `"${formulaVersion(formulaSource)}"); \`migrate schema\` rendered ${schema.stdout.length} bytes of DDL and ` +
+      `\`config-docs -check\` matches this commit's docs/configuration.md.`,
+  );
+  process.exit(0);
+}
+
+// Only dispatch when run as a script — importing the pure core for
+// brew-smoke.test.mjs must not fire the network driver or exit the test runner.
+const invokedDirectly = process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href;
+
+if (invokedDirectly) {
+  main().catch((e) => {
+    ghError(`brew-smoke: unexpected failure (${e.message})`);
+    process.exit(1);
+  });
+}

--- a/.github/scripts/brew-smoke.test.mjs
+++ b/.github/scripts/brew-smoke.test.mjs
@@ -1,0 +1,114 @@
+// brew-smoke.test.mjs — node:test guard for the post-publish Homebrew smoke's
+// pure core, run on the required `lint` lane AND as the first step of the
+// `brew-smoke` job itself.
+//
+// release.yml has no `pull_request:` trigger, so without this suite every edit
+// to the smoke would be unverified until a release is cut. The cases below pin
+// the three ways the smoke could go hollow:
+//
+//   1. a stale/never-pushed formula reported as fine (the goreleaser `brews:`
+//      regression the whole job exists to catch);
+//   2. a prerelease branch that bails out instead of asserting — `t.Skip` in
+//      workflow clothing, which would wave through a `skip_upload` regression;
+//   3. an unparseable formula degrading into "couldn't tell, so pass".
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { isStableRelease, formulaVersion, verdict } from './brew-smoke.mjs';
+
+// A minimal stand-in for what goreleaser writes into the tap.
+function formula(version) {
+  return [
+    'class Cerberus < Formula',
+    '  desc "Drop-in Prometheus / Loki / Tempo HTTP gateway for ClickHouse"',
+    '  homepage "https://github.com/tsouza/cerberus"',
+    `  version "${version}"`,
+    '  license "Apache-2.0"',
+    '',
+    '  on_macos do',
+    `    url "https://github.com/tsouza/cerberus/releases/download/v${version}/cerberus_${version}_darwin_arm64.tar.gz"`,
+    '  end',
+    '',
+    '  def install',
+    '    bin.install "cerberus"',
+    '  end',
+    'end',
+  ].join('\n');
+}
+
+test('isStableRelease separates stable releases from prereleases', () => {
+  assert.equal(isStableRelease('1.11.2'), true);
+  assert.equal(isStableRelease('10.0.0'), true);
+  assert.equal(isStableRelease('1.11.2-rc.1'), false);
+  assert.equal(isStableRelease('1.0.0-RC1'), false);
+  assert.equal(isStableRelease('v1.11.2'), false, 'the `v`-prefixed tag is not the app version');
+  assert.equal(isStableRelease(''), false);
+  assert.equal(isStableRelease(undefined), false);
+});
+
+test('formulaVersion reads the declaration, falls back to the archive name', () => {
+  assert.equal(formulaVersion(formula('1.11.2')), '1.11.2');
+
+  // No `version "…"` line: the archive filename still carries it.
+  const archiveOnly = [
+    'class Cerberus < Formula',
+    '  url "https://github.com/tsouza/cerberus/releases/download/v1.11.2/cerberus_1.11.2_linux_amd64.tar.gz"',
+    'end',
+  ].join('\n');
+  assert.equal(formulaVersion(archiveOnly), '1.11.2');
+});
+
+test('an unparseable formula THROWS rather than passing', () => {
+  assert.throws(() => formulaVersion('class Cerberus < Formula\nend\n'), /could not determine the version/);
+  assert.throws(() => formulaVersion(''), /could not determine the version/);
+  assert.throws(() => formulaVersion(undefined), /could not determine the version/);
+});
+
+test('stable + matching formula: no problems, install required', () => {
+  const v = verdict({ version: '1.11.2', formulaSource: formula('1.11.2') });
+  assert.deepEqual(v.problems, []);
+  assert.equal(v.mustInstall, true);
+});
+
+test('stable + STALE formula: blocked before brew is ever invoked', () => {
+  // The regression: brews block deleted, HOMEBREW_TAP_GITHUB_TOKEN expired, or
+  // the cross-repo push silently failed. The tap keeps declaring the previous
+  // version. A warm brew cache cannot mask this — it is read from the tap's git
+  // state, not from brew.
+  const v = verdict({ version: '1.11.2', formulaSource: formula('1.11.1') });
+  assert.equal(v.problems.length, 1, `expected exactly one problem, got: ${v.problems.join('; ')}`);
+  assert.match(v.problems[0], /declares version "1\.11\.1" but this release is "1\.11\.2"/);
+  assert.equal(v.mustInstall, true, 'a stale formula does not excuse skipping the install branch');
+});
+
+test('prerelease + older formula: no problems, and NO install', () => {
+  // `skip_upload: auto` means the prerelease wrote no formula, so the tap still
+  // declares the last stable. That is the healthy state — asserted, not skipped.
+  const v = verdict({ version: '1.12.0-rc.1', formulaSource: formula('1.11.2') });
+  assert.deepEqual(v.problems, []);
+  assert.equal(v.mustInstall, false);
+});
+
+test('prerelease + formula carrying THIS version: the skip_upload regression', () => {
+  const v = verdict({ version: '1.12.0-rc.1', formulaSource: formula('1.12.0-rc.1') });
+  assert.equal(v.problems.length, 1, `expected exactly one problem, got: ${v.problems.join('; ')}`);
+  assert.match(v.problems[0], /declares prerelease version "1\.12\.0-rc\.1"/);
+  assert.match(v.problems[0], /skip_upload: auto/);
+  assert.equal(v.mustInstall, false);
+});
+
+test('verdict is comparing the BARE version, so a `v`-prefixed input cannot pass', () => {
+  // The off-by-`v` trap: release.yml must pass `needs.gate.outputs.app_version`
+  // (bare), never `app_tag`. If it ever passed the tag, the stable branch's
+  // equality check fails loudly here rather than being papered over by a
+  // substring match.
+  const v = verdict({ version: 'v1.11.2', formulaSource: formula('1.11.2') });
+  assert.equal(v.mustInstall, false, 'a `v`-prefixed string is not a stable app version');
+  assert.deepEqual(v.problems, [], 'and it does not collide with the formula version either');
+});
+
+test('an unparseable formula propagates out of verdict on both branches', () => {
+  assert.throws(() => verdict({ version: '1.11.2', formulaSource: 'garbage' }), /could not determine the version/);
+  assert.throws(() => verdict({ version: '1.12.0-rc.1', formulaSource: 'garbage' }), /could not determine the version/);
+});

--- a/.github/scripts/migration-artifact.mjs
+++ b/.github/scripts/migration-artifact.mjs
@@ -1,0 +1,238 @@
+// migration-artifact.mjs — resolve WHICH cerberus the Layer-14 migration lane
+// tests, on every path, and refuse an incoherent input pair.
+//
+// migration-e2e.yml runs twice against the same commit for a release: once on
+// the push (proving the SOURCE TREE) and once via `workflow_call` from
+// release.yml's `release-artifact-migration` job (proving the ARTIFACT
+// goreleaser just built). Both runs execute the same three tier jobs, so the
+// ONE thing that differs is which cerberus binary the scenarios exec and which
+// image the compose stacks run. This module is that single decision point.
+//
+// Two plans, and nothing in between:
+//
+//   source  no image was supplied — `go build ./cmd/cerberus` produces the CLI
+//           (stamped `dev`, cmd/cerberus's `var Version`), and the compose
+//           stacks build their server from Dockerfile.local (stamped `e2e`).
+//           The CLI and the server are DIFFERENT builds, so there is no single
+//           stamp both report and `sharedVersion` is empty: the Go harness
+//           then holds each side to its own known-correct default rather than
+//           to one wrong shared value. Both sides still assert.
+//   image   a released image reference was supplied — the CLI is extracted OUT
+//           of that image (`docker create` + `docker cp`), so the binary the
+//           scenarios exec and the server the stack runs are literally the same
+//           bytes, and `sharedVersion` is the release version both must report.
+//
+// Supplying exactly one half of the (image, expect-version) pair is a hard
+// error, never a silent fall-back to `source`: that is precisely how a release
+// lane would end up testing a from-source build under an artifact-shaped job
+// name and reporting green.
+//
+// Env:
+//   CERBERUS_IMAGE_INPUT           released image ref to test; empty = build
+//                                  from this tree.
+//   CERBERUS_EXPECT_VERSION_INPUT  version that image's binary must report;
+//                                  travels with CERBERUS_IMAGE_INPUT.
+//   BUILD_DIR                      where the resolved binary lands
+//                                  (default `build`).
+//   GITHUB_ENV                     runner file the resolved plan is exported
+//                                  through (CERBERUS_BIN / CERBERUS_IMAGE /
+//                                  CERBERUS_EXPECT_VERSION).
+//
+// Exit: 0 with the plan exported; 1 on a half-supplied input pair, a failed
+// build / pull / extraction, or a `--version` probe that does not report
+// exactly the expected stamp.
+
+import { appendFileSync, mkdirSync, chmodSync } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+import { capture, error, notice, log } from './lib/gh.mjs';
+
+// SOURCE_BUILD_VERSION is what `go build ./cmd/cerberus` with no ldflags
+// reports — cmd/cerberus/main.go's `var Version = "dev"`. Held equal to that
+// declaration by test/regression/migration_tier1_test.go, which reads both.
+export const SOURCE_BUILD_VERSION = 'dev';
+
+// LOCAL_IMAGE_TAG is the tag the compose stacks run when no released image is
+// supplied. Held equal to the `${CERBERUS_IMAGE:-…}` default in
+// tiers/tier1-dual/docker-compose.dual.yml and to the Justfile's
+// MIGRATION_LOCAL_IMAGE by the same regression pin.
+export const LOCAL_IMAGE_TAG = 'cerberus:migration-tier1';
+
+// IMAGE_BINARY_PATH is where the cerberus image keeps its binary — the same
+// path Dockerfile.local's and Dockerfile's `COPY --from=build` write to, and
+// the same one the compose healthcheck execs.
+export const IMAGE_BINARY_PATH = '/usr/local/bin/cerberus';
+
+// BINARY_NAME is the filename the resolved binary lands under inside BUILD_DIR.
+const BINARY_NAME = 'cerberus';
+
+// EXECUTABLE_MODE is what an extracted binary is chmod'ed to. `docker cp`
+// preserves the image's mode, but an image built elsewhere is not this lane's
+// to trust.
+const EXECUTABLE_MODE = 0o755;
+
+// PAIRED_INPUTS_MESSAGE is the refusal for a half-supplied pair. Its exact text
+// is asserted by migration-artifact.test.mjs, so a loosening rewrite is caught.
+export const PAIRED_INPUTS_MESSAGE =
+  'cerberus_image and expect_version travel together: supply both (test a released artifact) ' +
+  'or neither (build from this tree). Supplying one alone would run a source build under an ' +
+  'artifact-shaped job name.';
+
+// resolvePlan is the testable core: it decides which cerberus the lane drives
+// from the two inputs alone, with no I/O.
+//
+// Returns { source, image, expectVersion, sharedVersion } where
+//   expectVersion  the stamp the CLI this module produces must report;
+//   sharedVersion  the stamp EVERY cerberus in the lane reports (CLI and
+//                  server), or '' when the two come from different builds.
+export function resolvePlan({ image, expectVersion } = {}) {
+  const ref = String(image ?? '').trim();
+  const want = String(expectVersion ?? '').trim();
+
+  if (ref === '' && want === '') {
+    return {
+      source: 'source',
+      image: LOCAL_IMAGE_TAG,
+      expectVersion: SOURCE_BUILD_VERSION,
+      sharedVersion: '',
+    };
+  }
+  if (ref === '' || want === '') {
+    throw new Error(PAIRED_INPUTS_MESSAGE);
+  }
+  return { source: 'image', image: ref, expectVersion: want, sharedVersion: want };
+}
+
+// buildFromSource compiles the CLI the scenarios exec out of this tree.
+function buildFromSource(binary) {
+  const res = capture('go', ['build', '-o', binary, './cmd/cerberus']);
+  if (res.status !== 0) {
+    error(`migration-artifact: go build ./cmd/cerberus failed:\n${res.stdout}${res.stderr}`);
+    process.exit(1);
+  }
+}
+
+// extractFromImage pulls the released image and copies its binary out, so the
+// CLI the scenarios exec is the same bytes as the server the stack runs.
+function extractFromImage(ref, binary) {
+  const pull = capture('docker', ['pull', ref]);
+  if (pull.status !== 0) {
+    error(
+      `migration-artifact: docker pull ${ref} failed — the released image is unpullable from this ` +
+        `job (check the GHCR login step and the package's visibility):\n${pull.stdout}${pull.stderr}`,
+    );
+    process.exit(1);
+  }
+
+  const created = capture('docker', ['create', ref]);
+  if (created.status !== 0) {
+    error(`migration-artifact: docker create ${ref} failed:\n${created.stdout}${created.stderr}`);
+    process.exit(1);
+  }
+  const container = created.stdout.trim().split('\n').pop().trim();
+  if (container === '') {
+    error(`migration-artifact: docker create ${ref} printed no container id`);
+    process.exit(1);
+  }
+
+  try {
+    const cp = capture('docker', ['cp', `${container}:${IMAGE_BINARY_PATH}`, binary]);
+    if (cp.status !== 0) {
+      error(
+        `migration-artifact: docker cp ${container}:${IMAGE_BINARY_PATH} failed — the image does ` +
+          `not carry the binary at that path:\n${cp.stdout}${cp.stderr}`,
+      );
+      process.exit(1);
+    }
+  } finally {
+    // Best-effort: the container is a throwaway created only to be copied out
+    // of, and a leaked one on an ephemeral runner cannot affect the verdict.
+    capture('docker', ['rm', '-f', container]);
+  }
+  chmodSync(binary, EXECUTABLE_MODE);
+}
+
+// probeVersion runs the resolved binary's `--version` and holds it to the
+// expected stamp. This is what turns a stale, wrong-arch or wrong-tree image
+// into a named failure before a single scenario runs.
+function probeVersion(binary, plan) {
+  const res = capture(binary, ['--version']);
+  if (res.status !== 0) {
+    error(
+      `migration-artifact: ${binary} --version exited ${res.status} (plan=${plan.source}, ` +
+        `image=${plan.image}):\n${res.stdout}${res.stderr}`,
+    );
+    process.exit(1);
+  }
+  const lines = res.stdout.split('\n').map((l) => l.trim()).filter((l) => l !== '');
+  if (lines.length !== 1) {
+    error(
+      `migration-artifact: ${binary} --version printed ${lines.length} non-empty line(s), want ` +
+        `exactly one bare version: ${JSON.stringify(res.stdout)}`,
+    );
+    process.exit(1);
+  }
+  if (lines[0] !== plan.expectVersion) {
+    error(
+      `migration-artifact: ${binary} reports version "${lines[0]}" but the ${plan.source} plan ` +
+        `expects "${plan.expectVersion}" (image=${plan.image}). The lane would have tested a ` +
+        `different build than the one it claims to.`,
+    );
+    process.exit(1);
+  }
+  return lines[0];
+}
+
+function exportEnv(entries) {
+  const file = process.env.GITHUB_ENV;
+  const block = entries.map(([k, v]) => `${k}=${v}`).join('\n');
+  if (!file) {
+    log(`[no $GITHUB_ENV in env; resolved plan follows]\n${block}`);
+    return;
+  }
+  appendFileSync(file, `${block}\n`);
+}
+
+function main() {
+  let plan;
+  try {
+    plan = resolvePlan({
+      image: process.env.CERBERUS_IMAGE_INPUT,
+      expectVersion: process.env.CERBERUS_EXPECT_VERSION_INPUT,
+    });
+  } catch (err) {
+    error(`migration-artifact: ${err.message}`);
+    process.exit(1);
+  }
+
+  const buildDir = path.resolve(process.env.BUILD_DIR || 'build');
+  mkdirSync(buildDir, { recursive: true });
+  const binary = path.join(buildDir, BINARY_NAME);
+
+  if (plan.source === 'source') {
+    buildFromSource(binary);
+  } else {
+    extractFromImage(plan.image, binary);
+  }
+
+  const version = probeVersion(binary, plan);
+
+  exportEnv([
+    ['CERBERUS_BIN', binary],
+    ['CERBERUS_IMAGE', plan.image],
+    ['CERBERUS_EXPECT_VERSION', plan.sharedVersion],
+  ]);
+
+  notice(
+    `migration-artifact: ${plan.source} plan — binary ${binary} reports ${version}, ` +
+      `compose runs ${plan.image}` +
+      (plan.sharedVersion === ''
+        ? ' (CLI and server are separate builds; each is held to its own stamp)'
+        : ` (CLI and server share the ${plan.sharedVersion} stamp)`),
+  );
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/.github/scripts/migration-artifact.test.mjs
+++ b/.github/scripts/migration-artifact.test.mjs
@@ -1,0 +1,112 @@
+// migration-artifact.test.mjs — node:test guard for the migration lane's
+// artifact resolver.
+//
+// Runs on the CHEAP required `lint` lane (`node --test`) — no Docker, no
+// network. migration-e2e.yml has no `pull_request:` trigger and release.yml
+// has none either, so without this suite every edit to resolvePlan would be
+// unverified until a release is cut.
+//
+// The headline case is the half-supplied input pair: a release lane wired with
+// `cerberus_image` but no `expect_version` must FAIL, not quietly degrade to a
+// from-source build under an artifact-shaped job name. Its negative control is
+// the positive path — both inputs empty is the PR/dispatch shape that keeps the
+// currently-green lane green.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  resolvePlan,
+  SOURCE_BUILD_VERSION,
+  LOCAL_IMAGE_TAG,
+  IMAGE_BINARY_PATH,
+  PAIRED_INPUTS_MESSAGE,
+} from './migration-artifact.mjs';
+
+const releaseImage = 'ghcr.io/tsouza/cerberus:1.11.2';
+const releaseVersion = '1.11.2';
+
+test('positive control: neither input supplied resolves the source plan', () => {
+  const plan = resolvePlan({ image: '', expectVersion: '' });
+
+  assert.equal(plan.source, 'source');
+  assert.equal(plan.image, LOCAL_IMAGE_TAG);
+  // The CLI comes from `go build` with no ldflags, so it reports `dev` …
+  assert.equal(plan.expectVersion, SOURCE_BUILD_VERSION);
+  // … while the compose server comes from Dockerfile.local and reports `e2e`,
+  // so there is no ONE stamp to export. An empty sharedVersion is what makes
+  // the Go harness hold each side to its own default instead of to a wrong
+  // shared value — the assertion is never skipped, only differently computed.
+  assert.equal(plan.sharedVersion, '');
+});
+
+test('positive control: undefined inputs are the same as empty ones', () => {
+  assert.deepEqual(resolvePlan({}), resolvePlan({ image: '', expectVersion: '' }));
+  assert.deepEqual(resolvePlan(), resolvePlan({ image: '', expectVersion: '' }));
+});
+
+test('whitespace-only inputs count as absent, not as a half-supplied pair', () => {
+  const plan = resolvePlan({ image: '   ', expectVersion: '\n' });
+  assert.equal(plan.source, 'source');
+});
+
+test('an image without an expected version is refused', () => {
+  assert.throws(
+    () => resolvePlan({ image: releaseImage, expectVersion: '' }),
+    (err) => {
+      assert.equal(err.message, PAIRED_INPUTS_MESSAGE);
+      return true;
+    },
+  );
+});
+
+test('an expected version without an image is refused', () => {
+  assert.throws(
+    () => resolvePlan({ image: '', expectVersion: releaseVersion }),
+    (err) => {
+      assert.equal(err.message, PAIRED_INPUTS_MESSAGE);
+      return true;
+    },
+  );
+});
+
+test('mutation control: a half pair never coerces to the source default', () => {
+  // The tempting "fix" for the half-supplied case is to fill the missing half
+  // in from the source defaults. That would run a `go build` while the job name
+  // and the notice both claim a released artifact — the exact hollow green this
+  // module exists to prevent — so assert the refusal is a THROW and that no
+  // plan carrying the source stamp escapes.
+  let escaped = null;
+  try {
+    escaped = resolvePlan({ image: releaseImage, expectVersion: '' });
+  } catch {
+    escaped = null;
+  }
+  assert.equal(escaped, null, 'resolvePlan returned a plan for a half-supplied pair');
+
+  let escapedInverse = null;
+  try {
+    escapedInverse = resolvePlan({ image: '', expectVersion: releaseVersion });
+  } catch {
+    escapedInverse = null;
+  }
+  assert.equal(escapedInverse, null, 'resolvePlan invented an image for a version-only input');
+});
+
+test('a full pair carries the ref and the version through verbatim', () => {
+  const plan = resolvePlan({ image: releaseImage, expectVersion: releaseVersion });
+
+  assert.equal(plan.source, 'image');
+  assert.equal(plan.image, releaseImage);
+  assert.equal(plan.expectVersion, releaseVersion);
+  // CLI and server are the same bytes on this path, so the stamp is shared and
+  // BOTH the binary probe and the live /info probe assert against it.
+  assert.equal(plan.sharedVersion, releaseVersion);
+  assert.notEqual(plan.expectVersion, SOURCE_BUILD_VERSION);
+});
+
+test('the extraction path is the image path the release Dockerfiles write', () => {
+  // Both Dockerfile and Dockerfile.local COPY the binary here and the compose
+  // healthcheck execs it here; a drift would make `docker cp` fail opaquely.
+  assert.equal(IMAGE_BINARY_PATH, '/usr/local/bin/cerberus');
+});

--- a/.github/scripts/release-preflight.mjs
+++ b/.github/scripts/release-preflight.mjs
@@ -1,37 +1,59 @@
-// release-preflight.mjs — the green-check guard for the MAINTENANCE-line
-// release path (a push to a `release/<major>.<minor>.x` hotfix branch).
+// release-preflight.mjs — the green-check guard for the release path. It runs
+// on BOTH release paths and refuses to publish unless the tree being released
+// is provably green.
 //
-// Why this exists ONLY for the maintenance path:
-//   A push to `main` is implicitly green — branch protection refuses to merge a
-//   PR whose required checks are red or whose tree is behind main, so the merge
-//   commit is releasable by construction. The publish-on-merge release.yml
-//   trusts that and runs no preflight on the main path.
+// Two MODES, selected from the pushed branch:
+//   MAINLINE     (`main`) — the merge commit of a release PR. Branch protection
+//                already refused to merge a PR whose REQUIRED checks were red,
+//                but that is not the whole story: a lane with no
+//                `pull_request:` trigger (today `migration-e2e`) has NEVER run
+//                on the tree being released, so the merge commit is the FIRST
+//                tree it sees. The mainline preflight is what makes those lanes
+//                gate. release.yml gates the job on "something actually
+//                publishes", so an ordinary merge pays nothing for it.
+//   MAINTENANCE  (`release/<major>.<minor>.x`) — a hotfix cherry-picked
+//                straight onto the line, with NO PR gate at all. Everything
+//                mainline mode does, PLUS two maintenance-only rules: the pushed
+//                commit must be the current TIP of its line, and the line must
+//                be inside the support window (an EOL line gets no hotfixes).
+//                Both are maintenance concepts — `main` legitimately moves
+//                under a release that is still waiting on CI, and the EOL
+//                window describes maintenance lines.
 //
-//   A push to a `release/*.x` maintenance branch has NO PR gate: a maintainer
-//   cherry-picks a hotfix straight onto the branch and pushes. Publishing that
-//   unguarded would risk shipping a RED commit. So before the publish jobs run,
-//   this preflight re-reads the pushed commit's check-runs + legacy statuses and
-//   refuses to release unless EVERY required check is settled GREEN.
+// ABSENCE IS A FAILURE (the rule an observation-derived gate cannot express):
+//   The green-check evaluation below iterates the check-runs the API RETURNED,
+//   so a lane that never ran contributes zero entries and therefore zero
+//   problems — a silently smaller gate that still reports "all N gated check(s)
+//   are settled green". RELEASE_REQUIRED_CHECKS is the EXPECTED set, and it is
+//   NOT derived from observation: every name in it must have posted a check-run
+//   on the commit, and a missing one is a blocking problem. An EMPTY
+//   RELEASE_REQUIRED_CHECKS is itself a blocking problem, so the gate cannot
+//   degrade back to pure observation by deleting one workflow env line. A
+//   required name that RELEASE_INFORMATIONAL_CHECKS would swallow by prefix, or
+//   that RELEASE_SELF_JOBS excludes, is a WIRING ERROR and blocks too —
+//   de-gating a required lane is not a de-gate, it is a hole.
 //
 // WAIT-then-EVALUATE (why it can't snapshot once):
 //   release.yml fires on the SAME push event as the CI workflows
-//   (ci / e2e / compatibility / chdb / …), so a one-shot snapshot taken the
-//   moment preflight starts sees every lane `queued` / `in_progress` and aborts
-//   with "still queued (not completed)" — a guaranteed false negative that used
-//   to force a manual re-run of release.yml after CI finished. So the driver
-//   first POLLS the commit's check-SUITES until every suite EXCEPT this release
-//   run's own suite is `completed`, THEN runs the existing one-shot green/tip/EOL
-//   evaluation exactly as before. Waiting on our own suite would deadlock (it is
-//   necessarily in-progress while we poll), so it is resolved by GITHUB_RUN_ID ->
-//   check_suite_id and excluded. The wait is bounded (maxWaitMs / pollIntervalMs);
-//   on timeout the preflight ABORTS naming the still-running suites — fail-safe,
-//   never publish on an unknown/incomplete state.
+//   (ci / e2e / compatibility / chdb / migration-e2e / …), so a one-shot
+//   snapshot taken the moment preflight starts sees every lane `queued` /
+//   `in_progress` and aborts with "still queued (not completed)" — a guaranteed
+//   false negative that used to force a manual re-run of release.yml after CI
+//   finished. So the driver first POLLS until BOTH (a) every check-SUITE except
+//   this release run's own is `completed` AND (b) every RELEASE_REQUIRED_CHECKS
+//   name has posted a COMPLETED check-run, THEN runs the one-shot
+//   green/tip/EOL evaluation. Condition (b) is what makes a lane that never
+//   started fail on the timeout rather than pass on its silence: a suite-only
+//   wait is `done` the instant the suites that DID run finish. Waiting on our
+//   own suite would deadlock (it is necessarily in-progress while we poll), so
+//   it is resolved by GITHUB_RUN_ID -> check_suite_id and excluded. The wait is
+//   bounded (releaseWaitMinutes / pollIntervalMs); on timeout the preflight
+//   ABORTS naming the MISSING and the still-RUNNING lanes separately —
+//   fail-safe, never publish on an unknown/incomplete state.
 //
 // The rule, with no softening:
-//   1. The pushed commit MUST be the current tip of the `release/*.x` branch
-//      it was pushed to. You release the tip of a maintenance line, never an
-//      older/side commit. (For a branch push GITHUB_SHA is normally already the
-//      tip; the check defends against a stale re-drive racing a newer push.)
+//   1. Every RELEASE_REQUIRED_CHECKS name must have posted a check-run on the
+//      commit. Silence is a failure, not a pass. (Both modes.)
 //   2. Every gated check-run + legacy status on the commit must be COMPLETED
 //      (nothing still running / queued) AND green (success / skipped / neutral).
 //      One running check, one failure, one cancelled/timed-out lane -> release
@@ -42,17 +64,28 @@
 //      are deliberately not part of the required gate (the required compose-smoke
 //      aggregate already rolls up the gating shards), so a flake there must not
 //      block a hotfix. Everything else gates by default — a new lane is never
-//      silently un-gated.
-//   3. The maintenance line must be INSIDE the support window — the latest
+//      silently un-gated. (Both modes.)
+//   3. The pushed commit MUST be the current tip of the `release/*.x` branch
+//      it was pushed to. You release the tip of a maintenance line, never an
+//      older/side commit. (For a branch push GITHUB_SHA is normally already the
+//      tip; the check defends against a stale re-drive racing a newer push.)
+//      MAINTENANCE only.
+//   4. The maintenance line must be INSIDE the support window — the latest
 //      SUPPORTED_MINOR_LINES minor lines (current + the two prior). A push to a
 //      line that is end-of-life (3+ minors behind the highest released minor)
 //      is REFUSED: an EOL line gets no further hotfixes. See the "Release
 //      support window / EOL policy" subsection of docs/operations.md.
+//      MAINTENANCE only.
 //
-// The ONLY exclusion is THIS release run's own jobs (gate / preflight /
-// goreleaser / chart-release): they are necessarily in-progress while the
-// preflight runs, so gating on them would deadlock. They are identified by name
-// via RELEASE_SELF_JOBS — structural, not a flakiness heuristic.
+// The ONLY structural exclusion is THIS release run's own jobs (gate /
+// preflight / goreleaser / release-artifact-migration / publish / brew-smoke /
+// chart-release): they are necessarily in-progress while the preflight runs, so
+// gating on them would deadlock. They are identified by name via
+// RELEASE_SELF_JOBS — structural, not a flakiness heuristic. A reusable
+// workflow called from one of those jobs posts its children as
+// "<job> / <child>", so self-job matching also covers that prefix
+// (REUSABLE_JOB_SEPARATOR); without it, `release-artifact-migration`'s children
+// would be gated on by the very preflight that must finish before they start.
 //
 // `skipped` counts as green: a job whose path-filter / `if:` guard deliberately
 // did not run is a settled non-failure (e.g. `changes` / `gate` no-ops), not a
@@ -65,33 +98,50 @@
 // Env contract (the single source of truth):
 //   GITHUB_TOKEN       token with checks:read + statuses:read + contents:read.
 //   GITHUB_REPOSITORY  "owner/name".
-//   GITHUB_SHA         the pushed (maintenance) commit SHA.
-//   GITHUB_REF_NAME    the pushed branch name, e.g. `release/1.4.x`. Must match
-//                      the `release/<major>.<minor>.x` shape — the preflight is
-//                      ONLY meaningful on the maintenance path and refuses to
-//                      run otherwise (a wiring guard, not a silent pass).
+//   GITHUB_SHA         the pushed commit SHA.
+//   GITHUB_REF_NAME    the pushed branch name. `release/<major>.<minor>.x`
+//                      selects MAINTENANCE mode; anything else (in practice
+//                      `main`) selects MAINLINE mode.
 //   GITHUB_API_URL     API base (default https://api.github.com).
 //   GITHUB_RUN_ID      this release run's id — resolved to its check_suite_id so
 //                      the wait phase can skip our own (in-progress) suite.
 //                      Auto-present in the Actions runtime; absent off-runner.
 //   RELEASE_SELF_JOBS  comma-separated check-run names belonging to THIS release
 //                      workflow, excluded from the gate.
+//   RELEASE_REQUIRED_CHECKS
+//                      comma-separated EXACT check-run names that MUST have
+//                      posted a run on the commit. The expected set — not
+//                      derived from the API response, which is the whole point.
+//                      Empty/unset is a blocking problem.
+//   RELEASE_INFORMATIONAL_CHECKS
+//                      comma-separated name PREFIXES of explicitly de-gated
+//                      informational lanes. An entry that swallows a
+//                      RELEASE_REQUIRED_CHECKS name is a wiring error.
 //
 // `evaluate(...)` takes the branch HEAD sha, the pushed sha, the raw check-runs,
-// the legacy statuses, the self-job name set, and the released-version tags, and
-// returns a list of blocking problems (empty == release may proceed) plus the
-// count of gated checks. It is a ONE-SHOT decision run AFTER the wait phase has
-// confirmed the CI matrix settled. No network, no exclusions beyond self-jobs —
-// exported so the self-test pins the exact pass/fail boundary. The support-window
-// check is a pure helper (`supportWindowProblem`) folded into the same problems
-// list.
+// the legacy statuses, the self-job name set, the REQUIRED name set, the mode,
+// and the released-version tags, and returns a list of blocking problems (empty
+// == release may proceed) plus the count of gated checks. It is a ONE-SHOT
+// decision run AFTER the wait phase has confirmed the CI matrix settled. No
+// network — exported so the self-test and release-preflight.test.mjs pin the
+// exact pass/fail boundary. The support-window check is a pure helper
+// (`supportWindowProblem`) folded into the same problems list.
 //
 // `allSuitesSettled(suites, ownSuiteId)` is the pure decision behind the wait
 // loop: a check-suite is settled when `status === "completed"`; the release run's
 // own suite (`ownSuiteId`) is ignored. Returns { done, pending } — side-effect
 // free so the self-test pins it; the polling / sleep wrapper lives in main().
 //
-// argv `--self-test` runs the in-process assertion suite and exits.
+// `requiredChecksPending(checkRuns, required)` is its companion: the required
+// names that have posted NO check-run (`missing`) and those whose latest run is
+// not yet `completed` (`running`). The wait loop keeps polling while either is
+// non-empty, so a required lane that never starts times out loudly instead of
+// being read as absent-and-therefore-fine.
+//
+// argv `--self-test` runs the in-process assertion suite and exits. The same
+// pure core is covered by `release-preflight.test.mjs` on the required `lint`
+// lane — release.yml has no `pull_request:` trigger, so `--self-test` alone
+// would leave every change here unverified until a release is cut.
 //
 // Imports only node: builtins (Node ships `fetch`). Run with
 // `node .github/scripts/release-preflight.mjs`.
@@ -102,6 +152,20 @@ import process from 'node:process';
 // `release/1.3.x`. It explicitly does NOT match a main release PR branch like
 // `release/v1.5.0-chart-0.6.4` (those don't end in `.x`).
 export const MAINTENANCE_BRANCH_RE = /^release\/(\d+)\.(\d+)\.x$/;
+
+// The two evaluation modes. MAINTENANCE additionally enforces the branch-tip
+// and support-window rules; MAINLINE does not (main legitimately moves under a
+// release that is still waiting on CI, and the EOL window is a maintenance
+// concept). Everything else — the required-set diff and the green gate — is
+// identical, which is what makes the mainline path a real gate rather than the
+// no-preflight hole it used to be.
+export const MODE_MAINTENANCE = 'maintenance';
+export const MODE_MAINLINE = 'mainline';
+
+// A reusable workflow called from job `X` posts its child check-runs as
+// "X / <child>". Self-job exclusion has to cover those children too: they are
+// downstream of this preflight, so gating on them deadlocks the release.
+export const REUSABLE_JOB_SEPARATOR = ' / ';
 
 // Conclusions that count as a settled, non-blocking check-run.
 const GREEN_CONCLUSIONS = new Set(['success', 'skipped', 'neutral']);
@@ -121,12 +185,19 @@ const APP_TAG_RE = /^v(\d+)\.(\d+)\.\d+$/;
 // publishes — `release-version-gate.mjs` emits `version` without the `v`).
 const APP_VERSION_RE = /^(\d+)\.(\d+)\.(\d+)$/;
 
-// Wait-phase bounds. The preflight polls the commit's check-suites until every
-// non-own suite is `completed`, then evaluates once. maxWaitMs caps the total
-// wall-clock wait (after which the preflight ABORTS — fail-safe, never publish on
-// an unknown state); pollIntervalMs is the gap between check-suite polls.
-const maxWaitMs = 50 * 60 * 1000; // 50 min — comfortably past the slowest CI lane
-const pollIntervalMs = 30 * 1000; // 30 s between check-suite polls
+// Wait-phase bounds. The preflight polls until every non-own check-suite is
+// `completed` AND every required lane has posted a completed run, then evaluates
+// once. releaseWaitMinutes caps the total wall-clock wait (after which the
+// preflight ABORTS — fail-safe, never publish on an unknown state);
+// pollIntervalMs is the gap between polls.
+//
+// The ceiling has to outlast the SLOWEST required lane, which is now
+// migration-e2e's serial path: setup (10) + tier1 (45) + tier2 (60) = 115 min
+// of job timeouts, plus runner queueing. 150 leaves headroom without letting a
+// wedged lane hold a release runner indefinitely.
+const releaseWaitMinutes = 150;
+const maxWaitMs = releaseWaitMinutes * 60 * 1000;
+const pollIntervalMs = 30 * 1000; // 30 s between polls
 
 // ---------------------------------------------------------------------------
 // pure core (exported for the self-test — no network, no process.exit)
@@ -156,6 +227,47 @@ export function allSuitesSettled(suites, ownSuiteId) {
     }
   }
   return { done: pending.length === 0, pending };
+}
+
+// latestByName — re-runs leave several check-runs with the same name; the
+// highest id is the check's current state, so a green re-run supersedes an
+// earlier red. Shared by the wait phase and the one-shot evaluation so the two
+// can never disagree about which run represents a lane.
+function latestByName(checkRuns) {
+  const latest = new Map();
+  for (const cr of checkRuns ?? []) {
+    const prev = latest.get(cr.name);
+    if (!prev || cr.id > prev.id) latest.set(cr.name, cr);
+  }
+  return latest;
+}
+
+// requiredChecksPending — the wait-phase companion to allSuitesSettled, and the
+// reason a lane that never starts cannot be mistaken for a lane that passed.
+// Given the commit's check-runs and the EXPECTED required names, split them:
+//   missing — no check-run with that name exists on the commit at all;
+//   running — a run exists but is not yet `completed`.
+// The wait loop keeps polling while either bucket is non-empty. Suite-level
+// settledness alone is `done` the moment the suites that DID run finish, which
+// is exactly the silence the required set exists to catch.
+//
+// Legacy combined statuses are deliberately NOT consulted here: the required
+// set names check-runs (Actions jobs), and a required name that only ever
+// appeared as a legacy status would sit in `missing` until the timeout — a loud
+// wiring failure rather than a silent pass.
+export function requiredChecksPending(checkRuns, required) {
+  const latest = latestByName(checkRuns);
+  const missing = [];
+  const running = [];
+  for (const name of required ?? []) {
+    const cr = latest.get(name);
+    if (!cr) {
+      missing.push(name);
+      continue;
+    }
+    if (cr.status !== 'completed') running.push(name);
+  }
+  return { missing, running };
 }
 
 // currentMinor — the highest released `<major>.<minor>` from the stable `v*`
@@ -259,35 +371,23 @@ export function retireLineForPublish({ version, tags, windowSize = SUPPORTED_MIN
 }
 
 // evaluate — given the branch tip sha, the pushed sha, the commit's raw
-// check-runs + legacy statuses, and the set of self-job names to exclude,
-// return { problems, gated }. `problems` empty == release may proceed.
-export function evaluate({ branchHead, pushedSha, checkRuns, statuses, selfJobs, branchLabel, tags, informational }) {
+// check-runs + legacy statuses, the self-job names to exclude, the EXPECTED
+// required names and the mode, return { problems, gated }. `problems` empty ==
+// release may proceed.
+export function evaluate({
+  branchHead,
+  pushedSha,
+  checkRuns,
+  statuses,
+  selfJobs,
+  branchLabel,
+  tags,
+  informational,
+  required,
+  mode = MODE_MAINTENANCE,
+}) {
   const problems = [];
-
-  // Support-window / EOL gate — independent of the tip + green-check gates, so
-  // it is evaluated even when the tip check below short-circuits. A push to an
-  // end-of-life line is refused regardless of how green it is.
-  const eol = supportWindowProblem({ branch: branchLabel, tags });
-  if (eol) problems.push(eol);
-
-  if (!branchHead) {
-    problems.push(`could not resolve HEAD of ${branchLabel}`);
-    return { problems, gated: 0 };
-  }
-  if (pushedSha !== branchHead) {
-    problems.push(
-      `pushed commit ${pushedSha.slice(0, 8)} is NOT the tip of ${branchLabel} ` +
-        `(${branchHead.slice(0, 8)}) — a maintenance release may only be cut from the tip of its line`,
-    );
-    return { problems, gated: 0 };
-  }
-
-  // Latest-per-name: the most recent run is the check's current state.
-  const latest = new Map();
-  for (const cr of checkRuns) {
-    const prev = latest.get(cr.name);
-    if (!prev || cr.id > prev.id) latest.set(cr.name, cr);
-  }
+  const requiredNames = required ?? [];
 
   // A check is excluded from the gate if it is one of THIS release run's own
   // jobs (structural — gating on them would deadlock) or an explicitly de-gated
@@ -298,10 +398,73 @@ export function evaluate({ branchHead, pushedSha, checkRuns, statuses, selfJobs,
   // info shard is redundant — a flake there must not block a release. Everything
   // else that ran must be completed + green (a new lane gates by default).
   const isInformational = (name) => (informational ?? []).some((p) => p && name.startsWith(p));
+  // Self-jobs match exactly, or as the parent of a reusable workflow's children
+  // ("<job> / <child>"). Both are structurally downstream of this preflight.
+  const isSelfJob = (name) =>
+    selfJobs.has(name) || [...selfJobs].some((j) => name.startsWith(j + REUSABLE_JOB_SEPARATOR));
+
+  if (mode === MODE_MAINTENANCE) {
+    // Support-window / EOL gate — independent of the tip + green-check gates, so
+    // it is evaluated even when the tip check below short-circuits. A push to an
+    // end-of-life line is refused regardless of how green it is.
+    const eol = supportWindowProblem({ branch: branchLabel, tags });
+    if (eol) problems.push(eol);
+
+    if (!branchHead) {
+      problems.push(`could not resolve HEAD of ${branchLabel}`);
+      return { problems, gated: 0 };
+    }
+    if (pushedSha !== branchHead) {
+      problems.push(
+        `pushed commit ${pushedSha.slice(0, 8)} is NOT the tip of ${branchLabel} ` +
+          `(${branchHead.slice(0, 8)}) — a maintenance release may only be cut from the tip of its line`,
+      );
+      return { problems, gated: 0 };
+    }
+  }
+
+  // Latest-per-name: the most recent run is the check's current state.
+  const latest = latestByName(checkRuns);
+
+  // --- the EXPECTED set ------------------------------------------------------
+  // Everything below this point is observation-derived and therefore blind to a
+  // lane that never ran. The required set is the only part of the gate that is
+  // not, so it is checked first and it is checked against a set the caller
+  // supplied, never against the API response.
+  if (requiredNames.length === 0) {
+    problems.push(
+      'RELEASE_REQUIRED_CHECKS is empty — the gate would degrade to the observational deny-list, ' +
+        'where a lane that never posted a check-run contributes zero problems and publishes silently',
+    );
+  }
+
+  const present = new Set([...latest.keys(), ...(statuses ?? []).map((s) => s.context)]);
+  for (const name of requiredNames) {
+    if (isSelfJob(name)) {
+      problems.push(
+        `${name} is both REQUIRED and excluded by RELEASE_SELF_JOBS — a required lane cannot be one of ` +
+          `this release run's own jobs; gating on it would deadlock. Fix the wiring, do not de-gate.`,
+      );
+      continue;
+    }
+    if (isInformational(name)) {
+      problems.push(
+        `${name} is both REQUIRED and de-gated by RELEASE_INFORMATIONAL_CHECKS (prefix match) — ` +
+          `the informational prefix swallows a required lane, which is a hole, not a de-gate.`,
+      );
+      continue;
+    }
+    if (!present.has(name)) {
+      problems.push(
+        `${name}: REQUIRED lane posted no check-run on ${String(pushedSha).slice(0, 8)} — ` +
+          `it never ran on this commit`,
+      );
+    }
+  }
 
   let gated = 0;
   for (const cr of latest.values()) {
-    if (selfJobs.has(cr.name) || isInformational(cr.name)) continue;
+    if (isSelfJob(cr.name) || isInformational(cr.name)) continue;
     gated += 1;
     if (cr.status !== 'completed') {
       problems.push(`${cr.name}: still ${cr.status} (not completed)`);
@@ -312,7 +475,7 @@ export function evaluate({ branchHead, pushedSha, checkRuns, statuses, selfJobs,
 
   // Legacy combined statuses (e.g. GitGuardian) — each gated context must succeed.
   for (const st of statuses ?? []) {
-    if (selfJobs.has(st.context) || isInformational(st.context)) continue;
+    if (isSelfJob(st.context) || isInformational(st.context)) continue;
     gated += 1;
     if (st.state !== 'success') {
       problems.push(`${st.context}: status ${st.state}`);
@@ -339,8 +502,14 @@ function selfTest() {
     if (!c) throw new Error('self-test: ' + m);
   };
   const cr = (name, status, conclusion, id = 1) => ({ name, status, conclusion, id });
-  const self = new Set(['gate', 'preflight', 'goreleaser', 'chart-release']);
+  const self = new Set(['gate', 'preflight', 'goreleaser', 'release-artifact-migration', 'publish', 'chart-release']);
   const label = 'release/1.4.x';
+  // Every evaluate() world below supplies `required` explicitly: an EMPTY
+  // required set is itself a blocking problem, so a world that omitted it would
+  // pin the degradation guard rather than the detector it means to pin. These
+  // sets are satisfied by construction in their world, so the only problems
+  // reported are the ones each case is about.
+  const requiredCheck = ['check'];
 
   // Branch-shape discrimination: maintenance lines match, main release PR
   // branches do NOT.
@@ -412,6 +581,7 @@ function selfTest() {
       cr('gate', 'in_progress', null), // self-job, excluded even mid-run
     ],
     statuses: [{ context: 'GitGuardian', state: 'success' }],
+    required: requiredCheck,
   });
   assert(r.problems.length === 0, 'all-green tip should pass: ' + r.problems.join('; '));
   assert(r.gated === 6, `expected 6 gated (self-jobs excluded), got ${r.gated}`);
@@ -431,6 +601,7 @@ function selfTest() {
       cr('dashboard-shard (shard-smoke-b)', 'completed', 'failure'),
     ],
     statuses: [],
+    required: requiredCheck,
   });
   assert(r.problems.length === 0, 'informational red must NOT block: ' + r.problems.join('; '));
   assert(r.gated === 2, `informational lanes excluded from the gate, got ${r.gated}`);
@@ -440,6 +611,7 @@ function selfTest() {
     branchHead: 'abc', pushedSha: 'abc', selfJobs: self, branchLabel: label, informational: info,
     checkRuns: [cr('check', 'completed', 'success'), cr('compose-smoke', 'completed', 'failure')],
     statuses: [],
+    required: requiredCheck,
   });
   assert(r.problems.some((p) => /compose-smoke: failure/.test(p)), 'a red gating check must still block');
 
@@ -449,15 +621,22 @@ function selfTest() {
     branchHead: 'abc', pushedSha: 'abc', selfJobs: self, branchLabel: label, informational: info,
     checkRuns: [cr('check', 'completed', 'success'), cr('some-new-lane', 'completed', 'failure')],
     statuses: [],
+    required: requiredCheck,
   });
   assert(r.problems.some((p) => /some-new-lane: failure/.test(p)), 'an unlisted lane must gate by default');
 
   // Pushed commit is NOT the branch tip -> reject (stale re-drive).
-  r = evaluate({ branchHead: 'def', pushedSha: 'abc', selfJobs: self, branchLabel: label, checkRuns: [], statuses: [] });
+  r = evaluate({
+    branchHead: 'def', pushedSha: 'abc', selfJobs: self, branchLabel: label,
+    checkRuns: [], statuses: [], required: requiredCheck,
+  });
   assert(r.problems.length === 1 && /NOT the tip/.test(r.problems[0]), 'non-tip commit must fail');
 
   // Unresolved branch head -> reject.
-  r = evaluate({ branchHead: null, pushedSha: 'abc', selfJobs: self, branchLabel: label, checkRuns: [], statuses: [] });
+  r = evaluate({
+    branchHead: null, pushedSha: 'abc', selfJobs: self, branchLabel: label,
+    checkRuns: [], statuses: [], required: requiredCheck,
+  });
   assert(r.problems.length === 1 && /could not resolve HEAD/.test(r.problems[0]), 'unresolved head must fail');
 
   // A still-running NON-self check -> reject (no "running" allowed).
@@ -468,6 +647,7 @@ function selfTest() {
     branchLabel: label,
     checkRuns: [cr('check', 'in_progress', null)],
     statuses: [],
+    required: requiredCheck,
   });
   assert(r.problems.some((p) => /check: still in_progress/.test(p)), 'running lane must block');
 
@@ -482,6 +662,7 @@ function selfTest() {
       cr('compatibility/loki', 'completed', 'cancelled'),
     ],
     statuses: [],
+    required: ['compose-smoke'],
   });
   assert(r.problems.length === 2, 'two reds must BOTH block (no exclusion)');
 
@@ -496,6 +677,7 @@ function selfTest() {
       cr('check', 'completed', 'success', 2),
     ],
     statuses: [],
+    required: requiredCheck,
   });
   assert(r.problems.length === 0, 'green re-run should supersede earlier fail');
 
@@ -507,6 +689,7 @@ function selfTest() {
     branchLabel: label,
     checkRuns: [],
     statuses: [{ context: 'GitGuardian', state: 'failure' }],
+    required: ['GitGuardian'],
   });
   assert(r.problems.length === 1 && /GitGuardian: status failure/.test(r.problems[0]), 'legacy status red must block');
 
@@ -538,6 +721,7 @@ function selfTest() {
     tags: releasedTags,
     checkRuns: [cr('check', 'completed', 'success')],
     statuses: [],
+    required: requiredCheck,
   });
   assert(r.problems.some((p) => /end-of-life/.test(p)), 'all-green EOL line must still be blocked');
 
@@ -550,6 +734,7 @@ function selfTest() {
     tags: releasedTags,
     checkRuns: [cr('check', 'completed', 'success')],
     statuses: [],
+    required: requiredCheck,
   });
   assert(r.problems.length === 0, 'in-window green line should pass: ' + r.problems.join('; '));
 
@@ -587,6 +772,100 @@ function selfTest() {
     assert(supportWindowProblem({ branch: 'release/1.4.x', tags }) === null, 'the line kept (1.4.x) is still in-window');
   }
 
+  // --- the EXPECTED set: absence must FAIL ---------------------------------
+  // The whole point of `required`. A lane that never ran contributes nothing to
+  // `checkRuns`, so every observation-derived detector above is blind to it.
+  const fullRequired = ['check', 'compose-smoke', 'migration-e2e'];
+  const greenWorld = (names) => ({
+    branchHead: 'abcdef1234',
+    pushedSha: 'abcdef1234',
+    selfJobs: self,
+    branchLabel: label,
+    checkRuns: names.map((n) => cr(n, 'completed', 'success')),
+    statuses: [],
+  });
+
+  // Positive control: every required lane ran green -> no problems.
+  r = evaluate({ ...greenWorld(fullRequired), required: fullRequired });
+  assert(r.problems.length === 0, 'all required lanes green -> pass: ' + r.problems.join('; '));
+
+  // migration-e2e never posted a run: green everywhere else, still BLOCKED.
+  r = evaluate({ ...greenWorld(['check', 'compose-smoke']), required: fullRequired });
+  assert(
+    r.problems.length === 1 && /migration-e2e: REQUIRED lane posted no check-run/.test(r.problems[0]),
+    'an absent REQUIRED lane must block: ' + r.problems.join('; '),
+  );
+  // Negative control: the SAME world with migration-e2e out of `required` is
+  // green — so the detector fires on absence, not unconditionally.
+  r = evaluate({ ...greenWorld(['check', 'compose-smoke']), required: ['check', 'compose-smoke'] });
+  assert(r.problems.length === 0, 'the absence detector must fire on absence only: ' + r.problems.join('; '));
+
+  // Empty required set -> the degradation guard, not a silent pass.
+  r = evaluate({ ...greenWorld(fullRequired), required: [] });
+  assert(
+    r.problems.some((p) => /RELEASE_REQUIRED_CHECKS is empty/.test(p)),
+    'an empty required set must be a blocking problem',
+  );
+
+  // An informational PREFIX that swallows a required name is a wiring error,
+  // reported as such rather than as mere absence.
+  r = evaluate({ ...greenWorld(fullRequired), required: fullRequired, informational: ['migration'] });
+  assert(
+    r.problems.length === 1 && /migration-e2e is both REQUIRED and de-gated/.test(r.problems[0]),
+    'a required lane swallowed by an informational prefix must be a wiring problem: ' + r.problems.join('; '),
+  );
+
+  // A required name that is also a self-job is the other wiring error.
+  r = evaluate({ ...greenWorld(fullRequired), required: [...fullRequired, 'goreleaser'] });
+  assert(
+    r.problems.some((p) => /goreleaser is both REQUIRED and excluded by RELEASE_SELF_JOBS/.test(p)),
+    'a required lane that is a self-job must be a wiring problem',
+  );
+
+  // A reusable workflow's children ("<self-job> / <child>") are self-jobs too.
+  r = evaluate({
+    branchHead: 'abc', pushedSha: 'abc', selfJobs: self, branchLabel: label,
+    checkRuns: [cr('release-artifact-migration / migration-tier1', 'in_progress', null)],
+    statuses: [], required: [],
+  });
+  assert(r.gated === 0, `reusable-workflow children of a self-job must not gate, got ${r.gated}`);
+  assert(
+    !r.problems.some((p) => /release-artifact-migration/.test(p)),
+    "a self-job's reusable children must raise no problem: " + r.problems.join('; '),
+  );
+
+  // --- wait phase: requiredChecksPending ------------------------------------
+  {
+    const runs = [cr('check', 'completed', 'success'), cr('compose-smoke', 'in_progress', null)];
+    const pending = requiredChecksPending(runs, fullRequired);
+    assert(pending.missing.length === 1 && pending.missing[0] === 'migration-e2e', 'a never-posted lane is MISSING');
+    assert(pending.running.length === 1 && pending.running[0] === 'compose-smoke', 'an incomplete lane is RUNNING');
+    const settled = requiredChecksPending(greenWorld(fullRequired).checkRuns, fullRequired);
+    assert(settled.missing.length === 0 && settled.running.length === 0, 'all required completed -> nothing pending');
+  }
+
+  // --- mode split -----------------------------------------------------------
+  // The branch-tip and EOL rules are MAINTENANCE-only; the required set and the
+  // green gate are not.
+  r = evaluate({
+    branchHead: 'def', pushedSha: 'abc', selfJobs: self, branchLabel: 'main',
+    checkRuns: [cr('check', 'completed', 'success')], statuses: [],
+    required: requiredCheck, mode: MODE_MAINLINE,
+  });
+  assert(r.problems.length === 0, 'mainline mode does not enforce the branch tip: ' + r.problems.join('; '));
+  r = evaluate({
+    branchHead: 'def', pushedSha: 'abc', selfJobs: self, branchLabel: label,
+    checkRuns: [cr('check', 'completed', 'success')], statuses: [],
+    required: requiredCheck, mode: MODE_MAINTENANCE,
+  });
+  assert(r.problems.some((p) => /NOT the tip/.test(p)), 'maintenance mode DOES enforce the branch tip');
+  r = evaluate({
+    branchHead: 'abc', pushedSha: 'abc', selfJobs: self, branchLabel: 'release/1.2.x', tags: releasedTags,
+    checkRuns: [cr('check', 'completed', 'success')], statuses: [],
+    required: requiredCheck, mode: MODE_MAINLINE,
+  });
+  assert(!r.problems.some((p) => /end-of-life/.test(p)), 'mainline mode does not enforce the EOL window');
+
   ghNotice('release-preflight --self-test: all assertions passed');
 }
 
@@ -614,14 +893,21 @@ async function main() {
     .split(',')
     .map((s) => s.trim())
     .filter(Boolean);
+  // The EXPECTED set — exact check-run names that MUST have posted a run on the
+  // commit. Parsed the same way as the informational list, but consumed as EXACT
+  // names, not prefixes: a required lane is a specific job, not a family.
+  const required = (process.env.RELEASE_REQUIRED_CHECKS ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
 
-  if (!MAINTENANCE_BRANCH_RE.test(branch)) {
-    ghError(
-      `release-preflight is the MAINTENANCE-path guard and must only run on a release/<major>.<minor>.x branch; ` +
-        `got GITHUB_REF_NAME="${branch}". This is a workflow-wiring error.`,
-    );
-    process.exit(1);
-  }
+  // Mode is derived from the branch, not passed in: a `release/*.x` push is the
+  // maintenance path (tip + support-window rules apply), anything else is the
+  // mainline path. There is no "not applicable" third state — the preflight
+  // always gates.
+  const mode = MAINTENANCE_BRANCH_RE.test(branch) ? MODE_MAINTENANCE : MODE_MAINLINE;
+  const label = mode === MODE_MAINTENANCE ? 'maintenance preflight' : 'mainline preflight';
+
   if (!repo || !pushedSha || !token) {
     ghError('GITHUB_REPOSITORY, GITHUB_SHA, and GITHUB_TOKEN are all required');
     process.exit(1);
@@ -714,33 +1000,47 @@ async function main() {
 
   // --- WAIT PHASE: poll until the CI matrix on the commit settles -------------
   // release.yml fires on the same push as CI, so a one-shot snapshot here would
-  // see everything queued/in_progress and false-abort. Poll the check-suites
-  // until every non-own suite is completed, bounded by maxWaitMs. On timeout,
-  // ABORT naming the still-running suites (fail-safe — never publish on an
-  // unknown state).
+  // see everything queued/in_progress and false-abort. Poll until BOTH every
+  // non-own check-SUITE is completed AND every REQUIRED lane has posted a
+  // completed check-run, bounded by maxWaitMs. The second condition is what
+  // makes a lane that never started time out loudly: suite settledness alone is
+  // satisfied by the suites that DID run, so silence would read as "settled".
+  // On timeout, ABORT naming missing and running lanes separately (fail-safe —
+  // never publish on an unknown state).
   const ownId = await ownSuiteId();
   const waitDeadline = Date.now() + maxWaitMs;
   for (;;) {
     const suites = await allCheckSuites();
     const { done, pending } = allSuitesSettled(suites, ownId);
-    if (done) {
+    const { missing, running } = requiredChecksPending(await allCheckRuns(), required);
+    if (done && missing.length === 0 && running.length === 0) {
       ghNotice(
-        `maintenance preflight: CI matrix on ${pushedSha.slice(0, 8)} has settled ` +
-          `(${suites.length} check-suite(s)); evaluating green gate.`,
+        `${label}: CI matrix on ${pushedSha.slice(0, 8)} has settled ` +
+          `(${suites.length} check-suite(s)) and all ${required.length} required lane(s) have completed; ` +
+          `evaluating green gate.`,
       );
       break;
     }
     if (Date.now() >= waitDeadline) {
+      if (missing.length > 0) {
+        ghError(
+          `${label}: REQUIRED lane(s) never posted a check-run on ${branch}@${pushedSha.slice(0, 8)}: ` +
+            `${missing.join(', ')}. Either the workflow does not trigger on this branch, or it failed to ` +
+            `start. A lane that did not run has not passed — refusing to publish.`,
+        );
+      }
       ghError(
-        `maintenance preflight: timed out after ${Math.round(maxWaitMs / 60000)} min waiting for CI on ` +
-          `${branch}@${pushedSha.slice(0, 8)} to finish — still running: ${pending.join(', ')}. ` +
+        `${label}: timed out after ${releaseWaitMinutes} min waiting for CI on ` +
+          `${branch}@${pushedSha.slice(0, 8)} to finish — required still running: ` +
+          `${running.join(', ') || '(none)'}; suites still running: ${pending.join(', ') || '(none)'}. ` +
           `Refusing to publish on an incomplete state; re-run once CI settles.`,
       );
       process.exit(1);
     }
     ghNotice(
-      `maintenance preflight: ${pending.length} check-suite(s) still running ` +
-        `(${pending.join(', ')}); re-polling in ${Math.round(pollIntervalMs / 1000)}s.`,
+      `${label}: ${pending.length} check-suite(s) still running (${pending.join(', ') || 'none'}); ` +
+        `required missing: ${missing.join(', ') || 'none'}; required running: ${running.join(', ') || 'none'}; ` +
+        `re-polling in ${Math.round(pollIntervalMs / 1000)}s.`,
     );
     await sleep(pollIntervalMs);
   }
@@ -760,19 +1060,23 @@ async function main() {
     branchLabel: branch,
     tags,
     informational,
+    required,
+    mode,
   });
 
   if (problems.length > 0) {
-    for (const p of problems) ghError(`maintenance preflight: ${p}`);
+    for (const p of problems) ghError(`${label}: ${p}`);
     ghError(
-      `maintenance release of ${branch}@${pushedSha.slice(0, 8)} BLOCKED: ` +
-        `${problems.length} problem(s) across ${gated} gated check(s). Fix the red/running checks and re-push.`,
+      `release of ${branch}@${pushedSha.slice(0, 8)} BLOCKED: ${problems.length} problem(s) across ` +
+        `${gated} gated check(s) and ${required.length} required lane(s). ` +
+        `Fix the red/running/absent checks and re-push.`,
     );
     process.exit(1);
   }
 
   ghNotice(
-    `maintenance preflight OK: ${branch}@${pushedSha.slice(0, 8)} is the branch tip and all ${gated} gated check(s) are settled green.`,
+    `${label} OK: ${branch}@${pushedSha.slice(0, 8)} has all ${required.length} required lane(s) present and ` +
+      `all ${gated} gated check(s) settled green.`,
   );
   process.exit(0);
 }
@@ -919,21 +1223,28 @@ async function retireLine() {
 // dispatcher
 // ---------------------------------------------------------------------------
 
-if (process.argv.includes('--self-test')) {
-  selfTest();
-  process.exit(0);
-}
+// Only dispatch when run as a script — importing the pure core for
+// release-preflight.test.mjs must not fire the network driver or exit the test
+// runner. (Same idiom as migration-e2e.mjs / compose-smoke-matrix.mjs.)
+const invokedDirectly = process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href;
 
-const cmd = process.argv[2];
-if (cmd === 'eol-retire-line') {
-  retireLine().catch((e) => {
-    // Even an unexpected throw is fail-open: the release already shipped.
-    ghError(`eol-retire-line: unexpected failure (${e.message}) — retiring nothing (fail-open)`);
+if (invokedDirectly) {
+  if (process.argv.includes('--self-test')) {
+    selfTest();
     process.exit(0);
-  });
-} else {
-  main().catch((e) => {
-    ghError(`release-preflight failed: ${e.message}`);
-    process.exit(1);
-  });
+  }
+
+  const cmd = process.argv[2];
+  if (cmd === 'eol-retire-line') {
+    retireLine().catch((e) => {
+      // Even an unexpected throw is fail-open: the release already shipped.
+      ghError(`eol-retire-line: unexpected failure (${e.message}) — retiring nothing (fail-open)`);
+      process.exit(0);
+    });
+  } else {
+    main().catch((e) => {
+      ghError(`release-preflight failed: ${e.message}`);
+      process.exit(1);
+    });
+  }
 }

--- a/.github/scripts/release-preflight.test.mjs
+++ b/.github/scripts/release-preflight.test.mjs
@@ -1,0 +1,224 @@
+// release-preflight.test.mjs — node:test guard for the RELEASE GATE's expected
+// set, run on the required `lint` lane.
+//
+// Why it exists separately from `release-preflight.mjs --self-test`: that
+// self-test only runs inside release.yml, which has NO `pull_request:` trigger.
+// Every change to the gate would therefore be unverified until a release is
+// actually cut — the one moment you least want to discover it. This suite runs
+// on every PR (`lint` has no `docs_only` condition, unlike `check`).
+//
+// What it pins, and why each pin is written the way it is:
+//
+//   The gate used to be observation-derived: `evaluate()` iterated the
+//   check-runs the API returned, so a lane that never ran contributed zero
+//   entries and therefore zero problems. "migration-e2e now gates the release"
+//   was satisfiable by changing nothing. The `required` set is the fix, so the
+//   headline test is a NEGATIVE control: the same absent-lane world must be
+//   GREEN once the name leaves `required`. A detector rewritten to fire
+//   unconditionally passes an absence test but fails that one.
+//
+//   Every case also asserts the OTHER detectors stay silent, so a rewrite that
+//   turns one problem into three does not slip through on a `.some()` match.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  evaluate,
+  requiredChecksPending,
+  allSuitesSettled,
+  MODE_MAINLINE,
+  MODE_MAINTENANCE,
+  REUSABLE_JOB_SEPARATOR,
+} from './release-preflight.mjs';
+
+// The release run's own jobs, as release.yml wires them into RELEASE_SELF_JOBS.
+const SELF_JOBS = new Set([
+  'gate',
+  'preflight',
+  'goreleaser',
+  'release-artifact-migration',
+  'publish',
+  'brew-smoke',
+  'chart-release',
+]);
+
+// A representative slice of the required set release.yml supplies. It MUST
+// contain `migration-e2e` — that is the lane the whole deliverable is about, and
+// the negative control below asserts on its removal, so a required set that
+// silently lost it would make this file's headline test vacuous.
+const REQUIRED = ['check', 'lint', 'compose-smoke', 'migration-e2e'];
+
+const SHA = 'abcdef1234567890';
+
+function run(name, { status = 'completed', conclusion = 'success', id = 1 } = {}) {
+  return { name, status, conclusion, id };
+}
+
+// A world in which exactly `names` posted a green check-run on the pushed
+// commit, which is also the branch tip.
+function world({ names = REQUIRED, statuses = [], ...rest } = {}) {
+  return {
+    branchHead: SHA,
+    pushedSha: SHA,
+    selfJobs: SELF_JOBS,
+    branchLabel: 'release/1.4.x',
+    checkRuns: names.map((n) => run(n)),
+    statuses,
+    required: REQUIRED,
+    mode: MODE_MAINTENANCE,
+    ...rest,
+  };
+}
+
+test('positive control: every required lane ran green -> no problems', () => {
+  const r = evaluate(world());
+  assert.deepEqual(r.problems, []);
+  assert.equal(r.gated, REQUIRED.length);
+});
+
+test('an absent required lane blocks, and ONLY on its absence', () => {
+  // Precondition: the negative control below is only meaningful if the name is
+  // actually in the required set.
+  assert.ok(REQUIRED.includes('migration-e2e'), 'REQUIRED must contain migration-e2e for this test to mean anything');
+
+  const withoutLane = REQUIRED.filter((n) => n !== 'migration-e2e');
+
+  // (a) The lane never posted a check-run: everything else is green, and the
+  // release is BLOCKED anyway.
+  const blocked = evaluate(world({ names: withoutLane }));
+  assert.equal(blocked.problems.length, 1, `expected exactly one problem, got: ${blocked.problems.join('; ')}`);
+  assert.match(blocked.problems[0], /^migration-e2e: REQUIRED lane posted no check-run/);
+
+  // (a, negative control) The SAME world with the name out of `required` is
+  // green. This is what fails if the detector is rewritten to fire
+  // unconditionally — the other way to fake an absence test green.
+  const green = evaluate(world({ names: withoutLane, required: withoutLane }));
+  assert.deepEqual(green.problems, []);
+});
+
+test('a required lane that ran RED is a different problem than one that never ran', () => {
+  const names = REQUIRED.filter((n) => n !== 'migration-e2e');
+  const r = evaluate(
+    world({
+      names,
+      checkRuns: [...names.map((n) => run(n)), run('migration-e2e', { conclusion: 'failure' })],
+    }),
+  );
+  assert.equal(r.problems.length, 1, `expected exactly one problem, got: ${r.problems.join('; ')}`);
+  assert.equal(r.problems[0], 'migration-e2e: failure');
+  assert.ok(
+    !r.problems.some((p) => /posted no check-run/.test(p)),
+    'a lane that ran and failed must not be reported as absent',
+  );
+});
+
+test('an empty required set is itself a blocking problem', () => {
+  const r = evaluate(world({ required: [] }));
+  assert.equal(r.problems.length, 1, `expected exactly one problem, got: ${r.problems.join('; ')}`);
+  assert.match(r.problems[0], /RELEASE_REQUIRED_CHECKS is empty/);
+  // The degradation this guards: without it, the same call is silently green.
+  assert.ok(/deny-list/.test(r.problems[0]), 'the message must name the failure mode it prevents');
+});
+
+test('an informational PREFIX that swallows a required lane is a wiring error, not an absence', () => {
+  // `migration` as an informational prefix would de-gate the whole migration
+  // family, including the required aggregate.
+  const r = evaluate(world({ informational: ['migration'] }));
+  assert.equal(r.problems.length, 1, `expected exactly one problem, got: ${r.problems.join('; ')}`);
+  assert.match(r.problems[0], /^migration-e2e is both REQUIRED and de-gated by RELEASE_INFORMATIONAL_CHECKS/);
+  assert.ok(
+    !r.problems.some((p) => /posted no check-run/.test(p)),
+    'the swallowed lane must be reported as mis-wired, not as merely absent',
+  );
+
+  // An informational prefix that does NOT collide stays a legitimate de-gate.
+  const ok = evaluate(world({ informational: ['compose-smoke-shard-info', 'dashboard'] }));
+  assert.deepEqual(ok.problems, []);
+});
+
+test('a required lane that is also a self-job is a wiring error', () => {
+  const r = evaluate(world({ required: [...REQUIRED, 'goreleaser'] }));
+  assert.equal(r.problems.length, 1, `expected exactly one problem, got: ${r.problems.join('; ')}`);
+  assert.match(r.problems[0], /^goreleaser is both REQUIRED and excluded by RELEASE_SELF_JOBS/);
+});
+
+test('requiredChecksPending splits missing from running', () => {
+  const checkRuns = [run('check'), run('lint'), run('compose-smoke', { status: 'in_progress', conclusion: null })];
+  const { missing, running } = requiredChecksPending(checkRuns, REQUIRED);
+  assert.deepEqual(missing, ['migration-e2e']);
+  assert.deepEqual(running, ['compose-smoke']);
+
+  // All present + completed -> nothing pending, so the wait loop proceeds.
+  const settled = requiredChecksPending(
+    REQUIRED.map((n) => run(n)),
+    REQUIRED,
+  );
+  assert.deepEqual(settled, { missing: [], running: [] });
+
+  // Latest-per-name: a green re-run supersedes an earlier in-flight run.
+  const rerun = requiredChecksPending(
+    [run('check', { status: 'in_progress', conclusion: null, id: 1 }), run('check', { id: 2 })],
+    ['check'],
+  );
+  assert.deepEqual(rerun, { missing: [], running: [] });
+});
+
+test('a required lane that never runs is NOT hidden by suite-level settledness', () => {
+  // The trap this closes: every suite that DID run is `completed`, so the
+  // suite-only wait is done and the gate would evaluate against a silence.
+  const suites = [{ id: 1, status: 'completed', app: { slug: 'ci' }, latest_check_runs_count: 3 }];
+  assert.equal(allSuitesSettled(suites, null).done, true);
+  const { missing } = requiredChecksPending([run('check'), run('lint'), run('compose-smoke')], REQUIRED);
+  assert.deepEqual(missing, ['migration-e2e'], 'suite settledness says done; the required set says otherwise');
+});
+
+test('mode split: the branch-tip rule is maintenance-only, in both directions', () => {
+  const moved = { branchHead: 'ffffffffffffffff' };
+
+  const mainline = evaluate(world({ ...moved, branchLabel: 'main', mode: MODE_MAINLINE }));
+  assert.deepEqual(mainline.problems, [], 'main legitimately moves under a release waiting on CI');
+
+  const maintenance = evaluate(world({ ...moved, mode: MODE_MAINTENANCE }));
+  assert.equal(maintenance.problems.length, 1, `expected exactly one problem, got: ${maintenance.problems.join('; ')}`);
+  assert.match(maintenance.problems[0], /is NOT the tip of release\/1\.4\.x/);
+});
+
+test('mode split: the EOL support window is maintenance-only, in both directions', () => {
+  const tags = ['v1.5.0', 'v1.4.0', 'v1.3.0', 'v1.2.0'];
+
+  const mainline = evaluate(world({ branchLabel: 'main', tags, mode: MODE_MAINLINE }));
+  assert.deepEqual(mainline.problems, []);
+
+  const maintenance = evaluate(world({ branchLabel: 'release/1.2.x', tags, mode: MODE_MAINTENANCE }));
+  assert.ok(
+    maintenance.problems.some((p) => /end-of-life/.test(p)),
+    `an EOL maintenance line must be refused, got: ${maintenance.problems.join('; ')}`,
+  );
+});
+
+test("a self-job's reusable-workflow children are excluded structurally", () => {
+  // release-artifact-migration `uses:` migration-e2e.yml, so its check-runs are
+  // posted as "release-artifact-migration / migration-tier1". They start AFTER
+  // this preflight, so gating on them deadlocks the release.
+  assert.equal(REUSABLE_JOB_SEPARATOR, ' / ');
+  const child = 'release-artifact-migration' + REUSABLE_JOB_SEPARATOR + 'migration-tier1';
+  const r = evaluate(
+    world({
+      names: REQUIRED,
+      checkRuns: [...REQUIRED.map((n) => run(n)), run(child, { status: 'in_progress', conclusion: null })],
+    }),
+  );
+  assert.deepEqual(r.problems, []);
+  assert.equal(r.gated, REQUIRED.length, 'the reusable child must not be counted as a gated check');
+});
+
+test('legacy statuses satisfy the required set too, and a red one still blocks', () => {
+  const required = [...REQUIRED, 'GitGuardian'];
+  const green = evaluate(world({ required, statuses: [{ context: 'GitGuardian', state: 'success' }] }));
+  assert.deepEqual(green.problems, []);
+
+  const red = evaluate(world({ required, statuses: [{ context: 'GitGuardian', state: 'failure' }] }));
+  assert.equal(red.problems.length, 1, `expected exactly one problem, got: ${red.problems.join('; ')}`);
+  assert.equal(red.problems[0], 'GitGuardian: status failure');
+});

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,6 +302,33 @@ jobs:
           MODE: verify
           SCENARIOS_JSON: build/migration-scenarios.json
 
+      # The release gate's own guards. release.yml has NO `pull_request:`
+      # trigger, so `release-preflight.mjs --self-test` and the brew smoke only
+      # ever execute while a release is being cut — the one moment a regression
+      # in them is most expensive. These two suites are pure (no network, no
+      # brew, no GitHub API), so they run here, on every PR, where a break is
+      # cheap.
+      #
+      # The preflight suite's headline case is that a REQUIRED lane which posted
+      # no check-run blocks the publish, with the negative control that the same
+      # world is green once the name leaves the required set — the gate used to
+      # be observation-derived, so "lane X now gates the release" was satisfiable
+      # by changing nothing.
+      - name: release-preflight self-test (required-set guard)
+        run: node --test .github/scripts/release-preflight.test.mjs
+
+      - name: brew-smoke self-test (formula-freshness guard)
+        run: node --test .github/scripts/brew-smoke.test.mjs
+
+      # The migration lane's artifact resolver, here for the same reason:
+      # migration-e2e.yml has no `pull_request:` trigger either, so this is the
+      # only place a loosening of `resolvePlan` — accepting a half-supplied
+      # (cerberus_image, expect_version) pair and quietly building from source
+      # under an artifact-shaped job name — is caught before a release run
+      # depends on it.
+      - name: migration-artifact self-test (build-once seam guard)
+        run: node --test .github/scripts/migration-artifact.test.mjs
+
   # `forbid-skip` is the GA test-discipline gate. The maintainer's
   # NON-NEGOTIABLE rule is "no t.Skip in test files — fix the bug, do
   # not skip." Greps `*_test.go` for `t.Skip` / `t.Skipf` / `t.SkipNow`

--- a/.github/workflows/migration-e2e.yml
+++ b/.github/workflows/migration-e2e.yml
@@ -29,7 +29,12 @@ name: migration-e2e
 
 on:
   push:
-    branches: [main]
+    # `release/*.x` is here because release.yml's `preflight` REQUIRES a green
+    # `migration-e2e` check-run on the released commit, and a maintenance
+    # backport publishes from its own line. Without this branch the required
+    # lane would simply never run there and every patch release would (correctly)
+    # block forever.
+    branches: [main, 'release/*.x']
   schedule:
     # Nightly, offset from the e2e and compatibility lanes.
     - cron: '37 4 * * *'
@@ -44,12 +49,45 @@ on:
         description: 'a single MIG id to drive, e.g. MIG-04'
         type: string
         required: false
+  # Called by release.yml's `release-artifact-migration`, which re-runs this lane
+  # against the image goreleaser just built — the push-triggered run above proves
+  # the SOURCE TREE, this one proves the ARTIFACT. `inputs.*` reads identically
+  # for workflow_dispatch and workflow_call, so the job bodies are unchanged.
+  #
+  # This is still NOT a `pull_request:` trigger: the workflow remains ineligible
+  # as a branch-protection check, and release.yml's preflight is what makes it
+  # blocking.
+  workflow_call:
+    inputs:
+      tier:
+        description: 'which tier(s) to run'
+        type: string
+        default: all
+      story:
+        description: 'a single MIG id to drive, e.g. MIG-04'
+        type: string
+        required: false
+      cerberus_image:
+        description: 'released image to drive instead of a locally built one; empty = build from this tree'
+        type: string
+        default: ''
+      expect_version:
+        description: 'version the running server must report; empty = no version assertion'
+        type: string
+        default: ''
 
 permissions:
   contents: read
+  # Pulling the released image from GHCR. A called workflow gets the
+  # INTERSECTION of the caller's grant and this block, so omitting it here would
+  # silently drop the caller's `packages: read`.
+  packages: read
 
 concurrency:
-  group: migration-e2e-${{ github.ref }}
+  # The artifact run and the source-tree run share a ref, so the image tag is
+  # part of the key: without it the release's call would queue behind (or be
+  # queued behind) the push run on the same commit.
+  group: migration-e2e-${{ github.ref }}-${{ inputs.cerberus_image || 'source-tree' }}
   cancel-in-progress: false
 
 jobs:
@@ -130,11 +168,32 @@ jobs:
           name: migration-scenarios
           path: build
 
-      # The scenarios exec a real `cerberus migrate`. Building it here and
-      # handing it over via CERBERUS_BIN keeps the build failure separate
-      # from a scenario failure in the log.
-      - name: build the cerberus binary the scenarios drive
-        run: go build -o build/cerberus ./cmd/cerberus
+      # Unconditional, in every tier job, ahead of the resolver: the released
+      # image lives in GHCR, and a first-publish package is not necessarily
+      # public at the instant the artifact lane pulls it. No `if:` guard, so
+      # there is no condition whose falsification would let the release path
+      # silently fall back to a source build.
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # WHICH cerberus this run tests. On a PR / dispatch / push run both inputs
+      # are empty and the resolver compiles the CLI from this tree; on
+      # release.yml's `release-artifact-migration` call it extracts the CLI out
+      # of the released image, so the binary the scenarios exec and the server
+      # the stack runs are the same bytes. Either way it probes `--version` and
+      # refuses a binary that is not the one this run claims to test, and
+      # exports CERBERUS_BIN / CERBERUS_IMAGE / CERBERUS_EXPECT_VERSION for
+      # every later step. Keeping it its own step also keeps a build failure
+      # separate from a scenario failure in the log.
+      - name: resolve the cerberus artifact under test
+        run: node .github/scripts/migration-artifact.mjs
+        env:
+          CERBERUS_IMAGE_INPUT: ${{ inputs.cerberus_image }}
+          CERBERUS_EXPECT_VERSION_INPUT: ${{ inputs.expect_version }}
 
       - name: run the migration scenarios
         run: node .github/scripts/migration-e2e.mjs
@@ -143,7 +202,6 @@ jobs:
           SCENARIOS_JSON: build/migration-scenarios.json
           TIER: tier0
           STORY: ${{ inputs.story }}
-          CERBERUS_BIN: ${{ github.workspace }}/build/cerberus
 
       # The cucumber-JSON run report MODE=run made the suite write. This is
       # the EVIDENCE half of the coverage ratchet: migration-aggregate
@@ -226,6 +284,15 @@ jobs:
           username: tsouza
           password: ${{ secrets.DOCKER_HUB_PAT }}
 
+      # See migration-tier0's identical block: unconditional so the artifact
+      # lane's GHCR pull can never silently degrade into a source build.
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       # migration-tier1 runs on a separate runner with a fresh checkout, so
       # the enumerator output from migration-setup must travel as an
       # artifact — same reason migration-tier0 downloads it too.
@@ -234,6 +301,18 @@ jobs:
         with:
           name: migration-scenarios
           path: build
+
+      # See migration-tier0's identical step. This tier used to acquire no CLI
+      # at all (lib.BuildCerberus compiled one in-process), which meant the
+      # release path had no seam to hand a released binary through and no place
+      # to fail early on a wrong one. It also puts CERBERUS_IMAGE into the env
+      # `just migration-cerberus-image` and the compose file read, so the stack
+      # below runs the image this run resolved.
+      - name: resolve the cerberus artifact under test
+        run: node .github/scripts/migration-artifact.mjs
+        env:
+          CERBERUS_IMAGE_INPUT: ${{ inputs.cerberus_image }}
+          CERBERUS_EXPECT_VERSION_INPUT: ${{ inputs.expect_version }}
 
       - name: bring the Tier-1 stack up
         run: just migration-tier1-up
@@ -361,11 +440,28 @@ jobs:
           username: tsouza
           password: ${{ secrets.DOCKER_HUB_PAT }}
 
+      # See migration-tier0's identical block.
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: download migration scenarios enumeration
         uses: actions/download-artifact@v7
         with:
           name: migration-scenarios
           path: build
+
+      # See migration-tier1's identical step — the Tier-2 stack is a superset of
+      # Tier-1's and runs the same `cerberus` service, so it resolves the same
+      # artifact.
+      - name: resolve the cerberus artifact under test
+        run: node .github/scripts/migration-artifact.mjs
+        env:
+          CERBERUS_IMAGE_INPUT: ${{ inputs.cerberus_image }}
+          CERBERUS_EXPECT_VERSION_INPUT: ${{ inputs.expect_version }}
 
       - name: bring the Tier-2 stack up
         run: just migration-tier2-up

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,19 @@ name: release
 #        auto-tag ONLY the changed artifact(s).
 #
 # The merge-when-green branch protection (every required check green on a tree
-# that is up to date with main) is the gate that the deleted `preflight` job
-# used to enforce by re-reading check-runs on the tagged commit. Because the PR
-# merged green against the exact merged tree, the merge commit is releasable by
-# construction — no second "is main green?" probe is needed.
+# that is up to date with main) covers the lanes that CAN be branch-protection
+# checks. It does NOT cover the lanes that carry no `pull_request:` trigger:
+# `migration-e2e` is deliberately push/schedule-only, so it can never become a
+# branch-protection check and has therefore NEVER run on the tree being
+# released — the merge commit is the first tree it sees. That is why the
+# `preflight` job below now runs on the MAIN path too, and why it is handed an
+# EXPECTED set (`RELEASE_REQUIRED_CHECKS`) rather than left to gate on whatever
+# the API happens to return: a lane that never ran contributes zero check-runs,
+# zero problems, and publishes in silence.
+#
+# `preflight` is PUBLISH-gated, not path-gated: it is skipped entirely on the
+# ordinary merges that publish nothing, so no runner time is spent waiting for
+# CI on a commit that ships no artifact.
 #
 # Idempotency / no-op safety: a merge that bumped NEITHER version line is a
 # complete no-op. The app gate (release-version-gate.mjs) sets publish=false
@@ -126,26 +135,40 @@ jobs:
           echo "app:   publish=${{ steps.app.outputs.publish }} version=${{ steps.app.outputs.version }} tag=${{ steps.app.outputs.tag }}"
           echo "chart: publish=${{ steps.chart.outputs.publish }} version=${{ steps.chart.outputs.version }}"
 
-  # Green-check guard — MAINTENANCE PATH ONLY.
+  # Green-check guard — BOTH release paths, gated on "something actually
+  # publishes" rather than on which branch was pushed.
   #
-  # A push to `main` is implicitly green: branch protection refuses to merge a
-  # PR whose required checks are red or whose tree is behind main, so the merge
-  # commit is releasable by construction and needs no preflight. A push to a
-  # `release/*.x` maintenance branch has NO PR gate — a maintainer cherry-picks
-  # a hotfix straight onto the branch — so publishing it unguarded could ship a
-  # RED commit. This job re-reads the pushed commit's check-runs + legacy
-  # statuses and FAILS the release unless the commit is the branch tip AND every
-  # required check is settled green.
+  # MAIN path: branch protection already refused to merge a PR whose REQUIRED
+  # checks were red, but `migration-e2e` has no `pull_request:` trigger by
+  # design, so it never ran on the PR and the merge commit is the first tree it
+  # sees. Without this job nothing re-reads main at all, and a red (or absent)
+  # migration lane publishes unobserved.
   #
-  # It runs ONLY on a `release/*.x` push (the `if` below); on main + dispatch it
-  # is skipped, and the publish jobs' `always() && (preflight skipped || passed)`
-  # guard keeps the main path preflight-free. The standard CI workflows (ci /
-  # compatibility / chdb / e2e) are wired to also run on `release/*.x` pushes,
-  # so there ARE check-runs on the maintenance commit for this gate to read.
+  # MAINTENANCE path (`release/*.x`): no PR gate whatsoever — a maintainer
+  # cherry-picks a hotfix straight onto the line — so on top of the green gate
+  # the script additionally requires the pushed commit to be the branch TIP and
+  # the line to be inside the support window (EOL lines get no hotfixes). Both
+  # rules are maintenance-only; `release-preflight.mjs` derives the mode from
+  # GITHUB_REF_NAME.
+  #
+  # The `if:` is a PUBLISH gate, not a path gate: an ordinary merge that bumps
+  # neither version line skips this job entirely, so no runner sits waiting on
+  # CI for a commit that ships nothing. The publish jobs still wrap their guards
+  # in `always()` — a SKIPPED preflight would otherwise cascade its skip down the
+  # chain — but they require `preflight == 'success'` outright: the old
+  # `|| skipped` disjunction existed only because preflight was maintenance-only,
+  # and keeping it would let a mis-edited `if:` publish unguarded.
+  #
+  # ABSENCE IS A FAILURE: `RELEASE_REQUIRED_CHECKS` is the EXPECTED set the
+  # script does not derive from the API response. Every name in it must have
+  # posted a check-run on the commit; an empty value, or a required name that
+  # `RELEASE_INFORMATIONAL_CHECKS` would swallow by prefix, is itself a blocking
+  # problem. test/regression/release_gate_test.go pins this wiring at PR time —
+  # this workflow has no `pull_request:` trigger, so nothing else does.
   preflight:
     name: preflight
     needs: gate
-    if: startsWith(github.ref, 'refs/heads/release/') && endsWith(github.ref, '.x')
+    if: needs.gate.outputs.app_publish == 'true' || needs.gate.outputs.chart_publish == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -157,22 +180,38 @@ jobs:
       - name: preflight self-test
         run: node .github/scripts/release-preflight.mjs --self-test
 
-      - name: Verify the line is in-window, the commit is the branch tip, and fully green
+      - name: preflight required-set guard
+        run: node --test .github/scripts/release-preflight.test.mjs
+
+      - name: Verify every required lane ran and the commit is fully green
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # This release run's own jobs are necessarily in-progress while the
           # preflight reads check-runs, so they're excluded structurally (gating
-          # on them would deadlock).
-          RELEASE_SELF_JOBS: gate,preflight,goreleaser,chart-release
+          # on them would deadlock). A reusable workflow called from one of them
+          # posts children as "<job> / <child>"; release-preflight.mjs matches
+          # that prefix too, so release-artifact-migration's tier jobs are
+          # excluded without being named individually.
+          RELEASE_SELF_JOBS: gate,preflight,goreleaser,release-artifact-migration,publish,brew-smoke,chart-release
+          # The EXPECTED set — exact check-run names that MUST have posted a run
+          # on this commit. It is the branch-protection required set (see
+          # CLAUDE.md) PLUS `migration-e2e`, which can never BE a
+          # branch-protection check because migration-e2e.yml has no
+          # `pull_request:` trigger. Deleting a name from here silently shrinks
+          # the gate, so release_gate_test.go asserts `migration-e2e` is present
+          # on every PR.
+          RELEASE_REQUIRED_CHECKS: "check,lint,forbid-skip,compatibility/prometheus,compatibility/loki,compatibility/tempo,probe,roundtrip (promql),roundtrip (logql),roundtrip (traceql),compose-smoke,migration-e2e"
           # De-gated INFORMATIONAL lanes, matched by name prefix (matrix children
           # carry a "(shard-…)" suffix). The required `compose-smoke` aggregate
           # does NOT `needs:` the crawl info shard, and `dashboard` is informational
-          # on merges — a flake in either must not block a hotfix release.
+          # on merges — a flake in either must not block a release. A prefix here
+          # that swallows a RELEASE_REQUIRED_CHECKS name fails the preflight as a
+          # wiring error rather than quietly de-gating it.
           RELEASE_INFORMATIONAL_CHECKS: compose-smoke-shard-info,dashboard
-        # Also enforces the support-window / EOL policy: a push to a maintenance
-        # line 3+ minors behind the current minor is refused (the line is EOL,
-        # gets no hotfixes). See docs/operations.md "Release support window / EOL
-        # policy".
+        # On the maintenance path this also enforces the support-window / EOL
+        # policy: a push to a line 3+ minors behind the current minor is refused
+        # (the line is EOL, gets no hotfixes). See docs/operations.md "Release
+        # support window / EOL policy".
         run: node .github/scripts/release-preflight.mjs
 
   # App release — binary archives + multi-arch images (GHCR + Docker Hub) +
@@ -188,16 +227,21 @@ jobs:
   goreleaser:
     name: goreleaser
     needs: [gate, preflight]
-    # Publish when the app gate says the appVersion is new AND the maintenance
-    # green-check guard is satisfied. On the main / dispatch path `preflight` is
-    # SKIPPED (result == 'skipped'), so `always()` unwraps the skip and the main
-    # path goes through preflight-free; on the maintenance path `preflight` must
-    # have SUCCEEDED. Requiring success-OR-skipped (not just `!= failure`) means
-    # a CANCELLED or otherwise non-green preflight also blocks the publish.
+    # Publish when the app gate says the appVersion is new AND the green-check
+    # guard is satisfied. `preflight` is gated on the SAME publish condition, so
+    # on every run that reaches here it ran — requiring SUCCESS outright, with no
+    # `|| skipped` disjunction. That used to be there because preflight was
+    # maintenance-only; keeping it now would be an escape hatch, since a
+    # preflight whose own `if:` was mis-edited into never running would report
+    # `skipped` and publish unguarded.
+    #
+    # `always()` is still load-bearing: without it, a SKIPPED preflight (the
+    # no-publish merge) cascades its skip down the chain rather than letting the
+    # explicit guards decide.
     if: |
       always() &&
       needs.gate.outputs.app_publish == 'true' &&
-      (needs.preflight.result == 'success' || needs.preflight.result == 'skipped')
+      needs.preflight.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -301,12 +345,69 @@ jobs:
         with:
           subject-path: 'dist/*.tar.gz'
 
+  # Drive the Layer-14 migration lane against the image goreleaser JUST BUILT,
+  # before the release becomes public.
+  #
+  # The push-triggered `migration-e2e` run that `preflight` requires proves the
+  # SOURCE TREE is good; it cannot prove the released artifact is, because the
+  # artifact does not exist until goreleaser runs. A bad ldflag, a wrong-arch
+  # build, Dockerfile drift, or a config default that only holds in
+  # Dockerfile.local would sail past it. So the same lane definition runs a
+  # second time with `cerberus_image` pointed at the published tag; the harness
+  # extracts the CLI from that image and asserts the running server's
+  # `GET /info` version equals `expect_version`, so both halves of the stack are
+  # provably the released bytes.
+  #
+  # `always()` is LOAD-BEARING for the same reason it is on `eol-retire`: this
+  # chain transitively depends on `preflight`, which is SKIPPED on a no-publish
+  # merge, and GitHub's skip-propagation would cascade that skip down the whole
+  # chain.
+  #
+  # The image tag is the bare `{{ .Version }}` form, matching .goreleaser.yml's
+  # `image_templates`.
+  release-artifact-migration:
+    name: release-artifact-migration
+    needs: [gate, goreleaser]
+    if: |
+      always() &&
+      needs.gate.outputs.app_publish == 'true' &&
+      needs.goreleaser.result == 'success'
+    uses: ./.github/workflows/migration-e2e.yml
+    secrets: inherit
+    permissions:
+      contents: read
+      packages: read
+    with:
+      tier: all
+      cerberus_image: ghcr.io/${{ github.repository_owner }}/cerberus:${{ needs.gate.outputs.app_version }}
+      expect_version: ${{ needs.gate.outputs.app_version }}
+
+  # Make the release public. This is a SEPARATE job from `goreleaser` on
+  # purpose: the draft->published flip is the point of no return, so everything
+  # that validates the built artifact has to sit between the two. Moving these
+  # steps back inside `goreleaser` would publish an image nothing ever drove —
+  # test/regression/release_gate_test.go asserts there is exactly one
+  # draft-to-published flip in this file and that its job `needs:`
+  # `release-artifact-migration`.
+  publish:
+    name: publish
+    needs: [gate, goreleaser, release-artifact-migration]
+    if: |
+      always() &&
+      needs.gate.outputs.app_publish == 'true' &&
+      needs.goreleaser.result == 'success' &&
+      needs.release-artifact-migration.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
       # goreleaser created the release as a DRAFT (see .goreleaser.yml
       # release.draft) so it could attach assets while the release is still
       # mutable. Flip it published NOW, AFTER the assets + provenance are in
-      # place: the repo's immutable-releases policy then freezes the release
-      # WITH its assets. Publishing up-front (e.g. `gh release create`) would
-      # lock it before goreleaser could upload — the 422 that broke v1.0.1.
+      # place AND the migration lane has driven the built image: the repo's
+      # immutable-releases policy then freezes the release WITH its assets.
+      # Publishing up-front (e.g. `gh release create`) would lock it before
+      # goreleaser could upload — the 422 that broke v1.0.1.
       # Idempotent: a no-op if already published.
       - name: Publish release (flip draft -> published)
         env:
@@ -324,6 +425,45 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_PAT }}
           repository: tsouza/cerberus
           readme-filepath: ./README.md
+
+  # Post-publish install smoke: prove `brew install tsouza/tap/cerberus` works
+  # for the version that just shipped.
+  #
+  # `needs: publish` is ordering, not decoration: `brew install` downloads the
+  # release tarball, which 404s while the release is still a draft. The reflex
+  # fixes for that 404 — a retry loop, `continue-on-error` — would ship the
+  # release unverified and green, so the fix is to run after the flip.
+  #
+  # Prereleases are NOT skipped. `skip_upload: auto` means an `rc.*` writes no
+  # formula, so brew-smoke.mjs takes the NEGATIVE branch instead: the formula
+  # must exist and must NOT declare this version.
+  brew-smoke:
+    name: brew-smoke
+    needs: [gate, publish]
+    if: |
+      always() &&
+      needs.gate.outputs.app_publish == 'true' &&
+      needs.publish.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      # The `config-docs -check` payload compares the SHIPPED binary's config
+      # registry against THIS commit's docs/configuration.md, so the release
+      # tree has to be on disk.
+      - uses: actions/checkout@v7
+
+      - name: brew-smoke self-test
+        run: node --test .github/scripts/brew-smoke.test.mjs
+
+      - name: install from the tap and smoke the published binary
+        env:
+          # The BARE version. Comparing `cerberus --version` to `app_tag` would
+          # be a guaranteed off-by-`v` mismatch.
+          RELEASE_VERSION: ${{ needs.gate.outputs.app_version }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO_ROOT: ${{ github.workspace }}
+        run: node .github/scripts/brew-smoke.mjs
 
   # Active EOL — after a NEW app version actually publishes, retire the release
   # line that just fell out of the latest-3-minor support window by DELETING its
@@ -353,19 +493,22 @@ jobs:
   # protected). See docs/operations.md "Release support window / EOL policy".
   eol-retire:
     name: eol-retire
-    needs: [gate, goreleaser]
-    # Only when a NEW app version actually published (goreleaser ran + succeeded).
+    needs: [gate, publish]
+    # Only when a NEW app version actually went PUBLIC. This hangs off `publish`,
+    # not `goreleaser`: retiring an old line while the new release is still a
+    # draft would shrink the support window on the strength of a release that may
+    # yet be blocked by `release-artifact-migration`.
     # `always()` is LOAD-BEARING: like `goreleaser` and `chart-release`, this job
-    # transitively depends on `preflight`, which is SKIPPED on the main / dispatch
-    # path. Without `always()`, GitHub's skip-propagation cascades the skip down
-    # this whole chain, so the job never runs on a real minor open and EOL lines
-    # never get retired. `always()` unwraps that skip; the two guards below then
-    # keep it a strict no-op on patches / backports / failed publishes — it only
-    # fires when goreleaser actually shipped a new version.
+    # transitively depends on `preflight`, which is SKIPPED on a no-publish merge.
+    # Without `always()`, GitHub's skip-propagation cascades the skip down this
+    # whole chain, so the job never runs on a real minor open and EOL lines never
+    # get retired. `always()` unwraps that skip; the two guards below then keep it
+    # a strict no-op on patches / backports / failed publishes — it only fires
+    # when a new version actually shipped.
     if: |
       always() &&
       needs.gate.outputs.app_publish == 'true' &&
-      needs.goreleaser.result == 'success'
+      needs.publish.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       # Deleting a branch ref needs contents:write. (The job uses RELEASE_PAT
@@ -401,13 +544,13 @@ jobs:
   chart-release:
     name: chart-release
     needs: [gate, preflight]
-    # Same guard as goreleaser: chart gate says new AND (main path: preflight
-    # skipped) OR (maintenance path: preflight succeeded). A failed / cancelled
-    # maintenance preflight blocks the chart publish too.
+    # Same guard as goreleaser: chart gate says new AND preflight SUCCEEDED.
+    # `preflight` fires on `chart_publish` too, so there is no run that reaches
+    # here with a skipped preflight — no `|| skipped` disjunction to hide behind.
     if: |
       always() &&
       needs.gate.outputs.chart_publish == 'true' &&
-      (needs.preflight.result == 'success' || needs.preflight.result == 'skipped')
+      needs.preflight.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/Justfile
+++ b/Justfile
@@ -1255,8 +1255,41 @@ compat-all: compat-promql compat-logql compat-traceql
 # three heads. Explicit lifecycle verbs plus a composite, mirroring the e2e-*
 # shape; the `tier1` prefix leaves room for the ruler tier without renaming.
 
-# Bring the Tier-1 stack up and wait for every healthcheck to pass. Builds
-# cerberus:migration-tier1 from the repo-root Dockerfile.local.
+# The image tag the migration stacks run when no released artifact is supplied.
+# Held equal to the `${CERBERUS_IMAGE:-…}` default in
+# tiers/tier1-dual/docker-compose.dual.yml by
+# test/regression/migration_tier1_test.go, so the recipe below and the compose
+# file cannot disagree about which tag "locally built" means.
+MIGRATION_LOCAL_IMAGE := "cerberus:migration-tier1"
+
+# Put the cerberus image the migration stacks run into the local Docker daemon —
+# the SINGLE acquisition point, shared by CI and local dev.
+#
+# Two paths, decided by CERBERUS_IMAGE alone: unset (every local run, every PR /
+# dispatch / push CI run) it builds MIGRATION_LOCAL_IMAGE from the repo-root
+# Dockerfile.local — whose final unnamed stage IS the cerberus image, so no
+# `--target` is needed — and the stack proves this tree. Set (release.yml's
+# artifact lane) it pulls that released tag and the stack proves the artifact.
+#
+# This exists because the compose up path deliberately cannot acquire the image
+# itself: `pull_policy: never` and no `--build` on the up recipes are what keep
+# a release run from recompiling the source tree over the released image.
+migration-cerberus-image:
+    @local_tag='{{MIGRATION_LOCAL_IMAGE}}'; \
+    img="${CERBERUS_IMAGE:-$local_tag}"; \
+    if [ "$img" = "$local_tag" ]; then \
+        echo "==> migration cerberus image: build $img from Dockerfile.local"; \
+        docker build -f Dockerfile.local -t "$img" .; \
+    else \
+        echo "==> migration cerberus image: pull $img"; \
+        docker pull "$img"; \
+    fi
+
+# Bring the Tier-1 stack up and wait for every healthcheck to pass. The cerberus
+# image is acquired first by migration-cerberus-image; there is deliberately no
+# `--build` here, because `--build` forces a source build regardless of
+# `pull_policy` and that is precisely how a released image gets silently
+# replaced by a recompile of whatever tree the runner has checked out.
 # The teardown is a sub-invocation rather than a `migration-tier1-up:
 # migration-tier1-down` dependency on purpose: just runs a recipe at most once
 # per invocation, so declaring it as a dependency would consume the trailing
@@ -1264,11 +1297,13 @@ compat-all: compat-promql compat-logql compat-traceql
 # running after a clean lane. Seeding an already-seeded stack is the failure
 # this closes — a run aborted by a failing assertion never reaches teardown,
 # and a second seed into the same live window collides on every sample instant.
+# migration-cerberus-image is a sub-invocation for the same reason.
 migration-tier1-up:
     @just migration-tier1-down
+    @just migration-cerberus-image
     @echo "==> migration tier-1 stack up"
     docker compose -f test/e2e/migration/tiers/tier1-dual/docker-compose.dual.yml \
-        up --build --wait --wait-timeout 300
+        up --wait --wait-timeout 300
 
 # Every archetype an `@tier1` scenario actually reads fixture data from:
 # MIG-02/06/07/08 read kube-prometheus-stack, every other `@tier1` scenario
@@ -1395,12 +1430,18 @@ migration-tier1: migration-tier1-up migration-tier1-seed migration-tier1-run mig
 # via the standard multi-`-f` invocation so both sets of services land in the
 # SAME compose project (docker-compose.ruler.yml deliberately declares no
 # `name:` of its own — see that file's header comment).
+#
+# Same image contract as migration-tier1-up: acquire once via
+# migration-cerberus-image, never `--build`. The ruler tier adds services on top
+# of Tier-1's `cerberus`, it does not declare a second one, so this stack runs
+# exactly the image that recipe put in the daemon.
 migration-tier2-up:
     @just migration-tier2-down
+    @just migration-cerberus-image
     @echo "==> migration tier-2 stack up"
     docker compose -f test/e2e/migration/tiers/tier1-dual/docker-compose.dual.yml \
         -f test/e2e/migration/tiers/tier2-ruler/docker-compose.ruler.yml \
-        up --build --wait --wait-timeout 300
+        up --wait --wait-timeout 300
 
 # Tier-2 runs against the same seeded window Tier-1 does — the ruler tier
 # adds Grafana-managed alerting on top of the SAME cerberus/ClickHouse pair,

--- a/docs/migration-testing.md
+++ b/docs/migration-testing.md
@@ -138,6 +138,56 @@ rather than `chdb_substrate`: the migration lane models the deployment surface
 an operator runs, not the SQL-parity substrate the chDB suites run on
 (asserted by `.github/scripts/clickhouse-version-sync.mjs`).
 
+### 3.0. Which cerberus the lane proves
+
+Every tier job resolves its cerberus through one module,
+`.github/scripts/migration-artifact.mjs`, before any scenario runs. Two workflow
+inputs travel together and decide the answer:
+
+| `cerberus_image` | `expect_version`   | What the lane proves                                                                                                                   |
+| ---------------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
+| unset            | unset              | **This tree.** The CLI is `go build`-ed from source; the compose stacks run `cerberus:migration-tier1`, built from `Dockerfile.local`. |
+| a tag            | that tag's version | **That artifact.** The image is pulled, the CLI is `docker cp`-ed out of it, and the compose stacks run the same image.                |
+| one of the two   | —                  | An error.                                                                                                                              |
+
+A half pair is rejected rather than defaulted, because the failure it produces
+is invisible: the job would build from source while its name, its logs, and the
+roll-up all say it exercised a released artifact.
+
+The CLI comes **out of the image** rather than out of a release tarball, so on
+the artifact path the binary the scenarios exec and the server the stack answers
+from are the same bytes. A tarball would leave the two free to diverge, and the
+30 scenarios would pass across a mixed pair.
+
+Whatever binary the module produced is then held to a version stamp before the
+lane proceeds: it runs `--version`, requires exit 0 and exactly one non-empty
+line, and string-compares the result. The three build paths stamp differently by
+construction, which is what makes the comparison a real discriminator:
+
+| Build                                      | Stamp               | Read back by               |
+| ------------------------------------------ | ------------------- | -------------------------- |
+| `go build ./cmd/cerberus` (no ldflags)     | `dev`               | `lib.SourceBuildVersion`   |
+| `Dockerfile.local` (`-X main.Version=e2e`) | `e2e`               | `lib.LocalImageVersion`    |
+| goreleaser                                 | the release version | the `expect_version` input |
+
+The Go side reads the same stamps from `test/e2e/migration/lib/provenance.go`.
+`lib.BuildCerberus` probes the CLI it hands each tier suite, and the tier-1
+substrate test probes the *server* over `GET /info`, so the two halves of the
+stack are checked independently — on a from-source run they legitimately
+disagree (`dev` CLI, `e2e` server), and only the artifact path collapses them
+onto one version. `CERBERUS_EXPECT_VERSION` is therefore exported only on the
+artifact path; on the source path each half falls back to its own stamp.
+
+The stacks are pinned so nothing can quietly rebuild over the artifact under
+test. `docker-compose.dual.yml` declares `image: ${CERBERUS_IMAGE:-cerberus:migration-tier1}`
+with `pull_policy: never`, and the `up` recipes carry no `--build`: the image is
+put into the daemon exactly once, by `just migration-cerberus-image` (which
+builds the local tag from `Dockerfile.local` or pulls anything else), before
+`up` runs. A missing image aborts `up` loudly instead of silently recompiling
+whatever tree the runner is holding. `test/regression/migration_tier1_test.go`
+pins every copy of the tag and every copy of the stamps equal, and pins the
+resolver step into all three tier jobs.
+
 ### 3.1. The all-signal seeder
 
 `test/e2e/migration/cmd/seed` builds one in-memory fixture from an archetype's

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1075,6 +1075,37 @@ a raw tag is pushed (release-please-style). The flow:
    A merge that bumped **neither** line publishes nothing — both gates return
    `publish=false`, so an ordinary code/docs merge is a complete no-op.
 
+The job graph on a publishing merge is:
+
+```text
+gate ─▶ preflight ─▶ goreleaser ─▶ release-artifact-migration ─▶ publish ─┬▶ brew-smoke
+                  │                                                       └▶ eol-retire
+                  └▶ chart-release
+```
+
+Each edge is a gate, not a sequence:
+
+- **`preflight`** runs on **both** paths (main and maintenance) whenever either
+  version gate says something would publish. Branch protection alone is not
+  enough even on main: it can only require lanes eligible to *be* a
+  branch-protection check, and the heavyweight push-triggered lanes — notably
+  `migration-e2e` (Layer 14) — are not. So the preflight carries its own
+  **expected set** (`RELEASE_REQUIRED_CHECKS`) and refuses to publish when a
+  required lane posted *no* check-run on the commit. A lane that did not run has
+  not passed.
+- **`goreleaser`** builds and uploads, but leaves the GitHub release a **draft**.
+- **`release-artifact-migration`** re-runs the migration lane
+  (`uses: ./.github/workflows/migration-e2e.yml`) against the image that was just
+  built, asserting the running server reports the released version. The
+  push-triggered run the preflight required proves the *source tree*; this proves
+  the *artifact* — a bad ldflag or Dockerfile drift lives only in the latter.
+- **`publish`** performs the draft→published flip. It is a separate job precisely
+  so everything that validates the built artifact sits before the point of no
+  return.
+- **`brew-smoke`** installs from the tap and smokes the published binary (see
+  below); **`eol-retire`** retires the line that just fell out of the support
+  window.
+
 The two version lines are independent: a chart-only fix (template change, new
 toggle) ships by bumping `version:` alone, and an app-only release bumps
 `appVersion:` (plus a patch to `version:` for the new default image). The
@@ -1105,6 +1136,19 @@ Two prerequisites make the push work, and both are one-time:
    secret is mandatory — without it the brew push on the next stable release
    fails.
 
+The `brew-smoke` job closes the loop on both of those prerequisites. It reads the
+tap's `Formula/cerberus.rb` through the API *before* touching `brew`, because a
+deleted `brews:` block or an expired `HOMEBREW_TAP_GITHUB_TOKEN` leaves a stale
+formula that an install would happily consume. A stable release must find the
+formula declaring exactly the version that just shipped; it then installs it and
+asserts `cerberus --version` equals that version and that two offline verbs
+(`migrate schema`, `config-docs -check`) work from the installed binary. A
+prerelease is **not** skipped — it takes the opposite assertion: `skip_upload:
+auto` means an `rc.*` must have written no formula, so a formula declaring the
+prerelease version is a reported regression. The job runs after `publish` because
+`brew install` downloads the release tarball, which 404s while the release is
+still a draft.
+
 #### Maintenance lines (hotfix backports)
 
 Beyond the main line, a hotfix can be cut on a **maintenance line** —
@@ -1115,9 +1159,13 @@ main release PR branch shape `release/v1.5.0-chart-0.6.4`). The same per-line
 version gates decide what to publish, and because the gates are
 absence-keyed (tag-absent / OCI-absent, not newest-wins) a hotfix older than the
 latest tag — `v1.4.1` cut after `v1.5.0` — still publishes. A maintenance push
-has no PR gate, so the `preflight` job (`release-preflight.mjs`) re-reads the
-pushed commit's check-runs and refuses to publish unless the commit is the
-branch tip and every required check is settled green.
+has no PR gate at all, so the `preflight` job (`release-preflight.mjs`) adds two
+rules on this path that the main path does not need: the pushed commit must be
+the **branch tip**, and the line must still be **inside the support window**. The
+required-set check is the same on both paths — every lane in
+`RELEASE_REQUIRED_CHECKS` must have posted a green check-run on the commit. That
+is why `migration-e2e.yml` push-triggers on `release/*.x` as well as `main`: a
+required lane that never runs on the branch would block every hotfix release.
 
 ### Release support window / EOL policy
 

--- a/test/e2e/migration/lib/cerberusbin.go
+++ b/test/e2e/migration/lib/cerberusbin.go
@@ -4,11 +4,14 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // cerberusBinEnv names a prebuilt cerberus binary the scenarios should drive.
-// The migration workflow builds the binary once in its own step and hands the
-// path in, so a matrix leg does not recompile it per scenario run.
+// The migration workflow resolves the binary once in its own step — from this
+// tree on a PR/dispatch run, out of the released image on a release run (see
+// .github/scripts/migration-artifact.mjs) — and hands the path in, so a tier
+// job does not recompile it per scenario run.
 const cerberusBinEnv = "CERBERUS_BIN"
 
 // cerberusPkg is the main package the harness compiles when no prebuilt binary
@@ -18,11 +21,35 @@ const cerberusPkg = "./cmd/cerberus"
 // binName is the filename the freshly-built binary gets inside dir.
 const binName = "cerberus"
 
+// versionFlag is the argument that makes cerberus print its bare build version
+// and nothing else (cmd/cerberus/cli.go's printVersion).
+const versionFlag = "--version"
+
 // BuildCerberus returns the path of the cerberus binary the scenarios exec.
 // CERBERUS_BIN short-circuits the build when a caller already produced one;
 // otherwise the binary is compiled from source into dir, which the caller owns
 // (a per-run temporary directory).
+//
+// Either way the resolved binary is then PROVED to be the one this run is
+// supposed to be testing: it must answer `--version` with exactly
+// ExpectedCLIVersion(). A stale artifact, a wrong-GOARCH build or an unrelated
+// executable all satisfy a stat-and-not-a-directory check, and a release run
+// that quietly fell back to a source build would report `dev` where the release
+// version was expected — so the probe runs unconditionally, on every path.
 func BuildCerberus(root, dir string) (string, error) {
+	bin, err := resolveCerberusBin(root, dir)
+	if err != nil {
+		return "", err
+	}
+	if err := assertCerberusVersion(bin); err != nil {
+		return "", err
+	}
+	return bin, nil
+}
+
+// resolveCerberusBin produces the binary path, from the environment or from a
+// compile, without asserting anything about what that binary is.
+func resolveCerberusBin(root, dir string) (string, error) {
 	if bin := os.Getenv(cerberusBinEnv); bin != "" {
 		info, err := os.Stat(bin) //nolint:gosec // the path is the harness operator's own build output
 		if err != nil {
@@ -49,4 +76,35 @@ func BuildCerberus(root, dir string) (string, error) {
 			cerberusPkg, res.ExitCode, string(res.Stderr))
 	}
 	return out, nil
+}
+
+// assertCerberusVersion holds the resolved binary to the version this run
+// expects. `--version` prints the bare version and nothing else, so anything
+// but a single non-empty line is itself a failure.
+func assertCerberusVersion(bin string) error {
+	res, err := Run(RunSpec{Bin: bin, Args: []string{versionFlag}, Env: os.Environ()})
+	if err != nil {
+		return fmt.Errorf("migration harness: %s %s: %w", bin, versionFlag, err)
+	}
+	if res.ExitCode != 0 {
+		return fmt.Errorf("migration harness: %s %s: exit %d: %s",
+			bin, versionFlag, res.ExitCode, string(res.Stderr))
+	}
+
+	var lines []string
+	for _, line := range strings.Split(string(res.Stdout), "\n") {
+		if trimmed := strings.TrimSpace(line); trimmed != "" {
+			lines = append(lines, trimmed)
+		}
+	}
+	if len(lines) != 1 {
+		return fmt.Errorf("migration harness: %s %s printed %d non-empty line(s), want exactly one bare version: %q",
+			bin, versionFlag, len(lines), string(res.Stdout))
+	}
+	if want := ExpectedCLIVersion(); lines[0] != want {
+		return fmt.Errorf("migration harness: %s reports version %q, but this run drives %q "+
+			"(%s=%q, %s=%q). The scenarios would have exercised a different build than the run claims to test",
+			bin, lines[0], want, ExpectVersionEnv, sharedExpectedVersion(), ImageEnv, ResolvedImage())
+	}
+	return nil
 }

--- a/test/e2e/migration/lib/lib_test.go
+++ b/test/e2e/migration/lib/lib_test.go
@@ -212,15 +212,25 @@ func TestAssertGoldenRegeneratesLocallyOnly(t *testing.T) {
 	}
 }
 
+// writeVersionStub writes an executable that answers `--version` with the given
+// stamp — the smallest stand-in for a cerberus build whose provenance the
+// harness has to decide about.
+func writeVersionStub(t *testing.T, dir, version string) string {
+	t.Helper()
+	path := filepath.Join(dir, "cerberus")
+	script := "#!/bin/sh\necho " + version + "\n"
+	if err := os.WriteFile(path, []byte(script), goldenDirMode); err != nil {
+		t.Fatalf("write version stub: %v", err)
+	}
+	return path
+}
+
 // TestBuildCerberusHonoursAPrebuiltBinary asserts CERBERUS_BIN short-circuits
 // the compile, and that a path naming a directory is rejected rather than
 // handed on as an unexecutable binary.
 func TestBuildCerberusHonoursAPrebuiltBinary(t *testing.T) {
 	dir := t.TempDir()
-	prebuilt := filepath.Join(dir, "cerberus")
-	if err := os.WriteFile(prebuilt, []byte("#!/bin/sh\n"), goldenDirMode); err != nil {
-		t.Fatalf("write prebuilt binary: %v", err)
-	}
+	prebuilt := writeVersionStub(t, dir, SourceBuildVersion)
 
 	t.Setenv(cerberusBinEnv, prebuilt)
 	got, err := BuildCerberus(t.TempDir(), dir)
@@ -235,6 +245,97 @@ func TestBuildCerberusHonoursAPrebuiltBinary(t *testing.T) {
 	if _, err := BuildCerberus(t.TempDir(), dir); err == nil {
 		t.Fatalf("BuildCerberus accepted a directory as %s", cerberusBinEnv)
 	}
+}
+
+// TestBuildCerberusProvesWhichBinaryItGot is the provenance half. A stat that
+// only proves "a file exists here" is satisfied by a stale artifact, a
+// wrong-GOARCH build, or a release lane that silently fell back to compiling
+// from source — every one of which would run the whole scenario set against a
+// cerberus the run is not supposed to be testing, and report green.
+func TestBuildCerberusProvesWhichBinaryItGot(t *testing.T) {
+	const releaseVersion = "1.11.2"
+
+	t.Run("source_run_expects_the_source_stamp", func(t *testing.T) {
+		dir := t.TempDir()
+		t.Setenv(ExpectVersionEnv, "")
+		t.Setenv(cerberusBinEnv, writeVersionStub(t, dir, SourceBuildVersion))
+		if _, err := BuildCerberus(t.TempDir(), dir); err != nil {
+			t.Fatalf("a from-source run rejected the %q stamp it is supposed to expect: %v",
+				SourceBuildVersion, err)
+		}
+	})
+
+	t.Run("release_run_rejects_a_source_build", func(t *testing.T) {
+		dir := t.TempDir()
+		t.Setenv(ExpectVersionEnv, releaseVersion)
+		t.Setenv(cerberusBinEnv, writeVersionStub(t, dir, SourceBuildVersion))
+		_, err := BuildCerberus(t.TempDir(), dir)
+		if err == nil {
+			t.Fatalf("a run pinned to %s accepted a binary reporting %q; a release lane that fell "+
+				"back to a source build would report green", releaseVersion, SourceBuildVersion)
+		}
+		for _, want := range []string{SourceBuildVersion, releaseVersion} {
+			if !strings.Contains(err.Error(), want) {
+				t.Fatalf("the mismatch error does not quote %q, so the log would not name what was "+
+					"actually run: %v", want, err)
+			}
+		}
+	})
+
+	t.Run("release_run_accepts_the_pinned_stamp", func(t *testing.T) {
+		dir := t.TempDir()
+		t.Setenv(ExpectVersionEnv, releaseVersion)
+		t.Setenv(cerberusBinEnv, writeVersionStub(t, dir, releaseVersion))
+		if _, err := BuildCerberus(t.TempDir(), dir); err != nil {
+			t.Fatalf("a run pinned to %s rejected a binary reporting exactly that: %v", releaseVersion, err)
+		}
+	})
+
+	t.Run("a_silent_binary_is_a_failure_not_a_pass", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "cerberus")
+		if err := os.WriteFile(path, []byte("#!/bin/sh\n"), goldenDirMode); err != nil {
+			t.Fatalf("write silent stub: %v", err)
+		}
+		t.Setenv(ExpectVersionEnv, "")
+		t.Setenv(cerberusBinEnv, path)
+		if _, err := BuildCerberus(t.TempDir(), dir); err == nil {
+			t.Fatalf("BuildCerberus accepted a binary that printed no version at all")
+		}
+	})
+}
+
+// TestExpectedVersionsSplitCLIFromServer pins the one asymmetry the provenance
+// helpers encode: on a from-source run the CLI (`go build`, no ldflags) and the
+// compose server (Dockerfile.local, `-X main.Version=e2e`) are DIFFERENT builds,
+// so each is held to its own stamp; on a released-artifact run they are the same
+// bytes and both are held to the run-wide one. Collapsing the two would make one
+// of the two probes assert against a value that can never hold.
+func TestExpectedVersionsSplitCLIFromServer(t *testing.T) {
+	t.Run("unset", func(t *testing.T) {
+		t.Setenv(ExpectVersionEnv, "")
+		if got := ExpectedCLIVersion(); got != SourceBuildVersion {
+			t.Fatalf("ExpectedCLIVersion() = %q, want %q", got, SourceBuildVersion)
+		}
+		if got := ExpectedServerVersion(); got != LocalImageVersion {
+			t.Fatalf("ExpectedServerVersion() = %q, want %q", got, LocalImageVersion)
+		}
+		if SourceBuildVersion == LocalImageVersion {
+			t.Fatalf("the CLI and the server stamps are both %q, so neither probe can tell a "+
+				"from-source run from an image run", SourceBuildVersion)
+		}
+	})
+
+	t.Run("pinned", func(t *testing.T) {
+		const releaseVersion = "1.11.2"
+		t.Setenv(ExpectVersionEnv, releaseVersion)
+		if got := ExpectedCLIVersion(); got != releaseVersion {
+			t.Fatalf("ExpectedCLIVersion() = %q, want %q", got, releaseVersion)
+		}
+		if got := ExpectedServerVersion(); got != releaseVersion {
+			t.Fatalf("ExpectedServerVersion() = %q, want %q", got, releaseVersion)
+		}
+	})
 }
 
 // TestRequireOfflineAcceptsOnlyAClosedEnvironment proves the check a scenario's

--- a/test/e2e/migration/lib/provenance.go
+++ b/test/e2e/migration/lib/provenance.go
@@ -1,0 +1,71 @@
+package lib
+
+import (
+	"os"
+	"strings"
+)
+
+// The migration lane runs the same three tier jobs twice against a release
+// commit: once on the push (proving the SOURCE TREE) and once against the image
+// goreleaser built (proving the ARTIFACT). Nothing about the job names, the
+// step names or the compose file changes between those two runs, so the ONLY
+// way a scenario can know which cerberus it is actually driving is to ask the
+// binary and the server what they are. These constants are the three answers
+// that are possible, and the two helpers compute which one is expected.
+//
+// Every path asserts. There is no branch in which the version check is
+// omitted — only branches in which the expected value differs.
+const (
+	// SourceBuildVersion is what `go build ./cmd/cerberus` with no ldflags
+	// reports: cmd/cerberus/main.go's `var Version = "dev"`.
+	// test/regression/migration_tier1_test.go holds the two equal.
+	SourceBuildVersion = "dev"
+
+	// LocalImageVersion is what the compose stacks' cerberus reports when its
+	// image was built from the repo-root Dockerfile.local, which stamps
+	// `-X main.Version=e2e`. The same regression pin holds the two equal.
+	LocalImageVersion = "e2e"
+
+	// ExpectVersionEnv carries the ONE version every cerberus in the run must
+	// report, and is set only when the CLI and the server are the same bytes —
+	// i.e. when .github/scripts/migration-artifact.mjs resolved an image plan.
+	// On a from-source run it is unset, because the CLI (`dev`) and the
+	// compose server (`e2e`) are genuinely different builds.
+	ExpectVersionEnv = "CERBERUS_EXPECT_VERSION"
+
+	// ImageEnv names the image the compose stacks run. Read only to quote back
+	// in a provenance failure — the value never changes what is asserted.
+	ImageEnv = "CERBERUS_IMAGE"
+)
+
+// sharedExpectedVersion returns the run-wide version stamp, or "" when the CLI
+// and the server come from separate builds.
+func sharedExpectedVersion() string {
+	return strings.TrimSpace(os.Getenv(ExpectVersionEnv))
+}
+
+// ExpectedCLIVersion is the version the cerberus binary the scenarios exec must
+// report. A released artifact pins it run-wide; otherwise the binary was
+// compiled from this tree with no ldflags and reports the source stamp.
+func ExpectedCLIVersion() string {
+	if v := sharedExpectedVersion(); v != "" {
+		return v
+	}
+	return SourceBuildVersion
+}
+
+// ExpectedServerVersion is the version the cerberus serving the compose stack
+// must report at GET /info. A released artifact pins it run-wide; otherwise the
+// stack built its image from Dockerfile.local, which stamps LocalImageVersion.
+func ExpectedServerVersion() string {
+	if v := sharedExpectedVersion(); v != "" {
+		return v
+	}
+	return LocalImageVersion
+}
+
+// ResolvedImage is the image the compose stacks were told to run, or "" when
+// nothing supplied one. Diagnostic only.
+func ResolvedImage() string {
+	return strings.TrimSpace(os.Getenv(ImageEnv))
+}

--- a/test/e2e/migration/tier1_stack_test.go
+++ b/test/e2e/migration/tier1_stack_test.go
@@ -27,6 +27,7 @@ import (
 
 	otlptrace "go.opentelemetry.io/proto/otlp/trace/v1"
 
+	"github.com/tsouza/cerberus/test/e2e/migration/lib"
 	"github.com/tsouza/cerberus/test/e2e/migration/seed"
 )
 
@@ -103,6 +104,10 @@ const (
 	detectedLevelKey = "detected_level"
 	probeLevel       = "info"
 )
+
+// cerberusServiceName is the `service` field GET /info stamps. It identifies
+// the process as cerberus rather than some other thing bound to the port.
+const cerberusServiceName = "cerberus"
 
 func envOr(key, fallback string) string {
 	if v := os.Getenv(key); v != "" {
@@ -181,6 +186,41 @@ func TestTier1Substrate(t *testing.T) {
 		body := getBody(t, ctx, base+"/api/echo")
 		if string(body) != "echo" {
 			t.Fatalf("tempo head /api/echo = %q, want %q", string(body), "echo")
+		}
+	})
+
+	// Which cerberus is SERVING this stack. The binary probe in
+	// lib.BuildCerberus only observes the CLI the scenarios exec; on a release
+	// run the whole point is that the compose stack runs the image goreleaser
+	// built, and a stack that quietly rebuilt from Dockerfile.local would leave
+	// every other assertion in this file green while proving nothing about the
+	// artifact. Runs after cerberus_serves_three_heads, which is what waited for
+	// the process to come up.
+	//
+	// GET /info is the cerberus-NATIVE fingerprint: its `version` field is
+	// main.Version verbatim. The Prometheus/Loki `/status/buildinfo` surfaces
+	// are upstream-compat mirrors and report what those APIs are expected to
+	// report, so they are the wrong probe for this question.
+	t.Run("cerberus_artifact_provenance", func(t *testing.T) {
+		base := envOr(cerberusURLEnvKey, defaultCerberusURL)
+
+		var info struct {
+			Service string `json:"service"`
+			Version string `json:"version"`
+		}
+		getJSON(t, ctx, base+"/info", &info)
+
+		if info.Service != cerberusServiceName {
+			t.Fatalf("%s/info reports service %q, want %q — the port is not served by cerberus",
+				base, info.Service, cerberusServiceName)
+		}
+		if want := lib.ExpectedServerVersion(); info.Version != want {
+			t.Fatalf("the tier-1 stack serves cerberus %q but this run drives %q (%s=%q, %s=%q). "+
+				"Either the stack rebuilt from source over the image under test, or the image is not "+
+				"the one the release is publishing — every parity assertion below would be about the "+
+				"wrong binary.",
+				info.Version, want, lib.ExpectVersionEnv, os.Getenv(lib.ExpectVersionEnv),
+				lib.ImageEnv, lib.ResolvedImage())
 		}
 	})
 

--- a/test/e2e/migration/tiers/tier1-dual/docker-compose.dual.yml
+++ b/test/e2e/migration/tiers/tier1-dual/docker-compose.dual.yml
@@ -157,8 +157,25 @@ services:
     # proven by polling /ready from the host, the same posture as loki above.
 
   cerberus:
-    image: cerberus:migration-tier1
-    pull_policy: build
+    # The cerberus under test, and the ONE knob that decides whether this lane
+    # proves the source tree or a released artifact.
+    #
+    # `CERBERUS_IMAGE` is written by .github/scripts/migration-artifact.mjs:
+    # unset (every PR / dispatch / push run) it falls back to the locally built
+    # tag and the stack runs this tree; on release.yml's
+    # `release-artifact-migration` call it names the image goreleaser just
+    # built and the stack runs THAT.
+    #
+    # The image is put into the daemon by `just migration-cerberus-image`
+    # (built from Dockerfile.local, or pulled) BEFORE `up` runs, and nothing in
+    # the up path may build or pull it: `pull_policy: never` plus the removal of
+    # `--build` from the up recipes is what stops compose recompiling the source
+    # tree over a released artifact and reporting green having tested source. A
+    # missing image therefore aborts `up` loudly instead of silently rebuilding.
+    # The `build:` stanza stays so `docker compose build` still works for humans.
+    # test/regression/migration_tier1_test.go pins all of it.
+    image: ${CERBERUS_IMAGE:-cerberus:migration-tier1}
+    pull_policy: never
     build:
       context: ../../../../..
       dockerfile: Dockerfile.local

--- a/test/regression/migration_tier1_test.go
+++ b/test/regression/migration_tier1_test.go
@@ -15,6 +15,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/tsouza/cerberus/test/e2e/migration/lib"
 	"github.com/tsouza/cerberus/test/e2e/migration/seed"
 	"github.com/tsouza/cerberus/test/e2e/migration/steps"
 )
@@ -55,6 +56,7 @@ var otherComposeFiles = []string{
 // composeService is the subset of a compose service definition these pins read.
 type composeService struct {
 	Image       string            `yaml:"image"`
+	PullPolicy  string            `yaml:"pull_policy"`
 	Command     []string          `yaml:"command"`
 	Environment map[string]string `yaml:"environment"`
 	Volumes     []string          `yaml:"volumes"`
@@ -1031,3 +1033,265 @@ func TestMigrationTier1SampleBudgetIsPinned(t *testing.T) {
 // tier1SampleBudgetEnv is the per-query sample budget the tier-1 cerberus runs
 // under — MIG-15's per-tenant read budget, in that scenario's tenancy model.
 const tier1SampleBudgetEnv = "CERBERUS_QUERY_MAX_SAMPLES"
+
+// The build-once seam (Layer 14, D2): the migration lane runs the SAME three
+// tier jobs twice against a release commit — once proving the source tree, once
+// proving the image goreleaser built — and the only thing that differs is which
+// cerberus the stack runs and which binary the scenarios exec. Every constant
+// below exists in more than one file by necessity (a compose interpolation
+// default, a Justfile variable, a Node const, a Go const, an ldflag), so the
+// pins here hold them equal. A drift is silent by construction: the lane goes
+// green having tested the wrong build.
+const (
+	// migrationArtifactScript resolves which cerberus the lane drives.
+	migrationArtifactScript = "../../.github/scripts/migration-artifact.mjs"
+	// migrationLocalImageVar is the Justfile variable naming the locally built
+	// image tag.
+	migrationLocalImageVar = "MIGRATION_LOCAL_IMAGE"
+	// migrationImageRecipe is the SINGLE point at which the image enters the
+	// Docker daemon.
+	migrationImageRecipe = "migration-cerberus-image"
+	// dockerfileLocalPath builds the image the stacks run when no released
+	// artifact is supplied; cerberusMainPath declares the source-build stamp.
+	dockerfileLocalPath = "../../Dockerfile.local"
+	cerberusMainPath    = "../../cmd/cerberus/main.go"
+	// buildFlag forces `docker compose up` to compile the build context even
+	// when the image is already present, which is exactly how a released
+	// artifact gets replaced by a recompile of whatever tree the runner holds.
+	buildFlag = "--build"
+)
+
+// composeImageDefaultRe splits a `${VAR:-default}` compose interpolation.
+var composeImageDefaultRe = regexp.MustCompile(`^\$\{([A-Za-z_][A-Za-z0-9_]*):-(.+)\}$`)
+
+// TestMigrationImageIsAcquiredOnceNeverRebuilt pins the seam that lets the
+// release lane test the artifact it just built.
+//
+// `pull_policy: build` plus `up --build` — the shape this replaced — means
+// pointing `image:` at a released tag does NOT stop compose recompiling the
+// source tree over it. The lane would report "tested the release artifact"
+// having tested source, and every gate in the pipeline would stay green.
+func TestMigrationImageIsAcquiredOnceNeverRebuilt(t *testing.T) {
+	t.Parallel()
+
+	cf := readCompose(t, tier1ComposePath)
+	cerb, ok := cf.Services[tier1CerberusService]
+	if !ok {
+		t.Fatalf("%s has no %q service", tier1ComposePath, tier1CerberusService)
+	}
+
+	m := composeImageDefaultRe.FindStringSubmatch(cerb.Image)
+	if m == nil {
+		t.Fatalf("%s's %s service declares image %q, want a `${VAR:-default}` interpolation. A literal "+
+			"tag gives release.yml's artifact lane no way to point the stack at the image goreleaser "+
+			"built, so it would prove the source tree under an artifact-shaped job name.",
+			tier1ComposePath, tier1CerberusService, cerb.Image)
+	}
+	imageEnvVar, localTag := m[1], m[2]
+	if imageEnvVar != lib.ImageEnv {
+		t.Fatalf("the compose image interpolates %s but the harness and the resolver read %s; the "+
+			"release lane would set a variable nothing consumes", imageEnvVar, lib.ImageEnv)
+	}
+	if cerb.PullPolicy != composePullPolicyNever {
+		t.Fatalf("%s's %s service declares pull_policy %q, want %q. Anything else lets the up path "+
+			"acquire the image itself, which is how a source rebuild silently replaces a released "+
+			"artifact. The image is put in the daemon by `just %s` BEFORE up runs.",
+			tier1ComposePath, tier1CerberusService, cerb.PullPolicy, composePullPolicyNever, migrationImageRecipe)
+	}
+
+	// The same tag lives in three files. Hold them equal, or a `just` run and a
+	// compose run would disagree about which image "locally built" means and
+	// the stack would fail to resolve one.
+	justfile, err := os.ReadFile("../../Justfile")
+	if err != nil {
+		t.Fatalf("read Justfile: %v", err)
+	}
+	body := string(justfile)
+	justTag := justVariableList(t, body, migrationLocalImageVar)
+	if len(justTag) != 1 || justTag[0] != localTag {
+		t.Fatalf("Justfile's %s is %v but %s defaults to %q; `just %s` would build one tag while "+
+			"compose looked for another", migrationLocalImageVar, justTag, tier1ComposePath, localTag,
+			migrationImageRecipe)
+	}
+	resolver, err := os.ReadFile(migrationArtifactScript)
+	if err != nil {
+		t.Fatalf("read %s: %v", migrationArtifactScript, err)
+	}
+	if want := "export const LOCAL_IMAGE_TAG = '" + localTag + "'"; !strings.Contains(string(resolver), want) {
+		t.Fatalf("%s does not declare %s, so the resolver would export a CERBERUS_IMAGE the compose "+
+			"stack does not recognise", migrationArtifactScript, want)
+	}
+
+	// The up recipes must acquire the image through the one recipe that knows
+	// the build-or-pull decision, and must not carry --build.
+	for _, recipe := range []string{"migration-tier1-up", "migration-tier2-up"} {
+		recipeBody := justRecipeBody(t, body, recipe)
+		if !strings.Contains(recipeBody, "just "+migrationImageRecipe) {
+			t.Fatalf("Justfile recipe %s does not invoke `just %s`, so nothing puts the image in the "+
+				"daemon and `up` (pull_policy: %s) cannot resolve it. Body:\n%s",
+				recipe, migrationImageRecipe, composePullPolicyNever, recipeBody)
+		}
+		if strings.Contains(recipeBody, buildFlag) {
+			t.Fatalf("Justfile recipe %s passes %s to `docker compose up`. That forces a source build "+
+				"regardless of pull_policy, so a release run would recompile this tree over the "+
+				"released image and still report green. Body:\n%s", recipe, buildFlag, recipeBody)
+		}
+	}
+
+	// The acquisition recipe itself must be able to do BOTH halves: build the
+	// local tag from Dockerfile.local, and pull anything else.
+	acquire := justRecipeBody(t, body, migrationImageRecipe)
+	for _, want := range []string{"docker build", "Dockerfile.local", "docker pull", lib.ImageEnv} {
+		if !strings.Contains(acquire, want) {
+			t.Fatalf("Justfile recipe %s does not reference %q; it must build the local tag from "+
+				"Dockerfile.local and pull a released one, decided by %s alone. Body:\n%s",
+				migrationImageRecipe, want, lib.ImageEnv, acquire)
+		}
+	}
+}
+
+// composePullPolicyNever is the only pull policy compatible with the
+// acquire-then-up contract.
+const composePullPolicyNever = "never"
+
+// TestMigrationVersionStampsMatchTheirBuilds holds the two stamps the harness
+// computes its expectations from equal to the builds that actually produce
+// them. lib.ExpectedServerVersion() asserting against a stale LocalImageVersion
+// would pass for the wrong reason on every from-source run and then hide a real
+// mis-wiring on the release path.
+func TestMigrationVersionStampsMatchTheirBuilds(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		path, want, why string
+	}{
+		{
+			path: dockerfileLocalPath,
+			want: "-X main.Version=" + lib.LocalImageVersion,
+			why: "the tier-1/tier-2 compose stacks run this image, and the live GET /info probe in " +
+				"tier1_stack_test.go holds the server to lib.LocalImageVersion",
+		},
+		{
+			path: cerberusMainPath,
+			want: `var Version = "` + lib.SourceBuildVersion + `"`,
+			why: "a from-source `go build` carries no ldflags, and lib.BuildCerberus holds the CLI it " +
+				"produced to lib.SourceBuildVersion",
+		},
+	} {
+		buf, err := os.ReadFile(tc.path)
+		if err != nil {
+			t.Fatalf("read %s: %v", tc.path, err)
+		}
+		if !strings.Contains(string(buf), tc.want) {
+			t.Fatalf("%s does not contain %q — %s. Move the stamp and the constant together.",
+				tc.path, tc.want, tc.why)
+		}
+	}
+
+	// The resolver computes the same source stamp on the Node side.
+	resolver, err := os.ReadFile(migrationArtifactScript)
+	if err != nil {
+		t.Fatalf("read %s: %v", migrationArtifactScript, err)
+	}
+	if want := "export const SOURCE_BUILD_VERSION = '" + lib.SourceBuildVersion + "'"; !strings.Contains(string(resolver), want) {
+		t.Fatalf("%s does not declare %s, so its `--version` probe would expect a different stamp "+
+			"than lib.BuildCerberus does and one of the two would fail on a healthy build",
+			migrationArtifactScript, want)
+	}
+
+	// The two stamps must differ, or neither probe could tell a from-source run
+	// from an image run.
+	if lib.SourceBuildVersion == lib.LocalImageVersion {
+		t.Fatalf("lib.SourceBuildVersion and lib.LocalImageVersion are both %q; the CLI and the "+
+			"server probes would agree on every path and prove nothing", lib.SourceBuildVersion)
+	}
+}
+
+// TestMigrationTiersAcquireTheProbedBinary asserts every tier package gets its
+// cerberus through lib.BuildCerberus — the ONE path that probes `--version` and
+// holds the answer to what this run is supposed to be testing. A tier that
+// `go build`s its own binary, or reads CERBERUS_BIN directly, would run its
+// whole scenario set against an unverified executable.
+func TestMigrationTiersAcquireTheProbedBinary(t *testing.T) {
+	t.Parallel()
+
+	entries, err := os.ReadDir(tiersDir)
+	if err != nil {
+		t.Fatalf("read %s: %v", tiersDir, err)
+	}
+
+	var scanned int
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		scanned++
+		dir := filepath.Join(tiersDir, e.Name())
+		files, err := os.ReadDir(dir)
+		if err != nil {
+			t.Fatalf("read %s: %v", dir, err)
+		}
+		var probed bool
+		for _, f := range files {
+			if f.IsDir() || !strings.HasSuffix(f.Name(), ".go") {
+				continue
+			}
+			buf, err := os.ReadFile(filepath.Join(dir, f.Name()))
+			if err != nil {
+				t.Fatalf("read %s: %v", filepath.Join(dir, f.Name()), err)
+			}
+			if strings.Contains(string(buf), "lib.BuildCerberus(") {
+				probed = true
+			}
+		}
+		if !probed {
+			t.Fatalf("tier package %s never calls lib.BuildCerberus, so the binary its scenarios exec "+
+				"is never held to the version this run drives", dir)
+		}
+	}
+
+	if scanned != wantTierSuites {
+		t.Fatalf("scanned %d tier package(s) under %s, want %d. A loop over vanished directories is "+
+			"vacuously green; a new tier must be wired through lib.BuildCerberus and this count raised.",
+			scanned, tiersDir, wantTierSuites)
+	}
+}
+
+// migrationTierJobs are the jobs in migration-e2e.yml that drive a tier.
+var migrationTierJobs = []string{"migration-tier0", tier1JobName, "migration-tier2"}
+
+// TestMigrationTierJobsResolveTheArtifact pins the resolver into every tier
+// job. A tier that skips it either compiles no CLI at all (release path: no
+// binary to hand the scenarios) or, worse, builds one from source while the job
+// claims to be driving a released image.
+func TestMigrationTierJobsResolveTheArtifact(t *testing.T) {
+	t.Parallel()
+
+	workflow, err := os.ReadFile(tier1WorkflowPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", tier1WorkflowPath, err)
+	}
+	body := string(workflow)
+
+	for _, job := range migrationTierJobs {
+		jobBody := workflowJobBody(t, body, job)
+		for _, want := range []string{
+			"node .github/scripts/migration-artifact.mjs",
+			"CERBERUS_IMAGE_INPUT: ${{ inputs.cerberus_image }}",
+			"CERBERUS_EXPECT_VERSION_INPUT: ${{ inputs.expect_version }}",
+		} {
+			if !strings.Contains(jobBody, want) {
+				t.Fatalf("%s job %q does not carry %q, so the release lane's `cerberus_image` input "+
+					"would not reach it and the tier would silently test this tree instead. Body:\n%s",
+					tier1WorkflowPath, job, want, jobBody)
+			}
+		}
+		// The raw compile the resolver replaced. Leaving one behind would hand
+		// the scenarios an unprobed binary on the release path.
+		if strings.Contains(jobBody, "go build -o build/cerberus") {
+			t.Fatalf("%s job %q still compiles the CLI directly. That binary bypasses the resolver's "+
+				"version probe, so a release run would exec a source build while claiming to test the "+
+				"released artifact. Body:\n%s", tier1WorkflowPath, job, jobBody)
+		}
+	}
+}

--- a/test/regression/release_gate_test.go
+++ b/test/regression/release_gate_test.go
@@ -1,0 +1,301 @@
+package regression
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// The release pipeline's shape is the only thing standing between a merge and a
+// public artifact, and none of it is exercised by a PR: release.yml has no
+// `pull_request:` trigger, so every edit to it is unverified until a release is
+// actually cut. The pins below are pure file reads over the workflows and
+// .goreleaser.yml, so they run on the required `check` lane and a regression
+// fails at merge time rather than mid-release.
+//
+// Each pin exists because the corresponding regression is INVISIBLE — it leaves
+// the pipeline green:
+//
+//   - a required lane dropped from RELEASE_REQUIRED_CHECKS: the preflight is
+//     observation-derived for everything outside that set, so a lane that never
+//     ran contributes zero problems and the release publishes on a silence;
+//   - the draft->published flip moved back inside `goreleaser`: the release goes
+//     public before anything drove the built image;
+//   - `continue-on-error` on brew-smoke: the job becomes decoration;
+//   - `skip_upload: auto` removed from .goreleaser.yml: prereleases start
+//     overwriting the tap formula, which is the thing brew-smoke's prerelease
+//     branch asserts against.
+const (
+	releaseWorkflowPath   = "../../.github/workflows/release.yml"
+	migrationWorkflowPath = "../../.github/workflows/migration-e2e.yml"
+	goreleaserPath        = "../../.goreleaser.yml"
+
+	// The lane this whole gate exists to make blocking. It is push/schedule
+	// triggered, so it can never be a branch-protection check — the preflight's
+	// required set is the only thing that makes it gate a release.
+	releaseGatedLane = "migration-e2e"
+
+	// The job that drives releaseGatedLane against the image goreleaser built,
+	// and the job that makes the release public. The ordering between them is
+	// the point: everything that validates the artifact sits before the flip.
+	artifactMigrationJob = "release-artifact-migration"
+	publishJob           = "publish"
+	brewSmokeJob         = "brew-smoke"
+	preflightJob         = "preflight"
+
+	// The single point of no return in the pipeline.
+	publishFlipToken = "--draft=false"
+)
+
+func readFileString(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
+}
+
+// requiredChecksFromPreflight extracts the RELEASE_REQUIRED_CHECKS value out of
+// the preflight job body. Parsing the value (rather than substring-matching the
+// whole file) is what makes the membership assertion below real: a name that
+// appears somewhere else in the workflow does not satisfy it.
+func requiredChecksFromPreflight(t *testing.T, job string) []string {
+	t.Helper()
+	const key = "RELEASE_REQUIRED_CHECKS:"
+	for _, line := range strings.Split(job, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, key) {
+			continue
+		}
+		raw := strings.TrimSpace(strings.TrimPrefix(trimmed, key))
+		raw = strings.Trim(raw, `"'`)
+		var out []string
+		for _, name := range strings.Split(raw, ",") {
+			if name = strings.TrimSpace(name); name != "" {
+				out = append(out, name)
+			}
+		}
+		return out
+	}
+	t.Fatalf("%s job %q declares no %s — the release gate has degraded to the "+
+		"observational deny-list, where a lane that never ran contributes zero problems. Body:\n%s",
+		releaseWorkflowPath, preflightJob, key, job)
+	return nil
+}
+
+func TestReleasePreflightRequiresTheMigrationLane(t *testing.T) {
+	t.Parallel()
+
+	workflow := readFileString(t, releaseWorkflowPath)
+	job := workflowJobBody(t, workflow, preflightJob)
+
+	required := requiredChecksFromPreflight(t, job)
+	if len(required) == 0 {
+		t.Fatalf("%s job %q declares an EMPTY required set, which is the same silence as declaring none",
+			releaseWorkflowPath, preflightJob)
+	}
+
+	found := false
+	for _, name := range required {
+		if name == releaseGatedLane {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("%s job %q does not require %q (required set: %v). That lane cannot be a branch-protection "+
+			"check, so dropping it here silently un-gates it: the preflight only reports problems for "+
+			"check-runs it observed, and a lane that never ran posts none.",
+			releaseWorkflowPath, preflightJob, releaseGatedLane, required)
+	}
+
+	// The gate must run on BOTH publish paths. A `refs/heads/release/` guard in
+	// the job body is the old maintenance-only wiring, under which a release cut
+	// from main skipped the green check entirely.
+	if strings.Contains(job, "refs/heads/release/") {
+		t.Fatalf("%s job %q still branch-gates itself to the maintenance lines; the preflight is "+
+			"publish-gated now, so a release from main must go through it too. Body:\n%s",
+			releaseWorkflowPath, preflightJob, job)
+	}
+	for _, want := range []string{"app_publish", "chart_publish"} {
+		if !strings.Contains(job, want) {
+			t.Fatalf("%s job %q does not gate on %q; it must run whenever something would publish. Body:\n%s",
+				releaseWorkflowPath, preflightJob, want, job)
+		}
+	}
+
+	// Informational entries are PREFIX matches inside the preflight, so an
+	// informational name that is a prefix of a required one de-gates the
+	// required lane. The script reports that as a wiring error at runtime; this
+	// pin catches it at merge time.
+	informational := informationalChecksFromPreflight(t, job)
+	for _, prefix := range informational {
+		for _, name := range required {
+			if strings.HasPrefix(name, prefix) {
+				t.Fatalf("%s job %q lists informational prefix %q, which swallows required lane %q — "+
+					"the required lane would be de-gated while still looking required",
+					releaseWorkflowPath, preflightJob, prefix, name)
+			}
+		}
+	}
+
+	// The self-test that proves the required set is actually enforced runs as a
+	// step of the job itself, and on the required `lint` lane.
+	if !strings.Contains(job, "release-preflight.test.mjs") {
+		t.Fatalf("%s job %q does not run release-preflight.test.mjs; the gate's own detectors would be "+
+			"unverified. Body:\n%s", releaseWorkflowPath, preflightJob, job)
+	}
+	ci := readFileString(t, "../../.github/workflows/ci.yml")
+	for _, want := range []string{"release-preflight.test.mjs", "brew-smoke.test.mjs"} {
+		if !strings.Contains(ci, want) {
+			t.Fatalf("../../.github/workflows/ci.yml does not run %q. release.yml has no pull_request "+
+				"trigger, so without this step the release gate's unit guards execute only while a "+
+				"release is being cut", want)
+		}
+	}
+}
+
+// informationalChecksFromPreflight reads the de-gate list the same way the
+// preflight does, so the disjointness assertion above compares like with like.
+func informationalChecksFromPreflight(t *testing.T, job string) []string {
+	t.Helper()
+	const key = "RELEASE_INFORMATIONAL_CHECKS:"
+	for _, line := range strings.Split(job, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, key) {
+			continue
+		}
+		raw := strings.Trim(strings.TrimSpace(strings.TrimPrefix(trimmed, key)), `"'`)
+		var out []string
+		for _, name := range strings.Split(raw, ",") {
+			if name = strings.TrimSpace(name); name != "" {
+				out = append(out, name)
+			}
+		}
+		return out
+	}
+	return nil
+}
+
+func TestReleasePublishesOnlyAfterTheBuiltArtifactIsDriven(t *testing.T) {
+	t.Parallel()
+
+	workflow := readFileString(t, releaseWorkflowPath)
+
+	// Exactly one flip, in exactly one job. Two would mean a second, unguarded
+	// path to publication; zero would mean the release never leaves draft.
+	if got := strings.Count(workflow, publishFlipToken); got != 1 {
+		t.Fatalf("%s contains %d occurrences of %q, want exactly 1 — the draft->published flip is the "+
+			"point of no return and must have a single, guarded call site",
+			releaseWorkflowPath, got, publishFlipToken)
+	}
+	publish := workflowJobBody(t, workflow, publishJob)
+	if !strings.Contains(publish, publishFlipToken) {
+		t.Fatalf("%s job %q does not perform the %q flip; publication has moved to another job, "+
+			"bypassing the artifact validation that this job's `needs:` enforces. Body:\n%s",
+			releaseWorkflowPath, publishJob, publishFlipToken, publish)
+	}
+	if !strings.Contains(publish, artifactMigrationJob) {
+		t.Fatalf("%s job %q does not depend on %q, so the release would go public without the built "+
+			"image ever being driven. Body:\n%s",
+			releaseWorkflowPath, publishJob, artifactMigrationJob, publish)
+	}
+
+	// The artifact lane must drive the RELEASED image and assert the version it
+	// reports; without either input it silently degrades into a second
+	// source-tree run that proves nothing new about the artifact.
+	artifact := workflowJobBody(t, workflow, artifactMigrationJob)
+	for _, want := range []string{
+		"uses: ./.github/workflows/migration-e2e.yml",
+		"cerberus_image:",
+		"expect_version:",
+	} {
+		if !strings.Contains(artifact, want) {
+			t.Fatalf("%s job %q is missing %q. Body:\n%s",
+				releaseWorkflowPath, artifactMigrationJob, want, artifact)
+		}
+	}
+}
+
+func TestBrewSmokeIsBlockingAndOrderedAfterPublish(t *testing.T) {
+	t.Parallel()
+
+	workflow := readFileString(t, releaseWorkflowPath)
+	job := workflowJobBody(t, workflow, brewSmokeJob)
+
+	for _, want := range []string{publishJob, "brew-smoke.mjs", "brew-smoke.test.mjs"} {
+		if !strings.Contains(job, want) {
+			t.Fatalf("%s job %q is missing %q. `brew install` downloads the release tarball, which 404s "+
+				"while the release is still a draft — the ordering is correctness, not cosmetics. Body:\n%s",
+				releaseWorkflowPath, brewSmokeJob, want, job)
+		}
+	}
+	if strings.Contains(job, "continue-on-error") {
+		t.Fatalf("%s job %q declares continue-on-error, which turns the install smoke into decoration: "+
+			"a broken tap would report green. Body:\n%s", releaseWorkflowPath, brewSmokeJob, job)
+	}
+
+	// The prerelease branch of brew-smoke.mjs asserts that an rc.* did NOT write
+	// a formula. That assertion is only meaningful while goreleaser is still
+	// configured to leave prerelease taps alone.
+	goreleaser := readFileString(t, goreleaserPath)
+	if !strings.Contains(goreleaser, "skip_upload: auto") {
+		t.Fatalf("%s no longer sets `skip_upload: auto` on the brews block; brew-smoke's prerelease "+
+			"branch asserts the opposite invariant and would start failing every rc", goreleaserPath)
+	}
+}
+
+func TestMigrationLaneIsCallableAndCoversTheReleaseBranches(t *testing.T) {
+	t.Parallel()
+
+	body := readFileString(t, migrationWorkflowPath)
+
+	var parsed struct {
+		On struct {
+			Push struct {
+				Branches []string `yaml:"branches"`
+			} `yaml:"push"`
+		} `yaml:"on"`
+	}
+	if err := yaml.Unmarshal([]byte(body), &parsed); err != nil {
+		t.Fatalf("parse %s: %v", migrationWorkflowPath, err)
+	}
+
+	// A maintenance backport publishes from its own line, and the preflight
+	// REQUIRES this lane on the released commit. Without the release-branch
+	// pattern the lane never runs there, so every patch release blocks forever.
+	for _, want := range []string{"main", "release/*.x"} {
+		found := false
+		for _, b := range parsed.On.Push.Branches {
+			if b == want {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("%s does not push-trigger on %q (branches: %v); the release preflight requires a "+
+				"green %q check-run on every commit it publishes",
+				migrationWorkflowPath, want, parsed.On.Push.Branches, releaseGatedLane)
+		}
+	}
+
+	if !strings.Contains(body, "\n  workflow_call:\n") {
+		t.Fatalf("%s declares no workflow_call trigger, so release.yml cannot re-run the lane against "+
+			"the image it just built", migrationWorkflowPath)
+	}
+	// The caller passes both inputs; an undeclared input is a hard workflow
+	// error at dispatch time, which is a failure DURING a release.
+	for _, want := range []string{"cerberus_image:", "expect_version:"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("%s declares no %q input, but release.yml passes it", migrationWorkflowPath, want)
+		}
+	}
+	// Still ineligible as a branch-protection check, which is the whole reason
+	// the preflight's required set exists.
+	if strings.Contains(body, "\n  pull_request:\n") {
+		t.Fatalf("%s gained a pull_request trigger. The lane is a heavyweight Docker/k3d suite kept off "+
+			"the PR path on purpose; if that changes, the required-set gate needs revisiting rather than "+
+			"quietly acquiring a second meaning", migrationWorkflowPath)
+	}
+}


### PR DESCRIPTION
Closes the gap between "the release is green" and "the release works". Three
seams, each of which was previously satisfiable without doing anything.

## 1. Absence was not a failure

`release-preflight.mjs` derived what it gated from what the GitHub API returned:
`evaluate()` iterated only over observed check-runs, so a lane that never ran
contributed zero entries, zero problems, and the release published in silence.

**Adding `migration-e2e` to any existing list would have changed nothing.** That
is the same hollow-green shape as the tier-2 attestation bug in #1293 — a gate
whose passing condition is "I saw no failures" rather than "I saw the successes I
required."

The gate now carries an EXPECTED set it does not derive from observation
(`RELEASE_REQUIRED_CHECKS`). A required name with no check-run on the commit
blocks the publish. Two anti-degradation guards are themselves blocking problems:

- an empty required set → the gate would silently revert to the deny-list
- a required name that a `RELEASE_INFORMATIONAL_CHECKS` prefix would swallow →
  a wiring error, not a de-gate (`compose-smoke` vs `compose-smoke-shard-info`
  makes this a live hazard, not a hypothetical)

Preflight also now runs on the **main** path, where releases actually happen. It
previously ran only on `release/*.x`, and `migration-e2e` has no `pull_request:`
trigger — so that lane had never run on a tree being released. It is publish-gated
(`app_publish || chart_publish`), so ordinary merges don't burn a runner.

## 2. The gated run tested source, not the artifact

The release artifact doesn't exist until goreleaser runs, so a push-triggered lane
can only ever test source builds.

The `--draft=false` flip therefore moves **out** of `goreleaser` into a new
`publish` job, with `release-artifact-migration` between them driving the *same*
`migration-e2e.yml` (now `workflow_call`-able) against
`ghcr.io/<owner>/cerberus:<version>`. A red artifact lane leaves the release a
draft.

- The CLI is extracted from that image (`docker create` + `docker cp`), so server
  and CLI are literally the same bytes.
- Compose gets `pull_policy: never` and `up --build` is removed, so a missing
  image fails `up` loudly instead of quietly rebuilding from source underneath an
  artifact-shaped job name — which would have been a green lane proving nothing.
- Provenance is asserted by version stamp on every path (`dev` / `e2e` /
  `<version>`), unconditionally, never skipped.

## 3. `brew install` was never exercised

`brew-smoke.mjs` reads `Formula/cerberus.rb` from the tap and requires it to
declare the released version — this is the anti-vacuous check, failing when the
formula was never pushed or is stale, independent of brew's cache — then installs
it, asserts `which cerberus` resolves under `brew --prefix`, asserts
`cerberus --version` equals the de-`v`'d app version, and runs two offline payload
verbs (`migrate schema`, `config-docs -check`) against the checked-out release
tree.

On a **prerelease** it asserts the negative: `skip_upload: auto` means no formula
should carry that version. Both branches assert; neither exits early on a
"not applicable" flag.

## Verification

The three `.mjs` suites (29 tests) run on every PR via `ci.yml`, because
`release.yml` has no `pull_request:` trigger and would otherwise only exercise
them mid-release — the one moment a regression is most expensive.

I sabotage-tested the three load-bearing claims rather than trusting the pins:

| Sabotage | Result |
|---|---|
| Drop `migration-e2e` from `RELEASE_REQUIRED_CHECKS` | `TestReleasePreflightRequiresTheMigrationLane` fails |
| Revert preflight to release-branch-only | `TestRelease*` fails |
| Let `publish` flip the draft without the artifact lane | `TestReleasePublishesOnlyAfterTheBuiltArtifactIsDriven` fails |

Full `test/regression` suite green; no version bump or tag in the diff.

## Not in this PR

No release is cut here. The full audit pass runs first.
