### PR TITLE
test(prom): pin the summary-metric exemplars short-circuit at the handler level

### DIFF
--- a/internal/api/prom/exemplars_test.go
+++ b/internal/api/prom/exemplars_test.go
@@ -4,11 +4,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
 
 	"github.com/tsouza/cerberus/internal/api/prom"
+	"github.com/tsouza/cerberus/internal/schema"
 )
 
 // exemplarsResponse mirrors prom.Response specialised to the
@@ -174,6 +176,95 @@ func TestQueryExemplars(t *testing.T) {
 				t.Errorf("exemplars handler did not reach CH; lastSQL is empty")
 			}
 		})
+	}
+}
+
+// newServerWithSchema mounts a prom handler against a caller-supplied
+// schema.Metrics rather than the fixed schema.DefaultOTelMetrics() that
+// newServer wires — needed to exercise routing decisions
+// (exemplarsTableFor's per-family short-circuit) that only trigger when
+// a specific table isn't configured. Mirrors the newServerWith* family
+// in handler_subquery_budget_test.go / handler_query_timeout_test.go.
+func newServerWithSchema(q prom.Querier, s schema.Metrics) *httptest.Server {
+	h := prom.New(q, s, nil)
+	mux := http.NewServeMux()
+	h.Mount(mux)
+	return httptest.NewServer(mux)
+}
+
+// TestQueryExemplars_SummaryMetricShortCircuit pins the
+// exemplarsTableFor short-circuit documented at
+// internal/api/prom/exemplars.go:121-127 ("Summary metrics short-
+// circuit with data:[] since the OTel-CH summary table has no
+// Exemplars column upstream"). Nothing at the handler level asserted
+// this branch before (see issue #1436): exemplars_basic.txtar only
+// carries -- sql -- / -- args -- sections (never executes), and
+// neither exemplars_test.go nor exemplars_chdb_test.go mentioned
+// "summary".
+//
+// exemplarsTableFor has no dedicated SummaryTable case — the OTel-CH
+// summary table is never wired into the routing table at all, so a
+// summary metric's bare quantile-series name (no _bucket/_count/_sum/
+// _total suffix — summaries expose "quantile" as a LABEL, not a name
+// suffix) falls through to the GaugeTable branch. This test wires a
+// schema whose GaugeTable is unconfigured (the shape an operator
+// running only summary + counter instrumentation would have) so that
+// fallthrough resolves to `ok=false` and the handler takes the
+// short-circuit — the same outcome the doc comment promises for
+// summary metrics.
+//
+// The assertion that actually proves the short-circuit fired (rather
+// than a round-trip to CH that just happened to return zero rows,
+// which is what the other "empty result" cases in TestQueryExemplars
+// exercise) is that the stub Querier's QueryExemplars is never
+// invoked: q.lastSQL stays empty because handleQueryExemplars returns
+// before calling chsql.EmitQueryExemplars / h.Client.QueryExemplars.
+func TestQueryExemplars_SummaryMetricShortCircuit(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	s.GaugeTable = ""
+
+	q := &stubQuerier{}
+	srv := newServerWithSchema(q, s)
+	t.Cleanup(srv.Close)
+
+	query := url.Values{
+		"query": {`http_request_duration_seconds{quantile="0.99"}`},
+		"start": {"1717995600"},
+		"end":   {"1717999200"},
+	}
+	resp, err := http.Get(srv.URL + "/api/v1/query_exemplars?" + query.Encode())
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", resp.StatusCode, body)
+	}
+
+	var parsed exemplarsResponse
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v\nbody=%s", err, body)
+	}
+	if parsed.Status != "success" {
+		t.Fatalf("status: got %q, want success; err=%s", parsed.Status, parsed.Error)
+	}
+	if len(parsed.Data) != 0 {
+		t.Fatalf("expected empty data slice for a summary-family metric, got %d entries", len(parsed.Data))
+	}
+	if !strings.Contains(body, `"data":[]`) {
+		t.Errorf("expected JSON to contain `\"data\":[]`; got %s", body)
+	}
+
+	// The load-bearing assertion: the short-circuit returns before ever
+	// calling QueryExemplars. If exemplarsTableFor's routing regressed
+	// to resolve a table for this schema/metric combination, the
+	// handler would instead reach CH (as the ordinary empty-result path
+	// does — see the "lastSQL is empty" check above) and this would
+	// fail even though the response body still looks like data:[].
+	if q.lastSQL != "" {
+		t.Errorf("expected the summary-metric short-circuit to skip CH entirely; got lastSQL=%q", q.lastSQL)
 	}
 }
 


### PR DESCRIPTION
## Summary

`internal/api/prom/exemplars.go`'s `handleQueryExemplars` short-circuits with `200 data:[]` when `exemplarsTableFor` can't resolve a table for the queried metric (e.g. summary metrics — the OTel-CH summary table is never wired into that routing, so it has no dedicated case). Nothing exercised that branch at the handler level:

- `test/spec/promql/exemplars_basic.txtar` only carries `-- sql --` / `-- args --` sections, so it never executes.
- Neither `exemplars_test.go` nor `exemplars_chdb_test.go` mention "summary".
- Only the lower-layer `chsql` rejection (`internal/chsql/query_exemplars_test.go:112-139`) was pinned, which answers a different question (SQL emission refusing the summary table directly) than "does the handler actually take the short-circuit branch for a summary-shaped query."

## Changes

- Add `TestQueryExemplars_SummaryMetricShortCircuit` in `internal/api/prom/exemplars_test.go`. It wires a schema with `GaugeTable` unset (the fallthrough path a bare-name summary quantile series — `http_request_duration_seconds{quantile="0.99"}` — takes, since `exemplarsTableFor` has no `SummaryTable` case) and asserts:
  - `200` status with `"data":[]` in the response body.
  - `q.lastSQL` stays empty — proving `QueryExemplars` is never invoked, i.e. the short-circuit returned *before* reaching CH, not that CH happened to return zero rows.
- Add a small `newServerWithSchema` test helper (mirrors the existing `newServerWith*` family) since the package's fixed `newServer` always wires `schema.DefaultOTelMetrics()`, under which the short-circuit is unreachable for every metrics family.

Verified locally that reverting the short-circuit branch in `exemplarsTableFor` makes the new test fail (asserting on `lastSQL` catching a live CH round-trip), then restored — confirms the test genuinely exercises the intended path rather than passing vacuously.

Closes #1436

## Test plan

- [x] `go test ./internal/api/prom/...` — full package passes.
- [x] `go test ./internal/api/prom/... -run TestQueryExemplars -v` — new test passes.
- [x] Temporarily broke `exemplarsTableFor` to always resolve a table; confirmed the new test fails with the expected `lastSQL` mismatch, then reverted.