### PR TITLE
fix(ci): skip empty placeholder commits in commitlint's PR range

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -267,6 +267,37 @@ uncomputable-diff fallback — cannot drift between the lanes that use it.
   - Exit: `0` when every cited path exists + pins are in range (or self-test
     passes), `1` on any dead reference / out-of-range pin (or a failed
     self-test).
+- **`commitlint-range.mjs`** — `ci.yml`, the `lint` job's `commitlint` step
+  (pull_request only). Lints a PR's commit range while skipping commits that
+  touched no files — GitHub Copilot's coding-agent workflow opens every PR it
+  authors with an empty "Initial plan" placeholder commit, which trips
+  commitlint's `subject-empty` / `type-empty` rules and reds the whole `lint`
+  required check (issue #1643). commitlint's own `--from`/`--to` range mode
+  enumerates every commit via its internal traversal and lints all of them
+  regardless of diff content; `--git-log-args=--diff-filter` was tried and
+  verified ineffective (byte-identical output with or without it). This
+  module filters the commit list itself — `git diff-tree --no-commit-id
+  --name-only -r <sha>` empty means "not a real change" — rather than keying
+  on Copilot's exact commit-message text (a commitlint `ignores` predicate
+  matching the literal string "Initial plan" was confirmed to work today but
+  would rot the moment the wording changes, and would also exempt any
+  accidental non-empty commit sharing that subject from real linting).
+  Surviving commits are linted exactly as before, one at a time via
+  commitlint's stdin mode.
+  - Env: `BASE_SHA` / `HEAD_SHA` (required, PR base/head SHAs),
+    `COMMITLINT_CONFIG` (optional; default `.commitlintrc.json`), `GIT_CWD`
+    (optional; default `process.cwd()`).
+  - Exit: `0` when every commit that touched a file passes commitlint (or the
+    range has no such commit), `1` on a real lint failure or an unresolvable
+    range (anti-vacuity: an unresolvable range fails rather than reading as
+    "no commits").
+  - Tests: `commitlint-range.test.mjs` (run in `ci.yml` immediately before the
+    `commitlint` step), exercised against real ephemeral git repos with an
+    injected fake linter (offline; the real commitlint wiring was verified
+    separately against the actual CLI). Negative controls: a genuinely bad
+    commit still fails the gate even beside a skipped empty one, and a
+    non-empty commit whose subject merely reads "Initial plan" is still
+    linted — proving the filter is diff-based, not text-based.
 - **`doc-counts.mjs`** — `ci.yml`, the `forbid-skip` job step "Assert
   doc-stated counts match source". The assert-from-source gate that stops
   doc-stated integer counts from drifting away from the source structures

--- a/.github/scripts/commitlint-range.mjs
+++ b/.github/scripts/commitlint-range.mjs
@@ -1,0 +1,197 @@
+#!/usr/bin/env node
+// commitlint-range.mjs — lints a pull request's commit range, skipping
+// commits that touched no files.
+//
+// WHY THIS EXISTS (issue #1643): GitHub Copilot's coding-agent workflow opens
+// every PR it authors with an empty "Initial plan" placeholder commit — no
+// changed files, empty subject, empty Conventional-Commits type. commitlint's
+// own `--from`/`--to` range mode enumerates every commit SHA in the range via
+// its internal traversal and lints ALL of them, including commits that
+// changed nothing, so that placeholder trips `subject-empty` / `type-empty`
+// and reds the whole `lint` required check on every Copilot PR.
+//
+// A first attempt added `--git-log-args="--diff-filter=ACMRT"` to the
+// commitlint invocation, on the theory that narrowing `git log`'s traversal
+// to commits with real file changes would narrow what commitlint lints.
+// VERIFIED INEFFECTIVE: reproduced locally with commitlint@19 — byte-
+// identical output with and without the flag, still failing on the empty
+// commit. commitlint's range mode does not consult `--git-log-args` to decide
+// which commits to lint.
+//
+// This module filters the commit LIST ourselves before commitlint ever sees
+// it, on the one fact that actually describes "not a real change": zero
+// files touched (`git diff-tree --no-commit-id --name-only -r <sha>` is
+// empty). That is deliberately NOT keyed on Copilot's exact commit-message
+// text ("Initial plan") — a commitlint `ignores` predicate matching that
+// literal string was considered and confirmed to work today, but it is
+// brittle two ways: it rots the moment the wording changes (a product
+// surface this repo does not control), and it would also exempt any
+// accidental non-empty commit that happened to share that exact subject line
+// from real linting. Filtering by diff emptiness generalises to any
+// future auto-generated empty commit, not just this one product's current
+// wording, and cannot be fooled by message text alone.
+//
+// Every commit that DID touch a file is linted exactly as before, one at a
+// time via commitlint's stdin ("--edit"-equivalent) mode — the same
+// per-commit linting commitlint's own range mode performs internally, minus
+// the empty ones. Merge commits are excluded via `git rev-list --no-merges`,
+// matching commitlint's existing `defaultIgnores` behaviour for merge-commit
+// subjects (enabled by default), so this is not a behaviour change for them.
+//
+// Env contract (only read when invoked as the program):
+//   BASE_SHA           REQUIRED. Range start (exclusive) — a resolvable ref/SHA.
+//   HEAD_SHA           REQUIRED. Range end (inclusive) — a resolvable ref/SHA.
+//   COMMITLINT_CONFIG  Path to the commitlint config file.
+//                      Default: .commitlintrc.json
+//   GIT_CWD            Working directory for git + commitlint invocations.
+//                      Default: process.cwd()
+//
+// Exit codes: 0 = every commit that touched a file passed commitlint (or the
+// range contains no such commit), 1 = a commit failed linting, or the range
+// itself could not be resolved (anti-vacuity: an unresolvable range is a
+// failure, never a silent pass).
+//
+// The pure/injectable parts (selectLintableCommits, run) are exported and
+// pinned by the `node --test` guard commitlint-range.test.mjs; the scan
+// itself runs only when this file is invoked as the program.
+
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+
+import { capture, error, log, notice } from './lib/gh.mjs';
+
+// listRangeCommits — non-merge commit SHAs in (baseSha, headSha], oldest
+// first, each paired with its full commit message.
+export function listRangeCommits(baseSha, headSha, opts = {}) {
+  const cwd = opts.cwd;
+  // %x00-delimited records so a multi-line commit body can't be mistaken for
+  // a record boundary; %H is the SHA, everything after the first NUL in a
+  // record is the raw message (subject + blank line + body).
+  const res = capture(
+    'git',
+    ['log', '--no-merges', '--reverse', '--format=%H%x00%B%x01', `${baseSha}..${headSha}`],
+    { cwd },
+  );
+  if (res.status !== 0) {
+    throw new Error(`git log ${baseSha}..${headSha} failed: ${res.stderr.trim() || res.stdout.trim()}`);
+  }
+  return res.stdout
+    .split('\x01')
+    .map((record) => record.replace(/^\n/, ''))
+    .filter((record) => record.trim().length > 0)
+    .map((record) => {
+      const nul = record.indexOf('\x00');
+      const sha = record.slice(0, nul);
+      // Trim exactly one trailing newline `git log` leaves before the %x01
+      // separator; preserve everything else (blank lines in the body matter
+      // to commitlint's body-leading-blank rule).
+      const message = record.slice(nul + 1).replace(/\n$/, '');
+      return { sha, message };
+    });
+}
+
+// hasFileChanges — true if `sha` touched at least one file. A commit with an
+// empty tree diff (GitHub Copilot's "Initial plan" placeholder is created via
+// `git commit --allow-empty`) prints nothing here regardless of its message.
+export function hasFileChanges(sha, opts = {}) {
+  const res = capture('git', ['diff-tree', '--no-commit-id', '--name-only', '-r', sha], {
+    cwd: opts.cwd,
+  });
+  if (res.status !== 0) {
+    throw new Error(`git diff-tree ${sha} failed: ${res.stderr.trim() || res.stdout.trim()}`);
+  }
+  return res.stdout.trim().length > 0;
+}
+
+// selectLintableCommits — the commits in (baseSha, headSha] commitlint should
+// actually see, plus the ones filtered out (for reporting). Throws if the
+// range itself does not resolve — an unresolvable range must never read as
+// "no commits to lint".
+export function selectLintableCommits(baseSha, headSha, opts = {}) {
+  const commits = listRangeCommits(baseSha, headSha, opts);
+  const lintable = [];
+  const skipped = [];
+  for (const commit of commits) {
+    if (hasFileChanges(commit.sha, opts)) {
+      lintable.push(commit);
+    } else {
+      skipped.push(commit);
+    }
+  }
+  return { lintable, skipped };
+}
+
+// defaultLintOne — lints a single commit message via the real commitlint
+// CLI, stdin mode (equivalent to `commitlint --edit` reading from a file: no
+// `--from`/`--to`, so commitlint's own range enumeration never runs — this
+// module IS the range enumeration now). `npx --no` refuses to fetch from the
+// registry, so this only succeeds when commitlint is already installed
+// (the workflow step installs it immediately before invoking this module).
+export function defaultLintOne(message, opts = {}) {
+  const config = opts.config ?? '.commitlintrc.json';
+  return capture('npx', ['--no', '--', 'commitlint', '--config', config, '--verbose'], {
+    cwd: opts.cwd,
+    input: message,
+  });
+}
+
+// run — the orchestration seam. `lintOne` defaults to defaultLintOne (real
+// commitlint) but is injectable so the orchestration logic can be pinned
+// offline without installing commitlint — see commitlint-range.test.mjs.
+export function run({ baseSha, headSha, cwd, config = '.commitlintrc.json', lintOne = defaultLintOne }) {
+  if (!baseSha || !headSha) {
+    error('commitlint-range: BASE_SHA and HEAD_SHA are both required.');
+    return 1;
+  }
+
+  let selection;
+  try {
+    selection = selectLintableCommits(baseSha, headSha, { cwd });
+  } catch (err) {
+    error(`commitlint-range: could not resolve commit range ${baseSha}..${headSha}: ${err.message}`);
+    return 1;
+  }
+
+  const { lintable, skipped } = selection;
+
+  for (const commit of skipped) {
+    const subject = commit.message.split('\n', 1)[0];
+    notice(`skipping ${commit.sha.slice(0, 12)} "${subject}" — no file changes`);
+  }
+
+  const failures = [];
+  for (const commit of lintable) {
+    const subject = commit.message.split('\n', 1)[0];
+    const result = lintOne(commit.message, { cwd, config });
+    log(`⧗   ${commit.sha.slice(0, 12)}   ${subject}`);
+    if (result.stdout) log(result.stdout.trimEnd());
+    if (result.stderr) log(result.stderr.trimEnd());
+    if (result.status !== 0) {
+      failures.push(commit);
+    }
+  }
+
+  if (failures.length > 0) {
+    error(
+      `commitlint-range: ${failures.length} of ${lintable.length} commit(s) failed — ` +
+        failures.map((c) => c.sha.slice(0, 12)).join(', '),
+    );
+    return 1;
+  }
+
+  notice(
+    `commitlint-range: ${lintable.length} commit(s) linted, ${skipped.length} skipped (no file changes).`,
+  );
+  return 0;
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isMain) {
+  const status = run({
+    baseSha: process.env.BASE_SHA,
+    headSha: process.env.HEAD_SHA,
+    cwd: process.env.GIT_CWD,
+    config: process.env.COMMITLINT_CONFIG ?? '.commitlintrc.json',
+  });
+  process.exit(status);
+}

--- a/.github/scripts/commitlint-range.test.mjs
+++ b/.github/scripts/commitlint-range.test.mjs
@@ -1,0 +1,208 @@
+// commitlint-range.test.mjs — in-process pins for the commitlint-range gate
+// (issue #1643: GitHub Copilot's empty "Initial plan" placeholder commit
+// trips commitlint's subject-empty/type-empty rules and reds the whole
+// `lint` required check).
+//
+// Exercised against REAL git repos in a temp dir, same idiom as
+// compat-publish-score.test.mjs: the empty-commit detection is a git
+// behaviour (`git diff-tree` on a `--allow-empty` commit), and a mock that
+// agreed with the module's own assumptions would pass while the real
+// placeholder commit still broke CI.
+//
+// The orchestration (`run`) is pinned with an INJECTED `lintOne` rather than
+// the real commitlint CLI, keeping this file dependency-light (node:
+// builtins only, per .github/scripts/README.md) and offline. The injected
+// fake reproduces exactly what real commitlint reports for a Conventional
+// Commit vs. not — `defaultLintOne`'s wiring to the real CLI was verified
+// separately against commitlint@19 (byte-for-byte the same pass/fail split
+// this file pins), see the issue for the transcript.
+//
+// Negative controls matter most here: a genuinely bad NON-empty commit must
+// still fail the gate even when an empty commit sits right next to it in the
+// range (the empty-commit skip must not neuter real linting), and a bad
+// commit whose SUBJECT happens to read "Initial plan" but which DID touch a
+// file must still fail (proving the filter is diff-based, not text-based —
+// the whole reason this module exists instead of a commitlint `ignores`
+// predicate keyed on that literal string).
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { test } from 'node:test';
+
+import { hasFileChanges, listRangeCommits, run, selectLintableCommits } from './commitlint-range.mjs';
+
+function git(cwd, args) {
+  const res = spawnSync('git', args, { cwd, encoding: 'utf8' });
+  assert.equal(res.status, 0, `git ${args.join(' ')} failed: ${res.stderr}`);
+  return res.stdout;
+}
+
+// makeRepo builds: base (real commit) -> real commit -> empty "Initial plan"
+// commit -> real commit. Returns the SHAs a test needs plus a helper to
+// extend the history further (for the negative-control cases).
+function makeRepo() {
+  const cwd = mkdtempSync(path.join(tmpdir(), 'commitlint-range-'));
+  git(cwd, ['init', '-q', '--initial-branch=main']);
+  git(cwd, ['config', 'user.name', 'test']);
+  git(cwd, ['config', 'user.email', 'test@example.com']);
+
+  writeFileSync(path.join(cwd, 'a.txt'), 'a\n');
+  git(cwd, ['add', 'a.txt']);
+  git(cwd, ['commit', '-q', '-m', 'feat: add a']);
+  const base = git(cwd, ['rev-parse', 'HEAD']).trim();
+
+  writeFileSync(path.join(cwd, 'b.txt'), 'b\n');
+  git(cwd, ['add', 'b.txt']);
+  git(cwd, ['commit', '-q', '-m', 'fix: fix b']);
+
+  git(cwd, ['commit', '-q', '--allow-empty', '-m', 'Initial plan']);
+
+  writeFileSync(path.join(cwd, 'c.txt'), 'c\n');
+  git(cwd, ['add', 'c.txt']);
+  git(cwd, ['commit', '-q', '-m', 'feat: add c']);
+
+  return { cwd, base, head: git(cwd, ['rev-parse', 'HEAD']).trim() };
+}
+
+function commit(cwd, file, contents, message, extraArgs = []) {
+  writeFileSync(path.join(cwd, file), contents);
+  git(cwd, ['add', file]);
+  git(cwd, ['commit', '-q', '-m', message, ...extraArgs]);
+  return git(cwd, ['rev-parse', 'HEAD']).trim();
+}
+
+// A fake `lintOne` standing in for real commitlint: Conventional-Commits
+// header shape (`type: subject`) passes, anything else fails — the same
+// split @commitlint/config-conventional's subject-empty/type-empty rules
+// produce for these exact inputs (verified against the real CLI).
+function fakeLintOne(message) {
+  const subject = message.split('\n', 1)[0];
+  const ok = /^[a-z]+(\([^)]+\))?: .+/.test(subject);
+  return { status: ok ? 0 : 1, stdout: ok ? '' : `✖ ${subject}`, stderr: '' };
+}
+
+test('listRangeCommits returns every non-merge commit, oldest first, with full messages', () => {
+  const { cwd, base, head } = makeRepo();
+  try {
+    const commits = listRangeCommits(base, head, { cwd });
+    assert.deepEqual(
+      commits.map((c) => c.message),
+      ['fix: fix b', 'Initial plan', 'feat: add c'],
+    );
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('hasFileChanges is false for an --allow-empty commit and true for a real one', () => {
+  const { cwd, base, head } = makeRepo();
+  try {
+    const commits = listRangeCommits(base, head, { cwd });
+    const bySubject = Object.fromEntries(commits.map((c) => [c.message, c.sha]));
+    assert.equal(hasFileChanges(bySubject['Initial plan'], { cwd }), false);
+    assert.equal(hasFileChanges(bySubject['fix: fix b'], { cwd }), true);
+    assert.equal(hasFileChanges(bySubject['feat: add c'], { cwd }), true);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('selectLintableCommits filters out only the empty commit', () => {
+  const { cwd, base, head } = makeRepo();
+  try {
+    const { lintable, skipped } = selectLintableCommits(base, head, { cwd });
+    assert.deepEqual(
+      lintable.map((c) => c.message),
+      ['fix: fix b', 'feat: add c'],
+    );
+    assert.deepEqual(
+      skipped.map((c) => c.message),
+      ['Initial plan'],
+    );
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('run() passes a range containing only the placeholder commit and valid commits', () => {
+  const { cwd, base, head } = makeRepo();
+  try {
+    const status = run({ baseSha: base, headSha: head, cwd, lintOne: fakeLintOne });
+    assert.equal(status, 0);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('run() still fails when a genuinely bad NON-empty commit sits beside the empty one', () => {
+  const { cwd, base, head } = makeRepo();
+  try {
+    const badHead = commit(cwd, 'd.txt', 'd\n', 'this is not conventional');
+    const status = run({ baseSha: base, headSha: badHead, cwd, lintOne: fakeLintOne });
+    assert.equal(status, 1, 'a real bad commit must still fail the gate');
+    void head; // the good head is unused in this scenario; kept for clarity
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('run() fails on a non-empty commit whose subject happens to read "Initial plan"', () => {
+  // Proves the filter is diff-based, not text-based: an empty-diff commit
+  // and a real commit that merely SHARES the placeholder's subject line must
+  // be treated differently.
+  const cwd = mkdtempSync(path.join(tmpdir(), 'commitlint-range-'));
+  try {
+    git(cwd, ['init', '-q', '--initial-branch=main']);
+    git(cwd, ['config', 'user.name', 'test']);
+    git(cwd, ['config', 'user.email', 'test@example.com']);
+    writeFileSync(path.join(cwd, 'a.txt'), 'a\n');
+    git(cwd, ['add', 'a.txt']);
+    git(cwd, ['commit', '-q', '-m', 'feat: add a']);
+    const base = git(cwd, ['rev-parse', 'HEAD']).trim();
+
+    const head = commit(cwd, 'b.txt', 'b\n', 'Initial plan');
+
+    const status = run({ baseSha: base, headSha: head, cwd, lintOne: fakeLintOne });
+    assert.equal(status, 1, 'a real commit must be linted even if its subject reads "Initial plan"');
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('run() passes a range with no lintable commits (every commit is empty)', () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), 'commitlint-range-'));
+  try {
+    git(cwd, ['init', '-q', '--initial-branch=main']);
+    git(cwd, ['config', 'user.name', 'test']);
+    git(cwd, ['config', 'user.email', 'test@example.com']);
+    writeFileSync(path.join(cwd, 'a.txt'), 'a\n');
+    git(cwd, ['add', 'a.txt']);
+    git(cwd, ['commit', '-q', '-m', 'feat: add a']);
+    const base = git(cwd, ['rev-parse', 'HEAD']).trim();
+    git(cwd, ['commit', '-q', '--allow-empty', '-m', 'Initial plan']);
+    const head = git(cwd, ['rev-parse', 'HEAD']).trim();
+
+    const status = run({ baseSha: base, headSha: head, cwd, lintOne: fakeLintOne });
+    assert.equal(status, 0);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('run() fails, not vacuously passes, on an unresolvable range', () => {
+  const { cwd, base } = makeRepo();
+  try {
+    const status = run({ baseSha: base, headSha: 'not-a-real-ref', cwd, lintOne: fakeLintOne });
+    assert.equal(status, 1);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('run() fails when BASE_SHA or HEAD_SHA is missing rather than defaulting silently', () => {
+  const status = run({ baseSha: '', headSha: 'HEAD', cwd: process.cwd(), lintOne: fakeLintOne });
+  assert.equal(status, 1);
+});

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,6 +336,15 @@ jobs:
       # pull_request events: base.sha..head.sha, i.e. the commits
       # unique to the PR head. `fetch-depth: 0` on the checkout above
       # guarantees both SHAs exist locally.
+      #
+      # The range is NOT handed to commitlint's own --from/--to range mode:
+      # GitHub Copilot's coding-agent workflow opens every PR with an empty
+      # "Initial plan" placeholder commit (no file changes), which trips
+      # subject-empty/type-empty and reds this whole job on every Copilot
+      # PR — a first fix attempt (--git-log-args=--diff-filter) was verified
+      # ineffective, commitlint's range enumeration ignores that flag. See
+      # .github/scripts/commitlint-range.mjs's header for the full
+      # reasoning and issue #1643.
       # Shared by commitlint (pull_request only) and the Playwright
       # typecheck below (every event) — set up unconditionally so both
       # consumers find a Node toolchain.
@@ -360,6 +369,10 @@ jobs:
           npm ci
           npx --no -- tsc --noEmit -p tsconfig.json
 
+      - name: commitlint-range self-test (empty-commit filter guard)
+        if: github.event_name == 'pull_request'
+        run: node --test .github/scripts/commitlint-range.test.mjs
+
       - name: commitlint
         if: github.event_name == 'pull_request'
         env:
@@ -367,8 +380,7 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           npm install --no-save @commitlint/cli@19 @commitlint/config-conventional@19
-          npx --no -- commitlint --config .commitlintrc.json \
-            --from "$BASE_SHA" --to "$HEAD_SHA" --verbose
+          node .github/scripts/commitlint-range.mjs
 
       - name: markdownlint
         uses: DavidAnson/markdownlint-cli2-action@6bf21b07787794f89a243495939cd651942aeabe  # v24.1.0


### PR DESCRIPTION
## Summary

- GitHub Copilot's coding-agent workflow opens every PR with an empty "Initial plan" commit (no file changes), which trips commitlint's `subject-empty`/`type-empty` rules and reds the whole `lint` required check on every Copilot PR (#1636, #1637, #1638, #1639 all hit this).
- A first fix attempt (`--git-log-args="--diff-filter=ACMRT"`) was verified ineffective: commitlint's `--from`/`--to` range mode enumerates every commit SHA via its own internal traversal, unaffected by that flag — reproduced locally with commitlint@19, byte-identical output either way.
- Adds `.github/scripts/commitlint-range.mjs`, which filters the commit range itself before commitlint ever sees it: `git diff-tree --no-commit-id --name-only -r <sha>` empty means "not a real change", so those commits are skipped. Deliberately NOT keyed on Copilot's literal "Initial plan" text — a commitlint `ignores` predicate matching that string was tried and confirmed to work today, but it's brittle two ways: it rots the moment the wording changes, and it would exempt any accidental non-empty commit sharing that subject from real linting. Filtering by diff emptiness generalises to any future auto-generated empty commit.
- Commits that DID touch a file are linted exactly as before, one at a time via commitlint's stdin mode.

## Verification

Reproduced against the real `commitlint@19` CLI in a throwaway repo (base → real commit → `git commit --allow-empty -m "Initial plan"` → real commit):

- Full range through the **shipped script** (`node .github/scripts/commitlint-range.mjs`, not a hand-rolled equivalent): skips the empty commit, lints the two real ones, exits `0`.
- Same range with a genuinely non-conventional commit added: still exits `1` — the empty-commit skip does not neuter real linting.

`.github/scripts/commitlint-range.test.mjs` (9 tests, all passing, `node --test`) pins the orchestration offline against real ephemeral git repos with an injected fake linter, including two negative controls:

- a genuinely bad non-empty commit still fails the gate even beside a skipped empty one;
- a non-empty commit whose subject happens to read exactly "Initial plan" is still linted (proves the filter is diff-based, not text-based).

`ci.yml`'s `lint` job now runs the self-test immediately before the `commitlint` step (same idiom as the repo's other CI-script self-tests), and the `commitlint` step calls the new script instead of `commitlint --from/--to` directly. `actionlint` and `markdownlint-cli2` both pass locally on the changed files (also re-verified via the pre-push hook).

Closes #1643

## Test plan

- [x] `node --test .github/scripts/commitlint-range.test.mjs` — 9/9 passing
- [x] Real `commitlint@19` end-to-end reproduction via the shipped script (pass case + negative-control fail case)
- [x] `actionlint .github/workflows/ci.yml` — clean
- [x] `markdownlint-cli2 .github/scripts/README.md` — clean
- [x] lefthook pre-push (golangci-lint, forbid-skip, forbid-sql-raw, actionlint, markdownlint, commitlint) — all green locally
- [ ] CI on this PR (in progress)

🤖 Generated with [Claude Code](https://claude.com/claude-code)