### PR TITLE
fix(engine): stamp routed drain outcomes

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -1051,11 +1051,12 @@ type CursorResult struct {
 	PlanNodeCount int
 	Headers       map[string]string
 	Meta          Meta
-	// QueryID is the per-dispatch ClickHouse query_id fixed for this cursor's
-	// dispatch (the corpus join key). The handler that drains the cursor passes
-	// it back to ObserveDrainOutcome so a sample-budget 422 surfacing during
-	// the drain is stamped onto the same corpus record. Empty when the dispatch
-	// carried no trace id (un-instrumented caller) or when the corpus is off.
+	// QueryID is this cursor's corpus-record key. It is the dispatch query_id
+	// for route A and one shard query_id for route B; the reconciler indexes all
+	// of a routed query's shard ids onto its one logical record. The handler
+	// passes it to ObserveDrainOutcome so a sample-budget 422 surfacing during
+	// the drain is stamped onto that record. Empty when the dispatch carried no
+	// trace id (un-instrumented caller) or when the corpus is off.
 	QueryID string
 
 	// Retry is the failure-driven route memo's A->B retry hook (docs
@@ -1348,7 +1349,23 @@ func (e *Engine) buildRoutedCursorResult(
 		PlanNodeCount: nodes,
 		Headers:       headers,
 		Meta:          meta,
+		QueryID:       routedQueryID(info),
 	}
+}
+
+// routedQueryID selects a shard join key for a logical route-B record. The
+// reconciler indexes every shard id onto that one record, so one non-empty id
+// is sufficient to stamp a terminal drain outcome onto the whole fan-out.
+func routedQueryID(info *solver.ExecInfo) string {
+	if info == nil {
+		return ""
+	}
+	for _, id := range info.ShardQueryIDs {
+		if id != "" {
+			return id
+		}
+	}
+	return ""
 }
 
 // ObserveDrainOutcome stamps a CERBERUS-side terminal outcome that surfaced
@@ -1442,5 +1459,6 @@ func (e *Engine) executeRoutedCursor(
 		PlanNodeCount: nodes,
 		Headers:       headers,
 		Meta:          meta,
+		QueryID:       routedQueryID(info),
 	}, nil
 }

--- a/internal/engine/routed_corpus_observe_test.go
+++ b/internal/engine/routed_corpus_observe_test.go
@@ -41,6 +41,7 @@ type routedCorpusObserver struct {
 	routedRoutes   []string
 	routedReasons  []string
 	routedKShards  []uint8
+	outcomes       [][2]string
 }
 
 func (o *routedCorpusObserver) ObserveQuery(
@@ -97,7 +98,11 @@ func (o *routedCorpusObserver) assertRoutedRowIdentity(
 	}
 }
 
-func (o *routedCorpusObserver) ObserveOutcome(string, string) {}
+func (o *routedCorpusObserver) ObserveOutcome(queryID, statusToken string) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.outcomes = append(o.outcomes, [2]string{queryID, statusToken})
+}
 
 func (o *routedCorpusObserver) ObserveRejection(
 	string, []string, string, string, bool, string, uint32, uint32, uint32, uint32, uint32, uint8, string,
@@ -303,6 +308,55 @@ func TestExecuteRoutedCursor_ObservesTheFanOut(t *testing.T) {
 		t.Errorf("observed parallelism %d >= %d shards; the fixture exists because P below K is the routine shape",
 			obs.routedParallel[0], len(ids))
 	}
+}
+
+// TestExecuteRoutedCursor_DrainOutcomeUsesLogicalRouteBRecord pins the cursor
+// drain seam: a route-B CursorResult exposes one of its shard ids, and that id
+// addresses the one logical record ObserveRoutedQuery already created.
+func TestExecuteRoutedCursor_DrainOutcomeUsesLogicalRouteBRecord(t *testing.T) {
+	t.Parallel()
+
+	cq := &idCapturingCursorClient{rows: 1}
+	obs := &routedCorpusObserver{}
+	eng := newRoutedCorpusEngine(t, cq, obs)
+	plan := memoWiringEligiblePlan()
+	d := routedDecision(t, eng, plan)
+
+	cr, err := eng.executeRoutedCursor(routedCorpusTraceCtx(), routedCorpusLang{}, Meta{IsMetric: true}, plan, d)
+	if err != nil {
+		t.Fatalf("executeRoutedCursor: %v", err)
+	}
+	defer func() { _ = cr.Cursor.Close() }()
+
+	_, routed := obs.snapshot()
+	if len(routed) != 1 {
+		t.Fatalf("routed observations = %d; want 1", len(routed))
+	}
+	if cr.QueryID == "" {
+		t.Fatal("routed cursor QueryID is empty; drain outcomes cannot reach the logical route-B record")
+	}
+	if !containsID(routed[0], cr.QueryID) {
+		t.Fatalf("routed cursor QueryID %q is not one of the logical record's shard ids %v", cr.QueryID, routed[0])
+	}
+
+	eng.ObserveDrainOutcome(cr.QueryID, solver.LangPromQL, chclient.ErrTooManySamples)
+	obs.mu.Lock()
+	defer obs.mu.Unlock()
+	if len(obs.outcomes) != 1 {
+		t.Fatalf("drain outcomes = %d; want 1", len(obs.outcomes))
+	}
+	if got := obs.outcomes[0]; got != [2]string{cr.QueryID, optcorpusExitSampleBudget} {
+		t.Errorf("drain outcome = %v; want [%q %q]", got, cr.QueryID, optcorpusExitSampleBudget)
+	}
+}
+
+func containsID(ids []string, want string) bool {
+	for _, id := range ids {
+		if id == want {
+			return true
+		}
+	}
+	return false
 }
 
 // TestExecuteRouted_ObservesTheFanOut pins the same contract on the eager


### PR DESCRIPTION
## Summary
- retain a routed cursor shard query ID as the logical route-B corpus record key
- let handler drain outcomes, including sample-budget failures, stamp the existing routed record
- cover routed drain outcome keying without changing route-A behavior

## Validation
- pre-commit: gofumpt and goimports
- commit-msg: commitlint
- pre-push: golangci-lint, actionlint, markdownlint, commitlint range, and discipline checks