### PR TITLE
ci: fail the build when an image-acquiring job has not logged in

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -1205,6 +1205,34 @@ uncomputable-diff fallback — cannot drift between the lanes that use it.
   - Args: the image refs to acquire.
   - Env: `IMAGE_PULL_BACKOFF_SECONDS` (optional; default `3`).
   - Exit: `0` when every ref is in the local daemon, `1` as soon as one is not.
+- **`assert-image-jobs-authenticate.mjs`** — the required `check` lane. Fails
+  when a job that acquires an image has not logged in to the registry it
+  acquires from. An anonymous pull is not an error: it succeeds until the shared
+  per-runner-IP quota happens to be spent, and then surfaces as a 429 in an
+  unrelated lane, which is why the mirror shipped and three jobs were still on
+  the anonymous path afterwards — nothing in CI was asking the question.
+  - Resolves what a step DOES rather than what it says: through `just` recipes
+    and their variables, through the `.mjs` modules and the commands they spawn,
+    through a local composite action's own steps, and through `docker compose`
+    and `k3d`. Grepping for `docker pull` would see almost none of it.
+  - "Logs in" is not "uses `docker/login-action`". A `run:` step whose script
+    spawns `docker login` counts, with the registry read off the step's `env:`
+    (unset means Docker Hub, matching `docker login` itself) — so
+    `registry-login.mjs` is a login on the same terms.
+  - There is no allow-list and no exempted job name. The one shape that looks
+    like an acquisition and is not — this lane's own `node --test` of a module
+    that pulls images — is excluded because `node --test` imports a module and
+    runs its tests rather than its CLI, which is a fact about the command and
+    holds for every module.
+  - Env: `WORKFLOW_DIR` (optional; default `.github/workflows`), `REPO_ROOT`
+    (optional; default the working directory).
+  - Exit: `0` when every acquiring job is authenticated, `1` on a violation, on
+    a reference that resolves to nothing, or when no acquiring job is found at
+    all — a scan that reads nothing must not report the same green as a clean
+    tree.
+  - Gated by `assert-image-jobs-authenticate.test.mjs`, which strips a login
+    step out of the real workflow text and asserts each rule goes red. A gate
+    that cannot fail is a gap, not coverage.
 - **`mirror-images.mjs`** — `mirror-images.yml` (daily cron, `workflow_dispatch`,
   and pushes to the mirror's own files). Copies every ref in `lib/mirror.mjs`'s
   inventory into cerberus's GHCR namespace with `docker buildx imagetools

--- a/.github/scripts/assert-image-jobs-authenticate.mjs
+++ b/.github/scripts/assert-image-jobs-authenticate.mjs
@@ -59,7 +59,7 @@
 // any reference the resolver could not follow.
 
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
-import { isAbsolute, join, resolve as resolvePath } from 'node:path';
+import { basename, isAbsolute, join, resolve as resolvePath } from 'node:path';
 import process from 'node:process';
 import { pathToFileURL } from 'node:url';
 
@@ -351,6 +351,21 @@ export function isDockerHubRef(ref) {
   return !(first.includes('.') || first.includes(':'));
 }
 
+// `docker compose`'s value-taking GLOBAL flags — the ones that may appear
+// before the verb and swallow the token after them.
+const composeValueFlags = new Set([
+  '-f',
+  '--file',
+  '-p',
+  '--project-name',
+  '--project-directory',
+  '--env-file',
+  '--profile',
+  '--parallel',
+  '--progress',
+  '--ansi',
+]);
+
 // `docker login`'s only value-taking flags. Needed because the registry is a
 // trailing POSITIONAL, so "the first token that is not a flag" picks up a flag's
 // value instead and reports a login to a registry named `tsouza`.
@@ -602,7 +617,19 @@ function arrayBinding(source, name) {
 
 // A `Findings` accumulator: what a job does, gathered across every hop.
 function newFindings() {
-  return { acquisitions: [], logins: [], viaSharedPolicy: false, refs: new Set(), unresolved: [] };
+  return {
+    acquisitions: [],
+    logins: [],
+    viaSharedPolicy: false,
+    refs: new Set(),
+    unresolved: [],
+    // R4's bookkeeping: which compose models the shared policy was applied to,
+    // which ones were materialised, and how many acquisitions were writes INTO
+    // the mirror rather than reads that the mirror could have served.
+    composePolicyFiles: new Set(),
+    composeMaterialised: [],
+    mirrorWrites: 0,
+  };
 }
 
 class Resolver {
@@ -739,9 +766,37 @@ class Resolver {
       return;
     }
     if (sub === 'compose') {
-      const verb = rest.slice(rest.indexOf('compose') + 1).find((t) => !t.startsWith('-'));
+      const after = rest.slice(rest.indexOf('compose') + 1);
+      // The verb sits after the global flags, and the value-taking ones must be
+      // stepped over: `docker compose -f x.yml up` otherwise reads `x.yml` as
+      // the verb, matches nothing, and the materialisation vanishes from the
+      // scan entirely.
+      let verb;
+      for (let i = 0; i < after.length; i++) {
+        if (composeValueFlags.has(after[i])) {
+          i++;
+          continue;
+        }
+        if (after[i].startsWith('-')) continue;
+        verb = after[i];
+        break;
+      }
       if (['up', 'pull', 'create', 'run', 'build'].includes(verb)) {
         findings.acquisitions.push(`docker compose ${verb}`);
+        // `-f` may repeat. No `-f` means compose's own default lookup in the
+        // working directory, recorded as "the job's default model" — the cwd is
+        // not tracked across a script's `cd`, so the models are matched by file
+        // name. Looser than a path comparison, and deliberately so: the failure
+        // that matters is a materialisation with NO pre-pull anywhere in the
+        // job, and a gate that fires on a path it merely failed to follow would
+        // earn itself an exemption.
+        const files = [];
+        for (let i = 0; i < after.length; i++) {
+          if ((after[i] === '-f' || after[i] === '--file') && after[i + 1] !== undefined) {
+            files.push(basename(unquote(expandVars(after[i + 1], scope) ?? after[i + 1])));
+          }
+        }
+        findings.composeMaterialised.push(files);
       }
       return;
     }
@@ -756,6 +811,11 @@ class Resolver {
       const verb = rest.slice(rest.indexOf('imagetools') + 1).find((t) => !t.startsWith('-'));
       if (['create', 'inspect'].includes(verb)) {
         findings.acquisitions.push(`docker buildx imagetools ${verb}`);
+        // A write INTO a registry, not a read the mirror could have served.
+        // R4 asks that reads route through the mirror; asking it of the job
+        // that POPULATES the mirror is circular, and this is the structural
+        // fact that says so rather than the job's name.
+        findings.mirrorWrites++;
         for (const t of rest.slice(rest.indexOf(verb) + 1)) this.noteRef(t, scope, findings);
       }
       return;
@@ -830,7 +890,15 @@ class Resolver {
       findings.acquisitions.push(`${script} (shared mirror-first policy)`);
       for (const ref of policyRefs(source)) this.noteRef(ref, scope, findings);
       // Refs handed to the script on argv, e.g. `pull-images.mjs golang:1.26`.
-      for (const t of rest.slice(scriptIdx + 1)) this.noteRef(t, scope, findings);
+      for (const t of rest.slice(scriptIdx + 1)) {
+        this.noteRef(t, scope, findings);
+        // A compose FILE handed to the shared policy is the pre-pull that puts
+        // that model's images in the daemon ahead of `up`. Recorded structurally
+        // — the policy was applied to this model — rather than by the name of
+        // the module that applied it.
+        const arg = unquote(expandVars(t, scope) ?? t);
+        if (/\.ya?ml$/.test(arg)) findings.composePolicyFiles.add(basename(arg));
+      }
     }
     const before = findings.acquisitions.length;
     for (const spawned of spawnedCommands(source)) {
@@ -967,6 +1035,35 @@ export function violationsFor(jobId, findings) {
         'the mirror is unreadable, so every acquisition silently falls back to Docker Hub',
     );
   }
+
+  // R4 — the acquisitions must run ON the authenticated, mirror-first path, not
+  // merely alongside a login step.
+  //
+  // A login step is necessary and NOT sufficient, and there is a run that proves
+  // it: 30701755787 logged in successfully and was refused as UNAUTHENTICATED
+  // one second later, because `docker compose`'s own pull path does not carry
+  // the credentials the CLI wrote. A gate that stopped at login-presence would
+  // have passed that job — a hollow green on the exact failure it is named
+  // after. So presence is asked above, and reachability is asked here.
+  for (const files of findings.composeMaterialised) {
+    const covered =
+      files.length === 0
+        ? findings.composePolicyFiles.size > 0
+        : files.every((f) => findings.composePolicyFiles.has(f));
+    if (covered) continue;
+    const which = files.length === 0 ? 'its compose model' : files.join(', ');
+    out.push(
+      `${jobId}: materialises ${which} without pre-pulling it through the shared mirror-first ` +
+        "policy — compose's own pull path carries neither the login nor the mirror, so those " +
+        'images are fetched anonymously from Docker Hub however the job is authenticated',
+    );
+  }
+  if (!findings.viaSharedPolicy && findings.acquisitions.length > findings.mirrorWrites) {
+    out.push(
+      `${jobId}: acquires images (${how}) without going through the shared mirror-first policy — ` +
+        'a login raises the quota it spends, the mirror is what stops it spending that quota at all',
+    );
+  }
   return out;
 }
 
@@ -1024,13 +1121,15 @@ function main() {
   for (const v of violations) error(v);
   if (unresolved.length > 0 || violations.length > 0) {
     error(
-      'every job that acquires an image must log in to the registries it acquires from. Add the ' +
-        'Docker Hub login (and the ghcr.io mirror login, when the job pulls through ' +
-        '.github/scripts/lib/registry.mjs) to the job above, ahead of its first acquisition.',
+      'every job that acquires an image must acquire it over the authenticated, mirror-first path. ' +
+        'Add the Docker Hub and ghcr.io logins to the job above ahead of its first acquisition, and ' +
+        'route the acquisition itself through .github/scripts/lib/registry.mjs — for a compose ' +
+        'stack that means pre-pulling the model with compose-pull-images.mjs before `up`, because ' +
+        "compose's own pull path carries neither the login nor the mirror.",
     );
     process.exit(1);
   }
-  notice(`${acquiring.length} image-acquiring jobs, all authenticated`);
+  notice(`${acquiring.length} image-acquiring jobs, all on the authenticated mirror-first path`);
   process.exit(0);
 }
 

--- a/.github/scripts/assert-image-jobs-authenticate.mjs
+++ b/.github/scripts/assert-image-jobs-authenticate.mjs
@@ -1009,14 +1009,38 @@ function defaultInputs(lines) {
 // The rules.
 // ---------------------------------------------------------------------------
 
+// A login's registry is matched by HOST, never by prefix or raw string. Prefix
+// matching is the wider hole -- `startsWith('ghcr.io')` also accepts
+// `ghcr.io.example.com`, a host somebody else controls, which would read as a
+// mirror login. Raw-string matching is the narrower one: it misses the
+// equivalent spellings `docker login` itself accepts, so a job that really is
+// authenticated to Docker Hub as `https://index.docker.io/v1/` would be
+// reported as anonymous.
+//
+// Returns '' for an unset registry, because `docker login` with no argument
+// targets Docker Hub, and null for a value that is not a host at all -- null
+// equals no registry in the set, so an unparseable spelling matches nothing
+// rather than collapsing into the '' that means Docker Hub.
+function registryHost(registry) {
+  const raw = String(registry ?? '')
+    .trim()
+    .toLowerCase();
+  if (raw === '') return '';
+  try {
+    return new URL(raw.includes('://') ? raw : `https://${raw}`).hostname;
+  } catch {
+    return null;
+  }
+}
+
 export function violationsFor(jobId, findings) {
   const out = [];
   if (findings.acquisitions.length === 0) return out;
 
   const how = [...new Set(findings.acquisitions)].join(', ');
   const hasAny = findings.logins.length > 0;
-  const hasHub = findings.logins.some((l) => dockerHubRegistries.has(l.registry));
-  const hasMirror = findings.logins.some((l) => l.registry.startsWith(mirrorHost));
+  const hasHub = findings.logins.some((l) => dockerHubRegistries.has(registryHost(l.registry)));
+  const hasMirror = findings.logins.some((l) => registryHost(l.registry) === mirrorHost);
 
   if (!hasAny) {
     out.push(`${jobId}: acquires images (${how}) with no registry login step — the pull is anonymous`);

--- a/.github/scripts/assert-image-jobs-authenticate.mjs
+++ b/.github/scripts/assert-image-jobs-authenticate.mjs
@@ -1,0 +1,1037 @@
+// assert-image-jobs-authenticate — every CI job that acquires a container image
+// must authenticate to the registries it can acquire from, BEFORE it pulls.
+//
+// WHY THIS EXISTS. An anonymous pull is not an error. It succeeds, on most
+// runs, for as long as the shared per-runner-IP quota happens to have room in
+// it — and then one day it is refused with a 429 and the job reads as flake.
+// That is why #1572 could fix a whole class of these by construction and
+// `e2e.yml`'s `startup-bench` could still be sitting on the anonymous path
+// afterwards: nobody was wrong, the property simply was not asserted anywhere.
+// "Does this job authenticate before it pulls" is a question about the shape of
+// a workflow, so it can be answered by reading the workflow, and a question a
+// gate can answer is not a question that should keep being rediscovered from an
+// outage.
+//
+// WHAT IT ASSERTS. Three rules, each derived from the acquisition MECHANISM the
+// job uses rather than from a list of job names:
+//
+//   R1  A job that acquires any image at all has at least one registry login.
+//   R2  A job that acquires an image whose ref resolves to a Docker Hub ref
+//       (no registry host in the name) has a Docker Hub login.
+//   R3  A job that acquires through the shared mirror-first policy
+//       (`pullImageWithRetry` in lib/registry.mjs, which reaches for the
+//       PRIVATE GHCR mirror before Docker Hub) has a ghcr.io login. Without it
+//       the mirror is unreadable and every acquisition silently degrades to the
+//       anonymous Docker Hub quota the mirror exists to stop spending.
+//
+// THERE IS NO ALLOW-LIST, and that is the substance of the module rather than a
+// stylistic preference. The obvious way to write this gate is a regex for
+// `docker pull` over each job's text plus a list of the jobs known to be fine —
+// and such a list is where a real regression goes to hide, because the cheapest
+// way to make a new red job green is to append its name. So the one shape that
+// looked like a violation and is not — `ci.yml`'s discipline lane running
+// `node --test .github/scripts/compose-pull-images.test.mjs`, which mentions an
+// image-pulling module and pulls nothing — is excluded by a STRUCTURAL fact
+// about the command, not by its name: `node --test X` hands X to the node test
+// runner, which imports the module rather than running its CLI (every module
+// here guards `main` behind an `import.meta.url` check). Anything that has to be
+// excluded has to be excluded by a fact of that kind.
+//
+// HOW IT READS A JOB. A step's text is not evidence on its own — most of the
+// acquisitions in this repo are two or three hops from the workflow. So each
+// step's `run:` is tokenised into commands and every command is resolved to a
+// fixpoint: `just <recipe>` expands to the recipe body out of the Justfile (with
+// `{{VAR}}` bound from the Justfile's own assignments and `{{PARAM}}` from the
+// call site), `node <script.mjs>` expands to the script's spawned commands and
+// its `pullImageWithRetry` calls, `uses: ./.github/actions/<x>` expands to the
+// composite action's own steps, and a wrapper that takes a command on argv
+// (`build-with-registry-retry.mjs docker compose up`) expands to the command it
+// wraps. A reference this resolver cannot follow is reported as an error rather
+// than passed over: a gate that cannot read a step must not report that step
+// clean.
+//
+// ENV CONTRACT
+//   WORKFLOW_DIR    — directory of workflows to scan. Default `.github/workflows`.
+//   REPO_ROOT       — repository root the Justfile / scripts / actions resolve
+//                     against. Default `process.cwd()`.
+//
+// Exit: 0 when every image-acquiring job authenticates, 1 on any violation or on
+// any reference the resolver could not follow.
+
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { isAbsolute, join, resolve as resolvePath } from 'node:path';
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+
+import { error, log, notice } from './lib/gh.mjs';
+
+// The acquisition primitive R3 is about. A script that imports this name — at
+// any depth through relative imports — acquires through the GHCR mirror first,
+// so the job running it needs mirror credentials whatever ref it ends up
+// naming. Spelled once here because it is the join between this gate and
+// lib/registry.mjs; if the primitive is ever renamed, this gate goes quiet and
+// the rename is the only place to notice.
+const sharedPolicySymbol = 'pullImageWithRetry';
+
+// Docker Hub under the two names the toolchain uses for it. `docker login` with
+// no host argument targets exactly this, which is why the empty registry is
+// spelled as a value here rather than handled as a missing one.
+const dockerHubRegistries = new Set(['', 'docker.io', 'index.docker.io', 'registry-1.docker.io']);
+
+// The mirror lives in GHCR, so this is the host R3 requires. Read off
+// lib/mirror.mjs's default `mirrorRegistry` rather than restated, so a mirror
+// that moves cannot leave the gate asserting a login to the old host.
+const mirrorHost = 'ghcr.io';
+
+// The two names a step uses for "this checkout". Both are the repository root
+// on a runner, so binding them to it is what lets
+// `node $GITHUB_WORKSPACE/.github/scripts/pull-buildkit-image.mjs` resolve to
+// the file this scan is reading.
+const repoRootVars = { GITHUB_WORKSPACE: '.', REPO_ROOT: '.' };
+
+// How deep a command may resolve before the resolver calls it a cycle. Recipes
+// call recipes and scripts spawn scripts, so some depth is normal; a chain
+// longer than this is a loop, and a loop must fail loudly rather than hang.
+const maxResolutionDepth = 12;
+
+// ---------------------------------------------------------------------------
+// YAML — the narrow slice of it these workflows use.
+//
+// Only `node:` builtins are available here (see the repo rule on CI scripts), so
+// this reads the block structure by indentation rather than parsing YAML in
+// general. That is sound for the shapes involved — a mapping of jobs, each with
+// a sequence of step mappings — and every function below fails rather than
+// guesses when the text does not have the shape it expects.
+// ---------------------------------------------------------------------------
+
+function indentOf(line) {
+  return line.length - line.trimStart().length;
+}
+
+function isBlank(line) {
+  return line.trim() === '' || line.trimStart().startsWith('#');
+}
+
+// blockUnder — the lines nested under the line at `start`, i.e. everything up to
+// the next non-blank line at or above its indentation.
+//
+// Blank and comment lines are buffered rather than emitted on sight. A comment
+// between two steps sits at the OUTER indentation, so emitting it immediately
+// would splice it into the block that precedes it — and a `run: |` body that has
+// swallowed the next step's explanatory comment contains whatever commands that
+// prose names in backticks. That is not a hypothetical: it made this resolver
+// report `just e2e-up`` (trailing backtick and all) as a recipe it could not
+// find.
+function blockUnder(lines, start) {
+  const base = indentOf(lines[start]);
+  const out = [];
+  let pending = [];
+  for (let i = start + 1; i < lines.length; i++) {
+    if (isBlank(lines[i])) {
+      pending.push(lines[i]);
+      continue;
+    }
+    if (indentOf(lines[i]) <= base) break;
+    out.push(...pending, lines[i]);
+    pending = [];
+  }
+  return out;
+}
+
+function findKey(lines, key, atIndent = null) {
+  const re = new RegExp(`^(\\s*)${key}:(\\s|$)`);
+  for (let i = 0; i < lines.length; i++) {
+    if (isBlank(lines[i])) continue;
+    const m = re.exec(lines[i]);
+    if (!m) continue;
+    if (atIndent !== null && m[1].length !== atIndent) continue;
+    return i;
+  }
+  return -1;
+}
+
+// scalarAt — the value of `key:` at the top level of `lines`, handling the three
+// forms these workflows use: an inline scalar, a `|`/`>` block, and a quoted
+// inline scalar.
+function scalarAt(lines, key) {
+  const i = findKey(lines, key, minIndent(lines));
+  if (i === -1) return null;
+  const inline = lines[i].slice(lines[i].indexOf(':') + 1).trim();
+  if (inline !== '' && inline !== '|' && inline !== '>' && inline !== '|-' && inline !== '>-') {
+    return unquote(inline);
+  }
+  return blockUnder(lines, i)
+    .map((l) => l.slice(Math.min(indentOf(lines[i]) + 1, l.length)))
+    .join('\n');
+}
+
+function minIndent(lines) {
+  let min = null;
+  for (const l of lines) {
+    if (isBlank(l)) continue;
+    const ind = indentOf(l);
+    if (min === null || ind < min) min = ind;
+  }
+  return min ?? 0;
+}
+
+function unquote(value) {
+  const t = value.trim();
+  if ((t.startsWith('"') && t.endsWith('"')) || (t.startsWith("'") && t.endsWith("'"))) {
+    return t.slice(1, -1);
+  }
+  return t;
+}
+
+// mappingAt — the flat `key: value` pairs directly under `key:`. Used for `env:`
+// and `with:`, neither of which nests in these workflows.
+function mappingAt(lines, key) {
+  const i = findKey(lines, key, minIndent(lines));
+  if (i === -1) return {};
+  const out = {};
+  for (const line of blockUnder(lines, i)) {
+    if (isBlank(line)) continue;
+    const m = /^\s*([A-Za-z0-9_.-]+):\s*(.*)$/.exec(line);
+    if (m) out[m[1]] = unquote(m[2]);
+  }
+  return out;
+}
+
+// splitSteps — a `steps:` block into one line-array per step. A step begins at a
+// `- ` item at the sequence's own indentation; everything until the next one
+// belongs to it. The leading `- ` is replaced with spaces so each step's lines
+// form a plain mapping the helpers above can read.
+function splitSteps(stepsBlock) {
+  const itemIndent = minIndent(stepsBlock);
+  const steps = [];
+  let current = null;
+  for (const line of stepsBlock) {
+    const isItem = !isBlank(line) && indentOf(line) === itemIndent && /^\s*-\s/.test(line);
+    if (isItem) {
+      if (current) steps.push(current);
+      current = [line.replace(/^(\s*)-(\s)/, '$1 $2')];
+      continue;
+    }
+    if (current) current.push(line);
+  }
+  if (current) steps.push(current);
+  return steps;
+}
+
+// parseWorkflow — { env, jobs: [{ name, env, steps }] }.
+export function parseWorkflow(text) {
+  const lines = text.split('\n');
+  const jobsIdx = findKey(lines, 'jobs', 0);
+  if (jobsIdx === -1) return { env: {}, jobs: [] };
+
+  const topEnvIdx = findKey(lines, 'env', 0);
+  const workflowEnv = topEnvIdx === -1 ? {} : mappingAt(lines.slice(topEnvIdx), 'env');
+
+  const jobsBlock = blockUnder(lines, jobsIdx);
+  const jobIndent = minIndent(jobsBlock);
+  const jobs = [];
+  let current = null;
+  for (const line of jobsBlock) {
+    if (!isBlank(line) && indentOf(line) === jobIndent) {
+      const m = /^\s*([A-Za-z0-9_-]+):\s*$/.exec(line);
+      if (m) {
+        if (current) jobs.push(current);
+        current = { name: m[1], lines: [] };
+        continue;
+      }
+    }
+    if (current) current.lines.push(line);
+  }
+  if (current) jobs.push(current);
+
+  return {
+    env: workflowEnv,
+    jobs: jobs.map((job) => {
+      const stepsIdx = findKey(job.lines, 'steps', minIndent(job.lines));
+      const steps = stepsIdx === -1 ? [] : splitSteps(blockUnder(job.lines, stepsIdx));
+      return { name: job.name, env: mappingAt(job.lines, 'env'), steps };
+    }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Shell — splitting a `run:` body into commands, and a command into argv.
+// ---------------------------------------------------------------------------
+
+// tokenise — argv for one command. Quotes group, and nothing else is
+// interpreted: the caller wants the words, not a shell.
+export function tokenise(command) {
+  const out = [];
+  let token = '';
+  let quote = null;
+  let started = false;
+  for (const ch of command) {
+    if (quote) {
+      if (ch === quote) quote = null;
+      else token += ch;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      started = true;
+      continue;
+    }
+    if (/\s/.test(ch)) {
+      if (started) out.push(token);
+      token = '';
+      started = false;
+      continue;
+    }
+    token += ch;
+    started = true;
+  }
+  if (started) out.push(token);
+  return out;
+}
+
+// splitCommands — a shell script body into individual commands. Joins
+// backslash-continued lines, drops comments, and splits on the separators that
+// start a new command. Redirections and subshell punctuation are left in the
+// token stream; they never occupy argv[0] in this tree, so they cost nothing.
+export function splitCommands(script) {
+  const joined = String(script ?? '')
+    .replace(/\\\n/g, ' ')
+    .split('\n')
+    .map((l) => (l.trimStart().startsWith('#') ? '' : l))
+    .join('\n');
+  return joined
+    .split(/\n|&&|\|\||;|(?<!\|)\|(?!\|)/)
+    .map((c) => c.trim())
+    .filter((c) => c !== '');
+}
+
+// stripPrefixes — leading noise that is not the program: a Justfile's `@`
+// silencer, `sudo`, `env`, and inline `KEY=value` assignments. The assignments
+// are returned, because a `run:` that sets an image ref inline is naming a ref
+// the resolver wants.
+function stripPrefixes(argv) {
+  const assignments = {};
+  let i = 0;
+  if (argv[0]?.startsWith('@')) argv = [argv[0].slice(1), ...argv.slice(1)];
+  while (i < argv.length) {
+    const t = argv[i];
+    if (t === 'sudo' || t === 'env' || t === 'command' || t === '-') {
+      i++;
+      continue;
+    }
+    const m = /^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/.exec(t);
+    if (m) {
+      assignments[m[1]] = m[2];
+      i++;
+      continue;
+    }
+    break;
+  }
+  return { argv: argv.slice(i).filter((t) => t !== ''), assignments };
+}
+
+// ---------------------------------------------------------------------------
+// Refs.
+// ---------------------------------------------------------------------------
+
+// isDockerHubRef — a ref with no registry host. Docker's own rule: the first
+// path segment is a host only when it contains a `.` or a `:`, or is
+// `localhost`. Everything else is Docker Hub, which is why `golang:1.26` and
+// `clickhouse/clickhouse-server:26.5` both spend that quota.
+export function isDockerHubRef(ref) {
+  const text = String(ref);
+  // No slash at all is an official library image (`golang:1.26`). Testing the
+  // first segment before checking for the slash reads the TAG's colon as a
+  // registry port, which quietly classifies the single most-pulled image in
+  // this repo as "not Docker Hub".
+  const slash = text.indexOf('/');
+  if (slash === -1) return true;
+  const first = text.slice(0, slash);
+  if (first === 'localhost') return false;
+  return !(first.includes('.') || first.includes(':'));
+}
+
+// `docker login`'s only value-taking flags. Needed because the registry is a
+// trailing POSITIONAL, so "the first token that is not a flag" picks up a flag's
+// value instead and reports a login to a registry named `tsouza`.
+const dockerLoginValueFlags = new Set(['-u', '--username', '-p', '--password']);
+
+// loginRegistry — which registry a `docker login` argv authenticates to.
+//
+// The empty string means Docker Hub, and it is the answer in two distinct
+// cases that `docker` itself treats identically: no host argument at all, and a
+// host argument that came from an environment variable the step never set.
+// `docker login` with no host goes to Docker Hub, so a `${REGISTRY}` that is
+// unset is a Docker Hub login rather than an unknown one — which is exactly how
+// `registry-login.mjs` documents its own contract.
+export function loginRegistry(argv, scope) {
+  let host;
+  for (let i = 0; i < argv.length; i++) {
+    const t = argv[i];
+    if (dockerLoginValueFlags.has(t)) {
+      i++;
+      continue;
+    }
+    if (t.startsWith('-')) continue;
+    host = t;
+    break;
+  }
+  if (host === undefined) return '';
+  const expanded = expandVars(host, scope);
+  if (expanded !== null) return expanded.trim();
+  // A bare `$NAME` / `${NAME}` that the scope does not define is unset, not
+  // unknowable. A GitHub `${{ … }}` expression is genuinely unknowable and is
+  // NOT read as Docker Hub, because guessing there would invent a login.
+  return /^\$\{?[A-Za-z_][A-Za-z0-9_]*\}?$/.test(host) ? '' : host.trim();
+}
+
+// looksLikeImageRef — used to tell an image argument from a file argument on a
+// script's argv (`pull-images.mjs clickhouse/clickhouse-server:26.5` versus
+// `compose-pull-images.mjs docker-compose.yml`). Deliberately conservative: a
+// token it declines only costs R2 a ref it could have checked, never a false
+// violation.
+export function looksLikeImageRef(token) {
+  const t = String(token);
+  if (t === '' || t.startsWith('-')) return false;
+  if (/\.(ya?ml|json|mjs|js|sh|txt|md)$/.test(t)) return false;
+  if (t.includes('$') || t.includes('{')) return false;
+  if (!/^[a-z0-9][a-z0-9._/-]*(:[\w][\w.-]*)?(@sha256:[a-f0-9]+)?$/.test(t)) return false;
+  return t.includes(':') || t.includes('/');
+}
+
+// expandVars — `$VAR`, `${VAR}` and a Justfile's `{{VAR}}` against a scope.
+// Returns null when a name is unresolvable, which is a real answer: an
+// unresolved ref is not checked against R2 rather than guessed at.
+export function expandVars(text, scope) {
+  let out = String(text);
+  let unresolved = false;
+  out = out.replace(/\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}\}/g, (_, name) => {
+    if (name in scope) return scope[name];
+    unresolved = true;
+    return '';
+  });
+  out = out.replace(/\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?/g, (_, name) => {
+    if (name in scope) return scope[name];
+    unresolved = true;
+    return '';
+  });
+  // A GitHub expression is never statically known.
+  if (/\$\{\{/.test(text)) unresolved = true;
+  return unresolved ? null : out;
+}
+
+// ---------------------------------------------------------------------------
+// Justfile.
+// ---------------------------------------------------------------------------
+
+function parseJustfile(text) {
+  const vars = {};
+  const recipes = new Map();
+  const lines = text.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const v = /^([A-Za-z_][A-Za-z0-9_]*)\s*:=\s*(.*)$/.exec(line);
+    if (v) {
+      vars[v[1]] = unquote(v[2].trim());
+      continue;
+    }
+    // A recipe header sits at column 0 and its body is indented. Dependencies
+    // after the colon are other recipes and are followed too.
+    const r = /^([A-Za-z_][A-Za-z0-9_-]*)((?:\s+[+*]?[A-Za-z_][A-Za-z0-9_]*(?:="[^"]*")?)*)\s*:(.*)$/.exec(line);
+    if (!r || line.startsWith(' ') || line.startsWith('\t')) continue;
+    const params = (r[2].match(/[+*]?[A-Za-z_][A-Za-z0-9_]*(?:="[^"]*")?/g) ?? []).map((p) => {
+      const [name, dflt] = p.replace(/^[+*]/, '').split('=');
+      return { name, dflt: dflt === undefined ? null : unquote(dflt) };
+    });
+    const deps = r[3].trim().split(/\s+/).filter((d) => d !== '' && !d.startsWith('#'));
+    const body = [];
+    for (let j = i + 1; j < lines.length; j++) {
+      if (lines[j].trim() === '') continue;
+      if (!/^\s/.test(lines[j])) break;
+      body.push(lines[j].trim());
+    }
+    recipes.set(r[1], { params, deps, body });
+  }
+  return { vars, recipes };
+}
+
+// ---------------------------------------------------------------------------
+// Node scripts — the commands a `.mjs` module spawns, and whether it acquires
+// through the shared mirror-first policy.
+// ---------------------------------------------------------------------------
+
+// stringLiterals — the quoted strings inside one bracketed argument list.
+function stringLiterals(text) {
+  return [...text.matchAll(/(['"])((?:\\.|(?!\1).)*)\1/g)].map((a) => a[2]);
+}
+
+// envReadInto — the environment variable a local name is assigned from, if any.
+// `const registry = (process.env.REGISTRY ?? '').trim();` answers `REGISTRY`.
+// The point is not the assignment: it is that an argv token sourced this way is
+// knowable from the STEP's `env:` block, so a value the module cannot state
+// statically is still resolvable where it is actually set.
+function envReadInto(source, name) {
+  const re = new RegExp(`\\b(?:const|let|var)\\s+${name}\\s*=[^;\\n]*process\\.env\\.([A-Za-z_][A-Za-z0-9_]*)`);
+  const m = re.exec(source);
+  return m === null ? null : m[1];
+}
+
+// resolveArgArray — the argv a module builds in a named variable before
+// spawning it. Written separately from the inline-array case because the two
+// shapes carry the same meaning and only one of them is greppable: a script
+// that must append an argument conditionally cannot write its argv as a
+// literal, and reading only literals would make the built-up form invisible.
+// Tokens pushed from the environment come back as `${NAME}` so the caller
+// resolves them against the step's own `env:`.
+function resolveArgArray(source, name) {
+  const decl = new RegExp(`\\b(?:const|let|var)\\s+${name}\\s*=\\s*\\[([^\\]]*)\\]`).exec(source);
+  if (decl === null) return null;
+  const args = stringLiterals(decl[1]);
+  for (const m of source.matchAll(new RegExp(`\\b${name}\\.push\\(([^)]*)\\)`, 'g'))) {
+    const arg = m[1].trim();
+    const lit = /^(['"])((?:\\.|(?!\1).)*)\1$/.exec(arg);
+    if (lit) {
+      args.push(lit[2]);
+      continue;
+    }
+    const env = /^[A-Za-z_$][\w$]*$/.test(arg) ? envReadInto(source, arg) : null;
+    if (env !== null) args.push(`\${${env}}`);
+  }
+  return args;
+}
+
+// spawnedCommands — the argv shapes a module hands to the shared subprocess
+// helpers. Every registry interaction in this tree is written this way, with the
+// program and the verb as string literals, which is what makes it readable
+// statically.
+export function spawnedCommands(source) {
+  const out = [];
+  const re = /\b(?:capture|exec|spawnSync|spawn)\(\s*(['"])([\w./-]+)\1\s*,\s*(\[[^\]]*\]|[A-Za-z_$][\w$]*)/g;
+  for (const m of source.matchAll(re)) {
+    const args = m[3].startsWith('[') ? stringLiterals(m[3]) : resolveArgArray(source, m[3]);
+    if (args === null) continue;
+    out.push([m[2], ...args]);
+  }
+  return out;
+}
+
+// literalRefs — the image refs a module states as string literals, including the
+// ones it states in a module it imports. `mirror-images.mjs` names none itself:
+// its inventory is `mirroredImages` over in `lib/mirror.mjs`, and the refs reach
+// `docker buildx imagetools` through a variable, so the argv alone says only
+// THAT it copies images and never WHICH. Read only for a module already judged
+// to acquire, so a ref mentioned by a module that acquires nothing stays
+// invisible.
+function literalRefs(source) {
+  const out = [];
+  for (const m of stripComments(source).matchAll(/\[([^\]]*)\]/g)) {
+    for (const lit of stringLiterals(m[1])) if (looksLikeImageRef(lit)) out.push(lit);
+  }
+  return out;
+}
+
+// policyRefs — the image refs a module hands to `pullImageWithRetry`, resolved
+// through its own top-level `const NAME = 'literal'` table so a ref named once
+// and used once is still visible.
+function policyRefs(source) {
+  const consts = {};
+  for (const m of source.matchAll(/^const\s+([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(['"])([^'"]+)\2\s*;?\s*$/gm)) {
+    consts[m[1]] = m[3];
+  }
+  const refs = [];
+  for (const m of source.matchAll(new RegExp(`${sharedPolicySymbol}\\(\\s*([^,)]+)`, 'g'))) {
+    const arg = m[1].trim();
+    const lit = /^(['"])([^'"]+)\1$/.exec(arg);
+    if (lit) refs.push(lit[2]);
+    else if (arg in consts) refs.push(consts[arg]);
+  }
+  return refs;
+}
+
+// stripComments — so a module that DOCUMENTS the primitive is not read as one
+// that calls it. lib/registry.mjs's header prints the signature
+// (`pullImageWithRetry(image, options)`) in prose, which is indistinguishable
+// from a call site to any regex that reads comments as code.
+function stripComments(source) {
+  return String(source ?? '')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .split('\n')
+    .map((l) => l.replace(/(^|\s)\/\/.*$/, '$1'))
+    .join('\n');
+}
+
+// callsSharedPolicy — the primitive is INVOKED here, as opposed to declared here
+// (lib/registry.mjs) or named in a comment. The `function` lookbehind is what
+// separates the declaration from every call of it.
+export function callsSharedPolicy(source) {
+  return new RegExp(`(?<!function\\s)\\b${sharedPolicySymbol}\\s*\\(`).test(stripComments(source));
+}
+
+function relativeImports(source) {
+  return [...source.matchAll(/^import[^'"]*(['"])(\.[^'"]+)\1/gm)].map((m) => m[2]);
+}
+
+// namedImports — `{ a, b as c }` per relative specifier. Used to attribute an
+// imported array to the module that actually reads it: every consumer of
+// `lib/mirror.mjs` imports `mirroredRef`, but only the mirroring job imports the
+// INVENTORY, and charging the inventory to all of them reports jobs as pulling
+// two dozen images they never touch.
+function namedImports(source) {
+  const out = new Map();
+  for (const m of stripComments(source).matchAll(/^import\s*\{([^}]*)\}\s*from\s*(['"])(\.[^'"]+)\2/gm)) {
+    const names = m[1]
+      .split(',')
+      .map((n) => n.trim().split(/\s+as\s+/)[0].trim())
+      .filter((n) => n !== '');
+    out.set(m[3], [...(out.get(m[3]) ?? []), ...names]);
+  }
+  return out;
+}
+
+// arrayBinding — the string literals of `const NAME = [ … ]` in a module.
+function arrayBinding(source, name) {
+  const m = new RegExp(`\\b(?:export\\s+)?(?:const|let|var)\\s+${name}\\s*=\\s*\\[([^\\]]*)\\]`).exec(
+    stripComments(source),
+  );
+  return m === null ? [] : stringLiterals(m[1]);
+}
+
+// ---------------------------------------------------------------------------
+// The resolver.
+// ---------------------------------------------------------------------------
+
+// A `Findings` accumulator: what a job does, gathered across every hop.
+function newFindings() {
+  return { acquisitions: [], logins: [], viaSharedPolicy: false, refs: new Set(), unresolved: [] };
+}
+
+class Resolver {
+  constructor(root) {
+    this.root = root;
+    this.just = null;
+    this.sourceCache = new Map();
+    this.policyCache = new Map();
+  }
+
+  read(path) {
+    const abs = isAbsolute(path) ? path : join(this.root, path);
+    if (!this.sourceCache.has(abs)) {
+      this.sourceCache.set(abs, existsSync(abs) ? readFileSync(abs, 'utf8') : null);
+    }
+    return this.sourceCache.get(abs);
+  }
+
+  justfile() {
+    if (this.just === null) {
+      const text = this.read('Justfile');
+      if (text === null) throw new Error('Justfile not found — `just` recipes cannot be resolved');
+      this.just = parseJustfile(text);
+    }
+    return this.just;
+  }
+
+  // usesSharedPolicy — does this module, or anything it imports, acquire through
+  // pullImageWithRetry? Memoised, and cycle-safe by marking before recursing.
+  //
+  // Following EVERY relative import rather than only the one the primitive
+  // arrives on over-approximates, deliberately. The two errors are not
+  // symmetric: over-approximating costs a job a login it did not strictly need,
+  // while under-approximating is the anonymous pull this whole module exists to
+  // catch.
+  usesSharedPolicy(path, seen = new Set()) {
+    if (this.policyCache.has(path)) return this.policyCache.get(path);
+    if (seen.has(path)) return false;
+    seen.add(path);
+    const source = this.read(path);
+    if (source === null) return false;
+    // A CALL, not a mention. lib/registry.mjs declares the primitive and
+    // chart-kubeconform.mjs imports a rate-limit classifier out of the same
+    // module — matching the bare identifier reported that job as pulling images
+    // it never pulls, and a gate that invents a violation gets an exemption
+    // written for it, which is the failure mode this module exists to avoid.
+    let answer = callsSharedPolicy(source);
+    if (!answer) {
+      const dir = join(this.root, path, '..');
+      for (const spec of relativeImports(source)) {
+        const child = resolvePath(dir, spec).slice(this.root.length + 1);
+        if (this.usesSharedPolicy(child, seen)) {
+          answer = true;
+          break;
+        }
+      }
+    }
+    this.policyCache.set(path, answer);
+    return answer;
+  }
+
+  // moduleLiteralRefs — the image refs this module states as literals, plus the
+  // ones held by an array binding it IMPORTS BY NAME.
+  //
+  // The import hop is the load-bearing half: the mirroring job's inventory lives
+  // in `lib/mirror.mjs` and reaches `docker buildx imagetools` through a loop
+  // variable, so its argv says only THAT it copies images and never which — R2
+  // would degrade to "this job logs in somewhere" for the one job whose whole
+  // purpose is reading Docker Hub. Following the NAME rather than the module is
+  // what stops that from charging the inventory to every job that imports
+  // `mirroredRef` out of the same file.
+  moduleLiteralRefs(path) {
+    const source = this.read(path);
+    if (source === null) return [];
+    const out = literalRefs(source);
+    const dir = join(this.root, path, '..');
+    for (const [spec, names] of namedImports(source)) {
+      const child = this.read(resolvePath(dir, spec).slice(this.root.length + 1));
+      if (child === null) continue;
+      for (const name of names) out.push(...arrayBinding(child, name).filter(looksLikeImageRef));
+    }
+    return out;
+  }
+
+  // command — classify one argv, following it wherever it goes.
+  command(rawArgv, scope, findings, depth) {
+    if (depth > maxResolutionDepth) {
+      findings.unresolved.push(`resolution depth exceeded at \`${rawArgv.join(' ')}\``);
+      return;
+    }
+    const { argv, assignments } = stripPrefixes(rawArgv);
+    if (argv.length === 0) return;
+    const inner = { ...scope, ...assignments };
+    const program = argv[0];
+
+    if (program === 'docker') return this.docker(argv, inner, findings, depth);
+    if (program === 'k3d') return this.k3d(argv, inner, findings, depth);
+    if (program === 'just') return this.justRecipe(argv, inner, findings, depth);
+    if (program === 'node') return this.node(argv, inner, findings, depth);
+    if (program === 'bash' || program === 'sh') {
+      // `-c` takes the script itself rather than a path to one.
+      const c = argv.indexOf('-c');
+      if (c !== -1 && argv[c + 1] !== undefined) {
+        for (const cmd of splitCommands(argv[c + 1])) {
+          this.command(tokenise(cmd), inner, findings, depth + 1);
+        }
+        return;
+      }
+      const script = argv.slice(1).find((t) => !t.startsWith('-'));
+      if (script) this.shellScript(script, inner, findings, depth);
+      return;
+    }
+    if (/\.sh$/.test(program)) return this.shellScript(program, inner, findings, depth);
+  }
+
+  docker(argv, scope, findings, depth) {
+    const rest = argv.slice(1).filter((t) => t !== '');
+    const sub = rest.find((t) => !t.startsWith('-'));
+    if (sub === 'login') {
+      findings.logins.push({ registry: loginRegistry(rest.slice(rest.indexOf('login') + 1), scope) });
+      return;
+    }
+    if (sub === 'pull') {
+      findings.acquisitions.push(`docker pull`);
+      for (const t of rest.slice(rest.indexOf('pull') + 1)) this.noteRef(t, scope, findings);
+      return;
+    }
+    if (sub === 'run' || sub === 'create') {
+      // The image argument sits after an arbitrary run of flags whose value
+      // arity is not knowable from the token stream, so the ref is left
+      // unresolved rather than guessed. R1 still applies; the ref that matters
+      // is normally named by the pre-pull in the same job anyway.
+      findings.acquisitions.push(`docker ${sub}`);
+      return;
+    }
+    if (sub === 'compose') {
+      const verb = rest.slice(rest.indexOf('compose') + 1).find((t) => !t.startsWith('-'));
+      if (['up', 'pull', 'create', 'run', 'build'].includes(verb)) {
+        findings.acquisitions.push(`docker compose ${verb}`);
+      }
+      return;
+    }
+    // `imagetools` reads a manifest straight out of the registry — `create`
+    // copies one ref to another, `inspect` resolves one. Neither puts an image
+    // in the local daemon, which is why it does not look like an acquisition,
+    // but the READ still spends the source registry's quota exactly as a pull
+    // does. The job that mirrors this repo's inventory acquires images this way
+    // and no other way, so leaving it out excused the one job whose entire
+    // purpose is reading Docker Hub.
+    if (sub === 'buildx' && rest.includes('imagetools')) {
+      const verb = rest.slice(rest.indexOf('imagetools') + 1).find((t) => !t.startsWith('-'));
+      if (['create', 'inspect'].includes(verb)) {
+        findings.acquisitions.push(`docker buildx imagetools ${verb}`);
+        for (const t of rest.slice(rest.indexOf(verb) + 1)) this.noteRef(t, scope, findings);
+      }
+      return;
+    }
+    if (sub === 'build' || (sub === 'buildx' && rest.includes('build'))) {
+      // A build resolves its `FROM` refs against the registry from inside
+      // BuildKit, so it is an acquisition even though nothing is pulled by the
+      // daemon.
+      findings.acquisitions.push('docker build');
+    }
+  }
+
+  k3d(argv, scope, findings, _depth) {
+    if (argv[1] !== 'cluster' || argv[2] !== 'create') return;
+    findings.acquisitions.push('k3d cluster create');
+    const i = argv.indexOf('--image');
+    if (i !== -1 && argv[i + 1]) this.noteRef(argv[i + 1], scope, findings);
+  }
+
+  justRecipe(argv, scope, findings, depth) {
+    const { vars, recipes } = this.justfile();
+    const name = argv[1];
+    if (name === undefined) return;
+    const recipe = recipes.get(name);
+    if (!recipe) {
+      findings.unresolved.push(`\`just ${name}\` names no recipe in the Justfile`);
+      return;
+    }
+    const bound = { ...vars, ...scope };
+    // Expanded AT THE CALL SITE. `just schema-ddl-test` runs
+    // `just _pull-retry {{CH_TEST_IMAGE}}`, so binding the argument verbatim
+    // would hand `_pull-retry` the literal text `{{CH_TEST_IMAGE}}` and the ref
+    // would arrive at `pull-images.mjs` still unexpanded — which is exactly how
+    // two jobs pulling a named Docker Hub image read as "ref unknown" and slipped
+    // the Docker Hub rule.
+    const args = argv.slice(2).map((a) => expandVars(a, bound) ?? a);
+    recipe.params.forEach((p, i) => {
+      // A variadic parameter swallows the rest; anything unsupplied falls back
+      // to its default, and a required parameter with nothing behind it stays
+      // unbound so `expandVars` reports it rather than inventing a value.
+      const value = i === recipe.params.length - 1 ? args.slice(i).join(' ') : args[i];
+      if (value !== undefined && value !== '') bound[p.name] = value;
+      else if (p.dflt !== null) bound[p.name] = p.dflt;
+    });
+    for (const dep of recipe.deps) this.command(['just', dep], scope, findings, depth + 1);
+    for (const line of recipe.body) {
+      for (const cmd of splitCommands(line)) {
+        this.command(tokenise(cmd), bound, findings, depth + 1);
+      }
+    }
+  }
+
+  node(argv, scope, findings, depth) {
+    const rest = argv.slice(1);
+    // `node --test X` runs X under the node test runner: it imports the module
+    // and executes its tests, never its CLI main. This is the structural reason
+    // ci.yml's discipline lane is not an image acquisition, and it holds for
+    // every module rather than for one named one.
+    if (rest.includes('--test')) return;
+    const scriptIdx = rest.findIndex((t) => !t.startsWith('-'));
+    if (scriptIdx === -1) return;
+    const script = expandVars(rest[scriptIdx], scope) ?? rest[scriptIdx];
+    if (/\.test\.mjs$/.test(script)) return;
+
+    const source = this.read(script);
+    if (source === null) {
+      findings.unresolved.push(`\`node ${script}\` names no file in the repository`);
+      return;
+    }
+    if (this.usesSharedPolicy(script)) {
+      findings.viaSharedPolicy = true;
+      findings.acquisitions.push(`${script} (shared mirror-first policy)`);
+      for (const ref of policyRefs(source)) this.noteRef(ref, scope, findings);
+      // Refs handed to the script on argv, e.g. `pull-images.mjs golang:1.26`.
+      for (const t of rest.slice(scriptIdx + 1)) this.noteRef(t, scope, findings);
+    }
+    const before = findings.acquisitions.length;
+    for (const spawned of spawnedCommands(source)) {
+      this.command(spawned, scope, findings, depth + 1);
+    }
+    // Only once the module has been judged to acquire. A ref stated by a module
+    // that acquires nothing is a name, not a pull.
+    if (findings.acquisitions.length > before) {
+      for (const ref of this.moduleLiteralRefs(script)) this.noteRef(ref, scope, findings);
+    }
+    // A wrapper takes the command it wraps on its own argv.
+    const wrapped = rest.slice(scriptIdx + 1);
+    if (wrapped.length > 0) this.command(wrapped, scope, findings, depth + 1);
+  }
+
+  shellScript(rawPath, scope, findings, depth) {
+    const path = expandVars(rawPath, scope) ?? rawPath;
+    const source = this.read(path);
+    if (source === null) {
+      findings.unresolved.push(`\`${path}\` names no file in the repository`);
+      return;
+    }
+    for (const cmd of splitCommands(source)) {
+      this.command(tokenise(cmd), scope, findings, depth + 1);
+    }
+  }
+
+  // noteRef — record every image ref a token names. Splits on whitespace because
+  // a variadic Justfile parameter arrives as ONE token holding several refs
+  // (`_pull-retry {{CH_TEST_IMAGE}} {{CH_TEST_IMAGE_PRIOR}}` binds `IMAGES` to
+  // both), and a two-ref token matches no image-ref shape at all — so the whole
+  // pair would vanish rather than half of it.
+  noteRef(token, scope, findings) {
+    const expanded = expandVars(token, scope);
+    if (expanded === null) return;
+    for (const part of unquote(expanded).trim().split(/\s+/)) {
+      if (looksLikeImageRef(part)) findings.refs.add(part);
+    }
+  }
+
+  // step — one workflow step, including a local composite action's own steps.
+  step(stepLines, scope, findings, depth = 0) {
+    const uses = scalarAt(stepLines, 'uses');
+    const run = scalarAt(stepLines, 'run');
+    const stepEnv = mappingAt(stepLines, 'env');
+    const inner = { ...scope, ...stepEnv };
+
+    if (uses !== null) {
+      if (/^docker\/login-action(@|$)/.test(uses)) {
+        const w = mappingAt(stepLines, 'with');
+        findings.logins.push({ registry: (w.registry ?? '').trim() });
+        return;
+      }
+      if (uses.startsWith('./')) {
+        const actionPath = ['action.yml', 'action.yaml']
+          .map((f) => join(uses.slice(2), f))
+          .find((p) => this.read(p) !== null);
+        if (actionPath === undefined) {
+          findings.unresolved.push(`\`uses: ${uses}\` resolves to no action.yml`);
+          return;
+        }
+        const lines = this.read(actionPath).split('\n');
+        const runsIdx = findKey(lines, 'runs', 0);
+        if (runsIdx === -1) return;
+        const runsBlock = blockUnder(lines, runsIdx);
+        const inputs = defaultInputs(lines);
+        const withValues = mappingAt(stepLines, 'with');
+        const actionScope = { ...inner, ...inputs, ...withValues };
+        const stepsIdx = findKey(runsBlock, 'steps', minIndent(runsBlock));
+        if (stepsIdx === -1) return;
+        for (const s of splitSteps(blockUnder(runsBlock, stepsIdx))) {
+          this.step(s, actionScope, findings, depth + 1);
+        }
+      }
+      return;
+    }
+
+    if (run === null) return;
+    for (const cmd of splitCommands(run)) {
+      this.command(tokenise(cmd), inner, findings, depth + 1);
+    }
+  }
+}
+
+// defaultInputs — a composite action's `inputs.<name>.default` values, so a
+// caller that does not override an input still resolves the ref it will use.
+function defaultInputs(lines) {
+  const i = findKey(lines, 'inputs', 0);
+  if (i === -1) return {};
+  const block = blockUnder(lines, i);
+  const nameIndent = minIndent(block);
+  const out = {};
+  let name = null;
+  for (const line of block) {
+    if (isBlank(line)) continue;
+    if (indentOf(line) === nameIndent) {
+      const m = /^\s*([A-Za-z0-9_-]+):\s*$/.exec(line);
+      name = m ? m[1] : null;
+      continue;
+    }
+    const d = /^\s*default:\s*(.*)$/.exec(line);
+    if (d && name) out[name] = unquote(d[1]);
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// The rules.
+// ---------------------------------------------------------------------------
+
+export function violationsFor(jobId, findings) {
+  const out = [];
+  if (findings.acquisitions.length === 0) return out;
+
+  const how = [...new Set(findings.acquisitions)].join(', ');
+  const hasAny = findings.logins.length > 0;
+  const hasHub = findings.logins.some((l) => dockerHubRegistries.has(l.registry));
+  const hasMirror = findings.logins.some((l) => l.registry.startsWith(mirrorHost));
+
+  if (!hasAny) {
+    out.push(`${jobId}: acquires images (${how}) with no registry login step — the pull is anonymous`);
+    return out;
+  }
+  const hubRefs = [...findings.refs].filter(isDockerHubRef);
+  if (hubRefs.length > 0 && !hasHub) {
+    out.push(
+      `${jobId}: acquires the Docker Hub image(s) ${hubRefs.sort().join(', ')} but has no Docker Hub ` +
+        'login — that pull spends the shared anonymous per-runner-IP quota',
+    );
+  }
+  if (findings.viaSharedPolicy && !hasMirror) {
+    out.push(
+      `${jobId}: acquires through the shared mirror-first policy but has no ${mirrorHost} login — ` +
+        'the mirror is unreadable, so every acquisition silently falls back to Docker Hub',
+    );
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// CLI.
+// ---------------------------------------------------------------------------
+
+export function scan({ root = process.cwd(), workflowDir = '.github/workflows' } = {}) {
+  const resolver = new Resolver(root);
+  // Absolute is honoured so a caller can point the scan at a doctored copy of
+  // the workflows while the Justfile / scripts / actions still resolve against
+  // the real tree. That is what lets the tests prove this gate FAILS, on the
+  // real workflow text, rather than only that it passes.
+  const dir = isAbsolute(workflowDir) ? workflowDir : join(root, workflowDir);
+  const results = [];
+  for (const file of readdirSync(dir).sort()) {
+    if (!/\.ya?ml$/.test(file)) continue;
+    const { env, jobs } = parseWorkflow(readFileSync(join(dir, file), 'utf8'));
+    for (const job of jobs) {
+      const findings = newFindings();
+      const scope = { ...repoRootVars, ...env, ...job.env };
+      for (const step of job.steps) resolver.step(step, scope, findings);
+      results.push({ id: `${file}:${job.name}`, findings });
+    }
+  }
+  return results;
+}
+
+function main() {
+  const root = process.env.REPO_ROOT || process.cwd();
+  const workflowDir = process.env.WORKFLOW_DIR || '.github/workflows';
+  const results = scan({ root, workflowDir });
+
+  const acquiring = results.filter((r) => r.findings.acquisitions.length > 0);
+  const violations = [];
+  const unresolved = [];
+  for (const { id, findings } of results) {
+    violations.push(...violationsFor(id, findings));
+    for (const u of findings.unresolved) unresolved.push(`${id}: ${u}`);
+  }
+
+  log(`scanned ${results.length} jobs; ${acquiring.length} acquire at least one image`);
+  for (const { id, findings } of acquiring) {
+    const logins = findings.logins.map((l) => l.registry || 'docker.io').sort().join(' + ') || 'NONE';
+    log(`  ${id} — ${[...new Set(findings.acquisitions)].join(', ')} | logins: ${logins}`);
+  }
+
+  // A job that no longer acquires anything would make this gate vacuous, and a
+  // vacuous gate reports the same green as a satisfied one.
+  if (acquiring.length === 0) {
+    error('no image-acquiring job was found at all — the detector is not reading the workflows');
+    process.exit(1);
+  }
+  for (const u of unresolved) error(`unreadable reference — ${u}`);
+  for (const v of violations) error(v);
+  if (unresolved.length > 0 || violations.length > 0) {
+    error(
+      'every job that acquires an image must log in to the registries it acquires from. Add the ' +
+        'Docker Hub login (and the ghcr.io mirror login, when the job pulls through ' +
+        '.github/scripts/lib/registry.mjs) to the job above, ahead of its first acquisition.',
+    );
+    process.exit(1);
+  }
+  notice(`${acquiring.length} image-acquiring jobs, all authenticated`);
+  process.exit(0);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) main();

--- a/.github/scripts/assert-image-jobs-authenticate.test.mjs
+++ b/.github/scripts/assert-image-jobs-authenticate.test.mjs
@@ -1,0 +1,366 @@
+// Tests for the image-acquisition authentication gate.
+//
+// Two things are at stake and they pull in opposite directions.
+//
+// The first is that the gate CAN FAIL. A detector that resolves a job wrongly
+// reports the same green as one that resolved it right, so "the tree is clean"
+// is not evidence of anything on its own — it is equally consistent with a
+// resolver that stopped reading at the first `just`. Every rule below is
+// therefore proved against the REAL workflow text with a login step removed
+// from it, not against a hand-written fixture that only resembles one.
+//
+// The second is that it fails for the RIGHT reason. The whole value of this gate
+// over a grep is that the one shape which looks like a violation and is not —
+// `node --test .github/scripts/compose-pull-images.test.mjs`, a unit test that
+// mentions an image-pulling module and pulls nothing — is excluded by a
+// structural fact rather than by its name. If that discrimination ever collapses
+// into a name list, the gate has become the thing it replaced, so it is pinned
+// here directly.
+
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import {
+  callsSharedPolicy,
+  expandVars,
+  isDockerHubRef,
+  looksLikeImageRef,
+  loginRegistry,
+  parseWorkflow,
+  scan,
+  spawnedCommands,
+  splitCommands,
+  tokenise,
+  violationsFor,
+} from './assert-image-jobs-authenticate.mjs';
+
+const repoRoot = process.cwd();
+const workflows = join(repoRoot, '.github/workflows');
+
+// The job used as the live specimen: it acquires through the shared policy AND
+// names a Docker Hub ref two hops away (`just _pull-retry "$CH_IMAGE"` →
+// `pull-images.mjs {{IMAGES}}`), so it exercises every rule at once.
+const specimenJob = 'e2e.yml:startup-bench';
+
+function realScan() {
+  return scan({ root: repoRoot, workflowDir: workflows });
+}
+
+function findingsFor(id, results) {
+  const hit = results.find((r) => r.id === id);
+  assert.ok(hit, `${id} was not found among the scanned jobs`);
+  return hit.findings;
+}
+
+// scanWith — the real workflow directory with ONE file replaced by a doctored
+// copy. The Justfile and the scripts still resolve against the real tree, so the
+// resolution under test is the real resolution.
+function scanWith(file, edit) {
+  const dir = mkdtempSync(join(tmpdir(), 'image-auth-gate-'));
+  const original = readFileSync(join(workflows, file), 'utf8');
+  const doctored = edit(original);
+  assert.notEqual(doctored, original, 'the negative control did not change the workflow text');
+  writeFileSync(join(dir, file), doctored);
+  return scan({ root: repoRoot, workflowDir: dir });
+}
+
+// Removes EVERY `- name: <title>` step, each up to the next step at its own
+// indentation. Deleting the login is the regression this gate exists to catch,
+// so it is also the way to prove the gate catches it.
+//
+// Every occurrence, not the first: `Log in to Docker Hub` is the title of a step
+// in six jobs of e2e.yml, so removing one match doctors whichever job happens to
+// come first in the file — which is not the job under test, and leaves the
+// control asserting that an untouched job is still clean.
+function withoutStep(title) {
+  return (text) => {
+    const lines = text.split('\n');
+    const out = [];
+    let i = 0;
+    let removed = 0;
+    while (i < lines.length) {
+      if (lines[i].trim() !== `- name: ${title}`) {
+        out.push(lines[i]);
+        i++;
+        continue;
+      }
+      const indent = lines[i].length - lines[i].trimStart().length;
+      removed++;
+      i++;
+      while (i < lines.length) {
+        const l = lines[i];
+        if (l.trim().startsWith('- ') && l.length - l.trimStart().length === indent) break;
+        i++;
+      }
+    }
+    assert.notEqual(removed, 0, `no step titled "${title}" to remove`);
+    return out.join('\n');
+  };
+}
+
+// ---------------------------------------------------------------------------
+// The tree, as it stands.
+// ---------------------------------------------------------------------------
+
+test('every image-acquiring job in the tree authenticates', () => {
+  const results = realScan();
+  const violations = results.flatMap((r) => violationsFor(r.id, r.findings));
+  assert.deepEqual(violations, []);
+  const unresolved = results.flatMap((r) => r.findings.unresolved.map((u) => `${r.id}: ${u}`));
+  assert.deepEqual(unresolved, [], 'a reference the resolver cannot follow is not a clean job');
+});
+
+test('the scan finds acquiring jobs at all', () => {
+  // Without this the suite above is satisfied by a resolver that reads nothing:
+  // zero jobs produce zero violations.
+  const acquiring = realScan().filter((r) => r.findings.acquisitions.length > 0);
+  assert.ok(acquiring.length >= 10, `only ${acquiring.length} acquiring jobs found — the resolver is not reading the tree`);
+});
+
+// ---------------------------------------------------------------------------
+// The discrimination that replaces an allow-list.
+// ---------------------------------------------------------------------------
+
+test('a unit test that names an image-pulling module is not an image acquisition', () => {
+  // ci.yml's discipline lane runs `node --test compose-pull-images.test.mjs`.
+  // A text search for the module name flags it; reading the command does not,
+  // because `--test` hands the file to the node test runner, which imports the
+  // module rather than running its CLI. That is the fact doing the work — no
+  // job name appears anywhere in this gate.
+  const results = realScan();
+  const disciplineJobs = results.filter((r) => r.id.startsWith('ci.yml:'));
+  assert.ok(disciplineJobs.length > 0, 'ci.yml produced no jobs');
+  for (const job of disciplineJobs) {
+    assert.deepEqual(
+      job.findings.acquisitions,
+      [],
+      `${job.id} was read as acquiring an image: ${job.findings.acquisitions.join(', ')}`,
+    );
+  }
+});
+
+test('the shared policy is detected by a CALL, not by a mention of it', () => {
+  // lib/registry.mjs prints the primitive's signature in its header comment and
+  // declares it. Reading either as a call site made chart-ci.yml's
+  // `chart-validate` — which imports only a rate-limit classifier out of that
+  // module and never pulls — look like an anonymous puller.
+  assert.equal(callsSharedPolicy('// pullImageWithRetry(image, options) acquires one image'), false);
+  assert.equal(callsSharedPolicy('export function pullImageWithRetry(image, options = {}) {'), false);
+  assert.equal(callsSharedPolicy('if (!pullImageWithRetry(ref, { backoffStepSeconds })) failed++;'), true);
+
+  const chart = realScan().find((r) => r.id === 'chart-ci.yml:chart-validate');
+  assert.ok(chart, 'chart-ci.yml:chart-validate was not scanned');
+  assert.deepEqual(chart.findings.acquisitions, []);
+});
+
+// ---------------------------------------------------------------------------
+// Resolution — the hops between a workflow step and the registry.
+// ---------------------------------------------------------------------------
+
+test('a ref is resolved through the job env and two Justfile hops', () => {
+  // `startup-bench` names the image once in the job's `env:`, spends it as
+  // `just _pull-retry "$CH_IMAGE"`, and the recipe forwards it to
+  // `pull-images.mjs {{IMAGES}}`. Every hop has to hold for the Docker Hub rule
+  // to have a ref to judge; a break anywhere reads as "ref unknown", which is
+  // silent.
+  const findings = findingsFor(specimenJob, realScan());
+  assert.ok(
+    [...findings.refs].some((r) => r.startsWith('clickhouse/clickhouse-server:')),
+    `no ClickHouse ref resolved; got ${[...findings.refs].join(', ') || '(none)'}`,
+  );
+  assert.equal(findings.viaSharedPolicy, true);
+});
+
+test('a variadic Justfile parameter yields every ref it holds, not none', () => {
+  // `_pull-retry {{CH_TEST_IMAGE}} {{CH_TEST_IMAGE_PRIOR}}` binds both refs to a
+  // single variadic parameter, so the expanded token holds two refs separated by
+  // a space — a shape that matches no image ref at all. Both used to vanish.
+  const findings = findingsFor('schema-integration.yml:schema-ddl', realScan());
+  const ch = [...findings.refs].filter((r) => r.startsWith('clickhouse/clickhouse-server:'));
+  assert.ok(ch.length >= 2, `expected both ClickHouse refs, got ${ch.join(', ') || '(none)'}`);
+});
+
+test('a composite action contributes its own steps', () => {
+  // `uses: ./.github/actions/setup-buildx` acquires the BuildKit bootstrap image
+  // inside the action, where no `run:` in the calling workflow mentions it.
+  const findings = findingsFor('release.yml:goreleaser', realScan());
+  assert.equal(findings.viaSharedPolicy, true, 'the setup-buildx bootstrap pull was not seen');
+});
+
+// ---------------------------------------------------------------------------
+// Negative controls — each rule, proved against the real workflow text.
+// ---------------------------------------------------------------------------
+
+test('R1 fires when an acquiring job has no login at all', () => {
+  const results = scanWith('e2e.yml', (text) =>
+    withoutStep('Log in to the image mirror (GHCR)')(withoutStep('Log in to Docker Hub')(text)),
+  );
+  const violations = violationsFor(specimenJob, findingsFor(specimenJob, results));
+  assert.equal(violations.length, 1);
+  assert.match(violations[0], /no registry login step — the pull is anonymous/);
+});
+
+test('R2 fires when an acquiring job has no Docker Hub login', () => {
+  const results = scanWith('e2e.yml', withoutStep('Log in to Docker Hub'));
+  const violations = violationsFor(specimenJob, findingsFor(specimenJob, results));
+  assert.equal(violations.length, 1);
+  assert.match(violations[0], /clickhouse\/clickhouse-server:[\d.]+/);
+  assert.match(violations[0], /no Docker Hub login/);
+});
+
+test('R3 fires when a job pulling through the mirror has no ghcr.io login', () => {
+  const results = scanWith('e2e.yml', withoutStep('Log in to the image mirror (GHCR)'));
+  const violations = violationsFor(specimenJob, findingsFor(specimenJob, results));
+  assert.equal(violations.length, 1);
+  assert.match(violations[0], /no ghcr\.io login/);
+});
+
+test('removing the acquisition removes the requirement, not the other way round', () => {
+  // The rules key off acquiring, so a job that stops pulling stops being
+  // judged — otherwise every login step in the repo would be load-bearing
+  // forever and the gate would fire on cleanups.
+  assert.deepEqual(violationsFor('some:job', { acquisitions: [], logins: [], refs: new Set(), viaSharedPolicy: false, unresolved: [] }), []);
+});
+
+// ---------------------------------------------------------------------------
+// Logging in without `docker/login-action`.
+//
+// "Logs in" must not be read as "uses docker/login-action". PR #1586 replaces
+// both of `mirror-images.yml`'s login steps with `run: node
+// .github/scripts/registry-login.mjs`, because the action has no retry input and
+// that step is where the mirror workflow died on its first real run. A detector
+// that recognises only the action would report the mirroring job — the one job
+// in the repo whose entire purpose is reading Docker Hub — as an anonymous
+// puller the moment that PR lands, and the fix for a gate that fires wrongly is
+// always an exemption, which is the outcome this module exists to prevent.
+//
+// The two tests below pin the shape rather than the filename, on the argv the
+// script actually builds. `registry-login.mjs` does not exist on this branch, so
+// they are written against its source text; they hold for any module that logs
+// in the same way.
+// ---------------------------------------------------------------------------
+
+// The argv-building shape from #1586's registry-login.mjs, verbatim: the host is
+// appended conditionally, which is precisely why it cannot be an inline literal
+// array and why reading only inline arrays would miss the login entirely.
+const conditionalLoginSource = `
+import { capture } from './lib/gh.mjs';
+function main() {
+  const registry = (process.env.REGISTRY ?? '').trim();
+  const username = requiredEnv('USERNAME');
+  const args = ['login', '--username', username, '--password-stdin'];
+  if (registry !== '') args.push(registry);
+  const res = capture('docker', args, { input: password });
+}
+`;
+
+test('an argv built up in a variable is still a spawned command', () => {
+  assert.deepEqual(spawnedCommands(conditionalLoginSource), [
+    ['docker', 'login', '--username', '--password-stdin', '${REGISTRY}'],
+  ]);
+});
+
+test('a login step names the registry it logs in to, or Docker Hub when it names none', () => {
+  const [[, ...argv]] = spawnedCommands(conditionalLoginSource);
+  const after = argv.slice(argv.indexOf('login') + 1);
+
+  // With REGISTRY set, this is the mirror login and satisfies R3.
+  assert.equal(loginRegistry(after, { REGISTRY: 'ghcr.io' }), 'ghcr.io');
+
+  // Unset is not unknown: `docker login` with no host argument goes to Docker
+  // Hub, which is the contract the script documents. Reading it as "some other
+  // registry" would leave the Docker Hub half of R2 unsatisfied for a job that
+  // is genuinely logged in to Docker Hub.
+  assert.equal(loginRegistry(after, {}), '');
+
+  // The flag arity is the substance: `--username` takes a value, so "the first
+  // token that is not a flag" is the USERNAME, and a gate that read it that way
+  // would record a login to a registry called `tsouza` and fail R2 on a job
+  // that is correctly authenticated.
+  assert.equal(loginRegistry(['--username', 'tsouza', '--password-stdin'], {}), '');
+  assert.equal(loginRegistry(['-u', 'tsouza', '-p', 'secret', 'ghcr.io'], {}), 'ghcr.io');
+
+  // A GitHub expression is genuinely unknowable, and guessing there would
+  // invent a login that may not exist.
+  assert.notEqual(loginRegistry(['${{ inputs.registry }}'], {}), '');
+});
+
+test('the job that mirrors the inventory acquires the images it mirrors', () => {
+  // `docker buildx imagetools create` puts nothing in the local daemon, so it
+  // does not look like an acquisition — but the manifest READ spends the source
+  // registry's quota exactly as a pull does, and this is the only way the
+  // mirroring job touches an image at all. Excusing it would exempt, by
+  // accident, the one job that exists to read Docker Hub.
+  const f = findingsFor('mirror-images.yml:mirror', realScan());
+  assert.ok(
+    f.acquisitions.some((a) => a.includes('imagetools')),
+    `expected an imagetools acquisition, got ${JSON.stringify(f.acquisitions)}`,
+  );
+  // And it knows WHICH images: the inventory lives in lib/mirror.mjs and reaches
+  // the command through a loop variable, so without the imported-binding hop R2
+  // would have no ref to check and would pass on any login at all.
+  assert.ok(
+    [...f.refs].some((r) => isDockerHubRef(r)),
+    `expected the mirrored inventory's Docker Hub refs, got ${JSON.stringify([...f.refs])}`,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// The primitives.
+// ---------------------------------------------------------------------------
+
+test('a ref with no registry host is Docker Hub', () => {
+  assert.equal(isDockerHubRef('golang:1.26'), true);
+  assert.equal(isDockerHubRef('clickhouse/clickhouse-server:26.5'), true);
+  assert.equal(isDockerHubRef('ghcr.io/tsouza/cerberus:1.13.2'), false);
+  assert.equal(isDockerHubRef('localhost:5000/x'), false);
+  assert.equal(isDockerHubRef('registry.k8s.io/pause:3.9'), false);
+});
+
+test('a compose file argument is not mistaken for an image ref', () => {
+  // `compose-pull-images.mjs docker-compose.yml` and
+  // `pull-images.mjs golang:1.26` are the same argv shape; only the token tells
+  // them apart, and a `.yml` read as an image would be judged as Docker Hub.
+  assert.equal(looksLikeImageRef('docker-compose.yml'), false);
+  assert.equal(looksLikeImageRef('golang:1.26'), true);
+  assert.equal(looksLikeImageRef('clickhouse/clickhouse-server:26.5-alpine'), true);
+  assert.equal(looksLikeImageRef('--quiet'), false);
+  assert.equal(looksLikeImageRef('$CH_IMAGE'), false);
+});
+
+test('an unresolvable variable yields null rather than a wrong ref', () => {
+  assert.equal(expandVars('$CH_IMAGE', { CH_IMAGE: 'golang:1.26' }), 'golang:1.26');
+  assert.equal(expandVars('{{K3S_IMAGE}}', { K3S_IMAGE: 'rancher/k3s:v1' }), 'rancher/k3s:v1');
+  assert.equal(expandVars('$MISSING', {}), null);
+  // A GitHub expression is never statically known; guessing at one is how a
+  // gate invents a violation.
+  assert.equal(expandVars('${{ inputs.cerberus_image }}', {}), null);
+});
+
+test('a command line splits on every separator that starts a new command', () => {
+  assert.deepEqual(splitCommands('docker pull a && docker run b'), ['docker pull a', 'docker run b']);
+  assert.deepEqual(splitCommands('# just a comment\ndocker pull a'), ['docker pull a']);
+  assert.deepEqual(splitCommands('docker \\\n  pull a'), ['docker    pull a']);
+  assert.deepEqual(tokenise('just _pull-retry "$CH_IMAGE"'), ['just', '_pull-retry', '$CH_IMAGE']);
+});
+
+test('a workflow parses into its jobs and their steps', () => {
+  const { jobs } = parseWorkflow(readFileSync(join(workflows, 'e2e.yml'), 'utf8'));
+  const bench = jobs.find((j) => j.name === 'startup-bench');
+  assert.ok(bench, 'startup-bench did not parse out of e2e.yml');
+  assert.equal(bench.env.CH_IMAGE?.startsWith('clickhouse/clickhouse-server:'), true);
+  assert.ok(bench.steps.length > 5, `only ${bench.steps.length} steps parsed`);
+});
+
+test('a comment between two steps does not leak into the previous step body', () => {
+  // A YAML comment sits at the OUTER indentation, so a block-scalar reader that
+  // emits blank lines on sight splices the next step's prose into the previous
+  // step's script — and prose naming `just e2e-up` in backticks then resolves as
+  // a recipe call with a stray backtick attached.
+  const results = realScan();
+  const unresolved = results.flatMap((r) => r.findings.unresolved);
+  assert.deepEqual(unresolved.filter((u) => u.includes('`')), unresolved.filter(() => false));
+});

--- a/.github/scripts/assert-image-jobs-authenticate.test.mjs
+++ b/.github/scripts/assert-image-jobs-authenticate.test.mjs
@@ -301,6 +301,69 @@ test('the job that writes the mirror is not required to read through it', () => 
 });
 
 // ---------------------------------------------------------------------------
+// A login's registry is matched by HOST, one policy for both registries.
+//
+// CodeQL flagged the mirror half as an incomplete-sanitization hole and it was
+// right: `registry.startsWith('ghcr.io')` also accepts `ghcr.io.evil.example`.
+// The Hub half had the mirrored defect in the other direction — a raw string-set
+// match misses spellings `docker login` itself accepts. Each case below goes red
+// on the pre-fix comparison, which is the only reason they are worth having.
+// ---------------------------------------------------------------------------
+
+// A job that pulls through the shared policy, so R3 is the rule under test and
+// the only variable is how its one login names a registry.
+const jobLoggingInTo = (registry) => ({
+  acquisitions: ['pullImageWithRetry'],
+  logins: [{ registry }],
+  viaSharedPolicy: true,
+  refs: new Set(),
+  unresolved: [],
+  composePolicyFiles: new Set(),
+  composeMaterialised: [],
+  mirrorWrites: 0,
+});
+
+test('a login to a host that merely starts with ghcr.io is not a mirror login', () => {
+  // `startsWith` accepted this; a hostname compare does not. Somebody else owns
+  // that name, so reading it as the mirror would greenlight an anonymous pull.
+  const violations = violationsFor('some:job', jobLoggingInTo('ghcr.io.evil.example'));
+  assert.ok(
+    violations.some((m) => m.includes('no ghcr.io login')),
+    `expected R3 to fire for a lookalike host, got ${JSON.stringify(violations)}`,
+  );
+  assert.deepEqual(violationsFor('some:job', jobLoggingInTo('ghcr.io')), []);
+});
+
+test('a Docker Hub login is recognised in every spelling docker login accepts', () => {
+  // Same normalisation on both halves. A raw string-set match saw only the bare
+  // forms, so a job authenticated as the URL form was reported as anonymous.
+  for (const spelling of ['', 'docker.io', 'index.docker.io', 'https://index.docker.io/v1/']) {
+    // The mirror login is held fixed so the Hub spelling is the only variable.
+    const f = {
+      ...jobLoggingInTo('ghcr.io'),
+      logins: [{ registry: 'ghcr.io' }, { registry: spelling }],
+      refs: new Set(['redis:7']),
+    };
+    assert.deepEqual(
+      violationsFor('some:job', f),
+      [],
+      `${JSON.stringify(spelling)} should read as a Docker Hub login`,
+    );
+  }
+});
+
+test('a registry value that is not a host at all matches nothing', () => {
+  // Deliberate failure direction. An unexpanded `${{ … }}` reaching this far is
+  // unparseable, and a false alarm about a login the job does have is the safe
+  // way to be wrong — the unsafe way is reading it as the empty registry, which
+  // means Docker Hub, and passing a job whose Hub credentials never resolved.
+  const f = { ...jobLoggingInTo('${{ env.REGISTRY }}'), refs: new Set(['redis:7']) };
+  const violations = violationsFor('some:job', f);
+  assert.ok(violations.some((m) => m.includes('no ghcr.io login')));
+  assert.ok(violations.some((m) => m.includes('no Docker Hub login')));
+});
+
+// ---------------------------------------------------------------------------
 // Logging in without `docker/login-action`.
 //
 // "Logs in" must not be read as "uses docker/login-action". PR #1586 replaces

--- a/.github/scripts/assert-image-jobs-authenticate.test.mjs
+++ b/.github/scripts/assert-image-jobs-authenticate.test.mjs
@@ -226,6 +226,81 @@ test('removing the acquisition removes the requirement, not the other way round'
 });
 
 // ---------------------------------------------------------------------------
+// R4 — a login step is necessary and NOT sufficient.
+//
+// Run 30701755787 (job 91375112426) logged in successfully:
+//
+//   13:50:32.0306552Z Logging into docker.io...
+//   13:50:32.3891751Z Login Succeeded!
+//
+// and was refused as UNAUTHENTICATED one second later:
+//
+//   13:50:33.1136472Z  clickhouse Pulling
+//   13:50:33.3467501Z  clickhouse Error toomanyrequests: You have reached your
+//                                  unauthenticated pull rate limit.
+//
+// `docker compose`'s own pull path does not carry the credentials the CLI wrote.
+// A gate that asked only "does this job have a login step?" would have passed
+// that job — a hollow green on the exact failure it is named after. So R4 asks
+// whether the acquisition actually RUNS on the mirror-first path.
+// ---------------------------------------------------------------------------
+
+// Replaces the harness call with a bare `compose up`, which is the pre-#1572
+// shape of the job that produced the run above: login, then straight to compose.
+const withoutTheComposePrePull = (text) =>
+  text.replace(
+    'run: ./compatibility/prometheus/scripts/run-compatibility.sh',
+    'run: docker compose -f docker-compose.yml up -d --build --wait clickhouse prometheus cerberus',
+  );
+
+test('R4 fires when a compose stack is materialised without a mirror-first pre-pull', () => {
+  const results = scanWith('compatibility.yml', withoutTheComposePrePull);
+  const v = findingsFor('compatibility.yml:prometheus', results);
+  const violations = violationsFor('compatibility.yml:prometheus', v);
+  assert.ok(
+    violations.some((m) => m.includes('without pre-pulling it through the shared mirror-first')),
+    `expected an R4 pre-pull violation, got ${JSON.stringify(violations)}`,
+  );
+  // And specifically NOT because the job is unauthenticated — it is. That is the
+  // whole point: the login rules are all satisfied here.
+  assert.ok(
+    !violations.some((m) => m.includes('no Docker Hub login') || m.includes('no registry login')),
+    'the doctored job still has both logins, so no login rule should fire',
+  );
+});
+
+test('R4 fires when a job acquires images off the shared policy entirely', () => {
+  const results = scanWith('compatibility.yml', withoutTheComposePrePull);
+  const violations = violationsFor(
+    'compatibility.yml:prometheus',
+    findingsFor('compatibility.yml:prometheus', results),
+  );
+  assert.ok(
+    violations.some((m) => m.includes('without going through the shared mirror-first policy')),
+    `expected an R4 off-policy violation, got ${JSON.stringify(violations)}`,
+  );
+});
+
+test('the job that writes the mirror is not required to read through it', () => {
+  // Circular otherwise: `imagetools create` POPULATES the mirror, so it cannot
+  // be served by it. The carve-out is the direction of the copy, not the job's
+  // name — which is what keeps it from becoming an exemption.
+  const f = findingsFor('mirror-images.yml:mirror', realScan());
+  assert.equal(f.viaSharedPolicy, false, 'the mirroring job does not pull through the mirror');
+  assert.ok(f.mirrorWrites > 0, 'its acquisitions are writes into the mirror');
+  assert.deepEqual(violationsFor('mirror-images.yml:mirror', f), []);
+
+  // But the carve-out is exactly as wide as the writes: give it one read that
+  // is not a write and R4 fires, so this cannot quietly excuse a real pull.
+  const withARead = { ...f, acquisitions: [...f.acquisitions, 'docker pull'] };
+  assert.ok(
+    violationsFor('mirror-images.yml:mirror', withARead).some((m) =>
+      m.includes('without going through the shared mirror-first policy'),
+    ),
+  );
+});
+
+// ---------------------------------------------------------------------------
 // Logging in without `docker/login-action`.
 //
 // "Logs in" must not be read as "uses docker/login-action". PR #1586 replaces

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -705,6 +705,23 @@ jobs:
       - name: Assert the mutation phase selector scopes correctly
         run: node --test .github/scripts/mutation-matrix.test.mjs
 
+      # Whether a job that pulls an image logged in first. An anonymous pull is
+      # not an error: it succeeds until the shared per-runner-IP quota happens to
+      # be spent, and then reads as flake — which is how #1572 fixed the class by
+      # construction and three jobs were still on the anonymous path afterwards.
+      # The detector resolves each step to the registry it reaches (through
+      # `just`, through the scripts, through the composite actions) rather than
+      # grepping for `docker pull`, because the one shape that looks like a
+      # violation and is not — this lane's own `node --test` of an image-pulling
+      # module — has to be excluded by a fact about the command and never by a
+      # list of job names. The tests run first: they prove the gate still FAILS
+      # on the real workflow text with a login step deleted, without which
+      # "clean" and "not reading the workflows" report the same green.
+      - name: Assert every image-acquiring job authenticates first
+        run: |
+          node --test .github/scripts/assert-image-jobs-authenticate.test.mjs
+          node .github/scripts/assert-image-jobs-authenticate.mjs
+
       # The two auto-labelers, same discipline: neither is a required check,
       # so a broken mapping never turns anything red — it just quietly stops
       # labeling, which is exactly how 62 issues ended up bare. The issue

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1239,6 +1239,20 @@ jobs:
         with:
           tool: just
 
+      # The mirror is reached for FIRST, but a mirror miss falls back to Docker
+      # Hub — and that fallback is the anonymous shared per-runner-IP quota
+      # unless this step has run. Every other image-acquiring job in this
+      # workflow carries both logins; this one carried only the mirror half,
+      # which is invisible for as long as the mirror keeps hitting.
+      - name: Log in to Docker Hub
+        if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
+        env:
+          DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
+        uses: docker/login-action@v4
+        with:
+          username: tsouza
+          password: ${{ secrets.DOCKER_HUB_PAT }}
+
       # Cerberus's own copy of every upstream image this job pulls lives in a
       # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before
       # Docker Hub. That reach works only once this step has written ghcr.io

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1248,10 +1248,9 @@ jobs:
         if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
         env:
           DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
-        uses: docker/login-action@v4
-        with:
-          username: tsouza
-          password: ${{ secrets.DOCKER_HUB_PAT }}
+          USERNAME: tsouza
+          PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
+        run: node .github/scripts/registry-login.mjs
 
       # Cerberus's own copy of every upstream image this job pulls lives in a
       # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before

--- a/.github/workflows/schema-integration.yml
+++ b/.github/workflows/schema-integration.yml
@@ -115,10 +115,9 @@ jobs:
         if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
         env:
           DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
-        uses: docker/login-action@v4
-        with:
-          username: tsouza
-          password: ${{ secrets.DOCKER_HUB_PAT }}
+          USERNAME: tsouza
+          PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
+        run: node .github/scripts/registry-login.mjs
 
       # Cerberus's own copy of every upstream image this job pulls lives in a
       # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before

--- a/.github/workflows/schema-integration.yml
+++ b/.github/workflows/schema-integration.yml
@@ -108,6 +108,18 @@ jobs:
         with:
           tool: just
 
+      # The mirror below is reached for FIRST, but a mirror miss falls back to
+      # Docker Hub — and that fallback spends the anonymous shared
+      # per-runner-IP quota unless this step has run.
+      - name: Log in to Docker Hub
+        if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
+        env:
+          DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
+        uses: docker/login-action@v4
+        with:
+          username: tsouza
+          password: ${{ secrets.DOCKER_HUB_PAT }}
+
       # Cerberus's own copy of every upstream image this job pulls lives in a
       # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before
       # Docker Hub. That reach works only once this step has written ghcr.io

--- a/.github/workflows/strict-scan.yml
+++ b/.github/workflows/strict-scan.yml
@@ -118,10 +118,9 @@ jobs:
         if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
         env:
           DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
-        uses: docker/login-action@v4
-        with:
-          username: tsouza
-          password: ${{ secrets.DOCKER_HUB_PAT }}
+          USERNAME: tsouza
+          PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
+        run: node .github/scripts/registry-login.mjs
 
       # Cerberus's own copy of every upstream image this job pulls lives in a
       # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before

--- a/.github/workflows/strict-scan.yml
+++ b/.github/workflows/strict-scan.yml
@@ -111,6 +111,18 @@ jobs:
         with:
           tool: just
 
+      # The mirror below is reached for FIRST, but a mirror miss falls back to
+      # Docker Hub — and that fallback spends the anonymous shared
+      # per-runner-IP quota unless this step has run.
+      - name: Log in to Docker Hub
+        if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
+        env:
+          DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
+        uses: docker/login-action@v4
+        with:
+          username: tsouza
+          password: ${{ secrets.DOCKER_HUB_PAT }}
+
       # Cerberus's own copy of every upstream image this job pulls lives in a
       # PRIVATE GHCR namespace, and `pullImageWithRetry` reaches for it before
       # Docker Hub. That reach works only once this step has written ghcr.io


### PR DESCRIPTION
Nothing in the repo asserted that a job which acquires an image logs in first, so a
missing login was invisible until a lane somewhere else caught the 429.

> **Stacked on #1586.** Base is `ci/mirror-login-retry`, not `main`. #1586 replaces
> every `docker/login-action` step with `run: node .github/scripts/registry-login.mjs`
> and adds a `CHECK=registry-login` ratchet that rejects the Action. The three logins
> this PR adds have to be written in that form, and the script does not exist on `main`,
> so building on `main` would either break CI or land three instant ratchet violations.
> GitHub retargets this to `main` when #1586 merges; it wants one rebase at that point.

## The three jobs that were pulling anonymously

The issue named `e2e.yml`'s `startup-bench`. Re-running the enumeration rather than
trusting the table found the cite half stale and the bug wider than one job: #1579 gave
`startup-bench` a **ghcr.io** login, and what it still lacked was the **Docker Hub** half.
Two more jobs were in exactly that state.

| job | had | lacked |
| --- | --- | --- |
| `e2e.yml:startup-bench` | ghcr.io | docker.io |
| `schema-integration.yml:schema-ddl` | ghcr.io | docker.io |
| `strict-scan.yml:strict-scan` | ghcr.io | docker.io |

Half a login is invisible for exactly as long as the mirror keeps hitting. A mirror miss
falls back to Docker Hub, spends the shared anonymous per-runner-IP quota, and the 429
then surfaces in whichever lane happened to pull next — never in the job that spent it.

## The gate

`.github/scripts/assert-image-jobs-authenticate.mjs` parses the workflows, resolves what
each job actually acquires, and fails when an acquisition is not on the authenticated
mirror-first path. It runs on the required `check` job's discipline lane, beside
`compose-smoke-scope.test.mjs` and `mirror-images.test.mjs`.

Four rules:

- **R1** — an acquiring job with no registry login at all.
- **R2** — an acquiring job that resolves a Docker Hub ref but has no Docker Hub login.
- **R3** — a job pulling through the shared policy with no `ghcr.io` login, which makes
  the mirror unreadable and turns every acquisition into a Docker Hub fallback.
- **R4** — an acquisition that never reaches the mirror-first path (below).

**No allow-list and no special-cased job name.** `ci.yml:forbid-skip` mentions image refs
but acquires nothing, and it is excluded by a structural fact rather than by name: the
command is `node --test`, which imports a module and runs its tests, never its CLI `main`.
That is a property of the command, so it holds for every module instead of for a listed one.

"Logs in" is likewise not "uses `docker/login-action`" — a `run:` step whose script spawns
a login counts, with the registry read off the step's `env:` and unset meaning Docker Hub,
matching `docker login` itself. That is what keeps #1586 from reading as a regression, and
it is now observed rather than asserted: with #1586 as the base, every login in the tree is
the script form and the scan still resolves all 18 acquiring jobs.

`docker buildx imagetools` is classified as an acquisition too. It puts nothing in the local
daemon, but the manifest read spends the source registry's quota exactly as a pull does, and
it is the only way `mirror-images.yml` touches an image — leaving it out exempted, by
accident, the one job whose entire purpose is reading Docker Hub.

## R4 — a login is necessary and not sufficient

Run 30701755787 (job 91375112426) logged in successfully:

```text
13:50:32.0306552Z Logging into docker.io...
13:50:32.3891751Z Login Succeeded!
```

and was refused as **unauthenticated** one second later:

```text
13:50:33.1136472Z  clickhouse Pulling
13:50:33.3467501Z  clickhouse Error toomanyrequests: You have reached your
                              unauthenticated pull rate limit.
```

`docker compose`'s own pull path does not carry the credentials the CLI wrote — the
falsification `lib/mirror.mjs`'s header already documents. A gate asking only "does this job
have a login step?" would have passed that job: a hollow green on the exact failure it is
named after. R4 asks the reachability question instead. A compose model materialised without
a pre-pull through the shared policy is a violation, as is a job whose acquisitions never
touch that policy at all.

The job that **populates** the mirror is not required to read through it — that would be
circular — and the carve-out is the direction of the copy (`imagetools` writes into a
registry), not the job's name, so it is exactly as wide as the writes and no wider.

**That run is stale, not a live gap.** All three compatibility harnesses do pre-pull through
`compose-pull-images.mjs` today; #1572 (`8207c25a`) added it and merged five hours *after*
that run was created, and `git merge-base --is-ancestor 8207c25a 1cd3fd67` exits 1 — the fix
was not in the run's tree. R4 is the ratchet that stops the shape returning unnoticed.

Writing R4's negative control surfaced a real hole in the detector: `docker compose -f x.yml up`
read `x.yml` as the verb, matched no materialising verb, and vanished from the scan entirely.
Compose's value-taking global flags are now stepped over — the same flag-arity fix the
`docker login` host parse needed.

## Proven able to fail

A gate that cannot fail is a gap, not coverage. Each rule was reddened by hand against the
real workflow text and then restored, and each is pinned by a test that does the same:

| control | result |
| --- | --- |
| delete both logins from `e2e.yml` | R1, naming the job |
| delete the Docker Hub login from `strict-scan.yml` | R2, naming `clickhouse/clickhouse-server:25.8-alpine, …:26.5-alpine` |
| delete the ghcr.io login | R3, `no ghcr.io login` |
| replace the harness call with a bare `compose up` | both R4 messages, on `prometheus` and `prometheus-forced-route` |
| delete the pre-pull line from `run-compatibility.sh` | both R4 messages, same two jobs |
| revert the host compare to `startsWith` | the lookalike-host test |
| revert the Hub compare to the raw string set | the URL-form Hub-login test |

Restored: 26/26 tests pass and the gate exits 0 across 72 jobs, 18 of which acquire.

## Registry matching (CodeQL)

CodeQL flagged `registry.startsWith('ghcr.io')` — it also accepts `ghcr.io.evil.example`,
a host somebody else controls, which would read as a mirror login. The Hub check beside it
had the mirrored defect in the other direction: a raw string-set match misses
`https://index.docker.io/v1/`, a spelling `docker login` accepts, and would report an
authenticated job as anonymous. Both now run through one hostname compare.

The direction for a value that is not a host at all is deliberate and commented: the helper
returns `null`, not `''`, so an unexpanded workflow expression matches no registry rather
than collapsing into the empty registry that *means* Docker Hub. A false alarm about a login
the job does have is the safe way to be wrong.

Closes #1575
