### PR TITLE
refactor(promql): consolidate wire-arm classification into a WireArms resolver

### DIFF
--- a/internal/promql/histogram_bucket.go
+++ b/internal/promql/histogram_bucket.go
@@ -3,7 +3,6 @@ package promql
 import (
 	"strings"
 
-	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/tsouza/cerberus/internal/chplan"
@@ -55,14 +54,28 @@ func isClassicBucketSelector(metricName string, s schema.Metrics) (bare string, 
 //
 // Copy-on-write semantics mirror stripBucketSuffix / rewriteMetricName:
 // the input slice + entries are never mutated.
+//
+// Classification is delegated to wireArms (#1756): WireArmWireBound picks
+// out the `le` split, and WireArmWireNamePinned is the one arm this
+// caller ever expects a `__name__` matcher to land in — the caller
+// (resolveSelectorRouting) only reaches splitBucketMatchers after
+// isClassicBucketSelector has already confirmed the selector's name is a
+// pinned, `_bucket`-suffixed literal. An unpinned `__name__` matcher
+// classifies WireArmWireNameUnpinned and — matching the pre-migration
+// behaviour, which had no branch for it either — passes through into
+// scanMatchers unchanged alongside WireArmStorage.
 func splitBucketMatchers(matchers []*labels.Matcher, bareName string) (scanMatchers, leMatchers []*labels.Matcher) {
 	scanMatchers = make([]*labels.Matcher, 0, len(matchers))
-	for _, m := range matchers {
-		if m.Name == "le" {
+	w := wireArms(matchers)
+	for i, m := range matchers {
+		switch w.Arms[i] {
+		case WireArmWireBound:
 			leMatchers = append(leMatchers, m)
-			continue
-		}
-		if m.Name == model.MetricNameLabel && m.Type == labels.MatchEqual && m.Value != bareName {
+		case WireArmWireNamePinned:
+			if m.Value == bareName {
+				scanMatchers = append(scanMatchers, m)
+				continue
+			}
 			copied, err := labels.NewMatcher(m.Type, m.Name, bareName)
 			if err != nil {
 				// labels.NewMatcher only fails on regex compile for the
@@ -73,9 +86,9 @@ func splitBucketMatchers(matchers []*labels.Matcher, bareName string) (scanMatch
 				continue
 			}
 			scanMatchers = append(scanMatchers, copied)
-			continue
+		default: // WireArmStorage, WireArmWireNameUnpinned
+			scanMatchers = append(scanMatchers, m)
 		}
-		scanMatchers = append(scanMatchers, m)
 	}
 	return scanMatchers, leMatchers
 }

--- a/internal/promql/histogram_quantile.go
+++ b/internal/promql/histogram_quantile.go
@@ -98,28 +98,36 @@ func stripBucketSuffix(matchers []*labels.Matcher) []*labels.Matcher {
 // Matcher order is preserved so an all-pinned, `le`-free selector folds
 // to exactly the predicate `buildPredicate(stripBucketSuffix(...))`
 // produced before the unpinned arm and the `le` split existed.
+//
+// Classification is delegated to wireArms (#1756): WireArmWireBound picks
+// out the `le` split, WireArmWireNameUnpinned picks out the synthetic-name
+// arm, and WireArmWireNamePinned's ResolveName call reproduces the strict
+// bare-name rejection below — DecisionUnsatisfiable short-circuits exactly
+// like the pre-migration inline check did.
 func histogramQuantileMatcherPredicate(matchers []*labels.Matcher, s schema.Metrics) (chplan.Expr, []*labels.Matcher) {
 	bucketWireName := func() chplan.Expr { return syntheticMetricNameExpr(s, bucketSuffix) }
 	stripped := stripBucketSuffix(matchers)
+	w := wireArms(matchers)
 	var out chplan.Expr
 	var leMatchers []*labels.Matcher
 	for i, m := range matchers {
-		if m.Name == "le" {
+		switch w.Arms[i] {
+		case WireArmWireBound:
 			leMatchers = append(leMatchers, m)
-			continue
-		}
-		if m.Name == model.MetricNameLabel && m.Type != labels.MatchEqual {
+		case WireArmWireNameUnpinned:
 			out = andExpr(out, metricNamePredicateOn(m, s, bucketWireName))
-			continue
+		case WireArmWireNamePinned:
+			if decision, _ := w.ResolveName(i, bucketSuffix); decision == DecisionUnsatisfiable {
+				// Strict bare-name rejection (#1483, MAINTAINER DECISION 1):
+				// short-circuit the whole predicate to unsatisfiable rather
+				// than let a bare-name pin resolve against the OTel-CH
+				// storage row.
+				return &chplan.LitBool{V: false}, nil
+			}
+			out = andExpr(out, matcherToExpr(stripped[i], s))
+		default: // WireArmStorage
+			out = andExpr(out, matcherToExpr(stripped[i], s))
 		}
-		if m.Name == model.MetricNameLabel && m.Type == labels.MatchEqual && !strings.HasSuffix(m.Value, bucketSuffix) {
-			// Strict bare-name rejection (#1483, MAINTAINER DECISION 1):
-			// short-circuit the whole predicate to unsatisfiable rather
-			// than let a bare-name pin resolve against the OTel-CH
-			// storage row.
-			return &chplan.LitBool{V: false}, nil
-		}
-		out = andExpr(out, matcherToExpr(stripped[i], s))
 	}
 	return out, leMatchers
 }

--- a/internal/promql/histogram_quantile_wire_arms_prewhere_test.go
+++ b/internal/promql/histogram_quantile_wire_arms_prewhere_test.go
@@ -1,0 +1,163 @@
+package promql
+
+import (
+	"testing"
+
+	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// containsFuncCall reports whether e's tree contains a *chplan.FuncCall
+// anywhere. internal/chsql/prewhere.go's isCheapPredicate treats FuncCall
+// (and a handful of other node kinds not reachable from a matcher
+// predicate) as NOT cheap, so any FuncCall in a predicate's tree keeps it
+// out of PREWHERE and off ClickHouse's granule-pruning path.
+func containsFuncCall(e chplan.Expr) bool {
+	switch v := e.(type) {
+	case *chplan.FuncCall:
+		return true
+	case *chplan.Binary:
+		return containsFuncCall(v.Left) || containsFuncCall(v.Right)
+	case *chplan.InList:
+		if containsFuncCall(v.Left) {
+			return true
+		}
+		for _, item := range v.List {
+			if containsFuncCall(item) {
+				return true
+			}
+		}
+		return false
+	default:
+		return false
+	}
+}
+
+// TestHistogramQuantileMatcherPredicate_PinnedNameStaysBareColumn pins the
+// #1756 PERFORMANCE INVARIANT: a PINNED (`=`) wire-name matcher must
+// resolve, at plan time, to a bare-column MetricName comparison — never a
+// *chplan.FuncCall (e.g. concat(...)) — because
+// internal/chsql/prewhere.go's isCheapPredicate treats *chplan.FuncCall as
+// not-cheap and keeps it out of PREWHERE. A regression here silently
+// converts a granule-pruned point lookup into a full table scan.
+//
+// The unpinned/regex case is asserted too (wantFuncCall: true) so the
+// FuncCall-freedom check above is not vacuous: WireArmWireNameUnpinned
+// legitimately DOES need the synthesized concat(MetricName, suffix)
+// expression, since no stored column holds the Prometheus wire name for
+// that case.
+func TestHistogramQuantileMatcherPredicate_PinnedNameStaysBareColumn(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+
+	cases := []struct {
+		name          string
+		matcherType   labels.MatchType
+		matcherValue  string
+		wantFuncCall  bool
+		wantColumnRef bool
+	}{
+		{
+			name:          "pinned_equal_correct_suffix_stays_bare_column",
+			matcherType:   labels.MatchEqual,
+			matcherValue:  "demo_api_request_duration_seconds_bucket",
+			wantFuncCall:  false,
+			wantColumnRef: true,
+		},
+		{
+			name:         "unpinned_regexp_needs_synthetic_concat",
+			matcherType:  labels.MatchRegexp,
+			matcherValue: "demo_api_request_duration_seconds_.+",
+			wantFuncCall: true,
+		},
+		{
+			name:         "unpinned_not_equal_needs_synthetic_concat",
+			matcherType:  labels.MatchNotEqual,
+			matcherValue: "demo_api_request_duration_seconds_bucket",
+			wantFuncCall: true,
+		},
+		{
+			name:         "unpinned_not_regexp_needs_synthetic_concat",
+			matcherType:  labels.MatchNotRegexp,
+			matcherValue: "demo_api_request_duration_seconds_.+",
+			wantFuncCall: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			m, err := labels.NewMatcher(tc.matcherType, "__name__", tc.matcherValue)
+			if err != nil {
+				t.Fatalf("NewMatcher: %v", err)
+			}
+			pred, leMatchers := histogramQuantileMatcherPredicate([]*labels.Matcher{m}, s)
+			if len(leMatchers) != 0 {
+				t.Fatalf("leMatchers = %v, want none — this matcher targets __name__, not le", leMatchers)
+			}
+			if got := containsFuncCall(pred); got != tc.wantFuncCall {
+				t.Fatalf("containsFuncCall(pred) = %v, want %v — predicate: %#v", got, tc.wantFuncCall, pred)
+			}
+			if !tc.wantColumnRef {
+				return
+			}
+			// A pinned `__name__=` matcher fans out across OTel's
+			// dotted-vs-underscored candidate spellings (see
+			// metricNamePredicateOn / lower.go), so the bare-column shape
+			// is either a plain equality (single-candidate value, e.g.
+			// values with no rewritable separator) or an InList over that
+			// same column — both are the "bare-column MetricName =/IN"
+			// shape internal/chsql/prewhere.go's isCheapPredicate accepts,
+			// as opposed to a *chplan.FuncCall-rooted comparison.
+			var col *chplan.ColumnRef
+			switch v := pred.(type) {
+			case *chplan.Binary:
+				if v.Op != chplan.OpEq {
+					t.Fatalf("pred = %#v, want Op: OpEq", pred)
+				}
+				col, _ = v.Left.(*chplan.ColumnRef)
+			case *chplan.InList:
+				col, _ = v.Left.(*chplan.ColumnRef)
+			default:
+				t.Fatalf("pred = %#v, want *chplan.Binary{Op: OpEq, ...} or *chplan.InList — the "+
+					"bare-column/IN shape internal/chsql/prewhere.go treats as cheap and PREWHERE-eligible", pred)
+			}
+			if col == nil || col.Name != s.MetricNameColumn {
+				t.Fatalf("pred's left-hand column = %#v, want *chplan.ColumnRef{Name: %q}", col, s.MetricNameColumn)
+			}
+		})
+	}
+}
+
+// TestSplitBucketMatchers_PinnedNameStaysBareColumn pins the same
+// performance invariant for splitBucketMatchers's rewritten scanMatchers:
+// a pinned `__name__=<bareName>_bucket`-style match rewrites to a plain
+// labels.MatchEqual against the bare storage name — matcherToExpr then
+// resolves it to a bare-column comparison — never a matcher that forces
+// synthetic-name resolution.
+func TestSplitBucketMatchers_PinnedNameStaysBareColumn(t *testing.T) {
+	t.Parallel()
+
+	const bareName = "demo_api_request_duration_seconds"
+
+	m, err := labels.NewMatcher(labels.MatchEqual, "__name__", bareName+bucketSuffix)
+	if err != nil {
+		t.Fatalf("NewMatcher: %v", err)
+	}
+	scanMatchers, leMatchers := splitBucketMatchers([]*labels.Matcher{m}, bareName)
+	if len(leMatchers) != 0 {
+		t.Fatalf("leMatchers = %v, want none", leMatchers)
+	}
+	if len(scanMatchers) != 1 {
+		t.Fatalf("scanMatchers = %v, want exactly one rewritten matcher", scanMatchers)
+	}
+	got := scanMatchers[0]
+	if got.Type != labels.MatchEqual || got.Name != "__name__" || got.Value != bareName {
+		t.Fatalf("scanMatchers[0] = %+v, want {Type: MatchEqual, Name: __name__, Value: %q} — "+
+			"a pinned wire name must rewrite to the bare storage name so matcherToExpr keeps it a "+
+			"bare-column comparison", got, bareName)
+	}
+}

--- a/internal/promql/histogram_wire_arms.go
+++ b/internal/promql/histogram_wire_arms.go
@@ -1,10 +1,10 @@
 package promql
 
 import (
+	"strings"
+
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
-
-	"github.com/tsouza/cerberus/internal/schema"
 )
 
 // WireArm names the wire-visible domain a matcher targets, as opposed to a
@@ -18,10 +18,20 @@ import (
 //
 //   - WireArmStorage matchers resolve directly against the stored row
 //     (matcherToExpr's ordinary Attributes/column path).
-//   - WireArmWireName matchers (an `__name__` matcher) resolve against a
-//     synthesized name expression — the bare/stripped name for a pinned
-//     equality match, or a rewritten `concat(MetricName, <suffix>)` for an
-//     unpinned match — never a literal stored column.
+//   - WireArmWireNamePinned is an `__name__=` matcher (pinned equality).
+//     A pin either rewrites to the bare/stripped storage name (when its
+//     value carries the caller's wire suffix) or is unconditionally
+//     unsatisfiable (when it doesn't) — see ResolveName. It never
+//     resolves through a synthesized name expression: pin-ness is
+//     exactly what lets the predicate stay a bare-column comparison
+//     ClickHouse can PREWHERE-promote and granule-prune on (see
+//     internal/chsql/prewhere.go's isCheapPredicate, which treats
+//     *chplan.FuncCall as not-cheap).
+//   - WireArmWireNameUnpinned is an `__name__` matcher using `=~` /
+//     `!=` / `!~`. No stored column holds the Prometheus wire name, so
+//     it only resolves against a synthesized `concat(MetricName,
+//     <suffix>)` expression — ResolveName always reports
+//     DecisionWireSynthetic for it.
 //   - WireArmWireBound matchers (an `le` matcher on a classic-histogram
 //     selector) exist only AFTER a bucket fan-out materializes the ladder
 //     as a synthetic Attributes entry; evaluated against the pre-fanout
@@ -30,19 +40,23 @@ import (
 // See #1755 for the investigation this classifier formalizes: the package
 // had three independent, inconsistent reimplementations of this split
 // (splitBucketMatchers, splitRegexHistogramMatchers, and the inline loop in
-// histogramQuantileMatcherPredicate) before wireArms existed, and the third
-// — histogram_quantile.go's — never classified `le` at all, which is the
-// direct root cause of #1478.
+// histogramQuantileMatcherPredicate) before wireArms existed, and the
+// original wireArms skeleton itself carried the same #1478-class bug —
+// its classification switch never inspected m.Type, so it could not tell
+// a pinned `=` matcher from an unpinned `=~`/`!=`/`!~` one apart, the
+// exact distinction the whole family turns on. #1756 migrates all three
+// call sites onto the m.Type-aware classification below.
 type WireArm int
 
 const (
 	// WireArmStorage is the default arm: a matcher that resolves directly
 	// against a stored column or Attributes entry.
 	WireArmStorage WireArm = iota
-	// WireArmWireName is an `__name__` matcher — the Prometheus wire
-	// surface's synthetic suffixed name space, never a literal stored
-	// column.
-	WireArmWireName
+	// WireArmWireNamePinned is a pinned (`=`) `__name__` matcher.
+	WireArmWireNamePinned
+	// WireArmWireNameUnpinned is an unpinned (`=~` / `!=` / `!~`)
+	// `__name__` matcher.
+	WireArmWireNameUnpinned
 	// WireArmWireBound is an `le` matcher on a classic-histogram selector
 	// — the synthetic bucket-ladder label, satisfiable only after a
 	// fan-out materializes it.
@@ -54,8 +68,10 @@ func (arm WireArm) String() string {
 	switch arm {
 	case WireArmStorage:
 		return "storage"
-	case WireArmWireName:
-		return "wire-name"
+	case WireArmWireNamePinned:
+		return "wire-name-pinned"
+	case WireArmWireNameUnpinned:
+		return "wire-name-unpinned"
 	case WireArmWireBound:
 		return "wire-bound"
 	default:
@@ -71,20 +87,24 @@ const bucketBoundLabel = "le"
 
 // WireArms is the per-matcher classification wireArms produces: Matchers[i]
 // was classified into Arms[i], in the ORIGINAL matcher order. Callers that
-// need per-arm slices use Storage / WireName / WireBound below rather than
-// re-deriving the classification.
+// need per-arm slices use Storage / WireName / WireNamePinned /
+// WireNameUnpinned / WireBound below rather than re-deriving the
+// classification.
 type WireArms struct {
 	Matchers []*labels.Matcher
 	Arms     []WireArm
 }
 
-// filter returns the subset of w.Matchers classified into arm, preserving
-// relative order.
-func (w WireArms) filter(arm WireArm) []*labels.Matcher {
+// filter returns the subset of w.Matchers classified into any of arms,
+// preserving relative order.
+func (w WireArms) filter(arms ...WireArm) []*labels.Matcher {
 	out := make([]*labels.Matcher, 0, len(w.Matchers))
 	for i, m := range w.Matchers {
-		if w.Arms[i] == arm {
-			out = append(out, m)
+		for _, arm := range arms {
+			if w.Arms[i] == arm {
+				out = append(out, m)
+				break
+			}
 		}
 	}
 	return out
@@ -93,41 +113,101 @@ func (w WireArms) filter(arm WireArm) []*labels.Matcher {
 // Storage returns the matchers classified WireArmStorage, preserving order.
 func (w WireArms) Storage() []*labels.Matcher { return w.filter(WireArmStorage) }
 
-// WireName returns the matchers classified WireArmWireName (the `__name__`
-// matchers), preserving order.
-func (w WireArms) WireName() []*labels.Matcher { return w.filter(WireArmWireName) }
+// WireName returns the matchers classified WireArmWireNamePinned or
+// WireArmWireNameUnpinned (any `__name__` matcher regardless of pin-ness),
+// preserving order. Callers that need to distinguish the two — anything
+// that has to decide bare-column vs synthesized-expression resolution —
+// use WireNamePinned / WireNameUnpinned / ResolveName instead.
+func (w WireArms) WireName() []*labels.Matcher {
+	return w.filter(WireArmWireNamePinned, WireArmWireNameUnpinned)
+}
 
-// WireBound returns the matchers classified WireArmWireBound (the `le`
-// matchers), preserving order.
+// WireNamePinned returns the matchers classified WireArmWireNamePinned,
+// preserving order.
+func (w WireArms) WireNamePinned() []*labels.Matcher { return w.filter(WireArmWireNamePinned) }
+
+// WireNameUnpinned returns the matchers classified WireArmWireNameUnpinned,
+// preserving order.
+func (w WireArms) WireNameUnpinned() []*labels.Matcher { return w.filter(WireArmWireNameUnpinned) }
+
+// WireBound returns the matchers classified WireArmWireBound, preserving
+// order.
 func (w WireArms) WireBound() []*labels.Matcher { return w.filter(WireArmWireBound) }
 
-// wireArms classifies each matcher in matchers into the wire domain it
-// targets (see WireArm), given the histogram-relevant configuration on s.
-//
-// This is deliberately a SKELETON, not yet wired into any consumer:
-// histogramQuantileMatcherPredicate, splitBucketMatchers, and
-// splitRegexHistogramMatchers each still carry their own inline or
-// bespoke split. Migrating them onto wireArms is tracked as a follow-up
-// (see the issue referenced from #1755) so it can land alongside — not
-// underneath — whichever PR fixes #1478/#1483/#1692 on
-// histogram_quantile.go, rather than racing it.
-//
-// s.HistogramTable == "" means the deployment has no classic-histogram
-// routing configured at all, in which case the wire-name / wire-bound
-// distinction is meaningless (there is no synthetic surface to route
-// around) and every matcher classifies WireArmStorage — mirroring the
-// existing schema gate in isClassicBucketSelector.
-func wireArms(matchers []*labels.Matcher, s schema.Metrics) WireArms {
-	arms := make([]WireArm, len(matchers))
-	if s.HistogramTable == "" {
-		return WireArms{Matchers: matchers, Arms: arms}
+// WireNameDecision is the plan-time resolution strategy a WireArmWireName*
+// matcher takes once the caller supplies the wire suffix its selector
+// context targets (e.g. "_bucket" for histogram_quantile's classic-bucket
+// path, and identically for splitBucketMatchers's caller).
+type WireNameDecision int
+
+const (
+	// DecisionStorageBare means the matcher already carries the caller's
+	// wire suffix: rewriting it to the bare storage name keeps the
+	// predicate a bare-column comparison — the shape
+	// internal/chsql/prewhere.go's isCheapPredicate accepts into PREWHERE
+	// and CH can granule-prune on. Only ever returned for a pinned
+	// matcher.
+	DecisionStorageBare WireNameDecision = iota
+	// DecisionWireSynthetic means the matcher can only be evaluated
+	// against a synthesized concat(MetricName, suffix) expression — no
+	// stored column holds the Prometheus wire name. Always returned for
+	// an unpinned matcher; isCheapPredicate treats the resulting
+	// *chplan.FuncCall as not-cheap, so a DecisionWireSynthetic predicate
+	// never reaches PREWHERE — that's the correct, expected cost, not a
+	// regression: only a pinned matcher can resolve to a granule-pruned
+	// point lookup at all.
+	DecisionWireSynthetic
+	// DecisionUnsatisfiable means a pinned matcher names a wire spelling
+	// the caller's domain doesn't expose (e.g. the bare classic-histogram
+	// name itself, or a companion suffix a bucket selector didn't ask
+	// for). The predicate is unconditionally false rather than falling
+	// through to the OTel-CH storage row, which lives under the bare name
+	// and would over-answer (#1483 MAINTAINER DECISION 1).
+	DecisionUnsatisfiable
+)
+
+// ResolveName computes the WireNameDecision for the i'th matcher — which
+// must be classified WireArmWireNamePinned or WireArmWireNameUnpinned,
+// i.e. drawn from w.WireName() — against wireSuffix, plus the bare storage
+// name a DecisionStorageBare resolves to (empty for the other two
+// decisions). Calling it for a matcher classified into any other arm is a
+// caller bug; ResolveName reports DecisionWireSynthetic defensively rather
+// than panicking, since that's the answer with no bare-column fallout.
+func (w WireArms) ResolveName(i int, wireSuffix string) (WireNameDecision, string) {
+	if w.Arms[i] != WireArmWireNamePinned {
+		return DecisionWireSynthetic, ""
 	}
+	m := w.Matchers[i]
+	if !strings.HasSuffix(m.Value, wireSuffix) {
+		return DecisionUnsatisfiable, ""
+	}
+	return DecisionStorageBare, strings.TrimSuffix(m.Value, wireSuffix)
+}
+
+// wireArms classifies each matcher in matchers into the wire domain it
+// targets (see WireArm).
+//
+// Classification is unconditional — it does not gate on
+// s.HistogramTable — because each of its consumers owns the appropriate
+// gate at its own call site instead: isClassicBucketSelector guards
+// splitBucketMatchers, the s.HistogramTable != "" check ahead of
+// lowerRegexHistogramSelector guards splitRegexHistogramMatchers, and —
+// critically — histogramQuantileMatcherPredicate's pre-migration inline
+// loop classified `le` / `__name__` matchers with no gate at all. Baking a
+// deployment-config gate into wireArms itself would silently change that
+// third consumer's behaviour on a deployment with no histogram table
+// configured, which is exactly the kind of golden-diverging regression
+// #1756 rules out.
+func wireArms(matchers []*labels.Matcher) WireArms {
+	arms := make([]WireArm, len(matchers))
 	for i, m := range matchers {
-		switch m.Name {
-		case bucketBoundLabel:
+		switch {
+		case m.Name == bucketBoundLabel:
 			arms[i] = WireArmWireBound
-		case model.MetricNameLabel:
-			arms[i] = WireArmWireName
+		case m.Name == model.MetricNameLabel && m.Type == labels.MatchEqual:
+			arms[i] = WireArmWireNamePinned
+		case m.Name == model.MetricNameLabel:
+			arms[i] = WireArmWireNameUnpinned
 		default:
 			arms[i] = WireArmStorage
 		}

--- a/internal/promql/histogram_wire_arms_test.go
+++ b/internal/promql/histogram_wire_arms_test.go
@@ -4,26 +4,36 @@ import (
 	"testing"
 
 	"github.com/prometheus/prometheus/model/labels"
-
-	"github.com/tsouza/cerberus/internal/schema"
 )
 
-// TestWireArms_ClassifiesEachDomain pins the three-way split: a `__name__`
-// matcher (pinned or unpinned) classifies WireArmWireName, an `le` matcher
+// TestWireArms_ClassifiesEachDomain pins the four-way split: a pinned
+// `__name__=` matcher classifies WireArmWireNamePinned, an unpinned
+// `__name__` matcher classifies WireArmWireNameUnpinned, an `le` matcher
 // classifies WireArmWireBound, and everything else classifies
-// WireArmStorage — in original order.
+// WireArmStorage — in original order. This is the direct fix for the
+// #1756 hard constraint: the pre-migration skeleton keyed its switch on
+// m.Name alone and could not distinguish a pinned matcher from an
+// unpinned one, the entire distinction the wire-name family turns on.
 func TestWireArms_ClassifiesEachDomain(t *testing.T) {
 	t.Parallel()
-	s := schema.DefaultOTelMetrics()
 
 	nameEq := mustMatcher(t, labels.MatchEqual, "__name__", "demo_api_request_duration_seconds_bucket")
 	nameRe := mustMatcher(t, labels.MatchRegexp, "__name__", "demo_api.*")
+	nameNeq := mustMatcher(t, labels.MatchNotEqual, "__name__", "demo_api_request_duration_seconds_bucket")
+	nameNre := mustMatcher(t, labels.MatchNotRegexp, "__name__", "demo_api.*")
 	le := mustMatcher(t, labels.MatchEqual, "le", "0.5")
 	job := mustMatcher(t, labels.MatchEqual, "job", "api")
 
-	got := wireArms([]*labels.Matcher{nameEq, le, job, nameRe}, s)
+	got := wireArms([]*labels.Matcher{nameEq, le, job, nameRe, nameNeq, nameNre})
 
-	want := []WireArm{WireArmWireName, WireArmWireBound, WireArmStorage, WireArmWireName}
+	want := []WireArm{
+		WireArmWireNamePinned,
+		WireArmWireBound,
+		WireArmStorage,
+		WireArmWireNameUnpinned,
+		WireArmWireNameUnpinned,
+		WireArmWireNameUnpinned,
+	}
 	if len(got.Arms) != len(want) {
 		t.Fatalf("Arms len = %d, want %d", len(got.Arms), len(want))
 	}
@@ -33,8 +43,14 @@ func TestWireArms_ClassifiesEachDomain(t *testing.T) {
 		}
 	}
 
-	if diff := len(got.WireName()); diff != 2 {
-		t.Errorf("WireName() len = %d, want 2", diff)
+	if diff := len(got.WireName()); diff != 4 {
+		t.Errorf("WireName() len = %d, want 4", diff)
+	}
+	if diff := len(got.WireNamePinned()); diff != 1 {
+		t.Errorf("WireNamePinned() len = %d, want 1", diff)
+	}
+	if diff := len(got.WireNameUnpinned()); diff != 3 {
+		t.Errorf("WireNameUnpinned() len = %d, want 3", diff)
 	}
 	if diff := len(got.WireBound()); diff != 1 {
 		t.Errorf("WireBound() len = %d, want 1", diff)
@@ -45,26 +61,8 @@ func TestWireArms_ClassifiesEachDomain(t *testing.T) {
 	if got.Storage()[0] != job {
 		t.Errorf("Storage()[0] = %v, want the job matcher", got.Storage()[0])
 	}
-}
-
-// TestWireArms_NoHistogramTableConfigured is the schema-gated fallback: a
-// deployment with no classic-histogram routing (s.HistogramTable == "") has
-// no synthetic wire surface to route around at all, so wireArms must not
-// pull `le` or `__name__` out into a wire arm — mirroring the same gate
-// isClassicBucketSelector already uses.
-func TestWireArms_NoHistogramTableConfigured(t *testing.T) {
-	t.Parallel()
-	s := schema.Metrics{} // zero value: HistogramTable == ""
-
-	le := mustMatcher(t, labels.MatchEqual, "le", "0.5")
-	name := mustMatcher(t, labels.MatchEqual, "__name__", "up")
-
-	got := wireArms([]*labels.Matcher{le, name}, s)
-
-	for i, arm := range got.Arms {
-		if arm != WireArmStorage {
-			t.Errorf("Arms[%d] = %s, want %s (HistogramTable unconfigured)", i, arm, WireArmStorage)
-		}
+	if got.WireNamePinned()[0] != nameEq {
+		t.Errorf("WireNamePinned()[0] = %v, want the pinned name matcher", got.WireNamePinned()[0])
 	}
 }
 
@@ -72,11 +70,10 @@ func TestWireArms_NoHistogramTableConfigured(t *testing.T) {
 // not panic and must return an empty-but-valid WireArms.
 func TestWireArms_EmptyInput(t *testing.T) {
 	t.Parallel()
-	s := schema.DefaultOTelMetrics()
 
-	got := wireArms(nil, s)
+	got := wireArms(nil)
 	if len(got.Matchers) != 0 || len(got.Arms) != 0 {
-		t.Fatalf("wireArms(nil, s) = %+v, want empty", got)
+		t.Fatalf("wireArms(nil) = %+v, want empty", got)
 	}
 	if len(got.Storage()) != 0 || len(got.WireName()) != 0 || len(got.WireBound()) != 0 {
 		t.Fatalf("filtered slices on empty WireArms must all be empty")
@@ -89,14 +86,77 @@ func TestWireArms_EmptyInput(t *testing.T) {
 func TestWireArm_String(t *testing.T) {
 	t.Parallel()
 	cases := map[WireArm]string{
-		WireArmStorage:   "storage",
-		WireArmWireName:  "wire-name",
-		WireArmWireBound: "wire-bound",
-		WireArm(99):      "unknown",
+		WireArmStorage:          "storage",
+		WireArmWireNamePinned:   "wire-name-pinned",
+		WireArmWireNameUnpinned: "wire-name-unpinned",
+		WireArmWireBound:        "wire-bound",
+		WireArm(99):             "unknown",
 	}
 	for arm, want := range cases {
 		if got := arm.String(); got != want {
 			t.Errorf("WireArm(%d).String() = %q, want %q", arm, got, want)
 		}
+	}
+}
+
+// TestWireArms_ResolveName pins the decision surface #1756 requires:
+// given a wire suffix, a pinned matcher resolves to either
+// DecisionStorageBare (with the stripped bare name) or
+// DecisionUnsatisfiable, never DecisionWireSynthetic — and an unpinned
+// matcher always resolves to DecisionWireSynthetic. This is the exact
+// distinction the PREWHERE performance invariant depends on: only
+// DecisionStorageBare keeps the predicate a bare-column comparison
+// internal/chsql/prewhere.go can promote; see
+// TestHistogramQuantileMatcherPredicate_PinnedNameStaysBareColumn for the
+// plan-shape assertion built on top of this.
+func TestWireArms_ResolveName(t *testing.T) {
+	t.Parallel()
+
+	const suffix = "_bucket"
+
+	cases := []struct {
+		name       string
+		matcher    *labels.Matcher
+		wantDecide WireNameDecision
+		wantBare   string
+	}{
+		{
+			name:       "pinned_with_suffix_resolves_bare",
+			matcher:    mustMatcher(t, labels.MatchEqual, "__name__", "demo_bucket"),
+			wantDecide: DecisionStorageBare,
+			wantBare:   "demo",
+		},
+		{
+			name:       "pinned_without_suffix_unsatisfiable",
+			matcher:    mustMatcher(t, labels.MatchEqual, "__name__", "demo"),
+			wantDecide: DecisionUnsatisfiable,
+			wantBare:   "",
+		},
+		{
+			name:       "unpinned_regex_always_synthetic",
+			matcher:    mustMatcher(t, labels.MatchRegexp, "__name__", "demo.*"),
+			wantDecide: DecisionWireSynthetic,
+			wantBare:   "",
+		},
+		{
+			name:       "unpinned_not_equal_always_synthetic",
+			matcher:    mustMatcher(t, labels.MatchNotEqual, "__name__", "demo_bucket"),
+			wantDecide: DecisionWireSynthetic,
+			wantBare:   "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			w := wireArms([]*labels.Matcher{tc.matcher})
+			decision, bare := w.ResolveName(0, suffix)
+			if decision != tc.wantDecide {
+				t.Errorf("ResolveName decision = %v, want %v", decision, tc.wantDecide)
+			}
+			if bare != tc.wantBare {
+				t.Errorf("ResolveName bare = %q, want %q", bare, tc.wantBare)
+			}
+		})
 	}
 }

--- a/internal/promql/regex_histogram_lower.go
+++ b/internal/promql/regex_histogram_lower.go
@@ -22,12 +22,20 @@ func hasUnpinnedMetricNameMatcher(matchers []*labels.Matcher) bool {
 	return false
 }
 
+// Classification is delegated to wireArms (#1756): the union of
+// WireArmWireNamePinned + WireArmWireNameUnpinned (via WireName()) is the
+// `names` split — both pin-nesses land here unchanged, since this
+// consumer resolves the wire name via a post-projection Filter over an
+// already-aliased synthetic-name column (see buildRegexHistogramCompanionArm
+// / buildRegexHistogramBucketArm) rather than a rewritten predicate, so it
+// has no need for wireArms's ResolveName decision.
 func splitRegexHistogramMatchers(matchers []*labels.Matcher) (names, scan, le []*labels.Matcher) {
-	for _, m := range matchers {
-		switch m.Name {
-		case model.MetricNameLabel:
+	w := wireArms(matchers)
+	for i, m := range matchers {
+		switch w.Arms[i] {
+		case WireArmWireNamePinned, WireArmWireNameUnpinned:
 			names = append(names, m)
-		case "le":
+		case WireArmWireBound:
 			le = append(le, m)
 		default:
 			scan = append(scan, m)


### PR DESCRIPTION
## Summary

- `wireArms` was dead code (`git grep "wireArms(" origin/main -- 'internal/**/*.go'` returns only the definition) while wire-domain matcher classification was independently reimplemented across `splitBucketMatchers`, `splitRegexHistogramMatchers`, and `histogramQuantileMatcherPredicate`, growing with every new consumer.
- Extends `WireArms` from a name-keyed taxonomy into a per-matcher **resolver**: carries `(label name x matcher pin-ness x wire suffix)` and exposes a decision (`DecisionStorageBare` / `DecisionWireSynthetic` / `DecisionUnsatisfiable`) via `WireArms.ResolveName(i, wireSuffix)`, not merely a domain label.
- Migrates the three duplicate suffix-chain resolvers named in #1756 onto the shared resolver.

## Bug fixed as part of this work (#1756 was unsafe as written)

The pre-migration `wireArms` skeleton switched on `m.Name` alone and never read `m.Type`, so it could not distinguish a **pinned** matcher (`=`) from an **unpinned** one (`=~` / `!=` / `!~`) — the entire axis the wire-name family turns on. Fixed via the new `WireArmWireNamePinned` / `WireArmWireNameUnpinned` split.

## Performance invariant (pinned with a new test)

A pinned wire name must resolve at plan time to a bare-column `MetricName =`/`IN` comparison, never a `*chplan.FuncCall` (e.g. `concat(...)`), since `internal/chsql/prewhere.go`'s `isCheapPredicate` treats `*chplan.FuncCall` as not-cheap and would silently convert a granule-pruned point lookup into a full scan. New file `internal/promql/histogram_quantile_wire_arms_prewhere_test.go` asserts FuncCall-freedom for pinned matchers *and* FuncCall-presence for unpinned ones (non-vacuous), plus the `splitBucketMatchers` rewrite shape.

## Resolver inventory (verified, not just named)

Migrated onto `WireArms`/`ResolveName`:

- `splitBucketMatchers` (`internal/promql/histogram_bucket.go`)
- `splitRegexHistogramMatchers` (`internal/promql/regex_histogram_lower.go`)
- `histogramQuantileMatcherPredicate` (`internal/promql/histogram_quantile.go`)

Audited and confirmed **not** duplicate wire-domain classifiers (verified-negative, checked at the call sites rather than assumed from the name):

- `expHistogramSelectorRouting` / `resolveSelectorRouting` (`internal/promql/lower.go`) — these are metric-**name**-based table routers that delegate to `splitBucketMatchers` (now migrated) and `rewriteMetricName`.
- `rewriteMetricName` (`internal/promql/lower.go`) — a fourth, structurally similar but domain-distinct resolver (unconditional bare-name substitution for exp-histogram/count/sum-companion routing, no le/wire-suffix classification), called from 4 sites. Left unmigrated on purpose and tracked as a follow-up: #1761.
- `exemplarsTableFor` (`internal/api/prom/exemplars.go`, subject of #1705) — operates on a bare metric-name string via a hand-rolled suffix chain to pick a **single** table, structurally different from `WireArms`'s per-matcher classification. It's a real correctness bug (no fan-out for ambiguous suffix cases that `schema.Metrics.TablesFor` already handles correctly), but fixing it needs new goldens (`UNION ALL` across candidate tables in the chsql emitter), which is out of this refactor's byte-identical-goldens scope. Posted a concrete migration shape as a comment on #1705 instead of leaving deferral prose.

No behavioral inconsistency between duplicate resolvers was found that required deciding correctness against reference Prometheus — the migration was a pure refactor.

## Goldens

`go test ./internal/promql/... -run TestLower -v` — the Layer 2a golden-check entrypoint over every `test/spec/promql/*.txtar` fixture — passes with **zero churn**, confirming byte-identical `-- sql --` / `-- args --` output across the whole histogram-adjacent corpus.

Closes #1755
Closes #1756

Follow-up tracked in #1761. Migration shape for #1705 posted as a PR-independent comment on that issue.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/promql/...`
- [x] `go test ./internal/promql/... -run TestLower -v` — zero golden churn
- [x] New `TestWireArms_*` + `TestHistogramQuantileMatcherPredicate_PinnedNameStaysBareColumn` + `TestSplitBucketMatchers_PinnedNameStaysBareColumn` all pass
- [ ] CI (20 required checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)