### PR TITLE
test(engine): pin the route-B fixture's K and prove the language column is forwarded

### DIFF
--- a/internal/engine/routed_corpus_observe_test.go
+++ b/internal/engine/routed_corpus_observe_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/tsouza/cerberus/internal/chclient"
 	"github.com/tsouza/cerberus/internal/chplan"
 	"github.com/tsouza/cerberus/internal/solver"
+	"github.com/tsouza/cerberus/internal/telemetry"
 )
 
 // routedCorpusLang is a minimal Lang: the routed paths only read Name(), and
@@ -72,13 +73,21 @@ func (o *routedCorpusObserver) ObserveRoutedQuery(
 // row is filed under (a wrong one silos the row into a population no PromQL
 // calibration reads), the real K, and the executor's effective parallelism
 // (which the observer folds the wall-clock and memory columns at).
-func (o *routedCorpusObserver) assertRoutedRowIdentity(t *testing.T, i int, wantK uint8, wantParallel int) {
+//
+// wantLang is a parameter rather than a fixed solver.LangPromQL because a seam
+// that ignored its language argument and stamped every row with the PromQL head
+// would satisfy a hard-coded expectation. The seam that takes the language as a
+// free argument is exercised with a different head below, so the assertion
+// distinguishes "forwards what it was given" from "always says promql".
+func (o *routedCorpusObserver) assertRoutedRowIdentity(
+	t *testing.T, i int, wantLang string, wantK uint8, wantParallel int,
+) {
 	t.Helper()
 	o.mu.Lock()
 	defer o.mu.Unlock()
-	if o.routedLangs[i] != solver.LangPromQL {
+	if o.routedLangs[i] != wantLang {
 		t.Errorf("language = %q; want %q — the row must be filed under the head that ran it",
-			o.routedLangs[i], solver.LangPromQL)
+			o.routedLangs[i], wantLang)
 	}
 	if o.routedKShards[i] != wantK {
 		t.Errorf("k_shards = %d; want %d (the decision's real K)", o.routedKShards[i], wantK)
@@ -174,6 +183,15 @@ func wantParallelism(eng *Engine, d *solver.Decision) int {
 	return p
 }
 
+// fixtureShardCount is the K the eligible fixture plan slices into under
+// ModeSharded. Every K-shaped assertion below compares the observed column
+// against the decision's own len(Slices), which is the right question to ask of
+// the seam but says nothing about the fixture: were the planner to start
+// slicing this plan into a single shard, the whole route-B observation family
+// would still pass while testing no fan-out at all. Pinning the number here
+// turns that degeneration into a failure at the one place it originates.
+const fixtureShardCount = 8
+
 // routedDecision classifies the eligible fixture plan into the routed decision
 // the engine's own route-B paths take.
 func routedDecision(t *testing.T, eng *Engine, plan chplan.Node) *solver.Decision {
@@ -184,6 +202,10 @@ func routedDecision(t *testing.T, eng *Engine, plan chplan.Node) *solver.Decisio
 	}
 	if d.Reason != solver.ReasonRouted {
 		t.Fatalf("routed decision reason = %q, want %q", d.Reason, solver.ReasonRouted)
+	}
+	if len(d.Slices) != fixtureShardCount {
+		t.Fatalf("fixture sliced into K=%d; want K=%d — a route-B fan-out test needs a real fan-out",
+			len(d.Slices), fixtureShardCount)
 	}
 	return d
 }
@@ -263,7 +285,7 @@ func TestExecuteRoutedCursor_ObservesTheFanOut(t *testing.T) {
 	if obs.routedReasons[0] != solver.ReasonRouted {
 		t.Errorf("decision_reason = %q; want %q", obs.routedReasons[0], solver.ReasonRouted)
 	}
-	obs.assertRoutedRowIdentity(t, 0, clampU8(int64(len(d.Slices))), wantParallelism(eng, d))
+	obs.assertRoutedRowIdentity(t, 0, solver.LangPromQL, clampU8(int64(len(d.Slices))), wantParallelism(eng, d))
 	if obs.routedShapes[0] != planShapeID(plan) {
 		t.Errorf("shape_id = %q; want the WHOLE plan's %q, so route-A and route-B rows join",
 			obs.routedShapes[0], planShapeID(plan))
@@ -315,7 +337,7 @@ func TestExecuteRouted_ObservesTheFanOut(t *testing.T) {
 	if len(routed[0]) != len(d.Slices) {
 		t.Errorf("observed %d shard ids; want %d", len(routed[0]), len(d.Slices))
 	}
-	obs.assertRoutedRowIdentity(t, 0, clampU8(int64(len(d.Slices))), wantParallelism(eng, d))
+	obs.assertRoutedRowIdentity(t, 0, solver.LangPromQL, clampU8(int64(len(d.Slices))), wantParallelism(eng, d))
 }
 
 // TestBuildRoutedCursorResult_ObservesOnce pins the third route-B family: the
@@ -338,7 +360,12 @@ func TestBuildRoutedCursorResult_ObservesOnce(t *testing.T) {
 	}
 	defer func() { _ = cursor.Close() }()
 
-	cr := eng.buildRoutedCursorResult(Meta{IsMetric: true}, plan, solver.LangPromQL, d, cursor, info, "memo-hit")
+	// The language reaches this seam as a plain argument, so it is the one place
+	// that can prove the column carries what the caller passed rather than a
+	// stamped-in head name. Feed it a head the rest of this file never produces:
+	// the two engine-driven tests above can only ever be promql (classify reads
+	// the fixture Lang's own Name()), so a hard-coded "promql" would satisfy them.
+	cr := eng.buildRoutedCursorResult(Meta{IsMetric: true}, plan, telemetry.QLLogQL, d, cursor, info, "memo-hit")
 	if cr.Cursor == nil {
 		t.Fatal("buildRoutedCursorResult returned no cursor")
 	}
@@ -359,7 +386,7 @@ func TestBuildRoutedCursorResult_ObservesOnce(t *testing.T) {
 	// This site holds the ExecInfo the Executor actually produced, so it pins
 	// parallelism against the executor's own read-out rather than a recomputed
 	// expectation — the row must carry what the fan-out really ran at.
-	obs.assertRoutedRowIdentity(t, 0, clampU8(int64(len(d.Slices))), info.Parallelism)
+	obs.assertRoutedRowIdentity(t, 0, telemetry.QLLogQL, clampU8(int64(len(d.Slices))), info.Parallelism)
 	if info.Parallelism < 1 {
 		t.Fatalf("ExecInfo.Parallelism = %d; the fixture must exercise a real concurrency read-out", info.Parallelism)
 	}


### PR DESCRIPTION
Closes the last two open findings from the adversarial review of #1402 (the router-corpus instrument). The other four had already been fixed — two by #1408/#1410 as briefed, and two more (the `exitSeverity` order pin and the `defaultRingCapacity` memory bound) swept up incidentally by #1410; both are re-verified here rather than re-fixed.

## `k_shards` — the fixture's K was never pinned

Every route-B assertion compares the observed `k_shards` against the decision's own `len(d.Slices)`. That is the right question to ask of the *seam*, but it says nothing about the *fixture*: were the planner to start slicing `memoWiringEligiblePlan()` into a single shard, the whole route-B observation family would still pass while exercising no fan-out at all — the hollow-green shape this instrument exists to detect in production.

`routedDecision` now pins the fixture's K to `fixtureShardCount = 8` (the solver's structural `MaxK`), so the degeneration fails once, at the place it originates, instead of quietly emptying three tests.

## `language` — the assertion could not distinguish forwarded from hard-coded

`buildRoutedCursorResult` takes `language string` as a free argument and forwards it to `observeRoutedQuery`. The assertion expected `solver.LangPromQL` — exactly the value a seam that *ignored* its argument and stamped in the PromQL head would produce.

The two engine-driven seams can only ever be promql (`classify` reads the fixture `Lang`'s own `Name()`), so the free-argument site is the only one able to tell the two apart. It now passes `telemetry.QLLogQL` and asserts it arrives verbatim; `assertRoutedRowIdentity` takes `wantLang` as a parameter accordingly.

## Planted-regression evidence

Both fixes were proven to bite before shipping.

Swap `ExitOOM`/`ExitTimeout` in `exitSeverity` (defect 1, already fixed by #1410 — verified, not re-fixed):

```
optcorpus (1 passed, 1 failed)
  [FAIL] TestExitSeverityOrderIsPinned
     routed_test.go:329: exitSeverityOf("timeout") = 7; want rank 6
     routed_test.go:329: exitSeverityOf("oom") = 6; want rank 7
     routed_test.go:337: "timeout" must rank strictly below "oom"
```

The membership-only sibling `TestExitSeverityRanksEveryExitStatus` stayed green throughout — which is the review's original point, and why the order test exists alongside it rather than replacing it.

Set `fixtureShardCount = 7`:

```
[FAIL] TestExecuteRoutedCursor_ObservesTheFanOut
   routed_corpus_observe_test.go:222: fixture sliced into K=8; want K=7 — a route-B fan-out test needs a real fan-out
```

That output is also the empirical confirmation that the fixture's real K is 8.

Hard-code `solver.LangPromQL` at `buildRoutedCursorResult`'s observe call:

```
[FAIL] TestBuildRoutedCursorResult_ObservesOnce
   routed_corpus_observe_test.go:389: language = "promql"; want "logql" — the row must be filed under the head that ran it
```

All three plants were reverted; the diff is one test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)