### PR TITLE
fix: backport the quantile NaN, chplan Equal and release-base fixes to 1.12.x

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -112,10 +112,19 @@ jobs:
         # Prefer RELEASE_PAT so the created PR triggers pull_request CI; fall
         # back to github.token (PR created, but its checks won't run — see the
         # header note). gh reads GH_TOKEN.
+        #
+        # BASE is the ref the run was dispatched on, not a literal `main`: a
+        # maintenance release is staged by dispatching this workflow on
+        # release/<major>.<minor>.x, and the staging branch is cut from that
+        # checkout, so a hardcoded base would open the PR against main and offer
+        # to merge a whole maintenance line into the head line. The `issues`
+        # trigger has no such choice — a label-driven release always runs on the
+        # default branch, where ref_name is already `main`.
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PAT || github.token }}
           VERSION: ${{ steps.prep.outputs.new_version }}
           CHART_VERSION: ${{ steps.prep.outputs.chart_version }}
+          BASE: ${{ github.ref_name }}
         run: |
           branch="release/v${VERSION}-chart-${CHART_VERSION}"
           title="chore(release): cerberus v${VERSION} / chart ${CHART_VERSION}"
@@ -125,7 +134,7 @@ jobs:
           git add deploy/helm/cerberus/Chart.yaml deploy/helm/cerberus/README.md CHANGELOG.md
           git commit -m "$title"
           git push -u origin "$branch"
-          url="$(gh pr create --base main --head "$branch" --title "$title" --body-file release-pr-body.md)"
+          url="$(gh pr create --base "$BASE" --head "$branch" --title "$title" --body-file release-pr-body.md)"
           echo "url=$url" >>"$GITHUB_OUTPUT"
           echo "PR: $url"
 

--- a/internal/api/httperr/httperr.go
+++ b/internal/api/httperr/httperr.go
@@ -18,6 +18,7 @@
 package httperr
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 )
@@ -55,12 +56,75 @@ func (e *Error) Error() string { return e.Err.Error() }
 // [errors.Is] / [errors.As] across the boundary.
 func (e *Error) Unwrap() error { return e.Err }
 
+// MarshalFailureKind is the error-type string [WriteJSON] reports when a
+// response body cannot be marshalled. It is deliberately the Prom / Loki
+// "internal" vocabulary word: a body that will not marshal is a defect in
+// this gateway, never something the request asked for.
+const MarshalFailureKind = "internal"
+
+// marshalFailure is the envelope [WriteJSON] falls back to when the
+// caller's body cannot be marshalled. Its field set is the union of the
+// three heads' error shapes — `status`/`errorType`/`error` for Prom and
+// Loki, `error`/`message` for Tempo — so whichever client is on the other
+// end reads a populated error rather than a parse failure. Every field is
+// a string, so this envelope cannot itself fail to marshal.
+type marshalFailure struct {
+	Status    string `json:"status"`
+	ErrorType string `json:"errorType"`
+	Error     string `json:"error"`
+	Message   string `json:"message"`
+}
+
 // WriteJSON writes `body` as JSON with the given HTTP status. The
-// Content-Type is set to `application/json` before WriteHeader, and the
-// encoder's error is intentionally discarded — at that point the status
-// is already on the wire and there's nothing the caller can do.
+// Content-Type is set to `application/json` before WriteHeader.
+//
+// The body is marshalled BEFORE the status line goes out. That ordering is
+// the point of this function: [json.Encoder.Encode] buffers the whole value
+// and only then reports a failure, so encoding straight to w commits the
+// status first and discovers the problem second. A body carrying a NaN or
+// ±Inf — the shape a numeric bug in any head produces — would then reach
+// the client as a 200 with zero bytes, which is indistinguishable from a
+// legitimately empty result. A wrong answer that presents as success is
+// worse than an outage: nothing upstream can detect it. Marshalling first
+// turns that class into a 500 carrying [marshalFailure] instead.
+//
+// Errors from the write itself stay discarded, unlike marshal errors: once
+// the header is committed the status is on the wire, and a client that
+// disconnected mid-body is not the server's to repair.
 func WriteJSON(w http.ResponseWriter, status int, body any) {
+	// Encode, not Marshal: Encode is what the response bytes have always
+	// been produced by, and it terminates the body with a newline that
+	// handler-side snapshots depend on.
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(body); err != nil {
+		writeMarshalFailure(w, err)
+		return
+	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	_ = json.NewEncoder(w).Encode(body)
+	_, _ = w.Write(buf.Bytes())
+}
+
+// writeMarshalFailure reports an unmarshalable response body as a 500. It
+// is reached only when [WriteJSON]'s caller handed over a value the JSON
+// encoder rejects, so the status the caller asked for is discarded: that
+// status described a response this gateway turned out to be unable to
+// produce.
+func writeMarshalFailure(w http.ResponseWriter, cause error) {
+	msg := "response body could not be encoded: " + cause.Error()
+	body, err := json.Marshal(marshalFailure{
+		Status:    "error",
+		ErrorType: MarshalFailureKind,
+		Error:     msg,
+		Message:   msg,
+	})
+	if err != nil {
+		// Unreachable: marshalFailure is four strings. Fall back to a bare
+		// status rather than pretending the response has a body.
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusInternalServerError)
+	_, _ = w.Write(append(body, '\n'))
 }

--- a/internal/api/httperr/httperr_test.go
+++ b/internal/api/httperr/httperr_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -82,5 +83,82 @@ func TestWriteJSON_TrailingNewline(t *testing.T) {
 
 	if !strings.HasSuffix(rec.Body.String(), "\n") {
 		t.Errorf("body: missing trailing newline, got %q", rec.Body.String())
+	}
+}
+
+// TestWriteJSON_UnmarshalableBodyIsNotASuccess pins the failure mode that
+// makes marshal-before-header worth the buffer: a body carrying a NaN or ±Inf
+// cannot be encoded, and encoding straight to the ResponseWriter commits the
+// caller's status BEFORE that is discovered. The client then reads a 200 with
+// zero bytes, which is exactly what a legitimately empty result looks like —
+// so a numeric bug in any head ships as a successful query returning nothing.
+func TestWriteJSON_UnmarshalableBodyIsNotASuccess(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name  string
+		value float64
+	}{
+		{"NaN", math.NaN()},
+		{"+Inf", math.Inf(1)},
+		{"-Inf", math.Inf(-1)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			rec := httptest.NewRecorder()
+			httperr.WriteJSON(rec, http.StatusOK, map[string]any{
+				"series": []map[string]any{{"value": tc.value}},
+			})
+
+			res := rec.Result()
+			defer res.Body.Close()
+
+			if res.StatusCode == http.StatusOK {
+				t.Fatalf("a body that cannot be encoded was reported as success (200); "+
+					"body was %q", rec.Body.String())
+			}
+			if res.StatusCode != http.StatusInternalServerError {
+				t.Errorf("status: got %d, want %d", res.StatusCode, http.StatusInternalServerError)
+			}
+			if ct := res.Header.Get("Content-Type"); ct != "application/json" {
+				t.Errorf("Content-Type: got %q, want application/json", ct)
+			}
+
+			// The envelope has to carry the fields every head's client reads:
+			// status/errorType/error for Prom and Loki, error/message for Tempo.
+			var body map[string]any
+			if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
+				t.Fatalf("the failure envelope is not itself valid JSON: %v", err)
+			}
+			if body["status"] != "error" || body["errorType"] != httperr.MarshalFailureKind {
+				t.Errorf("envelope: got %+v", body)
+			}
+			for _, field := range []string{"error", "message"} {
+				msg, _ := body[field].(string)
+				if !strings.Contains(msg, "could not be encoded") {
+					t.Errorf("envelope %q does not say what went wrong: %q", field, msg)
+				}
+			}
+		})
+	}
+}
+
+// TestWriteJSON_MarshalFailureLeavesNoPartialBody guards the other half of the
+// ordering: nothing of the rejected value may reach the wire. Encoding into the
+// ResponseWriter would emit whatever prefix serialised before the bad value,
+// producing a truncated document that a decoder reports as a parse error rather
+// than as the server error it is.
+func TestWriteJSON_MarshalFailureLeavesNoPartialBody(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	httperr.WriteJSON(rec, http.StatusOK, map[string]any{
+		"marker": "must-not-appear",
+		"value":  math.NaN(),
+	})
+
+	if strings.Contains(rec.Body.String(), "must-not-appear") {
+		t.Errorf("a prefix of the rejected body reached the wire: %q", rec.Body.String())
 	}
 }

--- a/internal/api/tempo/metrics_histogram.go
+++ b/internal/api/tempo/metrics_histogram.go
@@ -136,8 +136,16 @@ func log2QuantileWithBucket(p float64, buckets []histogramBucket) (float64, int)
 	frac := float64(target-consumed) / float64(buckets[idx].Count)
 
 	upper := math.Log2(buckets[idx].Max)
-	lower := upper - 1 // one octave below, for the no-predecessor case
-	if idx > 0 {
+	// One octave below is the lower boundary whenever the predecessor
+	// carries none. That covers the first bucket, which has no predecessor
+	// at all, and equally a predecessor whose Max is not positive: log2 of
+	// a non-positive boundary is -Inf or NaN, and an infinite octave span
+	// makes the interpolation below evaluate to NaN. A NaN here does not
+	// stay here — it reaches the JSON encoder, which refuses the whole
+	// response — so the boundary convention has to be total, not merely
+	// correct on well-formed input.
+	lower := upper - 1
+	if idx > 0 && buckets[idx-1].Max > 0 {
 		lower = math.Log2(buckets[idx-1].Max)
 	}
 	return math.Pow(2, lower+(upper-lower)*frac), idx

--- a/internal/api/tempo/metrics_histogram_quantile_test.go
+++ b/internal/api/tempo/metrics_histogram_quantile_test.go
@@ -1,0 +1,246 @@
+package tempo
+
+import (
+	"math"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// The tests in this file pin the boundary between the matrix SQL's zero-fill
+// convention and the histogram-quantile algorithm.
+//
+// The emitter plants a synthetic (bucket 0, count 0) row for every (group,
+// anchor) so an anchor with no spans still produces a row. The quantile
+// algorithm, mirroring upstream Tempo's HistogramAggregator, assumes the
+// opposite: a bucket exists only because something was observed in it. Feed
+// the synthetic row in and it is read as a real boundary — it sorts to the
+// front, becomes the predecessor the estimate interpolates down to, and
+// log2(0) is -Inf, so the interpolation evaluates to NaN.
+//
+// NaN is the reason these are unit tests rather than a fixture: it does not
+// surface as a wrong number a golden would catch. It reaches the JSON encoder,
+// which rejects the entire response, and the handler used to answer that with
+// a 200 and an empty body. The failure therefore presents to a client as "this
+// query legitimately matched nothing".
+
+// quantileProbePhis spans the interpolating and the boundary-landing cases:
+// 0.5 lands mid-bucket (interpolation runs, so a bad lower boundary shows),
+// 0.9 and 0.99 round up onto the top bucket's edge.
+var quantileProbePhis = []float64{0, 0.5, 0.9, 0.95, 0.99, 1}
+
+// TestLog2Quantile_ZeroFillBucketDoesNotChangeTheEstimate is the regression
+// proper: the same observed histogram must produce the same estimate whether
+// or not the emitter's synthetic zero-count row is sitting in front of it.
+func TestLog2Quantile_ZeroFillBucketDoesNotChangeTheEstimate(t *testing.T) {
+	t.Parallel()
+
+	observed := []histogramBucket{{Max: 8, Count: 3}, {Max: 16, Count: 2}}
+	withZeroFill := append([]histogramBucket{{Max: 0, Count: 0}}, observed...)
+
+	for _, phi := range quantileProbePhis {
+		want, _ := log2QuantileWithBucket(phi, observed)
+		got, _ := log2QuantileWithBucket(phi, withZeroFill)
+
+		if math.IsNaN(got) || math.IsInf(got, 0) {
+			t.Errorf("phi=%v: a zero-count boundary produced %v — the JSON encoder "+
+				"rejects the whole response rather than this one value", phi, got)
+			continue
+		}
+		if got != want {
+			t.Errorf("phi=%v: a zero-count boundary moved the estimate: got %v, want %v",
+				phi, got, want)
+		}
+	}
+}
+
+// TestLog2Quantile_FirstBucketSpansOneOctave pins the convention the fix
+// leans on: with no usable lower boundary the bucket is taken to span one
+// octave below its Max. Both a genuinely-first bucket and one preceded only by
+// a zero-count boundary have to resolve the same way, because they describe the
+// same thing — an observed bucket with nothing beneath it.
+func TestLog2Quantile_FirstBucketSpansOneOctave(t *testing.T) {
+	t.Parallel()
+
+	// One bucket, three samples; phi=0.5 targets the 2nd, so frac = 2/3 and
+	// the estimate is 2^(log2(8)-1 + 1*2/3).
+	const phi = 0.5
+	want := math.Pow(2, 2+2.0/3.0)
+
+	for _, tc := range []struct {
+		name    string
+		buckets []histogramBucket
+	}{
+		{"no predecessor", []histogramBucket{{Max: 8, Count: 3}}},
+		{"zero-count predecessor", []histogramBucket{{Max: 0, Count: 0}, {Max: 8, Count: 3}}},
+	} {
+		got, _ := log2QuantileWithBucket(phi, tc.buckets)
+		if got != want {
+			t.Errorf("%s: got %v, want %v", tc.name, got, want)
+		}
+	}
+}
+
+// TestLog2Quantile_IsNeverNaN sweeps the boundary shapes the emitter can
+// produce and asserts the helper is total over them. A NaN escaping here is
+// not a local wrong answer — it fails the response.
+func TestLog2Quantile_IsNeverNaN(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		buckets []histogramBucket
+	}{
+		{"empty", nil},
+		{"zero-fill only", []histogramBucket{{Max: 0, Count: 0}}},
+		{"zero-fill then one bucket", []histogramBucket{{Max: 0, Count: 0}, {Max: 8, Count: 3}}},
+		{"zero-fill then many buckets", []histogramBucket{
+			{Max: 0, Count: 0}, {Max: 2, Count: 1}, {Max: 8, Count: 5}, {Max: 64, Count: 2},
+		}},
+		{"zero-count bucket in the middle", []histogramBucket{
+			{Max: 2, Count: 1}, {Max: 8, Count: 0}, {Max: 64, Count: 2},
+		}},
+		{"single observation", []histogramBucket{{Max: 1, Count: 1}}},
+	} {
+		for _, phi := range quantileProbePhis {
+			got, _ := log2QuantileWithBucket(phi, tc.buckets)
+			if math.IsNaN(got) || math.IsInf(got, 0) {
+				t.Errorf("%s, phi=%v: got %v", tc.name, phi, got)
+			}
+		}
+	}
+}
+
+// quantileBucketSample builds one row of the matrix quantile stream: a
+// (group, anchor, bucket) tuple whose value is the bucket's count.
+func quantileBucketSample(svc string, anchor time.Time, bucket string, count float64) chclient.Sample {
+	return chclient.Sample{
+		Labels:    map[string]string{"service.name": svc, tempoQuantileBucketLabel: bucket},
+		Timestamp: anchor,
+		Value:     count,
+	}
+}
+
+// TestPostProcessQuantileBuckets_MultiPhiOverZeroFilledAnchors drives the
+// handler-side fold over the exact shape the failing dashboard panel produces:
+// `{ } | quantile_over_time(duration, .5, .9, .99)`, whose stream carries the
+// emitter's zero-fill row alongside the observed buckets. Every emitted sample
+// must be a finite number — one NaN anywhere in the response body is enough for
+// the encoder to refuse all of it.
+func TestPostProcessQuantileBuckets_MultiPhiOverZeroFilledAnchors(t *testing.T) {
+	t.Parallel()
+
+	populated := time.Unix(1_700_000_000, 0).UTC()
+	empty := populated.Add(15 * time.Second)
+
+	m := &chplan.MetricsAggregate{
+		Op:        chplan.MetricsOpQuantileOverTime,
+		Quantiles: []float64{0.5, 0.9, 0.99},
+	}
+	samples := []chclient.Sample{
+		// A populated anchor: the zero-fill row plus two observed buckets.
+		quantileBucketSample("checkout", populated, "0", 0),
+		quantileBucketSample("checkout", populated, "8", 3),
+		quantileBucketSample("checkout", populated, "16", 2),
+		// An anchor with no spans: zero-fill only.
+		quantileBucketSample("checkout", empty, "0", 0),
+	}
+
+	out := postProcessQuantileBuckets(samples, m)
+
+	if want := len(m.Quantiles) * 2; len(out) != want {
+		t.Fatalf("want one sample per (anchor, phi) = %d, got %d", want, len(out))
+	}
+	for _, s := range out {
+		if math.IsNaN(s.Value) || math.IsInf(s.Value, 0) {
+			t.Errorf("anchor %s p=%s: got %v — this value cannot be JSON-encoded, "+
+				"so it fails the whole response", s.Timestamp, s.Labels[tempoQuantileLabel], s.Value)
+		}
+	}
+
+	// The zero-fill-only anchor is what the emitter plants the row FOR: it
+	// must still be reported, and reported as 0.
+	for _, s := range out {
+		if !s.Timestamp.Equal(empty) {
+			continue
+		}
+		if s.Value != 0 {
+			t.Errorf("an anchor with no observations must read 0, got %v at p=%s",
+				s.Value, s.Labels[tempoQuantileLabel])
+		}
+	}
+
+	// The populated anchor must read the estimate its observed buckets imply,
+	// unshifted by the zero-fill row.
+	observed := []histogramBucket{{Max: 8, Count: 3}, {Max: 16, Count: 2}}
+	for _, s := range out {
+		if !s.Timestamp.Equal(populated) {
+			continue
+		}
+		phi, err := strconv.ParseFloat(s.Labels[tempoQuantileLabel], 64)
+		if err != nil {
+			t.Fatalf("unparsable p label %q: %v", s.Labels[tempoQuantileLabel], err)
+		}
+		want, _ := log2QuantileWithBucket(phi, observed)
+		if s.Value != want {
+			t.Errorf("p=%s: got %v, want %v — the zero-fill row moved the estimate",
+				s.Labels[tempoQuantileLabel], s.Value, want)
+		}
+	}
+}
+
+// TestPostProcessQuantileBuckets_UnobservedBucketDoesNotMoveTheEstimate pins
+// the fold's own contract, independently of the one-octave convention the
+// quantile helper falls back on.
+//
+// The histogram handed to the algorithm must contain the buckets that were
+// OBSERVED and nothing else — that is the invariant upstream's aggregator is
+// built on, since it appends a bucket the first time something lands in it. A
+// zero-count row is a zero-fill artefact of the SQL shape, not an observation.
+// The emitter plants those at edge 0 today, where the helper's fallback happens
+// to recover the same number; at any other edge a retained zero-count row is a
+// real boundary the estimate interpolates against, and the percentile silently
+// moves. Dropping the row is what makes the answer independent of where the
+// zero-fill lands.
+func TestPostProcessQuantileBuckets_UnobservedBucketDoesNotMoveTheEstimate(t *testing.T) {
+	t.Parallel()
+
+	anchor := time.Unix(1_700_000_000, 0).UTC()
+	m := &chplan.MetricsAggregate{
+		Op:        chplan.MetricsOpQuantileOverTime,
+		Quantiles: []float64{0.5, 0.9, 0.99},
+	}
+
+	// Three observations in one bucket: phi=0.5 targets the 2nd, which sits
+	// strictly inside the bucket, so the estimate is interpolated against the
+	// lower boundary rather than landing on an edge. That is what makes a
+	// spurious boundary observable at all.
+	observedOnly := []chclient.Sample{
+		quantileBucketSample("checkout", anchor, "8", 3),
+	}
+	// The same observations, plus zero-count rows at edges below and above.
+	// The one at edge 2 is the dangerous shape: retained, it becomes the
+	// predecessor and drags the interpolation an octave down.
+	withUnobserved := []chclient.Sample{
+		quantileBucketSample("checkout", anchor, "0", 0),
+		quantileBucketSample("checkout", anchor, "2", 0),
+		quantileBucketSample("checkout", anchor, "8", 3),
+		quantileBucketSample("checkout", anchor, "64", 0),
+	}
+
+	want := postProcessQuantileBuckets(observedOnly, m)
+	got := postProcessQuantileBuckets(withUnobserved, m)
+
+	if len(got) != len(want) {
+		t.Fatalf("sample count changed: got %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i].Value != want[i].Value {
+			t.Errorf("p=%s: an unobserved bucket moved the estimate: got %v, want %v",
+				want[i].Labels[tempoQuantileLabel], got[i].Value, want[i].Value)
+		}
+	}
+}

--- a/internal/api/tempo/metrics_query_range.go
+++ b/internal/api/tempo/metrics_query_range.go
@@ -347,7 +347,8 @@ func (h *Handler) handleMetricsQueryRange(w http.ResponseWriter, r *http.Request
 	// per (group, anchor) so empty anchors survive the GROUP BY).
 	// Collapse the bucket rows into the per-(group, phi, anchor) scalar
 	// wire shape via Tempo's `Log2QuantileWithBucket` — empty anchors
-	// resolve to 0 because the phantom-bucket totalCount is zero.
+	// resolve to 0 because the phantom rows are all the anchor has, so
+	// its histogram is empty once they are discarded.
 	samples := res.Samples
 	if metrics.Op == chplan.MetricsOpQuantileOverTime {
 		samples = postProcessQuantileBuckets(samples, metrics)
@@ -821,9 +822,22 @@ func postProcessQuantileBuckets(samples []chclient.Sample, m *chplan.MetricsAggr
 		sort.Slice(g.buckets, func(i, j int) bool {
 			return g.buckets[i].max < g.buckets[j].max
 		})
-		buckets := make([]histogramBucket, len(g.buckets))
-		for i, b := range g.buckets {
-			buckets[i] = histogramBucket{Max: b.max, Count: b.count}
+		// Drop the zero-fill rows before the histogram sees them. The
+		// emitter plants a synthetic (bucket 0, count 0) row per (group,
+		// anchor) so an anchor with no spans still produces a row, but
+		// upstream's Histogram only ever holds buckets that were actually
+		// observed — it appends a bucket on first observation. A synthetic
+		// bucket left in the slice is read as a real boundary: it sorts to
+		// the front and becomes the predecessor the quantile interpolates
+		// down to, moving the estimate a whole octave. An anchor whose rows
+		// are ALL zero-fill correctly reduces to an empty histogram, which
+		// the quantile reports as 0 — the zero-fill's whole purpose.
+		buckets := make([]histogramBucket, 0, len(g.buckets))
+		for _, b := range g.buckets {
+			if b.count <= 0 {
+				continue
+			}
+			buckets = append(buckets, histogramBucket{Max: b.max, Count: b.count})
 		}
 		for _, phi := range m.Quantiles {
 			value, _ := log2QuantileWithBucket(phi, buckets)

--- a/internal/api/tempo/metrics_query_range_quantile_chdb_test.go
+++ b/internal/api/tempo/metrics_query_range_quantile_chdb_test.go
@@ -1,0 +1,140 @@
+//go:build chdb
+
+// chDB-backed end-to-end pin for `| quantile_over_time(duration, ...)` on
+// /api/metrics/query_range: parse → lower → emit → embedded ClickHouse →
+// bucket fold → JSON response.
+//
+// The unit tests in metrics_histogram_quantile_test.go pin the fold in
+// isolation, against a hand-built row stream. This one pins it against the
+// stream the EMITTER actually produces, which is where the defect lived: the
+// matrix SQL plants a synthetic (bucket 0, count 0) row per (group, anchor) so
+// an anchor with no spans still yields a row, and the fold read that synthetic
+// row as an observed boundary. log2(0) is -Inf, the interpolation evaluated to
+// NaN, and a NaN cannot be JSON-encoded — so the response came back 200 with an
+// empty body. Nothing between the SQL and the client could tell that apart from
+// "this query matched nothing", which is why it reached a dashboard.
+//
+// A hand-built stream cannot catch a change in what the emitter plants; only a
+// roundtrip through real SQL can. That is the layer this file adds.
+package tempo_test
+
+import (
+	"encoding/json"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/api/tempo"
+	"github.com/tsouza/cerberus/internal/chclienttest"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestMetricsQueryRangeQuantile_MultiPhiOverSparseWindow_ChDB drives the exact
+// query shape the showcase dashboard's failing panel used —
+// `{ } | quantile_over_time(duration, .5, .9, .99)` — over a window whose grid
+// anchors are mostly empty, so the emitter's zero-fill rows are guaranteed to
+// be in the stream.
+func TestMetricsQueryRangeQuantile_MultiPhiOverSparseWindow_ChDB(t *testing.T) {
+	c := chclienttest.NewChDB(t)
+	c.Seed(t, `CREATE TABLE otel_traces (
+    TraceId String,
+    SpanId String,
+    ParentSpanId String,
+    SpanName String,
+    Duration Int64,
+    Timestamp DateTime64(9),
+    SpanAttributes Map(String, String),
+    ResourceAttributes Map(String, String)
+) ENGINE = MergeTree() ORDER BY (Timestamp);`)
+	// Four spans, all landing on the 10:02 anchor (anchors round up), split
+	// 3-to-1 across two duration buckets. The split matters: phi=0.5 targets
+	// the 2nd of 4 samples, which sits STRICTLY INSIDE the 3-sample bucket, so
+	// the estimate is interpolated against a lower boundary rather than landing
+	// on a bucket edge. Interpolation is the only path that reads the
+	// predecessor boundary, and therefore the only path a spurious zero-fill
+	// boundary can corrupt. The window's other three anchors hold no spans, so
+	// they arrive carrying only the emitter's zero-fill row.
+	c.Seed(t, `INSERT INTO otel_traces VALUES
+    ('a0000000000000000000000000000001', '1000000000000001', '', 'a', 1024, toDateTime64('2026-05-12 10:01:10.000000000', 9), map(), map('service.name', 'svc')),
+    ('a0000000000000000000000000000002', '1000000000000002', '', 'b', 1024, toDateTime64('2026-05-12 10:01:20.000000000', 9), map(), map('service.name', 'svc')),
+    ('a0000000000000000000000000000004', '1000000000000004', '', 'd', 1024, toDateTime64('2026-05-12 10:01:25.000000000', 9), map(), map('service.name', 'svc')),
+    ('a0000000000000000000000000000003', '1000000000000003', '', 'c', 100000000, toDateTime64('2026-05-12 10:01:30.000000000', 9), map(), map('service.name', 'svc'));`)
+
+	h := tempo.New(c, schema.DefaultOTelTraces(), "v-test", nil)
+	mux := http.NewServeMux()
+	h.Mount(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	u := metricsQueryRangeURL(srv.URL, "{ } | quantile_over_time(duration, .5, .9, .99)", map[string]string{
+		"start": fixtureStartUnix, // 2026-05-12T10:00:00Z
+		"end":   fixtureEndUnix,   // +3m
+		"step":  "60s",
+	})
+	resp, err := http.Get(u)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body := readBody(t, resp)
+
+	// The headline assertion. A NaN in the payload used to surface here as
+	// exactly this: 200, zero bytes.
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+	if body == "" {
+		t.Fatal("200 with an empty body — the response failed to encode, which is " +
+			"indistinguishable from a query that legitimately matched nothing")
+	}
+
+	var out tempo.MetricsQueryRangeResponse
+	if err := json.Unmarshal([]byte(body), &out); err != nil {
+		t.Fatalf("decode: %v\nbody: %s", err, body)
+	}
+
+	// One series per phi.
+	byPhi := map[string]tempo.MetricsSeries{}
+	for _, s := range out.Series {
+		for _, l := range s.Labels {
+			if l.Key == "p" {
+				byPhi[l.Value] = s
+			}
+		}
+	}
+	for _, phi := range []string{"0.5", "0.9", "0.99"} {
+		s, ok := byPhi[phi]
+		if !ok {
+			t.Errorf("missing p=%s series: %s", phi, body)
+			continue
+		}
+		// Every sample has to be a finite number: one NaN anywhere in the
+		// document is enough for the encoder to refuse all of it.
+		for i, sm := range s.Samples {
+			if math.IsNaN(sm.Value) || math.IsInf(sm.Value, 0) {
+				t.Errorf("p=%s sample[%d] = %g at ts=%d", phi, i, sm.Value, sm.TimestampMs)
+			}
+		}
+	}
+
+	// The populated anchor must carry a real estimate rather than collapsing
+	// to the zero-fill's 0 — otherwise "no NaN" would be satisfied by
+	// answering nothing everywhere.
+	const populatedAnchorMs = 1778580120000 // 10:02 — anchors round up
+	for phi, s := range byPhi {
+		var got float64
+		var found bool
+		for _, sm := range s.Samples {
+			if sm.TimestampMs == populatedAnchorMs {
+				got, found = sm.Value, true
+			}
+		}
+		if !found {
+			t.Errorf("p=%s: no sample at the populated anchor: %+v", phi, s.Samples)
+			continue
+		}
+		if got <= 0 {
+			t.Errorf("p=%s: populated anchor read %g, want a positive duration estimate", phi, got)
+		}
+	}
+}

--- a/internal/chplan/canonical_series_keys_test.go
+++ b/internal/chplan/canonical_series_keys_test.go
@@ -160,3 +160,136 @@ func TestCanonicalizeSeriesKeyExprs_LeavesCanonicalKeysAlone(t *testing.T) {
 		t.Fatalf("an already-canonical key must not be double-wrapped; got %#v", out)
 	}
 }
+
+// TestCanonicalizeSeriesKeyExprs_WrapsARawKeyAfterANonRawOne pins that a key
+// the walk cannot prove raw only makes THAT key pass through — the scan must
+// carry on to the keys behind it. A `break` in place of the `continue` stops
+// at the first ordinary key (a bare value column, which every real key list
+// carries alongside the attribute Map) and leaves the raw Map behind it
+// unwrapped, which is the silent series-split the whole file exists to stop.
+func TestCanonicalizeSeriesKeyExprs_WrapsARawKeyAfterANonRawOne(t *testing.T) {
+	inputs := []chplan.Node{gaugeScan()}
+	keys := []chplan.Expr{
+		&chplan.ColumnRef{Name: "Value"},      // not an attribute Map: skipped
+		&chplan.ColumnRef{Name: "Attributes"}, // raw Map: must still be wrapped
+	}
+
+	out := chplan.CanonicalizeSeriesKeyExprs(keys, inputs, attrCols())
+
+	if len(out) != 2 {
+		t.Fatalf("want 2 keys back, got %d", len(out))
+	}
+	if !out[0].Equal(keys[0]) {
+		t.Errorf("the non-raw key must pass through untouched; got %#v", out[0])
+	}
+	call, ok := out[1].(*chplan.FuncCall)
+	if !ok || call.Name != chplan.CanonicalMapFunc {
+		t.Fatalf("the raw key behind it must be wrapped in %s; got %#v", chplan.CanonicalMapFunc, out[1])
+	}
+}
+
+// TestCanonicalizeSeriesIdentityKeys_WrapsARawKeyAfterANonRawOne is the
+// whole-plan counterpart: an Aggregate keyed on an ordinary column AND the
+// raw attribute Map still gets the repair. The column scan behind the node's
+// key list has to survive a key it cannot prove raw.
+func TestCanonicalizeSeriesIdentityKeys_WrapsARawKeyAfterANonRawOne(t *testing.T) {
+	in := &chplan.Aggregate{
+		Input: gaugeScan(),
+		GroupBy: []chplan.Expr{
+			&chplan.ColumnRef{Name: "Value"},
+			&chplan.ColumnRef{Name: "Attributes"},
+		},
+		AggFuncs: []chplan.AggFunc{{Name: "count", Alias: "n"}},
+	}
+
+	out := chplan.CanonicalizeSeriesIdentityKeys(in, attrCols())
+
+	reps := projectReplacements(t, out)
+	if len(reps) != 1 || reps[0].Alias != "Attributes" {
+		t.Fatalf("want the Attributes column canonicalised beneath the Aggregate; got %#v", reps)
+	}
+}
+
+// TestCanonicalizeSeriesIdentityKeys_WrapsThroughAMapValuedCall pins that the
+// idempotence check tests for the CANONICAL function specifically. A key like
+// `mapConcat(Attributes)` is a Map-returning call sitting bare in a key list —
+// the binding site — so the walk has to descend into its arguments. Treating
+// every named call as already canonical skips the descent and leaves the
+// positional Map comparison unrepaired.
+func TestCanonicalizeSeriesIdentityKeys_WrapsThroughAMapValuedCall(t *testing.T) {
+	in := &chplan.Aggregate{
+		Input: gaugeScan(),
+		GroupBy: []chplan.Expr{&chplan.FuncCall{
+			Name: "mapConcat",
+			Args: []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+		}},
+		AggFuncs: []chplan.AggFunc{{Name: "count", Alias: "n"}},
+	}
+
+	out := chplan.CanonicalizeSeriesIdentityKeys(in, attrCols())
+
+	reps := projectReplacements(t, out)
+	if len(reps) != 1 || reps[0].Alias != "Attributes" {
+		t.Fatalf("want the Attributes column canonicalised beneath the Aggregate; got %#v", reps)
+	}
+}
+
+// TestCanonicalizeSeriesIdentityKeys_ResolvesTheProjectionThatBindsTheName
+// pins that resolving a column through an explicit projection list matches on
+// the alias that actually binds the name. Answering with the WRONG projection
+// reads a sibling's expression, so a plan whose projection already
+// canonicalises the Map is judged raw and gets a second, redundant repair
+// layer inserted beneath it.
+func TestCanonicalizeSeriesIdentityKeys_ResolvesTheProjectionThatBindsTheName(t *testing.T) {
+	canonicalising := &chplan.Project{
+		Input: gaugeScan(),
+		Projections: []chplan.Projection{
+			// A sibling that reads the RAW Map, bound under a different name.
+			{Expr: &chplan.ColumnRef{Name: "Attributes"}, Alias: "RawCopy"},
+			// The projection that actually binds "Attributes", already canonical.
+			{Expr: chplan.CanonicalAttributesExpr(&chplan.ColumnRef{Name: "Attributes"}), Alias: "Attributes"},
+		},
+	}
+	in := &chplan.Aggregate{
+		Input:    canonicalising,
+		GroupBy:  []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+		AggFuncs: []chplan.AggFunc{{Name: "count", Alias: "n"}},
+	}
+
+	out := chplan.CanonicalizeSeriesIdentityKeys(in, attrCols())
+
+	if out != chplan.Node(in) {
+		t.Fatalf("a key already canonicalised by the projection that binds it needs no repair; got %#v", out)
+	}
+}
+
+// TestCanonicalizeSeriesIdentityKeys_ScansPastANonBindingProjection is the
+// mirror of the test above: the projection that binds the key is again not the
+// first one, but this time it hands through the RAW Map, so the key does need
+// repair. Abandoning the projection list at the first alias that does not match
+// leaves the binding unresolved, and an unresolved binding is treated as "not
+// raw" — the plan then compares Maps positionally and answers with the wrong
+// series identity.
+func TestCanonicalizeSeriesIdentityKeys_ScansPastANonBindingProjection(t *testing.T) {
+	binding := &chplan.Project{
+		Input: gaugeScan(),
+		Projections: []chplan.Projection{
+			// A non-matching alias the scan has to walk past.
+			{Expr: chplan.CanonicalAttributesExpr(&chplan.ColumnRef{Name: "Attributes"}), Alias: "Canonical"},
+			// The projection that actually binds "Attributes", still raw.
+			{Expr: &chplan.ColumnRef{Name: "Attributes"}, Alias: "Attributes"},
+		},
+	}
+	in := &chplan.Aggregate{
+		Input:    binding,
+		GroupBy:  []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+		AggFuncs: []chplan.AggFunc{{Name: "count", Alias: "n"}},
+	}
+
+	out := chplan.CanonicalizeSeriesIdentityKeys(in, attrCols())
+
+	reps := projectReplacements(t, out)
+	if len(reps) != 1 || reps[0].Alias != "Attributes" {
+		t.Fatalf("want the Attributes column canonicalised beneath the Aggregate; got %#v", reps)
+	}
+}

--- a/internal/chplan/equal_field_discrimination_test.go
+++ b/internal/chplan/equal_field_discrimination_test.go
@@ -1,0 +1,190 @@
+package chplan
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+// This file pins the PER-FIELD DISCRIMINATION contract of every Node's
+// Equal method: two nodes of the same type that differ in exactly one
+// field must not compare Equal, in both directions.
+//
+// Why it is generic rather than a per-node list. Equal is a long
+// conjunction of field comparisons, and a hand-written negative case per
+// node reliably covers the fields someone thought of. The ones nobody
+// thought of are invisible: a field left out of the conjunction, or a
+// `&&` that should have been `||`, changes nothing a fixture can see —
+// the plan still emits, the optimizer still runs, and two structurally
+// DIFFERENT plans quietly compare equal. That is a wrong-answer class
+// (the fixpoint driver stops early, a rule's "did this change anything?"
+// check answers no), not a crash, so it ships silently.
+//
+// Driving the check off [allNodeCases] — the same registry
+// TestRewriteChildren_TableCoversEveryNodeType count-guards — makes the
+// contract total by construction: a new Node type has to be added to that
+// table, and every field it declares is discriminated here from the
+// moment it exists. There is no per-field opt-in to forget.
+//
+// Field values are synthesised by [synthValue], which produces two
+// distinct values for every type the IR's node structs use. A field whose
+// type it cannot synthesise fails the test rather than being skipped, so
+// widening the IR's type vocabulary is a visible event.
+
+// discriminationVariants is how many distinct values [synthValue]
+// produces per type: a baseline and one that must be observably different
+// from it.
+const discriminationVariants = 2
+
+// The per-kind value pairs. Index 0 builds the baseline node; index 1 is
+// the single differing field under test. The values carry no meaning
+// beyond "these two are not equal".
+var (
+	stringVariants = [discriminationVariants]string{"discriminantA", "discriminantB"}
+	intVariants    = [discriminationVariants]int64{1, 2}
+	uintVariants   = [discriminationVariants]uint64{1, 2}
+	floatVariants  = [discriminationVariants]float64{1.5, 2.5}
+	boolVariants   = [discriminationVariants]bool{false, true}
+	timeVariants   = [discriminationVariants]time.Time{
+		time.Unix(1_700_000_000, 0).UTC(),
+		time.Unix(1_700_000_060, 0).UTC(),
+	}
+)
+
+var (
+	nodeInterface = reflect.TypeOf((*Node)(nil)).Elem()
+	exprInterface = reflect.TypeOf((*Expr)(nil)).Elem()
+	timeType      = reflect.TypeOf(time.Time{})
+)
+
+// synthValue returns a value of typ for the given variant. Two calls with
+// different variants must produce values that any correct Equal reports as
+// different; two calls with the same variant must produce equal values.
+func synthValue(t *testing.T, typ reflect.Type, variant int) reflect.Value {
+	t.Helper()
+
+	if typ == timeType {
+		return reflect.ValueOf(timeVariants[variant])
+	}
+	if typ == nodeInterface {
+		return reflect.ValueOf(Node(&Scan{Table: stringVariants[variant]}))
+	}
+	if typ == exprInterface {
+		return reflect.ValueOf(Expr(&ColumnRef{Name: stringVariants[variant]}))
+	}
+
+	v := reflect.New(typ).Elem()
+	switch typ.Kind() {
+	case reflect.String:
+		v.SetString(stringVariants[variant])
+	case reflect.Bool:
+		v.SetBool(boolVariants[variant])
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		v.SetInt(intVariants[variant])
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		v.SetUint(uintVariants[variant])
+	case reflect.Float32, reflect.Float64:
+		v.SetFloat(floatVariants[variant])
+	case reflect.Slice:
+		return synthSlice(t, typ, variant, 1)
+	case reflect.Pointer:
+		p := reflect.New(typ.Elem())
+		p.Elem().Set(synthValue(t, typ.Elem(), variant))
+		return p
+	case reflect.Map:
+		m := reflect.MakeMap(typ)
+		m.SetMapIndex(synthValue(t, typ.Key(), variant), synthValue(t, typ.Elem(), variant))
+		return m
+	case reflect.Struct:
+		for i := range typ.NumField() {
+			f := typ.Field(i)
+			if !f.IsExported() {
+				t.Fatalf("field %s.%s is unexported, so no value can be synthesised for it; "+
+					"give the type an exported shape or teach synthValue about it", typ, f.Name)
+			}
+			v.Field(i).Set(synthValue(t, f.Type, variant))
+		}
+	default:
+		t.Fatalf("synthValue has no case for %s (kind %s); teach it one rather than "+
+			"leaving the field undiscriminated", typ, typ.Kind())
+	}
+	return v
+}
+
+// synthSlice builds a length-n slice of typ's element type. Element i takes
+// variant (variant+i) so a longer slice is also element-wise different from
+// the baseline, which is what makes the length case fail for the right
+// reason when a length check is missing.
+func synthSlice(t *testing.T, typ reflect.Type, variant, n int) reflect.Value {
+	t.Helper()
+	s := reflect.MakeSlice(typ, n, n)
+	for i := range n {
+		s.Index(i).Set(synthValue(t, typ.Elem(), (variant+i)%discriminationVariants))
+	}
+	return s
+}
+
+// synthNode builds a *T (typ is the struct type) with every field set to
+// the given variant's value.
+func synthNode(t *testing.T, typ reflect.Type, variant int) Node {
+	t.Helper()
+	p := reflect.New(typ)
+	p.Elem().Set(synthValue(t, typ, variant))
+	n, ok := p.Interface().(Node)
+	if !ok {
+		t.Fatalf("*%s does not implement Node", typ)
+	}
+	return n
+}
+
+func TestNodeEqual_DiscriminatesEveryField(t *testing.T) {
+	t.Parallel()
+
+	for _, c := range allNodeCases() {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			typ := reflect.TypeOf(c.node).Elem()
+			base := synthNode(t, typ, 0)
+			if twin := synthNode(t, typ, 0); !base.Equal(twin) {
+				t.Fatalf("two independently built, field-identical %s nodes must be Equal; "+
+					"an Equal that answers false here makes every discrimination case below vacuous", typ)
+			}
+
+			for i := range typ.NumField() {
+				field := typ.Field(i)
+				t.Run(field.Name, func(t *testing.T) {
+					assertDiscriminates(t, base, typ, i, synthValue(t, field.Type, 1), "value")
+
+					// A slice field also has to be discriminated by LENGTH:
+					// an Equal that compares elements pairwise but forgets
+					// the length check reports a prefix as equal to the
+					// whole.
+					if field.Type.Kind() == reflect.Slice {
+						longer := synthSlice(t, field.Type, 0, discriminationVariants)
+						assertDiscriminates(t, base, typ, i, longer, "length")
+					}
+				})
+			}
+		})
+	}
+}
+
+// assertDiscriminates builds a copy of base with exactly field i replaced by
+// value and asserts Equal reports the two as different, symmetrically.
+func assertDiscriminates(t *testing.T, base Node, typ reflect.Type, i int, value reflect.Value, why string) {
+	t.Helper()
+
+	mutated := synthNode(t, typ, 0)
+	reflect.ValueOf(mutated).Elem().Field(i).Set(value)
+
+	name := typ.Field(i).Name
+	if base.Equal(mutated) {
+		t.Errorf("%s.Equal ignores the %s of field %s: nodes differing only there compare Equal, "+
+			"so the optimizer treats two different plans as one", typ, why, name)
+	}
+	if mutated.Equal(base) {
+		t.Errorf("%s.Equal is not symmetric for the %s of field %s: the reversed comparison reports Equal",
+			typ, why, name)
+	}
+}

--- a/internal/chplan/gremlins_kill_test.go
+++ b/internal/chplan/gremlins_kill_test.go
@@ -400,3 +400,232 @@ func lwrNodeKill(start, end time.Time, step, lookback, offset time.Duration) *ch
 		ValueCol:      "Value",
 	}
 }
+
+// -----------------------------------------------------------------------
+// Nil-child guards on the two experimental grid nodes.
+//
+// RangeWindowResample and RangeWindowNative are the only Equal methods that
+// tolerate a nil Input, and they do it with an explicit `r.Input == nil ||
+// o.Input == nil` guard. TestNodeEqual_DiscriminatesEveryField cannot reach
+// the guard — it compares fully-populated nodes — so the contract is pinned
+// here: a nil Input on one side alone is a difference, and the comparison
+// must answer it rather than dereference the nil.
+// -----------------------------------------------------------------------
+
+func TestRangeWindowResample_Equal_NilInputIsADifference(t *testing.T) {
+	t.Parallel()
+
+	populated := func(input chplan.Node) *chplan.RangeWindowResample {
+		return &chplan.RangeWindowResample{
+			Input:         input,
+			Start:         time.Unix(1_700_000_000, 0).UTC(),
+			End:           time.Unix(1_700_003_600, 0).UTC(),
+			Step:          30 * time.Second,
+			Lookback:      5 * time.Minute,
+			MetricNameCol: "MetricName",
+			AttributesCol: "Attributes",
+			TimestampCol:  "TimeUnix",
+			ValueCol:      "Value",
+		}
+	}
+
+	withInput := populated(&chplan.Scan{Table: "metrics"})
+	noInput := populated(nil)
+
+	if withInput.Equal(noInput) {
+		t.Error("a node with an Input must not equal one without")
+	}
+	if noInput.Equal(withInput) {
+		t.Error("the nil-Input guard must answer symmetrically, not dereference the nil Input")
+	}
+	if !noInput.Equal(populated(nil)) {
+		t.Error("two nil-Input nodes with identical scalars must be Equal")
+	}
+}
+
+func TestRangeWindowNative_Equal_NilInputIsADifference(t *testing.T) {
+	t.Parallel()
+
+	populated := func(input chplan.Node) *chplan.RangeWindowNative {
+		return &chplan.RangeWindowNative{
+			Input:           input,
+			Func:            "rate",
+			Range:           5 * time.Minute,
+			Step:            30 * time.Second,
+			Start:           time.Unix(1_700_000_000, 0).UTC(),
+			End:             time.Unix(1_700_003_600, 0).UTC(),
+			TimestampColumn: "TimeUnix",
+			ValueColumn:     "Value",
+		}
+	}
+
+	withInput := populated(&chplan.Scan{Table: "metrics"})
+	noInput := populated(nil)
+
+	if withInput.Equal(noInput) {
+		t.Error("a node with an Input must not equal one without")
+	}
+	if noInput.Equal(withInput) {
+		t.Error("the nil-Input guard must answer symmetrically, not dereference the nil Input")
+	}
+	if !noInput.Equal(populated(nil)) {
+		t.Error("two nil-Input nodes with identical scalars must be Equal")
+	}
+}
+
+// -----------------------------------------------------------------------
+// RewriteChildren's InfoJoin arm rebuilds on a ONE-SIDED change.
+//
+// The exhaustiveness table plants its sentinel in every child slot at once,
+// so both sides always change together and the arm's `!inCh && !infoCh`
+// early-out is never exercised with a mixed verdict. Widening that to `||`
+// makes the arm drop a rewrite that reached only one side — the optimizer
+// then silently discards a rule's result on the base vector or the info
+// scan, whichever the other side did not also touch.
+// -----------------------------------------------------------------------
+
+func TestRewriteChildren_InfoJoin_KeepsAOneSidedRewrite(t *testing.T) {
+	t.Parallel()
+
+	base := &chplan.Scan{Table: "base"}
+	info := &chplan.Scan{Table: "info"}
+	rewritten := &chplan.Scan{Table: "rewritten"}
+
+	rewriteOnly := func(table string) func(chplan.Node) (chplan.Node, bool) {
+		return func(c chplan.Node) (chplan.Node, bool) {
+			if s, ok := c.(*chplan.Scan); ok && s.Table == table {
+				return rewritten, true
+			}
+			return c, false
+		}
+	}
+
+	for _, tc := range []struct {
+		name         string
+		side         string
+		wantInput    chplan.Node
+		wantInfoNode chplan.Node
+	}{
+		{name: "input only", side: "base", wantInput: rewritten, wantInfoNode: info},
+		{name: "info only", side: "info", wantInput: base, wantInfoNode: rewritten},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			in := &chplan.InfoJoin{Input: base, Info: info}
+			got, changed := chplan.RewriteChildren(in, rewriteOnly(tc.side))
+			if !changed {
+				t.Fatalf("rewriting the %s side must report changed=true", tc.side)
+			}
+			out, ok := got.(*chplan.InfoJoin)
+			if !ok {
+				t.Fatalf("RewriteChildren returned %T, want *chplan.InfoJoin", got)
+			}
+			if out == in {
+				t.Fatal("a changed InfoJoin must be rebuilt, not returned in place")
+			}
+			if out.Input != tc.wantInput {
+				t.Errorf("Input = %#v, want %#v", out.Input, tc.wantInput)
+			}
+			if out.Info != tc.wantInfoNode {
+				t.Errorf("Info = %#v, want %#v", out.Info, tc.wantInfoNode)
+			}
+		})
+	}
+}
+
+// -----------------------------------------------------------------------
+// inspectExpr's InSubquery arm.
+//
+// The arm carries the same `nodeVisit != nil && v.Subquery != nil` guard as
+// the ScalarSubquery arm above it, but only ScalarSubquery had a test. Each
+// half of the guard is load-bearing: InspectExpr passes a nil nodeVisit, and
+// an InSubquery built by a partially-lowered plan can carry a nil Subquery.
+// -----------------------------------------------------------------------
+
+func TestInspectExprNodes_InSubquery_SurfacesTheSubqueryPlan(t *testing.T) {
+	t.Parallel()
+
+	inner := &chplan.Scan{Table: "trace_ids"}
+	expr := &chplan.InSubquery{Left: &chplan.ColumnRef{Name: "TraceId"}, Subquery: inner}
+
+	var seen []chplan.Node
+	chplan.InspectExprNodes(expr, func(chplan.Expr) bool { return true }, func(n chplan.Node) {
+		seen = append(seen, n)
+	})
+
+	if len(seen) != 1 || seen[0] != chplan.Node(inner) {
+		t.Fatalf("nodeVisit saw %#v, want exactly the InSubquery's embedded plan Node", seen)
+	}
+}
+
+func TestInspectExprNodes_InSubquery_SkipsANilSubquery(t *testing.T) {
+	t.Parallel()
+
+	expr := &chplan.InSubquery{Left: &chplan.ColumnRef{Name: "TraceId"}}
+
+	chplan.InspectExprNodes(expr, func(chplan.Expr) bool { return true }, func(n chplan.Node) {
+		t.Fatalf("nodeVisit must not be invoked for a nil Subquery; got %#v", n)
+	})
+}
+
+func TestInspectExpr_InSubquery_StaysExprOnlyWithoutANodeVisitor(t *testing.T) {
+	t.Parallel()
+
+	expr := &chplan.InSubquery{
+		Left:     &chplan.ColumnRef{Name: "TraceId"},
+		Subquery: &chplan.Scan{Table: "trace_ids"},
+	}
+
+	// InspectExpr supplies a nil nodeVisit. The guard is what stops the arm
+	// calling through it; without it this panics rather than fails.
+	var visited []chplan.Expr
+	chplan.InspectExpr(expr, func(e chplan.Expr) bool {
+		visited = append(visited, e)
+		return true
+	})
+
+	if len(visited) != 2 {
+		t.Fatalf("visited %d expressions, want the InSubquery and its Left operand", len(visited))
+	}
+}
+
+// -----------------------------------------------------------------------
+// CanonicalAttributesExpr's idempotence check.
+//
+// The check tests the call's NAME, so it must wrap every OTHER Map-valued
+// call and skip only an already-canonical one. Inverting it turns the
+// helper into a no-op for exactly the calls that need the wrap.
+// -----------------------------------------------------------------------
+
+func TestCanonicalAttributesExpr_WrapsAnotherMapValuedCall(t *testing.T) {
+	t.Parallel()
+
+	inner := &chplan.FuncCall{
+		Name: "mapConcat",
+		Args: []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+	}
+
+	got := chplan.CanonicalAttributesExpr(inner)
+
+	call, ok := got.(*chplan.FuncCall)
+	if !ok || call.Name != chplan.CanonicalMapFunc {
+		t.Fatalf("got %#v, want a %s call wrapping the mapConcat", got, chplan.CanonicalMapFunc)
+	}
+	if len(call.Args) != 1 || call.Args[0] != chplan.Expr(inner) {
+		t.Fatalf("%s args = %#v, want exactly the wrapped expression", chplan.CanonicalMapFunc, call.Args)
+	}
+}
+
+func TestCanonicalAttributesExpr_LeavesACanonicalCallAlone(t *testing.T) {
+	t.Parallel()
+
+	inner := &chplan.FuncCall{
+		Name: chplan.CanonicalMapFunc,
+		Args: []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+	}
+
+	if got := chplan.CanonicalAttributesExpr(inner); got != chplan.Expr(inner) {
+		t.Fatalf("got %#v, want the already-canonical call back by identity", got)
+	}
+}

--- a/internal/chplan/metrics_compare.go
+++ b/internal/chplan/metrics_compare.go
@@ -110,6 +110,7 @@ func (m *MetricsCompare) Equal(other Node) bool {
 		return false
 	}
 	if m.TopN != o.TopN || m.StartNs != o.StartNs || m.EndNs != o.EndNs ||
+		m.InnerRootScoped != o.InnerRootScoped ||
 		m.TraceIDColumn != o.TraceIDColumn ||
 		m.RootNameAlias != o.RootNameAlias || m.RootServiceAlias != o.RootServiceAlias ||
 		m.SelAlias != o.SelAlias || m.AttrAlias != o.AttrAlias ||

--- a/test/regression/release_gate_test.go
+++ b/test/regression/release_gate_test.go
@@ -488,3 +488,50 @@ func TestReleaseGateDriftDetectorRunsLiveAndNotSelfTestOnly(t *testing.T) {
 			"would then be unexercised between weekly runs", driftScript, selfTestFlag)
 	}
 }
+
+// prepare-release.yml stages a release PR from whatever ref it was dispatched
+// on. Cutting a maintenance patch means dispatching it on
+// release/<major>.<minor>.x — the staging branch is then cut from that
+// checkout, so the base the PR is opened against is the only thing keeping the
+// release on its own line. A literal base sends a maintenance line's entire
+// history at the head line instead, and nothing downstream notices: the PR
+// opens, CI runs, and the mistake is visible only to whoever reads the base.
+const (
+	prepareReleaseWorkflowPath = "../../.github/workflows/prepare-release.yml"
+	prepareReleaseJob          = "prepare"
+
+	// The env var carrying github.ref_name into the step's shell, and the
+	// expression that must feed it.
+	prepareReleaseBaseEnv  = "BASE"
+	prepareReleaseBaseExpr = "${{ github.ref_name }}"
+)
+
+func TestPrepareReleaseOpensThePRAgainstTheDispatchedLine(t *testing.T) {
+	t.Parallel()
+
+	workflow := readFileString(t, prepareReleaseWorkflowPath)
+	job := workflowJobBody(t, workflow, prepareReleaseJob)
+
+	if !strings.Contains(job, prepareReleaseBaseEnv+": "+prepareReleaseBaseExpr) {
+		t.Fatalf("%s job %q does not bind %s to %s. Without it the base is whatever the run: block "+
+			"hardcodes, and a maintenance release staged on release/<line>.x opens against the head "+
+			"line. Body:\n%s",
+			prepareReleaseWorkflowPath, prepareReleaseJob, prepareReleaseBaseEnv, prepareReleaseBaseExpr, job)
+	}
+
+	var create string
+	for _, line := range strings.Split(job, "\n") {
+		if strings.Contains(line, "gh pr create") {
+			create = strings.TrimSpace(line)
+		}
+	}
+	if create == "" {
+		t.Fatalf("%s job %q no longer opens the release PR with `gh pr create`; this pin cannot see "+
+			"which base it targets. Body:\n%s", prepareReleaseWorkflowPath, prepareReleaseJob, job)
+	}
+	if !strings.Contains(create, `--base "$`+prepareReleaseBaseEnv+`"`) {
+		t.Fatalf("%s job %q opens the release PR as %q — the base must be $%s, the dispatched ref, "+
+			"not a fixed branch name",
+			prepareReleaseWorkflowPath, prepareReleaseJob, create, prepareReleaseBaseEnv)
+	}
+}


### PR DESCRIPTION
Backports the delta since #1367 onto `release/1.12.x`, so v1.12.3 ships it. All three cherry-picked clean.

- `bfbef969` — #1374 `fix(tempo): stop zero-fill buckets turning quantiles into NaN`. The emitter's synthetic `(bucket 0, count 0)` zero-fill row was read as a real histogram boundary; it sorts first, becomes the interpolation predecessor, and `math.Log2(0) = -Inf` turns every interpolating phi into NaN. Also fixes the class at the shared chokepoint: `httperr.WriteJSON` committed the status before discovering the encode failure, so an unmarshalable body in any of the three heads became a 200 with an empty body.
- `668ce8b4` — #1373 `test(chplan): discriminate every Equal field, fixing MetricsCompare`. A reflect-driven per-field discrimination contract over the existing node registry, which surfaced a real bug: `MetricsCompare.Equal` never compared `InnerRootScoped`, so two plans emitting different SQL compared equal.
- `bdb88205` — #1372 `ci(release): open the release PR against the dispatched line`. Without it, `prepare-release` dispatched on this branch opens its PR against `main`, so a maintenance release cannot be staged from the line it belongs to.

Together these are what unblocks `gremlins phase1 (./internal/chplan @ 95%)` / `mutation` on the v1.12.3 release PR.

**Merge with a merge commit, not a squash** — same as #1367. The per-commit conventional subjects are what `prepare-release` turns into the v1.12.3 CHANGELOG entries; squashing would collapse all three into one opaque line.