### PR TITLE
refactor(chsql): replace preflight double-render with sticky Builder.err

### DIFF
--- a/internal/chsql/absent_over_time.go
+++ b/internal/chsql/absent_over_time.go
@@ -178,8 +178,7 @@ func (e *emitter) emitAbsentOverTime(a *chplan.AbsentOverTime) error {
 		Select(As(absentGridAnchorFrag(offsetNS), a.TimestampColumn)).
 		Select(As(Call("toFloat64", Lit(float64(1))), a.ValueColumn))
 
-	e.emitSelect(outer)
-	return nil
+	return e.emitSelect(outer)
 }
 
 // absentGridAnchorFrag renders the OUTPUT timestamp for an absence row.

--- a/internal/chsql/builder.go
+++ b/internal/chsql/builder.go
@@ -25,6 +25,21 @@ import (
 type Builder struct {
 	sb   strings.Builder
 	args []any
+
+	// err is the first error Expr encountered while rendering into this
+	// Builder, first-error-wins. It exists because Frag has no error
+	// return (`func(b *Builder)`), so an expression embedded via a
+	// closure — `func(b *Builder) { _ = b.Expr(expr) }`, the shape every
+	// QueryBuilder clause slot (Select/Where/Having/OrderBy/...) takes —
+	// cannot propagate a chplan rendering error through its own return
+	// value. Before this field existed, every such call site paid for a
+	// throwaway `(&Builder{}).Expr(expr)` pre-flight render just to catch
+	// that error synchronously, ahead of the real render — see #1449.
+	// Expr now records the error here as a side effect, so the real
+	// render IS the check: Build (both Builder.Build and
+	// QueryBuilder.Build) surfaces err, and Subquery/Spliced propagate a
+	// nested QueryBuilder's err into the outer Builder they splice into.
+	err error
 }
 
 // NewBuilder returns an empty Builder. Equivalent to &Builder{}.
@@ -38,9 +53,10 @@ func (b *Builder) String() string { return b.sb.String() }
 // should not mutate it.
 func (b *Builder) Args() []any { return b.args }
 
-// Build is the conventional terminator: returns the rendered SQL and
-// its positional argument slice.
-func (b *Builder) Build() (string, []any) { return b.sb.String(), b.args }
+// Build is the conventional terminator: returns the rendered SQL, its
+// positional argument slice, and the first Expr render error (if any) —
+// see Builder.err.
+func (b *Builder) Build() (string, []any, error) { return b.sb.String(), b.args, b.err }
 
 // writeSQL appends raw SQL text. Unexported — external packages must
 // use the typed surface (QueryBuilder slots + Frag constructors like
@@ -265,7 +281,17 @@ func (b *Builder) ParamAgg(name string, params, args []func(b *Builder)) {
 // Builder helpers (Ident / Arg / etc.). It is used by the ported
 // emitFilter / emitProject to emit predicates and projection expressions
 // without reaching into the private emitter.
-func (b *Builder) Expr(x chplan.Expr) error {
+//
+// Besides returning the error to a caller that checks it directly, Expr
+// records the first one on b.err (first-error-wins) so a caller that
+// embeds it in a Frag closure — which cannot itself return an error —
+// still surfaces it once the enclosing Build runs. See Builder.err.
+func (b *Builder) Expr(x chplan.Expr) (err error) {
+	defer func() {
+		if err != nil && b.err == nil {
+			b.err = err
+		}
+	}()
 	switch v := x.(type) {
 	case *chplan.ColumnRef:
 		if v.Qualifier != "" {
@@ -1218,7 +1244,12 @@ func InlineLit(v any) Frag {
 func Render(f Frag) (string, []any) {
 	b := NewBuilder()
 	f(b)
-	return b.Build()
+	// Render's callers (RenderDDL) only ever hand it DDL Frags, which
+	// compose Ident / InlineLit / Call and never reach chplan.Expr — so
+	// b.err is always nil here. Discarding it keeps Render's signature
+	// stable for its one production caller; see Builder.err.
+	sql, args, _ := b.Build()
+	return sql, args
 }
 
 // UnionAll joins one or more Frags with " UNION ALL " between them. It
@@ -1625,8 +1656,16 @@ func IfNonZero(num, denom Frag) Frag {
 // statement. *QueryBuilder satisfies it; PreRenderedSQL adapts a
 // (sql, args) pair from the legacy emitter so its output can flow
 // through Subquery without raw-string composition.
+//
+// subquerySQL is deliberately unexported (rather than named Build) so
+// *QueryBuilder's public, two-value Build() — consumed across
+// internal/api/{prom,loki,tempo}, internal/optcorpus,
+// internal/routerrules and internal/preflight — keeps its existing
+// signature. Only the two types chsql itself defines implement
+// Subqueryable, so the unexported method is satisfiable without
+// reaching outside this package.
 type Subqueryable interface {
-	Build() (string, []any)
+	subquerySQL() (string, []any, error)
 }
 
 // Subquery returns a Frag rendering "(<rendered s>)" — wraps a
@@ -1641,7 +1680,10 @@ type Subqueryable interface {
 // port can collapse that emitter into the QueryBuilder surface.
 func Subquery(s Subqueryable) Frag {
 	return func(b *Builder) {
-		sql, args := s.Build()
+		sql, args, err := s.subquerySQL()
+		if err != nil && b.err == nil {
+			b.err = err
+		}
 		b.sb.WriteByte('(')
 		b.sb.WriteString(sql)
 		b.sb.WriteByte(')')
@@ -1660,7 +1702,10 @@ func Subquery(s Subqueryable) Frag {
 // user input.
 func Spliced(s Subqueryable) Frag {
 	return func(b *Builder) {
-		sql, args := s.Build()
+		sql, args, err := s.subquerySQL()
+		if err != nil && b.err == nil {
+			b.err = err
+		}
 		b.sb.WriteString(sql)
 		b.args = append(b.args, args...)
 	}
@@ -1679,8 +1724,10 @@ type PreRenderedSQL struct {
 	Args []any
 }
 
-// Build satisfies Subqueryable.
-func (p PreRenderedSQL) Build() (string, []any) { return p.SQL, p.Args }
+// subquerySQL satisfies Subqueryable. p.SQL is always already-rendered
+// text (from the legacy string emitter), so it never carries a render
+// error.
+func (p PreRenderedSQL) subquerySQL() (string, []any, error) { return p.SQL, p.Args, nil }
 
 // writeFragList emits Frags comma-separated (with ", " between
 // subsequent parts) into the builder. Shared helper for the function-
@@ -2199,6 +2246,19 @@ func (s *QueryBuilder) Frag() Frag {
 // Build renders the SELECT statement to (sql, args). Equivalent to
 // running Frag() into a fresh Builder, minus the surrounding parens.
 func (s *QueryBuilder) Build() (string, []any) {
+	sql, args, _ := s.subquerySQL()
+	return sql, args
+}
+
+// subquerySQL is Build's error-propagating counterpart (see
+// Subqueryable). It is what the recursive emitter's emitSelect/splice
+// and the Subquery/Spliced Frag helpers call instead of Build, so a
+// nested QueryBuilder's Builder.err first-error-wins state (#1449)
+// reaches the outer render rather than being silently dropped the way
+// the old pre-flight-then-discard-and-render-again pattern needed to
+// work around. Unexported: Build stays the public two-value surface
+// every non-chsql caller already depends on.
+func (s *QueryBuilder) subquerySQL() (string, []any, error) {
 	b := NewBuilder()
 	s.writeInto(b)
 	return b.Build()

--- a/internal/chsql/builder_bench_test.go
+++ b/internal/chsql/builder_bench_test.go
@@ -91,7 +91,7 @@ func BenchmarkBuilder_NewAndBuild(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		bld := NewBuilder()
 		frag(bld)
-		_, _ = bld.Build()
+		_, _, _ = bld.Build()
 	}
 }
 

--- a/internal/chsql/builder_expr_mutation_test.go
+++ b/internal/chsql/builder_expr_mutation_test.go
@@ -47,7 +47,7 @@ func TestMutation_ExprInSubquery_RendersLeftAndSubquery(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	sql, _ := b.Build()
+	sql, _, _ := b.Build()
 	if !strings.Contains(sql, "TraceId") || !strings.Contains(sql, "IN (") || !strings.Contains(sql, "otel_traces") {
 		t.Fatalf("expected `<col> IN (<SELECT … otel_traces>)`, got %q", sql)
 	}
@@ -71,7 +71,7 @@ func TestMutation_ExprLambda_MultiParamCommaSeparator(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	sql, _ := b.Build()
+	sql, _, _ := b.Build()
 	if !strings.HasPrefix(sql, "(k, v) -> ") {
 		t.Fatalf("multi-parameter lambda must render `(k, v) -> `, got %q", sql)
 	}
@@ -89,7 +89,7 @@ func TestMutation_ExprLambda_SingleParamNoParens(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	sql, _ := b.Build()
+	sql, _, _ := b.Build()
 	if !strings.HasPrefix(sql, "i -> ") {
 		t.Fatalf("single-parameter lambda must render `i -> `, got %q", sql)
 	}
@@ -121,7 +121,7 @@ func TestMutation_ExprMapWithoutEmptyValues_RendersFilter(t *testing.T) {
 	if err := b.Expr(&chplan.MapWithoutEmptyValues{Map: &chplan.ColumnRef{Name: "Attributes"}}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	sql, _ := b.Build()
+	sql, _, _ := b.Build()
 	if !strings.HasPrefix(sql, "mapFilter((k, v) -> v != '', ") || !strings.HasSuffix(sql, ")") {
 		t.Fatalf("expected a closed mapFilter call, got %q", sql)
 	}

--- a/internal/chsql/builder_modulo_chdb_test.go
+++ b/internal/chsql/builder_modulo_chdb_test.go
@@ -133,7 +133,7 @@ func TestEmitGoModulo_BitExactVsGo(t *testing.T) {
 			t.Errorf("emit (x=%v, y=%v): %v", tc.x, tc.y, err)
 			continue
 		}
-		sqlStr, args := bld.Build()
+		sqlStr, args, _ := bld.Build()
 		query := "SELECT " + sqlStr
 		var v float64
 		if err := db.QueryRow(query, args...).Scan(&v); err != nil {

--- a/internal/chsql/builder_mutation_test.go
+++ b/internal/chsql/builder_mutation_test.go
@@ -9,7 +9,7 @@ import (
 func renderFragToSQL(f Frag) string {
 	b := NewBuilder()
 	f(b)
-	sql, _ := b.Build()
+	sql, _, _ := b.Build()
 	return sql
 }
 
@@ -30,7 +30,7 @@ func TestMutation_WriteCTEs_NonRecursiveHead(t *testing.T) {
 	qb := &QueryBuilder{ctes: []cteClause{{Name: "cte0", Body: Col("a")}}}
 	b := NewBuilder()
 	qb.writeCTEs(b)
-	head, _ := b.Build()
+	head, _, _ := b.Build()
 
 	if !strings.HasPrefix(head, "WITH ") {
 		t.Fatalf("expected head to start with %q, got %q", "WITH ", head)
@@ -65,7 +65,7 @@ func TestMutation_WriteCTEs_RecursiveOrLeftBranch(t *testing.T) {
 	}}}
 	b := NewBuilder()
 	qb.writeCTEs(b)
-	head, _ := b.Build()
+	head, _, _ := b.Build()
 
 	if !strings.HasPrefix(head, "WITH RECURSIVE ") {
 		t.Fatalf("clause with a non-nil Anchor must render the RECURSIVE head, got %q", head)

--- a/internal/chsql/builder_test.go
+++ b/internal/chsql/builder_test.go
@@ -16,7 +16,7 @@ func TestBuilder_Empty(t *testing.T) {
 	t.Parallel()
 
 	var b Builder
-	sql, args := b.Build()
+	sql, args, _ := b.Build()
 	if sql != "" {
 		t.Errorf("empty Builder produced SQL %q; want empty", sql)
 	}
@@ -71,7 +71,7 @@ func TestBuilder_Arg(t *testing.T) {
 	b.Arg("hello")
 	b.writeSQL(", ")
 	b.Arg(42)
-	gotSQL, gotArgs := b.Build()
+	gotSQL, gotArgs, _ := b.Build()
 	if want := "?, ?"; gotSQL != want {
 		t.Errorf("SQL = %q; want %q", gotSQL, want)
 	}
@@ -86,7 +86,7 @@ func TestBuilder_MapAt(t *testing.T) {
 
 	b := NewBuilder()
 	b.MapAt("Attributes", "service.name")
-	gotSQL, gotArgs := b.Build()
+	gotSQL, gotArgs, _ := b.Build()
 	if want := "`Attributes`[?]"; gotSQL != want {
 		t.Errorf("SQL = %q; want %q", gotSQL, want)
 	}
@@ -101,7 +101,7 @@ func TestBuilder_MapKeys(t *testing.T) {
 
 	b := NewBuilder()
 	b.MapKeys("Attributes")
-	gotSQL, gotArgs := b.Build()
+	gotSQL, gotArgs, _ := b.Build()
 	if want := "mapKeys(`Attributes`)"; gotSQL != want {
 		t.Errorf("SQL = %q; want %q", gotSQL, want)
 	}
@@ -116,7 +116,7 @@ func TestBuilder_MapFilterExcept(t *testing.T) {
 
 	b := NewBuilder()
 	b.MapFilterExcept("Attributes", "instance", "job")
-	gotSQL, gotArgs := b.Build()
+	gotSQL, gotArgs, _ := b.Build()
 	want := "mapFilter((k, v) -> NOT (k IN (?, ?)), `Attributes`)"
 	if gotSQL != want {
 		t.Errorf("SQL = %q; want %q", gotSQL, want)
@@ -182,7 +182,7 @@ func TestBuilder_SubtractNanos_PreservesArgOrder(t *testing.T) {
 		b.MapAt("Attributes", "service.name")
 		b.writeSQL(")")
 	}, 1000)
-	gotSQL, gotArgs := b.Build()
+	gotSQL, gotArgs, _ := b.Build()
 	wantSQL := "(max(`Attributes`[?]) - toIntervalNanosecond(1000))"
 	if gotSQL != wantSQL {
 		t.Errorf("SQL = %q; want %q", gotSQL, wantSQL)
@@ -236,7 +236,7 @@ func TestBuilder_Lambda(t *testing.T) {
 		b.writeSQL("k = ")
 		b.Arg("env")
 	})
-	gotSQL, gotArgs := b.Build()
+	gotSQL, gotArgs, _ := b.Build()
 	if want := "(k, v) -> k = ?"; gotSQL != want {
 		t.Errorf("SQL = %q; want %q", gotSQL, want)
 	}
@@ -260,7 +260,7 @@ func TestBuilder_ParamAgg_Parameterised(t *testing.T) {
 			func(b *Builder) { b.Ident("Value") },
 		},
 	)
-	gotSQL, gotArgs := b.Build()
+	gotSQL, gotArgs, _ := b.Build()
 	if want := "quantile(?)(`Value`)"; gotSQL != want {
 		t.Errorf("SQL = %q; want %q", gotSQL, want)
 	}
@@ -302,7 +302,7 @@ func TestBuilder_ParamAgg_MultiParam(t *testing.T) {
 			func(b *Builder) { b.Ident("Value") },
 		},
 	)
-	gotSQL, gotArgs := b.Build()
+	gotSQL, gotArgs, _ := b.Build()
 	if want := "quantiles(?, ?)(`Value`)"; gotSQL != want {
 		t.Errorf("SQL = %q; want %q", gotSQL, want)
 	}
@@ -325,7 +325,7 @@ func TestFrag_HelpersBindAtPosition(t *testing.T) {
 	Call("now64", InlineLit(int64(9)))(b)
 	b.writeSQL(", ")
 	Qual("L", "TimeUnix")(b)
-	gotSQL, gotArgs := b.Build()
+	gotSQL, gotArgs, _ := b.Build()
 	wantSQL := "`Value`, ?, now64(9), `L`.`TimeUnix`"
 	if gotSQL != wantSQL {
 		t.Errorf("SQL = %q; want %q", gotSQL, wantSQL)
@@ -379,7 +379,7 @@ func TestUnionAll_JoinsParts(t *testing.T) {
 
 	b := NewBuilder()
 	UnionAll(left.Frag(), right.Frag())(b)
-	sql, args := b.Build()
+	sql, args, _ := b.Build()
 	want := "(SELECT `MetricName` FROM `gauge` WHERE `MetricName` = ?)" +
 		" UNION ALL " +
 		"(SELECT `MetricName` FROM `sum` WHERE `MetricName` = ?)"
@@ -882,7 +882,7 @@ func TestBuilder_Expr(t *testing.T) {
 			if err := b.Expr(tc.expr); err != nil {
 				t.Fatalf("Expr: %v", err)
 			}
-			sql, args := b.Build()
+			sql, args, _ := b.Build()
 			if sql != tc.wantSQL {
 				t.Errorf("SQL = %q; want %q", sql, tc.wantSQL)
 			}
@@ -946,7 +946,7 @@ func TestAnd_JoinsParts(t *testing.T) {
 		Eq(Col("b"), Lit(int64(2))),
 		Eq(Col("c"), Lit(int64(3))),
 	)(b)
-	sql, args := b.Build()
+	sql, args, _ := b.Build()
 	want := "`a` = ? AND `b` = ? AND `c` = ?"
 	if sql != want {
 		t.Errorf("And SQL = %q; want %q", sql, want)
@@ -1035,7 +1035,7 @@ func TestTuple_RendersCommaSeparated(t *testing.T) {
 
 	b := NewBuilder()
 	Tuple(Lit(int64(1)), Lit(int64(2)), Lit(int64(3)))(b)
-	sql, args := b.Build()
+	sql, args, _ := b.Build()
 	if got, want := sql, "(?, ?, ?)"; got != want {
 		t.Errorf("Tuple SQL = %q; want %q", got, want)
 	}
@@ -1139,7 +1139,7 @@ func TestArray_RendersLiteral(t *testing.T) {
 
 	b := NewBuilder()
 	Array(Lit("a"), Lit("b"), Lit("c"))(b)
-	sql, args := b.Build()
+	sql, args, _ := b.Build()
 	if got, want := sql, "[?, ?, ?]"; got != want {
 		t.Errorf("Array SQL = %q; want %q", got, want)
 	}
@@ -1166,7 +1166,7 @@ func TestSubscript_RendersBrackets(t *testing.T) {
 
 	b := NewBuilder()
 	Subscript(Col("Attributes"), Lit("service.name"))(b)
-	sql, args := b.Build()
+	sql, args, _ := b.Build()
 	if got, want := sql, "`Attributes`[?]"; got != want {
 		t.Errorf("Subscript SQL = %q; want %q", got, want)
 	}
@@ -1186,7 +1186,7 @@ func TestIf_RendersTernary(t *testing.T) {
 		Lit("yes"),
 		Lit("no"),
 	)(b)
-	sql, args := b.Build()
+	sql, args, _ := b.Build()
 	if got, want := sql, "if(`a` = ?, ?, ?)"; got != want {
 		t.Errorf("If SQL = %q; want %q", got, want)
 	}
@@ -1219,7 +1219,7 @@ func TestSubquery_QueryBuilder(t *testing.T) {
 
 	b := NewBuilder()
 	Subquery(inner)(b)
-	sql, args := b.Build()
+	sql, args, _ := b.Build()
 	want := "(SELECT `v` FROM `t` WHERE `k` = ?)"
 	if sql != want {
 		t.Errorf("Subquery SQL = %q; want %q", sql, want)
@@ -1263,7 +1263,7 @@ func TestIn_RendersList(t *testing.T) {
 
 	b := NewBuilder()
 	In(Col("a"), Lit("x"), Lit("y"), Lit("z"))(b)
-	sql, args := b.Build()
+	sql, args, _ := b.Build()
 	if got, want := sql, "`a` IN (?, ?, ?)"; got != want {
 		t.Errorf("In SQL = %q; want %q", got, want)
 	}
@@ -1314,7 +1314,7 @@ func TestCall_MultipleArgs(t *testing.T) {
 
 	b := NewBuilder()
 	Call("if", Eq(Col("a"), Lit(1)), Lit("y"), Lit("n"))(b)
-	sql, args := b.Build()
+	sql, args, _ := b.Build()
 	if want := "if(`a` = ?, ?, ?)"; sql != want {
 		t.Errorf("Call(if,...) = %q; want %q", sql, want)
 	}
@@ -1330,7 +1330,7 @@ func TestParametric_OneParamOneArg(t *testing.T) {
 
 	b := NewBuilder()
 	Parametric("quantile", []Frag{Lit(0.5)}, Col("Value"))(b)
-	sql, args := b.Build()
+	sql, args, _ := b.Build()
 	if want := "quantile(?)(`Value`)"; sql != want {
 		t.Errorf("Parametric = %q; want %q", sql, want)
 	}
@@ -1346,7 +1346,7 @@ func TestParametric_MultiParamMultiArg(t *testing.T) {
 
 	b := NewBuilder()
 	Parametric("quantiles", []Frag{Lit(0.5), Lit(0.9)}, Col("a"), Col("b"))(b)
-	sql, args := b.Build()
+	sql, args, _ := b.Build()
 	if want := "quantiles(?, ?)(`a`, `b`)"; sql != want {
 		t.Errorf("Parametric = %q; want %q", sql, want)
 	}
@@ -1442,7 +1442,7 @@ func TestBetween(t *testing.T) {
 
 	b := NewBuilder()
 	Between(Col("ts"), Lit(1), Lit(10))(b)
-	sql, args := b.Build()
+	sql, args, _ := b.Build()
 	if want := "`ts` BETWEEN ? AND ?"; sql != want {
 		t.Errorf("Between = %q; want %q", sql, want)
 	}
@@ -1491,7 +1491,7 @@ func TestRangeWindowFilter_BindsArgsInOrder(t *testing.T) {
 
 	b := NewBuilder()
 	RangeWindowFilter(Lit("S"), Lit("E"), Lit("A"))(b)
-	sql, args := b.Build()
+	sql, args, _ := b.Build()
 	want := "arrayFilter(p -> tupleElement(p, 1) > ? AND tupleElement(p, 1) <= ?, ?)"
 	if sql != want {
 		t.Errorf("RangeWindowFilter SQL = %q; want %q", sql, want)
@@ -1545,7 +1545,7 @@ func TestIfNonZero_Basic(t *testing.T) {
 		Call("arraySum", BareIdent("window_vals")),
 		Lit(60.0),
 	)(b)
-	sql, args := b.Build()
+	sql, args, _ := b.Build()
 	want := "if(length(window_vals) > 0, arraySum(window_vals) / ?, 0.0)"
 	if sql != want {
 		t.Errorf("IfNonZero SQL = %q; want %q", sql, want)
@@ -1563,7 +1563,7 @@ func TestIfNonZero_InlineDenom(t *testing.T) {
 
 	b := NewBuilder()
 	IfNonZero(BareIdent("window_vals"), BareIdent("range_seconds"))(b)
-	sql, args := b.Build()
+	sql, args, _ := b.Build()
 	want := "if(length(window_vals) > 0, window_vals / range_seconds, 0.0)"
 	if sql != want {
 		t.Errorf("IfNonZero SQL = %q; want %q", sql, want)

--- a/internal/chsql/chaos_sleep.go
+++ b/internal/chsql/chaos_sleep.go
@@ -138,5 +138,9 @@ func chaosSleepWrap(ctx context.Context, sql string, args []any) (string, []any)
 		From(Subquery(PreRenderedSQL{SQL: sql, Args: args})).
 		Where(Gte(Subquery(sleepSubquery), InlineLit(int64(0))))
 
-	return wrapped.Build()
+	// wrapped never calls Expr (only Call/InlineLit/Star/Gte/Subquery over
+	// a PreRenderedSQL + a literal-only subquery), so its sticky error is
+	// always nil here; see Builder.err.
+	wsql, wargs, _ := wrapped.subquerySQL()
+	return wsql, wargs
 }

--- a/internal/chsql/emit_node.go
+++ b/internal/chsql/emit_node.go
@@ -44,20 +44,34 @@ func (e *emitter) subqueryFrag(n chplan.Node) (Frag, error) {
 // emitSelect runs the assembled QueryBuilder and splices its rendered
 // SQL + args into the emitter's output. Centralises the splice
 // boilerplate so the per-node emitters stay focused on slot assembly.
-func (e *emitter) emitSelect(sb *QueryBuilder) {
-	sql, args := sb.Build()
+//
+// Returns sb's sticky first-error (see Builder.err, #1449) instead of
+// silently dropping it — callers propagate it via `return e.emitSelect(sb)`
+// rather than the old pre-flight-render-then-discard-and-render-again
+// pattern.
+func (e *emitter) emitSelect(sb *QueryBuilder) error {
+	sql, args, err := sb.subquerySQL()
+	if err != nil {
+		return err
+	}
 	e.b.WriteString(sql)
 	e.args = append(e.args, args...)
+	return nil
 }
 
 // splice drains b's accumulated SQL + args into the emitter. Retained
 // for the emitters in vector_join.go / structural_join.go that still
 // compose SQL fragments through a free-standing *Builder before
-// flushing to the shared emitter state.
-func (e *emitter) splice(b *Builder) {
-	sql, args := b.Build()
+// flushing to the shared emitter state. Returns b's sticky first-error
+// (see Builder.err, #1449).
+func (e *emitter) splice(b *Builder) error {
+	sql, args, err := b.Build()
+	if err != nil {
+		return err
+	}
 	e.b.WriteString(sql)
 	e.args = append(e.args, args...)
+	return nil
 }
 
 func (e *emitter) emitScan(s *chplan.Scan) error {
@@ -74,8 +88,7 @@ func (e *emitter) emitScan(s *chplan.Scan) error {
 		cols = append(cols, Col(c))
 	}
 	sb.Select(cols...)
-	e.emitSelect(sb)
-	return nil
+	return e.emitSelect(sb)
 }
 
 // validateScanShape enforces the mutual exclusion between Scan.Table and
@@ -102,8 +115,7 @@ func validateScanShape(s *chplan.Scan) error {
 // expressions for MetricName / Attributes / TimeUnix / Value.
 func (e *emitter) emitOneRow(_ *chplan.OneRow) error {
 	sb := NewQuery().Select(InlineLit(int64(1)))
-	e.emitSelect(sb)
-	return nil
+	return e.emitSelect(sb)
 }
 
 // emitStepGrid renders a single-column SELECT that fans out one row
@@ -137,8 +149,7 @@ func (e *emitter) emitStepGrid(g *chplan.StepGrid) error {
 		sb := NewQuery().Select(As(func(b *Builder) {
 			b.DateTime64Lit(g.Start)
 		}, "anchor_ts"))
-		e.emitSelect(sb)
-		return nil
+		return e.emitSelect(sb)
 	}
 	stepNS := g.Step.Nanoseconds()
 	// End-inclusive anchor count: anchors at Start, Start+Step, …
@@ -165,8 +176,7 @@ func (e *emitter) emitStepGrid(g *chplan.StepGrid) error {
 		),
 		"anchor_ts",
 	))
-	e.emitSelect(sb)
-	return nil
+	return e.emitSelect(sb)
 }
 
 // emitUnionAll renders an N-way UNION ALL of the per-arm subtrees.
@@ -200,8 +210,7 @@ func (e *emitter) emitUnionAll(u *chplan.UnionAll) error {
 	}
 	b := NewBuilder()
 	UnionAll(arms...)(b)
-	e.splice(b)
-	return nil
+	return e.splice(b)
 }
 
 // emitCrossJoin renders an unconditional Cartesian product as
@@ -231,8 +240,7 @@ func (e *emitter) emitCrossJoin(j *chplan.CrossJoin) error {
 	}
 	sb := NewQuery().From(aliasedFrag(leftSub, "L")).
 		Join(CrossJoin, aliasedFrag(rightSub, "R"), nil)
-	e.emitSelect(sb)
-	return nil
+	return e.emitSelect(sb)
 }
 
 // scanTableFrag returns the Frag that renders the Scan's table reference.
@@ -331,13 +339,6 @@ func regexQuoteMeta(s string) string {
 }
 
 func (e *emitter) emitFilter(f *chplan.Filter) error {
-	// Pre-flight the predicate so a chplan error surfaces here, not
-	// inside the Where-render callback (where the error has no path
-	// to the caller without re-introducing splice plumbing).
-	if err := (&Builder{}).Expr(f.Predicate); err != nil {
-		return err
-	}
-
 	// Filter(Scan(table)) is the case the codegen specialises: emit
 	// `SELECT * FROM <table> [PREWHERE …] WHERE …` directly. This is
 	// the only shape where CH's PREWHERE granule-skipping fires —
@@ -352,8 +353,7 @@ func (e *emitter) emitFilter(f *chplan.Filter) error {
 		return err
 	}
 	pred := func(b *Builder) { _ = b.Expr(f.Predicate) }
-	e.emitSelect(NewQuery().From(sub).Where(pred))
-	return nil
+	return e.emitSelect(NewQuery().From(sub).Where(pred))
 }
 
 // emitFilterScan renders a Filter directly above a Scan as the fused
@@ -421,8 +421,7 @@ func (e *emitter) emitFilterScan(f *chplan.Filter, scan *chplan.Scan) error {
 	if len(whereExprs) > 0 {
 		sb.Where(conjunctionFrag(whereExprs))
 	}
-	e.emitSelect(sb)
-	return nil
+	return e.emitSelect(sb)
 }
 
 // conjunctionFrag returns a Frag that renders exprs joined with " AND ".
@@ -454,15 +453,8 @@ func (e *emitter) emitProject(p *chplan.Project) error {
 		return err
 	}
 	sb := NewQuery().From(sub)
-	// Pre-flight every projection expression so a chplan error surfaces
-	// synchronously rather than from inside the Frag render. An empty
-	// Projections slice leaves the SELECT list empty, which renders as
-	// the bare `SELECT *` — no length guard needed.
-	for _, pr := range p.Projections {
-		if err := (&Builder{}).Expr(pr.Expr); err != nil {
-			return err
-		}
-	}
+	// An empty Projections slice leaves the SELECT list empty, which
+	// renders as the bare `SELECT *` — no length guard needed.
 	for _, pr := range p.Projections {
 		expr := pr.Expr
 		sb.SelectAs(func(b *Builder) { _ = b.Expr(expr) }, pr.Alias)
@@ -470,42 +462,15 @@ func (e *emitter) emitProject(p *chplan.Project) error {
 	if len(p.Projections) == 0 && len(p.Replacements) > 0 {
 		reps := make([]Frag, 0, len(p.Replacements))
 		for _, pr := range p.Replacements {
-			if err := (&Builder{}).Expr(pr.Expr); err != nil {
-				return err
-			}
 			expr := pr.Expr
 			reps = append(reps, As(func(b *Builder) { _ = b.Expr(expr) }, pr.Alias))
 		}
 		sb.Select(StarReplace(reps))
 	}
-	e.emitSelect(sb)
-	return nil
+	return e.emitSelect(sb)
 }
 
 func (e *emitter) emitAggregate(a *chplan.Aggregate) error {
-	// Pre-flight all expressions so chplan errors surface synchronously.
-	for _, g := range a.GroupBy {
-		if err := (&Builder{}).Expr(g); err != nil {
-			return err
-		}
-	}
-	for _, af := range a.AggFuncs {
-		for _, p := range af.Params {
-			if err := (&Builder{}).Expr(p); err != nil {
-				return err
-			}
-		}
-		for _, ar := range af.Args {
-			if err := (&Builder{}).Expr(ar); err != nil {
-				return err
-			}
-		}
-	}
-	if a.Having != nil {
-		if err := (&Builder{}).Expr(a.Having); err != nil {
-			return err
-		}
-	}
 	if len(a.GroupBy) == 0 && len(a.AggFuncs) == 0 {
 		return fmt.Errorf("%w: Aggregate with no GroupBy keys and no AggFuncs", ErrUnsupported)
 	}
@@ -550,8 +515,7 @@ func (e *emitter) emitAggregate(a *chplan.Aggregate) error {
 		having := a.Having
 		sb.Having(func(b *Builder) { _ = b.Expr(having) })
 	}
-	e.emitSelect(sb)
-	return nil
+	return e.emitSelect(sb)
 }
 
 // emitAggregateNoGroup renders the `Aggregate(GroupBy=[], …)` shape as
@@ -594,8 +558,7 @@ func (e *emitter) emitAggregateNoGroup(a *chplan.Aggregate, sub Frag) error {
 		outer.Select(c)
 	}
 	outer.Where(Gt(Col(guardAlias), InlineLit(int64(0))))
-	e.emitSelect(outer)
-	return nil
+	return e.emitSelect(outer)
 }
 
 // intReturningAggregates names the CH aggregates whose natural return
@@ -657,8 +620,7 @@ func (e *emitter) emitLimit(l *chplan.Limit) error {
 	// hasLimit = n > 0), so a zero / negative Count renders no LIMIT
 	// clause without an explicit guard.
 	sb.Limit(l.Count)
-	e.emitSelect(sb)
-	return nil
+	return e.emitSelect(sb)
 }
 
 // emitTopK renders `SELECT * FROM (<input>) ORDER BY <sortExpr> [DESC]
@@ -685,7 +647,7 @@ func (e *emitter) emitLimit(l *chplan.Limit) error {
 // entirely: the result is K *arbitrary* rows per partition, no ranking.
 // CH's `LIMIT K BY <by>` already returns the first K rows it encounters
 // per group, which is exactly limitk's "any K series" contract. SortExpr
-// is nil in this shape, so the pre-flight and ORDER BY clause are skipped.
+// is nil in this shape, so the ORDER BY clause is skipped.
 func (e *emitter) emitTopK(t *chplan.TopK) error {
 	if !t.Unordered && t.SortExpr == nil {
 		return fmt.Errorf("%w: TopK with nil SortExpr", ErrUnsupported)
@@ -702,18 +664,6 @@ func (e *emitter) emitTopK(t *chplan.TopK) error {
 	if t.KExpr != nil && t.K > 0 {
 		return fmt.Errorf("%w: TopK with both literal K=%d and KExpr set", ErrUnsupported, t.K)
 	}
-	// Pre-flight expressions so chplan errors surface synchronously.
-	if t.SortExpr != nil {
-		if err := (&Builder{}).Expr(t.SortExpr); err != nil {
-			return err
-		}
-	}
-	for _, by := range t.By {
-		if err := (&Builder{}).Expr(by); err != nil {
-			return err
-		}
-	}
-
 	if t.KExpr != nil {
 		return e.emitTopKComputed(t)
 	}
@@ -760,8 +710,7 @@ func (e *emitter) emitTopK(t *chplan.TopK) error {
 		}
 		outer.Select(cols...)
 	}
-	e.emitSelect(outer)
-	return nil
+	return e.emitSelect(outer)
 }
 
 // emitTopKComputed renders the computed-K variant of TopK. CH's LIMIT
@@ -838,8 +787,7 @@ func (e *emitter) emitTopKComputed(t *chplan.TopK) error {
 		}
 		outer.Select(cols...)
 	}
-	e.emitSelect(outer)
-	return nil
+	return e.emitSelect(outer)
 }
 
 // emitOrderBy renders `SELECT * FROM (<input>) ORDER BY <k1> [DESC], …`
@@ -848,13 +796,6 @@ func (e *emitter) emitTopKComputed(t *chplan.TopK) error {
 func (e *emitter) emitOrderBy(o *chplan.OrderBy) error {
 	if len(o.Keys) == 0 {
 		return fmt.Errorf("%w: OrderBy with no keys", ErrUnsupported)
-	}
-	// Pre-flight every key expression so chplan errors surface
-	// synchronously rather than from inside the Frag render.
-	for _, k := range o.Keys {
-		if err := (&Builder{}).Expr(k.Expr); err != nil {
-			return err
-		}
 	}
 	sub, err := e.subqueryFrag(o.Input)
 	if err != nil {
@@ -865,6 +806,5 @@ func (e *emitter) emitOrderBy(o *chplan.OrderBy) error {
 		expr := k.Expr
 		sb.OrderBy(func(b *Builder) { _ = b.Expr(expr) }, k.Desc)
 	}
-	e.emitSelect(sb)
-	return nil
+	return e.emitSelect(sb)
 }

--- a/internal/chsql/exemplars.go
+++ b/internal/chsql/exemplars.go
@@ -128,12 +128,6 @@ func (e *emitter) emitMetricsExemplars(
 	maxPerSeries int64,
 	spansTable string,
 ) error {
-	for _, g := range m.GroupBy {
-		if err := (&Builder{}).Expr(g); err != nil {
-			return err
-		}
-	}
-
 	end := endExprFrag(rw)
 	stepNS := rw.Step.Nanoseconds()
 	rangeDur := rw.Range
@@ -306,6 +300,5 @@ func (e *emitter) emitMetricsExemplars(
 		outerSb.LimitBy(limitByFrags...)
 	}
 
-	e.emitSelect(outerSb)
-	return nil
+	return e.emitSelect(outerSb)
 }

--- a/internal/chsql/frag_goldens_test.go
+++ b/internal/chsql/frag_goldens_test.go
@@ -321,7 +321,7 @@ func TestFrag_Goldens(t *testing.T) {
 			t.Parallel()
 			b := NewBuilder()
 			tc.frag(b)
-			gotSQL, gotArgs := b.Build()
+			gotSQL, gotArgs, _ := b.Build()
 			if gotSQL != tc.wantSQL {
 				t.Errorf("SQL = %q; want %q", gotSQL, tc.wantSQL)
 			}
@@ -352,7 +352,7 @@ func TestFrag_NestedComposition(t *testing.T) {
 	)
 	b := NewBuilder()
 	expr(b)
-	sql, args := b.Build()
+	sql, args, _ := b.Build()
 	want := "(`a` = ? OR `b` != ?) AND NOT `c` IN (?, ?)"
 	if sql != want {
 		t.Errorf("SQL = %q; want %q", sql, want)
@@ -484,7 +484,7 @@ func TestFrag_Array_BindsAtPosition(t *testing.T) {
 	Array(Lit(1), Lit(2), Lit(3))(b)
 	b.writeSQL(", ")
 	Lit(4)(b)
-	sql, args := b.Build()
+	sql, args, _ := b.Build()
 	if want := "[?, ?, ?], ?"; sql != want {
 		t.Errorf("SQL = %q; want %q", sql, want)
 	}
@@ -504,7 +504,7 @@ func TestFrag_Call_BindsAtPosition(t *testing.T) {
 	Call("concat", Lit("a"), Lit("b"))(b)
 	b.writeSQL(", ")
 	Lit("c")(b)
-	sql, args := b.Build()
+	sql, args, _ := b.Build()
 	if want := "concat(?, ?), ?"; sql != want {
 		t.Errorf("SQL = %q; want %q", sql, want)
 	}

--- a/internal/chsql/gremlins_kill_test.go
+++ b/internal/chsql/gremlins_kill_test.go
@@ -3331,7 +3331,7 @@ func TestWriteOptQualCol_QualifierBranch(t *testing.T) {
 		t.Parallel()
 		b := &Builder{}
 		writeOptQualCol(b, "", "Timestamp")
-		got, _ := b.Build()
+		got, _, _ := b.Build()
 		if got != "`Timestamp`" {
 			t.Errorf("empty qual must render bare `Timestamp`, got %q", got)
 		}
@@ -3340,7 +3340,7 @@ func TestWriteOptQualCol_QualifierBranch(t *testing.T) {
 		t.Parallel()
 		b := &Builder{}
 		writeOptQualCol(b, "t", "Timestamp")
-		got, _ := b.Build()
+		got, _, _ := b.Build()
 		if got != "`t`.`Timestamp`" {
 			t.Errorf("qual=t must render `t`.`Timestamp`, got %q", got)
 		}

--- a/internal/chsql/histogram_over_time.go
+++ b/internal/chsql/histogram_over_time.go
@@ -40,17 +40,6 @@ func (e *emitter) emitMetricsHistogramOverTime(m *chplan.MetricsHistogramOverTim
 	if m.Inner == nil {
 		return fmt.Errorf("%w: MetricsHistogramOverTime.Inner is nil", ErrUnsupported)
 	}
-	// Pre-flight every chplan expression so errors surface synchronously
-	// (mirrors emitMetricsAggregate's pre-flight loop).
-	if err := (&Builder{}).Expr(m.Attr); err != nil {
-		return err
-	}
-	for _, g := range m.GroupBy {
-		if err := (&Builder{}).Expr(g); err != nil {
-			return err
-		}
-	}
-
 	sub, err := e.subqueryFrag(m.Inner)
 	if err != nil {
 		return err
@@ -94,8 +83,7 @@ func (e *emitter) emitMetricsHistogramOverTime(m *chplan.MetricsHistogramOverTim
 	groupFrags = append(groupFrags, Col(bucketAlias))
 	sb.GroupBy(groupFrags...)
 
-	e.emitSelect(sb)
-	return nil
+	return e.emitSelect(sb)
 }
 
 // histogramBucketFrag renders the
@@ -209,16 +197,6 @@ func (e *emitter) emitRangeWindowHistogram(r *chplan.RangeWindow, m *chplan.Metr
 		return err
 	}
 
-	// Pre-flight expressions so chplan errors surface synchronously.
-	if err := (&Builder{}).Expr(m.Attr); err != nil {
-		return err
-	}
-	for _, g := range m.GroupBy {
-		if err := (&Builder{}).Expr(g); err != nil {
-			return err
-		}
-	}
-
 	end := endExprFrag(r)
 	stepNS := r.Step.Nanoseconds()
 	rangeDur := r.Range
@@ -314,8 +292,7 @@ func (e *emitter) emitRangeWindowHistogram(r *chplan.RangeWindow, m *chplan.Metr
 	groupFrags = append(groupFrags, Col(bucketAlias), Col("anchor_ts"))
 	outerSb.GroupBy(groupFrags...)
 
-	e.emitSelect(outerSb)
-	return nil
+	return e.emitSelect(outerSb)
 }
 
 // histogramZeroFillArgs bundles the inputs histogramZeroFillGridArm

--- a/internal/chsql/histogram_quantile.go
+++ b/internal/chsql/histogram_quantile.go
@@ -47,14 +47,6 @@ func (e *emitter) emitHistogramQuantile(h *chplan.HistogramQuantile) error {
 	if h.BucketCountsColumn == "" || h.ExplicitBoundsColumn == "" {
 		return fmt.Errorf("%w: HistogramQuantile requires BucketCountsColumn and ExplicitBoundsColumn", ErrUnsupported)
 	}
-	// Pre-flight every GroupBy expression so chplan errors surface
-	// synchronously rather than from inside a Frag callback.
-	for _, g := range h.GroupBy {
-		if err := (&Builder{}).Expr(g); err != nil {
-			return err
-		}
-	}
-
 	sub, err := e.subqueryFrag(h.Input)
 	if err != nil {
 		return err
@@ -70,8 +62,7 @@ func (e *emitter) emitHistogramQuantile(h *chplan.HistogramQuantile) error {
 		sb.SelectAs(func(b *Builder) { _ = b.Expr(expr) }, alias)
 	}
 	sb.SelectAs(histogramQuantileValueFrag(h), "Value")
-	e.emitSelect(sb)
-	return nil
+	return e.emitSelect(sb)
 }
 
 // histogramQuantileValueFrag returns the Frag that renders the per-row

--- a/internal/chsql/histogram_quantile_native.go
+++ b/internal/chsql/histogram_quantile_native.go
@@ -92,14 +92,6 @@ func (e *emitter) emitHistogramQuantileNative(h *chplan.HistogramQuantileNative)
 		h.NegativeOffsetColumn == "" || h.NegativeBucketCountsColumn == "" {
 		return fmt.Errorf("%w: HistogramQuantileNative requires Scale / ZeroCount / PositiveOffset / PositiveBucketCounts / NegativeOffset / NegativeBucketCounts column names", ErrUnsupported)
 	}
-	// Pre-flight every GroupBy expression so chplan errors surface
-	// synchronously rather than from inside a Frag callback.
-	for _, g := range h.GroupBy {
-		if err := (&Builder{}).Expr(g); err != nil {
-			return err
-		}
-	}
-
 	sub, err := e.subqueryFrag(h.Input)
 	if err != nil {
 		return err
@@ -115,8 +107,7 @@ func (e *emitter) emitHistogramQuantileNative(h *chplan.HistogramQuantileNative)
 		sb.SelectAs(func(b *Builder) { _ = b.Expr(expr) }, alias)
 	}
 	sb.SelectAs(histogramQuantileNativeValueFrag(h), "Value")
-	e.emitSelect(sb)
-	return nil
+	return e.emitSelect(sb)
 }
 
 // histogramQuantileNativeValueFrag returns the Frag rendering the

--- a/internal/chsql/info_join.go
+++ b/internal/chsql/info_join.go
@@ -121,8 +121,7 @@ func (e *emitter) emitInfoJoin(j *chplan.InfoJoin) error {
 		sb.GroupBy(infoBaseSampleKeyFrags(j)...)
 		sb.Having(infoConflictGuardFrag(j))
 	}
-	e.emitSelect(sb)
-	return nil
+	return e.emitSelect(sb)
 }
 
 // infoConflictGuardFrag renders the HAVING term that fails the query when

--- a/internal/chsql/late_mat.go
+++ b/internal/chsql/late_mat.go
@@ -344,24 +344,10 @@ func projectionColumnNames(ps []chplan.Projection) map[string]struct{} {
 // sides expose the row-key column names).
 //
 // Errors from the predicate / projection expression render flow back
-// through the same pre-flight pattern used by emitFilter / emitProject
-// — chplan errors surface synchronously rather than from inside a
-// Frag callback.
+// through Builder.err (see #1449) — a failing Expr sets the sticky
+// first-error inside the Frag closure it renders from, which
+// subquerySQL / emitSelect surface at the end of this function.
 func (e *emitter) emitLateMat(m *lateMatMatch) error {
-	// Pre-flight every projection expression and the (optional)
-	// predicate. Mirrors emitProject / emitFilter so chplan errors
-	// land at the caller, not inside a render closure.
-	for _, pr := range m.project.Projections {
-		if err := (&Builder{}).Expr(pr.Expr); err != nil {
-			return err
-		}
-	}
-	if m.filter != nil {
-		if err := (&Builder{}).Expr(m.filter.Predicate); err != nil {
-			return err
-		}
-	}
-
 	// Inner SELECT: thin columns + row key, WHERE pred (if any),
 	// LIMIT n. The thin column list already contains the row-key
 	// columns (isLateMatCandidate appends them last), so we just
@@ -390,8 +376,7 @@ func (e *emitter) emitLateMat(m *lateMatMatch) error {
 		outer.SelectAs(func(b *Builder) { _ = b.Expr(expr) }, pr.Alias)
 	}
 
-	e.emitSelect(outer)
-	return nil
+	return e.emitSelect(outer)
 }
 
 // lateMatJoinPredicate returns a Frag rendering the row-key JOIN's ON

--- a/internal/chsql/metrics_compare.go
+++ b/internal/chsql/metrics_compare.go
@@ -118,14 +118,6 @@ func (e *emitter) compareBaseQuery(m *chplan.MetricsCompare, bound *compareScanB
 	if m.Inner == nil {
 		return nil, fmt.Errorf("%w: MetricsCompare.Inner is nil", ErrUnsupported)
 	}
-	// Pre-flight chplan expressions so errors surface synchronously
-	// (mirrors emitMetricsAggregate's pre-flight loop).
-	if err := (&Builder{}).Expr(m.Selection); err != nil {
-		return nil, err
-	}
-	if err := (&Builder{}).Expr(m.Pairs); err != nil {
-		return nil, err
-	}
 
 	inner, err := e.subqueryFrag(m.Inner)
 	if err != nil {
@@ -498,8 +490,7 @@ func (e *emitter) emitMetricsCompare(m *chplan.MetricsCompare) error {
 	outer.GroupBy(Col(selA), Col(attrA), Col(valA))
 	outer.OrderBy(Col(selA), false).OrderBy(Col(attrA), false).OrderBy(Col(valA), false)
 
-	e.emitSelect(outer)
-	return nil
+	return e.emitSelect(outer)
 }
 
 // emitRangeWindowCompare renders the matrix shape — one row per
@@ -635,6 +626,5 @@ func (e *emitter) emitRangeWindowCompare(r *chplan.RangeWindow, m *chplan.Metric
 	outer.SelectAs(compareCountValueFrag(), compareValueOut(m))
 	outer.GroupBy(Col(selA), Col(attrA), Col(valA), Col(RangeWindowAnchorAlias))
 
-	e.emitSelect(outer)
-	return nil
+	return e.emitSelect(outer)
 }

--- a/internal/chsql/metrics_second_stage.go
+++ b/internal/chsql/metrics_second_stage.go
@@ -74,8 +74,7 @@ func (e *emitter) emitMetricsSecondStageTopK(m *chplan.MetricsSecondStage) error
 		parts = append(parts, func(b *Builder) { b.Ident(col) })
 	}
 	sb.LimitBy(parts...)
-	e.emitSelect(sb)
-	return nil
+	return e.emitSelect(sb)
 }
 
 // emitMetricsSecondStageThreshold renders the threshold wrap:
@@ -101,12 +100,8 @@ func (e *emitter) emitMetricsSecondStageThreshold(m *chplan.MetricsSecondStage) 
 		Left:  &chplan.ColumnRef{Name: m.ValueAlias},
 		Right: &chplan.LitFloat{V: m.ThresholdValue},
 	}
-	if err := (&Builder{}).Expr(pred); err != nil {
-		return err
-	}
 	sb := NewQuery().From(sub).Where(func(b *Builder) { _ = b.Expr(pred) })
-	e.emitSelect(sb)
-	return nil
+	return e.emitSelect(sb)
 }
 
 // isThresholdOp reports whether op is one of the six comparison

--- a/internal/chsql/nary_vector_set_op.go
+++ b/internal/chsql/nary_vector_set_op.go
@@ -101,8 +101,7 @@ func (e *emitter) emitNaryVectorSetOp(s *chplan.NaryVectorSetOp) error {
 			Select(outCols...).
 			From(windowed.Frag()).
 			Where(Eq(Col(setOpSideCol), Col(narySetOpMinSideCol)))
-		e.emitSelect(outer)
-		return nil
+		return e.emitSelect(outer)
 	case chplan.VectorSetAnd:
 		// present-in-every-arm: keep arm-0 rows whose signature's
 		// contributing-arm bitmask is all-ones (every arm present).
@@ -128,8 +127,7 @@ func (e *emitter) emitNaryVectorSetOp(s *chplan.NaryVectorSetOp) error {
 				Eq(Col(setOpSideCol), InlineLit(0)),
 				Eq(Col(narySetOpSidesMaskCol), InlineLit(fullMask)),
 			))
-		e.emitSelect(outer)
-		return nil
+		return e.emitSelect(outer)
 	}
 	return fmt.Errorf("%w: n-ary vector set op %q", ErrUnsupported, s.Op)
 }

--- a/internal/chsql/nested_set_annotate.go
+++ b/internal/chsql/nested_set_annotate.go
@@ -188,8 +188,7 @@ func (e *emitter) emitNestedSetAnnotate(n *chplan.NestedSetAnnotate) error {
 		).
 		From(aliasedFrag(inputSub, "m")).
 		Join(LeftJoin, aliasedFrag(numbering.Frag(), "ns"), onClause)
-	e.emitSelect(sb)
-	return nil
+	return e.emitSelect(sb)
 }
 
 // buildNestedSetNumbering assembles the numbering subquery: the
@@ -563,6 +562,7 @@ func optQualColFrag(qual, col string) Frag {
 func quoteIdent(name string) string {
 	b := &Builder{}
 	b.Ident(name)
-	sql, _ := b.Build()
+	// Ident never touches chplan.Expr, so b.err is always nil here.
+	sql, _, _ := b.Build()
 	return sql
 }

--- a/internal/chsql/query_builder_invariants_test.go
+++ b/internal/chsql/query_builder_invariants_test.go
@@ -293,7 +293,7 @@ func TestQueryBuilder_Frag_WrapsWithParens(t *testing.T) {
 
 	outer := NewBuilder()
 	inner.Frag()(outer)
-	sql, args := outer.Build()
+	sql, args, _ := outer.Build()
 	if want := "(SELECT `Value` FROM `t` WHERE `k` = ?)"; sql != want {
 		t.Errorf("Frag wrap = %q; want %q", sql, want)
 	}

--- a/internal/chsql/query_exemplars.go
+++ b/internal/chsql/query_exemplars.go
@@ -214,7 +214,10 @@ func EmitQueryExemplars(
 		).
 		From(inner.Frag())
 
-	sql, args := outer.Build()
+	sql, args, err := outer.subquerySQL()
+	if err != nil {
+		return "", nil, err
+	}
 	span.SetAttributes(cerbtrace.AttrSQLLength.Int(len(sql)))
 	return sql, args, nil
 }

--- a/internal/chsql/range_bucket_fanout.go
+++ b/internal/chsql/range_bucket_fanout.go
@@ -75,26 +75,6 @@ func (e *emitter) emitRangeBucketFanout(r *chplan.RangeBucketFanout) error {
 		return fmt.Errorf("%w: RangeBucketFanout requires at least one AggFunc", ErrUnsupported)
 	}
 
-	// Pre-flight group-key + aggregate expressions so chplan errors
-	// surface synchronously (mirrors emitAggregate).
-	for _, g := range r.GroupBy {
-		if err := (&Builder{}).Expr(g); err != nil {
-			return err
-		}
-	}
-	for _, af := range r.AggFuncs {
-		for _, p := range af.Params {
-			if err := (&Builder{}).Expr(p); err != nil {
-				return err
-			}
-		}
-		for _, a := range af.Args {
-			if err := (&Builder{}).Expr(a); err != nil {
-				return err
-			}
-		}
-	}
-
 	stepNS := r.Step.Nanoseconds()
 	lookbackNS := r.Lookback.Nanoseconds()
 
@@ -180,6 +160,5 @@ func (e *emitter) emitRangeBucketFanout(r *chplan.RangeBucketFanout) error {
 		collapse.Having(Gte(Call("uniqExact", Col(r.TimestampCol)), InlineLit(int64(r.MinSamples))))
 	}
 
-	e.emitSelect(collapse)
-	return nil
+	return e.emitSelect(collapse)
 }

--- a/internal/chsql/range_lwr.go
+++ b/internal/chsql/range_lwr.go
@@ -156,8 +156,7 @@ func (e *emitter) emitRangeLWR(r *chplan.RangeLWR) error {
 	outer.Select(As(verbatim("anchor_ts"), r.TimestampCol))
 	outer.Select(As(verbatim(lwrValueAlias), r.ValueCol))
 
-	e.emitSelect(outer)
-	return nil
+	return e.emitSelect(outer)
 }
 
 // lwrAnchorFanoutFrag renders the LWR sample-side anchor fan-out:

--- a/internal/chsql/range_window.go
+++ b/internal/chsql/range_window.go
@@ -28,23 +28,6 @@ func (e *emitter) emitMetricsAggregate(m *chplan.MetricsAggregate) error {
 	if err != nil {
 		return err
 	}
-	// Pre-flight expressions so chplan errors surface synchronously
-	// (mirrors emitAggregate's pre-flight loop).
-	for _, g := range m.GroupBy {
-		if err := (&Builder{}).Expr(g); err != nil {
-			return err
-		}
-	}
-	for _, p := range params {
-		if err := (&Builder{}).Expr(p); err != nil {
-			return err
-		}
-	}
-	for _, a := range args {
-		if err := (&Builder{}).Expr(a); err != nil {
-			return err
-		}
-	}
 	if m.Inner == nil {
 		return fmt.Errorf("%w: MetricsAggregate.Inner is nil", ErrUnsupported)
 	}
@@ -92,8 +75,7 @@ func (e *emitter) emitMetricsAggregate(m *chplan.MetricsAggregate) error {
 	sb.GroupBy(groupKeyFrags(m.GroupBy, selectedAliases)...)
 
 	if !multi {
-		e.emitSelect(sb)
-		return nil
+		return e.emitSelect(sb)
 	}
 
 	// Multi-phi wrap layer 1: arrayJoin the per-(group) quantiles
@@ -115,8 +97,7 @@ func (e *emitter) emitMetricsAggregate(m *chplan.MetricsAggregate) error {
 	}
 	final.Select(As(Call("tupleElement", BareIdent("phi_val"), InlineLit(int64(1))), metricsMultiQuantilePhiLabel))
 	final.Select(As(Call("tupleElement", BareIdent("phi_val"), InlineLit(int64(2))), m.ValueAlias))
-	e.emitSelect(final)
-	return nil
+	return e.emitSelect(final)
 }
 
 // metricsAggregateCH maps a MetricsAggregate.Op to the CH aggregate
@@ -333,9 +314,6 @@ func (e *emitter) emitRangeWindowPredictLinear(r *chplan.RangeWindow) error {
 	switch {
 	case len(r.ScalarExprs) == 1:
 		tExpr := r.ScalarExprs[0]
-		if err := (&Builder{}).Expr(tExpr); err != nil {
-			return err
-		}
 		writeT = func(b *Builder) { _ = b.Expr(tExpr) }
 	case len(r.Scalars) == 1:
 		t := r.Scalars[0]
@@ -557,8 +535,7 @@ func (e *emitter) emitWindowedArrayPairsAnchored(r *chplan.RangeWindow, valueWri
 		outerSb.Where(windowLenAtLeastFrag("window_pairs", minWindowSize))
 	}
 
-	e.emitSelect(outerSb)
-	return nil
+	return e.emitSelect(outerSb)
 }
 
 // emitWindowedArrayPairsMatrix is the OuterRange > 0 variant of
@@ -650,8 +627,7 @@ func (e *emitter) emitWindowedArrayPairsMatrix(r *chplan.RangeWindow, valueWrite
 		outer.Where(windowLenAtLeastFrag("window_pairs", minWindowSize))
 	}
 
-	e.emitSelect(outer)
-	return nil
+	return e.emitSelect(outer)
 }
 
 // endExprFrag returns a Frag rendering `<End> [- toIntervalNanosecond(<offset>)]`.
@@ -862,23 +838,6 @@ func (e *emitter) emitRangeWindowMetrics(r *chplan.RangeWindow, m *chplan.Metric
 		return err
 	}
 
-	// Pre-flight all expressions so chplan errors surface synchronously.
-	for _, g := range m.GroupBy {
-		if err := (&Builder{}).Expr(g); err != nil {
-			return err
-		}
-	}
-	for _, p := range params {
-		if err := (&Builder{}).Expr(p); err != nil {
-			return err
-		}
-	}
-	for _, a := range args {
-		if err := (&Builder{}).Expr(a); err != nil {
-			return err
-		}
-	}
-
 	end := endExprFrag(r)
 	stepNS := r.Step.Nanoseconds()
 	// Range defaults to Step (per-bucket = per-step). When r.Range is
@@ -1012,8 +971,7 @@ func (e *emitter) emitRangeWindowMetrics(r *chplan.RangeWindow, m *chplan.Metric
 	groupFrags = append(groupFrags, Col("anchor_ts"))
 	outerSb.GroupBy(groupFrags...)
 
-	e.emitSelect(outerSb)
-	return nil
+	return e.emitSelect(outerSb)
 }
 
 // zeroFillExtraCol is an extra (frag, alias) SELECT item the zero-fill
@@ -1190,16 +1148,6 @@ func (e *emitter) emitRangeWindowMetricsQuantileBuckets(r *chplan.RangeWindow, m
 		return err
 	}
 
-	// Pre-flight expressions so chplan errors surface synchronously.
-	if err := (&Builder{}).Expr(m.Attr); err != nil {
-		return err
-	}
-	for _, g := range m.GroupBy {
-		if err := (&Builder{}).Expr(g); err != nil {
-			return err
-		}
-	}
-
 	end := endExprFrag(r)
 	stepNS := r.Step.Nanoseconds()
 	rangeDur := r.Range
@@ -1295,8 +1243,7 @@ func (e *emitter) emitRangeWindowMetricsQuantileBuckets(r *chplan.RangeWindow, m
 	groupFrags = append(groupFrags, Col("anchor_ts"), Col(metricsQuantileBucketAlias))
 	outerSb.GroupBy(groupFrags...)
 
-	e.emitSelect(outerSb)
-	return nil
+	return e.emitSelect(outerSb)
 }
 
 // quantileBucketIfFrag renders the conditional `__bucket` projection
@@ -2553,8 +2500,7 @@ func (e *emitter) emitRangeWindowOverTimeDirect(r *chplan.RangeWindow, agg Frag)
 	)
 	sb.GroupBy(groupFrags...)
 
-	e.emitSelect(sb)
-	return nil
+	return e.emitSelect(sb)
 }
 
 // emitRangeWindowOverTimeDirectMatrix is the OuterRange > 0 variant of
@@ -2625,8 +2571,7 @@ func (e *emitter) emitRangeWindowOverTimeDirectMatrix(r *chplan.RangeWindow, agg
 	regroupKeys = append(regroupKeys, Col("anchor_ts"))
 	regroup.GroupBy(regroupKeys...)
 
-	e.emitSelect(regroup)
-	return nil
+	return e.emitSelect(regroup)
 }
 
 // emitRangeWindowDeriv emits SQL for `deriv(v[range])`.
@@ -2850,10 +2795,6 @@ func irateValueFrag() Frag {
 func (e *emitter) emitRangeWindowQuantileOverTime(r *chplan.RangeWindow) error {
 	if len(r.ScalarExprs) == 1 {
 		phiE := r.ScalarExprs[0]
-		// Pre-flight so chplan errors surface synchronously.
-		if err := (&Builder{}).Expr(phiE); err != nil {
-			return err
-		}
 		// Linear-interpolation quantile over the sorted window, computed-phi
 		// path. Mirrors Prom's quantile() helper: rank = phi*(n-1), the
 		// value is the lower / upper sorted samples blended by the
@@ -3060,8 +3001,7 @@ func (e *emitter) emitWindowedArrayExtrapolated(r *chplan.RangeWindow, kind extr
 	outer.Select(As(extrapolatedValueFrag(kind, rangeSeconds), r.ValueColumn))
 	outer.Where(windowLenAtLeastFrag("window_vals", 2))
 
-	e.emitSelect(outer)
-	return nil
+	return e.emitSelect(outer)
 }
 
 // emitWindowedArrayExtrapolatedMatrix is the OuterRange > 0 variant of
@@ -3170,8 +3110,7 @@ func (e *emitter) emitWindowedArrayExtrapolatedMatrix(r *chplan.RangeWindow, kin
 	outer.Select(As(extrapolatedValueFrag(kind, rangeSeconds), r.ValueColumn))
 	outer.Where(windowLenAtLeastFrag("window_vals", 2))
 
-	e.emitSelect(outer)
-	return nil
+	return e.emitSelect(outer)
 }
 
 // firstTsFrag renders `tupleElement(window_pairs[1], 1)` — the first
@@ -3488,8 +3427,7 @@ func (e *emitter) emitWindowedArray(r *chplan.RangeWindow, value Frag, minWindow
 		outer.Where(windowLenAtLeastFrag("window_vals", minWindowSize))
 	}
 
-	e.emitSelect(outer)
-	return nil
+	return e.emitSelect(outer)
 }
 
 // emitWindowedArrayMatrix is the OuterRange > 0 variant: each series
@@ -3601,8 +3539,7 @@ func (e *emitter) emitWindowedArrayMatrix(r *chplan.RangeWindow, value Frag, min
 		outer.Where(windowLenAtLeastFrag("window_vals", minWindowSize))
 	}
 
-	e.emitSelect(outer)
-	return nil
+	return e.emitSelect(outer)
 }
 
 // collectGroupByFrags renders each GroupBy expression to an isolated
@@ -3624,7 +3561,9 @@ func (e *emitter) collectGroupByFrags(group []chplan.Expr) ([]Frag, error) {
 		if err := sub.Expr(g); err != nil {
 			return nil, err
 		}
-		sql, args := sub.Build()
+		// Expr's error is already checked above; Build's sticky b.err is
+		// therefore always nil here — see Builder.err.
+		sql, args, _ := sub.Build()
 		// Append captured args to the emitter so they land at the
 		// position the outer SELECT-list will reference them. Since
 		// every supported group-by expression is currently arg-free

--- a/internal/chsql/range_window_fused.go
+++ b/internal/chsql/range_window_fused.go
@@ -265,8 +265,7 @@ func (e *emitter) emitFusedInstantSubquery(
 	outerQ.Select(As(reduce(BareIdent("vals")), r.ValueColumn))
 	outerQ.Where(Gt(Call("length", BareIdent("vals")), InlineLit(int64(0))))
 
-	e.emitSelect(outerQ)
-	return nil
+	return e.emitSelect(outerQ)
 }
 
 // tupleElemFrag renders `tupleElement(<t>, <idx>)` — the 1-based tuple

--- a/internal/chsql/range_window_native.go
+++ b/internal/chsql/range_window_native.go
@@ -469,8 +469,7 @@ func (e *emitter) emitRangeWindowNative(r *chplan.RangeWindowNative) error {
 	)
 	outer.Where(IsNotNull(Col(nativeGridValAlias)))
 
-	e.emitSelect(outer)
-	return nil
+	return e.emitSelect(outer)
 }
 
 // requireRecollapseEmittable rejects every deferred-shaping node the emitter

--- a/internal/chsql/range_window_pushdown_test.go
+++ b/internal/chsql/range_window_pushdown_test.go
@@ -662,12 +662,13 @@ func TestRangeLWRRejectsBadInput(t *testing.T) {
 	}
 }
 
-// TestRangeBucketFanoutRejectsBadAggExpr pins the per-AggFunc pre-flight
-// that synchronously surfaces chplan Expr errors from BOTH the Params and
-// the Args lists (the `(&Builder{}).Expr(...)` loops). A nil Expr element
-// hits Builder.Expr's default branch (ErrUnsupported), so a fan-out whose
-// AggFunc carries a nil Param / nil Arg must error — covering and killing
-// the mutants on those two pre-flight loops.
+// TestRangeBucketFanoutRejectsBadAggExpr pins that a bad chplan Expr in
+// EITHER an AggFunc's Params or its Args list surfaces as an Emit error,
+// from both the Params and the Args render paths. A nil Expr element hits
+// Builder.Expr's default branch (ErrUnsupported), which Builder.err's
+// first-error-wins state carries through to the final Build/subquerySQL
+// call (see #1449) — so a fan-out whose AggFunc carries a nil Param / nil
+// Arg must error, covering and killing the mutants on both render paths.
 func TestRangeBucketFanoutRejectsBadAggExpr(t *testing.T) {
 	t.Parallel()
 

--- a/internal/chsql/range_window_resample.go
+++ b/internal/chsql/range_window_resample.go
@@ -145,6 +145,5 @@ func (e *emitter) emitRangeWindowResample(r *chplan.RangeWindowResample) error {
 	)
 	outer.Where(IsNotNull(Col(nativeGridValAlias)))
 
-	e.emitSelect(outer)
-	return nil
+	return e.emitSelect(outer)
 }

--- a/internal/chsql/search_trace_limit.go
+++ b/internal/chsql/search_trace_limit.go
@@ -63,6 +63,5 @@ func (e *emitter) emitSearchTraceLimit(n *chplan.SearchTraceLimit) error {
 		Select(verbatim("s.*")).
 		From(aliasedFrag(outerSub, "s")).
 		Where(InSubquery(Col(n.TraceIDColumn), topN))
-	e.emitSelect(sb)
-	return nil
+	return e.emitSelect(sb)
 }

--- a/internal/chsql/set_op.go
+++ b/internal/chsql/set_op.go
@@ -103,16 +103,14 @@ func (e *emitter) emitSetOperation(s *chplan.SetOperation) error {
 
 	switch s.Op {
 	case chplan.SetIntersect:
-		e.emitSelect(intersectQuery(s, leftFrag, rightFrag, e.nextCTESeq()))
-		return nil
+		return e.emitSelect(intersectQuery(s, leftFrag, rightFrag, e.nextCTESeq()))
 	case chplan.SetUnion:
 		sb := NewQuery().
 			Select(verbatim("*")).
 			From(Paren(UnionAll(leftFrag, rightFrag))).
 			Limit(unionDedupLimitPerIdentity).
 			LimitBy(Col(s.TraceIDColumn), Col(s.SpanIDColumn))
-		e.emitSelect(sb)
-		return nil
+		return e.emitSelect(sb)
 	}
 	return fmt.Errorf("%w: set op %q", ErrUnsupported, s.Op)
 }

--- a/internal/chsql/structural_join.go
+++ b/internal/chsql/structural_join.go
@@ -167,8 +167,7 @@ func (e *emitter) emitStructuralDirectJoin(j *chplan.StructuralJoin) error {
 				aliasedFrag(leftSub, "L"),
 				structuralDirectOnFrag(j, relFrag),
 			)
-		e.emitSelect(sb)
-		return nil
+		return e.emitSelect(sb)
 	case j.Op.IsUnion():
 		// Union direct: (SELECT R.* FROM L INNER JOIN R ON <rel>)
 		//   UNION ALL
@@ -190,8 +189,7 @@ func (e *emitter) emitStructuralDirectJoin(j *chplan.StructuralJoin) error {
 				aliasedFrag(rightSub, "R"),
 				structuralDirectOnFrag(j, relFrag),
 			)
-		e.emitStructuralSpanUnion(j, rightArm, leftArm)
-		return nil
+		return e.emitStructuralSpanUnion(j, rightArm, leftArm)
 	default:
 		sb := NewQuery().
 			Select(rightProj...).
@@ -201,8 +199,7 @@ func (e *emitter) emitStructuralDirectJoin(j *chplan.StructuralJoin) error {
 				aliasedFrag(rightSub, "R"),
 				structuralDirectOnFrag(j, relFrag),
 			)
-		e.emitSelect(sb)
-		return nil
+		return e.emitSelect(sb)
 	}
 }
 
@@ -286,8 +283,7 @@ func (e *emitter) emitStructuralSiblingJoin(j *chplan.StructuralJoin) error {
 			From(aliasedFrag(rightSub, "R")).
 			Join(LeftJoin, aliasedFrag(aggL.Frag(), "L"), onEq).
 			Where(negWhere)
-		e.emitSelect(sb)
-		return nil
+		return e.emitSelect(sb)
 	case j.Op.IsUnion():
 		rightArm := NewQuery().
 			Select(rightProj...).
@@ -299,16 +295,14 @@ func (e *emitter) emitStructuralSiblingJoin(j *chplan.StructuralJoin) error {
 			From(aliasedFrag(leftSub, "L")).
 			Join(InnerJoin, aliasedFrag(rightSub, "R"), onEq).
 			Where(distinctSpan)
-		e.emitStructuralSpanUnion(j, rightArm, leftArm)
-		return nil
+		return e.emitStructuralSpanUnion(j, rightArm, leftArm)
 	default:
 		sb := NewQuery().
 			Select(rightProj...).
 			From(aliasedFrag(leftSub, "L")).
 			Join(InnerJoin, aliasedFrag(rightSub, "R"), onEq).
 			Where(distinctSpan)
-		e.emitSelect(sb)
-		return nil
+		return e.emitSelect(sb)
 	}
 }
 
@@ -405,7 +399,7 @@ func structuralUnionOutputCols(j *chplan.StructuralJoin) []string {
 // the same CH 25.8 analyzer constraint structuralProjectionFrags
 // documents. It falls back to `*` only on the `<side>.* EXCEPT (…)` arm
 // shape, where the column set is not knowable at emit time.
-func (e *emitter) emitStructuralSpanUnion(j *chplan.StructuralJoin, rightArm, leftArm *QueryBuilder) {
+func (e *emitter) emitStructuralSpanUnion(j *chplan.StructuralJoin, rightArm, leftArm *QueryBuilder) error {
 	proj := []Frag{verbatim("*")}
 	if cols := structuralUnionOutputCols(j); len(cols) > 0 {
 		proj = make([]Frag, 0, len(cols))
@@ -418,7 +412,7 @@ func (e *emitter) emitStructuralSpanUnion(j *chplan.StructuralJoin, rightArm, le
 		From(Paren(UnionAll(rightArm.Frag(), leftArm.Frag()))).
 		Limit(unionDedupLimitPerIdentity).
 		LimitBy(Col(j.TraceIDColumn), Col(j.SpanIDColumn))
-	e.emitSelect(sb)
+	return e.emitSelect(sb)
 }
 
 // aliasedSideCol renders `<side>.<col> AS <alias>` with `col` and
@@ -688,8 +682,7 @@ func (e *emitter) emitStructuralRecursive(j *chplan.StructuralJoin) error {
 		if len(j.TraceIDRestriction) > 0 {
 			sb = sb.Where(inStringLiteralsFrag(qualColFrag("R", j.TraceIDColumn), j.TraceIDRestriction))
 		}
-		e.emitSelect(sb)
-		return nil
+		return e.emitSelect(sb)
 	case j.Op.IsUnion():
 		// Union recursive: emit two closure-keyed INNER-JOIN arms —
 		// one projecting R.*, one L.* — glued by UNION ALL and
@@ -716,8 +709,7 @@ func (e *emitter) emitStructuralRecursive(j *chplan.StructuralJoin) error {
 			Select(leftProj...).
 			From(aliasedFrag(leftSub, "L")).
 			Join(InnerJoin, aliasedFrag(inverseClosure.Frag(), "R"), onClause)
-		e.emitStructuralSpanUnion(j, rightArm, leftArm)
-		return nil
+		return e.emitStructuralSpanUnion(j, rightArm, leftArm)
 	default:
 		// Outer SELECT R.* FROM (<closure>) AS L INNER JOIN (<R>) AS R ON L.TraceId = R.TraceId AND L.SpanId = R.SpanId.
 		sb := NewQuery().
@@ -730,8 +722,7 @@ func (e *emitter) emitStructuralRecursive(j *chplan.StructuralJoin) error {
 		if len(j.TraceIDRestriction) > 0 {
 			sb = sb.Where(inStringLiteralsFrag(qualColFrag("R", j.TraceIDColumn), j.TraceIDRestriction))
 		}
-		e.emitSelect(sb)
-		return nil
+		return e.emitSelect(sb)
 	}
 }
 

--- a/internal/chsql/vector_join.go
+++ b/internal/chsql/vector_join.go
@@ -89,8 +89,7 @@ func (e *emitter) emitVectorJoin(j *chplan.VectorJoin) error {
 	if isComparisonOp(j.Op) && !j.ReturnBool {
 		sb.Where(vectorJoinCompareFilterFrag(j))
 	}
-	e.emitSelect(sb)
-	return nil
+	return e.emitSelect(sb)
 }
 
 func (e *emitter) validateVectorJoinCols(j *chplan.VectorJoin) error {

--- a/internal/chsql/vector_set_op.go
+++ b/internal/chsql/vector_set_op.go
@@ -109,8 +109,7 @@ func (e *emitter) emitVectorSetOp(s *chplan.VectorSetOp) error {
 		outer := NewQuery().
 			Select(vectorSetOpOutputCols(s)...).
 			From(inner.Frag())
-		e.emitSelect(outer)
-		return nil
+		return e.emitSelect(outer)
 	case chplan.VectorSetUnless:
 		// SELECT MetricName, Attributes, TimeUnix, Value
 		//   FROM (SELECT MetricName, Attributes, TimeUnix, Value FROM (<A>) WHERE <sig> NOT IN (SELECT DISTINCT <sig> FROM (<B>)))
@@ -121,8 +120,7 @@ func (e *emitter) emitVectorSetOp(s *chplan.VectorSetOp) error {
 		outer := NewQuery().
 			Select(vectorSetOpOutputCols(s)...).
 			From(inner.Frag())
-		e.emitSelect(outer)
-		return nil
+		return e.emitSelect(outer)
 	case chplan.VectorSetOr:
 		// `A or B`: every LHS sample, plus every RHS sample whose match-
 		// key signature does NOT appear in A. Rendered as a SINGLE pass
@@ -201,8 +199,7 @@ func (e *emitter) emitVectorSetOp(s *chplan.VectorSetOp) error {
 				Eq(Col(setOpSideCol), InlineLit(0)),
 				Eq(Col(setOpHasLeftCol), InlineLit(0)),
 			))
-		e.emitSelect(outer)
-		return nil
+		return e.emitSelect(outer)
 	}
 	return fmt.Errorf("%w: vector set op %q", ErrUnsupported, s.Op)
 }


### PR DESCRIPTION
## Summary

Every Frag-embedded `chplan.Expr` render used to be preceded by a throwaway `(&Builder{}).Expr(x)` pre-flight call, run solely to surface a rendering error synchronously — `Frag` (`func(b *Builder)`) has no error return, so an error inside a Frag closure (`func(b *Builder) { _ = b.Expr(x) }`) would otherwise be silently discarded.

This PR replaces that pattern with a sticky first-error-wins `Builder.err` field: `Expr` now records into it as a side effect, so the real render *is* the check.

- `Builder.Build()` is now `(string, []any, error)`.
- `QueryBuilder.Build()`'s **public two-value signature is unchanged** — it's consumed across `internal/api/{prom,loki,tempo}`, `internal/optcorpus`, `internal/routerrules`, `internal/preflight`. An unexported `subquerySQL() (string, []any, error)` carries the three-value error-propagating form for internal chsql use.
- `Subqueryable`'s method is renamed from `Build` to the unexported `subquerySQL`, so only in-package types (`*QueryBuilder`, `PreRenderedSQL`) can satisfy it — external callers passing values into `Subquery()`/`Spliced()` are unaffected.
- `emitSelect`, `splice`, and `emitStructuralSpanUnion` are converted to error-returning so `Builder.err` actually reaches the caller instead of being dropped after a void call.
- Deletes all 34 preflight blocks across the 10 `internal/chsql` files that had them (`emit_node.go`, `range_window.go`, `histogram_quantile.go`, `histogram_quantile_native.go`, `histogram_over_time.go`, `exemplars.go`, `metrics_second_stage.go`, `range_bucket_fanout.go`, `late_mat.go`, `metrics_compare.go`).

Pure refactor — no behavior change. Every `test/spec` golden (default lane + `chdb`-tagged promql/logql/traceql) is byte-identical; `go test ./...` is green.

## Test plan

- [x] `go build ./...` / `go vet ./...` clean
- [x] `go vet -tags chdb ./...` and `go vet -tags chdb,chaos_sleep ./...` clean
- [x] `go test ./...` green
- [x] `go test -tags chdb -count=1 ./test/spec/...` green — byte-identical goldens (promql/logql/traceql)
- [x] `node .github/scripts/forbid-sql-raw.mjs` clean
- [x] `golangci-lint run ./...` clean (via pre-push hook)

Closes #1449