### PR TITLE
feat(migrate): read verify/inventory settings from cerberus.yaml

### DIFF
--- a/cmd/cerberus/cmd_migrate.go
+++ b/cmd/cerberus/cmd_migrate.go
@@ -486,9 +486,11 @@ type verifyInputs struct {
 // newMigrateVerifyCmd is the online cutover parity gate: it replays every corpus
 // query against its head's reference backend AND cerberus over one query_range
 // window and diffs the results series-by-series, exiting non-zero on any
-// divergence or error. Every flag falls back to CERBERUS_VERIFY_*.
+// divergence or error. Every flag falls back to CERBERUS_VERIFY_*, from the
+// environment or from the same cerberus.yaml the gateway reads.
 func newMigrateVerifyCmd() *cobra.Command {
 	var in verifyInputs
+	set := config.NewLookup()
 	cmd := &cobra.Command{
 		Use:   "verify",
 		Short: "Replay the corpus against each head's reference backend + cerberus (parity gate)",
@@ -507,7 +509,7 @@ func newMigrateVerifyCmd() *cobra.Command {
 			// The tolerance env is resolved even when --tolerance is set so a
 			// fat-fingered CERBERUS_VERIFY_TOLERANCE surfaces as a hard error rather
 			// than silently tightening the gate; an explicit flag still wins.
-			envTol, err := envFloat("CERBERUS_VERIFY_TOLERANCE", defaultVerifyTolerance)
+			envTol, err := settingFloat(set, "CERBERUS_VERIFY_TOLERANCE", defaultVerifyTolerance)
 			if err != nil {
 				return err
 			}
@@ -518,47 +520,47 @@ func newMigrateVerifyCmd() *cobra.Command {
 		},
 	}
 	f := cmd.Flags()
-	f.StringVar(&in.corpus, "corpus", envOr("CERBERUS_VERIFY_CORPUS", ""),
-		"corpus.json produced by `cerberus migrate harvest` (env: CERBERUS_VERIFY_CORPUS)")
-	f.StringVar(&in.prom.ref, "ref", envOr("CERBERUS_VERIFY_REF", ""),
-		"reference Prometheus base URL (env: CERBERUS_VERIFY_REF)")
-	f.StringVar(&in.prom.cerberus, "cerberus", envOr("CERBERUS_VERIFY_CERBERUS", ""),
-		"cerberus base URL for the prom head (env: CERBERUS_VERIFY_CERBERUS)")
-	f.StringVar(&in.prom.refToken, "ref-token", envOr("CERBERUS_VERIFY_REF_TOKEN", ""),
-		"bearer token for the reference Prometheus, sent as an Authorization header (env: CERBERUS_VERIFY_REF_TOKEN)")
-	f.StringVar(&in.prom.cerberusToken, "cerberus-token", envOr("CERBERUS_VERIFY_CERBERUS_TOKEN", ""),
-		"bearer token for cerberus, sent as an Authorization header (env: CERBERUS_VERIFY_CERBERUS_TOKEN)")
-	f.StringVar(&in.loki.ref, "ref-loki", envOr("CERBERUS_VERIFY_REF_LOKI", ""),
-		"reference Loki base URL; enables the LogQL metric lane (env: CERBERUS_VERIFY_REF_LOKI)")
-	f.StringVar(&in.loki.cerberus, "cerberus-loki", envOr("CERBERUS_VERIFY_CERBERUS_LOKI", ""),
-		"cerberus base URL for the loki head (env: CERBERUS_VERIFY_CERBERUS_LOKI)")
-	f.StringVar(&in.loki.refToken, "ref-loki-token", envOr("CERBERUS_VERIFY_REF_LOKI_TOKEN", ""),
-		"bearer token for the reference Loki (env: CERBERUS_VERIFY_REF_LOKI_TOKEN)")
-	f.StringVar(&in.loki.cerberusToken, "cerberus-loki-token", envOr("CERBERUS_VERIFY_CERBERUS_LOKI_TOKEN", ""),
-		"bearer token for cerberus on the loki head (env: CERBERUS_VERIFY_CERBERUS_LOKI_TOKEN)")
-	f.StringVar(&in.loki.refOrgID, "ref-loki-org-id", envOr("CERBERUS_VERIFY_REF_LOKI_ORG_ID", ""),
-		"X-Scope-OrgID for a multi-tenant reference Loki; cerberus reads no tenant header, so this is reference-side only (env: CERBERUS_VERIFY_REF_LOKI_ORG_ID)")
-	f.StringVar(&in.tempo.ref, "ref-tempo", envOr("CERBERUS_VERIFY_REF_TEMPO", ""),
-		"reference Tempo base URL; enables the TraceQL metrics lane (env: CERBERUS_VERIFY_REF_TEMPO)")
-	f.StringVar(&in.tempo.cerberus, "cerberus-tempo", envOr("CERBERUS_VERIFY_CERBERUS_TEMPO", ""),
-		"cerberus base URL for the tempo head (env: CERBERUS_VERIFY_CERBERUS_TEMPO)")
-	f.StringVar(&in.tempo.refToken, "ref-tempo-token", envOr("CERBERUS_VERIFY_REF_TEMPO_TOKEN", ""),
-		"bearer token for the reference Tempo (env: CERBERUS_VERIFY_REF_TEMPO_TOKEN)")
-	f.StringVar(&in.tempo.cerberusToken, "cerberus-tempo-token", envOr("CERBERUS_VERIFY_CERBERUS_TEMPO_TOKEN", ""),
-		"bearer token for cerberus on the tempo head (env: CERBERUS_VERIFY_CERBERUS_TEMPO_TOKEN)")
-	f.StringVar(&in.tempo.refOrgID, "ref-tempo-org-id", envOr("CERBERUS_VERIFY_REF_TEMPO_ORG_ID", ""),
-		"X-Scope-OrgID for a multi-tenant reference Tempo; cerberus reads no tenant header, so this is reference-side only (env: CERBERUS_VERIFY_REF_TEMPO_ORG_ID)")
-	f.StringVar(&in.start, "start", envOr("CERBERUS_VERIFY_START", "-1h"),
-		"range start (RFC3339, Unix seconds, or relative like -1h/now) (env: CERBERUS_VERIFY_START)")
-	f.StringVar(&in.end, "end", envOr("CERBERUS_VERIFY_END", "now"),
-		"range end (RFC3339, Unix seconds, or relative like -1h/now) (env: CERBERUS_VERIFY_END)")
-	f.StringVar(&in.step, "step", envOr("CERBERUS_VERIFY_STEP", "60s"),
-		"range step, e.g. 60s (env: CERBERUS_VERIFY_STEP)")
+	f.StringVar(&in.corpus, "corpus", settingOr(set, "CERBERUS_VERIFY_CORPUS", ""),
+		"corpus.json produced by `cerberus migrate harvest` (setting: CERBERUS_VERIFY_CORPUS)")
+	f.StringVar(&in.prom.ref, "ref", settingOr(set, "CERBERUS_VERIFY_REF", ""),
+		"reference Prometheus base URL (setting: CERBERUS_VERIFY_REF)")
+	f.StringVar(&in.prom.cerberus, "cerberus", settingOr(set, "CERBERUS_VERIFY_CERBERUS", ""),
+		"cerberus base URL for the prom head (setting: CERBERUS_VERIFY_CERBERUS)")
+	f.StringVar(&in.prom.refToken, "ref-token", settingOr(set, "CERBERUS_VERIFY_REF_TOKEN", ""),
+		"bearer token for the reference Prometheus, sent as an Authorization header (setting: CERBERUS_VERIFY_REF_TOKEN)")
+	f.StringVar(&in.prom.cerberusToken, "cerberus-token", settingOr(set, "CERBERUS_VERIFY_CERBERUS_TOKEN", ""),
+		"bearer token for cerberus, sent as an Authorization header (setting: CERBERUS_VERIFY_CERBERUS_TOKEN)")
+	f.StringVar(&in.loki.ref, "ref-loki", settingOr(set, "CERBERUS_VERIFY_REF_LOKI", ""),
+		"reference Loki base URL; enables the LogQL metric lane (setting: CERBERUS_VERIFY_REF_LOKI)")
+	f.StringVar(&in.loki.cerberus, "cerberus-loki", settingOr(set, "CERBERUS_VERIFY_CERBERUS_LOKI", ""),
+		"cerberus base URL for the loki head (setting: CERBERUS_VERIFY_CERBERUS_LOKI)")
+	f.StringVar(&in.loki.refToken, "ref-loki-token", settingOr(set, "CERBERUS_VERIFY_REF_LOKI_TOKEN", ""),
+		"bearer token for the reference Loki (setting: CERBERUS_VERIFY_REF_LOKI_TOKEN)")
+	f.StringVar(&in.loki.cerberusToken, "cerberus-loki-token", settingOr(set, "CERBERUS_VERIFY_CERBERUS_LOKI_TOKEN", ""),
+		"bearer token for cerberus on the loki head (setting: CERBERUS_VERIFY_CERBERUS_LOKI_TOKEN)")
+	f.StringVar(&in.loki.refOrgID, "ref-loki-org-id", settingOr(set, "CERBERUS_VERIFY_REF_LOKI_ORG_ID", ""),
+		"X-Scope-OrgID for a multi-tenant reference Loki; cerberus reads no tenant header, so this is reference-side only (setting: CERBERUS_VERIFY_REF_LOKI_ORG_ID)")
+	f.StringVar(&in.tempo.ref, "ref-tempo", settingOr(set, "CERBERUS_VERIFY_REF_TEMPO", ""),
+		"reference Tempo base URL; enables the TraceQL metrics lane (setting: CERBERUS_VERIFY_REF_TEMPO)")
+	f.StringVar(&in.tempo.cerberus, "cerberus-tempo", settingOr(set, "CERBERUS_VERIFY_CERBERUS_TEMPO", ""),
+		"cerberus base URL for the tempo head (setting: CERBERUS_VERIFY_CERBERUS_TEMPO)")
+	f.StringVar(&in.tempo.refToken, "ref-tempo-token", settingOr(set, "CERBERUS_VERIFY_REF_TEMPO_TOKEN", ""),
+		"bearer token for the reference Tempo (setting: CERBERUS_VERIFY_REF_TEMPO_TOKEN)")
+	f.StringVar(&in.tempo.cerberusToken, "cerberus-tempo-token", settingOr(set, "CERBERUS_VERIFY_CERBERUS_TEMPO_TOKEN", ""),
+		"bearer token for cerberus on the tempo head (setting: CERBERUS_VERIFY_CERBERUS_TEMPO_TOKEN)")
+	f.StringVar(&in.tempo.refOrgID, "ref-tempo-org-id", settingOr(set, "CERBERUS_VERIFY_REF_TEMPO_ORG_ID", ""),
+		"X-Scope-OrgID for a multi-tenant reference Tempo; cerberus reads no tenant header, so this is reference-side only (setting: CERBERUS_VERIFY_REF_TEMPO_ORG_ID)")
+	f.StringVar(&in.start, "start", settingOr(set, "CERBERUS_VERIFY_START", "-1h"),
+		"range start (RFC3339, Unix seconds, or relative like -1h/now) (setting: CERBERUS_VERIFY_START)")
+	f.StringVar(&in.end, "end", settingOr(set, "CERBERUS_VERIFY_END", "now"),
+		"range end (RFC3339, Unix seconds, or relative like -1h/now) (setting: CERBERUS_VERIFY_END)")
+	f.StringVar(&in.step, "step", settingOr(set, "CERBERUS_VERIFY_STEP", "60s"),
+		"range step, e.g. 60s (setting: CERBERUS_VERIFY_STEP)")
 	f.Float64Var(&in.tolerance, "tolerance", defaultVerifyTolerance,
-		"absolute value tolerance for a match (env: CERBERUS_VERIFY_TOLERANCE)")
+		"absolute value tolerance for a match (setting: CERBERUS_VERIFY_TOLERANCE)")
 	f.BoolVar(&in.asJSON, "json", false, "emit the machine-readable JSON report instead of the text report")
-	f.StringVar(&in.report, "report", envOr("CERBERUS_VERIFY_REPORT", ""),
-		"write the full JSON diagnostics to this file; additive, the text report still prints (env: CERBERUS_VERIFY_REPORT)")
+	f.StringVar(&in.report, "report", settingOr(set, "CERBERUS_VERIFY_REPORT", ""),
+		"write the full JSON diagnostics to this file; additive, the text report still prints (setting: CERBERUS_VERIFY_REPORT)")
 	f.StringVar(&in.out, "out", "",
 		"write the report here (default: stdout); same content (text or --json) as stdout")
 	return cmd
@@ -803,6 +805,7 @@ func newMigrateInventoryCmd() *cobra.Command {
 		lokiSelectors []string
 		tempoSource   string
 	)
+	set := config.NewLookup()
 	cmd := &cobra.Command{
 		Use:   "inventory",
 		Short: "Probe live migration sources for cardinality / OOM-risk facts",
@@ -860,23 +863,23 @@ func newMigrateInventoryCmd() *cobra.Command {
 			return writeInventory(cmd.OutOrStdout(), out, inv, asJSON)
 		},
 	}
-	cmd.Flags().StringVar(&source, "source", envOr("CERBERUS_INVENTORY_SOURCE", ""),
-		"source Prometheus base URL to probe for live cardinality (env: CERBERUS_INVENTORY_SOURCE)")
+	cmd.Flags().StringVar(&source, "source", settingOr(set, "CERBERUS_INVENTORY_SOURCE", ""),
+		"source Prometheus base URL to probe for live cardinality (setting: CERBERUS_INVENTORY_SOURCE)")
 	cmd.Flags().IntVar(&top, "top", migrateinventory.DefaultTop, "rank the top N metrics/labels/selectors by cardinality")
-	cmd.Flags().StringVar(&window, "window", envOr("CERBERUS_INVENTORY_WINDOW", ""),
+	cmd.Flags().StringVar(&window, "window", settingOr(set, "CERBERUS_INVENTORY_WINDOW", ""),
 		"optional observation window (duration like 1h); recorded as report context for Prometheus, "+
-			"and applied as the real query range for Loki's index/stats (env: CERBERUS_INVENTORY_WINDOW)")
+			"and applied as the real query range for Loki's index/stats (setting: CERBERUS_INVENTORY_WINDOW)")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "emit the machine-readable JSON report instead of text")
 	cmd.Flags().StringVar(&out, "out", "", "write the inventory here (default: stdout)")
-	cmd.Flags().StringVar(&lokiSource, "loki-source", envOr("CERBERUS_INVENTORY_LOKI_SOURCE", ""),
+	cmd.Flags().StringVar(&lokiSource, "loki-source", settingOr(set, "CERBERUS_INVENTORY_LOKI_SOURCE", ""),
 		"optional Loki base URL to probe per-selector stream cardinality/volume (requires --loki-selector; "+
-			"env: CERBERUS_INVENTORY_LOKI_SOURCE)")
-	cmd.Flags().StringArrayVar(&lokiSelectors, "loki-selector", envOrLokiSelectors("CERBERUS_INVENTORY_LOKI_SELECTORS"),
+			"setting: CERBERUS_INVENTORY_LOKI_SOURCE)")
+	cmd.Flags().StringArrayVar(&lokiSelectors, "loki-selector", settingLines(set, "CERBERUS_INVENTORY_LOKI_SELECTORS"),
 		"Loki stream selector to rank via /loki/api/v1/index/stats (repeatable; required with --loki-source; "+
-			"env: CERBERUS_INVENTORY_LOKI_SELECTORS, one selector per line — a selector may itself contain a comma)")
-	cmd.Flags().StringVar(&tempoSource, "tempo-source", envOr("CERBERUS_INVENTORY_TEMPO_SOURCE", ""),
+			"setting: CERBERUS_INVENTORY_LOKI_SELECTORS, one selector per line — a selector may itself contain a comma)")
+	cmd.Flags().StringVar(&tempoSource, "tempo-source", settingOr(set, "CERBERUS_INVENTORY_TEMPO_SOURCE", ""),
 		"optional Tempo base URL; presence alone records a fixed out-of-scope inventory entry, no probe is made "+
-			"(env: CERBERUS_INVENTORY_TEMPO_SOURCE)")
+			"(setting: CERBERUS_INVENTORY_TEMPO_SOURCE)")
 	return cmd
 }
 
@@ -1368,37 +1371,39 @@ func (e gateFailedError) Error() string {
 	return fmt.Sprintf("cutover gate failed: overall %s (a blocking stage said no-go)", e.overall)
 }
 
-// envOr returns the environment value for key, or def when unset/empty.
-func envOr(key, def string) string {
-	if v := os.Getenv(key); v != "" {
+// settingOr returns key's configured value — environment variable first, then
+// cerberus.yaml — or def when neither supplies one.
+func settingOr(set *config.Lookup, key, def string) string {
+	if v := set.String(key); v != "" {
 		return v
 	}
 	return def
 }
 
-// envOrLokiSelectors parses the environment fallback for the repeatable
-// --loki-selector flag. It deliberately does NOT comma-split the way a
-// generic repeatable-flag env fallback would: a LogQL stream selector
-// routinely contains a comma itself (e.g. the ordinary multi-label selector
-// `{app="checkout", env="prod"}`), and comma-splitting would corrupt it into
-// two malformed fragments. Each selector is instead one line, matching
-// --loki-selector's StringArrayVar CLI semantics where every occurrence of
-// the flag is one whole, unsplit selector. It returns nil (not an empty
-// non-nil slice) when the variable is unset, so cobra's flag default stays
+// settingLines resolves the configured fallback for the repeatable
+// --loki-selector flag. A cerberus.yaml sequence maps to the list directly;
+// the environment variable, which cannot express a sequence, is one selector
+// per line. Neither form comma-splits the way a generic repeatable-flag
+// fallback would: a LogQL stream selector routinely contains a comma itself
+// (e.g. the ordinary multi-label selector `{app="checkout", env="prod"}`), and
+// comma-splitting would corrupt it into two malformed fragments — matching
+// --loki-selector's StringArrayVar CLI semantics where every occurrence of the
+// flag is one whole, unsplit selector. It returns nil (not an empty non-nil
+// slice) when nothing is configured, so cobra's flag default stays
 // indistinguishable from "never set."
-func envOrLokiSelectors(key string) []string {
-	v := os.Getenv(key)
-	if v == "" {
+func settingLines(set *config.Lookup, key string) []string {
+	lines := normalizeList(set.Lines(key))
+	if len(lines) == 0 {
 		return nil
 	}
-	return normalizeList(strings.Split(v, "\n"))
+	return lines
 }
 
-// envFloat returns the float parsed from the environment value for key, or def
-// when the variable is unset. A set-but-unparseable value is an error, not a
+// settingFloat returns the float parsed from key's configured value, or def
+// when nothing is configured. A set-but-unparseable value is an error, not a
 // silent fallback to def.
-func envFloat(key string, def float64) (float64, error) {
-	v := os.Getenv(key)
+func settingFloat(set *config.Lookup, key string, def float64) (float64, error) {
+	v := set.String(key)
 	if v == "" {
 		return def, nil
 	}

--- a/cmd/cerberus/cmd_migrate.go
+++ b/cmd/cerberus/cmd_migrate.go
@@ -86,6 +86,10 @@ var errNoMigrateSubcommand = errors.New("nothing to do: pass a migrate subcomman
 // (verify); the rest run without a ClickHouse connection so an operator can
 // review exactly what cerberus will do before provisioning anything.
 func newMigrateCmd() *cobra.Command {
+	// One probe of cerberus.yaml for the whole migrate tree: cobra builds every
+	// subcommand on every invocation, so a per-constructor Lookup would read the
+	// same file twice and could, mid-run, read two different files.
+	set := config.NewLookup()
 	cmd := &cobra.Command{
 		Use:   "migrate",
 		Short: "Offline pre-cutover migration preview toolkit",
@@ -112,8 +116,8 @@ func newMigrateCmd() *cobra.Command {
 		newMigrateExplainCmd(),
 		newMigrateClassifyCmd(),
 		newMigrateRuleGraphCmd(),
-		newMigrateVerifyCmd(),
-		newMigrateInventoryCmd(),
+		newMigrateVerifyCmd(set),
+		newMigrateInventoryCmd(set),
 		newMigrateGateCmd(),
 	)
 	return cmd
@@ -152,7 +156,7 @@ func runMigrate(args []string, stdout, stderr io.Writer) error {
 // standalone. They exist so tests (and the parity/cutover exit-code contract)
 // exercise exactly one verb's flag parsing + logic without the parent tree.
 func runVerify(args []string, stdout, stderr io.Writer) error {
-	return execCmd(newMigrateVerifyCmd(), args, stdout, stderr)
+	return execCmd(newMigrateVerifyCmd(config.NewLookup()), args, stdout, stderr)
 }
 
 func runGate(args []string, stdout, stderr io.Writer) error {
@@ -160,7 +164,7 @@ func runGate(args []string, stdout, stderr io.Writer) error {
 }
 
 func runInventory(args []string, stdout, stderr io.Writer) error {
-	return execCmd(newMigrateInventoryCmd(), args, stdout, stderr)
+	return execCmd(newMigrateInventoryCmd(config.NewLookup()), args, stdout, stderr)
 }
 
 // normalizeList reproduces the legacy stringList semantics on top of cobra's
@@ -488,9 +492,8 @@ type verifyInputs struct {
 // window and diffs the results series-by-series, exiting non-zero on any
 // divergence or error. Every flag falls back to CERBERUS_VERIFY_*, from the
 // environment or from the same cerberus.yaml the gateway reads.
-func newMigrateVerifyCmd() *cobra.Command {
+func newMigrateVerifyCmd(set *config.Lookup) *cobra.Command {
 	var in verifyInputs
-	set := config.NewLookup()
 	cmd := &cobra.Command{
 		Use:   "verify",
 		Short: "Replay the corpus against each head's reference backend + cerberus (parity gate)",
@@ -794,7 +797,7 @@ func runVerifyCommand(cmd *cobra.Command, in verifyInputs) error {
 // --tempo-source, records a fixed out-of-scope entry rather than a fabricated
 // cardinality number, since Tempo's span/block storage exposes nothing
 // analogous. Flags fall back to CERBERUS_INVENTORY_*.
-func newMigrateInventoryCmd() *cobra.Command {
+func newMigrateInventoryCmd(set *config.Lookup) *cobra.Command {
 	var (
 		source        string
 		top           int
@@ -805,7 +808,6 @@ func newMigrateInventoryCmd() *cobra.Command {
 		lokiSelectors []string
 		tempoSource   string
 	)
-	set := config.NewLookup()
 	cmd := &cobra.Command{
 		Use:   "inventory",
 		Short: "Probe live migration sources for cardinality / OOM-risk facts",

--- a/cmd/cerberus/cmd_migrate_settings_test.go
+++ b/cmd/cerberus/cmd_migrate_settings_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/config"
+)
+
+// inCerberusYAML writes a cerberus.yaml into a fresh temp directory and makes
+// it the working directory, so the migrate commands' config.Lookup finds it —
+// the same file, same discovery path, the gateway itself reads.
+func inCerberusYAML(t *testing.T, body string) {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "cerberus.yaml"), []byte(body), 0o600); err != nil {
+		t.Fatalf("write cerberus.yaml: %v", err)
+	}
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir %s: %v", dir, err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+}
+
+// TestVerifyFlagsFromCerberusYAML asserts `migrate verify` takes its defaults
+// from cerberus.yaml, not only from the environment. Configuring a migration
+// by exporting two dozen variables was the gap: one file now carries the
+// engine settings and the migration settings together.
+func TestVerifyFlagsFromCerberusYAML(t *testing.T) {
+	inCerberusYAML(t, ""+
+		"CERBERUS_VERIFY_CORPUS: corpus.json\n"+
+		"CERBERUS_VERIFY_REF: http://prometheus.internal:9090\n"+
+		"CERBERUS_VERIFY_CERBERUS: http://cerberus.internal:8080\n"+
+		"CERBERUS_VERIFY_START: -6h\n"+
+		"CERBERUS_VERIFY_STEP: 30s\n"+
+		"CERBERUS_VERIFY_TOLERANCE: 0.5\n")
+
+	f := newMigrateVerifyCmd().Flags()
+	for _, tc := range []struct{ flag, want string }{
+		{"corpus", "corpus.json"},
+		{"ref", "http://prometheus.internal:9090"},
+		{"cerberus", "http://cerberus.internal:8080"},
+		{"start", "-6h"},
+		{"step", "30s"},
+		{"end", "now"}, // absent from the file: the built-in default stands.
+	} {
+		if got := f.Lookup(tc.flag).DefValue; got != tc.want {
+			t.Errorf("--%s default = %q; want %q from cerberus.yaml", tc.flag, got, tc.want)
+		}
+	}
+}
+
+// TestVerifyToleranceFromCerberusYAML asserts the one setting resolved at run
+// time rather than flag-registration time also reads the file.
+func TestVerifyToleranceFromCerberusYAML(t *testing.T) {
+	inCerberusYAML(t, "CERBERUS_VERIFY_TOLERANCE: 0.5\n")
+
+	got, err := settingFloat(config.NewLookup(), "CERBERUS_VERIFY_TOLERANCE", defaultVerifyTolerance)
+	if err != nil {
+		t.Fatalf("settingFloat: %v", err)
+	}
+	if got != 0.5 {
+		t.Errorf("tolerance = %v; want 0.5 from cerberus.yaml", got)
+	}
+}
+
+// TestInventoryFlagsFromCerberusYAML asserts `migrate inventory` reads the same
+// file, including the repeatable --loki-selector flag whose YAML form is a
+// sequence — each entry one whole selector, commas and all.
+func TestInventoryFlagsFromCerberusYAML(t *testing.T) {
+	inCerberusYAML(t, ""+
+		"CERBERUS_INVENTORY_SOURCE: http://prometheus.internal:9090\n"+
+		"CERBERUS_INVENTORY_WINDOW: 24h\n"+
+		"CERBERUS_INVENTORY_LOKI_SOURCE: http://loki.internal:3100\n"+
+		"CERBERUS_INVENTORY_LOKI_SELECTORS:\n"+
+		"  - '{app=\"checkout\", env=\"prod\"}'\n"+
+		"  - '{app=\"cart\"}'\n")
+
+	f := newMigrateInventoryCmd().Flags()
+	if got := f.Lookup("source").DefValue; got != "http://prometheus.internal:9090" {
+		t.Errorf("--source default = %q; want the cerberus.yaml value", got)
+	}
+	if got := f.Lookup("window").DefValue; got != "24h" {
+		t.Errorf("--window default = %q; want 24h", got)
+	}
+	if got := f.Lookup("loki-source").DefValue; got != "http://loki.internal:3100" {
+		t.Errorf("--loki-source default = %q; want the cerberus.yaml value", got)
+	}
+
+	got, err := f.GetStringArray("loki-selector")
+	if err != nil {
+		t.Fatalf("GetStringArray: %v", err)
+	}
+	want := []string{`{app="checkout", env="prod"}`, `{app="cart"}`}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("--loki-selector default = %#v; want %#v (sequence entries kept whole)", got, want)
+	}
+}
+
+// TestEnvBeatsCerberusYAML pins the precedence at the command level: an
+// operator overriding one setting from the environment still wins over the
+// file, matching every other cerberus setting.
+func TestEnvBeatsCerberusYAML(t *testing.T) {
+	inCerberusYAML(t, "CERBERUS_VERIFY_REF: http://fromfile:9090\n")
+	t.Setenv("CERBERUS_VERIFY_REF", "http://fromenv:9090")
+
+	if got := newMigrateVerifyCmd().Flags().Lookup("ref").DefValue; got != "http://fromenv:9090" {
+		t.Errorf("--ref default = %q; want the env value, which outranks the file", got)
+	}
+}

--- a/cmd/cerberus/cmd_migrate_settings_test.go
+++ b/cmd/cerberus/cmd_migrate_settings_test.go
@@ -1,13 +1,25 @@
 package main
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"reflect"
+	"regexp"
+	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	"github.com/tsouza/cerberus/internal/config"
 )
+
+// pkgSourceDir is this package's directory. `go test` starts each package in
+// its own source directory and variable initialisation runs before any test, so
+// this captures it before inCerberusYAML chdirs away — runtime.Caller cannot,
+// because -trimpath rewrites the recorded path to a module-relative one.
+var pkgSourceDir, _ = os.Getwd()
 
 // inCerberusYAML writes a cerberus.yaml into a fresh temp directory and makes
 // it the working directory, so the migrate commands' config.Lookup finds it —
@@ -41,7 +53,7 @@ func TestVerifyFlagsFromCerberusYAML(t *testing.T) {
 		"CERBERUS_VERIFY_STEP: 30s\n"+
 		"CERBERUS_VERIFY_TOLERANCE: 0.5\n")
 
-	f := newMigrateVerifyCmd().Flags()
+	f := newMigrateVerifyCmd(config.NewLookup()).Flags()
 	for _, tc := range []struct{ flag, want string }{
 		{"corpus", "corpus.json"},
 		{"ref", "http://prometheus.internal:9090"},
@@ -82,7 +94,7 @@ func TestInventoryFlagsFromCerberusYAML(t *testing.T) {
 		"  - '{app=\"checkout\", env=\"prod\"}'\n"+
 		"  - '{app=\"cart\"}'\n")
 
-	f := newMigrateInventoryCmd().Flags()
+	f := newMigrateInventoryCmd(config.NewLookup()).Flags()
 	if got := f.Lookup("source").DefValue; got != "http://prometheus.internal:9090" {
 		t.Errorf("--source default = %q; want the cerberus.yaml value", got)
 	}
@@ -103,6 +115,123 @@ func TestInventoryFlagsFromCerberusYAML(t *testing.T) {
 	}
 }
 
+// settingKeyRE pulls the CERBERUS_* key out of a flag's help text, which is the
+// only place the flag↔setting mapping is written down.
+var settingKeyRE = regexp.MustCompile(`setting: (CERBERUS_[A-Z_]+)`)
+
+// migrateSettingFlags walks both commands that take settings and returns the
+// flag→key mapping their help text declares. Deriving the list at run time
+// rather than hard-coding it is what makes TestEverySettingReadsCerberusYAML
+// exhaustive: a flag added later with a documented setting is covered the day
+// it lands, and one wired to os.Getenv instead of the Lookup fails immediately.
+func migrateSettingFlags(t *testing.T) map[string]string {
+	t.Helper()
+	byFlag := map[string]string{}
+	for _, cmd := range []*cobra.Command{
+		newMigrateVerifyCmd(config.NewLookup()),
+		newMigrateInventoryCmd(config.NewLookup()),
+	} {
+		cmd.Flags().VisitAll(func(f *pflag.Flag) {
+			if m := settingKeyRE.FindStringSubmatch(f.Usage); m != nil {
+				byFlag[f.Name] = m[1]
+			}
+		})
+	}
+	// Guard against a vacuous pass: if the help-text contract ever changes and
+	// discovery silently finds two keys instead of every one, the exhaustive
+	// test would still go green. Count the keys the source declares and demand
+	// the same number — a floor derived from the code, not a magic number.
+	src, err := os.ReadFile(filepath.Join(pkgSourceDir, "cmd_migrate.go"))
+	if err != nil {
+		t.Fatalf("read cmd_migrate.go: %v", err)
+	}
+	declared := map[string]bool{}
+	for _, m := range settingKeyRE.FindAllSubmatch(src, -1) {
+		declared[string(m[1])] = true
+	}
+	if len(byFlag) != len(declared) {
+		t.Fatalf("discovered %d settings from flag help, but cmd_migrate.go declares %d; "+
+			"a setting is documented without a flag, or discovery is broken", len(byFlag), len(declared))
+	}
+	return byFlag
+}
+
+// TestEverySettingReadsCerberusYAML is the exhaustive form of the sampled tests
+// above: EVERY setting the migrate commands document must resolve from
+// cerberus.yaml, not just the handful spot-checked. It writes one file carrying
+// a distinct sentinel per key and asserts each flag picks its own up.
+func TestEverySettingReadsCerberusYAML(t *testing.T) {
+	// Discovery runs somewhere without a cerberus.yaml, so the help text is read
+	// from pristine defaults.
+	inCerberusYAML(t, "")
+	byFlag := migrateSettingFlags(t)
+
+	// --tolerance is a Float64Var resolved in RunE rather than at flag
+	// registration, and --loki-selector is a repeatable StringArrayVar whose
+	// DefValue renders as a bracketed list; both are asserted separately, so
+	// they carry their own sentinel shapes here.
+	const tolerance, selectors = "CERBERUS_VERIFY_TOLERANCE", "CERBERUS_INVENTORY_LOKI_SELECTORS"
+
+	var yaml strings.Builder
+	want := map[string]string{}
+	for flag, key := range byFlag {
+		switch key {
+		case tolerance:
+			yaml.WriteString(key + ": 0.5\n")
+		case selectors:
+			yaml.WriteString(key + ":\n  - '{sentinel=\"" + flag + "\"}'\n")
+		default:
+			sentinel := "sentinel-" + flag
+			yaml.WriteString(key + ": " + sentinel + "\n")
+			want[flag] = sentinel
+		}
+	}
+	inCerberusYAML(t, yaml.String())
+
+	verify, inventory := newMigrateVerifyCmd(config.NewLookup()), newMigrateInventoryCmd(config.NewLookup())
+	for flag, wantValue := range want {
+		f := verify.Flags().Lookup(flag)
+		if f == nil {
+			f = inventory.Flags().Lookup(flag)
+		}
+		if f == nil {
+			t.Errorf("--%s vanished between discovery and assertion", flag)
+			continue
+		}
+		if f.DefValue != wantValue {
+			t.Errorf("--%s default = %q; want %q — %s is not read from cerberus.yaml",
+				flag, f.DefValue, wantValue, byFlag[flag])
+		}
+	}
+
+	got, err := inventory.Flags().GetStringArray("loki-selector")
+	if err != nil {
+		t.Fatalf("GetStringArray: %v", err)
+	}
+	if wantSel := []string{`{sentinel="loki-selector"}`}; !reflect.DeepEqual(got, wantSel) {
+		t.Errorf("--loki-selector default = %#v; want %#v", got, wantSel)
+	}
+	if tol, err := settingFloat(config.NewLookup(), tolerance, defaultVerifyTolerance); err != nil || tol != 0.5 {
+		t.Errorf("tolerance = %v, %v; want 0.5, nil", tol, err)
+	}
+}
+
+// TestNoDirectGetenvForMigrateSettings pins the fix at the source. Every
+// CERBERUS_VERIFY_* / CERBERUS_INVENTORY_* setting once resolved through a bare
+// os.Getenv, which bypassed the config file entirely; a new flag reaching for
+// os.Getenv would silently reintroduce exactly that gap, and no behavioural
+// test catches a setting nobody thought to add a case for.
+func TestNoDirectGetenvForMigrateSettings(t *testing.T) {
+	src, err := os.ReadFile(filepath.Join(pkgSourceDir, "cmd_migrate.go"))
+	if err != nil {
+		t.Fatalf("read cmd_migrate.go: %v", err)
+	}
+	if bytes.Contains(src, []byte("os.Getenv")) {
+		t.Error("cmd_migrate.go calls os.Getenv directly: settings must resolve " +
+			"through config.Lookup so cerberus.yaml is honoured alongside the environment")
+	}
+}
+
 // TestEnvBeatsCerberusYAML pins the precedence at the command level: an
 // operator overriding one setting from the environment still wins over the
 // file, matching every other cerberus setting.
@@ -110,7 +239,7 @@ func TestEnvBeatsCerberusYAML(t *testing.T) {
 	inCerberusYAML(t, "CERBERUS_VERIFY_REF: http://fromfile:9090\n")
 	t.Setenv("CERBERUS_VERIFY_REF", "http://fromenv:9090")
 
-	if got := newMigrateVerifyCmd().Flags().Lookup("ref").DefValue; got != "http://fromenv:9090" {
+	if got := newMigrateVerifyCmd(config.NewLookup()).Flags().Lookup("ref").DefValue; got != "http://fromenv:9090" {
 		t.Errorf("--ref default = %q; want the env value, which outranks the file", got)
 	}
 }

--- a/cmd/cerberus/cmd_migrate_verify_test.go
+++ b/cmd/cerberus/cmd_migrate_verify_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/tsouza/cerberus/internal/config"
 	"github.com/tsouza/cerberus/internal/migrateverify"
 )
 
@@ -349,22 +350,23 @@ func TestRunVerify_BadToleranceEnv(t *testing.T) {
 	}
 }
 
-// TestEnvFloat covers the unset / valid / unparseable branches directly.
-func TestEnvFloat(t *testing.T) {
+// TestSettingFloat covers the unset / valid / unparseable branches directly.
+func TestSettingFloat(t *testing.T) {
 	const key = "CERBERUS_VERIFY_TOLERANCE_TESTKEY"
+	set := config.NewLookup()
 
 	t.Setenv(key, "")
-	if got, err := envFloat(key, 1e-9); err != nil || got != 1e-9 {
+	if got, err := settingFloat(set, key, 1e-9); err != nil || got != 1e-9 {
 		t.Errorf("unset: got %v, %v; want 1e-9, nil", got, err)
 	}
 
 	t.Setenv(key, "0.25")
-	if got, err := envFloat(key, 1e-9); err != nil || got != 0.25 {
+	if got, err := settingFloat(set, key, 1e-9); err != nil || got != 0.25 {
 		t.Errorf("valid: got %v, %v; want 0.25, nil", got, err)
 	}
 
 	t.Setenv(key, "banana")
-	if _, err := envFloat(key, 1e-9); err == nil {
-		t.Error("unparseable: envFloat should error, not fall back to the default")
+	if _, err := settingFloat(set, key, 1e-9); err == nil {
+		t.Error("unparseable: settingFloat should error, not fall back to the default")
 	}
 }

--- a/docs/migration-reference.md
+++ b/docs/migration-reference.md
@@ -26,7 +26,7 @@ subcommands.
 The legacy `migrate --schema` root flag is now the `schema` subcommand, and the
 legacy `migrate --rules` root shorthand folded into `explain --rules`.
 
-### Environment fallbacks
+### Setting fallbacks
 
 The offline preview commands (`explain`, `classify`) load `config.FromEnv()`, so
 the preview runs under the **same per-query sample budget** the production
@@ -37,7 +37,15 @@ clean.
 fallbacks for their connection, window, credential and (for `verify`)
 `--report` flags — `--report` has a `CERBERUS_VERIFY_REPORT` fallback too — but
 **not** the stdout output flags (`--json` / `--out`, and for inventory not
-`--top`). The same run can therefore be driven from flags or from env.
+`--top`).
+
+Those fallbacks resolve exactly like every other cerberus setting: environment
+variable first, then a `cerberus.yaml` in the working directory or
+`/etc/cerberus/`, with an explicit flag outranking both. One file therefore
+configures both the migration and the gateway it migrates to. The repeatable
+`--loki-selector` takes a YAML sequence, one whole selector per entry — or, from
+the environment, one selector per line; neither form comma-splits, because a
+stream selector contains commas of its own.
 
 ## `verify` backends
 

--- a/docs/migration-testing.md
+++ b/docs/migration-testing.md
@@ -795,6 +795,23 @@ back off the binary's own `--help` and rejects a command line carrying a value
 the file should have supplied, so the covered path cannot quietly revert to the
 one almost nobody takes.
 
+The gateway those scenarios query is configured the same way. Tier-1's
+`cerberus` service mounts
+[`tiers/tier1-dual/cerberus.yaml`](../test/e2e/migration/tiers/tier1-dual/cerberus.yaml)
+read-only at `/etc/cerberus/cerberus.yaml` — one of the two paths cerberus
+discovers a config file on — and its compose `environment:` carries exactly one
+entry, `CERBERUS_CH_PASSWORD`. The credential stays out of a checked-in file,
+and keeping it there also proves the two sources compose rather than one
+shadowing the other: the gateway only reaches ClickHouse if it read the address
+from the file and the password from the environment. This is also the only
+place in the tree where a real cerberus process boots from a file, so the
+unquoted `false` and bare integer that file carries exercise typed YAML
+decoding end to end rather than only in unit tests.
+[`migration_tier1_test.go`](../test/regression/migration_tier1_test.go) pins the
+mount, runs the file through the gateway's own loader and asserts every value
+lands where the stack expects; without that, dropping the mount would leave
+cerberus on built-in defaults while every pin that reads the file still passed.
+
 The feature files ARE the manifest: there is no separate scenario registry to
 keep in step with them. Metadata rides on tags — `@MIG-16` binds the story,
 `@tier0`/`@tier1`/`@tier2` the tier(s), `@archetype:<name>` the archetypes. A

--- a/docs/migration-testing.md
+++ b/docs/migration-testing.md
@@ -781,6 +781,20 @@ because the assertions read the emitted artifacts as *typed structs* —
 `internal/migrateverify.Report` — rather than re-declaring those schemas in a
 second language where they would drift.
 
+Every command a scenario drives is a real child process whose environment is
+replaced wholesale (`lib.OfflineEnv` / `lib.LiveEnv`), so a result cannot depend
+on a `CERBERUS_*` variable the developer happens to have exported. Where a
+setting exists for a value — the `verify` corpus, backends and window, the
+`inventory` source — the harness writes it into a `cerberus.yaml` in the
+scenario's workspace and runs the command from there, because that is the shape
+[`migration.md`](migration.md) puts in front of an operator. Only per-run output
+choices (`--json`, `--out`, `--top`) stay on the command line, alongside the
+one-off `--source` MIG-02's fault case aims at a probe server minted on an
+ephemeral port. `lib.RequireSettingsFromFile` reads the flag-to-setting mapping
+back off the binary's own `--help` and rejects a command line carrying a value
+the file should have supplied, so the covered path cannot quietly revert to the
+one almost nobody takes.
+
 The feature files ARE the manifest: there is no separate scenario registry to
 keep in step with them. Metadata rides on tags — `@MIG-16` binds the story,
 `@tier0`/`@tier1`/`@tier2` the tier(s), `@archetype:<name>` the archetypes. A

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -34,25 +34,82 @@ cardinality.
 
 ## Configuration
 
-Everything is `CERBERUS_*` environment variables — the same ones the server
-reads. Four steps need them:
+One file: `cerberus.yaml`, in the directory you run the tool from or in
+`/etc/cerberus/`. Keys are the literal `CERBERUS_*` names. An exported
+environment variable overrides the file, and a CLI flag overrides both — so the
+file is where the settings live and the other two are for one-off overrides.
 
-| Step                  | Set                                         | So that                                    |
-| --------------------- | ------------------------------------------- | ------------------------------------------ |
-| 4 · classify, explain | `CERBERUS_QUERY_*`                          | previews run under your real sample budget |
-| 6 · inventory         | `CERBERUS_INVENTORY_*`                      | it reads the right Prometheus              |
-| 7 · schema            | `CERBERUS_CH_DATABASE`, `CERBERUS_SCHEMA_*` | the DDL matches what the server expects    |
-| 10 · verify           | `CERBERUS_VERIFY_*`                         | it reaches both backends, per head         |
+Here is a complete one for the general case: all three heads, one cerberus
+serving all of them.
 
-The other steps need none. Each step below gives the exact `export` lines; every
-variable also has a flag, and the flag wins.
+```yaml
+# cerberus.yaml
+
+# The engine. Give these the same values you give the deployed server —
+# `schema`, `classify` and `explain` read them so their output matches what
+# your cerberus will actually do.
+CERBERUS_CH_ADDR: clickhouse.internal:9000 # comma-separated for a cluster
+CERBERUS_CH_DATABASE: otel
+CERBERUS_CH_USERNAME: default
+CERBERUS_QUERY_MAX_SAMPLES: 5000000
+CERBERUS_QUERY_TIMEOUT: 2m
+
+# Where to measure live cardinality (step 6).
+CERBERUS_INVENTORY_SOURCE: http://prometheus.internal:9090
+CERBERUS_INVENTORY_WINDOW: 24h
+CERBERUS_INVENTORY_LOKI_SOURCE: http://loki.internal:3100
+CERBERUS_INVENTORY_LOKI_SELECTORS:
+  - '{job="checkout"}'
+  - '{job="cart"}'
+CERBERUS_INVENTORY_TEMPO_SOURCE: http://tempo.internal:3200
+
+# What to replay for parity, and against what (step 10).
+CERBERUS_VERIFY_CORPUS: corpus.json
+CERBERUS_VERIFY_REF: http://prometheus.internal:9090
+CERBERUS_VERIFY_CERBERUS: http://cerberus.internal:8080
+CERBERUS_VERIFY_REF_LOKI: http://loki.internal:3100
+CERBERUS_VERIFY_CERBERUS_LOKI: http://cerberus.internal:8080
+CERBERUS_VERIFY_REF_TEMPO: http://tempo.internal:3200
+CERBERUS_VERIFY_CERBERUS_TEMPO: http://cerberus.internal:8080
+CERBERUS_VERIFY_START: -6h
+CERBERUS_VERIFY_END: now
+CERBERUS_VERIFY_STEP: 60s
+```
+
+Drop the `LOKI` lines if you harvested no LogQL and the `TEMPO` lines if you
+harvested no TraceQL. For the `VERIFY` pairs it is both sides or neither — half
+a pair is an error, never a silently skipped head.
+
+Leave the file out entirely and you get `localhost:9000`, database `default`,
+user `default`, a `-1h`→`now` verify window at `60s`, and no backends to probe.
+
+Add only what applies to you:
+
+| Setting                                          | When you need it                                                        |
+| ------------------------------------------------ | ----------------------------------------------------------------------- |
+| `CERBERUS_CH_PROTOCOL: http`                     | Only port 8123 is reachable, not the native 9000.                       |
+| `CERBERUS_SCHEMA_CLUSTER`                        | You run `ON CLUSTER` DDL — the name goes into the rendered `CREATE`.    |
+| `CERBERUS_SCHEMA_LOGS_TABLE`, `..._TRACES_TABLE` | Your tables are not named the OTel defaults.                            |
+| `CERBERUS_VERIFY_TOLERANCE`                      | Two samples may differ by more than the default `1e-9` and still match. |
+| `CERBERUS_VERIFY_REPORT`                         | You want the full JSON diagnostics written to a file on a failing run.  |
+
+Keep credentials out of the file — export them instead:
+`CERBERUS_CH_PASSWORD`, and a bearer token per URL above
+(`CERBERUS_VERIFY_REF_TOKEN`, `..._CERBERUS_TOKEN`, `..._REF_LOKI_TOKEN`,
+`..._CERBERUS_LOKI_TOKEN`, `..._REF_TEMPO_TOKEN`, `..._CERBERUS_TEMPO_TOKEN`).
+A multi-tenant reference Loki or Tempo also wants
+`CERBERUS_VERIFY_REF_LOKI_ORG_ID` / `CERBERUS_VERIFY_REF_TEMPO_ORG_ID`, which
+send `X-Scope-OrgID`; cerberus itself reads no tenant header, deliberately, so
+there is no cerberus-side equivalent.
+
+`cerberus config-docs` prints every engine setting the file accepts;
+[`docs/configuration.md`](configuration.md) is the same list in prose, and
+[`docs/migration-reference.md`](migration-reference.md) is the full flag
+reference for the migration commands.
 
 Nothing here ever connects to ClickHouse. `schema` prints DDL for you to pipe,
 and only `inventory` and `verify` open a socket — to your existing Prometheus,
 Loki or Tempo.
-
-The full surface: `cerberus config-docs`, or
-[`docs/configuration.md`](configuration.md).
 
 ## Step 1: Install the binary
 
@@ -138,8 +195,9 @@ cerberus migrate harvest \
 **Pre-conditions:**
 
 - Step 3 done: `corpus.json` on disk.
-- Set `CERBERUS_QUERY_*` to the values your production server will run with, so
-  the preview is bound by the real per-query sample budget. Still no network.
+- `CERBERUS_QUERY_MAX_SAMPLES` and `CERBERUS_QUERY_TIMEOUT` set to the values
+  your production server will run with, so the preview is bound by the real
+  per-query budget. Still no network.
 
 **Do:**
 
@@ -194,16 +252,9 @@ cerberus migrate rulegraph \
 
 - The Prometheus you are migrating away from is running and reachable from this
   machine. This is the first step that goes on the network.
-- Point it there, by flag or by env:
-
-  ```sh
-  export CERBERUS_INVENTORY_SOURCE=http://prometheus.internal:9090
-  export CERBERUS_INVENTORY_WINDOW=24h
-  # only if you also harvested Loki or Tempo queries
-  export CERBERUS_INVENTORY_LOKI_SOURCE=http://loki.internal:3100
-  export CERBERUS_INVENTORY_LOKI_SELECTORS='{job="app"}'
-  export CERBERUS_INVENTORY_TEMPO_SOURCE=http://tempo.internal:3200
-  ```
+- `CERBERUS_INVENTORY_SOURCE` set, or `--source` passed. Add
+  `CERBERUS_INVENTORY_LOKI_SOURCE` / `_LOKI_SELECTORS` / `_TEMPO_SOURCE` only if
+  you harvested LogQL or TraceQL — see [Configuration](#configuration).
 
 **Do:**
 
@@ -225,14 +276,10 @@ cerberus migrate inventory \
 **Pre-conditions:**
 
 - A ClickHouse you can reach with `clickhouse-client`.
-- `CERBERUS_CH_DATABASE` and any `CERBERUS_SCHEMA_*` overrides set to exactly the
-  values you will give the server in step 9 — otherwise the tables you create
-  are not the tables it will look for:
-
-  ```sh
-  export CERBERUS_CH_DATABASE=otel           # server default is "default"
-  export CERBERUS_SCHEMA_CLUSTER=my_cluster  # only if you run ON CLUSTER DDL
-  ```
+- `CERBERUS_CH_DATABASE`, plus any `CERBERUS_SCHEMA_CLUSTER` or table-name
+  override, set to exactly the values you will give the server in step 9 —
+  otherwise the tables you create are not the tables it will look for. Your
+  `cerberus.yaml` from [Configuration](#configuration) already carries them.
 
 **Do:**
 
@@ -244,7 +291,7 @@ cerberus migrate schema | clickhouse-client -h clickhouse.internal --multiquery
 `migrate schema` renders offline and opens no connection — the pipe is what
 touches the database, and applying the DDL is a deliberate step you run
 yourself. Its output is byte-identical to what the server applies at startup,
-because it reads the same environment. It also loads and validates the *whole*
+because it reads the same configuration. It also loads and validates the *whole*
 config surface, so a typo anywhere in your `CERBERUS_*` set aborts it with the
 same error it would abort the server with — a cheap pre-deploy check.
 
@@ -301,20 +348,9 @@ This is the parity gate, and it is the only thing that earns you the flip.
 
 - Steps 3 and 9 done.
 - Dual-write open across the entire `--start`..`--end` window you ask for.
-- One backend pair — reference and cerberus — for **each head your corpus
-  contains**:
-
-| Head    | Reference backend           | Cerberus                         |
-| ------- | --------------------------- | -------------------------------- |
-| `prom`  | `CERBERUS_VERIFY_REF`       | `CERBERUS_VERIFY_CERBERUS`       |
-| `loki`  | `CERBERUS_VERIFY_REF_LOKI`  | `CERBERUS_VERIFY_CERBERUS_LOKI`  |
-| `tempo` | `CERBERUS_VERIFY_REF_TEMPO` | `CERBERUS_VERIFY_CERBERUS_TEMPO` |
-
-  The three cerberus URLs are normally the *same* address — one process serves
-  all three APIs. Configure only the heads you harvested; half a pair is a usage
-  error, never a silently skipped head. Bearer tokens and multi-tenant
-  `X-Scope-OrgID` values have their own variables — see the
-  [reference](migration-reference.md#verify-backends).
+- One `CERBERUS_VERIFY_REF*` / `CERBERUS_VERIFY_CERBERUS*` URL pair for **each
+  head your corpus contains** — the exact variables, plus tokens and tenant ids,
+  are in [Configuration](#configuration).
 
 **Do:**
 

--- a/internal/config/lookup.go
+++ b/internal/config/lookup.go
@@ -1,0 +1,86 @@
+package config
+
+import (
+	"os"
+	"strings"
+
+	"github.com/spf13/viper"
+)
+
+// Lookup resolves a CERBERUS_* setting that the server's typed registry does
+// not own — the `cerberus migrate` verify/inventory settings, which configure
+// a one-shot CLI run rather than the running gateway — from the same two
+// sources, in the same order, as every other cerberus setting: the
+// environment variable first, then an optional cerberus.yaml in the working
+// directory or /etc/cerberus.
+//
+// Those settings stay out of Config (and therefore out of the generated
+// docs/configuration.md) because nothing in the server reads them, but a
+// migration is configured from the same file as the gateway it migrates to,
+// so one cerberus.yaml carries both surfaces.
+type Lookup struct {
+	v *viper.Viper
+}
+
+// NewLookup probes for cerberus.yaml and returns a Lookup over it. A missing
+// — or malformed — file is not an error: every setting a Lookup serves also
+// has an environment variable and a CLI flag, so the file is pure convenience
+// and its absence leaves the other two sources intact.
+func NewLookup() *Lookup {
+	v := viper.New()
+	v.SetConfigName(configFileBaseName)
+	v.SetConfigType("yaml")
+	v.AddConfigPath(".")
+	v.AddConfigPath("/etc/cerberus")
+	_ = v.ReadInConfig()
+	return &Lookup{v: v}
+}
+
+// String returns key's value — the environment variable of that exact name
+// when it is set and non-empty, else the cerberus.yaml entry, else "".
+func (l *Lookup) String(key string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	if l == nil || l.v == nil {
+		return ""
+	}
+	return l.v.GetString(key)
+}
+
+// Lines returns key's value as an ordered list of entries, for the settings
+// whose CLI flag is repeatable. A YAML sequence maps to the list directly; a
+// scalar (and the environment variable, which has no way to express a
+// sequence) is split on newlines — never on commas, because these values are
+// LogQL stream selectors and a comma is ordinary syntax inside one.
+//
+// Entries are returned exactly as written; trimming and empty-entry pruning
+// belong to the caller, which applies the same normalisation to flag values.
+func (l *Lookup) Lines(key string) []string {
+	if v := os.Getenv(key); v != "" {
+		return strings.Split(v, "\n")
+	}
+	if l == nil || l.v == nil {
+		return nil
+	}
+	switch raw := l.v.Get(key).(type) {
+	case nil:
+		return nil
+	case []any:
+		out := make([]string, 0, len(raw))
+		for _, item := range raw {
+			s, ok := item.(string)
+			if !ok {
+				continue
+			}
+			out = append(out, s)
+		}
+		return out
+	default:
+		s := l.v.GetString(key)
+		if s == "" {
+			return nil
+		}
+		return strings.Split(s, "\n")
+	}
+}

--- a/internal/config/lookup.go
+++ b/internal/config/lookup.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"strings"
 
@@ -42,9 +43,6 @@ func (l *Lookup) String(key string) string {
 	if v := os.Getenv(key); v != "" {
 		return v
 	}
-	if l == nil || l.v == nil {
-		return ""
-	}
 	return l.v.GetString(key)
 }
 
@@ -56,31 +54,22 @@ func (l *Lookup) String(key string) string {
 //
 // Entries are returned exactly as written; trimming and empty-entry pruning
 // belong to the caller, which applies the same normalisation to flag values.
+// A non-string sequence entry is rendered rather than dropped, so a
+// mistyped selector fails loudly downstream instead of vanishing.
 func (l *Lookup) Lines(key string) []string {
 	if v := os.Getenv(key); v != "" {
 		return strings.Split(v, "\n")
 	}
-	if l == nil || l.v == nil {
-		return nil
-	}
-	switch raw := l.v.Get(key).(type) {
-	case nil:
-		return nil
-	case []any:
-		out := make([]string, 0, len(raw))
-		for _, item := range raw {
-			s, ok := item.(string)
-			if !ok {
-				continue
-			}
-			out = append(out, s)
+	if seq, ok := l.v.Get(key).([]any); ok {
+		out := make([]string, 0, len(seq))
+		for _, item := range seq {
+			out = append(out, fmt.Sprint(item))
 		}
 		return out
-	default:
-		s := l.v.GetString(key)
-		if s == "" {
-			return nil
-		}
-		return strings.Split(s, "\n")
 	}
+	s := l.v.GetString(key)
+	if s == "" {
+		return nil
+	}
+	return strings.Split(s, "\n")
 }

--- a/internal/config/lookup_test.go
+++ b/internal/config/lookup_test.go
@@ -1,0 +1,121 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+// writeLookupYAML drops a cerberus.yaml into a fresh temp directory and makes
+// it the working directory, so NewLookup's AddConfigPath(".") finds it.
+func writeLookupYAML(t *testing.T, body string) {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "cerberus.yaml"), []byte(body), 0o600); err != nil {
+		t.Fatalf("write cerberus.yaml: %v", err)
+	}
+	chdir(t, dir)
+}
+
+// TestLookupString_EnvBeatsFile pins the precedence the migrate CLI inherits
+// from the server loader: cerberus.yaml supplies the value when the
+// environment is silent, and the environment always wins when both speak.
+func TestLookupString_EnvBeatsFile(t *testing.T) {
+	writeLookupYAML(t, "CERBERUS_VERIFY_REF: http://fromfile:9090\n")
+
+	l := NewLookup()
+	if got := l.String("CERBERUS_VERIFY_REF"); got != "http://fromfile:9090" {
+		t.Errorf("String = %q; want the cerberus.yaml value when env is unset", got)
+	}
+
+	t.Setenv("CERBERUS_VERIFY_REF", "http://fromenv:9090")
+	if got := l.String("CERBERUS_VERIFY_REF"); got != "http://fromenv:9090" {
+		t.Errorf("String = %q; want the env value, which outranks the file", got)
+	}
+}
+
+// TestLookupString_EmptyEnvFallsThrough asserts an env var set to the empty
+// string does not shadow the file: the CLI treats unset and empty alike, so
+// an exported-but-blank variable must not blank out a configured setting.
+func TestLookupString_EmptyEnvFallsThrough(t *testing.T) {
+	writeLookupYAML(t, "CERBERUS_VERIFY_REF: http://fromfile:9090\n")
+	t.Setenv("CERBERUS_VERIFY_REF", "")
+
+	if got := NewLookup().String("CERBERUS_VERIFY_REF"); got != "http://fromfile:9090" {
+		t.Errorf("String = %q; want the file value (empty env is not a value)", got)
+	}
+}
+
+// TestLookupString_NoFile asserts a missing cerberus.yaml is not an error and
+// leaves the environment as the sole source — the CLI must run from any
+// directory, with or without a config file.
+func TestLookupString_NoFile(t *testing.T) {
+	chdir(t, t.TempDir())
+
+	l := NewLookup()
+	if got := l.String("CERBERUS_VERIFY_REF"); got != "" {
+		t.Errorf("String = %q; want empty with no file and no env", got)
+	}
+
+	t.Setenv("CERBERUS_VERIFY_REF", "http://fromenv:9090")
+	if got := l.String("CERBERUS_VERIFY_REF"); got != "http://fromenv:9090" {
+		t.Errorf("String = %q; want the env value with no file present", got)
+	}
+}
+
+// TestLookupString_MalformedFile asserts an unparseable cerberus.yaml degrades
+// to "no file" rather than killing the CLI: every setting still has an
+// environment variable and a flag, so a broken file must not be fatal.
+func TestLookupString_MalformedFile(t *testing.T) {
+	writeLookupYAML(t, "CERBERUS_VERIFY_REF: [unterminated\n")
+	t.Setenv("CERBERUS_VERIFY_REF", "http://fromenv:9090")
+
+	if got := NewLookup().String("CERBERUS_VERIFY_REF"); got != "http://fromenv:9090" {
+		t.Errorf("String = %q; want the env value despite the malformed file", got)
+	}
+}
+
+// TestLookupLines_YAMLSequence asserts the repeatable-flag settings read a YAML
+// sequence element-for-element — including selectors containing commas, which
+// any comma-splitting fallback would shred into malformed fragments.
+func TestLookupLines_YAMLSequence(t *testing.T) {
+	writeLookupYAML(t, ""+
+		"CERBERUS_INVENTORY_LOKI_SELECTORS:\n"+
+		"  - '{app=\"checkout\", env=\"prod\"}'\n"+
+		"  - '{app=\"cart\"}'\n")
+
+	want := []string{`{app="checkout", env="prod"}`, `{app="cart"}`}
+	if got := NewLookup().Lines("CERBERUS_INVENTORY_LOKI_SELECTORS"); !reflect.DeepEqual(got, want) {
+		t.Errorf("Lines = %#v; want %#v (one element per sequence entry, commas intact)", got, want)
+	}
+}
+
+// TestLookupLines_Scalar asserts a scalar file value and the environment
+// variable share the one-per-line encoding, the only form an env var can
+// express.
+func TestLookupLines_Scalar(t *testing.T) {
+	writeLookupYAML(t, "CERBERUS_INVENTORY_LOKI_SELECTORS: \"{app=\\\"a\\\"}\\n{app=\\\"b\\\"}\"\n")
+
+	want := []string{`{app="a"}`, `{app="b"}`}
+	if got := NewLookup().Lines("CERBERUS_INVENTORY_LOKI_SELECTORS"); !reflect.DeepEqual(got, want) {
+		t.Errorf("Lines (file scalar) = %#v; want %#v", got, want)
+	}
+
+	t.Setenv("CERBERUS_INVENTORY_LOKI_SELECTORS", "{app=\"x\"}\n{app=\"y\"}")
+	want = []string{`{app="x"}`, `{app="y"}`}
+	if got := NewLookup().Lines("CERBERUS_INVENTORY_LOKI_SELECTORS"); !reflect.DeepEqual(got, want) {
+		t.Errorf("Lines (env) = %#v; want %#v (env outranks the file)", got, want)
+	}
+}
+
+// TestLookupLines_Unset asserts nothing configured yields nil, not an empty
+// non-nil slice: cobra's flag default must stay indistinguishable from
+// "never set."
+func TestLookupLines_Unset(t *testing.T) {
+	chdir(t, t.TempDir())
+
+	if got := NewLookup().Lines("CERBERUS_INVENTORY_LOKI_SELECTORS"); got != nil {
+		t.Errorf("Lines = %#v; want nil when nothing is configured", got)
+	}
+}

--- a/internal/config/viper_test.go
+++ b/internal/config/viper_test.go
@@ -190,6 +190,75 @@ func TestFromEnv_ViperEnvBeatsConfigFile(t *testing.T) {
 	}
 }
 
+// TestFromEnv_ViperConfigFileNativeTypes asserts a cerberus.yaml written
+// the way YAML invites — an unquoted false, a bare integer, a duration
+// that can only be a string — resolves to the same typed value a quoted
+// one does. An operator hand-writing the file has no reason to quote a
+// boolean, and the env path never exercises this: every environment
+// variable arrives as a string, so a decoder that only handled strings
+// would pass every other test here and then silently mis-read the one
+// file most deployments configure the gateway from.
+func TestFromEnv_ViperConfigFileNativeTypes(t *testing.T) {
+	clearAllEnv(t)
+	dir := t.TempDir()
+	yaml := "" +
+		"CERBERUS_AUTO_CREATE_SCHEMA: false\n" +
+		"CERBERUS_CH_MAX_OPEN_CONNS: 42\n" +
+		"CERBERUS_QUERY_MAX_SAMPLES: 5000000\n" +
+		"CERBERUS_CH_DIAL_TIMEOUT: 10s\n" +
+		"CERBERUS_CH_KEEPALIVE_ENABLED: true\n"
+	if err := os.WriteFile(filepath.Join(dir, "cerberus.yaml"), []byte(yaml), 0o600); err != nil {
+		t.Fatalf("write cerberus.yaml: %v", err)
+	}
+	chdir(t, dir)
+
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	if cfg.AutoCreateSchema {
+		t.Errorf("AutoCreateSchema = true; want false (unquoted YAML bool honoured)")
+	}
+	if !cfg.ClickHouse.KeepAliveEnabled {
+		t.Errorf("KeepAliveEnabled = false; want true (unquoted YAML bool honoured)")
+	}
+	if cfg.ClickHouse.MaxOpenConns != 42 {
+		t.Errorf("MaxOpenConns = %d; want 42 (bare YAML integer honoured)", cfg.ClickHouse.MaxOpenConns)
+	}
+	if cfg.ClickHouse.MaxQuerySamples != 5_000_000 {
+		t.Errorf("MaxQuerySamples = %d; want 5000000 (bare YAML integer honoured)", cfg.ClickHouse.MaxQuerySamples)
+	}
+	if cfg.ClickHouse.DialTimeout != 10*time.Second {
+		t.Errorf("DialTimeout = %v; want 10s (duration string from the file honoured)", cfg.ClickHouse.DialTimeout)
+	}
+}
+
+// TestFromEnv_ViperConfigFileFalseBeatsTrueDefault is the case an
+// unquoted-bool bug hides behind: a file setting that agrees with the
+// built-in default proves nothing, so this one turns a default-true
+// setting off from the file. If the decoder dropped the value, the
+// default would sail through and the assertion would still read "true".
+func TestFromEnv_ViperConfigFileFalseBeatsTrueDefault(t *testing.T) {
+	clearAllEnv(t)
+	dir := t.TempDir()
+	if err := os.WriteFile(
+		filepath.Join(dir, "cerberus.yaml"),
+		[]byte("CERBERUS_CH_KEEPALIVE_ENABLED: false\n"),
+		0o600,
+	); err != nil {
+		t.Fatalf("write cerberus.yaml: %v", err)
+	}
+	chdir(t, dir)
+
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	if cfg.ClickHouse.KeepAliveEnabled {
+		t.Errorf("KeepAliveEnabled = true; want false (the file must be able to turn a default-on setting off)")
+	}
+}
+
 // clearAllEnv unsets every CERBERUS_* var the loader reads so a test
 // observes pristine defaults regardless of the ambient environment.
 func clearAllEnv(t *testing.T) {

--- a/test/e2e/migration/lib/configfile.go
+++ b/test/e2e/migration/lib/configfile.go
@@ -1,0 +1,133 @@
+package lib
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ConfigFileName is the file cerberus discovers in the working directory (or
+// in /etc/cerberus). The gateway and `cerberus migrate` read the same one, so
+// an operator configures a migration and the server it migrates to from a
+// single document — the path docs/migration.md puts in front of them, and
+// therefore the path these scenarios drive the CLI through.
+const ConfigFileName = "cerberus.yaml"
+
+// configFileMode keeps the written file readable only by its owner, matching
+// the guidance for a real operator's copy: it carries backend bearer tokens.
+const configFileMode os.FileMode = 0o600
+
+// Setting is one CERBERUS_* entry in that file. List renders a YAML sequence,
+// for the settings whose CLI flag is repeatable; otherwise Value renders a
+// scalar.
+type Setting struct {
+	Key   string
+	Value string
+	List  []string
+}
+
+// WriteConfigFile renders settings into dir/cerberus.yaml. Each entry is
+// marshalled on its own — a single-key map has no order to lose — so the file
+// reads top to bottom in the order the caller declared it, the way a
+// hand-written one does.
+func WriteConfigFile(dir string, settings []Setting) error {
+	if len(settings) == 0 {
+		return fmt.Errorf(
+			"migration harness: refusing to write an empty %s: a command configured from nothing would prove nothing about the config-file path",
+			ConfigFileName,
+		)
+	}
+	var doc strings.Builder
+	for _, s := range settings {
+		var value any = s.Value
+		if s.List != nil {
+			value = s.List
+		}
+		rendered, err := yaml.Marshal(map[string]any{s.Key: value})
+		if err != nil {
+			return fmt.Errorf("migration harness: render setting %s: %w", s.Key, err)
+		}
+		doc.Write(rendered)
+	}
+	path := filepath.Join(dir, ConfigFileName)
+	if err := os.WriteFile(path, []byte(doc.String()), configFileMode); err != nil {
+		return fmt.Errorf("migration harness: write %s: %w", path, err)
+	}
+	return nil
+}
+
+// settingFlagRE matches one line of a cobra flag table that names the setting
+// a flag's default comes from, e.g.
+//
+//	--ref string   reference Prometheus base URL (setting: CERBERUS_VERIFY_REF)
+var settingFlagRE = regexp.MustCompile(`--([a-zA-Z0-9-]+).*\(setting: (CERBERUS_[A-Z_]+)\)`)
+
+// settingFlags maps flag name to setting key for every flag a command's help
+// text declares one for. Reading the mapping back off the binary under test,
+// rather than restating it here, is what keeps RequireSettingsFromFile honest
+// as flags are added.
+func settingFlags(help string) map[string]string {
+	out := map[string]string{}
+	for _, line := range strings.Split(help, "\n") {
+		if m := settingFlagRE.FindStringSubmatch(line); m != nil {
+			out[m[1]] = m[2]
+		}
+	}
+	return out
+}
+
+// subcommandOf returns the leading subcommand path of args — everything before
+// the first flag.
+func subcommandOf(args []string) []string {
+	for i, a := range args {
+		if strings.HasPrefix(a, "-") {
+			return args[:i]
+		}
+	}
+	return args
+}
+
+// RequireSettingsFromFile fails when args carry a flag the command itself
+// documents a setting for. Those values belong in cerberus.yaml: an operator
+// following docs/migration.md writes one file and runs a bare command, so that
+// is the path these scenarios must exercise, and a later edit quietly moving a
+// value back onto the command line would leave it uncovered while every
+// assertion still passed. Flags with no setting — --json, --out, --top — are
+// per-run output choices rather than configuration, and stay where they are.
+func RequireSettingsFromFile(bin string, args []string) error {
+	sub := subcommandOf(args)
+	help := append(append([]string{}, sub...), "--help")
+	res, err := Run(RunSpec{Bin: bin, Args: help, Env: OfflineEnv()})
+	if err != nil {
+		return err
+	}
+	name := strings.Join(sub, " ")
+	if res.ExitCode != 0 {
+		return fmt.Errorf("migration harness: `%s --help` exited %d: %s",
+			name, res.ExitCode, strings.TrimSpace(string(res.Stderr)))
+	}
+	declared := settingFlags(string(res.Stdout))
+	if len(declared) == 0 {
+		return fmt.Errorf(
+			"migration harness: `%s --help` declares no setting at all, so this check would pass by proving nothing; the flag-to-setting contract it reads has changed",
+			name,
+		)
+	}
+	for _, a := range args {
+		if !strings.HasPrefix(a, "--") {
+			continue
+		}
+		flag, _, _ := strings.Cut(strings.TrimPrefix(a, "--"), "=")
+		if key, ok := declared[flag]; ok {
+			return fmt.Errorf(
+				"migration harness: `%s` was given --%s on the command line, but that value belongs in %s as %s: these scenarios configure a migration from the config file, because that is what an operator following docs/migration.md does",
+				name, flag, ConfigFileName, key,
+			)
+		}
+	}
+	return nil
+}

--- a/test/e2e/migration/lib/configfile_test.go
+++ b/test/e2e/migration/lib/configfile_test.go
@@ -1,0 +1,214 @@
+package lib
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// readConfigFile writes settings and reads the document back as YAML, so the
+// assertions below judge what the CLI's own loader would see rather than the
+// bytes' incidental shape.
+func readConfigFile(t *testing.T, settings []Setting) (string, map[string]any) {
+	t.Helper()
+	dir := t.TempDir()
+	if err := WriteConfigFile(dir, settings); err != nil {
+		t.Fatalf("WriteConfigFile: %v", err)
+	}
+	raw, err := os.ReadFile(filepath.Join(dir, ConfigFileName))
+	if err != nil {
+		t.Fatalf("read %s: %v", ConfigFileName, err)
+	}
+	var doc map[string]any
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("the written %s is not valid YAML: %v\n%s", ConfigFileName, err, raw)
+	}
+	return string(raw), doc
+}
+
+// TestWriteConfigFileRoundTrips asserts a scalar setting survives as itself —
+// including a value carrying the quotes and braces a LogQL selector is made of,
+// which a naive `key: value` renderer would emit unquoted and corrupt.
+func TestWriteConfigFileRoundTrips(t *testing.T) {
+	const selector = `{app="checkout", env="prod"}`
+	_, doc := readConfigFile(t, []Setting{
+		{Key: "CERBERUS_VERIFY_REF", Value: "http://prometheus.internal:9090"},
+		{Key: "CERBERUS_VERIFY_START", Value: "-6h"},
+		{Key: "CERBERUS_INVENTORY_LOKI_SELECTORS", Value: selector},
+	})
+	for key, want := range map[string]string{
+		"CERBERUS_VERIFY_REF":               "http://prometheus.internal:9090",
+		"CERBERUS_VERIFY_START":             "-6h",
+		"CERBERUS_INVENTORY_LOKI_SELECTORS": selector,
+	} {
+		if got := doc[key]; got != want {
+			t.Errorf("%s = %#v; want %q", key, got, want)
+		}
+	}
+}
+
+// TestWriteConfigFileRendersASequence asserts a repeatable setting becomes a
+// YAML sequence with each entry whole, which is how the CLI's Lookup.Lines
+// reads it — a comma inside one entry must never split it.
+func TestWriteConfigFileRendersASequence(t *testing.T) {
+	want := []string{`{app="checkout", env="prod"}`, `{app="cart"}`}
+	_, doc := readConfigFile(t, []Setting{{Key: "CERBERUS_INVENTORY_LOKI_SELECTORS", List: want}})
+
+	seq, ok := doc["CERBERUS_INVENTORY_LOKI_SELECTORS"].([]any)
+	if !ok {
+		t.Fatalf("CERBERUS_INVENTORY_LOKI_SELECTORS = %#v; want a YAML sequence", doc["CERBERUS_INVENTORY_LOKI_SELECTORS"])
+	}
+	got := make([]string, 0, len(seq))
+	for _, item := range seq {
+		got = append(got, item.(string))
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("sequence = %#v; want %#v", got, want)
+	}
+}
+
+// TestWriteConfigFileKeepsDeclarationOrder asserts the document reads in the
+// order the caller declared, so a failing scenario's artifact is a file an
+// operator can read top to bottom rather than a reshuffled map.
+func TestWriteConfigFileKeepsDeclarationOrder(t *testing.T) {
+	keys := []string{
+		"CERBERUS_VERIFY_CORPUS", "CERBERUS_VERIFY_REF", "CERBERUS_VERIFY_CERBERUS",
+		"CERBERUS_VERIFY_START", "CERBERUS_VERIFY_END", "CERBERUS_VERIFY_STEP",
+	}
+	settings := make([]Setting, 0, len(keys))
+	for _, k := range keys {
+		settings = append(settings, Setting{Key: k, Value: "x"})
+	}
+	raw, _ := readConfigFile(t, settings)
+
+	at := -1
+	for _, k := range keys {
+		i := strings.Index(raw, k)
+		if i < 0 {
+			t.Fatalf("%s is missing from the written file:\n%s", k, raw)
+		}
+		if i < at {
+			t.Fatalf("%s appears out of declaration order:\n%s", k, raw)
+		}
+		at = i
+	}
+}
+
+// TestWriteConfigFileRejectsNothing asserts an empty setting list is an error
+// rather than an empty file: a command configured from nothing would fall back
+// to its built-in defaults and prove nothing about the config-file path.
+func TestWriteConfigFileRejectsNothing(t *testing.T) {
+	dir := t.TempDir()
+	if err := WriteConfigFile(dir, nil); err == nil {
+		t.Fatal("an empty setting list was accepted")
+	}
+	if _, err := os.Stat(filepath.Join(dir, ConfigFileName)); !os.IsNotExist(err) {
+		t.Errorf("a file was written anyway: %v", err)
+	}
+}
+
+// helpFixture is the shape cobra prints a flag table in: name, type, usage,
+// and — for the flags whose default comes from a setting — the setting key.
+const helpFixture = `Usage:
+  cerberus migrate verify [flags]
+
+Flags:
+      --cerberus string   cerberus base URL (setting: CERBERUS_VERIFY_CERBERUS)
+      --corpus string     corpus.json produced by ` + "`cerberus migrate harvest`" + ` (setting: CERBERUS_VERIFY_CORPUS)
+      --json              emit machine-readable JSON report instead of a text report
+      --out string        write the report here (default: stdout)
+      --ref string        reference Prometheus base URL (setting: CERBERUS_VERIFY_REF)
+`
+
+// TestSettingFlagsReadsTheHelpTable asserts the parser picks up exactly the
+// flags that document a setting, and leaves the per-run output flags alone.
+func TestSettingFlagsReadsTheHelpTable(t *testing.T) {
+	got := settingFlags(helpFixture)
+	want := map[string]string{
+		"cerberus": "CERBERUS_VERIFY_CERBERUS",
+		"corpus":   "CERBERUS_VERIFY_CORPUS",
+		"ref":      "CERBERUS_VERIFY_REF",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("settingFlags = %#v; want %#v", got, want)
+	}
+}
+
+// fakeHelpBinary writes an executable that prints help on stdout and exits
+// zero, standing in for the cerberus binary so RequireSettingsFromFile's whole
+// path — exec the command's own --help, parse it, judge the command line —
+// runs here rather than only inside the Tier-1 stack. printf is a shell
+// builtin, so the child needs nothing resolved off PATH but the shell itself.
+func fakeHelpBinary(t *testing.T, help string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "cerberus")
+	script := "#!/bin/sh\nprintf '%s' '" + strings.ReplaceAll(help, "'", `'\''`) + "'\n"
+	if err := os.WriteFile(path, []byte(script), 0o700); err != nil { //nolint:gosec // a test fixture that must be executable
+		t.Fatalf("write fake binary: %v", err)
+	}
+	return path
+}
+
+// TestRequireSettingsFromFileAcceptsPerRunFlags asserts the flags with no
+// setting behind them — the output choices every invocation makes for itself —
+// are left alone.
+func TestRequireSettingsFromFileAcceptsPerRunFlags(t *testing.T) {
+	bin := fakeHelpBinary(t, helpFixture)
+	if err := RequireSettingsFromFile(bin, []string{"migrate", "verify", "--json", "--out", "/tmp/report.json"}); err != nil {
+		t.Fatalf("a command line carrying only per-run flags was rejected: %v", err)
+	}
+}
+
+// TestRequireSettingsFromFileRejectsASettingFlag is the guard itself: a value
+// that belongs in cerberus.yaml must not be smuggled back onto the command
+// line, because the scenario would then pass while covering the path an
+// operator does not take.
+func TestRequireSettingsFromFileRejectsASettingFlag(t *testing.T) {
+	bin := fakeHelpBinary(t, helpFixture)
+	for _, arg := range []string{"--ref", "--ref=http://prometheus:9090", "--corpus"} {
+		t.Run(arg, func(t *testing.T) {
+			err := RequireSettingsFromFile(bin, []string{"migrate", "verify", arg, "x", "--json"})
+			if err == nil {
+				t.Fatalf("%s was accepted on the command line", arg)
+			}
+			flag, _, _ := strings.Cut(strings.TrimPrefix(arg, "--"), "=")
+			if !strings.Contains(err.Error(), flag) || !strings.Contains(err.Error(), ConfigFileName) {
+				t.Errorf("error %q names neither %s nor %s", err, flag, ConfigFileName)
+			}
+		})
+	}
+}
+
+// TestRequireSettingsFromFileRejectsAHelpTableWithNoSettings pins the vacuity
+// guard: if the flag-to-setting contract the parser reads ever changes shape,
+// this check must fail loudly rather than pass by finding nothing to object to.
+func TestRequireSettingsFromFileRejectsAHelpTableWithNoSettings(t *testing.T) {
+	bin := fakeHelpBinary(t, "Flags:\n      --json   emit JSON\n      --out string   write here\n")
+	err := RequireSettingsFromFile(bin, []string{"migrate", "verify", "--json"})
+	if err == nil {
+		t.Fatal("a help table declaring no setting was accepted, so the check proved nothing")
+	}
+	if !strings.Contains(err.Error(), "no setting") {
+		t.Errorf("error %q does not name the empty contract as the reason", err)
+	}
+}
+
+// TestSubcommandOfStopsAtTheFirstFlag asserts the help probe is aimed at the
+// command being run, not at the whole command line.
+func TestSubcommandOfStopsAtTheFirstFlag(t *testing.T) {
+	for _, tc := range []struct {
+		args, want []string
+	}{
+		{args: []string{"migrate", "verify", "--json", "--out", "/tmp/r.json"}, want: []string{"migrate", "verify"}},
+		{args: []string{"migrate", "inventory"}, want: []string{"migrate", "inventory"}},
+		{args: []string{"--version"}, want: []string{}},
+	} {
+		if got := subcommandOf(tc.args); !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("subcommandOf(%v) = %v; want %v", tc.args, got, tc.want)
+		}
+	}
+}

--- a/test/e2e/migration/steps/artifacts.go
+++ b/test/e2e/migration/steps/artifacts.go
@@ -59,16 +59,27 @@ func (w *World) goldenPath(archetype, name string) string {
 	return harnessPath(w.root, archetypeDir, archetype, expectedDir, name)
 }
 
-// workPath resolves a path for an artifact this scenario is about to write. The
-// suffix distinguishes a re-run of the same command, so a determinism check
-// compares two files rather than a file with itself.
-func (w *World) workPath(archetype, name string) (string, error) {
+// workDir resolves — creating it on first use — this scenario's workspace
+// directory for one archetype: where its artifacts land, and where the
+// cerberus.yaml a config-file-driven command reads is written.
+func (w *World) workDir(archetype string) (string, error) {
 	if w.work == "" {
 		return "", fmt.Errorf("migration harness: no scenario workspace; the Before hook did not run")
 	}
 	dir := filepath.Join(w.work, archetype)
 	if err := os.MkdirAll(dir, workspaceDirMode); err != nil {
 		return "", fmt.Errorf("migration harness: create the workspace for %s: %w", archetype, err)
+	}
+	return dir, nil
+}
+
+// workPath resolves a path for an artifact this scenario is about to write. The
+// suffix distinguishes a re-run of the same command, so a determinism check
+// compares two files rather than a file with itself.
+func (w *World) workPath(archetype, name string) (string, error) {
+	dir, err := w.workDir(archetype)
+	if err != nil {
+		return "", err
 	}
 	return filepath.Join(dir, name), nil
 }

--- a/test/e2e/migration/steps/then_inventory.go
+++ b/test/e2e/migration/steps/then_inventory.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strconv"
 
 	"github.com/cucumber/godog"
@@ -115,7 +116,10 @@ func (w *World) givenNotFoundSource() error {
 }
 
 // whenInventoryReferencePrometheus drives the real CLI against the live
-// reference Prometheus and decodes its JSON inventory.
+// reference Prometheus and decodes its JSON inventory. The source reaches the
+// command through a cerberus.yaml, the way an operator following
+// docs/migration.md supplies it; --top and the output flags stay on the
+// command line because they are per-run choices with no setting behind them.
 func (w *World) whenInventoryReferencePrometheus() error {
 	if !w.liveSet {
 		return fmt.Errorf("migration harness: the tier-1 stack has not been established; the scenario must establish it first")
@@ -124,12 +128,14 @@ func (w *World) whenInventoryReferencePrometheus() error {
 	if err != nil {
 		return err
 	}
-	out, err := w.workPath(archetype, inventoryReportName)
+	dir, err := w.workDir(archetype)
 	if err != nil {
 		return err
 	}
-	res, err := w.runLive(nil, "migrate", "inventory",
-		"--source", w.live.PromURL, "--top", strconv.Itoa(inventoryTopN), "--json", "--out", out)
+	out := filepath.Join(dir, inventoryReportName)
+	res, err := w.runLiveConfigFile(dir,
+		[]lib.Setting{{Key: "CERBERUS_INVENTORY_SOURCE", Value: w.live.PromURL}},
+		"migrate", "inventory", "--top", strconv.Itoa(inventoryTopN), "--json", "--out", out)
 	if err != nil {
 		return err
 	}
@@ -154,6 +160,12 @@ func (w *World) whenInventoryReferencePrometheus() error {
 // server the Given established, then tears the probe server down — the
 // request has already completed by the time this returns, so nothing later
 // in the scenario needs it alive.
+//
+// This one passes --source on the command line, and is the harness's live
+// coverage of that surface: the probe server's URL is minted per run on an
+// ephemeral port, which is exactly the case a flag exists for, so the split is
+// the operator's own — a stable backend belongs in the config file, a one-off
+// override does not.
 func (w *World) whenInventoryNotFoundSource() error {
 	if w.inventory.notFound == nil {
 		return fmt.Errorf("migration harness: no not-found source established for this scenario")

--- a/test/e2e/migration/steps/then_verify.go
+++ b/test/e2e/migration/steps/then_verify.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -148,9 +149,12 @@ func (w *World) verifyCorpusPath(archetype string) string {
 // archetype, over the manifest's exact [VerifyStart, VerifyEnd] window — the
 // seeder's published fixture window, never a live `[-1h, now]`, because the
 // fixture stopped moving the moment `migration-tier1-seed` returned and a
-// window that keeps sliding cannot be compared. It captures the exit code as
-// data (never treats a non-zero parity-gate exit as a harness error) and
-// decodes the `--json` artifact into a typed Report every Then step reads.
+// window that keeps sliding cannot be compared. Corpus, backends and window
+// reach the command through a cerberus.yaml rather than through flags: that is
+// the shape docs/migration.md hands an operator, so it is the shape this
+// scenario proves. It captures the exit code as data (never treats a non-zero
+// parity-gate exit as a harness error) and decodes the `--json` artifact into a
+// typed Report every Then step reads.
 func (w *World) whenVerifyCorpus() error {
 	if !w.liveSet {
 		return fmt.Errorf("the tier-1 stack has not been established; the scenario must establish it first")
@@ -167,21 +171,19 @@ func (w *World) whenVerifyCorpus() error {
 			return err
 		}
 		w.manifest[a] = manifest
-		out, err := w.workPath(a, verifyReportName)
+		dir, err := w.workDir(a)
 		if err != nil {
 			return err
 		}
-		res, err := w.runLive(
-			nil,
-			"migrate", "verify",
-			"--corpus", w.verifyCorpusPath(a),
-			"--ref", w.live.PromURL,
-			"--cerberus", w.live.CerberusURL,
-			"--start", manifest.VerifyStart.UTC().Format(time.RFC3339Nano),
-			"--end", manifest.VerifyEnd.UTC().Format(time.RFC3339Nano),
-			"--step", manifest.Step,
-			"--json", "--out", out,
-		)
+		out := filepath.Join(dir, verifyReportName)
+		res, err := w.runLiveConfigFile(dir, []lib.Setting{
+			{Key: "CERBERUS_VERIFY_CORPUS", Value: w.verifyCorpusPath(a)},
+			{Key: "CERBERUS_VERIFY_REF", Value: w.live.PromURL},
+			{Key: "CERBERUS_VERIFY_CERBERUS", Value: w.live.CerberusURL},
+			{Key: "CERBERUS_VERIFY_START", Value: manifest.VerifyStart.UTC().Format(time.RFC3339Nano)},
+			{Key: "CERBERUS_VERIFY_END", Value: manifest.VerifyEnd.UTC().Format(time.RFC3339Nano)},
+			{Key: "CERBERUS_VERIFY_STEP", Value: manifest.Step},
+		}, "migrate", "verify", "--json", "--out", out)
 		if err != nil {
 			return err
 		}

--- a/test/e2e/migration/steps/world.go
+++ b/test/e2e/migration/steps/world.go
@@ -382,6 +382,35 @@ func (w *World) runLive(extraEnv []string, args ...string) (lib.Result, error) {
 	})
 }
 
+// runLiveConfigFile is runLive driven the way docs/migration.md tells an
+// operator to drive it: the settings go into a cerberus.yaml in dir, the
+// command line carries only the per-run output choices, and the child runs
+// from dir so it discovers that file. Configuring a migration by exporting two
+// dozen variables is the path almost nobody takes, so it is not the path these
+// scenarios prove works.
+//
+// Nothing separate asserts the file was read: every setting it carries is
+// mandatory, so a command that failed to find it exits non-zero naming the
+// value it is missing, and RequireSettingsFromFile rejects a command line that
+// smuggled one past the file.
+func (w *World) runLiveConfigFile(dir string, settings []lib.Setting, args ...string) (lib.Result, error) {
+	if w.bin == "" {
+		return lib.Result{}, fmt.Errorf("migration harness: no cerberus binary bound to the scenario world")
+	}
+	if err := lib.WriteConfigFile(dir, settings); err != nil {
+		return lib.Result{}, err
+	}
+	if err := lib.RequireSettingsFromFile(w.bin, args); err != nil {
+		return lib.Result{}, err
+	}
+	return lib.Run(lib.RunSpec{
+		Bin:  w.bin,
+		Args: args,
+		Dir:  dir,
+		Env:  lib.LiveEnv(),
+	})
+}
+
 // gateRun is one `migrate gate` invocation: the decision it emitted and the
 // exit code it left with. The exit code is asserted on directly — the gate's
 // documented no-go status is part of its contract with the operator's cutover

--- a/test/e2e/migration/tiers/tier1-dual/cerberus.yaml
+++ b/test/e2e/migration/tiers/tier1-dual/cerberus.yaml
@@ -1,0 +1,54 @@
+# The gateway's configuration for the Tier-1 dual stack, in the file an
+# operator actually writes.
+#
+# docs/migration.md hands a reader a cerberus.yaml and tells them to drop it
+# beside the binary or in /etc/cerberus; the compose service mounts this one at
+# /etc/cerberus/cerberus.yaml, so the stack every @tier1 scenario queries is
+# configured through the same path a deployment is. Configuring it by exporting
+# a dozen variables into the service definition would have proven a path almost
+# nobody takes, and would have left the file's own decoding — an unquoted
+# boolean, a bare integer — covered only by unit tests.
+#
+# One setting is deliberately NOT here: CERBERUS_CH_PASSWORD stays in the
+# compose service's `environment:`, both because a credential belongs in the
+# process environment rather than in a file checked into a repository, and
+# because keeping it there proves the two sources compose — the gateway reads
+# this file AND its environment, rather than one shadowing the other.
+#
+# test/regression/migration_tier1_test.go pins the mount and the two values
+# below that other tests depend on, so this file cannot go inert.
+
+CERBERUS_HTTP_ADDR: ":27080"
+CERBERUS_CH_ADDR: "clickhouse:9000"
+CERBERUS_CH_DATABASE: "otel"
+CERBERUS_CH_USERNAME: "cerberus"
+CERBERUS_CH_DIAL_TIMEOUT: "10s"
+
+# The collector's clickhouseexporter is the sole schema authority here.
+# cerberus creating its own tables would mint cerberus-named tables and mask a
+# real drift between the exporter's names and cerberus's read-side defaults;
+# with auto-create off, /readyz stays 503 until the exporter has provisioned the
+# schema cerberus expects.
+#
+# Written as an unquoted YAML boolean, the way a hand-written file has it: the
+# environment path can only ever deliver the string "false", so this is the one
+# place the stack exercises a real typed value reaching the loader.
+CERBERUS_AUTO_CREATE_SCHEMA: false
+
+# No CERBERUS_QUERY_TIMEOUT here, deliberately: cerberus keeps its two-minute
+# default for every scenario on this shared service. MIG-08 needs a much shorter
+# per-query cap to prove a paused ClickHouse is bounded by the GATEWAY rather
+# than by its own HTTP client, and it gets one by sending the standard
+# Prometheus `?timeout=` parameter on its own four requests
+# (faultGatewayQueryTimeout in steps/then_fault_injection.go), which cerberus
+# min's against this default. Setting the cap here instead would put every
+# @tier1 query under it, so one slow query on a cold runner would surface as a
+# 503 in an unrelated scenario — and it would duplicate the number, leaving a
+# copy that can drift.
+
+# The per-query sample budget, pinned to the product default rather than left
+# implicit. Under MIG-15's tenancy model — one cerberus per tenant, each bound
+# to its own CH database — this IS the per-tenant read budget the story asserts
+# is enforced, and that scenario derives its over-budget subquery grid from this
+# exact number. test/regression/migration_tier1_test.go holds the two equal.
+CERBERUS_QUERY_MAX_SAMPLES: 5000000

--- a/test/e2e/migration/tiers/tier1-dual/docker-compose.dual.yml
+++ b/test/e2e/migration/tiers/tier1-dual/docker-compose.dual.yml
@@ -179,38 +179,22 @@ services:
     build:
       context: ../../../../..
       dockerfile: Dockerfile.local
+    volumes:
+      # Every non-credential setting lives in this file, mounted where cerberus
+      # discovers it, because a config file is what a real deployment hands the
+      # gateway — docs/migration.md hands the reader one. Driving the service
+      # from `environment:` instead would leave the path most operators take
+      # untested by the only lane that runs a real gateway. The file carries its
+      # own rationale for each value; migration_tier1_test.go pins this mount so
+      # it cannot be dropped and leave the settings silently on defaults.
+      - ./cerberus.yaml:/etc/cerberus/cerberus.yaml:ro
     environment:
-      CERBERUS_HTTP_ADDR: ":27080"
-      CERBERUS_CH_ADDR: "clickhouse:9000"
-      CERBERUS_CH_DATABASE: "otel"
-      CERBERUS_CH_USERNAME: "cerberus"
+      # The one setting that stays in the environment. A credential does not
+      # belong in a file checked into a repository, and keeping it here also
+      # proves the two sources compose rather than one shadowing the other: the
+      # gateway only reaches ClickHouse if it read the mounted file for the
+      # address and this variable for the password.
       CERBERUS_CH_PASSWORD: "cerberus"
-      CERBERUS_CH_DIAL_TIMEOUT: "10s"
-      # The collector's clickhouseexporter is the sole schema authority here.
-      # cerberus creating its own tables would mint cerberus-named tables and
-      # mask a real drift between the exporter's names and cerberus's read-side
-      # defaults; with auto-create off, /readyz stays 503 until the exporter
-      # has provisioned the schema cerberus expects.
-      CERBERUS_AUTO_CREATE_SCHEMA: "false"
-      # No CERBERUS_QUERY_TIMEOUT here, deliberately: cerberus keeps its
-      # two-minute default for every scenario on this shared service. MIG-08
-      # needs a much shorter per-query cap to prove a paused ClickHouse is
-      # bounded by the GATEWAY rather than by its own HTTP client, and it gets
-      # one by sending the standard Prometheus `?timeout=` parameter on its
-      # own four requests (faultGatewayQueryTimeout in
-      # steps/then_fault_injection.go), which cerberus min's against this
-      # default. Setting the cap here instead would put every @tier1 query
-      # under it, so one slow query on a cold runner would surface as a 503 in
-      # an unrelated scenario — and it would duplicate the number, leaving a
-      # copy that can drift.
-
-      # The per-query sample budget, pinned to the product default rather than
-      # left implicit. Under MIG-15's tenancy model — one cerberus per tenant,
-      # each bound to its own CH database — this IS the per-tenant read budget
-      # the story asserts is enforced, and that scenario derives its
-      # over-budget subquery grid from this exact number.
-      # test/regression/migration_tier1_test.go holds the two equal.
-      CERBERUS_QUERY_MAX_SAMPLES: "5000000"
     depends_on:
       clickhouse:
         condition: service_healthy

--- a/test/regression/migration_tier1_test.go
+++ b/test/regression/migration_tier1_test.go
@@ -15,6 +15,8 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/tsouza/cerberus/internal/config"
+
 	"github.com/tsouza/cerberus/test/e2e/migration/lib"
 	"github.com/tsouza/cerberus/test/e2e/migration/seed"
 	"github.com/tsouza/cerberus/test/e2e/migration/steps"
@@ -35,6 +37,160 @@ const (
 	tier1ComposeProject  = "cerberus-migration-tier1"
 	tier1CerberusService = "cerberus"
 )
+
+// The gateway under test is configured from a file, not from the compose
+// service's environment, because that is how a real deployment configures it —
+// and because the only lane that runs a real gateway is the only place the
+// file's own decoding is exercised end to end. The mount is pinned alongside
+// the values: drop it and the settings below stop applying while every
+// assertion that reads this file still passes.
+const (
+	tier1CerberusConfigPath  = tier1Dir + "/cerberus.yaml"
+	tier1CerberusConfigMount = "./cerberus.yaml:/etc/cerberus/cerberus.yaml:ro"
+)
+
+// readTier1CerberusConfig parses the mounted cerberus.yaml into the shape the
+// gateway's loader sees: values keep their YAML types, so an unquoted `false`
+// reads back as a bool rather than as the string the environment path would
+// have delivered.
+func readTier1CerberusConfig(t *testing.T) map[string]any {
+	t.Helper()
+	buf, err := os.ReadFile(tier1CerberusConfigPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", tier1CerberusConfigPath, err)
+	}
+	var out map[string]any
+	if err := yaml.Unmarshal(buf, &out); err != nil {
+		t.Fatalf("parse %s: %v", tier1CerberusConfigPath, err)
+	}
+	if len(out) == 0 {
+		t.Fatalf("%s is empty; the gateway would fall back to built-in defaults and this stack would "+
+			"prove nothing about the config-file path", tier1CerberusConfigPath)
+	}
+	return out
+}
+
+// TestMigrationTier1CerberusConfigFileLoads runs the mounted file through the
+// gateway's own loader and asserts every value arrives where the stack expects
+// it. The compose file can only say the bytes are mounted; a key the loader
+// does not recognise, or a YAML scalar it decodes differently than intended,
+// costs nothing at boot — cerberus starts happily on defaults — and surfaces
+// hours later as a tier-1 scenario querying the wrong database. It also pins
+// the composition the service depends on: the password comes from the
+// environment while everything else comes from the file, and neither source
+// erases the other.
+//
+// Not parallel: it changes the process's working directory and environment,
+// which is what "the gateway discovers the file the way the container does"
+// means here.
+func TestMigrationTier1CerberusConfigFileLoads(t *testing.T) {
+	for _, kv := range os.Environ() {
+		key, _, _ := strings.Cut(kv, "=")
+		if strings.HasPrefix(key, "CERBERUS_") {
+			t.Setenv(key, "")
+			if err := os.Unsetenv(key); err != nil {
+				t.Fatalf("unset %s: %v", key, err)
+			}
+		}
+	}
+
+	src, err := os.ReadFile(tier1CerberusConfigPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", tier1CerberusConfigPath, err)
+	}
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "cerberus.yaml"), src, 0o600); err != nil {
+		t.Fatalf("stage the config file: %v", err)
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(cwd); err != nil {
+			t.Fatalf("restore cwd: %v", err)
+		}
+	})
+
+	// The compose service's one environment setting, supplied the same way.
+	const password = "cerberus"
+	t.Setenv("CERBERUS_CH_PASSWORD", password)
+
+	cfg, err := config.FromEnv()
+	if err != nil {
+		t.Fatalf("the gateway cannot load %s: %v", tier1CerberusConfigPath, err)
+	}
+	for _, tc := range []struct {
+		what      string
+		got, want any
+	}{
+		{"HTTP listen address", cfg.HTTPAddr, ":27080"},
+		{"ClickHouse address", cfg.ClickHouse.Addr, "clickhouse:9000"},
+		{"ClickHouse database", cfg.ClickHouse.Database, "otel"},
+		{"ClickHouse username", cfg.ClickHouse.Username, "cerberus"},
+		{"ClickHouse dial timeout", cfg.ClickHouse.DialTimeout, 10 * time.Second},
+		{"auto-create-schema", cfg.AutoCreateSchema, false},
+		{"per-query sample budget", int64(cfg.ClickHouse.MaxQuerySamples), int64(steps.Tier1QuerySampleBudget)},
+		{"ClickHouse password (from the environment)", cfg.ClickHouse.Password, password},
+	} {
+		if tc.got != tc.want {
+			t.Errorf("%s = %#v, want %#v. The tier-1 gateway is configured from %s; a value the loader "+
+				"does not pick up leaves it on a default and no scenario says so.",
+				tc.what, tc.got, tc.want, tier1CerberusConfigPath)
+		}
+	}
+}
+
+// TestMigrationTier1CerberusReadsItsConfigFile pins the mount that makes every
+// other setting in cerberus.yaml take effect. Without it the gateway boots on
+// built-in defaults — a wrong ClickHouse address, auto-create back on — and
+// nothing about that failure is loud: the tests that read the file still find
+// the values they expect, in a file no container ever opened.
+func TestMigrationTier1CerberusReadsItsConfigFile(t *testing.T) {
+	t.Parallel()
+
+	cf := readCompose(t, tier1ComposePath)
+	cerb, ok := cf.Services[tier1CerberusService]
+	if !ok {
+		t.Fatalf("%s has no %q service", tier1ComposePath, tier1CerberusService)
+	}
+	var mounted bool
+	for _, v := range cerb.Volumes {
+		if v == tier1CerberusConfigMount {
+			mounted = true
+		}
+	}
+	if !mounted {
+		t.Fatalf("service %s does not mount %q. That mount is what makes %s take effect; without it the "+
+			"gateway runs on built-in defaults while every pin that reads the file still passes.",
+			tier1CerberusService, tier1CerberusConfigMount, tier1CerberusConfigPath)
+	}
+	if _, err := os.Stat(tier1CerberusConfigPath); err != nil {
+		t.Fatalf("the mounted %s does not resolve: %v. Docker would create an empty directory in its "+
+			"place and the gateway would boot unconfigured.", tier1CerberusConfigPath, err)
+	}
+
+	// The credential is the one setting that stays in the environment, and it
+	// has to stay there: it also proves the two sources compose rather than one
+	// shadowing the other, since the gateway only reaches ClickHouse if it read
+	// the address from the file and the password from here.
+	if got := cerb.Environment["CERBERUS_CH_PASSWORD"]; got == "" {
+		t.Fatalf("service %s no longer passes CERBERUS_CH_PASSWORD in its environment. Keeping the one "+
+			"credential there is what proves file and environment compose; moving it into %s would also "+
+			"put a password in a checked-in file.", tier1CerberusService, tier1CerberusConfigPath)
+	}
+	for key := range cerb.Environment {
+		if key == "CERBERUS_CH_PASSWORD" {
+			continue
+		}
+		t.Fatalf("service %s sets %s in its environment. Every non-credential setting belongs in %s, "+
+			"because a config file is the path a real deployment takes and this lane is the only one "+
+			"that proves it works.", tier1CerberusService, key, tier1CerberusConfigPath)
+	}
+}
 
 // The published-port band tier-1 owns. Every other compose stack in the tree
 // sits outside it; reusing one of their ports would silently cross-wire a
@@ -188,14 +344,15 @@ func TestMigrationTier1SchemaAuthority(t *testing.T) {
 		t.Fatalf("compose project name = %q, want %q (the Justfile recipes and any leftover-container "+
 			"cleanup key on it)", cf.Name, tier1ComposeProject)
 	}
-	cerb, ok := cf.Services[tier1CerberusService]
-	if !ok {
+	if _, ok := cf.Services[tier1CerberusService]; !ok {
 		t.Fatalf("%s has no %q service", tier1ComposePath, tier1CerberusService)
 	}
-	if got := cerb.Environment["CERBERUS_AUTO_CREATE_SCHEMA"]; got != "false" {
-		t.Fatalf("cerberus CERBERUS_AUTO_CREATE_SCHEMA = %q, want %q. The collector is the sole schema "+
-			"authority in this stack; cerberus creating its own tables would mask exporter/read-side "+
-			"name drift instead of holding /readyz at 503.", got, "false")
+	// Written as an unquoted YAML boolean, so this reads it back as one: the
+	// string "false" here would mean the file had drifted into env semantics.
+	if got := readTier1CerberusConfig(t)["CERBERUS_AUTO_CREATE_SCHEMA"]; got != false {
+		t.Fatalf("cerberus CERBERUS_AUTO_CREATE_SCHEMA = %#v in %s, want the boolean false. The collector "+
+			"is the sole schema authority in this stack; cerberus creating its own tables would mask "+
+			"exporter/read-side name drift instead of holding /readyz at 503.", got, tier1CerberusConfigPath)
 	}
 
 	collector, err := os.ReadFile(tier1CollectorPath)
@@ -1008,31 +1165,28 @@ func tier1JustVarLine(t *testing.T, justfile, name string) string {
 func TestMigrationTier1SampleBudgetIsPinned(t *testing.T) {
 	t.Parallel()
 
-	cf := readCompose(t, tier1ComposePath)
-	cerb, ok := cf.Services[tier1CerberusService]
+	raw, ok := readTier1CerberusConfig(t)[tier1SampleBudgetSetting]
 	if !ok {
-		t.Fatalf("%s has no %q service", tier1ComposePath, tier1CerberusService)
-	}
-	raw, ok := cerb.Environment[tier1SampleBudgetEnv]
-	if !ok {
-		t.Fatalf("%s's %s service does not pin %s. MIG-15 derives its over-budget subquery grid "+
+		t.Fatalf("%s does not pin %s. MIG-15 derives its over-budget subquery grid "+
 			"from steps.Tier1QuerySampleBudget; an implicit budget makes that derivation a guess.",
-			tier1ComposePath, tier1CerberusService, tier1SampleBudgetEnv)
+			tier1CerberusConfigPath, tier1SampleBudgetSetting)
 	}
-	got, err := strconv.ParseInt(raw, 10, 64)
-	if err != nil {
-		t.Fatalf("%s's %s = %q, which is not an integer: %v", tier1ComposePath, tier1SampleBudgetEnv, raw, err)
+	// A bare YAML integer, the way a hand-written file has it — so this reads
+	// back as an int rather than as the string the environment path delivered.
+	got, ok := raw.(int)
+	if !ok {
+		t.Fatalf("%s's %s = %#v, which is not a YAML integer", tier1CerberusConfigPath, tier1SampleBudgetSetting, raw)
 	}
-	if got != steps.Tier1QuerySampleBudget {
+	if int64(got) != steps.Tier1QuerySampleBudget {
 		t.Fatalf("the tier-1 stack runs cerberus with %s=%d, but MIG-15 derives its over-budget grid "+
 			"from steps.Tier1QuerySampleBudget=%d. Move both together.",
-			tier1SampleBudgetEnv, got, steps.Tier1QuerySampleBudget)
+			tier1SampleBudgetSetting, got, steps.Tier1QuerySampleBudget)
 	}
 }
 
-// tier1SampleBudgetEnv is the per-query sample budget the tier-1 cerberus runs
-// under — MIG-15's per-tenant read budget, in that scenario's tenancy model.
-const tier1SampleBudgetEnv = "CERBERUS_QUERY_MAX_SAMPLES"
+// tier1SampleBudgetSetting is the per-query sample budget the tier-1 cerberus
+// runs under — MIG-15's per-tenant read budget, in that scenario's tenancy model.
+const tier1SampleBudgetSetting = "CERBERUS_QUERY_MAX_SAMPLES"
 
 // The build-once seam (Layer 14, D2): the migration lane runs the SAME three
 // tier jobs twice against a release commit — once proving the source tree, once


### PR DESCRIPTION
## The flaw

`cerberus migrate` resolved its ~25 `CERBERUS_VERIFY_*` / `CERBERUS_INVENTORY_*`
settings with bare `os.Getenv`, bypassing the viper loader every other cerberus
setting goes through. Configuring a migration meant exporting two dozen
variables by hand — while the gateway those settings point *at* was configured
from a file, and no `cerberus.yaml` could carry them.

## The fix

`config.Lookup` (`internal/config/lookup.go`) reuses the server loader's
`cerberus.yaml` discovery — working directory, then `/etc/cerberus` — with the
same precedence contract:

    explicit flag  >  environment variable  >  cerberus.yaml  >  built-in default

`newMigrateVerifyCmd` / `newMigrateInventoryCmd` resolve their fallbacks through
it. One file now configures both the migration and the gateway it migrates to.

Design notes:

- The keys stay **out of** `Config`, and therefore out of the generated
  `docs/configuration.md`, because nothing in the server reads them — they
  configure a one-shot CLI run, not the running gateway.
- A missing or malformed `cerberus.yaml` is not an error: every setting still
  has an environment variable and a flag.
- An env var set to the empty string does not shadow the file — unset and empty
  are alike, matching the previous `envOr` semantics.
- The repeatable `--loki-selector` takes a YAML **sequence**, one whole selector
  per entry. Neither that nor the environment's one-per-line form comma-splits:
  a LogQL stream selector contains commas of its own.
- Flag help reads `(setting: CERBERUS_X)` rather than `(env: CERBERUS_X)` now
  that a key has two sources.

## Docs

`docs/migration.md`'s Configuration section collapses to **one sample
`cerberus.yaml`** covering the general case (all three heads, one cerberus),
plus a short add-only-if-it-applies table and a keep-credentials-in-the-env
note. `docs/migration-reference.md` states the resolution order.

## Tests

- `internal/config/lookup_test.go` — env-beats-file, empty-env-falls-through,
  no-file, malformed-file, YAML-sequence, scalar/env line form, unset-is-nil.
- `cmd/cerberus/cmd_migrate_settings_test.go` — end-to-end at the command level:
  `verify` and `inventory` flag defaults come from `cerberus.yaml`, the
  run-time-resolved `--tolerance` reads it too, sequence selectors survive
  whole, and env still outranks the file.

## The e2e lane follows the same path

The migration scenarios configured every command with flags, so Layer 14 proved
the path almost nobody takes. `migrate verify`'s corpus, backends and window,
and `migrate inventory`'s source, now reach the CLI through a `cerberus.yaml`
written into the scenario workspace, with the command running from that
directory so it discovers the file the way a real one does.

Only per-run output choices stay on the command line — `--json`, `--out`,
`--top` — along with the one-off `--source` MIG-02's fault case aims at a probe
server minted on an ephemeral port. That split is the operator's own (a stable
backend belongs in the file, an ad-hoc override does not) and keeps the flag
surface covered too.

Nothing separate asserts the file was read: every setting it carries is
mandatory, so a command that failed to find it exits non-zero naming the value
it is missing. What needed guarding is the reverse — a later edit quietly moving
a value back onto the command line would leave the config-file path uncovered
while every assertion still passed. `lib.RequireSettingsFromFile` reads the
flag-to-setting mapping back off the binary's own `--help` and rejects such a
command line, refusing as well a help table that declares no setting at all,
since that would let the check pass by finding nothing to object to.

`migration-e2e` carries no `pull_request:` trigger, so this half is validated by
a manual dispatch of the lane against the branch rather than by a required
check; `test/e2e/migration/lib`'s own unit tests (config-file rendering, the
help parser, the guard's accept/reject/vacuity cases) run on the required
`check` job.


🤖 Generated with [Claude Code](https://claude.com/claude-code)


## …and so does the gateway it queries

The Tier-1 stack configured cerberus through eight `CERBERUS_*` entries in its
compose service, so the lane that runs the only real gateway in the tree never
booted one from a config file. Every non-credential setting now lives in
`test/e2e/migration/tiers/tier1-dual/cerberus.yaml`, mounted read-only at
`/etc/cerberus/cerberus.yaml`.

`CERBERUS_CH_PASSWORD` deliberately stays in `environment:` — a credential does
not belong in a checked-in file, and keeping it there proves the two sources
compose rather than one shadowing the other: the gateway only reaches ClickHouse
if it read the address from the file and the password from the environment.

The file writes its boolean unquoted and its sample budget as a bare integer,
the way a hand-written one has them, so typed YAML decoding is exercised by a
real process rather than only in unit tests.

Anti-inertness, because a dropped mount is silent — cerberus boots happily on
defaults:

- `TestMigrationTier1CerberusReadsItsConfigFile` pins the mount and asserts
  nothing but the password is left in the service's environment.
- `TestMigrationTier1CerberusConfigFileLoads` runs the file through the
  gateway's own loader and checks every value lands where the stack expects.
- The two existing pins (`SchemaAuthority`, `SampleBudgetIsPinned`) now read
  their values from the file, as native YAML types.

`internal/config/viper_test.go` gains the typed-config-file coverage it was
missing: an unquoted `false`, a bare integer, and a default-*on* setting turned
off from the file so the assertion cannot be satisfied by a default sailing
through.

Validated by a `workflow_dispatch` of `migration-e2e.yml` (`tier=all`) on this
branch — the lane has no `pull_request:` trigger, so PR checks do not cover the
Tier-1 half.
