### PR TITLE
fix(tempo): stamp non-nil SearchMetrics on every gRPC streaming frame

### DIFF
--- a/internal/api/tempo/grpc/metrics.go
+++ b/internal/api/tempo/grpc/metrics.go
@@ -131,13 +131,30 @@ func (s *Service) MetricsQueryInstant(req *tempopb.QueryInstantRequest, stream t
 // in spirit (separate helper to keep test-side helpers focused) but
 // is a single-frame pivot rather than a streaming flusher — range
 // mode emits one frame after eager drain (design §6).
+//
+// Metrics is always stamped non-nil with honest zero counters —
+// mirroring the tail-frame contract search.go's searchFlusher already
+// established for the Search RPC (see its doc-comment) — because
+// QueryRangeResponse.Metrics is a `*SearchMetrics` pointer upstream:
+// leaving it nil serialises to an explicit JSON/proto-JSON `null`
+// rather than an absent key. Grafana's Explore Traces app
+// dereferences `response.metrics.totalBlocks` unconditionally once a
+// query routes through the gRPC/h2c streaming transport (#1665
+// enabled `streamingEnabled.search`, which Grafana's TempoDatasource
+// also uses for TraceQL metrics-pipeline queries, not just Search), so
+// a nil Metrics here crashed the whole Explore Traces surface with
+// `runRequest.catchError TypeError: Cannot read properties of null
+// (reading 'totalBlocks')` (issue #1689). The HTTP JSON path never hit
+// this because MetricsQueryRangeResponse.Metrics is a value type that
+// always serialises, even unset (see metrics_query_range.go).
 func metricsExecRange(ctx context.Context, h *tempo.Handler, query string, start, end time.Time, step time.Duration) (*tempopb.QueryRangeResponse, error) {
 	res, err := h.ExecMetricsRange(ctx, query, start, end, step)
 	if err != nil {
 		return nil, err
 	}
 	out := &tempopb.QueryRangeResponse{
-		Series: make([]*tempopb.TimeSeries, 0, len(res.Series)),
+		Series:  make([]*tempopb.TimeSeries, 0, len(res.Series)),
+		Metrics: &tempopb.SearchMetrics{},
 	}
 	for _, ms := range res.Series {
 		ts := &tempopb.TimeSeries{
@@ -167,13 +184,18 @@ func metricsExecRange(ctx context.Context, h *tempo.Handler, query string, start
 // instant query and pivots the post-processed MetricsInstantSeries
 // list into the tempopb.QueryInstantResponse wire shape. Each series
 // carries a scalar Value rather than a Samples slice.
+//
+// Metrics is always stamped non-nil for the same reason
+// metricsExecRange stamps it — see that function's doc-comment
+// (issue #1689).
 func metricsExecInstant(ctx context.Context, h *tempo.Handler, query string, start, end time.Time) (*tempopb.QueryInstantResponse, error) {
 	res, err := h.ExecMetricsInstant(ctx, query, start, end)
 	if err != nil {
 		return nil, err
 	}
 	out := &tempopb.QueryInstantResponse{
-		Series: make([]*tempopb.InstantSeries, 0, len(res.Series)),
+		Series:  make([]*tempopb.InstantSeries, 0, len(res.Series)),
+		Metrics: &tempopb.SearchMetrics{},
 	}
 	for _, ms := range res.Series {
 		out.Series = append(out.Series, &tempopb.InstantSeries{

--- a/internal/api/tempo/grpc/metrics_test.go
+++ b/internal/api/tempo/grpc/metrics_test.go
@@ -164,6 +164,16 @@ func TestMetricsQueryRange_FrameShape(t *testing.T) {
 	if got, want := len(frames[0].Series), 1; got != want {
 		t.Fatalf("series count: got %d, want %d", got, want)
 	}
+	// #1689: Metrics must never be nil — tempopb.QueryRangeResponse.Metrics
+	// is a *SearchMetrics pointer, and Grafana's Explore Traces app
+	// dereferences response.metrics.totalBlocks unconditionally. A nil
+	// pointer here serialises to an explicit JSON `null` on the wire and
+	// crashes the whole Explore Traces surface with
+	// "runRequest.catchError TypeError: Cannot read properties of null
+	// (reading 'totalBlocks')".
+	if frames[0].Metrics == nil {
+		t.Fatal("Metrics: got nil, want a non-nil (possibly zeroed) *tempopb.SearchMetrics")
+	}
 	got := frames[0].Series[0]
 	if len(got.Labels) != 1 || got.Labels[0].Key != "__name__" || keyValueValue(got.Labels[0]) != "rate" {
 		t.Errorf("labels: want single {__name__=rate}, got %+v", got.Labels)
@@ -283,6 +293,12 @@ func TestMetricsQueryInstant_FrameShape(t *testing.T) {
 	}
 	if got, want := len(frames[0].Series), 2; got != want {
 		t.Fatalf("series count: got %d, want %d", got, want)
+	}
+	// #1689: same non-nil Metrics contract as MetricsQueryRange — see
+	// TestMetricsQueryRange_FrameShape's assertion for the wire-crash
+	// this guards against.
+	if frames[0].Metrics == nil {
+		t.Fatal("Metrics: got nil, want a non-nil (possibly zeroed) *tempopb.SearchMetrics")
 	}
 	// Series are sorted by canonical label key (deterministic
 	// emission); backend < frontend lexicographically.

--- a/internal/api/tempo/grpc/search.go
+++ b/internal/api/tempo/grpc/search.go
@@ -149,18 +149,31 @@ func (s *Service) Search(req *tempopb.SearchRequest, stream tempopb.StreamingQue
 		}
 	}
 
-	// Frame-batch the summaries into searchFrameSize-sized chunks.
-	// The tail frame carries SearchMetrics so Grafana sees the
-	// aggregate exactly once at end-of-stream — mirroring how the
-	// HTTP /api/search response embeds Metrics alongside the (single)
-	// traces array.
+	// Frame-batch the summaries into searchFrameSize-sized chunks. Every
+	// frame — intermediate shards AND the tail — carries the same
+	// SearchMetrics block. That's sound (not premature) because
+	// SearchResult above already ran eagerly: the full sample set, and
+	// therefore searchMetrics, was materialised before this loop starts
+	// (see the "Eager, not streaming" comment above), so there is no
+	// partial/unknown state to withhold. A nil Metrics on intermediate
+	// frames used to reach Grafana's Tempo datasource, which dereferences
+	// metrics.totalBlocks on every streamed frame (not just the last) to
+	// drive its "Streaming Progress" panel — a nil field there is a
+	// TypeError, not a benign omission (#1689). Sending the real,
+	// already-known aggregate on every frame keeps the envelope
+	// non-optional the way the upstream Tempo struct's non-pointer
+	// counters imply, instead of teaching the caller to tolerate null.
+	metricsFrame := &tempopb.SearchMetrics{
+		//nolint:gosec // trace count is bounded by CH row LIMIT; overflow would require > 4B traces which the engine can't materialise.
+		InspectedTraces: uint32(searchMetrics.InspectedTraces),
+	}
 	flusher := newSearchFlusher(searchFrameSize)
 	for i := range summaries {
 		shard, ready := flusher.Push(toTempopbTraceMetadata(summaries[i]))
 		if !ready {
 			continue
 		}
-		if err := stream.Send(&tempopb.SearchResponse{Traces: shard}); err != nil {
+		if err := stream.Send(&tempopb.SearchResponse{Traces: shard, Metrics: metricsFrame}); err != nil {
 			return mapStreamError(err)
 		}
 	}
@@ -175,11 +188,8 @@ func (s *Service) Search(req *tempopb.SearchRequest, stream tempopb.StreamingQue
 	// the tail and an empty trailer keeps the wire envelope round-
 	// tripable through the streaming/HTTP equivalence check.
 	if err := stream.Send(&tempopb.SearchResponse{
-		Traces: tail,
-		Metrics: &tempopb.SearchMetrics{
-			//nolint:gosec // trace count is bounded by CH row LIMIT; overflow would require > 4B traces which the engine can't materialise.
-			InspectedTraces: uint32(searchMetrics.InspectedTraces),
-		},
+		Traces:  tail,
+		Metrics: metricsFrame,
 	}); err != nil {
 		return mapStreamError(err)
 	}

--- a/internal/api/tempo/grpc/search_test.go
+++ b/internal/api/tempo/grpc/search_test.go
@@ -167,8 +167,16 @@ func drainSearch(t *testing.T, stream tempopb.StreamingQuerier_SearchClient) ([]
 
 // TestSearch_FrameBatching feeds 45 synthetic traces through the gRPC
 // Search RPC and asserts the wire-level frame layout: 2 full shards
-// of 20 traces each + 1 tail shard with the remaining 5, where the
-// tail carries the SearchMetrics with InspectedTraces = 45.
+// of 20 traces each + 1 tail shard with the remaining 5, where every
+// frame — intermediate shards included — carries the SearchMetrics
+// aggregate with InspectedTraces = 45. Intermediate frames used to
+// send Metrics=nil; Grafana's Tempo datasource dereferences
+// metrics.totalBlocks on every streamed frame (not just the tail) to
+// drive its "Streaming Progress" panel, so a nil field there threw a
+// TypeError in the browser (#1689). SearchResult runs eagerly (the
+// full sample set — and therefore the aggregate — is known before any
+// frame is sent), so stamping the same non-nil Metrics on every frame
+// is both correct and cheap.
 //
 // 45 = 2*searchFrameSize + 5 is picked so the test exercises both the
 // "shard fills exactly" path (Push returns ready=true) and the "tail
@@ -218,18 +226,15 @@ func TestSearch_FrameBatching(t *testing.T) {
 	if got := len(frames[2].Traces); got != 5 {
 		t.Errorf("frame[2] (tail) traces: got %d, want 5", got)
 	}
-	// Metrics live on the tail frame exclusively.
-	if frames[0].Metrics != nil {
-		t.Errorf("frame[0] metrics: want nil, got %+v", frames[0].Metrics)
-	}
-	if frames[1].Metrics != nil {
-		t.Errorf("frame[1] metrics: want nil, got %+v", frames[1].Metrics)
-	}
-	if frames[2].Metrics == nil {
-		t.Fatalf("frame[2] (tail) metrics: want non-nil")
-	}
-	if got, want := int(frames[2].Metrics.InspectedTraces), total; got != want {
-		t.Errorf("frame[2] InspectedTraces: got %d, want %d", got, want)
+	// Metrics ride EVERY frame — intermediate shards and the tail alike
+	// (#1689) — all stamped with the same eagerly-known aggregate.
+	for i, f := range frames {
+		if f.Metrics == nil {
+			t.Fatalf("frame[%d] metrics: want non-nil, got nil", i)
+		}
+		if got, want := int(f.Metrics.InspectedTraces), total; got != want {
+			t.Errorf("frame[%d] InspectedTraces: got %d, want %d", i, got, want)
+		}
 	}
 	// Sum-check: total traces across all frames matches the input.
 	sum := 0

--- a/internal/api/tempo/metrics_query_instant.go
+++ b/internal/api/tempo/metrics_query_instant.go
@@ -28,8 +28,13 @@ import (
 // Cerberus follows the same shape so the differ's CompareMetrics
 // (compatibility/tempo/driver/differ_metrics.go) can canonicalise
 // both backends' responses without a shape-specific branch.
+//
+// Metrics mirrors upstream's `tempopb.QueryInstantResponse.Metrics` —
+// see MetricsQueryRangeResponse.Metrics's doc-comment for why this
+// field must always be present (issue #1689).
 type MetricsQueryInstantResponse struct {
-	Series []MetricsInstantSeries `json:"series"`
+	Series  []MetricsInstantSeries `json:"series"`
+	Metrics SearchMetrics          `json:"metrics"`
 }
 
 // MetricsInstantSeries is one entry of MetricsQueryInstantResponse.Series.

--- a/internal/api/tempo/metrics_query_range.go
+++ b/internal/api/tempo/metrics_query_range.go
@@ -24,8 +24,21 @@ import (
 // labels) tuple, each carrying per-anchor samples sorted ascending by
 // timestamp. Grafana's Tempo datasource consumes this directly for the
 // service-graph node + edge metrics.
+//
+// Metrics mirrors upstream's `tempopb.QueryRangeResponse.Metrics`
+// (`*SearchMetrics`, always populated by reference Tempo — never nil
+// on a successful response). Grafana's Explore Traces app dereferences
+// `response.metrics.totalBlocks` unconditionally (see grafana/tempo's
+// datasource `module.js` `runRequest` path); omitting the field left
+// the app reading `.totalBlocks` off `null` and throwing
+// `runRequest.catchError TypeError` on every Explore Traces surface
+// once the gRPC/h2c streaming transport (#1665) started routing
+// metrics-pipeline queries through cerberus (issue #1689). Cerberus
+// reports the aggregate fields as zeros, matching the `/api/search`
+// SearchResponse.Metrics precedent in types.go.
 type MetricsQueryRangeResponse struct {
-	Series []MetricsSeries `json:"series"`
+	Series  []MetricsSeries `json:"series"`
+	Metrics SearchMetrics   `json:"metrics"`
 }
 
 // MetricsSeries is one entry of MetricsQueryRangeResponse.Series.


### PR DESCRIPTION
## Summary

Fixes the `grafana-exploretraces-app` Explore surface crash reported in #1689 (`runRequest.catchError TypeError: Cannot read properties of null (reading 'totalBlocks')`), which fails the `compose-smoke`/`dashboard` Playwright crawl oracle on push-to-main.

Two related but distinct gaps in cerberus's Tempo `StreamingQuerier` gRPC service, both in `internal/api/tempo/grpc/`:

1. **`metrics.go`** — `metricsExecRange`/`metricsExecInstant` never set `Metrics` on `QueryRangeResponse`/`QueryInstantResponse`, leaving it as a nil pointer that serializes to `null`. Fixed by always stamping `&tempopb.SearchMetrics{}` (zero-valued when nothing to report), matching upstream `tempopb.SearchMetrics`'s non-pointer-counter shape. Also added a `Metrics` field to the sibling HTTP responses (`metrics_query_range.go`/`metrics_query_instant.go`) for wire parity.

2. **`search.go`** (the actual root cause reproduced live) — the `Search` RPC only stamped `SearchMetrics` on the tail frame; intermediate shard frames (emitted every `searchFrameSize`=20 traces) had `Metrics: nil`. Grafana's bundled Tempo datasource plugin dereferences `metrics.totalBlocks` on **every** streamed frame (not just the last) to drive its "Streaming Progress" panel — hence the TypeError. `SearchResult` already runs eagerly (the full sample set is drained before any frame is sent), so the aggregate is known up front; there's no partial state to withhold. Fixed by stamping the same, already-known `SearchMetrics` value on every frame.

Neither upstream `tempopb.SearchMetrics` struct field is `omitempty`-pointer-typed inside the message itself — only the top-level `Metrics *SearchMetrics` field on the response messages is a pointer, and cerberus was leaving it nil instead of populating it. The fix makes cerberus emit the same non-optional-in-practice shape real Tempo emits, rather than teaching the Grafana crawl oracle (or the datasource) to tolerate null.

## Root cause investigation

- Confirmed via `gh api repos/tsouza/cerberus/issues/1689` that the failure is not new-regression-shaped — traced through recent gRPC/h2c work (#1676/#1453/#1665) via `git merge-base --is-ancestor`; the nil-Metrics gaps predate that work and were only surfaced once the streaming gRPC path started actually being exercised by the crawl.
- Traced the browser-side error through Grafana's actual shipped `tempo` datasource plugin bundle (extracted live from the running `grafana` container) to `Jt()`, the function building the "Streaming Progress" panel from the `metrics` field of each Grafana Live-channel message.
- Wrote a Playwright browser probe capturing raw Grafana Live-channel websocket frames against the live compose stack, confirming: before the fix, every intermediate `state=streaming` frame on `.../search/<id>` channels carried `metrics=null` (seeded compose data has 200 traces, well over `searchFrameSize=20`, so multiple intermediate frames fire in practice); after the fix, every frame — intermediate and tail — carries `metrics={"inspectedTraces":200}`.

## Verification

- `go test ./internal/api/tempo/grpc/...` — all tests pass, including updated `TestSearch_FrameBatching` (now asserts non-nil `Metrics` with the correct `InspectedTraces` total on every frame, not just the tail) and new `Metrics != nil` regression assertions on `TestMetricsQueryRange_FrameShape`/`TestMetricsQueryInstant_FrameShape`.
- Rebuilt the `cerberus` container in the local compose stack (`docker compose up -d --build cerberus`) and re-ran the Playwright browser probe: `totalBlocks` TypeError is gone, every frame carries non-null metrics.
- Ran the full crawl spec live: `CRAWL_STACK=compose SWEEP_DEPTH=lean npx playwright test crawl/crawl.spec.ts` — **13/13 passed**, including the main BFS crawl oracle covering all 6 `/a/grafana-exploretraces-app/explore` surface states named in #1689, with zero `totalBlocks` errors.

Closes #1689

🤖 Generated with [Claude Code](https://claude.com/claude-code)