### PR TITLE
ci(compat): extract the compat-scores badge publisher to a module

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -464,6 +464,21 @@ One implementation means a new rule guards BOTH lanes at once.
     `compatibility/parity-baseline.json`).
   - Exit: `0` at or above baseline, `1` on a below-baseline regression or
     a missing/malformed score or baseline.
+- **`compat-publish-score.mjs`** — `compatibility.yml`, the three
+  `Publish score to compat-scores branch` steps. Publishes the head's
+  shields.io endpoint-badge JSON to `badges/<head>.json` on the
+  `compat-scores` orphan branch, which the README badges read over the raw
+  URL. Projects the score file down to the four endpoint-schema keys
+  (shields.io renders an `invalid properties` title if it sees cerberus's
+  `passed` / `total` / `percent`), bootstraps the orphan branch on first
+  run, and retries a rejected push so the three head jobs can race the same
+  branch. The workflow's `if:` gate keeps it to push-to-`main`.
+  - Env: `HEAD` (`prometheus`, `tempo`, or `loki`), `SRC` (path to that
+    head's `compat-score.json`).
+  - Exit: `0` published / already current / no score file to publish; `1`
+    on a wiring slip, an unreadable score, or every push attempt rejected.
+  - Tests: `compat-publish-score.test.mjs` (run in `ci.yml`), which
+    publishes against a real bare-repo remote in a temp dir.
 - **`resolve-bench-refs.mjs`** — `perf-benchmark.yml`, the
   `resolve baseline + ref SHAs` step.
   - Env: `INPUT_BASELINE_REF` (optional); writes `ref_sha`,

--- a/.github/scripts/compat-publish-score.mjs
+++ b/.github/scripts/compat-publish-score.mjs
@@ -1,0 +1,186 @@
+// compat-publish-score.mjs — publish one head's shields.io endpoint-badge
+// JSON to the `compat-scores` orphan branch, extracted from the THREE
+// identical "Publish score to compat-scores branch" steps in
+// .github/workflows/compatibility.yml (prometheus / tempo / loki).
+//
+// The branch is an orphan branch in the same repo holding badge JSON at
+// badges/<head>.json; the README badges hit the raw URL
+// https://raw.githubusercontent.com/tsouza/cerberus/compat-scores/badges/<head>.json.
+//
+// Three things make this more than a `git push`, and are why it is a module
+// rather than inline YAML:
+//
+//   Schema projection — the run's compat-score.json carries cerberus-only
+//   bookkeeping (passed / total / percent) alongside the badge keys.
+//   shields.io's endpoint schema is strict and renders an "invalid
+//   properties: passed, total, percent" SVG title if it sees them, so the
+//   file is projected down to the four schema keys before publishing.
+//
+//   Orphan bootstrap — on the very first run origin/compat-scores does not
+//   exist, so the branch is created with --orphan and its tree cleared, and
+//   badges/ becomes the branch's initial state.
+//
+//   Concurrency — the three head jobs finish near-simultaneously and race to
+//   push to the same branch. A non-fast-forward rejection is expected, not
+//   exceptional: re-fetch the new tip, re-apply this head's badge over it,
+//   and push again, capped so an unreachable remote cannot spin forever.
+//
+// Env contract:
+//   HEAD  head name; names the badge file badges/<HEAD>.json (prometheus|tempo|loki)
+//   SRC   path to that head's compat-score.json
+//
+// The workflow gates the step with `if: github.event_name == 'push' &&
+// github.ref == 'refs/heads/main'`, so this module never runs on a pull
+// request and needs no event check of its own.
+//
+// Exit codes: 0 published / nothing to publish / already up to date;
+// 1 when every push attempt was rejected or a git step failed.
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { error, git, log } from './lib/gh.mjs';
+
+// The orphan branch and the directory within it that the README badge URLs
+// resolve against — changing either breaks every published badge.
+const SCORES_BRANCH = 'compat-scores';
+const BADGES_DIR = 'badges';
+
+// Identity for the badge commits. A distinct bot name keeps the branch's
+// history legible next to release commits from the same token.
+const BOT_NAME = 'cerberus-compat-bot';
+const BOT_EMAIL = 'cerberus-compat-bot@users.noreply.github.com';
+
+// A rejected push means another head won the race, so retrying is the
+// expected path, not error handling. The cap bounds the case where the
+// remote is unreachable rather than merely contended; the backoff spaces
+// attempts so three simultaneous heads deterministically de-collide.
+const MAX_ATTEMPTS = 5;
+const RETRY_BACKOFF_STEP_MS = 2000;
+
+// The four keys shields.io's endpoint-badge schema accepts. Anything else
+// in the score file is cerberus-side bookkeeping and must not be published.
+const SHIELDS_KEYS = ['schemaVersion', 'label', 'message', 'color'];
+
+// shieldsSubset projects a score object down to the shields.io endpoint
+// schema, preserving key order and rendering a missing key as null — the
+// same projection `jq '{schemaVersion, label, message, color}'` performs,
+// down to the byte, so a run that publishes an unchanged score still
+// produces an empty diff rather than a no-op commit.
+export function shieldsSubset(score) {
+  const out = {};
+  for (const key of SHIELDS_KEYS) out[key] = score?.[key] ?? null;
+  return `${JSON.stringify(out, null, 2)}\n`;
+}
+
+// retryDelayMs is the wait before re-attempting after `attempt` was rejected.
+// It grows with the attempt number so three heads pushing at once spread out
+// instead of re-colliding on a fixed cadence.
+export function retryDelayMs(attempt) {
+  return (attempt + 1) * RETRY_BACKOFF_STEP_MS;
+}
+
+// sleepSync blocks the loop between push attempts. The retry cadence has to
+// hold across a git push, so a synchronous wait keeps the whole publish a
+// single straight-line sequence rather than an async state machine.
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+// mustGit runs a git command that has no meaningful failure mode other than
+// "the runner is broken", and exits 1 with the command's own stderr when it
+// does fail — mirroring `set -e` in the bash this replaces.
+function mustGit(args) {
+  const res = git(args);
+  if (res.status !== 0) {
+    error(`git ${args.join(' ')} failed: ${res.stderr.trim() || res.stdout.trim()}`, {
+      title: 'compat-scores publish failed',
+    });
+    process.exit(1);
+  }
+  return res.stdout;
+}
+
+function main() {
+  const head = process.env.HEAD || '';
+  const src = process.env.SRC || '';
+
+  if (!head || !src) {
+    error('compat-publish-score.mjs: HEAD and SRC env vars are required', {
+      title: 'compat-scores publish failed',
+    });
+    process.exit(1);
+  }
+
+  // A missing score file means the harness failed before the scorer ran. That
+  // failure is already raised by the job's own "Fail job" step; publishing has
+  // simply got nothing to do, so it must not add a second red herring.
+  if (!existsSync(src)) {
+    log(`no score file at ${src}; nothing to publish`);
+    process.exit(0);
+  }
+
+  // Read and project BEFORE touching the branch: the orphan-bootstrap path
+  // clears the working tree, which would take the score file with it.
+  let badge;
+  try {
+    badge = shieldsSubset(JSON.parse(readFileSync(src, 'utf8')));
+  } catch (e) {
+    error(`could not read ${src}: ${e.message}`, { title: 'compat-scores publish failed' });
+    process.exit(1);
+  }
+
+  mustGit(['config', 'user.name', BOT_NAME]);
+  mustGit(['config', 'user.email', BOT_EMAIL]);
+
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    log(`==> publish attempt ${attempt} / ${MAX_ATTEMPTS}`);
+
+    // A fetch failure is not fatal on its own: the branch may simply not exist
+    // yet, which the rev-parse below distinguishes.
+    git(['fetch', 'origin', SCORES_BRANCH]);
+
+    if (git(['rev-parse', '--verify', `origin/${SCORES_BRANCH}`]).status === 0) {
+      mustGit(['checkout', '-B', SCORES_BRANCH, `origin/${SCORES_BRANCH}`]);
+    } else {
+      // First run: detach onto an orphan, then clear index and working tree so
+      // badges/ is the branch's entire initial state, not a copy of main.
+      mustGit(['checkout', '--orphan', SCORES_BRANCH]);
+      git(['rm', '-rf', '.']); // an empty index on a fresh orphan is not a failure
+      mustGit(['clean', '-fdx']);
+    }
+
+    mkdirSync(BADGES_DIR, { recursive: true });
+    writeFileSync(path.join(BADGES_DIR, `${head}.json`), badge);
+    mustGit(['add', `${BADGES_DIR}/`]);
+
+    if (git(['diff', '--staged', '--quiet']).status === 0) {
+      log('score unchanged; no commit needed');
+      process.exit(0);
+    }
+
+    mustGit(['commit', '-m', `${SCORES_BRANCH}: update ${head} score`]);
+
+    if (git(['push', 'origin', SCORES_BRANCH]).status === 0) {
+      log(`==> published ${head} score on attempt ${attempt}`);
+      process.exit(0);
+    }
+
+    log('==> push rejected (likely concurrent update); retrying');
+    // Drop back to a clean tree so the next attempt's checkout starts from a
+    // state git will fast-forward rather than refuse.
+    mustGit(['reset', '--hard']);
+    // No backoff after the final attempt — there is nothing left to wait for,
+    // and the bash this replaces spent its longest sleep on the way to exit 1.
+    if (attempt < MAX_ATTEMPTS) sleepSync(retryDelayMs(attempt));
+  }
+
+  error(`could not push ${head} score after ${MAX_ATTEMPTS} attempts`, {
+    title: 'compat-scores publish failed',
+  });
+  process.exit(1);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/.github/scripts/compat-publish-score.test.mjs
+++ b/.github/scripts/compat-publish-score.test.mjs
@@ -1,0 +1,261 @@
+// compat-publish-score.test.mjs — in-process pins for the compat-scores
+// badge publisher.
+//
+// The publish path is exercised against a REAL local git remote rather than a
+// mock: the orphan bootstrap, the badge commit, and the unchanged-score
+// short-circuit are all git behaviours, and a mock that agreed with the
+// script's assumptions would pass while the branch stayed empty in CI. The
+// remote is a bare repo in a temp dir, so the whole file runs offline in
+// well under a second.
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { test } from 'node:test';
+
+import { retryDelayMs, shieldsSubset } from './compat-publish-score.mjs';
+
+const SCRIPT = fileURLToPath(new URL('./compat-publish-score.mjs', import.meta.url));
+
+function git(cwd, args) {
+  const res = spawnSync('git', args, { cwd, encoding: 'utf8' });
+  assert.equal(res.status, 0, `git ${args.join(' ')} failed: ${res.stderr}`);
+  return res.stdout;
+}
+
+// makeRemote builds an origin/work pair: a bare repo standing in for GitHub
+// and a clone-shaped work repo with one commit on main, matching the state
+// actions/checkout leaves the runner in.
+function makeRemote() {
+  const root = mkdtempSync(path.join(tmpdir(), 'compat-scores-'));
+  const origin = path.join(root, 'origin.git');
+  const work = path.join(root, 'work');
+  git(root, ['init', '--bare', '--initial-branch=main', origin]);
+  git(root, ['init', '--initial-branch=main', work]);
+  git(work, ['config', 'user.name', 'test']);
+  git(work, ['config', 'user.email', 'test@example.com']);
+  writeFileSync(path.join(work, 'README.md'), '# work\n');
+  git(work, ['add', '.']);
+  git(work, ['commit', '-m', 'init']);
+  git(work, ['remote', 'add', 'origin', origin]);
+  git(work, ['push', '-u', 'origin', 'main']);
+  return { root, origin, work };
+}
+
+// writeScore drops a score file where the workflow's SRC points — INSIDE the
+// repo, as in production, so the orphan bootstrap's `git clean -fdx` really
+// does get the chance to delete it out from under the publisher.
+function writeScore(work, score) {
+  const dir = path.join(work, 'compatibility', 'prometheus');
+  mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, 'compat-score.json');
+  writeFileSync(file, `${JSON.stringify(score, null, 2)}\n`);
+  return file;
+}
+
+function publish(work, { head = 'prometheus', src }) {
+  return spawnSync(process.execPath, [SCRIPT], {
+    cwd: work,
+    encoding: 'utf8',
+    env: { ...process.env, HEAD: head, SRC: src },
+  });
+}
+
+// badgeOn reads the published badge straight out of the remote, so the
+// assertion is about what a shields.io fetch would see, not about local state.
+function badgeOn(origin, head) {
+  return git(origin, ['show', `compat-scores:badges/${head}.json`]);
+}
+
+const richScore = {
+  schemaVersion: 1,
+  label: 'promql compat',
+  message: '737/737',
+  color: 'brightgreen',
+  passed: 737,
+  total: 737,
+  percent: 100,
+};
+
+test('shieldsSubset keeps only the endpoint-schema keys, in order', () => {
+  const out = shieldsSubset(richScore);
+  assert.deepEqual(Object.keys(JSON.parse(out)), [
+    'schemaVersion',
+    'label',
+    'message',
+    'color',
+  ]);
+  // The cerberus-side bookkeeping is what makes shields.io render an
+  // "invalid properties" title instead of the badge.
+  for (const key of ['passed', 'total', 'percent']) {
+    assert.equal(out.includes(key), false, `${key} must not be published`);
+  }
+});
+
+test('shieldsSubset renders jq-identical bytes so an unchanged score is an empty diff', () => {
+  const jq = spawnSync('jq', ['{schemaVersion, label, message, color}'], {
+    input: JSON.stringify(richScore),
+    encoding: 'utf8',
+  });
+  // jq is present on ubuntu-latest and on the dev box; if it is genuinely
+  // absent the byte-for-byte claim cannot be checked here, and the publish
+  // integration test below still pins the behaviour that depends on it.
+  assert.equal(jq.status, 0, 'jq must be available to pin the byte-identical claim');
+  assert.equal(shieldsSubset(richScore), jq.stdout);
+});
+
+test('shieldsSubset nulls absent keys and preserves falsy ones', () => {
+  assert.deepEqual(JSON.parse(shieldsSubset({ schemaVersion: 1 })), {
+    schemaVersion: 1,
+    label: null,
+    message: null,
+    color: null,
+  });
+  // 0 and '' are legitimate badge values; only null/undefined become null.
+  assert.deepEqual(JSON.parse(shieldsSubset({ schemaVersion: 0, label: '' })), {
+    schemaVersion: 0,
+    label: '',
+    message: null,
+    color: null,
+  });
+});
+
+test('retryDelayMs grows with the attempt so racing heads de-collide', () => {
+  const delays = [1, 2, 3, 4, 5].map(retryDelayMs);
+  assert.deepEqual(delays, [4000, 6000, 8000, 10000, 12000]);
+});
+
+test('publish bootstraps the orphan branch and lands the badge on the remote', () => {
+  const { root, origin, work } = makeRemote();
+  try {
+    const src = writeScore(work, richScore);
+    const res = publish(work, { src });
+    assert.equal(res.status, 0, res.stdout + res.stderr);
+
+    assert.equal(badgeOn(origin, 'prometheus'), shieldsSubset(richScore));
+
+    // Orphan, not a branch off main: the badge tree must not carry main's
+    // files, or every badge push would drag the whole repo with it.
+    const tree = git(origin, ['ls-tree', '-r', '--name-only', 'compat-scores']);
+    assert.deepEqual(tree.trim().split('\n'), ['badges/prometheus.json']);
+    assert.equal(
+      git(origin, ['rev-list', '--count', 'compat-scores']).trim(),
+      '1',
+      'orphan branch must start its own history',
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('publish is idempotent: an unchanged score adds no commit', () => {
+  const { root, origin, work } = makeRemote();
+  try {
+    const src = writeScore(work, richScore);
+    assert.equal(publish(work, { src }).status, 0);
+    const first = git(origin, ['rev-parse', 'compat-scores']).trim();
+
+    // The bootstrap cleaned the tree, so restage the score the way a fresh
+    // runner would before the second publish.
+    const again = writeScore(work, richScore);
+    const res = publish(work, { src: again });
+    assert.equal(res.status, 0, res.stdout + res.stderr);
+    assert.match(res.stdout, /score unchanged; no commit needed/);
+    assert.equal(git(origin, ['rev-parse', 'compat-scores']).trim(), first);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('publish commits over the existing branch when the score moves', () => {
+  const { root, origin, work } = makeRemote();
+  try {
+    assert.equal(publish(work, { src: writeScore(work, richScore) }).status, 0);
+
+    const moved = { ...richScore, message: '738/738', passed: 738, total: 738 };
+    assert.equal(publish(work, { src: writeScore(work, moved) }).status, 0);
+
+    assert.equal(badgeOn(origin, 'prometheus'), shieldsSubset(moved));
+    assert.equal(
+      git(origin, ['rev-list', '--count', 'compat-scores']).trim(),
+      '2',
+      'a moved score must fast-forward the branch, not restart it',
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('a second head publishes alongside the first rather than replacing it', () => {
+  const { root, origin, work } = makeRemote();
+  try {
+    assert.equal(publish(work, { src: writeScore(work, richScore) }).status, 0);
+
+    const loki = { ...richScore, label: 'logql compat', message: '512/512' };
+    const res = publish(work, { head: 'loki', src: writeScore(work, loki) });
+    assert.equal(res.status, 0, res.stdout + res.stderr);
+
+    // Both badges must survive: the three heads share one branch, and a
+    // publisher that reset the tree would silently unpublish its siblings.
+    assert.deepEqual(
+      git(origin, ['ls-tree', '-r', '--name-only', 'compat-scores']).trim().split('\n').sort(),
+      ['badges/loki.json', 'badges/prometheus.json'],
+    );
+    assert.equal(badgeOn(origin, 'prometheus'), shieldsSubset(richScore));
+    assert.equal(badgeOn(origin, 'loki'), shieldsSubset(loki));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('a missing score file is a no-op, not a failure', () => {
+  const { root, origin, work } = makeRemote();
+  try {
+    const res = publish(work, { src: path.join(work, 'nope', 'compat-score.json') });
+    // The harness failure is raised by the job's own "Fail job" step; this
+    // step must not add a second red herring on top of it.
+    assert.equal(res.status, 0, res.stdout + res.stderr);
+    assert.match(res.stdout, /nothing to publish/);
+    assert.equal(
+      spawnSync('git', ['rev-parse', '--verify', 'compat-scores'], { cwd: origin }).status !== 0,
+      true,
+      'nothing may be published when there is no score',
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('a wiring slip with no HEAD/SRC fails loudly', () => {
+  const { root, work } = makeRemote();
+  try {
+    const res = spawnSync(process.execPath, [SCRIPT], {
+      cwd: work,
+      encoding: 'utf8',
+      env: { ...process.env, HEAD: '', SRC: '' },
+    });
+    assert.equal(res.status, 1);
+    assert.match(res.stdout, /HEAD and SRC env vars are required/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('the score file survives the orphan bootstrap that clears the tree', () => {
+  const { root, origin, work } = makeRemote();
+  try {
+    const src = writeScore(work, richScore);
+    assert.equal(publish(work, { src }).status, 0);
+    // Reading before switching branches is the only reason this works: the
+    // bootstrap's `git clean -fdx` deletes SRC, so a publisher that read it
+    // late would publish nothing at all on the very first run.
+    assert.equal(readFileSync(path.join(origin, 'HEAD'), 'utf8').length > 0, true);
+    assert.equal(badgeOn(origin, 'prometheus'), shieldsSubset(richScore));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -609,6 +609,14 @@ jobs:
           node --test .github/scripts/compose-smoke-matrix.test.mjs
           node --test .github/scripts/dashboard-matrix.test.mjs
 
+      # Same rationale, one lane over: the compat-scores badge publisher only
+      # runs on push-to-main, so a break in it would first surface as stale
+      # README badges nobody is watching. The test publishes against a real
+      # bare-repo remote in a temp dir — offline, ~1s — so the orphan
+      # bootstrap and the sibling-badge preservation are pinned on the PR path.
+      - name: Assert the compat-scores badge publisher still publishes
+        run: node --test .github/scripts/compat-publish-score.test.mjs
+
   # `link-check` is the INTERNAL markdown link + anchor integrity gate. It
   # runs lychee in pure OFFLINE mode (`--offline --include-fragments`): no
   # network is touched, so it CANNOT flake on a slow/blocked host — every

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -347,81 +347,15 @@ jobs:
       - name: Publish score to compat-scores branch
         # Only push: main triggers the publish; pull_request / schedule /
         # workflow_dispatch all short-circuit at the `if:` gate. The
-        # compat-scores branch
-        # is an orphan branch in the same repo that holds shields.io
-        # endpoint-badge JSON at badges/<head>.json — README badges hit
-        # the raw URL https://raw.githubusercontent.com/tsouza/cerberus/
-        # compat-scores/badges/<head>.json.
-        #
-        # First-run bootstrap: if origin/compat-scores doesn't exist yet,
-        # we create it as an --orphan branch with just the badges/ tree.
-        # Subsequent runs fast-forward over the previous tip.
-        #
-        # Concurrency: the three head jobs (prometheus / loki / tempo)
-        # may finish near-simultaneously and race to push to the same
-        # branch. We retry on "non-fast-forward" rejections by
-        # re-fetching the latest tip, re-applying our update, and
-        # pushing again — capped at MAX_ATTEMPTS to avoid an infinite
-        # loop if the remote is fundamentally unreachable.
+        # orphan-branch contract, the shields.io schema projection, and the
+        # retry that lets the three head jobs race safely against one branch
+        # all live in the module — see .github/scripts/compat-publish-score.mjs.
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         env:
           HEAD: prometheus
           SRC: compatibility/prometheus/compat-score.json
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          if [ ! -f "$SRC" ]; then
-            echo "no score file at $SRC; nothing to publish"
-            exit 0
-          fi
-          git config user.name "cerberus-compat-bot"
-          git config user.email "cerberus-compat-bot@users.noreply.github.com"
-          # Stash a shields-compatible subset of the score file before we
-          # switch branches: the rich score file (passed / total / percent)
-          # is great for the artifact + step-summary, but shields.io's
-          # endpoint-badge schema is strict and rejects unknown keys with
-          # an "invalid properties: passed, total, percent" SVG title.
-          # Strip to the four schema-spec keys here so the orphan-branch
-          # JSON renders cleanly.
-          tmp=$(mktemp)
-          jq '{schemaVersion, label, message, color}' "$SRC" > "$tmp"
-
-          MAX_ATTEMPTS=5
-          attempt=1
-          while [ "$attempt" -le "$MAX_ATTEMPTS" ]; do
-            echo "==> publish attempt $attempt / $MAX_ATTEMPTS"
-            git fetch origin compat-scores 2>/dev/null || true
-            if git rev-parse --verify origin/compat-scores >/dev/null 2>&1; then
-              git checkout -B compat-scores origin/compat-scores
-            else
-              # Orphan-bootstrap on first run: detach, clear the index +
-              # working tree, then commit the badges/ directory as the
-              # branch's initial state.
-              git checkout --orphan compat-scores
-              git rm -rf . 2>/dev/null || true
-              git clean -fdx
-            fi
-            mkdir -p badges
-            cp "$tmp" "badges/${HEAD}.json"
-            git add badges/
-            if git diff --staged --quiet; then
-              echo "score unchanged; no commit needed"
-              exit 0
-            fi
-            git commit -m "compat-scores: update ${HEAD} score"
-            if git push origin compat-scores; then
-              echo "==> published ${HEAD} score on attempt $attempt"
-              exit 0
-            fi
-            echo "==> push rejected (likely concurrent update); retrying"
-            # Reset our local branch state so the next iteration starts
-            # from a clean tree before re-fetching.
-            git reset --hard
-            attempt=$((attempt + 1))
-            sleep $((attempt * 2))
-          done
-          echo "::error title=compat-scores publish failed::could not push ${HEAD} score after $MAX_ATTEMPTS attempts"
-          exit 1
+        run: node .github/scripts/compat-publish-score.mjs
 
       - name: Disk-pressure self-diagnosis on failure
         # Infra-flake breadcrumb: the compose stack (CH + reference Prom +
@@ -739,51 +673,7 @@ jobs:
           HEAD: tempo
           SRC: compatibility/tempo/reports/compat-score.json
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          if [ ! -f "$SRC" ]; then
-            echo "no score file at $SRC; nothing to publish"
-            exit 0
-          fi
-          git config user.name "cerberus-compat-bot"
-          git config user.email "cerberus-compat-bot@users.noreply.github.com"
-          # Strip cerberus-only bookkeeping (passed / total / percent)
-          # before publishing: shields.io rejects unknown keys on the
-          # endpoint-badge schema with an "invalid properties" SVG title.
-          tmp=$(mktemp)
-          jq '{schemaVersion, label, message, color}' "$SRC" > "$tmp"
-
-          MAX_ATTEMPTS=5
-          attempt=1
-          while [ "$attempt" -le "$MAX_ATTEMPTS" ]; do
-            echo "==> publish attempt $attempt / $MAX_ATTEMPTS"
-            git fetch origin compat-scores 2>/dev/null || true
-            if git rev-parse --verify origin/compat-scores >/dev/null 2>&1; then
-              git checkout -B compat-scores origin/compat-scores
-            else
-              git checkout --orphan compat-scores
-              git rm -rf . 2>/dev/null || true
-              git clean -fdx
-            fi
-            mkdir -p badges
-            cp "$tmp" "badges/${HEAD}.json"
-            git add badges/
-            if git diff --staged --quiet; then
-              echo "score unchanged; no commit needed"
-              exit 0
-            fi
-            git commit -m "compat-scores: update ${HEAD} score"
-            if git push origin compat-scores; then
-              echo "==> published ${HEAD} score on attempt $attempt"
-              exit 0
-            fi
-            echo "==> push rejected (likely concurrent update); retrying"
-            git reset --hard
-            attempt=$((attempt + 1))
-            sleep $((attempt * 2))
-          done
-          echo "::error title=compat-scores publish failed::could not push ${HEAD} score after $MAX_ATTEMPTS attempts"
-          exit 1
+        run: node .github/scripts/compat-publish-score.mjs
 
       - name: Disk-pressure self-diagnosis on failure
         # Same self-diagnosis as the prometheus job: the harness tears the
@@ -908,51 +798,7 @@ jobs:
           HEAD: loki
           SRC: compatibility/loki/reports/compat-score.json
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          if [ ! -f "$SRC" ]; then
-            echo "no score file at $SRC; nothing to publish"
-            exit 0
-          fi
-          git config user.name "cerberus-compat-bot"
-          git config user.email "cerberus-compat-bot@users.noreply.github.com"
-          # Strip cerberus-only bookkeeping (passed / total / percent)
-          # before publishing: shields.io rejects unknown keys on the
-          # endpoint-badge schema with an "invalid properties" SVG title.
-          tmp=$(mktemp)
-          jq '{schemaVersion, label, message, color}' "$SRC" > "$tmp"
-
-          MAX_ATTEMPTS=5
-          attempt=1
-          while [ "$attempt" -le "$MAX_ATTEMPTS" ]; do
-            echo "==> publish attempt $attempt / $MAX_ATTEMPTS"
-            git fetch origin compat-scores 2>/dev/null || true
-            if git rev-parse --verify origin/compat-scores >/dev/null 2>&1; then
-              git checkout -B compat-scores origin/compat-scores
-            else
-              git checkout --orphan compat-scores
-              git rm -rf . 2>/dev/null || true
-              git clean -fdx
-            fi
-            mkdir -p badges
-            cp "$tmp" "badges/${HEAD}.json"
-            git add badges/
-            if git diff --staged --quiet; then
-              echo "score unchanged; no commit needed"
-              exit 0
-            fi
-            git commit -m "compat-scores: update ${HEAD} score"
-            if git push origin compat-scores; then
-              echo "==> published ${HEAD} score on attempt $attempt"
-              exit 0
-            fi
-            echo "==> push rejected (likely concurrent update); retrying"
-            git reset --hard
-            attempt=$((attempt + 1))
-            sleep $((attempt * 2))
-          done
-          echo "::error title=compat-scores publish failed::could not push ${HEAD} score after $MAX_ATTEMPTS attempts"
-          exit 1
+        run: node .github/scripts/compat-publish-score.mjs
 
       - name: Disk-pressure self-diagnosis on failure
         # Same self-diagnosis as the prometheus job: the harness tears the


### PR DESCRIPTION
## What

The three head jobs in `compatibility.yml` (prometheus / tempo / loki) each carried a **verbatim copy** of the same ~50-line publish block. This replaces all three with `node .github/scripts/compat-publish-score.mjs`, keeping the identical `HEAD` / `SRC` env contract.

Net: **-160 lines of triplicated inline bash**, +1 module, +1 test.

## Why

Two rules point the same way:

- *Non-trivial CI step logic lives in `.github/scripts/*.mjs`, not inline YAML.* The block is a `jq` schema projection, an orphan-branch bootstrap, and a retry loop — real logic, not a one-liner.
- Triplicated, it had no mechanism to stay in sync. The prometheus copy already carried a longer comment header than the other two; a fix applied to one would silently not reach the others.

## Behaviour preserved

| bash | module |
|---|---|
| `jq '{schemaVersion, label, message, color}'` | `shieldsSubset()` — **byte-identical**, pinned by a test that runs `jq` and compares |
| missing `$SRC` → `exit 0` | same (the job's own "Fail job" step raises the real failure; this must not add a second red herring) |
| orphan bootstrap on first run | same |
| `MAX_ATTEMPTS=5`, sleeps 4s/6s/8s/10s | same ladder, `retryDelayMs()` pinned by test |
| `::error title=compat-scores publish failed::` → `exit 1` | same |

**One deliberate deviation:** no backoff after the *final* attempt. The bash slept 12s on its way to `exit 1`, which bought nothing.

The byte-identical projection matters beyond tidiness: the publisher decides "nothing to do" via `git diff --staged --quiet`, so a reformat would have produced a spurious commit on all three badges the first time this ran.

## Test

`compat-publish-score.test.mjs` publishes against a **real bare-repo remote** in a temp dir — offline, ~1s — rather than a mock that would have agreed with the script's assumptions while the branch stayed empty in CI. It covers the orphan bootstrap, the fast-forward update, the unchanged-score short-circuit, the missing-score no-op, and that a second head's publish **leaves the first head's badge in place**.

Verified it bites: forcing the orphan path to always run (the plausible refactor slip, which would unpublish sibling badges on every push) fails 3 of the 11 tests.

Wired into `ci.yml`'s `forbid-skip` job alongside the existing `compose-smoke-matrix` / `dashboard-matrix` self-tests, for the same reason — the publisher only runs on push-to-`main`, so a break in it would otherwise first surface as stale README badges nobody is watching.

## Risk

The step is gated `if: github.event_name == 'push' && github.ref == 'refs/heads/main'`, so it does not execute on this PR. First real exercise is the merge commit; the badges are the observable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)