### PR TITLE
fix(chclient): stall the teardown destroy arm's probe so the cancel cannot race the drain

### DIFF
--- a/internal/chclient/conn_teardown_integration_test.go
+++ b/internal/chclient/conn_teardown_integration_test.go
@@ -37,6 +37,13 @@ import (
 // client-side view alone is driver bookkeeping; the server-side view makes
 // "the socket was destroyed" a fact rather than an inference.
 //
+// The arms do NOT share a probe, and that is load-bearing rather than
+// incidental — see teardownDrainableProbeSQL / teardownStalledProbeSQL. Each
+// ordering is only decidable when the driver has exactly one terminal branch
+// available to it, and the two orderings need opposite stream shapes to get
+// there: one needs a remainder that drains inside the budget, the other needs a
+// remainder the server has not produced yet.
+//
 // Gated behind the `integration` build tag (Docker required); the strict-scan
 // lane runs it via `just chclient-integration`.
 func TestCursorTeardown_ReturnsConnectionToPool(t *testing.T) {
@@ -45,7 +52,7 @@ func TestCursorTeardown_ReturnsConnectionToPool(t *testing.T) {
 
 	// The probe must stream several blocks so the driver's process goroutine is
 	// provably still in flight when the teardown runs. Asserted rather than
-	// left to a comment, because the shape is what makes the cancel arm
+	// left to a comment, because the shape is what makes the release arm
 	// deterministic and a future edit to either constant could silently undo it.
 	if blocks := teardownProbeRows / teardownProbeBlockRows; blocks <= driverBlockBufferDepth+1 {
 		t.Fatalf("probe streams %d blocks; need more than %d so the driver parks mid-stream",
@@ -65,7 +72,7 @@ func TestCursorTeardown_ReturnsConnectionToPool(t *testing.T) {
 
 	t.Run("close before cancel keeps the connection pooled", func(t *testing.T) {
 		qctx, qcancel := context.WithCancel(ctx)
-		cur, err := fx.subject.QueryCursor(qctx, teardownProbeSQL)
+		cur, err := fx.subject.QueryCursor(qctx, teardownDrainableProbeSQL)
 		if err != nil {
 			qcancel()
 			t.Fatalf("QueryCursor: %v", err)
@@ -98,7 +105,14 @@ func TestCursorTeardown_ReturnsConnectionToPool(t *testing.T) {
 
 	t.Run("cancel before close destroys the connection", func(t *testing.T) {
 		qctx, qcancel := context.WithCancel(ctx)
-		cur, err := fx.subject.QueryCursor(qctx, teardownProbeSQL)
+		// The STALLED probe. With the drainable one this arm asserts the
+		// outcome of a race inside clickhouse-go rather than the ordering:
+		// Close() drains, the drain unparks the driver's producer, and if the
+		// producer reaches EndOfStream before connect.cancel() closes the
+		// socket, `process` returns nil, `release(conn, nil)` pools the
+		// connection, and the session census never moves.
+		opened := time.Now()
+		cur, err := fx.subject.QueryCursor(qctx, teardownStalledProbeSQL)
 		if err != nil {
 			qcancel()
 			t.Fatalf("QueryCursor: %v", err)
@@ -107,7 +121,22 @@ func TestCursorTeardown_ReturnsConnectionToPool(t *testing.T) {
 			qcancel()
 			t.Fatalf("cursor yielded no rows: %v", cur.Err())
 		}
-		// The inverted ordering CloseCursor exists to prevent.
+		// The stall is this arm's PREMISE, so it is asserted rather than
+		// assumed. Reaching the first row costs the server one block's worth of
+		// per-row sleeps; if a future ClickHouse folds that away, the remainder
+		// is buffered client-side again and the assertion below silently decays
+		// into a coin flip. Failing here says so out loud instead.
+		if waited := time.Since(opened); waited < teardownStallFloor {
+			qcancel()
+			_ = cur.Close()
+			t.Fatalf("first row arrived after %s; want at least %s — the probe's per-row server-side stall is not in effect, so the remainder can be buffered client-side and the cancel would race the drain",
+				waited, teardownStallFloor)
+		}
+
+		// The inverted ordering CloseCursor exists to prevent. The remainder is
+		// still inside the server, so the drain in Close() has nothing to reach
+		// EndOfStream with: the driver's only terminal branch is the cancel,
+		// which destroys the socket.
 		qcancel()
 		_ = cur.Close()
 
@@ -145,14 +174,40 @@ const teardownOneRowSQL = teardownProbeColumns + ` LIMIT 1`
 // against a baseline rather than an absolute.
 const serverSessionsSQL = `SELECT value FROM system.metrics WHERE metric = 'TCPConnection'`
 
-// teardownProbeSQL is the probe both arms tear down mid-stream. max_block_size
-// is pinned so the result arrives in teardownProbeRows/teardownProbeBlockRows
-// blocks regardless of the server's own default — it is the block COUNT, not
-// the row count, that parks the driver mid-stream and makes the two orderings
-// diverge deterministically.
-var teardownProbeSQL = fmt.Sprintf(
+// teardownDrainableProbeSQL is the RELEASE arm's probe. max_block_size is
+// pinned so the result arrives in teardownProbeRows/teardownProbeBlockRows
+// blocks regardless of the server's own default: more than the driver's block
+// buffer holds, so the producer is parked mid-stream when the teardown starts
+// and the drain is a real one — yet small enough that the whole remainder
+// arrives well inside chclient.CursorDrainBudget, so the release is never
+// decided by machine speed.
+var teardownDrainableProbeSQL = fmt.Sprintf(
 	`%s SETTINGS max_block_size = %d`,
 	teardownProbeColumns, teardownProbeBlockRows,
+)
+
+// teardownStalledProbeSQL is the DESTROY arm's probe: the same shape, held back
+// by a per-row server-side sleep.
+//
+// The stall is what makes that arm an assertion instead of a coin flip.
+// clickhouse-go's `connect.process` selects over three ready-able cases —
+// ctx.Done, the reader's error, the reader's completion — and `rows.Close()`
+// DRAINS, which is precisely what lets the reader complete. Hand the destroy
+// arm a probe whose remainder is already in the client's socket buffer and the
+// drain can reach EndOfStream before the cancellation is observed; `process`
+// then returns nil, `release(conn, nil)` returns the connection to the idle
+// pool, and the server keeps the session the arm is trying to watch die. Two
+// orderings, one outcome, decided by whichever goroutine the scheduler picked.
+//
+// A remainder the SERVER has not produced yet removes that branch outright:
+// there is nothing to drain, the reader is blocked on the wire rather than on
+// the block channel, and the cancel is the only way the query can end. It also
+// keeps the reader off the block channel while the driver closes it, which is
+// the one ordering in which clickhouse-go would close a channel out from under
+// a parked sender.
+var teardownStalledProbeSQL = fmt.Sprintf(
+	`%s WHERE sleepEachRow(%v) = 0 SETTINGS max_block_size = %d`,
+	teardownProbeColumns, teardownStallSecondsPerRow, teardownProbeBlockRows,
 )
 
 const (
@@ -171,9 +226,28 @@ const (
 	// blocks: comfortably past driverBlockBufferDepth, yet small enough that
 	// the whole remainder drains in tens of milliseconds on a race-instrumented
 	// build — an order of magnitude inside chclient.CursorDrainBudget, so the
-	// release arm is never decided by machine speed.
+	// release arm is never decided by machine speed. teardownProbeBlockRows
+	// pins the probe table's index granularity as well as max_block_size, so
+	// the block count is the server's behaviour rather than arithmetic.
 	teardownProbeRows      = 2_000
 	teardownProbeBlockRows = 250
+
+	// teardownStallSecondsPerRow is the destroy arm's server-side brake: every
+	// row the stalled probe emits costs the server this much sleep, so the
+	// remainder stays inside ClickHouse instead of being buffered on the
+	// client where a drain could reach the end of it.
+	teardownStallSecondsPerRow = 0.002
+
+	// teardownStallPerBlock is what one block of the stalled probe therefore
+	// costs — the gap the cancellation has to win, against a scheduler wakeup
+	// and a socket close.
+	teardownStallPerBlock = time.Duration(teardownStallSecondsPerRow*float64(time.Second)) * teardownProbeBlockRows
+
+	// teardownStallFloor is how much of that gap must be OBSERVED for the stall
+	// to count as in effect. Half a block absorbs ClickHouse's own sleep
+	// granularity while staying two orders of magnitude above the unstalled
+	// case, which arrives in single-digit milliseconds.
+	teardownStallFloor = teardownStallPerBlock / 2
 
 	// poolSettleBudget is how long a pool statistic is given to reach its
 	// terminal value: the driver's release / destroy runs on its own process
@@ -228,14 +302,20 @@ func startTeardownFixture(ctx context.Context, t *testing.T) teardownFixture {
 		observer: newTeardownClient(t, addr, teardownObserverConns),
 	}
 
-	if err := fx.subject.Exec(ctx, `
+	// index_granularity is pinned to the probe's block size, not left at the
+	// default. A MergeTree reader cannot subdivide a granule for the filter
+	// stage, so with the default 8192 the whole 2000-row table is ONE block
+	// there however max_block_size is set — which would collapse the stalled
+	// probe into a single block with no remainder to stall.
+	if err := fx.subject.Exec(ctx, fmt.Sprintf(`
 		CREATE TABLE otel_metrics_gauge (
 			MetricName String,
 			Attributes Map(String, String),
 			TimeUnix DateTime64(9),
 			Value Float64
 		) ENGINE = MergeTree() ORDER BY (MetricName, TimeUnix)
-	`); err != nil {
+		SETTINGS index_granularity = %d
+	`, teardownProbeBlockRows)); err != nil {
 		t.Fatalf("create table: %v", err)
 	}
 	if err := fx.subject.Exec(ctx, `


### PR DESCRIPTION
## What broke

`strict-scan` fails intermittently on PRs that touch nothing under `internal/chclient`, blocking them for a reason that has nothing to do with their diff. Most recently on run [30700509166](https://github.com/tsouza/cerberus/actions/runs/30700509166), in the step *Run chclient connection-teardown differential (real ClickHouse)*:

```text
--- FAIL: TestCursorTeardown_ReturnsConnectionToPool (8.51s)
    --- FAIL: TestCursorTeardown_ReturnsConnectionToPool/cancel_before_close_destroys_the_connection (5.02s)
        conn_teardown_integration_test.go:116: server holds 2 native sessions after cancel-then-close teardown; want 1
```

The PR that hit it (#1424) touches `internal/promql`, `internal/chplan`, `internal/chsql` and PromQL fixtures; `strict-scan` was green on all six of its prior SHAs and is green 12/12 on recent `main`. So the lane is not reporting on that PR's change — it is reporting on a race the test itself contains, which is fixed here rather than tolerated there.

## Root cause

The destroy arm asserted the outcome of a race inside clickhouse-go rather than the ordering it exists to test.

Both arms shared one probe. The arm's sequence is `qcancel(); cur.Close()`, and `rows.Close()` **drains** — which is exactly what lets the driver's reader finish. The drain unparks the producer goroutine, the producer reads the remainder (already sitting in the client's socket buffer, because the probe is 2000 tiny rows the server delivers instantly) through to `ServerEndOfStream`, and `connect.process` is left with two ready cases:

```go
select {
case <-ctx.Done():   // the cancellation the arm is trying to observe
    c.cancel()
    return ctx.Err()
case err := <-errCh:
    return err
case <-doneCh:       // the reader completed, because Close() drained for it
    return nil
}
```

Go picks uniformly at random among ready cases. When `doneCh` wins, `process` returns nil, `release(conn, nil)` puts the connection back in the idle pool instead of destroying the socket, the server keeps its session, and the census stays at 2 forever — so the poll runs out its budget and reports the observed value. Same test, same ordering, opposite verdict, decided by the scheduler.

The parent hypothesis for this investigation — that the observer's census reads were being fast-failed by a tripped circuit breaker — is **refuted** by the code: `serverSessions` reads over `Client.Conn()`, which returns the raw `driver.Conn` and bypasses the breaker entirely, and a breaker 503 would fail the read outright rather than return a stale count. The breaker cannot even trip here: `breaker.record` treats `context.Canceled` as no-verdict. The `WARN ch circuit breaker tripped OPEN` lines interleaved in the CI log come from the package's other parallel tests, and the failure reproduces locally with zero breaker WARNs.

## The fix

The two arms need **opposite** stream shapes, and sharing one probe is what made the destroy arm undecidable:

- the release arm needs a remainder that drains to `EndOfStream` well inside `CursorDrainBudget`;
- the destroy arm needs a remainder that **cannot** be drained at all.

So they now get their own probes. `teardownStalledProbeSQL` holds the remainder inside ClickHouse with a per-row `sleepEachRow`. A remainder the server has not produced yet cannot be drained, so `doneCh` is never ready, the reader is blocked on the wire rather than on the block channel, and the cancel is the driver's only terminal branch. The assertion becomes an assertion.

Three supporting details, each of which is the reason the naive version of this does not work:

- **The stall is asserted, not assumed.** `teardownStallFloor` requires the first row to have cost the server roughly one block's worth of sleeps. If a ClickHouse release ever folds `sleepEachRow` away, this fails loudly with an explanation instead of silently restoring the coin flip. A premise nothing checks is how the original shape decayed.
- **`index_granularity` is pinned to the block size.** A MergeTree reader cannot subdivide a granule for the filter stage, so at the default 8192 the whole 2000-row table is one block there no matter what `max_block_size` says — which collapses the stalled probe into a single block with no remainder to stall. This also makes the "eight blocks" premise the existing guard asserts arithmetically true of the server's actual behaviour.
- **It removes a latent panic window.** In the old shape the producer is parked on the block channel when the cancel lands, and `conn_query.go` runs `close(stream)` right after `process` returns — closing a channel out from under a parked sender. The drain happened to unpark it first every time so far. With the stalled probe the reader is never on the channel at that moment.

## Why not a timeout bump

Widening `poolSettleBudget` or retrying the census would change nothing: once the driver has pooled the connection, the server keeps that session **forever**. The 5s budget is not too short — the value never arrives. Loosening the assertion, or skipping the arm, would delete the only coverage cerberus has of the destroy branch of the teardown contract, which is the branch that exists because a cancelling gateway churns connections under load.

## Verification

Against `clickhouse/clickhouse-server:25.8-alpine`, pinned to one CPU with `GOMAXPROCS=1` (the harshest scheduling environment for this race):

| | result |
|---|---|
| before, `-count=3` | 3/3 **FAIL**, each with the CI message verbatim: `server holds 2 native sessions after a cancel-then-close teardown; want 1` |
| after, `-count=3` pinned | 3/3 PASS |
| after, `-count=5` unpinned | 5/5 PASS |

Test-only change; no production code touched.
