### PR TITLE
fix(test/property): anchor the TraceQL oracle's =~ / !~ to match Tempo

### DIFF
--- a/test/property/oracle/traceql/evaluator.go
+++ b/test/property/oracle/traceql/evaluator.go
@@ -183,6 +183,39 @@ func attrGetter(attr string) (func(spanView) string, error) {
 	return nil, fmt.Errorf("unsupported attribute path %q", attr)
 }
 
+// TraceQL's `=~` / `!~` are FULLY ANCHORED, not substring searches:
+// `{ resource.service.name =~ "a.*" }` matches the service `api` and
+// does NOT match `batch`. Tempo evaluates every regex comparison
+// through `pkg/regexp.NewRegexp` (`pkg/traceql/ast_execute.go`), which
+// builds `labels.NewFastRegexMatcher`, which compiles
+// `"^(?s:" + pattern + ")$"` — so the anchors and the dot-matches-
+// newline flag are part of the operator's semantics, not of the
+// pattern the user wrote.
+//
+// The non-capturing group is load-bearing for alternation: `^a|b$`
+// alternates between `^a` and `b$`, so only `^(?s:a|b)$` expresses
+// "the whole value is a or b". `(?s:` additionally makes `.` match
+// `\n`, matching Prometheus's `syntax.DotNL` parse flag — a value
+// containing a newline is still matched by `.*`.
+//
+// A pattern that already carries its own `^`/`$` nests safely:
+// `^(?s:^api$)$` still matches only `api`, because `^`/`$` are
+// zero-width assertions that compose rather than conflict.
+//
+// Cerberus wraps the pattern as `^(?:…)$` at the single SQL site both
+// regex render paths share — `anchoredRegexPattern` in
+// `internal/chsql/builder.go` — and lands on identical semantics
+// because ClickHouse compiles `match()` with RE2's dot-matches-newline
+// option already on, while leaving `^`/`$` non-multiline. Probed
+// directly against chDB: `match('a\nc', '^(?:a.c)$')` = 1 (dot spans
+// the newline) and `match('abc\nxyz', '^(?:abc)$')` = 0 (the anchors
+// bind the whole value, not a line). Go's regexp defaults the other
+// way on the first of those, so the oracle spells the flag out.
+const (
+	anchorRegexPrefix = "^(?s:"
+	anchorRegexSuffix = ")$"
+)
+
 // newAttrCondition builds an attribute matcher condition for one of
 // the four operators the generator draws: `=`, `!=`, `=~`, `!~`.
 func newAttrCondition(attr, op, value string) (condition, error) {
@@ -196,7 +229,7 @@ func newAttrCondition(attr, op, value string) (condition, error) {
 	case "!=":
 		return condition{match: func(sv spanView) bool { return getter(sv) != value }}, nil
 	case "=~", "!~":
-		re, err := regexp.Compile(value)
+		re, err := regexp.Compile(anchorRegexPrefix + value + anchorRegexSuffix)
 		if err != nil {
 			return condition{}, fmt.Errorf("bad regex %q: %w", value, err)
 		}

--- a/test/property/oracle/traceql/evaluator_test.go
+++ b/test/property/oracle/traceql/evaluator_test.go
@@ -134,6 +134,57 @@ func TestEvaluate_Shapes(t *testing.T) {
 	}
 }
 
+// TestEvaluate_RegexIsFullyAnchored pins the semantics the TraceQL
+// property test drifted on: `=~` / `!~` are fully-anchored matches,
+// not substring searches.
+//
+// The counterexample rapid shrunk to (seed 5609448711362248639) was
+// `{ resource.service.name =~ "a.*" }` against a lone span whose
+// service is `batch`. An unanchored Go `regexp.MatchString` finds
+// `atch` at offset 1 and reports a match; Tempo does not, because
+// `pkg/traceql/ast_execute.go` routes every regex comparison through
+// `pkg/regexp.NewRegexp` → `labels.NewFastRegexMatcher` →
+// `regexp.Compile("^(?s:" + pattern + ")$")`. Cerberus agreed with
+// Tempo and the oracle was the wrong side.
+//
+// The `!~` half is asserted alongside because a negation that inherits
+// an over-broad matcher fails in the opposite direction — it drops
+// spans it should keep — and would not be caught by the `=~` case.
+func TestEvaluate_RegexIsFullyAnchored(t *testing.T) {
+	// fixtureDataset services: api (r1), web (c1), batch (g1), api (r2).
+	for _, tc := range []struct {
+		name      string
+		query     string
+		wantCount int
+	}{
+		// The shrunk counterexample: `a.*` is a prefix match, so it
+		// selects both `api` spans and neither `web` nor `batch` —
+		// unanchored it would additionally match `batch` ("atch").
+		{"prefix_excludes_infix_match", `{ resource.service.name =~ "a.*" }`, 2},
+		{"negated_prefix_keeps_infix_match", `{ resource.service.name !~ "a.*" }`, 2},
+		// A bare literal is an exact match, not a substring probe:
+		// unanchored, `pi` would match both `api` spans.
+		{"literal_is_not_a_substring_probe", `{ resource.service.name =~ "pi" }`, 0},
+		{"negated_literal_is_not_a_substring_probe", `{ resource.service.name !~ "pi" }`, 4},
+		// Alternation must bind as a whole-value choice: the
+		// non-capturing group in the wrap is what stops `^web|batc`
+		// parsing as (`^web`) or (`batc` at any offset).
+		{"alternation_binds_whole_value", `{ resource.service.name =~ "web|batc" }`, 1},
+		// A user-supplied anchor nests without conflicting.
+		{"user_supplied_anchors_nest", `{ resource.service.name =~ "^web$" }`, 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out := evalQ(t, tc.query)
+			if out.Err != nil {
+				t.Fatalf("query %q: unexpected error: %v", tc.query, out.Err)
+			}
+			if len(out.Rows) != tc.wantCount {
+				t.Fatalf("query %q: row count = %d, want %d", tc.query, len(out.Rows), tc.wantCount)
+			}
+		})
+	}
+}
+
 // TestEvaluate_ParseErrors asserts the recognizer rejects shapes
 // outside the generator's accept-set rather than silently
 // misevaluating them.


### PR DESCRIPTION
## Summary

- `TestTraceQL_Property` was red on `main` (`407fbdcb`, run 31029759093). rapid shrank it to a one-span dataset and a one-condition query; the drift is that **the from-scratch oracle treated TraceQL `=~` / `!~` as a substring search**, while cerberus (correctly) anchors them.
- **Cerberus was right, the oracle was wrong.** Tempo routes every regex comparison through `pkg/regexp.NewRegexp` (`pkg/traceql/ast_execute.go:436-440`, `:692-696`) → `labels.NewFastRegexMatcher` → `regexp.Compile("^(?s:" + pattern + ")$")`. The anchors are part of the operator's semantics, not of the pattern the user typed. Cerberus applies the same wrap at `anchoredRegexPattern` (`internal/chsql/builder.go`), landed by #1746 earlier the same day — the oracle was never updated to match.
- Fix: compile the oracle's pattern as `^(?s:…)$`. Add `TestEvaluate_RegexIsFullyAnchored`, six cases pinning the counterexample plus the alternation / user-anchor / negation halves that a naive wrap gets wrong.
- **The generator is untouched.** `<first-letter-of-a-service>.*` is a legitimate prefix pattern that discriminates correctly under anchored semantics, and it is exactly what surfaced the defect — narrowing it would have hidden a real bug.

## The minimal reproducer

Dataset — one span, service `batch`:

```sql
INSERT INTO otel_traces VALUES (
  toDateTime64('2026-05-13 12:00:00.000', 9),
  'a1a2a3a4a5a6a7a8a9aaabacadaeafb0', 'b2b3b4b5b6b7b8b9', '0000000000000000',
  'GET /api/0', 'Internal', 'batch',
  map('cluster', 'east', 'service.name', 'batch'), map('http.method', 'GET'),
  10000000, 'Ok', '', '', '');
```

Query:

```traceql
{ resource.service.name =~ "a.*" }
```

| side | pattern actually matched | `batch` | rows |
| --- | --- | --- | --- |
| oracle (before) | `a.*`, unanchored `MatchString` | finds `atch` at offset 1 | 1 |
| cerberus | `^(?:a.*)$` via CH `match()` | no match | 0 |
| **Tempo (reference)** | `^(?s:a.*)$` via `FastRegexMatcher` | **no match** | **0** |

Hence the CI diff `missing series in got: {}` — the oracle's row was the phantom one.

The all-zero `ParentSpanId` in the shrunk dataset is incidental: rapid shrank the trace to a single root span because one span is the smallest dataset that exhibits the drift. Root identity plays no part — #1481 (`any(SpanName)` in spanset aggregates) is a different defect on a different code path and is untouched here, as are #1758 and #1708.

## Why `^(?s:…)$` and not `^(?:…)$`

The `s` flag is needed on the **Go** side only, and the two engines still agree. Probed directly against chDB:

```text
match('a\nc',     '^(?:a.c)$')  = 1   -- CH's RE2 has dot-matches-newline ON by default
match('abc\nxyz', '^(?:abc)$')  = 0   -- CH's ^/$ are NOT multiline
match('batch',    '^(?s:a.*)$') = 0
match('api',      '^(?s:a.*)$') = 1
```

So ClickHouse already behaves as `(?s)` with whole-value anchors; Go's `regexp` defaults the other way on the first line, so the oracle spells the flag out. That also makes the oracle byte-equivalent to Prometheus's `syntax.Perl|syntax.DotNL` parse, which is what `FastRegexMatcher` uses. No `internal/chsql` change is warranted.

## Test plan

- [x] Failfile replay of the exact CI counterexample — `go test -tags chdb ./test/property/ -run TestTraceQL_Property -rapid.failfile=".../TestTraceQL_Property-20260805172723-14667.fail"` → **`ok  github.com/tsouza/cerberus/test/property  3.665s`** (fails on `main`, reproduced first).
- [x] Same seed as the red CI run, full depth — `go test -tags chdb ./test/property/ -run TestTraceQL_Property -rapid.seed=5609448711362248639 -rapid.checks=500` → **`[rapid] OK, passed 500 tests (17.556215529s)`**.
- [x] Whole property package at CI depth — `go test -tags chdb ./test/property/... -rapid.checks=500` → `ok test/property 155.147s`, `ok test/property/oracle/promql`, `ok test/property/oracle/traceql`.
- [x] Oracle unit suite — all 24 `TestEvaluate_Shapes` cases plus the 6 new `TestEvaluate_RegexIsFullyAnchored` cases pass; the two pre-existing `shape7_regex_*` cases used an already-anchored `^a.*` pattern, which is why they never caught this.
- [x] chDB probe of ClickHouse's `match()` flags (table above).
- [ ] CI green

## Notes for reviewers

The blast-radius claim that this also repairs the `coverage` required check does **not** hold, and I checked rather than assumed. `coverage` is red on push-to-`main` for an independent reason — four packages under their committed floor in `test/coverage-floor.json`:

```text
compatibility/tempo/driver:  52.55% < 58%
internal/chplan:             79.48% < 79.9%
internal/logql:              83.21% < 83.6%
test/property/oracle/promql: 70.05% < 71.2%
```

Run 30987124746 (commit `048d7bb1`, 08:13Z — *before* the anchoring commit that started the property drift) has no failing test at all and still reports the same four-package breach, and run 30960006572 from the previous evening reports a two-package breach. The floor ledger is a ratchet, so it cannot be rewritten to match. That is issue **#1807**, which I opened and which needs its own change.

Both `coverage` and `property` short-circuit to a green no-op on an ordinary PR (`RUN_HEAVY` in `property.yml` / `coverage.yml`), so neither check on this PR exercises the fix — the local N=500 run against the CI seed above is the evidence, and the push-to-`main` lane is where it re-verifies.

No existing issue describes this defect; per the task framing I did not open one purely to cite it.
