### PR TITLE
fix(ci): skip buildable images in the compose pre-pull

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -628,18 +628,24 @@ _pull-retry +IMAGES:
 # transient `prom/prometheus` fetch. `_pull-retry` already solved this for the
 # k3d lanes; the compose lanes just weren't going through it.
 #
-# Images already in the local daemon are skipped rather than re-pulled: the
-# cerberus image is acquired beforehand by its own recipe and may be a local
-# build (`pull_policy: never`) that no registry can serve.
+# Buildable services are skipped via compose's own `--ignore-buildable`, which
+# reads the `build:` sections in the model rather than guessing from what the
+# daemon happens to hold. Guessing is what broke Tier-2 on run 30281594098:
+# `dead-end-receiver` is built by compose during `up`, so it is absent from the
+# daemon at pre-pull time and a presence check classified it as "needs pulling"
+# — `cerberus-migration-tier2:dead-end-receiver` exists in no registry, so the
+# pull failed five times and took the lane with it. Whether an image is
+# *pullable* is a property of the compose model, not of daemon state.
 _compose-pull-retry +FILES:
     @args=""; for f in {{FILES}}; do args="$args -f $f"; done; \
-    missing=$(docker compose $args config --images | sort -u | while read -r img; do \
-        docker image inspect "$img" >/dev/null 2>&1 || echo "$img"; \
-    done); \
-    if [ -n "$missing" ]; then \
-        echo "==> pre-pulling compose images (retry — Docker Hub flaky from CI)"; \
-        just _pull-retry $missing; \
-    fi
+    echo "==> pre-pulling compose images (retry — Docker Hub flaky from CI)"; \
+    ok=0; \
+    for attempt in 1 2 3 4 5; do \
+        echo "    docker compose pull (attempt $attempt)"; \
+        docker compose $args pull --ignore-buildable --policy missing && { ok=1; break; }; \
+        sleep $((attempt * 3)); \
+    done; \
+    [ "$ok" = 1 ] || { echo "ERROR: docker compose pull failed after 5 attempts" >&2; exit 1; }
 
 e2e-up: e2e-down
     @echo "==> pre-pulling k3s node image (retry — Docker Hub flaky from CI)"

--- a/test/regression/justfile_pull_retry_test.go
+++ b/test/regression/justfile_pull_retry_test.go
@@ -5,8 +5,11 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 // The v1.13.0 release run died on this line, mid-publish:
@@ -205,6 +208,102 @@ func TestIntegrationImagePinsMatchTheJustfile(t *testing.T) {
 				"integration lane an image download it never uses.", img)
 		}
 	}
+}
+
+// TestComposePrePullSkipsBuildableImages pins that the compose pre-pull decides
+// what is pullable from the compose model, not from what the daemon happens to
+// hold.
+//
+// The first cut of `_compose-pull-retry` pulled every image `config --images`
+// listed that `docker image inspect` could not find locally. Tier-2's
+// `dead-end-receiver` is built by compose during `up`, so at pre-pull time it is
+// legitimately absent — and `cerberus-migration-tier2:dead-end-receiver` exists
+// in no registry, so the pull failed five times and took the lane with it (run
+// 30281594098). Absence from the daemon means "not built yet" just as often as
+// it means "not fetched yet"; only the `build:` sections distinguish them, which
+// is what compose's own `--ignore-buildable` reads.
+func TestComposePrePullSkipsBuildableImages(t *testing.T) {
+	t.Parallel()
+
+	buf, err := os.ReadFile("../../Justfile")
+	if err != nil {
+		t.Fatalf("read Justfile: %v", err)
+	}
+
+	const prePullRecipe = "_compose-pull-retry"
+	body, ok := justRecipes(t, string(buf))[prePullRecipe]
+	if !ok {
+		t.Fatalf("no %q recipe in the Justfile — the guard is scanning for a shape that no longer exists", prePullRecipe)
+	}
+
+	buildable := buildableComposeImages(t, "../../test/e2e/migration")
+	if len(buildable) == 0 {
+		t.Fatalf("no compose service under test/e2e/migration is built rather than fetched — " +
+			"the guard is scanning for a shape that no longer exists")
+	}
+
+	if !strings.Contains(body, "--ignore-buildable") {
+		t.Errorf("%s pulls without `--ignore-buildable`, but these compose services are built rather than fetched: %s.\n"+
+			"Their images exist in no registry, so pulling them fails the lane. Let compose read its own `build:` "+
+			"sections instead of inferring pullability from `docker image inspect`.", prePullRecipe, strings.Join(buildable, ", "))
+	}
+	if strings.Contains(body, "docker image inspect") {
+		t.Errorf("%s gates the pull on `docker image inspect`. Absence from the local daemon means \"not built yet\" "+
+			"as often as \"not fetched yet\" — %s are built during `up` and would be pulled from a registry that "+
+			"does not serve them.", prePullRecipe, strings.Join(buildable, ", "))
+	}
+}
+
+// buildableComposeImages returns `<file>: <service>` for every compose service
+// under root that compose builds rather than fetches.
+func buildableComposeImages(t *testing.T, root string) []string {
+	t.Helper()
+
+	type service struct {
+		Build      yaml.Node `yaml:"build"`
+		PullPolicy string    `yaml:"pull_policy"`
+	}
+	var found []string
+	files := 0
+
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		base := filepath.Base(path)
+		if d.IsDir() || !strings.HasPrefix(base, "docker-compose") {
+			return nil
+		}
+		if ext := filepath.Ext(base); ext != ".yml" && ext != ".yaml" {
+			return nil
+		}
+		src, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		var doc struct {
+			Services map[string]service `yaml:"services"`
+		}
+		if err := yaml.Unmarshal(src, &doc); err != nil {
+			return err
+		}
+		files++
+		for name, svc := range doc.Services {
+			if !svc.Build.IsZero() || svc.PullPolicy == "build" || svc.PullPolicy == "never" {
+				found = append(found, base+":"+name)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", root, err)
+	}
+	if files == 0 {
+		t.Fatalf("no compose file under %s — the guard is scanning for a shape that no longer exists", root)
+	}
+
+	sort.Strings(found)
+	return found
 }
 
 // TestJustfileNoUnretriedDockerPull pins that `docker pull` appears only inside


### PR DESCRIPTION
## What broke

`migration-e2e` has failed on every push to `main` since #1319 landed — runs [30279457059](https://github.com/tsouza/cerberus/actions/runs/30279457059) (`f0d1fba6`) and [30281594098](https://github.com/tsouza/cerberus/actions/runs/30281594098) (`40e84ffd`), both in `migration-tier2`:

```
    docker pull cerberus-migration-tier2:dead-end-receiver (attempt 1)
Error response from daemon: pull access denied for cerberus-migration-tier2,
repository does not exist or may require 'docker login'
... (5 attempts) ...
ERROR: docker pull cerberus-migration-tier2:dead-end-receiver failed after 5 attempts
error: recipe `migration-tier2-up` failed on line 1483 with exit code 1
```

## Root cause

`_compose-pull-retry` (added in #1319) enumerated `docker compose config --images` and pulled anything `docker image inspect` could not find locally. That heuristic reads daemon state as a proxy for "is this pullable", and the two are not the same question.

Tier-2's `dead-end-receiver` is built by compose during `up` (`pull_policy: build` + a `build:` section). At pre-pull time it is *correctly* absent from the daemon, so the heuristic classified it as "needs pulling" — and `cerberus-migration-tier2:dead-end-receiver` exists in no registry.

Tier-1 escaped only by luck: its buildable service (`cerberus`) is materialised by `migration-cerberus-image`, which runs *before* the pre-pull, so `inspect` happened to find it.

## Fix

Hand the decision to compose, which reads its own `build:` sections:

```
docker compose $args pull --ignore-buildable --policy missing
```

wrapped in the same five-attempt backoff `_pull-retry` uses. This also deletes the bespoke image enumeration. `--policy missing` preserves the previous skip-what-is-already-present behaviour, so a retry after a partial failure fetches only the remainder rather than starting over.

## Verification

Ran the recipe locally against the exact failing file set (`tier1-dual` + `tier2-ruler`) — exit 0, and compose reports the previously fatal image as skipped for the right reason:

```
==> pre-pulling compose images (retry — Docker Hub flaky from CI)
    docker compose pull (attempt 1)
 Image grafana/grafana:12.2.9 Skipped - Image is already present locally
 ...
 Image cerberus-migration-tier2:dead-end-receiver Skipped - Image can be built
```

## Guard

`TestComposePrePullSkipsBuildableImages` pins the class, not this one service: it parses every compose file under `test/e2e/migration`, and if any service is built rather than fetched, `_compose-pull-retry` must delegate the skip to `--ignore-buildable` and must not gate on `docker image inspect`. It fatals — rather than passing quietly — if no such service is found, so it can't rot into a no-op.

Both failure branches were mutation-checked (drop the flag → fails naming both buildable services; reintroduce the `inspect` gate → fails).

🤖 Generated with [Claude Code](https://claude.com/claude-code)