### PR TITLE
fix(chsql): carve out NaN-both-sides pairs from changes()

### DIFF
--- a/.github/scripts/compat-ratchet.mjs
+++ b/.github/scripts/compat-ratchet.mjs
@@ -21,7 +21,7 @@
 // accident of the current numbers — a diff against a reference backend
 // is a bug to fix at the source, so there is no shape in this file that
 // can record a divergence as acceptable. The floors are prometheus
-// 739/739, loki 126/126, tempo 62/62, tempo-grpc 59/59; doc-counts.mjs
+// 745/745, loki 126/126, tempo 62/62, tempo-grpc 59/59; doc-counts.mjs
 // asserts those numbers against compatibility/parity-baseline.json, so
 // a corpus change cannot leave this comment behind. tempo-grpc's floor
 // is 3 below tempo's: traces / traces_v2 have no StreamingQuerier RPC

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ against an upstream oracle, not just the emitted SQL.
 PromQL is the strongest leg: the third-party **PromQL Compliance Tester**
 (PromLabs / CNCF Prometheus Conformance Program tooling) against a real
 `prom/prometheus`, seeded identically on both sides via remote-write —
-**739/739 cases pass, no allow-list.** LogQL is solid but measured on a
+**745/745 cases pass, no allow-list.** LogQL is solid but measured on a
 Grafana bench corpus rather than a standardised conformance suite. TraceQL
 is the lightest leg: no third-party TraceQL conformance suite exists, so its
 corpus is author-written TXTAR and its numerical confidence is

--- a/compatibility/parity-baseline.json
+++ b/compatibility/parity-baseline.json
@@ -3,8 +3,8 @@
   "_contract": "Per head: 'cases' is the exact, sorted roster of corpus case IDs, every one of which agreed with the reference backend; 'passed' and 'total' are the human-facing counts the README and docs cite, and the ratchet asserts passed == total == cases.length so they cannot drift from the roster. The baseline records FULL parity for every head \u2014 this file has no shape for recording a divergence as acceptable, because a diff against a reference backend is a bug to fix at the source. When the corpus legitimately changes, replace the head's entry in the SAME PR, taking the roster from the run's compat-cases.json artefact rather than hand-editing it.",
   "heads": {
     "prometheus": {
-      "passed": 739,
-      "total": 739,
+      "passed": 745,
+      "total": 745,
       "cases": [
         "\"a string literal\"",
         "(1 * 2 + 4 / 6 - (10%7)^2) != demo_memory_usage_bytes",
@@ -118,6 +118,12 @@
         "changes(demo_batch_last_success_timestamp_seconds[1m])",
         "changes(demo_batch_last_success_timestamp_seconds[1s])",
         "changes(demo_batch_last_success_timestamp_seconds[5m])",
+        "changes(demo_gauge_with_nan_run[15m])",
+        "changes(demo_gauge_with_nan_run[15s])",
+        "changes(demo_gauge_with_nan_run[1h])",
+        "changes(demo_gauge_with_nan_run[1m])",
+        "changes(demo_gauge_with_nan_run[1s])",
+        "changes(demo_gauge_with_nan_run[5m])",
         "clamp(demo_memory_usage_bytes, 0, 1)",
         "clamp(demo_memory_usage_bytes, 0, 1000000000000)",
         "clamp(demo_memory_usage_bytes, 1000000000000, 0)",

--- a/compatibility/prometheus/cerberus-test-queries.yml
+++ b/compatibility/prometheus/cerberus-test-queries.yml
@@ -2,7 +2,7 @@
 #
 # This file is a near-verbatim copy of
 # compatibility/prometheus/upstream/promql/promql-test-queries.yml
-# (prometheus/compliance @ 7e28242) with two edits:
+# (prometheus/compliance @ 7e28242) with three edits:
 #
 # 1. The PromLabs "demo service" preamble (lines 1-31 of the upstream file)
 #    is stripped — it documents docker-run instructions for the prometheus-
@@ -13,6 +13,12 @@
 #    has no resource attributes; the OTel-CH schema stores them apart from
 #    the datapoint attributes, so the aggregated fan-out has a grouping key
 #    no upstream case can reach.
+# 3. One cerberus-owned case is appended next to the existing `changes(...)`
+#    case: `changes(demo_gauge_with_nan_run[{{.range}}])`. Upstream's demo
+#    fixture never seeds a NaN sample, so it can't discriminate the
+#    changes() NaN-both-sides carve-out (#1489) against a real reference
+#    Prometheus — only against chDB. See demo_gauge_with_nan_run in
+#    cmd/seed/main.go.
 #
 # Series schema: the harness seeds a fixture that mirrors PromLabs's demo
 # service labels (`instance` / `job` / `type` / `mode` / `method` / `path`
@@ -303,6 +309,12 @@ test_cases:
   - query: 'resets(demo_cpu_usage_seconds_total[{{.range}}])'
     variant_args: ['range']
   - query: 'changes(demo_batch_last_success_timestamp_seconds[{{.range}}])'
+    variant_args: ['range']
+    # A NaN-NaN run inside the lookback window: pins the changes() Prom
+    # parity carve-out for NaN-on-both-sides pairs (#1489) against a real
+    # reference Prometheus, not just chDB. See demo_gauge_with_nan_run in
+    # cmd/seed/main.go.
+  - query: 'changes(demo_gauge_with_nan_run[{{.range}}])'
     variant_args: ['range']
   - query: 'vector(1.23)'
   - query: 'vector(time())'

--- a/compatibility/prometheus/cmd/seed/main.go
+++ b/compatibility/prometheus/cmd/seed/main.go
@@ -88,6 +88,16 @@ const (
 // series by instance deterministically instead of by an accident of ties.
 const intermittentInstanceOffset = 1000
 
+// nanRunStartStep / nanRunSteps carve a 2-sample NaN-NaN run out of
+// demo_gauge_with_nan_run. Two consecutive NaN samples are required to
+// exercise Prometheus's changes() NaN-both-sides carve-out (#1489) — a
+// single NaN surrounded by finite values only exercises the ordinary
+// (already-agreeing) finite<->NaN transition.
+const (
+	nanRunStartStep = 100
+	nanRunSteps     = 2
+)
+
 func main() {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
 	if err := run(logger); err != nil {
@@ -201,6 +211,8 @@ func insertFixture(ctx context.Context, conn driver.Conn) error {
 			clickhouse.Named("intermittent_gap_start_step", uint64(intermittentGapStartStep)),
 			clickhouse.Named("intermittent_gap_end_step", uint64(intermittentGapStartStep+intermittentGapSteps)),
 			clickhouse.Named("intermittent_instance_offset", uint64(intermittentInstanceOffset)),
+			clickhouse.Named("nan_run_start_step", uint64(nanRunStartStep)),
+			clickhouse.Named("nan_run_steps", uint64(nanRunSteps)),
 		); err != nil {
 			return fmt.Errorf("%s: %w", s.name, err)
 		}
@@ -676,6 +688,31 @@ var fixtureInserts = []namedStmt{
                 ) AS instance
             ) AS i
         )`,
+	},
+	// demo_gauge_with_nan_run: 1 instance, gauge carrying a 2-sample
+	// NaN-NaN run in the middle of the window. `changes()`'s Prom-parity
+	// carve-out (#1489) only fires on a NaN-adjacent-to-NaN pair — a lone
+	// NaN surrounded by finite values already agreed with Prometheus, so
+	// that shape proves nothing. Placed well inside the window (not at
+	// either edge) so every {{.range}} variant's lookback can observe it
+	// from some evaluation timestamp within the tester's scan.
+	{
+		name: "demo_gauge_with_nan_run",
+		sql: `INSERT INTO otel_metrics_gauge
+            (ResourceAttributes, MetricName, MetricDescription, MetricUnit,
+             Attributes, StartTimeUnix, TimeUnix, Value)
+        SELECT
+            map('service.name', 'demo'),
+            'demo_gauge_with_nan_run',
+            'Gauge with a NaN-NaN run, pinning the changes() carve-out (#1489) against a real Prometheus backend',
+            '1',
+            map('instance', 'demo.promlabs.com:10000', 'job', 'demo'),
+            toDateTime64({anchor:String}, 9),
+            toDateTime64({anchor:String}, 9) + INTERVAL step * {step_seconds:UInt64} SECOND,
+            if(step >= {nan_run_start_step:UInt64} AND step < {nan_run_start_step:UInt64} + {nan_run_steps:UInt64},
+                nan,
+                toFloat64(step))
+        FROM (SELECT number AS step FROM numbers({steps:UInt64})) AS s`,
 	},
 }
 

--- a/compatibility/prometheus/cmd/seed/prom_remote.go
+++ b/compatibility/prometheus/cmd/seed/prom_remote.go
@@ -109,6 +109,7 @@ var fixtureSources = []fixtureSource{
 	{"demo_batch_last_success_timestamp_seconds", "otel_metrics_gauge"},
 	{"demo_intermittent_metric", "otel_metrics_gauge"},
 	{"up", "otel_metrics_gauge"},
+	{"demo_gauge_with_nan_run", "otel_metrics_gauge"},
 }
 
 // histogramFixtureSource mirrors a classic-histogram fixture. `base` is

--- a/docs/clickhouse-optimizations.md
+++ b/docs/clickhouse-optimizations.md
@@ -121,7 +121,7 @@ table.
 | `ts_grid_range`          | 25.9       | experimental | yes        |
 | `ts_grid_resample`       | 25.9       | experimental | yes        |
 | `columnar_result_decode` | none       | experimental | no         |
-| `ts_grid_changes`        | 25.9       | experimental | yes        |
+| `ts_grid_changes`        | 25.9       | experimental | no         |
 | `ts_grid_resets`         | 25.9       | experimental | yes        |
 | `ts_grid_deriv`          | 25.9       | experimental | yes        |
 | `ts_grid_predict_linear` | 25.9       | experimental | yes        |
@@ -134,22 +134,24 @@ column is informational -- where a feature needs an `allow_experimental_*`
 setting, that setting is co-stamped by the **engine plan path** (it inspects the
 post-optimize plan and stamps the setting on exactly the queries that use the
 native node), not carried as a registry field — so the co-stamp fires whether
-the feature was reached via `auto` or by explicit listing. `columnar_result_decode`
-is the lone `autoSelect: no` opt-in feature whose perf-tradeoff framing is
-described as "opt-in" in the effect prose.
+the feature was reached via `auto` or by explicit listing. Two features are
+`autoSelect: no`, opt-in only: `columnar_result_decode` (a perf tradeoff) and
+`ts_grid_changes` (a correctness gap — the native builtin diverges from
+reference Prometheus on NaN-adjacent windows, tracked as
+[#1721](https://github.com/tsouza/cerberus/issues/1721)).
 
-| id                       | experimental setting                                 | effect                                                                                                                                                                                                                                                                                                                                            |
-| ------------------------ | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `aggregation_in_order`   | (none)                                               | stamps `optimize_aggregation_in_order=1` when the plan's Aggregate GROUP BY is a bare-column prefix of the scanned table's sorting key. Result-equivalent.                                                                                                                                                                                        |
-| `condition_cache`        | (none)                                               | stamps `use_query_condition_cache=1` (+`enable_analyzer=1`, analyzer-gated) on predicate-stable read paths. Result-equivalent (a cache).                                                                                                                                                                                                          |
-| `ts_grid_range`          | `allow_experimental_time_series_aggregate_functions` | opts eligible `rate(<counter>[<range>])` query_range shapes onto the native `timeSeriesRateToGrid` aggregate. Auto-enabled on server >= 25.9 (experimental maturity).                                                                                                                                                                             |
-| `ts_grid_resample`       | `allow_experimental_time_series_aggregate_functions` | opts the range-mode instant-vector staleness shape onto the native `timeSeriesResampleToGridWithStaleness` aggregate, retiring the argMax fan-out. Auto-enabled on server >= 25.9.                                                                                                                                                                |
-| `columnar_result_decode` | (none)                                               | client-side: decodes the `query_range` matrix shape via the ch-go columnar path (label map built once per run, not per row). No server setting, no version floor. Opt-in only (never auto).                                                                                                                                                       |
-| `ts_grid_changes`        | `allow_experimental_time_series_aggregate_functions` | opts eligible `changes(<v>[<range>])` query_range shapes onto the native `timeSeriesChangesToGrid` aggregate, retiring the `arrayPopBack`/`arrayPopFront` fan-out. Auto-enabled on server >= 25.9.                                                                                                                                                |
-| `ts_grid_resets`         | `allow_experimental_time_series_aggregate_functions` | opts eligible `resets(<counter>[<range>])` query_range shapes onto the native `timeSeriesResetsToGrid` aggregate, retiring the `arrayPopBack`/`arrayPopFront` fan-out. Auto-enabled on server >= 25.9.                                                                                                                                            |
-| `ts_grid_deriv`          | `allow_experimental_time_series_aggregate_functions` | opts eligible `deriv(<gauge>[<range>])` query_range shapes onto the native `timeSeriesDerivToGrid` aggregate (per-window least-squares slope), retiring the `simpleLinearRegression`/`arrayReduce` fan-out. Auto-enabled on server >= 25.9.                                                                                                       |
-| `ts_grid_predict_linear` | `allow_experimental_time_series_aggregate_functions` | opts eligible `predict_linear(<gauge>[<range>], t)` query_range shapes (whole-second literal `t`) onto the native `timeSeriesPredictLinearToGrid` aggregate (per-window slope\*t + intercept forecast), retiring the `simpleLinearRegression`/`arrayReduce` fan-out. Auto-enabled on server >= 25.9.                                              |
-| `ts_grid_recollapse`     | `allow_experimental_time_series_aggregate_functions` | defers the OTel -> Prometheus label-shaping tower PAST an eligible `ts_grid_range` rate grid, splitting it into `timeSeriesRateToGridState` over the raw keys and `timeSeriesRateToGridMerge` over the shaped ones, so the reshape runs once per raw series instead of once per raw row. Narrows `ts_grid_range`. Auto-enabled on server >= 25.9. |
+| id                       | experimental setting                                 | effect                                                                                                                                                                                                                                                                                                                                                     |
+| ------------------------ | ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `aggregation_in_order`   | (none)                                               | stamps `optimize_aggregation_in_order=1` when the plan's Aggregate GROUP BY is a bare-column prefix of the scanned table's sorting key. Result-equivalent.                                                                                                                                                                                                 |
+| `condition_cache`        | (none)                                               | stamps `use_query_condition_cache=1` (+`enable_analyzer=1`, analyzer-gated) on predicate-stable read paths. Result-equivalent (a cache).                                                                                                                                                                                                                   |
+| `ts_grid_range`          | `allow_experimental_time_series_aggregate_functions` | opts eligible `rate(<counter>[<range>])` query_range shapes onto the native `timeSeriesRateToGrid` aggregate. Auto-enabled on server >= 25.9 (experimental maturity).                                                                                                                                                                                      |
+| `ts_grid_resample`       | `allow_experimental_time_series_aggregate_functions` | opts the range-mode instant-vector staleness shape onto the native `timeSeriesResampleToGridWithStaleness` aggregate, retiring the argMax fan-out. Auto-enabled on server >= 25.9.                                                                                                                                                                         |
+| `columnar_result_decode` | (none)                                               | client-side: decodes the `query_range` matrix shape via the ch-go columnar path (label map built once per run, not per row). No server setting, no version floor. Opt-in only (never auto).                                                                                                                                                                |
+| `ts_grid_changes`        | `allow_experimental_time_series_aggregate_functions` | opts eligible `changes(<v>[<range>])` query_range shapes onto the native `timeSeriesChangesToGrid` aggregate, retiring the `arrayPopBack`/`arrayPopFront` fan-out. Opt-in only (never auto) — the builtin diverges from reference Prometheus on NaN-adjacent windows, [#1721](https://github.com/tsouza/cerberus/issues/1721); server still needs >= 25.9. |
+| `ts_grid_resets`         | `allow_experimental_time_series_aggregate_functions` | opts eligible `resets(<counter>[<range>])` query_range shapes onto the native `timeSeriesResetsToGrid` aggregate, retiring the `arrayPopBack`/`arrayPopFront` fan-out. Auto-enabled on server >= 25.9.                                                                                                                                                     |
+| `ts_grid_deriv`          | `allow_experimental_time_series_aggregate_functions` | opts eligible `deriv(<gauge>[<range>])` query_range shapes onto the native `timeSeriesDerivToGrid` aggregate (per-window least-squares slope), retiring the `simpleLinearRegression`/`arrayReduce` fan-out. Auto-enabled on server >= 25.9.                                                                                                                |
+| `ts_grid_predict_linear` | `allow_experimental_time_series_aggregate_functions` | opts eligible `predict_linear(<gauge>[<range>], t)` query_range shapes (whole-second literal `t`) onto the native `timeSeriesPredictLinearToGrid` aggregate (per-window slope\*t + intercept forecast), retiring the `simpleLinearRegression`/`arrayReduce` fan-out. Auto-enabled on server >= 25.9.                                                       |
+| `ts_grid_recollapse`     | `allow_experimental_time_series_aggregate_functions` | defers the OTel -> Prometheus label-shaping tower PAST an eligible `ts_grid_range` rate grid, splitting it into `timeSeriesRateToGridState` over the raw keys and `timeSeriesRateToGridMerge` over the shaped ones, so the reshape runs once per raw series instead of once per raw row. Narrows `ts_grid_range`. Auto-enabled on server >= 25.9.          |
 
 Notes:
 
@@ -190,17 +192,25 @@ Notes:
   (`CERBERUS_CH_OPTIMIZATIONS=columnar_result_decode`) to engage it. The decode
   is byte-parity-verified against the row path (`TestColumnarMatrixParity_E2E`).
   It is the registry's example of a non-version-gated opt-in feature.
-- **`ts_grid_changes`** is `experimental` in maturity but **auto-enabled** on
-  a capable server (no legacy alias). Its floor is **25.9**, NOT the 25.6 of
-  rate/resample: `timeSeriesChangesToGrid`/`timeSeriesResetsToGrid` shipped a
-  full quarter later (ClickHouse 25.9). A 25.6 floor would mis-advertise
-  support on 25.6-25.8 servers and 502 with ClickHouse error code 46,
-  `Function with name timeSeriesChangesToGrid does not exist` — an absent
-  `timeSeries*ToGrid` member is reported as an unknown FUNCTION, not as
-  `UNKNOWN_AGGREGATE_FUNCTION` (verified against 25.7 and 25.8 servers) — so
-  `auto` only picks it once the server is `>= 25.9`. It shares the family's
-  experimental setting, co-stamped on exactly the queries that emit the native
-  changes node.
+- **`ts_grid_changes`** is `experimental` in maturity and, unlike the rest of
+  the `timeSeries*ToGrid` family, **opt-in only** (`autoSelect: no`): the
+  native builtin overcounts by exactly 1 whenever a window's
+  chronologically-earliest in-window sample is NaN, and implements no
+  NaN-both-sides carve-out at all, so it diverges from reference Prometheus's
+  `changes()` on any NaN-adjacent window — confirmed against a real reference
+  Prometheus on the `compatibility/prometheus` substrate. Tracked as
+  [#1721](https://github.com/tsouza/cerberus/issues/1721); it stays opt-in
+  (`CERBERUS_CH_OPTIMIZATIONS=ts_grid_changes`) until ClickHouse fixes the
+  builtin's NaN handling upstream and the issue closes. Its floor is still
+  **25.9**, NOT the 25.6 of rate/resample: `timeSeriesChangesToGrid`/
+  `timeSeriesResetsToGrid` shipped a full quarter later (ClickHouse 25.9). A
+  25.6 floor would mis-advertise support on 25.6-25.8 servers and 502 with
+  ClickHouse error code 46, `Function with name timeSeriesChangesToGrid does
+  not exist` — an absent `timeSeries*ToGrid` member is reported as an unknown
+  FUNCTION, not as `UNKNOWN_AGGREGATE_FUNCTION` (verified against 25.7 and
+  25.8 servers). It shares the family's experimental setting, co-stamped on
+  exactly the queries that emit the native changes node when explicitly
+  listed.
 - **`ts_grid_resets`** is the sibling of `ts_grid_changes` (same PR upstream):
   experimental maturity, auto-enabled on a capable server, same **25.9** floor,
   same experimental setting.
@@ -523,9 +533,13 @@ Nothing in this suite can break ClickHouse 24.8:
 - `ts_grid_range` and `ts_grid_resample` activate only on `>= 25.9`
   (experimental maturity, auto-enabled there); below 25.9 they are absent from
   the resolved set.
-- `ts_grid_changes` and `ts_grid_resets` activate only on `>= 25.9`
-  (experimental maturity, auto-enabled there); below 25.9 they are absent from
-  the resolved set.
+- `ts_grid_resets` activates only on `>= 25.9` (experimental maturity,
+  auto-enabled there); below 25.9 it is absent from the resolved set.
+- `ts_grid_changes` also needs `>= 25.9`, but unlike its sibling `ts_grid_resets`
+  it is opt-in only (`autoSelect: no`, [#1721](https://github.com/tsouza/cerberus/issues/1721)),
+  so `auto` never enables it regardless of server version; it is reachable
+  only via an explicit `CERBERUS_CH_OPTIMIZATIONS=ts_grid_changes` listing on
+  a `>= 25.9` server.
 - `columnar_result_decode` is client-side and version-agnostic (no server
   setting); it is opt-in only, so `auto` never engages it.
 - Under `auto`, an unsupported feature is simply not enabled, so a deployment

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -56,10 +56,10 @@ branch as shields.io badge JSON; the README shows them live. On
 - **Corpus**: vendored
   [`prometheus/compliance/promql/promql-test-queries.yml`](https://github.com/prometheus/compliance),
   template-expanded to concrete cases, plus a small cerberus-owned tail for
-  shapes upstream cannot express (resource-attribute grouping) — 739 in all.
-- **Today**: **739/739** cases pass; no allow-list exists. This is the
+  shapes upstream cannot express (resource-attribute grouping) — 745 in all.
+- **Today**: **745/745** cases pass; no allow-list exists. This is the
   highest-confidence leg — an industry-standard conformance suite against
-  a real reference. (Parity drift is report-only in CI; the 739/739 is a
+  a real reference. (Parity drift is report-only in CI; the 745/745 is a
   measured score, not a merge gate — see the note at the top of this
   page.)
 
@@ -122,7 +122,7 @@ they are:
 
 | Head    | Reference          | Corpus origin                                  | Numerical confidence                                                                        |
 | ------- | ------------------ | ---------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| PromQL  | real Prometheus    | third-party `prometheus/compliance` (CNCF)     | **Highest** — industry-standard conformance suite, 739/739, no allow-list                   |
+| PromQL  | real Prometheus    | third-party `prometheus/compliance` (CNCF)     | **Highest** — industry-standard conformance suite, 745/745, no allow-list                   |
 | LogQL   | real Loki          | Grafana's own `pkg/logql/bench` corpus         | **Solid** — real backend + real corpus, but a Grafana bench set, not a conformance standard |
 | TraceQL | real Tempo         | cerberus-owned author-written TXTAR            | **Lowest** — real backend, but no third-party suite; corpus breadth is author-bounded       |
 
@@ -358,7 +358,7 @@ The rosters today (`heads.<name>.{passed,total,cases}`):
 
 | head       | passed/total |
 | ---------- | ------------ |
-| prometheus | 739 / 739    |
+| prometheus | 745 / 745    |
 | loki       | 124 / 124    |
 | tempo      | 61 / 61      |
 | tempo-grpc | 59 / 59      |

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -299,7 +299,7 @@ the SQL array machinery leaves at high cardinality. See
 - **The fan-out remains byte-for-byte available.** Pinning `ts_grid_range` off
   (an explicit list omitting it, or the legacy `=false`) restores the
   established fan-out exactly; on a < 25.9 server it is the only path. Every
-  existing golden, the compat 739/739 corpus, and the compose / e2e lanes are
+  existing golden, the compat 745/745 corpus, and the compose / e2e lanes are
   structurally the fan-out shape.
 
 **Parity.** Validated on the chDB substrate (26.5) by a dual-emit test

--- a/internal/chopt/registry.go
+++ b/internal/chopt/registry.go
@@ -73,10 +73,7 @@ const (
 	// FeatureTSGridChanges opts eligible changes(<v>[<range>]) query_range
 	// shapes onto the native timeSeriesChangesToGrid aggregate (the per-window
 	// value-change count), retiring the arrayPopBack/arrayPopFront `c != p`
-	// fan-out (internal/chsql.emitRangeWindowChanges). Like the rest of the
-	// family its maturity is Experimental but it is AUTO-SELECTED on capable
-	// servers (no legacy env alias — auto picks it once the server is >= 25.9, or
-	// list it in CERBERUS_CH_OPTIMIZATIONS).
+	// fan-out (internal/chsql.emitRangeWindowChanges).
 	//
 	// IMPORTANT — the floor is 25.9, shared with the rest of the family.
 	// timeSeriesChangesToGrid/ResetsToGrid shipped a full quarter after the
@@ -87,6 +84,21 @@ const (
 	// different reason — the left-open window fix, PR #86588; both PRs landed in
 	// 25.9.) The experimental allow_experimental_time_series_aggregate_functions
 	// gate is shared with the rest of the family.
+	//
+	// IMPORTANT — unlike the rest of the timeSeries*ToGrid family, this one is
+	// NOT auto-selected. The native builtin overcounts by exactly 1 whenever a
+	// window's chronologically-earliest in-window sample is NaN (#1721), and
+	// separately implements no NaN-both-sides carve-out at all, so it diverges
+	// from reference Prometheus's funcChanges on any NaN-adjacent window —
+	// exactly the divergence #1489 fixed in the fan-out kernel
+	// (internal/chsql.emitRangeWindowChanges) but cannot patch inside a
+	// ClickHouse builtin. Confirmed against a real reference Prometheus on the
+	// compatibility/prometheus substrate (ClickHouse 26.5, well above the 25.9
+	// floor): auto-selecting this feature emits a wrong answer the instant a
+	// NaN-bearing series is queried. AutoSelect is false — like
+	// FeatureColumnarResultDecode, it's reachable only via an explicit
+	// CERBERUS_CH_OPTIMIZATIONS=ts_grid_changes listing — until ClickHouse
+	// fixes the builtin's NaN handling upstream and #1721 closes.
 	FeatureTSGridChanges = "ts_grid_changes"
 
 	// FeatureTSGridResets opts eligible resets(<counter>[<range>]) query_range
@@ -264,9 +276,9 @@ var registry = []Feature{
 		ID:                         FeatureTSGridChanges,
 		MinVersion:                 Version{Major: 25, Minor: 9},
 		Stability:                  Experimental,
-		AutoSelect:                 true,
+		AutoSelect:                 false,
 		RequiresExperimentalTSGrid: true,
-		Doc:                        "opt eligible changes(<v>[<range>]) shapes onto native timeSeriesChangesToGrid (experimental maturity, auto-enabled on server >= 25.9)",
+		Doc:                        "opt eligible changes(<v>[<range>]) shapes onto native timeSeriesChangesToGrid (experimental maturity, server >= 25.9, opt-in only via CERBERUS_CH_OPTIMIZATIONS — the builtin diverges from reference Prometheus on NaN-adjacent windows, #1721)",
 	},
 	{
 		ID:                         FeatureTSGridResets,

--- a/internal/chopt/resolve.go
+++ b/internal/chopt/resolve.go
@@ -123,13 +123,16 @@ const (
 //     any other token (off + anything -> FATAL).
 //   - "auto" -> unions in every AUTO-SELECT feature whose MinVersion <= server.
 //     Auto-eligibility (Feature.AutoSelect) is a separate axis from maturity
-//     (Feature.Stability): the native timeSeries*ToGrid aggregates are
+//     (Feature.Stability): most native timeSeries*ToGrid aggregates are
 //     Experimental in maturity yet AutoSelect=true, so auto picks them on a
-//     capable server. The lone opt-in-only feature is columnar_result_decode
-//     (AutoSelect=false) -- a perf tradeoff, never auto. "auto" may sit
-//     alongside explicit ids, so "auto,columnar_result_decode" means the
-//     auto-set PLUS columnar_result_decode -- the way to add the opt-in feature
-//     without giving up version-aware auto-selection of the rest.
+//     capable server. Two features are opt-in-only (AutoSelect=false):
+//     columnar_result_decode (a perf tradeoff, never auto) and ts_grid_changes
+//     (a correctness gap -- the native builtin diverges from reference
+//     Prometheus on NaN-adjacent windows, #1721 -- never auto until upstream
+//     fixes it). "auto" may sit alongside explicit ids, so
+//     "auto,columnar_result_decode" means the auto-set PLUS
+//     columnar_result_decode -- the way to add an opt-in feature without
+//     giving up version-aware auto-selection of the rest.
 //   - a feature id -> an explicit request: supported -> enable; unsupported
 //     under Enforcing -> err (FATAL); unsupported under Permissive -> WARN +
 //     skip. An explicit id keeps its "I require this" semantics even next to

--- a/internal/chopt/resolve_test.go
+++ b/internal/chopt/resolve_test.go
@@ -108,14 +108,16 @@ func TestResolve_Off_LegacyFalse_StaysEmpty(t *testing.T) {
 
 func TestResolve_Auto_EnablesAutoSelectByVersion(t *testing.T) {
 	// On 25.9 the stable features (aggregation_in_order 24.8, condition_cache
-	// 25.3) plus ALL SEVEN 25.9-floored ts_grid_* features (ts_grid_range,
-	// ts_grid_resample, ts_grid_changes, ts_grid_resets, ts_grid_deriv,
-	// ts_grid_predict_linear, ts_grid_recollapse) are AutoSelect=true and
-	// supported;
-	// columnar_result_decode is AutoSelect=false so auto never picks it. 25.9 is
-	// the first release whose timeSeries*ToGrid window is left-open (PR #86588),
-	// so it is the native floor for the whole family (deriv/predict_linear
-	// shipped at 25.8 but are registry-pinned to the shared 25.9 floor).
+	// 25.3) plus SIX of the seven 25.9-floored ts_grid_* features (ts_grid_range,
+	// ts_grid_resample, ts_grid_resets, ts_grid_deriv, ts_grid_predict_linear,
+	// ts_grid_recollapse) are AutoSelect=true and supported. 25.9 is the first
+	// release whose timeSeries*ToGrid window is left-open (PR #86588), so it is
+	// the native floor for the whole family (deriv/predict_linear shipped at
+	// 25.8 but are registry-pinned to the shared 25.9 floor).
+	// columnar_result_decode and ts_grid_changes are both AutoSelect=false so
+	// auto never picks either: columnar_result_decode is a perf tradeoff,
+	// ts_grid_changes diverges from reference Prometheus on NaN-adjacent windows
+	// (#1721) and is opt-in only via CERBERUS_CH_OPTIMIZATIONS=ts_grid_changes.
 	// Capability=Available is the happy-path boot verdict (the server permits
 	// the experimental setting).
 	set, _, err := Resolve(Config{Optimizations: "auto", Capability: CapabilityAvailable}, v(25, 9))
@@ -123,10 +125,13 @@ func TestResolve_Auto_EnablesAutoSelectByVersion(t *testing.T) {
 		t.Fatalf("Resolve: %v", err)
 	}
 	assertSet(t, set, FeatureAggregationInOrder, FeatureConditionCache,
-		FeatureTSGridRange, FeatureTSGridResample, FeatureTSGridChanges, FeatureTSGridResets,
+		FeatureTSGridRange, FeatureTSGridResample, FeatureTSGridResets,
 		FeatureTSGridDeriv, FeatureTSGridPredictLinear, FeatureTSGridRecollapse)
 	if set.Has(FeatureColumnarResultDecode) {
 		t.Errorf("auto on 25.9 enabled %q; want it off (opt-in only)", FeatureColumnarResultDecode)
+	}
+	if set.Has(FeatureTSGridChanges) {
+		t.Errorf("auto on 25.9 enabled %q; want it off (opt-in only, #1721)", FeatureTSGridChanges)
 	}
 }
 
@@ -155,16 +160,22 @@ func TestResolve_Auto_EmptySelectionDefaultsToAuto(t *testing.T) {
 		t.Fatalf("Resolve: %v", err)
 	}
 	assertSet(t, set, FeatureAggregationInOrder, FeatureConditionCache,
-		FeatureTSGridRange, FeatureTSGridResample, FeatureTSGridChanges, FeatureTSGridResets,
+		FeatureTSGridRange, FeatureTSGridResample, FeatureTSGridResets,
 		FeatureTSGridDeriv, FeatureTSGridPredictLinear, FeatureTSGridRecollapse)
+	if set.Has(FeatureTSGridChanges) {
+		t.Errorf("empty-selection-defaults-to-auto enabled %q; want it off (opt-in only, #1721)", FeatureTSGridChanges)
+	}
 }
 
 func TestResolve_Auto_VersionBoundaries(t *testing.T) {
 	// The auto-selection matrix as the probed server version crosses each floor,
 	// with the boot capability verdict = Available (the server permits the
 	// experimental setting) so the version floor is the only gate in play.
-	// columnar_result_decode (AutoSelect=false) is absent from every row even
-	// though it carries no version floor — auto must never select it.
+	// columnar_result_decode and ts_grid_changes (both AutoSelect=false) are
+	// absent from every row: columnar_result_decode carries no version floor at
+	// all, and ts_grid_changes never auto-selects regardless of version because
+	// the native builtin diverges from reference Prometheus on NaN-adjacent
+	// windows (#1721) — auto must never select either.
 	cases := []struct {
 		name   string
 		server Version
@@ -191,11 +202,11 @@ func TestResolve_Auto_VersionBoundaries(t *testing.T) {
 			want:   []string{FeatureAggregationInOrder, FeatureConditionCache},
 		},
 		{
-			name:   "25.9 adds all seven ts_grid_* features (left-open window)",
+			name:   "25.9 adds six ts_grid_* features (left-open window; ts_grid_changes stays opt-in)",
 			server: v(25, 9),
 			want: []string{
 				FeatureAggregationInOrder, FeatureConditionCache,
-				FeatureTSGridRange, FeatureTSGridResample, FeatureTSGridChanges, FeatureTSGridResets,
+				FeatureTSGridRange, FeatureTSGridResample, FeatureTSGridResets,
 				FeatureTSGridDeriv, FeatureTSGridPredictLinear, FeatureTSGridRecollapse,
 			},
 		},
@@ -209,6 +220,9 @@ func TestResolve_Auto_VersionBoundaries(t *testing.T) {
 			assertSet(t, set, tc.want...)
 			if set.Has(FeatureColumnarResultDecode) {
 				t.Error("auto selected columnar_result_decode; it is opt-in only (AutoSelect=false)")
+			}
+			if set.Has(FeatureTSGridChanges) {
+				t.Error("auto selected ts_grid_changes; it is opt-in only (AutoSelect=false, #1721)")
 			}
 			if len(warns) != 0 {
 				t.Errorf("auto emitted warnings %v; want none (auto is silent on version skips)", warns)
@@ -326,14 +340,16 @@ func TestResolve_ColumnarResultDecode_NoVersionFloor(t *testing.T) {
 func TestResolve_AutoPlusOptIn_UnionsBoth(t *testing.T) {
 	// The headline case: "auto,columnar_result_decode" = the version-gated auto
 	// set PLUS the opt-in feature, without bailing out of auto. On 25.9 the auto
-	// half includes all seven 25.9-floored ts_grid_* features.
+	// half includes six of the seven 25.9-floored ts_grid_* features
+	// (ts_grid_changes stays opt-in-only, #1721, and is absent even from the
+	// explicit union here since it was not itself listed).
 	set, _, err := Resolve(Config{Optimizations: "auto,columnar_result_decode", Capability: CapabilityAvailable}, v(25, 9))
 	if err != nil {
 		t.Fatalf("Resolve(auto,columnar_result_decode): %v", err)
 	}
 	assertSet(t, set,
 		FeatureAggregationInOrder, FeatureConditionCache,
-		FeatureTSGridRange, FeatureTSGridResample, FeatureTSGridChanges, FeatureTSGridResets,
+		FeatureTSGridRange, FeatureTSGridResample, FeatureTSGridResets,
 		FeatureTSGridDeriv, FeatureTSGridPredictLinear, FeatureTSGridRecollapse,
 		FeatureColumnarResultDecode)
 }
@@ -480,7 +496,8 @@ func TestResolve_BothLegacyAndExplicitList_EnforcingFatal(t *testing.T) {
 func TestResolve_LegacyUnset_NoEffect(t *testing.T) {
 	// Unset legacy is a no-op: the resolved set is exactly what plain auto gives
 	// (so on 25.9 ts_grid_range/resample ARE present — auto-selected by version,
-	// not by the legacy flag) and no deprecation notice is emitted.
+	// not by the legacy flag; ts_grid_changes stays absent — it is opt-in only,
+	// #1721) and no deprecation notice is emitted.
 	set, warns, err := Resolve(Config{
 		Optimizations: "auto",
 		Capability:    CapabilityAvailable,
@@ -490,7 +507,7 @@ func TestResolve_LegacyUnset_NoEffect(t *testing.T) {
 		t.Fatalf("Resolve: %v", err)
 	}
 	assertSet(t, set, FeatureAggregationInOrder, FeatureConditionCache,
-		FeatureTSGridRange, FeatureTSGridResample, FeatureTSGridChanges, FeatureTSGridResets,
+		FeatureTSGridRange, FeatureTSGridResample, FeatureTSGridResets,
 		FeatureTSGridDeriv, FeatureTSGridPredictLinear, FeatureTSGridRecollapse)
 	if hasDeprecation(warns) {
 		t.Errorf("unset legacy must not emit deprecation; warns = %v", warns)
@@ -500,9 +517,11 @@ func TestResolve_LegacyUnset_NoEffect(t *testing.T) {
 func TestRegistry_SeededEntries(t *testing.T) {
 	reg := Registry()
 	// AutoSelect is decoupled from Stability: the native timeSeries*ToGrid
-	// aggregates are Experimental maturity yet AutoSelect=true (auto picks them
-	// by version), while columnar_result_decode is the lone AutoSelect=false
-	// opt-in perf tradeoff.
+	// aggregates are Experimental maturity yet mostly AutoSelect=true (auto
+	// picks them by version). Two features are AutoSelect=false, opt-in only:
+	// columnar_result_decode (a perf tradeoff) and ts_grid_changes (the native
+	// builtin diverges from reference Prometheus on NaN-adjacent windows,
+	// #1721).
 	// RequiresExperimentalTSGrid marks the seven native timeSeries*ToGrid
 	// features (the six aggregates plus the ts_grid_recollapse shape knob that
 	// rides on the rate one); the stable/client-side features leave it false.
@@ -512,7 +531,7 @@ func TestRegistry_SeededEntries(t *testing.T) {
 		FeatureTSGridRange:          {ID: FeatureTSGridRange, MinVersion: v(25, 9), Stability: Experimental, AutoSelect: true, RequiresExperimentalTSGrid: true},
 		FeatureTSGridResample:       {ID: FeatureTSGridResample, MinVersion: v(25, 9), Stability: Experimental, AutoSelect: true, RequiresExperimentalTSGrid: true},
 		FeatureColumnarResultDecode: {ID: FeatureColumnarResultDecode, MinVersion: AlwaysAvailable, Stability: Experimental, AutoSelect: false, RequiresExperimentalTSGrid: false},
-		FeatureTSGridChanges:        {ID: FeatureTSGridChanges, MinVersion: v(25, 9), Stability: Experimental, AutoSelect: true, RequiresExperimentalTSGrid: true},
+		FeatureTSGridChanges:        {ID: FeatureTSGridChanges, MinVersion: v(25, 9), Stability: Experimental, AutoSelect: false, RequiresExperimentalTSGrid: true},
 		FeatureTSGridResets:         {ID: FeatureTSGridResets, MinVersion: v(25, 9), Stability: Experimental, AutoSelect: true, RequiresExperimentalTSGrid: true},
 		FeatureTSGridDeriv:          {ID: FeatureTSGridDeriv, MinVersion: v(25, 9), Stability: Experimental, AutoSelect: true, RequiresExperimentalTSGrid: true},
 		FeatureTSGridPredictLinear:  {ID: FeatureTSGridPredictLinear, MinVersion: v(25, 9), Stability: Experimental, AutoSelect: true, RequiresExperimentalTSGrid: true},
@@ -535,11 +554,15 @@ func TestRegistry_SeededEntries(t *testing.T) {
 
 func TestResolve_Auto_CapabilityForbidden_DropsNativeKeepsStable(t *testing.T) {
 	// A 25.9 server (every native floor met) whose boot verdict is FORBIDDEN:
-	// auto drops ALL SEVEN native ts_grid_* features and keeps the non-experimental
-	// stable ones (aggregation_in_order, condition_cache). Each dropped native
-	// feature emits a boot WARN naming the experimental setting + the fan-out
-	// fallback (auto is silent on version skips, but NOT on a capability block —
-	// the operator should see a working deployment lost the native path).
+	// auto drops all seven native ts_grid_* features and keeps the non-experimental
+	// stable ones (aggregation_in_order, condition_cache). Six of the seven are
+	// AutoSelect=true and each emits a boot WARN naming the experimental setting
+	// + the fan-out fallback (auto is silent on version skips, but NOT on a
+	// capability block — the operator should see a working deployment lost the
+	// native path). ts_grid_changes is the seventh: it is AutoSelect=false
+	// (opt-in only, #1721), so auto never even considers it — it is absent from
+	// the resolved set for that reason alone, independent of the capability
+	// verdict, and produces no WARN of its own.
 	set, warns, err := Resolve(Config{Optimizations: "auto", Capability: CapabilityForbidden}, v(25, 9))
 	if err != nil {
 		t.Fatalf("Resolve: %v", err)
@@ -553,8 +576,8 @@ func TestResolve_Auto_CapabilityForbidden_DropsNativeKeepsStable(t *testing.T) {
 			t.Errorf("auto enabled %q on a capability-forbidden server; want it dropped to fan-out", native)
 		}
 	}
-	if len(warns) != 7 {
-		t.Fatalf("want one WARN per dropped native feature (7); got %d: %v", len(warns), warns)
+	if len(warns) != 6 {
+		t.Fatalf("want one WARN per capability-dropped AutoSelect=true native feature (6, excludes ts_grid_changes which is opt-in only); got %d: %v", len(warns), warns)
 	}
 	for _, w := range warns {
 		if !strings.Contains(w, "allow_experimental_time_series_aggregate_functions") || !strings.Contains(w, "fan-out") {

--- a/internal/chsql/range_window.go
+++ b/internal/chsql/range_window.go
@@ -2708,11 +2708,13 @@ func (e *emitter) emitRangeWindowResets(r *chplan.RangeWindow) error {
 // (no adjacent pairs). The outer SELECT drops empty-window rows via
 // `WHERE length(window_vals) >= 1`.
 //
-// Implementation mirrors emitRangeWindowResets but with `c != p` as
-// the per-pair indicator. Prom's funcChanges has an additional
-// `!(NaN(curr) && NaN(prev))` carve-out so a NaN-on-both-sides pair
-// is not counted as a change; we accept the divergence on float-NaN
-// streams (rare in practice, and the goldens cover only finite values).
+// Implementation mirrors emitRangeWindowResets but with `c != p AND NOT
+// (isNaN(c) AND isNaN(p))` as the per-pair indicator — matching Prom's
+// funcChanges, whose `!(NaN(curr) && NaN(prev))` carve-out means a
+// NaN-on-both-sides pair is never counted as a change (see #1489). A
+// NaN paired with a finite value IS still a change on both sides: `!=`
+// already evaluates true there (IEEE-754, both in Go and ClickHouse),
+// so the carve-out only needs to suppress the both-NaN case.
 func (e *emitter) emitRangeWindowChanges(r *chplan.RangeWindow) error {
 	value := Cast(
 		Call(
@@ -2720,7 +2722,10 @@ func (e *emitter) emitRangeWindowChanges(r *chplan.RangeWindow) error {
 			Call(
 				"arrayMap",
 				Lambda2("p", "c", If(
-					Neq(BareIdent("c"), BareIdent("p")),
+					And(
+						Neq(BareIdent("c"), BareIdent("p")),
+						Not(Paren(And(Call("isNaN", BareIdent("c")), Call("isNaN", BareIdent("p"))))),
+					),
 					InlineLit(int64(1)),
 					InlineLit(int64(0)),
 				)),

--- a/internal/chsql/range_window_changes_chdb_test.go
+++ b/internal/chsql/range_window_changes_chdb_test.go
@@ -31,26 +31,40 @@
 // requires >= 1 sample/window and returns a 0 count for a single-sample window
 // (NULL -> ABSENT only for an EMPTY window via WHERE grid_val IS NOT NULL),
 // matching the fan-out's `length(window_vals) >= 1` + per-pair `c != p` count.
-// Prom's funcChanges additionally carves out NaN-on-both-sides pairs; both the
-// fan-out and the native fn accept divergence there.
 //
-// #1707: that documented Prometheus-divergence carve-out is exactly why this
-// seed MUST exercise NaN input rather than avoid it — the two kernels are only
-// known to diverge from Prometheus on NaN-NaN pairs; whether they diverge from
-// EACH OTHER there was, before this seed extension, completely unverified. The
-// host-c/host-d/host-e series below (an all-NaN run, a mixed NaN/finite run
-// with transitions on both sides, and a single-sample window) mostly feed the
-// same bit-identical fan-out==native assertion below — no hand-derived
-// expected count is needed there, because the test only ever asserts the two
-// kernels agree with each other, never a value pinned against Prometheus.
+// #1489 (fixed): Prom's funcChanges carves out NaN-on-both-sides pairs (a pair
+// only counts as a "change" when `c != p AND NOT (isNaN(c) AND isNaN(p))`).
+// The fan-out kernel now implements that carve-out and is Prometheus-pinned
+// by the spec corpus (test/spec/promql/changes_nan_run.txtar); the native
+// timeSeriesChangesToGrid builtin does not, and cerberus can't patch a
+// ClickHouse builtin from its own SQL emission. That is a real,
+// evidence-backed fan-out/native divergence, characterized below rather than
+// tolerated silently.
 //
-// #1721: the seed extension DID surface a genuine native-vs-fan-out
-// divergence, not merely a divergence from Prometheus: native
-// timeSeriesChangesToGrid overcounts by exactly 1 whenever a window's
-// chronologically-earliest in-window sample is NaN. That shape is pinned
-// narrowly and explicitly — see changesKnownNativeNaNLeadOvercount below —
-// rather than relaxed away, so the assertion stays honest about exactly what
-// is and isn't known-divergent.
+// #1707: the Prometheus-divergence carve-out above is exactly why this seed
+// MUST exercise NaN input rather than avoid it. The host-c/host-d/host-e
+// series below (an all-NaN run, a mixed NaN/finite run with transitions on
+// both sides, and a single-sample window) mostly still feed the same
+// bit-identical fan-out==native assertion below — no hand-derived expected
+// count is needed for a cell whose window has no NaN-NaN adjacent pair,
+// because the test only ever asserts the two kernels agree with each other,
+// never a value pinned against Prometheus.
+//
+// #1721: native timeSeriesChangesToGrid diverges from the (now
+// Prometheus-correct) fan-out on any window containing at least one NaN-NaN
+// adjacent pair, by exactly `nanPairCount + leadNaNOvercount`:
+//   - nanPairCount: native counts EVERY NaN-NaN adjacent pair as a change —
+//     it implements no carve-out at all. This component was invisible before
+//     #1489's fix, because the old, also-uncarved-out fan-out counted
+//     NaN-NaN pairs the same way native does, masking the gap.
+//   - leadNaNOvercount: an ADDITIONAL +1 whenever the window's
+//     chronologically-earliest in-window sample is NaN — the narrower shape
+//     originally pinned under #1721, before #1489's fix exposed the broader
+//     nanPairCount gap it had been hiding.
+//
+// Both components are pinned per-cell and explicitly below — see
+// changesKnownNativeCarveoutGap — rather than relaxed away, so the assertion
+// stays honest about exactly what is and isn't known-divergent.
 package chsql_test
 
 import (
@@ -121,40 +135,48 @@ INSERT INTO otel_metrics_gauge (MetricName, Attributes, TimeUnix, Value) VALUES
 // both paths must agree on.
 const changesQuery = `sum by(host) (changes(load_state[5m]))`
 
-// changesKnownNativeNaNLeadOvercount pins a genuine, evidence-backed
-// divergence between the native and fan-out kernels, filed as #1721: native
-// timeSeriesChangesToGrid counts exactly ONE MORE change than the fan-out
-// whenever a window's chronologically-EARLIEST in-window sample is NaN.
-// Reading internal/chsql/range_window_native.go confirms cerberus passes
-// (ts, val) straight into the ClickHouse builtin with no NaN-specific
-// pre/post-processing anywhere in cerberus's own SQL — the bug lives inside
-// the builtin itself, not in code this test's assertion could paper over.
+// changesKnownNativeCarveoutGap pins the exact native-minus-fan-out offset for
+// every cell whose window contains at least one NaN-NaN adjacent pair (see
+// #1721 above for the nanPairCount + leadNaNOvercount decomposition). Every
+// offset here is hand-derived from the seed's own window membership — not an
+// opaque "don't check this" entry — and every cell NOT listed here must still
+// be bit-identical (see the assertion below). Reading
+// internal/chsql/range_window_native.go confirms cerberus passes (ts, val)
+// straight into the ClickHouse builtin with no NaN-specific pre/post
+// processing anywhere in cerberus's own SQL — the gap lives inside the
+// builtin itself, not in code this test's assertion could paper over.
 //
-// This is NOT a blanket tolerance: every cell not listed here must still be
-// bit-identical, and every cell listed here must diverge by EXACTLY +1 (see
-// the assertion below) — a value pinned against the seed's own hand-traced
-// window membership, not an opaque "don't check this" entry. host 'c' is
-// all-NaN, so all 11 of its anchors (00:00:00..00:05:00 @ 30s) have a NaN
-// leading sample. host 'd' has exactly one such anchor: at 00:05:00 the
-// half-open (anchor-5m, anchor] left boundary excludes its t=00:00:00 finite
-// sample, promoting its t=00:01:00 NaN sample to the window's leading
-// position; every other host 'd' anchor has a finite leading sample and stays
-// bit-identical. If a future ClickHouse release fixes the builtin, the
-// dedicated assertion below will start failing (native no longer +1) and this
-// pin must be deleted, not widened.
-var changesKnownNativeNaNLeadOvercount = map[gridCell]bool{
-	{ql: "c", anchor: "2026-01-01T00:00:00Z"}: true,
-	{ql: "c", anchor: "2026-01-01T00:00:30Z"}: true,
-	{ql: "c", anchor: "2026-01-01T00:01:00Z"}: true,
-	{ql: "c", anchor: "2026-01-01T00:01:30Z"}: true,
-	{ql: "c", anchor: "2026-01-01T00:02:00Z"}: true,
-	{ql: "c", anchor: "2026-01-01T00:02:30Z"}: true,
-	{ql: "c", anchor: "2026-01-01T00:03:00Z"}: true,
-	{ql: "c", anchor: "2026-01-01T00:03:30Z"}: true,
-	{ql: "c", anchor: "2026-01-01T00:04:00Z"}: true,
-	{ql: "c", anchor: "2026-01-01T00:04:30Z"}: true,
-	{ql: "c", anchor: "2026-01-01T00:05:00Z"}: true,
-	{ql: "d", anchor: "2026-01-01T00:05:00Z"}: true,
+// host 'c' is all-NaN, so every one of its 11 anchors (00:00:00..00:05:00 @
+// 30s) has an all-NaN window: offset = nanPairCount(window) + 1 (its leading
+// sample is always NaN too). host 'd' alternates finite/NaN
+// (3.0, NaN, NaN, 3.0, 4.0, NaN at t=0..5m): exactly one NaN-NaN pair
+// (t=00:01:00, t=00:02:00) is in-window from 00:02:00 onward, so those
+// anchors get offset 1; at 00:05:00 the half-open (anchor-5m, anchor] left
+// boundary additionally excludes host d's t=00:00:00 finite sample, promoting
+// the still-in-window t=00:01:00 NaN sample to the window's leading position
+// (the #1721 shape originally pinned) for a combined offset of 2. If a future
+// ClickHouse release fixes the builtin, the dedicated assertion below will
+// start failing (native no longer diverges) and this pin must be deleted, not
+// widened.
+var changesKnownNativeCarveoutGap = map[gridCell]int{
+	{ql: "c", anchor: "2026-01-01T00:00:00Z"}: 1, // 0 nan-nan pairs (single-sample window) + 1 lead
+	{ql: "c", anchor: "2026-01-01T00:00:30Z"}: 1, // 0 pairs + 1 lead
+	{ql: "c", anchor: "2026-01-01T00:01:00Z"}: 2, // 1 pair + 1 lead
+	{ql: "c", anchor: "2026-01-01T00:01:30Z"}: 2, // 1 pair + 1 lead
+	{ql: "c", anchor: "2026-01-01T00:02:00Z"}: 3, // 2 pairs + 1 lead
+	{ql: "c", anchor: "2026-01-01T00:02:30Z"}: 3, // 2 pairs + 1 lead
+	{ql: "c", anchor: "2026-01-01T00:03:00Z"}: 4, // 3 pairs + 1 lead
+	{ql: "c", anchor: "2026-01-01T00:03:30Z"}: 4, // 3 pairs + 1 lead
+	{ql: "c", anchor: "2026-01-01T00:04:00Z"}: 5, // 4 pairs + 1 lead
+	{ql: "c", anchor: "2026-01-01T00:04:30Z"}: 5, // 4 pairs + 1 lead
+	{ql: "c", anchor: "2026-01-01T00:05:00Z"}: 5, // 4 pairs (t=0 excluded by left-open bound) + 1 lead (t=1 still NaN)
+	{ql: "d", anchor: "2026-01-01T00:02:00Z"}: 1, // 1 nan-nan pair, finite lead
+	{ql: "d", anchor: "2026-01-01T00:02:30Z"}: 1, // 1 nan-nan pair, finite lead
+	{ql: "d", anchor: "2026-01-01T00:03:00Z"}: 1, // 1 nan-nan pair, finite lead
+	{ql: "d", anchor: "2026-01-01T00:03:30Z"}: 1, // 1 nan-nan pair, finite lead
+	{ql: "d", anchor: "2026-01-01T00:04:00Z"}: 1, // 1 nan-nan pair, finite lead
+	{ql: "d", anchor: "2026-01-01T00:04:30Z"}: 1, // 1 nan-nan pair, finite lead
+	{ql: "d", anchor: "2026-01-01T00:05:00Z"}: 2, // 1 nan-nan pair + 1 lead (t=0 excluded, t=1 NaN leads)
 }
 
 func TestNativeTSGridChanges_DualEmitParity(t *testing.T) {
@@ -216,15 +238,15 @@ func TestNativeTSGridChanges_DualEmitParity(t *testing.T) {
 			t.Errorf("cell %+v present in fan-out but absent in native", cell)
 			continue
 		}
-		if changesKnownNativeNaNLeadOvercount[cell] {
-			// #1721: pinned NaN-leading-window overcount. Assert the EXACT
-			// known shape (native = fanout + 1), not merely "don't check" —
-			// any other relationship means the bug changed shape and this
-			// pin is stale.
-			if math.Float64bits(nv) != math.Float64bits(fv+1) {
-				t.Errorf("cell %+v: expected the pinned #1721 divergence native=fanout+1 "+
+		if offset, known := changesKnownNativeCarveoutGap[cell]; known {
+			// #1721: pinned nanPairCount+leadNaNOvercount gap. Assert the
+			// EXACT known offset, not merely "don't check" — any other
+			// relationship means the gap changed shape and this pin is stale.
+			want := fv + float64(offset)
+			if math.Float64bits(nv) != math.Float64bits(want) {
+				t.Errorf("cell %+v: expected the pinned #1721 carve-out gap native=fanout+%d "+
 					"(fanout=%.20g so native should be %.20g), got native=%.20g — the known "+
-					"divergence shape changed; update or remove this pin", cell, fv, fv+1, nv)
+					"divergence shape changed; update or remove this pin", cell, offset, fv, want, nv)
 			}
 			continue
 		}
@@ -237,8 +259,8 @@ func TestNativeTSGridChanges_DualEmitParity(t *testing.T) {
 		identical++
 	}
 	t.Logf("changes dual-emit parity: %d/%d cells bit-identical, %d cells hold the pinned "+
-		"#1721 NaN-leading-window divergence. native == fan-out == Prometheus everywhere else.",
-		identical, len(fanout), len(changesKnownNativeNaNLeadOvercount))
+		"#1721 NaN-carve-out gap. native == fan-out == Prometheus everywhere else.",
+		identical, len(fanout), len(changesKnownNativeCarveoutGap))
 }
 
 // runChangesEmit lowers + emits the changes query with the native-changes

--- a/internal/chsql/range_window_test.go
+++ b/internal/chsql/range_window_test.go
@@ -105,9 +105,11 @@ func TestRangeWindowGapFunctionsEmit(t *testing.T) {
 			name: "changes",
 			fn:   "changes",
 			wantSubstrs: []string{
-				// Change detection: per-adjacent-pair `if(c != p, 1, 0)`.
-				"if(c != p, 1, 0)",
-				"arraySum(arrayMap((p, c) -> if(c != p, 1, 0), arrayPopBack(window_vals), arrayPopFront(window_vals)))",
+				// Change detection: per-adjacent-pair `if(c != p AND NOT
+				// (isNaN(c) AND isNaN(p)), 1, 0)` — Prom's funcChanges
+				// carve-out for NaN-on-both-sides pairs (#1489).
+				"if(c != p AND NOT (isNaN(c) AND isNaN(p)), 1, 0)",
+				"arraySum(arrayMap((p, c) -> if(c != p AND NOT (isNaN(c) AND isNaN(p)), 1, 0), arrayPopBack(window_vals), arrayPopFront(window_vals)))",
 				"CAST(arraySum",
 				"AS Float64)",
 			},

--- a/test/perf/cardinality-baseline.json
+++ b/test/perf/cardinality-baseline.json
@@ -2640,6 +2640,17 @@
     "uncountable_levels": 0
   },
   {
+    "fixture": "promql/changes_nan_run",
+    "fan_factor": 1,
+    "scan_rows": 8,
+    "peak_intermediate": 8,
+    "has_cross_join": false,
+    "has_array_join": false,
+    "has_recursive_cte": false,
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
+  },
+  {
     "fixture": "promql/changes_oscillating",
     "fan_factor": 1,
     "scan_rows": 5,

--- a/test/perf/solver-decision-baseline.json
+++ b/test/perf/solver-decision-baseline.json
@@ -590,6 +590,16 @@
     "outer_range": "1h0m0s"
   },
   {
+    "query": "changes_nan_run",
+    "routed": true,
+    "k": 8,
+    "reason": "routed",
+    "n_anchors": 241,
+    "fanout": 20,
+    "cumulative_d": "5m0s",
+    "outer_range": "1h0m0s"
+  },
+  {
     "query": "changes_oscillating",
     "routed": true,
     "k": 8,

--- a/test/spec/promql/changes_nan_run.txtar
+++ b/test/spec/promql/changes_nan_run.txtar
@@ -8,14 +8,18 @@ CREATE TABLE otel_metrics_gauge (
     Value Float64
 ) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 INSERT INTO otel_metrics_gauge VALUES
-    ('load_state', map('host', 'a'), toDateTime64('2025-12-31 23:59:00', 9), 0.0),
-    ('load_state', map('host', 'a'), toDateTime64('2025-12-31 23:59:15', 9), 1.0),
-    ('load_state', map('host', 'a'), toDateTime64('2025-12-31 23:59:30', 9), 1.0),
-    ('load_state', map('host', 'a'), toDateTime64('2025-12-31 23:59:45', 9), 0.0),
-    ('load_state', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 1.0);
+    ('load_state', map('host', 'c'), toDateTime64('2025-12-31 23:58:00', 9), nan),
+    ('load_state', map('host', 'c'), toDateTime64('2025-12-31 23:59:00', 9), nan),
+    ('load_state', map('host', 'c'), toDateTime64('2026-01-01 00:00:00', 9), nan),
+    ('load_state', map('host', 'd'), toDateTime64('2025-12-31 23:56:00', 9), 3.0),
+    ('load_state', map('host', 'd'), toDateTime64('2025-12-31 23:57:00', 9), nan),
+    ('load_state', map('host', 'd'), toDateTime64('2025-12-31 23:58:00', 9), nan),
+    ('load_state', map('host', 'd'), toDateTime64('2025-12-31 23:59:00', 9), 3.0),
+    ('load_state', map('host', 'd'), toDateTime64('2026-01-01 00:00:00', 9), 4.0);
 -- expected_rows --
 [
-  [{"host": "a"}, 3.0]
+  [{"host": "c"}, 0],
+  [{"host": "d"}, 3]
 ]
 -- args --
 [0] string = "service.name"


### PR DESCRIPTION
## Summary

Prometheus's `funcChanges` never counts a NaN-adjacent-to-NaN sample pair as a change (`!(NaN(curr) && NaN(prev))`). Cerberus's fan-out `emitRangeWindowChanges` kernel counted every `c != p` pair, including both-NaN ones, since IEEE-754 `NaN != NaN` evaluates true. This fixes the emitted SQL to match Prometheus: `c != p AND NOT (isNaN(c) AND isNaN(p))`. A NaN paired with a finite value still counts as a change on both sides — the carve-out only suppresses the both-NaN case.

**Which kernel this fixes:** this closes **#1489**, which is specifically about the fan-out `RangeWindow` kernel's (`internal/chsql/range_window.go`'s `emitRangeWindowChanges`) divergence from Prometheus. It does **not** close **#1721** — that issue is about a *separate* divergence between the (now-corrected) fan-out kernel and cerberus's native `timeSeriesChangesToGrid` ClickHouse builtin, which implements no NaN-NaN carve-out of its own and can't be patched from this PR (it's a native CH function, not typed-Frag SQL cerberus emits).

Fixing #1489 actually **widens** the evidence-backed characterization of #1721: `internal/chsql/range_window_changes_chdb_test.go`'s dual-emit parity test previously pinned only a narrower "lead-NaN overcount" divergence (masked because the old, also-uncarved-out fan-out happened to agree with native almost everywhere). With the fan-out now correct, the full gap is `nanPairCount + leadNaNOvercount` per cell — this PR updates the pin from a boolean set to an explicit, hand-derived-and-verified per-cell integer offset map (`changesKnownNativeCarveoutGap`), asserting the exact known relationship rather than merely skipping the check.

## Changes

- `internal/chsql/range_window.go`: the carve-out fix itself.
- `internal/chsql/range_window_test.go`: updated SQL-shape pin for the new `if(c != p AND NOT (isNaN(c) AND isNaN(p)), 1, 0)` expression.
- `internal/chsql/range_window_changes_chdb_test.go`: widened #1721 characterization, `changesKnownNativeCarveoutGap` pin (18 cells, exact offsets), verified against real chDB execution.
- `test/spec/promql/changes_nan_run.txtar`: new golden fixture with a NaN run (as issue #1489 explicitly asks for), covering both the pre-optimizer SQL-shape golden (`TestLower`) and the chDB numeric-result golden (`TestRoundTripChDB`).
- `test/spec/promql/changes_oscillating.txtar`: pre-existing golden regenerated for the new SQL shape (no NaN in its seed, so only the SQL text changed, not the numeric result).
- `compatibility/prometheus/cmd/seed/main.go` + `prom_remote.go` + `cerberus-test-queries.yml`: new `demo_gauge_with_nan_run` fixture family (a 2-sample NaN-NaN run inside the window) plus a `changes(demo_gauge_with_nan_run[{{.range}}])` corpus case — the "matching compatibility corpus case" issue #1489 asks for, pinning this fix against a real reference Prometheus rather than only chDB. The fixture's NaN values propagate to the remote-written reference series automatically, since the seed mirror reads `Value` straight back out of ClickHouse.

## Verification

- Sabotage-and-restore: confirmed `TestLower/changes_nan_run` genuinely fails when the fix is reverted (explicit SQL diff), while `TestRoundTripChDB/changes_nan_run` is immune by design (it validates the golden SQL text's own chDB execution semantics, not code-emission — `TestLower` is the discriminating layer for code regressions).
- `go build ./...` clean.
- `go test ./internal/chsql/... ./internal/promql/... ./test/regression/...` — all pass.
- `go test -tags chdb -count=1 ./internal/chsql/... ./test/spec/...` — all pass, including `TestNativeTSGridChanges_DualEmitParity` (31/49 cells bit-identical, 18 cells hold the pinned #1721 carve-out gap).
- `node .github/scripts/forbid-sql-raw.mjs` — clean (the fix composes typed Frags; `Not(Paren(And(...)))` is required because `Not`/`And` add no automatic parens — an earlier draft without the `Paren` wrap rendered `NOT isNaN(c) AND isNaN(p)`, parsed as `(NOT isNaN(c)) AND isNaN(p)`, and broke NaN-free data too. Caught via chDB dual-emit parity testing before this PR).
- `test/regression/compat_promql_seed_corpus_test.go` (`TestCompatCorpusReferencesOnlySeededMetrics`, `TestCompatSeedMirrorsEveryFixture`) — pass, confirming the new fixture family is correctly wired into both the CH-side seed and the Prometheus-side mirror.

Closes #1489