### PR TITLE
fix(loki): stamp the parser-error labels Loki sets on a failed unpack

### DIFF
--- a/internal/api/loki/post_process.go
+++ b/internal/api/loki/post_process.go
@@ -2,10 +2,12 @@ package loki
 
 import (
 	"bytes"
-	"encoding/json"
+	"errors"
 	"fmt"
 	"regexp"
 	"text/template"
+
+	"github.com/buger/jsonparser"
 
 	logpattern "github.com/tsouza/cerberus/internal/logql/logpattern"
 
@@ -26,10 +28,12 @@ import (
 //     template-set labels on the row. Subsequent line_format stages
 //     see the updated label map; the streams response groups rows by
 //     the final (post-format) label set.
-//   - `| unpack` — parses the line as a JSON object and merges each
-//     string-valued key into the labels map. A special `_entry` key
-//     replaces the line, restoring the original payload from
-//     Promtail's `pack` stage.
+//   - `| unpack` — parses the line as a JSON object emitted by
+//     Promtail's `pack` stage. The special `_entry` key replaces the
+//     line with the original payload, and the remaining string-valued
+//     keys are merged into the labels map — but only if `_entry` was
+//     present. A payload that is not a JSON object, or that fails to
+//     parse, stamps the `__error__` / `__error_details__` pair.
 //   - `| pattern "<ip> <_> <method> <path>"` — matches the line against
 //     a Loki pattern expression and adds each named capture to the
 //     labels map. `<_>` skips a segment.
@@ -286,53 +290,104 @@ func newLabelFormatStep(formats []syntax.LabelFmt) (lineTransform, error) {
 	}, nil
 }
 
+// errUnexpectedJSONObject reproduces Loki's sentinel byte for byte. The
+// text reaches callers through `__error_details__`, so it is part of the
+// wire contract rather than an internal diagnostic: upstream builds it as
+// `fmt.Errorf("expecting json object(%d), but it is not", jsoniter.ObjectValue)`
+// and json-iterator's ObjectValue ordinal is 6.
+var errUnexpectedJSONObject = errors.New("expecting json object(6), but it is not")
+
+// jsonParserErr is the `__error__` value Loki stamps for every failure of
+// a JSON-family parser stage, `| unpack` included.
+const jsonParserErr = "JSONParserErr"
+
 // unpackStep implements `| unpack`. The line is expected to be a JSON
 // object emitted by Promtail's `pack` stage: each string-valued key
 // becomes a label, and the special `_entry` key replaces the line.
 //
-// Non-object payloads and JSON-decode errors leave the line and labels
-// unchanged — matching Loki's silent-on-malformed-JSON contract.
-// Non-string values (numbers, arrays, nested objects) are skipped at
-// the label level but the `_entry` rewrite still applies.
+// Three rules here are easy to get backwards, and all three are what
+// Loki's UnpackParser actually does (pkg/logql/log/parser.go):
+//
+//   - A payload that is not a JSON object, or one that fails to parse,
+//     is an ERROR, not a silent pass-through. Loki stamps
+//     `__error__="JSONParserErr"` plus an `__error_details__` message and
+//     returns the ORIGINAL line. Swallowing it inverts the meaning of a
+//     `| __error__=""` filter, which is the usual way callers ask for
+//     "only lines that parsed" (issue #1447).
+//   - Labels are collected into a buffer and flushed only if a top-level
+//     string `_entry` key was found. A well-formed object without one is
+//     a complete no-op: original line, and NO extracted labels.
+//   - Non-string values (numbers, booleans, arrays, nested objects) are
+//     skipped, and an empty line is not an error.
 //
 // Returns a FRESH labels map so callers can treat the input as
 // immutable, consistent with newLabelFormatStep.
 func unpackStep(line string, _ int64, labels map[string]string) (string, map[string]string) {
-	if len(line) == 0 || line[0] != '{' {
+	if len(line) == 0 {
 		return line, labels
 	}
-	var raw map[string]json.RawMessage
-	if err := json.Unmarshal([]byte(line), &raw); err != nil {
+	if line[0] != '{' {
+		return line, withParserError(labels, errUnexpectedJSONObject)
+	}
+
+	// Buffered as alternating key/value pairs so nothing is committed
+	// before the `_entry` gate below, matching upstream's lbsBuffer.
+	var buf []string
+	newLine := line
+	isPacked := false
+	err := jsonparser.ObjectEach([]byte(line),
+		func(key, value []byte, typ jsonparser.ValueType, _ int) error {
+			if typ != jsonparser.String {
+				return nil
+			}
+			k := string(key)
+			if k == syntax.PackedEntryKey {
+				var stackbuf [unescapeStackBufSize]byte
+				unescaped, uerr := jsonparser.Unescape(value, stackbuf[:])
+				if uerr != nil {
+					return uerr
+				}
+				newLine = string(unescaped)
+				isPacked = true
+				return nil
+			}
+			// Don't shadow a stream label — Loki appends a duplicate
+			// suffix to the RAW key, then sanitises the result.
+			if _, ok := labels[k]; ok {
+				k += duplicateSuffix
+			}
+			buf = append(buf, sanitizeLabelKey(k), unescapeJSONString(value))
+			return nil
+		})
+	if err != nil {
+		return line, withParserError(labels, err)
+	}
+	if !isPacked {
 		return line, labels
 	}
-	out := make(map[string]string, len(labels)+len(raw))
+
+	out := make(map[string]string, len(labels)+len(buf)/2)
 	for k, v := range labels {
 		out[k] = v
 	}
-	newLine := line
-	for k, v := range raw {
-		// Skip non-string values (Loki's unpack only extracts strings).
-		if len(v) == 0 || v[0] != '"' {
-			continue
-		}
-		var s string
-		if err := json.Unmarshal(v, &s); err != nil {
-			continue
-		}
-		if k == syntax.PackedEntryKey {
-			newLine = s
-			continue
-		}
-		// Don't shadow stream labels — Loki appends a duplicate suffix
-		// in that case. Mirror that behavior so cerberus's row output
-		// matches Loki's.
-		if _, ok := labels[k]; ok {
-			out[k+duplicateSuffix] = s
-			continue
-		}
-		out[k] = s
+	for i := 0; i < len(buf); i += 2 {
+		out[buf[i]] = buf[i+1]
 	}
 	return newLine, out
+}
+
+// withParserError returns a copy of labels carrying the `__error__` /
+// `__error_details__` pair Loki's addErrLabel stamps. The copy keeps the
+// step's caller-immutable contract; the extracted labels are deliberately
+// dropped, because upstream discards its buffer on the error path.
+func withParserError(labels map[string]string, err error) map[string]string {
+	out := make(map[string]string, len(labels)+2)
+	for k, v := range labels {
+		out[k] = v
+	}
+	out[syntax.ErrorLabel] = jsonParserErr
+	out[syntax.ErrorDetailsLabel] = err.Error()
+	return out
 }
 
 // duplicateSuffix matches Loki's `_extracted` suffix appended to

--- a/internal/api/loki/unpack_pattern_test.go
+++ b/internal/api/loki/unpack_pattern_test.go
@@ -58,22 +58,115 @@ func TestUnpack_DuplicateSuffix(t *testing.T) {
 	}
 }
 
-// TestUnpack_NonJSONLeavesLineAlone — a non-JSON line silently passes
-// through. Loki sets `__error__=JSONParserErr` in that case; cerberus
-// uses silent-fallback semantics (matching its line_format /
-// label_format style).
-func TestUnpack_NonJSONLeavesLineAlone(t *testing.T) {
+// TestUnpack_NonJSONStampsParserError — a payload that is not a JSON
+// object keeps the line but is an ERROR: Loki's UnpackParser stamps
+// `__error__="JSONParserErr"` and an `__error_details__` sentinel. The
+// details text is byte-compared because callers filter on it, and
+// because swallowing the pair inverts `| __error__=""` — the whole of
+// issue #1447.
+func TestUnpack_NonJSONStampsParserError(t *testing.T) {
 	t.Parallel()
 
 	expr, _ := syntax.ParseExpr(`{job="api"} | unpack`)
 	tx, _ := postProcessExtract(expr)
 
-	gotLine, gotLabels := tx("not json", 0, map[string]string{"job": "api"})
-	if gotLine != "not json" {
-		t.Errorf("line should pass through; got %q", gotLine)
+	for _, line := range []string{"not json", `[1,2]`, `"a string"`, `42`} {
+		gotLine, gotLabels := tx(line, 0, map[string]string{"job": "api"})
+		if gotLine != line {
+			t.Errorf("line should pass through; got %q, want %q", gotLine, line)
+		}
+		want := map[string]string{
+			"job":               "api",
+			"__error__":         "JSONParserErr",
+			"__error_details__": "expecting json object(6), but it is not",
+		}
+		if !reflect.DeepEqual(gotLabels, want) {
+			t.Errorf("labels for %q\n got %#v\nwant %#v", line, gotLabels, want)
+		}
+	}
+}
+
+// TestUnpack_EmptyLineIsNotAnError — upstream returns early on a
+// zero-length line BEFORE the `{` check, so no error is stamped. Folding
+// this into the non-object branch would mark every empty line broken.
+func TestUnpack_EmptyLineIsNotAnError(t *testing.T) {
+	t.Parallel()
+
+	expr, _ := syntax.ParseExpr(`{job="api"} | unpack`)
+	tx, _ := postProcessExtract(expr)
+
+	gotLine, gotLabels := tx("", 0, map[string]string{"job": "api"})
+	if gotLine != "" {
+		t.Errorf("line should stay empty; got %q", gotLine)
 	}
 	if !reflect.DeepEqual(gotLabels, map[string]string{"job": "api"}) {
 		t.Errorf("labels should be unchanged; got %#v", gotLabels)
+	}
+}
+
+// TestUnpack_MalformedObjectStampsParserError — a line that opens with
+// `{` but does not parse carries the underlying decoder's message
+// through to `__error_details__`, exactly as upstream passes
+// jsonparser's error to addErrLabel.
+func TestUnpack_MalformedObjectStampsParserError(t *testing.T) {
+	t.Parallel()
+
+	expr, _ := syntax.ParseExpr(`{job="api"} | unpack`)
+	tx, _ := postProcessExtract(expr)
+
+	const line = `{"_entry":"l","pod":`
+	gotLine, gotLabels := tx(line, 0, map[string]string{"job": "api"})
+	if gotLine != line {
+		t.Errorf("malformed line should pass through unmodified; got %q", gotLine)
+	}
+	if gotLabels["__error__"] != "JSONParserErr" {
+		t.Errorf("__error__ = %q, want JSONParserErr", gotLabels["__error__"])
+	}
+	if gotLabels["__error_details__"] == "" {
+		t.Error("__error_details__ should carry the decoder's message")
+	}
+	if _, ok := gotLabels["pod"]; ok {
+		t.Error("labels collected before the failure must be discarded")
+	}
+}
+
+// TestUnpack_NoPackedEntryExtractsNothing — upstream flushes its label
+// buffer only when a top-level string `_entry` key was found. A
+// well-formed object without one is a complete no-op. Extracting the
+// labels anyway invents series identity out of an ordinary JSON log
+// line, which is the silently-wrong shape from the other direction.
+func TestUnpack_NoPackedEntryExtractsNothing(t *testing.T) {
+	t.Parallel()
+
+	expr, _ := syntax.ParseExpr(`{job="api"} | unpack`)
+	tx, _ := postProcessExtract(expr)
+
+	const line = `{"pod":"web-1","container":"app"}`
+	gotLine, gotLabels := tx(line, 0, map[string]string{"job": "api"})
+	if gotLine != line {
+		t.Errorf("line should pass through; got %q", gotLine)
+	}
+	if !reflect.DeepEqual(gotLabels, map[string]string{"job": "api"}) {
+		t.Errorf("no labels should be extracted without `_entry`; got %#v", gotLabels)
+	}
+}
+
+// TestUnpack_SanitizesLabelKeys — upstream runs every extracted key
+// through sanitizeLabelKey, so a key that is not a valid label name
+// arrives normalised rather than verbatim.
+func TestUnpack_SanitizesLabelKeys(t *testing.T) {
+	t.Parallel()
+
+	expr, _ := syntax.ParseExpr(`{job="api"} | unpack`)
+	tx, _ := postProcessExtract(expr)
+
+	const line = `{"_entry":"l","pod-name":"web-1","9lives":"cat"}`
+	_, gotLabels := tx(line, 0, map[string]string{"job": "api"})
+	if gotLabels["pod_name"] != "web-1" {
+		t.Errorf("`pod-name` should sanitise to `pod_name`; got %#v", gotLabels)
+	}
+	if gotLabels["_9lives"] != "cat" {
+		t.Errorf("leading-digit key should gain the `_` prefix; got %#v", gotLabels)
 	}
 }
 


### PR DESCRIPTION
Closes #1447

## The bug

`| unpack` swallowed every failure. Both failure paths in `unpackStep` returned the line and labels untouched:

```go
if len(line) == 0 || line[0] != '{' {
    return line, labels
}
var raw map[string]json.RawMessage
if err := json.Unmarshal([]byte(line), &raw); err != nil {
    return line, labels
}
```

so a broken payload was indistinguishable from a clean parse. The doc comment above it asserted this was correct — *"matching Loki's silent-on-malformed-JSON contract"* — and `TestUnpack_NonJSONLeavesLineAlone` pinned it as deliberate. Both were wrong; Loki's `UnpackParser` stamps an error.

The user-visible consequence is that the two filters callers actually reach for are inverted. `| unpack | __error__=""` is the idiomatic *"only the lines that parsed"* query — it matched **everything**, broken lines included. Its complement `| unpack | __error__="JSONParserErr"` matched **nothing**. Both return plausible rows with the wrong membership, which is the silently-wrong shape.

## Upstream reference

Transcribed from `grafana/loki/v3@v3.7.1`, `pkg/logql/log/parser.go` — the version `test/oracle/go.mod` already pins. Three rules were each backwards:

| shape | Loki | cerberus (before) |
| --- | --- | --- |
| `not json`, `[1,2]`, `42` | `__error__="JSONParserErr"`, `__error_details__="expecting json object(6), but it is not"`, original line | silent pass-through |
| `{"_entry":"l","pod":` (malformed) | `__error__` + decoder's message, original line, collected labels discarded | silent pass-through |
| `{"pod":"web-1"}` (no `_entry`) | complete no-op — original line, **no** labels | merged `pod` as a label |
| `""` (empty) | not an error | not an error ✓ |
| key `pod-name` | sanitised to `pod_name` | verbatim `pod-name` |

The `_entry` gate is the subtle one: upstream accumulates into `u.lbsBuffer` and flushes only inside `if isPacked`, so a well-formed object that is not a `pack` payload extracts nothing. Cerberus merged its keys anyway, inventing series identity out of an ordinary JSON log line.

The `(6)` in the details text is json-iterator's `ObjectValue` ordinal, which upstream interpolates via `fmt.Errorf("expecting json object(%d), but it is not", jsoniter.ObjectValue)`. It is `jsoniter.ObjectValue`, **not** `jsonparser.Object` (which is 3) — worth stating because the two are easy to swap and only one renders the string Loki actually emits.

## Implementation notes

Traversal moves from `encoding/json` into a `map[string]json.RawMessage` over to `jsonparser.ObjectEach`. Three reasons, none of them cosmetic:

- **`github.com/buger/jsonparser` is already a direct dependency**, used by `detected_extract.go` in this very package. No new dep; no `go.mod` change.
- **Document order.** Go map iteration is randomised; `ObjectEach` walks in order. The `_extracted` duplicate-suffix rule and last-writer-wins on repeated keys both depend on order, so the old code was non-deterministic in those cases.
- **Exact error text by construction.** I verified the error values are byte-identical between `buger/jsonparser@v1.6.0` and the `grafana/jsonparser` fork Loki pins, so `__error_details__` matches upstream rather than being approximated by `encoding/json`'s unrelated messages.

`sanitizeLabelKey` and `unescapeJSONString` already existed in this package as clean-room reimplementations of the upstream helpers (differentially tested against the AGPL oracle), so the step reuses them rather than deriving the behaviour a second time.

## Tests

Red was proven for both rules by disabling them in turn, not assumed:

- With the error stamping neutered → `TestUnpack_NonJSONStampsParserError` and `TestUnpack_MalformedObjectStampsParserError` fail (`__error__ = "", want JSONParserErr`).
- With the `isPacked` gate removed → `TestUnpack_NoPackedEntryExtractsNothing` fails.

`TestUnpack_NonJSONLeavesLineAlone` is **replaced**, not amended — it asserted the bug was intended behaviour. New coverage: the four non-object shapes with a byte-compared details string, the empty-line non-error, the malformed-object path including the discard of partially-collected labels, the `_entry` gate, and key sanitisation. The whole `internal/api/loki` package is green at 341 tests, and `test/spec/logql` at 177 — the six existing `unpack*.txtar` fixtures are unaffected because the stage emits no SQL.

## Not in scope

Follow-up tracked in #1611: the `compatibility/loki` corpus contains **zero** `| unpack` queries (`grep -rc unpack compatibility/loki/upstream/loki-bench/` is 0 across every query file; the one hit is the word inside the LICENSE), and the seeder emits no packed lines. That is why this bug shipped and survived — no differential test could see it. The overlay `cerberus-test-queries.yml` is annotate-only by policy, so closing the gap needs an additive query list plus seeder support.