### PR TITLE
fix(test): match generated-artefact markers against the whole path, not the basename

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -137,7 +137,8 @@ test/e2e/migration/expected/schema/*.sql                 -merge
 # Regenerate: `CERBERUS_UPDATE_INVENTORY=1 go test <package>`. Each is a sorted
 # flat array of rows behind a small wrapper object — the wrapper does not help,
 # the hazard lives one level down. The `-exclusions.json` siblings of the
-# ql-inventory files are hand-authored and deliberately absent from this list.
+# ql-inventory files are hand-authored and deliberately absent from this list —
+# they are recorded in the hand-authored section at the bottom instead.
 # CERBERUS_UPDATE_INVENTORY=1 go test ./test/oracle/inventory/...
 test/e2e/grafana/ql-inventory/promql-feature-inventory.json   -merge
 test/e2e/grafana/ql-inventory/logql-feature-inventory.json    -merge
@@ -174,6 +175,13 @@ test/e2e/playwright/crawl/grafana-surface-inventory.k3d.json      -merge
 #   migration-e2e.mjs only reads it and errors telling you to reconcile.
 # hand-authored: test/e2e/migration/pass-assertions.pin.json — deliberately has
 #   no regeneration mode; the gate re-derives each sha256 before comparing.
+# hand-authored: test/e2e/grafana/ql-inventory/promql-feature-exclusions.json —
+#   curated exclusions, not regenerated; each entry names a feature the crawl
+#   must not expect, and a blended one fails the crawl it guards.
+# hand-authored: test/e2e/grafana/ql-inventory/logql-feature-exclusions.json —
+#   same, for the LogQL crawl.
+# hand-authored: test/e2e/grafana/ql-inventory/traceql-feature-exclusions.json —
+#   same, for the TraceQL crawl.
 #
 # Two further families are deliberately left ungated, for the same "a blend is
 # loud, not silent" reason:

--- a/test/regression/generated_artifact_merge_gate_test.go
+++ b/test/regression/generated_artifact_merge_gate_test.go
@@ -153,9 +153,9 @@ const catalogueShardExt = ".json"
 // rosterArtifacts returns the hand-written roster with the catalogue's shards
 // expanded into one entry apiece. Enumerating them beats hard-coding thirty
 // paths that turn over whenever a lowering file gains or loses its last
-// guard — and it is strictly stronger than the name-based net below, which
-// never sees a shard at all (a shard's BASENAME carries no generated-artefact
-// marker; only its directory does).
+// guard. The net below independently reaches the shards through their
+// directory name, so the two overlap here by design: this roster additionally
+// pins the regeneration command, which the net cannot.
 func rosterArtifacts(t *testing.T) []generatedArtifact {
 	t.Helper()
 
@@ -223,7 +223,8 @@ func TestGeneratedArtifactsRefuseLineMerge(t *testing.T) {
 // generatedNameMarkers are the naming families cerberus gives its generated data
 // artefacts. They are the net for artefacts added AFTER this gate landed: the
 // roster above can only cover what its author knew about, so anything committed
-// under one of these names has to be classified here one way or the other.
+// under one of these names has to be classified here one way or the other. A
+// family name on the DIRECTORY counts — see looksGenerated.
 var generatedNameMarkers = []string{"baseline", "inventory", "catalogue", ".pin."}
 
 // generatedDataExtensions restrict the net to DATA files. The same words appear
@@ -310,13 +311,19 @@ func TestNoGeneratedArtifactEscapesTheMergeGate(t *testing.T) {
 }
 
 // looksGenerated reports whether a tracked path is named like a generated data
-// artefact.
+// artefact. The markers are matched against the WHOLE path, not just the
+// basename: a sharded artefact carries the family name on its directory
+// (test/rejection-parity/catalogue/internal__promql__lower.go.json), so a
+// basename-only net would let every shard through — neither `-merge` gated nor
+// recorded as hand-authored — which is the silent-blend shape this gate exists
+// to prevent. The extension check stays on the basename, since only the file
+// itself decides whether it is a data file.
 func looksGenerated(path string) bool {
-	name := strings.ToLower(filepath.Base(path))
+	lower := strings.ToLower(path)
 
 	var dataFile bool
 	for _, ext := range generatedDataExtensions {
-		if strings.HasSuffix(name, ext) {
+		if strings.HasSuffix(filepath.Base(lower), ext) {
 			dataFile = true
 
 			break
@@ -327,12 +334,47 @@ func looksGenerated(path string) bool {
 	}
 
 	for _, marker := range generatedNameMarkers {
-		if strings.Contains(name, marker) {
+		if strings.Contains(lower, marker) {
 			return true
 		}
 	}
 
 	return false
+}
+
+// TestLooksGeneratedReadsTheWholePath pins the directory half of the net. The
+// net was basename-only when it landed, which meant a generated artefact whose
+// family name sat on its DIRECTORY — the shape every sharded artefact takes —
+// was classified as neither generated nor hand-authored, and merged silently
+// with every check green. That is the #1422 failure the gate exists to make
+// loud, so the distinction is pinned rather than left to the roster to cover
+// incidentally.
+func TestLooksGeneratedReadsTheWholePath(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{"marker on the basename", "test/perf/cardinality-baseline.json", true},
+		{"marker on the directory only", "test/rejection-parity/catalogue/internal__promql__lower.go.json", true},
+		{"marker on a directory further up", "test/rejection-parity/catalogue/nested/shard.json", true},
+		{"marker anywhere, uppercased", "test/Rejection-Parity/CATALOGUE/Shard.JSON", true},
+		{"no marker at all", "test/spec/promql/rate.json", false},
+		{"marker present but not a data file", "test/rejection-parity/catalogue.go", false},
+		{"marker on the directory, non-data extension", "test/rejection-parity/catalogue/shard.md", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := looksGenerated(tc.path); got != tc.want {
+				t.Errorf("looksGenerated(%q) = %v, want %v", tc.path, got, tc.want)
+			}
+		})
+	}
 }
 
 // readGitattributes loads the gate, failing loudly if it has gone missing —


### PR DESCRIPTION
`looksGenerated` — the half of `generated_artifact_merge_gate_test.go` that catches a tracked data file *named* like a generated artefact but gated by neither `.gitattributes` nor the hand-authored roster — ran its marker list over `filepath.Base(path)` only.

That was sound while every generated artefact was a single file whose own name carried the family marker. It stopped being sound the moment an artefact was **sharded**. `test/rejection-parity/catalogue/*.json` (30 shards since #1804) carries the family name on the **directory**: a shard is `internal__promql__lower.go.json`, which contains no marker at all. Every one of those 30 shards fell straight through the net — not classified as generated, therefore never checked for a `-merge` rule, therefore indistinguishable to the gate from an ungated blendable baseline.

## The fix

Match markers against the whole lowercased path. The extension check stays on the basename, since only the file itself decides whether it is a data file.

Widening the net pulls the catalogue shards back in — they were already gated, so no `.gitattributes` change was needed for them — and additionally pulls in the three `test/e2e/grafana/ql-inventory/*-feature-exclusions.json` siblings, which are hand-authored and now need an explicit record in the hand-authored section.

## Why this isn't hollow

`TestLooksGeneratedReadsTheWholePath` is a 7-case table that fails on the pre-fix function: a marker on the directory must classify, a marker further up the path must classify, uppercase must classify, and — the other direction — a directory marker over a non-data extension must still **not** classify, so the widening doesn't turn every file under a marked directory into a gated artefact.

Two comments that the pre-fix behaviour made true and this change makes false are corrected in the same commit: the `generatedNameMarkers` doc now says a family name on the directory counts, and `rosterArtifacts` no longer claims the net "never sees a shard at all." The two overlap by design — the roster additionally pins each artefact's regeneration command, which the net cannot.