### PR TITLE
fix(api): report a cancelled query as canceled, not a server fault

### DIFF
--- a/internal/api/loki/handler.go
+++ b/internal/api/loki/handler.go
@@ -528,7 +528,8 @@ func classifyEngineErr(err error) error {
 	// exceeded" path), NOT a 5xx fault — the query ran exactly as long as
 	// it was allowed to; ClickHouse is healthy (the chclient breaker
 	// treats code 159 as a success for the same reason). A plain
-	// context.Canceled (client gone) is deliberately not caught here.
+	// context.Canceled (client gone) is deliberately not caught here —
+	// it falls to the cancellation branch immediately below.
 	if errors.Is(err, chclient.ErrQueryTimeout) || errors.Is(err, context.DeadlineExceeded) {
 		msg := "query timed out"
 		var qt *chclient.QueryTimeoutError
@@ -538,6 +539,21 @@ func classifyEngineErr(err error) error {
 		return &apiError{
 			Kind:   ErrTimeout,
 			Err:    errors.New(msg),
+			Status: http.StatusServiceUnavailable,
+		}
+	}
+	// Caller-initiated cancellation: the client closed the connection (a
+	// browser tab shutting on a slow panel, an aborted fetch, a dashboard
+	// refresh superseding its own in-flight request), so net/http cancels
+	// the request context and the in-flight query unwinds with
+	// context.Canceled. HTTP 503 errorType=canceled, mirroring the Prom
+	// head — emphatically NOT a 5xx: nothing failed, the caller simply
+	// stopped waiting, and counting these as server faults inflates the
+	// 5xx rate with events that are not server errors.
+	if errors.Is(err, context.Canceled) {
+		return &apiError{
+			Kind:   ErrCanceled,
+			Err:    errors.New("query was canceled"),
 			Status: http.StatusServiceUnavailable,
 		}
 	}

--- a/internal/api/loki/handler_query_canceled_test.go
+++ b/internal/api/loki/handler_query_canceled_test.go
@@ -1,0 +1,77 @@
+package loki_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/api/loki"
+)
+
+// canceledQueryRangeURL builds a well-formed /query_range request whose
+// only interesting property is that the stub fails it — the parameters
+// just have to survive validation so the error reaches the classifier.
+func canceledQueryRangeURL(base string) string {
+	end := time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)
+	return fmt.Sprintf(
+		`%s/loki/api/v1/query_range?query=%%7Bjob%%3D%%22api%%22%%7D&start=%d&end=%d&step=60`,
+		base, end.Add(-time.Hour).Unix(), end.Unix(),
+	)
+}
+
+// getCanceled issues the request and returns the status code and body.
+func getCanceled(t *testing.T, url string) (int, string) {
+	t.Helper()
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	return resp.StatusCode, string(body)
+}
+
+// TestLokiQueryRange_Canceled503 — the client closed the connection
+// mid-query, so the query unwinds with context.Canceled wrapped in the
+// engine's stage prefix. The Loki head must answer 503
+// errorType=canceled rather than booking a caller hang-up as an
+// `engine: execute:` 502 server fault.
+func TestLokiQueryRange_Canceled503(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{err: fmt.Errorf("engine: execute: %w", context.Canceled)}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	status, body := getCanceled(t, canceledQueryRangeURL(srv.URL))
+	if status != http.StatusServiceUnavailable {
+		t.Fatalf("status: got %d, want 503; body=%s", status, body)
+	}
+	assertLokiErrorEnvelope(t, body, loki.ErrCanceled)
+}
+
+// TestLokiQueryRange_DeadlineExceededStaysTimeout — the discrimination
+// pin, mirroring the Prom head's. Both context sentinels map to 503, so
+// a classifier that collapsed them onto a single branch would still
+// return the right status and only the errorType would betray it. A
+// budget that expired is "timeout"; a caller that stopped waiting is
+// "canceled".
+func TestLokiQueryRange_DeadlineExceededStaysTimeout(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{err: fmt.Errorf("engine: execute: %w", context.DeadlineExceeded)}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	status, body := getCanceled(t, canceledQueryRangeURL(srv.URL))
+	if status != http.StatusServiceUnavailable {
+		t.Fatalf("status: got %d, want 503; body=%s", status, body)
+	}
+	assertLokiErrorEnvelope(t, body, loki.ErrTimeout)
+}

--- a/internal/api/prom/handler.go
+++ b/internal/api/prom/handler.go
@@ -897,9 +897,37 @@ func queryTimeoutAPIError(err error) *apiError {
 // expiry (context.DeadlineExceeded), the latter being how a query that
 // hangs past the budget without the server-side cap firing surfaces. A
 // plain context.Canceled (client walked away) is deliberately NOT
-// treated as a timeout — that maps to the canceled wire shape elsewhere.
+// treated as a timeout — isQueryCanceled maps it to the canceled wire
+// shape instead.
 func isQueryTimeout(err error) bool {
 	return errors.Is(err, chclient.ErrQueryTimeout) || errors.Is(err, context.DeadlineExceeded)
+}
+
+// isQueryCanceled reports whether err is a caller-initiated cancellation:
+// the client closed the connection (a browser tab shutting on a slow
+// panel, an aborted fetch, a dashboard refresh superseding its own
+// in-flight request), so net/http cancels the request context and the
+// in-flight query unwinds with context.Canceled. Distinct from
+// isQueryTimeout: nothing exceeded a budget, the caller simply stopped
+// waiting.
+func isQueryCanceled(err error) bool {
+	return errors.Is(err, context.Canceled)
+}
+
+// queryCanceledAPIError is the head-idiomatic reply for a cancelled
+// query — HTTP 503, errorType "canceled", mirroring upstream
+// Prometheus's web/api/v1 handling of promql.ErrQueryCanceled
+// (errorCanceled → 503) down to the message text. It is emphatically
+// NOT a 5xx server fault: cerberus and ClickHouse are both healthy and
+// nothing failed, so it is breaker-neutral. Counting these as server
+// errors inflates the 5xx rate with events that are not server errors,
+// which is what makes the signal unusable for alerting.
+func queryCanceledAPIError() *apiError {
+	return &apiError{
+		Kind:   ErrCanceled,
+		Err:    errors.New("query was canceled"),
+		Status: http.StatusServiceUnavailable,
+	}
 }
 
 // classifyDrainError maps errors surfaced while draining a query_range
@@ -919,6 +947,9 @@ func classifyDrainError(err error) error {
 	}
 	if isQueryTimeout(err) {
 		return queryTimeoutAPIError(err)
+	}
+	if isQueryCanceled(err) {
+		return queryCanceledAPIError()
 	}
 	return &apiError{Kind: ErrInternal, Err: err, Status: http.StatusBadGateway}
 }
@@ -970,6 +1001,12 @@ func classifyEngineError(err error) error {
 	// query ran exactly as long as it was allowed to.
 	if isQueryTimeout(err) {
 		return queryTimeoutAPIError(err)
+	}
+	// Caller-initiated cancellation (open path): the client hung up
+	// before the cursor opened. 503 errorType=canceled; never a 5xx —
+	// nothing failed, the caller stopped waiting.
+	if isQueryCanceled(err) {
+		return queryCanceledAPIError()
 	}
 	var ps *parseStageError
 	if errors.As(err, &ps) {

--- a/internal/api/prom/handler_query_canceled_test.go
+++ b/internal/api/prom/handler_query_canceled_test.go
@@ -1,0 +1,144 @@
+package prom_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/api/prom"
+	"github.com/tsouza/cerberus/internal/chclient"
+)
+
+// assertCanceled503 decodes a Prom error envelope and pins the
+// cancellation contract: HTTP 503, errorType "canceled" — mirroring
+// upstream Prometheus's handling of promql.ErrQueryCanceled
+// (errorCanceled → 503). The point of the contract is what it is NOT: a
+// client that hangs up mid-query must not be booked as a server fault,
+// or the 5xx rate fills with events no server caused.
+func assertCanceled503(t *testing.T, resp *http.Response) {
+	t.Helper()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status: got %d, want 503", resp.StatusCode)
+	}
+	var body queryResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	_ = resp.Body.Close()
+	if body.Status != "error" {
+		t.Fatalf("status field: got %q, want \"error\"", body.Status)
+	}
+	if body.ErrorType != prom.ErrCanceled {
+		t.Fatalf("errorType: got %q, want %q", body.ErrorType, prom.ErrCanceled)
+	}
+}
+
+// TestQuery_CanceledAtOpen503 — the client walked away before the cursor
+// opened, so engine.Query unwinds with context.Canceled wrapped in the
+// engine's stage prefix. That must map onto 503 errorType=canceled, not
+// the `engine: execute:` 502 the unclassified path produced.
+func TestQuery_CanceledAtOpen503(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{err: fmt.Errorf("engine: execute: %w", context.Canceled)}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v1/query?query=up")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	assertCanceled503(t, resp)
+}
+
+// TestQueryRange_CanceledMidDrain503 — the client hung up after the
+// query_range cursor opened, so the cancellation surfaces through
+// cursor.Err() on the drain path rather than at open. classifyDrainError
+// must reach the same verdict as classifyEngineError; a cancellation is
+// no more a server fault at row 40 than it was at row 0.
+func TestQueryRange_CanceledMidDrain503(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)
+	q := &canceledCursorQuerier{
+		stubQuerier: stubQuerier{
+			samples: []chclient.Sample{
+				{MetricName: "up", Labels: map[string]string{"job": "api"}, Timestamp: ts, Value: 1},
+			},
+		},
+	}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	url := fmt.Sprintf(
+		"%s/api/v1/query_range?query=up&start=%d&end=%d&step=15",
+		srv.URL, ts.Add(-time.Hour).Unix(), ts.Unix(),
+	)
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	assertCanceled503(t, resp)
+}
+
+// TestQuery_DeadlineExceededStaysTimeout — the discrimination pin. Both
+// context sentinels now map to 503, so a classifier that collapsed them
+// onto one branch would still return the right status code and only the
+// errorType would betray it. A budget that expired is "timeout"; a
+// caller that stopped waiting is "canceled". Without this test the two
+// branches could be reordered or merged and every status assertion above
+// would still pass.
+func TestQuery_DeadlineExceededStaysTimeout(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{err: fmt.Errorf("engine: execute: %w", context.DeadlineExceeded)}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v1/query?query=up")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	assertTimeout503(t, resp)
+}
+
+// canceledCursor yields its canned samples, then terminates the drain
+// with context.Canceled — the mid-stream shape a matrix query hits when
+// the caller closes the connection while rows are still streaming.
+type canceledCursor struct {
+	samples []chclient.Sample
+	idx     int
+	cur     chclient.Sample
+	err     error
+}
+
+func (c *canceledCursor) Next() bool {
+	if c.err != nil {
+		return false
+	}
+	if c.idx >= len(c.samples) {
+		c.err = context.Canceled
+		return false
+	}
+	c.cur = c.samples[c.idx]
+	c.idx++
+	return true
+}
+
+func (c *canceledCursor) Sample() chclient.Sample { return c.cur }
+func (c *canceledCursor) Err() error              { return c.err }
+func (c *canceledCursor) Close() error            { return nil }
+func (c *canceledCursor) Inspected() int64        { return int64(c.idx) }
+
+type canceledCursorQuerier struct {
+	stubQuerier
+}
+
+func (q *canceledCursorQuerier) QueryCursor(_ context.Context, sql string, args ...any) (chclient.Cursor, error) {
+	q.lastSQL = sql
+	q.lastArgs = args
+	return &canceledCursor{samples: q.samples}, nil
+}


### PR DESCRIPTION
## What

The Prometheus and Loki heads each declared an `ErrCanceled` errorType constant and **neither ever emitted it**. A query failing with `context.Canceled` fell through to the generic transport-failure branch and was reported as a **502 server fault**.

- `internal/api/prom/types.go:64` — `ErrCanceled = "canceled"`
- `internal/api/loki/types.go:222` — `ErrCanceled = "canceled"`

A repository-wide search for `ErrCanceled` returned exactly those two declarations and **zero** uses, so no code path could produce the `canceled` wire shape.

Both heads also carried a comment asserting that some *other* code handled cancellation:

- `internal/api/prom/handler.go` — `isQueryTimeout`: a plain `context.Canceled` "maps to the canceled wire shape **elsewhere**".
- `internal/api/loki/handler.go` — `classifyEngineErr`: `context.Canceled` (client gone) "is deliberately **not caught here**".

There was no elsewhere. Both comments are corrected to point at the branch that now exists.

## Why it matters

A client that disconnects mid-query — a browser tab closing on a slow Grafana panel, an aborted `fetch`, a dashboard refresh superseding its own in-flight request — was counted as a 5xx. That inflates the server-error rate with events no server caused, which is precisely what makes the signal unusable for alerting.

## How

Both heads now answer **HTTP 503, errorType `canceled`**, mirroring upstream Prometheus's `web/api/v1` handling of `promql.ErrQueryCanceled` (`errorCanceled` → 503) down to the message text. Like the wall-clock timeout branch it sits beside, it is breaker-neutral: nothing failed, the caller simply stopped waiting.

The Prom head covers **both** paths — `classifyEngineError` (cancelled before the cursor opened) and `classifyDrainError` (cancelled mid-stream) — because a cancellation is no more a server fault at row 40 than it was at row 0.

## Tests

Confirmed to **fail against the unfixed classifiers** (`status: got 502, want 503`) and pass with the fix — not written after the fact against already-green code.

Each head also gets a **discrimination pin**: `context.DeadlineExceeded` must stay `errorType=timeout`. Both sentinels now map to 503, so a classifier that collapsed them onto a single branch would still return the right status code and only the errorType would betray it. Without that pin the two branches could be reordered or merged and every status assertion would still pass.

## Scope note

The issue's suggested fix says to mirror `internal/api/tempo/errclass.go` "added in PR #1578". That file **is not on `main`** — it is introduced by the still-open #1581. This PR is therefore written standalone rather than against a file that does not yet exist, and touches no Tempo code, so it does not conflict with #1581.

Closes #1580