### PR TITLE
fix(solver): count chDB shard opens atomically so the cap contract can't lose increments

### DIFF
--- a/internal/solver/avb_chdb_lane_test.go
+++ b/internal/solver/avb_chdb_lane_test.go
@@ -45,6 +45,7 @@ import (
 	"math"
 	"sort"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -737,13 +738,18 @@ type chdbQuerier struct {
 	db                  *sql.DB
 	maxQueryMemoryBytes int64
 	sleep               time.Duration
-	opened              int
+	// opened counts QueryCursor calls. The Executor runs its shards under an
+	// errgroup with SetLimit(P_eff), so every shard's QueryCursor lands on a
+	// different goroutine concurrently — a plain int here loses increments to
+	// interleaved read-modify-write and under-reports the open count, which
+	// reads as "a shard never opened" in the assertions below.
+	opened atomic.Int64
 }
 
 func (q *chdbQuerier) MaxQueryMemoryBytes() int64 { return q.maxQueryMemoryBytes }
 
 func (q *chdbQuerier) QueryCursor(ctx context.Context, sqlText string, args ...any) (chclient.Cursor, error) {
-	q.opened++
+	q.opened.Add(1)
 	wrapped := wrapMapColumns(sqlText)
 	if q.sleep > 0 {
 		// CROSS JOIN forces ClickHouse to evaluate the scalar sleep()
@@ -961,14 +967,14 @@ func TestSolver_AvsB_ChDB_OutputCapContract(t *testing.T) {
 	// QueryCursor call the Executor was ever going to make has happened:
 	// exactly one per shard, never a retried/fallback query after the cap
 	// fired.
-	if q.opened != len(dec.Slices) {
+	if opened := q.opened.Load(); opened != int64(len(dec.Slices)) {
 		t.Fatalf("QueryCursor opened %d times, want exactly %d (one per shard, zero fallback queries)",
-			q.opened, len(dec.Slices))
+			opened, len(dec.Slices))
 	}
 
 	t.Logf("output-cap contract: real chDB route-B stream (%d total rows across %d shards) "+
 		"truncated at cap=%d with *OutputCapError, %d QueryCursor calls (no fallback)",
-		total, len(dec.Slices), cfg.MaxOutputRows, q.opened)
+		total, len(dec.Slices), cfg.MaxOutputRows, q.opened.Load())
 }
 
 // Wall-clock deadline margins for TestSolver_AvsB_ChDB_TimeoutContract's


### PR DESCRIPTION
## What

`chdbQuerier.opened` (the `CursorQuerier` test double behind the A-vs-B chDB lane) was a plain `int` incremented at the top of `QueryCursor`. Make it an `atomic.Int64`.

## Why

`probe` went red on PR #1296 with:

```
--- FAIL: TestSolver_AvsB_ChDB_OutputCapContract (0.19s)
    avb_chdb_lane_test.go:965: QueryCursor opened 7 times, want exactly 8 (one per shard, zero fallback queries)
```

on a diff that does not touch `internal/solver` at all.

The Executor runs its shards under an errgroup with `SetLimit(P_eff)` (`executor.go:266-297`), so every shard's `QueryCursor` call lands on a different goroutine **concurrently**. The unsynchronised `q.opened++` interleaves its read-modify-write and drops increments. One lost increment presents as `7 != 8` — which reads as *"a shard never opened"*, i.e. a real routing or fallback defect, when in fact all eight opens happened and the counter simply lost one.

The assertion being violated is **correct and worth keeping**:

- `errgroup.Go` under `SetLimit` always runs the function it is handed — it blocks for a slot, it never skips on cancellation.
- `runShard` calls `sc.client.QueryCursor(...)` unconditionally as its first real action, with no `ctx.Done()` short-circuit ahead of it.

So all K shards genuinely do open exactly once, and "exactly `len(dec.Slices)`, zero fallback queries" is the right contract. Only the counter was broken.

## Why it was never caught

The chdb-tagged lanes run `go test -tags chdb` **without `-race`**, so the detector never had a chance to flag it. It surfaced only as an intermittently red `probe` — the shape most likely to be waved through as a flake.

## Convention

`fakeQuerier`, the sibling `CursorQuerier` double in the same package (`exec_fakes_test.go`), already counts with `q.opened.Add(1)` behind an `atomic.Int64` and guards its maps with a `sync.Mutex`. This brings `chdbQuerier` in line with the pattern the package had already established rather than inventing a new one — `chdbQuerier` was the sole outlier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)