### PR TITLE
test(oracle): implement subqueries + label_replace/label_join (#1694)

### DIFF
--- a/test/integration/promql/matrix.go
+++ b/test/integration/promql/matrix.go
@@ -28,10 +28,11 @@ func (c exoticCase) ts() int64 {
 // oracle-evaluated and exercised below (cat3Aggregators, cat4SetOps,
 // cat8ScalarVector) — limitk is exact-match only at its two
 // iteration-order-independent endpoints (see cat3Aggregators's doc
-// comment); count_values and limit_ratio are exact-match throughout. The
+// comment); count_values and limit_ratio are exact-match throughout.
+// subqueries + label_replace/label_join are ALSO oracle-evaluated and
+// exercised below (cat12SubqueriesAndLabelTransforms), closing #1694. The
 // remaining categories the oracle can't yet evaluate are each tracked by
 // its own open issue, not by prose:
-//   - subqueries, label_replace, label_join — #1694
 //   - deriv, predict_linear, double_exponential_smoothing,
 //     quantile_over_time — #1695
 //   - native (exponential) histograms — #1696
@@ -63,6 +64,7 @@ var ExoticMatrix = func() []exoticCase {
 	m = append(m, cat8ScalarVector()...)
 	m = append(m, cat9OverTime()...)
 	m = append(m, cat10ScalarOps()...)
+	m = append(m, cat12SubqueriesAndLabelTransforms()...)
 	return m
 }()
 
@@ -352,6 +354,46 @@ func cat10ScalarOps() []exoticCase {
 		{name: "cat10/scalar_plus_rate", promql: "1 + rate(" + cpu + "[5m])"},
 		{name: "cat10/rate_gt_scalar", promql: "rate(" + cpu + "[5m]) > 0.5"},
 		{name: "cat10/div_by_count", promql: "sum(" + mem + ") / count(" + mem + ")"},
+	}
+}
+
+// cat12SubqueriesAndLabelTransforms covers the two shapes the oracle
+// gained in #1694: label_replace/label_join (pure label-set transforms,
+// test/property/oracle/promql/label_transform.go) and subqueries
+// (test/property/oracle/promql/subquery.go's evalSubqueryExpr +
+// evalRangeArg). The seed's 10-minute data window (seedSteps*stepInterval)
+// comfortably covers the 5m subquery windows used below.
+func cat12SubqueriesAndLabelTransforms() []exoticCase {
+	const mem = "demo_memory_usage_bytes"
+	const cpu = "demo_cpu_usage_seconds_total"
+	used := mem + `{type="used"}`
+	return []exoticCase{
+		// label_replace: extract the trailing port digits from `instance`
+		// into a new `port` label; every series' instance matches the
+		// pattern, so this is a pure rewrite (no pass-through rows).
+		{name: "cat12/label_replace_extract_port", promql: `label_replace(` + used + `, "port", "$1", "instance", ".*:([0-9]+)")`},
+		// label_replace where the regex only matches a SUBSET of series
+		// (job="demo" always matches, so this instead exercises a src
+		// label that never matches to prove pass-through-unchanged).
+		{name: "cat12/label_replace_no_match_passthrough", promql: `label_replace(` + used + `, "env", "prod", "job", "^nomatch$")`},
+		// label_join: concatenate job+instance into a synthetic id label.
+		{name: "cat12/label_join_job_instance", promql: `label_join(` + used + `, "id", "/", "job", "instance")`},
+		// label_replace composed with rate(): the label rewrite applies to
+		// rate's post-aggregation output labels (mode survives on cpu).
+		{name: "cat12/label_replace_over_rate", promql: `label_replace(rate(` + cpu + `[5m]), "cpu_mode", "$1", "mode", "(.+)")`},
+		// Subquery: max_over_time over a bare selector's re-sampled grid
+		// (explicit resolution).
+		{name: "cat12/subquery_max_over_time", promql: `max_over_time(` + used + `[5m:1m])`},
+		// Subquery: avg_over_time with the OMITTED resolution (defaults to
+		// 1m per PromQL spec, matching cerberus's + the oracle's
+		// defaultSubqueryStep).
+		{name: "cat12/subquery_avg_over_time_default_resolution", promql: `avg_over_time(demo_num_cpus[3m:])`},
+		// Subquery composed with an inner range function: rate() evaluated
+		// at each subquery anchor, then max'd across the anchors.
+		{name: "cat12/subquery_over_rate", promql: `max_over_time(rate(` + cpu + `[2m])[5m:1m])`},
+		// Subquery + offset: shifts the subquery's own end anchor back,
+		// independent of any offset inside the inner expression.
+		{name: "cat12/subquery_with_offset", promql: `avg_over_time(` + used + `[3m:1m] offset 1m)`},
 	}
 }
 

--- a/test/property/oracle/promql/evaluator.go
+++ b/test/property/oracle/promql/evaluator.go
@@ -102,6 +102,12 @@ func (e *Evaluator) evalAny(expr parser.Expr, evalTsMs int64) (value, error) {
 		return value{Kind: kindVec, Vec: e.evalVectorSelector(v, evalTsMs)}, nil
 	case *parser.MatrixSelector:
 		return value{Kind: kindRange, Range: e.evalMatrixSelector(v, evalTsMs)}, nil
+	case *parser.SubqueryExpr:
+		rp, err := e.evalSubqueryExpr(v, evalTsMs)
+		if err != nil {
+			return value{}, err
+		}
+		return value{Kind: kindRange, Range: rp}, nil
 	case *parser.Call:
 		return e.evalCall(v, evalTsMs)
 	case *parser.AggregateExpr:
@@ -171,6 +177,8 @@ func applyUnary(op parser.ItemType, in value) (value, error) {
 //   - absent(vec)         — see evalAbsent.
 //   - clamp/clamp_min/clamp_max — see evalClamp.
 //   - sort/sort_desc      — see evalSort.
+//   - label_replace/label_join — see evalLabelReplace / evalLabelJoin
+//     (label_transform.go).
 func (e *Evaluator) evalCall(c *parser.Call, evalTsMs int64) (value, error) {
 	name := c.Func.Name
 	if isRangeFunctionName(name) {
@@ -241,6 +249,10 @@ func (e *Evaluator) evalCall(c *parser.Call, evalTsMs int64) (value, error) {
 		return e.evalClamp(name, c, evalTsMs)
 	case "sort", "sort_desc":
 		return e.evalSort(c, evalTsMs)
+	case "label_replace":
+		return e.evalLabelReplace(c, evalTsMs)
+	case "label_join":
+		return e.evalLabelJoin(c, evalTsMs)
 	}
 	return value{}, fmt.Errorf("oracle: unsupported function %q", name)
 }

--- a/test/property/oracle/promql/functions.go
+++ b/test/property/oracle/promql/functions.go
@@ -28,27 +28,19 @@ import (
 //   - stddev_over_time(m[range])  — population stddev of window samples
 //   - stdvar_over_time(m[range])  — population variance of window samples
 //
+// The matrix argument itself may be a bare matrix selector (`m[5m]`) or
+// a subquery (`<expr>[5m:1m]`, #1694, e.g.
+// `max_over_time(rate(m[5m])[10m:1m])`) — see evalRangeArg
+// (subquery.go).
+//
 // Anything else returns an error so the caller can surface it.
 func (e *Evaluator) evalRangeFunction(c *parser.Call, evalTsMs int64) ([]VectorRow, error) {
 	if len(c.Args) == 0 {
 		return nil, fmt.Errorf("oracle: %s requires a range-vector arg", c.Func.Name)
 	}
-	ms, ok := c.Args[0].(*parser.MatrixSelector)
-	if !ok {
-		return nil, fmt.Errorf("oracle: %s argument must be a matrix selector, got %T", c.Func.Name, c.Args[0])
-	}
-	ranges := e.evalMatrixSelector(ms, evalTsMs)
-
-	vs, _ := ms.VectorSelector.(*parser.VectorSelector)
-	rangeMs := ms.Range.Milliseconds()
-	// The "window edges" are the (T-range, T] mathematical interval
-	// for extrapolation, where T already includes @-modifier + offset
-	// shifts. This is what Prom uses for rate's extrapolation, not
-	// the first/last actual sample timestamps.
-	effectiveTs := evalTsMs
-	if vs != nil {
-		effectiveTs = effectiveEvalTs(vs, evalTsMs, e.startMs, e.endMs)
-		effectiveTs -= vs.OriginalOffset.Milliseconds()
+	ranges, rangeMs, effectiveTs, err := e.evalRangeArg(c.Args[0], evalTsMs)
+	if err != nil {
+		return nil, fmt.Errorf("oracle: %s: %w", c.Func.Name, err)
 	}
 
 	out := make([]VectorRow, 0, len(ranges))

--- a/test/property/oracle/promql/label_transform.go
+++ b/test/property/oracle/promql/label_transform.go
@@ -1,0 +1,160 @@
+package promql
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/prometheus/prometheus/promql/parser"
+)
+
+// evalLabelReplace implements label_replace(v, dst, replacement, src,
+// regex) — a pure label-set transform over an already-evaluated instant
+// vector. Mirrors Prometheus's evalLabelReplace
+// (promql/functions.go): for each series, match `regex` (anchored
+// `^(?s:regex)$`, matching Go's ExpandString convention) against the
+// src label's value (empty string when the label is absent), and when
+// it matches, set dst to the expanded replacement template. Series
+// whose src value doesn't match are passed through unchanged — dst is
+// left as-is, not cleared.
+//
+// Unlike cerberus's real lowering (internal/promql/label_fns.go), this
+// does not validate that dst/src are syntactically valid label names:
+// cerberus's Attributes column is a generic Map(String, String), so its
+// lowering never rejects a label name shape reference Prometheus's Go
+// evaluator would panic on — matching cerberus's actual behavior here,
+// not the upstream Go evaluator's, is the point of this oracle.
+func (e *Evaluator) evalLabelReplace(c *parser.Call, evalTsMs int64) (value, error) {
+	if len(c.Args) != 5 {
+		return value{}, fmt.Errorf("oracle: label_replace expects 5 args, got %d", len(c.Args))
+	}
+	inner, err := e.evalAny(c.Args[0], evalTsMs)
+	if err != nil {
+		return value{}, err
+	}
+	if inner.Kind != kindVec {
+		return value{}, fmt.Errorf("oracle: label_replace first argument must be an instant vector")
+	}
+	dst, err := stringLiteralArg(c.Args[1], "label_replace", "dst")
+	if err != nil {
+		return value{}, err
+	}
+	repl, err := stringLiteralArg(c.Args[2], "label_replace", "replacement")
+	if err != nil {
+		return value{}, err
+	}
+	src, err := stringLiteralArg(c.Args[3], "label_replace", "src")
+	if err != nil {
+		return value{}, err
+	}
+	regexStr, err := stringLiteralArg(c.Args[4], "label_replace", "regex")
+	if err != nil {
+		return value{}, err
+	}
+	regex, err := regexp.Compile("^(?s:" + regexStr + ")$")
+	if err != nil {
+		return value{}, fmt.Errorf("oracle: label_replace: invalid regular expression %q: %w", regexStr, err)
+	}
+
+	out := make([]VectorRow, len(inner.Vec))
+	for i, r := range inner.Vec {
+		lbls := r.Labels
+		srcVal := lbls[src]
+		if idx := regex.FindStringSubmatchIndex(srcVal); idx != nil {
+			lbls = CopyLabels(r.Labels)
+			lbls[dst] = string(regex.ExpandString(nil, repl, srcVal, idx))
+		}
+		out[i] = VectorRow{Labels: lbls, T: r.T, V: r.V}
+	}
+	if err := requireUniqueLabelSets(out); err != nil {
+		return value{}, err
+	}
+	sortVectorRows(out)
+	return value{Kind: kindVec, Vec: out}, nil
+}
+
+// evalLabelJoin implements label_join(v, dst, sep, src1, src2, ...) —
+// concatenates the named source labels' values (empty string for an
+// absent label) with sep and assigns the result to dst, for every
+// series in the already-evaluated input vector. Mirrors Prometheus's
+// evalLabelJoin (promql/functions.go). Zero src labels is valid PromQL
+// (the parser allows a variadic tail of length 0); strings.Join of an
+// empty slice is "", so dst becomes the empty string — matching Prom's
+// documented behavior, no special case needed.
+func (e *Evaluator) evalLabelJoin(c *parser.Call, evalTsMs int64) (value, error) {
+	if len(c.Args) < 3 {
+		return value{}, fmt.Errorf("oracle: label_join expects at least 3 args (v, dst, sep[, src…]), got %d", len(c.Args))
+	}
+	inner, err := e.evalAny(c.Args[0], evalTsMs)
+	if err != nil {
+		return value{}, err
+	}
+	if inner.Kind != kindVec {
+		return value{}, fmt.Errorf("oracle: label_join first argument must be an instant vector")
+	}
+	dst, err := stringLiteralArg(c.Args[1], "label_join", "dst")
+	if err != nil {
+		return value{}, err
+	}
+	sep, err := stringLiteralArg(c.Args[2], "label_join", "sep")
+	if err != nil {
+		return value{}, err
+	}
+	srcs := make([]string, 0, len(c.Args)-3)
+	for i := 3; i < len(c.Args); i++ {
+		src, err := stringLiteralArg(c.Args[i], "label_join", fmt.Sprintf("src_%d", i-2))
+		if err != nil {
+			return value{}, err
+		}
+		srcs = append(srcs, src)
+	}
+
+	out := make([]VectorRow, len(inner.Vec))
+	for i, r := range inner.Vec {
+		vals := make([]string, len(srcs))
+		for j, src := range srcs {
+			vals[j] = r.Labels[src]
+		}
+		lbls := CopyLabels(r.Labels)
+		lbls[dst] = strings.Join(vals, sep)
+		out[i] = VectorRow{Labels: lbls, T: r.T, V: r.V}
+	}
+	if err := requireUniqueLabelSets(out); err != nil {
+		return value{}, err
+	}
+	sortVectorRows(out)
+	return value{Kind: kindVec, Vec: out}, nil
+}
+
+// stringLiteralArg extracts a static string literal from a Call
+// argument. PromQL's grammar requires a literal string at these
+// positions (label_replace/label_join's dst/replacement/src/regex/sep
+// params); this guards against an upstream parser shape change without
+// a bad-cast panic.
+func stringLiteralArg(e parser.Expr, fnName, paramName string) (string, error) {
+	sl, ok := e.(*parser.StringLiteral)
+	if !ok {
+		return "", fmt.Errorf("oracle: %s(%s) requires a string literal, got %T", fnName, paramName, e)
+	}
+	return sl.Val, nil
+}
+
+// requireUniqueLabelSets mirrors reference Prometheus's
+// mergeSeriesWithSameLabelset / ContainsSameLabelset check for the
+// instant-eval case: two output rows sharing the exact same label set
+// (including __name__) at the same timestamp is the
+// "vector cannot contain metrics with the same labelset" query error,
+// not a silent merge (Prom's merge path only applies across DIFFERENT
+// timestamps within a range query's per-series matrix, which doesn't
+// arise here since every row in an instant evaluation shares one ts).
+func requireUniqueLabelSets(rows []VectorRow) error {
+	seen := make(map[string]struct{}, len(rows))
+	for _, r := range rows {
+		k := labelKey(r.Labels)
+		if _, ok := seen[k]; ok {
+			return fmt.Errorf("oracle: vector cannot contain metrics with the same labelset %s", k)
+		}
+		seen[k] = struct{}{}
+	}
+	return nil
+}

--- a/test/property/oracle/promql/oracle_test.go
+++ b/test/property/oracle/promql/oracle_test.go
@@ -818,6 +818,142 @@ func TestHistogram_Quantile_SingleBucket(t *testing.T) {
 }
 
 // =================================================================
+// Label-transform tests — 7 (#1694)
+// =================================================================
+
+func TestLabelReplace_Match(t *testing.T) {
+	d := build(makeSeries("up", map[string]string{"job": "api-prod"}, sampleSpec{60, 1}))
+	o := eval(d, `label_replace(up, "svc", "$1", "job", "(.+)-prod")`, 90)
+	assertRows(t, o, []property.OutcomeRow{
+		row(map[string]string{"job": "api-prod", "svc": "api"}, 1),
+	})
+}
+
+func TestLabelReplace_NoMatch_PassesThroughUnchanged(t *testing.T) {
+	// src value doesn't match the anchored regex -> dst is left as-is
+	// (here, absent), not cleared or errored.
+	d := build(makeSeries("up", map[string]string{"job": "web"}, sampleSpec{60, 1}))
+	o := eval(d, `label_replace(up, "svc", "$1", "job", "(.+)-prod")`, 90)
+	assertRows(t, o, []property.OutcomeRow{
+		row(map[string]string{"job": "web"}, 1),
+	})
+}
+
+func TestLabelReplace_MissingSrcLabel_TreatedAsEmptyString(t *testing.T) {
+	// src label absent from the series -> matched against "".
+	d := build(makeSeries("up", map[string]string{"job": "api"}, sampleSpec{60, 1}))
+	o := eval(d, `label_replace(up, "region", "unknown", "zone", "^$")`, 90)
+	assertRows(t, o, []property.OutcomeRow{
+		row(map[string]string{"job": "api", "region": "unknown"}, 1),
+	})
+}
+
+func TestLabelReplace_NamedCaptureGroup(t *testing.T) {
+	d := build(makeSeries("up", map[string]string{"job": "api-prod"}, sampleSpec{60, 1}))
+	o := eval(d, `label_replace(up, "svc", "${name}", "job", "(?P<name>.+)-prod")`, 90)
+	assertRows(t, o, []property.OutcomeRow{
+		row(map[string]string{"job": "api-prod", "svc": "api"}, 1),
+	})
+}
+
+func TestLabelReplace_DuplicateLabelSetErrors(t *testing.T) {
+	// Two series collapse onto the same label set after the rewrite ->
+	// Prom's "vector cannot contain metrics with the same labelset".
+	d := build(
+		makeSeries("up", map[string]string{"job": "api", "instance": "a"}, sampleSpec{60, 1}),
+		makeSeries("up", map[string]string{"job": "api", "instance": "b"}, sampleSpec{60, 2}),
+	)
+	o := eval(d, `label_replace(up, "instance", "shared", "instance", ".*")`, 90)
+	if o.Err == nil {
+		t.Fatalf("expected duplicate-labelset error, got rows=%v", o.Rows)
+	}
+}
+
+func TestLabelJoin_MultipleSources(t *testing.T) {
+	d := build(makeSeries("up", map[string]string{"job": "api", "zone": "us"}, sampleSpec{60, 1}))
+	o := eval(d, `label_join(up, "id", "-", "job", "zone")`, 90)
+	assertRows(t, o, []property.OutcomeRow{
+		row(map[string]string{"job": "api", "zone": "us", "id": "api-us"}, 1),
+	})
+}
+
+func TestLabelJoin_ZeroSources_YieldsEmptyString(t *testing.T) {
+	d := build(makeSeries("up", map[string]string{"job": "api"}, sampleSpec{60, 1}))
+	o := eval(d, `label_join(up, "id", "-")`, 90)
+	assertRows(t, o, []property.OutcomeRow{
+		row(map[string]string{"job": "api", "id": ""}, 1),
+	})
+}
+
+// =================================================================
+// Subquery tests — 5 (#1694)
+// =================================================================
+
+func TestSubquery_MaxOverTime_GridAlignment(t *testing.T) {
+	// Gauge ramps 1,2,...,7 at t=0,10,...,60 (10s apart). Evaluate
+	// `max_over_time(g[40s:10s])` at eval=60: subquery grid anchors are
+	// multiples of 10s strictly greater than (60-40)=20, up to and
+	// including 60 -> {30,40,50,60}. At each anchor, g's instant value
+	// (LWR at that ts) is 4,5,6,7 respectively (t=30->4, t=40->5,
+	// t=50->6, t=60->7). max is 7.
+	d := build(makeSeries("g", map[string]string{},
+		sampleSpec{0, 1}, sampleSpec{10, 2}, sampleSpec{20, 3}, sampleSpec{30, 4},
+		sampleSpec{40, 5}, sampleSpec{50, 6}, sampleSpec{60, 7}))
+	o := eval(d, `max_over_time(g[40s:10s])`, 60)
+	assertRows(t, o, []property.OutcomeRow{row(map[string]string{}, 7)})
+}
+
+func TestSubquery_AvgOverTime_DefaultResolution(t *testing.T) {
+	// Omitted `:resolution` defaults to 1m (defaultSubqueryStep). One
+	// gauge sample at t=0 stays fresh (LWR) across the whole grid, so
+	// every anchor in the subquery's window evaluates to the same
+	// value and avg == that value.
+	d := build(makeSeries("g", map[string]string{}, sampleSpec{0, 42}))
+	o := eval(d, `avg_over_time(g[2m:])`, 90)
+	assertRows(t, o, []property.OutcomeRow{row(map[string]string{}, 42)})
+}
+
+func TestSubquery_OverRangeFunction_Composition(t *testing.T) {
+	// max_over_time(rate(counter[30s])[60s:30s]) — a subquery whose
+	// inner expression is itself a range function. Counter grows
+	// linearly (10/10s => 1/s), so rate() over any 30s sub-window is a
+	// constant ~1, and the outer max_over_time of a constant sequence
+	// is that same constant.
+	d := build(makeSeries("c", map[string]string{},
+		sampleSpec{0, 0}, sampleSpec{10, 10}, sampleSpec{20, 20}, sampleSpec{30, 30},
+		sampleSpec{40, 40}, sampleSpec{50, 50}, sampleSpec{60, 60}, sampleSpec{70, 70},
+		sampleSpec{80, 80}, sampleSpec{90, 90}))
+	o := eval(d, `max_over_time(rate(c[30s])[60s:30s])`, 90)
+	if len(o.Rows) != 1 {
+		t.Fatalf("expected 1 row, got %v", o.Rows)
+	}
+	if !valuesClose(o.Rows[0].Value, 1) {
+		t.Errorf("want~=1, got=%g", o.Rows[0].Value)
+	}
+}
+
+func TestSubquery_EmptyWindow_NoRows(t *testing.T) {
+	// Series only has samples far before the subquery's window -> every
+	// per-anchor instant eval is empty -> no output series at all.
+	d := build(makeSeries("g", map[string]string{}, sampleSpec{-1000, 1}))
+	o := eval(d, `avg_over_time(g[30s:10s])`, 60)
+	assertRows(t, o, nil)
+}
+
+func TestSubquery_AtModifierInsideInner_ResolvesPerAnchor(t *testing.T) {
+	// The inner expression carries its own offset, which applies
+	// relative to EACH subquery anchor independently (not the outer
+	// eval ts). g has one sample at t=0; querying
+	// `g offset 10s` inside a [30s:10s] subquery evaluated at eval=40
+	// means anchors {20,30,40} each look back 10s further: effective
+	// lookups at {10,20,30}, all of which see the t=0 sample via LWR
+	// (constant thereafter), so the result is a flat 1 at every anchor.
+	d := build(makeSeries("g", map[string]string{}, sampleSpec{0, 1}))
+	o := eval(d, `avg_over_time((g offset 10s)[30s:10s])`, 40)
+	assertRows(t, o, []property.OutcomeRow{row(map[string]string{}, 1)})
+}
+
+// =================================================================
 // Modifier tests — 6
 // =================================================================
 

--- a/test/property/oracle/promql/subquery.go
+++ b/test/property/oracle/promql/subquery.go
@@ -1,0 +1,149 @@
+package promql
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+)
+
+// defaultSubqueryStep is the resolution substituted when a subquery
+// omits an explicit `:resolution` (`expr[5m:]`). Matches Prometheus's
+// default and cerberus's own lowering (internal/promql/subquery.go's
+// defaultSubqueryStep).
+const defaultSubqueryStep = time.Minute
+
+// evalSubqueryExpr evaluates a subquery (`<expr>[range:resolution]`)
+// into a []RangePoints: one entry per distinct output series, each
+// carrying the samples produced by evaluating expr as an independent
+// INSTANT query at every point of an epoch-aligned anchor grid inside
+// (end-range, end].
+//
+// This mirrors reference Prometheus's engine.go eval()'s
+// `case *parser.SubqueryExpr:` exactly (durationMilliseconds +
+// noStepSubqueryIntervalFn):
+//
+//	newEv.interval = step (or the default when step == 0)
+//	newEv.startTimestamp = interval * ((end - interval) / interval)   // floor to a multiple of interval
+//	if newEv.startTimestamp <= (end - rangeMs) {
+//	    newEv.startTimestamp += interval                              // left-exclusive lower bound
+//	}
+//	// grid runs newEv.startTimestamp, +interval, ... up to and including end
+//
+// end already has the subquery's own @-modifier + offset applied,
+// mirroring effectiveEvalTs/OriginalOffset for a plain VectorSelector.
+// Each anchor evaluates sub.Expr as a fully independent instant query at
+// that timestamp — offsets/​@ modifiers inside sub.Expr resolve relative
+// to that anchor, and any nested @start()/@end() still resolves against
+// the OUTER query's startMs/endMs (PromQL's @start()/@end() always name
+// the top-level query's own bounds, never a subquery's synthetic grid),
+// which falls out naturally since e.startMs/e.endMs are untouched here.
+//
+// Nested subquery-of-subquery (`expr[r1:s1][r2:s2]`) is out of scope — a
+// genuinely rare shape — and returns a clear error rather than silently
+// mishandling it.
+func (e *Evaluator) evalSubqueryExpr(sub *parser.SubqueryExpr, evalTsMs int64) ([]RangePoints, error) {
+	if _, nested := sub.Expr.(*parser.SubqueryExpr); nested {
+		return nil, fmt.Errorf("oracle: nested subquery-of-subquery not supported")
+	}
+
+	end := subqueryEffectiveTs(sub, evalTsMs, e.startMs, e.endMs)
+	end -= sub.OriginalOffset.Milliseconds()
+
+	stepMs := sub.Step.Milliseconds()
+	if stepMs == 0 {
+		stepMs = defaultSubqueryStep.Milliseconds()
+	}
+	rangeMs := sub.Range.Milliseconds()
+
+	lowerBound := end - rangeMs
+	start := stepMs * (lowerBound / stepMs)
+	if start <= lowerBound {
+		start += stepMs
+	}
+
+	series := make(map[string]*RangePoints)
+	order := make([]string, 0)
+	for t := start; t <= end; t += stepMs {
+		v, err := e.evalAny(sub.Expr, t)
+		if err != nil {
+			return nil, err
+		}
+		if v.Kind != kindVec {
+			return nil, fmt.Errorf("oracle: subquery inner expression must evaluate to an instant vector, got kind=%d", v.Kind)
+		}
+		for _, row := range v.Vec {
+			key := labelKey(row.Labels)
+			rp, ok := series[key]
+			if !ok {
+				rp = &RangePoints{Labels: CopyLabels(row.Labels)}
+				series[key] = rp
+				order = append(order, key)
+			}
+			rp.Samples = append(rp.Samples, Sample{T: t, V: row.V})
+		}
+	}
+
+	sort.Strings(order)
+	out := make([]RangePoints, 0, len(order))
+	for _, k := range order {
+		out = append(out, *series[k])
+	}
+	return out, nil
+}
+
+// subqueryEffectiveTs is effectiveEvalTs's counterpart for
+// *parser.SubqueryExpr, which carries its own Timestamp/StartOrEnd
+// fields for @-modifier support (independent of the inner expression's
+// own @ modifier, if any).
+func subqueryEffectiveTs(v *parser.SubqueryExpr, evalTsMs, startMs, endMs int64) int64 {
+	if v.Timestamp != nil {
+		return *v.Timestamp
+	}
+	switch v.StartOrEnd {
+	case parser.START:
+		return startMs
+	case parser.END:
+		return endMs
+	}
+	return evalTsMs
+}
+
+// evalRangeArg evaluates a range-vector function's matrix argument — a
+// bare matrix selector (`m[5m]`) or a subquery (`<expr>[5m:1m]`, added
+// for #1694, e.g. `max_over_time(rate(m[5m])[10m:1m])`) — into its
+// per-series window samples, the window's duration, and the "effective"
+// end timestamp rate/increase/delta's extrapolation anchors to (the
+// (T-range, T] mathematical interval after @-modifier + offset shifts —
+// not necessarily the first/last actual sample timestamp).
+//
+// Note: reference Prometheus's own extrapolatedRate hard type-asserts
+// its arg as *parser.MatrixSelector (promql/functions.go), so
+// rate/increase/delta over a bare subquery argument panics upstream —
+// not a shape this oracle needs to reproduce faithfully, since no
+// exotic-matrix case exercises it. Every other range function
+// (*_over_time, deriv, predict_linear, quantile_over_time,
+// double_exponential_smoothing) only touches the resulting Matrix
+// samples, so they support a subquery argument fine both upstream and
+// here.
+func (e *Evaluator) evalRangeArg(arg parser.Expr, evalTsMs int64) (ranges []RangePoints, rangeMs, effectiveTs int64, err error) {
+	switch v := arg.(type) {
+	case *parser.MatrixSelector:
+		vs, _ := v.VectorSelector.(*parser.VectorSelector)
+		effectiveTs = evalTsMs
+		if vs != nil {
+			effectiveTs = effectiveEvalTs(vs, evalTsMs, e.startMs, e.endMs)
+			effectiveTs -= vs.OriginalOffset.Milliseconds()
+		}
+		return e.evalMatrixSelector(v, evalTsMs), v.Range.Milliseconds(), effectiveTs, nil
+	case *parser.SubqueryExpr:
+		ranges, err = e.evalSubqueryExpr(v, evalTsMs)
+		if err != nil {
+			return nil, 0, 0, err
+		}
+		effectiveTs = subqueryEffectiveTs(v, evalTsMs, e.startMs, e.endMs) - v.OriginalOffset.Milliseconds()
+		return ranges, v.Range.Milliseconds(), effectiveTs, nil
+	}
+	return nil, 0, 0, fmt.Errorf("oracle: range-vector argument must be a matrix selector or subquery, got %T", arg)
+}


### PR DESCRIPTION
## Summary

- Extends the from-scratch PromQL oracle (`test/property/oracle/promql`) with subquery evaluation (`subquery.go`: `evalRangeArg`, repeated instant evaluation across a resolution-spaced, epoch-aligned grid within `(evalTs-range, evalTs]`, matching upstream `SubqueryExpr` semantics and cerberus's own `internal/promql/subquery.go`'s `defaultSubqueryStep = 1m`) and `label_replace`/`label_join` (`label_transform.go`: pure label-set transforms, named capture groups, missing-source-label-as-empty-string, zero-source `label_join`, duplicate-labelset error).
- `evalRangeFunction` now routes its matrix arg through the new `evalRangeArg` so bare matrix selectors and subqueries share one evaluation path.
- 12 new oracle unit tests (`oracle_test.go`) covering both capabilities.
- 8 new `cat12SubqueriesAndLabelTransforms` integration cases wired into the chDB-backed exotic matrix (`test/integration/promql/matrix.go`), comparing real cerberus (HTTP handler + chDB) against the oracle for these exact constructs.

## Findings

All 8 new integration cases passed on the first real run against cerberus via chDB — cerberus's existing lowering (`internal/promql/subquery.go`, `label_fns.go`) already matches the oracle's from-scratch semantics for subqueries and label_replace/label_join. This closes #1694 as a pure oracle-coverage gap; no cerberus bug found, so no follow-up issue is needed.

Closes #1694

## Test plan

- [x] `go build ./...` and `go build -tags chdb ./...` both clean
- [x] `go test ./test/property/oracle/...` — all oracle unit tests pass (12 new + all pre-existing)
- [x] `go test -tags chdb ./test/integration/promql/... -run TestExoticPromQL` — all subtests pass, including the 8 new `cat12/*` cases, zero divergence from cerberus