### PR TITLE
test(integration): fix PromQL oracle differential coverage gaps (#1499, #1488)

### DIFF
--- a/test/integration/promql/matrix.go
+++ b/test/integration/promql/matrix.go
@@ -23,13 +23,26 @@ func (c exoticCase) ts() int64 {
 // ExoticMatrix is the hand-curated catalogue. Every entry is bound to a
 // construct the from-scratch oracle (test/property/oracle/promql) already
 // evaluates, so the assertion is a real cerberus-vs-spec comparison rather
-// than a both-erroring no-op. Categories the oracle can't yet evaluate
-// (set ops, subqueries, label_replace/label_join, absent/clamp/sort,
-// quantile/count_values/limitk, predict_linear/deriv,
-// double_exponential_smoothing, native histograms) are DEFERRED — they are
-// covered either by the deterministic promqltest tail (set ops, @
-// start/end, stale/NaN) or left as documented oracle gaps. See the package
-// doc and the PR body for the full deferred list.
+// than a both-erroring no-op. Set ops, absent/clamp/sort, and the
+// quantile/count_values/limitk/limit_ratio aggregator family are ALL
+// oracle-evaluated and exercised below (cat3Aggregators, cat4SetOps,
+// cat8ScalarVector) — count_values/limitk/limit_ratio specifically remain
+// oracle gaps tracked by #1693. The remaining categories the oracle can't
+// yet evaluate are each tracked by its own open issue, not by prose:
+//   - subqueries, label_replace, label_join — #1694
+//   - deriv, predict_linear, double_exponential_smoothing,
+//     quantile_over_time — #1695
+//   - native (exponential) histograms — #1696
+//
+// @ start()/end() determinism for range queries and stale/NaN handling are
+// NOT oracle gaps — they're covered by the Layer 2a txtar goldens under
+// test/spec/promql/ (at_start_basic.txtar, at_end_basic.txtar,
+// edge_at_start_range.txtar, edge_at_timestamp_range.txtar,
+// edge_increase_at_start.txtar, edge_at_then_offset_neg.txtar for @;
+// quantile_scalar_phi_nan.txtar, lwr_bare_selector_staleness_window.txtar,
+// scalar_many_series_nan.txtar, vector_scalar_multi_series_nan.txtar,
+// clamp_min_scalar_nan_bound.txtar for stale/NaN) rather than by any
+// "promqltest" package — no such package exists in this repo.
 //
 // CAT 1 is the priority class: vector-vector binary ops over
 // rate/irate/increase/delta. It is the explicit regression net for the
@@ -86,8 +99,31 @@ func cat1BinaryOverRate() []exoticCase {
 
 // cat2Histogram exercises histogram_quantile over the classic-histogram
 // fan-out. The oracle implements histogram_quantile + phi out-of-range
-// (-Inf / +Inf) but not the histogram_* value family, so those are
-// deferred.
+// (-Inf / +Inf); the histogram_* value family is not implemented by the
+// oracle and stays uncovered here.
+//
+// hq_p50 (#1488): previously excluded as a suspected cerberus/oracle
+// interpolation divergence — the p50 rank was the only one of the five
+// phi values exercised here that disagreed. Root-caused to the ORACLE:
+// test/property/oracle/promql/histogram.go's bucketQuantile overwrote
+// same-`le` buckets on merge (losing counts from duplicate bounds) and
+// skipped Prometheus's ensureMonotonicAndIgnoreSmallDeltas repair before
+// interpolating. Fixed there (coalesce-by-sum + monotonicity repair,
+// mirroring prometheus/promql/quantile.go); this case now passes.
+//
+// A second, DIFFERENT divergence surfaced while re-investigating this
+// marker: histogram_quantile over a bare, non-rate-wrapped aggregation
+// (`histogram_quantile(0.9, sum by(le)(demo_api_request_duration_seconds_bucket))`,
+// no rate()/increase()/sum_over_time() wrapper) is a genuine CERBERUS bug —
+// internal/promql/histogram_quantile.go's matchHistogramAggIdiom only
+// routes to the histogram-table path when the aggregated expression is
+// wrapped in rate/increase/sum_over_time; without one it falls into the
+// "unrecognised shape" branch and forces an empty result, even though the
+// aggregated selector names a real `_bucket` metric. Fixing that requires
+// a new lowering shape (latest-sample-per-series aggregation, not a
+// windowed reduction), which is out of scope for the oracle-coverage PR
+// that found it — tracked in
+// https://github.com/tsouza/cerberus/issues/1692.
 func cat2Histogram() []exoticCase {
 	const h = "demo_api_request_duration_seconds_bucket"
 	return []exoticCase{
@@ -99,19 +135,16 @@ func cat2Histogram() []exoticCase {
 		// stay in domain and fall through to the normal bucket search.
 		{name: "cat2/hq_phi_neg", promql: "histogram_quantile(-0.1, sum by(le)(rate(" + h + "[5m])))"},
 		{name: "cat2/hq_phi_over1", promql: "histogram_quantile(1.01, sum by(le)(rate(" + h + "[5m])))"},
-		// DEFERRED (cerberus-vs-oracle interpolation/edge divergences,
-		// outside the code-47 scope — see PR body):
-		//   - hq p50: cerberus's sub-bucket interpolation lands at a
-		//     different point than the oracle's bucketQuantile for the p50
-		//     rank (p90/p95 agree). Separate later PR (fix (a)).
-		//   - instant buckets (no rate): cerberus drops the {} series the
-		//     oracle keeps over raw cumulative bucket counts.
+		{name: "cat2/hq_p50", promql: "histogram_quantile(0.5, sum by(le)(rate(" + h + "[5m])))"},
 	}
 }
 
 // cat3Aggregators covers the aggregators the oracle implements:
-// sum/avg/min/max/count/topk/bottomk, with by/without grouping and edge k.
-// quantile/count_values/limitk/limit_ratio are DEFERRED (oracle gap).
+// sum/avg/min/max/count/topk/bottomk/quantile, with by/without grouping and
+// edge k / edge phi. count_values/limitk/limit_ratio are implemented by
+// cerberus (internal/promql/lower.go::lowerCountValues / lowerLimitRatio /
+// lowerLimitK) but NOT by the oracle — tracked in
+// https://github.com/tsouza/cerberus/issues/1693.
 func cat3Aggregators() []exoticCase {
 	const mem = "demo_memory_usage_bytes"
 	const cpu = "demo_cpu_usage_seconds_total"
@@ -128,15 +161,19 @@ func cat3Aggregators() []exoticCase {
 		{name: "cat3/min_by_instance", promql: "min by(instance)(" + mem + ")"},
 		{name: "cat3/count_by_job", promql: "count by(job)(" + mem + ")"},
 		{name: "cat3/sum_no_grouping", promql: "sum(" + mem + ")"},
+		{name: "cat3/quantile_p90_by_type", promql: "quantile(0.9, " + mem + ") by (type)"},
+		{name: "cat3/quantile_p50_by_instance", promql: "quantile(0.5, " + mem + ") by (instance)"},
+		// phi out of domain (Prom quantile.go): < 0 -> -Inf, > 1 -> +Inf.
+		{name: "cat3/quantile_phi_neg", promql: "quantile(-0.1, " + mem + ") by (type)"},
+		{name: "cat3/quantile_phi_over1", promql: "quantile(1.5, " + mem + ") by (type)"},
 	}
 }
 
 // cat4SetOps covers the set operators and / or / unless, matched both on
 // the full label set and via on()/ignoring(). The oracle's set-op support
-// is added in test/property/oracle/promql/binary.go::setOp so the
-// assertion drives the REAL cerberus handler against the spec (rather than
-// routing set ops to a Prometheus-only promqltest tail that would never
-// exercise cerberus's lowering).
+// is added in test/property/oracle/promql/binary.go::setOp, so the
+// assertion drives the REAL cerberus handler against an independent
+// from-scratch evaluator rather than a both-erroring no-op.
 func cat4SetOps() []exoticCase {
 	const mem = "demo_memory_usage_bytes"
 	const cpu = "demo_cpu_usage_seconds_total"
@@ -185,8 +222,13 @@ func cat5Matching() []exoticCase {
 }
 
 // cat7AtOffset covers the @ modifier + offset (absolute pin, compose with
-// offset, negative offset = forward). @ start()/end() determinism for range
-// queries is DEFERRED to the promqltest tail (instant @start==@end here).
+// offset, negative offset = forward) against the from-scratch oracle at a
+// single instant. @ start()/end() determinism specifically for RANGE
+// queries is covered separately by the Layer 2a txtar goldens
+// (test/spec/promql/at_start_basic.txtar, at_end_basic.txtar,
+// edge_at_start_range.txtar, edge_at_timestamp_range.txtar,
+// edge_increase_at_start.txtar, edge_at_then_offset_neg.txtar) rather than
+// by this instant-eval oracle matrix.
 func cat7AtOffset() []exoticCase {
 	const mem = "demo_memory_usage_bytes"
 	pin := EvalTs - 120 // 2 minutes before the default eval ts
@@ -203,8 +245,9 @@ func cat7AtOffset() []exoticCase {
 	}
 }
 
-// cat8ScalarVector covers scalar()/vector() and scalar-vector arithmetic.
-// absent/clamp/sort are DEFERRED (oracle gap).
+// cat8ScalarVector covers scalar()/vector(), scalar-vector arithmetic, and
+// absent()/clamp()/clamp_min()/clamp_max()/sort()/sort_desc() — all
+// oracle-evaluated (test/property/oracle/promql/absent_clamp_sort.go).
 func cat8ScalarVector() []exoticCase {
 	const mem = "demo_memory_usage_bytes"
 	return []exoticCase{
@@ -220,16 +263,28 @@ func cat8ScalarVector() []exoticCase {
 		// Both operands are label-less {} vectors, so they DO match ->
 		// one {} row with value 3 (the both-synthetic fold).
 		{name: "cat8/vector1_plus_vector2", promql: "vector(1) + vector(2)"},
+		// absent() over a selector that DOES match -> empty result.
+		{name: "cat8/absent_present", promql: "absent(" + mem + "{type=\"used\"})"},
+		// absent() over a selector that matches nothing -> single {} = 1.
+		{name: "cat8/absent_missing", promql: "absent(" + mem + "{type=\"does_not_exist\"})"},
+		{name: "cat8/clamp_both", promql: "clamp(" + mem + "{type=\"used\"}, 2.05e9, 2.02e9)"},
+		{name: "cat8/clamp_min", promql: "clamp_min(" + mem + "{type=\"used\"}, 2.05e9)"},
+		{name: "cat8/clamp_max", promql: "clamp_max(" + mem + "{type=\"used\"}, 2.01e9)"},
+		{name: "cat8/sort_asc", promql: "sort(" + mem + "{type=\"used\"})"},
+		{name: "cat8/sort_desc", promql: "sort_desc(" + mem + "{type=\"used\"})"},
 	}
 }
 
-// cat9OverTime covers the *_over_time family the oracle implements. The
-// deriv/predict_linear/double_exponential_smoothing/quantile_over_time/
-// stddev_over_time/changes/resets/last_over_time family is DEFERRED (oracle
-// gap).
+// cat9OverTime covers the *_over_time family the oracle implements —
+// including changes()/resets()/last_over_time()/stddev_over_time()/
+// stdvar_over_time() (test/property/oracle/promql/functions.go).
+// deriv/predict_linear/double_exponential_smoothing/quantile_over_time
+// remain a genuine oracle gap, tracked by
+// https://github.com/tsouza/cerberus/issues/1695.
 func cat9OverTime() []exoticCase {
 	const mem = "demo_memory_usage_bytes"
 	const inter = "demo_intermittent_metric"
+	const restarts = "demo_worker_restarts_total"
 	return []exoticCase{
 		{name: "cat9/avg_over_time", promql: "avg_over_time(" + mem + "{type=\"used\"}[5m])"},
 		{name: "cat9/min_over_time", promql: "min_over_time(" + mem + "{type=\"used\"}[5m])"},
@@ -238,6 +293,17 @@ func cat9OverTime() []exoticCase {
 		// count_over_time on the sparse series sees fewer samples than dense.
 		{name: "cat9/count_over_time_sparse", promql: "count_over_time(" + inter + "[5m])"},
 		{name: "cat9/count_over_time_dense", promql: "count_over_time(" + mem + "{type=\"used\"}[5m])"},
+		{name: "cat9/last_over_time", promql: "last_over_time(" + mem + "{type=\"used\"}[5m])"},
+		{name: "cat9/stddev_over_time", promql: "stddev_over_time(" + mem + "{type=\"used\"}[5m])"},
+		{name: "cat9/stdvar_over_time", promql: "stdvar_over_time(" + mem + "{type=\"used\"}[5m])"},
+		// demo_worker_restarts_total resets at the window midpoint (see
+		// seed.go), so a window wide enough to straddle the reset sees a
+		// real changes()/resets() count rather than a vacuous zero.
+		{name: "cat9/changes_across_reset", promql: "changes(" + restarts + "[10m])"},
+		{name: "cat9/resets_across_reset", promql: "resets(" + restarts + "[10m])"},
+		// A narrow window entirely after the reset sees no reset -> 0,
+		// distinguishing "no reset in this window" from "reset ignored".
+		{name: "cat9/resets_none_narrow_window", promql: "resets(" + restarts + "[1m])"},
 	}
 }
 

--- a/test/integration/promql/seed.go
+++ b/test/integration/promql/seed.go
@@ -111,15 +111,28 @@ func RichSeed() (ddl string, model *property.MetricsModel) {
 	// demo_items_shipped_total{instance}: a monotonic counter, one series
 	// per instance (so on(instance)/group_left joins resolve one-to-one).
 	// It is kept monotonic so rate() agrees byte-for-byte between cerberus
-	// and the oracle; counter-RESET behaviour (rate across a restart +
-	// resets()) is exercised separately by the deterministic promqltest
-	// tail (testdata/resets.test) where the expected values are pinned.
+	// and the oracle.
 	for i, inst := range instances {
 		lbls := map[string]string{"instance": inst, "job": "demo"}
 		slope := 5 + float64(i)
 		vals := counterValues(slope, false)
 		b.WriteString(sumInsert("demo_items_shipped_total", lbls, vals))
 		series = append(series, mkSeries("demo_items_shipped_total", lbls, vals))
+	}
+	// demo_worker_restarts_total{instance}: a counter that resets (drops
+	// back to a small value, modeling a process restart) at the window
+	// midpoint. This is the ONLY seeded series with a real reset — every
+	// other counter above is deliberately kept monotonic so its rate()
+	// agrees byte-for-byte with the oracle without a bridge. resets() and
+	// changes() need at least one series where a reset actually happens to
+	// be a meaningful assertion rather than a vacuously-zero one; see
+	// cat9OverTime's resets()/changes() cases.
+	for i, inst := range instances {
+		lbls := map[string]string{"instance": inst, "job": "demo"}
+		slope := 3 + float64(i)
+		vals := counterValues(slope, true)
+		b.WriteString(sumInsert("demo_worker_restarts_total", lbls, vals))
+		series = append(series, mkSeries("demo_worker_restarts_total", lbls, vals))
 	}
 
 	// --- Gauges (otel_metrics_gauge). ---

--- a/test/property/gen/promql_range.go
+++ b/test/property/gen/promql_range.go
@@ -1,0 +1,119 @@
+package gen
+
+import (
+	"time"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql/parser"
+	"pgregory.net/rapid"
+
+	"github.com/tsouza/cerberus/test/property"
+)
+
+// RangeQuery is a generated PromQL query string plus the query_range
+// grid (start/end/step, unix seconds) to evaluate it over — the
+// range-path counterpart to PromQLQuery's instant-only property.Query.
+type RangeQuery struct {
+	String   string
+	StartSec int64
+	EndSec   int64
+	StepSec  int64
+}
+
+// RangeGridStartOffsets is the pool of grid-start offsets (relative to
+// AnchorTime()) PromQLRangeQuery draws from. Deliberately includes
+// offsets BEFORE the dataset's first sample (AnchorTime()+0) and PAST
+// its last sample (AnchorTime()+135s, see MetricsDataset), so the
+// generated grid slides the query_range window across, before, and
+// beyond the seeded data — the axis the recurring window-anchor bug
+// class (#1499: range endpoints anchoring to now64() instead of the
+// request's [start,end]) lives on. A grid that only ever started
+// inside the safe data window couldn't distinguish a correctly
+// [start,end]-anchored implementation from one that silently
+// substitutes wall-clock `now` for every anchor whose true window
+// happens to still contain data by coincidence.
+var RangeGridStartOffsets = []time.Duration{
+	-60 * time.Second,
+	0,
+	60 * time.Second,
+	200 * time.Second,
+}
+
+// RangeGridSteps is the pool of query_range step sizes (seconds)
+// PromQLRangeQuery draws from. The smallest step densely samples the
+// anchor sweep (catching a window that's mis-anchored only over a
+// narrow sub-range); the largest step still produces a grid spanning
+// a meaningful fraction of RangeGridStartOffsets.
+var RangeGridSteps = []int64{15, 30, 60}
+
+// rangeGridPoints bounds how many anchors a single generated grid
+// produces (end = start + (rangeGridPoints-1)*step): enough to
+// exercise a real matrix per iteration while keeping each property
+// iteration's HTTP round-trip (one oracle eval + one cerberus request
+// per anchor) cheap.
+const rangeGridPoints = 5
+
+// PromQLRangeQuery returns a rapid generator that produces a random
+// RangeQuery targeted at d, restricted to expression shapes that can't
+// trip the known (separately tracked, see promql_test.go's doc
+// comment) aggregate-empty-GroupBy bug: every grouped-sum draw is
+// FORCED to a non-empty grouping label, and the ungrouped-sum /
+// sum(rate(...)) shapes from PromQLQuery's pool are excluded entirely.
+// That lets the grid safely include start offsets before and past the
+// dataset's data window (RangeGridStartOffsets) without spuriously
+// tripping that unrelated, already-documented bug — the whole point of
+// exercising those offsets is to stress the window-anchor property,
+// not to rediscover a different known issue.
+func PromQLRangeQuery(d property.Dataset) *rapid.Generator[RangeQuery] {
+	return rapid.Custom(func(t *rapid.T) RangeQuery {
+		names := d.Metrics.NamesPresent()
+		if len(names) == 0 {
+			// MetricsDataset filters this out before Run() draws a
+			// query; guard anyway so the generator never panics.
+			return RangeQuery{}
+		}
+
+		name := rapid.SampledFrom(names).Draw(t, "metric")
+		matchers := drawMatchers(t, name, d.Metrics)
+		expr := drawRangeExpr(t, name, matchers)
+
+		startOffset := rapid.SampledFrom(RangeGridStartOffsets).Draw(t, "startOffset")
+		step := rapid.SampledFrom(RangeGridSteps).Draw(t, "step")
+
+		startSec := AnchorTime().Add(startOffset).Unix()
+		endSec := startSec + int64(rangeGridPoints-1)*step
+
+		return RangeQuery{
+			String:   expr.String(),
+			StartSec: startSec,
+			EndSec:   endSec,
+			StepSec:  step,
+		}
+	})
+}
+
+// drawRangeExpr picks a restricted expression shape for the range-
+// query generator: bare selector, ALWAYS-grouped sum-by, or bare
+// rate(). Deliberately excludes the ungrouped `sum(...)` and
+// `sum(rate(...))` shapes drawExpr draws for the instant-query
+// generator (see PromQLRangeQuery's doc comment for why).
+func drawRangeExpr(t *rapid.T, name string, matchers []*labels.Matcher) parser.Expr {
+	shape := rapid.IntRange(0, 2).Draw(t, "rangeShape")
+	sel := &parser.VectorSelector{Name: name, LabelMatchers: matchers}
+	switch shape {
+	case 0:
+		return sel
+	case 1:
+		// Non-empty grouping only — never fall back to bare sum(...),
+		// unlike pickLabelName's 50%-chance-of-nil behaviour used by
+		// the instant generator.
+		group := []string{rapid.SampledFrom(LabelNamePool).Draw(t, "groupLabel")}
+		return &parser.AggregateExpr{Op: parser.SUM, Expr: sel, Grouping: group}
+	case 2:
+		return &parser.Call{
+			Func: parser.Functions["rate"],
+			Args: []parser.Expr{drawRangeSelector(t, name, matchers)},
+		}
+	}
+	return sel
+}

--- a/test/property/oracle/promql/absent_clamp_sort.go
+++ b/test/property/oracle/promql/absent_clamp_sort.go
@@ -1,0 +1,141 @@
+package promql
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql/parser"
+)
+
+// evalAbsent implements `absent(v)`: emits a single label-less-except-
+// matchers row with value 1 when v's inner vector is empty, otherwise
+// emits nothing. Matches Prom's funcAbsent + the common
+// createLabelsForAbsentFunction case (a bare vector selector's equality
+// matchers become the output's label set) — the property generator
+// only ever draws a bare selector as absent()'s argument, so the fuller
+// Prom algorithm (which also handles selectors joined by `and`/binary
+// ops) isn't needed here.
+func (e *Evaluator) evalAbsent(c *parser.Call, evalTsMs int64) (value, error) {
+	if len(c.Args) != 1 {
+		return value{}, fmt.Errorf("oracle: absent() expects 1 arg, got %d", len(c.Args))
+	}
+	inner, err := e.evalAny(c.Args[0], evalTsMs)
+	if err != nil {
+		return value{}, err
+	}
+	if inner.Kind != kindVec {
+		return value{}, fmt.Errorf("oracle: absent() argument must be vector")
+	}
+	if len(inner.Vec) > 0 {
+		return value{Kind: kindVec, Vec: nil}, nil
+	}
+	return value{Kind: kindVec, Vec: []VectorRow{
+		{Labels: absentLabels(c.Args[0]), T: evalTsMs, V: 1},
+	}}, nil
+}
+
+// absentLabels extracts the equality matchers off a bare vector
+// selector (excluding __name__) — Prom's createLabelsForAbsentFunction
+// for the single-selector case.
+func absentLabels(expr parser.Expr) map[string]string {
+	out := map[string]string{}
+	vs, ok := expr.(*parser.VectorSelector)
+	if !ok {
+		return out
+	}
+	for _, m := range vs.LabelMatchers {
+		if m.Type == labels.MatchEqual && m.Name != MetricNameLabel {
+			out[m.Name] = m.Value
+		}
+	}
+	return out
+}
+
+// evalClamp implements clamp(v, min, max) / clamp_min(v, min) /
+// clamp_max(v, max) — elementwise, matching Prom's promql/functions.go
+// funcClamp / funcClampMin / funcClampMax. clamp() with max < min
+// yields an empty vector (Prom's documented degenerate case).
+func (e *Evaluator) evalClamp(name string, c *parser.Call, evalTsMs int64) (value, error) {
+	wantArgs := map[string]int{"clamp": 3, "clamp_min": 2, "clamp_max": 2}[name]
+	if len(c.Args) != wantArgs {
+		return value{}, fmt.Errorf("oracle: %s() expects %d args, got %d", name, wantArgs, len(c.Args))
+	}
+	vecVal, err := e.evalAny(c.Args[0], evalTsMs)
+	if err != nil {
+		return value{}, err
+	}
+	if vecVal.Kind != kindVec {
+		return value{}, fmt.Errorf("oracle: %s() first argument must be vector", name)
+	}
+	scalarArg := func(idx int) (float64, error) {
+		sv, err := e.evalAny(c.Args[idx], evalTsMs)
+		if err != nil {
+			return 0, err
+		}
+		if sv.Kind != kindScalar {
+			return 0, fmt.Errorf("oracle: %s() argument %d must be scalar", name, idx)
+		}
+		return sv.Scalar, nil
+	}
+
+	var clampFn func(f float64) float64
+	switch name {
+	case "clamp":
+		minVal, err := scalarArg(1)
+		if err != nil {
+			return value{}, err
+		}
+		maxVal, err := scalarArg(2)
+		if err != nil {
+			return value{}, err
+		}
+		if maxVal < minVal {
+			return value{Kind: kindVec, Vec: nil}, nil
+		}
+		clampFn = func(f float64) float64 { return math.Max(minVal, math.Min(maxVal, f)) }
+	case "clamp_min":
+		minVal, err := scalarArg(1)
+		if err != nil {
+			return value{}, err
+		}
+		clampFn = func(f float64) float64 { return math.Max(minVal, f) }
+	case "clamp_max":
+		maxVal, err := scalarArg(1)
+		if err != nil {
+			return value{}, err
+		}
+		clampFn = func(f float64) float64 { return math.Min(maxVal, f) }
+	default:
+		return value{}, fmt.Errorf("oracle: unsupported clamp variant %q", name)
+	}
+
+	out := make([]VectorRow, len(vecVal.Vec))
+	for i, r := range vecVal.Vec {
+		out[i] = VectorRow{Labels: DropLabel(r.Labels, MetricNameLabel), T: r.T, V: clampFn(r.V)}
+	}
+	sortVectorRows(out)
+	return value{Kind: kindVec, Vec: out}, nil
+}
+
+// evalSort implements sort()/sort_desc(). The comparator (framework's
+// CompareOutcomes) groups rows by label set for comparison, so the
+// series ORDER PromQL specifies has no observable effect on the
+// property test's pass/fail outcome — it only reorders the same set of
+// (label, value) rows the input already carried, drops none, changes
+// none. A pass-through therefore mirrors Prom's actual output set
+// faithfully for this comparator; only the JSON array order (which the
+// comparator doesn't see) would differ.
+func (e *Evaluator) evalSort(c *parser.Call, evalTsMs int64) (value, error) {
+	if len(c.Args) != 1 {
+		return value{}, fmt.Errorf("oracle: sort()/sort_desc() expects 1 arg, got %d", len(c.Args))
+	}
+	inner, err := e.evalAny(c.Args[0], evalTsMs)
+	if err != nil {
+		return value{}, err
+	}
+	if inner.Kind != kindVec {
+		return value{}, fmt.Errorf("oracle: sort()/sort_desc() argument must be vector")
+	}
+	return inner, nil
+}

--- a/test/property/oracle/promql/aggregations.go
+++ b/test/property/oracle/promql/aggregations.go
@@ -126,8 +126,56 @@ func applyAggregator(a *parser.AggregateExpr, rows []VectorRow) ([]aggResult, er
 			return nil, err
 		}
 		return topKBottomK(rows, k, a.Op == parser.BOTTOMK), nil
+	case parser.QUANTILE:
+		phi, err := aggregatorParamFloat(a)
+		if err != nil {
+			return nil, err
+		}
+		return []aggResult{{labels: groupLabels, value: quantileAggregate(phi, rows)}}, nil
 	}
 	return nil, fmt.Errorf("oracle: unsupported aggregation op %s", a.Op)
+}
+
+// aggregatorParamFloat is aggregatorParam's float counterpart, for
+// `quantile(phi, …)` — phi is a real-valued scalar, not an int count.
+func aggregatorParamFloat(a *parser.AggregateExpr) (float64, error) {
+	if a.Param == nil {
+		return 0, fmt.Errorf("oracle: aggregator %s requires a parameter", a.Op)
+	}
+	n, ok := a.Param.(*parser.NumberLiteral)
+	if !ok {
+		return 0, fmt.Errorf("oracle: aggregator %s param must be NumberLiteral, got %T", a.Op, a.Param)
+	}
+	return n.Val, nil
+}
+
+// quantileAggregate implements the `quantile(phi, vector)` aggregator:
+// Prom's textbook sample-quantile over the group's values (promql/
+// quantile.go::quantile) — sort ascending, then weighted-average
+// interpolate between the two samples straddling rank = phi*(n-1).
+// phi < 0 / > 1 / NaN follow Prom's documented out-of-domain results.
+func quantileAggregate(phi float64, rows []VectorRow) float64 {
+	if math.IsNaN(phi) {
+		return math.NaN()
+	}
+	if phi < 0 {
+		return math.Inf(-1)
+	}
+	if phi > 1 {
+		return math.Inf(1)
+	}
+	values := make([]float64, len(rows))
+	for i, r := range rows {
+		values[i] = r.V
+	}
+	sort.Float64s(values)
+
+	n := float64(len(values))
+	rank := phi * (n - 1)
+	lowerIndex := math.Max(0, math.Floor(rank))
+	upperIndex := math.Min(n-1, lowerIndex+1)
+	weight := rank - math.Floor(rank)
+	return values[int(lowerIndex)]*(1-weight) + values[int(upperIndex)]*weight
 }
 
 // aggregatorParam extracts the constant k for topk/bottomk. PromQL

--- a/test/property/oracle/promql/evaluator.go
+++ b/test/property/oracle/promql/evaluator.go
@@ -158,15 +158,19 @@ func applyUnary(op parser.ItemType, in value) (value, error) {
 	return value{}, fmt.Errorf("oracle: unsupported unary op %s on kind=%d", op, in.Kind)
 }
 
-// evalCall dispatches a function call. The MVP set:
+// evalCall dispatches a function call. Supported:
 //
-//   - rate/increase/delta + *_over_time over range vectors.
+//   - rate/increase/delta + *_over_time family over range vectors (see
+//     isRangeFunctionName / evalRangeFunction).
 //   - histogram_quantile(phi, vector) — its second arg is an instant
 //     vector (typically a `sum by(le)(rate(...[range]))`) so we
 //     evaluate it the same way as any other instant vector.
 //   - scalar(vec)         — pick the single-element vector's value.
 //   - vector(scalar)      — wrap a scalar into a one-row, no-label
 //     vector.
+//   - absent(vec)         — see evalAbsent.
+//   - clamp/clamp_min/clamp_max — see evalClamp.
+//   - sort/sort_desc      — see evalSort.
 func (e *Evaluator) evalCall(c *parser.Call, evalTsMs int64) (value, error) {
 	name := c.Func.Name
 	if isRangeFunctionName(name) {
@@ -231,6 +235,12 @@ func (e *Evaluator) evalCall(c *parser.Call, evalTsMs int64) (value, error) {
 		return value{Kind: kindVec, Vec: []VectorRow{
 			{Labels: map[string]string{}, T: evalTsMs, V: inner.Scalar},
 		}}, nil
+	case "absent":
+		return e.evalAbsent(c, evalTsMs)
+	case "clamp", "clamp_min", "clamp_max":
+		return e.evalClamp(name, c, evalTsMs)
+	case "sort", "sort_desc":
+		return e.evalSort(c, evalTsMs)
 	}
 	return value{}, fmt.Errorf("oracle: unsupported function %q", name)
 }

--- a/test/property/oracle/promql/functions.go
+++ b/test/property/oracle/promql/functions.go
@@ -12,7 +12,7 @@ import (
 // stamped at the eval ts. Per Prom semantics, each series's output is
 // computed independently from its window samples.
 //
-// Supported (PR 2 MVP):
+// Supported:
 //
 //   - rate(m[range])              — extrapolated counter rate / sec
 //   - increase(m[range])          — extrapolated counter increase
@@ -22,6 +22,11 @@ import (
 //   - min_over_time(m[range])     — minimum sample
 //   - max_over_time(m[range])     — maximum sample
 //   - count_over_time(m[range])   — sample count in window
+//   - last_over_time(m[range])    — most recent sample in window
+//   - changes(m[range])           — count of value changes in window
+//   - resets(m[range])            — count of counter resets in window
+//   - stddev_over_time(m[range])  — population stddev of window samples
+//   - stdvar_over_time(m[range])  — population variance of window samples
 //
 // Anything else returns an error so the caller can surface it.
 func (e *Evaluator) evalRangeFunction(c *parser.Call, evalTsMs int64) ([]VectorRow, error) {
@@ -89,8 +94,78 @@ func applyRangeFn(name string, samples []Sample, rangeMs, effectiveTs int64) (fl
 		return maxOverTime(samples), len(samples) > 0
 	case "count_over_time":
 		return float64(len(samples)), len(samples) > 0
+	case "last_over_time":
+		if len(samples) == 0 {
+			return 0, false
+		}
+		return samples[len(samples)-1].V, true
+	case "changes":
+		// Prom drops the row only when the window is entirely empty; a
+		// single-sample window is well-defined at 0 changes.
+		return changesOverTime(samples), len(samples) > 0
+	case "resets":
+		return resetsOverTime(samples), len(samples) > 0
+	case "stddev_over_time":
+		return math.Sqrt(varianceOverTime(samples)), len(samples) > 0
+	case "stdvar_over_time":
+		return varianceOverTime(samples), len(samples) > 0
 	}
 	return 0, false
+}
+
+// changesOverTime counts the number of value changes between
+// consecutive samples in window order, matching Prom's funcChanges for
+// the float-only case (no native histograms in this oracle). Two
+// consecutive NaNs count as unchanged, mirroring Prom's explicit
+// !(NaN && NaN) guard.
+func changesOverTime(samples []Sample) float64 {
+	changes := 0
+	for i := 1; i < len(samples); i++ {
+		cur, prev := samples[i].V, samples[i-1].V
+		if cur != prev && !(math.IsNaN(cur) && math.IsNaN(prev)) {
+			changes++
+		}
+	}
+	return float64(changes)
+}
+
+// resetsOverTime counts counter resets (a value lower than the
+// immediately preceding one) across the window, matching Prom's
+// funcResets for the float-only case.
+func resetsOverTime(samples []Sample) float64 {
+	resets := 0
+	for i := 1; i < len(samples); i++ {
+		if samples[i].V < samples[i-1].V {
+			resets++
+		}
+	}
+	return float64(resets)
+}
+
+// varianceOverTime computes the population variance of the window's
+// values — the shared core of stddev_over_time / stdvar_over_time,
+// matching Prom's promql/functions.go::varianceOverTime (mean, then
+// mean of squared deviations). A plain two-pass computation rather
+// than Prom's single-pass Kahan-summed running variance: mathematically
+// equivalent, and the dataset's value magnitudes never approach the
+// range where the numerical difference would exceed the comparator's
+// tolerance.
+func varianceOverTime(samples []Sample) float64 {
+	if len(samples) == 0 {
+		return 0
+	}
+	var mean float64
+	for _, s := range samples {
+		mean += s.V
+	}
+	mean /= float64(len(samples))
+
+	var sumSquares float64
+	for _, s := range samples {
+		d := s.V - mean
+		sumSquares += d * d
+	}
+	return sumSquares / float64(len(samples))
 }
 
 // extrapolatedRate implements Prometheus's rate/increase/delta
@@ -237,13 +312,15 @@ func maxOverTime(samples []Sample) float64 {
 	return m
 }
 
-// isRangeFunctionName returns whether name is one of the MVP
-// range-vector functions this oracle implements.
+// isRangeFunctionName returns whether name is one of the range-vector
+// functions this oracle implements.
 func isRangeFunctionName(name string) bool {
 	switch name {
 	case "rate", "increase", "delta",
 		"sum_over_time", "avg_over_time",
-		"min_over_time", "max_over_time", "count_over_time":
+		"min_over_time", "max_over_time", "count_over_time",
+		"last_over_time", "changes", "resets",
+		"stddev_over_time", "stdvar_over_time":
 		return true
 	}
 	return false

--- a/test/property/oracle/promql/histogram.go
+++ b/test/property/oracle/promql/histogram.go
@@ -92,6 +92,13 @@ type bucketPoint struct {
 	count float64
 }
 
+// smallDeltaTolerance mirrors Prom's promql/quantile.go::smallDeltaTolerance:
+// the relative-delta threshold below which adjacent bucket counts are
+// treated as floating-point noise rather than a real (non-)monotonicity
+// signal. See ensureMonotonic's doc for why this matters for the p50
+// rank specifically.
+const smallDeltaTolerance = 1e-12
+
 // bucketQuantile is the textbook histogram_quantile interpolation,
 // matching Prom's promql/quantile.go::bucketQuantile.
 //
@@ -103,12 +110,17 @@ func bucketQuantile(phi float64, buckets []bucketPoint) (float64, bool) {
 	}
 	sort.Slice(buckets, func(i, j int) bool { return buckets[i].le < buckets[j].le })
 
-	// Ensure cumulative — input is supposed to be cumulative, but
-	// merge duplicate `le` and trust the data otherwise.
+	// Ensure cumulative — input is supposed to be cumulative, but merge
+	// duplicate `le` by SUMMING their counts (Prom's coalesceBuckets:
+	// two buckets sharing an upper bound are the same bucket split
+	// across series/scrapes, so their counts add — overwriting instead
+	// of summing was the bug: a low-rank quantile (e.g. p50) landing in
+	// a bucket with a duplicate `le` would search against an
+	// undercounted cumulative total).
 	deduped := buckets[:0]
 	for _, b := range buckets {
 		if len(deduped) > 0 && deduped[len(deduped)-1].le == b.le {
-			deduped[len(deduped)-1].count = b.count
+			deduped[len(deduped)-1].count += b.count
 			continue
 		}
 		deduped = append(deduped, b)
@@ -122,6 +134,7 @@ func bucketQuantile(phi float64, buckets []bucketPoint) (float64, bool) {
 	if len(buckets) < 2 {
 		return math.NaN(), true
 	}
+	ensureMonotonic(buckets)
 	total := buckets[len(buckets)-1].count
 	if total == 0 {
 		return math.NaN(), true
@@ -154,6 +167,50 @@ func bucketQuantile(phi float64, buckets []bucketPoint) (float64, bool) {
 		return bucketEnd, true
 	}
 	return bucketStart + (bucketEnd-bucketStart)*(rank/count), true
+}
+
+// ensureMonotonic mirrors Prom's promql/quantile.go::
+// ensureMonotonicAndIgnoreSmallDeltas: cumulative bucket counts are
+// supposed to be non-decreasing with `le`, but floating-point
+// accumulation (or genuinely inconsistent scrapes) can produce tiny
+// or even real decreases. bucketQuantile's binary search over
+// cumulative counts is undefined if they're not monotonic, so this
+// pass forces the invariant the same way real Prometheus does:
+// insignificant deltas (below smallDeltaTolerance, relative to the
+// pair's sum) are silently folded away, and any remaining decrease is
+// clamped up to the previous (higher) count.
+//
+// This is the second half of the p50-divergence fix alongside the
+// coalesce-by-sum change in bucketQuantile: without it, a bucket
+// sequence with a tiny non-monotonic step can put the phi*total rank
+// on the wrong side of sort.Search's monotonicity assumption,
+// producing a different bucket (and thus a different interpolated
+// value) than real Prometheus.
+func ensureMonotonic(buckets []bucketPoint) {
+	prev := buckets[0].count
+	for i := 1; i < len(buckets); i++ {
+		curr := buckets[i].count
+		switch {
+		case curr == prev:
+			// No correction needed.
+		case almostEqual(prev, curr, smallDeltaTolerance):
+			buckets[i].count = prev
+		case curr < prev:
+			buckets[i].count = prev
+		default:
+			prev = curr
+		}
+	}
+}
+
+// almostEqual mirrors Prom's util/almost.Equal for the non-stale-NaN
+// case this oracle needs: a and b are "almost equal" if they differ by
+// less than their sum times epsilon.
+func almostEqual(a, b, epsilon float64) bool {
+	if math.IsNaN(a) || math.IsNaN(b) {
+		return math.IsNaN(a) && math.IsNaN(b)
+	}
+	return math.Abs(a-b) <= (a+b)*epsilon
 }
 
 func emitConstQuantile(buckets []VectorRow, v float64, evalTsMs int64) []VectorRow {

--- a/test/property/promql_range_test.go
+++ b/test/property/promql_range_test.go
@@ -1,0 +1,122 @@
+//go:build chdb
+
+// Property test for the PromQL RANGE path (/api/v1/query_range).
+//
+// # Why this test exists (the gap it closes — #1499)
+//
+// TestPromQL_Property_FromScratch (promql_test.go) only ever drives
+// /api/v1/query — a single eval instant. The range path
+// (/api/v1/query_range, a [start,end,step] grid) has its own lowering
+// (internal/promql's range-query plan, internal/chsql's RangeWindow /
+// ts_grid emitters) and is exactly where the repo's recurring
+// window-anchor bug class lives: an endpoint anchoring to now64()
+// (server wall-clock at execution) instead of the request's actual
+// [start,end] window. That bug is invisible to an instant-only oracle
+// sweep — it only manifests when start/end/step actually vary and the
+// grid crosses (or starts before, or ends after) the seeded data.
+//
+// This file closes that gap with the minimal architecture the problem
+// actually needs: PromQL range-query semantics ARE repeated instant
+// evaluation at each grid timestamp (Prometheus's own definition), so
+// no new evaluator logic is required — gen.PromQLRangeQuery draws a
+// [start,end,step] grid (deliberately including offsets before and
+// past the dataset's data window, see its doc comment), the existing
+// from-scratch instant oracle is evaluated once per anchor via
+// oracleRangeOutcome (already defined in rate_dup_timestamp_test.go),
+// and cerberus is driven through its real query_range HTTP handler via
+// runCerberusRange (ditto). The framework's CompareOutcomes already
+// supports multi-row-per-series (matrix) comparison, so no framework
+// changes were needed either.
+//
+// # Aggregate-empty-GroupBy landmine
+//
+// gen.PromQLRangeQuery's expression pool deliberately excludes the
+// ungrouped `sum(...)` / `sum(rate(...))` shapes the instant generator
+// draws, to avoid re-triggering the separately-tracked
+// aggregate-empty-GroupBy bug documented in promql_test.go's doc
+// comment (chplan.Aggregate with empty GroupBy spuriously emits a
+// `{}=0` row on empty input instead of an empty result) — see
+// gen/promql_range.go's doc comment for the full reasoning. That bug
+// is orthogonal to the window-anchor property this test targets, and
+// letting it fire on every off-window anchor would drown the signal
+// this test exists to catch.
+//
+// # CI lane
+//
+// Build-tagged `chdb`; runs in the same `property` workflow as the
+// other property tests (`go test -tags chdb ./test/property/...`).
+package property_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"pgregory.net/rapid"
+
+	"github.com/tsouza/cerberus/internal/api/prom"
+	"github.com/tsouza/cerberus/internal/chclienttest"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/test/property"
+	"github.com/tsouza/cerberus/test/property/gen"
+)
+
+// TestPromQL_RangeProperty_FromScratch sweeps random [start,end,step]
+// grids (including offsets before/past the seeded data window) against
+// random datasets and queries, asserting cerberus's real
+// /api/v1/query_range matrix agrees with the from-scratch instant
+// oracle evaluated independently at every grid anchor.
+//
+// rapid's default iteration count applies (100 locally; the nightly
+// `property` workflow overrides to -rapid.checks=500). To reproduce a
+// failing CI run locally:
+//
+//	go test -tags chdb -run TestPromQL_RangeProperty_FromScratch \
+//	    -rapid.seed=<N> ./test/property/...
+func TestPromQL_RangeProperty_FromScratch(t *testing.T) {
+	cli := chclienttest.NewChDB(t)
+	h := prom.New(cli, schema.DefaultOTelMetrics(), nil)
+	mux := http.NewServeMux()
+	h.Mount(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	rapid.Check(t, func(rt *rapid.T) {
+		ds := gen.MetricsDataset().Draw(rt, "dataset")
+		if len(ds.Metrics.NamesPresent()) == 0 {
+			return
+		}
+		rq := gen.PromQLRangeQuery(ds).Draw(rt, "rangeQuery")
+		if rq.String == "" {
+			return
+		}
+
+		cli.Seed(t, ds.DDL)
+
+		anchors := gridAnchors(rq.StartSec, rq.EndSec, rq.StepSec)
+		oracleOut := oracleRangeOutcome(ds, rq.String, anchors)
+		if oracleOut.Err != nil {
+			// The oracle rejecting a shape this generator draws is a
+			// test-harness bug, not a property finding — every shape
+			// PromQLRangeQuery emits is one the oracle is supposed to
+			// support (bare selector / grouped sum / bare rate).
+			rt.Fatalf("range property: oracle error on generated query\nquery=%s start=%d end=%d step=%d\nerr=%v",
+				rq.String, rq.StartSec, rq.EndSec, rq.StepSec, oracleOut.Err)
+		}
+
+		cerberusOut := runCerberusRange(
+			context.Background(), srv.URL, rq.String,
+			rq.StartSec, rq.EndSec, rq.StepSec,
+		)
+		if cerberusOut.Err != nil {
+			rt.Fatalf("range property: cerberus error\nquery=%s start=%d end=%d step=%d\nerr=%v",
+				rq.String, rq.StartSec, rq.EndSec, rq.StepSec, cerberusOut.Err)
+		}
+
+		if diff := property.CompareOutcomes(oracleOut, cerberusOut); diff != "" {
+			rt.Fatalf("range property: drift vs oracle across grid %d..%d/%ds\nquery=%s\n--- diff ---\n%s",
+				rq.StartSec, rq.EndSec, rq.StepSec, rq.String, diff)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Fixes two related issues sharing one root cause: the PromQL oracle differential doesn't actually exercise what it claims to cover.

- **#1499** — `test/property/promql_test.go`'s rapid-based property harness only ever drove the INSTANT path (`/api/v1/query`); the range path (`/api/v1/query_range`) had no oracle coverage at all, despite being exactly where the repo's recurring window-anchor bug class (endpoints silently anchoring to `now64()` instead of the request's `[start,end]`) lives.
- **#1488** — Six `DEFERRED` markers in `test/integration/promql/matrix.go` excluded whole comparison families, functionally an allow-list-as-prose.

## #1499 — range-query property test

Adds `gen.PromQLRangeQuery` (a `[start,end,step]` grid generator that deliberately includes offsets before and past the seeded data window) and `TestPromQL_RangeProperty_FromScratch`. Range-query semantics ARE repeated instant evaluation, so no new oracle logic was needed — the existing from-scratch instant oracle is evaluated once per grid anchor and compared against cerberus's real `query_range` handler. Verified locally (200+ rapid iterations, all green).

## #1488 — per-marker findings

| Marker | Verdict | Resolution |
|---|---|---|
| `hq_p50` interpolation mismatch | **Oracle bug** | `histogram.go`'s `bucketQuantile` overwrote same-`le` buckets on merge and skipped Prometheus's monotonicity repair before interpolating. Fixed (coalesce-by-sum + `ensureMonotonic`, mirroring `prometheus/promql/quantile.go`). Now passes, wired into `cat2Histogram`. |
| `histogram_quantile` over a bare, non-`rate`-wrapped bucket-selector aggregation | **New cerberus bug, found while re-investigating `hq_p50`** | `histogram_quantile.go`'s `matchHistogramAggIdiom` only recognizes the `rate`/`increase`/`sum_over_time`-wrapped idiom and forces an unconditional empty result for anything else — including a real `_bucket` selector aggregated without a range-vector wrapper. Needs a new lowering shape (latest-sample-per-series aggregation, not a windowed reduction); out of scope here. **Filed #1692.** |
| `quantile()` aggregator | **Both already implemented, just not wired** | Cerberus and the oracle both support it. Added 4 cases to `cat3Aggregators`, all pass. |
| `count_values`/`limitk`/`limit_ratio` | **Genuine oracle gap** | Cerberus implements all three; the oracle doesn't (limitk/limit_ratio also raise a non-determinism design question for the oracle). **Filed #1693.** |
| Set operators (`and`/`or`/`unless`) | **Already oracle-evaluated** | Was never actually excluded — the original doc comment's claim was stale. No behavior change; comment corrected. |
| `absent`/`clamp`/`clamp_min`/`clamp_max`/`sort`/`sort_desc` | **Oracle support added** | New `test/property/oracle/promql/absent_clamp_sort.go`. Wired 6 new cases into `cat8ScalarVector`, all pass. |
| `changes`/`resets`/`last_over_time`/`stddev_over_time`/`stdvar_over_time` | **Oracle support added** | Wired into `cat9OverTime`. `resets()`/`changes()` need a series that actually resets to be a meaningful (non-vacuous) assertion — `seed.go` gains `demo_worker_restarts_total`, a new counter series with a real reset at the window midpoint (additive; no existing series changed). |
| `deriv`/`predict_linear`/`double_exponential_smoothing`/`quantile_over_time` | **Genuine oracle gap** | Distinct from the fold-shaped functions above — regression/smoothing math, not a simple accumulate. **Filed #1695.** |
| Subqueries, `label_replace`/`label_join` | **Genuine oracle gap** | Confirmed unimplemented via grep of `test/property/oracle/promql/*.go`. **Filed #1694.** |
| Native (exponential) histograms | **Genuine oracle gap** | The oracle is float-only; cerberus does support native histograms (Layer 2a `*_exp.txtar` goldens cover the SQL shape). Adding oracle support is a standalone feature-sized effort (new value representation + generator). **Filed #1696.** |

Also corrects the top-level `ExoticMatrix` doc comment and the `cat4`/`cat7` comments, which cited a "deterministic promqltest tail" as covering `@ start()/end()` and stale/NaN handling — **no such package exists anywhere in this repository** (`grep -rl promqltest` matches nothing but the stale comments themselves). Replaced with citations to the real `test/spec/promql/*.txtar` goldens that actually cover those cases.

## Verification

- `go test -tags chdb -run TestExoticPromQL ./test/integration/promql/ -v` — all ~90 subtests pass (including the 20 new/changed cases).
- `go test -tags chdb ./test/property/ -rapid.checks=20 -v` — all property suites pass, including the new range property test.
- `go build -tags chdb ./...` — clean.
- Pre-push hooks (golangci-lint, forbid-sql-raw, forbid-skip, markdownlint, commitlint) all green locally.

## Follow-up issues filed

- #1692 — `histogram_quantile` bare-aggregation-over-`_bucket` cerberus bug
- #1693 — oracle: implement `count_values`/`limitk`/`limit_ratio`
- #1694 — oracle: implement subqueries + `label_replace`/`label_join`
- #1695 — oracle: implement `deriv`/`predict_linear`/`double_exponential_smoothing`/`quantile_over_time`
- #1696 — oracle: implement native (exponential) histogram evaluation

Closes #1499
Closes #1488
