### PR TITLE
test(e2e): drive the Tempo gRPC/h2c StreamingQuerier listener from e2e

### DIFF
--- a/.github/scripts/compose-smoke-matrix.mjs
+++ b/.github/scripts/compose-smoke-matrix.mjs
@@ -160,6 +160,7 @@ const EXCLUDED = [
   'service_graph.spec.ts', //            head-specific flow; dashboard-lane only
   'smoke.spec.ts', //                    legacy single-smoke; dashboard-lane only
   'split_isolation.spec.ts', //          split-mode head-isolation; needs k3d per-head deployments, not the single-container compose stack; dashboard-lane only
+  'tempo_grpc_streaming.spec.ts', //     gRPC/h2c StreamingQuerier trigger (#1454); real Explore + Live round-trip, dashboard-lane only
   'tempo_search_flow.spec.ts', //        head-specific flow; dashboard-lane only
   'tempo_traces.spec.ts', //             head-specific flow; dashboard-lane only
   'tempo_traces_drilldown.spec.ts', //   head-specific flow; dashboard-lane only

--- a/.github/scripts/dashboard-matrix.mjs
+++ b/.github/scripts/dashboard-matrix.mjs
@@ -172,6 +172,7 @@ const SHARDS = [
       'iterate-drilldown-apps.spec.ts',
       'service_graph.spec.ts',
       'smoke.spec.ts',
+      'tempo_grpc_streaming.spec.ts', //         gRPC/h2c StreamingQuerier trigger (#1454)
       'tempo_search_flow.spec.ts',
       'tempo_traces.spec.ts',
       'tempo_traces_drilldown.spec.ts',

--- a/internal/api/tempo/grpc/server.go
+++ b/internal/api/tempo/grpc/server.go
@@ -15,8 +15,16 @@ import (
 //
 //   - otelgrpc.NewServerHandler() as the stats handler — every RPC
 //     becomes an OTel server span on the same TracerProvider the HTTP
-//     handlers use, and gets the standard set of gRPC metrics
-//     (`rpc.server.duration`, `rpc.server.request.size`, etc.).
+//     handlers use, and gets the standard gRPC server duration metric.
+//     otelgrpc (pinned v0.69.0) defaults to semconv v1.41.0's STABLE
+//     naming — `rpc.server.call.duration`, not the older
+//     `rpc.server.duration` — unless OTEL_SEMCONV_STABILITY_OPT_IN
+//     requests the legacy/dup mode (cerberus sets neither). The e2e
+//     compose collector's `transform/metric_names` processor rewrites
+//     dots to underscores before the point reaches ClickHouse, so the
+//     PromQL-queryable series is `rpc_server_call_duration_count` /
+//     `_sum` / `_bucket{le=...}` — see test/e2e/playwright/
+//     tempo_grpc_streaming.spec.ts (#1454), which asserts against it.
 //   - service.Limiter.StreamInterceptor() as the stream interceptor —
 //     per-RPC admission control sharing the same per-head semaphore
 //     the HTTP handlers use, so a saturated Tempo head rejects gRPC

--- a/test/e2e/grafana/compose/datasources/cerberus.yaml
+++ b/test/e2e/grafana/compose/datasources/cerberus.yaml
@@ -38,6 +38,20 @@ datasources:
       # rest of the stack.
       serviceMap:
         datasourceUid: cerberus-prometheus
+      # Streaming search: Grafana's Tempo datasource opens the
+      # `StreamingQuerier` gRPC service over h2c on the SAME :8080
+      # port (see cmd/cerberus/main.go's dual-stack HTTP/1.1 +
+      # h2c/gRPC listener) instead of the plain HTTP /api/search
+      # request. Without this flag every e2e/compose lane only ever
+      # drives the HTTP transport, leaving the gRPC listener with no
+      # coverage above its own bufconn unit tests (#1454). The
+      # `TempoJsonData` shape is `{search?: boolean}` — verified
+      # against the pinned `grafana/grafana:12.2.9` image's
+      # `public/app/plugins/datasource/tempo/types.ts`; there is no
+      # top-level flat boolean and (as of 12.2.9) no `metrics`
+      # sub-key on the provisioning-facing type.
+      streamingEnabled:
+        search: true
   # ---------------------------------------------------------------------
   # Grafana 12.x ships three built-in drilldown apps preinstalled:
   #   - grafana-metricsdrilldown-app  (Explore Metrics)

--- a/test/e2e/k3s/grafana.yaml
+++ b/test/e2e/k3s/grafana.yaml
@@ -41,6 +41,13 @@ data:
           # rest of the stack.
           serviceMap:
             datasourceUid: cerberus-prometheus
+          # Streaming search over the gRPC/h2c StreamingQuerier listener —
+          # see test/e2e/grafana/compose/datasources/cerberus.yaml for the
+          # full rationale + jsonData-shape verification (#1454). Mirrored
+          # here so the k3d `dashboard` e2e lane also exercises the gRPC
+          # transport, not just the HTTP one.
+          streamingEnabled:
+            search: true
       # Aliases for Grafana's built-in drilldown apps. Each app's
       # factory defaults reference Grafana Cloud's canonical
       # `grafanacloud-{metrics,logs,traces}` UIDs; without those

--- a/test/e2e/playwright/tempo_grpc_streaming.spec.ts
+++ b/test/e2e/playwright/tempo_grpc_streaming.spec.ts
@@ -131,7 +131,7 @@ test('Tempo streaming search exercises the gRPC/h2c StreamingQuerier listener', 
   await page.waitForLoadState('networkidle');
 
   const deadline = Date.now() + GRPC_METRIC_POLL_DEADLINE_MS;
-  let latest = baseline;
+  let latest: number;
   for (;;) {
     latest = await queryInstantSum(request, grpcDurationCountMetric);
     if (latest > baseline) break;

--- a/test/e2e/playwright/tempo_grpc_streaming.spec.ts
+++ b/test/e2e/playwright/tempo_grpc_streaming.spec.ts
@@ -1,0 +1,148 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+
+/**
+ * Tempo gRPC/h2c StreamingQuerier coverage (#1454).
+ *
+ * Every other tempo_*.spec.ts in this suite drives cerberus's Tempo
+ * HTTP handlers through Grafana's datasource PROXY
+ * (`/api/datasources/proxy/uid/cerberus-tempo/...`) — a plain HTTP
+ * request that never touches the gRPC/h2c `StreamingQuerier` listener
+ * cerberus also serves on the same `:8080` socket (see
+ * cmd/cerberus/main.go's dual-stack HTTP/1.1 + h2c/gRPC listener, and
+ * internal/api/tempo/grpc/server.go for the server-side wiring). Before
+ * this spec, that listener had zero coverage above its own bufconn unit
+ * tests: no provisioned datasource ever set `jsonData.streamingEnabled`,
+ * so Grafana's Tempo plugin never had a reason to open it.
+ *
+ * The trigger. Grafana's Tempo *frontend* datasource (not a raw HTTP
+ * call this suite can hand-roll) is what opens the gRPC path: when
+ * `jsonData.streamingEnabled.search` is true, `TempoDatasource.query()`
+ * routes a TraceQL search through `handleStreamingQuery()`, which opens
+ * a Grafana Live subscription; Grafana's own backend Go plugin
+ * (`pkg/tsdb/tempo/grpc.go`) then dials cerberus over h2c and streams
+ * the response back. That whole chain only runs inside a real Grafana
+ * frontend session — there is no REST shortcut for it — so this spec
+ * navigates an actual Explore page (mirroring the `exploreLeft` URL-state
+ * pattern `compose_grafana_smoke.spec.ts` already uses for its
+ * `explore:tempo` surface) instead of using the `request` fixture the
+ * rest of this suite prefers.
+ *
+ * The oracle. cerberus's gRPC server is wrapped in
+ * `otelgrpc.NewServerHandler()`, which (pinned contrib v0.69.0, default
+ * semconv mode) records the STABLE v1.41.0 `rpc.server.call.duration`
+ * histogram per RPC — verified against the pinned module's own
+ * `semconv/v1.41.0/rpcconv/metric.go` source, not assumed from the
+ * (stale) `rpc.server.duration` name an older doc comment in
+ * server.go used to cite. The e2e/compose otel-collector's
+ * `transform/metric_names` processor (test/e2e/otel-collector/
+ * compose-config.yaml) rewrites every dotted OTel metric name to
+ * underscores before it reaches ClickHouse, so the series cerberus's
+ * own Prom head answers is `rpc_server_call_duration_count` (companion
+ * of `_sum` / `_bucket{le=...}`, following the same `<base>_count`
+ * convention `internal/promql/histogram_synthetic_names.go` already
+ * serves for e.g. `http_server_request_duration_count`).
+ *
+ * Baseline discipline (same shape as #1502): rather than hard-asserting
+ * the counter is exactly absent/zero at the top of THIS test — which
+ * would flake depending on worker/file scheduling, since
+ * `compose_grafana_smoke.spec.ts`'s own `explore:tempo` surface targets
+ * the same now-streaming-enabled Cerberus-Tempo datasource and may have
+ * already ticked it — the test captures whatever the counter reads
+ * before its own trigger and then asserts a genuine DELTA after. That
+ * keeps the assertion bidirectional (it fails exactly when the gRPC
+ * listener isn't actually being exercised) without depending on test
+ * order for correctness.
+ */
+
+const promProxy = '/api/datasources/proxy/uid/cerberus-prometheus/api/v1';
+
+// See the file-level comment: verified against the pinned otelgrpc
+// v0.69.0 module + its default semconv v1.41.0 rpcconv package, then
+// underscored by the e2e collector's transform/metric_names processor.
+const grpcDurationCountMetric = 'rpc_server_call_duration_count';
+
+// One OTel export cycle is 10s (CERBERUS_OTLP_EXPORT_INTERVAL); the
+// deadline gives several cycles of headroom plus room for a cold
+// cerberus->CH circuit breaker (see project note on passive breaker
+// recovery) without ever masking a real regression as a timeout.
+const GRPC_METRIC_POLL_DEADLINE_MS = 90_000;
+const GRPC_METRIC_POLL_INTERVAL_MS = 3_000;
+
+/** Sum of an instant PromQL query's vector, via the Cerberus-Prometheus
+ * Grafana datasource proxy (self-dogfooding cerberus's own gRPC-server
+ * telemetry through its own Prom head — see #1454's triage decision).
+ * A metric with no series yet (absent, not merely zero) sums to 0,
+ * which is exactly the "not exercised yet" baseline this spec needs.
+ */
+async function queryInstantSum(
+  request: APIRequestContext,
+  expr: string,
+): Promise<number> {
+  const resp = await request.get(
+    `${promProxy}/query?query=${encodeURIComponent(expr)}`,
+  );
+  expect(resp.status(), `instant query ${expr} status`).toBe(200);
+  const body = (await resp.json()) as {
+    status?: string;
+    data?: { result?: Array<{ value?: [number, string] }> };
+  };
+  expect(body.status, `instant query ${expr} envelope status`).toBe('success');
+  const result = body.data?.result ?? [];
+  return result.reduce((sum, s) => sum + Number(s.value?.[1] ?? 0), 0);
+}
+
+/** Builds a Grafana Explore URL that pre-selects the Cerberus-Tempo
+ * datasource with a raw TraceQL query and auto-runs it on load — the
+ * same `left`-state mechanism compose_grafana_smoke.spec.ts's
+ * `exploreLeft` helper uses. `queryType: 'traceql'` + a non-empty
+ * `query` string is exactly the shape TempoDatasource.query() routes
+ * through `handleTraceQlQuery` -> `handleStreamingQuery` when
+ * `streamingEnabled.search` is on.
+ */
+function exploreTraceQlURL(query: string): string {
+  const state = {
+    datasource: 'cerberus-tempo',
+    queries: [
+      {
+        refId: 'A',
+        queryType: 'traceql',
+        query,
+        datasource: { type: 'tempo', uid: 'cerberus-tempo' },
+      },
+    ],
+    range: { from: 'now-1h', to: 'now' },
+  };
+  return `/explore?orgId=1&left=${encodeURIComponent(JSON.stringify(state))}`;
+}
+
+test('Tempo streaming search exercises the gRPC/h2c StreamingQuerier listener', async ({
+  page,
+  request,
+}) => {
+  test.setTimeout(GRPC_METRIC_POLL_DEADLINE_MS + 30_000);
+
+  const baseline = await queryInstantSum(request, grpcDurationCountMetric);
+
+  // Trigger: a real Explore navigation against the streaming-enabled
+  // Cerberus-Tempo datasource. `{}` is the match-everything TraceQL
+  // search the rest of this suite already seeds data for (see
+  // tempo_ux.spec.ts), so it always has something to stream back.
+  await page.goto(exploreTraceQlURL('{}'));
+  await page.waitForLoadState('networkidle');
+
+  const deadline = Date.now() + GRPC_METRIC_POLL_DEADLINE_MS;
+  let latest = baseline;
+  for (;;) {
+    latest = await queryInstantSum(request, grpcDurationCountMetric);
+    if (latest > baseline) break;
+    if (Date.now() >= deadline) break;
+    await new Promise((r) => setTimeout(r, GRPC_METRIC_POLL_INTERVAL_MS));
+  }
+
+  expect(
+    latest,
+    `${grpcDurationCountMetric} did not increase after a Tempo streaming search ` +
+      `(baseline=${baseline}, latest=${latest} after ${GRPC_METRIC_POLL_DEADLINE_MS}ms) — ` +
+      `the gRPC/h2c StreamingQuerier listener was not exercised`,
+  ).toBeGreaterThan(baseline);
+});


### PR DESCRIPTION
## Summary

- Cerberus serves a Tempo `StreamingQuerier` gRPC service over h2c on the same `:8080` port (`cmd/cerberus/main.go`), but no provisioned Grafana datasource ever set `jsonData.streamingEnabled`, so the listener had zero e2e coverage above its own bufconn unit tests (#1454).
- Flip `Cerberus-Tempo` to streaming search in both e2e provisioning files (`test/e2e/grafana/compose/datasources/cerberus.yaml`, `test/e2e/k3s/grafana.yaml`). The root `docker-compose.yml` already mounts the compose provisioning directory directly (`./test/e2e/grafana/compose/datasources:/etc/grafana/provisioning/datasources:ro`), so it picks up the change automatically — there is no separate root-compose datasource file to edit.
- Add a new Playwright spec (`tempo_grpc_streaming.spec.ts`) that drives a real Grafana Explore session against the streaming datasource and asserts, via cerberus's own self-observability metrics (self-dogfooded through the `Cerberus-Prometheus` datasource), that the gRPC listener actually got hit.
- Small doc-comment fix in `internal/api/tempo/grpc/server.go`: it cited the wrong otelgrpc metric name (`rpc.server.duration`), which the pinned library version doesn't emit by default.

## How I verified the `jsonData` shape (triage Q22)

Rather than trust the issue's assumption, I pulled the actual `TempoJsonData` TypeScript interface out of the **pinned** `grafana/grafana:12.2.9` tag:

```
$ curl -s https://raw.githubusercontent.com/grafana/grafana/v12.2.9/public/app/plugins/datasource/tempo/types.ts | grep -n streamingEnabled -A3
streamingEnabled?: {
    search?: boolean;
  };
```

So the correct provisioning shape at this pin is a **nested** `streamingEnabled: { search: true }` — not a flat boolean, and (at 12.2.9) no `metrics` sub-key on the provisioning-facing type (the frontend `datasource.ts` class field type does list `metrics?`, but the persisted/validated `TempoJsonData` schema used by provisioning does not). I also confirmed the trigger mechanism against the pinned source: `TempoDatasource.query()` routes a `queryType: 'traceql'` request through `handleStreamingQuery()` → Grafana Live → the backend Go plugin's gRPC client (`pkg/tsdb/tempo/grpc.go`), which dials the datasource's URL over h2c — exactly cerberus's listener.

## How I verified the metric name (triage Q23 — baseline discipline)

I did **not** assume `rpc.server.duration` (what a stale doc comment in `internal/api/tempo/grpc/server.go` claimed). Cerberus pins `go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.69.0`; reading that module's own vendored source (`stats_handler.go`, `config.go`) shows it defaults to `semconvModeNew` (`OTEL_SEMCONV_STABILITY_OPT_IN` unset, which cerberus never sets), which records the **stable v1.41.0** histogram — verified against the actual `semconv/v1.41.0/rpcconv/metric.go` source: the name is `rpc.server.call.duration`, not `rpc.server.duration` (that's the legacy v1.37.0 opt-in name). The e2e compose collector's `transform/metric_names` processor rewrites dots to underscores before ClickHouse, so the queryable series is `rpc_server_call_duration_count` (companion of `_sum`/`_bucket{le=...}`, same `<base>_count` convention `internal/promql/histogram_synthetic_names.go` already serves).

Baseline-then-triggered design (mirroring #1502's discipline): rather than hard-asserting the counter is exactly absent at test start — which would flake depending on file/worker scheduling, since `compose_grafana_smoke.spec.ts`'s pre-existing `explore:tempo` Explore surface targets the *same* now-streaming-enabled `Cerberus-Tempo` datasource and may run first — the spec captures whatever the counter reads before its own trigger, then asserts a genuine increase afterward. That keeps the signal bidirectional (fails exactly when the gRPC path isn't exercised) without depending on test order.

I was not able to boot the full docker-compose/k3d stack locally to execute the new spec live in this sandbox — port `3000`/`8080` were already bound by another concurrent agent's k3d cluster. The verification above is against the pinned library/image sources directly (module cache + the exact `v12.2.9` git tag), and `npx tsc --noEmit` passes clean on the new spec. The `dashboard` (k3d, release-gated) lane will be the first real execution of this spec; `compose-smoke` boots for real on this PR too (it touches `internal/api/**`) but the new spec is deliberately excluded from that lane, matching its `tempo_*.spec.ts` siblings.

## Test plan

- [x] `npx tsc --noEmit` clean on the new spec
- [x] YAML provisioning files parse (`yaml.safe_load_all`)
- [x] `node .github/scripts/compose-smoke-matrix.mjs verify` — 0 violations
- [x] `node .github/scripts/dashboard-matrix.mjs verify` — 0 violations
- [x] `node --test .github/scripts/{compose-smoke,dashboard}-matrix.test.mjs` — 14/14 pass
- [x] lefthook pre-push (golangci-lint, forbid-sql-raw, forbid-skip, markdownlint, actionlint) — clean
- [ ] CI green (`dashboard` release lane will execute `tempo_grpc_streaming.spec.ts` for the first time)

## Notes for reviewers

- The new spec is registered in `EXCLUDED` in `compose-smoke-matrix.mjs` and in `SHARDS` (`shard-smoke-b`) in `dashboard-matrix.mjs` — both scripts hard-fail on an undiscovered/unassigned spec, so this was required, not optional polish.
- I left `grafanacloud-traces` (the drilldown-app alias datasource) on HTTP; the issue's fix shape only asked for "at least one" streaming lane, and `Cerberus-Tempo` is the datasource every existing Tempo Playwright spec + dashboard panel already targets.

Closes #1454