### PR TITLE
docs(operations): document the canonical ordered release ritual

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,7 +131,7 @@ Grafana's Loki, Tempo, and `dskit` all use a forked memberlist internally (via t
 ## Pointers if you're lost
 
 - "How does this PR ship?" → branch + push + `gh pr create` → CI must pass → squash-merge with `gh pr merge --squash --delete-branch`.
-- "How are releases cut / which lines are still supported?" → `docs/operations.md` → "Release pipeline (publish-on-merge)" + "Release support window / EOL policy" (latest 3 minor lines; older lines are EOL — branch deleted, no hotfixes, tags/Releases retained; enforced in `release-preflight.mjs`).
+- "How are releases cut / which lines are still supported?" → `docs/operations.md` → "Release ritual (the ordered cycle)" (the canonical six-step cycle: merge everything → backport everything to every line that stays supported → settle the retirement set → audit the delta → publish backport patches → publish the head release last) + "Release pipeline (publish-on-merge)" + "Release support window / EOL policy" (latest 3 minor lines; older lines are EOL — branch deleted, no hotfixes, tags/Releases retained; enforced in `release-preflight.mjs`).
 - "Where do I add this feature?" → match the layer to the head: `internal/{promql,logql,traceql}/` for parse + lowering, `internal/chplan/` for the shared IR, `internal/optimizer/` for rewrites, `internal/chsql/` for SQL emission, `internal/api/{prom,loki,tempo}/` for HTTP handlers. Fixtures live in `test/spec/<head>/`.
 - "Can I update the Project from a PR?" → yes, the repo is linked. Move the matching draft item to `In Progress` when you start, `Done` when the PR merges (or wire a workflow that does it).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,10 +115,12 @@ release — is the
 
 The binary and the Helm chart (`deploy/helm/cerberus/`) follow **independent
 SemVer lines**. `Chart.yaml` carries both: `version` is the *chart's* own
-SemVer (its `values.yaml` contract — breaking values change = major, additive
-toggle = minor, fix = patch), and `appVersion` tracks the cerberus binary it
-deploys by default. They move independently so each kind of change is
-expressible:
+SemVer, tracking its `values.yaml` contract (breaking values change = major,
+additive toggle = minor, fix = patch), and `appVersion` tracks the cerberus
+binary it deploys by default. The binary's line follows its own rule: **a
+breaking change ships in a new minor and does not require a major bump** — see
+the [release ritual](docs/operations.md#release-ritual-the-ordered-cycle). They
+move independently so each kind of change is expressible:
 
 | Change                                                   | What to do                                                                                                    | What publishes                                                                                |
 | -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,6 +107,12 @@ If you use Claude Code (or any agent that reads `CLAUDE.md` / `AGENTS.md`), the 
 
 ## Releasing
 
+The ordered cycle a release runs — merge everything, backport everything to
+every line that stays supported, settle which line falls out of the support
+window, audit the delta, then publish the backport patches before the head
+release — is the
+[release ritual](docs/operations.md#release-ritual-the-ordered-cycle).
+
 The binary and the Helm chart (`deploy/helm/cerberus/`) follow **independent
 SemVer lines**. `Chart.yaml` carries both: `version` is the *chart's* own
 SemVer (its `values.yaml` contract — breaking values change = major, additive

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1110,8 +1110,8 @@ carries as much weight as the steps themselves:
    must exist before step 5 can publish a patch on it. See
    [maintenance lines](#maintenance-lines-hotfix-backports) for the mechanics.
 3. **Settle the retirement set before any backport is cut.** When the cycle
-   cuts a new minor, the oldest supported line falls out of the window defined
-   in
+   cuts a new minor — which a breaking change is by itself enough to force, see
+   below — the oldest supported line falls out of the window defined in
    [release support window / EOL policy](#release-support-window--eol-policy).
    Work out which line that is up front, because it takes **no backport and no
    patch release** this cycle — spending a release on a line about to be retired
@@ -1126,6 +1126,16 @@ carries as much weight as the steps themselves:
    line gets its patch tag before the new head release exists.
 6. **Publish the new MINOR (or patch) release last.** `main`'s release is always
    the final publish of the cycle.
+
+**Breaking changes are accepted in a new minor.** On the cerberus version line
+(`appVersion` / the `v<major>.<minor>.<patch>` tags) a breaking change does
+**not** require a major bump — the minor is its vehicle. That makes "does this
+delta break anything?" a step-3 input: a breaking change is on its own
+sufficient reason for the cycle to cut a minor rather than a patch, and cutting
+a minor is what pushes the oldest line out of the support window and calls for
+a maintenance branch on the minor `main` is leaving. A cycle carrying neither a
+breaking change nor a new feature is a patch cycle: it retires nothing, creates
+no line, and passes step 3 straight through.
 
 Two properties follow from that order. Publishing the older lines first means
 the newest tag is never the one users find while the older lines are still

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1087,6 +1087,56 @@ data already persisted.
 The distroless image enforces this separation by construction: it
 ships only the compiled binary and root CA bundle.
 
+### Release ritual (the ordered cycle)
+
+Publishing is machinery; deciding *what* ships — and in which order — is the
+release ritual. Every cycle runs these six steps top to bottom. The ordering
+carries as much weight as the steps themselves:
+
+1. **Drive everything merged first.** A cycle opens by draining the board: no
+   open PR and no dangling branch-without-a-PR is left behind. A release ships
+   the whole delta since the previous one, never a subset.
+2. **Backport everything to every line that stays supported.** Every fix that
+   landed on `main` since the previous release goes onto every
+   `release/<major>.<minor>.x` line that is still supported once this cycle
+   lands — step 3 settles which those are. "Everything" is the default rather
+   than a per-fix judgement call. A change is left out of a line only when the
+   backport is genuinely infeasible on that line, and a line that keeps
+   rejecting backports is a retirement candidate, not a standing exception. A
+   cycle that cuts a new minor also *adds* a line: the minor `main` is leaving
+   needs its own maintenance branch, created from the peeled tag of its last
+   release (`git push origin v<tag>^{}:refs/heads/release/<major>.<minor>.x` —
+   the ruleset carries no `creation` rule, so this needs no bypass). That branch
+   must exist before step 5 can publish a patch on it. See
+   [maintenance lines](#maintenance-lines-hotfix-backports) for the mechanics.
+3. **Settle the retirement set before any backport is cut.** When the cycle
+   cuts a new minor, the oldest supported line falls out of the window defined
+   in
+   [release support window / EOL policy](#release-support-window--eol-policy).
+   Work out which line that is up front, because it takes **no backport and no
+   patch release** this cycle — spending a release on a line about to be retired
+   is wasted work. This step is a decision, not an action: the retirement itself
+   is automatic, with the `eol-retire` job deleting the out-of-window branch
+   after the new minor publishes. A patch-only cycle retires nothing and passes
+   straight through.
+4. **Audit the delta.** One last pass over the complete diff since the previous
+   release: code against comments against docs, DRY, KISS, soundness. This is
+   the final gate — findings are fixed and merged here, before any tag exists.
+5. **Publish the backport PATCH releases first.** Every still-supported older
+   line gets its patch tag before the new head release exists.
+6. **Publish the new MINOR (or patch) release last.** `main`'s release is always
+   the final publish of the cycle.
+
+Two properties follow from that order. Publishing the older lines first means
+the newest tag is never the one users find while the older lines are still
+mid-flight: by the time the head release appears, every supported line already
+sits at its final version. And placing the audit immediately before the first
+publish means nothing merges between the audit and the tags it cleared.
+
+Each individual publish in steps 5 and 6 runs through the machinery below — a
+backport by pushing its `release/*.x` branch, the head release by merging its
+release PR.
+
 ### Release pipeline (publish-on-merge)
 
 Cerberus publishes when a **validated release PR is merged to main**, not when


### PR DESCRIPTION
Docs-only. Codifies the release cycle that the project already runs as an explicit, ordered ritual, so a cycle is reproducible rather than reconstructed from memory each time.

## What the ritual is

A new `### Release ritual (the ordered cycle)` section in `docs/operations.md`, placed immediately before `### Release pipeline (publish-on-merge)` — the ritual is the human-driven cycle, publish-on-merge is the machinery each of its publishes triggers. Six steps, run top to bottom:

1. **Drive everything merged first** — no open PR, no dangling branch-without-a-PR. A release ships the whole delta, not a subset.
2. **Backport everything to every line that stays supported** — "everything" is the default, not a per-fix judgement call; a line that keeps rejecting backports is a retirement candidate rather than a standing exception. A new-minor cycle also *adds* a line: the minor `main` is leaving needs its maintenance branch created from the peeled tag (no ruleset bypass required) before step 5 can publish a patch on it.
3. **Settle the retirement set before any backport is cut** — the line that falls out of the support window takes no backport and no patch release this cycle. Framed as a *decision*, not an action: the retirement itself is automatic (`eol-retire` deletes the branch after the new minor publishes).
4. **Audit the delta** — one final pass over the full diff since the previous release (code vs. comments vs. docs, DRY, KISS, soundness). Findings are fixed and merged here, before any tag exists.
5. **Publish the backport PATCH releases first** — every still-supported older line gets its patch tag before the head release exists.
6. **Publish the new MINOR (or patch) release last** — `main`'s release is always the final publish of the cycle.

The ordering is the substance: publishing older lines first means the newest tag is never the one users find while the older lines are still mid-flight, and putting the audit immediately before the first publish means nothing merges between the audit and the tags it cleared.

## Cross-links, not restatements

The support window, the `eol-retire` automation, and the maintenance-line branch mechanics are already documented in this file — the ritual links to `#release-support-window--eol-policy` and `#maintenance-lines-hotfix-backports` rather than duplicating or contradicting them.

## Pointers

- `CONTRIBUTING.md` → `## Releasing` gains a lead paragraph pointing at the ritual, above the existing chart/app SemVer-lines table.
- `CLAUDE.md` → the existing "How are releases cut / which lines are still supported?" pointer is extended (not duplicated) with the six-step summary.

## Test plan

Docs-only; no code paths touched. `markdownlint-cli2` runs via the pre-commit hook and the `lint` gate.
