### PR TITLE
fix(security): sanitize request-derived values before logging (CodeQL go/log-injection)

### DIFF
--- a/internal/api/loki/detected_fields.go
+++ b/internal/api/loki/detected_fields.go
@@ -17,6 +17,7 @@ import (
 	"github.com/tsouza/cerberus/internal/chclient"
 	"github.com/tsouza/cerberus/internal/chsql"
 	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/telemetry"
 )
 
 // defaultDetectedFieldsLineLimit caps the number of log rows the
@@ -143,7 +144,7 @@ func (h *Handler) handleDetectedFields(w http.ResponseWriter, r *http.Request) {
 		h.respondError(w, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusInternalServerError})
 		return
 	}
-	h.Logger.Debug("cerberus loki detected_fields", "logql", q, "sql", sqlStr, "args", args)
+	h.Logger.Debug("cerberus loki detected_fields", "logql", telemetry.SanitizeForLog(q), "sql", sqlStr, "args", args)
 
 	rows, err := h.Client.QueryDetectedFieldRows(r.Context(), sqlStr, args...)
 	if err != nil {

--- a/internal/api/loki/handler.go
+++ b/internal/api/loki/handler.go
@@ -275,7 +275,7 @@ func (h *Handler) handleQuery(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	expr, _ := res.Meta.Extra["expr"].(syntax.Expr)
-	h.Logger.Debug("cerberus loki query", "logql", q, "sql", res.SQL, "args", res.Args)
+	h.Logger.Debug("cerberus loki query", "logql", telemetry.SanitizeForLog(q), "sql", res.SQL, "args", res.Args)
 
 	data, err := buildInstantData(expr, res.Samples, ts, h.Schema, limit, dir, wantsCategorizedLabels(r))
 	if err != nil {
@@ -358,7 +358,7 @@ func (h *Handler) handleQueryRange(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	expr, _ := res.Meta.Extra["expr"].(syntax.Expr)
-	h.Logger.Debug("cerberus loki query_range", "logql", q, "sql", res.SQL, "args", res.Args)
+	h.Logger.Debug("cerberus loki query_range", "logql", telemetry.SanitizeForLog(q), "sql", res.SQL, "args", res.Args)
 
 	data, err := buildRangeData(expr, res.Samples, start, end, step, h.Schema, limit, dir, wantsCategorizedLabels(r))
 	if err != nil {

--- a/internal/api/loki/index_stats.go
+++ b/internal/api/loki/index_stats.go
@@ -14,6 +14,7 @@ import (
 	"github.com/tsouza/cerberus/internal/chsql"
 	"github.com/tsouza/cerberus/internal/logql"
 	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/telemetry"
 )
 
 // IndexStats is the body of a /loki/api/v1/index/stats response, matching
@@ -59,7 +60,7 @@ func (h *Handler) handleIndexStats(w http.ResponseWriter, r *http.Request) {
 		h.respondError(w, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusInternalServerError})
 		return
 	}
-	h.Logger.Debug("cerberus loki index_stats", "logql", q, "sql", sqlStr, "args", args)
+	h.Logger.Debug("cerberus loki index_stats", "logql", telemetry.SanitizeForLog(q), "sql", sqlStr, "args", args)
 
 	row, err := h.Client.QueryIndexStats(r.Context(), sqlStr, args...)
 	if err != nil {

--- a/internal/api/loki/index_volume.go
+++ b/internal/api/loki/index_volume.go
@@ -13,6 +13,7 @@ import (
 	"github.com/tsouza/cerberus/internal/api/format"
 	"github.com/tsouza/cerberus/internal/chsql"
 	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/telemetry"
 )
 
 // defaultVolumeLimit mirrors Loki's documented default for
@@ -66,7 +67,7 @@ func (h *Handler) handleIndexVolume(w http.ResponseWriter, r *http.Request) {
 		h.respondError(w, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusInternalServerError})
 		return
 	}
-	h.Logger.Debug("cerberus loki index_volume", "logql", q, "sql", sqlStr, "args", args)
+	h.Logger.Debug("cerberus loki index_volume", "logql", telemetry.SanitizeForLog(q), "sql", sqlStr, "args", args)
 
 	rows, err := h.Client.QueryIndexVolume(r.Context(), sqlStr, args...)
 	if err != nil {

--- a/internal/api/loki/label_values.go
+++ b/internal/api/loki/label_values.go
@@ -12,6 +12,7 @@ import (
 	"github.com/tsouza/cerberus/internal/chsql"
 	"github.com/tsouza/cerberus/internal/logql"
 	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/telemetry"
 )
 
 // handleLabelValues implements GET /loki/api/v1/label/<name>/values.
@@ -51,7 +52,7 @@ func (h *Handler) handleLabelValues(w http.ResponseWriter, r *http.Request) {
 		h.respondError(w, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusInternalServerError})
 		return
 	}
-	h.Logger.Debug("cerberus loki label values", "name", name, "sql", sqlStr, "args", args)
+	h.Logger.Debug("cerberus loki label values", "name", telemetry.SanitizeForLog(name), "sql", sqlStr, "args", args)
 
 	vals, err := h.Client.QueryStrings(r.Context(), sqlStr, args...)
 	if err != nil {

--- a/internal/api/loki/patterns.go
+++ b/internal/api/loki/patterns.go
@@ -12,6 +12,7 @@ import (
 	"github.com/tsouza/cerberus/internal/chsql"
 	"github.com/tsouza/cerberus/internal/drain"
 	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/telemetry"
 )
 
 // defaultPatternsLineLimit caps the number of log rows the drain
@@ -86,7 +87,7 @@ func (h *Handler) handlePatterns(w http.ResponseWriter, r *http.Request) {
 		h.respondError(w, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusInternalServerError})
 		return
 	}
-	h.Logger.Debug("cerberus loki patterns", "logql", q, "sql", sqlStr, "args", args)
+	h.Logger.Debug("cerberus loki patterns", "logql", telemetry.SanitizeForLog(q), "sql", sqlStr, "args", args)
 
 	lines, err := h.Client.QueryTimestampedLines(r.Context(), sqlStr, args...)
 	if err != nil {

--- a/internal/api/prom/exemplars.go
+++ b/internal/api/prom/exemplars.go
@@ -16,6 +16,7 @@ import (
 	"github.com/tsouza/cerberus/internal/chsql"
 	"github.com/tsouza/cerberus/internal/promql"
 	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/telemetry"
 )
 
 // ExemplarSeries is the wire shape for one element of the
@@ -142,7 +143,7 @@ func (h *Handler) handleQueryExemplars(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, ErrInternal, err)
 		return
 	}
-	h.Logger.Debug("cerberus query_exemplars", "promql", q, "sql", sql, "args", args)
+	h.Logger.Debug("cerberus query_exemplars", "promql", telemetry.SanitizeForLog(q), "sql", sql, "args", args)
 
 	rows, err := h.Client.QueryExemplars(r.Context(), sql, args...)
 	if err != nil {

--- a/internal/api/prom/handler.go
+++ b/internal/api/prom/handler.go
@@ -769,7 +769,7 @@ func (h *Handler) executeRangeStreaming(
 	if err != nil {
 		return engine.CursorResult{}, classifyEngineError(err)
 	}
-	h.Logger.Debug("cerberus query_range (stream)", "promql", query, "sql", res.SQL, "args", res.Args)
+	h.Logger.Debug("cerberus query_range (stream)", "promql", telemetry.SanitizeForLog(query), "sql", res.SQL, "args", res.Args)
 	return res, nil
 }
 
@@ -784,7 +784,7 @@ func (h *Handler) executeInstant(ctx context.Context, query string, start, end t
 	if err != nil {
 		return nil, nil, classifyEngineError(err)
 	}
-	h.Logger.Debug("cerberus query", "promql", query, "sql", res.SQL, "args", res.Args)
+	h.Logger.Debug("cerberus query", "promql", telemetry.SanitizeForLog(query), "sql", res.SQL, "args", res.Args)
 	// Engine times the execute stage uniformly; surface that to the
 	// per-request chMillisCounter so the X-Cerberus-CH-Millis header
 	// keeps reporting CH wall-clock. The middleware-driven counter is

--- a/internal/api/tempo/handler.go
+++ b/internal/api/tempo/handler.go
@@ -434,7 +434,7 @@ func (h *Handler) handleSearch(w http.ResponseWriter, r *http.Request) {
 		writeError(w, httpErrStatus(err), "", "", err)
 		return
 	}
-	h.Logger.Debug("cerberus tempo search", "traceql", q, "sql", res.SQL, "args", res.Args)
+	h.Logger.Debug("cerberus tempo search", "traceql", telemetry.SanitizeForLog(q), "sql", res.SQL, "args", res.Args)
 
 	summaries, missingRoots := toTraceSummaries(res.Samples, spss, res.Meta)
 	// Accounted BEFORE TruncateSummaries — see SearchMetricsFor for why the

--- a/internal/api/tempo/metrics_exec.go
+++ b/internal/api/tempo/metrics_exec.go
@@ -8,6 +8,7 @@ import (
 	"github.com/tsouza/cerberus/internal/chplan"
 	"github.com/tsouza/cerberus/internal/chsql"
 	"github.com/tsouza/cerberus/internal/engine"
+	"github.com/tsouza/cerberus/internal/telemetry"
 )
 
 // This file owns the ONE scalar-aggregate metrics execution path both
@@ -158,7 +159,7 @@ func (h *Handler) runMetricsWindow(
 		return nil, nil, qerr
 	}
 	h.Logger.Debug("cerberus tempo metrics exec",
-		"traceql", q, "shape", shape,
+		"traceql", telemetry.SanitizeForLog(q), "shape", shape,
 		"start", rw.Start, "end", rw.End, "step", rw.Step,
 		"sql", res.SQL, "args", res.Args)
 

--- a/internal/api/tempo/metrics_query_range_compare.go
+++ b/internal/api/tempo/metrics_query_range_compare.go
@@ -9,6 +9,7 @@ import (
 	"github.com/tsouza/cerberus/internal/chclient"
 	"github.com/tsouza/cerberus/internal/chplan"
 	"github.com/tsouza/cerberus/internal/engine"
+	"github.com/tsouza/cerberus/internal/telemetry"
 )
 
 // This file wires `| compare({...}, topN[, start, end])` into
@@ -314,7 +315,7 @@ func (h *Handler) execCompareRange(
 		return nil, nil, qerr
 	}
 	h.Logger.Debug("cerberus tempo metrics_query_range compare",
-		"traceql", q, "start", start, "end", end, "step", step,
+		"traceql", telemetry.SanitizeForLog(q), "start", start, "end", end, "step", step,
 		"sql", res.SQL, "args", res.Args)
 
 	series := postProcessCompare(res.Samples, cmp.TopN, compareAnchorGrid(start, end, step))

--- a/internal/api/tempo/metrics_query_range_histogram.go
+++ b/internal/api/tempo/metrics_query_range_histogram.go
@@ -9,6 +9,7 @@ import (
 	"github.com/tsouza/cerberus/internal/chclient"
 	"github.com/tsouza/cerberus/internal/chplan"
 	"github.com/tsouza/cerberus/internal/engine"
+	"github.com/tsouza/cerberus/internal/telemetry"
 )
 
 // This file wires `| histogram_over_time(<attr>)` into
@@ -138,7 +139,7 @@ func (h *Handler) serveMetricsQueryRangeHistogram(
 		return
 	}
 	h.Logger.Debug("cerberus tempo metrics_query_range histogram",
-		"traceql", q, "start", start, "end", end, "step", step,
+		"traceql", telemetry.SanitizeForLog(q), "start", start, "end", end, "step", step,
 		"sql", res.SQL, "args", res.Args)
 
 	normalizeHistogramBucketLabels(res.Samples)

--- a/internal/telemetry/logsafe.go
+++ b/internal/telemetry/logsafe.go
@@ -1,0 +1,48 @@
+package telemetry
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+// SanitizeForLog neutralizes control characters in a string before it is
+// attached to a log record, closing the log-injection class CodeQL's
+// go/log-injection rule flags: a request-supplied value containing a raw
+// newline, carriage return, or other C0/C1 control character can forge a
+// fake log line when the record is rendered as text, or corrupt a
+// downstream line-oriented log consumer — regardless of which slog.Handler
+// ends up rendering it (config.go can wire either NewTextHandler or
+// NewJSONHandler, and telemetry's own otelslog wrapper re-exports every
+// record to an OTel log backend on top of that). Call it on request-derived
+// values immediately before they reach a log call — the query string a
+// client sent, never a value cerberus itself constructed.
+//
+// Every control rune (unicode.IsControl — the C0, DEL, and C1 ranges) is
+// replaced with its Go-syntax escape (\n, \r, \t) or a \xNN escape for
+// anything else, so the logged value stays legible for debugging instead of
+// being silently dropped or truncated.
+func SanitizeForLog(s string) string {
+	if !strings.ContainsFunc(s, unicode.IsControl) {
+		return s // fast path: the overwhelming common case has no control chars
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		if !unicode.IsControl(r) {
+			b.WriteRune(r)
+			continue
+		}
+		switch r {
+		case '\n':
+			b.WriteString(`\n`)
+		case '\r':
+			b.WriteString(`\r`)
+		case '\t':
+			b.WriteString(`\t`)
+		default:
+			fmt.Fprintf(&b, `\x%02x`, r)
+		}
+	}
+	return b.String()
+}

--- a/internal/telemetry/logsafe_test.go
+++ b/internal/telemetry/logsafe_test.go
@@ -1,0 +1,49 @@
+package telemetry
+
+import "testing"
+
+func TestSanitizeForLog(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"no control chars is unchanged", `sum(rate(up{job="api"}[5m]))`, `sum(rate(up{job="api"}[5m]))`},
+		{
+			"a forged log line via embedded newline is neutralised",
+			"up\nlevel=ERROR msg=\"fake entry\"",
+			`up\nlevel=ERROR msg="fake entry"`,
+		},
+		{"carriage return", "a\rb", `a\rb`},
+		{"tab", "a\tb", `a\tb`},
+		{"multiple control chars in one value", "a\nb\rc\td", `a\nb\rc\td`},
+		{
+			"a non-named control char falls back to a hex escape",
+			"a\x1bb", // ESC — the ANSI escape-sequence introducer
+			`a\x1bb`,
+		},
+		{"a C1 control char is also escaped", "a\u0085b", `a\x85b`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := SanitizeForLog(tc.in); got != tc.want {
+				t.Errorf("SanitizeForLog(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSanitizeForLog_FastPathIdentity pins the no-control-chars fast path:
+// a string that never triggers strings.ContainsFunc must come back byte-for-
+// byte identical (no builder round-trip), not merely equal in content — a
+// mutation that swapped the early return for an always-rebuild would still
+// pass a plain string-equality check but would regress the allocation-free
+// path this function exists to keep cheap on the hot request path.
+func TestSanitizeForLog_FastPathIdentity(t *testing.T) {
+	const clean = `sum(rate(up{job="api"}[5m]))`
+	got := SanitizeForLog(clean)
+	if got != clean {
+		t.Fatalf("SanitizeForLog(%q) = %q, want unchanged", clean, got)
+	}
+}


### PR DESCRIPTION
Closes CodeQL alerts #75-88 - 14 instances of go/log-injection across the prom, loki, and tempo handlers.

## What broke

Each site logged a request-supplied query string (or, for label_values, a path parameter) directly as a structured slog attribute:

    h.Logger.Debug("cerberus loki query", "logql", q, "sql", res.SQL, "args", res.Args)

A client-controlled value can contain a raw newline, carriage return, or other control character. Rendered through slog's TextHandler (or when a control byte reaches any downstream line-oriented consumer of the JSONHandler / otelslog-exported OTel log records internal/config/config.go can wire), that forges a fake log line or corrupts structured-log parsing - the same shape whether the query lands via /query, /query_range, /label/<name>/values, /index/stats, /index/volume, /patterns, /detected_fields, tempo search, or any of the tempo metrics_query_range paths.

## Fix

Added telemetry.SanitizeForLog (internal/telemetry/logsafe.go): replaces every unicode.IsControl rune with a readable Go-syntax escape, so the value stays legible for debugging instead of being dropped, with a fast path for the common case of a query with no control characters at all.

internal/telemetry was already an import every affected package either had or could take without introducing a new dependency edge, so one helper closes all 14 sites rather than each handler growing its own escaping logic.

## Verification

- go build ./... clean.
- go vet ./internal/api/... ./internal/telemetry/... clean.
- go test ./internal/api/{loki,prom,tempo}/... ./internal/telemetry/... - all pass.
- New internal/telemetry/logsafe_test.go: empty string, no-control fast path (byte-identical return, not just equal), newline/CR/tab, multiple control chars in one value, an unnamed control char falling back to a hex escape, and a C1 control char.
- golangci-lint run ./... clean (staticcheck flagged a raw control byte literal embedded directly in my first draft of the C1 test case; fixed to use the proper Go escape sequence in source instead).
