### PR TITLE
fix(release): stop a backport publish from taking the Latest pointer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -264,8 +264,10 @@ jobs:
       # Whether THIS tag is the highest stable release (so we move the rolling
       # `:latest` images). A stable BACKPORT (e.g. v1.2.1 cut after v1.3.0) is
       # NOT highest -> `:latest` stays on v1.3.0. goreleaser reads this via
-      # `.Env.RELEASE_IS_LATEST` in the `latest-*` skip_push templates. Needs
-      # fetch-depth: 0 so all tags (including the one just pushed) are present.
+      # `.Env.RELEASE_IS_LATEST` in the `latest-*` skip_push templates, and the
+      # publish step below passes the same answer to `--latest` so the release
+      # pointer and the rolling images can never disagree. Needs fetch-depth: 0
+      # so all tags (including the one just pushed) are present.
       - name: Compute RELEASE_IS_LATEST
         env:
           TAG: ${{ needs.gate.outputs.app_tag }}
@@ -305,11 +307,18 @@ jobs:
       # WITH its assets. Publishing up-front (e.g. `gh release create`) would
       # lock it before goreleaser could upload — the 422 that broke v1.0.1.
       # Idempotent: a no-op if already published.
+      #
+      # `--latest` is passed EXPLICITLY: the GitHub release-update endpoint
+      # defaults `make_latest` to true, so a bare `--draft=false` hands
+      # /releases/latest to whichever release published most recently — which is
+      # how v1.11.3, a maintenance backport, took the pointer from v1.13.0.
+      # RELEASE_IS_LATEST already answers "is this the highest stable tag?" for
+      # the rolling `:latest` images; the same answer decides the pointer.
       - name: Publish release (flip draft -> published)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.gate.outputs.app_tag }}
-        run: gh release edit "${TAG}" --draft=false
+        run: gh release edit "${TAG}" --draft=false --latest="${RELEASE_IS_LATEST}"
 
       # Mirror README.md to the Docker Hub repo overview. Non-fatal: a stale
       # overview page must never turn an otherwise-published release red.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to cerberus will be documented in this file. The format roughly follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), with one entry per tagged release.
 
+## [Unreleased]
+
+## [v1.11.4] — 2026-07-28
+
+### Fixed
+
+- **release:** stop a maintenance backport publish from taking the GitHub `Latest` pointer — the draft-to-published flip defaulted `make_latest` to true, so /releases/latest followed publish order rather than version
+
 ## [v1.11.3] — 2026-07-28
 
 ### Fixed
@@ -16,8 +24,6 @@ All notable changes to cerberus will be documented in this file. The format roug
 
 - **loki:** reject a non-positive `?step=` on `/loki/api/v1/query_range` — `step=0` parses cleanly, so it reached the resolution-cap division and panicked with "integer divide by zero" (backport of #1298, tests #1300)
 - **tempo:** align the request window to the step grid and enforce the resolution ceiling on the gRPC `MetricsQueryRange` export — it returned samples off Tempo's grid and accepted an unbounded matrix fan-out (backport of #1298, tests #1300)
-
-## [Unreleased]
 
 ## [v1.11.1] — 2026-07-17
 

--- a/deploy/helm/cerberus/Chart.yaml
+++ b/deploy/helm/cerberus/Chart.yaml
@@ -8,11 +8,11 @@ type: application
 # upgrade?" and is the publish trigger: a chart-only fix bumps this without an
 # app re-tag; an app-only release bumps appVersion + a PATCH here for the new
 # default image. Starts 0.x because the values contract is not yet frozen.
-version: 0.11.3
+version: 0.11.4
 
 # appVersion tracks the GA cerberus binary. Quoted so SemVer-shaped values
 # aren't coerced to floats. image.tag defaults from this when left empty.
-appVersion: "1.11.3"
+appVersion: "1.11.4"
 
 # autoscaling/v2 + policy/v1 (PDB) + networking/v1 (Ingress) are all GA from
 # 1.21+; 1.23 is the conservative floor matching the manifests this chart
@@ -45,13 +45,9 @@ annotations:
       url: https://github.com/tsouza/cerberus/blob/main/docs/operations.md
   artifacthub.io/images: |
     - name: cerberus
-      image: ghcr.io/tsouza/cerberus:v1.11.3
+      image: ghcr.io/tsouza/cerberus:v1.11.4
   # Bump the `1.0.0` floor here when the chart raises its minimum supported
   # cerberus release; informational for Artifact Hub's compatibility hints.
   artifacthub.io/changes: |
     - kind: fixed
-      description: "promql: keep the @ pin in range mode on every range-vector lowering (backport #1325)"
-    - kind: fixed
-      description: "prom: bound windowless metadata discovery by real retention (backport #1327)"
-    - kind: fixed
-      description: "optimizer: keep AggFunc.Params through a constant fold (backport #1326)"
+      description: "release: stop a maintenance backport publish from taking the GitHub Latest pointer"

--- a/deploy/helm/cerberus/README.md
+++ b/deploy/helm/cerberus/README.md
@@ -5,7 +5,7 @@
      pipe-aligned, and the version footer adds a trailing blank — both are
      owned by helm-docs; realigning would fight the chart-ci drift check. -->
 
-![Version: 0.11.3](https://img.shields.io/badge/Version-0.11.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.11.3](https://img.shields.io/badge/AppVersion-1.11.3-informational?style=flat-square)
+![Version: 0.11.4](https://img.shields.io/badge/Version-0.11.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.11.4](https://img.shields.io/badge/AppVersion-1.11.4-informational?style=flat-square)
 
 Drop-in Prometheus / Loki / Tempo HTTP gateway for ClickHouse — a single stateless gateway that speaks three upstream query wire formats and lowers each to parameterised ClickHouse SQL.
 


### PR DESCRIPTION
## What

Pass `--latest="${RELEASE_IS_LATEST}"` on the draft→published flip in `release.yml`.

## Why

`gh release edit "${TAG}" --draft=false` ran bare. GitHub's release-update endpoint defaults `make_latest` to **true**, so `/releases/latest` goes to whichever release *published* most recently rather than to the highest version. v1.11.3 — a maintenance backport cut after v1.13.0 — therefore took the Latest pointer, which is what `https://github.com/tsouza/cerberus/releases/latest` and every "download the newest cerberus" link resolve to.

`RELEASE_IS_LATEST` is already computed in this job (tag == highest stable semver) to keep the rolling `:latest` container tags off backport releases. Feeding the same answer to `--latest` means the release pointer and the rolling images can never disagree — one signal, not two per-leg patches.

## Scope note

This line's `release.yml` predates the `release-artifact-migration` / `publish` / `brew-smoke` split on `main`. Those are deliberately **not** backported:

- `release-artifact-migration` drives `migration-e2e.yml` against the released image — neither the workflow nor the `cerberus migrate` CLI exists on 1.11.x, so there is nothing for it to verify.
- `brew-smoke` verifies the Homebrew formula — this line has no `brews:` block in `.goreleaser.yml` at all, so it never writes the tap and cannot hijack it. The tap hijack was 1.12.x-only.

That leaves the Latest pointer as the one real defect on this line, and this is the whole fix for it.

The regression pin that keeps the flip honest (`test/regression/release_gate_test.go`, asserting the flip passes `--latest=`) lives on `main`, where the file exists; every line cut from `main` inherits it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Cuts v1.11.4 / chart 0.11.4

Merging this PR **is** the release trigger — `release.yml` builds, publishes and tags on the push. The bump also restores the CHANGELOG's newest-first order on this line: the last backport sections had been prepended *above* `[Unreleased]`, stranding it mid-file.

This release is the live proof the fix works: once it publishes, `/releases/latest` must still resolve to **v1.13.1**, and `Formula/cerberus.rb` in the tap must still declare **1.13.1**.