### PR TITLE
test(perf): pin the solver cost grid in the decision ratchet, not just the route

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -365,7 +365,8 @@ update-cardinality-baseline:
 # Component D) from the current PromQL corpus. Parses every `-- query.promql --`
 # fixture under test/spec/promql/**, lowers it on the fixed eval grid
 # (end=2026-01-01T00:00:00Z, range=1h, step=15s), optimizes it, and records the
-# solver Planner's routing decision {routed, K, reason} under Mode=auto into
+# solver Planner's routing decision {routed, K, reason} plus the classifier's
+# cost grid {n_anchors, fanout, cumulative_d, outer_range} under Mode=auto into
 # test/perf/solver-decision-baseline.json (deterministic, sorted by query).
 # Pure Go — NO chDB — so it runs in the standard `check`/`just test` lane.
 # Run this — and REVIEW THE DIFF — whenever the ratchet test reports drift or a

--- a/internal/engine/plan_shape_id_carrier_test.go
+++ b/internal/engine/plan_shape_id_carrier_test.go
@@ -128,6 +128,24 @@ func carrierTokenCases() []carrierTokenCase {
 // differs by kind — a fan-out over histogram buckets and a last-value lookback
 // cost nothing alike — and a shared token would merge exactly the populations
 // an operator is trying to separate.
+// hasModifierToken reports whether id carries token as a WHOLE modifier.
+//
+// A substring test does not discriminate: "rw" is a prefix of both "rwn" and
+// "rwr", so a shape id that stamped a plain RangeWindow token for a native or
+// resampled carrier would satisfy `strings.Contains(id, ";rw")` and the row
+// would pass while the id it asserts on is wrong. Splitting on the modifier
+// separator and comparing whole tokens is the only form that fails there.
+func hasModifierToken(id, token string) bool {
+	parts := strings.Split(id, ";")
+	// parts[0] is the "cerb:<root>" prefix, never a modifier.
+	for _, mod := range parts[1:] {
+		if mod == token {
+			return true
+		}
+	}
+	return false
+}
+
 func TestShapeModifiers_EveryGridCarrierGetsAToken(t *testing.T) {
 	t.Parallel()
 
@@ -140,7 +158,7 @@ func TestShapeModifiers_EveryGridCarrierGetsAToken(t *testing.T) {
 			plan := &chplan.Project{Input: tc.node(&chplan.Scan{Table: "otel_metrics_sum"})}
 
 			id := planShapeID(plan)
-			if !strings.Contains(id, ";"+tc.token) {
+			if !hasModifierToken(id, tc.token) {
 				t.Errorf("shape id %q for %s carries no %q modifier; the carrier is invisible to "+
 					"log_comment clustering", id, tc.kind, tc.token)
 			}

--- a/test/perf/solver-decision-baseline.json
+++ b/test/perf/solver-decision-baseline.json
@@ -3,2688 +3,4480 @@
     "query": "abs_metric",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "absent_aggregate_no_series",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "absent_aggregate_with_series",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "absent_binary_no_series",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "absent_no_matchers",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "absent_no_series",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "absent_over_time_empty_window",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "absent_over_time_range_step_synth_labels",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "absent_over_time_synth_labels",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "absent_over_time_with_data",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "absent_with_series",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "agg_by_dotted_source",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "agg_by_service_name",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "agg_range_window_over_scalar_div",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "at_end_basic",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "at_modifier_range_mode_collapse",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "at_start_basic",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "binary_and",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "binary_and_ignoring",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "binary_and_on",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "binary_or",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "binary_or_ignoring",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "binary_or_increase_instant_canonicalises_arms",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "15m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "binary_or_increase_range_canonicalises_arms",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "15m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "binary_unless",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "binary_unless_ignoring",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "binop_atan2_scalar_vector",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "binop_atan2_vector_scalar",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "binop_atan2_vv",
     "routed": true,
     "k": 6,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "binop_ignoring_instance_strips_instance",
     "routed": true,
     "k": 6,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "binop_increase_plus_rate",
     "routed": true,
     "k": 6,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "binop_metric_minus_time",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "binop_on_job_strips_instance",
     "routed": true,
     "k": 6,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "binop_prod_repro",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "binop_rate_div_rate_ignoring",
     "routed": true,
     "k": 6,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "binop_rate_div_rate_on",
     "routed": true,
     "k": 6,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "binop_rate_plus_rate",
     "routed": true,
     "k": 6,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "binop_redis_hit_ratio_range",
     "routed": true,
     "k": 4,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "15m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "binop_scalar_mul_rate_div_rate_range",
     "routed": true,
     "k": 6,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "binop_sumby_rate_plus_sumby_rate",
     "routed": true,
     "k": 6,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "binop_time_arith_range",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "binop_time_lt_bool_metric",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "binop_time_lt_metric",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "binop_time_plus_metric",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "binop_vv_on_compare_eq",
     "routed": true,
     "k": 6,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "binop_vv_on_compare_lt",
     "routed": true,
     "k": 6,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "bool_lt",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "bool_vv_eq",
     "routed": true,
     "k": 6,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "bool_vv_gt",
     "routed": true,
     "k": 6,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "bottomk_2",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "bottomk_below_one_empty",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "bottomk_computed",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "bottomk_range_bare",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "bottomk_range_by_instance",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "bottomk_range_without_empty",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "bottomk_range_without_instance",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "bottomk_without_basic",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "ceil_metric",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "chained_filter",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "changes_oscillating",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "clamp",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "clamp_max",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "clamp_max_scalar_bound",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "clamp_min",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "clamp_min_scalar_bound",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "clamp_min_scalar_nan_bound",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "clamp_scalar_min_literal_max",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "comparison_arithmetic",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "count_agg_returns_float",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "count_no_group",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "count_values_basic",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "count_values_without",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "count_values_without_empty",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "day_of_month_default",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "day_of_month_of_vector",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "day_of_week_default",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "day_of_week_offset",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "day_of_year_of_vector",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "days_in_month_default",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "days_in_month_of_vector",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "deg_metric",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "delta_empty_window",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "delta_window",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "deriv_linear_increase",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "deriv_subscrape_drops",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "15s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "double_exponential_smoothing",
     "routed": true,
     "k": 6,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 40,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "edge_abs_over_rate",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "edge_absent_over_time_at_timestamp_range_pinned_absent",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "edge_absent_over_time_at_timestamp_range_pinned_present",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "edge_at_start_range",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "edge_at_then_offset_neg",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "edge_at_timestamp_range",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "edge_avg_over_time",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "edge_bool_eq",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "edge_bool_ge",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "edge_bool_le",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "edge_bool_ne",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "edge_ceil_over_sum_by",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "edge_clamp_neg_to_pos",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "edge_count_over_time",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "edge_double_exp_smoothing_at_timestamp_range_pinned",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "edge_hq_native_negative_p0",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "edge_hq_native_negative_p1",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "edge_hq_native_p25",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "edge_hq_native_p999",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "edge_increase_at_start",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "edge_join_ignoring_extra",
     "routed": true,
     "k": 6,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "edge_join_ignoring_group_right",
     "routed": true,
     "k": 6,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "edge_join_on_extra_labels",
     "routed": true,
     "k": 6,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "edge_join_on_three_keys",
     "routed": true,
     "k": 6,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "edge_last_over_time",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "edge_log10_over_rate",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "edge_max_over_time_subquery_at_pinned",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 5,
+    "cumulative_d": "15m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "edge_max_over_time_subquery_step_default",
     "routed": false,
     "k": 0,
-    "reason": "high-D"
+    "reason": "high-D",
+    "n_anchors": 241,
+    "fanout": 240,
+    "cumulative_d": "1h5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "edge_min_over_time",
     "routed": true,
     "k": 6,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 40,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "edge_neg_scalar_minus_vector",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "edge_offset_zero",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "edge_paren_chain_arith",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "edge_predict_linear_at_timestamp_range_pinned",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "edge_quantile_over_time_at_pinned_phi_above_one",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "edge_quantile_over_time_at_timestamp_range_pinned",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "edge_rate_at_timestamp_range_pinned",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "edge_rate_negative_offset",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "edge_round_step_half",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "edge_sqrt_over_aggregate",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "edge_subquery_nested",
     "routed": false,
     "k": 0,
-    "reason": "high-D"
+    "reason": "high-D",
+    "n_anchors": 241,
+    "fanout": 240,
+    "cumulative_d": "1h5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "empty_ignoring_join",
     "routed": true,
     "k": 6,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "empty_on_join",
     "routed": true,
     "k": 6,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "exp_metric",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "first_over_time",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "floor_metric",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "group_basic",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "group_by_job",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_avg_exp",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_avg_exp_latest_sample",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_avg_exp_range_latest_sample",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_bucket_companion",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_bucket_le_filter",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_count_basic",
     "routed": false,
     "k": 0,
-    "reason": "below-threshold"
+    "reason": "below-threshold",
+    "n_anchors": 241,
+    "fanout": 4,
+    "cumulative_d": "1m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_count_exp",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_count_exp_at_pinned_range",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_count_exp_bare_stale",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_count_exp_latest_sample",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_count_exp_range_latest_sample",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_count_float_metric_empty",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_fraction_exp",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_fraction_exp_negative_bounds",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_fraction_exp_negative_range",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_mean_latency",
     "routed": false,
     "k": 0,
-    "reason": "below-threshold"
+    "reason": "below-threshold",
+    "n_anchors": 241,
+    "fanout": 4,
+    "cumulative_d": "2m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_quantile_agg_empty",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_quantile_classic_agg_at_pinned_range",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_quantile_classic_agg_offset_range",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 8,
+    "cumulative_d": "2m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_quantile_classic_bare_at_pin_stale",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_quantile_classic_bare_at_pinned_range",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_quantile_classic_edge_p0",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_quantile_classic_edge_p100",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_quantile_classic_empty",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_quantile_classic_latest_sample",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_quantile_classic_multi_series",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_quantile_classic_range_step",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_quantile_classic_range_step_bare",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_quantile_classic_single_bucket",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_quantile_le_not_in_by",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_quantile_native_agg",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_quantile_native_agg_at_pinned_range",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_quantile_native_agg_groupby",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_quantile_native_agg_mixed_scale",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_quantile_native_agg_p50",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_quantile_native_bare_at_pinned_range",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_quantile_native_bare_offset_range",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_quantile_native_empty",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_quantile_native_latest_sample",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_quantile_native_multi_series",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_quantile_native_negative_only",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_quantile_native_negative_p50",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_quantile_native_p50",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_quantile_native_p99",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_quantile_native_range",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_quantile_native_range_latest",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_quantile_native_single_metric",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_quantile_native_zero_band",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_quantile_non_bucket_empty",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_quantile_over_sum_over_time_bucket",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_quantile_scalar_phi",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_quantile_sum_by_le",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_quantile_sum_by_le_p50",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_quantile_with_filter",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_quantiles_classic_multi_phi",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_quantiles_native_multi_phi",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_stddev_exp",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_stdvar_exp",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_sum_aggregate_arg_empty",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_sum_basic",
     "routed": false,
     "k": 0,
-    "reason": "below-threshold"
+    "reason": "below-threshold",
+    "n_anchors": 241,
+    "fanout": 4,
+    "cumulative_d": "1m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_sum_exp",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_sum_exp_latest_sample",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "histogram_sum_exp_range_latest_sample",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "hour_default",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "hour_of_vector",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "idelta_subscrape_drops",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "15s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "idelta_two_samples",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "increase_duplicate_timestamp_dedup",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "increase_empty_window",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "increase_left_edge_scan_bound",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "info_target_info_enrichment",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "instant_sum_over_suffixed_count_delta_sum",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "irate_over_subquery",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "6m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "irate_subscrape_drops",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "15s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "irate_two_samples",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "label_join_two_labels",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "label_join_with_separator",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "label_replace_basic",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "label_replace_missing_src",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "label_replace_missing_src_overwrite",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "label_replace_no_match",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "label_replace_regex_capture",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "limit_ratio_complement",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "limit_ratio_half",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "limitk_below_one_empty",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "limitk_by_job_all_survive",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "limitk_by_job_truncates",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "limitk_without_instance",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "ln_metric",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "log10_metric",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "log2_metric",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "lwr_bare_selector_eval_ts_boundary",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "lwr_bare_selector_latest_per_series",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "lwr_bare_selector_staleness_window",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "mad_over_time",
     "routed": true,
     "k": 6,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 40,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "map_key_order_count",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "map_key_order_exp_histogram_count",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "map_key_order_histogram_quantile",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "map_key_order_increase",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "map_key_order_sum_by_labels",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "map_key_order_sum_without_label",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "mapkey_order_binop_default_instant",
     "routed": true,
     "k": 6,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "mapkey_order_binop_ignoring_instant",
     "routed": true,
     "k": 6,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "mapkey_order_label_replace_binop_instant",
     "routed": true,
     "k": 6,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "mapkey_order_setop_and_default_instant",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "mapkey_order_setop_and_ignoring_range",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "mapkey_order_setop_and_on_instant",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "mapkey_order_setop_or_default_range",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "matcher_and_agg_by_service_name",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "matcher_dotted_source",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "matcher_service_name",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "matrix_selector_top_level",
     "routed": false,
     "k": 0,
-    "reason": "extraction-failed"
+    "reason": "extraction-failed",
+    "n_anchors": 0,
+    "fanout": 0,
+    "cumulative_d": "0s",
+    "outer_range": "0s"
   },
   {
     "query": "metadata_label_names_leaf_projection",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "metadata_label_values_bucket_le",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "metadata_label_values_collides_on_sanitized_name",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "metadata_label_values_dotted_source_key",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "metadata_label_values_leaf_projection",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "minute_default",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "minute_of_vector",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "mod_arithmetic",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "month_default",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "month_of_vector",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "multiple_matchers",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "native_changes_range_step",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "native_deriv_range_step",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "native_predict_linear_negative_horizon_fanout",
     "routed": true,
     "k": 6,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 40,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "native_predict_linear_range_step",
     "routed": true,
     "k": 6,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 40,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "native_rate_join_range_step",
     "routed": false,
     "k": 0,
-    "reason": "below-threshold"
+    "reason": "below-threshold",
+    "n_anchors": 241,
+    "fanout": 8,
+    "cumulative_d": "4m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "native_rate_range_step",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "native_rate_recollapse_collision",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "native_rate_recollapse_collision_two_level",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "native_rate_recollapse_histogram_companion",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "native_rate_recollapse_metric_name_isolation",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "native_rate_recollapse_range_step",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "native_resample_offset",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "native_resample_range_step",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "native_resets_range_step",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "negative_at",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "negative_offset",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "not_regex_label",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "not_regex_name_matcher_excludes_dotted",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "offset_negative",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "pi_constant",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "pow_arithmetic",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "power_op_basic",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "power_op_vv",
     "routed": true,
     "k": 6,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "predict_linear_scalar_horizon",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "predict_linear_simple",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "predict_linear_subscrape_drops",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "15s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "present_over_time_with_data",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "quantile_by_job",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "quantile_over_time_p95",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "quantile_over_time_p95_exact_interp",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "quantile_over_time_q_above_one",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "quantile_over_time_q_above_one_no_modifier",
     "routed": false,
     "k": 0,
-    "reason": "below-threshold"
+    "reason": "below-threshold",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "1s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "quantile_over_time_q_negative",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "quantile_over_time_q_negative_no_modifier",
     "routed": false,
     "k": 0,
-    "reason": "below-threshold"
+    "reason": "below-threshold",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "1s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "quantile_over_time_scalar_phi",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "quantile_q_above_one",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "quantile_q_negative",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "quantile_scalar_phi",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "quantile_scalar_phi_nan",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "query_context_range_range_mode",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "query_context_step_instant_zero",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "query_context_step_range_mode",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "rad_metric",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "range_window_func_over_scalar_div",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "rate_empty_window",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "rate_http_count",
     "routed": false,
     "k": 0,
-    "reason": "below-threshold"
+    "reason": "below-threshold",
+    "n_anchors": 241,
+    "fanout": 4,
+    "cumulative_d": "1m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "rate_offset_5m",
     "routed": false,
     "k": 0,
-    "reason": "below-threshold"
+    "reason": "below-threshold",
+    "n_anchors": 241,
+    "fanout": 4,
+    "cumulative_d": "1m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "regex_alternation",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "regex_anchored",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "regex_name_matcher_scans_sum_table",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "regex_name_matcher_underscored_matches_dotted",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "resets_counter",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "resource_attr_bare_selector",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "resource_attr_matcher",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "resource_attr_precedence_collision",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "resource_attr_sum_by",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "resource_attrs_allowlist_lookup_table",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "round_metric",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "round_scalar_to_nearest",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "round_to_nearest",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "scalar_binop_fold",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "scalar_binop_fold_bool",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "scalar_binop_fold_precedence",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "scalar_lt_vector",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "scalar_many_series_nan",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "scalar_minus_vector",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "scalar_mul_rate",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "scalar_single_series",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "scan_unions_gauge_for_suffixed_standalone_gauge",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "scan_unions_gauge_sum_for_unsuffixed_metric",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "scan_unions_histogram_sum_for_suffixed_metric",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "scientific_threshold",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "setop_and_instant_shared_signature",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "setop_and_range_gap",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "setop_and_rate",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "setop_and_subquery_arm_range",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "9m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "setop_or_instant_shared_signature",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "setop_or_native_ts_grid_range",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "setop_or_range_gap",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "setop_or_rate",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "setop_or_subquery_arm_range",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "9m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "setop_unless_range_gap",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "setop_unless_rate",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "sgn_metric",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "sort_ascending",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "sort_by_label_ascending",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "sort_by_label_desc_tiebreak",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "sort_by_label_natural_order",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "sort_desc_descending",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "sqrt_metric",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "stddev_by_job",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "stddev_over_time_window",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "stdvar_no_group",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "stdvar_over_time_basic",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "subquery_absent_missing_metric",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "subquery_absent_present_metric",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "subquery_agg_of_binary",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "6m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "subquery_avg_over_time_increase",
     "routed": false,
     "k": 0,
-    "reason": "high-D"
+    "reason": "high-D",
+    "n_anchors": 241,
+    "fanout": 120,
+    "cumulative_d": "35m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "subquery_avg_over_time_rate",
     "routed": false,
     "k": 0,
-    "reason": "below-threshold"
+    "reason": "below-threshold",
+    "n_anchors": 241,
+    "fanout": 8,
+    "cumulative_d": "3m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "subquery_bare_default_step",
     "routed": false,
     "k": 0,
-    "reason": "instant"
+    "reason": "instant",
+    "n_anchors": 6,
+    "fanout": 1,
+    "cumulative_d": "1m0s",
+    "outer_range": "5m0s"
   },
   {
     "query": "subquery_bare_vector",
     "routed": false,
     "k": 0,
-    "reason": "instant"
+    "reason": "instant",
+    "n_anchors": 6,
+    "fanout": 1,
+    "cumulative_d": "1m0s",
+    "outer_range": "5m0s"
   },
   {
     "query": "subquery_bare_vector_with_label",
     "routed": false,
     "k": 0,
-    "reason": "instant"
+    "reason": "instant",
+    "n_anchors": 6,
+    "fanout": 1,
+    "cumulative_d": "1m0s",
+    "outer_range": "5m0s"
   },
   {
     "query": "subquery_count_over_time_rate",
     "routed": false,
     "k": 0,
-    "reason": "high-D"
+    "reason": "high-D",
+    "n_anchors": 241,
+    "fanout": 240,
+    "cumulative_d": "1h5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "subquery_irate_nested",
     "routed": true,
     "k": 3,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 40,
+    "cumulative_d": "16m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "subquery_label_replace",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "6m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "subquery_max_over_time_delta",
     "routed": false,
     "k": 0,
-    "reason": "high-D"
+    "reason": "high-D",
+    "n_anchors": 241,
+    "fanout": 240,
+    "cumulative_d": "1h5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "subquery_max_over_time_rate",
     "routed": false,
     "k": 0,
-    "reason": "high-D"
+    "reason": "high-D",
+    "n_anchors": 241,
+    "fanout": 240,
+    "cumulative_d": "1h5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "subquery_min_over_time_increase",
     "routed": false,
     "k": 0,
-    "reason": "high-D"
+    "reason": "high-D",
+    "n_anchors": 241,
+    "fanout": 240,
+    "cumulative_d": "1h5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "subquery_nested",
     "routed": false,
     "k": 0,
-    "reason": "high-D"
+    "reason": "high-D",
+    "n_anchors": 241,
+    "fanout": 240,
+    "cumulative_d": "1h6m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "subquery_offset",
     "routed": false,
     "k": 0,
-    "reason": "instant"
+    "reason": "instant",
+    "n_anchors": 6,
+    "fanout": 1,
+    "cumulative_d": "1m0s",
+    "outer_range": "5m0s"
   },
   {
     "query": "subquery_over_avg_count",
     "routed": false,
     "k": 0,
-    "reason": "high-D"
+    "reason": "high-D",
+    "n_anchors": 241,
+    "fanout": 120,
+    "cumulative_d": "35m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "subquery_over_binexpr",
     "routed": false,
     "k": 0,
-    "reason": "below-threshold"
+    "reason": "below-threshold",
+    "n_anchors": 241,
+    "fanout": 4,
+    "cumulative_d": "1m30s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "subquery_over_bottomk",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 240,
+    "cumulative_d": "1h1m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "subquery_over_count_values",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "6m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "subquery_over_increase",
     "routed": false,
     "k": 0,
-    "reason": "instant"
+    "reason": "instant",
+    "n_anchors": 31,
+    "fanout": 5,
+    "cumulative_d": "5m0s",
+    "outer_range": "30m0s"
   },
   {
     "query": "subquery_over_limitk",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 240,
+    "cumulative_d": "1h1m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "subquery_over_quantile",
     "routed": false,
     "k": 0,
-    "reason": "high-D"
+    "reason": "high-D",
+    "n_anchors": 241,
+    "fanout": 240,
+    "cumulative_d": "1h1m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "subquery_over_rate",
     "routed": false,
     "k": 0,
-    "reason": "instant"
+    "reason": "instant",
+    "n_anchors": 13,
+    "fanout": 1,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "subquery_over_rate_range",
     "routed": false,
     "k": 0,
-    "reason": "below-threshold"
+    "reason": "below-threshold",
+    "n_anchors": 241,
+    "fanout": 8,
+    "cumulative_d": "3m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "subquery_over_sum_over_time",
     "routed": false,
     "k": 0,
-    "reason": "instant"
+    "reason": "instant",
+    "n_anchors": 31,
+    "fanout": 5,
+    "cumulative_d": "5m0s",
+    "outer_range": "30m0s"
   },
   {
     "query": "subquery_over_sum_rate",
     "routed": false,
     "k": 0,
-    "reason": "high-D"
+    "reason": "high-D",
+    "n_anchors": 241,
+    "fanout": 240,
+    "cumulative_d": "1h1m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "subquery_over_topk",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 240,
+    "cumulative_d": "1h1m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "subquery_over_without",
     "routed": false,
     "k": 0,
-    "reason": "high-D"
+    "reason": "high-D",
+    "n_anchors": 241,
+    "fanout": 240,
+    "cumulative_d": "1h1m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "subquery_quantile_scalar_phi",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "6m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "subquery_stddev",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "6m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "subquery_sum_over_time_rate",
     "routed": false,
     "k": 0,
-    "reason": "high-D"
+    "reason": "high-D",
+    "n_anchors": 241,
+    "fanout": 240,
+    "cumulative_d": "1h5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "subquery_topk_fractional_k",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "6m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "subquery_topk_zero_empty",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "6m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "subquery_unary_minus",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "6m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "sum_by_job",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "sum_by_rate_dotted_source",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "sum_by_rate_range_offset",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "sum_by_rate_range_offset_negative",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "sum_by_rate_range_step",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "sum_by_underscored_otel_label",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "sum_without_empty",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "sum_without_instance",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "sum_without_two_labels",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "time_eq_bool_time_range",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "time_minus_time_range",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "time_plus_time_range",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "time_returns_eval_ts",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "timestamp_of_metric",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "topk_3_by_job",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "topk_computed",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "topk_fractional_k",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "topk_over_rate_binop",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "topk_range_bare",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "topk_range_by_instance",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "topk_range_without_empty",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "topk_range_without_instance",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "topk_without_basic",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "topk_zero_empty",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "trig_acos_metric",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "trig_cos_metric",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "trig_sin_metric",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "trig_sinh_metric",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "ts_of_first_over_time",
     "routed": true,
     "k": 6,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 40,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "ts_of_last_over_time",
     "routed": true,
     "k": 6,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 40,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "ts_of_max_over_time",
     "routed": true,
     "k": 6,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 40,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "ts_of_min_over_time",
     "routed": true,
     "k": 6,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 40,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "unary_minus_binary_lhs",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "unary_minus_in_function",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "unary_minus_rate",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "unary_minus_vector",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "unary_plus_vector",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "up",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "up_at_offset_combined",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "up_at_timestamp",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "up_gt_bool",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "up_gt_threshold",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "up_ne_zero",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "up_offset_5m",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "up_times_two",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "up_with_label",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "up_with_regex",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "vector_div_scalar",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "vector_group_left",
     "routed": true,
     "k": 6,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "vector_group_left_ignoring",
     "routed": true,
     "k": 6,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "vector_group_left_multi_include",
     "routed": true,
     "k": 6,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "vector_group_right",
     "routed": true,
     "k": 6,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "vector_ignoring_instance",
     "routed": true,
     "k": 6,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "vector_mod_scalar",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "vector_on_job",
     "routed": true,
     "k": 6,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "vector_plus_vector",
     "routed": true,
     "k": 6,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "vector_pow_scalar",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "vector_promotes_scalar",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "vector_promotes_time",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "vector_scalar_multi_series_nan",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "vector_scalar_single_series",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "year_default",
     "routed": false,
     "k": 0,
-    "reason": "not-sliceable"
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 0,
+    "cumulative_d": "0s",
+    "outer_range": "1h0m0s"
   },
   {
     "query": "year_of_vector",
     "routed": true,
     "k": 8,
-    "reason": "routed"
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
   }
 ]

--- a/test/perf/solver_decision_ratchet_test.go
+++ b/test/perf/solver_decision_ratchet_test.go
@@ -27,7 +27,26 @@
 // Each query is parsed (reference Prometheus parser) → lowered
 // (`promql.LowerAtRange` at the fixed grid) → optimized (`optimizer.Default`)
 // → classified (`solver.Planner.Plan` under Mode=auto, the DefaultConfig
-// thresholds). The recorded decision is {routed, K, reason}.
+// thresholds). The recorded decision is {routed, K, reason} PLUS the
+// classifier's cost grid {n_anchors, fanout, cumulative_d, outer_range}.
+//
+// # Why the cost grid is part of the pin
+//
+// The route bit, K and the reason are the classifier's OUTPUT; the cost grid is
+// its INPUT — the features the signal walk extracted from the plan. Pinning
+// only the output leaves the extractor unratcheted over the corpus, and the
+// extractor's failure mode is silent by construction: a carrier kind the walk
+// stops measuring contributes an all-zero feature vector, which refuses the plan
+// for the SAME reason with the SAME K as measuring it properly would. Every
+// natively-lowered rate, every histogram bucket fan-out, every
+// `absent_over_time` in the corpus is refused either way, so an output-only
+// baseline is byte-identical whether those plans are measured or invisible.
+//
+// The cost grid is also what the calibration corpus records per query
+// (optcorpus's n_anchors / fanout / cumulative_d / outer_range columns), so
+// these rows are the offline replay of exactly the numbers a routing threshold
+// is fitted against. A drift here is a drift in every threshold's evidence base
+// even when no query changed route.
 //
 // # The ratchet semantics (bidirectional, no escape hatch)
 //
@@ -133,6 +152,22 @@ type decisionEntry struct {
 
 	// Reason is the shadow-header vocabulary value (one of solver.Reason*).
 	Reason string `json:"reason"`
+
+	// NAnchors / Fanout / CumulativeD / OuterRange are the classifier's cost
+	// grid — the features the signal walk extracted from the plan, and the
+	// same four scalars the calibration corpus stores per query. They are
+	// pinned because they are the only place an extraction regression is
+	// visible: a plan the walk cannot measure is refused with the same
+	// reason and the same K as one it measures, so the decision half of this
+	// row cannot tell the two apart.
+	//
+	// The two durations are recorded in Go's canonical duration form
+	// ("5m0s", "1h0m0s", "0s") rather than as raw nanoseconds so a moved row
+	// is readable in the diff without conversion.
+	NAnchors    int    `json:"n_anchors"`
+	Fanout      int64  `json:"fanout"`
+	CumulativeD string `json:"cumulative_d"`
+	OuterRange  string `json:"outer_range"`
 }
 
 // classifyCorpus parses, lowers, optimizes, and classifies every PromQL
@@ -201,7 +236,16 @@ func classifyCorpus(t *testing.T) map[string]decisionEntry {
 		plan = optimizer.Default().Run(context.Background(), plan)
 
 		d, routed := planner.Plan(plan, meta)
-		out[id] = decisionEntry{Query: id, Routed: routed, K: d.K, Reason: d.Reason}
+		out[id] = decisionEntry{
+			Query:       id,
+			Routed:      routed,
+			K:           d.K,
+			Reason:      d.Reason,
+			NAnchors:    d.NAnchors,
+			Fanout:      d.Fanout,
+			CumulativeD: d.CumulativeD.String(),
+			OuterRange:  d.OuterRange.String(),
+		}
 	}
 	if len(out) == 0 {
 		t.Fatalf("classified zero queries from %d fixtures — corpus seam broke", len(matches))
@@ -270,14 +314,14 @@ func TestSolverDecisionRatchet(t *testing.T) {
 			continue
 		}
 		t.Errorf("%s: routing decision drifted [%s]\n"+
-			"      baseline: routed=%v K=%d reason=%q\n"+
-			"      current:  routed=%v K=%d reason=%q\n"+
+			"      baseline: routed=%v K=%d reason=%q N=%d F=%d D=%s outer=%s\n"+
+			"      current:  routed=%v K=%d reason=%q N=%d F=%d D=%s outer=%s\n"+
 			"      A drift is NEVER auto-accepted: run `just update-solver-decision-baseline` to "+
 			"regenerate, review the diff, and (if this row is a REGRESSION) justify it in the PR "+
 			"with a real reason — a correctness fix that disqualifies the query, not a threshold tweak.",
 			id, classifyDrift(base, cur),
-			base.Routed, base.K, base.Reason,
-			cur.Routed, cur.K, cur.Reason)
+			base.Routed, base.K, base.Reason, base.NAnchors, base.Fanout, base.CumulativeD, base.OuterRange,
+			cur.Routed, cur.K, cur.Reason, cur.NAnchors, cur.Fanout, cur.CumulativeD, cur.OuterRange)
 	}
 }
 
@@ -288,6 +332,13 @@ func TestSolverDecisionRatchet(t *testing.T) {
 // either way — but it makes the direction of every moved row machine-visible
 // in the failure output so a reviewer can demand a justification for the
 // regressions specifically.
+//
+// COST-GRID is the label for a row whose route, K and reason all held while the
+// extracted features moved. It is not ranked as advancement or regression
+// because it is neither: the routing outcome is identical and what changed is
+// what the signal walk SAW. That is the direction an extraction regression
+// arrives from, so the label names it explicitly rather than letting it land in
+// the generic bucket.
 func classifyDrift(base, cur decisionEntry) string {
 	adv, reg := false, false
 
@@ -320,6 +371,12 @@ func classifyDrift(base, cur decisionEntry) string {
 			// as a drift the reviewer must read, not silently ranked.
 			return "REASON-CHANGE"
 		}
+	}
+
+	// classifyDrift is only called on a row that moved, so route, K and reason
+	// all holding means the extracted cost grid is what moved.
+	if !adv && !reg && base.Reason == cur.Reason {
+		return "COST-GRID"
 	}
 
 	switch {


### PR DESCRIPTION
Adversarial-review follow-up to #1403 (task #75). The production change in #1403 is sound — I re-derived the RangeWindow / RangeLWR extraction byte-for-byte against the pre-PR planner and confirmed no plan can now be SLICED that previously was not (every non-reanchorable carrier with `step > 0` sets `sawNonRangeWindowSpine`, which gate 1b reads before any threshold; Native / Resample / AbsentOverTime are additionally absent from `sliceInvariantKinds` so they fail gate 1 first). What was not sound is the corpus-level evidence.

## The defect

`test/perf/solver_decision_ratchet_test.go` recorded `{query, routed, k, reason}` per corpus entry — the classifier's **output**. The classifier's **input** — the cost grid the signal walk extracts from the plan (`n_anchors`, `fanout`, `cumulative_d`, `outer_range`) — was computed by `Plan` and then discarded.

That makes the 448-query ratchet structurally incapable of observing the quantity #1403 changed. The extractor's failure mode is silent by construction: a carrier kind the walk stops measuring contributes an all-zero feature vector, and an all-zero vector is refused for the **same reason** with the **same K** as a properly measured one. Every natively-lowered rate, every histogram bucket fan-out and every `absent_over_time` in the corpus is refused either way, so the output-only baseline is byte-identical whether those plans are measured or invisible.

Measured: reverting `internal/solver/planner.go` to `b623cc79^` and regenerating moved **exactly one row** of the old baseline. It moves **774 lines** of the new one.

## The fix

- `decisionEntry` gains `n_anchors` / `fanout` / `cumulative_d` / `outer_range`, populated from `d.NAnchors` / `d.Fanout` / `d.CumulativeD` / `d.OuterRange`. The two durations are stored in Go's canonical duration form so a moved row is readable in the diff without conversion.
- The drift error message prints both grids; `classifyDrift` gains a `COST-GRID` label for a row where route, K and reason all held and only the extracted features moved.
- The file header and the `Justfile` recipe comment state why the extraction half is part of the pin: these four scalars are exactly what the calibration corpus stores per query (optcorpus's `n_anchors` / `fanout` / `cumulative_d` / `outer_range` columns), so the rows are the offline replay of the numbers every routing threshold is fitted against. A drift here is a drift in every threshold's evidence base even when no query changed route.
- Baseline regenerated via `just update-solver-decision-baseline`.

## Second, smaller fix

`internal/engine/plan_shape_id_carrier_test.go` asserted `strings.Contains(id, ";"+tc.token)`. `";rw"` is a prefix of `";rwn"` and `";rwr"`, so a shape id that stamped a plain RangeWindow token for a native or resampled carrier satisfied the assertion and the row passed on the wrong id. Replaced with `hasModifierToken`, which splits on the modifier separator and compares whole tokens.

## Routed out, not fixed here

- `RangeLWR` does not append to `innerResolutions` and so never runs `checkCommensurability`, unlike `RangeWindow`. Changing it changes routing decisions, so it needs its own PR + baseline move.
- Cosmetic: `internal/engine/plan_shape_id.go`'s doc comment has a dangling fragment line ("and DELIBERATELY omits").

🤖 Generated with [Claude Code](https://claude.com/claude-code)