### PR TITLE
chore(release): retire release/1.11.x ahead of the support window

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -335,9 +335,22 @@ One implementation means a new rule guards BOTH lanes at once.
   (`X.Y.0`, `Y>0`) — patches / major bumps / backports / prereleases retire
   nothing — deletes only a provably out-of-window branch that exists (idempotent
   on a 404) with a `supportWindowProblem` cross-check, and ANY deletion failure
-  logs `::error::` and still exits 0 (the release already published). Pure
-  exported `MAINTENANCE_BRANCH_RE` + `currentMinor(tags)` +
+  logs `::error::` and still exits 0 (the release already published). A line can
+  also be retired AHEAD of the window slide, when it diverges far enough that
+  the fixes the supported lines carry no longer apply to it: `RETIRED_LINES`
+  maps such a branch to the reason it went early, `supportWindowProblem`
+  consults that map BEFORE the version arithmetic (so the refusal to publish
+  needs no resolvable tag set and survives the branch being re-created), and the
+  `eol-retire-declared` command — the `eol-retire.yml` manual dispatch, with a
+  `DRY_RUN` mode — deletes the declared branches. That driver is FAIL-CLOSED,
+  unlike its post-publish sibling: nothing rides on the dispatch, so a branch it
+  could not delete is a failed run rather than a silent no-op. Each deletion is
+  first proved lossless by `unpublishedWorkProblem`, which requires the branch
+  tip to be the commit of a published stable tag ON THAT LINE — a branch
+  carrying anything no release published stops the run and names the highest tag
+  to diff against. Pure exported `MAINTENANCE_BRANCH_RE` + `currentMinor(tags)` +
   `supportWindowProblem({branch, tags, windowSize})` +
+  `unpublishedWorkProblem({branch, tipSha, tags})` +
   `retireLineForPublish({version, tags, windowSize})` + `evaluate({branchHead,
   pushedSha, checkRuns, statuses, selfJobs, branchLabel, tags, informational,
   required, mode})` + `requiredChecksPending(checkRuns, required)` (no network,
@@ -365,8 +378,14 @@ One implementation means a new rule guards BOTH lanes at once.
   - Env (`eol-retire-line` command): `GITHUB_TOKEN` (contents:write — the
     workflow passes `RELEASE_PAT || github.token`), `GITHUB_REPOSITORY`,
     `RELEASE_APP_VERSION` (the just-published `X.Y.Z`), `GITHUB_API_URL`.
+  - Env (`eol-retire-declared` command): `GITHUB_TOKEN` (contents:write AND
+    bypass on the `release/*.x` deletion ruleset — in practice the admin-owned
+    `RELEASE_PAT`, since `github-actions[bot]` has write but not admin and is
+    refused with a 403), `GITHUB_REPOSITORY`, `GITHUB_API_URL`, `DRY_RUN`
+    (`'true'` resolves and checks every declared line but deletes nothing).
   - Args: argv `--self-test` runs the assertion suite; `eol-retire-line` runs
-    the active-EOL retirement; no command runs the preflight gate.
+    the active-EOL retirement; `eol-retire-declared` deletes the branches
+    `RETIRED_LINES` declares retired early; no command runs the preflight gate.
   - Exit (preflight): `0` when every required lane ran green and all other gated
     checks are green (plus, in `maintenance` mode, the line is in-window and the
     commit is the branch tip) — or a green self-test; `1` on a required lane
@@ -376,6 +395,11 @@ One implementation means a new rule guards BOTH lanes at once.
   - Exit (`eol-retire-line`): `0` always (fail-open — a retirement failure must
     never fail an already-published release); `1` only on a gross wiring error
     (missing repo/token) before any publish-affecting work.
+  - Exit (`eol-retire-declared`): `0` when every declared line is already absent
+    or was deleted; `1` on a missing env var, an unlistable tag set, a branch
+    that could not be resolved or deleted, or a branch carrying commits no
+    release published. Fail-CLOSED by design — nothing rides on the dispatch, so
+    an unreported no-op would be the only failure mode worth worrying about.
 - **`brew-smoke.mjs`** — `release.yml`, the `brew-smoke` job (post-`publish`),
   and `brew-verify.yml`, which re-runs the identical assertions on demand or
   weekly against an ALREADY-published version (the release-run job cannot be

--- a/.github/scripts/release-preflight.mjs
+++ b/.github/scripts/release-preflight.mjs
@@ -186,9 +186,30 @@ const GREEN_CONCLUSIONS = new Set(['success', 'skipped', 'neutral']);
 // window / EOL policy" subsection of docs/operations.md.
 export const SUPPORTED_MINOR_LINES = 3;
 
+// Lines retired AHEAD of the window slide, branch name -> why.
+//
+// The window above is an upper bound on support, not a promise. A line stops
+// being supported the moment it can no longer take the fixes the other
+// supported lines carry — waiting for the arithmetic to catch up would leave it
+// advertising a support level it does not have, which is worse than retiring it
+// early. Declaring it here is what makes the retirement real: `supportWindowProblem`
+// refuses to publish from it, and the `eol-retire-declared` driver deletes the
+// branch.
+//
+// The reason travels with the entry because "why is this line gone while a
+// newer-by-one line is not" is the question a reader arrives with, and the
+// version arithmetic cannot answer it.
+export const RETIRED_LINES = new Map([
+  [
+    'release/1.11.x',
+    'it predates both the Map-canonicalisation family and the regression suite those fixes are ' +
+      'pinned by, so the wrong-answer corrections 1.12.x and main carry do not apply to it',
+  ],
+]);
+
 // A released app tag, `v<major>.<minor>.<patch>` (stable only — a prerelease
 // suffix like `-rc.1` does NOT establish a new supported line).
-const APP_TAG_RE = /^v(\d+)\.(\d+)\.\d+$/;
+const APP_TAG_RE = /^v(\d+)\.(\d+)\.(\d+)$/;
 
 // A just-published app version, `<major>.<minor>.<patch>` (no `v`, stable). The
 // active-EOL retirement helper takes this shape (it is what the release gate
@@ -323,13 +344,28 @@ export function currentMinor(tags) {
 }
 
 // supportWindowProblem — given a maintenance branch and the released tag set,
-// return a blocking-problem string iff the branch is end-of-life (its minor is
-// SUPPORTED_MINOR_LINES or more behind the current minor on the same major), or
-// null when the line is in-window (or the window can't be computed yet). Lines
-// on an older major are always EOL once a newer major exists.
+// return a blocking-problem string iff the branch is end-of-life (declared in
+// RETIRED_LINES, or its minor is SUPPORTED_MINOR_LINES or more behind the
+// current minor on the same major), or null when the line is in-window (or the
+// window can't be computed yet). Lines on an older major are always EOL once a
+// newer major exists.
 export function supportWindowProblem({ branch, tags, windowSize = SUPPORTED_MINOR_LINES }) {
   const m = MAINTENANCE_BRANCH_RE.exec(branch);
   if (!m) return null; // not a maintenance line — caller already guards this
+
+  // Declared retirement outranks the arithmetic, and is checked BEFORE it: an
+  // early-retired line is EOL on the strength of the declaration alone, so this
+  // must not depend on the tag set being resolvable. Re-creating the deleted
+  // branch and pushing to it is therefore still refused.
+  const declared = RETIRED_LINES.get(branch);
+  if (declared) {
+    return (
+      `${branch} is end-of-life: it was retired ahead of the latest-${windowSize} support window because ` +
+      `${declared}. An EOL line gets no further hotfixes — see the Release support window / EOL policy ` +
+      `in docs/operations.md.`
+    );
+  }
+
   const line = [Number(m[1]), Number(m[2])];
   const cur = currentMinor(tags);
   if (!cur) return null; // no stable release yet — nothing to be behind of
@@ -351,6 +387,51 @@ export function supportWindowProblem({ branch, tags, windowSize = SUPPORTED_MINO
       `${branch} is end-of-life: minor ${line[0]}.${line[1]} is ${behind} minor(s) behind the current ` +
       `${cur[0]}.${cur[1]} (support window = latest ${windowSize} minor lines). An EOL line gets no ` +
       `further hotfixes — see the Release support window / EOL policy in docs/operations.md.`
+    );
+  }
+  return null;
+}
+
+// unpublishedWorkProblem — null when deleting `branch` at `tipSha` destroys
+// nothing, a blocking string when it might.
+//
+// Retiring a line deletes its branch, and the tags are what survive. That is
+// only lossless while every commit on the branch is reachable from one of them,
+// and the cheap sufficient check is that the TIP is a released tag's commit: if
+// it is, the branch is exactly its published history and the tags reconstruct
+// it. Anything else — a backport merged but never released, a revert, a
+// hand-pushed commit — moves the tip off the last tag, and the difference is
+// gone the moment the ref is deleted.
+//
+// The matching tag must belong to the line the branch names. A tip that happens
+// to coincide with some OTHER line's tag says nothing about this line's history
+// and usually means the branch name and the work on it have diverged, which is
+// the point at which a destructive step should stop rather than guess.
+//
+// `tags` is the `{ name, sha }` shape `listTags` returns.
+export function unpublishedWorkProblem({ branch, tipSha, tags }) {
+  const m = MAINTENANCE_BRANCH_RE.exec(branch);
+  if (!m) return `${branch} is not a release maintenance line — refusing to delete it.`;
+  if (!tipSha) return `could not resolve the tip commit of ${branch} — refusing to delete it.`;
+
+  const onLine = [];
+  for (const t of tags ?? []) {
+    const tag = APP_TAG_RE.exec(t.name ?? '');
+    if (tag && tag[1] === m[1] && tag[2] === m[2]) onLine.push({ ...t, patch: Number(tag[3]) });
+  }
+  if (onLine.length === 0) {
+    return (
+      `${branch} has no published stable tag — deleting it would be the only record of that work ` +
+      `disappearing. Refusing to delete it.`
+    );
+  }
+
+  if (!onLine.some((t) => t.sha === tipSha)) {
+    const highest = onLine.reduce((a, b) => (b.patch > a.patch ? b : a));
+    return (
+      `${branch} is at ${tipSha}, which is not the commit of any published v${m[1]}.${m[2]}.* tag ` +
+      `(highest on the line: ${highest.name} at ${highest.sha}). The branch carries commits no release ` +
+      `published, and deleting it would discard them. Publish or drop them first, then retire the line.`
     );
   }
   return null;
@@ -1177,6 +1258,35 @@ async function main() {
 // active-EOL driver — `eol-retire-line`
 // ---------------------------------------------------------------------------
 //
+// Both retirement drivers talk to the same API with the same auth, so the two
+// calls they share live here rather than being written twice with two chances
+// to drift.
+function apiHeaders(token) {
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+  };
+}
+
+// listTags — every tag as `{ name, sha }`, where `sha` is the COMMIT the tag
+// resolves to (the tags API dereferences annotated tags for us, so a peeled and
+// a lightweight tag are indistinguishable here — which is what both callers
+// want). Fetched via the API so neither step needs a fetch-depth.
+async function listTags({ apiBase, repo, headers }) {
+  const out = [];
+  let page = 1;
+  for (;;) {
+    const res = await fetch(`${apiBase}/repos/${repo}/tags?per_page=100&page=${page}`, { headers });
+    if (!res.ok) throw new Error(`GET tags -> ${res.status} ${res.statusText}`);
+    const data = (await res.json()) ?? [];
+    out.push(...data.map((t) => ({ name: t.name, sha: t.commit?.sha })));
+    if (data.length < 100) break;
+    page += 1;
+  }
+  return out;
+}
+
 // Runs POST-publish, after a NEW app version actually shipped. Computes the
 // line that just fell out of the support window via `retireLineForPublish`
 // (shared window math) and, if its `release/X.W.x` branch EXISTS, DELETES it.
@@ -1190,11 +1300,13 @@ async function main() {
 // could be marked continue-on-error too; we keep exit 0 to be safe regardless).
 //
 // Mechanism: deletes the ref via the Git refs API with the token in
-// GITHUB_TOKEN. The workflow passes RELEASE_PAT (fine-grained, contents:write)
-// when present, else the default github.token — both can delete an UNPROTECTED
-// `release/*.x` branch (verified: no ruleset / classic protection covers
-// `release/*`, only `main`). If a future ruleset protects `release/*`, wire a
-// bypass for the PAT identity; the fail-open contract means a 403 just logs.
+// GITHUB_TOKEN. The ruleset "release maintenance lines" targets
+// `refs/heads/release/*.x` and blocks `deletion`, so the token has to be able to
+// BYPASS it: the single bypass actor is the `admin` RepositoryRole in `always`
+// mode, which an admin-owned RELEASE_PAT inherits. The default `github.token`
+// acts as `github-actions[bot]` — write, never admin — and is refused with a
+// 403. The fail-open contract means that refusal logs loudly rather than
+// failing an already-published release.
 //
 // Env contract:
 //   GITHUB_TOKEN       token with contents:write (RELEASE_PAT or github.token).
@@ -1212,33 +1324,11 @@ async function retireLine() {
     process.exit(1);
   }
 
-  const headers = {
-    Authorization: `Bearer ${token}`,
-    Accept: 'application/vnd.github+json',
-    'X-GitHub-Api-Version': '2022-11-28',
-  };
-
-  // All tags — the window anchors to the highest released stable minor. Fetched
-  // via the API so the step needs no fetch-depth. Fail-open: if we cannot list
-  // tags we cannot safely compute the window, so we retire nothing and return.
-  async function allTags() {
-    const out = [];
-    let page = 1;
-    for (;;) {
-      const res = await fetch(`${apiBase}/repos/${repo}/tags?per_page=100&page=${page}`, { headers });
-      if (!res.ok) throw new Error(`GET tags -> ${res.status} ${res.statusText}`);
-      const data = await res.json();
-      const names = (data ?? []).map((t) => t.name);
-      out.push(...names);
-      if (names.length < 100) break;
-      page += 1;
-    }
-    return out;
-  }
+  const headers = apiHeaders(token);
 
   let tags;
   try {
-    tags = await allTags();
+    tags = (await listTags({ apiBase, repo, headers })).map((t) => t.name);
   } catch (e) {
     ghError(`eol-retire-line: could not list tags (${e.message}) — retiring nothing this run (fail-open)`);
     process.exit(0);
@@ -1312,6 +1402,122 @@ async function retireLine() {
 }
 
 // ---------------------------------------------------------------------------
+// declared-EOL driver — `eol-retire-declared`
+// ---------------------------------------------------------------------------
+//
+// Retires the lines RETIRED_LINES declares dead ahead of the window slide.
+// `eol-retire-line` above is the scheduled half — it retires whatever the
+// arithmetic pushed out when a minor shipped — and this is the deliberate half;
+// they are separate entry points because they run at different times for
+// different reasons, and share the window math + tag listing rather than the
+// trigger.
+//
+// FAIL-CLOSED, unlike its sibling. `eol-retire-line` runs after a release is
+// already public, so a token refusal there must not red an otherwise-successful
+// publish. This one is dispatched on its own with nothing riding on it, so a
+// branch that could not be deleted is a failure: a silent no-op would leave the
+// line standing while the declaration and the docs both say it is gone, and
+// nothing would ever point out the disagreement.
+//
+// Nothing here is inferred. A line is retired because RETIRED_LINES names it,
+// and it is deleted only after `unpublishedWorkProblem` confirms the tags
+// reconstruct it — a branch holding anything a release did not publish stops
+// the run rather than being retired at the cost of that work.
+//
+// Env contract:
+//   GITHUB_TOKEN       token with contents:write AND bypass on the
+//                      `release/*.x` deletion ruleset — in practice the
+//                      admin-owned RELEASE_PAT, since github-actions[bot] has
+//                      write but not admin and is refused with a 403.
+//   GITHUB_REPOSITORY  owner/repo.
+//   GITHUB_API_URL     API base (default https://api.github.com).
+//   DRY_RUN            'true' -> resolve and check every line, delete nothing.
+// Exit: 0 when every declared line is absent or was deleted, 1 otherwise.
+async function retireDeclared() {
+  const token = process.env.GITHUB_TOKEN;
+  const repo = process.env.GITHUB_REPOSITORY;
+  const apiBase = process.env.GITHUB_API_URL || 'https://api.github.com';
+  const dryRun = process.env.DRY_RUN === 'true';
+
+  if (!token || !repo) {
+    ghError('eol-retire-declared: GITHUB_TOKEN and GITHUB_REPOSITORY are required.');
+    process.exit(1);
+  }
+  if (RETIRED_LINES.size === 0) {
+    ghNotice('eol-retire-declared: RETIRED_LINES is empty — no line is declared retired, nothing to do.');
+    process.exit(0);
+  }
+
+  const headers = apiHeaders(token);
+
+  let tags;
+  try {
+    tags = await listTags({ apiBase, repo, headers });
+  } catch (e) {
+    ghError(`eol-retire-declared: could not list tags (${e.message}) — cannot prove a branch is safe to delete.`);
+    process.exit(1);
+  }
+
+  let failed = false;
+
+  for (const [branch, reason] of RETIRED_LINES) {
+    const ref = `heads/${branch}`;
+
+    let tipSha;
+    try {
+      const res = await fetch(`${apiBase}/repos/${repo}/git/ref/${ref}`, { headers });
+      if (res.status === 404) {
+        ghNotice(`eol-retire-declared: ${branch} is already absent — nothing to delete (idempotent).`);
+        continue;
+      }
+      if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+      tipSha = (await res.json())?.object?.sha;
+    } catch (e) {
+      ghError(`eol-retire-declared: could not resolve ${branch} (${e.message}).`);
+      failed = true;
+      continue;
+    }
+
+    const unsafe = unpublishedWorkProblem({ branch, tipSha, tags });
+    if (unsafe) {
+      ghError(`eol-retire-declared: ${unsafe}`);
+      failed = true;
+      continue;
+    }
+
+    if (dryRun) {
+      ghNotice(
+        `eol-retire-declared: DRY_RUN — would delete ${branch} (at ${tipSha}, a published tag's commit), ` +
+          `retired early because ${reason}.`,
+      );
+      continue;
+    }
+
+    try {
+      const res = await fetch(`${apiBase}/repos/${repo}/git/refs/${ref}`, { method: 'DELETE', headers });
+      if (res.status === 204) {
+        ghNotice(
+          `eol-retire-declared: deleted ${branch} — retired ahead of the latest-${SUPPORTED_MINOR_LINES} ` +
+            `support window because ${reason}. Its tags / Releases are retained.`,
+        );
+        continue;
+      }
+      const body = await res.text().catch(() => '');
+      throw new Error(`DELETE -> ${res.status} ${res.statusText} ${body}`);
+    } catch (e) {
+      ghError(
+        `eol-retire-declared: could not delete ${branch} (${e.message}). If this is a 403, the token ` +
+          `lacks bypass on the release/*.x deletion ruleset — dispatch again with RELEASE_PAT, or delete ` +
+          `it by hand: git push origin --delete ${branch}.`,
+      );
+      failed = true;
+    }
+  }
+
+  process.exit(failed ? 1 : 0);
+}
+
+// ---------------------------------------------------------------------------
 // dispatcher
 // ---------------------------------------------------------------------------
 
@@ -1332,6 +1538,13 @@ if (invokedDirectly) {
       // Even an unexpected throw is fail-open: the release already shipped.
       ghError(`eol-retire-line: unexpected failure (${e.message}) — retiring nothing (fail-open)`);
       process.exit(0);
+    });
+  } else if (cmd === 'eol-retire-declared') {
+    retireDeclared().catch((e) => {
+      // Fail-closed: nothing is riding on this dispatch, so an unexpected throw
+      // is reported rather than swallowed.
+      ghError(`eol-retire-declared: unexpected failure (${e.message}) — no line retired.`);
+      process.exit(1);
     });
   } else {
     main().catch((e) => {

--- a/.github/scripts/release-preflight.test.mjs
+++ b/.github/scripts/release-preflight.test.mjs
@@ -28,9 +28,13 @@ import {
   parseCheckList,
   requiredChecksPending,
   allSuitesSettled,
+  supportWindowProblem,
+  unpublishedWorkProblem,
   MODE_MAINLINE,
   MODE_MAINTENANCE,
   REUSABLE_JOB_SEPARATOR,
+  RETIRED_LINES,
+  SUPPORTED_MINOR_LINES,
 } from './release-preflight.mjs';
 
 test('parseCheckList keeps commas inside a check name', () => {
@@ -238,4 +242,108 @@ test('legacy statuses satisfy the required set too, and a red one still blocks',
   const red = evaluate(world({ required, statuses: [{ context: 'GitGuardian', state: 'failure' }] }));
   assert.equal(red.problems.length, 1, `expected exactly one problem, got: ${red.problems.join('; ')}`);
   assert.equal(red.problems[0], 'GitGuardian: status failure');
+});
+
+// ---------------------------------------------------------------------------
+// early retirement — RETIRED_LINES, and the guard on deleting a branch
+// ---------------------------------------------------------------------------
+
+// Tags spanning the three lines the window keeps, so anything the declaration
+// rejects is rejected DESPITE the arithmetic saying it is supported.
+const IN_WINDOW_TAGS = ['v1.13.2', 'v1.12.3', 'v1.11.4', 'v1.10.7'];
+
+test('every declared retirement is a branch the window math can see', () => {
+  // `supportWindowProblem` returns null for anything that is not a maintenance
+  // branch, and it does so BEFORE consulting the declaration. A typo in a
+  // RETIRED_LINES key — `releases/1.11.x`, `release/1.11`, a stray space — is
+  // therefore not a loud failure but a silent one: the entry sits in the map
+  // looking authoritative while the line it names stays publishable. Asserting
+  // the declaration actually fires is the only thing standing between a typo
+  // and a retired line quietly accepting a release.
+  assert.ok(RETIRED_LINES.size > 0, 'the map is expected to hold the lines retired so far');
+  for (const [branch, reason] of RETIRED_LINES) {
+    const problem = supportWindowProblem({ branch, tags: IN_WINDOW_TAGS });
+    assert.ok(problem, `${branch} is declared retired but the gate does not block it`);
+    assert.match(problem, /end-of-life/);
+    assert.ok(reason && reason.length > 0, `${branch} is declared retired with no reason`);
+  }
+});
+
+test('release/1.11.x is retired even though the window still counts it as supported', () => {
+  // The case the declaration exists for. v1.13 is current and the window keeps
+  // the latest 3 minors, so 1.11 is one inside the boundary by arithmetic; it
+  // is retired anyway, and the block has to name the reason rather than the
+  // version distance, because the distance is not why.
+  assert.equal(SUPPORTED_MINOR_LINES, 3, 'the fixture below assumes a latest-3 window');
+  assert.equal(supportWindowProblem({ branch: 'release/1.12.x', tags: IN_WINDOW_TAGS }), null);
+
+  const problem = supportWindowProblem({ branch: 'release/1.11.x', tags: IN_WINDOW_TAGS });
+  assert.match(problem, /end-of-life/);
+  assert.match(problem, /retired ahead of the latest-3 support window/);
+  assert.doesNotMatch(problem, /minor\(s\) behind/, 'the arithmetic reason would be the wrong one here');
+});
+
+test('a declared retirement does not depend on the tag set being resolvable', () => {
+  // The declaration is the whole basis for the block, so it must survive a
+  // world where the window cannot be computed at all. Otherwise re-creating the
+  // deleted branch and publishing from it would be refused only while the tag
+  // listing happened to work.
+  assert.match(supportWindowProblem({ branch: 'release/1.11.x', tags: [] }), /end-of-life/);
+  assert.equal(supportWindowProblem({ branch: 'release/1.12.x', tags: [] }), null, 'negative control');
+});
+
+test('a branch whose tip is a published tag on its own line is safe to delete', () => {
+  const tags = [
+    { name: 'v1.11.4', sha: 'aaa' },
+    { name: 'v1.11.3', sha: 'bbb' },
+    { name: 'v1.12.3', sha: 'ccc' },
+  ];
+  assert.equal(unpublishedWorkProblem({ branch: 'release/1.11.x', tipSha: 'aaa', tags }), null);
+});
+
+test('a branch carrying commits no release published is refused, and the highest tag is named', () => {
+  // The state that makes deletion lossy: a backport merged but never released.
+  // Reporting the highest tag is what turns the refusal into an action — it is
+  // the commit the operator has to diff against to see what would be lost.
+  const tags = [
+    { name: 'v1.11.4', sha: 'aaa' },
+    { name: 'v1.11.10', sha: 'ddd' },
+  ];
+  const problem = unpublishedWorkProblem({ branch: 'release/1.11.x', tipSha: 'unreleased', tags });
+  assert.match(problem, /not the commit of any published v1\.11\.\* tag/);
+  assert.match(problem, /v1\.11\.10 at ddd/, 'highest is by patch NUMBER, not string order');
+});
+
+test('a tip matching some other line\'s tag does not count as published', () => {
+  // A coincidence between a branch tip and an unrelated line's tag says nothing
+  // about this line's history, and usually means the branch and its name have
+  // diverged — the point at which a destructive step should stop.
+  const tags = [
+    { name: 'v1.12.3', sha: 'ccc' },
+    { name: 'v1.11.4', sha: 'aaa' },
+  ];
+  assert.match(
+    unpublishedWorkProblem({ branch: 'release/1.11.x', tipSha: 'ccc', tags }),
+    /not the commit of any published v1\.11\.\* tag/,
+  );
+});
+
+test('a line with no stable tag at all is refused rather than assumed empty', () => {
+  // No tag means no reconstruction: the branch IS the only record. A prerelease
+  // does not count, matching the rest of the gate's reading of what "published"
+  // means.
+  const tags = [
+    { name: 'v1.11.0-rc.1', sha: 'aaa' },
+    { name: 'v1.12.3', sha: 'ccc' },
+  ];
+  const problem = unpublishedWorkProblem({ branch: 'release/1.11.x', tipSha: 'aaa', tags });
+  assert.match(problem, /no published stable tag/);
+});
+
+test('an unresolvable tip and a non-maintenance branch are both refusals, not passes', () => {
+  // Both are the shape where "nothing to check" reads identically to "checked
+  // and fine". This driver deletes branches, so neither may return null.
+  const tags = [{ name: 'v1.11.4', sha: 'aaa' }];
+  assert.match(unpublishedWorkProblem({ branch: 'release/1.11.x', tipSha: '', tags }), /could not resolve/);
+  assert.match(unpublishedWorkProblem({ branch: 'main', tipSha: 'aaa', tags }), /not a release maintenance line/);
 });

--- a/.github/workflows/eol-retire.yml
+++ b/.github/workflows/eol-retire.yml
@@ -1,0 +1,53 @@
+name: eol-retire
+
+# Deletes the maintenance branches that `RETIRED_LINES` in
+# release-preflight.mjs declares retired ahead of the support window.
+#
+# The window slide is already automated — release.yml retires the line a new
+# minor pushed out, in the same run that published it. This workflow covers the
+# other case: a line that stops being supportable BEFORE the arithmetic reaches
+# it, because it can no longer take the fixes the supported lines carry. That is
+# a judgement, not a computation, so it is dispatched by hand after the entry is
+# merged rather than fired by a release.
+#
+# Manual dispatch rather than push-to-main for the same reason: merging the
+# declaration is what makes the refusal to publish from the line take effect
+# immediately, and deleting the branch is a separate, irreversible step that
+# should be taken deliberately. `dry_run` defaults to true so the first run
+# always reports what it would delete.
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Report what would be deleted without deleting it.'
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: write
+
+concurrency:
+  group: eol-retire
+  cancel-in-progress: false
+
+jobs:
+  retire:
+    name: retire declared EOL lines
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: release-preflight self-test
+        run: node .github/scripts/release-preflight.mjs --self-test
+
+      - name: retire declared EOL lines
+        env:
+          # The `release/*.x` ruleset blocks deletion and bypasses only the
+          # admin role, which an admin-owned RELEASE_PAT inherits and
+          # github-actions[bot] does not. Falling back to github.token keeps the
+          # dispatch runnable without the secret; it will report the 403 rather
+          # than pretend the branch is gone.
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: node .github/scripts/release-preflight.mjs eol-retire-declared

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1385,9 +1385,11 @@ required lane that never runs on the branch would block every hotfix release.
 
 ### Release support window / EOL policy
 
-Cerberus maintains the **latest 3 minor release lines**: the current minor plus
-the two prior. When a new minor ships, the line that becomes **3 minors behind**
-the current minor reaches **end-of-life (EOL)**. An EOL line:
+Cerberus maintains **at most the latest 3 minor release lines**: the current
+minor plus the two prior. When a new minor ships, the line that becomes **3
+minors behind** the current minor reaches **end-of-life (EOL)**. The window is an
+upper bound, not a promise — a line can also be **retired early** (see [Early
+retirement](#early-retirement)). An EOL line:
 
 - gets **no further hotfixes**;
 - has its `release/<major>.<minor>.x` maintenance branch **deleted
@@ -1457,6 +1459,40 @@ by release.yml's preflight on the commit being published.
 EOL retirement never unpublishes anything: the `v<major>.<minor>.*` git tags and
 their GitHub Releases — and the already-pushed images, charts, and binaries —
 stay available; only the future-hotfix branch is removed.
+
+#### Early retirement
+
+A line can reach end-of-life before the window slides past it. The window says
+how many lines cerberus is willing to support; it cannot say whether a
+particular line is still *supportable*. When a line diverges far enough that the
+fixes the other supported lines carry no longer apply to it — a correction that
+depends on a refactor it never took, a regression suite with no base on that
+branch — continuing to advertise support for it is the dishonest option.
+Retiring it early is the honest one.
+
+The declaration lives in `RETIRED_LINES` in
+`.github/scripts/release-preflight.mjs`, mapping the branch name to the reason
+it went early. Merging that entry is what makes the retirement real: the passive
+half (`supportWindowProblem`) consults the declaration **before** the version
+arithmetic, so the line stops being publishable immediately, and it stays
+refused even if the branch is later re-created.
+
+Deleting the branch is a separate, deliberate step — the `eol-retire` workflow,
+dispatched by hand, with `dry_run` defaulting to true so the first run only
+reports. Unlike its scheduled sibling it is **fail-closed**: nothing is riding on
+the dispatch, so a branch it could not delete is a failed run rather than a
+silent no-op that would leave the line standing while the docs said otherwise.
+Before each deletion it proves the retirement is lossless — the branch tip must
+be the commit of a published stable tag *on that line*, which is what makes the
+surviving tags a complete reconstruction of it. A branch carrying anything a
+release never published (an unreleased backport, a revert, a hand-pushed commit)
+stops the run and names the highest tag to diff against, rather than being
+retired at the cost of that work.
+
+Currently retired ahead of the window: **`release/1.11.x`**. It predates both
+the Map-canonicalisation family of wrong-answer fixes and the regression suite
+those fixes are pinned by, so the corrections `1.12.x` and `main` carry do not
+apply to it. `v1.11.*` tags and Releases are retained like any other EOL line.
 
 ## Dev / prod parity
 


### PR DESCRIPTION
## Why 1.11 goes now

The latest-3-minor window still counts 1.11 as supported — v1.13 is current, so
it sits one inside the boundary. It is retired anyway, because the window says
how many lines cerberus is *willing* to support and cannot say whether a
particular line is still *supportable*.

`release/1.11.x` predates both the Map-canonicalisation family of wrong-answer
corrections and the regression suite those fixes are pinned by. Backporting them
is a rewrite rather than a cherry-pick — a trial backport conflicted on
`canonical_series_keys_test.go`, which has no base on that line at all. Six
correctness fixes 1.12.x and `main` carry are absent from it (#1358, #1356,
#1362, #1340, #1347, #1374). Continuing to advertise support cerberus cannot
deliver is the worse option.

Nothing unpublished is destroyed: the branch tip is
`e000d4ae3b4d84ecb39b3a137ec31fb7ff53d681`, which is exactly `v1.11.4^{}`. The
`v1.11.*` tags and Releases are retained, like every other EOL line.

## The window becomes an upper bound

`RETIRED_LINES` maps a branch to the reason it went early, and
`supportWindowProblem` consults it **before** the version arithmetic. That
ordering is the point: the refusal to publish needs no resolvable tag set, and
it survives the branch being re-created and pushed to.

## Deleting the branch is a separate, deliberate step

`eol-retire.yml`, dispatched by hand, `dry_run` defaulting to true. It is
**fail-closed**, unlike its post-publish sibling `eol-retire-line`: that one runs
after a release is already public, so a token refusal there must not red a
successful publish. This one has nothing riding on it, so a branch it could not
delete is a failed run rather than a silent no-op that would leave the line
standing while the docs said it was gone.

Each deletion is first proved lossless by `unpublishedWorkProblem`: the branch
tip must be the commit of a published **stable** tag **on that line**, which is
what makes the surviving tags a complete reconstruction of the branch. A tip
that matches some other line's tag does not count — that coincidence says
nothing about this line's history and usually means the branch and its name have
diverged. A branch carrying an unreleased backport, a revert, or a hand-pushed
commit stops the run and names the highest tag to diff against.

## The silent failure mode the tests close

`supportWindowProblem` returns `null` for anything that is not a maintenance
branch, and it does so *before* consulting the declaration. So a typo'd
`RETIRED_LINES` key — `releases/1.11.x`, `release/1.11`, a stray space — is not
a loud failure but a silent one: the entry sits in the map looking authoritative
while the line it names stays publishable.

`every declared retirement is a branch the window math can see` asserts every
entry actually blocks, and that each carries a non-empty reason. Nine more cases
cover the declaration outranking the arithmetic, surviving an unresolvable tag
set, and every refusal branch of `unpublishedWorkProblem` — including that an
unresolvable tip and a non-maintenance branch are refusals rather than passes,
since "nothing to check" and "checked and fine" read identically in a driver
that deletes branches.

21/21 pass in `release-preflight.test.mjs` (required `lint` lane).

## Docs

`docs/operations.md` gains an **Early retirement** subsection under the EOL
policy, and the window is restated as an upper bound rather than a schedule.
`.github/scripts/README.md` gains the `eol-retire-declared` env + exit contract
and the new exported helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)