### PR TITLE
docs(migration): restructure the guide as numbered steps with pre/post-conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ gh attestation verify cerberus_*_linux_amd64.tar.gz --owner tsouza --repo cerber
 
 The same binary is a Homebrew formula (macOS and Linuxbrew), which is the
 quickest way to get the `cerberus migrate` CLI onto the machine holding your
-rules and dashboards — see [migrating to cerberus](docs/migration.md#install-the-binary):
+rules and dashboards — see [migrating to cerberus](docs/migration.md#step-1-install-the-binary):
 
 ```sh
 brew install tsouza/tap/cerberus

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -4,22 +4,80 @@ Move a Prometheus-backed setup onto cerberus (ClickHouse) **without rebuilding
 dashboards or rewriting alerts** — and prove what changes *before* real traffic
 depends on it.
 
-The work is driven by `cerberus migrate`, a command group in the release
-binary. It is read-only: it never writes to Prometheus, Grafana or ClickHouse.
-The only two steps that change anything — applying the schema and flipping the
-datasource — are ones **you** run by hand.
+Thirteen steps. Each one declares its **pre-conditions**, what you do, and its
+**post-conditions** — so you always know whether you are ready to run it and
+whether it worked. Do them in order. Steps 3–6 are the only ones that can be
+reordered among themselves.
 
-## Install the binary
+```text
+1–2  install + gather   ──▶  3–6  assess   ──▶  7–9  stand it up
+                                                   │
+                        12–13  cut over  ◀── 10–11  verify + gate
+```
+
+The work is driven by `cerberus migrate`, a command group in the release binary.
+It is read-only: it never writes to Prometheus, Grafana or ClickHouse. Steps 7,
+8, 9, 12 and 13 — the ones that change anything — are ones **you** run by hand.
+
+## Two things cerberus does not do
+
+It has **no ruler**. It answers the PromQL Grafana sends it, but it does not
+evaluate your recording and alerting rules on a schedule — so whatever evaluates
+them today has to keep doing so. Step 5 tells you exactly which ones matter.
+
+It **does not ingest**. Your OpenTelemetry Collector keeps writing into
+ClickHouse; you point no writer at cerberus.
+
+Get either wrong and you cut over to blank panels. It is also why this migration
+is organised around your **real queries** — the PromQL in rules and panels —
+rather than around `prometheus.yml`. A config file cannot tell you whether a
+query translates cleanly or falls over on cardinality. Only the queries and the
+live data can.
+
+## How the tool is configured
+
+There is **one** configuration surface, and it is the same one the cerberus
+server reads: `CERBERUS_*` environment variables. No migration-specific config
+file, no `--config` flag. Whatever the environment leaves unset falls back to an
+optional `cerberus.yaml` (working directory first, then `/etc/cerberus/`), then
+to a built-in default. `cerberus config-docs` prints the whole surface from the
+binary itself; [`docs/configuration.md`](configuration.md) is the same list in
+prose. Every variable also has an equivalent flag, and the flag wins — except
+the output flags (`--json`, `--out`, `--top`), which have no env fallback.
+
+**No `migrate` subcommand ever connects to ClickHouse.** `schema` renders DDL to
+stdout for *you* to apply, everything else works off local files, and the two
+commands that do open a socket talk to your existing Prometheus / Loki / Tempo —
+never to the database.
+
+| Command     | Opens a connection to                            | Reads from your environment                              |
+| ----------- | ------------------------------------------------ | -------------------------------------------------------- |
+| `harvest`   | nothing                                          | nothing                                                  |
+| `classify`  | nothing                                          | the query budget, so previews run under production rules |
+| `explain`   | nothing                                          | the query budget, plus `CERBERUS_SCHEMA_*` table names   |
+| `rulegraph` | nothing                                          | nothing                                                  |
+| `schema`    | nothing — it prints DDL, you pipe it             | `CERBERUS_CH_DATABASE` and `CERBERUS_SCHEMA_*`           |
+| `inventory` | your live Prometheus (and Loki / Tempo if asked) | `CERBERUS_INVENTORY_*`                                   |
+| `verify`    | both backends, one pair per head                 | `CERBERUS_VERIFY_*`                                      |
+| `gate`      | nothing                                          | nothing                                                  |
+
+Each step below repeats the configuration it needs in its own pre-conditions, so
+you can work straight down the page.
+
+## Step 1: Install the binary
+
+**Pre-conditions:**
+
+- A machine that holds — or can hold — your rule YAML and exported dashboard
+  JSON. A laptop or a jump host, not the cluster: the tool reads those files off
+  local disk and writes its artifacts back beside them.
+
+**Do:**
 
 ```sh
 brew install tsouza/tap/cerberus
 cerberus --version
 ```
-
-Put it on the machine that holds your rule YAML and exported dashboard JSON —
-a laptop or a jump host, not the cluster. The tool reads those files off local
-disk and writes its artifacts back beside them, and everything except `verify`
-and `inventory` runs fully offline.
 
 Only stable releases publish a formula, so `brew` never hands you a prerelease.
 If you would rather not use Homebrew, the same binary ships as a
@@ -32,107 +90,229 @@ docker run --rm -v "$PWD:/w" -w /w ghcr.io/tsouza/cerberus:<tag> \
   migrate harvest --rules rules/ --out corpus.json
 ```
 
-Every path you hand the container form has to be visible inside the mount,
-which is why the rest of this guide assumes a local binary.
+Every path you hand the container form has to be visible inside the mount, which
+is why the rest of this guide assumes a local binary.
 
-## What you need in place
+**Post-conditions:**
 
-1. **ClickHouse receiving your telemetry** through the OpenTelemetry
-   Collector's ClickHouse exporter — the same OTel-shaped tables cerberus reads
-   (see the [version requirements](../README.md#version-requirements)).
-2. **A dual-write window.** For a while, data flows into Prometheus *and*
-   ClickHouse at once. That overlap is what makes a real before/after
-   comparison possible. You never cut over cold.
-3. **Your queries as files** — Prometheus recording/alerting rule YAML and
-   exported Grafana dashboard JSON. Harvesting from a live Grafana API is not a
-   shipped capability; export the dashboards first.
+- `cerberus --version` prints a version.
+- Nothing anywhere else has changed.
 
-### Two things cerberus does not do
+## Step 2: Get your queries onto disk
 
-It has **no ruler**. It answers the PromQL Grafana sends it, but it does not
-evaluate your recording and alerting rules on a schedule — so whatever
-evaluates them today has to keep doing so.
+**Pre-conditions:**
 
-It **does not ingest**. Your OpenTelemetry Collector keeps writing into
-ClickHouse; you point no writer at cerberus.
+- Step 1 done.
 
-Get either wrong and you cut over to blank panels. It is also why this
-migration is organised around your **real queries** — the PromQL in rules and
-panels — rather than around `prometheus.yml`. A config file cannot tell you
-whether a query translates cleanly or falls over on cardinality. Only the
-queries and the live data can.
+**Do:**
 
-## Configure it
+Copy your Prometheus recording and alerting rule YAML to the machine, and export
+your Grafana dashboards to JSON (dashboard → *Share* → *Export* → *Save to
+file*, or the Grafana HTTP API). Harvesting from a live Grafana API is not a
+shipped capability — export first.
 
-There is **one** configuration surface, and it is the same one the cerberus
-server reads: `CERBERUS_*` environment variables. No migration-specific config
-file, no `--config` flag. Whatever the environment leaves unset falls back to an
-optional `cerberus.yaml` (working directory first, then `/etc/cerberus/`), then
-to a built-in default. `cerberus config-docs` prints the whole surface from the
-binary itself; [`docs/configuration.md`](configuration.md) is the same list in
-prose.
+**Post-conditions:**
 
-### None of it points the tool at ClickHouse
+- A directory of rule YAML and a directory of dashboard JSON, both readable
+  locally. If you also run Loki, its rule YAML too.
 
-That surprises people, so it is worth being blunt: **no `migrate` subcommand
-ever connects to ClickHouse.** `schema` renders DDL to stdout for *you* to
-apply, everything else works off local files, and the two commands that do open
-a socket talk to your existing Prometheus / Loki / Tempo — never to the
-database.
+## Step 3: Harvest your queries into a corpus
 
-| Command     | Opens a connection to                            | Reads from your environment                                |
-| ----------- | ------------------------------------------------ | ---------------------------------------------------------- |
-| `harvest`   | nothing                                          | nothing                                                    |
-| `classify`  | nothing                                          | the query budget, so previews run under production rules   |
-| `explain`   | nothing                                          | the query budget, plus `CERBERUS_SCHEMA_*` table names     |
-| `rulegraph` | nothing                                          | nothing                                                    |
-| `schema`    | nothing — it prints DDL, you pipe it             | `CERBERUS_CH_DATABASE` and `CERBERUS_SCHEMA_*`             |
-| `inventory` | your live Prometheus (and Loki / Tempo if asked) | `CERBERUS_INVENTORY_*`                                     |
-| `verify`    | both backends, one pair per head                 | `CERBERUS_VERIFY_*`                                        |
-| `gate`      | nothing                                          | nothing                                                    |
+**Pre-conditions:**
 
-So the whole assess stage — `harvest`, `classify`, `rulegraph` — needs **no
-configuration at all**. Run it on a laptop with the wifi off. The three stages
-that do need something are below, in the order you will hit them.
+- Step 2 done.
+- No configuration and no network needed.
 
-### `schema` — the shape of your tables
+**Do:**
 
-`migrate schema` renders exactly the DDL your cerberus server would apply at
-startup, from the same environment. Give it the same values you intend to give
-the server, or the tables you create will not be the tables it looks for:
-
-```sh
-export CERBERUS_CH_DATABASE=otel           # server default is "default"
-export CERBERUS_SCHEMA_CLUSTER=my_cluster  # only if you run ON CLUSTER DDL
-cerberus migrate schema
+```bash
+cerberus migrate harvest \
+  --rules './prometheus/rules/*.yml' \
+  --loki-rules './loki/rules/*.yml' \
+  --dashboards ./grafana/dashboards \
+  --out corpus.json
 ```
 
-It loads and validates the entire config surface, so a typo anywhere in your
-`CERBERUS_*` set aborts it with the same error it would abort the server with —
-which makes this a cheap way to sanity-check that set before you deploy. The
-connection knobs (`CERBERUS_CH_ADDR`, username, password) play no part: nothing
-connects, and *where* the DDL lands is decided entirely by the
-`clickhouse-client` invocation you pipe into.
+**Post-conditions:**
 
-### `inventory` — your live Prometheus
+- `corpus.json` exists: one deterministic corpus spanning all three heads —
+  Prometheus rules and panels as PromQL, Loki rules and panels as LogQL, Tempo
+  panels as TraceQL — each query tagged with its language and where it came
+  from.
+- Everything dropped (unreadable file, unsupported datasource, empty expr) is
+  counted and reported. Nothing is silently discarded, so a surprising total is
+  a signal to look, not to shrug.
 
-A read against `/api/v1/status/tsdb` on the Prometheus you are migrating away
-from. Point it there:
+## Step 4: Classify the corpus
 
-```sh
-export CERBERUS_INVENTORY_SOURCE=http://prometheus.internal:9090
-export CERBERUS_INVENTORY_WINDOW=24h
-# only if you also harvested Loki or Tempo queries
-export CERBERUS_INVENTORY_LOKI_SOURCE=http://loki.internal:3100
-export CERBERUS_INVENTORY_LOKI_SELECTORS='{job="app"}'
-export CERBERUS_INVENTORY_TEMPO_SOURCE=http://tempo.internal:3200
+**Pre-conditions:**
+
+- Step 3 done: `corpus.json` on disk.
+- Set `CERBERUS_QUERY_*` to the values your production server will run with, so
+  the preview is bound by the real per-query sample budget. Still no network.
+
+**Do:**
+
+```bash
+cerberus migrate classify --corpus corpus.json --json --out classify.json
 ```
 
-### `verify` — two URLs per head
+To see the SQL a specific query becomes — useful when `classify` calls something
+risky and you want to know why — add:
 
-The only stage with real setup, and the reason for the [prerequisites
-above](#what-you-need-in-place). For **each head your corpus contains**, `verify`
-needs a pair: the reference backend, and the cerberus meant to replace it.
+```bash
+cerberus migrate explain --corpus corpus.json
+```
+
+**Post-conditions:**
+
+- `classify.json` exists, with every query bucketed as *supported*,
+  *unsupported* (naming the construct that failed), or supported-but-**risky**.
+- You know which queries cerberus cannot express at all. Read "supported"
+  precisely: the query **translates**. Whether it returns the same numbers is
+  what step 10 is for.
+
+## Step 5: Map recording-rule consumers
+
+**Pre-conditions:**
+
+- Step 3 done, and the rule files from step 2 still on disk.
+- No configuration, no network.
+
+**Do:**
+
+```bash
+cerberus migrate rulegraph \
+  --rules './prometheus/rules/*.yml' \
+  --loki-rules './loki/rules/*.yml' \
+  --corpus corpus.json \
+  --json --out rulegraph.json
+```
+
+**Post-conditions:**
+
+- `rulegraph.json` links each recording rule's `record:` output to the
+  dashboards and alerts that read it.
+- You have the list of recorded series that must keep being materialized after
+  cutover. Cerberus has no ruler, so any *consumed* recorded series that stops
+  being produced turns its panel quietly blank. Rulegraph names them; keeping
+  them materialized is your job, and step 12 depends on it.
+
+## Step 6: Measure cardinality on the live Prometheus
+
+**Pre-conditions:**
+
+- The Prometheus you are migrating away from is running and reachable from this
+  machine. This is the first step that goes on the network.
+- Point it there, by flag or by env:
+
+  ```sh
+  export CERBERUS_INVENTORY_SOURCE=http://prometheus.internal:9090
+  export CERBERUS_INVENTORY_WINDOW=24h
+  # only if you also harvested Loki or Tempo queries
+  export CERBERUS_INVENTORY_LOKI_SOURCE=http://loki.internal:3100
+  export CERBERUS_INVENTORY_LOKI_SELECTORS='{job="app"}'
+  export CERBERUS_INVENTORY_TEMPO_SOURCE=http://tempo.internal:3200
+  ```
+
+**Do:**
+
+```bash
+cerberus migrate inventory \
+  --source http://prometheus.internal:9090 \
+  --top 50 --json --out inventory.json
+```
+
+**Post-conditions:**
+
+- `inventory.json` ranks top series and label cardinality, read from
+  `/api/v1/status/tsdb`.
+- You know which metrics carry the OOM risk — the one number that exists *only*
+  at runtime. It ranks that risk; it does not predict cerberus's memory use.
+
+## Step 7: Provision the ClickHouse schema
+
+**Pre-conditions:**
+
+- A ClickHouse you can reach with `clickhouse-client`.
+- `CERBERUS_CH_DATABASE` and any `CERBERUS_SCHEMA_*` overrides set to exactly the
+  values you will give the server in step 9 — otherwise the tables you create
+  are not the tables it will look for:
+
+  ```sh
+  export CERBERUS_CH_DATABASE=otel           # server default is "default"
+  export CERBERUS_SCHEMA_CLUSTER=my_cluster  # only if you run ON CLUSTER DDL
+  ```
+
+**Do:**
+
+```bash
+cerberus migrate schema                                         # review it first
+cerberus migrate schema | clickhouse-client -h clickhouse.internal --multiquery
+```
+
+`migrate schema` renders offline and opens no connection — the pipe is what
+touches the database, and applying the DDL is a deliberate step you run
+yourself. Its output is byte-identical to what the server applies at startup,
+because it reads the same environment. It also loads and validates the *whole*
+config surface, so a typo anywhere in your `CERBERUS_*` set aborts it with the
+same error it would abort the server with — a cheap pre-deploy check.
+
+**Post-conditions:**
+
+- The tables cerberus expects exist, in the database you named.
+- Nothing reads or writes them yet.
+
+## Step 8: Start dual-write
+
+**Pre-conditions:**
+
+- Step 7 done.
+- An OpenTelemetry Collector already collecting your telemetry.
+
+**Do:**
+
+Not a cerberus command — collector configuration. Add the OTel Collector's
+[ClickHouse exporter](../README.md#version-requirements) pointed at the database
+from step 7, and **keep the existing Prometheus write path running**. For a
+while, data flows into both.
+
+**Post-conditions:**
+
+- The same telemetry lands in Prometheus and in ClickHouse.
+- Note the wall-clock time. That overlap is what makes a real before/after
+  comparison possible, and step 10's `--start` cannot reach back before it. You
+  never cut over cold.
+
+## Step 9: Deploy cerberus against ClickHouse
+
+**Pre-conditions:**
+
+- Step 8 done, with enough data accumulated to cover the window you intend to
+  verify over.
+- Server configuration ready — `CERBERUS_CH_ADDR`, credentials, and the *same*
+  `CERBERUS_CH_DATABASE` / `CERBERUS_SCHEMA_*` you used in step 7. That is a
+  server job; [`docs/operations.md`](operations.md) is its subject.
+
+**Do:**
+
+Deploy the binary, container image or Helm chart and wait for `/readyz`.
+
+**Post-conditions:**
+
+- One endpoint serving the Prometheus, Loki and Tempo APIs, reading ClickHouse.
+- No writer points at it. Nothing in Grafana points at it yet either.
+
+## Step 10: Verify parity
+
+This is the parity gate, and it is the only thing that earns you the flip.
+
+**Pre-conditions:**
+
+- Steps 3 and 9 done.
+- Dual-write open across the entire `--start`..`--end` window you ask for.
+- One backend pair — reference and cerberus — for **each head your corpus
+  contains**:
 
 | Head    | Reference backend           | Cerberus                         |
 | ------- | --------------------------- | -------------------------------- |
@@ -140,46 +320,151 @@ needs a pair: the reference backend, and the cerberus meant to replace it.
 | `loki`  | `CERBERUS_VERIFY_REF_LOKI`  | `CERBERUS_VERIFY_CERBERUS_LOKI`  |
 | `tempo` | `CERBERUS_VERIFY_REF_TEMPO` | `CERBERUS_VERIFY_CERBERUS_TEMPO` |
 
-The three cerberus URLs are normally the *same* address — one process serves all
-three APIs. Configure only the heads you harvested; half a pair is a usage
-error, never a silently skipped head. Bearer tokens and multi-tenant
-`X-Scope-OrgID` values have their own variables — see the
-[reference](migration-reference.md#verify-backends).
+  The three cerberus URLs are normally the *same* address — one process serves
+  all three APIs. Configure only the heads you harvested; half a pair is a usage
+  error, never a silently skipped head. Bearer tokens and multi-tenant
+  `X-Scope-OrgID` values have their own variables — see the
+  [reference](migration-reference.md#verify-backends).
 
-By this point cerberus itself has to be deployed, configured against ClickHouse
-and serving. That is a *server* configuration job, and it is
-[`docs/operations.md`](operations.md)'s subject, not this tool's.
-
-### Flags or env, your choice
-
-Every variable above has an equivalent flag, and the flag wins. Use env when you
-are scripting the run, flags when you are exploring — the transcript below uses
-flags so each command reads on its own. The exception is the output flags
-(`--json`, `--out`, `--top`): those have no env fallback and stay on the command
-line.
-
-### What has to be standing, and when
-
-| Before you run | This must already exist                                                                                                                 |
-| -------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| assess         | your rule YAML and exported dashboard JSON, on local disk                                                                               |
-| `inventory`    | the Prometheus you are migrating away from — still running                                                                              |
-| `schema`       | a ClickHouse you can reach with `clickhouse-client`                                                                                     |
-| `verify`       | ClickHouse filling via the OTel Collector, **and** cerberus deployed against it, **and** dual-write open long enough to cover `--start` |
-| `gate`         | the JSON files the stages above wrote                                                                                                   |
-
-## The whole journey, as one script
-
-```text
-ASSESS ─▶ VALIDATE ─▶ VERIFY ─▶ DECIDE ─▶ CUT OVER ─▶ DECOMMISSION
-```
-
-Here it is end to end. The rest of this guide is one section per block.
+**Do:**
 
 ```bash
-# ── ASSESS ── what have you got, and how much of it lands cleanly? ─────
-# needs: your files on disk. No config, no network — except `inventory`,
-# which reads the Prometheus you are leaving.
+cerberus migrate verify \
+  --corpus corpus.json \
+  --ref http://prometheus.internal:9090 \
+  --cerberus http://cerberus.internal:8080 \
+  --ref-loki http://loki.internal:3100 \
+  --cerberus-loki http://cerberus.internal:8080 \
+  --ref-tempo http://tempo.internal:3200 \
+  --cerberus-tempo http://cerberus.internal:8080 \
+  --start -1h --end now --step 60s \
+  --json --out verify.json \
+  --report verify-diagnostics.json
+```
+
+It replays every corpus query against the reference backend **for its own
+head** — PromQL against Prometheus, LogQL against Loki, TraceQL against Tempo —
+and against cerberus over the same window, then diffs the two results.
+
+Run it, fix each divergence at the source, run it again.
+
+> If the cerberus you verify against has the experimental native ClickHouse
+> aggregates enabled (`timeSeries*ToGrid`, auto-selected on CH 25.9+), a
+> sub-observable last-bit rounding difference can surface as a `diverge`. Verify
+> against the exact configuration you intend to run — see the
+> [exactness-vs-scale tradeoff](performance.md#native-rate-exactness-vs-scale-should-i-enable-it).
+> Raise `--tolerance` only as a deliberate decision, never to paper over a real
+> difference.
+
+**Post-conditions:**
+
+- `verify.json` exists, with every query landed as `match`, `diverge`,
+  `undecidable`, `unsupported` or `error`, rolled up per head *and* per
+  `(head, shape)` family — because a Loki lane that diffed 412 log entries has
+  not thereby proved its metric panels.
+- Every family carries a `compared` count in its own unit (series, log entries,
+  traces, spans, tag values). That count is the only number that is evidence:
+  two empty results agree, so a family can be all matches while having diffed
+  nothing at all.
+- **You are done when the exit code is 0** — meaning the diverge count is zero,
+  every head is configured, and every family compared something. `verify` exits
+  **2** if a query diverges or errors, if a head with replayable queries had no
+  backend pair, if the run replayed nothing, or if any family compared nothing.
+  Divergence is never allow-listed and absence of evidence never counts as
+  passing.
+- On a failing run, `verify-diagnostics.json` holds full machine-readable
+  diagnostics with a copy-pasteable repro command, backend URLs and credentials
+  redacted. That is the file to attach to a bug report.
+
+The comparators, the dimensions no comparator can judge, and the pinned replay
+limits are all in the
+[migration reference](migration-reference.md#how-verify-decides-two-results-agree).
+
+## Step 11: Take the go/no-go
+
+**Pre-conditions:**
+
+- `verify.json`, `classify.json` and `rulegraph.json` on disk — all three are
+  required, and a missing one blocks. `inventory.json` is optional.
+- No configuration, no network.
+
+**Do:**
+
+```bash
+cerberus migrate gate \
+  --verify verify.json \
+  --classify classify.json \
+  --rulegraph rulegraph.json \
+  --inventory inventory.json
+```
+
+`gate` is a pure-offline aggregator: it folds the JSON the earlier stages
+emitted into **one** PASS/FAIL verdict with a per-stage checklist. It refuses
+(exit **3**) rather than warning:
+
+- **`verify`** blocks on any divergence or error, on a run that replayed
+  nothing, on a family that compared nothing, and on a replayable query whose
+  head had no backend pair.
+- **`classify`** blocks on any unsupported query, and on classifying nothing at
+  all. Risky queries only warn.
+- **`rulegraph`** blocks on any *consumed* recorded series, and on a consumer
+  expression it could not parse.
+- **`inventory`** never blocks. High cardinality warns, on every head.
+
+**Post-conditions:**
+
+- Exit **0** — and only exit 0 — means you are cleared to cut over.
+- Exit **3** means you are not, and the checklist names which stage said so. Fix
+  it and rerun from the affected step.
+
+## Step 12: Cut over
+
+**Pre-conditions:**
+
+- Step 11 exited 0.
+- Every *consumed* recorded series step 5 named is still being materialized by
+  something — cerberus will not do it for you.
+
+**Do:**
+
+An operator action, not a command:
+
+- Point the Grafana Prometheus **datasource URL** at cerberus, or swap DNS / the
+  service in front of it. Dashboards and alert rules are unchanged — that is the
+  whole point.
+- Flip read-path panels first. Leave anything that **pages** for last, once you
+  have watched the read path stay green.
+- Keep dual-write running.
+
+**Post-conditions:**
+
+- Grafana reads from cerberus.
+- Prometheus is still being written to, and is still your rollback.
+
+## Step 13: Decommission Prometheus storage
+
+**Pre-conditions:**
+
+- Your ClickHouse retention now covers the longest window your dashboards and
+  alerts look back over. That runway is your rollback; until it exists, do not
+  take this step.
+
+**Do:**
+
+Stop the Prometheus write and storage path. Not urgent — there is no prize for
+doing it early.
+
+**Post-conditions:**
+
+- One storage backend. Whatever evaluates your recording and alerting rules is
+  still running, because cerberus has no ruler.
+
+## The whole thing as one script
+
+Steps 3–6, 7 and 10–11 are the commands. Here they are in one paste:
+
+```bash
+# ── ASSESS (steps 3–6) ── what have you got, and how much lands cleanly? ──
 cerberus migrate harvest \
   --rules './prometheus/rules/*.yml' \
   --loki-rules './loki/rules/*.yml' \
@@ -198,14 +483,10 @@ cerberus migrate inventory \
   --source http://prometheus.internal:9090 \
   --top 50 --json --out inventory.json
 
-# ── VALIDATE ── create the tables cerberus expects ────────────────────
-# needs: CERBERUS_CH_DATABASE / CERBERUS_SCHEMA_* set to whatever you will
-# give the server, and a ClickHouse you can reach with clickhouse-client.
+# ── VALIDATE (step 7) ── create the tables cerberus expects ──────────────
 cerberus migrate schema | clickhouse-client -h clickhouse.internal --multiquery
 
-# ── VERIFY ── replay every query against both backends and diff ───────
-# needs: cerberus deployed against ClickHouse and serving, both backends
-# reachable, and dual-write open across the whole --start..--end window.
+# ── VERIFY (step 10) ── replay every query against both backends and diff ─
 cerberus migrate verify \
   --corpus corpus.json \
   --ref http://prometheus.internal:9090 \
@@ -218,8 +499,7 @@ cerberus migrate verify \
   --json --out verify.json \
   --report verify-diagnostics.json
 
-# ── DECIDE ── fold it all into one go/no-go. Exit 0 = cleared ─────────
-# needs: the four JSON files above. Offline again.
+# ── DECIDE (step 11) ── fold it into one go/no-go. Exit 0 = cleared ──────
 cerberus migrate gate \
   --verify verify.json \
   --classify classify.json \
@@ -227,155 +507,25 @@ cerberus migrate gate \
   --inventory inventory.json
 ```
 
-The first two blocks run today, before cerberus is even provisioned — one needs
-nothing but your files, the other a reachable ClickHouse. `verify` is the step
-that needs the full stack standing. `gate` is offline again, and only reads what
-the others wrote. The last two stages are operator actions, not commands — the
-tool stops at the go/no-go and hands you the flip.
-
-For every flag, every exit code and the exact rules each gate applies, see the
+For every flag and every exit code, see the
 [migration reference](migration-reference.md).
-
-## Assess
-
-Four commands, in this order. All offline except `inventory`.
-
-**`harvest`** collapses every rule file and exported dashboard into one
-deterministic `corpus.json` spanning all three heads: Prometheus rules and
-panels as PromQL, Loki rules (`--loki-rules`) and panels as LogQL, Tempo panels
-as TraceQL — each query tagged with its language and where it came from.
-Anything dropped (unreadable file, unsupported datasource, empty expr) is
-counted and reported; nothing is silently discarded.
-
-**`classify`** buckets each query as *supported*, *unsupported* (naming the
-construct that failed), or supported-but-**risky**. Read "supported" precisely:
-the query **translates**. Whether it returns the same numbers is what `verify`
-is for.
-
-**`rulegraph`** links each recording rule's `record:` output to the dashboards
-and alerts that read it. Cerberus has no ruler, so any *consumed* recorded
-series must keep being materialized after cutover or the panel reading it goes
-quietly blank. Rulegraph names exactly which ones; keeping them materialized is
-your job.
-
-**`inventory`** is the one that goes on the network. It reads the live
-Prometheus's `/api/v1/status/tsdb` and ranks top series and label cardinality —
-the number that drives OOM risk, and the one number that exists *only* at
-runtime. It ranks risk; it does not predict cerberus's memory use.
-
-Want to see the SQL a query becomes? `cerberus migrate explain --corpus
-corpus.json` dry-runs each one through the read pipeline and prints it — useful
-when `classify` calls something risky and you want to see why.
-
-## Validate
-
-Render the tables cerberus expects, offline, with no database connection. The
-output is byte-identical to what the server applies at startup — it reads the
-same `CERBERUS_*` environment — so it pipes straight into `clickhouse-client`:
-
-```bash
-cerberus migrate schema | clickhouse-client -h clickhouse.internal --multiquery
-```
-
-Applying the DDL is a deliberate step you run yourself. The tool only renders
-it.
-
-## Verify
-
-This is the parity gate, and it is the only thing that earns you the flip.
-
-Over the dual-write window, `verify` replays every corpus query against the
-reference backend **for its own head** — PromQL against Prometheus, LogQL
-against Loki, TraceQL against Tempo — and against cerberus over the same
-window, then diffs the two results. You configure one backend pair per head
-your corpus actually contains (see [Configure it](#configure-it) for the flags
-and their env equivalents); supplying half a pair is a usage error, never a
-silently skipped head.
-
-Each query lands as `match`, `diverge`, `undecidable`, `unsupported` or
-`error`, and the report rolls up per head *and* per `(head, shape)` family —
-because a Loki lane that diffed 412 log entries has not thereby proved its
-metric panels. Every family also carries a `compared` count in its own unit
-(series, log entries, traces, spans, tag values). That count is the only number
-that is evidence: two empty results agree, so a family can be all matches while
-having diffed nothing at all.
-
-`verify` exits **2** if a query diverges or errors, if a head with replayable
-queries had no backend pair, if the run replayed nothing, or if any family
-compared nothing. Divergence is never allow-listed and absence of evidence
-never counts as passing.
-
-Run it, fix each divergence at the source, run it again. **You are done when
-the diverge count is zero, with every head configured and every family
-comparing something.** That is your permission to flip traffic — not a leap of
-faith.
-
-On a failing run, add `--report diagnostics.json`: full machine-readable
-diagnostics with a copy-pasteable repro command, backend URLs and credentials
-redacted. That is the file to attach to a bug report.
-
-> If the cerberus you verify against has the experimental native ClickHouse
-> aggregates enabled (`timeSeries*ToGrid`, auto-selected on CH 25.9+), a
-> sub-observable last-bit rounding difference can surface as a `diverge`.
-> Verify against the exact configuration you intend to run — see the
-> [exactness-vs-scale tradeoff](performance.md#native-rate-exactness-vs-scale-should-i-enable-it).
-> Raise `--tolerance` only as a deliberate decision, never to paper over a real
-> difference.
-
-The comparators, the dimensions no comparator can judge, and the pinned replay
-limits are all in the [migration reference](migration-reference.md#how-verify-decides-two-results-agree).
-
-## Decide
-
-`gate` is a pure-offline aggregator: it reads the JSON the other stages emitted
-and folds them into **one** PASS/FAIL verdict with a per-stage checklist. It
-refuses (exit **3**) rather than warning:
-
-- **`verify`** blocks on any divergence or error, on a run that replayed
-  nothing, on a family that compared nothing, and on a replayable query whose
-  head had no backend pair.
-- **`classify`** blocks on any unsupported query, and on classifying nothing at
-  all. Risky queries only warn.
-- **`rulegraph`** blocks on any *consumed* recorded series, and on a consumer
-  expression it could not parse.
-- **`inventory`** never blocks. High cardinality warns, on every head.
-
-`verify`, `classify` and `rulegraph` are required artifacts, so a missing one
-blocks too. Exit 0 — and only exit 0 — means you are cleared to cut over.
-
-## Cut over
-
-An operator action, not a command:
-
-- Point the Grafana Prometheus **datasource URL** at cerberus, or swap DNS /
-  the service in front of it. Dashboards and alert rules are unchanged — that
-  is the whole point.
-- Flip read-path panels first. Leave anything that **pages** for last, once you
-  have watched the read path stay green.
-- Keep dual-write running as a safety net.
-
-## Decommission
-
-Also manual, and not urgent. Keep Prometheus's write and storage path until
-your ClickHouse retention covers the longest window your dashboards and alerts
-look back over. That runway is your rollback. Only then retire the old storage.
 
 ## What the tool will not tell you
 
 Being honest about the blind spots is the point of the tool.
 
 - **Cardinality is runtime, not config.** A query whose shape looks fine can
-  still exhaust memory on a metric with millions of label combinations.
-  `inventory` ranks that risk; it does not predict cerberus's memory.
-- **Translate ≠ match.** `classify` proving a query *supported* proves it
-  translates. Only `verify` proves the numbers agree.
+  still exhaust memory on a metric with millions of label combinations. Step 6
+  ranks that risk; it does not predict cerberus's memory.
+- **Translate ≠ match.** Step 4 proving a query *supported* proves it
+  translates. Only step 10 proves the numbers agree.
 - **A green gate must rest on evidence, not silence.** A match over two empty
   results, a lane whose every query was unsupported, and an all-out-of-scope
   corpus all look like "no divergences" — and all three block.
 - **A limitation is not a tolerance.** Where two backends cannot be compared on
-  some dimension, the report names it and counts what it covers. It never
-  widens what "equal" means, and if a limitation swallowed a whole result, the
-  evidence count is zero and the run blocks.
+  some dimension, the report names it and counts what it covers. It never widens
+  what "equal" means, and if a limitation swallowed a whole result, the evidence
+  count is zero and the run blocks.
 - **The gates refuse; they don't warn.** There is no escape hatch and no
   per-head opt-out. The honest way to narrow the gate is to harvest a narrower
   corpus, which is visible and diffable.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1126,7 +1126,7 @@ brew install tsouza/tap/cerberus
 That is also the shortest way to get the `cerberus migrate` CLI onto the
 machine that holds an operator's rules and dashboards, so the migration
 playbook points at it as the default install path — see
-[getting the `cerberus` binary](migration.md#install-the-binary).
+[getting the `cerberus` binary](migration.md#step-1-install-the-binary).
 
 This is wired via the goreleaser `brews:` block (a Homebrew *formula*, not a
 cask, so it installs on Linuxbrew as well as macOS). `skip_upload: auto` means


### PR DESCRIPTION
## Why

The guide read as prose. Prose does not answer the question an operator actually
has at any given moment: **am I ready to run this, and how do I know it
worked?** Adding a configuration section (#1311) helped but did not fix the
shape — structure does.

## What changed

`docs/migration.md` is now **thirteen numbered steps**. Every step declares:

- **Pre-conditions** — what must already be true: which earlier step, which
  `CERBERUS_*` variables with concrete `export` lines, what must be reachable
  over the network (and, for five of the eight subcommands, that the answer is
  "nothing").
- **Do** — the command, or the operator action when it is not a command.
- **Post-conditions** — what exists afterwards, what the exit code means, and
  what it does *not* prove.

The stand-up work that used to hide inside a bulleted prerequisites list is now
three real steps with their own gates:

| Step | Was |
| ------------------------------- | -------------------------------------- |
| 7 · Provision the ClickHouse schema | a line in the "Validate" paragraph |
| 8 · Start dual-write                | prerequisite bullet #2             |
| 9 · Deploy cerberus against ClickHouse | assumed, never stated           |

Retained up front as orientation: the single-`CERBERUS_*`-surface explainer and
the what-connects-to-what table. Retained at the end: the full transcript, as
one paste, with each block labelled by step number.

## Anchor

`## Install the binary` became `## Step 1: Install the binary`, so the two
inbound links (`README.md`, `docs/operations.md`) move to
`#step-1-install-the-binary` in the same commit — `link-check` stays green.

Docs only — no code, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)