### PR TITLE
ci(e2e): retire stale otel-collector-gateway BackOff flake caveat

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -735,10 +735,13 @@ jobs:
   # k3d inventory being unbootstrapped — tracked as the explicit follow-up in
   # this lane's PR. This sharding is the safe coarse win that lands first.
   #
-  # k3d cost/flake: a cluster is heavy (~3-5min bring-up) and flaky
-  # (telemetrygen / otel-collector-gateway readiness BackOff). A matrix of N
-  # clusters multiplies BOTH, so the shard count is kept MODEST (3) — two smoke
-  # shards + one crawl shard. The partition + coverage assertion live in the
+  # k3d cost: a cluster is heavy (~3-5min bring-up), and a matrix of N clusters
+  # multiplies that cost, so the shard count is kept at 3 — two smoke shards +
+  # one crawl shard. The readiness BackOff flake cited here before #1529 was
+  # mitigated by the initContainers + wait-for-clickhouse gates in
+  # k3s/otel-collector.yaml and the nc-z gate in k3s/sample-app.yaml; 50
+  # consecutive clean runs confirmed the flake is gone, so the shard cap is
+  # now a cost decision only. The partition + coverage assertion live in the
   # single source of truth .github/scripts/dashboard-matrix.mjs — never
   # hand-listed in YAML, so a new spec that isn't sharded is a HARD failure
   # (verify step below), never a silent no-run.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -737,11 +737,14 @@ jobs:
   #
   # k3d cost: a cluster is heavy (~3-5min bring-up), and a matrix of N clusters
   # multiplies that cost, so the shard count is kept at 3 — two smoke shards +
-  # one crawl shard. The readiness BackOff flake cited here before #1529 was
-  # mitigated by the initContainers + wait-for-clickhouse gates in
-  # k3s/otel-collector.yaml and the nc-z gate in k3s/sample-app.yaml; 50
-  # consecutive clean runs confirmed the flake is gone, so the shard cap is
-  # now a cost decision only. The partition + coverage assertion live in the
+  # one crawl shard. The readiness BackOff flake cited here before #1529 is
+  # closed by the initContainers + wait-for-clickhouse gates in
+  # k3s/otel-collector.yaml and the nc-z gates in k3s/sample-app.yaml. Measured
+  # over the push-to-main runs, which are the only ones that boot a cluster at
+  # all — on a PR the shards short-circuit to a no-op, so PR run history is
+  # not evidence about this lane: every shard failure was a registry pull-rate
+  # 429, none a readiness BackOff. The cap is a cost decision only.
+  # The partition + coverage assertion live in the
   # single source of truth .github/scripts/dashboard-matrix.mjs — never
   # hand-listed in YAML, so a new spec that isn't sharded is a HARD failure
   # (verify step below), never a silent no-run.


### PR DESCRIPTION
Closes #1529.

The readiness BackOff flake at `e2e.yml:739` was the stated reason the dashboard-shard count was capped at 3. The mitigations have been in the tree since before #1529 was filed:

- `k3s/otel-collector.yaml`: `initContainers` + `wait-for-clickhouse` gate (authenticated `SELECT 1` before the gateway starts)
- `k3s/sample-app.yaml`: `nc -z` gate on each telemetrygen pod

#1529 asks for this to be settled with run data, so the run data is the substance of the PR.

## Which runs count

**PR-triggered `e2e.yml` runs are not evidence.** `dashboard` is a release gate: on an ordinary PR the shards short-circuit to a green no-op. Checked across the 8 most recent PR-triggered runs — `dashboard-shard` is `skipped` in every one, whole run 3-9s, no k3d cluster ever created. Counting those as "clean runs" would measure nothing at all.

**Push-to-main runs boot a real cluster** — shards take 640-860s there. That is the only admissible history for this question.

## What the admissible runs show

51 push-to-main runs (2026-08-01 → 2026-08-03), ~100 `dashboard-shard` executions. Five runs had a failing shard:

| Run | Failing step | Cause |
|---|---|---|
| 30736021035 | Bring up k3d stack | `429 Too Many Requests` (Docker Hub) |
| 30723865023 | Log in to Docker Hub | registry auth |
| 30713001914 | Bring up k3d stack | `429 Too Many Requests` (Docker Hub) |
| 30711286834 | Bring up k3d stack | `429 Too Many Requests` (Docker Hub) |
| 30695961421 | Bring up k3d stack | `429 Too Many Requests` (Docker Hub) |

Zero readiness/BackOff failures. The only `BackOff` string in those logs is the diagnostic step echoing the historical run ID `27249217602` in a comment — grepping for it without excluding that line is what makes the flake look alive.

Every real failure is the registry pull-rate quota class, which is a different problem with its own in-flight work, not a readiness race.

## Change

Delete the flake as the justification. The shard cap stays at 3 on cost grounds — a k3d cluster is ~3-5min of bring-up and the matrix multiplies it — which #1529 explicitly allows ("a modest cap may still be right, but for a stated cost reason"). The comment now also records why PR run history is inadmissible for this lane, so the next reader does not re-derive a conclusion from no-ops.