### PR TITLE
fix(prom): return upstream's recursive AST shape from /api/v1/parse_query

### DIFF
--- a/internal/api/prom/conformance_test.go
+++ b/internal/api/prom/conformance_test.go
@@ -514,52 +514,104 @@ func TestConformance_FormatQueryWire(t *testing.T) {
 	}
 }
 
-// TestConformance_ParseQueryWire — `/api/v1/parse_query` returns
-// `data: {type, node}` — cerberus's minimal AST shape.
+// TestConformance_ParseQueryWire — `/api/v1/parse_query` returns the
+// SAME recursive node tree upstream Prometheus's `/api/v1/parse_query`
+// does (upstream's unexported `translateAST`, ported verbatim in
+// `internal/api/prom/parse_query_ast.go`), not a flattened `{type,
+// node}` stub — Grafana's query-builder tree view depends on the real
+// shape (#1440).
 func TestConformance_ParseQueryWire(t *testing.T) {
 	t.Parallel()
 
-	cases := []struct {
-		name string
-		path string
-	}{
-		{"identifier", "/api/v1/parse_query?query=up"},
-		{"function", "/api/v1/parse_query?query=rate(up%5B5m%5D)"},
-		{"binary", "/api/v1/parse_query?query=up%2Bdown"},
-	}
-	for _, tc := range cases {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			srv := newServer(&stubQuerier{})
-			t.Cleanup(srv.Close)
+	t.Run("identifier", func(t *testing.T) {
+		t.Parallel()
+		data := decodeParseQuery(t, "/api/v1/parse_query?query=up")
+		if got := data["type"]; got != "vectorSelector" {
+			t.Fatalf("type: got %v, want vectorSelector; data=%+v", got, data)
+		}
+		if got := data["name"]; got != "up" {
+			t.Errorf("name: got %v, want up", got)
+		}
+		matchers, ok := data["matchers"].([]any)
+		if !ok || len(matchers) != 1 {
+			t.Fatalf("matchers: got %+v, want one __name__ matcher", data["matchers"])
+		}
+		m, ok := matchers[0].(map[string]any)
+		if !ok || m["name"] != "__name__" || m["value"] != "up" {
+			t.Errorf("matcher[0]: got %+v, want __name__=up", matchers[0])
+		}
+	})
 
-			resp, err := http.Get(srv.URL + tc.path)
-			if err != nil {
-				t.Fatalf("GET: %v", err)
-			}
-			body := readBody(t, resp)
-			if resp.StatusCode != http.StatusOK {
-				t.Fatalf("status=%d body=%s", resp.StatusCode, body)
-			}
-			var env struct {
-				Status string `json:"status"`
-				Data   struct {
-					Type string `json:"type"`
-					Node string `json:"node"`
-				} `json:"data"`
-			}
-			if err := json.Unmarshal([]byte(body), &env); err != nil {
-				t.Fatalf("decode: %v body=%s", err, body)
-			}
-			if env.Status != "success" {
-				t.Errorf("status: got %q, want success", env.Status)
-			}
-			if env.Data.Type == "" || env.Data.Node == "" {
-				t.Errorf("expected non-empty Type+Node, got %+v", env.Data)
-			}
-		})
+	t.Run("function", func(t *testing.T) {
+		t.Parallel()
+		data := decodeParseQuery(t, "/api/v1/parse_query?query=rate(up%5B5m%5D)")
+		if got := data["type"]; got != "call" {
+			t.Fatalf("type: got %v, want call; data=%+v", got, data)
+		}
+		fn, ok := data["func"].(map[string]any)
+		if !ok || fn["name"] != "rate" {
+			t.Fatalf("func.name: got %+v, want rate", data["func"])
+		}
+		args, ok := data["args"].([]any)
+		if !ok || len(args) != 1 {
+			t.Fatalf("args: got %+v, want one matrixSelector arg", data["args"])
+		}
+		arg, ok := args[0].(map[string]any)
+		if !ok || arg["type"] != "matrixSelector" || arg["name"] != "up" {
+			t.Fatalf("args[0]: got %+v, want matrixSelector(up)", args[0])
+		}
+		const fiveMinutesMillis = float64(5 * time.Minute / time.Millisecond)
+		if got := arg["range"]; got != fiveMinutesMillis {
+			t.Errorf("args[0].range: got %v, want %v (5m in ms)", got, fiveMinutesMillis)
+		}
+	})
+
+	t.Run("binary", func(t *testing.T) {
+		t.Parallel()
+		data := decodeParseQuery(t, "/api/v1/parse_query?query=up%2Bdown")
+		if got := data["type"]; got != "binaryExpr" {
+			t.Fatalf("type: got %v, want binaryExpr; data=%+v", got, data)
+		}
+		if got := data["op"]; got != "+" {
+			t.Errorf("op: got %v, want +", got)
+		}
+		lhs, ok := data["lhs"].(map[string]any)
+		if !ok || lhs["type"] != "vectorSelector" || lhs["name"] != "up" {
+			t.Errorf("lhs: got %+v, want vectorSelector(up)", data["lhs"])
+		}
+		rhs, ok := data["rhs"].(map[string]any)
+		if !ok || rhs["type"] != "vectorSelector" || rhs["name"] != "down" {
+			t.Errorf("rhs: got %+v, want vectorSelector(down)", data["rhs"])
+		}
+	})
+}
+
+// decodeParseQuery issues a GET against `path` and returns the decoded
+// `data` object of a `/api/v1/parse_query` response.
+func decodeParseQuery(t *testing.T, path string) map[string]any {
+	t.Helper()
+	srv := newServer(&stubQuerier{})
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + path)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
 	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+	var env struct {
+		Status string         `json:"status"`
+		Data   map[string]any `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(body), &env); err != nil {
+		t.Fatalf("decode: %v body=%s", err, body)
+	}
+	if env.Status != "success" {
+		t.Fatalf("status: got %q, want success", env.Status)
+	}
+	return env.Data
 }
 
 // TestConformance_PromExemplarsBasic pins the populated-data envelope

--- a/internal/api/prom/handler.go
+++ b/internal/api/prom/handler.go
@@ -261,10 +261,10 @@ func (h *Handler) handleFormatQuery(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleParseQuery implements `/api/v1/parse_query`. Takes a `query`
-// param, parses it, and returns the AST. Upstream Prometheus returns
-// a rich nested-node tree; cerberus returns a minimal shape that
-// signals "parsed OK" via the Type field — enough for Grafana's
-// inline syntax check.
+// param, parses it, and returns the recursive AST — the exact node
+// shape upstream Prometheus's `/api/v1/parse_query` returns (see
+// [translatePromQLAST]), which Grafana's query-builder tree view
+// depends on.
 func (h *Handler) handleParseQuery(w http.ResponseWriter, r *http.Request) {
 	// r.FormValue merges URL query params with POST form-encoded body
 	// (auto-calling ParseForm). Matches the consistent surface used by
@@ -281,10 +281,7 @@ func (h *Handler) handleParseQuery(w http.ResponseWriter, r *http.Request) {
 	}
 	writeJSON(w, http.StatusOK, Response{
 		Status: "success",
-		Data: map[string]any{
-			"type": fmt.Sprintf("%T", expr),
-			"node": expr.String(),
-		},
+		Data:   translatePromQLAST(expr),
 	})
 }
 

--- a/internal/api/prom/handler_chdb_test.go
+++ b/internal/api/prom/handler_chdb_test.go
@@ -437,11 +437,8 @@ func TestParseQuery_ChDB(t *testing.T) {
 		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
 	}
 	var parsed struct {
-		Status string `json:"status"`
-		Data   struct {
-			Type string `json:"type"`
-			Node string `json:"node"`
-		} `json:"data"`
+		Status string         `json:"status"`
+		Data   map[string]any `json:"data"`
 	}
 	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
 		t.Fatalf("unmarshal: %v", err)
@@ -449,7 +446,7 @@ func TestParseQuery_ChDB(t *testing.T) {
 	if parsed.Status != "success" {
 		t.Fatalf("status=%q", parsed.Status)
 	}
-	if parsed.Data.Type == "" || parsed.Data.Node != "up" {
+	if parsed.Data["type"] != "vectorSelector" || parsed.Data["name"] != "up" {
 		t.Errorf("unexpected parse data: %+v", parsed.Data)
 	}
 }

--- a/internal/api/prom/handler_test.go
+++ b/internal/api/prom/handler_test.go
@@ -547,9 +547,10 @@ func TestFormatQuery(t *testing.T) {
 	}
 }
 
-// TestParseQuery — `/api/v1/parse_query` returns the AST type +
-// stringified node. Minimal shape; enough for Grafana's inline
-// syntax check.
+// TestParseQuery — `/api/v1/parse_query` returns the same recursive
+// AST node tree upstream Prometheus's endpoint does (#1440), not a
+// flattened `{type, node}` stub. `up` parses to a single
+// `vectorSelector` node carrying one `__name__` matcher.
 func TestParseQuery(t *testing.T) {
 	t.Parallel()
 
@@ -566,11 +567,8 @@ func TestParseQuery(t *testing.T) {
 	}
 
 	var parsed struct {
-		Status string `json:"status"`
-		Data   struct {
-			Type string `json:"type"`
-			Node string `json:"node"`
-		} `json:"data"`
+		Status string         `json:"status"`
+		Data   map[string]any `json:"data"`
 	}
 	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
 		t.Fatalf("unmarshal: %v\nbody=%s", err, body)
@@ -578,11 +576,19 @@ func TestParseQuery(t *testing.T) {
 	if parsed.Status != "success" {
 		t.Fatalf("status: got %q, want success", parsed.Status)
 	}
-	if parsed.Data.Type == "" {
-		t.Errorf("expected non-empty Type; got %q", parsed.Data.Type)
+	if got := parsed.Data["type"]; got != "vectorSelector" {
+		t.Errorf("expected type=vectorSelector; got %v (data=%+v)", got, parsed.Data)
 	}
-	if parsed.Data.Node != "up" {
-		t.Errorf("expected Node=`up`; got %q", parsed.Data.Node)
+	if got := parsed.Data["name"]; got != "up" {
+		t.Errorf("expected name=up; got %v", got)
+	}
+	matchers, ok := parsed.Data["matchers"].([]any)
+	if !ok || len(matchers) != 1 {
+		t.Fatalf("expected one matcher; got %+v", parsed.Data["matchers"])
+	}
+	m, ok := matchers[0].(map[string]any)
+	if !ok || m["name"] != "__name__" || m["value"] != "up" {
+		t.Errorf("expected __name__=up matcher; got %+v", matchers[0])
 	}
 }
 

--- a/internal/api/prom/parse_query_ast.go
+++ b/internal/api/prom/parse_query_ast.go
@@ -1,0 +1,217 @@
+package prom
+
+import (
+	"strconv"
+
+	"github.com/prometheus/prometheus/model/labels"
+	promparser "github.com/prometheus/prometheus/promql/parser"
+)
+
+// translatePromQLAST ports upstream Prometheus's `translateAST` (the
+// function backing its own `/api/v1/parse_query`, unexported in
+// `web/api/v1/translate_ast.go`) into cerberus verbatim — same field
+// reads, same JSON keys, same node-type coverage. Cerberus parses with
+// the identical `promql/parser` package (via the `tsouza/prometheus`
+// Dependabot-boundary fork, zero patches — see go.mod's replace and
+// docs/upstream-forks.md), so every field this function reads
+// (VectorSelector.Anchored/Smoothed/OriginalOffsetExpr/StartOrEnd,
+// MatrixSelector.RangeExpr, SubqueryExpr.StepExpr, DurationExpr,
+// BinaryExpr.VectorMatching, Call.Func) exists on cerberus's parsed AST
+// exactly as it does on upstream's. Reimplementing (rather than vendoring
+// the unexported function) is Apache-2.0-clean: it is upstream's own
+// Apache-licensed logic, transcribed rather than imported because the
+// symbol is unexported.
+//
+// Grafana's PromQL query-builder / tree view (and any other client
+// depending on Prometheus's documented `/api/v1/parse_query` response
+// shape) parses this exact recursive node structure — a `{type, node}`
+// stub broke that integration even though it "parsed OK".
+func translatePromQLAST(node promparser.Expr) any {
+	if node == nil {
+		return nil
+	}
+
+	switch n := node.(type) {
+	case *promparser.AggregateExpr:
+		return map[string]any{
+			"type":     "aggregation",
+			"op":       n.Op.String(),
+			"expr":     translatePromQLAST(n.Expr),
+			"param":    translatePromQLAST(n.Param),
+			"grouping": sanitizeStringList(n.Grouping),
+			"without":  n.Without,
+		}
+	case *promparser.BinaryExpr:
+		var matching any
+		if m := n.VectorMatching; m != nil {
+			matching = map[string]any{
+				"card":    m.Card.String(),
+				"labels":  sanitizeStringList(m.MatchingLabels),
+				"on":      m.On,
+				"include": sanitizeStringList(m.Include),
+				"fillValues": map[string]*float64{
+					"lhs": m.FillValues.LHS,
+					"rhs": m.FillValues.RHS,
+				},
+			}
+		}
+
+		return map[string]any{
+			"type":     "binaryExpr",
+			"op":       n.Op.String(),
+			"lhs":      translatePromQLAST(n.LHS),
+			"rhs":      translatePromQLAST(n.RHS),
+			"matching": matching,
+			"bool":     n.ReturnBool,
+		}
+	case *promparser.Call:
+		args := []any{}
+		for _, arg := range n.Args {
+			args = append(args, translatePromQLAST(arg))
+		}
+
+		return map[string]any{
+			"type": "call",
+			"func": map[string]any{
+				"name":       n.Func.Name,
+				"argTypes":   n.Func.ArgTypes,
+				"variadic":   n.Func.Variadic,
+				"returnType": n.Func.ReturnType,
+			},
+			"args": args,
+		}
+	case *promparser.MatrixSelector:
+		vs := n.VectorSelector.(*promparser.VectorSelector)
+		return map[string]any{
+			"type":       "matrixSelector",
+			"name":       vs.Name,
+			"range":      n.Range.Milliseconds(),
+			"rangeExpr":  translateDurationExpr(n.RangeExpr),
+			"offset":     vs.OriginalOffset.Milliseconds(),
+			"offsetExpr": translateDurationExpr(vs.OriginalOffsetExpr),
+			"matchers":   translatePromQLMatchers(vs.LabelMatchers),
+			"timestamp":  vs.Timestamp,
+			"startOrEnd": promQLStartOrEnd(vs.StartOrEnd),
+			"anchored":   vs.Anchored,
+			"smoothed":   vs.Smoothed,
+		}
+	case *promparser.SubqueryExpr:
+		return map[string]any{
+			"type":       "subquery",
+			"expr":       translatePromQLAST(n.Expr),
+			"range":      n.Range.Milliseconds(),
+			"rangeExpr":  translateDurationExpr(n.RangeExpr),
+			"offset":     n.OriginalOffset.Milliseconds(),
+			"offsetExpr": translateDurationExpr(n.OriginalOffsetExpr),
+			"step":       n.Step.Milliseconds(),
+			"stepExpr":   translateDurationExpr(n.StepExpr),
+			"timestamp":  n.Timestamp,
+			"startOrEnd": promQLStartOrEnd(n.StartOrEnd),
+		}
+	case *promparser.DurationExpr:
+		return translateDurationExpr(n)
+	case *promparser.NumberLiteral:
+		return map[string]string{
+			"type": "numberLiteral",
+			"val":  strconv.FormatFloat(n.Val, 'f', -1, 64),
+		}
+	case *promparser.ParenExpr:
+		return map[string]any{
+			"type": "parenExpr",
+			"expr": translatePromQLAST(n.Expr),
+		}
+	case *promparser.StringLiteral:
+		return map[string]any{
+			"type": "stringLiteral",
+			"val":  n.Val,
+		}
+	case *promparser.UnaryExpr:
+		return map[string]any{
+			"type": "unaryExpr",
+			"op":   n.Op.String(),
+			"expr": translatePromQLAST(n.Expr),
+		}
+	case *promparser.VectorSelector:
+		return map[string]any{
+			"type":       "vectorSelector",
+			"name":       n.Name,
+			"offset":     n.OriginalOffset.Milliseconds(),
+			"offsetExpr": translateDurationExpr(n.OriginalOffsetExpr),
+			"matchers":   translatePromQLMatchers(n.LabelMatchers),
+			"timestamp":  n.Timestamp,
+			"startOrEnd": promQLStartOrEnd(n.StartOrEnd),
+			"anchored":   n.Anchored,
+			"smoothed":   n.Smoothed,
+		}
+	}
+	panic("cerberus: unsupported PromQL AST node type in translatePromQLAST")
+}
+
+// translateDurationExpr mirrors upstream's `translateDurationExpr` — a
+// `*DurationExpr` recurses into its own shape, a `*NumberLiteral` (a bare
+// duration constant) gets its literal shape, and any other Expr (already
+// resolved, e.g. after constant folding) falls back to the general
+// translator.
+func translateDurationExpr(node promparser.Expr) any {
+	if node == nil {
+		return nil
+	}
+
+	switch n := node.(type) {
+	case *promparser.DurationExpr:
+		if n == nil {
+			return nil
+		}
+		return map[string]any{
+			"type":    "durationExpr",
+			"op":      n.Op.String(),
+			"lhs":     translateDurationExpr(n.LHS),
+			"rhs":     translateDurationExpr(n.RHS),
+			"wrapped": n.Wrapped,
+		}
+	case *promparser.NumberLiteral:
+		if n == nil {
+			return nil
+		}
+		return map[string]any{
+			"type":     "numberLiteral",
+			"val":      strconv.FormatFloat(n.Val, 'f', -1, 64),
+			"duration": n.Duration,
+		}
+	default:
+		return translatePromQLAST(n)
+	}
+}
+
+// sanitizeStringList mirrors upstream's `sanitizeList`: a nil grouping /
+// matching-labels slice serializes as `[]`, not `null` — Grafana's tree
+// view iterates the field unconditionally.
+func sanitizeStringList(l []string) []string {
+	if l == nil {
+		return []string{}
+	}
+	return l
+}
+
+// translatePromQLMatchers mirrors upstream's `translateMatchers`.
+func translatePromQLMatchers(in []*labels.Matcher) any {
+	out := []map[string]any{}
+	for _, m := range in {
+		out = append(out, map[string]any{
+			"name":  m.Name,
+			"value": m.Value,
+			"type":  m.Type.String(),
+		})
+	}
+	return out
+}
+
+// promQLStartOrEnd mirrors upstream's `getStartOrEnd`: the zero ItemType
+// means no `@ start()` / `@ end()` modifier was used, serialized as
+// `null` rather than the zero item's string representation.
+func promQLStartOrEnd(startOrEnd promparser.ItemType) any {
+	if startOrEnd == 0 {
+		return nil
+	}
+	return startOrEnd.String()
+}


### PR DESCRIPTION
## Summary

- `/api/v1/parse_query` returned `{"type": fmt.Sprintf("%T", expr), "node": expr.String()}` — a Go type name and the re-stringified query — instead of upstream Prometheus's documented recursive AST node tree. Grafana's query-builder tree view (and any client following the documented response shape) got a shape it can't parse, even though the endpoint reported `"status":"success"`.
- `internal/api/prom/parse_query_ast.go` ports upstream's own unexported `translateAST` (`web/api/v1/translate_ast.go` in the `tsouza/prometheus` fork cerberus already depends on, zero patches) verbatim — same node-type coverage, same JSON keys, same field reads. Cerberus parses with the identical `promql/parser` package, so every field read (`VectorSelector.Anchored/Smoothed/OriginalOffsetExpr/StartOrEnd`, `MatrixSelector.RangeExpr`, `SubqueryExpr.StepExpr`, `DurationExpr`, `BinaryExpr.VectorMatching`, `Call.Func`) exists identically on cerberus's parsed AST.
- `handleParseQuery` now returns `translatePromQLAST(expr)` directly as `Data`.

Fixes #1440.

## Test plan

- [x] `go build ./...` and `go build -tags chdb ./internal/api/prom/...`
- [x] `go test ./internal/api/prom/...` (includes `TestParseQuery`, updated `TestConformance_ParseQueryWire` — now asserts the real recursive shape for an identifier, a `rate(...[5m])` call/matrixSelector, and a binaryExpr — and `TestParseQuery_ChDB` under the `chdb` tag)
- [x] `gofumpt -extra -l` clean on touched files
- [x] lefthook pre-push (golangci-lint, forbid-sql-raw, forbid-skip, forbid-soft-assert, forbid-escape-hatch, markdownlint, actionlint, commitlint-range) green locally