### PR TITLE
fix(logql): wire queryShouldSurfaceDetectedLevel to the drop-stage label set

### DIFF
--- a/internal/logql/detected_level.go
+++ b/internal/logql/detected_level.go
@@ -492,17 +492,79 @@ func structuredMetadataExpr(s schema.Logs) chplan.Expr {
 // The function still walks the AST defensively so a `nil` expression
 // (only the metric branch should hit ProjectSamples without an `expr`
 // in [engine.Meta.Extra], but the log branch is the documented caller)
-// returns false rather than panicking. The walk is otherwise a no-op
-// for log queries — every log-shaped expression returns true. Metric
-// queries don't reach this code path (the metric branch in
-// [Lang.ProjectSamples] doesn't consult this gate).
+// returns false rather than panicking. Otherwise every log-shaped
+// expression returns true UNLESS the pipeline itself unconditionally
+// removes `detected_level` from the output label set — see
+// [pipelineDropsDetectedLevel]. Metric queries don't reach this code
+// path (the metric branch in [Lang.ProjectSamples] doesn't consult
+// this gate; narrowing the synthesized identity for `| drop` / `| keep`
+// on the metric path is tracked separately in #1607).
 func queryShouldSurfaceDetectedLevel(expr syntax.Expr) bool {
-	// Every parsed log-stream expression triggers the wrap. The
-	// signature stays AST-aware so future revisions can re-gate
-	// specific shapes (e.g., `| drop detected_level` if/when cerberus
-	// honours the drop-stage label set) without re-plumbing the
-	// projection site. A nil expression (defensive: callers should
-	// always populate `engine.Meta.Extra["expr"]`) opts out so the
-	// wrap doesn't run against an empty AST.
-	return expr != nil
+	if expr == nil {
+		return false
+	}
+	return !pipelineDropsDetectedLevel(expr)
+}
+
+// pipelineDropsDetectedLevel reports whether expr's pipeline
+// UNCONDITIONALLY removes the synthesized `detected_level` label from
+// the output label set — mirroring [newLabelProjectionStep]'s /
+// [narrowIdentityByProjection]'s drop/keep semantics, restricted to the
+// cases that are statically decidable without a row's actual severity
+// value:
+//
+//   - `| drop detected_level` (a bare entry, not a value matcher like
+//     `| drop detected_level="info"` — that only removes the label on
+//     rows whose derived value happens to match, so it can't be decided
+//     up front).
+//   - `| keep <names>` where the kept set is a non-empty, all-bare-name
+//     list that doesn't include `detected_level` — anything not named
+//     is dropped, so `detected_level` never survives.
+//
+// A query with neither shape returns false, matching the previous
+// permissive gate exactly (see queryShouldSurfaceDetectedLevel's doc
+// comment for why the gate stayed permissive by default — the
+// `fast/basic-selectors.yaml` regression). Not consumed by the metric
+// (range-aggregation) path; that gate is #1607.
+func pipelineDropsDetectedLevel(expr syntax.Expr) bool {
+	pipe, ok := expr.(*syntax.PipelineExpr)
+	if !ok {
+		return false
+	}
+	for _, stage := range pipe.MultiStages {
+		switch st := stage.(type) {
+		case *syntax.DropLabelsExpr:
+			for _, m := range st.Matchers() {
+				if m.Matcher == nil && isDetectedLevelLabel(m.Name) {
+					return true
+				}
+			}
+		case *syntax.KeepLabelsExpr:
+			if keepListExcludesDetectedLevel(st.Matchers()) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// keepListExcludesDetectedLevel reports whether a `| keep` stage's
+// entries statically guarantee `detected_level` is absent from the
+// surviving label set: the list must be non-empty (an empty keep list
+// is upstream's "keep everything"), every entry a bare name (a value
+// matcher like `| keep env="prod"` doesn't decide inclusion up front),
+// and none of those names the label.
+func keepListExcludesDetectedLevel(entries []syntax.NamedLabelMatcher) bool {
+	if len(entries) == 0 {
+		return false
+	}
+	for _, e := range entries {
+		if e.Matcher != nil {
+			return false
+		}
+		if isDetectedLevelLabel(e.Name) {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/logql/lang_test.go
+++ b/internal/logql/lang_test.go
@@ -860,3 +860,119 @@ func TestProjectSamples_LogQueryWithDetectedLevelFilterTriggersWrap(t *testing.T
 		})
 	}
 }
+
+// TestProjectSamples_DropDetectedLevelSkipsWrap pins #1547's fix:
+// queryShouldSurfaceDetectedLevel re-gates on whether the pipeline
+// unconditionally drops detected_level from the output label set,
+// instead of the previous inert `expr != nil` check. A bare
+// `| drop detected_level` (or a multi-name drop naming it, or an
+// equivalent `| keep <others>` that excludes it) must skip the
+// withDetectedLevel wrap entirely — the Attributes slot stays the
+// bare ResourceAttributes ColumnRef, matching
+// TestProjectSamples_NoParserStage_KeepsBareResourceAttributes's
+// no-parser-stage shape.
+func TestProjectSamples_DropDetectedLevelSkipsWrap(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelLogs()
+	l := &logql.Lang{Schema: s}
+
+	for _, q := range []string{
+		// bare drop of the canonical name
+		`{job="api"} | drop detected_level`,
+		// detected_level named alongside an unrelated label
+		`{job="api"} | drop env, detected_level`,
+		// keep-list that doesn't name detected_level — everything else
+		// is dropped, detected_level included
+		`{job="api"} | keep job`,
+		`{job="api"} | keep job, env`,
+	} {
+		t.Run(q, func(t *testing.T) {
+			t.Parallel()
+			expr, err := syntax.ParseExpr(q)
+			if err != nil {
+				t.Fatalf("ParseExpr: %v", err)
+			}
+			plan := &chplan.Scan{Table: s.LogsTable}
+			wrapped := l.ProjectSamples(plan, engine.Meta{
+				IsMetric: false,
+				Extra:    map[string]any{"expr": expr},
+			})
+			proj, ok := wrapped.(*chplan.Project)
+			if !ok {
+				t.Fatalf("ProjectSamples returned %T, want *chplan.Project", wrapped)
+			}
+			attrsSlot := proj.Projections[1]
+			if attrsSlot.Alias != "Attributes" {
+				t.Fatalf("attributes slot alias: got %q, want %q", attrsSlot.Alias, "Attributes")
+			}
+			ref, ok := attrsSlot.Expr.(*chplan.ColumnRef)
+			if !ok {
+				t.Fatalf("attributes slot expr for query %q: got %T, want *chplan.ColumnRef "+
+					"(the pipeline unconditionally drops detected_level, so the "+
+					"withDetectedLevel wrap must not run)", q, attrsSlot.Expr)
+			}
+			if ref.Name != s.ResourceAttributesColumn {
+				t.Errorf("attributes slot ColumnRef.Name for query %q: got %q, want %q",
+					q, ref.Name, s.ResourceAttributesColumn)
+			}
+		})
+	}
+}
+
+// TestProjectSamples_DropDetectedLevelStillSurfacesWhenNotUnconditional
+// is the control side of TestProjectSamples_DropDetectedLevelSkipsWrap:
+// shapes that do NOT statically guarantee detected_level is absent
+// from the output must keep triggering the wrap.
+//
+//   - `| drop env` never names detected_level — an unrelated drop must
+//     not suppress the wrap.
+//   - `| drop detected_level="info"` is a value matcher: it only
+//     removes the label on rows whose derived value happens to equal
+//     "info", so the gate can't decide up front and must stay
+//     permissive (dropping the wrap here would make ALL rows lose
+//     detected_level, not just the "info" ones).
+//   - `| keep job, detected_level` explicitly retains the label.
+//   - `| keep job="api"` is a value-matched keep entry — same
+//     can't-decide-statically reasoning as the drop matcher case.
+func TestProjectSamples_DropDetectedLevelStillSurfacesWhenNotUnconditional(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelLogs()
+	l := &logql.Lang{Schema: s}
+
+	for _, q := range []string{
+		`{job="api"} | drop env`,
+		`{job="api"} | drop detected_level="info"`,
+		`{job="api"} | keep job, detected_level`,
+		`{job="api"} | keep job="api"`,
+	} {
+		t.Run(q, func(t *testing.T) {
+			t.Parallel()
+			expr, err := syntax.ParseExpr(q)
+			if err != nil {
+				t.Fatalf("ParseExpr: %v", err)
+			}
+			plan := &chplan.Scan{Table: s.LogsTable}
+			wrapped := l.ProjectSamples(plan, engine.Meta{
+				IsMetric: false,
+				Extra:    map[string]any{"expr": expr},
+			})
+			proj, ok := wrapped.(*chplan.Project)
+			if !ok {
+				t.Fatalf("ProjectSamples returned %T, want *chplan.Project", wrapped)
+			}
+			attrsSlot := proj.Projections[1]
+			fn, ok := attrsSlot.Expr.(*chplan.FuncCall)
+			if !ok {
+				t.Fatalf("attributes slot expr for query %q: got %T, want *chplan.FuncCall "+
+					"(mapConcat) — this shape doesn't statically guarantee "+
+					"detected_level is dropped, so the wrap must still run", q, attrsSlot.Expr)
+			}
+			if fn.Name != "mapConcat" {
+				t.Errorf("attributes slot FuncCall.Name for query %q: got %q, want %q",
+					q, fn.Name, "mapConcat")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`queryShouldSurfaceDetectedLevel` (`internal/logql/detected_level.go`) had degenerated to `return expr != nil` — an always-true predicate whose own doc comment named its precondition for real gating as "cerberus honours the drop-stage label set (`| drop detected_level`)". That precondition is already met on `main`: `lower.go`'s `DropLabelsExpr` handling + `post_process.go`'s `newLabelProjectionStep` correctly strip `detected_level` post-fetch for log queries (and, per `toStreamsWithTransform`, do so *before* streams are grouped, so stream identity is already correct today).

This PR wires the predicate to do real work instead of leaving it inert:

- `queryShouldSurfaceDetectedLevel` now returns `false` (skip the `withDetectedLevel` SQL wrap) when the pipeline **unconditionally** removes `detected_level` from the output label set:
  - a bare `| drop detected_level` (or a multi-name drop naming it), or
  - a `| keep <names>` list that doesn't include it.
- Value-matched entries (`| drop detected_level="info"`, `| keep job="api"`) stay permissive — they only remove the label on rows whose derived value happens to match, so the gate can't decide statically without computing the value first.
- Unrelated drops/keeps (`| drop env`) are unaffected — the wrap still fires.

New helper: `pipelineDropsDetectedLevel` + `keepListExcludesDetectedLevel`.

## Scope note (checked #1607 before starting)

I checked issue #1607 (`logql: | drop / | keep do not apply to the synthetic detected_level label on metric queries`) per the task brief's instruction to verify its state before assuming its precondition applies. **#1607 is still OPEN**, not merged — it's a separate, still-unfixed bug about the **metric / range-aggregation path**, where `withDetectedLevel` is injected unconditionally at `range_aggregation.go` regardless of `queryShouldSurfaceDetectedLevel` (that predicate's sole call site is the **log-query** branch at `lang.go:264`). This PR only touches the log-query call site, which is unaffected by #1607's still-open scope. No change here depends on unmerged code.

## Test plan

- [x] New table-driven unit tests in `internal/logql/lang_test.go`:
  - `TestProjectSamples_DropDetectedLevelSkipsWrap` — `| drop detected_level`, `| drop env, detected_level`, `| keep job`, `| keep job, env` all skip the wrap (bare `ResourceAttributes` ColumnRef).
  - `TestProjectSamples_DropDetectedLevelStillSurfacesWhenNotUnconditional` — `| drop env`, `| drop detected_level="info"`, `| keep job, detected_level`, `| keep job="api"` all still trigger the wrap.
- [x] `go test ./internal/logql/... ./internal/api/loki/... ./test/spec/...` passes.
- [x] `go build ./...` passes.
- [x] `gofumpt -extra -l` clean.
- Note on test placement: the task brief suggested TXTAR fixtures under `test/spec/logql/`, but that harness (`internal/logql/lower_test.go`'s `TestLower`) drives `logql.Lower`/`LowerAt`/`LowerAtRange` directly and never calls `Lang.ProjectSamples` for a plain log query (confirmed by inspecting `pipeline_drop.txtar`, which shows a bare `Filter(Scan)` plan with no `Attributes` wrap at all). `queryShouldSurfaceDetectedLevel`'s only call site is inside `ProjectSamples`, so TXTAR fixtures can't exercise this gate — the existing test suite already covers this function exclusively via Go unit tests in `lang_test.go` (see `TestProjectSamples_BareLogQueryAlsoSurfacesDetectedLevel` et al.), and I followed that established pattern.

Closes #1547

