### PR TITLE
ci: migrate CodeQL to advanced setup with merge_group trigger

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,108 @@
+name: CodeQL
+
+# CodeQL advanced-setup replacement for GitHub's code-scanning default setup.
+#
+# Default setup builds its analysis workflow server-side and dispatches it on
+# `push` and `pull_request` only. There is no mechanism to add `merge_group`
+# to a server-side workflow, so with default setup enabled the merge queue
+# stalls waiting for a CodeQL check-run that is never posted on the projected
+# trunk commit (see #1558).
+#
+# Advanced setup is a workflow file in the repository. It can carry any trigger,
+# including `merge_group`, which is exactly what the queue needs.
+#
+# MIGRATION NOTE: default setup and advanced setup cannot coexist — SARIF
+# uploads are rejected while default setup is configured. Default setup was
+# disabled via the GitHub API immediately before this workflow was merged:
+#   gh api --method PUT repos/tsouza/cerberus/code-scanning/default-setup \
+#     -f state=not-configured
+# Branch protection continues to require the context named `CodeQL` (the `name:`
+# of the umbrella job below), so no branch-protection edit is needed.
+#
+# REQUIRED CONTEXT: `CodeQL` — produced by the umbrella job below, which
+# depends on all per-language analyze jobs. Branch protection requires this
+# name; any rename here must be accompanied by an update to the required-checks
+# list (`gh api repos/tsouza/cerberus/branches/main/protection`).
+#
+# LANGUAGES: the same set default setup was scanning:
+#   go, javascript-typescript, actions, python
+# The `actions` language scans workflow YAML for injection vulnerabilities.
+# The `javascript-typescript` language covers the .github/scripts/*.mjs files.
+#
+# TEST REGRESSION PIN: test/regression/merge_queue_test.go previously recorded
+# `CodeQL` in `queueExternalContexts` because default setup produced it with no
+# workflow owner in this repo. That entry is deleted in this PR — `codeql.yml`
+# is now the owner, and the test asserts the workflow declares `merge_group`.
+
+on:
+  push:
+    branches: [main, 'release/*.x']
+  pull_request:
+  merge_group:
+  schedule:
+    # Weekly deep scan — outside the standard PR/push gates so the
+    # extended query suite runs without gating PRs on its extra latency.
+    - cron: '30 2 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  # Never cancel on merge_group: a cancelled check-run is treated as failed
+  # by GitHub, which would dequeue the PR. Safe on pull_request and push.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [go, javascript-typescript, actions, python]
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        if: matrix.language == 'go'
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          # Default query suite mirrors what default setup was running.
+          queries: security-and-quality
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:${{ matrix.language }}
+
+  # Umbrella job — produces the `CodeQL` check-run that branch protection
+  # requires. It passes only when every per-language analysis passes, so
+  # branch protection still blocks on all language analyses via this single
+  # required context name (matching what default setup produced).
+  CodeQL:
+    name: CodeQL
+    needs: analyze
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Check all analyses passed
+        run: |
+          if [ "${{ needs.analyze.result }}" != "success" ]; then
+            echo "::error::One or more CodeQL analyses failed or were skipped."
+            exit 1
+          fi
+          echo "All CodeQL analyses passed."

--- a/test/regression/merge_queue_test.go
+++ b/test/regression/merge_queue_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"testing"
 
@@ -33,27 +34,31 @@ import (
 // projected trunk.
 const mergeGroupTrigger = "merge_group"
 
+// queueRequiredContextsOutsideReleaseGate are contexts branch protection
+// requires on `main` that are absent from branchProtectionContexts because they
+// appear in neither RELEASE_REQUIRED_CHECKS nor RELEASE_INFORMATIONAL_CHECKS —
+// adding them to that list would fail the totality assertion in
+// release_required_checks_test.go. That omission is a real gap in the release
+// gate, tracked in #1463. The merge queue's requirement is independent of the
+// release gate's, so it is asserted over the full set either way.
+var queueRequiredContextsOutsideReleaseGate = []string{
+	"CodeQL",
+	"strict-scan",
+}
+
 // queueExternalContexts are required contexts posted by a GitHub app rather
 // than by a workflow in this repository, mapped to the producer.
 //
-// `CodeQL` comes from code-scanning DEFAULT setup, which builds its own
-// analysis workflow server-side and dispatches it on `push` and
-// `pull_request` only — there is no file here to add a trigger to, and no
-// setting that adds `merge_group`. It is therefore the one required context a
-// merge queue cannot satisfy: an entry waits for a `CodeQL` check-run that the
-// app never posts. Resolving it is a repository-settings decision (drop the
-// context from the required set, or migrate to ADVANCED setup — disable
-// default setup and land a `codeql.yml` carrying the trigger), not a code
-// change, so this pin records the constraint instead of asserting past it.
-// Tracked in #1558.
+// Previously `CodeQL` was listed here because code-scanning default setup
+// dispatches only on `push` and `pull_request`, making the merge queue stall
+// on an absent check-run. That entry was removed in #1558: default setup was
+// disabled and `.github/workflows/codeql.yml` now owns the `CodeQL` context
+// with a `merge_group:` trigger.
 //
 // The map is not a tolerance list: the test below asserts in BOTH directions.
-// An entry here must have no workflow owner, so the moment `CodeQL` becomes a
-// workflow in this repo the entry has to be deleted, and deleting it puts the
-// context straight back under the `merge_group` requirement.
-var queueExternalContexts = map[string]string{
-	"CodeQL": "code-scanning default setup (the github-advanced-security app)",
-}
+// An entry here must have no workflow owner, so any future context that is
+// exclusively app-produced must be listed here instead of getting a workflow.
+var queueExternalContexts = map[string]string{}
 
 // onDeclares reports whether a workflow's `on:` block names an event. All three
 // legal shapes are handled — a mapping (`on: {push: …}`), a sequence
@@ -83,8 +88,9 @@ func TestEveryRequiredContextPostsOnTheMergeGroup(t *testing.T) {
 	t.Parallel()
 
 	owners := workflowCheckOwners(t)
+	required := slices.Concat(branchProtectionContexts, queueRequiredContextsOutsideReleaseGate)
 
-	for _, ctx := range branchProtectionContexts {
+	for _, ctx := range required {
 		owner, ok := owners.lookup(ctx)
 
 		if producer, external := queueExternalContexts[ctx]; external {


### PR DESCRIPTION
Closes #1558.

CodeQL default setup dispatches only on `push` and `pull_request`. The merge queue dispatches `merge_group` against a projected trunk commit and waits for every required context there. With default setup, the queue stalled waiting for a CodeQL check-run that the app never posted — the failure mode is silence, not a red X.

## Changes

**`.github/workflows/codeql.yml` (new)** — advanced-setup replacement:
- Same four languages as default setup: `go`, `javascript-typescript`, `actions`, `python`
- Matrix `Analyze (${{ matrix.language }})` jobs + umbrella `CodeQL` job
- The umbrella job name matches the existing required-context name — no branch-protection edit needed
- Triggers: `pull_request` + `push` + **`merge_group`** + weekly schedule
- `cancel-in-progress: ${{ github.event_name == 'pull_request' }}` — never cancels on `merge_group`

**`test/regression/merge_queue_test.go`** — remove `CodeQL` from `queueExternalContexts`. The entry existed because default setup had no workflow owner in this repo. Now that `codeql.yml` owns the context, the bidirectional assertion in `TestEveryRequiredContextPostsOnTheMergeGroup` verifies the workflow declares `merge_group`.

**Default setup** was disabled via API immediately before this commit (`gh api --method PATCH repos/tsouza/cerberus/code-scanning/default-setup -f state=not-configured`) — SARIF uploads are rejected while both setups are active.