### PR TITLE
fix(chsql): resolve late-materialisation shape via request schema, not default table name

### DIFF
--- a/internal/api/tempo/lang.go
+++ b/internal/api/tempo/lang.go
@@ -64,6 +64,16 @@ func (l *traceqlLang) Name() string { return telemetry.QLTraceQL }
 // is resource-bounded.
 func (l *traceqlLang) SpansTable() string { return l.schema.SpansTable }
 
+// LateMatShape implements internal/engine's lateMatTabler, returning this
+// request's actually-resolved spans table plus its wide/row-key columns.
+// The engine threads this onto the emit context (chsql.WithLateMatShape)
+// so chsql's late-materialisation gate matches even when SpansTable has
+// been overridden away from the OTel default (CERBERUS_SCHEMA_TRACES_TABLE
+// or the equivalent config key) — see #1703.
+func (l *traceqlLang) LateMatShape() (table string, wide, rowKey []string) {
+	return l.schema.SpansTable, l.schema.WideColumns, l.schema.RowKey
+}
+
 func (l *traceqlLang) Parse(ctx context.Context, query string) (chplan.Node, engine.Meta, error) {
 	// Parse pipeline-stage stopwatch — mirrors the inlined handler so
 	// cerberus.queries.parse_duration_ms keeps its per-head label.

--- a/internal/chsql/emit.go
+++ b/internal/chsql/emit.go
@@ -145,7 +145,13 @@ func Emit(ctx context.Context, n chplan.Node) (string, []any, error) {
 	// node past the canonicalising projection — cannot emit SQL that splits one
 	// series across two Map key orders.
 	n = chplan.CanonicalizeSeriesIdentityKeys(n, attributeMapColumns)
-	e := &emitter{spansTable: spansTable, ctxSpansTable: spansTable}
+	ctxLMTable, ctxLMShape, _ := lateMatShapeFromCtx(ctx)
+	e := &emitter{
+		spansTable:      spansTable,
+		ctxSpansTable:   spansTable,
+		ctxLateMatTable: ctxLMTable,
+		ctxLateMatShape: ctxLMShape,
+	}
 	if err := e.emitNode(n); err != nil {
 		span.RecordError(err)
 		return "", nil, err
@@ -190,6 +196,25 @@ type emitter struct {
 	// required only on the real Tempo path and the golden lane stays
 	// byte-identical (no window-bearing fixtures churn).
 	ctxSpansTable string
+
+	// ctxLateMatTable / ctxLateMatShape carry the resolved late-materialisation
+	// table + shape threaded via chsql.WithLateMatShape (see late_mat.go),
+	// mirroring the ctxSpansTable pattern above. #1703: the package-level
+	// lateMatShapes registry is keyed on the OTel DEFAULT table names, so a
+	// deployment overriding LogsTable / SpansTable (CERBERUS_SCHEMA_LOGS_TABLE
+	// / CERBERUS_SCHEMA_TRACES_TABLE) would silently never match it and lose
+	// late materialisation with no error, no metric, nothing — a pure perf
+	// cliff. internal/engine's lateMatTabler duck-type threads the actually-
+	// resolved (table, wide, rowKey) triple from each Lang's own schema.Logs /
+	// schema.Traces value onto the emit context; isLateMatCandidate prefers
+	// this over the static registry when the ctx table matches the Scan's
+	// table. ctxLateMatTable is "" when the caller hasn't threaded one (the
+	// spec/golden lane, or any as-yet-unmigrated caller), so
+	// isLateMatCandidate falls back to the default-name-keyed registry —
+	// existing callers see no behaviour change, only callers that opt in gain
+	// correctness under an overridden table name.
+	ctxLateMatTable string
+	ctxLateMatShape lateMatShape
 
 	// cteSeq is a monotonic counter handed out to every emitter that
 	// registers a named CTE, so each one gets a unique name: the

--- a/internal/chsql/emit_node.go
+++ b/internal/chsql/emit_node.go
@@ -445,7 +445,7 @@ func (e *emitter) emitProject(p *chplan.Project) error {
 	// references a wide column, emit the two-stage rewrite (inner thin
 	// SELECT + JOIN back for wide columns) instead of the canonical
 	// single-SELECT shape. See late_mat.go for the gate + emission.
-	if m, ok := isLateMatCandidate(p); ok {
+	if m, ok := e.isLateMatCandidate(p); ok {
 		return e.emitLateMat(m)
 	}
 

--- a/internal/chsql/late_mat.go
+++ b/internal/chsql/late_mat.go
@@ -1,6 +1,8 @@
 package chsql
 
 import (
+	"context"
+
 	"github.com/tsouza/cerberus/internal/chplan"
 	"github.com/tsouza/cerberus/internal/schema"
 )
@@ -57,13 +59,72 @@ type lateMatShape struct {
 // late materialisation.
 //
 // The registry is populated from the default OTel-CH schema at package
-// init time. Custom-schema deployments overriding table names via
-// Config bypass the rewrite — the registry keys on the default table
-// names. The seed value here is the OTel default plus a small
-// indirection layer.
+// init time, so it only ever matches the OTel DEFAULT table names. Callers
+// that know the request's actually-resolved table (a possibly-overridden
+// schema.Logs.LogsTable / schema.Traces.SpansTable) should prefer
+// (*emitter).resolveLateMatShape below, which checks the ctx-threaded shape
+// first and falls back to this static map — see #1703 / WithLateMatShape.
 func lateMatShapeFor(table string) (lateMatShape, bool) {
 	s, ok := lateMatShapes[table]
 	return s, ok
+}
+
+// resolveLateMatShape resolves table's late-mat shape, preferring the
+// request-scoped shape threaded via chsql.WithLateMatShape (the resolved
+// schema.Logs / schema.Traces this request's Lang actually uses — correct
+// even when CERBERUS_SCHEMA_LOGS_TABLE / CERBERUS_SCHEMA_TRACES_TABLE
+// renames the table) and falling back to the default-OTel-name-keyed static
+// registry above. The fallback means a caller that hasn't threaded
+// WithLateMatShape (the spec/golden lane, or any as-yet-unmigrated caller)
+// keeps its pre-#1703 behaviour unchanged — this only ever ADDS a match, it
+// never removes one.
+func (e *emitter) resolveLateMatShape(table string) (lateMatShape, bool) {
+	if e.ctxLateMatTable != "" && e.ctxLateMatTable == table {
+		return e.ctxLateMatShape, true
+	}
+	return lateMatShapeFor(table)
+}
+
+// lateMatShapeCtxKey is the unexported context key carrying the
+// request-resolved late-materialisation (table, wide, rowKey) triple.
+type lateMatShapeCtxKey struct{}
+
+// lateMatCtxShape is the value stored under lateMatShapeCtxKey.
+type lateMatCtxShape struct {
+	table  string
+	wide   []string
+	rowKey []string
+}
+
+// WithLateMatShape returns ctx carrying the resolved (table, wide-columns,
+// row-key) triple for the ONE table this request's plan may scan under late
+// materialisation — mirrors WithSpansTable (scan_resource_bound.go). The
+// engine threads this from the request's own Lang (internal/engine/engine.go's
+// lateMatTabler duck-type), which derives it from the resolved schema.Logs /
+// schema.Traces value rather than the OTel default, fixing #1703: a
+// deployment overriding LogsTable / SpansTable via CERBERUS_SCHEMA_LOGS_TABLE
+// / CERBERUS_SCHEMA_TRACES_TABLE previously never matched the default-keyed
+// static registry and silently lost the late-materialisation rewrite.
+//
+// table/wide/rowKey mirrors registerLateMatShape's own gate: any half being
+// empty means the shape can never legitimately match (no row key to JOIN on,
+// or no wide column to defer), so it is dropped rather than wedging an
+// unusable entry into the context.
+func WithLateMatShape(ctx context.Context, table string, wide, rowKey []string) context.Context {
+	if table == "" || len(wide) == 0 || len(rowKey) == 0 {
+		return ctx
+	}
+	return context.WithValue(ctx, lateMatShapeCtxKey{}, lateMatCtxShape{table: table, wide: wide, rowKey: rowKey})
+}
+
+// lateMatShapeFromCtx recovers the triple set by WithLateMatShape, or
+// ("", zero, false) when the caller never threaded one.
+func lateMatShapeFromCtx(ctx context.Context) (table string, shape lateMatShape, ok bool) {
+	v, vok := ctx.Value(lateMatShapeCtxKey{}).(lateMatCtxShape)
+	if !vok {
+		return "", lateMatShape{}, false
+	}
+	return v.table, lateMatShape{wide: v.wide, rowKey: v.rowKey}, true
 }
 
 // lateMatShapes seeds the registry from schema defaults. Mutating the
@@ -136,7 +197,12 @@ type lateMatMatch struct {
 //
 // A miss on any condition returns (nil, false) and the caller falls
 // through to the canonical single-SELECT emission path.
-func isLateMatCandidate(p chplan.Node) (*lateMatMatch, bool) {
+//
+// A method on *emitter (rather than a package-level function) so it can
+// resolve the Scan's table via (*emitter).resolveLateMatShape, which
+// prefers the request's ctx-threaded, possibly-overridden table shape over
+// the default-OTel-name-keyed static registry — see #1703.
+func (e *emitter) isLateMatCandidate(p chplan.Node) (*lateMatMatch, bool) {
 	proj, ok := p.(*chplan.Project)
 	if !ok || len(proj.Projections) == 0 {
 		return nil, false
@@ -164,7 +230,7 @@ func isLateMatCandidate(p chplan.Node) (*lateMatMatch, bool) {
 		return nil, false
 	}
 
-	shape, ok := lateMatShapeFor(scan.Table)
+	shape, ok := e.resolveLateMatShape(scan.Table)
 	if !ok {
 		return nil, false
 	}

--- a/internal/chsql/late_mat_test.go
+++ b/internal/chsql/late_mat_test.go
@@ -210,7 +210,7 @@ func TestIsLateMatCandidateConditions(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			m, ok := isLateMatCandidate(tt.plan)
+			m, ok := (&emitter{}).isLateMatCandidate(tt.plan)
 			if ok != tt.want {
 				t.Fatalf("isLateMatCandidate: got %t, want %t (%s)", ok, tt.want, tt.reason)
 			}
@@ -227,6 +227,80 @@ func TestIsLateMatCandidateConditions(t *testing.T) {
 // TestEmitLateMatShape smoke-tests the rendered SQL shape on the
 // canonical OTel logs Body+Timestamp+LIMIT 100 case. The TXTAR
 // fixtures under test/spec/codegen/late_mat/ are the byte-for-byte
+// TestIsLateMatCandidate_CtxOverriddenTableName is the #1703 regression:
+// a deployment that overrides its logs table name (CERBERUS_SCHEMA_LOGS_TABLE
+// / the schema.logs.table config key) ends up with Scan.Table set to
+// something other than "otel_logs" — a name the package-level, default-OTel-
+// name-keyed lateMatShapes registry has never heard of. Before this fix,
+// isLateMatCandidate silently fell through to "no match" for every such
+// deployment: no error, no metric, just a quiet loss of the late-mat
+// optimisation on exactly the LIMIT+WHERE queries it exists to help.
+func TestIsLateMatCandidate_CtxOverriddenTableName(t *testing.T) {
+	t.Parallel()
+
+	const customTable = "custom_logs"
+	plan := &chplan.Project{
+		Projections: []chplan.Projection{
+			{Expr: &chplan.ColumnRef{Name: "Body"}},
+			{Expr: &chplan.ColumnRef{Name: "Timestamp"}},
+		},
+		Input: &chplan.Limit{
+			Count: 100,
+			Input: &chplan.Scan{Table: customTable},
+		},
+	}
+	wide := []string{"Body", "ResourceAttributes", "LogAttributes"}
+	rowKey := []string{"Timestamp", "TraceId", "SpanId"}
+
+	t.Run("without threaded shape, an unregistered custom table never matches", func(t *testing.T) {
+		t.Parallel()
+		if _, ok := (&emitter{}).isLateMatCandidate(plan); ok {
+			t.Fatal("expected no match for a table absent from the static registry and with no ctx-threaded shape")
+		}
+	})
+
+	t.Run("ctx-threaded shape for the matching table makes it match", func(t *testing.T) {
+		t.Parallel()
+		ctx := WithLateMatShape(context.Background(), customTable, wide, rowKey)
+		table, shape, ok := lateMatShapeFromCtx(ctx)
+		if !ok || table != customTable {
+			t.Fatalf("lateMatShapeFromCtx: got (%q, %t), want (%q, true)", table, ok, customTable)
+		}
+		e := &emitter{ctxLateMatTable: table, ctxLateMatShape: shape}
+		m, ok := e.isLateMatCandidate(plan)
+		if !ok || m == nil {
+			t.Fatalf("isLateMatCandidate: got (%v, %t), want a match once the ctx-threaded shape resolves %q", m, ok, customTable)
+		}
+	})
+
+	t.Run("ctx-threaded shape for a DIFFERENT table falls back to the static registry (still no match)", func(t *testing.T) {
+		t.Parallel()
+		ctx := WithLateMatShape(context.Background(), "some_other_table", wide, rowKey)
+		table, shape, _ := lateMatShapeFromCtx(ctx)
+		e := &emitter{ctxLateMatTable: table, ctxLateMatShape: shape}
+		if _, ok := e.isLateMatCandidate(plan); ok {
+			t.Fatal("expected no match: the ctx-threaded shape is for a different table than the Scan's, so it must not apply, and the static registry has no entry for customTable either")
+		}
+	})
+
+	t.Run("existing default-table callers are unaffected: otel_logs still matches via the static registry alone", func(t *testing.T) {
+		t.Parallel()
+		defaultPlan := &chplan.Project{
+			Projections: []chplan.Projection{
+				{Expr: &chplan.ColumnRef{Name: "Body"}},
+				{Expr: &chplan.ColumnRef{Name: "Timestamp"}},
+			},
+			Input: &chplan.Limit{
+				Count: 100,
+				Input: &chplan.Scan{Table: "otel_logs"},
+			},
+		}
+		if _, ok := (&emitter{}).isLateMatCandidate(defaultPlan); !ok {
+			t.Fatal("expected the pre-#1703 default-table path (no ctx-threaded shape) to keep matching unchanged")
+		}
+	})
+}
+
 // goldens; this test just asserts the high-signal markers (two
 // SELECTs, INNER JOIN, scan/w aliases) so a regression that drops to
 // the single-SELECT path fails loudly here even when the txtar
@@ -284,6 +358,89 @@ func TestEmitLateMatShape(t *testing.T) {
 	if got := strings.Count(sql, "SELECT "); got != 2 {
 		t.Errorf("expected exactly 2 SELECT keywords in late-mat output, got %d\nSQL: %s", got, sql)
 	}
+}
+
+// TestEmitLateMatShape_CtxOverriddenTableName is the end-to-end #1703
+// regression: the same Project(Limit(Filter(Scan))) shape as
+// TestEmitLateMatShape, but scanning a custom table name that the static
+// lateMatShapes registry has never heard of. Without chsql.WithLateMatShape
+// threaded onto the context, Emit falls back to the canonical single-SELECT
+// path (no JOIN). With it threaded, Emit produces the same two-stage
+// JOIN rewrite as the default-table case, proving the fix reaches all the
+// way through chsql.Emit's public entrypoint — not just the internal gate.
+func TestEmitLateMatShape_CtxOverriddenTableName(t *testing.T) {
+	t.Parallel()
+
+	const customTable = "custom_logs"
+	plan := &chplan.Project{
+		Projections: []chplan.Projection{
+			{Expr: &chplan.ColumnRef{Name: "Body"}},
+			{Expr: &chplan.ColumnRef{Name: "Timestamp"}},
+			{Expr: &chplan.ColumnRef{Name: "SeverityNumber"}},
+		},
+		Input: &chplan.Limit{
+			Count: 100,
+			Input: &chplan.Filter{
+				Predicate: &chplan.Binary{
+					Op:    chplan.OpGe,
+					Left:  &chplan.ColumnRef{Name: "SeverityNumber"},
+					Right: &chplan.LitInt{V: 9},
+				},
+				Input: &chplan.Scan{Table: customTable},
+			},
+		},
+	}
+	wide := []string{"Body", "ResourceAttributes", "LogAttributes"}
+	rowKey := []string{"Timestamp", "TraceId", "SpanId"}
+
+	t.Run("without WithLateMatShape, falls back to the canonical single-SELECT path", func(t *testing.T) {
+		t.Parallel()
+		sql, _, err := Emit(context.Background(), plan)
+		if err != nil {
+			t.Fatalf("Emit: %v", err)
+		}
+		// The canonical (non-late-mat) path never emits the late-mat rewrite's
+		// distinctive markers — the two-stage INNER JOIN back to the wide
+		// table and its `w`-aliased scan side. Exact SELECT-nesting depth is
+		// an emitter-internal subquery-composition detail, not part of this
+		// regression's contract, so this only pins the semantic markers.
+		if strings.Contains(sql, "INNER JOIN") {
+			t.Errorf("did not expect a late-mat JOIN without a ctx-threaded shape\nSQL: %s", sql)
+		}
+		if strings.Contains(sql, "AS w") {
+			t.Errorf("did not expect the late-mat wide-table JOIN alias without a ctx-threaded shape\nSQL: %s", sql)
+		}
+	})
+
+	t.Run("with WithLateMatShape, emits the same two-stage JOIN rewrite as the default-table case", func(t *testing.T) {
+		t.Parallel()
+		ctx := WithLateMatShape(context.Background(), customTable, wide, rowKey)
+		sql, args, err := Emit(ctx, plan)
+		if err != nil {
+			t.Fatalf("Emit: %v", err)
+		}
+		if len(args) != 1 || args[0].(int64) != 9 {
+			t.Fatalf("args: got %v, want [9]", args)
+		}
+		wantMarkers := []string{
+			"INNER JOIN `" + customTable + "` AS w",
+			"LIMIT 100) AS scan",
+			"`scan`.`Timestamp` = `w`.`Timestamp`",
+			"`scan`.`TraceId` = `w`.`TraceId`",
+			"`scan`.`SpanId` = `w`.`SpanId`",
+			"`w`.`Body`",
+			"WHERE",
+			"LIMIT 100",
+		}
+		for _, marker := range wantMarkers {
+			if !strings.Contains(sql, marker) {
+				t.Errorf("rendered SQL missing marker %q\nSQL: %s", marker, sql)
+			}
+		}
+		if got := strings.Count(sql, "SELECT "); got != 2 {
+			t.Errorf("expected exactly 2 SELECT keywords once the ctx-threaded shape resolves %q, got %d\nSQL: %s", customTable, got, sql)
+		}
+	})
 }
 
 // TestEmitLateMatFallback asserts that the canonical single-SELECT

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -102,13 +102,32 @@ func (ChsqlEmitter) Emit(ctx context.Context, plan chplan.Node) (string, []any, 
 // chsql.Emit's RequireSpansScansBounded chokepoint runs over the whole plan.
 type spansTabler interface{ SpansTable() string }
 
-// emitForHead lowers plan to SQL, threading the spans-table scope onto the emit
-// context for a head that exposes one (Tempo). Heads without a spans table
-// (PromQL / LogQL) emit unchanged — RequireSpansScansBounded is a table-scoped
-// no-op for them.
+// lateMatTabler is implemented by a Lang that knows its own resolved
+// late-materialisation shape: the table it scans plus that table's wide
+// columns and row-key columns, straight from the request's actually-resolved
+// schema.Logs / schema.Traces value (which may differ from the OTel default
+// table name under CERBERUS_SCHEMA_LOGS_TABLE / CERBERUS_SCHEMA_TRACES_TABLE
+// or the equivalent config key). The engine threads that triple onto the
+// emit context so chsql's late-materialisation gate (see
+// internal/chsql/late_mat.go) matches even when the table has been renamed
+// — see #1703.
+type lateMatTabler interface {
+	LateMatShape() (table string, wide, rowKey []string)
+}
+
+// emitForHead lowers plan to SQL, threading the spans-table scope and the
+// late-materialisation shape onto the emit context for a head that exposes
+// them. Heads without a spans table (PromQL) emit unchanged —
+// RequireSpansScansBounded is a table-scoped no-op for them, and a Lang that
+// doesn't implement lateMatTabler leaves chsql to fall back to its
+// default-OTel-name-keyed static registry (pre-#1703 behaviour, unchanged).
 func emitForHead(ctx context.Context, lang Lang, plan chplan.Node) (string, []any, error) {
 	if st, ok := lang.(spansTabler); ok {
 		ctx = chsql.WithSpansTable(ctx, st.SpansTable())
+	}
+	if lt, ok := lang.(lateMatTabler); ok {
+		table, wide, rowKey := lt.LateMatShape()
+		ctx = chsql.WithLateMatShape(ctx, table, wide, rowKey)
 	}
 	return chsql.Emit(ctx, plan)
 }

--- a/internal/logql/lang.go
+++ b/internal/logql/lang.go
@@ -69,6 +69,16 @@ const (
 // onto progress-context keys and trace attributes.
 func (l *Lang) Name() string { return telemetry.QLLogQL }
 
+// LateMatShape implements internal/engine's lateMatTabler, returning this
+// request's actually-resolved logs table plus its wide/row-key columns.
+// The engine threads this onto the emit context (chsql.WithLateMatShape)
+// so chsql's late-materialisation gate matches even when LogsTable has
+// been overridden away from the OTel default (CERBERUS_SCHEMA_LOGS_TABLE
+// or the equivalent config key) — see #1703.
+func (l *Lang) LateMatShape() (table string, wide, rowKey []string) {
+	return l.Schema.LogsTable, l.Schema.WideColumns, l.Schema.RowKey
+}
+
 // Parse runs the LogQL parser, lowers the AST, and returns the plan
 // plus engine.Meta. Parser failures map to 400 bad_data; lowering
 // failures (e.g. unsupported `| json` stage in the M3 window) map to


### PR DESCRIPTION
## Summary

- `internal/chsql`'s `lateMatShapes` registry was built once at package-init time from `schema.DefaultOTelLogs()`/`DefaultOTelTraces()`, keyed strictly by the OTel **default** table names (`otel_logs`, `otel_traces`). `isLateMatCandidate` looked up a `Scan`'s table directly against that static map.
- A deployment overriding its table name (`CERBERUS_SCHEMA_LOGS_TABLE` / `CERBERUS_SCHEMA_TRACES_TABLE`, or the `schema.logs.table` / `schema.traces.table` config key — both real, tested override paths) produces a `Scan.Table` the registry has never heard of. `isLateMatCandidate` silently returned `(nil, false)` and every LIMIT+WHERE query on that table fell through to the canonical single-SELECT path — no error, no metric, just a quiet perf cliff on exactly the queries late materialisation exists to help.
- Fixes it by threading the request's actually-resolved `(table, wide, rowKey)` triple onto the emit context, mirroring the existing `WithSpansTable` / `spansTabler` / `emitForHead` pattern already used for the Tempo resource-bound chokepoint:
  - `chsql.WithLateMatShape(ctx, table, wide, rowKey)` / `lateMatShapeFromCtx(ctx)`.
  - `(*emitter).resolveLateMatShape` prefers the ctx-threaded shape when its table matches the `Scan` under consideration, falling back to the static registry otherwise — callers that never thread a shape (the spec/golden lane, or any as-yet-unmigrated caller) keep their pre-#1703 behaviour unchanged.
  - `isLateMatCandidate` becomes a method on `*emitter` so it can reach `resolveLateMatShape`.
  - `internal/engine`'s new `lateMatTabler` duck-type interface + `emitForHead` wiring threads the shape onto every request's emit context when the head's `Lang` implements it.
  - `logql.Lang` and `traceqlLang` both implement `LateMatShape()`, reading table/wide/rowKey straight from the request's already-resolved `schema.Logs` / `schema.Traces` value.

## Verification

- New regression tests in `internal/chsql/late_mat_test.go`:
  - `TestIsLateMatCandidate_CtxOverriddenTableName` — gate-level: an unregistered custom table name doesn't match without a threaded shape, matches once threaded, still doesn't match when the threaded shape names a *different* table, and the default-table path is unaffected.
  - `TestEmitLateMatShape_CtxOverriddenTableName` — end-to-end through `chsql.Emit`: without `WithLateMatShape`, the custom table falls back to the canonical single-SELECT path (no `INNER JOIN`); with it threaded, `Emit` produces the same two-stage JOIN rewrite as the default-table case.
- Full pre-existing `late_mat_test.go` suite passes unchanged (no behaviour change for existing callers).
- `go build ./...`, `go vet -tags=chdb ./internal/chsql/... ./internal/engine/... ./internal/logql/... ./internal/api/tempo/...`, `gofumpt -extra -l` all clean.
- `go test -tags=chdb ./internal/chsql/...` and `go test ./internal/engine/... ./internal/logql/... ./internal/api/tempo/...` all green.
- `node .github/scripts/forbid-sql-raw.mjs` clean (no raw SQL token writes introduced).

Closes #1703
