### PR TITLE
fix(perf): make fan_factor honest — null instead of a fabricated 1.00

### DIFF
--- a/cmd/perf-profile/main_chdb.go
+++ b/cmd/perf-profile/main_chdb.go
@@ -62,15 +62,20 @@ func main() {
 		printTopTable(os.Stderr, recs, *top)
 	}
 
-	// Summary line: total fixtures, how many had errors.
-	var nErr int
+	// Summary line: total fixtures, how many had errors, how many are
+	// unmeasured (fan_factor nil — see [profile.Record.FanFactor]).
+	var nErr, nUnmeasured int
 	var maxFan float64
 	for _, r := range recs {
 		if r.Err != "" {
 			nErr++
 		}
-		if r.FanFactor > maxFan {
-			maxFan = r.FanFactor
+		if r.FanFactor == nil {
+			nUnmeasured++
+			continue
+		}
+		if *r.FanFactor > maxFan {
+			maxFan = *r.FanFactor
 		}
 	}
 
@@ -79,13 +84,13 @@ func main() {
 		if n <= 0 {
 			n = 25
 		}
-		if err := writeMarkdown(*mdPath, recs, n, len(recs), nErr, maxFan); err != nil {
+		if err := writeMarkdown(*mdPath, recs, n, len(recs), nErr, nUnmeasured, maxFan); err != nil {
 			fmt.Fprintf(os.Stderr, "perf-profile: write markdown summary: %v\n", err)
 			os.Exit(1)
 		}
 	}
-	fmt.Fprintf(os.Stderr, "perf-profile: profiled %d fixtures (%d with errors), max fan_factor = %.2f\n",
-		len(recs), nErr, maxFan)
+	fmt.Fprintf(os.Stderr, "perf-profile: profiled %d fixtures (%d with errors, %d unmeasured), max fan_factor = %.2f\n",
+		len(recs), nErr, nUnmeasured, maxFan)
 
 	if *failOver > 0 && maxFan > *failOver {
 		fmt.Fprintf(os.Stderr, "perf-profile: FAIL — max fan_factor %.2f exceeds threshold %.2f\n", maxFan, *failOver)
@@ -111,25 +116,27 @@ func writeJSON(outPath string, recs []profile.Record) error {
 // writeMarkdown appends a GitHub-flavoured markdown table of the top-n
 // fan_factor fixtures plus a one-line corpus summary to mdPath (opened
 // in append mode so it can target $GITHUB_STEP_SUMMARY directly).
-func writeMarkdown(mdPath string, recs []profile.Record, n, total, nErr int, maxFan float64) error {
+func writeMarkdown(mdPath string, recs []profile.Record, n, total, nErr, nUnmeasured int, maxFan float64) error {
 	if n > len(recs) {
 		n = len(recs)
 	}
 	var b strings.Builder
 	fmt.Fprintf(&b, "## perf-profile (corpus fan-out)\n\n")
-	fmt.Fprintf(&b, "Profiled **%d** executable fixtures (%d with errors). Max fan_factor: **%.2f**.\n\n",
-		total, nErr, maxFan)
+	fmt.Fprintf(&b, "Profiled **%d** executable fixtures (%d with errors, %d unmeasured). Max fan_factor: **%.2f**.\n\n",
+		total, nErr, nUnmeasured, maxFan)
 	fmt.Fprintf(&b, "### top %d fixtures by fan_factor\n\n", n)
 	b.WriteString("| fixture | fan_factor | scan_rows | peak_intermediate | result_rows | cross_join | array_join | recursive_cte |\n")
 	b.WriteString("| --- | ---: | ---: | ---: | ---: | :---: | :---: | :---: |\n")
 	for i := 0; i < n; i++ {
 		r := recs[i]
-		fmt.Fprintf(&b, "| `%s` | %.2f | %d | %d | %d | %s | %s | %s |\n",
-			r.Fixture, r.FanFactor, r.ScanRows, r.PeakIntermediate, r.ResultRows,
+		fmt.Fprintf(&b, "| `%s` | %s | %d | %d | %d | %s | %s | %s |\n",
+			r.Fixture, fanFactorLabel(r.FanFactor), r.ScanRows, r.PeakIntermediate, r.ResultRows,
 			mdYesNo(r.HasCrossJoin), mdYesNo(r.HasArrayJoin), mdYesNo(r.HasRecursiveCTE))
 	}
 	b.WriteString("\n_fan_factor = peak intermediate cardinality / leaf scan rows. " +
-		"Fixtures are small golden seeds, so absolute counts are tiny; the ratio is the fan-out signal._\n\n")
+		"Fixtures are small golden seeds, so absolute counts are tiny; the ratio is the fan-out signal. " +
+		"`unmeasured` means the profiler could not see through every pipeline stage (a CTE reference or a " +
+		"recursive CTE step) — see [profile.Record.FanFactor]._\n\n")
 
 	f, err := os.OpenFile(mdPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644) //nolint:gosec // step-summary path
 	if err != nil {
@@ -138,6 +145,16 @@ func writeMarkdown(mdPath string, recs []profile.Record, n, total, nErr int, max
 	defer func() { _ = f.Close() }()
 	_, werr := f.WriteString(b.String())
 	return werr
+}
+
+// fanFactorLabel renders a nullable fan_factor for the human-facing
+// summary tables — nil (unmeasured) is spelled out rather than
+// collapsed to a fabricated number.
+func fanFactorLabel(f *float64) string {
+	if f == nil {
+		return "unmeasured"
+	}
+	return fmt.Sprintf("%.2f", *f)
 }
 
 func mdYesNo(v bool) string {
@@ -159,8 +176,8 @@ func printTopTable(w *os.File, recs []profile.Record, n int) {
 		"fixture", "fan_factor", "scan_rows", "peak_inter", "xjoin", "ajoin", "rcte")
 	for i := 0; i < n; i++ {
 		r := recs[i]
-		fmt.Fprintf(w, "%-48s %10.2f %12d %12d %6s %6s %6s\n",
-			truncate(r.Fixture, 48), r.FanFactor, r.ScanRows, r.PeakIntermediate,
+		fmt.Fprintf(w, "%-48s %10s %12d %12d %6s %6s %6s\n",
+			truncate(r.Fixture, 48), fanFactorLabel(r.FanFactor), r.ScanRows, r.PeakIntermediate,
 			yesno(r.HasCrossJoin), yesno(r.HasArrayJoin), yesno(r.HasRecursiveCTE))
 	}
 }

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -191,6 +191,24 @@ Improvements are always allowed (a fan-factor *decrease* never blocks); the
 ceiling only tightens when a maintainer re-runs
 `just update-cardinality-baseline`.
 
+**fan_factor is nullable, and null is never a free pass.** The profiler's
+per-subquery `count()` decomposition only descends the leftmost `FROM`
+source; it stops on a `WITH`-prefixed subquery (a CTE reference or a
+pre-rendered subquery splice — the `&&` `SetIntersect` shape in
+`internal/chsql/set_op.go` is the current example) and, structurally via
+`EXPLAIN`, on any `RECURSIVE` CTE step. Before #1519 those stages silently
+flattened to `fan_factor = 1.00` — the profiler reported "no fan-out" on
+exactly the constructs it exists to catch. `profile.Record.FanFactor` is
+now a `*float64`: nil (JSON `null`) whenever `UncountableLevels` is
+nonzero, never a fabricated `1.00`. The ratchet is null-aware rather than
+null-blind: a fixture whose current run is `null` must match what the
+committed baseline already says — `null` on both sides passes (already
+honestly acknowledged), a fixture that regresses from measured to `null`
+fails (a human has to look and re-baseline on purpose), and a fixture that
+becomes measurable is always allowed. See the "fan_factor can be
+unmeasured" section of `test/perf/cardinality_ratchet_test.go`'s file doc
+for the full truth table.
+
 A separate structural win holds the slicer's copy-on-write off-spine sharing in
 place. `chplan.ReanchorRange` shares the immutable off-spine subtree across the
 `K` shards instead of `CloneNode`-ing it K+1 times; the wall-clock measurement

--- a/test/perf/cardinality-baseline.json
+++ b/test/perf/cardinality-baseline.json
@@ -7,7 +7,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/absent_over_time_range",
@@ -17,7 +18,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/agg_by_severity",
@@ -27,7 +29,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/approx_topk",
@@ -37,7 +40,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/avg_count_over_time",
@@ -47,7 +51,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/binop_literal_vector",
@@ -57,7 +62,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/binop_scalar_vector",
@@ -67,7 +73,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/binop_scalar_vector_agg",
@@ -77,7 +84,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/binop_set_and",
@@ -87,7 +95,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/binop_set_or",
@@ -97,7 +106,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/binop_set_unless",
@@ -107,7 +117,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/binop_vector_vector_bool",
@@ -117,7 +128,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/binop_vv_add_bool_ignored",
@@ -127,7 +139,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/binop_vv_add_on",
@@ -137,7 +150,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/binop_vv_compare_filter",
@@ -147,7 +161,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/binop_vv_div_ignoring",
@@ -157,7 +172,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/binop_vv_eq_bool",
@@ -167,7 +183,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/binop_vv_group_left",
@@ -177,7 +194,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/binop_vv_group_left_with_agg_legs",
@@ -187,7 +205,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/bottomk",
@@ -197,7 +216,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/bytes_over_time",
@@ -207,7 +227,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/bytes_over_time_query",
@@ -217,7 +238,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/bytes_rate",
@@ -227,7 +249,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/bytes_rate_query",
@@ -237,7 +260,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/count_over_time",
@@ -247,7 +271,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/count_over_time_detected_level",
@@ -257,7 +282,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/decolorize",
@@ -267,7 +293,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/edge_bytes_over_time_filter",
@@ -277,7 +304,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/edge_bytes_rate_with_chain",
@@ -287,7 +315,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/edge_count_over_time_filter",
@@ -297,7 +326,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/edge_decolorize_after_filter",
@@ -307,7 +337,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/edge_label_filter_and_then_line_filter",
@@ -317,7 +348,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/edge_label_filter_or_chain",
@@ -327,7 +359,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/edge_label_format_rename_and_template",
@@ -337,7 +370,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/edge_label_format_template",
@@ -347,7 +381,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/edge_line_filter_chained_3",
@@ -357,7 +392,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/edge_line_filter_chained_5_mixed",
@@ -367,7 +403,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/edge_line_filter_not_chain_3",
@@ -377,7 +414,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/edge_line_filter_or_alt_chain",
@@ -387,7 +425,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/edge_line_format_missing_label",
@@ -397,7 +436,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/edge_multistage_filter_unpack_format",
@@ -407,7 +447,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/edge_multistage_pattern_filter_format",
@@ -417,7 +458,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/edge_nested_max_avg_by_unwrap",
@@ -427,7 +469,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/edge_pattern_msg_then_filter",
@@ -437,7 +480,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/edge_pattern_multi_capture",
@@ -447,7 +491,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/edge_sum_by_rate",
@@ -457,7 +502,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/edge_sum_without_rate",
@@ -467,7 +513,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/edge_unpack_then_label_filter",
@@ -477,7 +524,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/filter_bytes",
@@ -487,7 +535,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/filter_bytes_error",
@@ -497,7 +546,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/filter_bytes_error_filtered",
@@ -507,7 +557,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/filter_detected_level",
@@ -517,7 +568,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/filter_duration",
@@ -527,7 +579,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/filter_duration_error_filtered",
@@ -537,7 +590,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/filter_duration_micro_units",
@@ -547,7 +601,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/filter_numeric",
@@ -557,7 +612,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/filter_numeric_error",
@@ -567,7 +623,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/filter_numeric_error_filtered",
@@ -577,7 +634,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/filter_with_or_alt",
@@ -587,7 +645,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/first_over_time",
@@ -597,7 +656,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/label_filter_chained",
@@ -607,7 +667,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/label_filter_eq",
@@ -617,7 +678,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/label_filter_ip",
@@ -627,7 +689,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/label_filter_ip_not",
@@ -637,7 +700,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/label_filter_or",
@@ -647,7 +711,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/label_filter_regex",
@@ -657,7 +722,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/label_format",
@@ -667,7 +733,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/label_replace_backref_above_ch_ceiling",
@@ -677,7 +744,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/label_replace_basic",
@@ -687,7 +755,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/last_over_time",
@@ -697,7 +766,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/level_label_filter",
@@ -707,7 +777,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/line_filter_chained",
@@ -717,7 +788,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/line_filter_contains",
@@ -727,7 +799,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/line_filter_ip_cidr",
@@ -737,7 +810,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/line_filter_ip_not",
@@ -747,7 +821,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/line_filter_ip_v6",
@@ -757,7 +832,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/line_filter_not_contains",
@@ -767,7 +843,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/line_filter_not_pattern",
@@ -777,7 +854,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/line_filter_not_regex",
@@ -787,7 +865,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/line_filter_not_regex_case_insensitive",
@@ -797,7 +876,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/line_filter_pattern",
@@ -807,7 +887,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/line_filter_pattern_leading_literal",
@@ -817,7 +898,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/line_filter_regex",
@@ -827,7 +909,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/line_filter_regex_case_insensitive_multicase",
@@ -837,7 +920,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/line_format",
@@ -847,7 +931,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/line_format_after_line_filter",
@@ -857,7 +942,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/line_format_compose",
@@ -867,7 +953,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/literal_scalar",
@@ -877,7 +964,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/map_key_order_count_over_time",
@@ -887,7 +975,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/map_key_order_count_over_time_control",
@@ -897,7 +986,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/map_key_order_unwrap_error_bypass",
@@ -907,7 +997,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/matcher_k8s_namespace_materialized",
@@ -917,7 +1008,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/matcher_self_service",
@@ -927,7 +1019,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/matcher_severity_number",
@@ -937,7 +1030,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/matcher_severity_text",
@@ -947,7 +1041,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/matcher_trace_id",
@@ -957,7 +1052,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/multiple_label_matchers",
@@ -967,7 +1063,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/not_eq_matcher",
@@ -977,7 +1074,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/parser_json_bare",
@@ -987,7 +1085,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/parser_json_conflict",
@@ -997,7 +1096,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/parser_json_typed",
@@ -1007,7 +1107,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/parser_json_typed_conflict",
@@ -1017,7 +1118,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/parser_logfmt",
@@ -1027,7 +1129,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/parser_logfmt_conflict",
@@ -1037,7 +1140,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/parser_logfmt_typed",
@@ -1047,7 +1151,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/parser_logfmt_typed_conflict",
@@ -1057,7 +1162,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/parser_regexp",
@@ -1067,7 +1173,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/parser_regexp_conflict",
@@ -1077,7 +1184,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/pattern",
@@ -1087,7 +1195,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/pattern_after_line_filter",
@@ -1097,7 +1206,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/pattern_then_line_format",
@@ -1107,7 +1217,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/pattern_with_label_filter",
@@ -1117,7 +1228,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/pipeline_drop",
@@ -1127,7 +1239,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/pipeline_drop_merges_streams",
@@ -1137,7 +1250,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/pipeline_drop_multi",
@@ -1147,7 +1261,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/pipeline_drop_on_aggregation",
@@ -1157,7 +1272,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/pipeline_keep",
@@ -1167,7 +1283,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/pipeline_keep_multi",
@@ -1177,7 +1294,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/pipeline_keep_on_aggregation",
@@ -1187,7 +1305,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/range_agg_by_grouping",
@@ -1197,7 +1316,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/range_agg_without_grouping_unwrap",
@@ -1207,7 +1327,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/range_filter",
@@ -1217,7 +1338,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/range_mode_avg_over_time_unwrap",
@@ -1227,7 +1349,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/range_mode_count_over_time",
@@ -1237,7 +1360,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/range_mode_rate_unwrap_json",
@@ -1247,7 +1371,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/range_mode_sum_count_over_time",
@@ -1257,7 +1382,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/range_mode_sum_over_time_unwrap",
@@ -1267,7 +1393,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/range_mode_sum_rate_sparse_trim",
@@ -1277,7 +1404,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/rate",
@@ -1287,7 +1415,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/rate_counter",
@@ -1297,7 +1426,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/rate_with_filter",
@@ -1307,7 +1437,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/regex_alternation_filter",
@@ -1317,7 +1448,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/setop_and_range_per_step",
@@ -1327,7 +1459,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/setop_and_range_unaggregated_arms",
@@ -1337,7 +1470,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/setop_or_range_per_step",
@@ -1347,7 +1481,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/setop_or_range_unaggregated_arms",
@@ -1357,7 +1492,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/setop_unless_range_per_step",
@@ -1367,7 +1503,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/setop_unless_range_unaggregated_arms",
@@ -1377,7 +1514,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/sort",
@@ -1387,7 +1525,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/sort_desc",
@@ -1397,7 +1536,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/stream_selector",
@@ -1407,7 +1547,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/stream_with_regex",
@@ -1417,7 +1558,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/stream_with_regex_match_all",
@@ -1427,7 +1569,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/stream_with_two_labels",
@@ -1437,7 +1580,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/structured_metadata_group_by",
@@ -1447,7 +1591,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/structured_metadata_pipeline_filter",
@@ -1457,7 +1602,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/structured_metadata_precedence",
@@ -1467,7 +1613,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/structured_metadata_selector_unchanged",
@@ -1477,7 +1624,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/structured_metadata_stream_fallback",
@@ -1487,7 +1635,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/sum_by_job_rate",
@@ -1497,7 +1646,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/sum_by_level_count_over_time",
@@ -1507,7 +1657,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/sum_count_over_time",
@@ -1517,7 +1668,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/sum_count_over_time_line_filter",
@@ -1527,7 +1679,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/sum_rate",
@@ -1537,7 +1690,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/sum_without_pod",
@@ -1547,7 +1701,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/three_filter_chain",
@@ -1557,7 +1712,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/topk",
@@ -1567,7 +1723,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/topk_by_partition",
@@ -1577,7 +1734,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/topk_range_per_step",
@@ -1587,7 +1745,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/unpack",
@@ -1597,7 +1756,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/unpack_after_line_filter",
@@ -1607,7 +1767,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/unpack_then_line_format",
@@ -1617,7 +1778,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/unpack_with_label_filter",
@@ -1627,7 +1789,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/unwrap_avg_over_time",
@@ -1637,7 +1800,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/unwrap_bytes",
@@ -1647,7 +1811,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/unwrap_duration_error_postfilter",
@@ -1657,7 +1822,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/unwrap_duration_micro_error",
@@ -1667,7 +1833,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/unwrap_duration_seconds",
@@ -1677,7 +1844,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/unwrap_duration_unit_sweep",
@@ -1687,7 +1855,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/unwrap_quantile_over_time",
@@ -1697,7 +1866,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/unwrap_sum_over_time",
@@ -1707,7 +1877,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/variants_grouped",
@@ -1717,7 +1888,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/variants_multi",
@@ -1727,7 +1899,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/variants_range_count_bytes",
@@ -1737,7 +1910,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/variants_single",
@@ -1747,7 +1921,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/variants_sum_by_and_count",
@@ -1757,7 +1932,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/vector_agg_without_empty_unwrap",
@@ -1767,7 +1943,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "logql/whitespace_in_braces",
@@ -1777,7 +1954,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "metadata/label_values_no_bounds",
@@ -1787,7 +1965,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "metadata/labels_no_bounds",
@@ -1797,7 +1976,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "metadata/series_no_bounds",
@@ -1807,7 +1987,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/abs_metric",
@@ -1817,7 +1998,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/absent_aggregate_no_series",
@@ -1827,7 +2009,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/absent_aggregate_with_series",
@@ -1837,7 +2020,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/absent_binary_no_series",
@@ -1847,7 +2031,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/absent_no_matchers",
@@ -1857,7 +2042,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/absent_no_series",
@@ -1867,7 +2053,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/absent_over_time_empty_window",
@@ -1877,7 +2064,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/absent_over_time_range_step_synth_labels",
@@ -1887,7 +2075,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/absent_over_time_synth_labels",
@@ -1897,7 +2086,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/absent_over_time_with_data",
@@ -1907,7 +2097,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/absent_with_series",
@@ -1917,7 +2108,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/agg_by_dotted_source",
@@ -1927,7 +2119,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/agg_by_service_name",
@@ -1937,7 +2130,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/agg_range_window_over_scalar_div",
@@ -1947,7 +2141,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/at_end_basic",
@@ -1957,7 +2152,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/at_modifier_range_mode_collapse",
@@ -1967,7 +2163,8 @@
     "has_cross_join": true,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/at_start_basic",
@@ -1977,7 +2174,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/binary_and",
@@ -1987,7 +2185,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/binary_and_ignoring",
@@ -1997,7 +2196,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/binary_and_on",
@@ -2007,7 +2207,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/binary_or",
@@ -2017,7 +2218,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/binary_or_ignoring",
@@ -2027,7 +2229,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/binary_or_increase_instant_canonicalises_arms",
@@ -2037,7 +2240,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/binary_or_increase_range_canonicalises_arms",
@@ -2047,7 +2251,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/binary_unless",
@@ -2057,7 +2262,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/binary_unless_ignoring",
@@ -2067,7 +2273,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/binop_atan2_scalar_vector",
@@ -2077,7 +2284,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/binop_atan2_vector_scalar",
@@ -2087,7 +2295,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/binop_atan2_vv",
@@ -2097,7 +2306,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/binop_ignoring_instance_strips_instance",
@@ -2107,7 +2317,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/binop_increase_plus_rate",
@@ -2117,7 +2328,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/binop_metric_minus_time",
@@ -2127,7 +2339,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/binop_on_job_strips_instance",
@@ -2137,7 +2350,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/binop_prod_repro",
@@ -2147,7 +2361,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/binop_rate_div_rate_ignoring",
@@ -2157,7 +2372,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/binop_rate_div_rate_on",
@@ -2167,7 +2383,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/binop_rate_plus_rate",
@@ -2177,7 +2394,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/binop_redis_hit_ratio_range",
@@ -2187,7 +2405,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/binop_scalar_mul_rate_div_rate_range",
@@ -2197,7 +2416,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/binop_sumby_rate_plus_sumby_rate",
@@ -2207,7 +2427,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/binop_time_arith_range",
@@ -2217,7 +2438,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/binop_time_lt_bool_metric",
@@ -2227,7 +2449,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/binop_time_lt_metric",
@@ -2237,7 +2460,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/binop_time_plus_metric",
@@ -2247,7 +2471,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/binop_vv_on_compare_eq",
@@ -2257,7 +2482,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/binop_vv_on_compare_lt",
@@ -2267,7 +2493,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/bool_lt",
@@ -2277,7 +2504,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/bool_vv_eq",
@@ -2287,7 +2515,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/bool_vv_gt",
@@ -2297,7 +2526,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/bottomk_2",
@@ -2307,7 +2537,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/bottomk_below_one_empty",
@@ -2317,7 +2548,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/bottomk_computed",
@@ -2327,7 +2559,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/bottomk_range_bare",
@@ -2337,7 +2570,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/bottomk_range_by_instance",
@@ -2347,7 +2581,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/bottomk_range_without_empty",
@@ -2357,7 +2592,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/bottomk_range_without_instance",
@@ -2367,7 +2603,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/bottomk_without_basic",
@@ -2377,7 +2614,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/ceil_metric",
@@ -2387,7 +2625,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/chained_filter",
@@ -2397,7 +2636,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/changes_oscillating",
@@ -2407,7 +2647,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/clamp",
@@ -2417,7 +2658,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/clamp_max",
@@ -2427,7 +2669,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/clamp_max_scalar_bound",
@@ -2437,7 +2680,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/clamp_min",
@@ -2447,7 +2691,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/clamp_min_scalar_bound",
@@ -2457,7 +2702,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/clamp_min_scalar_nan_bound",
@@ -2467,7 +2713,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/clamp_scalar_min_literal_max",
@@ -2477,7 +2724,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/comparison_arithmetic",
@@ -2487,7 +2735,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/count_agg_returns_float",
@@ -2497,7 +2746,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/count_no_group",
@@ -2507,7 +2757,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/count_values_basic",
@@ -2517,7 +2768,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/count_values_without",
@@ -2527,7 +2779,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/count_values_without_empty",
@@ -2537,7 +2790,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/day_of_month_default",
@@ -2547,7 +2801,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/day_of_month_of_vector",
@@ -2557,7 +2812,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/day_of_week_default",
@@ -2567,7 +2823,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/day_of_week_offset",
@@ -2577,7 +2834,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/day_of_year_of_vector",
@@ -2587,7 +2845,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/days_in_month_default",
@@ -2597,7 +2856,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/days_in_month_of_vector",
@@ -2607,7 +2867,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/deg_metric",
@@ -2617,7 +2878,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/delta_empty_window",
@@ -2627,7 +2889,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/delta_window",
@@ -2637,7 +2900,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/deriv_linear_increase",
@@ -2647,7 +2911,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/deriv_subscrape_drops",
@@ -2657,7 +2922,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/double_exponential_smoothing",
@@ -2667,7 +2933,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/edge_abs_over_rate",
@@ -2677,7 +2944,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/edge_absent_over_time_at_timestamp_range_pinned_absent",
@@ -2687,7 +2955,8 @@
     "has_cross_join": true,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/edge_absent_over_time_at_timestamp_range_pinned_present",
@@ -2697,7 +2966,8 @@
     "has_cross_join": true,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/edge_at_start_range",
@@ -2707,7 +2977,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/edge_at_then_offset_neg",
@@ -2717,7 +2988,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/edge_at_timestamp_range",
@@ -2727,7 +2999,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/edge_avg_over_time",
@@ -2737,7 +3010,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/edge_bool_eq",
@@ -2747,7 +3021,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/edge_bool_ge",
@@ -2757,7 +3032,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/edge_bool_le",
@@ -2767,7 +3043,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/edge_bool_ne",
@@ -2777,7 +3054,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/edge_ceil_over_sum_by",
@@ -2787,7 +3065,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/edge_clamp_neg_to_pos",
@@ -2797,7 +3076,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/edge_count_over_time",
@@ -2807,7 +3087,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/edge_double_exp_smoothing_at_timestamp_range_pinned",
@@ -2817,7 +3098,8 @@
     "has_cross_join": true,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/edge_hq_native_negative_p0",
@@ -2827,7 +3109,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/edge_hq_native_negative_p1",
@@ -2837,7 +3120,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/edge_hq_native_p25",
@@ -2847,7 +3131,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/edge_hq_native_p999",
@@ -2857,7 +3142,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/edge_increase_at_start",
@@ -2867,7 +3153,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/edge_join_ignoring_extra",
@@ -2877,7 +3164,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/edge_join_ignoring_group_right",
@@ -2887,7 +3175,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/edge_join_on_extra_labels",
@@ -2897,7 +3186,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/edge_join_on_three_keys",
@@ -2907,7 +3197,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/edge_last_over_time",
@@ -2917,7 +3208,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/edge_log10_over_rate",
@@ -2927,7 +3219,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/edge_max_over_time_subquery_at_pinned",
@@ -2937,7 +3230,8 @@
     "has_cross_join": true,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/edge_max_over_time_subquery_step_default",
@@ -2947,7 +3241,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/edge_min_over_time",
@@ -2957,7 +3252,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/edge_neg_scalar_minus_vector",
@@ -2967,7 +3263,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/edge_offset_zero",
@@ -2977,7 +3274,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/edge_paren_chain_arith",
@@ -2987,7 +3285,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/edge_predict_linear_at_timestamp_range_pinned",
@@ -2997,7 +3296,8 @@
     "has_cross_join": true,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/edge_quantile_over_time_at_pinned_phi_above_one",
@@ -3007,7 +3307,8 @@
     "has_cross_join": true,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/edge_quantile_over_time_at_timestamp_range_pinned",
@@ -3017,7 +3318,8 @@
     "has_cross_join": true,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/edge_rate_at_timestamp_range_pinned",
@@ -3027,7 +3329,8 @@
     "has_cross_join": true,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/edge_rate_negative_offset",
@@ -3037,7 +3340,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/edge_round_step_half",
@@ -3047,7 +3351,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/edge_sqrt_over_aggregate",
@@ -3057,7 +3362,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/edge_subquery_nested",
@@ -3067,7 +3373,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/empty_ignoring_join",
@@ -3077,7 +3384,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/empty_on_join",
@@ -3087,7 +3395,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/exp_metric",
@@ -3097,7 +3406,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/first_over_time",
@@ -3107,7 +3417,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/floor_metric",
@@ -3117,7 +3428,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/group_basic",
@@ -3127,7 +3439,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/group_by_job",
@@ -3137,7 +3450,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_avg_exp",
@@ -3147,7 +3461,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_avg_exp_latest_sample",
@@ -3157,7 +3472,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_avg_exp_range_latest_sample",
@@ -3167,7 +3483,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_bucket_companion",
@@ -3177,7 +3494,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_bucket_le_filter",
@@ -3187,7 +3505,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_count_basic",
@@ -3197,7 +3516,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_count_exp",
@@ -3207,7 +3527,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_count_exp_at_pinned_range",
@@ -3217,7 +3538,8 @@
     "has_cross_join": true,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_count_exp_bare_stale",
@@ -3227,7 +3549,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_count_exp_latest_sample",
@@ -3237,7 +3560,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_count_exp_range_latest_sample",
@@ -3247,7 +3571,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_count_float_metric_empty",
@@ -3257,7 +3582,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_fraction_exp",
@@ -3267,7 +3593,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_fraction_exp_negative_bounds",
@@ -3277,7 +3604,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_fraction_exp_negative_range",
@@ -3287,7 +3615,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_mean_latency",
@@ -3297,7 +3626,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_quantile_agg_empty",
@@ -3307,7 +3637,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_quantile_avg_by_le",
@@ -3317,7 +3648,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_quantile_classic_agg_at_pinned_range",
@@ -3327,7 +3659,8 @@
     "has_cross_join": true,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_quantile_classic_agg_offset_range",
@@ -3337,7 +3670,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_quantile_classic_agg_plateau",
@@ -3347,7 +3681,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_quantile_classic_agg_rate_min_samples",
@@ -3357,7 +3692,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_quantile_classic_bare_at_pin_stale",
@@ -3367,7 +3703,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_quantile_classic_bare_at_pinned_range",
@@ -3377,7 +3714,8 @@
     "has_cross_join": true,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_quantile_classic_bare_rate_min_samples",
@@ -3387,7 +3725,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_quantile_classic_duplicate_bounds",
@@ -3397,7 +3736,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_quantile_classic_edge_p0",
@@ -3407,7 +3747,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_quantile_classic_edge_p100",
@@ -3417,7 +3758,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_quantile_classic_empty",
@@ -3427,7 +3769,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_quantile_classic_latest_sample",
@@ -3437,7 +3780,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_quantile_classic_multi_series",
@@ -3447,7 +3791,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_quantile_classic_negative_bound_upper_rank",
@@ -3457,7 +3802,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_quantile_classic_negative_lowest_bound",
@@ -3467,7 +3813,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_quantile_classic_plateau_overflow",
@@ -3477,7 +3824,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_quantile_classic_range_step",
@@ -3487,7 +3835,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_quantile_classic_range_step_bare",
@@ -3497,7 +3846,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_quantile_classic_single_bucket",
@@ -3507,7 +3857,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_quantile_classic_zero_count_plateau",
@@ -3517,7 +3868,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_quantile_count_by_le",
@@ -3527,7 +3879,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_quantile_le_not_in_by",
@@ -3537,7 +3890,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_quantile_max_by_le",
@@ -3547,7 +3901,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_quantile_native_agg",
@@ -3557,7 +3912,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_quantile_native_agg_at_pinned_range",
@@ -3567,7 +3923,8 @@
     "has_cross_join": true,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_quantile_native_agg_groupby",
@@ -3577,7 +3934,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_quantile_native_agg_mixed_scale",
@@ -3587,7 +3945,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_quantile_native_agg_p50",
@@ -3597,7 +3956,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_quantile_native_bare_at_pinned_range",
@@ -3607,7 +3967,8 @@
     "has_cross_join": true,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_quantile_native_bare_offset_range",
@@ -3617,7 +3978,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_quantile_native_empty",
@@ -3627,7 +3989,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_quantile_native_latest_sample",
@@ -3637,7 +4000,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_quantile_native_multi_series",
@@ -3647,7 +4011,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_quantile_native_negative_only",
@@ -3657,7 +4022,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_quantile_native_negative_p50",
@@ -3667,7 +4033,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_quantile_native_p50",
@@ -3677,7 +4044,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_quantile_native_p99",
@@ -3687,7 +4055,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_quantile_native_range",
@@ -3697,7 +4066,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_quantile_native_range_latest",
@@ -3707,7 +4077,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_quantile_native_single_metric",
@@ -3717,7 +4088,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_quantile_native_zero_band",
@@ -3727,7 +4099,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_quantile_non_bucket_empty",
@@ -3737,7 +4110,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_quantile_over_sum_over_time_bucket",
@@ -3747,7 +4121,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_quantile_quantile_by_le",
@@ -3757,7 +4132,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_quantile_scalar_phi",
@@ -3767,7 +4143,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_quantile_sum_by_le",
@@ -3777,7 +4154,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_quantile_sum_by_le_layout_change_midwindow",
@@ -3787,7 +4165,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_quantile_sum_by_le_mixed_layouts",
@@ -3797,7 +4176,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_quantile_sum_by_le_p50",
@@ -3807,7 +4187,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_quantile_with_filter",
@@ -3817,7 +4198,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_quantiles_classic_multi_phi",
@@ -3827,7 +4209,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_quantiles_native_multi_phi",
@@ -3837,7 +4220,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_stddev_exp",
@@ -3847,7 +4231,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_stdvar_exp",
@@ -3857,7 +4242,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_sum_aggregate_arg_empty",
@@ -3867,7 +4253,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_sum_basic",
@@ -3877,7 +4264,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_sum_exp",
@@ -3887,7 +4275,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_sum_exp_latest_sample",
@@ -3897,7 +4286,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/histogram_sum_exp_range_latest_sample",
@@ -3907,7 +4297,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/hour_default",
@@ -3917,7 +4308,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/hour_of_vector",
@@ -3927,7 +4319,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/idelta_subscrape_drops",
@@ -3937,7 +4330,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/idelta_two_samples",
@@ -3947,7 +4341,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/increase_duplicate_timestamp_dedup",
@@ -3957,7 +4352,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/increase_empty_window",
@@ -3967,7 +4363,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/increase_left_edge_scan_bound",
@@ -3977,7 +4374,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/info_base_label_wins_over_info",
@@ -3987,7 +4385,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/info_data_label_matcher_drops_unmatched",
@@ -3997,7 +4396,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/info_ignore_split_unpinned_base",
@@ -4007,7 +4407,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/info_ignores_base_info_series",
@@ -4017,7 +4418,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/info_ignores_base_info_series_multi_metric",
@@ -4027,7 +4429,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/info_regex_name_matcher_unions_info_metrics",
@@ -4037,7 +4440,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/info_target_info_enrichment",
@@ -4047,7 +4451,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/instant_sum_over_suffixed_count_delta_sum",
@@ -4057,7 +4462,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/irate_over_subquery",
@@ -4067,7 +4473,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/irate_subscrape_drops",
@@ -4077,7 +4484,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/irate_two_samples",
@@ -4087,7 +4495,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/label_join_two_labels",
@@ -4097,7 +4506,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/label_join_with_separator",
@@ -4107,7 +4517,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/label_replace_backref_above_ch_ceiling",
@@ -4117,7 +4528,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/label_replace_backref_above_group_count",
@@ -4127,7 +4539,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/label_replace_basic",
@@ -4137,7 +4550,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/label_replace_missing_src",
@@ -4147,7 +4561,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/label_replace_missing_src_overwrite",
@@ -4157,7 +4572,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/label_replace_named_capture",
@@ -4167,7 +4583,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/label_replace_no_match",
@@ -4177,7 +4594,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/label_replace_regex_capture",
@@ -4187,7 +4605,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/last_over_time_regex_name",
@@ -4197,7 +4616,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/limitk_below_one_empty",
@@ -4207,7 +4627,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/limitk_by_job_all_survive",
@@ -4217,7 +4638,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/limitk_by_job_truncates",
@@ -4227,7 +4649,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/limitk_without_instance",
@@ -4237,7 +4660,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/ln_metric",
@@ -4247,7 +4671,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/log10_metric",
@@ -4257,7 +4682,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/log2_metric",
@@ -4267,7 +4693,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/lwr_bare_selector_eval_ts_boundary",
@@ -4277,7 +4704,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/lwr_bare_selector_latest_per_series",
@@ -4287,7 +4715,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/lwr_bare_selector_staleness_window",
@@ -4297,7 +4726,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/mad_over_time",
@@ -4307,7 +4737,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/map_key_order_count",
@@ -4317,7 +4748,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/map_key_order_exp_histogram_count",
@@ -4327,7 +4759,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/map_key_order_histogram_quantile",
@@ -4337,7 +4770,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/map_key_order_increase",
@@ -4347,7 +4781,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/map_key_order_sum_by_labels",
@@ -4357,7 +4792,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/map_key_order_sum_without_label",
@@ -4367,7 +4803,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/mapkey_order_binop_default_instant",
@@ -4377,7 +4814,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/mapkey_order_binop_ignoring_instant",
@@ -4387,7 +4825,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/mapkey_order_label_replace_binop_instant",
@@ -4397,7 +4836,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/mapkey_order_setop_and_default_instant",
@@ -4407,7 +4847,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/mapkey_order_setop_and_ignoring_range",
@@ -4417,7 +4858,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/mapkey_order_setop_and_on_instant",
@@ -4427,7 +4869,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/mapkey_order_setop_or_default_range",
@@ -4437,7 +4880,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/matcher_and_agg_by_service_name",
@@ -4447,7 +4891,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/matcher_dotted_source",
@@ -4457,7 +4902,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/matcher_service_name",
@@ -4467,7 +4913,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/matrix_selector_top_level",
@@ -4477,7 +4924,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/metadata_label_values_bucket_le",
@@ -4487,7 +4935,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/metadata_label_values_collides_on_sanitized_name",
@@ -4497,7 +4946,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/metadata_label_values_dotted_source_key",
@@ -4507,7 +4957,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/minute_default",
@@ -4517,7 +4968,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/minute_of_vector",
@@ -4527,7 +4979,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/mod_arithmetic",
@@ -4537,7 +4990,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/month_default",
@@ -4547,7 +5001,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/month_of_vector",
@@ -4557,7 +5012,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/multiple_matchers",
@@ -4567,7 +5023,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/native_changes_range_step",
@@ -4577,7 +5034,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/native_deriv_range_step",
@@ -4587,7 +5045,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/native_predict_linear_negative_horizon_fanout",
@@ -4597,7 +5056,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/native_predict_linear_range_step",
@@ -4607,7 +5067,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/native_rate_join_range_step",
@@ -4617,7 +5078,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/native_rate_range_step",
@@ -4627,7 +5089,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/native_rate_recollapse_collision",
@@ -4637,7 +5100,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/native_rate_recollapse_collision_two_level",
@@ -4647,7 +5111,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/native_rate_recollapse_histogram_companion",
@@ -4657,7 +5122,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/native_rate_recollapse_metric_name_isolation",
@@ -4667,7 +5133,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/native_rate_recollapse_range_step",
@@ -4677,7 +5144,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/native_resample_offset",
@@ -4687,7 +5155,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/native_resample_range_step",
@@ -4697,7 +5166,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/native_resets_range_step",
@@ -4707,7 +5177,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/negative_at",
@@ -4717,7 +5188,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/negative_offset",
@@ -4727,7 +5199,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/not_regex_label",
@@ -4737,7 +5210,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/not_regex_name_matcher_excludes_dotted",
@@ -4747,7 +5221,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/offset_negative",
@@ -4757,7 +5232,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/pi_constant",
@@ -4767,7 +5243,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/pow_arithmetic",
@@ -4777,7 +5254,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/power_op_basic",
@@ -4787,7 +5265,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/power_op_vv",
@@ -4797,7 +5276,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/predict_linear_scalar_horizon",
@@ -4807,7 +5287,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/predict_linear_simple",
@@ -4817,7 +5298,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/predict_linear_subscrape_drops",
@@ -4827,7 +5309,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/present_over_time_with_data",
@@ -4837,7 +5320,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/quantile_by_job",
@@ -4847,7 +5331,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/quantile_over_time_p95",
@@ -4857,7 +5342,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/quantile_over_time_p95_exact_interp",
@@ -4867,7 +5353,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/quantile_over_time_q_above_one",
@@ -4877,7 +5364,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/quantile_over_time_q_above_one_no_modifier",
@@ -4887,7 +5375,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/quantile_over_time_q_negative",
@@ -4897,7 +5386,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/quantile_over_time_q_negative_no_modifier",
@@ -4907,7 +5397,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/quantile_over_time_scalar_phi",
@@ -4917,7 +5408,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/quantile_q_above_one",
@@ -4927,7 +5419,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/quantile_q_negative",
@@ -4937,7 +5430,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/quantile_scalar_phi",
@@ -4947,7 +5441,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/quantile_scalar_phi_nan",
@@ -4957,7 +5452,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/query_context_range_range_mode",
@@ -4967,7 +5463,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/query_context_step_instant_zero",
@@ -4977,7 +5474,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/query_context_step_range_mode",
@@ -4987,7 +5485,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/rad_metric",
@@ -4997,7 +5496,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/range_window_func_over_scalar_div",
@@ -5007,7 +5507,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/rate_empty_window",
@@ -5017,7 +5518,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/rate_http_count",
@@ -5027,7 +5529,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/rate_offset_5m",
@@ -5037,7 +5540,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/regex_alternation",
@@ -5047,7 +5551,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/regex_anchored",
@@ -5057,7 +5562,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/regex_name_matcher_scans_sum_table",
@@ -5067,7 +5573,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/regex_name_matcher_underscored_matches_dotted",
@@ -5077,7 +5584,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/resets_counter",
@@ -5087,7 +5595,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/resource_attr_bare_selector",
@@ -5097,7 +5606,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/resource_attr_matcher",
@@ -5107,7 +5617,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/resource_attr_precedence_collision",
@@ -5117,7 +5628,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/resource_attr_sum_by",
@@ -5127,7 +5639,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/round_metric",
@@ -5137,7 +5650,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/round_scalar_to_nearest",
@@ -5147,7 +5661,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/round_to_nearest",
@@ -5157,7 +5672,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/scalar_binop_fold",
@@ -5167,7 +5683,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/scalar_binop_fold_bool",
@@ -5177,7 +5694,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/scalar_binop_fold_precedence",
@@ -5187,7 +5705,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/scalar_lt_vector",
@@ -5197,7 +5716,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/scalar_many_series_nan",
@@ -5207,7 +5727,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/scalar_minus_vector",
@@ -5217,7 +5738,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/scalar_mul_rate",
@@ -5227,7 +5749,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/scalar_single_series",
@@ -5237,7 +5760,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/scan_unions_gauge_for_suffixed_standalone_gauge",
@@ -5247,7 +5771,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/scan_unions_gauge_sum_for_unsuffixed_metric",
@@ -5257,7 +5782,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/scan_unions_histogram_sum_for_suffixed_metric",
@@ -5267,7 +5793,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/scientific_threshold",
@@ -5277,7 +5804,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/setop_and_instant_shared_signature",
@@ -5287,7 +5815,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/setop_and_range_gap",
@@ -5297,7 +5826,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/setop_and_rate",
@@ -5307,7 +5837,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/setop_and_subquery_arm_range",
@@ -5317,7 +5848,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/setop_or_instant_shared_signature",
@@ -5327,7 +5859,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/setop_or_native_ts_grid_range",
@@ -5337,7 +5870,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/setop_or_range_gap",
@@ -5347,7 +5881,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/setop_or_rate",
@@ -5357,7 +5892,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/setop_or_subquery_arm_range",
@@ -5367,7 +5903,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/setop_unless_range_gap",
@@ -5377,7 +5914,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/setop_unless_rate",
@@ -5387,7 +5925,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/sgn_metric",
@@ -5397,7 +5936,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/sort_ascending",
@@ -5407,7 +5947,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/sort_by_label_ascending",
@@ -5417,7 +5958,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/sort_by_label_desc_tiebreak",
@@ -5427,7 +5969,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/sort_by_label_natural_order",
@@ -5437,7 +5980,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/sort_desc_descending",
@@ -5447,7 +5991,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/sqrt_metric",
@@ -5457,7 +6002,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/stddev_by_job",
@@ -5467,7 +6013,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/stddev_over_time_window",
@@ -5477,7 +6024,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/stdvar_no_group",
@@ -5487,7 +6035,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/stdvar_over_time_basic",
@@ -5497,7 +6046,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/subquery_absent_missing_metric",
@@ -5507,7 +6057,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/subquery_absent_present_metric",
@@ -5517,7 +6068,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/subquery_agg_of_binary",
@@ -5527,7 +6079,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/subquery_avg_over_time_increase",
@@ -5537,7 +6090,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/subquery_avg_over_time_rate",
@@ -5547,7 +6101,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/subquery_bare_aggregate_anchor_ts",
@@ -5557,7 +6112,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/subquery_bare_default_step",
@@ -5567,7 +6123,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/subquery_bare_vector",
@@ -5577,7 +6134,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/subquery_bare_vector_with_label",
@@ -5587,7 +6145,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/subquery_count_over_time_rate",
@@ -5597,7 +6156,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/subquery_irate_nested",
@@ -5607,7 +6167,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/subquery_label_replace",
@@ -5617,7 +6178,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/subquery_max_over_time_delta",
@@ -5627,7 +6189,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/subquery_max_over_time_rate",
@@ -5637,7 +6200,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/subquery_min_over_time_increase",
@@ -5647,7 +6211,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/subquery_nested",
@@ -5657,7 +6222,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/subquery_offset",
@@ -5667,7 +6233,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/subquery_over_avg_count",
@@ -5677,7 +6244,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/subquery_over_binexpr",
@@ -5687,7 +6255,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/subquery_over_bottomk",
@@ -5697,7 +6266,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/subquery_over_count_values",
@@ -5707,7 +6277,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/subquery_over_increase",
@@ -5717,7 +6288,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/subquery_over_limitk",
@@ -5727,7 +6299,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/subquery_over_quantile",
@@ -5737,7 +6310,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/subquery_over_quantile_phi_above_one",
@@ -5747,7 +6321,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/subquery_over_quantile_phi_negative",
@@ -5757,7 +6332,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/subquery_over_rate",
@@ -5767,7 +6343,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/subquery_over_rate_range",
@@ -5777,7 +6354,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/subquery_over_sum_over_time",
@@ -5787,7 +6365,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/subquery_over_sum_rate",
@@ -5797,7 +6376,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/subquery_over_topk",
@@ -5807,7 +6387,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/subquery_over_without",
@@ -5817,7 +6398,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/subquery_quantile_scalar_phi",
@@ -5827,7 +6409,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/subquery_stddev",
@@ -5837,7 +6420,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/subquery_sum_over_time_rate",
@@ -5847,7 +6431,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/subquery_time_minus_aggregate_offset",
@@ -5857,7 +6442,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/subquery_topk_fractional_k",
@@ -5867,7 +6453,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/subquery_topk_zero_empty",
@@ -5877,7 +6464,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/subquery_unary_minus",
@@ -5887,7 +6475,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/sum_by_job",
@@ -5897,7 +6486,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/sum_by_rate_dotted_source",
@@ -5907,7 +6497,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/sum_by_rate_range_offset",
@@ -5917,7 +6508,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/sum_by_rate_range_offset_negative",
@@ -5927,7 +6519,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/sum_by_rate_range_step",
@@ -5937,7 +6530,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/sum_by_underscored_otel_label",
@@ -5947,7 +6541,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/sum_without_empty",
@@ -5957,7 +6552,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/sum_without_instance",
@@ -5967,7 +6563,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/sum_without_two_labels",
@@ -5977,7 +6574,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/time_eq_bool_time_range",
@@ -5987,7 +6585,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/time_minus_time_range",
@@ -5997,7 +6596,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/time_plus_time_range",
@@ -6007,7 +6607,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/time_returns_eval_ts",
@@ -6017,7 +6618,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/timestamp_of_metric",
@@ -6027,7 +6629,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/topk_3_by_job",
@@ -6037,7 +6640,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/topk_computed",
@@ -6047,7 +6651,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/topk_fractional_k",
@@ -6057,7 +6662,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/topk_over_rate_binop",
@@ -6067,7 +6673,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/topk_range_bare",
@@ -6077,7 +6684,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/topk_range_by_instance",
@@ -6087,7 +6695,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/topk_range_without_empty",
@@ -6097,7 +6706,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/topk_range_without_instance",
@@ -6107,7 +6717,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/topk_without_basic",
@@ -6117,7 +6728,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/topk_zero_empty",
@@ -6127,7 +6739,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/trig_acos_metric",
@@ -6137,7 +6750,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/trig_cos_metric",
@@ -6147,7 +6761,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/trig_sin_metric",
@@ -6157,7 +6772,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/trig_sinh_metric",
@@ -6167,7 +6783,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/ts_of_first_over_time",
@@ -6177,7 +6794,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/ts_of_last_over_time",
@@ -6187,7 +6805,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/ts_of_max_over_time",
@@ -6197,7 +6816,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/ts_of_min_over_time",
@@ -6207,7 +6827,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/unary_minus_binary_lhs",
@@ -6217,7 +6838,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/unary_minus_in_function",
@@ -6227,7 +6849,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/unary_minus_rate",
@@ -6237,7 +6860,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/unary_minus_vector",
@@ -6247,7 +6871,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/unary_plus_vector",
@@ -6257,7 +6882,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/up",
@@ -6267,7 +6893,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/up_at_offset_combined",
@@ -6277,7 +6904,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/up_at_timestamp",
@@ -6287,7 +6915,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/up_gt_bool",
@@ -6297,7 +6926,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/up_gt_threshold",
@@ -6307,7 +6937,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/up_ne_zero",
@@ -6317,7 +6948,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/up_offset_5m",
@@ -6327,7 +6959,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/up_times_two",
@@ -6337,7 +6970,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/up_with_label",
@@ -6347,7 +6981,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/up_with_regex",
@@ -6357,7 +6992,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/vector_div_scalar",
@@ -6367,7 +7003,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/vector_group_left",
@@ -6377,7 +7014,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/vector_group_left_ignoring",
@@ -6387,7 +7025,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/vector_group_left_multi_include",
@@ -6397,7 +7036,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/vector_group_right",
@@ -6407,7 +7047,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/vector_ignoring_instance",
@@ -6417,7 +7058,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/vector_mod_scalar",
@@ -6427,7 +7069,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/vector_on_job",
@@ -6437,7 +7080,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/vector_plus_vector",
@@ -6447,7 +7091,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/vector_pow_scalar",
@@ -6457,7 +7102,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/vector_promotes_scalar",
@@ -6467,7 +7113,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/vector_promotes_time",
@@ -6477,7 +7124,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/vector_scalar_multi_series_nan",
@@ -6487,7 +7135,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/vector_scalar_single_series",
@@ -6497,7 +7146,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/year_default",
@@ -6507,7 +7157,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "promql/year_of_vector",
@@ -6517,7 +7168,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/and_or_combined",
@@ -6527,7 +7179,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/and_two_attrs",
@@ -6537,7 +7190,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/attr_eq_nil",
@@ -6547,7 +7201,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/attr_in_or_fold",
@@ -6557,7 +7212,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/attr_not_nil",
@@ -6567,7 +7223,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/attribute_arithmetic_add",
@@ -6577,7 +7234,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/attribute_arithmetic_mul",
@@ -6587,7 +7245,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/avg_duration",
@@ -6597,7 +7256,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/bool_attr",
@@ -6607,7 +7267,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/by_intrinsic_and_attr",
@@ -6617,7 +7278,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/by_mixed_scopes",
@@ -6627,7 +7289,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/by_multi_attribute",
@@ -6637,7 +7300,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/by_three_attributes",
@@ -6647,7 +7311,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/child_of",
@@ -6657,7 +7322,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/coalesce_simple",
@@ -6667,7 +7333,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/count",
@@ -6677,7 +7344,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/count_eq_zero",
@@ -6687,7 +7355,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/count_ge_threshold",
@@ -6697,7 +7366,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/count_lt_threshold",
@@ -6707,7 +7377,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/count_per_trace",
@@ -6717,7 +7388,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/drilldown_breakdown_kind_rate",
@@ -6727,7 +7399,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/duration_ge",
@@ -6737,7 +7410,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/duration_gt",
@@ -6747,7 +7421,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/duration_gt_compound_unit",
@@ -6757,7 +7432,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/duration_lt",
@@ -6767,7 +7443,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/edge_attr_default_ge",
@@ -6777,7 +7454,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/edge_attr_default_regex",
@@ -6787,7 +7465,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/edge_attr_resource_le",
@@ -6797,7 +7476,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/edge_attr_resource_not_regex",
@@ -6807,7 +7487,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/edge_attr_span_gt",
@@ -6817,7 +7498,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/edge_attr_span_lt",
@@ -6827,7 +7509,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/edge_catchall_compound_count",
@@ -6837,7 +7520,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/edge_catchall_pipeline_avg",
@@ -6847,7 +7531,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/edge_chain_ancestor_3",
@@ -6868,7 +7553,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/edge_chain_descendant_3",
@@ -6900,7 +7586,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/edge_group_by_span_attr",
@@ -6910,7 +7597,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/edge_inner_max_attr",
@@ -6920,7 +7608,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/edge_inner_min_attr",
@@ -6930,7 +7619,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/edge_inner_sum_attr",
@@ -6940,7 +7630,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/edge_intr_duration_eq",
@@ -6950,7 +7641,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/edge_intr_kind_consumer",
@@ -6960,7 +7652,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/edge_intr_name_regex",
@@ -6970,7 +7663,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/edge_intr_parent_with_attrs",
@@ -6980,7 +7674,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/edge_intr_span_id_eq",
@@ -6990,7 +7685,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/edge_intr_status_message_regex",
@@ -7000,7 +7696,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/edge_intr_trace_id_eq",
@@ -7010,7 +7707,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/edge_kind_producer",
@@ -7020,7 +7718,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/edge_link_combined_attr",
@@ -7030,7 +7729,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/edge_pipeline_coalesce_filter",
@@ -7040,7 +7740,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/edge_set_intersect_3",
@@ -7061,7 +7762,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/edge_sibling_with_attrs",
@@ -7071,7 +7773,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/edge_status_eq_ok",
@@ -7081,7 +7784,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/event_attr_eq_nil",
@@ -7091,7 +7795,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/event_attr_not_nil",
@@ -7101,7 +7806,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/event_attribute",
@@ -7111,7 +7817,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/event_attribute_regex",
@@ -7121,7 +7828,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/event_name",
@@ -7131,7 +7839,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/event_name_intrinsic",
@@ -7141,7 +7850,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/event_name_not_nil",
@@ -7151,7 +7861,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/flip_event_eq_fallthrough",
@@ -7161,7 +7872,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/flip_event_ge",
@@ -7171,7 +7883,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/flip_event_lt_duration",
@@ -7181,7 +7894,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/flip_link_ge",
@@ -7191,7 +7905,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/flip_link_gt",
@@ -7201,7 +7916,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/flip_link_le",
@@ -7211,7 +7927,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/flip_link_lt",
@@ -7221,7 +7938,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/flip_link_ne_fallthrough",
@@ -7231,7 +7949,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/flip_link_numeric",
@@ -7241,7 +7960,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/float_attr",
@@ -7251,7 +7971,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/group_by_attr",
@@ -7261,7 +7982,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/http_status_int",
@@ -7271,7 +7993,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/instrumentation_name_intrinsic",
@@ -7281,7 +8004,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/instrumentation_version_intrinsic",
@@ -7291,7 +8015,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/intrinsic_not_nil_kind",
@@ -7301,7 +8026,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/kind_eq_client",
@@ -7311,7 +8037,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/kind_eq_internal",
@@ -7321,7 +8048,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/kind_eq_server",
@@ -7331,7 +8059,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/kind_intrinsic",
@@ -7341,7 +8070,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/link_attribute",
@@ -7351,7 +8081,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/link_span_id",
@@ -7361,7 +8092,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/link_spanid_intrinsic",
@@ -7371,7 +8103,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/link_traceid_intrinsic",
@@ -7381,7 +8114,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/link_traceid_not_nil",
@@ -7391,7 +8125,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/max_duration",
@@ -7401,7 +8136,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/metrics_avg_over_time",
@@ -7411,7 +8147,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/metrics_avg_over_time_attr",
@@ -7421,7 +8158,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/metrics_avg_over_time_by",
@@ -7431,7 +8169,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/metrics_bottomk",
@@ -7441,7 +8180,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/metrics_chained",
@@ -7451,7 +8191,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/metrics_compare",
@@ -7461,7 +8202,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/metrics_compare_window",
@@ -7471,7 +8213,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/metrics_count_over_time",
@@ -7481,7 +8224,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/metrics_count_over_time_by_multi_service",
@@ -7491,7 +8235,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/metrics_groupby_resource_wire_label",
@@ -7501,7 +8246,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/metrics_histogram_over_time_attr",
@@ -7511,7 +8257,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/metrics_histogram_over_time_by",
@@ -7521,7 +8268,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/metrics_histogram_over_time_empty",
@@ -7531,7 +8279,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/metrics_max_over_time",
@@ -7541,7 +8290,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/metrics_min_over_time",
@@ -7551,7 +8301,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/metrics_multi_quantile",
@@ -7561,7 +8312,8 @@
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/metrics_quantile_over_time",
@@ -7571,7 +8323,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/metrics_quantile_over_time_by",
@@ -7581,7 +8334,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/metrics_rate",
@@ -7591,7 +8345,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/metrics_rate_by",
@@ -7601,7 +8356,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/metrics_rate_filtered_by",
@@ -7611,7 +8367,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/metrics_rate_standalone_by",
@@ -7621,7 +8378,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/metrics_sum_over_time",
@@ -7631,7 +8389,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/metrics_sum_over_time_by",
@@ -7641,7 +8400,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/metrics_threshold",
@@ -7651,7 +8411,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/metrics_topk",
@@ -7661,7 +8422,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/metrics_with_exemplars",
@@ -7671,7 +8433,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/min_duration",
@@ -7681,7 +8444,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/multi_attr_compound",
@@ -7691,7 +8455,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/multi_hop_chain",
@@ -7701,7 +8466,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/name_intrinsic",
@@ -7711,7 +8477,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/nested_set_left_position",
@@ -7732,7 +8499,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/nested_set_parent_root",
@@ -7742,7 +8510,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/nil_on_arithmetic_expr",
@@ -7752,7 +8521,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/not_eq_attr",
@@ -7762,7 +8532,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/not_regex_attr",
@@ -7772,7 +8543,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/or_two_attrs",
@@ -7782,7 +8554,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/parent_intrinsic",
@@ -7792,7 +8565,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/parent_of",
@@ -7802,7 +8576,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/recursive_ancestor",
@@ -7845,7 +8620,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/search_trace_limit_bare_table_map_column",
@@ -7855,7 +8631,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/search_trace_limit_exceeds_match_count",
@@ -7865,7 +8642,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/search_trace_limit_no_tie_ordering",
@@ -7875,7 +8653,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/search_trace_limit_tiebreak_boundary",
@@ -7885,7 +8664,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/search_traceid",
@@ -7895,7 +8675,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/select_attrs",
@@ -7905,7 +8686,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/select_duration",
@@ -7915,7 +8697,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/select_intrinsics",
@@ -7925,7 +8708,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/select_nested_set",
@@ -8001,7 +8785,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/select_resource_attrs",
@@ -8011,7 +8796,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/select_status_filter_attrs",
@@ -8021,7 +8807,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/service_name_eq",
@@ -8031,7 +8818,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/set_intersect_simple",
@@ -8052,7 +8840,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/set_union_simple",
@@ -8062,7 +8851,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/sibling_simple",
@@ -8072,7 +8862,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/span_attr_default",
@@ -8082,7 +8873,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/span_attr_explicit",
@@ -8092,7 +8884,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/span_attr_in_or_fold",
@@ -8102,7 +8895,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/span_attr_not_in_and_fold",
@@ -8112,7 +8906,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/span_id_intrinsic",
@@ -8122,7 +8917,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/spanset_and_distinct_spans",
@@ -8154,7 +8950,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/static_int",
@@ -8164,7 +8961,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/status_and_kind_combined",
@@ -8174,7 +8972,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/status_code_eq",
@@ -8184,7 +8983,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/status_code_ge",
@@ -8194,7 +8994,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/status_eq_error",
@@ -8204,7 +9005,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/status_message",
@@ -8214,7 +9016,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/status_neq_ok",
@@ -8224,7 +9027,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/status_unset",
@@ -8234,7 +9038,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/structural_child_of_union",
@@ -8244,7 +9049,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/structural_descendant_of_intersect",
@@ -8276,7 +9082,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/structural_not_descendant",
@@ -8297,7 +9104,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/structural_not_sibling",
@@ -8307,7 +9115,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/structural_union_child",
@@ -8317,7 +9126,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/structural_union_child_dup_key_order",
@@ -8327,7 +9137,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/structural_union_descendant",
@@ -8359,7 +9170,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/structural_union_sibling_dup_key_order",
@@ -8369,7 +9181,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/sum_duration",
@@ -8379,7 +9192,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/sum_span_attr",
@@ -8389,7 +9203,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/trace_id_intrinsic",
@@ -8399,7 +9214,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/trace_scoped_intrinsic_constant_false",
@@ -8409,7 +9225,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/unary_minus_arith",
@@ -8419,7 +9236,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/unary_minus_attr",
@@ -8429,7 +9247,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/unary_minus_duration",
@@ -8439,7 +9258,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/unary_not_attr",
@@ -8449,7 +9269,8 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   },
   {
     "fixture": "traceql/unary_not_intrinsic",
@@ -8459,6 +9280,7 @@
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
   }
 ]

--- a/test/perf/cardinality-baseline.json
+++ b/test/perf/cardinality-baseline.json
@@ -6851,13 +6851,14 @@
   },
   {
     "fixture": "traceql/edge_chain_ancestor_3",
-    "fan_factor": 1,
+    "fan_factor": null,
     "scan_rows": 1,
     "peak_intermediate": 1,
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": true,
-    "max_recursion_depth": 1
+    "max_recursion_depth": 1,
+    "uncountable_levels": 1
   },
   {
     "fixture": "traceql/edge_chain_child_5",
@@ -6871,23 +6872,25 @@
   },
   {
     "fixture": "traceql/edge_chain_descendant_3",
-    "fan_factor": 1,
+    "fan_factor": null,
     "scan_rows": 1,
     "peak_intermediate": 1,
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": true,
-    "max_recursion_depth": 1
+    "max_recursion_depth": 1,
+    "uncountable_levels": 1
   },
   {
     "fixture": "traceql/edge_chain_mixed_5",
-    "fan_factor": 1,
+    "fan_factor": null,
     "scan_rows": 1,
     "peak_intermediate": 1,
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": true,
-    "max_recursion_depth": 1
+    "max_recursion_depth": 1,
+    "uncountable_levels": 1
   },
   {
     "fixture": "traceql/edge_event_name_match",
@@ -7041,13 +7044,14 @@
   },
   {
     "fixture": "traceql/edge_set_intersect_3",
-    "fan_factor": 1,
+    "fan_factor": null,
     "scan_rows": 1,
     "peak_intermediate": 1,
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 1
   },
   {
     "fixture": "traceql/edge_set_union_3",
@@ -7711,13 +7715,14 @@
   },
   {
     "fixture": "traceql/nested_set_left_position",
-    "fan_factor": 1,
+    "fan_factor": null,
     "scan_rows": 4,
     "peak_intermediate": 4,
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": true,
-    "max_recursion_depth": 3
+    "max_recursion_depth": 3,
+    "uncountable_levels": 1
   },
   {
     "fixture": "traceql/nested_set_parent_nonroot",
@@ -7801,33 +7806,36 @@
   },
   {
     "fixture": "traceql/recursive_ancestor",
-    "fan_factor": 1,
+    "fan_factor": null,
     "scan_rows": 1,
     "peak_intermediate": 1,
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": true,
-    "max_recursion_depth": 1
+    "max_recursion_depth": 1,
+    "uncountable_levels": 1
   },
   {
     "fixture": "traceql/recursive_descendant",
-    "fan_factor": 1,
+    "fan_factor": null,
     "scan_rows": 1,
     "peak_intermediate": 1,
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": true,
-    "max_recursion_depth": 1
+    "max_recursion_depth": 1,
+    "uncountable_levels": 1
   },
   {
     "fixture": "traceql/recursive_mixed",
-    "fan_factor": 1,
+    "fan_factor": null,
     "scan_rows": 1,
     "peak_intermediate": 1,
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": true,
-    "max_recursion_depth": 1
+    "max_recursion_depth": 1,
+    "uncountable_levels": 1
   },
   {
     "fixture": "traceql/regex_attr",
@@ -7921,63 +7929,69 @@
   },
   {
     "fixture": "traceql/select_nested_set",
-    "fan_factor": 1,
+    "fan_factor": null,
     "scan_rows": 3,
     "peak_intermediate": 3,
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": true,
-    "max_recursion_depth": 3
+    "max_recursion_depth": 3,
+    "uncountable_levels": 1
   },
   {
     "fixture": "traceql/select_nested_set_drilldown_historical_window",
-    "fan_factor": 1,
+    "fan_factor": null,
     "scan_rows": 6,
     "peak_intermediate": 6,
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": true,
-    "max_recursion_depth": 4
+    "max_recursion_depth": 4,
+    "uncountable_levels": 1
   },
   {
     "fixture": "traceql/select_nested_set_drilldown_limited",
-    "fan_factor": 1,
+    "fan_factor": null,
     "scan_rows": 6,
     "peak_intermediate": 6,
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": true,
-    "max_recursion_depth": 4
+    "max_recursion_depth": 4,
+    "uncountable_levels": 1
   },
   {
     "fixture": "traceql/select_nested_set_drilldown_structure",
-    "fan_factor": 1,
+    "fan_factor": null,
     "scan_rows": 3,
     "peak_intermediate": 3,
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": true,
-    "max_recursion_depth": 2
+    "max_recursion_depth": 2,
+    "uncountable_levels": 1
   },
   {
     "fixture": "traceql/select_nested_set_drilldown_unbounded_noop",
-    "fan_factor": 1,
+    "fan_factor": null,
     "scan_rows": 12,
     "peak_intermediate": 12,
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": true,
-    "max_recursion_depth": 8
+    "max_recursion_depth": 8,
+    "uncountable_levels": 1
   },
   {
     "fixture": "traceql/select_nested_set_structural",
-    "fan_factor": 1,
+    "fan_factor": null,
     "scan_rows": 1,
     "peak_intermediate": 1,
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": true,
-    "max_recursion_depth": 1
+    "max_recursion_depth": 1,
+    "uncountable_levels": 1
   },
   {
     "fixture": "traceql/select_one_attr",
@@ -8021,13 +8035,14 @@
   },
   {
     "fixture": "traceql/set_intersect_simple",
-    "fan_factor": 1,
+    "fan_factor": null,
     "scan_rows": 4,
     "peak_intermediate": 4,
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 1
   },
   {
     "fixture": "traceql/set_union_mixed_granularity",
@@ -8111,23 +8126,25 @@
   },
   {
     "fixture": "traceql/spanset_and_distinct_spans",
-    "fan_factor": 1,
+    "fan_factor": null,
     "scan_rows": 2,
     "peak_intermediate": 2,
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 1
   },
   {
     "fixture": "traceql/spanset_pipeline_intersect",
-    "fan_factor": 1,
+    "fan_factor": null,
     "scan_rows": 1,
     "peak_intermediate": 1,
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": false,
-    "max_recursion_depth": 0
+    "max_recursion_depth": 0,
+    "uncountable_levels": 1
   },
   {
     "fixture": "traceql/static_float",
@@ -8231,23 +8248,25 @@
   },
   {
     "fixture": "traceql/structural_descendant_of_intersect",
-    "fan_factor": 1,
+    "fan_factor": null,
     "scan_rows": 1,
     "peak_intermediate": 1,
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": true,
-    "max_recursion_depth": 1
+    "max_recursion_depth": 1,
+    "uncountable_levels": 1
   },
   {
     "fixture": "traceql/structural_not_ancestor",
-    "fan_factor": 1,
+    "fan_factor": null,
     "scan_rows": 3,
     "peak_intermediate": 3,
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": true,
-    "max_recursion_depth": 2
+    "max_recursion_depth": 2,
+    "uncountable_levels": 1
   },
   {
     "fixture": "traceql/structural_not_child",
@@ -8261,13 +8280,14 @@
   },
   {
     "fixture": "traceql/structural_not_descendant",
-    "fan_factor": 1,
+    "fan_factor": null,
     "scan_rows": 4,
     "peak_intermediate": 4,
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": true,
-    "max_recursion_depth": 2
+    "max_recursion_depth": 2,
+    "uncountable_levels": 1
   },
   {
     "fixture": "traceql/structural_not_parent",
@@ -8311,23 +8331,25 @@
   },
   {
     "fixture": "traceql/structural_union_descendant",
-    "fan_factor": 1,
+    "fan_factor": null,
     "scan_rows": 2,
     "peak_intermediate": 2,
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": true,
-    "max_recursion_depth": 2
+    "max_recursion_depth": 2,
+    "uncountable_levels": 1
   },
   {
     "fixture": "traceql/structural_union_descendant_dup_key_order",
-    "fan_factor": 1,
+    "fan_factor": null,
     "scan_rows": 4,
     "peak_intermediate": 4,
     "has_cross_join": false,
     "has_array_join": false,
     "has_recursive_cte": true,
-    "max_recursion_depth": 2
+    "max_recursion_depth": 2,
+    "uncountable_levels": 1
   },
   {
     "fixture": "traceql/structural_union_sibling",

--- a/test/perf/cardinality_ratchet_test.go
+++ b/test/perf/cardinality_ratchet_test.go
@@ -67,6 +67,39 @@
 // so the fan_factor ceiling already pins peak_intermediate's bad direction and
 // a second rule would only forbid improvements.
 //
+// # fan_factor can be unmeasured — null never silently passes (#1519 part 2)
+//
+// profile.Record.FanFactor is a *float64: it is nil whenever the profiler's
+// leftmost-descent decomposition could not see through every pipeline stage —
+// a non-recursive WITH-prefixed level (a CTE reference or a pre-rendered
+// subquery splice; the ONLY current example is internal/chsql/set_op.go's `&&`
+// SetIntersect) or a RECURSIVE CTE step (detected structurally via EXPLAIN
+// PLAN's ReadFromRecursiveCTEStep, wherever in the plan it sits). Before this
+// was fixed, exactly those shapes silently flattened to fan_factor = 1.00 —
+// the profiler reported "no fan-out" precisely on the constructs it exists to
+// catch. A fabricated 1.00 is worse than an admitted unknown, so the profiler
+// now emits null instead.
+//
+// The baseline mirrors that nullability: baselineEntry.FanFactor is also
+// *float64, and a committed null is the explicit, reviewed acknowledgment
+// that a maintainer ran `just update-cardinality-baseline` and confirmed the
+// fixture's fan-out is genuinely uncountable with today's decomposition —
+// not an absence of data. The ratchet is null-aware, not null-blind:
+//
+//   - current null, baseline null: OK — already honestly acknowledged.
+//   - current null, baseline measured: FAIL — a fixture that used to be
+//     measurable stopped being measurable, which is either a profiler
+//     regression or a new construct the decomposition can't see through;
+//     either way it needs a human to look and re-baseline on purpose.
+//   - current measured, baseline null: OK, always — the fixture became
+//     measurable, which is strictly an improvement in what the gate can see.
+//   - both measured: the existing epsilon regression check below.
+//
+// This is a deliberate, maintainer-authorised asymmetry: null is NOT treated
+// as "pass" and it is NOT treated as "always fail" — it must match what the
+// committed baseline already says, the same discipline this file already
+// applies to every other structural field.
+//
 // # Metadata-endpoint fixtures (#1530)
 //
 // Three rows — metadata/series_no_bounds, metadata/labels_no_bounds,
@@ -122,22 +155,41 @@ const updateEnv = "UPDATE_CARDINALITY_BASELINE"
 
 // baselineEntry is the deterministic, structural subset of profile.Record the
 // ratchet compares + commits. See the file doc for why the noisy fields are
-// dropped.
+// dropped, and for the null/unmeasured fan_factor semantics.
 type baselineEntry struct {
-	Fixture           string  `json:"fixture"`
-	FanFactor         float64 `json:"fan_factor"`
-	ScanRows          int64   `json:"scan_rows"`
-	PeakIntermediate  int64   `json:"peak_intermediate"`
-	HasCrossJoin      bool    `json:"has_cross_join"`
-	HasArrayJoin      bool    `json:"has_array_join"`
-	HasRecursiveCTE   bool    `json:"has_recursive_cte"`
-	MaxRecursionDepth int64   `json:"max_recursion_depth"`
+	Fixture string `json:"fixture"`
+	// FanFactor is nil exactly when the fixture is unmeasured — see the
+	// file doc's "fan_factor can be unmeasured" section. A committed nil
+	// is the explicit, reviewed acknowledgment that this fixture's true
+	// fan-out is not currently countable, not a hole in the data.
+	FanFactor         *float64 `json:"fan_factor"`
+	ScanRows          int64    `json:"scan_rows"`
+	PeakIntermediate  int64    `json:"peak_intermediate"`
+	HasCrossJoin      bool     `json:"has_cross_join"`
+	HasArrayJoin      bool     `json:"has_array_join"`
+	HasRecursiveCTE   bool     `json:"has_recursive_cte"`
+	MaxRecursionDepth int64    `json:"max_recursion_depth"`
+	// UncountableLevels is diagnostic-only, mirroring profile.Record —
+	// carried through so a reviewer can see WHY a fixture is unmeasured
+	// without re-running the profiler. Never compared by the ratchet: it
+	// is a symptom count, not a budget, and it is only meaningful when
+	// FanFactor is nil.
+	UncountableLevels int `json:"uncountable_levels,omitempty"`
 }
 
 // fanFactorEpsilon absorbs float representation noise in the
 // peak_intermediate/scan_rows ratio so an exactly-equal fan_factor never
 // trips the ceiling.
 const fanFactorEpsilon = 1e-6
+
+// fmtFanFactor renders a nullable fan_factor for error messages — nil
+// (unmeasured) is spelled out rather than collapsed to a fabricated number.
+func fmtFanFactor(f *float64) string {
+	if f == nil {
+		return "unmeasured"
+	}
+	return fmt.Sprintf("%.2f", *f)
+}
 
 func toEntry(r profile.Record) baselineEntry {
 	return baselineEntry{
@@ -149,6 +201,7 @@ func toEntry(r profile.Record) baselineEntry {
 		HasArrayJoin:      r.HasArrayJoin,
 		HasRecursiveCTE:   r.HasRecursiveCTE,
 		MaxRecursionDepth: r.MaxRecursionDepth,
+		UncountableLevels: r.UncountableLevels,
 	}
 }
 
@@ -223,9 +276,11 @@ func TestCardinalityRatchet(t *testing.T) {
 	sort.Strings(removed)
 	for _, id := range added {
 		c := current[id]
-		t.Errorf("new fixture %q not in cardinality baseline (fan_factor=%.2f, cross_join=%v, "+
-			"recursive_cte=%v, max_depth=%d) — run `just update-cardinality-baseline` to record it",
-			id, c.FanFactor, c.HasCrossJoin, c.HasRecursiveCTE, c.MaxRecursionDepth)
+		t.Errorf("new fixture %q not in cardinality baseline (fan_factor=%s, cross_join=%v, "+
+			"recursive_cte=%v, max_depth=%d) — run `just update-cardinality-baseline` to record it. "+
+			"If fan_factor is \"unmeasured\", that is the honest state to commit — do not treat it as a "+
+			"reason to defer recording the fixture.",
+			id, fmtFanFactor(c.FanFactor), c.HasCrossJoin, c.HasRecursiveCTE, c.MaxRecursionDepth)
 	}
 	for _, id := range removed {
 		t.Errorf("baseline fixture %q no longer in the corpus — run `just update-cardinality-baseline` "+
@@ -242,11 +297,33 @@ func TestCardinalityRatchet(t *testing.T) {
 	sort.Strings(matched)
 	for _, id := range matched {
 		cur, base := current[id], baseline[id]
-		if cur.FanFactor > base.FanFactor+fanFactorEpsilon {
-			t.Errorf("%s: fan_factor regressed UPWARD %.2f → %.2f (peak_intermediate %d→%d at scan_rows %d). "+
-				"A query that fanned out N× now fans out more — root-cause the new intermediate blow-up; "+
-				"only run `just update-cardinality-baseline` if the increase is genuinely intended.",
-				id, base.FanFactor, cur.FanFactor, base.PeakIntermediate, cur.PeakIntermediate, cur.ScanRows)
+		// fan_factor is null-aware: see the file doc's "fan_factor can be
+		// unmeasured" section for the four-way truth table this implements.
+		// This is a pre-authorised maintainer decision — null must never
+		// silently pass, and it must never be blanket-failed either; it is
+		// compared against what the committed baseline already says.
+		switch {
+		case cur.FanFactor == nil && base.FanFactor == nil:
+			// Both unmeasured — already honestly acknowledged in the
+			// committed baseline. Nothing to check.
+		case cur.FanFactor == nil && base.FanFactor != nil:
+			t.Errorf("%s: fan_factor is now unmeasured (uncountable_levels=%d) but the baseline recorded a "+
+				"measured value of %s. A null fan_factor must never silently pass a fixture that used to be "+
+				"measured — either the profiler regressed (it can no longer see through a level it used to), "+
+				"or the fixture's SQL changed shape to one the decomposition can't see through. If the "+
+				"decomposition is correct and the fan-out is genuinely uncountable now, run "+
+				"`just update-cardinality-baseline` to record that explicitly; do not let this pass silently.",
+				id, cur.UncountableLevels, fmtFanFactor(base.FanFactor))
+		case cur.FanFactor != nil && base.FanFactor == nil:
+			// Became measurable — strictly an improvement in what the gate
+			// can see. Always allowed, no baseline update required.
+		default:
+			if *cur.FanFactor > *base.FanFactor+fanFactorEpsilon {
+				t.Errorf("%s: fan_factor regressed UPWARD %.2f → %.2f (peak_intermediate %d→%d at scan_rows %d). "+
+					"A query that fanned out N× now fans out more — root-cause the new intermediate blow-up; "+
+					"only run `just update-cardinality-baseline` if the increase is genuinely intended.",
+					id, *base.FanFactor, *cur.FanFactor, base.PeakIntermediate, cur.PeakIntermediate, cur.ScanRows)
+			}
 		}
 		if cur.ScanRows != base.ScanRows {
 			t.Errorf("%s: scan_rows drifted %d → %d. The leaf scan row count is a pure function of the "+

--- a/test/perf/cardinality_ratchet_test.go
+++ b/test/perf/cardinality_ratchet_test.go
@@ -173,8 +173,13 @@ type baselineEntry struct {
 	// carried through so a reviewer can see WHY a fixture is unmeasured
 	// without re-running the profiler. Never compared by the ratchet: it
 	// is a symptom count, not a budget, and it is only meaningful when
-	// FanFactor is nil.
-	UncountableLevels int `json:"uncountable_levels,omitempty"`
+	// FanFactor is nil. No `omitempty`: the baseline file's structural
+	// guard (.github/scripts/generated-baseline-structural-guard.mjs)
+	// requires every record to carry the same field set, so a
+	// zero-valued 0 must serialize explicitly rather than vanish —
+	// otherwise measured and unmeasured records blend into two
+	// distinct key sets and the guard's self-test fails the build.
+	UncountableLevels int `json:"uncountable_levels"`
 }
 
 // fanFactorEpsilon absorbs float representation noise in the

--- a/test/perf/profile/profile.go
+++ b/test/perf/profile/profile.go
@@ -75,10 +75,37 @@ type Record struct {
 	PeakIntermediate int64 `json:"peak_intermediate"`
 
 	// FanFactor is PeakIntermediate / ScanRows (1.0 when nothing fans
-	// out; >1 when an intermediate stage widened the row set). The
-	// headline number the nightly lane ranks on. 0 when ScanRows is 0
-	// (no leaf rows — an empty-seed or all-filtered fixture).
-	FanFactor float64 `json:"fan_factor"`
+	// out; >1 when an intermediate stage widened the row set; 0 when
+	// ScanRows is 0 — an empty-seed or all-filtered fixture, where every
+	// level WAS measured and they all counted zero rows, a degenerate
+	// ratio rather than an opaque one). The headline number the nightly
+	// lane ranks on. nil (JSON null) — NEVER a fabricated 1.00 —
+	// whenever [UncountableLevels] is nonzero: at least one pipeline
+	// stage was opaque to the per-level count() decomposition (a CTE
+	// reference, a pre-rendered subquery splice, or a RECURSIVE CTE
+	// step), so PeakIntermediate does not actually reflect the widest
+	// the row set gets anywhere in the pipeline. A 1.00 in that state
+	// reads as "no fan-out" on exactly the shapes most likely to hide
+	// one — see issue #1519, where emitSetOperation's `&&` CTE arms
+	// measured fan_factor=1.00 while costing 4 leaf reads.
+	FanFactor *float64 `json:"fan_factor"`
+
+	// UncountableLevels is the number of pipeline stages the profiler
+	// could not see through: a WITH-prefixed subquery (CTE reference /
+	// pre-rendered subquery splice) the leftmost-descent decomposition
+	// refused to enter because its body's names are only in scope at its
+	// own level, a RECURSIVE CTE step (detected structurally via EXPLAIN
+	// PLAN, wherever in the plan it sits), or a level whose isolated
+	// count() outright failed. Nonzero forces [FanFactor] to nil — see
+	// that field's doc. Zero means every level the decomposition visited
+	// was measured, so FanFactor (when ScanRows > 0) is trustworthy.
+	UncountableLevels int `json:"uncountable_levels"`
+
+	// UncountableReasons is one human-readable line per event counted in
+	// UncountableLevels, naming the depth (where applicable) and why it
+	// was opaque. Kept for debugging an unmeasured fixture — parallel to
+	// Levels but for the stages excluded from it.
+	UncountableReasons []string `json:"uncountable_reasons,omitempty"`
 
 	// ResultRows is count() of the full outer query — the rows the
 	// fixture's SQL ultimately returns.
@@ -259,7 +286,17 @@ func (p *Profiler) ProfileFixture(fixtureID string, prep *spec.PreparedRoundTrip
 	}
 
 	// Per-level count() decomposition over FROM-source subqueries.
-	levels := fromSourceLevels(query)
+	// levelsWithReasons additionally reports every point the descent
+	// stopped on a non-recursive WITH-prefixed subquery it could not see
+	// through — see that function's doc for why a RECURSIVE CTE is
+	// handled separately, below, from the structural EXPLAIN flag
+	// instead.
+	levels, descentReasons := levelsWithReasons(query)
+	rec.UncountableReasons = append(rec.UncountableReasons, descentReasons...)
+	if rec.HasRecursiveCTE {
+		rec.UncountableReasons = append(rec.UncountableReasons, recursiveCTEUncountableReason)
+	}
+
 	rec.Levels = make([]LevelCount, 0, len(levels))
 	var peak int64
 	var peakBytes uint64
@@ -267,9 +304,14 @@ func (p *Profiler) ProfileFixture(fixtureID string, prep *spec.PreparedRoundTrip
 		c, br, err := p.scalarCount(lvl)
 		if err != nil {
 			// A level that can't be counted in isolation (e.g. it
-			// references a CTE defined only at the outer level) is
-			// excluded — the outer-query count at depth 0 still anchors
-			// the result, and the leaf scan still anchors scan_rows.
+			// references a name only in scope at an outer level) is
+			// excluded from Levels AND recorded as uncountable — the
+			// outer-query count at depth 0 still anchors the result, and
+			// the leaf scan still anchors scan_rows, but this pipeline
+			// stage's contribution to PeakIntermediate is unknown rather
+			// than silently treated as zero.
+			rec.UncountableReasons = append(rec.UncountableReasons,
+				fmt.Sprintf("depth %d: count() failed in isolation: %v", depth, err))
 			continue
 		}
 		rec.Levels = append(rec.Levels, LevelCount{Depth: depth, Count: c})
@@ -289,8 +331,22 @@ func (p *Profiler) ProfileFixture(fixtureID string, prep *spec.PreparedRoundTrip
 		rec.ScanRows = rec.Levels[len(rec.Levels)-1].Count
 		rec.ResultRows = rec.Levels[0].Count
 	}
-	if rec.ScanRows > 0 {
-		rec.FanFactor = float64(rec.PeakIntermediate) / float64(rec.ScanRows)
+
+	rec.UncountableLevels = len(rec.UncountableReasons)
+	// FanFactor stays nil whenever any level was opaque: a fabricated
+	// 1.00 computed from a partial decomposition is worse than an
+	// admitted unknown. See the field doc + issue #1519 part 2. This is
+	// orthogonal to the ScanRows == 0 case (an empty-result fixture, e.g.
+	// an `absent_over_time` guard with no matching series): that ratio is
+	// mathematically degenerate rather than opaque — every level WAS
+	// measured, they just all counted zero rows — so it is still reported
+	// as a measured 0, matching the pre-#1519p2 convention.
+	if rec.UncountableLevels == 0 {
+		var ff float64
+		if rec.ScanRows > 0 {
+			ff = float64(rec.PeakIntermediate) / float64(rec.ScanRows)
+		}
+		rec.FanFactor = &ff
 	}
 
 	// max_recursion_depth: for a recursive CTE the closure size is the
@@ -328,11 +384,18 @@ func parseSingleCount(jsonBody string) (int64, error) {
 
 // SortByFanFactor orders records descending by FanFactor (then by
 // PeakIntermediate, then fixture name) so the nightly step-summary lists
-// the worst fan-outs first.
+// the worst fan-outs first. A nil FanFactor (unmeasured — see that
+// field's doc) sorts before every measured value: an unknown fan-out is
+// at least as much of a risk signal as a known-bad one, so it must not
+// silently sink to the bottom of the list.
 func SortByFanFactor(recs []Record) {
 	sort.Slice(recs, func(i, j int) bool {
-		if recs[i].FanFactor != recs[j].FanFactor {
-			return recs[i].FanFactor > recs[j].FanFactor
+		fi, fj := recs[i].FanFactor, recs[j].FanFactor
+		if (fi == nil) != (fj == nil) {
+			return fi == nil
+		}
+		if fi != nil && fj != nil && *fi != *fj {
+			return *fi > *fj
 		}
 		if recs[i].PeakIntermediate != recs[j].PeakIntermediate {
 			return recs[i].PeakIntermediate > recs[j].PeakIntermediate

--- a/test/perf/profile/profile_test.go
+++ b/test/perf/profile/profile_test.go
@@ -77,8 +77,14 @@ SELECT id, v FROM (SELECT id, vals FROM arr) ARRAY JOIN vals AS v
 	if rec.PeakIntermediate < 5 {
 		t.Errorf("PeakIntermediate = %d, want >= 5", rec.PeakIntermediate)
 	}
-	if rec.FanFactor < 5 {
-		t.Errorf("FanFactor = %.2f, want >= 5", rec.FanFactor)
+	if rec.UncountableLevels != 0 {
+		t.Errorf("UncountableLevels = %d, want 0: %v", rec.UncountableLevels, rec.UncountableReasons)
+	}
+	if rec.FanFactor == nil {
+		t.Fatalf("FanFactor = nil, want a measured value >= 5")
+	}
+	if *rec.FanFactor < 5 {
+		t.Errorf("FanFactor = %.2f, want >= 5", *rec.FanFactor)
 	}
 }
 
@@ -109,13 +115,22 @@ SELECT a FROM flat WHERE a >= 90
 		t.Errorf("unexpected fan-out operators: array=%v cross=%v rcte=%v",
 			rec.HasArrayJoin, rec.HasCrossJoin, rec.HasRecursiveCTE)
 	}
-	if rec.FanFactor != 1 {
-		t.Errorf("FanFactor = %.2f, want 1.0 (no fan-out)", rec.FanFactor)
+	if rec.UncountableLevels != 0 {
+		t.Errorf("UncountableLevels = %d, want 0: %v", rec.UncountableLevels, rec.UncountableReasons)
+	}
+	if rec.FanFactor == nil {
+		t.Fatalf("FanFactor = nil, want a measured value of 1.0")
+	}
+	if *rec.FanFactor != 1 {
+		t.Errorf("FanFactor = %.2f, want 1.0 (no fan-out)", *rec.FanFactor)
 	}
 }
 
 // TestProfileFixture_RecursiveCTE profiles a recursive CTE and asserts the
-// recursive flag fires and max_recursion_depth reflects the closure size.
+// recursive flag fires, max_recursion_depth reflects the closure size, and
+// — the point of issue #1519 part 2 — fan_factor is nil rather than a
+// fabricated 1.00: the per-level count() decomposition cannot see through
+// a RECURSIVE CTE step, so it must admit the fan-out is unmeasured.
 func TestProfileFixture_RecursiveCTE(t *testing.T) {
 	const body = `-- seed --
 CREATE TABLE anchor (n UInt64) ENGINE = MergeTree ORDER BY n;
@@ -144,19 +159,40 @@ WITH RECURSIVE walk AS (SELECT n FROM anchor UNION ALL SELECT n + 1 FROM walk WH
 	if rec.MaxRecursionDepth != 5 {
 		t.Errorf("MaxRecursionDepth = %d, want 5", rec.MaxRecursionDepth)
 	}
+	if rec.UncountableLevels == 0 {
+		t.Errorf("UncountableLevels = 0, want > 0: a recursive CTE step is opaque to the decomposition")
+	}
+	if rec.FanFactor != nil {
+		t.Errorf("FanFactor = %.2f, want nil (unmeasured — see issue #1519 part 2)", *rec.FanFactor)
+	}
+	foundReason := false
+	for _, r := range rec.UncountableReasons {
+		if r == recursiveCTEUncountableReason {
+			foundReason = true
+		}
+	}
+	if !foundReason {
+		t.Errorf("UncountableReasons = %v, want it to include the recursive-CTE reason", rec.UncountableReasons)
+	}
 }
 
+// ff is a small pointer-literal helper for FanFactor test fixtures.
+func ff(v float64) *float64 { return &v }
+
 // TestSortByFanFactor pins the descending ordering used by the nightly
-// step-summary.
+// step-summary, including that an unmeasured (nil) fan_factor sorts
+// first — ahead of every measured value, since an unknown fan-out is at
+// least as much of a risk signal as a known-bad one.
 func TestSortByFanFactor(t *testing.T) {
 	recs := []Record{
-		{Fixture: "a", FanFactor: 2},
-		{Fixture: "b", FanFactor: 10},
-		{Fixture: "c", FanFactor: 5},
+		{Fixture: "a", FanFactor: ff(2)},
+		{Fixture: "b", FanFactor: ff(10)},
+		{Fixture: "c", FanFactor: ff(5)},
+		{Fixture: "d", FanFactor: nil},
 	}
 	SortByFanFactor(recs)
-	if recs[0].Fixture != "b" || recs[1].Fixture != "c" || recs[2].Fixture != "a" {
-		t.Errorf("sort order = %s,%s,%s; want b,c,a",
-			recs[0].Fixture, recs[1].Fixture, recs[2].Fixture)
+	if recs[0].Fixture != "d" || recs[1].Fixture != "b" || recs[2].Fixture != "c" || recs[3].Fixture != "a" {
+		t.Errorf("sort order = %s,%s,%s,%s; want d,b,c,a",
+			recs[0].Fixture, recs[1].Fixture, recs[2].Fixture, recs[3].Fixture)
 	}
 }

--- a/test/perf/profile/sql.go
+++ b/test/perf/profile/sql.go
@@ -63,16 +63,67 @@ func planHasRecursiveCTE(plan string) bool {
 // intermediate cardinality. Keeping the decomposition in ONE place means
 // the corpus ratchet and the scale-wall pin agree on what "a pipeline
 // level" is by construction.
-func FromSourceLevels(query string) []string { return fromSourceLevels(query) }
+//
+// This wrapper deliberately drops the uncountable-level reasons
+// [levelsWithReasons] also returns: FromSourceLevels' only caller
+// (test/perf's scale-wall pin) already tolerates an individual level
+// failing to count in isolation (see its own comment at the call site),
+// so it has no honesty gap to plug the way [Record.FanFactor] does — see
+// issue #1519 part 2.
+func FromSourceLevels(query string) []string {
+	levels, _ := levelsWithReasons(query)
+	return levels
+}
 
+// fromSourceLevels is the levels-only view of [levelsWithReasons], kept
+// for callers (and tests) that only need the descent, not why it stopped.
 func fromSourceLevels(query string) []string {
+	levels, _ := levelsWithReasons(query)
+	return levels
+}
+
+// levelsWithReasons walks the same leftmost FROM-source chain
+// [fromSourceLevels] documents, and ADDITIONALLY reports, as
+// uncountableReasons, every point where the descent had to stop because
+// the next level is a WITH-prefixed (CTE) subquery whose body references
+// names only in scope at its own level — the profiler cannot run
+// `count() FROM (<that level>)` standalone, so its contribution to
+// PeakIntermediate is invisible.
+//
+// A RECURSIVE CTE (`WITH RECURSIVE ...`) is deliberately EXCLUDED from
+// the reasons returned here, even though it also stops the descent: its
+// closure can sit anywhere in the plan — the leftmost chain this function
+// walks, or a JOIN's right-hand branch this function (by design, see the
+// package doc) never visits at all, as `nested_set_left_position` and
+// `structural_not_ancestor` demonstrate: the recursive CTE lives inside a
+// JOIN RHS, so this descent never even reaches it. [ProfileFixture] gets
+// full, structural coverage of recursion (leftmost-chain OR join-branch)
+// from EXPLAIN PLAN's HasRecursiveCTE flag instead, and adds exactly one
+// "recursive_cte_step" reason from that flag — reporting it again here,
+// only for the fraction of cases the leftmost chain happens to pass
+// through, would both double-count some fixtures and miss others.
+//
+// The non-recursive case (a plain `WITH c AS (...) SELECT ...` CTE, e.g.
+// emitSetOperation's `&&` arms in internal/chsql/set_op.go) has no such
+// structural EXPLAIN signal, so it is reported here — this is the
+// "CTE reference" / "pre-rendered subquery splice" category from issue
+// #1519: the CTE body is exactly the pre-rendered SQL text
+// [subqueryFrag]-family emitters splice into a WITH clause, and once
+// spliced there this function cannot see through it.
+func levelsWithReasons(query string) ([]string, []string) {
 	query = strings.TrimSpace(query)
 	levels := []string{query}
 
-	// WITH-prefixed queries: keep depth 0 only. Descending into CTE
-	// bodies would reference out-of-scope CTE names.
+	// A RECURSIVE top-level query: 1 level, no reason (see doc above —
+	// ProfileFixture's HasRecursiveCTE-driven reason covers it).
+	if hasWithRecursivePrefix(query) {
+		return levels, nil
+	}
+	// A non-recursive WITH-prefixed top-level query: 1 level, and a
+	// reason — descending into the CTE bodies would reference
+	// out-of-scope CTE names.
 	if hasWithPrefix(query) {
-		return levels
+		return levels, []string{uncountableCTEReason(0)}
 	}
 
 	cur := query
@@ -86,21 +137,50 @@ func fromSourceLevels(query string) []string {
 		if inner == "" || strings.EqualFold(inner, cur) {
 			break
 		}
-		// A CTE-prefixed inner level can't be counted standalone; stop
-		// descending (its references are out of scope).
-		if hasWithPrefix(inner) {
+		if hasWithRecursivePrefix(inner) {
+			// Same rationale as the top-level case: no reason here, the
+			// HasRecursiveCTE flag covers it exactly once.
 			break
+		}
+		if hasWithPrefix(inner) {
+			return levels, []string{uncountableCTEReason(len(levels))}
 		}
 		levels = append(levels, inner)
 		cur = inner
 	}
-	return levels
+	return levels, nil
 }
 
+// uncountableCTEReason renders the human-readable line recorded in
+// [Record.UncountableReasons] when the descent stops on a non-recursive
+// WITH-prefixed subquery at the given depth.
+func uncountableCTEReason(depth int) string {
+	return fmt.Sprintf(
+		"depth %d: WITH-prefixed subquery (CTE reference / pre-rendered subquery splice) not descended — "+
+			"its body's inner row counts are out of scope to measure standalone", depth,
+	)
+}
+
+// recursiveCTEUncountableReason is the single reason [ProfileFixture]
+// records, once, whenever EXPLAIN PLAN reports a recursive CTE step
+// anywhere in the plan (leftmost chain or a JOIN branch) — see
+// [levelsWithReasons]' doc for why this is a structural (EXPLAIN-driven)
+// signal rather than one derived from the leftmost descent.
+const recursiveCTEUncountableReason = "recursive_cte_step: EXPLAIN plan reports a recursive CTE " +
+	"(ReadFromRecursiveCTEStep); the per-level count() decomposition cannot see the closure's own " +
+	"internal peak size, only whatever row count reaches the level that embeds it"
+
 // hasWithPrefix reports whether query begins with a `WITH ` keyword
-// (case-insensitive), i.e. carries a leading CTE chain.
+// (case-insensitive), i.e. carries a leading CTE chain (recursive or
+// not).
 func hasWithPrefix(query string) bool {
 	return strings.HasPrefix(strings.ToUpper(strings.TrimSpace(query)), "WITH ")
+}
+
+// hasWithRecursivePrefix reports whether query begins with `WITH
+// RECURSIVE ` — the RECURSIVE-step subset of [hasWithPrefix].
+func hasWithRecursivePrefix(query string) bool {
+	return strings.HasPrefix(strings.ToUpper(strings.TrimSpace(query)), "WITH RECURSIVE ")
 }
 
 // leftmostFromSubquery extracts the parenthesised subquery that is the

--- a/test/perf/profile/sql_test.go
+++ b/test/perf/profile/sql_test.go
@@ -108,6 +108,64 @@ func TestFromSourceLevels(t *testing.T) {
 	}
 }
 
+// TestLevelsWithReasons pins the honesty-relevant half of the descent:
+// a non-recursive WITH-prefixed level (CTE reference / pre-rendered
+// subquery splice) must produce an uncountable reason naming its depth,
+// while a RECURSIVE CTE — deliberately handled elsewhere via the
+// EXPLAIN-derived Record.HasRecursiveCTE flag, to avoid double-counting
+// a leftmost-chain recursive step and missing a JOIN-branch one — must
+// produce no reason from this function at all. See issue #1519 part 2.
+func TestLevelsWithReasons(t *testing.T) {
+	tests := []struct {
+		name        string
+		query       string
+		wantLevels  []string
+		wantReasons []string
+	}{
+		{
+			name:        "no WITH at all — nothing uncountable",
+			query:       "SELECT a FROM (SELECT b AS a FROM t)",
+			wantLevels:  []string{"SELECT a FROM (SELECT b AS a FROM t)", "SELECT b AS a FROM t"},
+			wantReasons: nil,
+		},
+		{
+			name:        "non-recursive WITH at depth 0",
+			query:       "WITH c AS (SELECT 1) SELECT * FROM c",
+			wantLevels:  []string{"WITH c AS (SELECT 1) SELECT * FROM c"},
+			wantReasons: []string{uncountableCTEReason(0)},
+		},
+		{
+			name:        "non-recursive WITH nested at depth 1",
+			query:       "SELECT x FROM (WITH c AS (SELECT 1) SELECT n AS x FROM c)",
+			wantLevels:  []string{"SELECT x FROM (WITH c AS (SELECT 1) SELECT n AS x FROM c)"},
+			wantReasons: []string{uncountableCTEReason(1)},
+		},
+		{
+			name:        "recursive WITH at depth 0 — no reason from this function",
+			query:       "WITH RECURSIVE c AS (SELECT 1 AS n UNION ALL SELECT n+1 FROM c WHERE n<5) SELECT * FROM c",
+			wantLevels:  []string{"WITH RECURSIVE c AS (SELECT 1 AS n UNION ALL SELECT n+1 FROM c WHERE n<5) SELECT * FROM c"},
+			wantReasons: nil,
+		},
+		{
+			name:        "recursive WITH nested at depth 1 — no reason from this function",
+			query:       "SELECT x FROM (WITH RECURSIVE c AS (SELECT 1 AS n UNION ALL SELECT n+1 FROM c WHERE n<5) SELECT n AS x FROM c)",
+			wantLevels:  []string{"SELECT x FROM (WITH RECURSIVE c AS (SELECT 1 AS n UNION ALL SELECT n+1 FROM c WHERE n<5) SELECT n AS x FROM c)"},
+			wantReasons: nil,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotLevels, gotReasons := levelsWithReasons(tc.query)
+			if !reflect.DeepEqual(gotLevels, tc.wantLevels) {
+				t.Errorf("levels mismatch\n got = %#v\nwant = %#v", gotLevels, tc.wantLevels)
+			}
+			if !reflect.DeepEqual(gotReasons, tc.wantReasons) {
+				t.Errorf("reasons mismatch\n got = %#v\nwant = %#v", gotReasons, tc.wantReasons)
+			}
+		})
+	}
+}
+
 func TestLeftmostFromSubquery(t *testing.T) {
 	tests := []struct {
 		query  string


### PR DESCRIPTION
## Summary

The corpus-wide fan-out profiler (`test/perf/profile`, Component B) and its per-PR ratchet gate (`test/perf/cardinality_ratchet_test.go`, Component C, part of the required `perf-guards` job) silently collapsed to `fan_factor = 1.00` on any fixture whose emitted SQL had a `WITH`-prefixed subquery it couldn't see through — a CTE reference / pre-rendered subquery splice, or a `WITH RECURSIVE` step. That's exactly `internal/chsql/set_op.go`'s `&&` (`SetIntersect`) construct and every recursive-CTE construct (nested-set numbering, structural ancestor/descendant joins) — the instrument reported "no fan-out" precisely where fan-out is worst, per issue #1519.

## What changed

- `profile.Record.FanFactor` is now `*float64`. It is **nil (JSON `null`)** — never a fabricated `1.00` — whenever a new `UncountableLevels` count is nonzero.
- New `Record.UncountableLevels` / `Record.UncountableReasons` fields record *why* a level couldn't be measured: a non-recursive `WITH`-prefixed subquery (detected in the leftmost-descent walk, `test/perf/profile/sql.go`), a `RECURSIVE` CTE step (detected structurally via `EXPLAIN PLAN`'s `HasRecursiveCTE` flag — position-independent, so it also catches recursion sitting inside a JOIN's right-hand branch, which the leftmost-only descent never visits at all), or a level whose isolated `count()` outright failed.
- The `0/0` degenerate case (an empty-seed / all-filtered fixture with `scan_rows = 0`) is **not** treated as uncountable — every level there genuinely was measured, they just all counted zero rows — so it still reports a measured `fan_factor = 0`, matching the pre-existing convention.
- The cardinality ratchet is now **null-aware, not null-blind** — a pre-authorised maintainer decision on #1519: a fixture whose current `fan_factor` is null must match what the committed baseline already says. Null on both sides passes (already honestly acknowledged); a regression from measured to null **fails** (a human has to look and re-baseline on purpose); becoming measurable is always allowed. A null is never a silent pass.
- `cmd/perf-profile/main_chdb.go` (the nightly step-summary renderer) and all touched tests updated for the pointer type.
- `docs/performance.md` documents the new null semantics.

## Baseline diff

Regenerated `test/perf/cardinality-baseline.json` via `just update-cardinality-baseline`. Exactly **22 `traceql/*` fixtures** flip from a fabricated `fan_factor: 1.0` to an honest `fan_factor: null` + `uncountable_levels: 1` — all either use the `&&` `SetIntersect` CTE construct or a recursive CTE (nested-set / structural-join queries). No other field on any fixture drifted. Verified with a structural diff against the pre-change baseline, not just a visual scan of the JSON.

Fixtures: `edge_chain_ancestor_3`, `edge_chain_descendant_3`, `edge_chain_mixed_5`, `edge_set_intersect_3`, `nested_set_left_position`, `recursive_ancestor`, `recursive_descendant`, `recursive_mixed`, `select_nested_set`, `select_nested_set_drilldown_historical_window`, `select_nested_set_drilldown_limited`, `select_nested_set_drilldown_structure`, `select_nested_set_drilldown_unbounded_noop`, `select_nested_set_structural`, `set_intersect_simple`, `spanset_and_distinct_spans`, `spanset_pipeline_intersect`, `structural_descendant_of_intersect`, `structural_not_ancestor`, `structural_not_descendant`, `structural_union_descendant`, `structural_union_descendant_dup_key_order`.

This unblocks measuring the actual fan-out on every dedup/perf claim in the backlog (#1445, #1525, #1672, #1519 part 1, #1501, #1443) — before this, the gate that's supposed to catch a fan-out regression on these shapes couldn't see one at all.

Addresses #1519 (part 2: measurement honesty). Part 1 stays open/tracked separately.

## Test plan

- [x] `just perf-chdb` passes locally against the regenerated baseline (`test/perf`, `test/perf/profile`, `test/perf/scaling` all green).
- [x] `go build ./...` and `go vet -tags chdb ./...` clean across the whole repo.
- [x] New unit tests: `TestLevelsWithReasons` (non-recursive CTE reason strings at depth 0 and nested; recursive CTE produces no reason from that function), updated `TestProfileFixture_RecursiveCTE` (asserts `FanFactor == nil` + the recursive-CTE reason is present), updated `TestProfileFixture_ArrayJoinFanOut` / `TestProfileFixture_NoFanOut` (pointer dereference + `UncountableLevels == 0`), updated `TestSortByFanFactor` (nil sorts first).
- [x] Verified the baseline diff by structural JSON comparison (not just `git diff`) — exactly the predicted 22 fixtures changed, nothing else.
- [x] Pre-push hooks green locally (`golangci-lint`, `forbid-sql-raw`, `markdownlint`, `actionlint`, etc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)