### PR TITLE
ci(security): pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/actions/setup-buildx/action.yml
+++ b/.github/actions/setup-buildx/action.yml
@@ -35,6 +35,6 @@ runs:
         BUILDKIT_IMAGE: ${{ inputs.buildkit-image }}
       run: node "$GITHUB_WORKSPACE/.github/scripts/pull-buildkit-image.mjs"
 
-    - uses: docker/setup-buildx-action@v4
+    - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4
       with:
         driver-opts: image=${{ inputs.buildkit-image }}

--- a/.github/workflows/agpl-oracle.yml
+++ b/.github/workflows/agpl-oracle.yml
@@ -95,7 +95,7 @@ jobs:
 
       - id: filter
         if: github.event_name == 'pull_request'
-        uses: dorny/paths-filter@v4
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4
         with:
           predicate-quantifier: 'every'
           filters: |

--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: meta
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98  # v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/chart-ci.yml
+++ b/.github/workflows/chart-ci.yml
@@ -47,7 +47,7 @@ jobs:
       - name: chart-kubeconform self-test (image-guard classifier + staging exemption)
         run: node .github/scripts/chart-kubeconform.mjs --self-test
 
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4
         id: changes
         with:
           filters: |
@@ -58,7 +58,7 @@ jobs:
               - '.github/scripts/chart-kubeconform.mjs'
 
       - if: steps.changes.outputs.chart == 'true'
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310  # v5
         with:
           version: v3.21.1
 
@@ -106,7 +106,7 @@ jobs:
 
       - name: chart-testing (ct) lint
         if: steps.changes.outputs.chart == 'true'
-        uses: helm/chart-testing-action@v2
+        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f  # v2
 
       # No `--charts` override: let ct's changed-chart detection drive the
       # version-bump enforcement. A PR that touches CI/scripts but not the

--- a/.github/workflows/chdb.yml
+++ b/.github/workflows/chdb.yml
@@ -92,7 +92,7 @@ jobs:
 
       - id: filter
         if: github.event_name == 'pull_request'
-        uses: dorny/paths-filter@v4
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4
         with:
           # See ci.yml for why `every` is required (the `**` baseline
           # plus negation patterns would otherwise always be true).
@@ -162,7 +162,7 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
 
-      - uses: taiki-e/install-action@v2.85.5
+      - uses: taiki-e/install-action@6a1bd70eaac3c8bdf093356838d7ee09fda951cf  # v2.85.5
         with:
           tool: just
 
@@ -200,7 +200,7 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
 
-      - uses: taiki-e/install-action@v2.85.5
+      - uses: taiki-e/install-action@6a1bd70eaac3c8bdf093356838d7ee09fda951cf  # v2.85.5
         with:
           tool: just
 
@@ -255,7 +255,7 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
 
-      - uses: taiki-e/install-action@v2.85.5
+      - uses: taiki-e/install-action@6a1bd70eaac3c8bdf093356838d7ee09fda951cf  # v2.85.5
         if: needs.changes.outputs.docs_only != 'true'
         with:
           tool: just
@@ -323,7 +323,7 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
 
-      - uses: taiki-e/install-action@v2.85.5
+      - uses: taiki-e/install-action@6a1bd70eaac3c8bdf093356838d7ee09fda951cf  # v2.85.5
         with:
           tool: just
 
@@ -365,7 +365,7 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
 
-      - uses: taiki-e/install-action@v2.85.5
+      - uses: taiki-e/install-action@6a1bd70eaac3c8bdf093356838d7ee09fda951cf  # v2.85.5
         with:
           tool: just
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
 
       - id: filter
         if: github.event_name == 'pull_request'
-        uses: dorny/paths-filter@v4
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4
         with:
           # `every` makes the negation patterns subtractive: a file is
           # in `code` iff it matches `**` AND does NOT match any of the
@@ -121,7 +121,7 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
 
-      - uses: taiki-e/install-action@v2.85.5
+      - uses: taiki-e/install-action@6a1bd70eaac3c8bdf093356838d7ee09fda951cf  # v2.85.5
         with:
           tool: just
 
@@ -141,7 +141,7 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
 
-      - uses: taiki-e/install-action@v2.85.5
+      - uses: taiki-e/install-action@6a1bd70eaac3c8bdf093356838d7ee09fda951cf  # v2.85.5
         with:
           tool: just
 
@@ -232,7 +232,7 @@ jobs:
 
       - name: golangci-lint (tagged build configuration)
         # v7+ is required for golangci-lint v2; v6 caps at v1.
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a  # v9
         with:
           version: v2.12.2
           # Honours .golangci.yml — including its `build-tags:` union, which is
@@ -260,7 +260,7 @@ jobs:
       # test/regression/lint_build_tags_test.go holds the two passes, the tag
       # union and the inert tag to what the tree's `//go:build` lines say.
       - name: golangci-lint (untagged build configuration)
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a  # v9
         with:
           version: v2.12.2
           args: --build-tags cerberus_untagged_build ./...
@@ -371,7 +371,7 @@ jobs:
             --from "$BASE_SHA" --to "$HEAD_SHA" --verbose
 
       - name: markdownlint
-        uses: DavidAnson/markdownlint-cli2-action@v24.1.0
+        uses: DavidAnson/markdownlint-cli2-action@6bf21b07787794f89a243495939cd651942aeabe  # v24.1.0
         with:
           globs: |
             **/*.md
@@ -486,7 +486,7 @@ jobs:
         run: node --test .github/scripts/goreleaser-deprecations.test.mjs
 
       - name: install goreleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94  # v7
         with:
           distribution: goreleaser
           version: '~> v2'

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -112,7 +112,7 @@ jobs:
 
       - id: filter
         if: github.event_name == 'pull_request'
-        uses: dorny/paths-filter@v4
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4
         with:
           # See ci.yml for why `every` is required (the `**` baseline
           # plus negation patterns would otherwise always be true).
@@ -246,7 +246,7 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
 
-      - uses: taiki-e/install-action@v2.85.5
+      - uses: taiki-e/install-action@6a1bd70eaac3c8bdf093356838d7ee09fda951cf  # v2.85.5
         with:
           tool: just
 
@@ -452,7 +452,7 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
 
-      - uses: taiki-e/install-action@v2.85.5
+      - uses: taiki-e/install-action@6a1bd70eaac3c8bdf093356838d7ee09fda951cf  # v2.85.5
         with:
           tool: just
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -72,7 +72,7 @@ jobs:
           cache: true
 
       - if: env.RUN_HEAVY == 'true'
-        uses: taiki-e/install-action@v2.85.5
+        uses: taiki-e/install-action@6a1bd70eaac3c8bdf093356838d7ee09fda951cf  # v2.85.5
         with:
           tool: just
 

--- a/.github/workflows/dependabot-tidy-nested-modules.yml
+++ b/.github/workflows/dependabot-tidy-nested-modules.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: meta
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98  # v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -888,14 +888,14 @@ jobs:
           cache: 'npm'
           cache-dependency-path: 'test/e2e/playwright/package-lock.json'
 
-      - uses: taiki-e/install-action@v2.85.5
+      - uses: taiki-e/install-action@6a1bd70eaac3c8bdf093356838d7ee09fda951cf  # v2.85.5
         if: env.RUN_SHARD == 'true'
         with:
           tool: just
 
       # cerberus is deployed via its Helm chart in `just e2e-up` (dogfooding
       # the published chart), so the runner needs helm.
-      - uses: azure/setup-helm@v5
+      - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310  # v5
         if: env.RUN_SHARD == 'true'
         with:
           version: v3.21.1
@@ -1241,7 +1241,7 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
 
-      - uses: taiki-e/install-action@v2.85.5
+      - uses: taiki-e/install-action@6a1bd70eaac3c8bdf093356838d7ee09fda951cf  # v2.85.5
         with:
           tool: just
 
@@ -1376,13 +1376,13 @@ jobs:
         with:
           node-version: '22'
 
-      - uses: taiki-e/install-action@v2.85.5
+      - uses: taiki-e/install-action@6a1bd70eaac3c8bdf093356838d7ee09fda951cf  # v2.85.5
         with:
           tool: just
 
       # cerberus is deployed via its Helm chart in `just e2e-up` (dogfooding
       # the published chart), so the runner needs helm.
-      - uses: azure/setup-helm@v5
+      - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310  # v5
         with:
           version: v3.21.1
 
@@ -1571,14 +1571,14 @@ jobs:
         with:
           node-version: '22'
 
-      - uses: taiki-e/install-action@v2.85.5
+      - uses: taiki-e/install-action@6a1bd70eaac3c8bdf093356838d7ee09fda951cf  # v2.85.5
         with:
           tool: just
 
       # cerberus + the bundled ClickHouse data tier are deployed via the Helm
       # chart in `just e2e-bwc-up` (dogfooding the chart), so the runner needs
       # helm.
-      - uses: azure/setup-helm@v5
+      - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310  # v5
         with:
           version: v3.21.1
 

--- a/.github/workflows/link-check-external.yml
+++ b/.github/workflows/link-check-external.yml
@@ -74,7 +74,7 @@ jobs:
       # spamming new ones. Never fails the job.
       - name: Open/update link-rot tracking issue
         if: steps.lychee.outputs.exit_code != 0
-        uses: peter-evans/create-issue-from-file@v6
+        uses: peter-evans/create-issue-from-file@fca9117c27cdc29c6c4db3b86c48e4115a786710  # v6
         with:
           title: Weekly external link check found dead links
           content-filepath: ./lychee-report.md

--- a/.github/workflows/migration-e2e.yml
+++ b/.github/workflows/migration-e2e.yml
@@ -266,7 +266,7 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
 
-      - uses: taiki-e/install-action@v2.85.5
+      - uses: taiki-e/install-action@6a1bd70eaac3c8bdf093356838d7ee09fda951cf  # v2.85.5
         with:
           tool: just
 
@@ -426,7 +426,7 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
 
-      - uses: taiki-e/install-action@v2.85.5
+      - uses: taiki-e/install-action@6a1bd70eaac3c8bdf093356838d7ee09fda951cf  # v2.85.5
         with:
           tool: just
 

--- a/.github/workflows/perf-profile.yml
+++ b/.github/workflows/perf-profile.yml
@@ -80,7 +80,7 @@ jobs:
           cache: true
 
       - if: env.RUN_HEAVY == 'true'
-        uses: taiki-e/install-action@v2.85.5
+        uses: taiki-e/install-action@6a1bd70eaac3c8bdf093356838d7ee09fda951cf  # v2.85.5
         with:
           tool: just
 

--- a/.github/workflows/property.yml
+++ b/.github/workflows/property.yml
@@ -109,7 +109,7 @@ jobs:
           cache: true
 
       - if: env.RUN_HEAVY == 'true'
-        uses: taiki-e/install-action@v2.85.5
+        uses: taiki-e/install-action@6a1bd70eaac3c8bdf093356838d7ee09fda951cf  # v2.85.5
         with:
           tool: just
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,7 @@ jobs:
         run: node .github/scripts/chart-publish.mjs --self-test
 
       # helm is needed for the chart gate's `helm show chart oci://…` probe.
-      - uses: azure/setup-helm@v5
+      - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310  # v5
         with:
           version: v3.21.1
 
@@ -327,7 +327,7 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
 
-      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8  # v4
 
       - name: Log in to GHCR
         env:
@@ -408,7 +408,7 @@ jobs:
           echo "tag=$tag highest_stable=$highest RELEASE_IS_LATEST=${is_latest}"
 
       - id: goreleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94  # v7
         with:
           distribution: goreleaser
           version: '~> v2'
@@ -514,7 +514,7 @@ jobs:
       # Mirror README.md to the Docker Hub repo overview. Non-fatal: a stale
       # overview page must never turn an otherwise-published release red.
       - name: Sync Docker Hub overview
-        uses: peter-evans/dockerhub-description@v5
+        uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa  # v5
         continue-on-error: true
         with:
           username: tsouza
@@ -707,15 +707,15 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: azure/setup-helm@v5
+      - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310  # v5
         with:
           version: v3.21.1
 
       # cosign-installer publishes NO moving v4 major tag (only v3 floats); pin
       # the exact latest v4 patch or the job fails resolving the action.
-      - uses: sigstore/cosign-installer@v4.1.2
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
 
-      - uses: oras-project/setup-oras@v2
+      - uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d  # v2
 
       - name: Log in to GHCR
         env:

--- a/.github/workflows/schema-integration.yml
+++ b/.github/workflows/schema-integration.yml
@@ -60,7 +60,7 @@ jobs:
 
       - id: filter
         if: github.event_name == 'pull_request'
-        uses: dorny/paths-filter@v4
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4
         with:
           predicate-quantifier: 'every'
           filters: |
@@ -104,7 +104,7 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
 
-      - uses: taiki-e/install-action@v2.85.5
+      - uses: taiki-e/install-action@6a1bd70eaac3c8bdf093356838d7ee09fda951cf  # v2.85.5
         with:
           tool: just
 

--- a/.github/workflows/strict-scan.yml
+++ b/.github/workflows/strict-scan.yml
@@ -66,7 +66,7 @@ jobs:
 
       - id: filter
         if: github.event_name == 'pull_request'
-        uses: dorny/paths-filter@v4
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4
         with:
           predicate-quantifier: 'every'
           filters: |
@@ -110,7 +110,7 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
 
-      - uses: taiki-e/install-action@v2.85.5
+      - uses: taiki-e/install-action@6a1bd70eaac3c8bdf093356838d7ee09fda951cf  # v2.85.5
         with:
           tool: just
 


### PR DESCRIPTION
## Summary

CodeQL reported 47 open `actions/unpinned-tag` alerts across this repo: third-party GitHub Actions referenced by a mutable tag (e.g. `@v5`, `@v2.85.5`) instead of an immutable commit SHA. A tag can be force-moved upstream to point at different, possibly malicious code without any change on our side — pinning to a SHA closes that.

This is one root cause across many files, fixed as one mechanical pass rather than 47 individual edits:

- Resolved the **14 distinct action references** behind the 47 flagged occurrences to their current commit SHA via `gh api repos/<owner>/<repo>/commits/<tag>` (which resolves both lightweight and annotated tags to the underlying commit).
- Rewrote every flagged `uses: owner/repo@vX` line as `uses: owner/repo@<40-char-sha>  # vX`, keeping the original tag as a trailing comment so Dependabot continues to update it automatically (it understands this exact form).
- Scope: `.github/workflows/*.yml` and `.github/actions/*/action.yml` — 17 files, 47 lines changed, 47 insertions / 47 deletions.
- `actions/*` (GitHub-owned) references — `actions/checkout`, `actions/setup-go`, `actions/upload-artifact`, etc. — were intentionally left untouched; CodeQL's `unpinned-tag` query does not flag GitHub's own first-party actions, and none of the 47 alerts point at them.

Verification after the rewrite:
- `grep` confirms zero remaining unpinned occurrences of any of the 14 flagged action refs anywhere under `.github/`.
- `actionlint` runs clean across every workflow file.
- All 17 changed files parse as valid YAML (spot-checked with `python3 -c "import yaml; yaml.safe_load(...)"` across the full changed-file set).
- Local pre-push hook (actionlint, forbid-skip/soft-assert/escape-hatch/sql-raw gates, golangci-lint, markdownlint) passed clean.

The 47 CodeQL alerts (rule `actions/unpinned-tag`) will auto-close on the next scan of `main` post-merge — no `Closes #N` here since these are code-scanning alerts, not issues.

## Test plan

- [x] `actionlint` over all `.github/workflows/*.yml` — clean
- [x] YAML parses for all 17 changed files
- [x] `grep` sweep: no unpinned occurrence remains for any of the 14 rewritten action refs
- [x] Pre-push hook suite (actionlint, discipline greps, golangci-lint, markdownlint) — clean
- [ ] CI required checks green (to be confirmed by the merge-loop agent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)