### PR TITLE
fix(rejection-parity): repoint the exp-histogram divergence at its own tracking issue

### DIFF
--- a/test/rejection-parity/catalogue.json
+++ b/test/rejection-parity/catalogue.json
@@ -562,7 +562,7 @@
       "message": "promql: %q is an exponential histogram metric; only histogram_quantile(), histogram_count(), histogram_sum(), and the %q/%q companion selectors are supported",
       "class": "divergence",
       "trigger_query": "rate(demo_exp_hist[5m])",
-      "tracking_issue": 1759
+      "tracking_issue": 1772
     },
     {
       "head": "promql",


### PR DESCRIPTION
## What

`test/rejection-parity/catalogue.json`'s `divergence` entry for `internal/promql/lower.go:expHistogramSelectorRouting#bcc398d7` cited **#1759** as its tracking issue. #1759 is now **closed** — PR #1767 closed it by delivering the divergence-class mechanism it asked for.

But the divergence itself is unresolved: cerberus still rejects `rate()` over an exponential histogram where reference Prometheus answers. So the entry pointed at a dead issue.

A `divergence` entry must always cite an **open** tracking issue — that liveness requirement is what stops the class decaying into an allow-list. The gate failed correctly on PR #1771:

```
#1759 is a closed issue — the divergence it tracked must be re-filed, and the
catalogue entry must cite the new issue
```

## Fix

Repoint at **#1772**, filed to track the divergence rather than the mechanism. Two separate concerns that were conflated in one issue:
- **#1759** — "give the catalogue a way to express this" → delivered by #1767, correctly closed
- **#1772** — "cerberus rejects exp-histogram `rate()` where Prometheus answers" → open, unresolved

## Verification

```
GITHUB_REPOSITORY=tsouza/cerberus node .github/scripts/rejection-parity-divergence-liveness.mjs
  divergence entries: 3
  distinct tracking issues resolved: 2
  violations: 0
```

`go test ./test/rejection-parity/...` passes (all catalogue meta-tests).

## Note

This is the liveness gate working on its first real encounter — it caught a dead citation within hours of shipping, which is exactly what it was built to do. It was blocking every PR that touches the catalogue, so this lands off `main` directly rather than riding along with one of them.