### PR TITLE
fix(chclient): thread ResponseShape through CursorQuerier as defense-in-depth

### DIFF
--- a/internal/api/prom/lang.go
+++ b/internal/api/prom/lang.go
@@ -8,6 +8,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/tsouza/cerberus/internal/cerbtrace"
+	"github.com/tsouza/cerberus/internal/chclient"
 	"github.com/tsouza/cerberus/internal/chplan"
 	"github.com/tsouza/cerberus/internal/engine"
 	"github.com/tsouza/cerberus/internal/promql"
@@ -115,7 +116,16 @@ func (l *lang) Parse(ctx context.Context, query string) (chplan.Node, engine.Met
 	if err != nil {
 		return nil, engine.Meta{}, &parseStageError{stage: "lower", err: err}
 	}
-	return plan, engine.Meta{IsMetric: true}, nil
+	meta := engine.Meta{IsMetric: true}
+	// Step is non-zero only on the /api/v1/query_range path (see the lang
+	// doc), which is the only PromQL caller that reaches engine.QueryCursor —
+	// executeInstant always goes through the eager engine.Query, which never
+	// reads ResponseShape. Declaring the matrix shape here lets chclient's
+	// columnar decode confirm caller intent as defense-in-depth (#1429).
+	if l.Step > 0 {
+		meta.ResponseShape = chclient.ResponseShapeMatrix
+	}
+	return plan, meta, nil
 }
 
 // ProjectSamples wraps plan with the Sample-shape Project via

--- a/internal/api/prom/lang_test.go
+++ b/internal/api/prom/lang_test.go
@@ -9,6 +9,7 @@ import (
 
 	promparser "github.com/prometheus/prometheus/promql/parser"
 
+	"github.com/tsouza/cerberus/internal/chclient"
 	"github.com/tsouza/cerberus/internal/chplan"
 	"github.com/tsouza/cerberus/internal/engine"
 	"github.com/tsouza/cerberus/internal/schema"
@@ -53,6 +54,39 @@ func TestLang_Parse_SimpleSelector(t *testing.T) {
 	if !meta.IsMetric {
 		t.Errorf("Meta.IsMetric: got false, want true (every PromQL query is metric-shaped)")
 	}
+}
+
+// TestLang_Parse_ResponseShape — Meta.ResponseShape is chclient.ResponseShapeMatrix
+// only when Step is set (the /api/v1/query_range shape, the only PromQL path
+// that reaches engine.QueryCursor / chclient's columnar decode), and left
+// empty for the instant-query shape (Step == 0, executeInstant's Query path,
+// which never reads ResponseShape). Pins the #1429 defense-in-depth signal
+// at its source so a future edit can't silently stop declaring it.
+func TestLang_Parse_ResponseShape(t *testing.T) {
+	t.Parallel()
+
+	t.Run("range query sets the matrix shape", func(t *testing.T) {
+		l := langForTest()
+		l.Step = 15 * time.Second
+		_, meta, err := l.Parse(context.Background(), "up")
+		if err != nil {
+			t.Fatalf("Parse(`up`): unexpected err: %v", err)
+		}
+		if meta.ResponseShape != chclient.ResponseShapeMatrix {
+			t.Errorf("Meta.ResponseShape: got %q, want %q", meta.ResponseShape, chclient.ResponseShapeMatrix)
+		}
+	})
+
+	t.Run("instant query leaves the shape unset", func(t *testing.T) {
+		l := langForTest()
+		_, meta, err := l.Parse(context.Background(), "up")
+		if err != nil {
+			t.Fatalf("Parse(`up`): unexpected err: %v", err)
+		}
+		if meta.ResponseShape != "" {
+			t.Errorf("Meta.ResponseShape: got %q, want empty (instant queries never reach QueryCursor)", meta.ResponseShape)
+		}
+	})
 }
 
 // TestLang_Parse_ParseError — invalid syntax surfaces as a

--- a/internal/chclient/columnar.go
+++ b/internal/chclient/columnar.go
@@ -41,7 +41,49 @@ import (
 // Value, in that order. The columnar path engages ONLY when a result block's
 // shape matches this exactly; any other shape (the five-column Loki log-stream
 // projection, the metadata endpoints) falls back to the row path.
+//
+// This is a name/type collision test, not a proof of intent: a future
+// projection that happens to reuse these four names and types (e.g. a
+// differently-shaped log-stream query) would pass it too. See
+// ResponseShapeMatrix below for the defense-in-depth layered on top (#1429).
 var matrixColumns = [...]string{"MetricName", "Attributes", "TimeUnix", "Value"}
+
+// ResponseShapeMatrix is the engine.Meta.ResponseShape value a caller stamps
+// onto a QueryCursor ctx (via WithResponseShape) to declare "this query's SQL
+// really is the prom query_range matrix projection". bindColumns ANDs this
+// against the structural name/type test above rather than replacing it: the
+// column-shape check alone caught every collision seen so far, but it is a
+// coincidence-of-naming test, not a statement of caller intent, so a second,
+// independent signal closes the class rather than the one instance (#1429).
+// A caller that hasn't been threaded to set a ResponseShape at all (empty
+// string) is treated as "unknown, defer to the structural test" so this gate
+// can be adopted incrementally without silently disabling the columnar
+// decode for not-yet-migrated callers.
+const ResponseShapeMatrix = "prom-matrix"
+
+// responseShapeCtxKey is the context key WithResponseShape and
+// ResponseShapeFromContext round-trip on.
+type responseShapeCtxKey struct{}
+
+// WithResponseShape attaches shape (an engine.Meta.ResponseShape value, e.g.
+// ResponseShapeMatrix) to ctx so the columnar matrix decode can confirm the
+// caller actually intends a matrix query before it engages — see
+// ResponseShapeMatrix.
+func WithResponseShape(ctx context.Context, shape string) context.Context {
+	return context.WithValue(ctx, responseShapeCtxKey{}, shape)
+}
+
+// ResponseShapeFromContext returns the ResponseShape ctx carries, or "" when
+// none was attached. Exported (mirroring SampleBudgetFromContext /
+// QuerySettingsFromContext / QueryIDFromContext) so callers outside this
+// package — notably internal/engine's wiring tests — can pin that a
+// ResponseShape set upstream actually reaches the ctx a CursorQuerier
+// receives, not just that WithResponseShape and the internal read-back agree
+// with each other.
+func ResponseShapeFromContext(ctx context.Context) string {
+	shape, _ := ctx.Value(responseShapeCtxKey{}).(string)
+	return shape
+}
 
 // columnarMatrixDecoder owns the dedicated ch-go pool used for the columnar
 // matrix decode. It is built (lazily-dialled, mirroring clickhouse.Open's lazy
@@ -167,6 +209,7 @@ func (d columnarDecoder) queryCursorColumnar(c *Client, ctx context.Context, sql
 	ctx, span := startExecuteSpan(ctx, sql, c.addr)
 
 	dec := &columnarCursor{
+		responseShape:  ResponseShapeFromContext(ctx),
 		budget:         budgetFromContext(ctx),
 		byteBudget:     drainByteBudgetFromContext(ctx),
 		maxSamples:     c.maxSamples,
@@ -242,6 +285,11 @@ func (d columnarDecoder) queryCursorColumnar(c *Client, ctx context.Context, sql
 type columnarCursor struct {
 	results chproto.Results
 
+	// responseShape is the engine.Meta.ResponseShape the caller declared for
+	// this query (via WithResponseShape), or "" when not threaded. See
+	// ResponseShapeMatrix.
+	responseShape string
+
 	samples []Sample
 	idx     int
 	err     error
@@ -296,7 +344,18 @@ type timeColumn interface {
 // bindColumns type-asserts the Auto-inferred result columns into the matrix
 // shape. A mismatch (wrong count, wrong names, wrong types — e.g. the
 // five-column Loki projection) reports false so the caller falls back.
+//
+// This ANDs two independent checks (#1429): the structural name/type test
+// below, unchanged, PLUS — when the caller declared a ResponseShape — a
+// confirmation that the caller actually intends the matrix decode. Either
+// one declining is enough to fall back to the row path; a caller that
+// hasn't been threaded to set a ResponseShape (empty string) skips only the
+// second check, so this is additive, never a narrowing of what the
+// structural test alone already accepted.
 func (d *columnarCursor) bindColumns() (matrixCols, bool) {
+	if d.responseShape != "" && d.responseShape != ResponseShapeMatrix {
+		return matrixCols{}, false
+	}
 	if len(d.results) != len(matrixColumns) {
 		return matrixCols{}, false
 	}

--- a/internal/chclient/columnar_shape_test.go
+++ b/internal/chclient/columnar_shape_test.go
@@ -1,0 +1,71 @@
+package chclient
+
+import (
+	"context"
+	"testing"
+
+	chproto "github.com/ClickHouse/ch-go/proto"
+)
+
+// matrixShapedResults builds a chproto.Results that structurally matches
+// matrixColumns exactly — same names, same types, in order — without any
+// ClickHouse connection. It stands in for a real query_range matrix result
+// block AND for the historical Loki-collision scenario (#1429): a
+// differently-intentioned projection that happens to reuse the same four
+// names and types.
+func matrixShapedResults() chproto.Results {
+	return chproto.Results{
+		{Name: "MetricName", Data: &chproto.ColStr{}},
+		{Name: "Attributes", Data: &chproto.ColMap[string, string]{}},
+		{Name: "TimeUnix", Data: &chproto.ColDateTime{}},
+		{Name: "Value", Data: &chproto.ColFloat64{}},
+	}
+}
+
+// TestBindColumns_StructuralMatchAlone proves the pre-#1429 behaviour is
+// unchanged: a structurally matrix-shaped result binds when no ResponseShape
+// was declared (responseShape == ""), i.e. a caller that hasn't opted into
+// the new gate sees byte-identical behaviour to before it existed.
+func TestBindColumns_StructuralMatchAlone(t *testing.T) {
+	cur := &columnarCursor{results: matrixShapedResults()}
+	if _, ok := cur.bindColumns(); !ok {
+		t.Fatal("bindColumns declined a structurally matching, unshaped (responseShape==\"\") result — pre-#1429 behaviour regressed")
+	}
+}
+
+// TestBindColumns_ResponseShapeMatch proves the happy defense-in-depth path:
+// a structurally matching result with the correct declared ResponseShape
+// still binds.
+func TestBindColumns_ResponseShapeMatch(t *testing.T) {
+	cur := &columnarCursor{results: matrixShapedResults(), responseShape: ResponseShapeMatrix}
+	if _, ok := cur.bindColumns(); !ok {
+		t.Fatal("bindColumns declined a structurally matching result whose declared ResponseShape agrees")
+	}
+}
+
+// TestBindColumns_ResponseShapeMismatch is the #1429 regression pin: a
+// result block that is STRUCTURALLY indistinguishable from the matrix shape
+// (same four names, same four types) must still be declined when the caller
+// declared a non-matrix ResponseShape — the scenario a future projection
+// reusing those names would hit. This is the second, independent check
+// ANDed on top of the untouched structural test; either one declining is
+// enough to fall back to the row path.
+func TestBindColumns_ResponseShapeMismatch(t *testing.T) {
+	cur := &columnarCursor{results: matrixShapedResults(), responseShape: "loki-streams"}
+	if _, ok := cur.bindColumns(); ok {
+		t.Fatal("bindColumns accepted a structurally matching result despite a mismatched declared ResponseShape — #1429 defense-in-depth gate not engaging")
+	}
+}
+
+// TestResponseShapeContext_RoundTrip pins WithResponseShape /
+// ResponseShapeFromContext against drift: the value set is exactly the
+// value read back, and an untouched ctx reads back "".
+func TestResponseShapeContext_RoundTrip(t *testing.T) {
+	if got := ResponseShapeFromContext(context.Background()); got != "" {
+		t.Fatalf("ResponseShapeFromContext(bare ctx) = %q, want \"\"", got)
+	}
+	ctx := WithResponseShape(context.Background(), ResponseShapeMatrix)
+	if got := ResponseShapeFromContext(ctx); got != ResponseShapeMatrix {
+		t.Fatalf("ResponseShapeFromContext = %q, want %q", got, ResponseShapeMatrix)
+	}
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -1322,6 +1322,14 @@ func (e *Engine) dispatchRouteACursor(
 
 	execT := telemetry.ObserveStage(telemetry.StageExecute, lang.Name())
 	execCtx, queryID := e.execContext(chclient.WithProgressFor(ctx, lang.Name()), plan, lang.Name(), decision)
+	// Thread the adapter's declared response shape onto the execute ctx so
+	// chclient's columnar matrix decode can confirm (defense-in-depth, on top
+	// of its own structural name/type check) that this query really is the
+	// matrix projection before it engages — see chclient.ResponseShapeMatrix
+	// (#1429). meta.ResponseShape is "" for adapters that haven't opted in,
+	// which chclient treats as "unknown, defer to the structural check
+	// alone" — byte-unchanged behaviour for those callers.
+	execCtx = chclient.WithResponseShape(execCtx, meta.ResponseShape)
 	cursor, err := cq.QueryCursor(execCtx, sql, args...)
 	execT.Done(ctx)
 	if err != nil {

--- a/internal/engine/response_shape_wiring_test.go
+++ b/internal/engine/response_shape_wiring_test.go
@@ -1,0 +1,105 @@
+package engine_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/engine"
+	"github.com/tsouza/cerberus/internal/optimizer"
+)
+
+// errShapeCaptureSentinel is the fixed error shapeCapturingCursorClient
+// returns from QueryCursor. It never opens a real cursor — the test only
+// needs to observe the ctx dispatchRouteACursor built before the open
+// attempt, not a working Cursor.
+var errShapeCaptureSentinel = errors.New("shapeCapturingCursorClient: sentinel open error")
+
+// shapeCapturingCursorClient implements engine.Querier (required by the
+// Engine.Client field type) plus engine.CursorQuerier (the optional
+// interface dispatchRouteACursor type-asserts for). Query is never exercised
+// by these tests — only QueryCursor, which records the ctx it was handed so
+// a test can read back whatever chclient.WithResponseShape stamped onto it.
+type shapeCapturingCursorClient struct {
+	gotCtx context.Context
+}
+
+func (c *shapeCapturingCursorClient) Query(context.Context, string, ...any) ([]chclient.Sample, error) {
+	return nil, errors.New("shapeCapturingCursorClient: Query not exercised by these tests")
+}
+
+func (c *shapeCapturingCursorClient) QueryCursor(ctx context.Context, _ string, _ ...any) (chclient.Cursor, error) {
+	c.gotCtx = ctx
+	return nil, errShapeCaptureSentinel
+}
+
+// TestDispatchRouteACursor_ThreadsResponseShape is the end-to-end wiring pin
+// for #1429: it proves engine.Meta.ResponseShape returned by Lang.Parse
+// actually reaches the ctx chclient's CursorQuerier receives via
+// dispatchRouteACursor's chclient.WithResponseShape call — not merely that
+// the two endpoints (lang.Parse setting Meta.ResponseShape, and
+// columnarCursor.bindColumns reading it back) each behave correctly in
+// isolation. Uses the plain nil-Solver / nil-RouteMemo Engine so
+// QueryCursor dispatches straight through dispatchRouteACursor, the exact
+// call site #1429 threads through.
+func TestDispatchRouteACursor_ThreadsResponseShape(t *testing.T) {
+	t.Parallel()
+
+	cq := &shapeCapturingCursorClient{}
+	eng := &engine.Engine{Optimizer: optimizer.Default(), Client: cq}
+	lang := &fakeLang{
+		name: "promql",
+		parseFn: func(context.Context, string) (chplan.Node, engine.Meta, error) {
+			return &chplan.Scan{Table: "otel_metrics_gauge"},
+				engine.Meta{IsMetric: true, ResponseShape: chclient.ResponseShapeMatrix},
+				nil
+		},
+	}
+
+	_, err := eng.QueryCursor(context.Background(), lang, "up")
+	if err == nil {
+		t.Fatal("QueryCursor: expected the sentinel open error to surface, got nil")
+	}
+	if !errors.Is(err, errShapeCaptureSentinel) {
+		t.Fatalf("QueryCursor err = %v, want it to wrap errShapeCaptureSentinel", err)
+	}
+	if cq.gotCtx == nil {
+		t.Fatal("QueryCursor: cursor client's QueryCursor was never invoked")
+	}
+	if got := chclient.ResponseShapeFromContext(cq.gotCtx); got != chclient.ResponseShapeMatrix {
+		t.Errorf("ResponseShapeFromContext(execCtx) = %q, want %q (Meta.ResponseShape never reached the CursorQuerier's ctx)",
+			got, chclient.ResponseShapeMatrix)
+	}
+}
+
+// TestDispatchRouteACursor_UnsetResponseShapeStaysEmpty is the negative
+// pairing: a Lang that hasn't opted into declaring ResponseShape (the
+// zero-value Meta) must thread an EMPTY string, not a stale or default
+// value — chclient's gate treats "" as "unknown, defer to the structural
+// check alone" (#1429's incremental-adoption safety valve), so this must
+// stay observably empty for any not-yet-migrated caller.
+func TestDispatchRouteACursor_UnsetResponseShapeStaysEmpty(t *testing.T) {
+	t.Parallel()
+
+	cq := &shapeCapturingCursorClient{}
+	eng := &engine.Engine{Optimizer: optimizer.Default(), Client: cq}
+	lang := &fakeLang{
+		name: "promql",
+		parseFn: func(context.Context, string) (chplan.Node, engine.Meta, error) {
+			return &chplan.Scan{Table: "otel_metrics_gauge"}, engine.Meta{IsMetric: true}, nil
+		},
+	}
+
+	_, err := eng.QueryCursor(context.Background(), lang, "up")
+	if err == nil {
+		t.Fatal("QueryCursor: expected the sentinel open error to surface, got nil")
+	}
+	if cq.gotCtx == nil {
+		t.Fatal("QueryCursor: cursor client's QueryCursor was never invoked")
+	}
+	if got := chclient.ResponseShapeFromContext(cq.gotCtx); got != "" {
+		t.Errorf("ResponseShapeFromContext(execCtx) = %q, want \"\" for a Lang that never set Meta.ResponseShape", got)
+	}
+}


### PR DESCRIPTION
## Summary

`columnar.go`'s `bindColumns()` decided whether a result took the columnar matrix fast path purely by testing column names/types against `matrixColumns` — a name-collision test, not a shape test. #1426 fixed the one known live collision (the Loki log-stream shape reusing the same four names+types), but the underlying weakness — a future projection reusing those names would be silently misrouted into the matrix decoder — was untouched.

- Adds `chclient.ResponseShapeMatrix` + `WithResponseShape` / `ResponseShapeFromContext` (mirroring the existing `SampleBudgetFromContext` / `QuerySettingsFromContext` / `QueryIDFromContext` ctx-threading pattern).
- Threads `engine.Meta.ResponseShape` through `engine.dispatchRouteACursor` onto the `QueryCursor` ctx.
- `bindColumns()` ANDs the declared shape against the existing structural name/type test — **not a replacement**: either signal declining is enough to fall back to the row path. The structural test is left completely untouched.
- A caller that hasn't been threaded to declare a shape (empty string) defers to the structural test alone — byte-unchanged behaviour for any not-yet-migrated caller.
- `internal/api/prom`'s `lang.Parse` declares `ResponseShapeMatrix` only on the `/api/v1/query_range` path (`Step > 0`), the only PromQL caller that reaches `engine.QueryCursor` (instant queries go through the eager `engine.Query`, which never reads `ResponseShape`).

## Scope note

`internal/solver` owns a structurally separate `CursorQuerier` interface and its own `QueryCursor` call site (Route-B dispatch, `executor.go:420`), which this PR does not thread — that path already falls back safely (empty `ResponseShape` → "defer to the structural test alone"), it just doesn't get the new AND-gate's extra protection yet. Tracked in #1753.

## Test plan

- [x] New unit tests pin `bindColumns()`'s AND-gate directly (`internal/chclient/columnar_shape_test.go`): structural-match-alone (pre-#1429 behaviour unchanged), matching declared shape, mismatched declared shape (the #1429 regression pin), and the ctx round-trip.
- [x] New unit tests pin `lang.Parse` setting `ResponseShapeMatrix` only for range queries (`internal/api/prom/lang_test.go`).
- [x] New end-to-end wiring tests prove `Meta.ResponseShape` actually threads from `Lang.Parse` through `dispatchRouteACursor`'s `chclient.WithResponseShape` call into the ctx a `CursorQuerier` receives — both the positive case and the unset-stays-empty negative case (`internal/engine/response_shape_wiring_test.go`).
- [x] `go build ./...`, `go vet ./...` clean.
- [x] `go test ./internal/chclient/... ./internal/engine/... ./internal/api/prom/...` — all pass.
- [x] `go test ./test/spec/...` — byte-identical goldens (this change is additive/non-emitting, no SQL shape changed).
- [x] `go-arch-lint check` — no warnings.
- [x] `node .github/scripts/forbid-sql-raw.mjs` — clean.
- [x] `gofumpt -extra -l` on touched files — clean.
- [x] Pre-push hook (golangci-lint, markdownlint, discipline greps) — all green.

Closes #1429

🤖 Generated with [Claude Code](https://claude.com/claude-code)