### PR TITLE
fix(cli): lead the root help with an ASCII banner and a plain-English blurb

### DIFF
--- a/cmd/cerberus/banner.go
+++ b/cmd/cerberus/banner.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"runtime/debug"
+	"strings"
+	"time"
+	"unicode/utf8"
+)
+
+// bannerArt is the ASCII wordmark printed at the top of the root help. A raw
+// literal keeps the backslashes verbatim; the whitespace-only final row is the
+// gap the build-identity line sits in.
+const bannerArt = `   ___          _
+  / __\___ _ __| |__   ___ _ __ _   _ ___
+ / /  / _ \ '__| '_ \ / _ \ '__| | | / __|
+/ /__|  __/ |  | |_) |  __/ |  | |_| \__ \
+\____/\___|_|  |_.__/ \___|_|   \__,_|___/
+`
+
+// bannerMetaSeparator joins the two build-identity fields on the banner's meta
+// line.
+const bannerMetaSeparator = " · "
+
+// bannerBuildDatePrefix labels the build-date field on the banner meta line.
+const bannerBuildDatePrefix = "built "
+
+// devVersion is the main.Version fallback for a build with no goreleaser ldflag.
+const devVersion = "dev"
+
+// vcsTimeSetting is the runtime/debug build setting carrying the commit
+// timestamp — the same embedded build info buildRevision reads vcs.revision from.
+const vcsTimeSetting = "vcs.time"
+
+// buildDateLayout renders the vcs.time stamp as a bare calendar date.
+const buildDateLayout = "2006-01-02"
+
+// rootDescription is the human-facing blurb under the wordmark: what cerberus
+// is, in the register of the project's one-line pitch, hard-wrapped to fit an
+// 80-column terminal. The subcommand list below it carries the rest.
+const rootDescription = "Drop-in Prometheus / Loki / Tempo HTTP gateway for ClickHouse.\n" +
+	"Translate PromQL, LogQL, and TraceQL into optimized ClickHouse SQL —\n" +
+	"keep Grafana, swap the backend.\n" +
+	"\n" +
+	"Run with no subcommand to start the server."
+
+// rootLong renders the root help body: the wordmark, the build-identity line
+// flush under it, then the description.
+func rootLong() string {
+	return renderBanner(Version, buildDate()) + "\n\n" + rootDescription
+}
+
+// renderBanner returns the wordmark with the build-identity line right-aligned
+// under it. An empty version degrades to "dev" and an empty buildDate drops the
+// build-date field entirely, so an unstamped dev build never prints "v · built ".
+func renderBanner(version, buildDate string) string {
+	meta := bannerMetaLine(version, buildDate)
+	var b strings.Builder
+	b.WriteString(strings.TrimRight(bannerArt, "\n"))
+	b.WriteByte('\n')
+	if pad := bannerArtWidth() - utf8.RuneCountInString(meta); pad > 0 {
+		b.WriteString(strings.Repeat(" ", pad))
+	}
+	b.WriteString(meta)
+	return b.String()
+}
+
+// bannerMetaLine renders the build-identity fields, omitting the build date when
+// the binary carries no VCS timestamp.
+func bannerMetaLine(version, buildDate string) string {
+	meta := bannerVersionLabel(version)
+	if buildDate != "" {
+		meta += bannerMetaSeparator + bannerBuildDatePrefix + buildDate
+	}
+	return meta
+}
+
+// bannerVersionLabel renders main.Version for display. goreleaser injects the
+// bare tag ("1.13.1"), which reads as a version only with a "v" prefix; anything
+// that doesn't start with a digit ("dev", an already-prefixed "v1.13.1") is
+// printed as-is.
+func bannerVersionLabel(version string) string {
+	if version == "" {
+		return devVersion
+	}
+	if c := version[0]; c >= '0' && c <= '9' {
+		return "v" + version
+	}
+	return version
+}
+
+// bannerArtWidth is the column count of the widest wordmark row, ignoring
+// trailing padding. The meta line is right-aligned to it so the version sits
+// flush with the wordmark's right edge.
+func bannerArtWidth() int {
+	width := 0
+	for _, line := range strings.Split(bannerArt, "\n") {
+		if n := utf8.RuneCountInString(strings.TrimRight(line, " ")); n > width {
+			width = n
+		}
+	}
+	return width
+}
+
+// buildDate returns the binary's build date as YYYY-MM-DD, read from the same
+// embedded build info as buildRevision. It is empty when the build carries no
+// VCS timestamp (a `go test` binary, or -buildvcs=false), which is what lets the
+// banner drop the field instead of printing a blank one.
+func buildDate() string {
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return ""
+	}
+	for _, s := range bi.Settings {
+		if s.Key != vcsTimeSetting {
+			continue
+		}
+		t, err := time.Parse(time.RFC3339, s.Value)
+		if err != nil {
+			return ""
+		}
+		return t.Format(buildDateLayout)
+	}
+	return ""
+}

--- a/cmd/cerberus/banner_test.go
+++ b/cmd/cerberus/banner_test.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// bannerArtGlyphRows is the number of rows the wordmark spells "Cerberus" over.
+const bannerArtGlyphRows = 5
+
+// bannerArtColumns is the wordmark's rendered width; the meta line is padded to
+// exactly this many columns so it ends flush with the art's right edge.
+const bannerArtColumns = 42
+
+// TestBannerArtShape pins the wordmark's geometry. Without it, blanking or
+// truncating bannerArt would still leave every "does the help contain the art"
+// assertion vacuously true.
+func TestBannerArtShape(t *testing.T) {
+	rows := 0
+	for _, line := range strings.Split(bannerArt, "\n") {
+		if strings.TrimSpace(line) != "" {
+			rows++
+		}
+	}
+	if rows != bannerArtGlyphRows {
+		t.Errorf("bannerArt has %d glyph rows, want %d", rows, bannerArtGlyphRows)
+	}
+	if w := bannerArtWidth(); w != bannerArtColumns {
+		t.Errorf("bannerArtWidth() = %d, want %d", w, bannerArtColumns)
+	}
+}
+
+// TestRootHelpRendersBanner pins that `cerberus --help` leads with every row of
+// the wordmark, followed by the build-identity line and the description — and
+// that the retired jargon is gone.
+func TestRootHelpRendersBanner(t *testing.T) {
+	root := newRootCmd(func() error {
+		t.Fatal("server RunE must not run for `--help`")
+		return nil
+	})
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs([]string{"--help"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("`cerberus --help` execute: %v", err)
+	}
+	help := out.String()
+
+	rows := 0
+	for _, line := range strings.Split(bannerArt, "\n") {
+		line = strings.TrimRight(line, " ")
+		if line == "" {
+			continue
+		}
+		rows++
+		if !strings.Contains(help, line) {
+			t.Errorf("help output is missing wordmark row %q; got:\n%s", line, help)
+		}
+	}
+	if rows != bannerArtGlyphRows {
+		t.Errorf("asserted %d wordmark rows, want %d", rows, bannerArtGlyphRows)
+	}
+
+	if want := bannerMetaLine(Version, buildDate()); !strings.Contains(help, want) {
+		t.Errorf("help output is missing the build-identity line %q; got:\n%s", want, help)
+	}
+	for _, line := range strings.Split(rootDescription, "\n") {
+		if line == "" {
+			continue
+		}
+		if !strings.Contains(help, line) {
+			t.Errorf("help output is missing description line %q; got:\n%s", line, help)
+		}
+	}
+	if strings.Contains(help, "env-driven") {
+		t.Errorf("help output still carries the retired jargon; got:\n%s", help)
+	}
+}
+
+// TestBannerMetaLine pins the build-identity rendering across the stamped and
+// unstamped builds: goreleaser's bare tag gains a "v", an already-prefixed or
+// non-numeric version is left alone, and a missing build date drops the whole
+// field rather than printing an empty one.
+func TestBannerMetaLine(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		version   string
+		buildDate string
+		want      string
+	}{
+		{"release build", "1.13.1", "2026-07-28", "v1.13.1 · built 2026-07-28"},
+		{"already prefixed", "v1.13.1", "2026-07-28", "v1.13.1 · built 2026-07-28"},
+		{"no vcs stamp", "1.13.1", "", "v1.13.1"},
+		{"dev build", devVersion, "", devVersion},
+		{"no ldflags at all", "", "", devVersion},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := bannerMetaLine(tc.version, tc.buildDate); got != tc.want {
+				t.Errorf("bannerMetaLine(%q, %q) = %q, want %q", tc.version, tc.buildDate, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRenderBannerRightAlignsMeta pins that the build-identity line ends flush
+// with the wordmark's right edge, and that an unstamped build degrades to a bare
+// "dev" with no dangling separator or "built " label.
+func TestRenderBannerRightAlignsMeta(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		version   string
+		buildDate string
+	}{
+		{"release build", "1.13.1", "2026-07-28"},
+		{"unstamped build", "", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			lines := strings.Split(renderBanner(tc.version, tc.buildDate), "\n")
+			if len(lines) != bannerArtGlyphRows+1 {
+				t.Fatalf("renderBanner produced %d lines, want %d", len(lines), bannerArtGlyphRows+1)
+			}
+			meta := lines[len(lines)-1]
+			if n := utf8.RuneCountInString(meta); n != bannerArtColumns {
+				t.Errorf("meta line is %d columns wide, want %d (flush with the art): %q", n, bannerArtColumns, meta)
+			}
+			if strings.TrimSpace(meta) != bannerMetaLine(tc.version, tc.buildDate) {
+				t.Errorf("meta line = %q, want %q padded", strings.TrimSpace(meta), bannerMetaLine(tc.version, tc.buildDate))
+			}
+		})
+	}
+
+	unstamped := renderBanner("", "")
+	if strings.Contains(unstamped, bannerBuildDatePrefix) || strings.Contains(unstamped, bannerMetaSeparator) {
+		t.Errorf("unstamped build must not print an empty build-date field; got:\n%s", unstamped)
+	}
+}

--- a/cmd/cerberus/cli.go
+++ b/cmd/cerberus/cli.go
@@ -29,14 +29,9 @@ func printVersion(w io.Writer) {
 // error line on failure: main() owns the single slog.Error + exit-code mapping.
 func newRootCmd(runServer func() error) *cobra.Command {
 	root := &cobra.Command{
-		Use:   "cerberus",
-		Short: "Drop-in Prometheus / Loki / Tempo HTTP gateway for ClickHouse",
-		Long: "cerberus is an env-driven, stateless HTTP gateway that speaks the\n" +
-			"Prometheus, Loki, and Tempo wire formats and translates queries into\n" +
-			"ClickHouse SQL. Invoked with no subcommand it starts the server, reading\n" +
-			"all configuration from CERBERUS_* environment variables (see\n" +
-			"`cerberus config-docs`). Subcommands cover the offline migration preview\n" +
-			"(`migrate`) and the repo's documentation/analysis generators.",
+		Use:           "cerberus",
+		Short:         "Drop-in Prometheus / Loki / Tempo HTTP gateway for ClickHouse",
+		Long:          rootLong(),
 		Args:          cobra.NoArgs,
 		SilenceUsage:  true,
 		SilenceErrors: true,


### PR DESCRIPTION
## Why

The root help (`cerberus help` / `cerberus --help`) opened with a dense paragraph that explained nothing to a first-time reader — "env-driven", "stateless", "wire formats" are all insider vocabulary.

### Before

```
cerberus is an env-driven, stateless HTTP gateway that speaks the
Prometheus, Loki, and Tempo wire formats and translates queries into
ClickHouse SQL. Invoked with no subcommand it starts the server, reading
all configuration from CERBERUS_* environment variables (see
`cerberus config-docs`). Subcommands cover the offline migration preview
(`migrate`) and the repo's documentation/analysis generators.

Usage:
  cerberus [flags]
  cerberus [command]
...
```

### After

Release build (`-ldflags "-X main.Version=1.13.1"`):

```
   ___          _
  / __\___ _ __| |__   ___ _ __ _   _ ___
 / /  / _ \ '__| '_ \ / _ \ '__| | | / __|
/ /__|  __/ |  | |_) |  __/ |  | |_| \__ \
\____/\___|_|  |_.__/ \___|_|   \__,_|___/
                v1.13.1 · built 2026-07-28

Drop-in Prometheus / Loki / Tempo HTTP gateway for ClickHouse.
Translate PromQL, LogQL, and TraceQL into optimized ClickHouse SQL —
keep Grafana, swap the backend.

Run with no subcommand to start the server.

Usage:
  cerberus [flags]
  cerberus [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  config-docs Regenerate docs/configuration.md from internal/config metadata
  help        Help about any command
  migrate     Offline pre-cutover migration preview toolkit
  optdocs     Regenerate the chopt feature table in docs/clickhouse-optimizations.md
  route-rules Offline router-rules catalog analysis (report generator; changes no routing)
  serve       Start the cerberus server (identical to bare `cerberus`)
  version     Print the cerberus version and exit

Flags:
  -h, --help   help for cerberus

Use "cerberus [command] --help" for more information about a command.
```

Unstamped local build (`go build ./cmd/cerberus`) — the version degrades to `dev`, everything else is identical:

```
\____/\___|_|  |_.__/ \___|_|   \__,_|___/
                    dev · built 2026-07-28
```

The description is the project's own GitHub blurb, and the discoverability the old paragraph tried to hand-write (`config-docs`, `migrate`, …) is already carried by the "Available Commands" list right below it.

## How version and build date are sourced

No new source of truth, and nothing hardcoded:

- **Version** — the existing `main.Version` package var, injected by goreleaser's `-X main.Version={{.Version}}` ldflag and defaulting to `"dev"`. The same var `printVersion` / `cerberus version` / the `/info` fingerprint already use.
- **Build date** — the `vcs.time` setting from `runtime/debug.ReadBuildInfo()`, i.e. the same embedded build info `buildRevision()` already reads `vcs.revision` from. Parsed as RFC3339 and rendered as a bare calendar date.

Both degrade rather than print placeholders:

| build | meta line |
|---|---|
| goreleaser tag + VCS stamp | `v1.13.1 · built 2026-07-28` |
| tag, no VCS stamp (`-buildvcs=false`) | `v1.13.1` |
| no ldflags at all | `dev` |

The `v` prefix is added only when the version starts with a digit (goreleaser injects the bare `1.13.1`), so `dev` and an already-prefixed `v1.13.1` are printed as-is — a `dev` build never renders `v · built `.

The meta line is right-aligned to the wordmark's width, which is computed from the art itself rather than pinned to a literal, so the alignment survives any future edit to the art.

## Tests

`cmd/cerberus/banner_test.go` — four tests, all mutation-proven to fail when the behaviour regresses:

| mutation | result |
|---|---|
| blank the `bannerArt` const | `TestBannerArtShape`, `TestRootHelpRendersBanner`, `TestRenderBannerRightAlignsMeta` FAIL |
| `bannerVersionLabel` returns `""` (version var unset) | `TestBannerMetaLine`, `TestRenderBannerRightAlignsMeta` FAIL |
| revert root `Long` to the old jargon string | `TestRootHelpRendersBanner` FAIL |

`TestBannerArtShape` exists specifically so blanking the art can't make the "help contains every wordmark row" assertions vacuously true.

## Notes

- Nothing else in the tree pinned the old help string — `grep` for `env-driven` / `Subcommands cover` / `stateless HTTP gateway` across code, docs, and tests found only `cli.go`. No doc carries a `--help` transcript, so no doc changes were needed.
- Cosmetic only: the bare-`cerberus` server path, `serve`, `version`, and the `--version` fast-path the distroless healthcheck greps are all untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
