### PR TITLE
fix(solver): extract features from every GridCarrier kind, not just RangeWindow

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -201,9 +201,11 @@ on any diff vs reference Prometheus.
 additive `X-Cerberus-Route-Decision` header reporting the per-request
 classification regardless of mode: `routed` (took route B),
 `below-threshold`, `instant`, `instant-join`, `not-sliceable`, `high-D`,
-`now64`, `grid-mismatch`, `incommensurate`, `scalar-heavy`, or
+`now64`, `grid-mismatch`, `incommensurate`, `scalar-heavy`,
 `routing-disabled` (the reason recorded under `single`, where no threshold is
-consulted at all). The header is **omitted**
+consulted at all), or `extraction-failed` (no grid carrier was measurable, so
+the reported cost grid is zero for want of data rather than because the plan is
+cheap). The header is **omitted**
 for non-PromQL heads and when the solver is fully off (nil). It is purely
 diagnostic — observe it to see what the solver would do (under `single`) or
 did (under `auto`) without changing the wire body.

--- a/docs/router-rules.md
+++ b/docs/router-rules.md
@@ -259,7 +259,7 @@ scalar) — context, never a gate, so no inline tolerance number is needed.
 `decision_reason` is the shadow-header value the solver records to explain each
 routing decision (`routed`, `below-threshold`, `not-sliceable`, `instant`,
 `instant-join`, `high-D`, `now64`, `grid-mismatch`, `incommensurate`,
-`scalar-heavy`, `routing-disabled`; see
+`scalar-heavy`, `routing-disabled`, `extraction-failed`; see
 [`internal/solver/decision.go`](../internal/solver/decision.go)). Its primary
 use is **grouping / attribution**: the failure rules group by it so the operator
 can see *which solver path* produced the failure and pick the right lever (shard

--- a/docs/solver.md
+++ b/docs/solver.md
@@ -40,10 +40,17 @@ The signals, each gathered in the one pass:
    marker is proven.
 2. **Routable spine family.** Re-anchoring rewrites the grid carried by the
    `RangeWindow` matrix family and the `RangeLWR` bare-selector
-   last-with-respect-to family. A `RangeBucketFanout` or `StepGrid` spine
-   carries its own eval grid that re-anchoring clones verbatim, so a plan whose
-   spine bound-carrier is one of those fails closed to route A (every shard
-   would otherwise emit stale bounds).
+   last-with-respect-to family. Every other grid carrier —
+   `RangeWindowNative`, `RangeWindowResample`, `RangeBucketFanout`, `StepGrid`,
+   `AbsentOverTime` — carries its own eval grid that re-anchoring clones
+   verbatim, so a plan whose spine bound-carrier is one of those fails closed to
+   route A (every shard would otherwise emit stale bounds).
+
+   Measurement is separate from admissibility: the signal walk records the cost
+   grid of **every** carrier kind, routable or not, because the corpus needs to
+   know how expensive the refused plans were. Being seen never makes a carrier
+   sliceable — that is decided solely by the marker in signal 1 and by whether
+   re-anchoring knows the node's grid.
 3. **Pinned bounds.** Both `Start` and `End` must be pinned (non-zero) on the
    outermost windowed node — it anchors the whole grid. An inner subquery node
    may be unpinned (both bounds zero, the shape the re-anchor fills); a
@@ -94,8 +101,8 @@ consulted when none was.
 Every classification — routed or not — produces a `Decision` carrying the
 reason (`routed`, `below-threshold`, `not-sliceable`, `instant`, `instant-join`,
 `high-D`, `now64`, `grid-mismatch`, `incommensurate`, `scalar-heavy`,
-`routing-disabled`) for the shadow header, alongside the plan's cost grid
-(`N`, `F`, `D`, `OuterRange`, `Step`).
+`routing-disabled`, `extraction-failed`) for the shadow header, alongside the
+plan's cost grid (`N`, `F`, `D`, `OuterRange`, `Step`).
 
 The grid is populated on **every** Decision, including the refusals. The signal
 walk that derives it makes no routing decision and mutates nothing, so it runs
@@ -109,6 +116,14 @@ genuine instant query cannot have. Both halves of that signature matter:
 `reason=instant` is also recorded for a range request carrying an unpinned or
 instant-shaped window, and that one has a real grid — it is the zero `Step`
 beside a populated grid that identifies a missed carrier.
+
+The complementary case — a range request whose plan yields no carrier the walk
+can measure at all — carries its own token, `extraction-failed`. It is the one
+refusal whose cost grid is legitimately all zeros, and it says so in the row
+rather than presenting as a cheap plan. That distinction is load-bearing for
+calibration: a threshold fitted over the refused population must exclude rows
+that were never measured, and no aggregate over `N`/`F`/`D` can tell an
+unmeasured plan from a trivial one unless the reason does.
 
 ## Slicing geometry
 

--- a/internal/engine/plan_shape_id.go
+++ b/internal/engine/plan_shape_id.go
@@ -15,8 +15,9 @@ const shapeIDPrefix = "cerb:"
 
 // planShapeID returns a COMPACT, literal-free identifier for plan's shape,
 // for stamping into ClickHouse log_comment. It captures the emit-root node
-// kind plus a few key structural modifiers (aggregate group-key arity,
-// presence of a range window / limit / join / union) and DELIBERATELY omits
+// kind plus a few key structural modifiers (aggregate group-key arity, which
+// grid-carrying range nodes are present, presence of a limit / join / union)
+// and DELIBERATELY omits
 // every literal: no metric names, no label values, no timestamps, no group-by
 // column names. Two queries with the same plan shape but different literals
 // hash to the same id, so operators can cluster system.query_log rows by
@@ -47,11 +48,15 @@ func shapeModifiers(plan chplan.Node) []string {
 		mods        []string
 		aggKeys     = -1
 		hasRange    bool
+		hasLWR      bool
 		hasLimit    bool
 		hasJoin     bool
 		hasUnion    bool
 		hasNative   bool
 		hasResample bool
+		hasFanout   bool
+		hasStepGrid bool
+		hasAbsentOT bool
 	)
 	chplan.Walk(plan, func(n chplan.Node) bool {
 		switch v := n.(type) {
@@ -66,6 +71,14 @@ func shapeModifiers(plan chplan.Node) []string {
 			hasNative = true
 		case *chplan.RangeWindowResample:
 			hasResample = true
+		case *chplan.RangeLWR:
+			hasLWR = true
+		case *chplan.RangeBucketFanout:
+			hasFanout = true
+		case *chplan.StepGrid:
+			hasStepGrid = true
+		case *chplan.AbsentOverTime:
+			hasAbsentOT = true
 		case *chplan.Limit:
 			hasLimit = true
 		case *chplan.Scan:
@@ -80,6 +93,11 @@ func shapeModifiers(plan chplan.Node) []string {
 	if aggKeys >= 0 {
 		mods = append(mods, "agg="+strconv.Itoa(aggKeys))
 	}
+	// The range-carrying modifiers below are the shape's per-anchor work. Every
+	// [chplan.GridCarrier] kind has its own token here: a carrier with no token
+	// is invisible to log_comment clustering, so an operator bucketing
+	// system.query_log sees a histogram fan-out and a bare projection under the
+	// SAME id — and the expensive shape hides inside the cheap bucket.
 	if hasRange {
 		mods = append(mods, "rw")
 	}
@@ -88,6 +106,18 @@ func shapeModifiers(plan chplan.Node) []string {
 	}
 	if hasResample {
 		mods = append(mods, "rwr")
+	}
+	if hasLWR {
+		mods = append(mods, "lwr")
+	}
+	if hasFanout {
+		mods = append(mods, "rbf")
+	}
+	if hasAbsentOT {
+		mods = append(mods, "aot")
+	}
+	if hasStepGrid {
+		mods = append(mods, "sg")
 	}
 	if hasJoin {
 		mods = append(mods, "join")
@@ -120,6 +150,14 @@ func nodeKind(n chplan.Node) string {
 		return "rwn"
 	case *chplan.RangeWindowResample:
 		return "rwr"
+	case *chplan.RangeLWR:
+		return "lwr"
+	case *chplan.RangeBucketFanout:
+		return "rbf"
+	case *chplan.AbsentOverTime:
+		return "aot"
+	case *chplan.StepGrid:
+		return "sg"
 	case *chplan.Limit:
 		return "limit"
 	case *chplan.OrderBy:

--- a/internal/engine/plan_shape_id_carrier_test.go
+++ b/internal/engine/plan_shape_id_carrier_test.go
@@ -1,0 +1,289 @@
+package engine
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// The canonical grid every carrier fixture below is built on. The values are
+// irrelevant to a shape id — it is literal-free by construction — but a carrier
+// still needs a well-formed grid to be the node it claims to be.
+var (
+	shapeGridStart = time.Unix(1_700_000_000, 0).UTC()
+	shapeGridEnd   = shapeGridStart.Add(time.Hour)
+)
+
+const (
+	shapeGridStep      = 15 * time.Second
+	shapeCarrierWindow = 5 * time.Minute
+)
+
+// carrierTokenCase pairs a [chplan.GridCarrier] kind with the modifier token
+// planShapeID must emit for it.
+type carrierTokenCase struct {
+	// kind is the chplan struct name, checked against the package source by
+	// TestShapeModifiers_CoverEveryGridCarrier.
+	kind  string
+	node  func(input chplan.Node) chplan.Node
+	token string
+}
+
+func carrierTokenCases() []carrierTokenCase {
+	return []carrierTokenCase{
+		{
+			kind:  "RangeWindow",
+			token: "rw",
+			node: func(in chplan.Node) chplan.Node {
+				return &chplan.RangeWindow{
+					Input: in, Func: "rate", Range: shapeCarrierWindow, Step: shapeGridStep,
+					OuterRange: shapeGridEnd.Sub(shapeGridStart), Start: shapeGridStart, End: shapeGridEnd,
+					TimestampColumn: "TimeUnix", ValueColumn: "Value",
+				}
+			},
+		},
+		{
+			kind:  "RangeWindowNative",
+			token: "rwn",
+			node: func(in chplan.Node) chplan.Node {
+				return &chplan.RangeWindowNative{
+					Input: in, Func: "rate", Range: shapeCarrierWindow, Step: shapeGridStep,
+					Start: shapeGridStart, End: shapeGridEnd,
+					TimestampColumn: "TimeUnix", ValueColumn: "Value",
+				}
+			},
+		},
+		{
+			kind:  "RangeWindowResample",
+			token: "rwr",
+			node: func(in chplan.Node) chplan.Node {
+				return &chplan.RangeWindowResample{
+					Input: in, Start: shapeGridStart, End: shapeGridEnd, Step: shapeGridStep,
+					Lookback: shapeCarrierWindow, MetricNameCol: "MetricName", AttributesCol: "Attributes",
+					TimestampCol: "TimeUnix", ValueCol: "Value",
+				}
+			},
+		},
+		{
+			kind:  "RangeLWR",
+			token: "lwr",
+			node: func(in chplan.Node) chplan.Node {
+				return &chplan.RangeLWR{
+					Input: in, Start: shapeGridStart, End: shapeGridEnd, Step: shapeGridStep,
+					Lookback: shapeCarrierWindow, MetricNameCol: "MetricName", AttributesCol: "Attributes",
+					TimestampCol: "TimeUnix", ValueCol: "Value",
+				}
+			},
+		},
+		{
+			kind:  "RangeBucketFanout",
+			token: "rbf",
+			node: func(in chplan.Node) chplan.Node {
+				return &chplan.RangeBucketFanout{
+					Input: in, Start: shapeGridStart, End: shapeGridEnd, Step: shapeGridStep,
+					Lookback:     shapeCarrierWindow,
+					AnchorAlias:  "anchor_ts",
+					TimestampCol: "TimeUnix",
+				}
+			},
+		},
+		{
+			kind:  "AbsentOverTime",
+			token: "aot",
+			node: func(in chplan.Node) chplan.Node {
+				return &chplan.AbsentOverTime{
+					Input: in, Range: shapeCarrierWindow, Start: shapeGridStart, End: shapeGridEnd,
+					Step: shapeGridStep, TimestampColumn: "TimeUnix", ValueColumn: "Value",
+					MetricNameColumn: "MetricName", AttributesColumn: "Attributes",
+				}
+			},
+		},
+		{
+			kind:  "StepGrid",
+			token: "sg",
+			node: func(chplan.Node) chplan.Node {
+				return &chplan.StepGrid{Start: shapeGridStart, End: shapeGridEnd, Step: shapeGridStep}
+			},
+		},
+	}
+}
+
+// TestShapeModifiers_EveryGridCarrierGetsAToken asserts each
+// [chplan.GridCarrier] kind contributes its modifier token to the shape id.
+//
+// Reverting the vocabulary widening drops the lwr / rbf / aot / sg rows: a
+// histogram fan-out over a union collapses to the SAME id as a bare projection,
+// so an operator clustering system.query_log by log_comment finds the expensive
+// shapes hidden inside the cheap bucket and cannot tell the two apart at all.
+//
+// The tokens are per-kind rather than per-family because the per-anchor work
+// differs by kind — a fan-out over histogram buckets and a last-value lookback
+// cost nothing alike — and a shared token would merge exactly the populations
+// an operator is trying to separate.
+func TestShapeModifiers_EveryGridCarrierGetsAToken(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range carrierTokenCases() {
+		t.Run(tc.kind, func(t *testing.T) {
+			t.Parallel()
+
+			// Wrapped in a Project so the carrier is a modifier, not the root
+			// kind — the root token would otherwise mask a missing modifier.
+			plan := &chplan.Project{Input: tc.node(&chplan.Scan{Table: "otel_metrics_sum"})}
+
+			id := planShapeID(plan)
+			if !strings.Contains(id, ";"+tc.token) {
+				t.Errorf("shape id %q for %s carries no %q modifier; the carrier is invisible to "+
+					"log_comment clustering", id, tc.kind, tc.token)
+			}
+		})
+	}
+}
+
+// TestShapeModifiers_DistinguishesFanoutFromBareProject is the concrete
+// collision the missing tokens caused: a plan that demonstrably contains a
+// range fan-out, a union and a join must not hash to the id of a plain
+// Project over an Aggregate.
+func TestShapeModifiers_DistinguishesFanoutFromBareProject(t *testing.T) {
+	t.Parallel()
+
+	groupBy := []chplan.Expr{
+		&chplan.ColumnRef{Name: "MetricName"},
+		&chplan.ColumnRef{Name: "Attributes"},
+		&chplan.ColumnRef{Name: "ServiceName"},
+	}
+	unionScan := &chplan.Scan{
+		Table:       "otel_metrics_exponential_histogram",
+		UnionTables: []string{"otel_metrics_histogram"},
+	}
+	fanout := &chplan.RangeBucketFanout{
+		Input: unionScan, Start: shapeGridStart, End: shapeGridEnd, Step: shapeGridStep,
+		Lookback: shapeCarrierWindow, AnchorAlias: "anchor_ts", TimestampCol: "TimeUnix",
+	}
+	rich := &chplan.Project{
+		Input: &chplan.Aggregate{
+			GroupBy: groupBy,
+			Input: &chplan.VectorJoin{
+				Left:  fanout,
+				Right: &chplan.StepGrid{Start: shapeGridStart, End: shapeGridEnd, Step: shapeGridStep},
+			},
+		},
+	}
+	bare := &chplan.Project{
+		Input: &chplan.Aggregate{GroupBy: groupBy, Input: &chplan.Scan{Table: "otel_metrics_sum"}},
+	}
+
+	richID, bareID := planShapeID(rich), planShapeID(bare)
+	if richID == bareID {
+		t.Fatalf("fan-out + union + join and a bare aggregate share the shape id %q", richID)
+	}
+	const wantRich = "cerb:project;agg=3;rbf;sg;join;union"
+	if richID != wantRich {
+		t.Errorf("shape id = %q; want %q", richID, wantRich)
+	}
+}
+
+// TestShapeModifiers_CoverEveryGridCarrier keeps the table above in lockstep
+// with chplan: a carrier kind added there without a token here fails HERE,
+// rather than silently shipping a plan shape that log_comment cannot see.
+//
+// It identifies a carrier the same way chplan's own completeness ratchet does —
+// by the (Start, End, Step) grid field signature — because the registry that
+// ratchet checks is unexported.
+func TestShapeModifiers_CoverEveryGridCarrier(t *testing.T) {
+	t.Parallel()
+
+	want := gridDeclaringChplanStructs(t)
+	got := make([]string, 0, len(carrierTokenCases()))
+	for _, tc := range carrierTokenCases() {
+		got = append(got, tc.kind)
+	}
+	sort.Strings(got)
+
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("shape-id carrier table covers [%s]; chplan declares [%s]. Every GridCarrier kind "+
+			"needs a modifier token in shapeModifiers.", strings.Join(got, ","), strings.Join(want, ","))
+	}
+}
+
+// gridDeclaringChplanStructs parses internal/chplan and returns the sorted names
+// of every struct declaring the (Start time.Time, End time.Time, Step
+// time.Duration) grid triple — the field signature chplan's own GridCarrier
+// completeness ratchet keys on.
+func gridDeclaringChplanStructs(t *testing.T) []string {
+	t.Helper()
+
+	dir := filepath.Join("..", "chplan")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read %s: %v", dir, err)
+	}
+
+	fset := token.NewFileSet()
+	var names []string
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		f, err := parser.ParseFile(fset, filepath.Join(dir, name), nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		ast.Inspect(f, func(n ast.Node) bool {
+			ts, ok := n.(*ast.TypeSpec)
+			if !ok {
+				return true
+			}
+			st, ok := ts.Type.(*ast.StructType)
+			if !ok || st.Fields == nil {
+				return true
+			}
+			var hasStart, hasEnd, hasStep bool
+			for _, fld := range st.Fields.List {
+				typeName := fieldTypeName(fld.Type)
+				for _, id := range fld.Names {
+					switch {
+					case id.Name == "Start" && typeName == "time.Time":
+						hasStart = true
+					case id.Name == "End" && typeName == "time.Time":
+						hasEnd = true
+					case id.Name == "Step" && typeName == "time.Duration":
+						hasStep = true
+					}
+				}
+			}
+			if hasStart && hasEnd && hasStep {
+				names = append(names, ts.Name.Name)
+			}
+			return true
+		})
+	}
+	if len(names) == 0 {
+		t.Fatal("found no grid-declaring structs in internal/chplan; the scan is broken, not the vocabulary")
+	}
+	sort.Strings(names)
+	return names
+}
+
+// fieldTypeName renders a qualified type expression as "pkg.Name", or "" for a
+// shape this scan does not care about.
+func fieldTypeName(e ast.Expr) string {
+	sel, ok := e.(*ast.SelectorExpr)
+	if !ok {
+		return ""
+	}
+	pkg, ok := sel.X.(*ast.Ident)
+	if !ok {
+		return ""
+	}
+	return pkg.Name + "." + sel.Sel.Name
+}

--- a/internal/routerrules/columns.go
+++ b/internal/routerrules/columns.go
@@ -213,6 +213,11 @@ var enumDomains = map[string]map[string]struct{}{
 		// Routing switched off deployment-wide: the plan was classified but no
 		// threshold was consulted, so the row says nothing about where one sits.
 		"routing-disabled",
+		// Nothing was measured: the walk found no grid carrier it could read,
+		// so this row's feature columns are zero for want of data rather than
+		// because the plan is cheap. A rule that reads the cost columns must
+		// exclude this population, not average it in.
+		"extraction-failed",
 	),
 }
 

--- a/internal/solver/carrier_geometry_test.go
+++ b/internal/solver/carrier_geometry_test.go
@@ -1,0 +1,547 @@
+package solver
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// The per-anchor lookback each carrier kind gets in the table below. Every value
+// is DISTINCT so a extractor that stamped one hard-coded duration onto every
+// kind — or that read the wrong kind's field — cannot satisfy the table.
+const (
+	geomRangeWindowRange   = 5 * time.Minute
+	geomRangeLWRLookback   = 4 * time.Minute
+	geomNativeRange        = 3 * time.Minute
+	geomResampleLookback   = 2 * time.Minute
+	geomFanoutLookback     = 6 * time.Minute
+	geomAbsentOverTimeSpan = 7 * time.Minute
+)
+
+// geomAnchors is the anchor count of the shared canonical grid: gridStart..gridEnd
+// is 1h at gridStep = 15s, end-inclusive, so N = 3600/15 + 1.
+const geomAnchors = 241
+
+// carrierCase is one row of the seven-kind extraction table.
+type carrierCase struct {
+	// kind is the chplan struct name, used to prove the table covers the whole
+	// GridCarrier set (see TestCarrierGeometry_CoversEveryCarrier).
+	kind string
+	// plan builds a plan whose ONLY grid carrier is this kind, on the canonical
+	// gridStart..gridEnd / gridStep grid.
+	plan func() chplan.Node
+	// wantD is the cumulative per-anchor lookback the extractor must record.
+	wantD time.Duration
+	// wantFanout is wantD / gridStep.
+	wantFanout int64
+	// reanchorable says whether chplan.ReanchorRange re-grids this kind. It is
+	// the ONLY thing that decides whether the plan may be sliced; every row
+	// records real features either way. A row with reanchorable == false must
+	// still be refused, which is the correctness half of this table.
+	reanchorable bool
+}
+
+// carrierCases is the full GridCarrier table. Every kind builds its own leaf
+// plan on the same grid so the expected N / OuterRange are shared and only the
+// per-anchor lookback varies.
+func carrierCases() []carrierCase {
+	return []carrierCase{
+		{
+			kind: "RangeWindow",
+			plan: func() chplan.Node {
+				return &chplan.RangeWindow{
+					Input:           leafScan(),
+					Func:            "rate",
+					Range:           geomRangeWindowRange,
+					Step:            gridStep,
+					OuterRange:      gridEnd.Sub(gridStart),
+					Start:           gridStart,
+					End:             gridEnd,
+					TimestampColumn: "TimeUnix",
+					ValueColumn:     "Value",
+					GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+				}
+			},
+			wantD:        geomRangeWindowRange,
+			wantFanout:   int64(geomRangeWindowRange / gridStep),
+			reanchorable: true,
+		},
+		{
+			kind: "RangeLWR",
+			plan: func() chplan.Node {
+				return &chplan.RangeLWR{
+					Input:         leafScan(),
+					Start:         gridStart,
+					End:           gridEnd,
+					Step:          gridStep,
+					Lookback:      geomRangeLWRLookback,
+					MetricNameCol: "MetricName",
+					AttributesCol: "Attributes",
+					TimestampCol:  "TimeUnix",
+					ValueCol:      "Value",
+				}
+			},
+			wantD:        geomRangeLWRLookback,
+			wantFanout:   int64(geomRangeLWRLookback / gridStep),
+			reanchorable: true,
+		},
+		{
+			// The regression this whole table exists for: a natively-lowered
+			// rate() is the plan's ONLY carrier, so an extractor blind to it
+			// records nothing at all.
+			kind: "RangeWindowNative",
+			plan: func() chplan.Node {
+				return &chplan.RangeWindowNative{
+					Input:           leafScan(),
+					Func:            "rate",
+					Range:           geomNativeRange,
+					Step:            gridStep,
+					Start:           gridStart,
+					End:             gridEnd,
+					TimestampColumn: "TimeUnix",
+					ValueColumn:     "Value",
+					GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+				}
+			},
+			wantD:        geomNativeRange,
+			wantFanout:   int64(geomNativeRange / gridStep),
+			reanchorable: false,
+		},
+		{
+			kind: "RangeWindowResample",
+			plan: func() chplan.Node {
+				return &chplan.RangeWindowResample{
+					Input:         leafScan(),
+					Start:         gridStart,
+					End:           gridEnd,
+					Step:          gridStep,
+					Lookback:      geomResampleLookback,
+					MetricNameCol: "MetricName",
+					AttributesCol: "Attributes",
+					TimestampCol:  "TimeUnix",
+					ValueCol:      "Value",
+				}
+			},
+			wantD:        geomResampleLookback,
+			wantFanout:   int64(geomResampleLookback / gridStep),
+			reanchorable: false,
+		},
+		{
+			kind: "RangeBucketFanout",
+			plan: func() chplan.Node {
+				return &chplan.RangeBucketFanout{
+					Input:          leafScan(),
+					Start:          gridStart,
+					End:            gridEnd,
+					Step:           gridStep,
+					Lookback:       geomFanoutLookback,
+					GroupBy:        []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+					GroupByAliases: []string{"Attributes"},
+					AggFuncs: []chplan.AggFunc{
+						{Name: "argMax", Args: []chplan.Expr{&chplan.ColumnRef{Name: "BucketCounts"}}, Alias: "BucketCounts"},
+					},
+					AnchorAlias:  "anchor_ts",
+					TimestampCol: "TimeUnix",
+				}
+			},
+			wantD:        geomFanoutLookback,
+			wantFanout:   int64(geomFanoutLookback / gridStep),
+			reanchorable: false,
+		},
+		{
+			kind: "AbsentOverTime",
+			plan: func() chplan.Node {
+				return &chplan.AbsentOverTime{
+					Input:            leafScan(),
+					Range:            geomAbsentOverTimeSpan,
+					Start:            gridStart,
+					End:              gridEnd,
+					Step:             gridStep,
+					TimestampColumn:  "TimeUnix",
+					ValueColumn:      "Value",
+					MetricNameColumn: "MetricName",
+					AttributesColumn: "Attributes",
+				}
+			},
+			wantD:        geomAbsentOverTimeSpan,
+			wantFanout:   int64(geomAbsentOverTimeSpan / gridStep),
+			reanchorable: false,
+		},
+		{
+			// A bare anchor axis (time(), vector(scalar), the date functions).
+			// It reads no samples, so a zero cumulative_d is the CORRECT
+			// extraction here, not a missed one — and the anchor grid it does
+			// carry must still be recorded, which is what separates it from an
+			// unmeasured plan.
+			kind: "StepGrid",
+			plan: func() chplan.Node {
+				return &chplan.StepGrid{Start: gridStart, End: gridEnd, Step: gridStep}
+			},
+			wantD:        0,
+			wantFanout:   0,
+			reanchorable: false,
+		},
+	}
+}
+
+// TestCarrierGeometry_ExtractsFeaturesForEveryKind is the table the briefing
+// calls for: every [chplan.GridCarrier] kind must yield a real (n_anchors,
+// outer_range, cumulative_d, fanout) readout on the Decision that reaches the
+// calibration corpus.
+//
+// Reverting the fix breaks this on four rows at once — RangeWindowNative,
+// RangeWindowResample, RangeBucketFanout and StepGrid all collapse to
+// NAnchors=0 / OuterRange=0 / CumulativeD=0, because walkNode had no arm that
+// recorded them and every feature is produced by that walk. AbsentOverTime
+// collapses on CumulativeD alone for the same reason.
+//
+// It also pins the correctness half in the same rows: measuring a carrier must
+// never make it sliceable. Only the two re-anchorable families may be eligible;
+// the other five are refused with a non-zero grid, which is exactly the state
+// the corpus needs (what it cost, and why we declined).
+func TestCarrierGeometry_ExtractsFeaturesForEveryKind(t *testing.T) {
+	t.Parallel()
+
+	wantOuterRange := gridEnd.Sub(gridStart)
+
+	for _, tc := range carrierCases() {
+		tc := tc
+		t.Run(tc.kind, func(t *testing.T) {
+			t.Parallel()
+
+			plan := tc.plan()
+
+			// Derive the request grid from the plan exactly as engine.classify
+			// does, so the fixture cannot smuggle in a grid the plan does not
+			// actually carry.
+			start, end, step := GridOf(plan)
+			if step != gridStep || !start.Equal(gridStart) || !end.Equal(gridEnd) {
+				t.Fatalf("fixture grid drifted: GridOf = (%s, %s, %s), want (%s, %s, %s)",
+					start, end, step, gridStart, gridEnd, gridStep)
+			}
+			meta := RequestMeta{Lang: LangPromQL, Start: start, End: end, Step: step}
+
+			p := &Planner{Cfg: autoCfg()}
+			d, routed := p.Plan(plan, meta)
+
+			if d.NAnchors != geomAnchors {
+				t.Errorf("NAnchors = %d, want %d — a carrier the walk cannot see contributes "+
+					"no anchor count and the corpus row is unreplayable", d.NAnchors, geomAnchors)
+			}
+			if d.OuterRange != wantOuterRange {
+				t.Errorf("OuterRange = %s, want %s", d.OuterRange, wantOuterRange)
+			}
+			if d.CumulativeD != tc.wantD {
+				t.Errorf("CumulativeD = %s, want %s", d.CumulativeD, tc.wantD)
+			}
+			if d.Fanout != tc.wantFanout {
+				t.Errorf("Fanout = %d, want %d", d.Fanout, tc.wantFanout)
+			}
+			if d.Step != gridStep {
+				t.Errorf("Step = %s, want %s", d.Step, gridStep)
+			}
+
+			// Extraction succeeded, so the reason must never be the
+			// nothing-was-measured token.
+			if d.Reason == ReasonExtractionFailed {
+				t.Errorf("reason = %q on a plan whose carrier WAS measured", d.Reason)
+			}
+
+			// The correctness gate: only ReanchorRange's own families slice.
+			if !tc.reanchorable {
+				if routed {
+					t.Errorf("plan routed B (K=%d) on a carrier ReanchorRange clones VERBATIM — "+
+						"every shard would emit the original full-grid bounds", d.K)
+				}
+				if d.Reason != ReasonNotSliceable {
+					t.Errorf("reason = %q, want %q — a non-re-anchorable carrier is refused by the "+
+						"slice-invariance gates, not by a cost threshold", d.Reason, ReasonNotSliceable)
+				}
+				if !chplanRefusesSlicing(plan) {
+					t.Errorf("plan is slice-invariant end-to-end; the refusal above is then resting on " +
+						"the spine flag alone with no structural backstop")
+				}
+			}
+		})
+	}
+}
+
+// chplanRefusesSlicing reports whether the plan is refused by chplan's own
+// slice-invariance registry OR by the solver's routable-spine flag. It is the
+// belt-and-braces read of the two independent correctness gates a
+// non-re-anchorable carrier must trip, checked from the test so a change that
+// silently dropped one of them is visible.
+func chplanRefusesSlicing(plan chplan.Node) bool {
+	refused := false
+	chplan.Walk(plan, func(n chplan.Node) bool {
+		if !chplan.IsSliceInvariant(n) {
+			refused = true
+			return false
+		}
+		if gc, ok := n.(chplan.GridCarrier); ok {
+			if geom, known := carrierGeometryOf(gc); !known || !geom.reanchorable {
+				if _, _, step := gc.EvalGrid(); step > 0 {
+					refused = true
+					return false
+				}
+			}
+		}
+		return true
+	})
+	return refused
+}
+
+// TestCarrierGeometry_CoversEveryCarrier closes the table above against
+// chplan's own definition of the carrier set, so a new grid-bearing node cannot
+// be added upstream while this package keeps extracting nothing from it.
+//
+// It recognises a carrier the same way chplan's completeness ratchet does — by
+// the (Start time.Time, End time.Time, Step time.Duration) field signature —
+// rather than by importing a list, because the registry there is unexported and
+// a second hand-kept list is exactly the drift this test exists to catch.
+func TestCarrierGeometry_CoversEveryCarrier(t *testing.T) {
+	t.Parallel()
+
+	declared := gridDeclaringChplanStructs(t)
+	if len(declared) == 0 {
+		t.Fatal("scanned internal/chplan and found no eval-grid structs; the scan is broken, " +
+			"not the package")
+	}
+
+	covered := make(map[string]bool, len(carrierCases()))
+	for _, tc := range carrierCases() {
+		covered[tc.kind] = true
+	}
+
+	for _, name := range declared {
+		if !covered[name] {
+			t.Errorf("chplan.%s declares an eval grid but has no row in carrierCases — the solver "+
+				"would extract an all-zero feature vector from every plan rooted on it", name)
+		}
+		delete(covered, name)
+	}
+	for name := range covered {
+		t.Errorf("carrierCases has a row for chplan.%s, which no longer declares an eval grid — "+
+			"drop the row", name)
+	}
+}
+
+// TestCarrierGeometryOf_UnclassifiableCarrierFailsClosed pins the default arm:
+// a carrier value the type switch cannot classify yields no geometry, and the
+// recorder then contributes NO features and forces route A instead of inventing
+// a cost.
+//
+// chplan.Node is sealed by an unexported marker method, so a carrier kind
+// outside chplan cannot be constructed here at all — the untyped nil carrier is
+// the only value that reaches the default arm from this package, and it stands
+// in for the kind-added-upstream case that
+// TestCarrierGeometry_CoversEveryCarrier independently rules out.
+func TestCarrierGeometryOf_UnclassifiableCarrierFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	if _, ok := carrierGeometryOf(nil); ok {
+		t.Fatal("carrierGeometryOf claimed a geometry for a carrier it cannot classify; a guessed " +
+			"geometry would route a plan on numbers nobody derived")
+	}
+
+	sig := &signals{}
+	(&Planner{Cfg: autoCfg()}).recordGridCarrier(nil, 0, sig)
+	if sig.sawGridCarrier {
+		t.Error("sawGridCarrier set for a carrier whose geometry was never derived — the resulting " +
+			"corpus row would claim measured features it does not have")
+	}
+	if !sig.sawNonRangeWindowSpine {
+		t.Error("sawNonRangeWindowSpine not set; an unmeasurable carrier must fail CLOSED to route A")
+	}
+	if sig.cumulativeD != 0 || sig.outerN != 0 || sig.hasWindow {
+		t.Errorf("unclassifiable carrier contributed features (D=%s N=%d hasWindow=%v); refusing to "+
+			"guess means recording nothing", sig.cumulativeD, sig.outerN, sig.hasWindow)
+	}
+}
+
+// TestCarrierGeometry_NativeIsMeasuredButNeverSliceable is the correctness pin
+// for the exact hazard widening extraction creates: making the solver SEE a
+// carrier must not make the slicer TAKE it.
+//
+// The subject is the shape the whole defect was found on — a natively-lowered
+// rate() whose RangeWindowNative is the plan's only grid carrier. Before the
+// fix it extracted nothing; after it, the Decision carries a real cost grid.
+// Both halves are asserted together, because either one alone is satisfiable by
+// a wrong change: extracting nothing still "never slices", and registering the
+// node slice-invariant would extract features while shipping wrong answers
+// (ReanchorRange clones the node verbatim, so every shard would evaluate the
+// ORIGINAL full grid and the merged result would be the query repeated K times
+// rather than partitioned).
+func TestCarrierGeometry_NativeIsMeasuredButNeverSliceable(t *testing.T) {
+	t.Parallel()
+
+	var native chplan.Node
+	for _, tc := range carrierCases() {
+		if tc.kind == "RangeWindowNative" {
+			native = tc.plan()
+		}
+	}
+	if native == nil {
+		t.Fatal("carrierCases lost its RangeWindowNative row; this pin has no subject")
+	}
+
+	// The dominant real shape: sum(rate(...)) with the rate lowered natively.
+	plan := &chplan.Aggregate{
+		Input:    native,
+		AggFuncs: []chplan.AggFunc{{Name: "sum", Args: []chplan.Expr{&chplan.ColumnRef{Name: "Value"}}}},
+	}
+
+	start, end, step := GridOf(plan)
+	meta := RequestMeta{Lang: LangPromQL, Start: start, End: end, Step: step}
+
+	// Measurement half.
+	d, routed := (&Planner{Cfg: autoCfg()}).Plan(plan, meta)
+	if d.NAnchors == 0 || d.OuterRange == 0 || d.CumulativeD == 0 || d.Fanout == 0 {
+		t.Errorf("natively-lowered rate() extracted N=%d OuterRange=%s D=%s F=%d — an all-zero "+
+			"cost grid is the extractor blindness this pin exists to catch",
+			d.NAnchors, d.OuterRange, d.CumulativeD, d.Fanout)
+	}
+
+	// Correctness half, at both public seams. Eligible deliberately bypasses
+	// the cost thresholds, so it is the stricter of the two.
+	if routed {
+		t.Errorf("Plan routed a RangeWindowNative spine (K=%d)", d.K)
+	}
+	if ed, eligible := (&Planner{Cfg: autoCfg()}).Eligible(plan, meta); eligible {
+		t.Errorf("Eligible routed a RangeWindowNative spine (K=%d) — the threshold-free seam is "+
+			"where an over-wide extraction shows up first", ed.K)
+	}
+
+	// And the structural backstop underneath both: the node is NOT registered
+	// slice-invariant, and must stay that way until ReanchorRange learns its
+	// grid. A change that "fixes" this test by registering it is the bug.
+	if chplan.IsSliceInvariant(native) {
+		t.Error("RangeWindowNative is registered slice-invariant, but chplan.ReanchorRange has no " +
+			"arm for it — every shard would emit the original full-grid bounds")
+	}
+}
+
+// TestClassify_NoCarrierRecordsExtractionFailed pins the reason token that
+// keeps an unmeasured plan out of the calibration population.
+//
+// Reverting the gate makes this plan report below-threshold with an all-zero
+// cost grid — the same row a genuinely trivial query produces. The two are then
+// indistinguishable in the corpus, and every threshold fitted over the refused
+// population is dragged toward zero by rows that were never measured.
+func TestClassify_NoCarrierRecordsExtractionFailed(t *testing.T) {
+	t.Parallel()
+
+	// A carrier-free plan: matcher filter over a scan, nothing that owns a grid.
+	plan := &chplan.Filter{
+		Input: leafScan(),
+		Predicate: &chplan.Binary{
+			Op:    chplan.OpEq,
+			Left:  &chplan.ColumnRef{Name: "MetricName"},
+			Right: &chplan.LitString{V: "m"},
+		},
+	}
+	if _, _, step := GridOf(plan); step != 0 {
+		t.Fatalf("fixture must carry no grid; GridOf reported step=%s", step)
+	}
+
+	// The request nonetheless declares a real range grid — the state a plan
+	// whose carrier the walk cannot see would present.
+	meta := oomMeta()
+
+	d, routed := (&Planner{Cfg: autoCfg()}).Plan(plan, meta)
+	if routed {
+		t.Fatalf("an unmeasured plan routed (K=%d)", d.K)
+	}
+	if d.Reason != ReasonExtractionFailed {
+		t.Errorf("reason = %q, want %q — a zero cost grid must say it was never measured, not "+
+			"imply the plan is cheap", d.Reason, ReasonExtractionFailed)
+	}
+	if d.NAnchors != 0 || d.Fanout != 0 || d.OuterRange != 0 || d.CumulativeD != 0 {
+		t.Errorf("extraction-failed row carries features N=%d F=%d OuterRange=%s D=%s; nothing was "+
+			"measured, so nothing may be reported",
+			d.NAnchors, d.Fanout, d.OuterRange, d.CumulativeD)
+	}
+}
+
+// gridDeclaringChplanStructs parses internal/chplan and returns the names of
+// every struct declaring the eval-grid field signature, sorted.
+func gridDeclaringChplanStructs(t *testing.T) []string {
+	t.Helper()
+
+	const chplanDir = "../chplan"
+	entries, err := os.ReadDir(chplanDir)
+	if err != nil {
+		t.Fatalf("read internal/chplan: %v", err)
+	}
+
+	fset := token.NewFileSet()
+	var names []string
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") || strings.HasSuffix(e.Name(), "_test.go") {
+			continue
+		}
+		f, err := parser.ParseFile(fset, filepath.Join(chplanDir, e.Name()), nil, parser.SkipObjectResolution)
+		if err != nil {
+			t.Fatalf("parse %s: %v", e.Name(), err)
+		}
+		ast.Inspect(f, func(n ast.Node) bool {
+			ts, ok := n.(*ast.TypeSpec)
+			if !ok {
+				return true
+			}
+			st, ok := ts.Type.(*ast.StructType)
+			if !ok {
+				return true
+			}
+			if declaresEvalGrid(st) {
+				names = append(names, ts.Name.Name)
+			}
+			return true
+		})
+	}
+	sort.Strings(names)
+	return names
+}
+
+// declaresEvalGrid reports whether a struct carries all three eval-grid fields
+// with the exact types that make it a grid owner: Start/End as time.Time and
+// Step as time.Duration.
+func declaresEvalGrid(st *ast.StructType) bool {
+	var start, end, step bool
+	for _, f := range st.Fields.List {
+		typeName := exprTypeName(f.Type)
+		for _, nm := range f.Names {
+			switch {
+			case nm.Name == "Start" && typeName == "time.Time":
+				start = true
+			case nm.Name == "End" && typeName == "time.Time":
+				end = true
+			case nm.Name == "Step" && typeName == "time.Duration":
+				step = true
+			}
+		}
+	}
+	return start && end && step
+}
+
+// exprTypeName renders a qualified type expression (pkg.Name) back to source
+// form; anything else returns "" and therefore never matches a grid field.
+func exprTypeName(e ast.Expr) string {
+	sel, ok := e.(*ast.SelectorExpr)
+	if !ok {
+		return ""
+	}
+	pkg, ok := sel.X.(*ast.Ident)
+	if !ok {
+		return ""
+	}
+	return pkg.Name + "." + sel.Sel.Name
+}

--- a/internal/solver/decision.go
+++ b/internal/solver/decision.go
@@ -138,6 +138,17 @@ const (
 	// now64 scanner. Fails closed to route A; only the StepAligned (range-mode)
 	// join, which step-aligns on the real per-anchor timestamp, routes B.
 	ReasonInstantJoin = "instant-join"
+
+	// ReasonExtractionFailed: the plan walk found no [chplan.GridCarrier] it
+	// could measure, so the Decision's cost grid is all zeros because NOTHING
+	// WAS MEASURED — not because the plan is cheap. Every other refusal
+	// asserts "the features were extracted and they lost"; without this token
+	// that claim is unfalsifiable, since an unmeasured plan and a genuinely
+	// zero-cost one produce the identical corpus row. It also covers a carrier
+	// kind added to chplan ahead of this package's geometry table: such a plan
+	// fails closed to route A and says so, instead of routing on invented
+	// numbers.
+	ReasonExtractionFailed = "extraction-failed"
 )
 
 // Reasons is the complete Reason vocabulary above, in declaration order.
@@ -161,6 +172,7 @@ var Reasons = []string{
 	ReasonScalarHeavy,
 	ReasonRoutingDisabled,
 	ReasonInstantJoin,
+	ReasonExtractionFailed,
 }
 
 // Slice is one shard of the anchor-grid decomposition. Bounds are

--- a/internal/solver/planner.go
+++ b/internal/solver/planner.go
@@ -197,17 +197,37 @@ func (p *Planner) classify(plan chplan.Node, meta RequestMeta) (sig signals, dec
 		return sig, notRouted(ReasonInstant).withGrid(sig, meta), 0, false
 	}
 
+	// (0) Extraction: the request declares a real grid (meta.Step > 0 by the
+	// guard above), so the plan must own at least one carrier the walk could
+	// measure. When it does not, the cost grid stamped below is all zeros
+	// because NOTHING WAS MEASURED — and every other refusal token would then
+	// be a claim about numbers that were never read. Recording that separately
+	// is the whole point: an unmeasured population averaged in with the
+	// genuinely-cheap one silently drags every calibration threshold toward
+	// zero. A carrier kind chplan grew ahead of carrierGeometryOf lands here
+	// too — its cost is unknown, not zero.
+	//
+	// Route-neutral by construction: both this and the gates below refuse, so
+	// the gate changes the recorded REASON and never the route.
+	if !sig.sawGridCarrier {
+		return sig, notRouted(ReasonExtractionFailed).withGrid(sig, meta), 0, false
+	}
+
 	// (1) Slice-invariance: any unmarked node anywhere → route A.
 	if !sig.allSliceInvariant {
 		return sig, notRouted(ReasonNotSliceable).withGrid(sig, meta), 0, false
 	}
 	// (1b) Routable-spine restriction: the routable spine families are the
-	// *RangeWindow matrix family and the *RangeLWR bare-selector
-	// last-with-respect-to family — ReanchorRange re-grids both. A
-	// RangeBucketFanout / StepGrid spine bound-carrier is still left at
-	// zero/stale bounds (ReanchorRange CloneNode's their grid verbatim), so
-	// those fail closed to route A. Widening to those families extends
-	// ReanchorRange + adds coverage.
+	// RangeWindow matrix family and the RangeLWR bare-selector
+	// last-with-respect-to family — ReanchorRange re-grids both. Every other
+	// [chplan.GridCarrier] kind (RangeWindowNative, RangeWindowResample,
+	// RangeBucketFanout, StepGrid, AbsentOverTime) has its grid CloneNode'd
+	// verbatim, so each shard would emit the original full-grid bounds; they
+	// fail closed to route A. Note the asymmetry this gate exists to preserve:
+	// the extractor MEASURES all seven kinds so the corpus can see what a
+	// refused plan costs, while only the two re-anchored families may be
+	// SLICED. Admitting a kind here means teaching ReanchorRange its grid
+	// first, not widening carrierGeometryOf.
 	if sig.sawNonRangeWindowSpine {
 		return sig, notRouted(ReasonNotSliceable).withGrid(sig, meta), 0, false
 	}
@@ -292,9 +312,10 @@ func (p *Planner) classify(plan chplan.Node, meta RequestMeta) (sig signals, dec
 // notRouted builds a non-route Decision carrying only the reason. Callers
 // chain .withGrid(sig, meta) to attach the cost-grid readout. Every refusal in
 // this package is raised after classify has run, so none of them reaches the
-// corpus with an all-zero grid — a refused row is still a calibration
-// datapoint, and a zero grid would be indistinguishable from a genuinely
-// trivial query.
+// corpus with an unexplained all-zero grid — a refused row is still a
+// calibration datapoint, and a zero grid would otherwise be indistinguishable
+// from a genuinely trivial query. The one refusal whose grid IS legitimately
+// all zeros carries ReasonExtractionFailed, which says so in the row itself.
 func notRouted(reason string) *Decision {
 	return &Decision{Reason: reason}
 }
@@ -335,21 +356,33 @@ type signals struct {
 	// TimestampColumn, does not set this flag and remains routable.
 	sawInstantVectorJoin bool
 
-	// sawNonRangeWindowSpine records a routed-spine grid bound-carrier whose
-	// grid ReanchorRange does NOT re-anchor — a RangeBucketFanout or StepGrid,
-	// which ReanchorRange CloneNode's verbatim (every shard would emit
-	// stale bounds). The routable set is the *RangeWindow matrix family
-	// plus the *RangeLWR bare-selector family: both are
-	// re-gridded by ReanchorRange and zeroed/re-filled by unpinSpine, so
-	// neither sets this flag. RangeBucketFanout / StepGrid fail closed to
-	// route A until ReanchorRange learns their grids.
+	// sawNonRangeWindowSpine records a grid bound-carrier whose grid
+	// ReanchorRange does NOT re-anchor — every [chplan.GridCarrier] kind
+	// outside the routable set, which ReanchorRange CloneNode's verbatim (so
+	// every shard would emit stale bounds). The routable set is the
+	// RangeWindow matrix family plus the RangeLWR bare-selector family: both
+	// are re-gridded by ReanchorRange and zeroed/re-filled by unpinSpine, so
+	// neither sets this flag. RangeWindowNative / RangeWindowResample /
+	// RangeBucketFanout / StepGrid / AbsentOverTime fail closed to route A
+	// until ReanchorRange learns their grids — see carrierGeometry.reanchorable,
+	// which is the single place that decision is recorded.
 	sawNonRangeWindowSpine bool
+
+	// sawGridCarrier records that the walk found at least one
+	// [chplan.GridCarrier] whose geometry carrierGeometryOf could derive. When
+	// it stays false the cost grid on the resulting Decision is all zeros
+	// because NOTHING WAS MEASURED, not because the plan is trivial — the
+	// distinction ReasonExtractionFailed exists to make. Without it the corpus
+	// cannot tell "looked at the plan and declined" from "extracted nothing",
+	// and a carrier kind added to chplan ahead of carrierGeometryOf would
+	// silently deflate every threshold calibrated off those rows.
+	sawGridCarrier bool
 
 	// Cost grid, derived from the OUTERMOST windowed node (the spine root).
 	outerN      int           // N = OuterRange/Step + 1
 	outerRange  time.Duration // OuterRange of the outermost spine
 	maxFanout   int64         // F over every windowed node
-	cumulativeD time.Duration // D = Σ Range down matrix spines + leaf RangeLWR.Lookback
+	cumulativeD time.Duration // D = Σ per-anchor lookback over every grid carrier
 
 	// innerResolutions records every inner-spine Step for the lcm
 	// commensurability check.
@@ -385,7 +418,8 @@ func (p *Planner) walkNode(n chplan.Node, predStart, predEnd time.Time, depth in
 
 	switch v := n.(type) {
 	case *chplan.RangeWindow:
-		p.recordRangeWindow(v, predStart, predEnd, depth, sig)
+		p.recordGridCarrier(v, depth, sig)
+		p.checkRangeWindowGrid(v, predStart, predEnd, depth, sig)
 		// Walk this node's exprs for now64 / scalar-heavy.
 		for _, e := range v.GroupBy {
 			p.walkExpr(e, sig)
@@ -403,8 +437,47 @@ func (p *Planner) walkNode(n chplan.Node, predStart, predEnd time.Time, depth in
 		return
 
 	case *chplan.RangeLWR:
-		p.recordRangeLWR(v, predStart, predEnd, depth, sig)
+		p.recordGridCarrier(v, depth, sig)
+		p.checkRangeLWRGrid(v, predStart, predEnd, depth, sig)
 		p.walkNode(v.Input, predStart, predEnd, depth+1, sig)
+		return
+
+	case *chplan.RangeWindowNative:
+		// The ClickHouse-native `timeSeriesRateToGrid` lowering of
+		// rate(m[Range]). It owns a full eval grid, so it is the ONLY carrier
+		// in a natively-lowered plan and the sole source of that plan's
+		// n_anchors / outer_range / cumulative_d. Its bounds are pinned by
+		// construction (range mode only), so no bound-pinning gate applies;
+		// recordGridCarrier's reanchorable check is what keeps it on route A.
+		p.recordGridCarrier(v, depth, sig)
+		for _, e := range v.GroupBy {
+			p.walkExpr(e, sig)
+		}
+		for _, pr := range v.Recollapse {
+			p.walkExpr(pr.Expr, sig)
+		}
+		// Each anchor reduces the samples in its own `Range` window, so the
+		// inner spine reaches back that far — the same widening the RangeWindow
+		// arm above applies.
+		p.walkNode(v.Input, predStart.Add(-v.Range), predEnd, depth+1, sig)
+		return
+
+	case *chplan.RangeWindowResample:
+		// The native staleness-resample lowering of a bare selector at each
+		// anchor. Same story as RangeWindowNative, with Lookback (the staleness
+		// horizon) as the per-anchor window depth. Its inner spine is walked at
+		// the unwidened bounds, mirroring the RangeLWR arm it is the native
+		// sibling of.
+		p.recordGridCarrier(v, depth, sig)
+		p.walkNode(v.Input, predStart, predEnd, depth+1, sig)
+		return
+
+	case *chplan.AbsentOverTime:
+		// absent_over_time's own grid. It carries no group-key or agg-arg
+		// exprs (only SynthLabels, which are literal label pairs), so the
+		// default child recursion below the record call is the whole sweep.
+		p.recordGridCarrier(v, depth, sig)
+		p.walkNode(v.Input, predStart.Add(-v.Range), predEnd, depth+1, sig)
 		return
 
 	case *chplan.Aggregate:
@@ -434,10 +507,9 @@ func (p *Planner) walkNode(n chplan.Node, predStart, predEnd time.Time, depth in
 		// args that the spine recursion never sweeps. Cover the same now64
 		// gap. It also carries its own eval grid (Start/End/Step) that
 		// ReanchorRange clones VERBATIM (never re-anchors), so every shard
-		// would emit stale bounds — fail closed to route A.
-		if v.Step > 0 {
-			sig.sawNonRangeWindowSpine = true
-		}
+		// would emit stale bounds — recordGridCarrier fails it closed to
+		// route A while still measuring the grid it does carry.
+		p.recordGridCarrier(v, depth, sig)
 		for _, e := range v.GroupBy {
 			p.walkExpr(e, sig)
 		}
@@ -456,11 +528,10 @@ func (p *Planner) walkNode(n chplan.Node, predStart, predEnd time.Time, depth in
 		// StepGrid carries an eval grid (Start/End/Step) that ReanchorRange
 		// clones VERBATIM — the grid-prediction guard cannot see it and the
 		// slicer would leave every shard on the original full-grid bounds.
-		// A StepGrid spine carrier is not in the routable set, so it
-		// fails closed to route A.
-		if v.Step > 0 {
-			sig.sawNonRangeWindowSpine = true
-		}
+		// A StepGrid spine carrier is not in the routable set, so it fails
+		// closed to route A. It is a leaf (no Children), and it reads no
+		// samples, so it contributes an anchor count and no lookback.
+		p.recordGridCarrier(v, depth, sig)
 		return
 
 	case *chplan.Filter:
@@ -496,22 +567,179 @@ func (p *Planner) walkNode(n chplan.Node, predStart, predEnd time.Time, depth in
 		return
 	}
 
-	// Default: not a spine node. Recurse into every child with the same
-	// predicted bounds, and walk any exprs the node carries via the
-	// generic node walk + a defensive expr sweep of nested ScalarSubqueries.
+	// Default: no dedicated arm above. Extraction is keyed on the
+	// [chplan.GridCarrier] INTERFACE, not on the arms of the switch, so a
+	// carrier kind that grows a grid before this walk grows an arm for it is
+	// still measured (and, if carrierGeometryOf does not know it, still fails
+	// closed) instead of contributing a silent all-zero feature vector. The
+	// arms above exist for the per-kind expr sweeps and recursion shapes;
+	// each returns, so nothing is recorded twice.
+	if gc, ok := n.(chplan.GridCarrier); ok {
+		p.recordGridCarrier(gc, depth, sig)
+	}
+
+	// Recurse into every child with the same predicted bounds, and walk any
+	// exprs the node carries via the generic node walk + a defensive expr
+	// sweep of nested ScalarSubqueries.
 	for _, c := range n.Children() {
 		p.walkNode(c, predStart, predEnd, depth, sig)
 	}
 }
 
-// recordRangeWindow gathers signals for a matrix/instant RangeWindow.
-func (p *Planner) recordRangeWindow(v *chplan.RangeWindow, predStart, predEnd time.Time, depth int, sig *signals) {
-	// Instant-shape window: Step == 0 or OuterRange == 0 on a non-leaf
-	// spine. The outermost window must carry a real anchor grid.
-	if v.Step <= 0 || (depth == 0 && v.OuterRange <= 0) {
+// carrierGeometry is the measurement-only projection of one
+// [chplan.GridCarrier]: the two spans every cost-grid feature (and therefore
+// every calibration-corpus row) is derived from, plus the single correctness
+// bit that says whether the slicer may re-grid the carrier at all.
+//
+// It exists so extraction is keyed on the GridCarrier INTERFACE rather than
+// on a hand-maintained list of concrete node kinds. A carrier the extractor
+// cannot see contributes nothing, and a Decision whose features are all zero
+// is indistinguishable from a plan that genuinely has no grid — so a missed
+// kind silently mislabels its whole population in the corpus rather than
+// raising anything.
+type carrierGeometry struct {
+	// outerRange is the span of the carrier's OWN anchor grid: first anchor
+	// to last. With the carrier's Step it yields n_anchors.
+	outerRange time.Duration
+
+	// lookback is how far back a SINGLE anchor reads — the [range] of a
+	// range-vector carrier, the staleness horizon of a resample / LWR
+	// carrier, zero for a carrier that emits a bare anchor axis and reads no
+	// samples. It is what the corpus records as cumulative_d, and with Step
+	// it yields the fan-out.
+	lookback time.Duration
+
+	// reanchorable reports whether [chplan.ReanchorRange] re-grids this kind.
+	// This is a CORRECTNESS bit, not a measurement one: a carrier
+	// ReanchorRange clones verbatim hands every shard the original full-grid
+	// bounds, so a live grid on such a kind must fail the plan closed to
+	// route A. Exactly the RangeWindow and RangeLWR families are re-gridded.
+	reanchorable bool
+}
+
+// carrierGeometryOf derives the measurement geometry of one grid carrier,
+// enumerating every [chplan.GridCarrier] implementation.
+//
+// The second return is false only for a kind added on the chplan side that
+// this package has not learned yet. The caller turns that into a LOUD
+// extraction-failed row plus a fail-closed route A rather than a silent
+// all-zero feature vector — guessing a geometry would be worse than either.
+// chplan's completeness ratchet closes the carrier set and
+// TestCarrierGeometry_CoversEveryCarrier pins this enumeration against it, so
+// the branch is unreachable in a consistent tree.
+func carrierGeometryOf(gc chplan.GridCarrier) (carrierGeometry, bool) {
+	switch v := gc.(type) {
+	case *chplan.RangeWindow:
+		// The fan-out matrix window. OuterRange is read explicitly rather
+		// than derived from End-Start because a subquery-inner window leaves
+		// both bounds zero for ReanchorRange to fill, and the span must stay
+		// measurable there.
+		return carrierGeometry{outerRange: v.OuterRange, lookback: v.Range, reanchorable: true}, true
+
+	case *chplan.RangeLWR:
+		// The bare-selector last-with-respect-to leaf: one sample per anchor,
+		// chosen inside the Lookback staleness horizon. Re-gridded by
+		// ReanchorRange and zeroed/re-filled by the slicer's unpinSpine, so
+		// the deriv / idelta / irate / instant-LWR / negative-offset families
+		// that lower to a bare RangeLWR spine are routable.
+		return carrierGeometry{outerRange: v.End.Sub(v.Start), lookback: v.Lookback, reanchorable: true}, true
+
+	case *chplan.RangeWindowNative:
+		// timeSeries<fn>ToGrid: the whole rate(m[Range]) collapses into one
+		// ClickHouse aggregate, so this node ALONE carries the grid of a
+		// natively-lowered plan — it is the sole source of that plan's
+		// n_anchors / outer_range / cumulative_d. ReanchorRange has no arm
+		// for it, so it stays route A.
+		return carrierGeometry{outerRange: v.End.Sub(v.Start), lookback: v.Range, reanchorable: false}, true
+
+	case *chplan.RangeWindowResample:
+		// timeSeriesResampleToGridWithStaleness: the native sibling of
+		// RangeLWR, with the staleness horizon as its per-anchor depth.
+		return carrierGeometry{outerRange: v.End.Sub(v.Start), lookback: v.Lookback, reanchorable: false}, true
+
+	case *chplan.RangeBucketFanout:
+		// The array-aggregate fan-out behind the histogram families. Its
+		// per-node shape is slice-invariant, but its grid is cloned verbatim,
+		// which is why measuring it must not be confused with routing it.
+		return carrierGeometry{outerRange: v.End.Sub(v.Start), lookback: v.Lookback, reanchorable: false}, true
+
+	case *chplan.AbsentOverTime:
+		// absent_over_time's own grid; Range is the per-anchor window.
+		return carrierGeometry{outerRange: v.End.Sub(v.Start), lookback: v.Range, reanchorable: false}, true
+
+	case *chplan.StepGrid:
+		// A bare anchor axis for the data-free shapes (time(), vector(scalar),
+		// the zero-arg date functions). It reads no samples at all, so its
+		// per-anchor lookback is genuinely zero rather than unknown: it
+		// contributes an anchor count and no cumulative_d.
+		return carrierGeometry{outerRange: v.End.Sub(v.Start), reanchorable: false}, true
+
+	default:
+		return carrierGeometry{}, false
+	}
+}
+
+// recordGridCarrier extracts the cost-grid features from one carrier of ANY
+// kind, and records the one correctness signal that is a property of the kind
+// itself (whether the slicer can re-anchor it).
+//
+// Measurement and slice-invariance are deliberately separate concerns here.
+// Every kind is MEASURED; only the re-anchorable kinds are ROUTABLE. A
+// non-re-anchorable carrier with a live grid therefore contributes its real
+// geometry to the corpus AND sets the fail-closed flag, so the row records
+// both what the plan costs and why it stayed on route A. Nothing in this
+// function can make a plan route that would not have routed before: a
+// non-re-anchorable carrier either has step <= 0 (and then never reaches the
+// hasWindow branch) or sets sawNonRangeWindowSpine, which gate (1b) reads
+// ahead of every threshold.
+func (p *Planner) recordGridCarrier(gc chplan.GridCarrier, depth int, sig *signals) {
+	geom, ok := carrierGeometryOf(gc)
+	if !ok {
+		// A carrier kind this package does not enumerate. Refuse to guess a
+		// geometry, and refuse to route a plan that cannot be measured. Leaving
+		// sawGridCarrier unset is what turns this into a ReasonExtractionFailed
+		// row rather than a refusal that claims numbers nobody derived.
+		sig.sawNonRangeWindowSpine = true
+		return
+	}
+	sig.sawGridCarrier = true
+
+	_, _, step := gc.EvalGrid()
+
+	// A live grid ReanchorRange would clone verbatim fails closed. A carrier
+	// with no grid of its own (step <= 0) is a broadcast instant subtree —
+	// sharing it verbatim across shards is exactly right, because its value
+	// does not depend on the shard's bounds.
+	if !geom.reanchorable && step > 0 {
+		sig.sawNonRangeWindowSpine = true
+	}
+
+	// The instant/degenerate-spine gate polices the ROUTABLE spine: an
+	// outermost routable carrier must own a real anchor grid. The
+	// non-routable kinds are already covered by the flag above.
+	if geom.reanchorable && (step <= 0 || (depth == 0 && geom.outerRange <= 0)) {
 		sig.sawInstantWindow = true
 	}
 
+	if step > 0 {
+		if fan := int64(geom.lookback / step); fan > sig.maxFanout {
+			sig.maxFanout = fan
+		}
+	}
+	sig.cumulativeD += geom.lookback
+
+	if depth == 0 && geom.outerRange > 0 && step > 0 {
+		sig.hasWindow = true
+		sig.outerRange = geom.outerRange
+		sig.outerN = int(geom.outerRange/step) + 1
+	}
+}
+
+// checkRangeWindowGrid runs the bound-pinning, grid-prediction and inner-
+// resolution gates that belong to the fan-out RangeWindow family specifically
+// — the ones that read the node's own Start/End against the bounds predicted
+// at this spine depth, which no cross-kind geometry can express.
+func (p *Planner) checkRangeWindowGrid(v *chplan.RangeWindow, predStart, predEnd time.Time, depth int, sig *signals) {
 	// (2) Both Start and End must be pinned (non-zero) — unless this is an
 	// unpinned subquery-inner shape that ReanchorRange fills. An unpinned
 	// inner node (Start && End zero) is the expected shape; a HALF-pinned
@@ -538,40 +766,20 @@ func (p *Planner) recordRangeWindow(v *chplan.RangeWindow, predStart, predEnd ti
 		}
 	}
 
-	// Cost signals.
-	if v.Step > 0 {
-		fan := int64(v.Range / v.Step)
-		if fan > sig.maxFanout {
-			sig.maxFanout = fan
-		}
-	}
-	sig.cumulativeD += v.Range
-
-	if depth == 0 && v.OuterRange > 0 && v.Step > 0 {
-		sig.hasWindow = true
-		sig.outerRange = v.OuterRange
-		sig.outerN = int(v.OuterRange/v.Step) + 1
-	} else if depth > 0 && v.Step > 0 {
-		// Inner spine resolution for the lcm commensurability check.
+	// (5) Inner spine resolution for the lcm commensurability check.
+	if depth > 0 && v.Step > 0 {
 		sig.innerResolutions = append(sig.innerResolutions, v.Step)
 		p.checkCommensurability(sig)
 	}
 }
 
-// recordRangeLWR gathers signals for a bare-selector last-with-respect-to
-// node — the leaf of the safe-set range family.
-func (p *Planner) recordRangeLWR(v *chplan.RangeLWR, predStart, predEnd time.Time, depth int, sig *signals) {
-	// The RangeLWR matrix family is in the routable set: a
-	// grid-carrying RangeLWR (Step > 0) is re-anchored by ReanchorRange
-	// (its Start/End re-gridded, the input spine widened by the offset-aware
-	// Offset+Lookback membership window) and zeroed/re-filled by the slicer's
-	// unpinSpine, so it does not set sawNonRangeWindowSpine. The deriv /
-	// idelta / irate / instant-LWR / negative-offset families that lower to a
-	// bare RangeLWR spine route B. RangeBucketFanout / StepGrid stay
-	// rejected — their grids are CloneNode'd verbatim by ReanchorRange.
-	if v.Step <= 0 || (depth == 0 && v.End.Sub(v.Start) <= 0) {
-		sig.sawInstantWindow = true
-	}
+// checkRangeLWRGrid runs the RangeLWR family's bound-pinning and
+// grid-prediction gates. It differs from the RangeWindow form in two ways
+// that are properties of the node, not of the check: RangeLWR has no separate
+// OuterRange field (its span IS End-Start), and it is a spine LEAF, so the
+// grid-prediction comparison is meaningful only at depth 0 where both bounds
+// are pinned.
+func (p *Planner) checkRangeLWRGrid(v *chplan.RangeLWR, predStart, predEnd time.Time, depth int, sig *signals) {
 	startZero := v.Start.IsZero()
 	endZero := v.End.IsZero()
 	if depth == 0 {
@@ -586,23 +794,6 @@ func (p *Planner) recordRangeLWR(v *chplan.RangeLWR, predStart, predEnd time.Tim
 		}
 	} else if startZero != endZero {
 		sig.sawUnpinnedBound = true
-	}
-
-	if v.Step > 0 {
-		fan := int64(v.Lookback / v.Step)
-		if fan > sig.maxFanout {
-			sig.maxFanout = fan
-		}
-	}
-	sig.cumulativeD += v.Lookback
-
-	if depth == 0 && v.Step > 0 {
-		outer := v.End.Sub(v.Start)
-		if outer > 0 {
-			sig.hasWindow = true
-			sig.outerRange = outer
-			sig.outerN = int(outer/v.Step) + 1
-		}
 	}
 }
 

--- a/test/perf/solver-decision-baseline.json
+++ b/test/perf/solver-decision-baseline.json
@@ -1467,7 +1467,7 @@
     "query": "matrix_selector_top_level",
     "routed": false,
     "k": 0,
-    "reason": "below-threshold"
+    "reason": "extraction-failed"
   },
   {
     "query": "metadata_label_names_leaf_projection",


### PR DESCRIPTION
## The defect

`internal/solver/planner.go`'s `recordRangeWindow` was the only producer of the
corpus features `n_anchors` / `outer_range` / `cumulative_d`, and its parameter
type admitted exactly **one** of the seven `chplan.GridCarrier` implementations.
`walkNode` had no arm for `RangeWindowNative` or `RangeWindowResample` at all.

So a plan whose only grid carrier is a natively-lowered `rate()` extracted
nothing: it collapsed to `decision_reason='not-sliceable'` with an all-zero
feature vector, indistinguishable in the calibration corpus from a genuinely
trivial query. On a reference deployment, 2,524 of 2,650 `not-sliceable`
verdicts over three days carried `outer_range=0`.

Two independent blindnesses, same root cause — a vocabulary keyed on one
concrete node type instead of on the `GridCarrier` interface:

| Site | Saw | Blind to |
|---|---|---|
| `solver` feature extraction | `RangeWindow`, `RangeLWR` | `RangeWindowNative`, `RangeWindowResample`, `RangeBucketFanout`, `StepGrid`, `AbsentOverTime` |
| `engine` `shapeModifiers` | `RangeWindow`, `RangeWindowNative`, `RangeWindowResample` | `RangeLWR`, `RangeBucketFanout`, `StepGrid`, `AbsentOverTime` |

## The fix

**1. Extraction keyed on the interface.** `recordRangeWindow` →
`recordGridCarrier(chplan.GridCarrier, …)`, backed by `carrierGeometryOf`, which
maps each of the seven kinds to its `(outerRange, lookback, reanchorable)`
geometry. `walkNode`'s **default** arm now records any `GridCarrier` that has no
dedicated arm, so extraction follows the interface rather than the arms of a type
switch. A carrier kind added to `chplan` ahead of the geometry table hits
`carrierGeometryOf`'s `default`, which sets `sawNonRangeWindowSpine` — cost
unknown, not zero.

The RangeWindow / RangeLWR grid checks (unpinned bounds, grid mismatch, inner
resolutions) split out into `checkRangeWindowGrid` / `checkRangeLWRGrid`
unchanged, so those two kinds behave byte-for-byte as before.

**2. `walkNode` arms** for `RangeWindowNative` (recurses widened by `-Range`,
sweeps `GroupBy` + `Recollapse` exprs) and `RangeWindowResample`.

**3. shape_id vocabulary**: `lwr`, `rbf`, `aot`, `sg`, plus the matching
`nodeKind` entries. Previously an expression containing a range fan-out, a union
and a join hashed to `cerb:project;agg=3` — the same id as a bare projection, so
`log_comment` clustering hid the expensive shape inside the cheap bucket.

**4. `decision_reason: extraction-failed`** — emitted when the walk found no
measurable carrier. It is the one refusal whose cost grid is legitimately all
zeros, and it now says so in the row, so a threshold fitted over the refused
population can exclude rows that were never measured instead of averaging them
in. `decision_reason` is `LowCardinality(String)`, **not** `Enum8`
(`internal/optcorpus/chtable.go`), so no DDL migration is needed — only the
`solver.Reasons` list and the `routerrules` mirror, which
`decision_reason_gate_test.go` pins in lockstep.

## Correctness: seeing a carrier never makes it sliceable

Widening extraction changes what is *measured*, never what is *routed*. Every
newly-measured carrier is still refused, by one of two independent gates that
both fire before the cost thresholds:

- `RangeWindowNative`, `RangeWindowResample`, `AbsentOverTime` are absent from
  `chplan`'s slice-invariant registry → `allSliceInvariant=false` → gate (1).
- `RangeBucketFanout`, `StepGrid` are registered slice-invariant but
  `ReanchorRange` clones their grid verbatim, so `recordGridCarrier` sets
  `sawNonRangeWindowSpine` for any non-reanchorable carrier with `Step > 0` →
  gate (1b).

`sawInstantWindow` is gated on `reanchorable` so an instant-shaped broadcast
subtree cannot newly refuse a plan that routes today, and `hasWindow` still
requires `Step > 0`, which no non-reanchorable carrier can reach without having
already tripped gate (1b). The new `extraction-failed` gate sits between the
`instant` guard and gate (1) and is route-neutral: both paths refuse, so it
changes only the recorded reason.

## Tests

- `TestCarrierGeometry_ExtractsFeaturesForEveryKind` — table over **all seven**
  `GridCarrier` kinds with a distinct lookback per kind, asserting the exact
  `NAnchors` / `OuterRange` / `CumulativeD` / `Fanout` / `Step`, and asserting
  that every non-reanchorable kind is still refused at both `Plan` and the
  threshold-free `Eligible` seam.
- `TestCarrierGeometry_CoversEveryCarrier` /
  `TestShapeModifiers_CoverEveryGridCarrier` — parse `internal/chplan` for the
  `(Start, End, Step)` grid signature (the same key chplan's own completeness
  ratchet uses; its registry is unexported) and fail if a kind exists with no
  table row. A carrier added upstream fails here instead of shipping an
  invisible shape.
- `TestCarrierGeometry_NativeIsMeasuredButNeverSliceable` — the correctness pin:
  `sum(rate(...))` lowered natively extracts non-zero features **and** is refused
  by `Plan`, by `Eligible`, and is not registered slice-invariant.
- `TestCarrierGeometryOf_UnclassifiableCarrierFailsClosed` — the default arm
  contributes no features and sets the fail-close flag.
- `TestClassify_NoCarrierRecordsExtractionFailed` — a carrier-free plan on a
  range request reports `extraction-failed` with an empty grid.
- `TestShapeModifiers_EveryGridCarrierGetsAToken` /
  `TestShapeModifiers_DistinguishesFanoutFromBareProject` — every carrier
  contributes its token; fan-out + union + join no longer collides with a bare
  aggregate.

## Golden churn

`test/spec/**` `-- chplan --` / `-- sql --`: **zero** — no lowering, optimizer or
emitter behaviour changes.

`test/perf/solver-decision-baseline.json`: **one row**,
`matrix_selector_top_level` (`up[5m]`), `below-threshold` → `extraction-failed`.
`routed=false, K=0` are unchanged, so this is not a routing move. The fixture's
plan is `Project → Filter → Project → Filter → Scan` with no grid carrier
anywhere: a raw matrix selector returns raw samples and owns no anchor grid, so
its zero cost grid was always absence of measurement rather than a cheap plan,
and the row now says which.
