### PR TITLE
fix(promql): keep __name__ per series for regex-matched last/first_over_time

### DIFF
--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -2027,8 +2027,11 @@ func lowerRangeVectorCall(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chpla
 		// across the step grid via a CrossJoin(StepGrid). This is the
 		// range-vector sibling of wrapRangeAbsoluteAtBroadcast (the
 		// bare-selector `@`-pin path).
-		return wrapRangeWindowAtBroadcast(rw, ctx, s, c.Func.Name,
-			metricNameFromMatchers(vs.LabelMatchers), &chplan.ColumnRef{Name: s.ValueColumn}), nil
+		var nameExpr chplan.Expr
+		if rangeFnPreservesName(c.Func.Name) {
+			nameExpr = preservedNameExpr(rw, vs.LabelMatchers, s)
+		}
+		return wrapRangeWindowAtBroadcast(rw, ctx, s, nameExpr, &chplan.ColumnRef{Name: s.ValueColumn}), nil
 	case gridFanout:
 		// In range mode, fan the range function across the request's step
 		// grid: each anchor in [start, end] (spaced by step) emits one row
@@ -2106,14 +2109,13 @@ func lowerRangeVectorCall(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chpla
 	// derived-shape `LitString{""} AS MetricName` synthesis, so the
 	// literal flows through and `__name__` appears on the wire.
 	//
-	// The matcher's `__name__` value must be a single equality matcher
-	// (`metric_name{...}`) for `metricNameFromMatchers` to return a
-	// non-empty string. Regex `__name__=~"foo|bar"` falls through to
-	// the existing empty-MetricName behaviour — threading per-series
-	// names through the windowed aggregation is a larger structural
-	// change not modelled here.
-	if c.Func.Name == "last_over_time" || c.Func.Name == "first_over_time" {
-		return wrapRangeWindowPreserveName(rw, s, metricNameFromMatchers(vs.LabelMatchers)), nil
+	// A single `__name__="x"` equality matcher pins one name for every
+	// row, so the projection can use a literal. A regex matcher
+	// (`__name__=~"foo|bar"`) spans several metrics whose names differ
+	// per series, so `preservedNameExpr` threads MetricName through the
+	// window's grouping key instead.
+	if rangeFnPreservesName(c.Func.Name) {
+		return wrapRangeWindowPreserveName(rw, s, preservedNameExpr(rw, vs.LabelMatchers, s)), nil
 	}
 	return node, nil
 }
@@ -2479,7 +2481,47 @@ func isIdentityColumnRef(x chplan.Expr, name string) bool {
 // the handler uses for derived-shape Projects. The outer
 // `wrapWithSampleProjection` canonical branch reads back the
 // `s.TimestampColumn` alias verbatim either way.
-func wrapRangeWindowPreserveName(rw *chplan.RangeWindow, s schema.Metrics, name string) chplan.Node {
+// rangeFnPreservesName reports whether a PromQL range function keeps
+// `__name__` on its output. Mirrors upstream:
+//
+//	prometheus/prometheus@cerberus-parser/promql/engine.go:2114
+//	`dropName := (e.Func.Name != "last_over_time" && e.Func.Name != "first_over_time")`
+func rangeFnPreservesName(fn string) bool {
+	return fn == "last_over_time" || fn == "first_over_time"
+}
+
+// preservedNameExpr picks the expression a preserve-name wrapper should
+// project as the MetricName column.
+//
+// A single `__name__="x"` equality matcher pins the same name onto every
+// row, so a literal is enough and the window's grouping key is left
+// alone. Anything else — `__name__=~"a|b"`, or a selector carrying no
+// name matcher — spans several metrics whose names differ per series. A
+// literal cannot express that: `last_over_time({__name__=~"a|b"}[5m])`
+// would answer with rows whose `__name__` is absent, and, worse, two
+// metrics sharing an attribute set would collapse into a single series
+// because MetricName is not part of the grouping key. So the name rides
+// through the window on the group key and is projected per row.
+func preservedNameExpr(rw *chplan.RangeWindow, ms []*labels.Matcher, s schema.Metrics) chplan.Expr {
+	if name := metricNameFromMatchers(ms); name != "" {
+		return &chplan.LitString{V: name}
+	}
+	if s.MetricNameColumn == "" {
+		// A schema with no metric-name column has no per-series name to
+		// carry; the literal keeps the canonical 4-column shape intact.
+		return &chplan.LitString{V: ""}
+	}
+	nameRef := &chplan.ColumnRef{Name: s.MetricNameColumn}
+	for _, g := range rw.GroupBy {
+		if isIdentityColumnRef(g, s.MetricNameColumn) {
+			return nameRef
+		}
+	}
+	rw.GroupBy = append(append(make([]chplan.Expr, 0, len(rw.GroupBy)+1), rw.GroupBy...), nameRef)
+	return nameRef
+}
+
+func wrapRangeWindowPreserveName(rw *chplan.RangeWindow, s schema.Metrics, name chplan.Expr) chplan.Node {
 	var tsExpr chplan.Expr
 	if rw.OuterRange > 0 {
 		// The matrix RangeWindow keeps anchor_ts offset-SHIFTED for the
@@ -2503,7 +2545,7 @@ func wrapRangeWindowPreserveName(rw *chplan.RangeWindow, s schema.Metrics, name 
 	return &chplan.Project{
 		Input: rw,
 		Projections: []chplan.Projection{
-			{Expr: &chplan.LitString{V: name}, Alias: s.MetricNameColumn},
+			{Expr: name, Alias: s.MetricNameColumn},
 			{Expr: &chplan.ColumnRef{Name: s.AttributesColumn}, Alias: s.AttributesColumn},
 			{Expr: tsExpr, Alias: s.TimestampColumn},
 			{Expr: &chplan.ColumnRef{Name: s.ValueColumn}, Alias: s.ValueColumn},
@@ -2524,12 +2566,14 @@ func wrapRangeWindowPreserveName(rw *chplan.RangeWindow, s schema.Metrics, name 
 // downstream consumers (aggregations, arithmetic) see the identical
 // column shape whether or not the inner carried an `@` pin.
 //
-// `last_over_time` / `first_over_time` preserve `__name__`
-// (dropName=false in Prom); for them the projection pins MetricName to
-// the matcher's literal name and exposes the canonical 4-column Sample
-// contract `(MetricName, Attributes, anchor_ts AS TimeUnix, Value)`,
-// mirroring wrapRangeWindowPreserveName's matrix branch. Every other
-// range fn drops `__name__`, so MetricName is omitted.
+// `name` is the expression projected as the MetricName column, or nil
+// when the range function drops `__name__`. `last_over_time` /
+// `first_over_time` preserve it (dropName=false in Prom); for them the
+// caller supplies `preservedNameExpr`'s literal-or-column choice and the
+// projection exposes the canonical 4-column Sample contract
+// `(MetricName, Attributes, anchor_ts AS TimeUnix, Value)`, mirroring
+// wrapRangeWindowPreserveName's matrix branch. Every other range fn
+// passes nil, so MetricName is omitted.
 //
 // `value` is the expression projected as the Value column. Callers that
 // forward the window's own value pass `&chplan.ColumnRef{Name:
@@ -2541,16 +2585,15 @@ func wrapRangeWindowPreserveName(rw *chplan.RangeWindow, s schema.Metrics, name 
 // TimeUnix and drops `anchor_ts`, which is precisely the column the
 // broadcast exists to carry.
 func wrapRangeWindowAtBroadcast(
-	rw *chplan.RangeWindow, ctx lowerCtx, s schema.Metrics, fn, name string, value chplan.Expr,
+	rw *chplan.RangeWindow, ctx lowerCtx, s schema.Metrics, name, value chplan.Expr,
 ) chplan.Node {
 	grid := &chplan.StepGrid{Start: ctx.start.UTC(), End: ctx.end.UTC(), Step: ctx.step}
 	joined := &chplan.CrossJoin{Left: grid, Right: rw}
 
-	preserveName := fn == "last_over_time" || fn == "first_over_time"
 	projections := make([]chplan.Projection, 0, 4)
-	if preserveName {
+	if name != nil {
 		projections = append(projections,
-			chplan.Projection{Expr: &chplan.LitString{V: name}, Alias: s.MetricNameColumn})
+			chplan.Projection{Expr: name, Alias: s.MetricNameColumn})
 	}
 	projections = append(
 		projections,

--- a/internal/promql/preserved_name_test.go
+++ b/internal/promql/preserved_name_test.go
@@ -1,0 +1,175 @@
+package promql
+
+import (
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+func mustMatcher(t *testing.T, typ labels.MatchType, name, value string) *labels.Matcher {
+	t.Helper()
+	m, err := labels.NewMatcher(typ, name, value)
+	if err != nil {
+		t.Fatalf("NewMatcher(%v, %q, %q): %v", typ, name, value, err)
+	}
+	return m
+}
+
+// newAttrOnlyWindow builds the RangeWindow shape the range-vector
+// lowering hands to the preserve-name wrappers: grouped on the
+// Attributes map alone, which is exactly why a per-series metric name
+// cannot survive it unaided.
+func newAttrOnlyWindow(s schema.Metrics) *chplan.RangeWindow {
+	return &chplan.RangeWindow{
+		Func:    "last_over_time",
+		GroupBy: []chplan.Expr{&chplan.ColumnRef{Name: s.AttributesColumn}},
+	}
+}
+
+// TestPreservedNameExpr_EqualityMatcherPinsLiteral: one name for every
+// row, so the window's grouping key must be left alone — widening it
+// would split nothing and cost a GROUP BY key.
+func TestPreservedNameExpr_EqualityMatcherPinsLiteral(t *testing.T) {
+	t.Parallel()
+	s := schema.DefaultOTelMetrics()
+	rw := newAttrOnlyWindow(s)
+
+	got := preservedNameExpr(rw, []*labels.Matcher{
+		mustMatcher(t, labels.MatchEqual, model.MetricNameLabel, "cpu_temp"),
+		mustMatcher(t, labels.MatchEqual, "host", "a"),
+	}, s)
+
+	lit, ok := got.(*chplan.LitString)
+	if !ok {
+		t.Fatalf("got %T, want *chplan.LitString", got)
+	}
+	if lit.V != "cpu_temp" {
+		t.Fatalf("literal name: got %q, want %q", lit.V, "cpu_temp")
+	}
+	if len(rw.GroupBy) != 1 {
+		t.Fatalf("grouping key widened for a pinned name: got %d keys, want 1", len(rw.GroupBy))
+	}
+}
+
+// TestPreservedNameExpr_RegexMatcherCarriesColumn is the case #1492
+// reported: the name differs per series, so it has to join the grouping
+// key or the metrics collapse into one another.
+func TestPreservedNameExpr_RegexMatcherCarriesColumn(t *testing.T) {
+	t.Parallel()
+	s := schema.DefaultOTelMetrics()
+	rw := newAttrOnlyWindow(s)
+
+	got := preservedNameExpr(rw, []*labels.Matcher{
+		mustMatcher(t, labels.MatchRegexp, model.MetricNameLabel, "cpu_temp|gpu_temp"),
+	}, s)
+
+	if !isIdentityColumnRef(got, s.MetricNameColumn) {
+		t.Fatalf("projected name expr: got %#v, want ColumnRef(%q)", got, s.MetricNameColumn)
+	}
+	if len(rw.GroupBy) != 2 {
+		t.Fatalf("grouping key: got %d keys, want 2 (Attributes + %s)", len(rw.GroupBy), s.MetricNameColumn)
+	}
+	if !isIdentityColumnRef(rw.GroupBy[1], s.MetricNameColumn) {
+		t.Fatalf("appended key: got %#v, want ColumnRef(%q)", rw.GroupBy[1], s.MetricNameColumn)
+	}
+	// The Attributes key must survive alongside it, not be replaced.
+	if !isIdentityColumnRef(rw.GroupBy[0], s.AttributesColumn) {
+		t.Fatalf("original key clobbered: got %#v, want ColumnRef(%q)", rw.GroupBy[0], s.AttributesColumn)
+	}
+}
+
+// TestPreservedNameExpr_NoNameMatcherCarriesColumn: a selector matching
+// purely on labels (`last_over_time({host="a"}[5m])`) spans every metric
+// carrying that label, so it needs the same per-row treatment as the
+// regex case.
+func TestPreservedNameExpr_NoNameMatcherCarriesColumn(t *testing.T) {
+	t.Parallel()
+	s := schema.DefaultOTelMetrics()
+	rw := newAttrOnlyWindow(s)
+
+	got := preservedNameExpr(rw, []*labels.Matcher{
+		mustMatcher(t, labels.MatchEqual, "host", "a"),
+	}, s)
+
+	if !isIdentityColumnRef(got, s.MetricNameColumn) {
+		t.Fatalf("projected name expr: got %#v, want ColumnRef(%q)", got, s.MetricNameColumn)
+	}
+	if len(rw.GroupBy) != 2 {
+		t.Fatalf("grouping key: got %d keys, want 2", len(rw.GroupBy))
+	}
+}
+
+// TestPreservedNameExpr_DoesNotDuplicateExistingKey pins idempotence: a
+// window that already groups on MetricName must not gain a second copy,
+// which would be a redundant GROUP BY key and a churned golden.
+func TestPreservedNameExpr_DoesNotDuplicateExistingKey(t *testing.T) {
+	t.Parallel()
+	s := schema.DefaultOTelMetrics()
+	rw := newAttrOnlyWindow(s)
+	rw.GroupBy = append(rw.GroupBy, &chplan.ColumnRef{Name: s.MetricNameColumn})
+
+	got := preservedNameExpr(rw, []*labels.Matcher{
+		mustMatcher(t, labels.MatchRegexp, model.MetricNameLabel, "cpu_temp|gpu_temp"),
+	}, s)
+
+	if !isIdentityColumnRef(got, s.MetricNameColumn) {
+		t.Fatalf("projected name expr: got %#v, want ColumnRef(%q)", got, s.MetricNameColumn)
+	}
+	if len(rw.GroupBy) != 2 {
+		t.Fatalf("grouping key gained a duplicate: got %d keys, want 2", len(rw.GroupBy))
+	}
+}
+
+// TestPreservedNameExpr_SchemaWithoutMetricNameColumn: there is no
+// per-series name to carry, so the wrapper keeps its canonical
+// 4-column shape with an empty literal rather than emitting a
+// ColumnRef to a column that does not exist.
+func TestPreservedNameExpr_SchemaWithoutMetricNameColumn(t *testing.T) {
+	t.Parallel()
+	s := schema.DefaultOTelMetrics()
+	s.MetricNameColumn = ""
+	rw := newAttrOnlyWindow(s)
+
+	got := preservedNameExpr(rw, []*labels.Matcher{
+		mustMatcher(t, labels.MatchRegexp, model.MetricNameLabel, "cpu_temp|gpu_temp"),
+	}, s)
+
+	lit, ok := got.(*chplan.LitString)
+	if !ok {
+		t.Fatalf("got %T, want *chplan.LitString", got)
+	}
+	if lit.V != "" {
+		t.Fatalf("literal name: got %q, want empty", lit.V)
+	}
+	if len(rw.GroupBy) != 1 {
+		t.Fatalf("grouping key widened with a nameless column: got %d keys, want 1", len(rw.GroupBy))
+	}
+}
+
+// TestRangeFnPreservesName pins the exact upstream membership. Widening
+// it silently restores `__name__` on functions Prometheus strips it
+// from; narrowing it re-opens #1492 for the other half of the pair.
+func TestRangeFnPreservesName(t *testing.T) {
+	t.Parallel()
+	preserving := []string{"last_over_time", "first_over_time"}
+	dropping := []string{
+		"rate", "increase", "delta", "irate", "idelta",
+		"avg_over_time", "sum_over_time", "min_over_time", "max_over_time",
+		"count_over_time", "stddev_over_time", "quantile_over_time",
+		"predict_linear", "holt_winters", "present_over_time",
+	}
+	for _, fn := range preserving {
+		if !rangeFnPreservesName(fn) {
+			t.Errorf("%s: got drop, want preserve", fn)
+		}
+	}
+	for _, fn := range dropping {
+		if rangeFnPreservesName(fn) {
+			t.Errorf("%s: got preserve, want drop", fn)
+		}
+	}
+}

--- a/internal/promql/range_fns.go
+++ b/internal/promql/range_fns.go
@@ -86,8 +86,7 @@ func lowerPredictLinear(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.
 		// across the grid. The native PredictLinear strategy is skipped
 		// deliberately — timeSeriesPredictLinearToGrid computes a
 		// per-grid-anchor regression, which is the shape the pin forbids.
-		return wrapRangeWindowAtBroadcast(rw, ctx, s, "predict_linear",
-			metricNameFromMatchers(vs.LabelMatchers), &chplan.ColumnRef{Name: s.ValueColumn}), nil
+		return wrapRangeWindowAtBroadcast(rw, ctx, s, nil, &chplan.ColumnRef{Name: s.ValueColumn}), nil
 	case gridSingleAnchor:
 	}
 	// Route through the boot-wired PredictLinear strategy: the native impl
@@ -166,8 +165,7 @@ func lowerHoltWinters(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.No
 	case gridBroadcast:
 		// `@`-pinned: smooth the pinned window once, broadcast the
 		// per-series result across the grid.
-		return wrapRangeWindowAtBroadcast(rw, ctx, s, "holt_winters",
-			metricNameFromMatchers(vs.LabelMatchers), &chplan.ColumnRef{Name: s.ValueColumn}), nil
+		return wrapRangeWindowAtBroadcast(rw, ctx, s, nil, &chplan.ColumnRef{Name: s.ValueColumn}), nil
 	case gridSingleAnchor:
 	}
 	return rw, nil
@@ -306,8 +304,7 @@ func lowerQuantileOverTime(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chpl
 		// across the grid. The value substitution folds into the
 		// broadcast projection rather than going through
 		// projectValueOverInner, which has no branch for that shape.
-		return wrapRangeWindowAtBroadcast(window, ctx, s, "quantile_over_time",
-			metricNameFromMatchers(vs.LabelMatchers), value), nil
+		return wrapRangeWindowAtBroadcast(window, ctx, s, nil, value), nil
 	case gridSingleAnchor:
 	}
 	if !replaceValue {

--- a/internal/promql/subquery.go
+++ b/internal/promql/subquery.go
@@ -542,7 +542,15 @@ func lowerOuterRangeFnOverSubquery(
 		// of this guard lives in `lowerRangeVectorCall`.
 		rw.End = anchor.End
 		widenSubquerySpine(inner, anchor.End.Add(-sub.Range), anchor.End)
-		return wrapRangeWindowAtBroadcast(rw, ctx, s, outer.Func.Name, "",
+		// The subquery spine groups by Attributes alone, so MetricName is
+		// already gone by the time this outer reducer runs — a preserving
+		// fn can only stamp the empty literal here. Widening the spine to
+		// carry it is issue #1602.
+		var nameExpr chplan.Expr
+		if rangeFnPreservesName(outer.Func.Name) {
+			nameExpr = &chplan.LitString{V: ""}
+		}
+		return wrapRangeWindowAtBroadcast(rw, ctx, s, nameExpr,
 			&chplan.ColumnRef{Name: s.ValueColumn}), nil
 	case rangeMode:
 		// Range mode: the outer reducer in `max_over_time(rate(m[5m])[1h:5m])`

--- a/test/perf/cardinality-baseline.json
+++ b/test/perf/cardinality-baseline.json
@@ -4020,6 +4020,16 @@
     "max_recursion_depth": 0
   },
   {
+    "fixture": "promql/last_over_time_regex_name",
+    "fan_factor": 1,
+    "scan_rows": 4,
+    "peak_intermediate": 4,
+    "has_cross_join": false,
+    "has_array_join": true,
+    "has_recursive_cte": false,
+    "max_recursion_depth": 0
+  },
+  {
     "fixture": "promql/limitk_below_one_empty",
     "fan_factor": 1,
     "scan_rows": 2,

--- a/test/perf/solver-decision-baseline.json
+++ b/test/perf/solver-decision-baseline.json
@@ -2280,6 +2280,16 @@
     "outer_range": "1h0m0s"
   },
   {
+    "query": "last_over_time_regex_name",
+    "routed": true,
+    "k": 8,
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
+  },
+  {
     "query": "limit_ratio_complement",
     "routed": true,
     "k": 8,

--- a/test/spec/promql/last_over_time_regex_name.txtar
+++ b/test/spec/promql/last_over_time_regex_name.txtar
@@ -1,0 +1,113 @@
+# `last_over_time` is one of the two range functions Prometheus does NOT
+# strip `__name__` from (`dropName=false`). With a regex `__name__`
+# matcher the name differs per series, so it cannot be pinned to a
+# literal — it has to ride through the window's grouping key.
+#
+# The two metrics below deliberately share an identical attribute set,
+# which makes both halves of the bug observable in one fixture:
+#
+#   * `__name__` must survive on each output row, and
+#   * the two metrics must stay two series. Grouping on Attributes alone
+#     merged them into one row carrying whichever value sorted last.
+-- query.promql --
+last_over_time({__name__=~"cpu_temp|gpu_temp"}[5m])
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('cpu_temp', map('host', 'a'), toDateTime64('2025-12-31 23:59:00', 9), 40.0),
+    ('cpu_temp', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 41.0),
+    ('gpu_temp', map('host', 'a'), toDateTime64('2025-12-31 23:59:00', 9), 70.0),
+    ('gpu_temp', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 71.0);
+-- The regex `__name__` matcher cannot be resolved to one table, so the
+-- scan unions every metrics table. Both are left empty: this fixture is
+-- about which labels come back, not about histogram fan-out.
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+CREATE TABLE otel_metrics_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    BucketCounts Array(UInt64),
+    ExplicitBounds Array(Float64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+-- expected_rows --
+[
+  ["cpu_temp", {"host": "a"}, "2025-12-31T23:59:56Z", 41],
+  ["gpu_temp", {"host": "a"}, "2025-12-31T23:59:56Z", 71]
+]
+-- args --
+[0] int64 = 9
+[1] int64 = 5000000000
+[2] string = "service.name"
+[3] string = "service_name"
+[4] string = "service.name"
+[5] string = "service_name"
+[6] string = ""
+[7] string = "service_name"
+[8] string = "cpu_temp|gpu_temp"
+[9] string = "[^a-zA-Z0-9_:]"
+[10] string = "_"
+[11] string = "cpu_temp|gpu_temp"
+[12] string = "service.name"
+[13] string = "service_name"
+[14] string = "service.name"
+[15] string = "service_name"
+[16] string = ""
+[17] string = "service_name"
+[18] string = "cpu_temp|gpu_temp"
+[19] string = "[^a-zA-Z0-9_:]"
+[20] string = "_"
+[21] string = "cpu_temp|gpu_temp"
+[22] string = "service.name"
+[23] string = "service_name"
+[24] string = "service.name"
+[25] string = "service_name"
+[26] string = ""
+[27] string = "service_name"
+[28] string = "cpu_temp|gpu_temp"
+[29] string = "[^a-zA-Z0-9_:]"
+[30] string = "_"
+[31] string = "cpu_temp|gpu_temp"
+[32] string = "le"
+[33] string = "+Inf"
+[34] int64 = 1
+[35] string = "service.name"
+[36] string = "service_name"
+[37] string = "service.name"
+[38] string = "service_name"
+[39] string = ""
+[40] string = "service_name"
+[41] string = "cpu_temp|gpu_temp"
+[42] string = "[^a-zA-Z0-9_:]"
+[43] string = "_"
+[44] string = "cpu_temp|gpu_temp"
+-- chplan --
+Project [MetricName AS MetricName, Attributes AS Attributes, (now64(9) - toIntervalNanosecond(5000000000)) AS TimeUnix, Value AS Value]
+  RangeWindow func=last_over_time range=5m0s step=0s ts=TimeUnix value=Value groupBy=[Attributes, MetricName] start=0001-01-01T00:00:00Z end=2026-01-01T00:00:01Z
+    UnionAll arms=4
+      Project [MetricName AS MetricName, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, Value AS Value]
+        Filter predicate=((MetricName =~ "cpu_temp|gpu_temp") OR (replaceRegexpAll(MetricName, "[^a-zA-Z0-9_:]", "_") =~ "cpu_temp|gpu_temp"))
+          Scan(merge(otel_metrics_gauge|otel_metrics_sum))
+      Filter predicate=((MetricName =~ "cpu_temp|gpu_temp") OR (replaceRegexpAll(MetricName, "[^a-zA-Z0-9_:]", "_") =~ "cpu_temp|gpu_temp"))
+        Project [concat(MetricName, "_count") AS MetricName, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, toFloat64(Count) AS Value]
+          Scan(otel_metrics_histogram)
+      Filter predicate=((MetricName =~ "cpu_temp|gpu_temp") OR (replaceRegexpAll(MetricName, "[^a-zA-Z0-9_:]", "_") =~ "cpu_temp|gpu_temp"))
+        Project [concat(MetricName, "_sum") AS MetricName, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, toFloat64(Sum) AS Value]
+          Scan(otel_metrics_histogram)
+      Filter predicate=((MetricName =~ "cpu_temp|gpu_temp") OR (replaceRegexpAll(MetricName, "[^a-zA-Z0-9_:]", "_") =~ "cpu_temp|gpu_temp"))
+        Project [concat(MetricName, "_bucket") AS MetricName, mapConcat(Attributes, map("le", if((le_idx > length(ExplicitBounds)), "+Inf", toString(ExplicitBounds[le_idx])))) AS Attributes, TimeUnix AS TimeUnix, toFloat64(arraySum(arraySlice(BucketCounts, 1, le_idx))) AS Value]
+          Project [MetricName AS MetricName, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, ExplicitBounds AS ExplicitBounds, BucketCounts AS BucketCounts, arrayJoin(arrayEnumerate(BucketCounts)) AS le_idx]
+            Scan(otel_metrics_histogram)
+-- sql --
+SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, (now64(?) - toIntervalNanosecond(?)) AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Attributes`, `MetricName`, if(length(window_vals) > 0, window_vals[length(window_vals)], nan) AS `Value` FROM (SELECT `Attributes`, `MetricName`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, `MetricName`, arrayFilter(p -> tupleElement(p, 1) > toDateTime64('2026-01-01 00:00:01.000000000', 9) - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= toDateTime64('2026-01-01 00:00:01.000000000', 9), series_array) AS `window_pairs` FROM (SELECT `Attributes`, `MetricName`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `series_array` FROM ((SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') WHERE (match(`MetricName`, ?) OR match(replaceRegexpAll(`MetricName`, ?, ?), ?)))) UNION ALL (SELECT * FROM (SELECT concat(`MetricName`, '_count') AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, toFloat64(`Count`) AS `Value` FROM (SELECT * FROM `otel_metrics_histogram`)) WHERE (match(`MetricName`, ?) OR match(replaceRegexpAll(`MetricName`, ?, ?), ?))) UNION ALL (SELECT * FROM (SELECT concat(`MetricName`, '_sum') AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, toFloat64(`Sum`) AS `Value` FROM (SELECT * FROM `otel_metrics_histogram`)) WHERE (match(`MetricName`, ?) OR match(replaceRegexpAll(`MetricName`, ?, ?), ?))) UNION ALL (SELECT * FROM (SELECT concat(`MetricName`, '_bucket') AS `MetricName`, mapConcat(`Attributes`, map(?, if((le_idx > length(`ExplicitBounds`)), ?, toString(`ExplicitBounds`[le_idx])))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, toFloat64(arraySum(arraySlice(`BucketCounts`, ?, le_idx))) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `ExplicitBounds` AS `ExplicitBounds`, `BucketCounts` AS `BucketCounts`, arrayJoin(arrayEnumerate(`BucketCounts`)) AS `le_idx` FROM (SELECT * FROM `otel_metrics_histogram`))) WHERE (match(`MetricName`, ?) OR match(replaceRegexpAll(`MetricName`, ?, ?), ?)))) WHERE `TimeUnix` > toDateTime64('2026-01-01 00:00:01.000000000', 9) - toIntervalNanosecond(300000000000) AND `TimeUnix` <= toDateTime64('2026-01-01 00:00:01.000000000', 9) GROUP BY `Attributes`, `MetricName`))) WHERE length(`window_vals`) >= 1)


### PR DESCRIPTION
## The bug

`last_over_time` and `first_over_time` are the two range functions Prometheus does *not* strip `__name__` from. Cerberus honoured that by pinning the MetricName projection to `metricNameFromMatchers(...)` — the value of a single `__name__="x"` **equality** matcher.

With a regex matcher (`{__name__=~"cpu_temp|gpu_temp"}`) that helper returns `""`, and two things went wrong at once:

1. every row came back with `__name__` **absent**; and
2. because the RangeWindow groups on the `Attributes` map alone, two metrics sharing an attribute set **merged into a single series**.

Measured on the new fixture — two metrics, same `{host="a"}`, `cpu_temp` last value 41, `gpu_temp` last value 71:

| | rows |
|---|---|
| **before** | `[["", {"host":"a"}, …, 71]]` |
| **after** | `[["cpu_temp", {"host":"a"}, …, 41], ["gpu_temp", {"host":"a"}, …, 71]]` |

`cpu_temp` did not just lose its name — it disappeared, and its value was silently replaced by `gpu_temp`'s.

The old code documented this as out of reach ("threading per-series names through the windowed aggregation is a larger structural change not modelled here"). It turns out to be one extra grouping key.

## The fix

`preservedNameExpr` picks the projection per selector:

- a **literal** when one equality matcher pins the name for every row (grouping key untouched — the existing goldens are byte-identical);
- otherwise a **ColumnRef**, with MetricName appended to the window's grouping key so the name rides through per series.

It is idempotent (a window already grouping on MetricName gains no duplicate) and falls back to the empty literal on a schema with no metric-name column.

While here, `wrapRangeWindowAtBroadcast`'s `fn string, name string` pair collapses to a single `name chplan.Expr` that is nil when the function drops `__name__`. The preserve-or-not decision is now made once per call site by the named `rangeFnPreservesName` predicate instead of being re-derived from a function name inside the wrapper.

## Tests

- `test/spec/promql/last_over_time_regex_name.txtar` — chDB round-trip; the two seeded metrics deliberately share an attribute set so both halves of the bug are observable in one fixture.
- **Red proven**: stashing the fix and regenerating the fixture against the old code reproduces the single `["", …, 71]` row and `groupBy=[Attributes]` shown above.
- `internal/promql/preserved_name_test.go` — six tests discriminating each branch: literal vs column, no-name-matcher, idempotence, nameless schema, and the exact upstream membership of `rangeFnPreservesName`.
- Full chDB spec suite green (`go test -tags chdb ./test/spec/promql/`, 82s), with **zero churn** to existing goldens.

## Out of scope, filed

The `@`-pinned subquery call site still stamps an empty name for the two preserving functions — its spine has already collapsed MetricName away before the reducer runs, so fixing it means widening the subquery IR. Left behaviourally byte-identical here and filed as #1602.

Closes #1492

🤖 Generated with [Claude Code](https://claude.com/claude-code)
