### PR TITLE
fix(release): eol-retire needs RELEASE_PAT — release/*.x is ruleset-protected

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -492,10 +492,17 @@ jobs:
   #     `continue-on-error: true` is belt-and-braces on top of the in-script
   #     fail-open.
   #
-  # Token: RELEASE_PAT (fine-grained, contents:write) when present, else the
-  # default GITHUB_TOKEN — both can delete an UNPROTECTED `release/*.x` branch
-  # (no ruleset / classic branch protection covers `release/*`; only `main` is
-  # protected). See docs/operations.md "Release support window / EOL policy".
+  # Token: RELEASE_PAT is REQUIRED here, not an optimisation. The repository
+  # ruleset "release maintenance lines" targets `refs/heads/release/*.x` with a
+  # `deletion` rule, and its only bypass actor is the `admin` RepositoryRole.
+  # `contents:write` is therefore NOT sufficient on its own: the default
+  # GITHUB_TOKEN acts as github-actions[bot], which holds write and never the
+  # admin role, so the ruleset rejects its delete. A PAT owned by an admin
+  # inherits that role and bypasses (the delete is accepted and logged by GitHub
+  # as `Bypassed rule violations`). The `|| secrets.GITHUB_TOKEN` fallback below
+  # is a best-effort attempt for a repo without the secret, not a supported
+  # path — expect it to be refused here.
+  # See docs/operations.md "Release support window / EOL policy".
   eol-retire:
     name: eol-retire
     needs: [gate, publish]
@@ -516,8 +523,9 @@ jobs:
       needs.publish.result == 'success'
     runs-on: ubuntu-latest
     permissions:
-      # Deleting a branch ref needs contents:write. (The job uses RELEASE_PAT
-      # when present; this scope covers the github.token fallback.)
+      # Deleting a branch ref needs contents:write. This scope only covers the
+      # github.token fallback; the `release/*.x` ruleset additionally requires
+      # the admin role, which only RELEASE_PAT carries. See the job comment.
       contents: write
     steps:
       - uses: actions/checkout@v7
@@ -528,10 +536,9 @@ jobs:
       - name: Retire the out-of-window release line (active EOL)
         continue-on-error: true
         env:
-          # RELEASE_PAT (fine-grained contents:write) deletes the branch even if
-          # a future ruleset protects `release/*` and grants the PAT bypass;
-          # falls back to github.token, which suffices for today's unprotected
-          # `release/*.x` branches.
+          # RELEASE_PAT is the supported token: the live `release/*.x` ruleset
+          # denies deletion to everything but the admin role, which an
+          # admin-owned PAT inherits and github-actions[bot] does not.
           GITHUB_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
           RELEASE_APP_VERSION: ${{ needs.gate.outputs.app_version }}
         run: node .github/scripts/release-preflight.mjs eol-retire-line

--- a/.serena/.gitignore
+++ b/.serena/.gitignore
@@ -1,0 +1,2 @@
+/cache
+/project.local.yml

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,0 +1,167 @@
+# the name by which the project can be referenced within Serena/when chatting with the LLM.
+project_name: "cerberus"
+
+# the encoding used by text files in the project
+# For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
+encoding: "utf-8"
+
+# optional shell command to run before the language backend (LSP or JetBrains) is initialised.
+# the command runs in the project root directory and is only executed if the project is trusted
+# (see trusted_project_path_patterns in the global configuration).
+# serena waits for the command to exit: a non-zero exit code is logged as an error but does not
+# abort activation. a per-project timeout (activation_command_timeout, default 180s) is the safety
+# backstop for non-terminating commands; on expiry the process is killed and activation continues.
+# example: activation_command: "npx nx run-many -t build"
+activation_command:
+
+# maximum time in seconds to wait for activation_command to complete before killing it (default 180s).
+# must be a positive number.
+activation_command_timeout: 180.0
+
+# line ending convention to use when writing source files.
+# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
+# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
+line_ending:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend:
+
+# whether to use project's .gitignore files to ignore files
+ignore_all_files_in_gitignore: true
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# The settings are considered only if the project is trusted (see global configuration to define trusted projects).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#language-server-specific-settings
+ls_specific_settings: {}
+
+# list of workspace folder paths (LSP backend only).
+# These folders will be used to build up Serena's symbol index.
+# Paths must be within the project root and should thus be relative to the project root.
+# Furthermore, the paths should not be filtered by ignore settings.
+# Default setting: The entire project root folder (".") is considered.
+# In (large) monorepos, this can be used to index only subfolders of the project root, e.g.
+#   ls_workspace_folders:
+#     - "./subproject1"
+#     - "./subproject2"
+ls_workspace_folders:
+- "."
+
+# list of additional workspace folder paths for cross-package reference support.
+# Paths can be absolute or relative to the project root.
+# Each folder is registered as an LSP workspace folder, enabling language servers to discover
+# symbols and references across package boundaries, but these folders are not indexed by Serena,
+# i.e. the respective symbols will not be found using Serena's symbol search tools.
+# Example:
+#   additional_workspace_folders:
+#     - ../sibling-package
+#     - ../shared-lib
+ls_additional_workspace_folders: []
+
+# list of additional paths to ignore in this project.
+# Same syntax as gitignore, so you can use * and **.
+# Important: quote patterns that start with `*`, otherwise YAML treats them as aliases.
+# Example:
+#   ignored_paths:
+#     - "examples/**"
+#     - ".worktrees/**"
+#     - "**/bin/**"
+#     - "**/obj/**"
+# Note: global ignored_paths from serena_config.yml are also applied additively.
+ignored_paths: []
+
+# whether the project is in read-only mode
+# If set to true, all editing tools will be disabled and attempts to use them will result in an error
+# Added on 2025-04-18
+read_only: false
+
+# list of tool names to exclude.
+# This extends the existing exclusions (e.g. from the global configuration)
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+excluded_tools: []
+
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+included_optional_tools: []
+
+# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
+# This cannot be combined with non-empty excluded_tools or included_optional_tools.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+fixed_tools: []
+
+# list of mode names that are to be activated by default, overriding the setting in the global configuration.
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# If the setting is undefined/empty, the default_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# Therefore, you can set this to [] if you do not want the default modes defined in the global config to apply
+# for this project.
+# This setting can, in turn, be overridden by CLI parameters (--mode).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+default_modes:
+
+# list of mode names to be activated additionally for this project, e.g. ["query-projects"]
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+added_modes:
+
+# initial prompt for the project. It will always be given to the LLM upon activating the project
+# (contrary to the memories, which are loaded on demand).
+initial_prompt: ""
+
+# time budget (seconds) per tool call for the retrieval of additional symbol information
+# such as docstrings or parameter information.
+# This overrides the corresponding setting in the global configuration; see the documentation there.
+# If null or missing, use the setting from the global configuration.
+symbol_info_budget:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []
+
+# list of language servers to start when using the LSP backend; choose from:
+#   ada                 al                  angular             ansible             bash
+#   bsl                 clojure             cpp                 cpp_ccls            crystal
+#   csharp              csharp_omnisharp    cue                 dart                elixir
+#   elm                 erlang              fortran             fsharp              gdscript
+#   go                  groovy              haskell             haxe                hlsl
+#   html                java                json                julia               kotlin
+#   latex               lean4               lua                 luau                markdown
+#   matlab              msl                 nix                 ocaml               pascal
+#   perl                php                 php_phpactor        php_phpantom        powershell
+#   python              python_jedi         python_pyrefly      python_ty           r
+#   rego                ruby                ruby_solargraph     rust                scala
+#   scss                solidity            svelte              swift               systemverilog
+#   terraform           toml                typescript          typescript_vts      vue
+#   yaml                zig
+#   (This list may be outdated; generated with scripts/print_language_list.py;
+#   For the current list, see values of Language enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py)
+# For some languages, there are several alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
+# Note:
+#   - For C, use cpp
+#   - For JavaScript, use typescript
+#   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
+#   - For Svelte projects, use svelte (subsumes typescript/javascript for .svelte projects; requires npm)
+#   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
+#   - For Free Pascal/Lazarus, use pascal
+# Special requirements:
+#   Some language servers require additional setup/installations.
+#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
+# When using multiple language servers, the first language server that supports a given file will be used for that file.
+# The first language server is the default language and the respective language server will be used as a fallback.
+# Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
+language_servers:
+- go

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1210,12 +1210,31 @@ source of truth):
   exists (idempotent — an already-absent branch is a clean no-op), with a
   `supportWindowProblem` cross-check before the destructive call; and it is
   **fail-open** — the release has already published, so any deletion failure
-  (token, future protection, network) logs loudly and the step still succeeds,
+  (token, protection, network) logs loudly and the step still succeeds,
   leaving a one-line manual `git push origin --delete release/X.W.x` as the
-  fallback. The job uses `RELEASE_PAT` (fine-grained, `contents:write`) when
-  present and falls back to the default `GITHUB_TOKEN`; both can delete the
-  `release/*.x` branches, which carry no branch protection or ruleset (only
-  `main` is protected).
+  fallback. The job needs `RELEASE_PAT` — see the ruleset note below for why
+  `contents:write` alone is not enough.
+
+The maintenance branches are **not** unprotected. The repository ruleset
+*"release maintenance lines"* targets `refs/heads/release/*.x` and is `active`:
+
+- `deletion` — the branch cannot be deleted.
+- `non_fast_forward` — no force-push; history is append-only.
+- `required_status_checks` — 12 contexts must pass before a backport merges:
+  `check`, `lint`, `forbid-skip`, `probe`, `roundtrip (promql)`,
+  `roundtrip (logql)`, `roundtrip (traceql)`, `chart-validate`, `coverage`,
+  `mutation`, `profile`, and
+  `property (PromQL + LogQL + TraceQL, rapid N=500)`.
+
+There is no `creation` rule, so cutting a **new** line (`git push origin
+v1.11.1^{}:refs/heads/release/1.11.x`) needs no bypass. The single bypass actor
+is the `admin` RepositoryRole in `always` mode, which is why `eol-retire` needs
+`RELEASE_PAT`: an admin-owned PAT inherits the admin role and bypasses the
+`deletion` rule (GitHub records this as `Bypassed rule violations`), whereas the
+default `GITHUB_TOKEN` acts as `github-actions[bot]` — write, never admin — and
+is refused. The required-check set is deliberately lighter than `main`'s: the
+heavy substrate lanes (`compatibility/*`, `compose-smoke`, `dashboard`) are not
+gated on maintenance lines, because a backport must stay cheap enough to ship.
 
 EOL retirement never unpublishes anything: the `v<major>.<minor>.*` git tags and
 their GitHub Releases — and the already-pushed images, charts, and binaries —

--- a/test/regression/release_gate_test.go
+++ b/test/regression/release_gate_test.go
@@ -299,3 +299,29 @@ func TestMigrationLaneIsCallableAndCoversTheReleaseBranches(t *testing.T) {
 			"quietly acquiring a second meaning", migrationWorkflowPath)
 	}
 }
+
+// The `release/*.x` ruleset ("release maintenance lines") denies `deletion` to
+// everyone but the admin RepositoryRole. `eol-retire` is fail-open by design —
+// a retirement hiccup must never fail a shipped release — so if its token loses
+// the admin bypass the job logs an ::error:: and still exits 0, the release
+// publishes green, and the EOL branch quietly survives. Nothing else in CI can
+// observe that: the job only ever runs on a real minor open, on main.
+//
+// RELEASE_PAT is the only token that carries the bypass (an admin-owned PAT
+// inherits the role; github-actions[bot] holds write and never admin). Pinning
+// the reference keeps the fallback from silently becoming the only path.
+func TestEOLRetireUsesTheTokenThatBypassesTheReleaseRuleset(t *testing.T) {
+	body := readFileString(t, releaseWorkflowPath)
+
+	const retireStep = "release-preflight.mjs eol-retire-line"
+	if !strings.Contains(body, retireStep) {
+		t.Fatalf("%s no longer invokes %q; the active-EOL half of the support window is gone",
+			releaseWorkflowPath, retireStep)
+	}
+	if !strings.Contains(body, "secrets.RELEASE_PAT") {
+		t.Fatalf("%s no longer passes secrets.RELEASE_PAT to %q. The default GITHUB_TOKEN acts as "+
+			"github-actions[bot], which the release/*.x ruleset refuses, and the job is fail-open — "+
+			"the branch would survive with the release still green",
+			releaseWorkflowPath, retireStep)
+	}
+}


### PR DESCRIPTION
## Why

`release.yml` and `docs/operations.md` both asserted that the `release/*.x` maintenance branches *"carry no branch protection or ruleset (only `main` is protected)"*, and justified the `secrets.RELEASE_PAT || secrets.GITHUB_TOKEN` fallback on that premise.

The premise is **false**. The repository ruleset *"release maintenance lines"* is `active` against `refs/heads/release/*.x` with `deletion`, `non_fast_forward` and 12 `required_status_checks`. Its only bypass actor is the `admin` RepositoryRole in `always` mode.

So `contents:write` is not sufficient: an admin-owned PAT inherits the admin role and bypasses `deletion`, while the default `GITHUB_TOKEN` acts as `github-actions[bot]` — write, never admin — and is refused.

## Why it matters

The combination is **silent**. `eol-retire` is fail-open by design (a retirement hiccup must never fail a shipped release), so on the `GITHUB_TOKEN` fallback the job would log an `::error::`, exit 0, and leave the EOL branch alive **while the release went out green**. Nothing else in CI can observe it — the job only ever runs on a real minor open, on `main`.

## What changed

- Corrected both comment sites in `release.yml` and the `docs/operations.md` EOL section, documenting the ruleset's actual rules.
- Documented the 12-context backport check set — deliberately lighter than `main`'s (no `compatibility/*`, `compose-smoke`, `dashboard`) so a backport stays cheap enough to ship.
- Documented that there is **no `creation` rule**, so cutting a new maintenance line needs no bypass.
- Pinned the `RELEASE_PAT` reference in `test/regression/release_gate_test.go`, alongside the existing pins for regressions that leave the pipeline green.

## Verification

Confirmed against the live ruleset while retiring `release/1.9.x` (its tip was exactly the peeled `v1.9.3`, so no history was lost): the admin-token delete was accepted and reported by GitHub as `remote: Bypassed rule violations`. All four `v1.9.*` tags and the GitHub Releases are retained, per the EOL policy.

No version bump — merging this does not trigger a release.