### PR TITLE
fix(loki): bucket /patterns mining per detected level

### DIFF
--- a/internal/api/loki/conformance_test.go
+++ b/internal/api/loki/conformance_test.go
@@ -623,6 +623,8 @@ func TestConformance_LokiDetectedLabelsWire(t *testing.T) {
 //     legacy wrapper was dropped in #514 to match upstream Loki's
 //     `WriteQueryPatternsResponseJSON`),
 //   - each element decodes into `loki.Pattern{Pattern, Level, Samples}`,
+//     and `Level` carries a real per-cluster detected level (#1434),
+//     never the empty string,
 //   - each `samples[i]` is a 2-tuple `[unix_seconds, count]`. The first
 //     slot is unix SECONDS (not ms/ns) per upstream's
 //     `sample.Timestamp.Unix()` projection.
@@ -693,10 +695,13 @@ func TestConformance_LokiPatternsBasic(t *testing.T) {
 		if p.Pattern == "" {
 			t.Errorf("env.Data[%d].Pattern is empty", i)
 		}
-		// Level is "" in this slice (PR B emits empty level — see
-		// patterns.go doc + plan §5).
-		if p.Level != "" {
-			t.Errorf("env.Data[%d].Level=%q want empty (PR B does not bucket by level)", i, p.Level)
+		// The canned rows carry no SeverityText, so the normalized
+		// detected level resolves to "unknown" — mirroring reference
+		// Loki's constants.LogLevelUnknown stamping for severity-free
+		// records (#1434). It must never be the empty string upstream
+		// Grafana clients treat as "field absent".
+		if p.Level != "unknown" {
+			t.Errorf("env.Data[%d].Level=%q want %q", i, p.Level, "unknown")
 		}
 		for j, s := range p.Samples {
 			// unix_seconds for 2026-05-14T12:00:00Z is ~1.78e9. unix_ms

--- a/internal/api/loki/patterns.go
+++ b/internal/api/loki/patterns.go
@@ -11,6 +11,7 @@ import (
 	"github.com/tsouza/cerberus/internal/chclient"
 	"github.com/tsouza/cerberus/internal/chsql"
 	"github.com/tsouza/cerberus/internal/drain"
+	"github.com/tsouza/cerberus/internal/logql"
 	"github.com/tsouza/cerberus/internal/schema"
 	"github.com/tsouza/cerberus/internal/telemetry"
 )
@@ -28,9 +29,10 @@ const defaultPatternsLineLimit = 1000
 // each sample as a `[unix_seconds, count]` 2-tuple — the timestamp is
 // `sample.Timestamp.Unix()`, which strips the millisecond component.
 //
-// Level mirrors upstream's per-cluster `detected_level` discriminant.
-// Cerberus emits `""` for every cluster (one drain instance for all
-// severities, no per-level bucketing).
+// Level mirrors upstream's per-cluster `detected_level` discriminant:
+// cerberus buckets pattern mining per row's normalized SeverityText
+// (see [minePatterns]), so each cluster carries the level of the lines
+// that trained it.
 type Pattern struct {
 	Pattern string     `json:"pattern"`
 	Level   string     `json:"level"`
@@ -47,7 +49,7 @@ type Pattern struct {
 // `WriteQueryPatternsResponseJSON` wire shape:
 //
 //	{"status":"success","data":[
-//	   {"pattern":"GET /api/<_> 200","level":"","samples":[[ts,n], ...]},
+//	   {"pattern":"GET /api/<_> 200","level":"info","samples":[[ts,n], ...]},
 //	   ...
 //	]}
 //
@@ -57,9 +59,9 @@ type Pattern struct {
 // order every time"; the SQL emits `ORDER BY Timestamp DESC LIMIT N` so
 // chDB returns rows in deterministic order.
 //
-// Cerberus trains a single drain instance for all severities and emits
-// `level:""` for every cluster; Grafana's pattern panel renders both
-// with-level and without-level payloads.
+// Cerberus trains one drain instance per detected level (see
+// [minePatterns]), so each cluster carries a real `level` value —
+// Grafana's pattern panel filters by level using this field.
 func (h *Handler) handlePatterns(w http.ResponseWriter, r *http.Request) {
 	q := r.FormValue("query")
 	if q == "" {
@@ -106,19 +108,21 @@ func (h *Handler) handlePatterns(w http.ResponseWriter, r *http.Request) {
 
 // buildPatternsSQL renders:
 //
-//	SELECT `Timestamp`, `Body`
+//	SELECT `Timestamp`, `Body`, `SeverityText`
 //	FROM `otel_logs`
 //	WHERE <matchers> AND <time bounds>
 //	ORDER BY `Timestamp` DESC
 //	LIMIT <lineLimit>
 //
-// Mirrors buildDetectedFieldsSQL but projects two columns — drain needs
-// both the body and a real timestamp to bucket per-cluster samples.
+// Mirrors buildDetectedFieldsSQL but projects three columns — drain
+// needs the body and a real timestamp to bucket per-cluster samples, and
+// [minePatterns] buckets mining itself by the row's raw severity.
 func buildPatternsSQL(s schema.Logs, matchers []*labels.Matcher, start, end time.Time, lineLimit int) (string, []any, error) {
 	sb := chsql.NewQuery().
 		Select(
 			chsql.Col(s.TimestampColumn),
 			chsql.Col(s.BodyColumn),
+			chsql.Col(s.SeverityColumn),
 		).
 		From(chsql.Col(s.LogsTable))
 
@@ -132,42 +136,64 @@ func buildPatternsSQL(s schema.Logs, matchers []*labels.Matcher, start, end time
 	return sqlStr, args, nil
 }
 
-// minePatterns trains a single drain instance over the peek window and
-// projects the resulting clusters onto the upstream `[]Pattern` wire
-// shape. Returns an empty (non-nil) slice when no lines hit any cluster
-// — the JSON envelope encodes that as `data:[]`, matching upstream Loki.
+// minePatterns buckets the peek window by each row's normalized
+// detected level ([logql.NormalizeDetectedLevel] of the row's raw
+// SeverityText), trains one drain instance per bucket, and projects the
+// resulting clusters onto the upstream `[]Pattern` wire shape — so each
+// cluster carries the real `level` of the lines that trained it, mirroring
+// upstream's per-cluster `detected_level` discriminant. Returns an empty
+// (non-nil) slice when no lines hit any cluster — the JSON envelope
+// encodes that as `data:[]`, matching upstream Loki.
 //
 // The miner is the in-house clean-room Drain implementation
 // (internal/drain), which tokenises on whitespace and treats
 // digit-bearing tokens as variables — generic enough for arbitrary log
-// lines without a per-format tokeniser gate.
+// lines without a per-format tokeniser gate. Each level bucket gets its
+// own drain.Miner instance (confirmed independent — a Miner owns its own
+// token tree and cluster slice, no shared state), so lines never mix
+// templates across levels.
 func minePatterns(lines []chclient.TimestampedLine) []Pattern {
-	d := drain.New(drain.DefaultConfig())
+	miners := make(map[string]*drain.Miner)
+	levels := make([]string, 0)
 	for _, line := range lines {
-		d.Train(line.Body, line.Timestamp.UnixNano())
+		level := logql.NormalizeDetectedLevel(line.Severity)
+		m, ok := miners[level]
+		if !ok {
+			m = drain.New(drain.DefaultConfig())
+			miners[level] = m
+			levels = append(levels, level)
+		}
+		m.Train(line.Body, line.Timestamp.UnixNano())
 	}
 
-	clusters := d.Clusters()
-	out := make([]Pattern, 0, len(clusters))
-	for _, c := range clusters {
-		if c == nil {
-			continue
+	out := make([]Pattern, 0)
+	for _, level := range levels {
+		for _, c := range miners[level].Clusters() {
+			if c == nil {
+				continue
+			}
+			s := c.String()
+			if s == "" {
+				continue
+			}
+			out = append(out, Pattern{
+				Pattern: s,
+				Level:   level,
+				Samples: projectSamples(c.Samples()),
+			})
 		}
-		s := c.String()
-		if s == "" {
-			continue
-		}
-		out = append(out, Pattern{
-			Pattern: s,
-			Level:   "",
-			Samples: projectSamples(c.Samples()),
-		})
 	}
 	// Stable response order — drain's Clusters() return order follows
 	// LRU cache traversal, which is not deterministic across runs.
-	// Sorting by pattern string lets Grafana / tests pin on the wire
-	// shape without flake.
-	sort.Slice(out, func(i, j int) bool { return out[i].Pattern < out[j].Pattern })
+	// Sorting by (pattern, level) lets Grafana / tests pin on the wire
+	// shape without flake; the level tiebreak matters now that the same
+	// pattern string can recur across two different level buckets.
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Pattern != out[j].Pattern {
+			return out[i].Pattern < out[j].Pattern
+		}
+		return out[i].Level < out[j].Level
+	})
 	return out
 }
 

--- a/internal/api/loki/patterns_chdb_test.go
+++ b/internal/api/loki/patterns_chdb_test.go
@@ -36,7 +36,8 @@ import (
 // logsDDL is the minimal otel_logs schema the patterns handler reads.
 // The full upstream OTel exporter DDL has many more columns than the
 // handler touches — this projection covers exactly what
-// buildPatternsSQL selects (Timestamp, Body) plus the matcher target
+// buildPatternsSQL selects (Timestamp, Body, SeverityText — the last
+// added for #1434's per-level bucketing) plus the matcher target
 // (ResourceAttributes). Engine = Memory keeps the seed fast and avoids
 // MergeTree's PREWHERE / sort-key constraints; the patterns SQL does
 // not depend on either (it's a straight SELECT ... ORDER BY Timestamp
@@ -44,6 +45,7 @@ import (
 const logsDDL = `CREATE TABLE otel_logs (
     Timestamp DateTime64(9),
     Body String,
+    SeverityText String,
     ResourceAttributes Map(String, String)
 ) ENGINE = Memory;`
 
@@ -124,7 +126,7 @@ func TestPatterns_ChDB_DrainRoundtrip(t *testing.T) {
 	}
 
 	var inserts strings.Builder
-	inserts.WriteString("INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES\n")
+	inserts.WriteString("INSERT INTO otel_logs (Timestamp, Body, SeverityText, ResourceAttributes) VALUES\n")
 	for i, row := range seedRows {
 		ts := base.Add(row.dt).Format(tsFmt)
 		comma := ","
@@ -132,7 +134,7 @@ func TestPatterns_ChDB_DrainRoundtrip(t *testing.T) {
 			comma = ";"
 		}
 		fmt.Fprintf(&inserts,
-			"    (toDateTime64('%s', 9), '%s', map('job', 'api'))%s\n",
+			"    (toDateTime64('%s', 9), '%s', 'INFO', map('job', 'api'))%s\n",
 			ts, row.body, comma)
 	}
 
@@ -234,8 +236,8 @@ func TestPatterns_ChDB_EmptyWindow(t *testing.T) {
 	ts := base.Format(tsFmt)
 
 	seed := logsDDL + fmt.Sprintf(`
-INSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES
-    (toDateTime64('%s', 9), 'GET /api/foo status=200 latency=5ms', map('job', 'api'));`, ts)
+INSERT INTO otel_logs (Timestamp, Body, SeverityText, ResourceAttributes) VALUES
+    (toDateTime64('%s', 9), 'GET /api/foo status=200 latency=5ms', 'INFO', map('job', 'api'));`, ts)
 
 	srv, _ := newChDBPatternsServer(t, seed)
 

--- a/internal/api/loki/patterns_test.go
+++ b/internal/api/loki/patterns_test.go
@@ -62,10 +62,10 @@ func TestPatterns_DrainExtractsCommonTemplate(t *testing.T) {
 	base := time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC)
 	q := &stubQuerier{
 		tsLines: []chclient.TimestampedLine{
-			{Timestamp: base, Body: "GET /api/users/1 status=200 latency=5ms"},
-			{Timestamp: base.Add(1 * time.Second), Body: "GET /api/users/2 status=200 latency=7ms"},
-			{Timestamp: base.Add(2 * time.Second), Body: "GET /api/users/42 status=200 latency=4ms"},
-			{Timestamp: base.Add(3 * time.Second), Body: "GET /api/users/1337 status=200 latency=11ms"},
+			{Timestamp: base, Body: "GET /api/users/1 status=200 latency=5ms", Severity: "INFO"},
+			{Timestamp: base.Add(1 * time.Second), Body: "GET /api/users/2 status=200 latency=7ms", Severity: "INFO"},
+			{Timestamp: base.Add(2 * time.Second), Body: "GET /api/users/42 status=200 latency=4ms", Severity: "INFO"},
+			{Timestamp: base.Add(3 * time.Second), Body: "GET /api/users/1337 status=200 latency=11ms", Severity: "INFO"},
 		},
 	}
 
@@ -130,10 +130,70 @@ func TestPatterns_DrainExtractsCommonTemplate(t *testing.T) {
 			t.Errorf("sample ts=%d out of expected window [%d ± 1d]; likely a unit mis-shift", s[0], baseUnix)
 		}
 	}
-	// Level is empty in PR B — per-cluster bucketing lands in a
-	// follow-up (see patterns.go doc + plan § 5).
-	if hit.Level != "" {
-		t.Errorf("expected empty Level in PR B; got %q", hit.Level)
+	// Pattern mining buckets per normalized detected level; every
+	// trained line here carries SeverityText "INFO", so the cluster's
+	// Level must resolve to the canonical lowercase "info" (#1434).
+	if hit.Level != "info" {
+		t.Errorf("expected Level %q, got %q", "info", hit.Level)
+	}
+}
+
+// TestPatterns_BucketsByDetectedLevel feeds the handler two structurally
+// identical templates at different severities and asserts the handler
+// emits two DISTINCT clusters, one per level — pattern mining must not
+// merge lines whose only difference is severity, and each cluster's
+// Level must carry the real (normalized) detected level rather than the
+// empty string (#1434).
+func TestPatterns_BucketsByDetectedLevel(t *testing.T) {
+	t.Parallel()
+
+	base := time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC)
+	q := &stubQuerier{
+		tsLines: []chclient.TimestampedLine{
+			{Timestamp: base, Body: "connection reset by peer", Severity: "ERROR"},
+			{Timestamp: base.Add(1 * time.Second), Body: "connection reset by peer", Severity: "err"},
+			{Timestamp: base.Add(2 * time.Second), Body: "connection reset by peer", Severity: "WARN"},
+		},
+	}
+
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL +
+		`/loki/api/v1/patterns?query=%7Bjob%3D%22api%22%7D&start=1778760000&end=1778760100`)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+
+	var out patternsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	byLevel := map[string]int64{}
+	for _, p := range out.Data {
+		var total int64
+		for _, s := range p.Samples {
+			total += s[1]
+		}
+		byLevel[p.Level] += total
+	}
+	// The two "ERROR"/"err" lines normalize to the same "error" bucket
+	// (two samples); the "WARN" line is its own "warn" bucket (one
+	// sample) — never merged with the error-level cluster despite an
+	// identical line body.
+	if byLevel["error"] != 2 {
+		t.Errorf("expected 2 samples in level=error, got %d (byLevel=%+v)", byLevel["error"], byLevel)
+	}
+	if byLevel["warn"] != 1 {
+		t.Errorf("expected 1 sample in level=warn, got %d (byLevel=%+v)", byLevel["warn"], byLevel)
+	}
+	if _, ok := byLevel[""]; ok {
+		t.Errorf("expected no empty-level cluster, got byLevel=%+v", byLevel)
 	}
 }
 
@@ -179,10 +239,12 @@ func TestPatterns_PushesLineLimitToSQL(t *testing.T) {
 			if !strings.Contains(gotSQL, tc.wantLimit) {
 				t.Errorf("expected SQL to contain %q; got: %s", tc.wantLimit, gotSQL)
 			}
-			// Peek SQL must project both Timestamp and Body — drain
-			// needs the (ts, line) pair to bucket per-cluster samples.
-			if !strings.Contains(gotSQL, "`Timestamp`") || !strings.Contains(gotSQL, "`Body`") {
-				t.Errorf("expected SQL to project both Timestamp and Body; got: %s", gotSQL)
+			// Peek SQL must project Timestamp, Body, and SeverityText —
+			// drain needs the (ts, line) pair to bucket per-cluster
+			// samples, and the handler buckets mining itself by the
+			// row's severity (#1434).
+			if !strings.Contains(gotSQL, "`Timestamp`") || !strings.Contains(gotSQL, "`Body`") || !strings.Contains(gotSQL, "`SeverityText`") {
+				t.Errorf("expected SQL to project Timestamp, Body, and SeverityText; got: %s", gotSQL)
 			}
 		})
 	}

--- a/internal/chclient/client.go
+++ b/internal/chclient/client.go
@@ -1476,20 +1476,24 @@ func (c *Client) QueryDetectedFieldRows(ctx context.Context, sql string, args ..
 	return out, nil
 }
 
-// TimestampedLine is one (Timestamp, Body) tuple from the peek-window
-// SQL backing /loki/api/v1/patterns. The timestamp is the row's
-// DateTime64 value verbatim; the body is the raw log line. The drain
-// template miner consumes the pair via [drain.Miner.Train], which takes
-// the timestamp as unix nanoseconds.
+// TimestampedLine is one (Timestamp, Body, Severity) tuple from the
+// peek-window SQL backing /loki/api/v1/patterns. The timestamp is the
+// row's DateTime64 value verbatim; the body is the raw log line. The
+// drain template miner consumes the (Timestamp, Body) pair via
+// [drain.Miner.Train], which takes the timestamp as unix nanoseconds;
+// Severity is the row's raw SeverityText, used to bucket pattern mining
+// per detected level (see internal/logql.NormalizeDetectedLevel).
 type TimestampedLine struct {
 	Timestamp time.Time
 	Body      string
+	Severity  string
 }
 
-// QueryTimestampedLines runs sql and decodes a (DateTime64, String)
-// two-column result set into a flat slice. Used by /loki/api/v1/patterns
-// to feed the drain template miner — drain needs both the line body and
-// a timestamp to bucket per-cluster samples.
+// QueryTimestampedLines runs sql and decodes a (DateTime64, String,
+// String) three-column result set into a flat slice. Used by
+// /loki/api/v1/patterns to feed the drain template miner — drain needs
+// the line body and a timestamp to bucket per-cluster samples, and the
+// handler buckets mining itself by the row's severity.
 //
 // Guarded by the circuit breaker (see [Client] doc).
 func (c *Client) QueryTimestampedLines(ctx context.Context, sql string, args ...any) ([]TimestampedLine, error) {
@@ -1515,10 +1519,11 @@ func (c *Client) QueryTimestampedLines(ctx context.Context, sql string, args ...
 	for rows.Next() {
 		var ts time.Time
 		var body string
-		if err := rows.Scan(&ts, &body); err != nil {
+		var severity string
+		if err := rows.Scan(&ts, &body, &severity); err != nil {
 			return nil, fmt.Errorf("chclient: scan: %w", err)
 		}
-		out = append(out, TimestampedLine{Timestamp: ts, Body: body})
+		out = append(out, TimestampedLine{Timestamp: ts, Body: body, Severity: severity})
 		buffered += int64(len(body))
 		if err := logPeekBytesExceeded(buffered); err != nil {
 			return nil, err

--- a/internal/chclienttest/client.go
+++ b/internal/chclienttest/client.go
@@ -258,9 +258,9 @@ func (c *Client) QueryDetectedFieldRows(ctx context.Context, query string, args 
 	return out, nil
 }
 
-// QueryTimestampedLines runs sql and decodes a (DateTime64, String)
-// two-column result set into chclient.TimestampedLine tuples. Used by
-// /loki/api/v1/patterns to feed the drain template miner.
+// QueryTimestampedLines runs sql and decodes a (DateTime64, String,
+// String) three-column result set into chclient.TimestampedLine tuples.
+// Used by /loki/api/v1/patterns to feed the drain template miner.
 func (c *Client) QueryTimestampedLines(ctx context.Context, query string, args ...any) ([]chclient.TimestampedLine, error) {
 	if c.err != nil {
 		return nil, c.err
@@ -274,13 +274,14 @@ func (c *Client) QueryTimestampedLines(ctx context.Context, query string, args .
 	var out []chclient.TimestampedLine
 	for rows.Next() {
 		var (
-			ts   time.Time
-			body string
+			ts       time.Time
+			body     string
+			severity string
 		)
-		if err := rows.Scan(&ts, &body); err != nil {
+		if err := rows.Scan(&ts, &body, &severity); err != nil {
 			return nil, fmt.Errorf("chclienttest: scan: %w", err)
 		}
-		out = append(out, chclient.TimestampedLine{Timestamp: ts, Body: body})
+		out = append(out, chclient.TimestampedLine{Timestamp: ts, Body: body, Severity: severity})
 	}
 	if err := tolerantRowsErr(rows.Err()); err != nil {
 		return nil, fmt.Errorf("chclienttest: rows.Err: %w", err)

--- a/internal/logql/detected_level.go
+++ b/internal/logql/detected_level.go
@@ -1,6 +1,8 @@
 package logql
 
 import (
+	"strings"
+
 	syntax "github.com/tsouza/cerberus/internal/logql/lsyntax"
 
 	"github.com/tsouza/cerberus/internal/chplan"
@@ -231,24 +233,7 @@ func normaliseLevelExpr(value chplan.Expr) chplan.Expr {
 		Args: []chplan.Expr{value},
 	}
 
-	// Each (variants, canonical) pair builds an OR-chain comparison.
-	// Order matches upstream Loki's `normalizeLogLevel` switch:
-	// trace / debug / info / warn / error / critical / fatal.
-	type group struct {
-		variants  []string
-		canonical string
-	}
-	groups := []group{
-		{[]string{"trace", "trc"}, "trace"},
-		{[]string{"debug", "dbg"}, "debug"},
-		{[]string{"info", "inf", "information"}, "info"},
-		{[]string{"warn", "wrn", "warning"}, "warn"},
-		{[]string{"error", "err"}, "error"},
-		{[]string{"critical"}, "critical"},
-		{[]string{"fatal"}, "fatal"},
-	}
-
-	args := make([]chplan.Expr, 0, (len(groups)+1)*2+1)
+	args := make([]chplan.Expr, 0, (len(levelNormalizationGroups)+1)*2+1)
 	// Empty severity first — reference Loki stamps "unknown" when no
 	// level is detectable (constants.LogLevelUnknown), it never leaves
 	// the label absent or empty.
@@ -257,7 +242,7 @@ func normaliseLevelExpr(value chplan.Expr) chplan.Expr {
 		&chplan.Binary{Op: chplan.OpEq, Left: lowerValue, Right: &chplan.LitString{V: ""}},
 		&chplan.LitString{V: "unknown"},
 	)
-	for _, g := range groups {
+	for _, g := range levelNormalizationGroups {
 		args = append(args, anyEqual(lowerValue, g.variants), &chplan.LitString{V: g.canonical})
 	}
 	// Default branch — pass through the lowercased original. Matches
@@ -265,6 +250,61 @@ func normaliseLevelExpr(value chplan.Expr) chplan.Expr {
 	args = append(args, lowerValue)
 
 	return &chplan.FuncCall{Name: "multiIf", Args: args}
+}
+
+// levelNormalizationGroup pairs the input-variant spellings upstream
+// Loki's `normalizeLogLevel` accepts with the canonical lowercase level
+// string they map to.
+type levelNormalizationGroup struct {
+	variants  []string
+	canonical string
+}
+
+// levelNormalizationGroups is the single source of truth for the
+// variant→canonical mapping, order matching upstream Loki's
+// `normalizeLogLevel` switch: trace / debug / info / warn / error /
+// critical / fatal. Shared by [normaliseLevelExpr] (the SQL `multiIf`
+// cascade) and [NormalizeDetectedLevel] (the plain-Go equivalent) so the
+// two derivations can't drift apart.
+var levelNormalizationGroups = []levelNormalizationGroup{
+	{[]string{"trace", "trc"}, "trace"},
+	{[]string{"debug", "dbg"}, "debug"},
+	{[]string{"info", "inf", "information"}, "info"},
+	{[]string{"warn", "wrn", "warning"}, "warn"},
+	{[]string{"error", "err"}, "error"},
+	{[]string{"critical"}, "critical"},
+	{[]string{"fatal"}, "fatal"},
+}
+
+// NormalizeDetectedLevel maps a raw severity/level string to Loki's
+// canonical lowercase level set entirely in Go — the string-typed
+// counterpart to [normaliseLevelExpr]'s SQL `multiIf` cascade, built from
+// the same [levelNormalizationGroups] table so the two can't diverge.
+//
+// An empty input maps to `"unknown"`, matching reference Loki's
+// `constants.LogLevelUnknown` stamping (see [normaliseLevelExpr]'s doc
+// comment). A non-empty input that matches none of the known variants
+// falls through to its lowercased form, matching upstream
+// `normalizeLogLevel`'s default branch.
+//
+// Used by `/loki/api/v1/patterns` (internal/api/loki/patterns.go) to
+// bucket pattern mining per detected level: that handler resolves each
+// row's SeverityText once in Go rather than pushing a chplan expression
+// through the optimizer/emit pipeline for a value it already has in
+// hand.
+func NormalizeDetectedLevel(raw string) string {
+	lower := strings.ToLower(raw)
+	if lower == "" {
+		return "unknown"
+	}
+	for _, g := range levelNormalizationGroups {
+		for _, v := range g.variants {
+			if lower == v {
+				return g.canonical
+			}
+		}
+	}
+	return lower
 }
 
 // anyEqual returns a left-folded OR-chain of `expr = variant`


### PR DESCRIPTION
## Summary

- `/loki/api/v1/patterns` trained one drain instance across every severity and hardcoded `level:""` on every cluster (`internal/api/loki/patterns.go:161-163` before this change) — a Grafana panel filtering patterns by level got nothing back.
- `minePatterns` now buckets lines by their normalized detected level (Go-side `logql.NormalizeDetectedLevel`, extracted from the same `levelNormalizationGroups` table `internal/logql/detected_level.go`'s SQL `multiIf` cascade already used, so the two derivations can't drift) and trains one `drain.Miner` per bucket. Each cluster's `Level` now reflects the lines that trained it. An empty/absent severity resolves to `"unknown"`, matching reference Loki's `constants.LogLevelUnknown` stamping.
- `buildPatternsSQL` now selects `SeverityText` alongside `Timestamp`/`Body`; `chclient.TimestampedLine` gains a `Severity` field.

Fixes #1434.

## Follow-up filed

`compatibility/loki` has no differential harness at all for `/loki/api/v1/patterns` (only `/detected_fields` has one) — building that is a distinct, non-trivial unit of work, tracked separately in #1743 rather than bundled here.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/api/loki/... ./internal/logql/... ./internal/chclient/... ./internal/chclienttest/...`
- [x] Updated `internal/api/loki/patterns_test.go` (fixed the stale "Level is empty in PR B" pin, added `TestPatterns_BucketsByDetectedLevel` proving two structurally-identical lines at different severities land in distinct level buckets and never merge) and `internal/api/loki/conformance_test.go` (flipped the wire-shape pin from empty `Level` to `"unknown"` for severity-free canned rows)
- [x] lefthook pre-push (golangci-lint, forbid-sql-raw, forbid-skip, forbid-soft-assert, forbid-escape-hatch, markdownlint) green locally