### PR TITLE
fix(justfile): record the cardinality baseline after the golden rewrite

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -318,26 +318,38 @@ coverage:
 # recipe fails fast without it rather than leaving stale expected_rows
 # behind (the PR #758 failure mode).
 #
-# It first runs the two perf-assessment ratchet baselines as PRIOR
-# dependencies so a SINGLE `just update-golden` records every fixture-derived
-# artefact in one shot: the solver routing-DECISION baseline, the cardinality
-# fan-factor baseline, and the text/expected_rows goldens (this body). This
-# closes the recurring miss where a new TXTAR fixture regenerated its goldens
-# but left `cardinality-baseline.json` unrecorded, turning the non-required
+# It also chains the two perf-assessment ratchet baselines so a SINGLE
+# `just update-golden` records every fixture-derived artefact in one shot:
+# the solver routing-DECISION baseline, the text/expected_rows goldens (this
+# body), and the cardinality fan-factor baseline. This closes the recurring
+# miss where a new TXTAR fixture regenerated its goldens but left
+# `cardinality-baseline.json` unrecorded, turning the non-required
 # `perf-guards` TestCardinalityRatchet red on main after merge (hit by #1096
 # native_resample_offset and #1098 increase_left_edge_scan_bound).
 #
-# Why PRIOR deps, not subsequent (`&&`): the body's default-tag
-# `GOLDEN_UPDATE=1 go test ./...` lane runs TestSolverDecisionRatchet in
-# ASSERT mode, which fails on a brand-new fixture not yet in the routing
-# baseline — aborting before any subsequent dependency could record it.
-# Recording both baselines FIRST means the body's asserting lanes pass for
-# the new fixture. The baselines re-derive from each fixture's input query
-# (not the regenerated `-- sql --` / `-- expected_rows --` cells), so running
-# them before the golden rewrite is order-safe; all three are no-ops on a
-# corpus already in sync (zero diff).
+# The two baselines sit on OPPOSITE sides of the body, because they read
+# opposite ends of a fixture:
+#
+# - `update-solver-decision-baseline` is a PRIOR dep. It re-derives every
+#   decision from the fixture's `-- query.promql --` INPUT (parse -> lower ->
+#   optimize -> classify), so the golden rewrite cannot change what it
+#   records. It must run FIRST because the body's default-tag
+#   `GOLDEN_UPDATE=1 go test ./...` lane runs TestSolverDecisionRatchet in
+#   ASSERT mode, which fails on a brand-new fixture not yet in the routing
+#   baseline — aborting before the body could finish.
+# - `update-cardinality-baseline` is a SUBSEQUENT dep (`&&`). It profiles the
+#   fixture's RECORDED `-- sql --` section verbatim: spec.PrepareRoundTrip
+#   rewrites that literal text and hands it to profile.ProfileFixture. Run
+#   BEFORE the body it profiles the very SQL this recipe is about to
+#   overwrite — and on a brand-new fixture `-- sql --` is still EMPTY, so
+#   PrepareRoundTrip returns ok=false, the fixture is not discovered as
+#   executable at all, and the row the chaining exists to record is silently
+#   skipped. It must run AFTER, which is safe: the body's chdb-tagged
+#   asserting lane scopes to ./test/spec/..., never ./test/perf/.
+#
+# All three are no-ops on a corpus already in sync (zero diff).
 # Review `git diff test/spec/ test/perf/*-baseline.json` before committing.
-update-golden: update-solver-decision-baseline update-cardinality-baseline
+update-golden: update-solver-decision-baseline && update-cardinality-baseline
     @test -f "{{CHDB_INSTALL_PATH}}" || { echo "error: {{CHDB_INSTALL_PATH}} not found — run 'just chdb-install' first; without it the chdb-tagged -- expected_rows -- sections (and the cardinality baseline) cannot regenerate and go stale" >&2; exit 1; }
     GOLDEN_UPDATE=1 go test ./...
     GOLDEN_UPDATE=1 go test -tags chdb -count=1 ./test/spec/...

--- a/test/regression/update_golden_baseline_order_test.go
+++ b/test/regression/update_golden_baseline_order_test.go
@@ -1,0 +1,145 @@
+package regression
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// justfilePath is the canonical task runner; `update-golden` lives here.
+const justfilePath = "../../Justfile"
+
+// prepareRoundTripPath holds the seam that decides WHICH SQL the cardinality
+// profiler measures. It is the reason the recipe ordering below is not free.
+const prepareRoundTripPath = "../../test/spec/prepare_chdb.go"
+
+// updateGoldenRecipePrefix opens the recipe header whose dependency shape this
+// file pins. Matched at column 0 so the prose above it cannot satisfy the pin.
+const updateGoldenRecipePrefix = "update-golden:"
+
+// solverBaselineRecipe re-derives its rows from each fixture's
+// `-- query.promql --` input, so the golden rewrite cannot change what it
+// records; it must run BEFORE the body, which asserts it.
+const solverBaselineRecipe = "update-solver-decision-baseline"
+
+// cardinalityBaselineRecipe profiles each fixture's RECORDED `-- sql --`
+// section, so it must run AFTER the body rewrites that section.
+const cardinalityBaselineRecipe = "update-cardinality-baseline"
+
+// subsequentDepSeparator is just's marker for dependencies that run after the
+// recipe body instead of before it.
+const subsequentDepSeparator = "&&"
+
+// recordedSQLField is the field spec.PrepareRoundTrip reads to build the query
+// the profiler measures: the fixture's recorded `-- sql --` section, verbatim.
+const recordedSQLField = "rt.SQL"
+
+// emptySQLGate is the guard that makes a fixture with an unfilled `-- sql --`
+// section invisible to the profiler entirely.
+const emptySQLGate = `strings.TrimSpace(rt.SQL) == ""`
+
+// TestUpdateGoldenRecordsCardinalityBaselineAfterRewrite pins the side of the
+// body each ratchet baseline runs on.
+//
+// `just update-golden` rewrites every fixture's `-- sql --` section. The
+// cardinality baseline does NOT re-lower `-- input --`; it profiles the
+// recorded `-- sql --` text — spec.PrepareRoundTrip reads rt.SQL, rewrites it,
+// and profile.ProfileFixture measures exactly that. So recording the baseline
+// before the rewrite profiles SQL the same invocation is about to replace, and
+// pins a fan factor for a query shape that no longer exists.
+//
+// The brand-new-fixture case is worse than stale: a new fixture's `-- sql --`
+// is empty until the body fills it, PrepareRoundTrip returns ok=false on an
+// empty section, and profile.FindExecutableFixtures therefore never sees the
+// fixture at all. Its row is silently skipped — which is precisely the miss
+// (#1096, #1098: unrecorded fixture, red `perf-guards` on main after merge)
+// that chaining the baseline into `update-golden` was added to close. Running
+// it first leaves the feature inert for its own primary use case, and inert
+// looks identical to working: the recipe exits 0 and prints an empty diff.
+//
+// The solver-decision baseline is the mirror image and must stay a PRIOR dep:
+// it re-derives from the `-- query.promql --` input, and the body's default-tag
+// lane runs TestSolverDecisionRatchet in ASSERT mode, which fails on a fixture
+// not yet in the routing baseline. Satisfying both is why just's `&&`
+// subsequent-dependency form is used rather than moving everything one way.
+func TestUpdateGoldenRecordsCardinalityBaselineAfterRewrite(t *testing.T) {
+	t.Parallel()
+
+	buf, err := os.ReadFile(justfilePath)
+	if err != nil {
+		t.Fatalf("read %s: %v", justfilePath, err)
+	}
+
+	var recipeLine string
+	for _, line := range strings.Split(string(buf), "\n") {
+		if strings.HasPrefix(line, updateGoldenRecipePrefix) {
+			recipeLine = line
+
+			break
+		}
+	}
+	if recipeLine == "" {
+		t.Fatalf("%s has no %q recipe header at column 0; this pin cannot see the dependency "+
+			"shape. If the recipe was renamed, re-point this test at the new name rather than "+
+			"deleting it.", justfilePath, updateGoldenRecipePrefix)
+	}
+
+	deps := strings.TrimPrefix(recipeLine, updateGoldenRecipePrefix)
+	prior, subsequent, split := strings.Cut(deps, subsequentDepSeparator)
+	if !split {
+		t.Fatalf("%s: %q has no %q separator, so every dependency runs BEFORE the body. %s "+
+			"profiles each fixture's recorded `-- sql --` section, which this recipe's body "+
+			"rewrites — and on a brand-new fixture that section is still empty, so the fixture is "+
+			"not even discovered and its row is never recorded. Make it a subsequent dependency: "+
+			"`%s %s %s %s`.",
+			justfilePath, strings.TrimSpace(recipeLine), subsequentDepSeparator,
+			cardinalityBaselineRecipe, updateGoldenRecipePrefix, solverBaselineRecipe,
+			subsequentDepSeparator, cardinalityBaselineRecipe)
+	}
+
+	if !strings.Contains(subsequent, cardinalityBaselineRecipe) {
+		t.Errorf("%s: %q does not run AFTER the body (not found among the %q dependencies %q). "+
+			"It profiles the recorded `-- sql --` section that the body rewrites, so running it "+
+			"first records a fan factor for SQL that no longer exists — and skips a brand-new "+
+			"fixture entirely, because its `-- sql --` is still empty at that point.",
+			justfilePath, cardinalityBaselineRecipe, subsequentDepSeparator,
+			strings.TrimSpace(subsequent))
+	}
+	if strings.Contains(prior, cardinalityBaselineRecipe) {
+		t.Errorf("%s: %q is still a PRIOR dependency (%q). Recording the cardinality baseline "+
+			"before the golden rewrite is the bug this test exists to prevent; it must appear "+
+			"only after %q.",
+			justfilePath, cardinalityBaselineRecipe, strings.TrimSpace(prior),
+			subsequentDepSeparator)
+	}
+
+	if !strings.Contains(prior, solverBaselineRecipe) {
+		t.Errorf("%s: %q does not run BEFORE the body (prior dependencies are %q). The body's "+
+			"default-tag lane runs TestSolverDecisionRatchet in ASSERT mode, which fails on a "+
+			"brand-new fixture absent from the routing baseline and aborts the whole recipe.",
+			justfilePath, solverBaselineRecipe, strings.TrimSpace(prior))
+	}
+
+	// Pin the provenance the ordering rests on, alongside the ordering itself.
+	// If the profiler is ever changed to re-lower `-- input --` instead of
+	// reading the recorded SQL, the constraint above dissolves and the comment
+	// block in the Justfile becomes false — this is what makes that visible
+	// instead of leaving a stale rationale behind.
+	prep, err := os.ReadFile(prepareRoundTripPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", prepareRoundTripPath, err)
+	}
+	body := string(prep)
+	if !strings.Contains(body, recordedSQLField) {
+		t.Errorf("%s no longer builds the profiled query from %s (the fixture's recorded "+
+			"`-- sql --` section). If it now re-derives from `-- input --`, the ordering pinned "+
+			"above is no longer required — re-derive it deliberately and update the Justfile "+
+			"rationale rather than leaving a stale explanation in place.",
+			prepareRoundTripPath, recordedSQLField)
+	}
+	if !strings.Contains(body, emptySQLGate) {
+		t.Errorf("%s no longer gates on %s. That guard is why a brand-new fixture is invisible "+
+			"to the cardinality profiler until the golden rewrite fills its `-- sql --` section; "+
+			"the recipe ordering above depends on it.", prepareRoundTripPath, emptySQLGate)
+	}
+}


### PR DESCRIPTION
## The bug

`Justfile:340` declared `update-golden: update-solver-decision-baseline update-cardinality-baseline`. `just` runs dependencies **before** the body, and the body (`Justfile:342-343`) is what rewrites every fixture's `-- sql --` section via `GOLDEN_UPDATE=1 go test`.

The cardinality baseline does **not** re-lower `-- input --`. It profiles the recorded SQL verbatim:

- `test/spec/prepare_chdb.go:88` — `substituteNow64(rt.SQL, rt.Args)`, where `rt.SQL` is the fixture's recorded `-- sql --` section.
- `test/perf/profile/profile.go:249` — `inlineArgs(prep.Query, prep.Args)` feeds that literal SQL to the profiler.

So every `just update-golden` profiled SQL the same invocation was about to overwrite, pinning a fan factor for a query shape that no longer existed.

## The sharper consequence: the chaining was inert for its own use case

`update-cardinality-baseline` was chained into `update-golden` to close a specific recurring miss — a new TXTAR fixture regenerates its goldens but leaves `cardinality-baseline.json` unrecorded, turning `perf-guards` `TestCardinalityRatchet` red on main after merge (#1096 `native_resample_offset`, #1098 `increase_left_edge_scan_bound`).

Running it **first** does not close that miss. On a brand-new fixture `-- sql --` is still empty when the baseline runs, so:

1. `PrepareRoundTrip` returns `ok=false` on the empty-section gate (`prepare_chdb.go:73`),
2. `profile.FindExecutableFixtures` (`test/perf/profile/corpus.go:41`) therefore never discovers the fixture,
3. its row is silently skipped.

The recipe exits 0 and prints an empty diff — inert is indistinguishable from working.

## The constraint that had to hold

The prior-dep ordering existed for a real reason (`Justfile:330-333`): the body's default-tag `GOLDEN_UPDATE=1 go test ./...` lane runs `TestSolverDecisionRatchet` in ASSERT mode, which fails on a brand-new fixture absent from the routing baseline and aborts the recipe.

I verified the other half of the comment rather than trusting it: the solver-decision ratchet reads `c.Section("query.promql")` (`solver_decision_ratchet_test.go:217`), parses with the reference Prometheus parser, lowers, optimizes and classifies — it genuinely **is** input-derived, so the golden rewrite cannot change what it records.

Both orderings are satisfied with just's `&&` subsequent-dependency form:

```
update-golden: update-solver-decision-baseline && update-cardinality-baseline
```

`just --dry-run update-golden` confirms the emitted order: solver baseline -> golden rewrite body -> cardinality baseline. Running the cardinality baseline after the body is safe — the body's chdb-tagged lane scopes to `./test/spec/...`, never `./test/perf/`.

## The false comment

`Justfile:335-336` claimed both baselines "re-derive from each fixture's input query (not the regenerated `-- sql --` / `-- expected_rows --` cells), so running before the golden rewrite is order-safe." True for the solver baseline, false for the cardinality one. That false half is why the ordering looked safe. The block is rewritten to state the split and the reason for each side.

## The pin

`test/regression/update_golden_baseline_order_test.go` (matching the existing justfile-shape pin style in `test/regression/`) asserts:

- `update-solver-decision-baseline` is a prior dependency,
- `update-cardinality-baseline` appears only after `&&`,
- and the provenance the ordering rests on — `prepare_chdb.go`'s `rt.SQL` read and its empty-section gate — so the Justfile rationale cannot go stale silently.

Verified **red** against the unfixed Justfile (`update_golden_baseline_order_test.go:90`, the missing-`&&` fatal), **green** after.

## CI

No change needed. No workflow and no `.github/scripts/*.mjs` invokes these regeneration recipes or replicates the ordering — `perf-guards` (`chdb.yml:289`) runs only the asserting side. `docs/test-strategy.md`'s claim that adding a TXTAR fixture "records its ratchet entry in the same pass that fills the goldens" was false before this change and is true after it, so it needs no edit.

Task #95.

🤖 Generated with [Claude Code](https://claude.com/claude-code)