### PR TITLE
chore(release): migrate goreleaser brews to homebrew_casks

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -354,12 +354,12 @@ One implementation means a new rule guards BOTH lanes at once.
   was at the release commit). Both jobs run on `macos-latest` — the Ubuntu
   runner image ships no Homebrew, so `brew` is a bare ENOENT there.
   Proves the Homebrew tap actually serves the version that just shipped. Reads
-  `Formula/cerberus.rb` from `tsouza/homebrew-tap` through the API FIRST: that
-  is the anti-vacuous check, because a deleted `brews:` block or an expired
-  `HOMEBREW_TAP_GITHUB_TOKEN` leaves a STALE formula that a warm `brew install`
+  `Casks/cerberus.rb` from `tsouza/homebrew-tap` through the API FIRST: that
+  is the anti-vacuous check, because a deleted `homebrew_casks:` block or an expired
+  `HOMEBREW_TAP_GITHUB_TOKEN` leaves a STALE cask that a warm `brew install`
   would install happily. Then it branches EXPLICITLY on the release kind rather
   than skipping: a stable `X.Y.Z` on the newest release line requires the
-  formula to declare exactly that version, then installs it and asserts the
+  cask to declare exactly that version, then installs it and asserts the
   binary lands under `brew --prefix`,
   that `cerberus --version` EQUALS the bare release version (string equality, so
   an off-by-`v` or a stale ldflag cannot pass a substring test), and that two
@@ -367,31 +367,51 @@ One implementation means a new rule guards BOTH lanes at once.
   `config-docs -check` against `REPO_ROOT`'s `docs/configuration.md`. The other
   two release shapes take negative branches, because `.goreleaser.yml`'s
   `skip_upload` template keeps both out of the tap: an `rc.*` must NOT have
-  written a formula, and a release that is not the highest stable tag (a
-  maintenance backport) must have left a STRICTLY NEWER formula in place — the
+  written a cask, and a release that is not the highest stable tag (a
+  maintenance backport) must have left a STRICTLY NEWER cask in place — the
   regression that let v1.12.1, cut after v1.13.0, downgrade every
   `brew install`. `migrate gate` / `migrate verify` are deliberately unused —
   they exit non-zero on a legitimate no-go, so they cannot distinguish a broken
   binary from a correct verdict. Pure exports `isStableRelease(version)`,
-  `formulaVersion(rbSource)` (declaration, then archive-name fallback, then
-  THROWS — an unparseable formula never degrades into a pass),
-  `compareVersions(a, b)` and `verdict({version, formulaSource, isLatest})`,
+  `caskVersion(rbSource)` (declaration, then archive-name fallback, then
+  THROWS — an unparseable cask never degrades into a pass),
+  `compareVersions(a, b)` and `verdict({version, caskSource, isLatest})`,
   covered by `brew-smoke.test.mjs` on the required `lint` lane and as the job's
   own first step.
   - Env: `RELEASE_VERSION` (the BARE `X.Y.Z[-rc.N]`, i.e.
     `needs.gate.outputs.app_version`, never the `v`-prefixed tag),
     `RELEASE_IS_LATEST` (`"true"`/`"false"` — whether this is the highest stable
-    tag, i.e. the line that owns the tap's single formula; required, and
+    tag, i.e. the line that owns the tap's single cask; required, and
     rejected unless it is exactly one of those two words, since it selects the
     assertion branch), `GITHUB_TOKEN` (contents:read on the tap),
     `GITHUB_API_URL` (default `https://api.github.com`), `REPO_ROOT`
     (checkout root, for the `config-docs -check` payload).
-  - Exit: `0` when the formula state matches the release kind and (newest stable
+  - Exit: `0` when the cask state matches the release kind and (newest stable
     line only) the installed binary passes every assertion; `1` on a stale /
-    missing / unparseable formula, a prerelease formula that should not exist, a
-    tap formula that a backport overwrote, a missing or unrecognised
+    missing / unparseable cask, a prerelease cask that should not exist, a
+    tap cask that a backport overwrote, a missing or unrecognised
     `RELEASE_IS_LATEST`, a failed install, a version mismatch, or a failing
     payload verb.
+- **`goreleaser-deprecations.mjs`** — `ci.yml`, the `lint` job. Fails the build
+  when `.goreleaser.yml` uses any goreleaser feature upstream has deprecated.
+  `goreleaser check` prints a deprecation as an advisory line and still exits
+  `0`, and release.yml (which has no `pull_request:` trigger) is the only other
+  place goreleaser runs — so a deprecation notice first becomes visible in the
+  scroll-back of a release that already published, which is how `brews:` stayed
+  in the config for several releases after `homebrew_casks:` replaced it. The
+  gate reads the real tool's output rather than scanning the YAML for a
+  hardcoded list of dead keys, so a deprecation announced upstream tomorrow is
+  caught without this module knowing about it in advance. The CI step installs
+  the same `distribution` / `version` release.yml pins, so the gate reports
+  exactly what the next release run will warn about. Pure export
+  `deprecationsIn(output)` returns the DEDUPLICATED notices in a transcript
+  (goreleaser repeats one line per offending block, and reporting the same
+  migration N times obscures how many distinct ones are outstanding), covered by
+  `goreleaser-deprecations.test.mjs` on the same lane.
+  - Env: `GORELEASER_CONFIG` (default `.goreleaser.yml`), `GORELEASER_BIN`
+    (default `goreleaser`).
+  - Exit: `0` when the config validates with no deprecation notices; `1` on any
+    notice, or when `goreleaser check` itself fails or cannot run.
 - **`chart-kubeconform.mjs`** — `chart-ci.yml`, the `Render + kubeconform`
   step. Renders the chart for the default values and every `ci/*-values.yaml`
   fixture, schema-validates each manifest set with `kubeconform -strict`, and

--- a/.github/scripts/brew-smoke.mjs
+++ b/.github/scripts/brew-smoke.mjs
@@ -1,11 +1,12 @@
 // brew-smoke.mjs — post-publish Homebrew install smoke for `release.yml`'s
 // `brew-smoke` job.
 //
-// What it is for: goreleaser's `brews:` block pushes a formula to a DIFFERENT
-// repository (tsouza/homebrew-tap) with a PAT. Nothing in this repo observes
-// that push. If the block is deleted, if HOMEBREW_TAP_GITHUB_TOKEN expires, or
-// if the cross-repo write silently fails, the release still goes green here and
-// `brew install tsouza/tap/cerberus` is discovered broken by a user.
+// What it is for: goreleaser's `homebrew_casks:` block pushes a cask to a
+// DIFFERENT repository (tsouza/homebrew-tap) with a PAT. Nothing in this repo
+// observes that push. If the block is deleted, if HOMEBREW_TAP_GITHUB_TOKEN
+// expires, or if the cross-repo write silently fails, the release still goes
+// green here and `brew install tsouza/tap/cerberus` is discovered broken by a
+// user.
 //
 // Ordering: it MUST run after the draft -> published flip. `brew install`
 // downloads the release tarball, and a draft release's assets 404 for anyone
@@ -18,16 +19,16 @@
 // for those the honest assertion is the NEGATIVE one. Bailing out on a "not
 // applicable" flag would be `t.Skip` in workflow clothing, and would wave
 // through the very `skip_upload` regressions this job exists to catch:
-//   - newest line + stable — the formula must declare EXACTLY this version;
-//   - prerelease (`rc.*`)  — the formula must exist and must NOT declare it;
-//   - not the highest stable tag (a maintenance backport) — the formula must
+//   - newest line + stable — the cask must declare EXACTLY this version;
+//   - prerelease (`rc.*`)  — the cask must exist and must NOT declare it;
+//   - not the highest stable tag (a maintenance backport) — the cask must
 //     declare a STRICTLY NEWER version, proving this publish did not overwrite
 //     the newest line's. v1.12.1, cut after v1.13.0, did exactly that.
 //
-// ANTI-VACUOUS: the formula's declared version is compared to the release
+// ANTI-VACUOUS: the cask's declared version is compared to the release
 // version BEFORE `brew install` runs. That reads the tap's git state through
 // the API, so a warm brew cache, a mirror, or a previously-installed cerberus
-// cannot make a stale/never-pushed formula look healthy. The installed
+// cannot make a stale/never-pushed cask look healthy. The installed
 // binary's `--version` is then compared with string EQUALITY against the
 // de-`v`'d release version — `grep -q "$TAG"` can never match (the tag carries
 // the `v`), and `grep -q "${TAG#v}"` passes on any superstring.
@@ -49,15 +50,15 @@
 //                     form the binary itself reports.
 //   RELEASE_IS_LATEST "true"/"false" — whether this tag is the highest stable
 //                     release, i.e. the line that owns the single shared tap
-//                     formula. Selects the assertion branch, so it is required
+//                     cask. Selects the assertion branch, so it is required
 //                     and has no default.
-//   GITHUB_TOKEN      token used to read the tap's formula via the contents API.
+//   GITHUB_TOKEN      token used to read the tap's cask via the contents API.
 //   GITHUB_API_URL    API base (default https://api.github.com).
 //   REPO_ROOT         checkout of the release commit — the working directory for
 //                     the `config-docs -check` payload run.
 //
 // Exit: 0 when every assertion for the branch taken holds; 1 on any missing or
-// unrecognised env var, an unreadable/unparseable formula, a formula-version
+// unrecognised env var, an unreadable/unparseable cask, a cask-version
 // mismatch (newest + stable), match (prerelease) or not-newer-than-us
 // (maintenance), a failed install, a binary resolved outside the brew prefix, a
 // `--version` mismatch, or a failing payload verb.
@@ -67,25 +68,26 @@
 import process from 'node:process';
 import { spawnSync } from 'node:child_process';
 
-// The tap goreleaser's `brews:` block writes to, and the formula path inside it.
+// The tap goreleaser's `homebrew_casks:` block writes to, and the cask path
+// inside it. Must stay in step with .goreleaser.yml's `directory: Casks`.
 const TAP_REPO = 'tsouza/homebrew-tap';
-const TAP_FORMULA_PATH = 'Formula/cerberus.rb';
+const TAP_CASK_PATH = 'Casks/cerberus.rb';
 
-// How an operator names the formula: `brew install tsouza/tap/cerberus`.
-const FORMULA_REF = 'tsouza/tap/cerberus';
+// How an operator names the cask: `brew install tsouza/tap/cerberus`.
+const CASK_REF = 'tsouza/tap/cerberus';
 
 // A STABLE release is exactly `<major>.<minor>.<patch>`. Anything with a
 // prerelease suffix (`-rc.1`, `-RC1`) is a prerelease, which `skip_upload: auto`
 // keeps out of the tap.
 const STABLE_VERSION_RE = /^\d+\.\d+\.\d+$/;
 
-// goreleaser's formula template declares `version "1.11.2"`.
-const FORMULA_VERSION_RE = /^\s*version\s+"([^"]+)"/m;
+// goreleaser's cask template declares `version "1.11.2"`.
+const CASK_VERSION_RE = /^\s*version\s+"([^"]+)"/m;
 
-// Fallback when the template stops emitting a bare `version` line: the archive
+// Fallback if the template stops emitting a bare `version` line: the archive
 // name goreleaser builds, `cerberus_<version>_<os>_<arch>.tar.gz` (the
 // `name_template` in .goreleaser.yml `archives:`).
-const FORMULA_ARCHIVE_RE = /cerberus_([^_]+)_(?:linux|darwin)_(?:amd64|arm64)\.tar\.gz/;
+const CASK_ARCHIVE_RE = /cerberus_([^_]+)_(?:linux|darwin)_(?:amd64|arm64)\.tar\.gz/;
 
 // The install command's timeout. A brew install that hangs must fail the job
 // rather than burn the whole runner allowance.
@@ -102,21 +104,21 @@ export function isStableRelease(version) {
   return STABLE_VERSION_RE.test(String(version ?? '').trim());
 }
 
-// formulaVersion — the version the tap formula declares. Tries the explicit
+// caskVersion — the version the tap cask declares. Tries the explicit
 // `version "..."` line, falls back to the archive filename, and THROWS when
-// neither parses. An unparseable formula is a failure, never a pass: silently
+// neither parses. An unparseable cask is a failure, never a pass: silently
 // returning null would let the stable branch's equality check degrade into
 // "well, we couldn't tell".
-export function formulaVersion(rbSource) {
+export function caskVersion(rbSource) {
   const src = String(rbSource ?? '');
-  const declared = FORMULA_VERSION_RE.exec(src);
+  const declared = CASK_VERSION_RE.exec(src);
   if (declared) return declared[1];
-  const archive = FORMULA_ARCHIVE_RE.exec(src);
+  const archive = CASK_ARCHIVE_RE.exec(src);
   if (archive) return archive[1];
   throw new Error(
-    `could not determine the version of ${TAP_REPO}:${TAP_FORMULA_PATH} — neither a \`version "…"\` ` +
+    `could not determine the version of ${TAP_REPO}:${TAP_CASK_PATH} — neither a \`version "…"\` ` +
       `declaration nor a cerberus_<version>_<os>_<arch>.tar.gz archive name is present. ` +
-      `An unreadable formula is a release failure, not a pass.`,
+      `An unreadable cask is a release failure, not a pass.`,
   );
 }
 
@@ -145,17 +147,17 @@ export function compareVersions(a, b) {
 
 // verdict — the pure decision every branch shares. Takes `isLatest`: whether the
 // release being smoked is the highest stable tag in the repo, i.e. whether it is
-// the line that OWNS the single shared tap formula. Returns:
+// the line that OWNS the single shared tap cask. Returns:
 //   mustInstall — true only when the tap is expected to declare exactly this
 //                 version (newest line + stable), so `brew install` must work.
 //                 False on the two branches where goreleaser deliberately wrote
-//                 no formula — each of which still gets its own assertion below,
+//                 no cask — each of which still gets its own assertion below,
 //                 never a bail-out.
 //   problems    — blocking problem strings; empty == the tap is in the state
 //                 this release requires.
-export function verdict({ version, formulaSource, isLatest }) {
+export function verdict({ version, caskSource, isLatest }) {
   const v = String(version ?? '').trim();
-  const declared = formulaVersion(formulaSource);
+  const declared = caskVersion(caskSource);
   const stable = isStableRelease(v);
   const newest = isLatest === true || String(isLatest).trim() === 'true';
   const problems = [];
@@ -167,8 +169,8 @@ export function verdict({ version, formulaSource, isLatest }) {
   if (!stable) {
     if (declared === v) {
       problems.push(
-        `${TAP_REPO}:${TAP_FORMULA_PATH} declares prerelease version "${v}". ` +
-          `.goreleaser.yml sets \`skip_upload: auto\`, so a prerelease must write NO formula — ` +
+        `${TAP_REPO}:${TAP_CASK_PATH} declares prerelease version "${v}". ` +
+          `.goreleaser.yml sets \`skip_upload: auto\`, so a prerelease must write NO cask — ` +
           `the stable tap is now pointing operators at a prerelease.`,
       );
     }
@@ -176,22 +178,22 @@ export function verdict({ version, formulaSource, isLatest }) {
     // MAINTENANCE branch. `skip_upload` resolves to "true" off RELEASE_IS_LATEST,
     // so this publish must have left the tap alone — and the tap must still be
     // ahead of it. `declared === v` is the exact regression that shipped v1.12.1
-    // over a v1.13.0 formula and downgraded every `brew install`.
+    // over a v1.13.0 cask and downgraded every `brew install`.
     if (compareVersions(declared, v) <= 0) {
       problems.push(
-        `${TAP_REPO}:${TAP_FORMULA_PATH} declares version "${declared}", which is not newer than this ` +
+        `${TAP_REPO}:${TAP_CASK_PATH} declares version "${declared}", which is not newer than this ` +
           `maintenance release "${v}". This release is not the highest stable tag, so .goreleaser.yml's ` +
-          `\`skip_upload\` template must have kept it out of the tap and left the newest line's formula ` +
-          `in place. \`brew install ${FORMULA_REF}\` now installs an older cerberus than the newest ` +
+          `\`skip_upload\` template must have kept it out of the tap and left the newest line's cask ` +
+          `in place. \`brew install ${CASK_REF}\` now installs an older cerberus than the newest ` +
           `released line.`,
       );
     }
   } else if (declared !== v) {
     problems.push(
-      `${TAP_REPO}:${TAP_FORMULA_PATH} declares version "${declared}" but this release is "${v}". ` +
-        `The formula was never pushed, or the push landed stale — goreleaser's brews block, ` +
+      `${TAP_REPO}:${TAP_CASK_PATH} declares version "${declared}" but this release is "${v}". ` +
+        `The cask was never pushed, or the push landed stale — goreleaser's homebrew_casks block, ` +
         `HOMEBREW_TAP_GITHUB_TOKEN, or the cross-repo write is broken. ` +
-        `\`brew install ${FORMULA_REF}\` would install the wrong version.`,
+        `\`brew install ${CASK_REF}\` would install the wrong version.`,
     );
   }
 
@@ -248,20 +250,20 @@ async function main() {
   // Required, and required to be one of exactly two words. Defaulting a missing
   // value either way would silently pick an assertion branch: absent-means-false
   // would stop asserting the tap was written on every mainline release, and
-  // absent-means-true would demand a formula a backport never wrote.
+  // absent-means-true would demand a cask a backport never wrote.
   if (isLatestRaw !== 'true' && isLatestRaw !== 'false') {
     fail(
       `RELEASE_IS_LATEST must be exactly "true" or "false" (got "${isLatestRaw}") — it selects which ` +
         `state the tap is asserted to be in, so it has no safe default.`,
     );
   }
-  if (!token) fail('GITHUB_TOKEN is required to read the tap formula');
+  if (!token) fail('GITHUB_TOKEN is required to read the tap cask');
   if (!repoRoot) fail('REPO_ROOT is required — the `config-docs -check` payload runs against this commit\'s docs');
 
-  // --- read the tap's formula through the API --------------------------------
+  // --- read the tap's cask through the API ------------------------------------
   // Both branches need it, and a 404 is a hard failure on both: a tap that has
-  // no cerberus formula at all is broken regardless of what we just published.
-  const url = `${apiBase}/repos/${TAP_REPO}/contents/${TAP_FORMULA_PATH}`;
+  // no cerberus cask at all is broken regardless of what we just published.
+  const url = `${apiBase}/repos/${TAP_REPO}/contents/${TAP_CASK_PATH}`;
   const res = await fetch(url, {
     headers: {
       Authorization: `Bearer ${token}`,
@@ -271,15 +273,15 @@ async function main() {
   });
   if (!res.ok) {
     fail(
-      `GET ${url} -> ${res.status} ${res.statusText}. ${TAP_REPO} has no readable ${TAP_FORMULA_PATH}: ` +
-        `\`brew install ${FORMULA_REF}\` is broken for every operator, whatever this release published.`,
+      `GET ${url} -> ${res.status} ${res.statusText}. ${TAP_REPO} has no readable ${TAP_CASK_PATH}: ` +
+        `\`brew install ${CASK_REF}\` is broken for every operator, whatever this release published.`,
     );
   }
-  const formulaSource = await res.text();
+  const caskSource = await res.text();
 
   let decision;
   try {
-    decision = verdict({ version, formulaSource, isLatest: isLatestRaw });
+    decision = verdict({ version, caskSource, isLatest: isLatestRaw });
   } catch (e) {
     fail(e.message);
   }
@@ -288,7 +290,7 @@ async function main() {
   if (decision.problems.length > 0) process.exit(1);
 
   if (!decision.mustInstall) {
-    // NO-FORMULA branches — asserted above, not skipped. `verdict` has already
+    // NO-CASK branches — asserted above, not skipped. `verdict` has already
     // proved the tap is in the state this release requires: for a prerelease,
     // that it does NOT declare this version; for a maintenance backport, that it
     // still declares a strictly newer one. Installing here would smoke the
@@ -296,7 +298,7 @@ async function main() {
     // not installing.
     ghNotice(
       `brew-smoke: ${version} did not write the tap (${isLatestRaw === 'true' ? 'prerelease' : 'not the highest stable tag'}); ` +
-        `the tap correctly still declares "${formulaVersion(formulaSource)}".`,
+        `the tap correctly still declares "${caskVersion(caskSource)}".`,
     );
     process.exit(0);
   }
@@ -310,9 +312,12 @@ async function main() {
   }
   const brewPrefix = prefixRes.stdout.trim();
 
-  const install = sh('brew', ['install', '--formula', FORMULA_REF], { timeout: INSTALL_TIMEOUT_MS });
+  // `--cask` rather than a bare name: the disambiguator makes the smoke fail
+  // loudly if the tap ever serves a same-named FORMULA again, instead of
+  // quietly installing that one and reporting the cask healthy.
+  const install = sh('brew', ['install', '--cask', CASK_REF], { timeout: INSTALL_TIMEOUT_MS });
   if (install.status !== 0) {
-    fail(`\`brew install --formula ${FORMULA_REF}\` failed. ${describe(install)}`);
+    fail(`\`brew install --cask ${CASK_REF}\` failed. ${describe(install)}`);
   }
 
   // The binary under test must be the one brew just installed — a cerberus
@@ -320,13 +325,13 @@ async function main() {
   // assertion below without the tap being involved at all.
   const which = sh('command -v cerberus', [], { shell: true });
   if (which.status !== 0) {
-    fail(`cerberus is not on PATH after \`brew install ${FORMULA_REF}\`. ${describe(which)}`);
+    fail(`cerberus is not on PATH after \`brew install ${CASK_REF}\`. ${describe(which)}`);
   }
   const resolved = which.stdout.trim();
   if (!resolved.startsWith(brewPrefix)) {
     fail(
       `cerberus resolved to ${resolved}, which is OUTSIDE the brew prefix ${brewPrefix} — ` +
-        `the smoke would be testing some other binary, not the published formula.`,
+        `the smoke would be testing some other binary, not the published cask.`,
     );
   }
 
@@ -367,8 +372,8 @@ async function main() {
   }
 
   ghNotice(
-    `brew-smoke: ${FORMULA_REF} installed ${reported} at ${resolved} (tap formula declares ` +
-      `"${formulaVersion(formulaSource)}"); \`migrate schema\` rendered ${schema.stdout.length} bytes of DDL and ` +
+    `brew-smoke: ${CASK_REF} installed ${reported} at ${resolved} (tap cask declares ` +
+      `"${caskVersion(caskSource)}"); \`migrate schema\` rendered ${schema.stdout.length} bytes of DDL and ` +
       `\`config-docs -check\` matches this commit's docs/configuration.md.`,
   );
   process.exit(0);

--- a/.github/scripts/brew-smoke.test.mjs
+++ b/.github/scripts/brew-smoke.test.mjs
@@ -6,35 +6,35 @@
 // to the smoke would be unverified until a release is cut. The cases below pin
 // the four ways the smoke could go hollow:
 //
-//   1. a stale/never-pushed formula reported as fine (the goreleaser `brews:`
-//      regression the whole job exists to catch);
-//   2. a no-formula branch that bails out instead of asserting — `t.Skip` in
+//   1. a stale/never-pushed cask reported as fine (the goreleaser
+//      `homebrew_casks:` regression the whole job exists to catch);
+//   2. a no-cask branch that bails out instead of asserting — `t.Skip` in
 //      workflow clothing, which would wave through a `skip_upload` regression;
-//   3. an unparseable formula degrading into "couldn't tell, so pass";
-//   4. a maintenance backport silently overwriting the newest line's formula,
+//   3. an unparseable cask degrading into "couldn't tell, so pass";
+//   4. a maintenance backport silently overwriting the newest line's cask,
 //      which is what v1.12.1 did to v1.13.0's.
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { isStableRelease, formulaVersion, verdict, compareVersions } from './brew-smoke.mjs';
+import { isStableRelease, caskVersion, verdict, compareVersions } from './brew-smoke.mjs';
 
 // A minimal stand-in for what goreleaser writes into the tap.
-function formula(version) {
+function cask(version) {
   return [
-    'class Cerberus < Formula',
+    'cask "cerberus" do',
+    `  version "${version}"`,
+    '',
+    '  url "https://github.com/tsouza/cerberus/releases/download/v' +
+      version +
+      '/cerberus_' +
+      version +
+      '_darwin_arm64.tar.gz"',
+    '  name "cerberus"',
     '  desc "Drop-in Prometheus / Loki / Tempo HTTP gateway for ClickHouse"',
     '  homepage "https://github.com/tsouza/cerberus"',
-    `  version "${version}"`,
-    '  license "Apache-2.0"',
     '',
-    '  on_macos do',
-    `    url "https://github.com/tsouza/cerberus/releases/download/v${version}/cerberus_${version}_darwin_arm64.tar.gz"`,
-    '  end',
-    '',
-    '  def install',
-    '    bin.install "cerberus"',
-    '  end',
+    '  binary "cerberus"',
     'end',
   ].join('\n');
 }
@@ -49,22 +49,22 @@ test('isStableRelease separates stable releases from prereleases', () => {
   assert.equal(isStableRelease(undefined), false);
 });
 
-test('formulaVersion reads the declaration, falls back to the archive name', () => {
-  assert.equal(formulaVersion(formula('1.11.2')), '1.11.2');
+test('caskVersion reads the declaration, falls back to the archive name', () => {
+  assert.equal(caskVersion(cask('1.11.2')), '1.11.2');
 
   // No `version "…"` line: the archive filename still carries it.
   const archiveOnly = [
-    'class Cerberus < Formula',
+    'cask "cerberus" do',
     '  url "https://github.com/tsouza/cerberus/releases/download/v1.11.2/cerberus_1.11.2_linux_amd64.tar.gz"',
     'end',
   ].join('\n');
-  assert.equal(formulaVersion(archiveOnly), '1.11.2');
+  assert.equal(caskVersion(archiveOnly), '1.11.2');
 });
 
-test('an unparseable formula THROWS rather than passing', () => {
-  assert.throws(() => formulaVersion('class Cerberus < Formula\nend\n'), /could not determine the version/);
-  assert.throws(() => formulaVersion(''), /could not determine the version/);
-  assert.throws(() => formulaVersion(undefined), /could not determine the version/);
+test('an unparseable cask THROWS rather than passing', () => {
+  assert.throws(() => caskVersion('cask "cerberus" do\nend\n'), /could not determine the version/);
+  assert.throws(() => caskVersion(''), /could not determine the version/);
+  assert.throws(() => caskVersion(undefined), /could not determine the version/);
 });
 
 // The release-shape vocabulary the whole table is written in. `verdict` only
@@ -100,12 +100,12 @@ const VERDICT_CASES = [
     tap: OLDER,
     release: RELEASED,
     isLatest: 'true',
-    mustInstall: true, // a stale formula does not excuse skipping the install branch
+    mustInstall: true, // a stale cask does not excuse skipping the install branch
     problem: `declares version "${OLDER}" but this release is "${RELEASED}"`,
   },
   {
     name: 'prerelease + a tap on the last stable — healthy, asserted rather than skipped',
-    // `skip_upload` wrote no formula, so the tap legitimately still declares an
+    // `skip_upload` wrote no cask, so the tap legitimately still declares an
     // older version.
     tap: OLDER,
     release: RC,
@@ -146,7 +146,7 @@ const VERDICT_CASES = [
   {
     name: 'maintenance backport that OVERWROTE the tap — the v1.12.1-over-v1.13.0 regression',
     // `skip_upload: auto` alone does not filter a stable backport, so goreleaser
-    // wrote the older line's formula over the newer one and every `brew install`
+    // wrote the older line's cask over the newer one and every `brew install`
     // started downgrading.
     tap: SAME,
     release: RELEASED,
@@ -166,7 +166,7 @@ const VERDICT_CASES = [
 
 for (const c of VERDICT_CASES) {
   test(`verdict: ${c.name}`, () => {
-    const v = verdict({ version: c.release, formulaSource: formula(c.tap), isLatest: c.isLatest });
+    const v = verdict({ version: c.release, caskSource: cask(c.tap), isLatest: c.isLatest });
     if (c.problem === null) {
       assert.deepEqual(v.problems, [], 'expected the healthy state');
     } else {
@@ -182,14 +182,14 @@ test('verdict is comparing the BARE version, so a `v`-prefixed input cannot pass
   // (bare), never `app_tag`. If it ever passed the tag, the stable branch's
   // equality check fails loudly here rather than being papered over by a
   // substring match.
-  const v = verdict({ version: `v${RELEASED}`, formulaSource: formula(SAME), isLatest: 'true' });
+  const v = verdict({ version: `v${RELEASED}`, caskSource: cask(SAME), isLatest: 'true' });
   assert.equal(v.mustInstall, false, 'a `v`-prefixed string is not a stable app version');
-  assert.deepEqual(v.problems, [], 'and it does not collide with the formula version either');
+  assert.deepEqual(v.problems, [], 'and it does not collide with the cask version either');
 });
 
-test('an unparseable formula propagates out of verdict on both branches', () => {
-  assert.throws(() => verdict({ version: RELEASED, formulaSource: 'garbage', isLatest: 'true' }), /could not determine the version/);
-  assert.throws(() => verdict({ version: RC, formulaSource: 'garbage', isLatest: 'false' }), /could not determine the version/);
+test('an unparseable cask propagates out of verdict on both branches', () => {
+  assert.throws(() => verdict({ version: RELEASED, caskSource: 'garbage', isLatest: 'true' }), /could not determine the version/);
+  assert.throws(() => verdict({ version: RC, caskSource: 'garbage', isLatest: 'false' }), /could not determine the version/);
 });
 
 test('compareVersions orders the two shapes goreleaser produces', () => {
@@ -210,12 +210,12 @@ test('compareVersions orders the two shapes goreleaser produces', () => {
   assert.equal(compareVersions(undefined, '0.0.0'), 0);
 });
 
-test('isLatest is read strictly: only the exact string "true" owns the formula', () => {
+test('isLatest is read strictly: only the exact string "true" owns the cask', () => {
   // The driver rejects anything that is not "true"/"false" before reaching here,
   // but verdict must not treat a truthy-looking value as the newest line either
   // — that would restore the equality assertion for a backport and demand a
-  // formula it deliberately never wrote.
-  const backport = { version: RELEASED, formulaSource: formula(NEWER) };
+  // cask it deliberately never wrote.
+  const backport = { version: RELEASED, caskSource: cask(NEWER) };
   assert.equal(verdict({ ...backport, isLatest: true }).problems.length, 1, 'boolean true is the newest line');
   assert.deepEqual(verdict({ ...backport, isLatest: 'false' }).problems, []);
   assert.deepEqual(verdict({ ...backport, isLatest: '' }).problems, [], 'not "true" means not the newest line');

--- a/.github/scripts/goreleaser-deprecations.mjs
+++ b/.github/scripts/goreleaser-deprecations.mjs
@@ -1,0 +1,91 @@
+// goreleaser-deprecations.mjs — fails the build when .goreleaser.yml uses any
+// goreleaser feature that upstream has deprecated.
+//
+// Why this is a gate rather than something to notice in a log: `goreleaser
+// check` reports deprecations as advisory lines and still exits 0, and the only
+// place goreleaser otherwise runs is release.yml — which has no `pull_request:`
+// trigger. So a deprecation notice first becomes visible in the scroll-back of a
+// release that already published, which is how `brews:` stayed in the config for
+// several releases after upstream replaced it with `homebrew_casks:`. Reading
+// the real tool's output (rather than scanning the YAML for a hardcoded list of
+// dead keys) means a deprecation announced upstream tomorrow is caught the same
+// day, without this file needing to know about it in advance.
+//
+// A red here is a real task, not a flake: release.yml pins `version: '~> v2'`,
+// so whatever goreleaser deprecates inside v2 is exactly what the next release
+// run will warn about, and the fix is to migrate the config.
+//
+// Env contract:
+//   GORELEASER_CONFIG  config file to check (default `.goreleaser.yml`).
+//   GORELEASER_BIN     binary to invoke (default `goreleaser`).
+//
+// Exit: 0 when the config validates with no deprecation notices; 1 when
+// goreleaser reports one, or when `goreleaser check` itself fails or cannot run.
+
+import { spawnSync } from 'node:child_process';
+
+import { error as ghError, notice as ghNotice } from './lib/gh.mjs';
+
+// Every deprecation notice goreleaser emits links its entry on the deprecations
+// page, so the URL is the most reliable marker. The other two are belt-and-
+// braces for a notice that is worded without the link — matching more broadly
+// costs a false positive at worst, while matching too narrowly reproduces the
+// exact miss this gate exists to prevent.
+const DEPRECATION_MARKERS = [/goreleaser\.com\/deprecations/i, /\bDEPRECATED\b/, /\bphased out\b/i];
+
+// goreleaser prefixes each advisory line with a bullet; strip it so the error
+// reads as a sentence.
+const BULLET_PREFIX = /^\s*[•*-]\s*/;
+
+// deprecationsIn — the deprecation notices in a `goreleaser check` transcript,
+// deduplicated. goreleaser repeats a notice once per offending config entry
+// (two `dockers` blocks produce two identical lines), and reporting the same
+// migration N times obscures how many DISTINCT things need fixing.
+export function deprecationsIn(output) {
+  const seen = new Set();
+  for (const raw of String(output ?? '').split('\n')) {
+    const line = raw.replace(BULLET_PREFIX, '').trim();
+    if (!line) continue;
+    if (DEPRECATION_MARKERS.some((re) => re.test(line))) seen.add(line);
+  }
+  return [...seen];
+}
+
+function main() {
+  const config = process.env.GORELEASER_CONFIG || '.goreleaser.yml';
+  const bin = process.env.GORELEASER_BIN || 'goreleaser';
+
+  const res = spawnSync(bin, ['check', config], { encoding: 'utf8' });
+  if (res.error) {
+    ghError(`goreleaser-deprecations: could not run \`${bin} check\` (${res.error.message}).`);
+    process.exit(1);
+  }
+
+  // stdout and stderr both carry advisory lines depending on the version, and a
+  // gate that reads only one of them would go quiet the moment goreleaser moves
+  // them.
+  const output = `${res.stdout ?? ''}\n${res.stderr ?? ''}`;
+  const found = deprecationsIn(output);
+
+  if (res.status !== 0) {
+    ghError(`goreleaser-deprecations: \`${bin} check ${config}\` failed (exit ${res.status}).\n${output.trim()}`);
+    process.exit(1);
+  }
+
+  if (found.length > 0) {
+    for (const d of found) ghError(`goreleaser-deprecations: ${d}`);
+    ghError(
+      `${config} uses ${found.length} deprecated goreleaser feature(s). Migrate the config — ` +
+        `a deprecated section keeps working only until goreleaser's next major, and the release ` +
+        `workflow is the only other place this would ever surface.`,
+    );
+    process.exit(1);
+  }
+
+  ghNotice(`goreleaser-deprecations: ${config} validates with no deprecation notices.`);
+  process.exit(0);
+}
+
+const invokedDirectly = process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href;
+
+if (invokedDirectly) main();

--- a/.github/scripts/goreleaser-deprecations.test.mjs
+++ b/.github/scripts/goreleaser-deprecations.test.mjs
@@ -1,0 +1,73 @@
+// goreleaser-deprecations.test.mjs — node:test guard for the detector that
+// decides whether a `goreleaser check` transcript contains a deprecation.
+//
+// The gate is only as good as this predicate: a detector that stops matching
+// reports "no deprecations" on a config full of them, which reads identically to
+// a healthy repo. The cases below are transcripts goreleaser actually produced
+// against this project's config.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { deprecationsIn } from './goreleaser-deprecations.mjs';
+
+// A clean run: the shape the gate must let through.
+const HEALTHY = [
+  '  • checking                                  path=.goreleaser.yml',
+  '  • 1 configuration file(s) validated',
+  '  • thanks for using GoReleaser!',
+].join('\n');
+
+test('a clean transcript yields nothing', () => {
+  assert.deepEqual(deprecationsIn(HEALTHY), []);
+  assert.deepEqual(deprecationsIn(''), []);
+  assert.deepEqual(deprecationsIn(undefined), []);
+});
+
+test('the three wordings goreleaser uses are all caught', () => {
+  // Linked deprecations page — the marker every notice carries.
+  const phasedOut =
+    '  • brews is being phased out in favor of homebrew_casks, check https://goreleaser.com/deprecations#brews for more info';
+  // The `DEPRECATED:` prefix form.
+  const flagged =
+    '  • DEPRECATED: brews should not be used anymore, check https://goreleaser.com/deprecations#brews for more info';
+  // Wording that carries neither the URL nor the prefix, only "phased out".
+  const bare = '  • dockers and docker_manifests are being phased out';
+
+  for (const line of [phasedOut, flagged, bare]) {
+    assert.equal(deprecationsIn(line).length, 1, `not detected: ${line}`);
+  }
+});
+
+test('the bullet prefix is stripped so the message reads as a sentence', () => {
+  const [only] = deprecationsIn(
+    '  • brews is being phased out in favor of homebrew_casks, check https://goreleaser.com/deprecations#brews for more info',
+  );
+  assert.ok(only.startsWith('brews is being phased out'), `got: ${only}`);
+});
+
+test('a notice repeated per config entry is reported once', () => {
+  // goreleaser emits one line per offending block; two `dockers` entries produce
+  // the identical line twice. Counting them separately would misreport how many
+  // distinct migrations are outstanding.
+  const line =
+    '  • dockers and docker_manifests are being phased out and will eventually be replaced by dockers_v2, check https://goreleaser.com/deprecations#dockers for more info';
+  assert.equal(deprecationsIn([line, line].join('\n')).length, 1);
+});
+
+test('distinct deprecations are reported separately', () => {
+  const transcript = [
+    '  • checking                                  path=.goreleaser.yml',
+    '  • dockers and docker_manifests are being phased out, check https://goreleaser.com/deprecations#dockers for more info',
+    '  • DEPRECATED: brews should not be used anymore, check https://goreleaser.com/deprecations#brews for more info',
+    '  • 1 configuration file(s) validated',
+  ].join('\n');
+  assert.equal(deprecationsIn(transcript).length, 2);
+});
+
+test('a link to the deprecations page in ordinary prose is not a false negative source', () => {
+  // The detector deliberately errs toward matching: a line mentioning the
+  // deprecations page IS a deprecation notice in goreleaser's output, and the
+  // cost of being wrong is a visible red rather than a silent pass.
+  assert.equal(deprecationsIn('  • see https://goreleaser.com/deprecations for details').length, 1);
+});

--- a/.github/workflows/brew-verify.yml
+++ b/.github/workflows/brew-verify.yml
@@ -10,13 +10,13 @@ name: brew-verify
 #     at the release commit, so a correction to the job (a different runner, a
 #     different tap path) can never be exercised against the release that
 #     needed it. v1.12.0 hit exactly that wall.
-#   * The tap is a separate repository. A formula can rot after publish —
+#   * The tap is a separate repository. A cask can rot after publish —
 #     someone edits the tap, an asset is deleted, a checksum stops matching —
 #     and nothing in this repo would notice until the NEXT release ran its
 #     smoke.
 #
 # It reuses `brew-smoke.mjs` unchanged, so there is one implementation of what
-# "the published formula is healthy" means; this lane only differs in when it
+# "the published cask is healthy" means; this lane only differs in when it
 # runs and which version it targets.
 on:
   workflow_dispatch:
@@ -60,7 +60,7 @@ jobs:
           # The HIGHEST stable release, not the most recently PUBLISHED one. A
           # maintenance backport publishes after the line above it, so
           # `--limit 1` returned v1.11.3 while v1.13.0 was the newest cerberus.
-          # The tap holds one formula and the highest tag owns it, so that is
+          # The tap holds one cask and the highest tag owns it, so that is
           # both the right default target and the signal brew-smoke.mjs needs to
           # pick its assertion branch.
           highest=$(gh release list --repo "$GITHUB_REPOSITORY" --exclude-drafts --exclude-pre-releases \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -409,8 +409,28 @@ jobs:
       - name: release-gate-drift self-test (gate rot detector)
         run: node .github/scripts/release-gate-drift.mjs --self-test
 
-      - name: brew-smoke self-test (formula-freshness guard)
+      - name: brew-smoke self-test (cask-freshness guard)
         run: node --test .github/scripts/brew-smoke.test.mjs
+
+      # goreleaser deprecation gate. `goreleaser check` reports a deprecated
+      # config section as an advisory line and still exits 0, and release.yml is
+      # the only other place goreleaser runs — so a deprecation first becomes
+      # visible in the scroll-back of a release that already published. That is
+      # how `brews:` outlived its replacement by several releases. The action is
+      # pinned to the same distribution/version release.yml uses, so this gate
+      # reports exactly what the next release run would warn about.
+      - name: goreleaser-deprecations self-test (detector guard)
+        run: node --test .github/scripts/goreleaser-deprecations.test.mjs
+
+      - name: install goreleaser
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          distribution: goreleaser
+          version: '~> v2'
+          install-only: true
+
+      - name: goreleaser config has no deprecated sections
+        run: node .github/scripts/goreleaser-deprecations.mjs
 
       # The migration lane's artifact resolver, here for the same reason:
       # migration-e2e.yml has no `pull_request:` trigger either, so this is the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -298,7 +298,7 @@ jobs:
     outputs:
       # Whether this tag is the highest stable release. Downstream jobs decide
       # what the newest line alone may own (the GitHub `Latest` pointer, the
-      # Homebrew formula) off this, so it has to leave the job, not just the
+      # Homebrew cask) off this, so it has to leave the job, not just the
       # step.
       is_latest: ${{ steps.is_latest.outputs.is_latest }}
     steps:
@@ -364,7 +364,7 @@ jobs:
       # and must not take:
       #   - the rolling `:latest` images (goreleaser's `latest-*` skip_push
       #     templates read `.Env.RELEASE_IS_LATEST`);
-      #   - the Homebrew formula (`brews[].skip_upload`, same env var) — `auto`
+      #   - the Homebrew cask (`homebrew_casks[].skip_upload`, same env var) — `auto`
       #     alone only filters prereleases, so v1.12.1 downgraded the tap from
       #     v1.13.0;
       #   - the GitHub `Latest` release pointer (the `publish` job's flip), which
@@ -396,7 +396,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_IS_LATEST: ${{ env.RELEASE_IS_LATEST }}
-          # Cross-repo push to tsouza/homebrew-tap for the brews block. The
+          # Cross-repo push to tsouza/homebrew-tap for the homebrew_casks block. The
           # default GITHUB_TOKEN cannot push to another repo; this PAT can.
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
 
@@ -512,8 +512,8 @@ jobs:
   #
   # Neither prereleases nor maintenance backports are skipped — each just gets a
   # different assertion, because `skip_upload` keeps both out of the tap:
-  #   - prerelease: the formula must exist and must NOT declare this version;
-  #   - not the highest stable tag: the formula must declare a STRICTLY NEWER
+  #   - prerelease: the cask must exist and must NOT declare this version;
+  #   - not the highest stable tag: the cask must declare a STRICTLY NEWER
   #     version, proving this publish did not overwrite the newest line's.
   brew-smoke:
     name: brew-smoke
@@ -547,7 +547,7 @@ jobs:
           # The BARE version. Comparing `cerberus --version` to `app_tag` would
           # be a guaranteed off-by-`v` mismatch.
           RELEASE_VERSION: ${{ needs.gate.outputs.app_version }}
-          # The same signal that decided whether goreleaser wrote the formula at
+          # The same signal that decided whether goreleaser wrote the cask at
           # all, so the smoke asserts the branch the tap actually took.
           RELEASE_IS_LATEST: ${{ needs.goreleaser.outputs.is_latest }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,45 +39,59 @@ archives:
       - README.md
       - CHANGELOG.md
 
-# Homebrew formula published to the tsouza/homebrew-tap tap, so operators can
-# `brew install tsouza/tap/cerberus`. The tap holds ONE cerberus formula, so
-# only stable releases on the newest line write it — see skip_upload below. The
+# Homebrew cask published to the tsouza/homebrew-tap tap, so operators can
+# `brew install tsouza/tap/cerberus`. The tap holds ONE cerberus cask, so only
+# stable releases on the newest line write it — see skip_upload below. The
 # cross-repo push needs a PAT (the default GITHUB_TOKEN cannot push to another
 # repo); it is supplied by the HOMEBREW_TAP_GITHUB_TOKEN secret in release.yml.
 #
-# We use `brews:` (a Homebrew FORMULA), not `homebrew_casks:`, on purpose:
-# goreleaser is nudging toward casks, but casks are macOS-only, and cerberus is
-# a Linux-first server binary — a formula installs on both Linuxbrew and macOS.
-brews:
+# A CASK, not a `brews:` formula: a formula describes something Homebrew builds
+# from source, while a cask installs a pre-built artifact — which is exactly
+# what a release archive is. It is not a macOS-only choice: `supports_linux?`
+# holds for any cask that declares no `depends_on macos`, and Homebrew's cask
+# installer gates on the CASK's declared OS rather than on the host being a
+# Mac, so one cask installs under Linuxbrew and macOS alike.
+homebrew_casks:
   - name: cerberus
     ids:
+      - cerberus
+    # Defaults to the cask name, which is already `cerberus`. Stated because
+    # brew-smoke.mjs asserts the installed binary resolves inside the brew
+    # prefix — the two have to agree on what gets linked into `bin`.
+    binaries:
       - cerberus
     repository:
       owner: tsouza
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
-    # Homebrew resolves a tap's formulae from `Formula/`, `HomebrewFormula/`,
-    # or the tap root, in that order — but goreleaser's `directory` defaults to
-    # EMPTY, i.e. the tap root, so v1.12.0 shipped `cerberus.rb` to the root.
-    # `Formula/` is the conventional layout, it is what `brew-smoke.mjs` pins
-    # (`TAP_FORMULA_PATH`), and it is the only one of the three that is not at
-    # risk from Homebrew's ongoing push to standardise tap layout. Pin it.
-    directory: Formula
+    # `Casks/` is both goreleaser's default and where Homebrew resolves a tap's
+    # casks from. Stated rather than inherited because brew-smoke.mjs pins the
+    # same path (`TAP_CASK_PATH`) and a silent drift between the two would make
+    # the smoke read a file no release writes.
+    directory: Casks
     homepage: "https://github.com/tsouza/cerberus"
     description: "Drop-in Prometheus / Loki / Tempo HTTP gateway for ClickHouse"
-    license: "Apache-2.0"
     # `auto` on its own only keeps PRERELEASES out of the tap. A stable
     # BACKPORT is not a prerelease, so `auto` alone let v1.12.1 — cut after
     # v1.13.0 — write the tap formula and DOWNGRADE every `brew install` to the
     # older line. Gate on RELEASE_IS_LATEST too (release.yml computes it from
     # the highest stable tag, the same signal the rolling `:latest` images use),
-    # so only the newest release line ever owns the formula. `skip_upload` is
+    # so only the newest release line ever owns the cask. `skip_upload` is
     # templated in goreleaser's run phase and read back at publish time.
     skip_upload: '{{ if eq .Env.RELEASE_IS_LATEST "true" }}auto{{ else }}true{{ end }}'
-    install: |
-      bin.install "cerberus"
-    test: |
-      system "#{bin}/cerberus", "--version"
+    hooks:
+      post:
+        # The release binaries are not Apple-signed or notarised, so macOS
+        # quarantines them on download and the first run dies with "cerberus is
+        # damaged and can't be opened" — a broken install that the tap looks
+        # perfectly healthy for. Stripping the quarantine xattr is Homebrew's
+        # and goreleaser's documented workaround. Guarded on OS.mac? because
+        # there is no such attribute on Linux and `xattr` is not there to run.
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr",
+                           args: ["-dr", "com.apple.quarantine", "#{staged_path}/cerberus"]
+          end
 
 checksum:
   name_template: "checksums.txt"

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ ships a [SLSA build provenance](https://slsa.dev) attestation:
 gh attestation verify cerberus_*_linux_amd64.tar.gz --owner tsouza --repo cerberus
 ```
 
-The same binary is a Homebrew formula (macOS and Linuxbrew), which is the
+The same binary is a Homebrew cask (macOS and Linuxbrew), which is the
 quickest way to get the `cerberus migrate` CLI onto the machine holding your
 rules and dashboards — see [migrating to cerberus](docs/migration.md#step-1-install-the-binary):
 
@@ -165,7 +165,7 @@ rules and dashboards — see [migrating to cerberus](docs/migration.md#step-1-in
 brew install tsouza/tap/cerberus
 ```
 
-Only stable releases publish a formula, so `brew` never hands you a prerelease.
+Only stable releases publish a cask, so `brew` never hands you a prerelease.
 
 The surrounding runtime contract (lifecycle, scaling, the solver and
 experimental knobs in context) lives in

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -141,7 +141,7 @@ brew install tsouza/tap/cerberus
 cerberus --version
 ```
 
-Only stable releases publish a formula, so `brew` never hands you a prerelease.
+Only stable releases publish a cask, so `brew` never hands you a prerelease.
 If you would rather not use Homebrew, the same binary ships as a
 [release archive](https://github.com/tsouza/cerberus/releases) (linux / darwin ×
 amd64 / arm64, each with a [SLSA](https://slsa.dev) provenance attestation). Or

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1119,7 +1119,7 @@ publish gates handle either or both.
 by comparing it against the highest stable `v*` tag — is the single answer to
 "is this the newest release line?", and every resource that only one line can
 hold at a time is gated on it: the rolling `:latest` image tags, the tap's
-single Homebrew formula, and the GitHub `Latest` release pointer. A prerelease
+single Homebrew cask, and the GitHub `Latest` release pointer. A prerelease
 or a stable backport never drags any of the three backwards.
 
 #### De-gated lanes on the publish path
@@ -1146,7 +1146,7 @@ now the only thing standing between them and a publish.
 
 #### Homebrew tap
 
-Stable releases publish a Homebrew formula to the
+Stable releases publish a Homebrew cask to the
 [`tsouza/homebrew-tap`](https://github.com/tsouza/homebrew-tap) tap, so operators
 can install the single `cerberus` binary with:
 
@@ -1159,17 +1159,26 @@ machine that holds an operator's rules and dashboards, so the migration
 playbook points at it as the default install path — see
 [getting the `cerberus` binary](migration.md#step-1-install-the-binary).
 
-This is wired via the goreleaser `brews:` block (a Homebrew *formula*, not a
-cask, so it installs on Linuxbrew as well as macOS). The tap holds a SINGLE
-`cerberus` formula, so `skip_upload` is templated on `RELEASE_IS_LATEST` — the
-highest-stable-tag signal `release.yml` computes after pushing the tag — and
-only a stable release on the newest line ever writes it. Neither an `rc.*` nor a
-maintenance backport touches the tap: a backport is not a prerelease, so the bare
-`skip_upload: auto` that predated this let v1.12.1 overwrite v1.13.0's formula
-and downgrade every `brew install`. The block pins `directory: Formula`: Homebrew resolves a tap's formulae from
-`Formula/`, `HomebrewFormula/` or the tap root, but goreleaser's `directory`
-defaults to **empty** — the tap root — and `Formula/` is both the conventional
-layout and the path the smoke reads.
+This is wired via the goreleaser `homebrew_casks:` block. A *cask* is the right
+vehicle for a pre-built binary — a formula describes something Homebrew builds
+from source — and it is not a macOS-only choice: a cask that declares no
+`depends_on macos` reports `supports_linux?`, and Homebrew's cask installer gates
+on the cask's declared OS rather than on the host being a Mac, so one cask
+installs under Linuxbrew and macOS alike. Because the release binaries are
+neither Apple-signed nor notarised, the cask carries a post-install hook that
+strips the `com.apple.quarantine` xattr, without which the first run on macOS
+dies with "cerberus is damaged and can't be opened".
+
+The tap holds a SINGLE `cerberus` cask, so `skip_upload` is templated on
+`RELEASE_IS_LATEST` — the highest-stable-tag signal `release.yml` computes after
+pushing the tag — and only a stable release on the newest line ever writes it.
+Neither an `rc.*` nor a maintenance backport touches the tap: a backport is not a
+prerelease, so the bare `skip_upload: auto` that predated this let v1.12.1
+overwrite v1.13.0's formula and downgrade every `brew install`. The block states
+`directory: Casks`, which is both goreleaser's default and where Homebrew
+resolves a tap's casks from; it is written out rather than inherited because
+`brew-smoke.mjs` pins the same path, and a silent drift between the two would
+leave the smoke reading a file no release writes.
 
 Two prerequisites make the push work, and both are one-time:
 
@@ -1177,32 +1186,34 @@ Two prerequisites make the push work, and both are one-time:
 2. A PAT with push (`contents: write`) access to that tap is stored as the
    `HOMEBREW_TAP_GITHUB_TOKEN` repository secret on `tsouza/cerberus`. The
    default workflow `GITHUB_TOKEN` **cannot** push to another repo, so this
-   secret is mandatory — without it the brew push on the next stable release
+   secret is mandatory — without it the cask push on the next stable release
    fails.
 
 The `brew-smoke` job closes the loop on both of those prerequisites. It reads the
-tap's `Formula/cerberus.rb` through the API *before* touching `brew`, because a
-deleted `brews:` block or an expired `HOMEBREW_TAP_GITHUB_TOKEN` leaves a stale
-formula that an install would happily consume. A stable release must find the
-formula declaring exactly the version that just shipped; it then installs it and
+tap's `Casks/cerberus.rb` through the API *before* touching `brew`, because a
+deleted `homebrew_casks:` block or an expired `HOMEBREW_TAP_GITHUB_TOKEN` leaves
+a stale cask that an install would happily consume. A stable release must find
+the cask declaring exactly the version that just shipped; it then installs it and
 asserts `cerberus --version` equals that version and that two offline verbs
-(`migrate schema`, `config-docs -check`) work from the installed binary. The two
-shapes that write no formula are **not** skipped — each takes the opposite
-assertion. An `rc.*` must have written none, so a formula declaring the
+(`migrate schema`, `config-docs -check`) work from the installed binary. The
+install names `--cask` explicitly, so if the tap ever serves a same-named formula
+again the job fails loudly instead of installing that one and calling the cask
+healthy. The two shapes that write no cask are **not** skipped — each takes the
+opposite assertion. An `rc.*` must have written none, so a cask declaring the
 prerelease version is a reported regression; a release that is not the highest
-stable tag must have left a strictly NEWER formula in place, so a tap that has
+stable tag must have left a strictly NEWER cask in place, so a tap that has
 fallen back to the backport's own version is one too. The job runs after
 `publish` because
 `brew install` downloads the release tarball, which 404s while the release is
 still a draft, and it runs on `macos-latest` because the Ubuntu runner image
-ships no Homebrew at all. That the formula (rather than a cask) also installs
-under Linuxbrew is a property of the artifact, not something CI exercises.
+ships no Homebrew at all. That the cask also installs under Linuxbrew is a
+property of the artifact, not something CI exercises.
 
 `brew-smoke` fires exactly once, inside the release run, which leaves one thing
 uncovered: it cannot re-check an *already-published* release. `rerun-failed-jobs`
 replays the workflow as it existed at the release commit, so a correction to the
 job — a different runner, a different tap path — can never be exercised against
-the release that needed it, and nothing here would notice a formula rotting
+the release that needed it, and nothing here would notice a cask rotting
 after publish (someone edits the tap, an asset is deleted, a checksum stops
 matching). The `brew-verify` workflow covers that: same `brew-smoke.mjs`, same
 assertions, but `workflow_dispatch` (with an optional bare `version`, defaulting

--- a/test/regression/release_gate_test.go
+++ b/test/regression/release_gate_test.go
@@ -25,7 +25,7 @@ import (
 //     public before anything drove the built image;
 //   - `continue-on-error` on brew-smoke: the job becomes decoration;
 //   - `skip_upload: auto` removed from .goreleaser.yml: prereleases start
-//     overwriting the tap formula, which is the thing brew-smoke's prerelease
+//     overwriting the tap cask, which is the thing brew-smoke's prerelease
 //     branch asserts against.
 const (
 	releaseWorkflowPath   = "../../.github/workflows/release.yml"
@@ -51,7 +51,7 @@ const (
 
 	// "Is this tag the highest stable release?" — the one signal that decides
 	// which release line may take a resource only one line can hold: the rolling
-	// `:latest` images, the Homebrew formula, and the GitHub `Latest` pointer.
+	// `:latest` images, the Homebrew cask, and the GitHub `Latest` pointer.
 	releaseIsLatestEnv = "RELEASE_IS_LATEST"
 	isLatestOutput     = "is_latest"
 	latestFlipToken    = "--latest="
@@ -246,8 +246,8 @@ func TestBrewSmokeIsBlockingAndOrderedAfterPublish(t *testing.T) {
 			"a broken tap would report green. Body:\n%s", releaseWorkflowPath, brewSmokeJob, job)
 	}
 
-	// The two no-formula branches of brew-smoke.mjs assert that a prerelease and
-	// a maintenance backport did NOT write a formula. Those assertions are only
+	// The two no-cask branches of brew-smoke.mjs assert that a prerelease and
+	// a maintenance backport did NOT write a cask. Those assertions are only
 	// meaningful while goreleaser is still configured to leave both taps alone,
 	// which is one template covering both conditions.
 	//
@@ -259,7 +259,7 @@ func TestBrewSmokeIsBlockingAndOrderedAfterPublish(t *testing.T) {
 	for _, want := range []string{releaseIsLatestEnv, "auto"} {
 		if !strings.Contains(skipUpload, want) {
 			t.Fatalf("%s has `skip_upload: %s`, which does not gate on %q. brew-smoke's prerelease and "+
-				"maintenance branches assert that neither wrote a formula, and would start failing every "+
+				"maintenance branches assert that neither wrote a cask, and would start failing every "+
 				"rc and every backport", goreleaserPath, skipUpload, want)
 		}
 	}
@@ -288,7 +288,7 @@ func valueOfYAMLKey(t *testing.T, body, key string) string {
 
 // TestOnlyTheNewestLineOwnsTheSharedReleaseResources pins the fix for v1.12.1 —
 // a backport cut after v1.13.0 — taking two resources that only one release line
-// can hold at a time: the Homebrew formula (it overwrote v1.13.0's, downgrading
+// can hold at a time: the Homebrew cask (it overwrote v1.13.0's, downgrading
 // every `brew install`) and the GitHub `Latest` pointer (v1.11.3, published last,
 // claimed it). Both defaults are silently wrong for a maintenance line:
 // `skip_upload: auto` filters only prereleases, and GitHub's release-update
@@ -331,7 +331,7 @@ func TestOnlyTheNewestLineOwnsTheSharedReleaseResources(t *testing.T) {
 	brew := workflowJobBody(t, workflow, brewSmokeJob)
 	if !strings.Contains(brew, releaseIsLatestEnv) {
 		t.Fatalf("%s job %q does not pass %s, so the smoke cannot assert that a backport left the "+
-			"newest line's formula in place. Body:\n%s",
+			"newest line's cask in place. Body:\n%s",
 			releaseWorkflowPath, brewSmokeJob, releaseIsLatestEnv, brew)
 	}
 }


### PR DESCRIPTION
## What

Migrates the goreleaser Homebrew publish from the deprecated `brews:` block to
`homebrew_casks:`, and adds a CI gate so the next deprecation does not have to
be spotted by reading a release log.

## Why the formula stayed, and why that reason was wrong

The config carried a comment justifying `brews:` on the grounds that *"casks are
macOS-only, and cerberus is a Linux-first server binary"*. That is not true.
`Cask#supports_linux?` holds for any cask that declares no `depends_on macos`,
and Homebrew's cask installer gates on the **cask's** declared OS rather than on
the host being a Mac — one cask installs under Linuxbrew and macOS alike.

A cask is also the more honest vehicle: a formula describes something Homebrew
*builds from source*, while the tap is serving a pre-built release archive.

`brews:` is soft-deprecated in goreleaser v2.10 and hard-deprecated in v2.16;
removal lands at the next major.

## The cask

- **Post-install `xattr -dr com.apple.quarantine`.** The release binaries are
  neither Apple-signed nor notarised, so without the hook the first run on macOS
  dies with *"cerberus is damaged and can't be opened"* — a broken install that
  the tap looks perfectly healthy for. Guarded on `OS.mac?`.
- **`directory: Casks`** — stated rather than inherited, because
  `brew-smoke.mjs` pins the same path and a silent drift would have the smoke
  read a file no release ever writes.
- **`skip_upload` template is byte-identical.** A maintenance backport still
  cannot overwrite the newest line's cask (the v1.12.1-over-v1.13.0 downgrade).
- Dropped `license:` / `install:` / `test:` — formula-only stanzas with no cask
  equivalent.

## `brew-smoke` follows the artifact

Reads `Casks/cerberus.rb`, and installs with an explicit `--cask`. The
disambiguator is deliberate: if the tap ever serves a same-named *formula*
again, the smoke fails loudly instead of quietly installing that one and
reporting the cask healthy. All three release-shape branches (newest stable /
`rc.*` / backport) keep their assertions unchanged. `brew-smoke.test.mjs`'s
fixture is now cask-shaped; the 8-row verdict table is untouched.

## Fix the class: `goreleaser-deprecations.mjs`

`goreleaser check` prints a deprecation as an advisory line and **still exits
0**, and `release.yml` — which has no `pull_request:` trigger — is the only
other place goreleaser runs. So a deprecation notice first becomes visible in
the scroll-back of a release that already published. That is precisely how
`brews:` survived several releases after `homebrew_casks:` replaced it.

The new gate runs on the required `lint` lane, reads the **real tool's output**
rather than scanning the YAML for a hardcoded list of dead keys (so a
deprecation announced upstream tomorrow is caught the same day without this
module knowing about it), and installs the same `distribution` / `version` that
`release.yml` pins — so it reports exactly what the next release run will warn
about.

Verified it actually fires:

| config | result |
| --- | --- |
| `origin/main` | `::error::… brews is being phased out in favor of homebrew_casks` — **exit 1** |
| this branch | `::notice::… validates with no deprecation notices` — **exit 0** |

## Not in this PR: the tap-side half

Adding `tap_migrations.json` to `tsouza/homebrew-tap` and deleting
`Formula/cerberus.rb` is sequenced for **after the first cask publishes** —
doing it before `Casks/cerberus.rb` exists would break `brew install
tsouza/tap/cerberus` in the gap. While both files coexist Homebrew prefers the
formula, so the follow-up also adds a "`Formula/cerberus.rb` must be absent"
assertion to `brew-smoke.mjs`, otherwise the smoke would read a fresh cask while
users keep getting the frozen formula.

## Validation

- `brew-smoke.test.mjs` — 15/15
- `goreleaser-deprecations.test.mjs` — 6/6
- `go test ./test/regression/ -run 'Release|Goreleaser|Brew'` — 10/10
- `actionlint`, `golangci-lint`, `markdownlint` — clean (pre-push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
