### PR TITLE
feat(compat): add a status-code parity axis to the compatibility corpora

### DIFF
--- a/.github/scripts/compat-ratchet.mjs
+++ b/.github/scripts/compat-ratchet.mjs
@@ -21,12 +21,14 @@
 // accident of the current numbers — a diff against a reference backend
 // is a bug to fix at the source, so there is no shape in this file that
 // can record a divergence as acceptable. The floors are prometheus
-// 739/739, loki 124/124, tempo 61/61, tempo-grpc 59/59; doc-counts.mjs
+// 739/739, loki 126/126, tempo 62/62, tempo-grpc 59/59; doc-counts.mjs
 // asserts those numbers against compatibility/parity-baseline.json, so
 // a corpus change cannot leave this comment behind. tempo-grpc's floor
-// is 2 below tempo's: traces / traces_v2 have no StreamingQuerier RPC
+// is 3 below tempo's: traces / traces_v2 have no StreamingQuerier RPC
 // (see compatibility/tempo/driver/grpc_diff.go), so those 2 corpus
-// cases never enter its roster.
+// cases never enter its roster, and one more (a -- expect_status --
+// rejection-parity case) is excluded pending #1714 (gRPC has no status
+// axis yet — see grpc_diff.go's skippedStatusParity).
 //
 // This is NOT an allow-list. An allow-list names the cases you are
 // permitted to fail; the roster names the cases that must pass, and

--- a/compatibility/loki/README.md
+++ b/compatibility/loki/README.md
@@ -173,6 +173,29 @@ bit-identical when both sides observed the same values. The pass
 queries with a `line_limit` above the per-service row count so
 neither backend truncates the peek window.
 
+## Status-parity differential pass
+
+The corpus and burndown passes both compare response BODIES, and fold
+any non-200 response into an `UnexpectedFailure` — correct for a
+"both backends must return this body" case, but it means neither pass
+can express "both backends must REJECT this request with the same
+status," or catch cerberus 400-ing where reference Loki 200s (or vice
+versa). `status_parity.go` closes that gap with a small, fixed set of
+known-invalid requests (a missing `query` parameter, syntactically
+invalid LogQL), fetched from both backends via a raw status probe that
+skips the 200-only fold entirely, asserting the HTTP status itself is
+the parity signal. This mirrors the Tempo/TraceQL `-- expect_status --`
+corpus axis (`compatibility/tempo/driver/corpus.go`) on the LogQL side.
+Results join the same report + score pipeline as every other pass.
+
+The two seeded cases are deliberately uncontroversial, protocol-level
+rejections both backends have always agreed on — case selection avoids
+any request shape tied to an open rejection-parity issue (a label or
+matcher case upstream accepts and cerberus currently rejects, or vice
+versa); those belong to their own issue once fixed, not to this list,
+because the committed `compatibility/parity-baseline.json` roster
+requires full parity from every entry it carries.
+
 ## Upstream-skip baseline
 
 The vendored corpus contains ~15 queries upstream marks `skip: true`

--- a/compatibility/loki/cmd/loki-compliance-tester/main.go
+++ b/compatibility/loki/cmd/loki-compliance-tester/main.go
@@ -196,6 +196,14 @@ func run() error {
 		// first/last_over_time, absent_over_time, topk/bottomk,
 		// sort/sort_desc. See burndown_value_parity.go.
 		results = append(results, compareBurndownValueParity(httpClient, f, metadata)...)
+
+		// Status-parity differential pass (range lane only — the
+		// endpoint distinction doesn't apply, this pass just needs to
+		// run once): a fixed set of requests both backends must REJECT
+		// with the same status, closing the same blind spot #1487 /
+		// #1435 / #1593 / #1484 / #1626 describe on the Tempo side. See
+		// status_parity.go.
+		results = append(results, compareStatusParityAll(httpClient, f)...)
 	}
 
 	report := Report{

--- a/compatibility/loki/cmd/loki-compliance-tester/status_parity.go
+++ b/compatibility/loki/cmd/loki-compliance-tester/status_parity.go
@@ -1,0 +1,218 @@
+package main
+
+// Status-parity differential pass — the LogQL sibling of the Tempo /
+// TraceQL "-- expect_status --" axis added alongside this file (see
+// compatibility/tempo/driver/corpus.go's -- expect_status -- section
+// and diff.go's diffStatusParityCase, landed for #1487 / #1435 /
+// #1593 / #1484 / #1626).
+//
+// The corpus + burndown passes (main.go's queryOne/doQuery,
+// burndown_value_parity.go) both fold ANY non-200 response into an
+// UnexpectedFailure via doQuery's status check (main.go's queryOne ->
+// doQuery, ~"resp.StatusCode != http.StatusOK") — correct for a
+// "should return 200 with this body" case, but it means neither pass
+// can express "both backends must REJECT this request" or catch
+// cerberus 400-ing where reference Loki 200s (or vice versa). This
+// pass closes that gap the same way the Tempo axis does: a small,
+// fixed set of known-invalid requests, fetched from both backends
+// WITHOUT the 200-only fold, asserting the HTTP status itself is the
+// parity signal.
+//
+// Case selection deliberately avoids the five open rejection-parity
+// issues above — those are about specific label/matcher shapes
+// upstream ACCEPTS that cerberus currently rejects (or vice versa),
+// exactly the kind of case this axis exists to eventually pin once
+// fixed. The two cases here are uncontroversial, protocol-level
+// rejections both backends have always agreed on: a missing `query`
+// parameter (internal/api/loki/detected_fields.go and the sibling
+// query/query_range handlers 400 with ErrBadData on this; reference
+// Loki has rejected a missing query since the endpoint existed) and
+// syntactically invalid LogQL (internal/api/loki's
+// TestQuery_InvalidLogQL pins cerberus's 400; upstream's parser 400s
+// the same class of input). They exist to prove the axis is wired
+// end-to-end without touching any of the open bugs.
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// statusParitySource is the report `testCase.source` for this pass,
+// mirroring burndownSource's naming convention.
+const statusParitySource = "cerberus/status-parity"
+
+// statusParityWindow is an arbitrary recent window for the two cases
+// below. Neither case's rejection depends on the seeded dataset or
+// the specific time range — both backends validate the request shape
+// before ever touching storage — so a wall-clock-relative window
+// keeps this pass independent of the harness's seeded fixture.
+const statusParityWindow = time.Hour
+
+// statusParityCase is one fixed request this pass issues against both
+// backends, asserting both return the SAME expected (non-2xx) status.
+type statusParityCase struct {
+	desc   string
+	path   string
+	params func(start, end time.Time) url.Values
+	expect int
+}
+
+// statusParityCases is the fixed case list. Extend it as more
+// protocol-level rejection-parity shapes need pinning; each entry
+// must be a rejection BOTH backends already agree on (see the
+// file-level comment) — a case tied to an open bug belongs in the
+// bug's own issue, not here, because the committed
+// compatibility/parity-baseline.json roster requires full parity.
+func statusParityCases() []statusParityCase {
+	return []statusParityCase{
+		{
+			desc: "missing query parameter on /query_range",
+			path: "/loki/api/v1/query_range",
+			params: func(start, end time.Time) url.Values {
+				v := url.Values{}
+				v.Set("start", strconv.FormatInt(start.UnixNano(), 10))
+				v.Set("end", strconv.FormatInt(end.UnixNano(), 10))
+				return v
+			},
+			expect: http.StatusBadRequest,
+		},
+		{
+			desc: "syntactically invalid LogQL (unbalanced selector) on /query_range",
+			path: "/loki/api/v1/query_range",
+			params: func(start, end time.Time) url.Values {
+				v := url.Values{}
+				v.Set("query", `{`)
+				v.Set("start", strconv.FormatInt(start.UnixNano(), 10))
+				v.Set("end", strconv.FormatInt(end.UnixNano(), 10))
+				return v
+			},
+			expect: http.StatusBadRequest,
+		},
+	}
+}
+
+// compareStatusParityAll runs the fixed status-parity case list and
+// returns one Result per case. Results join the same report + score
+// pipeline as every other pass — no separate bucket, no allow-list.
+func compareStatusParityAll(c *http.Client, f flags) []Result {
+	end := time.Now().UTC()
+	start := end.Add(-statusParityWindow)
+
+	cases := statusParityCases()
+	results := make([]Result, 0, len(cases))
+	for _, sc := range cases {
+		results = append(results, compareStatusParityOne(c, f, sc, start, end))
+	}
+	return results
+}
+
+func compareStatusParityOne(c *http.Client, f flags, sc statusParityCase, start, end time.Time) Result {
+	params := sc.params(start, end)
+	result := Result{TestCase: TestCase{
+		Query:       params.Get("query"),
+		Source:      statusParitySource,
+		Description: sc.desc,
+		Kind:        "status_parity",
+		Direction:   "n/a",
+		Start:       start.Format(time.RFC3339Nano),
+		End:         end.Format(time.RFC3339Nano),
+	}}
+
+	type fetched struct {
+		status int
+		body   string
+		err    error
+	}
+	out := make([]fetched, 2)
+	var wg sync.WaitGroup
+	wg.Add(2)
+	for idx, addr := range []string{f.addr1, f.addr2} {
+		idx, addr := idx, addr
+		go func() {
+			defer wg.Done()
+			status, body, err := fetchRawStatus(c, addr, sc.path, params)
+			out[idx] = fetched{status: status, body: body, err: err}
+		}()
+	}
+	wg.Wait()
+
+	refErr, testErr := out[0].err, out[1].err
+	switch {
+	case refErr != nil:
+		result.UnexpectedFailure = fmt.Sprintf("reference (-addr-1) request failed: %v", refErr)
+		return result
+	case testErr != nil:
+		result.UnexpectedFailure = fmt.Sprintf("test endpoint (-addr-2) request failed: %v", testErr)
+		return result
+	}
+
+	refStatus, testStatus := out[0].status, out[1].status
+	switch {
+	case refStatus != sc.expect && testStatus != sc.expect:
+		result.UnexpectedFailure = fmt.Sprintf(
+			"status parity: reference status=%d test status=%d, both expected %d (ref body=%s; test body=%s)",
+			refStatus, testStatus, sc.expect, statusParitySnippet(out[0].body), statusParitySnippet(out[1].body),
+		)
+	case refStatus != sc.expect:
+		result.UnexpectedFailure = fmt.Sprintf(
+			"status parity: reference (-addr-1) returned status=%d, expected %d (body=%s)",
+			refStatus, sc.expect, statusParitySnippet(out[0].body),
+		)
+	case testStatus != sc.expect:
+		result.UnexpectedFailure = fmt.Sprintf(
+			"status parity: test endpoint (-addr-2) returned status=%d, expected %d (body=%s)",
+			testStatus, sc.expect, statusParitySnippet(out[1].body),
+		)
+	}
+	return result
+}
+
+// fetchRawStatus issues a single GET and returns the raw status code
+// WITHOUT folding a non-2xx response into an error — that fold (see
+// doQuery in main.go) is exactly the blind spot this pass exists to
+// avoid. A non-nil error here means the request never completed at
+// all (network failure, timeout), which is a genuine harness problem
+// distinct from a — possibly mismatched — status code.
+func fetchRawStatus(c *http.Client, addr, path string, params url.Values) (int, string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
+	defer cancel()
+
+	u := strings.TrimRight(addr, "/") + path
+	if len(params) > 0 {
+		u += "?" + params.Encode()
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return 0, "", fmt.Errorf("new request: %w", err)
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		return 0, "", fmt.Errorf("http call: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, readErr := io.ReadAll(io.LimitReader(resp.Body, 16<<20))
+	if readErr != nil {
+		return 0, "", fmt.Errorf("read body: %w", readErr)
+	}
+	return resp.StatusCode, strings.TrimSpace(string(body)), nil
+}
+
+// statusParitySnippetMaxLen bounds the body snippet embedded in a
+// mismatch message so a wall-of-text error page doesn't dominate the
+// report, mirroring doQuery's / fetchDetectedFields's truncation.
+const statusParitySnippetMaxLen = 400
+
+func statusParitySnippet(body string) string {
+	if len(body) <= statusParitySnippetMaxLen {
+		return body
+	}
+	return body[:statusParitySnippetMaxLen] + "…"
+}

--- a/compatibility/loki/cmd/loki-compliance-tester/status_parity_test.go
+++ b/compatibility/loki/cmd/loki-compliance-tester/status_parity_test.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// statusServer starts a test server that always answers the given
+// status code, echoing the request body so mismatch tests can assert
+// on it.
+func statusServer(t *testing.T, status int) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(`{"status":"error","message":"boom"}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestCompareStatusParityOne_BothMatchExpectation_Passes — the case
+// this axis exists to make representable: both backends reject with
+// the expected status, and the pass records that as a plain success
+// rather than folding it into an opaque fetch error.
+func TestCompareStatusParityOne_BothMatchExpectation_Passes(t *testing.T) {
+	ref := statusServer(t, http.StatusBadRequest)
+	test := statusServer(t, http.StatusBadRequest)
+
+	f := flags{addr1: ref.URL, addr2: test.URL}
+	c := &http.Client{Timeout: 5 * time.Second}
+	sc := statusParityCases()[0]
+
+	end := time.Now().UTC()
+	start := end.Add(-time.Hour)
+	result := compareStatusParityOne(c, f, sc, start, end)
+
+	if !result.success() {
+		t.Fatalf("expected a passing result, got: %+v", result)
+	}
+}
+
+// TestCompareStatusParityOne_MismatchCaught — the exact blind spot
+// #1487 et al. describe: one backend accepts what the other rejects.
+// Both directions must surface as UnexpectedFailure, not a silent
+// pass or a generic "fetch error" that loses which side diverged.
+func TestCompareStatusParityOne_MismatchCaught(t *testing.T) {
+	tests := []struct {
+		name       string
+		refStatus  int
+		testStatus int
+		wantSubstr string
+	}{
+		{"reference accepts, test rejects", http.StatusOK, http.StatusBadRequest, "reference"},
+		{"reference rejects, test accepts", http.StatusBadRequest, http.StatusOK, "test endpoint"},
+		{"both wrong status class", http.StatusInternalServerError, http.StatusOK, "reference status=500 test status=200"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ref := statusServer(t, tc.refStatus)
+			test := statusServer(t, tc.testStatus)
+
+			f := flags{addr1: ref.URL, addr2: test.URL}
+			c := &http.Client{Timeout: 5 * time.Second}
+			sc := statusParityCases()[0]
+
+			end := time.Now().UTC()
+			start := end.Add(-time.Hour)
+			result := compareStatusParityOne(c, f, sc, start, end)
+
+			if result.success() {
+				t.Fatalf("expected a failing result, got success: %+v", result)
+			}
+			if !strings.Contains(result.UnexpectedFailure, tc.wantSubstr) {
+				t.Fatalf("UnexpectedFailure = %q, want substring %q", result.UnexpectedFailure, tc.wantSubstr)
+			}
+		})
+	}
+}
+
+// TestCompareStatusParityOne_FetchFailureDistinctFromMismatch — a
+// genuine network failure (server unreachable) must be attributed to
+// the side that failed, never silently reinterpreted as a status of 0
+// matching (or not matching) the expectation.
+func TestCompareStatusParityOne_FetchFailureDistinctFromMismatch(t *testing.T) {
+	test := statusServer(t, http.StatusBadRequest)
+
+	f := flags{addr1: "http://127.0.0.1:1", addr2: test.URL} // port 0 refuses connections
+	c := &http.Client{Timeout: 2 * time.Second}
+	sc := statusParityCases()[0]
+
+	end := time.Now().UTC()
+	start := end.Add(-time.Hour)
+	result := compareStatusParityOne(c, f, sc, start, end)
+
+	if result.success() {
+		t.Fatal("expected a failing result on unreachable reference")
+	}
+	if !strings.Contains(result.UnexpectedFailure, "reference") {
+		t.Fatalf("UnexpectedFailure should name the reference side: %q", result.UnexpectedFailure)
+	}
+}
+
+// TestStatusParityCases_ParamsWireCorrectly — sanity check that the
+// two fixed cases actually send the request shape their description
+// promises (missing query / malformed query), so a future edit to the
+// case table can't silently drift the params away from the intent.
+func TestStatusParityCases_ParamsWireCorrectly(t *testing.T) {
+	cases := statusParityCases()
+	if len(cases) < 2 {
+		t.Fatalf("expected at least 2 status-parity cases, got %d", len(cases))
+	}
+
+	start := time.Unix(0, 0)
+	end := time.Unix(3600, 0)
+
+	missingQuery := cases[0].params(start, end)
+	if missingQuery.Get("query") != "" {
+		t.Errorf("case 0 (%s) should carry no query param, got %q", cases[0].desc, missingQuery.Get("query"))
+	}
+	if missingQuery.Get("start") == "" || missingQuery.Get("end") == "" {
+		t.Errorf("case 0 (%s) should still carry start/end so the rejection is unambiguously about query", cases[0].desc)
+	}
+
+	badSyntax := cases[1].params(start, end)
+	if badSyntax.Get("query") == "" {
+		t.Errorf("case 1 (%s) should carry a (malformed) query param", cases[1].desc)
+	}
+
+	for _, sc := range cases {
+		if sc.expect < 400 || sc.expect > 599 {
+			t.Errorf("case %q: expect=%d is not a 4xx/5xx rejection", sc.desc, sc.expect)
+		}
+	}
+}

--- a/compatibility/parity-baseline.json
+++ b/compatibility/parity-baseline.json
@@ -748,9 +748,11 @@
       ]
     },
     "loki": {
-      "passed": 124,
-      "total": 124,
+      "passed": 126,
+      "total": 126,
       "cases": [
+        "cerberus/status-parity | status_parity | range | n/a |  | missing query parameter on /query_range",
+        "cerberus/status-parity | status_parity | range | n/a | { | syntactically invalid LogQL (unbalanced selector) on /query_range",
         "cerberus/wrong-rejection-burndown | log | range | BACKWARD | {cluster=\"cluster-0\", container=\"container-0\", datacenter=\"dc1\", env=\"production\", namespace=\"namespace-0\", pod=\"pod-0\", region=\"us-east-1\", service=\"web-server\", service_name=\"web-server\"} != ip(\"255.255.255.255\") | ip line filter negated: single-IP",
         "cerberus/wrong-rejection-burndown | log | range | BACKWARD | {cluster=\"cluster-0\", container=\"container-0\", datacenter=\"dc1\", env=\"production\", namespace=\"namespace-0\", pod=\"pod-0\", region=\"us-east-1\", service=\"web-server\", service_name=\"web-server\"} !> \"<_>error<_>\" | pattern line filter negated: embedded literal",
         "cerberus/wrong-rejection-burndown | log | range | BACKWARD | {cluster=\"cluster-0\", container=\"container-0\", datacenter=\"dc1\", env=\"production\", namespace=\"namespace-0\", pod=\"pod-0\", region=\"us-east-1\", service=\"web-server\", service_name=\"web-server\"} | json | client_ip != ip(\"10.0.0.0/8\") | ip label filter negated: CIDR over client_ip",
@@ -878,8 +880,8 @@
       ]
     },
     "tempo": {
-      "passed": 61,
-      "total": 61,
+      "passed": 62,
+      "total": 62,
       "cases": [
         "metrics_instant | metrics_avg_over_time_instant",
         "metrics_instant | metrics_count_over_time_instant",
@@ -939,6 +941,7 @@
         "tags_v1 | tags_v1_all",
         "tags_v2 | tags_v2_intrinsic",
         "tags_v2 | tags_v2_resource",
+        "tags_v2 | tags_v2_scope_all_rejected",
         "tags_v2 | tags_v2_span",
         "traces | trace_by_id_first_checkout",
         "traces_v2 | trace_by_id_v2_first_checkout"

--- a/compatibility/tempo/driver/corpus.go
+++ b/compatibility/tempo/driver/corpus.go
@@ -50,6 +50,16 @@
 //	                            check names; each check runs per-backend against
 //	                            the parsed response (see differ.go::SemanticChecks
 //	                            for the registered names)
+//	-- expect_status --         a 4xx/5xx HTTP status code both backends must
+//	                            return for this case (status-parity axis — see
+//	                            diff.go::diffStatusParityCase). Mutually
+//	                            exclusive with every expected_* body assertion
+//	                            and with semantic_checks (the body is never
+//	                            parsed for a status-parity case, so any of
+//	                            those would silently never run) and with
+//	                            endpoint=traces / traces_v2 (those two run
+//	                            through the proto-aware differ in
+//	                            proto_fetch.go, which this axis does not cover).
 //
 // There is intentionally no opt-out marker on a per-case basis: a case
 // that can't run is removed from the corpus, not flagged. Keeping the
@@ -198,6 +208,19 @@ type CorpusCase struct {
 	// "groupby_labels_present:resource.service.name" — the parser stores
 	// the raw "name:arg" string and the check function splits.
 	SemanticChecks []string
+
+	// ExpectedStatus, when non-zero, switches the case onto the
+	// status-parity axis (diff.go::diffStatusParityCase): the differ
+	// asserts BOTH backends respond with exactly this status code
+	// instead of requiring 2xx + running the body diff. This is what
+	// lets the corpus express "both backends must REJECT this input" —
+	// before this field, any non-2xx response from either side was
+	// folded into an opaque HardError, so a rejection-parity case could
+	// never be told apart from a genuine transport failure (see
+	// diff.go's package doc). Zero (the default) means "no expectation
+	// beyond both sides answering the usual way" and leaves the
+	// pre-existing 2xx-required behaviour untouched.
+	ExpectedStatus int
 }
 
 // LoadCorpus opens a corpus file and parses it into CorpusCases.
@@ -236,6 +259,7 @@ const (
 	secMaxSeries        = "expected_max_series"
 	secSamplesPerSeries = "expected_samples_per_series"
 	secSemanticChecks   = "semantic_checks"
+	secExpectStatus     = "expect_status"
 )
 
 // stripCommentLines returns the body with comment-only lines (`# ...`
@@ -309,6 +333,8 @@ func applySection(cur *CorpusCase, section, body string) error {
 		return applyIntSection(body, "expected_samples_per_series", &cur.ExpectedSamplesPerSeries)
 	case secSemanticChecks:
 		appendNonEmptyLines(body, &cur.SemanticChecks)
+	case secExpectStatus:
+		return applyIntSection(body, "expect_status", &cur.ExpectedStatus)
 	}
 	return nil
 }
@@ -378,7 +404,40 @@ func validateCase(cur CorpusCase, ord int) (CorpusCase, error) {
 	if cur.Endpoint == "metrics_range" && cur.Step == "" {
 		return cur, fmt.Errorf("case %q: endpoint=metrics_range requires -- step -- (e.g. \"60s\")", cur.Name)
 	}
+	if err := validateExpectedStatus(cur); err != nil {
+		return cur, err
+	}
 	return cur, nil
+}
+
+// validateExpectedStatus enforces the status-parity axis's invariants.
+// A zero ExpectedStatus (the default) skips every check below — the
+// case is an ordinary body-diff case and none of this applies.
+func validateExpectedStatus(cur CorpusCase) error {
+	if cur.ExpectedStatus == 0 {
+		return nil
+	}
+	if cur.ExpectedStatus < 400 || cur.ExpectedStatus > 599 {
+		return fmt.Errorf("case %q: -- expect_status -- must be a 4xx/5xx code (got %d) — this axis exists to express rejection parity, not 2xx parity, which the ordinary body-diff path already covers", cur.Name, cur.ExpectedStatus)
+	}
+	if cur.Endpoint == "traces" || cur.Endpoint == "traces_v2" {
+		return fmt.Errorf("case %q: -- expect_status -- is not supported on endpoint=%s (that endpoint runs through the proto-aware differ, which this axis does not cover)", cur.Name, cur.Endpoint)
+	}
+	// Every field below is a body-shape assertion; diffStatusParityCase
+	// never parses the body, so any of these set alongside expect_status
+	// would be silently dead corpus weight — parsed but never checked.
+	// Rejecting the combination at load time beats a passing assertion
+	// that isn't actually asserting anything.
+	switch {
+	case cur.ExpectedMinTraces != 0, cur.ExpectedMaxTraces != 0,
+		cur.ExpectedMinValues != 0, cur.ExpectedMaxValues != 0,
+		len(cur.ExpectedValues) != 0, len(cur.ExpectedScopes) != 0,
+		len(cur.ExpectedServices) != 0, cur.ExpectedRootNameRE != nil,
+		cur.ExpectedMinSeries != 0, cur.ExpectedMaxSeries != 0,
+		cur.ExpectedSamplesPerSeries != 0, len(cur.SemanticChecks) != 0:
+		return fmt.Errorf("case %q: -- expect_status -- cannot be combined with a body-shape assertion (expected_*/semantic_checks) — the status-parity path never parses the body", cur.Name)
+	}
+	return nil
 }
 
 // isTagEndpoint reports whether the given endpoint is one of the four
@@ -400,7 +459,8 @@ func isKnownSection(name string) bool {
 		secStep, secSpss,
 		secMinTraces, secMaxTraces, secMinValues, secMaxValues,
 		secValues, secScopes, secServices, secRootNameRE,
-		secMinSeries, secMaxSeries, secSamplesPerSeries, secSemanticChecks:
+		secMinSeries, secMaxSeries, secSamplesPerSeries, secSemanticChecks,
+		secExpectStatus:
 		return true
 	}
 	return false

--- a/compatibility/tempo/driver/corpus/smoke.txtar
+++ b/compatibility/tempo/driver/corpus/smoke.txtar
@@ -692,6 +692,26 @@ kind
 intrinsic
 
 -- name --
+tags_v2_scope_all_rejected
+-- endpoint --
+tags_v2
+-- scope --
+all
+# Status-parity axis (see diff.go's package doc + corpus.go's
+# -- expect_status -- documentation). "all" is deliberately not a
+# valid scope on either backend: upstream's traceql.AttributeScopeFromString
+# folds it to AttributeScopeUnknown, and internal/api/tempo/search_tags.go's
+# parseTagScope rejects it the same way on purpose (see the comment on
+# parseTagScope — cerberus intentionally does NOT accept "all" so it
+# doesn't train clients into a shape real Tempo 400s). Both backends
+# reject with "invalid scope: all", so this proves the axis end-to-end
+# without touching the OPEN scope-widening bug (#1593, which is about
+# scope values upstream *accepts* and cerberus currently rejects —
+# the opposite direction from this case).
+-- expect_status --
+400
+
+-- name --
 tag_values_v1_service_name
 -- endpoint --
 tag_values_v1

--- a/compatibility/tempo/driver/corpus_test.go
+++ b/compatibility/tempo/driver/corpus_test.go
@@ -418,3 +418,73 @@ metrics_instant
 		t.Fatalf("Endpoint = %q", got[0].Endpoint)
 	}
 }
+
+func TestParseCorpus_ExpectStatusOK(t *testing.T) {
+	t.Parallel()
+	in := `-- name --
+bad_scope
+-- endpoint --
+tags_v2
+-- scope --
+all
+-- expect_status --
+400
+`
+	got, err := parseCorpus(strings.NewReader(in), "test")
+	if err != nil {
+		t.Fatalf("parseCorpus: %v", err)
+	}
+	if got[0].ExpectedStatus != 400 {
+		t.Fatalf("ExpectedStatus = %d, want 400", got[0].ExpectedStatus)
+	}
+}
+
+func TestParseCorpus_ExpectStatusRejects2xx(t *testing.T) {
+	t.Parallel()
+	in := `-- name --
+bad
+-- query --
+{ x = 1 }
+-- endpoint --
+search
+-- expect_status --
+200
+`
+	if _, err := parseCorpus(strings.NewReader(in), "test"); err == nil {
+		t.Fatal("expect_status outside 4xx/5xx should fail — that's what the ordinary body-diff path is for")
+	}
+}
+
+func TestParseCorpus_ExpectStatusRejectsTracesEndpoint(t *testing.T) {
+	t.Parallel()
+	in := `-- name --
+bad
+-- endpoint --
+traces
+-- traceid_template --
+svc/0
+-- expect_status --
+404
+`
+	if _, err := parseCorpus(strings.NewReader(in), "test"); err == nil {
+		t.Fatal("expect_status on endpoint=traces should fail — that endpoint runs through the proto differ, which this axis does not cover")
+	}
+}
+
+func TestParseCorpus_ExpectStatusRejectsBodyAssertionCombo(t *testing.T) {
+	t.Parallel()
+	in := `-- name --
+bad
+-- query --
+{ x = 1 }
+-- endpoint --
+search
+-- expect_status --
+400
+-- expected_min_traces --
+1
+`
+	if _, err := parseCorpus(strings.NewReader(in), "test"); err == nil {
+		t.Fatal("expect_status combined with a body-shape assertion should fail — the status-parity path never parses the body, so expected_min_traces would silently never run")
+	}
+}

--- a/compatibility/tempo/driver/diff.go
+++ b/compatibility/tempo/driver/diff.go
@@ -13,6 +13,23 @@
 // hard errors (corpus load failure, write failure) bubble up. The
 // score JSON drives the downstream badge; CI uses the artifact, not
 // the exit code, to track drift over time.
+//
+// Status-parity axis: fetchJSON folds any non-2xx response into an
+// error, so by default a corpus case can only ever express "both
+// backends must answer 2xx with agreeing bodies" — it has no way to
+// say "both backends must REJECT this input", and no way to say
+// "cerberus 400s where upstream 200s" (or vice versa) as anything
+// other than an indistinguishable-from-a-network-blip HardError. That
+// blinds the differential to an entire class of rejection-parity bug
+// (cerberus #1593, #1484): the corpus simply cannot contain a case
+// that probes it. A corpus case that sets CorpusCase.ExpectedStatus
+// (TXTAR `-- expect_status --`) routes through diffStatusParityCase
+// instead, which compares the two backends' actual status codes
+// against the declared expectation as a first-class outcome — pass
+// when both sides return exactly that code, a normal (non-hard-error)
+// Assertion failure when either side doesn't. A genuine transport
+// failure (no response at all) still hard-errors; there is nothing to
+// compare in that case.
 
 package main
 
@@ -282,6 +299,15 @@ func diffCase(ctx context.Context, client *http.Client, tc CorpusCase, opts case
 	cerbBody, cerbStatus, cerr := fetchJSON(ctx, client, cerbURL)
 	res.TempoStatus = tempoStatus
 	res.CerberusStatus = cerbStatus
+
+	// Status-parity cases never reach the 2xx-required / body-diff path
+	// below: the whole point of -- expect_status -- is that a non-2xx
+	// response is the CORRECT outcome, not a hard error. See the
+	// package doc + diffStatusParityCase.
+	if tc.ExpectedStatus != 0 {
+		return diffStatusParityCase(tc, tempoStatus, cerbStatus, terr, cerr)
+	}
+
 	if terr != nil {
 		res.HardError = fmt.Sprintf("tempo fetch: %v", terr)
 	}
@@ -357,6 +383,49 @@ func diffCase(ctx context.Context, client *http.Client, tc CorpusCase, opts case
 		return res
 	}
 	res.Diff = d
+	return res
+}
+
+// diffStatusParityCase is diffCase's status-parity branch, taken when
+// the corpus case sets ExpectedStatus. It never looks at either
+// response body — validateExpectedStatus (corpus.go) forbids combining
+// -- expect_status -- with any body-shape assertion, so there is
+// nothing else to check.
+//
+// A zero status on either side means fetchJSON never got a response at
+// all (request build failure, transport error, or a body-read
+// failure) — that's a genuine hard error, not a rejection to grade.
+// Otherwise both sides produced a real status code, and the case's
+// only assertion is that each one equals tc.ExpectedStatus; a mismatch
+// is recorded as a normal Assertion (not a HardError) so it flows
+// through the same passed() predicate, report renderer, and
+// compat-cases.json roster as every other per-case outcome.
+func diffStatusParityCase(tc CorpusCase, tempoStatus, cerbStatus int, terr, cerr error) CaseResult {
+	res := CaseResult{Case: tc, TempoStatus: tempoStatus, CerberusStatus: cerbStatus}
+	if tempoStatus == 0 {
+		res.HardError = fmt.Sprintf("tempo fetch: %v", terr)
+		return res
+	}
+	if cerbStatus == 0 {
+		res.HardError = fmt.Sprintf("cerberus fetch: %v", cerr)
+		return res
+	}
+	if tempoStatus != tc.ExpectedStatus {
+		res.Assertions = append(res.Assertions, DiffReason{
+			Kind:   "status_mismatch",
+			Detail: fmt.Sprintf("tempo returned status %d, corpus -- expect_status -- says %d", tempoStatus, tc.ExpectedStatus),
+		})
+	}
+	if cerbStatus != tc.ExpectedStatus {
+		res.Assertions = append(res.Assertions, DiffReason{
+			Kind:   "status_mismatch",
+			Detail: fmt.Sprintf("cerberus returned status %d, corpus -- expect_status -- says %d", cerbStatus, tc.ExpectedStatus),
+		})
+	}
+	// No body was parsed, so there is no structural diff to compute —
+	// mark it trivially Equal so passed() (HardError=="" && Diff.Equal
+	// && len(Assertions)==0) reduces to "did the statuses match".
+	res.Diff = Diff{Equal: true}
 	return res
 }
 

--- a/compatibility/tempo/driver/diff_test.go
+++ b/compatibility/tempo/driver/diff_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -299,5 +300,68 @@ func TestBuildURL_MetricsInstant(t *testing.T) {
 	}
 	if strings.Contains(u, "step=") {
 		t.Fatalf("instant endpoint must not carry step: %s", u)
+	}
+}
+
+func TestDiffStatusParityCase_BothMatchExpectation_Passes(t *testing.T) {
+	t.Parallel()
+	tc := CorpusCase{Name: "bad_scope", ExpectedStatus: 400}
+	res := diffStatusParityCase(tc, 400, 400, nil, nil)
+	if !res.passed() {
+		t.Fatalf("expected passed()==true, got HardError=%q Assertions=%v Diff=%+v", res.HardError, res.Assertions, res.Diff)
+	}
+	if len(res.Assertions) != 0 {
+		t.Fatalf("expected no assertions, got %v", res.Assertions)
+	}
+}
+
+// TestDiffStatusParityCase_MismatchCaught proves the axis is non-vacuous:
+// a corpus case declaring expect_status must actually FAIL when either
+// backend's real status diverges from the declaration, not just when
+// the harness happens to agree with itself.
+func TestDiffStatusParityCase_MismatchCaught(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name               string
+		tempoStatus        int
+		cerbStatus         int
+		wantAssertionCount int
+	}{
+		{"tempo answers 200 instead of the declared 400", 200, 400, 1},
+		{"cerberus answers 200 instead of the declared 400", 400, 200, 1},
+		{"both sides diverge from the declaration", 500, 200, 2},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			tc := CorpusCase{Name: "bad_scope", ExpectedStatus: 400}
+			res := diffStatusParityCase(tc, c.tempoStatus, c.cerbStatus, nil, nil)
+			if res.passed() {
+				t.Fatalf("expected passed()==false for tempo=%d cerberus=%d expect=400", c.tempoStatus, c.cerbStatus)
+			}
+			if res.HardError != "" {
+				t.Fatalf("a status mismatch is a real outcome, not a hard error; got HardError=%q", res.HardError)
+			}
+			if len(res.Assertions) != c.wantAssertionCount {
+				t.Fatalf("Assertions = %v, want %d entries", res.Assertions, c.wantAssertionCount)
+			}
+			for _, a := range res.Assertions {
+				if a.Kind != "status_mismatch" {
+					t.Errorf("assertion Kind = %q, want status_mismatch", a.Kind)
+				}
+			}
+		})
+	}
+}
+
+func TestDiffStatusParityCase_NoResponseIsHardError(t *testing.T) {
+	t.Parallel()
+	tc := CorpusCase{Name: "bad_scope", ExpectedStatus: 400}
+	res := diffStatusParityCase(tc, 0, 400, errors.New("dial tcp: connection refused"), nil)
+	if res.HardError == "" {
+		t.Fatal("a zero status (no response at all) must hard-error rather than being graded as a mismatch")
+	}
+	if res.passed() {
+		t.Fatal("a hard error must never pass")
 	}
 }

--- a/compatibility/tempo/driver/grpc_diff.go
+++ b/compatibility/tempo/driver/grpc_diff.go
@@ -196,19 +196,39 @@ func runDiffGRPC(args []string) error {
 	}
 
 	var results []CaseResult
-	var skipped []CorpusCase
+	var skippedNoRPC []CorpusCase
+	var skippedStatusParity []CorpusCase
 	for _, tc := range cases {
 		tc := tc
-		if !grpcSupportsEndpoint(tc.Endpoint) {
-			skipped = append(skipped, tc)
+		switch {
+		case !grpcSupportsEndpoint(tc.Endpoint):
+			skippedNoRPC = append(skippedNoRPC, tc)
+			continue
+		case tc.ExpectedStatus != 0:
+			// The status-parity axis (-- expect_status --, diff.go's
+			// diffStatusParityCase) compares HTTP status ints. gRPC
+			// surfaces failures as codes.Code via status.FromError — a
+			// different domain with no canonical mapping — and
+			// diffCaseGRPC treats any non-nil RPC error as an
+			// unconditional HardError, so running an ExpectedStatus case
+			// through this transport unmodified would silently mis-grade
+			// it. Tracked as a distinct gRPC-side axis in #1714; until
+			// that lands, these cases are HTTP-transport-only, reported
+			// here rather than dropped.
+			skippedStatusParity = append(skippedStatusParity, tc)
 			continue
 		}
 		logger.Info("diffing case (grpc)", "name", tc.Name, "endpoint", tc.Endpoint)
 		results = append(results, diffCaseGRPC(ctx, tempoClient, cerbClient, tc, opts))
 	}
-	logger.Info("grpc corpus filtered", "ran", len(results), "skipped_no_grpc_rpc", len(skipped))
+	logger.Info(
+		"grpc corpus filtered",
+		"ran", len(results),
+		"skipped_no_grpc_rpc", len(skippedNoRPC),
+		"skipped_status_parity", len(skippedStatusParity),
+	)
 
-	if err := writeReportGRPC(*reportPath, results, skipped); err != nil {
+	if err := writeReportGRPC(*reportPath, results, skippedNoRPC, skippedStatusParity); err != nil {
 		return fmt.Errorf("write grpc report: %w", err)
 	}
 	logger.Info("wrote grpc markdown report", "path", *reportPath)
@@ -228,7 +248,8 @@ func runDiffGRPC(args []string) error {
 		"total", total,
 		"percent", s.Percent,
 		"color", s.Color,
-		"skipped_no_grpc_rpc", len(skipped),
+		"skipped_no_grpc_rpc", len(skippedNoRPC),
+		"skipped_status_parity", len(skippedStatusParity),
 	)
 	return nil
 }
@@ -568,14 +589,16 @@ func metricsSeriesFromProtoRange(ts *tempopb.TimeSeries) MetricsSeriesEntry {
 
 // writeReportGRPC renders the gRPC transport's markdown report: the
 // shared per-case body (writeReport / renderReport, diff.go) for every
-// case that ran, plus an explicit "skipped" section for corpus cases
-// with no StreamingQuerier RPC counterpart — documented, not silently
-// dropped.
-func writeReportGRPC(path string, results []CaseResult, skipped []CorpusCase) error {
+// case that ran, plus explicit "skipped" sections for corpus cases this
+// transport genuinely can't run — documented, not silently dropped.
+// skippedNoRPC is endpoints with no StreamingQuerier RPC counterpart at
+// all (traces/traces_v2); skippedStatusParity is expect_status cases
+// this transport doesn't yet grade (tracked in #1714).
+func writeReportGRPC(path string, results []CaseResult, skippedNoRPC, skippedStatusParity []CorpusCase) error {
 	if err := writeReport(path, grpcReportTitle, grpcStatusLabel, results); err != nil {
 		return err
 	}
-	if len(skipped) == 0 {
+	if len(skippedNoRPC) == 0 && len(skippedStatusParity) == 0 {
 		return nil
 	}
 	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600) //nolint:gosec // G304: report path is a trusted CLI argument, same as writeReport's os.Create
@@ -583,30 +606,52 @@ func writeReportGRPC(path string, results []CaseResult, skipped []CorpusCase) er
 		return fmt.Errorf("reopen report for skipped-section append: %w", err)
 	}
 	defer func() { _ = f.Close() }()
-	return renderSkippedSection(f, skipped)
+	if len(skippedNoRPC) > 0 {
+		if err := renderSkippedSection(
+			f, skippedNoRPC,
+			"## Skipped — no StreamingQuerier RPC for this endpoint",
+			"tempopb.StreamingQuerier exposes 7 RPCs (Search, SearchTags[V2], "+
+				"SearchTagValues[V2], MetricsQueryRange, MetricsQueryInstant) — "+
+				"there is no trace-by-id or search/recent RPC on either reference "+
+				"Tempo or cerberus. The %d case(s) below are genuinely inapplicable "+
+				"to this transport and are excluded from the score denominator "+
+				"rather than counted as failures:\n\n",
+		); err != nil {
+			return err
+		}
+	}
+	if len(skippedStatusParity) > 0 {
+		if err := renderSkippedSection(
+			f, skippedStatusParity,
+			"## Skipped — expect_status axis not yet implemented for gRPC",
+			"These corpus cases carry -- expect_status --, a rejection-parity "+
+				"axis compared against the HTTP status int (diff.go's "+
+				"diffStatusParityCase). gRPC surfaces failures as "+
+				"codes.Code via status.FromError, a different domain with no "+
+				"canonical mapping to HTTP status, and this transport doesn't "+
+				"grade that yet (tracked in #1714). The %d case(s) below are "+
+				"excluded from the score denominator rather than counted as "+
+				"failures:\n\n",
+		); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
-// renderSkippedSection appends the "no gRPC RPC" section, sorted by case
-// name for reproducibility across runs.
-func renderSkippedSection(w io.Writer, skipped []CorpusCase) error {
+// renderSkippedSection appends a documented "skipped, and why" section,
+// sorted by case name for reproducibility across runs.
+func renderSkippedSection(w io.Writer, skipped []CorpusCase, heading, explanation string) error {
 	sorted := append([]CorpusCase(nil), skipped...)
 	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Name < sorted[j].Name })
 
-	if _, err := fmt.Fprintln(w, "## Skipped — no StreamingQuerier RPC for this endpoint"); err != nil {
+	if _, err := fmt.Fprintln(w, heading); err != nil {
 		return err
 	}
 	if _, err := fmt.Fprintln(w); err != nil {
 		return err
 	}
-	if _, err := fmt.Fprintf(
-		w,
-		"tempopb.StreamingQuerier exposes 7 RPCs (Search, SearchTags[V2], "+
-			"SearchTagValues[V2], MetricsQueryRange, MetricsQueryInstant) — "+
-			"there is no trace-by-id or search/recent RPC on either reference "+
-			"Tempo or cerberus. The %d case(s) below are genuinely inapplicable "+
-			"to this transport and are excluded from the score denominator "+
-			"rather than counted as failures:\n\n", len(sorted),
-	); err != nil {
+	if _, err := fmt.Fprintf(w, explanation, len(sorted)); err != nil {
 		return err
 	}
 	for _, tc := range sorted {


### PR DESCRIPTION
## Summary

The comparator in each compatibility harness (`compatibility/{prometheus,loki,tempo}`) folds any non-2xx HTTP response into an opaque "fetch error," so none of the three corpora can express "both backends must REJECT this request" or "cerberus 400s where upstream 200s" (or vice versa). This blinds the required compatibility gate to a class of rejection-parity bug: #1487, #1435, #1593, #1484, #1626.

This PR builds a first-class status-code parity axis into the corpora so future bugs of this shape surface as real, gated divergences instead of vanishing into a generic fetch-error bucket. It does **not** fix the five bugs above — those need real investigation and stay open, each to be fixed in its own PR now that the corpora can represent them.

## What changed, per head

- **Tempo/TraceQL** (`compatibility/tempo/driver/`): new `-- expect_status --` TXTAR section in the corpus format (`corpus.go`, `validateExpectedStatus` enforces 4xx/5xx-only, not combinable with body assertions, not on `traces`/`traces_v2`), and a `diffStatusParityCase` comparator in `diff.go` that records/compares HTTP status as a first-class outcome. One new corpus case, `tags_v2_scope_all_rejected` (`corpus/smoke.txtar`), proves the axis end-to-end.
- **Tempo gRPC** (`grpc_diff.go`): `ExpectedStatus`-bearing cases are explicitly excluded from the gRPC/h2c `StreamingQuerier` transport (a new `skippedStatusParity` category, reported in its own markdown section) rather than silently mis-graded — gRPC surfaces failures as `codes.Code`, a different domain with no canonical HTTP-status mapping. Tracked as a distinct follow-up in #1714.
- **Loki/LogQL** (`compatibility/loki/cmd/loki-compliance-tester/status_parity.go`, new file): a driver-level differential pass, following the existing `detected_fields.go` / `burndown_value_parity.go` precedent, since the vendored AGPL `upstream/loki-bench` schema and the additive `cerberus-queries/` corpus have no status-expectation concept and can't be extended for this. Two fixed, uncontroversial cases (missing `query` parameter, syntactically invalid LogQL) prove the axis without touching any of the five open bugs. Wired into `main.go`'s `run()`.
- **Prometheus**: already has this axis via the `should_fail: true` corpus tag in `cerberus-test-queries.yml` (backed by the vendored `promql-compliance-tester`'s `UnexpectedSuccess`/`UnexpectedFailure` result fields) — no code change needed.

## Baseline / ratchet wiring

- `compatibility/parity-baseline.json`: `heads.tempo` bumped 61/61 → 62/62 (new case inserted, sorted); `heads.loki` bumped 124/124 → 126/126 (two new cases inserted, sorted). `heads.tempo-grpc` stays 59/59 (the new case is excluded there, see #1714).
- `.github/scripts/compat-ratchet.mjs`: header-comment floor claims updated to match (`doc-counts.mjs` asserts this comment against the baseline file — verified green).
- `compatibility/loki/README.md`: new "Status-parity differential pass" section documenting the addition, alongside the existing "Detected-fields differential pass" section.

## Follow-up issues

- #1714 — extend the `expect_status` axis to the Tempo gRPC transport (needs a `codes.Code`-based axis, no HTTP status domain there).
- This PR itself is tracked by / closes #1716, the A1 tracking issue for this work.

## Test plan

- [x] `go build ./... && go vet ./... && go test ./driver/...` — `compatibility/tempo` (all green, including 4 new corpus tests + 3 new diff tests + gRPC skip-category tests)
- [x] `go build ./... && go vet ./... && go test ./...` — `compatibility/loki` (all green, including new `status_parity_test.go`: both-match pass, both mismatch directions, genuine fetch failure distinguished from a status mismatch)
- [x] `node .github/scripts/doc-counts.mjs --self-test && node .github/scripts/doc-counts.mjs` — parity-floor claims match the baseline
- [x] `node --test .github/scripts/compat-ratchet.test.mjs` — 12/12 pass (head-list assertion `['loki','prometheus','tempo','tempo-grpc']` already covered the new roster)
- [x] `markdownlint-cli2 compatibility/loki/README.md` — clean
- [x] lefthook `pre-commit` + `pre-push` (gofumpt, goimports, markdownlint, golangci-lint, forbid-sql-raw, forbid-skip, forbid-escape-hatch, commitlint) — all green

Closes #1716