### PR TITLE
docs: document the Homebrew installer as the migration entry point

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -317,7 +317,12 @@ One implementation means a new rule guards BOTH lanes at once.
   - Exit (`eol-retire-line`): `0` always (fail-open — a retirement failure must
     never fail an already-published release); `1` only on a gross wiring error
     (missing repo/token) before any publish-affecting work.
-- **`brew-smoke.mjs`** — `release.yml`, the `brew-smoke` job (post-`publish`).
+- **`brew-smoke.mjs`** — `release.yml`, the `brew-smoke` job (post-`publish`),
+  and `brew-verify.yml`, which re-runs the identical assertions on demand or
+  weekly against an ALREADY-published version (the release-run job cannot be
+  replayed with a fix, since `rerun-failed-jobs` restores the workflow as it
+  was at the release commit). Both jobs run on `macos-latest` — the Ubuntu
+  runner image ships no Homebrew, so `brew` is a bare ENOENT there.
   Proves the Homebrew tap actually serves the version that just shipped. Reads
   `Formula/cerberus.rb` from `tsouza/homebrew-tap` through the API FIRST: that
   is the anti-vacuous check, because a deleted `brews:` block or an expired

--- a/README.md
+++ b/README.md
@@ -155,6 +155,16 @@ ships a [SLSA build provenance](https://slsa.dev) attestation:
 gh attestation verify cerberus_*_linux_amd64.tar.gz --owner tsouza --repo cerberus
 ```
 
+The same binary is a Homebrew formula (macOS and Linuxbrew), which is the
+quickest way to get the `cerberus migrate` CLI onto the machine holding your
+rules and dashboards — see [migrating to cerberus](docs/migration.md#getting-the-cerberus-binary):
+
+```sh
+brew install tsouza/tap/cerberus
+```
+
+Only stable releases publish a formula, so `brew` never hands you a prerelease.
+
 Cerberus is configured **entirely** through `CERBERUS_*` environment
 variables — see the full [configuration reference](docs/configuration.md).
 The surrounding runtime contract (lifecycle, scaling, the solver and

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -48,6 +48,49 @@ You need three things in place:
    from a live Grafana API is **not** a shipped capability today; export the
    dashboards to JSON first.)
 
+### Getting the `cerberus` binary
+
+Every step below is a `cerberus migrate …` invocation, so one more thing you
+need is the binary itself — on the machine that holds your rule YAML and your
+exported dashboard JSON. That is normally a laptop or a jump host rather than
+the cluster: the tool reads those files from local disk and writes its
+artifacts back beside them, and every subcommand except `verify`, `inventory`
+and `rulegraph` is fully offline.
+
+Homebrew is the shortest path, on macOS and on Linuxbrew alike:
+
+```sh
+brew install tsouza/tap/cerberus
+cerberus --version
+```
+
+The formula lives in the [`tsouza/homebrew-tap`](https://github.com/tsouza/homebrew-tap)
+tap and is published by the release pipeline itself. Only **stable** releases
+publish one — `rc.*` prereleases deliberately write no formula — so
+`brew install` always lands you on a GA build, and `brew upgrade` moves you
+between GA builds only. Every published formula is installed and smoked by the
+release run that publishes it, and again weekly thereafter; one of the verbs
+that smoke runs is `cerberus migrate schema`, the
+[Validate](#validate-render-the-schema) step of this very lifecycle. The
+release-engineering side of the tap — how the formula is pushed, and what the
+smoke asserts — is in
+[Homebrew tap](operations.md#homebrew-tap).
+
+If you would rather not use Homebrew, the same binary ships as a release
+archive (linux / darwin × amd64 / arm64, each with a
+[SLSA](https://slsa.dev) provenance attestation) on the
+[release page](https://github.com/tsouza/cerberus/releases), and inside the
+container image, whose entrypoint is `cerberus` itself:
+
+```sh
+docker run --rm -v "$PWD:/w" -w /w ghcr.io/tsouza/cerberus:<tag> \
+  migrate harvest --rules rules/ --out corpus.json
+```
+
+The container form works, but every path you hand it has to be visible from
+inside the container and every artifact it writes lands under the mount — which
+is why the rest of this guide assumes a local binary.
+
 ## The `migrate` tool
 
 `migrate` is a command group of the single `cerberus` binary, with eight
@@ -434,6 +477,10 @@ back over — that runway is your rollback. Only then retire the old storage.
 The commands pipe together into one assess → verify → gate flow:
 
 ```bash
+# ── INSTALL ───────────────────────────────────────────────────────────
+# One binary, on the machine holding the rules and dashboards.
+brew install tsouza/tap/cerberus
+
 # ── ASSESS ────────────────────────────────────────────────────────────
 # Harvest every real query (PromQL + LogQL + TraceQL) into one deterministic corpus.
 cerberus migrate harvest \

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1123,9 +1123,18 @@ can install the single `cerberus` binary with:
 brew install tsouza/tap/cerberus
 ```
 
+That is also the shortest way to get the `cerberus migrate` CLI onto the
+machine that holds an operator's rules and dashboards, so the migration
+playbook points at it as the default install path — see
+[getting the `cerberus` binary](migration.md#getting-the-cerberus-binary).
+
 This is wired via the goreleaser `brews:` block (a Homebrew *formula*, not a
 cask, so it installs on Linuxbrew as well as macOS). `skip_upload: auto` means
-`rc.*` prereleases never write a formula — only stable releases publish.
+`rc.*` prereleases never write a formula — only stable releases publish. The
+block pins `directory: Formula`: Homebrew resolves a tap's formulae from
+`Formula/`, `HomebrewFormula/` or the tap root, but goreleaser's `directory`
+defaults to **empty** — the tap root — and `Formula/` is both the conventional
+layout and the path the smoke reads.
 
 Two prerequisites make the push work, and both are one-time:
 
@@ -1147,7 +1156,22 @@ prerelease is **not** skipped — it takes the opposite assertion: `skip_upload:
 auto` means an `rc.*` must have written no formula, so a formula declaring the
 prerelease version is a reported regression. The job runs after `publish` because
 `brew install` downloads the release tarball, which 404s while the release is
-still a draft.
+still a draft, and it runs on `macos-latest` because the Ubuntu runner image
+ships no Homebrew at all. That the formula (rather than a cask) also installs
+under Linuxbrew is a property of the artifact, not something CI exercises.
+
+`brew-smoke` fires exactly once, inside the release run, which leaves one thing
+uncovered: it cannot re-check an *already-published* release. `rerun-failed-jobs`
+replays the workflow as it existed at the release commit, so a correction to the
+job — a different runner, a different tap path — can never be exercised against
+the release that needed it, and nothing here would notice a formula rotting
+after publish (someone edits the tap, an asset is deleted, a checksum stops
+matching). The `brew-verify` workflow covers that: same `brew-smoke.mjs`, same
+assertions, but `workflow_dispatch` (with an optional bare `version`, defaulting
+to the latest published non-prerelease) plus a weekly cron. It checks out the
+*tag* it is verifying, because `config-docs -check` compares the installed
+binary's config registry against the working tree's `docs/configuration.md` —
+against `main` it would red on unreleased doc drift that is not a defect.
 
 #### Maintenance lines (hotfix backports)
 


### PR DESCRIPTION
## Why

`docs/migration.md` opens the operator's first real command with `cerberus
migrate harvest …` and never says where the `cerberus` binary comes from. The
Homebrew installer existed but was documented in exactly one place —
`docs/operations.md`, from the **release-engineering** angle (the goreleaser
`brews:` block, the tap PAT, what the smoke asserts). Nothing told an operator
"this is how you get the tool this playbook is about".

## What changed

**`docs/migration.md`** — new `### Getting the cerberus binary` under *Before
you start*, ahead of `## The migrate tool`:

- `brew install tsouza/tap/cerberus` first. The migrate flow is a
  laptop/jump-host CLI workflow — it reads rule YAML and dashboard JSON off
  local disk and writes its artifacts back beside them, and every subcommand
  except `verify` / `inventory` / `rulegraph` is fully offline — so a local
  binary is what the rest of the guide assumes.
- Only stable releases publish a formula, so `brew install` / `brew upgrade`
  can never hand an operator an `rc.*` build.
- The release archive (with its SLSA attestation) and the container image as
  alternatives, with the caveat that every path handed to the container form
  has to be visible from inside the mount.
- Cross-link to `operations.md#homebrew-tap` for the publishing side.

The *full transcript* now starts with the install line, so it is genuinely
full.

**`README.md`** — the brew one-liner in *From a published release*, next to
`docker pull` and the release archives, linking into the migration section.

**`docs/operations.md`** — the operator cross-link, plus three facts the
Homebrew section was missing:

- the `brews:` block pins `directory: Formula` — goreleaser defaults
  `directory` to **empty**, i.e. the tap root, which Homebrew resolves *last*
  and which is not where the smoke reads;
- `brew-smoke` runs on `macos-latest` because the Ubuntu runner image ships no
  Homebrew at all — and that a *formula* (not a cask) installs under Linuxbrew
  is a property of the artifact, not something CI exercises;
- `brew-verify` covers what `brew-smoke` structurally cannot: re-checking an
  already-published release. `rerun-failed-jobs` restores the workflow as it
  was at the release commit, so a fix to the job can never be exercised
  against the release that needed it, and a formula can rot after publish.

**`.github/scripts/README.md`** — `brew-smoke.mjs` now records both of its
consumers (`release.yml` and `brew-verify.yml`) and the macOS runner
requirement.

## Notes

Docs-only; no behaviour change. `docs/test-strategy.md` needs nothing — its
gate inventory covers the PR/push lanes, not the release pipeline.
