### PR TITLE
ci: add agpl_oracle lane so tagged oracle tests actually run

### DIFF
--- a/.github/workflows/agpl-oracle.yml
+++ b/.github/workflows/agpl-oracle.yml
@@ -1,0 +1,133 @@
+name: agpl-oracle
+
+# Differential oracle lane for the in-house LogQL and TraceQL parser
+# reimplementations.
+#
+# Five test files in the root module carry `//go:build agpl_oracle` and
+# compare cerberus's own clean-room parsers against the upstream AGPL
+# reference parsers (grafana/loki/pkg/logql for LogQL; grafana/tempo/pkg/traceql
+# for TraceQL). These files are compiled and run by NO other lane — the default
+# `check` gate is CGO-free and passes no build tags beyond the defaults, so
+# without this workflow the oracle diffs are never exercised and a parser
+# regression can reach main undetected (see #1610 for the full evidence).
+#
+# Files covered:
+#   internal/api/loki/detected_extract_agpl_test.go
+#   internal/logql/logpattern/pattern_agpl_test.go
+#   internal/logql/jsonpath_agpl_test.go
+#   internal/logql/lsyntax/oracle_agpl_test.go
+#   test/agpl_oracle/oracle_test.go
+#
+# The tests do NOT require CGO, Docker, or libchdb — they are pure Go and
+# compile with a stock Go toolchain against the root-module deps.
+#
+# Required status check name: `agpl-oracle`
+# Required on: all PRs (docs-only PRs short-circuit to a green no-op so
+# the context always appears in the PR rollup without doing work).
+# Path note: the `changes` job shares the docs-only filter from ci.yml /
+# chdb.yml; see chdb.yml's matrix-expansion note for why the guard lives
+# on the STEPS rather than the job.
+#
+# Tag composition note: when #1520 lands and test/property/logql_test.go
+# acquires `//go:build chdb && agpl_oracle`, this lane will need to pass
+# BOTH tags and install libchdb.so. That change is tracked in #1520; until
+# then the lane is pure-Go and has no chdb dependency.
+#
+# Regression test: test/regression/agpl_oracle_tag_set_test.go asserts
+# that every `//go:build agpl_oracle` file in the root module is known to
+# this lane, so a new tagged file cannot arrive without a lane-coverage
+# update.
+
+on:
+  pull_request:
+  push:
+    branches: [main, 'release/*.x']
+  workflow_dispatch:
+  schedule:
+    # nightly at 03:30 UTC (ahead of property at 03:45 and chdb at 04:00)
+    - cron: '30 3 * * *'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: agpl-oracle-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  # Docs-only short-circuit — see chdb.yml for the full rationale. The
+  # `agpl-oracle` job uses per-step guards (not a job-level `if:`) so the
+  # required context is always published.
+  changes:
+    name: changes
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.compute.outputs.docs_only }}
+    steps:
+      - uses: actions/checkout@v7
+        if: github.event_name == 'pull_request'
+
+      - id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v4
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            code:
+              - '**'
+              - '!**/*.md'
+              - '!**/*.markdown'
+              - '!docs/**'
+              - '!LICENSE*'
+              - '!CHANGELOG.md'
+              - '!.markdownlint*'
+              - '!CLAUDE.md'
+              - '!AGENTS.md'
+              - '!README*'
+
+      - id: compute
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            if [ "${{ steps.filter.outputs.code }}" = "false" ]; then
+              echo "docs_only=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  # `agpl-oracle` compiles and runs the five `//go:build agpl_oracle` test
+  # files. A failure means the in-house parser has diverged from the AGPL
+  # reference in a way the test corpus exposes.
+  #
+  # The job also runs the regression test (test/regression) which includes
+  # agpl_oracle_tag_set_test.go — it asserts the set of tagged files matches
+  # what this lane covers, so a new oracle test file is caught immediately
+  # rather than silently running under no lane.
+  agpl-oracle:
+    name: agpl-oracle
+    needs: changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+        if: needs.changes.outputs.docs_only != 'true'
+
+      - uses: actions/setup-go@v7
+        if: needs.changes.outputs.docs_only != 'true'
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: Run agpl_oracle differential oracle tests
+        if: needs.changes.outputs.docs_only != 'true'
+        run: go test -race -tags agpl_oracle -count=1 ./internal/... ./test/agpl_oracle/...
+
+      - name: Verify agpl_oracle tag set coverage (regression)
+        if: needs.changes.outputs.docs_only != 'true'
+        run: go test -run TestAGPLOracleTagSetCoverage -count=1 ./test/regression/...
+
+      - name: No-op (docs-only PR)
+        if: needs.changes.outputs.docs_only == 'true'
+        run: echo "agpl-oracle is a green no-op on docs-only PRs."

--- a/Justfile
+++ b/Justfile
@@ -126,6 +126,15 @@ test-unit:
 vet-tagged:
     go vet -tags=migration_tier1 ./test/e2e/migration/...
     go vet -tags=migration_tier2 ./test/e2e/migration/...
+    go vet -tags=agpl_oracle ./internal/... ./test/agpl_oracle/...
+
+# Run the agpl_oracle differential oracle tests. These compare the in-house
+# LogQL and TraceQL parser reimplementations against the upstream AGPL
+# reference parsers (grafana/loki + grafana/tempo). Requires no CGO /
+# Docker / libchdb — just pure Go with the root-module deps.
+# Mirrors the `agpl-oracle` CI lane in .github/workflows/agpl-oracle.yml.
+test-agpl-oracle:
+    go test -race -tags agpl_oracle -count=1 ./internal/... ./test/agpl_oracle/...
 
 # Run the internal/schema/ddl integration tests against a real ClickHouse
 # container (spun up via testcontainers-go). Requires Docker. Gated behind

--- a/test/regression/agpl_oracle_tag_set_test.go
+++ b/test/regression/agpl_oracle_tag_set_test.go
@@ -1,0 +1,136 @@
+package regression
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestAGPLOracleTagSetCoverage asserts that every `//go:build agpl_oracle`
+// file in the root module is known to the agpl-oracle CI lane
+// (.github/workflows/agpl-oracle.yml). This is the "hold the tag set to the
+// lanes" regression described in #1610: a new oracle file that carries the tag
+// but is not covered by the lane's `go test` scope would compile under no CI
+// lane, defeating the differential oracle entirely.
+//
+// The test does NOT run the tagged files itself (it carries no agpl_oracle tag)
+// — it only verifies coverage. The agpl-oracle workflow runs
+// `go test -tags agpl_oracle -count=1 ./internal/... ./test/agpl_oracle/...`,
+// which covers every file in the set below. If you add a new //go:build
+// agpl_oracle file outside those scopes, add the package path to
+// agplOracleLaneScopes below AND extend the workflow's `go test` invocation to
+// include it.
+func TestAGPLOracleTagSetCoverage(t *testing.T) {
+	// Resolve to an absolute path so filepath.Base of the root isn't "..".
+	absRoot, err := filepath.Abs(repoRoot)
+	if err != nil {
+		t.Fatalf("filepath.Abs: %v", err)
+	}
+	// The package subtrees the agpl-oracle lane covers with `go test -tags
+	// agpl_oracle`. Expressed as repo-relative directory prefixes (slash-separated).
+	// These must match the scopes in .github/workflows/agpl-oracle.yml's
+	// "Run agpl_oracle differential oracle tests" step.
+	agplOracleLaneScopes := []string{
+		"internal/",
+		"test/agpl_oracle/",
+	}
+
+	tagged := findAGPLOracleFiles(t, absRoot)
+	if len(tagged) == 0 {
+		t.Fatal("no //go:build agpl_oracle files found in the root module; " +
+			"either the tag was removed from all files (update this test) " +
+			"or repoRoot is wrong")
+	}
+
+	var uncovered []string
+	for _, rel := range tagged {
+		rel = filepath.ToSlash(rel)
+		covered := false
+		for _, scope := range agplOracleLaneScopes {
+			if strings.HasPrefix(filepath.ToSlash(rel), scope) {
+				covered = true
+				break
+			}
+		}
+		if !covered {
+			uncovered = append(uncovered, rel)
+		}
+	}
+
+	if len(uncovered) > 0 {
+		t.Errorf("%d //go:build agpl_oracle file(s) are NOT covered by the agpl-oracle CI lane:\n",
+			len(uncovered))
+		for _, f := range uncovered {
+			t.Errorf("  %s", f)
+		}
+		t.Error("\nAdd the file's package subtree to agplOracleLaneScopes in this test AND " +
+			"to the `go test -tags agpl_oracle` invocation in " +
+			".github/workflows/agpl-oracle.yml.")
+	}
+
+	t.Logf("agpl_oracle tag set: %d file(s) across %d scope(s) — all covered",
+		len(tagged), len(agplOracleLaneScopes))
+	for _, f := range tagged {
+		t.Logf("  %s", filepath.ToSlash(f))
+	}
+}
+
+// findAGPLOracleFiles walks the module root and returns repo-relative paths
+// of every Go file (including _test.go) whose first build constraint line
+// contains agpl_oracle.
+func findAGPLOracleFiles(t *testing.T, root string) []string {
+	t.Helper()
+	var out []string
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		name := d.Name()
+		if d.IsDir() {
+			// Skip hidden dirs and vendor, but NOT the root itself
+			// (filepath.Base of an absolute root is the dir name, not ".").
+			if path != root && (name == "vendor" || strings.HasPrefix(name, ".")) {
+				return filepath.SkipDir
+			}
+			// Nested module: has its own go.mod — don't recurse.
+			if _, statErr := os.Stat(filepath.Join(path, "go.mod")); statErr == nil && path != root {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(name, ".go") {
+			return nil
+		}
+		if hasAGPLOracleBuildTag(path) {
+			rel, _ := filepath.Rel(root, path)
+			out = append(out, filepath.ToSlash(rel))
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("WalkDir: %v", err)
+	}
+	return out
+}
+
+// hasAGPLOracleBuildTag reports whether the Go file at path carries a
+// //go:build constraint that includes agpl_oracle. Reads only the preamble
+// (lines before the package declaration) to stay cheap.
+func hasAGPLOracleBuildTag(path string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	// Scan the preamble: lines before the package declaration.
+	for _, line := range strings.SplitN(string(data), "\n", 50) {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "package ") {
+			break
+		}
+		if strings.HasPrefix(trimmed, "//go:build ") && strings.Contains(trimmed, "agpl_oracle") {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Closes #1610.

Five files in the root module carry `//go:build agpl_oracle` — the differential A/B checks that prove the in-house clean-room LogQL/TraceQL parser reimplementations agree with the upstream AGPL reference parsers. No CI lane, Justfile recipe, or lefthook command ever passed that tag, so they compiled and ran under nothing. A parser regression could reach `main` with all required checks green.

## Changes

### `.github/workflows/agpl-oracle.yml` (new)
New `agpl-oracle` required-check workflow:
- `agpl-oracle` job runs `go test -race -tags agpl_oracle -count=1 ./internal/... ./test/agpl_oracle/...`
- Docs-only PRs get a green no-op (per-step guard, not job-level, so the context always appears in the PR rollup)
- Triggers: `pull_request` + push-to-main + `release/*.x` + nightly (03:30 UTC)

### `Justfile`
- `vet-tagged` now includes `go vet -tags=agpl_oracle ./internal/... ./test/agpl_oracle/...` so the type-checker visits oracle files on every local `just test`
- New `test-agpl-oracle` recipe mirrors the CI lane locally

### `test/regression/agpl_oracle_tag_set_test.go` (new)
`TestAGPLOracleTagSetCoverage` — the "hold the tag set to the lanes" regression from #1610:
- Walks the root module, collects every `//go:build agpl_oracle` file
- Asserts each one falls under a scope the agpl-oracle lane covers (`internal/`, `test/agpl_oracle/`)
- Currently passing: **5 files across 2 scopes**
- A new oracle file added outside those scopes fails this test immediately

**Tag-composition note:** when #1520 lands and `test/property/logql_test.go` acquires `chdb && agpl_oracle`, this lane will need libchdb.so and both tags. Tracked in #1520.