### PR TITLE
test(chopt): cover EnabledSet.Equal and Mode.String

### DIFF
--- a/internal/chopt/resolve_test.go
+++ b/internal/chopt/resolve_test.go
@@ -822,3 +822,79 @@ func anyContains(warns []string, sub string) bool {
 	}
 	return false
 }
+
+// The periodic re-resolution swaps the live set only when Equal reports a
+// genuine transition, so both of Equal's arms decide whether a running server
+// churns its optimizer state and its logs. Each arm is pinned on its own: a
+// size difference, and a same-size set whose ids differ.
+func TestEnabledSetEqual(t *testing.T) {
+	resolve := func(selection string, server Version) EnabledSet {
+		t.Helper()
+		set, _, err := Resolve(Config{Optimizations: selection, Capability: CapabilityAvailable}, server)
+		if err != nil {
+			t.Fatalf("Resolve(%q, %v): %v", selection, server, err)
+		}
+		return set
+	}
+
+	cases := []struct {
+		name string
+		a, b EnabledSet
+		want bool
+	}{
+		{
+			name: "same selection on the same server re-probes to the same set",
+			a:    resolve("aggregation_in_order,condition_cache", v(25, 8)),
+			b:    resolve("aggregation_in_order,condition_cache", v(25, 8)),
+			want: true,
+		},
+		{
+			name: "both empty",
+			a:    resolve("off", v(25, 9)),
+			b:    resolve("off", v(25, 8)),
+			want: true,
+		},
+		{
+			name: "different sizes",
+			a:    resolve("aggregation_in_order,condition_cache", v(25, 8)),
+			b:    resolve("aggregation_in_order", v(25, 8)),
+			want: false,
+		},
+		{
+			// Same cardinality, disjoint ids: the length check passes and only
+			// the membership loop can tell these apart.
+			name: "same size, different ids",
+			a:    resolve("aggregation_in_order", v(25, 8)),
+			b:    resolve("condition_cache", v(25, 8)),
+			want: false,
+		},
+		{
+			name: "empty versus non-empty",
+			a:    resolve("off", v(25, 8)),
+			b:    resolve("aggregation_in_order", v(25, 8)),
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.a.Equal(tc.b); got != tc.want {
+				t.Errorf("a.Equal(b) = %v; want %v (a=%v b=%v)", got, tc.want, tc.a.IDs(), tc.b.IDs())
+			}
+			// Equality is symmetric, and the loop only ever walks the receiver:
+			// checking one direction alone would miss a subset-shaped bug.
+			if got := tc.b.Equal(tc.a); got != tc.want {
+				t.Errorf("b.Equal(a) = %v; want %v (a=%v b=%v)", got, tc.want, tc.a.IDs(), tc.b.IDs())
+			}
+		})
+	}
+}
+
+func TestModeString(t *testing.T) {
+	if got := Enforcing.String(); got != "enforcing" {
+		t.Errorf("Enforcing.String() = %q; want %q", got, "enforcing")
+	}
+	if got := Permissive.String(); got != "permissive" {
+		t.Errorf("Permissive.String() = %q; want %q", got, "permissive")
+	}
+}


### PR DESCRIPTION
## What

Tests for `EnabledSet.Equal` and `Mode.String` in `internal/chopt`, restoring the package above its committed coverage floor.

## Why

`main` has failed the required `coverage` lane on every push since `60c9e57a` (#1823): `internal/chopt` sits at **91.78%** against a floor of **94.7%**. No test fails — the floor breach is the failure, and it has been red across five consecutive commits.

#1823 added `EnabledSet.Equal` so a periodic re-resolution swaps the live optimizer set, and logs the transition, only when the newly probed set genuinely differs from the one in force. Nothing exercised it, which left both of its arms — and therefore that churn-suppression behaviour — untested. `Mode.String` was uncovered alongside it.

## How

Equal's two arms are pinned separately, because either one alone looks correct on the cases the other decides:

- a **cardinality difference**, which the length check settles;
- a **same-cardinality set with disjoint ids**, where the length check passes and only the membership loop can tell the two apart.

Both directions of every case are asserted. The loop walks the receiver only, so a subset-shaped bug reads as equal from exactly one side.

Sets are built through `Resolve` rather than by reaching into the unexported id map, so the comparison runs over sets shaped the way the re-probe that calls `Equal` actually produces them.

`internal/chopt`: 91.8% → 97.9%. The floor is left at 94.7% — this restores the ratchet rather than moving it.
