### PR TITLE
fix(ci): retry the lychee download so link-check can't die before checking a link

### DIFF
--- a/.github/actions/setup-lychee/action.yml
+++ b/.github/actions/setup-lychee/action.yml
@@ -1,0 +1,41 @@
+name: Setup lychee
+description: >
+  Install a pinned lychee binary onto PATH, downloading it with a retrying
+  curl so a transient TLS/CDN blip on the GitHub release host cannot fail a
+  link-check lane before a single link has been checked.
+
+# Why a composite action: both link-check lanes need the same binary, and both
+# previously got it from `lycheeverse/lychee-action`, whose install step is a
+# bare `curl -sfLO`. One TLS reset there fails the job with curl exit 35 -
+# which is exactly wrong for these two lanes:
+#   * ci.yml `link-check` advertises itself as offline and deterministic. Its
+#     download was the one non-deterministic thing about it.
+#   * link-check-external.yml runs `fail: false` precisely so third-party
+#     flakiness can never red a lane - but an install failure red it anyway,
+#     bypassing that intent entirely.
+# Owning the download lets both lanes retry it and keeps the pinned version in
+# one place.
+
+inputs:
+  version:
+    description: lychee release tag to install, e.g. `v0.24.2`.
+    required: false
+    default: v0.24.2
+
+runs:
+  using: composite
+  steps:
+    - name: Install lychee
+      shell: bash
+      env:
+        LYCHEE_VERSION: ${{ inputs.version }}
+      run: |
+        # The archive nests the binary under a target-triple directory, so
+        # extract just that one path and strip the leading component.
+        tarball=lychee-x86_64-unknown-linux-gnu.tar.gz
+        curl -sSfL --retry 5 --retry-all-errors --retry-delay 3 -o "$tarball" \
+          "https://github.com/lycheeverse/lychee/releases/download/lychee-${LYCHEE_VERSION}/${tarball}"
+        tar -xzf "$tarball" --strip-components=1 lychee-x86_64-unknown-linux-gnu/lychee
+        sudo install -m 0755 lychee /usr/local/bin/lychee
+        rm -f "$tarball" lychee
+        lychee --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -511,23 +511,25 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # Fetching the checker is this lane's only network dependency, and it is
+      # retried - see the action for why that matters.
+      - uses: ./.github/actions/setup-lychee
+
       # OFFLINE link + fragment check. `--root-dir` anchors absolute-style
       # `/foo` links at the repo root; `--include-fragments` turns on the
-      # in-document `#anchor` existence check. `fail: true` makes a broken
-      # link/anchor fail the job. No `GITHUB_TOKEN` and no network: this lane
-      # is deterministic by construction.
+      # in-document `#anchor` existence check. lychee exits non-zero on a
+      # broken link/anchor, which fails the step. No `GITHUB_TOKEN` and no
+      # network: the check itself is deterministic by construction.
       - name: lychee (offline internal links + anchors)
-        uses: lycheeverse/lychee-action@v2
-        with:
-          fail: true
-          args: >-
-            --offline
-            --include-fragments
-            --root-dir "$GITHUB_WORKSPACE"
-            --exclude-path compatibility/prometheus/upstream
-            --exclude-path compatibility/tempo/upstream
-            --exclude-path compatibility/loki/upstream
-            --exclude-path node_modules
+        run: |
+          lychee \
+            --offline \
+            --include-fragments \
+            --root-dir "$GITHUB_WORKSPACE" \
+            --exclude-path compatibility/prometheus/upstream \
+            --exclude-path compatibility/tempo/upstream \
+            --exclude-path compatibility/loki/upstream \
+            --exclude-path node_modules \
             "**/*.md"
 
   # `agpl-clean` is the provably-clean-build licence gate. Cerberus ships

--- a/.github/workflows/link-check-external.yml
+++ b/.github/workflows/link-check-external.yml
@@ -5,7 +5,7 @@ name: link-check-external
 # party host availability, which is inherently flaky. A transient 5xx / DNS
 # blip / rate-limit on someone else's server must NEVER red a PR or abort a
 # release tag, so this lane runs ONLY on a weekly schedule + manual dispatch
-# and reports `fail: false`. The internal gate (offline, deterministic) is
+# and reports rot without failing. The internal gate (offline, deterministic) is
 # the one wired into PRs (and so, as a required check, into the release PR's
 # merge-when-green gate).
 on:
@@ -31,6 +31,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - uses: ./.github/actions/setup-lychee
+
       # Persist lychee's response cache across runs so a known-good link is
       # not re-fetched every week (and a known-bad one is not hammered).
       - name: Restore lychee cache
@@ -44,25 +46,27 @@ jobs:
       # ONLINE check: no `--offline`. `--cache` + `--max-cache-age 1d` reuse
       # recent verdicts; `GITHUB_TOKEN` is passed so github.com links are
       # checked authenticated (dodging the anonymous API rate-limit that
-      # otherwise yields false 429/404 negatives). `fail: false` -> the job
-      # stays green even with dead links; the report below carries the signal.
+      # otherwise yields false 429/404 negatives). The exit code is captured
+      # rather than propagated, so the job stays green even with dead links;
+      # the report below carries the signal.
       # The same upstream-snapshot + node_modules excludes as the internal gate.
       - name: lychee (external links)
         id: lychee
-        uses: lycheeverse/lychee-action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          fail: false
-          output: ./lychee-report.md
-          args: >-
-            --cache
-            --max-cache-age 1d
-            --exclude-path compatibility/prometheus/upstream
-            --exclude-path compatibility/tempo/upstream
-            --exclude-path compatibility/loki/upstream
-            --exclude-path node_modules
+        run: |
+          set +e
+          lychee \
+            --cache \
+            --max-cache-age 1d \
+            --format markdown \
+            --output ./lychee-report.md \
+            --exclude-path compatibility/prometheus/upstream \
+            --exclude-path compatibility/tempo/upstream \
+            --exclude-path compatibility/loki/upstream \
+            --exclude-path node_modules \
             "**/*.md"
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
 
       # Open or update a single tracking issue when rot is found. `exit_code`
       # is non-zero iff lychee saw at least one broken link. The action


### PR DESCRIPTION
## What broke

`link-check` failed on the #1296 merge — [run 30230090789](https://github.com/tsouza/cerberus/actions/runs/30230090789/job/89867183918) — with:

```
Downloading from: https://github.com/lycheeverse/lychee/releases/download/lychee-v0.24.2/lychee-x86_64-unknown-linux-gnu.tar.gz
##[error]Process completed with exit code 35
```

curl exit 35 is `CURLE_SSL_CONNECT_ERROR`. **No link was broken** — the job died fetching the link checker. Running the exact same lychee invocation against `main` locally: `271 Total, 200 OK, 0 Errors`.

`lycheeverse/lychee-action` installs its binary with a bare `curl -sfLO` and no retry, so a single TLS reset on the release CDN is fatal.

## Why it matters in both lanes

That failure mode contradicts what each lane says about itself:

- **`ci.yml` → `link-check`** documents itself as *"No `GITHUB_TOKEN` and no network: this lane is deterministic by construction."* True of the check; the *install* was the one non-deterministic thing in it.
- **`link-check-external.yml`** exists precisely so external flakiness can't hurt us — *"A transient 5xx / DNS blip / rate-limit on someone else's server must NEVER red a PR or abort a release tag"* — and runs `fail: false` to guarantee it. An install failure red it anyway, bypassing that intent completely.

So this is one root cause in a shared dependency, not two lane-local flakes.

## Fix

New `.github/actions/setup-lychee` composite action (matching the existing `setup-playwright-browsers` convention) that downloads the pinned binary with `curl --retry 5 --retry-all-errors --retry-delay 3` and installs it onto PATH. Both lanes consume it and then invoke `lychee` directly. The version pin lives in one place.

## Behaviour is otherwise unchanged

Verified against lychee 0.24.2 locally:

- **The internal gate still fails on rot.** A file with a dangling relative link and a missing `#anchor` exits **2**, catching both:
  ```
  [ERROR] …/a.md#nope (at 4:1) | Cannot find fragment
  [ERROR] …/does-not-exist.md (at 3:1) | File not found.
  ```
  The step has no `continue-on-error`, so that still reds the job — the gate stays enforcing.
- **Same args** in both lanes, including the upstream-snapshot and `node_modules` excludes.
- **The external lane still can't red.** It captures `$?` into `steps.lychee.outputs.exit_code` rather than propagating it, which is what `fail: false` did; the tracking-issue step still keys off that output.
- The archive nests the binary under a target-triple directory, so extraction uses `--strip-components=1` on that exact path (confirmed against the real 0.24.2 tarball).