### PR TITLE
fix(ci): verify GitHub server-side merge ignores -merge, add structural guard

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -30,6 +30,41 @@
 # directions by test/regression/generated_artifact_merge_gate_test.go, which
 # also fails on any tracked data file NAMED like a generated artefact that is
 # neither gated here nor recorded in the hand-authored section at the bottom.
+#
+# `-merge` protects a LOCAL `git merge` / `git rebase` / `git pull`, which
+# reads this file. Whether GitHub's SERVER-SIDE merge (the "Update branch"
+# button, `gh pr merge --squash`, the mergeability precomputation that decides
+# whether a PR shows conflict-free) honours it too went unverified until
+# #1568. It does not: verified empirically 2026-08-04 by pushing two
+# throwaway branches to this repo that each inserted one new record at a
+# different, non-overlapping line offset into
+# test/perf/solver-decision-baseline.json off the same base commit, and
+# opening a throwaway PR between them. `gh pr view --json mergeable` reported
+# `"mergeable":"MERGEABLE"` for that PR, while a LOCAL `git merge` of the
+# identical branch pair refused with "Cannot merge binary files" / `CONFLICT
+# (content)` — exactly the behaviour this file exists to force. The throwaway
+# PR was closed unmerged and both branches deleted immediately after; see
+# issue #1568 for the full experiment writeup.
+#
+# The defence-in-depth for that gap is two-fold — see
+# .github/scripts/generated-baseline-structural-guard.mjs's doc comment for
+# the full audit of what already covers what:
+#   1. nearly every path below already carries a REQUIRED, content-exact
+#      regenerate-and-diff ratchet in a required PR check (perf-guards,
+#      check, coverage, compatibility/*, and the Tier-0 migration goldens via
+#      `lint`) — the "re-run the generator and diff" defence #1568 asked for
+#      already existed for most of this list;
+#   2. the residual risk is that branch protection's "require branches to be
+#      up to date before merging" is OFF (`strict: false`), so a stale PR's
+#      squash-merge can in principle apply a diff against a `main` that moved
+#      without any of those checks ever running against the merged bytes.
+#      Turning `strict: true` on closes that window; it is a repo-admin
+#      setting, not a code change, and is recommended to the maintainer
+#      rather than flipped by the PR that added this note.
+# generated-baseline-structural-guard.mjs additionally adds a fast, always-on
+# structural pre-filter (unique key, sorted order, consistent field shape)
+# over the subset of paths below whose shape was hand-verified — a cheap
+# second signal, not a replacement for the regenerate-and-diff ratchets.
 
 # --- Perf ratchet baselines -------------------------------------------------
 # Regenerate: `just update-cardinality-baseline`

--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -116,6 +116,20 @@ uncomputable-diff fallback — cannot drift between the lanes that use it.
   files (`emit_node.go`, `emit.go`). See CLAUDE.md § "No raw SQL strings" and
   #1441. No env inputs; always runs the full scan.
   - Exit: `0` clean, `1` on any raw-write violation.
+- **`generated-baseline-structural-guard.mjs`** — `ci.yml`, the `forbid-skip`
+  job step "Structural sanity check over generated baseline shapes (#1568)".
+  A fast, dependency-free structural pre-filter (unique key, sorted order,
+  and — where verified uniform — one consistent field set) over the subset
+  of `-merge`-marked generated baselines (see `.gitattributes`) whose shape
+  was hand-checked against the committed content. Exists because #1568 found
+  that GitHub's server-side merge does not honour `-merge` at all (verified
+  empirically — see the script's own doc comment), so the content-exact
+  regenerate-and-diff ratchets that already cover most of these files (listed
+  in the doc comment) need a branch-protection `strict: true` to guarantee
+  they always run against the content that actually lands on `main`; this
+  script is a cheap, always-on second signal in the meantime. No env inputs.
+  - Exit: `0` clean (or self-test passed), `1` on a structural violation or
+    an unreadable/unparseable file.
 - **`forbid-skip.mjs`** — `ci.yml`, the `forbid-skip` discipline scans;
   `compatibility.yml`, the cheap-first `gate`.
   - Env: `CHECK` is `all` (every scan, in registry order) or one of `t-skip`,

--- a/.github/scripts/generated-baseline-structural-guard.mjs
+++ b/.github/scripts/generated-baseline-structural-guard.mjs
@@ -1,0 +1,409 @@
+// generated-baseline-structural-guard.mjs — cheap, fast structural sanity
+// check over a subset of the `-merge`-marked generated baselines listed in
+// .gitattributes.
+//
+// # Why this exists
+//
+// #1567 marked ~28 generated baselines `-merge` in .gitattributes so a LOCAL
+// `git merge` refuses to silently blend two branches that each insert a
+// record at a nearby offset (the #1422 corruption class: the record
+// boundaries shift, a name ends up paired with the next record's values, and
+// the result still parses as valid JSON with a plausible length while every
+// entry in the blended region is wrong — see .gitattributes' own header
+// comment for the full shape).
+//
+// #1568 asked whether GitHub's SERVER-SIDE merge (the "Update branch"
+// button, `gh pr merge --squash`, the mergeability precomputation that
+// decides whether a PR shows conflict-free) honours that attribute at all —
+// `-merge` is a built-in driver, but nothing had verified GitHub's merge
+// service actually reads .gitattributes rather than always falling back to a
+// plain line-based text merge.
+//
+// It does not. Verified empirically 2026-08-04: two throwaway branches in
+// this repo, each inserting one new record at a different, non-overlapping
+// line offset into test/perf/solver-decision-baseline.json off the same
+// base commit, were reported `"mergeable":"MERGEABLE"` by the GitHub API
+// (`gh pr view --json mergeable,mergeStateStatus`) for a throwaway PR
+// between them — while a LOCAL `git merge` of the identical branch pair
+// refused with "Cannot merge binary files" / `CONFLICT (content)`, exactly
+// as .gitattributes documents. The throwaway PR was closed unmerged and
+// both branches deleted immediately after; see issue #1568 for the full
+// experiment writeup.
+//
+// # What actually protects these files today
+//
+// Auditing every `-merge` path found that nearly all of them already carry a
+// REQUIRED, PR-blocking, content-EXACT validator that regenerates the
+// artefact from source and diffs it (byte-for-byte, or full-struct
+// equality, keyed per record) against the committed file:
+//   - TestCardinalityRatchet / TestSolverDecisionRatchet / TestScaleWallPin
+//     (test/perf, the `perf-guards` required job),
+//   - TestCatalogueIsRegenerable + the surface-parity inventory tests
+//     (test/rejection-parity, test/surface-parity — plain `go test`, the
+//     `check` required job),
+//   - compat-ratchet.mjs (the `compatibility/*` required jobs),
+//   - coverage-summary.mjs (the `coverage` required job),
+//   - the Tier-0 migration goldens, via
+//     `go test -tags=migration ./test/e2e/migration/tiers/tier0-offline/...`
+//     (the `lint` required job — see ci.yml's "Run the Tier-0 migration
+//     scenarios (explain-golden drift)" step).
+// Those are the STRONG defence #1568 asked for ("re-runs the generator on
+// the merge commit and diffs it against the committed file") — they were
+// already there for most of the list.
+//
+// The residual gap is procedural, not a missing validator: with branch
+// protection's "require branches to be up to date before merging" OFF
+// (`strict: false` as of this writing — confirmed via
+// `gh api repos/tsouza/cerberus/branches/main/protection`), a stale PR's
+// squash-merge computes its diff against a `main` that has since moved
+// WITHOUT ever re-running the checks above against the resulting content —
+// so a corrupted blend of one of these files can, in principle, land on
+// `main` with no CI run ever having seen the merged bytes. Turning
+// `strict: true` on closes that window for every file the list above
+// covers (it forces the "Update branch" step, which re-runs every required
+// check — including all of the above — against the exact content that will
+// land) and is the recommended follow-up. It is a branch-protection admin
+// setting, not a code change, so this script does not attempt it — see the
+// PR that added this file for the explicit recommendation to the
+// maintainer.
+//
+// One family was found to have WEAKER coverage on an ordinary PR:
+// test/e2e/playwright/crawl/grafana-surface-inventory.{compose,k3d}.json are
+// exercised at full depth only by the release-gated `dashboard` (k3d) lane,
+// which runs on the merge commit rather than blocking the PR; `compose-smoke`
+// only walks the `lean: true` subset of the `.compose.json` file's rows when
+// its own scope triggers. That gap is tracked separately (see the PR body /
+// the follow-up issue it filed) rather than guessed at here — the file's
+// row order was checked by hand and is NOT a simple lexical sort (it groups
+// by base path in crawl-discovery order), so folding it into this guard's
+// generic sorted/unique check would have been a false invariant.
+//
+// # What THIS script adds
+//
+// A fast, always-on, dependency-free structural pre-filter over the subset
+// of `-merge` files whose invariants (unique key, sorted order, and — where
+// the shape is genuinely uniform — one consistent field set) were verified
+// by hand against the committed content (see TARGETS below). It catches the
+// SHAPE-LEVEL symptom of a #1422-class blend (a duplicate or out-of-order
+// key) in milliseconds, before the heavier per-file ratchets run, as a
+// second, independent signal — deliberately not a replacement for the
+// content-exact ratchets above, since a structural check cannot tell a
+// value that is merely out of place from one that is subtly wrong.
+//
+// Usage:
+//   node .github/scripts/generated-baseline-structural-guard.mjs
+//   node .github/scripts/generated-baseline-structural-guard.mjs --self-test
+//
+// Exit codes:
+//   0  every configured target is well-formed (unique, sorted, and — where
+//      configured — one consistent field set).
+//   1  a structural violation, or an unreadable/unparseable file.
+
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import process from 'node:process';
+
+import { error, log, notice } from './lib/gh.mjs';
+
+// get() descends a path of object keys. An empty path returns the root
+// value unchanged, which is what the two top-level-array targets need.
+function get(obj, path) {
+  return path.reduce((o, k) => (o == null ? o : o[k]), obj);
+}
+
+// checkArray is the core structural assertion over an array of items —
+// either plain strings (a roster, e.g. a compat case list) when `key` is
+// null, or objects keyed by `key`. Returns a list of problem strings; an
+// empty list means clean.
+export function checkArray({ label, items, key, uniformShape }) {
+  const problems = [];
+  const values = key == null ? items : items.map((it) => it?.[key]);
+
+  values.forEach((v, i) => {
+    if (v === undefined) {
+      problems.push(`${label}[${i}]: missing key ${JSON.stringify(key)}`);
+    }
+  });
+
+  const firstSeenAt = new Map();
+  values.forEach((v, i) => {
+    if (firstSeenAt.has(v)) {
+      problems.push(
+        `${label}: duplicate ${key ?? 'value'} ${JSON.stringify(v)} at index ${firstSeenAt.get(v)} and ${i}`,
+      );
+    } else {
+      firstSeenAt.set(v, i);
+    }
+  });
+
+  for (let i = 1; i < values.length; i++) {
+    if (values[i] < values[i - 1]) {
+      problems.push(
+        `${label}: out of sorted order at index ${i} — ${JSON.stringify(values[i - 1])} then ` +
+          `${JSON.stringify(values[i])}. A merge that silently interleaved two branches' insertions into this ` +
+          'array (the #1422 shape) produces exactly this: a record landing next to the wrong neighbour.',
+      );
+    }
+  }
+
+  if (uniformShape && key != null) {
+    const shapes = new Set(items.filter((it) => it && typeof it === 'object').map((it) => JSON.stringify(Object.keys(it).sort())));
+    if (shapes.size > 1) {
+      problems.push(
+        `${label}: ${shapes.size} distinct field sets across records — expected exactly one. A blended merge ` +
+          'that spliced one record\'s trailing fields onto another\'s leading fields produces a record whose ' +
+          'key set does not match its neighbours.',
+      );
+    }
+  }
+
+  return problems;
+}
+
+// checkSortedLines is the text-file variant: non-comment, non-blank lines
+// must be unique and lexically sorted.
+export function checkSortedLines({ label, text, commentPrefix = '#' }) {
+  const lines = text.split('\n').filter((l) => l.trim() !== '' && !l.trimStart().startsWith(commentPrefix));
+  return checkArray({ label, items: lines, key: null, uniformShape: false });
+}
+
+// checkSortedKeys is the dict variant: an object's OWN keys (in the order
+// JSON.parse preserved them, i.e. source order) must be sorted. Values are
+// not otherwise inspected here — the file's own regenerate-and-diff test is
+// the content-exact authority for what a value should be.
+export function checkSortedKeys({ label, obj }) {
+  const keys = Object.keys(obj);
+  const problems = [];
+  for (let i = 1; i < keys.length; i++) {
+    if (keys[i] < keys[i - 1]) {
+      problems.push(
+        `${label}: keys out of sorted order at index ${i} — ${JSON.stringify(keys[i - 1])} then ` +
+          `${JSON.stringify(keys[i])}`,
+      );
+    }
+  }
+  return problems;
+}
+
+// TARGETS — every entry's shape was checked by hand against the committed
+// file before being added here (see the file doc above for the ones left
+// out and why). `arrayPath` / `dictPath` are lists of keys to descend from
+// the parsed JSON root; an empty array means "the root itself".
+export const TARGETS = [
+  {
+    path: 'test/perf/cardinality-baseline.json',
+    kind: 'array',
+    arrayPath: [],
+    key: 'fixture',
+    uniformShape: true,
+  },
+  {
+    path: 'test/perf/solver-decision-baseline.json',
+    kind: 'array',
+    arrayPath: [],
+    key: 'query',
+    uniformShape: true,
+  },
+  {
+    path: 'test/rejection-parity/catalogue.json',
+    kind: 'array',
+    arrayPath: ['entries'],
+    key: 'site',
+    // Entries carry optional fields (e.g. `trigger_query`, `endpoint`) —
+    // three distinct field sets are legitimate in the committed file today.
+    uniformShape: false,
+  },
+  {
+    path: 'test/e2e/grafana/ql-inventory/promql-feature-inventory.json',
+    kind: 'array',
+    arrayPath: ['rows'],
+    key: 'id',
+    // Some rows carry an optional `experimental` flag.
+    uniformShape: false,
+  },
+  {
+    path: 'test/e2e/grafana/ql-inventory/logql-feature-inventory.json',
+    kind: 'array',
+    arrayPath: ['rows'],
+    key: 'id',
+    uniformShape: true,
+  },
+  {
+    path: 'test/e2e/grafana/ql-inventory/traceql-feature-inventory.json',
+    kind: 'array',
+    arrayPath: ['rows'],
+    key: 'id',
+    uniformShape: true,
+  },
+  {
+    path: 'compatibility/parity-baseline.json',
+    kind: 'array',
+    arrayPath: ['heads', 'prometheus', 'cases'],
+    key: null,
+    uniformShape: false,
+  },
+  {
+    path: 'compatibility/parity-baseline.json',
+    kind: 'array',
+    arrayPath: ['heads', 'loki', 'cases'],
+    key: null,
+    uniformShape: false,
+  },
+  {
+    path: 'compatibility/parity-baseline.json',
+    kind: 'array',
+    arrayPath: ['heads', 'tempo', 'cases'],
+    key: null,
+    uniformShape: false,
+  },
+  {
+    path: 'compatibility/loki/upstream-skip-baseline.txt',
+    kind: 'lines',
+  },
+  {
+    path: 'test/surface-parity/promql-reference-verdicts.json',
+    kind: 'dict-keys',
+    dictPath: ['verdicts'],
+  },
+];
+
+export function runTarget(t, { readFile = (p) => readFileSync(p, 'utf8') } = {}) {
+  if (t.kind === 'lines') {
+    const text = readFile(t.path);
+    return checkSortedLines({ label: t.path, text });
+  }
+  if (t.kind === 'dict-keys') {
+    const doc = JSON.parse(readFile(t.path));
+    const obj = get(doc, t.dictPath);
+    const label = `${t.path}#${t.dictPath.join('.')}`;
+    if (obj == null || typeof obj !== 'object' || Array.isArray(obj)) {
+      return [`${label}: expected an object, got ${Array.isArray(obj) ? 'array' : typeof obj}`];
+    }
+    return checkSortedKeys({ label, obj });
+  }
+  // 'array'
+  const doc = JSON.parse(readFile(t.path));
+  const items = get(doc, t.arrayPath);
+  const label = `${t.path}#${t.arrayPath.join('.') || '(top)'}`;
+  if (!Array.isArray(items)) {
+    return [`${label}: expected an array, got ${typeof items}`];
+  }
+  return checkArray({ label, items, key: t.key, uniformShape: t.uniformShape });
+}
+
+function main() {
+  const problems = [];
+  for (const t of TARGETS) {
+    try {
+      problems.push(...runTarget(t));
+    } catch (e) {
+      problems.push(`${t.path}: ${e.message}`);
+    }
+  }
+
+  if (problems.length > 0) {
+    for (const p of problems) error(p, { title: 'generated-baseline-structural-guard' });
+    log(
+      `\n${problems.length} structural violation(s) across ${TARGETS.length} check(s). This shape is exactly ` +
+        'what a merge that silently blended two branches\' insertions into one of these generated baselines ' +
+        'produces (see #1568) — regenerate the artefact from source rather than hand-editing it.',
+    );
+    process.exit(1);
+  }
+
+  notice(
+    `generated-baseline-structural-guard: ${TARGETS.length} check(s) clean (unique, sorted, and shape-consistent ` +
+      'where asserted).',
+  );
+}
+
+function selfTest() {
+  // Clean: uniform, sorted, unique.
+  assert.deepEqual(
+    checkArray({ label: 't', items: [{ id: 'a' }, { id: 'b' }], key: 'id', uniformShape: true }),
+    [],
+  );
+
+  // Duplicate key.
+  const dup = checkArray({ label: 't', items: [{ id: 'a' }, { id: 'a' }], key: 'id', uniformShape: false });
+  assert.equal(dup.length, 1);
+  assert.match(dup[0], /duplicate id/);
+
+  // Out of order — the #1422 shape: an insertion landed at the wrong offset.
+  const unsorted = checkArray({ label: 't', items: [{ id: 'b' }, { id: 'a' }], key: 'id', uniformShape: false });
+  assert.equal(unsorted.length, 1);
+  assert.match(unsorted[0], /out of sorted order/);
+
+  // Non-uniform shape, asserted -> flagged.
+  const nonUniform = checkArray({
+    label: 't',
+    items: [{ id: 'a', x: 1 }, { id: 'b' }],
+    key: 'id',
+    uniformShape: true,
+  });
+  assert.equal(nonUniform.length, 1);
+  assert.match(nonUniform[0], /distinct field sets/);
+
+  // Non-uniform shape, NOT asserted -> tolerated (catalogue.json's optional fields).
+  assert.deepEqual(
+    checkArray({ label: 't', items: [{ id: 'a', x: 1 }, { id: 'b' }], key: 'id', uniformShape: false }),
+    [],
+  );
+
+  // Plain-string array (a compat case roster) — key is null, values compare directly.
+  assert.deepEqual(checkArray({ label: 't', items: ['a', 'b', 'c'], key: null, uniformShape: false }), []);
+  const dupStr = checkArray({ label: 't', items: ['a', 'a'], key: null, uniformShape: false });
+  assert.equal(dupStr.length, 1);
+
+  // Sorted lines, comments and blanks ignored.
+  assert.deepEqual(checkSortedLines({ label: 't', text: '# comment\n\na\nb\n' }), []);
+  const badLines = checkSortedLines({ label: 't', text: 'b\na\n' });
+  assert.equal(badLines.length, 1);
+
+  // Sorted dict keys.
+  assert.deepEqual(checkSortedKeys({ label: 't', obj: { a: 1, b: 2 } }), []);
+  const badKeys = checkSortedKeys({ label: 't', obj: { b: 1, a: 2 } });
+  assert.equal(badKeys.length, 1);
+
+  // runTarget dispatches on `kind` correctly, over an injected in-memory
+  // file — no real files touched by this half of the self-test.
+  const files = {
+    'a.json': JSON.stringify([{ id: 'a' }, { id: 'b' }]),
+    'b.json': JSON.stringify({ rows: [{ id: 'a' }, { id: 'z' }, { id: 'm' }] }),
+    'c.txt': 'b\na\n',
+    'd.json': JSON.stringify({ verdicts: { b: 1, a: 2 } }),
+  };
+  const readFile = (p) => {
+    if (!(p in files)) throw new Error(`unexpected read: ${p}`);
+    return files[p];
+  };
+  assert.deepEqual(
+    runTarget({ path: 'a.json', kind: 'array', arrayPath: [], key: 'id', uniformShape: true }, { readFile }),
+    [],
+  );
+  assert.equal(
+    runTarget({ path: 'b.json', kind: 'array', arrayPath: ['rows'], key: 'id', uniformShape: false }, { readFile })
+      .length,
+    1,
+  );
+  assert.equal(runTarget({ path: 'c.txt', kind: 'lines' }, { readFile }).length, 1);
+  assert.equal(
+    runTarget({ path: 'd.json', kind: 'dict-keys', dictPath: ['verdicts'] }, { readFile }).length,
+    1,
+  );
+
+  // Every configured TARGET is currently clean against the real committed
+  // files in this tree — the guard itself must not be a standing failure.
+  for (const t of TARGETS) {
+    const problems = runTarget(t);
+    assert.deepEqual(problems, [], `TARGETS entry ${t.path} is not currently clean: ${problems.join('; ')}`);
+  }
+
+  log('generated-baseline-structural-guard self-test: OK');
+}
+
+if (process.argv.includes('--self-test')) {
+  selfTest();
+} else {
+  main();
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -844,6 +844,19 @@ jobs:
       - name: Reject raw SQL writes outside the chsql Frag layer
         run: node .github/scripts/forbid-sql-raw.mjs
 
+      # #1568: GitHub's server-side merge does NOT honour the `-merge`
+      # .gitattributes driver (verified empirically — see the script's own
+      # doc comment for the experiment). Most `-merge`-marked generated
+      # baselines already have a required, content-exact regenerate-and-diff
+      # ratchet elsewhere; this is a fast, dependency-free structural
+      # pre-filter over the subset whose shape (unique key, sorted order,
+      # consistent field set) was hand-verified, catching the #1422 blend
+      # symptom in milliseconds as a second, independent signal.
+      - name: Structural sanity check over generated baseline shapes (#1568)
+        run: |
+          node .github/scripts/generated-baseline-structural-guard.mjs --self-test
+          node .github/scripts/generated-baseline-structural-guard.mjs
+
   # `forbid-deferral` used to live here. It moved to its own workflow file,
   # `.github/workflows/forbid-deferral.yml`, because one of its three surfaces
   # is the PR DESCRIPTION and this workflow's bare `pull_request:` trigger does

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -980,3 +980,61 @@ its own fix. `compatibility/parity-baseline.json` is the one exception
 worth knowing before you hit it: it is rebuilt from a compatibility run's
 `compat-cases.json` artefact and therefore **cannot** be regenerated
 locally.
+
+#### `-merge` only protects a LOCAL git merge — verified 2026-08-04
+
+`-merge` is a built-in git merge driver, honoured by any git CLIENT that
+reads `.gitattributes`: a local `git merge`, `git rebase`, or `git pull`.
+Cerberus's actual merge paths on GitHub are mostly SERVER-SIDE — the "Update
+branch" button, `gh pr merge --squash`, and the mergeability precomputation
+that decides whether a PR shows conflict-free — and nothing had verified
+those honour `.gitattributes` at all (issue #1568, spun out of #1567 while
+adding the gate above).
+
+They do not. Verified empirically 2026-08-04: two throwaway branches pushed
+to this repo, each inserting one new record at a different, non-overlapping
+line offset into `test/perf/solver-decision-baseline.json` off the same base
+commit, produced a throwaway PR that `gh pr view --json mergeable` reported
+as `"mergeable":"MERGEABLE"` — while a LOCAL `git merge` of the identical
+branch pair, run in a scratch worktree, refused with "Cannot merge binary
+files" / `CONFLICT (content)`, exactly as `.gitattributes` documents. The
+throwaway PR was closed unmerged and both branches deleted immediately after.
+
+Auditing every `-merge` path for what actually protects it turned up good
+news: nearly all of them already carry a REQUIRED, PR-blocking,
+content-exact ratchet that regenerates the artefact from source and diffs it
+against the committed file — `TestCardinalityRatchet` /
+`TestSolverDecisionRatchet` / `TestScaleWallPin` (`perf-guards`),
+`TestCatalogueIsRegenerable` and the surface-parity inventory tests
+(`check`), `compat-ratchet.mjs` (`compatibility/*`), `coverage-summary.mjs`
+(`coverage`), and the Tier-0 migration goldens via
+`go test -tags=migration ./test/e2e/migration/tiers/tier0-offline/...`
+(`lint`). Those are the strong "re-run the generator on the merge commit and
+diff it" defence #1568 asked for, and they were already there for most of
+the list.
+
+The residual gap is procedural rather than a missing validator: branch
+protection's "require branches to be up to date before merging" is OFF
+(`strict: false` as of this writing), so a stale PR's squash-merge computes
+its diff against whatever `main` has moved to WITHOUT re-running any of the
+checks above against the resulting content. Turning `strict: true` on closes
+that window — it forces the "Update branch" step, which re-runs every
+required check (including all of the above) against the exact content that
+will land — and is recommended to the maintainer as a follow-up; it is a
+branch-protection admin setting, not a code change, so no PR flips it
+unilaterally.
+
+`.github/scripts/generated-baseline-structural-guard.mjs`, wired into the
+required `forbid-skip` job, adds a fast, dependency-free structural
+pre-filter (unique key, sorted order, and — where verified uniform — one
+consistent field set) over the subset of `-merge` paths whose shape was
+hand-checked against the committed content. It is a cheap, always-on second
+signal, not a replacement for the content-exact ratchets above — a
+structural check cannot tell a value that is merely out of place from one
+that is subtly wrong. One family was found to have weaker per-PR coverage:
+`test/e2e/playwright/crawl/grafana-surface-inventory.{compose,k3d}.json` are
+exercised at full depth only by the release-gated `dashboard` (k3d) lane
+(the merge commit, not the PR), with `compose-smoke` walking only the
+`lean: true` subset of the `.compose.json` rows when its own scope triggers;
+that gap is tracked as a follow-up issue rather than papered over with an
+unverified invariant.

--- a/test/regression/generated_baseline_structural_guard_wired_test.go
+++ b/test/regression/generated_baseline_structural_guard_wired_test.go
@@ -1,0 +1,63 @@
+package regression
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// #1568 established empirically that GitHub's server-side merge does NOT
+// honour the `-merge` .gitattributes driver #1567 relies on: two throwaway
+// branches inserting non-overlapping records into the same `-merge`-marked
+// file were reported "mergeable" by the GitHub API even though a local `git
+// merge` of the identical pair refused with a conflict. Most `-merge` files
+// already have a required, content-exact regenerate-and-diff ratchet
+// elsewhere; generated-baseline-structural-guard.mjs is the fast structural
+// backstop layered on top (see its own doc comment for the full audit).
+//
+// A backstop that exists but is not wired into a required job is invisible —
+// it keeps compiling, keeps passing its own self-test, and stops being run
+// the moment its CI step is dropped or its job renamed. This pins the one
+// link a PR diff can silently break: the script's invocation inside the
+// `forbid-skip` job of ci.yml (a required status check), and that its
+// self-test — including the "every configured TARGET is currently clean"
+// assertion — passes against the tree as checked in.
+// ciWorkflowPath is shared with lint_cache_test.go.
+const (
+	forbidSkipJobName     = "forbid-skip"
+	structuralGuardScript = "generated-baseline-structural-guard.mjs"
+)
+
+func TestGeneratedBaselineStructuralGuardWired(t *testing.T) {
+	t.Parallel()
+
+	job := workflowJobBody(t, readFileString(t, ciWorkflowPath), forbidSkipJobName)
+	if !strings.Contains(job, structuralGuardScript) {
+		t.Fatalf("%s job %q does not invoke %s — the #1568 structural guard over generated `-merge` "+
+			"baselines is not wired into a required PR check. Body:\n%s",
+			ciWorkflowPath, forbidSkipJobName, structuralGuardScript, job)
+	}
+	if !strings.Contains(job, structuralGuardScript+" --self-test") {
+		t.Fatalf("%s job %q invokes %s without --self-test first — a regression in the guard's own "+
+			"comparison logic (e.g. the sorted-order or duplicate-key check silently inverted) would ship "+
+			"undetected. Body:\n%s",
+			ciWorkflowPath, forbidSkipJobName, structuralGuardScript, job)
+	}
+
+	// The script reads its TARGETS by repo-root-relative path (matching how
+	// ci.yml invokes it — `node .github/scripts/...` from the checkout root),
+	// so it must run with that as its working directory.
+	scriptPath := ".github/scripts/" + structuralGuardScript
+
+	cmd := exec.Command("node", scriptPath, "--self-test")
+	cmd.Dir = repoRoot
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("node %s --self-test failed: %v\n%s", structuralGuardScript, err, out)
+	}
+
+	cmd = exec.Command("node", scriptPath)
+	cmd.Dir = repoRoot
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("node %s reported a structural violation against the committed tree:\n%s", structuralGuardScript, out)
+	}
+}


### PR DESCRIPTION
## Summary

- **Empirical finding for #1568**: GitHub's server-side merge does **not** honour the `.gitattributes` `-merge` driver #1567 relies on. Verified by pushing two throwaway branches to this repo, each inserting one new record at a different, non-overlapping line offset into `test/perf/solver-decision-baseline.json` off the same base commit, and opening a throwaway PR between them (#1668, closed unmerged, both branches deleted immediately after). `gh pr view --json mergeable,mergeStateStatus` reported `"mergeable":"MERGEABLE","mergeStateStatus":"UNSTABLE"` for that PR — while a **local** `git merge` of the identical branch pair, run in a scratch worktree, refused with `Cannot merge binary files` / `CONFLICT (content)`, exactly as `.gitattributes` documents. `-merge` protects local clients only.
- **Audit of what actually protects every `-merge` path today**: nearly all of them already carry a required, PR-blocking, content-exact regenerate-and-diff ratchet — `TestCardinalityRatchet`/`TestSolverDecisionRatchet`/`TestScaleWallPin` (`perf-guards`), `TestCatalogueIsRegenerable` + the surface-parity inventory tests (`check`), `compat-ratchet.mjs` (`compatibility/*`), `coverage-summary.mjs` (`coverage`), and the Tier-0 migration goldens via `go test -tags=migration ./test/e2e/migration/tiers/tier0-offline/...` (`lint`). The "strong" defence #1568 asked for ("re-run the generator on the merge commit and diff it") already existed for most of the list — this was good news worth documenting rather than re-inventing.
- **Residual gap + recommendation**: branch protection's "require branches to be up to date before merging" is currently OFF (`strict: false`), so a stale PR's squash-merge can compute its diff against a `main` that has since moved *without* re-running any of the checks above against the resulting content. Turning `strict: true` on closes that window (it forces "Update branch" to re-run every required check against the exact content that will land). **This PR does not flip that setting** — it's a repo-admin branch-protection change, not a code change, and the harness's own safety classifier declined to let me make it autonomously. Recommending it to @tsouza as a manual follow-up.
- **Defense-in-depth added**: `.github/scripts/generated-baseline-structural-guard.mjs`, wired into the required `forbid-skip` job, is a fast, dependency-free structural pre-filter (unique key, sorted order, and — where hand-verified uniform — one consistent field set) over the `-merge` paths whose invariants I checked by hand against the committed content. It's a cheap second signal, not a replacement for the content-exact ratchets above.
- **One genuine coverage gap found and filed separately** (#1674, not closed by this PR): `test/e2e/playwright/crawl/grafana-surface-inventory.{compose,k3d}.json` are only exercised at full depth by the release-gated `dashboard` (k3d) lane (the merge commit, not the PR), with `compose-smoke` covering only the `lean: true` subset per-PR. Their row order isn't a simple lexical sort (confirmed by hand), so folding them into the new structural guard would have encoded a false invariant — left out rather than guessed at.
- Documents all of the above in `.gitattributes` (a dated, evidenced comment next to the `-merge` entries) and `docs/test-strategy.md` (new subsection under "Generated baselines never auto-merge").

## Test plan

- [x] `node .github/scripts/generated-baseline-structural-guard.mjs --self-test` — passes
- [x] `node .github/scripts/generated-baseline-structural-guard.mjs` — clean against the committed tree (11 checks)
- [x] `go build ./...`
- [x] `go test ./test/regression/...` — includes the new `TestGeneratedBaselineStructuralGuardWired`
- [x] `gofumpt -extra -l` / `goimports -l` — clean
- [x] `markdownlint-cli2` on `.github/scripts/README.md` and `docs/test-strategy.md` — clean
- [x] pre-push lefthook (golangci-lint, forbid-sql-raw, forbid-skip, markdownlint, actionlint) — clean
- [ ] CI (required checks)

Closes #1568