### PR TITLE
fix(ci): route build-with-registry-retry's argv through bash positionally

### DIFF
--- a/.github/scripts/build-with-registry-retry.mjs
+++ b/.github/scripts/build-with-registry-retry.mjs
@@ -92,18 +92,27 @@ const signalledChildStatus = 1;
 // Conventional shell status for "command could not be executed at all".
 const notExecutableStatus = 127;
 
-function shellQuote(word) {
-  return `'${String(word).replaceAll("'", "'\\''")}'`;
-}
-
 // runTeed — run argv with the parent's stdio, while also capturing everything
 // it wrote. Both halves matter: a container build streams its only progress
 // output for minutes, so swallowing it until the command returns would make a
 // stuck build unreadable, and the retry decision needs the text. `tee` through
 // bash with pipefail is what gives both plus the command's own exit status.
+//
+// argv reaches bash purely as POSITIONAL PARAMETERS ("$@"), and the log path
+// purely as an env var ($BUILD_RETRY_LOG_PATH) — neither is ever interpolated
+// into the script TEXT bash parses. That is a stronger guarantee than
+// quoting argv into the script string (this file's previous approach, via a
+// hand-rolled shellQuote): there is no script text left for a malicious argv
+// element to escape out of, so the question "is the quoting correct" doesn't
+// arise at all. The literal `bash` after `-c '...'` fills bash's own $0 slot
+// (POSIX: the first word after the script is $0, not $1), so `"$@"` starts
+// at the real argv[0].
 function runTeed(argv, logPath) {
-  const script = `set -o pipefail; ${argv.map(shellQuote).join(' ')} 2>&1 | tee ${shellQuote(logPath)}`;
-  const res = spawnSync('bash', ['-c', script], { stdio: 'inherit' });
+  const script = 'set -o pipefail; "$@" 2>&1 | tee "$BUILD_RETRY_LOG_PATH"';
+  const res = spawnSync('bash', ['-c', script, 'bash', ...argv], {
+    stdio: 'inherit',
+    env: { ...process.env, BUILD_RETRY_LOG_PATH: logPath },
+  });
 
   if (res.error) {
     return { status: notExecutableStatus, output: String(res.error.message) };

--- a/.github/scripts/build-with-registry-retry.test.mjs
+++ b/.github/scripts/build-with-registry-retry.test.mjs
@@ -1,0 +1,65 @@
+// build-with-registry-retry.test.mjs — node:test guard for runTeed's argv
+// handling.
+//
+// The module has no exported entrypoint (it runs its retry loop at module
+// top level off process.argv, by design — see its own header), so these
+// tests invoke the real script as a subprocess rather than importing its
+// internals. That is also the more meaningful test for a security-shaped
+// fix: it exercises exactly what CI actually runs, not a refactored stand-in.
+//
+// GO_IMAGE is set on every invocation so buildBaseImageArgs's "resolve the
+// mirror" step (a real `docker buildx imagetools inspect` probe) short-
+// circuits — these tests assert argv-safety, not mirror resolution, and
+// should not need Docker or network access to run.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT = fileURLToPath(new URL('./build-with-registry-retry.mjs', import.meta.url));
+
+function run(argv) {
+  return spawnSync('node', [SCRIPT, ...argv], {
+    encoding: 'utf8',
+    env: { ...process.env, GO_IMAGE: 'golang:1.26' },
+  });
+}
+
+test('a normal command runs, streams, and exits with its own status', () => {
+  const res = run(['echo', 'hello world']);
+  assert.equal(res.status, 0);
+  assert.match(res.stdout, /hello world/);
+});
+
+// The load-bearing case: an argv element shaped like a shell-metacharacter
+// payload must reach the command as a single literal argument, never as
+// shell syntax runTeed's own script text could be tricked into evaluating.
+// This is what the switch from a hand-quoted script string to bash's "$@"
+// positional-parameter form (this fix) makes true by construction, not by
+// the correctness of an escaping function.
+test('an argv element containing shell metacharacters is passed through literally, not interpreted', () => {
+  const payload = "it's a $(touch /tmp/should-not-exist-$$) `echo pwned` && echo also-pwned; echo semicolon";
+  const res = run(['echo', payload]);
+  assert.equal(res.status, 0);
+  // The whole payload comes back verbatim on one line — nothing in it ran.
+  assert.match(res.stdout, /it's a \$\(touch \/tmp\/should-not-exist-\$\$\) `echo pwned` && echo also-pwned; echo semicolon/);
+  assert.doesNotMatch(res.stdout, /^pwned$/m);
+  assert.doesNotMatch(res.stdout, /^also-pwned$/m);
+});
+
+test('a failing command exits with ITS status, not a masking failure from the tee pipeline', () => {
+  const res = run(['bash', '-c', 'echo partial-output; exit 42']);
+  assert.equal(res.status, 42);
+  assert.match(res.stdout, /partial-output/);
+});
+
+test('a genuine failure with no registry/network signal in its output fails on the first attempt', () => {
+  // isTransientRegistryFailure(output) is false for this output, so the
+  // module must not retry — a real bug must surface on attempt 1/N, not be
+  // hidden behind a wasted retry budget.
+  const res = run(['bash', '-c', 'echo not a registry problem; exit 3']);
+  assert.equal(res.status, 3);
+  // error() (lib/gh.mjs) writes the ::error:: workflow-command line to stdout.
+  assert.match(res.stdout, /failed with status 3.*no registry or network fault/s);
+});

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -685,6 +685,18 @@ jobs:
       - name: Assert the compose pre-pull fetches only fetchable images
         run: node --test .github/scripts/compose-pull-images.test.mjs
 
+      # runTeed's argv handling — every image-building command in the tree runs
+      # through it (see the module's own header). Pins that an argv element
+      # shaped like a shell-metacharacter payload reaches the command as a
+      # single literal argument rather than as shell syntax: argv reaches bash
+      # purely as positional parameters ("$@"), never interpolated into the
+      # script text bash parses, so there is no quoting-correctness question
+      # for a future edit to get wrong. Also pins pipefail (the real command's
+      # exit status survives the `| tee` pipe) and the no-retry-on-a-genuine-
+      # failure contract.
+      - name: Assert build-with-registry-retry runs argv safely
+        run: node --test .github/scripts/build-with-registry-retry.test.mjs
+
       # The GHCR mirror's inventory→ref mapping. A mapping bug is INVISIBLE at
       # runtime: `mirroredRef` returning null is the documented miss path, so a
       # broken mapping degrades every consumer back to the anonymous Docker Hub


### PR DESCRIPTION
Closes CodeQL alert #65 (js/indirect-command-line-injection).

## What broke

runTeed built a shell script STRING by mapping argv through a hand-rolled shellQuote() and joining it into `set -o pipefail; <quoted argv> 2>&1 | tee <quoted logPath>`, then ran it via spawnSync('bash', ['-c', script], ...).

shellQuote's escaping was itself correct (the standard replace-each-quote idiom), but that correctness is exactly what a static analyzer can't verify - and exactly what a future edit could get wrong without anyone noticing until it mattered. This module is the single choke point every image-building command in the tree runs through: docker build, docker compose up/build, three compatibility harnesses, the histogram bench.

## Fix

Rewrote runTeed so argv reaches bash purely as positional parameters ("$@") and the log path purely as an env var, never interpolated into the script TEXT bash parses. There is no script text left for a malicious argv element to escape out of, so the question "is the quoting correct" doesn't arise at all - a stronger guarantee than correct quoting, not just a different way to express the same one.

## Test

Added build-with-registry-retry.test.mjs. The module has no exported entrypoint by design (it runs its retry loop at module top level off process.argv), so this invokes the real script as a subprocess rather than importing a refactored stand-in - the more meaningful test for a security-shaped fix, since it exercises exactly what CI actually runs.

- a shell-metacharacter-shaped argv element (command substitution, backticks, &&, ;) reaches the command as one literal argument and nothing in it executes
- pipefail still surfaces the real command's exit status through the tee pipe, not tee's own status
- a genuine non-registry failure is not retried (fails loud on attempt 1)

Wired into ci.yml alongside the other script self-tests.

## Verification

- Manually verified the standalone runTeed logic against a literal injection payload before writing the test (confirmed it prints verbatim, nothing executes).
- node --test .github/scripts/build-with-registry-retry.test.mjs - 4/4 pass.
- node --check clean.
- golangci-lint run ./... clean (pre-push hook).
