### PR TITLE
fix(tempo): record cerberus_queries_* for gRPC StreamingQuerier RPCs

### DIFF
--- a/internal/api/tempo/grpc/export_test.go
+++ b/internal/api/tempo/grpc/export_test.go
@@ -5,3 +5,10 @@ package grpc
 // grpc_test package, so every class's code mapping can be pinned without
 // standing up a full streaming RPC.
 var GRPCStatusForTest = grpcStatusFor
+
+// GRPCCodeToHTTPStatusTest exposes grpcCodeToHTTPStatus — the reverse of
+// grpcCodeFor used by the query-telemetry interceptor (telemetry.go) to
+// classify a gRPC status code through the same telemetry.ClassifyStatus
+// the HTTP QueryMiddleware uses — so the mapping table can be pinned
+// directly.
+var GRPCCodeToHTTPStatusTest = grpcCodeToHTTPStatus

--- a/internal/api/tempo/grpc/server.go
+++ b/internal/api/tempo/grpc/server.go
@@ -4,6 +4,8 @@ import (
 	"github.com/grafana/tempo/pkg/tempopb"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
+
+	"github.com/tsouza/cerberus/internal/telemetry"
 )
 
 // NewServer builds the gRPC server that hosts cerberus's Tempo
@@ -25,11 +27,19 @@ import (
 //     PromQL-queryable series is `rpc_server_call_duration_count` /
 //     `_sum` / `_bucket{le=...}` — see test/e2e/playwright/
 //     tempo_grpc_streaming.spec.ts (#1454), which asserts against it.
-//   - service.Limiter.StreamInterceptor() as the stream interceptor —
-//     per-RPC admission control sharing the same per-head semaphore
-//     the HTTP handlers use, so a saturated Tempo head rejects gRPC
-//     and HTTP traffic symmetrically (gRPC sees codes.ResourceExhausted;
-//     HTTP sees 503 + Retry-After).
+//   - service.Limiter.StreamInterceptor() as the first stream
+//     interceptor — per-RPC admission control sharing the same
+//     per-head semaphore the HTTP handlers use, so a saturated Tempo
+//     head rejects gRPC and HTTP traffic symmetrically (gRPC sees
+//     codes.ResourceExhausted; HTTP sees 503 + Retry-After).
+//   - queryTelemetryInterceptor(telemetry.QLTraceQL) as the second
+//     stream interceptor — the gRPC counterpart of the
+//     telemetry.QueryMiddleware every HTTP route already gets, so
+//     cerberus_queries_total / cerberus_queries_duration_seconds cover
+//     the streaming surface too (#1452). Listed after the limiter so
+//     an admission-rejected RPC is not double-counted: only RPCs that
+//     actually ran the query pipeline are recorded, mirroring
+//     Limiter.Middleware wrapping QueryMiddleware on the HTTP side.
 //
 // A nil service is a programmer error and panics; the gRPC server
 // requires a registered implementation to dispatch RPCs to.
@@ -39,7 +49,10 @@ func NewServer(service *Service) *grpc.Server {
 	}
 	srv := grpc.NewServer(
 		grpc.StatsHandler(otelgrpc.NewServerHandler()),
-		grpc.ChainStreamInterceptor(service.Limiter.StreamInterceptor()),
+		grpc.ChainStreamInterceptor(
+			service.Limiter.StreamInterceptor(),
+			queryTelemetryInterceptor(telemetry.QLTraceQL),
+		),
 	)
 	tempopb.RegisterStreamingQuerierServer(srv, service)
 	return srv

--- a/internal/api/tempo/grpc/telemetry.go
+++ b/internal/api/tempo/grpc/telemetry.go
@@ -1,0 +1,93 @@
+package grpc
+
+import (
+	"net/http"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/tsouza/cerberus/internal/api/tempo"
+	"github.com/tsouza/cerberus/internal/telemetry"
+)
+
+// queryTelemetryInterceptor is the gRPC-transport counterpart of
+// telemetry.QueryMiddleware, which wraps every Prom/Loki/Tempo HTTP
+// route but has no reach into this package's gRPC StreamingQuerier
+// service (#1452). Before this interceptor existed, none of the six
+// implemented RPCs — Search, the four tag-list RPCs, the two metrics
+// RPCs — recorded a query outcome at all: a client running exclusively
+// through Grafana's gRPC/h2c "Streaming" toggle was invisible to
+// cerberus_queries_total / cerberus_queries_duration_seconds, so any
+// dashboard or alert built on those instruments silently excluded the
+// whole streaming surface.
+//
+// Wired once at server construction (see NewServer) rather than inside
+// each RPC method, mirroring QueryMiddleware's single-wiring-point
+// pattern: a stream interceptor can't drift out of sync as new RPCs
+// land, unlike a telemetry call scattered across every method body.
+//
+// ql is the AttrQL label value — always telemetry.QLTraceQL for this
+// service; threaded as a parameter (rather than hard-coded) so the
+// interceptor stays testable without standing up the full Service.
+//
+// The route label is info.FullMethod (e.g.
+// "/tempopb.StreamingQuerier/Search") — a closed, seven-member set
+// fixed by the tempopb.StreamingQuerier service definition, so
+// cardinality is bounded the same way AttrRoute is for the HTTP mux
+// pattern.
+//
+// Placed after service.Limiter.StreamInterceptor() in NewServer's
+// ChainStreamInterceptor list, so an admission-rejected RPC (saturated
+// head, codes.ResourceExhausted) never reaches this interceptor — the
+// same behaviour the HTTP path gets from Limiter.Middleware wrapping
+// QueryMiddleware, not the other way around. Only RPCs that actually
+// ran the query pipeline are counted as a query outcome.
+func queryTelemetryInterceptor(ql string) grpc.StreamServerInterceptor {
+	return func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		t := telemetry.ObserveQuery(ql, info.FullMethod)
+		err := handler(srv, ss)
+		t.Done(ss.Context(), telemetry.ClassifyStatus(grpcCodeToHTTPStatus(status.Code(err))))
+		return err
+	}
+}
+
+// grpcCodeToHTTPStatus reverses grpcCodeFor's table (see errclass.go's
+// HTTP↔gRPC correspondence comment) so a gRPC status code classifies
+// through the exact same telemetry.ClassifyStatus the HTTP
+// QueryMiddleware uses — guaranteeing an identical (result, reason,
+// status_class) telemetry triple for the same underlying pipeline
+// error regardless of which transport the client used, rather than
+// maintaining a second, independently-drifting closed-enum mapping.
+//
+// Two HTTP statuses collapse onto a single gRPC code in the forward
+// direction (400 Bad Request + 422 Unprocessable Entity both encode as
+// InvalidArgument; 502 Bad Gateway + 503 Service Unavailable both
+// encode as Unavailable), so this reverse mapping picks one
+// representative status per code. That's lossless for telemetry
+// purposes: both members of each collapsed pair land in the same
+// reason bucket under telemetry.ClassifyStatus (4xx -> ReasonBadRequest,
+// 5xx's 502/503 -> ReasonBackendUnavailable), so the choice of
+// representative never changes the recorded Outcome.
+//
+// codes.OK needs no case — status.Code(nil) already returns codes.OK,
+// and http.StatusOK classifies as ResultOK via ClassifyStatus's
+// status < http.StatusBadRequest short-circuit — so the default arm
+// (http.StatusInternalServerError) only ever fires for a genuine error
+// code, never for success.
+func grpcCodeToHTTPStatus(code codes.Code) int {
+	switch code {
+	case codes.OK:
+		return http.StatusOK
+	case codes.InvalidArgument:
+		return http.StatusBadRequest
+	case codes.ResourceExhausted:
+		return http.StatusUnprocessableEntity
+	case codes.Unavailable:
+		return http.StatusServiceUnavailable
+	case codes.Canceled:
+		return tempo.StatusClientClosedRequest
+	default:
+		return http.StatusInternalServerError
+	}
+}

--- a/internal/api/tempo/grpc/telemetry_test.go
+++ b/internal/api/tempo/grpc/telemetry_test.go
@@ -1,0 +1,180 @@
+package grpc_test
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/grafana/tempo/pkg/tempopb"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"google.golang.org/grpc/codes"
+
+	"github.com/tsouza/cerberus/internal/api/tempo"
+	tempogrpc "github.com/tsouza/cerberus/internal/api/tempo/grpc"
+	"github.com/tsouza/cerberus/internal/telemetry"
+)
+
+// installManualReader swaps the global MeterProvider with one backed by
+// a ManualReader so a test can pull a deterministic metrics snapshot
+// after driving RPCs through a real dialServer-built gRPC server.
+// Mirrors internal/telemetry/metrics_test.go's helper of the same name
+// — duplicated here rather than exported from internal/telemetry
+// because it is test-only scaffolding, not a package API.
+func installManualReader(t *testing.T) *metric.ManualReader {
+	t.Helper()
+	reader := metric.NewManualReader()
+	mp := metric.NewMeterProvider(metric.WithReader(reader))
+	telemetry.Install(mp)
+	t.Cleanup(func() { telemetry.Install(nil) })
+	return reader
+}
+
+// collectQueriesTotal drains the manual reader and returns the
+// cerberus_queries_total sum's data points.
+func collectQueriesTotal(t *testing.T, reader *metric.ManualReader) []metricdata.DataPoint[int64] {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(t.Context(), &rm); err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+	for _, sm := range rm.ScopeMetrics {
+		if !strings.HasSuffix(sm.Scope.Name, "internal/telemetry") {
+			continue
+		}
+		for _, m := range sm.Metrics {
+			if m.Name == "cerberus_queries_total" {
+				return m.Data.(metricdata.Sum[int64]).DataPoints
+			}
+		}
+	}
+	t.Fatalf("cerberus_queries_total not found; scopes=%v", rm.ScopeMetrics)
+	return nil
+}
+
+// attrString reads a string-valued attribute off a data point, failing
+// the test if it is absent.
+func attrString(t *testing.T, dp metricdata.DataPoint[int64], key attribute.Key) string {
+	t.Helper()
+	v, ok := dp.Attributes.Value(key)
+	if !ok {
+		t.Fatalf("attribute %q missing; have %v", key, dp.Attributes)
+	}
+	return v.AsString()
+}
+
+// TestQueryTelemetryInterceptor_Search_RecordsOK pins the success path
+// wired in NewServer (#1452): a gRPC Search RPC that completes cleanly
+// records exactly one cerberus_queries_total data point tagged with the
+// TraceQL language, the FullMethod route, and result=ok — the same
+// triple the HTTP /api/search handler records via QueryMiddleware. Before
+// the interceptor existed, this RPC recorded nothing at all, so the
+// dashboards and alerts built on cerberus_queries_total silently
+// excluded every client using Grafana's gRPC/h2c streaming toggle.
+func TestQueryTelemetryInterceptor_Search_RecordsOK(t *testing.T) {
+	// Not t.Parallel(): installManualReader swaps the process-global
+	// OTel MeterProvider (telemetry.Install), which two tests doing so
+	// concurrently would race — mirrors internal/telemetry/metrics_test.go,
+	// none of whose Install-using tests run in parallel either.
+	reader := installManualReader(t)
+
+	q := &stubCursorQuerier{}
+	client, cleanup := dialServer(t, q)
+	t.Cleanup(cleanup)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	stream, err := client.Search(ctx, &tempopb.SearchRequest{Query: "{}"})
+	if err != nil {
+		t.Fatalf("open stream: %v", err)
+	}
+	if _, err := drainSearch(t, stream); err != nil {
+		t.Fatalf("drain: %v", err)
+	}
+
+	dps := collectQueriesTotal(t, reader)
+	if len(dps) != 1 {
+		t.Fatalf("queries.total DPs: got %d want 1: %+v", len(dps), dps)
+	}
+	dp := dps[0]
+	if got := attrString(t, dp, telemetry.AttrQL); got != telemetry.QLTraceQL {
+		t.Errorf("ql: got %q want %q", got, telemetry.QLTraceQL)
+	}
+	if got := attrString(t, dp, telemetry.AttrRoute); got != "/tempopb.StreamingQuerier/Search" {
+		t.Errorf("route: got %q want /tempopb.StreamingQuerier/Search", got)
+	}
+	if got := attrString(t, dp, telemetry.AttrResult); got != telemetry.ResultOK {
+		t.Errorf("result: got %q want %q", got, telemetry.ResultOK)
+	}
+}
+
+// TestQueryTelemetryInterceptor_Search_RecordsError mirrors the OK test
+// on the parse-error path: an unparseable TraceQL query still reaches
+// codes.InvalidArgument (see TestSearch_ParseErrorMapsToInvalidArgument),
+// and the interceptor must record it as a failed query — a
+// cerberus_queries_total{result="error"} data point classified through
+// the same telemetry.ClassifyStatus the HTTP path uses for its
+// equivalent 400 Bad Request.
+func TestQueryTelemetryInterceptor_Search_RecordsError(t *testing.T) {
+	// Not t.Parallel() — see TestQueryTelemetryInterceptor_Search_RecordsOK.
+	reader := installManualReader(t)
+
+	q := &stubCursorQuerier{}
+	client, cleanup := dialServer(t, q)
+	t.Cleanup(cleanup)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	stream, err := client.Search(ctx, &tempopb.SearchRequest{Query: "{ unclosed"})
+	if err != nil {
+		t.Fatalf("open stream: %v", err)
+	}
+	if _, err := drainSearch(t, stream); err == nil {
+		t.Fatalf("want a parse error, got nil")
+	}
+
+	dps := collectQueriesTotal(t, reader)
+	if len(dps) != 1 {
+		t.Fatalf("queries.total DPs: got %d want 1: %+v", len(dps), dps)
+	}
+	dp := dps[0]
+	if got := attrString(t, dp, telemetry.AttrResult); got != telemetry.ResultError {
+		t.Errorf("result: got %q want %q", got, telemetry.ResultError)
+	}
+	if got := attrString(t, dp, telemetry.AttrErrorReason); got != telemetry.ReasonBadRequest {
+		t.Errorf("error_reason: got %q want %q", got, telemetry.ReasonBadRequest)
+	}
+}
+
+// TestGRPCCodeToHTTPStatus pins grpcCodeToHTTPStatus's table — the
+// reverse of grpcCodeFor's HTTP↔gRPC correspondence (errclass.go) that
+// the query-telemetry interceptor uses to reuse telemetry.ClassifyStatus
+// instead of maintaining a second closed-enum mapping. Table-driven in
+// the same spirit as TestGRPCStatusFor (errclass_test.go), which pins
+// the forward direction.
+func TestGRPCCodeToHTTPStatus(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		code codes.Code
+		want int
+	}{
+		{"ok", codes.OK, http.StatusOK},
+		{"invalid_argument", codes.InvalidArgument, http.StatusBadRequest},
+		{"resource_exhausted", codes.ResourceExhausted, http.StatusUnprocessableEntity},
+		{"unavailable", codes.Unavailable, http.StatusServiceUnavailable},
+		{"canceled", codes.Canceled, tempo.StatusClientClosedRequest},
+		{"unclassified_defaults_internal", codes.Unknown, http.StatusInternalServerError},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tempogrpc.GRPCCodeToHTTPStatusTest(tc.code); got != tc.want {
+				t.Errorf("grpcCodeToHTTPStatus(%v) = %d, want %d", tc.code, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- None of the six implemented Tempo gRPC `StreamingQuerier` RPCs (`Search`, the four tag-list RPCs, the two metrics RPCs) recorded a query outcome — only the HTTP mux was wrapped by `telemetry.QueryMiddleware`. A client using Grafana's gRPC/h2c streaming toggle was invisible to `cerberus_queries_total` / `cerberus_queries_duration_seconds`, so any dashboard or alert built on those instruments silently excluded the whole streaming surface (#1452).
- Adds `queryTelemetryInterceptor`, a single `grpc.StreamServerInterceptor` wired once in `NewServer` (after the admission-control interceptor, so a saturated-head rejection is not double-counted — mirrors `Limiter.Middleware` wrapping `QueryMiddleware` on the HTTP side).
- Classifies the RPC outcome by reversing the existing `grpcCodeFor` HTTP↔gRPC table into a new `grpcCodeToHTTPStatus`, then routes through the existing `telemetry.ClassifyStatus` — so gRPC and HTTP report an identical `(result, reason, status_class)` triple for the same underlying pipeline error instead of maintaining a second, independently-drifting mapping.
- No new metric or attribute: `docs/observability.md` already documents `cerberus_queries_total`'s attributes, and the "admission-control rejections are not in this counter" policy note still holds for gRPC (limiter interceptor stays outermost).

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/api/tempo/... -count=1` — new `TestQueryTelemetryInterceptor_Search_RecordsOK`, `TestQueryTelemetryInterceptor_Search_RecordsError`, and table-driven `TestGRPCCodeToHTTPStatus` all pass, alongside the full existing `internal/api/tempo/grpc` suite.
- [x] `go vet ./...`
- [x] pre-push lefthook (golangci-lint, forbid-sql-raw, forbid-skip, markdownlint, commitlint) — all green
