### PR TITLE
ci(compat): finish compat-QL rename for the prometheus head

### DIFF
--- a/.github/scripts/assert-image-jobs-authenticate.test.mjs
+++ b/.github/scripts/assert-image-jobs-authenticate.test.mjs
@@ -249,7 +249,7 @@ test('removing the acquisition removes the requirement, not the other way round'
 // shape of the job that produced the run above: login, then straight to compose.
 const withoutTheComposePrePull = (text) =>
   text.replace(
-    'run: ./compatibility/prometheus/scripts/run-compatibility.sh',
+    'run: ./compatibility/prometheus/scripts/run-prometheus-compatibility.sh',
     'run: docker compose -f docker-compose.yml up -d --build --wait clickhouse prometheus cerberus',
   );
 

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -235,7 +235,7 @@ jobs:
           fetch-depth: 0
 
       # ---- free runner disk BEFORE the compose stack boots (infra-flake fix) ----
-      # run-compatibility.sh does `docker compose up -d --build` for CH +
+      # run-prometheus-compatibility.sh does `docker compose up -d --build` for CH +
       # reference Prometheus + a freshly-built cerberus. The build layers +
       # CH data exhaust bone-stock ubuntu-latest's ~14 GB free root fs,
       # surfacing as "no space left on device" / unhealthy-container compose
@@ -299,7 +299,7 @@ jobs:
           # compatibility/prometheus/cmd/seed/main.go).
           TESTER_END_TIME: "2026-05-11T01:00:00Z"
           TESTER_RANGE: "3600"
-        run: ./compatibility/prometheus/scripts/run-compatibility.sh
+        run: ./compatibility/prometheus/scripts/run-prometheus-compatibility.sh
 
       - name: Summarise report
         if: always()
@@ -492,7 +492,7 @@ jobs:
         id: compat
         # CERBERUS_EVAL_ROUTE=sharded is interpolated into the cerberus
         # container's environment by docker-compose.yml; FAIL_ON_DIFF=1
-        # makes run-compatibility.sh re-raise ANY parity diff. Same seed
+        # makes run-prometheus-compatibility.sh re-raise ANY parity diff. Same seed
         # window + tester knobs as the standard prometheus job so the only
         # variable under test is the routing mode.
         env:
@@ -500,7 +500,7 @@ jobs:
           TESTER_RANGE: "3600"
           CERBERUS_EVAL_ROUTE: "sharded"
           FAIL_ON_DIFF: "1"
-        run: ./compatibility/prometheus/scripts/run-compatibility.sh
+        run: ./compatibility/prometheus/scripts/run-prometheus-compatibility.sh
 
       - name: Summarise report
         if: always()

--- a/Justfile
+++ b/Justfile
@@ -1399,11 +1399,11 @@ compose-grafana-smoke:
 # Sets up the Docker Compose stack (reference Prom + cerberus + CH + seeder),
 # runs the upstream tester, writes compatibility/prometheus/report.json.
 compat-promql:
-    ./compatibility/prometheus/scripts/run-compatibility.sh
+    ./compatibility/prometheus/scripts/run-prometheus-compatibility.sh
 
 # Keep the compatibility stack running after the tester finishes (for debugging).
 compat-promql-keep:
-    COMPOSE_KEEP=1 ./compatibility/prometheus/scripts/run-compatibility.sh
+    COMPOSE_KEEP=1 ./compatibility/prometheus/scripts/run-prometheus-compatibility.sh
 
 # Tear down the compatibility stack manually.
 compat-promql-down:

--- a/compatibility/loki/scripts/run-loki-compatibility.sh
+++ b/compatibility/loki/scripts/run-loki-compatibility.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # LogQL compatibility harness entry point.
 #
-# Lifecycle (mirrors compatibility/prometheus/scripts/run-compatibility.sh):
+# Lifecycle (mirrors compatibility/prometheus/scripts/run-prometheus-compatibility.sh):
 #
 #   1. `docker compose up --wait` brings reference Loki + cerberus + CH up.
 #   2. The Go seeder pushes a deterministic fixture to both targets and

--- a/compatibility/prometheus/docker-compose.yml
+++ b/compatibility/prometheus/docker-compose.yml
@@ -8,11 +8,11 @@
 #
 # Seeding is no longer a compose service — the fixture is loaded by
 # `go run ./compatibility/prometheus/cmd/seed/` invoked from
-# scripts/run-compatibility.sh. The seeder reuses internal/schema/ddl so
+# scripts/run-prometheus-compatibility.sh. The seeder reuses internal/schema/ddl so
 # the harness schema can't drift from cerberus's own DDL.
 #
 # Usage:
-#   ./scripts/run-compatibility.sh
+#   ./scripts/run-prometheus-compatibility.sh
 # or:
 #   docker compose up --wait
 #   go run ./compatibility/prometheus/cmd/seed/
@@ -21,7 +21,7 @@
 
 # Empty suffix in a primary checkout (and in CI); a per-worktree one otherwise,
 # so two checkouts don't share one stack. See scripts/compose-project-suffix.sh.
-name: cerberus-compatibility${COMPOSE_PROJECT_SUFFIX:-}
+name: cerberus-prometheus-compatibility${COMPOSE_PROJECT_SUFFIX:-}
 
 services:
   clickhouse:

--- a/compatibility/prometheus/scripts/run-prometheus-compatibility.sh
+++ b/compatibility/prometheus/scripts/run-prometheus-compatibility.sh
@@ -28,7 +28,7 @@
 # fix at the source.
 #
 # Usage:
-#   ./compatibility/prometheus/scripts/run-compatibility.sh        full lifecycle
+#   ./compatibility/prometheus/scripts/run-prometheus-compatibility.sh        full lifecycle
 #   COMPOSE_KEEP=1 ./...                                 leave stack up after run
 #
 # Env:

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -293,7 +293,7 @@ protecting.
 
 The `compatibility/prometheus-forced-route` lane additionally
 **hard-fails on any parity diff** (`FAIL_ON_DIFF=1` in
-`run-compatibility.sh`) as the corpus-wide proof that the sharded solver
+`run-prometheus-compatibility.sh`) as the corpus-wide proof that the sharded solver
 route is byte-identical to reference Prometheus; it is a required check, so
 every non-docs-only PR is gated on the full forced-route corpus run.
 


### PR DESCRIPTION
Closes #1437.

The workflow half of the compat-`<QL>` rename landed in #527. The compose/script half did not: the prometheus head was left with the unqualified project name `cerberus-compatibility` (vs `cerberus-loki-compatibility` / `cerberus-tempo-compatibility`) and `run-compatibility.sh` (vs `run-loki-…` / `run-tempo-…`). An unqualified project name is the exact shape that collides across concurrent checkouts.

## Changes
- `compatibility/prometheus/docker-compose.yml`: `cerberus-compatibility` → `cerberus-prometheus-compatibility`
- `compatibility/prometheus/scripts/run-compatibility.sh` → `run-prometheus-compatibility.sh` (rename + internal self-ref update)
- `.github/workflows/compatibility.yml`: both call sites updated
- `.github/scripts/assert-image-jobs-authenticate.test.mjs`: pin updated
- `compatibility/loki/scripts/run-loki-compatibility.sh`: mirror-ref comment updated
- `docs/compatibility.md`: script reference updated
- `Justfile`: both recipe invocations updated