### PR TITLE
fix(e2e): use TimeUnix, not Timestamp, in the metrics stale-row DELETEs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -451,6 +451,8 @@ jobs:
           docker compose logs --tail=200 grafana 2>&1 | tee -a /tmp/compose-state.log || true
           echo "=== otel-collector logs (last 200) ==="
           docker compose logs --tail=200 otel-collector 2>&1 | tee -a /tmp/compose-state.log || true
+          echo "=== seed logs (last 200) ==="
+          docker compose logs --tail=200 seed 2>&1 | tee -a /tmp/compose-state.log || true
           # Infra-flake breadcrumb. Fire ONLY on a REAL disk-full signal —
           # the kernel ENOSPC string in a container log, or root >=90% full.
           # The bare field names
@@ -630,6 +632,8 @@ jobs:
           docker compose logs --tail=200 grafana 2>&1 | tee -a /tmp/compose-state.log || true
           echo "=== otel-collector logs (last 200) ==="
           docker compose logs --tail=200 otel-collector 2>&1 | tee -a /tmp/compose-state.log || true
+          echo "=== seed logs (last 200) ==="
+          docker compose logs --tail=200 seed 2>&1 | tee -a /tmp/compose-state.log || true
           # Fire ONLY on a REAL disk-full signal — the kernel ENOSPC string
           # in a container log, or root >=90% full. The bare field names
           # 'DiskPressure'/'ephemeral-storage' were dropped: they are k8s

--- a/test/e2e/seed/cmd/seed/stale.go
+++ b/test/e2e/seed/cmd/seed/stale.go
@@ -20,7 +20,7 @@ import (
 // tick, unboundedly, for as long as the stack stayed up.
 //
 // The fix mirrors the showcase-traces shape exactly (a data-anchored
-// `max(Timestamp) - margin` DELETE run AFTER the INSERT, never before —
+// `max(<time column>) - margin` DELETE run AFTER the INSERT, never before —
 // see deleteStaleShowcaseTracesSQL's doc comment in showcase_traceql.go
 // for the full race analysis this ordering avoids) for every other
 // family. It accepts the same class of trade-off showcase-traces made:
@@ -117,8 +117,15 @@ var (
 )
 
 // Stale-row DELETEs, one per table these fixtures write to. Each scopes
-// both the outer DELETE and the max(Timestamp) subquery to the
+// both the outer DELETE and the max(<time column>) subquery to the
 // MetricName/ServiceName/TraceId set this seeder owns in that table —
+// the time column itself is NOT uniform across tables: the OTel-CH
+// exporter's schema names it `TimeUnix` on every otel_metrics_* table
+// (matching the INSERT column lists above — insertGaugeSQL et al. never
+// write a `Timestamp` column, because that column doesn't exist there;
+// `DESCRIBE TABLE otel_metrics_gauge` has no `Timestamp` row) and
+// `Timestamp` on otel_logs/otel_traces. The four metrics DELETEs below
+// use TimeUnix; the logs/base-traces DELETEs after them use Timestamp —
 // unscoped would either eat rows the dogfood self-telemetry pipeline
 // wrote into the same table (see showcase_traceql.go / showcase_logql.go
 // doc comments) or anchor the cutoff on foreign rows. The margin is a
@@ -129,32 +136,32 @@ var (
 const (
 	deleteStaleMetricsGaugeSQL = `ALTER TABLE otel_metrics_gauge DELETE
 WHERE MetricName IN ('up', 'target_info', 'showcase_flapping', 'showcase_multilabel')
-  AND Timestamp < (
-    SELECT max(Timestamp) - INTERVAL {margin:UInt64} SECOND
+  AND TimeUnix < (
+    SELECT max(TimeUnix) - INTERVAL {margin:UInt64} SECOND
     FROM otel_metrics_gauge
     WHERE MetricName IN ('up', 'target_info', 'showcase_flapping', 'showcase_multilabel')
   )`
 
 	deleteStaleMetricsSumSQL = `ALTER TABLE otel_metrics_sum DELETE
 WHERE MetricName IN ('http_server_request_duration_count', 'showcase_restarting_total')
-  AND Timestamp < (
-    SELECT max(Timestamp) - INTERVAL {margin:UInt64} SECOND
+  AND TimeUnix < (
+    SELECT max(TimeUnix) - INTERVAL {margin:UInt64} SECOND
     FROM otel_metrics_sum
     WHERE MetricName IN ('http_server_request_duration_count', 'showcase_restarting_total')
   )`
 
 	deleteStaleMetricsHistogramSQL = `ALTER TABLE otel_metrics_histogram DELETE
 WHERE MetricName = 'http_server_request_duration'
-  AND Timestamp < (
-    SELECT max(Timestamp) - INTERVAL {margin:UInt64} SECOND
+  AND TimeUnix < (
+    SELECT max(TimeUnix) - INTERVAL {margin:UInt64} SECOND
     FROM otel_metrics_histogram
     WHERE MetricName = 'http_server_request_duration'
   )`
 
 	deleteStaleMetricsExpHistSQL = `ALTER TABLE otel_metrics_exponential_histogram DELETE
 WHERE MetricName = 'showcase_latency_exp_hist'
-  AND Timestamp < (
-    SELECT max(Timestamp) - INTERVAL {margin:UInt64} SECOND
+  AND TimeUnix < (
+    SELECT max(TimeUnix) - INTERVAL {margin:UInt64} SECOND
     FROM otel_metrics_exponential_histogram
     WHERE MetricName = 'showcase_latency_exp_hist'
   )`


### PR DESCRIPTION
## Summary

- Fix-forward on #1671, which merged before its own `compose-smoke` gate finished — that gate started failing on every shard right after merge, with `cerberus-seed-1` exiting(1) ~17s into every stack boot. Live reproduction (`docker compose up --wait` against the real quickstart stack) surfaced the actual ClickHouse error, which CI's failure-dump never captured: `code: 47, message: Unknown expression or function identifier \`Timestamp\`` while evaluating the gauge-metrics stale-row DELETE.
- Root cause: `stale.go`'s four metrics DELETEs (gauge/sum/histogram/exponential histogram) filtered on a `Timestamp` column that has never existed on those tables. Both the OTel-CH exporter schema and cerberus's own auto-create DDL (`internal/schema/ddl/ddl.go:276`) name the metrics time column `TimeUnix` — only `otel_logs`/`otel_traces` carry `Timestamp`. The INSERTs right next to these DELETEs (`insertGaugeSQL` et al.) already used `TimeUnix`; the mismatch was local to `stale.go`'s WHERE clauses, introduced when #1527's stale-delete cleanup was generalized from the traces-only original to cover every fixture family.
- Fixed by binding the four metrics DELETEs to `TimeUnix` (logs/base-traces DELETEs already correctly used `Timestamp`, unchanged).
- Also closes the CI gap that hid this: the `compose-smoke` failure-dump step dumped `clickhouse`/`cerberus`/`grafana`/`otel-collector` logs but never `seed`, so the real ClickHouse error was invisible in the CI log and needed local reproduction to find. Added `docker compose logs --tail=200 seed` to both the required `compose-smoke-shard` job and its `compose-smoke-shard-info` twin. The k3d `dashboard` lane already tails `/tmp/cerberus-e2e-seed-rolling.log` on failure, so it needed no change there.

## Verification

Live, against the exact `docker-compose.yml` stack `compose-smoke` boots:

- Reproduced the crash on the pre-fix tree: `cerberus-seed-1` exited(1), `docker compose logs seed` showed the `Unknown expression or function identifier \`Timestamp\`` error inside `isZeroOrNull(...)` from the gauge-metrics `ALTER TABLE ... DELETE`.
- Confirmed via `DESCRIBE TABLE otel_metrics_gauge/_sum/_histogram/_exponential_histogram` against the live container that none of the four metrics tables have a `Timestamp` column, only `TimeUnix`; confirmed `otel_logs` does have `Timestamp`.
- Applied the fix, rebuilt, and ran two consecutive fresh `docker compose up --wait --wait-timeout 300` cycles from a clean `down -v` — both times every service (including `seed`) reached `Healthy` on the first pass.
- Let the stack run through 4+ rolling re-seed ticks (`--re-seed-interval=30s`) with zero failures logged.
- `curl /healthz` and `/readyz` both green against the running stack.
- `go build ./test/e2e/seed/...` and `go vet ./test/e2e/seed/...` clean; pre-push hooks (golangci-lint, actionlint, markdownlint, forbid-sql-raw, forbid-skip, commitlint) all passed on push.

## Test plan

- [x] Live `docker compose up --wait` reproduction of the failure (pre-fix)
- [x] Live `docker compose up --wait` verification of the fix, x2 fresh cycles
- [x] Rolling re-seed loop observed for 4+ ticks with no errors
- [x] `go build` / `go vet` on `test/e2e/seed/...`
- [x] Pre-push hooks green (lint, forbid-sql-raw, forbid-skip, commitlint, actionlint, markdownlint)
- [ ] CI: `compose-smoke` (this PR's own run is expected to short-circuit to a no-op per the release-gate posture — the real signal is the next `main` push/merge-commit run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)