### PR TITLE
docs(schema): fix stale TablesForUnknownName comment on histogram UnionAll

### DIFF
--- a/internal/schema/otel.go
+++ b/internal/schema/otel.go
@@ -582,10 +582,16 @@ func (m Metrics) TablesFor(metricName string) []string {
 //
 // The histogram / exp-histogram tables cannot join this candidate set:
 // their row shape (Count / Sum / BucketCounts, no Value column) is
-// disjoint from the Sample contract the `merge()` fan-out requires, so
-// surfacing classic-histogram series under regex name matchers needs
-// the per-arm UnionAll lowering (see the `_count` / `_sum` companion
-// path) — out of scope for the unknown-name fan-out.
+// disjoint from the Sample contract the `merge()` fan-out requires.
+// Classic-histogram series under a regex name matcher are surfaced by a
+// separate per-arm UnionAll lowering instead
+// (lowerRegexHistogramSelector in internal/promql/regex_histogram_lower.go,
+// wired from lowerVectorSelector for any selector with an unpinned
+// __name__ matcher): it unions this unknown-name candidate set with a
+// companion arm per `_count`/`_sum` suffix and a `_bucket` arm. Native
+// (exponential) histograms have no equivalent arm — HistogramCompanionColumn
+// only resolves [Metrics.IsExpHistogramMetric] from a literal bare name, so
+// ExpHistogramTable stays unreachable under a regex name matcher.
 func (m Metrics) TablesForUnknownName() []string {
 	if m.SumTable != "" && m.SumTable != m.GaugeTable {
 		return []string{m.GaugeTable, m.SumTable}


### PR DESCRIPTION
## Summary

The comment above `Metrics.TablesForUnknownName` (`internal/schema/otel.go`) said surfacing classic-histogram series under a regex `__name__` matcher "needs the per-arm UnionAll lowering ... out of scope for the unknown-name fan-out" — phrasing it as a prerequisite that hadn't landed yet.

That lowering exists and is wired today:

- `lowerVectorSelector` (`internal/promql/lower.go:499-500`) routes any selector with an unpinned `__name__` matcher (regex, negated, or absent) into `lowerRegexHistogramSelector`.
- `lowerRegexHistogramSelector` (`internal/promql/regex_histogram_lower.go`) builds a `chplan.UnionAll` of: the plain-Sample metric arm (using this very `TablesForUnknownName` candidate set), one companion arm per `_count`/`_sum` histogram-companion suffix, and a `_bucket` arm via `wrapHistogramBucketFanout`.
- Covered by existing fixtures, e.g. `test/spec/promql/regex_name_matcher_scans_sum_table.txtar`, `test/spec/promql/regex_name_matcher_underscored_matches_dotted.txtar`, `test/spec/promql/not_regex_name_matcher_excludes_dotted.txtar`.

Rewrote the comment to describe the lowering as present, and preserved the one part that's still true: native (exponential) histograms have no equivalent arm — `HistogramCompanionColumn` / `IsExpHistogramMetric` only resolve from a literal bare metric name, so `ExpHistogramTable` genuinely stays unreachable under a regex name matcher (that path only exists via `histogram_quantile()`'s literal-name lowering).

## Scope

Comment-only change in `internal/schema/otel.go`. No behavior change, no golden churn.

## Test plan

- [x] `go build ./...`
- [x] `git status` shows only the one comment edit
- [x] pre-push hook (golangci-lint, forbid-sql-raw, forbid-skip, markdownlint, actionlint, commitlint-range) — all green

Addresses #1549 (residue 3: stale comment).