### PR TITLE
fix(tempo): count exemplar-attach failures on the metrics path

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -193,6 +193,9 @@ each one so a rename cannot ship silently.
 | `cerberus_clickhouse_rows_read`            | histogram | `cerberus_ql`                                                                               |
 | `cerberus_clickhouse_bytes_read`           | histogram | `cerberus_ql`                                                                               |
 | `cerberus_query_inflight`                  | gauge     | `cerberus_ql`                                                                               |
+| `cerberus_tempo_exemplar_failures_total`   | counter   | `stage`                                                                                     |
+
+`cerberus_tempo_exemplar_failures_total` counts Tempo `/api/metrics/query_range` (and its gRPC `MetricsQueryRange` counterpart) exemplar-enrichment failures, split by which half of the best-effort exemplar attach failed: `stage="emit"` for a `chsql.EmitMetricsExemplars` render failure, `stage="execute"` for a ClickHouse query failure on the rendered SQL. Both failures still return the matrix response with an empty `exemplars` array — the same wire shape as a window with genuinely no exemplars — so this counter is the only way to notice a systematic exemplar outage without reading logs.
 
 #### ClickHouse connection lifecycle
 

--- a/internal/api/tempo/metrics_exec.go
+++ b/internal/api/tempo/metrics_exec.go
@@ -235,7 +235,12 @@ func (h *Handler) runMetricsWindow(
 // attachMetricsExemplars enriches series in place, best-effort: an emit
 // or execute failure keeps the empty Exemplars slice toMetricsSeries
 // already attached, so the wire envelope stays well-formed either way.
-// Both failures warn rather than degrade silently.
+// Both failures warn AND increment telemetry.ExemplarFailuresTotal
+// (#1460) — a log line alone left a systematic exemplar outage
+// wire-indistinguishable from "no exemplars in this window", visible
+// only by reading logs rather than on a dashboard. Shared by both the
+// HTTP and gRPC Tempo metrics entrypoints via execMetricsRange, so one
+// counter covers both transports.
 func (h *Handler) attachMetricsExemplars(
 	ctx context.Context,
 	series []MetricsSeries,
@@ -246,11 +251,13 @@ func (h *Handler) attachMetricsExemplars(
 		h.Schema.TraceIDColumn, h.Schema.SpanIDColumn, exemplarsPerSeries, h.Schema.SpansTable)
 	if exErr != nil {
 		h.Logger.Warn("cerberus tempo metrics exemplars emit failed (matrix returns without exemplars)", "err", exErr)
+		telemetry.RecordTempoExemplarFailure(ctx, telemetry.StageEmit)
 		return
 	}
 	exSamples, qErr := h.Client.Query(ctx, exSQL, exArgs...)
 	if qErr != nil {
 		h.Logger.Warn("cerberus tempo metrics exemplars query failed (matrix returns without exemplars)", "err", qErr)
+		telemetry.RecordTempoExemplarFailure(ctx, telemetry.StageExecute)
 		return
 	}
 	attachExemplars(series, exSamples, metrics)

--- a/internal/api/tempo/metrics_exec_test.go
+++ b/internal/api/tempo/metrics_exec_test.go
@@ -1,0 +1,155 @@
+package tempo
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/telemetry"
+)
+
+// errQuerier fails every Query / QueryStrings call with err — used to
+// force attachMetricsExemplars down its ClickHouse-failure branch
+// without wiring a full HTTP round trip.
+type errQuerier struct{ err error }
+
+func (q *errQuerier) Query(context.Context, string, ...any) ([]chclient.Sample, error) {
+	return nil, q.err
+}
+
+func (q *errQuerier) QueryStrings(context.Context, string, ...any) ([]string, error) {
+	return nil, q.err
+}
+
+// installManualReaderForExemplarTest swaps the process-global OTel
+// MeterProvider with one backed by a ManualReader, so a test can pull
+// a deterministic metrics snapshot after driving attachMetricsExemplars
+// directly. Mirrors internal/telemetry/metrics_test.go's helper of the
+// same name — duplicated here (test-only scaffolding, not a package
+// API) rather than exported from internal/telemetry.
+func installManualReaderForExemplarTest(t *testing.T) *metric.ManualReader {
+	t.Helper()
+	reader := metric.NewManualReader()
+	mp := metric.NewMeterProvider(metric.WithReader(reader))
+	telemetry.Install(mp)
+	t.Cleanup(func() { telemetry.Install(nil) })
+	return reader
+}
+
+// collectExemplarFailures drains the manual reader and returns the
+// cerberus_tempo_exemplar_failures_total sum's data points.
+func collectExemplarFailures(t *testing.T, reader *metric.ManualReader) []metricdata.DataPoint[int64] {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+	for _, sm := range rm.ScopeMetrics {
+		if !strings.HasSuffix(sm.Scope.Name, "internal/telemetry") {
+			continue
+		}
+		for _, m := range sm.Metrics {
+			if m.Name == "cerberus_tempo_exemplar_failures_total" {
+				return m.Data.(metricdata.Sum[int64]).DataPoints
+			}
+		}
+	}
+	t.Fatalf("cerberus_tempo_exemplar_failures_total not found; scopes=%v", rm.ScopeMetrics)
+	return nil
+}
+
+// attrString reads a string-valued attribute off a data point, failing
+// the test if it is absent.
+func attrString(t *testing.T, dp metricdata.DataPoint[int64], key attribute.Key) string {
+	t.Helper()
+	v, ok := dp.Attributes.Value(key)
+	if !ok {
+		t.Fatalf("attribute %q missing; have %v", key, dp.Attributes)
+	}
+	return v.AsString()
+}
+
+// TestAttachMetricsExemplars_EmitFailure_RecordsCounter pins the
+// chsql.EmitMetricsExemplars failure branch of attachMetricsExemplars
+// (#1460): a nil RangeWindow trips EmitMetricsExemplars's own
+// nil-guard, and the handler must record the failure on
+// ExemplarFailuresTotal with stage=StageEmit rather than only logging
+// it — before this fix, a systematic exemplar-emit outage was
+// wire-indistinguishable from "no exemplars in this window".
+func TestAttachMetricsExemplars_EmitFailure_RecordsCounter(t *testing.T) {
+	// Not t.Parallel(): installManualReaderForExemplarTest swaps the
+	// process-global OTel MeterProvider (telemetry.Install), which two
+	// tests doing so concurrently would race — mirrors
+	// internal/telemetry/metrics_test.go's convention.
+	reader := installManualReaderForExemplarTest(t)
+
+	h := &Handler{Logger: slog.Default()}
+	series := []MetricsSeries{{}}
+	metrics := &chplan.MetricsAggregate{
+		Op:         chplan.MetricsOpRate,
+		ValueAlias: "Value",
+		Inner:      &chplan.Scan{Table: "otel_traces"},
+	}
+
+	h.attachMetricsExemplars(context.Background(), series, nil, metrics)
+
+	dps := collectExemplarFailures(t, reader)
+	if len(dps) != 1 {
+		t.Fatalf("exemplar_failures DPs: got %d want 1: %+v", len(dps), dps)
+	}
+	if got := attrString(t, dps[0], telemetry.AttrStage); got != telemetry.StageEmit {
+		t.Errorf("stage: got %q want %q", got, telemetry.StageEmit)
+	}
+}
+
+// TestAttachMetricsExemplars_QueryFailure_RecordsCounter pins the
+// ClickHouse-query failure branch (#1460): a valid, emittable exemplars
+// query whose Client.Query call fails must record
+// ExemplarFailuresTotal with stage=StageExecute — distinct from the
+// emit-failure branch's StageEmit, so a dashboard can tell "we
+// couldn't build the exemplars SQL" apart from "ClickHouse rejected
+// it" without reading logs.
+func TestAttachMetricsExemplars_QueryFailure_RecordsCounter(t *testing.T) {
+	// Not t.Parallel() — see TestAttachMetricsExemplars_EmitFailure_RecordsCounter.
+	reader := installManualReaderForExemplarTest(t)
+
+	h := &Handler{
+		Client: &errQuerier{err: errors.New("ch unavailable")},
+		Schema: schema.DefaultOTelTraces(),
+		Logger: slog.Default(),
+	}
+	series := []MetricsSeries{{}}
+	metrics := &chplan.MetricsAggregate{
+		Op:         chplan.MetricsOpRate,
+		ValueAlias: "Value",
+		Inner:      &chplan.Scan{Table: "otel_traces"},
+	}
+	rw := &chplan.RangeWindow{
+		Input:           metrics,
+		Step:            time.Minute,
+		Range:           time.Minute,
+		Start:           time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC),
+		End:             time.Date(2026, 5, 13, 12, 5, 0, 0, time.UTC),
+		TimestampColumn: "Timestamp",
+	}
+
+	h.attachMetricsExemplars(context.Background(), series, rw, metrics)
+
+	dps := collectExemplarFailures(t, reader)
+	if len(dps) != 1 {
+		t.Fatalf("exemplar_failures DPs: got %d want 1: %+v", len(dps), dps)
+	}
+	if got := attrString(t, dps[0], telemetry.AttrStage); got != telemetry.StageExecute {
+		t.Errorf("stage: got %q want %q", got, telemetry.StageExecute)
+	}
+}

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -207,6 +207,17 @@ type Instruments struct {
 	// OutcomeSuccess for a memo-tracked dispatch, by which route produced
 	// it. Attribute: cerberus.route_choice ("a" / "b").
 	RouteABSuccessTotal metric.Int64Counter
+
+	// ExemplarFailuresTotal counts Tempo metrics-path exemplar
+	// enrichment failures, by which half of attachMetricsExemplars
+	// failed: the chsql.EmitMetricsExemplars render (stage=StageEmit)
+	// or the ClickHouse round trip for the rendered query
+	// (stage=StageExecute). attachMetricsExemplars degrades
+	// gracefully — the matrix response still returns, with an empty
+	// exemplars array — so this counter is the only wire-visible
+	// signal of a systematic exemplar outage; without it the failure
+	// is indistinguishable from "no exemplars in this window" (#1460).
+	ExemplarFailuresTotal metric.Int64Counter
 }
 
 // Histogram bucket boundaries, one ladder per instrument, matched to the
@@ -394,6 +405,14 @@ func mustBuild(meter metric.Meter) *Instruments {
 	if err != nil {
 		panic("telemetry: build route_ab_success_total: " + err.Error())
 	}
+	exemplarFailures, err := meter.Int64Counter(
+		"cerberus_tempo_exemplar_failures_total",
+		metric.WithDescription("Tempo metrics-path exemplar enrichment failures, by stage (emit/execute)."),
+		metric.WithUnit("{failure}"),
+	)
+	if err != nil {
+		panic("telemetry: build tempo_exemplar_failures_total: " + err.Error())
+	}
 	return &Instruments{
 		QueriesTotal:             queriesTotal,
 		QueryDuration:            queryDuration,
@@ -406,6 +425,7 @@ func mustBuild(meter metric.Meter) *Instruments {
 		RouteMemoPressureActive:  routeMemoPressureActive,
 		RoutedDispatchInflight:   routedDispatchInflight,
 		RouteABSuccessTotal:      routeABSuccess,
+		ExemplarFailuresTotal:    exemplarFailures,
 	}
 }
 
@@ -586,4 +606,16 @@ func ObserveRoutedDispatchInflight(ctx context.Context) func() {
 // resolves to OutcomeSuccess for a memo-tracked dispatch.
 func RecordRouteABSuccess(ctx context.Context, route string) {
 	Get().RouteABSuccessTotal.Add(ctx, 1, metric.WithAttributes(AttrRouteChoice.String(route)))
+}
+
+// RecordTempoExemplarFailure increments ExemplarFailuresTotal for the
+// given attachMetricsExemplars failure stage — StageEmit for a
+// chsql.EmitMetricsExemplars render failure, StageExecute for a
+// ClickHouse query failure on the rendered exemplars SQL. Reuses the
+// AttrStage vocabulary rather than minting a parallel one: both
+// values already name exactly the pipeline phase that failed. Caller
+// is internal/api/tempo/metrics_exec.go's attachMetricsExemplars,
+// shared by both the HTTP and gRPC Tempo metrics entrypoints.
+func RecordTempoExemplarFailure(ctx context.Context, stage string) {
+	Get().ExemplarFailuresTotal.Add(ctx, 1, metric.WithAttributes(AttrStage.String(stage)))
 }


### PR DESCRIPTION
## Summary

- `attachMetricsExemplars` (`internal/api/tempo/metrics_exec.go`) degrades gracefully on either half of its best-effort exemplar enrichment failing: a `chsql.EmitMetricsExemplars` render error, or a ClickHouse query error on the rendered SQL. `/api/metrics/query_range` — and its gRPC `MetricsQueryRange` counterpart, which shares this exact code path since #1577's `execMetricsRange` unification — keeps returning the matrix response with an empty `exemplars` array either way. That degrade-don't-fail behaviour is correct, but it made a systematic exemplar outage wire-indistinguishable from "no exemplars in this window": the only signal was a `Logger.Warn` line (#1460).
- Adds `cerberus_tempo_exemplar_failures_total`, a counter incremented at both of `attachMetricsExemplars`'s warn sites, labelled `stage="emit"` / `stage="execute"` — reusing `telemetry`'s existing `AttrStage` key/vocabulary rather than minting a parallel one, since both values already name exactly the pipeline phase that failed.
- Because `attachMetricsExemplars` is the single shared implementation both the HTTP and gRPC Tempo metrics entrypoints call into, one counter covers both transports — no change needed at the gRPC call site.
- Documents the new metric + its `stage` attribute in `docs/observability.md`'s self-metrics table.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/api/tempo/... ./internal/telemetry/... ./internal/chsql/... -count=1 -race` — new `TestAttachMetricsExemplars_EmitFailure_RecordsCounter` and `TestAttachMetricsExemplars_QueryFailure_RecordsCounter` pin the counter + `stage` label at both failure sites; full existing suites for the touched packages pass.
- [x] `go vet ./...`
- [x] pre-push lefthook (golangci-lint, forbid-sql-raw, forbid-skip, markdownlint, commitlint) — all green
