### PR TITLE
fix(codeql): close remaining static-analysis findings

### DIFF
--- a/.github/scripts/chart-kubeconform.mjs
+++ b/.github/scripts/chart-kubeconform.mjs
@@ -359,7 +359,7 @@ function selfTest() {
 
   // The fixture itself: its command line must carry no phrase the classifier
   // recognises, or the two assertions above would pass on `message` alone.
-  const [file, args] = failingProbe(NOT_FOUND_STDERR)('probe-self-test')
+  const [file, args] = failingProbe(NOT_FOUND_STDERR)()
   check(
     classifyProbeFailure({ stderr: null, message: `Command failed: ${file} ${args.join(' ')}` }) === 'unknown',
     'the probe fixture reaches the classifier on stderr only, never through the quoted command line',

--- a/.github/scripts/dashboard-matrix.test.mjs
+++ b/.github/scripts/dashboard-matrix.test.mjs
@@ -21,7 +21,6 @@ import {
   collectViolations,
   SHARDS,
   buildMatrix,
-  SMOKE_MODES,
   MODE_MONOLITH,
   MODE_SPLIT,
   SPLIT_ONLY_SPECS,

--- a/scripts/gen-coverage.py
+++ b/scripts/gen-coverage.py
@@ -126,7 +126,8 @@ def render_head(head, entries):
 
 
 def build():
-    inv = json.load(open(INVENTORY))
+    with open(INVENTORY) as f:
+        inv = json.load(f)
     e = inv["entries"]
     blocks = []
     for head, label in [("promql", "PromQL"), ("logql", "LogQL"),
@@ -139,12 +140,14 @@ def build():
 
 def main():
     body = build()
-    doc = open(DOC).read()
+    with open(DOC) as f:
+        doc = f.read()
     new = re.sub(re.escape(BEGIN) + r".*?" + re.escape(END),
                  BEGIN + "\n\n" + body + "\n" + END, doc, flags=re.S)
     if "--check" in sys.argv:
         sys.exit(0 if new == doc else 1)
-    open(DOC, "w").write(new)
+    with open(DOC, "w") as f:
+        f.write(new)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes the last three real CodeQL findings out of the alert batch (everything except the 47 `actions/unpinned-tag` alerts, which a sibling PR handles separately):

- **`scripts/gen-coverage.py`** (`py/file-not-closed` × 3, alerts #62/#63/#64): the inventory-JSON read, the doc read, and the doc write each used a bare `open(...)` with no guaranteed close. Switched all three to `with open(...) as f:` context managers. `python3 scripts/gen-coverage.py --check` still passes (doc is unchanged, byte-for-byte).
- **`.github/scripts/dashboard-matrix.test.mjs`** (`js/unused-local-variable`, alert #74): dropped the unused `SMOKE_MODES` import — `MODE_MONOLITH`/`MODE_SPLIT` are already imported and exercise the same behaviour directly. `node --test .github/scripts/dashboard-matrix.test.mjs` — all 11 assertions pass.
- **`.github/scripts/chart-kubeconform.mjs`** (`js/superfluous-trailing-arguments`, alert #73): the self-test's `failingProbe(NOT_FOUND_STDERR)('probe-self-test')` call passed an argument into a zero-parameter closure (`() => [...]`) — silently ignored, doing nothing. Dropped it. `node .github/scripts/chart-kubeconform.mjs --self-test` — all 55 assertions pass.

None of these touch prod behaviour; all three are script/tooling files.

## Alert triage (for the record)

Investigated the full remaining-alert set (all rules except `actions/unpinned-tag`):

- **14× `go/log-injection`** (alerts #91-#104, `internal/api/{loki,prom,tempo}/*.go`) — spot-checked all 14 sites on current `main`: each already wraps the flagged value in `telemetry.SanitizeForLog(...)` (landed in #1644). CodeQL doesn't recognize a custom sanitizer function as breaking the taint flow, so it keeps flagging the same shape. Dismissed all 14 as false positives citing #1644.
- **`js/indirect-command-line-injection`** (`.github/scripts/build-with-registry-retry.mjs`) — the original alert #65 already auto-closed (`state: fixed`) once #1645 merged; no new alert reopened against the current code shape. Nothing to dismiss.
- **`go/index-out-of-bounds`** (`test/property/oracle/logql/line_filters.go`) — alert #89 already auto-closed (`state: fixed`). Nothing to dismiss.
- **`js/file-access-to-http`** (alert #70, `.github/scripts/issue-label.mjs:609`) and **`js/http-to-file-access`** (alert #71, `.github/scripts/lib/gh.mjs:181`) — read the full SARIF code-flow for both. #70 is `issue.number` from the runner's own `$GITHUB_EVENT_PATH` file used to build a REST URL for the same triggering repo/issue, not file-content exfiltration. #71 is `appendFileSync` writing to `$GITHUB_STEP_SUMMARY`, the officially documented sink for job-summary markdown. Both are the intended, designed GitHub Actions idiom, not the "arbitrary file read → network" / "network → arbitrary file write" pattern the rules target. Dismissed both as false positives.
- **`actions/untrusted-checkout/medium`** (alert #61, `.github/workflows/dependabot-tidy-nested-modules.yml:50`) — read the workflow: trigger is plain `pull_request` (not `pull_request_target`), so fork-originated PRs never get write-scoped tokens or secrets regardless of the declared `permissions:` block — only same-repo branches do. The job additionally gates on `github.event.pull_request.user.login == 'dependabot[bot]'`, which can't be spoofed, and Dependabot never edits workflow files (only manifest files it's configured to track). Dismissed as a false positive.

## Test plan

- [x] `python3 scripts/gen-coverage.py --check` exits 0 (doc unchanged)
- [x] `node .github/scripts/chart-kubeconform.mjs --self-test` — 55/55 pass
- [x] `node --test .github/scripts/dashboard-matrix.test.mjs` — 11/11 pass
- [x] `node --check` on both touched `.mjs` files
- [ ] CI (lint / check / CodeQL / etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)