### PR TITLE
chore(release): cerberus v1.13.1 / chart 0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to cerberus will be documented in this file. The format roug
 
 ## [v1.13.1] — 2026-07-28
 
+### Changed
+
+- **release:** container images publish as a single multi-arch index (#1320). The per-arch `:<version>-amd64` / `-arm64` tags are gone — they only ever existed as inputs to the manifest, and nothing in the repo, chart, or docs pulled one. buildx now also attaches an SBOM attestation to the index.
+
 ### Fixed
 
 - **promql:** keep the `@` pin in range mode on every range-vector lowering (#1325)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to cerberus will be documented in this file. The format roug
 
 ## [Unreleased]
 
+## [v1.13.1] — 2026-07-28
+
+### Fixed
+
+- **promql:** keep the `@` pin in range mode on every range-vector lowering (#1325)
+- **prom:** bound windowless metadata discovery by real retention (#1327)
+- **ci:** make the release gate, image probe and doc claims hold under audit (#1329)
+- **migration:** forward the story dispatch input to the tier-2 run (#1328)
+- **optimizer:** keep AggFunc.Params through a constant fold (#1326)
+- **release:** close the three gaps that let a release ship unverified (#1322)
+- **ci:** skip buildable images in the compose pre-pull (#1321)
+- **ci:** retry every image pull instead of failing the lane (#1319)
+- **release:** name the workflow a preflight wait is blocked on (#1318)
+
+### Performance
+
+- **chsql:** skip the spans-scan emit guard when the SQL never names the spans table (#1330)
+
+### Documentation
+
+- correct parity-gate, config-source and forbid-skip claims (#1323)
+
 ## [v1.13.0] — 2026-07-27
 
 ### Added

--- a/deploy/helm/cerberus/Chart.yaml
+++ b/deploy/helm/cerberus/Chart.yaml
@@ -8,11 +8,11 @@ type: application
 # upgrade?" and is the publish trigger: a chart-only fix bumps this without an
 # app re-tag; an app-only release bumps appVersion + a PATCH here for the new
 # default image. Starts 0.x because the values contract is not yet frozen.
-version: 0.13.0
+version: 0.13.1
 
 # appVersion tracks the GA cerberus binary. Quoted so SemVer-shaped values
 # aren't coerced to floats. image.tag defaults from this when left empty.
-appVersion: "1.13.0"
+appVersion: "1.13.1"
 
 # autoscaling/v2 + policy/v1 (PDB) + networking/v1 (Ingress) are all GA from
 # 1.21+; 1.23 is the conservative floor matching the manifests this chart
@@ -45,15 +45,27 @@ annotations:
       url: https://github.com/tsouza/cerberus/blob/main/docs/operations.md
   artifacthub.io/images: |
     - name: cerberus
-      image: ghcr.io/tsouza/cerberus:v1.13.0
+      image: ghcr.io/tsouza/cerberus:v1.13.1
   # Bump the `1.0.0` floor here when the chart raises its minimum supported
   # cerberus release; informational for Artifact Hub's compatibility hints.
   artifacthub.io/changes: |
-    - kind: added
-      description: "config: accept the chart's nested shape in cerberus.yaml (#1316)"
-    - kind: added
-      description: "migrate: read verify/inventory settings from cerberus.yaml (#1314)"
     - kind: fixed
-      description: "release: make the Homebrew publish path actually work (Formula/ dir + a runner with brew) (#1306)"
+      description: "promql: keep the `@` pin in range mode on every range-vector lowering (#1325)"
     - kind: fixed
-      description: "test/e2e: scope the tempo duration-filter search to the seed corpus (#1305)"
+      description: "prom: bound windowless metadata discovery by real retention (#1327)"
+    - kind: fixed
+      description: "ci: make the release gate, image probe and doc claims hold under audit (#1329)"
+    - kind: fixed
+      description: "migration: forward the story dispatch input to the tier-2 run (#1328)"
+    - kind: fixed
+      description: "optimizer: keep AggFunc.Params through a constant fold (#1326)"
+    - kind: fixed
+      description: "release: close the three gaps that let a release ship unverified (#1322)"
+    - kind: fixed
+      description: "ci: skip buildable images in the compose pre-pull (#1321)"
+    - kind: fixed
+      description: "ci: retry every image pull instead of failing the lane (#1319)"
+    - kind: fixed
+      description: "release: name the workflow a preflight wait is blocked on (#1318)"
+    - kind: changed
+      description: "chsql: skip the spans-scan emit guard when the SQL never names the spans table (#1330)"

--- a/deploy/helm/cerberus/Chart.yaml
+++ b/deploy/helm/cerberus/Chart.yaml
@@ -69,3 +69,5 @@ annotations:
       description: "release: name the workflow a preflight wait is blocked on (#1318)"
     - kind: changed
       description: "chsql: skip the spans-scan emit guard when the SQL never names the spans table (#1330)"
+    - kind: changed
+      description: "release: container images publish as a single multi-arch index; the per-arch -amd64/-arm64 tags are gone (#1320)"

--- a/deploy/helm/cerberus/README.md
+++ b/deploy/helm/cerberus/README.md
@@ -5,7 +5,7 @@
      pipe-aligned, and the version footer adds a trailing blank — both are
      owned by helm-docs; realigning would fight the chart-ci drift check. -->
 
-![Version: 0.13.0](https://img.shields.io/badge/Version-0.13.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.13.0](https://img.shields.io/badge/AppVersion-1.13.0-informational?style=flat-square)
+![Version: 0.13.1](https://img.shields.io/badge/Version-0.13.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.13.1](https://img.shields.io/badge/AppVersion-1.13.1-informational?style=flat-square)
 
 Drop-in Prometheus / Loki / Tempo HTTP gateway for ClickHouse — a single stateless gateway that speaks three upstream query wire formats and lowers each to parameterised ClickHouse SQL.
 


### PR DESCRIPTION
Release-prep for **v1.13.1** (chart **0.13.1**), generated by `prepare-release.yml`.

- appVersion 1.13.0 -> 1.13.1, chart 0.13.0 -> 0.13.1

### Changes

### Fixed

- **promql:** keep the `@` pin in range mode on every range-vector lowering (#1325)
- **prom:** bound windowless metadata discovery by real retention (#1327)
- **ci:** make the release gate, image probe and doc claims hold under audit (#1329)
- **migration:** forward the story dispatch input to the tier-2 run (#1328)
- **optimizer:** keep AggFunc.Params through a constant fold (#1326)
- **release:** close the three gaps that let a release ship unverified (#1322)
- **ci:** skip buildable images in the compose pre-pull (#1321)
- **ci:** retry every image pull instead of failing the lane (#1319)
- **release:** name the workflow a preflight wait is blocked on (#1318)

### Performance

- **chsql:** skip the spans-scan emit guard when the SQL never names the spans table (#1330)

### Documentation

- correct parity-gate, config-source and forbid-skip claims (#1323)

Generated from the conventional commits since the last tag. Review and edit before merging; the tag is cut once this lands.
