### PR TITLE
fix(qlcommon): expand label_replace backrefs the way Go's ExpandString does

### DIFF
--- a/internal/logql/label_fns.go
+++ b/internal/logql/label_fns.go
@@ -52,11 +52,16 @@ func lowerLabelReplace(e *syntax.LabelReplaceExpr, s schema.Logs, lc lowerCtx) (
 	// `Attributes` — and rewrite THAT map. Reading ResourceAttributes
 	// unconditionally surfaced as 502 `Unknown expression identifier
 	// 'ResourceAttributes'` for `label_replace(sum by (...) (...), …)`.
+	chReplacement, err := qlcommon.ReplacementToCH(e.Replacement, e.Regex)
+	if err != nil {
+		return nil, fmt.Errorf("logql: label_replace: %w", err)
+	}
+
 	cols := logSampleColumns(inner, s)
 	attrs := &chplan.LabelReplace{
 		Map:              &chplan.ColumnRef{Name: cols.attrsCol},
 		Dst:              e.Dst,
-		Replacement:      qlcommon.ReplacementToCH(e.Replacement, e.Regex),
+		Replacement:      chReplacement,
 		Src:              e.Src,
 		Regex:            e.Regex,
 		EmptyReplacement: qlcommon.EmptyCapturesReplacement(e.Replacement),

--- a/internal/logql/label_fns_test.go
+++ b/internal/logql/label_fns_test.go
@@ -1,0 +1,52 @@
+package logql
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	syntax "github.com/tsouza/cerberus/internal/logql/lsyntax"
+
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestLowerLabelReplace_RejectsInexpressibleBackref is the LogQL twin
+// of the PromQL test with the same name. Both heads route their
+// replacement template through `qlcommon.ReplacementToCH`, so both must
+// surface its refusal as a query error instead of emitting a plan whose
+// destination label carries the wrong text.
+func TestLowerLabelReplace_RejectsInexpressibleBackref(t *testing.T) {
+	t.Parallel()
+
+	// Ten capture groups, so `$10` resolves to a group that exists and
+	// is above ClickHouse's `\9` substitution ceiling.
+	const q = `label_replace(sum by (host) (count_over_time({app="a"}[5m])), ` +
+		`"service", "$10", "host", "(.)(.)(.)(.)(.)(.)(.)(.)(.)(.)")`
+
+	expr, err := syntax.ParseExpr(q)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if _, err := Lower(context.Background(), expr, schema.DefaultOTelLogs()); err == nil {
+		t.Fatal("lowering accepted a replacement above ClickHouse's substitution ceiling; want an error")
+	} else if !strings.Contains(err.Error(), "label_replace") {
+		t.Fatalf("error does not name the function that failed: %v", err)
+	}
+}
+
+// TestLowerLabelReplace_AcceptsNamedCapture is the negative control:
+// a template the emitter can express must still lower cleanly.
+func TestLowerLabelReplace_AcceptsNamedCapture(t *testing.T) {
+	t.Parallel()
+
+	const q = `label_replace(sum by (host) (count_over_time({app="a"}[5m])), ` +
+		`"service", "svc-${svc}", "host", "host-(?P<svc>.*)")`
+
+	expr, err := syntax.ParseExpr(q)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if _, err := Lower(context.Background(), expr, schema.DefaultOTelLogs()); err != nil {
+		t.Fatalf("lowering rejected an expressible named backref: %v", err)
+	}
+}

--- a/internal/promql/label_fns.go
+++ b/internal/promql/label_fns.go
@@ -42,6 +42,11 @@ func lowerLabelReplace(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.N
 		return nil, err
 	}
 
+	chReplacement, err := qlcommon.ReplacementToCH(replacement, regex)
+	if err != nil {
+		return nil, fmt.Errorf("promql: label_replace: %w", err)
+	}
+
 	inner, err := lower(c.Args[0], s, ctx)
 	if err != nil {
 		return nil, err
@@ -49,7 +54,7 @@ func lowerLabelReplace(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.N
 	attrs := &chplan.LabelReplace{
 		Map:              &chplan.ColumnRef{Name: s.AttributesColumn},
 		Dst:              dst,
-		Replacement:      qlcommon.ReplacementToCH(replacement, regex),
+		Replacement:      chReplacement,
 		Src:              src,
 		Regex:            regex,
 		EmptyReplacement: qlcommon.EmptyCapturesReplacement(replacement),

--- a/internal/promql/label_fns_test.go
+++ b/internal/promql/label_fns_test.go
@@ -1,0 +1,53 @@
+package promql
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestLowerLabelReplace_RejectsInexpressibleBackref pins the head's
+// error path. `qlcommon.ReplacementToCH` refuses the handful of
+// replacement templates ClickHouse's fixed `\0`-`\9` substitution
+// cannot carry; lowering must surface that as a query error rather
+// than fall through and emit a plan whose destination label silently
+// holds the wrong text.
+func TestLowerLabelReplace_RejectsInexpressibleBackref(t *testing.T) {
+	t.Parallel()
+
+	// Ten capture groups, so `$10` resolves to a group that exists and
+	// is above the `\9` ceiling.
+	const q = `label_replace(temperature, "service", "$10", "host", "(.)(.)(.)(.)(.)(.)(.)(.)(.)(.)")`
+
+	expr, err := parser.NewParser(parser.Options{}).ParseExpr(q)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if _, err := Lower(context.Background(), expr, schema.DefaultOTelMetrics()); err == nil {
+		t.Fatal("lowering accepted a replacement above ClickHouse's substitution ceiling; want an error")
+	} else if !strings.Contains(err.Error(), "label_replace") {
+		t.Fatalf("error does not name the function that failed: %v", err)
+	}
+}
+
+// TestLowerLabelReplace_AcceptsNamedCapture is the negative control for
+// the test above: a template the emitter *can* express must still lower
+// cleanly, so the rejection above is evidence of a real boundary rather
+// than of label_replace being broken outright.
+func TestLowerLabelReplace_AcceptsNamedCapture(t *testing.T) {
+	t.Parallel()
+
+	const q = `label_replace(temperature, "service", "svc-${svc}", "host", "host-(?P<svc>.*)")`
+
+	expr, err := parser.NewParser(parser.Options{}).ParseExpr(q)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if _, err := Lower(context.Background(), expr, schema.DefaultOTelMetrics()); err != nil {
+		t.Fatalf("lowering rejected an expressible named backref: %v", err)
+	}
+}

--- a/internal/qlcommon/label_replace.go
+++ b/internal/qlcommon/label_replace.go
@@ -6,9 +6,26 @@
 package qlcommon
 
 import (
+	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 )
+
+// maxCHBackref is the highest capture-group index ClickHouse's
+// `replaceRegexpOne` substitution syntax can address: `\0` (the whole
+// match) through `\9`. Go's replacement templates have no such ceiling,
+// so a reference above this is the one shape the translation below
+// cannot express and rejects instead.
+const maxCHBackref = 9
+
+// unresolvedGroup is the capture-group index reported for a reference
+// that binds to nothing — an index past the regex's group count, or a
+// `$name` naming no group. Go's `ExpandString` substitutes the empty
+// string for both, so the translation drops the backref.
+const unresolvedGroup = -1
 
 // ReplacementToCH translates a Go-`regexp` replacement template
 // (`$1` / `${1}` / `$$` syntax — used by both PromQL's
@@ -32,54 +49,47 @@ import (
 // verbatim and emitted as the literal string `svc-$1` — the capture
 // group is never substituted.
 //
-// Translation rules implemented here (single-digit captures only — the
-// upstream label_replace functions don't constrain the index but CH's
-// backref syntax tops out at `\9`; multi-digit / named captures are
-// not used by any test or compatibility fixture and would need a
-// separate emit path):
+// Translation rules implemented here — the reference for every one of
+// them is Go's `Regexp.ExpandString`, which is the engine both QLs run
+// their replacement through, so this function reproduces its reference
+// splitter ([extractRef]) rather than approximating it:
 //
-//   - Pre-escape every existing `\` in the input to `\\`, so any
-//     literal backslash in the QL template survives as a literal
-//     backslash in CH (and is not re-interpreted as a CH backref by
-//     the digits we're about to introduce).
+//   - Every literal `\` in the input becomes `\\`, so a literal
+//     backslash in the QL template survives as a literal backslash in
+//     CH and is not re-read as the start of one of the `\N` backrefs
+//     spliced in below.
 //   - `$$` → `$` (literal dollar).
-//   - `$N` for a single ASCII digit (0-9) → `\N`.
-//   - `${N}` for a single ASCII digit (0-9) → `\N`.
-//   - Any other `$<x>` (including bare `$` at end-of-string, `$<letter>`,
-//     `${name}`, `$10` etc.) is preserved verbatim so we don't silently
-//     mistranslate a shape we don't fully support.
+//   - `$N` / `${N}` for ANY index N — including multi-digit `$10` —
+//     → `\N`, provided the regex has at least N capture groups.
+//   - `$name` / `${name}` → `\N` for the index of the capture group
+//     that carries that name.
+//   - A reference that binds to nothing — an index past the regex's
+//     group count, or a name no group carries — expands to the empty
+//     string, exactly as ExpandString does.
+//   - A `$` that starts no reference at all (end of string, `$-`,
+//     `${unclosed`) is emitted verbatim, again as ExpandString does.
 //
-// regex is the regex string the replacement is applied against;
-// it's used to count capture groups so out-of-range backrefs can be
-// rewritten to the empty string. CH validates `replaceRegexpOne`'s
-// substitution string against the regex's capture-group count at SQL-
-// parse time and rejects backrefs that exceed it (Code 36, BAD_ARGUMENTS)
-// — even on rows where match() short-circuits the if-branch that owns
-// the replaceRegexpOne call. The upstream QL semantics silently
-// substitute the empty string for missing groups (Go's ExpandString
-// semantics); replacing the backref with "" preserves that observable
-// behaviour on the (unreachable) hot path and unblocks the SQL parser
-// on the (very-much-reachable) cold path where the regex doesn't match
+// The single shape with no faithful translation is a reference to a
+// capture group that EXISTS but sits above CH's `\9` substitution
+// ceiling; that returns an error so the query is rejected loudly rather
+// than answered with a wrong label.
+//
+// regex is the regex string the replacement is applied against; it is
+// compiled to resolve capture-group names and to count groups so
+// out-of-range backrefs can be rewritten to the empty string. CH
+// validates `replaceRegexpOne`'s substitution string against the
+// regex's capture-group count at SQL-parse time and rejects backrefs
+// that exceed it (Code 36, BAD_ARGUMENTS) — even on rows where match()
+// short-circuits the if-branch that owns the replaceRegexpOne call.
+// Dropping the backref preserves the upstream empty-string semantics on
+// the (unreachable) hot path and unblocks the SQL parser on the
+// (very-much-reachable) cold path where the regex doesn't match
 // anything.
-func ReplacementToCH(repl, regex string) string {
-	// First pass: double every literal backslash so CH sees them as
-	// "literal backslash" (`\\`) rather than the start of its own
-	// backref escape sequence after we splice `\N` in below.
-	escaped := strings.ReplaceAll(repl, `\`, `\\`)
-
-	// Count capture groups in the anchored regex (the same anchoring
-	// the SQL emitter applies). Best-effort: if Go's parser can't
-	// compile the regex, fall back to allowing every single-digit
-	// backref — the emit-path will surface the compile error to the
-	// client via CH's own parse stage.
-	const maxBackref = 9
-	allowed := maxBackref
-	if compiled, err := regexp.Compile("^" + regex + "$"); err == nil {
-		allowed = compiled.NumSubexp()
-	}
+func ReplacementToCH(repl, regex string) (string, error) {
+	groups := newCaptureGroups(regex)
 
 	var b strings.Builder
-	b.Grow(len(escaped))
+	b.Grow(len(repl))
 	// Step-based loop: each branch returns the number of input bytes it
 	// consumed via `step`, and the for-iterator advances `i` by that
 	// amount. Phrasing the loop this way (rather than using `continue` /
@@ -90,77 +100,218 @@ func ReplacementToCH(repl, regex string) string {
 	// statements ran between the keyword and the iterator step. See PR
 	// #499 (the mutant-kill tests) and the follow-up PR that landed this
 	// refactor for the full diagnosis.
-	for i := 0; i < len(escaped); {
-		step := replacementStep(&b, escaped, i, allowed)
+	for i := 0; i < len(repl); {
+		step, err := replacementStep(&b, repl, i, groups)
+		if err != nil {
+			return "", err
+		}
 		i += step
 	}
-	return b.String()
+	return b.String(), nil
+}
+
+// captureGroups resolves a replacement template's `$N` / `$name`
+// references to capture-group indices for one regex.
+type captureGroups struct {
+	// count is the regex's capture-group count. A numbered reference
+	// above it binds to nothing.
+	count int
+	// byName maps each capture-group name to every index carrying it.
+	// Go's regexp permits the same name on several groups, so this is a
+	// slice rather than a single index. Empty when the regex did not
+	// compile, so every named reference then binds to nothing.
+	byName map[string][]int
+}
+
+// newCaptureGroups compiles regex for its capture-group metadata.
+//
+// Compilation is best-effort: when Go's parser rejects the regex there
+// is no group metadata to read, so every single-digit numbered backref
+// is allowed through and CH's own parse stage surfaces the regex error
+// to the client — the same fallback the pre-name-resolution version of
+// this file used.
+func newCaptureGroups(regex string) captureGroups {
+	// Anchored to mirror the SQL emitter. Anchoring shifts no group
+	// index, so the metadata read back is the unanchored regex's.
+	compiled, err := regexp.Compile("^" + regex + "$")
+	if err != nil {
+		return captureGroups{count: maxCHBackref}
+	}
+	g := captureGroups{count: compiled.NumSubexp(), byName: map[string][]int{}}
+	for i, name := range compiled.SubexpNames() {
+		if name == "" {
+			continue
+		}
+		g.byName[name] = append(g.byName[name], i)
+	}
+	return g
+}
+
+// resolve maps one extracted reference to its capture-group index, or
+// [unresolvedGroup] when the reference binds to nothing. It errors on
+// the references CH's fixed `\N` substitution cannot express.
+func (g captureGroups) resolve(ref templateRef) (int, error) {
+	idx := unresolvedGroup
+	switch carriers := g.byName[ref.name]; {
+	case ref.num != unresolvedGroup:
+		// A numbered reference past the regex's group count binds to
+		// nothing, which is the empty string — not an error.
+		if ref.num <= g.count {
+			idx = ref.num
+		}
+	case len(carriers) > 1:
+		// Go's regexp permits several groups to share one name, and
+		// ExpandString then picks the first of them that TOOK PART in
+		// the row's match. That choice varies row by row; a CH `\N`
+		// backref is fixed when the SQL is built and cannot follow it.
+		return 0, fmt.Errorf(
+			"references capture-group name %q, which %d capture groups share — "+
+				"ClickHouse's `\\N` substitution cannot pick between them per row",
+			ref.name, len(carriers),
+		)
+	case len(carriers) == 1:
+		idx = carriers[0]
+	}
+	if idx > maxCHBackref {
+		return 0, fmt.Errorf(
+			"references capture group %d, above ClickHouse's `\\%d` substitution ceiling",
+			idx, maxCHBackref,
+		)
+	}
+	return idx, nil
 }
 
 // replacementStep handles a single dispatch step of ReplacementToCH at
-// offset `i` of `escaped`. It writes the translated bytes to `b` and
-// returns the number of input bytes it consumed (always >= 1, so the
-// outer loop always makes progress).
+// offset `i` of `repl`. It writes the translated bytes to `b` and
+// returns the number of input bytes it consumed (always >= 1 on the
+// success path, so the outer loop always makes progress).
 //
 // Splitting this out of the loop body keeps the per-iteration consumed
 // count observable in the caller's iterator clause, so the gremlins
 // INVERT_LOOPCTRL operator can't swap `continue` ↔ `break` and produce
 // an equivalent mutant — the dispatch keywords don't live in a `for`
 // scope at all here.
-func replacementStep(b *strings.Builder, escaped string, i, allowed int) int {
-	c := escaped[i]
+func replacementStep(b *strings.Builder, repl string, i int, groups captureGroups) (int, error) {
+	c := repl[i]
 	if c != '$' {
+		if c == '\\' {
+			// Double the literal backslash so CH reads it as a literal
+			// rather than as the start of a `\N` backref.
+			b.WriteString(`\\`)
+			return 1, nil
+		}
 		b.WriteByte(c)
-		return 1
+		return 1, nil
 	}
-	// Lone `$` at end of string — preserve.
-	if i+1 >= len(escaped) {
+	// Lone `$` at end of string — ExpandString emits it verbatim.
+	if i+1 >= len(repl) {
 		b.WriteByte('$')
-		return 1
+		return 1, nil
 	}
-	next := escaped[i+1]
-	switch {
-	case next == '$':
+	if repl[i+1] == '$' {
 		// `$$` → literal `$`.
 		b.WriteByte('$')
-		return 2
-	case next >= '0' && next <= '9':
-		// `$N` → `\N` (single digit only — `$10` is preserved
-		// verbatim per upstream Go regexp semantics, but CH
-		// has no `\10`, so we'd mistranslate either way; preserving
-		// keeps the failure visible rather than silently wrong).
-		if i+2 < len(escaped) && escaped[i+2] >= '0' && escaped[i+2] <= '9' {
-			b.WriteByte('$')
-			return 1
-		}
-		n := int(next - '0')
-		// `\0` references the whole match and is always valid; for
-		// numbered captures, only emit `\N` if the regex actually
-		// has N capture groups. Out-of-range refs are dropped so
-		// CH's substitution validator stays happy.
-		if n == 0 || n <= allowed {
-			b.WriteByte('\\')
-			b.WriteByte(next)
-		}
-		return 2
-	case next == '{':
-		// `${N}` (single digit) → `\N`. Anything else (named
-		// captures, multi-digit indices) is preserved verbatim.
-		if i+3 < len(escaped) && escaped[i+2] >= '0' && escaped[i+2] <= '9' && escaped[i+3] == '}' {
-			n := int(escaped[i+2] - '0')
-			if n == 0 || n <= allowed {
-				b.WriteByte('\\')
-				b.WriteByte(escaped[i+2])
-			}
-			return 4
-		}
-		b.WriteByte('$')
-		return 1
-	default:
-		// `$<letter>` etc. — preserve verbatim.
-		b.WriteByte('$')
-		return 1
+		return 2, nil
 	}
+	ref, ok := extractRef(repl[i+1:])
+	if !ok {
+		// Not a reference at all (`$-`, `${unclosed`) — ExpandString
+		// emits the `$` verbatim and resumes at the next byte.
+		b.WriteByte('$')
+		return 1, nil
+	}
+	idx, err := groups.resolve(ref)
+	if err != nil {
+		return 0, fmt.Errorf("replacement %q %w", repl, err)
+	}
+	if idx != unresolvedGroup {
+		b.WriteByte('\\')
+		b.WriteString(strconv.Itoa(idx))
+	}
+	// An unresolved reference binds to nothing; ExpandString substitutes
+	// the empty string for it, so there is nothing to write.
+	return 1 + ref.width, nil
+}
+
+// templateRef is one `$…` reference split off the front of a Go
+// replacement template.
+type templateRef struct {
+	// name is the reference text with any braces stripped: `1`, `10`,
+	// `svc`.
+	name string
+	// num is the capture-group index when name is a plain decimal index,
+	// and [unresolvedGroup] when the reference is a NAME instead.
+	num int
+	// width is how many bytes of the template the reference occupies,
+	// not counting the leading `$`.
+	width int
+}
+
+// extractRef mirrors the unexported `extract` helper in Go's regexp
+// package, which is what `Regexp.ExpandString` — the engine both
+// PromQL's and LogQL's `label_replace` run their replacement through —
+// uses to split a `$…` reference off the front of a template.
+//
+// Reproducing it rather than pattern-matching a digit is what makes the
+// translation agree with the reference implementations on the shapes
+// that a hand-rolled scan gets wrong: `$10` is capture group TEN (Go
+// takes the LONGEST run of name characters, not one digit), `$1x` is a
+// reference to a group NAMED `1x` rather than group 1 followed by a
+// literal `x`, and `$01` is likewise a name because Go rejects leading
+// zeros as indices.
+//
+// str is the template starting immediately after the `$`. The reported
+// width excludes that `$`.
+func extractRef(str string) (templateRef, bool) {
+	rest := str
+	braced := strings.HasPrefix(rest, "{")
+	if braced {
+		rest = rest[1:]
+	}
+	// A name runs to the first byte that is not a letter, digit or `_`.
+	end := 0
+	for end < len(rest) {
+		r, size := utf8.DecodeRuneInString(rest[end:])
+		if !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '_' {
+			break
+		}
+		end += size
+	}
+	if end == 0 {
+		// An empty name is not a reference.
+		return templateRef{}, false
+	}
+	name := rest[:end]
+	width := end
+	if braced {
+		if end >= len(rest) || rest[end] != '}' {
+			// Missing closing brace — not a reference.
+			return templateRef{}, false
+		}
+		// Both braces are part of the reference's width.
+		width += len("{}")
+	}
+	return templateRef{name: name, num: refNum(name), width: width}, true
+}
+
+// refNum returns the capture-group index a reference name denotes, or
+// [unresolvedGroup] when the name is not a plain decimal index and must
+// be looked up as a capture-group NAME instead. Mirrors the numeric half
+// of Go's `extract`: a leading zero on a multi-character name, any
+// non-digit byte, or a value too large to hold demotes the reference to
+// a name lookup.
+func refNum(name string) int {
+	if name[0] == '0' && len(name) > 1 {
+		return unresolvedGroup
+	}
+	// The name charset is letters / digits / `_`, so Atoi can only fail
+	// on a non-digit byte or on overflow — both of which Go's own parse
+	// loop also treats as "this is a name".
+	num, err := strconv.Atoi(name)
+	if err != nil {
+		return unresolvedGroup
+	}
+	return num
 }
 
 // EmptyCapturesReplacement returns the result of substituting Go's
@@ -188,14 +339,19 @@ func replacementStep(b *strings.Builder, escaped string, i, allowed int) int {
 //	empty-captures result and using it as a short-circuit when the
 //	source value is empty at row time.
 //
-// Substitution rules (mirror `ReplacementToCH` but resolve each
-// backref to the empty string instead of CH's `\N` form):
+// Substitution rules (the same reference splitter `ReplacementToCH`
+// uses, but every reference resolves to the empty string instead of to
+// CH's `\N` form):
 //
-//   - `$$`                → literal `$`
-//   - `$N` / `${N}`       → empty string (the N-th capture binds to ""
-//     when the full match was "")
-//   - Any other `$<x>`    → preserved verbatim (named groups,
-//     multi-digit indices — same opt-out as `ReplacementToCH`)
+//   - `$$` → literal `$`
+//   - `$N` / `${N}` / `$name` / `${name}` → empty string. Every
+//     reference ExpandString recognises contributes "" here: a group
+//     that took part in the empty match expanded to "", and a group
+//     that bound to nothing (index past the group count, unknown name)
+//     expands to "" as well. No regex is needed to tell the two apart
+//     because the answer is the same either way.
+//   - A `$` that starts no reference (end of string, `$-`,
+//     `${unclosed`) → preserved verbatim, as ExpandString does.
 func EmptyCapturesReplacement(repl string) string {
 	var b strings.Builder
 	b.Grow(len(repl))
@@ -229,35 +385,19 @@ func emptyCapturesStep(b *strings.Builder, repl string, i int) int {
 		b.WriteByte('$')
 		return 1
 	}
-	next := repl[i+1]
-	switch {
-	case next == '$':
+	if repl[i+1] == '$' {
 		// `$$` → literal `$`.
 		b.WriteByte('$')
 		return 2
-	case next >= '0' && next <= '9':
-		// `$N` → "" (capture N is empty for an empty-string match).
-		// Two-digit `$10`+ is preserved verbatim — `ReplacementToCH`
-		// makes the same opt-out, so the regex compile / CH parse
-		// error surfaces consistently.
-		if i+2 < len(repl) && repl[i+2] >= '0' && repl[i+2] <= '9' {
-			b.WriteByte('$')
-			return 1
-		}
-		// Single-digit numbered capture → empty. Skip past the digit.
-		return 2
-	case next == '{':
-		// `${N}` (single digit) → "". Anything else (named captures,
-		// multi-digit indices) is preserved verbatim — same opt-out
-		// as `ReplacementToCH`.
-		if i+3 < len(repl) && repl[i+2] >= '0' && repl[i+2] <= '9' && repl[i+3] == '}' {
-			return 4
-		}
-		b.WriteByte('$')
-		return 1
-	default:
-		// `$<letter>` etc. — preserve verbatim.
+	}
+	ref, ok := extractRef(repl[i+1:])
+	if !ok {
+		// Not a reference — ExpandString emits the `$` verbatim and
+		// resumes at the next byte.
 		b.WriteByte('$')
 		return 1
 	}
+	// Every recognised reference expands to "" against an empty match,
+	// so there is nothing to write — just step over the reference.
+	return 1 + ref.width
 }

--- a/internal/qlcommon/label_replace_test.go
+++ b/internal/qlcommon/label_replace_test.go
@@ -1,12 +1,21 @@
 package qlcommon
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // nineCaptureRegex is a 9-group regex used as the "always-has-enough-
 // captures" sentinel in the table-driven test below. Each case that
 // references `$N` for any single-digit N expects the rewrite to succeed
 // because this regex has all 9 groups.
 const nineCaptureRegex = `(.)(.)(.)(.)(.)(.)(.)(.)(.)`
+
+// tenCaptureRegex has one group MORE than ClickHouse's `\9`
+// substitution ceiling, so `$10` against it names a group that really
+// exists and really cannot be expressed — the one shape
+// [ReplacementToCH] rejects instead of translating.
+const tenCaptureRegex = `(.)(.)(.)(.)(.)(.)(.)(.)(.)(.)`
 
 // TestReplacementToCH locks down the QL → ClickHouse replacement
 // template rewrite that PromQL + LogQL `label_replace` both rely on.
@@ -33,11 +42,44 @@ func TestReplacementToCH(t *testing.T) {
 		{"dollar_dollar_literal", "$$", nineCaptureRegex, "$"},
 		{"dollar_dollar_then_text", "$$x", nineCaptureRegex, "$x"},
 		{"braced_single_digit", "${1}-suffix", nineCaptureRegex, `\1-suffix`},
-		{"braced_multi_digit_preserved", "${10}", nineCaptureRegex, "${10}"},
-		{"multi_digit_unbraced_preserved", "$10", nineCaptureRegex, "$10"},
-		{"named_capture_preserved", "${name}", nineCaptureRegex, "${name}"},
+		{"braced_with_trailing_text", "xy${1}z", nineCaptureRegex, `xy\1z`},
 		{"lone_dollar_at_end", "abc$", nineCaptureRegex, "abc$"},
-		{"dollar_letter_preserved", "$x", nineCaptureRegex, "$x"},
+		// Every case below is an ExpandString shape a single-digit scan
+		// gets wrong. The `want` column is the CH template whose
+		// substitution reproduces what Go's ExpandString — the engine
+		// PromQL's and LogQL's label_replace both run the replacement
+		// through — actually yields; each was read off ExpandString
+		// rather than reasoned about. Go takes the LONGEST run of name
+		// characters after the `$`, so all of these are ONE reference,
+		// and each binds to nothing against a 9-group regex, which
+		// ExpandString renders as the empty string.
+		{"multi_digit_above_group_count", "$10", nineCaptureRegex, ""},
+		{"braced_multi_digit_above_group_count", "${10}", nineCaptureRegex, ""},
+		{"multi_digit_nineteen", "$19", nineCaptureRegex, ""},
+		{"unknown_named_capture_braced", "${name}", nineCaptureRegex, ""},
+		{"unknown_named_capture_bare", "$x", nineCaptureRegex, ""},
+		{"unknown_named_capture_underscore", "$_", nineCaptureRegex, ""},
+		// `$1x` is a reference to a group NAMED `1x`, not group 1
+		// followed by a literal `x` — the digit-scan reading emitted
+		// `\1x`, which substitutes a real capture and is the
+		// silently-wrong label the issue describes.
+		{"digit_then_letter_is_a_name", "$1x", nineCaptureRegex, ""},
+		// Leading zeros disqualify a reference from being an index, so
+		// `$01` is likewise a NAME lookup that finds nothing.
+		{"leading_zero_is_a_name", "$01", nineCaptureRegex, ""},
+		// Overflowing index — Go's parse loop gives up and treats it as
+		// a name, which no group carries.
+		{"index_overflow_is_a_name", "$99999999999999999999", nineCaptureRegex, ""},
+		{"literal_context_around_dropped_ref", "a-$x-b", nineCaptureRegex, "a--b"},
+		// `$` followed by a byte that can't start a name is not a
+		// reference at all; ExpandString emits the `$` verbatim.
+		{"dollar_then_non_name_byte", "$-", nineCaptureRegex, "$-"},
+		// Named captures resolve to the index of the group carrying the
+		// name — the whole point of the rewrite.
+		{"named_capture_resolves", "$svc", `(?P<svc>.*)`, `\1`},
+		{"named_capture_braced_resolves", "${svc}-x", `(?P<svc>.*)`, `\1-x`},
+		{"named_capture_second_group", "$svc", `(a)(?P<svc>.*)`, `\2`},
+		{"named_group_also_reachable_by_index", "$1", `(?P<svc>.*)`, `\1`},
 		{"existing_backslash_escaped", `\1`, nineCaptureRegex, `\\1`},
 		{"existing_backslash_and_backref", `\$1`, nineCaptureRegex, `\\\1`},
 		// Out-of-range backrefs drop. The regex has 0 capture groups,
@@ -59,64 +101,112 @@ func TestReplacementToCH(t *testing.T) {
 		// will surface the regex error to the client). The replacement
 		// translation is unchanged from the always-allowed shape.
 		{"invalid_regex_passthrough", "$1", "(.*", `\1`},
-		// Targeted mutation-kill cases pinning the gremlins CONDITIONALS_
-		// BOUNDARY / INVERT_LOGICAL / ARITHMETIC_BASE / REMOVE_SELF_
-		// ASSIGNMENTS mutants on the multi-digit-preserve and `${N}`
-		// branches inside `replacementStep` (the digit lookahead at the
-		// `next >= '0' && next <= '9'` arm, and the brace-block parse at
-		// the `next == '{'` arm). Each row below is calibrated so the
-		// original implementation produces the listed `want`, and at
-		// least one boundary-mutated variant produces an observably
-		// different string (or panics). Treat these as low-level guards
-		// — the user-facing semantics are already covered above; these
-		// only widen the discriminator set the mutation tool can use to
-		// prove the boundaries are load-bearing.
+		// Boundary guards on [extractRef]'s brace handling and on the
+		// capture-count gate. Each row is calibrated so the original
+		// produces the listed `want` and a boundary-mutated variant
+		// produces an observably different string (or panics), which is
+		// what lets the mutation tool prove the bounds are load-bearing.
 		//
-		//  * `multi_digit_unbraced_nine` pins the `<= '9'` upper bound
-		//    of the inner multi-digit lookahead inside the `next >= '0'`
-		//    case. Char at i+2 is exactly '9', so the boundary mutant
-		//    `< '9'` misses the branch and emits the single-digit form
-		//    `\19` instead of the verbatim `$19`.
-		{"multi_digit_unbraced_nine", "$19", nineCaptureRegex, "$19"},
-		//  * `braced_zero_with_caps` pins the `>= '0'` lower bound of
-		//    the braced digit check inside the `next == '{'` case. Char
-		//    at i+2 is exactly '0', so the boundary mutant `> '0'`
-		//    skips the branch and falls through to write the literal
-		//    `${0}` instead of the canonical `\0`.
+		//  * `braced_zero_with_caps` / `braced_nine_with_caps` pin the
+		//    `ref.num <= g.count` capture-count gate at both ends of
+		//    the single-digit range against a regex with exactly 9
+		//    groups: `< g.count` drops `\9`, and mishandling index 0
+		//    (the whole match, always valid) drops `\0`.
 		{"braced_zero_with_caps", "${0}", nineCaptureRegex, `\0`},
-		//  * `braced_nine_with_caps` pins both the `<= '9'` upper bound
-		//    of the braced digit check AND the `n <= allowed` capture-
-		//    count gate. Char at i+2 is exactly '9' and the regex has
-		//    exactly 9 capture groups, so both boundary mutants (`< '9'`
-		//    and `< allowed`) diverge from the canonical `\9`.
 		{"braced_nine_with_caps", "${9}", nineCaptureRegex, `\9`},
-		//  * `braced_non_digit_inner` pins both INVERT_LOGICAL mutants
-		//    on the chained `&&` in the brace-block parse. The char at
-		//    i+2 is a non-digit (`x`), so the original short-circuits
-		//    on `'x' <= '9'` and falls through to the literal-write
-		//    path. Either `&&` → `||` mutation upgrades the partial
-		//    truth into a full match, enters the consuming branch and
-		//    drops the entire `${x}` from the output.
-		{"braced_non_digit_inner", "${x}", nineCaptureRegex, "${x}"},
-		//  * `braced_truncated_digit` pins the ARITHMETIC_BASE mutant
-		//    on `i+3` AND the CONDITIONALS_BOUNDARY mutant on `<` in
-		//    the brace-block parse. The input is one byte short of a
-		//    closing `}`, so the original short-circuits on
-		//    `i+3 < len` (3 < 3 == false). The `i-3` mutant evaluates
-		//    `-3 < 3` as true and continues into the OOB `escaped[i+3]`
-		//    read; the `<=` mutant evaluates `3 <= 3` as true and does
-		//    the same. Both surface as test-failing panics.
+		//  * `braced_unclosed_before_text` pins the missing-closing-
+		//    brace rejection in extractRef. Dropping that check reads
+		//    `1` as a reference and emits `\1x` instead of the verbatim
+		//    text ExpandString produces.
+		{"braced_unclosed_before_text", "${1x", nineCaptureRegex, "${1x"},
+		//  * `braced_truncated_digit` pins the same rejection at
+		//    end-of-string, where a missing bounds check reads past the
+		//    end of the template.
 		{"braced_truncated_digit", "${1", nineCaptureRegex, "${1"},
+		//  * `empty_braces` pins the zero-length-name rejection: `${}`
+		//    carries no name, so it is not a reference.
+		{"empty_braces", "${}", nineCaptureRegex, "${}"},
+		//  * `brace_width_accounting` pins the `width += len("{}")`
+		//    term. If the braces aren't counted, the loop resumes
+		//    inside the reference and replays `}` as literal text.
+		{"brace_width_accounting", "${9}tail", nineCaptureRegex, `\9tail`},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			got := ReplacementToCH(tc.in, tc.regex)
+			got, err := ReplacementToCH(tc.in, tc.regex)
+			if err != nil {
+				t.Fatalf("ReplacementToCH(%q, %q): unexpected error: %v", tc.in, tc.regex, err)
+			}
 			if got != tc.want {
 				t.Fatalf("ReplacementToCH(%q, %q): got %q, want %q",
 					tc.in, tc.regex, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestReplacementToCHRejectsInexpressibleBackrefs pins the two shapes
+// that Go's ExpandString resolves to a real capture but ClickHouse's
+// fixed `\N` substitution cannot reproduce. Both used to be emitted as
+// literal template text — a 200 carrying a label whose value was the
+// template rather than an expansion of it, which is the silently-wrong
+// output issue #1490 reported. Rejecting at lowering makes the failure
+// loud instead.
+func TestReplacementToCHRejectsInexpressibleBackrefs(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		in       string
+		regex    string
+		wantErrs []string
+	}{
+		// Group 10 exists in a 10-group regex, so ExpandString expands
+		// it; CH tops out at `\9`.
+		{"index_above_ch_ceiling", "$10", tenCaptureRegex, []string{"capture group 10", `\9`}},
+		{"braced_index_above_ch_ceiling", "${10}", tenCaptureRegex, []string{"capture group 10", `\9`}},
+		// Go permits several groups to share a name and picks the first
+		// that took part in the row's match; a build-time `\N` can't.
+		{
+			"ambiguous_named_capture",
+			"$dup",
+			`(?P<dup>a)|(?P<dup>b)`,
+			[]string{`"dup"`, "2 capture groups"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ReplacementToCH(tc.in, tc.regex)
+			if err == nil {
+				t.Fatalf("ReplacementToCH(%q, %q): want error, got %q", tc.in, tc.regex, got)
+			}
+			if got != "" {
+				t.Fatalf("ReplacementToCH(%q, %q): want empty result alongside the error, got %q",
+					tc.in, tc.regex, got)
+			}
+			for _, want := range tc.wantErrs {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("ReplacementToCH(%q, %q): error %q does not name %q",
+						tc.in, tc.regex, err, want)
+				}
+			}
+		})
+	}
+}
+
+// TestReplacementToCHIndexBelowCeilingSurvivesLargeRegex guards the
+// rejection above from over-firing: a regex with more than nine groups
+// is fine as long as the replacement doesn't reach past `\9`.
+func TestReplacementToCHIndexBelowCeilingSurvivesLargeRegex(t *testing.T) {
+	t.Parallel()
+	got, err := ReplacementToCH("$9", tenCaptureRegex)
+	if err != nil {
+		t.Fatalf("ReplacementToCH($9, tenCaptureRegex): unexpected error: %v", err)
+	}
+	if want := `\9`; got != want {
+		t.Fatalf("ReplacementToCH($9, tenCaptureRegex): got %q, want %q", got, want)
 	}
 }
 
@@ -152,62 +242,48 @@ func TestEmptyCapturesReplacement(t *testing.T) {
 		{"dollar_dollar_then_text", "$$x", "$x"},
 		// Braced single-digit form behaves the same as bare `$N`.
 		{"braced_single_digit", "${1}-suffix", "-suffix"},
-		// Multi-digit indices and named captures are preserved verbatim
-		// — same opt-out as `ReplacementToCH`.
-		{"braced_multi_digit_preserved", "${10}", "${10}"},
-		{"multi_digit_unbraced_preserved", "$10", "$10"},
-		{"named_capture_preserved", "${name}", "${name}"},
-		// Edge cases that ExpandString handles literally.
+		// Multi-digit indices and named captures resolve to "" like any
+		// other reference: against an empty match a group that took
+		// part expanded to "", and one that binds to nothing expands to
+		// "" as well, so the two cases are indistinguishable here.
+		{"braced_multi_digit", "${10}", ""},
+		{"multi_digit_unbraced", "$10", ""},
+		{"named_capture", "${name}", ""},
+		{"named_capture_bare", "$svc", ""},
+		{"digit_then_letter_is_a_name", "$1x", ""},
+		{"leading_zero_is_a_name", "$01", ""},
+		// Edge cases that ExpandString handles literally: a `$` that
+		// starts no reference stays a `$`.
 		{"lone_dollar_at_end", "abc$", "abc$"},
-		{"dollar_letter_preserved", "$x", "$x"},
+		{"dollar_then_non_name_byte", "$-", "$-"},
+		{"empty_braces", "${}", "${}"},
+		{"braced_unclosed_before_text", "${1x", "${1x"},
 		// Literal backslashes pass through unchanged — only `$`-prefixed
 		// metacharacters are interpreted in the Go regex replacement
 		// template the QLs feed us.
 		{"existing_backslash_preserved", `\1`, `\1`},
-		// Targeted mutation-kill cases pinning the gremlins CONDITIONALS_
-		// BOUNDARY / INVERT_LOGICAL / ARITHMETIC_BASE / REMOVE_SELF_
-		// ASSIGNMENTS mutants on the multi-digit-preserve and `${N}`
-		// branches inside `emptyCapturesStep`. The mirror of the
-		// ReplacementToCH cases above, recalibrated for the empty-
-		// captures resolver (numbered captures collapse to "" instead
-		// of `\N`, so the original on the consuming branch returns the
-		// empty string).
+		// Boundary guards mirroring the ReplacementToCH set, calibrated
+		// for the empty-captures resolver (every recognised reference
+		// collapses to "" instead of to `\N`).
 		//
-		//  * `multi_digit_unbraced_nine` pins the `<= '9'` upper bound
-		//    of the multi-digit lookahead inside the `next >= '0'` case.
-		//    Char at i+2 is '9'; the boundary mutant `< '9'` falls into
-		//    the single-digit-collapse branch and emits the trailing
-		//    `9` alone instead of the verbatim `$19`.
-		{"multi_digit_unbraced_nine", "$19", "$19"},
-		//  * `braced_zero` pins the `>= '0'` lower bound in the brace-
-		//    block parse. Char at i+2 is '0'; the boundary mutant
-		//    `> '0'` skips the consuming branch and writes the literal
-		//    `${0}` instead of the empty result the original produces.
+		//  * `multi_digit_unbraced_nine` pins that the reference runs to
+		//    the END of the digit run. A splitter that stopped after one
+		//    digit would leave the trailing `9` in the output.
+		{"multi_digit_unbraced_nine", "$19", ""},
 		{"braced_zero", "${0}", ""},
-		//  * `braced_nine` pins the `<= '9'` upper bound in the brace-
-		//    block parse. Char at i+2 is '9'; the boundary mutant
-		//    `< '9'` skips the consuming branch and writes the literal
-		//    `${9}` instead of the empty result.
 		{"braced_nine", "${9}", ""},
-		//  * `braced_non_digit_inner` pins both INVERT_LOGICAL mutants
-		//    on the chained `&&` in the brace-block parse. Char at i+2
-		//    is non-digit; either `&&` → `||` swap upgrades the partial
-		//    truth into a full match and erases the brace block.
-		{"braced_non_digit_inner", "${x}", "${x}"},
-		//  * `braced_truncated_digit` pins ARITHMETIC_BASE on `i+3`
-		//    AND CONDITIONALS_BOUNDARY on `<` in the brace-block parse.
-		//    Same mechanism as the ReplacementToCH twin: the OOB
-		//    `repl[i+3]` read panics under either mutant.
+		//  * `braced_non_digit_inner` pins that a braced NAME is a
+		//    reference too, not literal text.
+		{"braced_non_digit_inner", "${x}", ""},
+		//  * `braced_truncated_digit` pins the missing-closing-brace
+		//    rejection, including the bounds check that a mutant would
+		//    read past.
 		{"braced_truncated_digit", "${1", "${1"},
-		//  * `braced_with_trailing_text` pins the ARITHMETIC_BASE
-		//    mutant on the `return 4` step value of the brace-block
-		//    branch. The literal prefix `xy` shifts the `${1}` to
-		//    offset 2; the original returns step 4 (consuming the
-		//    brace block) so the next iteration lands on `z`. If the
-		//    consumed-byte count is mutated to 1 the next iteration
-		//    lands on the digit `1` inside the brace block, replays
-		//    the suffix as plain text and emits `xy1}z` instead of
-		//    `xyz`.
+		//  * `braced_with_trailing_text` pins the reference's width
+		//    accounting. The literal prefix `xy` shifts the `${1}` to
+		//    offset 2; if the consumed-byte count is short, the next
+		//    iteration lands inside the brace block, replays the suffix
+		//    as plain text and emits `xy1}z` instead of `xyz`.
 		{"braced_with_trailing_text", "xy${1}z", "xyz"},
 	}
 	for _, tc := range cases {

--- a/test/perf/cardinality-baseline.json
+++ b/test/perf/cardinality-baseline.json
@@ -3970,6 +3970,16 @@
     "max_recursion_depth": 0
   },
   {
+    "fixture": "promql/label_replace_backref_above_group_count",
+    "fan_factor": 1,
+    "scan_rows": 1,
+    "peak_intermediate": 1,
+    "has_cross_join": false,
+    "has_array_join": false,
+    "has_recursive_cte": false,
+    "max_recursion_depth": 0
+  },
+  {
     "fixture": "promql/label_replace_basic",
     "fan_factor": 1,
     "scan_rows": 1,
@@ -3991,6 +4001,16 @@
   },
   {
     "fixture": "promql/label_replace_missing_src_overwrite",
+    "fan_factor": 1,
+    "scan_rows": 1,
+    "peak_intermediate": 1,
+    "has_cross_join": false,
+    "has_array_join": false,
+    "has_recursive_cte": false,
+    "max_recursion_depth": 0
+  },
+  {
+    "fixture": "promql/label_replace_named_capture",
     "fan_factor": 1,
     "scan_rows": 1,
     "peak_intermediate": 1,

--- a/test/perf/solver-decision-baseline.json
+++ b/test/perf/solver-decision-baseline.json
@@ -2230,6 +2230,16 @@
     "outer_range": "1h0m0s"
   },
   {
+    "query": "label_replace_backref_above_group_count",
+    "routed": true,
+    "k": 8,
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
+  },
+  {
     "query": "label_replace_basic",
     "routed": true,
     "k": 8,
@@ -2251,6 +2261,16 @@
   },
   {
     "query": "label_replace_missing_src_overwrite",
+    "routed": true,
+    "k": 8,
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
+  },
+  {
+    "query": "label_replace_named_capture",
     "routed": true,
     "k": 8,
     "reason": "routed",

--- a/test/rejection-parity/catalogue.json
+++ b/test/rejection-parity/catalogue.json
@@ -66,6 +66,13 @@
     },
     {
       "head": "logql",
+      "site": "internal/logql/label_fns.go:lowerLabelReplace#8cd9f67b",
+      "message": "logql: label_replace: %w",
+      "class": "rejection",
+      "trigger_query": "label_replace(rate({app=\"x\"}[5m]), \"d\", \"$10\", \"src\", \"(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)\")"
+    },
+    {
+      "head": "logql",
       "site": "internal/logql/label_fns.go:lowerLabelReplace#997ce6c3",
       "message": "logql: label_replace has nil inner",
       "class": "internal",
@@ -504,6 +511,13 @@
       "message": "promql: label_replace expects 5 arguments, got %d",
       "class": "internal",
       "rationale": "parser-enforced arity: label_replace requires exactly five arguments"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/label_fns.go:lowerLabelReplace#d11e3df4",
+      "message": "promql: label_replace: %w",
+      "class": "rejection",
+      "trigger_query": "label_replace(up, \"d\", \"$10\", \"src\", \"(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)\")"
     },
     {
       "head": "promql",

--- a/test/spec/promql/label_replace_backref_above_group_count.txtar
+++ b/test/spec/promql/label_replace_backref_above_group_count.txtar
@@ -1,0 +1,53 @@
+# `$10` is a reference to capture group TEN — Go's ExpandString takes
+# the longest run of name characters after the `$`, not one digit. The
+# regex here has a single group, so group ten binds to nothing and
+# Prometheus substitutes the empty string, leaving `service="svc-"`.
+#
+# Emitting the literal text `svc-$10` instead (the pre-fix behaviour)
+# was a 200 carrying a label whose value was the replacement template.
+-- query.promql --
+label_replace(temperature, "service", "svc-$10", "host", "host-(.*)")
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('temperature', map('host', 'host-prod'), toDateTime64('2026-01-01 00:00:00', 9), 22.5);
+-- expected_rows --
+[
+  ["temperature", {"host": "host-prod", "service": "svc-"}, "2026-01-01T00:00:00Z", 22.5]
+]
+-- args --
+[0] string = "host"
+[1] string = "^host-(.*)$"
+[2] string = "service"
+[3] string = "host"
+[4] string = "svc-"
+[5] string = "host"
+[6] string = "^host-(.*)$"
+[7] string = "svc-"
+[8] string = "service.name"
+[9] string = "service_name"
+[10] string = "service.name"
+[11] string = "service_name"
+[12] string = ""
+[13] string = "service_name"
+[14] string = "temperature"
+[15] string = "2026-01-01 00:00:01.000000000"
+[16] int64 = 9
+[17] string = "2026-01-01 00:00:01.000000000"
+[18] int64 = 9
+[19] int64 = 300000000000
+-- chplan --
+Project [MetricName, labelReplace(Attributes, dst="service", replacement="svc-", src="host", regex="host-(.*)", emptyReplacement="svc-") AS Attributes, TimeUnix, Value]
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=((TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9)) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Project [MetricName AS MetricName, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, Value AS Value]
+          Filter predicate=(MetricName = "temperature")
+            Scan(merge(otel_metrics_gauge|otel_metrics_sum))
+-- sql --
+SELECT `MetricName`, mapFilter((k, v) -> v != '', if(match(`Attributes`[?], ?), mapUpdate(`Attributes`, map(?, if(empty(`Attributes`[?]), ?, replaceRegexpOne(`Attributes`[?], ?, ?)))), `Attributes`)) AS `Attributes`, `TimeUnix`, `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') PREWHERE (`MetricName` = ?))) WHERE ((`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?))))) GROUP BY `MetricName`, `Attributes`))

--- a/test/spec/promql/label_replace_named_capture.txtar
+++ b/test/spec/promql/label_replace_named_capture.txtar
@@ -1,0 +1,52 @@
+# A named capture group in the regex, referenced as `${svc}` in the
+# replacement. Go's ExpandString — the engine Prometheus runs
+# label_replace's replacement through — resolves the name to the index
+# of the group carrying it, so the destination label gets the captured
+# text. qlcommon.ReplacementToCH performs that resolution at lowering
+# time and emits CH's positional `\1`.
+-- query.promql --
+label_replace(temperature, "service", "svc-${svc}", "host", "host-(?P<svc>.*)")
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('temperature', map('host', 'host-prod'), toDateTime64('2026-01-01 00:00:00', 9), 22.5);
+-- expected_rows --
+[
+  ["temperature", {"host": "host-prod", "service": "svc-prod"}, "2026-01-01T00:00:00Z", 22.5]
+]
+-- args --
+[0] string = "host"
+[1] string = "^host-(?P<svc>.*)$"
+[2] string = "service"
+[3] string = "host"
+[4] string = "svc-"
+[5] string = "host"
+[6] string = "^host-(?P<svc>.*)$"
+[7] string = "svc-\\1"
+[8] string = "service.name"
+[9] string = "service_name"
+[10] string = "service.name"
+[11] string = "service_name"
+[12] string = ""
+[13] string = "service_name"
+[14] string = "temperature"
+[15] string = "2026-01-01 00:00:01.000000000"
+[16] int64 = 9
+[17] string = "2026-01-01 00:00:01.000000000"
+[18] int64 = 9
+[19] int64 = 300000000000
+-- chplan --
+Project [MetricName, labelReplace(Attributes, dst="service", replacement="svc-\\1", src="host", regex="host-(?P<svc>.*)", emptyReplacement="svc-") AS Attributes, TimeUnix, Value]
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=((TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9)) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Project [MetricName AS MetricName, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, Value AS Value]
+          Filter predicate=(MetricName = "temperature")
+            Scan(merge(otel_metrics_gauge|otel_metrics_sum))
+-- sql --
+SELECT `MetricName`, mapFilter((k, v) -> v != '', if(match(`Attributes`[?], ?), mapUpdate(`Attributes`, map(?, if(empty(`Attributes`[?]), ?, replaceRegexpOne(`Attributes`[?], ?, ?)))), `Attributes`)) AS `Attributes`, `TimeUnix`, `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') PREWHERE (`MetricName` = ?))) WHERE ((`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?))))) GROUP BY `MetricName`, `Attributes`))


### PR DESCRIPTION
## The bug

`qlcommon.ReplacementToCH` scanned exactly **one digit** after a `$` and copied everything else through as literal text. Go's `regexp.ExpandString` — the engine both Prometheus and Loki run a `label_replace` replacement through — instead:

- takes the **longest run of name characters** after the `$` (so `$10` is group *ten*, not group one followed by `0`),
- accepts `${...}` bracing,
- resolves a non-numeric run as a capture-group **name**,
- substitutes the **empty string** for any reference that binds to nothing.

Every shape outside `$0`–`$9` therefore came out silently wrong. The query still returned rows, so the caller saw plausible-looking output carrying a label whose value was the replacement *template*:

| replacement | cerberus emitted | Prometheus / Loki |
|---|---|---|
| `svc-$10` (1-group regex) | `svc-$10` | `svc-` |
| `svc-${svc}` (`(?P<svc>...)`) | `svc-${svc}` | `svc-prod` |
| `svc-$x` | `svc-$x` | `svc-` |

Worse, the empty-match arm (`emptyReplacement`) *already* stripped these to `""`, so a single query disagreed with itself depending on whether the source label happened to match.

## The fix

The splitter now mirrors `regexp.extract` byte for byte, and resolves named groups against the compiled regex at lowering time so ClickHouse gets its positional `\N`.

Two shapes genuinely cannot be carried by CH's fixed `\0`–`\9` substitution, and are now **rejected as query errors** rather than mistranslated:

- an index above the `\9` ceiling that actually exists in the regex;
- a name shared by more than one capture group — Go resolves that per row to the first *participating* group, which a build-time `\N` cannot follow. (Go's `regexp` does permit duplicate group names; verified against a real compile.)

## Tests

- Unit expectations in `internal/qlcommon/label_replace_test.go` were **re-derived from a real `regexp.ExpandString` oracle**, not from the previous behaviour — the old "preserved verbatim" cases were pinning the bug.
- Two chDB round-trip fixtures under `test/spec/promql/` assert the label values end-to-end: `label_replace_named_capture` (`service="svc-prod"`) and `label_replace_backref_above_group_count` (`service="svc-"`).
- Both fixtures were confirmed **red** against the pre-fix code (stashed the fix, re-ran `TestLower`: `args` + `chplan` + `sql` all mismatch).
- New error-path tests at both head call sites (`internal/{promql,logql}/label_fns_test.go`), each with a negative control so the rejection is evidence of a real boundary rather than of `label_replace` being broken outright.

Closes #1490

🤖 Generated with [Claude Code](https://claude.com/claude-code)
