### PR TITLE
test(oracle): implement deriv/predict_linear/double_exponential_smoothing/quantile_over_time

### DIFF
--- a/test/integration/promql/matrix.go
+++ b/test/integration/promql/matrix.go
@@ -23,15 +23,15 @@ func (c exoticCase) ts() int64 {
 // ExoticMatrix is the hand-curated catalogue. Every entry is bound to a
 // construct the from-scratch oracle (test/property/oracle/promql) already
 // evaluates, so the assertion is a real cerberus-vs-spec comparison rather
-// than a both-erroring no-op. Set ops, absent/clamp/sort, and the
-// quantile/count_values/limitk/limit_ratio aggregator family are ALL
-// oracle-evaluated and exercised below (cat3Aggregators, cat4SetOps,
-// cat8ScalarVector) — count_values/limitk/limit_ratio specifically remain
-// oracle gaps tracked by #1693. The remaining categories the oracle can't
-// yet evaluate are each tracked by its own open issue, not by prose:
+// than a both-erroring no-op. Set ops, absent/clamp/sort, the
+// quantile/count_values/limitk/limit_ratio aggregator family, and the
+// deriv/predict_linear/double_exponential_smoothing/quantile_over_time
+// trend-function family are ALL oracle-evaluated and exercised below
+// (cat3Aggregators, cat4SetOps, cat8ScalarVector, cat11TrendFunctions) —
+// count_values/limitk/limit_ratio were closed by #1693, the trend
+// functions by #1695. The remaining categories the oracle can't yet
+// evaluate are each tracked by its own open issue, not by prose:
 //   - subqueries, label_replace, label_join — #1694
-//   - deriv, predict_linear, double_exponential_smoothing,
-//     quantile_over_time — #1695
 //   - native (exponential) histograms — #1696
 //
 // @ start()/end() determinism for range queries and stale/NaN handling are
@@ -61,6 +61,7 @@ var ExoticMatrix = func() []exoticCase {
 	m = append(m, cat8ScalarVector()...)
 	m = append(m, cat9OverTime()...)
 	m = append(m, cat10ScalarOps()...)
+	m = append(m, cat11TrendFunctions()...)
 	return m
 }()
 
@@ -277,10 +278,10 @@ func cat8ScalarVector() []exoticCase {
 
 // cat9OverTime covers the *_over_time family the oracle implements —
 // including changes()/resets()/last_over_time()/stddev_over_time()/
-// stdvar_over_time() (test/property/oracle/promql/functions.go).
-// deriv/predict_linear/double_exponential_smoothing/quantile_over_time
-// remain a genuine oracle gap, tracked by
-// https://github.com/tsouza/cerberus/issues/1695.
+// stdvar_over_time() (test/property/oracle/promql/functions.go). The
+// regression/smoothing trend-function family
+// (deriv/predict_linear/double_exponential_smoothing/quantile_over_time)
+// lives separately in cat11TrendFunctions.
 func cat9OverTime() []exoticCase {
 	const mem = "demo_memory_usage_bytes"
 	const inter = "demo_intermittent_metric"
@@ -304,6 +305,37 @@ func cat9OverTime() []exoticCase {
 		// A narrow window entirely after the reset sees no reset -> 0,
 		// distinguishing "no reset in this window" from "reset ignored".
 		{name: "cat9/resets_none_narrow_window", promql: "resets(" + restarts + "[1m])"},
+	}
+}
+
+// cat11TrendFunctions covers deriv/predict_linear/double_exponential_smoothing/
+// quantile_over_time — the trend-function family the oracle gained in #1695
+// (test/property/oracle/promql/functions.go's evalTrendFunction). Every case
+// targets demo_memory_usage_bytes{type="used"}, which seed.go's gaugeRamp
+// makes an exactly-linear ramp (base + step*1024), so deriv/predict_linear
+// have a closed-form expected answer independent of floating-point
+// regression noise: slope is exactly 1024 per stepInterval (15s).
+// double_exponential_smoothing and quantile_over_time don't need linearity,
+// but reuse the same series so the category stays self-contained.
+func cat11TrendFunctions() []exoticCase {
+	const mem = "demo_memory_usage_bytes"
+	used := mem + `{type="used"}`
+	return []exoticCase{
+		{name: "cat11/deriv_linear_ramp", promql: "deriv(" + used + "[5m])"},
+		// Project 5 minutes (300s) past the eval ts along the same slope.
+		{name: "cat11/predict_linear_forward", promql: "predict_linear(" + used + "[5m], 300)"},
+		// Negative horizon projects backward — exercises the same
+		// intercept/slope arithmetic with the opposite sign.
+		{name: "cat11/predict_linear_negative_horizon", promql: "predict_linear(" + used + "[5m], -120)"},
+		{name: "cat11/quantile_over_time_median", promql: "quantile_over_time(0.5, " + used + "[5m])"},
+		{name: "cat11/quantile_over_time_p90", promql: "quantile_over_time(0.9, " + used + "[5m])"},
+		// phi outside [0,1] is defined (±Inf), not an error — mirrors the
+		// aggregate quantile()'s out-of-domain behaviour.
+		{name: "cat11/quantile_over_time_phi_above_one", promql: "quantile_over_time(1.5, " + used + "[5m])"},
+		{name: "cat11/double_exponential_smoothing_basic", promql: "double_exponential_smoothing(" + used + "[5m], 0.5, 0.5)"},
+		// A second (sf, tf) pair exercises the recurrence's dependence on
+		// both factors independently, not just the sf==tf coincidence above.
+		{name: "cat11/double_exponential_smoothing_asymmetric_factors", promql: "double_exponential_smoothing(" + used + "[5m], 0.2, 0.8)"},
 	}
 }
 

--- a/test/property/oracle/promql/aggregations.go
+++ b/test/property/oracle/promql/aggregations.go
@@ -149,12 +149,27 @@ func aggregatorParamFloat(a *parser.AggregateExpr) (float64, error) {
 	return n.Val, nil
 }
 
-// quantileAggregate implements the `quantile(phi, vector)` aggregator:
-// Prom's textbook sample-quantile over the group's values (promql/
-// quantile.go::quantile) — sort ascending, then weighted-average
+// quantileAggregate implements the `quantile(phi, vector)` aggregator by
+// interpolating across the group's values at one instant. See
+// quantileInterpolate for the shared interpolation math.
+func quantileAggregate(phi float64, rows []VectorRow) float64 {
+	values := make([]float64, len(rows))
+	for i, r := range rows {
+		values[i] = r.V
+	}
+	return quantileInterpolate(phi, values)
+}
+
+// quantileInterpolate is Prom's textbook sample-quantile (promql/
+// quantile.go::quantile): sort ascending, then weighted-average
 // interpolate between the two samples straddling rank = phi*(n-1).
 // phi < 0 / > 1 / NaN follow Prom's documented out-of-domain results.
-func quantileAggregate(phi float64, rows []VectorRow) float64 {
+// Shared by the `quantile()` aggregator (quantileAggregate, above —
+// across series at one instant) and `quantile_over_time()`
+// (functions.go — across one series' window samples). Callers must
+// pass a slice they don't need back in its original order: this sorts
+// in place.
+func quantileInterpolate(phi float64, values []float64) float64 {
 	if math.IsNaN(phi) {
 		return math.NaN()
 	}
@@ -163,10 +178,6 @@ func quantileAggregate(phi float64, rows []VectorRow) float64 {
 	}
 	if phi > 1 {
 		return math.Inf(1)
-	}
-	values := make([]float64, len(rows))
-	for i, r := range rows {
-		values[i] = r.V
 	}
 	sort.Float64s(values)
 

--- a/test/property/oracle/promql/functions.go
+++ b/test/property/oracle/promql/functions.go
@@ -27,11 +27,28 @@ import (
 //   - resets(m[range])            — count of counter resets in window
 //   - stddev_over_time(m[range])  — population stddev of window samples
 //   - stdvar_over_time(m[range])  — population variance of window samples
+//   - deriv(m[range])             — per-series linear regression slope
+//   - predict_linear(m[range], t) — linear regression projected t
+//     seconds past the eval timestamp
+//   - double_exponential_smoothing(m[range], sf, tf) — iterative
+//     smoothing over the window's raw samples (the PromQL 3.x rename of
+//     holt_winters)
+//   - quantile_over_time(phi, m[range]) — per-series quantile
+//     interpolation over the window's raw sample values
+//
+// The last four have argument shapes evalRangeFunction's generic
+// single-matrix-arg path doesn't fit (extra scalar args, and
+// quantile_over_time's matrix arg comes second, not first) — they're
+// dispatched to evalTrendFunction below.
 //
 // Anything else returns an error so the caller can surface it.
 func (e *Evaluator) evalRangeFunction(c *parser.Call, evalTsMs int64) ([]VectorRow, error) {
 	if len(c.Args) == 0 {
 		return nil, fmt.Errorf("oracle: %s requires a range-vector arg", c.Func.Name)
+	}
+	switch c.Func.Name {
+	case "deriv", "predict_linear", "double_exponential_smoothing", "quantile_over_time":
+		return e.evalTrendFunction(c, evalTsMs)
 	}
 	ms, ok := c.Args[0].(*parser.MatrixSelector)
 	if !ok {
@@ -112,6 +129,217 @@ func applyRangeFn(name string, samples []Sample, rangeMs, effectiveTs int64) (fl
 	}
 	return 0, false
 }
+
+// evalTrendFunction handles the four range-vector functions whose
+// argument shape doesn't fit evalRangeFunction's generic single-matrix
+// path: predict_linear and quantile_over_time each take one extra
+// scalar, double_exponential_smoothing takes two, and
+// quantile_over_time's matrix arg is the SECOND argument rather than
+// the first (see prometheus/promql/parser/functions.go's ArgTypes
+// tables). Every scalar arg is evaluated once via e.evalAny — reusing
+// the general AST evaluator (rather than requiring parser.NumberLiteral
+// like the topk/bottomk aggregator params do) costs nothing here and
+// naturally handles e.g. `predict_linear(v[5m], 60*60)`.
+func (e *Evaluator) evalTrendFunction(c *parser.Call, evalTsMs int64) ([]VectorRow, error) {
+	name := c.Func.Name
+	matrixIdx := 0
+	if name == "quantile_over_time" {
+		matrixIdx = 1
+	}
+	if len(c.Args) <= matrixIdx {
+		return nil, fmt.Errorf("oracle: %s requires a range-vector arg", name)
+	}
+	ms, ok := c.Args[matrixIdx].(*parser.MatrixSelector)
+	if !ok {
+		return nil, fmt.Errorf("oracle: %s argument must be a matrix selector, got %T", name, c.Args[matrixIdx])
+	}
+	ranges := e.evalMatrixSelector(ms, evalTsMs)
+
+	scalars := make([]float64, 0, len(c.Args)-1)
+	for i, a := range c.Args {
+		if i == matrixIdx {
+			continue
+		}
+		v, err := e.evalAny(a, evalTsMs)
+		if err != nil {
+			return nil, err
+		}
+		if v.Kind != kindScalar {
+			return nil, fmt.Errorf("oracle: %s arg %d must be scalar, got kind=%d", name, i, v.Kind)
+		}
+		scalars = append(scalars, v.Scalar)
+	}
+
+	out := make([]VectorRow, 0, len(ranges))
+	for _, r := range ranges {
+		v, ok, err := applyTrendFn(name, r.Samples, evalTsMs, scalars)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			continue
+		}
+		out = append(out, VectorRow{
+			Labels: DropLabel(r.Labels, MetricNameLabel),
+			T:      evalTsMs,
+			V:      v,
+		})
+	}
+	sortVectorRows(out)
+	return out, nil
+}
+
+// applyTrendFn computes one series' output value for the trend-function
+// family. Returns (value, true, nil) on success, (0, false, nil) when
+// the function's output is undefined for this window (matching Prom's
+// silent row-drop for <2 samples), or a non-nil error when Prom itself
+// would refuse the query (double_exponential_smoothing's out-of-range sf
+// / tf, which upstream implements as a panic that surfaces as a query
+// execution error — both sides erroring is agreement per Evaluate's
+// both-erroring convention).
+func applyTrendFn(name string, samples []Sample, evalTsMs int64, scalars []float64) (float64, bool, error) {
+	switch name {
+	case "deriv":
+		if len(samples) < 2 {
+			return 0, false, nil
+		}
+		// Prom passes the window's first sample timestamp as the
+		// regression's x=0 anchor "to avoid floating point accuracy
+		// issues" (see prometheus/promql/functions.go::funcDeriv) —
+		// the fitted slope itself is anchor-invariant, only the
+		// numerical conditioning changes.
+		slope, _ := linearRegression(samples, samples[0].T)
+		return slope, true, nil
+	case "predict_linear":
+		if len(samples) < 2 {
+			return 0, false, nil
+		}
+		if len(scalars) != 1 {
+			return 0, false, fmt.Errorf("oracle: predict_linear requires 1 scalar arg, got %d", len(scalars))
+		}
+		duration := scalars[0]
+		// Prom anchors the regression at the eval timestamp (enh.Ts)
+		// so `intercept` is directly the fitted value AT the eval ts;
+		// projecting `duration` seconds forward is then just
+		// slope*duration added on top.
+		slope, intercept := linearRegression(samples, evalTsMs)
+		return slope*duration + intercept, true, nil
+	case "double_exponential_smoothing":
+		if len(scalars) != 2 {
+			return 0, false, fmt.Errorf("oracle: double_exponential_smoothing requires 2 scalar args, got %d", len(scalars))
+		}
+		sf, tf := scalars[0], scalars[1]
+		if sf <= 0 || sf >= 1 {
+			return 0, false, fmt.Errorf("oracle: double_exponential_smoothing: invalid smoothing factor, expected 0 < sf < 1, got %v", sf)
+		}
+		if tf <= 0 || tf >= 1 {
+			return 0, false, fmt.Errorf("oracle: double_exponential_smoothing: invalid trend factor, expected 0 < tf < 1, got %v", tf)
+		}
+		if len(samples) < 2 {
+			return 0, false, nil
+		}
+		return doubleExponentialSmoothing(samples, sf, tf), true, nil
+	case "quantile_over_time":
+		if len(scalars) != 1 {
+			return 0, false, fmt.Errorf("oracle: quantile_over_time requires 1 scalar arg, got %d", len(scalars))
+		}
+		if len(samples) == 0 {
+			return 0, false, nil
+		}
+		values := make([]float64, len(samples))
+		for i, s := range samples {
+			values[i] = s.V
+		}
+		return quantileInterpolate(scalars[0], values), true, nil
+	}
+	return 0, false, fmt.Errorf("oracle: unsupported trend function %q", name)
+}
+
+// linearRegression implements Prometheus's ordinary-least-squares fit
+// over a series' window samples (promql/functions.go::linearRegression),
+// shared by deriv and predict_linear. interceptTimeMs anchors x=0
+// (deriv passes the window's first sample time, predict_linear passes
+// the eval timestamp) — this only affects numerical conditioning, never
+// the fitted line itself, since both the slope and predict_linear's
+// slope*duration+intercept are anchor-invariant.
+//
+// Special case mirrored from upstream: when every sample shares the
+// same value, the fit is degenerate (the y variance is zero) and Prom
+// short-circuits to slope=0, intercept=that value — or slope=NaN,
+// intercept=NaN if the constant value is +-Inf, since a regression
+// through infinite points is undefined. A plain (non-Kahan) summation
+// is used for the rest, matching this package's established precedent
+// (see varianceOverTime's comment) — the dataset's value magnitudes
+// never approach the range where the numerical difference would exceed
+// the comparator's tolerance.
+func linearRegression(samples []Sample, interceptTimeMs int64) (slope, intercept float64) {
+	first := samples[0].V
+	constY := true
+	for _, s := range samples[1:] {
+		if s.V != first {
+			constY = false
+			break
+		}
+	}
+	if constY {
+		if math.IsInf(first, 0) {
+			return math.NaN(), math.NaN()
+		}
+		return 0, first
+	}
+
+	var n, sumX, sumY, sumXY, sumX2 float64
+	for _, s := range samples {
+		x := float64(s.T-interceptTimeMs) / float64(millisPerSecond)
+		n++
+		sumX += x
+		sumY += s.V
+		sumXY += x * s.V
+		sumX2 += x * x
+	}
+
+	covXY := sumXY - sumX*sumY/n
+	varX := sumX2 - sumX*sumX/n
+
+	slope = covXY / varX
+	intercept = sumY/n - slope*sumX/n
+	return slope, intercept
+}
+
+// doubleExponentialSmoothing implements Prometheus's
+// double_exponential_smoothing (promql/functions.go::
+// funcDoubleExponentialSmoothing + calcTrendValue), the PromQL 3.x
+// rename of holt_winters. Callers must have already validated
+// 0 < sf < 1 and 0 < tf < 1, and that len(samples) >= 2.
+func doubleExponentialSmoothing(samples []Sample, sf, tf float64) float64 {
+	s1 := samples[0].V
+	b := samples[1].V - samples[0].V
+	var s0 float64
+
+	for i := 1; i < len(samples); i++ {
+		x := sf * samples[i].V
+		b = calcTrendValue(i-1, tf, s0, s1, b)
+		y := (1 - sf) * (s1 + b)
+		s0, s1 = s1, x+y
+	}
+	return s1
+}
+
+// calcTrendValue mirrors Prom's promql/functions.go::calcTrendValue —
+// the trend component's update rule inside
+// double_exponential_smoothing's iteration.
+func calcTrendValue(i int, tf, s0, s1, b float64) float64 {
+	if i == 0 {
+		return b
+	}
+	x := tf * (s1 - s0)
+	y := (1 - tf) * b
+	return x + y
+}
+
+// millisPerSecond converts a millisecond timestamp delta into seconds
+// for linearRegression's x axis, matching Prom's own `/1e3`.
+const millisPerSecond = 1000
 
 // changesOverTime counts the number of value changes between
 // consecutive samples in window order, matching Prom's funcChanges for
@@ -320,7 +548,9 @@ func isRangeFunctionName(name string) bool {
 		"sum_over_time", "avg_over_time",
 		"min_over_time", "max_over_time", "count_over_time",
 		"last_over_time", "changes", "resets",
-		"stddev_over_time", "stdvar_over_time":
+		"stddev_over_time", "stdvar_over_time",
+		"deriv", "predict_linear", "double_exponential_smoothing",
+		"quantile_over_time":
 		return true
 	}
 	return false

--- a/test/property/oracle/promql/oracle_test.go
+++ b/test/property/oracle/promql/oracle_test.go
@@ -225,7 +225,7 @@ func TestSelector_EmptyLabelSet(t *testing.T) {
 }
 
 // =================================================================
-// Function tests — 8
+// Function tests — 15
 // =================================================================
 
 func TestFn_Rate_BasicCounter(t *testing.T) {
@@ -327,6 +327,78 @@ func TestFn_OverTime_EmptyWindow(t *testing.T) {
 	// Sample at t=0; window (60, 120] is empty → no rows.
 	d := build(makeSeries("g", map[string]string{}, sampleSpec{0, 5}))
 	o := eval(d, `sum_over_time(g[60s])`, 120)
+	assertRows(t, o, nil)
+}
+
+func TestFn_Deriv_PerfectlyLinear(t *testing.T) {
+	// Perfectly linear ramp: value = 100 + t (t in seconds). The
+	// regression slope over any subset of these points is exactly 1
+	// (value/sec), independent of the window edges or the intercept
+	// anchor — this is deriv's simplest, exactly-checkable case.
+	d := build(makeSeries("g", map[string]string{},
+		sampleSpec{0, 100}, sampleSpec{10, 110}, sampleSpec{20, 120}, sampleSpec{30, 130}))
+	o := eval(d, `deriv(g[40s])`, 30)
+	assertRows(t, o, []property.OutcomeRow{row(map[string]string{}, 1)})
+}
+
+func TestFn_Deriv_TooFewSamples(t *testing.T) {
+	// A single sample in the window has no defined derivative — Prom
+	// drops the row.
+	d := build(makeSeries("g", map[string]string{}, sampleSpec{0, 5}))
+	o := eval(d, `deriv(g[40s])`, 0)
+	assertRows(t, o, nil)
+}
+
+func TestFn_PredictLinear_ProjectsForward(t *testing.T) {
+	// Same perfectly-linear series as the deriv test: slope=1/s. Prom
+	// anchors the regression at the eval ts, so the fitted intercept
+	// equals the actual value there (130, since the fit is exact for
+	// collinear points); projecting 100s forward adds slope*100=100.
+	d := build(makeSeries("g", map[string]string{},
+		sampleSpec{0, 100}, sampleSpec{10, 110}, sampleSpec{20, 120}, sampleSpec{30, 130}))
+	o := eval(d, `predict_linear(g[40s], 100)`, 30)
+	assertRows(t, o, []property.OutcomeRow{row(map[string]string{}, 230)})
+}
+
+func TestFn_DoubleExponentialSmoothing_HandComputed(t *testing.T) {
+	// 3 samples [10, 15, 20], sf=tf=0.5. Hand-traced against Prom's
+	// funcDoubleExponentialSmoothing/calcTrendValue:
+	//   s1=10, b=5 (init)
+	//   i=1: b=calcTrendValue(0,...)=5 (i==0 short-circuit); y=0.5*(10+5)=7.5;
+	//        s0,s1 = 10, 0.5*15+7.5 = 15
+	//   i=2: b=calcTrendValue(1,0.5,10,15,5)=0.5*(15-10)+0.5*5=5; y=0.5*(15+5)=10;
+	//        s0,s1 = 15, 0.5*20+10 = 20
+	// Final output is s1=20.
+	d := build(makeSeries("g", map[string]string{},
+		sampleSpec{0, 10}, sampleSpec{10, 15}, sampleSpec{20, 20}))
+	o := eval(d, `double_exponential_smoothing(g[30s], 0.5, 0.5)`, 20)
+	assertRows(t, o, []property.OutcomeRow{row(map[string]string{}, 20)})
+}
+
+func TestFn_DoubleExponentialSmoothing_InvalidFactorErrors(t *testing.T) {
+	// sf outside (0,1) is a query error in Prom (funcDoubleExponentialSmoothing
+	// panics); the oracle mirrors that as an Evaluate error rather than
+	// silently producing a row.
+	d := build(makeSeries("g", map[string]string{}, sampleSpec{0, 10}, sampleSpec{10, 15}))
+	o := eval(d, `double_exponential_smoothing(g[30s], 1.5, 0.5)`, 10)
+	if o.Err == nil {
+		t.Fatalf("expected an error for out-of-range smoothing factor, got rows=%v", o.Rows)
+	}
+}
+
+func TestFn_QuantileOverTime_Median(t *testing.T) {
+	// Samples [1,2,3,4] in window order; median (phi=0.5) interpolates
+	// exactly halfway between the two middle values: rank=0.5*3=1.5 →
+	// values[1]*0.5 + values[2]*0.5 = 2*0.5 + 3*0.5 = 2.5.
+	d := build(makeSeries("g", map[string]string{},
+		sampleSpec{0, 1}, sampleSpec{10, 2}, sampleSpec{20, 3}, sampleSpec{30, 4}))
+	o := eval(d, `quantile_over_time(0.5, g[40s])`, 30)
+	assertRows(t, o, []property.OutcomeRow{row(map[string]string{}, 2.5)})
+}
+
+func TestFn_QuantileOverTime_EmptyWindow(t *testing.T) {
+	d := build(makeSeries("g", map[string]string{}, sampleSpec{0, 5}))
+	o := eval(d, `quantile_over_time(0.5, g[60s])`, 120)
 	assertRows(t, o, nil)
 }
 


### PR DESCRIPTION
## Summary

- The from-scratch PromQL oracle (`test/property/oracle/promql`) fell through `evalCall`'s default "unsupported function" case for `deriv`, `predict_linear`, `double_exponential_smoothing` (aka `holt_winters`), and `quantile_over_time`, so neither the property tests nor the exotic-matrix integration suite had differential coverage for these four despite cerberus implementing all four (`internal/promql/lower.go`, `range_fns.go`).
- Adds `evalTrendFunction` to `functions.go`, dispatching all four to reference-exact ports of Prometheus's `linearRegression` (shared by `deriv`/`predict_linear`), `funcDoubleExponentialSmoothing` + `calcTrendValue`, and a `quantileInterpolate` helper extracted out of the existing `quantile()` aggregator support (`aggregations.go`) and reused for `quantile_over_time`.
- Wires a new `cat11TrendFunctions` category into `test/integration/promql/matrix.go`'s `ExoticMatrix`, targeting the linear gauge ramp (`demo_memory_usage_bytes{type="used"}`) already seeded by `RichSeed`, covering deriv, forward + negative-horizon `predict_linear`, median/p90/out-of-domain `quantile_over_time`, and two `double_exponential_smoothing` factor pairs.
- 7 new oracle unit tests in `oracle_test.go` (hand-computed expectations for the linear ramp and the double-exponential-smoothing recurrence).

## Verification

- All 8 new `TestExoticPromQL/cat11/*` integration cases pass against real cerberus via chDB — **no divergence found**, confirming cerberus's lowering agrees with Prometheus's semantics for all four functions.
- Full `test/integration/promql` and `test/property/oracle/promql` suites pass with no regressions.
- `go build ./...`, `go vet ./test/...` clean; pre-push hooks (`golangci-lint`, `forbid-*`, `commitlint-range`, `markdownlint`) all green locally.

Closes #1695.

## Test plan

- [x] `go test -tags chdb ./test/integration/promql/...` — full suite green, including new cat11 cases
- [x] `go test ./test/property/oracle/promql/...` — unit tests green
- [x] CI: the 20 required status checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)