### PR TITLE
fix(rejection-parity): reclassify stale lowerHoltWinters internal entries

### DIFF
--- a/test/rejection-parity/catalogue.json
+++ b/test/rejection-parity/catalogue.json
@@ -715,22 +715,22 @@
       "head": "promql",
       "site": "internal/promql/range_fns.go:lowerHoltWinters#0ff3d8b3",
       "message": "promql: holt_winters smoothing factor must be in (0, 1), got %v",
-      "class": "internal",
-      "rationale": "unreachable via the PromQL lowering dispatch: double_exponential_smoothing is gated as experimental at lowerRangeVectorCall (reference-parity reject) before lowerHoltWinters runs, so this boundary check fires only from the package-internal mutation tests that call lowerHoltWinters directly"
+      "class": "rejection",
+      "trigger_query": "double_exponential_smoothing(http_requests_total[10m], 1.5, 0.5)"
     },
     {
       "head": "promql",
       "site": "internal/promql/range_fns.go:lowerHoltWinters#15e82804",
       "message": "promql: holt_winters requires scalar-literal smoothing and trend factors",
-      "class": "internal",
-      "rationale": "unreachable via the PromQL lowering dispatch: double_exponential_smoothing is gated as experimental at lowerRangeVectorCall (reference-parity reject) before lowerHoltWinters runs, so this scalar-literal check fires only from the package-internal mutation tests that call lowerHoltWinters directly"
+      "class": "rejection",
+      "trigger_query": "double_exponential_smoothing(http_requests_total[10m], scalar(up), 0.5)"
     },
     {
       "head": "promql",
       "site": "internal/promql/range_fns.go:lowerHoltWinters#2db9f2aa",
       "message": "promql: holt_winters trend factor must be in (0, 1), got %v",
-      "class": "internal",
-      "rationale": "unreachable via the PromQL lowering dispatch: double_exponential_smoothing is gated as experimental at lowerRangeVectorCall (reference-parity reject) before lowerHoltWinters runs, so this boundary check fires only from the package-internal mutation tests that call lowerHoltWinters directly"
+      "class": "rejection",
+      "trigger_query": "double_exponential_smoothing(http_requests_total[10m], 0.5, 1.5)"
     },
     {
       "head": "promql",


### PR DESCRIPTION
## Summary

`test/rejection-parity/catalogue.json` carried three `class: "internal"` entries for `internal/promql/range_fns.go:lowerHoltWinters` claiming the sites are unreachable via the PromQL lowering dispatch, on the theory that `double_exponential_smoothing` is gated as experimental at `lowerRangeVectorCall` (a reference-parity reject) before `lowerHoltWinters` ever runs.

That gate does not exist. `lowerRangeVectorCall`'s `case "holt_winters", "double_exponential_smoothing":` (`internal/promql/lower.go:2053`) dispatches straight to `lowerHoltWinters` for both spellings, with no experimental-gating in between — confirmed empirically per #1738's repro. The rationale was false from the start; #1456 (subquery-argument threading for `holt_winters`/`predict_linear`/`quantile_over_time`) made the sibling call path in `subquery.go:threadOuterRangeFnScalars` reachable and already classified those equivalent sites `rejection`, which is what made the stale `internal` classification on the plain (non-subquery) call path stand out.

## Classification decision

All three reclassified `internal` → `rejection` (not `divergence`):

- `lowerHoltWinters#0ff3d8b3` (smoothing factor bound) → `double_exponential_smoothing(http_requests_total[10m], 1.5, 0.5)`
- `lowerHoltWinters#15e82804` (scalar-literal requirement) → `double_exponential_smoothing(http_requests_total[10m], scalar(up), 0.5)`
- `lowerHoltWinters#2db9f2aa` (trend factor bound) → `double_exponential_smoothing(http_requests_total[10m], 0.5, 1.5)`

Both cerberus AND the reference reject each trigger query, so the `rejection` class's both-sides-reject contract holds — no tracking issue needed, `divergence` doesn't apply.

**Important caveat (why this "both reject" needs an asterisk):** `compatibility/prometheus/docker-compose.yml` pins `prom/prometheus:v3.11.3` **without** `--enable-feature=promql-experimental-functions`. `double_exponential_smoothing` is an experimental function, so the flag-OFF reference rejects the trigger queries at the parse/function-existence stage — before it would ever evaluate the (0,1) bound or scalar-literal checks cerberus's own validation performs. `compatibility/cmd/rejection-parity`'s `runCase` only compares status class (4xx vs 2xx), never message text, so this still reports `parity` — but that green result only proves *reachability parity* ("both reject a call to this experimental function"), not *guard parity* ("cerberus's specific bound/type checks agree with what the reference would do if the flag were on"). This exact caveat already applies to the two pre-existing `threadOuterRangeFnScalars` siblings from #1456/#1739, which use the identical pattern and already merged as `rejection`. Filed #1770 to track closing that gap properly (reusing the flag-enabled reference the `promql-surface` job already stands up).

## Follow-ups filed

- #1769 — `rejection-parity` has no drift detection for `class: "internal"` rationale claims; #1738 itself is proof a rationale can go stale silently. Symmetric-unreachability-test proposal for the other 158 `internal` entries.
- #1770 — the flag-OFF vacuity documented above: `rejection`-class parity verdicts on experimental-function trigger queries prove reachability, not guard parity.

## Verification

- `CERBERUS_UPDATE_INVENTORY=1 go test ./test/rejection-parity/... -run TestCatalogueIsRegenerable` — zero drift from the mechanical scan (only the three curated fields changed by hand).
- `go test ./test/rejection-parity/...` — full suite green, including `TestRejectionTriggersExerciseSites` for the three reclassified entries and `TestParityCorpusMatchesCatalogue`.

Closes #1738

🤖 Generated with [Claude Code](https://claude.com/claude-code)
