### PR TITLE
ci: put every image acquisition on the authenticated pull path

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -48,12 +48,22 @@ not two:
 - **everything else**: a genuine build / command failure. Fails on the first
   attempt, unretried.
 
-`pull-buildkit-image.mjs` (host-side bootstrap pull), the Justfile's
-`_pull-retry` / `_compose-pull-retry` (host pulls and compose pre-pulls, both
-routed through `build-with-registry-retry.mjs` rather than a bash loop),
-`build-with-registry-retry.mjs` (the build's own `FROM` resolution) and
-`chart-kubeconform.mjs`'s image probe all hit the same quota bucket and fail the
-same way, so they share the policy instead of re-deriving it.
+`pullImageWithRetry(ref, …)` is that policy applied to acquiring one image, and
+is the only implementation of the loop: `pull-buildkit-image.mjs` (the buildx
+bootstrap image, the one caller that accepts a locally present copy in place of
+a fetch), `compose-pull-images.mjs` (a compose stack's fetchable services),
+`promql-surface-gate.mjs` (the reference Prometheus it starts) and
+`migration-artifact.mjs` (the released image it extracts a binary from) all go
+through it. `build-with-registry-retry.mjs` (a build's own `FROM` resolution)
+and `chart-kubeconform.mjs`'s image probe apply the same classification to
+commands rather than to a single ref. Everything hits the same quota bucket and
+fails the same way, so nothing re-derives the policy.
+
+The pre-pull fetches with `docker pull`, never `docker compose pull`: the two
+paths do not share a credential source. Measured four seconds apart in one job,
+the CLI pull carried the runner's Docker Hub login while compose's was refused
+as *unauthenticated* — so routed through compose, the mechanism built to absorb
+Docker Hub failures was spending the anonymous per-IP quota (issue #1565).
 
 `lib/scope-gate.mjs` answers "does THIS pull request touch the scope a heavy
 lane guards?" — `runsFullLane()` (which events must never take a scoped
@@ -829,6 +839,10 @@ uncomputable-diff fallback — cannot drift between the lanes that use it.
   - Exit: `0` all checks pass / regenerate done, `1` on any gap / drift /
     misfile / infra error. Self-managing: starts + `docker rm -f`s its own
     reference container.
+  - Acquires `PROM_IMAGE` through `pullImageWithRetry` from `lib/registry.mjs`
+    before `docker run`, so a transport fault is retried and a Docker Hub rate
+    limit is diagnosed as such instead of surfacing as an opaque
+    container-start failure (#1562).
 
 - **`compose-smoke-scope.mjs`** — `e2e.yml`, the `compose-smoke-scope` job.
   Decides whether a pull request has to boot the compose stack at all. The lane
@@ -996,6 +1010,11 @@ uncomputable-diff fallback — cannot drift between the lanes that use it.
   - Exit: `0` once a binary exists and its `--version` matches, `1` on a half
     pair, a failed build / pull / extract, a `--version` that errors, prints
     nothing, prints more than one line, or prints the wrong stamp.
+  - The image path acquires `cerberus_image` through `pullImageWithRetry` from
+    `lib/registry.mjs`, without `acceptLocalCopy` — the point of the path is to
+    exercise the RELEASED bytes, so falling back to a same-named image the
+    daemon happens to hold is exactly the substitution this module exists to
+    prevent.
 
 - **`dashboard-matrix.mjs`** — `e2e.yml`, the `dashboard-setup` job. The k3d
   twin of `compose-smoke-matrix.mjs`: single source of truth for how the
@@ -1061,8 +1080,29 @@ uncomputable-diff fallback — cannot drift between the lanes that use it.
     `BUILDKIT_PULL_BACKOFF_SECONDS` (optional; default `3` — linear backoff
     step, attempt N sleeps N × this).
   - Exit: `0` when the image is in the local daemon, `1` when it is not.
+- **`compose-pull-images.mjs`** — the Justfile (`_compose-pull-retry`, used by
+  `migration-tier{1,2}-up`). Acquires every image a compose stack FETCHES,
+  before `docker compose up` reaches for them. Two decisions carry the module.
+  What is fetchable is read off the compose model's `build:` sections
+  (`docker compose config --format json`, compose's own `--ignore-buildable`
+  semantics) and never inferred from daemon state — absence from the daemon
+  means "not built yet" as often as "not fetched yet", and pulling Tier-2's
+  built-during-`up` `dead-end-receiver` from a registry that serves it nowhere
+  failed a lane five attempts deep (run 30281594098). And the fetch itself is
+  `docker pull`, because compose's pull path does not carry the credentials
+  `docker login` wrote (issue #1565). An image already in the daemon is skipped,
+  which is what `--policy missing` did.
+  - Args: the compose files the lane brings up (each becomes a `-f`).
+  - Env: `COMPOSE_PULL_BACKOFF_SECONDS` (optional; default `3`).
+  - Exit: `0` when every fetchable image is in the local daemon, `1` otherwise.
+  - Gated by `compose-pull-images.test.mjs` on the required `check` lane (the
+    model → image-set decision, including the built-service shapes the live tree
+    does not yet contain) and by
+    `test/regression/justfile_pull_retry_test.go`, which drives the module over
+    the REAL `test/e2e/migration` compose files with a stub `docker` and pins
+    the pulled set exactly.
 - **`build-with-registry-retry.mjs`** — the Justfile (`_pull-retry`,
-  `_compose-pull-retry`, `e2e-up`, `e2e-bwc-up`,
+  `e2e-up`, `e2e-bwc-up`,
   `migration-cerberus-image`, `migration-tier{1,2}-up`), `e2e.yml`'s
   compose-smoke shards, the three `compatibility/*/scripts/run-*.sh` harnesses,
   and `bench/histogram/run.sh`. Runs an image-building command (`docker build` /

--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -1081,7 +1081,9 @@ uncomputable-diff fallback — cannot drift between the lanes that use it.
     step, attempt N sleeps N × this).
   - Exit: `0` when the image is in the local daemon, `1` when it is not.
 - **`compose-pull-images.mjs`** — the Justfile (`_compose-pull-retry`, used by
-  `migration-tier{1,2}-up`). Acquires every image a compose stack FETCHES,
+  `migration-tier{1,2}-up`), the three `compatibility/*/scripts/run-*.sh`
+  harnesses, `e2e.yml`'s two compose-smoke jobs, and `bench/histogram/run.sh`.
+  Acquires every image a compose stack FETCHES,
   before `docker compose up` reaches for them. Two decisions carry the module.
   What is fetchable is read off the compose model's `build:` sections
   (`docker compose config --format json`, compose's own `--ignore-buildable`
@@ -1092,15 +1094,22 @@ uncomputable-diff fallback — cannot drift between the lanes that use it.
   `docker pull`, because compose's pull path does not carry the credentials
   `docker login` wrote (issue #1565). An image already in the daemon is skipped,
   which is what `--policy missing` did.
-  - Args: the compose files the lane brings up (each becomes a `-f`).
+  - Args: the compose files the lane brings up (each becomes a `-f`), then
+    optionally `--` and the service names to narrow the model to. Pass the
+    services when a stack starts one SEPARATELY because its failure is
+    tolerated (`bench/histogram`'s `mimir`, brought up with `|| MIMIR_OK=0`);
+    folding such an image into the core stack's pre-pull would turn a tolerated
+    failure into a hard one.
   - Env: `COMPOSE_PULL_BACKOFF_SECONDS` (optional; default `3`).
   - Exit: `0` when every fetchable image is in the local daemon, `1` otherwise.
   - Gated by `compose-pull-images.test.mjs` on the required `check` lane (the
     model → image-set decision, including the built-service shapes the live tree
     does not yet contain) and by
     `test/regression/justfile_pull_retry_test.go`, which drives the module over
-    the REAL `test/e2e/migration` compose files with a stub `docker` and pins
-    the pulled set exactly.
+    the REAL `test/e2e/migration` compose files with a stub `docker`, pins the
+    pulled set exactly, and scans the whole tree — Justfile recipes, shell
+    scripts, workflow files — so no unit can bring a compose stack up without
+    pre-pulling through this module first.
 - **`build-with-registry-retry.mjs`** — the Justfile (`_pull-retry`,
   `e2e-up`, `e2e-bwc-up`,
   `migration-cerberus-image`, `migration-tier{1,2}-up`), `e2e.yml`'s

--- a/.github/scripts/compose-pull-images.mjs
+++ b/.github/scripts/compose-pull-images.mjs
@@ -39,7 +39,15 @@
 // removes a fetch, so it cannot resurrect the bug above.
 //
 // Usage:
-//   node .github/scripts/compose-pull-images.mjs <compose-file>...
+//   node .github/scripts/compose-pull-images.mjs <compose-file>... [-- <service>...]
+//
+// The optional service list is forwarded to `docker compose config`, which
+// narrows the model to those services. Pass the ones the `up` being preceded
+// names, whenever a stack starts a service SEPARATELY because its failure is
+// tolerated: bench/histogram brings `mimir` up on its own with `|| MIMIR_OK=0`,
+// and folding its image into the core stack's pre-pull would convert that
+// tolerated failure into a hard one. With no service list the whole model is
+// pre-pulled, which is what a stack brought up in one command wants.
 //
 // Env:
 //   COMPOSE_PULL_BACKOFF_SECONDS  (optional; default 3) linear backoff step
@@ -83,10 +91,19 @@ export function pullableImages(model) {
   return [...refs].sort();
 }
 
-function resolveModel(files) {
+// splitArgs — compose files before the `--`, service names after it. Exported
+// for the self-test: the separator is the whole contract of the argument list.
+export function splitArgs(argv) {
+  const sep = argv.indexOf('--');
+  if (sep === -1) return { files: argv, services: [] };
+  return { files: argv.slice(0, sep), services: argv.slice(sep + 1) };
+}
+
+function resolveModel(files, services) {
   const args = ['compose'];
   for (const file of files) args.push('-f', file);
   args.push('config', '--format', 'json');
+  for (const service of services) args.push(service);
 
   const res = capture('docker', args);
   if (res.status !== 0) {
@@ -109,15 +126,17 @@ function presentLocally(image) {
   return capture('docker', ['image', 'inspect', image]).status === 0;
 }
 
-function main(files) {
+function main(argv) {
+  const { files, services } = splitArgs(argv);
   if (files.length === 0) {
     error('compose-pull-images: no compose file given. Pass every `-f` file the lane brings up.');
     process.exit(1);
   }
 
-  const images = pullableImages(resolveModel(files));
+  const scope = services.length === 0 ? files.join(', ') : `${files.join(', ')} (${services.join(', ')})`;
+  const images = pullableImages(resolveModel(files, services));
   if (images.length === 0) {
-    notice(`no fetchable image in ${files.join(', ')} — every service is built by compose.`);
+    notice(`no fetchable image in ${scope} — every service is built by compose.`);
     return 0;
   }
 

--- a/.github/scripts/compose-pull-images.mjs
+++ b/.github/scripts/compose-pull-images.mjs
@@ -1,0 +1,149 @@
+// compose-pull-images.mjs — acquire every image a compose stack fetches,
+// before `docker compose up` reaches for them, over the pull path that carries
+// the runner's Docker Hub credentials.
+//
+// WHY NOT `docker compose pull`, which is what this replaces:
+//
+// The two pull paths a job has do not share a credential source. Measured on
+// run 30702344415, job 91376064528 — one job, one runner, one IP, four seconds
+// apart:
+//
+//   13:53:19  docker/login-action    Login Succeeded!
+//   13:53:22  docker pull moby/buildkit:buildx-stable-1   -> all layers pulled
+//   13:53:27  docker compose up ... clickhouse            -> toomanyrequests:
+//             You have reached your UNAUTHENTICATED pull rate limit.
+//
+// The anonymous per-IP counter was demonstrably exhausted at 13:53:27, so an
+// anonymous pull at 13:53:22 would have been refused too — it was not. The CLI
+// pull carried the credentials `docker login` wrote; compose's did not, and
+// Docker Hub's own error names the request as unauthenticated. Two further jobs
+// show the same split, one of them with no buildx step at all, which rules the
+// `docker-container` driver out as the variable (issue #1565).
+//
+// The consequence for the pre-pull is worse than "it did not help": run through
+// compose, the mechanism built to absorb Docker Hub failures was itself spending
+// the ANONYMOUS quota, failing, and handing `up` a still-empty daemon and a
+// counter it had just pushed further into deficit. Resolving the model here and
+// fetching each image with `docker pull` puts the pre-pull on the authenticated
+// path, where the credentials the job established actually apply.
+//
+// WHAT IS PULLABLE is read off the compose model's `build:` sections — compose's
+// own `--ignore-buildable` semantics — never inferred from what the daemon
+// holds. Absence from the daemon means "not built yet" as often as "not fetched
+// yet": Tier-2's `cerberus-migration-tier2:dead-end-receiver` is built during
+// `up` and exists in no registry, and a presence check classified it as "needs
+// pulling", failing the lane five attempts deep (run 30281594098).
+//
+// Presence in the daemon is still consulted, for one narrower purpose: to skip
+// an image already held, which is what `--policy missing` did. That only ever
+// removes a fetch, so it cannot resurrect the bug above.
+//
+// Usage:
+//   node .github/scripts/compose-pull-images.mjs <compose-file>...
+//
+// Env:
+//   COMPOSE_PULL_BACKOFF_SECONDS  (optional; default 3) linear backoff step
+//                                 handed to the shared retry policy.
+//
+// Exit: 0 when every pullable image is in the local daemon, 1 otherwise.
+
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+
+import { capture, error, log, notice } from './lib/gh.mjs';
+import { pullImageWithRetry, readBackoffStepSeconds } from './lib/registry.mjs';
+
+// Matches the buildx bootstrap step: a compose stack's images are a manifest
+// and some layers apiece, not a build's dependency closure.
+const composeBackoffStepSeconds = 3;
+
+// A service compose BUILDS rather than fetches, in every form the model states
+// it. `build:` is the one `--ignore-buildable` reads; the two pull policies say
+// the same thing about a service that also names an image.
+function isBuildable(service) {
+  if (service === null || typeof service !== 'object') return false;
+  if (service.build !== undefined && service.build !== null) return true;
+  return service.pull_policy === 'build' || service.pull_policy === 'never';
+}
+
+// pullableImages — the images `docker compose up` would fetch from a registry,
+// as a sorted, deduplicated list. Exported for the self-test: the model→image
+// decision is the part worth pinning, and it is a pure function of the parsed
+// compose config.
+export function pullableImages(model) {
+  const services = model?.services;
+  if (services === null || typeof services !== 'object') return [];
+
+  const refs = new Set();
+  for (const service of Object.values(services)) {
+    if (isBuildable(service)) continue;
+    const image = typeof service?.image === 'string' ? service.image.trim() : '';
+    if (image !== '') refs.add(image);
+  }
+  return [...refs].sort();
+}
+
+function resolveModel(files) {
+  const args = ['compose'];
+  for (const file of files) args.push('-f', file);
+  args.push('config', '--format', 'json');
+
+  const res = capture('docker', args);
+  if (res.status !== 0) {
+    error(
+      `docker ${args.join(' ')} failed, so the compose model could not be read and no image can be ` +
+        `pre-pulled:\n${res.stdout}${res.stderr}`,
+    );
+    process.exit(1);
+  }
+
+  try {
+    return JSON.parse(res.stdout);
+  } catch (err) {
+    error(`docker ${args.join(' ')} did not print parseable JSON (${err.message}):\n${res.stdout}`);
+    process.exit(1);
+  }
+}
+
+function presentLocally(image) {
+  return capture('docker', ['image', 'inspect', image]).status === 0;
+}
+
+function main(files) {
+  if (files.length === 0) {
+    error('compose-pull-images: no compose file given. Pass every `-f` file the lane brings up.');
+    process.exit(1);
+  }
+
+  const images = pullableImages(resolveModel(files));
+  if (images.length === 0) {
+    notice(`no fetchable image in ${files.join(', ')} — every service is built by compose.`);
+    return 0;
+  }
+
+  const backoffStepSeconds = readBackoffStepSeconds('COMPOSE_PULL_BACKOFF_SECONDS', composeBackoffStepSeconds);
+  let failed = 0;
+  for (const image of images) {
+    if (presentLocally(image)) {
+      log(`    ${image} already in the local daemon`);
+      continue;
+    }
+    if (!pullImageWithRetry(image, { backoffStepSeconds })) failed++;
+  }
+
+  if (failed > 0) {
+    error(
+      `${failed} of ${images.length} compose image(s) could not be acquired; \`docker compose up\` would pull ` +
+        'them itself, single-attempt and unretried.',
+    );
+    return 1;
+  }
+  return 0;
+}
+
+// Run only when invoked as the entrypoint, so `compose-pull-images.test.mjs`
+// can import `pullableImages` without the import pulling images as a side
+// effect.
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  process.exit(main(process.argv.slice(2)));
+}

--- a/.github/scripts/compose-pull-images.test.mjs
+++ b/.github/scripts/compose-pull-images.test.mjs
@@ -17,7 +17,21 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { pullableImages } from './compose-pull-images.mjs';
+import { pullableImages, splitArgs } from './compose-pull-images.mjs';
+
+test('the argument list splits compose files from service names at `--`', () => {
+  assert.deepEqual(splitArgs(['docker-compose.yml']), { files: ['docker-compose.yml'], services: [] });
+  assert.deepEqual(splitArgs(['a.yml', 'b.yml', '--', 'clickhouse', 'cerberus']), {
+    files: ['a.yml', 'b.yml'],
+    services: ['clickhouse', 'cerberus'],
+  });
+  // A trailing separator narrows nothing, which is the whole model — the same
+  // answer as omitting it, rather than an empty pull set.
+  assert.deepEqual(splitArgs(['a.yml', '--']), { files: ['a.yml'], services: [] });
+  // No compose file before the separator is the caller error `main` exits on;
+  // the split still reports it faithfully rather than absorbing it.
+  assert.deepEqual(splitArgs(['--', 'mimir']), { files: [], services: ['mimir'] });
+});
 
 test('a missing or serviceless model yields no images', () => {
   assert.deepEqual(pullableImages(undefined), []);

--- a/.github/scripts/compose-pull-images.test.mjs
+++ b/.github/scripts/compose-pull-images.test.mjs
@@ -1,0 +1,90 @@
+// compose-pull-images.test.mjs — node:test guard for the model→image decision
+// the compose pre-pull makes.
+//
+// Runs on the CHEAP lint/check lane — no compose stack, no daemon — because the
+// decision is a pure function of the parsed compose config and its failure mode
+// is expensive elsewhere: classifying a BUILT service as pullable sends the lane
+// chasing an image ref that exists in no registry, five retries deep, and the
+// only symptom is a manifest-not-found five minutes into a substrate job (run
+// 30281594098).
+//
+// `test/regression/justfile_pull_retry_test.go` is the other half: it feeds the
+// REAL compose files under `test/e2e/migration` through the module with a stub
+// `docker` on PATH and pins the pulled set exactly. This file pins the shapes
+// the live tree does not currently contain, so a model that grows one is
+// already decided.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { pullableImages } from './compose-pull-images.mjs';
+
+test('a missing or serviceless model yields no images', () => {
+  assert.deepEqual(pullableImages(undefined), []);
+  assert.deepEqual(pullableImages({}), []);
+  assert.deepEqual(pullableImages({ services: {} }), []);
+});
+
+test('plain image services are pullable', () => {
+  assert.deepEqual(
+    pullableImages({
+      services: {
+        clickhouse: { image: 'clickhouse/clickhouse-server:26.5' },
+        prometheus: { image: 'prom/prometheus:v3.11.3' },
+      },
+    }),
+    ['clickhouse/clickhouse-server:26.5', 'prom/prometheus:v3.11.3'],
+  );
+});
+
+test('a service with a build section is never pulled', () => {
+  // The shape that broke run 30281594098: an image ref that exists in no
+  // registry, because compose builds it during `up`.
+  assert.deepEqual(
+    pullableImages({
+      services: {
+        'dead-end-receiver': {
+          image: 'cerberus-migration-tier2:dead-end-receiver',
+          build: { context: '.' },
+        },
+        clickhouse: { image: 'clickhouse/clickhouse-server:26.5' },
+      },
+    }),
+    ['clickhouse/clickhouse-server:26.5'],
+  );
+});
+
+test('pull_policy build/never are not fetched, missing is', () => {
+  assert.deepEqual(
+    pullableImages({
+      services: {
+        built: { image: 'cerberus:local', pull_policy: 'build' },
+        held: { image: 'cerberus:cached', pull_policy: 'never' },
+        fetched: { image: 'grafana/loki:3.7.0', pull_policy: 'missing' },
+      },
+    }),
+    ['grafana/loki:3.7.0'],
+  );
+});
+
+test('duplicate refs collapse and imageless services are skipped', () => {
+  assert.deepEqual(
+    pullableImages({
+      services: {
+        a: { image: 'clickhouse/clickhouse-server:26.5' },
+        b: { image: 'clickhouse/clickhouse-server:26.5' },
+        c: { image: '   ' },
+        d: {},
+      },
+    }),
+    ['clickhouse/clickhouse-server:26.5'],
+  );
+});
+
+test('importing the module pulls nothing (the entrypoint guard holds)', () => {
+  // The import above is the assertion: if the module ran `main()` on import it
+  // would have exited non-zero on "no compose file given" before this file's
+  // first test registered. Pinned explicitly so the guard cannot be dropped
+  // while the other tests keep passing by accident.
+  assert.equal(typeof pullableImages, 'function');
+});

--- a/.github/scripts/lib/registry.mjs
+++ b/.github/scripts/lib/registry.mjs
@@ -40,10 +40,12 @@
 //                                          and false for a genuine build error.
 //   rateLimitDiagnosis(subject)            the one explanation every consumer
 //                                          prints for the rate-limit class.
+//   pullImageWithRetry(image, options)     acquire one image into the local
+//                                          daemon under that policy.
 
 import process from 'node:process';
 
-import { error } from './gh.mjs';
+import { capture, error, log, notice } from './gh.mjs';
 
 // Five attempts with a linear backoff: long enough to ride out a registry blip
 // or a transport fault, short enough that a genuinely unreachable registry
@@ -154,4 +156,76 @@ export function isTransientRegistryFailure(text) {
   const haystack = String(text ?? '');
   if (isRegistryRateLimit(haystack)) return false;
   return transientRegistryFailurePatterns.some((re) => re.test(haystack));
+}
+
+// An acquisition is a single manifest plus a handful of layers, so a short step
+// is enough to ride out a reset connection; the image-build wrapper waits longer
+// because a build's `FROM` resolution sits behind a much longer tail.
+const defaultPullBackoffStepSeconds = 3;
+
+function presentLocally(image) {
+  return capture('docker', ['image', 'inspect', image]).status === 0;
+}
+
+// pullImageWithRetry — acquire one image into the local daemon under the policy
+// above, and report every outcome in the shared vocabulary. This is the one
+// implementation: a caller that hand-rolls the loop is a call site that will
+// eventually diverge on the question the module exists to answer.
+//
+// Options:
+//   backoffStepSeconds  linear step; attempt N sleeps N × this.
+//   acceptLocalCopy     a failed pull still succeeds when the image is already
+//                       in the daemon. For callers whose postcondition is
+//                       PRESENCE rather than freshness (the buildx bootstrap:
+//                       buildx itself falls back to the local copy). Off by
+//                       default, because a caller that needs the released bytes
+//                       must not silently accept whatever the runner cached.
+//   consequence         clause naming what breaks when the budget is spent,
+//                       appended to the exhaustion error.
+//
+// Returns true when the image is in the local daemon, false otherwise.
+export function pullImageWithRetry(image, options = {}) {
+  const {
+    backoffStepSeconds = defaultPullBackoffStepSeconds,
+    acceptLocalCopy = false,
+    consequence = '',
+  } = options;
+
+  for (let attempt = 1; attempt <= registryAttempts; attempt++) {
+    log(`    docker pull ${image} (attempt ${attempt}/${registryAttempts})`);
+    const res = capture('docker', ['pull', image]);
+    if (res.status === 0) {
+      log(res.stdout.trim());
+      return true;
+    }
+    process.stderr.write(res.stderr);
+
+    // A quota refusal is checked only after the local-copy fallback, because a
+    // copy already in the daemon satisfies that caller's postcondition no
+    // matter why the pull failed.
+    if (acceptLocalCopy && presentLocally(image)) {
+      notice(
+        `docker pull ${image} failed, but the image is already in the local daemon — ` +
+          'the caller accepts the local copy.',
+      );
+      return true;
+    }
+
+    // With nothing local to fall back on there is nothing to wait for either:
+    // the window outlasts the budget, so the remaining attempts would only
+    // deepen the deficit failing this job and every concurrent one.
+    if (isRegistryRateLimit(res.stderr + res.stdout)) {
+      error(rateLimitDiagnosis(`docker pull ${image}`));
+      return false;
+    }
+
+    if (attempt < registryAttempts) {
+      sleepSeconds(attempt * backoffStepSeconds);
+    }
+  }
+
+  const absent = acceptLocalCopy ? ' and the image is absent from the local daemon' : '';
+  const because = consequence === '' ? '.' : `, so ${consequence}`;
+  error(`docker pull ${image} failed ${registryAttempts} times on transport faults${absent}${because}`);
+  return false;
 }

--- a/.github/scripts/migration-artifact.mjs
+++ b/.github/scripts/migration-artifact.mjs
@@ -49,6 +49,7 @@ import path from 'node:path';
 import process from 'node:process';
 
 import { capture, error, notice, log } from './lib/gh.mjs';
+import { pullImageWithRetry } from './lib/registry.mjs';
 
 // SOURCE_BUILD_VERSION is what `go build ./cmd/cerberus` with no ldflags
 // reports — cmd/cerberus/main.go's `var Version = "dev"`. Held equal to that
@@ -136,11 +137,16 @@ function buildFromSource(binary) {
 // extractFromImage pulls the released image and copies its binary out, so the
 // CLI the scenarios exec is the same bytes as the server the stack runs.
 function extractFromImage(ref, binary) {
-  const pull = capture('docker', ['pull', ref]);
-  if (pull.status !== 0) {
+  // Through the shared policy rather than a bare `docker pull`: a transport
+  // fault gets the same retry budget every other registry fetch gets, and a
+  // quota refusal fails on the first attempt instead of spending four more of
+  // an exhausted counter. `acceptLocalCopy` is deliberately off — the whole
+  // point is to run the RELEASED bytes, so a stale copy the runner happens to
+  // hold must not stand in for them.
+  if (!pullImageWithRetry(ref, { consequence: 'the released binary cannot be extracted' })) {
     error(
-      `migration-artifact: docker pull ${ref} failed — the released image is unpullable from this ` +
-        `job (check the GHCR login step and the package's visibility):\n${pull.stdout}${pull.stderr}`,
+      `migration-artifact: ${ref} is unpullable from this job — if the failure above is not a registry ` +
+        "fault, check the GHCR login step and the package's visibility.",
     );
     process.exit(1);
   }

--- a/.github/scripts/promql-surface-gate.mjs
+++ b/.github/scripts/promql-surface-gate.mjs
@@ -89,6 +89,7 @@
 import { readFileSync, writeFileSync } from 'node:fs';
 import process from 'node:process';
 import { error, notice, log, capture } from './lib/gh.mjs';
+import { pullImageWithRetry } from './lib/registry.mjs';
 
 const PROM_IMAGE = process.env.PROM_IMAGE || 'prom/prometheus:v3.11.3';
 const REF_PORT = process.env.REF_PORT || '39090';
@@ -120,6 +121,16 @@ function sleep(ms) {
 // for /-/ready. The reference scrapes nothing and needs no fixture — the
 // surface verdict is parse + type validation only.
 function startReference() {
+  // Acquire the reference image explicitly. `docker run` pulls a missing image
+  // itself, single-attempt, so a Docker Hub blip or a quota refusal surfaced
+  // here as "failed to start reference container" — a registry fault wearing
+  // the costume of a broken gate. Going through the shared policy retries the
+  // transport class, stops dead on a quota refusal, and names which one it was
+  // (issue #1562).
+  if (!pullImageWithRetry(PROM_IMAGE, { consequence: 'the reference Prometheus cannot be started' })) {
+    die(`could not acquire the reference image ${PROM_IMAGE}`);
+  }
+
   capture('docker', ['rm', '-f', REF_CONTAINER]);
   const promYml = [
     'global:',

--- a/.github/scripts/pull-buildkit-image.mjs
+++ b/.github/scripts/pull-buildkit-image.mjs
@@ -38,23 +38,12 @@
 
 import process from 'node:process';
 
-import { capture, error, log, notice } from './lib/gh.mjs';
-import {
-  isRegistryRateLimit,
-  rateLimitDiagnosis,
-  readBackoffStepSeconds,
-  registryAttempts,
-  sleepSeconds,
-} from './lib/registry.mjs';
+import { error } from './lib/gh.mjs';
+import { pullImageWithRetry, readBackoffStepSeconds } from './lib/registry.mjs';
 
 // A bootstrap pull is a single manifest + a handful of layers, so a short step
-// is enough to ride out a reset connection; the image-build wrapper waits
-// longer because a Hub 429 burst outlives it.
-const defaultBackoffStepSeconds = 3;
-
-function presentLocally(image) {
-  return capture('docker', ['image', 'inspect', image]).status === 0;
-}
+// is enough to ride out a reset connection.
+const bootstrapBackoffStepSeconds = 3;
 
 const image = (process.env.BUILDKIT_IMAGE ?? '').trim();
 if (image === '') {
@@ -62,42 +51,11 @@ if (image === '') {
   process.exit(1);
 }
 
-const backoffStepSeconds = readBackoffStepSeconds('BUILDKIT_PULL_BACKOFF_SECONDS', defaultBackoffStepSeconds);
-
-for (let attempt = 1; attempt <= registryAttempts; attempt++) {
-  log(`    docker pull ${image} (attempt ${attempt}/${registryAttempts})`);
-  const res = capture('docker', ['pull', image]);
-  if (res.status === 0) {
-    log(res.stdout.trim());
-    process.exit(0);
-  }
-  process.stderr.write(res.stderr);
-
-  if (presentLocally(image)) {
-    notice(
-      `docker pull ${image} failed, but the image is already in the local daemon — ` +
-        'buildx boots the builder from the local copy.',
-    );
-    process.exit(0);
-  }
-
-  // A quota refusal is checked only after the local-image fallback, because a
-  // copy already in the daemon satisfies the postcondition no matter why the
-  // pull failed. With no local copy there is nothing to wait for: the window
-  // outlasts the budget, so the remaining attempts would only deepen the
-  // deficit that is failing this job and every concurrent one.
-  if (isRegistryRateLimit(res.stderr + res.stdout)) {
-    error(rateLimitDiagnosis(`docker pull ${image}`));
-    process.exit(1);
-  }
-
-  if (attempt < registryAttempts) {
-    sleepSeconds(attempt * backoffStepSeconds);
-  }
-}
-
-error(
-  `docker pull ${image} failed ${registryAttempts} times on transport faults and the image is absent from the ` +
-    'local daemon, so `buildx inspect --bootstrap` has nothing to boot from.',
-);
-process.exit(1);
+const acquired = pullImageWithRetry(image, {
+  backoffStepSeconds: readBackoffStepSeconds('BUILDKIT_PULL_BACKOFF_SECONDS', bootstrapBackoffStepSeconds),
+  // buildx boots from a local copy when its own pull fails, so presence — not a
+  // successful fetch — is this module's postcondition.
+  acceptLocalCopy: true,
+  consequence: '`buildx inspect --bootstrap` has nothing to boot from',
+});
+process.exit(acquired ? 0 : 1);

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -662,6 +662,13 @@ jobs:
       - name: Assert the compose-smoke scope gate decides correctly
         run: node --test .github/scripts/compose-smoke-scope.test.mjs
 
+      # The compose pre-pull's model→image decision. A service compose BUILDS
+      # must never be handed to `docker pull`: its ref exists in no registry, so
+      # the pre-pull burns every retry on a manifest that cannot resolve and
+      # fails the lane minutes in. Cheap to pin here, expensive to learn there.
+      - name: Assert the compose pre-pull fetches only fetchable images
+        run: node --test .github/scripts/compose-pull-images.test.mjs
+
       # Same discipline for the mutation lane's phase planner, one step further:
       # its selector decides which legs an ordinary PR runs, so a bug there is
       # not a slow release but a SILENT one — legs quietly deselected while the

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1164,6 +1164,10 @@ jobs:
     # mechanism kills the container on the first window expiry. Running
     # CH inline as a plain `docker run` step with our own poll loop
     # decouples the wait from GH's healthcheck timer and never races.
+    env:
+      # Named once: the pre-pull and the `docker run` must name the same ref,
+      # or the retry warms an image the run does not use.
+      CH_IMAGE: clickhouse/clickhouse-server:26.5
     steps:
       - uses: actions/checkout@v7
 
@@ -1175,6 +1179,12 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: just
+
+      # `docker run` pulls a missing image itself, single-attempt: a Docker Hub
+      # blip fails the job before ClickHouse is even started. `_pull-retry`
+      # acquires it under the shared registry policy first.
+      - name: Pre-pull ClickHouse
+        run: just _pull-retry "$CH_IMAGE"
 
       - name: Start ClickHouse
         run: |
@@ -1188,7 +1198,7 @@ jobs:
             -e CLICKHOUSE_DB=otel \
             -e CLICKHOUSE_USER=cerberus \
             -e CLICKHOUSE_PASSWORD=cerberus \
-            clickhouse/clickhouse-server:26.5
+            "$CH_IMAGE"
 
       - name: Wait for ClickHouse
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -297,6 +297,15 @@ jobs:
 
       - uses: ./.github/actions/setup-buildx
 
+      - name: pre-pull compose images (authenticated pull path)
+        run: |
+          # The images compose FETCHES are acquired here rather than by `up`.
+          # Compose's own pull path does not carry the credentials the login
+          # step above wrote: it spends the anonymous per-runner-IP quota and
+          # is refused as UNAUTHENTICATED seconds after a `docker pull` of the
+          # same image in the same job succeeded. See compose-pull-images.mjs.
+          node .github/scripts/compose-pull-images.mjs docker-compose.yml
+
       - name: compose up --wait (retried on registry faults)
         run: |
           # --wait-timeout caps the wait at 5 min. Cold runners need
@@ -510,6 +519,14 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_PAT }}
 
       - uses: ./.github/actions/setup-buildx
+
+      # The images compose FETCHES are acquired here rather than by `up`.
+      # Compose's own pull path does not carry the credentials the login step
+      # above wrote: it spends the anonymous per-runner-IP quota and is refused
+      # as UNAUTHENTICATED seconds after a `docker pull` of the same image in
+      # the same job succeeded. See compose-pull-images.mjs.
+      - name: pre-pull compose images (authenticated pull path)
+        run: node .github/scripts/compose-pull-images.mjs docker-compose.yml
 
       # `up` builds the cerberus service from Dockerfile.local, so it resolves
       # `FROM golang:1.26` against Docker Hub; the wrapper retries that on

--- a/Justfile
+++ b/Justfile
@@ -692,21 +692,18 @@ _pull-retry +IMAGES:
 # transient `prom/prometheus` fetch. `_pull-retry` already solved this for the
 # k3d lanes; the compose lanes just weren't going through it.
 #
-# Buildable services are skipped via compose's own `--ignore-buildable`, which
-# reads the `build:` sections in the model rather than guessing from what the
-# daemon happens to hold. Guessing is what broke Tier-2 on run 30281594098:
-# `dead-end-receiver` is built by compose during `up`, so it is absent from the
-# daemon at pre-pull time and a presence check classified it as "needs pulling"
-# — `cerberus-migration-tier2:dead-end-receiver` exists in no registry, so the
-# pull failed five times and took the lane with it. Whether an image is
-# *pullable* is a property of the compose model, not of daemon state.
-#
-# Same retry owner as `_pull-retry`, for the same reason.
+# The pre-pull runs `docker pull`, not `docker compose pull`, because the two
+# do not share a credential source: measured four seconds apart in one job, the
+# CLI pull carried the runner's Docker Hub login and compose's was refused as
+# UNAUTHENTICATED. Run through compose, the mechanism built to absorb Docker Hub
+# failures was spending the anonymous quota rather than the authenticated one —
+# which is why it never helped. `compose-pull-images.mjs` owns the resolution:
+# it reads which services are fetchable off the compose model's `build:`
+# sections (compose's own `--ignore-buildable` semantics) and pulls each one
+# through the shared retry policy. See that module's header for the evidence.
 _compose-pull-retry +FILES:
-    @args=""; for f in {{FILES}}; do args="$args -f $f"; done; \
-    echo "==> pre-pulling compose images (retry — Docker Hub flaky from CI)"; \
-    IMAGE_BUILD_RETRY_BACKOFF_SECONDS=3 node .github/scripts/build-with-registry-retry.mjs \
-        docker compose $args pull --ignore-buildable --policy missing
+    @echo "==> pre-pulling compose images (retry, over the authenticated pull path)"
+    @COMPOSE_PULL_BACKOFF_SECONDS=3 node .github/scripts/compose-pull-images.mjs {{FILES}}
 
 # `_pull-retry` / `_compose-pull-retry` protect the images the HOST daemon
 # fetches. The images a BUILD fetches — the `FROM` refs BuildKit resolves while

--- a/bench/histogram/run.sh
+++ b/bench/histogram/run.sh
@@ -48,6 +48,13 @@ case "$PROFILE" in
 esac
 
 echo "==> [1/5] building + starting core stack (clickhouse, cerberus, prometheus)"
+# The images compose FETCHES are acquired here rather than by `up`. Compose's
+# own pull path does not carry the credentials `docker login` wrote: it spends
+# the anonymous per-runner-IP quota and is refused as UNAUTHENTICATED seconds
+# after a `docker pull` of the same image in the same job succeeded. Scoped to
+# the core services so mimir's optional image stays on its own best-effort line
+# below. See ../../.github/scripts/compose-pull-images.mjs.
+node ../../.github/scripts/compose-pull-images.mjs docker-compose.yml -- clickhouse cerberus prometheus
 # Every compose `up` here can fetch from Docker Hub — the cerberus service
 # builds Dockerfile.local (`FROM golang:1.26`), the rest pull. The wrapper
 # retries on registry/network faults only; a real build failure still fails on
@@ -58,8 +65,14 @@ node ../../.github/scripts/build-with-registry-retry.mjs \
 
 echo "==> [2/5] starting mimir (best-effort)"
 MIMIR_OK=1
-node ../../.github/scripts/build-with-registry-retry.mjs \
-    docker compose up -d mimir || MIMIR_OK=0
+# Same authenticated pre-pull, on mimir's own best-effort line: a failure here
+# leaves MIMIR_OK=0 and the bench continues with cerberus + prometheus, exactly
+# as an `up` failure does.
+node ../../.github/scripts/compose-pull-images.mjs docker-compose.yml -- mimir || MIMIR_OK=0
+if [[ "$MIMIR_OK" == "1" ]]; then
+  node ../../.github/scripts/build-with-registry-retry.mjs \
+      docker compose up -d mimir || MIMIR_OK=0
+fi
 if [[ "$MIMIR_OK" == "1" ]]; then
   MIMIR_OK=0
   for i in $(seq 1 40); do

--- a/compatibility/loki/scripts/run-loki-compatibility.sh
+++ b/compatibility/loki/scripts/run-loki-compatibility.sh
@@ -109,6 +109,14 @@ trap cleanup EXIT
 
 mkdir -p "$(dirname "$REPORT")"
 
+# The images compose FETCHES (ClickHouse, reference Loki) are acquired here
+# rather than by `up`. Compose's own pull path does not carry the credentials
+# `docker login` wrote: it spends the anonymous per-runner-IP quota and is
+# refused as UNAUTHENTICATED seconds after a `docker pull` of the same image in
+# the same job succeeded. See .github/scripts/compose-pull-images.mjs.
+echo "==> pre-pulling compose images (retry, over the authenticated pull path)"
+node "$REPO_ROOT/.github/scripts/compose-pull-images.mjs" docker-compose.yml
+
 echo "==> bringing up loki-compatibility stack (compose up --wait)"
 # `--build` builds Dockerfile.local, whose `FROM golang:1.26` BuildKit resolves
 # from Docker Hub — a 429 there fails the lane before any query runs. The

--- a/compatibility/prometheus/scripts/run-compatibility.sh
+++ b/compatibility/prometheus/scripts/run-compatibility.sh
@@ -86,6 +86,14 @@ QUERIES=${TESTER_QUERIES:-"$ROOT_DIR/cerberus-test-queries.yml"}
 END_TIME=${TESTER_END_TIME:-"2026-05-11T01:00:00Z"}
 RANGE=${TESTER_RANGE:-3600}
 
+# The images compose FETCHES (ClickHouse, reference Prometheus) are acquired
+# here rather than by `up`. Compose's own pull path does not carry the
+# credentials `docker login` wrote: it spends the anonymous per-runner-IP quota
+# and is refused as UNAUTHENTICATED seconds after a `docker pull` of the same
+# image in the same job succeeded. See .github/scripts/compose-pull-images.mjs.
+echo "==> pre-pulling compose images (retry, over the authenticated pull path)"
+node "$REPO_ROOT/.github/scripts/compose-pull-images.mjs" docker-compose.yml
+
 echo "==> bringing up compatibility stack"
 # `--build` builds Dockerfile.local, whose `FROM golang:1.26` BuildKit resolves
 # from Docker Hub — a 429 there fails the lane before any query runs. The

--- a/compatibility/tempo/scripts/run-tempo-compatibility.sh
+++ b/compatibility/tempo/scripts/run-tempo-compatibility.sh
@@ -78,6 +78,14 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# The images compose FETCHES (ClickHouse, reference Tempo) are acquired here
+# rather than by either `up` below. Compose's own pull path does not carry the
+# credentials `docker login` wrote: it spends the anonymous per-runner-IP quota
+# and is refused as UNAUTHENTICATED seconds after a `docker pull` of the same
+# image in the same job succeeded. See .github/scripts/compose-pull-images.mjs.
+echo "==> pre-pulling compose images (retry, over the authenticated pull path)"
+node "$REPO_ROOT/.github/scripts/compose-pull-images.mjs" docker-compose.yml
+
 echo "==> bringing up tempo-compatibility stack"
 # Step 1: start tempo (no compose-level healthcheck — distroless image,
 # see compose.yml). The driver polls /ready before pushing.

--- a/test/regression/image_build_registry_retry_test.go
+++ b/test/regression/image_build_registry_retry_test.go
@@ -190,6 +190,92 @@ func TestImageBuildingCommandsGoThroughTheRetryWrapper(t *testing.T) {
 	}
 }
 
+// TestCiScriptModulesAcquireImagesThroughTheSharedPolicy pins the same class fix
+// one layer down, for the `.mjs` modules that drive docker themselves.
+//
+// `docker run` and `docker create` pull a missing image implicitly, and that
+// implicit pull is single-attempt: a Docker Hub blip or a quota refusal surfaced
+// as "failed to start reference container" — a registry fault wearing the
+// costume of a broken gate (issue #1562). Going through `pullImageWithRetry`
+// gives every such site the same budget for the transport class, the same
+// immediate stop on the quota class, and the same words for which one it was.
+func TestCiScriptModulesAcquireImagesThroughTheSharedPolicy(t *testing.T) {
+	t.Parallel()
+
+	const (
+		scriptsDir = "../../.github/scripts"
+		// The module that IMPLEMENTS the policy: it is where the raw `docker
+		// pull` legitimately lives.
+		policyModule = "registry.mjs"
+		policyCall   = "pullImageWithRetry"
+	)
+
+	// `capture('docker', ['pull'|'run'|'create', …])` — the three subcommands
+	// that fetch from a registry (the latter two implicitly, when the image is
+	// absent). Both quote styles, because either is valid ESM.
+	fetchingDockerCall := regexp.MustCompile(`\(\s*['"]docker['"]\s*,\s*\[\s*['"](?:pull|run|create)['"]`)
+
+	entries, err := os.ReadDir(scriptsDir)
+	if err != nil {
+		t.Fatalf("read %s: %v", scriptsDir, err)
+	}
+	files := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if !e.IsDir() && filepath.Ext(e.Name()) == ".mjs" {
+			files = append(files, filepath.Join(scriptsDir, e.Name()))
+		}
+	}
+	libEntries, err := os.ReadDir(filepath.Join(scriptsDir, "lib"))
+	if err != nil {
+		t.Fatalf("read %s/lib: %v", scriptsDir, err)
+	}
+	for _, e := range libEntries {
+		if !e.IsDir() && filepath.Ext(e.Name()) == ".mjs" && e.Name() != policyModule {
+			files = append(files, filepath.Join(scriptsDir, "lib", e.Name()))
+		}
+	}
+
+	sites := 0
+	for _, file := range files {
+		src, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("read %s: %v", file, err)
+		}
+		// Matched against the whole file, not line by line: the argv array of a
+		// `docker run` spans several lines in every module that has one, and a
+		// per-line scan silently matched none of them.
+		text := string(src)
+		for _, loc := range fetchingDockerCall.FindAllStringIndex(text, -1) {
+			call := strings.TrimSpace(strings.SplitN(text[loc[0]:loc[1]], "\n", 2)[0])
+			if isProse(lineContaining(text, loc[0])) {
+				continue
+			}
+			sites++
+			if !strings.Contains(text, policyCall) {
+				t.Errorf("%s fetches from a registry without the shared policy:\n    %s\n"+
+					"Acquire the image with `%s(ref, …)` from ./lib/registry.mjs first, so a transport fault "+
+					"retries and a rate-limit refusal fails on the first attempt instead of spending four more "+
+					"pulls out of an exhausted quota.", file, call, policyCall)
+			}
+		}
+	}
+
+	if sites == 0 {
+		t.Fatalf("no .mjs module under %s runs `docker pull|run|create` — the guard is scanning for a shape "+
+			"that no longer exists", scriptsDir)
+	}
+}
+
+// lineContaining returns the source line that offset falls on.
+func lineContaining(src string, offset int) string {
+	start := strings.LastIndexByte(src[:offset], '\n') + 1
+	end := strings.IndexByte(src[offset:], '\n')
+	if end < 0 {
+		return src[start:]
+	}
+	return src[start : offset+end]
+}
+
 // TestBuildRetryWrapperRetriesOnlyTransientRegistryFailures drives the module
 // against a stub `docker` on PATH. The three halves are equally load-bearing: a
 // wrapper that does not retry a reset connection fixes nothing, one that

--- a/test/regression/justfile_pull_retry_test.go
+++ b/test/regression/justfile_pull_retry_test.go
@@ -80,36 +80,101 @@ func justRecipes(t *testing.T, src string) map[string]string {
 	return recipes
 }
 
-// TestJustfileComposeUpPrePullsWithRetry pins that any recipe bringing a compose
-// stack up first acquires its images through `_compose-pull-retry`. Without it,
-// `up` does the pull itself, single-attempt, and a flaky registry fails the lane.
-func TestJustfileComposeUpPrePullsWithRetry(t *testing.T) {
+// composeUpUnits yields every unit of execution in the tree that can bring a
+// compose stack up, keyed by a label naming it: each Justfile recipe on its own,
+// and each shell script / workflow file whole. The unit is what a pre-pull has
+// to appear in — `just` runs one recipe, while a script and a job's step list
+// each run top to bottom in one shell, so anywhere above the `up` is the same
+// guarantee.
+func composeUpUnits(t *testing.T) map[string]string {
+	t.Helper()
+
+	units := map[string]string{}
+	for _, file := range buildScanFiles(t) {
+		src, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("read %s: %v", file, err)
+		}
+		if filepath.Base(file) == "Justfile" {
+			for name, body := range justRecipes(t, string(src)) {
+				units[file+":"+name] = body
+			}
+			continue
+		}
+		units[file] = string(src)
+	}
+	return units
+}
+
+// composePrePullMarkers are the two spellings of "this stack's images were
+// already acquired over the authenticated path": the Justfile's wrapper recipe,
+// and the module it delegates to, which a shell script or a workflow step calls
+// directly.
+var composePrePullMarkers = []string{composePrePullRecipeName, composePullModule}
+
+// `docker compose ... up`, on one logical line so the flags and `\`
+// continuations that sit between the two words don't hide it.
+var composeUpCommand = regexp.MustCompile(`\bdocker\s+compose\b.*\bup\b`)
+
+// minComposeUpSites is the floor for the class scan. The real count is 7 (2
+// Justfile recipes, 3 compatibility harnesses, e2e.yml, bench/histogram); the
+// floor sits below it so an ordinary lane removal doesn't fail the guard, while
+// a refactor that leaves it scanning for a shape nothing matches does.
+const minComposeUpSites = 5
+
+// TestComposeUpAcquiresImagesOverTheAuthenticatedPullPath pins that anything
+// bringing a compose stack up acquires that stack's images FIRST, through the
+// shared pre-pull.
+//
+// Two separate failures live in this one gate. `docker compose up` pulls what it
+// is missing with no retry of its own, so one transient Docker Hub timeout takes
+// the lane down — that is what broke the v1.13.0 release's Tier-1 leg. And
+// compose's pull path does not carry the credentials `docker login` wrote, so
+// even a retried compose pull spends the ANONYMOUS per-runner-IP quota: measured
+// three seconds after `Login Succeeded!`, `up` was refused with "you have reached
+// your UNAUTHENTICATED pull rate limit" while a `docker pull` of the same image
+// in the same job succeeded.
+//
+// The scan is repo-wide rather than Justfile-only because that is exactly how
+// the second failure survived the first fix: the Justfile lanes were covered,
+// and the three compatibility harnesses, e2e.yml's compose-smoke jobs and the
+// histogram bench — all of which call `docker compose up` from a shell script or
+// a workflow step — were not, so they went on spending the anonymous quota.
+func TestComposeUpAcquiresImagesOverTheAuthenticatedPullPath(t *testing.T) {
 	t.Parallel()
 
-	buf, err := os.ReadFile("../../Justfile")
-	if err != nil {
-		t.Fatalf("read Justfile: %v", err)
-	}
-
-	// `docker compose ... up`, allowing the flags and line continuations that
-	// sit between the two words in the real recipes.
-	composeUpRE := regexp.MustCompile(`docker compose[\s\S]*?\bup\b`)
-
 	found := 0
-	for name, body := range justRecipes(t, string(buf)) {
-		if !composeUpRE.MatchString(body) {
+	for label, body := range composeUpUnits(t) {
+		brings := false
+		for _, line := range logicalLines(body) {
+			if !isProse(line) && composeUpCommand.MatchString(line) {
+				brings = true
+				break
+			}
+		}
+		if !brings {
 			continue
 		}
 		found++
-		if !strings.Contains(body, "_compose-pull-retry") {
-			t.Errorf("Justfile recipe %q brings a compose stack up without calling `_compose-pull-retry` first. "+
-				"`docker compose up` pulls missing images with no retry, so one Docker Hub timeout fails the lane "+
-				"(this is what broke the v1.13.0 release's Tier-1 leg).", name)
+
+		prePulled := false
+		for _, marker := range composePrePullMarkers {
+			if strings.Contains(body, marker) {
+				prePulled = true
+				break
+			}
+		}
+		if !prePulled {
+			t.Errorf("%s brings a compose stack up without pre-pulling its images through %s. "+
+				"`docker compose up` pulls what it is missing single-attempt AND over the anonymous pull path, "+
+				"so a Docker Hub timeout or a rate limit fails the lane even though the job is logged in.",
+				label, strings.Join(composePrePullMarkers, " / "))
 		}
 	}
 
-	if found == 0 {
-		t.Fatal("no `docker compose ... up` recipe found — the guard is scanning for a shape that no longer exists")
+	if found < minComposeUpSites {
+		t.Fatalf("only %d unit(s) bring a compose stack up, want at least %d — the guard is scanning for a "+
+			"shape that no longer exists", found, minComposeUpSites)
 	}
 }
 

--- a/test/regression/justfile_pull_retry_test.go
+++ b/test/regression/justfile_pull_retry_test.go
@@ -1,10 +1,13 @@
 package regression
 
 import (
+	"encoding/json"
 	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
@@ -210,60 +213,170 @@ func TestIntegrationImagePinsMatchTheJustfile(t *testing.T) {
 	}
 }
 
-// TestComposePrePullSkipsBuildableImages pins that the compose pre-pull decides
-// what is pullable from the compose model, not from what the daemon happens to
-// hold.
+// TestComposePrePullUsesTheAuthenticatedPullPath pins that the pre-pull fetches
+// with `docker pull`, not `docker compose pull`.
 //
-// The first cut of `_compose-pull-retry` pulled every image `config --images`
-// listed that `docker image inspect` could not find locally. Tier-2's
-// `dead-end-receiver` is built by compose during `up`, so at pre-pull time it is
-// legitimately absent — and `cerberus-migration-tier2:dead-end-receiver` exists
-// in no registry, so the pull failed five times and took the lane with it (run
-// 30281594098). Absence from the daemon means "not built yet" just as often as
-// it means "not fetched yet"; only the `build:` sections distinguish them, which
-// is what compose's own `--ignore-buildable` reads.
-func TestComposePrePullSkipsBuildableImages(t *testing.T) {
+// The two do not share a credential source. Measured four seconds apart inside
+// one job (run 30702344415, job 91376064528): `docker pull` fetched a Docker Hub
+// image whole, while compose's pull in the same job was refused with "you have
+// reached your UNAUTHENTICATED pull rate limit" — the registry's own words for a
+// request that carried no credentials, seconds after `docker/login-action`
+// reported success. Run through compose, the mechanism built to absorb Docker
+// Hub failures was spending the ANONYMOUS quota, which is why the pre-pull never
+// helped the lanes it was added for (issue #1565).
+func TestComposePrePullUsesTheAuthenticatedPullPath(t *testing.T) {
 	t.Parallel()
 
 	buf, err := os.ReadFile("../../Justfile")
 	if err != nil {
 		t.Fatalf("read Justfile: %v", err)
 	}
+	body := composePrePullRecipe(t, string(buf))
 
-	const prePullRecipe = "_compose-pull-retry"
-	body, ok := justRecipes(t, string(buf))[prePullRecipe]
-	if !ok {
-		t.Fatalf("no %q recipe in the Justfile — the guard is scanning for a shape that no longer exists", prePullRecipe)
+	if !strings.Contains(body, composePullModule) {
+		t.Errorf("%s does not go through `%s`, which owns the model resolution and the shared retry policy.",
+			composePrePullRecipeName, composePullModule)
 	}
 
-	buildable := buildableComposeImages(t, "../../test/e2e/migration")
-	if len(buildable) == 0 {
-		t.Fatalf("no compose service under test/e2e/migration is built rather than fetched — " +
-			"the guard is scanning for a shape that no longer exists")
-	}
-
-	if !strings.Contains(body, "--ignore-buildable") {
-		t.Errorf("%s pulls without `--ignore-buildable`, but these compose services are built rather than fetched: %s.\n"+
-			"Their images exist in no registry, so pulling them fails the lane. Let compose read its own `build:` "+
-			"sections instead of inferring pullability from `docker image inspect`.", prePullRecipe, strings.Join(buildable, ", "))
-	}
-	if strings.Contains(body, "docker image inspect") {
-		t.Errorf("%s gates the pull on `docker image inspect`. Absence from the local daemon means \"not built yet\" "+
-			"as often as \"not fetched yet\" — %s are built during `up` and would be pulled from a registry that "+
-			"does not serve them.", prePullRecipe, strings.Join(buildable, ", "))
+	for _, line := range logicalLines(body) {
+		if isProse(line) {
+			continue
+		}
+		if regexp.MustCompile(`\bdocker\s+compose\b.*\bpull\b`).MatchString(line) {
+			t.Errorf("%s pre-pulls with `docker compose pull`: %s\n"+
+				"Compose's pull path does not carry the credentials `docker login` wrote, so it spends the "+
+				"anonymous per-runner-IP quota and fails while `docker pull` of the same image succeeds.",
+				composePrePullRecipeName, strings.TrimSpace(line))
+		}
 	}
 }
 
-// buildableComposeImages returns `<file>: <service>` for every compose service
-// under root that compose builds rather than fetches.
-func buildableComposeImages(t *testing.T, root string) []string {
+// TestComposePrePullPullsExactlyTheFetchableImages drives the resolver against a
+// stub `docker` whose `compose config` reports the REAL migration-tier compose
+// model, and asserts it pulls every fetchable image and no built one.
+//
+// The first cut of the pre-pull pulled every image `config --images` listed that
+// `docker image inspect` could not find locally. Tier-2's `dead-end-receiver` is
+// built by compose during `up`, so at pre-pull time it is legitimately absent —
+// and `cerberus-migration-tier2:dead-end-receiver` exists in no registry, so the
+// pull failed five times and took the lane with it (run 30281594098). Absence
+// from the daemon means "not built yet" just as often as "not fetched yet"; only
+// the `build:` sections distinguish them.
+func TestComposePrePullPullsExactlyTheFetchableImages(t *testing.T) {
+	t.Parallel()
+
+	model, fetchable, built := composeModelFromTree(t, "../../test/e2e/migration")
+	if len(built) == 0 {
+		t.Fatal("no compose service under test/e2e/migration is built rather than fetched — " +
+			"the guard is scanning for a shape that no longer exists")
+	}
+	if len(fetchable) == 0 {
+		t.Fatal("no compose service under test/e2e/migration is fetched from a registry — " +
+			"the guard is scanning for a shape that no longer exists")
+	}
+
+	dir := t.TempDir()
+	modelPath := filepath.Join(dir, "model.json")
+	if err := os.WriteFile(modelPath, model, 0o600); err != nil {
+		t.Fatalf("write compose model: %v", err)
+	}
+	callLog := filepath.Join(dir, "pulls")
+	writeStubComposeDocker(t, dir, modelPath, callLog)
+
+	cmd := exec.Command("node", "../../.github/scripts/"+composePullModule, "docker-compose.yml")
+	cmd.Env = append(
+		os.Environ(),
+		"PATH="+dir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"COMPOSE_PULL_BACKOFF_SECONDS=0",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s failed on a model whose every pull succeeds: %v\noutput:\n%s", composePullModule, err, out)
+	}
+
+	logged, err := os.ReadFile(callLog)
+	if err != nil {
+		t.Fatalf("read stub call log: %v", err)
+	}
+	pulled := strings.Fields(string(logged))
+	sort.Strings(pulled)
+
+	if !slices.Equal(pulled, fetchable) {
+		t.Errorf("pulled %v, want exactly %v\noutput:\n%s", pulled, fetchable, out)
+	}
+	for _, ref := range built {
+		if slices.Contains(pulled, ref) {
+			t.Errorf("pulled %q, which compose BUILDS during `up`. It exists in no registry, so the pull "+
+				"fails and takes the lane with it.", ref)
+		}
+	}
+}
+
+const (
+	composePrePullRecipeName = "_compose-pull-retry"
+	composePullModule        = "compose-pull-images.mjs"
+)
+
+func composePrePullRecipe(t *testing.T, justfile string) string {
+	t.Helper()
+
+	body, ok := justRecipes(t, justfile)[composePrePullRecipeName]
+	if !ok {
+		t.Fatalf("no %q recipe in the Justfile — the guard is scanning for a shape that no longer exists",
+			composePrePullRecipeName)
+	}
+	return body
+}
+
+// writeStubComposeDocker drops a `docker` onto dir that answers `compose …
+// config` with the model at modelPath, reports every image as absent from the
+// daemon, and records each `docker pull <ref>`.
+func writeStubComposeDocker(t *testing.T, dir, modelPath, callLog string) {
+	t.Helper()
+
+	script := strings.Join([]string{
+		"#!/bin/sh",
+		"case \"$1\" in",
+		"  compose)",
+		"    cat " + shellQuote(modelPath),
+		"    exit 0",
+		"    ;;",
+		"  image)",
+		// Nothing is held locally, so the model — not daemon state — is the
+		// only thing that can keep a built image out of the pull set.
+		"    exit 1",
+		"    ;;",
+		"  pull)",
+		"    echo \"$2\" >> " + shellQuote(callLog),
+		"    exit 0",
+		"    ;;",
+		"esac",
+		"echo \"stub: unexpected docker $*\" >&2",
+		"exit 2",
+		"",
+	}, "\n")
+
+	path := filepath.Join(dir, "docker")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write stub docker: %v", err)
+	}
+}
+
+// composeModelFromTree reads every compose file under root and renders the
+// merged services as the JSON `docker compose config --format json` prints,
+// alongside the sorted image refs compose would fetch and the ones it builds.
+func composeModelFromTree(t *testing.T, root string) (model []byte, fetchable, built []string) {
 	t.Helper()
 
 	type service struct {
+		Image      string    `yaml:"image"`
 		Build      yaml.Node `yaml:"build"`
 		PullPolicy string    `yaml:"pull_policy"`
 	}
-	var found []string
+
+	services := map[string]any{}
+	fetchSet := map[string]bool{}
+	builtSet := map[string]bool{}
 	files := 0
 
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
@@ -289,8 +402,20 @@ func buildableComposeImages(t *testing.T, root string) []string {
 		}
 		files++
 		for name, svc := range doc.Services {
-			if !svc.Build.IsZero() || svc.PullPolicy == "build" || svc.PullPolicy == "never" {
-				found = append(found, base+":"+name)
+			isBuilt := !svc.Build.IsZero() || svc.PullPolicy == "build" || svc.PullPolicy == "never"
+			rendered := map[string]any{"image": svc.Image}
+			if !svc.Build.IsZero() {
+				rendered["build"] = map[string]any{"context": "."}
+			}
+			if svc.PullPolicy != "" {
+				rendered["pull_policy"] = svc.PullPolicy
+			}
+			services[base+"-"+name] = rendered
+			switch {
+			case isBuilt:
+				builtSet[svc.Image] = true
+			case svc.Image != "":
+				fetchSet[svc.Image] = true
 			}
 		}
 		return nil
@@ -302,8 +427,26 @@ func buildableComposeImages(t *testing.T, root string) []string {
 		t.Fatalf("no compose file under %s — the guard is scanning for a shape that no longer exists", root)
 	}
 
-	sort.Strings(found)
-	return found
+	model, err = json.Marshal(map[string]any{"services": services})
+	if err != nil {
+		t.Fatalf("render compose model: %v", err)
+	}
+	// A ref that is built in one tier and fetched in another is built: compose
+	// would have it in the daemon, and no registry serves it.
+	for ref := range fetchSet {
+		if builtSet[ref] {
+			delete(fetchSet, ref)
+		}
+	}
+	for ref := range fetchSet {
+		fetchable = append(fetchable, ref)
+	}
+	for ref := range builtSet {
+		built = append(built, ref)
+	}
+	sort.Strings(fetchable)
+	sort.Strings(built)
+	return model, fetchable, built
 }
 
 // TestJustfileNoUnretriedDockerPull pins that `docker pull` appears only inside


### PR DESCRIPTION
## What

Puts every image acquisition in CI on the **authenticated** Docker Hub pull path, and closes the class with a gate.

Phase 2 items (1) and (3) of the Docker Hub rate-limit work. Phase 1 (making a 429 non-retryable at the root) shipped in #1563.

## The mechanism

The two pull paths a job has do not share a credential source. Measured on run `30702344415`, job `91376064528` — one job, one runner, one IP, eight seconds end to end:

| time | what | outcome |
|---|---|---|
| 13:53:19 | `docker/login-action` | `Login Succeeded!` |
| 13:53:22 | `docker pull moby/buildkit:buildx-stable-1` | all layers pulled |
| 13:53:27 | `docker compose up … clickhouse` | `toomanyrequests: You have reached your **UNAUTHENTICATED** pull rate limit.` |

The anonymous per-IP counter was demonstrably exhausted at 13:53:27, so an anonymous pull at 13:53:22 would have been refused too — it was not. The docker CLI carries what `docker login` wrote; Docker Compose v2's service pull does not, and Docker Hub's own error names the request unauthenticated. Job `91374578228` shows the same split with **no buildx step at all**, which rules the `docker-container` driver out as the variable.

`_compose-pull-retry` sat on the losing side of that split. The mechanism built specifically to absorb Docker Hub failures for compose lanes was itself spending the **anonymous** quota, failing, and handing `up` a still-empty daemon and a counter it had just pushed further into deficit — which is why the pre-pull never helped. The k3d lanes go through `_pull-retry` (`docker pull`) and are fine.

## Changes

**`compose-pull-images.mjs` (new)** — resolves the compose model (`docker compose config --format json`) and fetches each image with `docker pull` through the shared retry policy.

- What is fetchable is read off the model's `build:` sections — compose's own `--ignore-buildable` semantics — and **never** inferred from daemon state. `cerberus-migration-tier2:dead-end-receiver` is built during `up` and exists in no registry; a presence check classified it as "needs pulling" and failed the lane five attempts deep (run `30281594098`).
- Presence in the daemon is still consulted for the narrower purpose of **skipping** an image already held, which is what `--policy missing` did. That can only ever remove a fetch, so it cannot resurrect the bug above.

**Three other sites acquired images outside the policy and now share it:**

- `promql-surface-gate.mjs:132` started the reference Prometheus with a bare `docker run`, so a rate limit surfaced as an opaque container-start failure. This is #1562's own cited site.
- `migration-artifact.mjs` extracted the released binary after a bare `docker pull`. Deliberately **no** `acceptLocalCopy` — the point of that path is to exercise the RELEASED bytes, and falling back to a same-named image the daemon happens to hold is exactly the substitution that module exists to prevent.
- `e2e.yml`'s `startup-bench` inlined its ClickHouse ref in a `docker run`; it now pre-pulls through `_pull-retry`.

**`pullImageWithRetry`** is the extracted policy in `lib/registry.mjs`, and `pull-buildkit-image.mjs` collapses onto it rather than keeping its own copy.

## Gates

Two, both proven non-hollow by negative control:

- `TestCiScriptModulesAcquireImagesThroughTheSharedPolicy` fails any `.github/scripts/**.mjs` that reaches a registry via `docker pull|run|create` without the shared policy. Matched against **whole file text**, not per line: the surface gate's call is split across lines, and the first per-line version of this regex matched nothing — removing the import passed. It now correctly fails.
- `TestComposePrePullPullsExactlyTheFetchableImages` drives the module over the **real** `test/e2e/migration` compose files with a stub `docker` on `PATH` and pins the pulled set exactly, so a built ref can never re-enter it. Neutering `isBuildable` produces the exact `dead-end-receiver` failure.
- `compose-pull-images.test.mjs` on the required `check` lane pins the model → image-set decision, including shapes the live tree does not yet contain.

## What this does *not* do

It addresses the **proven** mechanism, not the class. Any pull path we have not yet found could be anonymous too. The **GHCR mirror (#1565)** is the durable fix and supersedes this one: a mirror is immune to *whichever* pull path turns out to be unauthenticated, including any we have not found. That is the follow-up PR.

Closes #1562

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## The lanes the first cut missed (added after review of its own red)

This PR's own `compatibility/{prometheus,tempo}`, `compatibility/prometheus-forced-route`
and `compose-smoke*` checks failed on the exact signature it exists to close —
`toomanyrequests: You have reached your unauthenticated pull rate limit`, on
`docker compose up`, seconds after `Login Succeeded!`. The same signature is the
whole of the `compatibility/*` + `compose-smoke` red across the open queue
(#1413, #1421, #1423, #1555, #1557, #1559).

The chokepoint was reached from the Justfile only. Every `docker compose up`
invoked from a shell script or a workflow step still went through compose's
anonymous pull path:

| unit | what it brings up |
|---|---|
| `compatibility/prometheus/scripts/run-compatibility.sh` | ClickHouse + reference Prometheus |
| `compatibility/loki/scripts/run-loki-compatibility.sh` | ClickHouse + reference Loki |
| `compatibility/tempo/scripts/run-tempo-compatibility.sh` | ClickHouse + reference Tempo |
| `.github/workflows/e2e.yml` (both compose-smoke jobs) | the root stack |
| `bench/histogram/run.sh` | ClickHouse + Prometheus + Mimir |

Each now pre-pulls through `compose-pull-images.mjs` before `up`.

**The guard is widened to the class, not to the five sites.**
`TestJustfileComposeUpPrePullsWithRetry` scanned Justfile recipes, which is
precisely why these five survived it. It is replaced by
`TestComposeUpAcquiresImagesOverTheAuthenticatedPullPath`, which scans every
unit of execution in the tree that can bring a stack up — each Justfile recipe,
each shell script, each workflow file — and fails any one of them that reaches
`docker compose up` without the pre-pull. Reverting any single site above fails
it.

`compose-pull-images.mjs` grows an optional `-- <service>...` suffix, forwarded
to `docker compose config`. `bench/histogram` starts Mimir separately under
`|| MIMIR_OK=0` because its failure is tolerated; folding its image into the
core stack's pre-pull would have converted that tolerated failure into a hard
one. `splitArgs` is pinned on the `check` lane.
