### PR TITLE
fix(tempo): reject scope=all on the tag-discovery endpoints

### DIFF
--- a/internal/api/tempo/search_tags.go
+++ b/internal/api/tempo/search_tags.go
@@ -85,16 +85,17 @@ type TagScope struct {
 //   - "intrinsic" → only the intrinsic bucket
 //   - "none" or "" → every scope (default; matches AttributeScopeNone)
 //
-// Anything else is a 400. We accept "all" as a friendly alias for the
-// default — upstream Tempo doesn't define it, but the parameter is
-// otherwise free-form to clients and "all" is the obvious user
-// intuition for "give me everything", so we let it through.
+// Anything else is a 400. In particular "all" is *not* a scope:
+// upstream's `traceql.AttributeScopeFromString` folds it to
+// AttributeScopeUnknown and ParseSearchTagsRequest turns that into
+// `invalid scope: all`. Accepting it here would make cerberus the more
+// permissive backend, which silently trains clients into a request
+// shape that breaks the moment they point at real Tempo.
 const (
 	tagScopeResource  = "resource"
 	tagScopeSpan      = "span"
 	tagScopeIntrinsic = "intrinsic"
 	tagScopeNone      = "none"
-	tagScopeAll       = "all"
 )
 
 // handleSearchTags implements `GET /api/search/tags`. Returns the union
@@ -201,12 +202,11 @@ func (h *Handler) respondTags(w http.ResponseWriter, r *http.Request, v2 bool) {
 // upstream Tempo allowlist. Returns the canonical scope keyword the
 // rest of the handler branches on, or an error suitable for a 400. The
 // empty string and the literal "none" both collapse to "none" (= every
-// scope, matching upstream's AttributeScopeNone). "all" is accepted as
-// a synonym for "none" because it's the obvious user intuition; every
-// other value is rejected with the same shape upstream Tempo uses.
+// scope, matching upstream's AttributeScopeNone). Every other value —
+// "all" included — is rejected with the same shape upstream Tempo uses.
 func parseTagScope(raw string) (string, error) {
 	switch raw {
-	case "", tagScopeNone, tagScopeAll:
+	case "", tagScopeNone:
 		return tagScopeNone, nil
 	case tagScopeResource, tagScopeSpan, tagScopeIntrinsic:
 		return raw, nil

--- a/internal/api/tempo/search_tags_test.go
+++ b/internal/api/tempo/search_tags_test.go
@@ -261,7 +261,7 @@ func TestSearchTagsV2_ScopePartition(t *testing.T) {
 // TestSearchTagsV2_ScopeFilter — the `?scope=` query parameter on
 // /api/v2/search/tags must restrict the response to the requested
 // bucket. Mirrors upstream Tempo's pkg/api.ParseSearchTagsRequest
-// semantics (resource / span / intrinsic / none-or-empty / "all" alias).
+// semantics (resource / span / intrinsic / none-or-empty).
 // Before this fix the handler silently emitted every scope, so
 // Grafana's per-scope autocomplete iterated over irrelevant keys.
 func TestSearchTagsV2_ScopeFilter(t *testing.T) {
@@ -280,7 +280,6 @@ func TestSearchTagsV2_ScopeFilter(t *testing.T) {
 		{name: "intrinsic_only", query: "?scope=intrinsic", wantScopes: []string{"intrinsic"}, wantTag: "name"},
 		{name: "none_default", query: "", wantScopes: []string{"resource", "span", "intrinsic"}},
 		{name: "none_explicit", query: "?scope=none", wantScopes: []string{"resource", "span", "intrinsic"}},
-		{name: "all_alias", query: "?scope=all", wantScopes: []string{"resource", "span", "intrinsic"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -356,6 +355,58 @@ func TestSearchTagsV2_InvalidScope(t *testing.T) {
 	}
 	if !strings.Contains(er.Message, "invalid scope") {
 		t.Errorf("expected error message to mention %q, got %q", "invalid scope", er.Message)
+	}
+}
+
+// TestSearchTags_ScopeAllRejected — `scope=all` is not a Tempo scope.
+// Upstream's `traceql.AttributeScopeFromString` (pkg/traceql/
+// enum_attributes.go) maps only "", "none", "trace", "span",
+// "resource", "event", "link" and "instrumentation" to a real scope;
+// everything else folds to AttributeScopeUnknown, and
+// `pkg/api.ParseSearchTagsRequest` (pkg/api/search_tags.go:392) turns
+// that into `invalid scope: <v>` — the same shape it produces for
+// upstream's own `scope=blerg` test case.
+//
+// Cerberus used to wave "all" through as a friendly alias for the
+// default. That made cerberus the strictly more permissive backend, so
+// a client written against cerberus broke the moment it was pointed at
+// real Tempo, and the differential harness could not catch it: it only
+// sends queries both backends accept.
+//
+// Both the V1 and V2 tag endpoints route through the same
+// `parseTagScope`, so both are pinned here.
+func TestSearchTags_ScopeAllRejected(t *testing.T) {
+	t.Parallel()
+	for _, path := range []string{"/api/search/tags", "/api/v2/search/tags"} {
+		t.Run(path, func(t *testing.T) {
+			t.Parallel()
+			q := &stubQuerier{stringsBySQL: map[string][]string{
+				"`ResourceAttributes`": {"service.name"},
+				"`SpanAttributes`":     {"http.method"},
+			}}
+			srv := newServer(q, "v1.0.0-test")
+			t.Cleanup(srv.Close)
+
+			resp, err := http.Get(srv.URL + path + "?scope=all")
+			if err != nil {
+				t.Fatalf("GET: %v", err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("scope=all: status=%d want 400 body=%s", resp.StatusCode, readBody(t, resp))
+			}
+			var er tempo.ErrorResponse
+			if err := json.NewDecoder(resp.Body).Decode(&er); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if !er.Error {
+				t.Errorf("expected error=true, got %+v", er)
+			}
+			// Byte-identical to upstream's `fmt.Errorf("invalid scope: %s", scope)`.
+			if want := "invalid scope: all"; !strings.Contains(er.Message, want) {
+				t.Errorf("message = %q, want it to contain %q", er.Message, want)
+			}
+		})
 	}
 }
 
@@ -527,8 +578,8 @@ func TestSearchTagsV2_IntrinsicListMatchesTempo(t *testing.T) {
 
 // TestSearchTags_V1OmitsIntrinsicsByDefault — pins the V1 no-leak rule:
 // without explicit `?scope=intrinsic`, the envelope must carry zero
-// intrinsics regardless of whether the caller passed `?scope=none`,
-// `?scope=all`, or no scope at all. Matches upstream Tempo's
+// intrinsics regardless of whether the caller passed `?scope=none` or
+// no scope at all. Matches upstream Tempo's
 // `tag_handlers.go` carve-out (intrinsics only when `Scope ==
 // ParamScopeIntrinsic`) so the tags_v1_all compat case passes.
 func TestSearchTags_V1OmitsIntrinsicsByDefault(t *testing.T) {
@@ -541,7 +592,7 @@ func TestSearchTags_V1OmitsIntrinsicsByDefault(t *testing.T) {
 		"span:name", "span:kind", "trace:id",
 		"event:name", "link:spanID", "instrumentation:name",
 	}
-	for _, query := range []string{"", "?scope=none", "?scope=all"} {
+	for _, query := range []string{"", "?scope=none"} {
 		query := query
 		t.Run("query="+query, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
## The divergence, verified against upstream

Cerberus accepted `?scope=all` on `/api/search/tags` and `/api/v2/search/tags`. Upstream Tempo does not define it.

Checked in the vendored upstream snapshot (`grafana/tempo@v1.5.1-0.20260508211128-2f74ea818de1`) rather than inferred:

`pkg/api/search_tags.go:391-394` rejects any scope that folds to `AttributeScopeUnknown`:

```go
attScope := traceql.AttributeScopeFromString(scope)
if attScope == traceql.AttributeScopeUnknown && scope != ParamScopeIntrinsic {
    return nil, fmt.Errorf("invalid scope: %s", scope)
}
```

`pkg/traceql/enum_attributes.go:46-67` maps exactly eight strings to a real scope — `trace`, `span`, `resource`, `event`, `link`, `instrumentation`, `""`, `none` — and returns `AttributeScopeUnknown` for everything else. `"all"` is in the everything-else bucket, so upstream answers `invalid scope: all`. Upstream's own table test (`pkg/api/search_tags_test.go:82-116`) pins the same behaviour for `scope=blerg`.

## Why it mattered

The old comment argued `all` is "the obvious user intuition". The direction of the leniency is the problem: cerberus was the strictly *more* permissive backend, so a client written against cerberus using `scope=all` breaks the moment it is pointed at real Tempo. Being permissive here silently trains callers into a non-portable request shape.

It is also invisible to the differential harness by construction — `compatibility/tempo` sends each corpus case to both backends and compares successful responses, so a request cerberus accepts and Tempo rejects is not a shape the corpus can generate.

## The change

`parseTagScope` drops the alias and the now-unused `tagScopeAll` constant. Both endpoints route through that one function, so V1 and V2 are fixed together, and the error body is byte-identical to upstream's (`tagScopeError.Error()` is `"invalid scope: " + raw`, upstream's is `fmt.Errorf("invalid scope: %s", scope)`).

Two existing tests pinned the old acceptance and are corrected rather than deleted: the `all_alias` row in `TestSearchTagsV2_ScopeFilter`, and `?scope=all` in `TestSearchTags_V1OmitsIntrinsicsByDefault`'s query loop.

Nothing else in the tree referenced `scope=all` — no doc, no corpus case, no dashboard, no e2e spec (`grep -rn 'scope=all'` over `*.go`/`*.md`/`*.json`/`*.txtar`/`*.ts`/`*.yaml`/`*.sh` returns only the new test).

## Proof the new test fails without the fix

`TestSearchTags_ScopeAllRejected` covers both endpoints. Stashing **only** `internal/api/tempo/search_tags.go` (keeping the test) and running it on the unfixed handler:

```text
--- FAIL: TestSearchTags_ScopeAllRejected (0.00s)
    --- FAIL: TestSearchTags_ScopeAllRejected//api/v2/search/tags (0.00s)
        search_tags_test.go:396: scope=all: status=200 want 400 body={"scopes":[{"name":"resource","tags":["service.name"]},{"name":"span","tags":["http.method"]},{"name":"intrinsic","tags":["duration","event:name",...,"trace:rootService"]}]}
    --- FAIL: TestSearchTags_ScopeAllRejected//api/search/tags (0.00s)
        search_tags_test.go:396: scope=all: status=200 want 400 body={"tagNames":["http.method","service.name"]}
FAIL
FAIL	github.com/tsouza/cerberus/internal/api/tempo	0.008s
```

With the fix restored, the whole `TestSearchTags*` set passes (28 tests).

## Found while verifying, filed separately

The same allowlist diverges in the **opposite** direction too: upstream accepts `scope=trace`, `scope=event`, `scope=link` and `scope=instrumentation`, and cerberus 400s on all four. That is not a one-line correction — it needs a decision about what cerberus returns for scopes whose attributes it has no column for, validated against reference Tempo. Tracked in #1593; deliberately not bundled here, because bundling it would have made this PR's upstream-parity claim depend on an unresolved semantics question.

Closes #1543

🤖 Generated with [Claude Code](https://claude.com/claude-code)
