### PR TITLE
fix(brew): migrate existing formula installs to the cask

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -424,7 +424,13 @@ One implementation means a new rule guards BOTH lanes at once.
   every root Homebrew loads formulae from, so a sharded or relocated formula
   cannot slip past — `installedArtifactProblems(caskList, formulaList)` — which
   of the two the bare install actually resolved to, read off
-  `brew list --{cask,formula} --versions` —
+  `brew list --{cask,formula} --versions`, via the shared
+  `brewListNames(out)` — `tapMigrationProblems(source)` — the tap's
+  `tap_migrations.json` must map `cerberus` to the bare tap name `tsouza/tap`,
+  which is what tells Homebrew the formula BECAME the cask; a missing map is
+  invisible to every fresh install and strands every existing formula install on
+  its old binary with no error printed, so the file is asserted on every release
+  rather than once at migration time —
   `compareVersions(a, b)` and `verdict({version, caskSource, isLatest})`,
   covered by `brew-smoke.test.mjs` on the required `lint` lane and as the job's
   own first step.
@@ -442,6 +448,37 @@ One implementation means a new rule guards BOTH lanes at once.
     tap cask that a backport overwrote, a missing or unrecognised
     `RELEASE_IS_LATEST`, a failed install, a version mismatch, or a failing
     payload verb.
+- **`brew-upgrade-path.mjs`** — `brew-verify.yml`, the `brew-migration` job
+  (`macos-latest` + `ubuntu-latest`, weekly + on demand). Proves an EXISTING
+  formula install is carried across to the cask. Every other install path CI
+  performs starts from an empty runner, and a machine with no cerberus on it
+  cannot observe the upgrade at all — which is how the formula → cask move
+  shipped with no `tap_migrations.json`: fresh installs were correct throughout
+  while every machine that already had the formula silently kept its old binary
+  (`brew upgrade` files a deleted formula under *Deleted Installed Formulae* and
+  moves on; installing the cask afterwards will not link over the formula's keg;
+  nothing in that sequence prints an error). The harness reconstructs a real
+  pre-migration machine: it rewinds the tap clone to the parent of the commit
+  that deleted the formula — derived from history, since a pinned SHA would drift
+  out of the tap and leave the job installing the CASK in step one and then
+  asserting vacuously that a cask is installed — installs the formula from it via
+  the bare ref, and lets `brew update` catch the clone up. That is the real
+  trigger: Homebrew drives the migration off the update's report of what was
+  DELETED, so it fires only for a clone that observes the deletion. It then
+  asserts three independent things, because they fail for different reasons: the
+  migration was announced, the cask ended up installed (Homebrew rescues a failed
+  migration install by design, so the announcement alone proves nothing), and the
+  binary on PATH reports the cask's version (the symptom the user sees, and the
+  one that fails on its own when the cask installed but could not link). Pure
+  export `upgradeOutcomeProblems({updateOutput, caskList, reportedVersion,
+  expectedVersion})`, covered by `brew-upgrade-path.test.mjs` on the required
+  `check` lane and as the job's own first step.
+  - Env: `TAP_MIGRATION_LEGACY_REV` (optional; overrides the derived rewind
+    point, for reproducing a specific report).
+  - Exit: `0` when the migration carried the machine across; `1` on a silent
+    update, a cask that never installed, a version that never moved, or a tap
+    whose history holds no formula to rewind to. There is no "could not tell"
+    exit.
 - **`goreleaser-deprecations.mjs`** — `ci.yml`, the `lint` job. Fails the build
   when `.goreleaser.yml` uses any goreleaser feature upstream has deprecated.
   `goreleaser check` prints a deprecation as an advisory line and still exits

--- a/.github/scripts/brew-smoke.mjs
+++ b/.github/scripts/brew-smoke.mjs
@@ -44,6 +44,16 @@
 // leftover formula, so the failure names its cause instead of surfacing as an
 // unexplained version mismatch.
 //
+// THE USERS A FRESH INSTALL CANNOT SEE: deleting the formula fixes the install
+// this job performs, and nothing else. A machine that already had the formula is
+// not upgraded by it — `brew upgrade` files a deleted formula under "Deleted
+// Installed Formulae" and moves on, and installing the cask afterwards declines
+// to link over the formula's binary. The user is left on the old version with no
+// error printed anywhere, and the earliest adopters are hit hardest. Homebrew's
+// mechanism for this is the tap's `tap_migrations.json`, which is a blob in a
+// repository this one cannot write, so it is ASSERTED here on every release the
+// same way the cask is.
+//
 // CROSS-PLATFORM: cerberus is a Linux-first server binary, so "the cask
 // installs" has to mean it installs on LINUX, not merely on whichever runner
 // happens to execute this. That is covered from two directions. This script is
@@ -94,6 +104,41 @@ import { spawnSync } from 'node:child_process';
 const TAP_REPO = 'tsouza/homebrew-tap';
 const TAP_CASK_PATH = 'Casks/cerberus.rb';
 
+// The tap's formula -> cask migration map, and the name it must carry.
+//
+// Deleting Formula/cerberus.rb makes the cask win a FRESH install, which is all
+// the shadow assertion below can see. It does nothing for a machine that
+// already has the formula: `brew upgrade` lists the package under "Deleted
+// Installed Formulae" and skips it (a deleted formula has no newer version to
+// move to), and installing the cask afterwards refuses to link because the
+// formula's keg still owns `<prefix>/bin/cerberus` — "It seems there is already
+// a Binary at … from formula cerberus; skipping link". The machine ends up with
+// the new cask in the Caskroom, the old binary on PATH, and no error anywhere.
+//
+// Homebrew's answer is this file. `Reporter#migrate_tap_migration` looks up
+// every package the update deleted in `tap.tap_migrations`, and when the target
+// resolves to a cask in the same tap it unlinks the formula and installs the
+// cask for the user. The lookup returns nil when the file is absent, which is
+// silently indistinguishable from "no migration needed".
+//
+// It is asserted here rather than written here for the same reason as the
+// shadow check: the tap is a different repository and goreleaser only writes
+// the one file it owns.
+export const TAP_MIGRATIONS_PATH = 'tap_migrations.json';
+export const TAP_MIGRATION_NAME = 'cerberus';
+
+// What the entry must point at: the tap's Homebrew name, unqualified —
+// `tsouza/homebrew-tap` on GitHub, `tsouza/tap` to brew. This is the shape
+// homebrew/core uses for its own formula -> cask migrations, and the only one
+// whose handling is unambiguous. Homebrew splits the target on `/`: a two-part
+// value has no name component, so it is read as "same package, that tap" and
+// installed as the fully-qualified `<tap>/cerberus`. A THREE-part value takes a
+// different branch that keeps only the trailing name and installs the BARE token
+// `cerberus`, leaving the resolution to whichever tap answers first. That is not
+// a spelling variant of the same instruction, so it is not accepted as one.
+export const TAP_BREW_NAME = `${TAP_REPO.split('/')[0]}/tap`;
+const TAP_MIGRATION_TARGET = TAP_BREW_NAME;
+
 // Every tap path from which Homebrew would load a FORMULA named `cerberus`,
 // shadowing the cask of the same name. The tap served `Formula/cerberus.rb`
 // before .goreleaser.yml moved from `brews:` to `homebrew_casks:`; goreleaser
@@ -119,10 +164,10 @@ const TAP_FORMULA_SHADOW_RE = /^(?:(?:Formula|HomebrewFormula)\/(?:.+\/)?cerberu
 // The path the tap actually holds today, named in the repair instructions so
 // the failure tells an operator which file to delete rather than describing a
 // pattern.
-const TAP_FORMULA_PATH = 'Formula/cerberus.rb';
+export const TAP_FORMULA_PATH = 'Formula/cerberus.rb';
 
 // How an operator names the cask: `brew install tsouza/tap/cerberus`.
-const CASK_REF = 'tsouza/tap/cerberus';
+export const CASK_REF = 'tsouza/tap/cerberus';
 
 // A STABLE release is exactly `<major>.<minor>.<patch>`. Anything with a
 // prerelease suffix (`-rc.1`, `-RC1`) is a prerelease, which `skip_upload: auto`
@@ -314,10 +359,92 @@ export function formulaShadowProblems(shadowPaths) {
     `${TAP_REPO} still serves ${found.join(', ')} alongside ${TAP_CASK_PATH}. Homebrew resolves the ` +
       `bare \`brew install ${CASK_REF}\` — the command README.md and docs/operations.md give operators — ` +
       `to the FORMULA when a tap holds both, so every install would get the formula's version and ignore ` +
-      `the cask this release just pushed. Delete ${TAP_FORMULA_PATH} from ${TAP_REPO} and add a ` +
-      `tap_migrations.json mapping {"cerberus": "${TAP_REPO.split('/')[0]}/tap"} so existing formula ` +
-      `installs are told how to move across.`,
+      `the cask this release just pushed. Delete ${TAP_FORMULA_PATH} from ${TAP_REPO}. (Existing formula ` +
+      `installs are moved across by ${TAP_MIGRATIONS_PATH}, asserted separately.)`,
   ];
+}
+
+// tapMigrationProblems — the tap must tell Homebrew that the formula BECAME the
+// cask, not merely that the formula is gone.
+//
+// This is the half of the formula -> cask move that no fresh install can
+// observe, which is why it shipped broken: every install path CI exercises
+// starts from a clean runner, where a missing migration map is invisible. The
+// machines it strands are the ones that had the formula first — the users who
+// adopted cerberus EARLIEST — and they get no error, just an old binary on PATH
+// under a `--version` that disagrees with the release notes.
+//
+// Absence is the failure this exists to catch, so an unreadable or malformed
+// file is treated as absent rather than shrugged off: `tapFile` already turns a
+// non-404 error into a hard failure, so `null` here means the file genuinely is
+// not there.
+export function tapMigrationProblems(source) {
+  const repair =
+    `Add ${TAP_MIGRATIONS_PATH} to ${TAP_REPO} containing ` +
+    `{"${TAP_MIGRATION_NAME}": "${TAP_BREW_NAME}"}.`;
+
+  if (source === null || source === undefined) {
+    return [
+      `${TAP_REPO} has no ${TAP_MIGRATIONS_PATH}. Homebrew looks a deleted package up in ` +
+        `\`tap.tap_migrations\` to decide whether it MOVED, so without that file every machine that ` +
+        `installed cerberus as a formula is stranded: \`brew upgrade\` skips it as a deleted formula, ` +
+        `and the cask cannot link over the formula's binary. Those users keep running the old version ` +
+        `with no error. ${repair}`,
+    ];
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(source);
+  } catch (e) {
+    return [
+      `${TAP_REPO}'s ${TAP_MIGRATIONS_PATH} is not valid JSON (${e.message}). Homebrew cannot read it, ` +
+        `so it migrates nobody — the same outcome as the file being absent, minus the clue. ${repair}`,
+    ];
+  }
+
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return [
+      `${TAP_REPO}'s ${TAP_MIGRATIONS_PATH} is not a JSON object (got ${Array.isArray(parsed) ? 'an array' : typeof parsed}). ` +
+        `Homebrew reads it as a name -> destination map. ${repair}`,
+    ];
+  }
+
+  const target = parsed[TAP_MIGRATION_NAME];
+  if (target === undefined) {
+    return [
+      `${TAP_REPO}'s ${TAP_MIGRATIONS_PATH} has no "${TAP_MIGRATION_NAME}" entry ` +
+        `(it maps ${Object.keys(parsed).length > 0 ? Object.keys(parsed).join(', ') : 'nothing'}). ` +
+        `The lookup is by package name, so an entry under any other name migrates nobody. ${repair}`,
+    ];
+  }
+
+  if (target !== TAP_MIGRATION_TARGET) {
+    return [
+      `${TAP_REPO}'s ${TAP_MIGRATIONS_PATH} points "${TAP_MIGRATION_NAME}" at "${target}" rather than ` +
+        `"${TAP_MIGRATION_TARGET}". Homebrew reads the target as the tap to move the package to, so ` +
+        `anything else either sends users to a tap that does not publish cerberus or drops them onto a ` +
+        `bare, tap-ambiguous token. ${repair}`,
+    ];
+  }
+
+  return [];
+}
+
+// brewListNames — the package names in `brew list --cask|--formula --versions`
+// output.
+//
+// Each line is `<name> <version…>`, so the leading token is the name. Matching
+// the leading token rather than searching the text is what stops a package
+// merely NAMED after cerberus, or a version string that happens to contain it,
+// from answering an is-it-installed question.
+export function brewListNames(out) {
+  return new Set(
+    String(out ?? '')
+      .split('\n')
+      .map((line) => line.trim().split(/\s+/)[0])
+      .filter(Boolean),
+  );
 }
 
 // installedArtifactProblems — after the bare `brew install`, WHICH of the two
@@ -338,13 +465,7 @@ export function formulaShadowProblems(shadowPaths) {
 // name. Those commands list what IS installed and exit 0 either way, so the
 // assertion never rests on an error code meaning what we hope it means.
 export function installedArtifactProblems(caskList, formulaList) {
-  const names = (out) =>
-    new Set(
-      String(out ?? '')
-        .split('\n')
-        .map((line) => line.trim().split(/\s+/)[0])
-        .filter(Boolean),
-    );
+  const names = brewListNames;
 
   const problems = [];
   if (!names(caskList).has('cerberus')) {
@@ -565,6 +686,15 @@ async function main() {
   // one of them describe a file no operator ever receives.
   const shadow = formulaShadowProblems(await tapPaths());
 
+  // The other half of the same move: the formula being gone is what makes the
+  // cask win a FRESH install, and this is what makes an EXISTING formula install
+  // follow it across. Checked on every release rather than once at migration
+  // time, because the file is a plain blob in another repository — nothing but
+  // this assertion would notice it being reverted, renamed or hand-edited, and
+  // the damage is invisible until an early adopter's `brew upgrade` quietly
+  // leaves them on an old binary.
+  const migration = tapMigrationProblems(await tapFile(TAP_MIGRATIONS_PATH));
+
   let decision;
   try {
     decision = verdict({ version, caskSource, isLatest: isLatestRaw });
@@ -572,7 +702,7 @@ async function main() {
     fail(e.message);
   }
 
-  const problems = [...shadow, ...decision.problems];
+  const problems = [...shadow, ...migration, ...decision.problems];
   for (const p of problems) ghError(`brew-smoke: ${p}`);
   if (problems.length > 0) process.exit(1);
 

--- a/.github/scripts/brew-smoke.test.mjs
+++ b/.github/scripts/brew-smoke.test.mjs
@@ -4,7 +4,7 @@
 //
 // release.yml has no `pull_request:` trigger, so without this suite every edit
 // to the smoke would be unverified until a release is cut. The cases below pin
-// the four ways the smoke could go hollow:
+// the ways the smoke could go hollow:
 //
 //   1. a stale/never-pushed cask reported as fine (the goreleaser
 //      `homebrew_casks:` regression the whole job exists to catch);
@@ -12,7 +12,9 @@
 //      workflow clothing, which would wave through a `skip_upload` regression;
 //   3. an unparseable cask degrading into "couldn't tell, so pass";
 //   4. a maintenance backport silently overwriting the newest line's cask,
-//      which is what v1.12.1 did to v1.13.0's.
+//      which is what v1.12.1 did to v1.13.0's;
+//   5. a missing formula -> cask migration map read as "nothing to migrate",
+//      which is what stranded every existing formula install on 1.13.1.
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
@@ -24,6 +26,7 @@ import {
   compareVersions,
   caskPortabilityProblems,
   formulaShadowProblems,
+  tapMigrationProblems,
   tapShadowingFormulaPaths,
   installedArtifactProblems,
   MACOS_ONLY_ARTIFACT_STANZAS,
@@ -251,6 +254,93 @@ test('the shadow scan does not fire on a cask, a doc, or another project', () =>
     ]),
     [],
   );
+});
+
+// --- the formula -> cask migration map --------------------------------------
+// Deleting the formula only decides what a FRESH install gets. These cases pin
+// the half that decides what an EXISTING formula install gets, which every
+// clean-runner install path is structurally blind to.
+
+test('a migration map pointing at this tap is the healthy state', () => {
+  assert.deepEqual(tapMigrationProblems('{"cerberus": "tsouza/tap"}'), []);
+});
+
+test('a fully-qualified migration target is NOT accepted as a spelling variant', () => {
+  // It reads as a different instruction, not a longer one. Homebrew splits the
+  // target on `/`: the two-part form has no name component and installs
+  // `<tap>/cerberus`, while the three-part form keeps only the trailing name and
+  // installs the bare token `cerberus`, resolved against whichever tap answers.
+  // Accepting both would bless a target whose behaviour was never verified.
+  assert.equal(tapMigrationProblems('{"cerberus": "tsouza/tap/cerberus"}').length, 1);
+});
+
+test('unrelated entries alongside the cerberus one are fine', () => {
+  // The map is shared by every project in the tap. Asserting on the whole file
+  // rather than the one key would fail the moment a second project migrates.
+  assert.deepEqual(
+    tapMigrationProblems('{"other-tool": "homebrew/core", "cerberus": "tsouza/tap"}'),
+    [],
+  );
+});
+
+test('an absent migration map is the reported failure, not a pass', () => {
+  // This is the bug as it actually shipped: `tap.tap_migrations[name]` returns
+  // nil for a missing file, which Homebrew reads as "this package did not move".
+  // The only signal is the one asserted here.
+  const problems = tapMigrationProblems(null);
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /tap_migrations\.json/);
+  assert.match(problems[0], /"cerberus": "tsouza\/tap"/, 'the failure must carry the repair');
+});
+
+test('an undefined map is treated as absent, not as an object', () => {
+  // `tapFile` returns null on 404, but a caller reordering or refactoring that
+  // read could hand over undefined. Falling through to the key lookup would
+  // throw, and a throw here fails the job with a stack trace instead of the
+  // repair instruction.
+  assert.equal(tapMigrationProblems(undefined).length, 1);
+});
+
+test('a malformed migration map fails rather than parsing loosely', () => {
+  const problems = tapMigrationProblems('{"cerberus": "tsouza/tap",}');
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /not valid JSON/);
+});
+
+test('a JSON value that is not a name -> target map fails', () => {
+  // Homebrew indexes the parsed value by package name. An array or a scalar
+  // yields undefined for every name, migrating nobody, so the shape is asserted
+  // rather than inferred from the lookup coming back empty.
+  for (const source of ['[]', '"tsouza/tap"', 'null', '3']) {
+    const problems = tapMigrationProblems(source);
+    assert.equal(problems.length, 1, `${source} should be rejected`);
+    assert.match(problems[0], /not a JSON object/);
+  }
+});
+
+test('a map that exists but omits cerberus fails', () => {
+  // The realistic regression once the tap holds several projects: the file is
+  // present and valid, and the one entry that matters was dropped in an edit.
+  const problems = tapMigrationProblems('{"other-tool": "homebrew/core"}');
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /no "cerberus" entry/);
+  assert.match(problems[0], /other-tool/, 'the failure should show what the map DOES carry');
+});
+
+test('a migration pointed at a different tap fails', () => {
+  // Sends users somewhere cerberus is not published. Homebrew would find no
+  // replacement there and the user is stranded exactly as if the entry were
+  // missing — so "an entry exists" is not the assertion.
+  const problems = tapMigrationProblems('{"cerberus": "homebrew/core"}');
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /homebrew\/core/);
+});
+
+test('the migration target is matched exactly, not by substring', () => {
+  // `tsouza/tap-old` contains `tsouza/tap`. A substring check would accept a
+  // typo that points at a tap which does not exist.
+  assert.equal(tapMigrationProblems('{"cerberus": "tsouza/tap-old"}').length, 1);
+  assert.equal(tapMigrationProblems('{"cerberus": "not-tsouza/tap"}').length, 1);
 });
 
 // --- which artifact the bare ref resolved to --------------------------------

--- a/.github/scripts/brew-upgrade-path.mjs
+++ b/.github/scripts/brew-upgrade-path.mjs
@@ -1,0 +1,295 @@
+// brew-upgrade-path.mjs — proves an EXISTING formula install is carried across
+// to the cask, for `brew-verify.yml`'s `brew-migration` job.
+//
+// What it covers that nothing else can
+// ------------------------------------
+// `brew-smoke.mjs` installs from an empty runner, which is the only install
+// shape CI ever performs — and a machine with no cerberus on it cannot observe
+// the upgrade path at all. That blindness is not theoretical: cerberus was
+// served as a formula through 1.13.1 and as a cask from 1.13.2, and the move
+// shipped with no `tap_migrations.json`. Every fresh install was correct
+// throughout. Every machine that already had the formula was left running the
+// old binary, because:
+//
+//   - `brew upgrade` files a deleted formula under "Deleted Installed Formulae"
+//     and moves on — a formula that no longer exists has no newer version to
+//     move to;
+//   - `brew install --cask …` afterwards puts the new cask in the Caskroom but
+//     declines to link it, since the formula's keg still owns
+//     `<prefix>/bin/cerberus`;
+//   - so `cerberus --version` keeps reporting the OLD version, and no step in
+//     that sequence prints an error.
+//
+// `brew-smoke.mjs` now asserts the tap carries the migration map, which catches
+// the file being absent. This job asserts what that file is FOR: it reconstructs
+// a real pre-migration machine and runs the upgrade a user would run. A map that
+// exists but does not fire — wrong target shape, a Homebrew behaviour change, a
+// cask that cannot link over the keg — is green under a static check and red
+// here.
+//
+// How the pre-migration machine is reconstructed
+// ----------------------------------------------
+// The tap clone is rewound to the commit BEFORE the formula was deleted, the
+// formula is installed from it exactly as an operator would have, and the clone
+// is then allowed to catch up via `brew update`. That is the real trigger:
+// Homebrew's migration runs out of `brew update`'s report of what the update
+// DELETED, so it fires only for a clone that observes the deletion. Rewinding is
+// what puts this runner in that position; a runner that taps at HEAD is already
+// past it and can never see the migration, which is precisely why the bug
+// reached users.
+//
+// The rewind point is derived, not pinned: the newest commit touching the
+// formula path is the one that deleted it, so its parent is the last revision
+// that still served it. A pinned SHA would drift out of the tap's history
+// unnoticed and leave this job rewinding to something that never had a formula —
+// which would install the CASK in step one and then assert, vacuously, that a
+// cask is installed.
+//
+// Env contract:
+//   TAP_MIGRATION_LEGACY_REV  optional; overrides the derived rewind point. For
+//                             reproducing a specific report, not for routine
+//                             runs.
+//
+// Exit: 0 when the migration carried the machine across, 1 otherwise. There is
+// no "could not tell" exit — every branch below either asserts or fails.
+//
+// node: builtins only.
+
+import { existsSync, mkdirSync } from 'node:fs';
+
+import { capture, error as ghError, git, log, notice } from './lib/gh.mjs';
+import {
+  CASK_REF,
+  TAP_BREW_NAME,
+  TAP_FORMULA_PATH,
+  TAP_MIGRATION_NAME,
+  brewListNames,
+  caskVersion,
+} from './brew-smoke.mjs';
+
+// What Homebrew prints when it migrates a formula to a cask within the same
+// tap (`Reporter#migrate_tap_migration`). Asserting on the announcement rather
+// than only on the end state is what distinguishes "the migration ran" from "the
+// runner happened to end up with a cask installed for some other reason".
+const MIGRATION_ANNOUNCEMENT = 'has been migrated from a formula to a cask';
+
+// `brew install` of a real release tarball, plus a full `brew update`. Generous,
+// because the failure this bounds is a hang, not slowness.
+const BREW_TIMEOUT_MS = 20 * 60 * 1000;
+
+// ---------------------------------------------------------------------------
+// pure core
+// ---------------------------------------------------------------------------
+
+// upgradeOutcomeProblems — did the update actually carry this machine across?
+//
+// Three independent things have to hold, and each is stated separately because
+// they fail for different reasons and the repair differs:
+//
+//   1. Homebrew announced the migration. Silence here is the shipped bug — the
+//      map missing, misspelled, or pointing at another tap.
+//   2. The cask ended up installed. The announcement can be printed and the
+//      install still fail (an untrusted tap, a download error); Homebrew
+//      swallows that failure by design so a broken migration cannot abort an
+//      update.
+//   3. The binary on PATH reports the cask's version. This is the one the user
+//      sees. It fails on its own when the cask installed but could not link over
+//      the formula's keg — the exact shape the bug report carried, where the
+//      Caskroom held 1.13.2 and `cerberus --version` said 1.13.1.
+export function upgradeOutcomeProblems({ updateOutput, caskList, reportedVersion, expectedVersion }) {
+  const problems = [];
+
+  if (!String(updateOutput ?? '').includes(MIGRATION_ANNOUNCEMENT)) {
+    problems.push(
+      `\`brew update\` did not announce the formula -> cask migration ("${MIGRATION_ANNOUNCEMENT}"). ` +
+        `Homebrew only migrates a deleted package it can find in the tap's tap_migrations.json, and a ` +
+        `miss is silent — the update reports success and leaves the old formula linked. Check that ` +
+        `tap_migrations.json maps "${TAP_MIGRATION_NAME}" to "${TAP_BREW_NAME}".`,
+    );
+  }
+
+  if (!brewListNames(caskList).has(TAP_MIGRATION_NAME)) {
+    problems.push(
+      `the ${TAP_MIGRATION_NAME} cask is not installed after \`brew update\` (\`brew list --cask ` +
+        `--versions\` does not list it). Homebrew rescues any exception raised while installing a ` +
+        `migration target so a failed migration cannot abort the update, which means the install can ` +
+        `fail without failing anything visible.`,
+    );
+  }
+
+  if (reportedVersion !== expectedVersion) {
+    problems.push(
+      `the cerberus on PATH reports "${reportedVersion}", but the tap's cask declares ` +
+        `"${expectedVersion}". The migration did not reach the user: this is what a cask that installed ` +
+        `into the Caskroom but could not link over the formula's keg looks like — the new version is on ` +
+        `disk, the old binary is still what runs, and nothing printed an error.`,
+    );
+  }
+
+  return problems;
+}
+
+// ---------------------------------------------------------------------------
+// driver
+// ---------------------------------------------------------------------------
+
+function fail(msg) {
+  ghError(`brew-upgrade-path: ${msg}`);
+  process.exit(1);
+}
+
+function describe(res) {
+  return `exit=${res.status}\n${res.stdout}\n${res.stderr}`.trim();
+}
+
+// brew — run a brew subcommand, returning the capture. HOMEBREW_NO_AUTO_UPDATE
+// keeps an incidental `brew install` from performing the very update whose
+// output this job needs to read, which would consume the migration before the
+// step that asserts on it ever ran.
+function brew(args, { timeout = BREW_TIMEOUT_MS } = {}) {
+  return capture('brew', args, {
+    timeout,
+    env: { ...process.env, HOMEBREW_NO_AUTO_UPDATE: '1', HOMEBREW_NO_ENV_HINTS: '1' },
+  });
+}
+
+function brewOrFail(args, what, opts) {
+  const res = brew(args, opts);
+  if (res.status !== 0) fail(`${what} failed. ${describe(res)}`);
+  return res;
+}
+
+function tapGit(tapRepo, args, what) {
+  const res = git(['-C', tapRepo, ...args]);
+  if (res.status !== 0) fail(`${what} failed. ${describe(res)}`);
+  return res.stdout.trim();
+}
+
+function main() {
+  if (capture('brew', ['--version']).status !== 0) {
+    fail('Homebrew is not on PATH on this runner.');
+  }
+
+  // --- reconstruct a pre-migration machine ---------------------------------
+  brewOrFail(['tap', TAP_BREW_NAME], `\`brew tap ${TAP_BREW_NAME}\``);
+  const tapRepo = brewOrFail(['--repo', TAP_BREW_NAME], `\`brew --repo ${TAP_BREW_NAME}\``).stdout.trim();
+
+  // A shallow tap clone has no history to rewind INTO, and `git rev-list` on it
+  // answers from the truncated graph rather than erroring — so the depth is
+  // removed before anything is derived from history.
+  if (existsSync(`${tapRepo}/.git/shallow`)) {
+    tapGit(tapRepo, ['fetch', '--unshallow'], 'unshallowing the tap clone');
+  }
+  tapGit(tapRepo, ['fetch', 'origin'], 'fetching the tap');
+
+  const override = process.env.TAP_MIGRATION_LEGACY_REV?.trim();
+  let legacyRev = override;
+  if (!legacyRev) {
+    const deletion = tapGit(
+      tapRepo,
+      ['rev-list', '-1', 'origin/HEAD', '--', TAP_FORMULA_PATH],
+      `finding the commit that deleted ${TAP_FORMULA_PATH}`,
+    );
+    if (!deletion) {
+      fail(
+        `no commit in ${TAP_BREW_NAME} ever touched ${TAP_FORMULA_PATH}, so there is no pre-migration ` +
+          `state to reconstruct. Either the tap's history was rewritten, or the formula lived at another ` +
+          `path — this job cannot assert the upgrade path without one, and must not pass by default.`,
+      );
+    }
+    legacyRev = `${deletion}^`;
+  }
+
+  // The rewind point must actually SERVE a formula. Without this, a history
+  // rewrite or a path change would land the job on a revision that only has the
+  // cask — step one would install the cask, and every assertion below would pass
+  // while testing nothing.
+  const hasFormula = git(['-C', tapRepo, 'cat-file', '-e', `${legacyRev}:${TAP_FORMULA_PATH}`]);
+  if (hasFormula.status !== 0) {
+    fail(
+      `${legacyRev} does not contain ${TAP_FORMULA_PATH}, so rewinding to it would not reconstruct a ` +
+        `formula install. ${describe(hasFormula)}`,
+    );
+  }
+
+  // The version the machine must END on: what the tap's cask declares at HEAD.
+  const caskSource = tapGit(
+    tapRepo,
+    ['show', `origin/HEAD:Casks/${TAP_MIGRATION_NAME}.rb`],
+    'reading the tap cask at HEAD',
+  );
+  const expectedVersion = caskVersion(caskSource);
+  if (!expectedVersion) {
+    fail(`the tap's cask at origin/HEAD declares no version, so there is nothing to assert against.`);
+  }
+
+  log(`rewinding ${TAP_BREW_NAME} to ${legacyRev} (parent of the commit that deleted the formula)`);
+  tapGit(tapRepo, ['reset', '--hard', legacyRev], `rewinding the tap to ${legacyRev}`);
+
+  // The BARE ref, which at this revision resolves to the formula — Homebrew
+  // prefers a formula over a same-named cask, which is how operators ended up
+  // with formula installs in the first place.
+  brewOrFail(['install', CASK_REF], `\`brew install ${CASK_REF}\` at ${legacyRev}`);
+
+  const formulaList = brewOrFail(['list', '--formula', '--versions'], '`brew list --formula --versions`');
+  if (!brewListNames(formulaList.stdout).has(TAP_MIGRATION_NAME)) {
+    fail(
+      `the setup install did not produce a FORMULA install (\`brew list --formula --versions\` does not ` +
+        `list ${TAP_MIGRATION_NAME}). There is no pre-migration state to migrate, so everything below ` +
+        `would assert against a machine that was already on the cask.`,
+    );
+  }
+  // Homebrew performs the migration only when a Caskroom already exists;
+  // otherwise it prints the same announcement followed by the commands to run by
+  // hand. Both are correct behaviour, but only the first has an outcome to
+  // assert, so the fixture is completed here the same way the tap rewind
+  // completes it — this is the state of any machine that has ever installed a
+  // cask, and Homebrew creates the directory on the first one. A runner image
+  // that has never installed a cask would otherwise steer this job onto the
+  // print-only branch and red it for a reason that is not a defect.
+  const caskroom = `${brewOrFail(['--prefix'], '`brew --prefix`').stdout.trim()}/Caskroom`;
+  mkdirSync(caskroom, { recursive: true });
+
+  notice(`brew-upgrade-path: reconstructed a formula install at ${legacyRev}; expecting ${expectedVersion} after update.`);
+
+  // --- run the upgrade an operator would run --------------------------------
+  // `brew update` is the trigger: the migration is driven by the report of what
+  // the update deleted, so it fires only for a clone that observes the deletion.
+  // Its exit status is deliberately not asserted — an unrelated tap failing to
+  // fetch reds it without saying anything about cerberus, and the assertions
+  // below read the outcome directly.
+  const update = capture('brew', ['update'], {
+    timeout: BREW_TIMEOUT_MS,
+    env: { ...process.env, HOMEBREW_NO_ENV_HINTS: '1' },
+  });
+  log(update.stdout);
+  log(update.stderr);
+
+  const caskList = brewOrFail(['list', '--cask', '--versions'], '`brew list --cask --versions`');
+
+  // The migration unlinks the formula and links the cask, so what `cerberus`
+  // resolves to now is the whole question. A failure to resolve is itself an
+  // outcome — an unlinked formula with no linked cask leaves the command gone —
+  // and is reported as an empty version rather than crashing the job.
+  const which = capture('command -v cerberus', [], { shell: true });
+  const resolved = which.status === 0 ? which.stdout.trim() : '';
+  const versionRes = resolved ? capture(resolved, ['--version']) : { status: 1, stdout: '', stderr: '' };
+  const reported = versionRes.status === 0 ? versionRes.stdout.trim() : '<not on PATH>';
+
+  const problems = upgradeOutcomeProblems({
+    updateOutput: `${update.stdout}\n${update.stderr}`,
+    caskList: caskList.stdout,
+    reportedVersion: reported,
+    expectedVersion,
+  });
+  for (const p of problems) ghError(`brew-upgrade-path: ${p}`);
+  if (problems.length > 0) process.exit(1);
+
+  notice(
+    `brew-upgrade-path: a ${legacyRev} formula install was migrated to the cask by \`brew update\`; ` +
+      `${resolved} reports ${reported}.`,
+  );
+}
+
+const invokedDirectly = process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href;
+if (invokedDirectly) main();

--- a/.github/scripts/brew-upgrade-path.test.mjs
+++ b/.github/scripts/brew-upgrade-path.test.mjs
@@ -1,0 +1,110 @@
+// brew-upgrade-path.test.mjs — node:test guard for the formula -> cask upgrade
+// harness's verdict, run on the required `check` lane.
+//
+// The harness itself needs a Homebrew installation and several minutes, so it
+// runs weekly rather than per-PR. Its verdict function does not, and it is the
+// part that decides whether a real migration failure is reported — a verdict
+// that reads a silent no-op as success would leave the weekly lane green while
+// every existing install stayed stranded, which is the same shape as the bug it
+// was written for.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { upgradeOutcomeProblems } from './brew-upgrade-path.mjs';
+import { brewListNames } from './brew-smoke.mjs';
+
+const ANNOUNCED = [
+  '==> tsouza/tap/cerberus has been migrated from a formula to a cask.',
+  '==> brew unlink cerberus',
+  '==> brew install --cask tsouza/tap/cerberus',
+].join('\n');
+
+const CASK_INSTALLED = 'cerberus 1.13.2\n';
+const NEW = '1.13.2';
+const OLD = '1.13.1';
+
+const healthy = {
+  updateOutput: ANNOUNCED,
+  caskList: CASK_INSTALLED,
+  reportedVersion: NEW,
+  expectedVersion: NEW,
+};
+
+test('a migration that ran, installed and linked has no problems', () => {
+  assert.deepEqual(upgradeOutcomeProblems(healthy), []);
+});
+
+test('a silent update is the reported failure', () => {
+  // The bug exactly as it shipped: `brew update` succeeds, says nothing about
+  // cerberus, and leaves the formula linked. Every signal here is an absence,
+  // which is why the assertion is on the announcement rather than on the exit
+  // status of anything.
+  const problems = upgradeOutcomeProblems({
+    ...healthy,
+    updateOutput: '==> Updated Homebrew from abc to def.\nAlready up-to-date.',
+    caskList: '',
+    reportedVersion: OLD,
+  });
+  assert.equal(problems.length, 3, 'all three symptoms should be named, not just the first');
+  assert.match(problems[0], /did not announce/);
+  assert.match(problems[0], /tap_migrations\.json/, 'the failure must point at the cause');
+});
+
+test('an announced migration whose install failed is caught', () => {
+  // Homebrew rescues any exception raised while installing a migration target,
+  // so a failed install leaves the announcement in the log and nothing else. If
+  // the announcement were the only assertion, this would pass.
+  const problems = upgradeOutcomeProblems({ ...healthy, caskList: '', reportedVersion: OLD });
+  assert.equal(problems.length, 2);
+  assert.match(problems[0], /cask is not installed/);
+  assert.match(problems[1], /reports "1\.13\.1"/);
+});
+
+test('a cask that installed but could not link is caught', () => {
+  // The state the bug report carried: the Caskroom holds the new version, the
+  // formula's keg still owns the binary, and `--version` disagrees with the
+  // release. Asserting only that the cask is installed would call this healthy.
+  const problems = upgradeOutcomeProblems({ ...healthy, reportedVersion: OLD });
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /could not link over the formula's keg/);
+});
+
+test('a cerberus that vanished from PATH is a failure, not a pass', () => {
+  // `brew unlink` runs before the cask install, so a migration that unlinks and
+  // then fails to install removes the command entirely. The harness reports that
+  // as a sentinel version rather than crashing, and it must not compare equal to
+  // anything.
+  const problems = upgradeOutcomeProblems({ ...healthy, reportedVersion: '<not on PATH>' });
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /<not on PATH>/);
+});
+
+test('an absent update output is treated as no announcement, not as a crash', () => {
+  // A `brew update` that died before writing anything yields undefined here.
+  // Reading that as "nothing to migrate" would be the same silent pass the
+  // harness exists to prevent.
+  const problems = upgradeOutcomeProblems({ ...healthy, updateOutput: undefined });
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /did not announce/);
+});
+
+test('the version comparison is exact, not a prefix or substring', () => {
+  // `1.13.20` contains `1.13.2`. A substring comparison would report a two-minor
+  // drift as a match, and the whole point of this lane is the version the user
+  // ends up on.
+  assert.equal(upgradeOutcomeProblems({ ...healthy, reportedVersion: '1.13.20' }).length, 1);
+  assert.equal(upgradeOutcomeProblems({ ...healthy, reportedVersion: 'v1.13.2' }).length, 1);
+});
+
+test('brewListNames reads the leading token, so a version cannot fake a name', () => {
+  // Shared with brew-smoke's installed-artifact assertion. `brew list --versions`
+  // prints `<name> <version…>`, and a search of the whole line would let a
+  // package whose VERSION contains cerberus answer an is-cerberus-installed
+  // question.
+  assert.deepEqual([...brewListNames('cerberus 1.13.2\njq 1.7\n')].sort(), ['cerberus', 'jq']);
+  assert.equal(brewListNames('cerberus-exporter 1.0\n').has('cerberus'), false);
+  assert.equal(brewListNames('other 1.0-cerberus\n').has('cerberus'), false);
+  assert.equal(brewListNames('').size, 0);
+  assert.equal(brewListNames(null).size, 0);
+});

--- a/.github/workflows/brew-verify.yml
+++ b/.github/workflows/brew-verify.yml
@@ -18,6 +18,15 @@ name: brew-verify
 # It reuses `brew-smoke.mjs` unchanged, so there is one implementation of what
 # "the published cask is healthy" means; this lane only differs in when it
 # runs and which version it targets.
+#
+# The second job, `brew-migration`, covers a different question: not whether a
+# fresh install works, but whether an EXISTING formula install is carried across
+# to the cask. Every install path CI performs starts from an empty runner and is
+# therefore blind to it, which is how cerberus shipped the formula -> cask move
+# with no tap_migrations.json and left early adopters running the old binary with
+# no error printed anywhere. It lives here rather than in release.yml because it
+# takes minutes and re-verifies a property of the TAP, which changes on its own
+# schedule.
 on:
   workflow_dispatch:
     inputs:
@@ -113,3 +122,41 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO_ROOT: ${{ github.workspace }}
         run: node .github/scripts/brew-smoke.mjs
+
+  # The upgrade path, which no install-from-empty can see. `brew-verify` above
+  # and `brew-smoke` in release.yml both start from a runner with no cerberus on
+  # it, so both are structurally blind to what happens to a machine that already
+  # had the FORMULA — the shape cerberus shipped through 1.13.1. That gap is how
+  # the missing tap_migrations.json reached users: every fresh install was
+  # correct while every existing one silently stayed on the old binary.
+  #
+  # Separate from the job above rather than a step inside it, because it rewinds
+  # the tap clone and installs a superseded release: sharing a runner with the
+  # published-cask assertions would have each job's brew state decide the other's
+  # verdict.
+  brew-migration:
+    name: brew-migration (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v7
+
+      # Same as the job above: the Ubuntu image ships Homebrew under
+      # /home/linuxbrew but leaves it off PATH.
+      - name: put Homebrew on PATH
+        if: runner.os == 'Linux'
+        run: |
+          test -x /home/linuxbrew/.linuxbrew/bin/brew || {
+            echo "::error::brew-migration: the ${{ matrix.os }} image no longer ships Homebrew at /home/linuxbrew/.linuxbrew — the Linux leg needs an install step."
+            exit 1
+          }
+          echo "/home/linuxbrew/.linuxbrew/bin" >> "$GITHUB_PATH"
+
+      - name: brew-upgrade-path self-test
+        run: node --test .github/scripts/brew-upgrade-path.test.mjs
+
+      - name: migrate a formula install to the cask
+        run: node .github/scripts/brew-upgrade-path.mjs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -440,6 +440,14 @@ jobs:
       - name: brew-smoke self-test (cask-freshness guard)
         run: node --test .github/scripts/brew-smoke.test.mjs
 
+      # The upgrade harness itself needs Homebrew and several minutes, so it runs
+      # weekly in brew-verify.yml. Its VERDICT does not, and that is the half
+      # deciding whether a silently-skipped migration is reported — a verdict
+      # that reads Homebrew's silence as success would leave the weekly lane
+      # green while every existing formula install stayed on the old binary.
+      - name: brew-upgrade-path self-test (formula -> cask migration verdict)
+        run: node --test .github/scripts/brew-upgrade-path.test.mjs
+
       # goreleaser deprecation gate. `goreleaser check` reports a deprecated
       # config section as an advisory line and still exits 0, and release.yml is
       # the only other place goreleaser runs — so a deprecation first becomes

--- a/README.md
+++ b/README.md
@@ -167,6 +167,16 @@ brew install tsouza/tap/cerberus
 
 Only stable releases publish a cask, so `brew` never hands you a prerelease.
 
+cerberus was briefly served as a Homebrew _formula_ instead. `brew update` moves
+an existing formula install across on its own, but a machine that had already
+updated past that point keeps running the old binary — `cerberus --version` will
+disagree with the release you expect. To repair it:
+
+```sh
+brew uninstall --formula --force cerberus
+brew reinstall --cask tsouza/tap/cerberus
+```
+
 The surrounding runtime contract (lifecycle, scaling, the solver and
 experimental knobs in context) lives in
 [`docs/operations.md`](docs/operations.md).

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1327,12 +1327,65 @@ nothing, so the tap's whole file listing is additionally scanned for a leftover
 formula — every root Homebrew loads formulae from (`Formula/`,
 `HomebrewFormula/`, the tap root, the first two recursively so a sharded
 `Formula/c/cerberus.rb` counts), not just the historical path — and the smoke
-fails while one is present. The repair (delete it, add a `tap_migrations.json`)
-belongs to the tap repository, which no release run can touch. Because the ref
+fails while one is present. The repair belongs to the tap repository, which no
+release run can touch. Because the ref
 being installed is the ambiguous one, the smoke also states *which* artifact
 Homebrew picked: after the install, `cerberus` must appear in
 `brew list --cask --versions` and must not appear in `brew list --formula
 --versions`. Neither `command -v` nor `--version` can tell those two apart.
+
+Deleting the formula decides what a **new** install receives. What an **existing**
+formula install receives is decided by a second file, `tap_migrations.json` at the
+tap root:
+
+```json
+{
+  "cerberus": "tsouza/tap"
+}
+```
+
+Homebrew looks every package an update *deleted* up in that map. A hit whose
+target resolves to a cask in the same tap makes `brew update` unlink the formula
+and install the cask in its place, printing `cerberus has been migrated from a
+formula to a cask.`. A miss — including the map being absent — is
+indistinguishable from "this package did not move", and that is the whole failure
+mode: `brew upgrade` files the package under *Deleted Installed Formulae* and
+moves on, because a deleted formula has no newer version to move to. Installing
+the cask by hand afterwards does not rescue it either, since the formula's keg
+still owns `<prefix>/bin/cerberus` and the cask declines to link over it
+(`It seems there is already a Binary at … from formula cerberus; skipping link`).
+The machine ends up with the new cask in the Caskroom, the old binary on `PATH`,
+and no error printed anywhere. The users it strands are the ones who installed
+cerberus *earliest*.
+
+The target is written as the bare tap name, which is how homebrew/core spells its
+own formula-to-cask migrations. Homebrew splits it on `/`: a two-part value has no
+name component and is read as "same package, that tap", installing the
+fully-qualified `tsouza/tap/cerberus`. A three-part `tsouza/tap/cerberus` takes a
+different branch that keeps only the trailing name and installs the bare token
+`cerberus`, resolved against whichever tap answers first — so the two spellings
+are different instructions, not variants of one, and `brew-smoke.mjs` accepts only
+the first. It reads the map on **every** release rather than treating the
+migration as a one-time event, because the file is a blob in a repository this one
+cannot write: nothing else would notice it being reverted, renamed or hand-edited,
+and no fresh install — which is every install path CI performs — can observe its
+absence.
+
+Operators who already hit this before the map landed are not migrated
+retroactively — the migration fires on the update that *observes* the deletion,
+which for them has already gone by. The repair is three commands:
+
+```sh
+brew uninstall --formula --force cerberus
+brew reinstall --cask tsouza/tap/cerberus
+cerberus --version
+```
+
+`--formula` is not optional: a bare `brew uninstall tsouza/tap/cerberus` resolves
+to the cask and removes the wrong one. And `reinstall` rather than `install`,
+because the cask is typically already registered as installed from the attempt
+that failed to link — `install` reports "the latest version is already installed"
+and never reaches the link step.
 
 The two shapes that write no cask are **not** skipped — each takes the
 opposite assertion. An `rc.*` must have written none, so a cask declaring the


### PR DESCRIPTION
## What broke

cerberus was served as a Homebrew **formula** through 1.13.1 and as a **cask**
from 1.13.2. The move deleted `Formula/cerberus.rb` from the tap and added
`Casks/cerberus.rb` — which makes every *fresh* install correct and every
*existing* install silently wrong:

```
$ brew upgrade
==> Deleted Installed Formulae
tsouza/tap/cerberus ✘                      # skipped, no error

$ brew install tsouza/tap/cerberus
Warning: It seems there is already a Binary at '/opt/homebrew/bin/cerberus'
from formula cerberus; skipping link.       # cask installed, never linked

$ cerberus --version
cerberus 1.13.1                             # still the old binary
```

Nothing prints an error at any step. The earliest adopters are hit hardest, and
the only symptom is a `--version` that disagrees with the release.

## Root cause

Homebrew's mechanism for carrying a formula install across to a cask is the
tap's `tap_migrations.json`. `Reporter#migrate_tap_migration`
(`Library/Homebrew/cmd/update_report/reporter.rb`) looks up
`tap.tap_migrations[name]` for every deleted formula in a `brew update` report
and, on a hit, runs `brew unlink` + `brew cleanup` + `brew install --cask`.

The tap shipped the migration with **no `tap_migrations.json` at all**, so the
lookup returned `nil` — indistinguishable from "no migration needed".

The user-facing half of the fix is already live in the tap
(`tsouza/homebrew-tap@d7323da`, `{"cerberus": "tsouza/tap"}`). This PR is the
repo-side half: the coverage that would have caught it, and the docs.

## Why CI could not have caught it

Every install path CI performs — release.yml's `brew-smoke`, brew-verify.yml's
`brew-verify` — starts from an empty runner. Both are structurally blind to
what happens to a machine that already had the formula. This PR closes that in
two layers:

- **Static** — `tapMigrationProblems()` in `brew-smoke.mjs` asserts the tap
  holds `tap_migrations.json` with the right entry, on **every release**, the
  same way the cask itself is asserted. The file is a plain blob in a repository
  this one cannot write, so nothing else would notice it being reverted,
  renamed or hand-edited.
- **Behavioural** — `brew-upgrade-path.mjs` reconstructs a pre-migration
  machine (rewind the tap clone to the commit before the formula was deleted,
  `brew install` the formula), runs `brew update`, and asserts the migration
  was *announced*, the cask is *installed*, and `cerberus --version` reports the
  *cask's* version. It runs in the weekly `brew-verify` lane
  (`brew-migration`, macOS + Linux); its **verdict function** is unit-tested on
  the required `check` lane, because a verdict that reads Homebrew's silence as
  success would leave the weekly lane green while every install stayed stranded.

The rewind point is derived (`git rev-list -1 origin/HEAD -- Formula/cerberus.rb`
then `^`) and self-verified with `git cat-file -e`, so a tap history rewrite
fails loudly rather than making the job vacuously green.

## Migration target shape

Only the bare `"tsouza/tap"` is accepted, not `"tsouza/tap/cerberus"`. These are
different instructions, not spelling variants: Homebrew's
`Utils.tap_from_full_name` splits on `/` and returns `nil` for a two-part value,
which routes to the branch that installs the fully-qualified `<tap>/cerberus`.
A three-part value takes the other branch and installs the **bare** token
`cerberus`, leaving resolution to whichever tap answers first.

## Docs

- `README.md` — the repair for anyone already stranded.
- `docs/operations.md` — the mechanism, the failure narrative, why the target
  shape matters, and why the assertion runs on every release.
- `.github/scripts/README.md` — module + env-contract entries for the new script
  and the two new `brew-smoke.mjs` exports.

The repair needs both flags to be exact: `--formula` is not optional (a bare
`brew uninstall cerberus` resolves to the *cask*), and it is `reinstall` rather
than `install` (install reports "already installed" and never reaches the link
step). Both were found the hard way.

```sh
brew uninstall --formula --force cerberus
brew reinstall --cask tsouza/tap/cerberus
cerberus --version
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)