### PR TITLE
fix(strict-scan): reconstruct production wrap-projection for TraceQL search fixtures

### DIFF
--- a/internal/traceql/lower.go
+++ b/internal/traceql/lower.go
@@ -741,7 +741,7 @@ func mapStructuralOp(op traceql.Operator) (chplan.StructuralOp, error) {
 // otel_traces. The field expression is recursively lowered into a
 // chplan.Expr predicate.
 func lowerSpansetFilter(f *traceql.SpansetFilter, s schema.Traces) (chplan.Node, error) {
-	pred, err := lowerFieldExpr(f.Expression, s)
+	pred, err := lowerBooleanFieldExpr(f.Expression, s)
 	if err != nil {
 		return nil, err
 	}
@@ -811,6 +811,38 @@ func lowerFieldExpr(e traceql.FieldExpression, s schema.Traces) (chplan.Expr, er
 		return lowerStatic(v)
 	}
 	return nil, fmt.Errorf("traceql: field expression %T is unsupported", e)
+}
+
+// lowerBooleanFieldExpr is lowerFieldExpr for the three positions a
+// FieldExpression is required to yield a BOOLEAN chplan.Expr: a spanset
+// filter's whole predicate (lowerSpansetFilter), an AND/OR operand
+// (lowerBinaryOperation), and a logical-NOT operand (lowerUnaryNot).
+//
+// Those are also the only positions where a bare `parent` (IntrinsicParent)
+// means TraceQL's "this span has a parent" boolean — ast.Attribute's own
+// impliedType() marks IntrinsicParent TypeNil (unlike every other backed
+// intrinsic, which has a real scalar type) precisely because it has no
+// value-position identity of its own; `parent = "<hex span id>"` is a
+// perfectly ordinary comparison against the raw ParentSpanId string
+// (span:parentID / IntrinsicParentID is the separate, TypeString intrinsic
+// for that value, but reference Tempo also accepts bare `parent` compared to
+// a literal) and must keep lowering to the bare column through the generic
+// lowerFieldExpr path — only the boolean position needs the rewrite.
+// ParentSpanId is a real ClickHouse String column, and a bare String
+// reference is not a valid boolean filter predicate — ClickHouse rejects it
+// with ILLEGAL_TYPE_OF_COLUMN_FOR_FILTER ("Invalid type for filter") — so
+// synthesise the presence check instead of a bare ColumnRef. Mirrors
+// rootnessReduction's identical `ParentSpanId != ""` pattern for the related
+// nestedSetParent root-ness reduction.
+func lowerBooleanFieldExpr(e traceql.FieldExpression, s schema.Traces) (chplan.Expr, error) {
+	if attr, ok := fieldExprAttribute(e); ok && attr.Intrinsic == traceql.IntrinsicParent {
+		return &chplan.Binary{
+			Op:    chplan.OpNe,
+			Left:  &chplan.ColumnRef{Name: s.ParentSpanIDColumn},
+			Right: &chplan.LitString{V: ""},
+		}, nil
+	}
+	return lowerFieldExpr(e, s)
 }
 
 // lowerUnaryOperation handles the unary FieldExpression forms.
@@ -936,7 +968,11 @@ func lowerUnaryMinus(u traceql.UnaryOperation, s schema.Traces) (chplan.Expr, er
 // / coerce paths), and `not(false)` is true — the same value reference
 // computes when the comparison evaluates StaticFalse on a missing span.
 func lowerUnaryNot(u traceql.UnaryOperation, s schema.Traces) (chplan.Expr, error) {
-	inner, err := lowerFieldExpr(u.Expression, s)
+	// The NOT operand is a boolean position — same rationale as the AND/OR
+	// operand rewrite in lowerBinaryOperation (see lowerBooleanFieldExpr's
+	// doc comment): `!parent` must lower to `not(ParentSpanId != "")`, not
+	// `not(<bare ColumnRef>)`.
+	inner, err := lowerBooleanFieldExpr(u.Expression, s)
 	if err != nil {
 		return nil, err
 	}
@@ -1153,11 +1189,22 @@ func lowerBinaryOperation(b *traceql.BinaryOperation, s schema.Traces) (chplan.E
 	if nested, ok := lowerNestedAttrBinary(b, op, s); ok {
 		return nested, nil
 	}
-	lhs, err := lowerFieldExpr(b.LHS, s)
+	// AND/OR operands are boolean positions — route through
+	// lowerBooleanFieldExpr so a bare `parent` operand (e.g.
+	// `{ parent && resource.service.name = "api" }`) lowers to the
+	// `ParentSpanId != ""` presence check rather than a bare (invalid
+	// filter-predicate-typed) ColumnRef. Every other op's operands are
+	// value positions (`parent = "<hex>"` must keep reading the raw
+	// column), so they keep going through the generic lowerFieldExpr.
+	lowerOperand := lowerFieldExpr
+	if op == chplan.OpAnd || op == chplan.OpOr {
+		lowerOperand = lowerBooleanFieldExpr
+	}
+	lhs, err := lowerOperand(b.LHS, s)
 	if err != nil {
 		return nil, err
 	}
-	rhs, err := lowerFieldExpr(b.RHS, s)
+	rhs, err := lowerOperand(b.RHS, s)
 	if err != nil {
 		return nil, err
 	}

--- a/test/spec/roundtrip_prep.go
+++ b/test/spec/roundtrip_prep.go
@@ -266,6 +266,200 @@ func PromoteCreateTable(stmt string) string {
 	return promoteCreateTable(stmt)
 }
 
+// tracesTableName is the fixed table name TraceQL round-trip seeds declare
+// for the spans table — schema.DefaultOTelTraces().SpansTable, mirrored here
+// as a literal so this build-tag-free file doesn't need to import
+// internal/schema just for one string.
+const tracesTableName = "otel_traces"
+
+// tracesBackfilledColumns are the production otel_traces columns
+// wrapWithSampleProjection's canonical wrap (internal/api/tempo/handler.go)
+// reads unconditionally: TraceId / SpanId / ParentSpanId feed the reserved
+// `__cerberus_*` Attributes keys, SpanName / ResourceAttributes / Timestamp /
+// Duration are the four Sample-shape source columns. A TraceQL spec fixture's
+// seed is written minimally — declaring only the columns ITS OWN pre-wrap
+// `-- sql --` touches — so most fixtures omit some of these; the strict-scan
+// differential's wrap reconstruction (traceqlWrapForStrictScan) needs all
+// seven present or the wrapped SQL 502s with UNKNOWN_IDENTIFIER, a false
+// failure that has nothing to do with the strict-scan / type-coercion bug
+// class this lane exists to catch. Types + names mirror the upstream OTel-CH
+// traces DDL (see internal/schema/traces.go's DefaultOTelTraces).
+var tracesBackfilledColumns = []backfilledColumn{
+	{name: "TraceId", ddl: "TraceId String DEFAULT ''"},
+	{name: "SpanId", ddl: "SpanId String DEFAULT ''"},
+	{name: "ParentSpanId", ddl: "ParentSpanId String DEFAULT ''"},
+	{name: "SpanName", ddl: "SpanName String DEFAULT ''"},
+	{name: "Duration", ddl: "Duration Int64 DEFAULT 0"},
+	{name: "Timestamp", ddl: "Timestamp DateTime64(9) DEFAULT toDateTime64(0, 9)"},
+	{name: "ResourceAttributes", ddl: "ResourceAttributes Map(String, String) DEFAULT map()"},
+}
+
+// BackfillTracesColumns mirrors production's otel_traces column set (see
+// [tracesBackfilledColumns]) onto a TraceQL fixture's simplified seed DDL —
+// the traces-table counterpart of [BackfillMetricsColumns]. Exported,
+// build-tag-free seam for the strict-scan differential's seed loop.
+func BackfillTracesColumns(stmts []string) []string {
+	return backfillTracesColumns(stmts)
+}
+
+func backfillTracesColumns(stmts []string) []string {
+	// table name -> ordered column names (pre-backfill) for tables we
+	// injected a column into. Only these tables' INSERTs are rewritten.
+	cols := map[string][]string{}
+	out := make([]string, 0, len(stmts))
+	for _, stmt := range stmts {
+		if table, colNames, body, ok := parseTracesCreate(stmt); ok {
+			cols[table] = colNames
+			out = append(out, body)
+			continue
+		}
+		if rewritten, ok := rewriteBackfilledInsert(stmt, cols); ok {
+			out = append(out, rewritten)
+			continue
+		}
+		out = append(out, stmt)
+	}
+	return out
+}
+
+// parseTracesCreate reports whether stmt is a `CREATE TABLE otel_traces` that
+// omits at least one [tracesBackfilledColumns] entry. On a match it returns
+// the table name, the ordered pre-backfill column names, and the rewritten
+// statement with the missing columns appended to the column list (order is
+// irrelevant — the INSERTs become explicit-column, mirroring
+// [parseMetricsCreate]).
+func parseTracesCreate(stmt string) (table string, colNames []string, rewritten string, ok bool) {
+	trimmed := stripLeadingNoise(stmt)
+	rest, ok := createTableTail(trimmed)
+	if !ok {
+		return "", nil, "", false
+	}
+	name := strings.ToLower(strings.TrimSpace(firstToken(rest)))
+	if name != tracesTableName {
+		return "", nil, "", false
+	}
+	open := strings.IndexByte(stmt, '(')
+	if open < 0 {
+		return "", nil, "", false
+	}
+	closeParen := matchParen(stmt, open)
+	if closeParen < 0 {
+		return "", nil, "", false
+	}
+	bodyCols := stmt[open+1 : closeParen]
+	defs := splitTopLevelCommas(bodyCols)
+	declared := make(map[string]bool, len(defs))
+	names := make([]string, 0, len(defs))
+	normDefs := make([]string, len(defs))
+	changed := false
+	for i, d := range defs {
+		cn := firstToken(strings.TrimSpace(d))
+		if cn != "" {
+			declared[cn] = true
+			names = append(names, cn)
+		}
+		nd := normalizeTracesColumnDef(d)
+		if nd != d {
+			changed = true
+		}
+		normDefs[i] = nd
+	}
+	missing := make([]string, 0, len(tracesBackfilledColumns))
+	for _, c := range tracesBackfilledColumns {
+		if !declared[c.name] {
+			missing = append(missing, c.ddl)
+		}
+	}
+	if len(missing) == 0 && !changed {
+		return "", nil, "", false
+	}
+	newDefs := make([]string, 0, len(normDefs)+len(missing))
+	newDefs = append(newDefs, normDefs...)
+	for _, ddl := range missing {
+		newDefs = append(newDefs, " "+ddl)
+	}
+	rewritten = stmt[:open+1] + strings.Join(newDefs, ",") + stmt[closeParen:]
+	return name, names, rewritten, true
+}
+
+// normalizeTracesColumnDef rewrites a single otel_traces column definition so
+// it type-matches production's OTel-CH schema closely enough for the
+// strict-scan wrap reconstruction (traceqlWrapForStrictScan) to strict-scan
+// cleanly, without touching any other lane's seed application — only the
+// strict-scan differential calls [BackfillTracesColumns]. Two independent
+// fixups, each addressing a fixture-authoring shortcut that predates the
+// wrap reconstruction and was invisible under the old pre-wrap-only `-- sql
+// --`:
+//
+//  1. `MATERIALIZED` -> `DEFAULT`. ClickHouse's bare `SELECT *` omits
+//     MATERIALIZED columns from the result set by design; several fixtures
+//     use MATERIALIZED as a terse way to derive a column (typically
+//     ResourceAttributes) from another column's value without a verbose
+//     per-row INSERT. wrapWithSampleProjection's canonical branch always
+//     projects from a `SELECT * FROM otel_traces WHERE ...` subquery, so a
+//     MATERIALIZED column it needs silently vanishes from that subquery's
+//     column set ("Unknown identifier") — not a real production bug, since
+//     real otel_traces columns are never MATERIALIZED. DEFAULT computes the
+//     identical value at INSERT time (these fixtures never override it) and
+//     DOES appear in `SELECT *`.
+//  2. Timestamp / Duration retyped to their real OTel-CH types
+//     (DateTime64(9) / Int64, see internal/schema/traces.go's
+//     DefaultOTelTraces) when a fixture declares them as a bare integer
+//     (UInt64 etc) — a shortcut that was invisible while nothing read
+//     Timestamp through the typed TimeUnix (time.Time) alias the wrap
+//     projects it under.
+func normalizeTracesColumnDef(def string) string {
+	rewritten := strings.Replace(def, " MATERIALIZED ", " DEFAULT ", 1)
+	switch firstToken(strings.TrimSpace(rewritten)) {
+	case "Timestamp":
+		if !hasColumnType(rewritten, "DateTime64") {
+			rewritten = replaceColumnType(rewritten, "DateTime64(9)")
+		}
+	case "Duration":
+		if !hasColumnType(rewritten, "Int64") {
+			rewritten = replaceColumnType(rewritten, "Int64")
+		}
+	}
+	return rewritten
+}
+
+// hasColumnType reports whether def's column-type token starts with prefix
+// (e.g. prefix "DateTime64" matches both "DateTime64(9)" and a bare
+// "DateTime64").
+func hasColumnType(def, prefix string) bool {
+	trimmed := strings.TrimSpace(def)
+	name := firstToken(trimmed)
+	rest := strings.TrimSpace(trimmed[len(name):])
+	return strings.HasPrefix(rest, prefix)
+}
+
+// replaceColumnType swaps def's leading type token (the run up to the next
+// top-level space, honouring the type's own parens — e.g. "DateTime64(9)")
+// for wantType, leaving any trailing DEFAULT/MATERIALIZED clause untouched.
+func replaceColumnType(def, wantType string) string {
+	trimmed := strings.TrimSpace(def)
+	name := firstToken(trimmed)
+	rest := strings.TrimSpace(trimmed[len(name):])
+	depth := 0
+	end := len(rest)
+	for i := 0; i < len(rest); i++ {
+		switch rest[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+		case ' ':
+			if depth == 0 {
+				end = i
+			}
+		}
+		if end != len(rest) {
+			break
+		}
+	}
+	return name + " " + wantType + rest[end:]
+}
+
 func backfillMetricsColumns(stmts []string) []string {
 	// table name -> ordered column names (pre-backfill) for tables we
 	// injected a column into. Only these tables' INSERTs are rewritten.
@@ -277,7 +471,7 @@ func backfillMetricsColumns(stmts []string) []string {
 			out = append(out, body)
 			continue
 		}
-		if rewritten, ok := rewriteMetricsInsert(stmt, cols); ok {
+		if rewritten, ok := rewriteBackfilledInsert(stmt, cols); ok {
 			out = append(out, rewritten)
 			continue
 		}
@@ -380,12 +574,15 @@ func parseMetricsCreate(stmt string) (table string, colNames []string, rewritten
 	return name, names, rewritten, true
 }
 
-// rewriteMetricsInsert rewrites a positional `INSERT INTO <table> VALUES`
+// rewriteBackfilledInsert rewrites a positional `INSERT INTO <table> VALUES`
 // into one carrying the recorded column list (sans the injected columns)
 // so the DEFAULT-filled columns do not break the value count. Inserts into
 // untracked tables, or that already carry an explicit column list, pass
-// through unchanged.
-func rewriteMetricsInsert(stmt string, cols map[string][]string) (string, bool) {
+// through unchanged. Shared by both the metrics backfill
+// ([backfillMetricsColumns]) and the traces backfill
+// ([backfillTracesColumns]) — the rewrite is column-registry-driven, not
+// metrics-specific.
+func rewriteBackfilledInsert(stmt string, cols map[string][]string) (string, bool) {
 	trimmed := stripLeadingNoise(stmt)
 	prefix := stmt[:len(stmt)-len(trimmed)]
 	upper := strings.ToUpper(trimmed)

--- a/test/spec/strictscan_integration_test.go
+++ b/test/spec/strictscan_integration_test.go
@@ -52,7 +52,14 @@
 // join emitters where Value-typed columns live are all under promql; logql and
 // traceql exercise the Map + log-stream + trace projections). The optimizer
 // lane has no round-trip fixtures. Args are taken verbatim from each fixture's
-// `-- args --` block, so no synthetic placeholder binding is needed.
+// `-- args --` block, so no synthetic placeholder binding is needed — EXCEPT
+// for TraceQL search-shaped fixtures, where traceqlWrapForStrictScan discards
+// the fixture's own `-- sql --` / `-- args --` and re-derives both (see its
+// doc comment): Layer 2a's TraceQL fixtures are captured before
+// engine.QueryPlan's wrap-projection stage (ProjectSamples), which
+// traceqlLang.ProjectSamples always applies in production via
+// wrapWithSampleProjection, so the recorded SQL for a search-shaped TraceQL
+// query never reaches a real server as-is (issue #1635).
 //
 // Gated by the `integration` build tag (Docker required). A REQUIRED status
 // check on `main` (see .github/workflows/strict-scan.yml) — promoted after
@@ -65,13 +72,19 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	tcclickhouse "github.com/testcontainers/testcontainers-go/modules/clickhouse"
 
+	"github.com/tsouza/cerberus/internal/api/tempo"
 	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/schema"
+	traceqllower "github.com/tsouza/cerberus/internal/traceql"
+	traceqlast "github.com/tsouza/cerberus/internal/traceql/ast"
 	"github.com/tsouza/cerberus/test/spec"
 )
 
@@ -116,6 +129,12 @@ func TestStrictScanDifferential(t *testing.T) {
 			if !rt.IsRoundTrip() || strings.TrimSpace(rt.SQL) == "" {
 				skippedNonRT++
 				return
+			}
+			if head == "traceql" {
+				// Search-shaped fixtures get their SQL/args replaced with the
+				// production wrap-projected reconstruction; metrics-pipeline
+				// fixtures are left untouched (see traceqlWrapForStrictScan).
+				traceqlWrapForStrictScan(t, c, rt)
 			}
 			switch runStrictScanCase(ctx, t, client, rt) {
 			case caseRan:
@@ -221,6 +240,100 @@ func runStrictScanCase(ctx context.Context, t *testing.T, client *chclient.Clien
 	return caseRan
 }
 
+// traceqlSearchExplainStep is passed to tempo.NewExplainLang but never
+// actually exercised: traceqlWrapForStrictScan only calls lang.Parse for
+// fixtures whose query is NOT a metrics pipeline, so explainLang.Parse always
+// takes its non-metrics branch, which ignores step. Kept a nonzero,
+// human-legible value only to satisfy NewExplainLang's documented "must be
+// > 0" contract defensively.
+const traceqlSearchExplainStep = time.Minute
+
+// traceqlWrapForStrictScan reconstructs the wrap-projected SQL production
+// actually sends to ClickHouse for a TraceQL round-trip fixture's
+// search-shaped plan, and substitutes it into rt in place (rt.SQL, rt.Args) —
+// closing the gap documented in issue #1635: Layer 2a's `-- sql --` section
+// (internal/traceql/lower_test.go) is captured BEFORE engine.QueryPlan's
+// wrap-projection stage (ProjectSamples), which traceqlLang.ProjectSamples
+// always applies via wrapWithSampleProjection before optimizing/emitting.
+// Every TraceQL search fixture's recorded SQL is therefore SQL that never
+// reaches a real ClickHouse server in production — executing it unmodified
+// either mis-classifies the fixture as caseNonMatrix (today's behaviour,
+// silently skipping the whole differential for this shape) or, worse, would
+// strict-scan SQL nobody sends.
+//
+// Reconstruction mirrors /api/search's own Lang exactly: tempo.NewExplainLang
+// embeds the SAME unexported traceqlLang the handler drives (see
+// internal/api/tempo/explain.go's doc comment), so Parse + ProjectSamples
+// here are byte-for-byte what engine.QueryPlan would run for this query.
+//
+// Metrics-pipeline queries (`| rate()`, `| count_over_time() by (...)`, …)
+// are left untouched — rt is not modified — because they never reach
+// traceqlLang in production: /api/metrics/query_range routes them through
+// the entirely separate metricsLang (internal/api/tempo/metrics_query_range.go),
+// whose own hand-rolled wrap this fixture corpus does not represent even
+// after reconstruction. Wrapping them via wrapWithSampleProjection's
+// isAggregateShape branch here would exercise a plan/wrap combination no
+// real request ever produces; they keep going through runStrictScanCase with
+// their original (pre-wrap) SQL, which — as today — gets classified
+// caseNonMatrix.
+func traceqlWrapForStrictScan(t *testing.T, c *spec.Case, rt *spec.RoundTripSections) {
+	t.Helper()
+
+	query, hasQuery := c.Section("query.traceql")
+	if !hasQuery {
+		t.Fatalf("fixture %s: traceql round-trip fixture missing query.traceql section", c.Name)
+	}
+	query = strings.TrimSpace(query)
+
+	expr, err := traceqlast.Parse(query)
+	if err != nil {
+		t.Fatalf("fixture %s: traceql parse: %v", c.Name, err)
+	}
+	if expr.MetricsPipeline != nil || expr.MetricsSecondStage != nil {
+		return
+	}
+
+	// Thread the fixture's optional search_limit / search_window sections
+	// the same way internal/traceql/lower_test.go does, so the reconstructed
+	// plan pins the same bounded-scan shape the fixture's `-- chplan --` /
+	// `-- sql --` sections were generated (and are still checked) against.
+	ctx := context.Background()
+	if v, hasLimit := c.Section("search_limit"); hasLimit {
+		n, err := strconv.Atoi(strings.TrimSpace(v))
+		if err != nil {
+			t.Fatalf("fixture %s: bad search_limit %q: %v", c.Name, v, err)
+		}
+		ctx = traceqllower.WithSearchTraceLimit(ctx, n)
+	}
+	if v, hasWindow := c.Section("search_window"); hasWindow {
+		fields := strings.Fields(v)
+		if len(fields) != 2 {
+			t.Fatalf("fixture %s: search_window wants two Unix-second bounds, got %q", c.Name, v)
+		}
+		startSec, err1 := strconv.ParseInt(fields[0], 10, 64)
+		endSec, err2 := strconv.ParseInt(fields[1], 10, 64)
+		if err1 != nil || err2 != nil {
+			t.Fatalf("fixture %s: bad search_window %q", c.Name, v)
+		}
+		ctx = traceqllower.WithSearchWindow(ctx, time.Unix(startSec, 0).UTC(), time.Unix(endSec, 0).UTC())
+	}
+
+	lang := tempo.NewExplainLang(schema.DefaultOTelTraces(), traceqlSearchExplainStep)
+	plan, meta, err := lang.Parse(ctx, query)
+	if err != nil {
+		t.Fatalf("fixture %s: traceql lower (wrap reconstruction): %v", c.Name, err)
+	}
+	wrapped := lang.ProjectSamples(plan, meta)
+
+	sqlStr, args, err := chsql.Emit(context.Background(), wrapped)
+	if err != nil {
+		t.Fatalf("fixture %s: chsql.Emit(wrapped): %v", c.Name, err)
+	}
+
+	rt.SQL = sqlStr
+	rt.Args = args
+}
+
 // isMatrixShape runs the query, reads the result column names, and reports
 // whether they are the production matrix projection (MetricName, Attributes,
 // TimeUnix, Value) optionally followed by a Metadata column. The probe drains
@@ -263,7 +376,16 @@ func isExperimentalFnError(err error) bool {
 // fixtures that share a table name (otel_metrics_gauge appears in ~250).
 func applyStrictScanSeed(ctx context.Context, t *testing.T, client *chclient.Client, seed string) {
 	t.Helper()
-	for _, stmt := range spec.BackfillMetricsColumns(spec.SplitSeedStatements(seed)) {
+	stmts := spec.BackfillMetricsColumns(spec.SplitSeedStatements(seed))
+	// Also backfill the otel_traces columns wrapWithSampleProjection reads
+	// unconditionally (TraceId / SpanId / ParentSpanId / SpanName / Duration /
+	// Timestamp / ResourceAttributes) — a no-op for promql/logql seeds, which
+	// never declare a table named otel_traces. Needed so
+	// traceqlWrapForStrictScan's reconstructed wrap-projected SQL doesn't
+	// 502 with UNKNOWN_IDENTIFIER against a fixture seed that (deliberately)
+	// only declares the columns its OWN pre-wrap SQL touches.
+	stmts = spec.BackfillTracesColumns(stmts)
+	for _, stmt := range stmts {
 		stmt = strings.TrimSpace(stmt)
 		if stmt == "" {
 			continue

--- a/test/spec/traceql/edge_intr_parent_with_attrs.txtar
+++ b/test/spec/traceql/edge_intr_parent_with_attrs.txtar
@@ -1,14 +1,15 @@
 -- query.traceql --
 { parent && resource.service.name = "api" }
 -- args --
-[0] string = "service.name"
-[1] string = "api"
+[0] string = ""
+[1] string = "service.name"
+[2] string = "api"
 -- sql --
-SELECT * FROM `otel_traces` PREWHERE `ParentSpanId` WHERE (`ResourceAttributes`[?] = ?)
+SELECT * FROM `otel_traces` PREWHERE (`ParentSpanId` != ?) WHERE (`ResourceAttributes`[?] = ?)
 -- seed --
 CREATE TABLE otel_traces (
     _idx UInt64,
-    ParentSpanId UInt8 MATERIALIZED if(_idx = 0, toUInt8(0), toUInt8(1)),
+    ParentSpanId String MATERIALIZED if(_idx = 0, '', '0000000000000001'),
     ResourceAttributes Map(String, String) MATERIALIZED map('service.name', if(_idx = 2, 'frontend', 'api'))
 ) ENGINE = MergeTree ORDER BY _idx;
 INSERT INTO otel_traces (_idx) VALUES (0), (1), (2);
@@ -17,5 +18,5 @@ INSERT INTO otel_traces (_idx) VALUES (0), (1), (2);
   [1]
 ]
 -- chplan --
-Filter predicate=(ParentSpanId AND (ResourceAttributes["service.name"] = "api"))
+Filter predicate=((ParentSpanId != "") AND (ResourceAttributes["service.name"] = "api"))
   Scan(otel_traces)


### PR DESCRIPTION
## Summary

- `test/spec/strictscan_integration_test.go` executed every TraceQL
  round-trip fixture's `-- sql --` verbatim — but search-shaped fixtures
  are captured by `internal/traceql/lower_test.go` **before**
  `engine.QueryPlan`'s `ProjectSamples` stage, which `traceqlLang`
  unconditionally applies via `wrapWithSampleProjection` before
  optimizing/emitting. Confirmed at the file:line the issue cited
  (`internal/api/tempo/handler.go:1036`, `internal/api/tempo/lang.go:105`,
  `internal/engine/engine.go:890`) and directly on a fixture
  (`search_traceid.txtar` recorded `TraceId, SpanId, Timestamp, ...`, not
  the matrix shape) — the recorded SQL never reaches production, and
  `isMatrixShape` silently classified essentially every non-metrics
  TraceQL search fixture as `caseNonMatrix`, skipping the whole
  differential for that shape.
- `traceqlWrapForStrictScan` reconstructs the wrap-projected SQL by
  driving the fixture's `query.traceql` text through
  `tempo.NewExplainLang` — the same unexported `traceqlLang` `/api/search`
  itself drives — then re-emits via `chsql.Emit`. No new production API
  surface needed: `NewExplainLang` was already exported for the migration
  preview / offline-explain use case and its non-metrics `Parse` +
  `ProjectSamples` path is byte-for-byte what `engine.QueryPlan` runs.
  Metrics-pipeline queries (`| rate()`, `| count_over_time() by (...)`)
  are deliberately left untouched — they route through the entirely
  separate `metricsLang` in production, never `traceqlLang`.

## What the reconstruction surfaced (and how it's handled)

Running the wrap for real against a real ClickHouse (via testcontainers)
surfaced two classes of gap the old pre-wrap-only regime never exercised:

1. **Fixture-seed schema shortcuts.** Several seeds use `MATERIALIZED`
   columns (excluded from ClickHouse's bare `SELECT *`, so a wrap that
   reads them 502s with `UNKNOWN_IDENTIFIER`) or declare `Timestamp`/
   `Duration` as bare integers instead of the real OTel-CH
   `DateTime64(9)`/`Int64` — invisible while nothing read them through the
   wrap's typed projections. `BackfillTracesColumns` /
   `normalizeTracesColumnDef` (`test/spec/roundtrip_prep.go`) bring the
   **strict-scan-local seed copy** into schema fidelity, mirroring the
   existing `BackfillMetricsColumns` pattern. Scoped to the strict-scan
   lane only — `runner_chdb.go` (the `roundtrip (traceql)` required check)
   is untouched, so no other lane's seed application changes.
2. **A real, separate, pre-existing production bug.** Resolved in this
   change: the `{ parent }` bare-boolean TraceQL intrinsic
   lowered to a bare `ParentSpanId` `ColumnRef` used directly as a
   `WHERE`/`PREWHERE` predicate. `ParentSpanId` is a real ClickHouse
   `String` column; ClickHouse rejects a bare `String` reference as a
   filter predicate (`ILLEGAL_TYPE_OF_COLUMN_FOR_FILTER`) — confirmed via
   a direct `clickhouse-client` repro against a plain `String` column,
   independent of this PR's own reconstruction path. `lowerBooleanFieldExpr`
   (`internal/traceql/lower.go`) routes the three genuine boolean
   positions — a spanset filter's whole predicate, AND/OR operands, and a
   logical-NOT operand — through a `ParentSpanId != ""` presence check,
   mirroring `rootnessReduction`'s identical pattern for `nestedSetParent`
   root-ness, while `parent = "<hex span id>"` comparisons keep reading
   the raw column exactly as before (verified: `parent_intrinsic.txtar`
   is unchanged).

## Follow-up filed (found while fixing this, correctly out of scope here)

#1653 — the same pre-wrap SQL-capture gap also applies, in narrower/
differently-shaped form, to (a) promql's and logql's own Layer 2a
fixtures (both heads' `ProjectSamples` does real work — promql's
offset-reanchoring for matrix range windows, logql's metric/log-stream
reshaping — not the "near-identity" this issue's scope-check speculated),
and (b) the chDB `roundtrip (traceql)` required check, which executes the
same pre-wrap SQL via the widely-shared `RunRoundTrip` (all three heads'
`roundtrip (<ql>)` checks route through it — a materially different,
bigger-blast-radius fix shape than this PR's self-contained
`strictscan_integration_test.go` loop).

## Result

The differential now strict-scans 566 matrix-shaped fixtures against a
real ClickHouse (up from a corpus that silently excluded nearly every
TraceQL search fixture before this PR), all green — no `t.Skip`, no
allowlist, no tolerated failure.

Closes #1635

## Test plan

- [x] `go build ./...` / `go build -tags integration ./...`
- [x] `go test ./internal/traceql/... ./internal/api/tempo/... ./internal/chsql/... ./test/spec/...`
- [x] `go test -tags=integration -count=1 -run TestStrictScanDifferential ./test/spec/... -timeout 15m` — all 566 matrix-shaped fixtures pass against a real `clickhouse/clickhouse-server:26.5-alpine` container
- [x] `gofumpt -extra -w` / `goimports -w` on changed files
- [ ] CI (`strict-scan` required check + the rest of the required matrix)
