### PR TITLE
DO NOT MERGE: throwaway experiment for issue #1568 (.gitattributes -merge server-side verification)

### DIFF
--- a/test/perf/solver-decision-baseline.json
+++ b/test/perf/solver-decision-baseline.json
@@ -2520,6 +2520,16 @@
     "outer_range": "1h0m0s"
   },
   {
+    "query": "mmm_experiment_branch_b_record",
+    "routed": false,
+    "k": 0,
+    "reason": "not-sliceable",
+    "n_anchors": 10,
+    "fanout": 0,
+    "cumulative_d": "0s",
+    "outer_range": "10m0s"
+  },
+  {
     "query": "map_key_order_count",
     "routed": true,
     "k": 8,


### PR DESCRIPTION
Throwaway experiment for #1568. Both branches insert a new record at a different, non-overlapping line offset into the -merge-marked array test/perf/solver-decision-baseline.json. Checking whether GitHub's server-side merge honours the -merge attribute (refuses / conflicts) or falls back to a normal text merge (silently blends). Will be closed/deleted without merging into main.