### PR TITLE
fix(promql): route exp-histogram companion selectors, reject the rest

### DIFF
--- a/internal/promql/exp_histogram_reject_test.go
+++ b/internal/promql/exp_histogram_reject_test.go
@@ -1,0 +1,92 @@
+package promql_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestLower_ExpHistogram_UnsupportedShapesRejectExplicitly pins issue #1704:
+// every PromQL shape over a pinned exponential-histogram selector OTHER
+// than histogram_quantile() / histogram_count() / histogram_sum() and the
+// `_count` / `_sum` companion selectors must fail lowering with a clear
+// error, never silently resolve against the Gauge/Sum tables and return an
+// empty-but-200 result. Before the fix, TablesFor never yielded
+// ExpHistogramTable for these shapes, so cerberus quietly scanned the
+// wrong tables and matched zero rows.
+func TestLower_ExpHistogram_UnsupportedShapesRejectExplicitly(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+
+	cases := []struct {
+		name  string
+		query string
+	}{
+		{name: "bare selector", query: `latency_exp_hist`},
+		{name: "bare selector with label matcher", query: `latency_exp_hist{service="api"}`},
+		{name: "rate", query: `rate(latency_exp_hist[5m])`},
+		{name: "resets", query: `resets(latency_exp_hist[5m])`},
+		{name: "changes", query: `changes(latency_exp_hist[5m])`},
+		{name: "increase", query: `increase(latency_exp_hist[5m])`},
+		{name: "sum aggregation", query: `sum(latency_exp_hist)`},
+		{name: "sum by", query: `sum by (service) (latency_exp_hist)`},
+		{name: "absent_over_time", query: `absent_over_time(latency_exp_hist[5m])`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			expr, err := p.ParseExpr(tc.query)
+			if err != nil {
+				t.Fatalf("ParseExpr(%q): %v", tc.query, err)
+			}
+			_, err = promql.Lower(context.Background(), expr, s)
+			if err == nil {
+				t.Fatalf("Lower(%q): expected an explicit rejection error, got nil (silent empty result)", tc.query)
+			}
+			if !strings.Contains(err.Error(), "latency_exp_hist") {
+				t.Fatalf("Lower(%q): error %q does not name the offending metric", tc.query, err.Error())
+			}
+			if !strings.Contains(err.Error(), "exponential histogram") {
+				t.Fatalf("Lower(%q): error %q does not explain the exp-histogram shape mismatch", tc.query, err.Error())
+			}
+		})
+	}
+}
+
+// TestLower_ExpHistogram_CompanionSuffixesStillWork pins the shapes that
+// MUST keep resolving after the #1704 fix: histogram_quantile() /
+// histogram_count() / histogram_sum() against a bare exp-histogram
+// selector, all of which detect the exp-histogram shape via their own
+// dedicated lowering before ever reaching the generic vector-selector
+// path this fix changed.
+func TestLower_ExpHistogram_DedicatedFunctionsStillWork(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+
+	queries := []string{
+		`histogram_quantile(0.9, latency_exp_hist)`,
+		`histogram_count(latency_exp_hist)`,
+		`histogram_sum(latency_exp_hist)`,
+	}
+	for _, q := range queries {
+		t.Run(q, func(t *testing.T) {
+			t.Parallel()
+			expr, err := p.ParseExpr(q)
+			if err != nil {
+				t.Fatalf("ParseExpr(%q): %v", q, err)
+			}
+			if _, err := promql.Lower(context.Background(), expr, s); err != nil {
+				t.Fatalf("Lower(%q): unexpected error: %v", q, err)
+			}
+		})
+	}
+}

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -336,6 +336,164 @@ func lowerHistogramSelectorInput(
 	return scan, pred, false
 }
 
+// expHistogramSelectorRouting resolves how lowerVectorSelector should
+// handle a selector that names (or companion-suffixes) an exp-histogram
+// metric — split out of lowerVectorSelector's if/else chain to keep that
+// function's cyclomatic complexity in check (see #1704).
+//
+// ok is false when metricName has nothing to do with an exp-histogram
+// metric at all, and the caller's existing classic-histogram / bucket
+// handling applies unchanged.
+//
+// When ok is true and err is nil, the `_count` / `_sum` companion suffix
+// is in play: the OTel-CH exp-histogram exporter writes Count/Sum as
+// columns on a single row keyed by the bare `<base>_exp_hist` name, the
+// same companion convention the classic-histogram path serves — just
+// reading from ExpHistogramTable instead of HistogramTable. Unlike the
+// classic case there is no hostmetrics/standalone-gauge name collision to
+// fan across: `_exp_hist` is cerberus's own synthetic marker suffix, not
+// an upstream naming convention any other emitter could produce, so this
+// is always a single-arm projection (the caller never routes it through
+// the multi-table companion union).
+//
+// When ok is true and err is non-nil, every other shape over a pinned
+// exp-histogram selector — a bare selector, or one wrapped in
+// rate()/resets()/changes()/sum()/etc. — has no scalar Value column to
+// read: the exp-histogram row shape (Sum/Count/Scale/PositiveCounts/
+// NegativeCounts) is disjoint from the Sample contract these functions
+// reduce over. histogram_quantile()/histogram_count()/histogram_sum()
+// detect this shape themselves before ever reaching lowerVectorSelector
+// (see their own s.IsExpHistogramMetric checks), and the companion arm
+// above is the one column-backed exception — so any selector that
+// reaches here is a shape none of those paths recognise. err rejects it
+// explicitly rather than silently matching zero rows against the
+// Gauge/Sum tables.
+//
+// Metadata enumeration (/series, /labels — ctx.metadataFullRange) is
+// exempted: it doesn't consume a Value column, only MetricName +
+// Attributes, so a hard error there would break legitimate series/label
+// discovery for a real metric. It still resolves against Gauge/Sum like
+// before this function existed — the exp-histogram table can't join that
+// merge() fan-out (disjoint row shape, see TablesForUnknownName) — a
+// separate, already-documented gap this function doesn't newly introduce.
+func expHistogramSelectorRouting(metricName string, s schema.Metrics, ctx lowerCtx, matchers []*labels.Matcher) (tables []string, newMatchers []*labels.Matcher, companionValueColumn, companionBare string, ok bool, err error) {
+	if bare, col, hasCompanion := s.HistogramCompanionColumn(metricName); hasCompanion && s.IsExpHistogramMetric(bare) && s.ExpHistogramTable != "" {
+		return []string{s.ExpHistogramTable}, rewriteMetricName(matchers, bare), col, bare, true, nil
+	}
+	if s.IsExpHistogramMetric(metricName) && !ctx.metadataFullRange {
+		return nil, nil, "", "", true, fmt.Errorf(
+			"promql: %q is an exponential histogram metric; only histogram_quantile(), "+
+				"histogram_count(), histogram_sum(), and the %q/%q companion selectors are supported",
+			metricName, metricName+"_count", metricName+"_sum",
+		)
+	}
+	return nil, nil, "", "", false, nil
+}
+
+// selectorRouting is resolveSelectorRouting's result: the physical
+// table(s) + matcher rewrite lowerVectorSelector's LWR/range-vector
+// pipeline should scan, plus whichever companion/bucket bookkeeping
+// downstream steps (lowerHistogramSelectorInput, needCompanionUnion)
+// need to pick the right Project/UnionAll shape.
+type selectorRouting struct {
+	tables                []string
+	matchers              []*labels.Matcher
+	companionValueColumn  string
+	bucketSuffixed        string
+	bucketLeMatchers      []*labels.Matcher
+	companionSuffixed     string
+	companionBare         string
+	expHistogramCompanion bool
+}
+
+// resolveSelectorRouting picks which physical table(s) a vector selector
+// scans and how its matchers should be rewritten, covering the
+// `_bucket` classic-histogram fan-out, the exp-histogram companion /
+// rejection routing (expHistogramSelectorRouting), and the classic
+// `_count`/`_sum` histogram-companion suffix — in that priority order.
+// Split out of lowerVectorSelector to keep that function's cyclomatic
+// complexity in check (see #1704); defaultTables is the TablesFor /
+// TablesForUnknownName result the caller already resolved, used as-is
+// when none of the three special cases match.
+func resolveSelectorRouting(metricName string, s schema.Metrics, ctx lowerCtx, defaultTables []string, matchers []*labels.Matcher) (selectorRouting, error) {
+	route := selectorRouting{tables: defaultTables, matchers: matchers}
+
+	// `<base>_bucket` takes a parallel-but-distinct path: the OTel-CH
+	// histogram row stores per-bucket counts as the `BucketCounts` array
+	// with `ExplicitBounds` carrying the bucket edges. Prom exposes the
+	// same data as N+1 separate series under `<base>_bucket{le=<bound>}`,
+	// so the bare-selector lowering fans the array into N+1 Sample-shape
+	// rows via arrayJoin. See wrapHistogramBucketFanout for the plan
+	// shape. The bucket suffix is detected via isClassicBucketSelector;
+	// the matcher-strip + `le` matcher split happens in splitBucketMatchers.
+	if bareBucket, ok := isClassicBucketSelector(metricName, s); ok {
+		route.tables = []string{s.HistogramTable}
+		route.bucketSuffixed = metricName
+		scanMatchers, leMatchers := splitBucketMatchers(matchers, bareBucket)
+		route.matchers = scanMatchers
+		route.bucketLeMatchers = leMatchers
+		return route, nil
+	}
+
+	if expTables, expMatchers, expCol, expBare, expOK, expErr := expHistogramSelectorRouting(metricName, s, ctx, matchers); expOK {
+		if expErr != nil {
+			return selectorRouting{}, expErr
+		}
+		route.tables = expTables
+		route.matchers = expMatchers
+		route.expHistogramCompanion = true
+		route.companionValueColumn = expCol
+		route.companionSuffixed = metricName
+		route.companionBare = expBare
+		return route, nil
+	}
+
+	// Classic-histogram companion routing: `<base>_count` / `<base>_sum`
+	// are Prom-convention companion names whose data lives, in the OTel-CH
+	// layout, as `Count` / `Sum` columns on rows written under the bare
+	// `<base>` name in the histogram table. Reroute the scan + strip the
+	// suffix off the `__name__` matcher + alias the column as `Value` so
+	// the downstream Sample-row contract holds. Mirrors stripBucketSuffix
+	// (PR #637) for the `_bucket` companion, and the exemplars handler's
+	// routing in internal/api/prom/exemplars.go::exemplarsTableFor.
+	//
+	// Two physical layouts may carry the matching rows:
+	//
+	//   1. The OTel-CH histogram exporter writes Count/Sum as columns on
+	//      a single row keyed by the BARE `<base>` name in the histogram
+	//      table.
+	//   2. The OTel-hostmetrics / sqlquery emitters write the suffixed
+	//      name (`system_cpu_logical_count`, `system_processes_count`,
+	//      `system_filesystem_inodes_count`,
+	//      `system_processes_created_count`, …) as a cumulative Sum
+	//      under the suffixed name in the sum table.
+	//
+	// When Sum is configured and distinct from Histogram, the caller
+	// fans the scan across both layouts via a UnionAll of per-arm
+	// Projects (needCompanionUnion / lowerCompanionUnion), keyed off
+	// companionValueColumn / companionSuffixed / companionBare below.
+	// When the union path doesn't apply (no Sum table configured, or Sum
+	// equals Histogram by config), the caller falls back to the
+	// single-arm histogram projection — same shape as before this
+	// multi-table fan-out.
+	if bare, col, ok := s.HistogramCompanionColumn(metricName); ok && s.HistogramTable != "" {
+		route.tables = []string{s.HistogramTable}
+		route.companionValueColumn = col
+		route.companionSuffixed = metricName
+		route.companionBare = bare
+		// The single-arm fallback rewrites matchers in-place to the bare
+		// name so the legacy histogram-companion-only emit shape stays
+		// byte-stable — but ONLY when there is no distinct Sum/Gauge value
+		// table to scan under the literal suffixed name (else the union path
+		// owns the rewrite per-arm).
+		if len(literalCompanionValueTables(s)) == 0 {
+			route.matchers = rewriteMetricName(matchers, bare)
+		}
+	}
+
+	return route, nil
+}
+
 func lowerVectorSelector(v *parser.VectorSelector, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
 	metricName := metricNameFromMatchers(v.LabelMatchers)
 	if metricName == "" && hasUnpinnedMetricNameMatcher(v.LabelMatchers) && s.HistogramTable != "" {
@@ -369,81 +527,29 @@ func lowerVectorSelector(v *parser.VectorSelector, s schema.Metrics, ctx lowerCt
 		tables = s.TablesFor(metricName)
 	}
 
-	// Classic-histogram companion routing: `<base>_count` / `<base>_sum`
-	// are Prom-convention companion names whose data lives, in the OTel-CH
-	// layout, as `Count` / `Sum` columns on rows written under the bare
-	// `<base>` name in the histogram table. Reroute the scan + strip the
-	// suffix off the `__name__` matcher + alias the column as `Value` so
-	// the downstream Sample-row contract holds. Mirrors stripBucketSuffix
-	// (PR #637) for the `_bucket` companion, and the exemplars handler's
-	// routing in internal/api/prom/exemplars.go::exemplarsTableFor.
-	//
-	// `<base>_bucket` takes a parallel-but-distinct path: the OTel-CH
-	// histogram row stores per-bucket counts as the `BucketCounts` array
-	// with `ExplicitBounds` carrying the bucket edges. Prom exposes the
-	// same data as N+1 separate series under `<base>_bucket{le=<bound>}`,
-	// so the bare-selector lowering fans the array into N+1 Sample-shape
-	// rows via arrayJoin. See wrapHistogramBucketFanout for the plan
-	// shape. The bucket suffix is detected via isClassicBucketSelector;
-	// the matcher-strip + `le` matcher split happens in splitBucketMatchers.
-	matchers := v.LabelMatchers
-	var companionValueColumn string
-	var bucketSuffixed string
-	var bucketLeMatchers []*labels.Matcher
-	var companionSuffixed string
-	var companionBare string
-	if bareBucket, ok := isClassicBucketSelector(metricName, s); ok {
-		tables = []string{s.HistogramTable}
-		bucketSuffixed = metricName
-		var scanMatchers []*labels.Matcher
-		scanMatchers, bucketLeMatchers = splitBucketMatchers(matchers, bareBucket)
-		matchers = scanMatchers
-	} else if bare, col, ok := s.HistogramCompanionColumn(metricName); ok && s.HistogramTable != "" {
-		// `<base>_count` / `<base>_sum` — a classic-histogram companion
-		// suffix. Two physical layouts may carry the matching rows:
-		//
-		//   1. The OTel-CH histogram exporter writes Count/Sum as
-		//      columns on a single row keyed by the BARE `<base>` name
-		//      in the histogram table.
-		//   2. The OTel-hostmetrics / sqlquery emitters write the
-		//      suffixed name (`system_cpu_logical_count`,
-		//      `system_processes_count`, `system_filesystem_inodes_count`,
-		//      `system_processes_created_count`, …) as a cumulative Sum
-		//      under the suffixed name in the sum table.
-		//
-		// When Sum is configured and distinct from Histogram, fan the
-		// scan across both layouts via a UnionAll of per-arm Projects.
-		// Each arm bakes its own MetricName filter so the union arms
-		// hold disjoint row sets by construction. The non-MetricName
-		// matchers (attribute / service equality / regex matchers) are
-		// applied inside each arm so the optimizer's PREWHERE promotion
-		// path still sees a Filter-over-Scan shape per arm.
-		//
-		// `companionValueColumn` / `companionSuffixed` / `companionBare`
-		// drive the per-arm Project-shape decision below. When the union
-		// path doesn't apply (no Sum table configured, or Sum equals
-		// Histogram by config), fall back to the single-arm histogram
-		// projection — same shape as before this multi-table fan-out.
-		tables = []string{s.HistogramTable}
-		companionValueColumn = col
-		companionSuffixed = metricName
-		companionBare = bare
-		// The single-arm fallback rewrites matchers in-place to the bare
-		// name so the legacy histogram-companion-only emit shape stays
-		// byte-stable — but ONLY when there is no distinct Sum/Gauge value
-		// table to scan under the literal suffixed name (else the union path
-		// below owns the rewrite per-arm).
-		if len(literalCompanionValueTables(s)) == 0 {
-			matchers = rewriteMetricName(matchers, bare)
-		}
+	// Resolve the `_bucket` / exp-histogram / classic-histogram-companion
+	// routing (see resolveSelectorRouting's doc comment for the full
+	// per-case rationale) and apply it to the scan tables + matchers
+	// before building the LWR / range-vector pipeline below.
+	route, err := resolveSelectorRouting(metricName, s, ctx, tables, v.LabelMatchers)
+	if err != nil {
+		return nil, err
 	}
+	tables = route.tables
+	matchers := route.matchers
+	companionValueColumn := route.companionValueColumn
+	bucketSuffixed := route.bucketSuffixed
+	bucketLeMatchers := route.bucketLeMatchers
+	companionSuffixed := route.companionSuffixed
+	companionBare := route.companionBare
+	expHistogramCompanion := route.expHistogramCompanion
 
 	// Multi-arm companion union: when both histogram + sum tables are
 	// in play for a `_count` / `_sum` selector, hand off to the
 	// dedicated builder which assembles the per-arm Projects, stitches
 	// them with chplan.UnionAll, and wraps the union with the right
 	// LWR / range-vector shape for ctx.
-	if needCompanionUnion(s, companionValueColumn, companionSuffixed, companionBare) {
+	if !expHistogramCompanion && needCompanionUnion(s, companionValueColumn, companionSuffixed, companionBare) {
 		return lowerCompanionUnion(
 			v, s, ctx, matchers,
 			companionBare, companionSuffixed, companionValueColumn,

--- a/test/perf/cardinality-baseline.json
+++ b/test/perf/cardinality-baseline.json
@@ -3641,6 +3641,17 @@
     "uncountable_levels": 0
   },
   {
+    "fixture": "promql/histogram_mean_latency_exp",
+    "fan_factor": 1,
+    "scan_rows": 2,
+    "peak_intermediate": 2,
+    "has_cross_join": false,
+    "has_array_join": true,
+    "has_recursive_cte": false,
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
+  },
+  {
     "fixture": "promql/histogram_quantile_agg_empty",
     "fan_factor": 0,
     "scan_rows": 0,

--- a/test/perf/solver-decision-baseline.json
+++ b/test/perf/solver-decision-baseline.json
@@ -1490,6 +1490,16 @@
     "outer_range": "1h0m0s"
   },
   {
+    "query": "histogram_mean_latency_exp",
+    "routed": false,
+    "k": 0,
+    "reason": "below-threshold",
+    "n_anchors": 241,
+    "fanout": 4,
+    "cumulative_d": "2m0s",
+    "outer_range": "1h0m0s"
+  },
+  {
     "query": "histogram_quantile_agg_empty",
     "routed": false,
     "k": 0,

--- a/test/rejection-parity/catalogue.json
+++ b/test/rejection-parity/catalogue.json
@@ -559,7 +559,7 @@
       "site": "internal/promql/lower.go:expHistogramSelectorRouting#bcc398d7",
       "message": "promql: %q is an exponential histogram metric; only histogram_quantile(), histogram_count(), histogram_sum(), and the %q/%q companion selectors are supported",
       "class": "rejection",
-      "trigger_query": "rate(demo_exp_histogram[5m])"
+      "trigger_query": "rate(demo_exp_hist[5m])"
     },
     {
       "head": "promql",

--- a/test/rejection-parity/catalogue.json
+++ b/test/rejection-parity/catalogue.json
@@ -556,6 +556,13 @@
     },
     {
       "head": "promql",
+      "site": "internal/promql/lower.go:expHistogramSelectorRouting#bcc398d7",
+      "message": "promql: %q is an exponential histogram metric; only histogram_quantile(), histogram_count(), histogram_sum(), and the %q/%q companion selectors are supported",
+      "class": "rejection",
+      "trigger_query": "rate(demo_exp_histogram[5m])"
+    },
+    {
+      "head": "promql",
       "site": "internal/promql/lower.go:lower#d33d0084",
       "message": "promql: unsupported expression %T",
       "class": "internal",

--- a/test/spec/promql/histogram_mean_latency_exp.txtar
+++ b/test/spec/promql/histogram_mean_latency_exp.txtar
@@ -1,0 +1,73 @@
+# Exponential-histogram analogue of histogram_mean_latency.txtar: the
+# `_count` / `_sum` companion suffixes now route to ExpHistogramTable (see
+# #1704) instead of silently fanning across Gauge/Sum and matching zero
+# rows. Single-arm projection — unlike the classic-histogram companion
+# path, there is no Sum/Gauge union to consider (see lowerVectorSelector's
+# exp-histogram companion branch).
+-- query.promql --
+rate(latency_exp_hist_sum[1m]) / rate(latency_exp_hist_count[1m])
+-- range_step --
+1m
+-- seed --
+CREATE TABLE otel_metrics_exponential_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    Scale Int32,
+    ZeroCount UInt64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64),
+    NegativeOffset Int32,
+    NegativeBucketCounts Array(UInt64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_exponential_histogram VALUES
+    ('latency_exp_hist', map('service', 'api'), toDateTime64('2025-12-31 23:59:30', 9), 10, 5.0, 0, 1, 0, [3, 4, 3], 1, [2]),
+    ('latency_exp_hist', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 70, 35.0, 0, 1, 0, [21, 28, 21], 1, [2]);
+-- args --
+[0] string = ""
+[1] string = ""
+[2] string = "service.name"
+[3] string = "service_name"
+[4] string = "service.name"
+[5] string = "service_name"
+[6] string = ""
+[7] string = "service_name"
+[8] string = "latency_exp_hist"
+[9] string = "latency.exp.hist"
+[10] string = "latency.exp/hist"
+[11] string = "latency.exp_hist"
+[12] string = "latency/exp/hist"
+[13] string = "latency/exp_hist"
+[14] string = "latency_exp.hist"
+[15] string = ""
+[16] string = "service.name"
+[17] string = "service_name"
+[18] string = "service.name"
+[19] string = "service_name"
+[20] string = ""
+[21] string = "service_name"
+[22] string = "latency_exp_hist"
+[23] string = "latency.exp.hist"
+[24] string = "latency.exp/hist"
+[25] string = "latency.exp_hist"
+[26] string = "latency/exp/hist"
+[27] string = "latency/exp_hist"
+[28] string = "latency_exp.hist"
+-- chplan --
+VectorJoin op=/ match=default card=one-to-one stepAligned
+  RangeWindow func=rate range=1m0s step=1m0s outerRange=5m0s ts=TimeUnix value=Value groupBy=[Attributes] start=2026-01-01T00:00:00Z end=2026-01-01T00:05:00Z
+    Filter predicate=(MetricName IN ("latency_exp_hist", "latency.exp.hist", "latency.exp/hist", "latency.exp_hist", "latency/exp/hist", "latency/exp_hist", "latency_exp.hist"))
+      Project [MetricName AS MetricName, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, toFloat64(Sum) AS Value]
+        Scan(otel_metrics_exponential_histogram)
+  RangeWindow func=rate range=1m0s step=1m0s outerRange=5m0s ts=TimeUnix value=Value groupBy=[Attributes] start=2026-01-01T00:00:00Z end=2026-01-01T00:05:00Z
+    Filter predicate=(MetricName IN ("latency_exp_hist", "latency.exp.hist", "latency.exp/hist", "latency.exp_hist", "latency/exp/hist", "latency/exp_hist", "latency_exp.hist"))
+      Project [MetricName AS MetricName, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, toFloat64(Count) AS Value]
+        Scan(otel_metrics_exponential_histogram)
+-- sql --
+SELECT ? AS `MetricName`, L.`Attributes` AS `Attributes`, L.`TimeUnix` AS `TimeUnix`, (L.`Value` / R.`Value`) AS `Value` FROM (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT ? AS `_join_MetricName`, mapSort(`Attributes`) AS `_join_Attributes`, `TimeUnix` AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value` FROM (SELECT `Attributes`, `anchor_ts`, anchor_ts AS `TimeUnix`, if(sampled_interval > 0, counter_delta * (sampled_interval + if(counter_delta > 0 AND first_val >= 0, least(duration_to_start, sampled_interval * first_val / counter_delta), duration_to_start) + duration_to_end) / sampled_interval / 60, nan) AS `Value` FROM (SELECT `Attributes`, `anchor_ts`, `window_vals`, `counter_delta`, `first_val`, toFloat64(dateDiff('nanosecond', first_ts, last_ts)) / 1e9 AS `sampled_interval`, if(toFloat64(dateDiff('nanosecond', anchor_ts - toIntervalNanosecond(60000000000), first_ts)) / 1e9 >= 1.1 * sampled_interval / (length(window_vals) - 1), sampled_interval / (length(window_vals) - 1) / 2, toFloat64(dateDiff('nanosecond', anchor_ts - toIntervalNanosecond(60000000000), first_ts)) / 1e9) AS `duration_to_start`, if(toFloat64(dateDiff('nanosecond', last_ts, anchor_ts)) / 1e9 >= 1.1 * sampled_interval / (length(window_vals) - 1), sampled_interval / (length(window_vals) - 1) / 2, toFloat64(dateDiff('nanosecond', last_ts, anchor_ts)) / 1e9) AS `duration_to_end` FROM (SELECT `Attributes`, `anchor_ts`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta`, tupleElement(window_pairs[1], 1) AS `first_ts`, tupleElement(window_pairs[length(window_pairs)], 1) AS `last_ts`, tupleElement(window_pairs[1], 2) AS `first_val` FROM (SELECT `Attributes`, `anchor_ts`, arrayReverse(arrayCompact(p -> tupleElement(p, 1), arrayReverse(window_pairs))) AS `window_pairs` FROM (SELECT `Attributes`, `anchor_ts`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `window_pairs` FROM (SELECT `Attributes`, `TimeUnix`, `Value`, arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:05:00.000000000', 9) - toIntervalNanosecond(i * 60000000000), range(greatest(0, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 60000000000, toInt64(60000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 60000000000, toInt64(60000000000)) < 0) + 1), least(6, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)), toInt64(60000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)), toInt64(60000000000)) < 0) + 1)))) AS `anchor_ts` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, toFloat64(`Sum`) AS `Value` FROM (SELECT * FROM `otel_metrics_exponential_histogram`)) WHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?))) WHERE `TimeUnix` > toDateTime64('2026-01-01 00:00:00.000000000', 9) - toIntervalNanosecond(60000000000) AND `TimeUnix` <= toDateTime64('2026-01-01 00:05:00.000000000', 9)) GROUP BY `Attributes`, `anchor_ts`)))) WHERE length(`window_vals`) >= 2) GROUP BY mapSort(`Attributes`), `TimeUnix`)) AS L INNER JOIN (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT ? AS `_join_MetricName`, mapSort(`Attributes`) AS `_join_Attributes`, `TimeUnix` AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value` FROM (SELECT `Attributes`, `anchor_ts`, anchor_ts AS `TimeUnix`, if(sampled_interval > 0, counter_delta * (sampled_interval + if(counter_delta > 0 AND first_val >= 0, least(duration_to_start, sampled_interval * first_val / counter_delta), duration_to_start) + duration_to_end) / sampled_interval / 60, nan) AS `Value` FROM (SELECT `Attributes`, `anchor_ts`, `window_vals`, `counter_delta`, `first_val`, toFloat64(dateDiff('nanosecond', first_ts, last_ts)) / 1e9 AS `sampled_interval`, if(toFloat64(dateDiff('nanosecond', anchor_ts - toIntervalNanosecond(60000000000), first_ts)) / 1e9 >= 1.1 * sampled_interval / (length(window_vals) - 1), sampled_interval / (length(window_vals) - 1) / 2, toFloat64(dateDiff('nanosecond', anchor_ts - toIntervalNanosecond(60000000000), first_ts)) / 1e9) AS `duration_to_start`, if(toFloat64(dateDiff('nanosecond', last_ts, anchor_ts)) / 1e9 >= 1.1 * sampled_interval / (length(window_vals) - 1), sampled_interval / (length(window_vals) - 1) / 2, toFloat64(dateDiff('nanosecond', last_ts, anchor_ts)) / 1e9) AS `duration_to_end` FROM (SELECT `Attributes`, `anchor_ts`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta`, tupleElement(window_pairs[1], 1) AS `first_ts`, tupleElement(window_pairs[length(window_pairs)], 1) AS `last_ts`, tupleElement(window_pairs[1], 2) AS `first_val` FROM (SELECT `Attributes`, `anchor_ts`, arrayReverse(arrayCompact(p -> tupleElement(p, 1), arrayReverse(window_pairs))) AS `window_pairs` FROM (SELECT `Attributes`, `anchor_ts`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `window_pairs` FROM (SELECT `Attributes`, `TimeUnix`, `Value`, arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:05:00.000000000', 9) - toIntervalNanosecond(i * 60000000000), range(greatest(0, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 60000000000, toInt64(60000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 60000000000, toInt64(60000000000)) < 0) + 1), least(6, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)), toInt64(60000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)), toInt64(60000000000)) < 0) + 1)))) AS `anchor_ts` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, toFloat64(`Count`) AS `Value` FROM (SELECT * FROM `otel_metrics_exponential_histogram`)) WHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?))) WHERE `TimeUnix` > toDateTime64('2026-01-01 00:00:00.000000000', 9) - toIntervalNanosecond(60000000000) AND `TimeUnix` <= toDateTime64('2026-01-01 00:05:00.000000000', 9)) GROUP BY `Attributes`, `anchor_ts`)))) WHERE length(`window_vals`) >= 2) GROUP BY mapSort(`Attributes`), `TimeUnix`)) AS R ON mapSort(L.`Attributes`) = mapSort(R.`Attributes`) AND L.`TimeUnix` = R.`TimeUnix`
+-- expected_rows --
+[
+  ["", {"service": "api"}, "2026-01-01T00:00:00Z", 0.5]
+]


### PR DESCRIPTION
## Summary

- `TablesFor` (`internal/schema/otel.go`) never yielded `ExpHistogramTable` for any pinned selector — only `histogram_quantile()`'s own six hardcoded sites ever scanned it. Every other shape over an exp-histogram metric (`rate(x_exp_hist[5m])`, `resets(...)`, `sum(...)`, a bare `{__name__="x_exp_hist"}`) silently scanned Gauge/Sum and returned an empty-but-200 result.
- `lowerVectorSelector` — the single funnel for every matrix-selector-based PromQL shape (rate/resets/changes/increase/sum/absent_over_time/info/subqueries) — now special-cases exp-histogram metrics:
  - The `_count` / `_sum` companion suffixes route to `ExpHistogramTable` via the same companion-projection mechanism classic histograms use (single-arm; no Gauge/Sum union, since `_exp_hist` is cerberus's own synthetic marker suffix with no naming-collision risk to fan across).
  - Every other shape over a pinned exp-histogram selector now fails lowering with an explicit, actionable error instead of silently matching zero rows.
  - Metadata enumeration (`/series`, `/labels`) is exempted, since it never consumes a Value column — it keeps resolving against Gauge/Sum exactly as before, a pre-existing documented gap this PR doesn't touch.
- `histogram_quantile()` / `histogram_count()` / `histogram_sum()` are unaffected: they detect the exp-histogram shape themselves before ever reaching `lowerVectorSelector`.
- The new routing logic is split into two small helpers (`expHistogramSelectorRouting`, `resolveSelectorRouting`) to keep `lowerVectorSelector`'s cyclomatic complexity within the repo's `maintidx` gate.

## Test plan

- [x] New unit test `internal/promql/exp_histogram_reject_test.go`: 9 rejected shapes (bare selector, `rate`, `resets`, `changes`, `increase`, `sum`, `sum by`, `absent_over_time`) + 3 still-working dedicated-function shapes (`histogram_quantile`, `histogram_count`, `histogram_sum`).
- [x] New TXTAR fixture `test/spec/promql/histogram_mean_latency_exp.txtar` — `rate(x_sum[1m]) / rate(x_count[1m])` over an exp-histogram metric, with `-- expected_rows --` chDB round-trip proof (mean latency = 0.5, matching the seeded Sum/Count deltas).
- [x] `test/perf/solver-decision-baseline.json` updated for the new fixture.
- [x] `go build ./...`, `go test ./internal/promql/...`, `go test -tags chdb ./test/spec/promql/... -run TestRoundTripChDB`, and `golangci-lint run ./...` all pass locally.

Closes #1704