### PR TITLE
refactor(promql): migrate rewriteMetricName onto WireArms classification

### DIFF
--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -1025,26 +1025,45 @@ func selectorAttributesExpr(ctx lowerCtx, s schema.Metrics) chplan.Expr {
 	return canonicalAttributesExpr(base)
 }
 
-// rewriteMetricName returns a copy of matchers where any
-// `__name__=<X>` (MatchEqual) matcher carries the supplied bare name in
-// place of `<X>`. Used by the classic-histogram companion rewrite to
-// strip the `_count` / `_sum` suffix from the `__name__` matcher so the
-// emitted filter resolves against the bare metric name OTel-CH writes.
+// rewriteMetricName returns a copy of matchers where the pinned
+// `__name__` matcher (WireArmWireNamePinned) carries the supplied name
+// in place of its original value. Used by the exp-histogram / classic
+// -histogram companion routing (expHistogramSelectorRouting,
+// resolveSelectorRouting, buildHistogramCompanionArm,
+// buildLiteralNameCompanionArm) to redirect the scan-side `__name__`
+// filter onto whichever physical table's stored name the caller has
+// already resolved — the bare base name for a histogram-table arm, the
+// literal suffixed name for a companion Sum/Gauge arm.
+//
+// This is a TABLE-ROUTING rewrite, not a wire-domain classification
+// decision: unlike WireArms.ResolveName (which trims a caller-supplied
+// wire suffix off a pinned matcher's existing value, or reports
+// DecisionUnsatisfiable when the value doesn't carry it),
+// rewriteMetricName unconditionally substitutes the caller's target
+// name regardless of the matcher's original value. It only shares
+// WireArms's PINNED-MATCHER CLASSIFICATION (m.Name == "__name__" &&
+// m.Type == MatchEqual) — the exact predicate #1756 centralized after
+// finding it reimplemented, subtly-inconsistently, at multiple call
+// sites (see wireArms's doc comment). Deriving that classification from
+// wireArms here, instead of re-checking m.Name/m.Type inline, is what
+// #1761 migrates: this was the fourth independent reimplementation of
+// that same pinned-name predicate.
 //
 // Non-`__name__` matchers and non-Equal `__name__` matchers (e.g.
-// `__name__=~"foo|bar"`) flow through unchanged: the bare-name strip
-// only applies to a single equality matcher, which is the only shape
+// `__name__=~"foo|bar"`) flow through unchanged: the rewrite only
+// applies to a single equality matcher, which is the only shape
 // `metricNameFromMatchers` recognises in the first place.
 //
 // Copy-on-write semantics mirror stripBucketSuffix: a fresh slice +
 // fresh matcher are allocated, the input is never mutated. The parser
 // can reuse the matcher slice across lowering passes and a mutation
 // here would silently bleed back into later passes.
-func rewriteMetricName(matchers []*labels.Matcher, bareName string) []*labels.Matcher {
+func rewriteMetricName(matchers []*labels.Matcher, name string) []*labels.Matcher {
 	out := make([]*labels.Matcher, len(matchers))
+	w := wireArms(matchers)
 	for i, m := range matchers {
-		if m.Name == model.MetricNameLabel && m.Type == labels.MatchEqual && m.Value != bareName {
-			copied, err := labels.NewMatcher(m.Type, m.Name, bareName)
+		if w.Arms[i] == WireArmWireNamePinned && m.Value != name {
+			copied, err := labels.NewMatcher(m.Type, m.Name, name)
 			if err != nil {
 				out[i] = m
 				continue


### PR DESCRIPTION
## What

`rewriteMetricName` (`internal/promql/lower.go`) is the fourth independent
reimplementation of the "is this the pinned `__name__` matcher" predicate that
#1756's `wireArms`/`WireArms` classifier was built to centralize — it
re-checked `m.Name == model.MetricNameLabel && m.Type == labels.MatchEqual`
inline instead of consuming the shared classification.

This migrates it: `rewriteMetricName` now calls `wireArms(matchers)` and
tests `w.Arms[i] == WireArmWireNamePinned` to find the matcher to rewrite,
instead of re-deriving the pin-ness check.

## What `rewriteMetricName` encodes, and why it stays its own helper

`rewriteMetricName` is a **table-routing** rewrite (used by
`expHistogramSelectorRouting`, `resolveSelectorRouting`,
`buildHistogramCompanionArm`, and `buildLiteralNameCompanionArm` — 4 call
sites) that unconditionally substitutes a caller-supplied name onto the
pinned `__name__` matcher, regardless of the matcher's original value. This
is a genuinely different domain from `WireArms.ResolveName`, which trims a
caller-supplied *wire suffix* off a pinned matcher's *existing* value (or
reports `DecisionUnsatisfiable` when it isn't present) — a suffix-based
wire-vs-storage-name decision, not a "rename to whatever the caller already
resolved." Forcing `rewriteMetricName` through `ResolveName` would be the
wrong fit; #1761's own investigation reached the same conclusion. So this PR
extends nothing on `WireArms` — it migrates only the pinned-matcher
*classification* (the part that actually was duplicated), and leaves the
table-routing rewrite itself local, per the issue's own analysis.

## Acceptance bar: byte-identical goldens

This is a pure refactor. Confirmed zero churn:

```
GOLDEN_UPDATE=1 go test -count=1 ./internal/promql/... ./internal/chsql/... \
  ./internal/optimizer/... ./internal/logql/... ./internal/traceql/...
GOLDEN_UPDATE=1 go test -tags chdb -count=1 ./internal/promql/... ./test/spec/...
```

Both runs are clean — `git status` shows only the one hand-edited file
(`internal/promql/lower.go`); no `test/spec/**` fixture changed, including
the chdb-tagged `-- expected_rows --` cells.

## Performance invariant

Unaffected — the rewrite still produces a `labels.NewMatcher(m.Type, m.Name,
name)` (`MatchEqual`), which downstream still lowers to a bare-column
`MetricName =` predicate. Only the *detection* of which matcher to rewrite
changed (now delegated to `wireArms`'s classification), not what gets
emitted.

## `exemplarsTableFor` / #1705 — NOT migrated here

I checked whether `exemplarsTableFor` (`internal/api/prom/exemplars.go`,
tracked as #1705) could ride along. It cannot, cleanly, and #1705's own
recorded decision comment already says so explicitly: **"The fix is not
'fold into `WireArms`'"** — `exemplarsTableFor` takes a bare metric-name
*string*, not a matcher list, and picks a physical table via suffix
heuristics; it's a `schema.Metrics.TablesFor`-shaped resolver, not a
`WireArms`-shaped one. #1705's recorded fix is to replace the hand-rolled
suffix chain with `s.TablesFor(metricName)` and teach
`chsql.EmitQueryExemplars` to fan out via `UnionAll` across the resulting
table candidates — a genuine **behaviour change** (previously-single-table
exemplar queries start fanning out for ambiguous names) requiring new/updated
TXTAR goldens, not byte-identical ones. Mixing that into this PR's
byte-identical-goldens acceptance bar would make the diff unreviewable as
"no behaviour change" and risks masking a real regression check. #1705
stays open, tracked separately, exactly as its own decision comment already
lays out.

Closes #1761