### PR TITLE
refactor(chplan): hoist trace_id_ts envelope builder into a shared helper

### DIFF
--- a/internal/api/tempo/handler.go
+++ b/internal/api/tempo/handler.go
@@ -785,17 +785,6 @@ func (h *Handler) lowerTraceByID(traceID string) (chplan.Node, error) {
 	}, nil
 }
 
-// traceIDTsEndPadSeconds compensates the trace_id_ts MV storing
-// End as a DateTime (1-second precision) computed as `max(Timestamp)`
-// over spans whose Timestamp is DateTime64(9). The DateTime64→DateTime
-// cast floors toward second granularity, so `End` is the second-truncated
-// max; a naive `Timestamp <= End` upper bound would drop every span in the
-// trace's final fractional second. Padding the bound by exactly one second
-// makes it a strict superset of the true max Timestamp (the dropped
-// sub-second carry is < 1s), so no in-trace span can fall above the window.
-// The value is the DateTime-vs-DateTime64 granularity, not a tuning knob.
-const traceIDTsEndPadSeconds = 1
-
 // traceIDTsWindow builds the correctness-preserving Timestamp-window
 // SUPERSET predicate read from the `<spans>_trace_id_ts` lookup MV for the
 // already-normalised trace id. It AND-folds two bounds onto the spans scan
@@ -804,49 +793,32 @@ const traceIDTsEndPadSeconds = 1
 // part to apply the bloom filter:
 //
 //	Timestamp >= (SELECT min(Start) FROM <ts> WHERE TraceId = id)
-//	Timestamp <= addSeconds((SELECT max(End) FROM <ts> WHERE TraceId = id), 1)
+//	Timestamp <= addSeconds((SELECT max(End) FROM <ts> WHERE TraceId = id), chplan.TraceIDTsEndPadSeconds)
 //
 // The lower bound is inherently safe: `Start = floor(min(Timestamp))`
 // already floors DOWNWARD. The upper bound is padded (see
-// traceIDTsEndPadSeconds). Each bound is a scalar subquery over a no-GROUP
-// Aggregate, which projects exactly one column and one row — satisfying
+// chplan.TraceIDTsEndPadSeconds — bound construction is shared with
+// internal/chsql's rootLookupTraceIDTsBounds via chplan.TraceIDTsBounds,
+// see #1438). Each bound is a scalar subquery over a no-GROUP Aggregate,
+// which projects exactly one column and one row — satisfying
 // chplan.ScalarSubquery's contract. The exact `TraceId = id` Eq stays
 // ANDed in lowerTraceByID, so even a stale/empty MV row only ever
 // over-includes by the window, never under-includes by TraceId.
 func (h *Handler) traceIDTsWindow(id string) chplan.Expr {
-	scalar := func(agg, col string) chplan.Expr {
-		return &chplan.ScalarSubquery{Input: &chplan.Aggregate{
-			Input: &chplan.Filter{
-				Input: &chplan.Scan{Table: h.Schema.TraceIDTsTable},
-				Predicate: &chplan.Binary{
-					Op:    chplan.OpEq,
-					Left:  &chplan.ColumnRef{Name: h.Schema.TraceIDColumn},
-					Right: &chplan.LitString{V: id},
-				},
-			},
-			AggFuncs: []chplan.AggFunc{{
-				Name:  agg,
-				Args:  []chplan.Expr{&chplan.ColumnRef{Name: col}},
-				Alias: col,
-			}},
-		}}
+	cohortPred := func() chplan.Expr {
+		return &chplan.Binary{
+			Op:    chplan.OpEq,
+			Left:  &chplan.ColumnRef{Name: h.Schema.TraceIDColumn},
+			Right: &chplan.LitString{V: id},
+		}
 	}
-	lower := &chplan.Binary{
-		Op:    chplan.OpGe,
-		Left:  &chplan.ColumnRef{Name: h.Schema.TimestampColumn},
-		Right: scalar("min", h.Schema.TraceIDTsStartColumn),
-	}
-	upper := &chplan.Binary{
-		Op:   chplan.OpLe,
-		Left: &chplan.ColumnRef{Name: h.Schema.TimestampColumn},
-		Right: &chplan.FuncCall{
-			Name: "addSeconds",
-			Args: []chplan.Expr{
-				scalar("max", h.Schema.TraceIDTsEndColumn),
-				&chplan.LitInt{V: traceIDTsEndPadSeconds},
-			},
-		},
-	}
+	lower, upper := chplan.TraceIDTsBounds(
+		h.Schema.TraceIDTsTable,
+		h.Schema.TraceIDTsStartColumn,
+		h.Schema.TraceIDTsEndColumn,
+		h.Schema.TimestampColumn,
+		cohortPred,
+	)
 	return &chplan.Binary{Op: chplan.OpAnd, Left: lower, Right: upper}
 }
 

--- a/internal/chplan/trace_id_ts.go
+++ b/internal/chplan/trace_id_ts.go
@@ -1,0 +1,68 @@
+package chplan
+
+// TraceIDTsEndPadSeconds compensates the trace_id_ts lookup MV storing End
+// as a DateTime (1-second precision) computed as `max(Timestamp)` over
+// spans whose Timestamp is DateTime64(9). The DateTime64->DateTime cast
+// floors toward second granularity, so End is the second-truncated max; a
+// naive `Timestamp <= End` upper bound would drop every span in the
+// trace's final fractional second. Padding the bound by exactly one
+// second makes it a strict superset of the true max Timestamp (the
+// dropped sub-second carry is < 1s), so no in-cohort span can fall above
+// the window. The value is the DateTime-vs-DateTime64 granularity, not a
+// tuning knob.
+const TraceIDTsEndPadSeconds = 1
+
+// TraceIDTsBounds builds the correctness-preserving Timestamp-window
+// SUPERSET bounds (lo, hi) read from a `trace_id_ts` lookup MV, scoped to
+// cohortPred (the predicate selecting the trace id(s) of interest — a
+// single-trace `TraceId = id` Eq, or a multi-trace `TraceId IN (seed)`
+// InSubquery; callers own that choice and its own correctness). cohortPred
+// is a factory, called once per bound, so lo and hi each embed their own
+// Expr instance rather than aliasing one node from two places in the plan
+// tree (see CloneNode's no-shared-mutable-state contract). It AND-folds
+// neither bound itself — the caller decides whether the two returned
+// Exprs are conjoined together or with other predicates:
+//
+//	timestampColumn >= (SELECT min(startColumn) FROM table WHERE cohortPred())
+//	timestampColumn <= addSeconds((SELECT max(endColumn) FROM table WHERE cohortPred()), TraceIDTsEndPadSeconds)
+//
+// The lower bound is inherently safe: startColumn is already floored
+// downward at MV-population time. The upper bound needs the pad (see
+// TraceIDTsEndPadSeconds). Each bound is a scalar subquery over a
+// no-GROUP Aggregate, which projects exactly one column and one row —
+// satisfying ScalarSubquery's contract.
+//
+// Hoisted from two independent copies (internal/chsql's
+// rootLookupTraceIDTsBounds and internal/api/tempo's traceIDTsWindow,
+// see #1438) that differed only in cohort predicate — the correctness-
+// bearing pad constant had drifted into two places that had to be kept
+// in lock-step by hand.
+func TraceIDTsBounds(table, startColumn, endColumn, timestampColumn string, cohortPred func() Expr) (lo, hi Expr) {
+	scalar := func(agg, column string) Expr {
+		return &ScalarSubquery{Input: &Aggregate{
+			Input: &Filter{
+				Input:     &Scan{Table: table},
+				Predicate: cohortPred(),
+			},
+			AggFuncs: []AggFunc{{
+				Name:  agg,
+				Args:  []Expr{&ColumnRef{Name: column}},
+				Alias: column,
+			}},
+		}}
+	}
+	lo = &Binary{
+		Op:    OpGe,
+		Left:  &ColumnRef{Name: timestampColumn},
+		Right: scalar("min", startColumn),
+	}
+	hi = &Binary{
+		Op:   OpLe,
+		Left: &ColumnRef{Name: timestampColumn},
+		Right: &FuncCall{Name: "addSeconds", Args: []Expr{
+			scalar("max", endColumn),
+			&LitInt{V: TraceIDTsEndPadSeconds},
+		}},
+	}
+	return lo, hi
+}

--- a/internal/chsql/metrics_compare.go
+++ b/internal/chsql/metrics_compare.go
@@ -56,9 +56,6 @@ import (
 const (
 	compareJoinLeftAlias  = "s"
 	compareJoinRightAlias = "r"
-	// rootLookupTraceIDTsEndPadSeconds compensates the trace_id_ts lookup's
-	// DateTime End value flooring a DateTime64(9) span timestamp.
-	rootLookupTraceIDTsEndPadSeconds = 1
 )
 
 // compareScanBound carries the (Start-range, End] Timestamp window the
@@ -360,41 +357,29 @@ func tsBoundExprs(tsCol string, startNano, endNano int64) (lo, hi chplan.Expr) {
 // configured — an envelope over an empty table or column identifier would be a
 // broken query, not a weaker bound. seed must be non-nil; the caller only
 // reaches here once it has one.
+//
+// The bound-construction itself is chplan.TraceIDTsBounds (#1438) — this
+// wrapper supplies the cohort predicate (an IN-subquery over seed, since a
+// MetricsCompare root lookup covers however many trace ids seed selects,
+// unlike the single-trace Eq the Tempo by-id handler uses).
 func rootLookupTraceIDTsBounds(m *chplan.MetricsCompare, seed chplan.Node, timestampColumn string) (lo, hi chplan.Expr) {
 	if m.RootLookupTraceIDTsTable == "" ||
 		m.RootLookupTraceIDTsStartColumn == "" || m.RootLookupTraceIDTsEndColumn == "" {
 		return nil, nil
 	}
-	scalar := func(agg, column string) chplan.Expr {
-		return &chplan.ScalarSubquery{Input: &chplan.Aggregate{
-			Input: &chplan.Filter{
-				Input: &chplan.Scan{Table: m.RootLookupTraceIDTsTable},
-				Predicate: &chplan.InSubquery{
-					Left:     &chplan.ColumnRef{Name: m.TraceIDColumn},
-					Subquery: chplan.CloneNode(seed),
-				},
-			},
-			AggFuncs: []chplan.AggFunc{{
-				Name:  agg,
-				Args:  []chplan.Expr{&chplan.ColumnRef{Name: column}},
-				Alias: column,
-			}},
-		}}
+	cohortPred := func() chplan.Expr {
+		return &chplan.InSubquery{
+			Left:     &chplan.ColumnRef{Name: m.TraceIDColumn},
+			Subquery: chplan.CloneNode(seed),
+		}
 	}
-	lo = &chplan.Binary{
-		Op:    chplan.OpGe,
-		Left:  &chplan.ColumnRef{Name: timestampColumn},
-		Right: scalar("min", m.RootLookupTraceIDTsStartColumn),
-	}
-	hi = &chplan.Binary{
-		Op:   chplan.OpLe,
-		Left: &chplan.ColumnRef{Name: timestampColumn},
-		Right: &chplan.FuncCall{Name: "addSeconds", Args: []chplan.Expr{
-			scalar("max", m.RootLookupTraceIDTsEndColumn),
-			&chplan.LitInt{V: rootLookupTraceIDTsEndPadSeconds},
-		}},
-	}
-	return lo, hi
+	return chplan.TraceIDTsBounds(
+		m.RootLookupTraceIDTsTable,
+		m.RootLookupTraceIDTsStartColumn,
+		m.RootLookupTraceIDTsEndColumn,
+		timestampColumn,
+		cohortPred,
+	)
 }
 
 // pushPredicateToSpansScanFilter walks n in place looking for the Filter


### PR DESCRIPTION
## Summary

- `internal/chsql`'s `rootLookupTraceIDTsBounds` and `internal/api/tempo`'s `traceIDTsWindow` independently built the same `(min(Start), max(End)+1s)` scalar-subquery envelope over a `trace_id_ts` lookup MV, each carrying its own copy of the correctness-bearing 1-second pad constant.
- Extracts the shared shape into `chplan.TraceIDTsBounds(table, startColumn, endColumn, timestampColumn, cohortPred)`, so the pad is explained once (`chplan.TraceIDTsEndPadSeconds`) and the two callers differ only in their cohort predicate — a single-trace `Eq` for the Tempo by-id handler, an `IN`-subquery over the `MetricsCompare` seed for the root lookup.
- `cohortPred` is a factory (`func() Expr`), called once per bound, so `lo`/`hi` never alias one predicate node from two places in the plan tree — consistent with `CloneNode`'s no-shared-mutable-state contract.
- Pure refactor, no behavior change: byte-identical goldens (default + `chdb`-tagged `test/spec` suites), `go-arch-lint check` clean, `forbid-sql-raw` clean.
- Prerequisite for #1443.

Closes #1438

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -count=1 ./...` (repo-wide, all green)
- [x] `go test -count=1 ./test/spec/...` (Layer 2a, byte-identical)
- [x] `go test -tags chdb -count=1 ./test/spec/...` (promql/logql/traceql chDB roundtrip, byte-identical)
- [x] `~/go/bin/go-arch-lint check` — OK, no warnings
- [x] `gofumpt -extra -l` on touched files — clean
- [x] `node .github/scripts/forbid-sql-raw.mjs` — clean
- [x] pre-push hooks (golangci-lint, markdownlint, commitlint, forbid-* discipline greps) — all green