### PR TITLE
fix(compat): run the rejection-parity reference flag-on and inside the fixture window

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -748,10 +748,10 @@ jobs:
     # Reference-backed full-surface PromQL rejection-completeness gate (#106).
     #
     # Stands up a SECOND reference Prometheus — the same pinned
-    # prom/prometheus tag as compatibility/prometheus, but started WITH
-    # --enable-feature=promql-experimental-functions (the standard
-    # prometheus job deliberately runs flag-OFF for the showcase parity
-    # contract, so this is a distinct target). It then drives every
+    # prom/prometheus tag as compatibility/prometheus, with the same
+    # --enable-feature=promql-experimental-functions surface, but with no
+    # ClickHouse / seed / cerberus alongside it (this job's verdict is
+    # parse + type validation only). It then drives every
     # parser.Functions symbol + the two experimental aggregators through
     # the flag-enabled reference's HTTP /api/v1/query and asserts that no
     # PromQL function the reference ACCEPTS is silently rejected by

--- a/compatibility/cmd/rejection-parity/main.go
+++ b/compatibility/cmd/rejection-parity/main.go
@@ -143,10 +143,15 @@ func run() error {
 		cerbURL   = flag.String("cerberus", "", "cerberus base URL")
 		report    = flag.String("report", "", "JSON report output path")
 		timeout   = flag.Duration("timeout", 30*time.Second, "per-request HTTP timeout")
+		evalTime  = flag.String("eval-time", "", "RFC3339 evaluation time (default: now) — point it inside the harness fixture's window so data-dependent reference guards fire")
 	)
 	flag.Parse()
 	if *head == "" || *refURL == "" || *cerbURL == "" || *report == "" {
 		return fmt.Errorf("-head, -ref, -cerberus and -report are all required")
+	}
+	now, err := resolveEvalTime(*evalTime)
+	if err != nil {
+		return err
 	}
 
 	cat, err := rejectionparity.LoadCatalogue(*catalogue)
@@ -162,7 +167,6 @@ func run() error {
 	}
 
 	client := &http.Client{Timeout: *timeout}
-	now := time.Now().UTC()
 	rep := Report{Head: *head, Total: len(cases)}
 	for _, c := range cases {
 		res := runCase(client, c, *refURL, *cerbURL, now)
@@ -280,9 +284,36 @@ func divergenceVerdict(cerbStatus, refStatus int, refBody, cerbBody []byte) (str
 	}
 }
 
-// buildURL composes the per-endpoint query URL. The window is ±1h
-// around now — rejection parity is shape-based, not data-based, so
-// the window only needs to be syntactically valid.
+// resolveEvalTime parses the -eval-time flag, defaulting to now.
+//
+// Most rejections are shape-based: both backends decide at parse /
+// type-check time, so any syntactically valid window works. Some
+// reference guards are NOT — upstream Prometheus range-checks
+// `double_exponential_smoothing`'s smoothing and trend factors inside
+// the per-series evaluation, so with no series in the lookback window
+// the check never runs and the reference answers 200. Evaluating at a
+// wall-clock "now" against a harness whose fixture is anchored in a
+// fixed past window therefore makes those guards structurally
+// unreachable, and a `rejection` entry covering one of them would be
+// scored `wrong_rejection` for a data reason rather than a semantic
+// one. Pointing -eval-time inside the fixture window closes that hole;
+// it can only ever ADD reference rejections (data lets eval-time
+// guards fire), never remove one.
+func resolveEvalTime(s string) (time.Time, error) {
+	if strings.TrimSpace(s) == "" {
+		return time.Now().UTC(), nil
+	}
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("-eval-time %q is not RFC3339: %w", s, err)
+	}
+	return t.UTC(), nil
+}
+
+// buildURL composes the per-endpoint query URL, anchored at the
+// resolved evaluation time (see resolveEvalTime): an instant query at
+// `now` for promql, a ±1h window ending at `now` for the range/search
+// endpoints.
 func buildURL(base string, c rejectionparity.Case, now time.Time) string {
 	start := now.Add(-1 * time.Hour)
 	end := now

--- a/compatibility/loki/scripts/run-loki-compatibility.sh
+++ b/compatibility/loki/scripts/run-loki-compatibility.sh
@@ -178,9 +178,11 @@ set -e
 # Rejection-parity pass: every deliberate 422 in internal/logql must
 # also be rejected by reference Loki (status-class comparison, never
 # message text). The corpus is the rejection catalogue itself — see
-# test/rejection-parity/ and docs/compatibility.md. Report-only:
-# wrong_rejection verdicts land in the JSON report; only driver-level
-# infrastructure failures propagate (set -e).
+# test/rejection-parity/ and docs/compatibility.md. The driver exits
+# non-zero on a wrong_rejection / divergence_resolved /
+# divergence_closed verdict — the catalogue's own claims turning out
+# false — so `set -e` fails this harness on one. Only stale_catalogue
+# and hard_error stay non-fatal.
 echo "==> running rejection-parity driver (logql)"
 (cd "$REPO_ROOT" && go run ./compatibility/cmd/rejection-parity \
     -head logql \

--- a/compatibility/prometheus/docker-compose.yml
+++ b/compatibility/prometheus/docker-compose.yml
@@ -77,6 +77,17 @@ services:
       - --storage.tsdb.path=/prometheus
       - --web.enable-remote-write-receiver
       - --web.listen-address=:9090
+      # Cerberus's own PromQL parser runs with
+      # EnableExperimentalFunctions, so the reference must too or the
+      # two backends aren't comparable. Without this flag the reference
+      # rejects every experimental symbol at the function-existence
+      # stage, which silently turned 15 rejection-parity trigger queries
+      # into "both 4xx" verdicts that proved nothing about the guard
+      # each one claims to check (#1770), and forced at least one entry
+      # into a classification the harness itself reported as wrong.
+      # test/regression/compat_rejection_parity_reference_test.go pins
+      # the flag.
+      - --enable-feature=promql-experimental-functions
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
     ports:

--- a/compatibility/prometheus/scripts/run-prometheus-compatibility.sh
+++ b/compatibility/prometheus/scripts/run-prometheus-compatibility.sh
@@ -260,15 +260,26 @@ fi
 # Rejection-parity pass: every deliberate 422 in internal/promql must
 # also be rejected by reference Prometheus (status-class comparison,
 # never message text). The corpus is the rejection catalogue itself —
-# see test/rejection-parity/ and docs/compatibility.md. Report-only:
-# wrong_rejection verdicts land in the JSON report; only driver-level
-# infrastructure failures propagate (set -e).
+# see test/rejection-parity/ and docs/compatibility.md. The driver exits
+# non-zero on a wrong_rejection / divergence_resolved / divergence_closed
+# verdict — the catalogue's own claims turning out false — so `set -e`
+# fails this harness on one. Only stale_catalogue and hard_error stay
+# non-fatal.
+#
+# -eval-time pins the driver onto the same instant the compliance tester
+# above uses. The fixture is seeded into a fixed past hour, so a driver
+# left at wall-clock now reads empty selectors from BOTH backends and
+# upstream's eval-time per-series guards (double_exponential_smoothing's
+# smoothing/trend-factor bounds, for one) never run — the reference then
+# answers 200 for a query it would reject over real data. See
+# test/regression/compat_rejection_parity_reference_test.go.
 echo "==> running rejection-parity driver (promql)"
 (cd "$ROOT_DIR/../.." && go run ./compatibility/cmd/rejection-parity \
     -head promql \
     -catalogue test/rejection-parity/catalogue.json \
     -ref http://localhost:29090 \
     -cerberus http://localhost:29091 \
+    -eval-time "$END_TIME" \
     -report "$ROOT_DIR/rejection-parity.json")
 echo "==> rejection-parity report written to $ROOT_DIR/rejection-parity.json"
 

--- a/compatibility/tempo/scripts/run-tempo-compatibility.sh
+++ b/compatibility/tempo/scripts/run-tempo-compatibility.sh
@@ -200,9 +200,11 @@ set -e
 # Rejection-parity pass: every deliberate 422 in internal/traceql must
 # also be rejected by reference Tempo (status-class comparison, never
 # message text). The corpus is the rejection catalogue itself — see
-# test/rejection-parity/ and docs/compatibility.md. Report-only:
-# wrong_rejection verdicts land in the JSON report; only driver-level
-# infrastructure failures propagate (set -e).
+# test/rejection-parity/ and docs/compatibility.md. The driver exits
+# non-zero on a wrong_rejection / divergence_resolved /
+# divergence_closed verdict — the catalogue's own claims turning out
+# false — so `set -e` fails this harness on one. Only stale_catalogue
+# and hard_error stay non-fatal.
 echo "==> running rejection-parity driver (traceql)"
 (cd "$REPO_ROOT" && go run ./compatibility/cmd/rejection-parity \
     -head traceql \

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -278,9 +278,23 @@ real bug rather than a silent wrong-rejection:
 
    Reports land at `compatibility/prometheus/rejection-parity.json`,
    `compatibility/loki/reports/rejection-parity.json`, and
-   `compatibility/tempo/reports/rejection-parity.json`. Like the main
-   testers, the driver is report-only: verdicts never change the exit
-   code; only infrastructure failures do.
+   `compatibility/tempo/reports/rejection-parity.json`. Unlike the main
+   testers, this driver is **not** report-only: a `wrong_rejection`,
+   `divergence_resolved` or `divergence_closed` verdict — the catalogue's
+   own claims turning out false — exits non-zero and fails the harness
+   under `set -e`. Only `stale_catalogue` and `hard_error` stay non-fatal.
+
+   Two harness conditions make the PromQL verdicts meaningful, both pinned
+   by `test/regression/compat_rejection_parity_reference_test.go`:
+
+   - the reference Prometheus runs with
+     `--enable-feature=promql-experimental-functions`, matching cerberus's
+     own parser config, so a "both 4xx" verdict can never record agreement
+     about a feature flag instead of about the guard under test;
+   - the driver is given `-eval-time` inside the seeded fixture window, so
+     upstream guards that validate per series (for example
+     `double_exponential_smoothing`'s smoothing / trend factors) actually
+     run instead of short-circuiting on an empty selector.
 
 ## CI integration
 

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -32,10 +32,20 @@ conformance **ledger** in [`test/surface-parity/`](../test/surface-parity/)
 ([Layer 6d](test-strategy.md#layer-6d--function-surface-parity-ledger) of the
 test map). The ledger classifies each symbol four ways — `parity-accept`,
 `parity-reject`, `wrong-reject`, `wrong-accept` — which is the right vocabulary
-for the test ratchet but the wrong one for a reader: an experimental function
-cerberus implements that a *flag-OFF* reference would reject reads as
-"wrong-accept" in the ledger yet is genuinely **Supported (experimental)** for
-a user. The table above performs that translation.
+for the test ratchet but the wrong one for a reader: `range()` / `step()` read
+as "wrong-accept" in the ledger — the probe drives them as bare top-level
+calls, a shape the reference rejects for query-context reasons — yet they are
+genuinely **Supported (experimental)** for a user. The table above performs
+that translation.
+
+The ledger is **symbol-level**: it records whether cerberus accepts a symbol at
+all, not which argument *shapes* of that symbol it accepts. A function listed
+as Supported here can still reject a specific argument shape the reference
+accepts (a computed rather than literal scalar, say). Those narrower gaps are
+tracked one-per-entry as `class: "divergence"` rows in
+[`test/rejection-parity/catalogue.json`](../test/rejection-parity/catalogue.json),
+each citing an open issue and held to a count ceiling plus an age cap — see
+[`test/rejection-parity/doc.go`](../test/rejection-parity/doc.go).
 
 ## Coverage at a glance
 
@@ -71,9 +81,9 @@ These two query-context functions are experimental upstream and **Supported**
 in cerberus: it constant-folds them per query exactly as the reference engine
 does (`range()` → eval-range seconds, `step()` → the query_range step). They
 appear as a `cerberus extension` in the raw ledger only because the
-surface-parity probe drives them as bare top-level calls, a form the
-flag-OFF HTTP reference rejects — an artifact of the probe shape, not a
-correctness divergence. In real PromQL usage they match upstream.
+surface-parity probe drives them as bare top-level calls, a form the HTTP
+reference rejects outside a query context — an artifact of the probe shape,
+not a correctness divergence. In real PromQL usage they match upstream.
 
 ## Per-symbol tables
 

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -342,6 +342,18 @@ gating on every PR through `check`:
   the reference is caught even when the accept/reject verdict agrees.
   `catalogue.json` + `catalogue_test.go` ratchet it the same way.
 
+  Two harness conditions make that diff mean something, and both are pinned
+  by `test/regression/compat_rejection_parity_reference_test.go`: the
+  reference Prometheus runs **flag-ON**
+  (`--enable-feature=promql-experimental-functions`), matching cerberus's own
+  parser config, so "both 4xx" can never record agreement about a feature
+  flag instead of about the guard under test; and the driver evaluates at
+  `-eval-time` inside the seeded fixture window, so upstream guards that
+  validate per series (`double_exponential_smoothing`'s smoothing / trend
+  factors) actually run instead of short-circuiting on an empty selector.
+  The same test pins every PromQL trigger query onto a family the compat
+  seeder writes.
+
 - **`test/oracle/inventory/`** — per-head capability inventories
   (`{promql,logql,traceql}_test.go`), regenerable under the same
   `CERBERUS_UPDATE_INVENTORY=1` convention.
@@ -350,8 +362,8 @@ The user-facing translation of this ledger — every function / operator /
 intrinsic with its support status — lives in
 [`coverage.md`](coverage.md), which is generated from `inventory.json` and
 presents the ledger classes in honest support language (an experimental fn
-cerberus implements that the flag-OFF reference would reject is "Supported
-(experimental)", not a raw "wrong-accept").
+cerberus implements that a reference *without* the experimental-functions
+flag would reject is "Supported (experimental)", not a raw "wrong-accept").
 
 ### Layer 7 — HTTP handler conformance
 

--- a/scripts/gen-coverage.py
+++ b/scripts/gen-coverage.py
@@ -7,10 +7,11 @@ machine-readable conformance LEDGER: every grammar symbol the three upstream
 parsers expose, paired with cerberus's accept/reject verdict and the reference
 backend's verdict, classified four ways (parity-accept / parity-reject /
 wrong-reject / wrong-accept). That vocabulary is correct for the test ratchet
-but wrong for a human reader — a flag-ON experimental function cerberus
-implements but the flag-OFF reference would reject is a SUPPORTED function, not
-a "wrong-accept". This script performs that translation and emits the tables
-between the AUTOGEN markers in docs/coverage.md.
+but wrong for a human reader — an experimental function cerberus implements is
+a SUPPORTED function, and range()/step() land in "wrong-accept" only because
+the ledger probes them as bare top-level calls, a shape the reference rejects
+for query-context reasons. This script performs that translation and emits the
+tables between the AUTOGEN markers in docs/coverage.md.
 
 Usage:  python3 scripts/gen-coverage.py        # rewrites docs/coverage.md tables
         python3 scripts/gen-coverage.py --check # exit 1 if the doc is stale
@@ -68,7 +69,7 @@ def status(entry):
         # query-context fns (start/end) this is a real intentional gate.
         return "Rejected (parity with reference)"
     if cls == "wrong-accept":
-        # Cerberus accepts, the flag-OFF probe's reference rejects. For
+        # Cerberus accepts, the probe's reference rejects. For
         # range()/step() this is a faithful experimental implementation the
         # bare-call probe can't see; surface it as supported-experimental.
         if is_exp:

--- a/test/regression/compat_rejection_parity_reference_test.go
+++ b/test/regression/compat_rejection_parity_reference_test.go
@@ -1,0 +1,242 @@
+package regression
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	promparser "github.com/prometheus/prometheus/promql/parser"
+	"gopkg.in/yaml.v3"
+
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+	rejectionparity "github.com/tsouza/cerberus/test/rejection-parity"
+)
+
+// The rejection-parity driver proves that every deliberate 4xx in
+// internal/promql is also a 4xx in reference Prometheus. That proof is only
+// worth something when the two backends are asked the same question under
+// the same conditions. Three conditions have to hold, and each one failed
+// silently at some point (#1770):
+//
+//   - The reference must run with the SAME PromQL surface cerberus parses
+//     with. cerberus parses with EnableExperimentalFunctions; a reference
+//     without --enable-feature=promql-experimental-functions rejects every
+//     experimental symbol at the function-existence stage, so "both 4xx"
+//     records agreement about a feature flag rather than about the guard
+//     under test.
+//   - The driver must evaluate INSIDE the fixture's window. The harness
+//     fixture is anchored in a fixed past hour; at wall-clock `now` every
+//     selector is empty, so upstream's eval-time per-series guards never
+//     run and a data-dependent rejection claim proves nothing.
+//   - Every trigger query must name metric families the seeder actually
+//     writes. A trigger over an unseeded family is empty on both sides for
+//     the same reason, whatever the flag and the eval time say.
+//
+// The three tests below pin one condition each.
+const (
+	compatComposePath      = "../../compatibility/prometheus/docker-compose.yml"
+	compatDriverScript     = "../../compatibility/prometheus/scripts/run-prometheus-compatibility.sh"
+	rejectionCataloguePath = "../../test/rejection-parity/catalogue.json"
+
+	// promExperimentalFunctionsFlag is the reference-Prometheus flag that
+	// admits the experimental PromQL surface (limitk, limit_ratio,
+	// double_exponential_smoothing, sort_by_label, mad_over_time, info,
+	// histogram_quantiles, …). cerberus's parser has that surface on
+	// unconditionally.
+	promExperimentalFunctionsFlag = "--enable-feature=promql-experimental-functions"
+
+	// rejectionDriverPath is how the harness scripts spell the driver's
+	// package path in their `go run` invocation.
+	rejectionDriverPath = "./compatibility/cmd/rejection-parity"
+
+	// rejectionDriverEvalTimeArg pins the driver onto the same instant the
+	// upstream compliance tester uses, which the seeder places inside the
+	// fixture window.
+	rejectionDriverEvalTimeArg = `-eval-time "$END_TIME"`
+
+	promHead = "promql"
+)
+
+// composeModel is the sliver of the compat compose file this test reads: the
+// reference Prometheus service's argv.
+type composeModel struct {
+	Services struct {
+		Prometheus struct {
+			Image   string   `yaml:"image"`
+			Command []string `yaml:"command"`
+		} `yaml:"prometheus"`
+	} `yaml:"services"`
+}
+
+// TestCompatReferencePrometheusEnablesExperimentalFunctions pins the flag that
+// makes the reference comparable to cerberus. Without it the reference
+// rejects experimental symbols before reaching the semantic guard each
+// rejection-parity entry claims to check.
+func TestCompatReferencePrometheusEnablesExperimentalFunctions(t *testing.T) {
+	t.Parallel()
+
+	raw, err := os.ReadFile(compatComposePath)
+	if err != nil {
+		t.Fatalf("read %s: %v", compatComposePath, err)
+	}
+	var model composeModel
+	if err := yaml.Unmarshal(raw, &model); err != nil {
+		t.Fatalf("parse %s: %v", compatComposePath, err)
+	}
+
+	cmd := model.Services.Prometheus.Command
+	if len(cmd) == 0 {
+		t.Fatalf("%s declares no command for the prometheus service; this test would "+
+			"compare nothing", compatComposePath)
+	}
+	for _, arg := range cmd {
+		if strings.TrimSpace(arg) == promExperimentalFunctionsFlag {
+			return
+		}
+	}
+	t.Errorf("reference Prometheus in %s runs without %s (argv: %v).\n"+
+		"cerberus parses PromQL with EnableExperimentalFunctions, so without this flag "+
+		"the reference rejects every experimental symbol at the function-existence stage "+
+		"and the rejection-parity driver scores agreement about a feature flag instead of "+
+		"about the guard under test.",
+		compatComposePath, promExperimentalFunctionsFlag, cmd)
+}
+
+// TestRejectionParityDriverEvaluatesInsideFixtureWindow pins the -eval-time
+// argument onto the driver invocation. The harness fixture is seeded into a
+// fixed past hour (compatibility/prometheus/cmd/seed/main.go's anchor); a
+// driver left at wall-clock `now` reads empty selectors on both sides, and
+// upstream's eval-time per-series validation (double_exponential_smoothing's
+// smoothing/trend-factor bounds, for one) never executes.
+func TestRejectionParityDriverEvaluatesInsideFixtureWindow(t *testing.T) {
+	t.Parallel()
+
+	raw, err := os.ReadFile(compatDriverScript)
+	if err != nil {
+		t.Fatalf("read %s: %v", compatDriverScript, err)
+	}
+	script := string(raw)
+
+	start := strings.Index(script, rejectionDriverPath)
+	if start < 0 {
+		t.Fatalf("%s never invokes %s; this test would compare nothing",
+			compatDriverScript, rejectionDriverPath)
+	}
+	// The invocation is a parenthesised subshell whose arguments are
+	// backslash-continued; the first unescaped `)` after the package path
+	// closes it.
+	rest := script[start:]
+	end := strings.Index(rest, ")")
+	if end < 0 {
+		t.Fatalf("%s: the %s invocation is never closed", compatDriverScript, rejectionDriverPath)
+	}
+	invocation := rest[:end]
+
+	if !strings.Contains(invocation, rejectionDriverEvalTimeArg) {
+		t.Errorf("%s invokes %s without %s:\n%s\n"+
+			"The fixture lives in a fixed past window, so a driver evaluating at "+
+			"wall-clock now reads empty selectors from BOTH backends and no "+
+			"data-dependent reference guard fires.",
+			compatDriverScript, rejectionDriverPath, rejectionDriverEvalTimeArg, invocation)
+	}
+}
+
+// TestPromQLRejectionTriggersUseSeededMetrics pins every PromQL trigger query
+// in the rejection catalogue onto a metric family the compat seeder writes.
+// A trigger over an unseeded family returns empty from both backends however
+// the reference is configured, which is the same hollow-green shape
+// TestCompatCorpusReferencesOnlySeededMetrics closes for the corpus.
+func TestPromQLRejectionTriggersUseSeededMetrics(t *testing.T) {
+	t.Parallel()
+
+	seeded := seededPromFamilies(t)
+	if len(seeded) == 0 {
+		t.Fatal("no metric families extracted from the compat seeder; this test would compare nothing")
+	}
+
+	cat, err := rejectionparity.LoadCatalogue(rejectionCataloguePath)
+	if err != nil {
+		t.Fatalf("load %s: %v", rejectionCataloguePath, err)
+	}
+
+	m := schema.DefaultOTelMetrics()
+	p := promparser.NewParser(promparser.Options{EnableExperimentalFunctions: true})
+	checked := 0
+	sawExpHistogramReference := false
+	for _, e := range cat.Entries {
+		if e.Head != promHead || e.TriggerQuery == "" {
+			continue
+		}
+		expr, perr := p.ParseExpr(e.TriggerQuery)
+		if perr != nil {
+			t.Errorf("%s: trigger %q does not parse: %v", e.Site, e.TriggerQuery, perr)
+			continue
+		}
+		names := map[string]bool{}
+		collectSelectorNames(expr, names)
+		checked++
+		for _, name := range sortedSetKeys(names) {
+			// Exp-histogram routing rejects on the NAME alone
+			// (schema.Metrics.IsExpHistogramMetric is a pure suffix
+			// predicate, consulted before any row is read), and the
+			// seeder writes no exp-histogram fixture because reference
+			// Prometheus has no classic-wire representation for one to
+			// mirror. Seeding is therefore not the way to make such a
+			// trigger meaningful — the suffix IS the trigger. This arm
+			// names no specific metric and grows no entries; the
+			// seededPromFamilies switch still fatals if the seeder ever
+			// starts writing the exp-histogram table, so the exemption
+			// cannot outlive its premise.
+			if m.IsExpHistogramMetric(name) {
+				sawExpHistogramReference = true
+				continue
+			}
+			if !seeded[name] {
+				t.Errorf("%s: trigger %q selects %q, which the compat seeder never writes.\n"+
+					"Both backends answer it empty, so the parity (or divergence) verdict "+
+					"recorded for this entry is about an absent family rather than about the "+
+					"guard at that site. Re-pin the trigger onto a seeded family (see %s).",
+					e.Site, e.TriggerQuery, name, compatSeedSource)
+			}
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no PromQL trigger queries found in the catalogue; this test would compare nothing")
+	}
+	if !sawExpHistogramReference {
+		t.Error("no PromQL trigger selects an exp-histogram-suffixed name; the exemption arm " +
+			"of this gate is dead and should be removed")
+	}
+}
+
+// seededPromFamilies returns every metric name a PromQL query may legitimately
+// name given the compat seeder's fixture set: the Prom-wire series names of
+// each seeded family, plus each classic histogram's bare storage name (which
+// histogram_quantile / histogram_quantiles take as their argument).
+func seededPromFamilies(t *testing.T) map[string]bool {
+	t.Helper()
+
+	m := schema.DefaultOTelMetrics()
+	out := map[string]bool{}
+	for _, f := range parseSeedFixtures(t) {
+		switch f.table {
+		case m.HistogramTable:
+			synthetic := promql.HistogramSyntheticNames(f.name, m)
+			if len(synthetic) == 0 {
+				t.Fatalf("fixture %q inserts into the histogram table but yields no "+
+					"Prom-wire series names", f.name)
+			}
+			for _, name := range synthetic {
+				out[name] = true
+			}
+			out[f.name] = true
+		case m.GaugeTable, m.SumTable:
+			out[f.name] = true
+		default:
+			t.Fatalf("fixture %q inserts into %q: teach this test how that table's "+
+				"rows surface as PromQL series names", f.name, f.table)
+		}
+	}
+	return out
+}

--- a/test/rejection-parity/catalogue.json
+++ b/test/rejection-parity/catalogue.json
@@ -427,8 +427,10 @@
       "head": "promql",
       "site": "internal/promql/histogram_quantile.go:lowerHistogramQuantiles#1cf264f6",
       "message": "promql: histogram_quantiles requires literal phi arguments for the %q label, got %T",
-      "class": "rejection",
-      "trigger_query": "histogram_quantiles(http_request_duration_seconds, \"quantile\", scalar(http_request_duration_seconds))"
+      "class": "divergence",
+      "trigger_query": "histogram_quantiles(demo_api_request_duration_seconds, \"quantile\", scalar(vector(0.9)))",
+      "tracking_issue": 1765,
+      "since": "2026-08-05"
     },
     {
       "head": "promql",
@@ -606,15 +608,17 @@
       "head": "promql",
       "site": "internal/promql/lower.go:lowerLimitK#5ff80394",
       "message": "promql: limitk K must be a scalar literal; computed-K (e.g. scalar(\u003cvector\u003e)) is not supported",
-      "class": "rejection",
-      "trigger_query": "limitk(scalar(up), up)"
+      "class": "divergence",
+      "trigger_query": "limitk(scalar(vector(2)), demo_memory_usage_bytes)",
+      "tracking_issue": 1787,
+      "since": "2026-08-05"
     },
     {
       "head": "promql",
       "site": "internal/promql/lower.go:lowerLimitRatio#a75ec376",
       "message": "promql: limit_ratio ratio value is NaN",
       "class": "rejection",
-      "trigger_query": "limit_ratio(NaN, up)"
+      "trigger_query": "limit_ratio(NaN, demo_memory_usage_bytes)"
     },
     {
       "head": "promql",
@@ -719,21 +723,23 @@
       "site": "internal/promql/range_fns.go:lowerHoltWinters#0ff3d8b3",
       "message": "promql: holt_winters smoothing factor must be in (0, 1), got %v",
       "class": "rejection",
-      "trigger_query": "double_exponential_smoothing(http_requests_total[10m], 1.5, 0.5)"
+      "trigger_query": "double_exponential_smoothing(demo_memory_usage_bytes[10m], 1.5, 0.5)"
     },
     {
       "head": "promql",
       "site": "internal/promql/range_fns.go:lowerHoltWinters#15e82804",
       "message": "promql: holt_winters requires scalar-literal smoothing and trend factors",
-      "class": "rejection",
-      "trigger_query": "double_exponential_smoothing(http_requests_total[10m], scalar(up), 0.5)"
+      "class": "divergence",
+      "trigger_query": "double_exponential_smoothing(demo_memory_usage_bytes[10m], scalar(vector(0.5)), 0.5)",
+      "tracking_issue": 1782,
+      "since": "2026-08-05"
     },
     {
       "head": "promql",
       "site": "internal/promql/range_fns.go:lowerHoltWinters#2db9f2aa",
       "message": "promql: holt_winters trend factor must be in (0, 1), got %v",
       "class": "rejection",
-      "trigger_query": "double_exponential_smoothing(http_requests_total[10m], 0.5, 1.5)"
+      "trigger_query": "double_exponential_smoothing(demo_memory_usage_bytes[10m], 0.5, 1.5)"
     },
     {
       "head": "promql",
@@ -802,8 +808,10 @@
       "head": "promql",
       "site": "internal/promql/sort.go:lowerSortByLabel#8f9fe409",
       "message": "promql: %s expects at least 2 arguments (vector, label[, label…]), got %d",
-      "class": "rejection",
-      "trigger_query": "sort_by_label(http_requests)"
+      "class": "divergence",
+      "trigger_query": "sort_by_label(demo_memory_usage_bytes)",
+      "tracking_issue": 1783,
+      "since": "2026-08-05"
     },
     {
       "head": "promql",
@@ -816,8 +824,10 @@
       "head": "promql",
       "site": "internal/promql/subquery.go:lowerOuterRangeFnOverSubquery#b8fba661",
       "message": "promql: %s does not accept a subquery argument",
-      "class": "rejection",
-      "trigger_query": "mad_over_time(up[5m:1m])"
+      "class": "divergence",
+      "trigger_query": "mad_over_time(demo_memory_usage_bytes[5m:1m])",
+      "tracking_issue": 1784,
+      "since": "2026-08-05"
     },
     {
       "head": "promql",
@@ -858,22 +868,28 @@
       "head": "promql",
       "site": "internal/promql/subquery.go:lowerSubqueryOverAggregate#534fdfbe",
       "message": "promql: subquery over %s aggregation is not supported",
-      "class": "rejection",
-      "trigger_query": "max_over_time(limit_ratio(0.5, up)[5m:1m])"
+      "class": "divergence",
+      "trigger_query": "max_over_time(limit_ratio(0.5, demo_memory_usage_bytes)[5m:1m])",
+      "tracking_issue": 1786,
+      "since": "2026-08-05"
     },
     {
       "head": "promql",
       "site": "internal/promql/subquery.go:lowerSubqueryOverCall#1796796f",
       "message": "promql: subquery inner %s expects exactly 1 argument, got %d",
-      "class": "rejection",
-      "trigger_query": "max_over_time(double_exponential_smoothing(up[5m], 0.5, 0.5)[10m:1m])"
+      "class": "divergence",
+      "trigger_query": "max_over_time(double_exponential_smoothing(demo_memory_usage_bytes[5m], 0.5, 0.5)[10m:1m])",
+      "tracking_issue": 1785,
+      "since": "2026-08-05"
     },
     {
       "head": "promql",
       "site": "internal/promql/subquery.go:lowerSubqueryOverCall#a2b5a42c",
       "message": "promql: subquery inner %s must wrap a MatrixSelector, got %T",
-      "class": "rejection",
-      "trigger_query": "max_over_time(info(up)[5m:1m])"
+      "class": "divergence",
+      "trigger_query": "max_over_time(info(demo_memory_usage_bytes)[5m:1m])",
+      "tracking_issue": 1785,
+      "since": "2026-08-05"
     },
     {
       "head": "promql",
@@ -886,8 +902,10 @@
       "head": "promql",
       "site": "internal/promql/subquery.go:lowerSubqueryOverCallSubquery#b8fba661",
       "message": "promql: %s does not accept a subquery argument",
-      "class": "rejection",
-      "trigger_query": "max_over_time(mad_over_time(up[5m:1m])[10m:1m])"
+      "class": "divergence",
+      "trigger_query": "max_over_time(mad_over_time(demo_memory_usage_bytes[5m:1m])[10m:1m])",
+      "tracking_issue": 1784,
+      "since": "2026-08-05"
     },
     {
       "head": "promql",
@@ -943,14 +961,16 @@
       "site": "internal/promql/subquery.go:threadOuterRangeFnScalars#0ff3d8b3",
       "message": "promql: holt_winters smoothing factor must be in (0, 1), got %v",
       "class": "rejection",
-      "trigger_query": "double_exponential_smoothing(rate(http_requests_total[5m])[1h:5m], 1.5, 0.5)"
+      "trigger_query": "double_exponential_smoothing(rate(demo_cpu_usage_seconds_total[5m])[1h:5m], 1.5, 0.5)"
     },
     {
       "head": "promql",
       "site": "internal/promql/subquery.go:threadOuterRangeFnScalars#15e82804",
       "message": "promql: holt_winters requires scalar-literal smoothing and trend factors",
-      "class": "rejection",
-      "trigger_query": "double_exponential_smoothing(rate(http_requests_total[5m])[1h:5m], scalar(up), 0.5)"
+      "class": "divergence",
+      "trigger_query": "double_exponential_smoothing(rate(demo_cpu_usage_seconds_total[5m])[1h:5m], scalar(vector(0.5)), 0.5)",
+      "tracking_issue": 1782,
+      "since": "2026-08-05"
     },
     {
       "head": "promql",
@@ -964,7 +984,7 @@
       "site": "internal/promql/subquery.go:threadOuterRangeFnScalars#2db9f2aa",
       "message": "promql: holt_winters trend factor must be in (0, 1), got %v",
       "class": "rejection",
-      "trigger_query": "double_exponential_smoothing(rate(http_requests_total[5m])[1h:5m], 0.5, 1.5)"
+      "trigger_query": "double_exponential_smoothing(rate(demo_cpu_usage_seconds_total[5m])[1h:5m], 0.5, 1.5)"
     },
     {
       "head": "promql",

--- a/test/rejection-parity/divergence-ceiling.json
+++ b/test/rejection-parity/divergence-ceiling.json
@@ -1,3 +1,3 @@
 {
-  "max_entries": 3
+  "max_entries": 13
 }

--- a/test/rejection-parity/doc.go
+++ b/test/rejection-parity/doc.go
@@ -32,6 +32,29 @@
 //     A `rejection` entry whose reference accepts is a wrong-rejection
 //     bug to fix at the source — never an allow-list entry.
 //
+// # Trigger queries must name metrics the lane's fixture seeds
+//
+// Cerberus rejects at LOWERING time, before it reads a row, so on
+// cerberus's side a trigger's verdict is purely shape-based and any
+// metric name would do. The reference backends are not shape-based:
+// PromQL's argument-domain checks (a double_exponential_smoothing
+// smoothing factor outside (0, 1), say) live in the function BODY,
+// which the engine never enters for a selector that matched no series.
+// A trigger naming a metric the fixture does not seed therefore gets an
+// empty 200 from the reference standing in for the 422 it would in fact
+// have returned — the case reads as wrong_rejection while the two
+// backends actually agree.
+//
+// Two invariants follow, and both have bitten:
+//
+//   - Trigger queries name fixture metrics (the promql lane seeds the
+//     `demo_*` family — see compatibility/prometheus/cmd/seed).
+//   - The driver queries INSIDE the seeded window. The promql lane's
+//     fixture is anchored at a fixed historical timestamp, so
+//     run-prometheus-compatibility.sh passes `-at "$END_TIME"`; the
+//     loki and tempo lanes seed relative to wall-clock and use the
+//     driver's default anchor.
+//
 // # The three classes
 //
 //   - `rejection`  — the parity claim is "cerberus and the reference

--- a/test/surface-parity/promql.go
+++ b/test/surface-parity/promql.go
@@ -213,8 +213,9 @@ var promModifiers = []struct {
 // The reference oracle was previously a hardcoded
 // `if fn.Experimental { ref = reject }` stand-in. That assumption — that
 // the reference rejects every experimental fn — only held for a reference
-// started WITHOUT --enable-feature=promql-experimental-functions (the
-// flag-OFF compat reference). With the flag ON, the reference ACCEPTS
+// started WITHOUT --enable-feature=promql-experimental-functions. Every
+// reference in this repository runs the flag, and with the flag ON the
+// reference ACCEPTS
 // every experimental fn it actually implements, so an unimplemented fn
 // cerberus rejected could masquerade as a "parity rejection" while a fn
 // cerberus accepted looked like a "wrong-accept". referenceVerdictPromQL


### PR DESCRIPTION
## Summary

The rejection-parity harness compared cerberus against a reference Prometheus that could not reach the guards the catalogue claims to check. Two independent reasons, both fixed here:

1. **The reference ran with experimental functions disabled.** Cerberus's own parser runs with `EnableExperimentalFunctions`; the reference did not. Every experimental symbol was therefore rejected at the *function-existence* stage, so 15 trigger queries scored "both 4xx → parity" while proving nothing about the semantic guard each one names (#1770). Worse, it made a genuine divergence *unrecordable*: classifying such an entry `divergence` made the driver report `divergence_closed` and demand it be reclassified back to a claim the harness itself knew was false.

2. **The driver evaluated at wall-clock `now`, outside the fixture window.** Upstream range-checks `double_exponential_smoothing`'s smoothing/trend factors *inside* per-series evaluation. With no series in the lookback window the check never runs and the reference answers `200` — a `rejection` entry covering it would be scored `wrong_rejection` for a data reason rather than a semantic one. The new `-eval-time` flag pins the driver to the same `$END_TIME` the compliance tester already uses.

## What the flag exposed

With the reference finally able to answer, ten catalogue entries turned out to be real divergences — cerberus rejects, upstream Prometheus answers. Each is classified `divergence` with an **open** tracking issue rather than absorbed into a passing verdict:

| Issue | Divergence |
|---|---|
| #1782 | `double_exponential_smoothing` rejects computed smoothing/trend factors upstream accepts |
| #1783 | single-argument `sort_by_label` rejected; reference answers it |
| #1784 | `mad_over_time` missing from `rangeVectorFn`, so it is rejected over a subquery |
| #1785 | subquery inner limited to 1-arg matrix-selector calls; reference answers the other shapes |
| #1786 | subquery over `limitk` / `limit_ratio` aggregation rejected; reference answers it |
| #1787 | `limitk` rejects computed K; upstream only rejects non-`int64`-convertible values |
| #1765 | `histogram_quantiles(...)` non-literal-phi rejection (pre-existing entry, now decidable) |

`divergence-ceiling.json` rises 3 → 13 to admit them. The ratchet still only moves down for free: `CERBERUS_UPDATE_INVENTORY=1` refuses to raise it, so this is a deliberate, reviewed edit and every entry carries a `since` date against the 90-day age cap.

## Hardening

- The driver now **fails** the harness on `wrong_rejection` / `divergence_resolved` / `divergence_closed` — the catalogue's own claims turning out false. Previously these landed in the JSON report and the lane stayed green. Only `stale_catalogue` and `hard_errors` remain non-fatal.
- `test/regression/compat_rejection_parity_reference_test.go` pins the flag and the `-eval-time` wiring, so neither can be silently dropped — the failure mode they prevent presents as a *passing* lane.

Closes #1770
