### PR TITLE
fix(tempo): stop zero-fill buckets turning quantiles into NaN

### DIFF
--- a/internal/api/httperr/httperr.go
+++ b/internal/api/httperr/httperr.go
@@ -18,6 +18,7 @@
 package httperr
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 )
@@ -55,12 +56,75 @@ func (e *Error) Error() string { return e.Err.Error() }
 // [errors.Is] / [errors.As] across the boundary.
 func (e *Error) Unwrap() error { return e.Err }
 
+// MarshalFailureKind is the error-type string [WriteJSON] reports when a
+// response body cannot be marshalled. It is deliberately the Prom / Loki
+// "internal" vocabulary word: a body that will not marshal is a defect in
+// this gateway, never something the request asked for.
+const MarshalFailureKind = "internal"
+
+// marshalFailure is the envelope [WriteJSON] falls back to when the
+// caller's body cannot be marshalled. Its field set is the union of the
+// three heads' error shapes — `status`/`errorType`/`error` for Prom and
+// Loki, `error`/`message` for Tempo — so whichever client is on the other
+// end reads a populated error rather than a parse failure. Every field is
+// a string, so this envelope cannot itself fail to marshal.
+type marshalFailure struct {
+	Status    string `json:"status"`
+	ErrorType string `json:"errorType"`
+	Error     string `json:"error"`
+	Message   string `json:"message"`
+}
+
 // WriteJSON writes `body` as JSON with the given HTTP status. The
-// Content-Type is set to `application/json` before WriteHeader, and the
-// encoder's error is intentionally discarded — at that point the status
-// is already on the wire and there's nothing the caller can do.
+// Content-Type is set to `application/json` before WriteHeader.
+//
+// The body is marshalled BEFORE the status line goes out. That ordering is
+// the point of this function: [json.Encoder.Encode] buffers the whole value
+// and only then reports a failure, so encoding straight to w commits the
+// status first and discovers the problem second. A body carrying a NaN or
+// ±Inf — the shape a numeric bug in any head produces — would then reach
+// the client as a 200 with zero bytes, which is indistinguishable from a
+// legitimately empty result. A wrong answer that presents as success is
+// worse than an outage: nothing upstream can detect it. Marshalling first
+// turns that class into a 500 carrying [marshalFailure] instead.
+//
+// Errors from the write itself stay discarded, unlike marshal errors: once
+// the header is committed the status is on the wire, and a client that
+// disconnected mid-body is not the server's to repair.
 func WriteJSON(w http.ResponseWriter, status int, body any) {
+	// Encode, not Marshal: Encode is what the response bytes have always
+	// been produced by, and it terminates the body with a newline that
+	// handler-side snapshots depend on.
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(body); err != nil {
+		writeMarshalFailure(w, err)
+		return
+	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	_ = json.NewEncoder(w).Encode(body)
+	_, _ = w.Write(buf.Bytes())
+}
+
+// writeMarshalFailure reports an unmarshalable response body as a 500. It
+// is reached only when [WriteJSON]'s caller handed over a value the JSON
+// encoder rejects, so the status the caller asked for is discarded: that
+// status described a response this gateway turned out to be unable to
+// produce.
+func writeMarshalFailure(w http.ResponseWriter, cause error) {
+	msg := "response body could not be encoded: " + cause.Error()
+	body, err := json.Marshal(marshalFailure{
+		Status:    "error",
+		ErrorType: MarshalFailureKind,
+		Error:     msg,
+		Message:   msg,
+	})
+	if err != nil {
+		// Unreachable: marshalFailure is four strings. Fall back to a bare
+		// status rather than pretending the response has a body.
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusInternalServerError)
+	_, _ = w.Write(append(body, '\n'))
 }

--- a/internal/api/httperr/httperr_test.go
+++ b/internal/api/httperr/httperr_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -82,5 +83,82 @@ func TestWriteJSON_TrailingNewline(t *testing.T) {
 
 	if !strings.HasSuffix(rec.Body.String(), "\n") {
 		t.Errorf("body: missing trailing newline, got %q", rec.Body.String())
+	}
+}
+
+// TestWriteJSON_UnmarshalableBodyIsNotASuccess pins the failure mode that
+// makes marshal-before-header worth the buffer: a body carrying a NaN or ±Inf
+// cannot be encoded, and encoding straight to the ResponseWriter commits the
+// caller's status BEFORE that is discovered. The client then reads a 200 with
+// zero bytes, which is exactly what a legitimately empty result looks like —
+// so a numeric bug in any head ships as a successful query returning nothing.
+func TestWriteJSON_UnmarshalableBodyIsNotASuccess(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name  string
+		value float64
+	}{
+		{"NaN", math.NaN()},
+		{"+Inf", math.Inf(1)},
+		{"-Inf", math.Inf(-1)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			rec := httptest.NewRecorder()
+			httperr.WriteJSON(rec, http.StatusOK, map[string]any{
+				"series": []map[string]any{{"value": tc.value}},
+			})
+
+			res := rec.Result()
+			defer res.Body.Close()
+
+			if res.StatusCode == http.StatusOK {
+				t.Fatalf("a body that cannot be encoded was reported as success (200); "+
+					"body was %q", rec.Body.String())
+			}
+			if res.StatusCode != http.StatusInternalServerError {
+				t.Errorf("status: got %d, want %d", res.StatusCode, http.StatusInternalServerError)
+			}
+			if ct := res.Header.Get("Content-Type"); ct != "application/json" {
+				t.Errorf("Content-Type: got %q, want application/json", ct)
+			}
+
+			// The envelope has to carry the fields every head's client reads:
+			// status/errorType/error for Prom and Loki, error/message for Tempo.
+			var body map[string]any
+			if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
+				t.Fatalf("the failure envelope is not itself valid JSON: %v", err)
+			}
+			if body["status"] != "error" || body["errorType"] != httperr.MarshalFailureKind {
+				t.Errorf("envelope: got %+v", body)
+			}
+			for _, field := range []string{"error", "message"} {
+				msg, _ := body[field].(string)
+				if !strings.Contains(msg, "could not be encoded") {
+					t.Errorf("envelope %q does not say what went wrong: %q", field, msg)
+				}
+			}
+		})
+	}
+}
+
+// TestWriteJSON_MarshalFailureLeavesNoPartialBody guards the other half of the
+// ordering: nothing of the rejected value may reach the wire. Encoding into the
+// ResponseWriter would emit whatever prefix serialised before the bad value,
+// producing a truncated document that a decoder reports as a parse error rather
+// than as the server error it is.
+func TestWriteJSON_MarshalFailureLeavesNoPartialBody(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	httperr.WriteJSON(rec, http.StatusOK, map[string]any{
+		"marker": "must-not-appear",
+		"value":  math.NaN(),
+	})
+
+	if strings.Contains(rec.Body.String(), "must-not-appear") {
+		t.Errorf("a prefix of the rejected body reached the wire: %q", rec.Body.String())
 	}
 }

--- a/internal/api/tempo/metrics_histogram.go
+++ b/internal/api/tempo/metrics_histogram.go
@@ -136,8 +136,16 @@ func log2QuantileWithBucket(p float64, buckets []histogramBucket) (float64, int)
 	frac := float64(target-consumed) / float64(buckets[idx].Count)
 
 	upper := math.Log2(buckets[idx].Max)
-	lower := upper - 1 // one octave below, for the no-predecessor case
-	if idx > 0 {
+	// One octave below is the lower boundary whenever the predecessor
+	// carries none. That covers the first bucket, which has no predecessor
+	// at all, and equally a predecessor whose Max is not positive: log2 of
+	// a non-positive boundary is -Inf or NaN, and an infinite octave span
+	// makes the interpolation below evaluate to NaN. A NaN here does not
+	// stay here — it reaches the JSON encoder, which refuses the whole
+	// response — so the boundary convention has to be total, not merely
+	// correct on well-formed input.
+	lower := upper - 1
+	if idx > 0 && buckets[idx-1].Max > 0 {
 		lower = math.Log2(buckets[idx-1].Max)
 	}
 	return math.Pow(2, lower+(upper-lower)*frac), idx

--- a/internal/api/tempo/metrics_histogram_quantile_test.go
+++ b/internal/api/tempo/metrics_histogram_quantile_test.go
@@ -1,0 +1,246 @@
+package tempo
+
+import (
+	"math"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// The tests in this file pin the boundary between the matrix SQL's zero-fill
+// convention and the histogram-quantile algorithm.
+//
+// The emitter plants a synthetic (bucket 0, count 0) row for every (group,
+// anchor) so an anchor with no spans still produces a row. The quantile
+// algorithm, mirroring upstream Tempo's HistogramAggregator, assumes the
+// opposite: a bucket exists only because something was observed in it. Feed
+// the synthetic row in and it is read as a real boundary — it sorts to the
+// front, becomes the predecessor the estimate interpolates down to, and
+// log2(0) is -Inf, so the interpolation evaluates to NaN.
+//
+// NaN is the reason these are unit tests rather than a fixture: it does not
+// surface as a wrong number a golden would catch. It reaches the JSON encoder,
+// which rejects the entire response, and the handler used to answer that with
+// a 200 and an empty body. The failure therefore presents to a client as "this
+// query legitimately matched nothing".
+
+// quantileProbePhis spans the interpolating and the boundary-landing cases:
+// 0.5 lands mid-bucket (interpolation runs, so a bad lower boundary shows),
+// 0.9 and 0.99 round up onto the top bucket's edge.
+var quantileProbePhis = []float64{0, 0.5, 0.9, 0.95, 0.99, 1}
+
+// TestLog2Quantile_ZeroFillBucketDoesNotChangeTheEstimate is the regression
+// proper: the same observed histogram must produce the same estimate whether
+// or not the emitter's synthetic zero-count row is sitting in front of it.
+func TestLog2Quantile_ZeroFillBucketDoesNotChangeTheEstimate(t *testing.T) {
+	t.Parallel()
+
+	observed := []histogramBucket{{Max: 8, Count: 3}, {Max: 16, Count: 2}}
+	withZeroFill := append([]histogramBucket{{Max: 0, Count: 0}}, observed...)
+
+	for _, phi := range quantileProbePhis {
+		want, _ := log2QuantileWithBucket(phi, observed)
+		got, _ := log2QuantileWithBucket(phi, withZeroFill)
+
+		if math.IsNaN(got) || math.IsInf(got, 0) {
+			t.Errorf("phi=%v: a zero-count boundary produced %v — the JSON encoder "+
+				"rejects the whole response rather than this one value", phi, got)
+			continue
+		}
+		if got != want {
+			t.Errorf("phi=%v: a zero-count boundary moved the estimate: got %v, want %v",
+				phi, got, want)
+		}
+	}
+}
+
+// TestLog2Quantile_FirstBucketSpansOneOctave pins the convention the fix
+// leans on: with no usable lower boundary the bucket is taken to span one
+// octave below its Max. Both a genuinely-first bucket and one preceded only by
+// a zero-count boundary have to resolve the same way, because they describe the
+// same thing — an observed bucket with nothing beneath it.
+func TestLog2Quantile_FirstBucketSpansOneOctave(t *testing.T) {
+	t.Parallel()
+
+	// One bucket, three samples; phi=0.5 targets the 2nd, so frac = 2/3 and
+	// the estimate is 2^(log2(8)-1 + 1*2/3).
+	const phi = 0.5
+	want := math.Pow(2, 2+2.0/3.0)
+
+	for _, tc := range []struct {
+		name    string
+		buckets []histogramBucket
+	}{
+		{"no predecessor", []histogramBucket{{Max: 8, Count: 3}}},
+		{"zero-count predecessor", []histogramBucket{{Max: 0, Count: 0}, {Max: 8, Count: 3}}},
+	} {
+		got, _ := log2QuantileWithBucket(phi, tc.buckets)
+		if got != want {
+			t.Errorf("%s: got %v, want %v", tc.name, got, want)
+		}
+	}
+}
+
+// TestLog2Quantile_IsNeverNaN sweeps the boundary shapes the emitter can
+// produce and asserts the helper is total over them. A NaN escaping here is
+// not a local wrong answer — it fails the response.
+func TestLog2Quantile_IsNeverNaN(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		buckets []histogramBucket
+	}{
+		{"empty", nil},
+		{"zero-fill only", []histogramBucket{{Max: 0, Count: 0}}},
+		{"zero-fill then one bucket", []histogramBucket{{Max: 0, Count: 0}, {Max: 8, Count: 3}}},
+		{"zero-fill then many buckets", []histogramBucket{
+			{Max: 0, Count: 0}, {Max: 2, Count: 1}, {Max: 8, Count: 5}, {Max: 64, Count: 2},
+		}},
+		{"zero-count bucket in the middle", []histogramBucket{
+			{Max: 2, Count: 1}, {Max: 8, Count: 0}, {Max: 64, Count: 2},
+		}},
+		{"single observation", []histogramBucket{{Max: 1, Count: 1}}},
+	} {
+		for _, phi := range quantileProbePhis {
+			got, _ := log2QuantileWithBucket(phi, tc.buckets)
+			if math.IsNaN(got) || math.IsInf(got, 0) {
+				t.Errorf("%s, phi=%v: got %v", tc.name, phi, got)
+			}
+		}
+	}
+}
+
+// quantileBucketSample builds one row of the matrix quantile stream: a
+// (group, anchor, bucket) tuple whose value is the bucket's count.
+func quantileBucketSample(svc string, anchor time.Time, bucket string, count float64) chclient.Sample {
+	return chclient.Sample{
+		Labels:    map[string]string{"service.name": svc, tempoQuantileBucketLabel: bucket},
+		Timestamp: anchor,
+		Value:     count,
+	}
+}
+
+// TestPostProcessQuantileBuckets_MultiPhiOverZeroFilledAnchors drives the
+// handler-side fold over the exact shape the failing dashboard panel produces:
+// `{ } | quantile_over_time(duration, .5, .9, .99)`, whose stream carries the
+// emitter's zero-fill row alongside the observed buckets. Every emitted sample
+// must be a finite number — one NaN anywhere in the response body is enough for
+// the encoder to refuse all of it.
+func TestPostProcessQuantileBuckets_MultiPhiOverZeroFilledAnchors(t *testing.T) {
+	t.Parallel()
+
+	populated := time.Unix(1_700_000_000, 0).UTC()
+	empty := populated.Add(15 * time.Second)
+
+	m := &chplan.MetricsAggregate{
+		Op:        chplan.MetricsOpQuantileOverTime,
+		Quantiles: []float64{0.5, 0.9, 0.99},
+	}
+	samples := []chclient.Sample{
+		// A populated anchor: the zero-fill row plus two observed buckets.
+		quantileBucketSample("checkout", populated, "0", 0),
+		quantileBucketSample("checkout", populated, "8", 3),
+		quantileBucketSample("checkout", populated, "16", 2),
+		// An anchor with no spans: zero-fill only.
+		quantileBucketSample("checkout", empty, "0", 0),
+	}
+
+	out := postProcessQuantileBuckets(samples, m)
+
+	if want := len(m.Quantiles) * 2; len(out) != want {
+		t.Fatalf("want one sample per (anchor, phi) = %d, got %d", want, len(out))
+	}
+	for _, s := range out {
+		if math.IsNaN(s.Value) || math.IsInf(s.Value, 0) {
+			t.Errorf("anchor %s p=%s: got %v — this value cannot be JSON-encoded, "+
+				"so it fails the whole response", s.Timestamp, s.Labels[tempoQuantileLabel], s.Value)
+		}
+	}
+
+	// The zero-fill-only anchor is what the emitter plants the row FOR: it
+	// must still be reported, and reported as 0.
+	for _, s := range out {
+		if !s.Timestamp.Equal(empty) {
+			continue
+		}
+		if s.Value != 0 {
+			t.Errorf("an anchor with no observations must read 0, got %v at p=%s",
+				s.Value, s.Labels[tempoQuantileLabel])
+		}
+	}
+
+	// The populated anchor must read the estimate its observed buckets imply,
+	// unshifted by the zero-fill row.
+	observed := []histogramBucket{{Max: 8, Count: 3}, {Max: 16, Count: 2}}
+	for _, s := range out {
+		if !s.Timestamp.Equal(populated) {
+			continue
+		}
+		phi, err := strconv.ParseFloat(s.Labels[tempoQuantileLabel], 64)
+		if err != nil {
+			t.Fatalf("unparsable p label %q: %v", s.Labels[tempoQuantileLabel], err)
+		}
+		want, _ := log2QuantileWithBucket(phi, observed)
+		if s.Value != want {
+			t.Errorf("p=%s: got %v, want %v — the zero-fill row moved the estimate",
+				s.Labels[tempoQuantileLabel], s.Value, want)
+		}
+	}
+}
+
+// TestPostProcessQuantileBuckets_UnobservedBucketDoesNotMoveTheEstimate pins
+// the fold's own contract, independently of the one-octave convention the
+// quantile helper falls back on.
+//
+// The histogram handed to the algorithm must contain the buckets that were
+// OBSERVED and nothing else — that is the invariant upstream's aggregator is
+// built on, since it appends a bucket the first time something lands in it. A
+// zero-count row is a zero-fill artefact of the SQL shape, not an observation.
+// The emitter plants those at edge 0 today, where the helper's fallback happens
+// to recover the same number; at any other edge a retained zero-count row is a
+// real boundary the estimate interpolates against, and the percentile silently
+// moves. Dropping the row is what makes the answer independent of where the
+// zero-fill lands.
+func TestPostProcessQuantileBuckets_UnobservedBucketDoesNotMoveTheEstimate(t *testing.T) {
+	t.Parallel()
+
+	anchor := time.Unix(1_700_000_000, 0).UTC()
+	m := &chplan.MetricsAggregate{
+		Op:        chplan.MetricsOpQuantileOverTime,
+		Quantiles: []float64{0.5, 0.9, 0.99},
+	}
+
+	// Three observations in one bucket: phi=0.5 targets the 2nd, which sits
+	// strictly inside the bucket, so the estimate is interpolated against the
+	// lower boundary rather than landing on an edge. That is what makes a
+	// spurious boundary observable at all.
+	observedOnly := []chclient.Sample{
+		quantileBucketSample("checkout", anchor, "8", 3),
+	}
+	// The same observations, plus zero-count rows at edges below and above.
+	// The one at edge 2 is the dangerous shape: retained, it becomes the
+	// predecessor and drags the interpolation an octave down.
+	withUnobserved := []chclient.Sample{
+		quantileBucketSample("checkout", anchor, "0", 0),
+		quantileBucketSample("checkout", anchor, "2", 0),
+		quantileBucketSample("checkout", anchor, "8", 3),
+		quantileBucketSample("checkout", anchor, "64", 0),
+	}
+
+	want := postProcessQuantileBuckets(observedOnly, m)
+	got := postProcessQuantileBuckets(withUnobserved, m)
+
+	if len(got) != len(want) {
+		t.Fatalf("sample count changed: got %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i].Value != want[i].Value {
+			t.Errorf("p=%s: an unobserved bucket moved the estimate: got %v, want %v",
+				want[i].Labels[tempoQuantileLabel], got[i].Value, want[i].Value)
+		}
+	}
+}

--- a/internal/api/tempo/metrics_query_range.go
+++ b/internal/api/tempo/metrics_query_range.go
@@ -347,7 +347,8 @@ func (h *Handler) handleMetricsQueryRange(w http.ResponseWriter, r *http.Request
 	// per (group, anchor) so empty anchors survive the GROUP BY).
 	// Collapse the bucket rows into the per-(group, phi, anchor) scalar
 	// wire shape via Tempo's `Log2QuantileWithBucket` — empty anchors
-	// resolve to 0 because the phantom-bucket totalCount is zero.
+	// resolve to 0 because the phantom rows are all the anchor has, so
+	// its histogram is empty once they are discarded.
 	samples := res.Samples
 	if metrics.Op == chplan.MetricsOpQuantileOverTime {
 		samples = postProcessQuantileBuckets(samples, metrics)
@@ -821,9 +822,22 @@ func postProcessQuantileBuckets(samples []chclient.Sample, m *chplan.MetricsAggr
 		sort.Slice(g.buckets, func(i, j int) bool {
 			return g.buckets[i].max < g.buckets[j].max
 		})
-		buckets := make([]histogramBucket, len(g.buckets))
-		for i, b := range g.buckets {
-			buckets[i] = histogramBucket{Max: b.max, Count: b.count}
+		// Drop the zero-fill rows before the histogram sees them. The
+		// emitter plants a synthetic (bucket 0, count 0) row per (group,
+		// anchor) so an anchor with no spans still produces a row, but
+		// upstream's Histogram only ever holds buckets that were actually
+		// observed — it appends a bucket on first observation. A synthetic
+		// bucket left in the slice is read as a real boundary: it sorts to
+		// the front and becomes the predecessor the quantile interpolates
+		// down to, moving the estimate a whole octave. An anchor whose rows
+		// are ALL zero-fill correctly reduces to an empty histogram, which
+		// the quantile reports as 0 — the zero-fill's whole purpose.
+		buckets := make([]histogramBucket, 0, len(g.buckets))
+		for _, b := range g.buckets {
+			if b.count <= 0 {
+				continue
+			}
+			buckets = append(buckets, histogramBucket{Max: b.max, Count: b.count})
 		}
 		for _, phi := range m.Quantiles {
 			value, _ := log2QuantileWithBucket(phi, buckets)

--- a/internal/api/tempo/metrics_query_range_quantile_chdb_test.go
+++ b/internal/api/tempo/metrics_query_range_quantile_chdb_test.go
@@ -1,0 +1,140 @@
+//go:build chdb
+
+// chDB-backed end-to-end pin for `| quantile_over_time(duration, ...)` on
+// /api/metrics/query_range: parse → lower → emit → embedded ClickHouse →
+// bucket fold → JSON response.
+//
+// The unit tests in metrics_histogram_quantile_test.go pin the fold in
+// isolation, against a hand-built row stream. This one pins it against the
+// stream the EMITTER actually produces, which is where the defect lived: the
+// matrix SQL plants a synthetic (bucket 0, count 0) row per (group, anchor) so
+// an anchor with no spans still yields a row, and the fold read that synthetic
+// row as an observed boundary. log2(0) is -Inf, the interpolation evaluated to
+// NaN, and a NaN cannot be JSON-encoded — so the response came back 200 with an
+// empty body. Nothing between the SQL and the client could tell that apart from
+// "this query matched nothing", which is why it reached a dashboard.
+//
+// A hand-built stream cannot catch a change in what the emitter plants; only a
+// roundtrip through real SQL can. That is the layer this file adds.
+package tempo_test
+
+import (
+	"encoding/json"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/api/tempo"
+	"github.com/tsouza/cerberus/internal/chclienttest"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestMetricsQueryRangeQuantile_MultiPhiOverSparseWindow_ChDB drives the exact
+// query shape the showcase dashboard's failing panel used —
+// `{ } | quantile_over_time(duration, .5, .9, .99)` — over a window whose grid
+// anchors are mostly empty, so the emitter's zero-fill rows are guaranteed to
+// be in the stream.
+func TestMetricsQueryRangeQuantile_MultiPhiOverSparseWindow_ChDB(t *testing.T) {
+	c := chclienttest.NewChDB(t)
+	c.Seed(t, `CREATE TABLE otel_traces (
+    TraceId String,
+    SpanId String,
+    ParentSpanId String,
+    SpanName String,
+    Duration Int64,
+    Timestamp DateTime64(9),
+    SpanAttributes Map(String, String),
+    ResourceAttributes Map(String, String)
+) ENGINE = MergeTree() ORDER BY (Timestamp);`)
+	// Four spans, all landing on the 10:02 anchor (anchors round up), split
+	// 3-to-1 across two duration buckets. The split matters: phi=0.5 targets
+	// the 2nd of 4 samples, which sits STRICTLY INSIDE the 3-sample bucket, so
+	// the estimate is interpolated against a lower boundary rather than landing
+	// on a bucket edge. Interpolation is the only path that reads the
+	// predecessor boundary, and therefore the only path a spurious zero-fill
+	// boundary can corrupt. The window's other three anchors hold no spans, so
+	// they arrive carrying only the emitter's zero-fill row.
+	c.Seed(t, `INSERT INTO otel_traces VALUES
+    ('a0000000000000000000000000000001', '1000000000000001', '', 'a', 1024, toDateTime64('2026-05-12 10:01:10.000000000', 9), map(), map('service.name', 'svc')),
+    ('a0000000000000000000000000000002', '1000000000000002', '', 'b', 1024, toDateTime64('2026-05-12 10:01:20.000000000', 9), map(), map('service.name', 'svc')),
+    ('a0000000000000000000000000000004', '1000000000000004', '', 'd', 1024, toDateTime64('2026-05-12 10:01:25.000000000', 9), map(), map('service.name', 'svc')),
+    ('a0000000000000000000000000000003', '1000000000000003', '', 'c', 100000000, toDateTime64('2026-05-12 10:01:30.000000000', 9), map(), map('service.name', 'svc'));`)
+
+	h := tempo.New(c, schema.DefaultOTelTraces(), "v-test", nil)
+	mux := http.NewServeMux()
+	h.Mount(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	u := metricsQueryRangeURL(srv.URL, "{ } | quantile_over_time(duration, .5, .9, .99)", map[string]string{
+		"start": fixtureStartUnix, // 2026-05-12T10:00:00Z
+		"end":   fixtureEndUnix,   // +3m
+		"step":  "60s",
+	})
+	resp, err := http.Get(u)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body := readBody(t, resp)
+
+	// The headline assertion. A NaN in the payload used to surface here as
+	// exactly this: 200, zero bytes.
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+	if body == "" {
+		t.Fatal("200 with an empty body — the response failed to encode, which is " +
+			"indistinguishable from a query that legitimately matched nothing")
+	}
+
+	var out tempo.MetricsQueryRangeResponse
+	if err := json.Unmarshal([]byte(body), &out); err != nil {
+		t.Fatalf("decode: %v\nbody: %s", err, body)
+	}
+
+	// One series per phi.
+	byPhi := map[string]tempo.MetricsSeries{}
+	for _, s := range out.Series {
+		for _, l := range s.Labels {
+			if l.Key == "p" {
+				byPhi[l.Value] = s
+			}
+		}
+	}
+	for _, phi := range []string{"0.5", "0.9", "0.99"} {
+		s, ok := byPhi[phi]
+		if !ok {
+			t.Errorf("missing p=%s series: %s", phi, body)
+			continue
+		}
+		// Every sample has to be a finite number: one NaN anywhere in the
+		// document is enough for the encoder to refuse all of it.
+		for i, sm := range s.Samples {
+			if math.IsNaN(sm.Value) || math.IsInf(sm.Value, 0) {
+				t.Errorf("p=%s sample[%d] = %g at ts=%d", phi, i, sm.Value, sm.TimestampMs)
+			}
+		}
+	}
+
+	// The populated anchor must carry a real estimate rather than collapsing
+	// to the zero-fill's 0 — otherwise "no NaN" would be satisfied by
+	// answering nothing everywhere.
+	const populatedAnchorMs = 1778580120000 // 10:02 — anchors round up
+	for phi, s := range byPhi {
+		var got float64
+		var found bool
+		for _, sm := range s.Samples {
+			if sm.TimestampMs == populatedAnchorMs {
+				got, found = sm.Value, true
+			}
+		}
+		if !found {
+			t.Errorf("p=%s: no sample at the populated anchor: %+v", phi, s.Samples)
+			continue
+		}
+		if got <= 0 {
+			t.Errorf("p=%s: populated anchor read %g, want a positive duration estimate", phi, got)
+		}
+	}
+}


### PR DESCRIPTION
## Symptom

The showcase dashboard's `{ } | quantile_over_time(duration, .5, .9, .99)` panel returned **HTTP 200 with zero bytes**. Playwright reported `body not JSON: Unexpected end of JSON input`; a Grafana user sees an empty panel, indistinguishable from a query that legitimately matched nothing.

Caught by `compose-smoke` on release PR #1371. That lane is a **release** gate, so it had not run on `main` since 2026-05-22 — the panel has been broken since #762.

## Root cause — two stacked defects

### 1. The value bug: a synthetic bucket read as a real boundary

The matrix SQL plants a synthetic `(bucket 0, count 0)` row per `(group, anchor)` so an anchor with no spans still produces a row. The handler fold passed it straight into the histogram — but the quantile algorithm mirrors upstream's `HistogramAggregator`, whose `Histogram` only ever holds buckets something was **observed** in.

So the synthetic row is read as a real boundary. It sorts to the front, becomes the predecessor the estimate interpolates down to, and `math.Log2(0)` is `-Inf`:

```
lower + (upper-lower)*frac  →  -Inf + Inf*frac  →  NaN
```

Reproduced deterministically:

| buckets | φ=0.5 |
|---|---|
| `[{Max:0,Count:0}, {Max:8,Count:3}]` | **NaN** |
| `[{Max:8,Count:3}]` | 6.3496042078727974 |

Only phis that **interpolate** are hit — which is exactly why single-phi panels rendered and the multi-phi one did not.

### 2. The class bug: a 200 that was never sent

`httperr.WriteJSON` encoded straight into the `ResponseWriter`. `json.Encoder.Encode` buffers the whole value and reports failure only *after* `WriteHeader` has committed the status — so **any** unmarshalable payload in **any** of the three heads becomes a 200 with an empty body. A wrong answer presenting as success, which nothing upstream can detect.

## Fixes

- **`postProcessQuantileBuckets`** drops zero-count rows before the histogram sees them, restoring the input domain the algorithm assumes. An anchor whose rows are *all* zero-fill correctly reduces to an empty histogram → reports 0, the zero-fill's whole purpose.
- **`log2QuantileWithBucket`** applies its existing one-octave convention to any predecessor carrying no usable `log2`, not just a missing one — total, rather than merely correct on well-formed input.
- **`httperr.WriteJSON`** marshals first; a marshal failure answers **500** with an envelope carrying the union of the three heads' error fields. Write errors after the header stay discarded — a disconnected client is not the server's to repair.

The two quantile fixes are independent, and each is pinned separately: the filter keeps the estimate right wherever a spurious boundary lands (verified with a zero-count bucket at a *nonzero* edge, which the one-octave convention does **not** rescue); the convention keeps the helper NaN-free.

## Test layers

| layer | file | reverting the fix gives |
|---|---|---|
| unit — boundary convention | `metrics_histogram_quantile_test.go` | `NaN, want 6.3496…` |
| unit — handler fold | same | `an unobserved bucket moved the estimate: got 5.0397, want 6.3496` |
| unit — response writer | `httperr_test.go` | `reported as success (200); body was ""` |
| **chDB roundtrip** | `metrics_query_range_quantile_chdb_test.go` | `200 with an empty body` |

The chDB test drives the panel's exact query through real SQL, so it catches a change in what the *emitter* plants — and it reproduced the original production symptom verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)