### PR TITLE
fix(ci): retry every image pull instead of failing the lane

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -97,6 +97,7 @@ test:
 # the `integration` build tag so regular `just test` doesn't pull in
 # Docker.
 schema-ddl-test:
+    @just _pull-retry {{CH_TEST_IMAGE}} {{CH_TEST_IMAGE_PRIOR}}
     go test -race -tags=integration ./internal/schema/ddl/...
 
 # Run the TXTAR spec suite with the chDB-backed round-trip assertion
@@ -160,6 +161,7 @@ perf-profile OUT="perf-profile.json" TOP="40":
 # ClickHouse container. Requires Docker. Gated behind the `integration`
 # build tag so regular `just test` doesn't pull in Docker.
 chclient-integration:
+    @just _pull-retry {{CH_TEST_IMAGE}}
     go test -race -tags=integration ./internal/chclient/...
 
 # Run the strict-scan differential: execute the matrix-shaped spec golden
@@ -171,6 +173,7 @@ chclient-integration:
 # `integration` build tag. See test/spec/strictscan_integration_test.go and
 # .github/workflows/strict-scan.yml.
 strict-scan-test:
+    @just _pull-retry {{CH_TEST_IMAGE}}
     go test -tags=integration -count=1 -run TestStrictScanDifferential ./test/spec/...
 
 # Run the router-corpus real-CH integration tests: the offline corpus WRITE
@@ -183,6 +186,7 @@ strict-scan-test:
 # Requires Docker; gated behind the `integration` build tag. See
 # internal/routerrules/realch_integration_test.go and strict-scan.yml.
 router-corpus-integration:
+    @just _pull-retry {{CH_TEST_IMAGE}}
     go test -tags=integration -count=1 -run 'RealClickHouse' ./internal/routerrules/... ./internal/optcorpus/...
 
 # Run the TraceQL spans-scan resource-bound real-CH guard (PR #1154): lowers +
@@ -195,6 +199,7 @@ router-corpus-integration:
 # behind the `integration` build tag. See
 # test/spec/traces_scan_resource_bound_integration_test.go and strict-scan.yml.
 traces-scan-bound-integration:
+    @just _pull-retry {{CH_TEST_IMAGE}}
     go test -tags=integration -count=1 -run TestTracesScanResourceBoundRealCH ./test/spec/...
 
 # Run the solver's mandatory per-shard memory-apportionment real-CH guard:
@@ -207,6 +212,7 @@ traces-scan-bound-integration:
 # Requires Docker; gated behind the `integration` build tag. See
 # internal/solver/executor_realch_integration_test.go and strict-scan.yml.
 solver-memory-apportion-integration:
+    @just _pull-retry {{CH_TEST_IMAGE}}
     go test -tags=integration -count=1 -run TestExecutor_PerShardMaxMemoryUsage_RealClickHouse ./internal/solver/...
 
 # Run the FuzzParse target for one parser head for a bounded duration.
@@ -558,6 +564,20 @@ E2E_EXTERNAL_IMAGES := "clickhouse/clickhouse-server:26.5-alpine ghcr.io/open-te
 # maps the CH container's pullPolicy to .Values.image.pullPolicy (Never in the
 # e2e values), so the exact bundled-CH tag MUST be imported here.
 E2E_BWC_IMAGES := "minio/minio:RELEASE.2025-09-07T16-13-09Z minio/mc:RELEASE.2025-08-13T08-35-41Z clickhouse/clickhouse-server:26.3"
+
+# ClickHouse images the `-tags=integration` Go tests start through
+# testcontainers. testcontainers does the pull itself, single-attempt, so a slow
+# Docker Hub fails those lanes the same way it failed the compose lanes — the
+# `schema-ddl` job died on a `clickhouse-server:25.8-alpine` manifest HEAD during
+# the v1.13.0 release window. Acquiring the images up front makes that pull
+# retryable: testcontainers reuses an image already in the daemon.
+#
+# CH_TEST_IMAGE_PRIOR is the older server the replicated-DDL test pins to prove
+# the DDL still applies on the previous supported line, so only that lane needs
+# it. TestIntegrationImagePinsMatchTheJustfile holds both against the literals in
+# the test sources.
+CH_TEST_IMAGE := "clickhouse/clickhouse-server:25.8-alpine"
+CH_TEST_IMAGE_PRIOR := "clickhouse/clickhouse-server:24.8-alpine"
 
 # k3s node image for the k3d clusters. Pinned (k3d otherwise picks a default tag
 # per k3d version) so we pull ONE known tag with retry and hand it to

--- a/Justfile
+++ b/Justfile
@@ -601,6 +601,26 @@ _pull-retry +IMAGES:
         [ "$ok" = 1 ] || { echo "ERROR: docker pull $img failed after 5 attempts" >&2; exit 1; }; \
     done
 
+# Acquire every image a compose stack needs, with retry, BEFORE `up` reaches for
+# them. `docker compose up` pulls what it is missing but has no retry of its own,
+# so one Docker Hub timeout ("context deadline exceeded" on a manifest HEAD)
+# fails the whole lane — which is how the v1.13.0 release's Tier-1 leg died on a
+# transient `prom/prometheus` fetch. `_pull-retry` already solved this for the
+# k3d lanes; the compose lanes just weren't going through it.
+#
+# Images already in the local daemon are skipped rather than re-pulled: the
+# cerberus image is acquired beforehand by its own recipe and may be a local
+# build (`pull_policy: never`) that no registry can serve.
+_compose-pull-retry +FILES:
+    @args=""; for f in {{FILES}}; do args="$args -f $f"; done; \
+    missing=$(docker compose $args config --images | sort -u | while read -r img; do \
+        docker image inspect "$img" >/dev/null 2>&1 || echo "$img"; \
+    done); \
+    if [ -n "$missing" ]; then \
+        echo "==> pre-pulling compose images (retry — Docker Hub flaky from CI)"; \
+        just _pull-retry $missing; \
+    fi
+
 e2e-up: e2e-down
     @echo "==> pre-pulling k3s node image (retry — Docker Hub flaky from CI)"
     @just _pull-retry {{K3S_IMAGE}}
@@ -1282,7 +1302,7 @@ migration-cerberus-image:
         docker build -f Dockerfile.local -t "$img" .; \
     else \
         echo "==> migration cerberus image: pull $img"; \
-        docker pull "$img"; \
+        just _pull-retry "$img"; \
     fi
 
 # Bring the Tier-1 stack up and wait for every healthcheck to pass. The cerberus
@@ -1301,6 +1321,7 @@ migration-cerberus-image:
 migration-tier1-up:
     @just migration-tier1-down
     @just migration-cerberus-image
+    @just _compose-pull-retry test/e2e/migration/tiers/tier1-dual/docker-compose.dual.yml
     @echo "==> migration tier-1 stack up"
     docker compose -f test/e2e/migration/tiers/tier1-dual/docker-compose.dual.yml \
         up --wait --wait-timeout 300
@@ -1438,6 +1459,8 @@ migration-tier1: migration-tier1-up migration-tier1-seed migration-tier1-run mig
 migration-tier2-up:
     @just migration-tier2-down
     @just migration-cerberus-image
+    @just _compose-pull-retry test/e2e/migration/tiers/tier1-dual/docker-compose.dual.yml \
+        test/e2e/migration/tiers/tier2-ruler/docker-compose.ruler.yml
     @echo "==> migration tier-2 stack up"
     docker compose -f test/e2e/migration/tiers/tier1-dual/docker-compose.dual.yml \
         -f test/e2e/migration/tiers/tier2-ruler/docker-compose.ruler.yml \

--- a/test/regression/justfile_pull_retry_test.go
+++ b/test/regression/justfile_pull_retry_test.go
@@ -1,7 +1,9 @@
 package regression
 
 import (
+	"io/fs"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
@@ -102,6 +104,106 @@ func TestJustfileComposeUpPrePullsWithRetry(t *testing.T) {
 
 	if found == 0 {
 		t.Fatal("no `docker compose ... up` recipe found — the guard is scanning for a shape that no longer exists")
+	}
+}
+
+// TestJustfileIntegrationLanesPrePullTestImages pins that every `-tags=integration`
+// recipe acquires its container images through `_pull-retry` first. Those tests
+// start ClickHouse via testcontainers, which does the pull itself with no retry
+// — the `schema-ddl` job failed exactly that way during the v1.13.0 release
+// window. testcontainers reuses an image already in the daemon, so pre-pulling
+// is what makes the pull retryable.
+func TestJustfileIntegrationLanesPrePullTestImages(t *testing.T) {
+	t.Parallel()
+
+	buf, err := os.ReadFile("../../Justfile")
+	if err != nil {
+		t.Fatalf("read Justfile: %v", err)
+	}
+
+	const integrationTag = "-tags=integration"
+
+	found := 0
+	for name, body := range justRecipes(t, string(buf)) {
+		if !strings.Contains(body, integrationTag) {
+			continue
+		}
+		found++
+		if !strings.Contains(body, "_pull-retry") {
+			t.Errorf("Justfile recipe %q runs %s tests without pre-pulling their images via `_pull-retry`. "+
+				"testcontainers pulls single-attempt, so one Docker Hub timeout fails the lane.", name, integrationTag)
+		}
+	}
+
+	if found == 0 {
+		t.Fatal("no `-tags=integration` recipe found — the guard is scanning for a shape that no longer exists")
+	}
+}
+
+// TestIntegrationImagePinsMatchTheJustfile holds the Justfile's pre-pull list
+// equal to the container images the integration tests actually name. A test that
+// introduces a new image without adding it here would go back to an unretried
+// testcontainers pull, and nothing else would notice.
+func TestIntegrationImagePinsMatchTheJustfile(t *testing.T) {
+	t.Parallel()
+
+	buf, err := os.ReadFile("../../Justfile")
+	if err != nil {
+		t.Fatalf("read Justfile: %v", err)
+	}
+	justfile := string(buf)
+
+	pinned := map[string]bool{}
+	for _, v := range []string{"CH_TEST_IMAGE", "CH_TEST_IMAGE_PRIOR"} {
+		for _, img := range justVariableList(t, justfile, v) {
+			pinned[img] = true
+		}
+	}
+
+	// `clickhouse/clickhouse-server:<tag>` as a Go string literal. Scoped to that
+	// repository because it is the only image the integration tests start; a new
+	// one lands as a failure here rather than silently widening the pattern.
+	imageRE := regexp.MustCompile(`"(clickhouse/clickhouse-server:[A-Za-z0-9._-]+)"`)
+
+	referenced := map[string][]string{}
+	for _, root := range []string{"../../internal", "../../test"} {
+		err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() || !strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+			src, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			for _, m := range imageRE.FindAllStringSubmatch(string(src), -1) {
+				referenced[m[1]] = append(referenced[m[1]], path)
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walk %s: %v", root, err)
+		}
+	}
+
+	if len(referenced) == 0 {
+		t.Fatal("no integration test names a ClickHouse image — the guard is scanning for a shape that no longer exists")
+	}
+
+	for img, files := range referenced {
+		if !pinned[img] {
+			t.Errorf("%s is started by %s but is not in the Justfile's pre-pull list; testcontainers would "+
+				"pull it single-attempt. Add it to CH_TEST_IMAGE / CH_TEST_IMAGE_PRIOR and to the lane that needs it.",
+				img, files[0])
+		}
+	}
+	for img := range pinned {
+		if _, ok := referenced[img]; !ok {
+			t.Errorf("the Justfile pre-pulls %s but no integration test starts it — a stale pin costs every "+
+				"integration lane an image download it never uses.", img)
+		}
 	}
 }
 

--- a/test/regression/justfile_pull_retry_test.go
+++ b/test/regression/justfile_pull_retry_test.go
@@ -1,0 +1,133 @@
+package regression
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// The v1.13.0 release run died on this line, mid-publish:
+//
+//	Head "https://registry-1.docker.io/v2/prom/prometheus/manifests/v3.11.3":
+//	context deadline exceeded (Client.Timeout exceeded while awaiting headers)
+//	error: recipe `migration-tier1-up` failed on line 1306 with exit code 1
+//
+// `docker compose up` pulls the images it is missing but has no retry of its
+// own, so one transient Docker Hub timeout took down the Tier-1 leg, which
+// failed `migration-e2e`, which skipped `publish` — a green build stopped one
+// step short of shipping because a registry HEAD request was slow once.
+//
+// The Justfile already had `_pull-retry` (5 attempts, linear backoff) for the
+// k3d lanes; the compose lanes simply never went through it. These tests pin
+// that every image acquisition in the Justfile is retried, so the next lane
+// added can't quietly reintroduce a single-attempt pull.
+
+// justRecipes splits a Justfile into recipe name -> body. A recipe header sits
+// at column 0 and ends in `:`; its body is the indented block beneath it.
+func justRecipes(t *testing.T, src string) map[string]string {
+	t.Helper()
+
+	headerRE := regexp.MustCompile(`^([A-Za-z_][A-Za-z0-9_-]*)\s*(?:[+*]?[A-Za-z0-9_]+\s*)*:`)
+
+	recipes := map[string]string{}
+	name := ""
+	var body strings.Builder
+	flush := func() {
+		if name != "" {
+			recipes[name] = body.String()
+		}
+		body.Reset()
+	}
+
+	for _, line := range strings.Split(src, "\n") {
+		switch {
+		case strings.HasPrefix(line, " ") || strings.HasPrefix(line, "\t"):
+			if name != "" {
+				body.WriteString(line)
+				body.WriteString("\n")
+			}
+		case strings.TrimSpace(line) == "" || strings.HasPrefix(line, "#"):
+			// Blank lines and comments do not end a recipe body in just, but
+			// they carry no commands either — skip without flushing.
+		case strings.Contains(line, ":="):
+			// A variable assignment, not a recipe header — both end in a colon
+			// as far as the header pattern is concerned.
+			flush()
+			name = ""
+		default:
+			flush()
+			if m := headerRE.FindStringSubmatch(line); m != nil {
+				name = m[1]
+			} else {
+				name = ""
+			}
+		}
+	}
+	flush()
+
+	if len(recipes) == 0 {
+		t.Fatal("parsed zero recipes from the Justfile — the parser, not the Justfile, is wrong")
+	}
+	return recipes
+}
+
+// TestJustfileComposeUpPrePullsWithRetry pins that any recipe bringing a compose
+// stack up first acquires its images through `_compose-pull-retry`. Without it,
+// `up` does the pull itself, single-attempt, and a flaky registry fails the lane.
+func TestJustfileComposeUpPrePullsWithRetry(t *testing.T) {
+	t.Parallel()
+
+	buf, err := os.ReadFile("../../Justfile")
+	if err != nil {
+		t.Fatalf("read Justfile: %v", err)
+	}
+
+	// `docker compose ... up`, allowing the flags and line continuations that
+	// sit between the two words in the real recipes.
+	composeUpRE := regexp.MustCompile(`docker compose[\s\S]*?\bup\b`)
+
+	found := 0
+	for name, body := range justRecipes(t, string(buf)) {
+		if !composeUpRE.MatchString(body) {
+			continue
+		}
+		found++
+		if !strings.Contains(body, "_compose-pull-retry") {
+			t.Errorf("Justfile recipe %q brings a compose stack up without calling `_compose-pull-retry` first. "+
+				"`docker compose up` pulls missing images with no retry, so one Docker Hub timeout fails the lane "+
+				"(this is what broke the v1.13.0 release's Tier-1 leg).", name)
+		}
+	}
+
+	if found == 0 {
+		t.Fatal("no `docker compose ... up` recipe found — the guard is scanning for a shape that no longer exists")
+	}
+}
+
+// TestJustfileNoUnretriedDockerPull pins that `docker pull` appears only inside
+// `_pull-retry`, the one recipe whose job is to retry it. Every other call site
+// goes through that recipe rather than rolling its own single-attempt pull.
+func TestJustfileNoUnretriedDockerPull(t *testing.T) {
+	t.Parallel()
+
+	buf, err := os.ReadFile("../../Justfile")
+	if err != nil {
+		t.Fatalf("read Justfile: %v", err)
+	}
+
+	const retryRecipe = "_pull-retry"
+
+	for name, body := range justRecipes(t, string(buf)) {
+		if name == retryRecipe {
+			continue
+		}
+		for _, line := range strings.Split(body, "\n") {
+			if strings.Contains(line, "docker pull ") {
+				t.Errorf("Justfile recipe %q calls `docker pull` directly: %s\n"+
+					"Route it through `just %s <image>...` so a transient registry timeout retries "+
+					"instead of failing the lane.", name, strings.TrimSpace(line), retryRecipe)
+			}
+		}
+	}
+}

--- a/test/regression/migration_tier1_test.go
+++ b/test/regression/migration_tier1_test.go
@@ -1238,6 +1238,10 @@ const (
 	// when the image is already present, which is exactly how a released
 	// artifact gets replaced by a recompile of whatever tree the runner holds.
 	buildFlag = "--build"
+	// pullRetryRecipe is how a released image is fetched. A bare `docker pull`
+	// is single-attempt, and one Docker Hub timeout on it failed the v1.13.0
+	// release's Tier-1 leg; see TestJustfileNoUnretriedDockerPull.
+	pullRetryRecipe = "_pull-retry"
 )
 
 // composeImageDefaultRe splits a `${VAR:-default}` compose interpolation.
@@ -1318,12 +1322,13 @@ func TestMigrationImageIsAcquiredOnceNeverRebuilt(t *testing.T) {
 	}
 
 	// The acquisition recipe itself must be able to do BOTH halves: build the
-	// local tag from Dockerfile.local, and pull anything else.
+	// local tag from Dockerfile.local, and pull anything else — the pull going
+	// through the retry helper rather than a single-attempt `docker pull`.
 	acquire := justRecipeBody(t, body, migrationImageRecipe)
-	for _, want := range []string{"docker build", "Dockerfile.local", "docker pull", lib.ImageEnv} {
+	for _, want := range []string{"docker build", "Dockerfile.local", pullRetryRecipe, lib.ImageEnv} {
 		if !strings.Contains(acquire, want) {
 			t.Fatalf("Justfile recipe %s does not reference %q; it must build the local tag from "+
-				"Dockerfile.local and pull a released one, decided by %s alone. Body:\n%s",
+				"Dockerfile.local and pull a released one (with retry), decided by %s alone. Body:\n%s",
 				migrationImageRecipe, want, lib.ImageEnv, acquire)
 		}
 	}


### PR DESCRIPTION
## What broke

The v1.13.0 release run died mid-publish, one step short of shipping:

```
Head "https://registry-1.docker.io/v2/prom/prometheus/manifests/v3.11.3":
context deadline exceeded (Client.Timeout exceeded while awaiting headers)
error: recipe `migration-tier1-up` failed on line 1306 with exit code 1
```

`migration-tier1` failing failed `migration-e2e` (23 attestation violations, all
`NEVER RAN` — pure fallout), which skipped `publish`, `brew-smoke` and
`eol-retire`. A `gh run rerun --failed` passed unchanged, confirming the
transient. Then this PR's *own* branch went red three more times the same way —
`schema-ddl`, `compatibility/promql-surface`, `compose-smoke-shard-info` — on
`clickhouse/clickhouse-server:25.8-alpine`.

## Root cause

Image acquisition in the Justfile had three shapes, only one of them retried:

| shape | retry? |
| --- | --- |
| `just _pull-retry` (k3d / bwc lanes) | yes — 5 attempts, linear backoff |
| `docker compose up` (migration tiers) | no — compose pulls what's missing, single-attempt |
| testcontainers (`-tags=integration`) | no — pulls single-attempt |

`_pull-retry` already existed. The compose and integration lanes simply never
went through it.

## Fix

- **`_compose-pull-retry`** enumerates a stack's images with
  `docker compose config --images`, filters to the ones not already in the
  daemon, and routes them through `_pull-retry`. Wired into
  `migration-tier1-up` and `migration-tier2-up`.
- **`migration-cerberus-image`** traded its bare `docker pull` for `_pull-retry`.
- **`CH_TEST_IMAGE` / `CH_TEST_IMAGE_PRIOR`** name the integration pins once, and
  all six `-tags=integration` recipes pre-pull them. testcontainers reuses an
  image already in the daemon, so pre-pulling is what makes its pull retryable.

## Guards, not call-site patches

`test/regression/justfile_pull_retry_test.go` pins the class so the next lane
added can't quietly reintroduce a single-attempt pull:

- `TestJustfileComposeUpPrePullsWithRetry` — every `docker compose … up` recipe
  must call `_compose-pull-retry` first.
- `TestJustfileIntegrationLanesPrePullTestImages` — every `-tags=integration`
  recipe must call `_pull-retry` first.
- `TestIntegrationImagePinsMatchTheJustfile` — the pin set must equal the images
  the tests actually name, both directions: a new image is a failure (it would
  go back to an unretried pull), and so is a stale pin (a download every lane
  pays for and never uses).
- `TestJustfileNoUnretriedDockerPull` — `docker pull` appears only inside
  `_pull-retry`.

Each guard was mutation-checked: reverting the tier-1 pre-pull, the
`migration-cerberus-image` retry, the chclient pre-pull, and the prior-version
pin each produce the expected failure, and restoring each one passes.

`migration_tier1_test.go`'s `TestMigrationImageIsAcquiredOnceNeverRebuilt` now
pins `_pull-retry` where it pinned the literal `docker pull` — strictly
stronger, and consistent with the guard above.
