### PR TITLE
fix(solver): distinguish routing-disabled from below-threshold

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -200,8 +200,10 @@ on any diff vs reference Prometheus.
 **Shadow header.** Every response to a PromQL `query_range` carries the
 additive `X-Cerberus-Route-Decision` header reporting the per-request
 classification regardless of mode: `routed` (took route B),
-`below-threshold`, `instant`, `not-sliceable`, `high-D`, `now64`,
-`grid-mismatch`, `incommensurate`, or `scalar-heavy`. The header is **omitted**
+`below-threshold`, `instant`, `instant-join`, `not-sliceable`, `high-D`,
+`now64`, `grid-mismatch`, `incommensurate`, `scalar-heavy`, or
+`routing-disabled` (the reason recorded under `single`, where no threshold is
+consulted at all). The header is **omitted**
 for non-PromQL heads and when the solver is fully off (nil). It is purely
 diagnostic — observe it to see what the solver would do (under `single`) or
 did (under `auto`) without changing the wire body.

--- a/docs/router-calibration.sql
+++ b/docs/router-calibration.sql
@@ -5,7 +5,7 @@
 -- DECISION the pure classifier made (internal/solver Planner.Plan) to the
 -- OBSERVED ClickHouse cost it actually paid (read_rows / read_bytes /
 -- query_duration_ms / memory_usage / exit_status). route = 'A' is a single CH
--- query (not routed / below-threshold); route = 'B' is a time-slice sharded
+-- query (any decision_reason other than 'routed'); route = 'B' is a sharded
 -- query (routed). N/F/D are the RAW classifier scalars (n_anchors / fanout /
 -- cumulative_d) recorded for BOTH routes.
 --

--- a/docs/router-rules.md
+++ b/docs/router-rules.md
@@ -244,7 +244,7 @@ scalar) — context, never a gate, so no inline tolerance number is needed.
 `decision_reason` is the shadow-header value the solver records to explain each
 routing decision (`routed`, `below-threshold`, `not-sliceable`, `instant`,
 `instant-join`, `high-D`, `now64`, `grid-mismatch`, `incommensurate`,
-`scalar-heavy`; see
+`scalar-heavy`, `routing-disabled`; see
 [`internal/solver/decision.go`](../internal/solver/decision.go)). Its primary
 use is **grouping / attribution**: the failure rules group by it so the operator
 can see *which solver path* produced the failure and pick the right lever (shard

--- a/docs/solver.md
+++ b/docs/solver.md
@@ -87,13 +87,15 @@ the plan stays on route A. Under `auto`, an eligible plan routes only when
 `F ≥ MinFanout`, `N×F ≥ MinAnchorPairs`, and `K ≥ 2`. Under `sharded` the cost
 thresholds drop to the floor, so every eligible plan routes at `K_min = 2`
 (ineligible plans always stay on A — the force knob never breaks anything).
-Under `single` the Planner classifies but never routes.
+Under `single` the Planner classifies but never routes, and records
+`routing-disabled` — not `below-threshold`, which would claim a threshold was
+consulted when none was.
 
 Every classification — routed or not — produces a `Decision` carrying the
 reason (`routed`, `below-threshold`, `not-sliceable`, `instant`, `instant-join`,
-`high-D`, `now64`, `grid-mismatch`, `incommensurate`, `scalar-heavy`) for the
-shadow header, alongside the plan's cost grid (`N`, `F`, `D`, `OuterRange`,
-`Step`).
+`high-D`, `now64`, `grid-mismatch`, `incommensurate`, `scalar-heavy`,
+`routing-disabled`) for the shadow header, alongside the plan's cost grid
+(`N`, `F`, `D`, `OuterRange`, `Step`).
 
 The grid is populated on **every** Decision, including the refusals. The signal
 walk that derives it makes no routing decision and mutates nothing, so it runs
@@ -102,8 +104,11 @@ corpus replayable: a refusal recorded with a zero grid says "we declined"
 without saying what we declined, which is indistinguishable from a plan that
 genuinely had no geometry. It also makes one silent failure mode legible — a
 range query whose grid carrier the classifier fails to find looks instant, and
-now records `reason=instant` next to a non-zero `N`/`F`/`OuterRange` that a
-genuine instant query could not have.
+now records a non-zero `N`/`F`/`OuterRange` next to a zero `Step`, which a
+genuine instant query cannot have. Both halves of that signature matter:
+`reason=instant` is also recorded for a range request carrying an unpinned or
+instant-shaped window, and that one has a real grid — it is the zero `Step`
+beside a populated grid that identifies a missed carrier.
 
 ## Slicing geometry
 
@@ -562,8 +567,9 @@ To answer it the engine closes the loop the optimization corpus
   alongside `Strategy` / `K` / `Reason`, populated for **both** routed and
   not-routed decisions. The overlap analysis compares route-A and route-B cost
   at equal `(N, F, D)`, so route A must record its grid too. Buckets key on the
-  raw scalars, never on `Reason` — the not-routed shadow header folds the
-  high-`D` class into `below-threshold`, so the reason string alone hides it.
+  raw scalars, never on `Reason` — the reason names WHICH gate refused a plan,
+  not where that plan sat relative to it, and a counterfactual re-fit needs the
+  latter.
 - **Join to observed cost.** At the dispatch seam the engine hands the corpus
   reconciler the decision read-out next to the CH `query_id`. The reconciler
   joins `query_id` → `system.query_log` (the cost columns plus a derived

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -330,8 +330,8 @@ const routeSecond = int64(time.Second)
 // columns empty. Durations (D / OuterRange / Step) are reported in whole
 // seconds to match the UInt32 corpus columns. The Route enum is "B" on a true
 // route (Strategy set), "A" otherwise — read from the recorded Strategy, never
-// the Reason string, so the high-D / below-threshold fold cannot misclassify
-// the route.
+// the Reason string, so a Reason added to the solver later cannot be misread as
+// a route.
 func routeFeatures(d *solver.Decision) (present bool, route string, nAnchors, fanout, cumulativeD, outerRange, step uint32, kShards uint8, reason string) {
 	if d == nil {
 		return false, "", 0, 0, 0, 0, 0, 0, ""

--- a/internal/engine/solver_wiring_test.go
+++ b/internal/engine/solver_wiring_test.go
@@ -193,8 +193,9 @@ func TestSolver_SingleMode_ShadowHeaderReportsClassification(t *testing.T) {
 	if !ok {
 		t.Fatalf("shadow header %s missing; headers=%v", engine.HeaderRouteDecision, res.Headers)
 	}
-	// Mode=single classifies an eligible plan as route-a / below-threshold.
-	const want = "route-a;reason=" + solver.ReasonBelowThreshold
+	// Mode=single classifies an eligible plan as route-a / routing-disabled:
+	// no threshold was consulted, so the header must not claim one refused it.
+	const want = "route-a;reason=" + solver.ReasonRoutingDisabled
 	if got != want {
 		t.Errorf("shadow header: got %q, want %q", got, want)
 	}

--- a/internal/optcorpus/optcorpus.go
+++ b/internal/optcorpus/optcorpus.go
@@ -42,9 +42,9 @@ import (
 // behavior. The features are present for BOTH route A (not-routed,
 // below-threshold) and route B (routed) decisions, because the overlap
 // analysis compares the cost distributions of the two routes at equal
-// (N, F, D). Buckets are keyed on the RAW scalars, never on Reason: the
-// not-routed shadow header folds the high-D class into below-threshold, so the
-// reason string alone hides it.
+// (N, F, D). Buckets are keyed on the RAW scalars, never on Reason: the reason
+// names WHICH gate refused a plan, not where that plan sat relative to it, and
+// a counterfactual re-fit needs the latter.
 type RouteFeatures struct {
 	// Route is "A" (single CH query) or "B" (time-slice sharded). It is the
 	// route the classifier actually chose for this dispatch.

--- a/internal/routerrules/columns.go
+++ b/internal/routerrules/columns.go
@@ -150,6 +150,9 @@ var enumDomains = map[string]map[string]struct{}{
 		// Structurally refused: route B cannot take the plan at any threshold.
 		"instant", "instant-join", "not-sliceable", "now64",
 		"grid-mismatch", "incommensurate", "scalar-heavy",
+		// Routing switched off deployment-wide: the plan was classified but no
+		// threshold was consulted, so the row says nothing about where one sits.
+		"routing-disabled",
 	),
 }
 

--- a/internal/solver/decision.go
+++ b/internal/solver/decision.go
@@ -62,10 +62,14 @@ type Decision struct {
 	// of values already derived in the eligibility pass — recording them
 	// changes no routing behavior.
 	//
-	// The corpus buckets on these RAW scalars, never on Reason: ReasonHighD
-	// folds into ReasonBelowThreshold on the not-routed shadow header, so the
-	// Reason string alone hides the high-D class. NAnchors / Fanout /
-	// CumulativeD / OuterRange / Step carry the unfolded signal.
+	// The corpus buckets on these RAW scalars, never on Reason. Reason is
+	// recorded verbatim and does distinguish the classes from each other —
+	// below-threshold, high-D, and the structural refusals are separate
+	// tokens — but it says nothing about WHERE a plan sat relative to the
+	// threshold that refused it, which is the quantity a counterfactual
+	// re-fit needs. NAnchors / Fanout / CumulativeD / OuterRange / Step carry
+	// that. (What does fold is the ROUTE token: every non-route reason
+	// collapses to "A".)
 	NAnchors    int           // N = OuterRange/Step + 1 (outermost spine)
 	Fanout      int64         // F = max(Range/Step or Lookback/Step) over windows
 	CumulativeD time.Duration // D = Σ spine lookback (Range / Lookback)
@@ -120,6 +124,13 @@ const (
 	// cannot pay for replicating it.
 	ReasonScalarHeavy = "scalar-heavy"
 
+	// ReasonRoutingDisabled: Cfg.Mode is "single" — the operator switched
+	// routing off deployment-wide, so the plan was classified but no cost
+	// threshold was ever consulted. Distinct from ReasonBelowThreshold, which
+	// asserts a threshold WAS evaluated and the plan fell under it: a corpus
+	// row is evidence about where the threshold sits only in the latter case.
+	ReasonRoutingDisabled = "routing-disabled"
+
 	// ReasonInstantJoin: an instant-mode (StepAligned==false) VectorJoin. The
 	// VectorJoin node kind is registered slice-invariant, but the instant shape
 	// synthesizes its join-side timestamp with now64(9) in the emitted SQL — a
@@ -148,6 +159,7 @@ var Reasons = []string{
 	ReasonGridMismatch,
 	ReasonIncommensurate,
 	ReasonScalarHeavy,
+	ReasonRoutingDisabled,
 	ReasonInstantJoin,
 }
 

--- a/internal/solver/decision_grid_modesingle_test.go
+++ b/internal/solver/decision_grid_modesingle_test.go
@@ -1,0 +1,102 @@
+package solver
+
+import "testing"
+
+// TestDecision_CostGrid_PopulatedUnderModeSingle pins that the operator
+// kill-switch does not blind the calibration corpus.
+//
+// Mode=single is the ship-dark default: the Planner still classifies every
+// plan, and every one of those Decisions reaches otel.cerberus_router_corpus.
+// A deployment that has never enabled routing is exactly the one whose corpus
+// an operator reads to decide whether to enable it, so a zero grid there is
+// not a harmless omission — it is the whole dataset.
+//
+// The two public entry points reach the mode gate by different paths (Plan's
+// classification seam, Eligible's route-memo seam) and must not disagree about
+// the same plan's geometry.
+func TestDecision_CostGrid_PopulatedUnderModeSingle(t *testing.T) {
+	t.Parallel()
+
+	cfg := DefaultConfig() // Mode == single
+	p := &Planner{Cfg: cfg}
+	plan, meta := oomWindow(), oomMeta()
+
+	// The grid the classifier actually computed for this plan, read back
+	// through the same withGrid production uses. Compared field-by-field
+	// below rather than against hard-coded numbers, so the test tracks the
+	// fixture instead of duplicating it.
+	sig, _, _, eligible := p.classify(plan, meta)
+	if !eligible {
+		t.Fatalf("fixture must be an ELIGIBLE plan so the ModeSingle branch is the one that refuses it")
+	}
+	want := (&Decision{}).withGrid(sig, meta)
+
+	// Anti-tautology guard: an all-zero grid would make the comparison below
+	// vacuous, so pin that the fixture carries real geometry to lose.
+	if want.NAnchors == 0 || want.Fanout == 0 || want.CumulativeD == 0 ||
+		want.OuterRange == 0 || want.Step == 0 {
+		t.Fatalf("fixture carries no geometry: N=%d F=%d D=%s OuterRange=%s Step=%s",
+			want.NAnchors, want.Fanout, want.CumulativeD, want.OuterRange, want.Step)
+	}
+
+	planD, planRouted := p.Plan(plan, meta)
+	eligD, eligRouted := p.Eligible(plan, meta)
+
+	for _, entry := range []struct {
+		name   string
+		d      *Decision
+		routed bool
+	}{
+		{"Plan", planD, planRouted},
+		{"Eligible", eligD, eligRouted},
+	} {
+		if entry.routed {
+			t.Fatalf("%s() routed under Mode=single — ship-dark guarantee broken", entry.name)
+		}
+		if entry.d == nil {
+			t.Fatalf("%s() returned a nil Decision", entry.name)
+		}
+		if entry.d.NAnchors != want.NAnchors || entry.d.Fanout != want.Fanout ||
+			entry.d.CumulativeD != want.CumulativeD || entry.d.OuterRange != want.OuterRange ||
+			entry.d.Step != want.Step {
+			t.Errorf("%s() grid = N=%d F=%d D=%s OuterRange=%s Step=%s, want N=%d F=%d D=%s OuterRange=%s Step=%s",
+				entry.name,
+				entry.d.NAnchors, entry.d.Fanout, entry.d.CumulativeD, entry.d.OuterRange, entry.d.Step,
+				want.NAnchors, want.Fanout, want.CumulativeD, want.OuterRange, want.Step)
+		}
+	}
+}
+
+// TestModeSingle_RefusalIsRoutingDisabledNotBelowThreshold pins the reason a
+// kill-switched deployment records.
+//
+// below-threshold asserts something specific: a cost threshold WAS evaluated
+// and this plan fell under it. That makes the row evidence about where the
+// threshold sits, and rules whose advice is "move the threshold" select on it.
+// Under Mode=single no threshold is consulted at all, so recording
+// below-threshold would seed those rules with a population that cannot support
+// their advice — the same defect as the zero cost grid, one field over: a
+// Decision claiming a conclusion the classifier never reached.
+func TestModeSingle_RefusalIsRoutingDisabledNotBelowThreshold(t *testing.T) {
+	t.Parallel()
+
+	cfg := DefaultConfig() // Mode == single
+	p := &Planner{Cfg: cfg}
+	plan, meta := oomWindow(), oomMeta()
+
+	for _, entry := range []struct {
+		name string
+		call func() (*Decision, bool)
+	}{
+		{"Plan", func() (*Decision, bool) { return p.Plan(plan, meta) }},
+		{"Eligible", func() (*Decision, bool) { return p.Eligible(plan, meta) }},
+	} {
+		d, routed := entry.call()
+		if routed || d == nil {
+			t.Fatalf("%s() = routed=%v decision=%v, want a non-nil refusal", entry.name, routed, d)
+		}
+		if d.Reason != ReasonRoutingDisabled {
+			t.Errorf("%s() reason = %q, want %q", entry.name, d.Reason, ReasonRoutingDisabled)
+		}
+	}
+}

--- a/internal/solver/planner.go
+++ b/internal/solver/planner.go
@@ -46,9 +46,12 @@ func (p *Planner) Plan(plan chplan.Node, meta RequestMeta) (*Decision, bool) {
 		return decision, false
 	}
 
-	// "single" classifies but never routes.
+	// "single" classifies but never routes. The reason is routing-disabled,
+	// NOT below-threshold: no threshold was consulted, so this row is not
+	// evidence about where the threshold sits and must not join a population
+	// whose advice is "move the threshold".
 	if p.Cfg.Mode == ModeSingle {
-		return notRouted(ReasonBelowThreshold).withGrid(sig, meta), false
+		return notRouted(ReasonRoutingDisabled).withGrid(sig, meta), false
 	}
 
 	if p.Cfg.Mode == ModeAuto {
@@ -98,12 +101,17 @@ func (p *Planner) Plan(plan chplan.Node, meta RequestMeta) (*Decision, bool) {
 // live-edge freshness, or corroboration — the caller applies its own gates
 // for those before dispatching.
 func (p *Planner) Eligible(plan chplan.Node, meta RequestMeta) (*Decision, bool) {
-	if p.Cfg.Mode == ModeSingle {
-		return notRouted(ReasonBelowThreshold).withGrid(signals{}, meta), false
-	}
+	// classify runs before the mode gate so this seam and Plan's cannot
+	// disagree about the same plan's geometry. Classification is a pure
+	// signal-gathering walk with no side effects, so running it on a
+	// deployment that will refuse anyway costs one tree walk and buys a
+	// corpus row that is honest about what was refused.
 	sig, decision, k, eligible := p.classify(plan, meta)
 	if !eligible {
 		return decision, false
+	}
+	if p.Cfg.Mode == ModeSingle {
+		return notRouted(ReasonRoutingDisabled).withGrid(sig, meta), false
 	}
 	return p.sliceAndDecide(plan, meta, sig, k)
 }
@@ -176,8 +184,15 @@ func (p *Planner) classify(plan chplan.Node, meta RequestMeta) (sig signals, dec
 	// silent-miss failure mode (solver.go: a grid carrier not found leaves
 	// step == 0, so a RANGE query is classified instant) visible in the
 	// corpus: a genuine instant query records no anchor grid because its plan
-	// carries none, whereas a missed carrier records reason=instant alongside
-	// a non-zero N/F/OuterRange from the plan itself.
+	// carries none, whereas a missed carrier records a non-zero N/F/OuterRange
+	// from the plan itself NEXT TO a zero Step.
+	//
+	// Both conjuncts are needed. reason=instant is also emitted further down
+	// (the sawUnpinnedBound / sawInstantWindow gate), and that one fires on a
+	// genuine RANGE request — non-zero Step, real grid — so reason=instant
+	// beside a populated grid is ordinary, not a missed carrier. It is
+	// reason=instant beside a ZERO Step and a non-zero grid that cannot happen
+	// any other way.
 	if meta.Step <= 0 {
 		return sig, notRouted(ReasonInstant).withGrid(sig, meta), 0, false
 	}
@@ -207,10 +222,10 @@ func (p *Planner) classify(plan chplan.Node, meta RequestMeta) (sig signals, dec
 	// wall-clock the plan-level now64 scanner never sees (it is minted in the
 	// SQL, not carried as a chplan FuncCall). Only the StepAligned (range-mode)
 	// join step-aligns on the real per-anchor TimestampColumn and is safe to
-	// slice; the instant shape fails closed to route A. Plan's Step<=0 guard
-	// already rejects instant *queries* before analyze, but a !StepAligned join
-	// can appear under a range-mode request, so this guard is both the
-	// load-bearing fail-close AND honest telemetry.
+	// slice; the instant shape fails closed to route A. The Step<=0 gate above
+	// already rejects instant *queries*, but a !StepAligned join can appear
+	// under a range-mode request, so this guard is both the load-bearing
+	// fail-close AND honest telemetry.
 	if sig.sawInstantVectorJoin {
 		return sig, notRouted(ReasonInstantJoin).withGrid(sig, meta), 0, false
 	}


### PR DESCRIPTION
Follow-up to #1384. An adversarial review pass over that diff found three more
places where a `Decision` records a conclusion the classifier never reached —
the same class #1384 exists to fix. #1384 auto-merged on its first commit
before these landed.

## `Eligible`'s `ModeSingle` short-circuit ran before `classify`

It was the one remaining zero-grid site in the package. On the same plan the two
public entry points disagreed:

```text
PLAN-MODESINGLE:     reason="below-threshold" N=241 F=20 D=5m0s OuterRange=1h0m0s Step=15s
ELIGIBLE-MODESINGLE: reason="below-threshold" N=0   F=0  D=0s   OuterRange=0s     Step=15s
```

`classify` now runs first at both seams, so no site can return a grid it did not
compute — correctness by construction rather than by inspecting every caller.
The cost is one pure tree walk on a deployment that will refuse anyway. Routing
behaviour is unchanged: both paths already returned `false`, and the caller
discards the `Decision` on `!eligible`.

## Both `ModeSingle` sites recorded `below-threshold`

That token asserts something specific — a cost threshold *was* evaluated and the
plan fell under it — which is what makes such a row evidence about where the
threshold sits. `Mode=single` is the ship-dark default and the documented
operator kill-switch: no threshold is consulted at all.

So those rows were seeding `route_a_high_fanout_should_shard` — whose advice is
*lower the route-B threshold* — with a population that cannot support it. The
rule #1384 had just narrowed for exactly this reason would have fired hardest on
the deployments where route B is switched off. New token `routing-disabled`,
added to `solver.Reasons` and to the closed `decision_reason` domain in
`internal/routerrules`.

## The missed-carrier signature was stated with one conjunct too few

`reason=instant` has two emit sites. The second (`sawUnpinnedBound ||
sawInstantWindow`) fires on a genuine **range** request, so it carries a
non-zero `Step` and a real grid — `reason=instant` beside a populated grid is
ordinary, not a missed carrier. The discriminator is a non-zero
`N`/`F`/`OuterRange` beside a **zero `Step`**.

The test already asserted both conjuncts; the prose around it did not. Fixed in
`planner.go`, `docs/solver.md`, and the doc comment.

## `high-D` does not fold into `below-threshold`

Three comments and one doc line claimed the not-routed shadow header folds the
high-D class into below-threshold. It does not — `engine.go:126` emits
`d.Reason` verbatim, and `TestDecision_CostGrid_HighDNotFoldedIntoReason` has
been pinning that all along. What folds is the *route* token, where every
non-route reason collapses to `A`. Corrected at all four sites; the real reason
the corpus buckets on raw scalars is that a reason names *which* gate refused a
plan, not *where* that plan sat relative to it.

## Tests

`internal/solver/decision_grid_modesingle_test.go` — the two entry points must
agree field-by-field on the grid under `Mode=single`, with an anti-tautology
guard that the fixture carries geometry to lose; and the refusal must read
`routing-disabled`. `internal/engine/solver_wiring_test.go` updates the shadow
header it pins to match.
