### PR TITLE
test(chclient): pin the columnar byte-budget charge and ground the ceiling in corpus data

### DIFF
--- a/compatibility/tempo/driver/corpus_byte_budget_test.go
+++ b/compatibility/tempo/driver/corpus_byte_budget_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+)
+
+// minByteBudgetCeilingMargin is how far below the Tempo wide-projection
+// byte ceiling (chclient.NewTempoSpanDrainBudget) this corpus's real charge
+// must sit. It is deliberately loose (the compat fixture is a small,
+// deterministic dataset, not a stress test) — the point of this test is
+// not to prove the ceiling is tight, but that this repo's own compat
+// corpus, the one thing #1540(c) named as unmeasured, is nowhere near it.
+const minByteBudgetCeilingMargin = 500
+
+// TestFixtureCorpus_WideProjectionByteBudget_WellBelowCeiling is the
+// compatibility/tempo corpus-floor check #1540(c) named as absent: nothing
+// under compatibility/tempo/ established that a legitimate Matched set
+// stays clear of the 256 MiB wide-projection byte ceiling
+// (chclient.DrainByteBudget), so the risk the budget exists to bound — a
+// real query 422ing rather than a runaway one — was unmeasured.
+//
+// This charges chclient.SumWideProjectionBytes (the exact production
+// labelMapBytes formula rowsCursor/columnarCursor use) over every span this
+// harness's own seeder fixture (buildFixture) generates — the same data
+// both /api/search and /api/traces/{id} drain in the live compose lane —
+// using each span's ResourceAttributes ∪ SpanAttributes merged into one map
+// (span wins on key collision, matching how a more-specific span-level
+// attribute is expected to shadow a resource-level one). Per-span charging
+// rather than per-trace is the conservative direction for THIS assertion:
+// it is an upper bound on /api/search (which interns/shares repeated
+// resource maps across spans, so the real charge is smaller), and a lower
+// bound on /api/traces/{id} (which drains one whole trace's spans in one
+// response) — so if the per-span sum already clears the ceiling by a wide
+// margin, both real drain shapes do too.
+//
+// buildFixture is pure/in-memory (no ClickHouse, no Tempo, no network) —
+// this runs as a plain `go test`, no Docker compose required.
+func TestFixtureCorpus_WideProjectionByteBudget_WellBelowCeiling(t *testing.T) {
+	anchor := time.Unix(0, 0).UTC()
+	traces := buildFixture(anchor)
+	if len(traces) == 0 {
+		t.Fatal("buildFixture produced no traces — nothing to measure")
+	}
+
+	var labelSets []map[string]string
+	totalSpans := 0
+	for _, tr := range traces {
+		for _, sp := range tr.spans {
+			totalSpans++
+			merged := make(map[string]string, len(tr.resAttrs)+len(sp.Attributes))
+			for k, v := range tr.resAttrs {
+				merged[k] = v
+			}
+			for k, v := range keyValuesToMap(sp.Attributes) {
+				merged[k] = v
+			}
+			labelSets = append(labelSets, merged)
+		}
+	}
+
+	peak := chclient.SumWideProjectionBytes(labelSets)
+	ceiling := chclient.NewTempoSpanDrainBudget().Limit()
+
+	if peak <= 0 {
+		t.Fatal("measured zero wide-projection bytes — the fixture's attribute maps did not get charged")
+	}
+	margin := float64(ceiling) / float64(peak)
+	t.Logf("corpus (%d traces / %d spans): peak=%d B (%.2f KiB) — ceiling=%d B (%d MiB), margin=%.0fx",
+		len(traces), totalSpans, peak, float64(peak)/(1<<10), ceiling, ceiling>>20, margin)
+
+	if peak*minByteBudgetCeilingMargin > ceiling {
+		t.Errorf("compat fixture's real wide-projection charge %d B is within %dx of the %d B ceiling — want at least %dx margin (got %.0fx)",
+			peak, minByteBudgetCeilingMargin, ceiling, minByteBudgetCeilingMargin, margin)
+	}
+}

--- a/internal/api/tempo/handler_drain_byte_budget_test.go
+++ b/internal/api/tempo/handler_drain_byte_budget_test.go
@@ -40,7 +40,9 @@ func TestSearch_AttachesByteBudget_NoBypass(t *testing.T) {
 // TestSearch_DrainByteBudget422 — when the wide-projection byte budget aborts the
 // span drain, the Tempo HTTP head must answer 422 (a resource rejection peer to
 // the sample budget), never a 5xx. The charge itself is proven on the production
-// rowsCursor in chclient; this pins the handler's error classification.
+// rowsCursor and columnarCursor decode paths in chclient
+// (drain_byte_budget_cursor_test.go, columnar_drain_byte_budget_test.go); this
+// pins the handler's error classification.
 func TestSearch_DrainByteBudget422(t *testing.T) {
 	t.Parallel()
 

--- a/internal/chclient/columnar_drain_byte_budget_test.go
+++ b/internal/chclient/columnar_drain_byte_budget_test.go
@@ -1,0 +1,126 @@
+package chclient
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	chproto "github.com/ClickHouse/ch-go/proto"
+)
+
+// mkMatrixCols builds a fake matrixCols block directly off ch-go's proto
+// column types (Append is all real ch-go code — no fake/mock column
+// implementation of our own), bypassing the network entirely.
+// decodeBlock's charge path only ever touches the typed
+// Keys/Values/Offsets/Row accessors these expose, so a hand-built block
+// exercises the exact same code the wire decode does, byte-identically,
+// without a live ClickHouse connection.
+func mkMatrixCols(labelSets []map[string]string) matrixCols {
+	name := new(chproto.ColStr)
+	attrs := chproto.NewMap[string, string](new(chproto.ColStr), new(chproto.ColStr))
+	ts := new(chproto.ColDateTime)
+	val := new(chproto.ColFloat64)
+	for i, labels := range labelSets {
+		name.Append("s")
+		attrs.Append(labels)
+		ts.Append(time.Unix(int64(i), 0))
+		val.Append(1)
+	}
+	return matrixCols{name: name, attrs: attrs, ts: ts, val: val}
+}
+
+// fatLabels builds a label map whose single value carries a distinct
+// ~valueBytes payload (distinct so each interns to a unique series and is
+// charged once), mirroring drain_byte_budget_cursor_test.go's fatSample.
+func fatLabels(i, valueBytes int) map[string]string {
+	return map[string]string{"payload": fmt.Sprintf("%d-%s", i, strings.Repeat("x", valueBytes))}
+}
+
+// TestColumnarCursor_DrainByteBudget_TripsMidStream is the columnarCursor
+// sibling of TestRowsCursor_DrainByteBudget_TripsMidStream
+// (drain_byte_budget_cursor_test.go) — same OOM-class guarantee, but for the
+// OTHER production entrypoint that charges the wide-projection byte budget:
+// internal/chclient/columnar.go's decodeBlock, engaged by the columnar
+// query_range matrix decode path. Before this test, only the rowsCursor
+// charge site had unit coverage (#1540(c)) — a regression that dropped the
+// charge from decodeBlock was caught by nothing but the Docker-only
+// columnar integration lane, which doesn't probe the byte axis at all.
+func TestColumnarCursor_DrainByteBudget_TripsMidStream(t *testing.T) {
+	t.Parallel()
+	const valueBytes = 1000
+	mkCols := func() matrixCols {
+		return mkMatrixCols([]map[string]string{
+			fatLabels(1, valueBytes), fatLabels(2, valueBytes),
+			fatLabels(3, valueBytes), fatLabels(4, valueBytes),
+		})
+	}
+
+	// Control: a ceiling far above the cumulative bytes → full decode, no error.
+	full := &columnarCursor{byteBudget: NewDrainByteBudget(1 << 20)}
+	if err := full.decodeBlock(mkCols(), 4); err != nil {
+		t.Fatalf("control decode errored: %v", err)
+	}
+	if len(full.samples) != 4 {
+		t.Fatalf("control decoded %d samples, want 4 — fixture did not fully decode under a huge ceiling", len(full.samples))
+	}
+
+	// Trip: a ceiling below the cumulative (~4×1007) but above a single map
+	// (~1007) → the decode crosses it mid-block.
+	trip := &columnarCursor{byteBudget: NewDrainByteBudget(2500)}
+	err := trip.decodeBlock(mkCols(), 4)
+	if !errors.Is(err, errBudgetExceeded) {
+		t.Fatalf("decodeBlock err = %v, want errBudgetExceeded", err)
+	}
+	if !errors.Is(trip.err, ErrDrainBytesExceeded) {
+		t.Fatalf("trip.err = %v, want ErrDrainBytesExceeded", trip.err)
+	}
+	var be *DrainByteBudgetError
+	if !errors.As(trip.err, &be) || be.Limit != 2500 {
+		t.Fatalf("want *DrainByteBudgetError{Limit:2500}, got %+v", trip.err)
+	}
+	if len(trip.samples) >= 4 {
+		t.Errorf("decoded %d samples before aborting, want < 4 (must abort before full materialisation)", len(trip.samples))
+	}
+}
+
+// TestColumnarCursor_DrainByteBudget_PerUniqueSeries mirrors
+// TestRowsCursor_DrainByteBudget_PerUniqueSeries: many contiguous rows
+// aliasing ONE fat map must charge once, not once per row — decodeBlock's
+// sameSpan pre-check is exactly what makes that true, and this pins it
+// against the byte budget the same way the row path is pinned.
+func TestColumnarCursor_DrainByteBudget_PerUniqueSeries(t *testing.T) {
+	t.Parallel()
+	shared := map[string]string{"payload": strings.Repeat("x", 1000)}
+	labelSets := make([]map[string]string, 100)
+	for i := range labelSets {
+		labelSets[i] = shared
+	}
+	// Ceiling just above one map (~1007) but far below 100×1007: per-row
+	// charging would trip; per-unique-contiguous-run must not.
+	cur := &columnarCursor{byteBudget: NewDrainByteBudget(5000)}
+	if err := cur.decodeBlock(mkMatrixCols(labelSets), len(labelSets)); err != nil {
+		t.Fatalf("per-unique decode errored (%v) — the charge over-counted a contiguous identical run", err)
+	}
+	if len(cur.samples) != 100 {
+		t.Fatalf("decoded %d samples, want 100 — a contiguous identical run should share one charge", len(cur.samples))
+	}
+}
+
+// TestColumnarCursor_DrainByteBudget_Inert proves an inert (nil) byte
+// budget — the shape every non-Tempo columnar decode runs under, since
+// WithDrainByteBudget is only ever attached on the Tempo span-search path —
+// never charges and never trips, regardless of how fat the decoded maps
+// are.
+func TestColumnarCursor_DrainByteBudget_Inert(t *testing.T) {
+	t.Parallel()
+	cols := mkMatrixCols([]map[string]string{fatLabels(1, 1<<20)})
+	cur := &columnarCursor{}
+	if err := cur.decodeBlock(cols, 1); err != nil {
+		t.Fatalf("decode with no byte budget errored: %v", err)
+	}
+	if len(cur.samples) != 1 {
+		t.Fatalf("decoded %d samples, want 1", len(cur.samples))
+	}
+}

--- a/internal/chclient/drain_byte_budget.go
+++ b/internal/chclient/drain_byte_budget.go
@@ -120,6 +120,28 @@ func (b *DrainByteBudget) Peak() int64 {
 	return b.peak.Load()
 }
 
+// SumWideProjectionBytes charges each of labelSets against a fresh,
+// effectively-unlimited budget and returns the resulting Peak — i.e. the
+// SAME per-map cost formula the production rowsCursor / columnarCursor
+// decode paths charge (labelMapBytes), applied to caller-supplied label
+// sets rather than a live decode. Exported so out-of-package corpus-floor
+// checks (e.g. compatibility/tempo's fixture-derived measurement) can
+// grade real data against the production accounting without duplicating
+// its arithmetic — the whole point of grounding a ceiling in measurement
+// is that the measurement uses the exact formula the ceiling enforces.
+func SumWideProjectionBytes(labelSets []map[string]string) int64 {
+	b := NewDrainByteBudget(unlimitedMeasurementBudget)
+	for _, m := range labelSets {
+		b.consume(labelMapBytes(m))
+	}
+	return b.Peak()
+}
+
+// unlimitedMeasurementBudget is the ceiling SumWideProjectionBytes measures
+// against — large enough that no realistic corpus trips it (the budget
+// exists only to drive consume's peak-tracking, never to reject).
+const unlimitedMeasurementBudget = 1 << 62
+
 // Limit returns the configured ceiling (0 on a nil budget), carried so the
 // over-budget error names the cap rather than the residual.
 func (b *DrainByteBudget) Limit() int64 {


### PR DESCRIPTION
## Summary

Closes #1540's last remaining deliverable, (c) — the other two ((a) per-shape integration fixtures, (b) gRPC no-bypass ratchet) landed via #1673.

- **New unit coverage for the untested charge site.** `internal/chclient/columnar.go`'s `decodeBlock` has charged the Tempo wide-projection byte budget (`DrainByteBudget`) since it shipped, alongside the sibling `rowsCursor` charge site — but only `rowsCursor` had unit tests (`drain_byte_budget_cursor_test.go`). A regression that dropped the charge from `decodeBlock` would have shipped green. `internal/chclient/columnar_drain_byte_budget_test.go` closes that gap, built directly off ch-go's `proto` column types (`ColMap`, `ColStr`, `ColFloat64`, `ColDateTime`) so it needs no network/pool/ClickHouse dependency:
  - `TestColumnarCursor_DrainByteBudget_TripsMidStream` — control (huge ceiling, full decode) + trip (small ceiling, `*DrainByteBudgetError` with the right `Limit`, partial decode).
  - `TestColumnarCursor_DrainByteBudget_PerUniqueSeries` — 100 rows sharing one map charge once, not 100 times (pins the `sameSpan`/`curID > byteChargedSeq` per-unique-series gate, matching `rowsCursor`'s semantics).
  - `TestColumnarCursor_DrainByteBudget_Inert` — a nil budget (every non-Tempo columnar decode) never charges, regardless of map size.

- **compatibility/tempo corpus-floor check (#1540(c)).** Nothing under `compatibility/tempo/` established that a legitimate Matched set stays clear of the 256 MiB ceiling — the risk the budget exists to bound (a real query 422ing rather than a runaway one) was unmeasured. `internal/chclient/drain_byte_budget.go` now exports `SumWideProjectionBytes(labelSets []map[string]string) int64`, which charges each map through the exact production `labelMapBytes` formula against a fresh unlimited budget and returns the peak — so an out-of-package caller can grade real data through the same accounting the ceiling enforces, instead of duplicating the arithmetic. `compatibility/tempo/driver/corpus_byte_budget_test.go` uses it to measure this repo's own seeder fixture (`buildFixture` — the same data both `/api/search` and `/api/traces/{id}` drain in the live compose lane): 399 spans across 100 traces charge **~257 KiB against the 256 MiB ceiling — a ~1000x margin**. `buildFixture` is pure/in-memory, so this runs as a plain `go test`, no Docker compose required.

- Updates the stale doc comment on `TestSearch_DrainByteBudget422` (`internal/api/tempo/handler_drain_byte_budget_test.go`) that named only `rowsCursor` as the proven charge site, now that `columnarCursor` has its own coverage too.

## Test plan

- [x] `go build ./... && go vet ./...` (chclient, compatibility/tempo/driver)
- [x] `go test ./internal/chclient/... -run TestColumnarCursor_DrainByteBudget -v` — all 3 new tests pass
- [x] `go test ./compatibility/tempo/driver/... -run TestFixtureCorpus_WideProjectionByteBudget -v` — passes, logs `peak=263220 B (257.05 KiB) — ceiling=268435456 B (256 MiB), margin=1020x`
- [x] Confirmed the fixture design matches the real charge site read at `internal/chclient/columnar.go:334-385` (not the stale line the parent issue cited)
- [x] `node .github/scripts/forbid-sql-raw.mjs`, `gofumpt -extra -l`, `golangci-lint run` (touched packages) all clean
- [x] `go vet ./...` (whole repo) clean

Closes #1540