### PR TITLE
fix(e2e): bound rolling re-seed duplication for every fixture family

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1207,10 +1207,20 @@ e2e-wait-otel:
         echo "==> timeout waiting for OTel data / metric history span"; \
         exit 1
 
-# Run Go E2E HTTP tests against the deployed stack.
+# Run Go E2E HTTP tests against the deployed stack. CH_ADDR/CH_DATABASE/
+# CH_USERNAME/CH_PASSWORD point at the same port-forward `e2e-seed-rolling`
+# already opened on 19000 — test/e2e/seed/cmd/seed/reseed_stability_test.go
+# (issue #1527's row-count-stability assertion, living next to the
+# re-seeder it tests) dials ClickHouse directly to drive its own seedAll
+# ticks; every other Go E2E test only talks to CERBERUS_URL and ignores
+# these.
 e2e-run:
     @echo "==> running Go E2E tests"
-    go test -tags=e2e ./test/e2e/...
+    CH_ADDR=127.0.0.1:19000 \
+        CH_DATABASE=otel \
+        CH_USERNAME=cerberus \
+        CH_PASSWORD=cerberus \
+        go test -tags=e2e ./test/e2e/...
 
 # A godog suite driving `cerberus migrate` over committed fixtures — no
 # Docker, no backend, seconds.

--- a/test/e2e/seed/cmd/seed/main.go
+++ b/test/e2e/seed/cmd/seed/main.go
@@ -51,6 +51,14 @@
 // drops that to ±5 min: any query at `t = seed + N min` sees a fresh
 // re-anchored window centered on `seed + N min - δ` where δ ≤ 30 s.
 //
+// Every family the rolling re-seeder re-inserts also carries a bounded
+// stale-row DELETE (stale.go) run right after that family's INSERT, so a
+// long-lived stack doesn't accumulate one full copy of every fixture per
+// tick indefinitely (issue #1527). See stale.go's package doc comment
+// for the shape (mirrored from showcase_traceql.go's
+// deleteStaleShowcaseTracesSQL, the original instance of this pattern)
+// and the margin derivation.
+//
 // SIGTERM / SIGINT triggers a clean shutdown — the Playwright fixture
 // (or `just e2e-down`) signals teardown and the goroutine exits before
 // the connection closes.
@@ -626,7 +634,10 @@ func insertMetrics(ctx context.Context, conn driver.Conn) error {
 	if err := conn.Exec(ctx, insertShowcaseExpHistSQL); err != nil {
 		return fmt.Errorf("showcase exp histogram: %w", err)
 	}
-	return nil
+	// Stale-row cleanup runs after every INSERT above has landed — see
+	// stale.go's package doc comment for why (mirrors
+	// deleteStaleShowcaseTracesSQL's insert-before-delete ordering).
+	return deleteStaleMetrics(ctx, conn)
 }
 
 // insertLogs inserts 40 log records across 3 services spanning a 10-minute
@@ -645,7 +656,12 @@ func insertLogs(ctx context.Context, conn driver.Conn) error {
 	// Showcase-LogQL streams (gateway / shop / proxy / painter /
 	// packer) — see showcase_logql.go for the per-stream shapes the
 	// showcase-logql dashboard's parser / filter / unwrap panels need.
-	return insertShowcaseLogQLLogs(ctx, conn)
+	if err := insertShowcaseLogQLLogs(ctx, conn); err != nil {
+		return err
+	}
+	// Stale-row cleanup runs after every stream above has landed — see
+	// stale.go's package doc comment.
+	return deleteStaleLogs(ctx, conn)
 }
 
 // insertTraces inserts 3 traces with mixed services + durations — preserved
@@ -655,7 +671,13 @@ func insertLogs(ctx context.Context, conn driver.Conn) error {
 // Trace 2 (a0...002): frontend → api → db     (spans 0003 + 0004 + 0005)
 // Trace 3 (a0...003): api → db                (spans 0006 + 0007)
 func insertTraces(ctx context.Context, conn driver.Conn) error {
-	return conn.Exec(ctx, insertTracesSQL)
+	if err := conn.Exec(ctx, insertTracesSQL); err != nil {
+		return err
+	}
+	// Stale-row cleanup runs after the INSERT above has landed — see
+	// stale.go's package doc comment. Scoped to the a0... range only;
+	// the b0... showcase traces have their own DELETE (showcase_traceql.go).
+	return deleteStaleBaseTraces(ctx, conn)
 }
 
 // verifyRowcounts mirrors the per-table `count()` UNION that the previous

--- a/test/e2e/seed/cmd/seed/reseed_stability_test.go
+++ b/test/e2e/seed/cmd/seed/reseed_stability_test.go
@@ -1,0 +1,312 @@
+//go:build e2e
+
+// Live row-count-stability assertion for the rolling re-seeder's bounded
+// stale-row cleanup (issue #1527), living next to the re-seeder it tests
+// rather than in test/regression (which stays pure static source-scan)
+// or a new harness layer.
+//
+// Runs against the SAME live ClickHouse the rolling re-seeder
+// (`just e2e-seed-rolling`, already running in the background by the
+// time `just e2e-run` executes this suite) is continuously re-anchoring.
+// It deliberately does not depend on waiting out real wall-clock time to
+// prove the bound — every family's staleMargin() is ~10 minutes wide
+// (see stale.go), far more than this suite's budget. Instead, for each
+// family it plants a single sentinel row whose Timestamp is manually
+// backdated past that family's own staleMargin() cutoff, drives a
+// handful of re-seed ticks by calling seedAll (the exact function both
+// this test and the background rolling process call), and asserts the
+// sentinel is gone — proving the DELETE fires and is scoped to the right
+// table/predicate regardless of when in the lane this test happens to
+// run. A secondary check confirms the family's total row count after
+// those ticks stays within a generous multiple of one tick's insert
+// size, rather than growing without bound.
+package main
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+)
+
+// reseedStabilityTicks is the number of seedAll ticks this test drives
+// itself before checking row-count bounds — small enough to keep the
+// test fast, large enough to exercise the DELETE-then-INSERT cycle more
+// than once per family.
+const reseedStabilityTicks = 3
+
+// reseedStabilityTickInterval only has to be long enough for
+// ClickHouse's now64(9) to advance measurably between this test's own
+// ticks; it does not need to match the production
+// --re-seed-interval=30s (docker-compose.yml / Justfile's
+// e2e-seed-rolling).
+const reseedStabilityTickInterval = 2 * time.Second
+
+// reseedStabilitySentinelSlack pushes a sentinel's backdated Timestamp
+// safely past its family's own staleMargin(), so the very first tick's
+// DELETE — whichever process runs it first, this test's own seedAll or
+// the concurrently-running background rolling re-seeder — is guaranteed
+// to catch it.
+const reseedStabilitySentinelSlack = 5 * time.Second
+
+// reseedStabilityBoundSlackTicks is the generous multiple applied to a
+// family's own single-tick row count when bounding its post-test total:
+// covers this test's own reseedStabilityTicks plus whatever the
+// concurrently-running background rolling re-seeder (30s cadence) could
+// plausibly add during this test's short run.
+const reseedStabilityBoundSlackTicks = reseedStabilityTicks + 3
+
+// Per-family row counts, expressed as multiples of the SAME
+// cadence/sample declarations stale.go derives its DELETE margins from
+// (see main.go / showcase_logql.go for the underlying `FROM numbers(N)`
+// INSERTs), rather than independently hand-picked totals.
+const (
+	// up (x2 job series) + target_info (x2) + showcase_flapping (x1) +
+	// showcase_multilabel (x3 colors).
+	reseedStabilityGaugeRowsPerTick = 8 * metricsNarrowSamples
+	// http_server_request_duration_count + showcase_restarting_total.
+	reseedStabilitySumRowsPerTick = 2 * metricsWideSamples
+	// http_server_request_duration.
+	reseedStabilityHistogramRowsPerTick = metricsWideSamples
+	// showcase_latency_exp_hist.
+	reseedStabilityExpHistRowsPerTick = metricsNarrowSamples
+	// base 3-service seed + the five showcase-logql streams.
+	reseedStabilityLogsRowsPerTick = 6 * logsSamples
+	// insertTracesSQL's fixed 7-row VALUES list (3 traces, not a
+	// numbers()-driven family — see tracesMinOffset/tracesMaxOffset in
+	// stale.go).
+	reseedStabilityTracesRowsPerTick = 7
+)
+
+// Sentinel INSERTs mirror the column list of the real production INSERT
+// for that table (main.go / showcase_logql.go) with a single VALUES row
+// instead of a `SELECT ... FROM numbers(N)`. Each carries a
+// 'reseed-stability-sentinel' marker (job / thread / sentinel attribute,
+// depending on the table's shape) so the corresponding count query can
+// find it precisely, and a MetricName/ServiceName/TraceId already
+// covered by that table's stale-row DELETE predicate (stale.go) so
+// planting it exercises the real production WHERE clause.
+const (
+	reseedStabilityPlantGaugeSentinelSQL = `INSERT INTO otel_metrics_gauge
+  (ResourceAttributes, ServiceName, MetricName, MetricDescription, MetricUnit, Attributes, StartTimeUnix, TimeUnix, Value)
+VALUES
+  (map('service.name', 'reseed-stability-sentinel'), 'reseed-stability-sentinel', 'up', 'reseed stability sentinel', '1',
+   map('job', 'reseed-stability-sentinel'),
+   now64(9) - INTERVAL {backdate:UInt64} SECOND,
+   now64(9) - INTERVAL {backdate:UInt64} SECOND,
+   1.0)`
+
+	reseedStabilityPlantSumSentinelSQL = `INSERT INTO otel_metrics_sum
+  (ResourceAttributes, ServiceName, MetricName, MetricDescription, MetricUnit, Attributes, StartTimeUnix, TimeUnix, Value, Flags, AggregationTemporality, IsMonotonic)
+VALUES
+  (map('service.name', 'reseed-stability-sentinel'), 'reseed-stability-sentinel', 'http_server_request_duration_count', 'reseed stability sentinel', '1',
+   map('job', 'reseed-stability-sentinel'),
+   now64(9) - INTERVAL {backdate:UInt64} SECOND,
+   now64(9) - INTERVAL {backdate:UInt64} SECOND,
+   toFloat64(1), toUInt32(0), toInt32(2), true)`
+
+	reseedStabilityPlantHistogramSentinelSQL = `INSERT INTO otel_metrics_histogram
+  (ResourceAttributes, ServiceName, MetricName, MetricDescription, MetricUnit, Attributes, StartTimeUnix, TimeUnix, Count, Sum, BucketCounts, ExplicitBounds, Flags, AggregationTemporality)
+VALUES
+  (map('service.name', 'reseed-stability-sentinel'), 'reseed-stability-sentinel', 'http_server_request_duration', 'reseed stability sentinel', 's',
+   map('job', 'reseed-stability-sentinel'),
+   now64(9) - INTERVAL {backdate:UInt64} SECOND,
+   now64(9) - INTERVAL {backdate:UInt64} SECOND,
+   toUInt64(1), toFloat64(1), [toUInt64(1)], [toFloat64(1)], toUInt32(0), toInt32(2))`
+
+	reseedStabilityPlantExpHistSentinelSQL = `INSERT INTO otel_metrics_exponential_histogram
+  (ResourceAttributes, ServiceName, MetricName, MetricDescription, MetricUnit, Attributes, StartTimeUnix, TimeUnix, Count, Sum, Scale, ZeroCount, PositiveOffset, PositiveBucketCounts, NegativeOffset, NegativeBucketCounts, Flags, Min, Max, AggregationTemporality)
+VALUES
+  (map('service.name', 'reseed-stability-sentinel'), 'reseed-stability-sentinel', 'showcase_latency_exp_hist', 'reseed stability sentinel', 's',
+   map('job', 'reseed-stability-sentinel'),
+   now64(9) - INTERVAL {backdate:UInt64} SECOND,
+   now64(9) - INTERVAL {backdate:UInt64} SECOND,
+   toUInt64(1), toFloat64(1), toInt32(0), toUInt64(0), toInt32(0), [toUInt64(1)], toInt32(0), [], toUInt32(0), toFloat64(0), toFloat64(1), toInt32(2))`
+
+	// TraceId/SpanId are a plain 32/16-char hex sentinel — the logs
+	// stale-row DELETE scopes on ServiceName only, not TraceId.
+	reseedStabilityPlantLogsSentinelSQL = `INSERT INTO otel_logs
+  (Timestamp, TraceId, SpanId, SeverityText, SeverityNumber, ServiceName, Body, ResourceAttributes, LogAttributes)
+VALUES
+  (now64(9) - INTERVAL {backdate:UInt64} SECOND,
+   'ff000000000000000000000000000000', 'ff00000000000000',
+   'INFO', 9, 'api', 'reseed stability sentinel',
+   map('service_name', 'api'),
+   map('thread', 'reseed-stability-sentinel'))`
+
+	// TraceId starts with the same 'a0...' prefix
+	// deleteStaleBaseTracesSQL's `LIKE 'a00000000000000000000000000000%'`
+	// scopes on, so planting it exercises the real predicate.
+	reseedStabilityPlantTracesSentinelSQL = `INSERT INTO otel_traces
+  (Timestamp, TraceId, SpanId, ParentSpanId, SpanName, SpanKind, ServiceName, ResourceAttributes, SpanAttributes, Duration, StatusCode)
+VALUES
+  (now64(9) - INTERVAL {backdate:UInt64} SECOND,
+   'a00000000000000000000000000000ff', 'ff00000000000000', '',
+   'reseed-stability-sentinel', 'Internal', 'reseed-stability-sentinel',
+   map('service.name', 'reseed-stability-sentinel'),
+   map('sentinel', 'reseed-stability-sentinel'),
+   1000000, 'Ok')`
+)
+
+// reseedStabilityFamily bundles one fixture family's staleness margin,
+// expected per-tick row count, and the three SQL statements the test
+// needs: plant a backdated sentinel, count that sentinel, count the
+// family's total in-scope rows.
+type reseedStabilityFamily struct {
+	name             string
+	margin           time.Duration
+	rowsPerTick      int
+	plantSentinelSQL string
+	countSentinelSQL string
+	countFamilySQL   string
+}
+
+var reseedStabilityFamilies = []reseedStabilityFamily{
+	{
+		name:             "metrics-gauge-shaped",
+		margin:           metricsNarrowStaleMargin,
+		rowsPerTick:      reseedStabilityGaugeRowsPerTick,
+		plantSentinelSQL: reseedStabilityPlantGaugeSentinelSQL,
+		countSentinelSQL: `SELECT count() FROM otel_metrics_gauge WHERE Attributes['job'] = 'reseed-stability-sentinel'`,
+		countFamilySQL:   `SELECT count() FROM otel_metrics_gauge WHERE MetricName IN ('up', 'target_info', 'showcase_flapping', 'showcase_multilabel')`,
+	},
+	{
+		name:             "metrics-sum",
+		margin:           metricsWideStaleMargin,
+		rowsPerTick:      reseedStabilitySumRowsPerTick,
+		plantSentinelSQL: reseedStabilityPlantSumSentinelSQL,
+		countSentinelSQL: `SELECT count() FROM otel_metrics_sum WHERE Attributes['job'] = 'reseed-stability-sentinel'`,
+		countFamilySQL:   `SELECT count() FROM otel_metrics_sum WHERE MetricName IN ('http_server_request_duration_count', 'showcase_restarting_total')`,
+	},
+	{
+		name:             "metrics-histogram",
+		margin:           metricsWideStaleMargin,
+		rowsPerTick:      reseedStabilityHistogramRowsPerTick,
+		plantSentinelSQL: reseedStabilityPlantHistogramSentinelSQL,
+		countSentinelSQL: `SELECT count() FROM otel_metrics_histogram WHERE Attributes['job'] = 'reseed-stability-sentinel'`,
+		countFamilySQL:   `SELECT count() FROM otel_metrics_histogram WHERE MetricName = 'http_server_request_duration'`,
+	},
+	{
+		name:             "metrics-exponential-histogram",
+		margin:           metricsNarrowStaleMargin,
+		rowsPerTick:      reseedStabilityExpHistRowsPerTick,
+		plantSentinelSQL: reseedStabilityPlantExpHistSentinelSQL,
+		countSentinelSQL: `SELECT count() FROM otel_metrics_exponential_histogram WHERE Attributes['job'] = 'reseed-stability-sentinel'`,
+		countFamilySQL:   `SELECT count() FROM otel_metrics_exponential_histogram WHERE MetricName = 'showcase_latency_exp_hist'`,
+	},
+	{
+		name:             "logs",
+		margin:           logsStaleMargin,
+		rowsPerTick:      reseedStabilityLogsRowsPerTick,
+		plantSentinelSQL: reseedStabilityPlantLogsSentinelSQL,
+		countSentinelSQL: `SELECT count() FROM otel_logs WHERE LogAttributes['thread'] = 'reseed-stability-sentinel'`,
+		countFamilySQL:   `SELECT count() FROM otel_logs WHERE ServiceName IN ('api', 'frontend', 'db', 'gateway', 'shop', 'proxy', 'painter', 'packer')`,
+	},
+	{
+		name:             "base-traces",
+		margin:           tracesStaleMargin,
+		rowsPerTick:      reseedStabilityTracesRowsPerTick,
+		plantSentinelSQL: reseedStabilityPlantTracesSentinelSQL,
+		countSentinelSQL: `SELECT count() FROM otel_traces WHERE SpanAttributes['sentinel'] = 'reseed-stability-sentinel'`,
+		countFamilySQL:   `SELECT count() FROM otel_traces WHERE TraceId LIKE 'a00000000000000000000000000000%'`,
+	},
+}
+
+// TestReSeedRowCountStability drives the rolling re-seeder's own seedAll
+// a few times and asserts every fixture family's stale-row DELETE
+// (stale.go) actually reaps old rows, and that row counts stay bounded
+// rather than growing by a full fixture's worth on every tick forever
+// (issue #1527).
+func TestReSeedRowCountStability(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	conn := reseedStabilityConn(t, ctx)
+
+	for _, fam := range reseedStabilityFamilies {
+		backdate := marginSeconds(fam.margin) + uint64(reseedStabilitySentinelSlack/time.Second)
+		if err := conn.Exec(ctx, fam.plantSentinelSQL, clickhouse.Named("backdate", backdate)); err != nil {
+			t.Fatalf("%s: plant sentinel: %v", fam.name, err)
+		}
+	}
+
+	// Drive a handful of re-seed ticks with the exact function the
+	// background rolling re-seeder calls every 30s.
+	for i := 0; i < reseedStabilityTicks; i++ {
+		if err := seedAll(ctx, conn); err != nil {
+			t.Fatalf("seedAll tick %d: %v", i, err)
+		}
+		if i < reseedStabilityTicks-1 {
+			time.Sleep(reseedStabilityTickInterval)
+		}
+	}
+
+	for _, fam := range reseedStabilityFamilies {
+		fam := fam
+		t.Run(fam.name, func(t *testing.T) {
+			var sentinelCount uint64
+			if err := conn.QueryRow(ctx, fam.countSentinelSQL).Scan(&sentinelCount); err != nil {
+				t.Fatalf("count sentinel: %v", err)
+			}
+			if sentinelCount != 0 {
+				t.Errorf("%s: sentinel row planted %ds behind now (past the %ds staleMargin) survived %d re-seed ticks — the stale-row DELETE isn't reaping old rows (issue #1527)",
+					fam.name, marginSeconds(fam.margin)+uint64(reseedStabilitySentinelSlack/time.Second), marginSeconds(fam.margin), reseedStabilityTicks)
+			}
+
+			var total uint64
+			if err := conn.QueryRow(ctx, fam.countFamilySQL).Scan(&total); err != nil {
+				t.Fatalf("count family: %v", err)
+			}
+			if total == 0 {
+				t.Errorf("%s: expected rows after seeding, got 0", fam.name)
+			}
+			bound := uint64(fam.rowsPerTick * reseedStabilityBoundSlackTicks) //nolint:gosec // G115: small, non-negative, compile-time-bounded product
+			if total > bound {
+				t.Errorf("%s: row count %d exceeds the bounded-duplication ceiling %d (%d rows/tick x %d ticks of slack) — growth looks unbounded",
+					fam.name, total, bound, fam.rowsPerTick, reseedStabilityBoundSlackTicks)
+			}
+		})
+	}
+}
+
+// reseedStabilityConn opens a connection using the same CH_ADDR /
+// CH_DATABASE / CH_USERNAME / CH_PASSWORD contract as run() in main.go.
+// `just e2e-run` (which drives this suite) exports these against the
+// same port-forward `just e2e-seed-rolling` already opened, so a live
+// ClickHouse is always reachable by the time this test runs.
+func reseedStabilityConn(t *testing.T, ctx context.Context) driver.Conn {
+	t.Helper()
+
+	addr := os.Getenv("CH_ADDR")
+	if addr == "" {
+		t.Fatalf("CH_ADDR is required (host:port of the ClickHouse native port) — run via `just e2e-run` after `just e2e-seed-rolling`")
+	}
+	database := os.Getenv("CH_DATABASE")
+	if database == "" {
+		database = "otel"
+	}
+
+	conn, err := clickhouse.Open(&clickhouse.Options{
+		Addr: []string{addr},
+		Auth: clickhouse.Auth{
+			Database: database,
+			Username: os.Getenv("CH_USERNAME"),
+			Password: os.Getenv("CH_PASSWORD"),
+		},
+		DialTimeout: 10 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("open clickhouse: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	pingCtx, pingCancel := context.WithTimeout(ctx, 10*time.Second)
+	defer pingCancel()
+	if err := conn.Ping(pingCtx); err != nil {
+		t.Fatalf("ping %s: %v", addr, err)
+	}
+	return conn
+}

--- a/test/e2e/seed/cmd/seed/stale.go
+++ b/test/e2e/seed/cmd/seed/stale.go
@@ -1,0 +1,227 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+)
+
+// Bounded stale-row cleanup for the rolling re-seeder (issue #1527).
+//
+// insertShowcaseTraces (showcase_traceql.go) was, until now, the ONLY
+// fixture family with a stale-row DELETE: every other family re-inserted
+// its window on every tick with nothing removing the previous tick's
+// rows, so a long-running rolling re-seeder (`--re-seed-interval`, driven
+// by `just e2e-seed-rolling` / docker-compose.yml's seed container)
+// stacked one full copy of the metrics/logs/base-traces fixtures per
+// tick, unboundedly, for as long as the stack stayed up.
+//
+// The fix mirrors the showcase-traces shape exactly (a data-anchored
+// `max(Timestamp) - margin` DELETE run AFTER the INSERT, never before —
+// see deleteStaleShowcaseTracesSQL's doc comment in showcase_traceql.go
+// for the full race analysis this ordering avoids) for every other
+// family. It accepts the same class of trade-off showcase-traces made:
+// a margin wider than a family's own re-seed window bounds duplication
+// to roughly (margin / tick-interval) copies rather than eliminating it
+// — naive, but bounded beats unbounded, and a delta-insert redesign is
+// unwarranted absent evidence the bound itself causes problems.
+//
+// Per-fixture margins are derived programmatically from each family's
+// own declared cadence + sample-count window (staleMargin/windowSpan
+// below) instead of hand-picked per-family constants — the metrics/logs
+// families share a `(number - anchor) * cadence` window shape whose span
+// is `(samples-1) * cadence` regardless of where the anchor sits, so one
+// small helper covers all of them.
+
+// staleMarginHeadroom is the safety slack added on top of a family's own
+// window span to get its DELETE margin — the same 2s slack already
+// implicit in deleteStaleShowcaseTracesSQL (18s insert spread → 20s
+// margin; see that constant's doc comment for why headroom in this range
+// is safe: it only has to absorb statement-gap timing and clock skew,
+// not a whole extra tick). Reused here instead of re-deriving a
+// per-family slack by hand.
+const staleMarginHeadroom = 2 * time.Second
+
+// windowSpan returns the width, in wall-clock time, of a
+// `(number - anchor) * cadence` seeded window spanning `samples` rows:
+// the distance between its earliest and latest sample. The result is
+// independent of where the anchor sits inside the window, so it applies
+// equally to the metrics/logs families (anchored mid-window, symmetric
+// around "now") without each needing its own span computation.
+func windowSpan(cadence time.Duration, samples int) time.Duration {
+	return time.Duration(samples-1) * cadence
+}
+
+// staleMargin derives a fixture family's DELETE-cutoff margin from its
+// own window span. The margin must exceed the span, or a freshly
+// inserted tick's own oldest row (up to `span` behind that same tick's
+// newest row) would be mistaken for a previous tick's stale row and
+// deleted immediately after being inserted.
+func staleMargin(span time.Duration) time.Duration {
+	return span + staleMarginHeadroom
+}
+
+// marginSeconds converts a margin to the whole-second count the DELETE
+// templates below bind as the `{margin:UInt64}` query parameter.
+func marginSeconds(margin time.Duration) uint64 {
+	return uint64(margin / time.Second) //nolint:gosec // G115: margin is a small compile-time-derived positive duration
+}
+
+// Re-seed window declarations. Each constant here names the exact
+// cadence + sample count already baked into the corresponding `FROM
+// numbers(N)` INSERT above (main.go / showcase_logql.go) — naming them
+// once and feeding staleMargin(windowSpan(...)) is what keeps the
+// margins below derived rather than hand-picked.
+const (
+	// metricsNarrowCadence/-Samples: the 15s-cadence, 40-sample
+	// gauge-shaped families sharing the `(number - 20) * 15` window —
+	// `up`, target_info, showcase_flapping, showcase_multilabel (all
+	// otel_metrics_gauge) and showcase_latency_exp_hist
+	// (otel_metrics_exponential_histogram). showcase_multilabel's
+	// `numbers(120)` covers the same 40 distinct timestamps 3x over
+	// (intDiv(number, 3)), so it shares this window too.
+	metricsNarrowCadence = 15 * time.Second
+	metricsNarrowSamples = 40
+
+	// metricsWideCadence/-Samples: the 1s-cadence, 600-sample
+	// counter/histogram-shaped families sharing the `(number - 300)`
+	// window — http_server_request_duration(_count) and
+	// showcase_restarting_total (otel_metrics_sum / otel_metrics_histogram).
+	metricsWideCadence = 1 * time.Second
+	metricsWideSamples = 600
+
+	// logsCadence/-Samples: every otel_logs stream — the base 3-service
+	// seed and the five showcase-logql streams — all share the same
+	// `(number - 20) * 15` window as the narrow metrics.
+	logsCadence = 15 * time.Second
+	logsSamples = 40
+
+	// tracesMinOffset/-MaxOffset are the earliest/latest `- INTERVAL n
+	// SECOND` offsets used by the literal a0... trace rows in
+	// insertTracesSQL (a fixed 7-row VALUES list, not a numbers()
+	// formula, so its span is declared directly rather than via
+	// cadence*samples).
+	tracesMinOffset = 9 * time.Second
+	tracesMaxOffset = 30 * time.Second
+)
+
+// Per-family margins, each derived from the window declarations above.
+var (
+	metricsNarrowStaleMargin = staleMargin(windowSpan(metricsNarrowCadence, metricsNarrowSamples))
+	metricsWideStaleMargin   = staleMargin(windowSpan(metricsWideCadence, metricsWideSamples))
+	logsStaleMargin          = staleMargin(windowSpan(logsCadence, logsSamples))
+	tracesStaleMargin        = staleMargin(tracesMaxOffset - tracesMinOffset)
+)
+
+// Stale-row DELETEs, one per table these fixtures write to. Each scopes
+// both the outer DELETE and the max(Timestamp) subquery to the
+// MetricName/ServiceName/TraceId set this seeder owns in that table —
+// unscoped would either eat rows the dogfood self-telemetry pipeline
+// wrote into the same table (see showcase_traceql.go / showcase_logql.go
+// doc comments) or anchor the cutoff on foreign rows. The margin is a
+// bound query parameter (`{margin:UInt64}`), not a literal, so it stays
+// in lockstep with the Go-side staleMargin() computation above — the
+// same `{name:Type}` parameter binding already used by
+// compatibility/prometheus/cmd/seed/main.go.
+const (
+	deleteStaleMetricsGaugeSQL = `DELETE FROM otel_metrics_gauge
+WHERE MetricName IN ('up', 'target_info', 'showcase_flapping', 'showcase_multilabel')
+  AND Timestamp < (
+    SELECT max(Timestamp) - INTERVAL {margin:UInt64} SECOND
+    FROM otel_metrics_gauge
+    WHERE MetricName IN ('up', 'target_info', 'showcase_flapping', 'showcase_multilabel')
+  )`
+
+	deleteStaleMetricsSumSQL = `DELETE FROM otel_metrics_sum
+WHERE MetricName IN ('http_server_request_duration_count', 'showcase_restarting_total')
+  AND Timestamp < (
+    SELECT max(Timestamp) - INTERVAL {margin:UInt64} SECOND
+    FROM otel_metrics_sum
+    WHERE MetricName IN ('http_server_request_duration_count', 'showcase_restarting_total')
+  )`
+
+	deleteStaleMetricsHistogramSQL = `DELETE FROM otel_metrics_histogram
+WHERE MetricName = 'http_server_request_duration'
+  AND Timestamp < (
+    SELECT max(Timestamp) - INTERVAL {margin:UInt64} SECOND
+    FROM otel_metrics_histogram
+    WHERE MetricName = 'http_server_request_duration'
+  )`
+
+	deleteStaleMetricsExpHistSQL = `DELETE FROM otel_metrics_exponential_histogram
+WHERE MetricName = 'showcase_latency_exp_hist'
+  AND Timestamp < (
+    SELECT max(Timestamp) - INTERVAL {margin:UInt64} SECOND
+    FROM otel_metrics_exponential_histogram
+    WHERE MetricName = 'showcase_latency_exp_hist'
+  )`
+
+	deleteStaleLogsSQL = `DELETE FROM otel_logs
+WHERE ServiceName IN ('api', 'frontend', 'db', 'gateway', 'shop', 'proxy', 'painter', 'packer')
+  AND Timestamp < (
+    SELECT max(Timestamp) - INTERVAL {margin:UInt64} SECOND
+    FROM otel_logs
+    WHERE ServiceName IN ('api', 'frontend', 'db', 'gateway', 'shop', 'proxy', 'painter', 'packer')
+  )`
+
+	deleteStaleBaseTracesSQL = `DELETE FROM otel_traces
+WHERE TraceId LIKE 'a00000000000000000000000000000%'
+  AND Timestamp < (
+    SELECT max(Timestamp) - INTERVAL {margin:UInt64} SECOND
+    FROM otel_traces
+    WHERE TraceId LIKE 'a00000000000000000000000000000%'
+  )`
+)
+
+// deleteStaleMetrics prunes previous-tick rows from every metrics table
+// insertMetrics writes to. Called after all of insertMetrics' INSERTs
+// have landed, so — like deleteStaleShowcaseTracesSQL — readers never
+// observe an empty or partially-deleted window.
+func deleteStaleMetrics(ctx context.Context, conn driver.Conn) error {
+	if err := conn.Exec(ctx, deleteStaleMetricsGaugeSQL,
+		clickhouse.Named("margin", marginSeconds(metricsNarrowStaleMargin))); err != nil {
+		return fmt.Errorf("gauge-shaped metrics stale delete: %w", err)
+	}
+	if err := conn.Exec(ctx, deleteStaleMetricsSumSQL,
+		clickhouse.Named("margin", marginSeconds(metricsWideStaleMargin))); err != nil {
+		return fmt.Errorf("sum metrics stale delete: %w", err)
+	}
+	if err := conn.Exec(ctx, deleteStaleMetricsHistogramSQL,
+		clickhouse.Named("margin", marginSeconds(metricsWideStaleMargin))); err != nil {
+		return fmt.Errorf("histogram metrics stale delete: %w", err)
+	}
+	if err := conn.Exec(ctx, deleteStaleMetricsExpHistSQL,
+		clickhouse.Named("margin", marginSeconds(metricsNarrowStaleMargin))); err != nil {
+		return fmt.Errorf("exponential histogram metrics stale delete: %w", err)
+	}
+	return nil
+}
+
+// deleteStaleLogs prunes previous-tick rows from otel_logs across every
+// stream insertLogs writes (the base 3-service seed + the five
+// showcase-logql streams share one window, so one DELETE covers all of
+// them). Called after both insertLogsSQL and insertShowcaseLogQLLogs
+// have landed.
+func deleteStaleLogs(ctx context.Context, conn driver.Conn) error {
+	if err := conn.Exec(ctx, deleteStaleLogsSQL,
+		clickhouse.Named("margin", marginSeconds(logsStaleMargin))); err != nil {
+		return fmt.Errorf("logs stale delete: %w", err)
+	}
+	return nil
+}
+
+// deleteStaleBaseTraces prunes previous-tick rows from the a0... base
+// trace fixture insertTraces writes (the b0... showcase-trace range has
+// its own DELETE — deleteStaleShowcaseTracesSQL in showcase_traceql.go —
+// scoped separately so the two margins, sized for very different
+// windows, never interact).
+func deleteStaleBaseTraces(ctx context.Context, conn driver.Conn) error {
+	if err := conn.Exec(ctx, deleteStaleBaseTracesSQL,
+		clickhouse.Named("margin", marginSeconds(tracesStaleMargin))); err != nil {
+		return fmt.Errorf("base traces stale delete: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

Closes #1527.

`insertShowcaseTraces` (`test/e2e/seed/cmd/seed/showcase_traceql.go`) was the *only* fixture family the rolling re-seeder cleaned up: every other family (metrics gauge/sum/histogram/exponential-histogram, base logs + the five showcase-logql streams, the `a0...` base traces) re-inserted its window on every `--re-seed-interval` tick with no stale-row DELETE at all, so a long-lived stack (or any lane that reuses a stack across ticks) accumulated one full copy of those fixtures per tick, unboundedly, for as long as it stayed up.

Per the issue's binding triage decision:

- **Fix shape**: extend showcase-traces' existing naive max-timestamp-margin DELETE (accepted as bounded-not-unbounded for v1; no delta-insert redesign) to every other family, run *after* that family's INSERT — same ordering, same reason (`DELETE`-then-`INSERT` opened an empty-range window on a prior PR; see `deleteStaleShowcaseTracesSQL`'s doc comment).
- **Margins**: derived programmatically in `test/e2e/seed/cmd/seed/stale.go` from each family's own already-declared cadence/sample-count window (`windowSpan(cadence, samples) = (samples-1)*cadence`, `staleMargin(span) = span + 2s headroom` — the same 2s slack already implicit in showcase-traces' 18s-spread/20s-margin pair), instead of ~8 hand-picked constants. The metrics/logs families share a 15s×40 or 1s×600 `(number - anchor) * cadence` window shape, so one small helper covers all of them; the `a0...` base traces (a fixed 7-row `VALUES` list, not a `numbers()` formula) declare their own min/max offset directly.
- **Live assertion**: `test/e2e/seed/cmd/seed/reseed_stability_test.go` (build-tagged `e2e`, runs via `just e2e-run`) — next to the re-seeder it tests, not `test/regression/` (kept pure static source-scan) and not a new harness layer. Rather than waiting out each family's real ~10-minute margin, it plants a sentinel row per family with a manually backdated Timestamp past that family's `staleMargin()`, drives `reseedStabilityTicks` (3) real `seedAll` ticks, and asserts the sentinel is gone — proving the DELETE fires and is scoped to the right table/predicate regardless of when in the lane the test runs. A secondary check bounds each family's total row count to a generous multiple of one tick's insert size.

## Verification

Every DELETE/sentinel SQL shape (parameterised `{margin:UInt64}` / `{backdate:UInt64}` via `clickhouse.Named`, `Map` subscript predicates, the `TraceId LIKE` scoping) was smoke-tested against a live ClickHouse 26.6 instance in an isolated throwaway database (created and dropped, `otel` untouched) to confirm the sentinel-planted-then-reaped flow behaves as designed before relying on CI's k3d/dashboard lane to exercise it for real.

`go build ./...`, `go vet -tags=e2e ./test/e2e/seed/...`, `gofumpt -extra`, and `golangci-lint run ./... --build-tags e2e` (via the pre-push hook) are all clean; `test/regression/seed_test.go`'s existing static pins (insert-before-delete ordering, data-anchored cutoff, etc.) still pass unmodified.

## Test plan

- [ ] CI: `check` / `lint` / `forbid-skip` / `forbid-deferral` / `strict-scan` / `CodeQL` (pre-push already mirrors most of these locally)
- [ ] CI: `mutation`, `property`, `roundtrip`, `compatibility/*`, `coverage`, `perf-guards` (unaffected — no `internal/**` change)
- [ ] Release gate: `dashboard` (k3d + Grafana + Playwright) exercises `TestReSeedRowCountStability` for real via `just e2e-run`, since this lane only runs its real work on the merge/release commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)