### PR TITLE
fix(e2e): wire a real $job template variable into showcase-promql

### DIFF
--- a/test/e2e/grafana/compose/dashboards/showcase-promql.json
+++ b/test/e2e/grafana/compose/dashboards/showcase-promql.json
@@ -7692,6 +7692,100 @@
         "expect": "nonempty",
         "why": "Cerberus implements this construct (lowering + chsql reducer, reference-exact against the flag-enabled reference Prometheus). Previously a parity-rejection pin in the collapsed rejection row \u2014 the maintainer flipped first_over_time / double_exponential_smoothing from gated to supported, so the contract was upgraded to a live nonempty result and the panel moved into the over-time showcase row."
       }
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "cerberus-prometheus"
+      },
+      "description": "Template-variable demo: $job is a static custom dashboard variable (options api|db, matching this dashboard's deterministic job label set) that filters up{} directly. Exercises Grafana's own client-side $job substitution on render plus the e2e sweep's buildProbeURL/substituteVariables wiring, which resolves the same token before firing the API-layer probe.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 229
+      },
+      "id": 121,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "cerberus-prometheus"
+          },
+          "editorMode": "code",
+          "expr": "up{job=\"$job\"}",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "up{job=\"$job\"} (template variable)",
+      "type": "timeseries",
+      "cerberus": {
+        "expect": "nonempty",
+        "why": "$job's current value (api) is a deterministic label this dashboard's up{job=\"api\"} panels already assert nonempty against \u2014 filtering by the variable must return the same live series."
+      }
     }
   ],
   "schemaVersion": 39,
@@ -7701,7 +7795,35 @@
     "promql"
   ],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "current": {
+          "text": "api",
+          "value": "api"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Job",
+        "multi": false,
+        "name": "job",
+        "options": [
+          {
+            "selected": true,
+            "text": "api",
+            "value": "api"
+          },
+          {
+            "selected": false,
+            "text": "db",
+            "value": "db"
+          }
+        ],
+        "query": "api,db",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      }
+    ]
   },
   "time": {
     "from": "now-15m",

--- a/test/e2e/playwright/helpers-variables.spec.ts
+++ b/test/e2e/playwright/helpers-variables.spec.ts
@@ -2,10 +2,13 @@
  * Stack-free unit tests for the template-variable contracts
  * (helpers/variables.ts): pin parsing, the set-equality matcher, the
  * variable-query parser for all three heads, the proxy-path builder,
- * and the response-shape extractors. The live resolution path
- * (resolveVariableOptions / checkDashboardVariable) is exercised by
- * iterate-all-dashboards.spec.ts once dashboards gain variables (P3);
- * the pure halves are pinned here. Run via:
+ * the response-shape extractors, and the expr-substitution helper
+ * that lets the probe loop resolve `$name` tokens the way Grafana
+ * does client-side. The live resolution path (resolveVariableOptions
+ * / checkDashboardVariable / substituteVariables feeding a real
+ * probe URL) is exercised end-to-end by iterate-all-dashboards.spec.ts
+ * against showcase-promql.json's `job` variable; the pure halves are
+ * pinned here. Run via:
  *
  *   cd test/e2e/playwright && npx playwright test helpers-variables.spec.ts
  */
@@ -18,6 +21,8 @@ import {
   extractVariableOptions,
   parseVariableQuery,
   readVariablePin,
+  resolveCurrentVariableValue,
+  substituteVariables,
   variableOptionsPath,
 } from './helpers/index.js';
 
@@ -95,6 +100,63 @@ test('checkVariableOptions requires non-empty options when unpinned', () => {
   const v = checkVariableOptions(null, []);
   expect(v).toHaveLength(1);
   expect(v[0]).toContain('zero options');
+});
+
+// --- resolveCurrentVariableValue / substituteVariables -----------------------
+
+test('resolveCurrentVariableValue reads a single-value current', () => {
+  expect(resolveCurrentVariableValue({ name: 'job', current: { value: 'api' } })).toBe(
+    'api',
+  );
+});
+
+test('resolveCurrentVariableValue reads the first entry of a multi-value current', () => {
+  expect(
+    resolveCurrentVariableValue({ name: 'job', current: { value: ['api', 'db'] } }),
+  ).toBe('api');
+});
+
+test('resolveCurrentVariableValue returns null when unresolvable', () => {
+  expect(resolveCurrentVariableValue({ name: 'job' })).toBeNull();
+  expect(resolveCurrentVariableValue({ name: 'job', current: {} })).toBeNull();
+  expect(
+    resolveCurrentVariableValue({ name: 'job', current: { value: '' } }),
+  ).toBeNull();
+  expect(
+    resolveCurrentVariableValue({ name: 'job', current: { value: [] } }),
+  ).toBeNull();
+});
+
+test('substituteVariables replaces $name, ${name}, and [[name]] forms', () => {
+  const vars = [{ name: 'job', current: { value: 'api' } }];
+  expect(substituteVariables('up{job="$job"}', vars)).toBe('up{job="api"}');
+  expect(substituteVariables('up{job="${job}"}', vars)).toBe('up{job="api"}');
+  expect(substituteVariables('up{job="[[job]]"}', vars)).toBe('up{job="api"}');
+});
+
+test('substituteVariables does not partial-match a longer name', () => {
+  const vars = [{ name: 'job', current: { value: 'api' } }];
+  expect(substituteVariables('up{job="$jobber"}', vars)).toBe('up{job="$jobber"}');
+});
+
+test('substituteVariables substitutes multiple distinct variables', () => {
+  const vars = [
+    { name: 'job', current: { value: 'api' } },
+    { name: 'status', current: { value: '200' } },
+  ];
+  expect(
+    substituteVariables('http_requests{job="$job", status="$status"}', vars),
+  ).toBe('http_requests{job="api", status="200"}');
+});
+
+test('substituteVariables leaves unresolvable and unknown tokens untouched', () => {
+  expect(substituteVariables('up{job="$job"}', [])).toBe('up{job="$job"}');
+  expect(
+    substituteVariables('up{job="$job"}', [{ name: 'job' }]),
+  ).toBe('up{job="$job"}');
+  expect(substituteVariables('up{job="api"}', [{ name: 'job', current: { value: 'api' } }])).toBe(
+    'up{job="api"}',
+  );
 });
 
 // --- parseVariableQuery ------------------------------------------------------

--- a/test/e2e/playwright/helpers/variables.ts
+++ b/test/e2e/playwright/helpers/variables.ts
@@ -46,6 +46,13 @@ export type VariableJSON = {
   type?: string;
   query?: unknown;
   datasource?: { type?: string; uid?: string } | string | null;
+  /**
+   * Grafana's persisted "currently selected" value — what a fresh
+   * page load substitutes into `$name` / `${name}` / `[[name]]`
+   * tokens before the panel's expr is fired. Multi-value variables
+   * persist an array; single-value ones persist a bare string.
+   */
+  current?: { value?: string | string[] };
   /** cerberus contract block: { expectOptions: string[] }. */
   cerberus?: unknown;
 };
@@ -125,6 +132,61 @@ export function checkVariableOptions(
     return ['variable resolved zero options (a blank dropdown is always a bug)'];
   }
   return [];
+}
+
+// ---------------------------------------------------------------------------
+// Variable substitution (pure) — the probe-side half of what Grafana does
+// client-side on page load: replace $name / ${name} / [[name]] tokens in a
+// panel expr with the variable's persisted `current.value` before the
+// expression is fired at the datasource proxy. Multi-value variables
+// substitute their first selected value — the probe fires one representative
+// query per target, same as every other target here; it does not attempt to
+// reproduce Grafana's multi-value repeat-panel behaviour.
+// ---------------------------------------------------------------------------
+
+/**
+ * Read a variable's persisted "currently selected" value. Returns null
+ * when the variable carries no resolvable current value (absent `current`,
+ * an empty string, or an empty array) — callers leave the token
+ * unsubstituted in that case rather than guessing.
+ */
+export function resolveCurrentVariableValue(
+  variable: VariableJSON,
+): string | null {
+  const value = variable.current?.value;
+  if (typeof value === 'string') return value !== '' ? value : null;
+  if (Array.isArray(value) && value.length > 0 && typeof value[0] === 'string') {
+    return value[0];
+  }
+  return null;
+}
+
+/**
+ * Substitute every declared variable's current value into `expr`,
+ * recognising Grafana's three token spellings: `$name`, `${name}`, and
+ * `[[name]]`. Variables without a name or a resolvable current value are
+ * skipped — their tokens (if any) pass through unresolved, which is exactly
+ * what a misconfigured dashboard would send Grafana too, so the probe stays
+ * honest about what's actually wired.
+ */
+export function substituteVariables(
+  expr: string,
+  variables: VariableJSON[],
+): string {
+  let out = expr;
+  for (const variable of variables) {
+    const name = variable.name;
+    if (!name) continue;
+    const value = resolveCurrentVariableValue(variable);
+    if (value === null) continue;
+    const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const token = new RegExp(
+      `\\$\\{${escapedName}\\}|\\$${escapedName}\\b|\\[\\[${escapedName}\\]\\]`,
+      'g',
+    );
+    out = out.replace(token, value);
+  }
+  return out;
 }
 
 // ---------------------------------------------------------------------------

--- a/test/e2e/playwright/iterate-all-dashboards.spec.ts
+++ b/test/e2e/playwright/iterate-all-dashboards.spec.ts
@@ -68,6 +68,7 @@ import {
   enforceExpectation,
   generateSelfTraffic,
   readPanelExpectation,
+  substituteVariables,
   sweepDepth,
 } from './helpers/index.js';
 
@@ -303,18 +304,26 @@ function normaliseDs(
  * Build the datasource-proxy URL that hits the same cerberus endpoint
  * Grafana itself would use for this target. Returns null for target
  * types we don't sweep (alerting expressions, dashboard variables…).
+ *
+ * `variables` is the dashboard's `templating.list` — mirrors what
+ * Grafana does client-side before firing a panel query: substitute
+ * every `$name` / `${name}` / `[[name]]` token in the expr with the
+ * variable's persisted `current.value` (substituteVariables, a no-op
+ * when the dashboard carries no variables or the expr has no tokens).
  */
 function buildProbeURL(
   baseURL: string,
   t: FlatTarget,
   nowSec: number,
+  variables: VariableJSON[],
 ): string | null {
   if (!t.expr || !t.dsUid) return null;
+  const expr = substituteVariables(t.expr, variables);
   const start = nowSec - QUERY_WINDOW_SECONDS;
   const end = nowSec;
   const dsType = t.dsType.toLowerCase();
   if (dsType === 'prometheus') {
-    const q = encodeURIComponent(t.expr);
+    const q = encodeURIComponent(expr);
     return (
       `${baseURL}/api/datasources/proxy/uid/${t.dsUid}` +
       `/api/v1/query_range?query=${q}` +
@@ -322,7 +331,7 @@ function buildProbeURL(
     );
   }
   if (dsType === 'loki') {
-    const q = encodeURIComponent(t.expr);
+    const q = encodeURIComponent(expr);
     return (
       `${baseURL}/api/datasources/proxy/uid/${t.dsUid}` +
       `/loki/api/v1/query_range?query=${q}` +
@@ -330,11 +339,11 @@ function buildProbeURL(
     );
   }
   if (dsType === 'tempo') {
-    const q = encodeURIComponent(t.expr || '{}');
+    const q = encodeURIComponent(expr || '{}');
     // TraceQL metrics-pipeline queries (`{...} | rate()` etc.) are
     // served by /api/metrics/query_range, not /api/search — the same
     // routing decision Grafana's Tempo datasource makes client-side.
-    if (isTraceQLMetricsQuery(t.expr)) {
+    if (isTraceQLMetricsQuery(expr)) {
       return (
         `${baseURL}/api/datasources/proxy/uid/${t.dsUid}` +
         `/api/metrics/query_range?q=${q}` +
@@ -591,7 +600,7 @@ test.describe('iterate-all-dashboards: full provisioned-dashboard sweep', () => 
       let nonEmptyTargets = 0;
       for (const panel of d.panels) {
         for (const t of panel.targets) {
-          const url = buildProbeURL(baseURL, t, nowSec);
+          const url = buildProbeURL(baseURL, t, nowSec, d.variables);
           if (!url) continue;
           probedTargets++;
           await probeTarget(request, url, d, panel, t, (count) => {
@@ -602,9 +611,11 @@ test.describe('iterate-all-dashboards: full provisioned-dashboard sweep', () => 
       // 3. Template-variable contracts — every variable's options
       //    resolve live (the same lookups Grafana fires for the
       //    dropdown); pinned variables (cerberus.expectOptions) get
-      //    set equality, unpinned ones non-emptiness. Today no
-      //    provisioned dashboard carries variables, so the loop is a
-      //    no-op — the path goes live the moment one lands (P3).
+      //    set equality, unpinned ones non-emptiness. showcase-promql's
+      //    `job` variable (static api/db options, see step 2 above for
+      //    the substitution into the panel expr) exercises this path
+      //    on every run; dashboards without variables leave the loop
+      //    an empty no-op.
       const variableViolations: string[] = [];
       for (const variable of d.variables) {
         variableViolations.push(


### PR DESCRIPTION
## Summary

- All 7 provisioned Grafana dashboards had `templating.list == []`. The 24-test variable-resolution helper (`test/e2e/playwright/helpers/variables.ts`) was fully built and unit-tested but never exercised end-to-end against a real dashboard — a hollow-green gap.
- Per issue #1468's triage decision, this wires **one** dashboard (`showcase-promql.json`) end-to-end rather than adding a declarative-only variable no panel uses, so the fix doesn't relocate the bug.

## What changed

- **`test/e2e/grafana/compose/dashboards/showcase-promql.json`**: added a static `job` custom template variable (options `api`/`db`) — matching this dashboard's existing deterministic `job` label set (`up{job="api"}` / `up{job="db"}` already appear in several panels), not the helper docstring's `cerberus.json`/`cerberus_ql` example, which the triage comment flagged as order-dependent. Added one new panel (`up{job="$job"} (template variable)`) that filters by `$job`.
- **`test/e2e/playwright/helpers/variables.ts`**: added `resolveCurrentVariableValue()` and `substituteVariables()` — pure functions that replace `$name` / `${name}` / `[[name]]` tokens in an expr with a variable's persisted `current.value`, mirroring what Grafana does client-side before firing a panel query.
- **`test/e2e/playwright/iterate-all-dashboards.spec.ts`**: `buildProbeURL` now takes the dashboard's `variables` and substitutes them into the target expr before building the probe URL, so the API-layer sweep resolves `$job` the same way the browser-render step already does. Updated the stale comment that said the variable-contract loop was "today... a no-op."
- **`test/e2e/playwright/helpers-variables.spec.ts`**: added unit coverage for the two new functions (7 new tests, 31 total) and updated the file docstring — the live path (`checkDashboardVariable` + `substituteVariables` feeding a real probe URL) is now exercised every sweep run against `showcase-promql.json`'s `job` variable instead of being unreachable.

## Scope

Per the issue's triage decision (Q14), exactly one dashboard gaining one working variable closes this issue. The other 6 provisioned dashboards are untouched — broader rollout is separate follow-up scope.

## Verification

- `npx tsc --noEmit` clean in `test/e2e/playwright`.
- `npx playwright test helpers-variables.spec.ts` — 31/31 pass (stack-free unit tests).
- Dashboard JSON validated with `python3 -m json.tool` / `json.load` — no panel-id collisions, well-formed `templating.list`.
- The full stack-dependent sweep (`iterate-all-dashboards.spec.ts`) runs in the `dashboard` release gate (k3d + Grafana + Playwright), which is a release gate rather than a per-PR gate per repo convention — it will exercise the new `$job` panel + variable contract on the next release/merge-commit run.

Closes #1468