### PR TITLE
docs: correct six comments that contradict the code they describe

### DIFF
--- a/compatibility/tempo/driver/corpus/smoke.txtar
+++ b/compatibility/tempo/driver/corpus/smoke.txtar
@@ -28,8 +28,10 @@
 #     traceIdx) seconds — last trace lands ~400s after anchor.
 #
 # Diff strategy reminder (see differ.go top-of-file):
-#   * Trace IDs are canonicalised via H(rootServiceName||rootTraceName)
-#     so cerberus's currently-synthetic TraceID doesn't false-positive.
+#   * Trace IDs are the diff key as-is: cerberus emits the real
+#     hex(TraceId), so byte-equality across backends is the contract and
+#     a mismatch surfaces as missing_in_a / missing_in_b rather than
+#     being canonicalised away.
 #   * Numeric fields compare under 1e-9 relative epsilon.
 #   * Cardinality is reported as a reason but every key-level miss is
 #     also surfaced under missing_in_a / missing_in_b.

--- a/compatibility/tempo/driver/differ.go
+++ b/compatibility/tempo/driver/differ.go
@@ -228,10 +228,9 @@ func Compare(aBody, bBody []byte, aLabel, bLabel string, opts DiffOptions) (Diff
 		})
 	}
 
-	// Intersection — diff every per-summary field that both sides
-	// populate. Skipping a side's blank field keeps the differ from
-	// false-positing on optional-field omission (Tempo and cerberus
-	// can each legitimately omit StartTimeUnixNano in some builds).
+	// Intersection — diff every per-summary field, blank included. An
+	// asymmetric blank is a real divergence (the backend that omitted the
+	// field is the bug), so there is no optional-field tolerance here.
 	matched := make([]string, 0, len(aByKey))
 	for key := range aByKey {
 		if _, ok := bByKey[key]; ok {

--- a/internal/api/loki/detected_fields.go
+++ b/internal/api/loki/detected_fields.go
@@ -38,9 +38,10 @@ const defaultDetectedFieldsLimit = 1000
 // not the cerberus heap. This clamp caps the row COUNT the SQL LIMIT returns
 // (and thus the buffered slice): 10k newest lines is 10x the default and ample
 // for a field/pattern heuristic. It removes the unbounded-row OOM; the
-// absolute heap still scales with line SIZE × concurrency, which the deferred
-// uniform per-drain maxSamples backstop (the "complete the net" follow-up)
-// bounds hard. Mirrors the parseLogLimit/maxLogQueryLimit clamp on the log path.
+// absolute heap still scales with line SIZE × concurrency, which chclient's
+// maxLogPeekBytes backstop bounds hard on the byte axis, alongside the
+// client-wide per-drain row budget (drainBudgetExceeded, Config.MaxQuerySamples).
+// Mirrors the parseLogLimit/maxLogQueryLimit clamp on the log path.
 const maxLogPeekLineLimit = 10_000
 
 // maxDetectedFieldsLimit hard-caps the returned-field count. Each tracked

--- a/internal/api/tempo/handler.go
+++ b/internal/api/tempo/handler.go
@@ -1016,14 +1016,15 @@ const (
 //     TimeUnix=now64(); read Value from the Aggregate's alias.
 //  4. Project — lowerSelect for `| select(...)` produces a user-shaped
 //     projection (TraceId, SpanId, Timestamp, <selected-attrs>) that
-//     doesn't expose SpanName / Duration / ResourceAttributes. The
-//     /api/search response envelope only needs the canonical Sample
-//     fields, so we strip the user Project and re-wrap the underlying
-//     Scan / Filter(Scan) with the canonical projection. The
-//     user-selected attrs are dropped from the HTTP search response
-//     (they were never surfaced in the trace-summary shape); the spec
-//     fixtures that pin the lowerSelect shape go through chDB without
-//     wrap-projection so they're unaffected.
+//     doesn't expose SpanName / Duration / ResourceAttributes. Replace
+//     the user Project with one rooted in the same input that emits the
+//     canonical Sample fields AND the selected values, each smuggled
+//     through a reserved `__cerberus_sel_*` Labels key that
+//     toTraceSummaries pivots into SpanSetSpan.Attributes — reference
+//     Tempo surfaces selected attributes there, and Grafana's Traces
+//     Drilldown structure tab hard-fails without nestedSetLeft /
+//     nestedSetRight. The spec fixtures that pin the lowerSelect shape
+//     go through chDB without wrap-projection so they're unaffected.
 func wrapWithSampleProjection(plan chplan.Node, s schema.Traces, meta engine.Meta) chplan.Node {
 	switch {
 	case isStructuralJoin(plan):

--- a/internal/api/tempo/structural_two_phase.go
+++ b/internal/api/tempo/structural_two_phase.go
@@ -25,12 +25,13 @@ const phaseARankTsAlias = "rankTs"
 // `| select(...)` Project wrapped over it (unwrapped here). The negated anti-join
 // is admitted because the emitter now restricts its R side to the top-N traces
 // (structural_join.go), so phase B stays a faithful subset — without that fix a
-// naive gate relax would leak non-top-N traces (a WRONG result). Direct ops
-// (`>` / `<` / `~`) have a far cheaper single-INNER-JOIN projection and are
-// excluded; the union (`&>>`) two-arm shape leaves its left arm's inverse-closure
-// side unrestricted and still needs its own emitter fix before admission. Any
-// other wrapped shape (a set operation, an aggregate, a NestedSetAnnotate) falls
-// to the single-query path — never a wrong result, just no memory win.
+// naive gate relax would leak non-top-N traces (a WRONG result). The union
+// (`&>>`) two-arm shape is admitted on the same footing: each arm INNER JOINs on
+// TraceId to a restricted closure side, so neither the canonical anchor nor the
+// inverse closure step leaks. Direct ops (`>` / `<` / `~`) have a far cheaper
+// single-INNER-JOIN projection and are excluded. Any other wrapped shape (a set
+// operation, an aggregate, a NestedSetAnnotate) falls to the single-query path —
+// never a wrong result, just no memory win.
 func structuralTwoPhaseTarget(plan chplan.Node) (*chplan.StructuralJoin, bool) {
 	root := plan
 	// Unwrap a single pure-select Project (`… >> … | select(attr)`). The select

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -3665,7 +3665,11 @@ func buildAggFunc(a *parser.AggregateExpr, s schema.Metrics, ctx lowerCtx) (chpl
 		}, nil
 
 	case parser.COUNT_VALUES:
-		return chplan.AggFunc{}, fmt.Errorf("promql: %s changes output shape and lands with M1.7 result shaping", a.Op.String())
+		// Unreachable from the wire: count_values changes the output shape
+		// (a synthetic label per distinct value), so lowerAggregate and
+		// lowerSubqueryOverAggregate intercept it before buildAggFunc is
+		// consulted. Arriving here is a routing bug, not a missing feature.
+		return chplan.AggFunc{}, fmt.Errorf("promql: %s must be lowered by lowerCountValues, not the generic aggregate path", a.Op.String())
 	}
 
 	return chplan.AggFunc{}, fmt.Errorf("promql: aggregation op %s is not yet supported", a.Op.String())

--- a/test/rejection-parity/catalogue.json
+++ b/test/rejection-parity/catalogue.json
@@ -514,6 +514,13 @@
     },
     {
       "head": "promql",
+      "site": "internal/promql/lower.go:buildAggFunc#4353c2b3",
+      "message": "promql: %s must be lowered by lowerCountValues, not the generic aggregate path",
+      "class": "internal",
+      "rationale": "count_values is intercepted by lowerCountValues / lowerSubqueryOverCountValues on every parser-producible path before buildAggFunc is consulted"
+    },
+    {
+      "head": "promql",
       "site": "internal/promql/lower.go:buildAggFunc#54d1c35e",
       "message": "promql: aggregation %s does not take a parameter",
       "class": "internal",
@@ -532,13 +539,6 @@
       "message": "promql: aggregation op %s is not yet supported",
       "class": "internal",
       "rationale": "defensive fallback: every PromQL aggregator the parser emits (sum/avg/count/min/max/group/stddev/stdvar/topk/bottomk/count_values/quantile/limitk/limit_ratio) is dispatched by lowerAggregate or handled in buildAggFunc's switch, so no wire-reachable query reaches this branch. It guards against a future parser op landing unlowered."
-    },
-    {
-      "head": "promql",
-      "site": "internal/promql/lower.go:buildAggFunc#e759e84f",
-      "message": "promql: %s changes output shape and lands with M1.7 result shaping",
-      "class": "internal",
-      "rationale": "count_values is intercepted by lowerCountValues / lowerSubqueryOverCountValues on every parser-producible path before buildAggFunc is consulted"
     },
     {
       "head": "promql",


### PR DESCRIPTION
Six comments described behaviour their own code no longer performs. Each was
verified at its own cited `file:line` against `origin/main` before being
rewritten — a plausible-sounding claim in an issue is not evidence that the
drift is still there.

Closes #1472
Closes #1496
Closes #1517
Closes #1475

## What each one said, and what the code does

**`internal/api/tempo/handler.go`** (#1472) — the `wrapWithSampleProjection`
docstring said user `| select(...)` attributes "are dropped from the HTTP
search response (they were never surfaced in the trace-summary shape)". They
are not dropped: each selected value is carried through a reserved
`__cerberus_sel_*` Labels key that `toTraceSummaries` pivots into
`SpanSetSpan.Attributes`, which is where reference Tempo surfaces them.

**`internal/api/tempo/structural_two_phase.go`** (#1517) — said the union
`&>>` shape "leaves its left arm's inverse-closure side unrestricted and still
needs its own emitter fix before admission". The `Positive()` switch eighteen
lines below admits it, and the case comment at `:50-58` explains why it is
sound. A comment declaring a shape inadmissible directly above the code that
admits it sends the next reader hunting a rejection that does not exist.

**`internal/api/loki/detected_fields.go`** (#1517) — described the uniform
per-drain backstop as pending. It shipped on both axes: the row budget
(`chclient.drainBudgetExceeded`, `Config.MaxQuerySamples`) and the byte budget
(`maxLogPeekBytes` / `logPeekBytesExceeded`, wired into the two line-peek
drains at `client.go:1469` and `:1523`). The byte-axis comment already
cross-references this docstring's "scales with line SIZE × concurrency"
phrase, so that phrase is kept and only the pending-work clause is replaced.
Read as written, the old text told a resource-bound auditor the endpoint was
unbounded.

**`compatibility/tempo/driver/differ.go`** (#1496) — the intersection comment
promised that "skipping a side's blank field keeps the differ from
false-positing on optional-field omission". `:318` states the opposite and
`:322` is what runs: any inequality fires, blank-vs-value included. The
tolerance advertised here does not exist, and a comment inviting someone to
restore a deliberately removed tolerance points the wrong way past the
no-allow-lists rule. `differ.go:59` already carried the corrected wording;
this was the last stale copy.

**`compatibility/tempo/driver/corpus/smoke.txtar`** (#1496) — the corpus
header described an `H(rootServiceName||rootTraceName)` TraceID
canonicalisation step. Cerberus emits the real `hex(TraceId)` and the differ
keys on it directly.

**`internal/promql/lower.go`** (#1475) — the `count_values` rejection named
milestone M1.7, which no longer exists, and read as "unimplemented" for an
aggregator that is fully lowered by `lowerCountValues` /
`lowerSubqueryOverCountValues`. Rewritten to say what the branch actually is:
unreachable from the wire, and a routing bug if reached.

## Catalogue churn

The rejection-parity site key is `sha256(message)[:8]`, so changing that one
error string moves the entry from `#e759e84f` to `#4353c2b3`. Regenerated with
`CERBERUS_UPDATE_INVENTORY=1`; the curated `class` / `rationale` were
re-applied verbatim because the reasoning did not change — the site is still
"intercepted upstream on every parser-producible path". `go test
./test/rejection-parity/` passes 31/31, including
`TestCatalogueEntriesAreClassified`, which would have failed had the entry
been left unclassified.

## Scope

`docs/benchmarks.md` publishes pre-#840 set-op numbers and contradicts itself
on the K-nesting residual; that is a re-measurement, not a comment rewrite, so
it stays open under its own issue #1474 rather than riding along here.

No behaviour changes: five comment rewrites, one error string, one regenerated
generated artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
