### PR TITLE
fix(chplan): honor RangeWindow.Offset when widening a spine's input grid

### DIFF
--- a/internal/chplan/range_window.go
+++ b/internal/chplan/range_window.go
@@ -199,6 +199,34 @@ func (r *RangeWindow) NumAnchors() int64 {
 	return r.OuterRange.Nanoseconds()/r.Step.Nanoseconds() + 1
 }
 
+// InputWindow returns the [start, end) bound r's OWN Input spine must be
+// widened to so every anchor r evaluates across [start, end] finds every
+// sample its window needs. This is the SINGLE owner of the "how far back
+// does a RangeWindow's input need to reach" arithmetic: every re-anchoring /
+// widening / grid-prediction pass that walks below a RangeWindow (chplan's
+// own ReanchorRange, promql's widenSubquerySpine, and the solver planner's
+// grid-prediction walk) calls this instead of re-deriving the formula, so
+// the three stay consistent by construction — see issue #1464, where the
+// RangeWindow arm of ReanchorRange re-derived `start.Add(-r.Range)` locally
+// and silently dropped the Offset term the RangeLWR arm got right.
+//
+// A matrix-shape window (Step > 0) reduces the samples in
+// `(anchor-Offset-Range, anchor-Offset]` at each anchor (the package doc
+// above documents the scanned span as [End-Offset-Range, End-Offset]), so
+// the union across every anchor in [start, end] needs input covering
+// [start-Offset-Range, end]. Offset enters with its sign, mirroring the
+// emitter's own maybePushInnerScanTimeBounds (internal/chsql/range_window.go)
+// and RangeLWR's Offset+Lookback widening. An instant-shape window (Step <=
+// 0) resolves a single anchor itself and is never walked below by these
+// passes; InputWindow returns (start, end) unchanged for it so a caller that
+// invokes it unconditionally is still safe.
+func (r *RangeWindow) InputWindow(start, end time.Time) (time.Time, time.Time) {
+	if r.Step <= 0 {
+		return start, end
+	}
+	return start.Add(-r.Offset - r.Range), end
+}
+
 func (r *RangeWindow) Equal(other Node) bool {
 	o, ok := other.(*RangeWindow)
 	if !ok {

--- a/internal/chplan/reanchor.go
+++ b/internal/chplan/reanchor.go
@@ -17,8 +17,8 @@ var ErrReanchorGridMismatch = errors.New("chplan: windowed node bounds do not ma
 
 // ReanchorRange returns a re-anchored view of n whose windowed spine is
 // re-anchored to evaluate one row per anchor across [start, end], with each
-// matrix RangeWindow's own input spine widened by a further Range of lookback
-// so every anchor finds the samples it needs.
+// matrix RangeWindow's own input spine widened per RangeWindow.InputWindow
+// (Offset+Range of lookback) so every anchor finds the samples it needs.
 //
 // It is the head-agnostic, no-mutate generalization of
 // promql.widenSubquerySpine (internal/promql/subquery.go): where
@@ -66,11 +66,12 @@ var ErrReanchorGridMismatch = errors.New("chplan: windowed node bounds do not ma
 // Spine shape mirrors widenSubquerySpine exactly so the two stay
 // equivalent on post-optimizer plans (pinned by the equivalence test in
 // internal/promql): matrix RangeWindows (Step > 0) re-anchor and recurse
-// into their input with start.Add(-Range); instant RangeWindows (Step == 0)
-// terminate the walk; the wrapper nodes the subquery lowerings interpose
-// (Project / Aggregate / TopK / Filter) pass the requirement through
-// unchanged. Every other node type is SHARED verbatim (the original pointer,
-// not a copy) — it is below the spine and does not move in time.
+// into their input via RangeWindow.InputWindow (start.Add(-Offset-Range));
+// instant RangeWindows (Step == 0) terminate the walk; the wrapper nodes the
+// subquery lowerings interpose (Project / Aggregate / TopK / Filter) pass
+// the requirement through unchanged. Every other node type is SHARED
+// verbatim (the original pointer, not a copy) — it is below the spine and
+// does not move in time.
 //
 // RangeLWR (the bare-selector last-with-respect-to leaf, the deriv / idelta /
 // irate / instant-LWR / negative-offset families) re-anchors the same way:
@@ -104,9 +105,13 @@ func reanchor(n Node, start, end time.Time) (Node, error) {
 		c.Start = start
 		c.End = end
 		c.OuterRange = end.Sub(start)
-		// Each of this window's anchors looks back v.Range; widen the input
-		// spine by that much so the inner grid covers every anchor's window.
-		input, err := reanchor(v.Input, start.Add(-v.Range), end)
+		// Each of this window's anchors looks back Offset+Range (the window
+		// is [End-Offset-Range, End-Offset], see the RangeWindow doc comment
+		// above); widen the input spine by that much via the single shared
+		// owner of this arithmetic so the inner grid covers every anchor's
+		// window.
+		inStart, inEnd := v.InputWindow(start, end)
+		input, err := reanchor(v.Input, inStart, inEnd)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/chplan/reanchor_test.go
+++ b/internal/chplan/reanchor_test.go
@@ -91,6 +91,49 @@ func TestReanchorRange_NestedSpineWidens(t *testing.T) {
 	}
 }
 
+// TestReanchorRange_NestedSpineWidensWithOffset is the offset-carrying
+// sibling of TestReanchorRange_NestedSpineWidens (#1464): the outer
+// RangeWindow's `offset` modifier must widen the inner spine's Start by
+// Offset+Range, not Range alone — RangeWindow.InputWindow is the single
+// owner of that arithmetic (mirrors RangeLWR's Offset+Lookback widening).
+// Before the fix, the RangeWindow arm of ReanchorRange silently dropped
+// Offset and under-scanned the inner spine.
+func TestReanchorRange_NestedSpineWidensWithOffset(t *testing.T) {
+	t.Parallel()
+
+	inner := matrixWindow(time.Minute, 30*time.Second, 0)
+	outer := &chplan.RangeWindow{
+		Input:           inner,
+		Func:            "max_over_time",
+		Range:           5 * time.Minute,
+		Offset:          10 * time.Minute,
+		Step:            time.Minute,
+		TimestampColumn: "anchor_ts",
+		ValueColumn:     "Value",
+		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+	}
+
+	start := time.Unix(10_000, 0).UTC()
+	end := time.Unix(20_000, 0).UTC()
+	out, err := chplan.ReanchorRange(outer, start, end)
+	if err != nil {
+		t.Fatalf("ReanchorRange: %v", err)
+	}
+	gotOuter := out.(*chplan.RangeWindow)
+	if !gotOuter.Start.Equal(start) || !gotOuter.End.Equal(end) {
+		t.Fatalf("outer not re-anchored to [%v,%v], got [%v,%v]", start, end, gotOuter.Start, gotOuter.End)
+	}
+	gotInner := gotOuter.Input.(*chplan.RangeWindow)
+	wantInnerStart := start.Add(-outer.Offset - outer.Range)
+	if !gotInner.Start.Equal(wantInnerStart) || !gotInner.End.Equal(end) {
+		t.Fatalf("inner not widened by Offset+Range: want Start=%v End=%v, got Start=%v End=%v",
+			wantInnerStart, end, gotInner.Start, gotInner.End)
+	}
+	if gotInner.OuterRange != end.Sub(wantInnerStart) {
+		t.Fatalf("inner OuterRange wrong: %v", gotInner.OuterRange)
+	}
+}
+
 // TestReanchorRange_RejectsAtPin asserts an @-pinned matrix window (End
 // already set to a value that is NOT the predicted grid End) is rejected so
 // the solver routes A.

--- a/internal/promql/reanchor_equivalence_test.go
+++ b/internal/promql/reanchor_equivalence_test.go
@@ -67,6 +67,11 @@ func TestReanchorRange_EquivalentToWidenSubquerySpine(t *testing.T) {
 		// Binary-inner subquery: the inner is evaluated per anchor on the
 		// epoch-aligned sub-step grid, so its grid is pinned at lowering.
 		{query: `max_over_time((demo_cpu * 2)[5m:1m])`, pinnedInner: true},
+		// Offset-carrying subquery (#1464): the outer reducer's own
+		// `offset` modifier must widen the inner spine by Offset+Range,
+		// not Range alone — this is what the RangeWindow arm of both
+		// ReanchorRange and widenSubquerySpine silently dropped.
+		{query: `max_over_time(rate(demo_cpu[1m])[5m:30s] offset 10m)`},
 	}
 
 	s := schema.DefaultOTelMetrics()
@@ -110,9 +115,12 @@ func TestReanchorRange_EquivalentToWidenSubquerySpine(t *testing.T) {
 			optimized := driver.Run(context.Background(), inner)
 			snapshot := chplan.CloneNode(optimized) // pre-pass reference
 
-			// widenSubquerySpine is called with [start.Add(-sub.Range), end]
-			// (lowerOuterRangeFnOverSubquery). Mirror that exactly.
-			wStart := start.Add(-sub.Range)
+			// widenSubquerySpine is called with
+			// [start.Add(-rw.Offset-sub.Range), end]
+			// (lowerOuterRangeFnOverSubquery, #1464). rw.Offset is always
+			// sub.OriginalOffset (subqueryAnchor sets it unconditionally).
+			// Mirror that exactly.
+			wStart := start.Add(-sub.OriginalOffset).Add(-sub.Range)
 
 			widenClone := chplan.CloneNode(optimized)
 			widenSubquerySpine(widenClone, wStart, end)

--- a/internal/promql/subquery.go
+++ b/internal/promql/subquery.go
@@ -541,7 +541,11 @@ func lowerOuterRangeFnOverSubquery(
 		// per-series value across the step grid. The range-vector sibling
 		// of this guard lives in `lowerRangeVectorCall`.
 		rw.End = anchor.End
-		widenSubquerySpine(inner, anchor.End.Add(-sub.Range), anchor.End)
+		// Widen by Offset+Range, matching RangeWindow.InputWindow (#1464) —
+		// rw.Step is still 0 here (this branch keeps the outer reducer
+		// instant-shaped), so InputWindow's Step<=0 guard can't be reused
+		// directly; the same Offset+Range arithmetic is inlined instead.
+		widenSubquerySpine(inner, anchor.End.Add(-rw.Offset-sub.Range), anchor.End)
 		// The subquery spine groups by Attributes alone, so MetricName is
 		// already gone by the time this outer reducer runs — a preserving
 		// fn can only stamp the empty literal here. Widening the spine to
@@ -590,7 +594,10 @@ func lowerOuterRangeFnOverSubquery(
 		// `max_over_time(sum(demo_memory_usage_bytes + ...)[5m:1m])`
 		// (and the stddev / quantile / nested-irate siblings) returned
 		// [] on query_range while instant answers were correct.
-		widenSubquerySpine(inner, ctx.start.Add(-sub.Range), ctx.end)
+		// Widen by Offset+Range, matching RangeWindow.InputWindow (#1464):
+		// the outer's own Offset (rw.Offset, from the subquery's `offset`
+		// modifier) shifts every anchor's window back by that much too.
+		widenSubquerySpine(inner, ctx.start.Add(-rw.Offset-sub.Range), ctx.end)
 	default:
 		// Instant eval (no query_range grid): the outer reducer collapses to a
 		// single anchor at anchor.End (now concrete via subqueryAnchor's eval-ts
@@ -603,7 +610,9 @@ func lowerOuterRangeFnOverSubquery(
 		// ts keeps the outer reducer and the widened inner grid on one base.
 		if !anchor.End.IsZero() {
 			rw.End = anchor.End
-			widenSubquerySpine(inner, anchor.End.Add(-sub.Range), anchor.End)
+			// Widen by Offset+Range, matching RangeWindow.InputWindow and the
+			// range-mode branch above (#1464).
+			widenSubquerySpine(inner, anchor.End.Add(-rw.Offset-sub.Range), anchor.End)
 		}
 	}
 	return rw, nil
@@ -612,11 +621,11 @@ func lowerOuterRangeFnOverSubquery(
 // widenSubquerySpine threads the range-mode evaluation window down a
 // lowered subquery plan's spine: every matrix RangeWindow on the spine
 // is re-anchored to emit one row per anchor across [start, end], and
-// its OWN input spine widens by a further window.Range of lookback so
-// each of its anchors finds the samples it needs. Wrapper nodes the
-// subquery lowerings interpose (Project / Aggregate / TopK / Filter)
-// pass the requirement through unchanged — they reshape rows per
-// anchor but don't move time.
+// its OWN input spine widens per RangeWindow.InputWindow (Offset+Range of
+// lookback — the window is [End-Offset-Range, End-Offset]) so each of its
+// anchors finds the samples it needs. Wrapper nodes the subquery lowerings
+// interpose (Project / Aggregate / TopK / Filter) pass the requirement
+// through unchanged — they reshape rows per anchor but don't move time.
 //
 // Instant-shape RangeWindows (Step == 0) terminate the walk: they
 // resolve a single anchor themselves and appear only below shapes
@@ -642,7 +651,12 @@ func widenSubquerySpine(n chplan.Node, start, end time.Time) {
 		// it correctly keeps StepAlign=false (the outer query_range grid
 		// uses user start + k*step, not epoch-aligned).
 		v.StepAlign = true
-		widenSubquerySpine(v.Input, start.Add(-v.Range), end)
+		// Widen by Offset+Range of lookback (the window is
+		// [End-Offset-Range, End-Offset]) via the single shared owner of this
+		// arithmetic — chplan.ReanchorRange and the solver planner's grid
+		// prediction call the same method so all three stay consistent (#1464).
+		inStart, inEnd := v.InputWindow(start, end)
+		widenSubquerySpine(v.Input, inStart, inEnd)
 	case *chplan.Project:
 		widenSubquerySpine(v.Input, start, end)
 	case *chplan.Aggregate:

--- a/internal/promql/subquery_time_offset_test.go
+++ b/internal/promql/subquery_time_offset_test.go
@@ -1,6 +1,7 @@
 package promql
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -53,6 +54,85 @@ func TestLowerSubqueryOverBinary_ShiftsSyntheticGridForOffset(t *testing.T) {
 	if !grid.End.Equal(wantEnd) {
 		t.Errorf("StepGrid.End = %s, want %s", grid.End, wantEnd)
 	}
+}
+
+// TestLowerOuterRangeFnOverSubquery_WidensInnerByOffsetPlusRange is the
+// direct-pipeline regression for #1464's route-A audit: three call sites in
+// lowerOuterRangeFnOverSubquery (the pinned, range-mode, and instant/default
+// branches) widened a subquery's inner matrix spine by `sub.Range` alone,
+// silently dropping the outer reducer's own `offset` modifier. Each
+// sub-test lowers a `max_over_time(rate(m[5m])[1h:5m] offset 10m)`-shaped
+// query through the real entrypoint (LowerAtRange / LowerAt) and asserts
+// the inner RangeWindow's widened Start honors Offset+Range.
+func TestLowerOuterRangeFnOverSubquery_WidensInnerByOffsetPlusRange(t *testing.T) {
+	t.Parallel()
+
+	const query = `max_over_time(rate(demo_cpu[5m])[1h:5m] offset 10m)`
+	offset := 10 * time.Minute
+	subRange := time.Hour
+	s := schema.DefaultOTelMetrics()
+
+	expr, err := parser.NewParser(parser.Options{}).ParseExpr(query)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", query, err)
+	}
+
+	t.Run("range mode", func(t *testing.T) {
+		t.Parallel()
+		start := time.Unix(1_700_000_000, 0).UTC()
+		end := start.Add(2 * time.Hour)
+		plan, err := LowerAtRange(context.Background(), expr, s, start, end, time.Minute)
+		if err != nil {
+			t.Fatalf("LowerAtRange(%q): %v", query, err)
+		}
+		outer, ok := plan.(*chplan.RangeWindow)
+		if !ok {
+			t.Fatalf("plan is %T, want *chplan.RangeWindow", plan)
+		}
+		inner := firstRangeWindow(outer.Input)
+		if inner == nil {
+			t.Fatal("no inner RangeWindow found under outer.Input")
+		}
+		wantStart := start.Add(-offset - subRange)
+		if !inner.Start.Equal(wantStart) {
+			t.Errorf("inner.Start = %s, want %s (start - offset - subRange)", inner.Start, wantStart)
+		}
+	})
+
+	t.Run("instant mode", func(t *testing.T) {
+		t.Parallel()
+		evalTS := time.Unix(1_700_010_000, 0).UTC()
+		plan, err := LowerAt(context.Background(), expr, s, evalTS, evalTS)
+		if err != nil {
+			t.Fatalf("LowerAt(%q): %v", query, err)
+		}
+		outer, ok := plan.(*chplan.RangeWindow)
+		if !ok {
+			t.Fatalf("plan is %T, want *chplan.RangeWindow", plan)
+		}
+		inner := firstRangeWindow(outer.Input)
+		if inner == nil {
+			t.Fatal("no inner RangeWindow found under outer.Input")
+		}
+		wantStart := evalTS.Add(-offset - subRange)
+		if !inner.Start.Equal(wantStart) {
+			t.Errorf("inner.Start = %s, want %s (evalTS - offset - subRange)", inner.Start, wantStart)
+		}
+	})
+}
+
+// firstRangeWindow depth-first searches for the first *chplan.RangeWindow
+// reachable from n (n itself included).
+func firstRangeWindow(n chplan.Node) *chplan.RangeWindow {
+	if rw, ok := n.(*chplan.RangeWindow); ok {
+		return rw
+	}
+	for _, child := range n.Children() {
+		if rw := firstRangeWindow(child); rw != nil {
+			return rw
+		}
+	}
+	return nil
 }
 
 func firstStepGrid(plan chplan.Node) *chplan.StepGrid {

--- a/internal/solver/planner.go
+++ b/internal/solver/planner.go
@@ -432,13 +432,12 @@ func (p *Planner) walkNode(n chplan.Node, predStart, predEnd time.Time, depth in
 		for _, e := range v.ScalarExprs {
 			p.walkExpr(e, sig)
 		}
-		// Recurse into the inner spine widened by Range (mirrors
-		// ReanchorRange / widenSubquerySpine).
-		if v.Step > 0 {
-			p.walkNode(v.Input, predStart.Add(-v.Range), predEnd, depth+1, sig)
-		} else {
-			p.walkNode(v.Input, predStart, predEnd, depth+1, sig)
-		}
+		// Recurse into the inner spine widened via the single shared owner
+		// of this arithmetic (mirrors ReanchorRange / widenSubquerySpine) so
+		// the grid this predicts for the child matches what re-anchoring
+		// actually produces — including the Offset term (#1464).
+		inStart, inEnd := v.InputWindow(predStart, predEnd)
+		p.walkNode(v.Input, inStart, inEnd, depth+1, sig)
 		return
 
 	case *chplan.RangeLWR:

--- a/internal/solver/slicer_test.go
+++ b/internal/solver/slicer_test.go
@@ -477,3 +477,82 @@ func TestSliceLWR_OffSpineIsShared(t *testing.T) {
 		}
 	}
 }
+
+// nestedOnSpineWindowPlan builds a two-level ON-SPINE matrix RangeWindow —
+// an outer RangeWindow (with the given Offset) whose Input is ANOTHER
+// RangeWindow directly on the spine (the `max_over_time(rate(m[5m])[1h:5m]
+// offset X)`-shaped route-B carrier). Distinct from nestedSubqueryWindowPlan
+// above, which nests through an OFF-spine TopK.KExpr child.
+func nestedOnSpineWindowPlan(start, end time.Time, step, rang, outerRange, offset time.Duration) chplan.Node {
+	inner := &chplan.RangeWindow{
+		Input:           &chplan.Scan{Table: "metrics", Columns: []string{"Value", "TimeUnix"}},
+		Func:            "rate",
+		Range:           rang,
+		Step:            30 * time.Second,
+		TimestampColumn: "TimeUnix",
+		ValueColumn:     "Value",
+		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+	}
+	return &chplan.RangeWindow{
+		Input:           inner,
+		Func:            "max_over_time",
+		Range:           outerRange,
+		Offset:          offset,
+		Step:            step,
+		OuterRange:      end.Sub(start),
+		Start:           start,
+		End:             end,
+		TimestampColumn: "anchor_ts",
+		ValueColumn:     "Value",
+		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+	}
+}
+
+// TestSlice_NestedOnSpineWidensWithOffset is the route-B regression for
+// #1464: an ON-spine nested matrix RangeWindow (outer wraps another
+// RangeWindow directly as Input, both on the spine) whose OUTER carries a
+// nonzero Offset must widen the INNER's re-anchored Start by Offset+Range
+// per shard, not Range alone. Before the fix, ReanchorRange's RangeWindow
+// arm re-derived `start.Add(-Range)` locally and silently dropped Offset,
+// under-scanning the inner spine on every shard whenever the outer carried
+// an `offset` modifier.
+func TestSlice_NestedOnSpineWidensWithOffset(t *testing.T) {
+	t.Parallel()
+	p := &Planner{Cfg: autoCfg()}
+	start := time.Unix(1_700_000_000, 0).UTC()
+	step := time.Minute
+	end := start.Add(time.Hour)
+	outerRange := 5 * time.Minute
+	offset := 10 * time.Minute
+	meta := RequestMeta{Lang: "promql", Start: start, End: end, Step: step}
+
+	plan := nestedOnSpineWindowPlan(start, end, step, time.Minute, outerRange, offset)
+
+	slices, err := p.slice(plan, meta, 4)
+	if err != nil {
+		t.Fatalf("slice: %v", err)
+	}
+	if len(slices) < 2 {
+		t.Fatalf("expected >= 2 slices, got %d", len(slices))
+	}
+
+	for i, s := range slices {
+		outer, ok := s.Plan.(*chplan.RangeWindow)
+		if !ok {
+			t.Fatalf("slice %d Plan is %T, want *chplan.RangeWindow", i, s.Plan)
+		}
+		if !outer.Start.Equal(s.Start) || !outer.End.Equal(s.End) {
+			t.Fatalf("slice %d outer not re-gridded: Start=%v End=%v want [%v,%v]",
+				i, outer.Start, outer.End, s.Start, s.End)
+		}
+		inner, ok := outer.Input.(*chplan.RangeWindow)
+		if !ok {
+			t.Fatalf("slice %d outer.Input is %T, want *chplan.RangeWindow", i, outer.Input)
+		}
+		wantInnerStart := s.Start.Add(-offset - outerRange)
+		if !inner.Start.Equal(wantInnerStart) || !inner.End.Equal(s.End) {
+			t.Fatalf("slice %d inner not widened by Offset+Range: want Start=%v End=%v, got Start=%v End=%v",
+				i, wantInnerStart, s.End, inner.Start, inner.End)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`ReanchorRange` (route B re-anchoring) ignored `RangeWindow.Offset` when widening a spine's input grid, causing route B to under-scan an offset-carrying spine by exactly the offset — a live wrong-answer bug for queries like `sum(rate(m[5m] offset 10m))` sliced across shards. The bug was invisible because the solver's own grid-prediction fail-closed guard (`planner.go`'s `walkNode`) computed the *same* wrong formula, so actual and predicted bounds always agreed.

Per #1464, this fixes the class rather than the single call site: `chplan.RangeWindow.InputWindow(start, end)` is now the single owner of "how far back must this RangeWindow's input reach," and every site that independently duplicated that arithmetic now calls it:

- `internal/chplan/reanchor.go` — the `RangeWindow` arm of `ReanchorRange`.
- `internal/solver/planner.go` — `walkNode`'s `RangeWindow` arm (the grid-prediction guard).
- `internal/promql/subquery.go` — `widenSubquerySpine`'s `RangeWindow` arm, plus (per the issue's explicit route-A audit requirement) the three call sites inside `lowerOuterRangeFnOverSubquery` (pinned / range-mode / instant-default branches) that widen a subquery's inner spine for an offset-carrying outer reducer, e.g. `max_over_time(rate(m[5m])[1h:5m] offset 10m)`.

## Route-A audit (issue's explicit ask)

The issue says fixing route B alone isn't enough — route A's identical widening needs the same audit. I traced every `sub.Range`-adjacent widen site in `subquery.go` and classified each:

- **Fixed here**: the three `lowerOuterRangeFnOverSubquery` call sites above.
- **Already correct, unchanged**: `subqueryGridCtx` already applies `Offset` uniformly to both bounds.
- **Out of scope, filed as #1732**: `lowerSubqueryOverAbsent` drops the subquery's `offset` modifier entirely (not a wrong-formula bug — total omission); `lowerSubqueryOverSubquery`/`lowerSubqueryOverCallSubquery` (nested subquery-of-subquery) don't fold the outer's Offset into the inner grid ctx, plus a possibly-separate `Start`-field gap worth auditing. Also filed: the identical but currently-inert `RangeWindowNative`/`AbsentOverTime` duplicates in `planner.go` (both non-reanchorable, so no live consequence), and the `carrierGeometryOf` cost-estimate (not correctness) gap.

## Tests

- `internal/chplan/reanchor_test.go`: `TestReanchorRange_NestedSpineWidensWithOffset` — asserts `ReanchorRange` widens a nested RangeWindow's input to `start.Add(-Offset-Range)`.
- `internal/solver/slicer_test.go`: `TestSlice_NestedOnSpineWidensWithOffset` — asserts the solver's per-shard slicing widens the same way across 4 shards.
- `internal/promql/reanchor_equivalence_test.go`: added an offset-carrying case to the existing `ReanchorRange`-vs-`widenSubquerySpine` equivalence suite.
- `internal/promql/subquery_time_offset_test.go`: `TestLowerOuterRangeFnOverSubquery_WidensInnerByOffsetPlusRange` — end-to-end regression through the real `LowerAtRange`/`LowerAt` entry points (both range and instant mode) for `max_over_time(rate(demo_cpu[5m])[1h:5m] offset 10m)`.

No existing TXTAR golden fixture exercises the `<outer-fn>(<subquery-with-own-offset>)` shape this PR touches, so no golden regeneration was needed.

## Follow-up

Deferred items tracked in #1732 (filed before arming auto-merge), none of which are live wrong-answer bugs today.

Fixes #1464
