### PR TITLE
ci(git): refuse to line-merge generated baselines

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,140 @@
+# Generated artefacts: never line-merge, always regenerate.
+#
+# Every path marked `-merge` below is written by a regeneration command, not by
+# hand. For those files a three-way line merge is NEVER a correct resolution —
+# and, the dangerous part, it usually does not look like an incorrect one
+# either. A generated baseline is typically a sorted array of records or a
+# sorted roster of IDs, so two branches that each insert entries at nearby
+# offsets produce a merge git resolves *without a conflict*: the record
+# boundaries shift, names end up paired with the next record's values, and the
+# result still parses as valid JSON with a plausible length while every entry in
+# the blended region is wrong.
+#
+# That happened on PR #1422 to test/perf/cardinality-baseline.json: the whole
+# traceql block came out off by one, and so did the promql
+# histogram_quantile_classic_* block from the other side. A ratchet fed a
+# silently blended baseline is worse than no ratchet — it reports green while
+# measuring nothing real.
+#
+# `-merge` is the fix. It unsets the merge attribute, so git falls back to the
+# binary merge driver and refuses to blend: a concurrent change leaves the path
+# CONFLICTED with no markers written into it, which forces the only correct
+# resolution — take the merged code, re-run the generator named below, commit
+# its output.
+#
+# `-merge` is not `-diff`. These stay ordinary text for `git diff`, `git blame`
+# and review; only the automatic merge is withheld. It also only bites when BOTH
+# sides changed the file — a one-sided change still resolves cleanly.
+#
+# Adding a new generated artefact? Add it here. The gate is pinned from both
+# directions by test/regression/generated_artifact_merge_gate_test.go, which
+# also fails on any tracked data file NAMED like a generated artefact that is
+# neither gated here nor recorded in the hand-authored section at the bottom.
+
+# --- Perf ratchet baselines -------------------------------------------------
+# Regenerate: `just update-cardinality-baseline`
+#   (UPDATE_CARDINALITY_BASELINE=1 go test -tags chdb -count=1
+#    -run TestCardinalityRatchet ./test/perf/ — needs libchdb.so via
+#   `just chdb-install`). Also reached by `just update-golden`, which chains it
+#   as a SUBSEQUENT dep so it profiles the freshly rewritten `-- sql --`.
+#   Top-level flat array of 805 fixture records: the shape that bit us.
+test/perf/cardinality-baseline.json          -merge
+
+# Regenerate: `just update-solver-decision-baseline`
+#   (UPDATE_SOLVER_DECISION_BASELINE=1 go test -count=1
+#    -run TestSolverDecisionRatchet ./test/perf/ — pure Go, no chDB). Also
+#   reached by `just update-golden`, which chains it as a PRIOR dep.
+#   Top-level flat array of 452 query records — same shape, same hazard.
+test/perf/solver-decision-baseline.json      -merge
+
+# Regenerate: `just update-scale-wall-baseline`
+#   (UPDATE_SCALE_WALL_BASELINE=1 go test -tags chdb -count=1
+#    -run TestScaleWallPin ./test/perf/ — needs libchdb.so). NOT chained into
+#   `just update-golden`: it records measured wall/scan ceilings, so it moves
+#   only when a cost increase is genuinely intended.
+test/perf/scale-wall-baseline.json           -merge
+
+# --- Compatibility ----------------------------------------------------------
+# CANNOT be regenerated locally. `.github/scripts/compat-baseline-sync.mjs`
+# rewrites one head's entry from that head's `compat-cases.json` RUN ARTEFACT,
+# which only a compatibility/{prometheus,loki,tempo} job against a live
+# reference backend produces. The resolution here is therefore NOT "re-run a
+# recipe": take the roster from the compatibility run on the merged commit, or
+# hand-fix the entry so `passed == total == cases.length` with `cases` sorted
+# and unique. compat-ratchet.mjs gates on the exact roster and fails closed.
+compatibility/parity-baseline.json           -merge
+
+# Regenerate: go run ./compatibility/loki/cmd/loki-compliance-tester
+#   -corpus=compatibility/loki/upstream/loki-bench/queries
+#   -skip-baseline=compatibility/loki/upstream-skip-baseline.txt -regen-baseline
+#   Corpus-only — contacts no Loki endpoint, so it runs locally.
+#   One sorted line per record, which is exactly what a line merge shuffles.
+compatibility/loki/upstream-skip-baseline.txt  -merge
+
+# --- Tier-0 migration harness goldens ---------------------------------------
+# Regenerate: `just migration-golden`
+#   (MIGRATION_UPDATE_GOLDENS=1 go test -tags=migration
+#    ./test/e2e/migration/tiers/tier0-offline/... -count=1).
+#   NOT covered by `just update-golden`, and it refuses to run when CI is set:
+#   a golden is a reviewed artefact, never rewritten by the lane asserting it.
+# Matched by basename so a new archetype's goldens are gated on arrival.
+# Deliberately NOT gated: expected/compliance-retention.json and
+# expected/tier1.json are hand-authored fixtures that are read, never written.
+test/e2e/migration/archetypes/*/expected/corpus.json     -merge
+test/e2e/migration/archetypes/*/expected/explain.txt     -merge
+test/e2e/migration/archetypes/*/expected/gate.json       -merge
+test/e2e/migration/archetypes/*/expected/gate-go.json    -merge
+test/e2e/migration/archetypes/*/expected/classify.json   -merge
+test/e2e/migration/archetypes/*/expected/lookback.json   -merge
+test/e2e/migration/archetypes/*/expected/rulegraph.json  -merge
+test/e2e/migration/expected/schema/*.sql                 -merge
+
+# --- Feature / surface inventories ------------------------------------------
+# Regenerate: `CERBERUS_UPDATE_INVENTORY=1 go test <package>`. Each is a sorted
+# flat array of rows behind a small wrapper object — the wrapper does not help,
+# the hazard lives one level down. The `-exclusions.json` siblings of the
+# ql-inventory files are hand-authored and deliberately absent from this list.
+# CERBERUS_UPDATE_INVENTORY=1 go test ./test/oracle/inventory/...
+test/e2e/grafana/ql-inventory/promql-feature-inventory.json   -merge
+test/e2e/grafana/ql-inventory/logql-feature-inventory.json    -merge
+test/e2e/grafana/ql-inventory/traceql-feature-inventory.json  -merge
+# CERBERUS_UPDATE_INVENTORY=1 go test ./test/rejection-parity/
+# (regen preserves the curated fields of surviving sites; new sites arrive
+#  unclassified, so the diff is the review)
+test/rejection-parity/catalogue.json         -merge
+# CERBERUS_UPDATE_INVENTORY=1 go test ./test/surface-parity/
+test/surface-parity/inventory.json           -merge
+# Regenerate: REGENERATE=1 node .github/scripts/promql-surface-gate.mjs
+#   (starts a local reference Prometheus in Docker; normally produced by the
+#    compatibility/promql-surface job)
+test/surface-parity/promql-reference-verdicts.json  -merge
+
+# --- Grafana surface crawl inventories --------------------------------------
+# Regenerate: CERBERUS_UPDATE_INVENTORY=1 SWEEP_DEPTH=full CRAWL_STACK=<stack>
+#   npx playwright test crawl/crawl.spec.ts — needs that stack healthy
+#   (compose: the local compose stack; k3d: `just e2e-up && just e2e-seed-rolling`,
+#   or dispatch the e2e workflow with update_crawl_inventory=true and commit the
+#   uploaded artefact). `surfaces` is a flat array sorted by URL.
+test/e2e/playwright/crawl/grafana-surface-inventory.compose.json  -merge
+test/e2e/playwright/crawl/grafana-surface-inventory.k3d.json      -merge
+
+# --- Named like a generated artefact, but HAND-AUTHORED ---------------------
+# These are recorded rather than gated. Each is hand-maintained, and each is
+# self-checking: its consumer recomputes the value it pins, so a bad blend fails
+# loudly instead of silently widening a tolerance — which is the property that
+# makes `-merge` necessary for everything above and unnecessary here.
+# hand-authored: test/e2e/migration/coverage-baseline.json — raise-only counts;
+#   migration-e2e.mjs only reads it and errors telling you to reconcile.
+# hand-authored: test/e2e/migration/pass-assertions.pin.json — deliberately has
+#   no regeneration mode; the gate re-derives each sha256 before comparing.
+#
+# Two further families are deliberately left ungated, for the same "a blend is
+# loud, not silent" reason:
+#   - test/spec/**/*.txtar — `-- sql --` / `-- expected_rows --` are generated by
+#     `just update-golden`, but every section is delimiter-framed, so a shifted
+#     boundary yields a malformed or duplicated `-- name --` header that the
+#     txtar parse surfaces immediately.
+#   - docs/configuration.md, docs/coverage.md, docs/clickhouse-optimizations.md,
+#     docs/benchmarks.md, CHANGELOG.md — generated from code, but each already
+#     has a CI drift gate that re-renders and diffs, so staleness cannot survive
+#     a merge unnoticed.

--- a/.github/scripts/repo-hygiene.mjs
+++ b/.github/scripts/repo-hygiene.mjs
@@ -90,6 +90,7 @@ export const ROOT_ALLOWLIST = [
   '.dockerignore',
   '.editorconfig',
   '.envrc',
+  '.gitattributes',
   '.github',
   '.gitignore',
   '.gitmodules',

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -872,3 +872,25 @@ recur:
   doesn't silently break CI.
 - `seed_test.go` — the e2e seed program's row-count and metric-name
   invariants.
+- `generated_artifact_merge_gate_test.go` — pins the `.gitattributes`
+  `-merge` gate on every generated baseline, golden and inventory, and
+  fails on a new one that arrives ungated.
+
+### Generated baselines never auto-merge
+
+Every baseline, golden and inventory in this document is written by a
+regeneration command, and most are sorted arrays of records. Git's
+line-based merge blends two such files *without raising a conflict* when
+both sides insert entries at nearby offsets: the record boundaries shift,
+names pair with the next record's values, and the result still parses as
+valid JSON of a plausible length while every blended entry is wrong. A
+ratchet fed that file reports green while measuring nothing.
+
+`.gitattributes` marks these paths `-merge`, so git refuses to blend them
+and leaves the path conflicted instead — the only correct resolution being
+to take the merged code and re-run the generator. That file is also where
+the per-artefact regeneration command is recorded, so the conflict names
+its own fix. `compatibility/parity-baseline.json` is the one exception
+worth knowing before you hit it: it is rebuilt from a compatibility run's
+`compat-cases.json` artefact and therefore **cannot** be regenerated
+locally.

--- a/test/regression/generated_artifact_merge_gate_test.go
+++ b/test/regression/generated_artifact_merge_gate_test.go
@@ -1,0 +1,322 @@
+package regression
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// This file pins the `.gitattributes` gate that stops git from three-way
+// line-merging a GENERATED artefact.
+//
+// PR #1422 merged test/perf/cardinality-baseline.json — a sorted array of
+// per-fixture records — with NO conflict. Both sides had inserted entries at
+// nearby offsets, git's line-based merge shifted the record boundaries, and
+// fixture names ended up paired with the next record's metrics: the whole
+// traceql block came out off by one, and so did the promql
+// histogram_quantile_classic_* block from the other side. The result parsed as
+// valid JSON, had a plausible length, and every entry in the blended region was
+// wrong — so the cardinality ratchet, whose entire job is catching perf
+// regressions, went on reporting green while measuring nothing real.
+//
+// A flagged conflict is loud and gets regenerated. This class is dangerous
+// precisely because it is NOT a conflict. `-merge` converts the silent case
+// into the loud one: git falls back to the binary merge driver, refuses to
+// blend, and leaves the path conflicted — so the only correct resolution, take
+// the merged code and re-run the generator, is the only one available.
+
+// gitattributesPath is the gate, relative to this package's directory.
+const gitattributesPath = repoRoot + "/.gitattributes"
+
+// mergeAttrUnset is what `git check-attr merge -- <path>` reports for a path
+// marked `-merge`. Git spells "this attribute is explicitly turned off" as
+// `unset`; `unspecified` means no rule matched the path at all, which is the
+// ungated default this gate exists to move files off.
+const mergeAttrUnset = "unset"
+
+// checkAttrSeparator splits `git check-attr`'s `<path>: <attr>: <state>` output.
+// A path may itself contain a colon, so the state is read from the LAST
+// separator rather than by splitting into a fixed field count.
+const checkAttrSeparator = ": "
+
+// handAuthoredMarker records, inside the gate itself, a file that is NAMED like
+// a generated artefact but is maintained by hand. Writing the exemption next to
+// the rule is what keeps the classification a decision someone made rather than
+// a gap nobody noticed.
+const handAuthoredMarker = "# hand-authored: "
+
+// generatedArtifact is one committed file written by a regeneration command
+// rather than by hand, together with the distinctive fragment of that command
+// which `.gitattributes` must carry. Pinning the fragment is what keeps the gate
+// self-documenting: whoever first hits one of these conflicts reads the
+// resolution off the file that caused it.
+type generatedArtifact struct {
+	// path is repo-root-relative, in the form `git ls-files` prints.
+	path string
+	// regen is a substring of the regeneration instruction that
+	// `.gitattributes` must carry.
+	regen string
+}
+
+// migrationGoldenRecipe regenerates every Tier-0 migration golden. It is NOT
+// reached by `just update-golden`, and it refuses to run when CI is set, so a
+// resolver who assumes the umbrella recipe covers it leaves these stale.
+const migrationGoldenRecipe = "just migration-golden"
+
+// inventoryUpdateEnv is the env gate that rewrites each feature/surface
+// inventory in place from the current parser surface.
+const inventoryUpdateEnv = "CERBERUS_UPDATE_INVENTORY=1"
+
+// crawlInventorySpec is the Playwright spec that rewrites the Grafana surface
+// inventories; it needs the named stack healthy, so the resolution is heavier
+// than a `go test` and the gate says so.
+const crawlInventorySpec = "npx playwright test crawl/crawl.spec.ts"
+
+// parityBaselineSync is the ONLY entry here that is not a local command. It
+// rewrites a head's entry from that head's compat-cases.json RUN ARTEFACT,
+// which only a compatibility job against a live reference backend produces —
+// naming the script rather than a recipe is the point: it tells the resolver
+// that re-running something locally is not on the table.
+const parityBaselineSync = "compat-baseline-sync.mjs"
+
+// generatedArtifacts is the canonical roster of committed generated artefacts.
+// Every entry must be `-merge` gated and documented in `.gitattributes`.
+var generatedArtifacts = []generatedArtifact{
+	{"test/perf/cardinality-baseline.json", "just update-cardinality-baseline"},
+	{"test/perf/solver-decision-baseline.json", "just update-solver-decision-baseline"},
+	{"test/perf/scale-wall-baseline.json", "just update-scale-wall-baseline"},
+
+	{"compatibility/parity-baseline.json", parityBaselineSync},
+	{"compatibility/loki/upstream-skip-baseline.txt", "-regen-baseline"},
+
+	{"test/e2e/migration/archetypes/already-otel/expected/corpus.json", migrationGoldenRecipe},
+	{"test/e2e/migration/archetypes/already-otel/expected/explain.txt", migrationGoldenRecipe},
+	{"test/e2e/migration/archetypes/already-otel/expected/gate.json", migrationGoldenRecipe},
+	{"test/e2e/migration/archetypes/kube-prometheus-stack/expected/corpus.json", migrationGoldenRecipe},
+	{"test/e2e/migration/archetypes/kube-prometheus-stack/expected/explain.txt", migrationGoldenRecipe},
+	{"test/e2e/migration/archetypes/kube-prometheus-stack/expected/gate.json", migrationGoldenRecipe},
+	{"test/e2e/migration/archetypes/kube-prometheus-stack/expected/rulegraph.json", migrationGoldenRecipe},
+	{"test/e2e/migration/archetypes/mimir-cortex/expected/corpus.json", migrationGoldenRecipe},
+	{"test/e2e/migration/archetypes/mimir-cortex/expected/explain.txt", migrationGoldenRecipe},
+	{"test/e2e/migration/archetypes/mimir-cortex/expected/gate.json", migrationGoldenRecipe},
+	{"test/e2e/migration/archetypes/prometheus-thanos/expected/corpus.json", migrationGoldenRecipe},
+	{"test/e2e/migration/archetypes/prometheus-thanos/expected/explain.txt", migrationGoldenRecipe},
+	{"test/e2e/migration/archetypes/prometheus-thanos/expected/gate.json", migrationGoldenRecipe},
+	{"test/e2e/migration/archetypes/prometheus-thanos/expected/lookback.json", migrationGoldenRecipe},
+	{"test/e2e/migration/archetypes/regulated-airgapped/expected/corpus.json", migrationGoldenRecipe},
+	{"test/e2e/migration/archetypes/regulated-airgapped/expected/explain.txt", migrationGoldenRecipe},
+	{"test/e2e/migration/archetypes/regulated-airgapped/expected/gate.json", migrationGoldenRecipe},
+	{"test/e2e/migration/archetypes/saas-repatriation/expected/classify.json", migrationGoldenRecipe},
+	{"test/e2e/migration/archetypes/saas-repatriation/expected/corpus.json", migrationGoldenRecipe},
+	{"test/e2e/migration/archetypes/saas-repatriation/expected/explain.txt", migrationGoldenRecipe},
+	{"test/e2e/migration/archetypes/saas-repatriation/expected/gate.json", migrationGoldenRecipe},
+	{"test/e2e/migration/archetypes/three-signal/expected/corpus.json", migrationGoldenRecipe},
+	{"test/e2e/migration/archetypes/three-signal/expected/explain.txt", migrationGoldenRecipe},
+	{"test/e2e/migration/archetypes/three-signal/expected/gate.json", migrationGoldenRecipe},
+	{"test/e2e/migration/archetypes/three-signal/expected/lookback.json", migrationGoldenRecipe},
+	{"test/e2e/migration/archetypes/victoriametrics/expected/classify.json", migrationGoldenRecipe},
+	{"test/e2e/migration/archetypes/victoriametrics/expected/corpus.json", migrationGoldenRecipe},
+	{"test/e2e/migration/archetypes/victoriametrics/expected/explain.txt", migrationGoldenRecipe},
+	{"test/e2e/migration/archetypes/victoriametrics/expected/gate.json", migrationGoldenRecipe},
+	{"test/e2e/migration/archetypes/victoriametrics/expected/lookback.json", migrationGoldenRecipe},
+	{"test/e2e/migration/expected/schema/default.sql", migrationGoldenRecipe},
+	{"test/e2e/migration/expected/schema/metrics-ttl-override.sql", migrationGoldenRecipe},
+
+	{"test/e2e/grafana/ql-inventory/promql-feature-inventory.json", inventoryUpdateEnv},
+	{"test/e2e/grafana/ql-inventory/logql-feature-inventory.json", inventoryUpdateEnv},
+	{"test/e2e/grafana/ql-inventory/traceql-feature-inventory.json", inventoryUpdateEnv},
+	{"test/rejection-parity/catalogue.json", inventoryUpdateEnv},
+	{"test/surface-parity/inventory.json", inventoryUpdateEnv},
+	{"test/surface-parity/promql-reference-verdicts.json", "promql-surface-gate.mjs"},
+
+	{"test/e2e/playwright/crawl/grafana-surface-inventory.compose.json", crawlInventorySpec},
+	{"test/e2e/playwright/crawl/grafana-surface-inventory.k3d.json", crawlInventorySpec},
+}
+
+// TestGeneratedArtifactsRefuseLineMerge asserts every generated artefact is
+// `-merge` gated and that `.gitattributes` names the command that regenerates
+// it. The second half is not decoration: a conflict git refuses to resolve is
+// only an improvement if the person staring at it can find the generator.
+func TestGeneratedArtifactsRefuseLineMerge(t *testing.T) {
+	t.Parallel()
+
+	attrBody := readGitattributes(t)
+
+	for _, artifact := range generatedArtifacts {
+		t.Run(artifact.path, func(t *testing.T) {
+			t.Parallel()
+
+			if _, err := os.Stat(filepath.Join(repoRoot, filepath.FromSlash(artifact.path))); err != nil {
+				t.Fatalf("%s is listed as a generated artefact but is not present: %v. If it was "+
+					"renamed or retired, update this roster and %s together rather than leaving "+
+					"the gate pointing at nothing.", artifact.path, err, gitattributesPath)
+			}
+
+			if got := mergeAttr(t, artifact.path); got != mergeAttrUnset {
+				t.Errorf("%s has merge=%s, want %s. It is written by %q, so a three-way line "+
+					"merge of it is never a correct resolution — and when both sides insert "+
+					"records at nearby offsets git produces NO conflict, shifts the record "+
+					"boundaries, and yields a file that still parses while every blended entry "+
+					"is wrong (PR #1422). Add a `-merge` entry for it in %s.",
+					artifact.path, got, mergeAttrUnset, artifact.regen, gitattributesPath)
+			}
+
+			if !strings.Contains(attrBody, artifact.regen) {
+				t.Errorf("%s does not mention %q, the command that regenerates %s. Refusing the "+
+					"merge is only half the fix: whoever hits the conflict must be able to read "+
+					"the correct resolution off the gate itself instead of guessing.",
+					gitattributesPath, artifact.regen, artifact.path)
+			}
+		})
+	}
+}
+
+// generatedNameMarkers are the naming families cerberus gives its generated data
+// artefacts. They are the net for artefacts added AFTER this gate landed: the
+// roster above can only cover what its author knew about, so anything committed
+// under one of these names has to be classified here one way or the other.
+var generatedNameMarkers = []string{"baseline", "inventory", "catalogue", ".pin."}
+
+// generatedDataExtensions restrict the net to DATA files. The same words appear
+// in the names of the Go and Node sources that PRODUCE these artefacts
+// (compat-baseline-sync.mjs, inventory.go, catalogue.go); those are hand-written
+// code, and code is line-mergeable.
+var generatedDataExtensions = []string{".json", ".txt"}
+
+// TestNoGeneratedArtifactEscapesTheMergeGate walks every tracked file and fails
+// on one that is named like a generated artefact yet is neither `-merge` gated
+// nor recorded as hand-authored in the gate. Without this the gate decays the
+// moment someone adds the next baseline: the roster above would still pass while
+// the new file merges silently, which is the shape of the bug rather than a fix
+// for it.
+func TestNoGeneratedArtifactEscapesTheMergeGate(t *testing.T) {
+	t.Parallel()
+
+	attrBody := readGitattributes(t)
+
+	// The net is name-based, so it sees only the subset of the roster that is
+	// actually NAMED like a generated artefact — the migration goldens are
+	// gated by path pattern instead and never match it. Counting that subset
+	// here is what makes the reachability check below compare like with like.
+	rostered := make(map[string]struct{}, len(generatedArtifacts))
+	var rosteredMatchingNet int
+	for _, artifact := range generatedArtifacts {
+		rostered[artifact.path] = struct{}{}
+		if looksGenerated(artifact.path) {
+			rosteredMatchingNet++
+		}
+	}
+
+	cmd := exec.Command("git", "ls-files")
+	cmd.Dir = repoRoot
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git ls-files: %v", err)
+	}
+
+	var matched int
+	for _, tracked := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if !looksGenerated(tracked) {
+			continue
+		}
+		matched++
+
+		gated := mergeAttr(t, tracked) == mergeAttrUnset
+		if _, ok := rostered[tracked]; ok {
+			if !gated {
+				// The per-artefact test above reports this in full; counting it
+				// here too would only duplicate the failure.
+				continue
+			}
+
+			continue
+		}
+
+		if gated {
+			t.Errorf("%s is `-merge` gated in %s but is missing from generatedArtifacts. The "+
+				"roster is what pins the regeneration command next to the rule, so an entry "+
+				"only in %s leaves the conflict undiagnosable. Add it, with the command that "+
+				"regenerates it.", tracked, gitattributesPath, gitattributesPath)
+
+			continue
+		}
+
+		if !strings.Contains(attrBody, handAuthoredMarker+tracked) {
+			t.Errorf("%s is named like a generated artefact but is neither `-merge` gated nor "+
+				"recorded as hand-authored in %s. If a command regenerates it, gate it and add "+
+				"it to generatedArtifacts — an ungated generated baseline is how PR #1422's "+
+				"silent blend got in. If it really is hand-maintained, say so there with a "+
+				"%q%s line and the reason a bad merge of it would fail loudly.",
+				tracked, gitattributesPath, handAuthoredMarker, tracked)
+		}
+	}
+
+	if matched < rosteredMatchingNet {
+		t.Fatalf("the generated-name net matched only %d tracked files, fewer than the %d rostered "+
+			"artefacts whose own names match it. The net is no longer reaching the tree it "+
+			"polices — check that this test runs with the repository root at %s.",
+			matched, rosteredMatchingNet, repoRoot)
+	}
+}
+
+// looksGenerated reports whether a tracked path is named like a generated data
+// artefact.
+func looksGenerated(path string) bool {
+	name := strings.ToLower(filepath.Base(path))
+
+	var dataFile bool
+	for _, ext := range generatedDataExtensions {
+		if strings.HasSuffix(name, ext) {
+			dataFile = true
+
+			break
+		}
+	}
+	if !dataFile {
+		return false
+	}
+
+	for _, marker := range generatedNameMarkers {
+		if strings.Contains(name, marker) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// readGitattributes loads the gate, failing loudly if it has gone missing —
+// without it every generated baseline is back to being silently line-merged.
+func readGitattributes(t *testing.T) string {
+	t.Helper()
+
+	buf, err := os.ReadFile(gitattributesPath)
+	if err != nil {
+		t.Fatalf("read %s: %v. This file IS the gate.", gitattributesPath, err)
+	}
+
+	return string(buf)
+}
+
+// mergeAttr returns the state git resolves the `merge` attribute to for path.
+func mergeAttr(t *testing.T, path string) string {
+	t.Helper()
+
+	cmd := exec.Command("git", "check-attr", "merge", "--", path)
+	cmd.Dir = repoRoot
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git check-attr merge -- %s: %v", path, err)
+	}
+
+	line := strings.TrimSpace(string(out))
+	idx := strings.LastIndex(line, checkAttrSeparator)
+	if idx < 0 {
+		t.Fatalf("git check-attr merge -- %s printed %q, which carries no %q separator",
+			path, line, checkAttrSeparator)
+	}
+
+	return line[idx+len(checkAttrSeparator):]
+}


### PR DESCRIPTION
## The defect

`test/perf/cardinality-baseline.json` is a sorted array of per-fixture records. On PR #1422 it **auto-merged into a corrupt file with no conflict marker**. Both sides inserted entries at nearby offsets, git's line-based merge shifted the record boundaries, and fixture *names* ended up paired with the *next* record's metrics — the traceql block came out off by one, and so did the promql `histogram_quantile_classic_*` block from the other side.

The result parsed as valid JSON, had a plausible length, and every entry in the blended region was wrong. A ratchet fed a corrupt baseline is worse than no ratchet: it reports green while measuring nothing real.

This is the dangerous case precisely because it is *not* a conflict. A flagged conflict is loud and gets regenerated; this one merges clean and passes a JSON parse.

## The fix

`.gitattributes` marks every generated artefact `-merge`, so git falls back to the binary merge driver and **refuses to blend** — a concurrent change leaves the path conflicted, forcing the only correct resolution: take the merged code, re-run the generator.

`-merge` is not `-diff`. These stay ordinary text for `git diff`, `git blame` and review; only the automatic merge is withheld. It also only bites when *both* sides changed the file — a one-sided change still resolves cleanly.

### Files gated

| Group | Regenerate with |
|---|---|
| `test/perf/cardinality-baseline.json` | `just update-cardinality-baseline` (needs libchdb.so) |
| `test/perf/solver-decision-baseline.json` | `just update-solver-decision-baseline` (pure Go) |
| `test/perf/scale-wall-baseline.json` | `just update-scale-wall-baseline` (needs libchdb.so) |
| `compatibility/parity-baseline.json` | `.github/scripts/compat-baseline-sync.mjs` — **cannot be regenerated locally** |
| `compatibility/loki/upstream-skip-baseline.txt` | `loki-compliance-tester -regen-baseline` |
| Tier-0 migration goldens (33 files) | `just migration-golden` — **not** covered by `just update-golden`, refuses to run under CI |
| ql-inventory / rejection-parity / surface-parity | `CERBERUS_UPDATE_INVENTORY=1 go test <pkg>` |
| `test/surface-parity/promql-reference-verdicts.json` | `REGENERATE=1 node .github/scripts/promql-surface-gate.mjs` |
| Grafana crawl inventories | `CERBERUS_UPDATE_INVENTORY=1 … npx playwright test crawl/crawl.spec.ts` |

The regeneration command is recorded **beside each entry in `.gitattributes`** — refusing the merge is only half the fix if the person staring at the conflict can't find the generator. `docs/test-strategy.md` cross-references it.

### Deliberately not gated, with reasons recorded in the gate

- `test/e2e/migration/{coverage-baseline.json,pass-assertions.pin.json}` — hand-authored, and self-checking: the consumer recomputes what they pin, so a bad blend fails loudly.
- `test/spec/**/*.txtar` — sections are delimiter-framed, so a shifted boundary yields a malformed `-- name --` header the parse surfaces immediately.
- Generated docs (`docs/configuration.md`, `docs/coverage.md`, …) — each already has a CI drift gate that re-renders and diffs.
- `expected/compliance-retention.json`, `expected/tier1.json` — hand-authored fixtures that are read, never written.

## The gate cannot decay

`test/regression/generated_artifact_merge_gate_test.go` pins it from both directions: every rostered artefact must exist, resolve to `merge: unset`, and have its regeneration command named in `.gitattributes`; and every *tracked data file named like* a generated artefact must be either gated or explicitly recorded as hand-authored. A new baseline that arrives ungated fails.

Verified against three mutants — gate file deleted, the `cardinality-baseline.json` entry removed, and a new ungated `*-baseline.json` added — each caught with a diagnostic naming the fix.

## Audit of `main`: clean

Re-derived every locally-regenerable baseline at `origin/main` and diffed. **All byte-identical — zero diff.**

- `cardinality-baseline.json`, `solver-decision-baseline.json`
- `rejection-parity/catalogue.json`, `surface-parity/inventory.json`
- `compatibility/loki/upstream-skip-baseline.txt`
- all 33 Tier-0 migration goldens
- the three `*-feature-inventory.json`

`compatibility/parity-baseline.json` cannot be regenerated locally, so it was audited by contract instead: prometheus 738/738/738, loki 116/116/116, tempo 48/48/48 — each `passed == total == len(cases)`, sorted, no duplicates. `compatibility/{prometheus,loki,tempo}` are green on `main`, and the ratchet fails on any roster mismatch, so the rosters match the real runs.

The Grafana crawl inventory needs a live stack; it was audited structurally instead — 295 records, one uniform shape, no duplicates, and exactly in the generator's own `localeCompare` order (the 42 apparent codepoint inversions are all ICU `&` before `#`).

Note: the tempo roster is **48**, not 49 — it has been 48 since the per-case roster contract landed in b58cd5a7 (2026-07-29).