### PR TITLE
fix(release): only the newest line takes Homebrew and the Latest pointer

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -323,31 +323,40 @@ One implementation means a new rule guards BOTH lanes at once.
   is the anti-vacuous check, because a deleted `brews:` block or an expired
   `HOMEBREW_TAP_GITHUB_TOKEN` leaves a STALE formula that a warm `brew install`
   would install happily. Then it branches EXPLICITLY on the release kind rather
-  than skipping: a stable `X.Y.Z` requires the formula to declare exactly that
-  version, then installs it and asserts the binary lands under `brew --prefix`,
+  than skipping: a stable `X.Y.Z` on the newest release line requires the
+  formula to declare exactly that version, then installs it and asserts the
+  binary lands under `brew --prefix`,
   that `cerberus --version` EQUALS the bare release version (string equality, so
   an off-by-`v` or a stale ldflag cannot pass a substring test), and that two
   OFFLINE payload verbs work — `migrate schema` (emits `CREATE` DDL) and
-  `config-docs -check` against `REPO_ROOT`'s `docs/configuration.md`. A
-  prerelease takes the negative branch: `.goreleaser.yml` sets
-  `skip_upload: auto`, so an `rc.*` must NOT have written a formula, and a
-  formula declaring the prerelease version is a reported regression. `migrate
-  gate` / `migrate verify` are deliberately unused — they exit non-zero on a
-  legitimate no-go, so they cannot distinguish a broken binary from a correct
-  verdict. Pure exports `isStableRelease(version)`, `formulaVersion(rbSource)`
-  (declaration, then archive-name fallback, then THROWS — an unparseable formula
-  never degrades into a pass) and `verdict({version, formulaSource})`, covered
-  by `brew-smoke.test.mjs` on the required `lint` lane and as the job's own
-  first step.
+  `config-docs -check` against `REPO_ROOT`'s `docs/configuration.md`. The other
+  two release shapes take negative branches, because `.goreleaser.yml`'s
+  `skip_upload` template keeps both out of the tap: an `rc.*` must NOT have
+  written a formula, and a release that is not the highest stable tag (a
+  maintenance backport) must have left a STRICTLY NEWER formula in place — the
+  regression that let v1.12.1, cut after v1.13.0, downgrade every
+  `brew install`. `migrate gate` / `migrate verify` are deliberately unused —
+  they exit non-zero on a legitimate no-go, so they cannot distinguish a broken
+  binary from a correct verdict. Pure exports `isStableRelease(version)`,
+  `formulaVersion(rbSource)` (declaration, then archive-name fallback, then
+  THROWS — an unparseable formula never degrades into a pass),
+  `compareVersions(a, b)` and `verdict({version, formulaSource, isLatest})`,
+  covered by `brew-smoke.test.mjs` on the required `lint` lane and as the job's
+  own first step.
   - Env: `RELEASE_VERSION` (the BARE `X.Y.Z[-rc.N]`, i.e.
     `needs.gate.outputs.app_version`, never the `v`-prefixed tag),
-    `GITHUB_TOKEN` (contents:read on the tap), `GITHUB_API_URL` (default
-    `https://api.github.com`), `REPO_ROOT` (checkout root, for the
-    `config-docs -check` payload).
-  - Exit: `0` when the formula state matches the release kind and (stable only)
-    the installed binary passes every assertion; `1` on a stale / missing /
-    unparseable formula, a prerelease formula that should not exist, a failed
-    install, a version mismatch, or a failing payload verb.
+    `RELEASE_IS_LATEST` (`"true"`/`"false"` — whether this is the highest stable
+    tag, i.e. the line that owns the tap's single formula; required, and
+    rejected unless it is exactly one of those two words, since it selects the
+    assertion branch), `GITHUB_TOKEN` (contents:read on the tap),
+    `GITHUB_API_URL` (default `https://api.github.com`), `REPO_ROOT`
+    (checkout root, for the `config-docs -check` payload).
+  - Exit: `0` when the formula state matches the release kind and (newest stable
+    line only) the installed binary passes every assertion; `1` on a stale /
+    missing / unparseable formula, a prerelease formula that should not exist, a
+    tap formula that a backport overwrote, a missing or unrecognised
+    `RELEASE_IS_LATEST`, a failed install, a version mismatch, or a failing
+    payload verb.
 - **`chart-kubeconform.mjs`** — `chart-ci.yml`, the `Render + kubeconform`
   step. Renders the chart for the default values and every `ci/*-values.yaml`
   fixture, schema-validates each manifest set with `kubeconform -strict`, and

--- a/.github/scripts/brew-smoke.mjs
+++ b/.github/scripts/brew-smoke.mjs
@@ -13,12 +13,16 @@
 // (`needs: publish`), never a retry loop and never `continue-on-error` — a
 // tolerated failure here is decoration, not a gate.
 //
-// PRERELEASES ARE NOT SKIPPED. `skip_upload: auto` in .goreleaser.yml means an
-// `rc.*` release writes NO formula, so the honest assertion for a prerelease is
-// the NEGATIVE one: the formula must still exist AND must NOT declare this
-// version. Bailing out on a "not applicable" flag would be `t.Skip` in workflow
-// clothing, and would wave through a `skip_upload` regression that started
-// publishing prerelease formulas to the stable tap.
+// NOTHING IS SKIPPED — the three releases shapes just get three assertions.
+// .goreleaser.yml's `skip_upload` template keeps two of them out of the tap, and
+// for those the honest assertion is the NEGATIVE one. Bailing out on a "not
+// applicable" flag would be `t.Skip` in workflow clothing, and would wave
+// through the very `skip_upload` regressions this job exists to catch:
+//   - newest line + stable — the formula must declare EXACTLY this version;
+//   - prerelease (`rc.*`)  — the formula must exist and must NOT declare it;
+//   - not the highest stable tag (a maintenance backport) — the formula must
+//     declare a STRICTLY NEWER version, proving this publish did not overwrite
+//     the newest line's. v1.12.1, cut after v1.13.0, did exactly that.
 //
 // ANTI-VACUOUS: the formula's declared version is compared to the release
 // version BEFORE `brew install` runs. That reads the tap's git state through
@@ -43,15 +47,20 @@
 //                     `1.11.2-rc.1`) — release.yml passes
 //                     `needs.gate.outputs.app_version`, which is the de-`v`'d
 //                     form the binary itself reports.
+//   RELEASE_IS_LATEST "true"/"false" — whether this tag is the highest stable
+//                     release, i.e. the line that owns the single shared tap
+//                     formula. Selects the assertion branch, so it is required
+//                     and has no default.
 //   GITHUB_TOKEN      token used to read the tap's formula via the contents API.
 //   GITHUB_API_URL    API base (default https://api.github.com).
 //   REPO_ROOT         checkout of the release commit — the working directory for
 //                     the `config-docs -check` payload run.
 //
-// Exit: 0 when every assertion for the branch taken holds; 1 on any missing env
-// var, an unreadable/unparseable formula, a formula-version mismatch (stable) or
-// match (prerelease), a failed install, a binary resolved outside the brew
-// prefix, a `--version` mismatch, or a failing payload verb.
+// Exit: 0 when every assertion for the branch taken holds; 1 on any missing or
+// unrecognised env var, an unreadable/unparseable formula, a formula-version
+// mismatch (newest + stable), match (prerelease) or not-newer-than-us
+// (maintenance), a failed install, a binary resolved outside the brew prefix, a
+// `--version` mismatch, or a failing payload verb.
 //
 // Imports only node: builtins. Run with `node .github/scripts/brew-smoke.mjs`.
 
@@ -111,36 +120,82 @@ export function formulaVersion(rbSource) {
   );
 }
 
-// verdict — the pure decision both branches share. Returns:
-//   mustInstall — true for a stable release (the formula is expected to declare
-//                 this version and `brew install` must work), false for a
-//                 prerelease (no formula is published for it).
+// compareVersions — semver-enough ordering for the two shapes goreleaser ever
+// puts in play: `X.Y.Z` and `X.Y.Z-<prerelease>`. Numeric triple first, then a
+// version WITH a prerelease suffix sorts below the same triple without one.
+// Returns <0, 0, >0. A non-numeric component sorts as 0 rather than NaN so a
+// malformed input can never make an ordering assertion vacuously true.
+export function compareVersions(a, b) {
+  const parts = (s) =>
+    String(s ?? '')
+      .trim()
+      .split('-', 1)[0]
+      .split('.')
+      .map((n) => (/^\d+$/.test(n) ? Number(n) : 0));
+  const pre = (s) => String(s ?? '').trim().includes('-');
+
+  const [pa, pb] = [parts(a), parts(b)];
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const d = (pa[i] ?? 0) - (pb[i] ?? 0);
+    if (d !== 0) return d < 0 ? -1 : 1;
+  }
+  if (pre(a) === pre(b)) return 0;
+  return pre(a) ? -1 : 1;
+}
+
+// verdict — the pure decision every branch shares. Takes `isLatest`: whether the
+// release being smoked is the highest stable tag in the repo, i.e. whether it is
+// the line that OWNS the single shared tap formula. Returns:
+//   mustInstall — true only when the tap is expected to declare exactly this
+//                 version (newest line + stable), so `brew install` must work.
+//                 False on the two branches where goreleaser deliberately wrote
+//                 no formula — each of which still gets its own assertion below,
+//                 never a bail-out.
 //   problems    — blocking problem strings; empty == the tap is in the state
 //                 this release requires.
-export function verdict({ version, formulaSource }) {
+export function verdict({ version, formulaSource, isLatest }) {
   const v = String(version ?? '').trim();
   const declared = formulaVersion(formulaSource);
   const stable = isStableRelease(v);
+  const newest = isLatest === true || String(isLatest).trim() === 'true';
   const problems = [];
 
-  if (stable) {
-    if (declared !== v) {
+  // Order matters: a PRERELEASE is never the highest stable tag, so it arrives
+  // here with newest === false. Testing it first keeps the forward `v1.14.0-rc.1`
+  // case (tap legitimately behind at v1.13.1) out of the maintenance branch's
+  // "the tap must be ahead of us" assertion, which only holds for backports.
+  if (!stable) {
+    if (declared === v) {
       problems.push(
-        `${TAP_REPO}:${TAP_FORMULA_PATH} declares version "${declared}" but this release is "${v}". ` +
-          `The formula was never pushed, or the push landed stale — goreleaser's brews block, ` +
-          `HOMEBREW_TAP_GITHUB_TOKEN, or the cross-repo write is broken. ` +
-          `\`brew install ${FORMULA_REF}\` would install the wrong version.`,
+        `${TAP_REPO}:${TAP_FORMULA_PATH} declares prerelease version "${v}". ` +
+          `.goreleaser.yml sets \`skip_upload: auto\`, so a prerelease must write NO formula — ` +
+          `the stable tap is now pointing operators at a prerelease.`,
       );
     }
-  } else if (declared === v) {
+  } else if (!newest) {
+    // MAINTENANCE branch. `skip_upload` resolves to "true" off RELEASE_IS_LATEST,
+    // so this publish must have left the tap alone — and the tap must still be
+    // ahead of it. `declared === v` is the exact regression that shipped v1.12.1
+    // over a v1.13.0 formula and downgraded every `brew install`.
+    if (compareVersions(declared, v) <= 0) {
+      problems.push(
+        `${TAP_REPO}:${TAP_FORMULA_PATH} declares version "${declared}", which is not newer than this ` +
+          `maintenance release "${v}". This release is not the highest stable tag, so .goreleaser.yml's ` +
+          `\`skip_upload\` template must have kept it out of the tap and left the newest line's formula ` +
+          `in place. \`brew install ${FORMULA_REF}\` now installs an older cerberus than the newest ` +
+          `released line.`,
+      );
+    }
+  } else if (declared !== v) {
     problems.push(
-      `${TAP_REPO}:${TAP_FORMULA_PATH} declares prerelease version "${v}". ` +
-        `.goreleaser.yml sets \`skip_upload: auto\`, so a prerelease must write NO formula — ` +
-        `the stable tap is now pointing operators at a prerelease.`,
+      `${TAP_REPO}:${TAP_FORMULA_PATH} declares version "${declared}" but this release is "${v}". ` +
+        `The formula was never pushed, or the push landed stale — goreleaser's brews block, ` +
+        `HOMEBREW_TAP_GITHUB_TOKEN, or the cross-repo write is broken. ` +
+        `\`brew install ${FORMULA_REF}\` would install the wrong version.`,
     );
   }
 
-  return { mustInstall: stable, problems };
+  return { mustInstall: newest && stable, problems };
 }
 
 // ---------------------------------------------------------------------------
@@ -184,11 +239,22 @@ function describe(res) {
 
 async function main() {
   const version = (process.env.RELEASE_VERSION ?? '').trim();
+  const isLatestRaw = (process.env.RELEASE_IS_LATEST ?? '').trim();
   const token = process.env.GITHUB_TOKEN;
   const apiBase = process.env.GITHUB_API_URL || 'https://api.github.com';
   const repoRoot = process.env.REPO_ROOT;
 
   if (!version) fail('RELEASE_VERSION is required (the BARE published version, e.g. 1.11.2)');
+  // Required, and required to be one of exactly two words. Defaulting a missing
+  // value either way would silently pick an assertion branch: absent-means-false
+  // would stop asserting the tap was written on every mainline release, and
+  // absent-means-true would demand a formula a backport never wrote.
+  if (isLatestRaw !== 'true' && isLatestRaw !== 'false') {
+    fail(
+      `RELEASE_IS_LATEST must be exactly "true" or "false" (got "${isLatestRaw}") — it selects which ` +
+        `state the tap is asserted to be in, so it has no safe default.`,
+    );
+  }
   if (!token) fail('GITHUB_TOKEN is required to read the tap formula');
   if (!repoRoot) fail('REPO_ROOT is required — the `config-docs -check` payload runs against this commit\'s docs');
 
@@ -213,7 +279,7 @@ async function main() {
 
   let decision;
   try {
-    decision = verdict({ version, formulaSource });
+    decision = verdict({ version, formulaSource, isLatest: isLatestRaw });
   } catch (e) {
     fail(e.message);
   }
@@ -222,11 +288,15 @@ async function main() {
   if (decision.problems.length > 0) process.exit(1);
 
   if (!decision.mustInstall) {
-    // PRERELEASE branch — asserted, not skipped. The formula exists and does NOT
-    // declare this version, which is exactly what `skip_upload: auto` promises.
+    // NO-FORMULA branches — asserted above, not skipped. `verdict` has already
+    // proved the tap is in the state this release requires: for a prerelease,
+    // that it does NOT declare this version; for a maintenance backport, that it
+    // still declares a strictly newer one. Installing here would smoke the
+    // NEWEST line's binary and report it as this release's, which is worse than
+    // not installing.
     ghNotice(
-      `brew-smoke: prerelease ${version}: the tap correctly still declares ` +
-        `"${formulaVersion(formulaSource)}"; no formula is published for prereleases (skip_upload: auto).`,
+      `brew-smoke: ${version} did not write the tap (${isLatestRaw === 'true' ? 'prerelease' : 'not the highest stable tag'}); ` +
+        `the tap correctly still declares "${formulaVersion(formulaSource)}".`,
     );
     process.exit(0);
   }

--- a/.github/scripts/brew-smoke.test.mjs
+++ b/.github/scripts/brew-smoke.test.mjs
@@ -4,18 +4,20 @@
 //
 // release.yml has no `pull_request:` trigger, so without this suite every edit
 // to the smoke would be unverified until a release is cut. The cases below pin
-// the three ways the smoke could go hollow:
+// the four ways the smoke could go hollow:
 //
 //   1. a stale/never-pushed formula reported as fine (the goreleaser `brews:`
 //      regression the whole job exists to catch);
-//   2. a prerelease branch that bails out instead of asserting — `t.Skip` in
+//   2. a no-formula branch that bails out instead of asserting — `t.Skip` in
 //      workflow clothing, which would wave through a `skip_upload` regression;
-//   3. an unparseable formula degrading into "couldn't tell, so pass".
+//   3. an unparseable formula degrading into "couldn't tell, so pass";
+//   4. a maintenance backport silently overwriting the newest line's formula,
+//      which is what v1.12.1 did to v1.13.0's.
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { isStableRelease, formulaVersion, verdict } from './brew-smoke.mjs';
+import { isStableRelease, formulaVersion, verdict, compareVersions } from './brew-smoke.mjs';
 
 // A minimal stand-in for what goreleaser writes into the tap.
 function formula(version) {
@@ -65,50 +67,156 @@ test('an unparseable formula THROWS rather than passing', () => {
   assert.throws(() => formulaVersion(undefined), /could not determine the version/);
 });
 
-test('stable + matching formula: no problems, install required', () => {
-  const v = verdict({ version: '1.11.2', formulaSource: formula('1.11.2') });
-  assert.deepEqual(v.problems, []);
-  assert.equal(v.mustInstall, true);
-});
+// The release-shape vocabulary the whole table is written in. `verdict` only
+// ever compares two versions, so what each case pins is the RELATION between
+// them — naming the versions keeps that relation on the page instead of leaving
+// the reader to diff two literals.
+const RELEASED = '1.12.1'; // the version being smoked
+const SAME = RELEASED; // the tap serving exactly it
+const OLDER = '1.11.3'; // the tap left behind
+const NEWER = '1.13.0'; // the tap already on a higher line
+const RC = '1.12.1-rc.1'; // a prerelease of RELEASED
+const FORWARD_RC = '1.14.0-rc.1'; // a prerelease ABOVE everything released
 
-test('stable + STALE formula: blocked before brew is ever invoked', () => {
-  // The regression: brews block deleted, HOMEBREW_TAP_GITHUB_TOKEN expired, or
-  // the cross-repo push silently failed. The tap keeps declaring the previous
-  // version. A warm brew cache cannot mask this — it is read from the tap's git
-  // state, not from brew.
-  const v = verdict({ version: '1.11.2', formulaSource: formula('1.11.1') });
-  assert.equal(v.problems.length, 1, `expected exactly one problem, got: ${v.problems.join('; ')}`);
-  assert.match(v.problems[0], /declares version "1\.11\.1" but this release is "1\.11\.2"/);
-  assert.equal(v.mustInstall, true, 'a stale formula does not excuse skipping the install branch');
-});
+// Each row: what the tap declares, what is being released, whether the release
+// is the highest stable tag, and the state that combination must be reported in.
+// `problem` null means "this is the healthy state"; a string means the case must
+// be blocked, and blocked for the stated reason rather than incidentally.
+const VERDICT_CASES = [
+  {
+    name: 'newest line + stable + the tap serving exactly it — the only shape that installs',
+    tap: SAME,
+    release: RELEASED,
+    isLatest: 'true',
+    mustInstall: true,
+    problem: null,
+  },
+  {
+    name: 'newest line + a STALE tap — blocked before brew is ever invoked',
+    // The regression: brews block deleted, HOMEBREW_TAP_GITHUB_TOKEN expired, or
+    // the cross-repo push silently failed, so the tap keeps declaring the
+    // previous version. Read from the tap's git state, so a warm brew cache
+    // cannot mask it.
+    tap: OLDER,
+    release: RELEASED,
+    isLatest: 'true',
+    mustInstall: true, // a stale formula does not excuse skipping the install branch
+    problem: `declares version "${OLDER}" but this release is "${RELEASED}"`,
+  },
+  {
+    name: 'prerelease + a tap on the last stable — healthy, asserted rather than skipped',
+    // `skip_upload` wrote no formula, so the tap legitimately still declares an
+    // older version.
+    tap: OLDER,
+    release: RC,
+    isLatest: 'false',
+    mustInstall: false,
+    problem: null,
+  },
+  {
+    name: 'prerelease the tap actually PUBLISHED — the skip_upload regression',
+    tap: RC,
+    release: RC,
+    isLatest: 'false',
+    mustInstall: false,
+    problem: `declares prerelease version "${RC}"`,
+  },
+  {
+    name: 'forward prerelease above a legitimately BEHIND tap — prerelease branch, not maintenance',
+    // RELEASE_IS_LATEST compares against the highest STABLE tag, so every rc
+    // arrives with isLatest=false while the tap sits below it. Testing the
+    // version shape first is what keeps the maintenance branch's "the tap must
+    // be ahead of us" rule — true only for backports — off every rc.
+    tap: NEWER,
+    release: FORWARD_RC,
+    isLatest: 'false',
+    mustInstall: false,
+    problem: null,
+  },
+  {
+    name: 'maintenance backport under a NEWER tap — healthy, and deliberately no install',
+    // Installing here would smoke the newest line's binary and report it as this
+    // release's.
+    tap: NEWER,
+    release: RELEASED,
+    isLatest: 'false',
+    mustInstall: false,
+    problem: null,
+  },
+  {
+    name: 'maintenance backport that OVERWROTE the tap — the v1.12.1-over-v1.13.0 regression',
+    // `skip_upload: auto` alone does not filter a stable backport, so goreleaser
+    // wrote the older line's formula over the newer one and every `brew install`
+    // started downgrading.
+    tap: SAME,
+    release: RELEASED,
+    isLatest: 'false',
+    mustInstall: false,
+    problem: `declares version "${SAME}", which is not newer than this maintenance release "${RELEASED}"`,
+  },
+  {
+    name: 'maintenance backport over an OLDER tap — a different cause, the same broken outcome',
+    tap: OLDER,
+    release: RELEASED,
+    isLatest: 'false',
+    mustInstall: false,
+    problem: 'not newer than this maintenance release',
+  },
+];
 
-test('prerelease + older formula: no problems, and NO install', () => {
-  // `skip_upload: auto` means the prerelease wrote no formula, so the tap still
-  // declares the last stable. That is the healthy state — asserted, not skipped.
-  const v = verdict({ version: '1.12.0-rc.1', formulaSource: formula('1.11.2') });
-  assert.deepEqual(v.problems, []);
-  assert.equal(v.mustInstall, false);
-});
-
-test('prerelease + formula carrying THIS version: the skip_upload regression', () => {
-  const v = verdict({ version: '1.12.0-rc.1', formulaSource: formula('1.12.0-rc.1') });
-  assert.equal(v.problems.length, 1, `expected exactly one problem, got: ${v.problems.join('; ')}`);
-  assert.match(v.problems[0], /declares prerelease version "1\.12\.0-rc\.1"/);
-  assert.match(v.problems[0], /skip_upload: auto/);
-  assert.equal(v.mustInstall, false);
-});
+for (const c of VERDICT_CASES) {
+  test(`verdict: ${c.name}`, () => {
+    const v = verdict({ version: c.release, formulaSource: formula(c.tap), isLatest: c.isLatest });
+    if (c.problem === null) {
+      assert.deepEqual(v.problems, [], 'expected the healthy state');
+    } else {
+      assert.equal(v.problems.length, 1, `expected exactly one problem, got: ${v.problems.join('; ')}`);
+      assert.ok(v.problems[0].includes(c.problem), `expected a problem naming \`${c.problem}\`, got: ${v.problems[0]}`);
+    }
+    assert.equal(v.mustInstall, c.mustInstall);
+  });
+}
 
 test('verdict is comparing the BARE version, so a `v`-prefixed input cannot pass', () => {
   // The off-by-`v` trap: release.yml must pass `needs.gate.outputs.app_version`
   // (bare), never `app_tag`. If it ever passed the tag, the stable branch's
   // equality check fails loudly here rather than being papered over by a
   // substring match.
-  const v = verdict({ version: 'v1.11.2', formulaSource: formula('1.11.2') });
+  const v = verdict({ version: `v${RELEASED}`, formulaSource: formula(SAME), isLatest: 'true' });
   assert.equal(v.mustInstall, false, 'a `v`-prefixed string is not a stable app version');
   assert.deepEqual(v.problems, [], 'and it does not collide with the formula version either');
 });
 
 test('an unparseable formula propagates out of verdict on both branches', () => {
-  assert.throws(() => verdict({ version: '1.11.2', formulaSource: 'garbage' }), /could not determine the version/);
-  assert.throws(() => verdict({ version: '1.12.0-rc.1', formulaSource: 'garbage' }), /could not determine the version/);
+  assert.throws(() => verdict({ version: RELEASED, formulaSource: 'garbage', isLatest: 'true' }), /could not determine the version/);
+  assert.throws(() => verdict({ version: RC, formulaSource: 'garbage', isLatest: 'false' }), /could not determine the version/);
+});
+
+test('compareVersions orders the two shapes goreleaser produces', () => {
+  assert.equal(compareVersions('1.13.0', '1.12.1'), 1);
+  assert.equal(compareVersions('1.12.1', '1.13.0'), -1);
+  assert.equal(compareVersions('1.12.1', '1.12.1'), 0);
+  assert.equal(compareVersions('1.13.0', '1.9.9'), 1, 'numeric, not lexicographic');
+  assert.equal(compareVersions('2.0.0', '1.99.99'), 1);
+
+  // A prerelease sorts below the same triple released.
+  assert.equal(compareVersions('1.13.0-rc.1', '1.13.0'), -1);
+  assert.equal(compareVersions('1.13.0', '1.13.0-rc.1'), 1);
+  assert.equal(compareVersions('1.14.0-rc.1', '1.13.1'), 1);
+
+  // Malformed components sort as 0 rather than NaN: NaN comparisons are all
+  // false, which would make `compareVersions(declared, v) <= 0` silently pass.
+  assert.equal(compareVersions('garbage', '1.0.0'), -1);
+  assert.equal(compareVersions(undefined, '0.0.0'), 0);
+});
+
+test('isLatest is read strictly: only the exact string "true" owns the formula', () => {
+  // The driver rejects anything that is not "true"/"false" before reaching here,
+  // but verdict must not treat a truthy-looking value as the newest line either
+  // — that would restore the equality assertion for a backport and demand a
+  // formula it deliberately never wrote.
+  const backport = { version: RELEASED, formulaSource: formula(NEWER) };
+  assert.equal(verdict({ ...backport, isLatest: true }).problems.length, 1, 'boolean true is the newest line');
+  assert.deepEqual(verdict({ ...backport, isLatest: 'false' }).problems, []);
+  assert.deepEqual(verdict({ ...backport, isLatest: '' }).problems, [], 'not "true" means not the newest line');
 });

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -248,6 +248,12 @@ jobs:
       packages: write
       id-token: write
       attestations: write
+    outputs:
+      # Whether this tag is the highest stable release. Downstream jobs decide
+      # what the newest line alone may own (the GitHub `Latest` pointer, the
+      # Homebrew formula) off this, so it has to leave the job, not just the
+      # step.
+      is_latest: ${{ steps.is_latest.outputs.is_latest }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -305,23 +311,34 @@ jobs:
             echo "created + pushed ${TAG} at ${GITHUB_SHA}"
           fi
 
-      # Whether THIS tag is the highest stable release (so we move the rolling
-      # `:latest` images). A stable BACKPORT (e.g. v1.2.1 cut after v1.3.0) is
-      # NOT highest -> `:latest` stays on v1.3.0. goreleaser reads this via
-      # `.Env.RELEASE_IS_LATEST` in the `latest-*` skip_push templates. Needs
-      # fetch-depth: 0 so all tags (including the one just pushed) are present.
+      # Whether THIS tag is the highest stable release — the single "is this the
+      # newest line?" signal every downstream owner-of-a-shared-resource decision
+      # reads. A stable BACKPORT (e.g. v1.2.1 cut after v1.3.0) is NOT highest,
+      # and must not take:
+      #   - the rolling `:latest` images (goreleaser's `latest-*` skip_push
+      #     templates read `.Env.RELEASE_IS_LATEST`);
+      #   - the Homebrew formula (`brews[].skip_upload`, same env var) — `auto`
+      #     alone only filters prereleases, so v1.12.1 downgraded the tap from
+      #     v1.13.0;
+      #   - the GitHub `Latest` release pointer (the `publish` job's flip), which
+      #     otherwise follows publish ORDER and left /releases/latest on v1.11.3.
+      # Needs fetch-depth: 0 so all tags (including the one just pushed) are
+      # present.
       - name: Compute RELEASE_IS_LATEST
+        id: is_latest
         env:
           TAG: ${{ needs.gate.outputs.app_tag }}
         run: |
           tag="${TAG#v}"
           highest=$(git tag -l 'v*.*.*' | awk '!/-/' | sed 's/^v//' | sort -V | tail -1)
           if [ "$tag" = "$highest" ]; then
-            echo "RELEASE_IS_LATEST=true" >> "$GITHUB_ENV"
+            is_latest=true
           else
-            echo "RELEASE_IS_LATEST=false" >> "$GITHUB_ENV"
+            is_latest=false
           fi
-          echo "tag=$tag highest_stable=$highest RELEASE_IS_LATEST set accordingly"
+          echo "RELEASE_IS_LATEST=${is_latest}" >> "$GITHUB_ENV"
+          echo "is_latest=${is_latest}" >> "$GITHUB_OUTPUT"
+          echo "tag=$tag highest_stable=$highest RELEASE_IS_LATEST=${is_latest}"
 
       - id: goreleaser
         uses: goreleaser/goreleaser-action@v7
@@ -414,11 +431,18 @@ jobs:
       # Publishing up-front (e.g. `gh release create`) would lock it before
       # goreleaser could upload — the 422 that broke v1.0.1.
       # Idempotent: a no-op if already published.
+      #
+      # `--latest` is explicit, not decoration: GitHub's update endpoint defaults
+      # `make_latest` to true, so the flip hands /releases/latest to whichever
+      # release published MOST RECENTLY. Cutting v1.11.3 after v1.13.0 therefore
+      # pointed the repo's Latest badge — and `gh release download` with no tag —
+      # at the oldest supported line. Only the highest stable tag takes it.
       - name: Publish release (flip draft -> published)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.gate.outputs.app_tag }}
-        run: gh release edit "${TAG}" --draft=false
+          IS_LATEST: ${{ needs.goreleaser.outputs.is_latest }}
+        run: gh release edit "${TAG}" --draft=false --latest="${IS_LATEST}"
 
       # Mirror README.md to the Docker Hub repo overview. Non-fatal: a stale
       # overview page must never turn an otherwise-published release red.
@@ -439,12 +463,14 @@ jobs:
   # fixes for that 404 — a retry loop, `continue-on-error` — would ship the
   # release unverified and green, so the fix is to run after the flip.
   #
-  # Prereleases are NOT skipped. `skip_upload: auto` means an `rc.*` writes no
-  # formula, so brew-smoke.mjs takes the NEGATIVE branch instead: the formula
-  # must exist and must NOT declare this version.
+  # Neither prereleases nor maintenance backports are skipped — each just gets a
+  # different assertion, because `skip_upload` keeps both out of the tap:
+  #   - prerelease: the formula must exist and must NOT declare this version;
+  #   - not the highest stable tag: the formula must declare a STRICTLY NEWER
+  #     version, proving this publish did not overwrite the newest line's.
   brew-smoke:
     name: brew-smoke
-    needs: [gate, publish]
+    needs: [gate, goreleaser, publish]
     if: |
       always() &&
       needs.gate.outputs.app_publish == 'true' &&
@@ -466,6 +492,9 @@ jobs:
           # The BARE version. Comparing `cerberus --version` to `app_tag` would
           # be a guaranteed off-by-`v` mismatch.
           RELEASE_VERSION: ${{ needs.gate.outputs.app_version }}
+          # The same signal that decided whether goreleaser wrote the formula at
+          # all, so the smoke asserts the branch the tap actually took.
+          RELEASE_IS_LATEST: ${{ needs.goreleaser.outputs.is_latest }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO_ROOT: ${{ github.workspace }}
         run: node .github/scripts/brew-smoke.mjs

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -40,10 +40,10 @@ archives:
       - CHANGELOG.md
 
 # Homebrew formula published to the tsouza/homebrew-tap tap, so operators can
-# `brew install tsouza/tap/cerberus`. skip_upload: auto means prereleases
-# (rc.*) never write a formula — only stable releases publish. The cross-repo
-# push needs a PAT (the default GITHUB_TOKEN cannot push to another repo); it is
-# supplied by the HOMEBREW_TAP_GITHUB_TOKEN secret wired in release.yml.
+# `brew install tsouza/tap/cerberus`. The tap holds ONE cerberus formula, so
+# only stable releases on the newest line write it — see skip_upload below. The
+# cross-repo push needs a PAT (the default GITHUB_TOKEN cannot push to another
+# repo); it is supplied by the HOMEBREW_TAP_GITHUB_TOKEN secret in release.yml.
 #
 # We use `brews:` (a Homebrew FORMULA), not `homebrew_casks:`, on purpose:
 # goreleaser is nudging toward casks, but casks are macOS-only, and cerberus is
@@ -56,10 +56,24 @@ brews:
       owner: tsouza
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    # Homebrew resolves a tap's formulae from `Formula/`, `HomebrewFormula/`,
+    # or the tap root, in that order — but goreleaser's `directory` defaults to
+    # EMPTY, i.e. the tap root, so v1.12.0 shipped `cerberus.rb` to the root.
+    # `Formula/` is the conventional layout, it is what `brew-smoke.mjs` pins
+    # (`TAP_FORMULA_PATH`), and it is the only one of the three that is not at
+    # risk from Homebrew's ongoing push to standardise tap layout. Pin it.
+    directory: Formula
     homepage: "https://github.com/tsouza/cerberus"
     description: "Drop-in Prometheus / Loki / Tempo HTTP gateway for ClickHouse"
     license: "Apache-2.0"
-    skip_upload: auto
+    # `auto` on its own only keeps PRERELEASES out of the tap. A stable
+    # BACKPORT is not a prerelease, so `auto` alone let v1.12.1 — cut after
+    # v1.13.0 — write the tap formula and DOWNGRADE every `brew install` to the
+    # older line. Gate on RELEASE_IS_LATEST too (release.yml computes it from
+    # the highest stable tag, the same signal the rolling `:latest` images use),
+    # so only the newest release line ever owns the formula. `skip_upload` is
+    # templated in goreleaser's run phase and read back at publish time.
+    skip_upload: '{{ if eq .Env.RELEASE_IS_LATEST "true" }}auto{{ else }}true{{ end }}'
     install: |
       bin.install "cerberus"
     test: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to cerberus will be documented in this file. The format roughly follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), with one entry per tagged release.
 
+## [Unreleased]
+
+## [v1.12.2] — 2026-07-28
+
+### Fixed
+
+- **release:** only the newest release line takes the Homebrew formula and the GitHub `Latest` pointer (backport of #1335)
+
 ## [v1.12.1] — 2026-07-28
 
 ### Fixed
@@ -9,8 +17,6 @@ All notable changes to cerberus will be documented in this file. The format roug
 - **promql:** keep the `@` pin in range mode on every range-vector lowering (backport of #1325)
 - **prom:** bound windowless metadata discovery by real retention (backport of #1327)
 - **optimizer:** keep AggFunc.Params through a constant fold (backport of #1326)
-
-## [Unreleased]
 
 ## [v1.12.0] — 2026-07-27
 

--- a/deploy/helm/cerberus/Chart.yaml
+++ b/deploy/helm/cerberus/Chart.yaml
@@ -8,11 +8,11 @@ type: application
 # upgrade?" and is the publish trigger: a chart-only fix bumps this without an
 # app re-tag; an app-only release bumps appVersion + a PATCH here for the new
 # default image. Starts 0.x because the values contract is not yet frozen.
-version: 0.12.1
+version: 0.12.2
 
 # appVersion tracks the GA cerberus binary. Quoted so SemVer-shaped values
 # aren't coerced to floats. image.tag defaults from this when left empty.
-appVersion: "1.12.1"
+appVersion: "1.12.2"
 
 # autoscaling/v2 + policy/v1 (PDB) + networking/v1 (Ingress) are all GA from
 # 1.21+; 1.23 is the conservative floor matching the manifests this chart
@@ -45,13 +45,9 @@ annotations:
       url: https://github.com/tsouza/cerberus/blob/main/docs/operations.md
   artifacthub.io/images: |
     - name: cerberus
-      image: ghcr.io/tsouza/cerberus:v1.12.1
+      image: ghcr.io/tsouza/cerberus:v1.12.2
   # Bump the `1.0.0` floor here when the chart raises its minimum supported
   # cerberus release; informational for Artifact Hub's compatibility hints.
   artifacthub.io/changes: |
     - kind: fixed
-      description: "promql: keep the @ pin in range mode on every range-vector lowering (backport #1325)"
-    - kind: fixed
-      description: "prom: bound windowless metadata discovery by real retention (backport #1327)"
-    - kind: fixed
-      description: "optimizer: keep AggFunc.Params through a constant fold (backport #1326)"
+      description: "release: only the newest release line takes the Homebrew formula and the GitHub Latest pointer (backport #1335)"

--- a/deploy/helm/cerberus/README.md
+++ b/deploy/helm/cerberus/README.md
@@ -5,7 +5,7 @@
      pipe-aligned, and the version footer adds a trailing blank — both are
      owned by helm-docs; realigning would fight the chart-ci drift check. -->
 
-![Version: 0.12.1](https://img.shields.io/badge/Version-0.12.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.12.1](https://img.shields.io/badge/AppVersion-1.12.1-informational?style=flat-square)
+![Version: 0.12.2](https://img.shields.io/badge/Version-0.12.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.12.2](https://img.shields.io/badge/AppVersion-1.12.2-informational?style=flat-square)
 
 Drop-in Prometheus / Loki / Tempo HTTP gateway for ClickHouse — a single stateless gateway that speaks three upstream query wire formats and lowers each to parameterised ClickHouse SQL.
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1101,7 +1101,10 @@ Each edge is a gate, not a sequence:
   the *artifact* — a bad ldflag or Dockerfile drift lives only in the latter.
 - **`publish`** performs the draft→published flip. It is a separate job precisely
   so everything that validates the built artifact sits before the point of no
-  return.
+  return. The flip states `--latest` explicitly: GitHub defaults `make_latest`
+  to true, so leaving it implicit hands the repo's `Latest` pointer to whichever
+  release published most recently — which is how backporting v1.11.3 after
+  v1.13.0 pointed `/releases/latest` at the oldest supported line.
 - **`brew-smoke`** installs from the tap and smokes the published binary (see
   below); **`eol-retire`** retires the line that just fell out of the support
   window.
@@ -1109,9 +1112,14 @@ Each edge is a gate, not a sequence:
 The two version lines are independent: a chart-only fix (template change, new
 toggle) ships by bumping `version:` alone, and an app-only release bumps
 `appVersion:` (plus a patch to `version:` for the new default image). The
-publish gates handle either or both. The `:latest` image tag advances only for
-the highest stable `v*` release (a prerelease or a stable backport never drags
-it backwards) — `RELEASE_IS_LATEST` is computed in `release.yml`.
+publish gates handle either or both.
+
+`RELEASE_IS_LATEST` — computed in `release.yml` right after the tag is pushed,
+by comparing it against the highest stable `v*` tag — is the single answer to
+"is this the newest release line?", and every resource that only one line can
+hold at a time is gated on it: the rolling `:latest` image tags, the tap's
+single Homebrew formula, and the GitHub `Latest` release pointer. A prerelease
+or a stable backport never drags any of the three backwards.
 
 #### Homebrew tap
 
@@ -1124,8 +1132,16 @@ brew install tsouza/tap/cerberus
 ```
 
 This is wired via the goreleaser `brews:` block (a Homebrew *formula*, not a
-cask, so it installs on Linuxbrew as well as macOS). `skip_upload: auto` means
-`rc.*` prereleases never write a formula — only stable releases publish.
+cask, so it installs on Linuxbrew as well as macOS). The tap holds a SINGLE
+`cerberus` formula, so `skip_upload` is templated on `RELEASE_IS_LATEST` — the
+highest-stable-tag signal `release.yml` computes after pushing the tag — and
+only a stable release on the newest line ever writes it. Neither an `rc.*` nor a
+maintenance backport touches the tap: a backport is not a prerelease, so the bare
+`skip_upload: auto` that predated this let v1.12.1 overwrite v1.13.0's formula
+and downgrade every `brew install`. The block pins `directory: Formula`: Homebrew resolves a tap's formulae from
+`Formula/`, `HomebrewFormula/` or the tap root, but goreleaser's `directory`
+defaults to **empty** — the tap root — and `Formula/` is both the conventional
+layout and the path the smoke reads.
 
 Two prerequisites make the push work, and both are one-time:
 
@@ -1142,12 +1158,17 @@ deleted `brews:` block or an expired `HOMEBREW_TAP_GITHUB_TOKEN` leaves a stale
 formula that an install would happily consume. A stable release must find the
 formula declaring exactly the version that just shipped; it then installs it and
 asserts `cerberus --version` equals that version and that two offline verbs
-(`migrate schema`, `config-docs -check`) work from the installed binary. A
-prerelease is **not** skipped — it takes the opposite assertion: `skip_upload:
-auto` means an `rc.*` must have written no formula, so a formula declaring the
-prerelease version is a reported regression. The job runs after `publish` because
-`brew install` downloads the release tarball, which 404s while the release is
-still a draft.
+(`migrate schema`, `config-docs -check`) work from the installed binary. The two
+shapes that write no formula are **not** skipped — each takes the opposite
+assertion. An `rc.*` must have written none, so a formula declaring the
+prerelease version is a reported regression; a release that is not the highest
+stable tag must have left a strictly NEWER formula in place, so a tap that has
+fallen back to the backport's own version is one too. The job runs after
+`publish` because `brew install` downloads the release tarball, which 404s
+while the release is still a draft, and it runs on `macos-latest` because the
+Ubuntu runner image ships no Homebrew at all. That the formula (rather than a
+cask) also installs under Linuxbrew is a property of the artifact, not
+something CI exercises.
 
 #### Maintenance lines (hotfix backports)
 

--- a/test/regression/release_gate_test.go
+++ b/test/regression/release_gate_test.go
@@ -44,9 +44,17 @@ const (
 	publishJob           = "publish"
 	brewSmokeJob         = "brew-smoke"
 	preflightJob         = "preflight"
+	goreleaserJobName    = "goreleaser"
 
 	// The single point of no return in the pipeline.
 	publishFlipToken = "--draft=false"
+
+	// "Is this tag the highest stable release?" — the one signal that decides
+	// which release line may take a resource only one line can hold: the rolling
+	// `:latest` images, the Homebrew formula, and the GitHub `Latest` pointer.
+	releaseIsLatestEnv = "RELEASE_IS_LATEST"
+	isLatestOutput     = "is_latest"
+	latestFlipToken    = "--latest="
 )
 
 func readFileString(t *testing.T, path string) string {
@@ -237,13 +245,93 @@ func TestBrewSmokeIsBlockingAndOrderedAfterPublish(t *testing.T) {
 			"a broken tap would report green. Body:\n%s", releaseWorkflowPath, brewSmokeJob, job)
 	}
 
-	// The prerelease branch of brew-smoke.mjs asserts that an rc.* did NOT write
-	// a formula. That assertion is only meaningful while goreleaser is still
-	// configured to leave prerelease taps alone.
-	goreleaser := readFileString(t, goreleaserPath)
-	if !strings.Contains(goreleaser, "skip_upload: auto") {
-		t.Fatalf("%s no longer sets `skip_upload: auto` on the brews block; brew-smoke's prerelease "+
-			"branch asserts the opposite invariant and would start failing every rc", goreleaserPath)
+	// The two no-formula branches of brew-smoke.mjs assert that a prerelease and
+	// a maintenance backport did NOT write a formula. Those assertions are only
+	// meaningful while goreleaser is still configured to leave both taps alone,
+	// which is one template covering both conditions.
+	//
+	// Matched on the `skip_upload:` LINE, not on the file: RELEASE_IS_LATEST also
+	// appears in the dockers_v2 `latest-*` skip_push templates, so a whole-file
+	// substring check would still pass after a revert to a bare `skip_upload:
+	// auto` — a pin that cannot fail for the thing it is pinning.
+	skipUpload := valueOfYAMLKey(t, readFileString(t, goreleaserPath), "skip_upload")
+	for _, want := range []string{releaseIsLatestEnv, "auto"} {
+		if !strings.Contains(skipUpload, want) {
+			t.Fatalf("%s has `skip_upload: %s`, which does not gate on %q. brew-smoke's prerelease and "+
+				"maintenance branches assert that neither wrote a formula, and would start failing every "+
+				"rc and every backport", goreleaserPath, skipUpload, want)
+		}
+	}
+}
+
+// valueOfYAMLKey returns the inline value of the single `<key>:` line in body,
+// failing when the key is absent or appears more than once. Scoping an assertion
+// to one line is what keeps it from passing on an unrelated occurrence of the
+// same token elsewhere in the file.
+func valueOfYAMLKey(t *testing.T, body, key string) string {
+	t.Helper()
+
+	var found []string
+	for _, line := range strings.Split(body, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if after, ok := strings.CutPrefix(trimmed, key+":"); ok {
+			found = append(found, strings.TrimSpace(after))
+		}
+	}
+	if len(found) != 1 {
+		t.Fatalf("want exactly 1 `%s:` line, found %d (%q) — the assertion below is scoped to a single "+
+			"line and cannot be trusted otherwise", key, len(found), found)
+	}
+	return found[0]
+}
+
+// TestOnlyTheNewestLineOwnsTheSharedReleaseResources pins the fix for v1.12.1 —
+// a backport cut after v1.13.0 — taking two resources that only one release line
+// can hold at a time: the Homebrew formula (it overwrote v1.13.0's, downgrading
+// every `brew install`) and the GitHub `Latest` pointer (v1.11.3, published last,
+// claimed it). Both defaults are silently wrong for a maintenance line:
+// `skip_upload: auto` filters only prereleases, and GitHub's release-update
+// endpoint defaults `make_latest` to true. Neither failure reds a release, so
+// nothing but this pin keeps the explicit gate in place.
+func TestOnlyTheNewestLineOwnsTheSharedReleaseResources(t *testing.T) {
+	t.Parallel()
+
+	workflow := readFileString(t, releaseWorkflowPath)
+
+	// The signal has to leave the goreleaser job: it can only be computed after
+	// the tag is pushed, and the two consumers below are separate jobs.
+	goreleaserJob := workflowJobBody(t, workflow, goreleaserJobName)
+	for _, want := range []string{"outputs:", isLatestOutput + ":", releaseIsLatestEnv} {
+		if !strings.Contains(goreleaserJob, want) {
+			t.Fatalf("%s job %q is missing %q, so the highest-stable-tag signal never leaves the job "+
+				"and the downstream owners fall back to their wrong-for-a-backport defaults. Body:\n%s",
+				releaseWorkflowPath, goreleaserJobName, want, goreleaserJob)
+		}
+	}
+
+	// Consumer 1: the draft->published flip must state the Latest pointer rather
+	// than inherit `make_latest: true`.
+	publish := workflowJobBody(t, workflow, publishJob)
+	if !strings.Contains(publish, latestFlipToken) {
+		t.Fatalf("%s job %q publishes without %q. GitHub defaults `make_latest` to true, so the flip "+
+			"hands /releases/latest to whichever release published most recently — a backport would "+
+			"take it from the newest line. Body:\n%s",
+			releaseWorkflowPath, publishJob, latestFlipToken, publish)
+	}
+	if !strings.Contains(publish, isLatestOutput) {
+		t.Fatalf("%s job %q sets %q from something other than the %q output, so the pointer no longer "+
+			"tracks the highest stable tag. Body:\n%s",
+			releaseWorkflowPath, publishJob, latestFlipToken, isLatestOutput, publish)
+	}
+
+	// Consumer 2: brew-smoke must be told which branch the tap actually took.
+	// Without it the smoke has no safe default and fails closed, but pinning it
+	// here keeps the maintenance assertion from being quietly dropped instead.
+	brew := workflowJobBody(t, workflow, brewSmokeJob)
+	if !strings.Contains(brew, releaseIsLatestEnv) {
+		t.Fatalf("%s job %q does not pass %s, so the smoke cannot assert that a backport left the "+
+			"newest line's formula in place. Body:\n%s",
+			releaseWorkflowPath, brewSmokeJob, releaseIsLatestEnv, brew)
 	}
 }
 


### PR DESCRIPTION
Backport of #1335 to `release/1.12.x` — the line that actually hit both defects.

## Two symptoms, one root cause

A maintenance publish competed for resources only the newest line can hold:

1. **The Homebrew tap.** `brews[].skip_upload: auto` only filters *prereleases*. A stable backport is not a prerelease, so v1.12.1 — cut after v1.13.0 — wrote the tap formula and downgraded every `brew install` to the older line.
2. **The Latest pointer.** The draft→published flip ran a bare `gh release edit --draft=false`. GitHub's release-update endpoint defaults `make_latest` to true, so `/releases/latest` followed publish **order** rather than version.

`RELEASE_IS_LATEST` already answered "is this the highest stable tag?" for the rolling `:latest` images. This promotes it to a job output and lets the same answer decide all three shared resources — one signal, not two per-leg patches.

## Also on this line

- **`directory: Formula`.** This branch's `brews:` block had no `directory`, and goreleaser defaults it to empty — the tap *root*. That is how the stray root `cerberus.rb` (pinned at 1.12.1) got there. The root copy has since been deleted from the tap; this stops it coming back.
- **brew-smoke gains a third assertion, not a skip.** A release that is not the highest stable tag must find a **strictly newer** formula, proving the publish did not overwrite the newest line's. Prereleases keep their own negative assertion.

## Deliberately not backported

`brew-verify.yml` — the weekly re-verification workflow does not exist on this line, and re-checking the *highest stable* release does not belong on a maintenance branch. Everything else applies verbatim; `test/regression/release_gate_test.go` came across with the new pins, and both fire against doctored inputs rather than merely passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Cuts v1.12.2 / chart 0.12.2

Merging this PR **is** the release trigger — `release.yml` builds, publishes and tags on the push. The bump also restores the CHANGELOG's newest-first order on this line: the last backport sections had been prepended *above* `[Unreleased]`, stranding it mid-file.

This release is the live proof the fix works: once it publishes, `/releases/latest` must still resolve to **v1.13.1**, and `Formula/cerberus.rb` in the tap must still declare **1.13.1**.