### PR TITLE
fix(ci): retry the mirror login and read every copy back out of GHCR

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -79,7 +79,7 @@ authenticated CLI `docker pull` of `clickhouse/clickhouse-server` was refused as
 A ref that names GHCR reaches GHCR whichever path resolves it, including the
 paths nobody has audited yet, and GHCR's budget is not the one every other
 tenant of the runner's IP is drawing on. The packages are **private**, so every consuming
-job needs a `docker/login-action` against `ghcr.io` with its own `GITHUB_TOKEN`
+job needs a `registry-login.mjs` step against `ghcr.io` with its own `GITHUB_TOKEN`
 and `packages: read`; a job that forgets is slower and quota-exposed, never
 broken. Nothing in the tree names a mirrored ref — compose files, Kubernetes
 manifests, the quickstart and the Helm chart keep naming Docker Hub, because
@@ -178,7 +178,7 @@ uncomputable-diff fallback — cannot drift between the lanes that use it.
 - **`repo-hygiene.mjs`** — `ci.yml`, the `forbid-skip` job's committed-artefact
   gate. Every other gate asks whether the tree COMPILES and PASSES; none asks
   what it CONTAINS, so a build artefact that is `git add`-ed by accident
-  survives indefinitely. Two scans close that class. `binary` rejects any
+  survives indefinitely. Three scans close that class. `binary` rejects any
   tracked blob that is compiled output, detected by CONTENT — an executable
   magic (ELF / Mach-O / PE / WebAssembly / ar archive) at offset 0, or a NUL
   byte inside the same leading window git itself sniffs when it classifies a
@@ -194,16 +194,27 @@ uncomputable-diff fallback — cannot drift between the lanes that use it.
   is retried out of the object store and, failing that, exits non-zero rather
   than being assumed to be text. Since `git ls-files` is the input, the
   companion fix for anything this catches is a `git rm` PLUS a `.gitignore`
-  rule — the ignore rule is what stops it coming back.
+  rule — the ignore rule is what stops it coming back. `registry-login`
+  rejects any workflow step that `uses: docker/login-action`: that Action has
+  no retry input, so a login losing one handshake fails the job before it has
+  pulled anything, and because a mirror miss falls back to Docker Hub a failed
+  GHCR login is SILENT at the point of use. Registry logins go through
+  `registry-login.mjs` instead, which retries transport faults and refuses to
+  retry a spent quota or a rejected credential. The scan matches the `uses:`
+  form only, so prose NAMING the Action — this paragraph included — stays
+  legal; a gate that policed the word instead of the step would make its own
+  rationale unwritable.
   `repo-hygiene.test.mjs` is the `node --test` guard (cheap discipline lane,
   run as the step BEFORE the gate): it builds a throwaway git repo, plants a
-  synthetic ELF blob and a stray root file, and asserts a non-zero exit
-  naming each, plus a clean exit on a conforming fixture — a gate never shown
-  to fail is indistinguishable from one that does nothing.
-  - Env: `CHECK` is one of `binary`, `root-allowlist`; `REPO_ROOT` (optional)
-    points the scan at another checkout (the self-test's fixture repo).
+  synthetic ELF blob, a stray root file, and a workflow step using
+  `docker/login-action`, and asserts a non-zero exit naming each, plus a clean
+  exit on a conforming fixture — a gate never shown to fail is
+  indistinguishable from one that does nothing.
+  - Env: `CHECK` is one of `binary`, `root-allowlist`, `registry-login`;
+    `REPO_ROOT` (optional) points the scan at another checkout (the
+    self-test's fixture repo).
   - Exit: `0` clean, `1` on any tracked binary / unsanctioned or rotted root
-    entry / unreadable blob / bad `CHECK`.
+    entry / `docker/login-action` step / unreadable blob / bad `CHECK`.
 - **`clickhouse-version-sync.mjs`** — `ci.yml`, the `forbid-skip` job's
   ClickHouse version-consistency gate. Reads `versions.yaml` (the single
   source of truth) and asserts the docker-compose quickstart + compatibility

--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -1205,6 +1205,34 @@ uncomputable-diff fallback — cannot drift between the lanes that use it.
   - Args: the image refs to acquire.
   - Env: `IMAGE_PULL_BACKOFF_SECONDS` (optional; default `3`).
   - Exit: `0` when every ref is in the local daemon, `1` as soon as one is not.
+- **`assert-image-jobs-authenticate.mjs`** — the required `check` lane. Fails
+  when a job that acquires an image has not logged in to the registry it
+  acquires from. An anonymous pull is not an error: it succeeds until the shared
+  per-runner-IP quota happens to be spent, and then surfaces as a 429 in an
+  unrelated lane, which is why the mirror shipped and three jobs were still on
+  the anonymous path afterwards — nothing in CI was asking the question.
+  - Resolves what a step DOES rather than what it says: through `just` recipes
+    and their variables, through the `.mjs` modules and the commands they spawn,
+    through a local composite action's own steps, and through `docker compose`
+    and `k3d`. Grepping for `docker pull` would see almost none of it.
+  - "Logs in" is not "uses `docker/login-action`". A `run:` step whose script
+    spawns `docker login` counts, with the registry read off the step's `env:`
+    (unset means Docker Hub, matching `docker login` itself) — so
+    `registry-login.mjs` is a login on the same terms.
+  - There is no allow-list and no exempted job name. The one shape that looks
+    like an acquisition and is not — this lane's own `node --test` of a module
+    that pulls images — is excluded because `node --test` imports a module and
+    runs its tests rather than its CLI, which is a fact about the command and
+    holds for every module.
+  - Env: `WORKFLOW_DIR` (optional; default `.github/workflows`), `REPO_ROOT`
+    (optional; default the working directory).
+  - Exit: `0` when every acquiring job is authenticated, `1` on a violation, on
+    a reference that resolves to nothing, or when no acquiring job is found at
+    all — a scan that reads nothing must not report the same green as a clean
+    tree.
+  - Gated by `assert-image-jobs-authenticate.test.mjs`, which strips a login
+    step out of the real workflow text and asserts each rule goes red. A gate
+    that cannot fail is a gap, not coverage.
 - **`mirror-images.mjs`** — `mirror-images.yml` (daily cron, `workflow_dispatch`,
   and pushes to the mirror's own files). Copies every ref in `lib/mirror.mjs`'s
   inventory into cerberus's GHCR namespace with `docker buildx imagetools

--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -1217,6 +1217,33 @@ uncomputable-diff fallback — cannot drift between the lanes that use it.
     the inventory→ref mapping and rejects two upstream refs colliding on one
     mirror ref — the one mirror bug that presents as a WRONG image rather than
     as a miss.
+  - Every copy is read back with `imagetools inspect` before it counts as
+    mirrored. "The copy command exited 0" and "a consumer can resolve this ref"
+    are different claims, and the difference is invisible downstream: an
+    unresolvable mirror is a miss, and a miss falls back to Docker Hub.
+- **`registry-login.mjs`** — `mirror-images.yml`, both login steps. `docker
+  login` under the same retry policy every other registry interaction here has.
+  It exists because `docker/login-action` has no retry input and the workflow
+  died on its first real run (30724446834) with `context deadline exceeded` on
+  the `/v2/` handshake, before pulling anything — so the mirror shipped inert
+  while the PR merged green, and every lane silently fell back to Docker Hub.
+  The classification is not re-implemented: it imports `lib/registry.mjs`'s
+  classifiers, so a login inherits the same verdicts a pull gets. Four classes,
+  asked in this order — a quota refusal fails on the first attempt (retrying
+  spends the window it was refused for), a rejected credential fails
+  immediately (wrong on attempt 1 is wrong on attempt 5), a transport fault
+  retries, anything else is fatal rather than retried five times and read as
+  flake.
+  - Env: `REGISTRY` (blank/unset means Docker Hub, matching `docker login`'s own
+    default), `USERNAME` (required), `PASSWORD` (required; passed on stdin,
+    never argv, so it cannot reach a process listing),
+    `REGISTRY_LOGIN_BACKOFF_STEP_SECONDS` (optional; default `2` — attempt N
+    waits N × step).
+  - Exit: `0` on a successful login, `1` on any class that is not retried and on
+    a transport fault that outlived every attempt.
+  - Gated by `registry-login.test.mjs` on the required `check` lane, which pins
+    the ORDER rather than the patterns: three of the four classes can match the
+    same output, and each wrong order fails silently in its own way.
 
 ## Notes
 

--- a/.github/scripts/assert-image-jobs-authenticate.mjs
+++ b/.github/scripts/assert-image-jobs-authenticate.mjs
@@ -1,0 +1,1160 @@
+// assert-image-jobs-authenticate — every CI job that acquires a container image
+// must authenticate to the registries it can acquire from, BEFORE it pulls.
+//
+// WHY THIS EXISTS. An anonymous pull is not an error. It succeeds, on most
+// runs, for as long as the shared per-runner-IP quota happens to have room in
+// it — and then one day it is refused with a 429 and the job reads as flake.
+// That is why #1572 could fix a whole class of these by construction and
+// `e2e.yml`'s `startup-bench` could still be sitting on the anonymous path
+// afterwards: nobody was wrong, the property simply was not asserted anywhere.
+// "Does this job authenticate before it pulls" is a question about the shape of
+// a workflow, so it can be answered by reading the workflow, and a question a
+// gate can answer is not a question that should keep being rediscovered from an
+// outage.
+//
+// WHAT IT ASSERTS. Three rules, each derived from the acquisition MECHANISM the
+// job uses rather than from a list of job names:
+//
+//   R1  A job that acquires any image at all has at least one registry login.
+//   R2  A job that acquires an image whose ref resolves to a Docker Hub ref
+//       (no registry host in the name) has a Docker Hub login.
+//   R3  A job that acquires through the shared mirror-first policy
+//       (`pullImageWithRetry` in lib/registry.mjs, which reaches for the
+//       PRIVATE GHCR mirror before Docker Hub) has a ghcr.io login. Without it
+//       the mirror is unreadable and every acquisition silently degrades to the
+//       anonymous Docker Hub quota the mirror exists to stop spending.
+//
+// THERE IS NO ALLOW-LIST, and that is the substance of the module rather than a
+// stylistic preference. The obvious way to write this gate is a regex for
+// `docker pull` over each job's text plus a list of the jobs known to be fine —
+// and such a list is where a real regression goes to hide, because the cheapest
+// way to make a new red job green is to append its name. So the one shape that
+// looked like a violation and is not — `ci.yml`'s discipline lane running
+// `node --test .github/scripts/compose-pull-images.test.mjs`, which mentions an
+// image-pulling module and pulls nothing — is excluded by a STRUCTURAL fact
+// about the command, not by its name: `node --test X` hands X to the node test
+// runner, which imports the module rather than running its CLI (every module
+// here guards `main` behind an `import.meta.url` check). Anything that has to be
+// excluded has to be excluded by a fact of that kind.
+//
+// HOW IT READS A JOB. A step's text is not evidence on its own — most of the
+// acquisitions in this repo are two or three hops from the workflow. So each
+// step's `run:` is tokenised into commands and every command is resolved to a
+// fixpoint: `just <recipe>` expands to the recipe body out of the Justfile (with
+// `{{VAR}}` bound from the Justfile's own assignments and `{{PARAM}}` from the
+// call site), `node <script.mjs>` expands to the script's spawned commands and
+// its `pullImageWithRetry` calls, `uses: ./.github/actions/<x>` expands to the
+// composite action's own steps, and a wrapper that takes a command on argv
+// (`build-with-registry-retry.mjs docker compose up`) expands to the command it
+// wraps. A reference this resolver cannot follow is reported as an error rather
+// than passed over: a gate that cannot read a step must not report that step
+// clean.
+//
+// ENV CONTRACT
+//   WORKFLOW_DIR    — directory of workflows to scan. Default `.github/workflows`.
+//   REPO_ROOT       — repository root the Justfile / scripts / actions resolve
+//                     against. Default `process.cwd()`.
+//
+// Exit: 0 when every image-acquiring job authenticates, 1 on any violation or on
+// any reference the resolver could not follow.
+
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { basename, isAbsolute, join, resolve as resolvePath } from 'node:path';
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+
+import { error, log, notice } from './lib/gh.mjs';
+
+// The acquisition primitive R3 is about. A script that imports this name — at
+// any depth through relative imports — acquires through the GHCR mirror first,
+// so the job running it needs mirror credentials whatever ref it ends up
+// naming. Spelled once here because it is the join between this gate and
+// lib/registry.mjs; if the primitive is ever renamed, this gate goes quiet and
+// the rename is the only place to notice.
+const sharedPolicySymbol = 'pullImageWithRetry';
+
+// Docker Hub under the two names the toolchain uses for it. `docker login` with
+// no host argument targets exactly this, which is why the empty registry is
+// spelled as a value here rather than handled as a missing one.
+const dockerHubRegistries = new Set(['', 'docker.io', 'index.docker.io', 'registry-1.docker.io']);
+
+// The mirror lives in GHCR, so this is the host R3 requires. Read off
+// lib/mirror.mjs's default `mirrorRegistry` rather than restated, so a mirror
+// that moves cannot leave the gate asserting a login to the old host.
+const mirrorHost = 'ghcr.io';
+
+// The two names a step uses for "this checkout". Both are the repository root
+// on a runner, so binding them to it is what lets
+// `node $GITHUB_WORKSPACE/.github/scripts/pull-buildkit-image.mjs` resolve to
+// the file this scan is reading.
+const repoRootVars = { GITHUB_WORKSPACE: '.', REPO_ROOT: '.' };
+
+// How deep a command may resolve before the resolver calls it a cycle. Recipes
+// call recipes and scripts spawn scripts, so some depth is normal; a chain
+// longer than this is a loop, and a loop must fail loudly rather than hang.
+const maxResolutionDepth = 12;
+
+// ---------------------------------------------------------------------------
+// YAML — the narrow slice of it these workflows use.
+//
+// Only `node:` builtins are available here (see the repo rule on CI scripts), so
+// this reads the block structure by indentation rather than parsing YAML in
+// general. That is sound for the shapes involved — a mapping of jobs, each with
+// a sequence of step mappings — and every function below fails rather than
+// guesses when the text does not have the shape it expects.
+// ---------------------------------------------------------------------------
+
+function indentOf(line) {
+  return line.length - line.trimStart().length;
+}
+
+function isBlank(line) {
+  return line.trim() === '' || line.trimStart().startsWith('#');
+}
+
+// blockUnder — the lines nested under the line at `start`, i.e. everything up to
+// the next non-blank line at or above its indentation.
+//
+// Blank and comment lines are buffered rather than emitted on sight. A comment
+// between two steps sits at the OUTER indentation, so emitting it immediately
+// would splice it into the block that precedes it — and a `run: |` body that has
+// swallowed the next step's explanatory comment contains whatever commands that
+// prose names in backticks. That is not a hypothetical: it made this resolver
+// report `just e2e-up`` (trailing backtick and all) as a recipe it could not
+// find.
+function blockUnder(lines, start) {
+  const base = indentOf(lines[start]);
+  const out = [];
+  let pending = [];
+  for (let i = start + 1; i < lines.length; i++) {
+    if (isBlank(lines[i])) {
+      pending.push(lines[i]);
+      continue;
+    }
+    if (indentOf(lines[i]) <= base) break;
+    out.push(...pending, lines[i]);
+    pending = [];
+  }
+  return out;
+}
+
+function findKey(lines, key, atIndent = null) {
+  const re = new RegExp(`^(\\s*)${key}:(\\s|$)`);
+  for (let i = 0; i < lines.length; i++) {
+    if (isBlank(lines[i])) continue;
+    const m = re.exec(lines[i]);
+    if (!m) continue;
+    if (atIndent !== null && m[1].length !== atIndent) continue;
+    return i;
+  }
+  return -1;
+}
+
+// scalarAt — the value of `key:` at the top level of `lines`, handling the three
+// forms these workflows use: an inline scalar, a `|`/`>` block, and a quoted
+// inline scalar.
+function scalarAt(lines, key) {
+  const i = findKey(lines, key, minIndent(lines));
+  if (i === -1) return null;
+  const inline = lines[i].slice(lines[i].indexOf(':') + 1).trim();
+  if (inline !== '' && inline !== '|' && inline !== '>' && inline !== '|-' && inline !== '>-') {
+    return unquote(inline);
+  }
+  return blockUnder(lines, i)
+    .map((l) => l.slice(Math.min(indentOf(lines[i]) + 1, l.length)))
+    .join('\n');
+}
+
+function minIndent(lines) {
+  let min = null;
+  for (const l of lines) {
+    if (isBlank(l)) continue;
+    const ind = indentOf(l);
+    if (min === null || ind < min) min = ind;
+  }
+  return min ?? 0;
+}
+
+function unquote(value) {
+  const t = value.trim();
+  if ((t.startsWith('"') && t.endsWith('"')) || (t.startsWith("'") && t.endsWith("'"))) {
+    return t.slice(1, -1);
+  }
+  return t;
+}
+
+// mappingAt — the flat `key: value` pairs directly under `key:`. Used for `env:`
+// and `with:`, neither of which nests in these workflows.
+function mappingAt(lines, key) {
+  const i = findKey(lines, key, minIndent(lines));
+  if (i === -1) return {};
+  const out = {};
+  for (const line of blockUnder(lines, i)) {
+    if (isBlank(line)) continue;
+    const m = /^\s*([A-Za-z0-9_.-]+):\s*(.*)$/.exec(line);
+    if (m) out[m[1]] = unquote(m[2]);
+  }
+  return out;
+}
+
+// splitSteps — a `steps:` block into one line-array per step. A step begins at a
+// `- ` item at the sequence's own indentation; everything until the next one
+// belongs to it. The leading `- ` is replaced with spaces so each step's lines
+// form a plain mapping the helpers above can read.
+function splitSteps(stepsBlock) {
+  const itemIndent = minIndent(stepsBlock);
+  const steps = [];
+  let current = null;
+  for (const line of stepsBlock) {
+    const isItem = !isBlank(line) && indentOf(line) === itemIndent && /^\s*-\s/.test(line);
+    if (isItem) {
+      if (current) steps.push(current);
+      current = [line.replace(/^(\s*)-(\s)/, '$1 $2')];
+      continue;
+    }
+    if (current) current.push(line);
+  }
+  if (current) steps.push(current);
+  return steps;
+}
+
+// parseWorkflow — { env, jobs: [{ name, env, steps }] }.
+export function parseWorkflow(text) {
+  const lines = text.split('\n');
+  const jobsIdx = findKey(lines, 'jobs', 0);
+  if (jobsIdx === -1) return { env: {}, jobs: [] };
+
+  const topEnvIdx = findKey(lines, 'env', 0);
+  const workflowEnv = topEnvIdx === -1 ? {} : mappingAt(lines.slice(topEnvIdx), 'env');
+
+  const jobsBlock = blockUnder(lines, jobsIdx);
+  const jobIndent = minIndent(jobsBlock);
+  const jobs = [];
+  let current = null;
+  for (const line of jobsBlock) {
+    if (!isBlank(line) && indentOf(line) === jobIndent) {
+      const m = /^\s*([A-Za-z0-9_-]+):\s*$/.exec(line);
+      if (m) {
+        if (current) jobs.push(current);
+        current = { name: m[1], lines: [] };
+        continue;
+      }
+    }
+    if (current) current.lines.push(line);
+  }
+  if (current) jobs.push(current);
+
+  return {
+    env: workflowEnv,
+    jobs: jobs.map((job) => {
+      const stepsIdx = findKey(job.lines, 'steps', minIndent(job.lines));
+      const steps = stepsIdx === -1 ? [] : splitSteps(blockUnder(job.lines, stepsIdx));
+      return { name: job.name, env: mappingAt(job.lines, 'env'), steps };
+    }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Shell — splitting a `run:` body into commands, and a command into argv.
+// ---------------------------------------------------------------------------
+
+// tokenise — argv for one command. Quotes group, and nothing else is
+// interpreted: the caller wants the words, not a shell.
+export function tokenise(command) {
+  const out = [];
+  let token = '';
+  let quote = null;
+  let started = false;
+  for (const ch of command) {
+    if (quote) {
+      if (ch === quote) quote = null;
+      else token += ch;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      started = true;
+      continue;
+    }
+    if (/\s/.test(ch)) {
+      if (started) out.push(token);
+      token = '';
+      started = false;
+      continue;
+    }
+    token += ch;
+    started = true;
+  }
+  if (started) out.push(token);
+  return out;
+}
+
+// splitCommands — a shell script body into individual commands. Joins
+// backslash-continued lines, drops comments, and splits on the separators that
+// start a new command. Redirections and subshell punctuation are left in the
+// token stream; they never occupy argv[0] in this tree, so they cost nothing.
+export function splitCommands(script) {
+  const joined = String(script ?? '')
+    .replace(/\\\n/g, ' ')
+    .split('\n')
+    .map((l) => (l.trimStart().startsWith('#') ? '' : l))
+    .join('\n');
+  return joined
+    .split(/\n|&&|\|\||;|(?<!\|)\|(?!\|)/)
+    .map((c) => c.trim())
+    .filter((c) => c !== '');
+}
+
+// stripPrefixes — leading noise that is not the program: a Justfile's `@`
+// silencer, `sudo`, `env`, and inline `KEY=value` assignments. The assignments
+// are returned, because a `run:` that sets an image ref inline is naming a ref
+// the resolver wants.
+function stripPrefixes(argv) {
+  const assignments = {};
+  let i = 0;
+  if (argv[0]?.startsWith('@')) argv = [argv[0].slice(1), ...argv.slice(1)];
+  while (i < argv.length) {
+    const t = argv[i];
+    if (t === 'sudo' || t === 'env' || t === 'command' || t === '-') {
+      i++;
+      continue;
+    }
+    const m = /^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/.exec(t);
+    if (m) {
+      assignments[m[1]] = m[2];
+      i++;
+      continue;
+    }
+    break;
+  }
+  return { argv: argv.slice(i).filter((t) => t !== ''), assignments };
+}
+
+// ---------------------------------------------------------------------------
+// Refs.
+// ---------------------------------------------------------------------------
+
+// isDockerHubRef — a ref with no registry host. Docker's own rule: the first
+// path segment is a host only when it contains a `.` or a `:`, or is
+// `localhost`. Everything else is Docker Hub, which is why `golang:1.26` and
+// `clickhouse/clickhouse-server:26.5` both spend that quota.
+export function isDockerHubRef(ref) {
+  const text = String(ref);
+  // No slash at all is an official library image (`golang:1.26`). Testing the
+  // first segment before checking for the slash reads the TAG's colon as a
+  // registry port, which quietly classifies the single most-pulled image in
+  // this repo as "not Docker Hub".
+  const slash = text.indexOf('/');
+  if (slash === -1) return true;
+  const first = text.slice(0, slash);
+  if (first === 'localhost') return false;
+  return !(first.includes('.') || first.includes(':'));
+}
+
+// `docker compose`'s value-taking GLOBAL flags — the ones that may appear
+// before the verb and swallow the token after them.
+const composeValueFlags = new Set([
+  '-f',
+  '--file',
+  '-p',
+  '--project-name',
+  '--project-directory',
+  '--env-file',
+  '--profile',
+  '--parallel',
+  '--progress',
+  '--ansi',
+]);
+
+// `docker login`'s only value-taking flags. Needed because the registry is a
+// trailing POSITIONAL, so "the first token that is not a flag" picks up a flag's
+// value instead and reports a login to a registry named `tsouza`.
+const dockerLoginValueFlags = new Set(['-u', '--username', '-p', '--password']);
+
+// loginRegistry — which registry a `docker login` argv authenticates to.
+//
+// The empty string means Docker Hub, and it is the answer in two distinct
+// cases that `docker` itself treats identically: no host argument at all, and a
+// host argument that came from an environment variable the step never set.
+// `docker login` with no host goes to Docker Hub, so a `${REGISTRY}` that is
+// unset is a Docker Hub login rather than an unknown one — which is exactly how
+// `registry-login.mjs` documents its own contract.
+export function loginRegistry(argv, scope) {
+  let host;
+  for (let i = 0; i < argv.length; i++) {
+    const t = argv[i];
+    if (dockerLoginValueFlags.has(t)) {
+      i++;
+      continue;
+    }
+    if (t.startsWith('-')) continue;
+    host = t;
+    break;
+  }
+  if (host === undefined) return '';
+  const expanded = expandVars(host, scope);
+  if (expanded !== null) return expanded.trim();
+  // A bare `$NAME` / `${NAME}` that the scope does not define is unset, not
+  // unknowable. A GitHub `${{ … }}` expression is genuinely unknowable and is
+  // NOT read as Docker Hub, because guessing there would invent a login.
+  return /^\$\{?[A-Za-z_][A-Za-z0-9_]*\}?$/.test(host) ? '' : host.trim();
+}
+
+// looksLikeImageRef — used to tell an image argument from a file argument on a
+// script's argv (`pull-images.mjs clickhouse/clickhouse-server:26.5` versus
+// `compose-pull-images.mjs docker-compose.yml`). Deliberately conservative: a
+// token it declines only costs R2 a ref it could have checked, never a false
+// violation.
+export function looksLikeImageRef(token) {
+  const t = String(token);
+  if (t === '' || t.startsWith('-')) return false;
+  if (/\.(ya?ml|json|mjs|js|sh|txt|md)$/.test(t)) return false;
+  if (t.includes('$') || t.includes('{')) return false;
+  if (!/^[a-z0-9][a-z0-9._/-]*(:[\w][\w.-]*)?(@sha256:[a-f0-9]+)?$/.test(t)) return false;
+  return t.includes(':') || t.includes('/');
+}
+
+// expandVars — `$VAR`, `${VAR}` and a Justfile's `{{VAR}}` against a scope.
+// Returns null when a name is unresolvable, which is a real answer: an
+// unresolved ref is not checked against R2 rather than guessed at.
+export function expandVars(text, scope) {
+  let out = String(text);
+  let unresolved = false;
+  out = out.replace(/\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}\}/g, (_, name) => {
+    if (name in scope) return scope[name];
+    unresolved = true;
+    return '';
+  });
+  out = out.replace(/\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?/g, (_, name) => {
+    if (name in scope) return scope[name];
+    unresolved = true;
+    return '';
+  });
+  // A GitHub expression is never statically known.
+  if (/\$\{\{/.test(text)) unresolved = true;
+  return unresolved ? null : out;
+}
+
+// ---------------------------------------------------------------------------
+// Justfile.
+// ---------------------------------------------------------------------------
+
+function parseJustfile(text) {
+  const vars = {};
+  const recipes = new Map();
+  const lines = text.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const v = /^([A-Za-z_][A-Za-z0-9_]*)\s*:=\s*(.*)$/.exec(line);
+    if (v) {
+      vars[v[1]] = unquote(v[2].trim());
+      continue;
+    }
+    // A recipe header sits at column 0 and its body is indented. Dependencies
+    // after the colon are other recipes and are followed too.
+    const r = /^([A-Za-z_][A-Za-z0-9_-]*)((?:\s+[+*]?[A-Za-z_][A-Za-z0-9_]*(?:="[^"]*")?)*)\s*:(.*)$/.exec(line);
+    if (!r || line.startsWith(' ') || line.startsWith('\t')) continue;
+    const params = (r[2].match(/[+*]?[A-Za-z_][A-Za-z0-9_]*(?:="[^"]*")?/g) ?? []).map((p) => {
+      const [name, dflt] = p.replace(/^[+*]/, '').split('=');
+      return { name, dflt: dflt === undefined ? null : unquote(dflt) };
+    });
+    const deps = r[3].trim().split(/\s+/).filter((d) => d !== '' && !d.startsWith('#'));
+    const body = [];
+    for (let j = i + 1; j < lines.length; j++) {
+      if (lines[j].trim() === '') continue;
+      if (!/^\s/.test(lines[j])) break;
+      body.push(lines[j].trim());
+    }
+    recipes.set(r[1], { params, deps, body });
+  }
+  return { vars, recipes };
+}
+
+// ---------------------------------------------------------------------------
+// Node scripts — the commands a `.mjs` module spawns, and whether it acquires
+// through the shared mirror-first policy.
+// ---------------------------------------------------------------------------
+
+// stringLiterals — the quoted strings inside one bracketed argument list.
+function stringLiterals(text) {
+  return [...text.matchAll(/(['"])((?:\\.|(?!\1).)*)\1/g)].map((a) => a[2]);
+}
+
+// envReadInto — the environment variable a local name is assigned from, if any.
+// `const registry = (process.env.REGISTRY ?? '').trim();` answers `REGISTRY`.
+// The point is not the assignment: it is that an argv token sourced this way is
+// knowable from the STEP's `env:` block, so a value the module cannot state
+// statically is still resolvable where it is actually set.
+function envReadInto(source, name) {
+  const re = new RegExp(`\\b(?:const|let|var)\\s+${name}\\s*=[^;\\n]*process\\.env\\.([A-Za-z_][A-Za-z0-9_]*)`);
+  const m = re.exec(source);
+  return m === null ? null : m[1];
+}
+
+// resolveArgArray — the argv a module builds in a named variable before
+// spawning it. Written separately from the inline-array case because the two
+// shapes carry the same meaning and only one of them is greppable: a script
+// that must append an argument conditionally cannot write its argv as a
+// literal, and reading only literals would make the built-up form invisible.
+// Tokens pushed from the environment come back as `${NAME}` so the caller
+// resolves them against the step's own `env:`.
+function resolveArgArray(source, name) {
+  const decl = new RegExp(`\\b(?:const|let|var)\\s+${name}\\s*=\\s*\\[([^\\]]*)\\]`).exec(source);
+  if (decl === null) return null;
+  const args = stringLiterals(decl[1]);
+  for (const m of source.matchAll(new RegExp(`\\b${name}\\.push\\(([^)]*)\\)`, 'g'))) {
+    const arg = m[1].trim();
+    const lit = /^(['"])((?:\\.|(?!\1).)*)\1$/.exec(arg);
+    if (lit) {
+      args.push(lit[2]);
+      continue;
+    }
+    const env = /^[A-Za-z_$][\w$]*$/.test(arg) ? envReadInto(source, arg) : null;
+    if (env !== null) args.push(`\${${env}}`);
+  }
+  return args;
+}
+
+// spawnedCommands — the argv shapes a module hands to the shared subprocess
+// helpers. Every registry interaction in this tree is written this way, with the
+// program and the verb as string literals, which is what makes it readable
+// statically.
+export function spawnedCommands(source) {
+  const out = [];
+  const re = /\b(?:capture|exec|spawnSync|spawn)\(\s*(['"])([\w./-]+)\1\s*,\s*(\[[^\]]*\]|[A-Za-z_$][\w$]*)/g;
+  for (const m of source.matchAll(re)) {
+    const args = m[3].startsWith('[') ? stringLiterals(m[3]) : resolveArgArray(source, m[3]);
+    if (args === null) continue;
+    out.push([m[2], ...args]);
+  }
+  return out;
+}
+
+// literalRefs — the image refs a module states as string literals, including the
+// ones it states in a module it imports. `mirror-images.mjs` names none itself:
+// its inventory is `mirroredImages` over in `lib/mirror.mjs`, and the refs reach
+// `docker buildx imagetools` through a variable, so the argv alone says only
+// THAT it copies images and never WHICH. Read only for a module already judged
+// to acquire, so a ref mentioned by a module that acquires nothing stays
+// invisible.
+function literalRefs(source) {
+  const out = [];
+  for (const m of stripComments(source).matchAll(/\[([^\]]*)\]/g)) {
+    for (const lit of stringLiterals(m[1])) if (looksLikeImageRef(lit)) out.push(lit);
+  }
+  return out;
+}
+
+// policyRefs — the image refs a module hands to `pullImageWithRetry`, resolved
+// through its own top-level `const NAME = 'literal'` table so a ref named once
+// and used once is still visible.
+function policyRefs(source) {
+  const consts = {};
+  for (const m of source.matchAll(/^const\s+([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(['"])([^'"]+)\2\s*;?\s*$/gm)) {
+    consts[m[1]] = m[3];
+  }
+  const refs = [];
+  for (const m of source.matchAll(new RegExp(`${sharedPolicySymbol}\\(\\s*([^,)]+)`, 'g'))) {
+    const arg = m[1].trim();
+    const lit = /^(['"])([^'"]+)\1$/.exec(arg);
+    if (lit) refs.push(lit[2]);
+    else if (arg in consts) refs.push(consts[arg]);
+  }
+  return refs;
+}
+
+// stripComments — so a module that DOCUMENTS the primitive is not read as one
+// that calls it. lib/registry.mjs's header prints the signature
+// (`pullImageWithRetry(image, options)`) in prose, which is indistinguishable
+// from a call site to any regex that reads comments as code.
+function stripComments(source) {
+  return String(source ?? '')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .split('\n')
+    .map((l) => l.replace(/(^|\s)\/\/.*$/, '$1'))
+    .join('\n');
+}
+
+// callsSharedPolicy — the primitive is INVOKED here, as opposed to declared here
+// (lib/registry.mjs) or named in a comment. The `function` lookbehind is what
+// separates the declaration from every call of it.
+export function callsSharedPolicy(source) {
+  return new RegExp(`(?<!function\\s)\\b${sharedPolicySymbol}\\s*\\(`).test(stripComments(source));
+}
+
+function relativeImports(source) {
+  return [...source.matchAll(/^import[^'"]*(['"])(\.[^'"]+)\1/gm)].map((m) => m[2]);
+}
+
+// namedImports — `{ a, b as c }` per relative specifier. Used to attribute an
+// imported array to the module that actually reads it: every consumer of
+// `lib/mirror.mjs` imports `mirroredRef`, but only the mirroring job imports the
+// INVENTORY, and charging the inventory to all of them reports jobs as pulling
+// two dozen images they never touch.
+function namedImports(source) {
+  const out = new Map();
+  for (const m of stripComments(source).matchAll(/^import\s*\{([^}]*)\}\s*from\s*(['"])(\.[^'"]+)\2/gm)) {
+    const names = m[1]
+      .split(',')
+      .map((n) => n.trim().split(/\s+as\s+/)[0].trim())
+      .filter((n) => n !== '');
+    out.set(m[3], [...(out.get(m[3]) ?? []), ...names]);
+  }
+  return out;
+}
+
+// arrayBinding — the string literals of `const NAME = [ … ]` in a module.
+function arrayBinding(source, name) {
+  const m = new RegExp(`\\b(?:export\\s+)?(?:const|let|var)\\s+${name}\\s*=\\s*\\[([^\\]]*)\\]`).exec(
+    stripComments(source),
+  );
+  return m === null ? [] : stringLiterals(m[1]);
+}
+
+// ---------------------------------------------------------------------------
+// The resolver.
+// ---------------------------------------------------------------------------
+
+// A `Findings` accumulator: what a job does, gathered across every hop.
+function newFindings() {
+  return {
+    acquisitions: [],
+    logins: [],
+    viaSharedPolicy: false,
+    refs: new Set(),
+    unresolved: [],
+    // R4's bookkeeping: which compose models the shared policy was applied to,
+    // which ones were materialised, and how many acquisitions were writes INTO
+    // the mirror rather than reads that the mirror could have served.
+    composePolicyFiles: new Set(),
+    composeMaterialised: [],
+    mirrorWrites: 0,
+  };
+}
+
+class Resolver {
+  constructor(root) {
+    this.root = root;
+    this.just = null;
+    this.sourceCache = new Map();
+    this.policyCache = new Map();
+  }
+
+  read(path) {
+    const abs = isAbsolute(path) ? path : join(this.root, path);
+    if (!this.sourceCache.has(abs)) {
+      this.sourceCache.set(abs, existsSync(abs) ? readFileSync(abs, 'utf8') : null);
+    }
+    return this.sourceCache.get(abs);
+  }
+
+  justfile() {
+    if (this.just === null) {
+      const text = this.read('Justfile');
+      if (text === null) throw new Error('Justfile not found — `just` recipes cannot be resolved');
+      this.just = parseJustfile(text);
+    }
+    return this.just;
+  }
+
+  // usesSharedPolicy — does this module, or anything it imports, acquire through
+  // pullImageWithRetry? Memoised, and cycle-safe by marking before recursing.
+  //
+  // Following EVERY relative import rather than only the one the primitive
+  // arrives on over-approximates, deliberately. The two errors are not
+  // symmetric: over-approximating costs a job a login it did not strictly need,
+  // while under-approximating is the anonymous pull this whole module exists to
+  // catch.
+  usesSharedPolicy(path, seen = new Set()) {
+    if (this.policyCache.has(path)) return this.policyCache.get(path);
+    if (seen.has(path)) return false;
+    seen.add(path);
+    const source = this.read(path);
+    if (source === null) return false;
+    // A CALL, not a mention. lib/registry.mjs declares the primitive and
+    // chart-kubeconform.mjs imports a rate-limit classifier out of the same
+    // module — matching the bare identifier reported that job as pulling images
+    // it never pulls, and a gate that invents a violation gets an exemption
+    // written for it, which is the failure mode this module exists to avoid.
+    let answer = callsSharedPolicy(source);
+    if (!answer) {
+      const dir = join(this.root, path, '..');
+      for (const spec of relativeImports(source)) {
+        const child = resolvePath(dir, spec).slice(this.root.length + 1);
+        if (this.usesSharedPolicy(child, seen)) {
+          answer = true;
+          break;
+        }
+      }
+    }
+    this.policyCache.set(path, answer);
+    return answer;
+  }
+
+  // moduleLiteralRefs — the image refs this module states as literals, plus the
+  // ones held by an array binding it IMPORTS BY NAME.
+  //
+  // The import hop is the load-bearing half: the mirroring job's inventory lives
+  // in `lib/mirror.mjs` and reaches `docker buildx imagetools` through a loop
+  // variable, so its argv says only THAT it copies images and never which — R2
+  // would degrade to "this job logs in somewhere" for the one job whose whole
+  // purpose is reading Docker Hub. Following the NAME rather than the module is
+  // what stops that from charging the inventory to every job that imports
+  // `mirroredRef` out of the same file.
+  moduleLiteralRefs(path) {
+    const source = this.read(path);
+    if (source === null) return [];
+    const out = literalRefs(source);
+    const dir = join(this.root, path, '..');
+    for (const [spec, names] of namedImports(source)) {
+      const child = this.read(resolvePath(dir, spec).slice(this.root.length + 1));
+      if (child === null) continue;
+      for (const name of names) out.push(...arrayBinding(child, name).filter(looksLikeImageRef));
+    }
+    return out;
+  }
+
+  // command — classify one argv, following it wherever it goes.
+  command(rawArgv, scope, findings, depth) {
+    if (depth > maxResolutionDepth) {
+      findings.unresolved.push(`resolution depth exceeded at \`${rawArgv.join(' ')}\``);
+      return;
+    }
+    const { argv, assignments } = stripPrefixes(rawArgv);
+    if (argv.length === 0) return;
+    const inner = { ...scope, ...assignments };
+    const program = argv[0];
+
+    if (program === 'docker') return this.docker(argv, inner, findings, depth);
+    if (program === 'k3d') return this.k3d(argv, inner, findings, depth);
+    if (program === 'just') return this.justRecipe(argv, inner, findings, depth);
+    if (program === 'node') return this.node(argv, inner, findings, depth);
+    if (program === 'bash' || program === 'sh') {
+      // `-c` takes the script itself rather than a path to one.
+      const c = argv.indexOf('-c');
+      if (c !== -1 && argv[c + 1] !== undefined) {
+        for (const cmd of splitCommands(argv[c + 1])) {
+          this.command(tokenise(cmd), inner, findings, depth + 1);
+        }
+        return;
+      }
+      const script = argv.slice(1).find((t) => !t.startsWith('-'));
+      if (script) this.shellScript(script, inner, findings, depth);
+      return;
+    }
+    if (/\.sh$/.test(program)) return this.shellScript(program, inner, findings, depth);
+  }
+
+  docker(argv, scope, findings, depth) {
+    const rest = argv.slice(1).filter((t) => t !== '');
+    const sub = rest.find((t) => !t.startsWith('-'));
+    if (sub === 'login') {
+      findings.logins.push({ registry: loginRegistry(rest.slice(rest.indexOf('login') + 1), scope) });
+      return;
+    }
+    if (sub === 'pull') {
+      findings.acquisitions.push(`docker pull`);
+      for (const t of rest.slice(rest.indexOf('pull') + 1)) this.noteRef(t, scope, findings);
+      return;
+    }
+    if (sub === 'run' || sub === 'create') {
+      // The image argument sits after an arbitrary run of flags whose value
+      // arity is not knowable from the token stream, so the ref is left
+      // unresolved rather than guessed. R1 still applies; the ref that matters
+      // is normally named by the pre-pull in the same job anyway.
+      findings.acquisitions.push(`docker ${sub}`);
+      return;
+    }
+    if (sub === 'compose') {
+      const after = rest.slice(rest.indexOf('compose') + 1);
+      // The verb sits after the global flags, and the value-taking ones must be
+      // stepped over: `docker compose -f x.yml up` otherwise reads `x.yml` as
+      // the verb, matches nothing, and the materialisation vanishes from the
+      // scan entirely.
+      let verb;
+      for (let i = 0; i < after.length; i++) {
+        if (composeValueFlags.has(after[i])) {
+          i++;
+          continue;
+        }
+        if (after[i].startsWith('-')) continue;
+        verb = after[i];
+        break;
+      }
+      if (['up', 'pull', 'create', 'run', 'build'].includes(verb)) {
+        findings.acquisitions.push(`docker compose ${verb}`);
+        // `-f` may repeat. No `-f` means compose's own default lookup in the
+        // working directory, recorded as "the job's default model" — the cwd is
+        // not tracked across a script's `cd`, so the models are matched by file
+        // name. Looser than a path comparison, and deliberately so: the failure
+        // that matters is a materialisation with NO pre-pull anywhere in the
+        // job, and a gate that fires on a path it merely failed to follow would
+        // earn itself an exemption.
+        const files = [];
+        for (let i = 0; i < after.length; i++) {
+          if ((after[i] === '-f' || after[i] === '--file') && after[i + 1] !== undefined) {
+            files.push(basename(unquote(expandVars(after[i + 1], scope) ?? after[i + 1])));
+          }
+        }
+        findings.composeMaterialised.push(files);
+      }
+      return;
+    }
+    // `imagetools` reads a manifest straight out of the registry — `create`
+    // copies one ref to another, `inspect` resolves one. Neither puts an image
+    // in the local daemon, which is why it does not look like an acquisition,
+    // but the READ still spends the source registry's quota exactly as a pull
+    // does. The job that mirrors this repo's inventory acquires images this way
+    // and no other way, so leaving it out excused the one job whose entire
+    // purpose is reading Docker Hub.
+    if (sub === 'buildx' && rest.includes('imagetools')) {
+      const verb = rest.slice(rest.indexOf('imagetools') + 1).find((t) => !t.startsWith('-'));
+      if (['create', 'inspect'].includes(verb)) {
+        findings.acquisitions.push(`docker buildx imagetools ${verb}`);
+        // A write INTO a registry, not a read the mirror could have served.
+        // R4 asks that reads route through the mirror; asking it of the job
+        // that POPULATES the mirror is circular, and this is the structural
+        // fact that says so rather than the job's name.
+        findings.mirrorWrites++;
+        for (const t of rest.slice(rest.indexOf(verb) + 1)) this.noteRef(t, scope, findings);
+      }
+      return;
+    }
+    if (sub === 'build' || (sub === 'buildx' && rest.includes('build'))) {
+      // A build resolves its `FROM` refs against the registry from inside
+      // BuildKit, so it is an acquisition even though nothing is pulled by the
+      // daemon.
+      findings.acquisitions.push('docker build');
+    }
+  }
+
+  k3d(argv, scope, findings, _depth) {
+    if (argv[1] !== 'cluster' || argv[2] !== 'create') return;
+    findings.acquisitions.push('k3d cluster create');
+    const i = argv.indexOf('--image');
+    if (i !== -1 && argv[i + 1]) this.noteRef(argv[i + 1], scope, findings);
+  }
+
+  justRecipe(argv, scope, findings, depth) {
+    const { vars, recipes } = this.justfile();
+    const name = argv[1];
+    if (name === undefined) return;
+    const recipe = recipes.get(name);
+    if (!recipe) {
+      findings.unresolved.push(`\`just ${name}\` names no recipe in the Justfile`);
+      return;
+    }
+    const bound = { ...vars, ...scope };
+    // Expanded AT THE CALL SITE. `just schema-ddl-test` runs
+    // `just _pull-retry {{CH_TEST_IMAGE}}`, so binding the argument verbatim
+    // would hand `_pull-retry` the literal text `{{CH_TEST_IMAGE}}` and the ref
+    // would arrive at `pull-images.mjs` still unexpanded — which is exactly how
+    // two jobs pulling a named Docker Hub image read as "ref unknown" and slipped
+    // the Docker Hub rule.
+    const args = argv.slice(2).map((a) => expandVars(a, bound) ?? a);
+    recipe.params.forEach((p, i) => {
+      // A variadic parameter swallows the rest; anything unsupplied falls back
+      // to its default, and a required parameter with nothing behind it stays
+      // unbound so `expandVars` reports it rather than inventing a value.
+      const value = i === recipe.params.length - 1 ? args.slice(i).join(' ') : args[i];
+      if (value !== undefined && value !== '') bound[p.name] = value;
+      else if (p.dflt !== null) bound[p.name] = p.dflt;
+    });
+    for (const dep of recipe.deps) this.command(['just', dep], scope, findings, depth + 1);
+    for (const line of recipe.body) {
+      for (const cmd of splitCommands(line)) {
+        this.command(tokenise(cmd), bound, findings, depth + 1);
+      }
+    }
+  }
+
+  node(argv, scope, findings, depth) {
+    const rest = argv.slice(1);
+    // `node --test X` runs X under the node test runner: it imports the module
+    // and executes its tests, never its CLI main. This is the structural reason
+    // ci.yml's discipline lane is not an image acquisition, and it holds for
+    // every module rather than for one named one.
+    if (rest.includes('--test')) return;
+    const scriptIdx = rest.findIndex((t) => !t.startsWith('-'));
+    if (scriptIdx === -1) return;
+    const script = expandVars(rest[scriptIdx], scope) ?? rest[scriptIdx];
+    if (/\.test\.mjs$/.test(script)) return;
+
+    const source = this.read(script);
+    if (source === null) {
+      findings.unresolved.push(`\`node ${script}\` names no file in the repository`);
+      return;
+    }
+    if (this.usesSharedPolicy(script)) {
+      findings.viaSharedPolicy = true;
+      findings.acquisitions.push(`${script} (shared mirror-first policy)`);
+      for (const ref of policyRefs(source)) this.noteRef(ref, scope, findings);
+      // Refs handed to the script on argv, e.g. `pull-images.mjs golang:1.26`.
+      for (const t of rest.slice(scriptIdx + 1)) {
+        this.noteRef(t, scope, findings);
+        // A compose FILE handed to the shared policy is the pre-pull that puts
+        // that model's images in the daemon ahead of `up`. Recorded structurally
+        // — the policy was applied to this model — rather than by the name of
+        // the module that applied it.
+        const arg = unquote(expandVars(t, scope) ?? t);
+        if (/\.ya?ml$/.test(arg)) findings.composePolicyFiles.add(basename(arg));
+      }
+    }
+    const before = findings.acquisitions.length;
+    for (const spawned of spawnedCommands(source)) {
+      this.command(spawned, scope, findings, depth + 1);
+    }
+    // Only once the module has been judged to acquire. A ref stated by a module
+    // that acquires nothing is a name, not a pull.
+    if (findings.acquisitions.length > before) {
+      for (const ref of this.moduleLiteralRefs(script)) this.noteRef(ref, scope, findings);
+    }
+    // A wrapper takes the command it wraps on its own argv.
+    const wrapped = rest.slice(scriptIdx + 1);
+    if (wrapped.length > 0) this.command(wrapped, scope, findings, depth + 1);
+  }
+
+  shellScript(rawPath, scope, findings, depth) {
+    const path = expandVars(rawPath, scope) ?? rawPath;
+    const source = this.read(path);
+    if (source === null) {
+      findings.unresolved.push(`\`${path}\` names no file in the repository`);
+      return;
+    }
+    for (const cmd of splitCommands(source)) {
+      this.command(tokenise(cmd), scope, findings, depth + 1);
+    }
+  }
+
+  // noteRef — record every image ref a token names. Splits on whitespace because
+  // a variadic Justfile parameter arrives as ONE token holding several refs
+  // (`_pull-retry {{CH_TEST_IMAGE}} {{CH_TEST_IMAGE_PRIOR}}` binds `IMAGES` to
+  // both), and a two-ref token matches no image-ref shape at all — so the whole
+  // pair would vanish rather than half of it.
+  noteRef(token, scope, findings) {
+    const expanded = expandVars(token, scope);
+    if (expanded === null) return;
+    for (const part of unquote(expanded).trim().split(/\s+/)) {
+      if (looksLikeImageRef(part)) findings.refs.add(part);
+    }
+  }
+
+  // step — one workflow step, including a local composite action's own steps.
+  step(stepLines, scope, findings, depth = 0) {
+    const uses = scalarAt(stepLines, 'uses');
+    const run = scalarAt(stepLines, 'run');
+    const stepEnv = mappingAt(stepLines, 'env');
+    const inner = { ...scope, ...stepEnv };
+
+    if (uses !== null) {
+      if (/^docker\/login-action(@|$)/.test(uses)) {
+        const w = mappingAt(stepLines, 'with');
+        findings.logins.push({ registry: (w.registry ?? '').trim() });
+        return;
+      }
+      if (uses.startsWith('./')) {
+        const actionPath = ['action.yml', 'action.yaml']
+          .map((f) => join(uses.slice(2), f))
+          .find((p) => this.read(p) !== null);
+        if (actionPath === undefined) {
+          findings.unresolved.push(`\`uses: ${uses}\` resolves to no action.yml`);
+          return;
+        }
+        const lines = this.read(actionPath).split('\n');
+        const runsIdx = findKey(lines, 'runs', 0);
+        if (runsIdx === -1) return;
+        const runsBlock = blockUnder(lines, runsIdx);
+        const inputs = defaultInputs(lines);
+        const withValues = mappingAt(stepLines, 'with');
+        const actionScope = { ...inner, ...inputs, ...withValues };
+        const stepsIdx = findKey(runsBlock, 'steps', minIndent(runsBlock));
+        if (stepsIdx === -1) return;
+        for (const s of splitSteps(blockUnder(runsBlock, stepsIdx))) {
+          this.step(s, actionScope, findings, depth + 1);
+        }
+      }
+      return;
+    }
+
+    if (run === null) return;
+    for (const cmd of splitCommands(run)) {
+      this.command(tokenise(cmd), inner, findings, depth + 1);
+    }
+  }
+}
+
+// defaultInputs — a composite action's `inputs.<name>.default` values, so a
+// caller that does not override an input still resolves the ref it will use.
+function defaultInputs(lines) {
+  const i = findKey(lines, 'inputs', 0);
+  if (i === -1) return {};
+  const block = blockUnder(lines, i);
+  const nameIndent = minIndent(block);
+  const out = {};
+  let name = null;
+  for (const line of block) {
+    if (isBlank(line)) continue;
+    if (indentOf(line) === nameIndent) {
+      const m = /^\s*([A-Za-z0-9_-]+):\s*$/.exec(line);
+      name = m ? m[1] : null;
+      continue;
+    }
+    const d = /^\s*default:\s*(.*)$/.exec(line);
+    if (d && name) out[name] = unquote(d[1]);
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// The rules.
+// ---------------------------------------------------------------------------
+
+// A login's registry is matched by HOST, never by prefix or raw string. Prefix
+// matching is the wider hole -- `startsWith('ghcr.io')` also accepts
+// `ghcr.io.example.com`, a host somebody else controls, which would read as a
+// mirror login. Raw-string matching is the narrower one: it misses the
+// equivalent spellings `docker login` itself accepts, so a job that really is
+// authenticated to Docker Hub as `https://index.docker.io/v1/` would be
+// reported as anonymous.
+//
+// Returns '' for an unset registry, because `docker login` with no argument
+// targets Docker Hub, and null for a value that is not a host at all -- null
+// equals no registry in the set, so an unparseable spelling matches nothing
+// rather than collapsing into the '' that means Docker Hub.
+function registryHost(registry) {
+  const raw = String(registry ?? '')
+    .trim()
+    .toLowerCase();
+  if (raw === '') return '';
+  try {
+    return new URL(raw.includes('://') ? raw : `https://${raw}`).hostname;
+  } catch {
+    return null;
+  }
+}
+
+export function violationsFor(jobId, findings) {
+  const out = [];
+  if (findings.acquisitions.length === 0) return out;
+
+  const how = [...new Set(findings.acquisitions)].join(', ');
+  const hasAny = findings.logins.length > 0;
+  const hasHub = findings.logins.some((l) => dockerHubRegistries.has(registryHost(l.registry)));
+  const hasMirror = findings.logins.some((l) => registryHost(l.registry) === mirrorHost);
+
+  if (!hasAny) {
+    out.push(`${jobId}: acquires images (${how}) with no registry login step — the pull is anonymous`);
+    return out;
+  }
+  const hubRefs = [...findings.refs].filter(isDockerHubRef);
+  if (hubRefs.length > 0 && !hasHub) {
+    out.push(
+      `${jobId}: acquires the Docker Hub image(s) ${hubRefs.sort().join(', ')} but has no Docker Hub ` +
+        'login — that pull spends the shared anonymous per-runner-IP quota',
+    );
+  }
+  if (findings.viaSharedPolicy && !hasMirror) {
+    out.push(
+      `${jobId}: acquires through the shared mirror-first policy but has no ${mirrorHost} login — ` +
+        'the mirror is unreadable, so every acquisition silently falls back to Docker Hub',
+    );
+  }
+
+  // R4 — the acquisitions must run ON the authenticated, mirror-first path, not
+  // merely alongside a login step.
+  //
+  // A login step is necessary and NOT sufficient, and there is a run that proves
+  // it: 30701755787 logged in successfully and was refused as UNAUTHENTICATED
+  // one second later, because `docker compose`'s own pull path does not carry
+  // the credentials the CLI wrote. A gate that stopped at login-presence would
+  // have passed that job — a hollow green on the exact failure it is named
+  // after. So presence is asked above, and reachability is asked here.
+  for (const files of findings.composeMaterialised) {
+    const covered =
+      files.length === 0
+        ? findings.composePolicyFiles.size > 0
+        : files.every((f) => findings.composePolicyFiles.has(f));
+    if (covered) continue;
+    const which = files.length === 0 ? 'its compose model' : files.join(', ');
+    out.push(
+      `${jobId}: materialises ${which} without pre-pulling it through the shared mirror-first ` +
+        "policy — compose's own pull path carries neither the login nor the mirror, so those " +
+        'images are fetched anonymously from Docker Hub however the job is authenticated',
+    );
+  }
+  if (!findings.viaSharedPolicy && findings.acquisitions.length > findings.mirrorWrites) {
+    out.push(
+      `${jobId}: acquires images (${how}) without going through the shared mirror-first policy — ` +
+        'a login raises the quota it spends, the mirror is what stops it spending that quota at all',
+    );
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// CLI.
+// ---------------------------------------------------------------------------
+
+export function scan({ root = process.cwd(), workflowDir = '.github/workflows' } = {}) {
+  const resolver = new Resolver(root);
+  // Absolute is honoured so a caller can point the scan at a doctored copy of
+  // the workflows while the Justfile / scripts / actions still resolve against
+  // the real tree. That is what lets the tests prove this gate FAILS, on the
+  // real workflow text, rather than only that it passes.
+  const dir = isAbsolute(workflowDir) ? workflowDir : join(root, workflowDir);
+  const results = [];
+  for (const file of readdirSync(dir).sort()) {
+    if (!/\.ya?ml$/.test(file)) continue;
+    const { env, jobs } = parseWorkflow(readFileSync(join(dir, file), 'utf8'));
+    for (const job of jobs) {
+      const findings = newFindings();
+      const scope = { ...repoRootVars, ...env, ...job.env };
+      for (const step of job.steps) resolver.step(step, scope, findings);
+      results.push({ id: `${file}:${job.name}`, findings });
+    }
+  }
+  return results;
+}
+
+function main() {
+  const root = process.env.REPO_ROOT || process.cwd();
+  const workflowDir = process.env.WORKFLOW_DIR || '.github/workflows';
+  const results = scan({ root, workflowDir });
+
+  const acquiring = results.filter((r) => r.findings.acquisitions.length > 0);
+  const violations = [];
+  const unresolved = [];
+  for (const { id, findings } of results) {
+    violations.push(...violationsFor(id, findings));
+    for (const u of findings.unresolved) unresolved.push(`${id}: ${u}`);
+  }
+
+  log(`scanned ${results.length} jobs; ${acquiring.length} acquire at least one image`);
+  for (const { id, findings } of acquiring) {
+    const logins = findings.logins.map((l) => l.registry || 'docker.io').sort().join(' + ') || 'NONE';
+    log(`  ${id} — ${[...new Set(findings.acquisitions)].join(', ')} | logins: ${logins}`);
+  }
+
+  // A job that no longer acquires anything would make this gate vacuous, and a
+  // vacuous gate reports the same green as a satisfied one.
+  if (acquiring.length === 0) {
+    error('no image-acquiring job was found at all — the detector is not reading the workflows');
+    process.exit(1);
+  }
+  for (const u of unresolved) error(`unreadable reference — ${u}`);
+  for (const v of violations) error(v);
+  if (unresolved.length > 0 || violations.length > 0) {
+    error(
+      'every job that acquires an image must acquire it over the authenticated, mirror-first path. ' +
+        'Add the Docker Hub and ghcr.io logins to the job above ahead of its first acquisition, and ' +
+        'route the acquisition itself through .github/scripts/lib/registry.mjs — for a compose ' +
+        'stack that means pre-pulling the model with compose-pull-images.mjs before `up`, because ' +
+        "compose's own pull path carries neither the login nor the mirror.",
+    );
+    process.exit(1);
+  }
+  notice(`${acquiring.length} image-acquiring jobs, all on the authenticated mirror-first path`);
+  process.exit(0);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) main();

--- a/.github/scripts/assert-image-jobs-authenticate.test.mjs
+++ b/.github/scripts/assert-image-jobs-authenticate.test.mjs
@@ -1,0 +1,504 @@
+// Tests for the image-acquisition authentication gate.
+//
+// Two things are at stake and they pull in opposite directions.
+//
+// The first is that the gate CAN FAIL. A detector that resolves a job wrongly
+// reports the same green as one that resolved it right, so "the tree is clean"
+// is not evidence of anything on its own — it is equally consistent with a
+// resolver that stopped reading at the first `just`. Every rule below is
+// therefore proved against the REAL workflow text with a login step removed
+// from it, not against a hand-written fixture that only resembles one.
+//
+// The second is that it fails for the RIGHT reason. The whole value of this gate
+// over a grep is that the one shape which looks like a violation and is not —
+// `node --test .github/scripts/compose-pull-images.test.mjs`, a unit test that
+// mentions an image-pulling module and pulls nothing — is excluded by a
+// structural fact rather than by its name. If that discrimination ever collapses
+// into a name list, the gate has become the thing it replaced, so it is pinned
+// here directly.
+
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import {
+  callsSharedPolicy,
+  expandVars,
+  isDockerHubRef,
+  looksLikeImageRef,
+  loginRegistry,
+  parseWorkflow,
+  scan,
+  spawnedCommands,
+  splitCommands,
+  tokenise,
+  violationsFor,
+} from './assert-image-jobs-authenticate.mjs';
+
+const repoRoot = process.cwd();
+const workflows = join(repoRoot, '.github/workflows');
+
+// The job used as the live specimen: it acquires through the shared policy AND
+// names a Docker Hub ref two hops away (`just _pull-retry "$CH_IMAGE"` →
+// `pull-images.mjs {{IMAGES}}`), so it exercises every rule at once.
+const specimenJob = 'e2e.yml:startup-bench';
+
+function realScan() {
+  return scan({ root: repoRoot, workflowDir: workflows });
+}
+
+function findingsFor(id, results) {
+  const hit = results.find((r) => r.id === id);
+  assert.ok(hit, `${id} was not found among the scanned jobs`);
+  return hit.findings;
+}
+
+// scanWith — the real workflow directory with ONE file replaced by a doctored
+// copy. The Justfile and the scripts still resolve against the real tree, so the
+// resolution under test is the real resolution.
+function scanWith(file, edit) {
+  const dir = mkdtempSync(join(tmpdir(), 'image-auth-gate-'));
+  const original = readFileSync(join(workflows, file), 'utf8');
+  const doctored = edit(original);
+  assert.notEqual(doctored, original, 'the negative control did not change the workflow text');
+  writeFileSync(join(dir, file), doctored);
+  return scan({ root: repoRoot, workflowDir: dir });
+}
+
+// Removes EVERY `- name: <title>` step, each up to the next step at its own
+// indentation. Deleting the login is the regression this gate exists to catch,
+// so it is also the way to prove the gate catches it.
+//
+// Every occurrence, not the first: `Log in to Docker Hub` is the title of a step
+// in six jobs of e2e.yml, so removing one match doctors whichever job happens to
+// come first in the file — which is not the job under test, and leaves the
+// control asserting that an untouched job is still clean.
+function withoutStep(title) {
+  return (text) => {
+    const lines = text.split('\n');
+    const out = [];
+    let i = 0;
+    let removed = 0;
+    while (i < lines.length) {
+      if (lines[i].trim() !== `- name: ${title}`) {
+        out.push(lines[i]);
+        i++;
+        continue;
+      }
+      const indent = lines[i].length - lines[i].trimStart().length;
+      removed++;
+      i++;
+      while (i < lines.length) {
+        const l = lines[i];
+        if (l.trim().startsWith('- ') && l.length - l.trimStart().length === indent) break;
+        i++;
+      }
+    }
+    assert.notEqual(removed, 0, `no step titled "${title}" to remove`);
+    return out.join('\n');
+  };
+}
+
+// ---------------------------------------------------------------------------
+// The tree, as it stands.
+// ---------------------------------------------------------------------------
+
+test('every image-acquiring job in the tree authenticates', () => {
+  const results = realScan();
+  const violations = results.flatMap((r) => violationsFor(r.id, r.findings));
+  assert.deepEqual(violations, []);
+  const unresolved = results.flatMap((r) => r.findings.unresolved.map((u) => `${r.id}: ${u}`));
+  assert.deepEqual(unresolved, [], 'a reference the resolver cannot follow is not a clean job');
+});
+
+test('the scan finds acquiring jobs at all', () => {
+  // Without this the suite above is satisfied by a resolver that reads nothing:
+  // zero jobs produce zero violations.
+  const acquiring = realScan().filter((r) => r.findings.acquisitions.length > 0);
+  assert.ok(acquiring.length >= 10, `only ${acquiring.length} acquiring jobs found — the resolver is not reading the tree`);
+});
+
+// ---------------------------------------------------------------------------
+// The discrimination that replaces an allow-list.
+// ---------------------------------------------------------------------------
+
+test('a unit test that names an image-pulling module is not an image acquisition', () => {
+  // ci.yml's discipline lane runs `node --test compose-pull-images.test.mjs`.
+  // A text search for the module name flags it; reading the command does not,
+  // because `--test` hands the file to the node test runner, which imports the
+  // module rather than running its CLI. That is the fact doing the work — no
+  // job name appears anywhere in this gate.
+  const results = realScan();
+  const disciplineJobs = results.filter((r) => r.id.startsWith('ci.yml:'));
+  assert.ok(disciplineJobs.length > 0, 'ci.yml produced no jobs');
+  for (const job of disciplineJobs) {
+    assert.deepEqual(
+      job.findings.acquisitions,
+      [],
+      `${job.id} was read as acquiring an image: ${job.findings.acquisitions.join(', ')}`,
+    );
+  }
+});
+
+test('the shared policy is detected by a CALL, not by a mention of it', () => {
+  // lib/registry.mjs prints the primitive's signature in its header comment and
+  // declares it. Reading either as a call site made chart-ci.yml's
+  // `chart-validate` — which imports only a rate-limit classifier out of that
+  // module and never pulls — look like an anonymous puller.
+  assert.equal(callsSharedPolicy('// pullImageWithRetry(image, options) acquires one image'), false);
+  assert.equal(callsSharedPolicy('export function pullImageWithRetry(image, options = {}) {'), false);
+  assert.equal(callsSharedPolicy('if (!pullImageWithRetry(ref, { backoffStepSeconds })) failed++;'), true);
+
+  const chart = realScan().find((r) => r.id === 'chart-ci.yml:chart-validate');
+  assert.ok(chart, 'chart-ci.yml:chart-validate was not scanned');
+  assert.deepEqual(chart.findings.acquisitions, []);
+});
+
+// ---------------------------------------------------------------------------
+// Resolution — the hops between a workflow step and the registry.
+// ---------------------------------------------------------------------------
+
+test('a ref is resolved through the job env and two Justfile hops', () => {
+  // `startup-bench` names the image once in the job's `env:`, spends it as
+  // `just _pull-retry "$CH_IMAGE"`, and the recipe forwards it to
+  // `pull-images.mjs {{IMAGES}}`. Every hop has to hold for the Docker Hub rule
+  // to have a ref to judge; a break anywhere reads as "ref unknown", which is
+  // silent.
+  const findings = findingsFor(specimenJob, realScan());
+  assert.ok(
+    [...findings.refs].some((r) => r.startsWith('clickhouse/clickhouse-server:')),
+    `no ClickHouse ref resolved; got ${[...findings.refs].join(', ') || '(none)'}`,
+  );
+  assert.equal(findings.viaSharedPolicy, true);
+});
+
+test('a variadic Justfile parameter yields every ref it holds, not none', () => {
+  // `_pull-retry {{CH_TEST_IMAGE}} {{CH_TEST_IMAGE_PRIOR}}` binds both refs to a
+  // single variadic parameter, so the expanded token holds two refs separated by
+  // a space — a shape that matches no image ref at all. Both used to vanish.
+  const findings = findingsFor('schema-integration.yml:schema-ddl', realScan());
+  const ch = [...findings.refs].filter((r) => r.startsWith('clickhouse/clickhouse-server:'));
+  assert.ok(ch.length >= 2, `expected both ClickHouse refs, got ${ch.join(', ') || '(none)'}`);
+});
+
+test('a composite action contributes its own steps', () => {
+  // `uses: ./.github/actions/setup-buildx` acquires the BuildKit bootstrap image
+  // inside the action, where no `run:` in the calling workflow mentions it.
+  const findings = findingsFor('release.yml:goreleaser', realScan());
+  assert.equal(findings.viaSharedPolicy, true, 'the setup-buildx bootstrap pull was not seen');
+});
+
+// ---------------------------------------------------------------------------
+// Negative controls — each rule, proved against the real workflow text.
+// ---------------------------------------------------------------------------
+
+test('R1 fires when an acquiring job has no login at all', () => {
+  const results = scanWith('e2e.yml', (text) =>
+    withoutStep('Log in to the image mirror (GHCR)')(withoutStep('Log in to Docker Hub')(text)),
+  );
+  const violations = violationsFor(specimenJob, findingsFor(specimenJob, results));
+  assert.equal(violations.length, 1);
+  assert.match(violations[0], /no registry login step — the pull is anonymous/);
+});
+
+test('R2 fires when an acquiring job has no Docker Hub login', () => {
+  const results = scanWith('e2e.yml', withoutStep('Log in to Docker Hub'));
+  const violations = violationsFor(specimenJob, findingsFor(specimenJob, results));
+  assert.equal(violations.length, 1);
+  assert.match(violations[0], /clickhouse\/clickhouse-server:[\d.]+/);
+  assert.match(violations[0], /no Docker Hub login/);
+});
+
+test('R3 fires when a job pulling through the mirror has no ghcr.io login', () => {
+  const results = scanWith('e2e.yml', withoutStep('Log in to the image mirror (GHCR)'));
+  const violations = violationsFor(specimenJob, findingsFor(specimenJob, results));
+  assert.equal(violations.length, 1);
+  assert.match(violations[0], /no ghcr\.io login/);
+});
+
+test('removing the acquisition removes the requirement, not the other way round', () => {
+  // The rules key off acquiring, so a job that stops pulling stops being
+  // judged — otherwise every login step in the repo would be load-bearing
+  // forever and the gate would fire on cleanups.
+  assert.deepEqual(violationsFor('some:job', { acquisitions: [], logins: [], refs: new Set(), viaSharedPolicy: false, unresolved: [] }), []);
+});
+
+// ---------------------------------------------------------------------------
+// R4 — a login step is necessary and NOT sufficient.
+//
+// Run 30701755787 (job 91375112426) logged in successfully:
+//
+//   13:50:32.0306552Z Logging into docker.io...
+//   13:50:32.3891751Z Login Succeeded!
+//
+// and was refused as UNAUTHENTICATED one second later:
+//
+//   13:50:33.1136472Z  clickhouse Pulling
+//   13:50:33.3467501Z  clickhouse Error toomanyrequests: You have reached your
+//                                  unauthenticated pull rate limit.
+//
+// `docker compose`'s own pull path does not carry the credentials the CLI wrote.
+// A gate that asked only "does this job have a login step?" would have passed
+// that job — a hollow green on the exact failure it is named after. So R4 asks
+// whether the acquisition actually RUNS on the mirror-first path.
+// ---------------------------------------------------------------------------
+
+// Replaces the harness call with a bare `compose up`, which is the pre-#1572
+// shape of the job that produced the run above: login, then straight to compose.
+const withoutTheComposePrePull = (text) =>
+  text.replace(
+    'run: ./compatibility/prometheus/scripts/run-compatibility.sh',
+    'run: docker compose -f docker-compose.yml up -d --build --wait clickhouse prometheus cerberus',
+  );
+
+test('R4 fires when a compose stack is materialised without a mirror-first pre-pull', () => {
+  const results = scanWith('compatibility.yml', withoutTheComposePrePull);
+  const v = findingsFor('compatibility.yml:prometheus', results);
+  const violations = violationsFor('compatibility.yml:prometheus', v);
+  assert.ok(
+    violations.some((m) => m.includes('without pre-pulling it through the shared mirror-first')),
+    `expected an R4 pre-pull violation, got ${JSON.stringify(violations)}`,
+  );
+  // And specifically NOT because the job is unauthenticated — it is. That is the
+  // whole point: the login rules are all satisfied here.
+  assert.ok(
+    !violations.some((m) => m.includes('no Docker Hub login') || m.includes('no registry login')),
+    'the doctored job still has both logins, so no login rule should fire',
+  );
+});
+
+test('R4 fires when a job acquires images off the shared policy entirely', () => {
+  const results = scanWith('compatibility.yml', withoutTheComposePrePull);
+  const violations = violationsFor(
+    'compatibility.yml:prometheus',
+    findingsFor('compatibility.yml:prometheus', results),
+  );
+  assert.ok(
+    violations.some((m) => m.includes('without going through the shared mirror-first policy')),
+    `expected an R4 off-policy violation, got ${JSON.stringify(violations)}`,
+  );
+});
+
+test('the job that writes the mirror is not required to read through it', () => {
+  // Circular otherwise: `imagetools create` POPULATES the mirror, so it cannot
+  // be served by it. The carve-out is the direction of the copy, not the job's
+  // name — which is what keeps it from becoming an exemption.
+  const f = findingsFor('mirror-images.yml:mirror', realScan());
+  assert.equal(f.viaSharedPolicy, false, 'the mirroring job does not pull through the mirror');
+  assert.ok(f.mirrorWrites > 0, 'its acquisitions are writes into the mirror');
+  assert.deepEqual(violationsFor('mirror-images.yml:mirror', f), []);
+
+  // But the carve-out is exactly as wide as the writes: give it one read that
+  // is not a write and R4 fires, so this cannot quietly excuse a real pull.
+  const withARead = { ...f, acquisitions: [...f.acquisitions, 'docker pull'] };
+  assert.ok(
+    violationsFor('mirror-images.yml:mirror', withARead).some((m) =>
+      m.includes('without going through the shared mirror-first policy'),
+    ),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// A login's registry is matched by HOST, one policy for both registries.
+//
+// CodeQL flagged the mirror half as an incomplete-sanitization hole and it was
+// right: `registry.startsWith('ghcr.io')` also accepts `ghcr.io.evil.example`.
+// The Hub half had the mirrored defect in the other direction — a raw string-set
+// match misses spellings `docker login` itself accepts. Each case below goes red
+// on the pre-fix comparison, which is the only reason they are worth having.
+// ---------------------------------------------------------------------------
+
+// A job that pulls through the shared policy, so R3 is the rule under test and
+// the only variable is how its one login names a registry.
+const jobLoggingInTo = (registry) => ({
+  acquisitions: ['pullImageWithRetry'],
+  logins: [{ registry }],
+  viaSharedPolicy: true,
+  refs: new Set(),
+  unresolved: [],
+  composePolicyFiles: new Set(),
+  composeMaterialised: [],
+  mirrorWrites: 0,
+});
+
+test('a login to a host that merely starts with ghcr.io is not a mirror login', () => {
+  // `startsWith` accepted this; a hostname compare does not. Somebody else owns
+  // that name, so reading it as the mirror would greenlight an anonymous pull.
+  const violations = violationsFor('some:job', jobLoggingInTo('ghcr.io.evil.example'));
+  assert.ok(
+    violations.some((m) => m.includes('no ghcr.io login')),
+    `expected R3 to fire for a lookalike host, got ${JSON.stringify(violations)}`,
+  );
+  assert.deepEqual(violationsFor('some:job', jobLoggingInTo('ghcr.io')), []);
+});
+
+test('a Docker Hub login is recognised in every spelling docker login accepts', () => {
+  // Same normalisation on both halves. A raw string-set match saw only the bare
+  // forms, so a job authenticated as the URL form was reported as anonymous.
+  for (const spelling of ['', 'docker.io', 'index.docker.io', 'https://index.docker.io/v1/']) {
+    // The mirror login is held fixed so the Hub spelling is the only variable.
+    const f = {
+      ...jobLoggingInTo('ghcr.io'),
+      logins: [{ registry: 'ghcr.io' }, { registry: spelling }],
+      refs: new Set(['redis:7']),
+    };
+    assert.deepEqual(
+      violationsFor('some:job', f),
+      [],
+      `${JSON.stringify(spelling)} should read as a Docker Hub login`,
+    );
+  }
+});
+
+test('a registry value that is not a host at all matches nothing', () => {
+  // Deliberate failure direction. An unexpanded `${{ … }}` reaching this far is
+  // unparseable, and a false alarm about a login the job does have is the safe
+  // way to be wrong — the unsafe way is reading it as the empty registry, which
+  // means Docker Hub, and passing a job whose Hub credentials never resolved.
+  const f = { ...jobLoggingInTo('${{ env.REGISTRY }}'), refs: new Set(['redis:7']) };
+  const violations = violationsFor('some:job', f);
+  assert.ok(violations.some((m) => m.includes('no ghcr.io login')));
+  assert.ok(violations.some((m) => m.includes('no Docker Hub login')));
+});
+
+// ---------------------------------------------------------------------------
+// Logging in without `docker/login-action`.
+//
+// "Logs in" must not be read as "uses docker/login-action". PR #1586 replaces
+// both of `mirror-images.yml`'s login steps with `run: node
+// .github/scripts/registry-login.mjs`, because the action has no retry input and
+// that step is where the mirror workflow died on its first real run. A detector
+// that recognises only the action would report the mirroring job — the one job
+// in the repo whose entire purpose is reading Docker Hub — as an anonymous
+// puller the moment that PR lands, and the fix for a gate that fires wrongly is
+// always an exemption, which is the outcome this module exists to prevent.
+//
+// The two tests below pin the shape rather than the filename, on the argv the
+// script actually builds. `registry-login.mjs` does not exist on this branch, so
+// they are written against its source text; they hold for any module that logs
+// in the same way.
+// ---------------------------------------------------------------------------
+
+// The argv-building shape from #1586's registry-login.mjs, verbatim: the host is
+// appended conditionally, which is precisely why it cannot be an inline literal
+// array and why reading only inline arrays would miss the login entirely.
+const conditionalLoginSource = `
+import { capture } from './lib/gh.mjs';
+function main() {
+  const registry = (process.env.REGISTRY ?? '').trim();
+  const username = requiredEnv('USERNAME');
+  const args = ['login', '--username', username, '--password-stdin'];
+  if (registry !== '') args.push(registry);
+  const res = capture('docker', args, { input: password });
+}
+`;
+
+test('an argv built up in a variable is still a spawned command', () => {
+  assert.deepEqual(spawnedCommands(conditionalLoginSource), [
+    ['docker', 'login', '--username', '--password-stdin', '${REGISTRY}'],
+  ]);
+});
+
+test('a login step names the registry it logs in to, or Docker Hub when it names none', () => {
+  const [[, ...argv]] = spawnedCommands(conditionalLoginSource);
+  const after = argv.slice(argv.indexOf('login') + 1);
+
+  // With REGISTRY set, this is the mirror login and satisfies R3.
+  assert.equal(loginRegistry(after, { REGISTRY: 'ghcr.io' }), 'ghcr.io');
+
+  // Unset is not unknown: `docker login` with no host argument goes to Docker
+  // Hub, which is the contract the script documents. Reading it as "some other
+  // registry" would leave the Docker Hub half of R2 unsatisfied for a job that
+  // is genuinely logged in to Docker Hub.
+  assert.equal(loginRegistry(after, {}), '');
+
+  // The flag arity is the substance: `--username` takes a value, so "the first
+  // token that is not a flag" is the USERNAME, and a gate that read it that way
+  // would record a login to a registry called `tsouza` and fail R2 on a job
+  // that is correctly authenticated.
+  assert.equal(loginRegistry(['--username', 'tsouza', '--password-stdin'], {}), '');
+  assert.equal(loginRegistry(['-u', 'tsouza', '-p', 'secret', 'ghcr.io'], {}), 'ghcr.io');
+
+  // A GitHub expression is genuinely unknowable, and guessing there would
+  // invent a login that may not exist.
+  assert.notEqual(loginRegistry(['${{ inputs.registry }}'], {}), '');
+});
+
+test('the job that mirrors the inventory acquires the images it mirrors', () => {
+  // `docker buildx imagetools create` puts nothing in the local daemon, so it
+  // does not look like an acquisition — but the manifest READ spends the source
+  // registry's quota exactly as a pull does, and this is the only way the
+  // mirroring job touches an image at all. Excusing it would exempt, by
+  // accident, the one job that exists to read Docker Hub.
+  const f = findingsFor('mirror-images.yml:mirror', realScan());
+  assert.ok(
+    f.acquisitions.some((a) => a.includes('imagetools')),
+    `expected an imagetools acquisition, got ${JSON.stringify(f.acquisitions)}`,
+  );
+  // And it knows WHICH images: the inventory lives in lib/mirror.mjs and reaches
+  // the command through a loop variable, so without the imported-binding hop R2
+  // would have no ref to check and would pass on any login at all.
+  assert.ok(
+    [...f.refs].some((r) => isDockerHubRef(r)),
+    `expected the mirrored inventory's Docker Hub refs, got ${JSON.stringify([...f.refs])}`,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// The primitives.
+// ---------------------------------------------------------------------------
+
+test('a ref with no registry host is Docker Hub', () => {
+  assert.equal(isDockerHubRef('golang:1.26'), true);
+  assert.equal(isDockerHubRef('clickhouse/clickhouse-server:26.5'), true);
+  assert.equal(isDockerHubRef('ghcr.io/tsouza/cerberus:1.13.2'), false);
+  assert.equal(isDockerHubRef('localhost:5000/x'), false);
+  assert.equal(isDockerHubRef('registry.k8s.io/pause:3.9'), false);
+});
+
+test('a compose file argument is not mistaken for an image ref', () => {
+  // `compose-pull-images.mjs docker-compose.yml` and
+  // `pull-images.mjs golang:1.26` are the same argv shape; only the token tells
+  // them apart, and a `.yml` read as an image would be judged as Docker Hub.
+  assert.equal(looksLikeImageRef('docker-compose.yml'), false);
+  assert.equal(looksLikeImageRef('golang:1.26'), true);
+  assert.equal(looksLikeImageRef('clickhouse/clickhouse-server:26.5-alpine'), true);
+  assert.equal(looksLikeImageRef('--quiet'), false);
+  assert.equal(looksLikeImageRef('$CH_IMAGE'), false);
+});
+
+test('an unresolvable variable yields null rather than a wrong ref', () => {
+  assert.equal(expandVars('$CH_IMAGE', { CH_IMAGE: 'golang:1.26' }), 'golang:1.26');
+  assert.equal(expandVars('{{K3S_IMAGE}}', { K3S_IMAGE: 'rancher/k3s:v1' }), 'rancher/k3s:v1');
+  assert.equal(expandVars('$MISSING', {}), null);
+  // A GitHub expression is never statically known; guessing at one is how a
+  // gate invents a violation.
+  assert.equal(expandVars('${{ inputs.cerberus_image }}', {}), null);
+});
+
+test('a command line splits on every separator that starts a new command', () => {
+  assert.deepEqual(splitCommands('docker pull a && docker run b'), ['docker pull a', 'docker run b']);
+  assert.deepEqual(splitCommands('# just a comment\ndocker pull a'), ['docker pull a']);
+  assert.deepEqual(splitCommands('docker \\\n  pull a'), ['docker    pull a']);
+  assert.deepEqual(tokenise('just _pull-retry "$CH_IMAGE"'), ['just', '_pull-retry', '$CH_IMAGE']);
+});
+
+test('a workflow parses into its jobs and their steps', () => {
+  const { jobs } = parseWorkflow(readFileSync(join(workflows, 'e2e.yml'), 'utf8'));
+  const bench = jobs.find((j) => j.name === 'startup-bench');
+  assert.ok(bench, 'startup-bench did not parse out of e2e.yml');
+  assert.equal(bench.env.CH_IMAGE?.startsWith('clickhouse/clickhouse-server:'), true);
+  assert.ok(bench.steps.length > 5, `only ${bench.steps.length} steps parsed`);
+});
+
+test('a comment between two steps does not leak into the previous step body', () => {
+  // A YAML comment sits at the OUTER indentation, so a block-scalar reader that
+  // emits blank lines on sight splices the next step's prose into the previous
+  // step's script — and prose naming `just e2e-up` in backticks then resolves as
+  // a recipe call with a stray backtick attached.
+  const results = realScan();
+  const unresolved = results.flatMap((r) => r.findings.unresolved);
+  assert.deepEqual(unresolved.filter((u) => u.includes('`')), unresolved.filter(() => false));
+});

--- a/.github/scripts/lib/mirror.mjs
+++ b/.github/scripts/lib/mirror.mjs
@@ -25,7 +25,7 @@
 // visibility, and would put a copy of other projects' images under this org's
 // name for anyone to pull — an outward-facing act this repository has no reason
 // to take for a CI convenience. The cost is that every consuming job needs a
-// `docker/login-action` against `ghcr.io` with the job's own `GITHUB_TOKEN`
+// `registry-login.mjs` step against `ghcr.io` with the job's own `GITHUB_TOKEN`
 // (`packages: read`); that is mechanical, reviewable, and local to each job.
 // Without it `acquireFromMirror` gets a denial, says so once at notice level,
 // and the caller falls back to Docker Hub — so a job that forgets the login is

--- a/.github/scripts/mirror-images.mjs
+++ b/.github/scripts/mirror-images.mjs
@@ -51,6 +51,23 @@ function copy(upstream, mirror) {
   return { ok: false, detail: (res.stderr + res.stdout).trim().split('\n').slice(-1)[0] ?? 'failed' };
 }
 
+// verify — read the mirrored ref back out of GHCR after writing it.
+//
+// A copy that reported success is not the same claim as a ref a consumer can
+// resolve, and the difference is invisible where it matters: `pullImageWithRetry`
+// treats an unresolvable mirror as a miss and falls back to Docker Hub, so a
+// mirror that is empty and a mirror that is working look identical from every
+// consuming job. Reading it back is the only step that can tell them apart, and
+// this job is the one place where the answer is actionable.
+function verify(mirror) {
+  const res = capture('docker', ['buildx', 'imagetools', 'inspect', mirror]);
+  if (res.status === 0) return { ok: true, detail: 'copied + resolves' };
+  return {
+    ok: false,
+    detail: `copied but does not resolve: ${(res.stderr + res.stdout).trim().split('\n').slice(-1)[0] ?? 'failed'}`,
+  };
+}
+
 function writeSummary(rows) {
   const path = process.env.GITHUB_STEP_SUMMARY;
   if (path === undefined || path.trim() === '') return;
@@ -88,7 +105,8 @@ function main(argv) {
   const rows = [];
   for (const { upstream, mirror } of pairs) {
     log(`==> ${upstream} -> ${mirror}`);
-    const outcome = copy(upstream, mirror);
+    const copied = copy(upstream, mirror);
+    const outcome = copied.ok ? verify(mirror) : copied;
     rows.push({ upstream, ...outcome });
     if (!outcome.ok) error(`could not mirror ${upstream}: ${outcome.detail}`);
   }

--- a/.github/scripts/registry-login.mjs
+++ b/.github/scripts/registry-login.mjs
@@ -1,0 +1,164 @@
+// registry-login — `docker login` with the same retry discipline every other
+// registry interaction in this repo already has.
+//
+// WHY THIS EXISTS. `mirror-images.yml` failed on its first real run (the
+// push-to-main for #1579, run 30724446834) at the *Log in to Docker Hub* step:
+//
+//   Error response from daemon: Get "https://registry-1.docker.io/v2/":
+//   context deadline exceeded
+//
+// The job died before pulling anything, so #1579 merged green while GHCR was
+// never populated and the mirror shipped INERT — every lane silently fell back
+// to Docker Hub, the exact condition the mirror exists to remove. That is worth
+// a script rather than a re-run for two reasons: this workflow is the fallback
+// path for everything else, so the most load-bearing registry interaction in
+// the repo was the least protected one; and its failure is silent at the point
+// of use, because a consumer reads a mirror miss as a fallback and pulls
+// upstream, making "the mirror is empty" and "the mirror is working"
+// indistinguishable from any consuming job.
+//
+// `docker/login-action` has no retry input, which is why the step is a script
+// instead. The classification is NOT re-implemented here: it imports
+// isTransientRegistryFailure / isRegistryRateLimit from lib/registry.mjs, so a
+// login inherits the same verdicts a pull gets and there is one place to fix
+// the class. That import is what keeps #1563 honest — a handshake that timed
+// out is genuinely transient and retries, while a quota refusal is a spent
+// rolling window that one more attempt can only spend further, so it fails on
+// the first attempt by design.
+//
+// A credential rejection is the third class and also fails immediately: a
+// password that is wrong on attempt 1 is wrong on attempt 5, and retrying it
+// only turns a clear error into a slow one.
+//
+// ENV CONTRACT
+//   REGISTRY  — registry host to log in to. Blank/unset means Docker Hub, which
+//               is what `docker login` itself does with no host argument.
+//   USERNAME  — required.
+//   PASSWORD  — required; passed on stdin, never as argv, so it cannot leak
+//               into a process listing.
+//   REGISTRY_LOGIN_BACKOFF_STEP_SECONDS — optional; attempt N waits N × step.
+
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+
+import { capture, error, log, notice } from './lib/gh.mjs';
+import {
+  isRegistryRateLimit,
+  isTransientRegistryFailure,
+  rateLimitDiagnosis,
+  readBackoffStepSeconds,
+  registryAttempts,
+  sleepSeconds,
+} from './lib/registry.mjs';
+
+// A login is one round trip to /v2/, so it needs less patience than an image
+// acquisition (whose tail includes layer transfer). Kept short because the
+// failure this rides out is a handshake blip, not a slow download.
+const defaultLoginBackoffStepSeconds = 2;
+
+// The signatures of a registry rejecting the credential itself, as distinct
+// from failing to reach the registry at all. Retrying these is pointless.
+const credentialRejectionPatterns = [
+  /\b401 Unauthorized\b/i,
+  /\bunauthorized\b/i,
+  /incorrect username or password/i,
+  /authentication required/i,
+  // GHCR answers a bad token with `denied: denied`; Docker Hub with `denied:
+  // requested access to the resource is denied`. Matching the bare word covers
+  // both, and nothing on the transport-fault list uses it.
+  /\bdenied\b/i,
+];
+
+function isCredentialRejection(text) {
+  const haystack = String(text ?? '');
+  return credentialRejectionPatterns.some((re) => re.test(haystack));
+}
+
+// classifyLoginFailure — the whole verdict in one pure function, so the
+// precedence between the classes is testable without spawning docker.
+//
+// The ORDER is the substance. A quota refusal is asked first and wins outright
+// because Docker Hub's 429 body can also name a transport fault, and the one
+// thing a caller must not do while a quota is exhausted is spend more of it —
+// the same reason lib/registry.mjs asks it first. Credentials come next: a
+// registry that answered "401" did reach us, so the transport is fine and the
+// secret is not. Only what is left is retried.
+export function classifyLoginFailure(text) {
+  if (isRegistryRateLimit(text)) return 'rate-limit';
+  if (isCredentialRejection(text)) return 'credential';
+  if (isTransientRegistryFailure(text)) return 'transient';
+  return 'fatal';
+}
+
+function requiredEnv(name) {
+  const value = process.env[name];
+  if (value === undefined || value === '') {
+    error(`${name} is required`);
+    process.exit(1);
+  }
+  return value;
+}
+
+function main() {
+  const registry = (process.env.REGISTRY ?? '').trim();
+  const username = requiredEnv('USERNAME');
+  const password = requiredEnv('PASSWORD');
+  // Docker Hub is the no-host form of the command, matching `docker login`'s
+  // own default rather than inventing a hostname for it.
+  const subject = registry === '' ? 'Docker Hub' : registry;
+  const args = ['login', '--username', username, '--password-stdin'];
+  if (registry !== '') args.push(registry);
+
+  const backoffStep = readBackoffStepSeconds(
+    'REGISTRY_LOGIN_BACKOFF_STEP_SECONDS',
+    defaultLoginBackoffStepSeconds,
+  );
+
+  for (let attempt = 1; attempt <= registryAttempts; attempt += 1) {
+    const res = capture('docker', args, { input: password });
+    if (res.status === 0) {
+      if (attempt > 1) notice(`Logged in to ${subject} on attempt ${attempt} of ${registryAttempts}.`);
+      return;
+    }
+
+    const output = `${res.stdout}\n${res.stderr}`;
+    log(output.trim());
+
+    const verdict = classifyLoginFailure(output);
+    if (verdict === 'rate-limit') {
+      error(rateLimitDiagnosis(`Logging in to ${subject}`));
+      process.exit(1);
+    }
+    if (verdict === 'credential') {
+      error(
+        `${subject} rejected the credential. This is not retried: a password that is wrong on the first ` +
+          'attempt is wrong on the last. Check that the secret is set on this repository and has not expired.',
+      );
+      process.exit(1);
+    }
+    if (verdict === 'fatal') {
+      error(
+        `Logging in to ${subject} failed with an error that is not a transport fault, a quota refusal or a ` +
+          'credential rejection, so it is not retried. See the command output above.',
+      );
+      process.exit(1);
+    }
+    if (attempt === registryAttempts) {
+      error(
+        `Logging in to ${subject} failed ${registryAttempts} times with a transport fault. The registry is ` +
+          'not reachable from this runner; this is not a quota. See the command output above.',
+      );
+      process.exit(1);
+    }
+    const waitSeconds = attempt * backoffStep;
+    log(
+      `Login to ${subject} hit a transport fault (attempt ${attempt} of ${registryAttempts}); ` +
+        `retrying in ${waitSeconds}s.`,
+    );
+    sleepSeconds(waitSeconds);
+  }
+}
+
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/.github/scripts/registry-login.test.mjs
+++ b/.github/scripts/registry-login.test.mjs
@@ -1,0 +1,71 @@
+// Tests for the `docker login` retry classifier.
+//
+// What is actually at stake here is the ORDER of the questions, not the
+// patterns. Three of the four classes can match the same output — Docker Hub
+// reports a quota refusal through BuildKit as `unexpected status from HEAD
+// request … 429`, which also reads as a transport fault, and its anonymous-limit
+// body says "unauthenticated", one letter-shuffle away from the credential
+// list. Get the order wrong and each mistake is silent in a different way: a
+// quota refusal retried four more times spends the quota it was refused for, a
+// credential rejection retried turns a clear error into a slow one, and a
+// handshake blip classed as fatal is the exact failure (run 30724446834) that
+// shipped the image mirror inert.
+//
+// So every case below is written as a precedence question, on the real output
+// strings the toolchain emits.
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { classifyLoginFailure } from './registry-login.mjs';
+
+// The output that killed the mirror workflow's first real run: the /v2/
+// handshake timed out before anything was pulled.
+const handshakeTimeout =
+  'Error response from daemon: Get "https://registry-1.docker.io/v2/": context deadline exceeded';
+
+test('a handshake that timed out is transient, so it is retried', () => {
+  assert.equal(classifyLoginFailure(handshakeTimeout), 'transient');
+});
+
+test('a quota refusal is never transient, even when it also names a transport fault', () => {
+  // BuildKit's shape: the 429 arrives INSIDE a phrase that is on the transient
+  // list. Asking the transient question first would retry it, and every extra
+  // attempt spends more of the window that is already exhausted.
+  const buildkit429 =
+    'unexpected status from HEAD request to https://registry-1.docker.io/v2/: 429 Too Many Requests';
+  assert.equal(classifyLoginFailure(buildkit429), 'rate-limit');
+
+  // Docker Hub's own prose body. "unauthenticated" must not be read as a
+  // credential rejection: the credential is fine, the counter is not.
+  const hubBody =
+    'toomanyrequests: You have reached your unauthenticated pull rate limit. ' +
+    'https://www.docker.com/increase-rate-limit';
+  assert.equal(classifyLoginFailure(hubBody), 'rate-limit');
+});
+
+test('a rejected credential is not retried, even alongside a transport fault', () => {
+  assert.equal(
+    classifyLoginFailure('Error response from daemon: Get "https://registry-1.docker.io/v2/": unauthorized: incorrect username or password'),
+    'credential',
+  );
+  assert.equal(classifyLoginFailure('denied: requested access to the resource is denied'), 'credential');
+  assert.equal(classifyLoginFailure('unauthorized: authentication required'), 'credential');
+
+  // A registry that answered 401 did reach us, so the transport is not the
+  // problem no matter what else the output mentions. Reordering these two
+  // branches would spend five attempts on a secret that is simply wrong.
+  assert.equal(
+    classifyLoginFailure(`401 Unauthorized\n${handshakeTimeout}`),
+    'credential',
+    'a credential rejection must win over a transport fault named in the same output',
+  );
+});
+
+test('an error off every list is fatal rather than retried', () => {
+  // Retrying an unrecognised failure is how a real, reproducible error gets
+  // reported five times and diagnosed as flake.
+  assert.equal(classifyLoginFailure('docker: command not found'), 'fatal');
+  assert.equal(classifyLoginFailure(''), 'fatal');
+  assert.equal(classifyLoginFailure(undefined), 'fatal');
+});

--- a/.github/scripts/repo-hygiene.mjs
+++ b/.github/scripts/repo-hygiene.mjs
@@ -26,7 +26,19 @@
 //                         `perf-profile`, and a root file that is deleted
 //                         cannot leave a rotting entry behind.
 //
-// Both scans read the tracked set from `git ls-files -s`, so .gitignored
+//   CHECK=registry-login  No workflow step may `uses: docker/login-action`.
+//                         That Action has no retry input, so a login that
+//                         loses one handshake fails the job before it pulls
+//                         anything — and because a mirror miss falls back to
+//                         Docker Hub, a failed GHCR login is invisible to
+//                         every consuming step. Registry logins go through
+//                         `.github/scripts/registry-login.mjs`, which retries
+//                         transport faults and refuses to retry a spent quota
+//                         or a rejected credential. The scan matches the
+//                         `uses:` form only, so prose that NAMES the Action
+//                         (this comment included) stays legal.
+//
+// All three scans read the tracked set from `git ls-files`, so .gitignored
 // paths are out of scope by construction: the companion fix for an artefact
 // this gate catches is usually a `git rm` PLUS a .gitignore rule, and the
 // ignore rule alone is what keeps it from coming back.
@@ -36,14 +48,14 @@
 // and, failing that, exit non-zero rather than assume it is text.
 //
 // Env contract:
-//   CHECK      one of: binary | root-allowlist   (required)
+//   CHECK      one of: binary | root-allowlist | registry-login   (required)
 //   REPO_ROOT  optional; directory to scan (default: the process cwd, which
 //              on a runner is the checkout root). The self-test points this
 //              at a synthetic fixture repo to prove the gate FIRES.
 //
 // Exit codes: 0 = clean, 1 = a violation was found (or bad $CHECK).
 
-import { closeSync, openSync, readSync } from 'node:fs';
+import { closeSync, openSync, readFileSync, readSync } from 'node:fs';
 import process from 'node:process';
 
 import { capture, error, git, log, notice } from './lib/gh.mjs';
@@ -169,6 +181,23 @@ export function diffAllowlist(entries, allowlist) {
   return { unexpected, stale };
 }
 
+// loginActionUses — the `uses: docker/login-action` step declarations in one
+// workflow's text, as [{ line, text }]. Anchored on `uses:` so that a comment
+// or a doc paragraph naming the Action is not a violation: the gate is about
+// what the workflow RUNS, not about what it is allowed to talk about. A gate
+// that policed the word instead of the step would make its own rationale
+// unwritable. Exported for the self-test.
+export function loginActionUses(source) {
+  const hits = [];
+  const lines = source.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    if (/^\s*-?\s*uses:\s*['"]?docker\/login-action\b/.test(lines[i])) {
+      hits.push({ line: i + 1, text: lines[i].trim() });
+    }
+  }
+  return hits;
+}
+
 // trackedBlobs — `git ls-files -s` -> [{ mode, sha, path }] for the entries
 // that carry sniffable content. Submodule gitlinks and symlinks are dropped
 // here (they have no blob in this repository / store a path, not content).
@@ -275,6 +304,36 @@ function scanRootAllowlist() {
   notice(`repo-hygiene: repository root matches the allow-list (${ROOT_ALLOWLIST.length} entries)`);
 }
 
+function scanRegistryLogin() {
+  const res = git(['ls-files', '-z', '.github/workflows']);
+  if (res.status !== 0) {
+    error(`git ls-files failed: ${res.stderr.trim()}`);
+    process.exit(res.status);
+  }
+  const workflows = res.stdout
+    .split('\0')
+    .filter((p) => p.endsWith('.yml') || p.endsWith('.yaml'))
+    .sort();
+  const violations = [];
+  for (const path of workflows) {
+    for (const hit of loginActionUses(readFileSync(path, 'utf8'))) {
+      violations.push({ path, ...hit });
+    }
+  }
+  if (violations.length > 0) {
+    for (const v of violations) log(`${v.path}:${v.line}: ${v.text}`);
+    error(
+      `${violations.length} workflow step(s) use docker/login-action, which has no retry input. A login that loses ` +
+        `one handshake fails the job before it pulls anything, and a failed GHCR login is silent at the point of ` +
+        `use because a mirror miss falls back to Docker Hub. Replace the step with ` +
+        `\`run: node .github/scripts/registry-login.mjs\`, passing REGISTRY (blank for Docker Hub), USERNAME and ` +
+        `PASSWORD as env.`,
+    );
+    process.exit(1);
+  }
+  notice(`repo-hygiene: no workflow uses docker/login-action (${workflows.length} workflows scanned)`);
+}
+
 function isMain() {
   const invoked = process.argv[1] || '';
   return invoked.endsWith('repo-hygiene.mjs');
@@ -291,8 +350,13 @@ if (isMain()) {
     case 'root-allowlist':
       scanRootAllowlist();
       break;
+    case 'registry-login':
+      scanRegistryLogin();
+      break;
     default:
-      error(`repo-hygiene.mjs: unknown CHECK="${CHECK}" (expected one of: binary, root-allowlist)`);
+      error(
+        `repo-hygiene.mjs: unknown CHECK="${CHECK}" (expected one of: binary, root-allowlist, registry-login)`,
+      );
       process.exit(1);
   }
   process.exit(0);

--- a/.github/scripts/repo-hygiene.test.mjs
+++ b/.github/scripts/repo-hygiene.test.mjs
@@ -16,6 +16,11 @@
 //      fixture carrying a synthetic ELF blob.
 //   5. the CLI exits non-zero, with an ::error:: naming the offender, on a
 //      fixture carrying a stray root file.
+//   6. loginActionUses matches the `uses:` step form and NOT prose naming the
+//      Action, so the gate's own rationale stays writable.
+//   7. the CLI exits non-zero, naming file:line, on a fixture workflow that
+//      uses docker/login-action.
+//   8. the CLI exits 0 on a fixture workflow that runs registry-login.mjs.
 //
 // The live tree is deliberately NOT asserted here: the workflow runs the real
 // CLI against it in the two steps that follow this one, so duplicating that
@@ -29,7 +34,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -39,6 +44,7 @@ import {
   classifyBlob,
   diffAllowlist,
   gitBinarySniffBytes,
+  loginActionUses,
   rootEntriesOf,
 } from './repo-hygiene.mjs';
 
@@ -158,4 +164,70 @@ test('the CLI rejects an unknown CHECK rather than passing silently', () => {
   const { status, out } = runGate('', dir);
   assert.notEqual(status, 0);
   assert.match(out, /unknown CHECK/);
+});
+
+// newWorkflowFixtureRepo — a throwaway repo carrying one tracked workflow.
+// Deliberately NOT newFixtureRepo(): that helper materialises every
+// ROOT_ALLOWLIST entry as a plain FILE, so `.github` there is a file and
+// could never hold `.github/workflows/*.yml`. The registry-login scan reads
+// the tracked workflow set and ignores the rest of the root, so a minimal
+// repo is both sufficient and honest about what the scan actually looks at.
+function newWorkflowFixtureRepo(workflowYaml) {
+  const dir = mkdtempSync(join(tmpdir(), 'repo-hygiene-wf-'));
+  const run = (args) => {
+    const res = spawnSync('git', args, { cwd: dir, encoding: 'utf8' });
+    assert.equal(res.status, 0, `git ${args.join(' ')} failed: ${res.stderr}`);
+  };
+  run(['init', '--quiet']);
+  mkdirSync(join(dir, '.github', 'workflows'), { recursive: true });
+  writeFileSync(join(dir, '.github', 'workflows', 'probe.yml'), workflowYaml);
+  run(['add', '-A']);
+  return dir;
+}
+
+test('loginActionUses matches the step form and not prose naming the Action', () => {
+  const source = [
+    '# docker/login-action@v4 is banned here; this comment must stay legal.',
+    '#   uses: docker/login-action@v4   <- indented inside a comment',
+    'jobs:',
+    '  a:',
+    '    steps:',
+    '      - uses: docker/login-action@v4',
+    "      - uses: 'docker/login-action@v4'",
+    '      - run: node .github/scripts/registry-login.mjs',
+  ].join('\n');
+  const hits = loginActionUses(source);
+  assert.deepEqual(
+    hits.map((h) => h.line),
+    [6, 7],
+    `only the two real step declarations are violations; got ${JSON.stringify(hits)}`,
+  );
+});
+
+test('the CLI FAILS on a workflow that uses docker/login-action, naming file:line', () => {
+  const dir = newWorkflowFixtureRepo(
+    ['jobs:', '  a:', '    steps:', '      - uses: docker/login-action@v4', ''].join('\n'),
+  );
+  const { status, out } = runGate('registry-login', dir);
+  assert.notEqual(status, 0, `the registry-login scan must fail; got:\n${out}`);
+  assert.match(out, /::error::/);
+  assert.match(out, /\.github\/workflows\/probe\.yml:4/);
+  assert.match(out, /registry-login\.mjs/);
+});
+
+test('the CLI PASSES on a workflow that runs the retrying login script', () => {
+  const dir = newWorkflowFixtureRepo(
+    [
+      'jobs:',
+      '  a:',
+      '    steps:',
+      '      - name: Log in to the image mirror (GHCR)',
+      '        env:',
+      '          REGISTRY: ghcr.io',
+      '        run: node .github/scripts/registry-login.mjs',
+      '',
+    ].join('\n'),
+  );
+  const { status, out } = runGate('registry-login', dir);
+  assert.equal(status, 0, `the registry-login scan must pass; got:\n${out}`);
 });

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -728,10 +728,11 @@ jobs:
       # motivating artefact had none), and the repository root must match an
       # exhaustive allow-list rather than a "dotfiles are fine" pattern.
       #
-      # The self-test runs FIRST and proves both scans actually fire: it
-      # builds a throwaway git repo, plants a synthetic ELF blob and a stray
-      # root file, and asserts a non-zero exit naming each — a gate never
-      # shown to fail is indistinguishable from one that does nothing.
+      # The self-test runs FIRST and proves every scan actually fires: it
+      # builds throwaway git repos, plants a synthetic ELF blob, a stray root
+      # file and a workflow step using docker/login-action, and asserts a
+      # non-zero exit naming each — a gate never shown to fail is
+      # indistinguishable from one that does nothing.
       - name: Self-test the committed-artefact gate
         run: node --test .github/scripts/repo-hygiene.test.mjs
       - name: Reject tracked binary artefacts
@@ -742,6 +743,15 @@ jobs:
         run: node .github/scripts/repo-hygiene.mjs
         env:
           CHECK: root-allowlist
+      # docker/login-action has no retry input, so a login that loses one
+      # handshake fails the job before it pulls anything — and a failed GHCR
+      # login is SILENT at the point of use, because a mirror miss falls back
+      # to Docker Hub. Without this scan the Action creeps back one step at a
+      # time, which is how it reached 32 sites.
+      - name: Reject registry logins that cannot retry
+        run: node .github/scripts/repo-hygiene.mjs
+        env:
+          CHECK: registry-login
 
       # Same rationale, one lane over: the compat-scores badge publisher only
       # runs on push-to-main, so a break in it surfaces either as stale README

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -705,6 +705,23 @@ jobs:
       - name: Assert the mutation phase selector scopes correctly
         run: node --test .github/scripts/mutation-matrix.test.mjs
 
+      # Whether a job that pulls an image logged in first. An anonymous pull is
+      # not an error: it succeeds until the shared per-runner-IP quota happens to
+      # be spent, and then reads as flake — which is how #1572 fixed the class by
+      # construction and three jobs were still on the anonymous path afterwards.
+      # The detector resolves each step to the registry it reaches (through
+      # `just`, through the scripts, through the composite actions) rather than
+      # grepping for `docker pull`, because the one shape that looks like a
+      # violation and is not — this lane's own `node --test` of an image-pulling
+      # module — has to be excluded by a fact about the command and never by a
+      # list of job names. The tests run first: they prove the gate still FAILS
+      # on the real workflow text with a login step deleted, without which
+      # "clean" and "not reading the workflows" report the same green.
+      - name: Assert every image-acquiring job authenticates first
+        run: |
+          node --test .github/scripts/assert-image-jobs-authenticate.test.mjs
+          node .github/scripts/assert-image-jobs-authenticate.mjs
+
       # The two auto-labelers, same discipline: neither is a required check,
       # so a broken mapping never turns anything red — it just quietly stops
       # labeling, which is exactly how 62 issues ended up bare. The issue

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -685,6 +685,16 @@ jobs:
       - name: Assert the image mirror maps its inventory correctly
         run: node --test .github/scripts/mirror-images.test.mjs
 
+      # The login that populates that mirror, and specifically the ORDER its
+      # failure classes are asked in. Three of the four can match one output —
+      # a quota refusal reaches BuildKit as `unexpected status from HEAD
+      # request … 429`, which also reads as a transport fault — and each wrong
+      # order is silent in its own way: a retried quota refusal spends the
+      # window it was refused for, and a handshake blip classed as fatal is the
+      # run (30724446834) that shipped the mirror inert.
+      - name: Assert the registry login retries only what retrying can fix
+        run: node --test .github/scripts/registry-login.test.mjs
+
       # Same discipline for the mutation lane's phase planner, one step further:
       # its selector decides which legs an ordinary PR runs, so a bug there is
       # not a slow release but a SILENT one — legs quietly deselected while the

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -15,9 +15,12 @@ name: compatibility
 #   * actions/setup-go@v7           — `go run ./cmd/seed` + driver builds.
 #   * ./.github/actions/setup-buildx — buildkit-backed compose build, with
 #     the BuildKit bootstrap image acquired through a retry.
-#   * docker/login-action@v4        — authed Docker Hub pulls (rate limits).
 #   * taiki-e/install-action@v2     — installs `just`.
 #   * actions/upload-artifact@v7    — per-head report upload.
+#
+# Registry logins are deliberately NOT an Action: `docker/login-action` has no
+# retry input, and a login that fails on a handshake blip fails the whole job
+# before it pulls anything. They run `.github/scripts/registry-login.mjs`.
 #
 # Each job ALSO:
 #   - appends the head's compat percent / passed-over-total to
@@ -268,10 +271,9 @@ jobs:
         if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
         env:
           DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
-        uses: docker/login-action@v4
-        with:
-          username: tsouza
-          password: ${{ secrets.DOCKER_HUB_PAT }}
+          USERNAME: tsouza
+          PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
+        run: node .github/scripts/registry-login.mjs
 
       # Cerberus's own copy of every upstream image this job pulls lives in a
       # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before
@@ -279,11 +281,11 @@ jobs:
       # credentials; without it the pull falls back to the shared anonymous
       # Docker Hub quota. See .github/scripts/lib/mirror.mjs.
       - name: Log in to the image mirror (GHCR)
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          REGISTRY: ghcr.io
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/registry-login.mjs
 
       - name: Run compatibility harness
         id: compat
@@ -470,10 +472,9 @@ jobs:
         if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
         env:
           DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
-        uses: docker/login-action@v4
-        with:
-          username: tsouza
-          password: ${{ secrets.DOCKER_HUB_PAT }}
+          USERNAME: tsouza
+          PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
+        run: node .github/scripts/registry-login.mjs
 
       # Cerberus's own copy of every upstream image this job pulls lives in a
       # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before
@@ -481,11 +482,11 @@ jobs:
       # credentials; without it the pull falls back to the shared anonymous
       # Docker Hub quota. See .github/scripts/lib/mirror.mjs.
       - name: Log in to the image mirror (GHCR)
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          REGISTRY: ghcr.io
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/registry-login.mjs
 
       - name: Run forced-route compatibility harness
         id: compat
@@ -606,10 +607,9 @@ jobs:
         if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
         env:
           DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
-        uses: docker/login-action@v4
-        with:
-          username: tsouza
-          password: ${{ secrets.DOCKER_HUB_PAT }}
+          USERNAME: tsouza
+          PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
+        run: node .github/scripts/registry-login.mjs
 
       # Cerberus's own copy of every upstream image this job pulls lives in a
       # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before
@@ -617,11 +617,11 @@ jobs:
       # credentials; without it the pull falls back to the shared anonymous
       # Docker Hub quota. See .github/scripts/lib/mirror.mjs.
       - name: Log in to the image mirror (GHCR)
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          REGISTRY: ghcr.io
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/registry-login.mjs
 
       - name: Run PromQL surface-completeness gate
         id: gate
@@ -664,10 +664,9 @@ jobs:
         if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
         env:
           DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
-        uses: docker/login-action@v4
-        with:
-          username: tsouza
-          password: ${{ secrets.DOCKER_HUB_PAT }}
+          USERNAME: tsouza
+          PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
+        run: node .github/scripts/registry-login.mjs
 
       # Cerberus's own copy of every upstream image this job pulls lives in a
       # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before
@@ -675,11 +674,11 @@ jobs:
       # credentials; without it the pull falls back to the shared anonymous
       # Docker Hub quota. See .github/scripts/lib/mirror.mjs.
       - name: Log in to the image mirror (GHCR)
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          REGISTRY: ghcr.io
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/registry-login.mjs
 
       # Buildx gives the Compose build cache, multi-arch support, and a
       # consistent build backend. The harness uses local build contexts
@@ -812,10 +811,9 @@ jobs:
         if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
         env:
           DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
-        uses: docker/login-action@v4
-        with:
-          username: tsouza
-          password: ${{ secrets.DOCKER_HUB_PAT }}
+          USERNAME: tsouza
+          PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
+        run: node .github/scripts/registry-login.mjs
 
       # Cerberus's own copy of every upstream image this job pulls lives in a
       # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before
@@ -823,11 +821,11 @@ jobs:
       # credentials; without it the pull falls back to the shared anonymous
       # Docker Hub quota. See .github/scripts/lib/mirror.mjs.
       - name: Log in to the image mirror (GHCR)
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          REGISTRY: ghcr.io
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/registry-login.mjs
 
       # Buildx gives the Compose build cache + a consistent backend
       # for the local cerberus image context.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -299,10 +299,9 @@ jobs:
         if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
         env:
           DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
-        uses: docker/login-action@v4
-        with:
-          username: tsouza
-          password: ${{ secrets.DOCKER_HUB_PAT }}
+          USERNAME: tsouza
+          PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
+        run: node .github/scripts/registry-login.mjs
 
       # Cerberus's own copy of every upstream image this job pulls lives in a
       # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before
@@ -310,11 +309,11 @@ jobs:
       # credentials; without it the pull falls back to the shared anonymous
       # Docker Hub quota. See .github/scripts/lib/mirror.mjs.
       - name: Log in to the image mirror (GHCR)
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          REGISTRY: ghcr.io
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/registry-login.mjs
 
       - uses: ./.github/actions/setup-buildx
 
@@ -534,10 +533,9 @@ jobs:
         if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
         env:
           DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
-        uses: docker/login-action@v4
-        with:
-          username: tsouza
-          password: ${{ secrets.DOCKER_HUB_PAT }}
+          USERNAME: tsouza
+          PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
+        run: node .github/scripts/registry-login.mjs
 
       # Cerberus's own copy of every upstream image this job pulls lives in a
       # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before
@@ -545,11 +543,11 @@ jobs:
       # credentials; without it the pull falls back to the shared anonymous
       # Docker Hub quota. See .github/scripts/lib/mirror.mjs.
       - name: Log in to the image mirror (GHCR)
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          REGISTRY: ghcr.io
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/registry-login.mjs
 
       - uses: ./.github/actions/setup-buildx
 
@@ -910,10 +908,9 @@ jobs:
         if: ${{ env.RUN_SHARD == 'true' && env.DOCKER_HUB_PAT_SET == 'true' }}
         env:
           DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
-        uses: docker/login-action@v4
-        with:
-          username: tsouza
-          password: ${{ secrets.DOCKER_HUB_PAT }}
+          USERNAME: tsouza
+          PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
+        run: node .github/scripts/registry-login.mjs
 
       # Cerberus's own copy of every upstream image this job pulls lives in a
       # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before
@@ -921,11 +918,11 @@ jobs:
       # credentials; without it the pull falls back to the shared anonymous
       # Docker Hub quota. See .github/scripts/lib/mirror.mjs.
       - name: Log in to the image mirror (GHCR)
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          REGISTRY: ghcr.io
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/registry-login.mjs
 
       - name: Bring up k3d stack
         if: env.RUN_SHARD == 'true'
@@ -1248,11 +1245,11 @@ jobs:
       # credentials; without it the pull falls back to the shared anonymous
       # Docker Hub quota. See .github/scripts/lib/mirror.mjs.
       - name: Log in to the image mirror (GHCR)
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          REGISTRY: ghcr.io
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/registry-login.mjs
 
       # `docker run` pulls a missing image itself, single-attempt: a Docker Hub
       # blip fails the job before ClickHouse is even started. `_pull-retry`
@@ -1383,10 +1380,9 @@ jobs:
         if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
         env:
           DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
-        uses: docker/login-action@v4
-        with:
-          username: tsouza
-          password: ${{ secrets.DOCKER_HUB_PAT }}
+          USERNAME: tsouza
+          PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
+        run: node .github/scripts/registry-login.mjs
 
       # Cerberus's own copy of every upstream image this job pulls lives in a
       # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before
@@ -1394,11 +1390,11 @@ jobs:
       # credentials; without it the pull falls back to the shared anonymous
       # Docker Hub quota. See .github/scripts/lib/mirror.mjs.
       - name: Log in to the image mirror (GHCR)
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          REGISTRY: ghcr.io
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/registry-login.mjs
 
       # Reuse the e2e k3d bring-up (same first steps as the dashboard job):
       # cluster, cerberus:e2e image, manifests, host port maps
@@ -1580,10 +1576,9 @@ jobs:
         if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
         env:
           DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
-        uses: docker/login-action@v4
-        with:
-          username: tsouza
-          password: ${{ secrets.DOCKER_HUB_PAT }}
+          USERNAME: tsouza
+          PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
+        run: node .github/scripts/registry-login.mjs
 
       # Cerberus's own copy of every upstream image this job pulls lives in a
       # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before
@@ -1591,11 +1586,11 @@ jobs:
       # credentials; without it the pull falls back to the shared anonymous
       # Docker Hub quota. See .github/scripts/lib/mirror.mjs.
       - name: Log in to the image mirror (GHCR)
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          REGISTRY: ghcr.io
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/registry-login.mjs
 
       - name: Bring up k3d + MinIO + bundled-ClickHouse stack
         run: just e2e-bwc-up

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1239,6 +1239,19 @@ jobs:
         with:
           tool: just
 
+      # The mirror is reached for FIRST, but a mirror miss falls back to Docker
+      # Hub — and that fallback is the anonymous shared per-runner-IP quota
+      # unless this step has run. Every other image-acquiring job in this
+      # workflow carries both logins; this one carried only the mirror half,
+      # which is invisible for as long as the mirror keeps hitting.
+      - name: Log in to Docker Hub
+        if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
+        env:
+          DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
+          USERNAME: tsouza
+          PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
+        run: node .github/scripts/registry-login.mjs
+
       # Cerberus's own copy of every upstream image this job pulls lives in a
       # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before
       # Docker Hub. That reach works only once this step has written ghcr.io

--- a/.github/workflows/migration-e2e.yml
+++ b/.github/workflows/migration-e2e.yml
@@ -174,11 +174,11 @@ jobs:
       # there is no condition whose falsification would let the release path
       # silently fall back to a source build.
       - name: Log in to GHCR
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          REGISTRY: ghcr.io
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/registry-login.mjs
 
       # WHICH cerberus this run tests. On a PR / dispatch / push run both inputs
       # are empty and the resolver compiles the CLI from this tree; on
@@ -279,19 +279,18 @@ jobs:
         if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
         env:
           DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
-        uses: docker/login-action@v4
-        with:
-          username: tsouza
-          password: ${{ secrets.DOCKER_HUB_PAT }}
+          USERNAME: tsouza
+          PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
+        run: node .github/scripts/registry-login.mjs
 
       # See migration-tier0's identical block: unconditional so the artifact
       # lane's GHCR pull can never silently degrade into a source build.
       - name: Log in to GHCR
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          REGISTRY: ghcr.io
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/registry-login.mjs
 
       # migration-tier1 runs on a separate runner with a fresh checkout, so
       # the enumerator output from migration-setup must travel as an
@@ -435,18 +434,17 @@ jobs:
         if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
         env:
           DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
-        uses: docker/login-action@v4
-        with:
-          username: tsouza
-          password: ${{ secrets.DOCKER_HUB_PAT }}
+          USERNAME: tsouza
+          PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
+        run: node .github/scripts/registry-login.mjs
 
       # See migration-tier0's identical block.
       - name: Log in to GHCR
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          REGISTRY: ghcr.io
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/registry-login.mjs
 
       - name: download migration scenarios enumeration
         uses: actions/download-artifact@v8

--- a/.github/workflows/mirror-images.yml
+++ b/.github/workflows/mirror-images.yml
@@ -68,22 +68,30 @@ jobs:
       # is exactly what this job exists to stop spending. Skips silently when
       # the secret is absent (forks), where the copy still works against the
       # anonymous limit for an inventory this small.
+      #
+      # RETRIED, and not via docker/login-action, which has no retry input. This
+      # step is where the workflow died on its first real run (30724446834) with
+      # `context deadline exceeded` on the /v2/ handshake — before pulling
+      # anything, so the mirror shipped inert while the PR merged green. The
+      # script classifies with lib/registry.mjs, so a handshake fault retries
+      # while a quota refusal still fails on the first attempt.
       - name: Log in to Docker Hub
         if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
         env:
           DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
-        uses: docker/login-action@v4
-        with:
-          username: tsouza
-          password: ${{ secrets.DOCKER_HUB_PAT }}
+          USERNAME: tsouza
+          PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
+        run: node .github/scripts/registry-login.mjs
 
-      # Writing side.
+      # Writing side. Retried for the same reason: an unpopulated mirror is
+      # silent at every point of use, so the handshake that enables writing to
+      # it is not a good place to be one-shot.
       - name: Log in to GHCR
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          REGISTRY: ghcr.io
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/registry-login.mjs
 
       - name: Mirror the inventory
         run: node .github/scripts/mirror-images.mjs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,11 +116,11 @@ jobs:
       # indeterminate registry error, so an unauthenticated probe could abort
       # the whole release).
       - name: Log in to GHCR
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          REGISTRY: ghcr.io
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/registry-login.mjs
 
       - id: app
         name: App version gate (publish iff appVersion un-tagged)
@@ -320,11 +320,11 @@ jobs:
       - uses: docker/setup-qemu-action@v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          REGISTRY: ghcr.io
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/registry-login.mjs
 
       # Docker Hub mirror — goreleaser pushes the same per-arch images +
       # manifests to docker.io/tsouza/cerberus in the same build. A login
@@ -332,10 +332,10 @@ jobs:
       # Both logins sit ahead of the builder setup so the BuildKit
       # bootstrap image is fetched under the same credentials.
       - name: Log in to Docker Hub
-        uses: docker/login-action@v4
-        with:
-          username: tsouza
-          password: ${{ secrets.DOCKER_HUB_PAT }}
+        env:
+          USERNAME: tsouza
+          PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
+        run: node .github/scripts/registry-login.mjs
 
       # `dockers_v2` builds linux/amd64 + linux/arm64 through buildx, which
       # needs the docker-container driver (the built-in `docker` driver is
@@ -708,11 +708,11 @@ jobs:
       - uses: oras-project/setup-oras@v2
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          REGISTRY: ghcr.io
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/registry-login.mjs
 
       # Create + push the `chart-v<version>` annotated tag at the merge commit.
       # Idempotent / fail-safe in the same shape as the app tag step above.

--- a/.github/workflows/schema-integration.yml
+++ b/.github/workflows/schema-integration.yml
@@ -108,6 +108,17 @@ jobs:
         with:
           tool: just
 
+      # The mirror below is reached for FIRST, but a mirror miss falls back to
+      # Docker Hub — and that fallback spends the anonymous shared
+      # per-runner-IP quota unless this step has run.
+      - name: Log in to Docker Hub
+        if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
+        env:
+          DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
+          USERNAME: tsouza
+          PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
+        run: node .github/scripts/registry-login.mjs
+
       # Cerberus's own copy of every upstream image this job pulls lives in a
       # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before
       # Docker Hub. That reach works only once this step has written ghcr.io

--- a/.github/workflows/schema-integration.yml
+++ b/.github/workflows/schema-integration.yml
@@ -114,11 +114,11 @@ jobs:
       # credentials; without it the pull falls back to the shared anonymous
       # Docker Hub quota. See .github/scripts/lib/mirror.mjs.
       - name: Log in to the image mirror (GHCR)
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          REGISTRY: ghcr.io
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/registry-login.mjs
 
       - name: Run schema/ddl integration tests (real ClickHouse)
         run: just schema-ddl-test

--- a/.github/workflows/strict-scan.yml
+++ b/.github/workflows/strict-scan.yml
@@ -117,11 +117,11 @@ jobs:
       # credentials; without it the pull falls back to the shared anonymous
       # Docker Hub quota. See .github/scripts/lib/mirror.mjs.
       - name: Log in to the image mirror (GHCR)
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          REGISTRY: ghcr.io
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/registry-login.mjs
 
       - name: Run strict-scan differential (real ClickHouse)
         run: just strict-scan-test

--- a/.github/workflows/strict-scan.yml
+++ b/.github/workflows/strict-scan.yml
@@ -111,6 +111,17 @@ jobs:
         with:
           tool: just
 
+      # The mirror below is reached for FIRST, but a mirror miss falls back to
+      # Docker Hub — and that fallback spends the anonymous shared
+      # per-runner-IP quota unless this step has run.
+      - name: Log in to Docker Hub
+        if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
+        env:
+          DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
+          USERNAME: tsouza
+          PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
+        run: node .github/scripts/registry-login.mjs
+
       # Cerberus's own copy of every upstream image this job pulls lives in a
       # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before
       # Docker Hub. That reach works only once this step has written ghcr.io

--- a/test/regression/mirror_login_test.go
+++ b/test/regression/mirror_login_test.go
@@ -20,10 +20,19 @@ import (
 // path looks green until the day the quota is spent, which is the failure this
 // whole mechanism exists to remove.
 
-// mirrorLoginMarker is the line `docker/login-action` carries when it is pointed
-// at GHCR. Matching the registry rather than the step name keeps the gate on
-// what the step DOES.
-const mirrorLoginMarker = "registry: ghcr.io"
+// mirrorLoginMarker is the line a login step carries when it is pointed at
+// GHCR: `REGISTRY: ghcr.io` in the env block of a `registry-login.mjs` step.
+// The case-insensitive form also admits `registry: ghcr.io`, the input name
+// `docker/login-action` used — that Action is forbidden repo-wide by the
+// `registry-login` hygiene scan, so nothing can reintroduce it, but keying on
+// the registry rather than the step name keeps the gate on what the step DOES
+// and survives the next change of login mechanism.
+var mirrorLoginMarker = regexp.MustCompile(`(?im)^\s*registry:\s*ghcr\.io\s*$`)
+
+// mirrorLoginRemedy is what to add when the gate fires. It names the script
+// rather than an Action because `registry-login.mjs` retries transport faults
+// and refuses to retry a spent quota or a rejected credential.
+const mirrorLoginRemedy = "`REGISTRY: ghcr.io` step running `node .github/scripts/registry-login.mjs`"
 
 // imageConsumingMarkers are the module and action names that acquire an image
 // through the shared policy, i.e. through the mirror.
@@ -147,11 +156,11 @@ func TestEveryImageConsumingJobLogsIntoTheMirror(t *testing.T) {
 				continue
 			}
 			consuming++
-			if !strings.Contains(body, mirrorLoginMarker) {
+			if !mirrorLoginMarker.MatchString(body) {
 				t.Errorf("%s job %q acquires images (%s) but never logs into ghcr.io, so every pull it makes "+
-					"misses the mirror and falls back to Docker Hub's shared anonymous quota. Add a "+
-					"`docker/login-action` step with `%s` and give the job `packages: read`.",
-					file, job, why, mirrorLoginMarker)
+					"misses the mirror and falls back to Docker Hub's shared anonymous quota. Add a %s "+
+					"and give the job `packages: read`.",
+					file, job, why, mirrorLoginRemedy)
 			}
 		}
 	}


### PR DESCRIPTION
## What broke

`docker/login-action` has no retry input. A login that loses a single
handshake fails the whole job before it has pulled anything — and because
`acquireFromMirror` treats a mirror MISS as non-fatal and falls back to
Docker Hub, a failed GHCR login is **silent at the point of use**: the
consuming step looks like a step that simply was not mirrored, while
quietly spending the metered Docker Hub bucket.

#1583 fixed one site. The identical `context deadline exceeded` then
reddened the **required** `compatibility/prometheus-forced-route`,
because 32 other steps still used the Action. That is the signature of a
leg fix rather than a class fix.

## What this PR does

1. **Retrying login script** (`.github/scripts/registry-login.mjs`) —
   classifies a login failure before deciding to retry:
   `classifyLoginFailure` returns `transient` (retry with backoff),
   `rate-limit` / `credential` (never retry — retrying a spent quota
   re-spends nothing and retrying a rejected credential just burns
   attempts), or `fatal`. The password goes in on stdin, never argv.

2. **Every remaining call site converted** — 32 sites across
   `strict-scan`, `schema-integration`, `release`, `migration-e2e`,
   `e2e` and `compatibility`, in three shapes: GHCR with
   `secrets.GITHUB_TOKEN` (19), Docker Hub behind the existing
   `DOCKER_HUB_PAT_SET` guard (12), and one bare Docker Hub login in
   `release.yml`. Final inventory: 34 `registry-login.mjs` steps,
   zero `uses: docker/login-action`.

3. **Read every mirrored copy back out of GHCR** — the mirroring job now
   verifies the copy it just pushed is pullable, so a mirror that
   silently failed to publish cannot present as a mirror miss.

4. **A ratchet, so there is no 33rd site** — `CHECK=registry-login` in
   `repo-hygiene.mjs`, wired into the `forbid-skip` job. Converting 32
   sites without a gate just resets the clock.

### The gate matches the step, not the word

`loginActionUses` anchors on `^\s*-?\s*uses:\s*['"]?docker/login-action\b`.
A comment or a README paragraph that *names* the Action stays legal —
including the gate's own doc block and this PR body. A gate that policed
the word instead of the step would make its own rationale unwritable.

## Proof the new gate can fail

A gate never shown red is indistinguishable from no gate. Neutering the
regex to `docker\/login-action-NEVERMATCHES` and re-running the suite:

```
✖ loginActionUses matches the step form and not prose naming the Action
  AssertionError: only the two real step declarations are violations; got []
    actual: [], expected: [ 6, 7 ]
✖ the CLI FAILS on a workflow that uses docker/login-action, naming file:line
  AssertionError: the registry-login scan must fail; got: …
    actual: 0, expected: 0
ℹ tests 12  ℹ pass 10  ℹ fail 2
```

Regex restored → **12/12 pass**. Against the real tree:

```
::notice::repo-hygiene: no workflow uses docker/login-action (26 workflows scanned)
exit=0
```

The three new tests build a throwaway git repo carrying one tracked
workflow (deliberately *not* the existing `newFixtureRepo`, which
materialises every `ROOT_ALLOWLIST` entry as a plain FILE — `.github`
there is a file and could never hold `.github/workflows/*.yml`).

## Validation

- YAML re-parsed with a duplicate-key-aware loader across all six
  converted workflows: no duplicate `env:` keys, no step carrying both
  `uses:` and `run:`. (The conversion had a real hazard here — the
  with-`env` shape must be rewritten before the bare shape, or the bare
  replacement emits a second `env:` key, which YAML accepts while
  dropping data.)
- Stale prose corrected where it described the old mechanism:
  `compatibility.yml`'s action inventory, `lib/mirror.mjs:28`, and the
  `.github/scripts/README.md` env-contract entry.

Closes #1583
