### PR TITLE
fix(chsql): name the canonical key-order function once, not twice

### DIFF
--- a/internal/chsql/vector_join.go
+++ b/internal/chsql/vector_join.go
@@ -454,14 +454,21 @@ func setOpMatchKeyFrags(m chplan.VectorMatch, attrsCol, tsCol string, stepAligne
 	return keys
 }
 
-// canonicalMatchKeyFrag wraps a Map-valued match key in mapSort.
+// canonicalMatchKeyFrag wraps a Map-valued match key in the canonical
+// key-order function.
 //
 // A CH Map compares and groups positionally over its (keys, values)
 // arrays, so two logically identical label sets stored in different key
-// orders are unequal; mapSort makes the key compare by label set. It is
+// orders are unequal; the wrap makes the key compare by label set. It is
 // order-only and idempotent, so it can never merge two genuinely
 // different label sets.
-func canonicalMatchKeyFrag(key Frag) Frag { return Call("mapSort", key) }
+//
+// The function is named by [chplan.CanonicalMapFunc] rather than spelled
+// here: the plan IR ([chplan.CanonicalAttributesExpr]) and the Loki
+// metadata Frags read the same constant, and its idempotence check
+// matches on that name. A literal here would let this site drift onto a
+// different function while the IR kept believing the map was canonical.
+func canonicalMatchKeyFrag(key Frag) Frag { return Call(chplan.CanonicalMapFunc, key) }
 
 // matchKeyGroupExprFrag returns a Frag for the GROUP BY expression
 // that collapses rows onto a single matching key. For default matching

--- a/test/regression/canonical_map_func_constant_test.go
+++ b/test/regression/canonical_map_func_constant_test.go
@@ -1,0 +1,109 @@
+package regression
+
+// Pins the Map key-order invariant to a single named function.
+//
+// Every series-identity key in the engine depends on the attributes Map
+// being ordered by key: a CH Map compares, groups and hashes POSITIONALLY
+// over its (keys, values) arrays, so one logical series delivered under
+// two OTLP key orders otherwise splits into two. Cerberus establishes the
+// invariant by wrapping the map in chplan.CanonicalMapFunc, and three
+// layers depend on that being ONE function:
+//
+//   - chplan.CanonicalAttributesExpr skips re-wrapping by matching a
+//     FuncCall against the constant, so a site that wrapped with a
+//     different function would be re-wrapped rather than recognised;
+//   - internal/chsql emits the plan IR's calls verbatim;
+//   - internal/api/loki builds the same wrap as a Frag for the metadata
+//     endpoints, which never cross the plan IR at all.
+//
+// A spelled-out literal at any of those sites can drift onto a different
+// function while the other layers keep believing the map is canonical —
+// and the resulting bug is a silent wrong answer (doubled counts, halved
+// volumes, empty range results), not an error. Naming the function once
+// is what makes the drift impossible, so this test fails if a literal
+// reappears.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const (
+	// The tree the invariant governs, and the sole file allowed to spell
+	// the function name — the one that declares the constant.
+	canonicalFuncRoot    = "../../internal"
+	canonicalFuncDeclare = "chplan/canonical_attributes.go"
+
+	// The Go string-literal form. Prose mentions in doc comments render
+	// the call as `mapSort(...)` without surrounding quotes, so matching
+	// the quoted form finds code without flagging documentation.
+	canonicalFuncLiteral = `"mapSort"`
+)
+
+// TestCanonicalMapFuncHasOneSpelling fails if any non-test file under
+// internal/ names the canonical key-order function directly instead of
+// referencing chplan.CanonicalMapFunc.
+func TestCanonicalMapFuncHasOneSpelling(t *testing.T) {
+	declare := filepath.FromSlash(canonicalFuncDeclare)
+	var offenders []string
+
+	err := filepath.WalkDir(canonicalFuncRoot, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		// Tests legitimately assert on emitted SQL text, where the
+		// function name is the expected output rather than a choice of
+		// implementation.
+		if strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		rel, relErr := filepath.Rel(canonicalFuncRoot, path)
+		if relErr != nil {
+			return relErr
+		}
+		if rel == declare {
+			return nil
+		}
+		src, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		if strings.Contains(string(src), canonicalFuncLiteral) {
+			offenders = append(offenders, rel)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", canonicalFuncRoot, err)
+	}
+
+	if len(offenders) > 0 {
+		t.Fatalf("these files spell the canonical key-order function as %s instead of "+
+			"referencing chplan.CanonicalMapFunc: %s.\n"+
+			"The plan IR recognises an already-canonical map by matching that constant, so a "+
+			"second spelling lets one layer wrap with a different function while the others "+
+			"believe the map is ordered — a silent wrong answer, not an error.",
+			canonicalFuncLiteral, strings.Join(offenders, ", "))
+	}
+}
+
+// TestCanonicalMapFuncConstantIsDeclared fails if the declaring file stops
+// carrying the literal, which would mean the constant was renamed or moved
+// and TestCanonicalMapFuncHasOneSpelling is now guarding nothing.
+func TestCanonicalMapFuncConstantIsDeclared(t *testing.T) {
+	path := filepath.Join(canonicalFuncRoot, filepath.FromSlash(canonicalFuncDeclare))
+	src, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if !strings.Contains(string(src), "CanonicalMapFunc = "+canonicalFuncLiteral) {
+		t.Fatalf("%s no longer declares CanonicalMapFunc = %s; the single-spelling gate "+
+			"has nothing to anchor on and would pass over a tree with no canonical "+
+			"function at all", canonicalFuncDeclare, canonicalFuncLiteral)
+	}
+}


### PR DESCRIPTION
Found by the pre-release audit of the delta since `v1.13.1`.

## The finding

The Map key-order invariant — *the attributes Map is ordered by key* — is
established in four places across the recent fix family (#1346, #1356,
#1357, #1358, #1360). Three of them name the function through
`chplan.CanonicalMapFunc`. One, `canonicalMatchKeyFrag` in
`internal/chsql/vector_join.go`, still spelled `mapSort` as a literal.

That is precisely the drift the shared constant was introduced to
prevent, and it is the dangerous kind: it fails silently in both
directions.

- `chplan.CanonicalAttributesExpr` decides a map is *already* canonical by
  matching a `FuncCall` against the constant. A site wrapping with a
  different function is not recognised — it gets wrapped again.
- A site that stops wrapping entirely still emits valid SQL. It just
  groups against whatever physical key order the store happens to hold.

Either way the symptom is a **wrong answer**, never an error: doubled
`count()`, halved byte volumes in `/index/volume`, or an empty range
result from a partition that ended up holding one sample.

## The fix

Reference the constant, and pin the single spelling so it cannot come
back: no non-test file under `internal/` may contain the quoted literal
except the file that declares the constant.

A companion test asserts that declaring file still carries the literal —
otherwise renaming or moving the constant would leave the gate happily
passing over a tree with no canonical function at all.

Tests are exempt: they assert on emitted SQL, where the function name is
expected output rather than a choice of implementation.

## Verification

The gate is not hollow — checked in both directions:

- with the fix applied → **PASS** (both tests)
- literal restored → **FAIL**, naming `chsql/vector_join.go`
- fix reinstated → **PASS**

Emission is unchanged: the constant's value is the same string, so no
golden moves. `go build ./internal/...` clean; the `chsql` vector-join
emitter tests pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)