### PR TITLE
feat(rejection-parity): ratchet the divergence class's count and age

### DIFF
--- a/test/rejection-parity/catalogue.go
+++ b/test/rejection-parity/catalogue.go
@@ -71,9 +71,11 @@ type Entry struct {
 	//                  the trigger query, the reference backend answers
 	//                  it, and an open GitHub issue tracks closing the
 	//                  gap. Requires TriggerQuery (+ Endpoint) exactly
-	//                  like "rejection", plus TrackingIssue; forbids
-	//                  Rationale. See doc.go for why this is a ratchet
-	//                  and not the allow-list the package forbids.
+	//                  like "rejection", plus TrackingIssue and Since;
+	//                  forbids Rationale. See doc.go for why this is a
+	//                  ratchet and not the allow-list the package
+	//                  forbids, and for the two mechanisms (a count
+	//                  ceiling + an age cap) that keep it that way.
 	//
 	// The verify test fails on any other value (including ""), so a
 	// new rejection site cannot land unclassified.
@@ -106,6 +108,15 @@ type Entry struct {
 	// be deleted (cerberus was fixed) or re-filed against a fresh
 	// issue, never left pointing at a closed one.
 	TrackingIssue int `json:"tracking_issue,omitempty"`
+
+	// Since (class=divergence) is the date, in divergenceDateLayout
+	// ("2026-01-02"), the entry was first classified as a divergence —
+	// backdated to the PR that introduced or reclassified it, never
+	// reset by later edits. TestDivergenceEntriesRespectAgeCap fails
+	// once now minus Since exceeds divergenceStaleAfter, so a
+	// divergence cannot sit past its age cap silently: see
+	// divergence_ratchet.go and doc.go.
+	Since string `json:"since,omitempty"`
 }
 
 // Catalogue is the checked-in JSON artifact shape
@@ -378,6 +389,7 @@ func Generate(repoRoot string, prev *Catalogue) (*Catalogue, error) {
 			e.Endpoint = p.Endpoint
 			e.Rationale = p.Rationale
 			e.TrackingIssue = p.TrackingIssue
+			e.Since = p.Since
 		}
 		out.Entries = append(out.Entries, e)
 	}

--- a/test/rejection-parity/catalogue.json
+++ b/test/rejection-parity/catalogue.json
@@ -564,7 +564,7 @@
       "message": "promql: %q is an exponential histogram metric; only histogram_quantile(), histogram_count(), histogram_sum(), and the %q/%q companion selectors are supported",
       "class": "divergence",
       "trigger_query": "rate(demo_exp_hist[5m])",
-      "tracking_issue": 1759,
+      "tracking_issue": 1777,
       "since": "2026-08-05"
     },
     {

--- a/test/rejection-parity/catalogue.json
+++ b/test/rejection-parity/catalogue.json
@@ -70,7 +70,8 @@
       "message": "logql: label_replace: %w",
       "class": "divergence",
       "trigger_query": "label_replace(rate({app=\"x\"}[5m]), \"d\", \"$dup\", \"src\", \"(?P\u003cdup\u003ea)|(?P\u003cdup\u003eb)\")",
-      "tracking_issue": 1768
+      "tracking_issue": 1768,
+      "since": "2026-08-05"
     },
     {
       "head": "logql",
@@ -519,7 +520,8 @@
       "message": "promql: label_replace: %w",
       "class": "divergence",
       "trigger_query": "label_replace(up, \"d\", \"$dup\", \"src\", \"(?P\u003cdup\u003ea)|(?P\u003cdup\u003eb)\")",
-      "tracking_issue": 1768
+      "tracking_issue": 1768,
+      "since": "2026-08-05"
     },
     {
       "head": "promql",
@@ -562,7 +564,8 @@
       "message": "promql: %q is an exponential histogram metric; only histogram_quantile(), histogram_count(), histogram_sum(), and the %q/%q companion selectors are supported",
       "class": "divergence",
       "trigger_query": "rate(demo_exp_hist[5m])",
-      "tracking_issue": 1759
+      "tracking_issue": 1759,
+      "since": "2026-08-05"
     },
     {
       "head": "promql",

--- a/test/rejection-parity/catalogue_test.go
+++ b/test/rejection-parity/catalogue_test.go
@@ -102,6 +102,9 @@ func TestCatalogueEntriesAreClassified(t *testing.T) {
 			if e.TrackingIssue != 0 {
 				t.Errorf("rejection entry %s carries a tracking issue — tracking issues belong to divergence entries", e.Site.Site)
 			}
+			if e.Since != "" {
+				t.Errorf("rejection entry %s carries a since date — since dates belong to divergence entries", e.Site.Site)
+			}
 		case ClassInternal:
 			if strings.TrimSpace(e.Rationale) == "" {
 				t.Errorf("internal entry %s carries no rationale — every internal classification must justify why the site is not wire-reachable", e.Site.Site)
@@ -111,6 +114,9 @@ func TestCatalogueEntriesAreClassified(t *testing.T) {
 			}
 			if e.TrackingIssue != 0 {
 				t.Errorf("internal entry %s carries a tracking issue — tracking issues belong to divergence entries", e.Site.Site)
+			}
+			if e.Since != "" {
+				t.Errorf("internal entry %s carries a since date — since dates belong to divergence entries", e.Site.Site)
 			}
 		case ClassDivergence:
 			if strings.TrimSpace(e.TriggerQuery) == "" {
@@ -128,6 +134,9 @@ func TestCatalogueEntriesAreClassified(t *testing.T) {
 			}
 			if e.TrackingIssue <= 0 {
 				t.Errorf("divergence entry %s has no tracking issue — every divergence must cite an open issue tracking closure", e.Site.Site)
+			}
+			if _, err := time.Parse(divergenceDateLayout, e.Since); err != nil {
+				t.Errorf("divergence entry %s has an invalid since date %q (want %s): %v — every divergence must record when it was first classified, so the age cap can measure it", e.Site.Site, e.Since, divergenceDateLayout, err)
 			}
 		default:
 			t.Errorf("entry %s is unclassified (class=%q) — classify as rejection (with trigger query), internal (with rationale), or divergence (with trigger query + tracking issue)", e.Site.Site, e.Class)

--- a/test/rejection-parity/divergence-ceiling.json
+++ b/test/rejection-parity/divergence-ceiling.json
@@ -1,0 +1,3 @@
+{
+  "max_entries": 3
+}

--- a/test/rejection-parity/divergence_ratchet.go
+++ b/test/rejection-parity/divergence_ratchet.go
@@ -1,0 +1,143 @@
+package rejectionparity
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+)
+
+// This file is the two mechanisms that keep class=divergence from decaying
+// into the allow-list this package forbids (see doc.go): a monotonic count
+// ceiling and a per-entry age cap. Both are enforced by
+// divergence_ratchet_test.go; this file holds the pure, independently
+// testable logic.
+
+// divergenceDateLayout is the on-disk format of Entry.Since — a bare date,
+// because a divergence's age is measured in days, not seconds.
+const divergenceDateLayout = "2006-01-02"
+
+// divergenceCeilingPath is the checked-in ratchet artifact path (relative to
+// this package's directory, mirroring cataloguePath).
+const divergenceCeilingPath = "divergence-ceiling.json"
+
+// divergenceStaleAfter bounds how long an entry may carry class=divergence
+// before TestDivergenceEntriesRespectAgeCap forces a conscious re-decision.
+// 90 days is long enough to cover a normal fix-it-properly cycle (file,
+// design, implement, land — the kind of change #1768's label_replace
+// duplicate-capture-group divergence needs, since closing it means moving
+// regex expansion from ClickHouse's extractGroups to Go) but short enough
+// that an entry cannot quietly become permanent: at the 90-day mark a human
+// has to look at it again and choose fix, won't-fix, or a deliberate,
+// acknowledged ceiling bump — never a silent extension.
+const divergenceStaleAfter = 90 * 24 * time.Hour
+
+// DivergenceCeiling is the checked-in ratchet artifact
+// (test/rejection-parity/divergence-ceiling.json): the maximum number of
+// class=divergence entries the catalogue may carry.
+type DivergenceCeiling struct {
+	MaxEntries int `json:"max_entries"`
+}
+
+// LoadDivergenceCeiling reads + parses the checked-in ceiling file.
+func LoadDivergenceCeiling(path string) (*DivergenceCeiling, error) {
+	raw, err := os.ReadFile(path) //nolint:gosec // repo-relative artifact path
+	if err != nil {
+		return nil, err
+	}
+	var c DivergenceCeiling
+	if err := json.Unmarshal(raw, &c); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	return &c, nil
+}
+
+// MarshalDivergenceCeiling renders the canonical on-disk JSON form (2-space
+// indent + trailing newline), mirroring MarshalCatalogue.
+func MarshalDivergenceCeiling(c *DivergenceCeiling) ([]byte, error) {
+	b, err := json.MarshalIndent(c, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(b, '\n'), nil
+}
+
+// CountDivergenceEntries counts the class=divergence entries in cat.
+func CountDivergenceEntries(cat *Catalogue) int {
+	n := 0
+	for _, e := range cat.Entries {
+		if e.Class == ClassDivergence {
+			n++
+		}
+	}
+	return n
+}
+
+// CheckDivergenceCeiling reports an error when count exceeds ceiling. This
+// is the enforcement half of the ratchet: it fires whether the excess came
+// from a new divergence entry landing without a hand-edited ceiling bump, or
+// (defensively) from a ceiling file update trying to raise the number on its
+// own — NextDivergenceCeiling never returns a value this check would reject.
+func CheckDivergenceCeiling(count, ceiling int) error {
+	if count > ceiling {
+		return fmt.Errorf(
+			"catalogue carries %d class=divergence entries, exceeding the committed ceiling of %d in %s — "+
+				"the count may never increase silently: bump max_entries by hand to %d (or higher) as a "+
+				"deliberate, reviewable line in this PR's diff, acknowledging the new divergence rather than "+
+				"letting the ratchet absorb it",
+			count, ceiling, divergenceCeilingPath, count,
+		)
+	}
+	return nil
+}
+
+// NextDivergenceCeiling computes the ratcheted ceiling for the
+// CERBERUS_UPDATE_INVENTORY regen path: it tightens the ceiling down to
+// match count for free, but REFUSES to raise it — count > existing is
+// returned as an error rather than a larger number, because an increase
+// must be a hand-edited line a reviewer sees, never a tool's silent output
+// (the same asymmetry coverage-summary.mjs's nextFloors enforces in the
+// opposite direction for a floor).
+func NextDivergenceCeiling(count, existing int) (int, error) {
+	if count > existing {
+		return 0, fmt.Errorf(
+			"catalogue carries %d class=divergence entries, exceeding the committed ceiling of %d in %s — "+
+				"regeneration cannot fix that by raising the ceiling: edit max_entries to %d by hand so the "+
+				"increase is a reviewable line in the diff",
+			count, existing, divergenceCeilingPath, count,
+		)
+	}
+	return count, nil
+}
+
+// CheckDivergenceAge reports an error when e (class=divergence) has sat open
+// longer than divergenceStaleAfter as of now, or when its Since date is
+// unparseable. The message spells out the three legitimate remedies — fix
+// it, close it won't-fix with recorded reasoning, or a deliberate,
+// acknowledged ceiling bump — because the wrong remedy (quietly extending
+// Since) is exactly the allow-list decay doc.go warns against. A divergence
+// can be real, correct, and expensive to close (see #1768: ClickHouse's
+// extractGroups cannot distinguish "group did not participate" from
+// "participated but matched empty", the exact semantic Go's ExpandString
+// relies on — closing it means moving the computation to Go); the cap does
+// not dispute that, it only forces the decision to stay conscious.
+func CheckDivergenceAge(e Entry, now time.Time) error {
+	since, err := time.Parse(divergenceDateLayout, e.Since)
+	if err != nil {
+		return fmt.Errorf("divergence entry %s has an unparseable since date %q (want %s): %w",
+			e.Site.Site, e.Since, divergenceDateLayout, err)
+	}
+	age := now.Sub(since)
+	if age > divergenceStaleAfter {
+		return fmt.Errorf(
+			"divergence entry %s (tracking #%d) has sat open %s since %s, past the %s age cap — a divergence "+
+				"does not get to decay into a permanent allow-list entry silently. Pick one, in this PR: fix "+
+				"the underlying rejection so the entry can be deleted; close #%d as won't-fix with the reasoning "+
+				"recorded there and delete the entry; or make a deliberate, acknowledged bump (a hand-edited "+
+				"Since date with fresh justification, or a ceiling increase) so the extension is a reviewable "+
+				"line in the diff. Never quietly push the deadline out",
+			e.Site.Site, e.TrackingIssue, age.Round(time.Hour), e.Since, divergenceStaleAfter, e.TrackingIssue,
+		)
+	}
+	return nil
+}

--- a/test/rejection-parity/divergence_ratchet_test.go
+++ b/test/rejection-parity/divergence_ratchet_test.go
@@ -1,0 +1,151 @@
+package rejectionparity
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+// TestDivergenceCeilingRatchet is the monotonic-count leg: the catalogue's
+// class=divergence entries may never exceed the committed ceiling in
+// divergence-ceiling.json without a hand-edited bump to that file in the
+// same diff. CERBERUS_UPDATE_INVENTORY=1 (the same env-var convention
+// TestCatalogueIsRegenerable uses, already wired into `just
+// update-parity-ledgers` / `just update-golden`) tightens the ceiling down
+// to match a decrease for free; it refuses to raise the ceiling to match an
+// increase, because that must be a reviewable line a human wrote, never a
+// tool's silent output.
+func TestDivergenceCeilingRatchet(t *testing.T) {
+	t.Parallel()
+
+	cat := loadCatalogue(t)
+	count := CountDivergenceEntries(cat)
+	ceiling, err := LoadDivergenceCeiling(divergenceCeilingPath)
+	if err != nil {
+		t.Fatalf("load %s: %v", divergenceCeilingPath, err)
+	}
+
+	if os.Getenv("CERBERUS_UPDATE_INVENTORY") != "" {
+		next, err := NextDivergenceCeiling(count, ceiling.MaxEntries)
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+		if next == ceiling.MaxEntries {
+			t.Logf("%s already matches (%d)", divergenceCeilingPath, next)
+			return
+		}
+		want, err := MarshalDivergenceCeiling(&DivergenceCeiling{MaxEntries: next})
+		if err != nil {
+			t.Fatalf("MarshalDivergenceCeiling: %v", err)
+		}
+		if err := os.WriteFile(divergenceCeilingPath, want, 0o644); err != nil {
+			t.Fatalf("write %s: %v", divergenceCeilingPath, err)
+		}
+		t.Logf("tightened %s: %d -> %d", divergenceCeilingPath, ceiling.MaxEntries, next)
+		return
+	}
+
+	if err := CheckDivergenceCeiling(count, ceiling.MaxEntries); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestDivergenceCeilingRatchetCatchesViolatingInput proves the ceiling gate
+// is not hollow: it must reject a count over the ceiling and refuse to raise
+// the ceiling automatically, while still passing the happy paths (at the
+// ceiling, and with slack below it) that CI runs every day.
+func TestDivergenceCeilingRatchetCatchesViolatingInput(t *testing.T) {
+	t.Parallel()
+
+	if err := CheckDivergenceCeiling(4, 3); err == nil {
+		t.Fatal("CheckDivergenceCeiling(4, 3): expected an error, count exceeds the ceiling")
+	}
+	if err := CheckDivergenceCeiling(3, 3); err != nil {
+		t.Fatalf("CheckDivergenceCeiling(3, 3): expected the at-ceiling happy path to pass, got %v", err)
+	}
+	if err := CheckDivergenceCeiling(2, 3); err != nil {
+		t.Fatalf("CheckDivergenceCeiling(2, 3): expected slack below the ceiling to pass, got %v", err)
+	}
+
+	if _, err := NextDivergenceCeiling(4, 3); err == nil {
+		t.Fatal("NextDivergenceCeiling(4, 3): expected an error, regeneration must not raise the ceiling automatically")
+	}
+	if next, err := NextDivergenceCeiling(2, 3); err != nil || next != 2 {
+		t.Fatalf("NextDivergenceCeiling(2, 3): expected (2, nil) — a decrease tightens for free, got (%d, %v)", next, err)
+	}
+	if next, err := NextDivergenceCeiling(3, 3); err != nil || next != 3 {
+		t.Fatalf("NextDivergenceCeiling(3, 3): expected (3, nil) — no movement when already exact, got (%d, %v)", next, err)
+	}
+}
+
+// TestDivergenceEntriesRespectAgeCap is the age-cap leg: no class=divergence
+// entry in the checked-in catalogue may silently outlive divergenceStaleAfter.
+// This test is wall-clock-driven by design — see divergence_ratchet.go's
+// CheckDivergenceAge doc comment and doc.go: an entry aging past the cap
+// (including one that is real, correct, and expensive to close, like
+// #1768's label_replace duplicate-capture-group divergence) is meant to
+// force a conscious re-decision, not to be treated as flake.
+func TestDivergenceEntriesRespectAgeCap(t *testing.T) {
+	t.Parallel()
+
+	cat := loadCatalogue(t)
+	now := time.Now()
+	for _, e := range cat.Entries {
+		if e.Class != ClassDivergence {
+			continue
+		}
+		if err := CheckDivergenceAge(e, now); err != nil {
+			t.Error(err)
+		}
+	}
+}
+
+// TestDivergenceAgeCapCatchesViolatingInput proves the age gate is not
+// hollow: it must reject an entry past the threshold and an unparseable
+// Since date, while passing a fresh entry and one sitting exactly at the
+// boundary.
+func TestDivergenceAgeCapCatchesViolatingInput(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 5, 0, 0, 0, 0, time.UTC)
+
+	stale := Entry{
+		Site:          Site{Site: "synthetic/stale"},
+		Class:         ClassDivergence,
+		Since:         now.Add(-divergenceStaleAfter - 24*time.Hour).Format(divergenceDateLayout),
+		TrackingIssue: 1,
+	}
+	if err := CheckDivergenceAge(stale, now); err == nil {
+		t.Fatal("CheckDivergenceAge(stale): expected an error, entry is past the age cap")
+	}
+
+	fresh := Entry{
+		Site:          Site{Site: "synthetic/fresh"},
+		Class:         ClassDivergence,
+		Since:         now.Add(-24 * time.Hour).Format(divergenceDateLayout),
+		TrackingIssue: 1,
+	}
+	if err := CheckDivergenceAge(fresh, now); err != nil {
+		t.Fatalf("CheckDivergenceAge(fresh): expected the happy path to pass, got %v", err)
+	}
+
+	boundary := Entry{
+		Site:          Site{Site: "synthetic/boundary"},
+		Class:         ClassDivergence,
+		Since:         now.Add(-divergenceStaleAfter).Format(divergenceDateLayout),
+		TrackingIssue: 1,
+	}
+	if err := CheckDivergenceAge(boundary, now); err != nil {
+		t.Fatalf("CheckDivergenceAge(boundary): expected an entry exactly at the cap to pass, got %v", err)
+	}
+
+	unparseable := Entry{
+		Site:          Site{Site: "synthetic/unparseable"},
+		Class:         ClassDivergence,
+		Since:         "not-a-date",
+		TrackingIssue: 1,
+	}
+	if err := CheckDivergenceAge(unparseable, now); err == nil {
+		t.Fatal("CheckDivergenceAge(unparseable): expected an error, since date does not parse")
+	}
+}

--- a/test/rejection-parity/doc.go
+++ b/test/rejection-parity/doc.go
@@ -87,6 +87,42 @@
 // failing the build. That is what distinguishes it from an allow-list
 // entry, which by definition stops anyone from checking again.
 //
+// # Why that alone is not enough, and the two mechanisms that close the gap
+//
+// The three claims above keep every EXISTING entry truthful, but they
+// say nothing about the SET of entries: nothing stops it from growing
+// without bound, and nothing stops an individual entry from sitting
+// behind a permanently-open tracking issue forever. Two entries is a
+// debt register; twenty is a parking lot wearing a better name — the
+// allow-list dynamic this package forbids, arrived at from the other
+// direction. divergence_ratchet.go adds the missing pressure with two
+// independent mechanisms, both enforced by divergence_ratchet_test.go:
+//
+//  1. A monotonic count ceiling (divergence-ceiling.json). The number
+//     of class=divergence entries may never increase without a
+//     hand-edited bump to that file in the SAME diff —
+//     CheckDivergenceCeiling fails the build otherwise. A decrease
+//     (an entry gets fixed or reclassified) is free and self-tightens:
+//     CERBERUS_UPDATE_INVENTORY=1 (the same regen convention
+//     TestCatalogueIsRegenerable uses) lowers the ceiling to match, but
+//     — mirroring test/coverage-floor.json's floor ratchet in the
+//     opposite direction — NextDivergenceCeiling refuses to RAISE it
+//     automatically. An increase is only ever a reviewable line a human
+//     wrote.
+//  2. A per-entry age cap (Entry.Since + divergenceStaleAfter).
+//     CheckDivergenceAge fails once an entry has sat open past the
+//     threshold, forcing a conscious re-decision instead of permanent
+//     silent tracking: fix the underlying rejection, close the
+//     tracking issue as won't-fix with the reasoning recorded there, or
+//     make a deliberate, acknowledged bump. This is expected to
+//     eventually fire on a divergence that is real, correct, and
+//     genuinely expensive to close — see #1768, where closing the
+//     label_replace duplicate-capture-group gap likely means moving
+//     regex expansion from ClickHouse's extractGroups to Go — and that
+//     is the point: the cap does not dispute the divergence, it only
+//     refuses to let it become permanent without someone looking at it
+//     again.
+//
 // Adding a new rejection to a lowering therefore requires: a
 // catalogue entry (the regen test fails without it), a trigger query
 // (the exerciser test fails without it), and — by construction — a


### PR DESCRIPTION
## Summary

PR #1767 added the `divergence` class to `test/rejection-parity` (cerberus deliberately rejects, the reference backend accepts, tracked by an open GitHub issue) — truthful and re-verified every compat run, but with nothing stopping the *set* of entries from growing unbounded or an individual entry from sitting behind a permanently-open issue forever. Two entries is a debt register; twenty is a parking lot wearing a better name — the exact allow-list dynamic this package forbids, arrived at from the other direction. This PR closes that gap with two independent, hand-edit-required gates.

## What's added

**1. A monotonic count ceiling** — `test/rejection-parity/divergence-ceiling.json` (`{"max_entries": 3}`, matching the current real count) + `CheckDivergenceCeiling`/`NextDivergenceCeiling` in the new `divergence_ratchet.go`. This deliberately mirrors `test/coverage-floor.json`'s ratchet in the opposite direction: `coverage-summary.mjs`'s `nextFloors` raises a floor (a minimum) automatically but refuses to lower it; here, `NextDivergenceCeiling` lowers a ceiling (a maximum) automatically — via the same `CERBERUS_UPDATE_INVENTORY=1` regen convention `TestCatalogueIsRegenerable` already uses — but refuses to raise it. A new divergence entry can only land alongside a hand-edited, reviewable bump to `max_entries` in the same diff.

Implemented as plain Go (not a new `.mjs` CI script) because, unlike the coverage/compat ratchets which consume CI-produced artifacts, `catalogue.json` is entirely Go-native with its own established Go-test ratchet convention already wired into `just update-parity-ledgers` / `just update-golden` — this reuses that shape rather than duplicating it.

**2. A per-entry age cap** — a new `Entry.Since` field (date the entry was first classified as `divergence`, format `2006-01-02`) + `divergenceStaleAfter = 90 * 24 * time.Hour` + `CheckDivergenceAge`. 90 days is long enough to cover a normal fix-it-properly cycle (file, design, implement, land) but short enough that an entry can't quietly become permanent — at the 90-day mark a human has to look at it again and pick: fix the underlying rejection, close the tracking issue as won't-fix with reasoning recorded there, or make a deliberate, acknowledged bump. The failure message spells out exactly those three remedies and explicitly forbids the fourth (quietly extending `Since`).

This is expected to eventually fire on #1768's label_replace duplicate-named-capture-group divergence — a real, correct, and genuinely expensive-to-close gap (ClickHouse's `extractGroups` cannot distinguish "group did not participate" from "participated but matched empty," the exact semantic Go's `ExpandString` relies on; closing it likely means moving regex expansion from ClickHouse to Go). That's intentional: the cap doesn't dispute the divergence, it only refuses to let it become permanent without someone consciously re-deciding.

**3. Existing entries backdated, not reset to today** — all three current `divergence` entries get `"since": "2026-08-05"`:
- `internal/promql/lower.go:expHistogramSelectorRouting` (#1759) — backdated to PR #1750 (63d23377), which introduced it.
- `internal/logql/label_fns.go:lowerLabelReplace` and `internal/promql/label_fns.go:lowerLabelReplace` (#1768) — backdated to PR #1767 (c421cb50), which reclassified them from `rejection` to `divergence`.

Both PRs landed the same day (2026-08-05) in this timeline, so all three share that date, but the mechanism backdates to the actual introducing/reclassifying commit, not "today" as a matter of habit.

**4. `doc.go`** gets a new section ("Why that alone is not enough, and the two mechanisms that close the gap") explaining both mechanisms as load-bearing prose for future readers, plus updated field docs on `Entry.Class`/`Entry.Since` in `catalogue.go`.

**5. Both gates are proven non-hollow.** `divergence_ratchet_test.go` adds, alongside the real-catalogue checks:
- `TestDivergenceCeilingRatchetCatchesViolatingInput` — asserts `CheckDivergenceCeiling(4, 3)` errors, `(3,3)`/`(2,3)` pass; `NextDivergenceCeiling(4,3)` errors, `(2,3)`→`(2,nil)`, `(3,3)`→`(3,nil)`.
- `TestDivergenceAgeCapCatchesViolatingInput` — synthetic entries: 91-days-old errors, 1-day-old passes, exactly-90-days-old passes (boundary is inclusive), unparseable `Since` errors.

`TestCatalogueEntriesAreClassified` also gained checks that `rejection`/`internal` entries never carry a `Since` (it's divergence-only) and that every `divergence` entry's `Since` parses.

## Test plan

- [x] `go build ./test/rejection-parity/...` / `go vet ./test/rejection-parity/...`
- [x] `go test ./test/rejection-parity/...` — all existing + new tests pass, including `TestCatalogueIsRegenerable` (the hand-added `since` fields are byte-identical to what regeneration produces)
- [ ] CI: `check`, `lint`, `forbid-skip`, `forbid-deferral`, `pr-body`, `coverage`, `mutation`, `compatibility/*`, `property`, `strict-scan`, `CodeQL`

Closes #1773