### PR TITLE
fix: backport the loki step guard and tempo gRPC window bounds (v1.10.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to cerberus will be documented in this file. The format roughly follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), with one entry per tagged release.
 
+## [v1.10.3] — 2026-07-27
+
+### Fixed
+
+- **loki:** reject a non-positive `?step=` on `/loki/api/v1/query_range` — `step=0` parses cleanly, so it reached the resolution-cap division and panicked with "integer divide by zero" (backport of #1298, tests #1300)
+- **tempo:** align the request window to the step grid and enforce the resolution ceiling on the gRPC `MetricsQueryRange` export — it returned samples off Tempo's grid and accepted an unbounded matrix fan-out (backport of #1298, tests #1300)
+
 ## [Unreleased]
 
 ## [v1.10.2] — 2026-07-17

--- a/deploy/helm/cerberus/Chart.yaml
+++ b/deploy/helm/cerberus/Chart.yaml
@@ -8,11 +8,11 @@ type: application
 # upgrade?" and is the publish trigger: a chart-only fix bumps this without an
 # app re-tag; an app-only release bumps appVersion + a PATCH here for the new
 # default image. Starts 0.x because the values contract is not yet frozen.
-version: 0.10.6
+version: 0.10.8
 
 # appVersion tracks the GA cerberus binary. Quoted so SemVer-shaped values
 # aren't coerced to floats. image.tag defaults from this when left empty.
-appVersion: "1.10.2"
+appVersion: "1.10.3"
 
 # autoscaling/v2 + policy/v1 (PDB) + networking/v1 (Ingress) are all GA from
 # 1.21+; 1.23 is the conservative floor matching the manifests this chart
@@ -45,9 +45,11 @@ annotations:
       url: https://github.com/tsouza/cerberus/blob/main/docs/operations.md
   artifacthub.io/images: |
     - name: cerberus
-      image: ghcr.io/tsouza/cerberus:v1.10.2
+      image: ghcr.io/tsouza/cerberus:v1.10.3
   # Bump the `1.0.0` floor here when the chart raises its minimum supported
   # cerberus release; informational for Artifact Hub's compatibility hints.
   artifacthub.io/changes: |
     - kind: fixed
-      description: "chsql: window-prune the compare root-lookup scan for root-scoped selections — fixes the traces-drilldown Comparison OOM/timeout (backport #1223)"
+      description: "loki: reject a non-positive ?step= on query_range instead of dividing by zero (backport #1298/#1300)"
+    - kind: fixed
+      description: "tempo: align the window to the step grid and enforce the resolution ceiling on the gRPC MetricsQueryRange export (backport #1298/#1300)"

--- a/deploy/helm/cerberus/README.md
+++ b/deploy/helm/cerberus/README.md
@@ -5,7 +5,7 @@
      pipe-aligned, and the version footer adds a trailing blank — both are
      owned by helm-docs; realigning would fight the chart-ci drift check. -->
 
-![Version: 0.10.6](https://img.shields.io/badge/Version-0.10.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.10.2](https://img.shields.io/badge/AppVersion-1.10.2-informational?style=flat-square)
+![Version: 0.10.8](https://img.shields.io/badge/Version-0.10.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.10.3](https://img.shields.io/badge/AppVersion-1.10.3-informational?style=flat-square)
 
 Drop-in Prometheus / Loki / Tempo HTTP gateway for ClickHouse — a single stateless gateway that speaks three upstream query wire formats and lowers each to parameterised ClickHouse SQL.
 

--- a/internal/api/loki/handler.go
+++ b/internal/api/loki/handler.go
@@ -316,6 +316,14 @@ func (h *Handler) handleQueryRange(w http.ResponseWriter, r *http.Request) {
 		// metric queries. Default to 1 minute when absent.
 		step = time.Minute
 	}
+	if step <= 0 {
+		// An explicitly non-positive step would divide by zero in the
+		// resolution cap below. Upstream Loki rejects the same shape
+		// (loghttp.ParseRangeQuery's errZeroOrNegativeStep), as does the
+		// Prom head's `step <= 0` guard.
+		writeError(w, http.StatusBadRequest, ErrBadData, errors.New("missing or invalid 'step' parameter"))
+		return
+	}
 	if !end.After(start) {
 		writeError(w, http.StatusBadRequest, ErrBadData, errors.New("'end' must be after 'start'"))
 		return

--- a/internal/api/loki/handler_test.go
+++ b/internal/api/loki/handler_test.go
@@ -806,6 +806,11 @@ func TestQueryRange_BadInput(t *testing.T) {
 		{"missing end", `/loki/api/v1/query_range?query=%7Bjob%3D%22api%22%7D&start=1717995600&step=60`},
 		{"end before start", `/loki/api/v1/query_range?query=%7Bjob%3D%22api%22%7D&start=1717999200&end=1717995600&step=60`},
 		{"invalid limit", `/loki/api/v1/query_range?query=%7Bjob%3D%22api%22%7D&start=1717995600&end=1717999200&step=60&limit=-5`},
+		// step=0 parses cleanly (format.ParseDuration accepts a bare float),
+		// so without the guard it reaches the (end-start)/step resolution cap
+		// and divides by zero. Upstream Loki rejects both shapes too.
+		{"zero step", `/loki/api/v1/query_range?query=%7Bjob%3D%22api%22%7D&start=1717995600&end=1717999200&step=0`},
+		{"negative step", `/loki/api/v1/query_range?query=%7Bjob%3D%22api%22%7D&start=1717995600&end=1717999200&step=-60`},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/api/tempo/grpc_exports.go
+++ b/internal/api/tempo/grpc_exports.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/tsouza/cerberus/internal/api/format"
 	"github.com/tsouza/cerberus/internal/chplan"
 	"github.com/tsouza/cerberus/internal/chsql"
 	"github.com/tsouza/cerberus/internal/engine"
@@ -178,6 +179,16 @@ func (h *Handler) ExecMetricsRange(ctx context.Context, query string, start, end
 	}
 	if step <= 0 {
 		return ExecMetricsRangeResult{}, fmt.Errorf("%w: 'step' must be > 0", errParseStage)
+	}
+	// The same grid alignment + resolution ceiling handleMetricsQueryRange
+	// applies. Without them this surface returns samples off Tempo's step
+	// grid and accepts an unbounded matrix fan-out (compute-DoS).
+	start, end = alignMetricsWindow(start, end, step)
+	if end.Sub(start)/step > format.MaxResolutionPoints {
+		// Pre-parse cap rejection: no CH query runs, so query_log can never
+		// reflect it. Record a decision-only "rejected" corpus row.
+		h.Engine.ObserveCapRejection("traceql")
+		return ExecMetricsRangeResult{}, fmt.Errorf("%w: %s", errParseStage, format.ResolutionCapMessage)
 	}
 
 	parseT := telemetry.ObserveStage(telemetry.StageParse)

--- a/internal/api/tempo/grpc_metrics_range_bounds_test.go
+++ b/internal/api/tempo/grpc_metrics_range_bounds_test.go
@@ -1,0 +1,95 @@
+package tempo
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/api/format"
+	"github.com/tsouza/cerberus/internal/engine"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// ExecMetricsRange is the gRPC sibling of handleMetricsQueryRange, and the two
+// have to agree on the request-window contract. The HTTP surface aligns the
+// window onto the step grid and refuses a matrix wider than
+// format.MaxResolutionPoints; when the gRPC export skipped both, it returned
+// samples off Tempo's step grid and let an unauthenticated caller ask for an
+// unbounded fan-out (compute-DoS) through a path no HTTP test covers.
+//
+// The cap sits BEFORE the parse stage on purpose — rejecting only after
+// parsing would still pay for parsing an arbitrarily large request. The
+// unparseable query below is the probe for that ordering: it can only produce
+// a cap error if the cap ran first.
+func TestExecMetricsRangeBoundsTheMatrixBeforeParsing(t *testing.T) {
+	t.Parallel()
+
+	// An empty Engine is enough: ObserveCapRejection short-circuits on a nil
+	// QueryObserver, and the cap returns before any engine work happens.
+	h := &Handler{Engine: &engine.Engine{}, Schema: schema.DefaultOTelTraces()}
+
+	const step = time.Second
+	// A query that cannot parse. If the error mentions the resolution cap, the
+	// cap necessarily ran before parseExpr.
+	const unparseable = "{ this is not traceql"
+
+	start := time.Unix(0, 0).UTC()
+	overCap := start.Add((format.MaxResolutionPoints + 1) * step)
+
+	if _, err := h.ExecMetricsRange(context.Background(), unparseable, start, overCap, step); err == nil {
+		t.Fatal("ExecMetricsRange accepted a matrix wider than the resolution cap")
+	} else if !strings.Contains(err.Error(), format.ResolutionCapMessage) {
+		t.Fatalf("window of %d steps was not rejected by the resolution cap: %v",
+			format.MaxResolutionPoints+1, err)
+	}
+
+	// Control: the same unparseable query inside the cap must fail at PARSE,
+	// not at the cap. Without this the assertion above would also pass if
+	// ExecMetricsRange simply reported the cap message for every error.
+	underCap := start.Add((format.MaxResolutionPoints - 1) * step)
+	_, err := h.ExecMetricsRange(context.Background(), unparseable, start, underCap, step)
+	if err == nil {
+		t.Fatal("ExecMetricsRange accepted an unparseable query")
+	}
+	if strings.Contains(err.Error(), format.ResolutionCapMessage) {
+		t.Fatalf("a window inside the cap was still rejected by the cap: %v", err)
+	}
+}
+
+// The gRPC export must anchor the window to the same step grid the HTTP
+// handler uses, so a caller driving both surfaces gets samples at identical
+// timestamps.
+//
+// Alignment is not directly observable from ExecMetricsRange's return value,
+// so this reads it through the cap boundary instead. alignMetricsWindow only
+// ever WIDENS a window (start truncates down, end rounds up), so a window that
+// is off-grid and exactly at the cap when raw is over the cap once aligned.
+// The cap error therefore proves alignment ran inside ExecMetricsRange —
+// without it the raw ratio stays at the limit and the call reaches the parser.
+func TestExecMetricsRangeAlignsTheWindowToTheStepGrid(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{Engine: &engine.Engine{}, Schema: schema.DefaultOTelTraces()}
+
+	const step = time.Minute
+	// 30s past a step boundary, so both ends move when aligned.
+	const offGridSeconds = 30
+
+	rawStart := time.Unix(offGridSeconds, 0).UTC()
+	// Exactly MaxResolutionPoints steps wide: `ratio > cap` is false, so the
+	// RAW window passes the cap untouched.
+	rawEnd := rawStart.Add(format.MaxResolutionPoints * step)
+	if rawEnd.Sub(rawStart)/step > format.MaxResolutionPoints {
+		t.Fatalf("test setup is wrong: the raw window already busts the cap")
+	}
+
+	_, err := h.ExecMetricsRange(context.Background(), "{ this is not traceql", rawStart, rawEnd, step)
+	if err == nil {
+		t.Fatal("ExecMetricsRange accepted an unparseable query")
+	}
+	if !strings.Contains(err.Error(), format.ResolutionCapMessage) {
+		t.Fatalf("off-grid window was not aligned before the cap — the raw window passed straight "+
+			"through to the parser, so gRPC and HTTP disagree on the sample grid: %v", err)
+	}
+}


### PR DESCRIPTION
## What

Backports the two request-window guards fixed on main by #1298, with the regression coverage added in #1300. Both defects are reachable on this line.

**loki** — `handleQueryRange` divides by `step` for the resolution cap. `step=0` parses cleanly (`format.ParseDuration` accepts a bare float), so `?step=0` reached the division and panicked:

```
runtime error: integer divide by zero
  internal/api/loki/handler.go:327
```

Recovered by the handler middleware, but a remotely triggerable request kill. Upstream Loki rejects the same shape via `errZeroOrNegativeStep`, as does the Prom head.

**tempo** — `ExecMetricsRange`, the gRPC sibling of `handleMetricsQueryRange`, skipped *both* the step-grid alignment and the resolution ceiling. It returned samples off Tempo's grid and accepted an unbounded matrix fan-out (compute-DoS), through a path no HTTP test covers.

## Tests

Ported with the fixes. The cap assertion uses an unparseable query to prove rejection happens *before* the parse stage; alignment is read through the cap boundary (`alignMetricsWindow` only ever widens, so an off-grid window exactly at the cap when raw is over it once aligned). Each guard was neutralised individually to confirm the matching test fails and the other still passes.

## Release

Merging this publishes **cerberus v1.10.3 / chart 0.10.8**.

> Chart version skips **0.10.7**: that number was already published from the (now retired) 1.9.x line, so 0.10.8 is the next free version on this line.