### PR TITLE
fix(promql): collapse info() series sharing one identity signature

### DIFF
--- a/internal/api/prom/handler.go
+++ b/internal/api/prom/handler.go
@@ -1093,7 +1093,7 @@ func classifyEngineError(err error) error {
 	if chsql.IsInfoConflictingLabelError(err) {
 		return &apiError{
 			Kind:   ErrExecution,
-			Err:    errors.New(chsql.InfoConflictingLabelMessage),
+			Err:    errors.New(chplan.InfoConflictingLabelMessage),
 			Status: http.StatusUnprocessableEntity,
 		}
 	}

--- a/internal/api/prom/handler_chdb_info_conflict_test.go
+++ b/internal/api/prom/handler_chdb_info_conflict_test.go
@@ -16,6 +16,13 @@
 // These tests pin the observable contract at the wire: a conflict is a
 // 422 execution error naming the conflict, not a 200 carrying a coin
 // flip, and not a 502 blaming the backend.
+//
+// TestInfo_SignatureTie_ChDB below exercises a DIFFERENT abort sharing the
+// same message and classifier: two info series collapsing onto the same
+// (metric name, identity labels) signature (internal/promql's
+// collapseInfoSeriesBySignature, issue #1630) that also tie exactly on the
+// winning timestamp. That case never reaches MergeInfoMetrics — it aborts
+// one join arm earlier, before the two sides even merge.
 
 package prom_test
 
@@ -29,7 +36,7 @@ import (
 	"time"
 
 	"github.com/tsouza/cerberus/internal/api/prom"
-	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/chplan"
 )
 
 // infoConflictSeedTime is the instant both the seed and the query use, so
@@ -99,9 +106,9 @@ func TestInfo_ConflictingLabel_ChDB(t *testing.T) {
 	if parsed.ErrorType != prom.ErrExecution {
 		t.Fatalf("errorType: got %q, want %q; body=%s", parsed.ErrorType, prom.ErrExecution, body)
 	}
-	if !strings.Contains(parsed.Error, chsql.InfoConflictingLabelMessage) {
+	if !strings.Contains(parsed.Error, chplan.InfoConflictingLabelMessage) {
 		t.Fatalf("error: got %q, want it to name %q; body=%s",
-			parsed.Error, chsql.InfoConflictingLabelMessage, body)
+			parsed.Error, chplan.InfoConflictingLabelMessage, body)
 	}
 	// A ClickHouse stack frame leaking to the client would mean the abort
 	// was forwarded rather than translated.
@@ -154,5 +161,62 @@ func TestInfo_NonConflictingMerge_ChDB(t *testing.T) {
 		if got := vec[0].Metric[k]; got != want {
 			t.Errorf("label %q: got %q, want %q; metric=%v", k, got, want, vec[0].Metric)
 		}
+	}
+}
+
+// infoSignatureTieQuery enriches from the single default `target_info`
+// info metric, so InfoJoin.MergeInfoMetrics is false and the only guard
+// that can fire is collapseInfoSeriesBySignature's per-signature
+// timestamp-tie throwIf — isolating it from the merge-conflict guard the
+// two tests above pin.
+const infoSignatureTieQuery = `info(up)`
+
+// TestInfo_SignatureTie_ChDB drives issue #1630's repro shape end to end:
+// two `target_info` series sharing the `{instance, job}` identity
+// signature but differing on a data label (`version`). At distinct
+// timestamps the collapse must keep only the newer sample (this half is
+// pinned by test/spec/promql/info_signature_collapse_keeps_newest.txtar's
+// chDB roundtrip); at the EXACT SAME timestamp there is no newer sample to
+// prefer, so the query must abort rather than pick one of the two
+// arbitrarily — the same 422/execution/IsInfoConflictingLabelError
+// contract TestInfo_ConflictingLabel_ChDB pins for the other guard.
+func TestInfo_SignatureTie_ChDB(t *testing.T) {
+	ts := infoConflictSeedTime.Format("2006-01-02 15:04:05.000000000")
+	seed := gaugeDDL + fmt.Sprintf(`
+INSERT INTO otel_metrics_gauge VALUES
+    ('up',          map('job', 'api'),                     toDateTime64('%s', 9), 1.0),
+    ('target_info', map('job', 'api', 'version', '1.2.3'), toDateTime64('%s', 9), 1.0),
+    ('target_info', map('job', 'api', 'version', '4.5.6'), toDateTime64('%s', 9), 1.0);`,
+		ts, ts, ts)
+	srv, _ := newChDBServer(t, seed)
+
+	resp, err := http.Get(fmt.Sprintf("%s/api/v1/query?query=%s&time=%d",
+		srv.URL, url.QueryEscape(infoSignatureTieQuery), infoConflictSeedTime.Unix()))
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body := readBody(t, resp)
+
+	if resp.StatusCode != http.StatusUnprocessableEntity {
+		t.Fatalf("status: got %d, want %d; body=%s",
+			resp.StatusCode, http.StatusUnprocessableEntity, body)
+	}
+
+	var parsed prom.Response
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, body)
+	}
+	if parsed.Status != "error" {
+		t.Fatalf("status: got %q, want %q; body=%s", parsed.Status, "error", body)
+	}
+	if parsed.ErrorType != prom.ErrExecution {
+		t.Fatalf("errorType: got %q, want %q; body=%s", parsed.ErrorType, prom.ErrExecution, body)
+	}
+	if !strings.Contains(parsed.Error, chplan.InfoConflictingLabelMessage) {
+		t.Fatalf("error: got %q, want it to name %q; body=%s",
+			parsed.Error, chplan.InfoConflictingLabelMessage, body)
+	}
+	if strings.Contains(parsed.Error, "DB::Exception") {
+		t.Errorf("error leaks the ClickHouse exception: %q", parsed.Error)
 	}
 }

--- a/internal/chplan/aggregate.go
+++ b/internal/chplan/aggregate.go
@@ -48,11 +48,24 @@ func (a AggFunc) Equal(other AggFunc) bool {
 // zeros for aggregate-only queries. PromQL / LogQL set it; TraceQL
 // (whose `| count() = 0` idiom requires a 0 row for empty input) does
 // not. Has no effect when GroupBy is non-empty.
+//
+// Having is an optional post-aggregation predicate rendered as a real SQL
+// `HAVING <Having>` clause. Nil means "no HAVING". This is deliberately
+// NOT the same shape as a runtime guard riding as an extra unreferenced
+// AggFunc in the SELECT list: ClickHouse's column-pruning analyzer drops
+// a SELECT-list expression nothing downstream reads — including a
+// `throwIf(...)` planted purely for its side effect — so a guard that
+// needs to fire unconditionally belongs in Having, where it gates row
+// production and cannot be pruned as dead code. Has no effect when
+// GroupBy is empty and DropEmptyOnNoGroup is set (that path renders a
+// different two-layer shape — see emitAggregateNoGroup); Having and
+// DropEmptyOnNoGroup are not combined by any caller today.
 type Aggregate struct {
 	Input              Node
 	GroupBy            []Expr
 	GroupByAliases     []string
 	AggFuncs           []AggFunc
+	Having             Expr
 	DropEmptyOnNoGroup bool
 }
 
@@ -80,6 +93,12 @@ func (a *Aggregate) Equal(other Node) bool {
 		if !a.AggFuncs[i].Equal(o.AggFuncs[i]) {
 			return false
 		}
+	}
+	if (a.Having == nil) != (o.Having == nil) {
+		return false
+	}
+	if a.Having != nil && !a.Having.Equal(o.Having) {
+		return false
 	}
 	return a.Input.Equal(o.Input)
 }

--- a/internal/chplan/info_join.go
+++ b/internal/chplan/info_join.go
@@ -2,6 +2,35 @@ package chplan
 
 import "slices"
 
+// InfoConflictingLabelMessage is the `throwIf` message a query-time info()
+// abort carries, shared between the lowering layer that plants the guard
+// (internal/promql's collapseInfoSeriesBySignature, internal/chsql's
+// infoConflictGuardFrag) and the classifier that recognises it on the way
+// back out (chsql.IsInfoConflictingLabelError). It lives in chplan — the
+// one layer both promql and chsql already depend on — rather than in
+// chsql, so promql can embed it in a plan expression without importing the
+// SQL-emission layer (see .go-arch-lint.yml: promql may depend on chplan
+// only).
+//
+// Two distinct scenarios raise it, both mirroring the reference engine's
+// refusal to silently pick a winner:
+//
+//   - collapseInfoSeriesBySignature: two ROWS on the info side share one
+//     (metric name, identity labels) signature AND tie exactly on the
+//     greatest timestamp (promql/info.go's "found duplicate series for
+//     info metric").
+//   - infoConflictGuardFrag: two matched info METRICS (MergeInfoMetrics)
+//     disagree on the value of the same data label (promql/info.go's
+//     "conflicting label: %s").
+//
+// Upstream distinguishes the two with different, more specific messages
+// that name the offending series/label; ClickHouse requires `throwIf`'s
+// message to be a compile-time constant, so cerberus can't interpolate
+// per-row detail into it. The observable behaviour both scenarios need —
+// the query aborts instead of returning an arbitrary pick — is what the
+// divergence in wording is about.
+const InfoConflictingLabelMessage = "conflicting label"
+
 // InfoJoin models PromQL's `info(v[, {label matchers}])` label-enrichment
 // join. PromQL's reference engine (promql/info.go::evalInfo) enriches each
 // base series in `v` with the data labels carried by a companion info
@@ -15,9 +44,15 @@ import "slices"
 //     canonical per-series-latest Sample shape (MetricName, Attributes,
 //     TimeUnix, Value).
 //   - Info   — the info-metric scan (default `target_info`, or the name
-//     selected by the second arg's `__name__` matcher), also lowered to
-//     the per-series-latest Sample shape so each base series matches at
-//     most one info series per identity key.
+//     selected by the second arg's `__name__` matcher), lowered through
+//     the same VectorSelector path and then COLLAPSED to one row per
+//     (metric name, identity-label values) signature — see
+//     internal/promql's collapseInfoSeriesBySignature. Two info series
+//     sharing a signature (e.g. two target_info scrapes with the same
+//     job/instance but different build versions) keep only the sample
+//     with the greatest timestamp; an exact tie on that timestamp aborts
+//     the query rather than picking one arbitrarily (mirrors upstream's
+//     combineWithInfoSeries/sigFunction).
 //
 // IdentityLabels are the labels the join keys on — the reference engine
 // hard-codes `{instance, job}`.

--- a/internal/chsql/emit_node.go
+++ b/internal/chsql/emit_node.go
@@ -501,8 +501,16 @@ func (e *emitter) emitAggregate(a *chplan.Aggregate) error {
 			}
 		}
 	}
+	if a.Having != nil {
+		if err := (&Builder{}).Expr(a.Having); err != nil {
+			return err
+		}
+	}
 	if len(a.GroupBy) == 0 && len(a.AggFuncs) == 0 {
 		return fmt.Errorf("%w: Aggregate with no GroupBy keys and no AggFuncs", ErrUnsupported)
+	}
+	if a.Having != nil && len(a.GroupBy) == 0 && a.DropEmptyOnNoGroup {
+		return fmt.Errorf("%w: Aggregate.Having combined with DropEmptyOnNoGroup", ErrUnsupported)
 	}
 
 	sub, err := e.subqueryFrag(a.Input)
@@ -538,6 +546,10 @@ func (e *emitter) emitAggregate(a *chplan.Aggregate) error {
 	// GROUP BY mirrors the SELECT-list group-by keys — see [groupKeyFrags]
 	// for why an aliased key is named by its alias.
 	sb.GroupBy(groupKeyFrags(a.GroupBy, a.GroupByAliases)...)
+	if a.Having != nil {
+		having := a.Having
+		sb.Having(func(b *Builder) { _ = b.Expr(having) })
+	}
 	e.emitSelect(sb)
 	return nil
 }

--- a/internal/chsql/info_join.go
+++ b/internal/chsql/info_join.go
@@ -14,18 +14,6 @@ import (
 // sample's identity and only grows its data labels).
 const infoMetricNameLabel = "__name__"
 
-// InfoConflictingLabelMessage is raised when two info metrics matched by
-// one base sample contribute the same data label with DIFFERENT values.
-// The reference engine fails the query there rather than picking a winner
-// (promql/info.go::combineWithInfoVector's `conflicting label: %s`).
-//
-// Upstream names the offending label; this message cannot, because
-// ClickHouse requires `throwIf`'s message to be a constant string and the
-// conflicting name is only known per row. The observable behaviour — the
-// query fails instead of returning an arbitrary one of the two values —
-// is what the divergence was about.
-const InfoConflictingLabelMessage = "conflicting label"
-
 // chExceptionPrefix is what ClickHouse puts in front of a `throwIf`
 // message when it surfaces the abort to the client:
 // `Code: 395. DB::Exception: <message>: while executing …`.
@@ -40,7 +28,7 @@ const chExceptionPrefix = "DB::Exception: "
 // alongside the message so a query that merely mentions the phrase in a
 // label value cannot be mistaken for one.
 func IsInfoConflictingLabelError(err error) bool {
-	return err != nil && strings.Contains(err.Error(), chExceptionPrefix+InfoConflictingLabelMessage)
+	return err != nil && strings.Contains(err.Error(), chExceptionPrefix+chplan.InfoConflictingLabelMessage)
 }
 
 // infoExtrasKeyElement / infoExtrasValueElement are the 1-based tuple
@@ -156,7 +144,7 @@ func infoConflictGuardFrag(j *chplan.InfoJoin) Frag {
 	distinctPairs := Call("length", Call("arrayDistinct", pairs))
 	distinctKeys := Call("length", Call("arrayDistinct", infoPairElementFrag(pairs, infoExtrasKeyElement)))
 	return Eq(
-		Call("throwIf", Neq(distinctPairs, distinctKeys), InlineLit(InfoConflictingLabelMessage)),
+		Call("throwIf", Neq(distinctPairs, distinctKeys), InlineLit(chplan.InfoConflictingLabelMessage)),
 		InlineLit(int64(0)),
 	)
 }

--- a/internal/promql/info_fn.go
+++ b/internal/promql/info_fn.go
@@ -307,7 +307,11 @@ func infoDropsUnmatched(dataMatchers []*labels.Matcher) bool {
 // so the info side gets the same per-series-latest (LWR) / per-step-
 // matrix treatment as the base vector — and so regex / negated name
 // matchers reuse the same unpinned-name scan fan-out an ordinary
-// `{__name__=~"…"}` selector gets.
+// `{__name__=~"…"}` selector gets. The result is then collapsed to one
+// row per (metric name, identity-label values) signature — see
+// collapseInfoSeriesBySignature — because lowerVectorSelector's
+// per-series-latest shape is keyed on the FULL label set, one level
+// finer than the signature upstream's info() enrichment keys on.
 func lowerInfoMetric(nameMatchers, dataMatchers []*labels.Matcher, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
 	matchers := make([]*labels.Matcher, 0, len(nameMatchers)+len(dataMatchers))
 	matchers = append(matchers, nameMatchers...)
@@ -319,7 +323,144 @@ func lowerInfoMetric(nameMatchers, dataMatchers []*labels.Matcher, s schema.Metr
 		Name:          metricNameFromMatchers(matchers),
 		LabelMatchers: matchers,
 	}
-	return lowerVectorSelector(sel, s, ctx)
+	node, err := lowerVectorSelector(sel, s, ctx)
+	if err != nil {
+		return nil, err
+	}
+	return collapseInfoSeriesBySignature(node, s), nil
+}
+
+// infoSignatureKeyAlias names the synthetic GROUP BY column
+// collapseInfoSeriesBySignature mints for the i-th identity label's
+// extracted value. These never survive past the wrapping Project either —
+// they exist only to make the GROUP BY key for that label addressable in
+// GROUP BY without re-rendering (and thereby risking a shadowed-alias
+// mismatch — see groupKeyFrags).
+func infoSignatureKeyAlias(i int) string {
+	return fmt.Sprintf("_cerberus_info_sig_%d", i)
+}
+
+// infoWinnerAttrsAlias, infoWinnerTimeAlias and infoWinnerValueAlias name
+// the synthetic aggregate-output columns collapseInfoSeriesBySignature
+// mints for the winning row's Attributes / TimeUnix / Value, mirroring the
+// LWR aggregate's lwr_ts/lwr_value convention (see lowerVectorSelector):
+// the wrapping Project is what renames these to the canonical Sample
+// column names, so the aggregate itself never aliases an output to the
+// SAME name as a raw column it also reads.
+//
+// That distinction is load-bearing, not stylistic: aliasing straight to
+// s.AttributesColumn (i.e. `argMax(Attributes, TimeUnix) AS Attributes`)
+// collides with the bare `Attributes` column collapseInfoSeriesBySignature
+// also reads inside the GROUP BY key expressions (`Attributes["instance"]`
+// for the signature columns), and ClickHouse's GROUP BY key elimination
+// then rejects the query with ILLEGAL_AGGREGATION ("argMax(...) AS
+// Attributes is found in GROUP BY"), reading the aggregate's own output
+// alias as if it re-entered the grouping key set.
+const (
+	infoWinnerAttrsAlias = "_cerberus_info_winner_attrs"
+	infoWinnerTimeAlias  = "_cerberus_info_winner_ts"
+	infoWinnerValueAlias = "_cerberus_info_winner_value"
+)
+
+// collapseInfoSeriesBySignature collapses the info side of an info() join
+// down to one row per (metric name, identity-label values) signature,
+// keeping the sample with the greatest timestamp — mirroring the
+// reference engine's combineWithInfoSeries/sigFunction (promql/info.go).
+//
+// lowerVectorSelector produces one row per FULL label set, which is
+// finer-grained than the signature upstream keys on: two info series
+// sharing every identity label but differing on a data label (e.g.
+// target_info{job="api",instance="i1",version="1.2.3"} @ t0 and
+// target_info{job="api",instance="i1",version="4.5.6"} @ t1, t1 > t0) must
+// collapse into the single, newest row rather than fan the join out to
+// both — see issue #1630.
+//
+// An exact tie on the winning timestamp is not picked arbitrarily: CH's
+// argMax is documented as choosing an unspecified one of the tied rows,
+// so the aggregate also computes whether more than one row shares the
+// group's maximum timestamp and, if so, aborts the query with
+// chplan.InfoConflictingLabelMessage — mirroring upstream's "found
+// duplicate series for info metric" error (the shared message is the
+// closest constant-string abort cerberus can raise; see
+// chplan.InfoConflictingLabelMessage's doc for why the wording differs).
+//
+// The tie check rides as a real HAVING clause (`chplan.Aggregate.Having`),
+// not an extra unreferenced SELECT-list column: ClickHouse's analyzer
+// prunes a SELECT expression nothing downstream reads, throwIf side
+// effect included, so a column-shaped guard silently never fires. HAVING
+// gates row production directly and cannot be pruned. See
+// chplan.Aggregate.Having's doc.
+func collapseInfoSeriesBySignature(node chplan.Node, s schema.Metrics) chplan.Node {
+	groupBy := make([]chplan.Expr, 0, 1+len(infoIdentityLabels))
+	groupByAliases := make([]string, 0, 1+len(infoIdentityLabels))
+	groupBy = append(groupBy, &chplan.ColumnRef{Name: s.MetricNameColumn})
+	groupByAliases = append(groupByAliases, s.MetricNameColumn)
+	for i, id := range infoIdentityLabels {
+		groupBy = append(groupBy, attributeLookup(s.AttributesColumn, id))
+		groupByAliases = append(groupByAliases, infoSignatureKeyAlias(i))
+	}
+
+	timeUnix := &chplan.ColumnRef{Name: s.TimestampColumn}
+	maxTimeUnix := &chplan.FuncCall{Name: "max", Args: []chplan.Expr{timeUnix}}
+	tieCount := &chplan.FuncCall{
+		Name: "countEqual",
+		Args: []chplan.Expr{
+			&chplan.FuncCall{Name: "groupArray", Args: []chplan.Expr{timeUnix}},
+			maxTimeUnix,
+		},
+	}
+
+	// throwIf returns 0 on success, so `= 0` is the HAVING gate — the same
+	// idiom internal/chsql/info_join.go's infoConflictGuardFrag uses for
+	// the sibling merge-conflict guard.
+	tieCheck := &chplan.Binary{
+		Op: chplan.OpEq,
+		Left: &chplan.FuncCall{
+			Name: "throwIf",
+			Args: []chplan.Expr{
+				&chplan.Binary{Op: chplan.OpGt, Left: tieCount, Right: &chplan.LitInt{V: 1}},
+				&chplan.InlineString{V: chplan.InfoConflictingLabelMessage},
+			},
+		},
+		Right: &chplan.LitInt{V: 0},
+	}
+
+	agg := &chplan.Aggregate{
+		Input:          node,
+		GroupBy:        groupBy,
+		GroupByAliases: groupByAliases,
+		AggFuncs: []chplan.AggFunc{
+			{
+				Name:  "argMax",
+				Args:  []chplan.Expr{&chplan.ColumnRef{Name: s.AttributesColumn}, timeUnix},
+				Alias: infoWinnerAttrsAlias,
+			},
+			{
+				Name:  "max",
+				Args:  []chplan.Expr{timeUnix},
+				Alias: infoWinnerTimeAlias,
+			},
+			{
+				Name:  "argMax",
+				Args:  []chplan.Expr{&chplan.ColumnRef{Name: s.ValueColumn}, timeUnix},
+				Alias: infoWinnerValueAlias,
+			},
+		},
+		Having: tieCheck,
+	}
+
+	// Drop the synthetic signature-key + tie-check columns, restoring the
+	// canonical four-column Sample shape lowerInfoJoin's Info field
+	// requires.
+	return &chplan.Project{
+		Input: agg,
+		Projections: []chplan.Projection{
+			{Expr: &chplan.ColumnRef{Name: s.MetricNameColumn}, Alias: s.MetricNameColumn},
+			{Expr: &chplan.ColumnRef{Name: infoWinnerAttrsAlias}, Alias: s.AttributesColumn},
+			{Expr: &chplan.ColumnRef{Name: infoWinnerTimeAlias}, Alias: s.TimestampColumn},
+			{Expr: &chplan.ColumnRef{Name: infoWinnerValueAlias}, Alias: s.ValueColumn},
+		},
+	}
 }
 
 // infoDataLabelNames returns the de-duplicated set of label names the

--- a/internal/promql/info_fn_ignore_test.go
+++ b/internal/promql/info_fn_ignore_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/chplan"
 )
 
 // TestLower_Info_IgnoresBaseInfoSeries pins the reference engine's
@@ -97,9 +97,17 @@ func TestLower_Info_IgnoresBaseInfoSeries(t *testing.T) {
 // `conflicting label: %s` when a second info metric contributes a data
 // label the first already recorded with a different value).
 //
-// The guard is only meaningful where several info metrics can merge onto
-// one base sample; a `__name__` equality pins a single info metric, so
-// there is nothing to disagree with and no guard is emitted.
+// This guard is only meaningful where several info metrics can merge
+// onto one base sample; a `__name__` equality pins a single info metric,
+// so there is nothing to disagree with and no merge guard is emitted. It
+// is distinct from — and always coexists with — the per-signature
+// timestamp-tie throwIf collapseInfoSeriesBySignature always plants on
+// the info arm as its own HAVING clause (see
+// TestLower_Info_SignatureCollapse), so both guards render as `HAVING
+// (throwIf(...) = ?)`. The merge guard's own marker is
+// `groupArrayArray(arrayZip(` — the per-info-metric label-pair fold only
+// the merge path builds — rather than the bare "HAVING" any info() query
+// now emits.
 func TestLower_Info_ConflictGuard(t *testing.T) {
 	t.Parallel()
 
@@ -107,7 +115,8 @@ func TestLower_Info_ConflictGuard(t *testing.T) {
 		name  string
 		query string
 		// guard is true when several info metrics may merge, so a
-		// conflict is representable and must abort the query.
+		// conflict is representable and the merge guard must abort the
+		// query.
 		guard bool
 	}{
 		{name: "regex name matcher merges several info metrics", query: `info(up, {__name__=~".+_info"})`, guard: true},
@@ -120,20 +129,52 @@ func TestLower_Info_ConflictGuard(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			sql, _ := emitInfoQuery(t, tc.query)
-			hasGuard := strings.Contains(sql, "throwIf(")
-			if hasGuard != tc.guard {
-				t.Fatalf("conflict guard present = %v, want %v for %s; full SQL:\n%s",
-					hasGuard, tc.guard, tc.query, sql)
+			// The pairs are zipped BEFORE the fold, so a key can never be
+			// paired with another info metric's value; its presence is
+			// what's unique to the merge-conflict guard.
+			hasMergeGuard := strings.Contains(sql, "groupArrayArray(arrayZip(")
+			if hasMergeGuard != tc.guard {
+				t.Fatalf("merge guard present = %v, want %v for %s; full SQL:\n%s",
+					hasMergeGuard, tc.guard, tc.query, sql)
 			}
-			if !tc.guard {
-				return
-			}
+			// The signature-tie HAVING guard is unconditional, so
+			// "HAVING" and the shared message always appear regardless
+			// of merge multiplicity.
 			for _, want := range []string{
 				"HAVING",
-				"'" + chsql.InfoConflictingLabelMessage + "'",
-				// The pairs are zipped BEFORE the fold, so a key can never
-				// be paired with another info metric's value.
-				"groupArrayArray(arrayZip(",
+				"'" + chplan.InfoConflictingLabelMessage + "'",
+			} {
+				if !strings.Contains(sql, want) {
+					t.Errorf("expected SQL to contain %q; full SQL:\n%s", want, sql)
+				}
+			}
+		})
+	}
+}
+
+// TestLower_Info_SignatureCollapse pins collapseInfoSeriesBySignature's
+// always-on shape: every info() lowering — merged or not — groups the
+// info arm by (metric name, identity-label values) and plants a
+// timestamp-tie throwIf in a real HAVING clause, so ClickHouse's
+// column-pruning analyzer can never optimise the guard away as an
+// unreferenced SELECT-list expression (see chplan.Aggregate.Having's
+// doc and issue #1630).
+func TestLower_Info_SignatureCollapse(t *testing.T) {
+	t.Parallel()
+
+	for _, query := range []string{
+		`info(up)`,
+		`info(up, {__name__="build_info"})`,
+		`info(up, {__name__=~".+_info"})`,
+	} {
+		t.Run(query, func(t *testing.T) {
+			t.Parallel()
+			sql, _ := emitInfoQuery(t, query)
+			for _, want := range []string{
+				"argMax(",
+				"HAVING",
+				"countEqual(groupArray(",
+				"'" + chplan.InfoConflictingLabelMessage + "'",
 			} {
 				if !strings.Contains(sql, want) {
 					t.Errorf("expected SQL to contain %q; full SQL:\n%s", want, sql)

--- a/test/perf/cardinality-baseline.json
+++ b/test/perf/cardinality-baseline.json
@@ -4444,6 +4444,17 @@
     "uncountable_levels": 0
   },
   {
+    "fixture": "promql/info_signature_collapse_keeps_newest",
+    "fan_factor": 1,
+    "scan_rows": 1,
+    "peak_intermediate": 1,
+    "has_cross_join": false,
+    "has_array_join": false,
+    "has_recursive_cte": false,
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
+  },
+  {
     "fixture": "promql/info_target_info_enrichment",
     "fan_factor": 1,
     "scan_rows": 2,

--- a/test/perf/solver-decision-baseline.json
+++ b/test/perf/solver-decision-baseline.json
@@ -2230,6 +2230,16 @@
     "outer_range": "1h0m0s"
   },
   {
+    "query": "info_signature_collapse_keeps_newest",
+    "routed": false,
+    "k": 0,
+    "reason": "not-sliceable",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "10m0s",
+    "outer_range": "1h0m0s"
+  },
+  {
     "query": "info_target_info_enrichment",
     "routed": false,
     "k": 0,

--- a/test/spec/promql/info_base_label_wins_over_info.txtar
+++ b/test/spec/promql/info_base_label_wins_over_info.txtar
@@ -49,24 +49,28 @@ INSERT INTO otel_metrics_gauge VALUES
 [13] string = "2026-01-01 00:00:01.000000000"
 [14] int64 = 9
 [15] int64 = 300000000000
-[16] string = "service.name"
-[17] string = "service_name"
+[16] string = "instance"
+[17] string = "job"
 [18] string = "service.name"
 [19] string = "service_name"
-[20] string = ""
+[20] string = "service.name"
 [21] string = "service_name"
-[22] string = "target_info"
-[23] string = "target.info"
-[24] string = "target/info"
-[25] string = "2026-01-01 00:00:01.000000000"
-[26] int64 = 9
+[22] string = ""
+[23] string = "service_name"
+[24] string = "target_info"
+[25] string = "target.info"
+[26] string = "target/info"
 [27] string = "2026-01-01 00:00:01.000000000"
 [28] int64 = 9
-[29] int64 = 300000000000
-[30] string = "instance"
-[31] string = "instance"
-[32] string = "job"
-[33] string = "job"
+[29] string = "2026-01-01 00:00:01.000000000"
+[30] int64 = 9
+[31] int64 = 300000000000
+[32] int64 = 1
+[33] int64 = 0
+[34] string = "instance"
+[35] string = "instance"
+[36] string = "job"
+[37] string = "job"
 -- chplan --
 InfoJoin identity=[instance, job]
   Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
@@ -75,11 +79,13 @@ InfoJoin identity=[instance, job]
         Project [MetricName AS MetricName, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, Value AS Value]
           Filter predicate=(MetricName = "up")
             Scan(merge(otel_metrics_gauge|otel_metrics_sum))
-  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
-    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
-      Filter predicate=((TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9)) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
-        Project [MetricName AS MetricName, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, Value AS Value]
-          Filter predicate=(MetricName IN ("target_info", "target.info", "target/info"))
-            Scan(merge(otel_metrics_gauge|otel_metrics_sum))
+  Project [MetricName AS MetricName, _cerberus_info_winner_attrs AS Attributes, _cerberus_info_winner_ts AS TimeUnix, _cerberus_info_winner_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes["instance"] AS _cerberus_info_sig_0, Attributes["job"] AS _cerberus_info_sig_1] funcs=[argMax(Attributes, TimeUnix) AS _cerberus_info_winner_attrs, max(TimeUnix) AS _cerberus_info_winner_ts, argMax(Value, TimeUnix) AS _cerberus_info_winner_value]
+      Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+        Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+          Filter predicate=((TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9)) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+            Project [MetricName AS MetricName, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, Value AS Value]
+              Filter predicate=(MetricName IN ("target_info", "target.info", "target/info"))
+                Scan(merge(otel_metrics_gauge|otel_metrics_sum))
 -- sql --
-SELECT L.`MetricName` AS `MetricName`, mapConcat(mapFilter((k, v) -> NOT (k IN (?, ?, ?)) AND v != ? AND NOT mapContains(L.`Attributes`, k), R.`Attributes`), L.`Attributes`) AS `Attributes`, L.`TimeUnix` AS `TimeUnix`, L.`Value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') PREWHERE (`MetricName` = ?))) WHERE ((`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?))))) GROUP BY `MetricName`, `Attributes`)) AS L LEFT JOIN (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') WHERE (`MetricName` IN (?, ?, ?)))) WHERE ((`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?))))) GROUP BY `MetricName`, `Attributes`)) AS R ON L.`Attributes`[?] = R.`Attributes`[?] AND L.`Attributes`[?] = R.`Attributes`[?]
+SELECT L.`MetricName` AS `MetricName`, mapConcat(mapFilter((k, v) -> NOT (k IN (?, ?, ?)) AND v != ? AND NOT mapContains(L.`Attributes`, k), R.`Attributes`), L.`Attributes`) AS `Attributes`, L.`TimeUnix` AS `TimeUnix`, L.`Value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') PREWHERE (`MetricName` = ?))) WHERE ((`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?))))) GROUP BY `MetricName`, `Attributes`)) AS L LEFT JOIN (SELECT `MetricName` AS `MetricName`, `_cerberus_info_winner_attrs` AS `Attributes`, `_cerberus_info_winner_ts` AS `TimeUnix`, `_cerberus_info_winner_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes`[?] AS `_cerberus_info_sig_0`, `Attributes`[?] AS `_cerberus_info_sig_1`, argMax(`Attributes`, `TimeUnix`) AS `_cerberus_info_winner_attrs`, max(`TimeUnix`) AS `_cerberus_info_winner_ts`, argMax(`Value`, `TimeUnix`) AS `_cerberus_info_winner_value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') WHERE (`MetricName` IN (?, ?, ?)))) WHERE ((`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?))))) GROUP BY `MetricName`, `Attributes`)) GROUP BY `MetricName`, `_cerberus_info_sig_0`, `_cerberus_info_sig_1` HAVING (throwIf((countEqual(groupArray(`TimeUnix`), max(`TimeUnix`)) > ?), 'conflicting label') = ?))) AS R ON L.`Attributes`[?] = R.`Attributes`[?] AND L.`Attributes`[?] = R.`Attributes`[?]

--- a/test/spec/promql/info_data_label_matcher_drops_unmatched.txtar
+++ b/test/spec/promql/info_data_label_matcher_drops_unmatched.txtar
@@ -40,30 +40,34 @@ INSERT INTO otel_metrics_gauge VALUES
 [11] string = "2026-01-01 00:00:01.000000000"
 [12] int64 = 9
 [13] int64 = 300000000000
-[14] string = "service.name"
-[15] string = "service_name"
+[14] string = "instance"
+[15] string = "job"
 [16] string = "service.name"
 [17] string = "service_name"
-[18] string = ""
+[18] string = "service.name"
 [19] string = "service_name"
-[20] string = "target_info"
-[21] string = "target.info"
-[22] string = "target/info"
-[23] string = "version"
-[24] string = ""
+[20] string = ""
+[21] string = "service_name"
+[22] string = "target_info"
+[23] string = "target.info"
+[24] string = "target/info"
 [25] string = "version"
 [26] string = ""
-[27] string = ""
-[28] string = ".+"
-[29] string = "2026-01-01 00:00:01.000000000"
-[30] int64 = 9
+[27] string = "version"
+[28] string = ""
+[29] string = ""
+[30] string = ".+"
 [31] string = "2026-01-01 00:00:01.000000000"
 [32] int64 = 9
-[33] int64 = 300000000000
-[34] string = "instance"
-[35] string = "instance"
-[36] string = "job"
-[37] string = "job"
+[33] string = "2026-01-01 00:00:01.000000000"
+[34] int64 = 9
+[35] int64 = 300000000000
+[36] int64 = 1
+[37] int64 = 0
+[38] string = "instance"
+[39] string = "instance"
+[40] string = "job"
+[41] string = "job"
 -- chplan --
 InfoJoin identity=[instance, job] dataLabels=[version] dropUnmatched
   Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
@@ -72,11 +76,13 @@ InfoJoin identity=[instance, job] dataLabels=[version] dropUnmatched
         Project [MetricName AS MetricName, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, Value AS Value]
           Filter predicate=(MetricName = "up")
             Scan(merge(otel_metrics_gauge|otel_metrics_sum))
-  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
-    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
-      Filter predicate=((TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9)) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
-        Project [MetricName AS MetricName, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, Value AS Value]
-          Filter predicate=((MetricName IN ("target_info", "target.info", "target/info")) AND (coalesce(nullIf(Attributes["version"], ""), nullIf(ResourceAttributes["version"], ""), "") =~ ".+"))
-            Scan(merge(otel_metrics_gauge|otel_metrics_sum))
+  Project [MetricName AS MetricName, _cerberus_info_winner_attrs AS Attributes, _cerberus_info_winner_ts AS TimeUnix, _cerberus_info_winner_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes["instance"] AS _cerberus_info_sig_0, Attributes["job"] AS _cerberus_info_sig_1] funcs=[argMax(Attributes, TimeUnix) AS _cerberus_info_winner_attrs, max(TimeUnix) AS _cerberus_info_winner_ts, argMax(Value, TimeUnix) AS _cerberus_info_winner_value]
+      Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+        Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+          Filter predicate=((TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9)) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+            Project [MetricName AS MetricName, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, Value AS Value]
+              Filter predicate=((MetricName IN ("target_info", "target.info", "target/info")) AND (coalesce(nullIf(Attributes["version"], ""), nullIf(ResourceAttributes["version"], ""), "") =~ ".+"))
+                Scan(merge(otel_metrics_gauge|otel_metrics_sum))
 -- sql --
-SELECT L.`MetricName` AS `MetricName`, mapConcat(mapFilter((k, v) -> k IN (?) AND v != ? AND NOT mapContains(L.`Attributes`, k), R.`Attributes`), L.`Attributes`) AS `Attributes`, L.`TimeUnix` AS `TimeUnix`, L.`Value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') PREWHERE (`MetricName` = ?))) WHERE ((`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?))))) GROUP BY `MetricName`, `Attributes`)) AS L INNER JOIN (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') PREWHERE (`MetricName` IN (?, ?, ?)) WHERE match(coalesce(nullIf(`Attributes`[?], ?), nullIf(`ResourceAttributes`[?], ?), ?), ?))) WHERE ((`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?))))) GROUP BY `MetricName`, `Attributes`)) AS R ON L.`Attributes`[?] = R.`Attributes`[?] AND L.`Attributes`[?] = R.`Attributes`[?]
+SELECT L.`MetricName` AS `MetricName`, mapConcat(mapFilter((k, v) -> k IN (?) AND v != ? AND NOT mapContains(L.`Attributes`, k), R.`Attributes`), L.`Attributes`) AS `Attributes`, L.`TimeUnix` AS `TimeUnix`, L.`Value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') PREWHERE (`MetricName` = ?))) WHERE ((`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?))))) GROUP BY `MetricName`, `Attributes`)) AS L INNER JOIN (SELECT `MetricName` AS `MetricName`, `_cerberus_info_winner_attrs` AS `Attributes`, `_cerberus_info_winner_ts` AS `TimeUnix`, `_cerberus_info_winner_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes`[?] AS `_cerberus_info_sig_0`, `Attributes`[?] AS `_cerberus_info_sig_1`, argMax(`Attributes`, `TimeUnix`) AS `_cerberus_info_winner_attrs`, max(`TimeUnix`) AS `_cerberus_info_winner_ts`, argMax(`Value`, `TimeUnix`) AS `_cerberus_info_winner_value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') PREWHERE (`MetricName` IN (?, ?, ?)) WHERE match(coalesce(nullIf(`Attributes`[?], ?), nullIf(`ResourceAttributes`[?], ?), ?), ?))) WHERE ((`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?))))) GROUP BY `MetricName`, `Attributes`)) GROUP BY `MetricName`, `_cerberus_info_sig_0`, `_cerberus_info_sig_1` HAVING (throwIf((countEqual(groupArray(`TimeUnix`), max(`TimeUnix`)) > ?), 'conflicting label') = ?))) AS R ON L.`Attributes`[?] = R.`Attributes`[?] AND L.`Attributes`[?] = R.`Attributes`[?]

--- a/test/spec/promql/info_ignore_split_unpinned_base.txtar
+++ b/test/spec/promql/info_ignore_split_unpinned_base.txtar
@@ -101,75 +101,79 @@ INSERT INTO otel_metrics_gauge VALUES
 [52] string = "target_info"
 [53] string = "target.info"
 [54] string = "target/info"
-[55] string = "service.name"
-[56] string = "service_name"
+[55] string = "instance"
+[56] string = "job"
 [57] string = "service.name"
 [58] string = "service_name"
-[59] string = ""
+[59] string = "service.name"
 [60] string = "service_name"
-[61] string = "target_info"
-[62] string = "target.info"
-[63] string = "target/info"
-[64] string = "2026-01-01 00:00:01.000000000"
-[65] int64 = 9
+[61] string = ""
+[62] string = "service_name"
+[63] string = "target_info"
+[64] string = "target.info"
+[65] string = "target/info"
 [66] string = "2026-01-01 00:00:01.000000000"
 [67] int64 = 9
-[68] int64 = 300000000000
-[69] string = "instance"
-[70] string = "instance"
-[71] string = "job"
-[72] string = "job"
-[73] string = "service.name"
-[74] string = "service_name"
-[75] string = "service.name"
-[76] string = "service_name"
-[77] string = ""
+[68] string = "2026-01-01 00:00:01.000000000"
+[69] int64 = 9
+[70] int64 = 300000000000
+[71] int64 = 1
+[72] int64 = 0
+[73] string = "instance"
+[74] string = "instance"
+[75] string = "job"
+[76] string = "job"
+[77] string = "service.name"
 [78] string = "service_name"
-[79] string = "up|target_info"
-[80] string = "[^a-zA-Z0-9_:]"
-[81] string = "_"
-[82] string = "up|target_info"
-[83] string = "service.name"
-[84] string = "service_name"
-[85] string = "service.name"
-[86] string = "service_name"
-[87] string = ""
+[79] string = "service.name"
+[80] string = "service_name"
+[81] string = ""
+[82] string = "service_name"
+[83] string = "up|target_info"
+[84] string = "[^a-zA-Z0-9_:]"
+[85] string = "_"
+[86] string = "up|target_info"
+[87] string = "service.name"
 [88] string = "service_name"
-[89] string = "up|target_info"
-[90] string = "[^a-zA-Z0-9_:]"
-[91] string = "_"
-[92] string = "up|target_info"
-[93] string = "service.name"
-[94] string = "service_name"
-[95] string = "service.name"
-[96] string = "service_name"
-[97] string = ""
+[89] string = "service.name"
+[90] string = "service_name"
+[91] string = ""
+[92] string = "service_name"
+[93] string = "up|target_info"
+[94] string = "[^a-zA-Z0-9_:]"
+[95] string = "_"
+[96] string = "up|target_info"
+[97] string = "service.name"
 [98] string = "service_name"
-[99] string = "up|target_info"
-[100] string = "[^a-zA-Z0-9_:]"
-[101] string = "_"
-[102] string = "up|target_info"
-[103] string = "le"
-[104] string = "+Inf"
-[105] int64 = 1
-[106] string = "service.name"
-[107] string = "service_name"
-[108] string = "service.name"
-[109] string = "service_name"
-[110] string = ""
+[99] string = "service.name"
+[100] string = "service_name"
+[101] string = ""
+[102] string = "service_name"
+[103] string = "up|target_info"
+[104] string = "[^a-zA-Z0-9_:]"
+[105] string = "_"
+[106] string = "up|target_info"
+[107] string = "le"
+[108] string = "+Inf"
+[109] int64 = 1
+[110] string = "service.name"
 [111] string = "service_name"
-[112] string = "up|target_info"
-[113] string = "[^a-zA-Z0-9_:]"
-[114] string = "_"
-[115] string = "up|target_info"
-[116] string = "2026-01-01 00:00:01.000000000"
-[117] int64 = 9
-[118] string = "2026-01-01 00:00:01.000000000"
-[119] int64 = 9
-[120] int64 = 300000000000
-[121] string = "target_info"
-[122] string = "target.info"
-[123] string = "target/info"
+[112] string = "service.name"
+[113] string = "service_name"
+[114] string = ""
+[115] string = "service_name"
+[116] string = "up|target_info"
+[117] string = "[^a-zA-Z0-9_:]"
+[118] string = "_"
+[119] string = "up|target_info"
+[120] string = "2026-01-01 00:00:01.000000000"
+[121] int64 = 9
+[122] string = "2026-01-01 00:00:01.000000000"
+[123] int64 = 9
+[124] int64 = 300000000000
+[125] string = "target_info"
+[126] string = "target.info"
+[127] string = "target/info"
 -- chplan --
 Project [MetricName AS MetricName, Attributes AS Attributes, TimeUnix AS TimeUnix, Value AS Value]
   UnionAll arms=2
@@ -192,12 +196,14 @@ Project [MetricName AS MetricName, Attributes AS Attributes, TimeUnix AS TimeUni
                   Project [concat(MetricName, "_bucket") AS MetricName, mapConcat(Attributes, map("le", if((le_idx > length(ExplicitBounds)), "+Inf", toString(ExplicitBounds[le_idx])))) AS Attributes, TimeUnix AS TimeUnix, toFloat64(arraySum(arraySlice(BucketCounts, 1, le_idx))) AS Value]
                     Project [MetricName AS MetricName, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, ExplicitBounds AS ExplicitBounds, BucketCounts AS BucketCounts, arrayJoin(arrayEnumerate(BucketCounts)) AS le_idx]
                       Scan(otel_metrics_histogram)
-      Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
-        Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
-          Filter predicate=((TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9)) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
-            Project [MetricName AS MetricName, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, Value AS Value]
-              Filter predicate=(MetricName IN ("target_info", "target.info", "target/info"))
-                Scan(merge(otel_metrics_gauge|otel_metrics_sum))
+      Project [MetricName AS MetricName, _cerberus_info_winner_attrs AS Attributes, _cerberus_info_winner_ts AS TimeUnix, _cerberus_info_winner_value AS Value]
+        Aggregate groupBy=[MetricName AS MetricName, Attributes["instance"] AS _cerberus_info_sig_0, Attributes["job"] AS _cerberus_info_sig_1] funcs=[argMax(Attributes, TimeUnix) AS _cerberus_info_winner_attrs, max(TimeUnix) AS _cerberus_info_winner_ts, argMax(Value, TimeUnix) AS _cerberus_info_winner_value]
+          Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+            Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+              Filter predicate=((TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9)) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+                Project [MetricName AS MetricName, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, Value AS Value]
+                  Filter predicate=(MetricName IN ("target_info", "target.info", "target/info"))
+                    Scan(merge(otel_metrics_gauge|otel_metrics_sum))
     Filter predicate=(MetricName IN ("target_info", "target.info", "target/info"))
       Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
         Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
@@ -217,4 +223,4 @@ Project [MetricName AS MetricName, Attributes AS Attributes, TimeUnix AS TimeUni
                   Project [MetricName AS MetricName, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, ExplicitBounds AS ExplicitBounds, BucketCounts AS BucketCounts, arrayJoin(arrayEnumerate(BucketCounts)) AS le_idx]
                     Scan(otel_metrics_histogram)
 -- sql --
-SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM ((SELECT L.`MetricName` AS `MetricName`, mapConcat(mapFilter((k, v) -> NOT (k IN (?, ?, ?)) AND v != ? AND NOT mapContains(L.`Attributes`, k), R.`Attributes`), L.`Attributes`) AS `Attributes`, L.`TimeUnix` AS `TimeUnix`, L.`Value` AS `Value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM ((SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') WHERE (match(`MetricName`, ?) OR match(replaceRegexpAll(`MetricName`, ?, ?), ?)))) UNION ALL (SELECT * FROM (SELECT concat(`MetricName`, '_count') AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, toFloat64(`Count`) AS `Value` FROM (SELECT * FROM `otel_metrics_histogram`)) WHERE (match(`MetricName`, ?) OR match(replaceRegexpAll(`MetricName`, ?, ?), ?))) UNION ALL (SELECT * FROM (SELECT concat(`MetricName`, '_sum') AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, toFloat64(`Sum`) AS `Value` FROM (SELECT * FROM `otel_metrics_histogram`)) WHERE (match(`MetricName`, ?) OR match(replaceRegexpAll(`MetricName`, ?, ?), ?))) UNION ALL (SELECT * FROM (SELECT concat(`MetricName`, '_bucket') AS `MetricName`, mapConcat(`Attributes`, map(?, if((le_idx > length(`ExplicitBounds`)), ?, toString(`ExplicitBounds`[le_idx])))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, toFloat64(arraySum(arraySlice(`BucketCounts`, ?, le_idx))) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `ExplicitBounds` AS `ExplicitBounds`, `BucketCounts` AS `BucketCounts`, arrayJoin(arrayEnumerate(`BucketCounts`)) AS `le_idx` FROM (SELECT * FROM `otel_metrics_histogram`))) WHERE (match(`MetricName`, ?) OR match(replaceRegexpAll(`MetricName`, ?, ?), ?)))) WHERE ((`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?))))) GROUP BY `MetricName`, `Attributes`)) WHERE (`MetricName` NOT IN (?, ?, ?))) AS L LEFT JOIN (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') WHERE (`MetricName` IN (?, ?, ?)))) WHERE ((`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?))))) GROUP BY `MetricName`, `Attributes`)) AS R ON L.`Attributes`[?] = R.`Attributes`[?] AND L.`Attributes`[?] = R.`Attributes`[?]) UNION ALL (SELECT * FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM ((SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') WHERE (match(`MetricName`, ?) OR match(replaceRegexpAll(`MetricName`, ?, ?), ?)))) UNION ALL (SELECT * FROM (SELECT concat(`MetricName`, '_count') AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, toFloat64(`Count`) AS `Value` FROM (SELECT * FROM `otel_metrics_histogram`)) WHERE (match(`MetricName`, ?) OR match(replaceRegexpAll(`MetricName`, ?, ?), ?))) UNION ALL (SELECT * FROM (SELECT concat(`MetricName`, '_sum') AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, toFloat64(`Sum`) AS `Value` FROM (SELECT * FROM `otel_metrics_histogram`)) WHERE (match(`MetricName`, ?) OR match(replaceRegexpAll(`MetricName`, ?, ?), ?))) UNION ALL (SELECT * FROM (SELECT concat(`MetricName`, '_bucket') AS `MetricName`, mapConcat(`Attributes`, map(?, if((le_idx > length(`ExplicitBounds`)), ?, toString(`ExplicitBounds`[le_idx])))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, toFloat64(arraySum(arraySlice(`BucketCounts`, ?, le_idx))) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `ExplicitBounds` AS `ExplicitBounds`, `BucketCounts` AS `BucketCounts`, arrayJoin(arrayEnumerate(`BucketCounts`)) AS `le_idx` FROM (SELECT * FROM `otel_metrics_histogram`))) WHERE (match(`MetricName`, ?) OR match(replaceRegexpAll(`MetricName`, ?, ?), ?)))) WHERE ((`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?))))) GROUP BY `MetricName`, `Attributes`)) WHERE (`MetricName` IN (?, ?, ?))))
+SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM ((SELECT L.`MetricName` AS `MetricName`, mapConcat(mapFilter((k, v) -> NOT (k IN (?, ?, ?)) AND v != ? AND NOT mapContains(L.`Attributes`, k), R.`Attributes`), L.`Attributes`) AS `Attributes`, L.`TimeUnix` AS `TimeUnix`, L.`Value` AS `Value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM ((SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') WHERE (match(`MetricName`, ?) OR match(replaceRegexpAll(`MetricName`, ?, ?), ?)))) UNION ALL (SELECT * FROM (SELECT concat(`MetricName`, '_count') AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, toFloat64(`Count`) AS `Value` FROM (SELECT * FROM `otel_metrics_histogram`)) WHERE (match(`MetricName`, ?) OR match(replaceRegexpAll(`MetricName`, ?, ?), ?))) UNION ALL (SELECT * FROM (SELECT concat(`MetricName`, '_sum') AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, toFloat64(`Sum`) AS `Value` FROM (SELECT * FROM `otel_metrics_histogram`)) WHERE (match(`MetricName`, ?) OR match(replaceRegexpAll(`MetricName`, ?, ?), ?))) UNION ALL (SELECT * FROM (SELECT concat(`MetricName`, '_bucket') AS `MetricName`, mapConcat(`Attributes`, map(?, if((le_idx > length(`ExplicitBounds`)), ?, toString(`ExplicitBounds`[le_idx])))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, toFloat64(arraySum(arraySlice(`BucketCounts`, ?, le_idx))) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `ExplicitBounds` AS `ExplicitBounds`, `BucketCounts` AS `BucketCounts`, arrayJoin(arrayEnumerate(`BucketCounts`)) AS `le_idx` FROM (SELECT * FROM `otel_metrics_histogram`))) WHERE (match(`MetricName`, ?) OR match(replaceRegexpAll(`MetricName`, ?, ?), ?)))) WHERE ((`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?))))) GROUP BY `MetricName`, `Attributes`)) WHERE (`MetricName` NOT IN (?, ?, ?))) AS L LEFT JOIN (SELECT `MetricName` AS `MetricName`, `_cerberus_info_winner_attrs` AS `Attributes`, `_cerberus_info_winner_ts` AS `TimeUnix`, `_cerberus_info_winner_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes`[?] AS `_cerberus_info_sig_0`, `Attributes`[?] AS `_cerberus_info_sig_1`, argMax(`Attributes`, `TimeUnix`) AS `_cerberus_info_winner_attrs`, max(`TimeUnix`) AS `_cerberus_info_winner_ts`, argMax(`Value`, `TimeUnix`) AS `_cerberus_info_winner_value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') WHERE (`MetricName` IN (?, ?, ?)))) WHERE ((`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?))))) GROUP BY `MetricName`, `Attributes`)) GROUP BY `MetricName`, `_cerberus_info_sig_0`, `_cerberus_info_sig_1` HAVING (throwIf((countEqual(groupArray(`TimeUnix`), max(`TimeUnix`)) > ?), 'conflicting label') = ?))) AS R ON L.`Attributes`[?] = R.`Attributes`[?] AND L.`Attributes`[?] = R.`Attributes`[?]) UNION ALL (SELECT * FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM ((SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') WHERE (match(`MetricName`, ?) OR match(replaceRegexpAll(`MetricName`, ?, ?), ?)))) UNION ALL (SELECT * FROM (SELECT concat(`MetricName`, '_count') AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, toFloat64(`Count`) AS `Value` FROM (SELECT * FROM `otel_metrics_histogram`)) WHERE (match(`MetricName`, ?) OR match(replaceRegexpAll(`MetricName`, ?, ?), ?))) UNION ALL (SELECT * FROM (SELECT concat(`MetricName`, '_sum') AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, toFloat64(`Sum`) AS `Value` FROM (SELECT * FROM `otel_metrics_histogram`)) WHERE (match(`MetricName`, ?) OR match(replaceRegexpAll(`MetricName`, ?, ?), ?))) UNION ALL (SELECT * FROM (SELECT concat(`MetricName`, '_bucket') AS `MetricName`, mapConcat(`Attributes`, map(?, if((le_idx > length(`ExplicitBounds`)), ?, toString(`ExplicitBounds`[le_idx])))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, toFloat64(arraySum(arraySlice(`BucketCounts`, ?, le_idx))) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `ExplicitBounds` AS `ExplicitBounds`, `BucketCounts` AS `BucketCounts`, arrayJoin(arrayEnumerate(`BucketCounts`)) AS `le_idx` FROM (SELECT * FROM `otel_metrics_histogram`))) WHERE (match(`MetricName`, ?) OR match(replaceRegexpAll(`MetricName`, ?, ?), ?)))) WHERE ((`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?))))) GROUP BY `MetricName`, `Attributes`)) WHERE (`MetricName` IN (?, ?, ?))))

--- a/test/spec/promql/info_regex_name_matcher_unions_info_metrics.txtar
+++ b/test/spec/promql/info_regex_name_matcher_unions_info_metrics.txtar
@@ -56,62 +56,62 @@ INSERT INTO otel_metrics_gauge VALUES
 [25] string = "2026-01-01 00:00:01.000000000"
 [26] int64 = 9
 [27] int64 = 300000000000
-[28] string = "service.name"
-[29] string = "service_name"
+[28] string = "instance"
+[29] string = "job"
 [30] string = "service.name"
 [31] string = "service_name"
-[32] string = ""
+[32] string = "service.name"
 [33] string = "service_name"
-[34] string = ".+_info"
-[35] string = "[^a-zA-Z0-9_:]"
-[36] string = "_"
-[37] string = ".+_info"
-[38] string = "service.name"
-[39] string = "service_name"
+[34] string = ""
+[35] string = "service_name"
+[36] string = ".+_info"
+[37] string = "[^a-zA-Z0-9_:]"
+[38] string = "_"
+[39] string = ".+_info"
 [40] string = "service.name"
 [41] string = "service_name"
-[42] string = ""
+[42] string = "service.name"
 [43] string = "service_name"
-[44] string = ".+_info"
-[45] string = "[^a-zA-Z0-9_:]"
-[46] string = "_"
-[47] string = ".+_info"
-[48] string = "service.name"
-[49] string = "service_name"
+[44] string = ""
+[45] string = "service_name"
+[46] string = ".+_info"
+[47] string = "[^a-zA-Z0-9_:]"
+[48] string = "_"
+[49] string = ".+_info"
 [50] string = "service.name"
 [51] string = "service_name"
-[52] string = ""
+[52] string = "service.name"
 [53] string = "service_name"
-[54] string = ".+_info"
-[55] string = "[^a-zA-Z0-9_:]"
-[56] string = "_"
-[57] string = ".+_info"
-[58] string = "le"
-[59] string = "+Inf"
-[60] int64 = 1
-[61] string = "service.name"
-[62] string = "service_name"
+[54] string = ""
+[55] string = "service_name"
+[56] string = ".+_info"
+[57] string = "[^a-zA-Z0-9_:]"
+[58] string = "_"
+[59] string = ".+_info"
+[60] string = "le"
+[61] string = "+Inf"
+[62] int64 = 1
 [63] string = "service.name"
 [64] string = "service_name"
-[65] string = ""
+[65] string = "service.name"
 [66] string = "service_name"
-[67] string = ".+_info"
-[68] string = "[^a-zA-Z0-9_:]"
-[69] string = "_"
-[70] string = ".+_info"
-[71] string = "2026-01-01 00:00:01.000000000"
-[72] int64 = 9
+[67] string = ""
+[68] string = "service_name"
+[69] string = ".+_info"
+[70] string = "[^a-zA-Z0-9_:]"
+[71] string = "_"
+[72] string = ".+_info"
 [73] string = "2026-01-01 00:00:01.000000000"
 [74] int64 = 9
-[75] int64 = 300000000000
-[76] string = "instance"
-[77] string = "instance"
-[78] string = "job"
-[79] string = "job"
+[75] string = "2026-01-01 00:00:01.000000000"
+[76] int64 = 9
+[77] int64 = 300000000000
+[78] int64 = 1
+[79] int64 = 0
 [80] string = "instance"
-[81] string = "job"
-[82] string = "__name__"
-[83] string = ""
+[81] string = "instance"
+[82] string = "job"
+[83] string = "job"
 [84] string = "instance"
 [85] string = "job"
 [86] string = "__name__"
@@ -124,6 +124,10 @@ INSERT INTO otel_metrics_gauge VALUES
 [93] string = "job"
 [94] string = "__name__"
 [95] string = ""
+[96] string = "instance"
+[97] string = "job"
+[98] string = "__name__"
+[99] string = ""
 -- chplan --
 InfoJoin identity=[instance, job] mergeInfoMetrics
   Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
@@ -132,22 +136,24 @@ InfoJoin identity=[instance, job] mergeInfoMetrics
         Project [MetricName AS MetricName, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, Value AS Value]
           Filter predicate=(MetricName = "up")
             Scan(merge(otel_metrics_gauge|otel_metrics_sum))
-  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
-    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
-      Filter predicate=((TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9)) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
-        UnionAll arms=4
-          Project [MetricName AS MetricName, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, Value AS Value]
-            Filter predicate=((MetricName =~ ".+_info") OR (replaceRegexpAll(MetricName, "[^a-zA-Z0-9_:]", "_") =~ ".+_info"))
-              Scan(merge(otel_metrics_gauge|otel_metrics_sum))
-          Filter predicate=((MetricName =~ ".+_info") OR (replaceRegexpAll(MetricName, "[^a-zA-Z0-9_:]", "_") =~ ".+_info"))
-            Project [concat(MetricName, "_count") AS MetricName, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, toFloat64(Count) AS Value]
-              Scan(otel_metrics_histogram)
-          Filter predicate=((MetricName =~ ".+_info") OR (replaceRegexpAll(MetricName, "[^a-zA-Z0-9_:]", "_") =~ ".+_info"))
-            Project [concat(MetricName, "_sum") AS MetricName, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, toFloat64(Sum) AS Value]
-              Scan(otel_metrics_histogram)
-          Filter predicate=((MetricName =~ ".+_info") OR (replaceRegexpAll(MetricName, "[^a-zA-Z0-9_:]", "_") =~ ".+_info"))
-            Project [concat(MetricName, "_bucket") AS MetricName, mapConcat(Attributes, map("le", if((le_idx > length(ExplicitBounds)), "+Inf", toString(ExplicitBounds[le_idx])))) AS Attributes, TimeUnix AS TimeUnix, toFloat64(arraySum(arraySlice(BucketCounts, 1, le_idx))) AS Value]
-              Project [MetricName AS MetricName, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, ExplicitBounds AS ExplicitBounds, BucketCounts AS BucketCounts, arrayJoin(arrayEnumerate(BucketCounts)) AS le_idx]
-                Scan(otel_metrics_histogram)
+  Project [MetricName AS MetricName, _cerberus_info_winner_attrs AS Attributes, _cerberus_info_winner_ts AS TimeUnix, _cerberus_info_winner_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes["instance"] AS _cerberus_info_sig_0, Attributes["job"] AS _cerberus_info_sig_1] funcs=[argMax(Attributes, TimeUnix) AS _cerberus_info_winner_attrs, max(TimeUnix) AS _cerberus_info_winner_ts, argMax(Value, TimeUnix) AS _cerberus_info_winner_value]
+      Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+        Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+          Filter predicate=((TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9)) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+            UnionAll arms=4
+              Project [MetricName AS MetricName, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, Value AS Value]
+                Filter predicate=((MetricName =~ ".+_info") OR (replaceRegexpAll(MetricName, "[^a-zA-Z0-9_:]", "_") =~ ".+_info"))
+                  Scan(merge(otel_metrics_gauge|otel_metrics_sum))
+              Filter predicate=((MetricName =~ ".+_info") OR (replaceRegexpAll(MetricName, "[^a-zA-Z0-9_:]", "_") =~ ".+_info"))
+                Project [concat(MetricName, "_count") AS MetricName, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, toFloat64(Count) AS Value]
+                  Scan(otel_metrics_histogram)
+              Filter predicate=((MetricName =~ ".+_info") OR (replaceRegexpAll(MetricName, "[^a-zA-Z0-9_:]", "_") =~ ".+_info"))
+                Project [concat(MetricName, "_sum") AS MetricName, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, toFloat64(Sum) AS Value]
+                  Scan(otel_metrics_histogram)
+              Filter predicate=((MetricName =~ ".+_info") OR (replaceRegexpAll(MetricName, "[^a-zA-Z0-9_:]", "_") =~ ".+_info"))
+                Project [concat(MetricName, "_bucket") AS MetricName, mapConcat(Attributes, map("le", if((le_idx > length(ExplicitBounds)), "+Inf", toString(ExplicitBounds[le_idx])))) AS Attributes, TimeUnix AS TimeUnix, toFloat64(arraySum(arraySlice(BucketCounts, 1, le_idx))) AS Value]
+                  Project [MetricName AS MetricName, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, ExplicitBounds AS ExplicitBounds, BucketCounts AS BucketCounts, arrayJoin(arrayEnumerate(BucketCounts)) AS le_idx]
+                    Scan(otel_metrics_histogram)
 -- sql --
-SELECT L.`MetricName` AS `MetricName`, mapConcat(mapFromArrays(arrayMap(t -> tupleElement(t, 1), arrayDistinct(groupArrayArray(arrayZip(mapKeys(mapFilter((k, v) -> NOT (k IN (?, ?, ?)) AND v != ? AND NOT mapContains(L.`Attributes`, k), R.`Attributes`)), mapValues(mapFilter((k, v) -> NOT (k IN (?, ?, ?)) AND v != ? AND NOT mapContains(L.`Attributes`, k), R.`Attributes`)))))), arrayMap(t -> tupleElement(t, 2), arrayDistinct(groupArrayArray(arrayZip(mapKeys(mapFilter((k, v) -> NOT (k IN (?, ?, ?)) AND v != ? AND NOT mapContains(L.`Attributes`, k), R.`Attributes`)), mapValues(mapFilter((k, v) -> NOT (k IN (?, ?, ?)) AND v != ? AND NOT mapContains(L.`Attributes`, k), R.`Attributes`))))))), L.`Attributes`) AS `Attributes`, L.`TimeUnix` AS `TimeUnix`, L.`Value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') PREWHERE (`MetricName` = ?))) WHERE ((`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?))))) GROUP BY `MetricName`, `Attributes`)) AS L LEFT JOIN (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM ((SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') WHERE (match(`MetricName`, ?) OR match(replaceRegexpAll(`MetricName`, ?, ?), ?)))) UNION ALL (SELECT * FROM (SELECT concat(`MetricName`, '_count') AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, toFloat64(`Count`) AS `Value` FROM (SELECT * FROM `otel_metrics_histogram`)) WHERE (match(`MetricName`, ?) OR match(replaceRegexpAll(`MetricName`, ?, ?), ?))) UNION ALL (SELECT * FROM (SELECT concat(`MetricName`, '_sum') AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, toFloat64(`Sum`) AS `Value` FROM (SELECT * FROM `otel_metrics_histogram`)) WHERE (match(`MetricName`, ?) OR match(replaceRegexpAll(`MetricName`, ?, ?), ?))) UNION ALL (SELECT * FROM (SELECT concat(`MetricName`, '_bucket') AS `MetricName`, mapConcat(`Attributes`, map(?, if((le_idx > length(`ExplicitBounds`)), ?, toString(`ExplicitBounds`[le_idx])))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, toFloat64(arraySum(arraySlice(`BucketCounts`, ?, le_idx))) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `ExplicitBounds` AS `ExplicitBounds`, `BucketCounts` AS `BucketCounts`, arrayJoin(arrayEnumerate(`BucketCounts`)) AS `le_idx` FROM (SELECT * FROM `otel_metrics_histogram`))) WHERE (match(`MetricName`, ?) OR match(replaceRegexpAll(`MetricName`, ?, ?), ?)))) WHERE ((`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?))))) GROUP BY `MetricName`, `Attributes`)) AS R ON L.`Attributes`[?] = R.`Attributes`[?] AND L.`Attributes`[?] = R.`Attributes`[?] GROUP BY L.`MetricName`, L.`Attributes`, L.`TimeUnix`, L.`Value` HAVING throwIf(length(arrayDistinct(groupArrayArray(arrayZip(mapKeys(mapFilter((k, v) -> NOT (k IN (?, ?, ?)) AND v != ? AND NOT mapContains(L.`Attributes`, k), R.`Attributes`)), mapValues(mapFilter((k, v) -> NOT (k IN (?, ?, ?)) AND v != ? AND NOT mapContains(L.`Attributes`, k), R.`Attributes`)))))) != length(arrayDistinct(arrayMap(t -> tupleElement(t, 1), groupArrayArray(arrayZip(mapKeys(mapFilter((k, v) -> NOT (k IN (?, ?, ?)) AND v != ? AND NOT mapContains(L.`Attributes`, k), R.`Attributes`)), mapValues(mapFilter((k, v) -> NOT (k IN (?, ?, ?)) AND v != ? AND NOT mapContains(L.`Attributes`, k), R.`Attributes`))))))), 'conflicting label') = 0
+SELECT L.`MetricName` AS `MetricName`, mapConcat(mapFromArrays(arrayMap(t -> tupleElement(t, 1), arrayDistinct(groupArrayArray(arrayZip(mapKeys(mapFilter((k, v) -> NOT (k IN (?, ?, ?)) AND v != ? AND NOT mapContains(L.`Attributes`, k), R.`Attributes`)), mapValues(mapFilter((k, v) -> NOT (k IN (?, ?, ?)) AND v != ? AND NOT mapContains(L.`Attributes`, k), R.`Attributes`)))))), arrayMap(t -> tupleElement(t, 2), arrayDistinct(groupArrayArray(arrayZip(mapKeys(mapFilter((k, v) -> NOT (k IN (?, ?, ?)) AND v != ? AND NOT mapContains(L.`Attributes`, k), R.`Attributes`)), mapValues(mapFilter((k, v) -> NOT (k IN (?, ?, ?)) AND v != ? AND NOT mapContains(L.`Attributes`, k), R.`Attributes`))))))), L.`Attributes`) AS `Attributes`, L.`TimeUnix` AS `TimeUnix`, L.`Value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') PREWHERE (`MetricName` = ?))) WHERE ((`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?))))) GROUP BY `MetricName`, `Attributes`)) AS L LEFT JOIN (SELECT `MetricName` AS `MetricName`, `_cerberus_info_winner_attrs` AS `Attributes`, `_cerberus_info_winner_ts` AS `TimeUnix`, `_cerberus_info_winner_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes`[?] AS `_cerberus_info_sig_0`, `Attributes`[?] AS `_cerberus_info_sig_1`, argMax(`Attributes`, `TimeUnix`) AS `_cerberus_info_winner_attrs`, max(`TimeUnix`) AS `_cerberus_info_winner_ts`, argMax(`Value`, `TimeUnix`) AS `_cerberus_info_winner_value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM ((SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') WHERE (match(`MetricName`, ?) OR match(replaceRegexpAll(`MetricName`, ?, ?), ?)))) UNION ALL (SELECT * FROM (SELECT concat(`MetricName`, '_count') AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, toFloat64(`Count`) AS `Value` FROM (SELECT * FROM `otel_metrics_histogram`)) WHERE (match(`MetricName`, ?) OR match(replaceRegexpAll(`MetricName`, ?, ?), ?))) UNION ALL (SELECT * FROM (SELECT concat(`MetricName`, '_sum') AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, toFloat64(`Sum`) AS `Value` FROM (SELECT * FROM `otel_metrics_histogram`)) WHERE (match(`MetricName`, ?) OR match(replaceRegexpAll(`MetricName`, ?, ?), ?))) UNION ALL (SELECT * FROM (SELECT concat(`MetricName`, '_bucket') AS `MetricName`, mapConcat(`Attributes`, map(?, if((le_idx > length(`ExplicitBounds`)), ?, toString(`ExplicitBounds`[le_idx])))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, toFloat64(arraySum(arraySlice(`BucketCounts`, ?, le_idx))) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `ExplicitBounds` AS `ExplicitBounds`, `BucketCounts` AS `BucketCounts`, arrayJoin(arrayEnumerate(`BucketCounts`)) AS `le_idx` FROM (SELECT * FROM `otel_metrics_histogram`))) WHERE (match(`MetricName`, ?) OR match(replaceRegexpAll(`MetricName`, ?, ?), ?)))) WHERE ((`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?))))) GROUP BY `MetricName`, `Attributes`)) GROUP BY `MetricName`, `_cerberus_info_sig_0`, `_cerberus_info_sig_1` HAVING (throwIf((countEqual(groupArray(`TimeUnix`), max(`TimeUnix`)) > ?), 'conflicting label') = ?))) AS R ON L.`Attributes`[?] = R.`Attributes`[?] AND L.`Attributes`[?] = R.`Attributes`[?] GROUP BY L.`MetricName`, L.`Attributes`, L.`TimeUnix`, L.`Value` HAVING throwIf(length(arrayDistinct(groupArrayArray(arrayZip(mapKeys(mapFilter((k, v) -> NOT (k IN (?, ?, ?)) AND v != ? AND NOT mapContains(L.`Attributes`, k), R.`Attributes`)), mapValues(mapFilter((k, v) -> NOT (k IN (?, ?, ?)) AND v != ? AND NOT mapContains(L.`Attributes`, k), R.`Attributes`)))))) != length(arrayDistinct(arrayMap(t -> tupleElement(t, 1), groupArrayArray(arrayZip(mapKeys(mapFilter((k, v) -> NOT (k IN (?, ?, ?)) AND v != ? AND NOT mapContains(L.`Attributes`, k), R.`Attributes`)), mapValues(mapFilter((k, v) -> NOT (k IN (?, ?, ?)) AND v != ? AND NOT mapContains(L.`Attributes`, k), R.`Attributes`))))))), 'conflicting label') = 0

--- a/test/spec/promql/info_signature_collapse_keeps_newest.txtar
+++ b/test/spec/promql/info_signature_collapse_keeps_newest.txtar
@@ -1,5 +1,31 @@
+# Two info series sharing one (metric name, identity-label) signature must
+# collapse to a single row before the join, keeping the sample with the
+# greatest timestamp — the reference engine's combineWithInfoSeries never
+# lets more than one info candidate per signature reach the merge. This is
+# issue #1630's own repro shape: two `target_info{job="api"}` series at
+# different timestamps, differing only in `version`.
+#
+# Cerberus without the collapse would fan the LEFT JOIN out to one output
+# row per matching info series — two `up` rows, one per `version`. The
+# fix must yield exactly one, carrying the NEWER `version`.
+
 -- query.promql --
 info(up)
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 1.0),
+    ('target_info', map('job', 'api', 'version', '1.2.3'), toDateTime64('2026-01-01 00:00:00', 9), 1.0),
+    ('target_info', map('job', 'api', 'version', '4.5.6'), toDateTime64('2026-01-01 00:00:00.500', 9), 1.0);
+-- expected_rows --
+[
+  ["up", {"job": "api", "version": "4.5.6"}, "2026-01-01T00:00:00Z", 1.0]
+]
 -- args --
 [0] string = "instance"
 [1] string = "job"
@@ -39,23 +65,6 @@ info(up)
 [35] string = "instance"
 [36] string = "job"
 [37] string = "job"
--- seed --
-CREATE TABLE otel_metrics_gauge (
-    MetricName String,
-    Attributes Map(String, String),
-    TimeUnix DateTime64(9),
-    Value Float64
-) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
-INSERT INTO otel_metrics_gauge VALUES
-    ('up', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 1.0),
-    ('up', map('job', 'db'), toDateTime64('2026-01-01 00:00:00', 9), 0.0),
-    ('target_info', map('job', 'api', 'version', '1.2.3'), toDateTime64('2026-01-01 00:00:00', 9), 1.0),
-    ('target_info', map('job', 'db', 'version', '4.5.6'), toDateTime64('2026-01-01 00:00:00', 9), 1.0);
--- expected_rows --
-[
-  ["up", {"job": "api", "version": "1.2.3"}, "2026-01-01T00:00:00Z", 1.0],
-  ["up", {"job": "db", "version": "4.5.6"}, "2026-01-01T00:00:00Z", 0.0]
-]
 -- chplan --
 InfoJoin identity=[instance, job]
   Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]


### PR DESCRIPTION
## Summary

`info()` enriches base series with data labels from a companion info metric (e.g. `target_info`), keyed on the `{instance, job}` identity. Two info series sharing that signature but differing on a data label (a metric re-scraped with a new build version) previously fanned the LEFT JOIN out to one output row per candidate instead of collapsing to a single enriched sample, diverging from upstream's `combineWithInfoSeries`/`sigFunction`.

`collapseInfoSeriesBySignature` now groups the info arm by `(metric name, identity-label values)` and keeps the sample with the greatest timestamp, raising `chplan.InfoConflictingLabelMessage` on an exact timestamp tie rather than picking one arbitrarily — mirroring upstream's "found duplicate series for info metric" abort.

Two bugs surfaced and were fixed along the way, both caught only once the chDB-tagged golden-update pass was actually run (the untagged variant leaves `seed:`/`expected_rows:` sections inert):

- **ILLEGAL_AGGREGATION**: aliasing the winning row's aggregate output straight to the raw column name it also reads inside the GROUP BY key expressions (`argMax(Attributes, TimeUnix) AS Attributes`) triggers ClickHouse's GROUP BY key elimination into misreading the alias as re-entering the grouping key set. Fixed with synthetic intermediate aliases, renamed to canonical names only in the wrapping `Project`.
- **Dead-guard**: the timestamp-tie `throwIf` guard, planted as an extra unreferenced SELECT-list column, is silently pruned by ClickHouse's dead-column elimination and never fires (verified with a minimal chDB repro: an unreferenced `throwIf` in a subquery's SELECT list never raises). `chplan.Aggregate` grows a `Having` field so the guard rides as a real `HAVING` clause instead, which cannot be pruned; wired through `internal/chsql`'s Aggregate emitter.

## Out of scope, filed as an issue

The same dead-column-elimination bug class affects `internal/chsql/vector_join.go`'s many-to-many vector-matching guard (`matchCheckFrag`) — verified empirically end to end (`a + on(job) b` with an ambiguous match key returns `200` with an arbitrary partial result instead of erroring). Filed as #1734; not touched by this PR.

## Test plan

- [x] `go build ./...`
- [x] `go test -tags chdb ./internal/promql/... ./internal/chplan/... ./internal/chsql/... ./internal/api/prom/...`
- [x] New TXTAR fixture `test/spec/promql/info_signature_collapse_keeps_newest.txtar` pins issue #1630's repro shape (two `target_info` series, distinct timestamps) through a full chDB roundtrip.
- [x] New handler-level `TestInfo_SignatureTie_ChDB` pins the exact-timestamp-tie abort (422 execution error) end to end through the HTTP handler.
- [x] `TestLower_Info_ConflictGuard` / `TestLower_Info_SignatureCollapse` updated for the new always-on HAVING shape.

Closes #1630
