### PR TITLE
refactor(qlcommon): lift instant-lookback constant to one owner

### DIFF
--- a/internal/api/loki/handler.go
+++ b/internal/api/loki/handler.go
@@ -21,6 +21,7 @@ import (
 	"github.com/tsouza/cerberus/internal/engine"
 	"github.com/tsouza/cerberus/internal/logql"
 	"github.com/tsouza/cerberus/internal/optimizer"
+	"github.com/tsouza/cerberus/internal/qlcommon"
 	"github.com/tsouza/cerberus/internal/schema"
 	"github.com/tsouza/cerberus/internal/telemetry"
 )
@@ -276,12 +277,12 @@ func (h *Handler) handleQuery(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 
 	// Instant /query: collapse the window onto a single point. Per
-	// upstream Loki contract the evaluation lookback is the previous
-	// 5 minutes (the same instant-lookback PromQL uses). Threading
-	// [ts - 5m, ts] keeps the Scan filtered to that envelope so the
-	// SQL doesn't return every matching log in the table.
-	const instantLookback = 5 * time.Minute
-	res, err := h.Engine.Query(ctx, h.langForRequest(ts.Add(-instantLookback), ts), q)
+	// upstream Loki contract the evaluation lookback is
+	// [qlcommon.InstantLookback] (the same instant-lookback PromQL
+	// uses). Threading [ts - InstantLookback, ts] keeps the Scan
+	// filtered to that envelope so the SQL doesn't return every
+	// matching log in the table.
+	res, err := h.Engine.Query(ctx, h.langForRequest(ts.Add(-qlcommon.InstantLookback), ts), q)
 	if err != nil {
 		h.respondError(w, classifyEngineErr(err))
 		return

--- a/internal/promql/modifiers.go
+++ b/internal/promql/modifiers.go
@@ -7,6 +7,7 @@ import (
 	"github.com/prometheus/prometheus/promql/parser"
 
 	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/qlcommon"
 )
 
 // evalAnchor describes the time-anchor that a VectorSelector's `@` and
@@ -128,12 +129,10 @@ func (c lowerCtx) rangeMode() bool {
 	return c.step > 0 && !c.start.IsZero() && !c.end.IsZero()
 }
 
-// instantLookback is the default Prometheus staleness window applied
-// when an instant-vector selector picks the latest sample per series.
-// Prom defaults to 5 minutes; cerberus matches the upstream constant
-// rather than reading a per-deployment override so the LWR predicate
-// behaves predictably across environments.
-const instantLookback = 5 * time.Minute
+// instantLookback aliases the single shared owner of the Prometheus
+// staleness window, [qlcommon.InstantLookback]. See its doc comment
+// for the full rationale and the list of consumers (#1470).
+const instantLookback = qlcommon.InstantLookback
 
 func anchorFromSelector(vs *parser.VectorSelector, ctx lowerCtx) (evalAnchor, error) {
 	a := evalAnchor{Offset: vs.OriginalOffset}

--- a/internal/qlcommon/lookback.go
+++ b/internal/qlcommon/lookback.go
@@ -1,0 +1,18 @@
+package qlcommon
+
+import "time"
+
+// InstantLookback is the default Prometheus staleness window: how far
+// back an instant-vector selector looks for the latest sample per
+// series. Prom defaults to 5 minutes; cerberus matches the upstream
+// constant rather than reading a per-deployment override, so the LWR
+// predicate behaves predictably across environments.
+//
+// One owner, three consumers: PromQL's own instant-selector lowering
+// (internal/promql/modifiers.go), PromQL's subquery staleness lookback
+// (internal/promql/subquery.go, which aliases this value rather than
+// redeclaring it), and Loki's instant-query handler
+// (internal/api/loki/handler.go), which windows its evaluation to
+// `[ts - InstantLookback, ts]` per the same upstream contract. See
+// #1470.
+const InstantLookback = 5 * time.Minute


### PR DESCRIPTION
## Summary
- The 5-minute PromQL/Loki staleness lookback window had three sites: `internal/promql/modifiers.go`'s `instantLookback`, its `subqueryStalenessLookback` alias, and an independently-declared copy in `internal/api/loki/handler.go`'s instant-query handler (line 283 — the maintainer comment on #1470 corrected an earlier `:271` citation, and this PR confirms 283 is the real line).
- Moves the canonical constant to the new `internal/qlcommon/lookback.go` as `qlcommon.InstantLookback`, a package already declared as a `commonComponent` in `.go-arch-lint.yml` (importable from both `promql` and `api-loki`, unlike a direct `promql` import which `api-loki`'s `mayDependOn` list excludes).
- Per Decision 12 on #1470: dedupe only, no configurability knob — a knob would make emitted SQL deployment-dependent and weaken the Layer-2a "one input ⇒ one SQL" contract.

## Verification
- `5m == 5m`, so the change is a pure ownership move — no behavior change.
- Ran `GOLDEN_UPDATE=1 go test -count=1 ./internal/promql/... ./internal/logql/... ./internal/traceql/...` (the Layer 2a TXTAR golden driver): **zero diff** in `test/spec/**`.
- `go-arch-lint check`: no warnings.
- `go build`, `go test ./internal/api/loki/...`: pass.

## Test plan
- [x] Golden fixtures byte-identical (verified via `GOLDEN_UPDATE=1`)
- [x] `go-arch-lint check` clean
- [x] `internal/api/loki` package tests pass
- [x] CI (`check`, `lint`, `forbid-skip`, `forbid-deferral`, etc.)

Closes #1470