### PR TITLE
ci(registry): a rate limit is not a retryable fault

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -30,13 +30,30 @@ One implementation means a new rule guards BOTH lanes at once.
 
 `lib/registry.mjs` owns the one retry policy every container-registry fetch
 follows — the attempt budget (`registryAttempts`), the linear backoff
-(`readBackoffStepSeconds` / `sleepSeconds`), and `isTransientRegistryFailure()`,
-which decides whether command output names a registry / network fault (Docker
-Hub 429, manifest HEAD failure, TLS / reset / DNS / module-proxy transport) or a
-genuine build error. `pull-buildkit-image.mjs` (host-side bootstrap pull) and
-`build-with-registry-retry.mjs` (the build's own `FROM` resolution) hit the same
-rate-limit bucket and fail the same way, so they share the policy instead of
-re-deriving it.
+(`readBackoffStepSeconds` / `sleepSeconds`), and the classification that decides
+whether another attempt is help or harm. It sorts a failure into three classes,
+not two:
+
+- **transport** (`isTransientRegistryFailure()`): manifest HEAD failure, TLS /
+  reset / DNS / 5xx / module-proxy transport. Retryable — the registry is still
+  willing, this attempt just didn't land.
+- **rate limit** (`isRegistryRateLimit()`): `429` / `toomanyrequests` / `pull
+  rate limit`. **Never retryable.** Docker Hub counts pulls per account, or per
+  runner IP when the pull is unauthenticated, over a rolling window measured in
+  hours; a retry budget measured in seconds cannot outlast it, and each attempt
+  spends more of the quota that is already exhausted. Asked FIRST, because
+  BuildKit reports a 429 as `unexpected status from HEAD request …` — a
+  transport signature — so the rate-limit answer has to win outright.
+  `rateLimitDiagnosis()` is the one explanation every consumer prints for it.
+- **everything else**: a genuine build / command failure. Fails on the first
+  attempt, unretried.
+
+`pull-buildkit-image.mjs` (host-side bootstrap pull), the Justfile's
+`_pull-retry` / `_compose-pull-retry` (host pulls and compose pre-pulls, both
+routed through `build-with-registry-retry.mjs` rather than a bash loop),
+`build-with-registry-retry.mjs` (the build's own `FROM` resolution) and
+`chart-kubeconform.mjs`'s image probe all hit the same quota bucket and fail the
+same way, so they share the policy instead of re-deriving it.
 
 `lib/scope-gate.mjs` answers "does THIS pull request touch the scope a heavy
 lane guards?" — `runsFullLane()` (which events must never take a scoped
@@ -648,13 +665,16 @@ uncomputable-diff fallback — cannot drift between the lanes that use it.
   probes the rendered container image tag against the registry — the guard for
   an `appVersion` pointing at an unpublished tag. An image passes only when the
   probe positively confirms it: a definitive not-found fails, and so does any
-  probe that reaches no verdict (auth refusal, rate limit, DNS/TLS), because a
+  probe that reaches no verdict (auth refusal, DNS/TLS, a rate limit), because a
   guard that could not run has verified nothing. Because the chart renders a
-  Docker Hub ref and Docker Hub rate-limits CI bursts, a probe with no verdict
+  Docker Hub ref and a runner's path to Docker Hub blips, a probe with no verdict
   is retried — five attempts with linear backoff, mirroring the Justfile's
-  `_pull-retry` — so a transient refusal does not become a permanent
+  `_pull-retry` — so a transport fault does not become a permanent
   non-verdict; a verdict (`present` or a definitive not-found) is never
-  retried. Exhausted retries still fail. The one exemption is the appVersion
+  retried, and neither is a rate-limit refusal, which is its own
+  `'rate-limited'` state (classified through `lib/registry.mjs`): it fails the
+  check exactly as `'unknown'` does, but re-probing it would only charge the
+  quota that refused. Exhausted retries still fail. The one exemption is the appVersion
   the change itself stages, and it covers a definitive not-found only. The
   `--self-test` drives the real probe against a controlled failing command, so
   the spawn options are pinned at the call site and the retry loop runs for
@@ -1035,11 +1055,14 @@ uncomputable-diff fallback — cannot drift between the lanes that use it.
   pre-acquiring it sufficient; the module therefore asserts presence in the
   daemon rather than a successful pull. The composite passes the same image ref
   to `driver-opts: image=…`, so the warmed ref and the booted ref cannot drift.
+  A rate-limit refusal ends the loop immediately (after the local-image
+  fallback, which is a pass regardless of why the pull failed).
   - Env: `BUILDKIT_IMAGE` (required — image ref to acquire),
     `BUILDKIT_PULL_BACKOFF_SECONDS` (optional; default `3` — linear backoff
     step, attempt N sleeps N × this).
   - Exit: `0` when the image is in the local daemon, `1` when it is not.
-- **`build-with-registry-retry.mjs`** — the Justfile (`e2e-up`, `e2e-bwc-up`,
+- **`build-with-registry-retry.mjs`** — the Justfile (`_pull-retry`,
+  `_compose-pull-retry`, `e2e-up`, `e2e-bwc-up`,
   `migration-cerberus-image`, `migration-tier{1,2}-up`), `e2e.yml`'s
   compose-smoke shards, the three `compatibility/*/scripts/run-*.sh` harnesses,
   and `bench/histogram/run.sh`. Runs an image-building command (`docker build` /
@@ -1056,11 +1079,17 @@ uncomputable-diff fallback — cannot drift between the lanes that use it.
   there is no local-image fallback: a tag an earlier run left in the daemon
   attests nothing about this tree, and a build failure that is not a registry
   failure fails on the FIRST attempt so a real break is never retried into
-  invisibility. Takes the command as its trailing argv.
+  invisibility. A rate-limit refusal fails on the first attempt too, for the
+  opposite reason: the retry cannot work and the attempts themselves are what
+  keep the quota window open (issue #1561). Takes the command as its trailing
+  argv, so the Justfile's host-side pulls route through it as well and inherit
+  the same three-way classification.
   - Env: `IMAGE_BUILD_RETRY_BACKOFF_SECONDS` (optional; default `10` — linear
-    backoff step, attempt N sleeps N × this).
-  - Exit: `0` on success; the command's own status when it failed for a
-    non-registry reason; `1` when the retry budget is spent.
+    backoff step, attempt N sleeps N × this; the Justfile's pull recipes pass
+    `3`).
+  - Exit: `0` on success; the command's own status when it failed for a reason
+    another attempt cannot clear (a genuine failure, or a rate-limit refusal);
+    `1` when the retry budget is spent on transport faults.
 
 ## Notes
 

--- a/.github/scripts/build-with-registry-retry.mjs
+++ b/.github/scripts/build-with-registry-retry.mjs
@@ -1,6 +1,13 @@
-// build-with-registry-retry.mjs — run an image-building command, and retry it
-// when (and only when) it failed because a registry did, not because the build
-// did.
+// build-with-registry-retry.mjs — run a command that fetches from a container
+// registry (an image build, a `docker pull`, a compose pre-pull) and retry it
+// when — and only when — it failed because the network path to the registry
+// did, not because the command itself did and not because the registry refused
+// on quota.
+//
+// The name is historical: the module was written for the build's own `FROM`
+// resolution, and the retry policy it applies turned out to be the same one
+// every registry fetch needs, so the host-side pulls route through it too
+// rather than re-deriving it in bash.
 //
 // The failure this closes, on main @ d939e299 (runs 30695961421 `e2e` and
 // 30695961427 `migration-e2e`, identical signature):
@@ -45,8 +52,11 @@
 //                                      seconds.
 //
 // Exit: 0 on success; the command's own status when it failed for a reason
-// that is not a registry / network fault (a real build error fails on the first
-// attempt, unretried); 1 when the retry budget is spent on transient failures.
+// another attempt cannot clear — a real build error, or a registry rate-limit
+// refusal (see `rateLimitDiagnosis` in lib/registry.mjs: the quota window is
+// hours, so retrying only spends more of the quota that is exhausted) — both
+// unretried, on the first attempt; 1 when the retry budget is spent on
+// transport faults.
 
 import { spawnSync } from 'node:child_process';
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
@@ -56,7 +66,9 @@ import process from 'node:process';
 
 import { error, log, notice } from './lib/gh.mjs';
 import {
+  isRegistryRateLimit,
   isTransientRegistryFailure,
+  rateLimitDiagnosis,
   readBackoffStepSeconds,
   registryAttempts,
   sleepSeconds,
@@ -124,10 +136,18 @@ for (let attempt = 1; attempt <= registryAttempts; attempt++) {
 
   if (status === 0) finish(0);
 
+  // Asked before the transient question, because a rate-limited fetch names a
+  // transport fault too — and this class is the one where another attempt makes
+  // the situation worse rather than merely wasting time.
+  if (isRegistryRateLimit(output)) {
+    error(rateLimitDiagnosis(`\`${rendered}\``));
+    finish(status);
+  }
+
   if (!isTransientRegistryFailure(output)) {
     error(
       `\`${rendered}\` failed with status ${status}, and its output names no registry or network fault. ` +
-        'Failing on the first attempt: retrying a genuine build failure only hides it.',
+        'Failing on the first attempt: retrying a genuine failure only hides it.',
     );
     finish(status);
   }
@@ -143,8 +163,9 @@ for (let attempt = 1; attempt <= registryAttempts; attempt++) {
 }
 
 error(
-  `\`${rendered}\` failed ${registryAttempts} times, every one of them on a transient registry or network ` +
-    'fault. The registry is not answering for this runner — failing the job rather than reporting a build ' +
-    'that never happened.',
+  `\`${rendered}\` failed ${registryAttempts} times, every one of them on a transport fault between this ` +
+    'runner and the registry (a reset connection, a TLS or DNS failure, a 5xx) — never a rate-limit refusal, ' +
+    'which fails on the first attempt instead. The network path to the registry is unhealthy for this runner: ' +
+    'failing the job rather than reporting a build that never happened.',
 );
 finish(1);

--- a/.github/scripts/chart-kubeconform.mjs
+++ b/.github/scripts/chart-kubeconform.mjs
@@ -23,6 +23,7 @@ import { execFileSync } from 'node:child_process'
 import { readdirSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { error as ghError, notice as ghNotice } from './lib/gh.mjs'
+import { isRegistryRateLimit, rateLimitDiagnosis } from './lib/registry.mjs'
 
 const CHART_DIR = process.env.CHART_DIR || 'deploy/helm/cerberus'
 const KUBE_VERSION = process.env.KUBE_VERSION || '1.28.0'
@@ -74,6 +75,13 @@ export function classifyProbeFailure(err) {
   if (/manifest unknown|not found|no such manifest|MANIFEST_UNKNOWN|NAME_UNKNOWN|404/i.test(msg)) {
     return 'missing'
   }
+  // A quota refusal is its own state, not a flavour of 'unknown'. It verifies
+  // nothing, so it fails the check exactly as 'unknown' does — but it is the
+  // one no-verdict that re-probing cannot turn into a verdict, and each probe
+  // is itself a registry request charged to the exhausted counter. Read the
+  // 429 out of `docker manifest inspect`'s stderr with the same vocabulary the
+  // build/pull wrappers use, so one registry speaks one language to CI.
+  if (isRegistryRateLimit(msg)) return 'rate-limited'
   return 'unknown'
 }
 
@@ -95,13 +103,15 @@ function probeOnce(ref, probeCmd) {
 }
 
 // Attempts and backoff mirror the Justfile's `_pull-retry`, which exists for
-// this same registry and this same failure: the chart renders a Docker Hub
-// ref (clickhouse-server), and Docker Hub answers a concurrency burst from CI
-// with `toomanyrequests` even on an authenticated runner. Since 'unknown'
-// FAILS the required `chart-validate` check, one refusal would otherwise fail
-// every open PR at once. Retrying is not tolerance — tolerance would be
-// accepting a non-verdict as a pass; this is giving the probe enough chances
-// to reach a verdict at all.
+// this same registry and this same class of failure: the chart renders a
+// Docker Hub ref (clickhouse-server), and a runner's connection to Docker Hub
+// resets, times out or 5xxes often enough that a single probe is not evidence.
+// Since a no-verdict FAILS the required `chart-validate` check, one transport
+// blip would otherwise fail every open PR at once. Retrying is not tolerance —
+// tolerance would be accepting a non-verdict as a pass; this is giving the
+// probe enough chances to reach a verdict at all. It is bounded to the faults
+// another attempt can clear: a 'rate-limited' probe leaves the loop at once
+// (see classifyProbeFailure).
 const PROBE_ATTEMPTS = 5
 const PROBE_BACKOFF_STEP_MS = 3_000
 
@@ -115,7 +125,10 @@ const PROBE_RETRY = { attempts: PROBE_ATTEMPTS, sleep: sleepSync }
 // imageExists returns the probe's verdict, retrying ONLY while it has none.
 // 'present' and 'missing' are verdicts and return immediately — re-probing a
 // definitive not-found would add PROBE_ATTEMPTS worth of backoff to every
-// release PR, whose staged appVersion is legitimately absent.
+// release PR, whose staged appVersion is legitimately absent. 'rate-limited'
+// returns immediately too, for the opposite reason: it is not a verdict and
+// never becomes one within this loop's timescale, so re-probing only charges
+// the counter that refused.
 export function imageExists(ref, probeCmd = DOCKER_MANIFEST_INSPECT, retry = PROBE_RETRY) {
   let state = 'unknown'
   for (let attempt = 1; attempt <= retry.attempts; attempt++) {
@@ -128,7 +141,8 @@ export function imageExists(ref, probeCmd = DOCKER_MANIFEST_INSPECT, retry = PRO
 
 // probeVerdict maps a probe state onto the check's verdict. An image counts as
 // verified only when the probe positively confirmed it, so 'unknown' — an
-// auth/permission refusal, a rate limit, a DNS or TLS failure — is FATAL: a
+// auth/permission refusal, a DNS or TLS failure — and 'rate-limited' are
+// FATAL: a
 // guard that reached no verdict has verified nothing, and reporting green on
 // it means the `chart-validate` required check passes precisely when the guard
 // is broken. `SKIP_IMAGE_CHECK=1` is the explicit, visible waiver for runs with
@@ -138,6 +152,29 @@ export function probeVerdict(state, isStaged) {
   if (state === 'present') return 'ok'
   if (state === 'missing' && isStaged) return 'staged'
   return 'fail'
+}
+
+// probeFailureReport — why this ref failed, in the terms that make the next
+// action obvious. The three failing states need three different sentences: a
+// definitive not-found is a chart bug, a quota refusal is a pull-volume
+// problem the shared diagnosis already explains, and everything else is
+// registry access that has to be fixed before the guard means anything.
+export function probeFailureReport(state, ref) {
+  if (state === 'missing') {
+    return `rendered image does not exist in the registry: ${ref} — the chart's appVersion/image.tag points at an unpublished tag`
+  }
+  if (state === 'rate-limited') {
+    return (
+      `could not verify image ${ref} — ${rateLimitDiagnosis('the registry existence probe')} ` +
+      'The image-existence guard did not run, and an unverified image is not a verified one.'
+    )
+  }
+  return (
+    `could not verify image ${ref} — the registry probe was retried ${PROBE_ATTEMPTS} times with backoff and still ` +
+    `reached no verdict, so the image-existence guard did not run. That is a registry that is down or refusing, not ` +
+    `a single flaky call. Fix the registry access (or set SKIP_IMAGE_CHECK=1 for an air-gapped run); an unverified ` +
+    `image is not a verified one.`
+  )
 }
 
 // The appVersion this very change stages, or null if it is unchanged.
@@ -188,6 +225,8 @@ function gitShow(ref, path) {
 // verdict, and a refusal that says nothing about whether the image exists.
 const NOT_FOUND_STDERR = 'manifest unknown'
 const NO_VERDICT_STDERR = 'unauthorized: authentication required'
+// …and the refusal that says nothing about the image AND cannot be re-asked.
+const RATE_LIMITED_STDERR = 'toomanyrequests: You have reached your unauthenticated pull rate limit.'
 
 // probeCmd factories for the self-test: a node subprocess that writes `phrase`
 // to stderr and exits non-zero, and one that succeeds silently.
@@ -207,8 +246,9 @@ const failingProbe = (phrase) => () => [
 const succeedingProbe = () => [process.execPath, ['-e', '']]
 
 // One command per probe state, so a test can script what each attempt sees.
+const probeStderrFor = { missing: NOT_FOUND_STDERR, 'rate-limited': RATE_LIMITED_STDERR }
 const probeFor = (state) =>
-  state === 'present' ? succeedingProbe() : failingProbe(state === 'missing' ? NOT_FOUND_STDERR : NO_VERDICT_STDERR)()
+  state === 'present' ? succeedingProbe() : failingProbe(probeStderrFor[state] ?? NO_VERDICT_STDERR)()
 
 // scriptedProbe hands out one command per attempt from `states` (the last
 // entry repeats) and counts the attempts, so a test can assert not just the
@@ -255,7 +295,7 @@ function selfTest() {
   const recovered = scriptedProbe(['unknown', 'present'])
   check(
     probeVerdict(imageExists('probe-self-test', recovered.cmd, recordedRetry([])), false) === 'ok',
-    'a rate-limited probe that then answers ends verified — the retry is what reaches the verdict',
+    'a probe with no verdict that then answers ends verified — the retry is what reaches the verdict',
   )
   check(recovered.calls.count === 2, 'retrying stops the moment the probe reaches a verdict')
 
@@ -270,6 +310,37 @@ function selfTest() {
   check(
     slept.join() === expectedBackoff.join(),
     'backoff grows linearly between attempts, and nothing waits after the last one',
+  )
+
+  // The rate-limit class, against the negative control directly above it: a
+  // transport no-verdict spends every attempt, a quota refusal spends one. The
+  // pair is the whole point — the probe must still retry what retrying fixes,
+  // and must stop charging a counter whose window outlasts the loop.
+  const rateLimited = scriptedProbe(['rate-limited'])
+  check(
+    imageExists('probe-self-test', rateLimited.cmd, recordedRetry([])) === 'rate-limited',
+    'a 429 on the probe classifies as rate-limited, not as a generic no-verdict',
+  )
+  check(
+    rateLimited.calls.count === 1,
+    'a rate-limited probe is asked exactly once — re-probing spends the quota that refused it',
+  )
+  check(
+    probeVerdict('rate-limited', false) === 'fail' && probeVerdict('rate-limited', true) === 'fail',
+    'a rate-limited probe fails the check, staged or not — it verified nothing',
+  )
+  const rateLimitReport = probeFailureReport('rate-limited', 'clickhouse/clickhouse-server:25.8')
+  check(
+    /QUOTA, not an outage/.test(rateLimitReport) && /retrying cannot clear it/.test(rateLimitReport),
+    'the rate-limit report names the quota and says retrying cannot help',
+  )
+  check(
+    !/retried \d+ times/.test(rateLimitReport),
+    'the rate-limit report does not claim a retry budget was spent — one attempt was made',
+  )
+  check(
+    /retried \d+ times/.test(probeFailureReport('unknown', 'clickhouse/clickhouse-server:25.8')),
+    'a transport no-verdict still reports the retries it spent',
   )
 
   const unpublished = scriptedProbe(['missing'])
@@ -304,9 +375,17 @@ function selfTest() {
 
   // None of these says the image is absent, and none of them says it is there
   // either: each classifies as unknown, and unknown fails the check.
-  for (const noVerdict of [NO_VERDICT_STDERR, 'toomanyrequests: retry later', 'tls: handshake timeout']) {
+  for (const noVerdict of [NO_VERDICT_STDERR, 'tls: handshake timeout', 'dial tcp: i/o timeout']) {
     check(classifyProbeFailure({ stderr: noVerdict }) === 'unknown', `not a not-found verdict: ${noVerdict}`)
     check(probeVerdict(classifyProbeFailure({ stderr: noVerdict }), false) === 'fail', `probe failure fails the check: ${noVerdict}`)
+  }
+
+  // The quota refusals, in the forms `docker manifest inspect` relays them.
+  // They fail the check exactly as the above do, and are held apart from them
+  // only so the loop stops re-asking.
+  for (const refused of [RATE_LIMITED_STDERR, 'toomanyrequests: retry later', 'received 429 Too Many Requests']) {
+    check(classifyProbeFailure({ stderr: refused }) === 'rate-limited', `a quota refusal is its own state: ${refused}`)
+    check(probeVerdict(classifyProbeFailure({ stderr: refused }), false) === 'fail', `a quota refusal fails the check: ${refused}`)
   }
 
   check(probeVerdict('present', false) === 'ok', 'a confirmed image passes')
@@ -413,14 +492,7 @@ if (!SKIP_IMAGE_CHECK) {
         ghNotice(`image not published yet, as expected — this change stages appVersion ${staged}: ${ref}`)
         break
       default:
-        ghError(
-          state === 'missing'
-            ? `rendered image does not exist in the registry: ${ref} — the chart's appVersion/image.tag points at an unpublished tag`
-            : `could not verify image ${ref} — the registry probe was retried ${PROBE_ATTEMPTS} times with backoff and still ` +
-                `reached no verdict, so the image-existence guard did not run. That is a registry that is down, refusing, or ` +
-                `rate-limiting, not a single flaky call. Fix the registry access (or set SKIP_IMAGE_CHECK=1 for an air-gapped ` +
-                `run); an unverified image is not a verified one.`,
-        )
+        ghError(probeFailureReport(state, ref))
         ok = false
     }
   }

--- a/.github/scripts/lib/registry.mjs
+++ b/.github/scripts/lib/registry.mjs
@@ -10,21 +10,46 @@
 // linear backoff, and the "is this failure worth another attempt" question
 // belong in one module rather than being re-derived per call site.
 //
+// A registry says no in two fundamentally different ways, and the difference
+// decides whether retrying is help or harm:
+//
+//   * a TRANSPORT fault — reset connection, TLS timeout, DNS, a 5xx — is a
+//     failed attempt at something the registry is still willing to do. Another
+//     attempt is free and usually works.
+//   * a RATE LIMIT is the registry declining on purpose, against a counter that
+//     only time decrements. Docker Hub counts pulls per account (or, for an
+//     unauthenticated pull, per source IP) over a rolling window measured in
+//     HOURS. A retry budget measured in seconds cannot outlast it, and each
+//     attempt spends more of the very quota that is exhausted — so retrying is
+//     strictly worse than failing, both for this job and for every other job
+//     sharing the counter.
+//
+// So the rate-limit class is classified separately and is NOT retryable. That
+// is not tolerance: the job still fails: it fails on the first attempt, with an
+// error that names the quota instead of implying an outage.
+//
 // Exports:
 //   registryAttempts                       attempts an acquisition gets.
 //   readBackoffStepSeconds(env, fallback)  validated linear backoff step.
 //   sleepSeconds(seconds)                  synchronous sleep.
-//   isTransientRegistryFailure(text)       true when command output names a
-//                                          registry / network fault rather
-//                                          than a genuine build error.
+//   isRegistryRateLimit(text)              true when output names a registry
+//                                          rate-limit refusal. Never retry.
+//   isTransientRegistryFailure(text)       true when output names a registry /
+//                                          network fault that another attempt
+//                                          can clear — false for a rate limit
+//                                          and false for a genuine build error.
+//   rateLimitDiagnosis(subject)            the one explanation every consumer
+//                                          prints for the rate-limit class.
 
 import process from 'node:process';
 
 import { error } from './gh.mjs';
 
 // Five attempts with a linear backoff: long enough to ride out a registry blip
-// or a Docker Hub 429 burst, short enough that a genuinely unreachable registry
-// fails the job rather than parking it. Mirrors the Justfile's `_pull-retry`.
+// or a transport fault, short enough that a genuinely unreachable registry
+// fails the job rather than parking it. It is deliberately NOT the budget a
+// rate limit gets — that class gets one attempt. Mirrors the Justfile's
+// `_pull-retry`.
 export const registryAttempts = 5;
 
 const msPerSecond = 1_000;
@@ -52,22 +77,51 @@ export function readBackoffStepSeconds(envName, fallbackSeconds) {
   return seconds;
 }
 
-// The failure signatures that mean "the registry / network said no", as
-// distinct from "the build said no". Every entry is a fault in fetching bytes
-// over the wire, never a compiler, linker, test or Dockerfile error — that
-// distinction is what lets a caller retry on this list and fail immediately off
-// it, instead of retrying (and so hiding) a real build failure.
-//
-// The 429 that took `e2e` + `migration-e2e` down on main lands in the first two
-// entries:
+// The signatures of a registry refusing on quota, in every form the toolchain
+// surfaces one: the HTTP status, the registry error code, and the prose the
+// daemon relays from Docker Hub's own body.
 //
 //   #5 ERROR: unexpected status from HEAD request to
 //      https://registry-1.docker.io/v2/library/golang/manifests/1.26:
 //      429 Too Many Requests
-const transientRegistryFailurePatterns = [
-  // Docker Hub rate limiting, in both the HTTP-status and the error-code form.
+//
+//   toomanyrequests: You have reached your unauthenticated pull rate limit.
+const registryRateLimitPatterns = [
   /429 Too Many Requests/i,
   /\btoomanyrequests\b/i,
+  /\bpull rate limit\b/i,
+  /\brate limit exceeded\b/i,
+];
+
+export function isRegistryRateLimit(text) {
+  const haystack = String(text ?? '');
+  return registryRateLimitPatterns.some((re) => re.test(haystack));
+}
+
+// rateLimitDiagnosis — the single explanation for the class, so every consumer
+// says the same true thing. The wording it replaced ("the registry is not
+// answering for this runner") described an outage, and a whole afternoon of
+// red lanes across every open PR was read as a Docker Hub incident before
+// anyone questioned it. Naming the quota, its window, and the fact that the
+// retry already happened and could not have helped is what makes the next
+// reader look at pull volume instead of at a vendor status page.
+export function rateLimitDiagnosis(subject) {
+  return (
+    `${subject} was refused by the registry's pull rate limit. This is a QUOTA, not an outage: the counter is ` +
+    'per account — or per runner IP when the pull is unauthenticated — over a rolling window measured in hours, ' +
+    'so retrying cannot clear it, and every extra attempt spends more of the quota that is already exhausted. ' +
+    'Failing on the first attempt by design. The fixes, in order: pull the image from a registry this project ' +
+    'controls, authenticate the pull, or cut the number of concurrent jobs pulling it and wait out the window.'
+  );
+}
+
+// The failure signatures that mean "the registry / network said no", as
+// distinct from "the build said no" and from "the registry said not-so-fast".
+// Every entry is a fault in fetching bytes over the wire, never a compiler,
+// linker, test or Dockerfile error — that distinction is what lets a caller
+// retry on this list and fail immediately off it, instead of retrying (and so
+// hiding) a real build failure.
+const transientRegistryFailurePatterns = [
   // BuildKit / containerd manifest + blob resolution against a registry that
   // answered with something other than the content.
   /unexpected status from (?:HEAD|GET|POST) request/i,
@@ -91,7 +145,13 @@ const transientRegistryFailurePatterns = [
   /server misbehaving/i,
 ];
 
+// A rate-limited fetch is reported by BuildKit as `unexpected status from HEAD
+// request … 429`, which matches the transient list too — so the rate-limit
+// question is asked FIRST and wins outright. Any output naming a quota refusal
+// is non-retryable even when it also names a transport fault: the one thing a
+// caller must not do while a quota is exhausted is spend more of it.
 export function isTransientRegistryFailure(text) {
   const haystack = String(text ?? '');
+  if (isRegistryRateLimit(haystack)) return false;
   return transientRegistryFailurePatterns.some((re) => re.test(haystack));
 }

--- a/.github/scripts/pull-buildkit-image.mjs
+++ b/.github/scripts/pull-buildkit-image.mjs
@@ -18,10 +18,12 @@
 // successful pull: an exhausted retry over an image the runner already holds
 // is a pass, because that is precisely the state buildx falls back to.
 //
-// The attempt budget, the backoff and the transient-failure vocabulary are
-// shared with the image-build wrapper via ./lib/registry.mjs — the bootstrap
-// pull and a build's `FROM` resolution hit the same registry and fail the same
-// way, so they retry to the same policy.
+// The attempt budget, the backoff and the failure vocabulary are shared with
+// the image-build wrapper via ./lib/registry.mjs — the bootstrap pull and a
+// build's `FROM` resolution hit the same registry and fail the same way, so
+// they retry to the same policy, and stop retrying on the same class: a
+// rate-limit refusal ends the loop at once rather than spending four more
+// pulls out of the quota that is refusing this one.
 //
 // Env:
 //   BUILDKIT_IMAGE                 (required) image ref to acquire, e.g.
@@ -37,7 +39,13 @@
 import process from 'node:process';
 
 import { capture, error, log, notice } from './lib/gh.mjs';
-import { readBackoffStepSeconds, registryAttempts, sleepSeconds } from './lib/registry.mjs';
+import {
+  isRegistryRateLimit,
+  rateLimitDiagnosis,
+  readBackoffStepSeconds,
+  registryAttempts,
+  sleepSeconds,
+} from './lib/registry.mjs';
 
 // A bootstrap pull is a single manifest + a handful of layers, so a short step
 // is enough to ride out a reset connection; the image-build wrapper waits
@@ -73,13 +81,23 @@ for (let attempt = 1; attempt <= registryAttempts; attempt++) {
     process.exit(0);
   }
 
+  // A quota refusal is checked only after the local-image fallback, because a
+  // copy already in the daemon satisfies the postcondition no matter why the
+  // pull failed. With no local copy there is nothing to wait for: the window
+  // outlasts the budget, so the remaining attempts would only deepen the
+  // deficit that is failing this job and every concurrent one.
+  if (isRegistryRateLimit(res.stderr + res.stdout)) {
+    error(rateLimitDiagnosis(`docker pull ${image}`));
+    process.exit(1);
+  }
+
   if (attempt < registryAttempts) {
     sleepSeconds(attempt * backoffStepSeconds);
   }
 }
 
 error(
-  `docker pull ${image} failed ${registryAttempts} times and the image is absent from the local daemon, ` +
-    'so `buildx inspect --bootstrap` has nothing to boot from.',
+  `docker pull ${image} failed ${registryAttempts} times on transport faults and the image is absent from the ` +
+    'local daemon, so `buildx inspect --bootstrap` has nothing to boot from.',
 );
 process.exit(1);

--- a/Justfile
+++ b/Justfile
@@ -671,15 +671,18 @@ K3D_EXTRA_ARGS := env_var_or_default("K3D_EXTRA_ARGS", "")
 # Pull each image with retry + linear backoff. Docker Hub from CI runners
 # intermittently times out the pull ("context deadline exceeded"); retrying
 # clears the transient failure instead of failing k3d creation / image staging.
+#
+# The retry itself is `.github/scripts/build-with-registry-retry.mjs` rather
+# than a bash loop, because WHICH failures deserve another attempt is the whole
+# question and it has exactly one right answer. A hand-rolled loop retries
+# everything: a `manifest unknown` five times (slower red, same verdict), and —
+# the failure that made this a rule — a Docker Hub rate-limit refusal five
+# times, spending four more pulls out of the quota that is already exhausted.
+# `lib/registry.mjs` owns that classification for every call site at once.
 _pull-retry +IMAGES:
     @for img in {{IMAGES}}; do \
-        ok=0; \
-        for attempt in 1 2 3 4 5; do \
-            echo "    docker pull $img (attempt $attempt)"; \
-            docker pull "$img" >/dev/null && { ok=1; break; }; \
-            sleep $((attempt * 3)); \
-        done; \
-        [ "$ok" = 1 ] || { echo "ERROR: docker pull $img failed after 5 attempts" >&2; exit 1; }; \
+        IMAGE_BUILD_RETRY_BACKOFF_SECONDS=3 node .github/scripts/build-with-registry-retry.mjs \
+            docker pull "$img" || exit 1; \
     done
 
 # Acquire every image a compose stack needs, with retry, BEFORE `up` reaches for
@@ -697,16 +700,13 @@ _pull-retry +IMAGES:
 # — `cerberus-migration-tier2:dead-end-receiver` exists in no registry, so the
 # pull failed five times and took the lane with it. Whether an image is
 # *pullable* is a property of the compose model, not of daemon state.
+#
+# Same retry owner as `_pull-retry`, for the same reason.
 _compose-pull-retry +FILES:
     @args=""; for f in {{FILES}}; do args="$args -f $f"; done; \
     echo "==> pre-pulling compose images (retry — Docker Hub flaky from CI)"; \
-    ok=0; \
-    for attempt in 1 2 3 4 5; do \
-        echo "    docker compose pull (attempt $attempt)"; \
-        docker compose $args pull --ignore-buildable --policy missing && { ok=1; break; }; \
-        sleep $((attempt * 3)); \
-    done; \
-    [ "$ok" = 1 ] || { echo "ERROR: docker compose pull failed after 5 attempts" >&2; exit 1; }
+    IMAGE_BUILD_RETRY_BACKOFF_SECONDS=3 node .github/scripts/build-with-registry-retry.mjs \
+        docker compose $args pull --ignore-buildable --policy missing
 
 # `_pull-retry` / `_compose-pull-retry` protect the images the HOST daemon
 # fetches. The images a BUILD fetches — the `FROM` refs BuildKit resolves while

--- a/test/regression/buildx_bootstrap_retry_test.go
+++ b/test/regression/buildx_bootstrap_retry_test.go
@@ -222,11 +222,21 @@ func TestBuildxCompositeAcquiresTheImageItBoots(t *testing.T) {
 func TestBuildkitImagePullRetriesAndFallsBack(t *testing.T) {
 	t.Parallel()
 
-	// The module's own retry budget. A pull that never succeeds against a
-	// daemon that holds no local copy must be attempted exactly this many
-	// times: fewer means the flake gets through, more means an unreachable
-	// registry stalls the job.
+	// The module's own retry budget for the TRANSPORT class. A pull that never
+	// succeeds against a daemon that holds no local copy must be attempted
+	// exactly this many times: fewer means the flake gets through, more means
+	// an unreachable registry stalls the job.
 	const pullAttempts = 5
+
+	// The two ways the bootstrap pull fails. A transport fault earns the full
+	// budget; a quota refusal earns exactly one attempt, because the window it
+	// is counted over outlasts any backoff this loop can spend and every extra
+	// attempt deepens the deficit (issue #1561).
+	const (
+		transportFault = "connection reset by peer"
+		rateLimited    = "toomanyrequests: You have reached your unauthenticated pull rate limit."
+		oneAttempt     = 1
+	)
 
 	cases := []struct {
 		name string
@@ -236,13 +246,17 @@ func TestBuildkitImagePullRetriesAndFallsBack(t *testing.T) {
 		// imageInDaemon makes the stub's `docker image inspect` succeed,
 		// i.e. the runner already holds the image.
 		imageInDaemon bool
-		wantExitCode  int
-		wantPulls     int
+		// failureText is what the stub's failing pull writes to stderr; it is
+		// what the module classifies on.
+		failureText  string
+		wantExitCode int
+		wantPulls    int
 	}{
 		{
 			name:           "retries a failing pull until the budget is spent",
 			pullSucceedsOn: pullAttempts + 1,
 			imageInDaemon:  false,
+			failureText:    transportFault,
 			wantExitCode:   1,
 			wantPulls:      pullAttempts,
 		},
@@ -250,6 +264,7 @@ func TestBuildkitImagePullRetriesAndFallsBack(t *testing.T) {
 			name:           "a transient failure is ridden out",
 			pullSucceedsOn: 2,
 			imageInDaemon:  false,
+			failureText:    transportFault,
 			wantExitCode:   0,
 			wantPulls:      2,
 		},
@@ -257,6 +272,29 @@ func TestBuildkitImagePullRetriesAndFallsBack(t *testing.T) {
 			name:           "an image already in the daemon satisfies the postcondition",
 			pullSucceedsOn: pullAttempts + 1,
 			imageInDaemon:  true,
+			failureText:    transportFault,
+			wantExitCode:   0,
+			wantPulls:      1,
+		},
+		{
+			name: "a rate-limited pull is attempted once, not five times",
+			// It would have succeeded on the second attempt. It still fails:
+			// what is under test is that the loop stops spending a quota it
+			// has just been told is exhausted.
+			pullSucceedsOn: 2,
+			imageInDaemon:  false,
+			failureText:    rateLimited,
+			wantExitCode:   1,
+			wantPulls:      oneAttempt,
+		},
+		{
+			name: "a locally present image still passes when the registry rate-limits",
+			// The fallback is asked BEFORE the quota question, because a copy
+			// in the daemon is the artefact wanted no matter why the pull
+			// failed — buildx boots from exactly that copy.
+			pullSucceedsOn: pullAttempts + 1,
+			imageInDaemon:  true,
+			failureText:    rateLimited,
 			wantExitCode:   0,
 			wantPulls:      1,
 		},
@@ -272,7 +310,7 @@ func TestBuildkitImagePullRetriesAndFallsBack(t *testing.T) {
 			if tc.imageInDaemon {
 				inspectStatus = 0
 			}
-			writeStubDocker(t, dir, callLog, tc.pullSucceedsOn, inspectStatus)
+			writeStubDocker(t, dir, callLog, tc.pullSucceedsOn, inspectStatus, tc.failureText)
 
 			cmd := exec.Command("node", "../../.github/scripts/"+buildxPullScript)
 			cmd.Env = append(
@@ -312,7 +350,7 @@ func TestBuildkitImagePullRetriesAndFallsBack(t *testing.T) {
 
 // writeStubDocker drops a `docker` onto dir that records every `pull` and
 // answers `image inspect` with inspectStatus.
-func writeStubDocker(t *testing.T, dir, callLog string, pullSucceedsOn, inspectStatus int) {
+func writeStubDocker(t *testing.T, dir, callLog string, pullSucceedsOn, inspectStatus int, failureText string) {
 	t.Helper()
 
 	script := strings.Join([]string{
@@ -322,7 +360,7 @@ func writeStubDocker(t *testing.T, dir, callLog string, pullSucceedsOn, inspectS
 		"    echo pull >> " + shellQuote(callLog),
 		"    attempts=$(wc -l < " + shellQuote(callLog) + " | tr -d ' ')",
 		"    [ \"$attempts\" -ge " + strconv.Itoa(pullSucceedsOn) + " ] && exit 0",
-		"    echo 'stub: connection reset by peer' >&2",
+		"    echo " + shellQuote("stub: "+failureText) + " >&2",
 		"    exit 1",
 		"    ;;",
 		"  image)",

--- a/test/regression/image_build_registry_retry_test.go
+++ b/test/regression/image_build_registry_retry_test.go
@@ -34,15 +34,28 @@ import (
 // wraps the build command itself, and these guards pin that every
 // build-invoking command goes through it and that it retries the transient
 // class ONLY.
+//
+// The rate limit is NOT in that class, and issue #1561 is what that cost. A
+// wrapper that retried `toomanyrequests` five times turned one refused pull
+// into five refused pulls on a counter that only time decrements — across ~8
+// open PRs and every image-pulling lane, the retry budget was itself holding
+// the quota window open. The window is hours; the backoff is ~100 seconds; no
+// number of attempts can outlast it. So a quota refusal fails on the FIRST
+// attempt, and the cases below pin both halves: the transport class still
+// retries, and the rate-limit class does not — even when the same output also
+// names a transport fault, which BuildKit's `unexpected status from HEAD
+// request … 429` always does.
 
 const (
 	buildRetryWrapper     = "build-with-registry-retry.mjs"
 	buildRetryWrapperPath = "../../.github/scripts/" + buildRetryWrapper
 
-	// The wrapper's own attempt budget (lib/registry.mjs `registryAttempts`).
-	// Fewer lets the flake through; more parks the job on a registry that is
-	// genuinely refusing this runner.
+	// The wrapper's own attempt budget for the TRANSPORT class (lib/registry.mjs
+	// `registryAttempts`). Fewer lets the flake through; more parks the job on a
+	// network path that is genuinely broken for this runner. A rate-limit
+	// refusal is not on this budget at all — it gets one attempt.
 	buildRetryAttempts = 5
+	rateLimitAttempts  = 1
 
 	// Floor for the class scan. The wrapped set is currently 13 (5 Justfile,
 	// 4 compatibility harness, 2 e2e.yml, 2 bench); the floor guards against a
@@ -178,20 +191,31 @@ func TestImageBuildingCommandsGoThroughTheRetryWrapper(t *testing.T) {
 }
 
 // TestBuildRetryWrapperRetriesOnlyTransientRegistryFailures drives the module
-// against a stub `docker` on PATH. The two halves are equally load-bearing: a
-// wrapper that does not retry the 429 fixes nothing, and one that retries a
-// genuine build failure is a `continue-on-error` in disguise — it would turn a
-// broken build into five broken builds and a slower red.
+// against a stub `docker` on PATH. The three halves are equally load-bearing: a
+// wrapper that does not retry a reset connection fixes nothing, one that
+// retries a genuine build failure is a `continue-on-error` in disguise — it
+// would turn a broken build into five broken builds and a slower red — and one
+// that retries a rate-limit refusal spends four more pulls out of the exhausted
+// quota that is failing this job and every concurrent one.
 func TestBuildRetryWrapperRetriesOnlyTransientRegistryFailures(t *testing.T) {
 	t.Parallel()
 
 	const (
+		// The two forms Docker Hub's refusal arrives in. The first is also a
+		// transport signature (`unexpected status from HEAD request`), so it
+		// doubles as the precedence case: rate limit wins, no retry.
 		hubRateLimit = "#5 ERROR: unexpected status from HEAD request to " +
 			"https://registry-1.docker.io/v2/library/golang/manifests/1.26: 429 Too Many Requests"
+		hubRateLimitProse = "toomanyrequests: You have reached your unauthenticated pull rate limit."
+
+		resetConnection     = `#4 ERROR: failed to do request: Head "https://registry-1.docker.io/v2/": read: connection reset by peer`
 		compileError        = "internal/api/prom/handler.go:12:2: undefined: notAThing"
 		compileExitStatus   = 2
 		neverSucceeds       = buildRetryAttempts + 1
 		succeedsImmediately = 1
+		// Late enough that a retrying wrapper WOULD have succeeded: the
+		// rate-limit cases fail anyway, which is the behaviour under test.
+		wouldSucceedOnRetry = 3
 	)
 
 	cases := []struct {
@@ -202,22 +226,46 @@ func TestBuildRetryWrapperRetriesOnlyTransientRegistryFailures(t *testing.T) {
 		failureExit  int
 		wantExitCode int
 		wantCalls    int
+		// wantReport is a phrase the failure report must carry. The wording is
+		// part of the fix, not decoration: the report this replaced said "the
+		// registry is not answering for this runner", and a whole afternoon of
+		// red lanes was diagnosed as a Docker Hub outage on the strength of it.
+		wantReport string
 	}{
 		{
-			name:         "a Docker Hub 429 is ridden out",
-			succeedsOn:   3,
-			failureText:  hubRateLimit,
+			name:         "a transport fault is ridden out",
+			succeedsOn:   wouldSucceedOnRetry,
+			failureText:  resetConnection,
 			failureExit:  1,
 			wantExitCode: 0,
-			wantCalls:    3,
+			wantCalls:    wouldSucceedOnRetry,
 		},
 		{
 			name:         "a registry that never answers spends the budget and fails the job",
 			succeedsOn:   neverSucceeds,
-			failureText:  hubRateLimit,
+			failureText:  resetConnection,
 			failureExit:  1,
 			wantExitCode: 1,
 			wantCalls:    buildRetryAttempts,
+			wantReport:   "transport fault",
+		},
+		{
+			name:         "a Docker Hub 429 fails on the first attempt, even though a retry would have worked",
+			succeedsOn:   wouldSucceedOnRetry,
+			failureText:  hubRateLimit,
+			failureExit:  1,
+			wantExitCode: 1,
+			wantCalls:    rateLimitAttempts,
+			wantReport:   "QUOTA, not an outage",
+		},
+		{
+			name:         "the prose form of the same refusal is not retried either",
+			succeedsOn:   wouldSucceedOnRetry,
+			failureText:  hubRateLimitProse,
+			failureExit:  1,
+			wantExitCode: 1,
+			wantCalls:    rateLimitAttempts,
+			wantReport:   "retrying cannot clear it",
 		},
 		{
 			name:         "a genuine build failure is not retried and keeps its exit status",
@@ -275,6 +323,10 @@ func TestBuildRetryWrapperRetriesOnlyTransientRegistryFailures(t *testing.T) {
 			calls := len(strings.Fields(string(logged)))
 			if calls != tc.wantCalls {
 				t.Errorf("the build ran %d time(s), want %d\noutput:\n%s", calls, tc.wantCalls, out)
+			}
+			if tc.wantReport != "" && !strings.Contains(string(out), tc.wantReport) {
+				t.Errorf("the failure report never says %q, so it does not name why the job failed\noutput:\n%s",
+					tc.wantReport, out)
 			}
 		})
 	}


### PR DESCRIPTION
## What

`#1534`'s retry wrapper classified Docker Hub's `toomanyrequests` as a transient
registry fault and gave it **five attempts**. For this fault class retrying
cannot succeed, and each attempt re-spends the exact quota that is exhausted —
so across ~8 open PRs × every image-pulling lane, the retry budget was itself
part of what held the rate-limit window open.

`lib/registry.mjs` now sorts a registry failure into **three** classes, not two:

| class | signatures | attempts |
|---|---|---|
| transport | reset, TLS/DNS, 5xx, manifest HEAD, module proxy | 5, unchanged |
| **rate limit** | `429` / `toomanyrequests` / `pull rate limit` | **1** |
| genuine failure | anything else | 1, unchanged |

The rate-limit question is asked **first**, because BuildKit reports a 429 as
`unexpected status from HEAD request …` — a transport signature — so the quota
answer has to win outright even when both appear in one log.

## Why the wording changed too

The old message —

> the registry is not answering for this runner — failing the job rather than
> reporting a build that never happened

— describes an *outage*. That is how an afternoon of red lanes across the repo
came to be read as a Docker Hub incident, which delayed the real diagnosis.
`rateLimitDiagnosis()` is now the single explanation every consumer prints: it
names the quota, says the counter is per account (or per runner IP when
unauthenticated) over a window measured in hours, and states that retrying
cannot clear it.

## Consumers, fixed at the root

Fixed once in `lib/registry.mjs`; no lane was patched individually.

- `build-with-registry-retry.mjs` — fails on the first attempt, propagating the
  command's own status.
- `pull-buildkit-image.mjs` — ends the loop at once, *after* the local-image
  fallback (a copy in the daemon is the artefact wanted no matter why the pull
  failed).
- `chart-kubeconform.mjs` — the image probe gains a `'rate-limited'` state. It
  fails the `chart-validate` check exactly as `'unknown'` does — an unverified
  image is still unverified — but is never re-probed, because each probe is
  itself a request charged to the refusing counter.
- `Justfile` `_pull-retry` / `_compose-pull-retry` — two hand-rolled bash loops
  that retried *everything* five times (including a `manifest unknown`) now
  route through the same wrapper, so one classification serves every call site.

## Tests

Behavioural, against a stub `docker` on `PATH`, with the negative controls that
make the split real rather than asserted:

- a transport fault still spends the full budget and still rides out a blip;
- a 429 fails on the **first** attempt in a fixture where a retry demonstrably
  *would* have succeeded (`succeedsOn: 3`);
- both refusal forms are covered — BuildKit's HEAD-request 429 (which doubles as
  the precedence case) and Docker Hub's `toomanyrequests` prose;
- the failure report is asserted to say `QUOTA, not an outage` and
  `retrying cannot clear it`, and *not* to claim a retry budget it did not spend;
- `chart-kubeconform --self-test` grows the rate-limited state, its
  one-attempt count, and its verdict (55 assertions green).

## Scope

This is the first of two parts of #1561 and does not close it. It cuts every
failing lane's pull cost from 5 attempts to 1, which reduces the load keeping
the window open. The stronger structural fix — mirroring the upstream images to
GHCR, which `compatibility.yml:255-258` already names as the right answer — is
tracked by #1561, which stays open, and subsumes #1562.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
