### PR TITLE
perf(ci): shard gremlins phase2 three ways, after killing its 37 live mutants

### DIFF
--- a/.github/scripts/mutation-matrix.test.mjs
+++ b/.github/scripts/mutation-matrix.test.mjs
@@ -92,8 +92,21 @@ test('a docs-only PR runs no phase at all', () => {
 
 test('a change under one scope selects exactly that scope’s leg', () => {
   assert.deepEqual(names(select(['internal/chplan/plan.go'])), ['phase1']);
-  assert.deepEqual(names(select(['internal/chsql/emit_node.go'])), ['phase2']);
   assert.deepEqual(names(select(['internal/spansscan/match.go'])), ['phase6-spansscan']);
+});
+
+test('the chsql legs partition the package by exclude_files, one leg per file', () => {
+  assert.deepEqual(names(select(['internal/chsql/metrics_compare.go'])), ['phase2-compare']);
+  assert.deepEqual(names(select(['internal/chsql/emit_node.go'])), ['phase2-builder']);
+  // `emit.go` and `emit_node.go` differ only by suffix, and `range_window.go` is
+  // a prefix of three siblings split across all three legs — the `$` anchor on
+  // every alternation is what keeps those from colliding.
+  assert.deepEqual(names(select(['internal/chsql/emit.go'])), ['phase2-compare']);
+  assert.deepEqual(names(select(['internal/chsql/range_window_native.go'])), ['phase2-compare']);
+  assert.deepEqual(names(select(['internal/chsql/range_window_resample.go'])), ['phase2-builder']);
+  // The catch-all leg owns range_window.go and everything no sibling names.
+  assert.deepEqual(names(select(['internal/chsql/range_window.go'])), ['phase2-other']);
+  assert.deepEqual(names(select(['internal/chsql/tableshape.go'])), ['phase2-other']);
 });
 
 test('the logql legs partition the package by exclude_files, one leg per file', () => {

--- a/.github/scripts/mutation-phases.mjs
+++ b/.github/scripts/mutation-phases.mjs
@@ -30,7 +30,64 @@ const SERIAL_WORKERS = 1;
 
 export const PHASES = [
   { phase: 'phase1', scope: './internal/chplan', efficacy: EFFICACY, workers: DEFAULT_WORKERS },
-  { phase: 'phase2', scope: './internal/chsql', efficacy: EFFICACY, workers: DEFAULT_WORKERS },
+
+  // ---------------------------------------------------------------------------
+  // phase2 — three sibling legs over ./internal/chsql.
+  //
+  // Unsharded, phase2 was the mutation lane's sole critical path: 936 executed
+  // mutants at ~2.4s each put it at 38 minutes while the next-slowest leg
+  // (phase4-promql) finished in 13. Every other leg idled for 25 minutes waiting
+  // on it, so the lane's wall time was phase2's wall time and nothing else.
+  //
+  // Unlike the phase4-logql split, this one is NOT a memory-ceiling workaround —
+  // chsql's test binary links no heavy parser graph and the leg never OOM'd. It
+  // is a pure wall-clock split, so the legs keep gremlins' default fan-out.
+  //
+  // The partition is by MEASURED executed-mutant count (KILLED + LIVED per file,
+  // read off a full phase2 report), greedily balanced to ~313/310/313 — roughly
+  // 12.5 minutes each. It is deliberately not thematic: range_window.go alone
+  // carries 186 mutants, so any split that kept "the range-window emitters"
+  // together would rebuild the critical path it exists to remove.
+  //
+  // Rebalance by re-measuring, never by moving a file to keep a shard above the
+  // bar. Shard boundaries chosen to hide a weak file are the same evasion as
+  // relaxing `efficacy` — both leave the tests that failed to kill a mutant
+  // exactly as weak, and only change which number reports it.
+  {
+    phase: 'phase2-compare',
+    scope: './internal/chsql',
+    efficacy: EFFICACY,
+    workers: DEFAULT_WORKERS,
+    // metrics_compare + prewhere + exemplars + structural_join + late_mat +
+    // range_window_native + range_bucket_fanout + emit + vector_set_op + set_op.
+    exclude_files:
+      '^(absent_over_time|builder|chaos_sleep|chaos_sleep_stub|ddl|doc|emit_node|histogram_over_time|histogram_quantile|histogram_quantile_native|info_join|metrics_second_stage|nary_vector_set_op|nested_set_annotate|query_exemplars|range_lwr|range_window|range_window_fused|range_window_resample|scan_resource_bound|search_trace_limit|tableshape|vector_join)\\.go$',
+  },
+  {
+    phase: 'phase2-builder',
+    scope: './internal/chsql',
+    efficacy: EFFICACY,
+    workers: DEFAULT_WORKERS,
+    // builder + emit_node + histogram_over_time + vector_join + range_lwr +
+    // histogram_quantile_native + range_window_resample + query_exemplars.
+    exclude_files:
+      '^(absent_over_time|chaos_sleep|chaos_sleep_stub|ddl|doc|emit|exemplars|histogram_quantile|info_join|late_mat|metrics_compare|metrics_second_stage|nary_vector_set_op|nested_set_annotate|prewhere|range_bucket_fanout|range_window|range_window_fused|range_window_native|scan_resource_bound|search_trace_limit|set_op|structural_join|tableshape|vector_set_op)\\.go$',
+  },
+  {
+    phase: 'phase2-other',
+    scope: './internal/chsql',
+    efficacy: EFFICACY,
+    workers: DEFAULT_WORKERS,
+    // catch-all leg: range_window + nested_set_annotate + scan_resource_bound +
+    // ddl + range_window_fused + metrics_second_stage + nary_vector_set_op +
+    // tableshape, plus every file no other leg claims. A file newly added to
+    // internal/chsql needs no edit here — it is picked up automatically, which
+    // is why this leg keeps no positive file list to fall out of sync. The two
+    // legs above DO enumerate it, so a new file is briefly mutated three times
+    // over; TestMutationLegsPartitionEveryScopedFile fails on exactly that.
+    exclude_files:
+      '^(builder|emit|emit_node|exemplars|histogram_over_time|histogram_quantile_native|late_mat|metrics_compare|prewhere|query_exemplars|range_bucket_fanout|range_lwr|range_window_native|range_window_resample|set_op|structural_join|vector_join|vector_set_op)\\.go$',
+  },
   {
     phase: 'phase3-optimizer',
     scope: './internal/optimizer',

--- a/internal/chsql/builder_expr_mutation_test.go
+++ b/internal/chsql/builder_expr_mutation_test.go
@@ -1,0 +1,128 @@
+package chsql
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// errExpr returns a chplan.Expr that Builder.Expr is guaranteed to reject.
+// A zero-parameter Lambda is the cheapest such shape: exprLambda rejects it
+// up front with ErrUnsupported, so wrapping it lets a test drive the error
+// path of any expression renderer that recurses into a child.
+func errExpr() chplan.Expr { return &chplan.Lambda{} }
+
+// TestMutation_ExprInSubquery_LeftErrorPropagates pins that a render error on
+// the LEFT side of `<left> IN (<subquery>)` reaches the caller. exprInSubquery
+// renders the left side inside a Frag closure, which cannot return, so it
+// stashes the error in leftErr and returns it after the Frag has run.
+//
+// Kills builder.go exprInSubquery's CONDITIONALS_NEGATION (`err != nil` ->
+// `err == nil`): under the negation the capture only fires on success, where
+// err is nil, so leftErr stays nil and a broken left operand renders as
+// silently truncated SQL instead of an error.
+func TestMutation_ExprInSubquery_LeftErrorPropagates(t *testing.T) {
+	t.Parallel()
+
+	err := NewBuilder().Expr(&chplan.InSubquery{
+		Left:     errExpr(),
+		Subquery: &chplan.Scan{Table: "otel_traces"},
+	})
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("InSubquery with an unrenderable Left must return ErrUnsupported, got %v", err)
+	}
+}
+
+// TestMutation_ExprInSubquery_RendersLeftAndSubquery pins the success shape so
+// the error assertion above cannot pass by rejecting every InSubquery.
+func TestMutation_ExprInSubquery_RendersLeftAndSubquery(t *testing.T) {
+	t.Parallel()
+
+	b := NewBuilder()
+	if err := b.Expr(&chplan.InSubquery{
+		Left:     &chplan.ColumnRef{Name: "TraceId"},
+		Subquery: &chplan.Scan{Table: "otel_traces"},
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	sql, _ := b.Build()
+	if !strings.Contains(sql, "TraceId") || !strings.Contains(sql, "IN (") || !strings.Contains(sql, "otel_traces") {
+		t.Fatalf("expected `<col> IN (<SELECT … otel_traces>)`, got %q", sql)
+	}
+}
+
+// TestMutation_ExprLambda_MultiParamCommaSeparator pins the parameter-list
+// rendering of a multi-parameter lambda: `(k, v) -> <body>`. The separator is
+// emitted before every parameter EXCEPT the first.
+//
+// Kills builder.go exprLambda's `i > 0` guard under both mutators —
+// CONDITIONALS_BOUNDARY (`i >= 0`, which prefixes a comma before the first
+// parameter: `(, k, v)`) and CONDITIONALS_NEGATION (`i <= 0`, which moves the
+// comma to the front and drops the one between: `(, kv)`).
+func TestMutation_ExprLambda_MultiParamCommaSeparator(t *testing.T) {
+	t.Parallel()
+
+	b := NewBuilder()
+	if err := b.Expr(&chplan.Lambda{
+		Params: []string{"k", "v"},
+		Body:   &chplan.ColumnRef{Name: "v"},
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	sql, _ := b.Build()
+	if !strings.HasPrefix(sql, "(k, v) -> ") {
+		t.Fatalf("multi-parameter lambda must render `(k, v) -> `, got %q", sql)
+	}
+}
+
+// TestMutation_ExprLambda_SingleParamNoParens pins the sibling shape: a
+// one-parameter lambda renders bare, with no parentheses and no separator.
+func TestMutation_ExprLambda_SingleParamNoParens(t *testing.T) {
+	t.Parallel()
+
+	b := NewBuilder()
+	if err := b.Expr(&chplan.Lambda{
+		Params: []string{"i"},
+		Body:   &chplan.ColumnRef{Name: "i"},
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	sql, _ := b.Build()
+	if !strings.HasPrefix(sql, "i -> ") {
+		t.Fatalf("single-parameter lambda must render `i -> `, got %q", sql)
+	}
+}
+
+// TestMutation_ExprMapWithoutEmptyValues_InnerErrorPropagates pins that a
+// render error on the wrapped map reaches the caller rather than producing a
+// truncated `mapFilter((k, v) -> v != ”, ` with no closing argument.
+//
+// Kills builder.go exprMapWithoutEmptyValues' CONDITIONALS_NEGATION
+// (`err != nil` -> `err == nil`), which returns nil on failure and — because
+// the renderer has already written the opening call — hands back SQL that
+// cannot parse.
+func TestMutation_ExprMapWithoutEmptyValues_InnerErrorPropagates(t *testing.T) {
+	t.Parallel()
+
+	err := NewBuilder().Expr(&chplan.MapWithoutEmptyValues{Map: errExpr()})
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("MapWithoutEmptyValues over an unrenderable Map must return ErrUnsupported, got %v", err)
+	}
+}
+
+// TestMutation_ExprMapWithoutEmptyValues_RendersFilter pins the success shape
+// so the error assertion above cannot pass by rejecting every map.
+func TestMutation_ExprMapWithoutEmptyValues_RendersFilter(t *testing.T) {
+	t.Parallel()
+
+	b := NewBuilder()
+	if err := b.Expr(&chplan.MapWithoutEmptyValues{Map: &chplan.ColumnRef{Name: "Attributes"}}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	sql, _ := b.Build()
+	if !strings.HasPrefix(sql, "mapFilter((k, v) -> v != '', ") || !strings.HasSuffix(sql, ")") {
+		t.Fatalf("expected a closed mapFilter call, got %q", sql)
+	}
+}

--- a/internal/chsql/emit_node.go
+++ b/internal/chsql/emit_node.go
@@ -381,8 +381,12 @@ func (e *emitter) emitFilterScan(f *chplan.Filter, scan *chplan.Scan) error {
 	// internal/chsql/tableshape.go). Resolving against the first member is
 	// correct for shape lookup; the PREWHERE/WHERE split CH then translates
 	// uniformly to every arm of the merge() fanout.
+	//
+	// validateScanShape above admits exactly two states — Table set with no
+	// UnionTables, or UnionTables set with no Table — so an empty Table is
+	// already proof that UnionTables is non-empty; no second guard.
 	shapeKey := scan.Table
-	if shapeKey == "" && len(scan.UnionTables) > 0 {
+	if shapeKey == "" {
 		shapeKey = scan.UnionTables[0]
 	}
 	shape := tableShapeFor(shapeKey)

--- a/internal/chsql/emit_node_project_mutation_test.go
+++ b/internal/chsql/emit_node_project_mutation_test.go
@@ -1,0 +1,49 @@
+package chsql
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// TestMutation_EmitProject_ExplicitProjectionsSupersedeReplacements pins that
+// the two projection modes are mutually exclusive, with the explicit list
+// winning. Replacements express the `SELECT * REPLACE (…)` shape — keep every
+// column, rewrite a few — which only makes sense when no explicit list is
+// given. Emitting both would append a `*` to a curated SELECT list, so the
+// query would return the whole row alongside the projected columns and every
+// consumer reading positionally would decode the wrong fields.
+//
+// Kills emit_node.go's `len(p.Projections) == 0 && len(p.Replacements) > 0`
+// INVERT_LOGICAL (`||`), which takes the star-replace branch whenever EITHER
+// side holds — including this both-populated plan.
+func TestMutation_EmitProject_ExplicitProjectionsSupersedeReplacements(t *testing.T) {
+	t.Parallel()
+
+	sql := emitNodeSQL(t, &chplan.Project{
+		Input:        &chplan.Scan{Table: "otel_traces"},
+		Projections:  []chplan.Projection{{Expr: &chplan.ColumnRef{Name: "TraceId"}, Alias: "tid"}},
+		Replacements: []chplan.Projection{{Expr: &chplan.ColumnRef{Name: "SpanName"}, Alias: "name"}},
+	})
+	// Pin the whole SELECT list, not just the presence of the projection: the
+	// mutant appends `, * REPLACE (…)` to exactly this list.
+	if !strings.HasPrefix(sql, "SELECT `TraceId` AS `tid` FROM ") {
+		t.Fatalf("the SELECT list must be the explicit projection alone: %q", sql)
+	}
+}
+
+// TestMutation_EmitProject_ReplacementsOnlyRenderStarReplace pins the
+// complement so the assertion above cannot pass by ignoring Replacements
+// entirely: with no explicit list, the replacements render as `* REPLACE (…)`.
+func TestMutation_EmitProject_ReplacementsOnlyRenderStarReplace(t *testing.T) {
+	t.Parallel()
+
+	sql := emitNodeSQL(t, &chplan.Project{
+		Input:        &chplan.Scan{Table: "otel_traces"},
+		Replacements: []chplan.Projection{{Expr: &chplan.ColumnRef{Name: "SpanName"}, Alias: "name"}},
+	})
+	if !strings.Contains(sql, "* REPLACE (") || !strings.Contains(sql, "AS `name`") {
+		t.Fatalf("replacements-only Project must render `* REPLACE (… AS `name`)`: %q", sql)
+	}
+}

--- a/internal/chsql/late_mat.go
+++ b/internal/chsql/late_mat.go
@@ -74,15 +74,28 @@ func lateMatShapeFor(table string) (lateMatShape, bool) {
 var lateMatShapes = func() map[string]lateMatShape {
 	out := map[string]lateMatShape{}
 	l := schema.DefaultOTelLogs()
-	if l.HasUniqueRowKey() && len(l.WideColumns) > 0 {
-		out[l.LogsTable] = lateMatShape{wide: l.WideColumns, rowKey: l.RowKey}
-	}
+	registerLateMatShape(out, l.LogsTable, l.HasUniqueRowKey(), l.WideColumns, l.RowKey)
 	tr := schema.DefaultOTelTraces()
-	if tr.HasUniqueRowKey() && len(tr.WideColumns) > 0 {
-		out[tr.SpansTable] = lateMatShape{wide: tr.WideColumns, rowKey: tr.RowKey}
-	}
+	registerLateMatShape(out, tr.SpansTable, tr.HasUniqueRowKey(), tr.WideColumns, tr.RowKey)
 	return out
 }()
+
+// registerLateMatShape records table as a late-materialisation candidate, but
+// only when the schema supplies BOTH halves of the coupled pair the rewrite
+// needs. A table with no unique row key cannot be joined back without
+// multiplying rows, and a table with no wide column has nothing to defer, so
+// either gap disqualifies it outright rather than degrading the rewrite.
+//
+// It takes the two metadata bits rather than a schema struct because the logs
+// and traces schemas are unrelated types that happen to carry the same pair;
+// splitting the decision out this way also puts it under direct test with
+// each half missing, which the package-level seeding above cannot express.
+func registerLateMatShape(out map[string]lateMatShape, table string, hasRowKey bool, wide, rowKey []string) {
+	if !hasRowKey || len(wide) == 0 {
+		return
+	}
+	out[table] = lateMatShape{wide: wide, rowKey: rowKey}
+}
 
 // lateMatMatch carries the matched plan fragments + the table metadata
 // needed by the emitter. Filter is optional (nil when the trigger

--- a/internal/chsql/late_mat_registry_mutation_test.go
+++ b/internal/chsql/late_mat_registry_mutation_test.go
@@ -1,0 +1,64 @@
+package chsql
+
+import "testing"
+
+// TestMutation_RegisterLateMatShape_RequiresBothHalves pins that late
+// materialisation is only offered for a table whose schema supplies BOTH the
+// unique row key and at least one wide column. The two are a coupled pair, not
+// independent hints: the rewrite defers wide columns out of the inner scan and
+// joins them back on the row key, so a table with no unique row key would
+// multiply rows on the join-back (wrong answers), and a table with no wide
+// column would pay for a self-join that defers nothing (slower, same answer).
+// Either gap disqualifies the table outright.
+//
+// Kills the guard's INVERT_LOGICAL (`||` -> `&&`, which registers a table with
+// only one half of the pair) and its CONDITIONALS_NEGATION on the wide-column
+// emptiness check.
+func TestMutation_RegisterLateMatShape_RequiresBothHalves(t *testing.T) {
+	t.Parallel()
+
+	const table = "otel_logs"
+	wide := []string{"Body"}
+	rowKey := []string{"Timestamp", "TraceId"}
+
+	for _, tc := range []struct {
+		name      string
+		hasRowKey bool
+		wide      []string
+		want      bool
+	}{
+		{name: "both halves present", hasRowKey: true, wide: wide, want: true},
+		{name: "no unique row key", hasRowKey: false, wide: wide},
+		{name: "no wide column", hasRowKey: true, wide: nil},
+		{name: "neither half", hasRowKey: false, wide: nil},
+	} {
+		out := map[string]lateMatShape{}
+		registerLateMatShape(out, table, tc.hasRowKey, tc.wide, rowKey)
+		if _, ok := out[table]; ok != tc.want {
+			t.Errorf("%s: registered=%v, want %v", tc.name, ok, tc.want)
+		}
+	}
+}
+
+// TestMutation_RegisterLateMatShape_CarriesSchemaColumns pins that a registered
+// table records the exact wide/row-key column lists it was given — the rewrite
+// reads both back to build the inner projection and the join-back key, so a
+// registration that drops either list emits a join on nothing.
+func TestMutation_RegisterLateMatShape_CarriesSchemaColumns(t *testing.T) {
+	t.Parallel()
+
+	const table = "otel_traces"
+	out := map[string]lateMatShape{}
+	registerLateMatShape(out, table, true, []string{"SpanAttributes"}, []string{"Timestamp", "SpanId"})
+
+	got, ok := out[table]
+	if !ok {
+		t.Fatalf("%s must be registered", table)
+	}
+	if len(got.wide) != 1 || got.wide[0] != "SpanAttributes" {
+		t.Errorf("wide columns not carried through: %v", got.wide)
+	}
+	if len(got.rowKey) != 2 || got.rowKey[1] != "SpanId" {
+		t.Errorf("row key not carried through: %v", got.rowKey)
+	}
+}

--- a/internal/chsql/metrics_compare_pushdown_mutation_test.go
+++ b/internal/chsql/metrics_compare_pushdown_mutation_test.go
@@ -1,0 +1,77 @@
+package chsql
+
+import (
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+const pushdownSpansTable = "otel_traces"
+
+// pushdownPred is the predicate the tests below fold into a spans scan.
+func pushdownPred() chplan.Expr {
+	return &chplan.Binary{
+		Op:    chplan.OpEq,
+		Left:  &chplan.ColumnRef{Name: "TraceId"},
+		Right: &chplan.LitString{V: "aabb"},
+	}
+}
+
+// TestMutation_PushPredicateToSpansScanFilter_RecursesThroughNestedFilter pins
+// that the walker keeps descending when a Filter's input is NOT a Scan. The
+// prod shape it serves is a stack of Filters over one spans Scan (PREWHERE
+// promotion and the optimizer both produce it), so a walker that only
+// recognises the Filter-directly-over-Scan case would fail to fold the window
+// bound and leave the root leg reading full retention.
+//
+// Kills metrics_compare.go's `ok && sc.Table == spansTable` INVERT_LOGICAL
+// (`||`): when the type assertion fails, `sc` is a nil *chplan.Scan, so the
+// mutant's second operand dereferences nil and panics on exactly the nested
+// shape this test builds.
+func TestMutation_PushPredicateToSpansScanFilter_RecursesThroughNestedFilter(t *testing.T) {
+	t.Parallel()
+
+	inner := &chplan.Filter{
+		Input:     &chplan.Scan{Table: pushdownSpansTable},
+		Predicate: &chplan.Binary{Op: chplan.OpEq, Left: &chplan.ColumnRef{Name: "ParentSpanId"}, Right: &chplan.LitString{V: ""}},
+	}
+	outer := &chplan.Filter{
+		Input:     inner,
+		Predicate: &chplan.Binary{Op: chplan.OpEq, Left: &chplan.ColumnRef{Name: "StatusCode"}, Right: &chplan.LitString{V: "Error"}},
+	}
+
+	if !pushPredicateToSpansScanFilter(outer, pushdownSpansTable, pushdownPred()) {
+		t.Fatal("a Filter stack over a spans Scan must accept the pushed predicate")
+	}
+	// The fold must land on the Filter that actually sits on the Scan — that is
+	// the only position from which ClickHouse can prune the MergeTree read.
+	if _, ok := inner.Predicate.(*chplan.Binary); !ok || inner.Predicate == nil {
+		t.Fatalf("inner Filter predicate not conjoined: %#v", inner.Predicate)
+	}
+	if inner.Predicate.(*chplan.Binary).Op != chplan.OpAnd {
+		t.Fatalf("expected the scan-adjacent Filter to gain an AND conjunct, got op %v", inner.Predicate.(*chplan.Binary).Op)
+	}
+	if outer.Predicate.(*chplan.Binary).Op == chplan.OpAnd {
+		t.Fatal("the predicate was folded into the outer Filter, which does not prune the scan")
+	}
+}
+
+// TestMutation_PushPredicateToSpansScanFilter_IgnoresForeignTable pins the
+// table half of the same guard: a Filter over a scan of some OTHER table is not
+// a fold target, so the walker reports failure rather than bounding an
+// unrelated relation. Without this the recursion assertion above could be
+// satisfied by a walker that folds into the first Filter it meets.
+func TestMutation_PushPredicateToSpansScanFilter_IgnoresForeignTable(t *testing.T) {
+	t.Parallel()
+
+	n := &chplan.Filter{
+		Input:     &chplan.Scan{Table: "otel_logs"},
+		Predicate: &chplan.Binary{Op: chplan.OpEq, Left: &chplan.ColumnRef{Name: "SeverityText"}, Right: &chplan.LitString{V: "ERROR"}},
+	}
+	if pushPredicateToSpansScanFilter(n, pushdownSpansTable, pushdownPred()) {
+		t.Fatal("a scan of a non-spans table must not accept the spans predicate")
+	}
+	if n.Predicate.(*chplan.Binary).Op == chplan.OpAnd {
+		t.Fatal("the predicate was folded into a foreign table's Filter")
+	}
+}

--- a/internal/chsql/metrics_compare_window_mutation_test.go
+++ b/internal/chsql/metrics_compare_window_mutation_test.go
@@ -1,0 +1,120 @@
+package chsql_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+)
+
+const (
+	compareWindowRange  = time.Minute
+	compareWindowOffset = 2 * time.Minute
+	// rootSeedMarker is the `TraceId IN (<windowed cohort>)` seed the compare
+	// emitter pushes onto the root-lookup scan. Its presence is what the guards
+	// under test decide.
+	rootSeedMarker = "`TraceId` IN (SELECT `TraceId` FROM"
+)
+
+var (
+	compareWindowStart = time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC)
+	compareWindowEnd   = time.Date(2026, 5, 12, 10, 3, 0, 0, time.UTC)
+)
+
+// compareRangeWindow wraps the root-lookup compare node in a RangeWindow with
+// the given request window and offset.
+func compareRangeWindow(start, end time.Time, offset time.Duration) *chplan.RangeWindow {
+	return &chplan.RangeWindow{
+		Input:           compareNodeWithRoot(),
+		Range:           compareWindowRange,
+		Step:            time.Minute,
+		Start:           start,
+		End:             end,
+		Offset:          offset,
+		TimestampColumn: "Timestamp",
+	}
+}
+
+// TestEmitCompare_PartialWindowEmitsNoScanBound pins that the compare scan
+// bound requires BOTH ends of the request window. The bound the emitter pushes
+// into each MergeTree leg is the half-open interval (Start-range, End]; with
+// only one endpoint known the other side would have to be invented, and an
+// invented endpoint on a scan bound silently drops real spans rather than
+// merely widening the read. So a half-specified window gets no bound at all and
+// the legs stay honest.
+//
+// Kills metrics_compare.go's `!r.Start.IsZero() && !r.End.IsZero()`
+// INVERT_LOGICAL (`||`), which builds a bound from a single endpoint.
+func TestEmitCompare_PartialWindowEmitsNoScanBound(t *testing.T) {
+	t.Parallel()
+
+	sql, _, err := chsql.Emit(context.Background(), compareRangeWindow(compareWindowStart, time.Time{}, 0))
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if strings.Contains(sql, "WHERE `Timestamp` >") {
+		t.Errorf("a window with no End must not bound the span scan:\n%s", sql)
+	}
+	if strings.Contains(sql, rootSeedMarker) {
+		t.Errorf("a window with no End must not seed the root-lookup scan:\n%s", sql)
+	}
+}
+
+// TestEmitCompare_NoWindowEmitsNoRootSeed pins the other conjunct of the
+// root-seed guard: the seed is derived from the scan bound, so with no window
+// there is nothing to seed from. The mutated form reaches the seed builder with
+// a nil bound and derives its interval from the ZERO time, producing a cohort
+// subquery bounded to year 1754 — which matches no span and silently empties
+// the root-name/root-service enrichment for every trace.
+//
+// Kills metrics_compare.go's `bound != nil && m.RootLookup != nil`
+// INVERT_LOGICAL (`||`).
+func TestEmitCompare_NoWindowEmitsNoRootSeed(t *testing.T) {
+	t.Parallel()
+
+	sql, _, err := chsql.Emit(context.Background(), compareRangeWindow(time.Time{}, time.Time{}, 0))
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if strings.Contains(sql, rootSeedMarker) {
+		t.Errorf("an unbounded request window must not seed the root-lookup scan:\n%s", sql)
+	}
+}
+
+// TestEmitCompare_RootSeedWindowIsOffsetShifted pins the arithmetic of the root
+// seed's cohort window. The seed must cover the SAME interval the span leg's own
+// scan bound uses — (Start - offset - range, End - offset] — because a trace
+// whose only matching span falls in the anchor lookback slice would otherwise
+// satisfy the span leg and miss the seed, silently losing its root enrichment.
+// The offset shift subtracts: a query with `offset 2m` reads spans two minutes
+// OLDER than the request window, so both endpoints move backwards.
+//
+// Kills the four mutants on the seed's bound expression — ARITHMETIC_BASE and
+// INVERT_NEGATIVES on each of `- offsetNS - rangeNS` and `- offsetNS` — every
+// one of which shifts the cohort window the wrong way or by the wrong amount.
+// A non-zero Offset is what makes them visible: at offset 0 the sign of a zero
+// term is unobservable.
+func TestEmitCompare_RootSeedWindowIsOffsetShifted(t *testing.T) {
+	t.Parallel()
+
+	sql, args, err := chsql.Emit(context.Background(),
+		compareRangeWindow(compareWindowStart, compareWindowEnd, compareWindowOffset))
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if !strings.Contains(sql, rootSeedMarker) {
+		t.Fatalf("a fully-specified window must seed the root-lookup scan:\n%s", sql)
+	}
+
+	wantLo := compareWindowStart.Add(-compareWindowOffset - compareWindowRange).UnixNano()
+	wantHi := compareWindowEnd.Add(-compareWindowOffset).UnixNano()
+	if !containsInt64Arg(args, wantLo) {
+		t.Errorf("root seed lower bound must be Start-offset-range (%d), args=%v", wantLo, args)
+	}
+	if !containsInt64Arg(args, wantHi) {
+		t.Errorf("root seed upper bound must be End-offset (%d), args=%v", wantHi, args)
+	}
+}

--- a/internal/chsql/prewhere.go
+++ b/internal/chsql/prewhere.go
@@ -170,15 +170,14 @@ func orderedConjuncts(conjuncts []chplan.Expr, shape TableShape) []chplan.Expr {
 	type ranked struct {
 		expr chplan.Expr
 		rank int
-		idx  int
 	}
 	var prefix []ranked
 	var skip []chplan.Expr
 	var rest []chplan.Expr
-	for i, c := range conjuncts {
+	for _, c := range conjuncts {
 		cols := collectColumnRefs(c)
 		if r := sortRankFor(cols, shape); r >= 0 {
-			prefix = append(prefix, ranked{expr: c, rank: r, idx: i})
+			prefix = append(prefix, ranked{expr: c, rank: r})
 			continue
 		}
 		hitsSkip := false
@@ -194,11 +193,14 @@ func orderedConjuncts(conjuncts []chplan.Expr, shape TableShape) []chplan.Expr {
 		}
 		rest = append(rest, c)
 	}
-	// Stable insertion sort by rank; ties broken by input order.
+	// Insertion sort by rank. The strict `>` is what makes it stable, and
+	// stability is what preserves input order within a rank — an equal-rank
+	// pair never swaps, so the earlier conjunct stays earlier. No explicit
+	// index tie-break is needed (nor would one ever fire: prefix[j] is always
+	// the element being inserted, so its input index is the largest in play).
 	for i := 1; i < len(prefix); i++ {
 		for j := i; j > 0; j-- {
-			if prefix[j-1].rank > prefix[j].rank ||
-				(prefix[j-1].rank == prefix[j].rank && prefix[j-1].idx > prefix[j].idx) {
+			if prefix[j-1].rank > prefix[j].rank {
 				prefix[j-1], prefix[j] = prefix[j], prefix[j-1]
 				continue
 			}

--- a/internal/chsql/range_window_alias_mutation_test.go
+++ b/internal/chsql/range_window_alias_mutation_test.go
@@ -1,0 +1,163 @@
+package chsql
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// emitNodeSQL renders a single plan node through a fresh emitter.
+func emitNodeSQL(t *testing.T, n chplan.Node) string {
+	t.Helper()
+	sql, _, err := Emit(context.Background(), n)
+	if err != nil {
+		t.Fatalf("Emit(%T): unexpected error: %v", n, err)
+	}
+	return sql
+}
+
+// TestMutation_MetricsAggregate_GroupByAliasesShorterThanGroupBy pins that the
+// SELECT-list loop treats GroupByAliases as OPTIONAL per group key: chplan
+// permits an unaliased group, so a plan carrying group keys and no aliases at
+// all must render them bare rather than indexing off the end of the slice.
+//
+// Kills range_window.go's `i < len(selectedAliases)` CONDITIONALS_BOUNDARY
+// (`i <= len(...)`): with one group key and zero aliases the mutated guard is
+// `0 <= 0`, so it reads selectedAliases[0] out of an empty slice and panics.
+func TestMutation_MetricsAggregate_GroupByAliasesShorterThanGroupBy(t *testing.T) {
+	t.Parallel()
+
+	sql := emitNodeSQL(t, &chplan.MetricsAggregate{
+		Op:         chplan.MetricsOpRate,
+		GroupBy:    []chplan.Expr{&chplan.ColumnRef{Name: "ServiceName"}},
+		ValueAlias: "Value",
+		Inner:      &chplan.Scan{Table: "otel_traces"},
+	})
+	if !strings.Contains(sql, "ServiceName") {
+		t.Fatalf("unaliased group key must still be projected, got %q", sql)
+	}
+}
+
+// TestMutation_MetricsAggregate_GroupByAliasesProjected pins the other half of
+// the same guard: when an alias IS supplied for a group key, the SELECT list
+// must carry `<expr> AS <alias>` — that alias is the name the GROUP BY below
+// refers to, so dropping it makes the query reference an unknown identifier.
+//
+// Kills range_window.go's `i < len(selectedAliases)` CONDITIONALS_NEGATION
+// (`i >= len(...)`), which inverts the guard so the alias is only picked up for
+// indexes past the end of the slice — i.e. never — and every group key renders
+// bare.
+func TestMutation_MetricsAggregate_GroupByAliasesProjected(t *testing.T) {
+	t.Parallel()
+
+	sql := emitNodeSQL(t, &chplan.MetricsAggregate{
+		Op:             chplan.MetricsOpRate,
+		GroupBy:        []chplan.Expr{&chplan.ColumnRef{Name: "ServiceName"}},
+		GroupByAliases: []string{"svc"},
+		ValueAlias:     "Value",
+		Inner:          &chplan.Scan{Table: "otel_traces"},
+	})
+	if !strings.Contains(sql, "AS `svc`") {
+		t.Fatalf("aliased group key must render `<expr> AS `svc``, got %q", sql)
+	}
+}
+
+// TestMutation_GroupKeyFrags_EveryAliasedKeySurvives pins that groupKeyFrags
+// walks the WHOLE group-by list. Each aliased key contributes its alias to the
+// GROUP BY; a truncated list silently groups by a prefix of the keys, which
+// merges series that should stay apart.
+//
+// Kills range_window.go groupKeyFrags' INVERT_LOOPCTRL (`continue` -> `break`):
+// the mutant stops at the first aliased key, so a two-key group-by renders a
+// one-key GROUP BY.
+func TestMutation_GroupKeyFrags_EveryAliasedKeySurvives(t *testing.T) {
+	t.Parallel()
+
+	frags := groupKeyFrags(
+		[]chplan.Expr{&chplan.ColumnRef{Name: "a"}, &chplan.ColumnRef{Name: "b"}},
+		[]string{"ka", "kb"},
+	)
+	if len(frags) != 2 {
+		t.Fatalf("expected one frag per group key, got %d", len(frags))
+	}
+	for i, want := range []string{"`ka`", "`kb`"} {
+		if got := renderFragToSQL(frags[i]); got != want {
+			t.Fatalf("frag %d: expected %q, got %q", i, want, got)
+		}
+	}
+}
+
+// TestMutation_GroupKeyFrags_UnaliasedKeyFallsBackToExpr pins the fall-through
+// arm: a key with no alias (or an empty one) groups by the expression itself.
+// Without this the loop-control assertion above could be satisfied by a
+// groupKeyFrags that always took the alias branch.
+func TestMutation_GroupKeyFrags_UnaliasedKeyFallsBackToExpr(t *testing.T) {
+	t.Parallel()
+
+	frags := groupKeyFrags(
+		[]chplan.Expr{&chplan.ColumnRef{Name: "a"}, &chplan.ColumnRef{Name: "b"}},
+		[]string{"", "kb"},
+	)
+	if len(frags) != 2 {
+		t.Fatalf("expected one frag per group key, got %d", len(frags))
+	}
+	if got := renderFragToSQL(frags[0]); got != "`a`" {
+		t.Fatalf("empty alias must group by the expression, got %q", got)
+	}
+	if got := renderFragToSQL(frags[1]); got != "`kb`" {
+		t.Fatalf("non-empty alias must group by the alias, got %q", got)
+	}
+}
+
+// TestMutation_RequireRecollapseEmittable_NeedsBothStateAndMerge pins that the
+// deferred re-collapse requires the COMPLETE -State/-Merge pair. Half a pair is
+// as unusable as none: the partial-aggregate column produced by -State can only
+// be folded back by its matching -Merge, so a func carrying one without the
+// other must be rejected up front rather than emitting SQL that cannot resolve.
+//
+// Kills range_window_native.go's `StateFn == "" || MergeFn == ""`
+// INVERT_LOGICAL (`&&`), which only rejects a func missing BOTH halves and
+// waves through either half-pair.
+func TestMutation_RequireRecollapseEmittable_NeedsBothStateAndMerge(t *testing.T) {
+	t.Parallel()
+
+	r := &chplan.RangeWindowNative{
+		Func:       "rate",
+		GroupBy:    []chplan.Expr{&chplan.ColumnRef{Name: "a"}},
+		Recollapse: []chplan.Projection{{Expr: &chplan.ColumnRef{Name: "a"}, Alias: "ka"}},
+	}
+	for _, agg := range []nativeTSGridAgg{
+		{Fn: "timeSeriesRateToGrid", StateFn: "someState", MergeFn: ""},
+		{Fn: "timeSeriesRateToGrid", StateFn: "", MergeFn: "someMerge"},
+		{Fn: "timeSeriesRateToGrid"},
+	} {
+		_, err := requireRecollapseEmittable(r, agg)
+		if !errors.Is(err, ErrUnsupported) {
+			t.Fatalf("agg %+v: an incomplete -State/-Merge pair must be rejected, got err=%v", agg, err)
+		}
+	}
+}
+
+// TestMutation_RequireRecollapseEmittable_AcceptsCompletePair pins the success
+// arm so the rejection assertion above cannot pass by rejecting everything.
+func TestMutation_RequireRecollapseEmittable_AcceptsCompletePair(t *testing.T) {
+	t.Parallel()
+
+	keys, err := requireRecollapseEmittable(
+		&chplan.RangeWindowNative{
+			Func:       "rate",
+			GroupBy:    []chplan.Expr{&chplan.ColumnRef{Name: "a"}},
+			Recollapse: []chplan.Projection{{Expr: &chplan.ColumnRef{Name: "a"}, Alias: "ka"}},
+		},
+		nativeTSGridAgg{Fn: "timeSeriesRateToGrid", StateFn: "someState", MergeFn: "someMerge"},
+	)
+	if err != nil {
+		t.Fatalf("a complete -State/-Merge pair must be accepted, got %v", err)
+	}
+	if len(keys) != 1 || keys[0] != "a" {
+		t.Fatalf("expected the GroupBy column names to be returned, got %v", keys)
+	}
+}

--- a/internal/chsql/structural_join_anchor_mutation_test.go
+++ b/internal/chsql/structural_join_anchor_mutation_test.go
@@ -1,0 +1,87 @@
+package chsql_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+)
+
+// structuralClosurePlan returns the canonical descendant closure, which the
+// recursive emitter renders as a WITH RECURSIVE anchor + step.
+func structuralClosurePlan() *chplan.StructuralJoin {
+	return &chplan.StructuralJoin{
+		Left:               &chplan.Scan{Table: "otel_traces"},
+		Right:              &chplan.Scan{Table: "otel_traces"},
+		Op:                 chplan.StructuralDescendant,
+		TraceIDColumn:      "TraceId",
+		SpanIDColumn:       "SpanId",
+		ParentSpanIDColumn: "ParentSpanId",
+	}
+}
+
+// TestEmitStructuralRecursive_AnchorCarriesCandidatePrefilter pins that the
+// candidate prefilter reaches the closure's ANCHOR SEED. The prefilter is what
+// makes a both-sides-selective closure affordable: without it the anchor seeds
+// the recursion with every trace the left side matches, and the step then walks
+// each of them even though the right side can never join. A prefilter computed
+// and then dropped is invisible in the result set and shows up only as the
+// runaway scan it was added to prevent.
+//
+// Kills structural_join.go's `len(seedWhere) > 0` CONDITIONALS_NEGATION
+// (`<= 0`), which applies the seed WHERE only when it is EMPTY — so exactly the
+// plans that asked for pruning get none.
+func TestEmitStructuralRecursive_AnchorCarriesCandidatePrefilter(t *testing.T) {
+	t.Parallel()
+
+	plan := structuralClosurePlan()
+	plan.CandidatePrefilter = true
+
+	sql, _, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if !strings.Contains(sql, "AS _seed WHERE `TraceId` IN (SELECT DISTINCT `TraceId`") {
+		t.Fatalf("candidate prefilter subquery missing from the anchor seed:\n%s", sql)
+	}
+}
+
+// TestEmitStructuralRecursive_AnchorCarriesTraceIDRestriction pins the other
+// producer of the same seed WHERE: the two-phase phase-B restriction to the
+// top-N trace ids. Dropping it turns a bounded phase-B into a full closure over
+// every seeded trace.
+//
+// Kills the same `len(seedWhere) > 0` CONDITIONALS_NEGATION via the second
+// conjunct source, so the assertion does not rest on the prefilter alone.
+func TestEmitStructuralRecursive_AnchorCarriesTraceIDRestriction(t *testing.T) {
+	t.Parallel()
+
+	plan := structuralClosurePlan()
+	plan.TraceIDRestriction = []string{"aabb", "ccdd"}
+
+	sql, _, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if !strings.Contains(sql, "AS _seed WHERE `TraceId` IN ('aabb', 'ccdd')") {
+		t.Fatalf("trace-id restriction missing from the anchor seed:\n%s", sql)
+	}
+}
+
+// TestEmitStructuralRecursive_UnrestrictedAnchorHasNoSeedWhere pins the
+// complement: a plan that opts into neither pruning bound must render the
+// anchor with no seed WHERE at all, so the two assertions above cannot be
+// satisfied by an emitter that always splices one in.
+func TestEmitStructuralRecursive_UnrestrictedAnchorHasNoSeedWhere(t *testing.T) {
+	t.Parallel()
+
+	sql, _, err := chsql.Emit(context.Background(), structuralClosurePlan())
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if strings.Contains(sql, "AS _seed WHERE") {
+		t.Fatalf("plan set no pruning bound, yet the anchor seed carries a WHERE:\n%s", sql)
+	}
+}

--- a/internal/chsql/vector_join_projection_mutation_test.go
+++ b/internal/chsql/vector_join_projection_mutation_test.go
@@ -1,0 +1,61 @@
+package chsql
+
+import (
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// TestMutation_ProjectionOutputsColumn pins the alias-wins rule that decides
+// whether a Project still carries the canonical timestamp column. An alias
+// RENAMES the output, so an aliased projection outputs its alias and nothing
+// else — the expression underneath is no longer visible to anything above.
+// Getting this wrong flips a vector join between the canonical (per-row
+// TimeUnix) and derived (one row per series) shapes, which changes the join key
+// and therefore the answer.
+//
+// Kills both CONDITIONALS_NEGATION mutants in vector_join.go's
+// projectionOutputsColumn:
+//   - `p.Alias != ""` -> `==`: the "renamed away" case below falls through to
+//     the ColumnRef arm and wrongly reports the shadowed column as an output,
+//     while the "bare column ref" case compares "" to col and reports false.
+//   - `p.Alias == col` -> `!=`: the alias cases invert outright.
+func TestMutation_ProjectionOutputsColumn(t *testing.T) {
+	t.Parallel()
+
+	const col = "TimeUnix"
+	for _, tc := range []struct {
+		name string
+		proj chplan.Projection
+		want bool
+	}{
+		{
+			name: "alias names the column",
+			proj: chplan.Projection{Expr: &chplan.ColumnRef{Name: "Timestamp"}, Alias: col},
+			want: true,
+		},
+		{
+			name: "alias renames the column away",
+			// The expression IS the column, but the alias republishes it under
+			// another name, so col is no longer an output of this projection.
+			proj: chplan.Projection{Expr: &chplan.ColumnRef{Name: col}, Alias: "anchor_ts"},
+		},
+		{
+			name: "bare column ref",
+			proj: chplan.Projection{Expr: &chplan.ColumnRef{Name: col}},
+			want: true,
+		},
+		{
+			name: "bare column ref to another column",
+			proj: chplan.Projection{Expr: &chplan.ColumnRef{Name: "Value"}},
+		},
+		{
+			name: "unaliased non-column expression",
+			proj: chplan.Projection{Expr: &chplan.FuncCall{Name: "now64"}},
+		},
+	} {
+		if got := projectionOutputsColumn(tc.proj, col); got != tc.want {
+			t.Errorf("%s: projectionOutputsColumn = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Why

`gremlins phase2 (./internal/chsql @ 95%)` was the mutation lane's **sole critical path**: 936 executed mutants at ~2.4s each put it at **38 minutes**, while the next-slowest leg (`phase4-promql`) finished in 13. Every other leg idled ~25 minutes waiting on it, so the lane's wall time was phase2's wall time and nothing else.

Sharding a leg redistributes its mutants across efficacy bars, so doing it first — before the survivors are dealt with — would let a weak file hide behind a strong one in whichever shard it landed in. The two commits are ordered accordingly.

## 1. Kill the survivors first (`test(chsql)`)

phase2 reported 96.05% — 899 killed, **37 alive**. Every survivor is a place where a mutated emitter still passed the whole suite, i.e. no test discriminated the two behaviours. New tests pin:

| file | what was unpinned |
|---|---|
| `builder.go` | `Expr`'s subquery arm swallowed a left-hand error; the lambda / `mapFilter` renderers had no test on their separators |
| `range_window.go`, `range_window_native.go` | alias + epoch-anchor branches rendered untested SQL shapes |
| `structural_join.go` | the anchor's seed `WHERE` was asserted through a substring the closure's own `SELECT` also matches |
| `metrics_compare.go` | the scan-bound and root-seed guards, and the **offset arithmetic** on the seed's cohort window — a wrong sign there empties root enrichment silently |
| `vector_join.go` | `projectionOutputsColumn`'s alias-wins rule decides a join key; the renamed-away case was untested |
| `emit_node.go` | a `Project` carrying both `Projections` and `Replacements` emitted `* REPLACE` alongside a curated `SELECT` list under mutation |

Three survivors were **equivalent mutants standing on provably dead code**. gremlins has no equivalence detection, so the honest response is to delete the code rather than write a test for the impossible:

- `prewhere.go` — the insertion sort's index tie-break can never fire (the element being inserted always holds the largest input index in play), and the strict `>` already makes the sort stable.
- `emit_node.go` — `len(scan.UnionTables) > 0` re-checked what `validateScanShape`, called two statements earlier, has already proven.
- `late_mat.go` — the registry guard was unreachable through the package-level seeding, which only ever passes the two real schemas. Extracting `registerLateMatShape` puts the coupled-pair rule under direct test with each half missing.

## 2. Then shard (`perf(ci)`)

Three sibling legs over `./internal/chsql`, partitioned by **measured** executed-mutant count (KILLED + LIVED per file, read off a full phase2 report), greedily balanced:

| leg | mutants | heaviest members |
|---|---|---|
| `phase2-compare` | 313 | `metrics_compare` 66, `prewhere` 64, `exemplars` 44, `structural_join` 40 |
| `phase2-builder` | 310 | `builder` 127, `emit_node` 60, `histogram_over_time` 31, `vector_join` 28 |
| `phase2-other` | 313 | `range_window` 186, `nested_set_annotate` 39, `scan_resource_bound` 26 |

~12.5 minutes each. The partition is deliberately **not thematic** — `range_window.go` alone carries 186 mutants, so any split keeping "the range-window emitters" together would rebuild the critical path it exists to remove.

Unlike the `phase4-logql` split this is **not** a memory-ceiling workaround: chsql's test binary links no heavy parser graph and the leg never OOM'd. It is a pure wall-clock split, so the legs keep gremlins' default fan-out.

All three keep `EFFICACY` (95). The comment block says plainly that boundaries are rebalanced by **re-measuring**, never by moving a file to keep a shard above the bar — shard boundaries chosen to hide a weak file are the same evasion as relaxing the threshold.

`phase2-other` is the catch-all, so a file newly added to `internal/chsql` is picked up with no edit to the table. The two enumerating legs would also claim it for one PR, which is exactly the shape `TestMutationLegsPartitionEveryScopedFile` fails on.

## Verification

- `TestMutationLegsPartitionEveryScopedFile` — every chsql source claimed by exactly one leg.
- `mutation-matrix.test.mjs` — new case pinning the chsql partition, including that `emit.go` / `emit_node.go` and the three `range_window*` siblings don't collide (the `$` anchor is load-bearing).
- The `mutation` lane on this PR runs all three new legs against the killed-off survivors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)