### PR TITLE
fix(ci): resolve build base images through the mirror and pin the e2e pre-pull

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -1186,9 +1186,20 @@ uncomputable-diff fallback — cannot drift between the lanes that use it.
   keep the quota window open (issue #1561). Takes the command as its trailing
   argv, so the Justfile's host-side pulls route through it as well and inherit
   the same three-way classification.
+    It also resolves the base images themselves, which retry alone cannot do: a
+    refusal that repeats every attempt is not a transport fault, and the wrapper
+    correctly declines to retry it. Before running the command it sets each name
+    in `lib/mirror.mjs`'s `buildBaseImageArgs` — one build arg per base image —
+    to that image's mirror ref when the mirror answers, and to the upstream ref
+    when it does not, so a `FROM ${GO_IMAGE}` resolves through GHCR without any
+    Dockerfile naming a package an outside contributor cannot read (issue
+    #1576). Every build site in the tree passes the arg through, so the wrapper
+    is the single place the decision is made.
   - Env: `IMAGE_BUILD_RETRY_BACKOFF_SECONDS` (optional; default `10` — linear
     backoff step, attempt N sleeps N × this; the Justfile's pull recipes pass
-    `3`).
+    `3`). `GO_IMAGE` (optional) — the Go toolchain base ref. Normally unset and
+    computed as above; an explicit non-empty value is left alone, so a caller
+    can pin a base image without the mirror overriding it.
   - Exit: `0` on success; the command's own status when it failed for a reason
     another attempt cannot clear (a genuine failure, or a rate-limit refusal);
     `1` when the retry budget is spent on transport faults.

--- a/.github/scripts/build-with-registry-retry.mjs
+++ b/.github/scripts/build-with-registry-retry.mjs
@@ -50,6 +50,12 @@
 //   IMAGE_BUILD_RETRY_BACKOFF_SECONDS  (optional; default 10) linear backoff
 //                                      step — attempt N sleeps N × this many
 //                                      seconds.
+//   GO_IMAGE (and any other key of `lib/mirror.mjs`'s `buildBaseImageArgs`)
+//                                      (optional) the ref the build resolves
+//                                      that base image from. Left unset, this
+//                                      module resolves it mirror-first and
+//                                      exports it to the command it runs; set,
+//                                      it is passed through untouched.
 //
 // Exit: 0 on success; the command's own status when it failed for a reason
 // another attempt cannot clear — a real build error, or a registry rate-limit
@@ -65,7 +71,9 @@ import { join } from 'node:path';
 import process from 'node:process';
 
 import { error, log, notice } from './lib/gh.mjs';
+import { buildBaseImageArgs } from './lib/mirror.mjs';
 import {
+  buildBaseImageRef,
   isRegistryRateLimit,
   isTransientRegistryFailure,
   rateLimitDiagnosis,
@@ -117,6 +125,28 @@ if (command.length === 0) {
       '`node .github/scripts/build-with-registry-retry.mjs docker build -f Dockerfile.local -t cerberus:e2e .`',
   );
   process.exit(1);
+}
+
+// Point the build's base-image `FROM` refs at the mirror.
+//
+// This belongs here, and only here, for the same reason the retry does: this
+// module is the single command every build in the tree runs through, pinned by
+// `TestImageBuildingCommandsGoThroughTheRetryWrapper`. Setting the refs in the
+// workflows instead would be one edit per building job — eight of them today —
+// with nothing to notice when the ninth lane forgets, which is the per-leg
+// shape the wrapper exists to replace.
+//
+// A ref the caller set explicitly always wins: an operator debugging against a
+// particular toolchain image passes it, and the mirror does not overrule them.
+//
+// Both consumers read these from the environment rather than from an argv this
+// module rewrites. Compose interpolates `${GO_IMAGE:-golang:1.26}` in the
+// `build.args` of each service, and the Justfile's direct builds pass
+// `--build-arg GO_IMAGE` with no value, which is docker's own "take it from the
+// environment" form. Neither needs this module to know which build sites exist.
+for (const [argName, upstreamRef] of Object.entries(buildBaseImageArgs)) {
+  if ((process.env[argName] ?? '') !== '') continue;
+  process.env[argName] = buildBaseImageRef(upstreamRef);
 }
 
 const backoffStepSeconds = readBackoffStepSeconds('IMAGE_BUILD_RETRY_BACKOFF_SECONDS', defaultBackoffStepSeconds);

--- a/.github/scripts/lib/mirror.mjs
+++ b/.github/scripts/lib/mirror.mjs
@@ -115,13 +115,31 @@ export const mirroredImages = [
   // matters because the two acquisition shapes need different treatment: the
   // re-tag in `pullImageWithRetry` populates the HOST daemon, and the
   // `docker-container` BuildKit driver has its own image store that never
-  // consults it, so a `FROM` resolves against the registry regardless. This ref
-  // is mirrored so the copy exists; making the build CONSUME it means threading
-  // the ref through a build arg, which is #1576. It is the ref that opened the
-  // incident: `unexpected status from HEAD request …/library/golang/manifests/
-  // 1.26: 429` is what reddened `e2e` and `migration-e2e` on main.
+  // consults it, so a `FROM` resolves against the registry regardless. The
+  // build CONSUMES the mirrored copy by naming it in a build arg — see
+  // `buildBaseImageArgs` below. It is the ref that opened the incident:
+  // `unexpected status from HEAD request …/library/golang/manifests/1.26: 429`
+  // is what reddened `e2e` and `migration-e2e` on main.
   'golang:1.26',
 ];
+
+// buildBaseImageArgs — every build arg this tree's Dockerfiles use to name a
+// base image, paired with the upstream ref that arg defaults to. One entry per
+// `ARG <name>=<ref>` + `FROM ${<name>}` pair.
+//
+// The indirection exists because a host-side pre-pull cannot reach a `FROM`:
+// the `docker-container` BuildKit driver resolves it against the registry from
+// its own content store. Naming the ref is the only lever, so the ref has to be
+// substitutable — and substitutable only from the outside, because the DEFAULT
+// must stay the upstream ref. The mirror packages are private, so a Dockerfile
+// that defaulted to them would be unbuildable by anyone outside this repo.
+//
+// This table is the single place the arg name and its upstream ref are paired.
+// `buildBaseImageRef` reads it to decide what CI passes, and the regression pin
+// checks it against the Dockerfiles and against the inventory above, so an arg
+// renamed in one place and not the other fails rather than silently reverting
+// every build to Docker Hub.
+export const buildBaseImageArgs = Object.freeze({ GO_IMAGE: 'golang:1.26' });
 
 const inventory = new Set(mirroredImages);
 

--- a/.github/scripts/lib/registry.mjs
+++ b/.github/scripts/lib/registry.mjs
@@ -43,6 +43,11 @@
 //   pullImageWithRetry(image, options)     acquire one image into the local
 //                                          daemon under that policy, from the
 //                                          GHCR mirror when there is one.
+//   buildBaseImageRef(image)               the ref a BUILD should resolve image
+//                                          from — the mirrored copy when this
+//                                          runner can read it, else upstream.
+//                                          A `FROM` cannot be served from the
+//                                          daemon, so it needs the ref itself.
 //
 // The best answer to a quota is not to draw on it. `pullImageWithRetry` reaches
 // for `lib/mirror.mjs`'s GHCR copy first and re-tags it to the upstream name,
@@ -215,6 +220,42 @@ function acquireFromMirror(image) {
 
   log(`    ${image} acquired from the mirror`);
   return true;
+}
+
+// buildBaseImageRef — the ref a BUILD should resolve `image` from: the mirrored
+// copy when this runner can actually read it, the upstream ref when it cannot.
+//
+// This is the same mirror-first-with-fallback decision `acquireFromMirror`
+// makes, moved one layer out. It has to be a separate decision because the two
+// acquisition shapes land in different places: `acquireFromMirror` pulls into
+// the HOST daemon and re-tags, which a `FROM` under the `docker-container`
+// driver never consults. Only the ref BuildKit is given can steer that, so the
+// question here is not "can I pull this" but "will BuildKit resolve this", and
+// `imagetools inspect` asks exactly that — it reads the manifest through the
+// same registry path a `FROM` takes, without pulling any layers.
+//
+// A miss is a notice, not a failure, for the reason the mirror pull gives: the
+// upstream ref is perfectly reachable, so refusing to build over a stale or
+// unreadable mirror would fail a lane for no gain. It is also what keeps forks
+// working — a fork's runner authenticates to ghcr.io as itself and cannot read
+// this repo's private packages, so it probes, misses, and builds from Docker
+// Hub exactly as it did before the mirror existed.
+export function buildBaseImageRef(image) {
+  const mirror = mirroredRef(image);
+  if (mirror === null) return image;
+
+  const probe = capture('docker', ['buildx', 'imagetools', 'inspect', mirror]);
+  if (probe.status !== 0) {
+    notice(
+      `${mirror} is not resolvable from this runner, so the build resolves ${image} from Docker Hub. ` +
+        'That spends the anonymous quota this mirror exists to stop spending; `mirror-images.mjs` is ' +
+        `what fixes it.\n${probe.stderr.trim()}`,
+    );
+    return image;
+  }
+
+  log(`    builds will resolve ${image} as ${mirror}`);
+  return mirror;
 }
 
 // pullImageWithRetry — acquire one image into the local daemon under the policy

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -5,7 +5,17 @@
 # built by goreleaser. For E2E we want a one-shot multi-stage build that
 # produces the same final image without needing goreleaser locally.
 
-FROM golang:1.26 AS build
+# The Go toolchain image, reached through a build arg so CI can point the build
+# at the GHCR mirror. BuildKit's `docker-container` driver resolves a `FROM`
+# against the registry with its own content store, never the host daemon's, so
+# a host-side pre-pull cannot cover this line — only the ref itself can.
+#
+# The default is the upstream ref and must stay that way. The mirror packages
+# are private, so a plain `docker build` run by anyone outside this repo has to
+# resolve Docker Hub. `build-with-registry-retry.mjs` sets GO_IMAGE for every
+# build CI runs; see .github/scripts/lib/mirror.mjs.
+ARG GO_IMAGE=golang:1.26
+FROM ${GO_IMAGE} AS build
 WORKDIR /src
 COPY go.mod go.sum ./
 # `go mod download` occasionally fails with a transient

--- a/Justfile
+++ b/Justfile
@@ -626,16 +626,20 @@ CERBERUS_BUILD_TAGS := env_var_or_default("CERBERUS_BUILD_TAGS", "")
 # pulling on the host docker daemon (which has its own auth + cache) and
 # importing into k3d via the API, we never go through containerd's pull
 # path. See run 26136032208 for the symptom.
-# MUST stay in lock-step with the image pins in test/e2e/k3s/*.yaml —
-# a stale entry here means the pod pulls straight from the registry at
-# start-up (no pre-pull, no import, full Docker-Hub-flake exposure).
-E2E_EXTERNAL_IMAGES := "clickhouse/clickhouse-server:26.5-alpine ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.116.0 grafana/grafana:12.2.9 otel/opentelemetry-collector-contrib:0.152.1 busybox:1.37"
+# This list and the image pins under test/e2e/k3s*/ are one set seen twice: an
+# image the manifests ask for and this list omits is pulled by containerd at pod
+# start — anonymously, un-mirrored, the whole exposure the pre-pull removes.
+# `TestE2EPrePullCoversEveryManifestImage` enforces the equality both ways,
+# because the convention it replaces had already failed silently: #1263 moved the
+# k3d ClickHouse to 26.6-alpine and left this line on 26.5-alpine, so for ten days
+# the one image the pre-pull was written for was the one it did not cover (#1461).
+E2E_EXTERNAL_IMAGES := "clickhouse/clickhouse-server:26.6-alpine ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.116.0 grafana/grafana:12.2.9 otel/opentelemetry-collector-contrib:0.152.1 busybox:1.37"
 
 # Extra images the bundled-ClickHouse ("bwc") object-storage lane needs on top
 # of E2E_EXTERNAL_IMAGES: the MinIO object store + its `mc` client (the
 # bucket-create Job) and the bundled ClickHouse image the Helm chart deploys.
-# Same pre-pull+import rationale as E2E_EXTERNAL_IMAGES. MUST stay in lock-step
-# with the pins in test/e2e/k3s-bwc/*.yaml (minio + mc) and
+# Same pre-pull+import rationale as E2E_EXTERNAL_IMAGES, and the same gate holds
+# it against the pins in test/e2e/k3s-bwc/*.yaml (minio + mc) and
 # test/e2e/k3s/cerberus-values-bwc.yaml (clickhouse.bundled.image) — the chart
 # maps the CH container's pullPolicy to .Values.image.pullPolicy (Never in the
 # e2e values), so the exact bundled-CH tag MUST be imported here.
@@ -669,8 +673,10 @@ CH_STRICT_SCAN_IMAGE := "clickhouse/clickhouse-server:26.5-alpine"
 # `k3d cluster create --image` — k3d then boots from the host-cached copy
 # instead of letting cluster creation pull k3s from Docker Hub mid-flight, which
 # intermittently times out ("registry-1.docker.io ... context deadline
-# exceeded") and fails the whole e2e. To drop the Docker Hub dependency entirely,
-# re-tag this into ghcr.io (co-located with the CI runners) and point here.
+# exceeded") and fails the whole e2e. The Docker Hub dependency is already gone:
+# `_pull-retry` resolves this ref through the GHCR mirror first and re-tags the
+# result to the upstream name, so the host cache holds it under the name below
+# without any file here naming a mirror an outside operator cannot read (#1514).
 K3S_IMAGE := "rancher/k3s:v1.31.5-k3s1"
 
 # Extra args appended verbatim to `k3d cluster create` in `e2e-up`. Empty by
@@ -751,7 +757,7 @@ e2e-up: e2e-down
         --wait
     @echo "==> building cerberus image (build tags: '{{CERBERUS_BUILD_TAGS}}')"
     node .github/scripts/build-with-registry-retry.mjs \
-        docker build -t {{CERBERUS_IMAGE}} --build-arg GO_BUILD_TAGS="{{CERBERUS_BUILD_TAGS}}" -f Dockerfile.local .
+        docker build -t {{CERBERUS_IMAGE}} --build-arg GO_BUILD_TAGS="{{CERBERUS_BUILD_TAGS}}" --build-arg GO_IMAGE -f Dockerfile.local .
     @echo "==> pre-pulling external images on host docker (retry)"
     @just _pull-retry {{E2E_EXTERNAL_IMAGES}}
     @echo "==> importing images into k3d ({{K3D_CLUSTER}}) — one at a time, with retry+verify"
@@ -1235,7 +1241,7 @@ e2e-bwc-up: e2e-down
         --wait
     @echo "==> [bwc] building cerberus image (build tags: '{{CERBERUS_BUILD_TAGS}}')"
     node .github/scripts/build-with-registry-retry.mjs \
-        docker build -t {{CERBERUS_IMAGE}} --build-arg GO_BUILD_TAGS="{{CERBERUS_BUILD_TAGS}}" -f Dockerfile.local .
+        docker build -t {{CERBERUS_IMAGE}} --build-arg GO_BUILD_TAGS="{{CERBERUS_BUILD_TAGS}}" --build-arg GO_IMAGE -f Dockerfile.local .
     @echo "==> [bwc] pre-pulling external + bwc images on host docker"
     @# The standalone-CH image (the *-alpine tag in E2E_EXTERNAL_IMAGES) backs
     @# test/e2e/k3s/clickhouse.yaml, which the bwc kustomization EXCLUDES — this
@@ -1433,7 +1439,7 @@ migration-cerberus-image:
     img="${CERBERUS_IMAGE:-$local_tag}"; \
     if [ "$img" = "$local_tag" ]; then \
         echo "==> migration cerberus image: build $img from Dockerfile.local"; \
-        node .github/scripts/build-with-registry-retry.mjs docker build -f Dockerfile.local -t "$img" .; \
+        node .github/scripts/build-with-registry-retry.mjs docker build --build-arg GO_IMAGE -f Dockerfile.local -t "$img" .; \
     else \
         echo "==> migration cerberus image: pull $img"; \
         just _pull-retry "$img"; \

--- a/bench/histogram/docker-compose.yml
+++ b/bench/histogram/docker-compose.yml
@@ -44,6 +44,9 @@ services:
     build:
       context: ../..
       dockerfile: Dockerfile.local
+      args:
+        # Mirror-first base image, default upstream. See lib/mirror.mjs.
+        GO_IMAGE: "${GO_IMAGE:-golang:1.26}"
     environment:
       CERBERUS_HTTP_ADDR: ":52091"
       CERBERUS_ENABLED_HEADS: "prom" # isolate the Prometheus head

--- a/compatibility/loki/docker-compose.yml
+++ b/compatibility/loki/docker-compose.yml
@@ -77,6 +77,9 @@ services:
     build:
       context: ../..
       dockerfile: Dockerfile.local
+      args:
+        # Mirror-first base image, default upstream. See lib/mirror.mjs.
+        GO_IMAGE: "${GO_IMAGE:-golang:1.26}"
     environment:
       CERBERUS_HTTP_ADDR: ":29092"
       CERBERUS_CH_ADDR: "clickhouse:9000"

--- a/compatibility/prometheus/docker-compose.yml
+++ b/compatibility/prometheus/docker-compose.yml
@@ -84,6 +84,9 @@ services:
     build:
       context: ../..
       dockerfile: Dockerfile.local
+      args:
+        # Mirror-first base image, default upstream. See lib/mirror.mjs.
+        GO_IMAGE: "${GO_IMAGE:-golang:1.26}"
     environment:
       CERBERUS_HTTP_ADDR: ":29091"
       CERBERUS_CH_ADDR: "clickhouse:9000"

--- a/compatibility/tempo/docker-compose.yml
+++ b/compatibility/tempo/docker-compose.yml
@@ -99,6 +99,9 @@ services:
     build:
       context: ../..
       dockerfile: Dockerfile.local
+      args:
+        # Mirror-first base image, default upstream. See lib/mirror.mjs.
+        GO_IMAGE: "${GO_IMAGE:-golang:1.26}"
     environment:
       CERBERUS_HTTP_ADDR: ":29092"
       CERBERUS_CH_ADDR: "clickhouse:9000"
@@ -146,6 +149,9 @@ services:
     build:
       context: ../..
       dockerfile: compatibility/tempo/driver/Dockerfile
+      args:
+        # Mirror-first base image, default upstream. See lib/mirror.mjs.
+        GO_IMAGE: "${GO_IMAGE:-golang:1.26}"
     command: ["seed"]
     environment:
       # Targets are reachable on the compose network by service name.

--- a/compatibility/tempo/driver/Dockerfile
+++ b/compatibility/tempo/driver/Dockerfile
@@ -21,7 +21,11 @@
 #                 + shields.io endpoint-badge score JSON. Report-only;
 #                 parity drift does not change the exit code.
 
-FROM golang:1.26 AS build
+# Reached through a build arg so CI resolves the GHCR mirror rather than Docker
+# Hub; the default stays upstream because the mirror packages are private. See
+# Dockerfile.local for the full rationale.
+ARG GO_IMAGE=golang:1.26
+FROM ${GO_IMAGE} AS build
 WORKDIR /src
 
 # Build context is the cerberus repo root (set in docker-compose.yml's

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -169,6 +169,9 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.local
+      args:
+        # Mirror-first base image, default upstream. See lib/mirror.mjs.
+        GO_IMAGE: "${GO_IMAGE:-golang:1.26}"
       target: seed
     networks: [cerberus-dev]
     environment:
@@ -268,6 +271,9 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.local
+      args:
+        # Mirror-first base image, default upstream. See lib/mirror.mjs.
+        GO_IMAGE: "${GO_IMAGE:-golang:1.26}"
     networks: [cerberus-dev]
     environment:
       # CERBERUS_HTTP_ADDR    HTTP listen addr for Prom/Loki/Tempo APIs.
@@ -390,6 +396,9 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.local
+      args:
+        # Mirror-first base image, default upstream. See lib/mirror.mjs.
+        GO_IMAGE: "${GO_IMAGE:-golang:1.26}"
     networks: [cerberus-dev]
     environment:
       CERBERUS_HTTP_ADDR: ":8080"

--- a/test/e2e/migration/tiers/tier1-dual/docker-compose.dual.yml
+++ b/test/e2e/migration/tiers/tier1-dual/docker-compose.dual.yml
@@ -185,6 +185,9 @@ services:
     build:
       context: ../../../../..
       dockerfile: Dockerfile.local
+      args:
+        # Mirror-first base image, default upstream. See lib/mirror.mjs.
+        GO_IMAGE: "${GO_IMAGE:-golang:1.26}"
     volumes:
       # Every non-credential setting lives in this file, mounted where cerberus
       # discovers it, because a config file is what a real deployment hands the

--- a/test/e2e/migration/tiers/tier2-ruler/docker-compose.ruler.yml
+++ b/test/e2e/migration/tiers/tier2-ruler/docker-compose.ruler.yml
@@ -121,6 +121,9 @@ services:
       # docker inspect if tier2-ruler ever moves to a different depth.
       context: ../../../../..
       dockerfile: test/e2e/migration/tiers/tier2-ruler/receiver/Dockerfile
+      args:
+        # Mirror-first base image, default upstream. See lib/mirror.mjs.
+        GO_IMAGE: "${GO_IMAGE:-golang:1.26}"
     ports:
       - "27450:8090"
     healthcheck:

--- a/test/e2e/migration/tiers/tier2-ruler/receiver/Dockerfile
+++ b/test/e2e/migration/tiers/tier2-ruler/receiver/Dockerfile
@@ -3,7 +3,11 @@
 # (test/e2e/migration/tiers/tier2-ruler/receiver/main.go). The binary imports
 # only the standard library, so building its one package pulls in none of the
 # module's external dependencies.
-FROM golang:1.26 AS build
+# Reached through a build arg so CI resolves the GHCR mirror rather than Docker
+# Hub; the default stays upstream because the mirror packages are private. See
+# Dockerfile.local for the full rationale.
+ARG GO_IMAGE=golang:1.26
+FROM ${GO_IMAGE} AS build
 WORKDIR /src
 COPY go.mod go.sum ./
 COPY test/e2e/migration/tiers/tier2-ruler/receiver ./test/e2e/migration/tiers/tier2-ruler/receiver

--- a/test/regression/build_base_image_arg_test.go
+++ b/test/regression/build_base_image_arg_test.go
@@ -1,0 +1,515 @@
+package regression
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// A build's `FROM` is the one image acquisition the GHCR mirror could not reach.
+//
+// `pullImageWithRetry` serves a mirrored copy by pulling it and re-tagging it to
+// the upstream name in the HOST daemon. That covers a compose `image:` key and a
+// `docker pull`, and covers nothing about a `FROM`: the `docker-container`
+// BuildKit driver `.github/actions/setup-buildx` installs runs BuildKit inside a
+// container with its own content store and resolves `FROM` against the registry
+// no matter what the host holds. So `golang:1.26` sat in the mirror inventory
+// while every build in the tree went on resolving it from Docker Hub — the
+// mirror present and inert on the exact ref that opened the incident:
+//
+//	#5 ERROR: unexpected status from HEAD request to
+//	   https://registry-1.docker.io/v2/library/golang/manifests/1.26:
+//	   429 Too Many Requests
+//
+// The only lever on a `FROM` is the ref itself, so the ref is a build arg and
+// `build-with-registry-retry.mjs` — the single command every build already runs
+// through — resolves it mirror-first and exports it.
+//
+// The regression shape is a Dockerfile that goes back to naming a Docker Hub
+// image directly in a `FROM`. It reintroduces the incident silently: the build
+// keeps working, on every machine, right up until the shared quota is out. So
+// the guards below are on the SHAPE — no Dockerfile this repo builds may name a
+// metered image in a `FROM`, every build site must pass the arg, and the table
+// pairing an arg with its upstream ref must agree with both the Dockerfiles and
+// the mirror inventory. A guard naming the three files that happened to have the
+// defect would not survive the fourth.
+const (
+	treeRoot = "../.."
+
+	// Floors for the discovery scans. There are 3 in-scope Dockerfiles, 10
+	// in-scope compose build stanzas and 3 direct `docker build` invocations
+	// today; each floor sits below its real count, so a refactor that leaves a
+	// guard scanning for a shape nothing matches fails instead of passing
+	// vacuously.
+	minBaseImageDockerfiles   = 3
+	minComposeBuildStanzas    = 8
+	minDirectBuildInvocations = 2
+)
+
+var (
+	// `ARG NAME=default` — the declaration that makes a `FROM` substitutable.
+	dockerfileArgDecl = regexp.MustCompile(`(?m)^\s*ARG\s+([A-Za-z_][A-Za-z0-9_]*)=(\S+)\s*$`)
+	// The image ref of a `FROM`, before any `AS <stage>`.
+	dockerfileFrom = regexp.MustCompile(`(?m)^\s*FROM\s+(\S+)`)
+	// `${NAME}` or `$NAME` as the whole ref.
+	dockerfileFromArg = regexp.MustCompile(`^\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?$`)
+	// The `buildBaseImageArgs` table in lib/mirror.mjs.
+	buildArgTableLiteral = regexp.MustCompile(`(?s)export const buildBaseImageArgs = Object\.freeze\(\{(.*?)\}\);`)
+	buildArgTableEntry   = regexp.MustCompile(`([A-Za-z_][A-Za-z0-9_]*)\s*:\s*['"]([^'"]+)['"]`)
+	// A `-f <path>` / `--file <path>` naming the Dockerfile a direct build uses.
+	dockerBuildDashF = regexp.MustCompile(`(?:-f|--file)[= ]+(\S+)`)
+)
+
+// buildBaseImageArgs reads the arg/ref table out of lib/mirror.mjs rather than
+// restating it, so this guard and the JS the wrapper actually runs cannot
+// disagree about which args exist.
+func buildBaseImageArgs(t *testing.T) map[string]string {
+	t.Helper()
+
+	src, err := os.ReadFile(mirrorModule)
+	if err != nil {
+		t.Fatalf("read %s: %v", mirrorModule, err)
+	}
+	body := buildArgTableLiteral.FindStringSubmatch(string(src))
+	if body == nil {
+		t.Fatalf("%s no longer exports a `buildBaseImageArgs` object literal — the guard cannot read the arg "+
+			"table, and without one every build silently reverts to resolving Docker Hub", mirrorModule)
+	}
+
+	out := map[string]string{}
+	for _, m := range buildArgTableEntry.FindAllStringSubmatch(body[1], -1) {
+		out[m[1]] = m[2]
+	}
+	if len(out) == 0 {
+		t.Fatalf("`buildBaseImageArgs` in %s is empty, so no build arg points any `FROM` at the mirror",
+			mirrorModule)
+	}
+	return out
+}
+
+// meteredFromRef reports the Docker-Hub-resolvable image a `FROM` names, or ""
+// when the ref is not one: an arg-indirected ref, a build stage by name
+// (`FROM build`), `FROM scratch`, or a ref on a registry with its own quota
+// (`gcr.io/distroless/static`). A digest suffix is stripped first — pinning by
+// digest fixes WHAT is pulled, not WHERE from, so a digest-pinned Hub ref is
+// metered exactly like a tagged one.
+func meteredFromRef(ref string) string {
+	if strings.HasPrefix(ref, "$") {
+		return ""
+	}
+	if at := strings.Index(ref, "@"); at != -1 {
+		ref = ref[:at]
+	}
+	if !strings.Contains(ref, ":") {
+		return "" // no tag: a stage name, `scratch`, or a degenerate ref
+	}
+	if !isDockerHubImageRef(ref) {
+		return ""
+	}
+	return ref
+}
+
+// composeBuildStanza is one `build:` block: which Dockerfile it builds, and
+// which build args it passes.
+type composeBuildStanza struct {
+	file       string
+	line       int
+	dockerfile string
+	args       map[string]bool
+}
+
+// composeBuildStanzas parses every `build:` block in the tree's compose files.
+// A hand-rolled indentation walk rather than a YAML dependency: the shape being
+// asserted IS the indentation — an `args:` block nested under the right
+// `build:` — and this package is dependency-light on purpose.
+func composeBuildStanzas(t *testing.T) []composeBuildStanza {
+	t.Helper()
+
+	var out []composeBuildStanza
+	for _, file := range mirrorScanFiles(t) {
+		if !strings.Contains(filepath.Base(file), "compose") {
+			continue
+		}
+		src, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("read %s: %v", file, err)
+		}
+		lines := strings.Split(string(src), "\n")
+		for i, line := range lines {
+			if strings.TrimSpace(line) != "build:" {
+				continue
+			}
+			stanza := composeBuildStanza{file: file, line: i + 1, args: map[string]bool{}}
+			buildIndent := indentOf(line)
+			argsIndent := -1
+			for _, child := range lines[i+1:] {
+				trimmed := strings.TrimSpace(child)
+				if trimmed == "" {
+					continue
+				}
+				if indentOf(child) <= buildIndent {
+					break
+				}
+				if argsIndent >= 0 && indentOf(child) > argsIndent {
+					if !strings.HasPrefix(trimmed, "#") {
+						stanza.args[strings.TrimSpace(strings.SplitN(trimmed, ":", 2)[0])] = true
+					}
+					continue
+				}
+				argsIndent = -1
+				if trimmed == "args:" {
+					argsIndent = indentOf(child)
+					continue
+				}
+				if rest, ok := strings.CutPrefix(trimmed, "dockerfile:"); ok {
+					stanza.dockerfile = strings.Trim(strings.TrimSpace(rest), `"'`)
+				}
+			}
+			out = append(out, stanza)
+		}
+	}
+	return out
+}
+
+// directBuildSite is one `docker build -f <path>` outside compose.
+type directBuildSite struct {
+	file       string
+	line       string
+	dockerfile string
+}
+
+// directBuildSites finds every `docker build` in the tree that names its
+// Dockerfile explicitly, reusing the same scan and prose filter as the sibling
+// guard that pins those builds to the retry wrapper.
+func directBuildSites(t *testing.T) []directBuildSite {
+	t.Helper()
+
+	var out []directBuildSite
+	for _, file := range buildScanFiles(t) {
+		src, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("read %s: %v", file, err)
+		}
+		for _, line := range logicalLines(string(src)) {
+			if isProse(line) || !dockerBuildCommand.MatchString(line) {
+				continue
+			}
+			if m := dockerBuildDashF.FindStringSubmatch(line); m != nil {
+				out = append(out, directBuildSite{file: file, line: line, dockerfile: m[1]})
+			}
+		}
+	}
+	return out
+}
+
+// dockerfilesThisRepoBuilds is the in-scope set, derived rather than listed: a
+// Dockerfile is in scope exactly when some build site in this tree names it.
+// That is what keeps the vendored upstream snapshot under
+// compatibility/tempo/upstream/ out of scope — nothing builds it — WITHOUT an
+// exclusion list, which would also hide a real Dockerfile added there later.
+func dockerfilesThisRepoBuilds(t *testing.T) map[string][]string {
+	t.Helper()
+
+	out := map[string][]string{}
+	for _, stanza := range composeBuildStanzas(t) {
+		if stanza.dockerfile != "" {
+			out[stanza.dockerfile] = append(out[stanza.dockerfile], stanza.file)
+		}
+	}
+	for _, site := range directBuildSites(t) {
+		out[site.dockerfile] = append(out[site.dockerfile], site.file)
+	}
+	return out
+}
+
+// baseImageArgsUsedBy maps each in-scope Dockerfile to the build args its own
+// `FROM` lines resolve through — the args every build site of that file must
+// pass.
+func baseImageArgsUsedBy(t *testing.T, table map[string]string) map[string][]string {
+	t.Helper()
+
+	needs := map[string][]string{}
+	for dockerfile := range dockerfilesThisRepoBuilds(t) {
+		src, err := os.ReadFile(filepath.Join(treeRoot, dockerfile))
+		if err != nil {
+			continue // reported by TestBuiltDockerfilesNameNoMeteredImageDirectly
+		}
+		for _, m := range dockerfileFrom.FindAllStringSubmatch(string(src), -1) {
+			name := dockerfileFromArg.FindStringSubmatch(m[1])
+			if name == nil {
+				continue
+			}
+			if _, known := table[name[1]]; known {
+				needs[dockerfile] = append(needs[dockerfile], name[1])
+			}
+		}
+	}
+	return needs
+}
+
+// TestBuiltDockerfilesNameNoMeteredImageDirectly guards the regression shape
+// itself. A `FROM golang:1.26` builds fine everywhere and reintroduces the 429
+// the moment the shared quota runs out — invisible at the only time anyone would
+// think to look for it.
+func TestBuiltDockerfilesNameNoMeteredImageDirectly(t *testing.T) {
+	t.Parallel()
+
+	table := buildBaseImageArgs(t)
+	scanned := 0
+
+	for dockerfile, sites := range dockerfilesThisRepoBuilds(t) {
+		src, err := os.ReadFile(filepath.Join(treeRoot, dockerfile))
+		if err != nil {
+			t.Errorf("%s is built by %s but cannot be read: %v", dockerfile, strings.Join(sites, ", "), err)
+			continue
+		}
+		scanned++
+
+		declared := map[string]string{}
+		for _, m := range dockerfileArgDecl.FindAllStringSubmatch(string(src), -1) {
+			declared[m[1]] = m[2]
+		}
+
+		for _, m := range dockerfileFrom.FindAllStringSubmatch(string(src), -1) {
+			ref := m[1]
+			if metered := meteredFromRef(ref); metered != "" {
+				t.Errorf("%s names the Docker Hub image %s directly in a FROM (built by %s). BuildKit's "+
+					"docker-container driver resolves that against the registry with its own content "+
+					"store, so no host-side pre-pull and no mirror can cover it — every build of this file "+
+					"spends the shared anonymous quota. Declare `ARG <NAME>=%s`, write `FROM ${<NAME>}`, "+
+					"and add the pair to `buildBaseImageArgs` in %s.",
+					dockerfile, metered, strings.Join(sites, ", "), metered, mirrorModule)
+				continue
+			}
+			name := dockerfileFromArg.FindStringSubmatch(ref)
+			if name == nil {
+				continue // a build stage by name, `scratch`, or an unmetered registry
+			}
+
+			upstream, known := table[name[1]]
+			if !known {
+				t.Errorf("%s resolves a FROM through ${%s}, but `buildBaseImageArgs` in %s has no entry for "+
+					"it, so the build wrapper never sets it and every build takes the ARG default — the "+
+					"mirror is bypassed silently.", dockerfile, name[1], mirrorModule)
+				continue
+			}
+			def, ok := declared[name[1]]
+			if !ok {
+				t.Errorf("%s uses ${%s} in a FROM without declaring `ARG %s=%s`. With no default, a plain "+
+					"`docker build` outside CI resolves an empty ref.", dockerfile, name[1], name[1], upstream)
+				continue
+			}
+			if def != upstream {
+				t.Errorf("%s declares `ARG %s=%s` but `buildBaseImageArgs` pairs %s with %s. The default is "+
+					"what someone outside this repo builds from — the mirror packages are private — so the "+
+					"two must name the same upstream image.", dockerfile, name[1], def, name[1], upstream)
+			}
+		}
+	}
+
+	if scanned < minBaseImageDockerfiles {
+		t.Errorf("only %d built Dockerfiles found (expected at least %d) — the discovery scan has stopped "+
+			"matching build sites, so this guard is asserting nothing", scanned, minBaseImageDockerfiles)
+	}
+}
+
+// TestEveryBuildSitePassesTheBaseImageArg pins the other half. Indirecting the
+// Dockerfile achieves nothing on its own: a build site that passes no arg gets
+// the ARG default, which is the upstream ref, which is the original defect with
+// extra steps.
+func TestEveryBuildSitePassesTheBaseImageArg(t *testing.T) {
+	t.Parallel()
+
+	table := buildBaseImageArgs(t)
+	needs := baseImageArgsUsedBy(t, table)
+
+	stanzas := 0
+	for _, stanza := range composeBuildStanzas(t) {
+		required, inScope := needs[stanza.dockerfile]
+		if !inScope {
+			continue
+		}
+		stanzas++
+		for _, arg := range required {
+			if !stanza.args[arg] {
+				t.Errorf("%s:%d builds %s but its `build:` passes no `%s` arg, so the build takes the ARG "+
+					"default and resolves Docker Hub. Add `args:` with `%s: \"${%s:-%s}\"` — the `:-` "+
+					"default keeps a plain `docker compose build` working for anyone without mirror "+
+					"credentials.", stanza.file, stanza.line, stanza.dockerfile, arg, arg, arg, table[arg])
+			}
+		}
+	}
+	if stanzas < minComposeBuildStanzas {
+		t.Errorf("only %d in-scope compose build stanzas found (expected at least %d) — the parser has "+
+			"stopped matching, so this half is asserting nothing", stanzas, minComposeBuildStanzas)
+	}
+
+	direct := 0
+	for _, site := range directBuildSites(t) {
+		required, inScope := needs[site.dockerfile]
+		if !inScope {
+			continue
+		}
+		direct++
+		for _, arg := range required {
+			if !strings.Contains(site.line, "--build-arg "+arg) {
+				t.Errorf("%s builds %s without `--build-arg %s`, so the build takes the ARG default and "+
+					"resolves Docker Hub:\n\t%s\nThe valueless form is deliberate — docker reads the value "+
+					"from the environment, which build-with-registry-retry.mjs has already resolved "+
+					"mirror-first.", site.file, site.dockerfile, arg, strings.TrimSpace(site.line))
+			}
+		}
+	}
+	if direct < minDirectBuildInvocations {
+		t.Errorf("only %d in-scope direct `docker build` invocations found (expected at least %d) — the "+
+			"scan has stopped matching, so this half is asserting nothing", direct, minDirectBuildInvocations)
+	}
+}
+
+// TestBuildWrapperResolvesBaseImagesThroughTheMirror is the behavioural half of
+// the pin. Everything above is structure — the arg exists, the Dockerfile takes
+// it, the build sites pass it. None of that says the wrapper puts the MIRROR ref
+// in it, and a wrapper that exported the upstream ref would satisfy every one of
+// those guards while leaving the incident exactly where it was.
+//
+// Three outcomes, because the fallback matters as much as the hit: a runner that
+// cannot read the mirror — a fork, a local machine, this repo before the mirror
+// is populated — must still build, from Docker Hub, rather than fail on a
+// private package it was never going to be able to pull.
+func TestBuildWrapperResolvesBaseImagesThroughTheMirror(t *testing.T) {
+	t.Parallel()
+
+	const arg = "GO_IMAGE"
+	upstream := buildBaseImageArgs(t)[arg]
+	if upstream == "" {
+		t.Fatalf("`buildBaseImageArgs` has no %s entry", arg)
+	}
+	mirrored := mirroredRefOf(t, upstream)
+	const operatorOverride = "golang:1.26-alpine"
+
+	cases := []struct {
+		name string
+		// probeHits is whether `docker buildx imagetools inspect` succeeds,
+		// i.e. whether this runner can read the mirror.
+		probeHits bool
+		preset    string
+		want      string
+	}{
+		{
+			name:      "a runner that can read the mirror builds from the mirror",
+			probeHits: true,
+			want:      mirrored,
+		},
+		{
+			name:      "a runner that cannot read the mirror still builds, from upstream",
+			probeHits: false,
+			want:      upstream,
+		},
+		{
+			name:      "a ref the caller set wins over the mirror",
+			probeHits: true,
+			preset:    operatorOverride,
+			want:      operatorOverride,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			seenPath := filepath.Join(dir, "seen")
+			writeStubDockerRecordingBuildArgEnv(t, dir, seenPath, arg, tc.probeHits)
+
+			cmd := exec.Command("node", buildRetryWrapperPath,
+				"docker", "build", "--build-arg", arg, "-f", "Dockerfile.local", "-t", "cerberus:e2e", ".")
+			cmd.Env = append(os.Environ(), "PATH="+dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+			if tc.preset != "" {
+				cmd.Env = append(cmd.Env, arg+"="+tc.preset)
+			}
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("run %s: %v\noutput:\n%s", buildRetryWrapper, err, out)
+			}
+
+			seen, err := os.ReadFile(seenPath)
+			if err != nil {
+				t.Fatalf("the build never ran, so nothing recorded what %s it saw: %v", arg, err)
+			}
+			if got := strings.TrimSpace(string(seen)); got != tc.want {
+				t.Errorf("the build saw %s=%q, want %q\noutput:\n%s", arg, got, tc.want, out)
+			}
+		})
+	}
+}
+
+// mirroredRefOf asks lib/mirror.mjs what the mirrored ref of an image is,
+// rather than restating the naming rule here. A copy of the rule would pass this
+// test while disagreeing with the mirror the workflows actually publish to.
+func mirroredRefOf(t *testing.T, image string) string {
+	t.Helper()
+
+	abs, err := filepath.Abs(mirrorModule)
+	if err != nil {
+		t.Fatalf("resolve %s: %v", mirrorModule, err)
+	}
+	out, err := exec.Command("node", "--input-type=module", "-e",
+		"import { mirroredRef } from "+strconv.Quote("file://"+abs)+";"+
+			"process.stdout.write(String(mirroredRef("+strconv.Quote(image)+")));").Output()
+	if err != nil {
+		t.Fatalf("ask %s for the mirrored ref of %s: %v", mirrorModule, image, err)
+	}
+	ref := strings.TrimSpace(string(out))
+	if ref == "" || ref == "null" {
+		t.Fatalf("`mirroredRef(%q)` is %q — the image is not in `mirroredImages`, so no build of it can "+
+			"reach the mirror", image, ref)
+	}
+	return ref
+}
+
+// writeStubDockerRecordingBuildArgEnv drops a `docker` onto dir that answers the
+// wrapper's mirror probe as probeHits dictates and, on a build, records the
+// value of the named build arg it inherited from the environment.
+func writeStubDockerRecordingBuildArgEnv(t *testing.T, dir, seenPath, arg string, probeHits bool) {
+	t.Helper()
+
+	probeExit := "1"
+	if probeHits {
+		probeExit = "0"
+	}
+	script := strings.Join([]string{
+		"#!/bin/sh",
+		`[ "$1" = buildx ] && exit ` + probeExit,
+		// `--build-arg NAME` with no value is docker's own "take it from the
+		// environment" form, so the environment IS the channel under test.
+		"printf '%s' \"$" + arg + "\" > " + shellQuote(seenPath),
+		"exit 0",
+		"",
+	}, "\n")
+
+	path := filepath.Join(dir, "docker")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write stub docker: %v", err)
+	}
+}
+
+// TestBaseImageArgsAreMirrored closes the loop: an arg pointing at an image the
+// mirror was never told about resolves upstream anyway, because `mirroredRef`
+// returns null outside the inventory. The indirection would be present, wired,
+// tested — and inert.
+func TestBaseImageArgsAreMirrored(t *testing.T) {
+	t.Parallel()
+
+	inventory := mirrorInventory(t)
+	for arg, image := range buildBaseImageArgs(t) {
+		if !inventory[image] {
+			t.Errorf("`buildBaseImageArgs` pairs %s with %s, which is absent from `mirroredImages` — "+
+				"`mirroredRef` returns null for it, so the wrapper resolves the upstream ref and every "+
+				"build still spends the Docker Hub quota.", arg, image)
+		}
+	}
+}

--- a/test/regression/e2e_prepull_lockstep_test.go
+++ b/test/regression/e2e_prepull_lockstep_test.go
@@ -1,0 +1,234 @@
+package regression
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// The k3d e2e lanes pull every external image on the HOST daemon and import the
+// result into the cluster, so the cluster's containerd never reaches a registry.
+// That is the only reason those lanes survive Docker Hub's anonymous per-IP
+// quota: a host pull authenticates and reaches the GHCR mirror first
+// (`lib/registry.mjs`), while an in-cluster containerd pull does neither.
+//
+// The mechanism covers exactly the images someone remembered to list. An image
+// the manifests ask for and the pre-pull omits is not pre-pulled, not imported,
+// and pulled by containerd at pod start — anonymously, un-mirrored, and at the
+// worst possible moment, since a rate-limited pod sits in `ImagePullBackOff`
+// until the deployment wait expires and the whole lane goes red.
+//
+// It had already failed silently. #1263 moved the k3d ClickHouse to
+// `26.6-alpine` because upstream 26.5 carried a topK-prefilter regression, and
+// left `E2E_EXTERNAL_IMAGES` on `26.5-alpine`. For ten days the pre-pull warmed
+// a tag no manifest asked for while the one image it was written for — the
+// biggest, slowest pull in the lane — went to Docker Hub on every run. Nothing
+// went red, because nothing was looking (issue #1461).
+//
+// The comment that was supposed to prevent this said the two sides "MUST stay in
+// lock-step". A comment is not a gate, and this is the gate. It runs in both
+// directions on purpose: an uncovered manifest image is the exposure, and a
+// stale pre-pull entry is how the list stops describing the lane — the exact
+// state that made the real gap hard to see.
+//
+// Floor for the manifest scan. There are 7 distinct refs across the two manifest
+// trees today; the floor sits below that so a move that leaves this guard
+// scanning an empty set fails instead of passing vacuously.
+const minManifestImageRefs = 5
+
+// manifestImage matches a Kubernetes/Helm-values `image:` whose value is a ref
+// on the same line. The scalar form is the requirement: `cerberus-values.yaml`
+// spells the chart's image as an `image:` BLOCK with `repository:` / `tag:`
+// children, and that one is built locally and loaded with `pullPolicy: Never`,
+// so it is not an external pull and must not be read as one.
+var manifestImage = regexp.MustCompile(`^\s*-?\s*image:\s*["']?([^"'\s#]+)["']?\s*$`)
+
+// manifestTrees are the directories holding the manifests the k3d lanes apply,
+// and prePullPins the Justfile lists whose union must account for them.
+//
+// The check is over the UNION rather than per-lane, and that is a deliberate
+// scope, not an oversight. A directory is not a lane: `cerberus-values-bwc.yaml`
+// lives under test/e2e/k3s but only the bwc lane passes it to Helm, and the bwc
+// lane in turn excludes test/e2e/k3s/clickhouse.yaml through its kustomization.
+// Recovering the true per-lane file set means interpreting `kubectl apply -f`,
+// `kubectl kustomize`, and `helm --values` out of two recipes plus a
+// kustomization that reaches across trees — machinery that can under-scan
+// silently, which is the exact defect being fixed.
+//
+// The union is the right scope anyway, because it is the SILENT half. An image
+// in neither list is pulled anonymously from Docker Hub by the cluster's own
+// containerd and usually succeeds, so it shows up as nothing at all until a
+// rate-limit window closes on it — the ten-day gap above. An image listed but
+// pre-pulled by the other lane fails loudly at pod start instead
+// (`ImagePullBackOff` against `pullPolicy: Never`, then a rollout timeout), so
+// it cannot hide.
+var (
+	manifestTrees = []string{"../../test/e2e/k3s", "../../test/e2e/k3s-bwc"}
+	prePullPins   = []string{"E2E_EXTERNAL_IMAGES", "E2E_BWC_IMAGES"}
+)
+
+// prePulledImages is the union of the pre-pull lists.
+func prePulledImages(t *testing.T) map[string]bool {
+	t.Helper()
+
+	pins := justfilePins(t)
+	union := map[string]bool{}
+	for _, pin := range prePullPins {
+		set, ok := pins[pin]
+		if !ok {
+			t.Fatalf("%s no longer defines %s, so this guard cannot tell what the k3d lanes pre-pull",
+				justfilePath, pin)
+		}
+		for ref := range set {
+			union[ref] = true
+		}
+	}
+	return union
+}
+
+// manifestImages is every externally-pulled image ref across all manifest trees,
+// mapped to the sites naming it.
+func manifestImages(t *testing.T) map[string][]string {
+	t.Helper()
+
+	all := map[string][]string{}
+	for _, dir := range manifestTrees {
+		for ref, sites := range manifestImagesUnder(t, dir) {
+			all[ref] = append(all[ref], sites...)
+		}
+	}
+	return all
+}
+
+// justfilePins reads every `NAME := "a b c"` pin out of the Justfile as a set of
+// space-separated refs, which is the shape the pre-pull lists use.
+func justfilePins(t *testing.T) map[string]map[string]bool {
+	t.Helper()
+
+	src, err := os.ReadFile(justfilePath)
+	if err != nil {
+		t.Fatalf("read %s: %v", justfilePath, err)
+	}
+
+	pins := map[string]map[string]bool{}
+	for _, m := range justAssignment.FindAllStringSubmatch(string(src), -1) {
+		set := map[string]bool{}
+		for _, ref := range strings.Fields(m[2]) {
+			set[ref] = true
+		}
+		pins[m[1]] = set
+	}
+	return pins
+}
+
+// manifestImagesUnder collects every externally-pulled image ref in a manifest
+// tree, mapped to the files that name it.
+func manifestImagesUnder(t *testing.T, dir string) map[string][]string {
+	t.Helper()
+
+	refs := map[string][]string{}
+	err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if ext := filepath.Ext(d.Name()); ext != ".yaml" && ext != ".yml" {
+			return nil
+		}
+		src, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		for i, line := range strings.Split(string(src), "\n") {
+			if isProse(line) {
+				continue
+			}
+			m := manifestImage.FindStringSubmatch(line)
+			if m == nil {
+				continue
+			}
+			// A templated ref is resolved by whatever renders it, not by the
+			// pre-pull, and `dockerHubRef` rejects it for the same reason the
+			// mirror inventory does.
+			if strings.Contains(m[1], "{{") || strings.Contains(m[1], "${") {
+				continue
+			}
+			refs[m[1]] = append(refs[m[1]], fmt.Sprintf("%s:%d", path, i+1))
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", dir, err)
+	}
+	return refs
+}
+
+// TestE2EPrePullCoversEveryManifestImage is the forward direction: every image a
+// k3d manifest asks for must be pre-pulled and imported, or the cluster pulls it
+// itself.
+func TestE2EPrePullCoversEveryManifestImage(t *testing.T) {
+	t.Parallel()
+
+	prePulled := prePulledImages(t)
+	found := manifestImages(t)
+
+	for _, ref := range sortedKeys(found) {
+		if prePulled[ref] {
+			continue
+		}
+		t.Errorf("the k3d manifests ask for %s (%s) but no pre-pull list names it (%s), so the host never "+
+			"pulls it and k3d never imports it — the cluster's own containerd fetches it at pod start, "+
+			"anonymously and bypassing the GHCR mirror, which is the entire exposure the pre-pull exists to "+
+			"remove. Add it to whichever list the lane using it imports.",
+			ref, strings.Join(dedupe(found[ref]), ", "), strings.Join(prePullPins, " / "))
+	}
+
+	if len(found) < minManifestImageRefs {
+		t.Errorf("found only %d distinct image refs across %s (expected at least %d) — the scanner is "+
+			"matching a shape the manifests no longer use, so this guard is asserting nothing",
+			len(found), describeTrees(), minManifestImageRefs)
+	}
+}
+
+// TestE2EPrePullListsNameOnlyManifestImages is the reverse direction. A pin no
+// manifest asks for costs a pull and an import on every e2e run, and — the
+// reason it is an error rather than a wart — it makes the list stop describing
+// the lane, which is precisely why the real gap went unnoticed for ten days: the
+// stale `26.5-alpine` entry made the list LOOK like it covered ClickHouse.
+func TestE2EPrePullListsNameOnlyManifestImages(t *testing.T) {
+	t.Parallel()
+
+	pins := justfilePins(t)
+	named := manifestImages(t)
+
+	for _, pin := range prePullPins {
+		set, ok := pins[pin]
+		if !ok {
+			t.Fatalf("%s no longer defines %s", justfilePath, pin)
+		}
+		for _, ref := range sortedSet(set) {
+			if _, ok := named[ref]; ok {
+				continue
+			}
+			t.Errorf("%s pre-pulls and imports %s, but no manifest under %s asks for it any more. Every e2e "+
+				"run pays for that pull, and a list naming images the lanes do not use is how a MISSING one "+
+				"hides. Drop the entry, or bump it to the tag the manifests moved to.",
+				pin, ref, describeTrees())
+		}
+	}
+}
+
+func describeTrees() string {
+	dirs := make([]string, 0, len(manifestTrees))
+	for _, dir := range manifestTrees {
+		dirs = append(dirs, strings.TrimPrefix(dir, "../../"))
+	}
+	sort.Strings(dirs)
+	return strings.Join(dirs, " / ")
+}

--- a/test/regression/image_build_registry_retry_test.go
+++ b/test/regression/image_build_registry_retry_test.go
@@ -418,13 +418,22 @@ func TestBuildRetryWrapperRetriesOnlyTransientRegistryFailures(t *testing.T) {
 	}
 }
 
-// writeStubDockerBuild drops a `docker` onto dir that records every call and
-// fails with failureText/failureExit until the succeedsOn-th one.
+// writeStubDockerBuild drops a `docker` onto dir that records every BUILD call
+// and fails with failureText/failureExit until the succeedsOn-th one. Any other
+// subcommand is refused without being recorded.
 func writeStubDockerBuild(t *testing.T, dir, callLog string, succeedsOn int, failureText string, failureExit int) {
 	t.Helper()
 
 	script := strings.Join([]string{
 		"#!/bin/sh",
+		// The stub stands in for the BUILD, so only a build counts as a call.
+		// The wrapper also probes the mirror for its base-image refs
+		// (`docker buildx imagetools inspect`), and a probe that failed the
+		// count would make the retry assertions below read one attempt short.
+		// Refusing it is the honest answer for a runner holding no mirror
+		// credentials, and it exercises the wrapper's fall-back-to-upstream
+		// path; the mirror-hit path is pinned by the sibling test.
+		`[ "$1" = build ] || exit 1`,
 		"echo call >> " + shellQuote(callLog),
 		"attempts=$(wc -l < " + shellQuote(callLog) + " | tr -d ' ')",
 		"[ \"$attempts\" -ge " + strconv.Itoa(succeedsOn) + " ] && exit 0",

--- a/test/regression/mirror_inventory_test.go
+++ b/test/regression/mirror_inventory_test.go
@@ -51,6 +51,10 @@ var inventoryEntry = regexp.MustCompile(`(?m)^\s*'([^']+)',\s*$`)
 //   - a composite-action input `default:`, which is where the BuildKit
 //     bootstrap image is pinned.
 //
+// One shape is not here because one line does not carry it: a `FROM ${ARG}`
+// whose default is declared elsewhere in the file. `upstreamImageRefsInTree`
+// resolves that pair itself.
+//
 // Matching CONTEXTS rather than ref-shaped text is what keeps the scan honest.
 // This tree is full of `name:name` tokens that are not images — every PromQL
 // recording rule under test/e2e/migration/archetypes (`slo:http_error_budget`),
@@ -223,11 +227,30 @@ func upstreamImageRefsInTree(t *testing.T) map[string][]string {
 		if err != nil {
 			t.Fatalf("read %s: %v", file, err)
 		}
+		// A Dockerfile's base image can reach its `FROM` through a build arg —
+		// `ARG GO_IMAGE=golang:1.26` + `FROM ${GO_IMAGE}`, the indirection that
+		// lets CI point the build at the mirror. The ARG default is the ref
+		// that gets resolved whenever the caller passes nothing, so it is an
+		// image reference in every sense this guard cares about. Only args a
+		// `FROM` in this same file actually substitutes count: an `ARG` is just
+		// a variable, and the rest of them are build tags and version strings.
+		baseImageArgs := map[string]bool{}
+		for _, m := range dockerfileFrom.FindAllStringSubmatch(string(src), -1) {
+			if name := dockerfileFromArg.FindStringSubmatch(m[1]); name != nil {
+				baseImageArgs[name[1]] = true
+			}
+		}
+
 		for _, line := range strings.Split(string(src), "\n") {
 			// Comments name images they do not pull — a bumped-from tag, an
 			// incident log, a worked example.
 			if isProse(line) {
 				continue
+			}
+			if m := dockerfileArgDecl.FindStringSubmatch(line); m != nil && baseImageArgs[m[1]] {
+				if dockerHubRef.MatchString(m[2]) && isDockerHubImageRef(m[2]) && !built[m[2]] {
+					refs[m[2]] = append(refs[m[2]], file)
+				}
 			}
 			for _, context := range imageRefContexts {
 				m := context.FindStringSubmatch(line)


### PR DESCRIPTION
## What

Two remaining image-acquisition paths reached Docker Hub anonymously instead of the authenticated GHCR mirror. They are one root cause seen from two angles — an acquisition the mirror cannot intercept — and each is fixed at a single enforcement point rather than per-site.

Closes #1576
Closes #1461

## Why now: this is what is failing merges today

PR #1599's `compose-smoke-shard` died in **52 seconds** (run 30736686185, job 91467073603). Reading that job's log rather than re-running it — a retry only re-spends an exhausted budget — the diagnosis is unambiguous:

- `moby/buildkit`, `clickhouse-server:26.6`, `grafana/grafana:12.2.9` and `otel/opentelemetry-collector-contrib:0.152.1` all logged **"acquired from the mirror"**. The compose service-image path is healthy.
- The sole refusal, at log lines 840/863:

  ```
  unexpected status from HEAD request to
  https://registry-1.docker.io/v2/library/golang/manifests/1.26: 429 Too Many Requests
  target cerberus: failed to solve
  ```

So the compose lane is red on the **BuildKit `FROM`**, which is exactly #1576 — not on compose pulling anonymously.

## #1576 — the base image a pre-pull can never cover

BuildKit's `docker-container` driver resolves a `FROM` against the registry from **its own content store, never the host daemon's**. No host-side pre-pull can protect a base image; only the ref itself can. Retry cannot help either: a 429 that repeats on every attempt is not a transport fault, and `build-with-registry-retry.mjs` correctly declines to retry it.

The three Dockerfiles this repo builds now take their base through a build arg:

```dockerfile
ARG GO_IMAGE=golang:1.26
FROM ${GO_IMAGE} AS build
```

Every build site passes the arg through — ten compose `build:` stanzas via `GO_IMAGE: "${GO_IMAGE:-golang:1.26}"`, and the three direct `docker build` calls via bare `--build-arg GO_IMAGE` (docker's take-it-from-the-environment form, which the Justfile needs because `{{VAR}}` expands at recipe-parse time).

**The decision is made in exactly one place.** The issue's literal suggestion was to set `GO_IMAGE` in each CI job that builds — eight per-leg edits with nothing to catch the ninth lane. Instead `build-with-registry-retry.mjs` sets it, because `TestImageBuildingCommandsGoThroughTheRetryWrapper` already pins that wrapper as the sole path for every build in the tree. **Zero workflow files change.** A new lane inherits the behaviour by construction.

```js
for (const [argName, upstreamRef] of Object.entries(buildBaseImageArgs)) {
  if ((process.env[argName] ?? '') !== '') continue;
  process.env[argName] = buildBaseImageRef(upstreamRef);
}
```

`buildBaseImageRef` probes `docker buildx imagetools inspect <mirror-ref>` — reading a manifest through the same registry path a `FROM` takes, without pulling layers — and returns the mirror ref on success, the upstream ref otherwise.

### The default stays `golang:1.26`, deliberately

The mirror packages are **private**. A fork or an outside contributor authenticates as itself, cannot read them, probes, misses, and builds from Docker Hub exactly as before. No file in this tree names a registry an outsider cannot pull from — which is why the ref is a defaulted `ARG` rather than a rewritten `FROM`.

## #1461 — the pre-pull that had silently stopped covering ClickHouse

`git blame`: `8e03142f` set the Justfile to `26.5-alpine`; `13666dcf` (#1263) moved the k3d manifests to `26.6-alpine` and left the Justfile behind. There is no `imagePullPolicy` under `test/e2e/k3s/`, so for ten days the cluster's own containerd pulled the largest image in the lane from Docker Hub — anonymously, un-mirrored — on every e2e run. Nothing went red because nothing was looking.

Both halves the issue asks for:

1. **Re-synced** the pin to `26.6-alpine`.
2. **Gated it**, in both directions, with a vacuity floor. The comment that said the two sides "MUST stay in lock-step" is precisely the thing that already failed; a fresher comment is not a fix.

The gate checks the **union** of `E2E_EXTERNAL_IMAGES` + `E2E_BWC_IMAGES` against the union of the manifest trees, and the scope is deliberate rather than an oversight — the reasoning is in the file. A directory is not a lane (`cerberus-values-bwc.yaml` lives under `test/e2e/k3s` but only the bwc lane passes it to Helm, which in turn excludes `test/e2e/k3s/clickhouse.yaml`), and recovering the true per-lane file set means interpreting `kubectl apply -f`, `kubectl kustomize` and `helm --values` across two recipes plus a cross-tree kustomization — machinery that can under-scan silently, which is the defect being fixed. The union is also the right scope on the merits: an image in **neither** list is the silent half (it usually pulls fine until a quota window closes), whereas an image covered by the other lane's list fails loudly at pod start against `pullPolicy: Never`.

My first draft *did* split by directory. It failed immediately on `cerberus-values-bwc.yaml`, which is how the fake precision was caught.

## Proof the gates can fail

A gate that cannot fail is a gap, not coverage. Every assertion here was reverted and observed red.

**1. The exact historical #1461 drift** — pin back to `26.5-alpine`. Both directions fire, and the forward one names the two real sites:

```
--- FAIL: TestE2EPrePullCoversEveryManifestImage
    the k3d manifests ask for clickhouse/clickhouse-server:26.6-alpine
    (../../test/e2e/k3s/clickhouse.yaml:82, ../../test/e2e/k3s/otel-collector.yaml:475)
    but no pre-pull list names it …
--- FAIL: TestE2EPrePullListsNameOnlyManifestImages
    E2E_EXTERNAL_IMAGES pre-pulls and imports clickhouse/clickhouse-server:26.5-alpine,
    but no manifest … asks for it any more.
```

**2. Vacuity floor** — break the scanner's regex so it matches nothing:

```
found only 0 distinct image refs across test/e2e/k3s / test/e2e/k3s-bwc
(expected at least 5) — the scanner is matching a shape the manifests no longer
use, so this guard is asserting nothing
```

**3.** `TestBuildWrapperResolvesBaseImagesThroughTheMirror` — three subtests over a stubbed docker (mirror readable → mirror ref; not readable → upstream ref; caller-preset value wins), each proven to fail when the wrapper's injection is removed.

**4.** The Dockerfile/compose/direct-build scope in `build_base_image_arg_test.go` is **derived, not listed**: a Dockerfile is in scope exactly when some build site in this tree names it. That is what keeps the vendored upstream snapshot under `compatibility/tempo/upstream/` out of scope without an exclusion list — an exclusion list would also hide a real Dockerfile added there later. `meteredFromRef` strips a `@sha256:` digest before deciding, because pinning by digest fixes *what* is pulled, not *where from*.

## Coupling the new pins surfaced

Two existing tests broke, and both were real coupling rather than test-fitting:

- `TestBuildRetryWrapperRetriesOnlyTransientRegistryFailures` counted my `docker buildx imagetools inspect` probe as a build, reading every retry assertion one attempt short. The PATH stub now dispatches on subcommand (`[ "$1" = build ] || exit 1`), so only a build counts — and refusing the probe is the honest answer for a runner holding no mirror credentials, which also exercises the fall-back-to-upstream path.
- `TestMirrorInventoryCoversEveryUpstreamImage` read `golang:1.26` as a stale inventory entry once the `FROM` became `${GO_IMAGE}`. `upstreamImageRefsInTree` now resolves the ARG/FROM pair. (Rejected the alternative of inventing a `*_IMAGE` arg-naming convention — that is a convention with no enforcement, i.e. the #1461 failure mode again.)

## Triage of the rest of the class — three issues verified fixed, closing with evidence

This PR was widened to a five-issue class. Verifying each at its own cited `file:line` rather than trusting the cite, three were already fixed and need no code here:

| Issue | Verdict | Evidence |
|---|---|---|
| **#1575** image-acquiring jobs not authenticating | **Fixed in main** | #1586 (`ff25ba38`) carries `assert-image-jobs-authenticate.mjs` + its test file. |
| **#1565** compose pulls service images anonymously | **Fixed in main** | #1572 (`8207c25a`) added `compose-pull-images.mjs`; `_compose-pull-retry` no longer runs `docker compose pull`. Positive live evidence in the #1599 job log — every service image logged "acquired from the mirror". |
| **#1514** `K3S_IMAGE` still pulls from Docker Hub | **Fixed in main** | #1579 (`af4f9ff8`) added `rancher/k3s:v1.31.5-k3s1` to `mirroredImages`, and `_pull-retry {{K3S_IMAGE}}` runs before `k3d cluster create --image`. This PR corrects the stale Justfile comment that still *asked* for the GHCR re-tag #1579 had already delivered. |

## Test plan

- `go test ./test/regression/` — green on `60f27b13`.
- Both new gates proven to fail on the exact historical drift and on a scanner that stops matching.
- Per the standing instruction not to verify a mirror fix by re-running a red compose lane: correctness here is read off the resolved reference and the login step, not off a green run that could just mean the rolling quota window reset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
