### PR TITLE
fix(engine): size the spill threshold at half the cap, not 512 MiB

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -434,8 +434,8 @@ type memoryCapQuerier interface {
 
 // queryMemoryCap returns the engine Client's per-query memory cap in bytes, or
 // 0 when the Client doesn't expose one. A 0 cap means "no max_memory_usage
-// configured", which spillThreshold treats as "use the fixed spill
-// threshold" (never min against a non-positive value).
+// configured", which spillThreshold treats as "use the absolute no-cap spill
+// threshold" rather than taking a fraction of a non-positive value.
 func (e *Engine) queryMemoryCap() int64 {
 	if mc, ok := e.Client.(memoryCapQuerier); ok {
 		return mc.MaxQueryMemoryBytes()

--- a/internal/engine/query_settings_rules_test.go
+++ b/internal/engine/query_settings_rules_test.go
@@ -229,11 +229,20 @@ func compareOverScan() *chplan.MetricsCompare {
 
 // TestApplyCompareMemoryBound_CompareStampsBoth — a compare() plan gets BOTH the
 // external-group-by spill threshold (sized at half the cap) and the read-thread
-// cap, so the previously-OOMing compare() stays under the per-query budget.
+// cap, so a compare() that would otherwise OOM stays under the per-query budget.
+//
+// The spill expectation is the LITERAL 1 GiB the prod validation ran at under
+// this 2 GiB cap, not a call to spillThreshold: computing the want from the
+// function under test would pass under any derivation, including one that stamps
+// a value the compare() bound was never validated with.
 func TestApplyCompareMemoryBound_CompareStampsBoth(t *testing.T) {
+	// validatedCompareSpillBytes is half of testQueryMemoryCap — the spill
+	// threshold the coupled compare() bound was validated against on prod.
+	const validatedCompareSpillBytes int64 = 1 << 30
+
 	ctx := applyCompareMemoryBound(context.Background(), compareOverScan(), testQueryMemoryCap)
 
-	if got, want := settingValue(ctx, settingMaxBytesBeforeExternalGroupBy), spillThreshold(testQueryMemoryCap); got != want {
+	if got, want := settingValue(ctx, settingMaxBytesBeforeExternalGroupBy), validatedCompareSpillBytes; got != want {
 		t.Errorf("max_bytes_before_external_group_by = %v; want %v (half the %d-byte cap)", got, want, testQueryMemoryCap)
 	}
 	if got, want := settingValue(ctx, settingMaxThreads), compareMaxThreads; got != want {

--- a/internal/engine/spill.go
+++ b/internal/engine/spill.go
@@ -23,11 +23,14 @@ const (
 // `sum by(user_id)`, LogQL `by(request_id)`, …) or a large sort otherwise
 // builds an unbounded in-memory state and aborts the query with
 // MEMORY_LIMIT_EXCEEDED (code 241) at whatever server-side limit it eventually
-// hits. With no cap to size against there is no principled fraction to take, so
-// the threshold is an absolute one: 512 MiB sits below the 1 GiB cap cerberus
-// configures by default, trading a slower disk-backed merge for a query that
-// COMPLETES instead of 422-ing.
-const spillThresholdBytes int64 = 512 << 20 // 536870912 bytes
+// hits. With no cap there is nothing to take a fraction of, so the fallback is
+// the threshold a DEFAULT-capped deployment gets: config's 1 GiB default
+// max_memory_usage divided by spillCapDenominator. An uncapped deployment
+// therefore spills exactly where a default-capped one does, trading a slower
+// disk-backed merge for a query that COMPLETES instead of 422-ing.
+// TestSpillThresholdBytes_MatchesDefaultCapThreshold pins that relationship, so
+// raising the config default without re-deriving this value fails loudly.
+const spillThresholdBytes int64 = 512 << 20 // 536870912 bytes — (1 GiB default cap) / 2
 
 // spillCapDenominator divides the live per-query memory cap to derive the
 // cap-relative spill threshold: the spill must begin at a fraction of the cap
@@ -42,11 +45,14 @@ const spillCapDenominator int64 = 2
 //
 // A configured cap is the only honest scale for the threshold, so the threshold
 // is derived from it and from nothing else: half the cap, per ClickHouse's own
-// guidance for max_bytes_before_external_group_by. That is safe at EVERY cap by
-// construction — cap/spillCapDenominator is strictly below the cap for every
-// positive cap — so the operation always reaches the spill threshold before it
-// reaches MEMORY_LIMIT_EXCEEDED, whether the operator raises
-// CERBERUS_CH_QUERY_MAX_MEMORY to many GiB or lowers it below 512 MiB. Sizing
+// guidance for max_bytes_before_external_group_by. That is safe by construction
+// at every cap a query can actually run under: for a cap of at least
+// spillCapDenominator bytes the quotient is positive AND strictly below the cap,
+// so the operation always reaches the spill threshold before it reaches
+// MEMORY_LIMIT_EXCEEDED, whether the operator raises
+// CERBERUS_CH_QUERY_MAX_MEMORY to many GiB or lowers it below 512 MiB. (A
+// single-byte cap admits no threshold at all — no positive byte count sits below
+// one byte — and no query runs under such a cap either way.) Sizing
 // against the cap is also what keeps the threshold HONEST in the other
 // direction: a threshold far below the cap spills state the query had the
 // budget to hold in RAM, paying a disk-backed merge (and the read amplification
@@ -67,8 +73,8 @@ func spillThreshold(maxMemory int64) int64 {
 // applySpillSettings stamps the external-group-by AND external-sort spill
 // thresholds on ctx for EVERY data-plane query.
 //
-// It is UNCONDITIONAL (it replaces the old MetricsCompare-only applyCompareSpill)
-// because the OOM-prone GROUP BY / sort is not unique to compare(): any head can
+// It is UNCONDITIONAL rather than scoped to one plan shape because the OOM-prone
+// GROUP BY / sort is not unique to TraceQL compare(): any head can
 // lower a high-cardinality aggregation (`sum by(user_id)`, LogQL `by(...)`,
 // TraceQL structural DISTINCT / nested-set window passes) or a large sort
 // (`topk`, `ORDER BY`) that would otherwise abort at the cap. Both settings are

--- a/internal/engine/spill.go
+++ b/internal/engine/spill.go
@@ -17,44 +17,51 @@ const (
 	settingMaxBytesBeforeExternalSort    = "max_bytes_before_external_sort"
 )
 
-// spillThresholdBytes is the default byte threshold at which a GROUP BY / sort
-// begins spilling to disk. A high-cardinality aggregation (TraceQL `compare()`
-// arrayJoin, PromQL `sum by(user_id)`, LogQL `by(request_id)`, …) or a large
-// sort otherwise builds an unbounded in-memory state and aborts the query with
-// MEMORY_LIMIT_EXCEEDED (code 241) at the per-query cap. Spilling at 512 MiB
-// keeps the operation well under the 1 GiB default cap, trading a slower
-// disk-backed merge for a query that COMPLETES instead of 422-ing.
+// spillThresholdBytes is the byte threshold at which a GROUP BY / sort begins
+// spilling to disk when NO per-query memory cap is configured. A
+// high-cardinality aggregation (TraceQL `compare()` arrayJoin, PromQL
+// `sum by(user_id)`, LogQL `by(request_id)`, …) or a large sort otherwise
+// builds an unbounded in-memory state and aborts the query with
+// MEMORY_LIMIT_EXCEEDED (code 241) at whatever server-side limit it eventually
+// hits. With no cap to size against there is no principled fraction to take, so
+// the threshold is an absolute one: 512 MiB sits below the 1 GiB cap cerberus
+// configures by default, trading a slower disk-backed merge for a query that
+// COMPLETES instead of 422-ing.
 const spillThresholdBytes int64 = 512 << 20 // 536870912 bytes
 
-// spillCapDenominator divides the live per-query memory cap to derive a
+// spillCapDenominator divides the live per-query memory cap to derive the
 // cap-relative spill threshold: the spill must begin at a fraction of the cap
 // so the disk-backed merge still has headroom under max_memory_usage.
 // ClickHouse's own guidance for max_bytes_before_external_group_by is ~50% of
-// max_memory_usage, hence 2 — half the cap.
+// max_memory_usage, hence 2 — half the cap. Any denominator >= 2 puts the
+// threshold strictly below the cap, which is the property the spill depends on.
 const spillCapDenominator int64 = 2
 
 // spillThreshold returns the byte threshold to stamp, given the live per-query
 // memory cap (max_memory_usage, in bytes; 0 = no cap configured).
 //
-// The fixed spillThresholdBytes (512 MiB) is only safe when the cap sits
-// comfortably above it. When an operator lowers CERBERUS_CH_QUERY_MAX_MEMORY to
-// at or below 512 MiB, a fixed 512 MiB threshold lands AT or ABOVE the cap, so
-// the operation never spills and OOMs before the threshold is reached — the
-// very bug this exists to prevent. So when a cap is set, take the smaller of
-// the fixed threshold and a cap-relative fraction (~50% of the cap), keeping
-// the spill strictly below the cap for every config.
+// A configured cap is the only honest scale for the threshold, so the threshold
+// is derived from it and from nothing else: half the cap, per ClickHouse's own
+// guidance for max_bytes_before_external_group_by. That is safe at EVERY cap by
+// construction — cap/spillCapDenominator is strictly below the cap for every
+// positive cap — so the operation always reaches the spill threshold before it
+// reaches MEMORY_LIMIT_EXCEEDED, whether the operator raises
+// CERBERUS_CH_QUERY_MAX_MEMORY to many GiB or lowers it below 512 MiB. Sizing
+// against the cap is also what keeps the threshold HONEST in the other
+// direction: a threshold far below the cap spills state the query had the
+// budget to hold in RAM, paying a disk-backed merge (and the read amplification
+// that comes with it) for no memory gain.
 //
-// When no cap is configured (cap <= 0) the threshold is the plain fixed value:
-// max_bytes_before_external_*=0 means the spill is DISABLED, so min'ing against
-// a non-positive cap would re-introduce the unbounded-RAM bug.
+// When no cap is configured (cap <= 0) there is no cap to take a fraction of,
+// so the threshold is the absolute spillThresholdBytes. It must not fall out of
+// the cap-relative arithmetic: max_bytes_before_external_*=0 means the spill is
+// DISABLED, which would re-introduce the unbounded-RAM abort this exists to
+// prevent.
 func spillThreshold(maxMemory int64) int64 {
 	if maxMemory <= 0 {
 		return spillThresholdBytes
 	}
-	if capRelative := maxMemory / spillCapDenominator; capRelative < spillThresholdBytes {
-		return capRelative
-	}
-	return spillThresholdBytes
+	return maxMemory / spillCapDenominator
 }
 
 // applySpillSettings stamps the external-group-by AND external-sort spill

--- a/internal/engine/spill_test.go
+++ b/internal/engine/spill_test.go
@@ -53,15 +53,25 @@ func TestApplySpillSettings_Unconditional(t *testing.T) {
 	}
 }
 
-// TestSpillThresholdBytes_BelowMemCap pins the no-cap fallback below the
-// per-query max_memory_usage cerberus configures by default, so a deployment
-// whose Client reports no cap still spills before that default aborts the
-// query. A future bump of either constant that inverts the ordering surfaces
-// loudly here.
-func TestSpillThresholdBytes_BelowMemCap(t *testing.T) {
+// TestSpillThresholdBytes_MatchesDefaultCapThreshold pins the no-cap fallback to
+// the threshold a DEFAULT-capped deployment gets, which is the only thing that
+// makes the absolute constant a derived value rather than a free-floating one: a
+// Client that reports no cap spills exactly where a default-capped one does.
+// Bumping config.defaultCHQueryMaxMemory or spillCapDenominator without
+// re-deriving spillThresholdBytes desynchronises the two regimes and fails here
+// (a mere `spillThresholdBytes < defaultMaxMemoryUsage` ordering check would
+// stay green through such a bump while the fallback silently drifted to a
+// fraction of the default-cap threshold).
+func TestSpillThresholdBytes_MatchesDefaultCapThreshold(t *testing.T) {
 	t.Parallel()
 
 	const defaultMaxMemoryUsage = gib // mirrors config.defaultCHQueryMaxMemory
+	if want := defaultMaxMemoryUsage / spillCapDenominator; spillThresholdBytes != want {
+		t.Errorf("no-cap spill threshold %d; want %d (default max_memory_usage %d / %d)",
+			spillThresholdBytes, want, defaultMaxMemoryUsage, spillCapDenominator)
+	}
+	// The derivation only means anything if it also keeps the fallback below the
+	// cap it mirrors — the spill must fire before MEMORY_LIMIT_EXCEEDED.
 	if spillThresholdBytes >= defaultMaxMemoryUsage {
 		t.Errorf("spill threshold %d >= default max_memory_usage %d; spill must trigger before the cap",
 			spillThresholdBytes, defaultMaxMemoryUsage)
@@ -122,21 +132,25 @@ func TestSpillThreshold_CapRelative(t *testing.T) {
 // constant above 1 GiB) fails here rather than silently under-spilling.
 //
 // The sweep spans five orders of magnitude around the deployed range, plus an
-// odd cap where integer division truncates. Its floor is sweepFloorCap: below a
-// couple of bytes cap/2 truncates to 0, and 0 is ClickHouse's encoding for
-// "spill disabled" rather than a threshold, so the invariant is only meaningful
-// for caps a deployment could plausibly configure.
+// odd cap where integer division truncates, plus minValidCap — the smallest cap
+// for which a positive threshold strictly below it exists at all. Anchoring the
+// sweep at that arithmetic boundary rather than at the deployed range is what
+// makes the invariant a proven domain instead of a floor picked to sit above
+// wherever it stops holding.
 func TestSpillThreshold_StrictlyBelowEveryCap(t *testing.T) {
 	t.Parallel()
 
 	const (
 		// An offset that makes a cap non-power-of-two so cap/2 truncates.
-		oddCapOffset  int64 = 12345
-		sweepFloorCap       = mib
+		oddCapOffset int64 = 12345
+		// A cap of one byte leaves no room for a positive threshold under it,
+		// so spillCapDenominator bytes is where the invariant starts holding —
+		// far below any cap a deployment configures, which is the point.
+		minValidCap = spillCapDenominator
 	)
 
 	caps := []int64{
-		sweepFloorCap, 3 * mib,
+		minValidCap, mib, 3 * mib,
 		64 * mib, 128 * mib, 256 * mib, 512 * mib,
 		gib, 2 * gib, 3 * gib, 4 * gib, 6 * gib, 8 * gib,
 		16 * gib, 32 * gib, 64 * gib, 128 * gib,

--- a/internal/engine/spill_test.go
+++ b/internal/engine/spill_test.go
@@ -7,32 +7,39 @@ import (
 	"github.com/tsouza/cerberus/internal/chclient"
 )
 
+const (
+	mib int64 = 1 << 20
+	gib int64 = 1 << 30
+)
+
 // TestApplySpillSettings_StampsBothThresholds — every data-plane query gets
 // BOTH the external-group-by and external-sort spill thresholds stamped at the
-// spill threshold, so a heavy GROUP BY or sort spills instead of OOMing.
+// cap-relative spill threshold, so a heavy GROUP BY or sort spills instead of
+// OOMing. Reverting the cap-relative derivation stamps 512 MiB here instead of
+// half the 2 GiB cap and this fails.
 func TestApplySpillSettings_StampsBothThresholds(t *testing.T) {
 	t.Parallel()
 
-	// High cap (2 GiB) leaves the fixed 512 MiB threshold the smaller of the
-	// two, so it is stamped verbatim.
-	const highCap int64 = 2 << 30
-	ctx := applySpillSettings(context.Background(), highCap)
+	const (
+		cap2GiB   = 2 * gib
+		wantStamp = gib // half the cap
+	)
+	ctx := applySpillSettings(context.Background(), cap2GiB)
 	settings := chclient.QuerySettingsFromContext(ctx)
 	for _, key := range []string{settingMaxBytesBeforeExternalGroupBy, settingMaxBytesBeforeExternalSort} {
 		got, ok := settings[key]
 		if !ok {
 			t.Fatalf("settings %v missing %s", settings, key)
 		}
-		if got != spillThresholdBytes {
-			t.Errorf("%s = %v (%T); want %d", key, got, got, spillThresholdBytes)
+		if got != wantStamp {
+			t.Errorf("%s = %v (%T); want %d (half the %d-byte cap)", key, got, got, wantStamp, cap2GiB)
 		}
 	}
 }
 
-// TestApplySpillSettings_Unconditional — unlike the old MetricsCompare-only
-// scope, the spill settings ride EVERY query (any head can lower a high-card
-// GROUP BY / large sort), not just compare. Even a bare cap with no plan stamps
-// both settings.
+// TestApplySpillSettings_Unconditional — the spill settings ride EVERY query
+// (any head can lower a high-card GROUP BY / large sort), not just compare.
+// Even a bare cap with no plan stamps both settings.
 func TestApplySpillSettings_Unconditional(t *testing.T) {
 	t.Parallel()
 
@@ -46,37 +53,43 @@ func TestApplySpillSettings_Unconditional(t *testing.T) {
 	}
 }
 
-// TestSpillThresholdBytes_BelowMemCap pins the spill threshold below the default
-// per-query max_memory_usage cap so the spill triggers before the memory cap
-// aborts the query. A future bump of either constant that inverts the ordering
-// surfaces loudly here.
+// TestSpillThresholdBytes_BelowMemCap pins the no-cap fallback below the
+// per-query max_memory_usage cerberus configures by default, so a deployment
+// whose Client reports no cap still spills before that default aborts the
+// query. A future bump of either constant that inverts the ordering surfaces
+// loudly here.
 func TestSpillThresholdBytes_BelowMemCap(t *testing.T) {
 	t.Parallel()
 
-	const defaultMaxMemoryUsage int64 = 1 << 30 // mirrors config.defaultCHQueryMaxMemory
+	const defaultMaxMemoryUsage = gib // mirrors config.defaultCHQueryMaxMemory
 	if spillThresholdBytes >= defaultMaxMemoryUsage {
 		t.Errorf("spill threshold %d >= default max_memory_usage %d; spill must trigger before the cap",
 			spillThresholdBytes, defaultMaxMemoryUsage)
 	}
 }
 
-// TestSpillThreshold_CapRelative pins spillThreshold across the cap regimes. The
-// load-bearing case is the lowered cap (256 MiB, at/below the fixed 512 MiB
-// threshold): the effective threshold MUST drop to a cap-relative fraction
-// (128 MiB with denominator 2) so the spill still triggers strictly below the
-// cap. Without the cap-relative clamp the stamped value would be the fixed
-// 512 MiB — at or above the cap — and the operation would OOM instead of
-// spilling. This case kills the mutant that reverts spillThreshold to a
-// constant return of spillThresholdBytes.
+// TestSpillThreshold_CapRelative pins spillThreshold across the cap regimes.
+//
+// The load-bearing case is the LARGE cap: a 6 GiB cap must yield half the cap
+// (3 GiB), not the 512 MiB no-cap constant. Reverting to a min() against
+// spillThresholdBytes stamps 536870912 there and this test fails. Over-spilling
+// is not a free safety margin — it forces a disk-backed merge on aggregations
+// the cap had ample room for.
+//
+// The lowered cap (256 MiB -> 128 MiB) pins the other end: the threshold still
+// lands strictly below a cap smaller than the no-cap constant, so the spill
+// fires before MEMORY_LIMIT_EXCEEDED. That is the safety property, and
+// cap/spillCapDenominator satisfies it on its own.
 func TestSpillThreshold_CapRelative(t *testing.T) {
 	t.Parallel()
 
 	const (
-		mib           int64 = 1 << 20
-		loweredCap          = 256 * mib // the lowered-cap regime
-		loweredExpect       = 128 * mib // 256 MiB / spillCapDenominator
-		highCap             = 2 << 30   // 2 GiB — comfortably above the fixed threshold
-		atFixedCap          = 1 << 30   // 1 GiB — cap/2 == fixed 512 MiB, so fixed wins (strict <)
+		largeCap      = 6 * gib
+		largeExpect   = 3 * gib   // 3221225472 — half of 6 GiB
+		loweredCap    = 256 * mib // cap smaller than the no-cap constant
+		loweredExpect = 128 * mib // 256 MiB / spillCapDenominator
+		boundaryCap   = gib       // cap/2 == spillThresholdBytes exactly
+		boundaryWant  = 512 * mib
 	)
 
 	cases := []struct {
@@ -84,11 +97,11 @@ func TestSpillThreshold_CapRelative(t *testing.T) {
 		maxMemory int64
 		want      int64
 	}{
-		{"lowered cap below fixed threshold spills cap-relative", loweredCap, loweredExpect},
-		{"high cap keeps fixed threshold", highCap, spillThresholdBytes},
-		{"cap/2 equals fixed threshold keeps fixed", atFixedCap, spillThresholdBytes},
-		{"no cap configured keeps fixed threshold", 0, spillThresholdBytes},
-		{"negative cap keeps fixed threshold (spill never disabled)", -1, spillThresholdBytes},
+		{"large cap spills at half the cap, not the no-cap constant", largeCap, largeExpect},
+		{"lowered cap spills at half the cap", loweredCap, loweredExpect},
+		{"cap where half coincides with the no-cap constant", boundaryCap, boundaryWant},
+		{"no cap configured uses the absolute fallback", 0, spillThresholdBytes},
+		{"negative cap uses the absolute fallback (spill never disabled)", -1, spillThresholdBytes},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -96,29 +109,64 @@ func TestSpillThreshold_CapRelative(t *testing.T) {
 			if got := spillThreshold(tc.maxMemory); got != tc.want {
 				t.Errorf("spillThreshold(%d) = %d; want %d", tc.maxMemory, got, tc.want)
 			}
-			// Whenever a positive cap is configured the threshold must sit
-			// strictly below it, or the spill can't fire before the OOM.
-			if tc.maxMemory > 0 {
-				if got := spillThreshold(tc.maxMemory); got >= tc.maxMemory {
-					t.Errorf("spillThreshold(%d) = %d; must be strictly < cap", tc.maxMemory, got)
-				}
-			}
 		})
 	}
 }
 
+// TestSpillThreshold_StrictlyBelowEveryCap asserts the invariant the whole
+// function exists for, as a property over a range of caps rather than at the
+// enumerated points: for EVERY positive cap the stamped threshold sits strictly
+// below the cap, so the operation always reaches the spill before it reaches
+// MEMORY_LIMIT_EXCEEDED. It also pins the threshold at exactly half the cap, so
+// any re-introduction of a fixed ceiling (which would flatten the sweep to a
+// constant above 1 GiB) fails here rather than silently under-spilling.
+//
+// The sweep spans five orders of magnitude around the deployed range, plus an
+// odd cap where integer division truncates. Its floor is sweepFloorCap: below a
+// couple of bytes cap/2 truncates to 0, and 0 is ClickHouse's encoding for
+// "spill disabled" rather than a threshold, so the invariant is only meaningful
+// for caps a deployment could plausibly configure.
+func TestSpillThreshold_StrictlyBelowEveryCap(t *testing.T) {
+	t.Parallel()
+
+	const (
+		// An offset that makes a cap non-power-of-two so cap/2 truncates.
+		oddCapOffset  int64 = 12345
+		sweepFloorCap       = mib
+	)
+
+	caps := []int64{
+		sweepFloorCap, 3 * mib,
+		64 * mib, 128 * mib, 256 * mib, 512 * mib,
+		gib, 2 * gib, 3 * gib, 4 * gib, 6 * gib, 8 * gib,
+		16 * gib, 32 * gib, 64 * gib, 128 * gib,
+		6*gib + oddCapOffset,
+	}
+	for _, maxMemory := range caps {
+		got := spillThreshold(maxMemory)
+		if got >= maxMemory {
+			t.Errorf("spillThreshold(%d) = %d; must be strictly < the cap or the spill never fires", maxMemory, got)
+		}
+		if got <= 0 {
+			t.Errorf("spillThreshold(%d) = %d; 0 disables the spill outright", maxMemory, got)
+		}
+		if want := maxMemory / spillCapDenominator; got != want {
+			t.Errorf("spillThreshold(%d) = %d; want %d (cap/%d)", maxMemory, got, want, spillCapDenominator)
+		}
+	}
+}
+
 // TestApplySpillSettings_LoweredCapStampsBelowCap drives the full stamp path
-// with a runtime cap LOWERED below the fixed 512 MiB threshold (256 MiB) and
+// with a runtime cap LOWERED below the no-cap 512 MiB constant (256 MiB) and
 // asserts BOTH effective stamped thresholds are the cap-relative 128 MiB —
-// strictly below the cap. A regression to a fixed 512 MiB stamp would surface
-// here as a value at/above the cap.
+// strictly below the cap. A regression to a fixed 512 MiB stamp surfaces here
+// as a value at/above the cap.
 func TestApplySpillSettings_LoweredCapStampsBelowCap(t *testing.T) {
 	t.Parallel()
 
 	const (
-		mib       int64 = 1 << 20
-		capBytes        = 256 * mib
-		wantStamp       = 128 * mib
+		capBytes  = 256 * mib
+		wantStamp = 128 * mib
 	)
 	settings := chclient.QuerySettingsFromContext(applySpillSettings(context.Background(), capBytes))
 	for _, key := range []string{settingMaxBytesBeforeExternalGroupBy, settingMaxBytesBeforeExternalSort} {


### PR DESCRIPTION
`spillThreshold` returned `min(512 MiB, cap/2)`, so the "~50% of `max_memory_usage`" its own comment
documented was only ever honoured when the cap sat **below 1 GiB**. Above that the `min` pinned it to
the flat 512 MiB constant. `applySpillSettings` is unconditional, so every data-plane query on all
three heads was told to spill at 512 MiB no matter how much memory it was actually allowed.

This makes the derivation match the documented intent: half the cap when a cap is configured, with
the 512 MiB constant surviving only as the no-cap fallback (a `0` stamp would *disable* spilling and
re-introduce the unbounded-RAM abort the setting exists to prevent). `cap/2` is strictly below the
cap for every positive cap, so the low-cap safety property the `min` was protecting is preserved by
construction rather than by clamping.

## Measured

A reference deployment with a 6 GiB per-query cap, so it was stamping 512 MiB instead of 3 GiB.
Controlled A/B: byte-identical SQL, `FORMAT Null`, run sequentially with the arms alternated, read
back from `system.query_log`. The subject is the highest-memory query observed over seven days
(five aggregation operators):

| arm | threshold | duration | result_rows | peak memory | spill parts | CPU |
|---|---|---|---|---|---|---|
| a | 512 MiB | 49,224 ms | 344,776 | 4.98 GiB | 15,069 | 607.5 s |
| b | **3 GiB** | **15,642 ms** | 344,776 | **3.22 GiB** | **254** | 263.0 s |
| c | 512 MiB | 51,411 ms | 344,776 | 4.92 GiB | 15,060 | 604.1 s |
| d | **3 GiB** | **16,126 ms** | 344,776 | **3.72 GiB** | **269** | 265.6 s |

**3.15x faster, and peak memory falls 4.95 -> 3.47 GiB.** `result_rows` is identical across all four
arms — both the correctness check and the evidence the win is not read-side. Two other real query
shapes reproduce it at 2.1x and 3.1x, and a four-aggregation query goes 4.50 -> 3.50 GiB peak with
spill parts dropping 15,119 -> 83.

## Why raising a spill threshold *lowers* peak memory

Spilling early costs memory rather than saving it. Each aggregation thread flushes its own two-level
buckets, so the part count scales with `max_threads`, and the readback merge then holds thousands of
part readers simultaneously. That merge is the peak. Cutting 15k parts to 254 removes both the merge
memory and the serialisation it imposes.

The same mechanism explains a result that had looked like an Amdahl ceiling: moving to a larger node
(14 -> 30 detected threads) produced no improvement, because more threads produced proportionally
more spill parts to merge. Effective parallelism here goes from 607 CPU-s / 49 s = 12.3 threads to
264 CPU-s / 15.6 s = 16.9 — total CPU drops **and** parallel efficiency rises.

## Risk

The concern worth stating is whether a larger threshold reintroduces the code 241
`MEMORY_LIMIT_EXCEEDED` class the constant was written to prevent, since
`max_bytes_before_external_group_by` is documented as applying per aggregation operator and
multi-operator queries are the norm (91% of observed queries carry a `UNION ALL`; one carries 14
`GROUP BY`s). Settled by measurement rather than by reading: the table above **is** a five-operator
query, and the four-operator case behaves the same way. The threshold acts as a query-global
watermark, and peak memory moves down, not up — so the change strictly *increases* headroom under
the cap.

## Tests

`spill_test.go` pins the large-cap case that regressing to `min()` would break (6 GiB -> 3 GiB, not
512 MiB), the lowered-cap end (256 MiB -> 128 MiB), the no-cap fallback, and a
`threshold < cap` invariant swept across caps. The group-by and sort settings are asserted to receive
the same value.
