### PR TITLE
fix(ci): unbreak the compatibility gate by making the scan set one list

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -109,9 +109,13 @@ uncomputable-diff fallback — cannot drift between the lanes that use it.
   - Env: `AGPL_CLEAN_PACKAGE` (optional; default `./cmd/cerberus`).
   - Exit: `0` clean; `1` on a violation. ENFORCING (a violation fails CI) and a
     required status check on `main`.
-- **`forbid-skip.mjs`** — `ci.yml`, the `forbid-skip` discipline scans.
-  - Env: `CHECK` is one of `t-skip`, `not-implemented`,
-    `soft-assert`, `should-skip`, `escape-hatch`, `feature-discipline`.
+- **`forbid-skip.mjs`** — `ci.yml`, the `forbid-skip` discipline scans;
+  `compatibility.yml`, the cheap-first `gate`.
+  - Env: `CHECK` is `all` (every scan, in registry order) or one of `t-skip`,
+    `soft-assert`, `should-skip`, `escape-hatch`, `feature-discipline`. The
+    `CHECKS` registry in the script is the one list — `all` iterates it, and
+    `doc-counts.mjs` asserts every workflow `CHECK:` value names a live entry,
+    so a removed scan cannot leave a caller behind.
   - Exit: `0` clean, `1` on any banned pattern or bad `CHECK`.
 - **`forbid-deferral.mjs`** — `forbid-deferral.yml`, its own workflow. The prose
   sibling of `forbid-skip`: where that one rejects a test that declines to
@@ -262,19 +266,24 @@ uncomputable-diff fallback — cannot drift between the lanes that use it.
   they describe. It derives each count LIVE — NOT from a hardcoded literal
   (which would just relocate the staleness) — and asserts every matching
   prose claim equals it:
-  - **forbid-skip CHECK count** — parses the `case '<name>':` arms of the
-    `CHECK` switch in `forbid-skip.mjs` (today: 5 — `t-skip`,
-    `not-implemented`, `soft-assert`, `should-skip`, `escape-hatch`) and
-    asserts the "N checks / scans / CHECK categories" claims in
-    `docs/forbid-skip.md` match. The doc distinguishes the 7 regex pattern
-    ROWS from the 5 dispatched scans; the gate keys on the scan/check
-    vocabulary, never the ambiguous bare "patterns".
+  - **forbid-skip CHECK count** — parses the keys of the `CHECKS` registry in
+    `forbid-skip.mjs` (today: 5 — `t-skip`, `soft-assert`, `should-skip`,
+    `escape-hatch`, `feature-discipline`) and asserts the "N checks / scans /
+    CHECK categories" claims in `docs/forbid-skip.md` match. The doc
+    distinguishes the 7 regex pattern ROWS from the 5 dispatched scans; the
+    gate keys on the scan/check vocabulary, never the ambiguous bare
+    "patterns".
+  - **forbid-skip workflow callers** — parses every `CHECK:` value the
+    workflows hand `forbid-skip.mjs` and asserts each names a live registry
+    entry (or `all`). Not cosmetic: an unknown `CHECK` exits 1, and
+    `compatibility.yml`'s `gate` is `needs:` for all three required
+    compatibility heads, so one stale caller reds every PR in the repo.
   - **test-layer count** — counts the DISTINCT integer layer numbers across
-    the `### Layer N[sub]` headings in `docs/test-strategy.md` (1..13,
-    collapsing 2a/2b/6d/7b to their integer = 13) and asserts the
+    the `### Layer N[sub]` headings in `docs/test-strategy.md` (1..14,
+    collapsing 2a/2b/6d/7b to their integer = 14) and asserts the
     "N-layer test map" / "tested in N layers" claims in `CLAUDE.md`,
     `docs/test-strategy.md`, and `README.md` match.
-  - Counts are parsed from the actual structures (switch arms / markdown
+  - Counts are parsed from the actual structures (registry keys / markdown
     headings), never from a string match on the prose they validate, so a
     doc can only go green by matching reality.
   - **`--self-test`** is a meta-test that feeds the derivers / extractors

--- a/.github/scripts/doc-counts.mjs
+++ b/.github/scripts/doc-counts.mjs
@@ -7,15 +7,14 @@
 // so a count can never silently drift. It is assert-from-source, NOT a pinned
 // literal (which would just relocate the staleness into a second place).
 //
-// Three assertions:
+// Four assertions:
 //
 //   1. forbid-skip CHECK count — the canonical number of discipline scans is
-//      the number of `case '<name>':` arms actually dispatched by the CHECK
-//      switch in .github/scripts/forbid-skip.mjs (today: t-skip,
-//      not-implemented, soft-assert, should-skip, escape-hatch,
-//      feature-discipline = 6). The gate
+//      the number of entries in the CHECKS registry in
+//      .github/scripts/forbid-skip.mjs (today: t-skip, soft-assert,
+//      should-skip, escape-hatch, feature-discipline = 5). The gate
 //      asserts every "N ... checks/scans/patterns" claim in
-//      docs/forbid-skip.md matches that live arm count.
+//      docs/forbid-skip.md matches that live registry size.
 //
 //   2. test-layer count — the canonical number of test layers is the count of
 //      DISTINCT integer layer numbers across the `### Layer N` subsection
@@ -32,6 +31,12 @@
 //      exactly one floor per head and that each matches the baseline, so
 //      bumping a floor cannot leave the explanation behind.
 //
+//   4. forbid-skip workflow callers — every `CHECK:` value any workflow hands
+//      forbid-skip.mjs must name a live registry entry (or `all`). A stale
+//      caller is not cosmetic drift: the invocation exits 1, and since the
+//      compatibility lane's `gate` is `needs:` for all three required
+//      compatibility heads, it reds every PR in the repository until fixed.
+//
 // Robustness: each count is parsed from the actual structure (switch arms /
 // markdown headings), never from a string match on the prose it validates, so
 // a doc edit can only make the gate go green by matching reality.
@@ -45,7 +50,7 @@
 // Exit codes: 0 = every doc count matches source, 1 = a drift was found (or a
 // self-test that should have failed did not).
 
-import { readFileSync } from 'node:fs';
+import { readFileSync, readdirSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import process from 'node:process';
@@ -61,22 +66,50 @@ const CLAUDE_DOC = join(REPO, 'CLAUDE.md');
 const README_DOC = join(REPO, 'README.md');
 const COMPAT_RATCHET_MJS = join(HERE, 'compat-ratchet.mjs');
 const PARITY_BASELINE = join(REPO, 'compatibility', 'parity-baseline.json');
+const WORKFLOWS_DIR = join(REPO, '.github', 'workflows');
+
+// The dispatch mode that runs every registered scan; a legal CHECK value that is
+// deliberately not a registry entry. Mirrors `ALL` in forbid-skip.mjs.
+const FORBID_SKIP_ALL_MODE = 'all';
 
 // --- source-count derivations (the "from source" half) ---------------------
 
 // countForbidSkipChecks — the live number of discipline scans is the number of
-// `case '<name>':` arms in forbid-skip.mjs's CHECK switch. We parse the case
-// labels (not a hardcoded list) so adding/removing a scan moves the count
-// automatically. The trailing `default:` arm is the error path, not a scan.
+// entries in forbid-skip.mjs's CHECKS registry. We parse the registry keys (not
+// a hardcoded list) so adding/removing a scan moves the count automatically.
+// `all` is a dispatch mode over the registry, not an entry in it, so it does not
+// count.
 export function countForbidSkipChecks(src) {
   const names = [];
-  // Match `case 'name': {` — single-quoted string label arms only.
-  const re = /\bcase\s+'([a-z][a-z0-9-]*)'\s*:/g;
+  // Match a registry entry — `  'name': () => {` at the object's own indent.
+  const re = /^ {2}'([a-z][a-z0-9-]*)':\s*\(\)\s*=>\s*\{/gm;
   let m;
   while ((m = re.exec(src)) !== null) {
     names.push(m[1]);
   }
   return { count: names.length, names };
+}
+
+// forbidSkipCallers — every `CHECK: <value>` a workflow hands forbid-skip.mjs.
+// A caller naming a scan the registry does not define is a HARD error at runtime
+// (`unknown CHECK`), and because the compatibility lane's `gate` is `needs:` for
+// all three required compatibility heads, one stale caller reds every PR in the
+// repository. That is exactly how #1538's scan removal shipped: ci.yml dropped
+// its step, compatibility.yml kept a copy. Parsing the callers back out of the
+// YAML closes the loop — a removed scan now fails HERE, on the PR that removes
+// it, naming the file still asking for it.
+export function forbidSkipCallers(workflows) {
+  const callers = [];
+  // A `run: node .github/scripts/forbid-skip.mjs` step followed by its `env:`
+  // block; the CHECK value is the next `CHECK:` within that step.
+  const re = /forbid-skip\.mjs[^\n]*\n(?:[^\n]*\n){0,3}?\s*CHECK:\s*([a-z][a-z0-9-]*)/g;
+  for (const { path, name, src } of workflows) {
+    let m;
+    while ((m = re.exec(src)) !== null) {
+      callers.push({ check: m[1], path, name });
+    }
+  }
+  return callers;
 }
 
 // countTestLayers — the live number of test layers is the count of DISTINCT
@@ -224,6 +257,47 @@ function assertParityFloors() {
   return ok;
 }
 
+// assertForbidSkipCallers checks every workflow `CHECK:` value against the live
+// registry. `all` is the dispatch-over-the-registry mode, so it is always valid;
+// anything else must name a registered scan.
+// `report` is the failure sink — the real run annotates via `error()`, the
+// self-test passes a no-op so proving the gate REJECTS a stale caller does not
+// post an ::error:: annotation on an otherwise-green job.
+export function assertForbidSkipCallers(names, callers, report = error) {
+  const known = new Set([...names, FORBID_SKIP_ALL_MODE]);
+  let ok = true;
+  for (const { check, name } of callers) {
+    if (!known.has(check)) {
+      report(
+        `forbid-skip-callers: ${name} passes CHECK="${check}", which forbid-skip.mjs ` +
+          `does not define (live scans: ${names.join(', ')}; plus "${FORBID_SKIP_ALL_MODE}"). ` +
+          `That invocation exits 1 at runtime — remove the step or point it at a live scan`,
+        { file: name },
+      );
+      ok = false;
+    }
+  }
+  if (callers.length === 0) {
+    report(
+      'forbid-skip-callers: found ZERO forbid-skip.mjs invocations across ' +
+        '.github/workflows — the discipline gate is not wired into CI at all',
+    );
+    ok = false;
+  }
+  return ok;
+}
+
+function readWorkflows() {
+  return readdirSync(WORKFLOWS_DIR)
+    .filter((f) => f.endsWith('.yml') || f.endsWith('.yaml'))
+    .sort()
+    .map((f) => ({
+      path: join(WORKFLOWS_DIR, f),
+      name: `.github/workflows/${f}`,
+      src: readFileSync(join(WORKFLOWS_DIR, f), 'utf8'),
+    }));
+}
+
 function runAssertions() {
   const forbidSrc = readFileSync(FORBID_SKIP_MJS, 'utf8');
   const { count: fsCount, names: fsNames } = countForbidSkipChecks(forbidSrc);
@@ -253,10 +327,18 @@ function runAssertions() {
 
   const parityOk = assertParityFloors();
 
-  if (forbidOk && layerOk && parityOk) {
+  const callers = forbidSkipCallers(readWorkflows());
+  log(
+    `forbid-skip workflow callers (live): ${callers.length} ` +
+      `[${callers.map((c) => `${c.name}:${c.check}`).join(', ')}]`,
+  );
+  const callersOk = assertForbidSkipCallers(fsNames, callers);
+
+  if (forbidOk && layerOk && parityOk && callersOk) {
     notice(
       `doc-counts: all doc-stated counts match source ` +
-        `(forbid-skip=${fsCount}, test-layers=${layerCount}, parity floors match the baseline)`,
+        `(forbid-skip=${fsCount}, test-layers=${layerCount}, parity floors match the baseline, ` +
+        `${callers.length} workflow CHECK callers all name a live scan)`,
     );
     return 0;
   }
@@ -279,22 +361,56 @@ function selfTest() {
     }
   };
 
-  // 1. The deriver counts real switch arms, not the default error path.
+  // 1. The deriver counts real registry entries, not the dispatch machinery.
   const fakeForbid = [
-    'switch (CHECK) {',
-    "  case 'a': { break; }",
-    "  case 'b': { break; }",
-    "  case 'c': { break; }",
-    '  default: process.exit(1);',
-    '}',
+    'const CHECKS = {',
+    "  'a': () => { fail('a'); },",
+    "  'b': () => { fail('b'); },",
+    "  'c': () => { fail('c'); },",
+    '};',
+    "if (CHECK === ALL) { for (const [name, scan] of Object.entries(CHECKS)) { scan(); } }",
+    "else if (Object.hasOwn(CHECKS, CHECK)) { CHECKS[CHECK](); }",
   ].join('\n');
   const { count: fakeCount, names } = countForbidSkipChecks(fakeForbid);
-  check('forbid-skip deriver counts 3 arms from a 3-arm switch', fakeCount === 3);
-  check('forbid-skip deriver ignores the default arm', !names.includes('default'));
+  check('forbid-skip deriver counts 3 entries from a 3-entry registry', fakeCount === 3);
+  check('forbid-skip deriver ignores the all-mode dispatch', !names.includes(FORBID_SKIP_ALL_MODE));
 
   // The REAL forbid-skip.mjs must derive exactly 5 (not-implemented removed in #1538).
   const realForbid = readFileSync(FORBID_SKIP_MJS, 'utf8');
-  check('real forbid-skip.mjs derives 5 CHECK arms', countForbidSkipChecks(realForbid).count === 5);
+  check('real forbid-skip.mjs derives 5 CHECK scans', countForbidSkipChecks(realForbid).count === 5);
+
+  // 1b. A workflow caller naming a scan the registry does not define must be
+  // REJECTED — the #1538 failure mode, where compatibility.yml kept asking for
+  // a deleted scan and reded every PR's compatibility heads.
+  const staleWorkflow = [
+    {
+      path: 'fake',
+      name: '.github/workflows/fake.yml',
+      src: [
+        '      - name: Reject a deleted scan',
+        '        run: node .github/scripts/forbid-skip.mjs',
+        '        env:',
+        '          CHECK: not-implemented',
+      ].join('\n'),
+    },
+  ];
+  const staleCallers = forbidSkipCallers(staleWorkflow);
+  check(
+    'caller parser extracts CHECK from a workflow step',
+    staleCallers.length === 1 && staleCallers[0].check === 'not-implemented',
+  );
+  check(
+    'caller gate would REJECT a workflow asking for a deleted scan',
+    !assertForbidSkipCallers(['t-skip', 'soft-assert'], staleCallers, () => {}),
+  );
+  check(
+    'caller gate ACCEPTS the all-mode dispatch value',
+    assertForbidSkipCallers(
+      ['t-skip'],
+      [{ check: FORBID_SKIP_ALL_MODE, name: 'fake.yml' }],
+      () => {},
+    ),
+  );
 
   // 2. A doc that claims the WRONG forbid-skip count must be REJECTED.
   const draftDoc = 'The gate has **7** patterns total.';

--- a/.github/scripts/forbid-skip.mjs
+++ b/.github/scripts/forbid-skip.mjs
@@ -14,7 +14,7 @@
 // in the same change — the self-test is the contract.
 //
 // Env contract:
-//   CHECK  one of:
+//   CHECK  `all` (run every scan below, in registry order), or one of:
 //     t-skip            Reject t.Skip / t.Skipf / t.SkipNow in *_test.go
 //     soft-assert       Reject soft-assertion / silent-recover patterns
 //     should-skip       Reject non-empty should_skip: overlay entries
@@ -68,8 +68,13 @@ function fail(message) {
   process.exit(1);
 }
 
-switch (CHECK) {
-  case 't-skip': {
+// CHECKS — the registry of discipline scans, keyed by $CHECK. This is the
+// single source of truth for the scan set: `all` iterates it, the unknown-CHECK
+// error enumerates it, and doc-counts.mjs derives both the doc-stated scan count
+// and the workflow-caller assertion from these keys. A scan added or removed
+// here therefore cannot leave a stale caller or a stale doc behind.
+const CHECKS = {
+  't-skip': () => {
     const { matched, output } = grepFiles({
       pathspecs: ['*_test.go', ':!:compatibility/*/upstream/**'],
       grepFlags: ['-nE'],
@@ -79,10 +84,9 @@ switch (CHECK) {
       log(output);
       fail('t.Skip / t.Skipf / t.SkipNow found in test files — fix the bug, do not skip');
     }
-    break;
-  }
+  },
 
-  case 'soft-assert': {
+  'soft-assert': () => {
     let bad = false;
     const softAssert = grepFiles({
       pathspecs: ['*_test.go', ':!:compatibility/*/upstream/**'],
@@ -109,10 +113,9 @@ switch (CHECK) {
         'soft-assertion or silent-recover pattern found — replace assert.Contains(x, "") with the actual substring, replace assert.ElementsMatch(x, []T{}) with len(x) == 0, replace defer recover() / defer func(){_ = recover()}() with assert.Panics(t, func(){...}, "reason")',
       );
     }
-    break;
-  }
+  },
 
-  case 'should-skip': {
+  'should-skip': () => {
     const matches = perlSlurp({
       pathspecs: [
         'compatibility/**/*.yml',
@@ -128,10 +131,9 @@ switch (CHECK) {
         'non-empty should_skip overlay entry found. The consumer code was removed in the structural-cleanup PR; entries here are silently ignored. Fix the underlying bug instead of skipping the case.',
       );
     }
-    break;
-  }
+  },
 
-  case 'escape-hatch': {
+  'escape-hatch': () => {
     const { matched, output } = grepFiles({
       pathspecs: [
         '*.ts',
@@ -152,10 +154,9 @@ switch (CHECK) {
         'test escape-hatch pattern found. Every assertion must fail loud; never mask a failure with an allow-list / tolerance / soft-assert. Fix the bug at the source (cerberus code, seed, dashboard, panel).',
       );
     }
-    break;
-  }
+  },
 
-  case 'feature-discipline': {
+  'feature-discipline': () => {
     let bad = false;
     // A Cucumber runner's default is to report an unimplemented step as
     // *pending* and carry on — a skip wearing a hat. A scenario-suppressing
@@ -194,12 +195,27 @@ switch (CHECK) {
         'a scenario-suppressing tag or a godog skip/pending route was found. A scenario runs and asserts, or it is deleted — @wip / @skip / @ignore / @manual / @todo / @pending and godog.ErrSkip / godog.ErrPending / T(ctx).Skip are t.Skip wearing a hat. Fix the scenario or remove it.',
       );
     }
-    break;
-  }
+  },
+};
 
-  default:
-    error(`forbid-skip.mjs: unknown CHECK="${CHECK}" (expected one of: t-skip, soft-assert, should-skip, escape-hatch, feature-discipline)`);
-    process.exit(1);
+// `all` runs every registered scan in one invocation, in registry order. It is
+// for callers that want the whole discipline set without enumerating it (the
+// compatibility lane's cheap-first `gate`); ci.yml keeps one named step per scan
+// so a failure is identifiable from the job graph alone.
+const ALL = 'all';
+
+if (CHECK === ALL) {
+  for (const [name, scan] of Object.entries(CHECKS)) {
+    log(`forbid-skip: ${name}`);
+    scan();
+  }
+} else if (Object.hasOwn(CHECKS, CHECK)) {
+  CHECKS[CHECK]();
+} else {
+  error(
+    `forbid-skip.mjs: unknown CHECK="${CHECK}" (expected ${ALL}, or one of: ${Object.keys(CHECKS).join(', ')})`,
+  );
+  process.exit(1);
 }
 
 // Reached only on a clean scan. The original bash printed nothing on pass;

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -177,30 +177,18 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
 
-      # The five discipline scans (pure `git grep` / `perl`, no Go
-      # toolchain) — byte-identical to ci.yml's `forbid-skip` job. These
-      # run first because they are the cheapest and the most common
-      # cause of a red PR.
-      - name: Reject t.Skip in test files
+      # Every discipline scan (pure `git grep` / `perl`, no Go toolchain),
+      # run first because they are the cheapest and the most common cause
+      # of a red PR. `CHECK: all` iterates forbid-skip.mjs's own registry
+      # rather than re-listing the scans here: an enumerated copy of the
+      # set drifted from ci.yml in BOTH directions before this — it still
+      # named the `not-implemented` scan #1538 deleted (a hard error that
+      # failed `gate`, and with it every compatibility head) while never
+      # having gained `feature-discipline`. The registry is the one list.
+      - name: Reject every discipline-scan violation
         run: node .github/scripts/forbid-skip.mjs
         env:
-          CHECK: t-skip
-      - name: Reject "not implemented" in production code
-        run: node .github/scripts/forbid-skip.mjs
-        env:
-          CHECK: not-implemented
-      - name: Reject soft-assertion / silent-recover patterns
-        run: node .github/scripts/forbid-skip.mjs
-        env:
-          CHECK: soft-assert
-      - name: Reject should_skip overlay entries
-        run: node .github/scripts/forbid-skip.mjs
-        env:
-          CHECK: should-skip
-      - name: Reject test escape-hatch patterns
-        run: node .github/scripts/forbid-skip.mjs
-        env:
-          CHECK: escape-hatch
+          CHECK: all
 
       # Compile sanity check. Far cheaper than `go test -race` (ci.yml's
       # `check`), but catches a non-building tree before the Docker heads


### PR DESCRIPTION
## What broke

`gate` in `compatibility.yml` still passed `CHECK: not-implemented` — the scan #1538 removed from `forbid-skip.mjs` (merged as #1619). The script exits 1 on an unknown `CHECK`, and `gate` is `needs:` for `compatibility/{prometheus,loki,tempo}` (three required status checks), so **every open PR was blocked**: #1621, #1622, #1624 all show `gate FAILURE`, and the heads they gate never ran.

```
::error::forbid-skip.mjs: unknown CHECK="not-implemented"
         (expected one of: t-skip, soft-assert, should-skip, escape-hatch, feature-discipline)
```

## The defect is the second copy of the list

`compatibility.yml` re-enumerated the scan set that `ci.yml` already enumerates, so it could drift — and had, in **both** directions: it named the deleted `not-implemented` scan, and it had never gained `feature-discipline`. Removing one stale line would leave the class intact.

- **`forbid-skip.mjs`** — the `CHECK` switch becomes a `CHECKS` registry, plus an `all` mode that iterates it. The registry is now the single source of the scan set: `all` dispatches from it, the unknown-`CHECK` error enumerates it, and `doc-counts.mjs` derives from it.
- **`compatibility.yml`** — `gate` runs one `CHECK: all` step instead of re-listing the scans. This also restores the `feature-discipline` coverage the copy never had.
- **`doc-counts.mjs`** — a fourth assertion parses every `CHECK:` value the workflows hand `forbid-skip.mjs` back out of `.github/workflows/` and fails when one names no live registry entry. The next scan removal therefore fails on its own PR, naming the file still asking for it.

`ci.yml` keeps one named step per scan on purpose — a discipline failure stays identifiable from the job graph without opening logs. It is covered by the new caller assertion either way.

## Verification

Ran locally in a clean worktree off `origin/main`:

- `CHECK=all` → runs all five scans in registry order, exit 0.
- `CHECK=not-implemented` → the improved error naming `all` + the five live scans, exit 1.
- `CHECK=t-skip` (and each other name) → unchanged behaviour, exit 0.
- `doc-counts.mjs` → `forbid-skip CHECK arms (live): 5`, `6 workflow CHECK callers all name a live scan` (5× `ci.yml`, 1× `compatibility.yml:all`), exit 0.
- `doc-counts.mjs --self-test` → 19/19 meta-assertions pass, including the three new ones: the caller parser extracts a `CHECK` from a workflow step, the gate **rejects** a workflow asking for a deleted scan (fed the exact `not-implemented` value that shipped), and it accepts `all`.

The self-test's deliberate-failure case passes a no-op reporter so proving rejection does not post an `::error::` annotation on a green job.

## Also swept in this change

Drift left behind by the same removal, all in files this PR already touches:

- `doc-counts.mjs`'s own header still described a 6-scan set including `not-implemented`.
- `.github/scripts/README.md` listed `not-implemented` in the `forbid-skip.mjs` env contract, described the deriver as reading `case` arms, and stated the test-layer count as 13 against a live 14.