### PR TITLE
fix(spec): resolve bare-table SELECT * against the seed's own CREATE TABLE DDL

### DIFF
--- a/test/perf/cardinality-baseline.json
+++ b/test/perf/cardinality-baseline.json
@@ -7780,6 +7780,16 @@
     "max_recursion_depth": 0
   },
   {
+    "fixture": "traceql/search_trace_limit_bare_table_map_column",
+    "fan_factor": 1,
+    "scan_rows": 1,
+    "peak_intermediate": 1,
+    "has_cross_join": false,
+    "has_array_join": false,
+    "has_recursive_cte": false,
+    "max_recursion_depth": 0
+  },
+  {
     "fixture": "traceql/search_trace_limit_tiebreak_boundary",
     "fan_factor": 1,
     "scan_rows": 5,

--- a/test/spec/eval_instant_sweep.go
+++ b/test/spec/eval_instant_sweep.go
@@ -174,10 +174,14 @@ var sweepServerNow = time.Date(2027, 6, 16, 12, 0, 0, 0, time.UTC)
 // The query goes through the same Map-projection rewrite pipeline
 // (`expandStarProjection` → `rewriteMapProjections` → `nestMapOrderBy`)
 // the round-trip lane uses, so the Map column scans the same way here.
+// The sweep's PromQL lowering always wraps its scan in a named `Project`
+// (never a bare `SELECT s.* FROM (SELECT * FROM <table>)` drain), so it
+// passes a nil column map: [expandQualifiedStar]'s seed-DDL fallback for
+// a bare table scan is not needed here.
 func runInstant(t *testing.T, db *sql.DB, sqlText string, args []any, T time.Time) evalInstantResult {
 	t.Helper()
 	query, queryArgs := substituteNow64At(sqlText, args, chNow64Literal(sweepServerNow))
-	query = expandStarProjection(query)
+	query = expandStarProjection(query, nil)
 	query = rewriteMapProjections(query)
 	query = nestMapOrderBy(query)
 

--- a/test/spec/prepare_chdb.go
+++ b/test/spec/prepare_chdb.go
@@ -121,7 +121,7 @@ func PrepareRoundTrip(c *Case) (*PreparedRoundTrip, bool, error) {
 	// the round-trip assertion executes — the perf profiler reads this
 	// prepared Query directly.
 	query, queryArgs := substituteNow64(rt.SQL, rt.Args)
-	query = expandStarProjection(query)
+	query = expandStarProjection(query, seedTableColumns(rt.Seed))
 	query = rewriteMapProjections(query)
 	query = nestMapOrderBy(query)
 	colCount := extractProjectionCount(query)

--- a/test/spec/runner_chdb.go
+++ b/test/spec/runner_chdb.go
@@ -223,13 +223,19 @@ func orderByReferencesMapSubscript(orderBy string) bool {
 // (<right>) AS R ON …`, whose columns come from the FIRST subquery —
 // the same one this function already borrows from), and the inner
 // subquery starts with `SELECT ` (case-insensitive). Anything else
-// passes through. The inner subquery's projections are re-rendered as
+// passes through. tableCols is the fixture's own seed DDL (see
+// [seedTableColumns]) — a lower-cased table name -> declared column
+// names in CREATE TABLE order — the fallback catalog [expandQualifiedStar]
+// consults when the inner relation is a bare table scan with no
+// projection list of its own to borrow from (#1431). May be nil, in
+// which case that shape still bails as before. The inner subquery's
+// projections are re-rendered as
 // their aliases (preferring explicit `AS <alias>` over the implicit
 // form), re-qualified with the star's own table alias so the JOIN
 // shape stays unambiguous, which lets the outer SELECT name the
 // columns and the Map-wrap pass do its work without touching the inner
 // shape.
-func expandStarProjection(query string) string {
+func expandStarProjection(query string, tableCols map[string][]string) string {
 	// A `WITH <cte> AS (...) SELECT …` head (the vector-set-op CSE CTE,
 	// or the structural-join WITH RECURSIVE closure) precedes the outer
 	// SELECT — peel it so the projection split sees the real outer
@@ -238,9 +244,9 @@ func expandStarProjection(query string) string {
 	// the outer projection needs the toJSONString wrap.
 	withHead, body := stripWithHead(query)
 	if withHead != "" {
-		return withHead + expandStarProjectionWithCTEs(body, withHead)
+		return withHead + expandStarProjectionWithCTEs(body, withHead, tableCols)
 	}
-	return expandStarProjectionWithCTEs(query, "")
+	return expandStarProjectionWithCTEs(query, "", tableCols)
 }
 
 // expandStarProjectionWithCTEs is [expandStarProjection] with the
@@ -253,18 +259,18 @@ func expandStarProjection(query string) string {
 // therefore peels the union to its first branch and, when that branch is
 // `SELECT * FROM <cte-ident>`, resolves the identifier back to its CTE
 // body in `withHead`. Everything else is delegated unchanged.
-func expandStarProjectionWithCTEs(query, withHead string) string {
+func expandStarProjectionWithCTEs(query, withHead string, tableCols map[string][]string) string {
 	head, tail := splitOuterSelect(query)
 	if head == "" {
 		return query
 	}
 	star := strings.TrimSpace(head)
 	if star != "*" {
-		return expandQualifiedStar(query)
+		return expandQualifiedStar(query, tableCols)
 	}
 	rest := strings.TrimSpace(strings.TrimPrefix(tail, " FROM "))
 	if !strings.HasPrefix(rest, "(") {
-		return expandQualifiedStar(query)
+		return expandQualifiedStar(query, tableCols)
 	}
 	depth, end := 0, -1
 	for i := 0; i < len(rest) && end < 0; i++ {
@@ -279,16 +285,16 @@ func expandStarProjectionWithCTEs(query, withHead string) string {
 		}
 	}
 	if end < 0 {
-		return expandQualifiedStar(query)
+		return expandQualifiedStar(query, tableCols)
 	}
 	inner := strings.TrimSpace(rest[1:end])
 	// Peel a parenthesised UNION down to its leading branch, then
 	// resolve a bare-CTE-reference branch (`SELECT * FROM <ident>`)
 	// against the WITH head so the column names come from the CTE body.
 	branch := peelUnionPrefix(inner)
-	names := cteBranchAliases(branch, withHead)
+	names := cteBranchAliases(branch, withHead, tableCols)
 	if len(names) == 0 {
-		return expandQualifiedStar(query)
+		return expandQualifiedStar(query, tableCols)
 	}
 	quoted := make([]string, len(names))
 	for i, n := range names {
@@ -302,7 +308,7 @@ func expandStarProjectionWithCTEs(query, withHead string) string {
 // in withHead and borrowing its body's projection aliases. Returns nil
 // for any shape it cannot canonically enumerate, so the caller falls
 // back to the conservative [expandStarProjection] path.
-func cteBranchAliases(branch, withHead string) []string {
+func cteBranchAliases(branch, withHead string, tableCols map[string][]string) []string {
 	bHead, bTail := splitOuterSelect(branch)
 	if strings.TrimSpace(bHead) != "*" {
 		return nil
@@ -320,7 +326,7 @@ func cteBranchAliases(branch, withHead string) []string {
 	// The CTE body is itself a `SELECT * FROM (SELECT <aliased projs>…)`
 	// shape with no further WITH head; reuse the CTE-unaware star
 	// expander for name discovery only.
-	expanded := expandQualifiedStar(body)
+	expanded := expandQualifiedStar(body, tableCols)
 	eHead, _ := splitOuterSelect(expanded)
 	if eHead == "" || strings.TrimSpace(eHead) == "*" {
 		return nil
@@ -374,7 +380,7 @@ func cteBody(withHead, name string) string {
 // [rewriteMapProjections] can wrap Map columns. It is the fallback path
 // [expandStarProjectionWithCTEs] delegates to whenever the outer FROM is
 // a borrowable subquery rather than a CTE-referencing UNION.
-func expandQualifiedStar(query string) string {
+func expandQualifiedStar(query string, tableCols map[string][]string) string {
 	head, tail := splitOuterSelect(query)
 	if head == "" {
 		return query
@@ -427,9 +433,28 @@ func expandQualifiedStar(query string) string {
 	// WHERE …` inside the JOIN arm). Expand it recursively for NAME
 	// DISCOVERY only — the rewritten inner is never spliced back, tail
 	// keeps the original subquery verbatim.
-	inner = expandStarProjection(inner)
-	innerHead, _ := splitOuterSelect(inner)
+	inner = expandStarProjection(inner, tableCols)
+	innerHead, innerTail := splitOuterSelect(inner)
 	if innerHead == "" {
+		return query
+	}
+	// The inner relation may itself be a BARE TABLE SCAN (`SELECT *
+	// FROM <table> ...`, no subquery) rather than a subquery with its
+	// own projection list to borrow from — exactly the shape
+	// emitSearchTraceLimit's drain produces (`SELECT s.* FROM (SELECT *
+	// FROM otel_traces ...) AS s ...`). The recursive expandStarProjection
+	// call above cannot rewrite that inner star (there is no nested
+	// subquery to name-discover against), so it comes back unchanged and
+	// innerHead is still the literal "*". Resolve the table's own column
+	// list from the fixture's seed DDL instead of bailing (#1431).
+	if strings.TrimSpace(innerHead) == "*" {
+		if names, ok := bareTableColumns(innerTail, tableCols); ok {
+			aliases := make([]string, len(names))
+			for i, n := range names {
+				aliases[i] = qual + "`" + n + "`"
+			}
+			return "SELECT " + strings.Join(aliases, ", ") + tail
+		}
 		return query
 	}
 	innerProjs := splitProjections(innerHead)
@@ -450,6 +475,96 @@ func expandQualifiedStar(query string) string {
 		aliases = append(aliases, qual+"`"+alias+"`")
 	}
 	return "SELECT " + strings.Join(aliases, ", ") + tail
+}
+
+// bareTableColumns resolves the column list for a bare `SELECT * FROM
+// <table> ...` inner relation — no subquery, so there is no projection
+// list [expandQualifiedStar] can borrow names from — by looking <table>
+// up in tableCols, the fixture's own seed DDL parsed by
+// [seedTableColumns]. Returns (nil, false) when tableCols is empty, the
+// FROM target isn't a single bare (optionally backtick-quoted)
+// identifier, or that identifier has no known column list — any of
+// which sends the caller back to the original conservative bail.
+func bareTableColumns(innerTail string, tableCols map[string][]string) ([]string, bool) {
+	if len(tableCols) == 0 {
+		return nil, false
+	}
+	rest := strings.TrimSpace(strings.TrimPrefix(innerTail, " FROM "))
+	table := firstToken(rest)
+	table = strings.TrimSuffix(strings.TrimPrefix(table, "`"), "`")
+	if table == "" {
+		return nil, false
+	}
+	names, ok := tableCols[strings.ToLower(table)]
+	if !ok || len(names) == 0 {
+		return nil, false
+	}
+	return names, true
+}
+
+// seedTableColumns parses a fixture's `-- seed --` script and returns a
+// map from lower-cased table name to its declared column names, in
+// CREATE TABLE order. It is the authoritative catalog
+// [expandQualifiedStar] falls back to (via [bareTableColumns]) when the
+// star's inner relation is a bare table scan rather than a subquery
+// with a borrowable projection list — the DDL is the only place those
+// names exist (#1431). Statements other than a `CREATE [OR REPLACE |
+// TEMPORARY] TABLE [IF NOT EXISTS] <name> (...)` are ignored; a table
+// with zero recognisable column definitions is omitted rather than
+// mapped to an empty slice, so a lookup miss and an empty declaration
+// both read as "unknown" to callers.
+//
+// MATERIALIZED and ALIAS columns are excluded from the list: a plain
+// `SELECT *` never projects them (that is ClickHouse's own semantics,
+// not a rewriter choice), so including one would hand
+// [expandQualifiedStar] a column name the real query never returns —
+// exactly the shape that broke the spanset_pipeline_intersect fixture
+// (its MATERIALIZED SpanAttributes) during development of this fix.
+func seedTableColumns(seed string) map[string][]string {
+	cols := map[string][]string{}
+	for _, stmt := range splitStatements(seed) {
+		trimmed := stripLeadingNoise(stmt)
+		rest, ok := createTableTail(trimmed)
+		if !ok {
+			continue
+		}
+		name := strings.ToLower(strings.TrimSpace(firstToken(rest)))
+		open := strings.IndexByte(stmt, '(')
+		if open < 0 {
+			continue
+		}
+		closeParen := matchParen(stmt, open)
+		if closeParen < 0 {
+			continue
+		}
+		defs := splitTopLevelCommas(stmt[open+1 : closeParen])
+		names := make([]string, 0, len(defs))
+		for _, d := range defs {
+			d = strings.TrimSpace(d)
+			cn := firstToken(d)
+			if cn == "" || isGeneratedColumnDef(d) {
+				continue
+			}
+			names = append(names, cn)
+		}
+		if len(names) > 0 {
+			cols[name] = names
+		}
+	}
+	return cols
+}
+
+// isGeneratedColumnDef reports whether a CREATE TABLE column definition
+// declares a MATERIALIZED or ALIAS column — the two ClickHouse column
+// kinds a bare `SELECT *` omits from its result set (DEFAULT columns,
+// by contrast, ARE included). Matched the same way
+// normalizeTracesColumnDef locates `MATERIALIZED`: a space-delimited
+// token search, which is safe here because both keywords only ever
+// appear as the modifier between a column's type and its generating
+// expression, never as (part of) a bare identifier or type name.
+func isGeneratedColumnDef(def string) bool {
+	upper := " " + strings.ToUpper(def) + " "
+	return strings.Contains(upper, " MATERIALIZED ") || strings.Contains(upper, " ALIAS ")
 }
 
 // rewriteMapProjections wraps any top-level SELECT projection whose
@@ -952,7 +1067,7 @@ func RunRoundTrip(t *testing.T, c *Case) {
 	// the args side is global, and ordering them this way keeps the
 	// argIdx accounting in substituteNow64 simple.
 	query, queryArgs := substituteNow64(rt.SQL, rt.Args)
-	query = expandStarProjection(query)
+	query = expandStarProjection(query, seedTableColumns(rt.Seed))
 	query = rewriteMapProjections(query)
 	query = nestMapOrderBy(query)
 	colCount := extractProjectionCount(query)

--- a/test/spec/star_expansion_test.go
+++ b/test/spec/star_expansion_test.go
@@ -33,7 +33,7 @@ func TestExpandStarProjection_CTEUnionResolvesAliases(t *testing.T) {
 		"WHERE `TraceId` IN (SELECT `TraceId` FROM _setand_l_1) " +
 		"AND `TraceId` IN (SELECT `TraceId` FROM _setand_r_1) LIMIT 1 BY `TraceId`"
 
-	got := expandStarProjection(query)
+	got := expandStarProjection(query, nil)
 
 	// The outer star must have been replaced by the CTE body's explicit
 	// alias list.
@@ -66,5 +66,73 @@ func TestExpandStarProjection_CTEUnionResolvesAliases(t *testing.T) {
 	full := rewriteMapProjections(got)
 	if !strings.Contains(full, "toJSONString(`ResourceAttrs`)") {
 		t.Errorf("Map column ResourceAttrs was not wrapped in toJSONString:\n%s", full)
+	}
+}
+
+// TestExpandStarProjection_BareTableResolvesFromSeedDDL pins #1431: the
+// emitSearchTraceLimit drain shape `SELECT s.* FROM (SELECT * FROM
+// <table> ...) AS s ...` has no inner SUBQUERY projection list to borrow
+// column names from — the inner relation is a bare table scan. Without a
+// fallback to the seed's own CREATE TABLE DDL, expandQualifiedStar bails
+// out unchanged and a Map column (SpanAttributes) rides through
+// unwrapped, which panics chdb-go's parquet driver with `could not cast
+// to type: MAP`.
+func TestExpandStarProjection_BareTableResolvesFromSeedDDL(t *testing.T) {
+	t.Parallel()
+
+	const seed = "CREATE TABLE otel_traces (\n" +
+		"    TraceId String,\n" +
+		"    SpanId String,\n" +
+		"    Timestamp DateTime64(9),\n" +
+		"    SpanName String,\n" +
+		"    SpanAttributes Map(String, String)\n" +
+		") ENGINE = MergeTree ORDER BY (Timestamp, SpanId);\n" +
+		"INSERT INTO otel_traces VALUES ('t1', 's1', toDateTime64('2026-01-01 00:00:00', 9), 'checkout', map());"
+	query := "SELECT s.* FROM (SELECT * FROM `otel_traces` PREWHERE (`SpanName` = ?) " +
+		"WHERE (`Timestamp` >= fromUnixTimestamp64Nano(?))) AS s WHERE `TraceId` IN " +
+		"(SELECT `TraceId` FROM (SELECT * FROM `otel_traces` PREWHERE (`SpanName` = ?)) " +
+		"GROUP BY `TraceId` ORDER BY min(`Timestamp`) DESC, `TraceId` LIMIT 2)"
+
+	got := expandStarProjection(query, seedTableColumns(seed))
+
+	head, _ := splitOuterSelect(got)
+	proj := strings.TrimSpace(head)
+	if proj == "s.*" || proj == "*" {
+		t.Fatalf("outer qualified star over a bare table scan was not expanded:\n%s", got)
+	}
+	wantCols := []string{"s.`TraceId`", "s.`SpanId`", "s.`Timestamp`", "s.`SpanName`", "s.`SpanAttributes`"}
+	for _, c := range wantCols {
+		if !strings.Contains(proj, c) {
+			t.Errorf("expanded outer projection missing %s:\n%s", c, proj)
+		}
+	}
+
+	// The inner IN-subquery scan (never itself starred at the outer
+	// level) and the ORDER BY / LIMIT tie-break clause must survive
+	// untouched — only the outer s.* projection is rewritten.
+	if !strings.Contains(got, "GROUP BY `TraceId` ORDER BY min(`Timestamp`) DESC, `TraceId` LIMIT 2") {
+		t.Errorf("inner tie-break subquery was altered:\n%s", got)
+	}
+
+	// The Map-wrap pass must now find the named Map column and wrap it.
+	full := rewriteMapProjections(got)
+	if !strings.Contains(full, "toJSONString(") || !strings.Contains(full, "SpanAttributes") {
+		t.Errorf("Map column SpanAttributes was not wrapped in toJSONString:\n%s", full)
+	}
+}
+
+// TestExpandStarProjection_BareTableWithoutSeedStillBails asserts the
+// pre-#1431 fallback behaviour is preserved when no seed-derived column
+// map is available (tableCols == nil): a qualified star over a bare
+// table scan is left unchanged rather than guessed at.
+func TestExpandStarProjection_BareTableWithoutSeedStillBails(t *testing.T) {
+	t.Parallel()
+
+	query := "SELECT s.* FROM (SELECT * FROM `otel_traces` WHERE (`SpanName` = ?)) AS s " +
+		"WHERE `TraceId` IN (SELECT `TraceId` FROM (SELECT * FROM `otel_traces`) GROUP BY `TraceId`)"
+
+	got := expandStarProjection(query, nil)
+	if got != query {
+		t.Errorf("expected query to pass through unchanged without a seed column map, got:\n%s", got)
 	}
 }

--- a/test/spec/traceql/search_trace_limit_bare_table_map_column.txtar
+++ b/test/spec/traceql/search_trace_limit_bare_table_map_column.txtar
@@ -1,0 +1,47 @@
+emitSearchTraceLimit renders the drain as `SELECT s.* FROM (<input>) AS s
+WHERE TraceId IN (...)`. When the query has no `select(...)` clause the
+`<input>` is a bare `Filter -> Scan` — it lowers straight to `SELECT *
+FROM otel_traces WHERE ...`, with no named projection list of its own.
+
+That is the shape the round-trip harness's expandQualifiedStar could not
+canonically enumerate (#1431): the outer star's inner relation is a bare
+table scan, not a subquery with a projection list to borrow column names
+from, so the rewriter used to bail and the seed's ResourceAttributes Map
+column rode through the outer `s.*` unwrapped — chdb-go's parquet driver
+then panics with `could not cast to type: MAP`. #1428 sidestepped this by
+matching on the `name` intrinsic so its seed carried no Map column at
+all, leaving the search head's Map-valued output unexercised by any
+round-trip. This fixture matches on a RESOURCE ATTRIBUTE instead, so the
+seed's ResourceAttributes column is a real Map that the round-trip must
+carry through toJSONString(...) successfully.
+
+-- search_limit --
+1
+-- query.traceql --
+{ resource.service.name = "frontend" }
+-- seed --
+CREATE TABLE otel_traces (
+    TraceId String,
+    SpanId String,
+    Timestamp DateTime64(9),
+    SpanName String,
+    ResourceAttributes Map(String, String)
+) ENGINE = MergeTree ORDER BY (Timestamp, SpanId);
+INSERT INTO otel_traces VALUES
+    ('0000000000000000000000000000aa01', '0000000000000011', toDateTime64('2026-01-01 00:00:10', 9), 'checkout', map('service.name', 'frontend')),
+    ('0000000000000000000000000000bb02', '0000000000000021', toDateTime64('2026-01-01 00:00:20', 9), 'checkout', map('service.name', 'backend'));
+-- expected_rows --
+[
+  ["0000000000000000000000000000aa01", "0000000000000011", "2026-01-01T00:00:10Z", "checkout", {"service.name": "frontend"}]
+]
+-- args --
+[0] string = "service.name"
+[1] string = "frontend"
+[2] string = "service.name"
+[3] string = "frontend"
+-- chplan --
+SearchTraceLimit traceLimit=1
+  Filter predicate=(ResourceAttributes["service.name"] = "frontend")
+    Scan(otel_traces)
+-- sql --
+SELECT s.* FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) AS s WHERE `TraceId` IN (SELECT `TraceId` FROM (SELECT * FROM `otel_traces` WHERE (`ResourceAttributes`[?] = ?)) GROUP BY `TraceId` ORDER BY min(`Timestamp`) DESC, `TraceId` LIMIT 1)

--- a/test/spec/traceql/search_trace_limit_tiebreak_boundary.txtar
+++ b/test/spec/traceql/search_trace_limit_tiebreak_boundary.txtar
@@ -22,9 +22,15 @@ on the other side of the boundary too, and ranking ASC instead of DESC drops
 the newest trace.
 
 The matcher is the `name` intrinsic rather than a resource attribute so the
-seed carries no Map column: the emitted drain is `SELECT s.*`, and the
-round-trip harness cannot enumerate a bare `SELECT * FROM <table>` to wrap a
-Map in toJSONString.
+seed carries no Map column — this fixture's purpose is pinning the TraceId
+tie-break order, and staying Map-free keeps it that way rather than also
+depending on the Map round-trip. That combination WAS a forced choice: the
+round-trip harness could not enumerate a bare `SELECT * FROM <table>` to wrap
+a Map in toJSONString, so no fixture of this drain shape could assert on a
+Map column at all. Resolved in this change (#1431) — expandQualifiedStar now
+falls back to the fixture's own seed DDL for a bare table scan's column list,
+and search_trace_limit_bare_table_map_column.txtar exercises the Map-bearing
+case directly.
 
 -- search_limit --
 2


### PR DESCRIPTION
## What

`test/spec/runner_chdb.go`'s `expandQualifiedStar` derived column names from an inner **subquery's** projection list. When the inner relation was a bare table scan (`SELECT * FROM <table>`, no subquery) there was no projection list to borrow from, so the rewriter bailed and a Map column rode through unwrapped — chdb-go's parquet driver then panicked with `could not cast to type: MAP`.

That is exactly the drain shape `emitSearchTraceLimit` produces (`SELECT s.* FROM (SELECT * FROM <table> ...) AS s ...`). The consequence was a coverage ceiling: no seeded fixture of this shape could assert on `ResourceAttributes` / `SpanAttributes` at all. #1428 sidestepped it by matching on the `name` intrinsic so its seed carried no Map column, and said so in the fixture header — but the search head's Map-valued output stayed unexercised by any round-trip.

## Fix

`expandQualifiedStar` now falls back to the fixture's own `-- seed --` DDL, via a new `seedTableColumns` helper, when the inner relation is a bare table scan with no projection list of its own to borrow column names from. `seedTableColumns` parses the seed's `CREATE TABLE` statements into a `table -> ordered column names` map, threaded down through `expandStarProjection` / `expandStarProjectionWithCTEs` / `cteBranchAliases` (all now take a `tableCols map[string][]string`, nil-safe — a nil map keeps the pre-existing conservative bail).

`RunRoundTrip` (the chDB assertion path) and `PrepareRoundTrip` (the perf-profiler prep seam) now pass `seedTableColumns(rt.Seed)`. The eval-instant sweep (`eval_instant_sweep.go`) passes `nil` — its PromQL lowering always wraps scans in a named `Project`, never a bare `SELECT s.* FROM (SELECT * FROM <table>)` drain, so the new fallback isn't needed there.

**MATERIALIZED / ALIAS columns are excluded** from `seedTableColumns`'s output: ClickHouse's own `SELECT *` semantics never project them, so including one would hand the rewriter a column name the real query never returns. Missing this filter in an earlier iteration of this fix broke `spanset_pipeline_intersect.txtar` (its `SpanAttributes` column is `MATERIALIZED`) — caught by running the full `traceql` round-trip suite before pushing, not by CI.

## Verification

- Reproduced the exact panic pre-fix with a new fixture (`search_trace_limit_bare_table_map_column.txtar`, a resource-attribute search with `search_limit` and no `select()`, seeded with a real `ResourceAttributes` Map column): `rows.Err: could not cast to type: MAP`.
- Same fixture passes post-fix and its `expected_rows` were generated via `just update-golden`.
- Two new unit tests in `star_expansion_test.go` pin the new resolution path directly (`TestExpandStarProjection_BareTableResolvesFromSeedDDL`) and the nil-tableCols fallback (`TestExpandStarProjection_BareTableWithoutSeedStillBails`).
- Full `just update-golden` run (all fixtures, chdb tag, cardinality baseline) — only the expected diffs: the new fixture's cardinality-baseline row, the new fixture file, and the code changes. No drift in solver/migration/parity goldens.
- `go test -tags chdb ./test/spec/...` and `go test -tags chdb -run TestCardinalityRatchet ./test/perf/` both green after the update.
- `go build ./...`, `go vet -tags chdb ./test/spec/...` clean.
- Pre-push lefthook gates (golangci-lint, forbid-sql-raw, forbid-skip, markdownlint, actionlint) all green locally.

## Follow-up on #1428's workaround

Updated the stale prose in `search_trace_limit_tiebreak_boundary.txtar` (which explained why it avoided a Map-bearing matcher) to note the limitation is resolved in this change, while keeping its own matcher choice (the `name` intrinsic) as-is — that fixture's purpose is pinning the TraceId tie-break order, which stays cleanest without also depending on the Map round-trip. The new fixture in this PR is what now exercises the Map-bearing case directly.

Closes #1431

🤖 Generated with [Claude Code](https://claude.com/claude-code)