### PR TITLE
ci(lint): analyse every build configuration, not just the default one

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,12 +230,13 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
 
-      - name: golangci-lint (Go + formatters)
+      - name: golangci-lint (tagged build configuration)
         # v7+ is required for golangci-lint v2; v6 caps at v1.
         uses: golangci/golangci-lint-action@v9
         with:
           version: v2.12.2
-          # Honours .golangci.yml; runs across the whole module.
+          # Honours .golangci.yml — including its `build-tags:` union, which is
+          # every tag in the tree. Runs across the whole module.
           args: ./...
           # Analyse cold. The action's analysis cache is a shared GitHub
           # Actions entry, and those entries are immutable: once a key holds
@@ -251,16 +252,24 @@ jobs:
           # a bad entry fails verification instead of being trusted.
           skip-cache: true
 
-      # The Tier-0 migration runner is `migration`-tagged, so neither the
-      # test job nor golangci-lint (which sets no build-tags) compiles it —
-      # a type error there would surface only on the scheduled migration
-      # lane. `go vet` with the tag type-checks the runner plus its step
-      # library on every PR: seconds, no Docker, no binary build.
-      - name: vet the migration harness (tagged runner)
-        run: go vet -tags=migration ./test/e2e/migration/...
+      # The union above excludes the files constrained the other way — the
+      # `!chdb` and `!chaos_sleep` stubs — so they get the plain build
+      # configuration here. `--build-tags` replaces the config's value rather
+      # than adding to it, and `cerberus_untagged_build` is a tag no file in
+      # the tree constrains on, so this pass sees the default build.
+      # test/regression/lint_build_tags_test.go holds the two passes, the tag
+      # union and the inert tag to what the tree's `//go:build` lines say.
+      - name: golangci-lint (untagged build configuration)
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.12.2
+          args: --build-tags cerberus_untagged_build ./...
+          skip-cache: true
 
-      # Vetting proves the runner compiles; it proves nothing about whether
-      # the committed explain goldens still describe what the emitter emits.
+      # The tagged lint pass above type-checks the `migration`-tagged Tier-0
+      # runner, which is what the `go vet -tags=migration` step that used to
+      # stand here did. Compiling it proves nothing about whether the committed
+      # explain goldens still describe what the emitter emits.
       # Those goldens are the migration lane's only assertion over generated
       # SQL, and the lane has no `pull_request:` trigger — so a change to a
       # query shape merged green and turned `main` red on the next push,

--- a/.gitignore
+++ b/.gitignore
@@ -38,10 +38,8 @@ dist/
 # route-rules CLI build output (never commit the compiled binary)
 /route-rules
 /cmd/route-rules/route-rules
-# perf-profile CLI build output + the JSON report `just perf-profile` writes
-# (`go build ./cmd/perf-profile` drops the compiled binary at the repo root
-# under the bare package name, with no extension to give it away).
-/perf-profile
+# The JSON report `just perf-profile` writes (the CLI's own binary is covered
+# by the cmd/ build-output block below).
 /perf-profile.json
 # Generated release-PR body — `just prepare-release` / prepare-release.yml
 # write it next to the checkout and feed it straight to `gh pr create`.
@@ -89,4 +87,11 @@ test/e2e/playwright/playwright-report/
 # Tier-1 migration substrate: the seeder's manifest is a per-run artifact
 # (its window rolls with wall-clock time), not a committed fixture.
 /test/e2e/migration/.out/
+
+# `go build ./cmd/<x>` drops its output at the repo root under the package's
+# own name, so every cmd/ package gets an entry here — the `forbid-skip` gate
+# rejects a tracked binary, and the point is that a stray local build cannot
+# reach a commit in the first place.
+/bench-report
 /cerberus
+/perf-profile

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,6 +51,34 @@ version: "2"
 run:
   timeout: 5m
 
+  # golangci-lint analyses ONE build configuration per invocation, so a run
+  # that sets no tags cannot see a single tagged file — 120 `chdb` files (the
+  # round-trip execution layer, the property harness's chDB driver, the seeded
+  # fixture paths), the `agpl_oracle` differentials, the `integration` and
+  # `e2e` suites, the migration tiers. `./...` still reports green over what is
+  # left, and that green reads as "the tree is clean" when it means "the
+  # default build is clean". This list is the union of every build tag in the
+  # tree.
+  #
+  # One configuration is not enough on its own: five files are constrained the
+  # other way (`!chdb`, `!chaos_sleep` stubs), and this configuration excludes
+  # exactly those. The `lint` recipe therefore runs a second, untagged pass.
+  # Every `//go:build` line in the tree is a single term, positive or negated,
+  # so those two passes between them analyse every file —
+  # test/regression/lint_build_tags_test.go proves both halves of that claim
+  # from the tree's own constraints rather than trusting this comment.
+  build-tags:
+    - agpl_oracle
+    - chaos_sleep
+    - chdb
+    - e2e
+    - integration
+    - migration
+    - migration_tier1
+    - migration_tier2
+    - remote_correctness
+    - startup_bench
+
 linters:
   default: none
   enable:

--- a/Justfile
+++ b/Justfile
@@ -11,6 +11,14 @@ MARKDOWNLINT_VERSION := "v0.18.1"
 ACTIONLINT_VERSION := "v1.7.12"
 MODULE := "github.com/tsouza/cerberus"
 
+# The build tag the untagged lint pass runs under. `.golangci.yml` declares the
+# union of every tag in the tree, and golangci-lint's flag REPLACES that value
+# rather than adding to it — so naming a tag no file constrains on is how the
+# second pass gets the plain build configuration, the one that owns the `!chdb`
+# and `!chaos_sleep` stubs the union excludes.
+# test/regression/lint_build_tags_test.go asserts it stays inert.
+LINT_UNTAGGED_BUILD := "cerberus_untagged_build"
+
 # Per-checkout compose project suffix, exported into every recipe so no compose
 # call site has to remember it: each docker-compose file spells its project name
 # `<stable-base>${COMPOSE_PROJECT_SUFFIX:-}`, and a compose invocation from a
@@ -541,9 +549,16 @@ mutate-chdb:
 
 # === Lint / format ===
 
-# Run Go linters.
+# Run Go linters over both build configurations.
+#
+# One invocation analyses one build configuration. The first pass takes the tag
+# union from `.golangci.yml`, which is every tagged file in the tree; the second
+# names an inert tag to clear that union, which is the `!chdb` / `!chaos_sleep`
+# stubs. Every `//go:build` line in the tree is a single term, so the two passes
+# together leave no file unanalysed.
 lint:
     golangci-lint run ./...
+    golangci-lint run --build-tags {{LINT_UNTAGGED_BUILD}} ./...
 
 # Validate GitHub Actions workflow files (expression contexts, action
 # inputs, shellcheck of run blocks). Deliberately separate from `lint`

--- a/cmd/bench-report/e2e_chdb.go
+++ b/cmd/bench-report/e2e_chdb.go
@@ -9,10 +9,10 @@ import (
 	"time"
 
 	"github.com/prometheus/prometheus/promql/parser"
-	logqlsyntax "github.com/tsouza/cerberus/internal/logql/lsyntax"
 
 	"github.com/tsouza/cerberus/internal/chsql"
 	"github.com/tsouza/cerberus/internal/logql"
+	logqlsyntax "github.com/tsouza/cerberus/internal/logql/lsyntax"
 	"github.com/tsouza/cerberus/internal/optimizer"
 	"github.com/tsouza/cerberus/internal/promql"
 	"github.com/tsouza/cerberus/internal/schema"

--- a/cmd/bench-report/hostinfo_chdb.go
+++ b/cmd/bench-report/hostinfo_chdb.go
@@ -227,19 +227,18 @@ func normalizeCacheSize(s string) string {
 	if s == "" {
 		return ""
 	}
+	const kibPerMiB = 1024
 	unit := s[len(s)-1]
-	numPart := s
+	numPart := strings.TrimSpace(s[:len(s)-1])
 	var kib int64
 	switch unit {
 	case 'K', 'k':
-		numPart = s[:len(s)-1]
-		if n, err := strconv.ParseInt(strings.TrimSpace(numPart), 10, 64); err == nil {
+		if n, err := strconv.ParseInt(numPart, 10, 64); err == nil {
 			kib = n
 		}
 	case 'M', 'm':
-		numPart = s[:len(s)-1]
-		if n, err := strconv.ParseInt(strings.TrimSpace(numPart), 10, 64); err == nil {
-			kib = n * 1024
+		if n, err := strconv.ParseInt(numPart, 10, 64); err == nil {
+			kib = n * kibPerMiB
 		}
 	default:
 		return s // unknown form — pass through untouched
@@ -247,8 +246,8 @@ func normalizeCacheSize(s string) string {
 	if kib == 0 {
 		return s
 	}
-	if kib%1024 == 0 {
-		return fmt.Sprintf("%d MiB", kib/1024)
+	if kib%kibPerMiB == 0 {
+		return fmt.Sprintf("%d MiB", kib/kibPerMiB)
 	}
 	return fmt.Sprintf("%d KiB", kib)
 }
@@ -316,13 +315,48 @@ func splitColon(line string) (key, val string, ok bool) {
 	return strings.TrimSpace(line[:i]), strings.TrimSpace(line[i+1:]), true
 }
 
-// readTrim reads a whole small sysfs/proc file and trims trailing newline.
+// pseudoFSRoots are the only trees this reporter reads. Everything it wants
+// is host state the kernel publishes, so anything outside them is a bug in a
+// caller rather than a file worth opening.
+var pseudoFSRoots = []string{"/proc", "/sys"}
+
+// readTrim reads a whole small /proc or /sys file and trims surrounding
+// whitespace, returning "" for anything it cannot read.
+//
+// The read goes through os.Root rather than os.ReadFile so it is confined to
+// the pseudo-filesystem root the path names: the remainder is resolved inside
+// that tree, and a symlink pointing out of it fails instead of quietly
+// yielding some other file's contents. Several of the paths reaching here are
+// built from a `/sys/devices/system/cpu/…` glob, so the confinement is what
+// keeps a hostile sysfs entry from turning a cache-topology probe into a read
+// of arbitrary host state.
 func readTrim(path string) string {
-	b, err := os.ReadFile(path)
+	root, rel, ok := pseudoFSPath(path)
+	if !ok {
+		return ""
+	}
+	r, err := os.OpenRoot(root)
+	if err != nil {
+		return ""
+	}
+	defer r.Close()
+	b, err := r.ReadFile(rel)
 	if err != nil {
 		return ""
 	}
 	return strings.TrimSpace(string(b))
+}
+
+// pseudoFSPath splits an absolute path into the pseudoFSRoots entry it lives
+// under and the remainder relative to it.
+func pseudoFSPath(path string) (root, rel string, ok bool) {
+	clean := filepath.Clean(path)
+	for _, r := range pseudoFSRoots {
+		if rest, under := strings.CutPrefix(clean, r+string(filepath.Separator)); under && rest != "" {
+			return r, rest, true
+		}
+	}
+	return "", "", false
 }
 
 // readUint reads a small file expected to hold a single unsigned integer.

--- a/cmd/bench-report/matrix_chdb.go
+++ b/cmd/bench-report/matrix_chdb.go
@@ -189,52 +189,66 @@ func measureMatrixCell(ctx context.Context, s *session, iters int, st matrixStra
 	cell.Routed = routed
 
 	if routed {
-		// Route B: run every shard's re-anchored plan sequentially, sum the
-		// walls, and take the worst shard's intermediate as the per-query
-		// memory driver (each shard is capped independently).
 		cell.K = dec.K
-		var sumWall time.Duration
-		var maxPairs int64
-		for _, sl := range dec.Slices {
-			sql, err := emitMatrix(ctx, sl.Plan, tsgrid)
-			if err != nil {
-				return matrixCell{}, fmt.Errorf("emit shard %d: %w", sl.Index, err)
-			}
-			w, err := s.bestWall(sql, iters)
-			if err != nil {
-				return matrixCell{}, fmt.Errorf("exec shard %d: %w", sl.Index, err)
-			}
-			sumWall += w
-			pairs, err := matrixIntermediate(s, sl.Start, sl.End, tsgrid)
-			if err != nil {
-				return matrixCell{}, fmt.Errorf("shard %d intermediate: %w", sl.Index, err)
-			}
-			if pairs > maxPairs {
-				maxPairs = pairs
-			}
-		}
-		cell.Wall = sumWall
-		cell.PeakRows = maxPairs
+		cell.Wall, cell.PeakRows, err = measureRoutedShards(ctx, s, iters, dec, tsgrid)
 	} else {
-		// Route A / single: one statement over the whole anchor grid.
-		sql, err := emitMatrix(ctx, plan, tsgrid)
-		if err != nil {
-			return matrixCell{}, fmt.Errorf("emit route A: %w", err)
-		}
-		w, err := s.bestWall(sql, iters)
-		if err != nil {
-			return matrixCell{}, fmt.Errorf("exec route A: %w", err)
-		}
-		cell.Wall = w
-		pairs, err := matrixIntermediate(s, matrixStart, matrixEnd, tsgrid)
-		if err != nil {
-			return matrixCell{}, fmt.Errorf("route-A intermediate: %w", err)
-		}
-		cell.PeakRows = pairs
+		cell.Wall, cell.PeakRows, err = measureSingleStatement(ctx, s, iters, plan, tsgrid)
+	}
+	if err != nil {
+		return matrixCell{}, err
 	}
 
 	cell.PeakMem = modeledBytes(cell.PeakRows)
 	return cell, nil
+}
+
+// measureRoutedShards times route B: every shard's re-anchored plan runs
+// sequentially, so the walls sum, while the worst shard's intermediate is the
+// per-query memory driver — each shard is capped independently.
+func measureRoutedShards(
+	ctx context.Context, s *session, iters int, dec *solver.Decision, tsgrid bool,
+) (time.Duration, int64, error) {
+	var sumWall time.Duration
+	var maxPairs int64
+	for _, sl := range dec.Slices {
+		sql, err := emitMatrix(ctx, sl.Plan, tsgrid)
+		if err != nil {
+			return 0, 0, fmt.Errorf("emit shard %d: %w", sl.Index, err)
+		}
+		w, err := s.bestWall(sql, iters)
+		if err != nil {
+			return 0, 0, fmt.Errorf("exec shard %d: %w", sl.Index, err)
+		}
+		sumWall += w
+		pairs, err := matrixIntermediate(s, sl.Start, sl.End, tsgrid)
+		if err != nil {
+			return 0, 0, fmt.Errorf("shard %d intermediate: %w", sl.Index, err)
+		}
+		if pairs > maxPairs {
+			maxPairs = pairs
+		}
+	}
+	return sumWall, maxPairs, nil
+}
+
+// measureSingleStatement times route A: one statement over the whole anchor
+// grid.
+func measureSingleStatement(
+	ctx context.Context, s *session, iters int, plan chplan.Node, tsgrid bool,
+) (time.Duration, int64, error) {
+	sql, err := emitMatrix(ctx, plan, tsgrid)
+	if err != nil {
+		return 0, 0, fmt.Errorf("emit route A: %w", err)
+	}
+	w, err := s.bestWall(sql, iters)
+	if err != nil {
+		return 0, 0, fmt.Errorf("exec route A: %w", err)
+	}
+	pairs, err := matrixIntermediate(s, matrixStart, matrixEnd, tsgrid)
+	if err != nil {
+		return 0, 0, fmt.Errorf("route-A intermediate: %w", err)
+	}
+	return w, pairs, nil
 }
 
 // lowerMatrixPlan lowers + optimizes the focus query for the given tsgrid

--- a/internal/api/prom/handler_chdb_subquery_test.go
+++ b/internal/api/prom/handler_chdb_subquery_test.go
@@ -115,20 +115,20 @@ func TestQueryRange_SubqueryBareVector_ChDB(t *testing.T) {
 func escape(q string) string {
 	var b strings.Builder
 	for _, r := range q {
-		switch {
-		case r == ' ':
+		switch r {
+		case ' ':
 			b.WriteByte('+')
-		case r == '[':
+		case '[':
 			b.WriteString("%5B")
-		case r == ']':
+		case ']':
 			b.WriteString("%5D")
-		case r == ':':
+		case ':':
 			b.WriteString("%3A")
-		case r == '{':
+		case '{':
 			b.WriteString("%7B")
-		case r == '}':
+		case '}':
 			b.WriteString("%7D")
-		case r == '"':
+		case '"':
 			b.WriteString("%22")
 		default:
 			b.WriteRune(r)

--- a/internal/logql/lsyntax/oracle_agpl_test.go
+++ b/internal/logql/lsyntax/oracle_agpl_test.go
@@ -178,7 +178,7 @@ func normalize(v reflect.Value) string {
 		return "nil"
 	}
 	switch v.Kind() {
-	case reflect.Ptr:
+	case reflect.Pointer:
 		if v.IsNil() {
 			return "nil"
 		}
@@ -291,7 +291,7 @@ func isLeafLabelType(name string) bool {
 func leafString(i interface{}) string {
 	rv := reflect.ValueOf(i)
 	name := rv.Type().Name()
-	if rv.Kind() == reflect.Ptr && rv.Elem().Kind() == reflect.Struct {
+	if rv.Kind() == reflect.Pointer && rv.Elem().Kind() == reflect.Struct {
 		name = rv.Elem().Type().Name()
 	}
 	if name == "StringLabelFilter" || name == "LineFilterLabelFilter" {
@@ -305,7 +305,7 @@ func leafString(i interface{}) string {
 // embeddedMatcher returns the *labels.Matcher field embedded in a leaf
 // label-filter value, or nil.
 func embeddedMatcher(rv reflect.Value) *labels.Matcher {
-	if rv.Kind() == reflect.Ptr {
+	if rv.Kind() == reflect.Pointer {
 		if rv.IsNil() {
 			return nil
 		}

--- a/internal/promql/limit_ratio_chdb_test.go
+++ b/internal/promql/limit_ratio_chdb_test.go
@@ -42,9 +42,9 @@ import (
 	"time"
 
 	_ "github.com/chdb-io/chdb-go/chdb/driver"
+	prommodel "github.com/prometheus/prometheus/model/labels"
 	promparser "github.com/prometheus/prometheus/promql/parser"
 
-	prommodel "github.com/prometheus/prometheus/model/labels"
 	"github.com/tsouza/cerberus/internal/chsql"
 	"github.com/tsouza/cerberus/internal/promql"
 	"github.com/tsouza/cerberus/internal/schema"

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -54,8 +54,14 @@ pre-push:
   commands:
     golangci-lint:
       tags: lint
+      # `just lint`, not a bare `golangci-lint run ./...`: one invocation
+      # analyses one build configuration, so the bare form skipped every
+      # tagged file — the `chdb` round-trip layer, the `agpl_oracle`
+      # differentials, the migration tiers — and reported clean over what was
+      # left. The recipe runs the tagged pass and the untagged one, which is
+      # what CI's lint job runs.
       run: |
-        golangci-lint run ./...
+        just lint
     # Workflow-file validation. GitHub rejects invalid workflow files
     # SERVER-side as zero-job "invalid workflow file" failure runs,
     # which silently prevents required pull_request checks from ever

--- a/test/property/scan_resource_bound_explain_test.go
+++ b/test/property/scan_resource_bound_explain_test.go
@@ -187,7 +187,7 @@ func TestScanResourceBound_PartitionPruneEXPLAIN(t *testing.T) {
 
 	boundParts, _ := explainEstimate(t, db, narrowSQL)
 	fullParts, _ := explainEstimate(t, db, wideSQL)
-	if !(boundParts < fullParts) {
+	if boundParts >= fullParts {
 		t.Errorf("window bound must prune partitions: bounded_parts=%d full_parts=%d\nnarrow: %s",
 			boundParts, fullParts, narrowSQL)
 	}

--- a/test/regression/lint_build_tags_test.go
+++ b/test/regression/lint_build_tags_test.go
@@ -1,0 +1,295 @@
+package regression
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// golangci-lint analyses ONE build configuration per invocation. That single
+// fact is why a lint gate can report green over a tree it never read: a run
+// that sets no tags cannot see a `//go:build chdb` file, and `./...` reports
+// clean over what is left. The green then reads as "the tree is clean" when it
+// means "the default build is clean" — 120 chdb files, the agpl_oracle
+// differentials, the integration and e2e suites and the migration tiers all
+// sit outside it, along with the discipline linters that are supposed to apply
+// project-wide.
+//
+// The fix is two passes: one under the tag union in `.golangci.yml`, one under
+// the plain build configuration. That pair is TOTAL only because of a property
+// of this tree — every `//go:build` line is a single term, positive or negated
+// — so the pins below establish the property first and then hold every
+// invocation site to it. A compound constraint arriving later would slip
+// between the two passes silently, which is why it fails here rather than
+// being tolerated.
+
+const (
+	golangciConfigPath = repoRoot + "/.golangci.yml"
+	lefthookPath       = repoRoot + "/lefthook.yml"
+)
+
+// buildConstraintLine matches the `//go:build` line's constraint expression.
+// Only the FIRST such line in a file counts: the directive is only a build
+// constraint above the package clause, and a later one is a comment.
+var buildConstraintLine = regexp.MustCompile(`(?m)^//go:build (.+)$`)
+
+// singleTermConstraint matches the one constraint shape the two-pass scheme
+// covers: a lone tag, or a lone negated tag.
+var singleTermConstraint = regexp.MustCompile(`^(!?)([a-z0-9_]+)$`)
+
+// skippedDirs are directories with no Go the lint gate is responsible for.
+// `test/oracle` is a nested module with its own go.mod, exercised by its own
+// CI step; the rest hold no compilable input.
+var skippedDirs = map[string]bool{
+	".git":          true,
+	".claude":       true,
+	"node_modules":  true,
+	"test/oracle":   true,
+	"build":         true,
+	"dist":          true,
+	"bin":           true,
+	"vendor":        true,
+	"scratchpad":    true,
+	"testdata-temp": true,
+}
+
+// constraint is one file's build constraint.
+type constraint struct {
+	file    string
+	term    string
+	negated bool
+}
+
+// treeConstraints walks the root module for `//go:build` lines. Reading the
+// first line only mirrors the toolchain: a directive below the package clause
+// is not a constraint.
+func treeConstraints(t *testing.T) []constraint {
+	t.Helper()
+
+	var out []constraint
+	err := filepath.WalkDir(repoRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, relErr := filepath.Rel(repoRoot, path)
+		if relErr != nil {
+			return relErr
+		}
+		if d.IsDir() {
+			if skippedDirs[d.Name()] || skippedDirs[filepath.ToSlash(rel)] {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if filepath.Ext(path) != ".go" {
+			return nil
+		}
+		buf, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		m := buildConstraintLine.FindSubmatch(buf)
+		if m == nil {
+			return nil
+		}
+		expr := strings.TrimSpace(string(m[1]))
+		parts := singleTermConstraint.FindStringSubmatch(expr)
+		if parts == nil {
+			t.Errorf("%s carries the build constraint %q, which is not a single term. The lint gate "+
+				"runs exactly two passes — the tag union in %s, and the plain build configuration — "+
+				"and that pair covers every file only while each constraint is one tag or one negated "+
+				"tag. A compound constraint is satisfied by neither pass, so this file would be "+
+				"analysed by nothing while the gate still reported green. Split it, or add the third "+
+				"build configuration it needs to every invocation site and widen this pin.",
+				filepath.ToSlash(rel), expr, golangciConfigPath)
+			return nil
+		}
+		out = append(out, constraint{
+			file:    filepath.ToSlash(rel),
+			term:    parts[2],
+			negated: parts[1] == "!",
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", repoRoot, err)
+	}
+	if len(out) == 0 {
+		t.Fatalf("no `//go:build` line found under %s — the walk is reading the wrong tree, so every "+
+			"assertion below would pass over an empty set", repoRoot)
+	}
+	return out
+}
+
+// configuredBuildTags reads the tag union out of `.golangci.yml`.
+func configuredBuildTags(t *testing.T) []string {
+	t.Helper()
+
+	var doc struct {
+		Run struct {
+			BuildTags []string `yaml:"build-tags"`
+		} `yaml:"run"`
+	}
+	if err := yaml.Unmarshal([]byte(readFileString(t, golangciConfigPath)), &doc); err != nil {
+		t.Fatalf("parse %s: %v", golangciConfigPath, err)
+	}
+	return doc.Run.BuildTags
+}
+
+// justVariable reads a `NAME := "value"` assignment out of the Justfile.
+func justVariable(t *testing.T, name string) string {
+	t.Helper()
+
+	re := regexp.MustCompile(`(?m)^` + regexp.QuoteMeta(name) + `\s*:=\s*"([^"]*)"`)
+	m := re.FindStringSubmatch(readFileString(t, repoRoot+"/Justfile"))
+	if m == nil {
+		t.Fatalf("Justfile declares no %s variable", name)
+	}
+	return m[1]
+}
+
+// TestEveryBuildConstraintIsASingleTerm establishes the premise the two-pass
+// lint scheme rests on. treeConstraints reports a compound constraint as a
+// failure, so this names the invariant rather than letting it surface under
+// whichever other test happened to walk the tree first.
+func TestEveryBuildConstraintIsASingleTerm(t *testing.T) {
+	t.Parallel()
+
+	treeConstraints(t)
+}
+
+func TestGolangciBuildTagsCoverEveryTagInTheTree(t *testing.T) {
+	t.Parallel()
+
+	constraints := treeConstraints(t)
+
+	var inTree []string
+	for _, c := range constraints {
+		if !c.negated && !slices.Contains(inTree, c.term) {
+			inTree = append(inTree, c.term)
+		}
+	}
+	slices.Sort(inTree)
+
+	configured := configuredBuildTags(t)
+	sorted := slices.Clone(configured)
+	slices.Sort(sorted)
+	if !slices.Equal(configured, sorted) {
+		t.Errorf("%s lists build-tags out of order: %v. Keep it sorted so an addition is a one-line "+
+			"diff rather than a re-read of the whole list.", golangciConfigPath, configured)
+	}
+
+	for _, tag := range inTree {
+		if !slices.Contains(configured, tag) {
+			var files []string
+			for _, c := range constraints {
+				if c.term == tag && !c.negated {
+					files = append(files, c.file)
+				}
+			}
+			t.Errorf("build tag %q constrains %d file(s) — e.g. %s — and is absent from %s's "+
+				"`run.build-tags`. golangci-lint analyses one build configuration, so those files are "+
+				"invisible to every linter while `./...` still reports green over the rest.",
+				tag, len(files), files[0], golangciConfigPath)
+		}
+	}
+
+	for _, tag := range configured {
+		if !slices.Contains(inTree, tag) {
+			t.Errorf("%s declares build tag %q, which constrains no file in the tree. A stale tag is "+
+				"not harmless: it is the residue of code that moved or went away, and it makes the "+
+				"list stop being a readable statement of what the gate analyses. Delete it.",
+				golangciConfigPath, tag)
+		}
+	}
+}
+
+func TestUntaggedLintPassRunsUnderAnInertTag(t *testing.T) {
+	t.Parallel()
+
+	inert := justVariable(t, "LINT_UNTAGGED_BUILD")
+
+	for _, c := range treeConstraints(t) {
+		if c.term == inert {
+			t.Errorf("%s constrains on %q, the tag the untagged lint pass uses to CLEAR the union in "+
+				"%s. A file that reacts to it makes that pass a third build configuration rather than "+
+				"the plain one, so the `!chdb` / `!chaos_sleep` stubs it exists to cover stop being "+
+				"covered. Rename the variable, or drop the constraint.",
+				c.file, inert, golangciConfigPath)
+		}
+	}
+
+	if slices.Contains(configuredBuildTags(t), inert) {
+		t.Errorf("%s lists %q in `run.build-tags`. That is the tag the second pass passes in order to "+
+			"replace the union — listing it here makes the two passes the same build configuration, "+
+			"and the negated-constraint stubs go unanalysed by both.", golangciConfigPath, inert)
+	}
+
+	if ci := readFileString(t, ciWorkflowPath); !strings.Contains(ci, "--build-tags "+inert) {
+		t.Errorf("%s never passes `--build-tags %s`. The Justfile and the workflow have to name the "+
+			"same inert tag, or CI's second pass runs a build configuration nobody pinned.",
+			ciWorkflowPath, inert)
+	}
+}
+
+// golangciRunLine matches an invocation of the linter in a recipe or hook.
+var golangciRunLine = regexp.MustCompile(`(?m)^\s*golangci-lint run (.+)$`)
+
+func TestEveryLintSiteRunsBothBuildConfigurations(t *testing.T) {
+	t.Parallel()
+
+	inert := justVariable(t, "LINT_UNTAGGED_BUILD")
+
+	// The `lint` recipe is the definition of "run the lint gate", so it is the
+	// one site that has to spell both passes out.
+	recipe := justRecipeBody(t, readFileString(t, repoRoot+"/Justfile"), "lint")
+	runs := golangciRunLine.FindAllStringSubmatch(recipe, -1)
+	if len(runs) != 2 {
+		t.Fatalf("the Justfile `lint` recipe invokes golangci-lint %d time(s); it needs exactly two — "+
+			"one under the tag union in %s, one under the plain build configuration. Recipe:\n%s",
+			len(runs), golangciConfigPath, recipe)
+	}
+	tagged, untagged := strings.TrimSpace(runs[0][1]), strings.TrimSpace(runs[1][1])
+	if strings.Contains(tagged, "--build-tags") {
+		t.Errorf("the Justfile `lint` recipe's first pass overrides the tag union with %q. The union "+
+			"lives in %s so there is one place to read it; a flag here silently shadows it.",
+			tagged, golangciConfigPath)
+	}
+	if !strings.Contains(untagged, "--build-tags {{LINT_UNTAGGED_BUILD}}") {
+		t.Errorf("the Justfile `lint` recipe's second pass is %q, which does not clear the tag union "+
+			"with `--build-tags {{LINT_UNTAGGED_BUILD}}`. Both passes then analyse the same build "+
+			"configuration and the negated-constraint stubs are analysed by neither.", untagged)
+	}
+
+	// CI runs the linter through the official action rather than the recipe, so
+	// its two steps are pinned against the same pair.
+	ci := readFileString(t, ciWorkflowPath)
+	if got := strings.Count(ci, "golangci/golangci-lint-action@"); got != 2 {
+		t.Errorf("%s uses golangci-lint-action %d time(s); the gate is two build configurations, so "+
+			"it needs two steps. One step means CI lints a subset of what `just lint` does and the "+
+			"required check disagrees with the hook.", ciWorkflowPath, got)
+	}
+	if !strings.Contains(ci, "args: ./...") {
+		t.Errorf("%s has no golangci-lint step running bare `args: ./...` — the pass that takes the "+
+			"tag union from %s.", ciWorkflowPath, golangciConfigPath)
+	}
+	if !strings.Contains(ci, "args: --build-tags "+inert+" ./...") {
+		t.Errorf("%s has no golangci-lint step running `args: --build-tags %s ./...` — the pass that "+
+			"covers the negated-constraint stubs.", ciWorkflowPath, inert)
+	}
+
+	// pre-push exists to fail locally whatever CI would fail. Delegating to the
+	// recipe is what keeps it from drifting back to a single pass.
+	hook := readFileString(t, lefthookPath)
+	if !strings.Contains(hook, "just lint") {
+		t.Errorf("%s does not run `just lint`. A bare `golangci-lint run ./...` there analyses one "+
+			"build configuration, so a push passes the hook and fails the required check on exactly "+
+			"the tagged files the hook could not see.", lefthookPath)
+	}
+}

--- a/test/spec/eval_instant_sweep.go
+++ b/test/spec/eval_instant_sweep.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	"github.com/prometheus/prometheus/promql/parser"
+
 	"github.com/tsouza/cerberus/internal/chsql"
 	"github.com/tsouza/cerberus/internal/promql"
 	"github.com/tsouza/cerberus/internal/schema"


### PR DESCRIPTION
## The hole

`golangci-lint` analyses **one** build configuration per invocation. Every lint site in this repo — the `lint` CI job, the `lefthook` pre-push hook, `just lint` — ran it with no build tags. That invocation cannot see a single `//go:build`-constrained file:

| tag | files |
| --- | ---: |
| `chdb` | 120 |
| `integration` | 16 |
| `e2e` | 8 |
| `agpl_oracle` | 5 |
| `chaos_sleep` | 4 |
| `migration_tier1` | 3 |
| `migration`, `migration_tier2` | 2 each |
| `remote_correctness`, `startup_bench` | 1 each |

`./...` still reported green over what was left, and that green read as *"the tree is clean"* when it meant *"the default build is clean"*. The round-trip execution layer, the property harness's chDB driver, the seeded fixture paths, the AGPL differentials, both migration tiers and the whole e2e suite were outside it — including `forbidigo`'s project-wide `unsafe.Pointer` / `reflect.FieldByName` ban, which the config exists to apply to all of `internal/**`.

## The fix

`.golangci.yml` now declares the union of every build tag in the tree, and the `lint` recipe runs a **second** pass under an inert tag. `--build-tags` *replaces* the config's value rather than adding to it, so naming a tag no file constrains on is how that pass gets the plain build configuration — the one that owns the `!chdb` and `!chaos_sleep` stubs the union excludes. CI's `lint` job runs the same pair as two `golangci-lint-action` steps.

`lefthook.yml`'s pre-push now delegates to `just lint` instead of carrying its own single-pass invocation, so the hook and the required check agree on what they analysed rather than the hook passing on a strictly smaller set.

The `go vet -tags=migration` step is removed: the tagged lint pass type-checks that runner, which is all the vet step proved.

## Why two passes are enough

The pair is total only because of a property of this tree: **every `//go:build` line is a single term**, positive or negated. A compound constraint (`chdb && !e2e`) would be satisfied by neither pass and would go unanalysed behind a green check.

`test/regression/lint_build_tags_test.go` does not assume that — it establishes it from the tree's own constraint lines and then holds everything to it:

- `TestEveryBuildConstraintIsASingleTerm` — walks the module and fails on any compound constraint, naming the file and telling the reader what to do about it.
- `TestGolangciBuildTagsCoverEveryTagInTheTree` — the union equals the set of positive tags in the tree, in both directions (a missing tag is a blind spot; a stale one is residue), and stays sorted.
- `TestUntaggedLintPassRunsUnderAnInertTag` — the sentinel constrains no file, is absent from the union, and is the same token the workflow passes.
- `TestEveryLintSiteRunsBothBuildConfigurations` — the recipe runs exactly two passes with the right flags, CI runs two action steps, and pre-push goes through the recipe.

## What the tagged pass found

11 real issues in files nothing had ever linted. None is a regression — they are what the single build configuration was hiding. Fixed in the second commit:

- **gosec G304** — `readTrim` in the host reporter read arbitrary paths through `os.ReadFile`, while several callers build the path from a `/sys/devices/system/cpu/…` glob. It now reads through `os.Root`, confined to the `/proc` or `/sys` tree the path names, so a sysfs symlink pointing out of that tree fails instead of quietly yielding some other file's contents.
- **ineffassign** — `normalizeCacheSize` seeded `numPart` with a value both live branches overwrote and the third never read. The trim is hoisted; the repeated `1024` becomes `kibPerMiB`.
- **nestif** — `measureMatrixCell` carried both route arms inline; they split into `measureRoutedShards` / `measureSingleStatement`.
- **govet** — `reflect.Ptr` → `reflect.Pointer` (×3) in the LogQL oracle differential.
- **staticcheck** — a seven-arm `switch { case r == 'x': }` becomes `switch r` (QF1002); `!(a < b)` becomes `a >= b` (QF1001).
- **goimports** — three files grouped their imports against the configured local prefix.

Both passes now report zero issues.

## Scope

This ships #1507 only. #1520 (tag the LogQL surface-parity and oracle files) stays open: tagging `test/surface-parity/logql.go` breaks `package surfaceparity` — seven sibling files use its symbols — and tagging `test/property/oracle/logql` would move the LogQL oracle behind a tag no lane sets, hollowing out a leg of the required `property (PromQL + LogQL + TraceQL, rapid N=500)` check. #1610 is the prerequisite: no lane passes `-tags agpl_oracle` today, so five root-module test files are compiled by nothing. Doing build-tag totality first satisfies #1520's own ordering constraint — once this lands, that tagging cannot silently shrink lint coverage.

Closes #1507