### PR TITLE
test(cmd/cerberus): assert ClickHouse client Close() on graceful exit

### DIFF
--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -311,6 +311,11 @@ func run() error {
 	if err != nil {
 		return fmt.Errorf("configure clickhouse client: %w", err)
 	}
+	// Safety net for every early-return path below (schema boot, requirements
+	// check, head mounting, …) that exits before the shutdownSteps below are
+	// ever built. The graceful-shutdown path closes the client explicitly, via
+	// steps.closeCH; Client.Close is documented idempotent, so this defer
+	// firing again afterward is a deliberate no-op, not a double-close bug.
 	defer func() {
 		_ = client.Close()
 	}()
@@ -473,6 +478,7 @@ func run() error {
 	steps := shutdownSteps{
 		drainHTTP: srv.Shutdown,
 		flushOTLP: providers.Shutdown,
+		closeCH:   client.Close,
 	}
 	// nil when the tempo head is disabled — no gRPC server was built.
 	if grpcServer != nil {
@@ -491,7 +497,7 @@ func run() error {
 	return nil
 }
 
-// shutdownSteps is the teardown surface run() owns, narrowed to the three calls
+// shutdownSteps is the teardown surface run() owns, narrowed to the four calls
 // whose ORDER and whose run-even-on-failure contract are the thing worth
 // asserting. Extracting it is what makes that contract reachable from a test at
 // all: run() itself needs a listener, a ClickHouse pool and a signal.
@@ -500,10 +506,20 @@ func run() error {
 // drain may block: GracefulStop takes no context and waits for every active RPC
 // to return, so calling it after the HTTP drain has already blown its deadline
 // would inherit that hang with nothing left to bound it.
+//
+// closeCH is run() 's client.Close, which run() ALSO defers unconditionally so
+// every early-return path (config load, schema boot, requirements check — all
+// before this steps struct is ever built) still tears the pool down. Routing it
+// through this struct too is safe rather than a double-teardown risk because
+// Client.Close is documented idempotent (internal/chclient/client.go): the
+// recovery-loop stop and the pool close both guard against a second call. This
+// is the one path that lets a test observe the CLOSE HAPPENING on the graceful
+// exit, not just on process teardown the test can't drive.
 type shutdownSteps struct {
 	drainHTTP func(context.Context) error
 	stopGRPC  func(graceful bool)
 	flushOTLP func(context.Context) error
+	closeCH   func() error
 }
 
 // shutdown tears the process down in dependency order and runs EVERY step even
@@ -511,13 +527,15 @@ type shutdownSteps struct {
 //
 // The order is a dependency chain: the HTTP drain closes the HTTP/2 transports
 // the gRPC streams ride on, so the gRPC drain after it is a no-op on the happy
-// path; the telemetry flush is last because the two steps before it emit the
-// spans and metrics it is flushing.
+// path; the telemetry flush comes next because the two steps before it emit the
+// spans and metrics it is flushing; the ClickHouse client closes LAST because
+// the HTTP drain is what guarantees no in-flight query is still using it.
 //
 // Running the tail unconditionally is the whole point. Returning at the first
 // error would drop exactly the telemetry that describes the failed shutdown —
 // the one teardown an operator actually needs to see — and would leave the gRPC
-// listener holding its sockets until the process image went away.
+// listener holding its sockets, or the ClickHouse pool holding its connections,
+// until the process image went away.
 func shutdown(ctx context.Context, steps shutdownSteps, logger *slog.Logger) error {
 	var firstErr error
 	drained := true
@@ -532,6 +550,12 @@ func shutdown(ctx context.Context, steps shutdownSteps, logger *slog.Logger) err
 	// Noop when telemetry was disabled (Endpoint == "").
 	if err := steps.flushOTLP(ctx); err != nil {
 		logger.Warn("telemetry shutdown returned error", "err", err)
+	}
+	// Mirrors run()'s outer `_ = client.Close()` discard: a close failure here
+	// is logged, never promoted to the process's exit status, and never masks
+	// an earlier, more actionable failure already captured in firstErr.
+	if err := steps.closeCH(); err != nil {
+		logger.Warn("clickhouse client close returned error", "err", err)
 	}
 	return firstErr
 }

--- a/cmd/cerberus/shutdown_test.go
+++ b/cmd/cerberus/shutdown_test.go
@@ -15,6 +15,13 @@ type recorder struct {
 }
 
 func (r *recorder) steps3(httpErr, otlpErr error) shutdownSteps {
+	return r.steps4(httpErr, otlpErr, nil)
+}
+
+// steps4 is steps3 plus a chErr for the ClickHouse client Close() step, for
+// tests that need to control (or observe) that step independently of the
+// OTLP flush.
+func (r *recorder) steps4(httpErr, otlpErr, chErr error) shutdownSteps {
 	return shutdownSteps{
 		drainHTTP: func(context.Context) error {
 			r.steps = append(r.steps, "http")
@@ -27,6 +34,10 @@ func (r *recorder) steps3(httpErr, otlpErr error) shutdownSteps {
 		flushOTLP: func(context.Context) error {
 			r.steps = append(r.steps, "otlp")
 			return otlpErr
+		},
+		closeCH: func() error {
+			r.steps = append(r.steps, "ch")
+			return chErr
 		},
 	}
 }
@@ -47,7 +58,7 @@ func TestShutdown_RunsTheTailWhenTheHTTPDrainFails(t *testing.T) {
 	if !strings.Contains(err.Error(), "graceful shutdown") {
 		t.Errorf("shutdown err = %q, want it to name the failing stage", err)
 	}
-	want := []string{"http", "grpc", "otlp"}
+	want := []string{"http", "grpc", "otlp", "ch"}
 	if got := strings.Join(r.steps, ","); got != strings.Join(want, ",") {
 		t.Fatalf("steps run = [%s], want [%s] — the tail must run even when the drain fails", got, strings.Join(want, ","))
 	}
@@ -70,7 +81,7 @@ func TestShutdown_HappyPathDrainsGracefullyInOrder(t *testing.T) {
 	if err := shutdown(context.Background(), r.steps3(nil, nil), discardLogger()); err != nil {
 		t.Fatalf("shutdown err = %v, want nil", err)
 	}
-	if got, want := strings.Join(r.steps, ","), "http,grpc,otlp"; got != want {
+	if got, want := strings.Join(r.steps, ","), "http,grpc,otlp,ch"; got != want {
 		t.Fatalf("steps run = [%s], want [%s]", got, want)
 	}
 	if !r.gracefulGRPC {
@@ -94,11 +105,58 @@ func TestShutdown_SkipsTheGRPCStopWhenNoServerWasBuilt(t *testing.T) {
 	steps := shutdownSteps{
 		drainHTTP: func(context.Context) error { return nil },
 		flushOTLP: func(context.Context) error { flushed = true; return nil },
+		closeCH:   func() error { return nil },
 	}
 	if err := shutdown(context.Background(), steps, discardLogger()); err != nil {
 		t.Fatalf("shutdown err = %v, want nil", err)
 	}
 	if !flushed {
 		t.Error("telemetry was not flushed when the tempo head is disabled")
+	}
+}
+
+// The gap #1433 filed: run()'s ClickHouse client Close() ran only inside an
+// unasserted `defer` in main.go, so nothing exercised it on the process's own
+// graceful-exit path. closeCH being wired into shutdownSteps and called by
+// shutdown() is what makes that call reachable from a test at all.
+func TestShutdown_ClosesTheClickHouseClient(t *testing.T) {
+	r := &recorder{}
+	if err := shutdown(context.Background(), r.steps4(nil, nil, nil), discardLogger()); err != nil {
+		t.Fatalf("shutdown err = %v, want nil", err)
+	}
+	want := []string{"http", "grpc", "otlp", "ch"}
+	if got := strings.Join(r.steps, ","); got != strings.Join(want, ",") {
+		t.Fatalf("steps run = [%s], want [%s] — ClickHouse must close LAST, once the HTTP drain guarantees no in-flight query still needs it", got, strings.Join(want, ","))
+	}
+}
+
+// The CH client Close() runs even when the HTTP drain already failed — mirrors
+// TestShutdown_RunsTheTailWhenTheHTTPDrainFails but asserts the "ch" step
+// specifically, since that is the exact gap #1433 named.
+func TestShutdown_ClosesTheClickHouseClientEvenWhenAnEarlierStepFails(t *testing.T) {
+	r := &recorder{}
+	_ = shutdown(context.Background(), r.steps4(errors.New("http drain failed"), errors.New("otlp flush failed"), nil), discardLogger())
+	if got, want := strings.Join(r.steps, ","), "http,grpc,otlp,ch"; got != want {
+		t.Fatalf("steps run = [%s], want [%s] — the CH close must still run after earlier failures", got, want)
+	}
+}
+
+// A ClickHouse close failure is logged, mirroring run()'s own discard
+// (`_ = client.Close()`): it is not promoted to the process's exit status, and
+// it must not mask an earlier, more actionable HTTP-drain failure that shutdown
+// already captured in firstErr.
+func TestShutdown_ClickHouseCloseErrorIsNotFatalAndDoesNotMaskAnEarlierError(t *testing.T) {
+	r := &recorder{}
+	closeErr := errors.New("clickhouse: connection already closed")
+
+	err := shutdown(context.Background(), r.steps4(nil, nil, closeErr), discardLogger())
+	if err != nil {
+		t.Fatalf("shutdown err = %v, want nil — a CH close failure must not fail the process exit", err)
+	}
+
+	drainErr := errors.New("deadline exceeded draining connections")
+	err = shutdown(context.Background(), r.steps4(drainErr, nil, closeErr), discardLogger())
+	if !errors.Is(err, drainErr) {
+		t.Fatalf("shutdown err = %v, want it to still wrap the earlier drain error %v, not the later CH close error", err, drainErr)
 	}
 }


### PR DESCRIPTION
## Summary

- `run()`'s ClickHouse client `Close()` ran only inside an unasserted `defer`, so no test could observe it happening on the process's own graceful-shutdown path — this was the second half of #1433 (the OTLP-flush half was already covered by the existing `shutdownSteps`/`shutdown()` seam).
- Wires `client.Close` into `shutdownSteps` as a fourth step (`closeCH`), called last in `shutdown()` — after the HTTP drain, which is what guarantees no in-flight query still needs the client.
- `Client.Close` is documented idempotent (`internal/chclient/client.go`), so the outer `defer func() { _ = client.Close() }()` in `run()` stays in place as a safety net for every early-return path (config load, schema boot, requirements check, …) that exits before the `shutdownSteps` are ever built — it firing again on the graceful path is a deliberate no-op, not a double-close bug.
- Adds four assertions in `shutdown_test.go`: CH close runs and runs last in the happy path, it still runs when an earlier step (HTTP drain, OTLP flush) fails, and a CH close error is logged but neither fails the process exit nor masks an earlier, more actionable error already captured.

This is a minimal, targeted extension of the seam #1433's earlier work already built (`shutdownSteps`/`shutdown()`), not a rewrite of `run()`'s control flow — `run()` itself remains not directly testable (it still owns `os.Stderr`, a real `config.FromEnv` read, and a CH client built off env vars), which is the pre-existing, correctly-scoped limitation `lifecycle_test.go`/`startup_test.go` document.

## Test plan

- [x] `go build ./...`
- [x] `go test ./cmd/cerberus/...` — all existing + new tests pass
- [x] New tests specifically assert: CH close happens, runs last (after http/grpc/otlp), still runs after an earlier step fails, and a close error is logged without becoming the process's fatal exit or masking an earlier drain error
- [x] `git push` pre-push hooks (`golangci-lint`, `forbid-skip`, `forbid-sql-raw`, `markdownlint`, `actionlint`, `commitlint-range`) all green

Closes #1433