### PR TITLE
fix(ci): pre-release audit fixes for v1.14.0

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -219,7 +219,7 @@ uncomputable-diff fallback — cannot drift between the lanes that use it.
   - Exit: `0` clean / matrix emitted; `1` on a table violation, a coverage gap,
     or a bad `MODE`.
   - Tests: `node --test .github/scripts/mutation-matrix.test.mjs` (run by the
-    `check` job).
+    `forbid-skip` job).
 - **`release-version-gate.mjs`** — `release.yml`, the `gate` job (app side).
   The publish-on-merge pipeline ships when a validated `release/*` PR is MERGED
   to main (not on a raw pushed tag — that trigger is retired). On the resulting
@@ -512,7 +512,7 @@ uncomputable-diff fallback — cannot drift between the lanes that use it.
   one that fails on its own when the cask installed but could not link). Pure
   export `upgradeOutcomeProblems({updateOutput, caskList, reportedVersion,
   expectedVersion})`, covered by `brew-upgrade-path.test.mjs` on the required
-  `check` lane and as the job's own first step.
+  `lint` job and as the job's own first step.
   - Env: `TAP_MIGRATION_LEGACY_REV` (optional; overrides the derived rewind
     point, for reproducing a specific report).
   - Exit: `0` when the migration carried the machine across; `1` on a silent
@@ -720,11 +720,13 @@ uncomputable-diff fallback — cannot drift between the lanes that use it.
   coverage the chdb-backed layers already give. `verify` asserts every declared
   path still exists (a renamed entry matches nothing and silently retires the
   gate); `emit` writes `in_scope` to `$GITHUB_OUTPUT`. Every ambiguity resolves
-  to `true`: push / schedule / dispatch / `release/*` PRs always run the full
-  lane, and an uncomputable diff boots the stack rather than skipping it.
+  to `true`: push / schedule / `release/*` PRs always run the full lane, and an
+  uncomputable diff boots the stack rather than skipping it. `workflow_dispatch`
+  is the one named exception (`NON_BOOTING_EVENTS`) — e2e.yml's only dispatch
+  input regenerates the k3d crawl inventory, which no compose shard can see.
   `compose-smoke-scope.test.mjs` pins the in/out decisions exactly (run on the
-  `check` lane), and the `compose-smoke` aggregator treats a skipped setup as
-  green only when this job SUCCEEDED and reported `in_scope=false`.
+  `forbid-skip` job), and the `compose-smoke` aggregator treats a skipped setup
+  as green only when this job SUCCEEDED and reported `in_scope=false`.
   - Env: `MODE` (`verify` | `emit`; also `argv[2]`; default `verify`),
     `EVENT_NAME`, `HEAD_REF`, `BASE_SHA`, `HEAD_SHA`, `GITHUB_OUTPUT`.
 
@@ -740,7 +742,7 @@ uncomputable-diff fallback — cannot drift between the lanes that use it.
   no-run. Coverage assertion is collect-all-violations: unassigned (the
   forbidden gap), double-assigned, phantom/stale, and bad-shard-name are each
   reported, then `exit 1`. `compose-smoke-matrix.test.mjs` is the `node --test`
-  guard (run on the cheap `gate` lane) that pins the invariant + proves the
+  guard (run on the cheap `forbid-skip` job) that pins the invariant + proves the
   detectors fire. Two extra responsibilities: (1) it carries the per-shard
   `timeoutMinutes` ceiling on each emitted entry — the crawl shard gets a hard
   30-min cap (`CRAWL_SHARD_TIMEOUT_MIN`; fail fast, release the concurrency
@@ -886,7 +888,7 @@ uncomputable-diff fallback — cannot drift between the lanes that use it.
   no-run. Coverage assertion is collect-all-violations (unassigned,
   double-assigned, phantom/stale, bad-shard-name, and the "exactly one shard
   runs Go e2e" invariant), then `exit 1`. `dashboard-matrix.test.mjs` is the
-  `node --test` guard (run on the cheap `gate` lane) pinning the invariant +
+  `node --test` guard (run on the cheap `forbid-skip` job) pinning the invariant +
   proving the detectors fire. k3d is heavy + flaky, so the shard count is kept
   deliberately small. Each emitted entry also carries a per-shard
   `timeoutMinutes`: the crawl shard gets a hard 30-min cap

--- a/.github/scripts/brew-smoke.mjs
+++ b/.github/scripts/brew-smoke.mjs
@@ -359,10 +359,11 @@ export function formulaShadowProblems(shadowPaths) {
   if (found.length === 0) return [];
   return [
     `${TAP_REPO} still serves ${found.join(', ')} alongside ${TAP_CASK_PATH}. Homebrew resolves the ` +
-      `bare \`brew install ${CASK_REF}\` — the command README.md and docs/operations.md give operators — ` +
-      `to the FORMULA when a tap holds both, so every install would get the formula's version and ignore ` +
-      `the cask this release just pushed. Delete ${TAP_FORMULA_PATH} from ${TAP_REPO}. (Existing formula ` +
-      `installs are moved across by ${TAP_MIGRATIONS_PATH}, asserted separately.)`,
+      `bare \`brew install ${CASK_REF}\` to the FORMULA when a tap holds both, so anyone typing it — ` +
+      `off an older doc, a blog post, or muscle memory from before the cask — gets the formula's ` +
+      `version and ignores the cask this release just pushed. Delete ${TAP_FORMULA_PATH} from ` +
+      `${TAP_REPO}. (Existing formula installs are moved across by ${TAP_MIGRATIONS_PATH}, asserted ` +
+      `separately.)`,
   ];
 }
 

--- a/.github/scripts/brew-upgrade-path.mjs
+++ b/.github/scripts/brew-upgrade-path.mjs
@@ -271,7 +271,9 @@ function main() {
   // resolves to now is the whole question. A failure to resolve is itself an
   // outcome — an unlinked formula with no linked cask leaves the command gone —
   // and is reported as an empty version rather than crashing the job.
-  const which = capture('command -v cerberus', [], { shell: true });
+  // `command` is a shell builtin, so this needs a shell — spawned explicitly,
+  // because capture() does not forward a `shell` option.
+  const which = capture('sh', ['-c', 'command -v cerberus']);
   const resolved = which.status === 0 ? which.stdout.trim() : '';
   const versionRes = resolved ? capture(resolved, ['--version']) : { status: 1, stdout: '', stderr: '' };
   const reported = versionRes.status === 0 ? versionRes.stdout.trim() : '<not on PATH>';

--- a/.github/scripts/brew-upgrade-path.test.mjs
+++ b/.github/scripts/brew-upgrade-path.test.mjs
@@ -1,5 +1,5 @@
 // brew-upgrade-path.test.mjs — node:test guard for the formula -> cask upgrade
-// harness's verdict, run on the required `check` lane.
+// harness's verdict, run on the required `lint` job.
 //
 // The harness itself needs a Homebrew installation and several minutes, so it
 // runs weekly rather than per-PR. Its verdict function does not, and it is the

--- a/.github/scripts/compose-smoke-scope.mjs
+++ b/.github/scripts/compose-smoke-scope.mjs
@@ -22,8 +22,9 @@
 //
 // So the gate is neither "always" nor "never": a PR that touches the surface
 // this stack can see boots it, and every other PR short-circuits exactly as
-// before. Push, schedule, dispatch and `release/*` PRs are untouched — they
-// always ran the full lane and still do.
+// before. Push, schedule and `release/*` PRs are untouched — they always ran
+// the full lane and still do. `workflow_dispatch` never did, and still does
+// not: see NON_BOOTING_EVENTS.
 //
 // Two modes (env MODE, or argv[2]; default `verify`):
 //   - verify : assert every declared path still exists in the tree. A scope
@@ -112,6 +113,28 @@ export function stalePaths(paths) {
   });
 }
 
+// Events whose answer comes from the event alone, in the "don't boot"
+// direction. e2e.yml's only `workflow_dispatch` input regenerates the k3d
+// Grafana crawl inventory — a dashboard-lane artefact that no compose shard can
+// observe — so booting ClickHouse, a collector, a seeder and Grafana for it is
+// pure wall time. The guard this module replaced excluded dispatch for exactly
+// that reason; the exclusion is restated here rather than inherited.
+//
+// It lives HERE, not in the shared runsFullLane(), for two reasons. The other
+// consumer of that helper is the mutation sweep, which genuinely does want a
+// manual dispatch to sweep the whole matrix. And runsFullLane() fails OPEN by
+// design — anything that is not a pull request runs everything — so turning it
+// into an allow-list would make an event nobody anticipated silently skip the
+// lane, which is precisely the hollow green this module exists to prevent.
+// Not booting is therefore always a named, per-lane decision.
+export const NON_BOOTING_EVENTS = ['workflow_dispatch'];
+
+// Whether the changed-path diff matters at all, or the event settles it. Used
+// by the driver to skip computing a diff it would only discard.
+function settledByEvent({ eventName, headRef }) {
+  return NON_BOOTING_EVENTS.includes(eventName) || runsFullLane({ eventName, headRef });
+}
+
 // decide — should this event boot the compose stack, and why?
 //
 // The `null` changed-set (no merge base, shallow clone, a git failure) resolves
@@ -119,6 +142,9 @@ export function stalePaths(paths) {
 // cost of guessing wrong in that direction is a release-blocking bug that
 // reached main unexamined.
 export function decide({ eventName, headRef, changed }) {
+  if (NON_BOOTING_EVENTS.includes(eventName)) {
+    return { inScope: false, reason: `event "${eventName}" exercises no compose-visible surface` };
+  }
   if (runsFullLane({ eventName, headRef })) {
     return { inScope: true, reason: `event "${eventName}" always runs the full lane` };
   }
@@ -167,7 +193,7 @@ function main() {
 
   const eventName = (process.env.EVENT_NAME || '').trim();
   const headRef = (process.env.HEAD_REF || '').trim();
-  const changed = runsFullLane({ eventName, headRef })
+  const changed = settledByEvent({ eventName, headRef })
     ? null
     : changedPaths({ baseSha: process.env.BASE_SHA, headSha: process.env.HEAD_SHA });
 

--- a/.github/scripts/compose-smoke-scope.test.mjs
+++ b/.github/scripts/compose-smoke-scope.test.mjs
@@ -1,5 +1,5 @@
 // Unit tests for compose-smoke-scope.mjs — run by `node --test` in ci.yml's
-// `check` job.
+// `forbid-skip` job.
 //
 // The decisions pinned here are the ones whose failure mode is silence. A gate
 // that wrongly says "in scope" costs 25 minutes of runner time and is obvious.
@@ -10,7 +10,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { HARNESS_PATHS, SCOPE_PATHS, decide, stalePaths } from './compose-smoke-scope.mjs';
+import { HARNESS_PATHS, NON_BOOTING_EVENTS, SCOPE_PATHS, decide, stalePaths } from './compose-smoke-scope.mjs';
 
 const pr = { eventName: 'pull_request', headRef: 'fix/whatever' };
 
@@ -18,7 +18,7 @@ test('every declared scope path exists in the tree', () => {
   // The lists are plain strings: a rename turns an entry into one that matches
   // no diff, and the lane silently stops gating on the surface that entry was
   // added to guard. The driver checks this too — pinned here so it fails in the
-  // fast `check` job rather than only when e2e.yml next runs.
+  // fast `forbid-skip` job rather than only when e2e.yml next runs.
   assert.deepEqual(stalePaths([...HARNESS_PATHS, ...SCOPE_PATHS]), []);
 });
 
@@ -81,11 +81,10 @@ test('an empty diff short-circuits', () => {
   assert.equal(inScope, false);
 });
 
-test('push, schedule, dispatch and release PRs always run the full lane', () => {
+test('push, schedule and release PRs always run the full lane', () => {
   const events = [
     { eventName: 'push', headRef: '' },
     { eventName: 'schedule', headRef: '' },
-    { eventName: 'workflow_dispatch', headRef: '' },
     { eventName: 'pull_request', headRef: 'release/1.13.x' },
   ];
   for (const ev of events) {
@@ -94,6 +93,28 @@ test('push, schedule, dispatch and release PRs always run the full lane', () => 
     // regardless of what the commit happened to touch.
     const { inScope } = decide({ ...ev, changed: ['docs/engine.md'] });
     assert.equal(inScope, true, `${ev.eventName} ${ev.headRef} should run the full lane`);
+  }
+});
+
+test('workflow_dispatch does not boot the stack, whatever the diff says', () => {
+  // The guard this module replaced listed push / schedule / release-PR and left
+  // workflow_dispatch out, so dispatching e2e.yml never booted compose. That
+  // exclusion is deliberate — the workflow's only dispatch input regenerates the
+  // k3d crawl inventory — and it is easy to lose by accident, because
+  // runsFullLane() answers `true` for every non-PR event. Pinned in both
+  // directions: even a diff that WOULD put a PR in scope must not boot here.
+  for (const changed of [['docs/engine.md'], ['internal/chsql/emit_node.go'], null]) {
+    const { inScope } = decide({ eventName: 'workflow_dispatch', headRef: '', changed });
+    assert.equal(inScope, false, `workflow_dispatch with changed=${JSON.stringify(changed)} must short-circuit`);
+  }
+});
+
+test('the non-booting event list is explicit, never an allow-list', () => {
+  // The inverse — listing the events that DO boot — would make an event nobody
+  // anticipated skip the lane silently, which reports as a clean green.
+  assert.deepEqual(NON_BOOTING_EVENTS, ['workflow_dispatch']);
+  for (const ev of ['push', 'schedule', 'pull_request']) {
+    assert.ok(!NON_BOOTING_EVENTS.includes(ev), `${ev} must still reach the scope decision`);
   }
 });
 

--- a/.github/scripts/gh.test.mjs
+++ b/.github/scripts/gh.test.mjs
@@ -1,0 +1,53 @@
+// Unit tests for lib/gh.mjs — the module every other script in here runs its
+// subprocesses through.
+//
+// The decision pinned here is capture()'s option contract. capture() does not
+// spread its `opts` into spawnSync; it names the keys it forwards. That is the
+// right shape — it keeps the surface small — but it made an unsupported key a
+// SILENT no-op, and the failure that produced was invisible: a caller passing
+// `{ shell: true }` got its whole command string handed to spawnSync as argv[0],
+// which never resolves, so the gate reading that status saw a plain non-zero
+// exit and concluded the command had answered "no". The brew formula-to-cask
+// migration check ran that way and carried zero signal until an audit read it.
+// Rejecting unknown keys turns a permanently-wrong gate into a first-run crash.
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { capture } from './lib/gh.mjs';
+
+test('capture forwards the options it documents', () => {
+  const res = capture('sh', ['-c', 'printf "%s" "$MARKER"'], {
+    env: { MARKER: 'forwarded' },
+    timeout: 30_000,
+  });
+  assert.equal(res.status, 0);
+  assert.equal(res.stdout, 'forwarded');
+});
+
+test('capture rejects an option it would otherwise drop', () => {
+  // `shell` is the one that actually bit us; the assertion is about the class,
+  // so an arbitrary key has to be rejected the same way.
+  for (const opts of [{ shell: true }, { stdio: 'inherit' }, { cwd: '.', shell: false }]) {
+    assert.throws(
+      () => capture('true', [], opts),
+      (err) => err instanceof TypeError && /not forwarded to spawnSync/.test(err.message),
+      `capture() must reject ${JSON.stringify(opts)} rather than silently ignore it`,
+    );
+  }
+});
+
+test('capture still accepts an empty options object', () => {
+  // The guard must not turn the common no-options call into a throw.
+  const res = capture('sh', ['-c', 'exit 3']);
+  assert.equal(res.status, 3);
+});
+
+test('capture reports an unspawnable command as a status, not a throw', () => {
+  // The whole point of capture() is that the caller decides what failure means,
+  // so a missing binary must come back as data. This is also what the `shell`
+  // bug looked like from the outside — which is why the guard above exists.
+  const res = capture('cerberus-no-such-binary-4f3a', []);
+  assert.notEqual(res.status, 0);
+  assert.match(res.stderr, /ENOENT|not found/i);
+});

--- a/.github/scripts/lib/gh.mjs
+++ b/.github/scripts/lib/gh.mjs
@@ -71,12 +71,32 @@ export function log(line = '') {
   process.stdout.write(`${line}\n`);
 }
 
+// The spawnSync options capture()/exec() forward. Anything outside this set is
+// a caller mistake, and one that used to be SILENT: capture() builds its own
+// options object rather than spreading `opts`, so an unrecognised key was
+// dropped without a word. `capture(cmd, [], { shell: true })` therefore ran the
+// whole command string as argv[0], which never resolves — the caller saw a
+// plain non-zero status and read it as "the command said no", so the gate that
+// depended on it was permanently, quietly wrong. Failing loudly turns that into
+// a first-run crash instead of a lane that reports nothing for months.
+const CAPTURE_OPTS = new Set(['encoding', 'maxBuffer', 'input', 'cwd', 'env', 'timeout', 'killSignal']);
+
 // capture() — run a command, return { status, stdout, stderr }. Never
 // throws on a non-zero exit; the caller decides what a failure means.
 // `input` (Buffer|string) is fed to stdin when provided. `timeout` (ms), when
 // set, bounds the run — spawnSync kills the child past the deadline and sets
 // res.error, which we surface as a non-zero { status }.
+//
+// There is no `shell` option on purpose. To run something that needs a shell,
+// spawn one explicitly: capture('sh', ['-c', '<script>']).
 export function capture(cmd, args, opts = {}) {
+  const unknown = Object.keys(opts).filter((k) => !CAPTURE_OPTS.has(k));
+  if (unknown.length > 0) {
+    throw new TypeError(
+      `capture(${cmd}): unsupported option(s) ${unknown.join(', ')} — they are not forwarded to spawnSync. ` +
+        `Supported: ${[...CAPTURE_OPTS].join(', ')}. For a shell, spawn one: capture('sh', ['-c', '…']).`,
+    );
+  }
   const res = spawnSync(cmd, args, {
     encoding: opts.encoding === undefined ? 'utf8' : opts.encoding,
     maxBuffer: opts.maxBuffer ?? 256 * 1024 * 1024,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -645,6 +645,15 @@ jobs:
           node --test .github/scripts/compose-smoke-matrix.test.mjs
           node --test .github/scripts/dashboard-matrix.test.mjs
 
+      # The subprocess helper every script above runs its commands through.
+      # capture() names the spawnSync options it forwards rather than spreading
+      # `opts`, so an unsupported key used to vanish without a word — and a
+      # vanished `shell: true` turns the command string into an argv[0] that
+      # never resolves, which the caller reads as a legitimate non-zero answer.
+      # The tests pin that unknown options now throw.
+      - name: Assert the shared subprocess helper honours its option contract
+        run: node --test .github/scripts/gh.test.mjs
+
       # The compose lane's scope gate, same discipline one level up: it decides
       # whether an ordinary PR boots the stack at all, and a wrong `false` is
       # invisible — a clean short-circuit and a real one look identical from the

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -150,7 +150,7 @@ jobs:
   # ~Nx, but wall-clock drops from the serial sum toward the longest shard.
   # That latency win on the slowest required PR gate is the whole point.
   # Decides whether THIS pull request has to boot the stack. push / schedule /
-  # dispatch / `release/*` PRs always do, exactly as before; an ordinary PR does
+  # `release/*` PRs always do, exactly as before; an ordinary PR does
   # only when it changed a path this stack can see differently from chDB — the
   # emitted column types, the HTTP surface, the driver, the binary's own startup.
   # Everything else short-circuits in seconds, which is the de-gating this lane
@@ -184,10 +184,11 @@ jobs:
   compose-smoke-setup:
     name: compose-smoke-setup
     needs: compose-smoke-scope
-    # The scope job answers push / schedule / dispatch / `release/*` with an
-    # unconditional true, so those paths run the full lane exactly as they did
-    # when this guard was an inline event test. What changed is the ordinary PR:
-    # it now boots the stack when it touched something the stack can see.
+    # The scope job answers push / schedule / `release/*` with an unconditional
+    # true and `workflow_dispatch` with an unconditional false, so every path
+    # runs exactly as it did when this guard was an inline event test. What
+    # changed is the ordinary PR: it now boots the stack when it touched
+    # something the stack can see.
     if: needs.compose-smoke-scope.outputs.in_scope == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/docs/router-calibration.sql
+++ b/docs/router-calibration.sql
@@ -4,10 +4,20 @@
 -- CERBERUS_CH_OPT_CORPUS_ENABLED=1 with SINK_MODE=chtable) joins every routing
 -- DECISION the pure classifier made (internal/solver Planner.Plan) to the
 -- OBSERVED ClickHouse cost it actually paid (read_rows / read_bytes /
--- query_duration_ms / memory_usage / exit_status). route = 'A' is a single CH
--- query (any decision_reason other than 'routed'); route = 'B' is a sharded
--- query (routed). N/F/D are the RAW classifier scalars (n_anchors / fanout /
--- cumulative_d) recorded for BOTH routes.
+-- query_duration_ms / memory_usage / exit_status). route values (the full set
+-- internal/optcorpus can write):
+--   'A' — a single CH query: the classifier looked at the plan and declined to
+--         shard it, for whichever decision_reason it recorded.
+--   'B' — a sharded query (decision_reason 'routed').
+--   ''  — unclassified: the classifier never ran on this query at all. Every
+--         LogQL and TraceQL row lands here, since the solver only classifies
+--         PromQL. decision_reason is empty too, which is what distinguishes
+--         these from an 'A' refusal.
+-- N/F/D are the RAW classifier scalars (n_anchors / fanout / cumulative_d),
+-- recorded for both classified routes and left zero for the unclassified ones.
+-- The misroute queries below therefore say `route = 'A'` rather than
+-- `route != 'B'`: a rate over rows the classifier never saw is not a misroute
+-- rate.
 --
 -- exit_status values (the full set internal/optcorpus can write):
 --   * CH-side (derived from system.query_log):

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -70,7 +70,7 @@ that changes something the stack can see differently — `internal/chsql`
 short-circuits in seconds. `.github/scripts/compose-smoke-scope.mjs`
 owns the decision and the two path lists, computes them from the PR's
 own diff against its merge base, falls back to booting the stack when
-that diff cannot be computed, and is unit-tested in the `check` job. Every other job below is
+that diff cannot be computed, and is unit-tested in the `forbid-skip` job. Every other job below is
 informational — it runs (push-to-main, nightly, or dispatch) and reports,
 but a red result does not block a merge. Informational does **not** mean
 tolerated: a red informational lane is a real failure to fix, it is just
@@ -570,14 +570,13 @@ PR, and any PR touching the lane's own harness all sweep the FULL
 matrix, so no phase's floor is ever load-bearing on some PR happening
 to touch its package. `.github/scripts/mutation-matrix.mjs` computes
 that selection from the PR's own diff against its merge base and is
-unit-tested in the `check` job; when the diff cannot be computed it
-falls back to the full matrix rather than to an empty one.
+unit-tested in the `forbid-skip` job; when the diff cannot be computed
+it falls back to the full matrix rather than to an empty one.
 
 The phase inventory is not restated here. `mutation-phases.mjs` is the
-one place that carries it, and a table duplicated into prose drifts
-silently — this section previously named a `phase4-traceql` leg that
-had already been split in four, and a 93% floor that had already been
-raised back to 95%. Read the module.
+one place that carries it: leg names and per-leg efficacy floors change
+with the packages they cover, and a table duplicated into prose drifts
+out of step without anything going red. Read the module.
 
 `internal/logql` is split into four sibling matrix entries (each scoped
 to `./internal/logql` but with disjoint `--exclude-files` regexes) to

--- a/internal/engine/solver_wiring_test.go
+++ b/internal/engine/solver_wiring_test.go
@@ -17,7 +17,8 @@ import (
 // outermost RangeWindow carries it pinned so the solver's GridOf reads back
 // exactly (meta.Start/End/Step) and the Planner sees a grid-matched,
 // slice-invariant, eligible plan — which Mode=single classifies WITHOUT
-// routing (Reason=below-threshold).
+// routing (Reason=routing-disabled: the mode refuses before any threshold is
+// consulted, so the reason names the mode, not the plan's shape).
 var (
 	gridStart = time.Date(2026, 6, 13, 0, 0, 0, 0, time.UTC)
 	gridStep  = 15 * time.Second

--- a/internal/solver/planner.go
+++ b/internal/solver/planner.go
@@ -290,10 +290,11 @@ func (p *Planner) classify(plan chplan.Node, meta RequestMeta) (sig signals, dec
 }
 
 // notRouted builds a non-route Decision carrying only the reason. Callers
-// chain .withGrid(sig, meta) to attach the cost-grid readout. Every caller
-// inside classify runs after analyze, so no refusal is stamped with an empty
-// grid; Eligible's ModeSingle short-circuit is the one site that returns
-// before classify at all, and it documents its own zero grid.
+// chain .withGrid(sig, meta) to attach the cost-grid readout. Every refusal in
+// this package is raised after classify has run, so none of them reaches the
+// corpus with an all-zero grid — a refused row is still a calibration
+// datapoint, and a zero grid would be indistinguishable from a genuinely
+// trivial query.
 func notRouted(reason string) *Decision {
 	return &Decision{Reason: reason}
 }


### PR DESCRIPTION
Release-ritual step 3 for v1.14.0: audit the delta since `v1.13.2`, fix what it finds, merge onto `main` before any tag exists.

26 agents, 19 findings raised, 9 survived adversarial verification: **2 should-fix, 7 nits, no wrong-answer bugs in the query engine.**

## Should-fix

### `capture()` silently dropped unsupported options

`lib/gh.mjs`'s `capture()` builds its spawnSync options from a fixed list rather than spreading `opts`, so an unrecognised key vanished without a word. `brew-upgrade-path.mjs:274` passed `{ shell: true }` for its PATH probe — the whole command string went to spawnSync as `argv[0]`, never resolved, and came back `status 127`, which the caller read as a legitimate "cerberus is not on PATH". The weekly `brew-migration` job was therefore **permanently red on a healthy tap and a broken one alike**: the check that verifies the formula→cask upgrade path carried zero signal.

Fixed at the callsite (`capture('sh', ['-c', 'command -v cerberus'])`) and at the class: `capture()` now throws a `TypeError` naming the unsupported key, so the next such call crashes on its first run instead of misreporting for months. New `gh.test.mjs` pins it, wired into `forbid-skip`.

The sibling call in `brew-smoke.mjs:768` looks identical but goes through that file's own `sh()` helper, which *does* forward `shell` — not a bug, and left alone.

### `workflow_dispatch` started booting the compose stack

The inline guard #1379 replaced (`push || schedule || release/* PR`) excluded `workflow_dispatch` deliberately: e2e.yml's only dispatch input regenerates the **k3d** Grafana crawl inventory, a surface no compose shard can observe. `runsFullLane()` answers `true` for every non-PR event, so dispatching e2e.yml silently began paying a full N-shard ClickHouse + collector + seeder + Grafana boot. Three comments and a docs table asserted this had not changed.

Restored as a named `NON_BOOTING_EVENTS` branch in `compose-smoke-scope.mjs` — the module that owns the compose decision — rather than an allow-list in the shared helper. `runsFullLane()` fails **open** by design (anything that is not a pull request runs everything), and its other consumer, the mutation sweep, genuinely wants a dispatch to cover the whole matrix. Turning it into an allow-list would make an unanticipated event skip a lane silently, which is the hollow green the module exists to prevent. Not booting stays an explicit, per-lane decision, pinned in both directions.

## Nits — stale claims

| Site | Claim | Reality |
|---|---|---|
| `internal/solver/planner.go` | `notRouted`'s comment describes an `Eligible` short-circuit returning before `classify` with a zero grid | #1385 moved that check below `classify` and gave it `.withGrid`; no such site exists |
| `internal/engine/solver_wiring_test.go` | header says `Mode=single` classifies the fixture as `below-threshold` | the assertion 177 lines below says `routing-disabled` |
| `.github/scripts/brew-smoke.mjs` | the bare tap ref is "the command README.md and docs/operations.md give operators" | both flipped to `--cask`; the same commit updated three sibling comments and missed this one |
| `docs/router-calibration.sql` | route `'A'` is "any decision_reason other than 'routed'" | the unclassified `""` member landed later in the same delta; every LogQL/TraceQL row carries it |
| `docs/test-strategy.md` ×2, `.github/scripts/README.md` ×4 | six `node --test` steps attributed to the `check` job | they run in `forbid-skip` and `lint`; `check` is a pure aggregator. Two of the six predate this delta ("the cheap `gate` lane" — no such job) and are fixed with them |
| `docs/test-strategy.md` | the mutation section narrates its own edit history — "previously named a `phase4-traceql` leg… a 93% floor" | neither artefact exists in the tree; timeless-docs violation. Rewritten to state *why* the inventory lives in the module |

## Verification

`node --test` across the four affected suites: 67 pass, 0 fail. `MODE=verify compose-smoke-scope.mjs`: 16 declared paths, all present.