### PR TITLE
chore(release): cerberus v1.14.0 / chart 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to cerberus will be documented in this file. The format roug
 
 ## [Unreleased]
 
+## [v1.14.0] — 2026-07-30
+
+### Fixed
+
+- **ci:** pre-release audit fixes for v1.14.0 (#1391)
+- **compose:** give every stack a per-checkout project name (#1390)
+- **routerrules:** stop geometry gates firing on every unclassified failure (#1389)
+- **solver:** distinguish routing-disabled from below-threshold (#1385)
+- **solver:** record the real cost grid on every routing refusal (#1384)
+- **brew:** migrate existing formula installs to the cask (#1380)
+
+### Performance
+
+- **promql:** defer OTel label shaping past the native rate grid (#1388)
+
+### CI
+
+- **mutation:** run the legs a PR's scope changed instead of skipping all (#1378)
+
+### Documentation
+
+- cask-only brew instructions and a README humans can skim (#1386)
+
 ## [v1.13.2] — 2026-07-29
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to cerberus will be documented in this file. The format roug
 
 ## [v1.14.0] — 2026-07-30
 
+A minor rather than a patch because of the PromQL label-shaping hoist (#1388): OTel attribute shaping now happens after the native rate grid instead of before it, which changes the emitted SQL shape for every `rate()`-family query over shaped labels. Answers are unchanged — the rewrite is only sound for `-State`/`-Merge` aggregates, and the naive form of it returns wrong results — but the plan a query produces is not what v1.13.x produced, so it does not belong in a patch release.
+
 ### Fixed
 
 - **ci:** pre-release audit fixes for v1.14.0 (#1391)
@@ -26,6 +28,7 @@ All notable changes to cerberus will be documented in this file. The format roug
 ### Documentation
 
 - cask-only brew instructions and a README humans can skim (#1386)
+- **migration:** install the cask, not the formula (#1383)
 
 ## [v1.13.2] — 2026-07-29
 

--- a/deploy/helm/cerberus/Chart.yaml
+++ b/deploy/helm/cerberus/Chart.yaml
@@ -8,11 +8,11 @@ type: application
 # upgrade?" and is the publish trigger: a chart-only fix bumps this without an
 # app re-tag; an app-only release bumps appVersion + a PATCH here for the new
 # default image. Starts 0.x because the values contract is not yet frozen.
-version: 0.13.2
+version: 0.14.0
 
 # appVersion tracks the GA cerberus binary. Quoted so SemVer-shaped values
 # aren't coerced to floats. image.tag defaults from this when left empty.
-appVersion: "1.13.2"
+appVersion: "1.14.0"
 
 # autoscaling/v2 + policy/v1 (PDB) + networking/v1 (Ingress) are all GA from
 # 1.21+; 1.23 is the conservative floor matching the manifests this chart
@@ -45,27 +45,21 @@ annotations:
       url: https://github.com/tsouza/cerberus/blob/main/docs/operations.md
   artifacthub.io/images: |
     - name: cerberus
-      image: ghcr.io/tsouza/cerberus:v1.13.2
+      image: ghcr.io/tsouza/cerberus:v1.14.0
   # Bump the `1.0.0` floor here when the chart raises its minimum supported
   # cerberus release; informational for Artifact Hub's compatibility hints.
   artifacthub.io/changes: |
     - kind: fixed
-      description: "tempo: stop zero-fill buckets turning quantiles into NaN (#1374)"
+      description: "ci: pre-release audit fixes for v1.14.0 (#1391)"
     - kind: fixed
-      description: "ci: analyse cold in the lint lane so a cache cannot decide the gate (#1363)"
+      description: "compose: give every stack a per-checkout project name (#1390)"
     - kind: fixed
-      description: "ci: publish compat-scores from a scratch worktree, not the checkout (#1361)"
+      description: "routerrules: stop geometry gates firing on every unclassified failure (#1389)"
     - kind: fixed
-      description: "chsql: name the canonical key-order function once, not twice (#1365)"
+      description: "solver: distinguish routing-disabled from below-threshold (#1385)"
     - kind: fixed
-      description: "chsql: canonicalise raw attribute-Map series keys at the emit chokepoint (#1362)"
+      description: "solver: record the real cost grid on every routing refusal (#1384)"
     - kind: fixed
-      description: "ci: run the Tier-0 explain goldens on pull requests (#1364)"
-    - kind: fixed
-      description: "loki: canonicalise Map key order on metadata series-identity keys (#1360)"
-    - kind: fixed
-      description: "logql: canonicalise Map key order on stream-identity keys (#1358)"
-    - kind: fixed
-      description: "chsql: dedupe TraceQL structural unions on span identity (#1357)"
-    - kind: fixed
-      description: "promql: canonicalise Map key order on the non-join and histogram paths (#1356)"
+      description: "brew: migrate existing formula installs to the cask (#1380)"
+    - kind: changed
+      description: "promql: defer OTel label shaping past the native rate grid (#1388)"

--- a/deploy/helm/cerberus/README.md
+++ b/deploy/helm/cerberus/README.md
@@ -5,7 +5,7 @@
      pipe-aligned, and the version footer adds a trailing blank — both are
      owned by helm-docs; realigning would fight the chart-ci drift check. -->
 
-![Version: 0.13.2](https://img.shields.io/badge/Version-0.13.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.13.2](https://img.shields.io/badge/AppVersion-1.13.2-informational?style=flat-square)
+![Version: 0.14.0](https://img.shields.io/badge/Version-0.14.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.14.0](https://img.shields.io/badge/AppVersion-1.14.0-informational?style=flat-square)
 
 Drop-in Prometheus / Loki / Tempo HTTP gateway for ClickHouse — a single stateless gateway that speaks three upstream query wire formats and lowers each to parameterised ClickHouse SQL.
 


### PR DESCRIPTION
Release-prep for **v1.14.0** (chart **0.14.0**), generated by `prepare-release.yml`.

- appVersion 1.13.2 -> 1.14.0, chart 0.13.2 -> 0.14.0

### Changes

### Fixed

- **ci:** pre-release audit fixes for v1.14.0 (#1391)
- **compose:** give every stack a per-checkout project name (#1390)
- **routerrules:** stop geometry gates firing on every unclassified failure (#1389)
- **solver:** distinguish routing-disabled from below-threshold (#1385)
- **solver:** record the real cost grid on every routing refusal (#1384)
- **brew:** migrate existing formula installs to the cask (#1380)

### Performance

- **promql:** defer OTel label shaping past the native rate grid (#1388)

### CI

- **mutation:** run the legs a PR's scope changed instead of skipping all (#1378)

### Documentation

- cask-only brew instructions and a README humans can skim (#1386)

Generated from the conventional commits since the last tag. Review and edit before merging; the tag is cut once this lands.
