### PR TITLE
fix(test/e2e): scope the tempo duration-filter search to the seed corpus

### DIFF
--- a/test/e2e/e2e_tempo_extra_test.go
+++ b/test/e2e/e2e_tempo_extra_test.go
@@ -34,13 +34,25 @@ func TestTempoSearch_EmptyQ(t *testing.T) {
 // trace summaries for the seeded spans whose Duration exceeds 50ms
 // (the seed includes a 600ms POST /checkout, 450ms POST /api/order,
 // 300ms orders.insert, 150ms GET /home, 80ms GET /api/users, 90ms
-// cron.refresh — six spans match).
+// cron.refresh — six spans match; the 40ms cache.refresh does not).
+//
+// The service-name arm scopes the search to the seed corpus, exactly
+// as every other tempo search test in this file does. `otel_traces`
+// is NOT seed-only: the k3d shard also carries live spans from the
+// `sample-app` telemetrygen deployment and from cerberus's own OTLP
+// self-export, whose durations are whatever the cluster happened to
+// do. An unscoped query therefore matches real spans of, say,
+// 50.4ms — and since `durationMs` is whole milliseconds
+// (`ns / 1e6`, truncating, matching Tempo's wire spec and pinned
+// exactly by the tempo compatibility differ) such a trace reports
+// `durationMs=50` while genuinely satisfying `duration > 50ms`. The
+// assertion below is strict, so the corpus has to be the closed one.
 func TestTempoSearch_DurationFilter(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
 	v := url.Values{}
-	v.Set("q", `{ duration > 50ms }`)
+	v.Set("q", `{ resource.service.name =~ "frontend|api|db" && duration > 50ms }`)
 	resp := getJSON(ctx, t, "/api/search?"+v.Encode())
 	var parsed struct {
 		Traces []struct {


### PR DESCRIPTION
## What broke

`dashboard-shard (shard-smoke-a-monolith)` failed on the **v1.12.0 release commit** (`0cbb91c7`, job [89891118049](https://github.com/tsouza/cerberus/actions/runs/30238455035/job/89891118049)):

```
--- FAIL: TestTempoSearch_DurationFilter (0.03s)
    e2e_tempo_extra_test.go:56: trace with durationMs=50 in result; should be >50
    e2e_tempo_extra_test.go:56: trace with durationMs=50 in result; should be >50
```

`dashboard` is prefix-matched in `RELEASE_INFORMATIONAL_CHECKS`, so it did not block the publish — that only decides *which* PR fixes it, never whether.

## Why

The test issued a bare `{ duration > 50ms }` and asserted every returned summary reports `durationMs > 50`.

`otel_traces` is **not** seed-only. The k3d shard also carries live spans from the `sample-app` telemetrygen deployment (`test/e2e/k3s/sample-app.yaml`) and from cerberus's own OTLP self-export (`test/e2e/k3s/cerberus-values.yaml`) — `just e2e-wait-otel` gates on exactly that real traffic before the Go tests run. So the unscoped query matched real spans of arbitrary duration.

`durationMs` is whole milliseconds — `int(ns / 1_000_000)`, truncating (`internal/api/tempo/handler.go:1772`, `root_lookup.go:361`) — which is Tempo's `/api/search` wire spec and is pinned **exactly** against reference Tempo by the `compatibility/tempo` differ (`internal/migrateverify/compare_tracesearch.go`). A trace of 50.4ms therefore reports `durationMs=50` while genuinely satisfying `duration > 50ms`.

**The emitter is correct. The query was open over a corpus that is not closed.** This was latent from the day the test landed (#123) and surfaces whenever the cluster happens to produce a span in the 50–51ms band.

## Fix

Scope the search to the three seeded services, exactly as **every other** tempo search test in this file already does (`TestTempoSearch`, `_AndFilter`, `_StructuralChild`, `_CountScalar` all pin `resource.service.name`). This was the only unscoped one.

The assertion stays strict — no tolerance, no filtering of results — it just runs over a closed corpus again. The six seeded spans above 50ms still match; the 40ms `cache.refresh` still does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)