### PR TITLE
ci(lefthook): mirror repo-hygiene gate into pre-push

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,8 +2,9 @@
 #
 #   pre-commit — fast formatters on staged files only (sub-second).
 #   pre-push   — heavier static checks (golangci-lint, markdown verify,
-#                forbid-skip discipline grep) that mirror what the
-#                `check` + `lint` + `forbid-skip` CI gates would run.
+#                forbid-skip discipline grep, repo-hygiene) that mirror
+#                what the `check` + `lint` + `forbid-skip` + `forbid-skip`
+#                (binary/root-allowlist) CI gates would run.
 #                Lives on push, not commit, so the inner-loop stays
 #                fast — one ~70s wait per push instead of per commit.
 #
@@ -45,8 +46,8 @@ pre-commit:
       run: |
         markdownlint-cli2 --fix {staged_files}
 
-# pre-push runs once per `git push`. The three commands mirror the
-# CI gates (check / lint / forbid-skip) so a push that would have
+# pre-push runs once per `git push`. The commands mirror the CI gates
+# (check / lint / forbid-skip / repo-hygiene) so a push that would have
 # failed CI fails locally first instead of round-tripping through
 # the runner. Set `LEFTHOOK=0` to bypass for WIP pushes.
 pre-push:
@@ -198,6 +199,27 @@ pre-push:
           echo "lefthook: non-empty should_skip overlay entry — consumer code was removed; fix the underlying bug"
           exit 1
         fi
+
+    # Mirrors the CI `repo-hygiene` gate's two checks:
+    #   - binary:         rejects committed ELF/Mach-O/PE executables and
+    #                     other binary artefacts tracked in git
+    #   - root-allowlist: rejects stray files at the repo root that don't
+    #                     appear in the allowlist
+    # Both are fast (pure-JS, no network, no Go compile) and have caught
+    # real pushes (bench-report committed in PR #1613). The self-test
+    # that validates the detector logic is CI-only (it needs the git
+    # history to fabricate fake tracked blobs); the two functional scans
+    # run cleanly on a working tree.
+    repo-hygiene-binary:
+      tags: discipline
+      run: node .github/scripts/repo-hygiene.mjs
+      env:
+        CHECK: binary
+    repo-hygiene-root-allowlist:
+      tags: discipline
+      run: node .github/scripts/repo-hygiene.mjs
+      env:
+        CHECK: root-allowlist
 
 commit-msg:
   commands:


### PR DESCRIPTION
Closes #1536.

The blocker from the original deferral (`#1348` / `mpd_check_main.go` at the repo root) has been gone since that PR merged. Mirror the two repo-hygiene checks that are already required in CI:

- **`repo-hygiene-binary`** — rejects committed ELF/Mach-O/PE blobs (`CHECK=binary`)
- **`repo-hygiene-root-allowlist`** — rejects stray root-level files (`CHECK=root-allowlist`)

Both run `node .github/scripts/repo-hygiene.mjs` (pure JS, sub-second) so the push latency cost is negligible. The self-test step that exercises the detector logic itself is CI-only (needs git history to stage fake blobs); the two functional scans work cleanly on a working tree.

The PR #1613 incident (bench-report committed, caught only after push) is the exact failure mode this gate prevents locally.

## Changes

- `lefthook.yml`: add `repo-hygiene-binary` + `repo-hygiene-root-allowlist` commands to `pre-push`; update header comments to reflect the wider mirror scope