### PR TITLE
fix(ci): stop capture() executing a program named by the environment

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -864,7 +864,7 @@ uncomputable-diff fallback — cannot drift between the lanes that use it.
   half pair never yields a plan in either direction.
   - Env: `CERBERUS_IMAGE_INPUT` / `CERBERUS_EXPECT_VERSION_INPUT` (the two
     workflow inputs; both empty = build from source, both set = test that
-    image, exactly one set = error), `BUILD_DIR` (default `build`),
+    image, exactly one set = error),
     `GITHUB_ENV` (the runner file `CERBERUS_BIN` / `CERBERUS_IMAGE` /
     `CERBERUS_EXPECT_VERSION` are appended to), `COMPOSE_PROJECT_SUFFIX` (the
     per-checkout suffix the local image tag carries, so the tag this module

--- a/.github/scripts/brew-upgrade-path.mjs
+++ b/.github/scripts/brew-upgrade-path.mjs
@@ -247,8 +247,8 @@ function main() {
   // cask, and Homebrew creates the directory on the first one. A runner image
   // that has never installed a cask would otherwise steer this job onto the
   // print-only branch and red it for a reason that is not a defect.
-  const caskroom = `${brewOrFail(['--prefix'], '`brew --prefix`').stdout.trim()}/Caskroom`;
-  mkdirSync(caskroom, { recursive: true });
+  const brewPrefix = brewOrFail(['--prefix'], '`brew --prefix`').stdout.trim();
+  mkdirSync(`${brewPrefix}/Caskroom`, { recursive: true });
 
   notice(`brew-upgrade-path: reconstructed a formula install at ${legacyRev}; expecting ${expectedVersion} after update.`);
 
@@ -275,7 +275,23 @@ function main() {
   // because capture() does not forward a `shell` option.
   const which = capture('sh', ['-c', 'command -v cerberus']);
   const resolved = which.status === 0 ? which.stdout.trim() : '';
-  const versionRes = resolved ? capture(resolved, ['--version']) : { status: 1, stdout: '', stderr: '' };
+
+  // WHERE it resolved is an assertion, not a log line. This job's claim is that
+  // the cask is what a migrated machine now runs, and a `cerberus` sitting
+  // anywhere else on PATH would satisfy the version match below while the link
+  // the migration exists to create was never made — green for the wrong reason.
+  if (resolved !== '' && !resolved.startsWith(`${brewPrefix}/`)) {
+    fail(
+      `\`cerberus\` resolves to ${resolved}, which is outside the Homebrew prefix ${brewPrefix}. ` +
+        `Whatever that binary is, it is not the cask this job installed, so the version it reports ` +
+        `says nothing about whether the migration linked.`,
+    );
+  }
+
+  // Probed under its bare name so PATH does the resolving — both what an
+  // operator actually types, and what keeps a path this module derived at
+  // runtime from becoming the program it executes.
+  const versionRes = resolved ? capture('cerberus', ['--version']) : { status: 1, stdout: '', stderr: '' };
   const reported = versionRes.status === 0 ? versionRes.stdout.trim() : '<not on PATH>';
 
   const problems = upgradeOutcomeProblems({

--- a/.github/scripts/migration-artifact.mjs
+++ b/.github/scripts/migration-artifact.mjs
@@ -32,8 +32,6 @@
 //                                  from this tree.
 //   CERBERUS_EXPECT_VERSION_INPUT  version that image's binary must report;
 //                                  travels with CERBERUS_IMAGE_INPUT.
-//   BUILD_DIR                      where the resolved binary lands
-//                                  (default `build`).
 //   COMPOSE_PROJECT_SUFFIX         per-checkout suffix the local image tag
 //                                  carries, so the tag named here is the one
 //                                  the compose stack runs. Empty in a primary
@@ -80,7 +78,13 @@ export const LOCAL_IMAGE_TAG = expandComposeSuffix('cerberus:migration-tier1${CO
 // the same one the compose healthcheck execs.
 export const IMAGE_BINARY_PATH = '/usr/local/bin/cerberus';
 
-// BINARY_NAME is the filename the resolved binary lands under inside BUILD_DIR.
+// BUILD_DIR is the repo-relative directory the resolved binary lands in, and
+// BINARY_NAME the filename it lands under. Both are constants rather than env
+// knobs on purpose: the joined path is handed to capture() as the command to
+// execute, so an env-supplied component would let whoever sets the environment
+// choose which program this module runs and then stamps as "the cerberus under
+// test". No workflow ever set the knob this replaced.
+const BUILD_DIR = 'build';
 const BINARY_NAME = 'cerberus';
 
 // EXECUTABLE_MODE is what an extracted binary is chmod'ed to. `docker cp`
@@ -222,7 +226,7 @@ function main() {
     process.exit(1);
   }
 
-  const buildDir = path.resolve(process.env.BUILD_DIR || 'build');
+  const buildDir = path.resolve(BUILD_DIR);
   mkdirSync(buildDir, { recursive: true });
   const binary = path.join(buildDir, BINARY_NAME);
 


### PR DESCRIPTION
Closes CodeQL alert [#12](https://github.com/tsouza/cerberus/security/code-scanning/12) — `js/shell-command-injection-from-environment`, three flows reaching `spawnSync` in `.github/scripts/lib/gh.mjs`.

## What the alert is, and what it is not

`capture()` refuses a `shell` option by construction, so no argument can inject a metacharacter. What the three flows actually reach is **argv[0]** — the program that runs. Whoever controls the environment gets to choose which binary these modules execute and then report on.

Neither callsite was reachable by an outside contributor: no workflow feeds fork-controlled input into either source, and neither module ships in `cmd/cerberus`. So this is CI-tooling hygiene, not an exploitable hole — which is why it is landing on its own after v1.14.0 rather than blocking the release. It gets fixed at the source either way; the alert is not dismissed.

## `migration-artifact.mjs`

Read `BUILD_DIR` from the environment, joined a binary path under it, and executed that. **No workflow has ever set the knob** — grep the tree — so it bought nothing and cost the one guarantee this module exists to give: that the `--version` it stamps came from the cerberus it just built or extracted. Now a constant.

## `brew-upgrade-path.mjs`

Executed whatever path `command -v cerberus` printed. The probe now runs the bare name and lets PATH resolve it — which is both what an operator actually types and what keeps a runtime-derived path out of argv[0].

Where it resolved became an **assertion** rather than a discarded value, and that is a real strengthening independent of the alert. The job's claim is that *the cask* is what a migrated machine runs. A `cerberus` sitting anywhere else on PATH would have satisfied the version match while the link the migration exists to create was never made — green for the wrong reason, in a job whose entire purpose is catching a migration that silently does not fire.

## The class gate

I wrote one (assert every `capture()`/`exec()` command name is a string literal) and then removed it. It over-fires — `path.resolve('build')` is fully determined by the module's own constants and is not a vector — and an over-firing gate earns an exemption list that rots. CodeQL already does the real dataflow analysis and is what caught both.

**The actual gap is that it does not gate.** Code scanning is configured (default setup, weekly + PR) but no code-scanning context is in `main`'s required checks, so alert #12 landed on `main` without blocking anything. Promoting it belongs with #40 (`strict-scan` → required), as one branch-protection edit after this cycle — flagging rather than doing, since that is a maintainer call and adding a required context mid-release would block the staged release PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)