### PR TITLE
fix(ci): lower query-parallelism for the floor-pinned compat lane

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -639,10 +639,29 @@ jobs:
         # CH_IMAGE pins the compose ClickHouse service to the declared
         # floor; everything else matches compatibility/prometheus exactly
         # so the only variable under test is the server version.
+        #
+        # TESTER_QUERY_PARALLELISM=2: below the ts_grid_* / native-rate
+        # floor (25.9, #1500) the fallback SQL does real per-row
+        # rate/quantile/reset aggregation, which is genuinely slower than
+        # the native-function path every other lane exercises. The
+        # upstream tester hardcodes a 10s deadline per comparison
+        # (upstream/promql/comparer/comparer.go) with no flag to raise
+        # it, so at its default -query-parallelism=20 enough
+        # genuinely-slower floor queries queue behind each other that
+        # some miss that shared deadline on pure contention, not a real
+        # divergence (report.json shows empty diffs, just "context
+        # deadline exceeded"). Measured directly against this same image
+        # under a 2-vCPU cap (this runner class): every affected query
+        # answers in under 3s alone; concurrency 20 reproduces >10s
+        # response times, concurrency 2 stays under ~4s with comfortable
+        # margin. Lowering parallelism is the honest fix — it changes
+        # only how much load the floor lane offers at once, not which
+        # SQL cerberus emits or what the ratchet compares.
         env:
           TESTER_END_TIME: "2026-05-11T01:00:00Z"
           TESTER_RANGE: "3600"
           CH_IMAGE: "clickhouse/clickhouse-server:24.8"
+          TESTER_QUERY_PARALLELISM: "2"
         run: ./compatibility/prometheus/scripts/run-prometheus-compatibility.sh
 
       - name: Summarise report

--- a/compatibility/prometheus/scripts/run-prometheus-compatibility.sh
+++ b/compatibility/prometheus/scripts/run-prometheus-compatibility.sh
@@ -57,6 +57,36 @@
 #                      interpolation before compose-pull-images.mjs reads
 #                      the model, so the override reaches both the
 #                      pre-pull and `up`.
+#   TESTER_QUERY_PARALLELISM  passed through to the upstream tester's
+#                      `-query-parallelism` flag (tester default: 20).
+#                      Unset here means the flag is omitted and the
+#                      tester's own default applies — the standard
+#                      compatibility/prometheus lane relies on that.
+#                      compatibility/prometheus-floor sets this LOW (see
+#                      that job's comment in compatibility.yml): below
+#                      25.9 every ts_grid_* native-rate feature resolves
+#                      OFF (#1500), so the floor lane's fallback SQL does
+#                      real per-row rate/quantile/reset aggregation
+#                      instead of ClickHouse's native windowed
+#                      functions — genuinely slower, not incorrect.
+#                      promql-compliance-tester's comparer
+#                      (upstream/promql/comparer/comparer.go) wraps EACH
+#                      comparison's ref+test QueryRange pair in one
+#                      hardcoded `context.WithTimeout(..., 10*time.Second)`
+#                      with no flag to raise it, so at the tester's
+#                      default 20-way concurrency, enough of these
+#                      genuinely-slower floor-lane queries queue behind
+#                      each other that some individually-fast queries miss
+#                      the shared 10s deadline purely from contention —
+#                      "context deadline exceeded" with an empty diff, not
+#                      a semantic divergence. Confirmed by direct
+#                      measurement: every one of the CI-observed timeout
+#                      cases answers in under 3s in isolation; firing the
+#                      same query set at -query-parallelism-equivalent
+#                      concurrency against a 2-vCPU-constrained container
+#                      (matching a GH Actions standard runner) reproduces
+#                      individual response times past 10s at concurrency
+#                      20, comfortably under it at concurrency 2.
 #
 # Upstream tester invocation (post-PR #298 / #300 audit):
 #   The upstream `promql-compliance-tester` only accepts `-config-file`
@@ -200,12 +230,18 @@ echo "==> running tester"
 # distinguish the two by checking whether report.json was produced
 # AND parses as JSON with a non-null results array — if so, RC=1 is
 # parity drift; otherwise it's hard.
+TESTER_ARGS=(
+    -config-file "$ROOT_DIR/test-cerberus.yml"
+    -config-file "$QUERIES"
+    -config-file "$OVERLAY"
+    -output-format json
+)
+if [ -n "${TESTER_QUERY_PARALLELISM:-}" ]; then
+    TESTER_ARGS+=(-query-parallelism "$TESTER_QUERY_PARALLELISM")
+fi
+
 set +e
-"$TESTER_BIN" \
-    -config-file "$ROOT_DIR/test-cerberus.yml" \
-    -config-file "$QUERIES" \
-    -config-file "$OVERLAY" \
-    -output-format json > "$OUTPUT"
+"$TESTER_BIN" "${TESTER_ARGS[@]}" > "$OUTPUT"
 TESTER_RC=$?
 set -e
 


### PR DESCRIPTION
## Summary

`compatibility/prometheus-floor` (added in #1691, informational, not a required
check) has been red on `main` since #1691 merged — both post-merge runs
(`d966d866`, `af1e9c7f`) failed with exactly this one job, nothing else. This
PR is the fix.

## Why this is a separate PR instead of landing in #1691

I had this fix ready and committed on `fix/ch-floor-pinned-compat-1500`
(#1691's head branch), but #1691 merged (auto-merge, once all *required*
checks went green — `prometheus-floor` is informational so it didn't block)
before I pushed it. Per this repo's "never push to the head branch of a
merged PR" rule, that commit is stranded on a closed PR — this is a fresh
branch off `origin/main` carrying the same commit via cherry-pick, verified
`git merge-base --is-ancestor` shows it is genuinely not yet in `main`.

## Root cause

`compatibility/prometheus-floor` runs the standard PromQL differential corpus
against `clickhouse/clickhouse-server:24.8` instead of the usual 26.5-class
substrate. Below `min_native_rate` (25.9, #1500) every `ts_grid_*` feature in
`internal/chopt` resolves OFF, so the floor lane's fallback SQL does real
per-row rate/quantile/reset aggregation instead of ClickHouse's native
windowed functions — genuinely slower per query, not incorrect.

`promql-compliance-tester`'s comparer
(`compatibility/prometheus/upstream/promql/comparer/comparer.go`) wraps every
comparison's ref+test `QueryRange` pair in one hardcoded
`context.WithTimeout(ctx, 10*time.Second)` with no flag to raise it, and the
harness runs at the tester's default `-query-parallelism 20`. Enough of the
genuinely-slower floor-lane queries queue behind each other under that
concurrency that some individually-fast queries miss the shared 10s deadline
on pure contention — CI shows this as `"unexpectedFailure": "...context
deadline exceeded"` with an empty `diff` (20/739 cases in #1691's CI runs;
the two post-merge runs on `main` show the same shape), which the ratchet
correctly reads as ARRIVED-FAILING since it's not in the baseline.

Confirmed this is contention, not a correctness gap:

- **Isolated latency.** Curled each failing query individually against a
  live 24.8-pinned stack: all returned `200` in under 3s (`histogram_quantile`
  worst case ~2.1s, `resets`/`changes`/`clamp*` all <0.15s).
- **Reproduced under load.** Firing the same failing-query set at
  concurrency 20 against a 2-vCPU-constrained container (matching a GH
  Actions standard runner) reproduced response times past 10s; the same set
  at concurrency 2 stayed under ~4s with comfortable margin.

## Fix

Thread a new `TESTER_QUERY_PARALLELISM` env var through
`run-prometheus-compatibility.sh` into the upstream tester's existing
`-query-parallelism` flag (a first-class supported flag — no source patch to
the vendored tester needed, unlike the existing symmetric-sort patch which
fixes a real upstream ordering bug). Left unset for
`compatibility/prometheus` and `compatibility/prometheus-forced-route`, so
they keep the tester's own default of 20; set to `2` for
`prometheus-floor` only, since it's the one lane whose fallback SQL is
genuinely slower.

## Verification

Ran the full harness locally against a clean `clickhouse-server:24.8` stack
with the fix (submodule initialised at the pinned commit, full 739-case
corpus, `-query-parallelism 2`):

**`passed=739 total=739 percent=100.00`, zero diffs, zero unexpected
failures.**

This is also the concrete answer to #1691's design fork (floor-pinned CI lane
vs. raising `minCHBase`): the 24.8 lane does go green once this harness-level
concurrency issue is fixed, so `minCHBase` stays at 24.8 — the failure was
never a floor-fallback SQL problem.

## Test plan

- [x] `just lint` clean (pre-push lefthook ran `golangci-lint run ./...` +
      `--build-tags cerberus_untagged_build`, 0 issues; `markdownlint-cli2`,
      0 errors)
- [x] Full local run of `run-prometheus-compatibility.sh` against a clean
      `clickhouse-server:24.8` stack with the `-query-parallelism 2` fix —
      `passed=739 total=739 percent=100.00`, zero diffs, zero unexpected
      failures
- [ ] CI green — pending, polling (including `compatibility/prometheus-floor`
      itself, which is informational but should now pass)
