### PR TITLE
refactor(release): publish one multi-arch image, dropping per-arch tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,22 @@ jobs:
         run: go test ./...
         working-directory: test/oracle
 
+      # goreleaser's `before` hook runs `go mod tidy` on every release, so a
+      # go.mod that isn't tidy means the release mutates the tree it is cutting
+      # from. That is how `spf13/pflag` sat marked `// indirect` while
+      # cmd/cerberus imported it directly. Both modules, since the nested
+      # oracle module drifts the same way and `just test` never reaches it.
+      - name: go.mod is tidy
+        run: |
+          for mod in . test/oracle; do
+            (cd "$mod" && go mod tidy)
+          done
+          if ! git diff --quiet -- '**/go.mod' '**/go.sum' go.mod go.sum; then
+            echo "::error::go mod tidy changed go.mod/go.sum — commit the result:"
+            git --no-pager diff -- '**/go.mod' '**/go.sum' go.mod go.sum
+            exit 1
+          fi
+
   # `lint` consolidates ALL linting in one job:
   #   - Go (golangci-lint v2 = formatters + linters from .golangci.yml)
   #   - Commit messages (commitlint, PR-only)

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -81,123 +81,60 @@ snapshot:
 changelog:
   use: github-native
 
-dockers:
-  # Per-arch versioned image. Always pushed regardless of prerelease
-  # status. Tagged both `{{ .Version }}` (e.g. `1.0.0-RC1`, the
-  # goreleaser convention) and `v{{ .Version }}` (e.g. `v1.0.0-RC1`,
-  # the SemVer-with-`v` convention many ops tools default to).
-  - id: cerberus-amd64
-    image_templates:
-      - "ghcr.io/tsouza/cerberus:{{ .Version }}-amd64"
-      - "ghcr.io/tsouza/cerberus:v{{ .Version }}-amd64"
-      - "docker.io/tsouza/cerberus:{{ .Version }}-amd64"
-      - "docker.io/tsouza/cerberus:v{{ .Version }}-amd64"
-    use: buildx
-    goos: linux
-    goarch: amd64
-    dockerfile: Dockerfile
-    build_flag_templates:
-      - "--platform=linux/amd64"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.description=Drop-in Prometheus / Loki / Tempo HTTP gateway for ClickHouse"
-      - "--label=org.opencontainers.image.url=https://github.com/tsouza/cerberus"
-      - "--label=org.opencontainers.image.source=https://github.com/tsouza/cerberus"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.licenses=Apache-2.0"
+# Registry operations retry rather than failing the release on one slow
+# response. Stated rather than inherited -- these ARE goreleaser's defaults, but
+# "a transient registry timeout stopped the release one step short of shipping"
+# is a failure mode this repo has already been bitten by, so the retry belongs
+# where someone reading the publish config will see it.
+retry:
+  attempts: 10
+  delay: 10s
+  max_delay: 5m
 
-  - id: cerberus-arm64
-    image_templates:
-      - "ghcr.io/tsouza/cerberus:{{ .Version }}-arm64"
-      - "ghcr.io/tsouza/cerberus:v{{ .Version }}-arm64"
-      - "docker.io/tsouza/cerberus:{{ .Version }}-arm64"
-      - "docker.io/tsouza/cerberus:v{{ .Version }}-arm64"
-    use: buildx
-    goos: linux
-    goarch: arm64
+# One entry replaces the four `dockers` blocks and six `docker_manifests`
+# blocks this used to be. `dockers_v2` drives `docker buildx` directly, so the
+# multi-arch manifest is a product of listing `platforms` rather than a second
+# section that has to be kept in sync with the per-arch image names by hand.
+#
+# The per-arch `:{{ .Version }}-amd64` / `-arm64` tags the old shape published
+# are gone. They existed only as manifest inputs — nothing in this repo, the
+# chart, or the docs ever pulled one.
+#
+# Tagged both `{{ .Version }}` (e.g. `1.0.0-RC1`, the goreleaser convention)
+# and `v{{ .Version }}` (e.g. `v1.0.0-RC1`, the SemVer-with-`v` convention many
+# ops tools default to). Both registries get the identical tag set.
+dockers_v2:
+  - id: cerberus
+    ids:
+      - cerberus
     dockerfile: Dockerfile
-    build_flag_templates:
-      - "--platform=linux/arm64"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.description=Drop-in Prometheus / Loki / Tempo HTTP gateway for ClickHouse"
-      - "--label=org.opencontainers.image.url=https://github.com/tsouza/cerberus"
-      - "--label=org.opencontainers.image.source=https://github.com/tsouza/cerberus"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.licenses=Apache-2.0"
-
-  # `latest-*` tags published ONLY for the HIGHEST stable release
-  # (RELEASE_IS_LATEST, computed in release.yml: tag == highest stable
-  # semver). A prerelease never advances `:latest`, AND a stable BACKPORT
-  # (e.g. v1.2.1 cut after v1.3.0) must not drag `:latest` backwards either.
-  - id: cerberus-amd64-latest
-    image_templates:
-      - "ghcr.io/tsouza/cerberus:latest-amd64"
-      - "docker.io/tsouza/cerberus:latest-amd64"
-    skip_push: '{{ if and (not .Prerelease) (eq .Env.RELEASE_IS_LATEST "true") }}false{{ else }}true{{ end }}'
-    use: buildx
-    goos: linux
-    goarch: amd64
-    dockerfile: Dockerfile
-    build_flag_templates:
-      - "--platform=linux/amd64"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.url=https://github.com/tsouza/cerberus"
-      - "--label=org.opencontainers.image.source=https://github.com/tsouza/cerberus"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.licenses=Apache-2.0"
-
-  - id: cerberus-arm64-latest
-    image_templates:
-      - "ghcr.io/tsouza/cerberus:latest-arm64"
-      - "docker.io/tsouza/cerberus:latest-arm64"
-    skip_push: '{{ if and (not .Prerelease) (eq .Env.RELEASE_IS_LATEST "true") }}false{{ else }}true{{ end }}'
-    use: buildx
-    goos: linux
-    goarch: arm64
-    dockerfile: Dockerfile
-    build_flag_templates:
-      - "--platform=linux/arm64"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.url=https://github.com/tsouza/cerberus"
-      - "--label=org.opencontainers.image.source=https://github.com/tsouza/cerberus"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.licenses=Apache-2.0"
-
-docker_manifests:
-  # Versioned multi-arch manifests — always published.
-  - name_template: "ghcr.io/tsouza/cerberus:{{ .Version }}"
-    image_templates:
-      - "ghcr.io/tsouza/cerberus:{{ .Version }}-amd64"
-      - "ghcr.io/tsouza/cerberus:{{ .Version }}-arm64"
-  - name_template: "ghcr.io/tsouza/cerberus:v{{ .Version }}"
-    image_templates:
-      - "ghcr.io/tsouza/cerberus:v{{ .Version }}-amd64"
-      - "ghcr.io/tsouza/cerberus:v{{ .Version }}-arm64"
-  # `:latest` manifest — only the HIGHEST stable release (RELEASE_IS_LATEST):
-  # neither a prerelease nor a stable backport advances the rolling `:latest`.
-  - name_template: "ghcr.io/tsouza/cerberus:latest"
-    skip_push: '{{ if and (not .Prerelease) (eq .Env.RELEASE_IS_LATEST "true") }}false{{ else }}true{{ end }}'
-    image_templates:
-      - "ghcr.io/tsouza/cerberus:latest-amd64"
-      - "ghcr.io/tsouza/cerberus:latest-arm64"
-  # Docker Hub mirrors of the same manifests (same per-arch images, pushed to
-  # both registries in one build) — identical tag set and `:latest` gating.
-  - name_template: "docker.io/tsouza/cerberus:{{ .Version }}"
-    image_templates:
-      - "docker.io/tsouza/cerberus:{{ .Version }}-amd64"
-      - "docker.io/tsouza/cerberus:{{ .Version }}-arm64"
-  - name_template: "docker.io/tsouza/cerberus:v{{ .Version }}"
-    image_templates:
-      - "docker.io/tsouza/cerberus:v{{ .Version }}-amd64"
-      - "docker.io/tsouza/cerberus:v{{ .Version }}-arm64"
-  - name_template: "docker.io/tsouza/cerberus:latest"
-    skip_push: '{{ if and (not .Prerelease) (eq .Env.RELEASE_IS_LATEST "true") }}false{{ else }}true{{ end }}'
-    image_templates:
-      - "docker.io/tsouza/cerberus:latest-amd64"
-      - "docker.io/tsouza/cerberus:latest-arm64"
+    images:
+      - ghcr.io/tsouza/cerberus
+      - docker.io/tsouza/cerberus
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    tags:
+      - "{{ .Version }}"
+      - "v{{ .Version }}"
+      # `:latest` moves ONLY for the HIGHEST stable release (RELEASE_IS_LATEST,
+      # computed in release.yml: tag == highest stable semver). A prerelease
+      # never advances it, AND a stable BACKPORT (e.g. v1.2.1 cut after v1.3.0)
+      # must not drag it backwards either. An empty tag is dropped, which is how
+      # dockers_v2 spells the conditional push the old `skip_push` did.
+      - '{{ if and (not .Prerelease) (eq .Env.RELEASE_IS_LATEST "true") }}latest{{ end }}'
+    labels:
+      org.opencontainers.image.title: "{{ .ProjectName }}"
+      org.opencontainers.image.description: "Drop-in Prometheus / Loki / Tempo HTTP gateway for ClickHouse"
+      org.opencontainers.image.url: "https://github.com/tsouza/cerberus"
+      org.opencontainers.image.source: "https://github.com/tsouza/cerberus"
+      org.opencontainers.image.version: "{{ .Version }}"
+      org.opencontainers.image.revision: "{{ .FullCommit }}"
+      org.opencontainers.image.licenses: "Apache-2.0"
+    # buildx attaches an SBOM attestation to the index. New with this shape --
+    # the old `dockers` blocks published none -- and it costs nothing: no extra
+    # secret, no extra tool, and it pairs with the binaries' SLSA provenance.
+    sbom: true
 
 release:
   # draft:true so goreleaser creates the GitHub release as a DRAFT (mutable)

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,12 @@ LABEL org.opencontainers.image.url="https://github.com/tsouza/cerberus"
 LABEL org.opencontainers.image.source="https://github.com/tsouza/cerberus"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 
-COPY cerberus /usr/local/bin/cerberus
+# goreleaser's `dockers_v2` builds one multi-arch image and lays the context
+# out per platform (`linux/amd64/cerberus`, `linux/arm64/cerberus`), so the
+# right binary is selected by buildx's TARGETPLATFORM rather than by a separate
+# single-arch build per architecture.
+ARG TARGETPLATFORM
+COPY $TARGETPLATFORM/cerberus /usr/local/bin/cerberus
 
 EXPOSE 8080
 

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/prometheus/common v0.70.1
 	github.com/prometheus/prometheus v0.311.3
 	github.com/spf13/cobra v1.10.2
+	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go/modules/clickhouse v0.43.0
@@ -268,7 +269,6 @@ require (
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
-	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/stretchr/objx v0.5.3 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/testcontainers/testcontainers-go v0.43.0 // indirect


### PR DESCRIPTION
## Why

Every release run logs:

```
dockers and docker_manifests are being phased out and will eventually be
replaced by dockers_v2
```

## What changed

`dockers_v2` drives `docker buildx` directly, so the multi-arch manifest is a
product of listing `platforms` rather than a second section that has to be kept
in sync with the per-arch image names by hand. **Four `dockers` blocks and six
`docker_manifests` blocks collapse to one entry — 117 lines deleted.**

`retry` sits at the *root*, not under the entry: `dockers_v2.retry` was itself
already deprecated (v2.15.3, "all retry configuration moved to the root").
Caught by running `goreleaser check` rather than by reading the migration page.

## Behaviour changes (both intended)

| | before | after |
| --- | --- | --- |
| `:{{ .Version }}`, `:v{{ .Version }}` on both registries | published | unchanged |
| `:latest` gating | `skip_push` template | empty-tag template, same condition |
| `:{{ .Version }}-amd64` / `-arm64` | published | **gone** |
| SBOM attestation on the index | none | **attached** |

The per-arch tags existed only as manifest inputs. Nothing in this repo, the
chart, or the docs ever pulled one — checked before deleting them.

The SBOM is buildx's own attestation: no extra secret, no extra tool, and it
pairs with the SLSA provenance already attested for the binaries.

`:latest` still moves **only** for the highest stable release, so neither a
prerelease nor a stable backport (v1.2.1 cut after v1.3.0) advances it. In
dockers_v2 a tag that renders empty is dropped, which is how it spells the
conditional push `skip_push` used to do.

## Dockerfile

dockers_v2 builds one image for all platforms and lays the context out per
platform (`linux/amd64/cerberus`, `linux/arm64/cerberus`), so the COPY moves to
`$TARGETPLATFORM/cerberus`. That Dockerfile is goreleaser-only — local builds
go through `Dockerfile.local`.

## Verification

Not "the config looks right":

- `goreleaser check` exits 0.
- `goreleaser release --snapshot` builds the binaries, prepares the context and
  reaches `docker buildx build` with the expected tag set.
- A buildx build over a goreleaser-shaped context produces an OCI index whose
  **linux/amd64 layer holds an x86-64 ELF at `/usr/local/bin/cerberus` and whose
  linux/arm64 layer holds an aarch64 one** — the failure a wrong `COPY` would
  cause is a *working build* of a broken image, so this is the check that
  matters.

## `brews` stays

goreleaser also deprecates `brews` in favour of `homebrew_casks`. Declining:
Homebrew casks are macOS-only, and cerberus is a Linux-first server binary, so a
cask would drop Linuxbrew installs outright. `brews` still functions —
deprecated options are only removed on major versions. The rationale is in the
config comment.

## Drift this surfaced

goreleaser's `before` hook runs `go mod tidy`, which promoted `spf13/pflag` from
`// indirect` to direct: `cmd/cerberus/cmd_migrate_settings_test.go` imports it
directly and go.mod never caught up. An untidy go.mod means **the release
mutates the tree it is cutting from**, and nothing gated it. The `check` job now
does, for the root module and the nested `test/oracle` one.
