### PR TITLE
fix(promql): honour info() drop semantics and non-equality __name__ matchers

### DIFF
--- a/internal/chplan/info_join.go
+++ b/internal/chplan/info_join.go
@@ -20,11 +20,15 @@ import "slices"
 //     most one info series per identity key.
 //
 // IdentityLabels are the labels the join keys on — the reference engine
-// hard-codes `{instance, job}`. The emitter renders a LEFT JOIN so base
-// series with no matching info series pass through unchanged (the default
-// `target_info` case has no data-label matcher, so unmatched base series
-// are always kept — see combineWithInfoVector's `allMatchersMatchEmpty`
-// branch).
+// hard-codes `{instance, job}`.
+//
+// DropUnmatched selects the join flavour. The reference engine keeps a
+// base sample that matched no info series only when every data-label
+// matcher also matches the empty string (combineWithInfoVector's
+// `allMatchersMatchEmpty` branch): `info(v)` and `info(v, {k=~".*"})`
+// keep it, `info(v, {k="x"})` and `info(v, {k=~".+"})` do not. False →
+// LEFT JOIN (pass unmatched base samples through unenriched); true →
+// INNER JOIN (drop them).
 //
 // DataLabels, when non-empty, restricts the set of info labels copied onto
 // the output to exactly those names — the second-arg label-matcher case
@@ -32,6 +36,15 @@ import "slices"
 // already present on the base" (the default case). The identity labels are
 // never copied (they're already on the base by construction), and the info
 // metric's `__name__` is never copied.
+//
+// MergeInfoMetrics is set when the second argument's `__name__` matchers
+// can select more than one info metric (a regex, a negation, or several
+// matchers). A base series then joins one row per matched info metric,
+// while the reference engine unions all of their data labels onto a
+// single output sample. The emitter folds the extra rows back together
+// by grouping on the base sample's identity. A lone `__name__` equality
+// (including the default `target_info`) matches at most one info metric
+// per identity key, so the fold is skipped.
 //
 // The output Attributes is `mapConcat(infoExtras, base.Attributes)` so the
 // base side wins on any conflicting key — matching the reference rule that
@@ -45,6 +58,13 @@ type InfoJoin struct {
 	// DataLabels restricts which info labels are copied onto the output.
 	// Empty → copy every non-identity, non-__name__ info label.
 	DataLabels []string
+	// DropUnmatched drops base samples that matched no info series
+	// (INNER JOIN) instead of passing them through (LEFT JOIN).
+	DropUnmatched bool
+	// MergeInfoMetrics folds the per-info-metric join rows of one base
+	// sample back into a single output row with the union of their data
+	// labels.
+	MergeInfoMetrics bool
 
 	MetricNameColumn string
 	AttributesColumn string
@@ -63,6 +83,9 @@ func (j *InfoJoin) Equal(other Node) bool {
 	}
 	if !slices.Equal(j.IdentityLabels, o.IdentityLabels) ||
 		!slices.Equal(j.DataLabels, o.DataLabels) {
+		return false
+	}
+	if j.DropUnmatched != o.DropUnmatched || j.MergeInfoMetrics != o.MergeInfoMetrics {
 		return false
 	}
 	if j.MetricNameColumn != o.MetricNameColumn ||

--- a/internal/chsql/info_join.go
+++ b/internal/chsql/info_join.go
@@ -32,7 +32,19 @@ const infoMetricNameLabel = "__name__"
 // The join is LEFT so base series with no matching info series pass
 // through unchanged — matching the reference engine, whose default
 // `target_info` case (no data-label matcher) keeps every unmatched base
-// series. `<info extras>` is the info Attributes with the identity labels
+// series. When InfoJoin.DropUnmatched is set the join is INNER instead:
+// a data-label matcher that cannot match the empty string makes an
+// unmatched base sample unrepresentable, and the reference engine drops
+// it (see combineWithInfoVector's `allMatchersMatchEmpty` branch).
+//
+// When InfoJoin.MergeInfoMetrics is set the `__name__` matchers may
+// select several info metrics at once, so one base sample can join
+// several info rows. The reference engine unions their data labels onto
+// a single output sample; the emitter reproduces that by grouping on the
+// base sample's four columns and folding the per-row extras maps into
+// one (see infoMergedExtrasFrag).
+//
+// `<info extras>` is the info Attributes with the identity labels
 // + `__name__` stripped (and, when DataLabels is set, narrowed to exactly
 // those names); `mapConcat(extras, base)` lets the base side win on any
 // conflicting key, mirroring the reference rule that skips info labels
@@ -60,6 +72,11 @@ func (e *emitter) emitInfoJoin(j *chplan.InfoJoin) error {
 		return err
 	}
 
+	kind := LeftJoin
+	if j.DropUnmatched {
+		kind = InnerJoin
+	}
+
 	sb := NewQuery().
 		Select(
 			As(qualColFrag("L", j.MetricNameColumn), j.MetricNameColumn),
@@ -69,12 +86,29 @@ func (e *emitter) emitInfoJoin(j *chplan.InfoJoin) error {
 		).
 		From(aliasedFrag(leftFrag, "L")).
 		Join(
-			LeftJoin,
+			kind,
 			aliasedFrag(rightFrag, "R"),
 			infoJoinPredicateFrag(j),
 		)
+	if j.MergeInfoMetrics {
+		sb.GroupBy(infoBaseSampleKeyFrags(j)...)
+	}
 	e.emitSelect(sb)
 	return nil
+}
+
+// infoBaseSampleKeyFrags returns the four base-side columns that identify
+// one output sample. Grouping the join result on them collapses the
+// per-info-metric fan-out back to one row per base sample; the base side
+// is per-series-latest (or per-step) by construction, so the group is
+// exactly the join's own fan-out and never merges distinct base samples.
+func infoBaseSampleKeyFrags(j *chplan.InfoJoin) []Frag {
+	return []Frag{
+		qualColFrag("L", j.MetricNameColumn),
+		qualColFrag("L", j.AttributesColumn),
+		qualColFrag("L", j.TimestampColumn),
+		qualColFrag("L", j.ValueColumn),
+	}
 }
 
 func (e *emitter) validateInfoJoinCols(j *chplan.InfoJoin) error {
@@ -111,11 +145,33 @@ func infoJoinPredicateFrag(j *chplan.InfoJoin) Frag {
 // later-key-wins, so listing L.Attributes second keeps the base side's
 // value on any conflicting key — matching the reference engine's rule of
 // skipping info labels already present on the base.
+//
+// Under MergeInfoMetrics the extras map is first folded across the base
+// sample's join rows (one per matched info metric) so the union of every
+// matched info metric's data labels lands on one output sample.
 func infoOutputAttributesFrag(j *chplan.InfoJoin) Frag {
+	extras := infoExtrasFrag(j)
+	if j.MergeInfoMetrics {
+		extras = infoMergedExtrasFrag(extras)
+	}
 	return Call(
 		"mapConcat",
-		infoExtrasFrag(j),
+		extras,
 		qualColFrag("L", j.AttributesColumn),
+	)
+}
+
+// infoMergedExtrasFrag folds a per-join-row extras map into one map per
+// group: `mapFromArrays(groupArrayArray(mapKeys(x)), groupArrayArray(mapValues(x)))`
+// concatenates every row's key array and value array position-wise, so
+// the result carries every matched info metric's data labels. An
+// unmatched LEFT JOIN row contributes the default empty map, which
+// concatenates as nothing.
+func infoMergedExtrasFrag(extras Frag) Frag {
+	return Call(
+		"mapFromArrays",
+		Call("groupArrayArray", Call("mapKeys", extras)),
+		Call("groupArrayArray", Call("mapValues", extras)),
 	)
 }
 

--- a/internal/promql/info_fn.go
+++ b/internal/promql/info_fn.go
@@ -18,6 +18,14 @@ import (
 // reference engine's `targetInfo` constant (promql/info.go).
 const targetInfoMetric = "target_info"
 
+// infoNameFallbackPattern is the synthetic `__name__` regex the reference
+// engine substitutes when a second-argument selector carries ONLY negated
+// name matchers: with no positive matcher to anchor the scan, upstream
+// narrows the candidate set to the conventional `*_info` metric family
+// rather than scanning every metric. Mirrors promql/info.go's
+// `effectiveInfoNameMatchers`.
+const infoNameFallbackPattern = ".+_info"
+
 // infoIdentityLabels are the labels the info-enrichment join keys on. The
 // reference engine hard-codes `{instance, job}` (promql/info.go's
 // `identifyingLabels`); the SQL join matches base ↔ info series on these.
@@ -45,9 +53,12 @@ var infoIdentityLabels = []string{"instance", "job"}
 //   - The two sides wrap in a chplan.InfoJoin keyed on `{instance, job}`.
 //
 // The optional second argument is a label-selector: its `__name__`
-// matcher (if any) picks the info metric; its non-`__name__` matchers
-// both filter the info series and restrict which info labels copy onto
-// the output (the InfoJoin.DataLabels list).
+// matchers (of any type — equality, regex, or negated) pick the info
+// metrics; its non-`__name__` matchers both filter the info series and
+// restrict which info labels copy onto the output (the
+// InfoJoin.DataLabels list). Those same non-`__name__` matchers also
+// decide whether a base sample that matches no info series survives at
+// all — see infoDropsUnmatched.
 func lowerInfo(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
 	if len(c.Args) < 1 || len(c.Args) > 2 {
 		return nil, fmt.Errorf("promql: info expects 1 or 2 arguments, got %d", len(c.Args))
@@ -58,8 +69,7 @@ func lowerInfo(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, err
 		return nil, err
 	}
 
-	infoName := targetInfoMetric
-	var dataMatchers []*labels.Matcher
+	var nameMatchers, dataMatchers []*labels.Matcher
 	if len(c.Args) == 2 {
 		sel, ok := c.Args[1].(*parser.VectorSelector)
 		if !ok {
@@ -67,17 +77,15 @@ func lowerInfo(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, err
 		}
 		for _, m := range sel.LabelMatchers {
 			if m.Name == model.MetricNameLabel {
-				if m.Type != labels.MatchEqual {
-					return nil, fmt.Errorf("promql: info(...) second-argument __name__ matcher must be an equality match, got %q", m.Type)
-				}
-				infoName = m.Value
+				nameMatchers = append(nameMatchers, m)
 				continue
 			}
 			dataMatchers = append(dataMatchers, m)
 		}
 	}
+	nameMatchers = effectiveInfoNameMatchers(nameMatchers)
 
-	infoNode, err := lowerInfoMetric(infoName, dataMatchers, s, ctx)
+	infoNode, err := lowerInfoMetric(nameMatchers, dataMatchers, s, ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -89,6 +97,8 @@ func lowerInfo(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, err
 		Info:             infoNode,
 		IdentityLabels:   slices.Clone(infoIdentityLabels),
 		DataLabels:       dataLabels,
+		DropUnmatched:    infoDropsUnmatched(dataMatchers),
+		MergeInfoMetrics: !pinsSingleInfoMetric(nameMatchers),
 		MetricNameColumn: s.MetricNameColumn,
 		AttributesColumn: s.AttributesColumn,
 		TimestampColumn:  s.TimestampColumn,
@@ -96,18 +106,79 @@ func lowerInfo(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, err
 	}, nil
 }
 
+// effectiveInfoNameMatchers returns the `__name__` matcher set that
+// actually selects info series, given the ones a second-argument
+// selector spelled out. Ports promql/info.go's function of the same
+// name:
+//
+//   - At least one positive matcher (`=` or `=~`) → use the set as-is;
+//     the negated matchers ride along as extra narrowing.
+//   - Only negated matchers → prepend the synthetic `.+_info` regex so
+//     the scan is anchored to the conventional info-metric family
+//     instead of every metric in the store.
+//   - No matchers at all (bare `info(v)`, or a selector carrying only
+//     data-label matchers) → the default `target_info` equality.
+func effectiveInfoNameMatchers(nameMatchers []*labels.Matcher) []*labels.Matcher {
+	for _, m := range nameMatchers {
+		if m.Type == labels.MatchEqual || m.Type == labels.MatchRegexp {
+			return nameMatchers
+		}
+	}
+	if len(nameMatchers) > 0 {
+		fallback := labels.MustNewMatcher(labels.MatchRegexp, model.MetricNameLabel, infoNameFallbackPattern)
+		return append([]*labels.Matcher{fallback}, nameMatchers...)
+	}
+	return []*labels.Matcher{
+		labels.MustNewMatcher(labels.MatchEqual, model.MetricNameLabel, targetInfoMetric),
+	}
+}
+
+// pinsSingleInfoMetric reports whether the effective `__name__` matcher
+// set can only ever select one info metric — a lone equality matcher.
+// Anything else (a regex, a negation, or several matchers) may match
+// several info metrics at once, and the reference engine then unions the
+// data labels of every matched info series onto a single output sample
+// (promql/info.go::combineWithInfoVector iterates `seenInfoMetrics` and
+// merges into one label builder). The join emitter needs that signal to
+// fold its per-info-metric join rows back into one row per base sample.
+func pinsSingleInfoMetric(nameMatchers []*labels.Matcher) bool {
+	return len(nameMatchers) == 1 && nameMatchers[0].Type == labels.MatchEqual
+}
+
+// infoDropsUnmatched reports whether a base sample that matches no info
+// series must be dropped from the result rather than passed through
+// unenriched. The reference engine keeps such a sample only when every
+// data-label matcher also matches the empty string
+// (promql/info.go::combineWithInfoVector's `allMatchersMatchEmpty`
+// branch): a matcher like `k="v"` or `k=~".+"` cannot be satisfied by a
+// series carrying no `k` at all, so the sample is not part of the
+// result. `k=~".*"` / `k!="v"` do match the empty string, so unmatched
+// samples survive.
+func infoDropsUnmatched(dataMatchers []*labels.Matcher) bool {
+	for _, m := range dataMatchers {
+		if !m.Matches("") {
+			return true
+		}
+	}
+	return false
+}
+
 // lowerInfoMetric lowers the info-metric side of the join: a synthetic
-// VectorSelector for `infoName` carrying any data-label matchers, run
-// through the regular VectorSelector lowering so the info side gets the
-// same per-series-latest (LWR) / per-step-matrix treatment as the base
-// vector.
-func lowerInfoMetric(infoName string, dataMatchers []*labels.Matcher, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
-	matchers := make([]*labels.Matcher, 0, len(dataMatchers)+1)
-	matchers = append(matchers, labels.MustNewMatcher(labels.MatchEqual, model.MetricNameLabel, infoName))
+// VectorSelector carrying the effective `__name__` matchers plus any
+// data-label matchers, run through the regular VectorSelector lowering
+// so the info side gets the same per-series-latest (LWR) / per-step-
+// matrix treatment as the base vector — and so regex / negated name
+// matchers reuse the same unpinned-name scan fan-out an ordinary
+// `{__name__=~"…"}` selector gets.
+func lowerInfoMetric(nameMatchers, dataMatchers []*labels.Matcher, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+	matchers := make([]*labels.Matcher, 0, len(nameMatchers)+len(dataMatchers))
+	matchers = append(matchers, nameMatchers...)
 	matchers = append(matchers, dataMatchers...)
 
 	sel := &parser.VectorSelector{
-		Name:          infoName,
+		// Empty unless a `__name__` equality pins the name, matching the
+		// parser's own convention for `{__name__=~"…"}` selectors.
+		Name:          metricNameFromMatchers(matchers),
 		LabelMatchers: matchers,
 	}
 	return lowerVectorSelector(sel, s, ctx)

--- a/internal/promql/info_fn_test.go
+++ b/internal/promql/info_fn_test.go
@@ -2,6 +2,7 @@ package promql_test
 
 import (
 	"context"
+	"slices"
 	"strings"
 	"testing"
 
@@ -15,19 +16,18 @@ import (
 // TestLower_Info covers PromQL's `info(v[, {matchers}])` label-enrichment
 // join. `info` is experimental, so the parser must enable experimental
 // functions. The lowering builds a chplan.InfoJoin keyed on
-// {instance, job}; the chsql emitter renders a LEFT JOIN whose output
-// keeps the base side's value/timestamp and grows its Attributes with the
-// info series' data labels via mapConcat.
+// {instance, job}; the chsql emitter renders a join whose output keeps
+// the base side's value/timestamp and grows its Attributes with the info
+// series' data labels via mapConcat.
 func TestLower_Info(t *testing.T) {
 	t.Parallel()
 
-	s := schema.DefaultOTelMetrics()
-	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
-
 	cases := []struct {
-		name      string
-		query     string
-		wantInSQL []string
+		name         string
+		query        string
+		wantInSQL    []string
+		notWantInSQL []string
+		wantArgs     []string
 	}{
 		{
 			name:  "default target_info enrichment",
@@ -40,6 +40,7 @@ func TestLower_Info(t *testing.T) {
 				"L.`Value` AS `Value`",
 				"L.`MetricName` AS `MetricName`",
 			},
+			notWantInSQL: []string{"INNER JOIN", "groupArrayArray("},
 		},
 		{
 			name:  "second-arg name matcher selects info metric",
@@ -48,37 +49,187 @@ func TestLower_Info(t *testing.T) {
 				"LEFT JOIN",
 				"mapConcat(",
 			},
+			notWantInSQL: []string{"INNER JOIN", "groupArrayArray("},
+			wantArgs:     []string{"build_info"},
 		},
 		{
 			name:  "second-arg data-label matcher restricts copied labels",
 			query: `info(up, {version=~".+"})`,
 			wantInSQL: []string{
-				"LEFT JOIN",
+				"INNER JOIN",
 				"mapFilter((k, v) -> k IN (?)",
 			},
+			notWantInSQL: []string{"LEFT JOIN", "groupArrayArray("},
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			expr, err := p.ParseExpr(tc.query)
-			if err != nil {
-				t.Fatalf("ParseExpr: %v", err)
-			}
-			plan, err := promql.Lower(context.Background(), expr, s)
-			if err != nil {
-				t.Fatalf("Lower: %v", err)
-			}
-			sql, _, err := chsql.Emit(context.Background(), plan)
-			if err != nil {
-				t.Fatalf("Emit: %v", err)
-			}
+			sql, args := emitInfoQuery(t, tc.query)
 			for _, want := range tc.wantInSQL {
 				if !strings.Contains(sql, want) {
 					t.Errorf("expected SQL to contain %q; full SQL:\n%s", want, sql)
 				}
 			}
+			for _, unwanted := range tc.notWantInSQL {
+				if strings.Contains(sql, unwanted) {
+					t.Errorf("expected SQL NOT to contain %q; full SQL:\n%s", unwanted, sql)
+				}
+			}
+			for _, want := range tc.wantArgs {
+				if !slices.Contains(args, want) {
+					t.Errorf("expected args to contain %q; got %v", want, args)
+				}
+			}
 		})
 	}
+}
+
+// TestLower_Info_DropsUnmatchedBaseSamples pins the reference engine's
+// drop branch (promql/info.go::combineWithInfoVector,
+// `allMatchersMatchEmpty`): a base sample that matched no info series
+// survives only when every data-label matcher also matches the empty
+// string. A matcher that cannot match "" therefore turns the enrichment
+// into an INNER JOIN — an unmatched base sample is not in the result.
+func TestLower_Info_DropsUnmatchedBaseSamples(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		query string
+		// drop is true when the reference engine would omit an
+		// info-less base sample from the result.
+		drop bool
+	}{
+		{name: "no second argument keeps unmatched", query: `info(up)`, drop: false},
+		{name: "name-only selector keeps unmatched", query: `info(up, {__name__="build_info"})`, drop: false},
+		{name: "match-all regex keeps unmatched", query: `info(up, {version=~".*"})`, drop: false},
+		{name: "negated matcher keeps unmatched", query: `info(up, {version!="1.2.3"})`, drop: false},
+		{name: "empty-matching negated regex keeps unmatched", query: `info(up, {version!~".+"})`, drop: false},
+		{name: "equality matcher drops unmatched", query: `info(up, {version="1.2.3"})`, drop: true},
+		{name: "non-empty regex drops unmatched", query: `info(up, {version=~".+"})`, drop: true},
+		{name: "negated empty matcher drops unmatched", query: `info(up, {version!=""})`, drop: true},
+		{name: "one non-empty matcher among several drops unmatched", query: `info(up, {version=~".*", build=~".+"})`, drop: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			sql, _ := emitInfoQuery(t, tc.query)
+			wantJoin, unwantedJoin := "LEFT JOIN", "INNER JOIN"
+			if tc.drop {
+				wantJoin, unwantedJoin = "INNER JOIN", "LEFT JOIN"
+			}
+			if !strings.Contains(sql, wantJoin) {
+				t.Errorf("expected %s for %s; full SQL:\n%s", wantJoin, tc.query, sql)
+			}
+			if strings.Contains(sql, unwantedJoin) {
+				t.Errorf("expected no %s for %s; full SQL:\n%s", unwantedJoin, tc.query, sql)
+			}
+		})
+	}
+}
+
+// TestLower_Info_NameMatcherTypes pins the reference engine's
+// `__name__`-matcher handling (promql/info.go::effectiveInfoNameMatchers).
+// Equality, regex, negated and multi-metric selectors all lower; a
+// selector carrying only negated name matchers gains the synthetic
+// `.+_info` regex so the info scan stays anchored to the info-metric
+// family. Selectors that can match several info metrics additionally fold
+// the per-metric join rows back to one row per base sample, because the
+// reference engine unions their data labels onto a single output sample.
+func TestLower_Info_NameMatcherTypes(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		// query is the info() call under test.
+		query string
+		// merge is true when the selector may match several info
+		// metrics, so the emitter must fold their rows together.
+		merge bool
+		// wantArgs are bound values the emitted SQL must carry — the
+		// name-matcher values that reached the info-side scan.
+		wantArgs []string
+	}{
+		{
+			name:     "equality name matcher pins one metric",
+			query:    `info(up, {__name__="build_info"})`,
+			merge:    false,
+			wantArgs: []string{"build_info"},
+		},
+		{
+			name:     "regex name matcher may match several metrics",
+			query:    `info(up, {__name__=~".*_info"})`,
+			merge:    true,
+			wantArgs: []string{".*_info"},
+		},
+		{
+			name:     "negated-only name matcher gains the .+_info fallback",
+			query:    `info(up, {__name__!="target_info"})`,
+			merge:    true,
+			wantArgs: []string{".+_info", "target_info"},
+		},
+		{
+			name:     "negated regex name matcher gains the .+_info fallback",
+			query:    `info(up, {__name__!~"target.*"})`,
+			merge:    true,
+			wantArgs: []string{".+_info", "target.*"},
+		},
+		{
+			name:     "positive plus negated name matchers keep the positive anchor",
+			query:    `info(up, {__name__=~".*_info", __name__!="build_info"})`,
+			merge:    true,
+			wantArgs: []string{".*_info", "build_info"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			sql, args := emitInfoQuery(t, tc.query)
+			for _, want := range tc.wantArgs {
+				if !slices.Contains(args, want) {
+					t.Errorf("expected args to contain %q; got %v\nfull SQL:\n%s", want, args, sql)
+				}
+			}
+			// The fold is the outer GROUP BY on the four base-side
+			// columns plus the groupArrayArray map union; the inner
+			// per-series-latest aggregate carries its own GROUP BY, so
+			// the base-side key list is what discriminates.
+			const foldGroupBy = "GROUP BY L.`MetricName`, L.`Attributes`, L.`TimeUnix`, L.`Value`"
+			hasFold := strings.Contains(sql, "groupArrayArray(") && strings.Contains(sql, foldGroupBy)
+			if hasFold != tc.merge {
+				t.Errorf("multi-metric fold present=%v, want %v; full SQL:\n%s", hasFold, tc.merge, sql)
+			}
+		})
+	}
+}
+
+// emitInfoQuery parses, lowers and emits an `info(...)` query, returning
+// the SQL text and the string-typed bound arguments.
+func emitInfoQuery(t *testing.T, query string) (string, []string) {
+	t.Helper()
+
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	expr, err := p.ParseExpr(query)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", query, err)
+	}
+	plan, err := promql.Lower(context.Background(), expr, schema.DefaultOTelMetrics())
+	if err != nil {
+		t.Fatalf("Lower(%q): %v", query, err)
+	}
+	sql, args, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit(%q): %v", query, err)
+	}
+	strs := make([]string, 0, len(args))
+	for _, a := range args {
+		if s, ok := a.(string); ok {
+			strs = append(strs, s)
+		}
+	}
+	return sql, strs
 }

--- a/test/perf/cardinality-baseline.json
+++ b/test/perf/cardinality-baseline.json
@@ -3850,6 +3850,26 @@
     "max_recursion_depth": 0
   },
   {
+    "fixture": "promql/info_data_label_matcher_drops_unmatched",
+    "fan_factor": 1,
+    "scan_rows": 2,
+    "peak_intermediate": 2,
+    "has_cross_join": false,
+    "has_array_join": false,
+    "has_recursive_cte": false,
+    "max_recursion_depth": 0
+  },
+  {
+    "fixture": "promql/info_regex_name_matcher_unions_info_metrics",
+    "fan_factor": 1,
+    "scan_rows": 1,
+    "peak_intermediate": 1,
+    "has_cross_join": false,
+    "has_array_join": true,
+    "has_recursive_cte": false,
+    "max_recursion_depth": 0
+  },
+  {
     "fixture": "promql/info_target_info_enrichment",
     "fan_factor": 1,
     "scan_rows": 2,

--- a/test/perf/solver-decision-baseline.json
+++ b/test/perf/solver-decision-baseline.json
@@ -2110,6 +2110,26 @@
     "outer_range": "1h0m0s"
   },
   {
+    "query": "info_data_label_matcher_drops_unmatched",
+    "routed": false,
+    "k": 0,
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
+  },
+  {
+    "query": "info_regex_name_matcher_unions_info_metrics",
+    "routed": false,
+    "k": 0,
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
+  },
+  {
     "query": "info_target_info_enrichment",
     "routed": false,
     "k": 0,

--- a/test/rejection-parity/catalogue.json
+++ b/test/rejection-parity/catalogue.json
@@ -451,13 +451,6 @@
     },
     {
       "head": "promql",
-      "site": "internal/promql/info_fn.go:lowerInfo#4ef6f344",
-      "message": "promql: info(...) second-argument __name__ matcher must be an equality match, got %q",
-      "class": "rejection",
-      "trigger_query": "info(up, {__name__=~\"target.*\"})"
-    },
-    {
-      "head": "promql",
       "site": "internal/promql/info_fn.go:lowerInfo#9e913846",
       "message": "promql: info expects 1 or 2 arguments, got %d",
       "class": "internal",

--- a/test/spec/chplan_print.go
+++ b/test/spec/chplan_print.go
@@ -330,6 +330,12 @@ func printNode(b *strings.Builder, n chplan.Node, depth int) {
 		if len(v.DataLabels) > 0 {
 			fmt.Fprintf(b, " dataLabels=[%s]", strings.Join(v.DataLabels, ", "))
 		}
+		if v.DropUnmatched {
+			b.WriteString(" dropUnmatched")
+		}
+		if v.MergeInfoMetrics {
+			b.WriteString(" mergeInfoMetrics")
+		}
 		b.WriteString("\n")
 		printNode(b, v.Input, depth+1)
 		printNode(b, v.Info, depth+1)

--- a/test/spec/promql/info_data_label_matcher_drops_unmatched.txtar
+++ b/test/spec/promql/info_data_label_matcher_drops_unmatched.txtar
@@ -1,0 +1,81 @@
+# A second-argument data-label matcher that cannot match the empty string
+# makes an info-less base sample unrepresentable, so the reference engine
+# drops it (promql/info.go::combineWithInfoVector's `allMatchersMatchEmpty`
+# branch). `version=~".+"` is such a matcher: `up{job="db"}` has no
+# `target_info` companion carrying a `version`, so it must NOT appear in
+# the result — only `up{job="api"}` survives, enriched with `version`.
+# The enrichment therefore lowers to an INNER JOIN rather than the LEFT
+# JOIN the default `info(v)` case uses.
+
+-- query.promql --
+info(up, {version=~".+"})
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 1.0),
+    ('up', map('job', 'db'), toDateTime64('2026-01-01 00:00:00', 9), 0.0),
+    ('target_info', map('job', 'api', 'version', '1.2.3'), toDateTime64('2026-01-01 00:00:00', 9), 1.0),
+    ('target_info', map('job', 'db'), toDateTime64('2026-01-01 00:00:00', 9), 1.0);
+-- expected_rows --
+[
+  ["up", {"job": "api", "version": "1.2.3"}, "2026-01-01T00:00:00Z", 1]
+]
+-- args --
+[0] string = "version"
+[1] string = "service.name"
+[2] string = "service_name"
+[3] string = "service.name"
+[4] string = "service_name"
+[5] string = ""
+[6] string = "service_name"
+[7] string = "up"
+[8] string = "2026-01-01 00:00:01.000000000"
+[9] int64 = 9
+[10] string = "2026-01-01 00:00:01.000000000"
+[11] int64 = 9
+[12] int64 = 300000000000
+[13] string = "service.name"
+[14] string = "service_name"
+[15] string = "service.name"
+[16] string = "service_name"
+[17] string = ""
+[18] string = "service_name"
+[19] string = "target_info"
+[20] string = "target.info"
+[21] string = "target/info"
+[22] string = "version"
+[23] string = ""
+[24] string = "version"
+[25] string = ""
+[26] string = ""
+[27] string = ".+"
+[28] string = "2026-01-01 00:00:01.000000000"
+[29] int64 = 9
+[30] string = "2026-01-01 00:00:01.000000000"
+[31] int64 = 9
+[32] int64 = 300000000000
+[33] string = "instance"
+[34] string = "instance"
+[35] string = "job"
+[36] string = "job"
+-- chplan --
+InfoJoin identity=[instance, job] dataLabels=[version] dropUnmatched
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=((TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9)) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Project [MetricName AS MetricName, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, Value AS Value]
+          Filter predicate=(MetricName = "up")
+            Scan(merge(otel_metrics_gauge|otel_metrics_sum))
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=((TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9)) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Project [MetricName AS MetricName, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, Value AS Value]
+          Filter predicate=((MetricName IN ("target_info", "target.info", "target/info")) AND (coalesce(nullIf(Attributes["version"], ""), nullIf(ResourceAttributes["version"], ""), "") =~ ".+"))
+            Scan(merge(otel_metrics_gauge|otel_metrics_sum))
+-- sql --
+SELECT L.`MetricName` AS `MetricName`, mapConcat(mapFilter((k, v) -> k IN (?), R.`Attributes`), L.`Attributes`) AS `Attributes`, L.`TimeUnix` AS `TimeUnix`, L.`Value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') PREWHERE (`MetricName` = ?))) WHERE ((`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?))))) GROUP BY `MetricName`, `Attributes`)) AS L INNER JOIN (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') PREWHERE (`MetricName` IN (?, ?, ?)) WHERE match(coalesce(nullIf(`Attributes`[?], ?), nullIf(`ResourceAttributes`[?], ?), ?), ?))) WHERE ((`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?))))) GROUP BY `MetricName`, `Attributes`)) AS R ON L.`Attributes`[?] = R.`Attributes`[?] AND L.`Attributes`[?] = R.`Attributes`[?]

--- a/test/spec/promql/info_regex_name_matcher_unions_info_metrics.txtar
+++ b/test/spec/promql/info_regex_name_matcher_unions_info_metrics.txtar
@@ -1,0 +1,127 @@
+# A regex `__name__` matcher selects a whole family of info metrics, not
+# one (promql/info.go::effectiveInfoNameMatchers returns the matcher set
+# as-is whenever it holds a positive matcher). `up{job="api"}` here has
+# two companions — `target_info` carrying `version` and `build_info`
+# carrying `revision` — and the reference engine merges the data labels of
+# every matched info series onto ONE output sample
+# (combineWithInfoVector's `seenInfoMetrics` loop shares a single label
+# builder). The emitter reproduces that by folding the per-info-metric
+# join rows back together on the base sample's identity, so the result is
+# a single `up{job="api", revision=…, version=…}` series rather than one
+# series per matched info metric.
+
+-- query.promql --
+info(up, {__name__=~".+_info"})
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 1.0),
+    ('target_info', map('job', 'api', 'version', '1.2.3'), toDateTime64('2026-01-01 00:00:00', 9), 1.0),
+    ('build_info', map('job', 'api', 'revision', 'abc123'), toDateTime64('2026-01-01 00:00:00', 9), 1.0);
+-- expected_rows --
+[
+  ["up", {"job": "api", "revision": "abc123", "version": "1.2.3"}, "2026-01-01T00:00:00Z", 1]
+]
+-- args --
+[0] string = "instance"
+[1] string = "job"
+[2] string = "__name__"
+[3] string = "instance"
+[4] string = "job"
+[5] string = "__name__"
+[6] string = "service.name"
+[7] string = "service_name"
+[8] string = "service.name"
+[9] string = "service_name"
+[10] string = ""
+[11] string = "service_name"
+[12] string = "up"
+[13] string = "2026-01-01 00:00:01.000000000"
+[14] int64 = 9
+[15] string = "2026-01-01 00:00:01.000000000"
+[16] int64 = 9
+[17] int64 = 300000000000
+[18] string = "service.name"
+[19] string = "service_name"
+[20] string = "service.name"
+[21] string = "service_name"
+[22] string = ""
+[23] string = "service_name"
+[24] string = ".+_info"
+[25] string = "[^a-zA-Z0-9_:]"
+[26] string = "_"
+[27] string = ".+_info"
+[28] string = "service.name"
+[29] string = "service_name"
+[30] string = "service.name"
+[31] string = "service_name"
+[32] string = ""
+[33] string = "service_name"
+[34] string = ".+_info"
+[35] string = "[^a-zA-Z0-9_:]"
+[36] string = "_"
+[37] string = ".+_info"
+[38] string = "service.name"
+[39] string = "service_name"
+[40] string = "service.name"
+[41] string = "service_name"
+[42] string = ""
+[43] string = "service_name"
+[44] string = ".+_info"
+[45] string = "[^a-zA-Z0-9_:]"
+[46] string = "_"
+[47] string = ".+_info"
+[48] string = "le"
+[49] string = "+Inf"
+[50] int64 = 1
+[51] string = "service.name"
+[52] string = "service_name"
+[53] string = "service.name"
+[54] string = "service_name"
+[55] string = ""
+[56] string = "service_name"
+[57] string = ".+_info"
+[58] string = "[^a-zA-Z0-9_:]"
+[59] string = "_"
+[60] string = ".+_info"
+[61] string = "2026-01-01 00:00:01.000000000"
+[62] int64 = 9
+[63] string = "2026-01-01 00:00:01.000000000"
+[64] int64 = 9
+[65] int64 = 300000000000
+[66] string = "instance"
+[67] string = "instance"
+[68] string = "job"
+[69] string = "job"
+-- chplan --
+InfoJoin identity=[instance, job] mergeInfoMetrics
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=((TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9)) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Project [MetricName AS MetricName, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, Value AS Value]
+          Filter predicate=(MetricName = "up")
+            Scan(merge(otel_metrics_gauge|otel_metrics_sum))
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=((TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9)) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        UnionAll arms=4
+          Project [MetricName AS MetricName, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, Value AS Value]
+            Filter predicate=((MetricName =~ ".+_info") OR (replaceRegexpAll(MetricName, "[^a-zA-Z0-9_:]", "_") =~ ".+_info"))
+              Scan(merge(otel_metrics_gauge|otel_metrics_sum))
+          Filter predicate=((MetricName =~ ".+_info") OR (replaceRegexpAll(MetricName, "[^a-zA-Z0-9_:]", "_") =~ ".+_info"))
+            Project [concat(MetricName, "_count") AS MetricName, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, toFloat64(Count) AS Value]
+              Scan(otel_metrics_histogram)
+          Filter predicate=((MetricName =~ ".+_info") OR (replaceRegexpAll(MetricName, "[^a-zA-Z0-9_:]", "_") =~ ".+_info"))
+            Project [concat(MetricName, "_sum") AS MetricName, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, toFloat64(Sum) AS Value]
+              Scan(otel_metrics_histogram)
+          Filter predicate=((MetricName =~ ".+_info") OR (replaceRegexpAll(MetricName, "[^a-zA-Z0-9_:]", "_") =~ ".+_info"))
+            Project [concat(MetricName, "_bucket") AS MetricName, mapConcat(Attributes, map("le", if((le_idx > length(ExplicitBounds)), "+Inf", toString(ExplicitBounds[le_idx])))) AS Attributes, TimeUnix AS TimeUnix, toFloat64(arraySum(arraySlice(BucketCounts, 1, le_idx))) AS Value]
+              Project [MetricName AS MetricName, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, ExplicitBounds AS ExplicitBounds, BucketCounts AS BucketCounts, arrayJoin(arrayEnumerate(BucketCounts)) AS le_idx]
+                Scan(otel_metrics_histogram)
+-- sql --
+SELECT L.`MetricName` AS `MetricName`, mapConcat(mapFromArrays(groupArrayArray(mapKeys(mapFilter((k, v) -> NOT (k IN (?, ?, ?)), R.`Attributes`))), groupArrayArray(mapValues(mapFilter((k, v) -> NOT (k IN (?, ?, ?)), R.`Attributes`)))), L.`Attributes`) AS `Attributes`, L.`TimeUnix` AS `TimeUnix`, L.`Value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') PREWHERE (`MetricName` = ?))) WHERE ((`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?))))) GROUP BY `MetricName`, `Attributes`)) AS L LEFT JOIN (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM ((SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') WHERE (match(`MetricName`, ?) OR match(replaceRegexpAll(`MetricName`, ?, ?), ?)))) UNION ALL (SELECT * FROM (SELECT concat(`MetricName`, '_count') AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, toFloat64(`Count`) AS `Value` FROM (SELECT * FROM `otel_metrics_histogram`)) WHERE (match(`MetricName`, ?) OR match(replaceRegexpAll(`MetricName`, ?, ?), ?))) UNION ALL (SELECT * FROM (SELECT concat(`MetricName`, '_sum') AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, toFloat64(`Sum`) AS `Value` FROM (SELECT * FROM `otel_metrics_histogram`)) WHERE (match(`MetricName`, ?) OR match(replaceRegexpAll(`MetricName`, ?, ?), ?))) UNION ALL (SELECT * FROM (SELECT concat(`MetricName`, '_bucket') AS `MetricName`, mapConcat(`Attributes`, map(?, if((le_idx > length(`ExplicitBounds`)), ?, toString(`ExplicitBounds`[le_idx])))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, toFloat64(arraySum(arraySlice(`BucketCounts`, ?, le_idx))) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `ExplicitBounds` AS `ExplicitBounds`, `BucketCounts` AS `BucketCounts`, arrayJoin(arrayEnumerate(`BucketCounts`)) AS `le_idx` FROM (SELECT * FROM `otel_metrics_histogram`))) WHERE (match(`MetricName`, ?) OR match(replaceRegexpAll(`MetricName`, ?, ?), ?)))) WHERE ((`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?))))) GROUP BY `MetricName`, `Attributes`)) AS R ON L.`Attributes`[?] = R.`Attributes`[?] AND L.`Attributes`[?] = R.`Attributes`[?] GROUP BY L.`MetricName`, L.`Attributes`, L.`TimeUnix`, L.`Value`


### PR DESCRIPTION
Two PromQL `info()` defects that live in the same ~15-line matcher loop in `internal/promql/info_fn.go::lowerInfo`, fixed together.

Closes #1457
Closes #1458

## #1457 — `info()` never dropped the base sample

`lowerInfo` appended every non-`__name__` matcher to `dataMatchers` with no drop branch, and `internal/chsql/info_join.go` always emitted a `LeftJoin`. A base sample that matched no info series therefore passed through un-enriched.

The reference engine (`promql/info.go::combineWithInfoVector`, the `allMatchersMatchEmpty` branch) keeps such a sample only when *every* data-label matcher also matches the empty string — otherwise the enriched series it would have to produce is unrepresentable, so the sample is dropped.

`lowerInfo` now computes that predicate into a new `chplan.InfoJoin.DropUnmatched`, and `emitInfoJoin` renders `INNER JOIN` instead of `LEFT JOIN` when it is set. `info(up, {version=~".+"})` drops; `info(up)`, `info(up, {version=~".*"})`, `info(up, {version!~".+"})` keep.

## #1458 — `info()` hardcoded `__name__` equality

A second-argument `__name__` matcher had to be `MatchEqual`; anything else was rejected at lowering (`info(...) second-argument __name__ matcher must be an equality match`). Upstream's `effectiveInfoNameMatchers` (`promql/info.go:92-107`) accepts regex, negated and multi-metric selectors, and prepends a synthetic `.+_info` regex when a selector carries *only* negated name matchers — with no positive matcher to anchor the scan, upstream narrows to the conventional info-metric family rather than scanning every metric.

That function is ported verbatim, and the effective matcher set is handed straight to `lowerVectorSelector`, which already resolves unpinned / regex names via `TablesForUnknownName` + the regex-histogram fan-out.

### The merge that came with it

A selector that can match several info metrics fans one base sample out across several join rows, where upstream emits **one** sample carrying the *union* of their data labels. Shipping #1458 without handling that would have swapped a rejection for a silent wrong answer, so the new `InfoJoin.MergeInfoMetrics` folds the fan-out back on the base-sample key:

```
GROUP BY L.MetricName, L.Attributes, L.TimeUnix, L.Value
… mapFromArrays(groupArrayArray(mapKeys(extras)), groupArrayArray(mapValues(extras)))
```

It is gated on the effective `__name__` matcher set not being a lone equality, so the default `target_info` path is untouched — `test/spec/promql/info_target_info_enrichment.txtar` shows **zero** diff.

## Tests

- `TestLower_Info_DropsUnmatchedBaseSamples` — 9 cases across the empty-matching / non-empty-matching matcher split; each asserts the wanted join kind is present *and* the other is absent.
- `TestLower_Info_NameMatcherTypes` — 5 cases (equality / regex / negated / negated-regex / positive+negated) pinning both the bound name-matcher args that reach the info-side scan and whether the fold is emitted. The fold assertion pins the exact outer `GROUP BY` key list, because a bare `GROUP BY` substring is true of every `info()` query via the inner per-series-latest aggregate.
- Two new chDB-executed TXTAR fixtures, both matching upstream's answer:
  - `info_data_label_matcher_drops_unmatched.txtar` — `info(up, {version=~".+"})` over an `up{job="db"}` with no `version`-carrying companion returns only `up{job="api"}`.
  - `info_regex_name_matcher_unions_info_metrics.txtar` — `info(up, {__name__=~".+_info"})` over `target_info{version=…}` + `build_info{revision=…}` returns **one** row carrying both labels.
- `test/rejection-parity/catalogue.json` regenerated: the equality-only rejection site is gone, and `TestRejectionTriggersExerciseSites` no longer has an unreachable trigger.
- `test/spec/chplan_print.go` discriminates both new IR fields, and `InfoJoin.Equal` compares them.

## Not fixed here

Two further upstream divergences surfaced while reading `promql/info.go`; both are verified at the cited lines and filed rather than described:

- #1587 — the `ignoreSeries` pass-through (base series that are themselves info series must never be enriched *or* dropped) has no cerberus equivalent, and `DropUnmatched` gives it a new way to bite.
- #1588 — upstream errors with `conflicting label: %s` when two matched info metrics contribute the same label name with different values; the merged-map fold silently keeps one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
