### PR TITLE
chore(release): cerberus v1.13.0 / chart 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,25 @@ All notable changes to cerberus will be documented in this file. The format roug
 
 ## [Unreleased]
 
+## [v1.13.0] — 2026-07-27
+
 ### Added
 
-- **config:** `cerberus.yaml` accepts the Helm chart's nested shape — `clickhouse.addr`, `query.maxSamples`, `migrate.verify.ref` and the rest — so one file mirrors `values.yaml` instead of restating the `CERBERUS_*` table in YAML syntax. A nested file is exactly equivalent to exporting the corresponding variables, precedence unchanged (flag > env > file > default), and the flat `CERBERUS_*` key still works as the long-tail escape hatch. `docs/configuration.md` now lists the config-file path beside every variable.
+- **config:** accept the chart's nested shape in cerberus.yaml (#1316)
+- **migrate:** read verify/inventory settings from cerberus.yaml (#1314)
 
-### Changed
+### Fixed
 
-- **config:** a `cerberus.yaml` that exists but does not parse, or that carries a key cerberus does not recognise, is now a startup error naming the nearest key that does. Previously such a file was tolerated and its unrecognised settings silently ignored.
+- **release:** make the Homebrew publish path actually work (Formula/ dir + a runner with brew) (#1306)
+- **test/e2e:** scope the tempo duration-filter search to the seed corpus (#1305)
+
+### Documentation
+
+- **migration:** cut the configuration section down to what needs configuring (#1313)
+- **migration:** restructure the guide as numbered steps with pre/post-conditions (#1312)
+- **migration:** add the configuration step the guide jumped over (#1311)
+- **migration:** rewrite as a readable guide, split the contract into a reference (#1310)
+- document the Homebrew installer as the migration entry point (#1307)
 
 ## [v1.12.0] — 2026-07-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,12 @@ All notable changes to cerberus will be documented in this file. The format roug
 
 ### Added
 
-- **config:** accept the chart's nested shape in cerberus.yaml (#1316)
+- **config:** accept the chart's nested shape in cerberus.yaml (#1316) — `clickhouse.addr`, `query.maxSamples`, `migrate.verify.ref` and the rest, so one file mirrors the chart's `values.yaml` instead of restating the `CERBERUS_*` table in YAML syntax. A nested file is exactly equivalent to exporting the corresponding variables, precedence unchanged (flag > env > file > default), and the flat `CERBERUS_*` key still works as the long-tail escape hatch. `docs/configuration.md` lists the config-file path beside every variable.
 - **migrate:** read verify/inventory settings from cerberus.yaml (#1314)
+
+### Changed
+
+- **config:** a `cerberus.yaml` that exists but does not parse, or that carries a key cerberus does not recognise, is now a startup error naming the nearest key that does (#1316). Previously such a file was tolerated and its unrecognised settings silently ignored. **Upgrading:** a file with a typo, or one pointed at chart-only keys, will now stop the process at startup instead of running with defaults.
 
 ### Fixed
 

--- a/deploy/helm/cerberus/Chart.yaml
+++ b/deploy/helm/cerberus/Chart.yaml
@@ -8,11 +8,11 @@ type: application
 # upgrade?" and is the publish trigger: a chart-only fix bumps this without an
 # app re-tag; an app-only release bumps appVersion + a PATCH here for the new
 # default image. Starts 0.x because the values contract is not yet frozen.
-version: 0.12.0
+version: 0.13.0
 
 # appVersion tracks the GA cerberus binary. Quoted so SemVer-shaped values
 # aren't coerced to floats. image.tag defaults from this when left empty.
-appVersion: "1.12.0"
+appVersion: "1.13.0"
 
 # autoscaling/v2 + policy/v1 (PDB) + networking/v1 (Ingress) are all GA from
 # 1.21+; 1.23 is the conservative floor matching the manifests this chart
@@ -45,27 +45,15 @@ annotations:
       url: https://github.com/tsouza/cerberus/blob/main/docs/operations.md
   artifacthub.io/images: |
     - name: cerberus
-      image: ghcr.io/tsouza/cerberus:v1.12.0
+      image: ghcr.io/tsouza/cerberus:v1.13.0
   # Bump the `1.0.0` floor here when the chart raises its minimum supported
   # cerberus release; informational for Artifact Hub's compatibility hints.
   artifacthub.io/changes: |
     - kind: added
-      description: "release: gate publish on migration-e2e and smoke the released artifact (#1296)"
+      description: "config: accept the chart's nested shape in cerberus.yaml (#1316)"
     - kind: added
-      description: "migration: make Layer-14 coverage mean executed, and pin the PASS assertions (#1286)"
-    - kind: added
-      description: "migration: stand up Tier-2 ruler substrate (Layer 14, phase 3a) (#1284)"
-    - kind: added
-      description: "migration: drive cerberus migrate verify through Gherkin against the live tier-1 stack (#1283)"
-    - kind: added
-      description: "migrate: extend inventory + rulegraph to Loki, fold into gate (#1276)"
-    - kind: added
-      description: "solver: failure-driven route memo for resource-exhaustion retries (#1275)"
-    - kind: added
-      description: "migrate: judge log-stream, trace-search and trace-by-id parity in verify (#1269)"
-    - kind: added
-      description: "telemetry: classify query failures, extend latency tails, attribute stages by language (#1274)"
-    - kind: added
-      description: "migration: pinned reference stack + deterministic all-signal seeder (#1267)"
-    - kind: added
-      description: "migrate: verify the Loki + Tempo metric lanes for migration parity (#1266)"
+      description: "migrate: read verify/inventory settings from cerberus.yaml (#1314)"
+    - kind: fixed
+      description: "release: make the Homebrew publish path actually work (Formula/ dir + a runner with brew) (#1306)"
+    - kind: fixed
+      description: "test/e2e: scope the tempo duration-filter search to the seed corpus (#1305)"

--- a/deploy/helm/cerberus/README.md
+++ b/deploy/helm/cerberus/README.md
@@ -5,7 +5,7 @@
      pipe-aligned, and the version footer adds a trailing blank — both are
      owned by helm-docs; realigning would fight the chart-ci drift check. -->
 
-![Version: 0.12.0](https://img.shields.io/badge/Version-0.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.12.0](https://img.shields.io/badge/AppVersion-1.12.0-informational?style=flat-square)
+![Version: 0.13.0](https://img.shields.io/badge/Version-0.13.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.13.0](https://img.shields.io/badge/AppVersion-1.13.0-informational?style=flat-square)
 
 Drop-in Prometheus / Loki / Tempo HTTP gateway for ClickHouse — a single stateless gateway that speaks three upstream query wire formats and lowers each to parameterised ClickHouse SQL.
 


### PR DESCRIPTION
Release-prep for **v1.13.0** (chart **0.13.0**), generated by `prepare-release.yml`.

- appVersion 1.12.0 -> 1.13.0, chart 0.12.0 -> 0.13.0

### Changes

### Added

- **config:** accept the chart's nested shape in cerberus.yaml (#1316)
- **migrate:** read verify/inventory settings from cerberus.yaml (#1314)

### Fixed

- **release:** make the Homebrew publish path actually work (Formula/ dir + a runner with brew) (#1306)
- **test/e2e:** scope the tempo duration-filter search to the seed corpus (#1305)

### Documentation

- **migration:** cut the configuration section down to what needs configuring (#1313)
- **migration:** restructure the guide as numbered steps with pre/post-conditions (#1312)
- **migration:** add the configuration step the guide jumped over (#1311)
- **migration:** rewrite as a readable guide, split the contract into a reference (#1310)
- document the Homebrew installer as the migration entry point (#1307)

Generated from the conventional commits since the last tag. Review and edit before merging; the tag is cut once this lands.
