### PR TITLE
ci: detect release-gate rot before it breaks a publish

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -233,6 +233,30 @@ One implementation means a new rule guards BOTH lanes at once.
     `1` on a parse failure / `helm push` / `oras push` error, or when the
     version-gate cannot definitively determine existence (fails closed, with one
     `::error::`).
+- **`release-gate-drift.mjs`** — `release-gate-drift.yml`, the weekly `drift`
+  job. Rot detector for the EXPECTED set `release-preflight.mjs` gates on. Reads
+  `RELEASE_REQUIRED_CHECKS` + `RELEASE_INFORMATIONAL_CHECKS` out of release.yml
+  itself (one copy of the data, one parser; an empty parse throws rather than
+  comparing against nothing) and checks two directions the preflight structurally
+  cannot see from the inside. PROTECTION DRIFT: a live branch-protection required
+  context in neither list is a lane every PR must pass and the release does not
+  wait for — the dangerous direction, and invisible to an allow-list of names to
+  wait for. LANE DRIFT: a required name that posted no check-run anywhere in the
+  scanned commit window no longer matches a lane, so the next release waits out
+  its full window and aborts mid-publish. The window spans many commits because a
+  single commit's check-runs are a subset of the lane inventory (a docs-only push
+  skips `check`); absent from every commit means dead, not skipped. Pure exported
+  `parseBlockScalar` / `parseCheckLists` / `protectionDrift` / `laneDrift` plus a
+  `--self-test` the job runs first.
+  - Env: `GITHUB_TOKEN` (must be repo-ADMIN — branch protection is unreadable
+    with the default workflow token at any `permissions:` level, so the workflow
+    passes `RELEASE_PAT`), `GITHUB_REPOSITORY`, `GITHUB_API_URL` (default
+    `https://api.github.com`), `DRIFT_BRANCH` (default `main`), `DRIFT_HISTORY`
+    (default 20 commits), `RELEASE_WORKFLOW` (default
+    `.github/workflows/release.yml`).
+  - Exit: `0` when both directions are clean; `1` on any drift, an API read
+    failure, an unparseable release.yml, or protection reporting zero contexts
+    (fails closed — unreadable protection is not a clean bill of health).
 - **`release-preflight.mjs`** — `release.yml`, the `preflight` job. The
   green-check guard for BOTH release paths, gated on the publish decision rather
   than on the branch: it runs whenever `app_publish` or `chart_publish` is true,

--- a/.github/scripts/release-gate-drift.mjs
+++ b/.github/scripts/release-gate-drift.mjs
@@ -1,0 +1,294 @@
+// release-gate-drift.mjs — scheduled drift detector for the RELEASE GATE's
+// expected check set.
+//
+// `release-preflight.mjs` gates a publish on `RELEASE_REQUIRED_CHECKS`, an
+// EXPECTED set hand-maintained in release.yml. That set is only ever exercised
+// mid-publish, and it can rot in two independent directions that the preflight
+// itself structurally cannot see:
+//
+//   A. PROTECTION DRIFT — branch protection gains a required context that is in
+//      neither `RELEASE_REQUIRED_CHECKS` nor `RELEASE_INFORMATIONAL_CHECKS`.
+//      Every PR now has to pass it, but the release does not wait for it, so it
+//      publishes past a lane the repo considers gating. The preflight cannot
+//      catch this: its set is an allow-list of names to WAIT for, and a name
+//      nobody listed is a name nobody waits for. Fails silently, in the
+//      dangerous direction.
+//
+//   B. LANE DRIFT — a name in `RELEASE_REQUIRED_CHECKS` stops matching any lane
+//      that actually posts a check-run (a job renamed, a matrix leg's display
+//      string reworded, a workflow deleted). The preflight then waits out its
+//      full window on a check-run that will never arrive and ABORTS the
+//      release. Fails closed rather than open, but it fails at the single worst
+//      moment — mid-publish, with the tag already cut. `property (PromQL +
+//      LogQL + TraceQL, rapid N=500)` is the standing reminder that these names
+//      are display strings, not identifiers.
+//
+// So: run both checks on a schedule, off the release critical path, where the
+// fix is a one-line PR instead of a broken publish.
+//
+// The lists are read from release.yml itself rather than duplicated here —
+// there is exactly one copy of the data and one parser for it. A parse that
+// yields an empty required set is a hard failure, not an empty comparison,
+// because a silently-empty set makes BOTH checks vacuously green.
+//
+// Env:
+//   GITHUB_TOKEN       REQUIRED. Reading branch protection needs a token with
+//                      repo-admin rights — the default `GITHUB_TOKEN` does NOT
+//                      qualify, so the workflow passes `RELEASE_PAT`.
+//   GITHUB_REPOSITORY  owner/repo (runner-provided).
+//   GITHUB_API_URL     API base (default https://api.github.com).
+//   DRIFT_BRANCH       Branch whose protection is compared (default `main`).
+//   DRIFT_HISTORY      How many recent commits on that branch are scanned for
+//                      posted check-run names (default 20).
+//   RELEASE_WORKFLOW   Path to the workflow holding the lists
+//                      (default .github/workflows/release.yml).
+//   argv `--self-test` runs the pure-logic assertions and exits.
+//
+// Exit: 0 when both directions are clean; 1 on any drift, a failed API read, or
+// an unparseable release.yml.
+
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import process from 'node:process';
+
+import { error, notice, log, appendStepSummary } from './lib/gh.mjs';
+
+// How far back the lane-drift scan looks. A single commit is not enough: lanes
+// legitimately condition themselves off (a docs-only push skips `check`), so
+// one commit's check-run set is a subset of the lane inventory, not the whole
+// of it. A name absent from EVERY commit in this window is dead, not skipped.
+const defaultHistoryCommits = 20;
+
+// GitHub caps `per_page` at 100 for both the commit list and the check-run list.
+const maxPerPage = 100;
+
+// A block scalar's content is indented deeper than its key; the first line at or
+// below the key's indentation ends it. Comment lines sit at the key's own
+// indentation in release.yml, so they terminate the scalar rather than becoming
+// content — which is why they need no stripping here.
+export function parseBlockScalar(yamlText, key) {
+  const lines = yamlText.split('\n');
+  const start = lines.findIndex((l) => new RegExp(`^(\\s*)${key}:\\s*\\|\\s*$`).test(l));
+  if (start === -1) return null;
+  const keyIndent = lines[start].length - lines[start].trimStart().length;
+  const items = [];
+  for (const line of lines.slice(start + 1)) {
+    if (line.trim() === '') continue;
+    const indent = line.length - line.trimStart().length;
+    if (indent <= keyIndent) break;
+    items.push(line.trim());
+  }
+  return items;
+}
+
+// parseCheckLists — pull the three lists out of release.yml. Throws rather than
+// returning a partial result: every caller below treats an empty list as
+// "nothing to compare", so a silent parse failure would report a clean bill of
+// health on a set it never read.
+export function parseCheckLists(yamlText) {
+  const required = parseBlockScalar(yamlText, 'RELEASE_REQUIRED_CHECKS');
+  const informational = parseBlockScalar(yamlText, 'RELEASE_INFORMATIONAL_CHECKS');
+  if (required === null) {
+    throw new Error('RELEASE_REQUIRED_CHECKS block scalar not found in the release workflow');
+  }
+  if (informational === null) {
+    throw new Error('RELEASE_INFORMATIONAL_CHECKS block scalar not found in the release workflow');
+  }
+  if (required.length === 0) {
+    throw new Error('RELEASE_REQUIRED_CHECKS parsed as empty — both drift checks would be vacuously green');
+  }
+  return { required, informational };
+}
+
+// Same prefix rule release-preflight.mjs applies, so "covered" here means
+// exactly what "not gated on" means there. Duplicating the semantics with a
+// different match would make this detector agree with a preflight that
+// disagrees with it.
+function isInformational(name, informational) {
+  return (informational ?? []).some((p) => p && name.startsWith(p));
+}
+
+// Direction A. A live required context is accounted for when the release either
+// WAITS for it (exact name in `required`) or has explicitly DE-GATED it (prefix
+// in `informational`). Anything else is a context the repo gates PRs on and the
+// release does not gate publishes on.
+export function protectionDrift({ liveContexts, required, informational }) {
+  const req = new Set(required);
+  return (liveContexts ?? [])
+    .filter((ctx) => !req.has(ctx) && !isInformational(ctx, informational))
+    .map(
+      (ctx) =>
+        `${ctx}: branch-protection REQUIRED context in neither RELEASE_REQUIRED_CHECKS nor ` +
+        `RELEASE_INFORMATIONAL_CHECKS — the release publishes without waiting for it. ` +
+        `Add it to the required set, or de-gate it explicitly with a reason.`,
+    );
+}
+
+// Direction B. `required` names are check-run display strings; `observed` is
+// every display string seen across the scanned window. A required name that
+// nothing posts is a name the preflight will block the next release waiting for.
+export function laneDrift({ required, observed }) {
+  const seen = new Set(observed ?? []);
+  return (required ?? [])
+    .filter((name) => !seen.has(name))
+    .map(
+      (name) =>
+        `${name}: RELEASE_REQUIRED_CHECKS name posted no check-run in the scanned window — ` +
+        `nothing produces it any more, so the next release will wait out its full ` +
+        `window on it and abort. Fix the name, or drop the lane from the required set.`,
+    );
+}
+
+async function apiJson(url, headers, what) {
+  const res = await fetch(url, { headers });
+  if (!res.ok) {
+    throw new Error(`${what}: HTTP ${res.status} ${res.statusText} for ${url}`);
+  }
+  return res.json();
+}
+
+async function main() {
+  const workflowPath = process.env.RELEASE_WORKFLOW || '.github/workflows/release.yml';
+  const branch = process.env.DRIFT_BRANCH || 'main';
+  const history = Number(process.env.DRIFT_HISTORY || defaultHistoryCommits);
+  const repo = process.env.GITHUB_REPOSITORY;
+  const token = process.env.GITHUB_TOKEN;
+  const apiBase = process.env.GITHUB_API_URL || 'https://api.github.com';
+
+  if (!repo) throw new Error('GITHUB_REPOSITORY is unset');
+  if (!token) throw new Error('GITHUB_TOKEN is unset — reading branch protection needs a repo-admin token');
+
+  const { required, informational } = parseCheckLists(readFileSync(workflowPath, 'utf8'));
+
+  const headers = {
+    Accept: 'application/vnd.github+json',
+    Authorization: `Bearer ${token}`,
+    'X-GitHub-Api-Version': '2022-11-28',
+  };
+
+  const protection = await apiJson(
+    `${apiBase}/repos/${repo}/branches/${encodeURIComponent(branch)}/protection`,
+    headers,
+    'read branch protection',
+  );
+  const liveContexts = protection?.required_status_checks?.contexts ?? [];
+  if (liveContexts.length === 0) {
+    throw new Error(
+      `branch protection on ${branch} reports zero required contexts — either protection was ` +
+        `removed or the token cannot see it; both make this check vacuous`,
+    );
+  }
+
+  const commits = await apiJson(
+    `${apiBase}/repos/${repo}/commits?sha=${encodeURIComponent(branch)}&per_page=${Math.min(history, maxPerPage)}`,
+    headers,
+    'list recent commits',
+  );
+
+  const observed = new Set();
+  for (const c of commits) {
+    const runs = await apiJson(
+      `${apiBase}/repos/${repo}/commits/${c.sha}/check-runs?per_page=${maxPerPage}`,
+      headers,
+      `read check-runs for ${c.sha}`,
+    );
+    for (const run of runs?.check_runs ?? []) observed.add(run.name);
+    for (const s of (await apiJson(`${apiBase}/repos/${repo}/commits/${c.sha}/status`, headers, 'read statuses'))
+      ?.statuses ?? []) {
+      observed.add(s.context);
+    }
+  }
+
+  const problems = [
+    ...protectionDrift({ liveContexts, required, informational }),
+    ...laneDrift({ required, observed: [...observed] }),
+  ];
+
+  appendStepSummary(
+    [
+      `## release gate drift — \`${branch}\``,
+      '',
+      `- branch-protection required contexts: **${liveContexts.length}**`,
+      `- \`RELEASE_REQUIRED_CHECKS\`: **${required.length}**`,
+      `- \`RELEASE_INFORMATIONAL_CHECKS\`: **${informational.length}**`,
+      `- commits scanned for posted lane names: **${commits.length}**`,
+      '',
+      problems.length === 0 ? 'No drift.' : problems.map((p) => `- ❌ ${p}`).join('\n'),
+    ].join('\n'),
+  );
+
+  if (problems.length > 0) {
+    for (const p of problems) error(p, { title: 'release gate drift' });
+    process.exit(1);
+  }
+
+  notice(
+    `release gate is in sync: ${liveContexts.length} protected context(s) all accounted for, ` +
+      `${required.length} required lane(s) all still posting across ${commits.length} commit(s)`,
+    { title: 'release gate drift' },
+  );
+}
+
+function selfTest() {
+  const yaml = [
+    '        env:',
+    '          RELEASE_REQUIRED_CHECKS: |',
+    '            check',
+    '            property (PromQL + LogQL + TraceQL, rapid N=500)',
+    '            migration-e2e',
+    '          # a comment at key indentation ends the scalar',
+    '          RELEASE_INFORMATIONAL_CHECKS: |',
+    '            compose-smoke-shard-info',
+    '            mutation',
+    '        steps:',
+  ].join('\n');
+
+  const { required, informational } = parseCheckLists(yaml);
+  assert.deepEqual(required, ['check', 'property (PromQL + LogQL + TraceQL, rapid N=500)', 'migration-e2e']);
+  assert.deepEqual(informational, ['compose-smoke-shard-info', 'mutation']);
+
+  // An unparseable / empty required set must throw, not compare against nothing.
+  assert.throws(() => parseCheckLists('env:\n  OTHER: |\n    x\n'), /RELEASE_REQUIRED_CHECKS block scalar not found/);
+  assert.throws(
+    () => parseCheckLists('  RELEASE_REQUIRED_CHECKS: |\nsteps:\n  RELEASE_INFORMATIONAL_CHECKS: |\n    m\n'),
+    /parsed as empty/,
+  );
+
+  // Direction A: covered exactly, covered by prefix, and uncovered.
+  assert.deepEqual(
+    protectionDrift({ liveContexts: ['check', 'mutation'], required, informational }),
+    [],
+    'an exact required name and a prefix-de-gated name are both accounted for',
+  );
+  const aDrift = protectionDrift({ liveContexts: ['check', 'brand-new-gate'], required, informational });
+  assert.equal(aDrift.length, 1, `expected exactly one problem, got: ${aDrift.join('; ')}`);
+  assert.match(aDrift[0], /^brand-new-gate: branch-protection REQUIRED context in neither/);
+
+  // Direction B: a name nothing posts, versus a full set that everything posts.
+  assert.deepEqual(laneDrift({ required, observed: required }), []);
+  const bDrift = laneDrift({ required, observed: ['check', 'migration-e2e'] });
+  assert.equal(bDrift.length, 1, `expected exactly one problem, got: ${bDrift.join('; ')}`);
+  assert.match(bDrift[0], /^property \(PromQL \+ LogQL \+ TraceQL, rapid N=500\): RELEASE_REQUIRED_CHECKS name posted no/);
+
+  // Negative control for the comma trap parseCheckList exists to avoid: the
+  // matrix name survives the block-scalar parse as ONE name, so it matches the
+  // one check-run that posts it. Split on `,` it would drift in direction B.
+  assert.deepEqual(
+    laneDrift({
+      required: ['property (PromQL + LogQL + TraceQL, rapid N=500)'],
+      observed: ['property (PromQL + LogQL + TraceQL, rapid N=500)'],
+    }),
+    [],
+  );
+
+  log('release-gate-drift self-test: OK');
+}
+
+if (process.argv.includes('--self-test')) {
+  selfTest();
+} else {
+  main().catch((e) => {
+    error(String(e?.message ?? e), { title: 'release gate drift' });
+    process.exit(1);
+  });
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -399,6 +399,16 @@ jobs:
       - name: release-preflight self-test (required-set guard)
         run: node --test .github/scripts/release-preflight.test.mjs
 
+      # Same reasoning one level out: release-gate-drift.yml is schedule-only, so
+      # its detector would otherwise go unexercised between weekly runs. The pure
+      # half — the release.yml block-scalar parse and the two drift comparisons —
+      # runs here. Its own negative controls matter most: a required name covered
+      # exactly, a protected context covered only by an informational PREFIX, and
+      # the `property (…, rapid N=500)` name surviving as ONE name, since a parser
+      # that split it would report permanent lane drift on a healthy repo.
+      - name: release-gate-drift self-test (gate rot detector)
+        run: node .github/scripts/release-gate-drift.mjs --self-test
+
       - name: brew-smoke self-test (formula-freshness guard)
         run: node --test .github/scripts/brew-smoke.test.mjs
 

--- a/.github/workflows/release-gate-drift.yml
+++ b/.github/workflows/release-gate-drift.yml
@@ -1,0 +1,52 @@
+name: release-gate-drift
+
+# Scheduled rot detector for the RELEASE GATE's expected check set.
+#
+# `release-preflight.mjs` blocks a publish until every name in release.yml's
+# `RELEASE_REQUIRED_CHECKS` has posted a green check-run. That list is
+# hand-maintained and only ever exercised mid-publish, so it rots in two
+# directions the preflight cannot see from the inside:
+#
+#   - branch protection gains a required context nobody added to the list, and
+#     the release publishes past a lane every PR has to pass;
+#   - a required name stops matching any lane that posts (a job renamed, a
+#     matrix leg reworded), and the next release waits out its full window on a
+#     check-run that never arrives, then aborts with the tag already cut.
+#
+# Both are one-line fixes when found here on a Tuesday and a broken publish when
+# found during one. The job is deliberately NOT a PR check: the drift it detects
+# comes from repo settings and from lanes over time, neither of which a PR diff
+# contains, so gating PRs on it would red them for something they did not do.
+on:
+  schedule:
+    # Tuesdays 06:00 UTC — a day offset from the weekly link check so the two
+    # scheduled reports do not land together.
+    - cron: '0 6 * * 2'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-gate-drift
+  cancel-in-progress: false
+
+jobs:
+  drift:
+    name: drift
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: drift self-test
+        run: node .github/scripts/release-gate-drift.mjs --self-test
+
+      # RELEASE_PAT, not the default GITHUB_TOKEN: reading a branch's protection
+      # settings requires repo-admin rights, which the workflow token does not
+      # have at any `permissions:` level. The script fails closed if the token
+      # cannot see the protection (zero contexts reads as "vacuous", not "clean").
+      - name: Compare the release gate against live branch protection
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: node .github/scripts/release-gate-drift.mjs

--- a/test/regression/release_gate_test.go
+++ b/test/regression/release_gate_test.go
@@ -326,3 +326,64 @@ func TestEOLRetireUsesTheTokenThatBypassesTheReleaseRuleset(t *testing.T) {
 			releaseWorkflowPath, retireStep)
 	}
 }
+
+// release-gate-drift.yml watches RELEASE_REQUIRED_CHECKS for rot: a protected
+// context nobody listed (the release publishes past a lane every PR must pass)
+// or a listed name nothing posts (the next release waits out its window and
+// aborts mid-publish). Being schedule-only, it has the same blind spot the
+// release workflow has — no PR ever runs it — so the ways it can degrade to
+// decoration are invisible in a diff:
+//
+//   - the live comparison step dropped, leaving only `--self-test`: the weekly
+//     run goes green every week while comparing nothing;
+//   - RELEASE_PAT swapped for the default GITHUB_TOKEN: branch protection is
+//     unreadable to github-actions[bot] at any `permissions:` level, so the job
+//     reds every week until someone deletes it as noise;
+//   - the schedule removed: the detector survives as a manual-dispatch button
+//     nobody presses.
+func TestReleaseGateDriftDetectorRunsLiveAndNotSelfTestOnly(t *testing.T) {
+	t.Parallel()
+
+	const (
+		driftWorkflowPath = "../../.github/workflows/release-gate-drift.yml"
+		driftScript       = "release-gate-drift.mjs"
+		selfTestFlag      = "--self-test"
+	)
+
+	body := readFileString(t, driftWorkflowPath)
+
+	if !strings.Contains(body, "schedule:") {
+		t.Fatalf("%s has no schedule: trigger. A rot detector that only runs on manual dispatch "+
+			"reports drift after the release it was meant to protect", driftWorkflowPath)
+	}
+
+	// The load-bearing assertion: at least one invocation WITHOUT the self-test
+	// flag. A file that mentions the script only inside a `--self-test` step is
+	// the exact hollow-green shape this pin exists to reject.
+	live := 0
+	for _, line := range strings.Split(body, "\n") {
+		if strings.Contains(line, driftScript) && !strings.Contains(line, selfTestFlag) {
+			live++
+		}
+	}
+	if live == 0 {
+		t.Fatalf("%s never runs %s without %s — the workflow proves its own logic and compares it "+
+			"against nothing, so the gate is green whatever branch protection says",
+			driftWorkflowPath, driftScript, selfTestFlag)
+	}
+
+	if !strings.Contains(body, "secrets.RELEASE_PAT") {
+		t.Fatalf("%s no longer passes secrets.RELEASE_PAT. Reading a branch's protection settings "+
+			"needs repo-admin rights, which the default GITHUB_TOKEN lacks at every permissions: "+
+			"level, so the live comparison cannot run at all", driftWorkflowPath)
+	}
+
+	// The pure half has to stay on a PR lane, for the same reason
+	// release-preflight.test.mjs does: otherwise a logic regression sits
+	// undetected until the next weekly run.
+	ci := readFileString(t, "../../.github/workflows/ci.yml")
+	if !strings.Contains(ci, driftScript+" "+selfTestFlag) {
+		t.Fatalf("ci.yml no longer runs %s %s. The detector's parse and both drift comparisons "+
+			"would then be unexercised between weekly runs", driftScript, selfTestFlag)
+	}
+}


### PR DESCRIPTION
## What

Adds `release-gate-drift.yml` — a weekly detector for rot in the EXPECTED check set that `release-preflight.mjs` gates every publish on.

## Why

`RELEASE_REQUIRED_CHECKS` is hand-maintained in `release.yml` and only ever exercised mid-publish. It rots in two directions the preflight structurally cannot see from the inside:

| Direction | What happens | Why the preflight is blind to it |
|---|---|---|
| **Protection drift** | Branch protection gains a required context that is in neither `RELEASE_REQUIRED_CHECKS` nor `RELEASE_INFORMATIONAL_CHECKS`. Every PR must pass it; the release does not wait for it. | The set is an allow-list of names to *wait for*. A name nobody listed is a name nobody waits for. Fails **silently, open**. |
| **Lane drift** | A required name stops matching any lane that posts — a job renamed, a matrix leg reworded. | The preflight waits out its full window on a check-run that never arrives, then aborts **with the tag already cut**. Fails closed, at the worst possible moment. |

`property (PromQL + LogQL + TraceQL, rapid N=500)` is the standing reminder that these are display strings, not identifiers.

## How

- **One copy of the data.** The lists are parsed out of `release.yml` itself, not duplicated into the script. An empty parse *throws* rather than comparing against nothing — a silently-empty set makes both checks vacuously green. Protection reporting zero contexts throws for the same reason: unreadable protection is not a clean bill of health.
- **Same prefix semantics as the preflight** for informational de-gating, so this detector cannot agree with a preflight that disagrees with it.
- **The lane-drift window spans many commits.** One commit's check-runs are a subset of the lane inventory (a docs-only push skips `check`), so a name absent from *every* commit in the window is dead, not skipped.
- **`RELEASE_PAT`, not the workflow token** — branch protection is unreadable to `github-actions[bot]` at every `permissions:` level.
- **Not a PR check.** The drift it detects comes from repo settings and from lanes over time; neither is in a PR diff, so gating PRs on it would red them for something they did not do.

## Verified against the live repo before wiring

Green today:

```
- branch-protection required contexts: 15
- RELEASE_REQUIRED_CHECKS: 18
- RELEASE_INFORMATIONAL_CHECKS: 2
- commits scanned for posted lane names: 20
No drift.
```

The 15 live contexts are all accounted for (`mutation` via the informational list), and all 18 required lane names — including the merge-only `compose-smoke` / `dashboard` / `profile` / `migration-e2e` — still post.

Both detectors then fired against real API data with `release.yml` doctored to add an unpostable lane and drop `coverage` from both lists (exit 1, one `::error::` each).

## Not letting the detector decay into decoration

No PR ever runs a scheduled workflow, so the ways this can go hollow are invisible in a diff. Two guards:

- `ci.yml` runs the pure half on every PR — the block-scalar parse plus both comparisons, with negative controls (a context covered only by an informational *prefix*; the `rapid N=500` name surviving as **one** name, since a parser that split it would report permanent lane drift on a healthy repo).
- `TestReleaseGateDriftDetectorRunsLiveAndNotSelfTestOnly` rejects a workflow that mentions the script only inside a `--self-test` step, drops the `schedule:` trigger, or swaps the admin token — the three shapes that stay green while comparing nothing.