### PR TITLE
fix(release): close the three gaps that let a release ship unverified

### DIFF
--- a/.github/scripts/chart-kubeconform.mjs
+++ b/.github/scripts/chart-kubeconform.mjs
@@ -19,7 +19,7 @@
 // Exit 1 on any kubeconform failure or a definitively-missing image.
 
 import { execFileSync } from 'node:child_process'
-import { readdirSync } from 'node:fs'
+import { readdirSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { error as ghError, notice as ghNotice } from './lib/gh.mjs'
 
@@ -47,10 +47,14 @@ function kubeconform(manifests, label) {
   }
 }
 
-// Collect distinct `image:` references from rendered manifests.
-function imagesIn(manifests) {
+// Collect distinct `image:` references from YAML text. Applied to the rendered
+// manifests AND to Chart.yaml itself, whose `artifacthub.io/images` annotation
+// advertises a `v`-prefixed ref that no rendered manifest carries — a second
+// tag shape, from a second goreleaser `tags:` entry, that nothing probed while
+// only rendered output was scanned.
+export function imagesIn(yamlText) {
   const out = new Set()
-  for (const m of manifests.matchAll(/^\s*image:\s*["']?([^"'\s]+)["']?\s*$/gm)) {
+  for (const m of yamlText.matchAll(/^\s*image:\s*["']?([^"'\s]+)["']?\s*$/gm)) {
     out.add(m[1])
   }
   return [...out]
@@ -59,18 +63,142 @@ function imagesIn(manifests) {
 // Best-effort registry existence probe. Only a DEFINITIVE not-found fails
 // the build; transient/auth errors are surfaced as a notice so a flaky
 // registry never blocks a chart PR.
+//
+// stderr MUST be piped. `docker manifest inspect` writes its verdict there
+// ("manifest unknown"), and with `stdio: 'ignore'` the thrown error carries
+// `stderr === null` and a `message` of only "Command failed: docker manifest
+// inspect <ref>" — no phrase the classifier below can match. Every failure,
+// including a definitive not-found, therefore fell through to 'unknown' and
+// was downgraded to a notice: the `chart-validate` required check could not
+// fail on the one condition it exists to catch.
+export function classifyProbeFailure(err) {
+  const msg = String(err.stderr || err.message || '')
+  if (/manifest unknown|not found|no such manifest|MANIFEST_UNKNOWN|NAME_UNKNOWN|404/i.test(msg)) {
+    return 'missing'
+  }
+  return 'unknown'
+}
+
+// Named so the self-test can pin it. classifyProbeFailure is pure and would go
+// on passing its own assertions if this reverted to `stdio: 'ignore'` — the
+// defect lived here, not in the classifier, so this is what has to be gated.
+export const PROBE_SPAWN_OPTS = { stdio: ['ignore', 'ignore', 'pipe'], encoding: 'utf8' }
+
 function imageExists(ref) {
   try {
-    execFileSync('docker', ['manifest', 'inspect', ref], { stdio: 'ignore' })
+    execFileSync('docker', ['manifest', 'inspect', ref], PROBE_SPAWN_OPTS)
     return 'present'
   } catch (e) {
-    const msg = String(e.stderr || e.message || '')
-    if (/manifest unknown|not found|no such manifest|MANIFEST_UNKNOWN|NAME_UNKNOWN|404/i.test(msg)) {
-      return 'missing'
-    }
-    return 'unknown'
+    return classifyProbeFailure(e)
   }
 }
+
+// The appVersion this very change stages, or null if it is unchanged.
+//
+// A release PR bumps appVersion to a tag that does not exist yet — publishing
+// it is what MERGING the PR does — and chart-ci runs again on the merge commit
+// concurrently with release.yml's publish. So the newly-staged tag is expected
+// to be absent on both events, and only that tag: every other missing image is
+// still fatal. Returns null when the base cannot be resolved, which withholds
+// the exemption rather than widening it.
+export function stagedAppVersion(headYaml, baseYaml) {
+  const head = appVersionOf(headYaml)
+  const base = appVersionOf(baseYaml)
+  if (!head || !base || head === base) return null
+  return head
+}
+
+export function appVersionOf(chartYaml) {
+  const m = /^appVersion:\s*["']?([^"'\s]+)["']?\s*$/m.exec(chartYaml || '')
+  return m ? m[1] : null
+}
+
+// A ref is exempt only if its tag is exactly the staged appVersion or its
+// `v`-prefixed twin — the two shapes .goreleaser.yml publishes.
+export function isStagedRef(ref, staged) {
+  if (!staged) return false
+  const tag = ref.slice(ref.lastIndexOf(':') + 1)
+  return tag === staged || tag === `v${staged}`
+}
+
+function gitShow(ref, path) {
+  try {
+    return execFileSync('git', ['show', `${ref}:${path}`], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] })
+  } catch {
+    return null
+  }
+}
+
+// --- self-test: pins the pure classification/exemption logic ---------------
+//
+// Each case that guards a regression also proves the OLD behaviour is gone,
+// rather than only that the new behaviour is present: `stdio: 'ignore'`
+// produced an error object with `stderr === null` and a bare "Command failed"
+// message, and that exact shape must classify as 'missing' now that stderr is
+// piped — asserting only on a piped-stderr fixture would pass either way.
+function selfTest() {
+  const fails = []
+  let passes = 0
+  const check = (cond, msg) => {
+    if (cond) passes++
+    else fails.push(msg)
+  }
+
+  // The defect was the spawn options, not the classifier. Pin them directly:
+  // without a piped stderr every branch below is unreachable in production.
+  check(PROBE_SPAWN_OPTS.stdio[2] === 'pipe', 'the probe pipes stderr — the classifier sees nothing otherwise')
+  check(PROBE_SPAWN_OPTS.encoding === 'utf8', 'probe stderr is decoded to a string, not a Buffer')
+
+  const notFound = { stderr: 'manifest unknown\n', message: 'Command failed: docker manifest inspect x' }
+  check(classifyProbeFailure(notFound) === 'missing', 'piped not-found stderr classifies as missing')
+
+  // The regression itself: with stdio 'ignore' this is all the probe ever saw.
+  const swallowed = { stderr: null, message: 'Command failed: docker manifest inspect ghcr.io/tsouza/cerberus:1.13.1' }
+  check(
+    classifyProbeFailure(swallowed) === 'unknown',
+    'stderr-less failure is unknown — proves the guard was inert until stderr was piped',
+  )
+
+  for (const transient of ['unauthorized: authentication required', 'toomanyrequests: retry later', 'tls: handshake timeout']) {
+    check(classifyProbeFailure({ stderr: transient }) === 'unknown', `transient stays unknown: ${transient}`)
+  }
+
+  check(appVersionOf('appVersion: "1.13.0"\n') === '1.13.0', 'appVersion parsed through quotes')
+  check(appVersionOf('appVersion: 1.13.0\n') === '1.13.0', 'appVersion parsed unquoted')
+  check(appVersionOf('version: 0.13.0\n') === null, 'chart version is not mistaken for appVersion')
+
+  const base = 'appVersion: "1.13.0"\n'
+  const bumped = 'appVersion: "1.13.1"\n'
+  check(stagedAppVersion(bumped, base) === '1.13.1', 'a bump stages the new appVersion')
+  check(stagedAppVersion(base, base) === null, 'an unchanged appVersion stages nothing')
+  check(stagedAppVersion(bumped, null) === null, 'an unresolvable base withholds the exemption')
+
+  check(isStagedRef('ghcr.io/tsouza/cerberus:1.13.1', '1.13.1'), 'bare staged tag is exempt')
+  check(isStagedRef('ghcr.io/tsouza/cerberus:v1.13.1', '1.13.1'), 'v-prefixed staged tag is exempt')
+  check(!isStagedRef('ghcr.io/tsouza/cerberus:1.13.0', '1.13.1'), 'the PREVIOUS release is not exempt')
+  check(!isStagedRef('grafana/grafana:12.2.9', '1.13.1'), 'a third-party image is never exempt')
+  check(!isStagedRef('ghcr.io/tsouza/cerberus:1.13.1', null), 'no staged version means no exemption at all')
+
+  // The annotation ref is a second tag shape that only Chart.yaml carries.
+  const chartYaml = 'annotations:\n  artifacthub.io/images: |\n    - name: cerberus\n      image: ghcr.io/tsouza/cerberus:v1.13.0\n'
+  check(imagesIn(chartYaml).includes('ghcr.io/tsouza/cerberus:v1.13.0'), 'artifacthub.io/images annotation is probed')
+
+  for (const bad of ['1.13', '1.13.O', 'v1.13.1', '']) {
+    check(!APP_VERSION_RE.test(bad), `malformed appVersion rejected offline: ${JSON.stringify(bad)}`)
+  }
+  check(APP_VERSION_RE.test('1.13.1') && APP_VERSION_RE.test('1.14.0-rc.1'), 'release and pre-release appVersions accepted')
+
+  if (fails.length) {
+    for (const f of fails) ghError(`chart-kubeconform --self-test FAIL: ${f}`)
+    process.exit(1)
+  }
+  ghNotice(`chart-kubeconform --self-test: all ${passes} assertions passed`)
+  process.exit(0)
+}
+
+const APP_VERSION_RE = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/
+
+if (process.argv.includes('--self-test')) selfTest()
 
 const fixtures = [null]
 try {
@@ -97,10 +225,31 @@ for (const fixture of fixtures) {
   for (const img of imagesIn(rendered)) seenImages.add(img)
 }
 
+const headChartYaml = readFileSync(join(CHART_DIR, 'Chart.yaml'), 'utf8')
+for (const img of imagesIn(headChartYaml)) seenImages.add(img)
+
+// A malformed appVersion cannot be caught by the registry probe once the
+// staging exemption below is in play — `1.13.O` would be "the tag this change
+// stages" and get waved through. Assert the shape offline instead, where no
+// exemption applies.
+const headAppVersion = appVersionOf(headChartYaml)
+if (!headAppVersion || !APP_VERSION_RE.test(headAppVersion)) {
+  ghError(`chart appVersion is not a semver release: ${JSON.stringify(headAppVersion)}`)
+  ok = false
+}
+
+// pull_request runs compare against the PR base; push runs against the parent
+// of the pushed commit. Either way the question is the same: does THIS change
+// stage a new appVersion?
+const baseRef = process.env.GITHUB_BASE_REF ? `origin/${process.env.GITHUB_BASE_REF}` : 'HEAD^'
+const staged = stagedAppVersion(headChartYaml, gitShow(baseRef, join(CHART_DIR, 'Chart.yaml')))
+
 if (!SKIP_IMAGE_CHECK) {
   for (const ref of [...seenImages].sort()) {
     const state = imageExists(ref)
-    if (state === 'missing') {
+    if (state === 'missing' && isStagedRef(ref, staged)) {
+      ghNotice(`image not published yet, as expected — this change stages appVersion ${staged}: ${ref}`)
+    } else if (state === 'missing') {
       ghError(`rendered image does not exist in the registry: ${ref} — the chart's appVersion/image.tag points at an unpublished tag`)
       ok = false
     } else if (state === 'unknown') {

--- a/.github/scripts/release-preflight.mjs
+++ b/.github/scripts/release-preflight.mjs
@@ -233,6 +233,20 @@ const quietHeartbeatPolls = 10;
 // never reaches `completed`, so waiting on it would hang the preflight until
 // timeout — and it contributes zero check-runs to the green-gate (`evaluate`),
 // so it is irrelevant to settledness. Treat empty suites as already settled.
+// parseCheckList reads one of the RELEASE_*_CHECKS / RELEASE_SELF_JOBS env
+// vars. The separator is the NEWLINE, not a comma: check-run names are job
+// display names and may legitimately contain commas — `property (PromQL +
+// LogQL + TraceQL, rapid N=500)` is a branch-protection required context and
+// splitting it on `,` yields two names that no lane will ever post, so the
+// preflight would wait out its window and abort every release. release.yml
+// therefore declares these as YAML block scalars, one name per line.
+export function parseCheckList(raw) {
+  return (raw ?? '')
+    .split('\n')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
 export function allSuitesSettled(suites, ownSuiteId, workflowNames) {
   const pending = [];
   for (const s of suites ?? []) {
@@ -930,26 +944,15 @@ async function main() {
   const apiBase = process.env.GITHUB_API_URL || 'https://api.github.com';
   const token = process.env.GITHUB_TOKEN;
   const runId = process.env.GITHUB_RUN_ID;
-  const selfJobs = new Set(
-    (process.env.RELEASE_SELF_JOBS ?? '')
-      .split(',')
-      .map((s) => s.trim())
-      .filter(Boolean),
-  );
+  const selfJobs = new Set(parseCheckList(process.env.RELEASE_SELF_JOBS));
   // Name-prefix list of explicitly de-gated INFORMATIONAL lanes (e.g. the
   // compose-smoke-shard-info crawl shard, the dashboard smoke). A flake in one
   // of these must not block a maintenance release; everything else still gates.
-  const informational = (process.env.RELEASE_INFORMATIONAL_CHECKS ?? '')
-    .split(',')
-    .map((s) => s.trim())
-    .filter(Boolean);
+  const informational = parseCheckList(process.env.RELEASE_INFORMATIONAL_CHECKS);
   // The EXPECTED set — exact check-run names that MUST have posted a run on the
   // commit. Parsed the same way as the informational list, but consumed as EXACT
   // names, not prefixes: a required lane is a specific job, not a family.
-  const required = (process.env.RELEASE_REQUIRED_CHECKS ?? '')
-    .split(',')
-    .map((s) => s.trim())
-    .filter(Boolean);
+  const required = parseCheckList(process.env.RELEASE_REQUIRED_CHECKS);
 
   // Mode is derived from the branch, not passed in: a `release/*.x` push is the
   // maintenance path (tip + support-window rules apply), anything else is the

--- a/.github/scripts/release-preflight.test.mjs
+++ b/.github/scripts/release-preflight.test.mjs
@@ -25,12 +25,29 @@ import assert from 'node:assert/strict';
 
 import {
   evaluate,
+  parseCheckList,
   requiredChecksPending,
   allSuitesSettled,
   MODE_MAINLINE,
   MODE_MAINTENANCE,
   REUSABLE_JOB_SEPARATOR,
 } from './release-preflight.mjs';
+
+test('parseCheckList keeps commas inside a check name', () => {
+  // `property (PromQL + LogQL + TraceQL, rapid N=500)` is a branch-protection
+  // required context. Under a comma separator it split into two names no lane
+  // will ever post, so the preflight waited out its full window and aborted
+  // the release — a wiring bug that only ever surfaces mid-publish.
+  const names = parseCheckList(
+    'check\nproperty (PromQL + LogQL + TraceQL, rapid N=500)\n  migration-e2e  \n\n',
+  );
+  assert.deepEqual(names, [
+    'check',
+    'property (PromQL + LogQL + TraceQL, rapid N=500)',
+    'migration-e2e',
+  ]);
+  assert.deepEqual(parseCheckList(undefined), []);
+});
 
 // The release run's own jobs, as release.yml wires them into RELEASE_SELF_JOBS.
 const SELF_JOBS = new Set([

--- a/.github/workflows/chart-ci.yml
+++ b/.github/workflows/chart-ci.yml
@@ -11,7 +11,11 @@ name: chart-ci
 on:
   pull_request:
   push:
-    branches: [main]
+    # `release/*.x` so `chart-validate` also runs on a maintenance-line hotfix
+    # push. There is no PR on that path, so release.yml's preflight is the only
+    # gate, and a lane that posts no check-run there would be certified by
+    # absence rather than by passing.
+    branches: [main, 'release/*.x']
   workflow_dispatch:
 
 permissions:
@@ -28,6 +32,12 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+
+      # Unconditional: the image guard's classifier and staging exemption are
+      # pure logic, and pinning them only when chart files change would leave
+      # them unexercised on the PRs most likely to edit the guard itself.
+      - name: chart-kubeconform self-test (image-guard classifier + staging exemption)
+        run: node .github/scripts/chart-kubeconform.mjs --self-test
 
       - uses: dorny/paths-filter@v4
         id: changes

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -462,10 +462,11 @@ jobs:
     # reference Prometheus, so a green result is the corpus-wide proof that
     # route B == reference — far stronger than the 3 chDB-lane fixtures.
     #
-    # This is intentionally a NORMAL CI job, not a branch-protection-required
-    # check: its green status on the flip PR is the proof, and keeping it
-    # off the required-checks list avoids gating every unrelated PR on the
-    # full forced-route corpus run.
+    # It is a branch-protection REQUIRED check, and one of the release
+    # preflight's required lanes: route B is a correctness-equivalent
+    # rewriting of the same query, so a diff here is a wrong answer served to
+    # a user, not a performance regression. The proof has to hold on every
+    # commit that ships, not only on the flip PR.
     name: compatibility/prometheus-forced-route
     needs: [changes, gate]
     if: needs.changes.outputs.docs_only != 'true'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,7 +17,10 @@ name: coverage
 on:
   pull_request:
   push:
-    branches: [main]
+    # `release/*.x` so `coverage` also runs on a maintenance-line hotfix push —
+    # release.yml's preflight is the only gate on that path (no PR, so no
+    # branch protection) and it requires this check-run to exist.
+    branches: [main, 'release/*.x']
   schedule:
     # nightly at 05:30 UTC (45 min after compatibility.yml at 04:00 UTC
     # so the runner doesn't double-book; well clear of the chdb job).

--- a/.github/workflows/perf-profile.yml
+++ b/.github/workflows/perf-profile.yml
@@ -38,7 +38,10 @@ name: perf-profile
 on:
   pull_request:
   push:
-    branches: [main]
+    # `release/*.x` so `profile` also runs on a maintenance-line hotfix push —
+    # release.yml's preflight is the only gate on that path (no PR, so no
+    # branch protection) and it requires this check-run to exist.
+    branches: [main, 'release/*.x']
   workflow_dispatch:
   schedule:
     # nightly at 05:00 UTC (after the chdb lane's 04:00 cron)

--- a/.github/workflows/property.yml
+++ b/.github/workflows/property.yml
@@ -46,7 +46,10 @@ name: property
 on:
   pull_request:
   push:
-    branches: [main]
+    # `release/*.x` so the `property (…)` check also runs on a maintenance-line
+    # hotfix push — release.yml's preflight is the only gate on that path (no
+    # PR, so no branch protection) and it requires this check-run to exist.
+    branches: [main, 'release/*.x']
   workflow_dispatch:
   schedule:
     # nightly at 03:45 UTC, ahead of `chdb.yml` (04:00 UTC) so the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,22 +192,62 @@ jobs:
           # posts children as "<job> / <child>"; release-preflight.mjs matches
           # that prefix too, so release-artifact-migration's tier jobs are
           # excluded without being named individually.
-          RELEASE_SELF_JOBS: gate,preflight,goreleaser,release-artifact-migration,publish,brew-smoke,chart-release
+          # All three lists are NEWLINE-separated, one name per line: check-run
+          # names are job display names and may contain commas (see `property
+          # (…, rapid N=500)` below), so a comma cannot be the separator.
+          RELEASE_SELF_JOBS: |
+            gate
+            preflight
+            goreleaser
+            release-artifact-migration
+            publish
+            brew-smoke
+            chart-release
           # The EXPECTED set — exact check-run names that MUST have posted a run
-          # on this commit. It is the branch-protection required set (see
-          # CLAUDE.md) PLUS `migration-e2e`, which can never BE a
-          # branch-protection check because migration-e2e.yml has no
-          # `pull_request:` trigger. Deleting a name from here silently shrinks
-          # the gate, so release_gate_test.go asserts `migration-e2e` is present
-          # on every PR.
-          RELEASE_REQUIRED_CHECKS: "check,lint,forbid-skip,compatibility/prometheus,compatibility/loki,compatibility/tempo,probe,roundtrip (promql),roundtrip (logql),roundtrip (traceql),compose-smoke,migration-e2e"
+          # on this commit. The invariant is TOTALITY: every branch-protection
+          # required context is accounted for here, either by being named below
+          # or by being named in RELEASE_INFORMATIONAL_CHECKS with a reason. A
+          # context in neither list is certified by absence, which is exactly
+          # what this gate exists to prevent — and it matters most on the
+          # MAINTENANCE path, where there is no PR and therefore no branch
+          # protection, leaving this preflight as the only gate. Plus
+          # `migration-e2e`, which can never BE a branch-protection check
+          # because migration-e2e.yml has no `pull_request:` trigger.
+          # release_required_checks_test.go asserts the totality invariant, and
+          # that every name here is owned by a workflow that actually triggers
+          # on `release/*.x` — a name with no lane behind it stalls the gate.
+          RELEASE_REQUIRED_CHECKS: |
+            check
+            lint
+            forbid-skip
+            chart-validate
+            compatibility/prometheus
+            compatibility/loki
+            compatibility/tempo
+            compatibility/prometheus-forced-route
+            probe
+            roundtrip (promql)
+            roundtrip (logql)
+            roundtrip (traceql)
+            compose-smoke
+            coverage
+            profile
+            property (PromQL + LogQL + TraceQL, rapid N=500)
+            migration-e2e
           # De-gated INFORMATIONAL lanes, matched by name prefix (matrix children
           # carry a "(shard-…)" suffix). The required `compose-smoke` aggregate
           # does NOT `needs:` the crawl info shard, and `dashboard` is informational
-          # on merges — a flake in either must not block a release. A prefix here
-          # that swallows a RELEASE_REQUIRED_CHECKS name fails the preflight as a
-          # wiring error rather than quietly de-gating it.
-          RELEASE_INFORMATIONAL_CHECKS: compose-smoke-shard-info,dashboard
+          # on merges — a flake in either must not block a release. `mutation` is
+          # a test-QUALITY ratchet rather than a correctness gate on the artifact
+          # being shipped; it already ran green under branch protection on the
+          # release PR, and requiring it here would put its ~11-leg matrix on the
+          # critical path of every publish, including maintenance hotfixes. A
+          # prefix here that swallows a RELEASE_REQUIRED_CHECKS name fails the
+          # preflight as a wiring error rather than quietly de-gating it.
+          RELEASE_INFORMATIONAL_CHECKS: |
+            compose-smoke-shard-info
+            dashboard
+            mutation
         # On the maintenance path this also enforces the support-window / EOL
         # policy: a push to a line 3+ minors behind the current minor is refused
         # (the line is EOL, gets no hotfixes). See docs/operations.md "Release

--- a/Justfile
+++ b/Justfile
@@ -1586,7 +1586,7 @@ release-prep version chart_bump="patch":
     gh pr create --base main --head "$branch" \
         --title "chore(release): cerberus v{{version}} / chart ${chart}" \
         --body-file release-pr-body.md
-    echo "Opened release PR on $branch. After it merges + main is green: just release-tag {{version}}"
+    echo "Opened release PR on $branch. MERGING it publishes — release.yml runs on push-to-main, gates on the staged version bumps, and creates v{{version}} itself. Do not tag by hand."
 
 # Create/switch to the release/<major>.<minor>.x maintenance line off the
 # latest matching tag, ready for cherry-picking fix: commits to backport.
@@ -1602,8 +1602,9 @@ backport-line minor:
     echo "On release/{{minor}}.x (off $base). Cherry-pick the fix commits, then: just release-prep-backport <{{minor}}.Z>"
 
 # Stage a backport release on the current release/X.Y.x branch (after the
-# fix: commits are cherry-picked) and push the branch. Tag afterward with
-# `just release-tag`. No PR — the maintenance line is pushed + tagged.
+# fix: commits are cherry-picked) and push the branch. Pushing IS the trigger:
+# release.yml runs on `release/*.x` pushes, gates on the staged version bumps,
+# and creates the tag itself. No PR, and no manual tag.
 # Usage: just release-prep-backport 1.3.2
 release-prep-backport version chart_bump="patch":
     #!/usr/bin/env bash
@@ -1617,16 +1618,12 @@ release-prep-backport version chart_bump="patch":
     git add deploy/helm/cerberus/Chart.yaml deploy/helm/cerberus/README.md CHANGELOG.md
     git commit -m "chore(release): cerberus v{{version}} / chart ${chart}"
     git push -u origin "$(git rev-parse --abbrev-ref HEAD)"
-    echo "Staged v{{version}} on $(git rev-parse --abbrev-ref HEAD). After main is green: just release-tag {{version}}"
+    echo "Pushed v{{version}} to $(git rev-parse --abbrev-ref HEAD) — that push IS the trigger; release.yml builds, publishes, and tags. Do not tag by hand."
 
-# Tag the current HEAD as v<version> and push it (triggers release.yml).
-# Guards that HEAD's chart appVersion matches, so a tag can't drift from
-# the staged release commit. Usage: just release-tag 1.4.0
-release-tag version:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    app="$(awk -F'"' '/^appVersion:/{print $2; exit}' deploy/helm/cerberus/Chart.yaml)"
-    test "$app" = "{{version}}" || { echo "HEAD appVersion=$app != {{version}} — run release-prep first"; exit 1; }
-    git tag "v{{version}}"
-    git push origin "v{{version}}"
-    echo "Pushed tag v{{version}} — release.yml will build + publish."
+# There is deliberately no `release-tag` recipe. release.yml's raw-tag trigger
+# was retired in favour of publish-on-merge, and `release-version-gate.mjs`
+# decides whether to publish by asking whether `v<appVersion>` already exists.
+# So pre-creating the tag by hand does not start a release — it PERMANENTLY
+# cancels one: the gate sees the tag, sets publish=false, and goreleaser,
+# publish and chart-release all skip. No job fails, and nothing ships.
+# `test/regression/release_gate_test.go` keeps the recipe from coming back.

--- a/test/regression/release_gate_test.go
+++ b/test/regression/release_gate_test.go
@@ -64,25 +64,41 @@ func readFileString(t *testing.T, path string) string {
 // appears somewhere else in the workflow does not satisfy it.
 func requiredChecksFromPreflight(t *testing.T, job string) []string {
 	t.Helper()
-	const key = "RELEASE_REQUIRED_CHECKS:"
-	for _, line := range strings.Split(job, "\n") {
+	out := checkListFromPreflight(job, "RELEASE_REQUIRED_CHECKS:")
+	if out == nil {
+		t.Fatalf("%s job %q declares no RELEASE_REQUIRED_CHECKS — the release gate has degraded to the "+
+			"observational deny-list, where a lane that never ran contributes zero problems. Body:\n%s",
+			releaseWorkflowPath, preflightJob, job)
+	}
+	return out
+}
+
+// checkListFromPreflight reads one of the newline-separated check lists out of
+// the preflight step's `env:` block, the same way release-preflight.mjs's
+// parseCheckList reads it at runtime. The separator is a newline rather than a
+// comma because `property (PromQL + LogQL + TraceQL, rapid N=500)` — a
+// branch-protection required context — contains one. Returns nil when the key
+// is absent, which callers distinguish from an empty list.
+func checkListFromPreflight(job, key string) []string {
+	lines := strings.Split(job, "\n")
+	for i, line := range lines {
 		trimmed := strings.TrimSpace(line)
 		if !strings.HasPrefix(trimmed, key) {
 			continue
 		}
-		raw := strings.TrimSpace(strings.TrimPrefix(trimmed, key))
-		raw = strings.Trim(raw, `"'`)
-		var out []string
-		for _, name := range strings.Split(raw, ",") {
-			if name = strings.TrimSpace(name); name != "" {
-				out = append(out, name)
+		indent := len(line) - len(strings.TrimLeft(line, " "))
+		out := []string{}
+		for _, body := range lines[i+1:] {
+			if strings.TrimSpace(body) == "" {
+				continue
 			}
+			if len(body)-len(strings.TrimLeft(body, " ")) <= indent {
+				break
+			}
+			out = append(out, strings.TrimSpace(body))
 		}
 		return out
 	}
-	t.Fatalf("%s job %q declares no %s — the release gate has degraded to the "+
-		"observational deny-list, where a lane that never ran contributes zero problems. Body:\n%s",
-		releaseWorkflowPath, preflightJob, key, job)
 	return nil
 }
 
@@ -161,22 +177,7 @@ func TestReleasePreflightRequiresTheMigrationLane(t *testing.T) {
 // preflight does, so the disjointness assertion above compares like with like.
 func informationalChecksFromPreflight(t *testing.T, job string) []string {
 	t.Helper()
-	const key = "RELEASE_INFORMATIONAL_CHECKS:"
-	for _, line := range strings.Split(job, "\n") {
-		trimmed := strings.TrimSpace(line)
-		if !strings.HasPrefix(trimmed, key) {
-			continue
-		}
-		raw := strings.Trim(strings.TrimSpace(strings.TrimPrefix(trimmed, key)), `"'`)
-		var out []string
-		for _, name := range strings.Split(raw, ",") {
-			if name = strings.TrimSpace(name); name != "" {
-				out = append(out, name)
-			}
-		}
-		return out
-	}
-	return nil
+	return checkListFromPreflight(job, "RELEASE_INFORMATIONAL_CHECKS:")
 }
 
 func TestReleasePublishesOnlyAfterTheBuiltArtifactIsDriven(t *testing.T) {

--- a/test/regression/release_required_checks_test.go
+++ b/test/regression/release_required_checks_test.go
@@ -1,0 +1,269 @@
+package regression
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// On the MAINTENANCE publish path (`release/*.x`) there is no pull request, so
+// there is no branch protection either: release.yml's preflight is the ONLY
+// gate between a push and a published artifact. That makes two silent failure
+// modes possible, and both look identical to a healthy release — green, quiet,
+// and shipped:
+//
+//   - A branch-protection lane missing from RELEASE_REQUIRED_CHECKS is
+//     certified by ABSENCE. The preflight is observation-derived: it waits for
+//     the check-runs it was told to expect and ignores the rest, so a lane that
+//     never ran contributes zero problems.
+//   - A lane NAMED in the required set whose workflow has no `release/*.x`
+//     push trigger can never post a check-run there. The preflight waits out
+//     its window and aborts every maintenance release — the opposite failure,
+//     equally invisible until a hotfix is actually needed.
+//
+// These pins close both: totality against a checked-in copy of the branch
+// protection contexts, and trigger-coverage against the workflow files.
+
+// branchProtectionContexts is the required status-check set on `main`. The
+// live source of truth is
+//
+//	gh api repos/tsouza/cerberus/branches/main/protection \
+//	  --jq '.required_status_checks.contexts[]'
+//
+// and this copy exists so the totality assertion below has something to be
+// total OVER. Adding a required check to branch protection without adding it
+// here is the one drift this file cannot see; adding it here without wiring it
+// into release.yml fails immediately.
+var branchProtectionContexts = []string{
+	"chart-validate",
+	"check",
+	"compatibility/loki",
+	"compatibility/prometheus",
+	"compatibility/prometheus-forced-route",
+	"compatibility/tempo",
+	"compose-smoke",
+	"coverage",
+	"dashboard",
+	"forbid-skip",
+	"lint",
+	"mutation",
+	"probe",
+	"profile",
+	"property (PromQL + LogQL + TraceQL, rapid N=500)",
+	"roundtrip (logql)",
+	"roundtrip (promql)",
+	"roundtrip (traceql)",
+}
+
+const workflowsDir = "../../.github/workflows"
+
+// maintenanceBranchPattern is the push-trigger glob every workflow owning a
+// release-required check must carry, so the check-run exists on the
+// maintenance publish path where no PR is opened.
+const maintenanceBranchPattern = "release/*.x"
+
+func TestReleasePreflightCoversEveryBranchProtectionContext(t *testing.T) {
+	t.Parallel()
+
+	job := workflowJobBody(t, readFileString(t, releaseWorkflowPath), preflightJob)
+	required := requiredChecksFromPreflight(t, job)
+	informational := informationalChecksFromPreflight(t, job)
+
+	inRequired := map[string]bool{}
+	for _, name := range required {
+		inRequired[name] = true
+	}
+
+	for _, ctx := range branchProtectionContexts {
+		if inRequired[ctx] {
+			continue
+		}
+		degated := false
+		for _, prefix := range informational {
+			if strings.HasPrefix(ctx, prefix) {
+				degated = true
+				break
+			}
+		}
+		if !degated {
+			t.Errorf("branch-protection context %q appears in neither RELEASE_REQUIRED_CHECKS nor "+
+				"RELEASE_INFORMATIONAL_CHECKS of %s job %q. On the maintenance path there is no PR "+
+				"and therefore no branch protection, so an unlisted lane is certified by absence: "+
+				"the preflight ignores what it was not told to expect and the release publishes on "+
+				"silence. Either require it, or de-gate it explicitly with a written reason.",
+				ctx, releaseWorkflowPath, preflightJob)
+		}
+	}
+}
+
+func TestReleaseRequiredChecksAllHaveAMaintenanceTrigger(t *testing.T) {
+	t.Parallel()
+
+	job := workflowJobBody(t, readFileString(t, releaseWorkflowPath), preflightJob)
+	required := requiredChecksFromPreflight(t, job)
+	owners := workflowCheckOwners(t)
+
+	for _, name := range required {
+		owner, ok := owners.lookup(name)
+		if !ok {
+			t.Errorf("RELEASE_REQUIRED_CHECKS names %q, but no job in %s declares that check name. "+
+				"The preflight would wait out its whole window for a check-run that nothing can post, "+
+				"then abort the release.", name, workflowsDir)
+			continue
+		}
+		if !owner.pushesOn("main") {
+			t.Errorf("check %q is owned by %s, which has no push trigger on `main`; the preflight "+
+				"requires it on the main publish path", name, owner.file)
+		}
+		if !owner.pushesOn(maintenanceBranchPattern) {
+			t.Errorf("check %q is owned by %s, which has no `%s` push trigger. A hotfix pushed to a "+
+				"maintenance line would never produce this check-run, so every maintenance release "+
+				"would stall in the preflight and abort. Add the trigger, or move the check to "+
+				"RELEASE_INFORMATIONAL_CHECKS with a reason.",
+				name, owner.file, maintenanceBranchPattern)
+		}
+	}
+}
+
+// TestNoJustfileRecipePushesAReleaseTag pins the deletion of `just
+// release-tag`. release.yml's raw-tag trigger is retired, and
+// release-version-gate.mjs decides whether to publish by asking whether
+// `v<appVersion>` already exists — so pre-creating the tag by hand does not
+// START a release, it permanently CANCELS one. The gate sees the tag, sets
+// publish=false, and goreleaser / publish / chart-release all skip. No job
+// fails and nothing ships, which is why this needs a pin rather than a
+// convention: the failure mode is a silent success.
+func TestNoJustfileRecipePushesAReleaseTag(t *testing.T) {
+	t.Parallel()
+
+	recipes := justRecipes(t, readFileString(t, "../../Justfile"))
+	if len(recipes) == 0 {
+		t.Fatal("parsed no recipes out of the Justfile")
+	}
+	for name, body := range recipes {
+		for _, line := range strings.Split(body, "\n") {
+			if !strings.Contains(line, "git tag") && !strings.Contains(line, "git push") {
+				continue
+			}
+			if strings.Contains(line, "v{{version}}") || strings.Contains(line, "chart-v") {
+				t.Errorf("Justfile recipe %q creates or pushes a release tag:\n\t%s\n"+
+					"Tags are created BY release.yml after it publishes. A hand-made tag makes "+
+					"the version gate see the version as already released, so the release is "+
+					"skipped in silence — every job green, nothing shipped.",
+					name, strings.TrimSpace(line))
+			}
+		}
+	}
+}
+
+// checkOwner is the workflow that posts a given check-run name.
+type checkOwner struct {
+	file         string
+	pushBranches []string
+}
+
+func (o checkOwner) pushesOn(branch string) bool {
+	for _, b := range o.pushBranches {
+		if b == branch {
+			return true
+		}
+	}
+	return false
+}
+
+// checkOwnerIndex resolves a check-run name to the workflow that posts it.
+// Job names that interpolate a matrix value (`roundtrip (${{ matrix.ql }})`)
+// are indexed by their literal prefix rather than expanded — enumerating the
+// matrix would be more machinery than the assertion needs, and the prefix is
+// unambiguous in practice.
+type checkOwnerIndex struct {
+	exact    map[string]checkOwner
+	prefixes []struct {
+		prefix string
+		owner  checkOwner
+	}
+}
+
+func (i checkOwnerIndex) lookup(name string) (checkOwner, bool) {
+	if o, ok := i.exact[name]; ok {
+		return o, true
+	}
+	for _, p := range i.prefixes {
+		if p.prefix != "" && strings.HasPrefix(name, p.prefix) {
+			return p.owner, true
+		}
+	}
+	return checkOwner{}, false
+}
+
+// workflowCheckOwners indexes every check-run name declared under
+// .github/workflows, together with the push triggers of its workflow.
+func workflowCheckOwners(t *testing.T) checkOwnerIndex {
+	t.Helper()
+
+	entries, err := os.ReadDir(workflowsDir)
+	if err != nil {
+		t.Fatalf("read %s: %v", workflowsDir, err)
+	}
+
+	exact := map[string]checkOwner{}
+	var prefixes []struct {
+		prefix string
+		owner  checkOwner
+	}
+
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".yml" {
+			continue
+		}
+		path := filepath.Join(workflowsDir, e.Name())
+
+		// `on:` is not always a mapping — `on: pull_request_target` and
+		// `on: [push, pull_request]` are both legal — so it is decoded
+		// separately and only when it has the shape we care about.
+		var doc struct {
+			On   yaml.Node `yaml:"on"`
+			Jobs map[string]struct {
+				Name string `yaml:"name"`
+			} `yaml:"jobs"`
+		}
+		if err := yaml.Unmarshal([]byte(readFileString(t, path)), &doc); err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+
+		var triggers struct {
+			Push struct {
+				Branches []string `yaml:"branches"`
+			} `yaml:"push"`
+		}
+		if doc.On.Kind == yaml.MappingNode {
+			if err := doc.On.Decode(&triggers); err != nil {
+				t.Fatalf("parse %s `on:` block: %v", path, err)
+			}
+		}
+
+		owner := checkOwner{file: path, pushBranches: triggers.Push.Branches}
+		for id, jb := range doc.Jobs {
+			name := jb.Name
+			if name == "" {
+				name = id
+			}
+			if i := strings.Index(name, "${{"); i >= 0 {
+				prefixes = append(prefixes, struct {
+					prefix string
+					owner  checkOwner
+				}{strings.TrimRight(name[:i], " "), owner})
+				continue
+			}
+			exact[name] = owner
+		}
+	}
+
+	if len(exact) == 0 {
+		t.Fatalf("parsed no job names out of %s", workflowsDir)
+	}
+	return checkOwnerIndex{exact: exact, prefixes: prefixes}
+}


### PR DESCRIPTION
The pre-release audit for 1.13.1 turned up three ways the publish path can report green while gating nothing. All three are silent by construction — no job fails, no log line looks unusual, and the artifact ships anyway. That's what makes them worth a PR of their own rather than a fix-forward during a release.

## 1. `just release-tag` cancelled releases instead of starting them

`release.yml`'s raw-tag trigger is retired; publishing happens on push-to-main / push-to-`release/*.x`, and `release-version-gate.mjs` decides whether to publish by asking whether `v<appVersion>` already exists.

So creating the tag by hand does not start a release — it **permanently cancels** one. The gate sees its own tag, sets `publish=false`, and `goreleaser`, `publish` and `chart-release` all skip. Every job is green. Nothing ships.

- recipe deleted, with a comment at the site explaining why there deliberately isn't one
- the three places that pointed at it (`release-prep`, `release-prep-backport` header + closing echo) now say the push *is* the trigger
- `TestNoJustfileRecipePushesAReleaseTag` refuses any recipe that creates or pushes a `v*` / `chart-v*` tag

## 2. The chart image-existence guard could not see a missing image

`chart-kubeconform.mjs` probed with `docker manifest inspect` under `stdio: 'ignore'`. `execFileSync` then throws with `stderr === null` and a bare `Command failed: <cmd>` message, so the classifier — which keys on `manifest unknown` / `404` / etc. — could never match, and **every** failure fell through as `unknown` and was tolerated.

- stderr is piped, so the registry's own words reach the classifier
- the spawn options are a named export (`PROBE_SPAWN_OPTS`) so the self-test pins *the defect*, not just the pure classifier — reverting `stdio` to `'ignore'` now fails the self-test (mutation-verified, `EXIT=1`)
- `Chart.yaml` is scanned for images too: the artifacthub `images` annotation carries a `v`-prefixed ref that no rendered manifest holds, so it was never checked
- a staging exemption keeps the guard honest on the release PR itself, where the new appVersion's image legitimately doesn't exist yet
- the self-test is wired into `chart-ci` **unconditionally** — pinning it only when chart files change leaves it unexercised on exactly the PRs that edit the guard

## 3. `RELEASE_REQUIRED_CHECKS` covered 11 of the 18 required contexts

On the maintenance path (`release/*.x`) there is no PR, so there is no branch protection either: the preflight is the *only* gate between a push and a published artifact. The preflight is observation-derived — it waits for the check-runs it was told to expect and ignores the rest — so a lane missing from the set is **certified by absence**.

Missing: `chart-validate`, `compatibility/prometheus-forced-route`, `coverage`, `profile`, `property (…)`, `dashboard`, `mutation`.

The set is now **total**: every branch-protection context is either required or de-gated by name with a written reason. `mutation` is de-gated deliberately — it's a test-quality ratchet rather than a correctness gate on the artifact being shipped, it already ran green under branch protection on the release PR, and requiring it would put its ~11-leg matrix on the critical path of every publish including hotfixes.

Ordering mattered: `chart-ci`, `coverage`, `perf-profile` and `property` gained `release/*.x` push triggers **first**. A required name with no lane behind it doesn't gate a maintenance release — it stalls one, waiting out the full preflight window and then aborting.

### The lists are newline-separated now

`property (PromQL + LogQL + TraceQL, rapid N=500)` is a required context and it contains a comma. Under the old comma separator it split into two names that no lane will ever post, so adding it would have hung every release. `parseCheckList` splits on newlines; `release.yml` declares all three lists as block scalars.

## Pins

- `TestReleasePreflightCoversEveryBranchProtectionContext` — totality, against a checked-in copy of `gh api …/branches/main/protection`
- `TestReleaseRequiredChecksAllHaveAMaintenanceTrigger` — every required name resolves to a workflow that push-triggers on both `main` and `release/*.x`, parsed out of the workflow files rather than asserted by hand
- `parseCheckList keeps commas inside a check name` in `release-preflight.test.mjs`

Each was mutation-checked: drop `coverage` from the required set → totality fails; drop `release/*.x` from `coverage.yml` → trigger-coverage fails; re-add a tagging recipe → the Justfile pin fails.

Also corrects a comment in `compatibility.yml` claiming `compatibility/prometheus-forced-route` is deliberately *not* a required check — it has been one since the gate flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)