### PR TITLE
feat(rejection-parity): add divergence class for deliberate, tracked backend gaps

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -200,6 +200,41 @@ uncomputable-diff fallback — cannot drift between the lanes that use it.
   - Exit: `0` when every marker is tracked by an open issue (or none were
     found); `1` on an untracked deferral or a malformed input. ENFORCING and a
     required status check on `main`.
+- **`rejection-parity-divergence-liveness.mjs`** — `forbid-deferral.yml`, the
+  same `forbid-deferral` job, as an additional step. The liveness half of the
+  `test/rejection-parity/catalogue.json` `class: "divergence"` contract (see
+  `test/rejection-parity/doc.go`'s "Why `divergence` is not the allow-list this
+  package forbids" section): a divergence entry cites an open GitHub issue
+  tracking closure of a deliberate cerberus/reference-backend gap, and that
+  citation must stay live forever, not just at the moment it was written. The
+  Go meta-tests in `test/rejection-parity` run offline and pin only the
+  STRUCTURAL half (`TrackingIssue` is a positive integer —
+  `TestCatalogueEntriesAreClassified`); this script pins the LIVENESS half by
+  re-reading the catalogue on every run (not just a diff) and resolving each
+  cited number through the GitHub API. It runs unconditionally, because the
+  failure mode it exists to catch — someone closes the tracking issue without
+  ever touching this repository's tree — leaves no diff for a scoped gate to
+  see. Reuses `forbid-deferral.mjs`'s exported `issuesReadability` two-request
+  capability probe unchanged (same 404-means-two-things reason: GitHub answers
+  an issue the token cannot read the same way it answers one that does not
+  exist), and mirrors (does not import, since they are unexported) its private
+  `apiHeaders` / `probeStatus` / `apiJson` / `requireEnv` helpers and its
+  probe-at-most-once-per-run resolution loop.
+  `rejection-parity-divergence-liveness.test.mjs` is the `node --test` guard
+  (run as the step BEFORE the gate): it pins the pure halves — which entries
+  count as `divergence`, the structural check, and the open/closed/pull-request
+  verdict — reusing the same three real fixture numbers (`#1535` open,
+  `#1486` closed, `#1143` a closed pull request) `forbid-deferral.test.mjs`
+  already resolves, so the two gates' notion of "what a resolved citation looks
+  like" cannot drift apart silently.
+  - Env: `GITHUB_REPOSITORY`, `GITHUB_TOKEN` (needs `issues: read`; already
+    granted to the `forbid-deferral` job), `GITHUB_API_URL` (optional;
+    runner-provided), `CATALOGUE_PATH` (optional; default
+    `test/rejection-parity/catalogue.json`).
+  - Exit: `0` when every divergence entry cites an open issue (or there are no
+    divergence entries); `1` on a missing / closed / PR-shaped citation, a
+    malformed entry, or a capability fault. ENFORCING and a required status
+    check on `main` (as a step of the required `forbid-deferral` context).
 - **`repo-hygiene.mjs`** — `ci.yml`, the `forbid-skip` job's committed-artefact
   gate. Every other gate asks whether the tree COMPILES and PASSES; none asks
   what it CONTAINS, so a build artefact that is `git add`-ed by accident

--- a/.github/scripts/rejection-parity-divergence-liveness.mjs
+++ b/.github/scripts/rejection-parity-divergence-liveness.mjs
@@ -1,0 +1,238 @@
+// rejection-parity-divergence-liveness.mjs — the divergence-tracking-issue
+// liveness gate.
+//
+// test/rejection-parity/catalogue.json's `class: "divergence"` entries make a
+// ratchet claim (see test/rejection-parity/doc.go): cerberus deliberately
+// rejects a query the reference backend answers, and an OPEN GitHub issue in
+// this repository tracks closing the gap. The Go meta-tests under
+// test/rejection-parity run offline and cannot dial the GitHub API, so they
+// pin the STRUCTURAL half of that claim (TrackingIssue is a positive integer —
+// see TestCatalogueEntriesAreClassified). This script pins the LIVENESS half:
+// every cited issue actually exists, is an issue rather than a pull request,
+// and is still open. A divergence entry whose tracking issue was closed by
+// someone who never touched the catalogue is exactly the failure mode this
+// catches — nothing about editing the issue touches this repository's tree,
+// so only a check that re-reads the catalogue on every run (not just a diff)
+// can see it. Wired as an extra step in the `forbid-deferral` job
+// (.github/workflows/forbid-deferral.yml), which already runs on every
+// pull_request / push / merge_group and already carries the `issues: read`
+// grant this lookup needs — mirrors the same liveness discipline
+// forbid-deferral.mjs enforces for deferral markers, just against the
+// catalogue's own state instead of a diff.
+//
+// This is the load-bearing half of why `divergence` is not the allow-list
+// test/rejection-parity/doc.go forbids: an allow-list entry, once accepted,
+// requires nothing further of anyone. A divergence entry requires its
+// tracking issue to STAY open, checked mechanically forever — closing the
+// issue without deleting or reclassifying the entry is a build failure, not a
+// silent success.
+//
+// Env contract:
+//   GITHUB_REPOSITORY  REQUIRED. `owner/repo` (runner-provided).
+//   GITHUB_TOKEN       REQUIRED. Needs `issues: read`.
+//   GITHUB_API_URL     API base (runner-provided; default https://api.github.com).
+//   CATALOGUE_PATH     Path to the catalogue JSON artifact (default
+//                      test/rejection-parity/catalogue.json).
+//
+// Exit codes: 0 = every divergence entry's tracking issue is open and is an
+// issue (or there are no divergence entries at all), 1 = a missing / closed /
+// PR-shaped citation, a malformed entry, or a capability fault (token cannot
+// read issues — see issuesReadability in forbid-deferral.mjs, imported and
+// reused unchanged here for the same 404-means-two-things reason its own
+// header documents).
+
+import { readFileSync } from 'node:fs';
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+
+import { issuesReadability } from './forbid-deferral.mjs';
+import { appendStepSummary, error, log, notice } from './lib/gh.mjs';
+
+const HTTP_NOT_FOUND = 404;
+
+// --- pure halves --------------------------------------------------------
+
+// divergenceEntries — every class="divergence" entry in the catalogue,
+// unchanged, in file order. Any other class is out of scope for this script;
+// TestCatalogueEntriesAreClassified is what polices "rejection" / "internal".
+export function divergenceEntries(catalogue) {
+  const entries = catalogue && Array.isArray(catalogue.entries) ? catalogue.entries : null;
+  if (entries === null) {
+    throw new Error('catalogue has no "entries" array — malformed or wrong file');
+  }
+  return entries.filter((e) => e.class === 'divergence');
+}
+
+// structuralViolation — the check that needs no network call: TrackingIssue
+// must be a positive integer. TestCatalogueEntriesAreClassified pins this in
+// Go too; it is re-asserted here because this script must not resolve a
+// non-number against the GitHub API.
+export function structuralViolation(entry) {
+  const n = entry.tracking_issue;
+  if (typeof n !== 'number' || !Number.isInteger(n) || n <= 0) {
+    return `tracking_issue is ${JSON.stringify(n)} — must be a positive integer issue number`;
+  }
+  return null;
+}
+
+// livenessViolation — given a resolved { kind, state } for one issue number
+// (or null when the lookup 404s), the reason it fails the liveness claim, or
+// null when it holds. Mirrors forbid-deferral.mjs's citationVerdict, narrowed
+// to a single citation (a divergence entry cites exactly one tracking issue,
+// not a set).
+export function livenessViolation(n, resolved) {
+  if (!resolved || resolved.kind === 'missing') {
+    return `#${n} names nothing in this repository`;
+  }
+  if (resolved.kind === 'pull-request') {
+    return `#${n} is a pull request, not an issue`;
+  }
+  if (resolved.state !== 'open') {
+    return `#${n} is a ${resolved.state} issue — the divergence it tracked must be re-filed, ` +
+      'and the catalogue entry must cite the new issue (or be deleted if the divergence is ' +
+      'actually resolved, or reclassified to "rejection" if the reference backend now also rejects)';
+  }
+  return null;
+}
+
+// --- network halves (mirrors forbid-deferral.mjs's private helpers) -----
+
+function apiHeaders(token) {
+  return {
+    Accept: 'application/vnd.github+json',
+    Authorization: `Bearer ${token}`,
+    'X-GitHub-Api-Version': '2022-11-28',
+  };
+}
+
+async function probeStatus(url, token) {
+  const res = await fetch(url, { headers: apiHeaders(token) });
+  return { ok: res.ok, status: res.status, statusText: res.statusText };
+}
+
+async function apiJson(url, token, what) {
+  const res = await fetch(url, { headers: apiHeaders(token) });
+  if (res.status === HTTP_NOT_FOUND) return null;
+  if (!res.ok) {
+    throw new Error(`${what}: HTTP ${res.status} ${res.statusText} for ${url}`);
+  }
+  return res.json();
+}
+
+// resolveIssue — one issue number -> { kind: 'missing' | 'pull-request' |
+// 'issue', state } | null. The capability probe fires at most once per run,
+// only once a lookup has actually come back 404 — see forbid-deferral.mjs's
+// resolveRefs, which this mirrors for a single-number caller.
+async function resolveIssues(numbers, { repo, token, apiBase }) {
+  const resolved = new Map();
+  let probed = false;
+  for (const n of numbers) {
+    const issue = await apiJson(`${apiBase}/repos/${repo}/issues/${n}`, token, `resolve #${n}`);
+    if (issue === null) {
+      if (!probed) {
+        probed = true;
+        const capability = await issuesReadability({
+          repo,
+          apiBase,
+          get: (url) => probeStatus(url, token),
+        });
+        if (!capability.readable) throw new Error(capability.reason);
+      }
+      resolved.set(n, { kind: 'missing' });
+      continue;
+    }
+    resolved.set(n, { kind: issue.pull_request ? 'pull-request' : 'issue', state: issue.state });
+  }
+  return resolved;
+}
+
+function requireEnv(name, why) {
+  const v = process.env[name];
+  if (v === undefined || v === '') {
+    throw new Error(`${name} is unset — ${why}`);
+  }
+  return v;
+}
+
+// --- runner ---------------------------------------------------------------
+
+async function main() {
+  const repo = requireEnv('GITHUB_REPOSITORY', 'the gate cannot resolve a cited issue without it');
+  const token = requireEnv('GITHUB_TOKEN', 'resolving a cited issue needs issues:read');
+  const apiBase = process.env.GITHUB_API_URL || 'https://api.github.com';
+  const cataloguePath = process.env.CATALOGUE_PATH || 'test/rejection-parity/catalogue.json';
+
+  const raw = readFileSync(cataloguePath, 'utf8');
+  const catalogue = JSON.parse(raw);
+  const entries = divergenceEntries(catalogue);
+
+  const violations = [];
+  const structurallyValid = [];
+  for (const e of entries) {
+    const structural = structuralViolation(e);
+    if (structural) {
+      violations.push({ site: e.site, detail: structural });
+      continue;
+    }
+    structurallyValid.push(e);
+  }
+
+  const numbers = [...new Set(structurallyValid.map((e) => e.tracking_issue))].sort((a, b) => a - b);
+  const resolved = await resolveIssues(numbers, { repo, token, apiBase });
+
+  for (const e of structurallyValid) {
+    const detail = livenessViolation(e.tracking_issue, resolved.get(e.tracking_issue));
+    if (detail) violations.push({ site: e.site, detail });
+  }
+
+  const summary = [
+    `- divergence entries: **${entries.length}**`,
+    `- distinct tracking issues resolved: **${numbers.length}**`,
+    `- violations: **${violations.length}**`,
+  ];
+  appendStepSummary(
+    [
+      '## rejection-parity divergence liveness',
+      '',
+      ...summary,
+      '',
+      violations.length === 0
+        ? 'Every divergence entry cites an open tracking issue.'
+        : violations.map((v) => `- ❌ ${v.site}: ${v.detail}`).join('\n'),
+    ].join('\n'),
+  );
+  for (const line of summary) log(line.replace(/\*\*/g, ''));
+
+  if (violations.length > 0) {
+    for (const v of violations) {
+      error(
+        `${v.site}: ${v.detail}. See test/rejection-parity/doc.go for the divergence-class ` +
+          'contract — a divergence entry must always point at an open, live tracking issue.',
+        { title: 'rejection-parity-divergence-liveness' },
+      );
+    }
+    error(
+      `rejection-parity-divergence-liveness: ${violations.length} divergence entry(ies) with a ` +
+        'dead tracking-issue citation.',
+      { title: 'rejection-parity-divergence-liveness' },
+    );
+    process.exit(1);
+  }
+
+  notice(
+    entries.length === 0
+      ? 'rejection-parity-divergence-liveness: no divergence entries in the catalogue.'
+      : `rejection-parity-divergence-liveness: ${entries.length} divergence entry(ies), all citing ` +
+        'an open tracking issue.',
+    { title: 'rejection-parity-divergence-liveness' },
+  );
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((e) => {
+    error(`rejection-parity-divergence-liveness: ${String(e?.message ?? e)}`, {
+      title: 'rejection-parity-divergence-liveness',
+    });
+    process.exit(1);
+  });
+}

--- a/.github/scripts/rejection-parity-divergence-liveness.test.mjs
+++ b/.github/scripts/rejection-parity-divergence-liveness.test.mjs
@@ -1,0 +1,85 @@
+// Unit tests for rejection-parity-divergence-liveness.mjs — run by
+// `node --test` before the gate itself runs, mirroring the convention
+// forbid-deferral.test.mjs establishes: only the pure halves (no live GitHub
+// API call) are exercised, and the network half (resolveIssues) is left
+// untested here because it is a thin loop around apiJson +
+// issuesReadability — both already pinned by forbid-deferral.test.mjs
+// against the same two-request capability-probe contract this script
+// imports and reuses unchanged.
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  divergenceEntries,
+  livenessViolation,
+  structuralViolation,
+} from './rejection-parity-divergence-liveness.mjs';
+
+// --- divergenceEntries -------------------------------------------------------
+
+test('divergenceEntries keeps only class=divergence, in file order', () => {
+  const catalogue = {
+    entries: [
+      { site: 'a', class: 'rejection' },
+      { site: 'b', class: 'divergence', tracking_issue: 1759 },
+      { site: 'c', class: 'internal' },
+      { site: 'd', class: 'divergence', tracking_issue: 42 },
+    ],
+  };
+  assert.deepEqual(
+    divergenceEntries(catalogue).map((e) => e.site),
+    ['b', 'd'],
+  );
+});
+
+test('divergenceEntries is empty, not an error, when the catalogue has none', () => {
+  assert.deepEqual(divergenceEntries({ entries: [{ site: 'a', class: 'rejection' }] }), []);
+});
+
+test('divergenceEntries rejects a catalogue with no entries array — a wrong file is not a clean pass', () => {
+  assert.throws(() => divergenceEntries({}), /malformed or wrong file/);
+  assert.throws(() => divergenceEntries(null), /malformed or wrong file/);
+});
+
+// --- structuralViolation -----------------------------------------------------
+
+test('a positive integer tracking_issue is structurally fine', () => {
+  assert.equal(structuralViolation({ tracking_issue: 1759 }), null);
+});
+
+for (const bad of [0, -1, 1.5, undefined, null, '1759', '#1759']) {
+  test(`structuralViolation rejects tracking_issue=${JSON.stringify(bad)}`, () => {
+    assert.match(structuralViolation({ tracking_issue: bad }), /must be a positive integer/);
+  });
+}
+
+// --- livenessViolation -------------------------------------------------------
+
+// The same three real fixtures forbid-deferral.test.mjs uses (RESOLVED map):
+// #1535 open issue, #1486 closed issue, #1143 closed pull request. Reusing
+// them keeps the two gates' notion of "what a resolved citation looks like"
+// visibly in lock-step rather than independently invented.
+test('an open issue satisfies the liveness claim', () => {
+  assert.equal(livenessViolation(1535, { kind: 'issue', state: 'open' }), null);
+});
+
+test('a missing resolution (never looked up / not in the map) fails', () => {
+  assert.match(livenessViolation(9999, undefined), /names nothing/);
+});
+
+test('a lookup that resolved to "missing" fails the same way', () => {
+  assert.match(livenessViolation(9999, { kind: 'missing' }), /names nothing/);
+});
+
+test('a pull request is not an issue', () => {
+  assert.match(livenessViolation(1143, { kind: 'pull-request', state: 'closed' }), /pull request, not an issue/);
+});
+
+test('a closed issue fails and explains the three remedies', () => {
+  const detail = livenessViolation(1486, { kind: 'issue', state: 'closed' });
+  assert.match(detail, /closed issue/);
+  assert.match(detail, /re-filed/);
+  assert.match(detail, /deleted/);
+  assert.match(detail, /reclassified to "rejection"/);
+});

--- a/.github/workflows/forbid-deferral.yml
+++ b/.github/workflows/forbid-deferral.yml
@@ -101,3 +101,16 @@ jobs:
           # range end below needs no extra term.
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      # test/rejection-parity/catalogue.json's class=divergence entries carry
+      # the same tracking-issue liveness contract this job already enforces
+      # for deferral markers, just read off the catalogue's own state instead
+      # of a diff — see rejection-parity-divergence-liveness.mjs's header. It
+      # runs unconditionally (not diff-scoped) because the failure mode it
+      # exists to catch is someone closing the tracking issue without ever
+      # touching this repository's tree at all.
+      - name: Assert the divergence liveness scanner matches
+        run: node --test .github/scripts/rejection-parity-divergence-liveness.test.mjs
+      - name: Reject a divergence entry with a dead tracking-issue citation
+        run: node .github/scripts/rejection-parity-divergence-liveness.mjs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/compatibility/cmd/rejection-parity/main.go
+++ b/compatibility/cmd/rejection-parity/main.go
@@ -1,33 +1,58 @@
 // Command rejection-parity is the differential harness for cerberus's
 // deliberate rejections. It consumes the rejection catalogue
 // (test/rejection-parity/catalogue.json — see that package's doc for
-// the full mechanism) and, for every class=rejection entry of the
-// selected head, sends the entry's trigger query to BOTH the reference
-// backend and cerberus, then compares the rejection *status class*:
+// the full mechanism) and, for every class=rejection or
+// class=divergence entry of the selected head, sends the entry's
+// trigger query to BOTH the reference backend and cerberus, then
+// compares the *status class* — never message text, because the two
+// backends phrase rejections differently by construction. The
+// comparison direction depends on the case's class:
 //
-//   - both 4xx                → parity (cerberus's rejection claim holds)
+// class=rejection (the claim: both backends reject this query):
+//
+//   - both 4xx                    → parity (the claim holds)
 //   - reference 2xx, cerberus 4xx → wrong_rejection — cerberus rejects a
 //     query the reference backend answers; a real bug to fix at the
 //     source (the `kind != nil` class), never an allow-list entry
-//   - cerberus 2xx            → stale_catalogue — the catalogue says
+//   - cerberus 2xx                → stale_catalogue — the catalogue says
 //     cerberus rejects this, but the live binary accepts it; the
 //     catalogue needs regenerating
-//   - 5xx / transport failure → hard_error (infrastructure, not parity)
+//   - 5xx / transport failure     → hard_error (infrastructure, not parity)
 //
-// Only the status class is compared — never message text — because
-// the two backends phrase rejections differently by construction.
+// class=divergence (the claim: cerberus rejects, the reference
+// answers — see test/rejection-parity's doc.go for why this is a
+// ratchet, not an allow-list):
+//
+//   - cerberus 2xx                 → divergence_resolved — cerberus now
+//     answers a query the entry says it rejects; the divergence closed
+//     from cerberus's side and the entry must be deleted
+//   - cerberus 4xx, reference 2xx  → divergence_confirmed (the claim
+//     holds; this is the expected, passing state for a live divergence)
+//   - cerberus 4xx, reference 4xx  → divergence_closed — the reference
+//     backend now also rejects; the divergence closed from the
+//     reference's side and the entry must be reclassified to
+//     `rejection`
+//   - 5xx / transport failure      → hard_error (infrastructure, not parity)
 //
 // The corpus is the catalogue itself (rejectionparity.BuildCases), so
-// corpus-case count == catalogue rejection-entry count by
+// corpus-case count == catalogue rejection+divergence-entry count by
 // construction; the meta-tests under test/rejection-parity pin the
 // remaining legs of the ratchet (site scan == catalogue, triggers
 // exercise their sites).
 //
-// Exit semantics mirror the other compat drivers (task #68,
-// report-only): parity drift — including wrong_rejection — is recorded
-// in the JSON report and the stderr summary but does not change the
-// exit code. Only driver-wide hard errors (catalogue load, report
-// write) escalate to a non-zero rc.
+// Exit semantics: ordinary numeric parity drift in the sibling
+// promql-compliance-tester report stays report-only (task #68), but
+// this driver's own verdicts are claims this package makes about
+// itself, not observational drift — a wrong_rejection, a
+// divergence_resolved, or a divergence_closed verdict means one of
+// the catalogue's own assertions is now false. run() writes the JSON
+// report first (the artifact survives either way) and then returns a
+// non-zero exit whenever any of those three verdicts occurred, so the
+// enclosing compat shell script's `set -e` fails the check instead of
+// shipping green on a stale claim. Only stale_catalogue and hard_error
+// stay non-fatal here: stale_catalogue needs a regenerate-and-curate
+// pass a CI run cannot perform on its own, and hard_error is
+// infrastructure, not a parity verdict.
 package main
 
 import (
@@ -65,8 +90,16 @@ type CaseResult struct {
 	RefStatus      int `json:"refStatus"`
 	CerberusStatus int `json:"cerberusStatus"`
 
-	// Verdict: "parity" | "wrong_rejection" | "stale_catalogue" |
-	// "hard_error".
+	// Class is the case's catalogue classification (ClassRejection or
+	// ClassDivergence), carried through so the report is
+	// self-describing without a join back to the catalogue.
+	Class string `json:"class"`
+
+	// Verdict: for class=rejection, "parity" | "wrong_rejection" |
+	// "stale_catalogue" | "hard_error". For class=divergence,
+	// "divergence_confirmed" | "divergence_resolved" |
+	// "divergence_closed" | "hard_error". See the package doc for the
+	// meaning of each.
 	Verdict string `json:"verdict"`
 	// Detail carries the transport error or a snippet of the
 	// unexpected response body for triage.
@@ -75,13 +108,31 @@ type CaseResult struct {
 
 // Report is the on-disk JSON artifact.
 type Report struct {
-	Head           string       `json:"head"`
-	Total          int          `json:"total"`
-	Parity         int          `json:"parity"`
-	WrongRejection int          `json:"wrongRejection"`
-	StaleCatalogue int          `json:"staleCatalogue"`
-	HardErrors     int          `json:"hardErrors"`
-	Cases          []CaseResult `json:"cases"`
+	Head   string `json:"head"`
+	Total  int    `json:"total"`
+	Parity int    `json:"parity"`
+
+	// WrongRejection / StaleCatalogue count class=rejection verdicts.
+	WrongRejection int `json:"wrongRejection"`
+	StaleCatalogue int `json:"staleCatalogue"`
+
+	// DivergenceConfirmed / DivergenceResolved / DivergenceClosed count
+	// class=divergence verdicts — see the package doc.
+	DivergenceConfirmed int `json:"divergenceConfirmed"`
+	DivergenceResolved  int `json:"divergenceResolved"`
+	DivergenceClosed    int `json:"divergenceClosed"`
+
+	HardErrors int          `json:"hardErrors"`
+	Cases      []CaseResult `json:"cases"`
+}
+
+// Fatal reports whether the report's verdict counts include a claim
+// this package makes about ITSELF that turned out false — a
+// wrong_rejection, a divergence_resolved, or a divergence_closed. See
+// the package doc's exit-semantics section for why these three (and
+// only these three) are fatal.
+func (r Report) Fatal() bool {
+	return r.WrongRejection > 0 || r.DivergenceResolved > 0 || r.DivergenceClosed > 0
 }
 
 func run() error {
@@ -122,6 +173,12 @@ func run() error {
 			rep.WrongRejection++
 		case "stale_catalogue":
 			rep.StaleCatalogue++
+		case "divergence_confirmed":
+			rep.DivergenceConfirmed++
+		case "divergence_resolved":
+			rep.DivergenceResolved++
+		case "divergence_closed":
+			rep.DivergenceClosed++
 		default:
 			rep.HardErrors++
 		}
@@ -132,21 +189,39 @@ func run() error {
 		return fmt.Errorf("write report: %w", err)
 	}
 	fmt.Fprintf(os.Stderr,
-		"==> rejection-parity %s: total=%d parity=%d wrong_rejection=%d stale_catalogue=%d hard_errors=%d -> %s\n",
-		rep.Head, rep.Total, rep.Parity, rep.WrongRejection, rep.StaleCatalogue, rep.HardErrors, *report)
+		"==> rejection-parity %s: total=%d parity=%d wrong_rejection=%d stale_catalogue=%d "+
+			"divergence_confirmed=%d divergence_resolved=%d divergence_closed=%d hard_errors=%d -> %s\n",
+		rep.Head, rep.Total, rep.Parity, rep.WrongRejection, rep.StaleCatalogue,
+		rep.DivergenceConfirmed, rep.DivergenceResolved, rep.DivergenceClosed, rep.HardErrors, *report)
 	for _, c := range rep.Cases {
-		if c.Verdict != "parity" {
+		if c.Verdict != "parity" && c.Verdict != "divergence_confirmed" {
 			fmt.Fprintf(os.Stderr, "    [%s] %s (%s): ref=%d cerberus=%d query=%s\n",
 				c.Verdict, c.Name, c.Endpoint, c.RefStatus, c.CerberusStatus, c.Query)
 		}
+	}
+
+	// A wrong_rejection, divergence_resolved, or divergence_closed
+	// verdict means one of the catalogue's own assertions is now
+	// false — this is not observational drift, it's a broken claim
+	// this package makes about itself. Fail the check (see the
+	// package doc's exit-semantics section); the report above already
+	// landed on disk so the artifact survives this branch.
+	if rep.Fatal() {
+		return fmt.Errorf(
+			"rejection-parity %s: %d wrong_rejection + %d divergence_resolved + %d divergence_closed verdict(s) — "+
+				"see %s for detail; a wrong_rejection is a bug to fix at the source, a divergence_resolved means the "+
+				"catalogue entry must be deleted, a divergence_closed means it must be reclassified to \"rejection\"",
+			rep.Head, rep.WrongRejection, rep.DivergenceResolved, rep.DivergenceClosed, *report,
+		)
 	}
 	return nil
 }
 
 // runCase fires the trigger query at both backends and classifies the
-// status pair.
+// status pair. The comparison direction depends on c.Class — see the
+// package doc.
 func runCase(client *http.Client, c rejectionparity.Case, refURL, cerbURL string, now time.Time) CaseResult {
-	res := CaseResult{Name: c.Name, Endpoint: c.Endpoint, Query: c.Query}
+	res := CaseResult{Name: c.Name, Endpoint: c.Endpoint, Query: c.Query, Class: c.Class}
 
 	refStatus, refBody, refErr := fetch(client, buildURL(refURL, c, now))
 	cerbStatus, cerbBody, cerbErr := fetch(client, buildURL(cerbURL, c, now))
@@ -162,6 +237,8 @@ func runCase(client *http.Client, c rejectionparity.Case, refURL, cerbURL string
 	case refStatus/100 == 5 || cerbStatus/100 == 5:
 		res.Verdict = "hard_error"
 		res.Detail = fmt.Sprintf("5xx: ref=%q cerberus=%q", snippet(refBody), snippet(cerbBody))
+	case c.Class == rejectionparity.ClassDivergence:
+		res.Verdict, res.Detail = divergenceVerdict(cerbStatus, refStatus, refBody, cerbBody)
 	case cerbStatus/100 == 2:
 		// The catalogue claims cerberus rejects this query; the live
 		// binary accepted it. The catalogue (or the lowering) moved —
@@ -179,6 +256,28 @@ func runCase(client *http.Client, c rejectionparity.Case, refURL, cerbURL string
 		res.Detail = fmt.Sprintf("unclassifiable status pair; ref=%q cerberus=%q", snippet(refBody), snippet(cerbBody))
 	}
 	return res
+}
+
+// divergenceVerdict classifies a class=divergence case's status pair.
+// The entry's claim is inverted relative to class=rejection: cerberus
+// REJECTS the trigger query and the reference backend ACCEPTS it.
+func divergenceVerdict(cerbStatus, refStatus int, refBody, cerbBody []byte) (string, string) {
+	switch {
+	case cerbStatus/100 == 2:
+		// cerberus now answers a query the entry says it rejects —
+		// the divergence closed from cerberus's side.
+		return "divergence_resolved", fmt.Sprintf("cerberus accepted (divergence entry expects 4xx); ref=%q", snippet(refBody))
+	case refStatus/100 == 2:
+		// The expected, passing state: cerberus still rejects, the
+		// reference still answers.
+		return "divergence_confirmed", ""
+	case refStatus/100 == 4:
+		// The reference now also rejects — the divergence closed from
+		// the reference's side; reclassify to "rejection".
+		return "divergence_closed", fmt.Sprintf("reference now rejects (divergence entry expects 2xx); ref=%q cerberus=%q", snippet(refBody), snippet(cerbBody))
+	default:
+		return "hard_error", fmt.Sprintf("unclassifiable status pair; ref=%q cerberus=%q", snippet(refBody), snippet(cerbBody))
+	}
 }
 
 // buildURL composes the per-endpoint query URL. The window is ±1h

--- a/test/rejection-parity/catalogue.go
+++ b/test/rejection-parity/catalogue.go
@@ -54,37 +54,58 @@ type Entry struct {
 
 	// Class is the curated classification:
 	//
-	//   "rejection" — reachable from a parseable query: a deliberate
-	//                 semantic rejection whose parity against the
-	//                 reference backend the compat harnesses verify.
-	//                 Requires TriggerQuery (+ Endpoint for traceql
-	//                 metrics-pipeline sites).
-	//   "internal"  — not reachable from a parseable query through the
-	//                 HTTP query endpoints: parser-enforced shapes,
-	//                 internal invariants, error-propagation wrappers
-	//                 (%w), or paths only reachable via non-wire entry
-	//                 points. Requires Rationale.
+	//   "rejection"  — reachable from a parseable query: a deliberate
+	//                  semantic rejection whose parity against the
+	//                  reference backend the compat harnesses verify.
+	//                  Requires TriggerQuery (+ Endpoint for traceql
+	//                  metrics-pipeline sites); forbids Rationale and
+	//                  TrackingIssue.
+	//   "internal"   — not reachable from a parseable query through the
+	//                  HTTP query endpoints: parser-enforced shapes,
+	//                  internal invariants, error-propagation wrappers
+	//                  (%w), or paths only reachable via non-wire entry
+	//                  points. Requires Rationale; forbids TriggerQuery,
+	//                  Endpoint and TrackingIssue.
+	//   "divergence" — reachable AND wire-verified to differ from the
+	//                  reference backend on purpose: cerberus rejects
+	//                  the trigger query, the reference backend answers
+	//                  it, and an open GitHub issue tracks closing the
+	//                  gap. Requires TriggerQuery (+ Endpoint) exactly
+	//                  like "rejection", plus TrackingIssue; forbids
+	//                  Rationale. See doc.go for why this is a ratchet
+	//                  and not the allow-list the package forbids.
 	//
 	// The verify test fails on any other value (including ""), so a
 	// new rejection site cannot land unclassified.
 	Class string `json:"class"`
 
-	// TriggerQuery (class=rejection) is a minimal concrete query that
-	// parses with the head's reference parser and fails this site's
-	// lowering with this site's message. Pinned by
+	// TriggerQuery (class=rejection, class=divergence) is a minimal
+	// concrete query that parses with the head's reference parser and
+	// fails this site's lowering with this site's message. Pinned by
 	// TestRejectionTriggersExerciseSites.
 	TriggerQuery string `json:"trigger_query,omitempty"`
 
-	// Endpoint (class=rejection) selects the HTTP endpoint the parity
-	// driver sends TriggerQuery to. Empty means the head default
-	// (DefaultEndpoint). TraceQL metrics-pipeline rejections set
-	// "traceql_metrics" because /api/search does not accept metrics
-	// expressions.
+	// Endpoint (class=rejection, class=divergence) selects the HTTP
+	// endpoint the parity driver sends TriggerQuery to. Empty means
+	// the head default (DefaultEndpoint). TraceQL metrics-pipeline
+	// rejections set "traceql_metrics" because /api/search does not
+	// accept metrics expressions.
 	Endpoint string `json:"endpoint,omitempty"`
 
 	// Rationale (class=internal) documents why the site is not a
 	// wire-reachable semantic rejection.
 	Rationale string `json:"rationale,omitempty"`
+
+	// TrackingIssue (class=divergence) is the number of an open GitHub
+	// issue, in this repository, tracking closure of the divergence.
+	// The forbid-deferral workflow asserts on every PR/push/merge_group
+	// that the issue exists, is open, and is an issue rather than a
+	// pull request — the same liveness contract forbid-deferral.mjs
+	// already enforces for deferral markers. A closed or missing issue
+	// with the entry still present is a failure: the entry must either
+	// be deleted (cerberus was fixed) or re-filed against a fresh
+	// issue, never left pointing at a closed one.
+	TrackingIssue int `json:"tracking_issue,omitempty"`
 }
 
 // Catalogue is the checked-in JSON artifact shape
@@ -105,6 +126,14 @@ const (
 	EndpointLogQLRange     = "logql_range"
 	EndpointTraceQLSearch  = "traceql_search"
 	EndpointTraceQLMetrics = "traceql_metrics"
+)
+
+// Class identifiers — see the Entry.Class doc comment for the full
+// semantics of each.
+const (
+	ClassRejection  = "rejection"
+	ClassInternal   = "internal"
+	ClassDivergence = "divergence"
 )
 
 // DefaultEndpoint returns the per-head endpoint used when an entry
@@ -134,9 +163,10 @@ func ValidEndpoint(head, ep string) bool {
 	return false
 }
 
-// Case is one parity-corpus case derived from a rejection entry. The
-// driver sends Query to Endpoint on both backends and asserts both
-// reject (4xx).
+// Case is one parity-corpus case derived from a rejection or
+// divergence entry. The driver sends Query to Endpoint on both
+// backends; the expected verdict depends on Class — see
+// compatibility/cmd/rejection-parity's runCase.
 type Case struct {
 	// Name is the catalogue site key — stable, unique, and greppable
 	// straight back to the error-construction site.
@@ -145,30 +175,40 @@ type Case struct {
 	// Endpoint is resolved (entry override or head default).
 	Endpoint string `json:"endpoint"`
 	Query    string `json:"query"`
+	// Class is the entry's classification (ClassRejection or
+	// ClassDivergence — BuildCases never emits ClassInternal cases).
+	// The driver branches its verdict logic on this field: a
+	// rejection case asserts BOTH backends reject; a divergence case
+	// asserts cerberus rejects AND the reference backend answers.
+	Class string `json:"class"`
 }
 
 // BuildCases derives the parity corpus for one head from the
-// catalogue: exactly one case per class=rejection entry, no more, no
-// fewer. The 1:1 derivation is the "corpus-case count == catalogue
-// count" leg of the ratchet — there is no separate corpus file to
-// drift.
+// catalogue: exactly one case per class=rejection or class=divergence
+// entry, no more, no fewer. The 1:1 derivation is the "corpus-case
+// count == catalogue count" leg of the ratchet — there is no separate
+// corpus file to drift. Divergence entries are included deliberately:
+// being checked on every compat run — with an inverted expected
+// verdict — is the entire point of the class (see doc.go); silently
+// dropping them from the corpus would turn "divergence" into exactly
+// the allow-list the package forbids.
 func BuildCases(cat *Catalogue, head string) ([]Case, error) {
 	var out []Case
 	for _, e := range cat.Entries {
-		if e.Head != head || e.Class != "rejection" {
+		if e.Head != head || (e.Class != ClassRejection && e.Class != ClassDivergence) {
 			continue
 		}
 		if strings.TrimSpace(e.TriggerQuery) == "" {
-			return nil, fmt.Errorf("rejection entry %s has no trigger query", e.Site.Site)
+			return nil, fmt.Errorf("%s entry %s has no trigger query", e.Class, e.Site.Site)
 		}
 		ep := e.Endpoint
 		if ep == "" {
 			ep = DefaultEndpoint(head)
 		}
 		if !ValidEndpoint(head, ep) {
-			return nil, fmt.Errorf("rejection entry %s: endpoint %q invalid for head %s", e.Site.Site, ep, head)
+			return nil, fmt.Errorf("%s entry %s: endpoint %q invalid for head %s", e.Class, e.Site.Site, ep, head)
 		}
-		out = append(out, Case{Name: e.Site.Site, Head: head, Endpoint: ep, Query: e.TriggerQuery})
+		out = append(out, Case{Name: e.Site.Site, Head: head, Endpoint: ep, Query: e.TriggerQuery, Class: e.Class})
 	}
 	return out, nil
 }
@@ -314,10 +354,10 @@ func stringLiteral(e ast.Expr) (string, bool) {
 
 // Generate scans repoRoot and merges the result with the previous
 // catalogue: sites present in prev keep their curated classification
-// (class / trigger query / endpoint / rationale); new sites land with
-// an empty class so the verify test demands curation; sites that
-// disappeared from the source are dropped. Shrink and growth are both
-// therefore deliberate, reviewable diffs.
+// (class / trigger query / endpoint / rationale / tracking issue);
+// new sites land with an empty class so the verify test demands
+// curation; sites that disappeared from the source are dropped.
+// Shrink and growth are both therefore deliberate, reviewable diffs.
 func Generate(repoRoot string, prev *Catalogue) (*Catalogue, error) {
 	sites, err := ScanSites(repoRoot)
 	if err != nil {
@@ -337,6 +377,7 @@ func Generate(repoRoot string, prev *Catalogue) (*Catalogue, error) {
 			e.TriggerQuery = p.TriggerQuery
 			e.Endpoint = p.Endpoint
 			e.Rationale = p.Rationale
+			e.TrackingIssue = p.TrackingIssue
 		}
 		out.Entries = append(out.Entries, e)
 	}

--- a/test/rejection-parity/catalogue.json
+++ b/test/rejection-parity/catalogue.json
@@ -68,8 +68,9 @@
       "head": "logql",
       "site": "internal/logql/label_fns.go:lowerLabelReplace#8cd9f67b",
       "message": "logql: label_replace: %w",
-      "class": "rejection",
-      "trigger_query": "label_replace(rate({app=\"x\"}[5m]), \"d\", \"$dup\", \"src\", \"(?P\u003cdup\u003ea)|(?P\u003cdup\u003eb)\")"
+      "class": "divergence",
+      "trigger_query": "label_replace(rate({app=\"x\"}[5m]), \"d\", \"$dup\", \"src\", \"(?P\u003cdup\u003ea)|(?P\u003cdup\u003eb)\")",
+      "tracking_issue": 1768
     },
     {
       "head": "logql",
@@ -516,8 +517,9 @@
       "head": "promql",
       "site": "internal/promql/label_fns.go:lowerLabelReplace#d11e3df4",
       "message": "promql: label_replace: %w",
-      "class": "rejection",
-      "trigger_query": "label_replace(up, \"d\", \"$dup\", \"src\", \"(?P\u003cdup\u003ea)|(?P\u003cdup\u003eb)\")"
+      "class": "divergence",
+      "trigger_query": "label_replace(up, \"d\", \"$dup\", \"src\", \"(?P\u003cdup\u003ea)|(?P\u003cdup\u003eb)\")",
+      "tracking_issue": 1768
     },
     {
       "head": "promql",

--- a/test/rejection-parity/catalogue.json
+++ b/test/rejection-parity/catalogue.json
@@ -558,8 +558,9 @@
       "head": "promql",
       "site": "internal/promql/lower.go:expHistogramSelectorRouting#bcc398d7",
       "message": "promql: %q is an exponential histogram metric; only histogram_quantile(), histogram_count(), histogram_sum(), and the %q/%q companion selectors are supported",
-      "class": "rejection",
-      "trigger_query": "rate(demo_exp_hist[5m])"
+      "class": "divergence",
+      "trigger_query": "rate(demo_exp_hist[5m])",
+      "tracking_issue": 1759
     },
     {
       "head": "promql",

--- a/test/rejection-parity/catalogue_test.go
+++ b/test/rejection-parity/catalogue_test.go
@@ -68,8 +68,9 @@ func TestCatalogueIsRegenerable(t *testing.T) {
 }
 
 // TestCatalogueEntriesAreClassified is the curation gate: every
-// scanned site must be classified, rejection entries must carry a
-// trigger query + valid endpoint, and internal entries must justify
+// scanned site must be classified, rejection/divergence entries must
+// carry a trigger query + valid endpoint (divergence additionally
+// requires a tracking issue), and internal entries must justify
 // themselves with a rationale. An unclassified entry (the regen
 // default for a new rejection site) fails here — a new deliberate
 // rejection cannot land without a parity-corpus case.
@@ -84,7 +85,7 @@ func TestCatalogueEntriesAreClassified(t *testing.T) {
 		}
 		seen[e.Site.Site] = true
 		switch e.Class {
-		case "rejection":
+		case ClassRejection:
 			if strings.TrimSpace(e.TriggerQuery) == "" {
 				t.Errorf("rejection entry %s has no trigger query", e.Site.Site)
 			}
@@ -98,32 +99,58 @@ func TestCatalogueEntriesAreClassified(t *testing.T) {
 			if e.Rationale != "" {
 				t.Errorf("rejection entry %s carries a rationale — rationales belong to internal entries; a rejection justifies itself via its trigger query", e.Site.Site)
 			}
-		case "internal":
+			if e.TrackingIssue != 0 {
+				t.Errorf("rejection entry %s carries a tracking issue — tracking issues belong to divergence entries", e.Site.Site)
+			}
+		case ClassInternal:
 			if strings.TrimSpace(e.Rationale) == "" {
 				t.Errorf("internal entry %s carries no rationale — every internal classification must justify why the site is not wire-reachable", e.Site.Site)
 			}
 			if e.TriggerQuery != "" || e.Endpoint != "" {
 				t.Errorf("internal entry %s carries trigger query / endpoint — those belong to rejection entries", e.Site.Site)
 			}
+			if e.TrackingIssue != 0 {
+				t.Errorf("internal entry %s carries a tracking issue — tracking issues belong to divergence entries", e.Site.Site)
+			}
+		case ClassDivergence:
+			if strings.TrimSpace(e.TriggerQuery) == "" {
+				t.Errorf("divergence entry %s has no trigger query", e.Site.Site)
+			}
+			ep := e.Endpoint
+			if ep == "" {
+				ep = DefaultEndpoint(e.Head)
+			}
+			if !ValidEndpoint(e.Head, ep) {
+				t.Errorf("divergence entry %s: endpoint %q invalid for head %s", e.Site.Site, ep, e.Head)
+			}
+			if e.Rationale != "" {
+				t.Errorf("divergence entry %s carries a rationale — rationales belong to internal entries; a divergence justifies itself via its trigger query + tracking issue", e.Site.Site)
+			}
+			if e.TrackingIssue <= 0 {
+				t.Errorf("divergence entry %s has no tracking issue — every divergence must cite an open issue tracking closure", e.Site.Site)
+			}
 		default:
-			t.Errorf("entry %s is unclassified (class=%q) — classify as rejection (with trigger query) or internal (with rationale)", e.Site.Site, e.Class)
+			t.Errorf("entry %s is unclassified (class=%q) — classify as rejection (with trigger query), internal (with rationale), or divergence (with trigger query + tracking issue)", e.Site.Site, e.Class)
 		}
 	}
 }
 
 // TestRejectionTriggersExerciseSites is the centrepiece pin: for every
-// class=rejection entry, the trigger query (a) parses with the head's
-// reference parser — proving the rejection is semantic, not a parse
-// error — and (b) fails the head's lowering with an error matching the
-// site's message — proving the trigger actually exercises the
-// catalogued site, so the parity corpus diffs the claim the site makes
-// and not some other failure.
+// class=rejection or class=divergence entry, the trigger query (a)
+// parses with the head's reference parser — proving the rejection is
+// semantic, not a parse error — and (b) fails the head's lowering with
+// an error matching the site's message — proving the trigger actually
+// exercises the catalogued site, so the parity corpus diffs the claim
+// the site makes and not some other failure. Divergence entries share
+// this reachability proof with rejection entries — the two classes
+// only disagree about what the REFERENCE backend does with the same
+// trigger, never about whether cerberus itself rejects it.
 func TestRejectionTriggersExerciseSites(t *testing.T) {
 	t.Parallel()
 
 	cat := loadCatalogue(t)
 	for _, e := range cat.Entries {
-		if e.Class != "rejection" {
+		if e.Class != ClassRejection && e.Class != ClassDivergence {
 			continue
 		}
 		e := e
@@ -140,9 +167,11 @@ func TestRejectionTriggersExerciseSites(t *testing.T) {
 
 // TestParityCorpusMatchesCatalogue pins the third leg of the ratchet:
 // the parity-corpus case set the compat driver runs is derived 1:1
-// from the rejection entries — same count, same site keys — for every
-// head. BuildCases is the same function the driver binary calls, so
-// the corpus cannot drift from the catalogue.
+// from the rejection + divergence entries — same count, same site
+// keys, same class tags — for every head. BuildCases is the same
+// function the driver binary calls, so the corpus cannot drift from
+// the catalogue, and a divergence entry cannot be silently dropped
+// from the set that gets checked.
 func TestParityCorpusMatchesCatalogue(t *testing.T) {
 	t.Parallel()
 
@@ -152,22 +181,26 @@ func TestParityCorpusMatchesCatalogue(t *testing.T) {
 		if err != nil {
 			t.Fatalf("BuildCases(%s): %v", head, err)
 		}
-		var rejections []string
+		var wantNames, wantClasses []string
 		for _, e := range cat.Entries {
-			if e.Head == head && e.Class == "rejection" {
-				rejections = append(rejections, e.Site.Site)
+			if e.Head == head && (e.Class == ClassRejection || e.Class == ClassDivergence) {
+				wantNames = append(wantNames, e.Site.Site)
+				wantClasses = append(wantClasses, e.Class)
 			}
 		}
-		if len(cases) != len(rejections) {
-			t.Fatalf("head %s: %d parity cases for %d rejection entries", head, len(cases), len(rejections))
+		if len(cases) != len(wantNames) {
+			t.Fatalf("head %s: %d parity cases for %d rejection/divergence entries", head, len(cases), len(wantNames))
 		}
 		for i, c := range cases {
-			if c.Name != rejections[i] {
-				t.Fatalf("head %s: case %d is %s, want %s", head, i, c.Name, rejections[i])
+			if c.Name != wantNames[i] {
+				t.Fatalf("head %s: case %d is %s, want %s", head, i, c.Name, wantNames[i])
+			}
+			if c.Class != wantClasses[i] {
+				t.Fatalf("head %s: case %d (%s) has class %s, want %s", head, i, c.Name, c.Class, wantClasses[i])
 			}
 		}
 		if len(cases) == 0 {
-			t.Fatalf("head %s: zero parity cases — the catalogue lost its rejection entries", head)
+			t.Fatalf("head %s: zero parity cases — the catalogue lost its rejection/divergence entries", head)
 		}
 	}
 }

--- a/test/rejection-parity/doc.go
+++ b/test/rejection-parity/doc.go
@@ -17,25 +17,81 @@
 //     `errors.New("<head>: ...")` construction site in the three
 //     lowering packages via go/ast — the mechanical universe of
 //     rejection candidates.
-//  2. catalogue.json classifies every site as either `rejection`
-//     (reachable from a parseable query; carries a minimal
-//     trigger query) or `internal` (defensive / invariant /
-//     error-propagation wrapper; carries a rationale).
+//  2. catalogue.json classifies every site into one of three classes —
+//     `rejection`, `internal`, or `divergence` (see below).
 //  3. The meta-tests in catalogue_test.go pin the three-way ratchet:
 //     scanned-site set == catalogue set (regenerable via
-//     CERBERUS_UPDATE_INVENTORY=1), every `rejection` entry's trigger
-//     query parses AND fails lowering with the site's message, and
-//     the parity-corpus case set is derived 1:1 from the `rejection`
-//     entries via BuildCases.
+//     CERBERUS_UPDATE_INVENTORY=1), every `rejection`/`divergence`
+//     entry's trigger query parses AND fails lowering with the site's
+//     message, and the parity-corpus case set is derived 1:1 from the
+//     `rejection` + `divergence` entries via BuildCases.
 //  4. compatibility/cmd/rejection-parity consumes BuildCases inside
-//     each compat harness and asserts the REFERENCE backend also
-//     rejects every trigger query. Reference accepting is a
-//     wrong-rejection bug to fix at the source — never an allow-list
-//     entry.
+//     each compat harness and, per case, asserts the class's claim:
+//     for `rejection`, that the REFERENCE backend also rejects the
+//     trigger query; for `divergence`, that it ACCEPTS it (see below).
+//     A `rejection` entry whose reference accepts is a wrong-rejection
+//     bug to fix at the source — never an allow-list entry.
+//
+// # The three classes
+//
+//   - `rejection`  — the parity claim is "cerberus and the reference
+//     backend both reject this query". Requires a trigger query (+
+//     endpoint override where needed); forbids a rationale or a
+//     tracking issue.
+//   - `internal`   — the site is not reachable from a parseable query
+//     through the HTTP query endpoints at all (parser-enforced
+//     shapes, internal invariants, %w error-propagation wrappers).
+//     Requires a rationale explaining why; forbids a trigger query,
+//     endpoint, or tracking issue.
+//   - `divergence` — the parity claim is "cerberus rejects this query
+//     AND the reference backend answers it, on purpose, and that gap
+//     is tracked". Requires everything `rejection` requires PLUS an
+//     open GitHub issue number (TrackingIssue) tracking closure.
+//
+// # Why `divergence` is not the allow-list this package forbids
+//
+// The obvious wrong shape for a third class would be "cerberus knows
+// it disagrees with the reference here, so stop checking" — exactly
+// the allow-list mechanism note (4) above forbids, and exactly the
+// failure mode that let the `kind != nil` incident (a real
+// wrong-rejection bug) ship silently before this package existed.
+// `divergence` is deliberately NOT that. It makes three POSITIVE,
+// machine-checked claims, in both directions, every compat run:
+//
+//  1. cerberus still rejects the trigger query — the same
+//     in-process reachability proof TestRejectionTriggersExerciseSites
+//     already runs for `rejection` entries, reused unchanged.
+//  2. the reference backend still accepts it — literally the inverse
+//     of what a `rejection` entry asserts; compatibility/cmd/
+//     rejection-parity's runCase branches on the case's Class and
+//     checks the opposite status-class pairing.
+//  3. an issue in this repository, cited by number, is open and is an
+//     issue rather than a pull request — checked on every
+//     pull_request / push / merge_group by a dedicated forbid-deferral
+//     workflow step, mirroring the same liveness probe
+//     forbid-deferral.mjs already runs for deferral markers.
+//
+// Each claim is a ratchet, not an exemption:
+//
+//   - If someone fixes the divergence (cerberus starts answering),
+//     claim 1 fails — cerberus now returns 2xx for a case the
+//     catalogue says it rejects — and the entry must be deleted.
+//   - If upstream changes to also reject, claim 2 fails — both sides
+//     now return 4xx — and the entry must be reclassified to
+//     `rejection`.
+//   - If the tracking issue is closed while the entry remains, claim 3
+//     fails regardless of what either backend does today.
+//
+// A `divergence` entry can therefore never sit still: it is always
+// either being actively re-verified against both backends, or it is
+// failing the build. That is what distinguishes it from an allow-list
+// entry, which by definition stops anyone from checking again.
 //
 // Adding a new rejection to a lowering therefore requires: a
 // catalogue entry (the regen test fails without it), a trigger query
 // (the exerciser test fails without it), and — by construction — a
 // parity-corpus case the next compat run diffs against the reference
-// backend.
+// backend. Reclassifying a `rejection` to `divergence` additionally
+// requires filing (or citing) an open tracking issue first — the
+// classification test fails without one.
 package rejectionparity


### PR DESCRIPTION
## Summary

Closes #1759.

Adds a third catalogue class, `divergence`, alongside the existing `rejection`
and `internal` in `test/rejection-parity/catalogue.json`. It exists to
correctly classify sites where cerberus *deliberately* rejects a query the
reference backend answers — a real, documented, wire-reachable divergence
that neither existing class fits:

- `rejection` claims "cerberus and the reference both reject this" — wrong for
  a site the reference actually answers.
- `internal` claims "this site is not wire-reachable at all" — wrong for a
  site a real HTTP request can hit.

`divergence` requires everything `rejection` requires (trigger query +
endpoint) plus a `tracking_issue` (an open GitHub issue, in this repository,
tracking closure). It is **not** the allow-list `test/rejection-parity/doc.go`
forbids — see that file's new "Why `divergence` is not the allow-list this
package forbids" section for the three positive, ratcheted claims it makes
every compat run (cerberus still rejects / reference still accepts / issue
still open), each of which fails the build the moment it stops being true.

## Changes

- `test/rejection-parity/catalogue.go` — `ClassDivergence` + `TrackingIssue`
  field; `BuildCases` now derives cases from both `rejection` and `divergence`
  entries, carrying the class through to the driver.
- `test/rejection-parity/catalogue_test.go` — classification + exerciser +
  corpus-matches-catalogue meta-tests updated for the third class.
- `test/rejection-parity/doc.go` — documents all three classes and the
  load-bearing "not an allow-list" argument.
- `compatibility/cmd/rejection-parity/main.go` — `divergenceVerdict` (inverted
  status-pair check vs. `rejection`); `Report.Fatal()` now makes
  `wrong_rejection`, `divergence_resolved`, and `divergence_closed` verdicts
  fail the binary's exit code, which propagates through the unwrapped `set -e`
  in all three `run-*-compatibility.sh` scripts — previously the harness wrote
  these verdicts into the JSON report but always exited 0, so the catalogue
  was a gate in name only.
- `test/rejection-parity/catalogue.json` — reclassifies
  `internal/promql/lower.go:expHistogramSelectorRouting#bcc398d7`
  (`rate(demo_exp_hist[5m])`) from `rejection` to `divergence`, citing #1759.
  Per Decision 3: the rejection itself is correct and intentional (cerberus
  serves `histogram_quantile`/`count`/`sum` + companions for exponential
  histograms and explicitly rejects the rest, because a silent HTTP 200-empty
  is forbidden), but reference Prometheus does answer `rate()` over native
  histograms, so the old `rejection` classification falsely claimed parity.
- `.github/scripts/rejection-parity-divergence-liveness.mjs` (+ paired
  `.test.mjs`) — the liveness half of the `divergence` contract: the offline
  Go meta-tests can only pin that `TrackingIssue` is a positive integer, not
  that the cited issue is still open. This script re-reads the catalogue on
  every run and resolves each cited number through the GitHub API, reusing
  `forbid-deferral.mjs`'s exported `issuesReadability` capability probe
  unchanged. Wired into `forbid-deferral.yml` (the job already has `issues:
  read` and fires on every pull_request/push/merge_group), because that job
  already carries the identical liveness discipline for deferral-marker
  citations — this is the same contract, checked against the catalogue's own
  state instead of a diff.

## Live CI proved the fatal-exit mechanism works — and it found two more bugs

The first CI run against a real reference Prometheus/Loki (`compatibility/prometheus`,
`compatibility/prometheus-forced-route`, `compatibility/prometheus-floor`,
`compatibility/loki`) confirmed both halves of this PR end to end:

- `divergence_confirmed=1` for the exp-histogram entry — reference Prometheus
  really does answer `rate(demo_exp_hist[5m])`, and cerberus still rejects it,
  exactly as Decision 3 predicted.
- The new `Report.Fatal()` gate caught two genuine, previously-silent
  `wrong_rejection` verdicts that pre-date this PR:
  `internal/promql/label_fns.go:lowerLabelReplace#d11e3df4` and
  `internal/logql/label_fns.go:lowerLabelReplace#8cd9f67b`. Both reject
  `label_replace(..., "$dup", ..., "(?P<dup>a)|(?P<dup>b)")` (a replacement
  referencing a capture-group name shared by two regex groups) with 422,
  while reference Prometheus/Loki accept it (200) via Go's
  `Regexp.ExpandString` "first participating group wins" semantics.

Investigated `internal/qlcommon/label_replace.go`'s `captureGroups.resolve`:
the rejection is deliberate, not an outdated validation bug — ClickHouse's
`extractGroups` cannot distinguish "group did not participate in the match"
from "group participated and matched empty", both render as `''`, so there is
no SQL expression that reproduces Go's per-row disambiguation. Confirmed
against Go's own `regexp` package (`regexp.Compile` happily accepts duplicate
subexpression names; `ExpandString` picks the first participating index).
This is a genuine ClickHouse expressiveness gap — filed #1768 with the full
investigation and reclassified both catalogue entries from `rejection` to
`divergence`, citing it.

## Audit

Swept the remaining `rejection`-class entries for other mis-classifications.
Found two candidates via code-comment evidence (not live differential
testing, since no reference Prometheus/Loki/Tempo instance is available in
this environment) — filed rather than reclassified, since the task's own
constraint is "reclassify only what you can substantiate against the
reference's actual behaviour, never bulk-reclassify on suspicion":

- #1765 — `histogram_quantiles()` non-literal phi rejection
  (`internal/promql/histogram_quantile.go:lowerHistogramQuantiles#1cf264f6`)
- #1766 — `topk()`/`bottomk()` mixed-shape computed-K rejection
  (`internal/promql/lower.go:lowerTopKComputed#8af012e4`)

Both doc comments at the cited sites explicitly frame the cerberus-side
restriction as narrower than reference Prometheus's behavior; live-reference
verification is what would confirm and let either be reclassified.

## Test plan

- [x] `go build ./...`
- [x] `go test ./test/rejection-parity/... -v` — all four meta-tests pass,
      including the reclassified entries' exerciser subtests
- [x] `CERBERUS_UPDATE_INVENTORY=1 go test ./test/rejection-parity/... -run TestCatalogueIsRegenerable` —
      confirms every hand-curated entry round-trips through `Generate()`
- [x] `go build ./compatibility/cmd/rejection-parity/...`
- [x] `node --test .github/scripts/rejection-parity-divergence-liveness.test.mjs`
      — 16/16 pass
- [x] `rejection-parity-divergence-liveness.mjs` run live against GitHub —
      3 divergence entries, 2 distinct tracking issues, 0 violations
- [x] lefthook `pre-push` (golangci-lint, forbid-sql-raw, forbid-skip,
      markdownlint, actionlint, commitlint-range) — all green locally
- [x] CI: `compatibility/prometheus` / `-forced-route` / `-floor` /
      `compatibility/loki` — first live end-to-end check of the new
      divergence verdict logic and the fatal-exit mechanism; caught and fixed
      two genuine pre-existing `wrong_rejection` bugs (see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
