### PR TITLE
test(traceql): widen property generator to 14 query shapes

### DIFF
--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -654,6 +654,29 @@ Each test:
 Failures shrink to a minimal repro via rapid's automatic shrinking and
 land in the standard test output.
 
+### Per-head generator breadth
+
+The `property` check's name (`property (PromQL + LogQL + TraceQL, rapid
+N=500)`) advertises all three heads, but nothing enforces that each
+leg's query generator actually draws a variety of shapes rather than
+one — a leg can sit at its first-sweep accept-set indefinitely while
+still reporting 500 green iterations, because every iteration is the
+same query shape wearing different literal values. Issue #1471 caught
+exactly this for TraceQL. This table is the per-head ledger so a
+stalled leg is visible without diffing generator source:
+
+| Head    | Generator                         | Shape count | Shapes                                                                                                                                                                                                                                                                                                    |
+| ------- | --------------------------------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| PromQL  | `gen/promql.go`'s `drawExpr`      | 5           | bare selector, `sum(...)`, `sum by(label)(...)`, `rate(...[range] offset d)`, `sum(rate(...))`                                                                                                                                                                                                            |
+| LogQL   | `gen/logql.go`'s `LogQLQuery`     | 6           | bare stream selector; line filter (contains / not-contains); `label_format` rename; IP line filter (contains / not-contains `ip(...)`); pattern line filter (contains / not-contains)                                                                                                                     |
+| TraceQL | `gen/traceql.go`'s `TraceQLQuery` | 14          | bare selector; `count()` filter; attribute matcher beyond service.name; span-attribute matcher; duration intrinsic; status intrinsic; name intrinsic; regex matcher; negated matcher; multi-condition (`&&`); structural child (`>`); structural descendant (`>>`); avg/min/max/sum(duration); `select()` |
+
+When a head's generator widens, update its row here in the same PR —
+the oracle under `test/property/oracle/<head>/` must already be able
+to evaluate every shape the generator draws before the shape lands
+(never the reverse), so this table doubles as a manifest of what the
+independent specification actually covers.
+
 ## Gremlins mutation
 
 `.gremlins.yaml` carries the floor for an unscoped whole-repo `just

--- a/test/property/gen/traceql.go
+++ b/test/property/gen/traceql.go
@@ -18,6 +18,44 @@ import (
 // matches multiple spans (predictable count() arithmetic).
 var TraceQLServicePool = []string{"api", "web", "batch"}
 
+// TraceQLClusterPool is the resource-attribute pool for "cluster" — a
+// second resource attribute alongside service.name, used to exercise
+// attribute matchers beyond resource.service.name.
+var TraceQLClusterPool = []string{"east", "west"}
+
+// TraceQLHTTPMethodPool is the span-attribute pool for "http.method",
+// used to exercise span-scope attribute matchers (`span.http.method`).
+// Deliberately a different pool than TraceQLSpanNamePool so a
+// coincidental value match between the two doesn't mask a real bug.
+var TraceQLHTTPMethodPool = []string{"GET", "POST", "PUT"}
+
+// TraceQLStatusPool is the intrinsic status pool, in the CH-stored
+// (title-case) form. TraceQL query literals are lowercase
+// (ok/error/unset); statusQueryLiteral bridges the two.
+var TraceQLStatusPool = []string{"Ok", "Error", "Unset"}
+
+// TraceQLDurationPoolNs is the fixed duration-bucket pool spans draw
+// from, in nanoseconds. Multiple distinct buckets give the duration
+// intrinsic and avg|min|max|sum(duration) filters real spread to
+// discriminate on, rather than every span sharing one fixed value.
+var TraceQLDurationPoolNs = []int64{10_000_000, 50_000_000, 120_000_000, 300_000_000}
+
+// TraceQLDurationThresholdPoolMs is the pool of millisecond thresholds
+// the query generator draws for duration comparisons (`duration OP
+// Nms`, `avg(duration) OP Nms`, …). Includes values that land exactly
+// on a TraceQLDurationPoolNs bucket and values that fall strictly
+// between buckets, so the boundary case is exercised too.
+var TraceQLDurationThresholdPoolMs = []int64{10, 50, 75, 120, 200, 300}
+
+// traceQLComparisonOps is the scalar-comparison operator pool shared by
+// every numeric filter the generator draws (count(), duration, and the
+// avg|min|max|sum(duration) metrics).
+var traceQLComparisonOps = []string{">", ">=", "<", "<=", "="}
+
+// traceQLEqualityOps is the equality/inequality operator pool for
+// intrinsics that only support (in)equality comparison (status).
+var traceQLEqualityOps = []string{"=", "!="}
+
 // TraceQLSpanNamePool is the fixed span-name pool. Each generated
 // span draws a name from this pool plus a per-span ordinal so the
 // (SpanName, Timestamp) pair is unique across the dataset (Tempo's
@@ -40,23 +78,43 @@ var traceQLAnchor = time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC)
 // generator anchors span timestamps to.
 func TraceQLAnchorTime() time.Time { return traceQLAnchor }
 
+// traceQLRootParentID is the all-zero ParentSpanId literal the OTel-CH
+// schema uses to mark a root span (no parent).
+const traceQLRootParentID = "0000000000000000"
+
+// traceQLMaxTraces / traceQLMaxChainDepth bound the dataset's trace
+// count and per-trace parent-chain depth. A linear chain (rather than
+// a branching tree) is enough to exercise both structural operators
+// the generator draws — `>` (immediate child) and `>>` (descendant at
+// any depth) — while keeping ancestor/descendant computation in the
+// oracle a simple walk up a unique parent chain, no general tree
+// algorithm required.
+const (
+	traceQLMaxTraces     = 3
+	traceQLMaxChainDepth = 3
+)
+
 // TraceQLDataset returns a rapid generator that draws a random
-// property.Dataset of OTel-CH traces rows. The dataset is intentionally
-// narrow for the first TraceQL property test:
+// property.Dataset of OTel-CH traces rows.
 //
-//   - 1–5 spans.
-//   - Each span carries a service.name from TraceQLServicePool stored
-//     under ResourceAttributes['service.name'].
+//   - 1–3 traces, each a linear parent→child chain of 1–3 spans (root
+//     first). The chain lets structural-operator queries (`>`, `>>`)
+//     exercise a real ancestor/descendant relationship instead of
+//     every span being trace-root.
+//   - Each span carries a resource.service.name (TraceQLServicePool),
+//     a second resource attribute resource.cluster (TraceQLClusterPool),
+//     and a span attribute span.http.method (TraceQLHTTPMethodPool) —
+//     the pool beyond service.name attribute matchers exercise.
 //   - Span names draw from TraceQLSpanNamePool plus a per-span ordinal
 //     suffix so (SpanName, Timestamp) pairs are unique across the
 //     dataset — Tempo's /api/search collapses traces by name+ts, and
 //     the property test wants one TraceSummary per span so the count
 //     comparator is exact.
-//   - Per-span StartTime is anchor + i*1s; Duration is fixed
-//     50 000 000 ns (50ms). The values don't matter to the selector +
-//     count() queries the generator produces.
-//   - StatusCode = "Unset" for every span (the only intrinsic the
-//     generator touches today).
+//   - Per-span StartTime is anchor + i*1s (i = the global span
+//     ordinal, unique across every trace); Duration and StatusCode
+//     draw from TraceQLDurationPoolNs / TraceQLStatusPool so the
+//     duration/status intrinsic filters have real spread to
+//     discriminate on.
 //
 // The returned Dataset's DDL is a multi-statement script
 // (`CREATE OR REPLACE TABLE otel_traces (...); INSERT ...;`) the chDB
@@ -65,42 +123,58 @@ func TraceQLAnchorTime() time.Time { return traceQLAnchor }
 // SeriesData entries with MetricName=SpanName, Labels carrying the
 // span-level + resource attributes via reserved key prefixes:
 //
-//   - "resource.<key>"  → ResourceAttributes[<key>]
-//   - "span.<key>"      → SpanAttributes[<key>] (unused today; reserved
-//     for span-scope matchers when the generator widens)
+//   - "resource.<key>"  → ResourceAttributes[<key>] (service.name, cluster)
+//   - "span.<key>"      → SpanAttributes[<key>] (http.method)
 //   - "__name__"        → SpanName (mirrors the PromQL convention; the
 //     oracle's labels-minus-__name__ identity rule reuses it)
-//   - "__traceID__"     → TraceID (unique 32-hex per span)
+//   - "__traceID__"     → TraceID (shared by every span in a trace's chain)
 //   - "__spanID__"      → SpanID (unique 16-hex per span)
+//   - "__parentSpanID__" → ParentSpanId (unique per chain: the
+//     preceding span's SpanID, or traceQLRootParentID for the chain root)
 //   - "__duration_ns__" → string-formatted Duration (so the oracle
 //     can read it without changing SeriesData's float64 Point shape)
-//   - "__status__"      → "Unset" (the seeded value)
+//   - "__status__"      → the CH-stored status literal (Ok/Error/Unset)
 //
 // MergeTree is the chosen engine (matches PromQL property test
 // rationale: Memory engine refuses PREWHERE the cerberus optimizer
 // emits).
 func TraceQLDataset() *rapid.Generator[property.Dataset] {
 	return rapid.Custom(func(t *rapid.T) property.Dataset {
-		numSpans := rapid.IntRange(1, 5).Draw(t, "numSpans")
-		spans := make([]traceQLSpan, 0, numSpans)
-		for i := 0; i < numSpans; i++ {
-			service := rapid.SampledFrom(TraceQLServicePool).Draw(t, fmt.Sprintf("service_%d", i))
-			baseName := rapid.SampledFrom(TraceQLSpanNamePool).Draw(t, fmt.Sprintf("spanName_%d", i))
-			// Unique suffix → unique (SpanName, Timestamp) across spans:
-			// Tempo's toTraceSummaries() keys by name+timestamp and collapses
-			// duplicates. Suffixing the span index is the cheapest way to
-			// guarantee uniqueness without adding a second random draw.
-			name := fmt.Sprintf("%s /api/%d", baseName, i)
-			spans = append(spans, traceQLSpan{
-				traceID:    deterministicTraceID(i, 0xa1),
-				spanID:     deterministicSpanID(i, 0xb2),
-				parentID:   "0000000000000000",
-				service:    service,
-				name:       name,
-				startTime:  traceQLAnchor.Add(time.Duration(i) * time.Second),
-				durationNs: 50_000_000,
-				statusCode: "Unset",
-			})
+		numTraces := rapid.IntRange(1, traceQLMaxTraces).Draw(t, "numTraces")
+		var spans []traceQLSpan
+		spanOrdinal := 0
+		for ti := 0; ti < numTraces; ti++ {
+			traceID := deterministicTraceID(ti, 0xa1)
+			chainDepth := rapid.IntRange(1, traceQLMaxChainDepth).Draw(t, fmt.Sprintf("chainDepth_%d", ti))
+			parentID := traceQLRootParentID
+			for ci := 0; ci < chainDepth; ci++ {
+				service := rapid.SampledFrom(TraceQLServicePool).Draw(t, fmt.Sprintf("service_%d_%d", ti, ci))
+				cluster := rapid.SampledFrom(TraceQLClusterPool).Draw(t, fmt.Sprintf("cluster_%d_%d", ti, ci))
+				httpMethod := rapid.SampledFrom(TraceQLHTTPMethodPool).Draw(t, fmt.Sprintf("httpMethod_%d_%d", ti, ci))
+				baseName := rapid.SampledFrom(TraceQLSpanNamePool).Draw(t, fmt.Sprintf("spanName_%d_%d", ti, ci))
+				status := rapid.SampledFrom(TraceQLStatusPool).Draw(t, fmt.Sprintf("status_%d_%d", ti, ci))
+				durationNs := rapid.SampledFrom(TraceQLDurationPoolNs).Draw(t, fmt.Sprintf("duration_%d_%d", ti, ci))
+				// Unique suffix → unique (SpanName, Timestamp) across spans:
+				// Tempo's toTraceSummaries() keys by name+timestamp and collapses
+				// duplicates. Suffixing the global span ordinal is the cheapest way
+				// to guarantee uniqueness without adding a second random draw.
+				name := fmt.Sprintf("%s /api/%d", baseName, spanOrdinal)
+				spanID := deterministicSpanID(spanOrdinal, 0xb2)
+				spans = append(spans, traceQLSpan{
+					traceID:    traceID,
+					spanID:     spanID,
+					parentID:   parentID,
+					service:    service,
+					cluster:    cluster,
+					httpMethod: httpMethod,
+					name:       name,
+					startTime:  traceQLAnchor.Add(time.Duration(spanOrdinal) * time.Second),
+					durationNs: durationNs,
+					statusCode: status,
+				})
+				parentID = spanID
+				spanOrdinal++
+			}
 		}
 		series := traceQLSpansToSeries(spans)
 		return property.Dataset{
@@ -112,12 +186,14 @@ func TraceQLDataset() *rapid.Generator[property.Dataset] {
 
 // traceQLSpan is the in-memory mirror of one row of otel_traces the
 // generator emits. The Dataset.Metrics mirror stores spans as
-// SeriesData entries keyed by SpanName; this struct is the bridge.
+// SeriesData entries; this struct is the bridge.
 type traceQLSpan struct {
-	traceID    string // 32-hex
+	traceID    string // 32-hex, shared by every span in a trace's chain
 	spanID     string // 16-hex
-	parentID   string // 16-hex (all-zero for root)
+	parentID   string // 16-hex (traceQLRootParentID for a chain root)
 	service    string
+	cluster    string
+	httpMethod string
 	name       string
 	startTime  time.Time
 	durationNs int64
@@ -137,6 +213,8 @@ func traceQLSpansToSeries(spans []traceQLSpan) []property.SeriesData {
 	for _, s := range spans {
 		labels := map[string]string{
 			"resource.service.name": s.service,
+			"resource.cluster":      s.cluster,
+			"span.http.method":      s.httpMethod,
 			"__name__":              s.name,
 			"__traceID__":           s.traceID,
 			"__spanID__":            s.spanID,
@@ -161,7 +239,11 @@ func traceQLSpansToSeries(spans []traceQLSpan) []property.SeriesData {
 // ParentSpanId, ServiceName (kept for OTel parity; the generator
 // queries via ResourceAttributes), SpanName, ResourceAttributes,
 // SpanAttributes, StartTimeUnixNano (column name `Timestamp` per
-// OTel-CH default), DurationNs (column name `Duration`), StatusCode.
+// OTel-CH default), DurationNs (column name `Duration`), StatusCode,
+// ScopeName, ScopeVersion — the last two are unvaried (always empty
+// string) but must exist: schema.DefaultOTelTraces() names them, and
+// the structural-join (`>`/`>>`) lowering projects them unconditionally
+// (see the ScopeName/ScopeVersion comment in renderTraceQLRow).
 //
 // `CREATE OR REPLACE TABLE` keeps re-runs idempotent (chdb-go shares
 // one catalog across sessions).
@@ -171,9 +253,9 @@ func renderTraceQLDDL(spans []traceQLSpan) string {
 	b.WriteString(SpansTableName)
 	b.WriteString(` (
     Timestamp DateTime64(9),
-    TraceId FixedString(32),
-    SpanId FixedString(16),
-    ParentSpanId FixedString(16),
+    TraceId String,
+    SpanId String,
+    ParentSpanId String,
     SpanName String,
     SpanKind LowCardinality(String),
     ServiceName LowCardinality(String),
@@ -181,7 +263,9 @@ func renderTraceQLDDL(spans []traceQLSpan) string {
     SpanAttributes Map(String, String),
     Duration Int64,
     StatusCode LowCardinality(String),
-    StatusMessage String
+    StatusMessage String,
+    ScopeName String,
+    ScopeVersion String
 ) ENGINE = MergeTree ORDER BY (Timestamp, TraceId);
 `)
 	if len(spans) == 0 {
@@ -227,10 +311,13 @@ func renderTraceQLRow(s traceQLSpan) string {
 	b.WriteString(quoteSQL(s.service))
 	b.WriteString(", ")
 	// ResourceAttributes
-	b.WriteString(renderTraceQLMap(map[string]string{"service.name": s.service}))
+	b.WriteString(renderTraceQLMap(map[string]string{
+		"service.name": s.service,
+		"cluster":      s.cluster,
+	}))
 	b.WriteString(", ")
-	// SpanAttributes (empty for now; reserved for span.<attr> matchers)
-	b.WriteString("map()")
+	// SpanAttributes
+	b.WriteString(renderTraceQLMap(map[string]string{"http.method": s.httpMethod}))
 	b.WriteString(", ")
 	// Duration
 	fmt.Fprintf(&b, "%d", s.durationNs)
@@ -239,6 +326,16 @@ func renderTraceQLRow(s traceQLSpan) string {
 	b.WriteString(quoteSQL(s.statusCode))
 	b.WriteString(", ")
 	// StatusMessage
+	b.WriteString("''")
+	b.WriteString(", ")
+	// ScopeName / ScopeVersion — the generator doesn't vary instrumentation
+	// scope, but the columns must exist: structuralExtraProjectionColumns
+	// (internal/traceql/lower.go) hard-codes schema.Traces.ScopeNameColumn /
+	// ScopeVersionColumn into every structural-join (`>`/`>>`) wrap
+	// projection, so a table missing them 502s with UNKNOWN_IDENTIFIER the
+	// moment a structural query runs.
+	b.WriteString("''")
+	b.WriteString(", ")
 	b.WriteString("''")
 	b.WriteByte(')')
 	return b.String()
@@ -271,9 +368,10 @@ func renderTraceQLMap(m map[string]string) string {
 
 // quoteSQL renders s as a single-quoted CH SQL string literal. Embedded
 // single quotes get backslash-escaped. The generator only emits values
-// from fixed pools (TraceQLServicePool, TraceQLSpanNamePool, hex IDs),
-// none of which contain quotes — but the escape is here so future
-// generator widening can stay safe.
+// from fixed pools (TraceQLServicePool, TraceQLClusterPool,
+// TraceQLHTTPMethodPool, TraceQLSpanNamePool, hex IDs), none of which
+// contain quotes — but the escape is here so future generator widening
+// can stay safe.
 func quoteSQL(s string) string {
 	if !strings.Contains(s, "'") && !strings.Contains(s, "\\") {
 		return "'" + s + "'"
@@ -311,19 +409,46 @@ func deterministicSpanID(seed, salt int) string {
 	return hex.EncodeToString(buf[:])
 }
 
+// statusQueryLiteral maps a CH-stored StatusCode value (Ok/Error/Unset)
+// to the lowercase literal TraceQL's `status` intrinsic expects on the
+// query side (ok/error/unset).
+func statusQueryLiteral(chStatus string) string {
+	return strings.ToLower(chStatus)
+}
+
 // TraceQLQuery returns a rapid generator that draws a property.Query
-// targeted at dataset d. The accept-set for this first sweep:
+// targeted at dataset d. The accept-set, widened from the first sweep's
+// single selector shape (issue #1471) to a breadth comparable to the
+// PromQL leg's drawExpr (test/property/gen/promql.go), spans 14 shapes
+// drawn uniformly via rapid.IntRange(0, 13):
 //
-//   - Selector only:           `{ resource.service.name = "<value>" }`
-//   - Selector + count filter: `{ resource.service.name = "<v>" } | count() OP N`
-//     where OP ∈ {>, >=, <, <=, =} and N ∈ [0, len(d.Series)].
+//   - 0: bare service-name selector          — `{ resource.service.name = "<v>" }`
+//   - 1: selector + count() scalar filter    — `{ ... } | count() OP N`
+//   - 2: resource attribute beyond service.name — `{ resource.cluster = "<v>" }`
+//   - 3: span attribute matcher              — `{ span.http.method = "<v>" }`
+//   - 4: duration intrinsic                  — `{ duration OP Nms }`
+//   - 5: status intrinsic (eq or negated)    — `{ status OP <ok|error|unset> }`
+//   - 6: name intrinsic (exact match)        — `{ name = "<v>" }`
+//   - 7: regex attribute matcher             — `{ resource.service.name =~ "<pattern>" }`
+//   - 8: negated attribute matcher           — `{ resource.service.name != "<v>" }`
+//   - 9: multi-condition (&&) filter         — `{ resource.service.name = "<v>" && status = <lit> }`
+//   - 10: structural child (`>`)             — `{ A } > { B }`
+//   - 11: structural descendant (`>>`)       — `{ A } >> { B }`
+//   - 12: metric beyond count()              — `{ ... } | avg|min|max|sum(duration) OP Nms`
+//   - 13: select() pipeline stage            — `{ ... } | select(span.http.method)`
+//
+// Every shape's oracle counterpart lives in test/property/oracle/traceql
+// — see that package's parseQuery/Evaluate for the independent
+// specification each shape is checked against. A shape is added here
+// only once the oracle can evaluate it (never the reverse), so the
+// property test is never vacuous for a generated shape.
 //
 // The selector's RHS is always a value drawn from the dataset's
-// observed services so half of the iterations exercise a matching
-// service (genuine non-empty result) and the other half exercise a
-// service not present (empty result). The mix is implicit — rapid
-// draws across the pool uniformly, and the dataset's spans cover only
-// a subset of TraceQLServicePool on any iteration.
+// observed pools so a good share of iterations exercise a matching
+// value (genuine non-empty result) and the rest exercise an absent one
+// (empty result). The mix is implicit — rapid draws across the pools
+// uniformly, and any one dataset draw covers only a subset of a given
+// pool.
 //
 // EvalTs is stamped at TraceQLAnchorTime() + 1h for log completeness.
 // /api/search DOES thread a time range now (the harness sends an explicit
@@ -332,23 +457,8 @@ func deterministicSpanID(seed, salt int) string {
 // dataset out), but the query value itself doesn't carry it.
 func TraceQLQuery(d property.Dataset) *rapid.Generator[property.Query] {
 	return rapid.Custom(func(t *rapid.T) property.Query {
-		// Draw service value — always from the global pool so half the
-		// queries hit "absent service" (zero matches), exercising the
-		// empty-result path on both sides.
-		service := rapid.SampledFrom(TraceQLServicePool).Draw(t, "service")
-
-		// Optional `| count() OP N` filter.
-		hasCount := rapid.Bool().Draw(t, "hasCount")
-		query := fmt.Sprintf(`{ resource.service.name = "%s" }`, service)
-		if hasCount {
-			op := rapid.SampledFrom([]string{">", ">=", "<", "<=", "="}).Draw(t, "countOp")
-			// Bound N at [0, len(spans)] so the threshold is sometimes
-			// satisfied and sometimes not. len(d.Series) is the upper
-			// bound; using a slightly wider range exercises the
-			// "threshold above ceiling" path too.
-			n := rapid.IntRange(0, len(d.Metrics.Series)+1).Draw(t, "countN")
-			query = fmt.Sprintf("%s | count() %s %d", query, op, n)
-		}
+		shape := rapid.IntRange(0, 13).Draw(t, "shape")
+		query := drawTraceQLQueryString(t, d, shape)
 
 		evalTs := traceQLAnchor.Add(time.Hour).Unix()
 		return property.Query{
@@ -356,4 +466,102 @@ func TraceQLQuery(d property.Dataset) *rapid.Generator[property.Query] {
 			EvalTs: evalTs,
 		}
 	})
+}
+
+// drawTraceQLQueryString renders the query string for the given shape
+// index. Split out of TraceQLQuery so each shape's construction reads
+// as one focused case rather than a single sprawling closure.
+func drawTraceQLQueryString(t *rapid.T, d property.Dataset, shape int) string {
+	switch shape {
+	case 0:
+		service := rapid.SampledFrom(TraceQLServicePool).Draw(t, "service")
+		return fmt.Sprintf(`{ resource.service.name = "%s" }`, service)
+	case 1:
+		return drawTraceQLCountQuery(t, d)
+	case 2:
+		cluster := rapid.SampledFrom(TraceQLClusterPool).Draw(t, "cluster")
+		return fmt.Sprintf(`{ resource.cluster = "%s" }`, cluster)
+	case 3:
+		method := rapid.SampledFrom(TraceQLHTTPMethodPool).Draw(t, "httpMethod")
+		return fmt.Sprintf(`{ span.http.method = "%s" }`, method)
+	case 4:
+		op := rapid.SampledFrom(traceQLComparisonOps).Draw(t, "durationOp")
+		thresholdMs := rapid.SampledFrom(TraceQLDurationThresholdPoolMs).Draw(t, "durationThresholdMs")
+		return fmt.Sprintf(`{ duration %s %dms }`, op, thresholdMs)
+	case 5:
+		op := rapid.SampledFrom(traceQLEqualityOps).Draw(t, "statusOp")
+		statusCH := rapid.SampledFrom(TraceQLStatusPool).Draw(t, "status")
+		return fmt.Sprintf(`{ status %s %s }`, op, statusQueryLiteral(statusCH))
+	case 6:
+		return fmt.Sprintf(`{ name = %q }`, drawTraceQLNameValue(t, d))
+	case 7:
+		service := rapid.SampledFrom(TraceQLServicePool).Draw(t, "service")
+		pattern := service[:1] + ".*"
+		return fmt.Sprintf(`{ resource.service.name =~ %q }`, pattern)
+	case 8:
+		service := rapid.SampledFrom(TraceQLServicePool).Draw(t, "service")
+		return fmt.Sprintf(`{ resource.service.name != "%s" }`, service)
+	case 9:
+		service := rapid.SampledFrom(TraceQLServicePool).Draw(t, "service")
+		statusCH := rapid.SampledFrom(TraceQLStatusPool).Draw(t, "status")
+		return fmt.Sprintf(`{ resource.service.name = "%s" && status = %s }`,
+			service, statusQueryLiteral(statusCH))
+	case 10:
+		left := rapid.SampledFrom(TraceQLServicePool).Draw(t, "leftService")
+		right := rapid.SampledFrom(TraceQLServicePool).Draw(t, "rightService")
+		return fmt.Sprintf(`{ resource.service.name = "%s" } > { resource.service.name = "%s" }`, left, right)
+	case 11:
+		left := rapid.SampledFrom(TraceQLServicePool).Draw(t, "leftService")
+		right := rapid.SampledFrom(TraceQLServicePool).Draw(t, "rightService")
+		return fmt.Sprintf(`{ resource.service.name = "%s" } >> { resource.service.name = "%s" }`, left, right)
+	case 12:
+		return drawTraceQLMetricQuery(t)
+	case 13:
+		service := rapid.SampledFrom(TraceQLServicePool).Draw(t, "service")
+		return fmt.Sprintf(`{ resource.service.name = "%s" } | select(span.http.method)`, service)
+	}
+	// Unreachable: rapid.IntRange(0, 13) never draws outside [0, 13].
+	panic(fmt.Sprintf("gen/traceql: unhandled query shape %d", shape))
+}
+
+// drawTraceQLCountQuery renders shape 1: a service selector with an
+// optional `| count() OP N` scalar filter — the accept-set the first
+// sweep shipped, preserved verbatim as one shape among the widened set.
+func drawTraceQLCountQuery(t *rapid.T, d property.Dataset) string {
+	service := rapid.SampledFrom(TraceQLServicePool).Draw(t, "service")
+	query := fmt.Sprintf(`{ resource.service.name = "%s" }`, service)
+	if !rapid.Bool().Draw(t, "hasCount") {
+		return query
+	}
+	op := rapid.SampledFrom(traceQLComparisonOps).Draw(t, "countOp")
+	// Bound N at [0, len(spans)+1] so the threshold is sometimes
+	// satisfied and sometimes not, including the "above ceiling" case.
+	n := rapid.IntRange(0, len(d.Metrics.Series)+1).Draw(t, "countN")
+	return fmt.Sprintf("%s | count() %s %d", query, op, n)
+}
+
+// drawTraceQLMetricQuery renders shape 12: a service selector piped
+// into one of avg|min|max|sum(duration) with a scalar comparison —
+// count()'s sibling aggregates, exercising the same trace-scoped
+// aggregate pipeline with a different reducer.
+func drawTraceQLMetricQuery(t *rapid.T) string {
+	service := rapid.SampledFrom(TraceQLServicePool).Draw(t, "service")
+	fn := rapid.SampledFrom([]string{"avg", "min", "max", "sum"}).Draw(t, "metricFn")
+	op := rapid.SampledFrom(traceQLComparisonOps).Draw(t, "metricOp")
+	thresholdMs := rapid.SampledFrom(TraceQLDurationThresholdPoolMs).Draw(t, "metricThresholdMs")
+	return fmt.Sprintf(`{ resource.service.name = "%s" } | %s(duration) %s %dms`,
+		service, fn, op, thresholdMs)
+}
+
+// drawTraceQLNameValue picks the RHS for shape 6's `{ name = "<v>" }`.
+// Half the draws (when the dataset has spans) pick a name that's
+// actually present so the equality has something to match; the rest
+// pick a value that's guaranteed absent, exercising the empty-result
+// path deliberately rather than by accident.
+func drawTraceQLNameValue(t *rapid.T, d property.Dataset) string {
+	names := d.Metrics.NamesPresent()
+	if len(names) > 0 && rapid.Bool().Draw(t, "nameExists") {
+		return rapid.SampledFrom(names).Draw(t, "existingName")
+	}
+	return "nonexistent-span-name"
 }

--- a/test/property/oracle/traceql/doc.go
+++ b/test/property/oracle/traceql/doc.go
@@ -1,15 +1,37 @@
 // Package traceql is the from-scratch TraceQL evaluator that serves
 // as the independent specification for cerberus's property-testing
-// framework. The Tempo TraceQL parser is treated as a string-format
-// parser only; semantic evaluation lives in-tree, derived from the
-// Grafana TraceQL documentation rather than reusing Tempo's engine.
+// framework. The Tempo TraceQL parser and cerberus's own
+// internal/traceql/ast are both treated as out of scope for this
+// package — semantic evaluation lives here, derived from the Grafana
+// TraceQL documentation rather than reusing either engine.
 //
-// # MVP coverage (Phase 1)
+// # Coverage
 //
-//   - SpansetFilter: `{ resource.service.name = "<value>" }` —
-//     attribute-equality matcher against ResourceAttributes['service.name'].
-//   - Scalar filter pipeline: `| count() OP N` where OP ∈
-//     {>, >=, <, <=, =} and N is a non-negative integer literal.
+// The generator (test/property/gen/traceql.go's TraceQLQuery) draws 14
+// query shapes, widened from the first sweep's single-selector accept
+// set (issue #1471) to a breadth comparable to the PromQL leg's
+// drawExpr. This package evaluates every one of them:
+//
+//   - Attribute matchers: `resource.service.name`, `resource.cluster`,
+//     `span.http.method`, with `=`, `!=`, `=~`, `!~`.
+//   - Intrinsics: `duration OP Nms` (all five comparison operators),
+//     `status OP <ok|error|unset>` (`=`/`!=`), `name = "<value>"`.
+//   - Multi-condition filters: `{ A && B }`.
+//   - Structural relations: `{ A } > { B }` (immediate child) and
+//     `{ A } >> { B }` (descendant at any depth), evaluated by walking
+//     the generator's linear parent chains (see TraceQLDataset's doc —
+//     the dataset never branches, so "some ancestor matches A" reduces
+//     to a chain walk).
+//   - Scalar-filter pipelines: `| count() OP N` and
+//     `| avg|min|max|sum(duration) OP Nms`, both trace-scoped
+//     aggregates.
+//   - `| select(...)`: recognized and treated as a no-op on the result
+//     row count (select() only adds projected columns — see
+//     test/spec/traceql/select_one_attr.txtar).
+//
+// A shape is added to the generator only once this package can
+// evaluate it — never the reverse — so the property test is never
+// vacuous for a generated shape.
 //
 // # Semantics (per the TraceQL spec)
 //
@@ -17,39 +39,45 @@
 // spans matching the upstream filter; pipeline operators reduce or
 // transform the spanset on a per-trace basis.
 //
-//  1. Spanset filter (`{ <attr> = <value> }`): each span is
-//     evaluated against the predicate; surviving spans form the
+//  1. Spanset filter (`{ <cond> (&& <cond>)* }`): each span is
+//     evaluated against every condition; surviving spans form the
 //     per-trace spanset.
-//  2. count() aggregate: returns the number of matching spans IN A
+//  2. Structural relation (`{A} > {B}` / `{A} >> {B}`): B's spanset is
+//     narrowed to spans that are, respectively, an immediate child or
+//     any-depth descendant of some span in A's spanset within the same
+//     trace.
+//  3. count() aggregate: returns the number of matching spans IN A
 //     TRACE. With a scalar filter (`| count() > N`), every trace
 //     whose per-trace count satisfies the predicate is included in
 //     the result; traces whose count fails the predicate are
 //     dropped. Cerberus's wire surface emits one chclient.Sample
 //     per surviving trace (the Aggregate groups by TraceId — see
 //     internal/api/tempo/handler.go's isSpansetAggregateShape) so
-//     the evaluator mirrors that per-trace shape.
+//     the evaluator mirrors that per-trace shape. avg|min|max|sum(duration)
+//     reduce the same per-trace spanset's Duration values instead of
+//     counting them (see test/spec/traceql/avg_duration.txtar).
 //
 // # Wire-shape comparison
 //
-// Tempo's /api/search response carries the count as `inspectedTraces`
-// (which equals `len(res.Samples)` — see internal/api/tempo/handler.go's
-// SearchMetrics population). The evaluator therefore reports:
+// Tempo's /api/search response carries the drained-row count as
+// `X-Cerberus-Inspected-Spans` (which equals `len(res.Samples)` — see
+// internal/api/tempo/search_metrics.go's SearchMetricsFor). That count
+// tracks the query's result row count for every shape above — a plain
+// filter, a structural join, an aggregate, or a select() projection —
+// so the evaluator reports:
 //
-//   - Selector-only query: one outcome row per matching span, all
-//     stamped with the same empty label set so the framework's
-//     comparator counts rows-per-group. The generator stamps each
-//     span on its own TraceID so per-trace and per-span counts
-//     coincide.
-//   - count() query: one outcome row per matching trace whose
-//     per-trace count satisfies `count() OP N` (zero rows when no
-//     trace's count satisfies the predicate).
+//   - Filter / structural / select() query: one outcome row per
+//     matching span, all stamped with the same empty label set so the
+//     framework's comparator counts rows-per-group. The generator
+//     stamps each span on its own (SpanName, Timestamp) pair so
+//     per-trace and per-span counts coincide (Tempo's TraceSummary
+//     collapse never triggers).
+//   - count() / avg|min|max|sum(duration) query: one outcome row per
+//     matching trace whose per-trace aggregate satisfies the scalar
+//     filter (zero rows when no trace's aggregate satisfies it).
 //
 // The framework's CompareOutcomes diff is multiset-aware over the
-// empty-label group, so the row count is what we compare. Tempo's
-// /api/search collapses multiple spans with the same (SpanName,
-// Timestamp) into one trace summary — the generator avoids that
-// collapse by stamping a unique suffix on each span name, so
-// `len(samples) == len(traces)` on the cerberus side.
+// empty-label group, so the row count is what we compare.
 //
 // # Entry point
 //

--- a/test/property/oracle/traceql/evaluator.go
+++ b/test/property/oracle/traceql/evaluator.go
@@ -4,29 +4,38 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/tsouza/cerberus/test/property"
 )
 
+// nsPerMillisecond converts a `Nms` query-literal threshold into
+// nanoseconds, matching how cerberus's TraceQL lowering scales
+// duration literals before comparing against the Duration column.
+const nsPerMillisecond = 1_000_000
+
 // Evaluate runs the property-test oracle against d for query q. The
 // query string is parsed via the package-private parser (a small
-// hand-rolled recognizer keyed to the generator's accept-set) — no
-// dependency on Tempo's traceql package, so the oracle stays a
-// spec-derived implementation rather than a wrapper.
+// hand-rolled recognizer keyed to the generator's accept-set — see
+// test/property/gen/traceql.go's TraceQLQuery doc for the full shape
+// list) — no dependency on Tempo's traceql package, so the oracle
+// stays a spec-derived implementation rather than a wrapper.
 //
 // Returns property.Outcome carrying:
 //
-//   - one row per matching span (labels: empty map) when the query is a
-//     bare selector — Tempo's /api/search emits one TraceSummary per
-//     matching trace, and the generator stamps each span on its own
-//     TraceID so the per-trace and per-span counts coincide;
-//   - one row per matching trace whose per-trace count satisfies the
-//     `| count() OP N` predicate (labels: empty map). TraceQL's
-//     pipeline aggregates are trace-scoped per the spec —
-//     `{ ... } | count() > 0` returns one row per matching trace, not
-//     a single corpus-wide aggregate;
-//   - zero rows when no trace's per-trace count satisfies the
-//     predicate;
+//   - one row per matching span (labels: empty map) for a plain
+//     filter, a structural (`>`/`>>`) filter, or a filter followed by
+//     `| select(...)` — Tempo's /api/search inspected-span count
+//     tracks the query's result row count regardless of shape (see
+//     internal/api/tempo/search_metrics.go's SearchMetricsFor), and
+//     select() only adds projected columns, never changes which spans
+//     survive;
+//   - one row per matching trace whose per-trace `count()` /
+//     `avg|min|max|sum(duration)` aggregate satisfies the scalar
+//     filter (labels: empty map). TraceQL's pipeline aggregates are
+//     trace-scoped per the spec — `{ ... } | count() > 0` returns one
+//     row per matching trace, not a single corpus-wide aggregate;
+//   - zero rows when no trace's aggregate satisfies the predicate;
 //   - an Err otherwise (parse failure / unsupported shape).
 //
 // The per-trace row shape mirrors Tempo's /api/search wire shape after
@@ -43,53 +52,460 @@ func Evaluate(d property.Dataset, q property.Query) property.Outcome {
 		return property.Outcome{Err: fmt.Errorf("oracle: parse %q: %w", q.String, err)}
 	}
 
-	spans := filterSpans(d, parsed.selector)
-	if parsed.hasCount {
-		// Trace-scoped count: group surviving spans by TraceID, then
-		// emit one outcome row per trace whose per-trace count
-		// satisfies `count() OP N`. Mirrors the per-trace aggregate
-		// cerberus emits (one chclient.Sample per matching TraceId)
-		// — see PR #536. The generator stamps each span on its own
-		// TraceID, so per-trace counts are usually 1; the predicate
-		// arithmetic still has to hold for the trace to surface.
-		perTrace := groupByTraceID(spans)
-		rows := make([]property.OutcomeRow, 0, len(perTrace))
-		for _, count := range perTrace {
-			if compareCount(count, parsed.countOp, parsed.countN) {
-				rows = append(rows, property.OutcomeRow{
-					Labels:      map[string]string{},
-					TimestampMs: 0,
-					Value:       0,
-				})
-			}
+	matched, err := evalBase(spanViews(d), parsed.base)
+	if err != nil {
+		return property.Outcome{Err: fmt.Errorf("oracle: eval %q: %w", q.String, err)}
+	}
+
+	switch parsed.pipeline.kind {
+	case pipelineNone, pipelineSelect:
+		// Selector-only (or selector + select()): one row per matching
+		// span. Labels stay empty so the framework's labelKey() groups
+		// all rows under "{}", and the comparator's per-group row-count
+		// check is exactly the span-count check we want. Timestamp +
+		// Value are stamped at zero so the per-group multiset diff
+		// doesn't drift on per-span metadata the comparator isn't
+		// designed to inspect (the search response shape collapses span
+		// identity into `inspectedSpans`, not per-span timestamps).
+		rows := make([]property.OutcomeRow, 0, len(matched))
+		for range matched {
+			rows = append(rows, property.OutcomeRow{Labels: map[string]string{}})
 		}
 		return property.Outcome{Rows: rows}
+	case pipelineCount:
+		return countPipelineOutcome(matched, parsed.pipeline)
+	case pipelineMetric:
+		return metricPipelineOutcome(matched, parsed.pipeline)
 	}
-
-	// Selector-only: one row per matching span. Labels stay empty so
-	// the framework's labelKey() groups all rows under "{}", and the
-	// comparator's per-group row-count check is exactly the
-	// span-count check we want. Timestamp + Value are stamped at zero
-	// so the per-group multiset diff doesn't drift on per-span
-	// metadata the comparator isn't designed to inspect (the search
-	// response shape collapses span identity into `inspectedTraces`,
-	// not per-span timestamps).
-	rows := make([]property.OutcomeRow, 0, len(spans))
-	for range spans {
-		rows = append(rows, property.OutcomeRow{
-			Labels:      map[string]string{},
-			TimestampMs: 0,
-			Value:       0,
-		})
-	}
-	return property.Outcome{Rows: rows}
+	return property.Outcome{Err: fmt.Errorf("oracle: unhandled pipeline kind %v", parsed.pipeline.kind)}
 }
 
-// groupByTraceID buckets surviving spans by TraceID and returns each
-// bucket's per-trace count. The generator stamps each span on its own
-// TraceID via deterministicTraceID(i, …) so most buckets are size 1,
-// but the helper is shape-agnostic — a future generator widening
-// (multi-span traces) flows through unchanged.
+// spanView is the oracle's per-span snapshot: just the fields the
+// evaluator needs to apply matchers, intrinsics, structural relations,
+// and aggregates. Built once per Evaluate call from the dataset's
+// MetricsModel series.
+type spanView struct {
+	traceID    string
+	spanID     string
+	parentID   string
+	service    string
+	cluster    string
+	httpMethod string
+	name       string
+	statusCode string
+	durationNs int64
+}
+
+// spanKey identifies a span within a trace — TraceId alone isn't
+// unique (a trace has many spans), so structural lookups key on the
+// (TraceId, SpanId) pair.
+type spanKey struct {
+	traceID string
+	spanID  string
+}
+
+// spanViews pivots the dataset's MetricsModel into the spanView shape
+// every evaluator helper reads. See gen/traceql.go's TraceQLDataset
+// doc for the reserved-label-key convention this mirrors.
+func spanViews(d property.Dataset) []spanView {
+	if d.Metrics == nil {
+		return nil
+	}
+	out := make([]spanView, 0, len(d.Metrics.Series))
+	for _, s := range d.Metrics.Series {
+		var durationNs int64
+		if raw, ok := s.Labels["__duration_ns__"]; ok {
+			if v, err := strconv.ParseInt(raw, 10, 64); err == nil {
+				durationNs = v
+			}
+		}
+		out = append(out, spanView{
+			traceID:    s.Labels["__traceID__"],
+			spanID:     s.Labels["__spanID__"],
+			parentID:   s.Labels["__parentSpanID__"],
+			service:    s.Labels["resource.service.name"],
+			cluster:    s.Labels["resource.cluster"],
+			httpMethod: s.Labels["span.http.method"],
+			name:       s.MetricName,
+			statusCode: s.Labels["__status__"],
+			durationNs: durationNs,
+		})
+	}
+	return out
+}
+
+// condition is one matcher in a spanset filter — an attribute
+// equality/regex test or a duration/status/name intrinsic test.
+// Represented as a closure rather than a tagged struct because every
+// shape reduces to "does this span satisfy me", and the parser already
+// carries the type-specific error handling.
+type condition struct {
+	match func(sv spanView) bool
+}
+
+// matchAll reports whether sv satisfies every condition in conds — the
+// `&&` combination the multi-condition filter shape draws.
+func matchAll(sv spanView, conds []condition) bool {
+	for _, c := range conds {
+		if !c.match(sv) {
+			return false
+		}
+	}
+	return true
+}
+
+// filterSpans returns the spans satisfying every condition in conds.
+func filterSpans(spans []spanView, conds []condition) []spanView {
+	var out []spanView
+	for _, sv := range spans {
+		if matchAll(sv, conds) {
+			out = append(out, sv)
+		}
+	}
+	return out
+}
+
+// attrGetter resolves a `resource.<attr>` / `span.<attr>` path to the
+// spanView field it reads. Kept as an explicit allow-list — a path
+// outside the generator's pool (TraceQLServicePool /
+// TraceQLClusterPool / TraceQLHTTPMethodPool) is a generator bug, not
+// a real query, so it fails the parse rather than silently reading a
+// zero value.
+func attrGetter(attr string) (func(spanView) string, error) {
+	switch attr {
+	case "resource.service.name":
+		return func(sv spanView) string { return sv.service }, nil
+	case "resource.cluster":
+		return func(sv spanView) string { return sv.cluster }, nil
+	case "span.http.method":
+		return func(sv spanView) string { return sv.httpMethod }, nil
+	}
+	return nil, fmt.Errorf("unsupported attribute path %q", attr)
+}
+
+// newAttrCondition builds an attribute matcher condition for one of
+// the four operators the generator draws: `=`, `!=`, `=~`, `!~`.
+func newAttrCondition(attr, op, value string) (condition, error) {
+	getter, err := attrGetter(attr)
+	if err != nil {
+		return condition{}, err
+	}
+	switch op {
+	case "=":
+		return condition{match: func(sv spanView) bool { return getter(sv) == value }}, nil
+	case "!=":
+		return condition{match: func(sv spanView) bool { return getter(sv) != value }}, nil
+	case "=~", "!~":
+		re, err := regexp.Compile(value)
+		if err != nil {
+			return condition{}, fmt.Errorf("bad regex %q: %w", value, err)
+		}
+		negate := op == "!~"
+		return condition{match: func(sv spanView) bool { return re.MatchString(getter(sv)) != negate }}, nil
+	}
+	return condition{}, fmt.Errorf("unsupported attribute operator %q", op)
+}
+
+// int64Comparator returns the comparison function for one of the
+// generator's five scalar operators, applied to int64 operands
+// (duration-in-ns and count()'s integer threshold).
+func int64Comparator(op string) (func(a, b int64) bool, error) {
+	switch op {
+	case ">":
+		return func(a, b int64) bool { return a > b }, nil
+	case ">=":
+		return func(a, b int64) bool { return a >= b }, nil
+	case "<":
+		return func(a, b int64) bool { return a < b }, nil
+	case "<=":
+		return func(a, b int64) bool { return a <= b }, nil
+	case "=":
+		return func(a, b int64) bool { return a == b }, nil
+	}
+	return nil, fmt.Errorf("unsupported comparison operator %q", op)
+}
+
+// float64Comparator is int64Comparator's sibling for the
+// avg|min|max|sum(duration) metric pipeline, whose avg branch produces
+// a non-integer value.
+func float64Comparator(op string) (func(a, b float64) bool, error) {
+	switch op {
+	case ">":
+		return func(a, b float64) bool { return a > b }, nil
+	case ">=":
+		return func(a, b float64) bool { return a >= b }, nil
+	case "<":
+		return func(a, b float64) bool { return a < b }, nil
+	case "<=":
+		return func(a, b float64) bool { return a <= b }, nil
+	case "=":
+		return func(a, b float64) bool { return a == b }, nil
+	}
+	return nil, fmt.Errorf("unsupported comparison operator %q", op)
+}
+
+// newDurationCondition builds the `duration OP Nms` intrinsic filter.
+func newDurationCondition(op string, thresholdNs int64) (condition, error) {
+	cmp, err := int64Comparator(op)
+	if err != nil {
+		return condition{}, err
+	}
+	return condition{match: func(sv spanView) bool { return cmp(sv.durationNs, thresholdNs) }}, nil
+}
+
+// statusCHValue maps the TraceQL query literal (ok/error/unset) to the
+// CH-stored StatusCode value (Ok/Error/Unset) — the inverse of
+// gen/traceql.go's statusQueryLiteral.
+func statusCHValue(literal string) (string, error) {
+	switch literal {
+	case "ok":
+		return "Ok", nil
+	case "error":
+		return "Error", nil
+	case "unset":
+		return "Unset", nil
+	}
+	return "", fmt.Errorf("unsupported status literal %q", literal)
+}
+
+// newStatusCondition builds the `status OP <ok|error|unset>` intrinsic
+// filter.
+func newStatusCondition(op, literal string) (condition, error) {
+	chValue, err := statusCHValue(literal)
+	if err != nil {
+		return condition{}, err
+	}
+	switch op {
+	case "=":
+		return condition{match: func(sv spanView) bool { return sv.statusCode == chValue }}, nil
+	case "!=":
+		return condition{match: func(sv spanView) bool { return sv.statusCode != chValue }}, nil
+	}
+	return condition{}, fmt.Errorf("unsupported status operator %q", op)
+}
+
+// newNameCondition builds the `name = "<v>"` intrinsic filter — exact
+// match against the span's full generated name (pool value + ordinal
+// suffix, see gen/traceql.go).
+func newNameCondition(value string) condition {
+	return condition{match: func(sv spanView) bool { return sv.name == value }}
+}
+
+// condition-recognizer patterns, one per intrinsic/attribute shape the
+// generator draws. Anchored so an unexpected shape fails fast rather
+// than silently matching a prefix. Values are always plain pool
+// strings (letters, digits, `/`, spaces) — the generator never emits a
+// quote or backslash inside a string literal, so a bare `[^"]*` capture
+// (no backslash-escape handling) is exact, not an approximation.
+var (
+	durationCondRe = regexp.MustCompile(`^duration\s*(>=|<=|>|<|=)\s*(\d+)ms$`)
+	statusCondRe   = regexp.MustCompile(`^status\s*(=|!=)\s*(ok|error|unset)$`)
+	nameCondRe     = regexp.MustCompile(`^name\s*=\s*"([^"]*)"$`)
+	attrCondRe     = regexp.MustCompile(`^((?:resource|span)\.[a-zA-Z_.]+)\s*(=~|!~|!=|=)\s*"([^"]*)"$`)
+)
+
+// parseCondition recognizes one atomic condition inside a spanset
+// filter's `{ ... }` body (the multi-condition shape splits on ` && `
+// before calling this).
+func parseCondition(s string) (condition, error) {
+	s = strings.TrimSpace(s)
+	if m := durationCondRe.FindStringSubmatch(s); m != nil {
+		ms, err := strconv.ParseInt(m[2], 10, 64)
+		if err != nil {
+			return condition{}, fmt.Errorf("duration threshold %q: %w", m[2], err)
+		}
+		return newDurationCondition(m[1], ms*nsPerMillisecond)
+	}
+	if m := statusCondRe.FindStringSubmatch(s); m != nil {
+		return newStatusCondition(m[1], m[2])
+	}
+	if m := nameCondRe.FindStringSubmatch(s); m != nil {
+		return newNameCondition(m[1]), nil
+	}
+	if m := attrCondRe.FindStringSubmatch(s); m != nil {
+		return newAttrCondition(m[1], m[2], m[3])
+	}
+	return condition{}, fmt.Errorf("condition does not match a known shape %q", s)
+}
+
+// parseSpansetFilter parses one `{ cond (&& cond)* }` block into its
+// component conditions.
+func parseSpansetFilter(s string) ([]condition, error) {
+	s = strings.TrimSpace(s)
+	if !strings.HasPrefix(s, "{") || !strings.HasSuffix(s, "}") {
+		return nil, fmt.Errorf("spanset filter missing braces %q", s)
+	}
+	inner := strings.TrimSpace(s[1 : len(s)-1])
+	if inner == "" {
+		return nil, fmt.Errorf("empty spanset filter %q", s)
+	}
+	parts := strings.Split(inner, " && ")
+	conds := make([]condition, 0, len(parts))
+	for _, p := range parts {
+		c, err := parseCondition(p)
+		if err != nil {
+			return nil, err
+		}
+		conds = append(conds, c)
+	}
+	return conds, nil
+}
+
+// baseQuery is the non-pipeline part of a query: either a single
+// spanset filter (Op == "", conditions in Right) or a structural
+// relation between two spanset filters (Op == ">" or ">>", Left is the
+// ancestor/parent-side filter and Right is the descendant/child-side
+// filter the result set is drawn from).
+type baseQuery struct {
+	op    string
+	left  []condition
+	right []condition
+}
+
+// baseRe recognizes the generator's base-query shapes: a lone spanset
+// filter, or two filters joined by `>` or `>>`. Conditions never
+// contain `{`/`}` (values are plain pool strings), so a non-greedy
+// `[^{}]*` capture per spanset block is exact.
+var baseRe = regexp.MustCompile(`^(\{[^{}]*\})(?:\s*(>>|>)\s*(\{[^{}]*\}))?$`)
+
+// parseBase parses the base-query portion of a query string (the part
+// before any ` | ` pipeline suffix).
+func parseBase(s string) (baseQuery, error) {
+	m := baseRe.FindStringSubmatch(strings.TrimSpace(s))
+	if m == nil {
+		return baseQuery{}, fmt.Errorf("base query does not match expected shape %q", s)
+	}
+	firstConds, err := parseSpansetFilter(m[1])
+	if err != nil {
+		return baseQuery{}, err
+	}
+	if m[2] == "" {
+		return baseQuery{right: firstConds}, nil
+	}
+	secondConds, err := parseSpansetFilter(m[3])
+	if err != nil {
+		return baseQuery{}, err
+	}
+	return baseQuery{op: m[2], left: firstConds, right: secondConds}, nil
+}
+
+// evalBase evaluates a baseQuery against spans, returning the matching
+// spans (op == "") or the right-side spans that satisfy the structural
+// relation to some left-side match (op == ">" / ">>").
+//
+// Both structural operators are evaluated by walking a span's parent
+// chain — sound because the generator only ever produces linear
+// parent→child chains (see gen/traceql.go's TraceQLDataset doc), so
+// "some ancestor matches Left" reduces to a chain walk rather than a
+// general tree search.
+func evalBase(spans []spanView, b baseQuery) ([]spanView, error) {
+	if b.op == "" {
+		return filterSpans(spans, b.right), nil
+	}
+
+	leftMatched := filterSpans(spans, b.left)
+	leftSet := make(map[spanKey]bool, len(leftMatched))
+	for _, sv := range leftMatched {
+		leftSet[spanKey{sv.traceID, sv.spanID}] = true
+	}
+
+	bySpanID := make(map[spanKey]spanView, len(spans))
+	for _, sv := range spans {
+		bySpanID[spanKey{sv.traceID, sv.spanID}] = sv
+	}
+
+	rightMatched := filterSpans(spans, b.right)
+	var out []spanView
+	switch b.op {
+	case ">":
+		// Immediate child: r's own parent must be a Left match.
+		for _, r := range rightMatched {
+			if leftSet[spanKey{r.traceID, r.parentID}] {
+				out = append(out, r)
+			}
+		}
+	case ">>":
+		// Descendant at any depth: walk r's ancestor chain looking for
+		// a Left match.
+		for _, r := range rightMatched {
+			parentKey := spanKey{r.traceID, r.parentID}
+			for {
+				parent, ok := bySpanID[parentKey]
+				if !ok {
+					break // reached the chain root; no more ancestors
+				}
+				if leftSet[parentKey] {
+					out = append(out, r)
+					break
+				}
+				parentKey = spanKey{parent.traceID, parent.parentID}
+			}
+		}
+	default:
+		return nil, fmt.Errorf("unsupported structural operator %q", b.op)
+	}
+	return out, nil
+}
+
+// pipelineKind discriminates the four pipeline shapes the generator
+// draws after a base query.
+type pipelineKind int
+
+const (
+	pipelineNone pipelineKind = iota
+	pipelineCount
+	pipelineMetric
+	pipelineSelect
+)
+
+// pipeline is the parsed `| ...` suffix, if any.
+type pipeline struct {
+	kind pipelineKind
+	// op is the scalar comparison operator for pipelineCount / pipelineMetric.
+	op string
+	// n is the count() integer threshold (pipelineCount only).
+	n int64
+	// fn is avg/min/max/sum (pipelineMetric only).
+	fn string
+	// thresholdNs is the avg|min|max|sum(duration) threshold, already
+	// scaled to nanoseconds (pipelineMetric only).
+	thresholdNs int64
+}
+
+var (
+	countPipelineRe  = regexp.MustCompile(`^count\(\)\s*(>=|<=|>|<|=)\s*(\d+)$`)
+	metricPipelineRe = regexp.MustCompile(`^(avg|min|max|sum)\(duration\)\s*(>=|<=|>|<|=)\s*(\d+)ms$`)
+	selectPipelineRe = regexp.MustCompile(`^select\(.*\)$`)
+)
+
+// parsePipeline recognizes the pipeline suffix (everything after the
+// first ` | `).
+func parsePipeline(s string) (pipeline, error) {
+	s = strings.TrimSpace(s)
+	if m := countPipelineRe.FindStringSubmatch(s); m != nil {
+		n, err := strconv.ParseInt(m[2], 10, 64)
+		if err != nil {
+			return pipeline{}, fmt.Errorf("count threshold %q: %w", m[2], err)
+		}
+		return pipeline{kind: pipelineCount, op: m[1], n: n}, nil
+	}
+	if m := metricPipelineRe.FindStringSubmatch(s); m != nil {
+		ms, err := strconv.ParseInt(m[3], 10, 64)
+		if err != nil {
+			return pipeline{}, fmt.Errorf("metric threshold %q: %w", m[3], err)
+		}
+		return pipeline{kind: pipelineMetric, fn: m[1], op: m[2], thresholdNs: ms * nsPerMillisecond}, nil
+	}
+	if selectPipelineRe.MatchString(s) {
+		return pipeline{kind: pipelineSelect}, nil
+	}
+	return pipeline{}, fmt.Errorf("pipeline stage does not match a known shape %q", s)
+}
+
+// groupByTraceID buckets spans by TraceID and returns each bucket's
+// per-trace count. The generator stamps each chain's spans on a shared
+// TraceID (see gen/traceql.go), so a multi-span chain now produces a
+// bucket with size > 1 — the shape count() is meant to discriminate on.
 func groupByTraceID(spans []spanView) map[string]int64 {
 	out := map[string]int64{}
 	for _, s := range spans {
@@ -98,168 +514,186 @@ func groupByTraceID(spans []spanView) map[string]int64 {
 	return out
 }
 
-// spanView is the oracle's per-span snapshot: just the fields the
-// evaluator needs to apply the selector and aggregate. Built once per
-// Evaluate call from the dataset's MetricsModel series.
-type spanView struct {
-	traceID       string
-	service       string
-	name          string
-	startTimeMs   int64
-	durationFloat float64
+// countPipelineOutcome implements `| count() OP N`: one outcome row
+// per trace whose per-trace count of matched spans satisfies the
+// predicate.
+func countPipelineOutcome(spans []spanView, pl pipeline) property.Outcome {
+	cmp, err := int64Comparator(pl.op)
+	if err != nil {
+		return property.Outcome{Err: err}
+	}
+	perTrace := groupByTraceID(spans)
+	rows := make([]property.OutcomeRow, 0, len(perTrace))
+	for _, count := range perTrace {
+		if cmp(count, pl.n) {
+			rows = append(rows, property.OutcomeRow{Labels: map[string]string{}})
+		}
+	}
+	return property.Outcome{Rows: rows}
 }
 
-// filterSpans pivots the dataset's MetricsModel into the spanView
-// shape and applies the selector predicate. Only one selector kind is
-// supported today: `resource.service.name = "<value>"`. The TraceID
-// is threaded through so trace-scoped aggregates (`| count()`) can
-// bucket by trace identity rather than flattening across the corpus.
-func filterSpans(d property.Dataset, sel selector) []spanView {
-	if d.Metrics == nil {
-		return nil
+// aggregateDurations reduces a trace's matched-span durations (ns)
+// with the named function — the same four reducers cerberus's
+// avg|min|max|sum(duration) pipeline lowers to (see e.g.
+// test/spec/traceql/avg_duration.txtar's `Aggregate ... funcs=[avg(Duration) ...]`).
+func aggregateDurations(fn string, durations []int64) (float64, error) {
+	if len(durations) == 0 {
+		return 0, fmt.Errorf("aggregateDurations: empty durations for fn %q", fn)
 	}
-	out := make([]spanView, 0, len(d.Metrics.Series))
-	for _, s := range d.Metrics.Series {
-		svc := s.Labels["resource.service.name"]
-		if !sel.match(svc) {
-			continue
+	switch fn {
+	case "avg":
+		var sum int64
+		for _, d := range durations {
+			sum += d
 		}
-		// SeriesData carries one Point per span (Generator invariant).
-		// startTimeMs / duration come from that Point.
-		var startMs int64
-		var durFloat float64
-		if len(s.Points) > 0 {
-			startMs = s.Points[0].TimestampMs
-			durFloat = s.Points[0].Value
+		return float64(sum) / float64(len(durations)), nil
+	case "min":
+		m := durations[0]
+		for _, d := range durations[1:] {
+			if d < m {
+				m = d
+			}
 		}
-		out = append(out, spanView{
-			traceID:       s.Labels["__traceID__"],
-			service:       svc,
-			name:          s.MetricName,
-			startTimeMs:   startMs,
-			durationFloat: durFloat,
-		})
+		return float64(m), nil
+	case "max":
+		m := durations[0]
+		for _, d := range durations[1:] {
+			if d > m {
+				m = d
+			}
+		}
+		return float64(m), nil
+	case "sum":
+		var sum int64
+		for _, d := range durations {
+			sum += d
+		}
+		return float64(sum), nil
 	}
-	return out
+	return 0, fmt.Errorf("unsupported metric function %q", fn)
 }
 
-// parsedQuery is what parseQuery returns. The selector + optional
-// scalar-filter components are decoupled so the evaluator can stamp
-// them onto separate code paths.
+// metricPipelineOutcome implements `| avg|min|max|sum(duration) OP
+// Nms`: one outcome row per trace whose per-trace duration aggregate
+// satisfies the predicate.
+func metricPipelineOutcome(spans []spanView, pl pipeline) property.Outcome {
+	perTrace := map[string][]int64{}
+	for _, sv := range spans {
+		perTrace[sv.traceID] = append(perTrace[sv.traceID], sv.durationNs)
+	}
+	cmp, err := float64Comparator(pl.op)
+	if err != nil {
+		return property.Outcome{Err: err}
+	}
+	rows := make([]property.OutcomeRow, 0, len(perTrace))
+	for _, durations := range perTrace {
+		value, err := aggregateDurations(pl.fn, durations)
+		if err != nil {
+			return property.Outcome{Err: err}
+		}
+		if cmp(value, float64(pl.thresholdNs)) {
+			rows = append(rows, property.OutcomeRow{Labels: map[string]string{}})
+		}
+	}
+	return property.Outcome{Rows: rows}
+}
+
+// parsedQuery is what parseQuery returns: the base spanset/structural
+// query plus an optional pipeline stage.
 type parsedQuery struct {
-	selector selector
-	hasCount bool
-	countOp  string
-	countN   int64
+	base     baseQuery
+	pipeline pipeline
 }
-
-// selector is the spanset-filter predicate the oracle understands.
-// Only the equality variant is supported today; future generator
-// widening (regex, !=, intrinsics) lands new helpers + match() arms.
-type selector struct {
-	attr  string // always "resource.service.name" today
-	value string
-}
-
-func (s selector) match(observed string) bool {
-	if s.attr == "" {
-		return true
-	}
-	return observed == s.value
-}
-
-// queryRe matches the generator's full output shape:
-//
-//	{ resource.service.name = "<value>" } [| count() <op> <int>]
-//
-// Anchored so unexpected characters fail fast. The selector group
-// captures the quoted service name; the optional pipeline group
-// captures the scalar filter operator + threshold.
-var queryRe = regexp.MustCompile(
-	`^\s*\{\s*resource\.service\.name\s*=\s*"([^"]*)"\s*\}` +
-		`(?:\s*\|\s*count\(\)\s*(>=|<=|>|<|=)\s*(\d+))?\s*$`,
-)
 
 // parseQuery is the hand-rolled recognizer keyed to the generator's
-// accept-set. Anything outside that set returns an error — the
-// generator never emits other shapes so a parse failure is a
-// generator bug, not a real divergence. (rapid will still surface
-// it as a property-test failure, but the failure log says "oracle:
-// parse" which is the right pointer.)
+// accept-set (test/property/gen/traceql.go's TraceQLQuery doc lists
+// all 14 shapes). Anything outside that set returns an error — the
+// generator never emits other shapes so a parse failure is a generator
+// bug, not a real divergence. (rapid will still surface it as a
+// property-test failure, but the failure log says "oracle: parse"
+// which is the right pointer.)
 //
 // The recognizer is intentionally narrow rather than wrapping
-// `tempo/pkg/traceql.Parse` because the entire purpose of the
+// `internal/traceql/ast`'s parser because the entire purpose of the
 // from-scratch oracle is to NOT share code with the side under test.
 // When the cerberus pipeline imports the same parser, a parser-side
 // bug becomes invisible to a property test that reuses it.
 func parseQuery(q string) (parsedQuery, error) {
-	m := queryRe.FindStringSubmatch(q)
-	if m == nil {
-		return parsedQuery{}, fmt.Errorf("query does not match expected shape %q", q)
+	baseStr, pipelineStr, hasPipeline := splitPipeline(strings.TrimSpace(q))
+	base, err := parseBase(baseStr)
+	if err != nil {
+		return parsedQuery{}, err
 	}
-	out := parsedQuery{
-		selector: selector{
-			attr:  "resource.service.name",
-			value: m[1],
-		},
-	}
-	if m[2] != "" {
-		out.hasCount = true
-		out.countOp = m[2]
-		n, err := strconv.ParseInt(m[3], 10, 64)
+	pl := pipeline{kind: pipelineNone}
+	if hasPipeline {
+		pl, err = parsePipeline(pipelineStr)
 		if err != nil {
-			return parsedQuery{}, fmt.Errorf("count threshold %q: %w", m[3], err)
+			return parsedQuery{}, err
 		}
-		out.countN = n
 	}
-	return out, nil
+	return parsedQuery{base: base, pipeline: pl}, nil
 }
 
-// compareCount applies the scalar-filter operator to (count, n).
-// Operators are the five the generator emits.
-func compareCount(count int64, op string, n int64) bool {
-	switch op {
-	case ">":
-		return count > n
-	case ">=":
-		return count >= n
-	case "<":
-		return count < n
-	case "<=":
-		return count <= n
-	case "=":
-		return count == n
+// splitPipeline splits q on its first top-level ` | `. Base-query
+// values never contain `|` (plain pool strings), so the first
+// occurrence is always the pipeline boundary.
+func splitPipeline(q string) (base, pipelineStr string, hasPipeline bool) {
+	idx := strings.Index(q, " | ")
+	if idx < 0 {
+		return q, "", false
 	}
-	// Defensive: the generator only emits the five operators, but
-	// strings.Contains-style false positives are harmless — surface
-	// the unknown op so the property test fails loudly instead of
-	// silently agreeing on the wrong predicate.
-	return false
+	return q[:idx], q[idx+len(" | "):], true
 }
 
-// init validates the recognizer once at package load. queryRe must
-// not change behaviour from a typo in the literal; the test below
-// pins the supported shape so a future edit that breaks parsing
+// init validates the recognizer once at package load, one query per
+// generator shape (test/property/gen/traceql.go's TraceQLQuery doc).
+// Pins the supported grammar so a future edit that breaks parsing
 // fires at package-init rather than mid-iteration.
-//
-// Kept lightweight: the strings exercised here are the same constants
-// the generator emits, so a future generator change will surface as a
-// failed property test rather than a panic here.
 func init() {
 	for _, q := range []string{
+		// Shape 0: bare selector.
 		`{ resource.service.name = "api" }`,
+		// Shape 1: selector + count() filter, all five operators.
 		`{ resource.service.name = "api" } | count() > 0`,
 		`{ resource.service.name = "api" } | count() >= 1`,
 		`{ resource.service.name = "api" } | count() < 5`,
 		`{ resource.service.name = "api" } | count() <= 3`,
 		`{ resource.service.name = "api" } | count() = 2`,
+		// Shape 2: resource attribute beyond service.name.
+		`{ resource.cluster = "east" }`,
+		// Shape 3: span attribute matcher.
+		`{ span.http.method = "GET" }`,
+		// Shape 4: duration intrinsic.
+		`{ duration > 100ms }`,
+		`{ duration = 50ms }`,
+		// Shape 5: status intrinsic, eq and negated.
+		`{ status = ok }`,
+		`{ status != error }`,
+		// Shape 6: name intrinsic.
+		`{ name = "GET /api/0" }`,
+		// Shape 7: regex attribute matcher.
+		`{ resource.service.name =~ "a.*" }`,
+		// Shape 8: negated attribute matcher.
+		`{ resource.service.name != "api" }`,
+		// Shape 9: multi-condition (&&) filter.
+		`{ resource.service.name = "api" && status = ok }`,
+		// Shape 10 / 11: structural child / descendant.
+		`{ resource.service.name = "api" } > { resource.service.name = "web" }`,
+		`{ resource.service.name = "api" } >> { resource.service.name = "web" }`,
+		// Shape 12: metric beyond count().
+		`{ resource.service.name = "api" } | avg(duration) > 50ms`,
+		`{ resource.service.name = "api" } | min(duration) <= 10ms`,
+		`{ resource.service.name = "api" } | max(duration) >= 300ms`,
+		`{ resource.service.name = "api" } | sum(duration) = 120ms`,
+		// Shape 13: select() pipeline stage.
+		`{ resource.service.name = "api" } | select(span.http.method)`,
 	} {
 		if _, err := parseQuery(q); err != nil {
 			panic(fmt.Sprintf("oracle/traceql: package-init recognizer regression on %q: %v", q, err))
 		}
 	}
-	// Sanity: a query the recognizer must REJECT.
+	// Sanity: a query the recognizer must REJECT (unknown attribute path).
 	if _, err := parseQuery(`{ span.unknown = "x" }`); err == nil {
-		panic("oracle/traceql: recognizer should reject span-scope attribute query")
+		panic("oracle/traceql: recognizer should reject an unlisted attribute path")
 	}
 }

--- a/test/property/oracle/traceql/evaluator_test.go
+++ b/test/property/oracle/traceql/evaluator_test.go
@@ -1,0 +1,152 @@
+package traceql
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/tsouza/cerberus/test/property"
+)
+
+// testSpan is the compact per-span fixture shape these tests build
+// datasets from. Mirrors gen/traceql.go's traceQLSpan, minus the
+// timing fields the oracle doesn't read.
+type testSpan struct {
+	trace, id, parent string
+	service, cluster  string
+	method            string
+	name              string
+	status            string
+	durationMs        int64
+}
+
+// buildDataset pivots testSpans into the property.Dataset shape
+// gen/traceql.go's traceQLSpansToSeries produces, using the same
+// reserved-label-key convention (see evaluator.go's spanViews).
+func buildDataset(spans ...testSpan) property.Dataset {
+	series := make([]property.SeriesData, 0, len(spans))
+	for i, s := range spans {
+		series = append(series, property.SeriesData{
+			MetricName: s.name,
+			Labels: map[string]string{
+				"resource.service.name": s.service,
+				"resource.cluster":      s.cluster,
+				"span.http.method":      s.method,
+				"__name__":              s.name,
+				"__traceID__":           s.trace,
+				"__spanID__":            s.id,
+				"__parentSpanID__":      s.parent,
+				"__status__":            s.status,
+				"__duration_ns__":       fmt.Sprintf("%d", s.durationMs*nsPerMillisecond),
+			},
+			Points: []property.Point{{TimestampMs: int64(i), Value: float64(s.durationMs * nsPerMillisecond)}},
+		})
+	}
+	return property.Dataset{Metrics: &property.MetricsModel{Series: series}}
+}
+
+// fixtureDataset is the shared trace shape every shape test below
+// evaluates queries against:
+//
+//	t1: r1(api, east, GET, Ok, 50ms) -> c1(web, east, POST, Error, 100ms) -> g1(batch, west, GET, Unset, 300ms)
+//	t2: r2(api, west, GET, Ok, 10ms)
+//
+// A linear 3-deep chain in t1 plus a lone root in t2 exercises both
+// structural operators (`>`, `>>`) and gives count()/avg|min|max|sum
+// a multi-span trace to aggregate over.
+func fixtureDataset() property.Dataset {
+	return buildDataset(
+		testSpan{trace: "t1", id: "s1", parent: "0000000000000000", service: "api", cluster: "east", method: "GET", name: "r1", status: "Ok", durationMs: 50},
+		testSpan{trace: "t1", id: "s2", parent: "s1", service: "web", cluster: "east", method: "POST", name: "c1", status: "Error", durationMs: 100},
+		testSpan{trace: "t1", id: "s3", parent: "s2", service: "batch", cluster: "west", method: "GET", name: "g1", status: "Unset", durationMs: 300},
+		testSpan{trace: "t2", id: "s10", parent: "0000000000000000", service: "api", cluster: "west", method: "GET", name: "r2", status: "Ok", durationMs: 10},
+	)
+}
+
+func evalQ(t *testing.T, q string) property.Outcome {
+	t.Helper()
+	return Evaluate(fixtureDataset(), property.Query{String: q, EvalTs: 0})
+}
+
+// TestEvaluate_Shapes covers one representative query per generator
+// shape (test/property/gen/traceql.go's TraceQLQuery doc), asserting
+// the exact row count against the fixtureDataset by hand-derived
+// expectation. Every case here failed with a parse or evaluation error
+// before this change — the recognizer only understood the bare
+// selector and `| count()` shapes.
+func TestEvaluate_Shapes(t *testing.T) {
+	cases := []struct {
+		name      string
+		query     string
+		wantCount int
+	}{
+		{"shape0_bare_selector", `{ resource.service.name = "api" }`, 2},            // r1, r2
+		{"shape0_bare_selector_no_match", `{ resource.service.name = "cache" }`, 0}, // no span uses this service
+
+		{"shape1_count_satisfied", `{ resource.cluster = "east" } | count() = 2`, 1}, // t1 has 2 east-cluster spans
+		{"shape1_count_unsatisfied", `{ resource.cluster = "east" } | count() = 3`, 0},
+
+		{"shape2_attr_beyond_service", `{ resource.cluster = "west" }`, 2}, // g1, r2
+
+		{"shape3_span_attr", `{ span.http.method = "POST" }`, 1}, // c1
+
+		{"shape4_duration_gt", `{ duration > 100ms }`, 1}, // g1 (300ms)
+		{"shape4_duration_le", `{ duration <= 10ms }`, 1}, // r2 (10ms)
+
+		{"shape5_status_eq", `{ status = ok }`, 2},      // r1, r2
+		{"shape5_status_neq", `{ status != error }`, 3}, // r1, g1, r2
+
+		{"shape6_name_match", `{ name = "c1" }`, 1},
+		{"shape6_name_no_match", `{ name = "nonexistent-span-name" }`, 0},
+
+		{"shape7_regex_match", `{ resource.service.name =~ "^a.*" }`, 2},   // api, api
+		{"shape7_regex_negated", `{ resource.service.name !~ "^a.*" }`, 2}, // web, batch
+
+		{"shape8_negation", `{ resource.service.name != "api" }`, 2}, // web, batch
+
+		{"shape9_multi_condition_match", `{ resource.service.name = "api" && status = ok }`, 2},
+		{"shape9_multi_condition_narrows", `{ resource.cluster = "east" && span.http.method = "POST" }`, 1}, // c1 only, not r1
+
+		{"shape10_structural_child_match", `{ resource.service.name = "api" } > { resource.service.name = "web" }`, 1},      // c1's parent r1 is api
+		{"shape10_structural_child_no_match", `{ resource.service.name = "batch" } > { resource.service.name = "api" }`, 0}, // roots have no matching parent
+
+		{"shape11_structural_descendant_match", `{ resource.service.name = "api" } >> { resource.service.name = "batch" }`, 1}, // g1's ancestor r1 is api
+		{"shape11_structural_descendant_excludes_self", `{ resource.service.name = "web" } >> { resource.service.name = "web" }`, 0},
+
+		{"shape12_avg", `{ resource.cluster = "east" } | avg(duration) > 60ms`, 1}, // (50+100)/2=75 > 60
+		{"shape12_avg_unsatisfied", `{ resource.cluster = "east" } | avg(duration) > 80ms`, 0},
+		{"shape12_min", `{ resource.cluster = "east" } | min(duration) <= 50ms`, 1},
+		{"shape12_max", `{ resource.cluster = "east" } | max(duration) >= 100ms`, 1},
+		{"shape12_sum", `{ resource.cluster = "east" } | sum(duration) = 150ms`, 1},
+
+		{"shape13_select", `{ resource.service.name = "api" } | select(span.http.method)`, 2}, // same row count as the bare selector
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := evalQ(t, tc.query)
+			if out.Err != nil {
+				t.Fatalf("query %q: unexpected error: %v", tc.query, out.Err)
+			}
+			if len(out.Rows) != tc.wantCount {
+				t.Fatalf("query %q: row count = %d, want %d", tc.query, len(out.Rows), tc.wantCount)
+			}
+		})
+	}
+}
+
+// TestEvaluate_ParseErrors asserts the recognizer rejects shapes
+// outside the generator's accept-set rather than silently
+// misevaluating them.
+func TestEvaluate_ParseErrors(t *testing.T) {
+	for _, q := range []string{
+		"not a traceql query at all",
+		`{ resource.service.name = "api" `,              // unbalanced brace
+		`{ span.unknown.attr = "x" }`,                   // attribute path outside the generator's pool
+		`{ resource.service.name = "api" } | avg() > 1`, // avg() needs an argument
+	} {
+		out := evalQ(t, q)
+		if out.Err == nil {
+			t.Fatalf("query %q: expected a parse error, got rows=%d", q, len(out.Rows))
+		}
+	}
+}

--- a/test/property/traceql_test.go
+++ b/test/property/traceql_test.go
@@ -11,9 +11,11 @@
 //     (shared across iterations; each iteration's
 //     CREATE OR REPLACE TABLE statement keeps replays idempotent).
 //  3. The TraceQL generator (gen.TraceQLQuery) draws a random query
-//     targeting the dataset's service pool — either a bare
-//     `{ resource.service.name = "<value>" }` selector or a
-//     selector + `| count() OP N` scalar filter.
+//     from 14 shapes — attribute matchers (resource + span scope,
+//     equality/negation/regex), duration/status/name intrinsics,
+//     multi-condition filters, structural relations (`>`/`>>`),
+//     count()/avg()/min()/max()/sum() scalar-filter pipelines, and
+//     select() — see gen.TraceQLQuery's doc for the full list.
 //  4. The from-scratch oracle (oracle/traceql.Evaluate) evaluates the
 //     query against an in-memory mirror of the dataset, implementing
 //     spanset filter + count() semantics directly from the TraceQL


### PR DESCRIPTION
## Summary

`test/property/gen/traceql.go` drew exactly one spanset filter shape — `{ resource.service.name = "<v>" }` — plus an optional `| count() OP N` filter, as issue #1471 described (verified at the file:line it cited; the docstring literally still said "The accept-set for this first sweep"). Every one of the 500 rapid iterations the required `property (PromQL + LogQL + TraceQL, rapid N=500)` check runs was that same shape wearing different literal values, so the check name advertised TraceQL coverage the generator never supplied.

- Widens `TraceQLQuery` to 14 shapes (drawn via `rapid.IntRange(0, 13)`, matching the breadth pattern of the PromQL leg's `drawExpr`): attribute matchers beyond `service.name` (a second resource attribute + a span attribute), duration/status/name intrinsics, regex matchers, negation, multi-condition (`&&`) filters, structural operators (`>`, `>>`), `avg`/`min`/`max`/`sum(duration)` alongside `count()`, and `select()`.
- Widens `TraceQLDataset` to emit multi-span traces (linear parent chains, 1-3 deep) so the structural operators have a real ancestor/descendant relationship to exercise, and to vary status/duration per span instead of fixing them.
- Extends the from-scratch oracle (`test/property/oracle/traceql`) to independently evaluate every added shape — per the issue's explicit requirement, a shape only lands once the oracle can verify it, never the reverse. Adds `evaluator_test.go` pinning one hand-derived row-count expectation per shape (27 sub-tests), plus a parse-error/rejection test.
- States each head's current generator breadth in `docs/test-strategy.md` (new "Per-head generator breadth" table) so a stalled leg is visible without diffing generator source, per the issue's fix-shape suggestion.

## What I found while widening it

Running the widened generator against real cerberus (chdb-tagged `TestTraceQL_Property`, two independent runs of 500 iterations, both green) surfaced two dataset-fidelity gaps in the property-test fixture that the original single-shape generator never exercised:

1. The seed DDL was missing the `ScopeName`/`ScopeVersion` columns. `internal/traceql/lower.go`'s `structuralExtraProjectionColumns` projects them unconditionally into every structural-join (`>`/`>>`) wrap query, so the first structural query 502'd with `UNKNOWN_IDENTIFIER`.
2. `TraceId`/`SpanId`/`ParentSpanId` were typed `FixedString` in the generator's DDL, but `internal/schema/traces.go` documents (and `test/spec/traceql/*.txtar` fixtures consistently use) plain `String` — the recursive `>>` closure query's implicit cast broke on the mismatch (`could not cast to type: FIXED_LEN_BYTE_ARRAY(32)`).

Both are bugs in the property-test's synthetic dataset, not in cerberus — real OTel-CH-exported tables always carry these columns/types, so production traffic was never at risk. Fixed alongside the widening since they blocked every structural-operator shape from running at all; resolved in this change.

## Test plan

- [x] `go build ./...`
- [x] `go test ./test/property/oracle/traceql/...` (27 new sub-tests, one hand-derived expectation per shape)
- [x] `go test -tags chdb -run TestTraceQL_Property -rapid.checks=500 ./test/property/...` — two independent runs, both green
- [x] `go test -tags chdb ./test/property/...` (full PromQL + LogQL + TraceQL property suite, unaffected)
- [x] `markdownlint-cli2 docs/test-strategy.md` (table alignment for MD060)
- [x] pre-push hook (golangci-lint full + build-tags, forbid-skip/escape-hatch/sql-raw/soft-assert greps, actionlint, commitlint) — all green locally

Closes #1471