### PR TITLE
ci(spec): round-trip the OPTIMIZED plan, not just the pre-optimizer one

### DIFF
--- a/internal/logql/lower_test.go
+++ b/internal/logql/lower_test.go
@@ -82,8 +82,19 @@ func TestLower(t *testing.T) {
 		// Every real lowered plan must pass the fail-closed
 		// scan-time-bound invariant (see AssertScanTimeBoundAccepts):
 		// the LogQL unwrap / *_over_time leaves are instant
-		// windowed-array leaves too.
-		spec.AssertScanTimeBoundAccepts(t, plan)
+		// windowed-array leaves too. AssertScanTimeBoundAccepts also
+		// returns the OPTIMIZED plan — production always runs the
+		// optimizer before chsql.Emit (see internal/engine/engine.go)
+		// — so re-emitting it and round-tripping against chDB below
+		// is the post-optimizer half of the golden coverage the
+		// pre-optimizer sql/args/chplan sections above already
+		// provide (issue #1700).
+		optimized := spec.AssertScanTimeBoundAccepts(t, plan)
+		optSQL, optArgs, err := chsql.Emit(context.Background(), optimized)
+		if err != nil {
+			t.Fatalf("Emit(optimized plan): %v", err)
+		}
+		spec.RunRoundTripSQL(t, c, optSQL, optArgs)
 	})
 }
 

--- a/internal/promql/lower_test.go
+++ b/internal/promql/lower_test.go
@@ -191,7 +191,12 @@ func TestLower(t *testing.T) {
 		// NormalizeScanTimeBound establishes the instant windowed-array
 		// leaf scan bound and RequireScanTimeBound verifies it. A panic
 		// here would mean this query shape reaches production unbounded.
-		spec.AssertScanTimeBoundAccepts(t, plan)
+		optimized := spec.AssertScanTimeBoundAccepts(t, plan)
+		optSQL, optArgs, err := chsql.Emit(context.Background(), optimized)
+		if err != nil {
+			t.Fatalf("Emit(optimized plan): %v", err)
+		}
+		spec.RunRoundTripSQL(t, c, optSQL, optArgs)
 	})
 }
 

--- a/internal/traceql/lower_test.go
+++ b/internal/traceql/lower_test.go
@@ -84,6 +84,31 @@ func TestLower(t *testing.T) {
 		// Every real lowered plan must pass the fail-closed
 		// scan-time-bound invariant (see AssertScanTimeBoundAccepts).
 		spec.AssertScanTimeBoundAccepts(t, plan)
+
+		// Production always runs the optimizer before chsql.Emit (see
+		// internal/engine/engine.go's Parse -> ProjectSamples -> Optimize
+		// -> Emit order), but for a search-shaped query it optimizes the
+		// WRAPPED plan (post-ProjectSamples), not the raw plan lowered
+		// above. Reconstruct that wrapped shape via the same helper the
+		// chDB round-trip lane already leans on for issue #1653, so the
+		// optimized SQL below matches what expected_rows was captured
+		// against. Metrics-pipeline queries never take the wrap (see
+		// ReconstructTraceQLSearchWrapPlan's doc comment), so they fall
+		// back to optimizing the raw lowered plan directly, matching how
+		// expected_rows was captured for them too. Closing this gap is
+		// issue #1700.
+		roundTripInput := plan
+		if wrapPlan, ok, werr := spec.ReconstructTraceQLSearchWrapPlan(c); werr != nil {
+			t.Fatalf("fixture %s: traceql wrap reconstruction: %v", c.Name, werr)
+		} else if ok {
+			roundTripInput = wrapPlan
+		}
+		optimized := spec.AssertScanTimeBoundAccepts(t, roundTripInput)
+		optSQL, optArgs, err := chsql.Emit(context.Background(), optimized)
+		if err != nil {
+			t.Fatalf("Emit(optimized plan): %v", err)
+		}
+		spec.RunRoundTripSQL(t, c, optSQL, optArgs)
 	})
 }
 

--- a/test/spec/runner_chdb.go
+++ b/test/spec/runner_chdb.go
@@ -1056,6 +1056,8 @@ func RunRoundTrip(t *testing.T, c *Case) {
 		t.Fatalf("fixture %s has seed/expected_rows but missing sql section", c.Name)
 	}
 
+	sql, args := rt.SQL, rt.Args
+
 	// TraceQL search-shaped fixtures are captured pre-ProjectSamples (see
 	// ReconstructTraceQLSearchWrap's doc comment) — the SAME gap #1635 fixed
 	// for the strict-scan differential (issue #1653). Substitute the
@@ -1068,9 +1070,60 @@ func RunRoundTrip(t *testing.T, c *Case) {
 	if wrapSQL, wrapArgs, ok, err := ReconstructTraceQLSearchWrap(c); err != nil {
 		t.Fatalf("fixture %s: traceql wrap reconstruction: %v", c.Name, err)
 	} else if ok {
-		rt.SQL = wrapSQL
-		rt.Args = wrapArgs
+		sql, args = wrapSQL, wrapArgs
 	}
+
+	// expected_rows is ground truth for the pre-optimizer SQL above, so a
+	// mismatch here is safe to fold into GOLDEN_UPDATE.
+	runRoundTripSQL(t, c, rt, sql, args, true)
+}
+
+// RunRoundTripSQL is [RunRoundTrip]'s post-optimizer twin: it executes a
+// CALLER-SUPPLIED sql/args pair — typically chsql.Emit of the OPTIMIZED
+// plan (see spec.AssertScanTimeBoundAccepts's return value) — against the
+// same fixture's `seed:` and asserts the resulting rows still match
+// `expected_rows:`.
+//
+// This exists because production always runs the optimizer before
+// chsql.Emit (internal/engine/engine.go's Parse → ProjectSamples →
+// Optimize → Emit order), but every *.txtar fixture's own `sql:` /
+// `chplan:` sections — and, until now, the `expected_rows:` round-trip
+// itself — only ever validated the PRE-optimizer plan (issue #1700). The
+// optimizer is meant to be semantics-preserving, so the optimized SQL's
+// result set should be byte-identical to the pre-optimizer SQL's; a
+// mismatch here is a real optimizer bug, not a golden to regenerate — so,
+// unlike RunRoundTrip, GOLDEN_UPDATE=1 never rewrites `expected_rows` from
+// this path. `expected_rows` stays anchored to the pre-optimizer
+// execution that RunRoundTrip captures; this function only ever compares
+// against it.
+//
+// A no-op for fixtures that never opted into round-trip execution, same
+// as RunRoundTrip.
+func RunRoundTripSQL(t *testing.T, c *Case, sql string, args []any) {
+	t.Helper()
+	rt, err := LoadRoundTrip(c)
+	if err != nil {
+		t.Fatalf("LoadRoundTrip: %v", err)
+	}
+	if !rt.IsRoundTrip() {
+		return
+	}
+	if strings.TrimSpace(sql) == "" {
+		t.Fatalf("fixture %s: optimized SQL is empty", c.Name)
+	}
+	runRoundTripSQL(t, c, rt, sql, args, false)
+}
+
+// runRoundTripSQL is the shared chDB-execution core both RunRoundTrip and
+// RunRoundTripSQL delegate to: it seeds an ephemeral chDB session, executes
+// sql/args, and asserts the resulting rows match rt.ExpectedRows.
+// allowGoldenUpdate gates whether a mismatch under GOLDEN_UPDATE=1 rewrites
+// `expected_rows` in place (RunRoundTrip, the pre-optimizer ground truth)
+// or fails outright (RunRoundTripSQL, the post-optimizer check — a
+// mismatch there must never silently become the new "expected", since
+// that would launder a real optimizer bug into a passing golden).
+func runRoundTripSQL(t *testing.T, c *Case, rt *RoundTripSections, sql string, args []any, allowGoldenUpdate bool) {
+	t.Helper()
 
 	// Acquire the process-global chDB engine lock for the FULL engine
 	// span of this case: open/ping/seed, query, row iteration, and
@@ -1093,7 +1146,7 @@ func RunRoundTrip(t *testing.T, c *Case) {
 	// inspects the SQL. The two passes are independent textually but
 	// the args side is global, and ordering them this way keeps the
 	// argIdx accounting in substituteNow64 simple.
-	query, queryArgs := substituteNow64(rt.SQL, rt.Args)
+	query, queryArgs := substituteNow64(sql, args)
 	query = expandStarProjection(query, seedTableColumns(rt.Seed))
 	query = rewriteMapProjections(query)
 	query = nestMapOrderBy(query)
@@ -1167,8 +1220,9 @@ func RunRoundTrip(t *testing.T, c *Case) {
 		// internal/promql/lower_test.go. Lets dev/CI regenerate the
 		// round-trip cells after a semantically-correct query
 		// change (e.g., PromQL `__name__`-drop fix in #355) without
-		// hand-editing 70+ fixtures.
-		if os.Getenv(envGoldenUpdate) == "1" {
+		// hand-editing 70+ fixtures. Never taken from the
+		// post-optimizer path (see RunRoundTripSQL's doc comment).
+		if allowGoldenUpdate && os.Getenv(envGoldenUpdate) == "1" {
 			Match(t, c, map[string]string{
 				"expected_rows": formatExpectedRows(gotNorm),
 			})

--- a/test/spec/runner_nochdb.go
+++ b/test/spec/runner_nochdb.go
@@ -19,3 +19,14 @@ func RunRoundTrip(t *testing.T, c *Case) {
 	// the chdb build tag.
 	_ = c
 }
+
+// RunRoundTripSQL is a no-op when the `chdb` build tag is not set. The
+// real implementation lives in runner_chdb.go.
+func RunRoundTripSQL(t *testing.T, c *Case, sql string, args []any) {
+	t.Helper()
+	// Intentionally empty — seed: / expected_rows: are inert without
+	// the chdb build tag.
+	_ = c
+	_ = sql
+	_ = args
+}

--- a/test/spec/scan_time_bound.go
+++ b/test/spec/scan_time_bound.go
@@ -11,7 +11,8 @@ import (
 // AssertScanTimeBoundAccepts runs the full optimizer pipeline — which includes
 // the fail-closed analyzer.scan-time-bound batch (NormalizeScanTimeBound then
 // RequireScanTimeBound) — over a real lowered plan and fails the test if the
-// invariant rejects it.
+// invariant rejects it. It returns the optimized plan so callers can reuse it
+// instead of running the optimizer a second time.
 //
 // NormalizeScanTimeBound establishes the instant windowed-array leaf scan bound
 // and RequireScanTimeBound verifies every such leaf carries it; a panic here
@@ -21,17 +22,28 @@ import (
 // corpus into a standing proof that NormalizeScanTimeBound's reach matches
 // RequireScanTimeBound's demand across every lowered shape.
 //
+// Production always runs the optimizer before chsql.Emit (see
+// internal/engine/engine.go's Parse → ProjectSamples → Optimize → Emit
+// order), so the plan returned here — not the raw pre-optimizer plan the
+// caller's own `-- sql --` / `-- chplan --` golden sections capture — is
+// what actually reaches ClickHouse in production. Callers use it to re-emit
+// and round-trip against chDB (see RunRoundTripSQL), closing the gap
+// described in issue #1700: a fixture corpus that only ever validated the
+// pre-optimizer plan.
+//
 // Run never mutates its input, so calling this after the emit-golden assertion
 // leaves the caller's plan untouched.
-func AssertScanTimeBoundAccepts(t *testing.T, plan chplan.Node) {
+func AssertScanTimeBoundAccepts(t *testing.T, plan chplan.Node) chplan.Node {
 	t.Helper()
 	if plan == nil {
-		return
+		return nil
 	}
+	var optimized chplan.Node
 	defer func() {
 		if r := recover(); r != nil {
 			t.Fatalf("scan-time-bound invariant rejected a real lowered plan: %v", r)
 		}
 	}()
-	_ = optimizer.Default().Run(context.Background(), plan)
+	optimized = optimizer.Default().Run(context.Background(), plan)
+	return optimized
 }

--- a/test/spec/traceql_wrap.go
+++ b/test/spec/traceql_wrap.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/tsouza/cerberus/internal/api/tempo"
+	"github.com/tsouza/cerberus/internal/chplan"
 	"github.com/tsouza/cerberus/internal/chsql"
 	"github.com/tsouza/cerberus/internal/schema"
 	traceqllower "github.com/tsouza/cerberus/internal/traceql"
@@ -66,51 +67,67 @@ const traceqlWrapExplainStep = time.Minute
 // ProjectSamples here are byte-for-byte what engine.QueryPlan would run for
 // this query.
 func ReconstructTraceQLSearchWrap(c *Case) (sqlStr string, args []any, ok bool, err error) {
+	plan, ok, err := ReconstructTraceQLSearchWrapPlan(c)
+	if err != nil || !ok {
+		return "", nil, ok, err
+	}
+	sqlStr, args, err = chsql.Emit(context.Background(), plan)
+	if err != nil {
+		return "", nil, false, fmt.Errorf("chsql.Emit(wrapped): %w", err)
+	}
+	return sqlStr, args, true, nil
+}
+
+// ReconstructTraceQLSearchWrapPlan is [ReconstructTraceQLSearchWrap]'s
+// plan-level twin: it returns the WRAPPED, pre-optimizer chplan.Node
+// instead of already-emitted SQL, so a caller can run its own optimizer
+// pass before emitting — see internal/traceql/lower_test.go's post-
+// optimizer round-trip check (issue #1700), which needs the wrapped shape
+// production actually optimizes for search-shaped queries, not the raw
+// pre-wrap plan its own `-- chplan --` / `-- sql --` golden sections
+// capture. ok/err follow the exact same contract as
+// ReconstructTraceQLSearchWrap; see that function's doc comment for the
+// two "leave the fixture's original plan untouched" cases.
+func ReconstructTraceQLSearchWrapPlan(c *Case) (plan chplan.Node, ok bool, err error) {
 	query, hasQuery := c.Section("query.traceql")
 	if !hasQuery {
-		return "", nil, false, nil
+		return nil, false, nil
 	}
 	query = strings.TrimSpace(query)
 
 	expr, err := traceqlast.Parse(query)
 	if err != nil {
-		return "", nil, false, fmt.Errorf("traceql parse: %w", err)
+		return nil, false, fmt.Errorf("traceql parse: %w", err)
 	}
 	if expr.MetricsPipeline != nil || expr.MetricsSecondStage != nil {
-		return "", nil, false, nil
+		return nil, false, nil
 	}
 
 	ctx := context.Background()
 	if v, hasLimit := c.Section("search_limit"); hasLimit {
 		n, perr := strconv.Atoi(strings.TrimSpace(v))
 		if perr != nil {
-			return "", nil, false, fmt.Errorf("bad search_limit %q: %w", v, perr)
+			return nil, false, fmt.Errorf("bad search_limit %q: %w", v, perr)
 		}
 		ctx = traceqllower.WithSearchTraceLimit(ctx, n)
 	}
 	if v, hasWindow := c.Section("search_window"); hasWindow {
 		fields := strings.Fields(v)
 		if len(fields) != 2 {
-			return "", nil, false, fmt.Errorf("search_window wants two Unix-second bounds, got %q", v)
+			return nil, false, fmt.Errorf("search_window wants two Unix-second bounds, got %q", v)
 		}
 		startSec, err1 := strconv.ParseInt(fields[0], 10, 64)
 		endSec, err2 := strconv.ParseInt(fields[1], 10, 64)
 		if err1 != nil || err2 != nil {
-			return "", nil, false, fmt.Errorf("bad search_window %q", v)
+			return nil, false, fmt.Errorf("bad search_window %q", v)
 		}
 		ctx = traceqllower.WithSearchWindow(ctx, time.Unix(startSec, 0).UTC(), time.Unix(endSec, 0).UTC())
 	}
 
 	lang := tempo.NewExplainLang(schema.DefaultOTelTraces(), traceqlWrapExplainStep)
-	plan, meta, err := lang.Parse(ctx, query)
+	rawPlan, meta, err := lang.Parse(ctx, query)
 	if err != nil {
-		return "", nil, false, fmt.Errorf("traceql lower (wrap reconstruction): %w", err)
+		return nil, false, fmt.Errorf("traceql lower (wrap reconstruction): %w", err)
 	}
-	wrapped := lang.ProjectSamples(plan, meta)
-
-	sqlStr, args, err = chsql.Emit(context.Background(), wrapped)
-	if err != nil {
-		return "", nil, false, fmt.Errorf("chsql.Emit(wrapped): %w", err)
-	}
-	return sqlStr, args, true, nil
+	return lang.ProjectSamples(rawPlan, meta), true, nil
 }


### PR DESCRIPTION
## Summary

Every `*.txtar` fixture's `sql`/`args`/`chplan` sections, and even the chDB `expected_rows` round-trip, only ever validated the plan **before** `optimizer.Default().Run` — production always optimizes before `chsql.Emit` (`internal/engine/engine.go`'s `Parse -> ProjectSamples -> Optimize -> Emit` order). `ProjectionPushdown` narrows a leaf `Scan`'s column list only post-optimization, so a fixture could pass every gate while the actual production plan referenced a base column the narrowed `Scan` no longer selects — a 502 with everything green, and no detector for it.

This PR closes the gap the honest way (design option (b) from the issue): it round-trips the **optimized** plan against chDB, not just the pre-optimizer one.

- `spec.AssertScanTimeBoundAccepts` (already invoked by all three heads' `TestLower` on real lowered plans, to enforce the fail-closed scan-time-bound invariant) now **returns** the optimized plan instead of discarding it.
- Each head (`internal/promql`, `internal/logql`, `internal/traceql`) re-emits that optimized plan and executes it against chDB via a new `spec.RunRoundTripSQL(t, c, sql, args)` entrypoint (with a `!chdb` no-op stub, mirroring `RunRoundTrip`'s existing dual-file pattern), asserting the result still matches the fixture's existing `expected_rows`.
- The optimizer is supposed to be semantics-preserving, so this is a real correctness check, not a golden to regenerate: unlike `RunRoundTrip`, `RunRoundTripSQL` **never** lets `GOLDEN_UPDATE=1` rewrite `expected_rows` on a mismatch — that would launder a real optimizer bug into a passing fixture.
- TraceQL search-shaped fixtures optimize the **wrapped** (post-`ProjectSamples`) plan via a new `spec.ReconstructTraceQLSearchWrapPlan` (a plan-returning sibling of the existing `ReconstructTraceQLSearchWrap`, which now delegates to it), matching what `expected_rows` was captured against for those fixtures (see issue #1653). Metrics-pipeline fixtures fall back to optimizing the raw lowered plan, exactly as `expected_rows` was captured for them.

## Result

Ran the full chdb-tagged suite (~855 real per-head fixtures across promql/logql/traceql, plus the existing `test/spec/{promql,logql,traceql}` round-trip packages) against this new gate: **zero mismatches**. The optimizer is semantics-preserving across the entire existing corpus, so this lands with no golden churn — the gate is ready to catch the *next* regression instead of merely documenting today's clean state.

Local verification:
- `go build ./...` and `go build -tags chdb ./...` — clean.
- `go test -tags chdb -run TestLower ./internal/{promql,logql,traceql}/...` — all green.
- `go test -tags chdb ./test/spec/...` — all green (existing round-trip packages unaffected by the `runner_chdb.go` refactor).
- `go build -tags integration ./test/spec/...` — clean (the strict-scan differential's use of `ReconstructTraceQLSearchWrap` is untouched — same signature, same behavior, now implemented via the new plan-returning sibling).

Closes #1700