### PR TITLE
feat(promql): add wireArms classifier skeleton for histogram matcher domains

### DIFF
--- a/internal/promql/histogram_wire_arms.go
+++ b/internal/promql/histogram_wire_arms.go
@@ -1,0 +1,136 @@
+package promql
+
+import (
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// WireArm names the wire-visible domain a matcher targets, as opposed to a
+// plain OTel-CH storage column/attribute. A classic histogram is stored as
+// ONE row per observation under the bare metric name, with no `le`
+// attribute at all — its Prometheus wire surface (the `<base>_bucket` /
+// `<base>_count` / `<base>_sum` triple, and the `le` ladder label the
+// `_bucket` series exposes) exists ONLY as a cerberus-side rewrite, never
+// as literal storage. A matcher on each domain needs a different
+// resolution strategy:
+//
+//   - WireArmStorage matchers resolve directly against the stored row
+//     (matcherToExpr's ordinary Attributes/column path).
+//   - WireArmWireName matchers (an `__name__` matcher) resolve against a
+//     synthesized name expression — the bare/stripped name for a pinned
+//     equality match, or a rewritten `concat(MetricName, <suffix>)` for an
+//     unpinned match — never a literal stored column.
+//   - WireArmWireBound matchers (an `le` matcher on a classic-histogram
+//     selector) exist only AFTER a bucket fan-out materializes the ladder
+//     as a synthetic Attributes entry; evaluated against the pre-fanout
+//     row they are unconditionally unsatisfiable.
+//
+// See #1755 for the investigation this classifier formalizes: the package
+// had three independent, inconsistent reimplementations of this split
+// (splitBucketMatchers, splitRegexHistogramMatchers, and the inline loop in
+// histogramQuantileMatcherPredicate) before wireArms existed, and the third
+// — histogram_quantile.go's — never classified `le` at all, which is the
+// direct root cause of #1478.
+type WireArm int
+
+const (
+	// WireArmStorage is the default arm: a matcher that resolves directly
+	// against a stored column or Attributes entry.
+	WireArmStorage WireArm = iota
+	// WireArmWireName is an `__name__` matcher — the Prometheus wire
+	// surface's synthetic suffixed name space, never a literal stored
+	// column.
+	WireArmWireName
+	// WireArmWireBound is an `le` matcher on a classic-histogram selector
+	// — the synthetic bucket-ladder label, satisfiable only after a
+	// fan-out materializes it.
+	WireArmWireBound
+)
+
+// String renders arm for diagnostics/test failure messages.
+func (arm WireArm) String() string {
+	switch arm {
+	case WireArmStorage:
+		return "storage"
+	case WireArmWireName:
+		return "wire-name"
+	case WireArmWireBound:
+		return "wire-bound"
+	default:
+		return "unknown"
+	}
+}
+
+// bucketBoundLabel is the synthetic ladder-bound label name Prometheus's
+// classic-histogram wire convention uses. Named as a constant (rather than
+// a bare "le" literal at each call site) so a future non-Prometheus wire
+// convention has exactly one place to override it.
+const bucketBoundLabel = "le"
+
+// WireArms is the per-matcher classification wireArms produces: Matchers[i]
+// was classified into Arms[i], in the ORIGINAL matcher order. Callers that
+// need per-arm slices use Storage / WireName / WireBound below rather than
+// re-deriving the classification.
+type WireArms struct {
+	Matchers []*labels.Matcher
+	Arms     []WireArm
+}
+
+// filter returns the subset of w.Matchers classified into arm, preserving
+// relative order.
+func (w WireArms) filter(arm WireArm) []*labels.Matcher {
+	out := make([]*labels.Matcher, 0, len(w.Matchers))
+	for i, m := range w.Matchers {
+		if w.Arms[i] == arm {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+// Storage returns the matchers classified WireArmStorage, preserving order.
+func (w WireArms) Storage() []*labels.Matcher { return w.filter(WireArmStorage) }
+
+// WireName returns the matchers classified WireArmWireName (the `__name__`
+// matchers), preserving order.
+func (w WireArms) WireName() []*labels.Matcher { return w.filter(WireArmWireName) }
+
+// WireBound returns the matchers classified WireArmWireBound (the `le`
+// matchers), preserving order.
+func (w WireArms) WireBound() []*labels.Matcher { return w.filter(WireArmWireBound) }
+
+// wireArms classifies each matcher in matchers into the wire domain it
+// targets (see WireArm), given the histogram-relevant configuration on s.
+//
+// This is deliberately a SKELETON, not yet wired into any consumer:
+// histogramQuantileMatcherPredicate, splitBucketMatchers, and
+// splitRegexHistogramMatchers each still carry their own inline or
+// bespoke split. Migrating them onto wireArms is tracked as a follow-up
+// (see the issue referenced from #1755) so it can land alongside — not
+// underneath — whichever PR fixes #1478/#1483/#1692 on
+// histogram_quantile.go, rather than racing it.
+//
+// s.HistogramTable == "" means the deployment has no classic-histogram
+// routing configured at all, in which case the wire-name / wire-bound
+// distinction is meaningless (there is no synthetic surface to route
+// around) and every matcher classifies WireArmStorage — mirroring the
+// existing schema gate in isClassicBucketSelector.
+func wireArms(matchers []*labels.Matcher, s schema.Metrics) WireArms {
+	arms := make([]WireArm, len(matchers))
+	if s.HistogramTable == "" {
+		return WireArms{Matchers: matchers, Arms: arms}
+	}
+	for i, m := range matchers {
+		switch m.Name {
+		case bucketBoundLabel:
+			arms[i] = WireArmWireBound
+		case model.MetricNameLabel:
+			arms[i] = WireArmWireName
+		default:
+			arms[i] = WireArmStorage
+		}
+	}
+	return WireArms{Matchers: matchers, Arms: arms}
+}

--- a/internal/promql/histogram_wire_arms_test.go
+++ b/internal/promql/histogram_wire_arms_test.go
@@ -1,0 +1,102 @@
+package promql
+
+import (
+	"testing"
+
+	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestWireArms_ClassifiesEachDomain pins the three-way split: a `__name__`
+// matcher (pinned or unpinned) classifies WireArmWireName, an `le` matcher
+// classifies WireArmWireBound, and everything else classifies
+// WireArmStorage — in original order.
+func TestWireArms_ClassifiesEachDomain(t *testing.T) {
+	t.Parallel()
+	s := schema.DefaultOTelMetrics()
+
+	nameEq := mustMatcher(t, labels.MatchEqual, "__name__", "demo_api_request_duration_seconds_bucket")
+	nameRe := mustMatcher(t, labels.MatchRegexp, "__name__", "demo_api.*")
+	le := mustMatcher(t, labels.MatchEqual, "le", "0.5")
+	job := mustMatcher(t, labels.MatchEqual, "job", "api")
+
+	got := wireArms([]*labels.Matcher{nameEq, le, job, nameRe}, s)
+
+	want := []WireArm{WireArmWireName, WireArmWireBound, WireArmStorage, WireArmWireName}
+	if len(got.Arms) != len(want) {
+		t.Fatalf("Arms len = %d, want %d", len(got.Arms), len(want))
+	}
+	for i, w := range want {
+		if got.Arms[i] != w {
+			t.Errorf("Arms[%d] (matcher %s) = %s, want %s", i, got.Matchers[i], got.Arms[i], w)
+		}
+	}
+
+	if diff := len(got.WireName()); diff != 2 {
+		t.Errorf("WireName() len = %d, want 2", diff)
+	}
+	if diff := len(got.WireBound()); diff != 1 {
+		t.Errorf("WireBound() len = %d, want 1", diff)
+	}
+	if diff := len(got.Storage()); diff != 1 {
+		t.Errorf("Storage() len = %d, want 1", diff)
+	}
+	if got.Storage()[0] != job {
+		t.Errorf("Storage()[0] = %v, want the job matcher", got.Storage()[0])
+	}
+}
+
+// TestWireArms_NoHistogramTableConfigured is the schema-gated fallback: a
+// deployment with no classic-histogram routing (s.HistogramTable == "") has
+// no synthetic wire surface to route around at all, so wireArms must not
+// pull `le` or `__name__` out into a wire arm — mirroring the same gate
+// isClassicBucketSelector already uses.
+func TestWireArms_NoHistogramTableConfigured(t *testing.T) {
+	t.Parallel()
+	s := schema.Metrics{} // zero value: HistogramTable == ""
+
+	le := mustMatcher(t, labels.MatchEqual, "le", "0.5")
+	name := mustMatcher(t, labels.MatchEqual, "__name__", "up")
+
+	got := wireArms([]*labels.Matcher{le, name}, s)
+
+	for i, arm := range got.Arms {
+		if arm != WireArmStorage {
+			t.Errorf("Arms[%d] = %s, want %s (HistogramTable unconfigured)", i, arm, WireArmStorage)
+		}
+	}
+}
+
+// TestWireArms_EmptyInput is the degenerate no-matchers case: wireArms must
+// not panic and must return an empty-but-valid WireArms.
+func TestWireArms_EmptyInput(t *testing.T) {
+	t.Parallel()
+	s := schema.DefaultOTelMetrics()
+
+	got := wireArms(nil, s)
+	if len(got.Matchers) != 0 || len(got.Arms) != 0 {
+		t.Fatalf("wireArms(nil, s) = %+v, want empty", got)
+	}
+	if len(got.Storage()) != 0 || len(got.WireName()) != 0 || len(got.WireBound()) != 0 {
+		t.Fatalf("filtered slices on empty WireArms must all be empty")
+	}
+}
+
+// TestWireArm_String pins the diagnostic String() rendering used in test
+// failure messages above, so a future arm addition can't silently regress
+// to "unknown" without a test noticing.
+func TestWireArm_String(t *testing.T) {
+	t.Parallel()
+	cases := map[WireArm]string{
+		WireArmStorage:   "storage",
+		WireArmWireName:  "wire-name",
+		WireArmWireBound: "wire-bound",
+		WireArm(99):      "unknown",
+	}
+	for arm, want := range cases {
+		if got := arm.String(); got != want {
+			t.Errorf("WireArm(%d).String() = %q, want %q", arm, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- `internal/promql` has three independent, inconsistent reimplementations of "classify a matcher list by which Prometheus-wire-visible domain it targets": `splitBucketMatchers`, `splitRegexHistogramMatchers`, and the inline loop inside `histogramQuantileMatcherPredicate`. The third never classifies `le` matchers at all — the direct root cause of #1478. Full writeup in #1755.
- Adds `wireArms(matchers, s)` + `WireArm`/`WireArms` types as a standalone, unit-tested classifier (`internal/promql/histogram_wire_arms.go`) with three domains: `WireArmStorage`, `WireArmWireName` (`__name__`), `WireArmWireBound` (`le`).
- This is deliberately a **skeleton, not a migration**: `internal/promql/histogram_quantile.go` is intentionally left untouched — it's owned by a concurrent PR fixing #1478/#1483/#1692, and wiring `wireArms` in underneath that work would race it. Consumer migration (all three call sites onto `wireArms`) is tracked as its own follow-up: #1756.

## Scope note

Out of scope for this PR (tracked separately, not deferral prose):
- #1755 — the full domain-conflation analysis (already filed, this PR is the first deliverable toward it).
- #1756 — migrating `splitBucketMatchers` / `splitRegexHistogramMatchers` / `histogramQuantileMatcherPredicate` onto `wireArms`, held until #1478/#1483/#1692 land.

## Test plan

- [x] `go build ./internal/promql/...`
- [x] `go vet ./internal/promql/...`
- [x] `go test ./internal/promql/... -run TestWireArm -v` — 4/4 new tests pass (`TestWireArms_ClassifiesEachDomain`, `TestWireArms_NoHistogramTableConfigured`, `TestWireArms_EmptyInput`, `TestWireArm_String`)
- [x] `golangci-lint run ./internal/promql/...` — 0 issues
- [x] `internal/promql/histogram_quantile.go` confirmed untouched (`git status --short internal/promql/`)
- [x] lefthook pre-push (golangci-lint, markdownlint, commitlint, discipline greps) — all green