### PR TITLE
docs: correct parity-gate, config-source and forbid-skip claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,8 +167,6 @@ brew install tsouza/tap/cerberus
 
 Only stable releases publish a formula, so `brew` never hands you a prerelease.
 
-Cerberus is configured **entirely** through `CERBERUS_*` environment
-variables — see the full [configuration reference](docs/configuration.md).
 The surrounding runtime contract (lifecycle, scaling, the solver and
 experimental knobs in context) lives in
 [`docs/operations.md`](docs/operations.md).
@@ -284,17 +282,28 @@ just compat-all          # or compat-promql / compat-logql / compat-traceql
 ```
 
 **What the required checks enforce.** The three `compatibility/<head>`
-checks run on every PR and **fail on infrastructure breakage** (stack
-won't boot, seed fails, report unparseable). Per-case **parity drift is
-report-only** by design ([#503](https://github.com/tsouza/cerberus/pull/503)):
-it is recorded in `report.json` and rendered into the live `compat-score.json`
-badge, but does not turn the required check red. The one lane that
-_hard-fails on any parity diff_ is `compatibility/prometheus-forced-route`
-(`FAIL_ON_DIFF=1`, proving the sharded solver route is byte-identical to
-reference Prometheus over the whole corpus) — and that lane _is_ a
-required check. The honest reading: the three head badges are a
-continuously re-measured conformance score, not a merge gate on numeric
-correctness.
+checks run on every PR in two layers. The harness itself is _scored_
+([#503](https://github.com/tsouza/cerberus/pull/503)): it accumulates
+per-case results into `report.json` / `compat-score.json` and exits 0
+even when a case diverges, so the harness step alone reddens the job
+only on infrastructure breakage (stack won't boot, seed fails, report
+unparseable). The gate is the step after it —
+[`compat-ratchet.mjs`](.github/scripts/compat-ratchet.mjs) compares the
+run's score against the committed floor in
+[`compatibility/parity-baseline.json`](compatibility/parity-baseline.json)
+and **fails the required job on any drop**. Both `passed` and `total`
+are floored, so a regression cannot hide by shrinking the corpus.
+Raising a floor is a deliberate same-PR edit to the baseline file.
+
+`compatibility/prometheus-forced-route` is stricter still: it runs with
+`FAIL_ON_DIFF=1` and hard-fails on _any_ per-case diff, which is what
+proves the sharded solver route is byte-identical to reference
+Prometheus over the whole corpus.
+
+So the three head badges are both: a continuously re-measured
+conformance score, and — through the ratchet floor — a merge gate.
+[`docs/compatibility.md`](docs/compatibility.md#parity-regression-ratchet-the-gate)
+is the canonical reference.
 
 **No allow-lists** — every diff against the reference is a real bug to
 fix at the source, not an exception to suppress. The full playbook

--- a/docs/forbid-skip.md
+++ b/docs/forbid-skip.md
@@ -20,12 +20,22 @@ known baseline instead of re-deriving from CI failure tickers.
 
 ## Where the patterns live
 
-The patterns run in **two places**, and the two MUST stay in sync:
+The gate **runs** in two places:
 
 1. `.github/workflows/ci.yml` job `forbid-skip` — required status check
-   on `main`.
-2. `lefthook.yml` `pre-push` hook — local-mirror of the same gate so a
+   on `main`. The job holds no regexes of its own: every step is
+   `run: node .github/scripts/forbid-skip.mjs` with a `CHECK:` naming
+   the arm to dispatch.
+2. `lefthook.yml` `pre-push` hook — local mirror of the same gate so a
    push that would have failed CI fails locally first.
+
+The regex **text** lives in three files, which MUST stay in lock-step:
+
+1. `.github/scripts/forbid-skip.mjs` — the CI source of truth, one
+   `case '<name>':` arm of the `CHECK` switch per scan.
+2. `lefthook.yml` — inline mirror, one command per scan.
+3. `scripts/test-forbid-skip.sh` — its own literal copies, asserted
+   against the match / counter-example pairs documented below.
 
 `scripts/test-forbid-skip.sh` is the assertion that the regexes still
 match their canonical positive examples and still reject the matching
@@ -34,8 +44,8 @@ the script directly) and as a step inside the `forbid-skip` CI job. The
 lefthook `forbid-skip-self-test` command runs the same script on
 pre-push.
 
-The two locations carry **identical** patterns for rows 1–5 of the
-summary table below. Row 6 is enforced by the CI `forbid-skip` job step
+Rows 1–5 of the summary table below are carried by all three copies.
+Row 6 is enforced by the CI `forbid-skip` job step
 "Reject should_skip overlay entries", which rejects every non-empty
 `should_skip:` block in `compatibility/**/*.{yml,yaml}` outright. Row 7
 is enforced by the CI step "Reject test escape-hatch patterns". Rows 8
@@ -72,8 +82,12 @@ count (6), so the number can never drift from the source switch.
 
 When a new offender shape is discovered:
 
-1. Add the new regex to **both** `.github/workflows/ci.yml` and
-   `lefthook.yml` in the same PR.
+1. Add the new regex to **all three** copies in the same PR:
+   `.github/scripts/forbid-skip.mjs` (widen an existing `case '<name>':`
+   arm of the `CHECK` switch, or add a new arm plus a matching
+   `run: node .github/scripts/forbid-skip.mjs` step with `CHECK: <name>`
+   in the `forbid-skip` job of `.github/workflows/ci.yml`),
+   `lefthook.yml`, and `scripts/test-forbid-skip.sh`.
 2. Add a new row to the summary table below + a detailed subsection
    covering the regex, its intent, a match-example, and a
    counter-example.

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -52,18 +52,22 @@ tolerated: a red informational lane is a real failure to fix, it is just
 not wired as a branch-protection gate (typically because it needs the chDB
 substrate, a Docker stack, or a soak streak before promotion).
 
-One subtlety on the three `compatibility/<head>` checks: they are required,
-but the *check* fails only on infrastructure breakage — per-case **numeric
-parity drift is report-only** (rendered into the badge score, not the exit
-code; see [`compatibility.md`](compatibility.md#ci-integration) and
-[#503](https://github.com/tsouza/cerberus/pull/503)). The only lane that
-hard-fails on a numeric parity diff is the *required*
-`compatibility/prometheus-forced-route` (`FAIL_ON_DIFF=1`). So the
-required differential checks gate *that the harness runs clean*, while the
-parity number itself is a continuously-measured score rather than a merge
-gate. A fail-on-parity gate is already required on the forced-route lane;
-extending it to the three `compatibility/<head>` heads is a tracked
-improvement.
+One subtlety on the three `compatibility/<head>` checks: each gates in two
+layers. The harness is *scored* — it accumulates per-case results into
+`compat-score.json` and exits 0 even when an individual case diverges
+([#503](https://github.com/tsouza/cerberus/pull/503)), so the harness step
+alone reddens the job only on infrastructure breakage. The gate is the step
+after it: `.github/scripts/compat-ratchet.mjs` compares the run's
+`passed` / `total` against the committed per-head floor in
+`compatibility/parity-baseline.json` and **fails the required job on any
+drop** — fewer passing cases, or a corpus smaller than baseline so a
+regression cannot hide by dropping a failing case. Noise *within* the
+floor is tolerated: the ratchet pins the aggregate, not individual case
+identity, so one case regressing while another starts passing does not
+gate. `compatibility/prometheus-forced-route` is stricter still — it runs
+the harness with `FAIL_ON_DIFF=1` and hard-fails on *any* per-case diff.
+See [`compatibility.md`](compatibility.md#parity-regression-ratchet-the-gate)
+for the floors themselves and the procedure for raising one.
 
 | Gate                                    | Workflow (job)                                       | Trigger                             | Required? | Scope                                                                                                                                                                                                                                                                                                                                                                               |
 | --------------------------------------- | ---------------------------------------------------- | ----------------------------------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -72,9 +76,9 @@ improvement.
 | `forbid-skip`                           | `ci.yml` (`forbid-skip`)                             | PR + push                           | Required  | `t.Skip*`, "not implemented" in prod code, soft-assertion / silent-recover, escape-hatch patterns, `should_skip` overlay, scenario-suppressing `.feature` tags + godog skip routes, regex self-test, doc-count gate (`doc-counts.mjs`)                                                                                                                                              |
 | `probe`                                 | `chdb.yml` (`probe`)                                 | PR + push + nightly                 | Required  | chDB driver sanity (`TestChDBProbe`) + `just test-chdb` (api-handler + Layer 7b chdb lane)                                                                                                                                                                                                                                                                                          |
 | `roundtrip (promql / logql / traceql)`  | `chdb.yml` (matrix)                                  | PR + push + nightly                 | Required  | TXTAR chDB roundtrip per head (Layer 6a-c)                                                                                                                                                                                                                                                                                                                                          |
-| `compatibility/prometheus`              | `compatibility.yml` (`compatibility/prometheus`)     | PR + push + nightly + dispatch      | Required  | PromQL differential vs reference Prometheus (`prometheus/compliance` harness)                                                                                                                                                                                                                                                                                                       |
-| `compatibility/loki`                    | `compatibility.yml` (`compatibility/loki`)           | PR + push + nightly + dispatch      | Required  | LogQL differential vs reference Loki + vendored `loki:pkg/logql/bench` corpus                                                                                                                                                                                                                                                                                                       |
-| `compatibility/tempo`                   | `compatibility.yml` (`compatibility/tempo`)          | PR + push + nightly + dispatch      | Required  | TraceQL differential vs reference Tempo (cerberus-owned TXTAR corpus)                                                                                                                                                                                                                                                                                                               |
+| `compatibility/prometheus`              | `compatibility.yml` (`compatibility/prometheus`)     | PR + push + nightly + dispatch      | Required  | PromQL differential vs reference Prometheus (`prometheus/compliance` harness) + parity-regression ratchet vs `compatibility/parity-baseline.json`                                                                                                                                                                                                                                   |
+| `compatibility/loki`                    | `compatibility.yml` (`compatibility/loki`)           | PR + push + nightly + dispatch      | Required  | LogQL differential vs reference Loki + vendored `loki:pkg/logql/bench` corpus + parity-regression ratchet vs `compatibility/parity-baseline.json`                                                                                                                                                                                                                                   |
+| `compatibility/tempo`                   | `compatibility.yml` (`compatibility/tempo`)          | PR + push + nightly + dispatch      | Required  | TraceQL differential vs reference Tempo (cerberus-owned TXTAR corpus) + parity-regression ratchet vs `compatibility/parity-baseline.json`                                                                                                                                                                                                                                           |
 | `compose-smoke`                         | `e2e.yml` (`compose-smoke`)                          | PR + push + nightly                 | Required  | `docker compose up --wait` + `/healthz` / `/readyz` / Grafana `/api/health` + Playwright catch-net + `compose` crawl (lean PR, full nightly)                                                                                                                                                                                                                                        |
 | `chart-validate`                        | `chart-ci.yml` (`chart-validate`)                    | PR + push + dispatch                | Required  | Helm chart lint + `helm-docs` README drift gate + `kubeconform` render + render assertions (split PDBs / derived `GOMEMLIMIT`) + `ct lint` over `deploy/helm/cerberus`; short-circuits to a green no-op when no chart file changed, so it reports on every PR                                                                                                                       |
 | `compatibility/prometheus-forced-route` | `compatibility.yml` (forced-route job)               | PR + push + nightly + dispatch      | Required  | Corpus-wide proof that the solver route B (`CERBERUS_EVAL_ROUTE=sharded`) is byte-identical to route A vs reference Prom                                                                                                                                                                                                                                                            |


### PR DESCRIPTION
Three documentation statements contradicted the code they describe. Found by the pre-release audit (findings #15–#18).

## 1. Parity gating is a two-layer gate, not report-only

`README.md` and `docs/test-strategy.md` both stated that per-case parity drift on the three `compatibility/<head>` checks is **report-only**, and that extending a fail-on-parity gate beyond `compatibility/prometheus-forced-route` was "a tracked improvement".

It already exists, in two layers:

1. The harness is *scored* (#503) — it accumulates per-case results into `report.json` / `compat-score.json` and exits 0 even when a case diverges, so the harness step alone reddens the job only on infrastructure breakage.
2. The step after it, [`.github/scripts/compat-ratchet.mjs`](.github/scripts/compat-ratchet.mjs), compares the run's score against the committed per-head floor in [`compatibility/parity-baseline.json`](compatibility/parity-baseline.json) (prometheus 718/718, loki 116/116, tempo 48/48) and **fails the required job on any drop**.

Both `passed` *and* `total` are floored — flooring `total` is what stops a regression from hiding by dropping a failing case out of the corpus. What the ratchet does *not* pin is individual case identity, so noise within the floor (one case regressing while another starts passing) is tolerated; both docs now say so explicitly rather than leaving the reader to infer either extreme.

`compatibility/prometheus-forced-route` remains stricter: `FAIL_ON_DIFF=1`, hard-fails on *any* per-case diff.

The three `compatibility/<head>` rows in the test-strategy gate table now name the ratchet in their Scope cells, and both prose pointers retarget to `docs/compatibility.md#parity-regression-ratchet-the-gate` (the canonical reference) instead of the generic `#ci-integration`.

## 2. Config source of truth

`README.md` claimed cerberus is configured "entirely through `CERBERUS_*` environment variables" — two paragraphs after describing the YAML schema-override file that is also configuration. The sentence is deleted; the pointer to `docs/operations.md` stands on its own.

## 3. forbid-skip pattern copies

`docs/forbid-skip.md` said the patterns live in two places and are "identical" across them. The regex *text* actually lives in three files: `.github/scripts/forbid-skip.mjs` (the CI source of truth — `ci.yml` holds only step wiring), `lefthook.yml`, and `scripts/test-forbid-skip.sh`.

A contributor following the old two-file instruction would leave the shell test's copy stale, and the gate and its own test would silently disagree. "Where the patterns live" now separates where the gate **runs** (2 places) from where the regex **text** lives (3 files), and "Adding a new pattern" step 1 names all three.

## Verification

- `node .github/scripts/doc-counts.mjs` → `all doc-stated counts match source (forbid-skip=6, test-layers=14)`
- `markdownlint-cli2 README.md docs/test-strategy.md docs/forbid-skip.md` → 0 errors (the three widened table rows were re-aligned)
- Every claim checked against source: `compat-ratchet.mjs` floors both fields; `compatibility/parity-baseline.json` carries the three head floors; `docs/compatibility.md` §"Parity-regression ratchet (the gate)" exists.

Docs-only — no code paths touched.