### PR TITLE
fix(engine): record routed (route-B) dispatches in the router corpus

### DIFF
--- a/internal/chclient/client.go
+++ b/internal/chclient/client.go
@@ -938,13 +938,34 @@ func ensureQueryID(ctx context.Context) (string, context.Context) {
 	if id, ok := ctx.Value(queryIDKey).(string); ok {
 		return id, ctx
 	}
+	id := mintQueryID(ctx)
+	return id, withQueryID(ctx, id)
+}
+
+// mintQueryID derives a NEW per-dispatch query_id from ctx's trace WITHOUT
+// reading or writing the ctx cache. It is the single place the id's shape is
+// built, shared by every seam that needs one (ensureQueryID, freshQueryID, and
+// the exported MintQueryID the routed fan-out pre-mints its per-shard ids
+// with), so the "<traceID>-<spanID>-<counter>" form and the no-trace ""
+// contract cannot drift between them.
+func mintQueryID(ctx context.Context) string {
 	sc := trace.SpanContextFromContext(ctx)
 	if !sc.HasTraceID() {
-		return "", ctx
+		return ""
 	}
-	id := sc.TraceID().String() + "-" + sc.SpanID().String() + "-" +
+	return sc.TraceID().String() + "-" + sc.SpanID().String() + "-" +
 		strconv.FormatUint(queryIDCounter.Add(1), 10)
-	return id, context.WithValue(ctx, queryIDKey, id)
+}
+
+// withQueryID caches id as ctx's per-dispatch query_id, so queryContext stamps
+// exactly that value on the ClickHouse query and queryIDFromContext reads it
+// back. An empty id returns ctx unchanged (the no-trace case: the driver
+// self-generates an id and nothing is cached).
+func withQueryID(ctx context.Context, id string) context.Context {
+	if id == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, queryIDKey, id)
 }
 
 // queryIDFromContext returns the per-dispatch ClickHouse query_id stamped on
@@ -971,13 +992,8 @@ func queryIDFromContext(ctx context.Context) string {
 // is "" (the driver self-generates one) and ctx is returned unchanged, matching
 // ensureQueryID's no-trace contract.
 func freshQueryID(ctx context.Context) (string, context.Context) {
-	sc := trace.SpanContextFromContext(ctx)
-	if !sc.HasTraceID() {
-		return "", ctx
-	}
-	id := sc.TraceID().String() + "-" + sc.SpanID().String() + "-" +
-		strconv.FormatUint(queryIDCounter.Add(1), 10)
-	return id, context.WithValue(ctx, queryIDKey, id)
+	id := mintQueryID(ctx)
+	return id, withQueryID(ctx, id)
 }
 
 // EnsureQueryID is the exported single-source-of-truth seam for the
@@ -1010,6 +1026,30 @@ func EnsureQueryID(ctx context.Context) (string, context.Context) {
 // observational and never an error path.
 func QueryIDFromContext(ctx context.Context) string {
 	return queryIDFromContext(ctx)
+}
+
+// MintQueryID returns a NEW per-dispatch ClickHouse query_id derived from ctx's
+// trace, without caching it on ctx. It is the seam for a caller that must fix
+// SEVERAL ids up front for several physical CH queries — the solver's routed
+// fan-out, which pre-mints one id per shard before any shard context exists so
+// the corpus can record the whole fan-out at the dispatch seam. EnsureQueryID
+// cannot serve that case: it caches ONE id on the parent context, and every
+// shard context descends from that parent, so all K shards would inherit the
+// same query_id — which ClickHouse rejects with code 216.
+//
+// Pair it with WithQueryID on each per-shard context. When no valid trace is
+// present the id is "" (the driver self-generates one), matching EnsureQueryID.
+func MintQueryID(ctx context.Context) string {
+	return mintQueryID(ctx)
+}
+
+// WithQueryID fixes id as ctx's per-dispatch ClickHouse query_id, so the query
+// dispatched on the returned context is stamped with exactly that value and
+// QueryIDFromContext reads it back. It is the stamping half of the MintQueryID
+// seam (the routed fan-out mints K ids, then stamps one onto each shard's own
+// context). An empty id returns ctx unchanged.
+func WithQueryID(ctx context.Context, id string) context.Context {
+	return withQueryID(ctx, id)
 }
 
 // Conn returns the underlying clickhouse-go/v2 driver connection. It is

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -215,6 +215,48 @@ func (e *Engine) observeQuery(queryID string, plan chplan.Node, language string,
 	)
 }
 
+// observeRoutedQuery is observeQuery's route-B counterpart: it records the
+// routed dispatch as ONE corpus observation carrying the K per-shard query_ids
+// the Executor minted, so a routed query lands in the corpus with its real
+// route ("B"), k_shards and decision reason. Without it the corpus can only
+// ever see route A — every routed path returns before reaching the route-A
+// dispatch seam — and an empty route-B population reads as "route B never
+// fires" when it really means "route B is unobservable".
+//
+// ONE observation per routed QUERY, not per shard: the corpus row is the unit
+// of A/B comparison and carries no request identifier to group shards by after
+// the fact, so a per-shard row would compare a fraction of route B against a
+// whole route-A query. The observer folds the K query_log rows into that one
+// row.
+//
+// The shape-id is the WHOLE plan's — the same plan route A would have run — so
+// an A row and a B row for the same query shape share a shape_id and join
+// directly in the calibration analysis.
+//
+// Like observeQuery it is a no-op without a registered observer and cannot fail
+// the query: the seam returns nothing, is non-blocking, and drops under burst.
+// A shard whose id is empty (the request carries no trace) has no join key and
+// is left out; with none left there is nothing to record.
+func (e *Engine) observeRoutedQuery(info *solver.ExecInfo, plan chplan.Node, language string, decision *solver.Decision) {
+	if e.QueryObserver == nil || info == nil {
+		return
+	}
+	ids := make([]string, 0, len(info.ShardQueryIDs))
+	for _, id := range info.ShardQueryIDs {
+		if id != "" {
+			ids = append(ids, id)
+		}
+	}
+	if len(ids) == 0 {
+		return
+	}
+	present, route, nAnchors, fanout, cumD, outerRange, step, kShards, reason := routeFeatures(decision)
+	e.QueryObserver.ObserveRoutedQuery(
+		ids, planShapeID(plan), e.Settings.enabledOpts(), language,
+		present, route, nAnchors, fanout, cumD, outerRange, step, kShards, reason,
+	)
+}
+
 // outcomeTokenForErr classifies a dispatch error into the corpus exit-status
 // token for the CERBERUS-side terminal outcome it represents, or "" when the
 // error is not a resource rejection the corpus records in-process (CH-side
@@ -324,6 +366,14 @@ func (e *Engine) observeDispatchedRejection(queryID, language string, plan chpla
 // the whole seconds the corpus stores its grid columns in.
 const routeSecond = int64(time.Second)
 
+// corpusRouteA / corpusRouteB are the two values of the corpus row's `route`
+// column: A is the single-query dispatch, B the sharded fan-out. The mining
+// rules and the pinned corpus invariants key on these exact tokens.
+const (
+	corpusRouteA = "A"
+	corpusRouteB = "B"
+)
+
 // routeFeatures unpacks a solver Decision into the primitive routing-feature
 // scalars the QueryObserver seam takes. A nil decision (no classification ran)
 // returns present=false with zero scalars so the corpus leaves the routing
@@ -336,9 +386,9 @@ func routeFeatures(d *solver.Decision) (present bool, route string, nAnchors, fa
 	if d == nil {
 		return false, "", 0, 0, 0, 0, 0, 0, ""
 	}
-	route = "A"
+	route = corpusRouteA
 	if d.Strategy != "" {
-		route = "B"
+		route = corpusRouteB
 	}
 	return true,
 		route,
@@ -518,6 +568,31 @@ type Engine struct {
 type QueryObserver interface {
 	ObserveQuery(
 		queryID, shapeID string,
+		opts []string,
+		language string,
+		routePresent bool,
+		route string,
+		nAnchors, fanout, cumulativeD, outerRange, step uint32,
+		kShards uint8,
+		decisionReason string,
+	)
+
+	// ObserveRoutedQuery is ObserveQuery's route-B sibling: it records ONE
+	// dispatched query that fanned out into K physical ClickHouse queries, one
+	// per shard, identified by shardQueryIDs (the join keys into
+	// system.query_log). The observer folds the K query_log rows into a SINGLE
+	// corpus row, because the corpus exists to compare route A against route B
+	// per REQUEST — a row per shard would compare one shard against a whole
+	// route-A query and make B look K times cheaper than it is.
+	//
+	// It is a distinct method rather than a widened ObserveQuery so route A's
+	// seam — the overwhelmingly hot one — stays byte-identical. The remaining
+	// parameters carry the same meaning as ObserveQuery's; route is "B" and
+	// kShards is K on every call that reaches here. It must be non-blocking and
+	// cheap.
+	ObserveRoutedQuery(
+		shardQueryIDs []string,
+		shapeID string,
 		opts []string,
 		language string,
 		routePresent bool,
@@ -895,6 +970,11 @@ func (e *Engine) executeRouted(
 		execT.Done(ctx)
 		return Result{}, fmt.Errorf("engine: solver execute: %w", err)
 	}
+	// Record the fan-out at its dispatch seam, symmetrically with route A's
+	// execContext: the shards are running, so the corpus row is registered
+	// before the drain rather than after (a drain that never finishes would
+	// otherwise lose the observation entirely).
+	e.observeRoutedQuery(info, plan, lang.Name(), decision)
 	defer func() { _ = cursor.Close() }()
 
 	var samples []chclient.Sample
@@ -1077,7 +1157,7 @@ func (e *Engine) QueryPlanCursor(ctx context.Context, lang Lang, plan chplan.Nod
 	// never run (Major-2's symmetric fallback).
 	budget := chclient.SampleBudgetFromContext(ctx)
 	if cur, info, usedDecision, key, ok := e.tryRouteMemoHit(chclient.WithProgressFor(ctx, lang.Name()), lang.Name(), plan, decision, budget); ok {
-		result := e.buildRoutedCursorResult(meta, plan, usedDecision, cur, info, "memo-hit")
+		result := e.buildRoutedCursorResult(meta, plan, lang.Name(), usedDecision, cur, info, "memo-hit")
 		result.Retry = func(retryCtx context.Context, drainErr error) (CursorResult, bool) {
 			// The verdict already existed before this dispatch (that is
 			// what made it a memo-hit); a clean drain needed no
@@ -1112,7 +1192,7 @@ func (e *Engine) QueryPlanCursor(ctx context.Context, lang Lang, plan chplan.Nod
 		// route-A error is what surfaces, unchanged.
 		execCtx := chclient.WithProgressFor(ctx, lang.Name())
 		if cur, info, usedDecision, observeFn, retried := e.retryOnRouteAResourceFailure(execCtx, lang.Name(), plan, decision, budget, err); retried {
-			retryResult := e.buildRoutedCursorResult(meta, plan, usedDecision, cur, info, "retry")
+			retryResult := e.buildRoutedCursorResult(meta, plan, lang.Name(), usedDecision, cur, info, "retry")
 			retryResult.ObserveDrainOutcome = observeFn
 			return retryResult, nil
 		}
@@ -1135,7 +1215,7 @@ func (e *Engine) QueryPlanCursor(ctx context.Context, lang Lang, plan chplan.Nod
 			if !retried {
 				return CursorResult{}, false
 			}
-			retryResult := e.buildRoutedCursorResult(meta, plan, usedDecision, cur, info, "retry")
+			retryResult := e.buildRoutedCursorResult(meta, plan, lang.Name(), usedDecision, cur, info, "retry")
 			retryResult.ObserveDrainOutcome = observeFn
 			return retryResult, true
 		}
@@ -1215,22 +1295,33 @@ func (e *Engine) dispatchRouteACursor(
 }
 
 // buildRoutedCursorResult composes the CursorResult for a cursor obtained
-// via the Solver's Executor — shared by executeRoutedCursor's ordinary
-// threshold-triggered route and the failure-driven route memo's memo-hit /
-// retry dispatch sites, so header and strategy construction cannot drift
-// between the three. via is a short label folded into the shadow header's
-// decision-reason position ("memo-hit" / "retry") distinguishing a memo-
-// driven route from an ordinary threshold-triggered one; it never appears
-// on the ordinary executeRoutedCursor path, which passes its own decision's
-// real Reason (ReasonRouted) instead by calling routeDecisionValue directly.
+// via the Solver's Executor — shared by the failure-driven route memo's
+// memo-hit and its two retry dispatch sites, so header and strategy
+// construction cannot drift between the three. via is a short label folded
+// into the shadow header's decision-reason position ("memo-hit" / "retry")
+// distinguishing a memo-driven route from an ordinary threshold-triggered one;
+// it never appears on the ordinary executeRoutedCursor path, which builds its
+// own headers from its decision's real Reason (ReasonRouted) via
+// routeDecisionValue.
+//
+// It is also the single corpus dispatch seam for those three route-B sites, so
+// none of them can be added or moved without the routed observation coming
+// along — and, because executeRoutedCursor observes for itself and never calls
+// here, no routed dispatch is ever recorded twice. The corpus records the
+// DECISION's own Reason (ReasonRouted: the memo re-derives its decision through
+// the Planner), never via — decision_reason carries the classifier's vocabulary
+// and "route B iff reason=routed" is a pinned corpus invariant, so via stays a
+// response-header detail.
 func (e *Engine) buildRoutedCursorResult(
 	meta Meta,
 	plan chplan.Node,
+	language string,
 	decision *solver.Decision,
 	cursor chclient.Cursor,
 	info *solver.ExecInfo,
 	via string,
 ) CursorResult {
+	e.observeRoutedQuery(info, plan, language, decision)
 	nodes := cerbtrace.CountNodes(plan)
 	strategy := strategyFor(meta)
 	sql, args := routedSQLArgs(info)
@@ -1319,6 +1410,9 @@ func (e *Engine) executeRoutedCursor(
 	if err != nil {
 		return CursorResult{}, fmt.Errorf("engine: solver execute: %w", err)
 	}
+	// Dispatch seam for the streaming route-B path (the caller owns the drain,
+	// so there is no later engine-side site to record from).
+	e.observeRoutedQuery(info, plan, lang.Name(), decision)
 
 	nodes := cerbtrace.CountNodes(plan)
 	strategy := strategyFor(meta)

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -91,6 +91,15 @@ type recordingObserver struct {
 	lastStep     uint32
 	lastKShards  uint8
 
+	// routed* capture the route-B seam (ObserveRoutedQuery), which is separate
+	// from ObserveQuery precisely so a test can tell the two apart: one entry per
+	// ROUTED dispatch, carrying that dispatch's K shard query_ids.
+	routedIDs     [][]string
+	routedPresent []bool
+	routedRoutes  []string
+	routedReasons []string
+	routedKShards []uint8
+
 	// outcomes captures (queryID, token) pairs from ObserveOutcome; rejections
 	// captures (language, token) pairs from ObserveRejection; dispatchedRej
 	// captures (queryID, language, token) triples from ObserveDispatchedRejection
@@ -120,6 +129,24 @@ func (o *recordingObserver) ObserveQuery(
 	o.lastOuterRng = outerRange
 	o.lastStep = step
 	o.lastKShards = kShards
+}
+
+func (o *recordingObserver) ObserveRoutedQuery(
+	shardQueryIDs []string,
+	_ string,
+	_ []string,
+	_ string,
+	routePresent bool,
+	route string,
+	_, _, _, _, _ uint32,
+	kShards uint8,
+	decisionReason string,
+) {
+	o.routedIDs = append(o.routedIDs, append([]string(nil), shardQueryIDs...))
+	o.routedPresent = append(o.routedPresent, routePresent)
+	o.routedRoutes = append(o.routedRoutes, route)
+	o.routedReasons = append(o.routedReasons, decisionReason)
+	o.routedKShards = append(o.routedKShards, kShards)
 }
 
 func (o *recordingObserver) ObserveOutcome(queryID, statusToken string) {

--- a/internal/engine/routed_corpus_observe_test.go
+++ b/internal/engine/routed_corpus_observe_test.go
@@ -1,0 +1,378 @@
+package engine
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/solver"
+)
+
+// routedCorpusLang is a minimal Lang: the routed paths only read Name(), and
+// classify() gates on it being the PromQL head.
+type routedCorpusLang struct{}
+
+func (routedCorpusLang) Name() string { return solver.LangPromQL }
+
+func (routedCorpusLang) Parse(context.Context, string) (chplan.Node, Meta, error) {
+	return memoWiringEligiblePlan(), Meta{IsMetric: true}, nil
+}
+
+func (routedCorpusLang) ProjectSamples(plan chplan.Node, _ Meta) chplan.Node { return plan }
+
+// routedCorpusObserver records both corpus seams separately so a test can tell
+// a route-A observation from a route-B one — and catch a dispatch recorded on
+// both.
+type routedCorpusObserver struct {
+	mu sync.Mutex
+
+	routeAIDs []string
+
+	routedIDs     [][]string
+	routedShapes  []string
+	routedPresent []bool
+	routedRoutes  []string
+	routedReasons []string
+	routedKShards []uint8
+}
+
+func (o *routedCorpusObserver) ObserveQuery(
+	queryID, _ string, _ []string, _ string,
+	_ bool, _ string, _, _, _, _, _ uint32, _ uint8, _ string,
+) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.routeAIDs = append(o.routeAIDs, queryID)
+}
+
+func (o *routedCorpusObserver) ObserveRoutedQuery(
+	shardQueryIDs []string, shapeID string, _ []string, _ string,
+	routePresent bool, route string, _, _, _, _, _ uint32, kShards uint8, decisionReason string,
+) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.routedIDs = append(o.routedIDs, append([]string(nil), shardQueryIDs...))
+	o.routedShapes = append(o.routedShapes, shapeID)
+	o.routedPresent = append(o.routedPresent, routePresent)
+	o.routedRoutes = append(o.routedRoutes, route)
+	o.routedReasons = append(o.routedReasons, decisionReason)
+	o.routedKShards = append(o.routedKShards, kShards)
+}
+
+func (o *routedCorpusObserver) ObserveOutcome(string, string) {}
+
+func (o *routedCorpusObserver) ObserveRejection(
+	string, []string, string, string, bool, string, uint32, uint32, uint32, uint32, uint32, uint8, string,
+) {
+}
+
+func (o *routedCorpusObserver) ObserveDispatchedRejection(
+	string, string, []string, string, string, bool, string,
+	uint32, uint32, uint32, uint32, uint32, uint8, string,
+) {
+}
+
+func (o *routedCorpusObserver) snapshot() ([]string, [][]string) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return append([]string(nil), o.routeAIDs...), append([][]string(nil), o.routedIDs...)
+}
+
+// idCapturingCursorClient is fakeSolverCursorClient plus the ClickHouse
+// query_id each shard's dispatch context actually carries — the id
+// system.query_log would record for that shard.
+type idCapturingCursorClient struct {
+	rows int
+
+	mu  sync.Mutex
+	ids []string
+}
+
+func (c *idCapturingCursorClient) QueryCursor(ctx context.Context, _ string, _ ...any) (chclient.Cursor, error) {
+	c.mu.Lock()
+	c.ids = append(c.ids, chclient.QueryIDFromContext(ctx))
+	c.mu.Unlock()
+	return &fakeMemoWiringCursor{remaining: c.rows}, nil
+}
+
+func (c *idCapturingCursorClient) MaxQueryMemoryBytes() int64 { return 0 }
+
+func (c *idCapturingCursorClient) dispatchedIDs() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]string(nil), c.ids...)
+}
+
+// routedCorpusTraceCtx returns a ctx carrying a real span context, which is
+// what the per-shard query_ids are minted from.
+func routedCorpusTraceCtx() context.Context {
+	sc := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID: trace.TraceID{
+			0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8,
+			0xa9, 0xaa, 0xab, 0xac, 0xad, 0xae, 0xaf, 0xb0,
+		},
+		SpanID: trace.SpanID{0xb1, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7, 0xb8},
+	})
+	return trace.ContextWithSpanContext(context.Background(), sc)
+}
+
+// newRoutedCorpusEngine builds an Engine whose Solver routes every eligible
+// plan (ModeSharded floors the cost thresholds), with the corpus observer
+// attached.
+func newRoutedCorpusEngine(t *testing.T, cursorClient solver.CursorQuerier, obs QueryObserver) *Engine {
+	t.Helper()
+	cfg := solver.DefaultConfig()
+	cfg.Mode = solver.ModeSharded
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("solver config invalid: %v", err)
+	}
+	sv := solver.New(cfg, fakeSolverEmitter{}, solver.ExecDeps{Client: cursorClient})
+	eng := &Engine{Solver: sv}
+	if obs != nil {
+		eng.QueryObserver = obs
+	}
+	return eng
+}
+
+// routedDecision classifies the eligible fixture plan into the routed decision
+// the engine's own route-B paths take.
+func routedDecision(t *testing.T, eng *Engine, plan chplan.Node) *solver.Decision {
+	t.Helper()
+	d, routed := eng.classify(plan, routedCorpusLang{})
+	if !routed || d == nil {
+		t.Fatalf("fixture must classify as ROUTED under ModeSharded; got routed=%v decision=%+v", routed, d)
+	}
+	if d.Reason != solver.ReasonRouted {
+		t.Fatalf("routed decision reason = %q, want %q", d.Reason, solver.ReasonRouted)
+	}
+	return d
+}
+
+// TestExecuteRoutedCursor_ObservesTheFanOut pins the defect this seam exists to
+// close: before it, observeQuery was reachable only from the route-A dispatch
+// path, so a route-B query could never produce a corpus row and an empty
+// route-B population read as "the router never routes" when it actually meant
+// "a routed query is unobservable".
+//
+// Revert the observeRoutedQuery call in executeRoutedCursor and this fails on
+// the very first assertion: zero routed observations for a dispatch that ran K
+// shards. It also pins the property that makes the row usable — the observed
+// ids are EXACTLY the ids ClickHouse ran the shards under, so the reconciler's
+// system.query_log join resolves.
+func TestExecuteRoutedCursor_ObservesTheFanOut(t *testing.T) {
+	t.Parallel()
+
+	cq := &idCapturingCursorClient{rows: 1}
+	obs := &routedCorpusObserver{}
+	eng := newRoutedCorpusEngine(t, cq, obs)
+	plan := memoWiringEligiblePlan()
+	d := routedDecision(t, eng, plan)
+
+	cr, err := eng.executeRoutedCursor(routedCorpusTraceCtx(), routedCorpusLang{}, Meta{IsMetric: true}, plan, d)
+	if err != nil {
+		t.Fatalf("executeRoutedCursor: %v", err)
+	}
+	for cr.Cursor.Next() {
+	}
+	if err := cr.Cursor.Err(); err != nil {
+		t.Fatalf("drain: %v", err)
+	}
+	if err := cr.Cursor.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	routeA, routed := obs.snapshot()
+	if len(routed) != 1 {
+		t.Fatalf("routed observations = %d; want exactly 1 (one row per routed QUERY)", len(routed))
+	}
+	if len(routeA) != 0 {
+		t.Errorf("route-A observations = %d; want 0 (a routed dispatch must not also be recorded as route A)", len(routeA))
+	}
+
+	ids := routed[0]
+	if len(ids) != len(d.Slices) {
+		t.Errorf("observed %d shard ids; want %d (one per shard, so the join covers the whole fan-out)", len(ids), len(d.Slices))
+	}
+	seen := map[string]bool{}
+	for _, id := range ids {
+		if id == "" {
+			t.Fatalf("observed an empty shard query_id: %v", ids)
+		}
+		if seen[id] {
+			t.Fatalf("shard query_id %q observed twice; ClickHouse rejects a duplicate live id", id)
+		}
+		seen[id] = true
+	}
+
+	// The ids the corpus recorded must be the ids the shards actually ran under,
+	// or the query_log join silently matches nothing.
+	dispatched := cq.dispatchedIDs()
+	if len(dispatched) != len(ids) {
+		t.Fatalf("ClickHouse saw %d shard dispatches; the corpus recorded %d ids", len(dispatched), len(ids))
+	}
+	for _, id := range dispatched {
+		if !seen[id] {
+			t.Errorf("shard dispatched with query_id %q, which the corpus never recorded (join would miss it)", id)
+		}
+	}
+
+	if !obs.routedPresent[0] || obs.routedRoutes[0] != corpusRouteB {
+		t.Errorf("routing read-out = (present=%v route=%q); want (true, %q)",
+			obs.routedPresent[0], obs.routedRoutes[0], corpusRouteB)
+	}
+	if obs.routedReasons[0] != solver.ReasonRouted {
+		t.Errorf("decision_reason = %q; want %q", obs.routedReasons[0], solver.ReasonRouted)
+	}
+	if obs.routedKShards[0] == 0 {
+		t.Error("k_shards = 0 on a routed observation; want the decision's real K")
+	}
+	if obs.routedShapes[0] != planShapeID(plan) {
+		t.Errorf("shape_id = %q; want the WHOLE plan's %q, so route-A and route-B rows join",
+			obs.routedShapes[0], planShapeID(plan))
+	}
+}
+
+// TestExecuteRouted_ObservesTheFanOut pins the same contract on the eager
+// route-B path (QueryPlan's sibling of the streaming one). The two paths return
+// through different code, so wiring one and not the other leaves half of route
+// B invisible — reverting executeRouted's call makes this fail with zero routed
+// observations while the streaming test above still passes.
+func TestExecuteRouted_ObservesTheFanOut(t *testing.T) {
+	t.Parallel()
+
+	cq := &idCapturingCursorClient{rows: 2}
+	obs := &routedCorpusObserver{}
+	eng := newRoutedCorpusEngine(t, cq, obs)
+	plan := memoWiringEligiblePlan()
+	d := routedDecision(t, eng, plan)
+
+	res, err := eng.executeRouted(routedCorpusTraceCtx(), routedCorpusLang{}, Meta{IsMetric: true}, plan, d)
+	if err != nil {
+		t.Fatalf("executeRouted: %v", err)
+	}
+	if len(res.Samples) == 0 {
+		t.Fatal("eager routed execution returned no samples; the fixture streams rows per shard")
+	}
+
+	routeA, routed := obs.snapshot()
+	if len(routed) != 1 {
+		t.Fatalf("routed observations = %d; want exactly 1", len(routed))
+	}
+	if len(routeA) != 0 {
+		t.Errorf("route-A observations = %d; want 0", len(routeA))
+	}
+	if len(routed[0]) != len(d.Slices) {
+		t.Errorf("observed %d shard ids; want %d", len(routed[0]), len(d.Slices))
+	}
+}
+
+// TestBuildRoutedCursorResult_ObservesOnce pins the third route-B family: the
+// memo-hit and the two A->B retry sites all return through
+// buildRoutedCursorResult, which is therefore their single corpus seam. It is
+// also the double-record guard: executeRoutedCursor records for itself and
+// never calls here, so exactly one observation exists per physical dispatch.
+func TestBuildRoutedCursorResult_ObservesOnce(t *testing.T) {
+	t.Parallel()
+
+	cq := &idCapturingCursorClient{rows: 1}
+	obs := &routedCorpusObserver{}
+	eng := newRoutedCorpusEngine(t, cq, obs)
+	plan := memoWiringEligiblePlan()
+	d := routedDecision(t, eng, plan)
+
+	cursor, info, err := eng.Solver.Executor.Execute(routedCorpusTraceCtx(), solver.LangPromQL, d, nil)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	defer func() { _ = cursor.Close() }()
+
+	cr := eng.buildRoutedCursorResult(Meta{IsMetric: true}, plan, solver.LangPromQL, d, cursor, info, "memo-hit")
+	if cr.Cursor == nil {
+		t.Fatal("buildRoutedCursorResult returned no cursor")
+	}
+
+	routeA, routed := obs.snapshot()
+	if len(routed) != 1 {
+		t.Fatalf("routed observations = %d; want exactly 1", len(routed))
+	}
+	if len(routeA) != 0 {
+		t.Errorf("route-A observations = %d; want 0", len(routeA))
+	}
+	// The corpus carries the CLASSIFIER's vocabulary, not the response header's
+	// "memo-hit"/"retry" label: "route B iff decision_reason=routed" is a pinned
+	// corpus invariant (test/regression/router_corpus_seed_test.go).
+	if obs.routedReasons[0] != solver.ReasonRouted {
+		t.Errorf("decision_reason = %q; want %q even on a memo-hit dispatch", obs.routedReasons[0], solver.ReasonRouted)
+	}
+}
+
+// TestExecuteRoutedCursor_UntracedRequestStillSucceeds pins the "recording can
+// never fail the query" half of the seam's contract at its one branch that can
+// legitimately produce nothing: without a trace context there is no query_id to
+// mint, so there is no join key and nothing is recorded — and the routed query
+// must still run and stream its rows.
+func TestExecuteRoutedCursor_UntracedRequestStillSucceeds(t *testing.T) {
+	t.Parallel()
+
+	cq := &idCapturingCursorClient{rows: 1}
+	obs := &routedCorpusObserver{}
+	eng := newRoutedCorpusEngine(t, cq, obs)
+	plan := memoWiringEligiblePlan()
+	d := routedDecision(t, eng, plan)
+
+	cr, err := eng.executeRoutedCursor(context.Background(), routedCorpusLang{}, Meta{IsMetric: true}, plan, d)
+	if err != nil {
+		t.Fatalf("executeRoutedCursor without a trace: %v", err)
+	}
+	rows := 0
+	for cr.Cursor.Next() {
+		rows++
+	}
+	if err := cr.Cursor.Err(); err != nil {
+		t.Fatalf("drain: %v", err)
+	}
+	if err := cr.Cursor.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if rows == 0 {
+		t.Error("untraced routed query streamed no rows; the corpus seam must never change what the query returns")
+	}
+
+	if _, routed := obs.snapshot(); len(routed) != 0 {
+		t.Errorf("routed observations = %d for an untraced request; want 0 (no join key exists)", len(routed))
+	}
+}
+
+// TestExecuteRoutedCursor_NoObserverStillSucceeds pins the default deployment:
+// with no corpus wired (QueryObserver nil — the zero value), the routed path
+// must behave exactly as before the seam existed.
+func TestExecuteRoutedCursor_NoObserverStillSucceeds(t *testing.T) {
+	t.Parallel()
+
+	cq := &idCapturingCursorClient{rows: 1}
+	eng := newRoutedCorpusEngine(t, cq, nil)
+	plan := memoWiringEligiblePlan()
+	d := routedDecision(t, eng, plan)
+
+	cr, err := eng.executeRoutedCursor(routedCorpusTraceCtx(), routedCorpusLang{}, Meta{IsMetric: true}, plan, d)
+	if err != nil {
+		t.Fatalf("executeRoutedCursor with no observer: %v", err)
+	}
+	rows := 0
+	for cr.Cursor.Next() {
+		rows++
+	}
+	if err := cr.Cursor.Err(); err != nil {
+		t.Fatalf("drain: %v", err)
+	}
+	if err := cr.Cursor.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if rows == 0 {
+		t.Error("routed query with no observer streamed no rows")
+	}
+}

--- a/internal/optcorpus/optcorpus.go
+++ b/internal/optcorpus/optcorpus.go
@@ -248,8 +248,15 @@ func parseTerminalRejectionStatus(token string) (ExitStatus, bool) {
 type Record struct {
 	// QueryID is the ClickHouse query_id (the per-dispatch
 	// "<traceID>-<spanID>-<counter>" id; the cerberus trace id is its prefix),
-	// the unique join key into system.query_log.
+	// the unique join key into system.query_log. It is empty on a routed
+	// (route-B) record, which joins through ShardQueryIDs instead.
 	QueryID string
+	// ShardQueryIDs are the K per-shard query_ids of a ROUTED dispatch: one
+	// logical query that ClickHouse ran as K statements. All K join to the same
+	// record and fold into ONE corpus row, because the corpus compares route A
+	// against route B per REQUEST — a row per shard would measure a fraction of
+	// route B against a whole route-A query. Empty on route A.
+	ShardQueryIDs []string
 	// ShapeID is the literal-free cerb:<root>[;mod...] plan shape id from
 	// engine.planShapeID.
 	ShapeID string
@@ -281,6 +288,22 @@ type Record struct {
 	// straight to the sink with zero cost rather than carrying them in the
 	// query_log IN(...) join.
 	DecisionOnly bool
+}
+
+// joinIDs returns every system.query_log query_id this record joins on: the K
+// shard ids of a routed dispatch, or the single dispatch id of a route-A one
+// (empty when the record has no join key at all — a pre-dispatch rejection).
+// The ring, the IN(...) snapshot, and the reconcile join all read the id set
+// through here, so route A and route B differ only in how many ids one record
+// carries, never in how the ring or the join treats them.
+func (rec Record) joinIDs() []string {
+	if len(rec.ShardQueryIDs) > 0 {
+		return rec.ShardQueryIDs
+	}
+	if rec.QueryID == "" {
+		return nil
+	}
+	return []string{rec.QueryID}
 }
 
 // Row is the durable corpus tuple written to the sink. The field shape is
@@ -499,7 +522,10 @@ func New(src QueryLogSource, sink Sink, opts Options) *Reconciler {
 //     from the join index here so the query_log reconcile cannot double-write it.
 //   - outcome-update (HasOutcome with no ShapeID): merges a cerberus-side
 //     terminal outcome onto an already-ringed dispatch record by query_id.
-//   - dispatch (the default): the normal at-dispatch metadata record.
+//   - dispatch (the default): the normal at-dispatch metadata record. A ROUTED
+//     dispatch occupies ONE slot and indexes all K of its shard query_ids at
+//     that slot, so every shard's query_log row joins back to the same record
+//     and folds into one corpus row.
 func (r *Reconciler) Observe(rec Record) {
 	if rec.DecisionOnly {
 		// A terminal rejection recorded at the engine site: no usable CH cost,
@@ -519,7 +545,8 @@ func (r *Reconciler) Observe(rec Record) {
 		r.mu.Unlock()
 		return
 	}
-	if rec.QueryID == "" {
+	ids := rec.joinIDs()
+	if len(ids) == 0 {
 		return
 	}
 	r.mu.Lock()
@@ -544,32 +571,47 @@ func (r *Reconciler) Observe(rec Record) {
 	// observation time so a re-observed id is not TTL-evicted prematurely.
 	// Preserve any cerberus-side outcome already merged onto the slot so an
 	// out-of-order outcome-update is not lost on a late dispatch re-observe.
-	if idx, ok := r.byID[rec.QueryID]; ok {
+	// The first id identifies the record: every id of one dispatch is written
+	// to the same slot in the same call, so they are never split across slots.
+	if idx, ok := r.byID[ids[0]]; ok {
 		if r.ring[idx].HasOutcome && !rec.HasOutcome {
 			rec.Outcome = r.ring[idx].Outcome
 			rec.HasOutcome = true
 		}
-		r.ring[idx] = rec
-		r.seenAt[rec.QueryID] = r.now()
+		r.index(idx, rec, ids)
 		return
 	}
 
 	slot := r.head
 	if r.count == r.cap {
 		// Full: the slot we are about to overwrite holds the oldest record;
-		// drop its index so the join no longer points at the reused slot.
-		evicted := r.ring[slot]
-		if r.byID[evicted.QueryID] == slot {
-			delete(r.byID, evicted.QueryID)
-			delete(r.seenAt, evicted.QueryID)
+		// drop ALL of its ids from the index so the join no longer points at
+		// the reused slot (a routed record contributes K of them).
+		for _, id := range r.ring[slot].joinIDs() {
+			if idx, ok := r.byID[id]; ok && idx == slot {
+				delete(r.byID, id)
+				delete(r.seenAt, id)
+			}
 		}
 	} else {
 		r.count++
 	}
-	r.ring[slot] = rec
-	r.byID[rec.QueryID] = slot
-	r.seenAt[rec.QueryID] = r.now()
+	r.index(slot, rec, ids)
 	r.head = (r.head + 1) % r.cap
+}
+
+// index writes rec into slot and points every one of its join ids at that slot,
+// stamping the shared observation time. A routed record's K shard ids all land
+// on the same slot, which is what makes their K query_log rows fold back into
+// one corpus row — and what makes them expire together under the TTL. Callers
+// hold the ring mutex.
+func (r *Reconciler) index(slot int, rec Record, ids []string) {
+	r.ring[slot] = rec
+	now := r.now()
+	for _, id := range ids {
+		r.byID[id] = slot
+		r.seenAt[id] = now
+	}
 }
 
 // ObserveQuery is the data-plane dispatch seam (engine.QueryObserver). It does
@@ -619,6 +661,52 @@ func (r *Reconciler) ObserveQuery(
 		},
 	}
 	r.enqueue(rec)
+}
+
+// ObserveRoutedQuery is ObserveQuery's route-B seam: one logical query that
+// ClickHouse ran as K statements, identified by shardQueryIDs. All K ids index
+// the SAME ring record, and the reconciler folds their K query_log rows into a
+// single corpus row (see rowFor) — the corpus's unit is the request, so
+// a routed query must weigh as one row against the route-A row it is compared
+// with. Same non-blocking, drop-under-burst contract as ObserveQuery; the ids
+// are copied because the caller owns the slice.
+func (r *Reconciler) ObserveRoutedQuery(
+	shardQueryIDs []string,
+	shapeID string,
+	opts []string,
+	language string,
+	routePresent bool,
+	route string,
+	nAnchors, fanout, cumulativeD, outerRange, step uint32,
+	kShards uint8,
+	decisionReason string,
+) {
+	ids := make([]string, 0, len(shardQueryIDs))
+	for _, id := range shardQueryIDs {
+		if id != "" {
+			ids = append(ids, id)
+		}
+	}
+	if len(ids) == 0 {
+		return
+	}
+	r.enqueue(Record{
+		ShardQueryIDs: ids,
+		ShapeID:       shapeID,
+		Opts:          opts,
+		Language:      language,
+		Route: RouteFeatures{
+			Present:        routePresent,
+			Route:          route,
+			NAnchors:       nAnchors,
+			Fanout:         fanout,
+			CumulativeD:    cumulativeD,
+			OuterRange:     outerRange,
+			Step:           step,
+			KShards:        kShards,
+			DecisionReason: decisionReason,
+		},
+	})
 }
 
 // ObserveOutcome is the data-plane seam for a CERBERUS-side terminal outcome on
@@ -784,16 +872,19 @@ func (r *Reconciler) snapshotIDs() []string {
 	return ids
 }
 
-// recordFor returns the observed Record for query_id, or ok=false. Safe for
-// concurrent Observe.
-func (r *Reconciler) recordFor(id string) (Record, bool) {
+// recordFor returns the observed Record for query_id plus the ring slot it
+// lives in, or ok=false. The slot is the record's identity for the join: a
+// routed record is reachable through any of its K shard ids, so source rows are
+// grouped by slot rather than by the id that found them. Safe for concurrent
+// Observe.
+func (r *Reconciler) recordFor(id string) (Record, int, bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	idx, ok := r.byID[id]
 	if !ok {
-		return Record{}, false
+		return Record{}, 0, false
 	}
-	return r.ring[idx], true
+	return r.ring[idx], idx, true
 }
 
 // forget drops the supplied ids from the join index after they have been
@@ -902,37 +993,23 @@ func (r *Reconciler) reconcileOnce(ctx context.Context) {
 		return
 	}
 
-	rows := make([]Row, 0, len(srcRows))
+	groups := groupByRecord(srcRows, r.recordFor)
+	rows := make([]Row, 0, len(groups))
 	reconciled := make([]string, 0, len(srcRows))
-	for _, sr := range srcRows {
-		rec, ok := r.recordFor(sr.QueryID)
-		if !ok {
-			// Evicted between snapshot and read, or a stray id — skip.
+	for _, g := range groups {
+		joined := g.rec.joinIDs()
+		if len(g.rows) < len(joined) {
+			// A routed dispatch whose remaining shards have not landed in
+			// query_log yet. Wait for them rather than writing a row whose cost
+			// columns count part of the fan-out: an under-counted route-B row is
+			// worse than a missing one, because the corpus exists to compare
+			// route B's cost against route A's. The ids stay in the join index
+			// and are retried next interval (and expire on the TTL if the
+			// missing shards never ran at all).
 			continue
 		}
-		row := Row{
-			ShapeID:             rec.ShapeID,
-			Opts:                rec.Opts,
-			Language:            rec.Language,
-			NormalizedQueryHash: sr.NormalizedQueryHash,
-			ReadRows:            sr.ReadRows,
-			ReadBytes:           sr.ReadBytes,
-			QueryDurationMS:     sr.QueryDurationMS,
-			MemoryUsage:         sr.MemoryUsage,
-			ProfileEvents:       sr.ProfileEvents,
-			// exit_status is the observed-cost discriminator the go/no-go
-			// analysis reads (oom / timeout = the cost route B avoids).
-			// Precedence: a CERBERUS-side outcome (e.g. the sample-budget 422
-			// that fired after a clean CH finish) is authoritative over the
-			// query_log-derived status — the query_log shows 'ok' with real
-			// cost, but cerberus actually rejected the client. The COST columns
-			// are kept (the richest signal: "CH cost = X, but cerberus
-			// rejected"); only the exit status is overridden.
-			ExitStatus: exitStatusToken(sr.ExitStatus, rec),
-		}
-		joinRouteFeatures(&row, rec)
-		rows = append(rows, row)
-		reconciled = append(reconciled, sr.QueryID)
+		rows = append(rows, rowFor(g))
+		reconciled = append(reconciled, joined...)
 	}
 	if len(rows) == 0 {
 		return
@@ -943,6 +1020,152 @@ func (r *Reconciler) reconcileOnce(ctx context.Context) {
 		return
 	}
 	r.forget(reconciled)
+}
+
+// joinGroup is the set of query_log rows that reconcile into ONE corpus row:
+// the observed Record plus every source row that joined back to it. A route-A
+// dispatch contributes exactly one row; a routed (route-B) dispatch contributes
+// K, one per shard, because ClickHouse ran that one logical query as K
+// statements.
+type joinGroup struct {
+	rec  Record
+	rows []SourceRow
+}
+
+// groupByRecord folds source rows onto the Records they join back to, keyed by
+// the ring slot the lookup returns. The slot — not the query_id — is the group
+// key because a routed Record is reachable through any of its K shard ids, and
+// keying on the id that found it would shatter one fan-out into K groups.
+//
+// Rows whose id no longer resolves (evicted between the snapshot and the read)
+// are dropped, and a re-delivered id is counted once, so a group's row count is
+// a truthful "how many shards have landed" tally rather than a delivery count.
+// First-seen order is preserved so the sink's row order stays a function of the
+// source's.
+func groupByRecord(srcRows []SourceRow, lookup func(string) (Record, int, bool)) []joinGroup {
+	order := make([]int, 0, len(srcRows))
+	bySlot := make(map[int]*joinGroup, len(srcRows))
+	seen := make(map[string]struct{}, len(srcRows))
+	for _, sr := range srcRows {
+		if _, dup := seen[sr.QueryID]; dup {
+			continue
+		}
+		seen[sr.QueryID] = struct{}{}
+		rec, slot, ok := lookup(sr.QueryID)
+		if !ok {
+			continue
+		}
+		g, tracked := bySlot[slot]
+		if !tracked {
+			g = &joinGroup{rec: rec, rows: make([]SourceRow, 0, len(rec.joinIDs()))}
+			bySlot[slot] = g
+			order = append(order, slot)
+		}
+		g.rows = append(g.rows, sr)
+	}
+	out := make([]joinGroup, 0, len(order))
+	for _, slot := range order {
+		out = append(out, *bySlot[slot])
+	}
+	return out
+}
+
+// rowFor folds one join group into the single corpus Row for its dispatch.
+//
+// ONE row per logical query, never one per shard: the corpus exists to compare
+// what route A costs against what route B costs for the same request, and it
+// carries no request identifier to GROUP BY after the fact. A row per shard
+// would put a fraction of a route-B fan-out beside a whole route-A query in
+// every comparison the calibration draws.
+//
+// The cost columns are therefore folded so a route-B row means the same thing a
+// route-A row means:
+//
+//   - read_rows / read_bytes are SUMMED. They measure work done, and the whole
+//     point of the A/B comparison is whether the fan-out reads more or less in
+//     total than the single query would have. A max would report one shard's
+//     share and understate route B by roughly K.
+//   - memory_usage is SUMMED. Shards run concurrently, so the server-side
+//     memory a routed request holds at once is the sum of the shards' peaks —
+//     that (not any single shard's peak) is the quantity comparable to route
+//     A's single peak, and it is the conservative side to err on for a column
+//     the calibration learns memory watermarks from.
+//   - query_duration_ms is the MAX. Shards run concurrently, so the slowest one
+//     is the request's ClickHouse-side latency; summing would yield a
+//     CPU-time-like number that corresponds to nothing route A reports. Engine
+//     wall-clock was rejected for the same reason in reverse: route A's
+//     duration comes from query_log, and mixing instruments would make the two
+//     routes' latency columns incomparable.
+//   - profile_events are summed per key, matching read_rows' "total work"
+//     reading of the same fan-out.
+//   - normalized_query_hash comes from the first joined row. The shards are K
+//     parameterisations of one emitted statement, so they normalise alike, and
+//     the column identifies the query SHAPE rather than any one dispatch.
+//   - exit_status is the most severe shard status (see exitSeverity), because a
+//     fan-out that OOMed one shard is an OOM for the request even though its
+//     siblings finished.
+func rowFor(g joinGroup) Row {
+	row := Row{
+		ShapeID:  g.rec.ShapeID,
+		Opts:     g.rec.Opts,
+		Language: g.rec.Language,
+	}
+	chStatus := ExitOK
+	for i, sr := range g.rows {
+		if i == 0 {
+			row.NormalizedQueryHash = sr.NormalizedQueryHash
+			chStatus = sr.ExitStatus
+		} else if exitSeverityOf(sr.ExitStatus) > exitSeverityOf(chStatus) {
+			chStatus = sr.ExitStatus
+		}
+		row.ReadRows += sr.ReadRows
+		row.ReadBytes += sr.ReadBytes
+		row.MemoryUsage += sr.MemoryUsage
+		if sr.QueryDurationMS > row.QueryDurationMS {
+			row.QueryDurationMS = sr.QueryDurationMS
+		}
+		for name, count := range sr.ProfileEvents {
+			if row.ProfileEvents == nil {
+				row.ProfileEvents = make(map[string]int64, len(sr.ProfileEvents))
+			}
+			row.ProfileEvents[name] += count
+		}
+	}
+	row.ExitStatus = exitStatusToken(chStatus, g.rec)
+	joinRouteFeatures(&row, g.rec)
+	return row
+}
+
+// exitSeverity ranks the terminal classes from least to most diagnostic, so a
+// multi-shard fan-out can be folded to the one status that describes the
+// request. ExitAborted sits barely above ExitOK because the shard group is an
+// errgroup with first-error-wins cancellation: when one shard fails, its
+// siblings are cancelled and land as aborted, so an abort is usually the
+// CONSEQUENCE of another shard's real terminal cause and must never mask it.
+// The resource verdicts rank highest: they are what the calibration learns its
+// watermarks from, and losing one to a sibling's plain error would silently
+// shrink that population.
+var exitSeverity = []ExitStatus{
+	ExitOK,
+	ExitAborted,
+	ExitSampleBudget,
+	ExitRejected,
+	ExitBreaker,
+	ExitError,
+	ExitTimeout,
+	ExitOOM,
+}
+
+// exitSeverityOf returns e's rank in exitSeverity. A status missing from the
+// ranking outranks every listed one: an unranked member is a bug, and losing an
+// unrecognised terminal class into an "ok" fold would hide it.
+func exitSeverityOf(e ExitStatus) int {
+	for rank, s := range exitSeverity {
+		if s == e {
+			return rank
+		}
+	}
+	return len(exitSeverity)
 }
 
 // exitStatusToken resolves the exit_status token for a joined row, giving a

--- a/internal/optcorpus/optcorpus_test.go
+++ b/internal/optcorpus/optcorpus_test.go
@@ -119,7 +119,7 @@ func TestObserve_ReplaceInPlace_NoGrowth(t *testing.T) {
 	if len(ids) != 1 {
 		t.Fatalf("ring size = %d; want 1 (replace in place)", len(ids))
 	}
-	rec, ok := r.recordFor("q0")
+	rec, _, ok := r.recordFor("q0")
 	if !ok || rec.ShapeID != "cerb:b" {
 		t.Errorf("replace-in-place lost the latest record: %+v ok=%v", rec, ok)
 	}
@@ -151,7 +151,7 @@ func TestDrainIngest_MovesSeamRecordsIntoRing(t *testing.T) {
 	if len(ids) != 2 {
 		t.Fatalf("after drain ring size = %d; want 2", len(ids))
 	}
-	rec, ok := r.recordFor("qa")
+	rec, _, ok := r.recordFor("qa")
 	if !ok || rec.ShapeID != "cerb:a" || rec.Language != "logql" {
 		t.Errorf("drain dropped seam metadata: %+v ok=%v", rec, ok)
 	}

--- a/internal/optcorpus/outcome_test.go
+++ b/internal/optcorpus/outcome_test.go
@@ -104,7 +104,7 @@ func TestObserveOutcome_MergePreservesDispatchMetadata(t *testing.T) {
 	r.ObserveOutcome("qid-m", ExitTokenSampleBudget)
 	r.drainIngest()
 
-	rec, ok := r.recordFor("qid-m")
+	rec, _, ok := r.recordFor("qid-m")
 	if !ok {
 		t.Fatal("dispatch record lost after outcome merge")
 	}
@@ -139,7 +139,7 @@ func TestObserveOutcome_IgnoresNonCerberusSideToken(t *testing.T) {
 	r.ObserveOutcome("qid-x", "oom") // CH-side token — must be ignored
 	r.ObserveOutcome("", ExitTokenSampleBudget)
 	r.drainIngest()
-	rec, ok := r.recordFor("qid-x")
+	rec, _, ok := r.recordFor("qid-x")
 	if !ok || rec.HasOutcome {
 		t.Errorf("non-cerberus-side / empty-id outcome should not stamp: %+v ok=%v", rec, ok)
 	}

--- a/internal/optcorpus/routed_test.go
+++ b/internal/optcorpus/routed_test.go
@@ -1,0 +1,260 @@
+package optcorpus
+
+import (
+	"context"
+	"sort"
+	"strconv"
+	"testing"
+)
+
+// observeRouted calls ObserveRoutedQuery with the routing read-out a real
+// routed dispatch always carries (route B, reason "routed"), keeping the call
+// sites below readable.
+func observeRouted(r *Reconciler, shardIDs []string, shapeID string, kShards uint8) {
+	r.ObserveRoutedQuery(shardIDs, shapeID, nil, "promql", true, "B", 240, 4, 900, 3600, 15, kShards, "routed")
+}
+
+// TestObserveRoutedQuery_FoldsShardRowsIntoOneRow pins the whole point of the
+// routed seam: a route-B dispatch is ONE corpus row whose cost columns describe
+// the whole fan-out, not K rows each describing a fraction of it.
+//
+// Revert the seam (or fold the shards per-row instead of per-request) and this
+// fails two ways at once: the row count stops being 1, and read_rows stops
+// being the sum of what the K shards actually read — which is exactly the
+// comparison against a route-A row the corpus exists to make.
+func TestObserveRoutedQuery_FoldsShardRowsIntoOneRow(t *testing.T) {
+	src := newFakeSource()
+	sink := &memSink{}
+	r := New(src, sink, Options{RingCapacity: 8, ObserveBuffer: 16})
+
+	ids := []string{"trace-a-1", "trace-a-2", "trace-a-3"}
+	src.seed(SourceRow{
+		QueryID: ids[0], NormalizedQueryHash: 99,
+		ReadRows: 100, ReadBytes: 1_000, MemoryUsage: 10, QueryDurationMS: 30,
+		ProfileEvents: map[string]int64{"SelectedMarks": 2},
+	})
+	src.seed(SourceRow{
+		QueryID: ids[1], NormalizedQueryHash: 99,
+		ReadRows: 200, ReadBytes: 2_000, MemoryUsage: 20, QueryDurationMS: 70,
+		ProfileEvents: map[string]int64{"SelectedMarks": 3},
+	})
+	src.seed(SourceRow{
+		QueryID: ids[2], NormalizedQueryHash: 99,
+		ReadRows: 300, ReadBytes: 3_000, MemoryUsage: 30, QueryDurationMS: 50,
+		ProfileEvents: map[string]int64{"SelectedRanges": 5},
+	})
+
+	observeRouted(r, ids, "cerb:rangewindow", uint8(len(ids)))
+	r.drainIngest()
+	r.reconcileOnce(context.Background())
+
+	rows := sink.snapshot()
+	if len(rows) != 1 {
+		t.Fatalf("routed dispatch wrote %d rows; want exactly 1 (the corpus unit is the request)", len(rows))
+	}
+	got := rows[0]
+	if got.ReadRows != 600 {
+		t.Errorf("read_rows = %d; want 600 (sum across shards)", got.ReadRows)
+	}
+	if got.ReadBytes != 6_000 {
+		t.Errorf("read_bytes = %d; want 6000 (sum across shards)", got.ReadBytes)
+	}
+	if got.MemoryUsage != 60 {
+		t.Errorf("memory_usage = %d; want 60 (sum of the concurrent shards' peaks)", got.MemoryUsage)
+	}
+	if got.QueryDurationMS != 70 {
+		t.Errorf("query_duration_ms = %d; want 70 (max: the shards run concurrently)", got.QueryDurationMS)
+	}
+	if got.NormalizedQueryHash != 99 {
+		t.Errorf("normalized_query_hash = %d; want 99", got.NormalizedQueryHash)
+	}
+	if got.ProfileEvents["SelectedMarks"] != 5 || got.ProfileEvents["SelectedRanges"] != 5 {
+		t.Errorf("profile_events = %v; want SelectedMarks=5 (2+3) and SelectedRanges=5", got.ProfileEvents)
+	}
+	if got.Route != "B" || got.DecisionReason != "routed" || got.KShards != uint8(len(ids)) {
+		t.Errorf("routing read-out = (route=%q reason=%q k=%d); want (B, routed, %d)",
+			got.Route, got.DecisionReason, got.KShards, len(ids))
+	}
+	if got.ShapeID != "cerb:rangewindow" {
+		t.Errorf("shape_id = %q; want cerb:rangewindow (the WHOLE plan's shape, so A and B rows join)", got.ShapeID)
+	}
+
+	// Every shard id is retired from the join index once the row is written, so
+	// the next interval cannot emit a second row for the same dispatch.
+	if n := len(r.snapshotIDs()); n != 0 {
+		t.Errorf("join index still holds %d ids after the routed row was written; want 0", n)
+	}
+}
+
+// TestObserveRoutedQuery_WaitsForEveryShard pins the partial-join rule: a
+// routed row is written only once every shard's query_log row is visible.
+// Reverting it produces a row whose cost columns count part of the fan-out —
+// an under-counted route-B row, which is worse than a missing one because the
+// calibration cannot tell it apart from a genuinely cheap dispatch.
+func TestObserveRoutedQuery_WaitsForEveryShard(t *testing.T) {
+	src := newFakeSource()
+	sink := &memSink{}
+	r := New(src, sink, Options{RingCapacity: 8, ObserveBuffer: 16})
+
+	ids := []string{"trace-b-1", "trace-b-2", "trace-b-3"}
+	src.seed(SourceRow{QueryID: ids[0], ReadRows: 100})
+	src.seed(SourceRow{QueryID: ids[1], ReadRows: 200})
+
+	observeRouted(r, ids, "cerb:rangewindow", uint8(len(ids)))
+	r.drainIngest()
+	r.reconcileOnce(context.Background())
+
+	if rows := sink.snapshot(); len(rows) != 0 {
+		t.Fatalf("wrote %d rows with a shard still missing from query_log; want 0 (wait, do not under-count)", len(rows))
+	}
+	if n := len(r.snapshotIDs()); n != len(ids) {
+		t.Fatalf("join index holds %d ids after the deferred reconcile; want %d (all retried next interval)", n, len(ids))
+	}
+
+	// The last shard lands: now the whole fan-out reconciles, in one row.
+	src.seed(SourceRow{QueryID: ids[2], ReadRows: 300})
+	r.reconcileOnce(context.Background())
+
+	rows := sink.snapshot()
+	if len(rows) != 1 {
+		t.Fatalf("wrote %d rows once every shard landed; want 1", len(rows))
+	}
+	if rows[0].ReadRows != 600 {
+		t.Errorf("read_rows = %d; want 600 (all three shards)", rows[0].ReadRows)
+	}
+}
+
+// TestObserveRoutedQuery_MostSevereShardExitWins pins the exit-status fold: a
+// fan-out that OOMed one shard is an OOM for the request, even though its
+// siblings finished and the cancelled ones report an abort. Reverting it (say,
+// to "first shard wins") reports the request as clean and silently removes it
+// from the population the memory watermarks are learnt from.
+func TestObserveRoutedQuery_MostSevereShardExitWins(t *testing.T) {
+	src := newFakeSource()
+	sink := &memSink{}
+	r := New(src, sink, Options{RingCapacity: 8, ObserveBuffer: 16})
+
+	ids := []string{"trace-c-1", "trace-c-2", "trace-c-3"}
+	src.seed(SourceRow{QueryID: ids[0], ExitStatus: ExitOK})
+	src.seed(SourceRow{QueryID: ids[1], ExitStatus: ExitAborted}) // cancelled by its sibling's failure
+	src.seed(SourceRow{QueryID: ids[2], ExitStatus: ExitOOM})
+
+	observeRouted(r, ids, "cerb:rangewindow", uint8(len(ids)))
+	r.drainIngest()
+	r.reconcileOnce(context.Background())
+
+	rows := sink.snapshot()
+	if len(rows) != 1 {
+		t.Fatalf("wrote %d rows; want 1", len(rows))
+	}
+	if rows[0].ExitStatus != ExitOOM.String() {
+		t.Errorf("exit_status = %q; want %q (the most severe shard outcome)", rows[0].ExitStatus, ExitOOM.String())
+	}
+}
+
+// TestExitSeverityRanksEveryExitStatus pins the severity ranking against the
+// enum it ranks. A new ExitStatus member that never reaches exitSeverity would
+// otherwise fold as "more severe than everything" forever, silently relabelling
+// whole fan-outs; this test turns that into a compile-time-adjacent failure.
+func TestExitSeverityRanksEveryExitStatus(t *testing.T) {
+	if len(exitSeverity) != len(exitStatuses) {
+		t.Fatalf("exitSeverity ranks %d statuses; exitStatuses has %d", len(exitSeverity), len(exitStatuses))
+	}
+	ranked := make(map[ExitStatus]bool, len(exitSeverity))
+	for _, s := range exitSeverity {
+		if ranked[s] {
+			t.Errorf("exitSeverity lists %q twice", s)
+		}
+		ranked[s] = true
+	}
+	for _, s := range exitStatuses {
+		if !ranked[s] {
+			t.Errorf("exitSeverity is missing %q — it would outrank every ranked status", s)
+		}
+	}
+}
+
+// TestObserveRoutedQuery_NonBlocking_DropsWhenBufferFull pins the seam's
+// data-plane contract, identical to ObserveQuery's: recording a routed dispatch
+// must never block the query that is being recorded. If it blocked, this test
+// would hang rather than fail.
+func TestObserveRoutedQuery_NonBlocking_DropsWhenBufferFull(t *testing.T) {
+	r := New(newFakeSource(), &memSink{}, Options{RingCapacity: 8, ObserveBuffer: 2})
+	for i := 0; i < 1000; i++ {
+		observeRouted(r, []string{"q" + strconv.Itoa(i) + "-a", "q" + strconv.Itoa(i) + "-b"}, "cerb:scan", 2)
+	}
+	if n := len(r.snapshotIDs()); n != 0 {
+		t.Errorf("ring populated without a drain; got %d", n)
+	}
+	if r.dropped.Load() == 0 {
+		t.Error("expected dropped count > 0 when the ingest buffer overflowed")
+	}
+}
+
+// TestObserveRoutedQuery_EmptyShardIDsRecordNothing pins the untraced-request
+// contract: the shard ids are minted from the request's trace, so a dispatch
+// with no trace context yields empty ids. Those cannot join to anything, and a
+// record with no join key would sit in the ring until the TTL evicted it.
+func TestObserveRoutedQuery_EmptyShardIDsRecordNothing(t *testing.T) {
+	r := New(newFakeSource(), &memSink{}, Options{RingCapacity: 8, ObserveBuffer: 16})
+	observeRouted(r, []string{"", ""}, "cerb:scan", 2)
+	r.drainIngest()
+	if n := len(r.snapshotIDs()); n != 0 {
+		t.Errorf("ring holds %d records for an untraced routed dispatch; want 0", n)
+	}
+}
+
+// TestObserveRoutedQuery_AllShardsIndexOneRecord pins the join-index shape the
+// fold depends on: every shard id must resolve to the SAME ring slot, so K
+// query_log rows reconcile into one record instead of K competing ones.
+func TestObserveRoutedQuery_AllShardsIndexOneRecord(t *testing.T) {
+	r := New(newFakeSource(), &memSink{}, Options{RingCapacity: 8, ObserveBuffer: 16})
+	ids := []string{"trace-d-1", "trace-d-2", "trace-d-3"}
+	observeRouted(r, ids, "cerb:rangewindow", uint8(len(ids)))
+	r.drainIngest()
+
+	slots := map[int]struct{}{}
+	for _, id := range ids {
+		rec, slot, ok := r.recordFor(id)
+		if !ok {
+			t.Fatalf("shard id %q does not resolve to a record", id)
+		}
+		if rec.ShapeID != "cerb:rangewindow" {
+			t.Errorf("shard id %q resolves to shape %q; want cerb:rangewindow", id, rec.ShapeID)
+		}
+		slots[slot] = struct{}{}
+	}
+	if len(slots) != 1 {
+		t.Errorf("the %d shard ids resolve to %d ring slots; want 1", len(ids), len(slots))
+	}
+
+	got := r.snapshotIDs()
+	sort.Strings(got)
+	if len(got) != len(ids) {
+		t.Fatalf("join index holds %v; want all %d shard ids", got, len(ids))
+	}
+}
+
+// TestObserveRoutedQuery_RingEvictionDropsEveryShardID pins the eviction half of
+// the same shape: when a routed record's slot is reused, ALL K of its ids must
+// leave the index. A leftover id would later resolve to whatever record now
+// occupies the slot and contaminate that dispatch's row.
+func TestObserveRoutedQuery_RingEvictionDropsEveryShardID(t *testing.T) {
+	const ringCap = 2
+	r := New(newFakeSource(), &memSink{}, Options{RingCapacity: ringCap, ObserveBuffer: 16})
+	routedIDs := []string{"trace-e-1", "trace-e-2", "trace-e-3"}
+	observeRouted(r, routedIDs, "cerb:routed", uint8(len(routedIDs)))
+	r.drainIngest()
+
+	// Fill the ring past the routed record's slot.
+	for i := 0; i < ringCap; i++ {
+		observeNoRoute(r, "single-"+strconv.Itoa(i), "cerb:scan", nil, "promql")
+	}
+	r.drainIngest()
+
+	for _, id := range routedIDs {
+		if _, _, ok := r.recordFor(id); ok {
+			t.Errorf("shard id %q still resolves after its record was evicted", id)
+		}
+	}
+}

--- a/internal/solver/executor.go
+++ b/internal/solver/executor.go
@@ -25,6 +25,18 @@ type ExecInfo struct {
 	// ShardArgs is the positional-arg list per shard, parallel to SQLs.
 	ShardArgs [][]any
 
+	// ShardQueryIDs is the ClickHouse query_id each shard is dispatched with,
+	// parallel to SQLs. The ids are minted HERE, before any shard context
+	// exists, because they are the join key the router corpus records for the
+	// whole fan-out at the dispatch seam — a routed query is otherwise
+	// unobservable (route B's cost never reaches the corpus, and "no route-B
+	// rows" reads as "route B never fires"). Minting per shard rather than
+	// reusing one id is mandatory: ClickHouse rejects a second concurrent query
+	// carrying a live query_id with code 216. An entry is "" when the request
+	// carries no trace (the driver then self-generates the id and the fan-out is
+	// simply not recorded), matching chclient's own no-trace contract.
+	ShardQueryIDs []string
+
 	// Parallelism is the effective P after the admission clamp — equal to
 	// Cfg.Parallel when the top-up granted everything, lower (down to 1)
 	// when it degraded. Reported so capacity dashboards can see the clamp.
@@ -121,8 +133,9 @@ func (x *Executor) Execute(
 		return nil, nil, fmt.Errorf("%w: nil emitter", ErrSolverEmit)
 	}
 	info := &ExecInfo{
-		SQLs:      make([]string, k),
-		ShardArgs: make([][]any, k),
+		SQLs:          make([]string, k),
+		ShardArgs:     make([][]any, k),
+		ShardQueryIDs: make([]string, k),
 	}
 	for i := range d.Slices {
 		sql, args, err := x.Emitter.Emit(ctx, d.Slices[i].Plan)
@@ -134,6 +147,10 @@ func (x *Executor) Execute(
 		}
 		info.SQLs[i] = sql
 		info.ShardArgs[i] = args
+		// One query_id per shard, fixed here so the caller can record the whole
+		// fan-out at the dispatch seam and runShard stamps the same id onto the
+		// query ClickHouse actually runs.
+		info.ShardQueryIDs[i] = chclient.MintQueryID(ctx)
 	}
 
 	// 2. TWO-STAGE WEIGHTED ADMISSION (degrade-don't-reject). The handler
@@ -328,9 +345,10 @@ func (sc *shardCursor) launchShards(
 			shardIdx := i
 			sql := info.SQLs[shardIdx]
 			args := info.ShardArgs[shardIdx]
+			queryID := info.ShardQueryIDs[shardIdx]
 			out := sc.chans[shardIdx]
 			sc.g.Go(func() error {
-				return sc.runShard(sc.gctx, langName, shardIdx, sql, args, budget, perShardMemoryBytes, out)
+				return sc.runShard(sc.gctx, langName, shardIdx, sql, args, queryID, budget, perShardMemoryBytes, out)
 			})
 		}
 	}()
@@ -361,6 +379,7 @@ func (sc *shardCursor) runShard(
 	idx int,
 	sql string,
 	args []any,
+	queryID string,
 	budget *chclient.SampleBudget,
 	perShardMemoryBytes int64,
 	out chan<- chclient.Sample,
@@ -371,6 +390,12 @@ func (sc *shardCursor) runShard(
 
 	// Per-shard progress recorder (one per ctx key).
 	pctx := chclient.WithProgressFor(gctx, langName)
+	// This shard's own ClickHouse query_id, pre-minted by Execute. Stamping it
+	// here — rather than letting chclient mint one lazily — is what makes the
+	// fan-out joinable: the id recorded for the request at the dispatch seam is
+	// byte-identical to the one system.query_log records for this shard. Every
+	// shard carries its OWN id (a shared one is CH error 216).
+	pctx = chclient.WithQueryID(pctx, queryID)
 	// Carry the shared per-request sample budget so the max-samples 422
 	// parity stays per-REQUEST across all shards.
 	if budget != nil {


### PR DESCRIPTION
## The defect

`internal/engine`'s corpus observation seam (`observeQuery`) is reachable **only** from `execContext`, and `execContext`'s two call sites — `QueryPlan` and `dispatchRouteACursor` — are both on the non-routed path. `executeRouted` and `executeRoutedCursor` return before ever reaching it.

A sharded (route-B) dispatch could therefore **never** produce a router-corpus row. The standing read-out that "0 of 192,565 corpus rows are route B" was a statement about the instrument, not about the router: with this seam missing, that count is 0 by construction whether or not route B ever fires.

## The fix

- **`internal/engine/engine.go`** — new `observeRoutedQuery(info, plan, language, decision)` helper plus a `QueryObserver.ObserveRoutedQuery` method. Called from `executeRouted`, `executeRoutedCursor`, and `buildRoutedCursorResult` (the shared tail of the three memo/retry route-B paths). `executeRoutedCursor` does **not** go through `buildRoutedCursorResult`, so the two wirings cannot double-record — verified by walking all five route-B dispatch sites. Route tokens `"A"` / `"B"` are lifted to named `corpusRouteA` / `corpusRouteB` consts.
- **`internal/solver/executor.go`** — `ExecInfo` now carries `ShardQueryIDs []string`, minted per shard in the existing emit loop and stamped onto each shard's context in `runShard`. Every shard needs a **distinct** id: all K shard contexts descend from one parent, so the pre-existing `EnsureQueryID` ctx cache would hand all of them the same id, which ClickHouse rejects with error 216 (`QUERY_WITH_SAME_ID_IS_ALREADY_RUNNING`).
- **`internal/chclient/client.go`** — `ensureQueryID` split into `mintQueryID` (derive without caching) + `withQueryID` (cache), exported as `MintQueryID` / `WithQueryID` for exactly that fan-out case.
- **`internal/optcorpus/optcorpus.go`** — a `Record` may now hold K shard ids; all K index to a single ring slot, and eviction drops every id of the evicted record. `reconcileOnce` groups `system.query_log` rows by ring slot and emits **one row per logical query**.

### Cost-fold semantics (the design questions, answered in `rowFor`'s doc comment)

| column | fold | why |
|---|---|---|
| `read_rows`, `read_bytes`, `memory_usage` | **sum** | the corpus exists to compare route B's *total* cost against route A's; a max would understate the fan-out. `memory_usage` sums because the shards run concurrently, so the peak really is roughly additive. |
| `query_duration_ms` | **max** | summing yields a CPU-time-like number that is not comparable to route A's wall-clock; engine-side wall-clock would mix instruments with route A's `query_log`-derived value. |
| `profile_events` | **sum per key** | same reasoning as `read_rows`. |
| `exit_status` | **most severe** | one failed shard fails the request. `aborted` ranks barely above `ok` because `errgroup` first-error-wins cancels the siblings, so most aborts are consequences, not causes. |
| row count | **one per request** | the corpus's unit is the request; K rows per routed query would make every A/B aggregate silently weight route B by K. |

A group is written only once **all** K shards are visible in `query_log`; a partial group is left in the join index and retried next interval (and expires on the existing TTL if the missing shards never ran). An under-counted route-B row is worse than a missing one for a corpus whose whole purpose is A-vs-B cost comparison.

Recording cannot fail the query: the seam is the same non-blocking channel send `ObserveQuery` already uses (drop-under-burst, counted in `dropped`), it is nil-guarded, and it spawns no goroutine — so no new goleak surface.

## Tests

`internal/engine/routed_corpus_observe_test.go` (new):

- `TestExecuteRoutedCursor_ObservesTheFanOut` — a routed cursor produces exactly **one** routed observation and **zero** route-A observations, carrying K distinct non-empty ids that are byte-identical to the ids ClickHouse actually saw, `route == "B"`, `decision_reason == solver.ReasonRouted`, `k_shards > 0`, `shape_id == planShapeID(plan)`. Reverting the seam drops the count to 0.
- `TestExecuteRouted_ObservesTheFanOut` — same for the eager path.
- `TestBuildRoutedCursorResult_ObservesOnce` — the memo-hit / retry seam records exactly once, with `routed` as the reason (not the `via` label).
- `TestExecuteRoutedCursor_UntracedRequestStillSucceeds` / `TestExecuteRoutedCursor_NoObserverStillSucceeds` — a query with no ids to record, and a query with no observer at all, still stream their rows.

`internal/optcorpus/routed_test.go` (new): fold correctness (3 shards → 1 row, sums/max asserted), the wait-for-every-shard rule (2 of 3 → 0 rows and the ids retained; the 3rd arrival releases the complete row), most-severe exit wins, `exitSeverityOf` ranks every declared `ExitStatus`, non-blocking drop under a full buffer, empty-id records are no-ops, all K ids resolve to one record, and ring eviction drops every shard id.

Existing route-A coverage in `internal/engine/engine_test.go` still asserts exactly one `ObserveQuery` per non-routed query, so the no-double-count property is pinned on both sides.

## Not fixed here (separate PRs)

1. **91% of corpus rows carry an empty `decision_reason`** — *different* root cause, not this one. `solver.Solver.Classify` returns `(nil, false)` for any head that is not `solver.LangPromQL`, so LogQL/TraceQL dispatches legitimately record `route_present=false`; additionally `ObserveDrainOutcome` and `ObserveCapRejection` deliberately carry no routing read-out. `test/regression/router_corpus_seed_test.go` already pins that as by-design, so the 91% is expected-shape rather than a bug — but the corpus would be more useful if the non-PromQL heads recorded *why* they are unclassified instead of recording nothing.
2. **Routed `CursorResult`s carry no `QueryID`** — so a sample-budget 422 surfacing during a routed drain cannot be stamped onto the corpus (`ObserveDrainOutcome` no-ops on an empty query id). Routed outcomes are therefore still invisible to the outcome seam even after this PR fixes the dispatch seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
