### PR TITLE
test(optimizer): cover all three excluded Input node kinds in RequireScanTimeBound

### DIFF
--- a/internal/optimizer/scan_time_bound_test.go
+++ b/internal/optimizer/scan_time_bound_test.go
@@ -123,10 +123,16 @@ func TestDefault_AcceptsBoundedInstantLeaf(t *testing.T) {
 
 // TestRequireScanTimeBound_IgnoresNonInstantLeaves proves scope honesty: the
 // invariant fires ONLY for instant windowed-array leaves. The matrix
-// (OuterRange > 0) and MetricsAggregate-input shapes carry their own emit-time
-// bound (maybePushInnerScanTimeBounds) and are NOT instant windowed-array
-// leaves, so RequireScanTimeBound must accept them even with the flag unset —
-// it must never demand an IR flag for a path whose bound it does not govern.
+// (OuterRange > 0) and the three metrics-emitter Input node kinds
+// (chplan.IsInstantWindowedLeaf's own type switch — MetricsAggregate,
+// MetricsHistogramOverTime, MetricsCompare) carry their own emit-time bound
+// (maybePushInnerScanTimeBounds) and are NOT instant windowed-array leaves, so
+// RequireScanTimeBound must accept them even with the flag unset — it must
+// never demand an IR flag for a path whose bound it does not govern. Every
+// case here mirrors one arm of that type switch; dropping any one of the three
+// Input kinds from IsInstantWindowedLeaf would make its own case's
+// self-check (`chplan.IsInstantWindowedLeaf(rw)`) fail loudly rather than let
+// RequireScanTimeBound silently start rejecting the shape.
 func TestRequireScanTimeBound_IgnoresNonInstantLeaves(t *testing.T) {
 	t.Parallel()
 
@@ -147,6 +153,25 @@ func TestRequireScanTimeBound_IgnoresNonInstantLeaves(t *testing.T) {
 		"metrics-aggregate": &chplan.RangeWindow{
 			Func:            "rate",
 			Input:           &chplan.MetricsAggregate{},
+			Range:           5 * time.Minute,
+			TimestampColumn: "TimeUnix",
+			ValueColumn:     "Value",
+		},
+		// MetricsHistogramOverTime input: the TraceQL histogram-over-time
+		// matrix path, same emit-time-bounded family as MetricsAggregate —
+		// a distinct node kind in IsInstantWindowedLeaf's type switch.
+		"metrics-histogram-over-time": &chplan.RangeWindow{
+			Func:            "rate",
+			Input:           &chplan.MetricsHistogramOverTime{},
+			Range:           5 * time.Minute,
+			TimestampColumn: "TimeUnix",
+			ValueColumn:     "Value",
+		},
+		// MetricsCompare input: the TraceQL compare() matrix path, the third
+		// and last excluded node kind in the type switch.
+		"metrics-compare": &chplan.RangeWindow{
+			Func:            "rate",
+			Input:           &chplan.MetricsCompare{},
 			Range:           5 * time.Minute,
 			TimestampColumn: "TimeUnix",
 			ValueColumn:     "Value",


### PR DESCRIPTION
## Summary

Part of the Lane B queue's "fail-closed analyzer firing tests" item: audits the two must-run, panic-on-violation `AnalyzerRule`s (`RequireScanTimeBound`, `RequireScanResourceBound`) for gaps in per-node-kind coverage.

`RequireScanResourceBound` (`internal/optimizer/scan_resource_bound.go`, `scan_resource_bound_test.go`) already has thorough hand-constructed violating/passing-plan coverage for its single node kind (`*chplan.NestedSetAnnotate`) — six tests covering the lock-step-gate pass case, the stripped-gate panic, the ignored-unbounded case, the literal-`InList`-witness pass case, the cardinality-mismatch panic, and the negated-`InList` panic. `RequireScanTimeBound` (`internal/optimizer/scan_time_bound.go`, `scan_time_bound_test.go`) already had a solid violating-plan test (`TestRequireScanTimeBound_RejectsUnboundedInstantLeaf`) plus an establish→verify acceptance test, but its scope-honesty test (`TestRequireScanTimeBound_IgnoresNonInstantLeaves`) only exercised **one of the three** `Input` node kinds `chplan.IsInstantWindowedLeaf`'s type switch excludes (`MetricsAggregate`, `MetricsHistogramOverTime`, `MetricsCompare`) — the other two arms of the switch were unpinned by any analyzer-level test.

That's a real gap: a regression dropping the `MetricsHistogramOverTime` or `MetricsCompare` arm from the switch would make `RequireScanTimeBound` start panicking on legitimate TraceQL histogram-over-time / compare() matrix plans in production, with no test catching it at this layer (only whichever emitter-level integration test happened to build that exact shape, if any did).

## Changes

- `internal/optimizer/scan_time_bound_test.go`: adds the two missing cases (`metrics-histogram-over-time`, `metrics-compare`) to `TestRequireScanTimeBound_IgnoresNonInstantLeaves`'s table, mirroring the existing `metrics-aggregate` case shape.

Verified non-hollow: temporarily narrowing `chplan.IsInstantWindowedLeaf`'s type switch to a single arm makes both new subtests fail with a clear message (`"... must not be classified as an instant windowed-array leaf"`), confirming they exercise the real classifier rather than a vacuous no-op. Change reverted before commit.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofumpt -extra -l` clean
- [x] `go test -count=1 ./internal/optimizer/...` — full package green, including the two new subtests
- [x] Confirmed both new subtests fail when the invariant they pin is broken (see PR description above), then reverted the break
- [x] Pre-push lefthook gates (golangci-lint, forbid-sql-raw, forbid-skip, forbid-soft-assert, forbid-escape-hatch, commitlint-range, markdownlint) all green locally