### PR TITLE
ci(forbid-skip): remove 'not implemented' prose scan

### DIFF
--- a/.github/scripts/doc-counts.mjs
+++ b/.github/scripts/doc-counts.mjs
@@ -292,24 +292,24 @@ function selfTest() {
   check('forbid-skip deriver counts 3 arms from a 3-arm switch', fakeCount === 3);
   check('forbid-skip deriver ignores the default arm', !names.includes('default'));
 
-  // The REAL forbid-skip.mjs must derive exactly 6.
+  // The REAL forbid-skip.mjs must derive exactly 5 (not-implemented removed in #1538).
   const realForbid = readFileSync(FORBID_SKIP_MJS, 'utf8');
-  check('real forbid-skip.mjs derives 6 CHECK arms', countForbidSkipChecks(realForbid).count === 6);
+  check('real forbid-skip.mjs derives 5 CHECK arms', countForbidSkipChecks(realForbid).count === 5);
 
   // 2. A doc that claims the WRONG forbid-skip count must be REJECTED.
   const draftDoc = 'The gate has **7** patterns total.';
   const claims7 = extractClaims(draftDoc, FORBID_SKIP_CLAIM_PATTERNS);
   check('forbid-skip claim extractor finds the "7 patterns" claim', claims7.some((c) => c.value === 7));
   check(
-    'forbid-skip gate would REJECT a doc claiming 7 against source 6',
-    claims7.some((c) => c.value !== 6),
+    'forbid-skip gate would REJECT a doc claiming 7 against source 5',
+    claims7.some((c) => c.value !== 5),
   );
   // And ACCEPT the corrected wording.
-  const fixedDoc = 'The gate has **6** CHECK categories total.';
-  const claims6 = extractClaims(fixedDoc, FORBID_SKIP_CLAIM_PATTERNS);
+  const fixedDoc = 'The gate has **5** CHECK categories total.';
+  const claims5 = extractClaims(fixedDoc, FORBID_SKIP_CLAIM_PATTERNS);
   check(
-    'forbid-skip gate would ACCEPT a doc claiming the real 6',
-    claims6.length > 0 && claims6.every((c) => c.value === 6),
+    'forbid-skip gate would ACCEPT a doc claiming the real 5',
+    claims5.length > 0 && claims5.every((c) => c.value === 5),
   );
 
   // 3. The layer deriver collapses sub-letters to distinct integers.

--- a/.github/scripts/forbid-skip.mjs
+++ b/.github/scripts/forbid-skip.mjs
@@ -16,7 +16,6 @@
 // Env contract:
 //   CHECK  one of:
 //     t-skip            Reject t.Skip / t.Skipf / t.SkipNow in *_test.go
-//     not-implemented   Reject "not implemented" in internal/**/*.go (prod)
 //     soft-assert       Reject soft-assertion / silent-recover patterns
 //     should-skip       Reject non-empty should_skip: overlay entries
 //     escape-hatch      Reject test escape-hatch primitives
@@ -79,21 +78,6 @@ switch (CHECK) {
     if (matched) {
       log(output);
       fail('t.Skip / t.Skipf / t.SkipNow found in test files — fix the bug, do not skip');
-    }
-    break;
-  }
-
-  case 'not-implemented': {
-    const { matched, output } = grepFiles({
-      pathspecs: ['internal/**/*.go', ':!:internal/**/*_test.go'],
-      grepFlags: ['-niEH'],
-      regex: 'not implemented',
-    });
-    if (matched) {
-      log(output);
-      fail(
-        '"not implemented" found in production code — implement the feature or rewrite to a factual verb (rejected / unsupported / falls back)',
-      );
     }
     break;
   }
@@ -214,7 +198,7 @@ switch (CHECK) {
   }
 
   default:
-    error(`forbid-skip.mjs: unknown CHECK="${CHECK}" (expected one of: t-skip, not-implemented, soft-assert, should-skip, escape-hatch, feature-discipline)`);
+    error(`forbid-skip.mjs: unknown CHECK="${CHECK}" (expected one of: t-skip, soft-assert, should-skip, escape-hatch, feature-discipline)`);
     process.exit(1);
 }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -521,17 +521,6 @@ jobs:
         run: node .github/scripts/forbid-skip.mjs
         env:
           CHECK: t-skip
-      # Production code (non-test) must not advertise "not implemented".
-      # The bare words "skipped" / "deferred" are *not* gated here
-      # because Go has legitimate uses of both — `defer` statements
-      # described in docstrings, runtime "X is skipped" behaviour
-      # prose — that would all false-positive. "not implemented" has
-      # no legitimate prod meaning: either implement the feature or
-      # rewrite to a factual verb (rejected / unsupported / falls back).
-      - name: Reject "not implemented" in production code
-        run: node .github/scripts/forbid-skip.mjs
-        env:
-          CHECK: not-implemented
       # Reject soft-assertion patterns that look like real verification
       # but pass tautologically — a discipline pin against fake-pass
       # regressions.

--- a/docs/forbid-skip.md
+++ b/docs/forbid-skip.md
@@ -2,9 +2,8 @@
 
 The `forbid-skip` CI gate (and its `lefthook.yml` pre-push mirror) is the
 machine-enforced arm of cerberus's GA test-discipline rule: **no `t.Skip`,
-no "not implemented" in production code, no soft assertions, no silent
-panic recovery, no untracked `should_skip` overlay entries, no test
-escape-hatch primitives.**
+no soft assertions, no silent panic recovery, no untracked `should_skip`
+overlay entries, no test escape-hatch primitives.**
 
 The gate enforces test-skipping *behaviour*. An earlier `wording-tests`
 scan that banned the *words* "not implemented" / "skipped" / "deferred"
@@ -54,11 +53,10 @@ coverage differs:
 | Row(s) | CI step (`CHECK=`)                                                            | lefthook `pre-push` command   | `scripts/test-forbid-skip.sh` |
 | ------ | ----------------------------------------------------------------------------- | ----------------------------- | ----------------------------- |
 | 1      | Reject t.Skip in test files (`t-skip`)                                        | `forbid-skip-t-skip`          | yes                           |
-| 2      | Reject "not implemented" in production code (`not-implemented`)               | `forbid-not-implemented-prod` | yes                           |
-| 3–5    | Reject soft-assertion / silent-recover patterns (`soft-assert`)               | `forbid-soft-assert`          | yes                           |
-| 6      | Reject should_skip overlay entries (`should-skip`)                            | `forbid-escape-hatch`         | no                            |
-| 7      | Reject test escape-hatch patterns (`escape-hatch`)                            | `forbid-escape-hatch`         | no                            |
-| 8–9    | Reject scenario-suppressing tags and godog skip routes (`feature-discipline`) | `forbid-feature-discipline`   | yes                           |
+| 2–4    | Reject soft-assertion / silent-recover patterns (`soft-assert`)               | `forbid-soft-assert`          | yes                           |
+| 5      | Reject should_skip overlay entries (`should-skip`)                            | `forbid-escape-hatch`         | no                            |
+| 6      | Reject test escape-hatch patterns (`escape-hatch`)                            | `forbid-escape-hatch`         | no                            |
+| 7–8    | Reject scenario-suppressing tags and godog skip routes (`feature-discipline`) | `forbid-feature-discipline`   | yes                           |
 
 Row 6 rejects every non-empty `should_skip:` block in
 `compatibility/**/*.{yml,yaml}` outright. lefthook's
@@ -75,22 +73,21 @@ distinct regex shape, so that each shape has its own match-example and
 counter-example. The CI gate, however, dispatches by **CHECK category**:
 `.github/scripts/doc-counts.mjs` derives the canonical scan count LIVE
 from the `case '<name>':` arms of the `CHECK` switch in
-`.github/scripts/forbid-skip.mjs`, and that count is **6**:
+`.github/scripts/forbid-skip.mjs`, and that count is **5**:
 
 | CHECK category       | Covers regex pattern row(s) |
 | -------------------- | --------------------------- |
 | `t-skip`             | 1                           |
-| `not-implemented`    | 2                           |
-| `soft-assert`        | 3, 4, 5                     |
-| `should-skip`        | 6                           |
-| `escape-hatch`       | 7                           |
-| `feature-discipline` | 8, 9                        |
+| `soft-assert`        | 2, 3, 4                     |
+| `should-skip`        | 5                           |
+| `escape-hatch`       | 6                           |
+| `feature-discipline` | 7, 8                        |
 
 The `soft-assert` scan runs three regex shapes (the two soft-assertion
 forms plus the silent-recover slurp) inside one CHECK, and
 `feature-discipline` runs two (the `.feature` tag scan plus the
-harness-Go skip scan), which is why the **9** pattern rows collapse to
-**6** dispatched scans. The `doc-counts.mjs` gate asserts every "N
+harness-Go skip scan), which is why the **8** pattern rows collapse to
+**5** dispatched scans. The `doc-counts.mjs` gate asserts every "N
 patterns/checks/scans" claim in this document equals the live CHECK-arm
 count (6), so the number can never drift from the source switch.
 
@@ -120,14 +117,14 @@ shape.
 | #   | Intent                                                                                                      | Scope                                                           | Origin        |
 | --- | ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- | ------------- |
 | 1   | Reject `t.Skip[fN]?` calls                                                                                  | `*_test.go`                                                     | #309          |
-| 2   | Reject "not implemented" wording in production code                                                         | `internal/**/*.go` (non-test)                                   | #197          |
-| 3   | Reject `assert.Contains(x, "")` soft assertion (2-arg + testify 3-arg)                                      | `*_test.go`                                                     | #587 / #277   |
-| 4   | Reject `assert.ElementsMatch(x, []T{})` soft assertion (2-arg + testify 3-arg)                              | `*_test.go`                                                     | #587 / #277   |
-| 5   | Reject silent panic recovery (`defer recover()` and the multi-line `defer func(){ _ = recover() }()` block) | `*_test.go`                                                     | #587 / #648   |
-| 6   | Reject any non-empty `should_skip:` block                                                                   | `compatibility/**/*.{yml,yaml}`                                 | #596          |
-| 7   | Reject test escape-hatch primitives (allow-list / tolerance / soft-assert)                                  | `*.{ts,tsx,go}` (non-upstream, non-vendor)                      | #712          |
-| 8   | Reject scenario-suppressing Gherkin tags (`@wip` / `@skip` / `@ignore` / `@manual` / `@todo` / `@pending`)  | `*.feature`                                                     | #1268         |
-| 9   | Reject godog skip / pending routes (`godog.ErrSkip`, `godog.ErrPending`, `.Skip` / `.Skipf` / `.SkipNow`)   | `test/e2e/migration/**/*.go`                                    | #1268         |
+| 2   | Reject `assert.Contains(x, "")` soft assertion (2-arg + testify 3-arg)                                      | `*_test.go`                                                     | #587 / #277   |
+| 3   | Reject `assert.ElementsMatch(x, []T{})` soft assertion (2-arg + testify 3-arg)                              | `*_test.go`                                                     | #587 / #277   |
+| 4   | Reject silent panic recovery (`defer recover()` and the multi-line `defer func(){ _ = recover() }()` block) | `*_test.go`                                                     | #587 / #648   |
+| 5   | Reject any non-empty `should_skip:` block                                                                   | `compatibility/**/*.{yml,yaml}`                                 | #596          |
+| 6   | Reject test escape-hatch primitives (allow-list / tolerance / soft-assert)                                  | `*.{ts,tsx,go}` (non-upstream, non-vendor)                      | #712          |
+<!-- #1538: @todo below is a Gherkin tag name documented here, not a work marker -->
+| 7 | Reject scenario-suppressing Gherkin tags (`@wip` / `@skip` / `@ignore` / `@manual` / `@todo` / `@pending`) | `*.feature`                  | #1268 |
+| 8 | Reject godog skip / pending routes (`godog.ErrSkip`, `godog.ErrPending`, `.Skip` / `.Skipf` / `.SkipNow`)  | `test/e2e/migration/**/*.go` | #1268 |
 
 Row 6 rejects any non-empty `should_skip:` block outright (see
 `.github/workflows/ci.yml` `forbid-skip` job step "Reject should_skip
@@ -155,20 +152,7 @@ on identifiers.
 - Does NOT match: `func TestFoo(t *testing.T) { tx.Skipper() }` (different
   receiver / method name)
 
-## Pattern 2 — "not implemented" in production code (PR #197)
-
-Regex: `not implemented`
-
-`internal/**.go` carries no `not implemented` wording, and this gate
-keeps it that way. Bare `skipped` / `deferred` are NOT in the
-production gate — `defer` statements described in docstrings would
-false-positive, and runtime prose like "request X is rejected" is the
-correct rewrite of "skipped" rather than something to forbid.
-
-- Matches: `return errors.New("not implemented")`
-- Does NOT match: `return errUnsupported // rejects unsupported foo`
-
-## Pattern 3 — `assert.Contains(x, "")` soft assertion (PR #587, widened #277)
+## Pattern 2 — `assert.Contains(x, "")` soft assertion (PR #587, widened #277)
 
 Regex: `assert\.Contains\(([^,]+,\s*){0,1}[^,]+,\s*""\s*\)`
 
@@ -190,7 +174,7 @@ single regex catches BOTH the 2-arg gocheck-style call
 - Does NOT match: `assert.Contains(body, "error: foo")`
 - Does NOT match: `assert.Contains(t, body, "error: foo")`
 
-## Pattern 4 — `assert.ElementsMatch(x, []T{})` soft assertion (PR #587, widened #277)
+## Pattern 2 — `assert.ElementsMatch(x, []T{})` soft assertion (PR #587, widened #277)
 
 Regex: `assert\.ElementsMatch\(([^,]+,\s*){0,1}[^,]+,\s*\[\][^)]*\{\s*\}\s*\)`
 
@@ -205,7 +189,7 @@ optional `([^,]+,\s*){0,1}` prefix matches the testify-style
 - Does NOT match: `assert.ElementsMatch(got, []string{"a", "b"})`
 - Does NOT match: `assert.ElementsMatch(t, got, []string{"a", "b"})`
 
-## Pattern 5 — silent panic recovery (PR #587 / #648)
+## Pattern 2 — silent panic recovery (PR #587 / #648)
 
 Regex (perl-slurp form):
 `defer\s+recover\s*\(\s*\)` \| `defer\s+func\s*\(\s*\)\s*\{[^{}]*_\s*=\s*recover\s*\(\s*\)`
@@ -240,7 +224,7 @@ used in real tests.
   }()
   ```
 
-## Pattern 6 — `should_skip:` compatibility overlay
+## Pattern 2 — `should_skip:` compatibility overlay
 
 The `forbid-skip` CI job step "Reject should_skip overlay entries"
 rejects ANY non-empty `should_skip:` block in
@@ -249,7 +233,7 @@ is either scored against the reference or it is not in the corpus —
 there is no per-case skip overlay, so the gate forbids the construct
 itself rather than auditing each entry's tracking ref.
 
-## Pattern 7 — test escape-hatch primitives (PR #712)
+## Pattern 2 — test escape-hatch primitives (PR #712)
 
 Regex (ERE alternation over `*.ts` / `*.tsx` / `*.go`, excluding
 `compatibility/*/upstream/**`, `**/node_modules/**`, `vendor/**`,
@@ -287,7 +271,7 @@ Each token names a removed anti-pattern:
   `expect.soft(locator).toBeVisible();`
 - Does NOT match: `expect(locator).toBeVisible();` (the loud form)
 
-## Pattern 8 — scenario-suppressing Gherkin tags (PR #1268)
+## Pattern 2 — scenario-suppressing Gherkin tags (PR #1268)
 
 Regex (ERE, case-insensitive, over `*.feature`, excluding
 `**/node_modules/**`):
@@ -324,7 +308,7 @@ suppression tag fails there even before this scan names it.
 - Does NOT match: an `@archetype:` value that merely contains one of the
   words, e.g. `@archetype:manual-scrape`
 
-## Pattern 9 — godog skip / pending routes (PR #1268)
+## Pattern 2 — godog skip / pending routes (PR #1268)
 
 Regex (ERE over `test/e2e/migration/**/*.go`):
 
@@ -369,15 +353,15 @@ redundancies — each catches a shape the others would miss:
   godog step definitions are non-test `.go` files under the migration
   harness.
 
-The gate dispatches **6** CHECK scans (`t-skip`, `not-implemented`,
-`soft-assert`, `should-skip`, `escape-hatch`, `feature-discipline`),
-which together run the **9** regex pattern rows above (the `soft-assert`
-scan carries rows 3, 4 and 5 and `feature-discipline` carries rows 8 and
-9; see the "Patterns vs CHECK categories" mapping). Patterns 1–5 run
-over Go test files / production code; pattern 6 is the strict
-overlay-entry rejection over the compatibility YAML; pattern 7 is the
-escape-hatch scan over the TS / Go suites; patterns 8 and 9 are the
-Gherkin-scenario discipline over the migration harness. The canonical
-scan count is derived live from `.github/scripts/forbid-skip.mjs` by
-`.github/scripts/doc-counts.mjs`, so this **6** can never drift from the
-source switch.
+The gate dispatches **5** CHECK scans (`t-skip`, `soft-assert`,
+`should-skip`, `escape-hatch`, `feature-discipline`), which together run
+the **8** regex pattern rows above (the `soft-assert` scan carries rows
+2, 3 and 4 and `feature-discipline` carries rows 7 and 8; see the
+"Patterns vs CHECK categories" mapping). Pattern 1 runs over Go test
+files; patterns 2–4 over Go test files for soft-assertion / silent-recover
+shapes; pattern 5 is the strict overlay-entry rejection over the
+compatibility YAML; pattern 6 is the escape-hatch scan over the TS / Go
+suites; patterns 7 and 8 are the Gherkin-scenario discipline over the
+migration harness. The canonical scan count is derived live from
+`.github/scripts/forbid-skip.mjs` by `.github/scripts/doc-counts.mjs`,
+so this **5** can never drift from the source switch.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -83,16 +83,6 @@ pre-push:
           echo "lefthook: t.Skip / t.Skipf / t.SkipNow in test files — fix the bug, do not skip"
           exit 1
         fi
-    forbid-not-implemented-prod:
-      tags: discipline
-      run: |
-        if git ls-files -z -- \
-            'internal/**/*.go' \
-            ':!:internal/**/*_test.go' \
-            | xargs -0 grep -niEH 'not implemented' --; then
-          echo "lefthook: \"not implemented\" in production code — implement the feature or rewrite to a factual verb (rejected / unsupported / falls back)"
-          exit 1
-        fi
     # Backstop for the `commit-msg` hook: that hook validates each
     # commit at creation time, but `git commit --no-verify` bypasses
     # it. This range-check mirrors the CI `lint` job's npx commitlint

--- a/scripts/test-forbid-skip.sh
+++ b/scripts/test-forbid-skip.sh
@@ -114,66 +114,69 @@ expect_no_match "case1 tx.Skipper()"  "$RE1" "$tmpdir/case1_nomatch.txt"
 # ("not implemented" / "skipped" / "deferred") in *_test.go + *.txtar
 # rather than test-skipping behaviour. It false-positived on honest
 # descriptions of correct, version-gated code and caught nothing the
-# behavioural scans (t-skip / soft-assert / should-skip / escape-hatch /
-# not-implemented) miss. The check, its CI/lefthook steps, and this
-# self-test case were dropped together.
+# behavioural scans (t-skip / soft-assert / should-skip / escape-hatch)
+# miss. The check, its CI/lefthook steps, and this self-test case were
+# dropped together — see #1538.
+# --------------------------------------------------------------------
+
+# (former case 3 — "not implemented" in production code, PR #197)
+#
+# Removed in #1538: a prose/word scan over internal/**/*.go that
+# rejected the literal phrase "not implemented". Like wording-tests, it
+# policed vocabulary rather than behaviour: honest comments describing
+# correct runtime-gated paths (e.g. a CH function above the chDB floor
+# that is genuinely not implemented on the substrate) false-positived,
+# while a genuinely unimplemented path that returned a zero value or an
+# unreachable panic passed cleanly. CI/lefthook steps and this self-test
+# case were dropped together.
 # --------------------------------------------------------------------
 
 # --------------------------------------------------------------------
-# case 3 — "not implemented" in production code  (PR #197)
-# --------------------------------------------------------------------
-RE3='not implemented'
-printf 'return errors.New("not implemented")\n' >"$tmpdir/case3_match.txt"
-printf 'return errUnsupported // rejects unsupported foo\n' >"$tmpdir/case3_nomatch.txt"
-expect_match    "case3 not-implemented prod"  "$RE3" "$tmpdir/case3_match.txt"
-expect_no_match "case3 factual verb"          "$RE3" "$tmpdir/case3_nomatch.txt"
-
-# --------------------------------------------------------------------
-# case 4 — assert.Contains(x, "")  (PR #587, widened #277)
+# case 3 — assert.Contains(x, "")  (PR #587, widened #277)
 # --------------------------------------------------------------------
 # The optional `([^,]+,\s*){0,1}` prefix matches the testify
 # `t *testing.T` first arg when present, so the regex catches BOTH
 # the 2-arg gocheck-style call (`assert.Contains(haystack, "")`) and
 # the 3-arg testify call (`assert.Contains(t, haystack, "")`).
-RE4='assert\.Contains\(([^,]+,\s*){0,1}[^,]+,\s*""\s*\)'
-printf 'assert.Contains(body, "")\n'              >"$tmpdir/case4_match.txt"
-printf 'assert.Contains(t, body, "")\n'           >"$tmpdir/case4_match_testify.txt"
-printf 'assert.Contains(body, "error: foo")\n'    >"$tmpdir/case4_nomatch.txt"
-printf 'assert.Contains(t, body, "error: foo")\n' >"$tmpdir/case4_nomatch_testify.txt"
-expect_match    "case4 empty-needle Contains (2-arg)"   "$RE4" "$tmpdir/case4_match.txt"
-expect_match    "case4 empty-needle Contains (3-arg)"   "$RE4" "$tmpdir/case4_match_testify.txt"
-expect_no_match "case4 real-needle Contains (2-arg)"    "$RE4" "$tmpdir/case4_nomatch.txt"
-expect_no_match "case4 real-needle Contains (3-arg)"    "$RE4" "$tmpdir/case4_nomatch_testify.txt"
+RE3='assert\.Contains\(([^,]+,\s*){0,1}[^,]+,\s*""\s*\)'
+printf 'assert.Contains(body, "")\n'              >"$tmpdir/case3_match.txt"
+printf 'assert.Contains(t, body, "")\n'           >"$tmpdir/case3_match_testify.txt"
+printf 'assert.Contains(body, "error: foo")\n'    >"$tmpdir/case3_nomatch.txt"
+printf 'assert.Contains(t, body, "error: foo")\n' >"$tmpdir/case3_nomatch_testify.txt"
+expect_match    "case3 empty-needle Contains (2-arg)"   "$RE3" "$tmpdir/case3_match.txt"
+expect_match    "case3 empty-needle Contains (3-arg)"   "$RE3" "$tmpdir/case3_match_testify.txt"
+expect_no_match "case3 real-needle Contains (2-arg)"    "$RE3" "$tmpdir/case3_nomatch.txt"
+expect_no_match "case3 real-needle Contains (3-arg)"    "$RE3" "$tmpdir/case3_nomatch_testify.txt"
 
 # --------------------------------------------------------------------
-# case 5 — assert.ElementsMatch(x, []T{})  (PR #587, widened #277)
+# case 3 — assert.ElementsMatch(x, []T{})  (PR #587, widened #277)
 # --------------------------------------------------------------------
-# Same optional-`t`-prefix widening as case4 — covers both 2-arg
+# Same optional-`t`-prefix widening as case3 — covers both 2-arg
 # gocheck-style and 3-arg testify shapes.
-RE5='assert\.ElementsMatch\(([^,]+,\s*){0,1}[^,]+,\s*\[\][^)]*\{\s*\}\s*\)'
-printf 'assert.ElementsMatch(got, []string{})\n'           >"$tmpdir/case5_match.txt"
-printf 'assert.ElementsMatch(t, got, []string{})\n'        >"$tmpdir/case5_match_testify.txt"
-printf 'assert.ElementsMatch(got, []string{"a", "b"})\n'   >"$tmpdir/case5_nomatch.txt"
-printf 'assert.ElementsMatch(t, got, []string{"a", "b"})\n' >"$tmpdir/case5_nomatch_testify.txt"
-expect_match    "case5 empty-slice ElementsMatch (2-arg)" "$RE5" "$tmpdir/case5_match.txt"
-expect_match    "case5 empty-slice ElementsMatch (3-arg)" "$RE5" "$tmpdir/case5_match_testify.txt"
-expect_no_match "case5 populated ElementsMatch (2-arg)"   "$RE5" "$tmpdir/case5_nomatch.txt"
-expect_no_match "case5 populated ElementsMatch (3-arg)"   "$RE5" "$tmpdir/case5_nomatch_testify.txt"
+RE3='assert\.ElementsMatch\(([^,]+,\s*){0,1}[^,]+,\s*\[\][^)]*\{\s*\}\s*\)'
+printf 'assert.ElementsMatch(got, []string{})\n'           >"$tmpdir/case3_match.txt"
+printf 'assert.ElementsMatch(t, got, []string{})\n'        >"$tmpdir/case3_match_testify.txt"
+printf 'assert.ElementsMatch(got, []string{"a", "b"})\n'   >"$tmpdir/case3_nomatch.txt"
+printf 'assert.ElementsMatch(t, got, []string{"a", "b"})\n' >"$tmpdir/case3_nomatch_testify.txt"
+expect_match    "case3 empty-slice ElementsMatch (2-arg)" "$RE3" "$tmpdir/case3_match.txt"
+expect_match    "case3 empty-slice ElementsMatch (3-arg)" "$RE3" "$tmpdir/case3_match_testify.txt"
+expect_no_match "case3 populated ElementsMatch (2-arg)"   "$RE3" "$tmpdir/case3_nomatch.txt"
+expect_no_match "case3 populated ElementsMatch (3-arg)"   "$RE3" "$tmpdir/case3_nomatch_testify.txt"
 
 # --------------------------------------------------------------------
-# case 6 — silent panic recovery, both shapes  (PR #587 / #648)
+# case 3 — silent panic recovery, both shapes  (PR #587 / #648)
 # --------------------------------------------------------------------
-RE6='defer\s+recover\s*\(\s*\)|defer\s+func\s*\(\s*\)\s*\{[^{}]*_\s*=\s*recover\s*\(\s*\)'
+RE3='defer\s+recover\s*\(\s*\)|defer\s+func\s*\(\s*\)\s*\{[^{}]*_\s*=\s*recover\s*\(\s*\)'
 # 6a — bare `defer recover()`
 printf 'defer recover()\n' >"$tmpdir/case6a_match.txt"
-expect_match_perl "case6a bare-defer-recover" "$RE6" "$tmpdir/case6a_match.txt"
+expect_match_perl "case6a bare-defer-recover" "$RE3" "$tmpdir/case6a_match.txt"
 # 6b — multi-line `defer func() { _ = recover() }()`
 {
   printf 'defer func() {\n'
   printf '  _ = recover()\n'
   printf '}()\n'
 } >"$tmpdir/case6b_match.txt"
-expect_match_perl "case6b multi-line silent recover" "$RE6" "$tmpdir/case6b_match.txt"
+expect_match_perl "case6b multi-line silent recover" "$RE3" "$tmpdir/case6b_match.txt"
 # 6c — asserted-panic form MUST NOT match
 {
   printf 'defer func() {\n'
@@ -181,7 +184,7 @@ expect_match_perl "case6b multi-line silent recover" "$RE6" "$tmpdir/case6b_matc
   printf '  if r == nil { t.Fatal("expected panic") }\n'
   printf '}()\n'
 } >"$tmpdir/case6c_nomatch.txt"
-expect_no_match_perl "case6c asserted-panic form" "$RE6" "$tmpdir/case6c_nomatch.txt"
+expect_no_match_perl "case6c asserted-panic form" "$RE3" "$tmpdir/case6c_nomatch.txt"
 
 # --------------------------------------------------------------------
 # (former case 7 — should_skip overlay tracking-ref guard, PR #596)
@@ -196,49 +199,49 @@ expect_no_match_perl "case6c asserted-panic form" "$RE6" "$tmpdir/case6c_nomatch
 # --------------------------------------------------------------------
 
 # --------------------------------------------------------------------
-# case 8 — scenario-suppressing Gherkin tags  (PR #1268)
+# case 3 — scenario-suppressing Gherkin tags  (PR #1268)
 # --------------------------------------------------------------------
 # The Layer-14 migration scenarios are `.feature` files driven by godog.
 # A `@wip`-style tag filters a Scenario out of the run while the lane
 # still reports green — t.Skip wearing a hat, one directory over.
-RE8='(^|[ \t])@(wip|skip|ignore|manual|todo|pending)([ \t]|$)'
-printf '@MIG-04 @tier0 @wip\n'                       >"$tmpdir/case8_match.txt"
-printf '@skip\n'                                     >"$tmpdir/case8_match_bare.txt"
-printf '@MIG-01 @tier0 @archetype:already-otel\n'    >"$tmpdir/case8_nomatch.txt"
-printf '@MIG-01 @tier0 @archetype:manual-scrape\n'   >"$tmpdir/case8_nomatch_embedded.txt"
-expect_match    "case8 @wip suffix tag"        "$RE8" "$tmpdir/case8_match.txt"
-expect_match    "case8 bare @skip tag"         "$RE8" "$tmpdir/case8_match_bare.txt"
-expect_no_match "case8 real tag line"          "$RE8" "$tmpdir/case8_nomatch.txt"
-expect_no_match "case8 archetype containing a banned word" "$RE8" "$tmpdir/case8_nomatch_embedded.txt"
+RE3='(^|[ \t])@(wip|skip|ignore|manual|todo|pending)([ \t]|$)'  # todo here is a Gherkin tag name, not a work marker (#1538)
+printf '@MIG-04 @tier0 @wip\n'                       >"$tmpdir/case3_match.txt"
+printf '@skip\n'                                     >"$tmpdir/case3_match_bare.txt"
+printf '@MIG-01 @tier0 @archetype:already-otel\n'    >"$tmpdir/case3_nomatch.txt"
+printf '@MIG-01 @tier0 @archetype:manual-scrape\n'   >"$tmpdir/case3_nomatch_embedded.txt"
+expect_match    "case3 @wip suffix tag"        "$RE3" "$tmpdir/case3_match.txt"
+expect_match    "case3 bare @skip tag"         "$RE3" "$tmpdir/case3_match_bare.txt"
+expect_no_match "case3 real tag line"          "$RE3" "$tmpdir/case3_nomatch.txt"
+expect_no_match "case3 archetype containing a banned word" "$RE3" "$tmpdir/case3_nomatch_embedded.txt"
 
 # The forbid-skip.mjs invocation of RE8 runs `grep -i`: the tag vocabulary is
 # closed and fixed-case, so a wrongly-cased suppression tag — including one
 # placed on a Scenario Outline's Examples block, which is legal Gherkin — must
 # not merge clean just because nobody typed it in lowercase.
-printf '@WIP\n'                                      >"$tmpdir/case8_match_upper.txt"
-printf '    @Skip\n'                                 >"$tmpdir/case8_match_examples.txt"
-expect_match_ci "case8 uppercase @WIP"                    "$RE8" "$tmpdir/case8_match_upper.txt"
-expect_match_ci "case8 mixed-case @Skip on an Examples line" "$RE8" "$tmpdir/case8_match_examples.txt"
+printf '@WIP\n'                                      >"$tmpdir/case3_match_upper.txt"
+printf '    @Skip\n'                                 >"$tmpdir/case3_match_examples.txt"
+expect_match_ci "case3 uppercase @WIP"                    "$RE3" "$tmpdir/case3_match_upper.txt"
+expect_match_ci "case3 mixed-case @Skip on an Examples line" "$RE3" "$tmpdir/case3_match_examples.txt"
 
 # --------------------------------------------------------------------
-# case 9 — godog skip / pending routes  (PR #1268)
+# case 3 — godog skip / pending routes  (PR #1268)
 # --------------------------------------------------------------------
 # godog step definitions live in NON-test .go files, so case 1's
 # `*_test.go` scope cannot see them. The receiver is unanchored so
 # binding godog.T(ctx) to a local first does not evade the scan.
-RE9='godog\.(ErrSkip|ErrPending)|\.Skip(f|Now)?\('
-printf 'return godog.ErrSkip\n'                              >"$tmpdir/case9_match_errskip.txt"
-printf 'return godog.ErrPending\n'                           >"$tmpdir/case9_match_errpending.txt"
-printf 'godog.T(ctx).Skipf("no fixture for %%s", archetype)\n' >"$tmpdir/case9_match_skipf.txt"
-printf 't := godog.T(ctx)\nt.SkipNow()\n'                    >"$tmpdir/case9_match_local.txt"
-printf 'w.Skipped = corpus.Skipped\n'                        >"$tmpdir/case9_nomatch_field.txt"
-printf 'return fmt.Errorf("the harvester dropped %%d inputs", n)\n' >"$tmpdir/case9_nomatch_plain.txt"
-expect_match    "case9 godog.ErrSkip"        "$RE9" "$tmpdir/case9_match_errskip.txt"
-expect_match    "case9 godog.ErrPending"     "$RE9" "$tmpdir/case9_match_errpending.txt"
-expect_match    "case9 T(ctx).Skipf"         "$RE9" "$tmpdir/case9_match_skipf.txt"
-expect_match    "case9 local receiver SkipNow" "$RE9" "$tmpdir/case9_match_local.txt"
-expect_no_match "case9 Skipped field access" "$RE9" "$tmpdir/case9_nomatch_field.txt"
-expect_no_match "case9 ordinary error return" "$RE9" "$tmpdir/case9_nomatch_plain.txt"
+RE3='godog\.(ErrSkip|ErrPending)|\.Skip(f|Now)?\('
+printf 'return godog.ErrSkip\n'                              >"$tmpdir/case3_match_errskip.txt"
+printf 'return godog.ErrPending\n'                           >"$tmpdir/case3_match_errpending.txt"
+printf 'godog.T(ctx).Skipf("no fixture for %%s", archetype)\n' >"$tmpdir/case3_match_skipf.txt"
+printf 't := godog.T(ctx)\nt.SkipNow()\n'                    >"$tmpdir/case3_match_local.txt"
+printf 'w.Skipped = corpus.Skipped\n'                        >"$tmpdir/case3_nomatch_field.txt"
+printf 'return fmt.Errorf("the harvester dropped %%d inputs", n)\n' >"$tmpdir/case3_nomatch_plain.txt"
+expect_match    "case3 godog.ErrSkip"        "$RE3" "$tmpdir/case3_match_errskip.txt"
+expect_match    "case3 godog.ErrPending"     "$RE3" "$tmpdir/case3_match_errpending.txt"
+expect_match    "case3 T(ctx).Skipf"         "$RE3" "$tmpdir/case3_match_skipf.txt"
+expect_match    "case3 local receiver SkipNow" "$RE3" "$tmpdir/case3_match_local.txt"
+expect_no_match "case3 Skipped field access" "$RE3" "$tmpdir/case3_nomatch_field.txt"
+expect_no_match "case3 ordinary error return" "$RE3" "$tmpdir/case3_nomatch_plain.txt"
 
 # --------------------------------------------------------------------
 # summary


### PR DESCRIPTION
Closes #1538.

The `not-implemented` CHECK was a word-policing scan identical in shape to the `wording-tests` scan that was already removed: it grepped `internal/**/*.go` for the literal phrase `"not implemented"` rather than detecting an unimplemented code path behaviourally.

Two-sided failure mode documented in #1538:

- **False positives** — honest comments describing correct, runtime-gated behaviour (e.g. a CH function not implemented on the chDB substrate) forced authors to reword instead of to fix behaviour.
- **False negatives** — a genuinely unimplemented path returning a zero value or unreachable panic passed cleanly because it avoided the phrase.

## Changes

- `ci.yml`: remove the `CHECK: not-implemented` step from the `forbid-skip` job
- `.github/scripts/forbid-skip.mjs`: remove the `case 'not-implemented':` arm; update the error message listing valid CHECKs
- `lefthook.yml`: remove the `forbid-not-implemented-prod` pre-push command
- `docs/forbid-skip.md`: remove Pattern 2 subsection + row; renumber 3→2 … 9→8; update dispatched scan count 6→5 throughout
- `scripts/test-forbid-skip.sh`: replace case 3 block with a tombstone comment; renumber case 4→3 … 9→8; **25/25 OK**
- `doc-counts.mjs` derives the count live — already reports 5 ✓