### PR TITLE
ci(mutation): close the hollow green on the 1.12.x line

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -28,6 +28,14 @@ universe, from `PLAYWRIGHT_DIR`) and `collectShardCoverageViolations()`
 (unassigned / double-assigned / phantom / stale-exclude / bad-shard-name).
 One implementation means a new rule guards BOTH lanes at once.
 
+`lib/scope-gate.mjs` answers "does THIS pull request touch the scope a heavy
+lane guards?" — `runsFullLane()` (which events must never take a scoped
+subset), `changedPaths()` (the PR's own diff against its merge base, or `null`
+when it cannot be computed, which callers must read as "run everything" rather
+than as "nothing changed"), and segment-wise `underPrefix` / `matchesAny`.
+It exists so the two dangerous parts — the always-full event set and the
+uncomputable-diff fallback — cannot drift between the lanes that use it.
+
 ## Modules
 
 - **`agpl-clean.mjs`** — `ci.yml`, the `agpl-clean` job. The provably-clean-build
@@ -180,6 +188,38 @@ One implementation means a new rule guards BOTH lanes at once.
   `enforce efficacy threshold` step.
   - Env: `REPORT` (default `gremlins.json`), `THRESHOLD` (a number).
   - Exit: `0` when efficacy is `>=` threshold, `1` when below.
+- **`mutation-phases.mjs`** — data, imported by `mutation-matrix.mjs`. The single
+  source of truth for the `mutation` lane's phase partition: each entry is one
+  gremlins run (`scope` package, optional scope-relative `exclude_files` RE2
+  alternation, `workers` cap, `--threshold-efficacy` bar), rendered straight into
+  `mutation.yml`'s `strategy.matrix`. It carries the per-leg rationale — the
+  logql/traceql OOM splits, the equivalent-mutant analysis behind each bar — that
+  used to live in the workflow. Also exports `HARNESS_PATHS`: the paths that
+  change the lane itself and therefore force the FULL matrix.
+  - Env: none (pure data module).
+- **`mutation-matrix.mjs`** — `mutation.yml`, the `select` job. Decides WHICH
+  phases run and emits them as the `mutate` `strategy.matrix`. On push /
+  schedule / dispatch and on a `release/*` PR it selects every phase; on an
+  ordinary PR it selects only the legs whose scope the diff touches, applying
+  each leg's `exclude_files` to the SCOPE-RELATIVE path exactly as gremlins does.
+  A changed path that lies inside a phase scope while claiming no leg is a
+  coverage gap and fails the job rather than being dropped. `verify` mode asserts
+  the table alone (every scope an existing directory, every pattern legal under
+  Go's RE2 — no lookaround, no backreferences); `emit` re-runs verify first, so
+  it cannot ship a matrix built from a table that would have failed. `dump`
+  validates and then writes the table to stdout as JSON and nothing else —
+  that is the stream `test/regression/mutation_leg_partition_test.go` parses to
+  assert every mutable file under a mutated package is claimed by exactly one
+  leg, an invariant no single leg's regex can express.
+  - Env: `MODE` (`emit` | `verify` | `dump`, also argv\[2]; default `verify`),
+    `EVENT_NAME`, `HEAD_REF`, `BASE_SHA`, `HEAD_SHA`, `GITHUB_OUTPUT`.
+  - Outputs: `matrix` (`{include:[…]}`), `has_phases` (`true` | `false` — the
+    aggregator reads it to tell "nothing in scope changed" apart from "the matrix
+    did not run").
+  - Exit: `0` clean / matrix emitted; `1` on a table violation, a coverage gap,
+    or a bad `MODE`.
+  - Tests: `node --test .github/scripts/mutation-matrix.test.mjs` (run by the
+    `forbid-skip` job).
 - **`release-version-gate.mjs`** — `release.yml`, the `gate` job (app side).
   The publish-on-merge pipeline ships when a validated `release/*` PR is MERGED
   to main (not on a raw pushed tag — that trigger is retired). On the resulting

--- a/.github/scripts/lib/scope-gate.mjs
+++ b/.github/scripts/lib/scope-gate.mjs
@@ -1,0 +1,117 @@
+// scope-gate.mjs — the shared decision behind "does THIS pull request touch the
+// scope a heavy lane guards?", used by the `mutation` and `compose-smoke` lanes.
+//
+// Why this exists
+// ---------------
+// Both lanes are expensive enough that they were moved off the ordinary-PR path
+// wholesale: the matrix job carried a job-level `if:` that skipped every leg
+// unless the event was a push, a schedule, a dispatch, or a `release/*` PR, and
+// the required aggregator read a skipped matrix as a green pass-through. That
+// bought PR wall-clock at the price of a HOLLOW GREEN — a PR could regress
+// exactly what the lane guards, merge with the required context reporting
+// green, and only surface the regression after the merge (push-to-main) or, in
+// the worst case, at release time, where it blocks the release instead of the
+// PR that caused it. Both blockers of the v1.13.2 cycle arrived that way.
+//
+// The fix is not "run everything on every PR" (that reinstates the wall-clock
+// bill this skip was introduced to remove) and not "skip and hope". It is to
+// run the legs whose SCOPE the PR actually changed: a PR that edits
+// internal/chplan runs the chplan mutation leg and nothing else; a PR that
+// edits only docs runs none. Cost tracks the diff, coverage tracks the diff,
+// and the class of "regressed a lane that never ran" closes.
+//
+// The pieces are shared here rather than duplicated per lane because the
+// non-obvious parts — which events must always run everything, and what to do
+// when the diff cannot be computed — are exactly the parts that are dangerous
+// to get subtly different in two places.
+//
+// node: builtins only — no npm deps, no setup-node needed.
+
+import { git, warning } from './gh.mjs';
+
+// Events that must run the FULL lane, never a diff-scoped subset:
+//
+//   push / schedule / workflow_dispatch — these are the safety net the scoped
+//     PR path leans on. A PR selects legs from its own diff, so a leg whose
+//     scope no PR happened to touch (an indirect dependency, a generated
+//     golden, a toolchain bump landing through another path) is still swept
+//     here. Scoping THESE would leave the sweep with no floor at all.
+//
+//   pull_request with a `release/*` head — the release-staging PR is the last
+//     gate before a tag exists, and RELEASE_REQUIRED_CHECKS names these lanes.
+//     It runs the whole thing regardless of how small its own diff is (a
+//     release PR's diff is a version bump and a CHANGELOG — nearly empty by
+//     construction, and exactly the moment full evidence is required).
+export function runsFullLane({ eventName, headRef }) {
+  if (eventName !== 'pull_request') return true;
+  return String(headRef ?? '').startsWith('release/');
+}
+
+// changedPaths — the repo-relative paths this PR touches, as a Set.
+//
+// Returns null when the diff CANNOT be computed (missing refs, a shallow
+// checkout, an unrelated-history merge-base failure). null is not "nothing
+// changed" — the caller must read it as "run the full lane". Collapsing an
+// unknown diff into an empty selection is the same hollow green this module
+// exists to close, so the ambiguity is preserved in the type rather than
+// resolved to the cheap answer.
+export function changedPaths({ baseSha, headSha }) {
+  const base = String(baseSha ?? '').trim();
+  const head = String(headSha ?? '').trim();
+  if (!base || !head) {
+    warning(`scope-gate: base ("${base}") or head ("${head}") sha missing — running the full lane.`);
+    return null;
+  }
+
+  // Three-dot semantics (changes on the HEAD side since the merge base) is the
+  // question being asked: "what did this PR do", not "how does it differ from
+  // the tip of main". Resolving the merge base explicitly rather than relying
+  // on `a...b` lets a missing base commit surface as a diagnosable failure here
+  // instead of an empty diff further down.
+  const mb = git(['merge-base', base, head]);
+  if (mb.status !== 0) {
+    warning(
+      `scope-gate: \`git merge-base ${base} ${head}\` failed (${mb.stderr.trim()}) — running the full lane.`,
+    );
+    return null;
+  }
+
+  const diff = git(['diff', '--name-only', `${mb.stdout.trim()}`, head]);
+  if (diff.status !== 0) {
+    warning(`scope-gate: \`git diff\` failed (${diff.stderr.trim()}) — running the full lane.`);
+    return null;
+  }
+
+  return new Set(
+    diff.stdout
+      .split('\n')
+      .map((l) => l.trim())
+      .filter(Boolean),
+  );
+}
+
+// underPrefix — is `path` inside directory `prefix` (or the prefix itself)?
+//
+// Compared segment-wise rather than with a bare `startsWith`, so `internal/log`
+// does not claim `internal/logql/lower.go`. Both sides are normalised from the
+// `./internal/logql` form the matrix scopes use to the `internal/logql` form
+// git reports.
+export function underPrefix(path, prefix) {
+  const p = normalise(path);
+  const dir = normalise(prefix);
+  if (dir === '') return true;
+  return p === dir || p.startsWith(`${dir}/`);
+}
+
+export function normalise(p) {
+  return String(p ?? '')
+    .replace(/^\.\//, '')
+    .replace(/\/+$/, '');
+}
+
+// matchesAny — does `path` fall under ANY of `prefixes`? A prefix ending in a
+// non-directory name still matches the exact file, so a single file can be
+// named as its own scope entry.
+export function matchesAny(path, prefixes) {
+  return prefixes.some((prefix) => underPrefix(path, prefix));
+}

--- a/.github/scripts/mutation-matrix.mjs
+++ b/.github/scripts/mutation-matrix.mjs
@@ -1,0 +1,273 @@
+// mutation-matrix.mjs — decides WHICH mutation phases run, and emits them as
+// the `mutate` job's strategy.matrix (mutation.yml).
+//
+// Why this exists
+// ---------------
+// The `mutation` lane used to be all-or-nothing on a pull request: a job-level
+// `if:` skipped the entire matrix unless the event was a push, a schedule, a
+// dispatch, or a `release/*` PR, and the required `mutation` aggregator read the
+// skipped matrix as a green pass-through. A PR could therefore drop
+// internal/chplan's efficacy below its 95% floor, merge with `mutation` green,
+// and only surface on push-to-main — or, as happened in the v1.13.2 cycle, on
+// the release PR, where it blocks the release instead of the change that caused
+// it. That is a hollow green: a required check reporting on work it never did.
+//
+// The answer is neither "skip" nor "run all ~15 legs on every PR" (the matrix
+// cost the skip existed to avoid). It is to run the legs whose SCOPE the PR
+// actually changed. A PR editing internal/chplan runs phase1. A PR editing only
+// docs runs nothing and the aggregator passes through honestly, because there
+// was nothing in this lane's scope to check. Push / schedule / dispatch and
+// release PRs still sweep the FULL matrix, so no leg's floor is ever load-bearing
+// on some PR happening to touch it.
+//
+// Three modes (env MODE, or argv[2]; default `verify`):
+//   - verify : assert the PHASES table is internally sound — unique phase names,
+//              every `scope` an existing directory, every `exclude_files`
+//              pattern compiling AND staying inside RE2 (no lookaround, no
+//              backreferences: Go's regexp rejects them, and round 11 of the
+//              traceql split burned a full CI cycle discovering that mid-run).
+//              Runs in milliseconds, installs nothing.
+//   - emit   : run the same assertions, select the phases this event needs, and
+//              write `matrix=<json>` + `has_phases=true|false` to $GITHUB_OUTPUT.
+//              emit re-runs verify internally, so it can never ship a matrix
+//              built from a table that would have failed the check.
+//   - dump   : write the validated PHASES table to stdout as JSON, and nothing
+//              else. This is the table's machine-readable face: Go's
+//              test/regression leg-partition test reads it to check that every
+//              mutable file under a mutated package is claimed by exactly one
+//              leg — an invariant no single leg's regex can express, and which
+//              therefore has to be checked against the whole table at once.
+//
+// Env:
+//   MODE          `emit` | `verify` | `dump` (also argv[2]); default `verify`.
+//   EVENT_NAME    github.event_name.
+//   HEAD_REF      github.head_ref (empty off pull_request).
+//   BASE_SHA      (emit, PR) github.event.pull_request.base.sha.
+//   HEAD_SHA      (emit, PR) github.event.pull_request.head.sha.
+//   GITHUB_OUTPUT (emit) runner file the matrix JSON is appended to.
+//
+// Exit: 0 clean / matrix emitted; 1 on a table violation, a coverage gap, or a
+// bad MODE.
+//
+// node: builtins only — no npm deps, no setup-node needed.
+
+import { statSync } from 'node:fs';
+
+import { error, log, notice, setOutput } from './lib/gh.mjs';
+import { changedPaths, matchesAny, normalise, runsFullLane, underPrefix } from './lib/scope-gate.mjs';
+import { HARNESS_PATHS, PHASES } from './mutation-phases.mjs';
+
+// Constructs Go's regexp (RE2) rejects outright. gremlins passes exclude_files
+// straight to Go, so a JS-valid pattern using any of these compiles fine here
+// and then errors the leg out at run time — which is how round 11's `(?!…)`
+// slipped through review and cost a CI cycle. Checked as source text because a
+// compiled JS RegExp has already accepted them.
+const NON_RE2_CONSTRUCTS = [
+  { re: /\(\?=/, what: 'lookahead `(?=`' },
+  { re: /\(\?!/, what: 'negative lookahead `(?!`' },
+  { re: /\(\?<=/, what: 'lookbehind `(?<=`' },
+  { re: /\(\?<!/, what: 'negative lookbehind `(?<!`' },
+  { re: /\\[1-9]/, what: 'a backreference `\\1`' },
+];
+
+// tableViolations — everything wrong with the PHASES table, as strings.
+export function tableViolations(phases) {
+  const problems = [];
+  const seen = new Set();
+
+  for (const p of phases) {
+    const name = p.phase;
+    if (!name) {
+      problems.push(`a phase entry has no \`phase\` name: ${JSON.stringify(p)}`);
+      continue;
+    }
+    if (seen.has(name)) {
+      problems.push(
+        `duplicate phase name "${name}" — phase names become artifact names (gremlins-<phase>) and ` +
+          `check names, so a collision silently overwrites one leg's report with another's.`,
+      );
+    }
+    seen.add(name);
+
+    if (!p.scope) {
+      problems.push(`phase "${name}" has no \`scope\` package.`);
+    } else if (!isDirectory(normalise(p.scope))) {
+      problems.push(
+        `phase "${name}" scopes "${p.scope}", which is not a directory in this tree. A stale scope ` +
+          `makes gremlins mutate nothing and report a vacuous 100% efficacy.`,
+      );
+    }
+
+    if (!Number.isInteger(p.efficacy) || p.efficacy < 0 || p.efficacy > 100) {
+      problems.push(`phase "${name}" has a non-percentage \`efficacy\`: ${JSON.stringify(p.efficacy)}`);
+    }
+    if (!Number.isInteger(p.workers) || p.workers < 0) {
+      problems.push(`phase "${name}" has a negative or non-integer \`workers\`: ${JSON.stringify(p.workers)}`);
+    }
+
+    if (p.exclude_files !== undefined) {
+      problems.push(...excludeViolations(name, p.exclude_files));
+    }
+  }
+
+  return problems;
+}
+
+function excludeViolations(name, pattern) {
+  const problems = [];
+  if (typeof pattern !== 'string' || pattern === '') {
+    problems.push(`phase "${name}" has an empty \`exclude_files\` — omit the key instead of excluding nothing.`);
+    return problems;
+  }
+  for (const { re, what } of NON_RE2_CONSTRUCTS) {
+    if (re.test(pattern)) {
+      problems.push(
+        `phase "${name}" \`exclude_files\` uses ${what}, which Go's RE2 engine rejects. gremlins would ` +
+          `error the leg out at run time, after the checkout and toolchain setup have already been paid for.`,
+      );
+    }
+  }
+  try {
+    new RegExp(pattern);
+  } catch (e) {
+    problems.push(`phase "${name}" \`exclude_files\` is not a valid regular expression: ${e.message}`);
+  }
+  return problems;
+}
+
+function isDirectory(path) {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+// phaseClaims — does this phase mutate `path`? True when the path lies under the
+// phase's scope AND its SCOPE-RELATIVE form is not excluded — the same two-step
+// gremlins itself applies, so the selection can never claim a file the run would
+// then skip.
+//
+// Deliberately not restricted to non-test `.go` files. gremlins mutates only
+// production Go, but a leg's efficacy is `killed / (killed + lived)` over the
+// package's OWN tests: editing a `_test.go` or a testdata fixture moves the
+// number without touching a mutable line. Selecting on any changed path under
+// the scope over-selects a little (a `lexer_test.go` edit also claims the leg
+// whose exclude names `lexer.go`) and under-selects never, which is the correct
+// direction for a gate.
+export function phaseClaims(phase, path) {
+  if (!underPrefix(path, phase.scope)) return false;
+  if (!phase.exclude_files) return true;
+  const rel = normalise(path).slice(normalise(phase.scope).length + 1);
+  return !new RegExp(phase.exclude_files).test(rel);
+}
+
+// selectPhases — the phases this event must run, plus the reason, plus any
+// changed path that fell inside a scope while claiming NO leg.
+//
+// A path in that last bucket is a real coverage gap: it sits in a package the
+// mutation lane owns, yet every leg's exclude regex skips it, so no leg mutates
+// it on ANY event. Reported rather than shrugged off — silently dropping it
+// would let a leg partition drift into leaving a file permanently unmutated.
+export function selectPhases({ phases, harnessPaths, eventName, headRef, changed }) {
+  if (runsFullLane({ eventName, headRef })) {
+    return { phases, reason: `event "${eventName}" always runs the full matrix`, gaps: [] };
+  }
+  if (changed === null) {
+    return { phases, reason: 'the changed-path set could not be computed', gaps: [] };
+  }
+
+  const paths = [...changed];
+  const harnessHit = paths.filter((p) => matchesAny(p, harnessPaths));
+  if (harnessHit.length > 0) {
+    return {
+      phases,
+      reason: `the lane's own harness changed (${harnessHit.join(', ')})`,
+      gaps: [],
+    };
+  }
+
+  const selected = phases.filter((phase) => paths.some((p) => phaseClaims(phase, p)));
+  const gaps = paths.filter(
+    (p) => phases.some((phase) => underPrefix(p, phase.scope)) && !phases.some((phase) => phaseClaims(phase, p)),
+  );
+
+  return {
+    phases: selected,
+    reason:
+      selected.length > 0
+        ? `${selected.length} of ${phases.length} phases scope a changed path`
+        : 'no changed path falls in any phase scope',
+    gaps,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// driver
+// ---------------------------------------------------------------------------
+
+function main() {
+  const mode = (process.env.MODE || process.argv[2] || 'verify').trim();
+  if (mode !== 'verify' && mode !== 'emit' && mode !== 'dump') {
+    error(`mutation-matrix: MODE must be "verify", "emit" or "dump" (got "${mode}")`);
+    process.exit(1);
+  }
+
+  const problems = tableViolations(PHASES);
+  for (const p of problems) error(`mutation-matrix: ${p}`);
+  if (problems.length > 0) process.exit(1);
+
+  // dump puts the table on stdout and NOTHING else, because a consumer parses
+  // that stream as JSON. Validation still runs first: a dump of a table that
+  // would have failed verify is worse than no dump at all.
+  if (mode === 'dump') {
+    process.stdout.write(`${JSON.stringify(PHASES, null, 2)}\n`);
+
+    return;
+  }
+
+  log(`mutation-matrix: ${PHASES.length} phases, table sound.`);
+
+  if (mode === 'verify') return;
+
+  const eventName = (process.env.EVENT_NAME || '').trim();
+  const headRef = (process.env.HEAD_REF || '').trim();
+  const changed = runsFullLane({ eventName, headRef })
+    ? null
+    : changedPaths({ baseSha: process.env.BASE_SHA, headSha: process.env.HEAD_SHA });
+
+  const { phases, reason, gaps } = selectPhases({
+    phases: PHASES,
+    harnessPaths: HARNESS_PATHS,
+    eventName,
+    headRef,
+    changed,
+  });
+
+  for (const gap of gaps) {
+    error(
+      `mutation-matrix: "${gap}" lies inside a mutation phase scope but every leg's exclude_files skips it — ` +
+        `no event mutates that file. Claim it in a leg (usually the scope's catch-all) or move it out of scope.`,
+    );
+  }
+  if (gaps.length > 0) process.exit(1);
+
+  notice(
+    `mutation-matrix: running ${phases.length}/${PHASES.length} phases — ${reason}` +
+      (phases.length > 0 ? ` (${phases.map((p) => p.phase).join(', ')})` : ''),
+  );
+
+  // `matrix` is the whole strategy.matrix object (mirrors compose-smoke-setup),
+  // so mutation.yml interpolates it as `matrix: ${{ fromJSON(...) }}` rather
+  // than reaching into a bare array. `has_phases` is emitted separately because
+  // a job-level `if:` cannot introspect a matrix: without it, a SKIPPED `mutate`
+  // is indistinguishable to the aggregator from a selection that was legitimately
+  // empty — which is precisely the ambiguity this lane is being fixed to remove.
+  setOutput('matrix', JSON.stringify({ include: phases }));
+  setOutput('has_phases', String(phases.length > 0));
+}
+
+// Only dispatch when run as a script — importing for the unit test must not
+// exit the test runner.
+const invokedDirectly = process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href;
+if (invokedDirectly) main();

--- a/.github/scripts/mutation-matrix.test.mjs
+++ b/.github/scripts/mutation-matrix.test.mjs
@@ -1,0 +1,174 @@
+// mutation-matrix.test.mjs — unit tests for the mutation lane's phase selector.
+//
+// Two things are pinned here, and both are gates rather than documentation:
+//
+//   1. The REAL PHASES table is sound against the REAL tree — every scope is an
+//      existing directory, every exclude_files pattern is RE2-legal. This is the
+//      cheap in-process version of the check that otherwise costs a full
+//      checkout + toolchain setup per leg before failing.
+//
+//   2. The selection is EXACT, not merely non-empty. Asserting "chplan.go
+//      selects at least one leg" would pass while quietly running all fifteen;
+//      asserting the precise leg set is what proves the scoping actually scopes,
+//      and that a file claimed by one leg's exclude alternation is not silently
+//      claimed by a sibling's too.
+//
+// Run: node --test .github/scripts/mutation-matrix.test.mjs (from the repo root).
+
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { test } from 'node:test';
+
+import { phaseClaims, selectPhases, tableViolations } from './mutation-matrix.mjs';
+import { HARNESS_PATHS, PHASES } from './mutation-phases.mjs';
+import { underPrefix } from './lib/scope-gate.mjs';
+
+const select = (changed, over = {}) =>
+  selectPhases({
+    phases: PHASES,
+    harnessPaths: HARNESS_PATHS,
+    eventName: 'pull_request',
+    headRef: 'feat/some-branch',
+    changed: changed === null ? null : new Set(changed),
+    ...over,
+  });
+
+const names = (result) => result.phases.map((p) => p.phase).sort();
+
+test('the shipped PHASES table is sound against this tree', () => {
+  assert.deepEqual(tableViolations(PHASES), []);
+});
+
+test('duplicate phase names are rejected', () => {
+  const dup = [PHASES[0], { ...PHASES[1], phase: PHASES[0].phase }];
+  const problems = tableViolations(dup);
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /duplicate phase name/);
+});
+
+test('a scope that is not a directory is rejected', () => {
+  const problems = tableViolations([{ ...PHASES[0], scope: './internal/does-not-exist' }]);
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /not a directory/);
+});
+
+test('an exclude_files pattern using RE2-illegal lookahead is rejected', () => {
+  // The exact shape that errored out round 11 of the traceql split at run time.
+  const problems = tableViolations([{ ...PHASES[0], exclude_files: '^(?!parser)\\w+\\.go$' }]);
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /negative lookahead/);
+});
+
+test('a non-percentage efficacy and a negative worker count are rejected', () => {
+  const problems = tableViolations([{ ...PHASES[0], efficacy: 140, workers: -1 }]);
+  assert.equal(problems.length, 2);
+});
+
+test('push, schedule, dispatch and release PRs all run the full matrix', () => {
+  for (const eventName of ['push', 'schedule', 'workflow_dispatch']) {
+    assert.equal(select(['docs/engine.md'], { eventName }).phases.length, PHASES.length, eventName);
+  }
+  const release = select(['CHANGELOG.md'], { headRef: 'release/v1.13.2-chart-0.13.2' });
+  assert.equal(release.phases.length, PHASES.length);
+});
+
+test('an uncomputable diff runs the full matrix rather than nothing', () => {
+  const result = select(null);
+  assert.equal(result.phases.length, PHASES.length);
+  assert.match(result.reason, /could not be computed/);
+});
+
+test('a change to the lane harness runs the full matrix', () => {
+  for (const path of HARNESS_PATHS) {
+    assert.equal(select([path]).phases.length, PHASES.length, path);
+  }
+});
+
+test('a docs-only PR runs no phase at all', () => {
+  const result = select(['docs/engine.md', 'README.md', '.github/workflows/ci.yml']);
+  assert.deepEqual(result.phases, []);
+  assert.deepEqual(result.gaps, []);
+});
+
+test('a change under one scope selects exactly that scope’s leg', () => {
+  assert.deepEqual(names(select(['internal/chplan/plan.go'])), ['phase1']);
+  assert.deepEqual(names(select(['internal/chsql/emit_node.go'])), ['phase2']);
+  assert.deepEqual(names(select(['internal/spansscan/match.go'])), ['phase6-spansscan']);
+});
+
+test('the logql legs partition the package by exclude_files, one leg per file', () => {
+  assert.deepEqual(names(select(['internal/logql/lower.go'])), ['phase4-logql-lower']);
+  assert.deepEqual(names(select(['internal/logql/range_aggregation.go'])), ['phase4-logql-aggregation']);
+  assert.deepEqual(names(select(['internal/logql/dotted_labels.go'])), ['phase4-logql-other-a']);
+  // The catch-all leg owns everything no sibling names.
+  assert.deepEqual(names(select(['internal/logql/variants.go'])), ['phase4-logql-other-b']);
+  assert.deepEqual(names(select(['internal/logql/logpattern/parse.go'])), ['phase4-logql-other-b']);
+});
+
+test('the lsyntax subtree is excluded from the logql legs and owned by its own', () => {
+  // The round-13 incident in reverse: `scope: ./internal/logql` RECURSES into
+  // lsyntax/, so without the `^lsyntax/` excludes these four legs would each
+  // claim the parser too.
+  assert.deepEqual(names(select(['internal/logql/lsyntax/parser.go'])), ['phase4-logql-parser']);
+  assert.deepEqual(names(select(['internal/logql/lsyntax/lexer.go'])), ['phase4-logql-lsyntax']);
+});
+
+test('the traceql ast subtree is excluded from the package legs and owned by its own', () => {
+  assert.deepEqual(names(select(['internal/traceql/lower.go'])), ['phase4-traceql-lower']);
+  assert.deepEqual(names(select(['internal/traceql/metrics_compare.go'])), ['phase4-traceql-other']);
+  assert.deepEqual(names(select(['internal/traceql/ast/parser.go'])), ['phase4-traceql-parser']);
+  assert.deepEqual(names(select(['internal/traceql/ast/lexer.go'])), ['phase4-traceql-ast']);
+});
+
+test('several changed paths union their legs', () => {
+  assert.deepEqual(names(select(['internal/chplan/plan.go', 'internal/traceql/ast/parser.go', 'docs/engine.md'])), [
+    'phase1',
+    'phase4-traceql-parser',
+  ]);
+});
+
+test('a file every leg excludes is reported as a coverage gap, not dropped', () => {
+  // A scope whose only leg excludes the changed file: the file is inside a
+  // package the lane owns, yet nothing mutates it on any event.
+  const phases = [{ phase: 'solo', scope: './internal/chplan', efficacy: 95, workers: 0, exclude_files: '^plan\\.go$' }];
+  const result = selectPhases({
+    phases,
+    harnessPaths: HARNESS_PATHS,
+    eventName: 'pull_request',
+    headRef: 'feat/x',
+    changed: new Set(['internal/chplan/plan.go']),
+  });
+  assert.deepEqual(result.phases, []);
+  assert.deepEqual(result.gaps, ['internal/chplan/plan.go']);
+});
+
+test('scope matching is segment-wise, so a prefix cannot claim a sibling package', () => {
+  assert.equal(underPrefix('internal/logql/lower.go', './internal/log'), false);
+  assert.equal(underPrefix('internal/logql/lower.go', './internal/logql'), true);
+  assert.equal(underPrefix('internal/logql', './internal/logql'), true);
+});
+
+test('phaseClaims applies the exclude to the SCOPE-RELATIVE path, as gremlins does', () => {
+  const leg = PHASES.find((p) => p.phase === 'phase4-traceql-parser');
+  // `parser.go` is scope-relative to ./internal/traceql/ast; the same basename
+  // one directory up is a different file and belongs to a different leg.
+  assert.equal(phaseClaims(leg, 'internal/traceql/ast/parser.go'), true);
+  assert.equal(phaseClaims(leg, 'internal/traceql/lower.go'), false);
+});
+
+test('dump mode writes the table to stdout as JSON and nothing else', () => {
+  // test/regression/mutation_leg_partition_test.go parses this stream to check
+  // an invariant no single leg's regex can express — every mutable file under a
+  // mutated package claimed by exactly one leg. A stray log line on stdout
+  // breaks that parse, so the contract is pinned here rather than discovered in
+  // the Go suite.
+  const dumped = execFileSync(process.execPath, ['.github/scripts/mutation-matrix.mjs', 'dump'], {
+    encoding: 'utf8',
+  });
+  const legs = JSON.parse(dumped);
+  assert.deepEqual(
+    legs.map((leg) => leg.phase),
+    PHASES.map((p) => p.phase),
+  );
+  for (const leg of legs) assert.ok(leg.scope, `dumped leg ${leg.phase} lost its scope`);
+});

--- a/.github/scripts/mutation-phases.mjs
+++ b/.github/scripts/mutation-phases.mjs
@@ -1,0 +1,254 @@
+// mutation-phases.mjs — the single source of truth for the `mutation` lane's
+// phase partition (mutation.yml's `mutate` strategy.matrix).
+//
+// Each entry is one gremlins run: a `scope` package (walked recursively), an
+// optional scope-relative `exclude_files` RE2 alternation carving that scope
+// into sibling legs, a `workers` cap, and the `--threshold-efficacy` bar the
+// leg must clear. The keys are the matrix keys mutation.yml interpolates as
+// `matrix.scope` / `matrix.workers` / `matrix.exclude_files` / `matrix.efficacy`
+// / `matrix.phase`, so this table renders straight into `strategy.matrix.include`.
+//
+// It lives in JS rather than inline YAML because mutation-matrix.mjs has to
+// REASON about it — selecting the legs an ordinary PR's diff actually touches,
+// and asserting the exclude regexes stay RE2-safe — and a workflow `include:`
+// block is data the workflow cannot read back.
+//
+// node: builtins only — no npm deps, no setup-node needed.
+
+// Every leg clears the same bar. `.gremlins.yaml`'s threshold (currently 95) is
+// the floor for the unscoped whole-repo `just mutate` invocation only; the
+// per-phase bar is set here so one weak package cannot hide behind a strong one
+// in a repo-wide average.
+const EFFICACY = 95;
+
+// gremlins' default fan-out is runtime.NumCPU(). DEFAULT_WORKERS keeps it;
+// SERIAL_WORKERS caps a leg at one concurrent `go test` cycle, which is what
+// the heavy parser/lowering legs need to stay under the ubuntu-latest memory
+// ceiling (see the phase4 rationale blocks below).
+const DEFAULT_WORKERS = 0;
+const SERIAL_WORKERS = 1;
+
+export const PHASES = [
+  { phase: 'phase1', scope: './internal/chplan', efficacy: EFFICACY, workers: DEFAULT_WORKERS },
+  { phase: 'phase2', scope: './internal/chsql', efficacy: EFFICACY, workers: DEFAULT_WORKERS },
+  {
+    phase: 'phase3-optimizer',
+    scope: './internal/optimizer',
+    efficacy: EFFICACY,
+    workers: DEFAULT_WORKERS,
+  },
+  {
+    phase: 'phase4-promql',
+    scope: './internal/promql',
+    efficacy: EFFICACY,
+    workers: DEFAULT_WORKERS,
+  },
+
+  // ---------------------------------------------------------------------------
+  // phase4-logql — four sibling legs over ./internal/logql, plus two over the
+  // lsyntax subpackage.
+  //
+  // phase4-logql historically OOM-killed the ubuntu-latest runner (~7 GB RAM) at
+  // the 3-minute mark. Rounds 1-3 tried gremlins' default runtime.NumCPU()
+  // workers and the runner died ~3 min in. Round 4 capped workers at 2, round 5
+  // dropped to workers=1, and round 6's job log (77180086677,
+  // 2026-05-21T13:13:26Z) confirmed `--workers "1"` engaged, every emitted
+  // mutant was KILLED (no LIVED), gremlins.json never written, and the runner
+  // received a shutdown signal at the same ~3m37s mark. The bottleneck is
+  // therefore NOT parallel `go test` fan-out but cumulative runner RSS growth
+  // from gremlins' long-lived process state + each mutant's full
+  // `go test ./internal/logql` cycle dragging the heavy LogQL parser dep graph
+  // (loki + prometheus + dskit + memberlist) through the linker. Workers=1 alone
+  // cannot land below the ceiling because the wall-clock budget before OOM
+  // admits ~80 of ~300+ mutants in the package.
+  //
+  // Round 7 split phase4-logql into three sibling entries (lower / aggregation /
+  // other), each scoped to ./internal/logql but with --exclude-files regexes
+  // carving the source set into roughly equal slices. Round 8 split `other` into
+  // `other-a` + `other-b`. Round 9 peeled dotted_labels.go into its own slice,
+  // and round 10 (job 77211633492) proved even a single-file slice of that
+  // surface SIGTERM'd at ~3 min — the runner-budget ceiling sat below it. That
+  // was the runaway-mutant class, now bounded absolutely by --timeout-max, so
+  // dotted_labels.go is mutated again in other-a rather than left uncovered.
+  //
+  // phase4-logql-aggregation was historically relaxed to 93 (94.83%, 18 LIVED)
+  // citing equivalent mutants. The KILLABLE survivors are now pinned by
+  // range_aggregation_mutation_test.go + vector_aggregation_mutation_test.go
+  // (10 killed: absent-window Interval+Offset arithmetic, the absent synth-label
+  // conjunction, the post-filter error-mark return gate, the topk/quantile outer-by
+  // threading + ungrouped-partition guards — each verified by hand-applying the
+  // mutation). The remaining survivors are GENUINELY EQUIVALENT and can't be killed:
+  //   - `make([]Expr, 0, len(Groups)*2 (+1))` slice-CAPACITY hints
+  //     (range_aggregation.go, vector_aggregation.go, duration.go) — a cap literal
+  //     changes only allocator behaviour, not output (CLAUDE.md: capacity hints
+  //     out of scope).
+  //   - empty-group CONDITIONALS_BOUNDARY guards (`len(...) > 0` vs `>= 0`) whose
+  //     only distinguishing input (`by ()`) threads a len-0 label slice the
+  //     lowering collapses to nil — a byte-identical no-op.
+  // With the killable set covered the bar is back at 95; the equivalents sit
+  // comfortably under it (~97.7%).
+  //
+  // Round 13 (2026-07-25): all four ./internal/logql legs started dying with the
+  // same OOM signature ~20-25 min into every push-to-main run, 100% reproducible,
+  // starting exactly at the commit that moved internal/logql/dotted_labels.go's
+  // implementation AND its large table-driven test suite into
+  // internal/logql/lsyntax. `scope: ./internal/logql` recurses into every
+  // subdirectory, so lsyntax/*.go was ALREADY being swept into these four legs —
+  // none of the exclude regexes covered lsyntax's own files (ast.go, lexer.go,
+  // parser.go, …), only dotted_labels.go itself (matched by filename regardless
+  // of directory). Once dotted_labels_test.go relocated into package lsyntax,
+  // every covered mutant anywhere in lsyntax forced
+  // `go test .../internal/logql/lsyntax` to link and run that heavier test
+  // binary, on every one of the four legs. Fix: exclude the whole lsyntax
+  // subtree (scope-relative '^lsyntax/', mirroring the phase4-traceql-lower
+  // '^ast/' precedent) from all four legs, and give lsyntax its own dedicated
+  // legs so the package keeps its mutation coverage instead of losing it.
+  // ---------------------------------------------------------------------------
+  {
+    phase: 'phase4-logql-lower',
+    scope: './internal/logql',
+    efficacy: EFFICACY,
+    workers: SERIAL_WORKERS,
+    // Mutate only lower.go (~50 KB, the package's largest source file).
+    // Excludes every other logql source plus the lsyntax subtree.
+    exclude_files:
+      '^lsyntax/|(binary|detected_level|dotted_labels|literal|label_fns|top_level_columns|range_aggregation|vector_aggregation|lang)\\.go$|^logpattern/|^(doc|duration|ip|jsonpath|numbytes|pattern_filter|variants)\\.go$',
+  },
+  {
+    phase: 'phase4-logql-aggregation',
+    scope: './internal/logql',
+    efficacy: EFFICACY,
+    workers: SERIAL_WORKERS,
+    // Mutate range_aggregation.go + vector_aggregation.go + lang.go (~54 KB).
+    exclude_files:
+      '^lsyntax/|(binary|detected_level|dotted_labels|literal|label_fns|top_level_columns|lower)\\.go$|^logpattern/|^(doc|duration|ip|jsonpath|numbytes|pattern_filter|variants)\\.go$',
+  },
+  {
+    phase: 'phase4-logql-other-a',
+    scope: './internal/logql',
+    efficacy: EFFICACY,
+    workers: SERIAL_WORKERS,
+    // Mutate binary.go + detected_level.go + dotted_labels.go (~21 KB).
+    exclude_files:
+      '^lsyntax/|(lower|range_aggregation|vector_aggregation|lang|literal|label_fns|top_level_columns)\\.go$|^logpattern/|^(doc|duration|ip|jsonpath|numbytes|pattern_filter|variants)\\.go$',
+  },
+  {
+    phase: 'phase4-logql-other-b',
+    scope: './internal/logql',
+    efficacy: EFFICACY,
+    workers: SERIAL_WORKERS,
+    // The catch-all leg: literal.go + label_fns.go + top_level_columns.go, plus
+    // every file no other leg claims (doc.go, duration.go, ip.go, jsonpath.go,
+    // numbytes.go, pattern_filter.go, variants.go, logpattern/). A file newly
+    // added to internal/logql needs no edit here — it is picked up
+    // automatically, which is why this leg keeps no positive file list to fall
+    // out of sync.
+    exclude_files:
+      '^lsyntax/|(lower|range_aggregation|vector_aggregation|lang|binary|detected_level|dotted_labels)\\.go$',
+  },
+  {
+    phase: 'phase4-logql-parser',
+    scope: './internal/logql/lsyntax',
+    efficacy: EFFICACY,
+    workers: SERIAL_WORKERS,
+    // Mutate parser.go only (~27 KB, the recursive-descent LogQL parser — the
+    // densest control-flow surface in the package, same shape as
+    // phase4-traceql-parser). dotted_labels.go belongs to the lsyntax leg.
+    exclude_files: '^(ast|binop|dotted_labels|errors|labelfilter|lexer|ops|string)\\.go$',
+  },
+  {
+    phase: 'phase4-logql-lsyntax',
+    scope: './internal/logql/lsyntax',
+    efficacy: EFFICACY,
+    workers: SERIAL_WORKERS,
+    // The rest of the lsyntax package (AST node defs, lexer, label-filter
+    // matching, operators, dotted-label normalisation); parser.go runs above.
+    exclude_files: '^parser\\.go$',
+  },
+
+  // ---------------------------------------------------------------------------
+  // phase4-traceql — four legs, split by PACKAGE.
+  //
+  // The original monolithic phase OOM-killed the runner after ~3 minutes: it
+  // contained ~109 timeout-inducing mutants in the recursive-descent parser plus
+  // tens of thousands more in lower.go. Round 11's first split OOM-killed
+  // `-other` (it kept most of the ast package) and the `-parser`/`-lower` legs
+  // errored before running: their exclude regexes used negative lookahead
+  // `(?!…)`, which Go's RE2 engine rejects — pinned now by mutation-matrix.mjs's
+  // RE2-safety assertion, so that mistake fails at PR time instead of mid-run.
+  // Round 12 splits into four legs, each an RE2-safe alternation of the files to
+  // exclude.
+  //
+  // Efficacy is preserved by scoping rather than lost: gremlins runs the mutated
+  // file's own package tests per mutant, so scoping the ast legs to
+  // ./internal/traceql/ast still runs parser_test.go / *_mutation_test.go.
+  // ---------------------------------------------------------------------------
+  {
+    phase: 'phase4-traceql-parser',
+    scope: './internal/traceql/ast',
+    efficacy: EFFICACY,
+    workers: SERIAL_WORKERS,
+    // ast/parser.go only — where the ~109 timeout-inducing loop-control mutants
+    // live. exclude-files matches SCOPE-RELATIVE paths (here, relative to
+    // ./internal/traceql/ast), so entries are bare filenames.
+    exclude_files: '^(assert|attribute|doc|enum|expr|lexer|metrics|parse|pipeline|rewrite|static)\\.go$',
+  },
+  {
+    phase: 'phase4-traceql-ast',
+    scope: './internal/traceql/ast',
+    efficacy: EFFICACY,
+    workers: SERIAL_WORKERS,
+    // The rest of the ast package (lexer + node defs); parser.go runs above.
+    exclude_files: '^parser\\.go$',
+  },
+  {
+    phase: 'phase4-traceql-lower',
+    scope: './internal/traceql',
+    efficacy: EFFICACY,
+    workers: SERIAL_WORKERS,
+    // lower.go only (~84 KB). scope ./internal/traceql recurses into ast/, so
+    // exclude the whole ast subtree plus the other top-level files.
+    exclude_files: '^ast/|^(aggregate|doc|group_coalesce|metrics_compare|metrics_pipeline|search_limit|select)\\.go$',
+  },
+  {
+    phase: 'phase4-traceql-other',
+    scope: './internal/traceql',
+    efficacy: EFFICACY,
+    workers: SERIAL_WORKERS,
+    // The remaining top-level files (aggregate, metrics_compare,
+    // metrics_pipeline, group_coalesce, search_limit, select).
+    exclude_files: '^ast/|^lower\\.go$',
+  },
+
+  {
+    phase: 'phase5-qlcommon',
+    scope: './internal/qlcommon',
+    efficacy: EFFICACY,
+    workers: DEFAULT_WORKERS,
+  },
+  // phase6-spansscan covers the shared spans-scan partition-pruning matcher —
+  // the predicate functions behind the universal emit-chokepoint guard and the
+  // perf/fanout corpus lint. A tiny stdlib-only leaf package, so the run is fast.
+  {
+    phase: 'phase6-spansscan',
+    scope: './internal/spansscan',
+    efficacy: EFFICACY,
+    workers: DEFAULT_WORKERS,
+  },
+];
+
+// Paths that change the LANE ITSELF rather than a single scope: the phase table,
+// the selector, the threshold gate, the workflow, gremlins' own config, and the
+// module graph every leg's `go test` links. A PR touching any of them gets the
+// FULL matrix, because a scoped subset would be testing the new harness against
+// an arbitrary slice of the tree and proving nothing about the rest.
+export const HARNESS_PATHS = [
+  '.github/workflows/mutation.yml',
+  '.github/scripts/mutation-phases.mjs',
+  '.github/scripts/mutation-matrix.mjs',
+  '.github/scripts/gremlins-threshold.mjs',
+  '.github/scripts/lib/scope-gate.mjs',
+  '.gremlins.yaml',
+  'go.mod',
+  'go.sum',
+];

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -580,6 +580,16 @@ jobs:
           node --test .github/scripts/compose-smoke-matrix.test.mjs
           node --test .github/scripts/dashboard-matrix.test.mjs
 
+      # Same discipline for the mutation lane's phase planner, one step further:
+      # its selector decides which legs an ordinary PR runs, so a bug there is
+      # not a slow release but a SILENT one — legs quietly deselected while the
+      # required `mutation` context still reports green. The tests pin the phase
+      # table against this tree (every scope a real directory, every
+      # exclude_files pattern legal under Go's RE2) and pin the selection
+      # EXACTLY, not merely non-empty.
+      - name: Assert the mutation phase selector scopes correctly
+        run: node --test .github/scripts/mutation-matrix.test.mjs
+
       # Committed-artefact discipline. Every other gate asks whether the tree
       # COMPILES and PASSES; none asks what it CONTAINS, so a build artefact
       # that gets `git add`-ed by accident survives indefinitely — a compiled

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -1,17 +1,27 @@
 name: mutation
 
 # Mutation testing runs on push-to-main + nightly + manual dispatch, and on
-# pull_request as a parity lane for the publish-on-merge release flow. The
-# `mutate` matrix is SKIPPED entirely on an ordinary (non-release) PR — zero
-# gremlins jobs queued — and runs the real gremlins kill-zone only on push /
-# schedule / dispatch and on a `release/*` PR (so a release PR's green status
-# includes mutation). The single `mutation` aggregator job is the required
-# status check: it treats a skipped matrix as a green pass-through, so an
-# ordinary PR still REPORTS the required context green without spinning up ~11
-# matrix legs. On ordinary PRs the lane stays the informational push/nightly
-# tool it always was (test-quality regressions, not prod-blocking bugs); the
-# job-level skip keeps the high matrix cost — and the runner-capacity drain of
-# queuing legs just to no-op — off non-release PRs.
+# pull_request as a real gate for the publish-on-merge release flow.
+#
+# On an ordinary PR the `mutate` matrix runs the legs whose SCOPE the PR
+# changed, and only those: a PR editing internal/chplan runs phase1, a PR
+# editing only docs runs no leg at all. The selection is computed by
+# .github/scripts/mutation-matrix.mjs from the PR's own diff against its merge
+# base; the phase table it selects from lives in mutation-phases.mjs. Push /
+# schedule / dispatch and `release/*` PRs sweep the FULL matrix, so no leg's
+# efficacy floor depends on some PR happening to touch its package.
+#
+# Previously the matrix was skipped WHOLESALE on any non-release PR and the
+# required `mutation` aggregator reported that skip as green. That is a hollow
+# green — a required check passing on work it never did — and it let a PR drop
+# internal/chplan below its 95% floor, merge green, and surface the regression
+# on the release PR, where it blocked the release instead of the change that
+# caused it. Scoping keeps the wall-clock win that motivated the skip (most PRs
+# still queue one leg or none) without the blind spot.
+#
+# The single `mutation` aggregator job remains the required status check. It
+# passes through green ONLY when the selector proved no phase scope changed,
+# and fails if the selector itself failed — an unknown selection is never a pass.
 
 on:
   pull_request:
@@ -25,299 +35,72 @@ permissions:
   contents: read
 
 jobs:
+  # select — decide WHICH phases this event runs, and emit them as the `mutate`
+  # strategy.matrix.
+  #
+  # The phase table itself lives in .github/scripts/mutation-phases.mjs, not
+  # inline here, because the selector has to REASON about it (match each leg's
+  # scope + scope-relative exclude_files against the PR diff, and assert the
+  # exclude patterns stay inside Go's RE2 dialect) — and a workflow `include:`
+  # block is data the workflow cannot read back. Same single-source-of-truth
+  # shape as compose-smoke-setup / .github/scripts/compose-smoke-matrix.mjs.
+  #
+  # Cheap by construction: node + a `git diff`, no toolchain, no gremlins. A
+  # docs-only PR pays a few seconds here and queues zero mutation legs.
+  select:
+    name: mutation-select
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      matrix: ${{ steps.emit.outputs.matrix }}
+      # `has_phases` is read by the aggregator to tell "nothing in scope
+      # changed" (a legitimate green) apart from "the matrix did not run" (not).
+      has_phases: ${{ steps.emit.outputs.has_phases }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # The selector diffs the PR head against its MERGE BASE, which a
+          # shallow clone cannot resolve. A failed diff is not read as "nothing
+          # changed" — mutation-matrix.mjs falls back to the full matrix — but
+          # that fallback is a safety net, not the intended path.
+          fetch-depth: 0
+
+      # BASE_SHA/HEAD_SHA are empty off pull_request; the selector already runs
+      # the full matrix for those events and never consults them.
+      - id: emit
+        name: select the phases this event runs
+        run: node .github/scripts/mutation-matrix.mjs
+        env:
+          MODE: emit
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_REF: ${{ github.head_ref }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+
   mutate:
     # Per-phase mutation kill-zone. gremlins v0.6.0 has no per-package
     # threshold, so each phase runs as its own matrix entry scoped to a
     # single package with its own --threshold-efficacy bar. The bar in
     # `.gremlins.yaml` (currently 95) is the floor for the unscoped
-    # whole-repo `just mutate` invocation only — the matrix below
-    # mirrors it per phase. All matrix entries stay informational on
-    # push-to-main + nightly + dispatch; promotion to a required PR
-    # gate happens after every phase stays green for a week at 95%.
-    #
-    # All phases sit at 95% efficacy: the nightly runs have been
-    # clearing every phase for an extended period, so the floor is
-    # unified. Never lower a bar without a follow-up PR that
-    # re-establishes the headroom + a clear test-quality rationale.
+    # whole-repo `just mutate` invocation only — the phase table in
+    # .github/scripts/mutation-phases.mjs mirrors it per phase, and carries
+    # the per-leg rationale (the logql/traceql OOM splits, the equivalent-mutant
+    # analysis behind each bar) that used to live in this block.
     name: gremlins ${{ matrix.phase }} (${{ matrix.scope }} @ ${{ matrix.efficacy }}%)
+    needs: select
+    # Skipped only when the selector proved NOTHING in any phase scope changed.
+    # The aggregator re-checks `has_phases`, so a skip here can never be mistaken
+    # for a pass over work that should have run.
+    if: ${{ needs.select.outputs.has_phases == 'true' }}
     runs-on: ubuntu-latest
-    # 90 (not 60): phase4-traceql runs workers=1 (see its matrix note) to stay
-    # under the runner memory ceiling, which serialises its ~109 timeout mutants
-    # and pushes its wall-clock toward an hour on a 2-core runner. The faster
+    # 90 (not 60): the parser legs run workers=1 (see mutation-phases.mjs) to
+    # stay under the runner memory ceiling, which serialises their ~109 timeout
+    # mutants and pushes wall-clock toward an hour on a 2-core runner. The faster
     # phases finish well inside this; it only bounds a genuinely-hung leg.
     timeout-minutes: 90
-    # Heavy mutation work runs on push / schedule / dispatch, and on a release
-    # PR (head branch release/*). On an ordinary (non-release) pull_request the
-    # ENTIRE matrix is SKIPPED — zero gremlins jobs queued — so the high matrix
-    # cost never lands on routine PRs. The `mutation` aggregator below treats a
-    # skipped matrix as a green pass-through so the required check still reports.
-    # Previously the matrix queued ~11 no-op legs per non-release PR (RUN_HEAVY
-    # short-circuit); skipping the job at the source keeps runner capacity free.
-    if: ${{ github.event_name != 'pull_request' || startsWith(github.head_ref, 'release/') }}
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - phase: phase1
-            scope: ./internal/chplan
-            efficacy: 95
-            workers: 0
-          - phase: phase2
-            scope: ./internal/chsql
-            efficacy: 95
-            workers: 0
-          - phase: phase3-optimizer
-            scope: ./internal/optimizer
-            efficacy: 95
-            workers: 0
-          - phase: phase4-promql
-            scope: ./internal/promql
-            efficacy: 95
-            workers: 0
-          # phase4-logql historically OOM-killed the ubuntu-latest
-          # runner (~7 GB RAM) at the 3-minute mark. Rounds 1-3
-          # tried gremlins' default `runtime.NumCPU()` workers and
-          # the runner died ~3 min in. Round 4 capped workers at 2,
-          # round 5 dropped to workers=1, and round 6's job log
-          # (77180086677, 2026-05-21T13:13:26Z) confirmed
-          # `--workers "1"` engaged, every emitted mutant was KILLED
-          # (no LIVED), gremlins.json never written, and the runner
-          # received a shutdown signal at the same ~3m37s mark. The
-          # bottleneck is therefore NOT parallel `go test` fan-out
-          # but cumulative runner RSS growth from gremlins'
-          # long-lived process state + each mutant's full
-          # `go test ./internal/logql` cycle dragging the heavy
-          # LogQL parser dep graph (loki + prometheus + dskit +
-          # memberlist) through the linker. Workers=1 alone cannot
-          # land below the ceiling because the wall-clock budget
-          # before OOM admits ~80 of ~300+ mutants in the package.
-          #
-          # Round 7 split phase4-logql into three sibling matrix
-          # entries (lower / aggregation / other), each scoped to
-          # `./internal/logql` but with `--exclude-files` regexes
-          # carving the source set into roughly equal slices.
-          # `phase4-logql-lower` landed green. `aggregation` ran
-          # cleanly to completion in ~1m32s (Killed: 106, Lived: 7
-          # — efficacy gap, not runner budget) so it does not need
-          # further splitting; the 7 LIVED mutants are tracked as
-          # test-quality follow-up and the mutation lane stays
-          # informational per CLAUDE.md until each sub-phase has
-          # held green for a week. `other` still OOM-killed the
-          # runner at ~3 min after processing binary.go +
-          # detected_level.go + dotted_labels.go (partial), never
-          # reaching literal.go / label_fns.go / top_level_columns.go.
-          #
-          # Round 8 split `other` into two sibling entries
-          # `other-a` (binary + detected_level + dotted_labels) +
-          # `other-b` (literal + label_fns + top_level_columns).
-          # `other-b` landed green but `other-a` still OOM-killed
-          # the runner at ~4 min (job 77205717481, shutdown signal
-          # at 15:19:38Z after starting 15:15:44Z). The kill log
-          # showed every emitted mutant KILLED (0 LIVED) right up
-          # to dotted_labels.go:203 — same wall-clock-budget
-          # signature as the earlier rounds. binary.go +
-          # detected_level.go finished cleanly inside ~2.5 min;
-          # dotted_labels.go alone was responsible for pushing the
-          # job past the ceiling because it carries the bulk of
-          # the package's mutable surface (the OTel dotted-label
-          # walker has the most branchy code in logql/).
-          #
-          # Round 9 peeled dotted_labels.go off into its own slice
-          # `other-c` (mutating just that single ~7 KB file with
-          # `--workers 1`). Round 10's job 77211633492 confirmed
-          # the slice still SIGTERM'd at ~3 min after admitting
-          # ~40 mutants of the file (every emitted mutant KILLED,
-          # 0 LIVED) — the runner-budget ceiling sits below even
-          # a single-file slice of this surface. The bottleneck
-          # is cumulative gremlins-driver RSS plus each mutant's
-          # full `go test ./internal/logql` cycle re-linking the
-          # loki + prometheus + dskit + memberlist parser dep
-          # graph; there's nothing left to slice. dotted_labels.go
-          # is now excluded from gremlins runs entirely via
-          # `.gremlins.yaml` excluded-files (see the rationale
-          # block there), and the `phase4-logql-other-c` matrix
-          # entry is dropped. The file is still covered by
-          # Layer-2 TXTAR fixtures + the standalone unit tests in
-          # `dotted_labels_test.go`. Re-introduce the phase when
-          # gremlins gains an incremental-test-binary mode or the
-          # lane moves to a larger runner class.
-          #
-          # phase4-logql-aggregation was historically relaxed to 93
-          # (94.83%, 18 LIVED) citing equivalent mutants. The KILLABLE
-          # survivors are now pinned by range_aggregation_mutation_test.go
-          # + vector_aggregation_mutation_test.go (10 killed: absent-window
-          # Interval+Offset arithmetic, the absent synth-label conjunction,
-          # the post-filter error-mark return gate, the topk/quantile
-          # outer-by threading + ungrouped-partition guards — each verified
-          # by hand-applying the mutation). The remaining survivors are
-          # GENUINELY EQUIVALENT and can't be killed:
-          #   - `make([]Expr, 0, len(Groups)*2 (+1))` slice-CAPACITY hints
-          #     (range_aggregation.go, vector_aggregation.go, duration.go)
-          #     — a cap literal changes only allocator behaviour, not
-          #     output (CLAUDE.md: capacity hints out of scope).
-          #   - empty-group CONDITIONALS_BOUNDARY guards (`len(...) > 0` vs
-          #     `>= 0`) whose only distinguishing input (`by ()`) threads a
-          #     len-0 label slice the lowering collapses to nil — a
-          #     byte-identical no-op.
-          # With the killable set covered the bar is RAISED BACK TO 95; the
-          # equivalents sit comfortably under it (~97.7%).
-          # Round 13 (2026-07-25, this incident): all four phase4-logql-*
-          # legs below started dying with the same "runner received a
-          # shutdown signal" OOM signature ~20-25 min into every push-to-main
-          # run, 100% reproducible, starting exactly at the commit that
-          # moved internal/logql/dotted_labels.go's implementation AND its
-          # large table-driven test suite into internal/logql/lsyntax
-          # (dotted_labels_test.go went from package logql to package
-          # lsyntax). `scope: ./internal/logql` recurses into every
-          # subdirectory (gremlins walks the whole scope tree), so
-          # internal/logql/lsyntax/*.go was ALREADY being swept into these
-          # four legs — none of the exclude_files regexes below ever
-          # covered lsyntax's own files (ast.go, lexer.go, parser.go, …),
-          # only dotted_labels.go itself (matched by filename regardless of
-          # directory). Once dotted_labels_test.go relocated into package
-          # lsyntax, every covered mutant found anywhere in lsyntax now
-          # forces `go test .../internal/logql/lsyntax` to link and run
-          # that heavier test binary, on every one of the four legs, and
-          # cumulative runner RSS crossed the ubuntu-latest ceiling before
-          # the run finished — the same root cause documented for
-          # dotted_labels.go itself in rounds 4-10 above, just reached via
-          # a different file. Fix: exclude the whole lsyntax subtree
-          # (scope-relative '^lsyntax/', mirroring the phase4-traceql-lower
-          # '^ast/' precedent below) from all four legs, and give lsyntax
-          # its own dedicated phase4-logql-parser / phase4-logql-lsyntax
-          # legs (see below phase4-traceql-parser/-ast) so the package
-          # keeps its mutation coverage instead of losing it.
-          - phase: phase4-logql-lower
-            scope: ./internal/logql
-            efficacy: 95
-            workers: 1
-            # Mutate only lower.go (~50 KB, the package's largest
-            # source file). Excludes every other logql source plus the
-            # lsyntax subtree (own dedicated legs below).
-            exclude_files: '^lsyntax/|(binary|detected_level|dotted_labels|literal|label_fns|top_level_columns|range_aggregation|vector_aggregation|lang)\.go$|^logpattern/|^(doc|duration|ip|jsonpath|numbytes|pattern_filter|variants)\.go$'
-          - phase: phase4-logql-aggregation
-            scope: ./internal/logql
-            efficacy: 95
-            workers: 1
-            # Mutate range_aggregation.go + vector_aggregation.go +
-            # lang.go (~54 KB total). Excludes everything else.
-            # Bar at 93 (not 95) — see round-10 rationale above.
-            exclude_files: '^lsyntax/|(binary|detected_level|dotted_labels|literal|label_fns|top_level_columns|lower)\.go$|^logpattern/|^(doc|duration|ip|jsonpath|numbytes|pattern_filter|variants)\.go$'
-          - phase: phase4-logql-other-a
-            scope: ./internal/logql
-            efficacy: 95
-            workers: 1
-            # Mutate binary.go + detected_level.go + dotted_labels.go
-            # (~21 KB total). Round 8's `other-a` OOM-killed the runner
-            # inside dotted_labels.go, which is why later rounds carved
-            # it out. That was the runaway-mutant class — now bounded by
-            # --timeout-max — so the file is mutated here again rather
-            # than left uncovered.
-            exclude_files: '^lsyntax/|(lower|range_aggregation|vector_aggregation|lang|literal|label_fns|top_level_columns)\.go$|^logpattern/|^(doc|duration|ip|jsonpath|numbytes|pattern_filter|variants)\.go$'
-          - phase: phase4-logql-other-b
-            scope: ./internal/logql
-            efficacy: 95
-            workers: 1
-            # The catch-all leg: literal.go + label_fns.go +
-            # top_level_columns.go, plus every file no other leg claims
-            # (doc.go, duration.go, ip.go, jsonpath.go, numbytes.go,
-            # pattern_filter.go, variants.go, logpattern/). Those
-            # stragglers used to fall through all four ./internal/logql
-            # legs' regexes, so they were mutated four times over; they
-            # are now excluded from the other three and land here.
-            # A file newly added to internal/logql needs no edit — it is
-            # picked up here automatically, which is why this leg keeps
-            # no positive file list to fall out of sync.
-            exclude_files: '^lsyntax/|(lower|range_aggregation|vector_aggregation|lang|binary|detected_level|dotted_labels)\.go$'
-          - phase: phase4-logql-parser
-            scope: ./internal/logql/lsyntax
-            efficacy: 95
-            workers: 1
-            # Mutate parser.go only (~27 KB, the recursive-descent
-            # LogQL parser — the densest control-flow surface in the
-            # package, same shape as phase4-traceql-parser below).
-            # dotted_labels.go belongs to the phase4-logql-lsyntax leg.
-            exclude_files: '^(ast|binop|dotted_labels|errors|labelfilter|lexer|ops|string)\.go$'
-          - phase: phase4-logql-lsyntax
-            scope: ./internal/logql/lsyntax
-            efficacy: 95
-            workers: 1
-            # Mutate the rest of the lsyntax package (AST node defs,
-            # lexer, label-filter matching, operators, dotted-label
-            # normalisation); parser.go runs in its own leg above.
-            exclude_files: '^parser\.go$'
-          # phase4-traceql historically OOM-killed the ubuntu-latest runner
-          # (~7 GB RAM) after ~3 minutes. The original monolithic phase
-          # contained ~109 timeout-inducing mutants in the recursive-descent
-          # parser plus tens of thousands more in lower.go. Even with
-          # workers=1 to serialize test cycles, cumulative gremlins-driver RSS
-          # plus each mutant's full `go test` re-link of the in-house TraceQL
-          # parser + lowering dep graph pushes past the ceiling. Round 11's
-          # first split OOM-killed `-other` (it kept most of the ast package)
-          # and the `-parser`/`-lower` legs errored before running: their
-          # exclude regexes used negative lookahead `(?!…)`, which Go's RE2
-          # engine rejects. Round 12 splits by PACKAGE into four legs, each an
-          # RE2-safe alternation of the files to exclude (no lookahead):
-          #
-          # - parser: ast/parser.go only — the recursive-descent parser, where
-          #   the ~109 timeout-inducing loop-control/conditional mutants live.
-          # - ast:    the rest of the internal/traceql/ast package (lexer + the
-          #   AST node defs).
-          # - lower:  lower.go only (the ~84 KB lowering file).
-          # - other:  the remaining top-level files (aggregate, metrics_compare,
-          #   metrics_pipeline, group_coalesce, search_limit, select).
-          #
-          # Efficacy is preserved: gremlins runs the mutated file's own package
-          # tests per mutant, so scoping the ast legs to ./internal/traceql/ast
-          # still runs parser_test.go / *_mutation_test.go. If a leg still
-          # OOM-kills, split it further or exclude the file in .gremlins.yaml
-          # (per the dotted_labels.go precedent); it stays covered by Layer-2
-          # TXTAR fixtures + unit tests. Promotion to required after all hold
-          # green for a week.
-          - phase: phase4-traceql-parser
-            scope: ./internal/traceql/ast
-            efficacy: 95
-            workers: 1
-            # Mutate ast/parser.go only; exclude the rest of the ast package.
-            # exclude-files matches SCOPE-RELATIVE paths (here, relative to
-            # ./internal/traceql/ast), so entries are bare filenames.
-            exclude_files: '^(assert|attribute|doc|enum|expr|lexer|metrics|parse|pipeline|rewrite|static)\.go$'
-          - phase: phase4-traceql-ast
-            scope: ./internal/traceql/ast
-            efficacy: 95
-            workers: 1
-            # Mutate the rest of the ast package (lexer + node defs); parser.go
-            # runs in its own leg above.
-            exclude_files: '^parser\.go$'
-          - phase: phase4-traceql-lower
-            scope: ./internal/traceql
-            efficacy: 95
-            workers: 1
-            # Mutate lower.go only. scope ./internal/traceql recurses into ast/,
-            # so exclude the whole ast subtree (scope-relative '^ast/') plus the
-            # other top-level files.
-            exclude_files: '^ast/|^(aggregate|doc|group_coalesce|metrics_compare|metrics_pipeline|search_limit|select)\.go$'
-          - phase: phase4-traceql-other
-            scope: ./internal/traceql
-            efficacy: 95
-            workers: 1
-            # Mutate the remaining top-level files; exclude lower.go + the ast
-            # subtree (scope-relative, ast/ pulled in by recursion).
-            exclude_files: '^ast/|^lower\.go$'
-          - phase: phase5-qlcommon
-            scope: ./internal/qlcommon
-            efficacy: 95
-            workers: 0
-          # phase6-spansscan covers the shared spans-scan partition-pruning
-          # matcher (internal/spansscan) — the predicate functions behind the
-          # universal emit-chokepoint guard and the perf/fanout corpus lint.
-          # It is a tiny stdlib-only leaf package, so the run is fast; the bar
-          # matches every other phase. Stays informational until it holds green
-          # for a week, per the rollout note above.
-          - phase: phase6-spansscan
-            scope: ./internal/spansscan
-            efficacy: 95
-            workers: 0
+      matrix: ${{ fromJSON(needs.select.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
@@ -391,37 +174,51 @@ jobs:
           retention-days: 14
 
   # Single rolled-up required-check context (mirrors compose-smoke). The matrix
-  # above exposes ONE .result to dependents: `success` only if EVERY phase
-  # succeeded, `failure`/`cancelled` if any did, `skipped` when the whole job is
-  # skipped at the source (non-release PR). On a non-release PR the matrix is
-  # SKIPPED, so this passes the required check through green WITHOUT queuing any
-  # gremlins legs; on a release/* PR or a push it reflects the real efficacy
-  # gate. `if: always()` guarantees the context always REPORTS (never resolves
-  # to "Expected" / never-reports, which would deadlock branch protection). Add
-  # `mutation` (not the per-phase `gremlins …` names) as the required check.
+  # above exposes ONE .result to dependents: `success` only if EVERY selected
+  # phase succeeded, `failure`/`cancelled` if any did, `skipped` when nothing in
+  # any phase scope changed. `if: always()` guarantees the context always REPORTS
+  # (never resolves to "Expected" / never-reports, which would deadlock branch
+  # protection). Add `mutation` (not the per-phase `gremlins …` names) as the
+  # required check.
+  #
+  # The gate is a decision table over TWO facts, not one, and that is the point:
+  # a skipped matrix is green ONLY when `select` succeeded AND reported that it
+  # chose no phases. A skip for any other reason — the selector crashed, the
+  # matrix was dropped — is a failure. Reading `mutate.result == skipped` alone
+  # is what made this check hollow before.
   mutation:
     name: mutation
-    needs: [mutate]
+    needs: [select, mutate]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: gate on every mutation phase
         run: |
+          echo "select = ${{ needs.select.result }} (has_phases = '${{ needs.select.outputs.has_phases }}')"
           echo "mutate = ${{ needs.mutate.result }}"
-          # Non-release PR → the `mutate` matrix is skipped at the job-level `if`.
-          # The required check must report green without work, mirroring the
-          # compose-smoke aggregator's docs-only skip pass-through.
+
+          # An unknown selection is never a pass: without it there is no claim
+          # about what was or wasn't checked.
+          if [ "${{ needs.select.result }}" != "success" ]; then
+            echo "::error::mutation-select did not succeed (${{ needs.select.result }}) — the set of phases this change needs is unknown, so this check cannot report green."
+            exit 1
+          fi
+
           if [ "${{ needs.mutate.result }}" = "skipped" ]; then
-            echo "mutation matrix skipped on non-release PR — required check passes through."
+            if [ "${{ needs.select.outputs.has_phases }}" = "true" ]; then
+              echo "::error::mutation-select chose phases to run but the matrix was skipped — the required check would otherwise pass over work that never ran."
+              exit 1
+            fi
+            echo "no changed path falls in any mutation phase scope — nothing for this lane to check."
             exit 0
           fi
-          # Heavy case (push / schedule / dispatch / release-PR): strict
-          # != 'success' catches failure AND cancelled (a contains-failure check
-          # would miss a cancelled phase). fail-fast:false keeps a real efficacy
-          # failure a clean `failure`, not an ambiguous `cancelled`.
+
+          # Strict != 'success' catches failure AND cancelled (a contains-failure
+          # check would miss a cancelled phase). fail-fast:false keeps a real
+          # efficacy failure a clean `failure`, not an ambiguous `cancelled`.
           if [ "${{ needs.mutate.result }}" != "success" ]; then
             echo "::error::one or more mutation phases failed/cancelled (rolled-up: ${{ needs.mutate.result }})."
             exit 1
           fi
-          echo "all mutation phases green."
+          echo "all selected mutation phases green."

--- a/test/regression/mutation_leg_partition_test.go
+++ b/test/regression/mutation_leg_partition_test.go
@@ -1,13 +1,14 @@
 package regression
 
 import (
+	"encoding/json"
+	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
-
-	"gopkg.in/yaml.v3"
 )
 
 // repoRoot locates the module root from this package's directory.
@@ -16,27 +17,51 @@ const repoRoot = "../.."
 // testdataDir holds fixture inputs, not mutable production source.
 const testdataDir = "testdata"
 
-// mutationMatrixJob is the job whose matrix partitions packages across legs.
-const mutationMatrixJob = "mutate"
+// mutationMatrixScript owns the phase table mutation.yml expands into its
+// matrix. It is JavaScript rather than YAML because the selector that reads it
+// has to reason about each leg's scope and exclude regex, and a workflow's own
+// `include:` block is data the workflow cannot read back.
+const mutationMatrixScript = ".github/scripts/mutation-matrix.mjs"
 
-// mutationWorkflow mirrors just enough of mutation.yml to read the leg matrix.
-// Everything else in the file is deliberately left untyped: this test pins the
-// file/leg partition, not the workflow's shape.
-type mutationWorkflow struct {
-	Jobs map[string]struct {
-		Strategy struct {
-			Matrix struct {
-				Include []mutationLeg `yaml:"include"`
-			} `yaml:"matrix"`
-		} `yaml:"strategy"`
-	} `yaml:"jobs"`
-}
+// mutationMatrixDumpMode makes that script write the validated table to stdout
+// as JSON and nothing else, which is how this test reads it.
+const mutationMatrixDumpMode = "dump"
 
 // mutationLeg is one matrix entry: a package scope plus the files it skips.
 type mutationLeg struct {
-	Phase        string `yaml:"phase"`
-	Scope        string `yaml:"scope"`
-	ExcludeFiles string `yaml:"exclude_files"`
+	Phase        string `json:"phase"`
+	Scope        string `json:"scope"`
+	ExcludeFiles string `json:"exclude_files"`
+}
+
+// mutationLegs reads the phase table by running the script that owns it, so
+// this test and the CI selector can never disagree about what the legs are.
+//
+// A missing `node` is a hard failure, not a reason to pass: the repo already
+// requires node for commitlint, markdownlint, and every .github/scripts module,
+// and a partition check that quietly opts out on a thin machine is exactly the
+// silent gap the assertions below exist to close.
+func mutationLegs(t *testing.T) []mutationLeg {
+	t.Helper()
+
+	cmd := exec.Command("node", mutationMatrixScript, mutationMatrixDumpMode)
+	cmd.Dir = repoRoot
+	out, err := cmd.Output()
+	if err != nil {
+		var stderr string
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			stderr = string(exitErr.Stderr)
+		}
+		t.Fatalf("run `node %s %s`: %v\n%s", mutationMatrixScript, mutationMatrixDumpMode, err, stderr)
+	}
+
+	var legs []mutationLeg
+	if err := json.Unmarshal(out, &legs); err != nil {
+		t.Fatalf("parse the %s table: %v", mutationMatrixScript, err)
+	}
+
+	return legs
 }
 
 // TestMutationLegsPartitionEveryScopedFile pins the invariant that every
@@ -65,27 +90,10 @@ type mutationLeg struct {
 func TestMutationLegsPartitionEveryScopedFile(t *testing.T) {
 	t.Parallel()
 
-	raw, err := os.ReadFile(mutationWorkflowPath)
-	if err != nil {
-		t.Fatalf("read %s: %v", mutationWorkflowPath, err)
-	}
-
-	var wf mutationWorkflow
-	if err := yaml.Unmarshal(raw, &wf); err != nil {
-		t.Fatalf("parse %s: %v", mutationWorkflowPath, err)
-	}
-
-	job, ok := wf.Jobs[mutationMatrixJob]
-	if !ok {
-		t.Fatalf("%s has no %q job; if the mutation matrix moved, re-point this test at it rather "+
-			"than deleting it — the partition it guards is still unenforced anywhere else.",
-			mutationWorkflowPath, mutationMatrixJob)
-	}
-
-	legs := job.Strategy.Matrix.Include
+	legs := mutationLegs(t)
 	if len(legs) == 0 {
-		t.Fatalf("%s job %q declares no matrix legs; the partition check below would vacuously pass",
-			mutationWorkflowPath, mutationMatrixJob)
+		t.Fatalf("%s declares no matrix legs; the partition check below would vacuously pass",
+			mutationMatrixScript)
 	}
 
 	// claims[file] = the legs that mutate it.
@@ -102,19 +110,20 @@ func TestMutationLegsPartitionEveryScopedFile(t *testing.T) {
 
 		var exclude *regexp.Regexp
 		if leg.ExcludeFiles != "" {
-			exclude, err = regexp.Compile(leg.ExcludeFiles)
+			compiled, err := regexp.Compile(leg.ExcludeFiles)
 			if err != nil {
 				t.Errorf("matrix leg %q has an uncompilable exclude_files %q: %v",
 					leg.Phase, leg.ExcludeFiles, err)
 
 				continue
 			}
+			exclude = compiled
 		}
 
 		for _, file := range mutableGoFiles(t, dir) {
-			rel, relErr := filepath.Rel(dir, file)
-			if relErr != nil {
-				t.Fatalf("relativise %s against %s: %v", file, dir, relErr)
+			rel, err := filepath.Rel(dir, file)
+			if err != nil {
+				t.Fatalf("relativise %s against %s: %v", file, dir, err)
 			}
 			scoped[file] = true
 			// gremlins matches exclude_files against the path relative to the
@@ -128,7 +137,7 @@ func TestMutationLegsPartitionEveryScopedFile(t *testing.T) {
 
 	if len(scoped) == 0 {
 		t.Fatalf("no mutable Go files found under any matrix scope in %s; the scopes are probably "+
-			"wrong, and every assertion below would vacuously pass", mutationWorkflowPath)
+			"wrong, and every assertion below would vacuously pass", mutationMatrixScript)
 	}
 
 	for file := range scoped {


### PR DESCRIPTION
## What

Backports the **mutation half** of #1378 to `release/1.12.x`, and only that half.

## Why

`mutation` is one of the 12 required status checks in the `release maintenance lines` ruleset (id `18472142`, `refs/heads/release/*.x`). On this line it reports green having run **zero legs**: the job-level `if:` skips the whole matrix unless the event is a push / schedule / dispatch / `release/*` PR, and the aggregator reads that skip as a pass-through.

So an ordinary backport PR into `release/1.12.x` satisfies a required check that never looked at its diff. That is a hollow green — a required context reporting on work it never did.

**This already happened, on the PR that merged an hour ago.** #1393 carried a production type narrowing in `internal/chsql/ddl.go` (`EnumPair.Value` `int64` → `int8`) squarely inside phase2's scope, and merged with `mutation` SUCCESS and every `gremlins` leg SKIPPED. The same shape is on #1367 and #1375.

## Why only half

#1378's compose-smoke/e2e half is deliberately excluded: `e2e.yml` diverges from main's by 363 lines on this line, and that half is a PR wall-time optimisation whose mis-resolution would itself fail as a clean green. The mutation half needs no such judgement — `release/1.12.x`'s `mutation.yml` is **byte-identical** to `c6c8154e^`'s, so it ports with zero conflict. Same for `mutation_leg_partition_test.go` and `gremlins-threshold.mjs`.

`release_required_checks_test.go` does not exist on this line, so #1378's hunk for it is dropped.

## Verified against this tree, not assumed

| Check | Result |
|---|---|
| `MODE=verify mutation-matrix.mjs` | `16 phases, table sound` — every scope a real directory on this line, every `exclude_files` pattern legal under RE2 |
| `node --test mutation-matrix.test.mjs` | 18/18 pass |
| Replay #1393's own diff (`f5a4f87f..a7822440`), non-`release/` head | selects **all 16 legs** (it bumps `go.mod`, a harness path) — previously **zero** |
| Replay #1389 alone (`internal/chsql/ddl.go`) | selects **exactly `phase2`** — scoped, not just always-full |

The last two rows are the point: the gate **activates**, and it activates *scoped*. A port that verified clean but selected nothing would be indistinguishable from the bug it fixes.

## Expected on this PR

It touches the lane's own harness, so it sweeps the **full 16-leg matrix**. That matrix has not run on this line since #1377 (the v1.12.3 staging PR), which predates #1384/#1385/#1387/#1389/#1390. If a leg lands under its 95% floor, the fix is to raise the coverage — not to re-exclude #1378.

## Ordering

Merges **before** v1.12.4 is staged, so the fix ships in that release rather than waiting for a v1.12.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)