### PR TITLE
fix(e2e): drive the Traces-Drilldown wire pin over the proxy, restore report upload

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -421,7 +421,7 @@ jobs:
           # metrics-explorer, and crawl (BFS + ds/query + lints) contracts.
           # See docs/test-strategy.md (interaction sweep) for the per-spec map
           # and the shard manifest for which spec lands on which shard.
-          npx playwright test ${{ matrix.specs }} --reporter=list
+          npx playwright test ${{ matrix.specs }} --reporter=list,html
 
       - name: upload Playwright report on failure
         if: steps.playwright_smoke.outcome == 'failure'
@@ -604,7 +604,7 @@ jobs:
           CERBERUS_URL: http://localhost:8080
           SWEEP_DEPTH: ${{ github.event_name == 'schedule' && 'full' || 'lean' }}
           CRAWL_STACK: compose
-        run: npx playwright test ${{ matrix.specs }} --reporter=list
+        run: npx playwright test ${{ matrix.specs }} --reporter=list,html
 
       - name: upload Playwright report on failure
         if: steps.playwright_smoke.outcome == 'failure'
@@ -1007,7 +1007,7 @@ jobs:
           # so loki_explore_columns.spec.ts — the #908 Logs-Drilldown column
           # gate that queries {service_name="clickhouse"} directly — runs here.
           DASHBOARDS_DIR: ${{ github.workspace }}/test/e2e/grafana/dashboards
-        run: npx playwright test ${{ matrix.specs }} --reporter=list
+        run: npx playwright test ${{ matrix.specs }} --reporter=list,html
 
       # ---- crawl shard (CRAWL_STACK=k3d) ----
       # The same crawl framework the compose-smoke job runs per-PR
@@ -1035,7 +1035,7 @@ jobs:
           CRAWL_STACK: ${{ matrix.crawlStack }}
           SWEEP_DEPTH: full
           CERBERUS_UPDATE_INVENTORY: ${{ github.event_name == 'workflow_dispatch' && inputs.update_crawl_inventory && '1' || '' }}
-        run: npx playwright test ${{ matrix.specs }} --reporter=list
+        run: npx playwright test ${{ matrix.specs }} --reporter=list,html
 
       - name: Upload regenerated k3d crawl inventory
         if: always() && matrix.crawlStack == 'k3d' && github.event_name == 'workflow_dispatch' && inputs.update_crawl_inventory
@@ -1082,6 +1082,17 @@ jobs:
           retention-days: 14
           if-no-files-found: ignore
 
+      # A `--reporter=` on the command line REPLACES the config's
+      # `reporter` array outright, so the bare `--reporter=list` this job
+      # used to pass silenced playwright.config.ts's html reporter and
+      # this step uploaded nothing on every red run ("No files were found
+      # with the provided path: test/e2e/playwright/playwright-report",
+      # run 31029759827) — a failure-diagnosis path that had been inert
+      # since the flag was added. The playwright steps above therefore
+      # name both reporters explicitly (`list,html`), and the upload
+      # carries `test-results` too: traces, screenshots, videos and
+      # error-context live there, and without them a red drilldown-app
+      # shard is undiagnosable after the fact.
       - name: Upload Playwright report on failure
         if: failure()
         uses: actions/upload-artifact@v7
@@ -1089,7 +1100,10 @@ jobs:
           # Per-shard name — a static name 409s across the matrix
           # (upload-artifact@v4+ rejects a second upload to a used name).
           name: playwright-report-${{ matrix.name }}
-          path: test/e2e/playwright/playwright-report
+          path: |
+            test/e2e/playwright/playwright-report
+            test/e2e/playwright/test-results
+          if-no-files-found: ignore
           retention-days: 14
 
       - name: Dump cluster state on failure

--- a/test/e2e/playwright/tempo_traces_drilldown.spec.ts
+++ b/test/e2e/playwright/tempo_traces_drilldown.spec.ts
@@ -17,6 +17,21 @@
  * it; this spec asserts what the UI actually renders plus the wire
  * field the transform consumes.
  *
+ * Transport split (#1665): the `cerberus-tempo` datasource carries
+ * `jsonData.streamingEnabled.search: true`, so Grafana's Tempo
+ * datasource routes a TraceQL search through `handleStreamingQuery()`
+ * → Grafana Live (`/api/live/ws`) → the Grafana backend's h2c gRPC
+ * call into cerberus's `StreamingQuerier`. The browser therefore
+ * issues ZERO `/api/search?` HTTP requests on this datasource, and a
+ * `page.on('response')` capture of that URL is structurally empty —
+ * it is evidence of the transport in use, not of the payload shape.
+ * The wire-shape pin below is consequently driven by an explicit
+ * request through the datasource proxy rather than by whatever the
+ * page happened to emit: that request always happens, so the shape
+ * assertions can never go vacuous. Any `/api/search` response the
+ * page DOES emit (a non-streaming lane, or a future app version that
+ * falls back to HTTP) is still folded into the same shape check.
+ *
  * Gate posture: NIGHTLY ONLY (auto-discovered by the `dashboard` job's
  * unfiltered `npx playwright test` run in .github/workflows/e2e.yml;
  * deliberately NOT in the compose-smoke job's explicit spec list —
@@ -50,8 +65,53 @@ const traceListURL =
   '/a/grafana-exploretraces-app/explore' +
   '?actionView=traceList&var-ds=cerberus-tempo&from=now-30m&to=now';
 
+// Grafana's datasource-proxy route onto the same cerberus Tempo head
+// the drilldown queries — the HTTP half of the transport split
+// documented in the module header.
+const tempoProxySearch = '/api/datasources/proxy/uid/cerberus-tempo/api/search';
+
+// The trace-list query the drilldown issues is tableType=spans with an
+// explicit result cap (`limit`) and a per-trace span cap (`spss`) —
+// both were ignored by cerberus in the #770 regression this spec pins,
+// so the probe must carry them rather than search bare.
+const TRACE_LIST_LIMIT = 20;
+const TRACE_LIST_SPANS_PER_SPAN_SET = 10;
+
+// A seeded resource attribute (test/e2e/seed/cmd/seed/main.go inserts
+// `frontend`/`api`/`db` services) so the probe matches deterministically
+// rather than depending on the self-telemetry window being non-empty.
+const SEEDED_SERVICE_QUERY = '{ resource.service.name = "frontend" }';
+
+type SearchBody = {
+  traces?: Array<{
+    spanSets?: Array<{ spans?: unknown[] }>;
+    spanSet?: { spans?: unknown[] };
+  }>;
+};
+
+/**
+ * Assert every trace summary in `body` carries the exact fields
+ * Grafana's tempo resultTransformer reads to build the spans table.
+ */
+function assertSpanSetShape(body: SearchBody, source: string): void {
+  for (const trace of body.traces ?? []) {
+    expect(
+      Array.isArray(trace.spanSets) && trace.spanSets.length > 0,
+      `${source}: every trace summary carries spanSets (got: ${JSON.stringify(trace).slice(0, 200)})`,
+    ).toBe(true);
+    expect(
+      (trace.spanSets?.[0]?.spans?.length ?? 0) > 0,
+      `${source}: spanSets[0].spans is non-empty`,
+    ).toBe(true);
+    expect(
+      (trace.spanSet?.spans?.length ?? 0) > 0,
+      `${source}: legacy spanSet mirror is populated`,
+    ).toBe(true);
+  }
+}
+
 test.describe('Traces Drilldown — trace list (tableType=spans)', () => {
-  test('Traces tab badge > 0 and span table renders rows', async ({ page }) => {
+  test('Traces tab badge > 0 and span table renders rows', async ({ page, request }) => {
     // The app boots its own React tree + fires a wave of datasource
     // queries; budget generously for a cold ClickHouse.
     test.setTimeout(180_000);
@@ -121,38 +181,32 @@ test.describe('Traces Drilldown — trace list (tableType=spans)', () => {
 
     page.off('response', onResponse);
 
-    // Wire-shape pin: at least one captured /api/search response must
-    // carry per-trace spanSets (and the legacy spanSet mirror) — the
-    // exact fields Grafana's resultTransformer reads. An empty traces
-    // window would have failed the badge assertion already.
-    type SearchBody = {
-      traces?: Array<{
-        spanSets?: Array<{ spans?: unknown[] }>;
-        spanSet?: { spans?: unknown[] };
-      }>;
-    };
-    const withTraces = (searchBodies as SearchBody[]).filter(
-      (b) => Array.isArray(b?.traces) && b.traces.length > 0,
+    // Wire-shape pin, HTTP half. Driven explicitly (not harvested from
+    // the page) because the drilldown's own search rides the streaming
+    // gRPC transport — see the module header. The proxy request carries
+    // the same limit + spss caps the drilldown sends, so this asserts
+    // the exact response shape Grafana's resultTransformer consumes.
+    const probeResp = await request.get(
+      `${tempoProxySearch}?q=${encodeURIComponent(SEEDED_SERVICE_QUERY)}` +
+        `&limit=${TRACE_LIST_LIMIT}&spss=${TRACE_LIST_SPANS_PER_SPAN_SET}`,
     );
+    expect(probeResp.status(), 'tableType=spans search returns 200').toBe(200);
+    const probeBody = (await probeResp.json()) as SearchBody;
     expect(
-      withTraces.length,
-      'at least one /api/search response with traces was captured',
+      Array.isArray(probeBody.traces) ? probeBody.traces.length : 0,
+      'tableType=spans search returns at least one trace summary',
     ).toBeGreaterThan(0);
-    for (const body of withTraces) {
-      for (const trace of body.traces ?? []) {
-        expect(
-          Array.isArray(trace.spanSets) && trace.spanSets.length > 0,
-          `every trace summary carries spanSets (got: ${JSON.stringify(trace).slice(0, 200)})`,
-        ).toBe(true);
-        expect(
-          (trace.spanSets?.[0]?.spans?.length ?? 0) > 0,
-          'spanSets[0].spans is non-empty',
-        ).toBe(true);
-        expect(
-          (trace.spanSet?.spans?.length ?? 0) > 0,
-          'legacy spanSet mirror is populated',
-        ).toBe(true);
-      }
+    assertSpanSetShape(probeBody, 'proxied /api/search');
+
+    // Wire-shape pin, passive half. Any /api/search response the page
+    // itself emitted (a lane whose Tempo datasource has streaming off,
+    // or a future app version that falls back to HTTP) gets the same
+    // shape check. Zero captures is the expected streaming-lane state
+    // and is not itself an assertion — the explicit probe above is what
+    // guarantees the shape is checked at all.
+    for (const body of searchBodies as SearchBody[]) {
+      if (!Array.isArray(body?.traces) || body.traces.length === 0) continue;
+      assertSpanSetShape(body, 'page-captured /api/search');
     }
   });
 });


### PR DESCRIPTION
## What

Two defects in the `dashboard` release gate (`dashboard-shard`, leg
`shard-smoke-b-monolith`), both red on every push to `main` since
407fbdcb.

### 1. `tempo_traces_drilldown.spec.ts` — HTTP capture on a streaming datasource

The spec's wire-shape pin harvested `/api/search?` responses with
`page.on('response')` and required at least one capture. PR #1665 set
`jsonData.streamingEnabled.search: true` on the `cerberus-tempo`
datasource, and this spec pins `var-ds=cerberus-tempo`, so Grafana's
Tempo datasource routes the drilldown's TraceQL search through
`handleStreamingQuery()` → Grafana Live (`/api/live/ws`) → the Grafana
backend's h2c gRPC call into cerberus's `StreamingQuerier`. The browser
therefore issues **zero** `/api/search?` HTTP requests, and the capture
is structurally empty.

This is a harness premise going void, not a cerberus regression: the
spec's UI half — Traces tab badge > 0, no empty state, span table rows
> 1, all of which are built exclusively from `spanSets` — **passed on
every CI attempt**, which is itself proof the gRPC path returns
correctly shaped payloads.

The HTTP half is now driven explicitly through the Grafana datasource
proxy with the same `limit` + `spss` caps the drilldown sends, and
asserts `200` + non-empty `traces` + non-empty `spanSets[0].spans` +
the populated legacy `spanSet` mirror. Nothing is relaxed: the shape
check moves *off* "whatever the page happened to emit" and *onto* a
request that always happens, so it cannot pass vacuously. Any
`/api/search` response the page does emit (a lane with streaming off, a
future app version that falls back to HTTP) still receives the
identical shape check.

### 2. The lane's Playwright report upload had never uploaded anything

A `--reporter=` on the command line **replaces** the config's
`reporter` array outright, so the bare `--reporter=list` these jobs
passed silenced `playwright.config.ts`'s html reporter. Every red run
logged:

```
##[warning]No files were found with the provided path: test/e2e/playwright/playwright-report. No artifacts will be uploaded.
```

and run 31029759827 has **zero** artifacts. The playwright steps now
name both reporters (`list,html`), and the dashboard upload carries
`test-results` alongside the report so traces, videos, screenshots and
error-context survive a red run.

This is load-bearing, not housekeeping: diagnosing the *other* failure
in this same shard required reproducing the entire 198-test shard
locally on k3d, purely because no CI evidence existed.

## Verification

Live k3d stack (`just e2e-up` → `just e2e-seed-rolling` → `just
e2e-wait-otel`), Grafana 12.2.9, `grafana-exploretraces-app@2.1.0`:

- `tempo_traces_drilldown.spec.ts` standalone — passes (10.0s).
- Full `shard-smoke-b-monolith` spec list under `CI=true` (198 tests,
  `workers: 1`) — the spec passes in-shard.
- The proxied search asserted by the new probe returns `traces: 2`,
  `spanSets: 1`, `spanSets[0].spans: 1`, legacy `spanSet.spans: 1` —
  the assertions have teeth against live data.
