### PR TITLE
fix(e2e): assert drilldown-app drill depth instead of only annotating it

### DIFF
--- a/test/e2e/playwright/iterate-drilldown-apps.spec.ts
+++ b/test/e2e/playwright/iterate-drilldown-apps.spec.ts
@@ -18,6 +18,10 @@
  *      the whole app sweep. Plugin failures (chunk-load errors,
  *      datasource-resource 502s, fetch aborts) all surface as
  *      console errors.
+ *   5. Each app reaches the expected drill depth (EXPECTED_DRILL_DEPTH,
+ *      currently 2 — both click-drills complete). A depth stuck at 0
+ *      or 1 with no other failure used to report as a clean pass; see
+ *      #1502.
  *
  * Gate posture: NIGHTLY ONLY. Wired into the `dashboard` job in
  * `.github/workflows/e2e.yml`, which runs on push-to-main + nightly +
@@ -95,6 +99,13 @@ type DrilldownFailure = {
 // resp.finished() normally resolves in single-digit ms once the body lands;
 // the cap only guards against a genuinely-stalled stream hanging the sweep.
 const BODY_FINISH_TIMEOUT_MS = 2_000;
+
+// Floor for `levelsClicked` (see drillTwoLevels): every catalogued app is
+// expected to complete both click-drills. Below this, the affordance chain
+// broke before reaching the full depth — a "drilled-clean" outcome with no
+// other failure would otherwise mask that as a silent pass (see #1502: the
+// depth was annotated into the report but never asserted).
+const EXPECTED_DRILL_DEPTH = 2;
 
 test('drilldown-apps: each installed drilldown app drills two levels without 4xx/5xx + no role=alert error + no console errors', async ({
   page,
@@ -178,7 +189,7 @@ test('drilldown-apps: each installed drilldown app drills two levels without 4xx
  *   - after each settled level, snapshot `role="alert"` banners,
  *   - tear down listeners,
  *   - apply: zero non-2xx, zero role=alert banners, zero console
- *     errors.
+ *     errors, and a minimum drill-depth floor (EXPECTED_DRILL_DEPTH).
  *
  * Returns a list of failures — empty if the app sweep is clean.
  */
@@ -418,6 +429,20 @@ async function sweepDrilldownApp(
     type: 'drilldown-app-depth',
     description: `${app.id}: levelsClicked=${levelsClicked}, rootHadNoAffordance=${rootHadNoAffordance}, capturedResponses=${captured.length}`,
   });
+
+  // 4. Drill-depth floor — the annotation above makes depth visible to a
+  //    reviewer reading the report, but a reviewer has to go looking. Assert
+  //    it too: a "drilled-clean" outcome that never actually reached
+  //    EXPECTED_DRILL_DEPTH (affordance present but the second click didn't
+  //    register, or the app rendered nothing to click past level 0/1) is a
+  //    broken drilldown affordance, not a clean sweep.
+  if (levelsClicked < EXPECTED_DRILL_DEPTH) {
+    failures.push({
+      app: app.id,
+      rule: 'drill-depth-below-floor',
+      detail: `levelsClicked=${levelsClicked}, expected >= ${EXPECTED_DRILL_DEPTH} (rootHadNoAffordance=${rootHadNoAffordance}). The click-drill chain broke before reaching the expected depth.`,
+    });
+  }
 
   return failures;
 }


### PR DESCRIPTION
## Summary

- `test/e2e/playwright/iterate-drilldown-apps.spec.ts` computed `levelsClicked` per app (0/1/2) and wrote it into a `drilldown-app-depth` `testInfo` annotation, but never asserted a floor on it. A broken drill-in affordance (second click doesn't register, or nothing renders past the root) reported as a `drilled-clean` pass as long as no other rule (wire status / role=alert / console errors) happened to fire.
- Add a named `EXPECTED_DRILL_DEPTH = 2` constant (matches `drillTwoLevels`' max — see `test/e2e/playwright/helpers/drilldown.ts`) and, after the existing depth annotation, push a `drill-depth-below-floor` entry through the spec's existing `failures.push({ app, rule, detail })` idiom whenever `levelsClicked < EXPECTED_DRILL_DEPTH`. Updated the file-header doc comment and the `sweepDrilldownApp` JSDoc to describe the new assertion as rule 5 / part of what the function enforces.

## Gate posture

Kept **nightly-only**, matching this spec's existing deliberate PR-gate-avoidance policy (see the file's own "Gate posture" doc comment — wired into the `dashboard` job in `.github/workflows/e2e.yml`, which runs on push-to-main + nightly + manual dispatch, not `pull_request`). Not promoted to a PR-blocking gate.

## Baseline verification

Attempted to verify today's live drill-depth baseline for all 3 catalogued apps (Explore Metrics, Explore Logs, Explore Traces) per the fix instructions, so a floor assertion wouldn't ship red on day one.

- `docker ps -a` in this environment shows no Grafana/cerberus/k3d stack already running (only unrelated containers from other local projects — the persistent `docker-clickhouse-1` on 8123/9000 referenced by repo convention wasn't present in this sandbox either).
- `k3d cluster list` returned no clusters, and the current `kubectl` context points to an unrelated, expired-credential AWS EKS cluster.
- Bringing up a fresh stack requires `just e2e-up` (k3d cluster create + Grafana + ClickHouse provisioning) followed by `just e2e-seed`/`e2e-seed-rolling` and then running this spec directly — a multi-minute, resource-heavy sequence. This worktree is one of ~90 concurrent agent worktrees sharing the same Docker/k3d host in this sandbox; `e2e-up` starts with `e2e-down` (tears down any existing cluster first), so running it here risks colliding with another concurrent agent's stack rather than yielding a trustworthy, isolated baseline reading.

**Residual risk:** the live baseline was not verified in this environment. If any of the three catalogued apps is currently stuck below drill depth 2 on `main`, this PR's new assertion will surface that as a nightly `dashboard` job failure rather than catching it here. That failure would be a real, pre-existing regression to fix (not a reason to loosen or skip the new assertion) — flagging this explicitly per the task's own guidance rather than silently assuming the baseline is clean.

## Test plan

- [x] `lefthook` pre-push gate (golangci-lint, forbid-sql-raw, forbid-skip, markdownlint, actionlint, commitlint-range) ran clean on push.
- [ ] CI: `check`, `lint`, `forbid-skip`, `forbid-deferral`, `pr-body`, and the other required PR gates.
- [ ] Nightly `dashboard` job (`.github/workflows/e2e.yml`) is the first run that will actually execute this spec against a live stack and either confirm depth 2 for all 3 apps or surface a real regression — see Residual risk above.

Closes #1502