### PR TITLE
fix(promql): thread scalar args for predict_linear/holt_winters/quantile_over_time over a subquery

### DIFF
--- a/internal/chsql/range_window_fused.go
+++ b/internal/chsql/range_window_fused.go
@@ -5,7 +5,7 @@ import "github.com/tsouza/cerberus/internal/chplan"
 // This file implements the memory-bounded FUSED emitter for instant PromQL
 // subqueries of the shape `<reducer>(rate|increase|delta(m[range])[outer:step])`
 // where <reducer> is an order-independent *_over_time aggregate
-// (min/max/count/present).
+// (min/max/count).
 //
 // The materialized path (emitWindowedArrayExtrapolatedMatrix +
 // emitRangeWindowOverTimeDirect) builds a 5-layer stack whose
@@ -42,6 +42,13 @@ type fusedReduce func(perAnchorVals Frag) Frag
 // materialized path. Only the order-independent reducers that route through
 // emitRangeWindowOverTimeDirect are fusible here; sum/avg/quantile/stddev/…
 // reach the array path (emitWindowedArray) and never hit this dispatch.
+//
+// present_over_time is deliberately absent: it is NOT a member of
+// rangeVectorFn (internal/promql/subquery.go), the set that gates whether a
+// PromQL function accepts a subquery argument at all, so no valid query can
+// build the nested-RangeWindow shape tryEmitFusedInstantSubquery dispatches
+// on for it. Adding a case here without also widening rangeVectorFn would be
+// dead code with zero fixture or chDB coverage backing its correctness (#1706).
 func fusedOuterReducer(fn string) (fusedReduce, bool) {
 	switch fn {
 	case "max_over_time":
@@ -55,12 +62,6 @@ func fusedOuterReducer(fn string) (fusedReduce, bool) {
 		return func(vals Frag) Frag {
 			return Call("toFloat64", Call("arrayReduce", InlineLit("count"), vals))
 		}, true
-	case "present_over_time":
-		// The outer WHERE length(qualified_anchors) > 0 guarantees at least
-		// one qualifying anchor, so present is the constant 1 — matching the
-		// materialized direct path's toFloat64(1). vals is intentionally
-		// unused (and so never rendered).
-		return func(Frag) Frag { return Call("toFloat64", InlineLit(int64(1))) }, true
 	}
 	return nil, false
 }

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -1840,8 +1840,16 @@ func matchOp(t labels.MatchType) chplan.BinaryOp {
 func lowerCall(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
 	// `quantile_over_time(phi, v[range])` takes a scalar first; the
 	// range-vector lives at c.Args[1]. Route it before the generic
-	// "is c.Args[0] a MatrixSelector?" check below.
+	// "is c.Args[0] a MatrixSelector?" check below — including the
+	// subquery form `quantile_over_time(phi, rate(m[5m])[1h:5m])`, whose
+	// range-vector arg is a SubqueryExpr rather than a MatrixSelector and
+	// so needs its own outer-reducer dispatch (#1456).
 	if c.Func.Name == "quantile_over_time" {
+		if len(c.Args) == 2 {
+			if sq, ok := c.Args[1].(*parser.SubqueryExpr); ok {
+				return lowerOuterRangeFnOverSubquery(c, sq, s, ctx)
+			}
+		}
 		return lowerQuantileOverTime(c, s, ctx)
 	}
 	if len(c.Args) >= 1 {

--- a/internal/promql/subquery.go
+++ b/internal/promql/subquery.go
@@ -512,13 +512,31 @@ func lowerOuterRangeFnOverSubquery(
 	}
 
 	rw := &chplan.RangeWindow{
-		Input:           inner,
-		Func:            outer.Func.Name,
+		Input: inner,
+		// Use the canonical "holt_winters" IR name regardless of whether
+		// the source query used the legacy name or the
+		// `double_exponential_smoothing` alias — the chsql emitter
+		// switches on the IR name only, mirroring lowerHoltWinters's
+		// same canonicalization in range_fns.go.
+		Func:            canonicalRangeWindowFunc(outer.Func.Name),
 		Range:           sub.Range,
 		Offset:          anchor.Offset,
 		TimestampColumn: "anchor_ts",
 		ValueColumn:     s.ValueColumn,
 		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: s.AttributesColumn}},
+	}
+
+	// predict_linear / holt_winters / quantile_over_time carry extra
+	// scalar arguments beyond the subquery itself; thread them onto rw
+	// the same way the non-subquery lowerers in range_fns.go do
+	// (Scalars for a literal, ScalarExprs for a computed scalar()
+	// expression). value is ordinarily rw's own Value column;
+	// quantile_over_time's out-of-range literal phi folds it to the
+	// PromQL-spec ±Inf/NaN constant instead, mirroring
+	// lowerQuantileOverTime's post-Project fold (#1456).
+	value, replaceValue, err := threadOuterRangeFnScalars(outer, rw, s, ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	rangeMode := ctx.rangeMode()
@@ -555,8 +573,7 @@ func lowerOuterRangeFnOverSubquery(
 		if rangeFnPreservesName(outer.Func.Name) {
 			nameExpr = &chplan.LitString{V: ""}
 		}
-		return wrapRangeWindowAtBroadcast(rw, ctx, s, nameExpr,
-			&chplan.ColumnRef{Name: s.ValueColumn}), nil
+		return wrapRangeWindowAtBroadcast(rw, ctx, s, nameExpr, value), nil
 	case rangeMode:
 		// Range mode: the outer reducer in `max_over_time(rate(m[5m])[1h:5m])`
 		// must fan across the request's step grid so each anchor in
@@ -616,7 +633,102 @@ func lowerOuterRangeFnOverSubquery(
 			widenSubquerySpine(inner, anchor.End.Add(-rw.Offset-sub.Range), anchor.End)
 		}
 	}
-	return rw, nil
+	if !replaceValue {
+		return rw, nil
+	}
+	return projectValueOverInner(rw, s, value), nil
+}
+
+// canonicalRangeWindowFunc maps a parsed PromQL function name to the
+// name the chsql emitter's RangeWindow dispatch switches on. Only
+// holt_winters / double_exponential_smoothing need this: the upstream
+// parser only recognises the `double_exponential_smoothing` spelling
+// (the legacy `holt_winters` name was removed upstream and is rejected
+// at parse time), but the emitter's switch — and rangeVectorFn below —
+// key on the IR's "holt_winters" name regardless of source spelling.
+func canonicalRangeWindowFunc(name string) string {
+	if name == "double_exponential_smoothing" {
+		return "holt_winters"
+	}
+	return name
+}
+
+// threadOuterRangeFnScalars extracts and validates the extra scalar
+// argument(s) an outer range-vector function over a subquery requires,
+// beyond the subquery itself — mirroring lowerPredictLinear /
+// lowerHoltWinters / lowerQuantileOverTime's literal-vs-computed
+// extraction in range_fns.go, adapted for the arg POSITIONS this call
+// shape uses: predict_linear / holt_winters carry the subquery at
+// outer.Args[0] with the trailing scalar(s) after it; quantile_over_time
+// carries phi at outer.Args[0] with the subquery at outer.Args[1] (its
+// PromQL signature is `quantile_over_time(phi, v[range])`).
+//
+// Functions outside this set (rate, *_over_time without extra scalars,
+// …) fall through untouched: value is rw's own Value column and
+// replaceValue is false.
+//
+// The returned value is the expression the caller should ultimately
+// project as the Value column: ordinarily rw's own Value column, or —
+// for quantile_over_time with an out-of-range literal phi —
+// PromQL-spec's ±Inf / NaN constant, with replaceValue=true telling the
+// caller to fold it in via projectValueOverInner /
+// wrapRangeWindowAtBroadcast instead of forwarding rw's own aggregate.
+func threadOuterRangeFnScalars(
+	outer *parser.Call, rw *chplan.RangeWindow, s schema.Metrics, ctx lowerCtx,
+) (value chplan.Expr, replaceValue bool, err error) {
+	value = &chplan.ColumnRef{Name: s.ValueColumn}
+	switch outer.Func.Name {
+	case "predict_linear":
+		if len(outer.Args) != 2 {
+			return nil, false, fmt.Errorf("promql: predict_linear expects 2 arguments, got %d", len(outer.Args))
+		}
+		if t, ok := tryScalarLiteral(outer.Args[1]); ok {
+			rw.Scalars = []float64{t}
+		} else {
+			computed, cerr := lowerScalarArg(outer.Args[1], s, ctx)
+			if cerr != nil {
+				return nil, false, cerr
+			}
+			rw.ScalarExprs = []chplan.Expr{computed}
+		}
+	case "holt_winters", "double_exponential_smoothing":
+		if len(outer.Args) != 3 {
+			return nil, false, fmt.Errorf("promql: holt_winters expects 3 arguments, got %d", len(outer.Args))
+		}
+		sf, okSf := tryScalarLiteral(outer.Args[1])
+		tf, okTf := tryScalarLiteral(outer.Args[2])
+		if !okSf || !okTf {
+			return nil, false, fmt.Errorf("promql: holt_winters requires scalar-literal smoothing and trend factors")
+		}
+		if sf <= 0 || sf >= 1 {
+			return nil, false, fmt.Errorf("promql: holt_winters smoothing factor must be in (0, 1), got %v", sf)
+		}
+		if tf <= 0 || tf >= 1 {
+			return nil, false, fmt.Errorf("promql: holt_winters trend factor must be in (0, 1), got %v", tf)
+		}
+		rw.Scalars = []float64{sf, tf}
+	case "quantile_over_time":
+		if len(outer.Args) != 2 {
+			return nil, false, fmt.Errorf("promql: quantile_over_time expects 2 arguments, got %d", len(outer.Args))
+		}
+		if phi, ok := tryScalarLiteral(outer.Args[0]); ok {
+			if infValue, replace := outOfRangePhiInf(phi); replace {
+				// Out-of-range / NaN literal: feed the same in-domain
+				// sentinel the non-subquery lowering uses to the inner
+				// aggregate and fold the spec value on the way out.
+				rw.Scalars = []float64{quantileSentinelPhi}
+				return &chplan.LitFloat{V: infValue}, true, nil
+			}
+			rw.ScalarExprs = []chplan.Expr{&chplan.LitFloat{V: phi}}
+		} else {
+			computed, cerr := lowerScalarArg(outer.Args[0], s, ctx)
+			if cerr != nil {
+				return nil, false, cerr
+			}
+			rw.ScalarExprs = []chplan.Expr{computed}
+		}
+	}
+	return value, false, nil
 }
 
 // widenSubquerySpine threads the range-mode evaluation window down a
@@ -673,26 +785,34 @@ func widenSubquerySpine(n chplan.Node, start, end time.Time) {
 // handles as range-vector reducers — i.e. every RangeWindow.Func the
 // windowed-array emitters support in both instant and matrix
 // (OuterRange > 0) modes. Subquery-argument lowering only fires for
-// these. predict_linear / holt_winters / quantile_over_time are
-// excluded: they carry extra scalar arguments the subquery RangeWindow
-// construction doesn't thread.
+// these. predict_linear / holt_winters / quantile_over_time carry extra
+// scalar arguments beyond the subquery itself; threadOuterRangeFnScalars
+// (called from lowerOuterRangeFnOverSubquery) threads them onto the
+// RangeWindow the same way range_fns.go's non-subquery lowerers do (#1456).
+// Both "holt_winters" and "double_exponential_smoothing" are listed even
+// though the upstream parser only ever produces the latter today — same
+// forward-compat rationale as lowerRangeVectorCall's two-spelling case.
 var rangeVectorFn = map[string]struct{}{
-	"rate":             {},
-	"irate":            {},
-	"increase":         {},
-	"delta":            {},
-	"idelta":           {},
-	"deriv":            {},
-	"resets":           {},
-	"changes":          {},
-	"sum_over_time":    {},
-	"avg_over_time":    {},
-	"min_over_time":    {},
-	"max_over_time":    {},
-	"count_over_time":  {},
-	"last_over_time":   {},
-	"stddev_over_time": {},
-	"stdvar_over_time": {},
+	"rate":                         {},
+	"irate":                        {},
+	"increase":                     {},
+	"delta":                        {},
+	"idelta":                       {},
+	"deriv":                        {},
+	"resets":                       {},
+	"changes":                      {},
+	"sum_over_time":                {},
+	"avg_over_time":                {},
+	"min_over_time":                {},
+	"max_over_time":                {},
+	"count_over_time":              {},
+	"last_over_time":               {},
+	"stddev_over_time":             {},
+	"stdvar_over_time":             {},
+	"predict_linear":               {},
+	"holt_winters":                 {},
+	"double_exponential_smoothing": {},
+	"quantile_over_time":           {},
 }
 
 // instantTransformFns is the set of sample-preserving instant-vector

--- a/test/perf/cardinality-baseline.json
+++ b/test/perf/cardinality-baseline.json
@@ -6171,6 +6171,17 @@
     "uncountable_levels": 0
   },
   {
+    "fixture": "promql/subquery_holt_winters_rate",
+    "fan_factor": 1,
+    "scan_rows": 4,
+    "peak_intermediate": 4,
+    "has_cross_join": false,
+    "has_array_join": true,
+    "has_recursive_cte": false,
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
+  },
+  {
     "fixture": "promql/subquery_irate_nested",
     "fan_factor": 5,
     "scan_rows": 3,
@@ -6406,6 +6417,39 @@
     "fan_factor": 1.3333333333333333,
     "scan_rows": 6,
     "peak_intermediate": 8,
+    "has_cross_join": false,
+    "has_array_join": true,
+    "has_recursive_cte": false,
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
+  },
+  {
+    "fixture": "promql/subquery_predict_linear_rate",
+    "fan_factor": 1,
+    "scan_rows": 4,
+    "peak_intermediate": 4,
+    "has_cross_join": false,
+    "has_array_join": true,
+    "has_recursive_cte": false,
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
+  },
+  {
+    "fixture": "promql/subquery_quantile_over_time_out_of_range_phi",
+    "fan_factor": 1,
+    "scan_rows": 2,
+    "peak_intermediate": 2,
+    "has_cross_join": false,
+    "has_array_join": true,
+    "has_recursive_cte": false,
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
+  },
+  {
+    "fixture": "promql/subquery_quantile_over_time_rate",
+    "fan_factor": 1,
+    "scan_rows": 2,
+    "peak_intermediate": 2,
     "has_cross_join": false,
     "has_array_join": true,
     "has_recursive_cte": false,

--- a/test/perf/solver-decision-baseline.json
+++ b/test/perf/solver-decision-baseline.json
@@ -3850,6 +3850,16 @@
     "outer_range": "1h0m0s"
   },
   {
+    "query": "subquery_holt_winters_rate",
+    "routed": false,
+    "k": 0,
+    "reason": "high-D",
+    "n_anchors": 241,
+    "fanout": 240,
+    "cumulative_d": "1h5m0s",
+    "outer_range": "1h0m0s"
+  },
+  {
     "query": "subquery_irate_nested",
     "routed": true,
     "k": 3,
@@ -4067,6 +4077,36 @@
     "n_anchors": 241,
     "fanout": 240,
     "cumulative_d": "1h1m0s",
+    "outer_range": "1h0m0s"
+  },
+  {
+    "query": "subquery_predict_linear_rate",
+    "routed": false,
+    "k": 0,
+    "reason": "high-D",
+    "n_anchors": 241,
+    "fanout": 240,
+    "cumulative_d": "1h5m0s",
+    "outer_range": "1h0m0s"
+  },
+  {
+    "query": "subquery_quantile_over_time_out_of_range_phi",
+    "routed": false,
+    "k": 0,
+    "reason": "high-D",
+    "n_anchors": 241,
+    "fanout": 240,
+    "cumulative_d": "1h5m0s",
+    "outer_range": "1h0m0s"
+  },
+  {
+    "query": "subquery_quantile_over_time_rate",
+    "routed": false,
+    "k": 0,
+    "reason": "high-D",
+    "n_anchors": 241,
+    "fanout": 240,
+    "cumulative_d": "1h5m0s",
     "outer_range": "1h0m0s"
   },
   {

--- a/test/rejection-parity/catalogue.json
+++ b/test/rejection-parity/catalogue.json
@@ -927,6 +927,48 @@
     },
     {
       "head": "promql",
+      "site": "internal/promql/subquery.go:threadOuterRangeFnScalars#0ff3d8b3",
+      "message": "promql: holt_winters smoothing factor must be in (0, 1), got %v",
+      "class": "rejection",
+      "trigger_query": "double_exponential_smoothing(rate(http_requests_total[5m])[1h:5m], 1.5, 0.5)"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/subquery.go:threadOuterRangeFnScalars#15e82804",
+      "message": "promql: holt_winters requires scalar-literal smoothing and trend factors",
+      "class": "rejection",
+      "trigger_query": "double_exponential_smoothing(rate(http_requests_total[5m])[1h:5m], scalar(up), 0.5)"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/subquery.go:threadOuterRangeFnScalars#2b0de462",
+      "message": "promql: predict_linear expects 2 arguments, got %d",
+      "class": "internal",
+      "rationale": "parser-enforced arity: predict_linear is pinned at two arguments, so the subquery-argument lowering path can never observe a call with a different count"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/subquery.go:threadOuterRangeFnScalars#2db9f2aa",
+      "message": "promql: holt_winters trend factor must be in (0, 1), got %v",
+      "class": "rejection",
+      "trigger_query": "double_exponential_smoothing(rate(http_requests_total[5m])[1h:5m], 0.5, 1.5)"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/subquery.go:threadOuterRangeFnScalars#682124f4",
+      "message": "promql: quantile_over_time expects 2 arguments, got %d",
+      "class": "internal",
+      "rationale": "parser-enforced arity: quantile_over_time is pinned at two arguments, so the subquery-argument lowering path can never observe a call with a different count"
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/subquery.go:threadOuterRangeFnScalars#ceef5c3b",
+      "message": "promql: holt_winters expects 3 arguments, got %d",
+      "class": "internal",
+      "rationale": "parser-enforced arity: double_exponential_smoothing is pinned at three arguments, so the subquery-argument lowering path can never observe a call with a different count"
+    },
+    {
+      "head": "promql",
       "site": "internal/promql/synthetic.go:lowerQueryContextFold#5004da30",
       "message": "promql: %s() takes no arguments, got %d",
       "class": "internal",

--- a/test/spec/promql/subquery_holt_winters_rate.txtar
+++ b/test/spec/promql/subquery_holt_winters_rate.txtar
@@ -1,0 +1,47 @@
+# holt_winters over a subquery (#1456): the trailing smoothing/trend
+# scalars must thread through the chained-RangeWindow construction the
+# same way a plain (non-subquery) holt_winters threads them via
+# range_fns.go. `double_exponential_smoothing` is the only spelling the
+# upstream parser recognises (the legacy `holt_winters` name was removed
+# upstream and is rejected at parse time); the IR still canonicalizes to
+# "holt_winters" regardless (see canonicalRangeWindowFunc).
+-- query.promql --
+double_exponential_smoothing(rate(http_requests_total[5m])[1h:5m], 0.5, 0.5)
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_sum VALUES
+    ('http_requests_total', map('job', 'api'), toDateTime64('2025-12-31 23:50:30', 9), 0.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('2025-12-31 23:54:30', 9), 8.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('2025-12-31 23:55:30', 9), 8.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('2025-12-31 23:59:30', 9), 20.0);
+-- expected_rows --
+[
+  [{"job": "api"}, 0.05]
+]
+-- args --
+[0] string = "service.name"
+[1] string = "service_name"
+[2] string = "service.name"
+[3] string = "service_name"
+[4] string = ""
+[5] string = "service_name"
+[6] string = "http_requests_total"
+[7] string = "http.requests.total"
+[8] string = "http.requests/total"
+[9] string = "http.requests_total"
+[10] string = "http/requests/total"
+[11] string = "http/requests_total"
+[12] string = "http_requests.total"
+-- chplan --
+RangeWindow func=holt_winters range=1h0m0s step=0s ts=anchor_ts value=Value groupBy=[Attributes] scalars=[0.5, 0.5] start=0001-01-01T00:00:00Z end=2026-01-01T00:00:01Z
+  RangeWindow func=rate range=5m0s step=5m0s outerRange=1h0m0s ts=TimeUnix value=Value groupBy=[Attributes] start=2025-12-31T23:00:01Z end=2026-01-01T00:00:01Z
+    Project [MetricName AS MetricName, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, Value AS Value]
+      Filter predicate=(MetricName IN ("http_requests_total", "http.requests.total", "http.requests/total", "http.requests_total", "http/requests/total", "http/requests_total", "http_requests.total"))
+        Scan(otel_metrics_sum)
+-- sql --
+SELECT `Attributes`, if(length(window_vals) > 1, tupleElement(arrayFold((acc, x) -> (0.5 * x + 0.5 * (tupleElement(acc, 1) + tupleElement(acc, 2)), 0.5 * (0.5 * x + 0.5 * (tupleElement(acc, 1) + tupleElement(acc, 2)) - tupleElement(acc, 1)) + 0.5 * tupleElement(acc, 2)), arraySlice(window_vals, 3), (window_vals[2], window_vals[2] - window_vals[1])), 1), nan) AS `Value` FROM (SELECT `Attributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, arrayFilter(p -> tupleElement(p, 1) > toDateTime64('2026-01-01 00:00:01.000000000', 9) - toIntervalNanosecond(3600000000000) AND tupleElement(p, 1) <= toDateTime64('2026-01-01 00:00:01.000000000', 9), series_array) AS `window_pairs` FROM (SELECT `Attributes`, arraySort(groupArray((`anchor_ts`, `Value`))) AS `series_array` FROM (SELECT `Attributes`, `anchor_ts`, anchor_ts AS `TimeUnix`, if(sampled_interval > 0, counter_delta * (sampled_interval + if(counter_delta > 0 AND first_val >= 0, least(duration_to_start, sampled_interval * first_val / counter_delta), duration_to_start) + duration_to_end) / sampled_interval / 300, nan) AS `Value` FROM (SELECT `Attributes`, `anchor_ts`, `window_vals`, `counter_delta`, `first_val`, toFloat64(dateDiff('nanosecond', first_ts, last_ts)) / 1e9 AS `sampled_interval`, if(toFloat64(dateDiff('nanosecond', anchor_ts - toIntervalNanosecond(300000000000), first_ts)) / 1e9 >= 1.1 * sampled_interval / (length(window_vals) - 1), sampled_interval / (length(window_vals) - 1) / 2, toFloat64(dateDiff('nanosecond', anchor_ts - toIntervalNanosecond(300000000000), first_ts)) / 1e9) AS `duration_to_start`, if(toFloat64(dateDiff('nanosecond', last_ts, anchor_ts)) / 1e9 >= 1.1 * sampled_interval / (length(window_vals) - 1), sampled_interval / (length(window_vals) - 1) / 2, toFloat64(dateDiff('nanosecond', last_ts, anchor_ts)) / 1e9) AS `duration_to_end` FROM (SELECT `Attributes`, `anchor_ts`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta`, tupleElement(window_pairs[1], 1) AS `first_ts`, tupleElement(window_pairs[length(window_pairs)], 1) AS `last_ts`, tupleElement(window_pairs[1], 2) AS `first_val` FROM (SELECT `Attributes`, `anchor_ts`, arrayReverse(arrayCompact(p -> tupleElement(p, 1), arrayReverse(window_pairs))) AS `window_pairs` FROM (SELECT `Attributes`, `anchor_ts`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `window_pairs` FROM (SELECT `Attributes`, `TimeUnix`, `Value`, arrayJoin(arrayMap(i -> fromUnixTimestamp64Nano(intDiv(toUnixTimestamp64Nano(toDateTime64('2026-01-01 00:00:01.000000000', 9)), 300000000000) * 300000000000) - toIntervalNanosecond(i * 300000000000), range(greatest(0, intDiv(dateDiff('nanosecond', `TimeUnix`, fromUnixTimestamp64Nano(intDiv(toUnixTimestamp64Nano(toDateTime64('2026-01-01 00:00:01.000000000', 9)), 300000000000) * 300000000000)) - 300000000000, toInt64(300000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, fromUnixTimestamp64Nano(intDiv(toUnixTimestamp64Nano(toDateTime64('2026-01-01 00:00:01.000000000', 9)), 300000000000) * 300000000000)) - 300000000000, toInt64(300000000000)) < 0) + 1), least(12, intDiv(dateDiff('nanosecond', `TimeUnix`, fromUnixTimestamp64Nano(intDiv(toUnixTimestamp64Nano(toDateTime64('2026-01-01 00:00:01.000000000', 9)), 300000000000) * 300000000000)), toInt64(300000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, fromUnixTimestamp64Nano(intDiv(toUnixTimestamp64Nano(toDateTime64('2026-01-01 00:00:01.000000000', 9)), 300000000000) * 300000000000)), toInt64(300000000000)) < 0) + 1)))) AS `anchor_ts` FROM (SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?)))) WHERE `TimeUnix` > toDateTime64('2025-12-31 23:00:01.000000000', 9) - toIntervalNanosecond(300000000000) AND `TimeUnix` <= toDateTime64('2026-01-01 00:00:01.000000000', 9)) GROUP BY `Attributes`, `anchor_ts`)))) WHERE length(`window_vals`) >= 2) WHERE `anchor_ts` > toDateTime64('2026-01-01 00:00:01.000000000', 9) - toIntervalNanosecond(3600000000000) AND `anchor_ts` <= toDateTime64('2026-01-01 00:00:01.000000000', 9) GROUP BY `Attributes`))) WHERE length(`window_vals`) >= 2

--- a/test/spec/promql/subquery_predict_linear_rate.txtar
+++ b/test/spec/promql/subquery_predict_linear_rate.txtar
@@ -1,0 +1,44 @@
+# predict_linear over a subquery (#1456): the trailing horizon scalar
+# must thread through the chained-RangeWindow construction the same way
+# a plain (non-subquery) predict_linear threads it via range_fns.go.
+-- query.promql --
+predict_linear(rate(http_requests_total[5m])[1h:5m], 3600)
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_sum VALUES
+    ('http_requests_total', map('job', 'api'), toDateTime64('2025-12-31 23:50:30', 9), 0.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('2025-12-31 23:54:30', 9), 8.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('2025-12-31 23:55:30', 9), 8.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('2025-12-31 23:59:30', 9), 20.0);
+-- expected_rows --
+[
+  [{"job": "api"}, 0.2900666666666667]
+]
+-- args --
+[0] float64 = 3600
+[1] string = "service.name"
+[2] string = "service_name"
+[3] string = "service.name"
+[4] string = "service_name"
+[5] string = ""
+[6] string = "service_name"
+[7] string = "http_requests_total"
+[8] string = "http.requests.total"
+[9] string = "http.requests/total"
+[10] string = "http.requests_total"
+[11] string = "http/requests/total"
+[12] string = "http/requests_total"
+[13] string = "http_requests.total"
+-- chplan --
+RangeWindow func=predict_linear range=1h0m0s step=0s ts=anchor_ts value=Value groupBy=[Attributes] scalars=[3600] start=0001-01-01T00:00:00Z end=2026-01-01T00:00:01Z
+  RangeWindow func=rate range=5m0s step=5m0s outerRange=1h0m0s ts=TimeUnix value=Value groupBy=[Attributes] start=2025-12-31T23:00:01Z end=2026-01-01T00:00:01Z
+    Project [MetricName AS MetricName, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, Value AS Value]
+      Filter predicate=(MetricName IN ("http_requests_total", "http.requests.total", "http.requests/total", "http.requests_total", "http/requests/total", "http/requests_total", "http_requests.total"))
+        Scan(otel_metrics_sum)
+-- sql --
+SELECT `Attributes`, if(length(window_pairs) > 1, tupleElement(arrayReduce('simpleLinearRegression', arrayMap(p -> dateDiff('second', toDateTime64('2026-01-01 00:00:01.000000000', 9), tupleElement(p, 1)), window_pairs), arrayMap(p -> tupleElement(p, 2), window_pairs)), 2) + tupleElement(arrayReduce('simpleLinearRegression', arrayMap(p -> dateDiff('second', toDateTime64('2026-01-01 00:00:01.000000000', 9), tupleElement(p, 1)), window_pairs), arrayMap(p -> tupleElement(p, 2), window_pairs)), 1) * ?, nan) AS Value FROM (SELECT `Attributes`, arrayFilter(p -> tupleElement(p, 1) > toDateTime64('2026-01-01 00:00:01.000000000', 9) - toIntervalNanosecond(3600000000000) AND tupleElement(p, 1) <= toDateTime64('2026-01-01 00:00:01.000000000', 9), series_array) AS window_pairs FROM (SELECT `Attributes`, arraySort(groupArray((`anchor_ts`, `Value`))) AS series_array FROM (SELECT `Attributes`, `anchor_ts`, anchor_ts AS `TimeUnix`, if(sampled_interval > 0, counter_delta * (sampled_interval + if(counter_delta > 0 AND first_val >= 0, least(duration_to_start, sampled_interval * first_val / counter_delta), duration_to_start) + duration_to_end) / sampled_interval / 300, nan) AS `Value` FROM (SELECT `Attributes`, `anchor_ts`, `window_vals`, `counter_delta`, `first_val`, toFloat64(dateDiff('nanosecond', first_ts, last_ts)) / 1e9 AS `sampled_interval`, if(toFloat64(dateDiff('nanosecond', anchor_ts - toIntervalNanosecond(300000000000), first_ts)) / 1e9 >= 1.1 * sampled_interval / (length(window_vals) - 1), sampled_interval / (length(window_vals) - 1) / 2, toFloat64(dateDiff('nanosecond', anchor_ts - toIntervalNanosecond(300000000000), first_ts)) / 1e9) AS `duration_to_start`, if(toFloat64(dateDiff('nanosecond', last_ts, anchor_ts)) / 1e9 >= 1.1 * sampled_interval / (length(window_vals) - 1), sampled_interval / (length(window_vals) - 1) / 2, toFloat64(dateDiff('nanosecond', last_ts, anchor_ts)) / 1e9) AS `duration_to_end` FROM (SELECT `Attributes`, `anchor_ts`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta`, tupleElement(window_pairs[1], 1) AS `first_ts`, tupleElement(window_pairs[length(window_pairs)], 1) AS `last_ts`, tupleElement(window_pairs[1], 2) AS `first_val` FROM (SELECT `Attributes`, `anchor_ts`, arrayReverse(arrayCompact(p -> tupleElement(p, 1), arrayReverse(window_pairs))) AS `window_pairs` FROM (SELECT `Attributes`, `anchor_ts`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `window_pairs` FROM (SELECT `Attributes`, `TimeUnix`, `Value`, arrayJoin(arrayMap(i -> fromUnixTimestamp64Nano(intDiv(toUnixTimestamp64Nano(toDateTime64('2026-01-01 00:00:01.000000000', 9)), 300000000000) * 300000000000) - toIntervalNanosecond(i * 300000000000), range(greatest(0, intDiv(dateDiff('nanosecond', `TimeUnix`, fromUnixTimestamp64Nano(intDiv(toUnixTimestamp64Nano(toDateTime64('2026-01-01 00:00:01.000000000', 9)), 300000000000) * 300000000000)) - 300000000000, toInt64(300000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, fromUnixTimestamp64Nano(intDiv(toUnixTimestamp64Nano(toDateTime64('2026-01-01 00:00:01.000000000', 9)), 300000000000) * 300000000000)) - 300000000000, toInt64(300000000000)) < 0) + 1), least(12, intDiv(dateDiff('nanosecond', `TimeUnix`, fromUnixTimestamp64Nano(intDiv(toUnixTimestamp64Nano(toDateTime64('2026-01-01 00:00:01.000000000', 9)), 300000000000) * 300000000000)), toInt64(300000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, fromUnixTimestamp64Nano(intDiv(toUnixTimestamp64Nano(toDateTime64('2026-01-01 00:00:01.000000000', 9)), 300000000000) * 300000000000)), toInt64(300000000000)) < 0) + 1)))) AS `anchor_ts` FROM (SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?)))) WHERE `TimeUnix` > toDateTime64('2025-12-31 23:00:01.000000000', 9) - toIntervalNanosecond(300000000000) AND `TimeUnix` <= toDateTime64('2026-01-01 00:00:01.000000000', 9)) GROUP BY `Attributes`, `anchor_ts`)))) WHERE length(`window_vals`) >= 2) WHERE `anchor_ts` > toDateTime64('2026-01-01 00:00:01.000000000', 9) - toIntervalNanosecond(3600000000000) AND `anchor_ts` <= toDateTime64('2026-01-01 00:00:01.000000000', 9) GROUP BY `Attributes`)) WHERE length(`window_pairs`) >= 2

--- a/test/spec/promql/subquery_quantile_over_time_out_of_range_phi.txtar
+++ b/test/spec/promql/subquery_quantile_over_time_out_of_range_phi.txtar
@@ -1,0 +1,45 @@
+# quantile_over_time over a subquery with an out-of-range literal phi
+# (#1456): exercises threadOuterRangeFnScalars' replaceValue path —
+# the compile-time PromQL-spec +Inf fold (mirroring the non-subquery
+# quantile_over_time_q_above_one.txtar fixture) — through
+# projectValueOverInner rather than lowerQuantileOverTime's own
+# post-Project fold.
+-- query.promql --
+quantile_over_time(1.5, rate(http_requests_total[5m])[1h:5m])
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_sum VALUES
+    ('http_requests_total', map('job', 'api'), toDateTime64('2025-12-31 23:55:30', 9), 0.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('2025-12-31 23:59:30', 9), 30.0);
+-- expected_rows --
+[
+  [{"job": "api"}, "+Inf"]
+]
+-- args --
+[0] string = "service.name"
+[1] string = "service_name"
+[2] string = "service.name"
+[3] string = "service_name"
+[4] string = ""
+[5] string = "service_name"
+[6] string = "http_requests_total"
+[7] string = "http.requests.total"
+[8] string = "http.requests/total"
+[9] string = "http.requests_total"
+[10] string = "http/requests/total"
+[11] string = "http/requests_total"
+[12] string = "http_requests.total"
+-- chplan --
+Project [Attributes, +Inf AS Value]
+  RangeWindow func=quantile_over_time range=1h0m0s step=0s ts=anchor_ts value=Value groupBy=[Attributes] scalars=[0.5] start=0001-01-01T00:00:00Z end=2026-01-01T00:00:01Z
+    RangeWindow func=rate range=5m0s step=5m0s outerRange=1h0m0s ts=TimeUnix value=Value groupBy=[Attributes] start=2025-12-31T23:00:01Z end=2026-01-01T00:00:01Z
+      Project [MetricName AS MetricName, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, Value AS Value]
+        Filter predicate=(MetricName IN ("http_requests_total", "http.requests.total", "http.requests/total", "http.requests_total", "http/requests/total", "http/requests_total", "http_requests.total"))
+          Scan(otel_metrics_sum)
+-- sql --
+SELECT `Attributes`, (1.0/0) AS `Value` FROM (SELECT `Attributes`, if(length(window_vals) > 0, arrayReduce('quantile(0.5)', window_vals), nan) AS `Value` FROM (SELECT `Attributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, arrayFilter(p -> tupleElement(p, 1) > toDateTime64('2026-01-01 00:00:01.000000000', 9) - toIntervalNanosecond(3600000000000) AND tupleElement(p, 1) <= toDateTime64('2026-01-01 00:00:01.000000000', 9), series_array) AS `window_pairs` FROM (SELECT `Attributes`, arraySort(groupArray((`anchor_ts`, `Value`))) AS `series_array` FROM (SELECT `Attributes`, `anchor_ts`, anchor_ts AS `TimeUnix`, if(sampled_interval > 0, counter_delta * (sampled_interval + if(counter_delta > 0 AND first_val >= 0, least(duration_to_start, sampled_interval * first_val / counter_delta), duration_to_start) + duration_to_end) / sampled_interval / 300, nan) AS `Value` FROM (SELECT `Attributes`, `anchor_ts`, `window_vals`, `counter_delta`, `first_val`, toFloat64(dateDiff('nanosecond', first_ts, last_ts)) / 1e9 AS `sampled_interval`, if(toFloat64(dateDiff('nanosecond', anchor_ts - toIntervalNanosecond(300000000000), first_ts)) / 1e9 >= 1.1 * sampled_interval / (length(window_vals) - 1), sampled_interval / (length(window_vals) - 1) / 2, toFloat64(dateDiff('nanosecond', anchor_ts - toIntervalNanosecond(300000000000), first_ts)) / 1e9) AS `duration_to_start`, if(toFloat64(dateDiff('nanosecond', last_ts, anchor_ts)) / 1e9 >= 1.1 * sampled_interval / (length(window_vals) - 1), sampled_interval / (length(window_vals) - 1) / 2, toFloat64(dateDiff('nanosecond', last_ts, anchor_ts)) / 1e9) AS `duration_to_end` FROM (SELECT `Attributes`, `anchor_ts`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta`, tupleElement(window_pairs[1], 1) AS `first_ts`, tupleElement(window_pairs[length(window_pairs)], 1) AS `last_ts`, tupleElement(window_pairs[1], 2) AS `first_val` FROM (SELECT `Attributes`, `anchor_ts`, arrayReverse(arrayCompact(p -> tupleElement(p, 1), arrayReverse(window_pairs))) AS `window_pairs` FROM (SELECT `Attributes`, `anchor_ts`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `window_pairs` FROM (SELECT `Attributes`, `TimeUnix`, `Value`, arrayJoin(arrayMap(i -> fromUnixTimestamp64Nano(intDiv(toUnixTimestamp64Nano(toDateTime64('2026-01-01 00:00:01.000000000', 9)), 300000000000) * 300000000000) - toIntervalNanosecond(i * 300000000000), range(greatest(0, intDiv(dateDiff('nanosecond', `TimeUnix`, fromUnixTimestamp64Nano(intDiv(toUnixTimestamp64Nano(toDateTime64('2026-01-01 00:00:01.000000000', 9)), 300000000000) * 300000000000)) - 300000000000, toInt64(300000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, fromUnixTimestamp64Nano(intDiv(toUnixTimestamp64Nano(toDateTime64('2026-01-01 00:00:01.000000000', 9)), 300000000000) * 300000000000)) - 300000000000, toInt64(300000000000)) < 0) + 1), least(12, intDiv(dateDiff('nanosecond', `TimeUnix`, fromUnixTimestamp64Nano(intDiv(toUnixTimestamp64Nano(toDateTime64('2026-01-01 00:00:01.000000000', 9)), 300000000000) * 300000000000)), toInt64(300000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, fromUnixTimestamp64Nano(intDiv(toUnixTimestamp64Nano(toDateTime64('2026-01-01 00:00:01.000000000', 9)), 300000000000) * 300000000000)), toInt64(300000000000)) < 0) + 1)))) AS `anchor_ts` FROM (SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?)))) WHERE `TimeUnix` > toDateTime64('2025-12-31 23:00:01.000000000', 9) - toIntervalNanosecond(300000000000) AND `TimeUnix` <= toDateTime64('2026-01-01 00:00:01.000000000', 9)) GROUP BY `Attributes`, `anchor_ts`)))) WHERE length(`window_vals`) >= 2) WHERE `anchor_ts` > toDateTime64('2026-01-01 00:00:01.000000000', 9) - toIntervalNanosecond(3600000000000) AND `anchor_ts` <= toDateTime64('2026-01-01 00:00:01.000000000', 9) GROUP BY `Attributes`))) WHERE length(`window_vals`) >= 1)

--- a/test/spec/promql/subquery_quantile_over_time_rate.txtar
+++ b/test/spec/promql/subquery_quantile_over_time_rate.txtar
@@ -1,0 +1,52 @@
+# quantile_over_time over a subquery (#1456): phi lives at Args[0] and
+# the subquery at Args[1] — lowerCall's quantile_over_time special-case
+# must route the subquery form to lowerOuterRangeFnOverSubquery instead
+# of always calling lowerQuantileOverTime (which expects a plain
+# MatrixSelector at Args[1]).
+-- query.promql --
+quantile_over_time(0.9, rate(http_requests_total[5m])[1h:5m])
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_sum VALUES
+    ('http_requests_total', map('job', 'api'), toDateTime64('2025-12-31 23:55:30', 9), 0.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('2025-12-31 23:59:30', 9), 30.0);
+-- expected_rows --
+[
+  [{"job": "api"}, 0.1125]
+]
+-- args --
+[0] float64 = 0.9
+[1] float64 = 0.9
+[2] float64 = 0.9
+[3] float64 = 0.9
+[4] float64 = 0.9
+[5] float64 = 0.9
+[6] float64 = 0.9
+[7] float64 = 0.9
+[8] float64 = 0.9
+[9] string = "service.name"
+[10] string = "service_name"
+[11] string = "service.name"
+[12] string = "service_name"
+[13] string = ""
+[14] string = "service_name"
+[15] string = "http_requests_total"
+[16] string = "http.requests.total"
+[17] string = "http.requests/total"
+[18] string = "http.requests_total"
+[19] string = "http/requests/total"
+[20] string = "http/requests_total"
+[21] string = "http_requests.total"
+-- chplan --
+RangeWindow func=quantile_over_time range=1h0m0s step=0s ts=anchor_ts value=Value groupBy=[Attributes] scalarExprs=[0.9] start=0001-01-01T00:00:00Z end=2026-01-01T00:00:01Z
+  RangeWindow func=rate range=5m0s step=5m0s outerRange=1h0m0s ts=TimeUnix value=Value groupBy=[Attributes] start=2025-12-31T23:00:01Z end=2026-01-01T00:00:01Z
+    Project [MetricName AS MetricName, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, Value AS Value]
+      Filter predicate=(MetricName IN ("http_requests_total", "http.requests.total", "http.requests/total", "http.requests_total", "http/requests/total", "http/requests_total", "http_requests.total"))
+        Scan(otel_metrics_sum)
+-- sql --
+SELECT `Attributes`, multiIf(isNaN(toFloat64(?)), nan, toFloat64(?) < 0, (-1.0/0), toFloat64(?) > 1, (1.0/0), arraySort(window_vals)[toUInt32(floor((toFloat64(?) * toFloat64(length(window_vals) - 1)))) + 1] * (1 - ((toFloat64(?) * toFloat64(length(window_vals) - 1)) - floor((toFloat64(?) * toFloat64(length(window_vals) - 1))))) + arraySort(window_vals)[toUInt32(least(toFloat64(length(window_vals) - 1), floor((toFloat64(?) * toFloat64(length(window_vals) - 1))) + 1)) + 1] * ((toFloat64(?) * toFloat64(length(window_vals) - 1)) - floor((toFloat64(?) * toFloat64(length(window_vals) - 1))))) AS `Value` FROM (SELECT `Attributes`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta` FROM (SELECT `Attributes`, arrayFilter(p -> tupleElement(p, 1) > toDateTime64('2026-01-01 00:00:01.000000000', 9) - toIntervalNanosecond(3600000000000) AND tupleElement(p, 1) <= toDateTime64('2026-01-01 00:00:01.000000000', 9), series_array) AS `window_pairs` FROM (SELECT `Attributes`, arraySort(groupArray((`anchor_ts`, `Value`))) AS `series_array` FROM (SELECT `Attributes`, `anchor_ts`, anchor_ts AS `TimeUnix`, if(sampled_interval > 0, counter_delta * (sampled_interval + if(counter_delta > 0 AND first_val >= 0, least(duration_to_start, sampled_interval * first_val / counter_delta), duration_to_start) + duration_to_end) / sampled_interval / 300, nan) AS `Value` FROM (SELECT `Attributes`, `anchor_ts`, `window_vals`, `counter_delta`, `first_val`, toFloat64(dateDiff('nanosecond', first_ts, last_ts)) / 1e9 AS `sampled_interval`, if(toFloat64(dateDiff('nanosecond', anchor_ts - toIntervalNanosecond(300000000000), first_ts)) / 1e9 >= 1.1 * sampled_interval / (length(window_vals) - 1), sampled_interval / (length(window_vals) - 1) / 2, toFloat64(dateDiff('nanosecond', anchor_ts - toIntervalNanosecond(300000000000), first_ts)) / 1e9) AS `duration_to_start`, if(toFloat64(dateDiff('nanosecond', last_ts, anchor_ts)) / 1e9 >= 1.1 * sampled_interval / (length(window_vals) - 1), sampled_interval / (length(window_vals) - 1) / 2, toFloat64(dateDiff('nanosecond', last_ts, anchor_ts)) / 1e9) AS `duration_to_end` FROM (SELECT `Attributes`, `anchor_ts`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta`, tupleElement(window_pairs[1], 1) AS `first_ts`, tupleElement(window_pairs[length(window_pairs)], 1) AS `last_ts`, tupleElement(window_pairs[1], 2) AS `first_val` FROM (SELECT `Attributes`, `anchor_ts`, arrayReverse(arrayCompact(p -> tupleElement(p, 1), arrayReverse(window_pairs))) AS `window_pairs` FROM (SELECT `Attributes`, `anchor_ts`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `window_pairs` FROM (SELECT `Attributes`, `TimeUnix`, `Value`, arrayJoin(arrayMap(i -> fromUnixTimestamp64Nano(intDiv(toUnixTimestamp64Nano(toDateTime64('2026-01-01 00:00:01.000000000', 9)), 300000000000) * 300000000000) - toIntervalNanosecond(i * 300000000000), range(greatest(0, intDiv(dateDiff('nanosecond', `TimeUnix`, fromUnixTimestamp64Nano(intDiv(toUnixTimestamp64Nano(toDateTime64('2026-01-01 00:00:01.000000000', 9)), 300000000000) * 300000000000)) - 300000000000, toInt64(300000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, fromUnixTimestamp64Nano(intDiv(toUnixTimestamp64Nano(toDateTime64('2026-01-01 00:00:01.000000000', 9)), 300000000000) * 300000000000)) - 300000000000, toInt64(300000000000)) < 0) + 1), least(12, intDiv(dateDiff('nanosecond', `TimeUnix`, fromUnixTimestamp64Nano(intDiv(toUnixTimestamp64Nano(toDateTime64('2026-01-01 00:00:01.000000000', 9)), 300000000000) * 300000000000)), toInt64(300000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, fromUnixTimestamp64Nano(intDiv(toUnixTimestamp64Nano(toDateTime64('2026-01-01 00:00:01.000000000', 9)), 300000000000) * 300000000000)), toInt64(300000000000)) < 0) + 1)))) AS `anchor_ts` FROM (SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?)))) WHERE `TimeUnix` > toDateTime64('2025-12-31 23:00:01.000000000', 9) - toIntervalNanosecond(300000000000) AND `TimeUnix` <= toDateTime64('2026-01-01 00:00:01.000000000', 9)) GROUP BY `Attributes`, `anchor_ts`)))) WHERE length(`window_vals`) >= 2) WHERE `anchor_ts` > toDateTime64('2026-01-01 00:00:01.000000000', 9) - toIntervalNanosecond(3600000000000) AND `anchor_ts` <= toDateTime64('2026-01-01 00:00:01.000000000', 9) GROUP BY `Attributes`))) WHERE length(`window_vals`) >= 1


### PR DESCRIPTION
## Summary

- Fixes `predict_linear` / `holt_winters` / `quantile_over_time` being wrongly rejected over a subquery argument (#1456): these three carry extra scalar arguments beyond the range-vector argument itself, and the subquery-argument lowering path (`lowerOuterRangeFnOverSubquery`) never threaded them onto the constructed `RangeWindow`. Adds `threadOuterRangeFnScalars` in `internal/promql/subquery.go`, mirroring the literal-vs-computed scalar extraction `range_fns.go`'s non-subquery lowerers already do, and routes `quantile_over_time`'s phi-first subquery form (`quantile_over_time(phi, v[range:step])`) through the same dispatch from `lowerCall`.
- Fixes `fusedOuterReducer`'s dead `present_over_time` branch (#1706), resolved via removal (#1706's own "option 2"): `present_over_time` was never a member of `rangeVectorFn`, the set gating which functions accept a subquery argument at all, so no valid query could ever reach that branch.
- Along the way, found and fixed a real parser-spelling bug: the upstream (`tsouza/prometheus`) parser only accepts the `double_exponential_smoothing` spelling — the legacy `holt_winters` name is rejected at parse time — but the subquery-argument gate (`rangeVectorFn`) and `threadOuterRangeFnScalars`'s switch only recognised `holt_winters`. The subquery form of the function was unreachable via any parseable query. Added `canonicalRangeWindowFunc` so the IR's `RangeWindow.Func` always uses the canonical `"holt_winters"` name regardless of source spelling (mirroring `lowerHoltWinters`'s own canonicalization for the non-subquery path), and widened both the gate map and the scalar-threading switch to accept both spellings.

## Fixtures

Four new TXTAR fixtures under `test/spec/promql/`, each with `seed` + chDB-executed `expected_rows`:

- `subquery_predict_linear_rate.txtar` — `predict_linear(rate(m[5m])[1h:5m], 3600)`
- `subquery_holt_winters_rate.txtar` — `double_exponential_smoothing(rate(m[5m])[1h:5m], 0.5, 0.5)`
- `subquery_quantile_over_time_rate.txtar` — `quantile_over_time(0.9, rate(m[5m])[1h:5m])`
- `subquery_quantile_over_time_out_of_range_phi.txtar` — `quantile_over_time(1.5, rate(m[5m])[1h:5m])`, exercising the PromQL-spec out-of-range-phi → `+Inf` fold through the subquery path's `projectValueOverInner`, mirroring the existing non-subquery `quantile_over_time_q_above_one.txtar` fixture's `Project [Attributes, +Inf AS Value]` shape.

## Rejection-parity catalogue

`threadOuterRangeFnScalars`'s new error sites needed classification in `test/rejection-parity/catalogue.json`:

- 3 arity-check sites → `class: "internal"` (parser-enforced arity — confirmed via probe that a wrong-arity call is a **parse** error, never reaches lowering).
- 3 `holt_winters` domain/literal-requirement sites → `class: "rejection"` with trigger queries — confirmed via probe (using the exact `LowerAtRange` call shape `TestRejectionTriggersExerciseSites` uses) that these genuinely are wire-reachable through ordinary subquery-form queries.

While classifying these, found the **pre-existing** (not touched by this PR) `internal/promql/range_fns.go:lowerHoltWinters` catalogue entries for the same three error messages carry a stale rationale claiming they're unreachable ("gated as experimental at lowerRangeVectorCall") — empirically false today for both non-subquery and subquery forms. Filed as #1738 rather than fixed here, since it's the pre-existing non-subquery sites, not the new subquery ones this PR adds.

Closes #1456
Closes #1706

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofumpt -extra -l .` clean
- [x] `go test ./internal/promql/... ./internal/chsql/... ./test/spec/... ./test/rejection-parity/... ./test/surface-parity/... ./test/perf/...`
- [x] `go test -tags chdb ./test/spec/...` (chDB roundtrip for all 4 new fixtures)
- [x] `node .github/scripts/forbid-sql-raw.mjs` clean
- [x] `just update-golden` full run (solver-decision baseline, tier-0 migration goldens, rejection/surface-parity ledgers, chDB fixtures, cardinality baseline) — all regenerated cleanly against latest `origin/main`
- [x] `TestCatalogueIsRegenerable`, `TestCatalogueEntriesAreClassified`, `TestRejectionTriggersExerciseSites` all pass
