### PR TITLE
ci: retry image builds on transient Docker Hub registry faults

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -28,6 +28,16 @@ universe, from `PLAYWRIGHT_DIR`) and `collectShardCoverageViolations()`
 (unassigned / double-assigned / phantom / stale-exclude / bad-shard-name).
 One implementation means a new rule guards BOTH lanes at once.
 
+`lib/registry.mjs` owns the one retry policy every container-registry fetch
+follows — the attempt budget (`registryAttempts`), the linear backoff
+(`readBackoffStepSeconds` / `sleepSeconds`), and `isTransientRegistryFailure()`,
+which decides whether command output names a registry / network fault (Docker
+Hub 429, manifest HEAD failure, TLS / reset / DNS / module-proxy transport) or a
+genuine build error. `pull-buildkit-image.mjs` (host-side bootstrap pull) and
+`build-with-registry-retry.mjs` (the build's own `FROM` resolution) hit the same
+rate-limit bucket and fail the same way, so they share the policy instead of
+re-deriving it.
+
 `lib/scope-gate.mjs` answers "does THIS pull request touch the scope a heavy
 lane guards?" — `runsFullLane()` (which events must never take a scoped
 subset), `changedPaths()` (the PR's own diff against its merge base, or `null`
@@ -936,6 +946,28 @@ uncomputable-diff fallback — cannot drift between the lanes that use it.
     `BUILDKIT_PULL_BACKOFF_SECONDS` (optional; default `3` — linear backoff
     step, attempt N sleeps N × this).
   - Exit: `0` when the image is in the local daemon, `1` when it is not.
+- **`build-with-registry-retry.mjs`** — the Justfile (`e2e-up`, `e2e-bwc-up`,
+  `migration-cerberus-image`, `migration-tier{1,2}-up`), `e2e.yml`'s
+  compose-smoke shards, the three `compatibility/*/scripts/run-*.sh` harnesses,
+  and `bench/histogram/run.sh`. Runs an image-building command (`docker build` /
+  `docker compose up|build`), retrying it when — and only when — its output
+  names a registry or network fault. It exists because a build's BASE images are
+  resolved by BuildKit *during* the build, so no host-side pre-pull protects
+  them: a Docker Hub 429 on `golang:1.26` (the `FROM` of `Dockerfile.local`)
+  failed `e2e` and `migration-e2e` on main with `unexpected status from HEAD
+  request … 429 Too Many Requests`. The retry wraps the command rather than
+  pre-pulling the ref because the built-in `docker` driver resolves `FROM` from
+  the daemon's image store while the `docker-container` driver
+  (`.github/actions/setup-buildx`) never does — a pre-pull would protect some
+  lanes and silently protect nothing in the rest. Unlike the bootstrap pull
+  there is no local-image fallback: a tag an earlier run left in the daemon
+  attests nothing about this tree, and a build failure that is not a registry
+  failure fails on the FIRST attempt so a real break is never retried into
+  invisibility. Takes the command as its trailing argv.
+  - Env: `IMAGE_BUILD_RETRY_BACKOFF_SECONDS` (optional; default `10` — linear
+    backoff step, attempt N sleeps N × this).
+  - Exit: `0` on success; the command's own status when it failed for a
+    non-registry reason; `1` when the retry budget is spent.
 
 ## Notes
 

--- a/.github/scripts/build-with-registry-retry.mjs
+++ b/.github/scripts/build-with-registry-retry.mjs
@@ -1,0 +1,150 @@
+// build-with-registry-retry.mjs — run an image-building command, and retry it
+// when (and only when) it failed because a registry did, not because the build
+// did.
+//
+// The failure this closes, on main @ d939e299 (runs 30695961421 `e2e` and
+// 30695961427 `migration-e2e`, identical signature):
+//
+//   #5 ERROR: unexpected status from HEAD request to
+//      https://registry-1.docker.io/v2/library/golang/manifests/1.26:
+//      429 Too Many Requests
+//
+// `golang:1.26` is the `FROM` of Dockerfile.local — the base image BuildKit
+// resolves while running the build. Every lane that builds a cerberus image
+// (e2e / dashboard, migration-e2e, compose-smoke, the three compatibility
+// harnesses) resolves it, so one Docker Hub rate-limit burst takes all of them
+// down at once, including two release gates.
+//
+// WHY THE RETRY WRAPS THE BUILD, not a pre-pull. The obvious mirror of
+// `pull-buildkit-image.mjs` — `docker pull golang:1.26` on the host first —
+// only works when the builder can read the host daemon's image store, which
+// depends on the driver the lane happens to use: the built-in `docker` driver
+// (migration-e2e, the k3d lanes) does consult it, but the `docker-container`
+// driver that `.github/actions/setup-buildx` installs (compatibility, release)
+// runs BuildKit inside a container with its own content store and resolves
+// `FROM` from the registry regardless. A host pre-pull would therefore protect
+// some lanes and silently protect nothing in the others — the same "warms an
+// image nothing uses" hazard the setup-buildx composite calls out. Wrapping the
+// build works for every driver, and needs no knowledge of which base image refs
+// the Dockerfile names, so the retry and the build cannot drift apart.
+//
+// There is deliberately NO local-image fallback here, unlike the bootstrap
+// pull's "already present in the daemon is a pass". That postcondition is
+// correct for a pull (a present image IS the artefact wanted) and wrong for a
+// build: a tag left in the daemon by an earlier run attests nothing about this
+// tree, so accepting it would be exactly the swallowed build failure this
+// module exists not to be.
+//
+// Usage — the command to run is the trailing argv:
+//   node .github/scripts/build-with-registry-retry.mjs docker build -f Dockerfile.local -t cerberus:e2e .
+//   node .github/scripts/build-with-registry-retry.mjs docker compose up --wait --wait-timeout 300
+//
+// Env:
+//   IMAGE_BUILD_RETRY_BACKOFF_SECONDS  (optional; default 10) linear backoff
+//                                      step — attempt N sleeps N × this many
+//                                      seconds.
+//
+// Exit: 0 on success; the command's own status when it failed for a reason
+// that is not a registry / network fault (a real build error fails on the first
+// attempt, unretried); 1 when the retry budget is spent on transient failures.
+
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import process from 'node:process';
+
+import { error, log, notice } from './lib/gh.mjs';
+import {
+  isTransientRegistryFailure,
+  readBackoffStepSeconds,
+  registryAttempts,
+  sleepSeconds,
+} from './lib/registry.mjs';
+
+// A Docker Hub 429 is a burst window measured in tens of seconds, not the
+// couple of seconds a reset connection needs, so the build wrapper waits
+// longer per attempt than the bootstrap pull does.
+const defaultBackoffStepSeconds = 10;
+
+// spawnSync reports a signalled child as status null.
+const signalledChildStatus = 1;
+// Conventional shell status for "command could not be executed at all".
+const notExecutableStatus = 127;
+
+function shellQuote(word) {
+  return `'${String(word).replaceAll("'", "'\\''")}'`;
+}
+
+// runTeed — run argv with the parent's stdio, while also capturing everything
+// it wrote. Both halves matter: a container build streams its only progress
+// output for minutes, so swallowing it until the command returns would make a
+// stuck build unreadable, and the retry decision needs the text. `tee` through
+// bash with pipefail is what gives both plus the command's own exit status.
+function runTeed(argv, logPath) {
+  const script = `set -o pipefail; ${argv.map(shellQuote).join(' ')} 2>&1 | tee ${shellQuote(logPath)}`;
+  const res = spawnSync('bash', ['-c', script], { stdio: 'inherit' });
+
+  if (res.error) {
+    return { status: notExecutableStatus, output: String(res.error.message) };
+  }
+
+  let output = '';
+  try {
+    output = readFileSync(logPath, 'utf8');
+  } catch {
+    // No log file means the pipeline never started; the status still stands.
+  }
+  return { status: res.status === null ? signalledChildStatus : res.status, output };
+}
+
+const command = process.argv.slice(2);
+if (command.length === 0) {
+  error(
+    'build-with-registry-retry.mjs takes the image-building command as its trailing arguments, e.g. ' +
+      '`node .github/scripts/build-with-registry-retry.mjs docker build -f Dockerfile.local -t cerberus:e2e .`',
+  );
+  process.exit(1);
+}
+
+const backoffStepSeconds = readBackoffStepSeconds('IMAGE_BUILD_RETRY_BACKOFF_SECONDS', defaultBackoffStepSeconds);
+const rendered = command.join(' ');
+
+const scratchDir = mkdtempSync(join(tmpdir(), 'cerberus-build-retry-'));
+const logPath = join(scratchDir, 'build.log');
+
+function finish(code) {
+  rmSync(scratchDir, { recursive: true, force: true });
+  process.exit(code);
+}
+
+for (let attempt = 1; attempt <= registryAttempts; attempt++) {
+  log(`==> ${rendered} (attempt ${attempt}/${registryAttempts})`);
+  const { status, output } = runTeed(command, logPath);
+
+  if (status === 0) finish(0);
+
+  if (!isTransientRegistryFailure(output)) {
+    error(
+      `\`${rendered}\` failed with status ${status}, and its output names no registry or network fault. ` +
+        'Failing on the first attempt: retrying a genuine build failure only hides it.',
+    );
+    finish(status);
+  }
+
+  if (attempt < registryAttempts) {
+    const waitSeconds = attempt * backoffStepSeconds;
+    notice(
+      `\`${rendered}\` failed on a transient registry/network fault (attempt ${attempt}/${registryAttempts}); ` +
+        `retrying in ${waitSeconds}s.`,
+    );
+    sleepSeconds(waitSeconds);
+  }
+}
+
+error(
+  `\`${rendered}\` failed ${registryAttempts} times, every one of them on a transient registry or network ` +
+    'fault. The registry is not answering for this runner — failing the job rather than reporting a build ' +
+    'that never happened.',
+);
+finish(1);

--- a/.github/scripts/lib/registry.mjs
+++ b/.github/scripts/lib/registry.mjs
@@ -1,0 +1,97 @@
+// registry.mjs — the one retry policy cerberus applies to every container
+// registry fetch its CI performs.
+//
+// Two different fetches, one policy. The BuildKit *bootstrap* image is pulled
+// by the host daemon before buildx boots a builder from it
+// (`pull-buildkit-image.mjs`); the *base* images an image build names in `FROM`
+// are resolved by BuildKit itself, inside the build
+// (`build-with-registry-retry.mjs`). Docker Hub answers both out of the same
+// rate-limit bucket and fails both the same way, so the attempt budget, the
+// linear backoff, and the "is this failure worth another attempt" question
+// belong in one module rather than being re-derived per call site.
+//
+// Exports:
+//   registryAttempts                       attempts an acquisition gets.
+//   readBackoffStepSeconds(env, fallback)  validated linear backoff step.
+//   sleepSeconds(seconds)                  synchronous sleep.
+//   isTransientRegistryFailure(text)       true when command output names a
+//                                          registry / network fault rather
+//                                          than a genuine build error.
+
+import process from 'node:process';
+
+import { error } from './gh.mjs';
+
+// Five attempts with a linear backoff: long enough to ride out a registry blip
+// or a Docker Hub 429 burst, short enough that a genuinely unreachable registry
+// fails the job rather than parking it. Mirrors the Justfile's `_pull-retry`.
+export const registryAttempts = 5;
+
+const msPerSecond = 1_000;
+
+// Synchronous sleep: the callers are linear sequences of spawnSync calls, so
+// there is no event loop to yield to.
+export function sleepSeconds(seconds) {
+  if (seconds <= 0) return;
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, seconds * msPerSecond);
+}
+
+// readBackoffStepSeconds — read a linear backoff step out of the environment,
+// falling back when the variable is unset or blank. Attempt N sleeps N × the
+// step. Exits non-zero on a value that isn't a non-negative number, because a
+// silently-coerced backoff is a retry loop that no longer waits.
+export function readBackoffStepSeconds(envName, fallbackSeconds) {
+  const raw = process.env[envName];
+  if (raw === undefined || raw.trim() === '') return fallbackSeconds;
+
+  const seconds = Number(raw);
+  if (!Number.isFinite(seconds) || seconds < 0) {
+    error(`${envName} must be a non-negative number, got ${raw}`);
+    process.exit(1);
+  }
+  return seconds;
+}
+
+// The failure signatures that mean "the registry / network said no", as
+// distinct from "the build said no". Every entry is a fault in fetching bytes
+// over the wire, never a compiler, linker, test or Dockerfile error — that
+// distinction is what lets a caller retry on this list and fail immediately off
+// it, instead of retrying (and so hiding) a real build failure.
+//
+// The 429 that took `e2e` + `migration-e2e` down on main lands in the first two
+// entries:
+//
+//   #5 ERROR: unexpected status from HEAD request to
+//      https://registry-1.docker.io/v2/library/golang/manifests/1.26:
+//      429 Too Many Requests
+const transientRegistryFailurePatterns = [
+  // Docker Hub rate limiting, in both the HTTP-status and the error-code form.
+  /429 Too Many Requests/i,
+  /\btoomanyrequests\b/i,
+  // BuildKit / containerd manifest + blob resolution against a registry that
+  // answered with something other than the content.
+  /unexpected status from (?:HEAD|GET|POST) request/i,
+  /error pulling image configuration/i,
+  /failed to copy: httpReadSeeker/i,
+  /failed to do request/i,
+  // Registry-side 5xx: the fetch is retryable by definition.
+  /\b5\d\d (?:Bad Gateway|Service Unavailable|Internal Server Error|Gateway Time-?out)\b/i,
+  // Transport faults on the way to a registry or a module proxy. `go mod
+  // download` inside a build stage fails the same way against proxy.golang.org.
+  /TLS handshake timeout/i,
+  /connection reset by peer/i,
+  /\bi\/o timeout\b/i,
+  /context deadline exceeded/i,
+  /net\/http: request canceled/i,
+  /http2: (?:server sent GOAWAY|stream error)/i,
+  /INTERNAL_ERROR; received from peer/i,
+  // DNS.
+  /temporary failure in name resolution/i,
+  /no such host/i,
+  /server misbehaving/i,
+];
+
+export function isTransientRegistryFailure(text) {
+  const haystack = String(text ?? '');
+  return transientRegistryFailurePatterns.some((re) => re.test(haystack));
+}

--- a/.github/scripts/pull-buildkit-image.mjs
+++ b/.github/scripts/pull-buildkit-image.mjs
@@ -18,6 +18,11 @@
 // successful pull: an exhausted retry over an image the runner already holds
 // is a pass, because that is precisely the state buildx falls back to.
 //
+// The attempt budget, the backoff and the transient-failure vocabulary are
+// shared with the image-build wrapper via ./lib/registry.mjs — the bootstrap
+// pull and a build's `FROM` resolution hit the same registry and fail the same
+// way, so they retry to the same policy.
+//
 // Env:
 //   BUILDKIT_IMAGE                 (required) image ref to acquire, e.g.
 //                                  `moby/buildkit:buildx-stable-1`. Must be
@@ -32,20 +37,12 @@
 import process from 'node:process';
 
 import { capture, error, log, notice } from './lib/gh.mjs';
+import { readBackoffStepSeconds, registryAttempts, sleepSeconds } from './lib/registry.mjs';
 
-// Five attempts with a linear backoff, matching the Justfile's `_pull-retry`:
-// long enough to ride out a registry blip, short enough that a genuinely
-// unreachable registry fails the job in under a minute.
-const pullAttempts = 5;
+// A bootstrap pull is a single manifest + a handful of layers, so a short step
+// is enough to ride out a reset connection; the image-build wrapper waits
+// longer because a Hub 429 burst outlives it.
 const defaultBackoffStepSeconds = 3;
-const msPerSecond = 1_000;
-
-// Synchronous sleep: this module is a linear sequence of spawnSync calls, so
-// there is no event loop to yield to.
-function sleepSeconds(seconds) {
-  if (seconds <= 0) return;
-  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, seconds * msPerSecond);
-}
 
 function presentLocally(image) {
   return capture('docker', ['image', 'inspect', image]).status === 0;
@@ -57,14 +54,10 @@ if (image === '') {
   process.exit(1);
 }
 
-const backoffStepSeconds = Number(process.env.BUILDKIT_PULL_BACKOFF_SECONDS ?? defaultBackoffStepSeconds);
-if (!Number.isFinite(backoffStepSeconds) || backoffStepSeconds < 0) {
-  error(`BUILDKIT_PULL_BACKOFF_SECONDS must be a non-negative number, got ${process.env.BUILDKIT_PULL_BACKOFF_SECONDS}`);
-  process.exit(1);
-}
+const backoffStepSeconds = readBackoffStepSeconds('BUILDKIT_PULL_BACKOFF_SECONDS', defaultBackoffStepSeconds);
 
-for (let attempt = 1; attempt <= pullAttempts; attempt++) {
-  log(`    docker pull ${image} (attempt ${attempt}/${pullAttempts})`);
+for (let attempt = 1; attempt <= registryAttempts; attempt++) {
+  log(`    docker pull ${image} (attempt ${attempt}/${registryAttempts})`);
   const res = capture('docker', ['pull', image]);
   if (res.status === 0) {
     log(res.stdout.trim());
@@ -80,13 +73,13 @@ for (let attempt = 1; attempt <= pullAttempts; attempt++) {
     process.exit(0);
   }
 
-  if (attempt < pullAttempts) {
+  if (attempt < registryAttempts) {
     sleepSeconds(attempt * backoffStepSeconds);
   }
 }
 
 error(
-  `docker pull ${image} failed ${pullAttempts} times and the image is absent from the local daemon, ` +
+  `docker pull ${image} failed ${registryAttempts} times and the image is absent from the local daemon, ` +
     'so `buildx inspect --bootstrap` has nothing to boot from.',
 );
 process.exit(1);

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -297,12 +297,18 @@ jobs:
 
       - uses: ./.github/actions/setup-buildx
 
-      - name: docker compose up --wait
+      - name: compose up --wait (retried on registry faults)
         run: |
           # --wait-timeout caps the wait at 5 min. Cold runners need
           # ~30-60s for the Go build + ~10-20s for CH first-boot; 300s
           # is generous slack.
-          docker compose up --wait --wait-timeout 300
+          #
+          # `up` builds the cerberus service from Dockerfile.local, so it
+          # resolves `FROM golang:1.26` against Docker Hub; the wrapper
+          # retries that on registry/network faults only (a real build
+          # failure still fails on the first attempt).
+          node .github/scripts/build-with-registry-retry.mjs \
+            docker compose up --wait --wait-timeout 300
 
       - name: smoke cerberus /healthz + /readyz
         run: |
@@ -505,8 +511,12 @@ jobs:
 
       - uses: ./.github/actions/setup-buildx
 
-      - name: docker compose up --wait
-        run: docker compose up --wait --wait-timeout 300
+      # `up` builds the cerberus service from Dockerfile.local, so it resolves
+      # `FROM golang:1.26` against Docker Hub; the wrapper retries that on
+      # registry/network faults only (a real build failure still fails on the
+      # first attempt).
+      - name: compose up --wait (retried on registry faults)
+        run: node .github/scripts/build-with-registry-retry.mjs docker compose up --wait --wait-timeout 300
 
       - name: smoke cerberus /healthz + /readyz
         run: |

--- a/Justfile
+++ b/Justfile
@@ -708,6 +708,16 @@ _compose-pull-retry +FILES:
     done; \
     [ "$ok" = 1 ] || { echo "ERROR: docker compose pull failed after 5 attempts" >&2; exit 1; }
 
+# `_pull-retry` / `_compose-pull-retry` protect the images the HOST daemon
+# fetches. The images a BUILD fetches — the `FROM` refs BuildKit resolves while
+# running `docker build` / `docker compose up` — are a separate exposure that no
+# host-side pre-pull reaches (the `docker-container` driver resolves them from
+# the registry regardless of what the daemon holds), and a Docker Hub 429 on
+# `golang:1.26` took `e2e` + `migration-e2e` down on main. Every build-invoking
+# command below therefore runs through
+# `.github/scripts/build-with-registry-retry.mjs`, which retries the command on
+# registry/network faults only and fails immediately on a real build error.
+
 e2e-up: e2e-down
     @echo "==> pre-pulling k3s node image (retry — Docker Hub flaky from CI)"
     @just _pull-retry {{K3S_IMAGE}}
@@ -721,7 +731,8 @@ e2e-up: e2e-down
         {{K3D_EXTRA_ARGS}} \
         --wait
     @echo "==> building cerberus image (build tags: '{{CERBERUS_BUILD_TAGS}}')"
-    docker build -t {{CERBERUS_IMAGE}} --build-arg GO_BUILD_TAGS="{{CERBERUS_BUILD_TAGS}}" -f Dockerfile.local .
+    node .github/scripts/build-with-registry-retry.mjs \
+        docker build -t {{CERBERUS_IMAGE}} --build-arg GO_BUILD_TAGS="{{CERBERUS_BUILD_TAGS}}" -f Dockerfile.local .
     @echo "==> pre-pulling external images on host docker (retry)"
     @just _pull-retry {{E2E_EXTERNAL_IMAGES}}
     @echo "==> importing images into k3d ({{K3D_CLUSTER}}) — one at a time, with retry+verify"
@@ -1196,7 +1207,8 @@ e2e-bwc-up: e2e-down
         {{K3D_EXTRA_ARGS}} \
         --wait
     @echo "==> [bwc] building cerberus image (build tags: '{{CERBERUS_BUILD_TAGS}}')"
-    docker build -t {{CERBERUS_IMAGE}} --build-arg GO_BUILD_TAGS="{{CERBERUS_BUILD_TAGS}}" -f Dockerfile.local .
+    node .github/scripts/build-with-registry-retry.mjs \
+        docker build -t {{CERBERUS_IMAGE}} --build-arg GO_BUILD_TAGS="{{CERBERUS_BUILD_TAGS}}" -f Dockerfile.local .
     @echo "==> [bwc] pre-pulling external + bwc images on host docker"
     @# The standalone-CH image (the *-alpine tag in E2E_EXTERNAL_IMAGES) backs
     @# test/e2e/k3s/clickhouse.yaml, which the bwc kustomization EXCLUDES — this
@@ -1394,7 +1406,7 @@ migration-cerberus-image:
     img="${CERBERUS_IMAGE:-$local_tag}"; \
     if [ "$img" = "$local_tag" ]; then \
         echo "==> migration cerberus image: build $img from Dockerfile.local"; \
-        docker build -f Dockerfile.local -t "$img" .; \
+        node .github/scripts/build-with-registry-retry.mjs docker build -f Dockerfile.local -t "$img" .; \
     else \
         echo "==> migration cerberus image: pull $img"; \
         just _pull-retry "$img"; \
@@ -1418,7 +1430,8 @@ migration-tier1-up:
     @just migration-cerberus-image
     @just _compose-pull-retry test/e2e/migration/tiers/tier1-dual/docker-compose.dual.yml
     @echo "==> migration tier-1 stack up"
-    docker compose -f test/e2e/migration/tiers/tier1-dual/docker-compose.dual.yml \
+    node .github/scripts/build-with-registry-retry.mjs \
+        docker compose -f test/e2e/migration/tiers/tier1-dual/docker-compose.dual.yml \
         up --wait --wait-timeout 300
 
 # Every archetype an `@tier1` scenario actually reads fixture data from:
@@ -1557,7 +1570,8 @@ migration-tier2-up:
     @just _compose-pull-retry test/e2e/migration/tiers/tier1-dual/docker-compose.dual.yml \
         test/e2e/migration/tiers/tier2-ruler/docker-compose.ruler.yml
     @echo "==> migration tier-2 stack up"
-    docker compose -f test/e2e/migration/tiers/tier1-dual/docker-compose.dual.yml \
+    node .github/scripts/build-with-registry-retry.mjs \
+        docker compose -f test/e2e/migration/tiers/tier1-dual/docker-compose.dual.yml \
         -f test/e2e/migration/tiers/tier2-ruler/docker-compose.ruler.yml \
         up --wait --wait-timeout 300
 

--- a/bench/histogram/run.sh
+++ b/bench/histogram/run.sh
@@ -48,11 +48,18 @@ case "$PROFILE" in
 esac
 
 echo "==> [1/5] building + starting core stack (clickhouse, cerberus, prometheus)"
-docker compose up -d --build --wait clickhouse cerberus prometheus
+# Every compose `up` here can fetch from Docker Hub — the cerberus service
+# builds Dockerfile.local (`FROM golang:1.26`), the rest pull. The wrapper
+# retries on registry/network faults only; a real build failure still fails on
+# the first attempt, and the best-effort `|| MIMIR_OK=0` below still sees a
+# non-zero status once the retries are spent.
+node ../../.github/scripts/build-with-registry-retry.mjs \
+    docker compose up -d --build --wait clickhouse cerberus prometheus
 
 echo "==> [2/5] starting mimir (best-effort)"
 MIMIR_OK=1
-docker compose up -d mimir || MIMIR_OK=0
+node ../../.github/scripts/build-with-registry-retry.mjs \
+    docker compose up -d mimir || MIMIR_OK=0
 if [[ "$MIMIR_OK" == "1" ]]; then
   MIMIR_OK=0
   for i in $(seq 1 40); do

--- a/compatibility/loki/scripts/run-loki-compatibility.sh
+++ b/compatibility/loki/scripts/run-loki-compatibility.sh
@@ -110,7 +110,12 @@ trap cleanup EXIT
 mkdir -p "$(dirname "$REPORT")"
 
 echo "==> bringing up loki-compatibility stack (compose up --wait)"
-docker compose up -d --build --wait clickhouse loki cerberus
+# `--build` builds Dockerfile.local, whose `FROM golang:1.26` BuildKit resolves
+# from Docker Hub — a 429 there fails the lane before any query runs. The
+# wrapper retries the command on registry/network faults only; a genuine build
+# failure still fails on the first attempt.
+node "$REPO_ROOT/.github/scripts/build-with-registry-retry.mjs" \
+    docker compose up -d --build --wait clickhouse loki cerberus
 
 echo "==> running seeder (go run ./cmd/seed)"
 (cd "$REPO_ROOT" && go run ./compatibility/loki/cmd/seed/)

--- a/compatibility/prometheus/scripts/run-compatibility.sh
+++ b/compatibility/prometheus/scripts/run-compatibility.sh
@@ -87,7 +87,12 @@ END_TIME=${TESTER_END_TIME:-"2026-05-11T01:00:00Z"}
 RANGE=${TESTER_RANGE:-3600}
 
 echo "==> bringing up compatibility stack"
-docker compose up -d --build --wait clickhouse prometheus cerberus
+# `--build` builds Dockerfile.local, whose `FROM golang:1.26` BuildKit resolves
+# from Docker Hub — a 429 there fails the lane before any query runs. The
+# wrapper retries the command on registry/network faults only; a genuine build
+# failure still fails on the first attempt.
+node "$REPO_ROOT/.github/scripts/build-with-registry-retry.mjs" \
+    docker compose up -d --build --wait clickhouse prometheus cerberus
 echo "==> running seeder (go run ./cmd/seed)"
 (cd "$ROOT_DIR/../.." && go run ./compatibility/prometheus/cmd/seed/)
 

--- a/compatibility/tempo/scripts/run-tempo-compatibility.sh
+++ b/compatibility/tempo/scripts/run-tempo-compatibility.sh
@@ -81,13 +81,20 @@ trap cleanup EXIT
 echo "==> bringing up tempo-compatibility stack"
 # Step 1: start tempo (no compose-level healthcheck — distroless image,
 # see compose.yml). The driver polls /ready before pushing.
-docker compose up -d --build tempo
+# Both `--build` invocations below build Dockerfile.local / the driver
+# Dockerfile, whose `FROM golang:1.26` BuildKit resolves from Docker Hub — a 429
+# there fails the lane before any query runs. The wrapper retries the command on
+# registry/network faults only; a genuine build failure still fails on the first
+# attempt.
+node "$REPO_ROOT/.github/scripts/build-with-registry-retry.mjs" \
+    docker compose up -d --build tempo
 
 # Step 2: `--wait` block on the healthchecked services. 5min compose-
 # level timeout is generous: CH boot can take 30-60s on a cold runner,
 # cerberus is <2s. If we time out, it's an infra-layer issue (image
 # pull, cgroup, etc.), not a harness bug.
-docker compose up -d --build --wait --wait-timeout 300 \
+node "$REPO_ROOT/.github/scripts/build-with-registry-retry.mjs" \
+    docker compose up -d --build --wait --wait-timeout 300 \
     clickhouse cerberus-tempo
 
 # The seeder and differ run as Go binaries on the host, connecting

--- a/test/regression/image_build_registry_retry_test.go
+++ b/test/regression/image_build_registry_retry_test.go
@@ -1,0 +1,302 @@
+package regression
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// Two lanes went red on main @ d939e299 with one signature — `e2e` run
+// 30695961421 (`dashboard-shard`, step "Bring up k3d stack") and
+// `migration-e2e` run 30695961427 (`migration-tier1`):
+//
+//	#5 ERROR: unexpected status from HEAD request to
+//	   https://registry-1.docker.io/v2/library/golang/manifests/1.26:
+//	   429 Too Many Requests
+//
+// `golang:1.26` is the `FROM` of Dockerfile.local — a base image BuildKit
+// resolves from Docker Hub while running the build, not an image the host
+// daemon pulls. `_pull-retry` / `pull-buildkit-image.mjs` already cover
+// host-side pulls and the BuildKit bootstrap image; nothing covered the build's
+// own `FROM` resolution, which every cerberus-image-building lane performs
+// (e2e / dashboard, migration-e2e, compose-smoke, the three compatibility
+// harnesses — two of them release gates).
+//
+// A host-side pre-pull cannot close it uniformly: the built-in `docker` driver
+// resolves `FROM` from the daemon's image store, but the `docker-container`
+// driver `.github/actions/setup-buildx` installs runs BuildKit in a container
+// with its own content store and always goes to the registry. So the retry
+// wraps the build command itself, and these guards pin that every
+// build-invoking command goes through it and that it retries the transient
+// class ONLY.
+
+const (
+	buildRetryWrapper     = "build-with-registry-retry.mjs"
+	buildRetryWrapperPath = "../../.github/scripts/" + buildRetryWrapper
+
+	// The wrapper's own attempt budget (lib/registry.mjs `registryAttempts`).
+	// Fewer lets the flake through; more parks the job on a registry that is
+	// genuinely refusing this runner.
+	buildRetryAttempts = 5
+
+	// Floor for the class scan. The wrapped set is currently 13 (5 Justfile,
+	// 4 compatibility harness, 2 e2e.yml, 2 bench); the floor guards against a
+	// refactor that leaves the guard scanning for a shape nothing matches, so
+	// it sits just below the real count rather than tracking it exactly.
+	minWrappedBuildSites = 10
+)
+
+// A command that makes a builder resolve base images: `docker build`,
+// `docker buildx build`, and any `docker compose … up|build` (compose builds
+// every service with a `build:` stanza whose image is absent).
+var (
+	dockerBuildCommand   = regexp.MustCompile(`\bdocker\s+(?:buildx\s+)?build\b`)
+	dockerComposeCommand = regexp.MustCompile(`\bdocker\s+compose\b.*\b(?:up|build)\b`)
+)
+
+// prosePrefixes are the line shapes that mention a docker command without
+// running one: comments (shell / Justfile / YAML / JS), workflow step names,
+// and echoed progress lines.
+var prosePrefixes = []string{"#", "@#", "//", "- name:", "name:", "echo", "@echo", "@printf", "printf"}
+
+func isProse(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	for _, p := range prosePrefixes {
+		if strings.HasPrefix(trimmed, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// logicalLines joins backslash-continued lines, so a command split across a
+// `\`-continuation (every multi-`-f` compose invocation in the Justfile) is
+// judged as the single command the shell actually runs.
+func logicalLines(src string) []string {
+	var out []string
+	var buf strings.Builder
+	for _, raw := range strings.Split(src, "\n") {
+		line := strings.TrimRight(raw, " \t\r")
+		if strings.HasSuffix(line, `\`) {
+			buf.WriteString(strings.TrimSuffix(line, `\`))
+			buf.WriteString(" ")
+			continue
+		}
+		buf.WriteString(line)
+		out = append(out, buf.String())
+		buf.Reset()
+	}
+	if buf.Len() > 0 {
+		out = append(out, buf.String())
+	}
+	return out
+}
+
+// buildScanFiles walks the repo for the file kinds that can invoke a builder:
+// the Justfile, every shell script, and every workflow / composite-action YAML.
+func buildScanFiles(t *testing.T) []string {
+	t.Helper()
+
+	const repoRoot = "../.."
+	// Vendored upstream trees and per-agent worktrees are not cerberus's
+	// build entry points; scanning them would pin someone else's shapes.
+	skipDirs := map[string]bool{".git": true, ".claude": true, "node_modules": true, "upstream": true, "vendor": true}
+
+	var files []string
+	err := filepath.WalkDir(repoRoot, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if skipDirs[d.Name()] {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		name := d.Name()
+		ext := filepath.Ext(name)
+		switch {
+		case name == "Justfile":
+		case ext == ".sh":
+		case (ext == ".yml" || ext == ".yaml") && strings.Contains(filepath.ToSlash(path), "/.github/"):
+		default:
+			return nil
+		}
+		files = append(files, path)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", repoRoot, err)
+	}
+	if len(files) == 0 {
+		t.Fatal("no Justfile / shell script / workflow found — the guard is scanning for a shape that no longer exists")
+	}
+	return files
+}
+
+// TestImageBuildingCommandsGoThroughTheRetryWrapper pins the class fix: every
+// command that makes a builder resolve a base image runs through the wrapper.
+// A new lane that shells out to `docker build` directly reintroduces exactly
+// the Docker Hub 429 that took `e2e` + `migration-e2e` down, so the guard is on
+// the command shape rather than on the two call sites that happened to fail.
+func TestImageBuildingCommandsGoThroughTheRetryWrapper(t *testing.T) {
+	t.Parallel()
+
+	wrapped := 0
+	for _, file := range buildScanFiles(t) {
+		src, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("read %s: %v", file, err)
+		}
+		for _, line := range logicalLines(string(src)) {
+			if isProse(line) {
+				continue
+			}
+			if !dockerBuildCommand.MatchString(line) && !dockerComposeCommand.MatchString(line) {
+				continue
+			}
+			if strings.Contains(line, buildRetryWrapper) {
+				wrapped++
+				continue
+			}
+			t.Errorf("%s invokes a builder without the retry wrapper:\n    %s\n"+
+				"Base images are resolved from Docker Hub during the build, and a 429 there fails the lane "+
+				"outright. Run it through `node .github/scripts/%s <command>`, which retries registry/network "+
+				"faults only.", file, strings.TrimSpace(line), buildRetryWrapper)
+		}
+	}
+
+	if wrapped < minWrappedBuildSites {
+		t.Errorf("only %d build invocation(s) go through %s, want at least %d — the guard is scanning for a "+
+			"shape that no longer exists", wrapped, buildRetryWrapper, minWrappedBuildSites)
+	}
+}
+
+// TestBuildRetryWrapperRetriesOnlyTransientRegistryFailures drives the module
+// against a stub `docker` on PATH. The two halves are equally load-bearing: a
+// wrapper that does not retry the 429 fixes nothing, and one that retries a
+// genuine build failure is a `continue-on-error` in disguise — it would turn a
+// broken build into five broken builds and a slower red.
+func TestBuildRetryWrapperRetriesOnlyTransientRegistryFailures(t *testing.T) {
+	t.Parallel()
+
+	const (
+		hubRateLimit = "#5 ERROR: unexpected status from HEAD request to " +
+			"https://registry-1.docker.io/v2/library/golang/manifests/1.26: 429 Too Many Requests"
+		compileError        = "internal/api/prom/handler.go:12:2: undefined: notAThing"
+		compileExitStatus   = 2
+		neverSucceeds       = buildRetryAttempts + 1
+		succeedsImmediately = 1
+	)
+
+	cases := []struct {
+		name string
+		// succeedsOn is the 1-based attempt at which the stub starts exiting 0.
+		succeedsOn   int
+		failureText  string
+		failureExit  int
+		wantExitCode int
+		wantCalls    int
+	}{
+		{
+			name:         "a Docker Hub 429 is ridden out",
+			succeedsOn:   3,
+			failureText:  hubRateLimit,
+			failureExit:  1,
+			wantExitCode: 0,
+			wantCalls:    3,
+		},
+		{
+			name:         "a registry that never answers spends the budget and fails the job",
+			succeedsOn:   neverSucceeds,
+			failureText:  hubRateLimit,
+			failureExit:  1,
+			wantExitCode: 1,
+			wantCalls:    buildRetryAttempts,
+		},
+		{
+			name:         "a genuine build failure is not retried and keeps its exit status",
+			succeedsOn:   neverSucceeds,
+			failureText:  compileError,
+			failureExit:  compileExitStatus,
+			wantExitCode: compileExitStatus,
+			wantCalls:    1,
+		},
+		{
+			name:         "a build that works runs exactly once",
+			succeedsOn:   succeedsImmediately,
+			failureText:  hubRateLimit,
+			failureExit:  1,
+			wantExitCode: 0,
+			wantCalls:    1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			callLog := filepath.Join(dir, "calls")
+			writeStubDockerBuild(t, dir, callLog, tc.succeedsOn, tc.failureText, tc.failureExit)
+
+			cmd := exec.Command("node", buildRetryWrapperPath,
+				"docker", "build", "-f", "Dockerfile.local", "-t", "cerberus:e2e", ".")
+			cmd.Env = append(
+				os.Environ(),
+				"PATH="+dir+string(os.PathListSeparator)+os.Getenv("PATH"),
+				// Zero backoff: what is under test is the retry decision, not
+				// the wall clock it burns.
+				"IMAGE_BUILD_RETRY_BACKOFF_SECONDS=0",
+			)
+			out, err := cmd.CombinedOutput()
+
+			exitCode := 0
+			if err != nil {
+				var ee *exec.ExitError
+				if !errors.As(err, &ee) {
+					t.Fatalf("run %s: %v (node and bash must be on PATH)", buildRetryWrapper, err)
+				}
+				exitCode = ee.ExitCode()
+			}
+			if exitCode != tc.wantExitCode {
+				t.Errorf("exit code = %d, want %d\noutput:\n%s", exitCode, tc.wantExitCode, out)
+			}
+
+			logged, err := os.ReadFile(callLog)
+			if err != nil && !os.IsNotExist(err) {
+				t.Fatalf("read stub call log: %v", err)
+			}
+			calls := len(strings.Fields(string(logged)))
+			if calls != tc.wantCalls {
+				t.Errorf("the build ran %d time(s), want %d\noutput:\n%s", calls, tc.wantCalls, out)
+			}
+		})
+	}
+}
+
+// writeStubDockerBuild drops a `docker` onto dir that records every call and
+// fails with failureText/failureExit until the succeedsOn-th one.
+func writeStubDockerBuild(t *testing.T, dir, callLog string, succeedsOn int, failureText string, failureExit int) {
+	t.Helper()
+
+	script := strings.Join([]string{
+		"#!/bin/sh",
+		"echo call >> " + shellQuote(callLog),
+		"attempts=$(wc -l < " + shellQuote(callLog) + " | tr -d ' ')",
+		"[ \"$attempts\" -ge " + strconv.Itoa(succeedsOn) + " ] && exit 0",
+		"echo " + shellQuote(failureText) + " >&2",
+		"exit " + strconv.Itoa(failureExit),
+		"",
+	}, "\n")
+
+	path := filepath.Join(dir, "docker")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write stub docker: %v", err)
+	}
+}


### PR DESCRIPTION
## Root cause

Two lanes are red on `main` @ `d939e299` from one shared cause: a Docker Hub
**429 Too Many Requests** on `library/golang:1.26` — the base image of
`Dockerfile.local` — resolved by BuildKit *during* the image build.

Evidence:

- run **30695961421** — `e2e`, job `dashboard-shard (shard-smoke-a-monolith, monolith, …)`, step "Bring up k3d stack"
- run **30695961427** — `migration-e2e`, job `migration-tier1`

Both failed with the identical line:

```text
#5 ERROR: unexpected status from HEAD request to https://registry-1.docker.io/v2/library/golang/manifests/1.26: 429 Too Many Requests
```

The `Log in to Docker Hub` step **succeeded** in both runs, so this is not a
missing-credentials problem — an authenticated pull can still be rate-limited,
and Hub 429s arrive in bursts. It is also not the BuildKit *bootstrap* image:
that one is already protected (`.github/actions/setup-buildx` →
`.github/scripts/pull-buildkit-image.mjs`, plus the Justfile `_pull-retry` /
`_compose-pull-retry` helpers). The **`FROM` base image** had no equivalent
protection anywhere in the repo.

## Why the retry has to wrap the build

`golang:1.26` is resolved by **BuildKit**, as step `#5` of the build DAG, inside
the same `docker build` / `docker compose up --build` process. That matters for
where a retry can possibly be effective:

| buildx driver | who resolves `FROM` | does a host-side `docker pull` help? |
| --- | --- | --- |
| `docker` (dockerd's built-in BuildKit) | dockerd, against its own image store | yes |
| `docker-container` (`setup-buildx`) | the BuildKit container, own content store | **no — always re-resolves from the registry** |

Both driver shapes are live in this repo: `migration-e2e` and the `e2e`
`dashboard-shard` job use the built-in driver, while `compatibility.yml`, the
`e2e` compose-smoke shards and `release.yml` use `setup-buildx`. So a host-side
pre-pull would protect some lanes and *silently protect nothing* in others —
green on a PR (these lanes short-circuit on ordinary PRs) while still 429-ing on
the merge commit. That is precisely the hollow-green failure mode, so the retry
does **not** live there.

Instead a small wrapper re-runs the **build invocation itself**. That is
driver-agnostic (it works identically for both rows above) and needs no
knowledge of the base-image ref, so a warmed-ref / resolved-ref drift is
structurally impossible — there is no warmed ref.

## What changed

- **`.github/scripts/lib/registry.mjs`** (new) — the single shared retry policy:
  attempt count, backoff sleep, backoff-seconds env parsing, and the
  transient-registry-failure classifier (429 / `toomanyrequests`, `unexpected
  status from HEAD/GET/POST request`, registry 5xx, TLS handshake timeout,
  `i/o timeout`, connection reset, DNS failures, http2 GOAWAY, …).
- **`.github/scripts/build-with-registry-retry.mjs`** (new) — takes an image-build
  command as its trailing argv, runs it teed to a temp log, and retries **only**
  when the output matches the transient classifier.
- **`.github/scripts/pull-buildkit-image.mjs`** — now imports the shared policy
  instead of carrying its own copy. Behaviour unchanged (it keeps its shorter
  backoff step and its "already present locally is a pass" postcondition).
- **Call sites wrapped** — every image-building entry point in the repo, not just
  the two that failed: `Justfile` (`e2e-up`, `e2e-bwc-up`,
  `migration-cerberus-image`, `migration-tier1-up`, `migration-tier2-up`), the
  three `compatibility/*/scripts/run-*.sh` harnesses, `bench/histogram/run.sh`,
  and the two `e2e.yml` compose-smoke `compose up` steps.
- **`test/regression/image_build_registry_retry_test.go`** (new) — two guards so
  this cannot silently regress:
  1. a repo-wide scan that fails if any `docker build` / `docker compose up|build`
     command in a `Justfile`, `*.sh` or `.github/**` workflow is not routed
     through the wrapper (with a floor on the number of wrapped sites, so
     deleting them all cannot pass vacuously);
  2. a behavioural test that puts a stub `docker` on `PATH` and asserts the four
     outcomes below.
- **`.github/scripts/README.md`** — module + env-contract inventory updated.

## This does not paper over anything

The wrapper classifies before it retries:

| scenario | behaviour |
| --- | --- |
| transient registry fault, then success | retries, exits `0` |
| transient fault on every attempt | attempts exhausted, exits **`1`** — the job fails |
| genuine build failure (compile error, bad Dockerfile) | **no retry at all**; fails on the first attempt, propagating the build's own exit status |
| success | one invocation, exits `0` |

No `continue-on-error`, no `|| true`, no lane downgraded, no allow-list. There
is also deliberately **no** "use the local image if the build fails" fallback for
the build path: a tag left in the daemon by an earlier run attests nothing about
this tree.

## Scope statement — verified vs. reasoned

Verified locally on this machine (no running containers touched, no daemon
state changed):

- the wrapper's four behaviours above, driven by a stub `docker` on `PATH`
  (transient-then-success → 3 invocations, exit 0; always-transient → 5
  invocations, exit 1; genuine failure → 1 invocation, exit 2; success → 1
  invocation, exit 0);
- the class scan finds **13** wrapped build sites and **0** unwrapped ones
  across 38 scanned files;
- `pull-buildkit-image.mjs` still errors and exits 1 on an empty env after the
  refactor.

Reasoned about statically, **not executed** (these lanes are expensive, and
`dashboard` / `compose-smoke` short-circuit on ordinary PRs, so a green PR would
prove nothing about them anyway): the real `e2e`, `migration-e2e`, `dashboard`,
`compose-smoke` and `compatibility` lanes. The argument that the fix reaches
them is the driver analysis above plus the fact that every one of those lanes
now invokes its build through the wrapper — the retry sits in the same process
tree as the `FROM` resolution that 429'd, for both driver shapes.

Fixes the `e2e` + `migration-e2e` breakage on `main`, and de-flakes the
`dashboard` and `compose-smoke` release gates (named in `release.yml`'s
`RELEASE_REQUIRED_CHECKS`) against the same fault.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
