### PR TITLE
fix(optcorpus): fold routed cost at the Executor's effective shard concurrency

### DIFF
--- a/docs/solver.md
+++ b/docs/solver.md
@@ -586,7 +586,8 @@ To answer it the engine closes the loop the optimization corpus
   not where that plan sat relative to it, and a counterfactual re-fit needs the
   latter.
 - **Join to observed cost.** At the dispatch seam the engine hands the corpus
-  reconciler the decision read-out next to the CH `query_id`. The reconciler
+  reconciler the decision read-out next to the CH `query_id`s the dispatch will
+  run under — one on route A, K on a route-B fan-out. The reconciler
   joins `query_id` → `system.query_log` (the cost columns plus a derived
   `exit_status` of `ok` / `oom` / `timeout` / `aborted` / `error` from the row
   type + exception code) and writes one corpus row per dispatch. Terminal rows
@@ -606,6 +607,22 @@ To answer it the engine closes the loop the optimization corpus
   flag-gated, production-only, failure-open, and the observe call is a
   non-blocking channel send — the hot path is byte-unchanged when the corpus is
   off.
+- **One row per REQUEST, K statements or one.** The corpus row is the unit of
+  A/B comparison and carries no request identifier to group by after the fact,
+  so a route-B fan-out is folded into a single row rather than K: a row per
+  shard would put a fraction of route B beside a whole route-A query in every
+  comparison. All K shard ids index one ring record, and the reconciler holds
+  the group until every shard's `query_log` row is visible — a partially joined
+  fan-out is deferred to the next interval, never written under-counted. The
+  fold keeps a route-B row meaning what a route-A row means: `read_rows` /
+  `read_bytes` / `profile_events` are summed (total work done), `exit_status` is
+  the most severe shard status (an OOMed shard is an OOM for the request), and
+  the two schedule-dependent columns read the Executor's EFFECTIVE concurrency
+  P, which is routinely below K — `memory_usage` is the sum of the P largest
+  shard peaks (only P coexist) and `query_duration_ms` is the makespan bound
+  `max(slowest shard, total / P)`. Assuming a fully parallel fan-out instead
+  would understate route-B latency and overstate its memory by roughly K/P at
+  the default P.
 - **Cerberus-side terminal outcomes.** `system.query_log` only reflects what
   ClickHouse saw — it cannot show a request cerberus *itself* terminated. Three
   cerberus-side outcomes are captured in-process and take precedence over (or

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -227,7 +227,8 @@ func (e *Engine) observeQuery(queryID string, plan chplan.Node, language string,
 // of A/B comparison and carries no request identifier to group shards by after
 // the fact, so a per-shard row would compare a fraction of route B against a
 // whole route-A query. The observer folds the K query_log rows into that one
-// row.
+// row, and needs the Executor's EFFECTIVE concurrency to do it — the wall-clock
+// and memory columns depend on how many of the K shards actually overlapped.
 //
 // The shape-id is the WHOLE plan's — the same plan route A would have run — so
 // an A row and a B row for the same query shape share a shape_id and join
@@ -252,7 +253,7 @@ func (e *Engine) observeRoutedQuery(info *solver.ExecInfo, plan chplan.Node, lan
 	}
 	present, route, nAnchors, fanout, cumD, outerRange, step, kShards, reason := routeFeatures(decision)
 	e.QueryObserver.ObserveRoutedQuery(
-		ids, planShapeID(plan), e.Settings.enabledOpts(), language,
+		ids, info.Parallelism, planShapeID(plan), e.Settings.enabledOpts(), language,
 		present, route, nAnchors, fanout, cumD, outerRange, step, kShards, reason,
 	)
 }
@@ -585,6 +586,14 @@ type QueryObserver interface {
 	// per REQUEST — a row per shard would compare one shard against a whole
 	// route-A query and make B look K times cheaper than it is.
 	//
+	// parallelism is the EFFECTIVE shard concurrency the Executor ran the
+	// fan-out at, which is routinely below K (the configured P, further clamped
+	// by the admission top-up and the shard gate). The observer needs it to fold
+	// the wall-clock and memory columns: at concurrency P the K shards' peaks do
+	// not all coexist and their durations do not all overlap, so a fold that
+	// assumed full parallelism would understate route B's latency and overstate
+	// its memory by roughly K/P.
+	//
 	// It is a distinct method rather than a widened ObserveQuery so route A's
 	// seam — the overwhelmingly hot one — stays byte-identical. The remaining
 	// parameters carry the same meaning as ObserveQuery's; route is "B" and
@@ -592,6 +601,7 @@ type QueryObserver interface {
 	// cheap.
 	ObserveRoutedQuery(
 		shardQueryIDs []string,
+		parallelism int,
 		shapeID string,
 		opts []string,
 		language string,

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -94,11 +94,12 @@ type recordingObserver struct {
 	// routed* capture the route-B seam (ObserveRoutedQuery), which is separate
 	// from ObserveQuery precisely so a test can tell the two apart: one entry per
 	// ROUTED dispatch, carrying that dispatch's K shard query_ids.
-	routedIDs     [][]string
-	routedPresent []bool
-	routedRoutes  []string
-	routedReasons []string
-	routedKShards []uint8
+	routedIDs      [][]string
+	routedParallel []int
+	routedPresent  []bool
+	routedRoutes   []string
+	routedReasons  []string
+	routedKShards  []uint8
 
 	// outcomes captures (queryID, token) pairs from ObserveOutcome; rejections
 	// captures (language, token) pairs from ObserveRejection; dispatchedRej
@@ -133,6 +134,7 @@ func (o *recordingObserver) ObserveQuery(
 
 func (o *recordingObserver) ObserveRoutedQuery(
 	shardQueryIDs []string,
+	parallelism int,
 	_ string,
 	_ []string,
 	_ string,
@@ -143,6 +145,7 @@ func (o *recordingObserver) ObserveRoutedQuery(
 	decisionReason string,
 ) {
 	o.routedIDs = append(o.routedIDs, append([]string(nil), shardQueryIDs...))
+	o.routedParallel = append(o.routedParallel, parallelism)
 	o.routedPresent = append(o.routedPresent, routePresent)
 	o.routedRoutes = append(o.routedRoutes, route)
 	o.routedReasons = append(o.routedReasons, decisionReason)

--- a/internal/engine/routed_corpus_observe_test.go
+++ b/internal/engine/routed_corpus_observe_test.go
@@ -32,12 +32,13 @@ type routedCorpusObserver struct {
 
 	routeAIDs []string
 
-	routedIDs     [][]string
-	routedShapes  []string
-	routedPresent []bool
-	routedRoutes  []string
-	routedReasons []string
-	routedKShards []uint8
+	routedIDs      [][]string
+	routedParallel []int
+	routedShapes   []string
+	routedPresent  []bool
+	routedRoutes   []string
+	routedReasons  []string
+	routedKShards  []uint8
 }
 
 func (o *routedCorpusObserver) ObserveQuery(
@@ -50,12 +51,13 @@ func (o *routedCorpusObserver) ObserveQuery(
 }
 
 func (o *routedCorpusObserver) ObserveRoutedQuery(
-	shardQueryIDs []string, shapeID string, _ []string, _ string,
+	shardQueryIDs []string, parallelism int, shapeID string, _ []string, _ string,
 	routePresent bool, route string, _, _, _, _, _ uint32, kShards uint8, decisionReason string,
 ) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 	o.routedIDs = append(o.routedIDs, append([]string(nil), shardQueryIDs...))
+	o.routedParallel = append(o.routedParallel, parallelism)
 	o.routedShapes = append(o.routedShapes, shapeID)
 	o.routedPresent = append(o.routedPresent, routePresent)
 	o.routedRoutes = append(o.routedRoutes, route)
@@ -233,6 +235,19 @@ func TestExecuteRoutedCursor_ObservesTheFanOut(t *testing.T) {
 	if obs.routedShapes[0] != planShapeID(plan) {
 		t.Errorf("shape_id = %q; want the WHOLE plan's %q, so route-A and route-B rows join",
 			obs.routedShapes[0], planShapeID(plan))
+	}
+
+	// The observer folds the K shards' wall-clock and memory into one row, which
+	// it can only do knowing how many of them overlapped. Hand it 0 (or K) and
+	// the fold reads a K=8/P=3 fan-out as if all eight shards ran at once:
+	// route-B latency understated and memory overstated by roughly K/P.
+	wantP := solver.DefaultConfig().Parallel
+	if got := obs.routedParallel[0]; got != wantP {
+		t.Errorf("observed parallelism = %d; want the Executor's effective P (%d)", got, wantP)
+	}
+	if obs.routedParallel[0] >= len(ids) {
+		t.Errorf("observed parallelism %d >= %d shards; the fixture exists because P below K is the routine shape",
+			obs.routedParallel[0], len(ids))
 	}
 }
 

--- a/internal/optcorpus/optcorpus.go
+++ b/internal/optcorpus/optcorpus.go
@@ -24,6 +24,7 @@ package optcorpus
 import (
 	"context"
 	"log/slog"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -257,6 +258,14 @@ type Record struct {
 	// against route B per REQUEST — a row per shard would measure a fraction of
 	// route B against a whole route-A query. Empty on route A.
 	ShardQueryIDs []string
+	// Parallelism is the EFFECTIVE shard concurrency the Executor ran the
+	// fan-out at (its P after the admission and gate clamps), which is routinely
+	// below len(ShardQueryIDs). rowFor needs it to fold the wall-clock and
+	// memory columns: only P of the K shards are ever in flight together, so
+	// their peaks do not all coexist and their durations do not all overlap.
+	// Zero on route A and on any record that carries a single id, where the fold
+	// is the identity either way.
+	Parallelism int
 	// ShapeID is the literal-free cerb:<root>[;mod...] plan shape id from
 	// engine.planShapeID.
 	ShapeID string
@@ -670,8 +679,12 @@ func (r *Reconciler) ObserveQuery(
 // a routed query must weigh as one row against the route-A row it is compared
 // with. Same non-blocking, drop-under-burst contract as ObserveQuery; the ids
 // are copied because the caller owns the slice.
+//
+// parallelism is the Executor's EFFECTIVE shard concurrency, which the fold
+// needs because it is routinely below K — see Record.Parallelism.
 func (r *Reconciler) ObserveRoutedQuery(
 	shardQueryIDs []string,
+	parallelism int,
 	shapeID string,
 	opts []string,
 	language string,
@@ -692,6 +705,7 @@ func (r *Reconciler) ObserveRoutedQuery(
 	}
 	r.enqueue(Record{
 		ShardQueryIDs: ids,
+		Parallelism:   parallelism,
 		ShapeID:       shapeID,
 		Opts:          opts,
 		Language:      language,
@@ -1085,17 +1099,22 @@ func groupByRecord(srcRows []SourceRow, lookup func(string) (Record, int, bool))
 //     point of the A/B comparison is whether the fan-out reads more or less in
 //     total than the single query would have. A max would report one shard's
 //     share and understate route B by roughly K.
-//   - memory_usage is SUMMED. Shards run concurrently, so the server-side
-//     memory a routed request holds at once is the sum of the shards' peaks —
-//     that (not any single shard's peak) is the quantity comparable to route
-//     A's single peak, and it is the conservative side to err on for a column
-//     the calibration learns memory watermarks from.
-//   - query_duration_ms is the MAX. Shards run concurrently, so the slowest one
-//     is the request's ClickHouse-side latency; summing would yield a
-//     CPU-time-like number that corresponds to nothing route A reports. Engine
-//     wall-clock was rejected for the same reason in reverse: route A's
-//     duration comes from query_log, and mixing instruments would make the two
-//     routes' latency columns incomparable.
+//   - memory_usage is the sum of the P LARGEST shard peaks. At most P of the K
+//     shards are ever in flight together, so that sum — not the sum of all K —
+//     bounds the server-side memory the request holds at once, which is the
+//     quantity comparable to route A's single peak. It stays a bound rather
+//     than an exact reading (peaks within a wave need not coincide), which is
+//     the conservative side to err on for a column the calibration learns
+//     memory watermarks from.
+//   - query_duration_ms is the makespan bound max(slowest shard, total / P):
+//     K tasks on P workers cannot finish before either term, and the tighter of
+//     the two is the estimate. With a fully parallel fan-out it is the slowest
+//     shard; serialised down to P=1 it is the total. A plain MAX would read the
+//     ClickHouse-side latency of a K=8/P=3 fan-out as one shard's, understating
+//     route B by roughly K/P against a route-A row it is compared with. Engine
+//     wall-clock was rejected for the opposite reason: route A's duration comes
+//     from query_log, and mixing instruments would make the two routes' latency
+//     columns incomparable.
 //   - profile_events are summed per key, matching read_rows' "total work"
 //     reading of the same fan-out.
 //   - normalized_query_hash comes from the first joined row. The shards are K
@@ -1111,6 +1130,8 @@ func rowFor(g joinGroup) Row {
 		Language: g.rec.Language,
 	}
 	chStatus := ExitOK
+	memPeaks := make([]uint64, 0, len(g.rows))
+	var slowestMS, totalMS uint64
 	for i, sr := range g.rows {
 		if i == 0 {
 			row.NormalizedQueryHash = sr.NormalizedQueryHash
@@ -1120,9 +1141,10 @@ func rowFor(g joinGroup) Row {
 		}
 		row.ReadRows += sr.ReadRows
 		row.ReadBytes += sr.ReadBytes
-		row.MemoryUsage += sr.MemoryUsage
-		if sr.QueryDurationMS > row.QueryDurationMS {
-			row.QueryDurationMS = sr.QueryDurationMS
+		memPeaks = append(memPeaks, sr.MemoryUsage)
+		totalMS += sr.QueryDurationMS
+		if sr.QueryDurationMS > slowestMS {
+			slowestMS = sr.QueryDurationMS
 		}
 		for name, count := range sr.ProfileEvents {
 			if row.ProfileEvents == nil {
@@ -1131,9 +1153,63 @@ func rowFor(g joinGroup) Row {
 			row.ProfileEvents[name] += count
 		}
 	}
+	p := concurrencyOf(g.rec, len(g.rows))
+	row.MemoryUsage = sumTopN(memPeaks, p)
+	row.QueryDurationMS = makespanMS(slowestMS, totalMS, p)
 	row.ExitStatus = exitStatusToken(chStatus, g.rec)
 	joinRouteFeatures(&row, g.rec)
 	return row
+}
+
+// concurrencyOf returns how many of a group's joined rows could have been in
+// flight together. A record that carries the Executor's effective P uses it,
+// bounded by the number of rows actually joined (a group missing rows cannot
+// have run more shards concurrently than it has). Anything else — a route-A
+// record, or a record predating a known P — folds as fully concurrent, which is
+// the identity for the single-row case and preserves the sum/max reading where
+// there is nothing better to say.
+func concurrencyOf(rec Record, rows int) int {
+	if rec.Parallelism > 0 && rec.Parallelism < rows {
+		return rec.Parallelism
+	}
+	return rows
+}
+
+// sumTopN sums the n largest values, the bound on what n concurrent shards hold
+// at once. It sorts a copy: the caller's slice order is the join order, which
+// other columns still read.
+func sumTopN(vals []uint64, n int) uint64 {
+	if n >= len(vals) {
+		var all uint64
+		for _, v := range vals {
+			all += v
+		}
+		return all
+	}
+	desc := slices.Clone(vals)
+	slices.Sort(desc)
+	var top uint64
+	for _, v := range desc[len(desc)-n:] {
+		top += v
+	}
+	return top
+}
+
+// makespanMS is the lower bound on how long p workers need to finish tasks
+// whose slowest takes slowest and whose durations total total: neither term can
+// be beaten, so the larger is the estimate. Division rounds up because a
+// truncated millisecond would report a makespan the work provably cannot fit
+// into. p is never below 1 for a non-empty group (concurrencyOf floors it at
+// the row count), so the division is safe.
+func makespanMS(slowest, total uint64, p int) uint64 {
+	if p < 1 {
+		return slowest
+	}
+	perWorker := (total + uint64(p) - 1) / uint64(p)
+	if perWorker > slowest {
+		return perWorker
+	}
+	return slowest
 }
 
 // exitSeverity ranks the terminal classes from least to most diagnostic, so a

--- a/internal/optcorpus/routed_test.go
+++ b/internal/optcorpus/routed_test.go
@@ -7,11 +7,17 @@ import (
 	"testing"
 )
 
-// observeRouted calls ObserveRoutedQuery with the routing read-out a real
-// routed dispatch always carries (route B, reason "routed"), keeping the call
-// sites below readable.
+// observeRoutedAtP calls ObserveRoutedQuery with the routing read-out a real
+// routed dispatch always carries (route B, reason "routed") at an explicit
+// effective shard concurrency, keeping the call sites below readable.
+func observeRoutedAtP(r *Reconciler, shardIDs []string, parallelism int, shapeID string, kShards uint8) {
+	r.ObserveRoutedQuery(shardIDs, parallelism, shapeID, nil, "promql", true, "B", 240, 4, 900, 3600, 15, kShards, "routed")
+}
+
+// observeRouted is observeRoutedAtP for the fully parallel fan-out, where every
+// shard overlaps every other and the cost fold is the plain sum/max.
 func observeRouted(r *Reconciler, shardIDs []string, shapeID string, kShards uint8) {
-	r.ObserveRoutedQuery(shardIDs, shapeID, nil, "promql", true, "B", 240, 4, 900, 3600, 15, kShards, "routed")
+	observeRoutedAtP(r, shardIDs, len(shardIDs), shapeID, kShards)
 }
 
 // TestObserveRoutedQuery_FoldsShardRowsIntoOneRow pins the whole point of the
@@ -60,10 +66,10 @@ func TestObserveRoutedQuery_FoldsShardRowsIntoOneRow(t *testing.T) {
 		t.Errorf("read_bytes = %d; want 6000 (sum across shards)", got.ReadBytes)
 	}
 	if got.MemoryUsage != 60 {
-		t.Errorf("memory_usage = %d; want 60 (sum of the concurrent shards' peaks)", got.MemoryUsage)
+		t.Errorf("memory_usage = %d; want 60 (all three peaks coexist at P=3)", got.MemoryUsage)
 	}
 	if got.QueryDurationMS != 70 {
-		t.Errorf("query_duration_ms = %d; want 70 (max: the shards run concurrently)", got.QueryDurationMS)
+		t.Errorf("query_duration_ms = %d; want 70 (150ms of work on 3 workers cannot beat the slowest shard)", got.QueryDurationMS)
 	}
 	if got.NormalizedQueryHash != 99 {
 		t.Errorf("normalized_query_hash = %d; want 99", got.NormalizedQueryHash)
@@ -83,6 +89,73 @@ func TestObserveRoutedQuery_FoldsShardRowsIntoOneRow(t *testing.T) {
 	// the next interval cannot emit a second row for the same dispatch.
 	if n := len(r.snapshotIDs()); n != 0 {
 		t.Errorf("join index still holds %d ids after the routed row was written; want 0", n)
+	}
+}
+
+// TestObserveRoutedQuery_ClampedConcurrencyFoldsTheWholeFanOut pins the fold
+// against the shape the Executor actually runs: K shards at an effective
+// concurrency P that is routinely BELOW K (the configured P, further clamped by
+// the admission top-up and the shard gate, down to sequential). Only P peaks
+// coexist and only P durations overlap, so the wall-clock and memory columns
+// are not the plain max and sum.
+//
+// Drop Record.Parallelism and fold as if the fan-out were fully parallel and
+// this fails on both columns at once: the three shards below take 150ms of
+// ClickHouse time that one worker cannot compress below 150ms, but a plain max
+// reports 70 — a route-B latency understated by more than half against the
+// route-A row it is compared with — while a plain sum reports memory three
+// shards never held at the same time.
+func TestObserveRoutedQuery_ClampedConcurrencyFoldsTheWholeFanOut(t *testing.T) {
+	type want struct {
+		memory   uint64
+		duration uint64
+	}
+	// 150ms of work and peaks of 10/20/30 across three shards. P=1 serialises
+	// them (sum the durations, only the largest peak is ever held); P=2 runs two
+	// waves (75ms beats the 70ms slowest shard, and the two largest peaks
+	// coexist); P=3 is the fully parallel case.
+	cases := map[int]want{
+		1: {memory: 30, duration: 150},
+		2: {memory: 50, duration: 75},
+		3: {memory: 60, duration: 70},
+	}
+	for p, w := range cases {
+		t.Run("P="+strconv.Itoa(p), func(t *testing.T) {
+			src := newFakeSource()
+			sink := &memSink{}
+			r := New(src, sink, Options{RingCapacity: 8, ObserveBuffer: 16})
+
+			ids := []string{
+				"trace-p" + strconv.Itoa(p) + "-1",
+				"trace-p" + strconv.Itoa(p) + "-2",
+				"trace-p" + strconv.Itoa(p) + "-3",
+			}
+			src.seed(SourceRow{QueryID: ids[0], ReadRows: 100, MemoryUsage: 10, QueryDurationMS: 30})
+			src.seed(SourceRow{QueryID: ids[1], ReadRows: 200, MemoryUsage: 20, QueryDurationMS: 70})
+			src.seed(SourceRow{QueryID: ids[2], ReadRows: 300, MemoryUsage: 30, QueryDurationMS: 50})
+
+			observeRoutedAtP(r, ids, p, "cerb:rangewindow", uint8(len(ids)))
+			r.drainIngest()
+			r.reconcileOnce(context.Background())
+
+			rows := sink.snapshot()
+			if len(rows) != 1 {
+				t.Fatalf("routed dispatch wrote %d rows; want exactly 1", len(rows))
+			}
+			got := rows[0]
+			if got.MemoryUsage != w.memory {
+				t.Errorf("memory_usage = %d; want %d (the %d largest peaks, the most that coexist)", got.MemoryUsage, w.memory, p)
+			}
+			if got.QueryDurationMS != w.duration {
+				t.Errorf("query_duration_ms = %d; want %d (150ms of work on %d workers, no faster than the slowest shard)",
+					got.QueryDurationMS, w.duration, p)
+			}
+			// The work columns are concurrency-independent: the fan-out reads
+			// what it reads however it is scheduled.
+			if got.ReadRows != 600 {
+				t.Errorf("read_rows = %d; want 600 regardless of concurrency", got.ReadRows)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Follow-up to #1402 — the first of the defects an adversarial review found in the merged router-corpus instrument.

## The defect

The route-B fold assumed all K shards run concurrently: `memory_usage` summed every shard
peak and `query_duration_ms` took the MAX.

The Executor's effective P is routinely **below** K — `defaultParallel` is 3, K reaches
`defaultMaxK` = 8, and it is clamped further by the admission top-up and the shard gate. So
the old fold **understates route-B latency and overstates its memory by roughly K/P**. Both
errors point the same way: they bias the calibration corpus against route B, which is the
route the corpus exists to evaluate.

## The fix

Plumb `ExecInfo.Parallelism` through the observer seam into `Record.Parallelism` and fold
with the principled bounds instead:

- **memory** — the sum of the **P largest** shard peaks (only P shards are ever resident together)
- **duration** — the makespan bound `max(slowest shard, total / P)`

Route A and any single-id record are unchanged: `p` collapses to the row count, where both
folds are the identity.

## Note on provenance

The fix was authored on `fix/router-corpus-observes-routed`, whose base predates #1402's
squash-merge, so a PR from that branch would have shown a doubled diff. This is the same
commit cherry-picked onto current `main`; the stale branch will be deleted once this merges.
Remaining defects from that review land separately.