### PR TITLE
ci(release): open the release PR against the dispatched line

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -112,10 +112,19 @@ jobs:
         # Prefer RELEASE_PAT so the created PR triggers pull_request CI; fall
         # back to github.token (PR created, but its checks won't run — see the
         # header note). gh reads GH_TOKEN.
+        #
+        # BASE is the ref the run was dispatched on, not a literal `main`: a
+        # maintenance release is staged by dispatching this workflow on
+        # release/<major>.<minor>.x, and the staging branch is cut from that
+        # checkout, so a hardcoded base would open the PR against main and offer
+        # to merge a whole maintenance line into the head line. The `issues`
+        # trigger has no such choice — a label-driven release always runs on the
+        # default branch, where ref_name is already `main`.
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PAT || github.token }}
           VERSION: ${{ steps.prep.outputs.new_version }}
           CHART_VERSION: ${{ steps.prep.outputs.chart_version }}
+          BASE: ${{ github.ref_name }}
         run: |
           branch="release/v${VERSION}-chart-${CHART_VERSION}"
           title="chore(release): cerberus v${VERSION} / chart ${CHART_VERSION}"
@@ -125,7 +134,7 @@ jobs:
           git add deploy/helm/cerberus/Chart.yaml deploy/helm/cerberus/README.md CHANGELOG.md
           git commit -m "$title"
           git push -u origin "$branch"
-          url="$(gh pr create --base main --head "$branch" --title "$title" --body-file release-pr-body.md)"
+          url="$(gh pr create --base "$BASE" --head "$branch" --title "$title" --body-file release-pr-body.md)"
           echo "url=$url" >>"$GITHUB_OUTPUT"
           echo "PR: $url"
 

--- a/test/regression/release_gate_test.go
+++ b/test/regression/release_gate_test.go
@@ -489,3 +489,50 @@ func TestReleaseGateDriftDetectorRunsLiveAndNotSelfTestOnly(t *testing.T) {
 			"would then be unexercised between weekly runs", driftScript, selfTestFlag)
 	}
 }
+
+// prepare-release.yml stages a release PR from whatever ref it was dispatched
+// on. Cutting a maintenance patch means dispatching it on
+// release/<major>.<minor>.x — the staging branch is then cut from that
+// checkout, so the base the PR is opened against is the only thing keeping the
+// release on its own line. A literal base sends a maintenance line's entire
+// history at the head line instead, and nothing downstream notices: the PR
+// opens, CI runs, and the mistake is visible only to whoever reads the base.
+const (
+	prepareReleaseWorkflowPath = "../../.github/workflows/prepare-release.yml"
+	prepareReleaseJob          = "prepare"
+
+	// The env var carrying github.ref_name into the step's shell, and the
+	// expression that must feed it.
+	prepareReleaseBaseEnv  = "BASE"
+	prepareReleaseBaseExpr = "${{ github.ref_name }}"
+)
+
+func TestPrepareReleaseOpensThePRAgainstTheDispatchedLine(t *testing.T) {
+	t.Parallel()
+
+	workflow := readFileString(t, prepareReleaseWorkflowPath)
+	job := workflowJobBody(t, workflow, prepareReleaseJob)
+
+	if !strings.Contains(job, prepareReleaseBaseEnv+": "+prepareReleaseBaseExpr) {
+		t.Fatalf("%s job %q does not bind %s to %s. Without it the base is whatever the run: block "+
+			"hardcodes, and a maintenance release staged on release/<line>.x opens against the head "+
+			"line. Body:\n%s",
+			prepareReleaseWorkflowPath, prepareReleaseJob, prepareReleaseBaseEnv, prepareReleaseBaseExpr, job)
+	}
+
+	var create string
+	for _, line := range strings.Split(job, "\n") {
+		if strings.Contains(line, "gh pr create") {
+			create = strings.TrimSpace(line)
+		}
+	}
+	if create == "" {
+		t.Fatalf("%s job %q no longer opens the release PR with `gh pr create`; this pin cannot see "+
+			"which base it targets. Body:\n%s", prepareReleaseWorkflowPath, prepareReleaseJob, job)
+	}
+	if !strings.Contains(create, `--base "$`+prepareReleaseBaseEnv+`"`) {
+		t.Fatalf("%s job %q opens the release PR as %q — the base must be $%s, the dispatched ref, "+
+			"not a fixed branch name",
+			prepareReleaseWorkflowPath, prepareReleaseJob, create, prepareReleaseBaseEnv)
+	}
+}


### PR DESCRIPTION
## Problem

`prepare-release.yml` cuts its staging branch from whatever ref the run was
dispatched on, but opened the PR with a hardcoded base:

```yaml
url="$(gh pr create --base main --head "$branch" ...)"
```

Dispatching it on `release/<major>.<minor>.x` — the documented way to stage a
maintenance patch — therefore produces a PR proposing to merge an entire
maintenance line into the head line. Nothing downstream catches it: the PR
opens, CI runs, and the only symptom is the base branch nobody rereads.

This bit during the v1.12.3 / v1.13.2 cycle. Both maintenance release PRs had
to be staged by hand instead — run `prepare-release.mjs` + helm-docs locally on
the branch, commit, push, `gh pr create --base <line>` — which is the same two
steps the workflow runs, minus the wrong base.

## Fix

The base comes from `github.ref_name`. The `issues` trigger is unaffected: a
label-driven release always runs on the default branch, where `ref_name` is
already `main`.

## Test

`release_gate_test.go` pins both halves — the `BASE:` env binding and the
`--base "$BASE"` call site. `prepare-release.yml` has no `pull_request` trigger,
so without a pin every edit to it stays unverified until someone stages a
release with it; that is the same reason every other pin in that file exists.

Verified the pin is not hollow: it passes as committed, and reverting
`--base "$BASE"` back to `--base main` fails it with the offending line quoted.

## Merge order

This waits behind the release in flight — **v1.12.3 (#1369) then v1.13.2 (#1371)
publish first**, so `main` is not moved out from under the staged release PR.
