### PR TITLE
fix(tempo): accept the full upstream tag-scope vocabulary

### DIFF
--- a/.github/scripts/compat-ratchet.mjs
+++ b/.github/scripts/compat-ratchet.mjs
@@ -21,7 +21,7 @@
 // accident of the current numbers — a diff against a reference backend
 // is a bug to fix at the source, so there is no shape in this file that
 // can record a divergence as acceptable. The floors are prometheus
-// 765/765, loki 130/130, tempo 68/68, tempo-grpc 65/65; doc-counts.mjs
+// 765/765, loki 130/130, tempo 72/72, tempo-grpc 69/69; doc-counts.mjs
 // asserts those numbers against compatibility/parity-baseline.json, so
 // a corpus change cannot leave this comment behind. tempo-grpc's floor
 // is 3 below tempo's: traces / traces_v2 have no StreamingQuerier RPC

--- a/compatibility/parity-baseline.json
+++ b/compatibility/parity-baseline.json
@@ -910,8 +910,8 @@
       ]
     },
     "tempo": {
-      "passed": 68,
-      "total": 68,
+      "passed": 72,
+      "total": 72,
       "cases": [
         "metrics_instant | metrics_avg_over_time_instant",
         "metrics_instant | metrics_count_over_time_instant",
@@ -975,17 +975,21 @@
         "tag_values_v2 | tag_values_v2_service_name",
         "tag_values_v2 | tag_values_v2_unknown_tag_empty",
         "tags_v1 | tags_v1_all",
+        "tags_v2 | tags_v2_event",
+        "tags_v2 | tags_v2_instrumentation",
         "tags_v2 | tags_v2_intrinsic",
+        "tags_v2 | tags_v2_link",
         "tags_v2 | tags_v2_resource",
         "tags_v2 | tags_v2_scope_all_rejected",
         "tags_v2 | tags_v2_span",
+        "tags_v2 | tags_v2_trace",
         "traces | trace_by_id_first_checkout",
         "traces_v2 | trace_by_id_v2_first_checkout"
       ]
     },
     "tempo-grpc": {
-      "passed": 65,
-      "total": 65,
+      "passed": 69,
+      "total": 69,
       "cases": [
         "metrics_instant | metrics_avg_over_time_instant",
         "metrics_instant | metrics_count_over_time_instant",
@@ -1049,9 +1053,13 @@
         "tag_values_v2 | tag_values_v2_service_name",
         "tag_values_v2 | tag_values_v2_unknown_tag_empty",
         "tags_v1 | tags_v1_all",
+        "tags_v2 | tags_v2_event",
+        "tags_v2 | tags_v2_instrumentation",
         "tags_v2 | tags_v2_intrinsic",
+        "tags_v2 | tags_v2_link",
         "tags_v2 | tags_v2_resource",
-        "tags_v2 | tags_v2_span"
+        "tags_v2 | tags_v2_span",
+        "tags_v2 | tags_v2_trace"
       ]
     }
   }

--- a/compatibility/tempo/driver/corpus.go
+++ b/compatibility/tempo/driver/corpus.go
@@ -15,10 +15,16 @@
 //	                            `traces` / `traces_v2`)
 //	-- tag_name --              attribute key whose values to enumerate
 //	                            (tag_values_v1 / tag_values_v2 only)
-//	-- scope --                 optional `?scope=` filter for tags_v2 (one of
-//	                            resource | span | intrinsic | none); empty
-//	                            omits the parameter so both backends return
-//	                            the unfiltered scope set
+//	-- scope --                 optional `?scope=` filter for tags_v2. The
+//	                            accepted set is upstream Tempo's:
+//	                            none | trace | span | resource | event | link |
+//	                            instrumentation (traceql.AttributeScopeFromString)
+//	                            plus intrinsic (api.ParseSearchTagsRequest's
+//	                            carve-out). Empty omits the parameter, so both
+//	                            backends return the unfiltered scope set.
+//	                            Anything outside that set — `all` included — is a
+//	                            400 on both backends and belongs in an
+//	                            `-- expect_status --` case.
 //	-- step --                  step duration (e.g. "60s") — only for metrics_range
 //	-- spss --                  integer; sent as the `spss` (spans-per-spanset)
 //	                            URL param on search cases AND switches on the
@@ -140,8 +146,10 @@ type CorpusCase struct {
 	TagName string
 
 	// Scope is the optional `?scope=` query parameter for tags_v2. One of
-	// "resource" / "span" / "intrinsic" / "none". Empty leaves the
-	// parameter off the URL (Tempo defaults to returning every scope).
+	// upstream Tempo's scope keywords — "none" / "trace" / "span" /
+	// "resource" / "event" / "link" / "instrumentation" / "intrinsic".
+	// Empty leaves the parameter off the URL (Tempo defaults to returning
+	// every scope).
 	Scope string
 
 	// Step is only consulted when Endpoint == "metrics_range". The string

--- a/compatibility/tempo/driver/corpus/smoke.txtar
+++ b/compatibility/tempo/driver/corpus/smoke.txtar
@@ -675,11 +675,10 @@ tags_v2_resource
 tags_v2
 -- scope --
 resource
-# Cerberus today ignores ?scope= and always returns the full scope set,
-# so the differ will surface a scope-axis diff between cerberus and
-# Tempo here. The subset assertion still passes on both sides because
-# `service.name` lives in the resource scope on Tempo and cerberus
-# both surfaces it (from ResourceAttributes / static map).
+# `service.name` lives in the resource scope on both backends —
+# reference Tempo reads it off the resource-level parquet columns,
+# cerberus off ResourceAttributes — so both the scope axis and the
+# subset assertion pin to the same answer.
 -- expected_min_values --
 1
 -- expected_max_values --
@@ -735,12 +734,61 @@ all
 # parseTagScope rejects it the same way on purpose (see the comment on
 # parseTagScope — cerberus intentionally does NOT accept "all" so it
 # doesn't train clients into a shape real Tempo 400s). Both backends
-# reject with "invalid scope: all", so this proves the axis end-to-end
-# without touching the OPEN scope-widening bug (#1593, which is about
-# scope values upstream *accepts* and cerberus currently rejects —
-# the opposite direction from this case).
+# reject with "invalid scope: all", so this proves the axis end-to-end.
+# The four cases below pin the other direction: every scope upstream
+# *does* accept is a 200 here too.
 -- expect_status --
 400
+
+-- name --
+tags_v2_event
+-- endpoint --
+tags_v2
+-- scope --
+event
+# `event` is a first-class upstream scope (traceql.AttributeScopeEvent).
+# Cerberus enumerates it from the OTel-CH `Events`.`Attributes` Nested
+# column; reference Tempo from vparquet4's event-attribute branch. The
+# seeder writes no span events, so both sides report an empty scope list
+# — and this case pins that they agree on *empty*, not that cerberus
+# 400s where Tempo answers. No subset assertion: an
+# `-- expected_values --` here would be asserting against data the
+# fixture doesn't contain.
+
+-- name --
+tags_v2_link
+-- endpoint --
+tags_v2
+-- scope --
+link
+# Same shape as tags_v2_event one column over: cerberus reads
+# `Links`.`Attributes`, Tempo reads its link-attribute branch, and the
+# seeder writes no span links, so both report an empty scope list.
+
+-- name --
+tags_v2_trace
+-- endpoint --
+tags_v2
+-- scope --
+trace
+# `trace` parses to a real scope on both backends but no attribute
+# family lives under it: upstream's vparquet4 tag scan branches on
+# resource / instrumentation / span / event / link, and
+# AttributeScopeTrace matches none of them. Both backends therefore
+# answer 200 with an empty scope list — intrinsics are added only for
+# the "" / none / intrinsic requests.
+
+-- name --
+tags_v2_instrumentation
+-- endpoint --
+tags_v2
+-- scope --
+instrumentation
+# The seeder rides every span under an InstrumentationScope carrying a
+# name + version but no scope-level attributes, and the upstream OTel-CH
+# traces DDL declares no ScopeAttributes column at all — so both
+# backends report an empty scope list here. The scope keyword is still
+# accepted rather than rejected, which is what this case pins.
 
 -- name --
 tag_values_v1_service_name

--- a/compatibility/tempo/driver/differ.go
+++ b/compatibility/tempo/driver/differ.go
@@ -822,8 +822,8 @@ func CompareTagNames(aBody, bBody []byte, aLabel, bLabel string, v2 bool) (Diff,
 
 	if v2 {
 		// Scope-set differences ride on top of the tag-name diff because
-		// they describe a different axis (cerberus today returns the same
-		// scope set regardless of ?scope=, real Tempo filters). Reporting
+		// they describe a different axis: two backends can agree on every
+		// tag name yet partition them into different buckets. Reporting
 		// the scope axis explicitly keeps the markdown report actionable.
 		addScopeDiff(&out, aScopes, bScopes, aLabel, bLabel)
 	}

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -383,8 +383,8 @@ The rosters today (`heads.<name>.{passed,total,cases}`):
 | ---------- | ------------ |
 | prometheus | 765 / 765    |
 | loki       | 130 / 130    |
-| tempo      | 68 / 68      |
-| tempo-grpc | 65 / 65      |
+| tempo      | 72 / 72      |
+| tempo-grpc | 69 / 69      |
 
 The baseline records **full parity** for every head — the ratchet asserts
 `passed == total == cases.length`, so the file has no shape in which a

--- a/docs/migration-reference.md
+++ b/docs/migration-reference.md
@@ -181,8 +181,7 @@ probes are corpus-**anchored**, not harvested: an unfiltered tag-name enumeratio
 runs once per head your corpus touches, and a tag-value probe runs once per
 distinct label or attribute key that head's own queries reference. Agreement is
 exact **set equality**, scoped where the wire contract scopes it — Tempo's v2
-tag-names surface is diffed per scope (resource, span, intrinsic), not as one
-flat set. The only exception is a reference response the reference itself
+tag-names surface is diffed per scope bucket, not as one flat set. The only exception is a reference response the reference itself
 reports as partial, which is declined by name with both job counts rather than
 diffed against cerberus's complete answer.
 

--- a/docs/migration-testing.md
+++ b/docs/migration-testing.md
@@ -461,8 +461,8 @@ seven comparison modes, and no scenario mixes them silently:
 
 7. **Tag/label set equality — discovery, asymmetric on cardinality.** Tag-name
    and tag-value enumeration is set equality, scoped where the wire contract
-   scopes it (Tempo's v2 tag-names surface is diffed per scope — resource,
-   span, intrinsic — rather than as one flat set), but the two directions of
+   scopes it (Tempo's v2 tag-names surface is diffed per scope bucket rather
+   than as one flat set), but the two directions of
    "present on one side only" are not judged the same way. A tag or value the
    reference has but cerberus does not is always a real divergence: cerberus's
    own enumeration is one unbounded ClickHouse `DISTINCT`, complete-or-errored

--- a/internal/api/tempo/conformance_test.go
+++ b/internal/api/tempo/conformance_test.go
@@ -378,7 +378,7 @@ func TestConformance_TempoSearchTagsWire(t *testing.T) {
 		if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
 			t.Fatalf("decode: %v", err)
 		}
-		// V2: three scopes — resource, span, intrinsic.
+		// V2: one bucket per scope that reported a key, plus intrinsic.
 		seen := map[string]bool{}
 		for _, s := range r.Scopes {
 			seen[s.Name] = true

--- a/internal/api/tempo/grpc/tags.go
+++ b/internal/api/tempo/grpc/tags.go
@@ -44,10 +44,10 @@ import (
 
 // SearchTags implements StreamingQuerier_SearchTagsServer. Mirrors
 // the HTTP /api/search/tags endpoint: returns the union of every
-// dynamic span- + resource-attribute key seen in the time window,
-// sorted ascending. Intrinsics are excluded by default (parity with
-// upstream Tempo); only the explicit `scope=intrinsic` request emits
-// the static intrinsic inventory.
+// dynamic attribute key seen in the time window across each scope the
+// request selects, sorted ascending. Intrinsics are excluded by
+// default (parity with upstream Tempo); only the explicit
+// `scope=intrinsic` request emits the static intrinsic inventory.
 func (s *Service) SearchTags(req *tempopb.SearchTagsRequest, stream tempopb.StreamingQuerier_SearchTagsServer) error {
 	if s.Handler == nil {
 		return status.Error(codes.Internal, "tempo gRPC service not wired to handler")
@@ -58,14 +58,15 @@ func (s *Service) SearchTags(req *tempopb.SearchTagsRequest, stream tempopb.Stre
 		return status.Error(codes.InvalidArgument, err.Error())
 	}
 	start, end := tempoTagsBounds(req.GetStart(), req.GetEnd())
-	resource, span, err := s.collectTagKeys(ctx, scope, start, end)
+	buckets, err := s.Handler.CollectAttributeTagScopes(ctx, scope, start, end)
 	if err != nil {
 		return status.Error(codes.Internal, err.Error())
 	}
-	all := make([]string, 0, len(resource)+len(span)+len(tempo.IntrinsicTags()))
-	all = append(all, resource...)
-	all = append(all, span...)
-	// Default + scope=resource/span carve out intrinsics; only an
+	var all []string
+	for _, b := range buckets {
+		all = append(all, b.Tags...)
+	}
+	// Default + scoped attribute requests carve out intrinsics; only an
 	// explicit scope=intrinsic surfaces them on the V1 envelope
 	// (matches the HTTP handler's respondTags policy).
 	if scope == tempo.TagScopeIntrinsic {
@@ -75,10 +76,14 @@ func (s *Service) SearchTags(req *tempopb.SearchTagsRequest, stream tempopb.Stre
 }
 
 // SearchTagsV2 implements StreamingQuerier_SearchTagsV2Server. Same
-// data as SearchTags, partitioned into resource / span / intrinsic
-// scope buckets so Grafana's autocomplete can surface each prefix
-// separately. The intrinsic bucket is always emitted on a `none`
-// request (the default); scoped requests filter to one bucket.
+// data as SearchTags, partitioned into one bucket per attribute scope
+// (resource / instrumentation / span / event / link) plus intrinsic,
+// so Grafana's autocomplete can surface each prefix separately. A
+// scope that carries no key in the window contributes no bucket —
+// upstream's tags-V2 combiner builds its scope list from the keys
+// storage actually reported, so an empty bucket never appears. The
+// intrinsic bucket is emitted on a `none` request (the default) and
+// on an explicit `scope=intrinsic`.
 func (s *Service) SearchTagsV2(req *tempopb.SearchTagsRequest, stream tempopb.StreamingQuerier_SearchTagsV2Server) error {
 	if s.Handler == nil {
 		return status.Error(codes.Internal, "tempo gRPC service not wired to handler")
@@ -89,16 +94,13 @@ func (s *Service) SearchTagsV2(req *tempopb.SearchTagsRequest, stream tempopb.St
 		return status.Error(codes.InvalidArgument, err.Error())
 	}
 	start, end := tempoTagsBounds(req.GetStart(), req.GetEnd())
-	resource, span, err := s.collectTagKeys(ctx, scope, start, end)
+	buckets, err := s.Handler.CollectAttributeTagScopes(ctx, scope, start, end)
 	if err != nil {
 		return status.Error(codes.Internal, err.Error())
 	}
-	scopes := make([]*tempopb.SearchTagsV2Scope, 0, 3)
-	if scope == tempo.TagScopeNone || scope == tempo.TagScopeResource {
-		scopes = append(scopes, &tempopb.SearchTagsV2Scope{Name: tempo.TagScopeResource, Tags: tempo.SortedUnique(resource)})
-	}
-	if scope == tempo.TagScopeNone || scope == tempo.TagScopeSpan {
-		scopes = append(scopes, &tempopb.SearchTagsV2Scope{Name: tempo.TagScopeSpan, Tags: tempo.SortedUnique(span)})
+	scopes := make([]*tempopb.SearchTagsV2Scope, 0, len(buckets)+1)
+	for _, b := range buckets {
+		scopes = append(scopes, &tempopb.SearchTagsV2Scope{Name: b.Name, Tags: b.Tags})
 	}
 	if scope == tempo.TagScopeNone || scope == tempo.TagScopeIntrinsic {
 		scopes = append(scopes, &tempopb.SearchTagsV2Scope{Name: tempo.TagScopeIntrinsic, Tags: tempo.IntrinsicTags()})
@@ -152,27 +154,6 @@ func (s *Service) SearchTagValuesV2(req *tempopb.SearchTagValuesRequest, stream 
 		out = append(out, &tempopb.TagValue{Type: typ, Value: v})
 	}
 	return stream.Send(&tempopb.SearchTagValuesV2Response{TagValues: out})
-}
-
-// collectTagKeys runs the two attribute-map lookups (one per scope
-// bucket) the V1 + V2 tag-list endpoints both share. The boolean
-// branches mirror respondTags in search_tags.go so the gRPC and
-// HTTP surfaces agree on what data each scope returns: a scoped
-// request runs only one query, a `none` (default) request runs both.
-func (s *Service) collectTagKeys(ctx context.Context, scope string, start, end time.Time) (resource, span []string, err error) {
-	if scope == tempo.TagScopeNone || scope == tempo.TagScopeResource {
-		resource, err = s.Handler.FetchTagKeys(ctx, s.Handler.Schema.ResourceAttributesColumn, start, end)
-		if err != nil {
-			return nil, nil, err
-		}
-	}
-	if scope == tempo.TagScopeNone || scope == tempo.TagScopeSpan {
-		span, err = s.Handler.FetchTagKeys(ctx, s.Handler.Schema.AttributesColumn, start, end)
-		if err != nil {
-			return nil, nil, err
-		}
-	}
-	return resource, span, nil
 }
 
 // lookupTagValues encapsulates the parse-name + resolve-scope +

--- a/internal/api/tempo/grpc/tags_test.go
+++ b/internal/api/tempo/grpc/tags_test.go
@@ -169,8 +169,10 @@ func TestSearchTags_SingleFrame(t *testing.T) {
 }
 
 // TestSearchTagsV2_ScopeBuckets asserts the V2 RPC streams one frame
-// containing the three scope buckets (resource / span / intrinsic),
-// each carrying the sorted attribute keys for that scope. The
+// containing one bucket per scope that reported a key, each carrying
+// the sorted attribute keys for that scope. Only resource and span are
+// populated here, so those two plus intrinsic are the whole envelope —
+// the event / link scopes report nothing and contribute no bucket. The
 // intrinsic bucket comes from cerberus's static inventory so its
 // length pins to len(IntrinsicTags()) regardless of what the fake
 // querier returns.
@@ -253,6 +255,67 @@ func TestSearchTagsV2_ScopeFilter(t *testing.T) {
 		if strings.Contains(sql, "`SpanAttributes`") {
 			t.Errorf("scope=resource leaked a SpanAttributes lookup: %s", sql)
 		}
+	}
+}
+
+// TestSearchTagsV2_UpstreamScopeVocabulary asserts the gRPC surface
+// accepts every scope keyword upstream Tempo does, and partitions the
+// nested `event` / `link` families into their own buckets. Both
+// surfaces route through Handler.CollectAttributeTagScopes, so this
+// pins that the RPC cannot drift from the HTTP envelope on which
+// scopes exist.
+func TestSearchTagsV2_UpstreamScopeVocabulary(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		scope     string
+		wantScope string
+		wantTag   string
+	}{
+		{scope: "event", wantScope: "event", wantTag: "exception.type"},
+		{scope: "link", wantScope: "link", wantTag: "link.kind"},
+		// `trace` is a real upstream keyword with no attribute family
+		// behind it: accepted, and answered with intrinsics only.
+		{scope: "trace"},
+		{scope: "instrumentation"},
+	} {
+		t.Run("scope="+tc.scope, func(t *testing.T) {
+			t.Parallel()
+			q := &fakeQuerier{stringsBySQL: map[string][]string{
+				"`Events`.`Attributes`": {"exception.type"},
+				"`Links`.`Attributes`":  {"link.kind"},
+			}}
+			client := newTagsTestServer(t, q)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			t.Cleanup(cancel)
+			stream, err := client.SearchTagsV2(ctx, &tempopb.SearchTagsRequest{Scope: tc.scope})
+			if err != nil {
+				t.Fatalf("open SearchTagsV2 stream: %v", err)
+			}
+			frames, err := recvAll[tempopb.SearchTagsV2Response](t, stream)
+			if err != nil {
+				t.Fatalf("recvAll: %v", err)
+			}
+			if len(frames) != 1 {
+				t.Fatalf("frame count: want 1, got %d", len(frames))
+			}
+			scopes := frames[0].GetScopes()
+			if tc.wantScope == "" {
+				if len(scopes) != 0 {
+					t.Fatalf("scope=%s: want no buckets, got %v", tc.scope, scopes)
+				}
+				return
+			}
+			if len(scopes) != 1 {
+				t.Fatalf("scope=%s: want 1 bucket, got %d (%v)", tc.scope, len(scopes), scopes)
+			}
+			if scopes[0].GetName() != tc.wantScope {
+				t.Errorf("scope name: want %q, got %q", tc.wantScope, scopes[0].GetName())
+			}
+			if got := scopes[0].GetTags(); len(got) != 1 || got[0] != tc.wantTag {
+				t.Errorf("%s bucket: want [%s], got %v", tc.wantScope, tc.wantTag, got)
+			}
+		})
 	}
 }
 

--- a/internal/api/tempo/grpc_exports.go
+++ b/internal/api/tempo/grpc_exports.go
@@ -52,20 +52,20 @@ func IntrinsicTags() []string {
 }
 
 // ParseTagScope normalises the SearchTagsRequest.Scope proto field
-// against the upstream Tempo allowlist. Empty / "none" / "all" all
-// collapse to TagScopeNone (every scope). Returns an error suitable
-// for codes.InvalidArgument on any unrecognised value.
+// against the upstream Tempo vocabulary. Empty and "none" collapse to
+// TagScopeNone (every scope). Returns an error suitable for
+// codes.InvalidArgument on any unrecognised value.
 func ParseTagScope(raw string) (string, error) {
 	return parseTagScope(raw)
 }
 
-// FetchTagKeys runs the DISTINCT mapKeys lookup for the given
-// attribute map column (Handler.Schema.AttributesColumn for span
-// keys, Handler.Schema.ResourceAttributesColumn for resource keys).
-// The (sorted, de-duplicated) string slice is the same one the HTTP
-// V1 / V2 envelopes are built from.
-func (h *Handler) FetchTagKeys(ctx context.Context, mapCol string, start, end time.Time) ([]string, error) {
-	return h.fetchTagKeys(ctx, mapCol, start, end)
+// CollectAttributeTagScopes runs the key lookup for every
+// attribute-backed scope bucket the requested scope selects, and
+// returns the non-empty ones. Exported so the gRPC tag services build
+// their scope partition from the exact same buckets the HTTP V1 / V2
+// envelopes do — the two surfaces cannot drift on which scopes exist.
+func (h *Handler) CollectAttributeTagScopes(ctx context.Context, scope string, start, end time.Time) ([]TagScope, error) {
+	return h.collectAttributeTagScopes(ctx, scope, start, end)
 }
 
 // SortedUnique returns the de-duplicated, lexicographically sorted

--- a/internal/api/tempo/handler_test.go
+++ b/internal/api/tempo/handler_test.go
@@ -78,7 +78,15 @@ func (s *stubQuerier) QueryStrings(_ context.Context, sql string, args ...any) (
 }
 
 func newServer(q tempo.Querier, version string) *httptest.Server {
-	h := tempo.New(q, schema.DefaultOTelTraces(), version, nil)
+	return newServerWithSchema(q, schema.DefaultOTelTraces(), version)
+}
+
+// newServerWithSchema is newServer for the tests that need a traces
+// schema other than the OTel default — e.g. one that points
+// ScopeAttributesColumn at a real column, which the upstream traces DDL
+// does not declare.
+func newServerWithSchema(q tempo.Querier, s schema.Traces, version string) *httptest.Server {
+	h := tempo.New(q, s, version, nil)
 	mux := http.NewServeMux()
 	h.Mount(mux)
 	return httptest.NewServer(mux)

--- a/internal/api/tempo/search_tags.go
+++ b/internal/api/tempo/search_tags.go
@@ -78,12 +78,18 @@ type TagScope struct {
 }
 
 // scope query-param values accepted by /api/v2/search/tags. Mirrors
-// upstream Tempo's `pkg/api.ParseSearchTagsRequest` semantics:
+// upstream Tempo's `pkg/api.ParseSearchTagsRequest` semantics — the
+// whole `traceql.AttributeScopeFromString` set plus the `intrinsic`
+// carve-out that function does not know about:
 //
-//   - "resource"  → only the resource scope bucket
-//   - "span"      → only the span scope bucket
-//   - "intrinsic" → only the intrinsic bucket
-//   - "none" or "" → every scope (default; matches AttributeScopeNone)
+//   - "resource"        → only the resource-attribute bucket
+//   - "span"            → only the span-attribute bucket
+//   - "event"           → only the span-event attribute bucket
+//   - "link"            → only the span-link attribute bucket
+//   - "instrumentation" → only the instrumentation-scope attribute bucket
+//   - "intrinsic"       → only the intrinsic bucket
+//   - "trace"           → a scope with no attribute family behind it
+//   - "none" or ""      → every scope (default; matches AttributeScopeNone)
 //
 // Anything else is a 400. In particular "all" is *not* a scope:
 // upstream's `traceql.AttributeScopeFromString` folds it to
@@ -92,24 +98,31 @@ type TagScope struct {
 // permissive backend, which silently trains clients into a request
 // shape that breaks the moment they point at real Tempo.
 const (
-	tagScopeResource  = "resource"
-	tagScopeSpan      = "span"
-	tagScopeIntrinsic = "intrinsic"
-	tagScopeNone      = "none"
+	tagScopeResource        = "resource"
+	tagScopeSpan            = "span"
+	tagScopeEvent           = "event"
+	tagScopeLink            = "link"
+	tagScopeInstrumentation = "instrumentation"
+	tagScopeIntrinsic       = "intrinsic"
+	tagScopeTrace           = "trace"
+	tagScopeNone            = "none"
 )
 
+// nestedAttributesSubfield is the sub-column of the OTel-CH `Events` /
+// `Links` Nested columns that carries the per-event / per-link
+// attribute map, stored as `Array(Map(String, String))` — one map per
+// event / link on the span row.
+const nestedAttributesSubfield = "Attributes"
+
 // handleSearchTags implements `GET /api/search/tags`. Returns the union
-// of every dynamic attribute key (span + resource maps) plus the static
-// intrinsic-span list, sorted ascending. Honours optional `start`/`end`
-// time bounds (Unix seconds; nanoseconds also accepted via the same
-// heuristic Loki uses, see parseTempoTime).
+// of every dynamic attribute key across the scopes the request selects,
+// sorted ascending. Honours optional `start`/`end` time bounds (Unix
+// seconds; nanoseconds also accepted via the same heuristic Loki uses,
+// see parseTempoTime).
 //
-// SQL shape:
+// SQL shape — one query per scope bucket, e.g. for `span`:
 //
-//	SELECT DISTINCT arrayJoin(arrayConcat(
-//	    mapKeys(`SpanAttributes`),
-//	    mapKeys(`ResourceAttributes`)
-//	)) AS `tag`
+//	SELECT DISTINCT arrayJoin(mapKeys(`SpanAttributes`))
 //	FROM `otel_traces`
 //	WHERE `Timestamp` >= ? AND `Timestamp` <= ?
 //
@@ -120,15 +133,16 @@ func (h *Handler) handleSearchTags(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleSearchTagsV2 implements `GET /api/v2/search/tags`. Same data
-// as V1, partitioned by scope (resource / span / intrinsic). Grafana's
-// Tempo datasource queries V2 when available.
+// as V1, partitioned by scope (one bucket per attribute family the
+// schema carries, plus intrinsic). Grafana's Tempo datasource queries
+// V2 when available.
 func (h *Handler) handleSearchTagsV2(w http.ResponseWriter, r *http.Request) {
 	h.respondTags(w, r, true)
 }
 
-// respondTags is the shared core of V1 + V2: it runs two independent
-// CH lookups (one per attribute map) so the V2 response can keep the
-// resource-vs-span split, then unions them for the V1 envelope.
+// respondTags is the shared core of V1 + V2: it runs one independent CH
+// lookup per attribute-backed scope so the V2 response can keep the
+// per-scope split, then unions them for the V1 envelope.
 //
 // The optional `?scope=` query parameter filters which buckets are
 // fetched and returned. Honouring it on V2 was missing before — the
@@ -152,42 +166,27 @@ func (h *Handler) respondTags(w http.ResponseWriter, r *http.Request, v2 bool) {
 		return
 	}
 
-	var resourceTags, spanTags []string
-	if scope == tagScopeNone || scope == tagScopeResource {
-		resourceTags, err = h.fetchTagKeys(r.Context(), h.Schema.ResourceAttributesColumn, start, end)
-		if err != nil {
-			h.Logger.Error("cerberus tempo /search/tags resource CH query failed", "err", err)
-			writeError(w, tagsErrStatus(err), "", "", err)
-			return
-		}
+	scopes, err := h.collectAttributeTagScopes(r.Context(), scope, start, end)
+	if err != nil {
+		writeError(w, tagsErrStatus(err), "", "", err)
+		return
 	}
-	if scope == tagScopeNone || scope == tagScopeSpan {
-		spanTags, err = h.fetchTagKeys(r.Context(), h.Schema.AttributesColumn, start, end)
-		if err != nil {
-			h.Logger.Error("cerberus tempo /search/tags span CH query failed", "err", err)
-			writeError(w, tagsErrStatus(err), "", "", err)
-			return
-		}
+	var all []string
+	for _, s := range scopes {
+		all = append(all, s.Tags...)
 	}
 
 	if v2 {
-		scopes := make([]TagScope, 0, 3)
-		if scope == tagScopeNone || scope == tagScopeResource {
-			scopes = append(scopes, TagScope{Name: tagScopeResource, Tags: sortedUnique(resourceTags)})
-		}
-		if scope == tagScopeNone || scope == tagScopeSpan {
-			scopes = append(scopes, TagScope{Name: tagScopeSpan, Tags: sortedUnique(spanTags)})
-		}
 		if scope == tagScopeNone || scope == tagScopeIntrinsic {
 			scopes = append(scopes, TagScope{Name: tagScopeIntrinsic, Tags: append([]string(nil), intrinsicTags...)})
+		}
+		if scopes == nil {
+			scopes = []TagScope{}
 		}
 		writeJSON(w, http.StatusOK, SearchTagsResponseV2{Scopes: scopes})
 		return
 	}
 
-	all := make([]string, 0, len(resourceTags)+len(spanTags)+len(intrinsicTags))
-	all = append(all, resourceTags...)
-	all = append(all, spanTags...)
 	// V1 mirrors upstream Tempo: intrinsics only surface when the caller
 	// asks for `scope=intrinsic` explicitly. The default (and `scope=none`)
 	// returns dynamic attributes only — leaking intrinsics here puts the
@@ -196,6 +195,74 @@ func (h *Handler) respondTags(w http.ResponseWriter, r *http.Request, v2 bool) {
 		all = append(all, intrinsicTags...)
 	}
 	writeJSON(w, http.StatusOK, SearchTagsResponse{TagNames: sortedUnique(all)})
+}
+
+// collectAttributeTagScopes runs the key lookup for every
+// attribute-backed scope the requested `scope` selects, and returns
+// the buckets that carry at least one key, sorted and de-duplicated.
+//
+// A scope with no keys in the window contributes no bucket: upstream's
+// tags-V2 combiner materialises a bucket only from keys the storage
+// layer actually reported, so emitting an empty one would put cerberus
+// a scope ahead of reference Tempo.
+func (h *Handler) collectAttributeTagScopes(ctx context.Context, scope string, start, end time.Time) ([]TagScope, error) {
+	var scopes []TagScope
+	for _, src := range attributeTagScopes(h.Schema) {
+		if scope != tagScopeNone && scope != src.name {
+			continue
+		}
+		tags, err := h.fetchTagKeys(ctx, src.name, src.keys, start, end)
+		if err != nil {
+			h.Logger.Error("cerberus tempo tag-key lookup failed", "scope", src.name, "err", err)
+			return nil, err
+		}
+		if tags = sortedUnique(tags); len(tags) == 0 {
+			continue
+		}
+		scopes = append(scopes, TagScope{Name: src.name, Tags: tags})
+	}
+	return scopes, nil
+}
+
+// attributeTagScope binds one scope bucket to the CH projection that
+// enumerates its attribute keys.
+type attributeTagScope struct {
+	name string
+	keys chsql.Frag
+}
+
+// attributeTagScopes returns the scope buckets whose keys come from a
+// column on the spans table, in the order upstream Tempo's storage
+// layer scans them (`vparquet4/block_search_tags.go`).
+//
+// A scope the configured schema carries no column for is absent from
+// the slice rather than present-and-empty: `trace` has no attribute
+// family at all in either backend, and the upstream OTel-CH traces DDL
+// declares no instrumentation-scope attribute map (a custom schema may
+// point ScopeAttributesColumn at one, which puts the bucket back).
+// Requesting such a scope is still a 200 — upstream accepts the value
+// and answers with whatever its storage reports, which is nothing.
+func attributeTagScopes(s schema.Traces) []attributeTagScope {
+	out := make([]attributeTagScope, 0, 5)
+	add := func(name string, keys chsql.Frag) {
+		out = append(out, attributeTagScope{name: name, keys: keys})
+	}
+	if s.ResourceAttributesColumn != "" {
+		add(tagScopeResource, distinctMapKeysFrag(s.ResourceAttributesColumn))
+	}
+	if s.ScopeAttributesColumn != "" {
+		add(tagScopeInstrumentation, distinctMapKeysFrag(s.ScopeAttributesColumn))
+	}
+	if s.AttributesColumn != "" {
+		add(tagScopeSpan, distinctMapKeysFrag(s.AttributesColumn))
+	}
+	if s.EventsColumn != "" {
+		add(tagScopeEvent, distinctNestedMapKeysFrag(s.EventsColumn))
+	}
+	if s.LinksColumn != "" {
+		add(tagScopeLink, distinctNestedMapKeysFrag(s.LinksColumn))
+	}
+	return out
 }
 
 // parseTagScope normalises the `?scope=` query parameter against the
@@ -208,7 +275,8 @@ func parseTagScope(raw string) (string, error) {
 	switch raw {
 	case "", tagScopeNone:
 		return tagScopeNone, nil
-	case tagScopeResource, tagScopeSpan, tagScopeIntrinsic:
+	case tagScopeResource, tagScopeSpan, tagScopeEvent, tagScopeLink,
+		tagScopeInstrumentation, tagScopeIntrinsic, tagScopeTrace:
 		return raw, nil
 	default:
 		return "", &tagScopeError{raw: raw}
@@ -221,22 +289,22 @@ type tagScopeError struct{ raw string }
 
 func (e *tagScopeError) Error() string { return "invalid scope: " + e.raw }
 
-// fetchTagKeys runs the mapKeys-distinct lookup for a single attribute
-// map column. Splitting into two queries (rather than one with
-// arrayConcat) keeps the V2 scope partition cheap — V1 unions the two
-// slices in Go.
-func (h *Handler) fetchTagKeys(ctx context.Context, mapCol string, start, end time.Time) ([]string, error) {
-	sqlStr, args := buildSearchTagsSQL(h.Schema, mapCol, start, end)
-	h.Logger.Debug("cerberus tempo /search/tags", "col", mapCol, "sql", sqlStr, "args", args)
+// fetchTagKeys runs the distinct-key lookup for a single scope bucket.
+// Keeping one query per scope (rather than one with arrayConcat) is
+// what lets the V2 partition skip the buckets the caller didn't ask
+// for — V1 unions the surviving slices in Go.
+func (h *Handler) fetchTagKeys(ctx context.Context, scope string, keys chsql.Frag, start, end time.Time) ([]string, error) {
+	sqlStr, args := buildSearchTagsSQL(h.Schema, keys, start, end)
+	h.Logger.Debug("cerberus tempo /search/tags", "scope", scope, "sql", sqlStr, "args", args)
 	return h.Client.QueryStrings(ctx, sqlStr, args...)
 }
 
-// buildSearchTagsSQL builds the SELECT for one attribute map column.
-// Exposed for tests so the SQL shape is pinned without spinning up the
-// HTTP layer.
-func buildSearchTagsSQL(s schema.Traces, mapCol string, start, end time.Time) (string, []any) {
+// buildSearchTagsSQL builds the SELECT for one scope bucket's
+// key-enumerating projection. Exposed for tests so the SQL shape is
+// pinned without spinning up the HTTP layer.
+func buildSearchTagsSQL(s schema.Traces, keys chsql.Frag, start, end time.Time) (string, []any) {
 	sb := chsql.NewQuery().
-		Select(distinctMapKeysFrag(mapCol)).
+		Select(keys).
 		From(chsql.Col(s.SpansTable))
 	if !start.IsZero() {
 		sb.Where(tempoTimeGteFrag(s.TimestampColumn, start))
@@ -258,6 +326,34 @@ func distinctMapKeysFrag(col string) chsql.Frag {
 		chsql.Call(
 			"arrayJoin",
 			chsql.Call("mapKeys", chsql.Col(col)),
+		),
+	)
+}
+
+// distinctNestedMapKeysFrag is the same idea one nesting level up:
+// `Events.Attributes` / `Links.Attributes` are Array(Map(...)) — one
+// map per event / link on the span row — so the keys of every element
+// are collected with arrayMap+mapKeys, flattened into a single key
+// array, and then unrolled by arrayJoin.
+//
+// Emits "DISTINCT arrayJoin(arrayFlatten(arrayMap(m -> mapKeys(m),
+// `<col>`.`Attributes`)))". `nestedMapParam` is the lambda's bound
+// element. The sub-column is addressed with the same qualified-identifier
+// spelling every other Nested reference in the emitter uses (see
+// Builder.exprNestedArrayExists).
+func distinctNestedMapKeysFrag(col string) chsql.Frag {
+	const nestedMapParam = "m"
+	return chsql.Distinct(
+		chsql.Call(
+			"arrayJoin",
+			chsql.Call(
+				"arrayFlatten",
+				chsql.Call(
+					"arrayMap",
+					chsql.Lambda1(nestedMapParam, chsql.Call("mapKeys", chsql.BareIdent(nestedMapParam))),
+					chsql.Qual(col, nestedAttributesSubfield),
+				),
+			),
 		),
 	)
 }

--- a/internal/api/tempo/search_tags_test.go
+++ b/internal/api/tempo/search_tags_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/tsouza/cerberus/internal/api/tempo"
+	"github.com/tsouza/cerberus/internal/schema"
 )
 
 // TestSearchTags_UnionsDynamicAttributes — the V1 endpoint returns the
@@ -79,7 +80,7 @@ func TestSearchTags_SQLShape(t *testing.T) {
 	srv := newServer(q, "v1.0.0-test")
 	t.Cleanup(srv.Close)
 
-	resp, err := http.Get(srv.URL + "/api/search/tags")
+	resp, err := http.Get(srv.URL + "/api/search/tags?scope=span")
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
@@ -87,12 +88,50 @@ func TestSearchTags_SQLShape(t *testing.T) {
 	for _, want := range []string{
 		"SELECT DISTINCT",
 		"arrayJoin(",
-		"mapKeys(",
+		"mapKeys(`SpanAttributes`)",
 		"FROM `otel_traces`",
 	} {
 		if !strings.Contains(q.lastSQL, want) {
 			t.Errorf("SQL missing %q\n  got: %s", want, q.lastSQL)
 		}
+	}
+}
+
+// TestSearchTags_NestedScopeSQLShape — the `event` / `link` scopes read
+// their keys out of the OTel-CH Nested columns, whose Attributes
+// sub-column is Array(Map(String, String)) rather than a bare Map. One
+// extra arrayMap+arrayFlatten level collects the keys of every event /
+// link on the span row before arrayJoin unrolls them.
+//
+// The sub-column must be addressed as two backtick-quoted identifiers
+// joined by a dot (`Events`.`Attributes`) — the same spelling every
+// other Nested reference in the emitter uses. A single quoted
+// `Events.Attributes` is a different identifier to ClickHouse.
+func TestSearchTags_NestedScopeSQLShape(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		scope string
+		col   string
+	}{
+		{scope: "event", col: "`Events`.`Attributes`"},
+		{scope: "link", col: "`Links`.`Attributes`"},
+	} {
+		t.Run(tc.scope, func(t *testing.T) {
+			t.Parallel()
+			q := &stubQuerier{strings: []string{"a"}}
+			srv := newServer(q, "v1.0.0-test")
+			t.Cleanup(srv.Close)
+
+			resp, err := http.Get(srv.URL + "/api/search/tags?scope=" + tc.scope)
+			if err != nil {
+				t.Fatalf("GET: %v", err)
+			}
+			resp.Body.Close()
+			want := "SELECT DISTINCT arrayJoin(arrayFlatten(arrayMap(m -> mapKeys(m), " + tc.col + ")))"
+			if !strings.Contains(q.lastSQL, want) {
+				t.Errorf("SQL missing %q\n  got: %s", want, q.lastSQL)
+			}
+		})
 	}
 }
 
@@ -219,9 +258,8 @@ func TestSearchTags_EmptyArray(t *testing.T) {
 }
 
 // TestSearchTagsV2_ScopePartition — the V2 endpoint groups tags by
-// scope (resource / span / intrinsic). The two map lookups feed
-// distinct scope buckets, and the static intrinsic list lives in its
-// own.
+// scope. Each attribute-map lookup feeds its own scope bucket, and the
+// static intrinsic list lives in one of its own.
 func TestSearchTagsV2_ScopePartition(t *testing.T) {
 	t.Parallel()
 	q := &stubQuerier{stringsBySQL: map[string][]string{
@@ -261,7 +299,7 @@ func TestSearchTagsV2_ScopePartition(t *testing.T) {
 // TestSearchTagsV2_ScopeFilter — the `?scope=` query parameter on
 // /api/v2/search/tags must restrict the response to the requested
 // bucket. Mirrors upstream Tempo's pkg/api.ParseSearchTagsRequest
-// semantics (resource / span / intrinsic / none-or-empty).
+// semantics across the full upstream scope vocabulary.
 // Before this fix the handler silently emitted every scope, so
 // Grafana's per-scope autocomplete iterated over irrelevant keys.
 func TestSearchTagsV2_ScopeFilter(t *testing.T) {
@@ -277,16 +315,20 @@ func TestSearchTagsV2_ScopeFilter(t *testing.T) {
 	}{
 		{name: "resource_only", query: "?scope=resource", wantScopes: []string{"resource"}, wantTag: "service.name"},
 		{name: "span_only", query: "?scope=span", wantScopes: []string{"span"}, wantTag: "http.method"},
+		{name: "event_only", query: "?scope=event", wantScopes: []string{"event"}, wantTag: "exception.type"},
+		{name: "link_only", query: "?scope=link", wantScopes: []string{"link"}, wantTag: "link.kind"},
 		{name: "intrinsic_only", query: "?scope=intrinsic", wantScopes: []string{"intrinsic"}, wantTag: "name"},
-		{name: "none_default", query: "", wantScopes: []string{"resource", "span", "intrinsic"}},
-		{name: "none_explicit", query: "?scope=none", wantScopes: []string{"resource", "span", "intrinsic"}},
+		{name: "none_default", query: "", wantScopes: []string{"resource", "span", "event", "link", "intrinsic"}},
+		{name: "none_explicit", query: "?scope=none", wantScopes: []string{"resource", "span", "event", "link", "intrinsic"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			q := &stubQuerier{stringsBySQL: map[string][]string{
-				"`ResourceAttributes`": {"service.name"},
-				"`SpanAttributes`":     {"http.method"},
+				"`ResourceAttributes`":  {"service.name"},
+				"`SpanAttributes`":      {"http.method"},
+				"`Events`.`Attributes`": {"exception.type"},
+				"`Links`.`Attributes`":  {"link.kind"},
 			}}
 			srv := newServer(q, "v1.0.0-test")
 			t.Cleanup(srv.Close)
@@ -407,6 +449,157 @@ func TestSearchTags_ScopeAllRejected(t *testing.T) {
 				t.Errorf("message = %q, want it to contain %q", er.Message, want)
 			}
 		})
+	}
+}
+
+// TestSearchTags_UpstreamScopeVocabulary — every value upstream Tempo
+// accepts on `?scope=` must be a 200 here too. Upstream's vocabulary is
+// the union of two sources:
+//
+//   - `traceql.AttributeScopeFromString` (pkg/traceql/
+//     enum_attributes.go): "", "none", "trace", "span", "resource",
+//     "event", "link", "instrumentation".
+//   - the `intrinsic` carve-out in `pkg/api.ParseSearchTagsRequest`.
+//
+// Cerberus used to accept only resource / span / intrinsic / none, so a
+// Grafana autocomplete that asked for `scope=event` got a 400 from
+// cerberus and a tag list from real Tempo. The differential harness
+// could not catch it — it only sends queries both backends accept.
+func TestSearchTags_UpstreamScopeVocabulary(t *testing.T) {
+	t.Parallel()
+	upstreamScopes := []string{
+		"", "none", "trace", "span", "resource", "event", "link",
+		"instrumentation", "intrinsic",
+	}
+	for _, path := range []string{"/api/search/tags", "/api/v2/search/tags"} {
+		for _, scope := range upstreamScopes {
+			t.Run(path+"/scope="+scope, func(t *testing.T) {
+				t.Parallel()
+				q := &stubQuerier{strings: []string{"a"}}
+				srv := newServer(q, "v1.0.0-test")
+				t.Cleanup(srv.Close)
+
+				resp, err := http.Get(srv.URL + path + "?scope=" + scope)
+				if err != nil {
+					t.Fatalf("GET: %v", err)
+				}
+				defer resp.Body.Close()
+				if resp.StatusCode != http.StatusOK {
+					t.Fatalf("scope=%q: status=%d want 200 body=%s", scope, resp.StatusCode, readBody(t, resp))
+				}
+			})
+		}
+	}
+}
+
+// TestSearchTagsV2_TraceScopeEmptyEnvelope — `scope=trace` is a real
+// upstream scope keyword but no attribute family lives under it in
+// either backend: upstream's vparquet4 tag scan (block_search_tags.go)
+// branches on resource / instrumentation / span / event / link and
+// AttributeScopeTrace matches none of them, so storage reports nothing
+// and the combiner materialises no bucket. Cerberus answers the same
+// way — a 200 with an empty (never null) scope list, and no CH query.
+func TestSearchTagsV2_TraceScopeEmptyEnvelope(t *testing.T) {
+	t.Parallel()
+	q := &stubQuerier{strings: []string{"should.not.appear"}}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v2/search/tags?scope=trace")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d want 200 body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	if q.lastSQL != "" {
+		t.Errorf("scope=trace must not hit CH, got SQL=%q", q.lastSQL)
+	}
+	body := readBody(t, resp)
+	if strings.Contains(body, `"scopes":null`) {
+		t.Errorf("scope=trace emitted null `scopes` (must be `[]`): %s", body)
+	}
+	if !strings.Contains(body, `"scopes":[]`) {
+		t.Errorf("scope=trace must produce an empty scope list, got: %s", body)
+	}
+}
+
+// TestSearchTagsV2_EmptyScopeOmitted — a scope whose lookup returns no
+// key contributes NO bucket, rather than a present-but-empty one.
+// Upstream's tags-V2 combiner (modules/frontend/combiner/
+// search_tags.go) builds its scope list by ranging over the distinct
+// values storage reported, so a scope with nothing in the window never
+// reaches the wire. Emitting `{"name":"event","tags":[]}` here would put
+// cerberus one bucket ahead of reference Tempo on every fixture without
+// span events.
+func TestSearchTagsV2_EmptyScopeOmitted(t *testing.T) {
+	t.Parallel()
+	q := &stubQuerier{stringsBySQL: map[string][]string{
+		"`SpanAttributes`": {"http.method"},
+	}}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v2/search/tags")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	var body tempo.SearchTagsResponseV2
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	got := make([]string, 0, len(body.Scopes))
+	for _, s := range body.Scopes {
+		got = append(got, s.Name)
+	}
+	// resource / event / link all returned nothing; only span + the
+	// static intrinsic bucket survive.
+	want := []string{"span", "intrinsic"}
+	if len(got) != len(want) {
+		t.Fatalf("scope buckets=%v want=%v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("scope buckets=%v want=%v", got, want)
+		}
+	}
+}
+
+// TestSearchTagsV2_InstrumentationScope — the upstream OTel-CH traces
+// DDL declares no instrumentation-scope attribute map, so
+// schema.DefaultOTelTraces leaves ScopeAttributesColumn empty and the
+// `instrumentation` bucket never materialises on the default schema.
+// A deployment that points the override config at such a column gets
+// the bucket back, keyed off the same scope keyword upstream uses.
+func TestSearchTagsV2_InstrumentationScope(t *testing.T) {
+	t.Parallel()
+	s := schema.DefaultOTelTraces()
+	s.ScopeAttributesColumn = "ScopeAttributes"
+	q := &stubQuerier{stringsBySQL: map[string][]string{
+		"`ScopeAttributes`": {"otel.scope.custom"},
+	}}
+	srv := newServerWithSchema(q, s, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v2/search/tags?scope=instrumentation")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d want 200 body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	var body tempo.SearchTagsResponseV2
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Scopes) != 1 || body.Scopes[0].Name != "instrumentation" {
+		t.Fatalf("scopes=%+v want a single `instrumentation` bucket", body.Scopes)
+	}
+	if !contains(body.Scopes[0].Tags, "otel.scope.custom") {
+		t.Errorf("instrumentation bucket missing key: %+v", body.Scopes[0].Tags)
 	}
 }
 

--- a/internal/migrateverify/dialect_tempo.go
+++ b/internal/migrateverify/dialect_tempo.go
@@ -218,10 +218,10 @@ const (
 	SurfaceTempoTagValuesV2 = "tag-values-v2"
 )
 
-// tempoTagDiscoveryScopeAll requests every scope bucket (resource, span,
-// intrinsic) on the v2 tags endpoint. The unfiltered per-scope tag-NAME diff
-// is exact and complete on its own — see corpus_tags.go — so this probe is
-// never narrowed to a single scope.
+// tempoTagDiscoveryScopeAll requests every scope bucket the backend carries
+// on the v2 tags endpoint. The unfiltered per-scope tag-NAME diff is exact
+// and complete on its own — see corpus_tags.go — so this probe is never
+// narrowed to a single scope.
 const tempoTagDiscoveryScopeAll = "none"
 
 // TempoTagDiscoveryDialect speaks Tempo's four tag/tag-value discovery


### PR DESCRIPTION
Closes #1593.

## Problem

`/api/search/tags` and `/api/v2/search/tags` rejected `?scope=trace`, `?scope=event`, `?scope=link` and `?scope=instrumentation` with a 400. Upstream Tempo's `pkg/api.ParseSearchTagsRequest` accepts every value `traceql.AttributeScopeFromString` knows — `""`, `none`, `trace`, `span`, `resource`, `event`, `link`, `instrumentation` — plus the `intrinsic` carve-out. Grafana's per-scope autocomplete asks for each of them, so four of the nine legal scopes were an error rather than a result.

## What changed

**Event and link scopes really enumerate.** They are not empty stubs: the OTel-CH traces schema carries `Events.Attributes` / `Links.Attributes` as `Array(Map(String, String))`. Both scopes now flatten those nested maps through a typed Frag:

```sql
SELECT DISTINCT arrayJoin(arrayFlatten(arrayMap(m -> mapKeys(m), `Events`.`Attributes`)))
```

The nested column is spelled `chsql.Qual(col, "Attributes")` — the same two-quoted-idents form `Builder.exprNestedArrayExists` already emits — not `Col("Events.Attributes")`.

**Scopes with no attribute family contribute no bucket.** `instrumentation` reads `ScopeAttributesColumn`, which the upstream traces DDL does not declare, and `trace` has no attribute family at all. Neither emits an empty bucket: upstream's tags-V2 combiner (`modules/frontend/combiner/search_tags.go`) builds `final.Scopes` only from the scopes that reported distinct values, so omitting is the parity-correct behaviour. Point `ScopeAttributesColumn` at a real column via schema override and the `instrumentation` bucket appears — `TestSearchTagsV2_InstrumentationScope` pins that.

**`scope=all` stays a 400.** It is not a scope in upstream's vocabulary.

**HTTP and gRPC share one collector.** `CollectAttributeTagScopes` replaces the old `FetchTagKeys` export and the gRPC-side `collectTagKeys`, so the two surfaces cannot drift on which buckets exist. Intrinsic placement is unchanged and still mirrors upstream: V2 appends the intrinsic bucket for `scope=none`/`""`/`intrinsic`; V1 surfaces intrinsics only on an explicit `scope=intrinsic`.

## Tests

- `TestSearchTags_UpstreamScopeVocabulary` — all nine accepted values return 200, `all` and other junk return 400.
- `TestSearchTags_NestedScopeSQLShape` — pins the `Events` / `Links` projection byte-for-byte.
- `TestSearchTagsV2_TraceScopeEmptyEnvelope`, `TestSearchTagsV2_EmptyScopeOmitted` — a scope with nothing behind it yields `{"scopes":[]}`, never a bucket with an empty tag list.
- `TestSearchTagsV2_InstrumentationScope` — schema-override variant proving the bucket is real when the column exists.
- `TestSearchTagsV2_UpstreamScopeVocabulary` (gRPC) — the same partition over the streaming RPCs.
- Four compat corpus cases (`tags_v2_event`, `tags_v2_link`, `tags_v2_trace`, `tags_v2_instrumentation`) diff the body against reference Tempo. The tempo seeder emits no span events, links or scope attributes, so both backends legitimately report an empty scope list — the assertion these carry is that cerberus answers 200 with the same envelope upstream does, where it used to answer 400.

Parity floors move `tempo` 68→72 and `tempo-grpc` 65→69 in `compatibility/parity-baseline.json`, `.github/scripts/compat-ratchet.mjs` and the `docs/compatibility.md` roster; `node .github/scripts/doc-counts.mjs` and `node .github/scripts/forbid-sql-raw.mjs` are both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)