### PR TITLE
fix(compat/loki): seed a generic structured-metadata key and diff it

### DIFF
--- a/.github/scripts/compat-ratchet.mjs
+++ b/.github/scripts/compat-ratchet.mjs
@@ -21,7 +21,7 @@
 // accident of the current numbers — a diff against a reference backend
 // is a bug to fix at the source, so there is no shape in this file that
 // can record a divergence as acceptable. The floors are prometheus
-// 739/739, loki 120/120, tempo 49/49, tempo-grpc 47/47; doc-counts.mjs
+// 739/739, loki 124/124, tempo 49/49, tempo-grpc 47/47; doc-counts.mjs
 // asserts those numbers against compatibility/parity-baseline.json, so
 // a corpus change cannot leave this comment behind. tempo-grpc's floor
 // is 2 below tempo's: traces / traces_v2 have no StreamingQuerier RPC

--- a/compatibility/loki/cerberus-queries/README.md
+++ b/compatibility/loki/cerberus-queries/README.md
@@ -46,6 +46,9 @@ cerberus-queries/
                           currently empty (see fast/README.md)
   regression/
     unpack.yaml           | unpack differential coverage (issue #1611)
+    structured-metadata-generic.yaml
+                          generic (non-detected_level) structured-
+                          metadata differential coverage (issue #1498)
   exhaustive/             suite dir required by QueryRegistry.Load;
                           currently empty (see exhaustive/README.md)
 ```

--- a/compatibility/loki/cerberus-queries/regression/structured-metadata-generic.yaml
+++ b/compatibility/loki/cerberus-queries/regression/structured-metadata-generic.yaml
@@ -1,0 +1,99 @@
+# yaml-language-server: $schema=../../upstream/loki-bench/queries/schema.json
+---
+# Generic (non-detected_level) structured-metadata differential
+# coverage — see issue #1498.
+#
+# Before this file, the seeder (compatibility/loki/cmd/seed/main.go)
+# stamped exactly one structured-metadata key — `detected_level`, a
+# synthesized, small-closed-set severity discriminant — into both
+# ClickHouse's LogAttributes and the reference Loki push. Structured
+# metadata is a first-class Loki label source (selectors, `|
+# label_filter`, metric-query grouping, /detected_fields), so every
+# path exercising an ARBITRARY key — the far more common real-world
+# OTel/Loki shape (correlation ids, free-form annotations, ...) — ran
+# with zero differential coverage.
+#
+# generateRequestID (cmd/seed/main.go) now stamps a second key,
+# `request_id`, on ONE dedicated stream (`metadata-probe`): an
+# unconstrained-value-domain correlation id present on 2 of every 3
+# entries (see requestIDAbsenceEvery) and absent on the third.
+# request_id is deliberately confined to that single stream rather than
+# riding along on every seeded service — see metadataProbeFormat's doc
+# comment in cmd/seed/main.go. Reference Loki folds any structured-
+# metadata value a matching line carries directly into that line's
+# output identity (log-query stream labels, ungrouped metric series
+# `metric` map), so a SECOND, high-cardinality key present broadly
+# would reshape the output of dozens of pre-existing corpus cases that
+# have nothing to do with structured metadata (confirmed locally: an
+# earlier revision that stamped request_id on every service turned 41
+# previously-passing cases into diffs). metadata-probe mirrors
+# packed-source's isolation trick (an unmatched `log_format`, so the
+# vendored corpus's `${SELECTOR}` resolver never picks it) precisely so
+# the cases below are the only queries in the whole differential corpus
+# that ever observe request_id.
+#
+# /detected_fields parity for request_id is already covered without a
+# corpus entry: compareDetectedFieldsAll (cmd/loki-compliance-tester/
+# detected_fields.go) diffs the FULL field set both backends return
+# per service, generically — no per-key allow-list — so it picks up
+# metadata-probe's request_id automatically now that the seeder stamps
+# it.
+#
+# A `kind: log` case filtering on request_id being PRESENT is
+# deliberately NOT included here (mirroring how
+# cerberus-queries/regression/unpack.yaml left a metric-mode case out
+# for issue #1652 rather than gate this required check on an unrelated,
+# unmade fix). Reference Loki folds any structured-metadata value a
+# matching line carries directly into that line's output STREAM label
+# set — even for a single matching line, i.e. this isn't a
+# cardinality/fragmentation artefact — while cerberus only does this
+# for the hardcoded `detected_level` key (see
+# queryShouldSurfaceDetectedLevel / internal/logql/detected_level.go);
+# a generic key like request_id never reaches a log query's output
+# stream identity at all. That's a real, separate gap, filed as issue
+# #1684 rather than worked around here. The `absent` case below stays
+# in-corpus because it doesn't trip the gap: when request_id is truly
+# absent there is nothing for either backend to fold into stream
+# identity, so the two agree.
+queries:
+  - description: stream selector referencing a structured-metadata-only key matches nothing on both backends
+    query: '{request_id="req-00000000"}'
+    kind: log
+    time_range:
+      length: 24h
+    directions: both
+    tags:
+      - structured-metadata
+      - generic
+      - rejection-parity
+      - empty-result
+    notes: >-
+      request_id is structured metadata, never an indexed stream
+      label — reference Loki's `{}` stream selector only consults the
+      index (stream labels), never structured metadata, so this must
+      resolve to zero results on both backends rather than erroring or
+      silently matching.
+
+  - description: generic structured-metadata label filter - absent resolves to empty string
+    query: '{service_name="metadata-probe"} | request_id=""'
+    kind: log
+    time_range:
+      length: 24h
+    directions: backward # forward log queries over structured metadata unsupported by v2 engine (mirrors the detected_level cases in upstream/loki-bench/queries/fast/structured-metadata.yaml)
+    tags:
+      - structured-metadata
+      - generic
+      - filter
+      - absent
+
+  - description: metric query grouped by a generic, unconstrained-value-domain structured-metadata key
+    query: sum by (request_id) (count_over_time({service_name="metadata-probe"}[24h]))
+    kind: metric
+    time_range:
+      length: 24h
+      step: 1h
+    tags:
+      - structured-metadata
+      - generic
+      - metric
+      - grouping

--- a/compatibility/loki/cmd/loki-compliance-tester/main_test.go
+++ b/compatibility/loki/cmd/loki-compliance-tester/main_test.go
@@ -125,7 +125,13 @@ func TestCheckExpansion(t *testing.T) {
 // query definitions (2 cases each) — a metric-mode third case was
 // deliberately left out (issue #1652: metric-mode grouping/filtering
 // by an unpack-extracted label is a separate, unfixed gap) — for a
-// total of 90.
+// total of 90. cerberus-queries/regression/structured-metadata-generic.yaml
+// (issue #1498) then adds a 5th definition set: one `directions: both`
+// log query (2 cases) plus one `directions: backward` log query (1
+// case) plus one metric query (1 case) — a `kind: log` "generic key
+// present" case was deliberately left out (issue #1684: log-query
+// stream-identity fragmentation over a generic structured-metadata key
+// is a separate, unfixed gap) — for +4, a total of 94.
 func TestLoadCases_FullCorpusExpansion(t *testing.T) {
 	t.Parallel()
 	f := flags{
@@ -138,8 +144,8 @@ func TestLoadCases_FullCorpusExpansion(t *testing.T) {
 	if err != nil {
 		t.Fatalf("loadCases: %v", err)
 	}
-	if len(cases) != 90 {
-		t.Fatalf("corpus expanded to %d cases, want 90", len(cases))
+	if len(cases) != 94 {
+		t.Fatalf("corpus expanded to %d cases, want 94", len(cases))
 	}
 
 	revived := []string{

--- a/compatibility/loki/cmd/seed/main.go
+++ b/compatibility/loki/cmd/seed/main.go
@@ -33,12 +33,46 @@ const entryInterval = 1 * time.Minute
 
 const seedValue = int64(42)
 
+// requestIDSeed seeds the PRNG generateRequestID draws from — a value
+// distinct from seedValue so the two draw streams stay independent (see
+// buildStreams).
+const requestIDSeed = int64(1498)
+
+// requestIDAbsenceEvery gates generateRequestID: one entry in every
+// requestIDAbsenceEvery carries NO request_id structured-metadata key
+// at all, the rest carry a distinct one. detected_level is present on
+// every row (it's a synthesized severity discriminant); request_id
+// models the far more common OTel/Loki shape — a generic, arbitrary
+// correlation id that's only sometimes attached — so leaving a
+// deterministic gap keeps the "absent on some entries" half of issue
+// #1498's fix honest rather than accidentally seeding it as universal.
+const requestIDAbsenceEvery = 3
+
 // packedFormat identifies packed-source's stream format: entries cycle
 // through the four payload shapes `| unpack` must discriminate (see
 // generatePackedLine). It is not one of the three formats
 // LogFormat/QueryRequirements.log_format recognises (json/logfmt/
 // unstructured) because none of them describe a Promtail-pack payload.
 const packedFormat = "packed"
+
+// metadataProbeFormat identifies metadata-probe's stream format, the
+// ONLY seeded stream that carries the generic `request_id`
+// structured-metadata key (see generateRequestID / issue #1498). Like
+// packedFormat, it is deliberately NOT one of the three formats
+// LogFormat/QueryRequirements.log_format recognises (json/logfmt/
+// unstructured): the vendored corpus's `${SELECTOR}` resolver picks a
+// stream at random from whichever ones satisfy a case's `requires:`
+// bounds, and reference Loki folds structured-metadata values directly
+// into a log/metric query's output identity (stream labels / ungrouped
+// series `metric` map) — so a resolver-selected stream that
+// unexpectedly carries a SECOND, high-cardinality structured-metadata
+// key would silently reshape the output of every EXISTING corpus case
+// that happens to land on it, with no relation to what that case
+// actually tests. Keeping request_id off the log_format enum blocks
+// the resolver from ever picking metadata-probe; only this file's own
+// LITERAL-selector cerberus-queries corpus (which names the stream
+// explicitly) ever queries it.
+const metadataProbeFormat = "metadata-probe"
 
 type serviceConfig struct {
 	Name        string
@@ -72,6 +106,11 @@ var serviceConfigs = []serviceConfig{
 	// every other service's JSON lines are plain structured logs that
 	// `| unpack` would either no-op on or reject, never extract from.
 	{Name: "packed-source", ServiceName: "packed-source", Format: packedFormat, Cluster: "cluster-1", Namespace: "namespace-5", Pod: "pod-13", Container: "container-1"},
+	// metadata-probe is the ONLY seeded stream carrying the generic
+	// `request_id` structured-metadata key — see metadataProbeFormat's
+	// doc comment for why request_id can't safely ride along on any of
+	// the streams above.
+	{Name: "metadata-probe", ServiceName: "metadata-probe", Format: metadataProbeFormat, Cluster: "cluster-1", Namespace: "namespace-6", Pod: "pod-14", Container: "container-1"},
 }
 
 var (
@@ -249,13 +288,25 @@ type stream struct {
 }
 
 type entry struct {
-	ts    time.Time
-	level string
-	line  string
+	ts        time.Time
+	level     string
+	line      string
+	requestID string // "" means absent — see generateRequestID.
 }
 
 func buildStreams(start time.Time) []stream {
 	rng := rand.New(rand.NewSource(seedValue)) //nolint:gosec
+	// requestIDRng is deliberately a SEPARATE PRNG stream from rng, seeded
+	// with its own constant, rather than drawing request_id values from
+	// rng inline alongside level / line-content generation. Every other
+	// generator below (generateJSONLine, generateLogfmtLine, ...) draws
+	// its random content from `rng` in a fixed, load-bearing sequence
+	// that OTHER corpus cases pin exact values against (client_ip CIDR
+	// membership, error-message selection, ...); interleaving even one
+	// extra conditional rng.Uint32() draw per entry would shift every
+	// later draw in the shared sequence and silently reshape unrelated
+	// seeded content. See issue #1498.
+	requestIDRng := rand.New(rand.NewSource(requestIDSeed)) //nolint:gosec
 	levels := []string{"INFO", "WARN", "ERROR", "DEBUG"}
 	out := make([]stream, 0, len(serviceConfigs))
 
@@ -281,6 +332,13 @@ func buildStreams(start time.Time) []stream {
 		for i := 0; i < entriesPerService; i++ {
 			ts := start.Add(time.Duration(i) * entryInterval)
 			level := levels[rng.Intn(len(levels))]
+			// request_id is scoped to metadata-probe ONLY — see
+			// metadataProbeFormat's doc comment for why it can't ride
+			// along on any of the other seeded streams.
+			var requestID string
+			if sc.Format == metadataProbeFormat {
+				requestID = generateRequestID(requestIDRng, i)
+			}
 			var line string
 			switch sc.Format {
 			case "json":
@@ -289,14 +347,38 @@ func buildStreams(start time.Time) []stream {
 				line = generateLogfmtLine(sc.Name, level, ts, rng, i)
 			case packedFormat:
 				line = generatePackedLine(level, i)
+			case metadataProbeFormat:
+				// Reuses generateJSONLine's own default arm (svc name
+				// "metadata-probe" matches none of its named cases) —
+				// realistic JSON content, no bespoke generator needed.
+				line = generateJSONLine(sc.Name, level, ts, rng, i)
 			default:
 				line = generateUnstructuredLine(sc.Name, level, ts, rng, i)
 			}
-			s.entries = append(s.entries, entry{ts: ts, level: level, line: line})
+			s.entries = append(s.entries, entry{ts: ts, level: level, line: line, requestID: requestID})
 		}
 		out = append(out, s)
 	}
 	return out
+}
+
+// generateRequestID returns a generic structured-metadata value for the
+// entry at index idx — a synthetic per-record correlation id, the
+// unconstrained-value-domain twin of the small, closed-set
+// `detected_level` — or "" when this entry should carry no request_id
+// key at all (see requestIDAbsenceEvery). Unlike detected_level
+// (derived from severity), the value here is unbounded and
+// content-free: it exists purely to exercise generic structured
+// metadata — selectors, `| label_filter`, and metric-query `by(...)`
+// grouping over an arbitrary key — the gap issue #1498 identified
+// (compatibility/loki/cmd/seed/main.go previously stamped
+// detected_level only, so every non-detected_level structured-metadata
+// path went undiffed against reference Loki).
+func generateRequestID(rng *rand.Rand, idx int) string {
+	if idx%requestIDAbsenceEvery == 0 {
+		return ""
+	}
+	return fmt.Sprintf("req-%08x", rng.Uint32())
 }
 
 func generateJSONLine(svc, level string, ts time.Time, rng *rand.Rand, idx int) string {
@@ -613,14 +695,26 @@ func insertCHLogs(ctx context.Context, conn driver.Conn, streams []stream) error
 			level := e.level
 			// LogAttributes carries per-record attributes — the OTel-CH
 			// analogue of Loki's structured metadata. The key set MUST
-			// mirror what pushLoki sends as structured metadata
-			// (detected_level only): the /detected_fields differential
-			// compares the two backends' structured-metadata-derived
-			// fields, so any CH-only key here would surface as a
-			// permanent parity diff. Stream labels live in
-			// resourceAttrs above, not here.
+			// mirror what pushLoki sends as structured metadata: the
+			// /detected_fields differential compares the two backends'
+			// structured-metadata-derived fields, so any CH-only key
+			// here would surface as a permanent parity diff. Stream
+			// labels live in resourceAttrs above, not here.
+			//
+			// Two keys are stamped: detected_level (synthesized,
+			// present on every row, small closed value set) and
+			// request_id (generic, unconstrained value domain,
+			// non-empty only on metadata-probe's rows per
+			// generateRequestID / e.requestID's scoping — see
+			// metadataProbeFormat) — see issue #1498, which found the
+			// seeder previously carried detected_level only, leaving
+			// every generic structured-metadata path undiffed against
+			// reference Loki.
 			logAttrs := map[string]string{
 				"detected_level": strings.ToLower(level),
+			}
+			if e.requestID != "" {
+				logAttrs["request_id"] = e.requestID
 			}
 			if err := batch.Append(
 				e.ts,
@@ -683,9 +777,15 @@ func pushLoki(ctx context.Context, baseURL string, streams []stream) error {
 			var sm []logproto.LabelAdapter
 			lvl := strings.ToLower(e.level)
 			if lvl != "" {
-				sm = []logproto.LabelAdapter{
-					{Name: "detected_level", Value: lvl},
-				}
+				sm = append(sm, logproto.LabelAdapter{Name: "detected_level", Value: lvl})
+			}
+			// request_id is the generic-structured-metadata twin of
+			// detected_level (see generateRequestID / issue #1498):
+			// unconstrained value domain, absent on some entries. Must
+			// stay in lockstep with insertCHLogs' logAttrs so the
+			// /detected_fields differential compares like-for-like.
+			if e.requestID != "" {
+				sm = append(sm, logproto.LabelAdapter{Name: "request_id", Value: e.requestID})
 			}
 			entries = append(entries, logproto.Entry{
 				Timestamp:          e.ts,

--- a/compatibility/parity-baseline.json
+++ b/compatibility/parity-baseline.json
@@ -748,8 +748,8 @@
       ]
     },
     "loki": {
-      "passed": 120,
-      "total": 120,
+      "passed": 124,
+      "total": 124,
       "cases": [
         "cerberus/wrong-rejection-burndown | log | range | BACKWARD | {cluster=\"cluster-0\", container=\"container-0\", datacenter=\"dc1\", env=\"production\", namespace=\"namespace-0\", pod=\"pod-0\", region=\"us-east-1\", service=\"web-server\", service_name=\"web-server\"} != ip(\"255.255.255.255\") | ip line filter negated: single-IP",
         "cerberus/wrong-rejection-burndown | log | range | BACKWARD | {cluster=\"cluster-0\", container=\"container-0\", datacenter=\"dc1\", env=\"production\", namespace=\"namespace-0\", pod=\"pod-0\", region=\"us-east-1\", service=\"web-server\", service_name=\"web-server\"} !> \"<_>error<_>\" | pattern line filter negated: embedded literal",
@@ -863,6 +863,10 @@
         "regression/metric-queries.yaml | metric | range | FORWARD | sum(sum_over_time({cluster=\"cluster-1\", container=\"container-1\", datacenter=\"dc1\", env=\"production\", namespace=\"namespace-4\", pod=\"pod-8\", region=\"us-east-1\", service=\"tempo\", service_name=\"tempo\"} | logfmt | unwrap bytes [5m])) | step=1m0s | Bytes conversion with sum",
         "regression/metric-queries.yaml | metric | range | FORWARD | sum(sum_over_time({cluster=\"cluster-1\", container=\"container-1\", datacenter=\"dc1\", env=\"production\", namespace=\"namespace-4\", pod=\"pod-9\", region=\"us-east-1\", service=\"grafana\", service_name=\"grafana\"} | logfmt | duration != \"\" | unwrap duration_seconds(duration) [5m])) | step=1m0s | Duration seconds with sum over time",
         "regression/metric-queries.yaml | metric | range | FORWARD | sum(sum_over_time({cluster=\"cluster-1\", container=\"container-1\", datacenter=\"dc1\", env=\"production\", namespace=\"namespace-4\", pod=\"pod-9\", region=\"us-east-1\", service=\"grafana\", service_name=\"grafana\"} | logfmt | size != \"\" | unwrap size [5m])) | step=1m0s | Logfmt size unwrap",
+        "regression/structured-metadata-generic.yaml | log | range | BACKWARD | {request_id=\"req-00000000\"} | stream selector referencing a structured-metadata-only key matches nothing on both backends",
+        "regression/structured-metadata-generic.yaml | log | range | BACKWARD | {service_name=\"metadata-probe\"} | request_id=\"\" | generic structured-metadata label filter - absent resolves to empty string",
+        "regression/structured-metadata-generic.yaml | log | range | FORWARD | {request_id=\"req-00000000\"} | stream selector referencing a structured-metadata-only key matches nothing on both backends",
+        "regression/structured-metadata-generic.yaml | metric | range | FORWARD | sum by (request_id) (count_over_time({service_name=\"metadata-probe\"}[24h])) | step=1h0m0s | metric query grouped by a generic, unconstrained-value-domain structured-metadata key",
         "regression/structured-metadata.yaml | log | range | BACKWARD | {cluster=\"cluster-1\", container=\"container-1\", datacenter=\"dc1\", env=\"production\", namespace=\"namespace-2\", pod=\"pod-5\", region=\"us-east-1\", service=\"prometheus\", service_name=\"prometheus\"} |~ \"error|exception\" | detected_level=\"error\" | Combined line and metadata filter",
         "regression/structured-metadata.yaml | log | range | BACKWARD | {cluster=\"cluster-1\", container=\"container-1\", datacenter=\"dc1\", env=\"production\", namespace=\"namespace-3\", pod=\"pod-7\", region=\"us-east-1\", service=\"mimir\", service_name=\"mimir\"} | detected_level=~\"error|warn\" |~ \"(?i)refused\" | Drilldown with error/warn level and refused search",
         "regression/structured-metadata.yaml | log | range | BACKWARD | {cluster=\"cluster-1\", container=\"container-1\", datacenter=\"dc1\", env=\"production\", namespace=\"namespace-4\", pod=\"pod-8\", region=\"us-east-1\", service=\"tempo\", service_name=\"tempo\"} | detected_level=\"error\" |~ \"(?i)failed\" | Drilldown with failed search and error level",

--- a/internal/api/loki/handler.go
+++ b/internal/api/loki/handler.go
@@ -824,9 +824,43 @@ func toVector(samples []chclient.Sample, ts time.Time) []VectorSample {
 	stamp := float64(ts.UnixMilli()) / msToSeconds
 	for _, l := range bySeries {
 		out = append(out, VectorSample{
-			Metric: format.NormalizeLabelMap(l.labels),
+			Metric: format.NormalizeLabelMap(dropEmptyLabelValues(l.labels)),
 			Value:  [2]any{stamp, strconv.FormatFloat(l.value, 'f', -1, 64)},
 		})
+	}
+	return out
+}
+
+// dropEmptyLabelValues returns a copy of `in` with every empty-valued
+// entry removed — the metric/vector-result twin of [normalizeMetadata]'s
+// same rule for per-line structured metadata. A `by (<generic structured
+// metadata key>)` grouping resolves an ABSENT key to the empty string
+// (see structuredOrStreamLookup in internal/logql), which is the correct
+// internal group-key value (it collapses every "key not present" row
+// into one group), but reference Loki's LabelsBuilder never MATERIALISES
+// an empty-value label into a series' output label set — a group with no
+// value for that key comes back with the key entirely absent, not
+// present with value "". Without this the `metric` field for that group
+// diverges from reference Loki byte-for-byte even though the grouping
+// itself (series count / membership) already agrees — see issue #1498,
+// which found generic structured metadata had zero differential
+// coverage and surfaced this on arrival.
+//
+// Scoped to the metric-result callers (toVector / toMatrixStepGrid):
+// stream (log-query) labels come from ResourceAttributes, which the
+// OTel-CH schema never populates with a genuinely empty value, so
+// toStreams' `format.NormalizeLabelMap(a.labels)` is left alone rather
+// than widening this rule to a path it was never observed to affect.
+func dropEmptyLabelValues(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return in
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		if v == "" {
+			continue
+		}
+		out[k] = v
 	}
 	return out
 }
@@ -878,7 +912,7 @@ func toMatrixStepGrid(samples []chclient.Sample, start, end time.Time, _ time.Du
 
 	out := make([]MatrixSample, 0, len(bySeries))
 	for _, st := range bySeries {
-		ms := MatrixSample{Metric: format.NormalizeLabelMap(st.labels)}
+		ms := MatrixSample{Metric: format.NormalizeLabelMap(dropEmptyLabelValues(st.labels))}
 		for _, r := range st.rows {
 			if r.Timestamp.Before(start) || r.Timestamp.After(end) {
 				continue

--- a/internal/api/loki/to_matrix_test.go
+++ b/internal/api/loki/to_matrix_test.go
@@ -483,3 +483,79 @@ func TestToMatrixStepGrid_StepLargerThanWindow(t *testing.T) {
 			len(got[0].Values), got[0].Values)
 	}
 }
+
+// TestToMatrixStepGrid_DropsEmptyValuedLabels pins dropEmptyLabelValues'
+// wiring into toMatrixStepGrid: a `by (<generic structured metadata
+// key>)` grouping resolves an entry lacking that key to the empty
+// string (see structuredOrStreamLookup in internal/logql), but
+// reference Loki never materialises an empty-value label into a
+// series' output label set — the key is simply absent. See issue
+// #1498 (found while adding generic structured-metadata differential
+// coverage — a `sum by (request_id) (count_over_time(...))` case where
+// some rows carry request_id and others don't diverged from reference
+// Loki on exactly this: `metric=map[]` expected vs `metric=map[request_id:]`
+// actual).
+func TestToMatrixStepGrid_DropsEmptyValuedLabels(t *testing.T) {
+	t.Parallel()
+
+	f := newFixture()
+	samples := []chclient.Sample{
+		// One series where the group-by key resolved to a real value...
+		{Labels: map[string]string{"job": "api", "request_id": "req-abc123"}, Timestamp: f.at(0), Value: 1},
+		// ...and one where it resolved to "" (the key was absent on the
+		// underlying row).
+		{Labels: map[string]string{"job": "api", "request_id": ""}, Timestamp: f.at(0), Value: 2},
+	}
+
+	got := sortByMetric(toMatrixStepGrid(samples, f.at(0), f.at(0), 30*time.Second))
+	if len(got) != 2 {
+		t.Fatalf("expected 2 distinct series, got %d: %+v", len(got), got)
+	}
+	if want := (map[string]string{"job": "api"}); !mapsEqual(got[0].Metric, want) {
+		t.Errorf("empty-valued request_id: Metric=%v, want %v (key dropped entirely)", got[0].Metric, want)
+	}
+	if want := (map[string]string{"job": "api", "request_id": "req-abc123"}); !mapsEqual(got[1].Metric, want) {
+		t.Errorf("non-empty request_id: Metric=%v, want %v (key retained)", got[1].Metric, want)
+	}
+}
+
+// TestToVector_DropsEmptyValuedLabels is toVector's (instant-query)
+// companion to TestToMatrixStepGrid_DropsEmptyValuedLabels — same rule,
+// different pivot helper.
+func TestToVector_DropsEmptyValuedLabels(t *testing.T) {
+	t.Parallel()
+
+	f := newFixture()
+	samples := []chclient.Sample{
+		{Labels: map[string]string{"job": "api", "request_id": "req-abc123"}, Timestamp: f.at(0), Value: 1},
+		{Labels: map[string]string{"job": "api", "request_id": ""}, Timestamp: f.at(0), Value: 2},
+	}
+
+	got := toVector(samples, f.at(0))
+	sort.Slice(got, func(i, j int) bool {
+		return format.CanonicalKey(got[i].Metric) < format.CanonicalKey(got[j].Metric)
+	})
+	if len(got) != 2 {
+		t.Fatalf("expected 2 distinct series, got %d: %+v", len(got), got)
+	}
+	if want := (map[string]string{"job": "api"}); !mapsEqual(got[0].Metric, want) {
+		t.Errorf("empty-valued request_id: Metric=%v, want %v (key dropped entirely)", got[0].Metric, want)
+	}
+	if want := (map[string]string{"job": "api", "request_id": "req-abc123"}); !mapsEqual(got[1].Metric, want) {
+		t.Errorf("non-empty request_id: Metric=%v, want %v (key retained)", got[1].Metric, want)
+	}
+}
+
+// mapsEqual is a small order-independent map[string]string comparator
+// local to this file's empty-label-drop assertions.
+func mapsEqual(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if b[k] != v {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary

- `compatibility/loki/cmd/seed/main.go` previously stamped exactly one structured-metadata key (`detected_level`, a synthesized, closed-set severity discriminant) into both ClickHouse's `LogAttributes` and the reference Loki push, so every LogQL path exercising a *generic* structured-metadata key — selectors, `| label_filter`, metric-query `by(...)` grouping — ran with zero differential coverage against reference Loki.
- Adds a second key, `request_id` (unconstrained value domain, present on 2 of every 3 entries, absent on the third — see `generateRequestID`), scoped to one new dedicated stream (`metadata-probe`). It's isolated the same way `packed-source` is (an unmatched `log_format`, so the vendored corpus's `${SELECTOR}` resolver can never pick it) — an earlier revision that stamped `request_id` on *every* seeded service turned 41 previously-passing corpus cases into diffs, because reference Loki folds any structured-metadata value a matching line carries directly into that line's output identity, everywhere.
- Adds `compatibility/loki/cerberus-queries/regression/structured-metadata-generic.yaml` with 3 new query definitions (4 expanded cases): a stream-selector rejection-parity check (`{request_id="..."}` matches nothing on either backend — structured metadata isn't indexed), a `label_filter` on the key's absence, and a metric query grouped `by (request_id)`.
- `compatibility/parity-baseline.json`'s `loki` entry grows from 120 → 124 cases, all passing.

## Bugs found while verifying

Running the differential harness against the new corpus surfaced two real divergences:

1. **cerberus's metric `by(...)` grouping rendered an absent structured-metadata key as an explicit empty-string label** instead of omitting it — reference Loki never materializes a `key=""` entry into a group's output label set when the key was simply never present. Fixed here: `dropEmptyLabelValues` in `internal/api/loki/handler.go`, wired into `toVector` / `toMatrixStepGrid` (the metric-result call sites only — log-stream labels come from `ResourceAttributes`, which the OTel-CH schema never populates with a genuinely empty value). Covered by two new unit tests (`TestToMatrixStepGrid_DropsEmptyValuedLabels`, `TestToVector_DropsEmptyValuedLabels`).
2. **cerberus's log-query (`kind: log`) stream-identity computation only widens by the hardcoded `detected_level` key**, never generic structured metadata — reference Loki folds *every* structured-metadata value observed per line into that line's output stream labels (`toStreams` in `internal/api/loki/handler.go` groups only by `ResourceAttributes` + the `detected_level` special case in `internal/logql/detected_level.go`). This is a real, separate, substantial gap with wide blast radius (every existing log-query response would reshape whenever structured metadata varies per line) — filed as **#1684** rather than fixed here. The corpus deliberately excludes a `kind: log` "generic key present" case to avoid gating this required check on that unrelated, unmade fix — mirrors how `unpack.yaml` (#1611) excluded a metric-mode case for #1652.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/api/loki/... ./compatibility/loki/...`
- [x] `just compat-logql` — 124/124 passed, 0 diffs, 0 unexpected failures (verified 4 times across iterations while narrowing the corpus/seed scoping)
- [x] `node .github/scripts/doc-counts.mjs` — parity-floor comment matches the baseline
- [x] `node .github/scripts/compat-ratchet.test.mjs` — 12/12 pass

Closes #1498
