### PR TITLE
test(promql): cover subquery-shaped out-of-range phi guard

### DIFF
--- a/test/perf/cardinality-baseline.json
+++ b/test/perf/cardinality-baseline.json
@@ -5730,6 +5730,26 @@
     "max_recursion_depth": 0
   },
   {
+    "fixture": "promql/subquery_over_quantile_phi_above_one",
+    "fan_factor": 1.3333333333333333,
+    "scan_rows": 6,
+    "peak_intermediate": 8,
+    "has_cross_join": false,
+    "has_array_join": true,
+    "has_recursive_cte": false,
+    "max_recursion_depth": 0
+  },
+  {
+    "fixture": "promql/subquery_over_quantile_phi_negative",
+    "fan_factor": 1.3333333333333333,
+    "scan_rows": 6,
+    "peak_intermediate": 8,
+    "has_cross_join": false,
+    "has_array_join": true,
+    "has_recursive_cte": false,
+    "max_recursion_depth": 0
+  },
+  {
     "fixture": "promql/subquery_over_rate",
     "fan_factor": 1,
     "scan_rows": 2,

--- a/test/perf/solver-decision-baseline.json
+++ b/test/perf/solver-decision-baseline.json
@@ -3980,6 +3980,26 @@
     "outer_range": "1h0m0s"
   },
   {
+    "query": "subquery_over_quantile_phi_above_one",
+    "routed": false,
+    "k": 0,
+    "reason": "high-D",
+    "n_anchors": 241,
+    "fanout": 240,
+    "cumulative_d": "1h1m0s",
+    "outer_range": "1h0m0s"
+  },
+  {
+    "query": "subquery_over_quantile_phi_negative",
+    "routed": false,
+    "k": 0,
+    "reason": "high-D",
+    "n_anchors": 241,
+    "fanout": 240,
+    "cumulative_d": "1h1m0s",
+    "outer_range": "1h0m0s"
+  },
+  {
     "query": "subquery_over_rate",
     "routed": false,
     "k": 0,

--- a/test/spec/promql/subquery_over_quantile_phi_above_one.txtar
+++ b/test/spec/promql/subquery_over_quantile_phi_above_one.txtar
@@ -1,0 +1,55 @@
+# Regression for #1548: `wrapSubqueryQuantilePhiGuard`'s literal
+# out-of-range-phi branch (internal/promql/subquery.go) had no
+# subquery-shaped fixture — only the non-subquery `quantile(...)`
+# aggregate (quantile_q_above_one.txtar) and an in-range subquery
+# quantile (subquery_over_quantile.txtar) existed. A literal phi > 1
+# must fold to +Inf per Prom's funcQuantile semantics, mirroring
+# subquery_over_quantile.txtar but with an out-of-range phi.
+-- query.promql --
+max_over_time(quantile by(job)(1.5, rate(http_requests_total[1m]))[1h:30s])
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_sum VALUES
+    ('http_requests_total', map('job', 'api', 'instance', 'a'), toDateTime64('2025-12-31 23:59:30', 9), 100.0),
+    ('http_requests_total', map('job', 'api', 'instance', 'a'), toDateTime64('2025-12-31 23:59:45', 9), 110.0),
+    ('http_requests_total', map('job', 'api', 'instance', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 120.0),
+    ('http_requests_total', map('job', 'api', 'instance', 'b'), toDateTime64('2025-12-31 23:59:30', 9), 50.0),
+    ('http_requests_total', map('job', 'api', 'instance', 'b'), toDateTime64('2025-12-31 23:59:45', 9), 55.0),
+    ('http_requests_total', map('job', 'api', 'instance', 'b'), toDateTime64('2026-01-01 00:00:00', 9), 60.0);
+-- expected_rows --
+[
+  [{"job": "api"}, "+Inf"]
+]
+-- args --
+[0] string = "job"
+[1] string = "job"
+[2] float64 = 0.5
+[3] string = "service.name"
+[4] string = "service_name"
+[5] string = "service.name"
+[6] string = "service_name"
+[7] string = ""
+[8] string = "service_name"
+[9] string = "http_requests_total"
+[10] string = "http.requests.total"
+[11] string = "http.requests/total"
+[12] string = "http.requests_total"
+[13] string = "http/requests/total"
+[14] string = "http/requests_total"
+[15] string = "http_requests.total"
+-- chplan --
+RangeWindow func=max_over_time range=1h0m0s step=0s ts=anchor_ts value=Value groupBy=[Attributes] start=0001-01-01T00:00:00Z end=2026-01-01T00:00:01Z
+  Project [Attributes AS Attributes, anchor_ts AS anchor_ts, anchor_ts AS TimeUnix, +Inf AS Value]
+    Project [map("job", gkey_0) AS Attributes, anchor_ts AS anchor_ts, anchor_ts AS TimeUnix, toFloat64(Value) AS Value]
+      Aggregate groupBy=[Attributes["job"] AS gkey_0, anchor_ts AS anchor_ts] funcs=[quantile(0.5)(Value) AS Value]
+        RangeWindow func=rate range=1m0s step=30s outerRange=1h0m0s ts=TimeUnix value=Value groupBy=[Attributes] start=2025-12-31T23:00:01Z end=2026-01-01T00:00:01Z
+          Project [MetricName AS MetricName, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, Value AS Value]
+            Filter predicate=(MetricName IN ("http_requests_total", "http.requests.total", "http.requests/total", "http.requests_total", "http/requests/total", "http/requests_total", "http_requests.total"))
+              Scan(otel_metrics_sum)
+-- sql --
+SELECT `Attributes`, max(`Value`) AS `Value` FROM (SELECT `Attributes` AS `Attributes`, `anchor_ts` AS `anchor_ts`, `anchor_ts` AS `TimeUnix`, (1.0/0) AS `Value` FROM (SELECT map(?, `gkey_0`) AS `Attributes`, `anchor_ts` AS `anchor_ts`, `anchor_ts` AS `TimeUnix`, toFloat64(`Value`) AS `Value` FROM (SELECT `Attributes`[?] AS `gkey_0`, `anchor_ts` AS `anchor_ts`, quantile(toFloat64(?))(`Value`) AS `Value` FROM (SELECT `Attributes`, `anchor_ts`, anchor_ts AS `TimeUnix`, if(sampled_interval > 0, counter_delta * (sampled_interval + if(counter_delta > 0 AND first_val >= 0, least(duration_to_start, sampled_interval * first_val / counter_delta), duration_to_start) + duration_to_end) / sampled_interval / 60, nan) AS `Value` FROM (SELECT `Attributes`, `anchor_ts`, `window_vals`, `counter_delta`, `first_val`, toFloat64(dateDiff('nanosecond', first_ts, last_ts)) / 1e9 AS `sampled_interval`, if(toFloat64(dateDiff('nanosecond', anchor_ts - toIntervalNanosecond(60000000000), first_ts)) / 1e9 >= 1.1 * sampled_interval / (length(window_vals) - 1), sampled_interval / (length(window_vals) - 1) / 2, toFloat64(dateDiff('nanosecond', anchor_ts - toIntervalNanosecond(60000000000), first_ts)) / 1e9) AS `duration_to_start`, if(toFloat64(dateDiff('nanosecond', last_ts, anchor_ts)) / 1e9 >= 1.1 * sampled_interval / (length(window_vals) - 1), sampled_interval / (length(window_vals) - 1) / 2, toFloat64(dateDiff('nanosecond', last_ts, anchor_ts)) / 1e9) AS `duration_to_end` FROM (SELECT `Attributes`, `anchor_ts`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta`, tupleElement(window_pairs[1], 1) AS `first_ts`, tupleElement(window_pairs[length(window_pairs)], 1) AS `last_ts`, tupleElement(window_pairs[1], 2) AS `first_val` FROM (SELECT `Attributes`, `anchor_ts`, arrayReverse(arrayCompact(p -> tupleElement(p, 1), arrayReverse(window_pairs))) AS `window_pairs` FROM (SELECT `Attributes`, `anchor_ts`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `window_pairs` FROM (SELECT `Attributes`, `TimeUnix`, `Value`, arrayJoin(arrayMap(i -> fromUnixTimestamp64Nano(intDiv(toUnixTimestamp64Nano(toDateTime64('2026-01-01 00:00:01.000000000', 9)), 30000000000) * 30000000000) - toIntervalNanosecond(i * 30000000000), range(greatest(0, intDiv(dateDiff('nanosecond', `TimeUnix`, fromUnixTimestamp64Nano(intDiv(toUnixTimestamp64Nano(toDateTime64('2026-01-01 00:00:01.000000000', 9)), 30000000000) * 30000000000)) - 60000000000, toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, fromUnixTimestamp64Nano(intDiv(toUnixTimestamp64Nano(toDateTime64('2026-01-01 00:00:01.000000000', 9)), 30000000000) * 30000000000)) - 60000000000, toInt64(30000000000)) < 0) + 1), least(120, intDiv(dateDiff('nanosecond', `TimeUnix`, fromUnixTimestamp64Nano(intDiv(toUnixTimestamp64Nano(toDateTime64('2026-01-01 00:00:01.000000000', 9)), 30000000000) * 30000000000)), toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, fromUnixTimestamp64Nano(intDiv(toUnixTimestamp64Nano(toDateTime64('2026-01-01 00:00:01.000000000', 9)), 30000000000) * 30000000000)), toInt64(30000000000)) < 0) + 1)))) AS `anchor_ts` FROM (SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?)))) WHERE `TimeUnix` > toDateTime64('2025-12-31 23:00:01.000000000', 9) - toIntervalNanosecond(60000000000) AND `TimeUnix` <= toDateTime64('2026-01-01 00:00:01.000000000', 9)) GROUP BY `Attributes`, `anchor_ts`)))) WHERE length(`window_vals`) >= 2) GROUP BY `gkey_0`, `anchor_ts`))) WHERE `anchor_ts` > toDateTime64('2026-01-01 00:00:01.000000000', 9) - toIntervalNanosecond(3600000000000) AND `anchor_ts` <= toDateTime64('2026-01-01 00:00:01.000000000', 9) GROUP BY `Attributes`

--- a/test/spec/promql/subquery_over_quantile_phi_negative.txtar
+++ b/test/spec/promql/subquery_over_quantile_phi_negative.txtar
@@ -1,0 +1,55 @@
+# Regression for #1548: `wrapSubqueryQuantilePhiGuard`'s literal
+# out-of-range-phi branch (internal/promql/subquery.go) had no
+# subquery-shaped fixture — only the non-subquery `quantile(...)`
+# aggregate (quantile_q_negative.txtar) and an in-range subquery
+# quantile (subquery_over_quantile.txtar) existed. A literal phi < 0
+# must fold to -Inf per Prom's funcQuantile semantics, mirroring
+# subquery_over_quantile.txtar but with an out-of-range phi.
+-- query.promql --
+max_over_time(quantile by(job)(-0.5, rate(http_requests_total[1m]))[1h:30s])
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_sum VALUES
+    ('http_requests_total', map('job', 'api', 'instance', 'a'), toDateTime64('2025-12-31 23:59:30', 9), 100.0),
+    ('http_requests_total', map('job', 'api', 'instance', 'a'), toDateTime64('2025-12-31 23:59:45', 9), 110.0),
+    ('http_requests_total', map('job', 'api', 'instance', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 120.0),
+    ('http_requests_total', map('job', 'api', 'instance', 'b'), toDateTime64('2025-12-31 23:59:30', 9), 50.0),
+    ('http_requests_total', map('job', 'api', 'instance', 'b'), toDateTime64('2025-12-31 23:59:45', 9), 55.0),
+    ('http_requests_total', map('job', 'api', 'instance', 'b'), toDateTime64('2026-01-01 00:00:00', 9), 60.0);
+-- expected_rows --
+[
+  [{"job": "api"}, "-Inf"]
+]
+-- args --
+[0] string = "job"
+[1] string = "job"
+[2] float64 = 0.5
+[3] string = "service.name"
+[4] string = "service_name"
+[5] string = "service.name"
+[6] string = "service_name"
+[7] string = ""
+[8] string = "service_name"
+[9] string = "http_requests_total"
+[10] string = "http.requests.total"
+[11] string = "http.requests/total"
+[12] string = "http.requests_total"
+[13] string = "http/requests/total"
+[14] string = "http/requests_total"
+[15] string = "http_requests.total"
+-- chplan --
+RangeWindow func=max_over_time range=1h0m0s step=0s ts=anchor_ts value=Value groupBy=[Attributes] start=0001-01-01T00:00:00Z end=2026-01-01T00:00:01Z
+  Project [Attributes AS Attributes, anchor_ts AS anchor_ts, anchor_ts AS TimeUnix, -Inf AS Value]
+    Project [map("job", gkey_0) AS Attributes, anchor_ts AS anchor_ts, anchor_ts AS TimeUnix, toFloat64(Value) AS Value]
+      Aggregate groupBy=[Attributes["job"] AS gkey_0, anchor_ts AS anchor_ts] funcs=[quantile(0.5)(Value) AS Value]
+        RangeWindow func=rate range=1m0s step=30s outerRange=1h0m0s ts=TimeUnix value=Value groupBy=[Attributes] start=2025-12-31T23:00:01Z end=2026-01-01T00:00:01Z
+          Project [MetricName AS MetricName, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, Value AS Value]
+            Filter predicate=(MetricName IN ("http_requests_total", "http.requests.total", "http.requests/total", "http.requests_total", "http/requests/total", "http/requests_total", "http_requests.total"))
+              Scan(otel_metrics_sum)
+-- sql --
+SELECT `Attributes`, max(`Value`) AS `Value` FROM (SELECT `Attributes` AS `Attributes`, `anchor_ts` AS `anchor_ts`, `anchor_ts` AS `TimeUnix`, (-1.0/0) AS `Value` FROM (SELECT map(?, `gkey_0`) AS `Attributes`, `anchor_ts` AS `anchor_ts`, `anchor_ts` AS `TimeUnix`, toFloat64(`Value`) AS `Value` FROM (SELECT `Attributes`[?] AS `gkey_0`, `anchor_ts` AS `anchor_ts`, quantile(toFloat64(?))(`Value`) AS `Value` FROM (SELECT `Attributes`, `anchor_ts`, anchor_ts AS `TimeUnix`, if(sampled_interval > 0, counter_delta * (sampled_interval + if(counter_delta > 0 AND first_val >= 0, least(duration_to_start, sampled_interval * first_val / counter_delta), duration_to_start) + duration_to_end) / sampled_interval / 60, nan) AS `Value` FROM (SELECT `Attributes`, `anchor_ts`, `window_vals`, `counter_delta`, `first_val`, toFloat64(dateDiff('nanosecond', first_ts, last_ts)) / 1e9 AS `sampled_interval`, if(toFloat64(dateDiff('nanosecond', anchor_ts - toIntervalNanosecond(60000000000), first_ts)) / 1e9 >= 1.1 * sampled_interval / (length(window_vals) - 1), sampled_interval / (length(window_vals) - 1) / 2, toFloat64(dateDiff('nanosecond', anchor_ts - toIntervalNanosecond(60000000000), first_ts)) / 1e9) AS `duration_to_start`, if(toFloat64(dateDiff('nanosecond', last_ts, anchor_ts)) / 1e9 >= 1.1 * sampled_interval / (length(window_vals) - 1), sampled_interval / (length(window_vals) - 1) / 2, toFloat64(dateDiff('nanosecond', last_ts, anchor_ts)) / 1e9) AS `duration_to_end` FROM (SELECT `Attributes`, `anchor_ts`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta`, tupleElement(window_pairs[1], 1) AS `first_ts`, tupleElement(window_pairs[length(window_pairs)], 1) AS `last_ts`, tupleElement(window_pairs[1], 2) AS `first_val` FROM (SELECT `Attributes`, `anchor_ts`, arrayReverse(arrayCompact(p -> tupleElement(p, 1), arrayReverse(window_pairs))) AS `window_pairs` FROM (SELECT `Attributes`, `anchor_ts`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `window_pairs` FROM (SELECT `Attributes`, `TimeUnix`, `Value`, arrayJoin(arrayMap(i -> fromUnixTimestamp64Nano(intDiv(toUnixTimestamp64Nano(toDateTime64('2026-01-01 00:00:01.000000000', 9)), 30000000000) * 30000000000) - toIntervalNanosecond(i * 30000000000), range(greatest(0, intDiv(dateDiff('nanosecond', `TimeUnix`, fromUnixTimestamp64Nano(intDiv(toUnixTimestamp64Nano(toDateTime64('2026-01-01 00:00:01.000000000', 9)), 30000000000) * 30000000000)) - 60000000000, toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, fromUnixTimestamp64Nano(intDiv(toUnixTimestamp64Nano(toDateTime64('2026-01-01 00:00:01.000000000', 9)), 30000000000) * 30000000000)) - 60000000000, toInt64(30000000000)) < 0) + 1), least(120, intDiv(dateDiff('nanosecond', `TimeUnix`, fromUnixTimestamp64Nano(intDiv(toUnixTimestamp64Nano(toDateTime64('2026-01-01 00:00:01.000000000', 9)), 30000000000) * 30000000000)), toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, fromUnixTimestamp64Nano(intDiv(toUnixTimestamp64Nano(toDateTime64('2026-01-01 00:00:01.000000000', 9)), 30000000000) * 30000000000)), toInt64(30000000000)) < 0) + 1)))) AS `anchor_ts` FROM (SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?)))) WHERE `TimeUnix` > toDateTime64('2025-12-31 23:00:01.000000000', 9) - toIntervalNanosecond(60000000000) AND `TimeUnix` <= toDateTime64('2026-01-01 00:00:01.000000000', 9)) GROUP BY `Attributes`, `anchor_ts`)))) WHERE length(`window_vals`) >= 2) GROUP BY `gkey_0`, `anchor_ts`))) WHERE `anchor_ts` > toDateTime64('2026-01-01 00:00:01.000000000', 9) - toIntervalNanosecond(3600000000000) AND `anchor_ts` <= toDateTime64('2026-01-01 00:00:01.000000000', 9) GROUP BY `Attributes`


### PR DESCRIPTION
## Summary

- `wrapSubqueryQuantilePhiGuard`'s literal out-of-range-phi branch (`internal/promql/subquery.go`) had zero fixture coverage. The only subquery-quantile fixture (`subquery_over_quantile.txtar`) used an in-range phi (`0.5`), and the only out-of-range-phi fixtures (`quantile_over_time_q_above_one.txtar` / `quantile_over_time_q_negative.txtar`) exercise plain instant aggregations, not subqueries. A near-miss fixture (`subquery_quantile_scalar_phi.txtar`) covers a *computed* phi via `scalar(...)`, but that phi is in-range and takes the runtime `outOfRangePhiGuardExpr` path rather than the compile-time literal fold.
- Added two fixtures: `subquery_over_quantile_phi_above_one.txtar` (`quantile by(job)(1.5, rate(...))[1h:30s]`) and `subquery_over_quantile_phi_negative.txtar` (same query with phi `-0.5`), each with `-- seed --` / `-- expected_rows --` so the fixture executes against chDB and asserts the actual returned value, not just the generated SQL text.
- Ran both fixtures through `TestLower` (SQL/plan golden check) and `TestRoundTripChDB` (actual chDB execution): both pass, returning `+Inf` for phi=1.5 and `-Inf` for phi=-0.5 — the correct signed Inf per Prometheus's `funcQuantile` semantics. **No bug found** — this closes a genuine test-coverage gap; the existing guard logic was already sound, but nothing in the suite could have caught a regression in it (inverted comparison, swapped sign, or a deleted branch) before this PR.

## Test plan

- [x] `go test ./internal/promql/... -tags chdb` — all fixtures (including the two new ones) pass the SQL/plan golden check.
- [x] `go test ./test/spec/promql/... -run TestRoundTripChDB -tags chdb` — both new fixtures execute against an in-process chDB session and match `expected_rows` (`+Inf` / `-Inf`).
- [x] `just update-golden` run once to fill in `sql` / `args` / `chplan` / `expected_rows` sections plus the `test/perf/solver-decision-baseline.json` and `test/perf/cardinality-baseline.json` entries the new fixtures add.
- [x] `go build ./...` clean.

Closes #1548

🤖 Generated with [Claude Code](https://claude.com/claude-code)