### PR TITLE
test(traceql): cover no-tie ordering and limit-exceeds-matches for emitSearchTraceLimit

### DIFF
--- a/test/perf/cardinality-baseline.json
+++ b/test/perf/cardinality-baseline.json
@@ -7840,6 +7840,26 @@
     "max_recursion_depth": 0
   },
   {
+    "fixture": "traceql/search_trace_limit_exceeds_match_count",
+    "fan_factor": 1,
+    "scan_rows": 3,
+    "peak_intermediate": 3,
+    "has_cross_join": false,
+    "has_array_join": false,
+    "has_recursive_cte": false,
+    "max_recursion_depth": 0
+  },
+  {
+    "fixture": "traceql/search_trace_limit_no_tie_ordering",
+    "fan_factor": 1,
+    "scan_rows": 3,
+    "peak_intermediate": 3,
+    "has_cross_join": false,
+    "has_array_join": false,
+    "has_recursive_cte": false,
+    "max_recursion_depth": 0
+  },
+  {
     "fixture": "traceql/search_trace_limit_tiebreak_boundary",
     "fan_factor": 1,
     "scan_rows": 5,

--- a/test/spec/traceql/search_trace_limit_exceeds_match_count.txtar
+++ b/test/spec/traceql/search_trace_limit_exceeds_match_count.txtar
@@ -1,0 +1,57 @@
+emitSearchTraceLimit's top-N subquery ranks matching traces and LIMITs the
+ranking to `TraceLimit`. This fixture covers issue #1451's residual "limit
+larger than the result set" case: `search_limit` set well above the number of
+traces that actually match, so the `LIMIT` clause in the inner ranking
+subquery never binds and every matching trace's spans must survive the outer
+`WHERE TraceId IN (...)` drain unabridged — no truncation, no error from the
+CH-side LIMIT exceeding the candidate set.
+
+The seed carries three traces, but only two match the `name = "checkout"`
+predicate:
+
+  - `0000…aa01` — two `checkout` spans, at 00:00:10 and 00:00:15.
+  - `0000…bb02` — one `checkout` span, at 00:00:20.
+  - `0000…cc03` — one `other` span, at 00:00:25 — does NOT match.
+
+`search_limit: 5` exceeds the 2 matching traces by a wide margin. Expected
+output is all three `checkout` spans (`aa01` ×2 + `bb02` ×1); `cc03` is
+excluded by the FILTER predicate, not by the limit, confirming the two stay
+independent even when the limit has plenty of headroom to spare.
+
+-- search_limit --
+5
+-- search_window --
+1767225600 1767225660
+-- query.traceql --
+{ name = "checkout" }
+-- seed --
+CREATE TABLE otel_traces (
+    TraceId String,
+    SpanId String,
+    Timestamp DateTime64(9),
+    SpanName String
+) ENGINE = MergeTree ORDER BY (Timestamp, SpanId);
+INSERT INTO otel_traces VALUES
+    ('0000000000000000000000000000aa01', '0000000000000011', toDateTime64('2026-01-01 00:00:10', 9), 'checkout'),
+    ('0000000000000000000000000000aa01', '0000000000000012', toDateTime64('2026-01-01 00:00:15', 9), 'checkout'),
+    ('0000000000000000000000000000bb02', '0000000000000021', toDateTime64('2026-01-01 00:00:20', 9), 'checkout'),
+    ('0000000000000000000000000000cc03', '0000000000000031', toDateTime64('2026-01-01 00:00:25', 9), 'other');
+-- expected_rows --
+[
+  ["checkout", {"__cerberus_parentSpanID": "", "__cerberus_spanID": "0000000000000011", "__cerberus_traceID": "0000000000000000000000000000aa01"}, "2026-01-01T00:00:10Z", 0],
+  ["checkout", {"__cerberus_parentSpanID": "", "__cerberus_spanID": "0000000000000012", "__cerberus_traceID": "0000000000000000000000000000aa01"}, "2026-01-01T00:00:15Z", 0],
+  ["checkout", {"__cerberus_parentSpanID": "", "__cerberus_spanID": "0000000000000021", "__cerberus_traceID": "0000000000000000000000000000bb02"}, "2026-01-01T00:00:20Z", 0]
+]
+-- args --
+[0] string = "checkout"
+[1] int64 = 1767225600000000000
+[2] int64 = 1767225660000000000
+[3] string = "checkout"
+[4] int64 = 1767225600000000000
+[5] int64 = 1767225660000000000
+-- chplan --
+SearchTraceLimit traceLimit=5
+  Filter predicate=(((SpanName = "checkout") AND (Timestamp >= fromUnixTimestamp64Nano(1767225600000000000))) AND (Timestamp <= fromUnixTimestamp64Nano(1767225660000000000)))
+    Scan(otel_traces)
+-- sql --
+SELECT s.* FROM (SELECT * FROM `otel_traces` PREWHERE (`SpanName` = ?) WHERE (`Timestamp` >= fromUnixTimestamp64Nano(?)) AND (`Timestamp` <= fromUnixTimestamp64Nano(?))) AS s WHERE `TraceId` IN (SELECT `TraceId` FROM (SELECT * FROM `otel_traces` PREWHERE (`SpanName` = ?) WHERE (`Timestamp` >= fromUnixTimestamp64Nano(?)) AND (`Timestamp` <= fromUnixTimestamp64Nano(?))) GROUP BY `TraceId` ORDER BY min(`Timestamp`) DESC, `TraceId` LIMIT 5)

--- a/test/spec/traceql/search_trace_limit_no_tie_ordering.txtar
+++ b/test/spec/traceql/search_trace_limit_no_tie_ordering.txtar
@@ -1,0 +1,54 @@
+emitSearchTraceLimit ranks traces by `min(Timestamp) DESC, TraceId ASC` and
+keeps the first N. #1428 / search_trace_limit_tiebreak_boundary.txtar pins the
+TraceId tie-break at an exact boundary tie. This fixture is the complementary
+shape: three traces with three *distinct* start times, so the sort key alone
+decides the outcome and the TraceId leg never gets consulted at all — a plain
+"newest N wins, in the obvious order" case with no boundary ambiguity.
+
+`search_limit: 2` over three matching traces, all inside the request window:
+
+  - `0000…aa01` starts at 00:00:10 — oldest, drops off the page.
+  - `0000…bb02` starts at 00:00:20 — second newest, keeps its slot.
+  - `0000…cc03` starts at 00:00:30 — newest, keeps its slot.
+
+Expected output carries `bb02`'s and `cc03`'s spans only; `aa01` contributes
+nothing. This is issue #1451's residual "no-tie ordering" case: distinct from
+the tie-break fixture (which requires two traces to share a start time), it
+exercises the emitter's ordinary path where the outer drain and the top-N
+subquery agree on a clean linear order.
+
+-- search_limit --
+2
+-- search_window --
+1767225600 1767225660
+-- query.traceql --
+{ name = "checkout" }
+-- seed --
+CREATE TABLE otel_traces (
+    TraceId String,
+    SpanId String,
+    Timestamp DateTime64(9),
+    SpanName String
+) ENGINE = MergeTree ORDER BY (Timestamp, SpanId);
+INSERT INTO otel_traces VALUES
+    ('0000000000000000000000000000aa01', '0000000000000011', toDateTime64('2026-01-01 00:00:10', 9), 'checkout'),
+    ('0000000000000000000000000000bb02', '0000000000000021', toDateTime64('2026-01-01 00:00:20', 9), 'checkout'),
+    ('0000000000000000000000000000cc03', '0000000000000031', toDateTime64('2026-01-01 00:00:30', 9), 'checkout');
+-- expected_rows --
+[
+  ["checkout", {"__cerberus_parentSpanID": "", "__cerberus_spanID": "0000000000000021", "__cerberus_traceID": "0000000000000000000000000000bb02"}, "2026-01-01T00:00:20Z", 0],
+  ["checkout", {"__cerberus_parentSpanID": "", "__cerberus_spanID": "0000000000000031", "__cerberus_traceID": "0000000000000000000000000000cc03"}, "2026-01-01T00:00:30Z", 0]
+]
+-- args --
+[0] string = "checkout"
+[1] int64 = 1767225600000000000
+[2] int64 = 1767225660000000000
+[3] string = "checkout"
+[4] int64 = 1767225600000000000
+[5] int64 = 1767225660000000000
+-- chplan --
+SearchTraceLimit traceLimit=2
+  Filter predicate=(((SpanName = "checkout") AND (Timestamp >= fromUnixTimestamp64Nano(1767225600000000000))) AND (Timestamp <= fromUnixTimestamp64Nano(1767225660000000000)))
+    Scan(otel_traces)
+-- sql --
+SELECT s.* FROM (SELECT * FROM `otel_traces` PREWHERE (`SpanName` = ?) WHERE (`Timestamp` >= fromUnixTimestamp64Nano(?)) AND (`Timestamp` <= fromUnixTimestamp64Nano(?))) AS s WHERE `TraceId` IN (SELECT `TraceId` FROM (SELECT * FROM `otel_traces` PREWHERE (`SpanName` = ?) WHERE (`Timestamp` >= fromUnixTimestamp64Nano(?)) AND (`Timestamp` <= fromUnixTimestamp64Nano(?))) GROUP BY `TraceId` ORDER BY min(`Timestamp`) DESC, `TraceId` LIMIT 2)


### PR DESCRIPTION
## Summary

Closes #1451.

Issue #1451 originally flagged `internal/chsql`'s `emitSearchTraceLimit` as having zero golden/round-trip coverage. Scope has since shrunk considerably:

- #1428 landed `search_trace_limit_tiebreak_boundary.txtar`, covering the TraceId tie-break at an exact boundary tie.
- #1657 (merged) landed `search_trace_limit_bare_table_map_column.txtar`, satisfying the "Map-valued projection blocked by harness limitation" case.

That left two residual cases from the issue's own inventory unfiled/uncovered, which this PR closes:

- **No-tie ordering** — `search_trace_limit_no_tie_ordering.txtar`: three matching traces with distinct start times, so the sort key alone decides the kept set and the TraceId tie-break leg is never consulted.
- **Limit larger than the result set** — `search_trace_limit_exceeds_match_count.txtar`: `search_limit` set well above the number of matching traces, verifying the inner ranking subquery's `LIMIT` never truncates or errors when it doesn't bind, and that the unrelated FILTER predicate still excludes non-matching traces.

Both fixtures carry `-- seed --` / `-- expected_rows --` sections verified against real chDB execution (`GOLDEN_UPDATE=1 go test -tags chdb ./test/spec/traceql/...`).

## Test plan

- [x] `go test -count=1 ./internal/traceql/...` — Layer 2a SQL/chplan goldens
- [x] `go test -tags chdb -count=1 -run TestRoundTripChDB ./test/spec/traceql/...` — both new fixtures pass against chDB
- [x] `go test -count=1 ./test/spec/... ./test/regression/...` — no regressions, including the seeded-fixture inertness pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)