### PR TITLE
chore(release): cerberus v1.13.2 / chart 0.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,46 @@ All notable changes to cerberus will be documented in this file. The format roug
 
 ## [Unreleased]
 
+## [v1.13.2] — 2026-07-29
+
+### Fixed
+
+- **tempo:** stop zero-fill buckets turning quantiles into NaN (#1374)
+- **ci:** analyse cold in the lint lane so a cache cannot decide the gate (#1363)
+- **ci:** publish compat-scores from a scratch worktree, not the checkout (#1361)
+- **chsql:** name the canonical key-order function once, not twice (#1365)
+- **chsql:** canonicalise raw attribute-Map series keys at the emit chokepoint (#1362)
+- **ci:** run the Tier-0 explain goldens on pull requests (#1364)
+- **loki:** canonicalise Map key order on metadata series-identity keys (#1360)
+- **logql:** canonicalise Map key order on stream-identity keys (#1358)
+- **chsql:** dedupe TraceQL structural unions on span identity (#1357)
+- **promql:** canonicalise Map key order on the non-join and histogram paths (#1356)
+- **audit:** unwedge the routed fan-out, harden the enum guard and shutdown ordering (#1353)
+- **release:** smoke the documented brew command on Linux too (#1352)
+- **config:** one duration grammar for every CERBERUS_* knob (#1348)
+- **chsql:** canonicalise Map-valued vector-match keys with mapSort (#1346)
+- **chclient:** release pooled ClickHouse connections on cursor teardown (#1347)
+- **ci:** retry the buildkit bootstrap pull behind one buildx setup action (#1345)
+- **chsql:** bind a set-op arm's timestamp to the arm's own outer scope (#1344)
+- **optcorpus:** ingest query_log exception exits and reconcile the exit_status enum (#1341)
+- **cli:** lead the root help with an ASCII banner and a plain-English blurb (#1343)
+- **promql:** evaluate vector set operators per evaluation timestamp (#1340)
+- **release:** only the newest line takes Homebrew and the Latest pointer (#1335)
+
+### CI
+
+- **release:** open the release PR against the dispatched line (#1372)
+- **compat:** gate the parity ratchet on per-case identity, not a count (#1350)
+- **compat:** extract the compat-scores badge publisher to a module (#1342)
+- detect release-gate rot before it breaks a publish (#1334)
+
+### Documentation
+
+- **config:** say what `0` does on every duration knob that accepts it (#1355)
+- **operations:** audit the delta before the backport, not after (#1354)
+- **operations:** document the canonical ordered release ritual (#1349)
+- **migration:** replace the configuration dump with a step 0 (#1339)
+
 ## [v1.13.1] — 2026-07-28
 
 ### Changed

--- a/deploy/helm/cerberus/Chart.yaml
+++ b/deploy/helm/cerberus/Chart.yaml
@@ -8,11 +8,11 @@ type: application
 # upgrade?" and is the publish trigger: a chart-only fix bumps this without an
 # app re-tag; an app-only release bumps appVersion + a PATCH here for the new
 # default image. Starts 0.x because the values contract is not yet frozen.
-version: 0.13.1
+version: 0.13.2
 
 # appVersion tracks the GA cerberus binary. Quoted so SemVer-shaped values
 # aren't coerced to floats. image.tag defaults from this when left empty.
-appVersion: "1.13.1"
+appVersion: "1.13.2"
 
 # autoscaling/v2 + policy/v1 (PDB) + networking/v1 (Ingress) are all GA from
 # 1.21+; 1.23 is the conservative floor matching the manifests this chart
@@ -45,29 +45,27 @@ annotations:
       url: https://github.com/tsouza/cerberus/blob/main/docs/operations.md
   artifacthub.io/images: |
     - name: cerberus
-      image: ghcr.io/tsouza/cerberus:v1.13.1
+      image: ghcr.io/tsouza/cerberus:v1.13.2
   # Bump the `1.0.0` floor here when the chart raises its minimum supported
   # cerberus release; informational for Artifact Hub's compatibility hints.
   artifacthub.io/changes: |
     - kind: fixed
-      description: "promql: keep the `@` pin in range mode on every range-vector lowering (#1325)"
+      description: "tempo: stop zero-fill buckets turning quantiles into NaN (#1374)"
     - kind: fixed
-      description: "prom: bound windowless metadata discovery by real retention (#1327)"
+      description: "ci: analyse cold in the lint lane so a cache cannot decide the gate (#1363)"
     - kind: fixed
-      description: "ci: make the release gate, image probe and doc claims hold under audit (#1329)"
+      description: "ci: publish compat-scores from a scratch worktree, not the checkout (#1361)"
     - kind: fixed
-      description: "migration: forward the story dispatch input to the tier-2 run (#1328)"
+      description: "chsql: name the canonical key-order function once, not twice (#1365)"
     - kind: fixed
-      description: "optimizer: keep AggFunc.Params through a constant fold (#1326)"
+      description: "chsql: canonicalise raw attribute-Map series keys at the emit chokepoint (#1362)"
     - kind: fixed
-      description: "release: close the three gaps that let a release ship unverified (#1322)"
+      description: "ci: run the Tier-0 explain goldens on pull requests (#1364)"
     - kind: fixed
-      description: "ci: skip buildable images in the compose pre-pull (#1321)"
+      description: "loki: canonicalise Map key order on metadata series-identity keys (#1360)"
     - kind: fixed
-      description: "ci: retry every image pull instead of failing the lane (#1319)"
+      description: "logql: canonicalise Map key order on stream-identity keys (#1358)"
     - kind: fixed
-      description: "release: name the workflow a preflight wait is blocked on (#1318)"
-    - kind: changed
-      description: "chsql: skip the spans-scan emit guard when the SQL never names the spans table (#1330)"
-    - kind: changed
-      description: "release: container images publish as a single multi-arch index; the per-arch -amd64/-arm64 tags are gone (#1320)"
+      description: "chsql: dedupe TraceQL structural unions on span identity (#1357)"
+    - kind: fixed
+      description: "promql: canonicalise Map key order on the non-join and histogram paths (#1356)"

--- a/deploy/helm/cerberus/README.md
+++ b/deploy/helm/cerberus/README.md
@@ -5,7 +5,7 @@
      pipe-aligned, and the version footer adds a trailing blank — both are
      owned by helm-docs; realigning would fight the chart-ci drift check. -->
 
-![Version: 0.13.1](https://img.shields.io/badge/Version-0.13.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.13.1](https://img.shields.io/badge/AppVersion-1.13.1-informational?style=flat-square)
+![Version: 0.13.2](https://img.shields.io/badge/Version-0.13.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.13.2](https://img.shields.io/badge/AppVersion-1.13.2-informational?style=flat-square)
 
 Drop-in Prometheus / Loki / Tempo HTTP gateway for ClickHouse — a single stateless gateway that speaks three upstream query wire formats and lowers each to parameterised ClickHouse SQL.
 


### PR DESCRIPTION
Release-prep for **v1.13.2** (chart **0.13.2**), generated by `prepare-release.yml`.

- appVersion 1.13.1 -> 1.13.2, chart 0.13.1 -> 0.13.2

### Changes

### Fixed

- **tempo:** stop zero-fill buckets turning quantiles into NaN (#1374)
- **ci:** analyse cold in the lint lane so a cache cannot decide the gate (#1363)
- **ci:** publish compat-scores from a scratch worktree, not the checkout (#1361)
- **chsql:** name the canonical key-order function once, not twice (#1365)
- **chsql:** canonicalise raw attribute-Map series keys at the emit chokepoint (#1362)
- **ci:** run the Tier-0 explain goldens on pull requests (#1364)
- **loki:** canonicalise Map key order on metadata series-identity keys (#1360)
- **logql:** canonicalise Map key order on stream-identity keys (#1358)
- **chsql:** dedupe TraceQL structural unions on span identity (#1357)
- **promql:** canonicalise Map key order on the non-join and histogram paths (#1356)
- **audit:** unwedge the routed fan-out, harden the enum guard and shutdown ordering (#1353)
- **release:** smoke the documented brew command on Linux too (#1352)
- **config:** one duration grammar for every CERBERUS_* knob (#1348)
- **chsql:** canonicalise Map-valued vector-match keys with mapSort (#1346)
- **chclient:** release pooled ClickHouse connections on cursor teardown (#1347)
- **ci:** retry the buildkit bootstrap pull behind one buildx setup action (#1345)
- **chsql:** bind a set-op arm's timestamp to the arm's own outer scope (#1344)
- **optcorpus:** ingest query_log exception exits and reconcile the exit_status enum (#1341)
- **cli:** lead the root help with an ASCII banner and a plain-English blurb (#1343)
- **promql:** evaluate vector set operators per evaluation timestamp (#1340)
- **release:** only the newest line takes Homebrew and the Latest pointer (#1335)

### CI

- **release:** open the release PR against the dispatched line (#1372)
- **compat:** gate the parity ratchet on per-case identity, not a count (#1350)
- **compat:** extract the compat-scores badge publisher to a module (#1342)
- detect release-gate rot before it breaks a publish (#1334)

### Documentation

- **config:** say what `0` does on every duration knob that accepts it (#1355)
- **operations:** audit the delta before the backport, not after (#1354)
- **operations:** document the canonical ordered release ritual (#1349)
- **migration:** replace the configuration dump with a step 0 (#1339)

Generated from the conventional commits since the last tag. Review and edit before merging; the tag is cut once this lands.
