### PR TITLE
fix(traceql): stop dotted attributes colliding with intrinsic names

### DIFF
--- a/.github/scripts/compat-ratchet.mjs
+++ b/.github/scripts/compat-ratchet.mjs
@@ -21,7 +21,7 @@
 // accident of the current numbers — a diff against a reference backend
 // is a bug to fix at the source, so there is no shape in this file that
 // can record a divergence as acceptable. The floors are prometheus
-// 739/739, loki 126/126, tempo 62/62, tempo-grpc 59/59; doc-counts.mjs
+// 739/739, loki 126/126, tempo 63/63, tempo-grpc 60/60; doc-counts.mjs
 // asserts those numbers against compatibility/parity-baseline.json, so
 // a corpus change cannot leave this comment behind. tempo-grpc's floor
 // is 3 below tempo's: traces / traces_v2 have no StreamingQuerier RPC

--- a/compatibility/parity-baseline.json
+++ b/compatibility/parity-baseline.json
@@ -880,8 +880,8 @@
       ]
     },
     "tempo": {
-      "passed": 62,
-      "total": 62,
+      "passed": 63,
+      "total": 63,
       "cases": [
         "metrics_instant | metrics_avg_over_time_instant",
         "metrics_instant | metrics_count_over_time_instant",
@@ -901,6 +901,7 @@
         "search | descendant_op_payments_to_consumer",
         "search | direct_child_op_client_under_checkout",
         "search | direct_parent_op_checkout_to_child",
+        "search | dotted_attr_name_collision",
         "search | duration_gt_100ms",
         "search | duration_lt_300ms",
         "search | kind_eq_server",
@@ -948,8 +949,8 @@
       ]
     },
     "tempo-grpc": {
-      "passed": 59,
-      "total": 59,
+      "passed": 60,
+      "total": 60,
       "cases": [
         "metrics_instant | metrics_avg_over_time_instant",
         "metrics_instant | metrics_count_over_time_instant",
@@ -969,6 +970,7 @@
         "search | descendant_op_payments_to_consumer",
         "search | direct_child_op_client_under_checkout",
         "search | direct_parent_op_checkout_to_child",
+        "search | dotted_attr_name_collision",
         "search | duration_gt_100ms",
         "search | duration_lt_300ms",
         "search | kind_eq_server",

--- a/compatibility/tempo/driver/corpus/smoke.txtar
+++ b/compatibility/tempo/driver/corpus/smoke.txtar
@@ -143,6 +143,17 @@ search
 -- expected_max_traces --
 500
 
+-- name --
+dotted_attr_name_collision
+-- query --
+{ .name = "attr-name-collision-sentinel" }
+-- endpoint --
+search
+-- expected_min_traces --
+1
+-- expected_max_traces --
+500
+
 # --- Intrinsics (4) ---
 
 -- name --

--- a/compatibility/tempo/driver/seeder.go
+++ b/compatibility/tempo/driver/seeder.go
@@ -103,6 +103,12 @@ const (
 	rootSpanDurationNs = int64(150 * time.Millisecond)
 )
 
+// attrNameCollisionValue is the root span's "name" span-attribute value —
+// deliberately colliding with the `name` intrinsic identifier so the
+// corpus can pin the dotted-vs-bare distinction (#1598): `.name` must read
+// this attribute while bare `name` must keep reading SpanName.
+const attrNameCollisionValue = "attr-name-collision-sentinel"
+
 // seederScopeName / seederScopeVersion identify the OTLP
 // InstrumentationScope every pushed span rides under. The CH-side seed
 // mirrors them into the ScopeName / ScopeVersion columns so both
@@ -312,6 +318,12 @@ func newTrace(start time.Time, svc string, svcIdx, traceIdx int) *fixtureTrace {
 			"http.method": "GET",
 			"http.target": fmt.Sprintf("/api/%s/%d", svc, traceIdx),
 			"trace.index": fmt.Sprintf("%d", traceIdx),
+			// "name" collides with the `name` intrinsic on purpose: it
+			// pins the dotted-vs-bare distinction (#1598) — `.name`
+			// must read this span attribute, while bare `name` must
+			// keep reading the SpanName ("GET /api/<svc>/<idx>")
+			// intrinsic column instead.
+			"name": attrNameCollisionValue,
 		}),
 		Status: &otlptrace.Status{
 			Code: otlptrace.Status_STATUS_CODE_OK,

--- a/internal/traceql/ast/attribute.go
+++ b/internal/traceql/ast/attribute.go
@@ -40,10 +40,14 @@ func (a Attribute) impliedType() StaticType {
 	}
 }
 
-// NewAttribute builds an unscoped attribute, resolving the name to an
-// intrinsic when it names one.
+// NewAttribute builds an unscoped, dotted-form attribute (the `.name`
+// spelling). It never resolves an intrinsic: upstream Tempo only reaches
+// intrinsics through their own dedicated bare-identifier grammar productions
+// (NewIntrinsic) or the scoped/parent form's guarded resolution
+// (NewScopedAttribute), so `.name`, `.duration`, `.status`, etc. always name
+// a real span attribute, even when they collide with an intrinsic's name.
 func NewAttribute(name string) Attribute {
-	return Attribute{Name: name, Intrinsic: intrinsicFromString(name)}
+	return Attribute{Name: name, Intrinsic: IntrinsicNone}
 }
 
 // NewScopedAttribute builds a scoped (or parent-qualified) attribute. An

--- a/internal/traceql/ast/attribute_mutation_test.go
+++ b/internal/traceql/ast/attribute_mutation_test.go
@@ -38,11 +38,20 @@ func TestNewScopedAttributeIntrinsicResolution(t *testing.T) {
 	}
 }
 
-// TestNewAttributeResolvesIntrinsic pins the unscoped constructor.
-func TestNewAttributeResolvesIntrinsic(t *testing.T) {
+// TestNewAttributeNeverResolvesIntrinsic pins the dotted-form constructor:
+// `.name` names a real span attribute even when the name collides with an
+// intrinsic's name (mirrors upstream Tempo, which only resolves intrinsics
+// through their own bare-identifier grammar productions).
+func TestNewAttributeNeverResolvesIntrinsic(t *testing.T) {
 	t.Parallel()
-	if got := NewAttribute("status").Intrinsic; got != IntrinsicStatus {
-		t.Errorf("NewAttribute(status).Intrinsic = %v; want IntrinsicStatus", got)
+	if got := NewAttribute("status").Intrinsic; got != IntrinsicNone {
+		t.Errorf("NewAttribute(status).Intrinsic = %v; want IntrinsicNone", got)
+	}
+	if got := NewAttribute("name").Intrinsic; got != IntrinsicNone {
+		t.Errorf("NewAttribute(name).Intrinsic = %v; want IntrinsicNone", got)
+	}
+	if got := NewAttribute("duration").Intrinsic; got != IntrinsicNone {
+		t.Errorf("NewAttribute(duration).Intrinsic = %v; want IntrinsicNone", got)
 	}
 	if got := NewAttribute("http.method").Intrinsic; got != IntrinsicNone {
 		t.Errorf("NewAttribute(http.method).Intrinsic = %v; want IntrinsicNone", got)

--- a/test/perf/cardinality-baseline.json
+++ b/test/perf/cardinality-baseline.json
@@ -7469,6 +7469,39 @@
     "uncountable_levels": 0
   },
   {
+    "fixture": "traceql/edge_attr_dotted_duration_collision",
+    "fan_factor": 1,
+    "scan_rows": 1,
+    "peak_intermediate": 1,
+    "has_cross_join": false,
+    "has_array_join": false,
+    "has_recursive_cte": false,
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
+  },
+  {
+    "fixture": "traceql/edge_attr_dotted_name_collision",
+    "fan_factor": 1,
+    "scan_rows": 1,
+    "peak_intermediate": 1,
+    "has_cross_join": false,
+    "has_array_join": false,
+    "has_recursive_cte": false,
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
+  },
+  {
+    "fixture": "traceql/edge_attr_dotted_status_collision",
+    "fan_factor": 1,
+    "scan_rows": 1,
+    "peak_intermediate": 1,
+    "has_cross_join": false,
+    "has_array_join": false,
+    "has_recursive_cte": false,
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
+  },
+  {
     "fixture": "traceql/edge_attr_resource_le",
     "fan_factor": 1,
     "scan_rows": 2,

--- a/test/spec/traceql/edge_attr_dotted_duration_collision.txtar
+++ b/test/spec/traceql/edge_attr_dotted_duration_collision.txtar
@@ -1,0 +1,23 @@
+-- query.traceql --
+{ .duration = "slow" }
+-- args --
+[0] string = "duration"
+[1] string = "slow"
+-- sql --
+SELECT * FROM `otel_traces` WHERE (`SpanAttributes`[?] = ?)
+-- seed --
+CREATE TABLE otel_traces (
+    Duration UInt64,
+    SpanAttributes Map(String, String) MATERIALIZED if(Duration = 10000000, map('duration', 'slow'), if(Duration = 20000000, map('duration', 'fast'), map()))
+) ENGINE = MergeTree ORDER BY Duration;
+INSERT INTO otel_traces (Duration) VALUES
+    (10000000),
+    (20000000),
+    (30000000);
+-- expected_rows --
+[
+  ["", {"__cerberus_parentSpanID": "", "__cerberus_spanID": "", "__cerberus_traceID": ""}, "1970-01-01T00:00:00Z", 10000000]
+]
+-- chplan --
+Filter predicate=(SpanAttributes["duration"] = "slow")
+  Scan(otel_traces)

--- a/test/spec/traceql/edge_attr_dotted_name_collision.txtar
+++ b/test/spec/traceql/edge_attr_dotted_name_collision.txtar
@@ -1,0 +1,24 @@
+-- query.traceql --
+{ .name = "checkout" }
+-- args --
+[0] string = "name"
+[1] string = "checkout"
+-- sql --
+SELECT * FROM `otel_traces` WHERE (`SpanAttributes`[?] = ?)
+-- seed --
+CREATE TABLE otel_traces (
+    Duration UInt64,
+    SpanName String,
+    SpanAttributes Map(String, String) MATERIALIZED if(Duration = 10000000, map('name', 'checkout'), if(Duration = 20000000, map('name', 'billing'), map()))
+) ENGINE = MergeTree ORDER BY Duration;
+INSERT INTO otel_traces (Duration, SpanName) VALUES
+    (10000000, 'checkout-span'),
+    (20000000, 'billing-span'),
+    (30000000, 'other-span');
+-- expected_rows --
+[
+  ["checkout-span", {"__cerberus_parentSpanID": "", "__cerberus_spanID": "", "__cerberus_traceID": ""}, "1970-01-01T00:00:00Z", 10000000]
+]
+-- chplan --
+Filter predicate=(SpanAttributes["name"] = "checkout")
+  Scan(otel_traces)

--- a/test/spec/traceql/edge_attr_dotted_status_collision.txtar
+++ b/test/spec/traceql/edge_attr_dotted_status_collision.txtar
@@ -1,0 +1,24 @@
+-- query.traceql --
+{ .status = "degraded" }
+-- args --
+[0] string = "status"
+[1] string = "degraded"
+-- sql --
+SELECT * FROM `otel_traces` WHERE (`SpanAttributes`[?] = ?)
+-- seed --
+CREATE TABLE otel_traces (
+    Duration UInt64,
+    StatusCode String,
+    SpanAttributes Map(String, String) MATERIALIZED if(Duration = 10000000, map('status', 'degraded'), if(Duration = 20000000, map('status', 'healthy'), map()))
+) ENGINE = MergeTree ORDER BY Duration;
+INSERT INTO otel_traces (Duration, StatusCode) VALUES
+    (10000000, 'Ok'),
+    (20000000, 'Ok'),
+    (30000000, 'Ok');
+-- expected_rows --
+[
+  ["", {"__cerberus_parentSpanID": "", "__cerberus_spanID": "", "__cerberus_traceID": ""}, "1970-01-01T00:00:00Z", 10000000]
+]
+-- chplan --
+Filter predicate=(SpanAttributes["status"] = "degraded")
+  Scan(otel_traces)


### PR DESCRIPTION
## Summary

- `NewAttribute` (the sole constructor for the dotted `.name` attribute form, called only by `tokDot` in `internal/traceql/ast/parser.go`) resolved an intrinsic whenever the attribute's name collided with an intrinsic identifier, so `.name`, `.duration`, `.status`, etc. silently lowered to the intrinsic column (`SpanName`, `Duration`, `StatusCode`) instead of `SpanAttributes[...]`.
- Upstream Tempo's own `NewAttribute` always pins `Intrinsic: IntrinsicNone` for the dotted form — only the bare identifier (via dedicated grammar productions) and `NewIntrinsic` resolve intrinsics. `NewScopedAttribute` already guarded this correctly for `resource.` / `span.` / `parent.`; `NewAttribute` did not.
- Verified `NewAttribute` has exactly one non-test caller repo-wide, so the fix changes it in place rather than adding a sibling constructor (per the issue's guidance to check callers first).
- Added TXTAR fixtures (`test/spec/traceql/edge_attr_dotted_{name,duration,status}_collision.txtar`) pinning the `SpanAttributes[...]` lowering, verified against chDB via the `expected_rows` roundtrip.
- Added a `compatibility/tempo` corpus case (`dotted_attr_name_collision`) plus a seeded root-span attribute literally named `name` so the differential harness now covers this collision going forward.

## Test plan

- [x] `go test ./internal/traceql/...` (unit + Layer 2a spec lowering)
- [x] `go test -tags chdb ./internal/traceql/...` — new fixtures pass their chDB `expected_rows` roundtrip
- [x] `go build ./...`, `go vet ./internal/traceql/... ./compatibility/tempo/...`
- [x] `cd compatibility/tempo/driver && go build ./... && go test ./...`
- [x] lefthook pre-push (golangci-lint, forbid-sql-raw, forbid-skip, markdownlint, commitlint) — all green
- [ ] CI: `compatibility/tempo` job exercises the new corpus case against reference Tempo

Closes #1598

🤖 Generated with [Claude Code](https://claude.com/claude-code)