### PR TITLE
fix(e2e): unblock the red release gates — unary-! showcase contract + OTel resource env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -300,6 +300,14 @@ services:
       # safe inside the cerberus-dev docker network.
       CERBERUS_OTLP_ENDPOINT: "otel-collector:4317"
       CERBERUS_OTLP_INSECURE: "true"
+      # OTEL_RESOURCE_ATTRIBUTES  standard OTel resource dimensions for
+      # cerberus's own self-telemetry. Kept in lock-step with the k3d stack
+      # (test/e2e/k3s/cerberus-values.yaml) so a dashboard or drilldown flow
+      # that groups spans by a resource axis behaves identically on both
+      # substrates. Without it cerberus describes itself along service.name /
+      # service.version / service.instance.id only, and any breakdown by
+      # another resource dimension is genuinely empty (#1818).
+      OTEL_RESOURCE_ATTRIBUTES: "service.namespace=cerberus-dev,deployment.environment=dev"
       # CERBERUS_CH_QUERY_MAX_MEMORY   per-query ClickHouse memory cap
       # (`max_memory_usage` on every data-plane query). 1 GiB, matching
       # the binary default and the k3d stack

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -177,6 +177,26 @@ the SDK on top of the cerberus-specific knobs above. When both are set,
 the `CERBERUS_OTLP_*` value wins for that field because cerberus passes
 it explicitly to the exporter constructor.
 
+`OTEL_SERVICE_NAME` and `OTEL_RESOURCE_ATTRIBUTES` reach the resource
+cerberus stamps on every exported span, metric point and log record.
+Precedence runs derived defaults (`service.name=cerberus`,
+`service.version=dev`, `service.instance.id` from the hostname) →
+environment → `CERBERUS_OTLP_SERVICE_NAME` / `_SERVICE_VERSION`, so the
+environment overrides a guess and explicit configuration overrides the
+environment. `OTEL_RESOURCE_ATTRIBUTES` is the only channel for the
+dimensions cerberus has no dedicated knob for, and deployments should use
+it to describe cerberus along the same axes as every other producer they
+run:
+
+```sh
+OTEL_RESOURCE_ATTRIBUTES=service.namespace=platform,deployment.environment=prod
+```
+
+This is not cosmetic. Grafana's Traces Drilldown breaks a selected
+service down by `resource.service.namespace`, so a cerberus that
+publishes no `service.namespace` produces an empty breakdown and the
+drill dead-ends one level in.
+
 ### Self-metrics
 
 The instrument set lives in `internal/telemetry`. Names, units and

--- a/internal/telemetry/lifecycle_test.go
+++ b/internal/telemetry/lifecycle_test.go
@@ -15,6 +15,7 @@ import (
 // in Config still produces "cerberus" on the resource. Anchors the
 // invariant cerberus dashboards rely on (service.name=cerberus).
 func TestBuildResource_DefaultsServiceName(t *testing.T) {
+	clearResourceEnv(t)
 	res, err := buildResource(t.Context(), Config{}, nil)
 	if err != nil {
 		t.Fatalf("buildResource: %v", err)
@@ -27,6 +28,7 @@ func TestBuildResource_DefaultsServiceName(t *testing.T) {
 // TestBuildResource_DefaultsServiceVersion confirms an empty
 // ServiceVersion in Config falls back to "dev".
 func TestBuildResource_DefaultsServiceVersion(t *testing.T) {
+	clearResourceEnv(t)
 	res, err := buildResource(t.Context(), Config{}, nil)
 	if err != nil {
 		t.Fatalf("buildResource: %v", err)
@@ -272,4 +274,94 @@ func attr(res *resource.Resource, key string) string {
 		}
 	}
 	return ""
+}
+
+// clearResourceEnv neutralises the two standard OTel resource env vars
+// for the duration of a test. buildResource now honours them (that is
+// the whole point of the WithFromEnv detector), so a test asserting a
+// *default* has to state that the environment supplies nothing —
+// otherwise a developer shell or CI runner that exports OTEL_SERVICE_NAME
+// turns a genuine assertion into an environment-dependent coin flip.
+// t.Setenv restores the prior value on cleanup, and the SDK's fromEnv
+// detector treats an empty value as absent.
+func clearResourceEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("OTEL_SERVICE_NAME", "")
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "")
+}
+
+// TestBuildResource_HonoursResourceAttributesEnv pins the fix for the
+// Traces Drilldown depth regression (#1818): cerberus's own
+// self-telemetry carried only service.name / service.version /
+// service.instance.id, so a breakdown query grouping by any other
+// resource dimension — the Drilldown app walks a fixed attribute list
+// and appends `&& <groupBy> != nil` to every query — returned nothing
+// and the drill dead-ended one level in. OTEL_RESOURCE_ATTRIBUTES is the
+// standard channel for the dimensions cerberus has no config knob for,
+// it is what docs/observability.md documents, and before this it was
+// silently dropped.
+func TestBuildResource_HonoursResourceAttributesEnv(t *testing.T) {
+	clearResourceEnv(t)
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "service.namespace=cerberus-e2e,deployment.environment=e2e")
+
+	res, err := buildResource(t.Context(), Config{}, nil)
+	if err != nil {
+		t.Fatalf("buildResource: %v", err)
+	}
+	if got := attr(res, "service.namespace"); got != "cerberus-e2e" {
+		t.Errorf("service.namespace = %q; want cerberus-e2e", got)
+	}
+	if got := attr(res, "deployment.environment"); got != "e2e" {
+		t.Errorf("deployment.environment = %q; want e2e", got)
+	}
+	// The derived defaults survive alongside the env attributes.
+	if got := attr(res, "service.name"); got != "cerberus" {
+		t.Errorf("service.name = %q; want cerberus", got)
+	}
+	if got := attr(res, "service.instance.id"); got == "" {
+		t.Error("service.instance.id = empty; want non-empty")
+	}
+}
+
+// TestBuildResource_EnvServiceNameBeatsDefault confirms OTEL_SERVICE_NAME
+// overrides the derived "cerberus" fallback. The fallback is a guess;
+// the environment is an explicit operator statement, so it must win.
+func TestBuildResource_EnvServiceNameBeatsDefault(t *testing.T) {
+	clearResourceEnv(t)
+	t.Setenv("OTEL_SERVICE_NAME", "cerberus-gateway")
+
+	res, err := buildResource(t.Context(), Config{}, nil)
+	if err != nil {
+		t.Fatalf("buildResource: %v", err)
+	}
+	if got := attr(res, "service.name"); got != "cerberus-gateway" {
+		t.Errorf("service.name = %q; want cerberus-gateway", got)
+	}
+}
+
+// TestBuildResource_ConfigBeatsEnv pins the precedence contract
+// docs/observability.md states: when both the CERBERUS_OTLP_* knob and
+// the OTel env var set the same field, the cerberus config wins. The
+// env-only attributes it does NOT set are untouched.
+func TestBuildResource_ConfigBeatsEnv(t *testing.T) {
+	clearResourceEnv(t)
+	t.Setenv("OTEL_SERVICE_NAME", "from-env")
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "service.version=from-env,service.namespace=kept")
+
+	res, err := buildResource(t.Context(), Config{
+		ServiceName:    "from-config",
+		ServiceVersion: "v9.9.9",
+	}, nil)
+	if err != nil {
+		t.Fatalf("buildResource: %v", err)
+	}
+	if got := attr(res, "service.name"); got != "from-config" {
+		t.Errorf("service.name = %q; want from-config", got)
+	}
+	if got := attr(res, "service.version"); got != "v9.9.9" {
+		t.Errorf("service.version = %q; want v9.9.9", got)
+	}
+	if got := attr(res, "service.namespace"); got != "kept" {
+		t.Errorf("service.namespace = %q; want kept", got)
+	}
 }

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -9,8 +9,10 @@
 // resource carrying `service.name`, `service.version`, and
 // `service.instance.id`.
 //
-// The OTel Go SDK also reads standard `OTEL_EXPORTER_OTLP_*` env vars on
-// its own; cerberus's CERBERUS_OTLP_* knobs apply on top of those.
+// The OTel Go SDK also reads the standard `OTEL_EXPORTER_OTLP_*` env
+// vars on its own, and buildResource wires in the standard resource
+// detector so `OTEL_SERVICE_NAME` / `OTEL_RESOURCE_ATTRIBUTES` are
+// honoured too; cerberus's CERBERUS_OTLP_* knobs apply on top of those.
 package telemetry
 
 import (
@@ -21,6 +23,7 @@ import (
 	"os"
 	"time"
 
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
@@ -84,7 +87,8 @@ func (p *Providers) Shutdown(ctx context.Context) error {
 // cfg.Endpoint returns noop providers and a no-op Shutdown — the safe
 // "OTel disabled" default. A non-empty endpoint builds real gRPC OTLP
 // exporters; resource attributes are filled from cfg.ServiceName,
-// cfg.ServiceVersion, and the local hostname (with a random fallback).
+// cfg.ServiceVersion, the standard OTel resource env vars, and the local
+// hostname (with a random fallback) — see buildResource for precedence.
 func New(ctx context.Context, cfg Config) (*Providers, error) {
 	if cfg.Endpoint == "" {
 		return &Providers{
@@ -241,26 +245,37 @@ func newLoggerProvider(ctx context.Context, cfg Config, res *resource.Resource) 
 // errored hostnames).
 type hostnameFunc func() (string, error)
 
-// buildResource composes the resource attached to every exported span
-// and metric. Attribute fallbacks:
+// Fallback resource values used when neither the cerberus config nor the
+// standard OTel environment supplies one.
+const (
+	defaultServiceName    = "cerberus"
+	defaultServiceVersion = "dev"
+)
+
+// buildResource composes the resource attached to every exported span,
+// metric, and log record. Three precedence tiers are merged in order,
+// each one overriding the tier before it (resource.New merges detectors
+// left-to-right, and Merge lets the right-hand resource win):
 //
-//   - service.name        ← cfg.ServiceName  (defaults to "cerberus" if blank)
-//   - service.version     ← cfg.ServiceVersion (defaults to "dev" if blank)
-//   - service.instance.id ← hostname()        (falls back to a random 16-byte
-//     hex string when hostname lookup errors out — common in scratch
-//     containers)
+//  1. Derived defaults — service.name "cerberus", service.version "dev",
+//     and service.instance.id from hostname() (a random 16-byte hex
+//     string when hostname lookup errors out or returns empty, common in
+//     scratch containers). These are guesses, so anything explicit beats
+//     them.
+//  2. The standard OTel environment — OTEL_SERVICE_NAME and
+//     OTEL_RESOURCE_ATTRIBUTES, via resource.WithFromEnv. This is the
+//     only channel through which a deployment can attach resource
+//     attributes cerberus has no config knob for (service.namespace,
+//     deployment.environment, k8s.*), which is what every other OTLP
+//     producer in a stack does and what docs/observability.md documents.
+//  3. Explicit cerberus config — CERBERUS_OTLP_SERVICE_NAME /
+//     _SERVICE_VERSION. Applied last so the documented "when both are
+//     set, the CERBERUS_* value wins for that field" contract holds.
+//     Blank config fields contribute nothing, leaving tiers 1-2 intact.
 //
 // hostname is parameterised for testability — production callers pass
 // os.Hostname; tests supply a stub. Nil is treated as os.Hostname.
 func buildResource(ctx context.Context, cfg Config, hostname hostnameFunc) (*resource.Resource, error) {
-	name := cfg.ServiceName
-	if name == "" {
-		name = "cerberus"
-	}
-	version := cfg.ServiceVersion
-	if version == "" {
-		version = "dev"
-	}
 	if hostname == nil {
 		hostname = os.Hostname
 	}
@@ -268,13 +283,24 @@ func buildResource(ctx context.Context, cfg Config, hostname hostnameFunc) (*res
 	if err != nil || instance == "" {
 		instance = randomInstanceID()
 	}
+
+	explicit := make([]attribute.KeyValue, 0, 2)
+	if cfg.ServiceName != "" {
+		explicit = append(explicit, semconv.ServiceName(cfg.ServiceName))
+	}
+	if cfg.ServiceVersion != "" {
+		explicit = append(explicit, semconv.ServiceVersion(cfg.ServiceVersion))
+	}
+
 	return resource.New(
 		ctx,
 		resource.WithAttributes(
-			semconv.ServiceName(name),
-			semconv.ServiceVersion(version),
+			semconv.ServiceName(defaultServiceName),
+			semconv.ServiceVersion(defaultServiceVersion),
 			semconv.ServiceInstanceID(instance),
 		),
+		resource.WithFromEnv(),
+		resource.WithAttributes(explicit...),
 	)
 }
 

--- a/test/e2e/grafana/compose/dashboards/showcase-traceql.json
+++ b/test/e2e/grafana/compose/dashboards/showcase-traceql.json
@@ -3536,14 +3536,14 @@
     },
     {
      "cerberus": {
-      "expect": "nonempty",
-      "why": "Cerberus lowers `!( <comparison> )` to a NOT predicate. The showcase has Internal / Client / Producer / Consumer spans, so the negation returns the non-server spans."
+      "expect": "empty",
+      "why": "Reference Tempo empties ANY top-level `!( <comparison> )` spanset filter regardless of the inner comparison's selectivity, so cerberus folds that shape to a constant-false predicate for bit-for-bit parity. Pinned upstream-side by the compatibility/tempo corpus case `negated_kind_not_client` and engine-side by test/spec/traceql/unary_not_intrinsic.txtar (same query, `[]` rows). A real NOT predicate is emitted when the negated operand is compound and sits under && / || — see test/spec/traceql/unary_not_compound_and_operand.txtar."
      },
      "datasource": {
       "type": "tempo",
       "uid": "cerberus-tempo"
      },
-     "description": "Cerberus implements `{ !(kind = server) }`; reference Tempo accepts it too. This panel pins the nonempty result bidirectionally.",
+     "description": "`{ !(kind = server) }` — a top-level unary `!` over a bare comparison. Reference Tempo returns nothing for this shape, so cerberus does too. This panel pins the empty result bidirectionally: series appearing here means the parity fold regressed.",
      "fieldConfig": {
       "defaults": {
        "color": {

--- a/test/e2e/k3s/cerberus-values.yaml
+++ b/test/e2e/k3s/cerberus-values.yaml
@@ -97,6 +97,19 @@ extraEnv:
   # cgroup OOMs.
   - name: GOMEMLIMIT
     value: 2048MiB
+  # Resource dimensions cerberus's own self-telemetry carries, matching the
+  # telemetrygen sample apps in sample-app.yaml so every OTLP producer in the
+  # cluster describes itself along the SAME axes. Grafana Traces Drilldown
+  # walks a fixed attribute list when it breaks a selection down: clicking
+  # "Include" on resource.service.name=cerberus auto-advances the groupBy to
+  # resource.service.namespace and appends `&& resource.service.namespace !=
+  # nil` to the breakdown query. A cerberus that published only
+  # service.name / service.version / service.instance.id made that query
+  # genuinely empty ("No data for selected query"), the second-level
+  # affordance never rendered, and iterate-drilldown-apps.spec.ts failed the
+  # two-level floor with levelsClicked=1 (#1818).
+  - name: OTEL_RESOURCE_ATTRIBUTES
+    value: service.namespace=cerberus-e2e,deployment.environment=e2e
 
 resources:
   requests:

--- a/test/perf/cardinality-baseline.json
+++ b/test/perf/cardinality-baseline.json
@@ -9581,6 +9581,17 @@
     "uncountable_levels": 0
   },
   {
+    "fixture": "traceql/unary_not_compound_and_operand",
+    "fan_factor": 1,
+    "scan_rows": 1,
+    "peak_intermediate": 1,
+    "has_cross_join": false,
+    "has_array_join": false,
+    "has_recursive_cte": false,
+    "max_recursion_depth": 0,
+    "uncountable_levels": 0
+  },
+  {
     "fixture": "traceql/unary_not_double_negation",
     "fan_factor": 1,
     "scan_rows": 1,

--- a/test/regression/k3s_env_test.go
+++ b/test/regression/k3s_env_test.go
@@ -79,3 +79,81 @@ func TestK3sCerberusDeploymentWiresOTLP(t *testing.T) {
 		t.Errorf("%s does not wire OTLP — expected an `otlp:` block with a non-empty `endpoint:` so the k3d cerberus deployment exports self-telemetry; without it the cerberus dashboard panels return empty matrices", valuesPath)
 	}
 }
+
+// drilldownBreakdownDimension is the resource axis Grafana Traces
+// Drilldown auto-advances to after the operator includes a service:
+// clicking "Include" on `resource.service.name` sets the app's groupBy to
+// `resource.service.namespace` and appends `&& resource.service.namespace
+// != nil` to the breakdown query.
+const drilldownBreakdownDimension = "service.namespace"
+
+// TestK3sCerberusPublishesBreakdownResourceDimensions pins the manifest
+// half of the fix for #1818: the Traces Drilldown app drilled only one
+// level in the k3d `dashboard` lane, failing
+// test/e2e/playwright/iterate-drilldown-apps.spec.ts's two-level floor
+// with `levelsClicked=1`.
+//
+// The chain: the harness clicks the first "Include" affordance, which
+// selects `resource.service.name = cerberus` — cerberus's own
+// self-telemetry. The app then breaks that selection down by
+// `resource.service.namespace`. Cerberus published only service.name /
+// service.version / service.instance.id, so the breakdown query was
+// genuinely empty, the panel rendered "No data for selected query", and
+// no second-level affordance existed to click.
+//
+// Two things had to be true, and this test pins the one that is a
+// manifest rather than code:
+//
+//  1. The binary must honour OTEL_RESOURCE_ATTRIBUTES at all —
+//     internal/telemetry.buildResource installs resource.WithFromEnv, and
+//     internal/telemetry's TestBuildResource_HonoursResourceAttributesEnv
+//     asserts it.
+//  2. The k3d deployment must actually SET it, along the same axes the
+//     telemetrygen sample apps already describe themselves by, so every
+//     OTLP producer in the cluster is breakdown-able.
+//
+// The lane that would otherwise catch a regression here (`dashboard`) is
+// a release gate: it short-circuits to a green no-op on an ordinary pull
+// request and does its real work on the merge commit. A static pin in the
+// `check` lane fails on the PR instead.
+func TestK3sCerberusPublishesBreakdownResourceDimensions(t *testing.T) {
+	t.Parallel()
+
+	valuesPath := "../e2e/k3s/cerberus-values.yaml"
+	values, err := os.ReadFile(valuesPath)
+	if err != nil {
+		t.Fatalf("read e2e values %s: %v", valuesPath, err)
+	}
+
+	// The chart renders `extraEnv` verbatim into the container's env, so
+	// the name/value pair appearing there IS the deployed variable.
+	attrsRE := regexp.MustCompile(`(?m)^\s*-\s*name:\s*OTEL_RESOURCE_ATTRIBUTES\s*$\n\s*value:\s*(\S.*?)\s*$`)
+	m := attrsRE.FindStringSubmatch(string(values))
+	if m == nil {
+		t.Fatalf("%s does not set OTEL_RESOURCE_ATTRIBUTES in extraEnv — cerberus then describes itself along service.name / service.version / service.instance.id only, every Traces Drilldown breakdown by another resource axis is empty, and iterate-drilldown-apps.spec.ts fails its two-level floor (#1818)", valuesPath)
+	}
+	deployed := strings.Trim(m[1], `"'`)
+	if !strings.Contains(deployed, drilldownBreakdownDimension+"=") {
+		t.Errorf("%s sets OTEL_RESOURCE_ATTRIBUTES=%q, which carries no %s — that is the exact axis Traces Drilldown breaks a service selection down by, so the drill dead-ends one level in (#1818)", valuesPath, deployed, drilldownBreakdownDimension)
+	}
+
+	// Lock-step with the telemetrygen sample apps: the whole cluster has to
+	// describe itself along the SAME axis, or a breakdown that works for
+	// the sample services silently dead-ends on cerberus (and vice versa).
+	appPath := "../e2e/k3s/sample-app.yaml"
+	app, err := os.ReadFile(appPath)
+	if err != nil {
+		t.Fatalf("read sample app %s: %v", appPath, err)
+	}
+	if !strings.Contains(string(app), drilldownBreakdownDimension+"=") {
+		t.Fatalf("%s no longer sets %s on the telemetrygen producers — this test's lock-step premise is gone; re-derive which resource axis the cluster is uniformly breakdown-able on", appPath, drilldownBreakdownDimension)
+	}
+	sampleNSRE := regexp.MustCompile(regexp.QuoteMeta(drilldownBreakdownDimension) + `="?([A-Za-z0-9_.-]+)"?`)
+	sample := sampleNSRE.FindStringSubmatch(string(app))
+	if sample == nil {
+		t.Fatalf("%s sets %s but its value did not parse — adjust the pattern rather than dropping the lock-step assertion", appPath, drilldownBreakdownDimension)
+	}
+	if !strings.Contains(deployed, drilldownBreakdownDimension+"="+sample[1]) {
+		t.Errorf("%s deploys OTEL_RESOURCE_ATTRIBUTES=%q but %s puts the telemetrygen producers in %s=%q — the two must agree so the whole k3d cluster is breakdown-able along one namespace", valuesPath, deployed, appPath, drilldownBreakdownDimension, sample[1])
+	}
+}

--- a/test/spec/traceql/unary_not_compound_and_operand.txtar
+++ b/test/spec/traceql/unary_not_compound_and_operand.txtar
@@ -1,0 +1,41 @@
+A unary `!` whose operand is a COMPOUND boolean (an `||` of two
+comparisons) and which sits as an AND operand. This is the one position
+where cerberus emits a real `not(...)` predicate rather than reference
+Tempo's positional fold: reference empties a top-level
+`!( <comparison> )` outright (#1712, pinned by unary_not_intrinsic.txtar)
+and drops a bare-comparison NOT as the parent combinator's identity
+element (unary_not_or_composition.txtar), but neither rule is a clean
+identity for a compound operand, so cerberus computes the correct answer.
+
+The seed makes the negation load-bearing rather than decorative. The
+un-negated conjunct `kind != producer` alone selects Server + Client +
+Internal; only the `not(Server || Client)` half narrows that to Internal.
+A regression that dropped the NOT — folding it to `true` the way the
+bare-comparison case does — would return three rows instead of one, so
+this fixture fails on both an over- and an under-selective negation.
+
+-- query.traceql --
+{ kind != producer && !(kind = server || kind = client) }
+-- seed --
+CREATE TABLE otel_traces (
+    SpanId String,
+    SpanKind String
+) ENGINE = MergeTree ORDER BY SpanId;
+INSERT INTO otel_traces (SpanId, SpanKind) VALUES
+    ('aaaa', 'Server'),
+    ('bbbb', 'Client'),
+    ('cccc', 'Internal'),
+    ('dddd', 'Producer');
+-- expected_rows --
+[
+  ["", {"__cerberus_parentSpanID": "", "__cerberus_spanID": "cccc", "__cerberus_traceID": ""}, "1970-01-01T00:00:00Z", 0]
+]
+-- args --
+[0] string = "Producer"
+[1] string = "Server"
+[2] string = "Client"
+-- chplan --
+Filter predicate=((SpanKind != "Producer") AND not(((SpanKind = "Server") OR (SpanKind = "Client"))))
+  Scan(otel_traces)
+-- sql --
+SELECT * FROM `otel_traces` PREWHERE (`SpanKind` != ?) WHERE not(((`SpanKind` = ?) OR (`SpanKind` = ?)))


### PR DESCRIPTION
## Summary

- **#1817 — `compose-smoke` (shard-kiosk).** The showcase-traceql panel `unary ! negation` declared `expect: nonempty` for `{ !(kind = server) }`, but cerberus deliberately folds a top-level `!( <comparison> )` to a constant-false predicate to match reference Tempo, which empties that shape regardless of the inner comparison. The stale declaration is the bug, not the engine — the fold is pinned green from two independent directions already (the `compatibility/tempo` corpus case `negated_kind_not_client`, and `test/spec/traceql/unary_not_intrinsic.txtar` running this panel's exact query). Flipped to `expect: empty` with the rationale on the panel.
- **#1817 — new coverage for the path that DOES negate.** Nothing exercised the one position where `lowerUnaryNot` emits a real `not(...)`: a compound operand under `&&` / `||`. `test/spec/traceql/unary_not_compound_and_operand.txtar` covers it, and its seed makes the negation load-bearing rather than decorative — `kind != producer` alone selects three of the four spans, only `not(Server || Client)` narrows it to one, so the fixture fails on an over- and an under-selective negation alike.
- **#1818 — `dashboard` (shard-smoke-b-monolith).** Traces Drilldown dead-ended one level in because cerberus published only `service.name` / `service.version` / `service.instance.id`: the harness includes `resource.service.name = cerberus`, the app breaks that down by `resource.service.namespace`, the query is genuinely empty, and no second-level affordance renders. Root defect is that `buildResource` never installed `resource.WithFromEnv`, so `OTEL_RESOURCE_ATTRIBUTES` — the documented channel for exactly these dimensions — was silently dropped.
- **#1818 — precedence made explicit.** Resource attributes now merge derived defaults → environment → explicit `CERBERUS_OTLP_*`, so the environment beats a guess and configuration beats the environment, which is the contract `docs/observability.md` already stated.

## Test plan

- [x] `go test -run TestBuildResource ./internal/telemetry/` — new env-precedence tests pass; the pre-existing default-value tests now neutralise the environment instead of depending on the runner's
- [x] `go test -run TestK3sCerberus ./test/regression/` — manifest pin passes and is non-vacuous (asserted the parsed values by hand: `service.namespace=cerberus-e2e,deployment.environment=e2e` vs the sample apps' `cerberus-e2e`)
- [x] `just update-golden` — the new fixture's generated sections were filled by a live chDB roundtrip; the `expected_rows` I predicted came back byte-identical, which is the proof the negation partitions the span set
- [x] `just update-cardinality-baseline` re-run after rebasing onto the current `origin/main` — diff is the single new fixture row, nothing else moved
- [x] New / updated TXTAR fixture reviewed: `test/spec/traceql/unary_not_compound_and_operand.txtar`
- [ ] CI green
- `compose-smoke` runs on this PR rather than short-circuiting (the diff touches `test/e2e/grafana/compose` and `docker-compose.yml`, both harness paths), so the #1817 fix is verified here. `dashboard` is a release gate with no such narrowing, so the #1818 fix is verified by the two Go layers on the PR and by the lane itself on the merge commit — which is why the manifest pin exists at all.

## Notes for reviewers

- Flipping the panel to `expect: empty` is a **bidirectional pin, not an exclusion**. The gate fails just as loudly if series ever appear there, and the panel sits in the `Schema-boundary constructs — defined empty / nonempty contract` row alongside five other panels that pin a defined-empty result. No allow-list, tolerance file or weakened assertion is involved, and the drill-depth floor of 2 is untouched.
- The compose stack gets `OTEL_RESOURCE_ATTRIBUTES` alongside k3d purely for stack parity. It is safe to review as a real change rather than a copy: `compose-smoke` exercises it on this PR.
- While diagnosing #1818 I first suspected the tag-discovery endpoint and found that `respondTags` ignores upstream Tempo's `q=` TraceQL scoping parameter. The failing run's network trace disproved it as the cause (the app issues one `/api/v2/search/tags?limit=5000` call with no `q`), but the parity gap is real and verified at `internal/api/tempo/search_tags.go:138`. Filed as #1820.

Closes #1817
Closes #1818