### PR TITLE
test(oracle): cover count_values, limitk, limit_ratio PromQL aggregators

### DIFF
--- a/test/integration/promql/matrix.go
+++ b/test/integration/promql/matrix.go
@@ -23,12 +23,14 @@ func (c exoticCase) ts() int64 {
 // ExoticMatrix is the hand-curated catalogue. Every entry is bound to a
 // construct the from-scratch oracle (test/property/oracle/promql) already
 // evaluates, so the assertion is a real cerberus-vs-spec comparison rather
-// than a both-erroring no-op. Set ops, absent/clamp/sort, and the
+// than a both-erroring no-op. Set ops, absent/clamp/sort, and the full
 // quantile/count_values/limitk/limit_ratio aggregator family are ALL
 // oracle-evaluated and exercised below (cat3Aggregators, cat4SetOps,
-// cat8ScalarVector) — count_values/limitk/limit_ratio specifically remain
-// oracle gaps tracked by #1693. The remaining categories the oracle can't
-// yet evaluate are each tracked by its own open issue, not by prose:
+// cat8ScalarVector) — limitk is exact-match only at its two
+// iteration-order-independent endpoints (see cat3Aggregators's doc
+// comment); count_values and limit_ratio are exact-match throughout. The
+// remaining categories the oracle can't yet evaluate are each tracked by
+// its own open issue, not by prose:
 //   - subqueries, label_replace, label_join — #1694
 //   - deriv, predict_linear, double_exponential_smoothing,
 //     quantile_over_time — #1695
@@ -140,10 +142,18 @@ func cat2Histogram() []exoticCase {
 }
 
 // cat3Aggregators covers the aggregators the oracle implements:
-// sum/avg/min/max/count/topk/bottomk/quantile, with by/without grouping and
-// edge k / edge phi. count_values/limitk/limit_ratio are implemented by
-// cerberus (internal/promql/lower.go::lowerCountValues / lowerLimitRatio /
-// lowerLimitK) but NOT by the oracle — tracked in
+// sum/avg/min/max/count/topk/bottomk/quantile/count_values/limit_ratio,
+// with by/without grouping and edge k / edge phi. count_values and
+// limit_ratio are exact-match cases (both are deterministic — count_values
+// is a real grouping aggregation, limit_ratio's per-series hash test
+// (test/property/oracle/promql/aggregations.go::limitRatio) is bit-for-bit
+// identical to cerberus's own ratioOffsetExpr SQL lowering). limitk is
+// PARTIALLY covered: the oracle's limitK only reproduces the two
+// iteration-order-independent endpoints (K<1 empty, K at/above a group's
+// cardinality keeps everything) — real Prometheus's mid-range limitk
+// selection has no shared ordering contract with ClickHouse's own
+// `LIMIT k BY`, so only those two endpoints are exercised here as
+// exact-match cases; see limitK's doc comment and
 // https://github.com/tsouza/cerberus/issues/1693.
 func cat3Aggregators() []exoticCase {
 	const mem = "demo_memory_usage_bytes"
@@ -166,6 +176,22 @@ func cat3Aggregators() []exoticCase {
 		// phi out of domain (Prom quantile.go): < 0 -> -Inf, > 1 -> +Inf.
 		{name: "cat3/quantile_phi_neg", promql: "quantile(-0.1, " + mem + ") by (type)"},
 		{name: "cat3/quantile_phi_over1", promql: "quantile(1.5, " + mem + ") by (type)"},
+		// demo_memory_usage_bytes's (instance,type) bases are all distinct
+		// (2e9 + i*1e7 + ti*1e6), so every minted "val" collapses to a
+		// singleton group — still a real assertion on lowerCountValues's
+		// grouping/minting shape, just not a many-to-one collapse.
+		{name: "cat3/count_values_no_grouping", promql: `count_values("val", ` + mem + `)`},
+		{name: "cat3/count_values_by_type", promql: `count_values("val", ` + mem + `) by (type)`},
+		// limit_ratio's per-series hash test is deterministic and
+		// oracle-matched exactly (see doc comment above).
+		{name: "cat3/limit_ratio_half", promql: "limit_ratio(0.5, " + mem + ")"},
+		{name: "cat3/limit_ratio_neg_half", promql: "limit_ratio(-0.5, " + mem + ")"},
+		{name: "cat3/limit_ratio_zero", promql: "limit_ratio(0, " + mem + ")"},
+		// limitk endpoints only (see func doc comment): K<1 empty, K at/above
+		// cardinality keeps everything (12 series overall, 4 per instance).
+		{name: "cat3/limitk_0", promql: "limitk(0, " + mem + ")"},
+		{name: "cat3/limitk_huge", promql: "limitk(9999999999, " + mem + ")"},
+		{name: "cat3/limitk_by_instance_all", promql: "limitk(4, " + mem + ") by (instance)"},
 	}
 }
 

--- a/test/integration/promql/seed.go
+++ b/test/integration/promql/seed.go
@@ -482,8 +482,17 @@ func renderFloatArray(vals []float64) string {
 	return "[" + strings.Join(parts, ", ") + "]"
 }
 
+// formatFloat renders v as a plain-decimal (never scientific-notation)
+// literal for embedding in seed SQL. ClickHouse's SQL literal parser does
+// not correctly round-trip scientific-notation Float64 literals at large
+// magnitudes (e.g. "2.000039936e+09" parses back as 2000039935.9999998,
+// not the exact 2000039936 the shortest-round-trip decimal represents),
+// while the equivalent plain-decimal literal parses exactly. 'f' with
+// precision -1 still emits the shortest round-tripping decimal, just
+// never switches to exponent form, which keeps every gauge/counter value
+// exact through the INSERT -> SELECT round trip regardless of magnitude.
 func formatFloat(v float64) string {
-	return strconv.FormatFloat(v, 'g', -1, 64)
+	return strconv.FormatFloat(v, 'f', -1, 64)
 }
 
 func formatInt(v int64) string {

--- a/test/property/oracle/promql/aggregations.go
+++ b/test/property/oracle/promql/aggregations.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"strconv"
 
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
 )
 
@@ -132,8 +134,178 @@ func applyAggregator(a *parser.AggregateExpr, rows []VectorRow) ([]aggResult, er
 			return nil, err
 		}
 		return []aggResult{{labels: groupLabels, value: quantileAggregate(phi, rows)}}, nil
+	case parser.COUNT_VALUES:
+		label, err := aggregatorParamString(a)
+		if err != nil {
+			return nil, err
+		}
+		return countValues(a, label, rows), nil
+	case parser.LIMITK:
+		k, err := aggregatorParam(a)
+		if err != nil {
+			return nil, err
+		}
+		return limitK(rows, k), nil
+	case parser.LIMIT_RATIO:
+		r, err := aggregatorParamFloat(a)
+		if err != nil {
+			return nil, err
+		}
+		return limitRatio(r, rows), nil
 	}
 	return nil, fmt.Errorf("oracle: unsupported aggregation op %s", a.Op)
+}
+
+// aggregatorParamString extracts the constant label name for
+// count_values(label, expr) — the only aggregator whose parameter is
+// a string literal rather than a number.
+func aggregatorParamString(a *parser.AggregateExpr) (string, error) {
+	if a.Param == nil {
+		return "", fmt.Errorf("oracle: aggregator %s requires a parameter", a.Op)
+	}
+	s, ok := a.Param.(*parser.StringLiteral)
+	if !ok {
+		return "", fmt.Errorf("oracle: aggregator %s param must be StringLiteral, got %T", a.Op, a.Param)
+	}
+	return s.Val, nil
+}
+
+// countValues implements count_values(label, expr) (Prom engine.go::
+// aggregationCountValues): every input row is stamped with `label`
+// set to its value rendered via Prom's exact formatting
+// (strconv.FormatFloat(v, 'f', -1, 64)), and rows are then re-grouped
+// by the resulting FULL label set — the with/without projection PLUS
+// the minted label — one output row per distinct group, valued at
+// the group's row count.
+//
+// Minting the label BEFORE computing the projection (rather than
+// adding it to the caller's already-narrowed groupLabels) mirrors
+// Prom's own two-step and handles `by`/`without` uniformly: for `by`
+// mode Prom explicitly appends the value label to the grouping key
+// even when the caller didn't name it, so KeepLabels's normal
+// keep-list is widened with an explicit re-set after projection; for
+// `without` mode the minted label naturally survives the projection
+// unless the caller listed it explicitly in without(...), which
+// DropLabels already handles correctly with no special-casing.
+func countValues(a *parser.AggregateExpr, label string, rows []VectorRow) []aggResult {
+	type bucket struct {
+		labels map[string]string
+		count  int
+	}
+	buckets := make(map[string]*bucket)
+	keys := make([]string, 0)
+	for _, r := range rows {
+		merged := CopyLabels(r.Labels)
+		merged[label] = strconv.FormatFloat(r.V, 'f', -1, 64)
+
+		var out map[string]string
+		if a.Without {
+			out = DropLabels(merged, a.Grouping)
+		} else {
+			out = KeepLabels(merged, a.Grouping)
+			out[label] = merged[label]
+		}
+
+		key := labelKey(out)
+		b, ok := buckets[key]
+		if !ok {
+			b = &bucket{labels: out}
+			buckets[key] = b
+			keys = append(keys, key)
+		}
+		b.count++
+	}
+
+	sort.Strings(keys)
+	result := make([]aggResult, 0, len(keys))
+	for _, k := range keys {
+		b := buckets[k]
+		result = append(result, aggResult{labels: b.labels, value: float64(b.count)})
+	}
+	return result
+}
+
+// maxUint64AsFloat is math.MaxUint64 widened to float64, matching
+// Prom's HashRatioSampler.SampleOffset (promql/engine.go) and
+// cerberus's own ratioOffsetExpr SQL lowering
+// (internal/promql/lower.go) — the divisor that turns a series's
+// label hash into a value in [0, 1).
+const maxUint64AsFloat = float64(math.MaxUint64)
+
+// limitRatio implements limit_ratio(r, expr) (Prom engine.go::
+// HashRatioSampler.AddRatioSampleWithOffset): a per-row, per-series
+// deterministic keep/drop test independent of `by`/`without`
+// grouping — Prom applies the identical ratio test to every sample
+// regardless of which aggregation group it lands in (confirmed by
+// reading engine.go's aggregation loop: the `!group.seen` and later
+// branches both call ratiosampler.AddRatioSample with no group-scoped
+// state), and cerberus's own lowering matches: lowerLimitRatio emits
+// a flat chplan.Filter with no groupBy dependency. So this ignores
+// a.Grouping/groupLabels entirely and filters rows independently,
+// which composes correctly with evalAggregation's outer with/without
+// grouping loop since the per-row survival decision never depends on
+// group membership.
+//
+// r == 0 is a hard empty result (Prom returns before any group is
+// even created). r is clamped to [-1, 1]; r >= 0 keeps offset < r,
+// r < 0 keeps offset >= 1+r. Surviving rows keep their full original
+// label set minus __name__, matching topKBottomK's convention.
+func limitRatio(r float64, rows []VectorRow) []aggResult {
+	if r == 0 {
+		return nil
+	}
+	if r > 1 {
+		r = 1
+	} else if r < -1 {
+		r = -1
+	}
+
+	result := make([]aggResult, 0, len(rows))
+	for _, row := range rows {
+		offset := float64(labels.FromMap(row.Labels).Hash()) / maxUint64AsFloat
+		var keep bool
+		if r >= 0 {
+			keep = offset < r
+		} else {
+			keep = offset >= 1+r
+		}
+		if keep {
+			result = append(result, aggResult{
+				labels: DropLabel(row.Labels, MetricNameLabel),
+				value:  row.V,
+			})
+		}
+	}
+	return result
+}
+
+// limitK implements the oracle-observable boundary of limitk(k, expr):
+// K<1 keeps nothing, and K at or beyond the group's cardinality keeps
+// everything (each surviving row keeps its full original label set
+// minus __name__, matching topKBottomK's convention). Prometheus's
+// real selection in between those endpoints is documented as
+// "whatever K rows the storage/evaluation iterator produces first per
+// group" (engine.go: `if int64(len(group.heap)) < k`), with no
+// ordering contract shared with ClickHouse's own `LIMIT k BY <group>`
+// — so this intentionally does NOT try to reproduce cerberus's exact
+// mid-range row selection; callers exercising limitk against real
+// cerberus output must restrict themselves to the two endpoints this
+// implements. See https://github.com/tsouza/cerberus/issues/1693.
+func limitK(rows []VectorRow, k int) []aggResult {
+	if k < 1 {
+		return nil
+	}
+	if k > len(rows) {
+		k = len(rows)
+	}
+	result := make([]aggResult, 0, k)
+	for _, row := range rows[:k] {
+		result = append(result, aggResult{
+			labels: DropLabel(row.Labels, MetricNameLabel),
+			value:  row.V,
+		})
+	}
+	return result
 }
 
 // aggregatorParamFloat is aggregatorParam's float counterpart, for

--- a/test/property/oracle/promql/oracle_test.go
+++ b/test/property/oracle/promql/oracle_test.go
@@ -331,7 +331,7 @@ func TestFn_OverTime_EmptyWindow(t *testing.T) {
 }
 
 // =================================================================
-// Aggregation tests — 12
+// Aggregation tests — 19
 // =================================================================
 
 func TestAgg_Sum_NoGrouping(t *testing.T) {
@@ -481,6 +481,132 @@ func TestAgg_PerSeries_LWR(t *testing.T) {
 	)
 	o := eval(d, `sum(g)`, 90)
 	assertRows(t, o, []property.OutcomeRow{row(map[string]string{}, 6)})
+}
+
+func TestAgg_CountValues_By(t *testing.T) {
+	// Two "job=api" series share value 1; "job=web" has a distinct 2.
+	// count_values("count", g) by (job) mints a "count" label from
+	// each row's rendered value BEFORE grouping, so the two job=api
+	// rows (both valued 1) collapse into one output row valued 2,
+	// while job=web's single row (valued 2) stays its own group.
+	d := build(
+		makeSeries("g", map[string]string{"job": "api", "i": "1"}, sampleSpec{60, 1}),
+		makeSeries("g", map[string]string{"job": "api", "i": "2"}, sampleSpec{60, 1}),
+		makeSeries("g", map[string]string{"job": "web", "i": "1"}, sampleSpec{60, 2}),
+	)
+	o := eval(d, `count_values("count", g) by (job)`, 90)
+	assertRows(t, o, []property.OutcomeRow{
+		row(map[string]string{"job": "api", "count": "1"}, 2),
+		row(map[string]string{"job": "web", "count": "2"}, 1),
+	})
+}
+
+func TestAgg_CountValues_Without(t *testing.T) {
+	// without(i) drops the per-series discriminator, so the two
+	// job=api rows (both valued 1, i.e. same minted "count" label)
+	// merge into one row valued 2, exactly as the `by` case above —
+	// the two grouping modes agree here because both project down to
+	// {job, count}.
+	d := build(
+		makeSeries("g", map[string]string{"job": "api", "i": "1"}, sampleSpec{60, 1}),
+		makeSeries("g", map[string]string{"job": "api", "i": "2"}, sampleSpec{60, 1}),
+		makeSeries("g", map[string]string{"job": "web", "i": "1"}, sampleSpec{60, 2}),
+	)
+	o := eval(d, `count_values("count", g) without (i)`, 90)
+	assertRows(t, o, []property.OutcomeRow{
+		row(map[string]string{"job": "api", "count": "1"}, 2),
+		row(map[string]string{"job": "web", "count": "2"}, 1),
+	})
+}
+
+// TestAgg_LimitRatio_PositiveMid pins limit_ratio's per-series hash
+// test against REAL Prometheus label hashes (computed via
+// labels.FromMap({"__name__":"g","i":"<n>"}).Hash(), the exact
+// function the oracle calls): i=1 offset≈0.7779, i=2 offset≈0.4536,
+// i=3 offset≈0.2495. At r=0.5 (r>=0 branch: keep offset<r), only i=2
+// and i=3 survive.
+func TestAgg_LimitRatio_PositiveMid(t *testing.T) {
+	d := build(
+		makeSeries("g", map[string]string{"i": "1"}, sampleSpec{60, 10}),
+		makeSeries("g", map[string]string{"i": "2"}, sampleSpec{60, 20}),
+		makeSeries("g", map[string]string{"i": "3"}, sampleSpec{60, 30}),
+	)
+	o := eval(d, `limit_ratio(0.5, g)`, 90)
+	assertRows(t, o, []property.OutcomeRow{
+		row(map[string]string{"i": "2"}, 20),
+		row(map[string]string{"i": "3"}, 30),
+	})
+}
+
+// TestAgg_LimitRatio_NegativeMid exercises the r<0 branch (keep
+// offset>=1+r) against the same real hashes as the positive-mid case:
+// at r=-0.5 the threshold is 0.5, so only i=1 (offset≈0.7779)
+// survives — the complement of the r=0.5 case, as Prom's
+// AddRatioSampleWithOffset documents (negative ratios approximate the
+// complementary sample of the corresponding positive ratio).
+func TestAgg_LimitRatio_NegativeMid(t *testing.T) {
+	d := build(
+		makeSeries("g", map[string]string{"i": "1"}, sampleSpec{60, 10}),
+		makeSeries("g", map[string]string{"i": "2"}, sampleSpec{60, 20}),
+		makeSeries("g", map[string]string{"i": "3"}, sampleSpec{60, 30}),
+	)
+	o := eval(d, `limit_ratio(-0.5, g)`, 90)
+	assertRows(t, o, []property.OutcomeRow{row(map[string]string{"i": "1"}, 10)})
+}
+
+func TestAgg_LimitRatio_ZeroIsEmpty(t *testing.T) {
+	// r == 0 is a hard empty result — Prom returns before any group is
+	// even created (engine.go: HashRatioSampler.AddRatioSample with
+	// ratioLimit == 0 always reports "not sampled").
+	d := build(
+		makeSeries("g", map[string]string{"i": "1"}, sampleSpec{60, 10}),
+		makeSeries("g", map[string]string{"i": "2"}, sampleSpec{60, 20}),
+	)
+	o := eval(d, `limit_ratio(0, g)`, 90)
+	assertRows(t, o, nil)
+}
+
+func TestAgg_LimitRatio_ClampAboveOneKeepsAll(t *testing.T) {
+	// r > 1 clamps to 1: offset < 1 is true for every hash (offset is
+	// always in [0, 1)), so every series survives regardless of its
+	// individual hash — a clamp-correctness pin that needs no
+	// hand-computed hash value.
+	d := build(
+		makeSeries("g", map[string]string{"i": "1"}, sampleSpec{60, 10}),
+		makeSeries("g", map[string]string{"i": "2"}, sampleSpec{60, 20}),
+	)
+	o := eval(d, `limit_ratio(1.5, g)`, 90)
+	assertRows(t, o, []property.OutcomeRow{
+		row(map[string]string{"i": "1"}, 10),
+		row(map[string]string{"i": "2"}, 20),
+	})
+}
+
+// TestAgg_LimitK_BelowOneIsEmpty and TestAgg_LimitK_AtCardinalityKeepsAll
+// pin ONLY the two endpoints limitk's oracle implementation claims to
+// reproduce (see limitK's doc comment in aggregations.go) — K<1 empty,
+// K at or beyond the group's cardinality keeps everything. The
+// mid-range row-selection order has no cross-implementation contract
+// with cerberus's `LIMIT k BY` and is intentionally NOT asserted here.
+func TestAgg_LimitK_BelowOneIsEmpty(t *testing.T) {
+	d := build(
+		makeSeries("g", map[string]string{"i": "1"}, sampleSpec{60, 10}),
+		makeSeries("g", map[string]string{"i": "2"}, sampleSpec{60, 20}),
+	)
+	o := eval(d, `limitk(0, g)`, 90)
+	assertRows(t, o, nil)
+}
+
+func TestAgg_LimitK_AtCardinalityKeepsAll(t *testing.T) {
+	d := build(
+		makeSeries("g", map[string]string{"i": "1"}, sampleSpec{60, 10}),
+		makeSeries("g", map[string]string{"i": "2"}, sampleSpec{60, 20}),
+	)
+	o := eval(d, `limitk(2, g)`, 90)
+	assertRows(t, o, []property.OutcomeRow{
+		row(map[string]string{"i": "1"}, 10),
+		row(map[string]string{"i": "2"}, 20),
+	})
 }
 
 // =================================================================


### PR DESCRIPTION
## Summary

- Extends the from-scratch PromQL oracle (`test/property/oracle/promql/aggregations.go`) to model three previously-unsupported aggregators:
  - `count_values(label, vector)` — mints `label` from `strconv.FormatFloat(v, 'f', -1, 64)` per row, honoring Prometheus's grouping-key semantics (the minted label is always part of the group key for `by`, and drops out normally for `without`).
  - `limit_ratio(r, vector)` — per-row deterministic hash test using the real `github.com/prometheus/prometheus/model/labels` package (`labels.FromMap(row.Labels).Hash()`), matching upstream's clamp/offset/keep rules exactly; grouping is functionally inert for the output, confirmed against both real Prometheus and cerberus's own flat lowering.
  - `limitk(k, vector)` — endpoint-only oracle coverage (`k<1` → empty, `k>=cardinality` → keep all). Mid-range selection has no shared iteration-order contract between Prometheus and ClickHouse's `LIMIT k BY`, so that portion is out of scope by design (documented in code).
- Adds 8 unit tests in `test/property/oracle/promql/oracle_test.go` covering both grouping modes for `count_values`, four `limit_ratio` cases (positive/negative mid-range, zero, clamp-above-one), and the two `limitk` endpoints.
- Wires 8 new exotic-matrix integration cases into `test/integration/promql/matrix.go`'s `cat3Aggregators()`, comparing real cerberus (via chDB) against the oracle end-to-end.

## Fixture bug found and fixed along the way

While adding the `count_values` cases (the first oracle construct that turns a raw metric value into an exact-match **string** label), the exotic-matrix comparison started failing on a genuine floating-point divergence: cerberus's real chDB execution produced value-labels like `"2000039935.9999998"` where the oracle expected the exact `"2000039936"`.

Root-caused to `test/integration/promql/seed.go`'s `formatFloat`, which used `strconv.FormatFloat(v, 'g', -1, 64)` to render seed INSERT literals. For large-magnitude gauge values this renders in scientific notation (e.g. `"2.000039936e+09"`), and ClickHouse's SQL literal parser does not correctly round-trip scientific-notation `Float64` literals at this magnitude. Confirmed directly: `INSERT ... VALUES (1, 2.000039936e+09), (2, 2000039936)` followed by `SELECT toString(v)` returns `2000039935.9999998` for row 1 and the exact `2000039936` for row 2 — same value, two literal forms, only the plain-decimal form round-trips exactly.

Fixed by switching `formatFloat` to `'f'` format (still the shortest round-tripping decimal, just never switches to exponent notation), which makes every seeded value exact through the INSERT → SELECT round trip regardless of magnitude. This is a test-fixture bug, not a cerberus product bug — no production SQL emission path is affected. Verified no regression: `histoBounds` (`0.1, 0.5, 1, 2.5`) render identically under both formats, and the full `test/integration/promql` suite (chdb-tagged) passes clean before and after.

## Test plan

- [x] `go build ./...`
- [x] `go vet -tags chdb ./test/integration/promql/... ./test/property/oracle/promql/...`
- [x] `go test ./test/property/oracle/promql/...` — all 27 oracle unit tests pass, including the 8 new ones
- [x] `go test -tags chdb ./test/integration/promql/...` — full suite passes, including all new `cat3/count_values_*`, `cat3/limit_ratio_*`, `cat3/limitk_*` exotic-matrix cases

Refs #1693.