### PR TITLE
test(migration): wire counter-reset into the three-signal hotspot corpus

### DIFF
--- a/test/e2e/migration/archetypes/three-signal/seed/fixture.json
+++ b/test/e2e/migration/archetypes/three-signal/seed/fixture.json
@@ -8,5 +8,8 @@
   "histogram_metric": "cerberus_migration_request_duration_seconds",
   "histogram_bounds": [0.1, 0.5, 1.0],
   "traces_per_service": 20,
-  "spans_per_trace": [3, 4, 5]
+  "spans_per_trace": [3, 4, 5],
+  "restarts": {
+    "payments|500": [60]
+  }
 }

--- a/test/e2e/migration/archetypes/three-signal/seed/verify-hotspots.json
+++ b/test/e2e/migration/archetypes/three-signal/seed/verify-hotspots.json
@@ -20,6 +20,18 @@
       "lang": "promql"
     },
     {
+      "expr": "rate(cerberus_migration_requests_total{service_name=\"payments\", http_status_code=\"500\"}[5m])",
+      "source": "manual:test/e2e/migration/archetypes/three-signal/seed/verify-hotspots.json/counter rate across pod restart",
+      "kind": "panel",
+      "lang": "promql"
+    },
+    {
+      "expr": "increase(cerberus_migration_requests_total{service_name=\"payments\", http_status_code=\"500\"}[5m])",
+      "source": "manual:test/e2e/migration/archetypes/three-signal/seed/verify-hotspots.json/counter increase across pod restart",
+      "kind": "panel",
+      "lang": "promql"
+    },
+    {
       "expr": "histogram_quantile(0.95, sum by (le) (rate(cerberus_migration_request_duration_seconds_bucket[5m])))",
       "source": "manual:test/e2e/migration/archetypes/three-signal/seed/verify-hotspots.json/histogram quantile",
       "kind": "panel",


### PR DESCRIPTION
## Summary

- Addresses #1542 (Half A: counter-reset coverage only).
- The three-signal archetype's `seed/fixture.json` never set `Restarts`, so `test/e2e/migration/seed/fixture.go`'s already-wired `restartIndices`/`buildCounter` machinery never fired for the corpus MIG-17 replays: the hotspot query set queried only monotonic counters, despite `docs/migration-testing.md`'s section-6 PASS cell (pinned in `pass-assertions.pin.json`) claiming reset coverage.
- Declares one counter-reset — `payments`/`500` resets at sample index 60 (mid verify window, comfortably inside `[VerifyStart, VerifyEnd]` with margin on both sides) — via the existing `Restarts` field in `fixture.json`.
- Adds two new scoped queries to `verify-hotspots.json`: `rate(...)` and `increase(...)` filtered to exactly that restarting series, so the differential-parity gate (cerberus vs reference Prometheus) is now genuinely asserting the reset is handled correctly rather than incidentally, unassertedly overlapping it.
- No new Go code — this wires existing, already-implemented fixture machinery into the corpus that was never extended to use it. Verified locally that the reset produces the expected near-zero dip at the declared index and climbs again afterward.
- `pass-assertions.pin.json`'s MIG-17 hash is unchanged: that pin hashes the `docs/migration-testing.md` section-6 PASS-cell **prose**, not the fixture/corpus JSON, and this PR doesn't edit that prose (the prose already correctly claimed reset coverage — the corpus just didn't deliver it until now).

## Out of scope (explicitly deferred)

Half B of #1542 — the `up==0`/staleness half — is **intentionally out of scope** here and deferred pending a separate maintainer decision: whether to build synthetic gap-generation infrastructure (to induce a real target-down/stale-marker condition in the fixture) or instead narrow the PASS-cell claim to match current coverage. That decision and its implementation belong in a separate PR.

## Test plan

- [x] `go build ./test/e2e/migration/...`
- [x] `go test ./test/e2e/migration/...` (non-tier1-tagged packages; tier1 requires the live compose stack)
- [x] Verified locally via a throwaway `go run` harness that `seed.LoadDeclaration` parses the updated `fixture.json` and `seed.Build` produces the expected counter dip/reset at sample index 60 for the `payments`/`500` series
- [x] Validated both edited JSON files parse (`python3 -m json.tool`)
- [ ] CI: `MIG-17` / Tier-1 e2e lane (`@tier1 @archetype:three-signal`) replays the two new queries against the live dual-backend stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)