### PR TITLE
fix(api/prom): parse metadata match[] with ParseMetricSelector

### DIFF
--- a/internal/api/prom/handler.go
+++ b/internal/api/prom/handler.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/prometheus/prometheus/model/labels"
 	promparser "github.com/prometheus/prometheus/promql/parser"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
@@ -715,6 +716,57 @@ func (h *Handler) parseExpr(ctx context.Context, query string) (promparser.Expr,
 		return nil, err
 	}
 	return expr, nil
+}
+
+// parseMatchSelector parses one `match[]` value the way upstream Prometheus
+// parses it on the metadata / series endpoints: with ParseMetricSelector,
+// the grammar entrypoint that accepts a bare vector selector only and
+// rejects everything else — aggregations, calls, binary expressions, and
+// the offset / `@` modifiers — at the parse boundary. This is deliberately
+// narrower than parseExpr (the general-expression grammar `/query` and
+// `/query_range` use): a match[] selector that upstream rejects must fail
+// here too, rather than being walked down to a vector selector that
+// silently discards whatever wrapped it.
+//
+// ParseMetricSelector's grammar alone accepts `{}` (or a selector whose
+// matchers all match the empty string) — the "no non-empty matcher"
+// rejection is not a parser rule, it's a check upstream's own HTTP layer
+// applies afterwards (web/api/v1's matchersParam), so requireNonEmptyMatcher
+// mirrors it here rather than relying on the grammar to catch it.
+//
+// The result is wrapped back into a *parser.VectorSelector so callers can
+// keep feeding it through the existing Expr-shaped lowering path
+// (promql.LowerMetadataRange / lowerVectorSelector), which derives the
+// metric name from LabelMatchers and never reads the modifier fields
+// ParseMetricSelector's grammar can't produce anyway.
+func (h *Handler) parseMatchSelector(ctx context.Context, matcher string) (promparser.Expr, error) {
+	_, span := tracer.Start(ctx, cerbtrace.SpanParse,
+		trace.WithAttributes(cerbtrace.ParseAttrs("promql", matcher)...))
+	defer span.End()
+	matchers, err := h.parser.ParseMetricSelector(normalizeDottedSelectors(matcher))
+	if err != nil {
+		span.RecordError(err)
+		return nil, err
+	}
+	if err := requireNonEmptyMatcher(matchers); err != nil {
+		span.RecordError(err)
+		return nil, err
+	}
+	return &promparser.VectorSelector{LabelMatchers: matchers}, nil
+}
+
+// requireNonEmptyMatcher rejects a match[] selector whose matchers all
+// match the empty string (including the trivial `{}` selector), matching
+// upstream Prometheus's web/api/v1 matchersParam check: without it, a
+// selector like `{}` implicitly selects every metric — almost always a
+// caller typo rather than intent.
+func requireNonEmptyMatcher(matchers []*labels.Matcher) error {
+	for _, m := range matchers {
+		if m != nil && !m.Matches("") {
+			return nil
+		}
+	}
+	return errors.New("match[] must contain at least one non-empty matcher")
 }
 
 // scalarPoint renders the [<unix_seconds_float>, "<value_string>"]

--- a/internal/api/prom/metadata.go
+++ b/internal/api/prom/metadata.go
@@ -1203,7 +1203,7 @@ func (h *Handler) catalogMatcherSQL(
 	ctx context.Context, matcher string, start, end time.Time,
 	lowerCatalog func(context.Context, promparser.Expr, schema.Metrics, time.Time, time.Time) (chplan.Node, error),
 ) (string, []any, error) {
-	expr, err := h.parseExpr(ctx, matcher)
+	expr, err := h.parseMatchSelector(ctx, matcher)
 	if err != nil {
 		return "", nil, &apiError{Kind: ErrBadData, Err: err, Status: http.StatusBadRequest}
 	}
@@ -1438,7 +1438,7 @@ func (h *Handler) querySamples(ctx context.Context, sql string, args []any) ([]c
 // what makes /series return a series with any in-window sample instead of
 // only series with a sample in the last 5m at wall-clock `now`.
 func (h *Handler) seriesMatcherSQL(ctx context.Context, matcher string, start, end time.Time) (string, []any, error) {
-	expr, err := h.parseExpr(ctx, matcher)
+	expr, err := h.parseMatchSelector(ctx, matcher)
 	if err != nil {
 		return "", nil, &apiError{Kind: ErrBadData, Err: err, Status: http.StatusBadRequest}
 	}

--- a/internal/api/prom/metadata_test.go
+++ b/internal/api/prom/metadata_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -580,6 +581,85 @@ func TestMetadata_NoMonotonicColumnFallsBackToCounter(t *testing.T) {
 	}
 	if sumCalls[0].kind != "counter" {
 		t.Errorf("fallback sum arm reported type %q, want counter", sumCalls[0].kind)
+	}
+}
+
+// matchSelectorRejectedShapes are match[] values upstream Prometheus
+// rejects at the ParseMetricSelector boundary — a range-vector call, the
+// offset modifier, the @ modifier, and an aggregation — because that
+// grammar entrypoint only accepts a bare instant vector selector. #1487:
+// cerberus used to parse match[] with the general ParseExpr grammar,
+// which accepts every one of these, walks down to the inner vector
+// selector, and silently drops whatever wrapped it (the range, the
+// offset, the @ timestamp, the aggregation) — turning a caller mistake
+// into a wrong 200 instead of upstream's 400.
+var matchSelectorRejectedShapes = []string{
+	"rate(http_requests_total[5m])",
+	"foo offset 1h",
+	"foo @ 1600000000",
+	"sum(foo)",
+}
+
+func TestLabels_MatchSelectorRejectsNonSelector(t *testing.T) {
+	t.Parallel()
+
+	for _, m := range matchSelectorRejectedShapes {
+		t.Run(m, func(t *testing.T) {
+			t.Parallel()
+			srv := newServer(&stubQuerier{})
+			t.Cleanup(srv.Close)
+
+			resp, err := http.Get(srv.URL + "/api/v1/labels?" + url.Values{"match[]": {m}}.Encode())
+			if err != nil {
+				t.Fatalf("GET: %v", err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("match[]=%q: expected 400, got %d body=%s", m, resp.StatusCode, readBody(t, resp))
+			}
+		})
+	}
+}
+
+func TestLabelValues_MatchSelectorRejectsNonSelector(t *testing.T) {
+	t.Parallel()
+
+	for _, m := range matchSelectorRejectedShapes {
+		t.Run(m, func(t *testing.T) {
+			t.Parallel()
+			srv := newServer(&stubQuerier{})
+			t.Cleanup(srv.Close)
+
+			resp, err := http.Get(srv.URL + "/api/v1/label/job/values?" + url.Values{"match[]": {m}}.Encode())
+			if err != nil {
+				t.Fatalf("GET: %v", err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("match[]=%q: expected 400, got %d body=%s", m, resp.StatusCode, readBody(t, resp))
+			}
+		})
+	}
+}
+
+func TestSeries_MatchSelectorRejectsNonSelector(t *testing.T) {
+	t.Parallel()
+
+	for _, m := range matchSelectorRejectedShapes {
+		t.Run(m, func(t *testing.T) {
+			t.Parallel()
+			srv := newServer(&stubQuerier{})
+			t.Cleanup(srv.Close)
+
+			resp, err := http.Get(srv.URL + "/api/v1/series?" + url.Values{"match[]": {m}}.Encode())
+			if err != nil {
+				t.Fatalf("GET: %v", err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("match[]=%q: expected 400, got %d body=%s", m, resp.StatusCode, readBody(t, resp))
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

`/api/v1/series`, `/api/v1/labels`, and `/api/v1/label/<name>/values` parsed `match[]` with the general `ParseExpr` grammar (`catalogMatcherSQL` / `seriesMatcherSQL` → `h.parseExpr`), which accepts range-vector calls, `offset`/`@` modifiers, and aggregations — shapes upstream Prometheus's `ParseMetricSelector` boundary rejects at parse time. Cerberus instead walked down to the inner vector selector and silently discarded whatever wrapped it, answering a *different* query than the one the caller wrote (200 instead of upstream's 400).

The originally-cited sites in #1487 were wrong — `histogram_bare_match.go`, `metric_name_candidates.go`, and `regex_name_histogram.go` are opportunistic fan-out helpers where a parse failure is a benign skip, not the rejection boundary. The real sites (per the issue's re-scope comment) are `catalogMatcherSQL` (`internal/api/prom/metadata.go:1206`) and `seriesMatcherSQL` (`internal/api/prom/metadata.go:1441`).

## Fix

- Added `Handler.parseMatchSelector`, which parses with `h.parser.ParseMetricSelector` (upstream's own metadata-endpoint grammar entrypoint) instead of `ParseExpr`, then wraps the result back into a `*parser.VectorSelector` so it keeps flowing through the existing `promql.LowerMetadataRange` / `lowerVectorSelector` path unchanged.
- `ParseMetricSelector`'s grammar alone still accepts the trivial `{}` selector (or one whose matchers all match the empty string) — that rejection is upstream's own HTTP-layer check (`web/api/v1`'s `matchersParam`), not a parser rule. Added `requireNonEmptyMatcher` to mirror it, otherwise `match[]={}` regressed from 400 to 200 (caught by the existing `TestConformance_LabelsMatchEdge/invalid_matcher` test).
- Wired `parseMatchSelector` into both `catalogMatcherSQL` and `seriesMatcherSQL` in place of `parseExpr`.

## Tests

- New: `TestLabels_MatchSelectorRejectsNonSelector`, `TestLabelValues_MatchSelectorRejectsNonSelector`, `TestSeries_MatchSelectorRejectsNonSelector` in `internal/api/prom/metadata_test.go` — each asserts 400 for `rate(http_requests_total[5m])`, `foo offset 1h`, `foo @ 1600000000`, and `sum(foo)` on all three metadata endpoints.
- Full `internal/api/prom` suite green, including the pre-existing `TestConformance_LabelsMatchEdge` / `TestConformance_SeriesMatchEdge` edge-case tests and every existing `match[]` fan-out test (histogram companion expansion, regex-name expansion, multi-matcher chunking).

## Compatibility-corpus gap (filed, not fixed here)

I looked for a live-diff mechanism to pin this against reference Prometheus per the wave's guidance (the new status-code-parity axis from #1717). Neither existing mechanism reaches these endpoints:

- `compatibility/prometheus` (`promql-compliance-tester` + the `should_fail: true` axis) only drives `/api/v1/query` and `/api/v1/query_range`.
- `compatibility/cmd/rejection-parity` (the catalogue-driven driver) is scoped to error-construction sites inside the *lowering* packages (`internal/{promql,logql,traceql}`); this fix's rejection lives in `internal/api/prom/handler.go`, an HTTP-layer parse boundary the catalogue scanner never visits, with no metadata-endpoint entry in its `Endpoint` model.

Extending either mechanism to cover metadata-endpoint match[] parity is real infrastructure work outside this bug fix's scope, so I filed #1729 to track it rather than leaving a note in this PR body.

Closes #1487

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/api/prom/...` (full package, 45s, all green)
- [x] `gofumpt -l` clean on changed files
- [x] lefthook pre-commit + pre-push (gofumpt, goimports, commitlint, golangci-lint, forbid-sql-raw, forbid-skip, forbid-escape-hatch, forbid-soft-assert) — all green