### PR TITLE
test(coverage): raise real coverage above the floor in four packages

### DIFF
--- a/compatibility/tempo/driver/grpc_convert_test.go
+++ b/compatibility/tempo/driver/grpc_convert_test.go
@@ -1,0 +1,273 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/grafana/tempo/pkg/tempopb"
+	v1 "github.com/grafana/tempo/pkg/tempopb/common/v1"
+)
+
+// The grpc_convert.go converters exist to make the gRPC transport produce
+// byte-shape-compatible input to the UNCHANGED comparator. Every test here
+// therefore asserts on the *encoding conventions* the file's doc comment
+// promises — zero-uint64 collapses to an omitted JSON field, AnyValue
+// variants collapse to the flat string form MetricsLabel already tolerates
+// — rather than on field-copy plumbing alone. A converter that formatted a
+// zero as "0" would still round-trip through a field-by-field equality
+// check; it would not survive these.
+
+func TestFormatUint64OrEmpty(t *testing.T) {
+	t.Parallel()
+	if got := formatUint64OrEmpty(0); got != "" {
+		t.Fatalf("formatUint64OrEmpty(0) = %q, want %q (proto3-JSON omits zero-valued fields)", got, "")
+	}
+	if got := formatUint64OrEmpty(1); got != "1" {
+		t.Fatalf("formatUint64OrEmpty(1) = %q, want %q", got, "1")
+	}
+	// uint64 range must not narrow through an int conversion.
+	const maxUint64Decimal = "18446744073709551615"
+	if got := formatUint64OrEmpty(^uint64(0)); got != maxUint64Decimal {
+		t.Fatalf("formatUint64OrEmpty(max) = %q, want %q", got, maxUint64Decimal)
+	}
+}
+
+func TestTraceSummaryFromProto_ZeroTimestampOmittedInJSON(t *testing.T) {
+	t.Parallel()
+	// The whole point of formatUint64OrEmpty: a zero startTimeUnixNano
+	// must vanish from the marshalled body exactly as the HTTP/protojson
+	// side omits it, so the differ sees the same absent field on both
+	// transports.
+	summary := traceSummaryFromProto(&tempopb.TraceSearchMetadata{
+		TraceID:           "abc",
+		StartTimeUnixNano: 0,
+	})
+	body, err := json.Marshal(summary)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(body), "startTimeUnixNano") {
+		t.Fatalf("zero startTimeUnixNano leaked into JSON: %s", body)
+	}
+
+	summary = traceSummaryFromProto(&tempopb.TraceSearchMetadata{
+		TraceID:           "abc",
+		StartTimeUnixNano: 1_700_000_000_000_000_000,
+	})
+	body, err = json.Marshal(summary)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(body), `"startTimeUnixNano":"1700000000000000000"`) {
+		t.Fatalf("non-zero startTimeUnixNano not rendered as a decimal string: %s", body)
+	}
+}
+
+func TestTraceSummaryFromProto_Fields(t *testing.T) {
+	t.Parallel()
+	got := traceSummaryFromProto(&tempopb.TraceSearchMetadata{
+		TraceID:           "aabb",
+		RootServiceName:   "checkout",
+		RootTraceName:     "GET /api/checkout",
+		StartTimeUnixNano: 1000,
+		DurationMs:        150,
+		SpanSet:           &tempopb.SpanSet{Matched: 2},
+		SpanSets: []*tempopb.SpanSet{
+			{Matched: 1, Spans: []*tempopb.Span{{SpanID: "s1", Name: "db", DurationNanos: 42}}},
+			{Matched: 3},
+		},
+	})
+	if got.TraceID != "aabb" || got.RootServiceName != "checkout" || got.RootTraceName != "GET /api/checkout" {
+		t.Fatalf("identity fields not carried: %+v", got)
+	}
+	if got.StartTimeUnixNano != "1000" {
+		t.Fatalf("StartTimeUnixNano = %q, want %q", got.StartTimeUnixNano, "1000")
+	}
+	if got.DurationMs != 150 {
+		t.Fatalf("DurationMs = %d, want 150", got.DurationMs)
+	}
+	if got.SpanSet == nil || got.SpanSet.Matched != 2 {
+		t.Fatalf("SpanSet = %+v, want a non-nil pointer with Matched=2", got.SpanSet)
+	}
+	if len(got.SpanSets) != 2 {
+		t.Fatalf("SpanSets len = %d, want 2", len(got.SpanSets))
+	}
+	if got.SpanSets[0].Matched != 1 || got.SpanSets[1].Matched != 3 {
+		t.Fatalf("SpanSets order/content wrong: %+v", got.SpanSets)
+	}
+	if len(got.SpanSets[0].Spans) != 1 || got.SpanSets[0].Spans[0].DurationNanos != "42" {
+		t.Fatalf("nested span not converted: %+v", got.SpanSets[0])
+	}
+}
+
+func TestTraceSummaryFromProto_NilAndAbsentSpanSet(t *testing.T) {
+	t.Parallel()
+	if got := traceSummaryFromProto(nil); got.TraceID != "" || got.SpanSet != nil || got.SpanSets != nil {
+		t.Fatalf("traceSummaryFromProto(nil) = %+v, want the zero TraceSummary", got)
+	}
+	// An absent SpanSet must stay a nil pointer (JSON-omitted), not a
+	// pointer to a zero SpanSetJSON, which would render `"spanSet":{}`
+	// and diff against the HTTP side's omission.
+	got := traceSummaryFromProto(&tempopb.TraceSearchMetadata{TraceID: "x"})
+	if got.SpanSet != nil {
+		t.Fatalf("absent SpanSet materialised as %+v, want nil", got.SpanSet)
+	}
+	body, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(body), "spanSet") {
+		t.Fatalf("absent spanSet leaked into JSON: %s", body)
+	}
+}
+
+func TestSpanSetFromProto_NilSetAndNilSpanSkipped(t *testing.T) {
+	t.Parallel()
+	if got := spanSetFromProto(nil); got.Matched != 0 || got.Spans != nil {
+		t.Fatalf("spanSetFromProto(nil) = %+v, want the zero SpanSetJSON", got)
+	}
+	got := spanSetFromProto(&tempopb.SpanSet{
+		Matched: 7,
+		Spans: []*tempopb.Span{
+			nil,
+			{SpanID: "s1", Name: "db.query", StartTimeUnixNano: 5, DurationNanos: 0},
+		},
+	})
+	if got.Matched != 7 {
+		t.Fatalf("Matched = %d, want 7", got.Matched)
+	}
+	if len(got.Spans) != 1 {
+		t.Fatalf("Spans len = %d, want 1 (the nil span must be skipped, not converted)", len(got.Spans))
+	}
+	sp := got.Spans[0]
+	if sp.SpanID != "s1" || sp.Name != "db.query" || sp.StartTimeUnixNano != "5" {
+		t.Fatalf("span fields wrong: %+v", sp)
+	}
+	if sp.DurationNanos != "" {
+		t.Fatalf("zero DurationNanos = %q, want %q", sp.DurationNanos, "")
+	}
+}
+
+func TestTagsV2ScopeFromProto_NilAndDefensiveCopy(t *testing.T) {
+	t.Parallel()
+	if got := tagsV2ScopeFromProto(nil); got.Name != "" || got.Tags != nil {
+		t.Fatalf("tagsV2ScopeFromProto(nil) = %+v, want the zero TagNamesScope", got)
+	}
+	src := &tempopb.SearchTagsV2Scope{Name: "resource", Tags: []string{"service.name", "cluster"}}
+	got := tagsV2ScopeFromProto(src)
+	if got.Name != "resource" || len(got.Tags) != 2 {
+		t.Fatalf("tagsV2ScopeFromProto = %+v", got)
+	}
+	// The converter copies rather than aliasing, so a later reuse of the
+	// streamed frame's backing array can't rewrite an already-accumulated
+	// scope.
+	src.Tags[0] = "mutated"
+	if got.Tags[0] != "service.name" {
+		t.Fatalf("Tags aliases the proto frame's slice: got %q after mutating the source", got.Tags[0])
+	}
+}
+
+func TestTagValueV2FromProto(t *testing.T) {
+	t.Parallel()
+	if got := tagValueV2FromProto(nil); got.Type != "" || got.Value != "" {
+		t.Fatalf("tagValueV2FromProto(nil) = %+v, want the zero TagValueV2", got)
+	}
+	got := tagValueV2FromProto(&tempopb.TagValue{Type: "string", Value: "checkout"})
+	if got.Type != "string" || got.Value != "checkout" {
+		t.Fatalf("tagValueV2FromProto = %+v", got)
+	}
+}
+
+func TestAnyValueToString_AllVariants(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   *v1.AnyValue
+		want string
+	}{
+		{"nil pointer", nil, ""},
+		{"unset variant (nil group-by bucket)", &v1.AnyValue{}, ""},
+		{"string", &v1.AnyValue{Value: &v1.AnyValue_StringValue{StringValue: "checkout"}}, "checkout"},
+		{"empty string stays empty", &v1.AnyValue{Value: &v1.AnyValue_StringValue{StringValue: ""}}, ""},
+		{"int64 as decimal string", &v1.AnyValue{Value: &v1.AnyValue_IntValue{IntValue: -7}}, "-7"},
+		{"double", &v1.AnyValue{Value: &v1.AnyValue_DoubleValue{DoubleValue: 1.5}}, "1.5"},
+		{"bool true", &v1.AnyValue{Value: &v1.AnyValue_BoolValue{BoolValue: true}}, "true"},
+		{"bool false", &v1.AnyValue{Value: &v1.AnyValue_BoolValue{BoolValue: false}}, "false"},
+		{"unsupported variant falls back to empty", &v1.AnyValue{Value: &v1.AnyValue_BytesValue{BytesValue: []byte("x")}}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := anyValueToString(tc.in); got != tc.want {
+				t.Fatalf("anyValueToString = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAnyValueToString_MatchesHTTPSideUnmarshal(t *testing.T) {
+	t.Parallel()
+	// The converter's contract is "produce what MetricsLabel.UnmarshalJSON
+	// produces from the equivalent HTTP body". Pin the two representations
+	// against each other so a change to either side has to change both.
+	var viaHTTP MetricsLabel
+	if err := json.Unmarshal([]byte(`{"key":"k","value":{"doubleValue":1.5}}`), &viaHTTP); err != nil {
+		t.Fatalf("unmarshal HTTP-shape label: %v", err)
+	}
+	viaGRPC := keyValuesToLabels([]v1.KeyValue{{
+		Key:   "k",
+		Value: &v1.AnyValue{Value: &v1.AnyValue_DoubleValue{DoubleValue: 1.5}},
+	}})
+	if len(viaGRPC) != 1 || viaGRPC[0] != viaHTTP {
+		t.Fatalf("gRPC label %+v != HTTP label %+v", viaGRPC, viaHTTP)
+	}
+}
+
+func TestKeyValuesToLabels_OrderAndEmpty(t *testing.T) {
+	t.Parallel()
+	// An empty label set must convert to a non-nil empty slice: nil would
+	// marshal to `null` where the HTTP side emits `[]`.
+	got := keyValuesToLabels(nil)
+	if got == nil {
+		t.Fatal("keyValuesToLabels(nil) returned a nil slice; want an empty non-nil slice")
+	}
+	if len(got) != 0 {
+		t.Fatalf("keyValuesToLabels(nil) = %+v, want empty", got)
+	}
+
+	got = keyValuesToLabels([]v1.KeyValue{
+		{Key: "b", Value: &v1.AnyValue{Value: &v1.AnyValue_StringValue{StringValue: "2"}}},
+		{Key: "a", Value: nil},
+	})
+	want := []MetricsLabel{{Key: "b", Value: "2"}, {Key: "a", Value: ""}}
+	if len(got) != len(want) {
+		t.Fatalf("len = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("label[%d] = %+v, want %+v (wire order must be preserved)", i, got[i], want[i])
+		}
+	}
+}
+
+func TestMarshalDiffBody(t *testing.T) {
+	t.Parallel()
+	body, err := marshalDiffBody(TagNamesResponseV1{TagNames: []string{"a"}})
+	if err != nil {
+		t.Fatalf("marshalDiffBody: %v", err)
+	}
+	if string(body) != `{"tagNames":["a"]}` {
+		t.Fatalf("body = %s", body)
+	}
+
+	// The error arm exists so every fetcher wraps a marshal failure
+	// identically; a channel is the canonical unmarshalable value.
+	_, err = marshalDiffBody(make(chan int))
+	if err == nil {
+		t.Fatal("marshalDiffBody(chan) returned no error")
+	}
+	if !strings.Contains(err.Error(), "marshal accumulated grpc response") {
+		t.Fatalf("error not wrapped with the shared prefix: %v", err)
+	}
+}

--- a/compatibility/tempo/driver/grpc_diff_test.go
+++ b/compatibility/tempo/driver/grpc_diff_test.go
@@ -1,0 +1,764 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/grafana/tempo/pkg/tempopb"
+	v1 "github.com/grafana/tempo/pkg/tempopb/common/v1"
+	"google.golang.org/grpc"
+)
+
+// The gRPC transport's whole claim is that it is a transport-only
+// difference from the comparator's perspective: drain the stream, flatten
+// the frames, hand the comparator the same JSON shape the HTTP path
+// decodes. tempopb.StreamingQuerierClient is an interface, so that claim
+// is testable without a server — the fake below returns canned frames and
+// the assertions below check the three things that can actually go wrong:
+// multi-frame accumulation, request-field wiring (the Unix-seconds vs
+// nanoseconds split between the search-side and metrics-side RPCs), and
+// error wrapping on the open / recv arms.
+
+// fakeStream replays canned frames and then either io.EOF or a canned
+// recv error. It embeds the nil grpc.ClientStream because the fetchers
+// only ever call Recv.
+type fakeStream[T any] struct {
+	grpc.ClientStream
+	frames []T
+	recv   error
+	i      int
+}
+
+func (f *fakeStream[T]) Recv() (T, error) {
+	if f.i < len(f.frames) {
+		v := f.frames[f.i]
+		f.i++
+		return v, nil
+	}
+	var zero T
+	if f.recv != nil {
+		return zero, f.recv
+	}
+	return zero, io.EOF
+}
+
+var (
+	errOpen = errors.New("dial refused")
+	errRecv = errors.New("stream broke mid-drain")
+)
+
+// fakeQuerier implements tempopb.StreamingQuerierClient over canned
+// frames, records the request each RPC received, and can be told to fail
+// either at open time or mid-drain.
+type fakeQuerier struct {
+	searchFrames       []*tempopb.SearchResponse
+	tagsV1Frames       []*tempopb.SearchTagsResponse
+	tagsV2Frames       []*tempopb.SearchTagsV2Response
+	tagValuesV1Frames  []*tempopb.SearchTagValuesResponse
+	tagValuesV2Frames  []*tempopb.SearchTagValuesV2Response
+	metricsRangeFrames []*tempopb.QueryRangeResponse
+	metricsInstFrames  []*tempopb.QueryInstantResponse
+
+	openErr error
+	recvErr error
+
+	searchReq    *tempopb.SearchRequest
+	tagsReq      *tempopb.SearchTagsRequest
+	tagsV2Req    *tempopb.SearchTagsRequest
+	tagValuesReq *tempopb.SearchTagValuesRequest
+	tagValsV2Req *tempopb.SearchTagValuesRequest
+	rangeReq     *tempopb.QueryRangeRequest
+	instantReq   *tempopb.QueryInstantRequest
+}
+
+func (f *fakeQuerier) Search(_ context.Context, in *tempopb.SearchRequest, _ ...grpc.CallOption) (tempopb.StreamingQuerier_SearchClient, error) {
+	f.searchReq = in
+	if f.openErr != nil {
+		return nil, f.openErr
+	}
+	return &fakeStream[*tempopb.SearchResponse]{frames: f.searchFrames, recv: f.recvErr}, nil
+}
+
+func (f *fakeQuerier) SearchTags(_ context.Context, in *tempopb.SearchTagsRequest, _ ...grpc.CallOption) (tempopb.StreamingQuerier_SearchTagsClient, error) {
+	f.tagsReq = in
+	if f.openErr != nil {
+		return nil, f.openErr
+	}
+	return &fakeStream[*tempopb.SearchTagsResponse]{frames: f.tagsV1Frames, recv: f.recvErr}, nil
+}
+
+func (f *fakeQuerier) SearchTagsV2(_ context.Context, in *tempopb.SearchTagsRequest, _ ...grpc.CallOption) (tempopb.StreamingQuerier_SearchTagsV2Client, error) {
+	f.tagsV2Req = in
+	if f.openErr != nil {
+		return nil, f.openErr
+	}
+	return &fakeStream[*tempopb.SearchTagsV2Response]{frames: f.tagsV2Frames, recv: f.recvErr}, nil
+}
+
+func (f *fakeQuerier) SearchTagValues(_ context.Context, in *tempopb.SearchTagValuesRequest, _ ...grpc.CallOption) (tempopb.StreamingQuerier_SearchTagValuesClient, error) {
+	f.tagValuesReq = in
+	if f.openErr != nil {
+		return nil, f.openErr
+	}
+	return &fakeStream[*tempopb.SearchTagValuesResponse]{frames: f.tagValuesV1Frames, recv: f.recvErr}, nil
+}
+
+func (f *fakeQuerier) SearchTagValuesV2(_ context.Context, in *tempopb.SearchTagValuesRequest, _ ...grpc.CallOption) (tempopb.StreamingQuerier_SearchTagValuesV2Client, error) {
+	f.tagValsV2Req = in
+	if f.openErr != nil {
+		return nil, f.openErr
+	}
+	return &fakeStream[*tempopb.SearchTagValuesV2Response]{frames: f.tagValuesV2Frames, recv: f.recvErr}, nil
+}
+
+func (f *fakeQuerier) MetricsQueryRange(_ context.Context, in *tempopb.QueryRangeRequest, _ ...grpc.CallOption) (tempopb.StreamingQuerier_MetricsQueryRangeClient, error) {
+	f.rangeReq = in
+	if f.openErr != nil {
+		return nil, f.openErr
+	}
+	return &fakeStream[*tempopb.QueryRangeResponse]{frames: f.metricsRangeFrames, recv: f.recvErr}, nil
+}
+
+func (f *fakeQuerier) MetricsQueryInstant(_ context.Context, in *tempopb.QueryInstantRequest, _ ...grpc.CallOption) (tempopb.StreamingQuerier_MetricsQueryInstantClient, error) {
+	f.instantReq = in
+	if f.openErr != nil {
+		return nil, f.openErr
+	}
+	return &fakeStream[*tempopb.QueryInstantResponse]{frames: f.metricsInstFrames, recv: f.recvErr}, nil
+}
+
+// testWindowStart / testWindowEnd are a fixed compatibility window; the
+// exact instants don't matter, only that the two RPC families encode them
+// in their own units.
+var (
+	testWindowStart = time.Unix(1_700_000_000, 0).UTC()
+	testWindowEnd   = time.Unix(1_700_003_600, 0).UTC()
+)
+
+func testOpts() caseOpts {
+	return caseOpts{startTS: testWindowStart, endTS: testWindowEnd, searchLimit: 20}
+}
+
+func TestGRPCSupportsEndpoint(t *testing.T) {
+	t.Parallel()
+	// The 7 RPCs tempopb.StreamingQuerier actually exposes.
+	for _, ep := range []string{"search", "tags_v1", "tags_v2", "tag_values_v1", "tag_values_v2", "metrics_range", "metrics_instant"} {
+		if !grpcSupportsEndpoint(ep) {
+			t.Errorf("grpcSupportsEndpoint(%q) = false, want true — it has a StreamingQuerier RPC", ep)
+		}
+	}
+	// There is no trace-by-id and no search/recent RPC on either backend.
+	for _, ep := range []string{"traces", "traces_v2", "search_recent", "", "SEARCH"} {
+		if grpcSupportsEndpoint(ep) {
+			t.Errorf("grpcSupportsEndpoint(%q) = true, want false — no StreamingQuerier RPC exists", ep)
+		}
+	}
+}
+
+func TestUnixSeconds32_ClampsInsteadOfWrapping(t *testing.T) {
+	t.Parallel()
+	if got := unixSeconds32(testWindowStart); got != 1_700_000_000 {
+		t.Fatalf("unixSeconds32(recent) = %d, want 1700000000", got)
+	}
+	// A pre-epoch instant must saturate to 0 rather than wrap to a huge
+	// uint32, which would silently push the window bound past the data.
+	if got := unixSeconds32(time.Unix(-1, 0)); got != 0 {
+		t.Fatalf("unixSeconds32(pre-epoch) = %d, want 0", got)
+	}
+	if got := unixSeconds32(time.Unix(math.MaxUint32+1, 0)); got != math.MaxUint32 {
+		t.Fatalf("unixSeconds32(post-2106) = %d, want %d", got, uint32(math.MaxUint32))
+	}
+	if got := unixSeconds32(time.Unix(math.MaxUint32, 0)); got != math.MaxUint32 {
+		t.Fatalf("unixSeconds32(exactly MaxUint32) = %d, want %d", got, uint32(math.MaxUint32))
+	}
+}
+
+func TestFetchGRPCSearch_AccumulatesEveryFrame(t *testing.T) {
+	t.Parallel()
+	// cerberus batches searchFrameSize=20 summaries per frame, so the
+	// fetcher MUST drain to EOF; a fetcher that returned after the first
+	// frame would silently truncate the result set and read as a diff.
+	client := &fakeQuerier{searchFrames: []*tempopb.SearchResponse{
+		{Traces: []*tempopb.TraceSearchMetadata{
+			{TraceID: "t1", RootServiceName: "checkout", DurationMs: 5},
+			{TraceID: "t2", RootServiceName: "cart"},
+		}},
+		{Traces: []*tempopb.TraceSearchMetadata{{TraceID: "t3"}}},
+	}}
+	tc := CorpusCase{Name: "c", Endpoint: "search", Query: `{}`, Spss: 3}
+	body, err := fetchGRPCSearch(context.Background(), client, tc, testOpts())
+	if err != nil {
+		t.Fatalf("fetchGRPCSearch: %v", err)
+	}
+	for _, id := range []string{`"t1"`, `"t2"`, `"t3"`} {
+		if !strings.Contains(string(body), id) {
+			t.Fatalf("frame accumulation dropped %s: %s", id, body)
+		}
+	}
+	if client.searchReq.Query != `{}` {
+		t.Fatalf("Query = %q, want %q", client.searchReq.Query, `{}`)
+	}
+	if client.searchReq.Limit != 20 {
+		t.Fatalf("Limit = %d, want the caseOpts searchLimit 20", client.searchReq.Limit)
+	}
+	if client.searchReq.SpansPerSpanSet != 3 {
+		t.Fatalf("SpansPerSpanSet = %d, want 3", client.searchReq.SpansPerSpanSet)
+	}
+	// SearchRequest's Start/End are Unix SECONDS, not nanoseconds.
+	if client.searchReq.Start != 1_700_000_000 || client.searchReq.End != 1_700_003_600 {
+		t.Fatalf("Start/End = %d/%d, want unix seconds 1700000000/1700003600", client.searchReq.Start, client.searchReq.End)
+	}
+}
+
+func TestFetchGRPCSearch_SpssLeftUnsetWhenZero(t *testing.T) {
+	t.Parallel()
+	client := &fakeQuerier{}
+	if _, err := fetchGRPCSearch(context.Background(), client, CorpusCase{Endpoint: "search"}, testOpts()); err != nil {
+		t.Fatalf("fetchGRPCSearch: %v", err)
+	}
+	if client.searchReq.SpansPerSpanSet != 0 {
+		t.Fatalf("SpansPerSpanSet = %d with no corpus -- spss --, want it left unset", client.searchReq.SpansPerSpanSet)
+	}
+}
+
+func TestFetchGRPCSearch_EmptyStreamMarshalsEmptyEnvelope(t *testing.T) {
+	t.Parallel()
+	body, err := fetchGRPCSearch(context.Background(), &fakeQuerier{}, CorpusCase{Endpoint: "search"}, testOpts())
+	if err != nil {
+		t.Fatalf("fetchGRPCSearch: %v", err)
+	}
+	// The comparator decodes this; it must be valid JSON with a traces key.
+	if !strings.Contains(string(body), "traces") {
+		t.Fatalf("empty stream produced %s, want a traces envelope", body)
+	}
+}
+
+func TestFetchGRPCTagsV1(t *testing.T) {
+	t.Parallel()
+	client := &fakeQuerier{tagsV1Frames: []*tempopb.SearchTagsResponse{
+		{TagNames: []string{"a"}},
+		{TagNames: []string{"b", "c"}},
+	}}
+	body, err := fetchGRPCTagsV1(context.Background(), client, testOpts())
+	if err != nil {
+		t.Fatalf("fetchGRPCTagsV1: %v", err)
+	}
+	if string(body) != `{"tagNames":["a","b","c"]}` {
+		t.Fatalf("body = %s", body)
+	}
+	if client.tagsReq.Start != 1_700_000_000 || client.tagsReq.End != 1_700_003_600 {
+		t.Fatalf("window not wired: %+v", client.tagsReq)
+	}
+}
+
+func TestFetchGRPCTagsV2_CarriesScope(t *testing.T) {
+	t.Parallel()
+	client := &fakeQuerier{tagsV2Frames: []*tempopb.SearchTagsV2Response{
+		{Scopes: []*tempopb.SearchTagsV2Scope{{Name: "resource", Tags: []string{"service.name"}}}},
+		{Scopes: []*tempopb.SearchTagsV2Scope{{Name: "span", Tags: []string{"http.method"}}}},
+	}}
+	tc := CorpusCase{Endpoint: "tags_v2", Scope: "resource"}
+	body, err := fetchGRPCTagsV2(context.Background(), client, tc, testOpts())
+	if err != nil {
+		t.Fatalf("fetchGRPCTagsV2: %v", err)
+	}
+	if !strings.Contains(string(body), `"resource"`) || !strings.Contains(string(body), `"span"`) {
+		t.Fatalf("scopes not accumulated across frames: %s", body)
+	}
+	if client.tagsV2Req.Scope != "resource" {
+		t.Fatalf("Scope = %q, want the corpus case's scope", client.tagsV2Req.Scope)
+	}
+}
+
+func TestFetchGRPCTagValuesV1(t *testing.T) {
+	t.Parallel()
+	client := &fakeQuerier{tagValuesV1Frames: []*tempopb.SearchTagValuesResponse{
+		{TagValues: []string{"checkout"}},
+		{TagValues: []string{"cart"}},
+	}}
+	tc := CorpusCase{Endpoint: "tag_values_v1", TagName: "service.name"}
+	body, err := fetchGRPCTagValuesV1(context.Background(), client, tc, testOpts())
+	if err != nil {
+		t.Fatalf("fetchGRPCTagValuesV1: %v", err)
+	}
+	if string(body) != `{"tagValues":["checkout","cart"]}` {
+		t.Fatalf("body = %s", body)
+	}
+	if client.tagValuesReq.TagName != "service.name" {
+		t.Fatalf("TagName = %q, want the corpus case's tag name", client.tagValuesReq.TagName)
+	}
+}
+
+func TestFetchGRPCTagValuesV2_KeepsTypes(t *testing.T) {
+	t.Parallel()
+	client := &fakeQuerier{tagValuesV2Frames: []*tempopb.SearchTagValuesV2Response{
+		{TagValues: []*tempopb.TagValue{{Type: "string", Value: "checkout"}}},
+		{TagValues: []*tempopb.TagValue{{Type: "int", Value: "7"}}},
+	}}
+	tc := CorpusCase{Endpoint: "tag_values_v2", TagName: "span.http.status_code"}
+	body, err := fetchGRPCTagValuesV2(context.Background(), client, tc, testOpts())
+	if err != nil {
+		t.Fatalf("fetchGRPCTagValuesV2: %v", err)
+	}
+	if !strings.Contains(string(body), `"type":"string"`) || !strings.Contains(string(body), `"type":"int"`) {
+		t.Fatalf("typed values not carried: %s", body)
+	}
+	if client.tagValsV2Req.TagName != "span.http.status_code" {
+		t.Fatalf("TagName = %q", client.tagValsV2Req.TagName)
+	}
+}
+
+func TestFetchGRPCMetricsRange_NanosecondWindowAndStep(t *testing.T) {
+	t.Parallel()
+	client := &fakeQuerier{metricsRangeFrames: []*tempopb.QueryRangeResponse{{
+		Series: []*tempopb.TimeSeries{{
+			Labels:  []v1.KeyValue{{Key: "svc", Value: &v1.AnyValue{Value: &v1.AnyValue_StringValue{StringValue: "checkout"}}}},
+			Samples: []tempopb.Sample{{TimestampMs: 1000, Value: 2.5}},
+		}},
+	}}}
+	tc := CorpusCase{Endpoint: "metrics_range", Query: `{} | rate()`, Step: "60s"}
+	body, err := fetchGRPCMetricsRange(context.Background(), client, tc, testOpts())
+	if err != nil {
+		t.Fatalf("fetchGRPCMetricsRange: %v", err)
+	}
+	if !strings.Contains(string(body), `"checkout"`) || !strings.Contains(string(body), "2.5") {
+		t.Fatalf("series not converted: %s", body)
+	}
+	// The metrics RPCs use NANOSECOND bounds, unlike the search-side RPCs.
+	if client.rangeReq.Start != uint64(testWindowStart.UnixNano()) {
+		t.Fatalf("Start = %d, want nanoseconds %d", client.rangeReq.Start, testWindowStart.UnixNano())
+	}
+	if client.rangeReq.End != uint64(testWindowEnd.UnixNano()) {
+		t.Fatalf("End = %d, want nanoseconds %d", client.rangeReq.End, testWindowEnd.UnixNano())
+	}
+	if client.rangeReq.Step != uint64(time.Minute.Nanoseconds()) {
+		t.Fatalf("Step = %d, want 60s in nanoseconds", client.rangeReq.Step)
+	}
+}
+
+func TestFetchGRPCMetricsRange_BadStepIsAnError(t *testing.T) {
+	t.Parallel()
+	tc := CorpusCase{Endpoint: "metrics_range", Step: "banana"}
+	_, err := fetchGRPCMetricsRange(context.Background(), &fakeQuerier{}, tc, testOpts())
+	if err == nil {
+		t.Fatal("unparseable -- step -- accepted")
+	}
+	if !strings.Contains(err.Error(), "banana") {
+		t.Fatalf("error should name the offending step: %v", err)
+	}
+}
+
+func TestFetchGRPCMetricsInstant_ScalarValueAndNilSeriesSkipped(t *testing.T) {
+	t.Parallel()
+	client := &fakeQuerier{metricsInstFrames: []*tempopb.QueryInstantResponse{{
+		Series: []*tempopb.InstantSeries{
+			nil,
+			{
+				Labels: []v1.KeyValue{{Key: "svc", Value: &v1.AnyValue{Value: &v1.AnyValue_StringValue{StringValue: "cart"}}}},
+				Value:  3.25,
+			},
+		},
+	}}}
+	tc := CorpusCase{Endpoint: "metrics_instant", Query: `{} | count_over_time()`}
+	body, err := fetchGRPCMetricsInstant(context.Background(), client, tc, testOpts())
+	if err != nil {
+		t.Fatalf("fetchGRPCMetricsInstant: %v", err)
+	}
+	if strings.Count(string(body), `"value"`) != 1 {
+		t.Fatalf("nil series not skipped (want exactly one value entry): %s", body)
+	}
+	if !strings.Contains(string(body), "3.25") {
+		t.Fatalf("scalar value missing: %s", body)
+	}
+	if strings.Contains(string(body), "samples") {
+		t.Fatalf("instant response must not carry a samples array: %s", body)
+	}
+	if client.instantReq.Start != uint64(testWindowStart.UnixNano()) {
+		t.Fatalf("Start = %d, want nanoseconds", client.instantReq.Start)
+	}
+}
+
+func TestMetricsSeriesFromProtoRange(t *testing.T) {
+	t.Parallel()
+	if got := metricsSeriesFromProtoRange(nil); got.Labels != nil || got.Samples != nil {
+		t.Fatalf("metricsSeriesFromProtoRange(nil) = %+v, want the zero entry", got)
+	}
+	got := metricsSeriesFromProtoRange(&tempopb.TimeSeries{
+		Labels:  []v1.KeyValue{{Key: "svc", Value: &v1.AnyValue{Value: &v1.AnyValue_IntValue{IntValue: 7}}}},
+		Samples: []tempopb.Sample{{TimestampMs: 10, Value: 1}, {TimestampMs: 20, Value: 2}},
+		Exemplars: []tempopb.Exemplar{{
+			Labels:      []v1.KeyValue{{Key: "trace", Value: &v1.AnyValue{Value: &v1.AnyValue_StringValue{StringValue: "abc"}}}},
+			Value:       9,
+			TimestampMs: 15,
+		}},
+	})
+	if len(got.Labels) != 1 || got.Labels[0].Value != "7" {
+		t.Fatalf("labels = %+v, want the int variant flattened to \"7\"", got.Labels)
+	}
+	if len(got.Samples) != 2 || got.Samples[1].TimestampMs != 20 || got.Samples[1].Value != 2 {
+		t.Fatalf("samples = %+v", got.Samples)
+	}
+	if len(got.Exemplars) != 1 || got.Exemplars[0].Value != 9 || got.Exemplars[0].TimestampMs != 15 {
+		t.Fatalf("exemplars = %+v", got.Exemplars)
+	}
+	if len(got.Exemplars[0].Labels) != 1 || got.Exemplars[0].Labels[0].Key != "trace" {
+		t.Fatalf("exemplar labels = %+v", got.Exemplars[0].Labels)
+	}
+	// Range series carry Samples, never a scalar Value.
+	if got.Value != nil {
+		t.Fatalf("Value = %v, want nil on a range series", *got.Value)
+	}
+}
+
+func TestFetchGRPCForEndpoint_DispatchesToTheMatchingRPC(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		endpoint string
+		hit      func(*fakeQuerier) bool
+	}{
+		{"search", func(f *fakeQuerier) bool { return f.searchReq != nil }},
+		{"tags_v1", func(f *fakeQuerier) bool { return f.tagsReq != nil }},
+		{"tags_v2", func(f *fakeQuerier) bool { return f.tagsV2Req != nil }},
+		{"tag_values_v1", func(f *fakeQuerier) bool { return f.tagValuesReq != nil }},
+		{"tag_values_v2", func(f *fakeQuerier) bool { return f.tagValsV2Req != nil }},
+		{"metrics_range", func(f *fakeQuerier) bool { return f.rangeReq != nil }},
+		{"metrics_instant", func(f *fakeQuerier) bool { return f.instantReq != nil }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.endpoint, func(t *testing.T) {
+			t.Parallel()
+			client := &fakeQuerier{}
+			cc := CorpusCase{Endpoint: tc.endpoint, Step: "60s", TagName: "svc"}
+			if _, err := fetchGRPCForEndpoint(context.Background(), client, cc, testOpts()); err != nil {
+				t.Fatalf("fetchGRPCForEndpoint(%s): %v", tc.endpoint, err)
+			}
+			if !tc.hit(client) {
+				t.Fatalf("endpoint %q dispatched to the wrong RPC", tc.endpoint)
+			}
+		})
+	}
+}
+
+func TestFetchGRPCForEndpoint_UnsupportedEndpoint(t *testing.T) {
+	t.Parallel()
+	for _, ep := range []string{"traces", "traces_v2", "search_recent"} {
+		_, err := fetchGRPCForEndpoint(context.Background(), &fakeQuerier{}, CorpusCase{Endpoint: ep}, testOpts())
+		if err == nil {
+			t.Fatalf("endpoint %q accepted; it has no StreamingQuerier RPC", ep)
+		}
+		if !strings.Contains(err.Error(), ep) {
+			t.Fatalf("error should name the endpoint, got %v", err)
+		}
+	}
+}
+
+func TestFetchGRPC_OpenErrorIsWrappedPerRPC(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		endpoint string
+		wantWrap string
+	}{
+		{"search", "open Search stream"},
+		{"tags_v1", "open SearchTags stream"},
+		{"tags_v2", "open SearchTagsV2 stream"},
+		{"tag_values_v1", "open SearchTagValues stream"},
+		{"tag_values_v2", "open SearchTagValuesV2 stream"},
+		{"metrics_range", "open MetricsQueryRange stream"},
+		{"metrics_instant", "open MetricsQueryInstant stream"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.endpoint, func(t *testing.T) {
+			t.Parallel()
+			client := &fakeQuerier{openErr: errOpen}
+			cc := CorpusCase{Endpoint: tc.endpoint, Step: "60s"}
+			_, err := fetchGRPCForEndpoint(context.Background(), client, cc, testOpts())
+			if err == nil {
+				t.Fatalf("open failure swallowed for %s", tc.endpoint)
+			}
+			if !strings.Contains(err.Error(), tc.wantWrap) {
+				t.Fatalf("error = %v, want it wrapped with %q", err, tc.wantWrap)
+			}
+			if !errors.Is(err, errOpen) {
+				t.Fatalf("error = %v, want the cause preserved via %%w", err)
+			}
+		})
+	}
+}
+
+func TestFetchGRPC_RecvErrorIsWrappedPerRPC(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		endpoint string
+		wantWrap string
+	}{
+		{"search", "recv Search frame"},
+		{"tags_v1", "recv SearchTags frame"},
+		{"tags_v2", "recv SearchTagsV2 frame"},
+		{"tag_values_v1", "recv SearchTagValues frame"},
+		{"tag_values_v2", "recv SearchTagValuesV2 frame"},
+		{"metrics_range", "recv MetricsQueryRange frame"},
+		{"metrics_instant", "recv MetricsQueryInstant frame"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.endpoint, func(t *testing.T) {
+			t.Parallel()
+			client := &fakeQuerier{recvErr: errRecv}
+			cc := CorpusCase{Endpoint: tc.endpoint, Step: "60s"}
+			_, err := fetchGRPCForEndpoint(context.Background(), client, cc, testOpts())
+			if err == nil {
+				t.Fatalf("mid-drain failure swallowed for %s — a truncated stream would read as a diff", tc.endpoint)
+			}
+			if !strings.Contains(err.Error(), tc.wantWrap) {
+				t.Fatalf("error = %v, want it wrapped with %q", err, tc.wantWrap)
+			}
+			if !errors.Is(err, errRecv) {
+				t.Fatalf("error = %v, want the cause preserved via %%w", err)
+			}
+		})
+	}
+}
+
+func TestDiffCaseGRPC_AgreeingBackends(t *testing.T) {
+	t.Parallel()
+	frames := func() []*tempopb.SearchResponse {
+		return []*tempopb.SearchResponse{{Traces: []*tempopb.TraceSearchMetadata{
+			{TraceID: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", RootServiceName: "checkout", RootTraceName: "GET /", DurationMs: 5, StartTimeUnixNano: 1000},
+		}}}
+	}
+	tc := CorpusCase{Name: "agree", Endpoint: "search", Query: `{}`, ExpectedMinTraces: 1}
+	res := diffCaseGRPC(context.Background(),
+		&fakeQuerier{searchFrames: frames()},
+		&fakeQuerier{searchFrames: frames()},
+		tc, testOpts())
+	if res.HardError != "" {
+		t.Fatalf("HardError = %q, want none", res.HardError)
+	}
+	if len(res.Assertions) != 0 {
+		t.Fatalf("Assertions = %+v, want none", res.Assertions)
+	}
+	if !res.Diff.Equal {
+		t.Fatalf("Diff.Equal = false, want true for byte-identical streams: %+v", res.Diff)
+	}
+	if !res.passed() {
+		t.Fatal("passed() = false for an agreeing case")
+	}
+}
+
+func TestDiffCaseGRPC_DivergingBackendsSurfaceADiff(t *testing.T) {
+	t.Parallel()
+	tempoFrames := []*tempopb.SearchResponse{{Traces: []*tempopb.TraceSearchMetadata{
+		{TraceID: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", RootServiceName: "checkout"},
+	}}}
+	cerbFrames := []*tempopb.SearchResponse{{Traces: []*tempopb.TraceSearchMetadata{
+		{TraceID: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", RootServiceName: "checkout"},
+	}}}
+	tc := CorpusCase{Name: "diverge", Endpoint: "search", Query: `{}`}
+	res := diffCaseGRPC(context.Background(),
+		&fakeQuerier{searchFrames: tempoFrames},
+		&fakeQuerier{searchFrames: cerbFrames},
+		tc, testOpts())
+	if res.HardError != "" {
+		t.Fatalf("HardError = %q, want none — the fetch succeeded on both sides", res.HardError)
+	}
+	if res.Diff.Equal {
+		t.Fatal("Diff.Equal = true for backends returning different trace IDs")
+	}
+	if res.passed() {
+		t.Fatal("passed() = true for a diverging case")
+	}
+}
+
+func TestDiffCaseGRPC_AssertionFailureIsNotAHardError(t *testing.T) {
+	t.Parallel()
+	// Both backends agree with each other but neither meets the corpus's
+	// cardinality floor: that is an assertion, not a transport failure,
+	// and it must keep the diff result intact.
+	tc := CorpusCase{Name: "too-few", Endpoint: "search", Query: `{}`, ExpectedMinTraces: 2}
+	res := diffCaseGRPC(context.Background(), &fakeQuerier{}, &fakeQuerier{}, tc, testOpts())
+	if res.HardError != "" {
+		t.Fatalf("HardError = %q, want none", res.HardError)
+	}
+	if len(res.Assertions) != 2 {
+		t.Fatalf("Assertions = %+v, want one per backend", res.Assertions)
+	}
+	if res.passed() {
+		t.Fatal("passed() = true despite a failed assertion")
+	}
+}
+
+func TestDiffCaseGRPC_HardErrorsNameTheFailingSide(t *testing.T) {
+	t.Parallel()
+	tc := CorpusCase{Name: "boom", Endpoint: "search", Query: `{}`}
+	ok := func() *fakeQuerier { return &fakeQuerier{} }
+	bad := func() *fakeQuerier { return &fakeQuerier{openErr: errOpen} }
+
+	res := diffCaseGRPC(context.Background(), bad(), ok(), tc, testOpts())
+	if !strings.Contains(res.HardError, "tempo grpc:") || strings.Contains(res.HardError, "cerberus grpc:") {
+		t.Fatalf("HardError = %q, want tempo-only attribution", res.HardError)
+	}
+
+	res = diffCaseGRPC(context.Background(), ok(), bad(), tc, testOpts())
+	if !strings.Contains(res.HardError, "cerberus grpc:") || strings.Contains(res.HardError, "tempo grpc:") {
+		t.Fatalf("HardError = %q, want cerberus-only attribution", res.HardError)
+	}
+
+	res = diffCaseGRPC(context.Background(), bad(), bad(), tc, testOpts())
+	if !strings.Contains(res.HardError, "tempo grpc:") || !strings.Contains(res.HardError, "cerberus grpc:") {
+		t.Fatalf("HardError = %q, want both sides reported", res.HardError)
+	}
+	if res.passed() {
+		t.Fatal("passed() = true for a case that never reached either backend")
+	}
+}
+
+func TestWriteReportGRPC_DocumentsSkippedCases(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "nested", "report.md")
+	results := []CaseResult{{Case: CorpusCase{Name: "ok", Endpoint: "search"}, Diff: Diff{Equal: true}}}
+	noRPC := []CorpusCase{
+		{Name: "zeta-by-id", Endpoint: "traces"},
+		{Name: "alpha-by-id", Endpoint: "traces_v2"},
+	}
+	statusParity := []CorpusCase{{Name: "bad-syntax", Endpoint: "search"}}
+
+	if err := writeReportGRPC(path, results, noRPC, statusParity); err != nil {
+		t.Fatalf("writeReportGRPC: %v", err)
+	}
+	raw, err := os.ReadFile(path) //nolint:gosec // test-owned temp path
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	report := string(raw)
+
+	if !strings.Contains(report, grpcReportTitle) {
+		t.Fatalf("report is missing the gRPC title:\n%s", report)
+	}
+	if !strings.Contains(report, "## Skipped — no StreamingQuerier RPC for this endpoint") {
+		t.Fatalf("no-RPC skip section missing:\n%s", report)
+	}
+	if !strings.Contains(report, "## Skipped — expect_status axis not yet implemented for gRPC") {
+		t.Fatalf("status-parity skip section missing:\n%s", report)
+	}
+	// The count in the explanation is the section's own case count.
+	if !strings.Contains(report, "The 2 case(s) below") || !strings.Contains(report, "The 1 case(s) below") {
+		t.Fatalf("per-section counts wrong:\n%s", report)
+	}
+	// Skipped cases are sorted by name so reruns produce identical bytes.
+	alpha := strings.Index(report, "`alpha-by-id`")
+	zeta := strings.Index(report, "`zeta-by-id`")
+	if alpha < 0 || zeta < 0 || alpha > zeta {
+		t.Fatalf("skipped cases not sorted by name (alpha=%d zeta=%d):\n%s", alpha, zeta, report)
+	}
+	// The skipped cases are documented, not counted as failures.
+	if strings.Contains(report, "`zeta-by-id` — ") {
+		t.Fatalf("a skipped case leaked into the per-case results:\n%s", report)
+	}
+}
+
+func TestWriteReportGRPC_NoSkippedSectionsWhenNothingSkipped(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "report.md")
+	if err := writeReportGRPC(path, nil, nil, nil); err != nil {
+		t.Fatalf("writeReportGRPC: %v", err)
+	}
+	raw, err := os.ReadFile(path) //nolint:gosec // test-owned temp path
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	if strings.Contains(string(raw), "## Skipped") {
+		t.Fatalf("a skip section was rendered with no skipped cases:\n%s", raw)
+	}
+}
+
+func TestWriteReportGRPC_UnwritablePathIsAnError(t *testing.T) {
+	t.Parallel()
+	// A directory where the report file should be: os.Create fails, and
+	// the caller must see it rather than a silently missing report.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.md")
+	if err := os.Mkdir(path, 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := writeReportGRPC(path, nil, []CorpusCase{{Name: "x"}}, nil); err == nil {
+		t.Fatal("writeReportGRPC returned nil for an unwritable report path")
+	}
+}
+
+func TestRenderSkippedSection_EmptyListStillRendersTheHeading(t *testing.T) {
+	t.Parallel()
+	var sb strings.Builder
+	if err := renderSkippedSection(&sb, nil, "## Heading", "The %d case(s):\n\n"); err != nil {
+		t.Fatalf("renderSkippedSection: %v", err)
+	}
+	out := sb.String()
+	if !strings.Contains(out, "## Heading") || !strings.Contains(out, "The 0 case(s):") {
+		t.Fatalf("output = %q", out)
+	}
+}
+
+// failWriter fails on the Nth write so every error return in
+// renderSkippedSection's Fprint ladder is reachable.
+type failWriter struct {
+	failAt int
+	n      int
+}
+
+func (w *failWriter) Write(p []byte) (int, error) {
+	w.n++
+	if w.n >= w.failAt {
+		return 0, errRecv
+	}
+	return len(p), nil
+}
+
+func TestRenderSkippedSection_PropagatesWriteErrors(t *testing.T) {
+	t.Parallel()
+	skipped := []CorpusCase{{Name: "a", Endpoint: "traces"}}
+	// 5 writes: heading, blank line, explanation, one case line, trailing
+	// blank line. Every one of them must surface its error.
+	for at := 1; at <= 5; at++ {
+		err := renderSkippedSection(&failWriter{failAt: at}, skipped, "## H", "The %d case(s):\n\n")
+		if err == nil {
+			t.Fatalf("write failure at call %d was swallowed", at)
+		}
+		if !errors.Is(err, errRecv) {
+			t.Fatalf("write failure at call %d returned %v, want the writer's error", at, err)
+		}
+	}
+}
+
+func TestCaseSet_IdentityAndVerdict(t *testing.T) {
+	t.Parallel()
+	results := []CaseResult{
+		{Case: CorpusCase{Name: "agree", Endpoint: "search"}, Diff: Diff{Equal: true}},
+		{Case: CorpusCase{Name: "diverge", Endpoint: "tags_v2"}, Diff: Diff{Equal: false}},
+		{Case: CorpusCase{Name: "boom", Endpoint: "metrics_range"}, HardError: "dial", Diff: Diff{Equal: true}},
+	}
+	got := caseSet(results)
+	if len(got) != len(results) {
+		t.Fatalf("caseSet dropped cases: got %d, want %d — the ratchet gates on WHICH cases failed", len(got), len(results))
+	}
+	want := []struct {
+		id     string
+		passed bool
+	}{
+		{"search | agree", true},
+		{"tags_v2 | diverge", false},
+		{"metrics_range | boom", false},
+	}
+	for i, w := range want {
+		if got[i].ID != w.id {
+			t.Fatalf("case[%d].ID = %q, want %q", i, got[i].ID, w.id)
+		}
+		if got[i].Passed != w.passed {
+			t.Fatalf("case[%d] (%s) Passed = %v, want %v", i, w.id, got[i].Passed, w.passed)
+		}
+	}
+}

--- a/internal/chplan/scan_bound_test.go
+++ b/internal/chplan/scan_bound_test.go
@@ -1,0 +1,536 @@
+package chplan
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// This file exercises the two IR-level scan-bound invariants — the instant
+// windowed-array leaf mark (scan_time_bound.go) and the spans-scan resource
+// bound (scan_resource_bound.go). Both are fail-closed safety gates: the
+// interesting behaviour is which shapes they REJECT, so every case below
+// pins an accept/reject decision rather than merely walking the tree.
+
+const (
+	spansTable    = "otel_traces"
+	metricsTable  = "otel_metrics_gauge"
+	traceIDCol    = "TraceId"
+	timestampCol  = "Timestamp"
+	parentSpanCol = "ParentSpanId"
+)
+
+func spansScan() *Scan { return &Scan{Table: spansTable} }
+
+func windowPred() Expr {
+	return &Binary{
+		Op:    OpGe,
+		Left:  &ColumnRef{Name: timestampCol},
+		Right: &FuncCall{Name: "fromUnixTimestamp64Nano", Args: []Expr{&LitInt{V: 1}}},
+	}
+}
+
+func traceIDInPred() Expr {
+	return &InList{
+		Left: &ColumnRef{Name: traceIDCol},
+		List: []Expr{&LitString{V: "abc"}},
+	}
+}
+
+func btsPred() Expr {
+	return &BoundedTraceScope{
+		SpansTable:         spansTable,
+		TraceIDColumn:      traceIDCol,
+		ParentSpanIDColumn: parentSpanCol,
+		TimestampColumn:    timestampCol,
+		TraceLimit:         7,
+	}
+}
+
+// =================================================================
+// SpansScanResourceBound — the predicate classifier
+// =================================================================
+
+func TestSpansScanResourceBound_Classification(t *testing.T) {
+	attrPred := &Binary{
+		Op:    OpEq,
+		Left:  &FieldAccess{Source: &ColumnRef{Name: "SpanAttributes"}, Path: "http.method"},
+		Right: &LitString{V: "GET"},
+	}
+	cases := []struct {
+		name string
+		pred Expr
+		cols ScanBoundCols
+		want ScanBoundKind
+	}{
+		{"nil predicate is unbounded", nil, ScanBoundCols{}, boundNone},
+		{"attribute equality proves nothing", attrPred, ScanBoundCols{}, boundNone},
+		{"window comparison", windowPred(), ScanBoundCols{}, boundWindow},
+		{"literal TraceId IN", traceIDInPred(), ScanBoundCols{}, boundTraceIDSet},
+		{"BoundedTraceScope", btsPred(), ScanBoundCols{}, boundTraceIDSet},
+		{
+			"TraceId equality singleton",
+			&Binary{Op: OpEq, Left: &ColumnRef{Name: traceIDCol}, Right: &LitString{V: "abc"}},
+			ScanBoundCols{TraceID: traceIDCol},
+			boundTraceIDSet,
+		},
+		{
+			"reversed TraceId equality",
+			&Binary{Op: OpEq, Left: &LitString{V: "abc"}, Right: &ColumnRef{Name: traceIDCol}},
+			ScanBoundCols{TraceID: traceIDCol},
+			boundTraceIDSet,
+		},
+		{
+			"constant-false wins over everything else in the conjunction",
+			&Binary{Op: OpAnd, Left: &LitBool{V: false}, Right: windowPred()},
+			ScanBoundCols{},
+			boundEmpty,
+		},
+		{
+			"constant-TRUE is not a bound",
+			&Binary{Op: OpAnd, Left: &LitBool{V: true}, Right: attrPred},
+			ScanBoundCols{},
+			boundNone,
+		},
+		{
+			"trace-id set is reported ahead of a window in the same conjunction",
+			&Binary{Op: OpAnd, Left: windowPred(), Right: traceIDInPred()},
+			ScanBoundCols{},
+			boundTraceIDSet,
+		},
+		{
+			"window buried in a nested AND tree is still found",
+			&Binary{
+				Op:    OpAnd,
+				Left:  &Binary{Op: OpAnd, Left: attrPred, Right: windowPred()},
+				Right: attrPred,
+			},
+			ScanBoundCols{},
+			boundWindow,
+		},
+		{
+			"NOT IN over TraceId is not a finite set",
+			&InList{Left: &ColumnRef{Name: traceIDCol}, List: []Expr{&LitString{V: "a"}}, Negated: true},
+			ScanBoundCols{},
+			boundNone,
+		},
+		{
+			"IN over a different column is rejected once the column is known",
+			&InList{Left: &ColumnRef{Name: "SpanId"}, List: []Expr{&LitString{V: "a"}}},
+			ScanBoundCols{TraceID: traceIDCol},
+			boundNone,
+		},
+		{
+			"qualified TraceId is not the bare column",
+			&InList{Left: &ColumnRef{Name: traceIDCol, Qualifier: "t"}, List: []Expr{&LitString{V: "a"}}},
+			ScanBoundCols{TraceID: traceIDCol},
+			boundNone,
+		},
+		{
+			"BoundedTraceScope over a different trace column is rejected",
+			&BoundedTraceScope{TraceIDColumn: "OtherId", TraceLimit: 3},
+			ScanBoundCols{TraceID: traceIDCol},
+			boundNone,
+		},
+		{
+			"equality against a non-constant is not a singleton",
+			&Binary{Op: OpEq, Left: &ColumnRef{Name: traceIDCol}, Right: &ColumnRef{Name: "SpanId"}},
+			ScanBoundCols{TraceID: traceIDCol},
+			boundNone,
+		},
+		{
+			"Timestamp compared against a plain literal is not a request window",
+			&Binary{Op: OpGe, Left: &ColumnRef{Name: timestampCol}, Right: &LitInt{V: 1}},
+			ScanBoundCols{Timestamp: timestampCol},
+			boundNone,
+		},
+		{
+			"Timestamp equality is not a window comparison",
+			&Binary{
+				Op:    OpEq,
+				Left:  &ColumnRef{Name: timestampCol},
+				Right: &FuncCall{Name: "fromUnixTimestamp64Nano", Args: []Expr{&LitInt{V: 1}}},
+			},
+			ScanBoundCols{Timestamp: timestampCol},
+			boundNone,
+		},
+		{
+			"window with the time literal on the left is still a window",
+			&Binary{
+				Op:    OpLt,
+				Left:  &FuncCall{Name: "fromUnixTimestamp", Args: []Expr{&LitInt{V: 1}}},
+				Right: &ColumnRef{Name: timestampCol},
+			},
+			ScanBoundCols{Timestamp: timestampCol},
+			boundWindow,
+		},
+		{
+			"an unrecognised time constructor is not a window",
+			&Binary{
+				Op:    OpGe,
+				Left:  &ColumnRef{Name: timestampCol},
+				Right: &FuncCall{Name: "now64", Args: []Expr{&LitInt{V: 9}}},
+			},
+			ScanBoundCols{Timestamp: timestampCol},
+			boundNone,
+		},
+		{
+			"window over a non-Timestamp column is rejected once the column is known",
+			&Binary{
+				Op:    OpGe,
+				Left:  &ColumnRef{Name: "Duration"},
+				Right: &FuncCall{Name: "fromUnixTimestamp64Nano", Args: []Expr{&LitInt{V: 1}}},
+			},
+			ScanBoundCols{Timestamp: timestampCol},
+			boundNone,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := SpansScanResourceBound(tc.pred, tc.cols); got != tc.want {
+				t.Fatalf("SpansScanResourceBound = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestScanBoundKind_String(t *testing.T) {
+	want := map[ScanBoundKind]string{
+		boundNone:            "none",
+		boundWindow:          "window",
+		boundTraceIDSet:      "trace-id-set",
+		boundMemoryStreaming: "memory-streaming",
+		boundEmpty:           "empty",
+	}
+	for k, s := range want {
+		if got := k.String(); got != s {
+			t.Fatalf("ScanBoundKind(%d).String() = %q, want %q", int(k), got, s)
+		}
+	}
+}
+
+func TestTraceIDSetCardinality_ReportsTheSetSize(t *testing.T) {
+	cols := ScanBoundCols{TraceID: traceIDCol}
+	cases := []struct {
+		name string
+		expr Expr
+		want int64
+		ok   bool
+	}{
+		{"BoundedTraceScope reports its own top-N", btsPred(), 7, true},
+		{
+			"literal InList reports the list length",
+			&InList{Left: &ColumnRef{Name: traceIDCol}, List: []Expr{
+				&LitString{V: "a"}, &LitString{V: "b"}, &LitString{V: "c"},
+			}},
+			3, true,
+		},
+		{
+			"equality is a singleton",
+			&Binary{Op: OpEq, Left: &ColumnRef{Name: traceIDCol}, Right: &LitString{V: "a"}},
+			1, true,
+		},
+		{
+			"a non-equality comparison is not a set",
+			&Binary{Op: OpGt, Left: &ColumnRef{Name: traceIDCol}, Right: &LitString{V: "a"}},
+			0, false,
+		},
+		{"an unrelated expression is not a set", &ColumnRef{Name: traceIDCol}, 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := TraceIDSetCardinality(tc.expr, cols)
+			if ok != tc.ok || got != tc.want {
+				t.Fatalf("TraceIDSetCardinality = (%d, %v), want (%d, %v)", got, ok, tc.want, tc.ok)
+			}
+		})
+	}
+}
+
+// =================================================================
+// RequireSpansScansBounded — the tree descent
+// =================================================================
+
+func TestRequireSpansScansBounded_RejectsAnUnfilteredSpansScan(t *testing.T) {
+	err := RequireSpansScansBounded(spansTable, spansScan())
+	var v *ScanResourceBoundViolation
+	if !errors.As(err, &v) {
+		t.Fatalf("want *ScanResourceBoundViolation, got %v", err)
+	}
+	if v.Table != spansTable {
+		t.Fatalf("violation names table %q, want %q", v.Table, spansTable)
+	}
+	if !strings.Contains(v.Error(), spansTable) {
+		t.Fatalf("error text does not name the table: %s", v.Error())
+	}
+}
+
+func TestRequireSpansScansBounded_EmptyTableNameIsANoOp(t *testing.T) {
+	// PromQL / metrics emission never sets a spans table; the invariant must
+	// not fire on those plans even though the tree holds a bare Scan.
+	if err := RequireSpansScansBounded("", spansScan()); err != nil {
+		t.Fatalf("empty spansTable must be a no-op, got %v", err)
+	}
+}
+
+func TestRequireSpansScansBounded_NilRootIsANoOp(t *testing.T) {
+	if err := RequireSpansScansBounded(spansTable, nil); err != nil {
+		t.Fatalf("nil root must be a no-op, got %v", err)
+	}
+}
+
+func TestRequireSpansScansBounded_OtherTablesAreNotGoverned(t *testing.T) {
+	if err := RequireSpansScansBounded(spansTable, &Scan{Table: metricsTable}); err != nil {
+		t.Fatalf("a non-spans scan must not be gated, got %v", err)
+	}
+}
+
+func TestRequireSpansScansBounded_AcceptsEachBoundedForm(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		pred Expr
+	}{
+		{"window", windowPred()},
+		{"trace-id set", traceIDInPred()},
+		{"bounded trace scope", btsPred()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := &Filter{Input: spansScan(), Predicate: tc.pred}
+			if err := RequireSpansScansBounded(spansTable, root); err != nil {
+				t.Fatalf("bounded scan rejected: %v", err)
+			}
+		})
+	}
+}
+
+func TestRequireSpansScansBounded_AccumulatesConjunctsDownTheFilterSpine(t *testing.T) {
+	// Filter_window(Filter_attr(Scan)): neither filter alone is decisive at
+	// the leaf, but the accumulated conjunction is windowed.
+	// A map-attribute equality: unlike a bare `col = literal` it is not a
+	// TraceId singleton in either lenient or strict mode.
+	attr := &Binary{
+		Op:    OpEq,
+		Left:  &FieldAccess{Source: &ColumnRef{Name: "SpanAttributes"}, Path: "http.method"},
+		Right: &LitString{V: "GET"},
+	}
+	root := &Filter{
+		Predicate: windowPred(),
+		Input:     &Filter{Predicate: attr, Input: spansScan()},
+	}
+	if err := RequireSpansScansBounded(spansTable, root); err != nil {
+		t.Fatalf("outer window must reach the leaf: %v", err)
+	}
+	// Same shape without the outer window is still a violation — proving the
+	// accumulation above is what saved it.
+	bare := &Filter{Predicate: attr, Input: spansScan()}
+	if err := RequireSpansScansBounded(spansTable, bare); err == nil {
+		t.Fatal("attribute-only filter must not satisfy the bound")
+	}
+}
+
+func TestRequireSpansScansBounded_LimitIsAMemoryStreamingBound(t *testing.T) {
+	root := &Limit{Count: 20, Input: &Project{Input: spansScan()}}
+	if err := RequireSpansScansBounded(spansTable, root); err != nil {
+		t.Fatalf("top-N Limit must bound the scan: %v", err)
+	}
+	// A zero Count is "no limit" and must not be mistaken for a top-N.
+	zero := &Limit{Count: 0, Input: &Project{Input: spansScan()}}
+	if err := RequireSpansScansBounded(spansTable, zero); err == nil {
+		t.Fatal("LIMIT 0 must not count as a bound")
+	}
+}
+
+func TestRequireSpansScansBounded_LimitDoesNotSurviveAnAggregate(t *testing.T) {
+	// The GROUP BY hash table materialises in full before the outer LIMIT
+	// applies, so the top-N above it cannot bound the inner scan.
+	root := &Limit{Count: 20, Input: &Aggregate{Input: spansScan()}}
+	if err := RequireSpansScansBounded(spansTable, root); err == nil {
+		t.Fatal("a Limit above an Aggregate must not bound the inner scan")
+	}
+	// …but a bound established beneath the Aggregate still counts.
+	ok := &Limit{Count: 20, Input: &Aggregate{
+		Input: &Filter{Predicate: windowPred(), Input: spansScan()},
+	}}
+	if err := RequireSpansScansBounded(spansTable, ok); err != nil {
+		t.Fatalf("window beneath the Aggregate must bound the scan: %v", err)
+	}
+}
+
+func TestRequireSpansScansBounded_MetricsSubtreesAreOwnedByTheirEmitters(t *testing.T) {
+	// The metrics matrix emitters bound their own inner scan at emit time, so
+	// their (IR-unbounded) inner must be skipped rather than false-rejected.
+	for _, root := range []Node{
+		Node(&MetricsAggregate{Inner: spansScan()}),
+		Node(&MetricsCompare{Inner: spansScan()}),
+		Node(&MetricsHistogramOverTime{Inner: spansScan()}),
+	} {
+		if err := RequireSpansScansBounded(spansTable, root); err != nil {
+			t.Fatalf("%T subtree must be skipped, got %v", root, err)
+		}
+	}
+}
+
+func TestRequireSpansScansBounded_DerivesColumnsFromABoundedTraceScope(t *testing.T) {
+	// With a BoundedTraceScope in the tree the classifier learns the real
+	// column names, which makes an IN over a *different* column stop counting
+	// as a trace-id set. The sibling arm below would pass in lenient mode.
+	strict := &Filter{
+		Predicate: &Binary{Op: OpAnd, Left: btsPred(), Right: &LitBool{V: true}},
+		Input: &Project{Input: &Filter{
+			Predicate: &InList{Left: &ColumnRef{Name: "SpanId"}, List: []Expr{&LitString{V: "s"}}},
+			Input:     &Scan{Table: spansTable, Columns: []string{"SpanId"}},
+		}},
+	}
+	// The outer BoundedTraceScope conjunct is accumulated down the spine, so
+	// the leaf is bounded regardless — assert the derivation itself instead.
+	if got := deriveScanBoundCols(strict); got.TraceID != traceIDCol ||
+		got.Timestamp != timestampCol || got.ParentSpanID != parentSpanCol {
+		t.Fatalf("deriveScanBoundCols = %+v, want the BoundedTraceScope columns", got)
+	}
+	if got := deriveScanBoundCols(spansScan()); got != (ScanBoundCols{}) {
+		t.Fatalf("no BoundedTraceScope must yield empty cols, got %+v", got)
+	}
+	// Lenient (empty-cols) mode accepts the SpanId IN; strict mode does not.
+	spanIDIn := &InList{Left: &ColumnRef{Name: "SpanId"}, List: []Expr{&LitString{V: "s"}}}
+	if SpansScanResourceBound(spanIDIn, ScanBoundCols{}) != boundTraceIDSet {
+		t.Fatal("lenient mode must accept any bare-column IN")
+	}
+	if SpansScanResourceBound(spanIDIn, ScanBoundCols{TraceID: traceIDCol}) != boundNone {
+		t.Fatal("strict mode must reject an IN over a non-TraceId column")
+	}
+}
+
+func TestRequireSpansScansBounded_ReportsTheFirstViolationOnly(t *testing.T) {
+	// Two unbounded leaves: the descent short-circuits after the first, so
+	// the returned error is a single violation naming the spans table.
+	root := &Project{Input: &Filter{
+		Predicate: &LitBool{V: true},
+		Input:     &UnionAll{Inputs: []Node{spansScan(), spansScan()}},
+	}}
+	err := RequireSpansScansBounded(spansTable, root)
+	var v *ScanResourceBoundViolation
+	if !errors.As(err, &v) {
+		t.Fatalf("want *ScanResourceBoundViolation, got %v", err)
+	}
+}
+
+// =================================================================
+// scan_time_bound.go — the instant windowed-array leaf mark
+// =================================================================
+
+func instantWindow(input Node) *RangeWindow {
+	return &RangeWindow{Input: input, Func: "rate", Range: time.Minute}
+}
+
+func TestIsInstantWindowedLeaf(t *testing.T) {
+	cases := []struct {
+		name string
+		rw   *RangeWindow
+		want bool
+	}{
+		{"instant over a raw scan", instantWindow(spansScan()), true},
+		{
+			"matrix window is not the instant leaf",
+			&RangeWindow{Input: spansScan(), OuterRange: time.Hour},
+			false,
+		},
+		{"over MetricsAggregate", instantWindow(&MetricsAggregate{Inner: spansScan()}), false},
+		{"over MetricsCompare", instantWindow(&MetricsCompare{Inner: spansScan()}), false},
+		{
+			"over MetricsHistogramOverTime",
+			instantWindow(&MetricsHistogramOverTime{Inner: spansScan()}),
+			false,
+		},
+		{"over a Filter", instantWindow(&Filter{Input: spansScan(), Predicate: windowPred()}), true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsInstantWindowedLeaf(tc.rw); got != tc.want {
+				t.Fatalf("IsInstantWindowedLeaf = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAttachInstantScanTimeBounds_MarksTheLeafWithoutMutatingTheInput(t *testing.T) {
+	rw := instantWindow(spansScan())
+	root := Node(&Project{Input: rw})
+
+	out := AttachInstantScanTimeBounds(root)
+	if out == root {
+		t.Fatal("an unmarked tree must be cloned, not mutated in place")
+	}
+	if rw.InstantScanBounded {
+		t.Fatal("the caller's tree was mutated")
+	}
+	marked, ok := out.(*Project).Input.(*RangeWindow)
+	if !ok {
+		t.Fatalf("clone reshaped the tree: %T", out.(*Project).Input)
+	}
+	if !marked.InstantScanBounded {
+		t.Fatal("the instant windowed leaf was not marked")
+	}
+}
+
+func TestAttachInstantScanTimeBounds_IsIdempotentAndCloneFree(t *testing.T) {
+	rw := instantWindow(spansScan())
+	rw.InstantScanBounded = true
+	root := Node(&Project{Input: rw})
+	if out := AttachInstantScanTimeBounds(root); out != root {
+		t.Fatal("an already-marked tree must be returned unchanged, with no clone")
+	}
+}
+
+func TestAttachInstantScanTimeBounds_LeavesNonLeafShapesAlone(t *testing.T) {
+	// A matrix window is bounded at emit time, not by this flag: nothing to
+	// mark, so the walk must return the same pointer.
+	root := Node(&RangeWindow{Input: spansScan(), OuterRange: time.Hour})
+	if out := AttachInstantScanTimeBounds(root); out != root {
+		t.Fatal("a matrix window must not trigger a clone")
+	}
+	if AttachInstantScanTimeBounds(nil) != nil {
+		t.Fatal("nil root must round-trip as nil")
+	}
+}
+
+func TestAttachInstantScanTimeBounds_MarksEveryLeafInTheTree(t *testing.T) {
+	a, b := instantWindow(spansScan()), instantWindow(spansScan())
+	b.InstantScanBounded = true // one already marked, one not
+	out := AttachInstantScanTimeBounds(&UnionAll{Inputs: []Node{a, b}})
+	for i, c := range out.(*UnionAll).Inputs {
+		rw, ok := c.(*RangeWindow)
+		if !ok {
+			t.Fatalf("input %d reshaped to %T", i, c)
+		}
+		if !rw.InstantScanBounded {
+			t.Fatalf("input %d left unmarked", i)
+		}
+	}
+}
+
+func TestWithInstantScanTimeBound(t *testing.T) {
+	rw := instantWindow(spansScan())
+	got, changed := WithInstantScanTimeBound(rw)
+	if !changed {
+		t.Fatal("an unmarked instant leaf must report a change")
+	}
+	if got == rw {
+		t.Fatal("the flag must be set on a copy, never on the caller's node")
+	}
+	if !got.InstantScanBounded || rw.InstantScanBounded {
+		t.Fatalf("flag placement wrong: copy=%v original=%v", got.InstantScanBounded, rw.InstantScanBounded)
+	}
+
+	// Idempotent: a second application is a no-op returning the same pointer.
+	again, changed := WithInstantScanTimeBound(got)
+	if changed || again != got {
+		t.Fatalf("second application must be a no-op, got changed=%v same=%v", changed, again == got)
+	}
+
+	// A non-leaf shape is never marked.
+	matrix := &RangeWindow{Input: spansScan(), OuterRange: time.Hour}
+	if out, changed := WithInstantScanTimeBound(matrix); changed || out != matrix {
+		t.Fatal("a matrix window must be returned untouched")
+	}
+}

--- a/internal/logql/coverage_gaps_internal_test.go
+++ b/internal/logql/coverage_gaps_internal_test.go
@@ -1,0 +1,399 @@
+package logql
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/tsouza/cerberus/internal/api/httperr"
+	"github.com/tsouza/cerberus/internal/chplan"
+	syntax "github.com/tsouza/cerberus/internal/logql/lsyntax"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/telemetry"
+)
+
+// =================================================================
+// Lang — the engine adapter surface
+// =================================================================
+
+func TestLang_Name(t *testing.T) {
+	l := &Lang{Schema: schema.DefaultOTelLogs()}
+	if got := l.Name(); got != telemetry.QLLogQL {
+		t.Fatalf("Name() = %q, want %q", got, telemetry.QLLogQL)
+	}
+}
+
+func TestLang_LateMatShape_ReportsTheResolvedTableNotTheDefault(t *testing.T) {
+	s := schema.DefaultOTelLogs()
+	s.LogsTable = "custom_logs"
+	l := &Lang{Schema: s}
+
+	table, wide, rowKey := l.LateMatShape()
+	if table != "custom_logs" {
+		t.Fatalf("LateMatShape table = %q, want the overridden table", table)
+	}
+	if len(wide) != len(s.WideColumns) {
+		t.Fatalf("wide columns = %v, want %v", wide, s.WideColumns)
+	}
+	for i := range wide {
+		if wide[i] != s.WideColumns[i] {
+			t.Fatalf("wide[%d] = %q, want %q", i, wide[i], s.WideColumns[i])
+		}
+	}
+	if len(rowKey) != len(s.RowKey) {
+		t.Fatalf("row key = %v, want %v", rowKey, s.RowKey)
+	}
+}
+
+func TestLang_Parse_LogStreamQuery(t *testing.T) {
+	l := &Lang{Schema: schema.DefaultOTelLogs()}
+	plan, meta, err := l.Parse(context.Background(), `{service_name="api"}`)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if plan == nil {
+		t.Fatal("Parse returned a nil plan")
+	}
+	if meta.IsMetric {
+		t.Fatal("a stream selector must not classify as a metric query")
+	}
+	if meta.ResponseShape != "loki-streams" {
+		t.Fatalf("ResponseShape = %q, want loki-streams", meta.ResponseShape)
+	}
+	if _, ok := meta.Extra["expr"]; !ok {
+		t.Fatalf("Meta.Extra must carry the parsed expr, got %v", meta.Extra)
+	}
+}
+
+func TestLang_Parse_MetricQuery(t *testing.T) {
+	l := &Lang{Schema: schema.DefaultOTelLogs()}
+	_, meta, err := l.Parse(context.Background(), `rate({service_name="api"}[5m])`)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if !meta.IsMetric {
+		t.Fatal("rate(...) must classify as a metric query")
+	}
+	if meta.ResponseShape != "loki-matrix" {
+		t.Fatalf("ResponseShape = %q, want loki-matrix", meta.ResponseShape)
+	}
+}
+
+func TestLang_Parse_ParseFailureIsA400BadData(t *testing.T) {
+	l := &Lang{Schema: schema.DefaultOTelLogs()}
+	_, _, err := l.Parse(context.Background(), `{service_name=`)
+	var he *httperr.Error
+	if !errors.As(err, &he) {
+		t.Fatalf("want *httperr.Error, got %#v", err)
+	}
+	if he.Status != http.StatusBadRequest || he.Kind != errBadData {
+		t.Fatalf("parse failure mapped to %d/%s, want 400/%s", he.Status, he.Kind, errBadData)
+	}
+}
+
+func TestLang_Parse_NormalisesDottedStreamSelectorKeys(t *testing.T) {
+	// A Grafana Loki datasource sends `service.name`; the upstream grammar
+	// rejects the dot, so Parse must rewrite it before parsing. Without the
+	// normalisation this is a 400.
+	l := &Lang{Schema: schema.DefaultOTelLogs()}
+	if _, _, err := l.Parse(context.Background(), `{service.name="api"}`); err != nil {
+		t.Fatalf("dotted selector must parse: %v", err)
+	}
+}
+
+func TestNormalizeDottedLabels_RewritesOnlyTheSelectorKeys(t *testing.T) {
+	got := NormalizeDottedLabels(`{service.name="a.b"}`)
+	if !strings.Contains(got, `service_name=`) {
+		t.Fatalf("key not normalised: %q", got)
+	}
+	if !strings.Contains(got, `"a.b"`) {
+		t.Fatalf("the value must not be rewritten: %q", got)
+	}
+	// The package-private twin Lang.Parse routes through must agree.
+	if other := normalizeLokiDottedLabels(`{service.name="a.b"}`); other != got {
+		t.Fatalf("normalizeLokiDottedLabels = %q, want %q", other, got)
+	}
+}
+
+// =================================================================
+// NormalizeDetectedLevel
+// =================================================================
+
+func TestNormalizeDetectedLevel(t *testing.T) {
+	cases := map[string]string{
+		"":            "unknown",
+		"INFO":        "info",
+		"Inf":         "info",
+		"information": "info",
+		"WRN":         "warn",
+		"warning":     "warn",
+		"ERR":         "error",
+		"Error":       "error",
+		"TRC":         "trace",
+		"dbg":         "debug",
+		"CRITICAL":    "critical",
+		"Fatal":       "fatal",
+		// An unknown variant falls through as its lowercased self, matching
+		// upstream normalizeLogLevel's default branch.
+		"NOTICE": "notice",
+	}
+	for in, want := range cases {
+		if got := NormalizeDetectedLevel(in); got != want {
+			t.Fatalf("NormalizeDetectedLevel(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// =================================================================
+// MatchesIPPattern — the Go-side twin of the SQL rendering
+// =================================================================
+
+func TestMatchesIPPattern(t *testing.T) {
+	cases := []struct {
+		name    string
+		subject string
+		pattern string
+		want    bool
+	}{
+		{"exact v4 hit", "from 10.0.0.1 ok", "10.0.0.1", true},
+		{"exact v4 miss", "from 10.0.0.2 ok", "10.0.0.1", false},
+		{"cidr contains", "client=192.168.4.7", "192.168.0.0/16", true},
+		{"cidr excludes", "client=192.169.4.7", "192.168.0.0/16", false},
+		{"cidr lower edge", "10.1.0.0", "10.1.0.0/24", true},
+		{"cidr upper edge", "10.1.0.255", "10.1.0.0/24", true},
+		{"cidr just past the edge", "10.1.1.0", "10.1.0.0/24", false},
+		{"range contains", "ip 172.16.0.9", "172.16.0.1-172.16.0.10", true},
+		{"range excludes", "ip 172.16.0.11", "172.16.0.1-172.16.0.10", false},
+		{"no candidate at all", "no addresses here", "10.0.0.0/8", false},
+		{"v6 hit", "peer=[2001:db8::5]", "2001:db8::/32", true},
+		{"v6 miss", "peer=[2001:dc8::5]", "2001:db8::/32", false},
+		// Family mismatch: a v4 candidate must never satisfy a v6 pattern.
+		{"v4 candidate against a v6 pattern", "10.0.0.1", "2001:db8::/32", false},
+		{"v6 candidate against a v4 pattern", "2001:db8::5", "10.0.0.0/8", false},
+		// A candidate run that is not a parseable address is skipped, not
+		// an error — the following real one still matches.
+		{"unparseable candidate then a hit", "1.2.3.4.5 and 10.0.0.1", "10.0.0.1", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := MatchesIPPattern(tc.subject, tc.pattern)
+			if err != nil {
+				t.Fatalf("MatchesIPPattern: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("MatchesIPPattern(%q, %q) = %v, want %v", tc.subject, tc.pattern, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMatchesIPPattern_InvalidPatternIsAnError(t *testing.T) {
+	got, err := MatchesIPPattern("10.0.0.1", "not-an-ip")
+	if err == nil {
+		t.Fatalf("invalid pattern must error, got match=%v", got)
+	}
+	if got {
+		t.Fatal("an errored pattern must not report a match")
+	}
+	if !strings.Contains(err.Error(), "invalid pattern") {
+		t.Fatalf("error text %q does not mirror the reference wording", err.Error())
+	}
+}
+
+// =================================================================
+// SelectorPredicate — the /index/stats + /index/volume entry point
+// =================================================================
+
+func TestSelectorPredicate(t *testing.T) {
+	s := schema.DefaultOTelLogs()
+
+	if got := SelectorPredicate(nil, s); got != nil {
+		t.Fatalf("no matchers must yield a nil predicate, got %#v", got)
+	}
+
+	one := SelectorPredicate([]*labels.Matcher{
+		labels.MustNewMatcher(labels.MatchEqual, "app", "api"),
+	}, s)
+	b, ok := one.(*chplan.Binary)
+	if !ok {
+		t.Fatalf("single matcher lowered to %T, want *chplan.Binary", one)
+	}
+	if b.Op != chplan.OpEq {
+		t.Fatalf("op = %v, want OpEq", b.Op)
+	}
+	if lit, ok := b.Right.(*chplan.LitString); !ok || lit.V != "api" {
+		t.Fatalf("rhs = %#v, want LitString{api}", b.Right)
+	}
+
+	two := SelectorPredicate([]*labels.Matcher{
+		labels.MustNewMatcher(labels.MatchEqual, "app", "api"),
+		labels.MustNewMatcher(labels.MatchNotEqual, "env", "dev"),
+	}, s)
+	and, ok := two.(*chplan.Binary)
+	if !ok || and.Op != chplan.OpAnd {
+		t.Fatalf("two matchers must AND-fold, got %#v", two)
+	}
+	if !and.Left.Equal(one) {
+		t.Fatalf("the AND's left arm must be the first matcher's predicate, got %#v", and.Left)
+	}
+}
+
+// =================================================================
+// FiltersErrorLabel — the dynamic-label gate shared with the HTTP layer
+// =================================================================
+
+func TestFiltersErrorLabel(t *testing.T) {
+	errStr := &syntax.StringLabelFilter{
+		Matcher: labels.MustNewMatcher(labels.MatchEqual, syntax.ErrorLabel, ""),
+	}
+	detailsStr := &syntax.StringLabelFilter{
+		Matcher: labels.MustNewMatcher(labels.MatchEqual, syntax.ErrorDetailsLabel, "x"),
+	}
+	plainStr := &syntax.StringLabelFilter{
+		Matcher: labels.MustNewMatcher(labels.MatchEqual, "level", "info"),
+	}
+
+	cases := []struct {
+		name string
+		in   syntax.LabelFilterer
+		want bool
+	}{
+		{"__error__ string filter", errStr, true},
+		{"__error_details__ string filter", detailsStr, true},
+		{"ordinary string filter", plainStr, false},
+		{"numeric filter on __error__", &syntax.NumericLabelFilter{Name: syntax.ErrorLabel}, true},
+		{"numeric filter on a plain label", &syntax.NumericLabelFilter{Name: "status"}, false},
+		{"duration filter on __error__", &syntax.DurationLabelFilter{Name: syntax.ErrorLabel}, true},
+		{"duration filter on a plain label", &syntax.DurationLabelFilter{Name: "dur"}, false},
+		{"bytes filter on __error_details__", &syntax.BytesLabelFilter{Name: syntax.ErrorDetailsLabel}, true},
+		{"bytes filter on a plain label", &syntax.BytesLabelFilter{Name: "size"}, false},
+		{"ip filter on __error__", &syntax.IPLabelFilter{Label: syntax.ErrorLabel}, true},
+		{"ip filter on a plain label", &syntax.IPLabelFilter{Label: "addr"}, false},
+		{
+			"binary composition finds it on the left",
+			&syntax.BinaryLabelFilter{Left: errStr, Right: plainStr},
+			true,
+		},
+		{
+			"binary composition finds it on the right",
+			&syntax.BinaryLabelFilter{Left: plainStr, Right: detailsStr},
+			true,
+		},
+		{
+			"binary composition of plain filters is clean",
+			&syntax.BinaryLabelFilter{Left: plainStr, Right: plainStr},
+			false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := FiltersErrorLabel(tc.in); got != tc.want {
+				t.Fatalf("FiltersErrorLabel = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// =================================================================
+// Small mapping helpers
+// =================================================================
+
+func TestLabelFilterOp(t *testing.T) {
+	want := map[syntax.LabelFilterType]chplan.BinaryOp{
+		syntax.LabelFilterEqual:              chplan.OpEq,
+		syntax.LabelFilterNotEqual:           chplan.OpNe,
+		syntax.LabelFilterGreaterThan:        chplan.OpGt,
+		syntax.LabelFilterGreaterThanOrEqual: chplan.OpGe,
+		syntax.LabelFilterLesserThan:         chplan.OpLt,
+		syntax.LabelFilterLesserThanOrEqual:  chplan.OpLe,
+	}
+	for in, exp := range want {
+		if got := labelFilterOp(in); got != exp {
+			t.Fatalf("labelFilterOp(%v) = %v, want %v", in, got, exp)
+		}
+	}
+}
+
+func TestLogqlBinaryOp(t *testing.T) {
+	want := map[string]chplan.BinaryOp{
+		syntax.OpTypeAdd:   chplan.OpAdd,
+		syntax.OpTypeSub:   chplan.OpSub,
+		syntax.OpTypeMul:   chplan.OpMul,
+		syntax.OpTypeDiv:   chplan.OpDiv,
+		syntax.OpTypeMod:   chplan.OpMod,
+		syntax.OpTypePow:   chplan.OpPow,
+		syntax.OpTypeCmpEQ: chplan.OpEq,
+		syntax.OpTypeNEQ:   chplan.OpNe,
+		syntax.OpTypeLT:    chplan.OpLt,
+		syntax.OpTypeLTE:   chplan.OpLe,
+		syntax.OpTypeGT:    chplan.OpGt,
+		syntax.OpTypeGTE:   chplan.OpGe,
+	}
+	for in, exp := range want {
+		got, err := logqlBinaryOp(in)
+		if err != nil {
+			t.Fatalf("logqlBinaryOp(%q): %v", in, err)
+		}
+		if got != exp {
+			t.Fatalf("logqlBinaryOp(%q) = %v, want %v", in, got, exp)
+		}
+	}
+	// The logical ops are routed to lowerVectorSetOp before this is called,
+	// so reaching here with one is a genuine unknown-operator error.
+	if _, err := logqlBinaryOp(syntax.OpTypeOr); err == nil {
+		t.Fatal("a logical op must not resolve to a chplan binary op")
+	}
+}
+
+func TestGateMark_AndsTheGateOnTheLeftAndKeepsTheDiagnostics(t *testing.T) {
+	m := labelFilterMark{
+		cond:    &chplan.ColumnRef{Name: "c"},
+		kind:    "SampleExtractionErr",
+		details: &chplan.LitString{V: "boom"},
+	}
+	gate := &chplan.ColumnRef{Name: "g"}
+
+	out := gateMark(m, gate)
+	b, ok := out.cond.(*chplan.Binary)
+	if !ok || b.Op != chplan.OpAnd {
+		t.Fatalf("gateMark cond = %#v, want an AND", out.cond)
+	}
+	if !b.Left.Equal(gate) {
+		t.Fatalf("the gate must be the left arm, got %#v", b.Left)
+	}
+	if !b.Right.Equal(m.cond) {
+		t.Fatalf("the original condition must be the right arm, got %#v", b.Right)
+	}
+	if out.kind != m.kind || !out.details.Equal(m.details) {
+		t.Fatalf("gateMark must carry kind/details through, got %q/%#v", out.kind, out.details)
+	}
+	// The input mark is left untouched — the caller may reuse it.
+	if _, mutated := m.cond.(*chplan.Binary); mutated {
+		t.Fatal("gateMark mutated its input mark")
+	}
+}
+
+func TestJPToken_Text(t *testing.T) {
+	cases := []struct {
+		tok  jpToken
+		want string
+	}{
+		{jpToken{kind: jpEOF}, "<eof>"},
+		{jpToken{kind: jpField, str: "user"}, "user"},
+		{jpToken{kind: jpString, str: "a.b"}, "a.b"},
+		{jpToken{kind: jpIndex, idx: 12}, "12"},
+		{jpToken{kind: jpDot}, "."},
+		{jpToken{kind: jpLSB}, "["},
+		{jpToken{kind: jpRSB}, "]"},
+		{jpToken{kind: jpTokenKind(99)}, "?"},
+	}
+	for _, tc := range cases {
+		if got := tc.tok.text(); got != tc.want {
+			t.Fatalf("jpToken{kind:%v}.text() = %q, want %q", tc.tok.kind, got, tc.want)
+		}
+	}
+}

--- a/test/property/oracle/promql/oracle_gaps_test.go
+++ b/test/property/oracle/promql/oracle_gaps_test.go
@@ -1,0 +1,405 @@
+package promql
+
+import (
+	"math"
+	"testing"
+
+	"github.com/tsouza/cerberus/test/property"
+)
+
+// This file covers oracle surface the property runs exercise only when
+// the generator happens to draw the shape, and which the hand-written
+// oracle_test.go never pinned: the set operators, the absent/clamp/sort
+// family, the quantile aggregator, the counter-shape window functions,
+// unary negation, and the out-of-domain histogram_quantile arms.
+//
+// Every assertion states the Prometheus semantics the oracle claims to
+// mirror, so a divergence introduced in the oracle fails here rather
+// than showing up as an unexplained property-test diff against chDB.
+
+// =================================================================
+// Set operators — and / or / unless
+// =================================================================
+
+func TestSetOp_And_KeepsOnlyMatchedLHSRows(t *testing.T) {
+	d := build(
+		makeSeries("a", map[string]string{"job": "api"}, sampleSpec{60, 1}),
+		makeSeries("a", map[string]string{"job": "db"}, sampleSpec{60, 2}),
+		makeSeries("b", map[string]string{"job": "api"}, sampleSpec{60, 99}),
+	)
+	// `and` keeps the LHS row's own VALUE, not the RHS's.
+	assertRows(t, eval(d, `a and b`, 90), []property.OutcomeRow{
+		row(map[string]string{"job": "api"}, 1),
+	})
+}
+
+func TestSetOp_Unless_KeepsOnlyUnmatchedLHSRows(t *testing.T) {
+	d := build(
+		makeSeries("a", map[string]string{"job": "api"}, sampleSpec{60, 1}),
+		makeSeries("a", map[string]string{"job": "db"}, sampleSpec{60, 2}),
+		makeSeries("b", map[string]string{"job": "api"}, sampleSpec{60, 99}),
+	)
+	assertRows(t, eval(d, `a unless b`, 90), []property.OutcomeRow{
+		row(map[string]string{"job": "db"}, 2),
+	})
+}
+
+func TestSetOp_Or_LHSWinsOnCollision(t *testing.T) {
+	d := build(
+		makeSeries("a", map[string]string{"job": "api"}, sampleSpec{60, 1}),
+		makeSeries("b", map[string]string{"job": "api"}, sampleSpec{60, 99}),
+		makeSeries("b", map[string]string{"job": "db"}, sampleSpec{60, 7}),
+	)
+	// `or` emits every LHS row, then only the RHS rows whose key is
+	// absent from the LHS — the api row must keep the LHS value 1.
+	assertRows(t, eval(d, `a or b`, 90), []property.OutcomeRow{
+		row(map[string]string{"job": "api"}, 1),
+		row(map[string]string{"job": "db"}, 7),
+	})
+}
+
+func TestSetOp_And_OnClauseNarrowsTheMatchKey(t *testing.T) {
+	d := build(
+		makeSeries("a", map[string]string{"job": "api", "instance": "x"}, sampleSpec{60, 1}),
+		makeSeries("b", map[string]string{"job": "api", "instance": "y"}, sampleSpec{60, 2}),
+	)
+	// Full label sets differ, so a bare `and` matches nothing...
+	assertRows(t, eval(d, `a and b`, 90), nil)
+	// ...but on(job) makes them the same key, and the surviving row
+	// keeps its FULL label set (set ops never reshape labels).
+	assertRows(t, eval(d, `a and on(job) b`, 90), []property.OutcomeRow{
+		row(map[string]string{"job": "api", "instance": "x"}, 1),
+	})
+}
+
+func TestSetOp_Unless_IgnoringClause(t *testing.T) {
+	d := build(
+		makeSeries("a", map[string]string{"job": "api", "instance": "x"}, sampleSpec{60, 1}),
+		makeSeries("b", map[string]string{"job": "api", "instance": "y"}, sampleSpec{60, 2}),
+	)
+	// ignoring(instance) collapses both to {job=api}, so the LHS row is
+	// excluded; without it, nothing matches and the row survives.
+	assertRows(t, eval(d, `a unless ignoring(instance) b`, 90), nil)
+	assertRows(t, eval(d, `a unless b`, 90), []property.OutcomeRow{
+		row(map[string]string{"job": "api", "instance": "x"}, 1),
+	})
+}
+
+func TestSetOp_EmptyRHS(t *testing.T) {
+	d := build(makeSeries("a", map[string]string{"job": "api"}, sampleSpec{60, 1}))
+	assertRows(t, eval(d, `a and b`, 90), nil)
+	assertRows(t, eval(d, `a unless b`, 90), []property.OutcomeRow{
+		row(map[string]string{"job": "api"}, 1),
+	})
+	assertRows(t, eval(d, `a or b`, 90), []property.OutcomeRow{
+		row(map[string]string{"job": "api"}, 1),
+	})
+}
+
+// =================================================================
+// absent()
+// =================================================================
+
+func TestAbsent_EmptyInnerEmitsMatcherLabels(t *testing.T) {
+	d := build(makeSeries("other", map[string]string{"job": "api"}, sampleSpec{60, 1}))
+	// The equality matchers (minus __name__) become the output labels;
+	// the value is 1.
+	assertRows(t, eval(d, `absent(up{job="api"})`, 90), []property.OutcomeRow{
+		row(map[string]string{"job": "api"}, 1),
+	})
+}
+
+func TestAbsent_NonEmptyInnerEmitsNothing(t *testing.T) {
+	d := build(makeSeries("up", map[string]string{"job": "api"}, sampleSpec{60, 5}))
+	assertRows(t, eval(d, `absent(up{job="api"})`, 90), nil)
+}
+
+func TestAbsent_NonEqualityMatchersAreNotCarried(t *testing.T) {
+	d := build()
+	// Only MatchEqual matchers become labels — a regex matcher does not
+	// name a single value, so Prom drops it.
+	assertRows(t, eval(d, `absent(up{job=~"a.*",env="prod"})`, 90), []property.OutcomeRow{
+		row(map[string]string{"env": "prod"}, 1),
+	})
+}
+
+// =================================================================
+// clamp / clamp_min / clamp_max
+// =================================================================
+
+func TestClamp_BoundsBothEnds(t *testing.T) {
+	d := build(
+		makeSeries("m", map[string]string{"s": "lo"}, sampleSpec{60, -5}),
+		makeSeries("m", map[string]string{"s": "mid"}, sampleSpec{60, 3}),
+		makeSeries("m", map[string]string{"s": "hi"}, sampleSpec{60, 11}),
+	)
+	assertRows(t, eval(d, `clamp(m, 0, 10)`, 90), []property.OutcomeRow{
+		row(map[string]string{"s": "lo"}, 0),
+		row(map[string]string{"s": "mid"}, 3),
+		row(map[string]string{"s": "hi"}, 10),
+	})
+}
+
+func TestClamp_MaxBelowMinIsEmpty(t *testing.T) {
+	d := build(makeSeries("m", map[string]string{"s": "a"}, sampleSpec{60, 3}))
+	// Prom's documented degenerate case: max < min yields no samples.
+	assertRows(t, eval(d, `clamp(m, 10, 0)`, 90), nil)
+}
+
+func TestClampMinAndMax(t *testing.T) {
+	d := build(
+		makeSeries("m", map[string]string{"s": "lo"}, sampleSpec{60, -5}),
+		makeSeries("m", map[string]string{"s": "hi"}, sampleSpec{60, 11}),
+	)
+	assertRows(t, eval(d, `clamp_min(m, 0)`, 90), []property.OutcomeRow{
+		row(map[string]string{"s": "lo"}, 0),
+		row(map[string]string{"s": "hi"}, 11),
+	})
+	assertRows(t, eval(d, `clamp_max(m, 10)`, 90), []property.OutcomeRow{
+		row(map[string]string{"s": "lo"}, -5),
+		row(map[string]string{"s": "hi"}, 10),
+	})
+}
+
+func TestClamp_NonScalarBoundIsAnError(t *testing.T) {
+	d := build(makeSeries("m", map[string]string{"s": "a"}, sampleSpec{60, 3}))
+	// clamp's bounds are scalars; a vector there is a type error, not a
+	// silently-ignored argument.
+	o := eval(d, `clamp_min(m, m)`, 90)
+	if o.Err == nil {
+		t.Fatalf("clamp_min with a vector bound returned rows %v, want an error", o.Rows)
+	}
+}
+
+// =================================================================
+// sort / sort_desc
+// =================================================================
+
+func TestSort_PreservesTheRowSet(t *testing.T) {
+	d := build(
+		makeSeries("m", map[string]string{"s": "a"}, sampleSpec{60, 3}),
+		makeSeries("m", map[string]string{"s": "b"}, sampleSpec{60, 1}),
+	)
+	want := []property.OutcomeRow{
+		row(map[string]string{"s": "a"}, 3),
+		row(map[string]string{"s": "b"}, 1),
+	}
+	// The comparator groups by label set, so sort()/sort_desc() must not
+	// add, drop, or alter any row — only the (unobserved) array order.
+	assertRows(t, eval(d, `sort(m)`, 90), want)
+	assertRows(t, eval(d, `sort_desc(m)`, 90), want)
+}
+
+// =================================================================
+// quantile() aggregator
+// =================================================================
+
+func TestAgg_Quantile_InterpolatesAcrossSeries(t *testing.T) {
+	d := build(
+		makeSeries("m", map[string]string{"s": "a"}, sampleSpec{60, 1}),
+		makeSeries("m", map[string]string{"s": "b"}, sampleSpec{60, 2}),
+		makeSeries("m", map[string]string{"s": "c"}, sampleSpec{60, 3}),
+		makeSeries("m", map[string]string{"s": "d"}, sampleSpec{60, 4}),
+	)
+	// rank = phi*(n-1) = 0.5*3 = 1.5 → halfway between 2 and 3.
+	assertRows(t, eval(d, `quantile(0.5, m)`, 90), []property.OutcomeRow{
+		row(map[string]string{}, 2.5),
+	})
+	assertRows(t, eval(d, `quantile(0, m)`, 90), []property.OutcomeRow{
+		row(map[string]string{}, 1),
+	})
+	assertRows(t, eval(d, `quantile(1, m)`, 90), []property.OutcomeRow{
+		row(map[string]string{}, 4),
+	})
+}
+
+func TestAgg_Quantile_By(t *testing.T) {
+	d := build(
+		makeSeries("m", map[string]string{"job": "api", "s": "a"}, sampleSpec{60, 1}),
+		makeSeries("m", map[string]string{"job": "api", "s": "b"}, sampleSpec{60, 3}),
+		makeSeries("m", map[string]string{"job": "db", "s": "c"}, sampleSpec{60, 10}),
+	)
+	assertRows(t, eval(d, `quantile(0.5, m) by (job)`, 90), []property.OutcomeRow{
+		row(map[string]string{"job": "api"}, 2),
+		row(map[string]string{"job": "db"}, 10),
+	})
+}
+
+func TestAgg_Quantile_OutOfDomainPhi(t *testing.T) {
+	d := build(
+		makeSeries("m", map[string]string{"s": "a"}, sampleSpec{60, 1}),
+		makeSeries("m", map[string]string{"s": "b"}, sampleSpec{60, 4}),
+	)
+	// Prom's documented out-of-domain results: -Inf below 0, +Inf above 1.
+	o := eval(d, `quantile(-0.5, m)`, 90)
+	if len(o.Rows) != 1 || !math.IsInf(o.Rows[0].Value, -1) {
+		t.Fatalf("quantile(-0.5) = %v, want a single -Inf row", o.Rows)
+	}
+	o = eval(d, `quantile(1.5, m)`, 90)
+	if len(o.Rows) != 1 || !math.IsInf(o.Rows[0].Value, 1) {
+		t.Fatalf("quantile(1.5) = %v, want a single +Inf row", o.Rows)
+	}
+	o = eval(d, `quantile(NaN, m)`, 90)
+	if len(o.Rows) != 1 || !math.IsNaN(o.Rows[0].Value) {
+		t.Fatalf("quantile(NaN) = %v, want a single NaN row", o.Rows)
+	}
+}
+
+// =================================================================
+// Window functions the generator draws rarely
+// =================================================================
+
+func TestFn_ChangesOverWindow(t *testing.T) {
+	d := build(makeSeries("m", map[string]string{"s": "a"},
+		sampleSpec{10, 1}, sampleSpec{20, 2}, sampleSpec{30, 2}, sampleSpec{40, 5}))
+	// Three transitions are possible; the repeated 2 is not one of them, and
+	// the very FIRST pair (1→2) counts — the walk starts at index 1, not 2.
+	assertRows(t, eval(d, `changes(m[5m])`, 60), []property.OutcomeRow{
+		row(map[string]string{"s": "a"}, 2),
+	})
+}
+
+func TestFn_ChangesOverWindow_ConsecutiveNaNsAreUnchanged(t *testing.T) {
+	d := build(makeSeries("m", map[string]string{"s": "a"},
+		sampleSpec{10, 1}, sampleSpec{20, math.NaN()},
+		sampleSpec{30, math.NaN()}, sampleSpec{40, 2}))
+	// NaN != NaN in IEEE terms, but Prom explicitly guards that pair, so
+	// only 1→NaN and NaN→2 count.
+	assertRows(t, eval(d, `changes(m[5m])`, 60), []property.OutcomeRow{
+		row(map[string]string{"s": "a"}, 2),
+	})
+}
+
+func TestFn_ResetsOverWindow(t *testing.T) {
+	d := build(makeSeries("m", map[string]string{"s": "a"},
+		sampleSpec{10, 5}, sampleSpec{20, 5}, sampleSpec{30, 6},
+		sampleSpec{40, 1}, sampleSpec{50, 2}, sampleSpec{55, 0}))
+	// Two drops (6→1, 2→0). A FLAT step (5→5) is not a reset — the
+	// comparison is strictly-less, not less-or-equal — and a rising step
+	// never is.
+	assertRows(t, eval(d, `resets(m[5m])`, 60), []property.OutcomeRow{
+		row(map[string]string{"s": "a"}, 2),
+	})
+}
+
+func TestFn_StddevAndStdvarOverTime(t *testing.T) {
+	d := build(makeSeries("m", map[string]string{"s": "a"},
+		sampleSpec{10, 2}, sampleSpec{20, 4}, sampleSpec{30, 4},
+		sampleSpec{40, 4}, sampleSpec{50, 5}, sampleSpec{55, 5}))
+	// Population variance of {2,4,4,4,5,5} is 1 (mean 4), so stddev is 1.
+	assertRows(t, eval(d, `stdvar_over_time(m[5m])`, 60), []property.OutcomeRow{
+		row(map[string]string{"s": "a"}, 1),
+	})
+	assertRows(t, eval(d, `stddev_over_time(m[5m])`, 60), []property.OutcomeRow{
+		row(map[string]string{"s": "a"}, 1),
+	})
+}
+
+func TestFn_StdvarOverTime_SinglePointIsZero(t *testing.T) {
+	d := build(makeSeries("m", map[string]string{"s": "a"}, sampleSpec{10, 7}))
+	assertRows(t, eval(d, `stdvar_over_time(m[5m])`, 60), []property.OutcomeRow{
+		row(map[string]string{"s": "a"}, 0),
+	})
+}
+
+func TestFn_LastOverTime_TakesTheNewestSample(t *testing.T) {
+	d := build(makeSeries("m", map[string]string{"s": "a"},
+		sampleSpec{10, 1}, sampleSpec{50, 9}))
+	assertRows(t, eval(d, `last_over_time(m[5m])`, 60), []property.OutcomeRow{
+		row(map[string]string{"s": "a"}, 9),
+	})
+}
+
+// =================================================================
+// Unary operators
+// =================================================================
+
+func TestUnary_NegateVectorFlipsEverySample(t *testing.T) {
+	d := build(
+		makeSeries("m", map[string]string{"s": "a"}, sampleSpec{60, 3}),
+		makeSeries("m", map[string]string{"s": "b"}, sampleSpec{60, -4}),
+	)
+	assertRows(t, eval(d, `-m`, 90), []property.OutcomeRow{
+		row(map[string]string{"s": "a"}, -3),
+		row(map[string]string{"s": "b"}, 4),
+	})
+}
+
+func TestUnary_PlusIsIdentity(t *testing.T) {
+	d := build(makeSeries("m", map[string]string{"s": "a"}, sampleSpec{60, 3}))
+	// `+x` is a literal no-op — same row, same value, sign untouched.
+	assertRows(t, eval(d, `+m`, 90), []property.OutcomeRow{
+		row(map[string]string{"s": "a"}, 3),
+	})
+}
+
+func TestUnary_NegateScalar(t *testing.T) {
+	d := build()
+	assertRows(t, eval(d, `-(2 + 3)`, 90), []property.OutcomeRow{
+		row(map[string]string{}, -5),
+	})
+}
+
+// =================================================================
+// histogram_quantile out-of-domain phi
+// =================================================================
+
+func TestHistogram_Quantile_PhiOutOfDomainEmitsOneRowPerSeries(t *testing.T) {
+	d := build(
+		makeSeries("h_bucket", map[string]string{"job": "api", "le": "1"}, sampleSpec{60, 1}),
+		makeSeries("h_bucket", map[string]string{"job": "api", "le": "+Inf"}, sampleSpec{60, 2}),
+		makeSeries("h_bucket", map[string]string{"job": "db", "le": "1"}, sampleSpec{60, 3}),
+		makeSeries("h_bucket", map[string]string{"job": "db", "le": "+Inf"}, sampleSpec{60, 4}),
+	)
+	// Out-of-domain phi collapses to a constant per histogram series —
+	// grouped by the non-`le` labels, so two rows, not four.
+	o := eval(d, `histogram_quantile(-1, h_bucket)`, 90)
+	if len(o.Rows) != 2 {
+		t.Fatalf("phi<0: want 2 rows (one per job), got %v", o.Rows)
+	}
+	for _, r := range o.Rows {
+		if !math.IsInf(r.Value, -1) {
+			t.Errorf("phi<0 row %v: want -Inf, got %g", r.Labels, r.Value)
+		}
+		if _, ok := r.Labels["le"]; ok {
+			t.Errorf("le label survived into the output: %v", r.Labels)
+		}
+	}
+	o = eval(d, `histogram_quantile(2, h_bucket)`, 90)
+	if len(o.Rows) != 2 {
+		t.Fatalf("phi>1: want 2 rows, got %v", o.Rows)
+	}
+	for _, r := range o.Rows {
+		if !math.IsInf(r.Value, 1) {
+			t.Errorf("phi>1 row %v: want +Inf, got %g", r.Labels, r.Value)
+		}
+	}
+}
+
+// =================================================================
+// Series identity
+// =================================================================
+
+func TestSeries_NameAndSeriesKeyExcludeMetricName(t *testing.T) {
+	d := build(makeSeries("m", map[string]string{"job": "api", "instance": "x"}, sampleSpec{60, 1}))
+	model := FromDataset(d)
+	if len(model.Series) != 1 {
+		t.Fatalf("want 1 series, got %d", len(model.Series))
+	}
+	s := model.Series[0]
+	if s.Name() != "m" {
+		t.Fatalf("Name() = %q, want %q", s.Name(), "m")
+	}
+	// SeriesKey is the join/group identity: it must not include the
+	// metric name, or `a + b` would never match.
+	key := s.SeriesKey()
+	if key == "" {
+		t.Fatal("SeriesKey() is empty for a labelled series")
+	}
+	if got := (&Series{Labels: map[string]string{"job": "api", "instance": "x"}}).SeriesKey(); got != key {
+		t.Fatalf("SeriesKey() = %q with __name__, %q without — the metric name leaked into the identity", key, got)
+	}
+	if got := (&Series{Labels: map[string]string{}}).Name(); got != "" {
+		t.Fatalf("Name() on an unnamed series = %q, want empty", got)
+	}
+}

--- a/test/property/oracle/promql/selector.go
+++ b/test/property/oracle/promql/selector.go
@@ -2,7 +2,6 @@ package promql
 
 import (
 	"sort"
-	"time"
 
 	"github.com/prometheus/prometheus/promql/parser"
 
@@ -169,15 +168,3 @@ func sortVectorRows(rows []VectorRow) {
 		return labelKey(rows[i].Labels) < labelKey(rows[j].Labels)
 	})
 }
-
-// instantSampleTimestampForOffset returns the effective evaluation
-// timestamp millis after applying offset. Unused as a standalone
-// function today — callers compute it inline — but kept here so the
-// LWR semantics are documented in one place. Reserved for future
-// expansion (e.g. when subquery offsets need to recurse).
-func instantSampleTimestampForOffset(evalTsMs int64, offset time.Duration) int64 {
-	return evalTsMs - offset.Milliseconds()
-}
-
-// _ silences unused-function lints on instantSampleTimestampForOffset.
-var _ = instantSampleTimestampForOffset


### PR DESCRIPTION
## Why

The `coverage` required check is red on push-to-main: four packages sit below
the floor committed in `test/coverage-floor.json`. The floor file is a ratchet,
so the resolution is more real coverage — no floor number is touched by this PR.

## What

New behavioural tests in the four breaching packages. Every test asserts an
outcome; none exists to walk lines. Each new area was mutation spot-checked
(break the code, confirm a test fails, revert), listed below.

### `compatibility/tempo/driver` — 52.55% to 65.23% (floor 58)

`grpc_convert.go` (42 stmts) and `grpc_diff.go` (258 stmts) were entirely
uncovered: nothing constructed a `tempopb.StreamingQuerierClient`. Two new
files fake that interface (a generic `fakeStream[T]` plus a `fakeQuerier`
covering all seven streaming RPCs), which lets the tests pin:

- proto to differ-JSON conversion, including the proto3-JSON conventions the
  HTTP side produces (uint64 rendered as a decimal string, zero timestamps
  omitted, `v1.AnyValue` collapsed to a flat string for each variant);
- every fetcher's frame accumulation to EOF, its per-RPC error wrapping
  (`open X stream` / `recv X frame`), and the empty-stream envelope;
- `unixSeconds32`'s saturating clamp rather than a wrap;
- `diffCaseGRPC` on agreeing backends, diverging backends, an assertion
  failure (soft) versus a hard error (which must name the failing side);
- `writeReportGRPC` / `renderSkippedSection`, including write-error paths.

`runDiffGRPC`, `main`, `usage` and most of `seeder.go` stay uncovered — they
need a real gRPC dial and a live ClickHouse, which no unit test can supply.
That is why this package lands at 65.2% rather than higher; it clears the
floor with margin without faking a network.

### `internal/chplan` — 79.48% to 87.75% (floor 79.9)

`scan_resource_bound.go` and `scan_time_bound.go` — the two IR-level
fail-closed scan-bound invariants — had **zero** coverage from this package's
own tests. `internal/chplan/scan_bound_test.go` now pins their decisions:

- `SpansScanResourceBound` accept/reject across window, literal `TraceId IN`,
  `BoundedTraceScope`, `TraceId = <lit>`, constant-false, constant-true,
  negated `IN`, qualified columns, non-window `Timestamp` comparisons, and
  unrecognised time constructors — in both lenient and column-strict modes;
- `RequireSpansScansBounded`'s descent: bare scan rejected, conjuncts
  accumulated down the `Filter` spine, `LIMIT N` as a memory-streaming bound,
  that bound *not* surviving an `Aggregate`, metrics subtrees skipped, and the
  empty-table / nil-root no-ops;
- `AttachInstantScanTimeBounds`: marks every leaf, never mutates the caller's
  tree, returns the same pointer (no clone) when there is nothing to mark;
- `WithInstantScanTimeBound`: copy-on-write, idempotent, non-leaf untouched.

### `internal/logql` — 83.21% to 88.76% (floor 83.6)

`internal/logql/coverage_gaps_internal_test.go` covers the engine-adapter
surface and the pure helpers that had no caller in tests:

- `Lang.Parse` — stream vs metric classification and `ResponseShape`, a parse
  failure mapping to 400 `bad_data`, and the dotted-key normalisation that
  makes `{service.name="api"}` parse at all;
- `Lang.Name`, `Lang.LateMatShape` (reports the *overridden* logs table);
- `NormalizeDetectedLevel` across every variant group plus the empty and
  fall-through cases;
- `MatchesIPPattern` — exact / CIDR / range, both edges and just past them,
  IPv4-vs-IPv6 family mismatch, unparseable candidate runs, invalid pattern;
- `SelectorPredicate` (nil, single, AND-folded), `FiltersErrorLabel` across
  all six filter kinds and binary composition, `labelFilterOp`,
  `logqlBinaryOp` (including the unknown-operator error), `gateMark`,
  `jpToken.text`.

### `test/property/oracle/promql` — 70.05% to 81.18% (floor 71.2)

`test/property/oracle/promql/oracle_gaps_test.go` covers oracle semantics that
the rapid-driven property lane never reached: `and` / `or` / `unless`
(including `on(...)` / `ignoring(...)` and the LHS-wins collision rule),
`absent`, the three `clamp` variants (with the `max < min` empty case and the
non-scalar-bound error), `sort` / `sort_desc` row-set preservation, the
`quantile()` aggregator's interpolation, `changes` / `resets` /
`stddev_over_time` / `stdvar_over_time` / `last_over_time`, unary operators,
and `histogram_quantile` with an out-of-domain phi.

It also deletes `instantSampleTimestampForOffset` from `selector.go`: the
function had no caller and was kept alive solely by a `var _ =` silencer.

## Verification

`coverage` short-circuits to a green no-op on an ordinary pull request
(`RUN_HEAVY` is false for `pull_request` in `.github/workflows/coverage.yml`),
so a green `coverage` check on this PR proves nothing — the real gate runs on
the push to main after merge. The local run below is therefore the only real
evidence, and these numbers are the claim this PR is making.

Run exactly as the lane does — `COVERAGE_REQUIRE_LANES=default+chdb just
coverage`, i.e. the default lane and the `chdb`-tagged lane merged per-block:

| package | before | after | floor |
| --- | --- | --- | --- |
| `compatibility/tempo/driver` | 52.55% | **65.23%** | 58.0 |
| `internal/chplan` | 79.48% | **87.75%** | 79.9 |
| `internal/logql` | 83.21% | **88.76%** | 83.6 |
| `test/property/oracle/promql` | 70.05% | **81.18%** | 71.2 |

Whole-repo verdict from that run:

```text
 88.76%   1200 / 1352   internal/logql
 87.75%   1347 / 1535   internal/chplan
 81.18%   1070 / 1318   test/property/oracle/promql
 65.23%   1229 / 1884   compatibility/tempo/driver
total: 64.2% (30393 / 47333 statements)
coverage-summary: 70 package floor(s) clear
```

`test/coverage-floor.json` is untouched — `git diff` against it is empty. The
ratchet only ever moves up, and this PR moves no number in it at all.

## Mutation spot-checks

Each mutation was applied, the tests run, then reverted:

| mutation | killed by |
| --- | --- |
| `chplan`: constant-false conjunct check inverted (`!lb.V` to `lb.V`) | `TestSpansScanResourceBound_Classification`, `TestRequireSpansScansBounded_ReportsTheFirstViolationOnly` |
| `chplan`: `IsInstantWindowedLeaf`'s `OuterRange != 0` to `== 0` | 4 `AttachInstantScanTimeBounds` / `WithInstantScanTimeBound` tests |
| `logql`: `NormalizeDetectedLevel` empty case returns `""` | `TestNormalizeDetectedLevel` |
| `logql`: `MatchesIPPattern` upper bound `<= 0` to `< 0` | `TestMatchesIPPattern` |
| `logql`: parse failure status 400 to 418 | `TestLang_Parse_ParseFailureIsA400BadData` |
| `oracle`: `changesOverTime` loop starts at 2 | `TestFn_ChangesOverWindow` |
| `oracle`: `resetsOverTime` `<` to `<=` | `TestFn_ResetsOverWindow` |
| `oracle`: `changesOverTime` NaN-pair guard removed | `TestFn_ChangesOverWindow_ConsecutiveNaNsAreUnchanged` |
| `oracle`: `unless` membership test inverted | 3 set-op tests |
| `oracle`: `clamp`'s `max < min` check inverted; `clamp_min` uses `math.Min` | 3 clamp tests |
| `tempo/driver`: 3 converter/fetcher mutations | 7 tests |

The first pass of the oracle `changes` / `resets` tests survived their
mutations because the sample data happened to be insensitive to them; the data
was reworked until each mutation is killed.
