### PR TITLE
fix(optimizer): restate scan-resource-bound witness set to include literal InList

### DIFF
--- a/internal/chplan/scan_resource_bound.go
+++ b/internal/chplan/scan_resource_bound.go
@@ -149,32 +149,59 @@ func flattenConjuncts(e Expr) []Expr {
 	return append(flattenConjuncts(b.Left), flattenConjuncts(b.Right)...)
 }
 
-// isTraceIDSetConjunct reports whether c proves a finite TraceId membership:
-//   - a BoundedTraceScope (self-identifying top-N subquery);
-//   - a non-negated InList over the bare TraceId column (root lookup);
-//   - a `TraceId = <literal>` equality (the /traces/{id} singleton set).
+// TraceIDSetCardinality reports the finite trace-set size c proves for cols,
+// or (0, false) when c is not a recognized trace-id-set conjunct. It is the
+// single classification both TraceId-set witnesses share:
+//   - a BoundedTraceScope (self-identifying top-N subquery): cardinality is
+//     its own TraceLimit (the top-N the subquery keeps);
+//   - a non-negated InList over the bare TraceId column (root lookup, or the
+//     resolve-in-Go-and-splice-literals rewrite of a BoundedTraceScope):
+//     cardinality is the literal list length;
+//   - a `TraceId = <literal>` equality (the /traces/{id} singleton set):
+//     cardinality is 1.
 //
 // When cols.TraceID is empty the column checks accept any bare (unqualified)
 // ColumnRef — over a spans scan that is an id column, never an attribute
 // predicate (attribute INs / equalities carry a MapAccess / FieldAccess left,
 // not a bare ColumnRef).
-func isTraceIDSetConjunct(c Expr, cols ScanBoundCols) bool {
+//
+// This is the ONE classifier both the emit-chokepoint invariant
+// (SpansScanResourceBound, which only needs presence — any cardinality
+// proves form-b) and the optimizer's NestedSetAnnotate analyzer
+// (RequireScanResourceBound, which additionally compares the returned
+// cardinality against NestedSetAnnotate.TraceLimit for a lock-step match)
+// read off of, so a literal InList counts as a witness identically in both
+// places (#1702).
+func TraceIDSetCardinality(c Expr, cols ScanBoundCols) (int64, bool) {
 	switch v := c.(type) {
 	case *BoundedTraceScope:
-		return cols.TraceID == "" || v.TraceIDColumn == cols.TraceID
-	case *InList:
-		if v.Negated {
-			return false
+		if cols.TraceID != "" && v.TraceIDColumn != cols.TraceID {
+			return 0, false
 		}
-		return isTraceIDCol(v.Left, cols)
+		return v.TraceLimit, true
+	case *InList:
+		if v.Negated || !isTraceIDCol(v.Left, cols) {
+			return 0, false
+		}
+		return int64(len(v.List)), true
 	case *Binary:
 		if v.Op != OpEq {
-			return false
+			return 0, false
 		}
-		return (isTraceIDCol(v.Left, cols) && isConstExpr(v.Right)) ||
-			(isTraceIDCol(v.Right, cols) && isConstExpr(v.Left))
+		if (isTraceIDCol(v.Left, cols) && isConstExpr(v.Right)) ||
+			(isTraceIDCol(v.Right, cols) && isConstExpr(v.Left)) {
+			return 1, true
+		}
 	}
-	return false
+	return 0, false
+}
+
+// isTraceIDSetConjunct reports whether c proves a finite TraceId membership
+// of ANY cardinality — the emit chokepoint only needs "some finite set", not
+// a specific size.
+func isTraceIDSetConjunct(c Expr, cols ScanBoundCols) bool {
+	_, ok := TraceIDSetCardinality(c, cols)
+	return ok
 }
 
 // isTraceIDCol reports whether e is the bare (unqualified) TraceId column.

--- a/internal/optimizer/scan_resource_bound.go
+++ b/internal/optimizer/scan_resource_bound.go
@@ -14,11 +14,18 @@ import "github.com/tsouza/cerberus/internal/chplan"
 // NestedSetAnnotate's TraceLimit > 0 and pushes a matching BoundedTraceScope
 // onto the row-source leaves IN LOCK-STEP (both under the same
 // inputGuaranteesRootInResult precondition). If a NestedSetAnnotate reaches the
-// optimizer with TraceLimit > 0 but no BoundedTraceScope on its input, the two
-// bounds drifted apart — the numbering scope would be bounded while the row
-// source is not (or vice versa), stranding kept rows at the 0/0/0 LEFT-JOIN
-// default and unbounding the structural closures. That is a real bug, so the
-// rule fails closed.
+// optimizer with TraceLimit > 0 but no trace-id-set witness of matching
+// cardinality on its input, the two bounds drifted apart — the numbering
+// scope would be bounded while the row source is not (or vice versa),
+// stranding kept rows at the 0/0/0 LEFT-JOIN default and unbounding the
+// structural closures. That is a real bug, so the rule fails closed.
+//
+// The accepted witness set matches chplan.SpansScanResourceBound's form-b
+// classification exactly (chplan.TraceIDSetCardinality): a BoundedTraceScope
+// subquery, OR a literal InList over TraceId whose length equals TraceLimit —
+// the shape a resolve-in-Go-and-splice-literals rewrite of the subquery
+// produces (#1702). A drifted witness (wrong cardinality, or a shape neither
+// classifier recognizes) still fails closed.
 //
 // It mutates nothing (trivially idempotent) and reads no ctx / schema. The
 // TraceLimit == 0 numbering shapes (single-trace /traces/{id}, non-search
@@ -35,16 +42,23 @@ func (RequireScanResourceBound) Apply(n chplan.Node) (chplan.Node, bool) {
 	if !ok || nsa.TraceLimit <= 0 {
 		return n, false
 	}
-	if !inputCarriesBoundedTraceScope(nsa.Input, nsa.TraceLimit) {
+	cols := chplan.ScanBoundCols{TraceID: nsa.TraceIDColumn}
+	if !inputCarriesBoundedTraceIDSet(nsa.Input, cols, nsa.TraceLimit) {
 		panic(&chplan.ScanResourceBoundViolation{Table: nsa.SpansTable})
 	}
 	return n, false
 }
 
-// inputCarriesBoundedTraceScope reports whether the numbering walk's row source
-// carries a BoundedTraceScope conjunct with the same TraceLimit — the lock-step
-// partner of NestedSetAnnotate.TraceLimit.
-func inputCarriesBoundedTraceScope(input chplan.Node, limit int64) bool {
+// inputCarriesBoundedTraceIDSet reports whether the numbering walk's row
+// source carries a trace-id-set witness whose cardinality matches limit — the
+// lock-step partner of NestedSetAnnotate.TraceLimit. It reads off
+// chplan.TraceIDSetCardinality, the SAME classification the emit-chokepoint
+// invariant (chplan.SpansScanResourceBound) uses for form-b, so a literal
+// InList (e.g. the resolve-in-Go-and-splice-literals rewrite of a
+// BoundedTraceScope subquery) counts as a witness here identically to how it
+// already counts at the chokepoint — restated per #1702 rather than the
+// previous bespoke BoundedTraceScope-only walk.
+func inputCarriesBoundedTraceIDSet(input chplan.Node, cols chplan.ScanBoundCols, limit int64) bool {
 	found := false
 	chplan.Walk(input, func(node chplan.Node) bool {
 		f, ok := node.(*chplan.Filter)
@@ -52,7 +66,7 @@ func inputCarriesBoundedTraceScope(input chplan.Node, limit int64) bool {
 			return true
 		}
 		chplan.InspectExpr(f.Predicate, func(e chplan.Expr) bool {
-			if bts, ok := e.(*chplan.BoundedTraceScope); ok && bts.TraceLimit == limit {
+			if card, ok := chplan.TraceIDSetCardinality(e, cols); ok && card == limit {
 				found = true
 			}
 			return true

--- a/internal/optimizer/scan_resource_bound_test.go
+++ b/internal/optimizer/scan_resource_bound_test.go
@@ -51,6 +51,23 @@ func boundedTraceScopeLeaf(limit int64) chplan.Node {
 	}
 }
 
+// traceIDInListLeaf builds a literal `TraceId IN (<n literal ids>)` leaf —
+// the shape a resolve-in-Go-and-splice-literals rewrite of a
+// BoundedTraceScope subquery produces (#1702).
+func traceIDInListLeaf(n int) chplan.Node {
+	list := make([]chplan.Expr, n)
+	for i := range list {
+		list[i] = &chplan.LitString{V: "id"}
+	}
+	return &chplan.Filter{
+		Input: &chplan.Scan{Table: "otel_traces"},
+		Predicate: &chplan.InList{
+			Left: &chplan.ColumnRef{Name: "TraceId"},
+			List: list,
+		},
+	}
+}
+
 // TestRequireScanResourceBound_PassesWithLockstepGate: a bounded
 // NestedSetAnnotate (TraceLimit > 0) over an input carrying the matching
 // BoundedTraceScope passes — no panic, no mutation.
@@ -103,5 +120,62 @@ func TestRequireScanResourceBound_IgnoresUnboundedNumbering(t *testing.T) {
 	})
 	if v != nil {
 		t.Fatalf("TraceLimit==0 numbering must be ignored, got violation: %v", v)
+	}
+}
+
+// TestRequireScanResourceBound_PassesWithLiteralInListWitness: #1702 — a
+// literal `TraceId IN (<n ids>)` whose length matches TraceLimit is an
+// equally valid witness to a BoundedTraceScope subquery (the
+// resolve-in-Go-and-splice-literals rewrite of one), matching the general
+// chplan.SpansScanResourceBound chokepoint's form-b classification.
+func TestRequireScanResourceBound_PassesWithLiteralInListWitness(t *testing.T) {
+	t.Parallel()
+	nsa := nestedSetNode(20, traceIDInListLeaf(20))
+	v := recoverScanResourceBoundViolation(t, func() {
+		out, changed := optimizer.RequireScanResourceBound{}.Apply(nsa)
+		if changed {
+			t.Errorf("RequireScanResourceBound must not mutate the tree")
+		}
+		if out != chplan.Node(nsa) {
+			t.Errorf("RequireScanResourceBound must return the node unchanged")
+		}
+	})
+	if v != nil {
+		t.Fatalf("bounded NestedSetAnnotate with a matching-cardinality InList must pass, got violation: %v", v)
+	}
+}
+
+// TestRequireScanResourceBound_PanicsOnCardinalityMismatch: #1702 — a literal
+// InList whose length does NOT match TraceLimit has drifted out of lock-step
+// (it proves a different-sized trace set than the numbering walk claims) and
+// must still fail closed, not be waved through merely for being an InList.
+func TestRequireScanResourceBound_PanicsOnCardinalityMismatch(t *testing.T) {
+	t.Parallel()
+	nsa := nestedSetNode(20, traceIDInListLeaf(5))
+	v := recoverScanResourceBoundViolation(t, func() {
+		optimizer.RequireScanResourceBound{}.Apply(nsa)
+	})
+	if v == nil {
+		t.Fatalf("TraceLimit=20 NestedSetAnnotate with a 5-element InList must panic ScanResourceBoundViolation")
+		return
+	}
+	if v.Table != "otel_traces" {
+		t.Errorf("violation Table = %q, want otel_traces", v.Table)
+	}
+}
+
+// TestRequireScanResourceBound_PanicsOnNegatedInList: a `TraceId NOT IN (...)`
+// proves the opposite of a bounded set (an exclusion, not a membership) and
+// must never count as a witness regardless of its length.
+func TestRequireScanResourceBound_PanicsOnNegatedInList(t *testing.T) {
+	t.Parallel()
+	leaf := traceIDInListLeaf(20)
+	leaf.(*chplan.Filter).Predicate.(*chplan.InList).Negated = true
+	nsa := nestedSetNode(20, leaf)
+	v := recoverScanResourceBoundViolation(t, func() {
+		optimizer.RequireScanResourceBound{}.Apply(nsa)
+	})
+	if v == nil {
+		t.Fatalf("a negated InList must never satisfy the lock-step witness, expected panic")
 	}
 }


### PR DESCRIPTION
## Summary

Closes #1702.

`RequireScanResourceBound` (the NestedSetAnnotate analyzer, `internal/optimizer/scan_resource_bound.go`) and `SpansScanResourceBound` (the emit-chokepoint invariant, `internal/chplan/scan_resource_bound.go`) independently classified what counts as a bounded trace-id-set witness on a spans Scan's row source. The chokepoint already accepted a non-negated `InList` over `TraceId` (any cardinality) as form-b; the analyzer only ever recognized a `BoundedTraceScope` subquery. A future resolve-in-Go-and-splice-literals rewrite of that subquery into a literal `InList` — the shape #1672's structural-join fix already produces via `internal/api/tempo/structural_two_phase.go` — would false-fail the analyzer despite satisfying the chokepoint's own invariant.

- Added `chplan.TraceIDSetCardinality`, the single classifier both sites now share: `BoundedTraceScope` (cardinality = its own `TraceLimit`), a non-negated `InList` over `TraceId` (cardinality = list length), or a `TraceId = <literal>` equality (cardinality 1).
- `chplan.isTraceIDSetConjunct` (the chokepoint's form-b check) becomes a thin wrapper over the new classifier — any cardinality still proves form-b, unchanged behavior.
- `optimizer.inputCarriesBoundedTraceIDSet` (renamed from `inputCarriesBoundedTraceScope`) additionally requires the witness's cardinality to exactly match `NestedSetAnnotate.TraceLimit` — the lock-step invariant is **restated over a wider witness set, not relaxed**: a cardinality mismatch or a negated `InList` still fails closed, and the rule is not retired.

## Test plan

- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test -count=1 ./internal/chplan/... ./internal/optimizer/... ./internal/chsql/... ./internal/api/tempo/... ./internal/traceql/...` — all pass
- [x] New tests: matching-cardinality `InList` witness passes; cardinality-mismatched `InList` still panics `ScanResourceBoundViolation`; a negated `InList` (proves exclusion, not membership) still panics regardless of length
- [x] `gofumpt -extra -l` clean; `node .github/scripts/forbid-sql-raw.mjs` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)