### PR TITLE
fix(solver): record the real cost grid on every routing refusal

### DIFF
--- a/docs/router-rules.md
+++ b/docs/router-rules.md
@@ -215,7 +215,7 @@ finding by the **solver decision reason** (see below).
 | ---------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `oom_on_route_a`                   | critical | route-A OOMs (route B exists to avoid them; unconditional, no threshold).                                                                                                                                                                            |
 | `route_a_memory_near_cap`          | high     | route-A queries whose peak memory is at/above a fraction (`memory_near_cap_fraction`, default 0.8) of the configured cap (`query.max_memory_bytes`) — the leading indicator before an OOM. Gated on proximity to the actual cap, not the corpus p95. |
-| `route_a_high_fanout_should_shard` | medium   | route-A queries with fan-out in the range the deployment normally shards.                                                                                                                                                                            |
+| `route_a_high_fanout_should_shard` | medium   | route-A queries with fan-out in the range the deployment normally shards, restricted to the ones route B *could* have taken — `decision_reason` in {`below-threshold`, `high-D`}. A structural refusal cannot be un-refused by a threshold.          |
 | `route_a_timeout_should_shard`     | high     | route-A timeouts (time-slicing bounds per-shard wall-clock).                                                                                                                                                                                         |
 | `route_a_hit_sample_budget`        | high     | route-A queries that hit the sample budget (sharding keeps each shard under budget).                                                                                                                                                                 |
 | `route_b_overshard_low_fanout`     | medium   | route-B queries that paid k-shard overhead below the fan-out floor while finishing fast (route-B regret).                                                                                                                                            |
@@ -239,23 +239,37 @@ ships the buildable form instead: it fires on the cerberus-side rejection
 share as message context (`{cerberus_reject_ratio}`, a `corpus_count_ratio`
 scalar) — context, never a gate, so no inline tolerance number is needed.
 
-### decision_reason is an attribution column, never a condition operand
+### decision_reason attributes a finding, and gates the rules whose advice depends on it
 
-The catalogVersion-2 failure rules group by `decision_reason` — the
-shadow-header value the solver records to explain each non-route decision
-(`routed`, `below-threshold`, `not-sliceable`, `instant`, `high-D`, `now64`,
-`grid-mismatch`, `incommensurate`, `scalar-heavy`; see
-[`internal/solver/decision.go`](../internal/solver/decision.go)). It is a
-**grouping / attribution** column: it tells the operator *which solver path*
-produced the failure, so they can pick the right lever (shard vs cap vs reject
-vs rewrite) — the catalog never encodes that branch in a number. It is **never**
-a condition operand (the grammar classifies it `ColumnGroup`, rejected in a
-leaf). Because the rules only group by it, they are immune to token drift; the
-finding message is the only place the token surfaces, so it always shows
-whatever token the corpus actually carries. A meta-test
-([`test/regression/router_corpus_seed_test.go`](../test/regression/router_corpus_seed_test.go))
-pins the seed corpus's `decision_reason` tokens to the solver's `Reason*`
-constants so the fixtures never drift from production.
+`decision_reason` is the shadow-header value the solver records to explain each
+routing decision (`routed`, `below-threshold`, `not-sliceable`, `instant`,
+`instant-join`, `high-D`, `now64`, `grid-mismatch`, `incommensurate`,
+`scalar-heavy`; see
+[`internal/solver/decision.go`](../internal/solver/decision.go)). Its primary
+use is **grouping / attribution**: the failure rules group by it so the operator
+can see *which solver path* produced the failure and pick the right lever (shard
+vs cap vs reject vs rewrite) — the catalog never encodes that branch in a number.
+
+It is also a legal **condition operand**, because for some rules the reason is
+not colour but correctness. `route_a_high_fanout_should_shard` advises "lower
+the route-B threshold", which can only change the outcome for a plan the solver
+found *eligible* and then declined on cost — `below-threshold` and `high-D`.
+Every other token is a **structural** refusal: route B cannot take an instant
+query, a now64 plan, or a non-slice-invariant plan at *any* threshold, so the
+same advice there is wrong rather than merely weak. The rule states the
+membership positively (`in [below-threshold, high-D]`), so a Reason added to the
+solver later is excluded by default instead of silently joining the population.
+
+That makes the token set a **closed domain**, not free text: the grammar
+classifies `decision_reason` `ColumnEnum` and validates every literal against
+the vocabulary, so `route_a_high_fanout_should_shard`-style typos
+(`below_threshold`) fail at catalog load rather than producing a rule that never
+fires. Two meta-tests keep the vocabulary honest — one in
+[`internal/routerrules`](../internal/routerrules/decision_reason_gate_test.go)
+pins the enum domain against `solver.Reasons` (and proves the reason gate itself
+fires only for the two cost-declined tokens), and one in
+[`test/regression`](../test/regression/router_corpus_seed_test.go) pins the seed
+corpus's tokens to the same list so the fixtures never drift from production.
 
 ## Running it
 

--- a/docs/solver.md
+++ b/docs/solver.md
@@ -90,9 +90,20 @@ thresholds drop to the floor, so every eligible plan routes at `K_min = 2`
 Under `single` the Planner classifies but never routes.
 
 Every classification — routed or not — produces a `Decision` carrying the
-reason (`routed`, `below-threshold`, `not-sliceable`, `instant`, `high-D`,
-`now64`, `grid-mismatch`, `incommensurate`, `scalar-heavy`) for the shadow
-header.
+reason (`routed`, `below-threshold`, `not-sliceable`, `instant`, `instant-join`,
+`high-D`, `now64`, `grid-mismatch`, `incommensurate`, `scalar-heavy`) for the
+shadow header, alongside the plan's cost grid (`N`, `F`, `D`, `OuterRange`,
+`Step`).
+
+The grid is populated on **every** Decision, including the refusals. The signal
+walk that derives it makes no routing decision and mutates nothing, so it runs
+before the gates rather than after them. This is what makes the calibration
+corpus replayable: a refusal recorded with a zero grid says "we declined"
+without saying what we declined, which is indistinguishable from a plan that
+genuinely had no geometry. It also makes one silent failure mode legible — a
+range query whose grid carrier the classifier fails to find looks instant, and
+now records `reason=instant` next to a non-zero `N`/`F`/`OuterRange` that a
+genuine instant query could not have.
 
 ## Slicing geometry
 

--- a/internal/routerrules/catalog/catalog.yaml
+++ b/internal/routerrules/catalog/catalog.yaml
@@ -18,10 +18,12 @@
 #
 # Grammar: see docs/router-rules.md. Adding a rule = dropping a new
 # rules/<rule_id>.yaml file (filename = rule id) and bumping catalogVersion —
-# no Go change.
+# no Go change. Narrowing or widening an existing rule's population bumps the
+# version too: it is what tells an operator their findings shifted for a reason
+# other than their own corpus moving.
 
 apiVersion: routerrules.cerberus/v1
-catalogVersion: 2
+catalogVersion: 3
 
 # --------------------------------------------------------------------------
 # params: NAME + how to RESOLVE, never the value.

--- a/internal/routerrules/catalog/rules/route_a_high_fanout_should_shard.yaml
+++ b/internal/routerrules/catalog/rules/route_a_high_fanout_should_shard.yaml
@@ -1,3 +1,12 @@
+# The decision_reason leaf is a CORRECTNESS gate, not a noise filter. This
+# rule's advice is "lower the route-B threshold", which is only actionable for a
+# plan the solver found ELIGIBLE and then declined on cost — below-threshold and
+# high-D are the only two reasons that describe. Every other reason is a
+# structural refusal (instant, instant-join, not-sliceable, now64, grid-mismatch,
+# incommensurate, scalar-heavy): route B cannot take those plans at ANY
+# threshold, so recommending a lower one is wrong advice rather than weak
+# advice. The leaf is stated positively so a Reason added to the solver later is
+# excluded by default instead of silently joining the population.
 rules:
   - id: route_a_high_fanout_should_shard
     severity: medium
@@ -9,8 +18,9 @@ rules:
     condition:
       all:
         - { col: route, op: eq, enum: A }
+        - { col: decision_reason, op: in, enum: [below-threshold, high-D] }
         - { col: fanout, op: gte, param: fanout_route_b_floor }
     evidence:
       report: [count, "max(fanout)"]
-    finding: "route A class {shape_id}/{language} has fan-out at/above {fanout_route_b_floor} (the range this deployment normally shards) — consider routing to B"
+    finding: "route A class {shape_id}/{language} has fan-out at/above {fanout_route_b_floor} (the range this deployment normally shards) and was declined on cost, not structure — consider routing to B"
     action: lower_route_b_threshold

--- a/internal/routerrules/columns.go
+++ b/internal/routerrules/columns.go
@@ -12,8 +12,8 @@ import "sort"
 const CorpusTableName = "cerberus_router_corpus"
 
 // ColumnKind classifies each corpus column so the validator can tell which
-// columns may legitimately carry an enum literal in a rule condition (the three
-// Enum-typed columns) versus which may only be compared against a resolved
+// columns may legitimately carry an enum literal in a rule condition (the
+// closed-domain columns) versus which may only be compared against a resolved
 // numeric parameter (the cost/feature columns).
 type ColumnKind uint8
 
@@ -22,16 +22,21 @@ const (
 	// condition may compare it only against a resolved ${param}, never against
 	// an inline number.
 	ColumnNumeric ColumnKind = iota
-	// ColumnEnum is one of the three Enum-typed columns. A condition may
-	// compare it against a domain category literal (eq / in) — these are
-	// classifier categories, not tunable numbers.
+	// ColumnEnum is a CLOSED-DOMAIN classifier column. A condition may compare
+	// it against a domain category literal (eq / in) — these are classifier
+	// categories, not tunable numbers. Membership is decided by whether the
+	// writer's vocabulary is closed, not by the ClickHouse storage type:
+	// decision_reason is LowCardinality(String) on disk but its value set is the
+	// solver's fixed Reason* vocabulary, so a rule may filter on it exactly as
+	// it filters on route or exit_status.
 	ColumnEnum
 	// ColumnTime is the event_time column. It is window-bounded by the source
 	// (via --since), never used as a rule-condition operand.
 	ColumnTime
-	// ColumnGroup is an identity/grouping column (shape id, query hash,
-	// decision reason). It is used as a group key or carried as finding
-	// context, never compared numerically.
+	// ColumnGroup is an OPEN-domain identity column (shape id, query hash). Its
+	// values are minted from the query text, so no closed literal set exists to
+	// validate a condition against. It is used as a group key or carried as
+	// finding context, never compared.
 	ColumnGroup
 )
 
@@ -64,7 +69,7 @@ var corpusColumns = []corpusColumn{
 	{name: "step", kind: ColumnNumeric},
 	{name: "route", kind: ColumnEnum},
 	{name: "k_shards", kind: ColumnNumeric},
-	{name: "decision_reason", kind: ColumnGroup},
+	{name: "decision_reason", kind: ColumnEnum},
 	{name: "read_rows", kind: ColumnNumeric, runtimeCost: true},
 	{name: "read_bytes", kind: ColumnNumeric, runtimeCost: true},
 	{name: "query_duration_ms", kind: ColumnNumeric, runtimeCost: true},
@@ -114,14 +119,38 @@ var runtimeCostColumns = func() map[string]struct{} {
 	return m
 }()
 
-// enumDomains is the closed set of accepted category tokens per Enum column,
-// matching the optcorpus Enum8 DDL. A condition that compares an enum column
-// against a token outside its domain fails validation, catching typos like
-// route='C' or exit_status='killed'.
+// enumDomains is the closed set of category tokens a rule may name per enum
+// column. A condition that compares an enum column against a token outside its
+// domain fails validation, catching typos like route='C' or exit_status='killed'.
+//
+// route / exit_status / language mirror the optcorpus Enum8 DDL. decision_reason
+// is LowCardinality(String) on disk but its writer-side vocabulary is just as
+// closed: it is re-declared here verbatim from the solver's Reason* consts,
+// following the same deliberate no-import contract as CorpusTableName above
+// (this package depends on neither the solver nor optcorpus). The two
+// declarations are a wire contract — a new Reason* const must be added here in
+// lockstep, and decision_reason_gate_test.go pins that they agree (a test file
+// may import the solver; production code in this package may not).
+//
+// The unclassified reason (the empty string every non-PromQL row carries,
+// because Solver.Classify only classifies PromQL) is deliberately NOT a member:
+// a rule must select its population by `language`, never by the absence of a
+// classification.
 var enumDomains = map[string]map[string]struct{}{
 	"route":       setOf("A", "B"),
 	"exit_status": setOf("ok", "oom", "timeout", "sample_budget", "breaker", "rejected", "aborted", "error"),
 	"language":    setOf("promql", "logql", "traceql"),
+	"decision_reason": setOf(
+		// Eligible: the plan cleared every structural gate and the COST
+		// thresholds decided the route. Only these two are actionable evidence
+		// about where a routing threshold sits.
+		"below-threshold", "high-D",
+		// Routed: eligible and sharded.
+		"routed",
+		// Structurally refused: route B cannot take the plan at any threshold.
+		"instant", "instant-join", "not-sliceable", "now64",
+		"grid-mismatch", "incommensurate", "scalar-heavy",
+	),
 }
 
 func setOf(xs ...string) map[string]struct{} {
@@ -155,7 +184,7 @@ func knownColumn(name string) bool {
 	return ok
 }
 
-// isEnumColumn reports whether name is one of the three Enum-typed columns.
+// isEnumColumn reports whether name is a closed-domain column.
 func isEnumColumn(name string) bool {
 	return columnKinds[name] == ColumnEnum
 }

--- a/internal/routerrules/decision_reason_gate_test.go
+++ b/internal/routerrules/decision_reason_gate_test.go
@@ -1,0 +1,126 @@
+package routerrules
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/solver"
+)
+
+// costDeclinedReasons are the two solver reasons that mean "the plan was
+// ELIGIBLE for route B and the cost thresholds declined it". They are the only
+// reasons for which route_a_high_fanout_should_shard's advice — lower the
+// route-B threshold — can change the outcome.
+var costDeclinedReasons = map[string]bool{
+	solver.ReasonBelowThreshold: true,
+	solver.ReasonHighD:          true,
+}
+
+// TestDecisionReasonDomainMatchesSolverVocabulary pins the hand-maintained wire
+// contract between the solver's Reason* vocabulary and the decision_reason enum
+// domain this package declares. routerrules deliberately imports neither the
+// solver nor optcorpus in production code (see the CorpusTableName contract in
+// columns.go), so nothing but this test stops the two from drifting: a Reason
+// added to the solver but not here is a token no rule can ever name, and a token
+// here that the solver never emits is a rule that can never fire.
+func TestDecisionReasonDomainMatchesSolverVocabulary(t *testing.T) {
+	t.Parallel()
+
+	want := append([]string(nil), solver.Reasons...)
+	sort.Strings(want)
+	got := EnumDomain("decision_reason")
+
+	if len(got) != len(want) {
+		t.Fatalf("decision_reason domain has %d tokens, solver.Reasons has %d\n got: %v\nwant: %v",
+			len(got), len(want), got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("decision_reason domain drifted from solver.Reasons at %d: got %q, want %q\n got: %v\nwant: %v",
+				i, got[i], want[i], got, want)
+		}
+	}
+}
+
+// TestRouteAHighFanoutShouldShard_OnlyFiresOnCostDeclinedReasons is the
+// correctness gate on the rule's advice. Every solver reason gets its own
+// route-A class, all at the same well-above-floor fan-out, so the ONLY thing
+// separating them is decision_reason. The rule must fire for the two
+// cost-declined reasons and stay silent for every structural refusal: route B
+// cannot take a structurally refused plan at any threshold, so "consider routing
+// to B" there is wrong advice rather than weak advice.
+//
+// The instant class is the one this matters most for. An instant query's anchor
+// grid is a single point, so it can never shard — yet it is route A, and once
+// the classifier stamps its real cost grid onto the refusal (rather than four
+// zeros) its inner-spine fan-out is a real number that clears any floor.
+func TestRouteAHighFanoutShouldShard_OnlyFiresOnCostDeclinedReasons(t *testing.T) {
+	t.Parallel()
+
+	// A route-B population is required for fanout_route_b_floor to resolve at
+	// all — the param is scoped to route B, and an empty sub-population makes it
+	// no-signal, which skips the rule wholesale and would make this test vacuous.
+	const (
+		shardedFanout = 10  // every route-B row, so the p50 floor is exactly this
+		probeFanout   = 100 // every route-A probe row, comfortably above the floor
+		rowsPerClass  = 2
+	)
+
+	var rows []BenchRow
+	for range rowsPerClass {
+		rows = append(rows, BenchRow{
+			ShapeID: "probe:sharded", Language: "promql", Route: "B", KShards: 4,
+			Fanout: shardedFanout, DecisionReason: solver.ReasonRouted, ExitStatus: "ok",
+		})
+	}
+	for _, reason := range solver.Reasons {
+		if reason == solver.ReasonRouted {
+			continue // routed is a route-B outcome; it cannot be a route-A class
+		}
+		for range rowsPerClass {
+			rows = append(rows, BenchRow{
+				ShapeID: "probe:" + reason, Language: "promql", Route: "A",
+				Fanout: probeFanout, DecisionReason: reason, ExitStatus: "ok",
+			})
+		}
+	}
+
+	cat, err := LoadEmbeddedCatalog()
+	if err != nil {
+		t.Fatalf("load catalog: %v", err)
+	}
+	report, err := NewEvaluator(cat, evalConfig(), (&BenchCorpus{Rows: rows}).AsCorpusSource()).
+		Evaluate(context.Background(), EvalOptions{})
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+
+	fired := map[string]bool{}
+	for _, f := range report.Findings {
+		if f.RuleID == "route_a_high_fanout_should_shard" {
+			fired[f.GroupKey["shape_id"]] = true
+		}
+	}
+
+	sawFire := false
+	for _, reason := range solver.Reasons {
+		if reason == solver.ReasonRouted {
+			continue
+		}
+		got, want := fired["probe:"+reason], costDeclinedReasons[reason]
+		switch {
+		case want && !got:
+			t.Errorf("reason %q: rule did not fire; a plan the solver found eligible and declined on "+
+				"cost is exactly the population this rule exists to surface", reason)
+		case !want && got:
+			t.Errorf("reason %q: rule fired; route B cannot take a structurally refused plan at any "+
+				"threshold, so recommending a lower one is wrong advice", reason)
+		}
+		sawFire = sawFire || got
+	}
+	if !sawFire {
+		t.Fatal("the rule fired on no class at all — the fan-out floor or the corpus shape made this " +
+			"test vacuous rather than proving the reason gate")
+	}
+}

--- a/internal/routerrules/validate.go
+++ b/internal/routerrules/validate.go
@@ -178,7 +178,7 @@ func validateScope(owner string, scope Scope, add func(string, ...any)) {
 			continue
 		}
 		if !isEnumColumn(col) {
-			add("%q scope filters non-enum column %q (only route/exit_status/language may be scoped)", owner, col)
+			add("%q scope filters non-enum column %q (only closed-domain columns may be scoped)", owner, col)
 			continue
 		}
 		if !validEnumValue(col, val) {

--- a/internal/solver/decision.go
+++ b/internal/solver/decision.go
@@ -129,6 +129,28 @@ const (
 	ReasonInstantJoin = "instant-join"
 )
 
+// Reasons is the complete Reason vocabulary above, in declaration order.
+//
+// It exists because the vocabulary is MIRRORED outside this package — every
+// Decision reaches the calibration corpus, and internal/routerrules re-declares
+// the token set as the closed domain of the decision_reason column so a rule may
+// filter on it. That mirror is a hand-maintained wire contract (routerrules
+// deliberately imports neither the solver nor optcorpus), so it needs one
+// enumerable source to be pinned against; adding a Reason* const without adding
+// it here is what the lockstep test in that package catches.
+var Reasons = []string{
+	ReasonRouted,
+	ReasonBelowThreshold,
+	ReasonNotSliceable,
+	ReasonInstant,
+	ReasonHighD,
+	ReasonNow64,
+	ReasonGridMismatch,
+	ReasonIncommensurate,
+	ReasonScalarHeavy,
+	ReasonInstantJoin,
+}
+
 // Slice is one shard of the anchor-grid decomposition. Bounds are
 // anchor-grid-aligned; Plan is a re-anchored view of the optimized plan that
 // SHARES the immutable off-spine subtrees with the original (only the

--- a/internal/solver/decision_grid_instant_test.go
+++ b/internal/solver/decision_grid_instant_test.go
@@ -1,0 +1,237 @@
+package solver
+
+import (
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// The two distinct spine lookbacks the instant table below uses. Two values,
+// not one, so a classifier that stamped a single hard-coded duration onto every
+// instant refusal could not satisfy the table.
+const (
+	instantLookback     = 5 * time.Minute
+	longInstantLookback = time.Hour
+)
+
+// instantRangeWindow is how internal/promql lowers an instant range-vector call
+// (`rate(m[<lookback>])` evaluated through LowerAt): a matrix RangeWindow whose
+// Range is the lookback, whose End is the single eval instant, and whose Step /
+// Start / OuterRange are all left unset. That unset Step is exactly why GridOf
+// finds no carrier and reports a zero grid, which is what makes the request
+// meta's Step zero and the classification "instant".
+func instantRangeWindow(lookback time.Duration) *chplan.RangeWindow {
+	return &chplan.RangeWindow{
+		Input:           leafScan(),
+		Func:            "rate",
+		Range:           lookback,
+		End:             gridEnd,
+		TimestampColumn: "TimeUnix",
+		ValueColumn:     "Value",
+		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+	}
+}
+
+// instantAggregate wraps an instant range-vector call in the outer `sum(...)`
+// of the dominant dashboard shape.
+func instantAggregate(lookback time.Duration) chplan.Node {
+	return &chplan.Aggregate{
+		Input:    instantRangeWindow(lookback),
+		AggFuncs: []chplan.AggFunc{{Name: "sum", Args: []chplan.Expr{&chplan.ColumnRef{Name: "Value"}}}},
+	}
+}
+
+// TestDecision_CostGrid_PopulatedOnInstant pins the third corner of the
+// cost-grid contract, alongside the routed and route-A cases in
+// decision_grid_test.go: an INSTANT query's refusal must carry the plan's real
+// spine lookback.
+//
+// Every Decision reaches the calibration corpus, refusals included, and a
+// refusal recorded with an all-zero grid is unreplayable — it says "we
+// declined" without saying what we declined. CumulativeD is the whole answer
+// for an instant query (there is no anchor grid to measure), so a zero D makes
+// the instant population uninterpretable in aggregate.
+//
+// Each fixture derives its RequestMeta from GridOf exactly as engine.classify
+// derives it in production, never hand-setting Step, so every row proves it is
+// a GENUINE instant plan — one whose own grid is zero — rather than a
+// meta/plan disagreement that merely simulates one.
+func TestDecision_CostGrid_PopulatedOnInstant(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		plan  func() chplan.Node
+		wantD time.Duration
+	}{
+		{
+			name:  "bare instant range-vector call",
+			plan:  func() chplan.Node { return instantRangeWindow(instantLookback) },
+			wantD: instantLookback,
+		},
+		{
+			name:  "instant range-vector under an aggregate",
+			plan:  func() chplan.Node { return instantAggregate(instantLookback) },
+			wantD: instantLookback,
+		},
+		{
+			// A different lookback must produce a different D: the recorded
+			// value tracks the plan, it is not a constant.
+			name:  "long-lookback instant range-vector",
+			plan:  func() chplan.Node { return instantAggregate(longInstantLookback) },
+			wantD: longInstantLookback,
+		},
+		{
+			// An instant vector-vector binop lowers to a !StepAligned
+			// VectorJoin over two independent instant spines. D is the SUM of
+			// both arms' lookbacks, which is the cost the corpus needs — one
+			// arm's Range would understate it by half. The refusal reason
+			// stays "instant" (not "instant-join"): the Step<=0 gate is
+			// definitional and precedes the join gate.
+			name: "instant vector-vector binop over two spines",
+			plan: func() chplan.Node {
+				return &chplan.VectorJoin{
+					Left:             instantAggregate(instantLookback),
+					Right:            instantAggregate(instantLookback),
+					Op:               chplan.OpDiv,
+					MetricNameColumn: "MetricName",
+				}
+			},
+			wantD: 2 * instantLookback,
+		},
+		{
+			// A bare instant selector carries no windowed spine node at all,
+			// so its honest D is zero — the plan has no lookback to report.
+			// Pinned so a future reader knows an all-zero instant corpus row
+			// is still legitimate for this family, and is not evidence the
+			// grid was dropped.
+			name: "bare instant selector carries no spine lookback",
+			plan: func() chplan.Node {
+				return &chplan.Filter{
+					Input:     leafScan(),
+					Predicate: &chplan.Binary{Op: chplan.OpEq, Left: &chplan.ColumnRef{Name: "MetricName"}, Right: &chplan.LitString{V: "m"}},
+				}
+			},
+			wantD: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			plan := tc.plan()
+
+			// engine.classify builds RequestMeta from the plan's own grid
+			// carrier; mirroring that here is what makes the fixture honest.
+			start, end, step := GridOf(plan)
+			if step != 0 {
+				t.Fatalf("fixture is not an instant plan: GridOf step = %s, want 0", step)
+			}
+			meta := RequestMeta{Lang: LangPromQL, Start: start, End: end, Step: step}
+
+			p := &Planner{Cfg: autoCfg()}
+			_, decision, k, eligible := p.classify(plan, meta)
+
+			// The refusal itself is unchanged: instant queries never route.
+			if eligible {
+				t.Fatalf("instant plan reported eligible; it can never route B")
+			}
+			if k != 0 {
+				t.Errorf("k = %d, want 0 on an instant refusal", k)
+			}
+			if decision.Reason != ReasonInstant {
+				t.Fatalf("reason = %q, want %q", decision.Reason, ReasonInstant)
+			}
+			if decision.Strategy != "" {
+				t.Errorf("Strategy = %q, want empty on a refusal", decision.Strategy)
+			}
+
+			// The positive claim: the refusal carries the plan's real lookback.
+			if decision.CumulativeD != tc.wantD {
+				t.Errorf("CumulativeD = %s, want %s — an instant refusal recorded with a zero "+
+					"lookback is unreplayable in the calibration corpus",
+					decision.CumulativeD, tc.wantD)
+			}
+
+			// A genuine instant plan carries no anchor grid, so N/F/OuterRange
+			// and the request Step are zero because the PLAN and the REQUEST
+			// say so — not because analyze was skipped. Non-zero here is
+			// GridOf's silent-miss signature, pinned by the test below.
+			if decision.NAnchors != 0 || decision.Fanout != 0 ||
+				decision.OuterRange != 0 || decision.Step != 0 {
+				t.Errorf("instant decision carries an anchor grid: N=%d F=%d OuterRange=%s Step=%s, want all zero",
+					decision.NAnchors, decision.Fanout, decision.OuterRange, decision.Step)
+			}
+
+			// The same grid must survive both public entry points, which is
+			// where the engine actually reads the Decision from.
+			planD, planRouted := p.Plan(plan, meta)
+			eligD, eligRouted := p.Eligible(plan, meta)
+			for _, entry := range []struct {
+				name   string
+				d      *Decision
+				routed bool
+			}{
+				{"Plan", planD, planRouted},
+				{"Eligible", eligD, eligRouted},
+			} {
+				if entry.routed {
+					t.Errorf("%s: instant plan routed (K=%d)", entry.name, entry.d.K)
+					continue
+				}
+				if entry.d.Reason != ReasonInstant || entry.d.CumulativeD != tc.wantD {
+					t.Errorf("%s: reason=%q CumulativeD=%s, want %q / %s",
+						entry.name, entry.d.Reason, entry.d.CumulativeD, ReasonInstant, tc.wantD)
+				}
+			}
+		})
+	}
+}
+
+// TestDecision_CostGrid_InstantWithAnchorGridIsAMissedCarrier pins the
+// DETECTION signature the instant grid buys: a RANGE plan the classifier was
+// told is instant records reason=instant AND a non-zero anchor grid, so the two
+// populations stay separable in the corpus instead of collapsing onto one
+// all-zero row.
+//
+// The injection point is faithful, not contrived. engine.classify builds
+// RequestMeta.Step from solver.GridOf(plan) verbatim, so "GridOf missed the
+// carrier" IS "meta.Step == 0 for a plan whose own grid step is non-zero" —
+// exactly the state constructed here. What is NOT constructible is a plan that
+// makes GridOf miss: chplan's completeness ratchet closes the GridCarrier set,
+// so every grid-declaring node is visible to GridOf by construction
+// (TestGridOf_ReadsEveryCarrier pins that). This test therefore pins the
+// weaker, honest property — that such a miss would be DIAGNOSABLE from the
+// corpus rather than silent — which is the only half that is testable.
+func TestDecision_CostGrid_InstantWithAnchorGridIsAMissedCarrier(t *testing.T) {
+	t.Parallel()
+
+	plan := oomWindow()
+	if _, _, step := GridOf(plan); step == 0 {
+		t.Fatalf("fixture must be a RANGE plan for this to model a missed carrier")
+	}
+
+	// The meta a missed carrier would hand the Planner: zero step, real plan.
+	missedMeta := oomMeta()
+	missedMeta.Step = 0
+
+	d, routed := (&Planner{Cfg: autoCfg()}).Plan(plan, missedMeta)
+	if routed {
+		t.Fatalf("a zero-step request must never route (K=%d)", d.K)
+	}
+	if d.Reason != ReasonInstant {
+		t.Fatalf("reason = %q, want %q", d.Reason, ReasonInstant)
+	}
+	// The smoking gun: an instant row that nonetheless carries an anchor grid.
+	if d.NAnchors == 0 || d.Fanout == 0 || d.OuterRange == 0 {
+		t.Errorf("missed-carrier decision recorded N=%d F=%d OuterRange=%s; a corpus row with "+
+			"reason=instant and an all-zero grid is indistinguishable from a genuine instant query",
+			d.NAnchors, d.Fanout, d.OuterRange)
+	}
+	if d.Step != 0 {
+		t.Errorf("Step = %s, want 0 — Step mirrors the REQUEST grid, which is what went missing", d.Step)
+	}
+}

--- a/internal/solver/planner.go
+++ b/internal/solver/planner.go
@@ -154,16 +154,33 @@ func (p *Planner) sliceAndDecide(plan chplan.Node, meta RequestMeta, sig signals
 // Cfg.MinAnchorsPerSlice) — no caller trusts a Decision computed at an
 // earlier point in time or against a different plan.
 func (p *Planner) classify(plan chplan.Node, meta RequestMeta) (sig signals, decision *Decision, k int64, eligible bool) {
-	// (2)-prefix: instant queries are never time-slice routed.
-	// Step == 0 means an instant evaluation; there is no anchor grid. The
-	// analyze pass below derives the cost grid (N/F/D/OuterRange); it has not
-	// run yet here, so the only meaningful scalar is Step (zero on an instant
-	// query). costGrid threads whatever the empty signals carry plus meta.Step.
-	if meta.Step <= 0 {
-		return signals{}, notRouted(ReasonInstant).withGrid(signals{}, meta), 0, false
-	}
-
+	// analyze runs FIRST, before any gate, so every Decision this classifier
+	// returns carries the plan's real cost grid — including the ones that
+	// refuse. The calibration corpus exists to replay routing decisions
+	// offline, and a refusal recorded with a zero grid is unreplayable: it
+	// says "we declined" without saying what we declined. analyze is a pure
+	// signal-gathering walk (it makes no routing decision and mutates no
+	// state), so hoisting it above the gates changes no outcome.
 	sig = p.analyze(plan, meta)
+
+	// (2)-prefix: instant queries are never time-slice routed. Step == 0 means
+	// an instant evaluation: the anchor grid is a single point (N = 1), and
+	// route B's only decomposition is anchor-grid partitioning (slicer.go),
+	// which needs N >= 2 to produce more than one shard. The refusal is
+	// definitional, so it is checked before the correctness gates.
+	//
+	// The grid this stamps is load-bearing for the corpus in two ways. It
+	// records the spine lookback (cumulativeD) that decides whether an instant
+	// query is heavy enough to be worth a different decomposition at all — a
+	// question the zero grid could not even be asked. And it makes GridOf's
+	// silent-miss failure mode (solver.go: a grid carrier not found leaves
+	// step == 0, so a RANGE query is classified instant) visible in the
+	// corpus: a genuine instant query records no anchor grid because its plan
+	// carries none, whereas a missed carrier records reason=instant alongside
+	// a non-zero N/F/OuterRange from the plan itself.
+	if meta.Step <= 0 {
+		return sig, notRouted(ReasonInstant).withGrid(sig, meta), 0, false
+	}
 
 	// (1) Slice-invariance: any unmarked node anywhere → route A.
 	if !sig.allSliceInvariant {
@@ -258,8 +275,10 @@ func (p *Planner) classify(plan chplan.Node, meta RequestMeta) (sig signals, dec
 }
 
 // notRouted builds a non-route Decision carrying only the reason. Callers
-// chain .withGrid(sig, meta) to attach the cost-grid readout once analyze
-// has run; the pre-analyze instant guard passes empty signals.
+// chain .withGrid(sig, meta) to attach the cost-grid readout. Every caller
+// inside classify runs after analyze, so no refusal is stamped with an empty
+// grid; Eligible's ModeSingle short-circuit is the one site that returns
+// before classify at all, and it documents its own zero grid.
 func notRouted(reason string) *Decision {
 	return &Decision{Reason: reason}
 }

--- a/test/regression/router_corpus_seed_test.go
+++ b/test/regression/router_corpus_seed_test.go
@@ -14,21 +14,16 @@ import (
 const routerCorpusSeed = "../../internal/routerrules/testdata/seed.jsonl"
 
 // validRouterDecisionReasons is the closed set of decision_reason tokens the
-// production solver actually emits (internal/solver/decision.go Reason* consts).
-// Importing the consts directly means a solver rename surfaces here as a compile
-// break, not a silent seed/production drift.
+// production solver actually emits. It is derived from solver.Reasons rather
+// than re-listed here: a hand-copied list only catches a RENAME (as a compile
+// break) and silently misses an ADDITION, which is how this set drifted a
+// Reason behind the solver once already.
 func validRouterDecisionReasons() map[string]struct{} {
-	return map[string]struct{}{
-		solver.ReasonRouted:         {},
-		solver.ReasonBelowThreshold: {},
-		solver.ReasonNotSliceable:   {},
-		solver.ReasonInstant:        {},
-		solver.ReasonHighD:          {},
-		solver.ReasonNow64:          {},
-		solver.ReasonGridMismatch:   {},
-		solver.ReasonIncommensurate: {},
-		solver.ReasonScalarHeavy:    {},
+	m := make(map[string]struct{}, len(solver.Reasons))
+	for _, r := range solver.Reasons {
+		m[r] = struct{}{}
 	}
+	return m
 }
 
 // TestRouterCorpusSeedUsesRealDecisionReasons pins the routerrules seed corpus


### PR DESCRIPTION
## The blind spot

`Planner.classify` returned an empty `signals{}` for the instant gate — *before*
the `analyze` pass had run — so `withGrid` stamped four zeros onto every instant
`Decision` that reached `otel.cerberus_router_corpus`.

The corpus exists to replay routing decisions offline. A refusal recorded with a
zero grid is unreplayable: it says *we declined* without saying *what* we
declined, which is indistinguishable from a plan that genuinely had no geometry.

`analyze` is a pure signal-gathering walk — it makes no routing decision and
mutates no state — so hoisting it above the gates is behaviour-preserving. It is
now the first thing `classify` does, and every `Decision` carries the plan's real
`N` / `F` / `D` / `OuterRange` / `Step`.

Two things follow:

* **Instant queries get an interpretable cost.** `CumulativeD` is the whole
  answer for an instant query — there is no anchor grid to measure — and
  `recordRangeWindow` accumulates it unguarded by `Step > 0`, so the spine
  lookback was there all along and was simply thrown away.
* **`GridOf`'s silent-miss mode becomes diagnosable.** A range query whose grid
  carrier the classifier fails to find is classified instant. It now records
  `reason=instant` next to a non-zero `N`/`F`/`OuterRange` that a genuine instant
  query cannot have, so the two populations stay separable in the corpus instead
  of collapsing onto one all-zero row.

This is the only blind spot of its kind on the write path. `Plan`'s `ModeSingle`
branch already passes the real signals, and `Eligible`'s zero-grid `Decision` is
discarded on `!eligible` before it reaches telemetry.

## The defect recording the geometry exposes

`route_a_high_fanout_should_shard` gated on `route == A AND fanout >= floor` and
nothing else. Its advice is *lower the route-B threshold*, which can only change
the outcome for a plan the solver found **eligible** and then declined on cost —
`below-threshold` and `high-D`. Every other reason is a **structural** refusal:
route B cannot take an instant query, a `now64` plan, or a non-slice-invariant
plan at *any* threshold, so the same advice there is wrong rather than weak.

`not-sliceable` and `now64` rows already polluted that population. The instant
rows this PR gives real fan-out to would have enlarged it several-fold. The rule
now carries a positive `decision_reason` leaf, stated as membership rather than
exclusion, so a `Reason` added to the solver later is excluded by default instead
of silently joining the population.

That required promoting `decision_reason` from `ColumnGroup` to `ColumnEnum`.
Its storage type is `LowCardinality(String)`, but its *writer-side* vocabulary is
the solver's closed `Reason*` set, so a condition on it can be validated exactly
like `route` or `exit_status` — membership in the enum kind is about whether the
domain is closed, not about the ClickHouse type. `solver.Reasons` now exposes
that set as one enumerable list, which also replaces the hand-copied mirror in
`test/regression` that had already drifted a `Reason` behind (`instant-join` was
missing — precisely the failure mode a hand-copied list cannot catch, since a
rename breaks the build but an addition is silent).

`catalogVersion` goes to 3: a narrowed population is a change an operator needs
to be able to attribute to the catalog rather than to their own corpus moving.

## Operator-visible behaviour change

`d_high_watermark` is a percentile over `cumulative_d` across all `promql` rows.
Instant rows were the large majority of that population on a reference
deployment, every one of them at a fabricated zero. Once they carry real values
the watermark **rises** (measured there: q95 3×, q99 6×), so its only consumer,
`heavy_shape_geometry_failing`, fires **less**.

That is a correction, not a regression — the watermark was previously fit
against fiction. It is called out explicitly because it is a live autotune
behaviour change that a reader of the diff would not otherwise predict.

## Not in scope (routed to a follow-up)

`Solver.Classify` only classifies PromQL, so every `logql` and `traceql` row
carries `cumulative_d = 0` and an empty `decision_reason`. Their
`d_high_watermark` is therefore 0 and `cumulative_d >= 0` is vacuously true,
which degenerates `heavy_shape_geometry_failing` into "every oom/timeout row
fires" for those two heads. Same class — unclassified rows polluting a percentile
fit — different mechanism: the honest fix is for `corpus_percentile` to exclude
unclassified rows, which is a change to the param resolver rather than to the
solver. This PR does not make it worse.

## Tests

* `internal/solver/decision_grid_instant_test.go` — the third corner of the
  cost-grid contract. Each fixture derives its `RequestMeta` from `GridOf`
  exactly as `engine.classify` does, so every row proves it is a *genuine*
  instant plan rather than a meta/plan disagreement that merely simulates one.
  Two distinct lookbacks, so a classifier stamping one hard-coded duration could
  not satisfy the table; a V-V binop case pinning that `D` sums both arms; and a
  bare-selector case pinning that an all-zero instant row is still legitimate
  when the plan carries no spine.
* `internal/routerrules/decision_reason_gate_test.go` — every solver reason gets
  its own route-A class at the same above-floor fan-out, so `decision_reason` is
  the only variable. Verified as a real gate: deleting the leaf makes all seven
  structural reasons fire.

## Second commit — three residual defects of the same class

An adversarial review pass over the first commit found three more places where
a `Decision` records a conclusion the classifier never reached.

* **`Eligible`'s `ModeSingle` short-circuit ran before `classify`**, so it was
  the one remaining zero-grid site in the package. On the same plan the two
  public entry points disagreed: `Plan` reported `N=241 F=20 D=5m
  OuterRange=1h`, `Eligible` reported all zeros. `classify` now runs first at
  both seams, so correctness is by construction rather than by inspecting every
  caller. The cost is one pure tree walk on a deployment that will refuse anyway.
* **Both `ModeSingle` sites recorded `below-threshold`**, which asserts a
  threshold was evaluated and the plan fell under it. `Mode=single` is the
  ship-dark default and the documented operator kill-switch — no threshold is
  consulted at all. Those rows were seeding `route_a_high_fanout_should_shard`,
  whose advice is *lower the route-B threshold*, with a population that cannot
  support it: the rule would have fired hardest on exactly the deployments where
  route B is switched off. New token `routing-disabled`.
* **The missed-carrier signature was stated with one conjunct too few.**
  `reason=instant` is also emitted for a *range* request carrying an unpinned or
  instant-shaped window, and that one has a real grid — so `reason=instant`
  beside a populated grid is ordinary, not a missed carrier. The discriminator is
  a non-zero `N`/`F`/`OuterRange` beside a **zero `Step`**. The test already
  asserted both conjuncts; the prose around it did not.

Plus a correctness fix to three comments and one doc line claiming `high-D`
folds into `below-threshold` on the shadow header. It does not — `engine.go`
emits `d.Reason` verbatim, and `TestDecision_CostGrid_HighDNotFoldedIntoReason`
has been pinning that all along. What folds is the *route* token, where every
non-route reason collapses to `A`.

New tests: `internal/solver/decision_grid_modesingle_test.go` — the two entry
points must agree field-by-field on the grid under `Mode=single` (with an
anti-tautology guard that the fixture carries geometry to lose), and the refusal
must read `routing-disabled`.
