### PR TITLE
chore(harness): trim CLAUDE.md and check in the Claude Code agent harness

### DIFF
--- a/.claude/agents/chsql-emitter.md
+++ b/.claude/agents/chsql-emitter.md
@@ -1,0 +1,115 @@
+---
+name: chsql-emitter
+description: Domain specialist for internal/chsql, the plan-to-ClickHouse-SQL emitter. Use for any change that adds or alters emitted SQL, adds a Frag constructor, or investigates a wrong-SQL bug.
+tools: Read, Grep, Glob, Edit, Write, Bash
+model: opus
+---
+
+You specialise in `internal/chsql`, the layer that turns a `chplan` plan into parameterised
+ClickHouse SQL. It is the last stage before the database, so a defect here reaches every head at
+once and is invisible to any test that stops at the plan.
+
+You have no memory between invocations. Everything you need is in the tree; the sections below say
+where. Read the relevant files before proposing a change rather than working from what a prompt
+summarised.
+
+## The invariant that governs this package
+
+**No raw SQL strings. Typed Frags only.**
+
+Queries are composed through `chsql.QueryBuilder` slots — `.Select`, `.From`, `.Where`, `.GroupBy`,
+`.OrderBy`, `.Limit`, `.Prewhere`, `.Join`, `.WithRecursive` — and expressions through typed Frag
+constructors in `builder.go`: `Col`, `Qual`, `Lit`, `InlineLit`, `BareIdent`, `Call`, `Parametric`,
+`Cast`, `Paren`, `Eq`/`Neq`/`Lt`/`Gt`/`Gte`/`Lte`, `And`/`Or`, `Add`/`Sub`/`Mul`/`Div`/`Mod`/`Neg`,
+`Like`/`NotLike`, `In`/`InSubquery`/`NotInSubquery`, `Between`, `IsNull`/`IsNotNull`, `If`,
+`Lambda1`/`Lambda2`, `Array`, `Subscript`, `Subquery`, `UnionAll`/`UnionDistinct`, `As`/`RawAs`,
+`Window`, `Distinct`, `Star`/`QualStar`/`StarReplace`.
+
+Any ClickHouse function is `Call("fn", args…)`. Arithmetic is the binary-operator constructors.
+Lambdas are `Lambda1` / `Lambda2` with `BareIdent("i")`-style parameters.
+
+Writing SQL tokens into a `strings.Builder`, through `writeSQL(...)`, through `fmt.Sprintf`, or by
+`+`-concatenating strings is forbidden **everywhere except the Frag-primitive constructors in
+`builder.go`** — `Call`, `binOp`, `Cast`, `Paren`, `InlineLit`, and the QueryBuilder clause renderer
+legitimately write tokens because they *are* the typed surface. The known-good exceptions outside
+`builder.go` are the pre-rendered subquery splice in `emit_node.go` (`subqueryFrag`), the output
+buffer field in `emit.go`, and the regex escaper `regexQuoteMeta`. Nothing else.
+
+`verbatim(...)` is for emitter-chosen synthetic tokens — an alias name, a pre-quoted literal, a
+pre-rendered subquery — never for a whole expression shape.
+
+The domain emitters build query and expression *shapes* and must compose Frags:
+`range_window.go`, `range_window_fused.go`, `range_window_native.go`, `range_window_resample.go`,
+`range_lwr.go`, `range_bucket_fanout.go`, `absent_over_time.go`, `histogram_over_time.go`,
+`histogram_quantile.go`, `histogram_quantile_native.go`, `metrics_compare.go`,
+`metrics_second_stage.go`, `vector_join.go`, `vector_set_op.go`, `nary_vector_set_op.go`,
+`set_op.go`, `structural_join.go`, `info_join.go`, `late_mat.go`, `prewhere.go`,
+`scan_resource_bound.go`, `search_trace_limit.go`, `exemplars.go`, `query_exemplars.go`,
+`tableshape.go`.
+
+When a shape is not expressible, add a typed constructor to `builder.go` rather than reaching for a
+string. That is the intended escape route and it keeps the surface closed by construction.
+
+### Self-check, every time
+
+```bash
+node .github/scripts/forbid-sql-raw.mjs
+```
+
+Run it from the repo root before you finish. It is wired into CI and into lefthook's `pre-push`, and
+it catches the token-writing primitives. It cannot judge the semantic shape — whether a valid Frag
+could have replaced a write it permits — so read your own diff for that.
+
+A worked conversion, for calibration. Raw:
+
+```go
+b.sb.WriteString("fromUnixTimestamp64Nano(intDiv(toUnixTimestamp64Nano(")
+end(b)
+b.sb.WriteString(") / step) * step)")
+```
+
+Typed:
+
+```go
+Call("fromUnixTimestamp64Nano", Mul(Call("intDiv", Call("toUnixTimestamp64Nano", end), step), step))
+```
+
+`Call` and the binary operators add no parentheses of their own and `InlineLit(int64)` emits a bare
+integer, so the typed form is byte-identical to the hand-rolled string. Regenerate the goldens and
+confirm zero churn — a conversion that changes emitted bytes is a behaviour change wearing a
+refactor's clothes, and must be justified as one.
+
+## Other invariants that bite here
+
+- **No magic constants.** A meaning-bearing literal becomes a named `const` whose name is the
+  explanation.
+- **Parameterisation.** `Lit` binds a query parameter; `InlineLit` writes the value into the SQL
+  text. Use `InlineLit` only where a parameter is not legal or where the value is emitter-chosen and
+  not attacker-influenced; reach for `Lit` by default.
+- **chDB is not a ClickHouse server.** chDB coerces some column types the server rejects outright, so
+  an emit-type defect can pass every chdb-tagged lane and fail in production. `compose-smoke` is the
+  lane that runs against a real server, and it is scoped to changes in `internal/chsql`,
+  `internal/api`, `internal/chclient`, and `cmd/cerberus` — which means a change you make triggers
+  it on the PR itself.
+- **Blast radius.** This package is shared by all three heads. A change made for PromQL reaches LogQL
+  and TraceQL; check the fixtures for all three.
+
+## Verifying a change
+
+`test/spec/<head>/*.txtar` holds the goldens: the `-- sql --` section is what this package emits, and
+`-- expected_rows --` is the chDB roundtrip. Regenerate with `just update-golden` — never hand-edit a
+golden, because every generated path is marked `-merge` in `.gitattributes` precisely because an
+edited or line-merged one still parses while being wrong. `just update-golden` needs `libchdb.so`
+(`just chdb-install`).
+
+Read the golden diff as the primary evidence of what you changed. Unexpected churn in a fixture you
+did not mean to touch is the signal that the shape is shared more widely than you assumed.
+
+The promql spec lane runs **pre-optimizer**, so a change that only manifests after an optimizer rule
+fires will not show up there; `docs/test-strategy.md` maps which layer covers what.
+
+## Reference
+
+`docs/engine.md` for the pipeline this package terminates, `docs/clickhouse-optimizations.md` and
+`docs/native-clickhouse.md` for the CH-native functions available and the version floors that gate
+them, `docs/test-strategy.md` for layer selection, and `CLAUDE.md` for the full invariant list.

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,0 +1,66 @@
+---
+name: code-reviewer
+description: Reviews the working diff for regressions, missing tests, and repository-invariant breaches before a commit. Use proactively once a change is complete and before committing or opening a PR.
+tools: Read, Grep, Glob, Bash
+model: opus
+---
+
+You review changes. You do not make them.
+
+## Read-only constraint
+
+You have `Bash`, and frontmatter cannot narrow it to a single git subcommand, so the constraint is
+yours to hold: use `Bash` **only** to inspect state. Permitted shapes, and nothing beyond them:
+
+- `git diff`, `git diff --staged`, `git diff origin/main...HEAD`, `git status`, `git log`,
+  `git show`, `git ls-files`, `git merge-base`
+- `gh pr view`, `gh pr diff`, `gh issue view`, `gh api` read paths
+- `node .github/scripts/forbid-sql-raw.mjs` and the other read-only discipline scripts
+
+Never run a command that writes: no `git add`, `commit`, `push`, `checkout`, `restore`, `reset`,
+`stash`, `rebase`, `merge`, no `gh pr create` or `gh pr merge`, no file writes or deletions, no
+formatters. You have no `Edit` or `Write` tool by design. Report problems; the caller fixes them.
+
+Do not run the test suite or `golangci-lint`. That work belongs to lefthook's `pre-push` stage and to
+CI, and a linter run from a fresh agent worktree has been observed reporting a clean tree without
+having analysed it. Your value is judgement over the diff, not a second copy of a gate.
+
+## What to review
+
+Start from the actual diff — `git diff origin/main...HEAD` for a branch, `git diff` for uncommitted
+work — and read the surrounding code for anything the diff touches. A hunk read without its context
+is how a plausible-looking change gets approved.
+
+Check, in this order:
+
+1. **Correctness against the reference.** Cerberus is a drop-in for Prometheus, Loki, and Tempo. For
+   a behaviour change, ask what the reference backend answers for the same input. A change that
+   makes cerberus self-consistent but divergent from upstream is a bug.
+2. **Test coverage that can actually fail.** For every behaviour the diff adds or changes, name the
+   test that would go red if it were reverted. A test that passes whether or not the change is
+   present is a gap, not soft coverage. Watch for assertions over empty collections, tests whose
+   fixture never exercises the new branch, and axis intersections nobody covers.
+3. **Repository invariants.** Walk the numbered list in `CLAUDE.md`. The ones a diff most often
+   breaks: raw SQL outside the typed Frag layer (invariant 10), magic constants (13), hand-edited
+   generated artefacts (9), `t.Skip` / soft-assert / silent-recover (6), allow-lists and tolerance
+   sets (7), a new `internal/**` package missing from `.go-arch-lint.yml` (16).
+4. **Regression risk.** What else calls the changed function? Use `Grep` to find every caller and ask
+   whether the new behaviour is right for each. Pay attention to shared code paths across the three
+   heads — a fix for PromQL that changes `internal/chplan` or `internal/chsql` reaches LogQL and
+   TraceQL too.
+5. **Generated artefacts.** If the diff changes lowering or emission, `test/spec/` goldens, the
+   parity ledgers, or a baseline should have moved. A behaviour change with no golden churn usually
+   means the fixture corpus does not reach the new code.
+6. **Deferral prose.** The required `forbid-deferral` gate scans the change's own additions. Flag any
+   marker that lacks a citation to an open issue in this repository.
+
+## How to report
+
+Group findings as **blocking**, **should fix**, and **consider**. For each: the file and line, what
+is wrong, and why it matters. Quote the specific lines. Propose the fix in words; do not apply it.
+
+If a finding is real but genuinely belongs outside this change, say so and state that it needs a
+GitHub Issue filed before the PR merges — never suggest a sentence in the PR body instead.
+
+Say plainly when a diff is clean. A review that manufactures findings to look thorough costs more
+than it saves.

--- a/.claude/agents/explorer.md
+++ b/.claude/agents/explorer.md
@@ -1,0 +1,42 @@
+---
+name: explorer
+description: Fast, cheap codebase search. Use when the question is "where does X live", "what calls Y", or "which files mention Z" and the answer is a list of locations rather than an analysis.
+tools: Read, Grep, Glob, Bash
+model: haiku
+---
+
+You locate things in the cerberus tree. You report where code is, not whether it is correct.
+
+Answer with file paths and line numbers, plus the few lines of context needed to show why each hit
+matches. Do not paste whole files, do not summarise a package's design, and do not review what you
+find. If the caller wants an assessment, that is a different agent.
+
+## Where things live
+
+- `internal/promql/`, `internal/logql/`, `internal/traceql/` — per-head parse and lowering.
+  `lower.go` in each is the entry point. LogQL's parser is `internal/logql/lsyntax`; TraceQL's is
+  `internal/traceql/ast`.
+- `internal/chplan/` — the shared plan IR every head lowers into.
+- `internal/optimizer/` — plan rewrite rules.
+- `internal/chsql/` — plan to ClickHouse SQL emission.
+- `internal/api/{prom,loki,tempo}/` — HTTP handlers.
+- `internal/chclient/`, `internal/schema/`, `internal/config/` — driver, table layout, runtime config.
+- `test/spec/<head>/*.txtar` — golden fixtures. `test/property/`, `test/regression/`, `test/e2e/`.
+- `compatibility/{prometheus,loki,tempo}/` — differential harnesses.
+- `.github/scripts/*.mjs` — CI gate logic. `Justfile` — every task recipe.
+
+## Search discipline
+
+Use `Grep` for content and `Glob` for names; both are faster than shelling out. When you do use
+`Bash` for search, use `rtk proxy grep` rather than `rtk grep` — the filtered form can report that a
+pattern is absent when it is present, so it can never be used to prove absence. Omit
+`--include=*.go`, which fails under this shell; scope with a path argument instead.
+
+Restrict `Bash` to searching and reading. Never write, move, or delete a file, and never run git
+commands that change state.
+
+## Reporting
+
+Lead with the direct answer. Then a flat list of `path:line — one-line note` entries, most relevant
+first. If a search genuinely finds nothing, say so and name the patterns you tried, so the caller can
+tell an absent feature from a bad guess at its name.

--- a/.claude/agents/test-runner.md
+++ b/.claude/agents/test-runner.md
@@ -1,0 +1,55 @@
+---
+name: test-runner
+description: Runs a test suite and reports only the failures, with enough context to act on each. Use when a change needs verifying and the caller wants a verdict rather than a transcript.
+tools: Bash, Read, Grep, Glob
+model: sonnet
+---
+
+You run tests and report what failed. Full output is never the deliverable.
+
+## Choosing the recipe
+
+`just` is the canonical runner; a bare `go test` misses the race flag, the cover profile, and the
+build tags. Match the recipe to the question:
+
+- `just test` — the default: race-detected unit and spec suite plus the tagged-lane type-check.
+- `just test-unit` — the suite alone, when the caller only changed non-tagged Go code.
+- `go test -race ./internal/<pkg>/...` — a single package during a tight loop. Say in your report
+  that the run was scoped, so nobody reads a narrow green as a whole-tree green.
+- `just spec-chdb` / `just test-chdb` / `just property` — the chDB-backed lanes. These need
+  `libchdb.so`; if it is missing, report that as a blocked run and name `just chdb-install`. Do not
+  substitute an untagged run and present it as equivalent.
+- `just lint`, `just lint-md`, `just lint-actions` — when the caller asks about linting specifically.
+- `just coverage` — coverage profile and floor.
+
+Never edit a test, a fixture, or production code. You have no `Edit` or `Write` tool. If a test looks
+wrong, say so in the report and let the caller decide.
+
+## Reporting
+
+Lead with one line: what ran, and pass or fail with counts.
+
+For a green run, stop there. Do not paste the transcript.
+
+For each failure, report:
+
+- the test name and its file and line
+- the assertion that failed, with expected and actual values
+- the shortest command that reproduces just that test, for example
+  `go test -race -run '^TestName$' ./internal/promql/`
+- one sentence on the likely cause when the failure message makes it obvious; say nothing rather than
+  guessing when it does not
+
+Group failures that share a cause and say so — twenty failures from one broken helper is a different
+report from twenty independent ones.
+
+Distinguish a **failure** from an **error**: a compile error, a missing shared library, or a panic in
+setup means the suite never ran, and reporting that as "N tests failed" sends the caller after the
+wrong thing.
+
+Never soften a result. Do not call a failure a flake without evidence such as a passing rerun plus a
+named nondeterminism, and never omit a failure because it looks unrelated to the current change — in
+this repository "pre-existing" decides which PR fixes a bug, never whether it gets fixed. Report it.
+
+If a run exceeds a few minutes with no output, say the run is still going rather than reporting a
+result you do not have.

--- a/.claude/hooks/format-touched-file.mjs
+++ b/.claude/hooks/format-touched-file.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+// PostToolUse hook for Edit / Write / MultiEdit.
+//
+// Formats the SINGLE file the tool just touched, and nothing else. Two
+// commands, matching what the CI `lint` gate enforces:
+//
+//   gofumpt -extra -w <file>
+//   goimports -w -local github.com/tsouza/cerberus <file>
+//
+// `-extra` is not decorative. `.golangci.yml` sets `gofumpt.extra-rules: true`,
+// so the required `lint` gate applies the extra rule set; a plain `gofumpt -w`
+// leaves formatting that CI rejects, which is the worst kind of local
+// formatter — one that reports success over a file that will fail.
+//
+// `-local` mirrors `.golangci.yml`'s `goimports.local-prefixes`, so cerberus's
+// own imports land in their own block rather than being shuffled into the
+// third-party group on every save.
+//
+// Scope is deliberately one file: no `./...`, no repo-wide linter. A hook that
+// runs on every edit has to stay in the tens of milliseconds, and repo-wide
+// validation already belongs to lefthook's pre-push stage and to CI.
+//
+// Non-Go files are a silent no-op. Markdown is handled by lefthook's
+// `pre-commit` stage, which pairs `markdownlint-cli2 --fix` with the MD060
+// table-padding pass those two need to run together.
+//
+// Failure posture: this hook never blocks. A missing formatter binary or a file
+// that does not parse is reported on stderr and exits 0, because a syntax error
+// mid-edit is an expected transient state, not a reason to refuse the edit that
+// is about to fix it.
+//
+// Input: the PostToolUse JSON payload on stdin (`tool_name`, `tool_input`).
+// Exit codes: always 0.
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import process from 'node:process';
+
+const LOCAL_IMPORT_PREFIX = 'github.com/tsouza/cerberus';
+const FORMATTED_EXTENSION = '.go';
+
+function readPayload() {
+  let raw = '';
+  try {
+    raw = readFileSync(0, 'utf8');
+  } catch {
+    return null;
+  }
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+// run — execute a formatter over one file. Returns true when it ran cleanly.
+// A missing binary (ENOENT) and a non-zero exit are reported the same way and
+// neither is fatal; see the failure posture note above.
+function run(bin, args) {
+  try {
+    execFileSync(bin, args, { stdio: ['ignore', 'ignore', 'pipe'] });
+    return true;
+  } catch (e) {
+    const detail = e.code === 'ENOENT' ? `${bin} not on PATH` : String(e.stderr ?? e.message).trim();
+    process.stderr.write(`format-touched-file: ${bin} skipped — ${detail}\n`);
+    return false;
+  }
+}
+
+function main() {
+  const payload = readPayload();
+  if (!payload) return 0;
+
+  const file = payload?.tool_input?.file_path;
+  if (typeof file !== 'string' || !file.endsWith(FORMATTED_EXTENSION)) return 0;
+  if (!existsSync(file)) return 0;
+
+  run('gofumpt', ['-extra', '-w', file]);
+  run('goimports', ['-w', '-local', LOCAL_IMPORT_PREFIX, file]);
+  return 0;
+}
+
+process.exit(main());

--- a/.claude/hooks/guard-git.mjs
+++ b/.claude/hooks/guard-git.mjs
@@ -1,0 +1,219 @@
+#!/usr/bin/env node
+// PreToolUse hook for Bash. Guards `git commit` and `git push`.
+//
+// WHAT IT BLOCKS
+//
+//   1. A commit or push aimed at `main`. This repository is PR-per-change and
+//      branch protection rejects the push server-side anyway; failing locally
+//      turns a confusing remote rejection into a one-line message before any
+//      work is done. Also catches the subtler form — an explicit
+//      `git push origin HEAD:main` from a feature branch.
+//
+//   2. A commit or push while lefthook's git hooks are not installed.
+//      `lefthook.yml` is the layer that actually owns local validation:
+//      `pre-commit` formats staged files, `commit-msg` runs commitlint, and
+//      `pre-push` mirrors the CI `check` + `lint` + `forbid-skip` jobs. When
+//      those hooks are absent every one of those gates is silently off, and the
+//      first signal is a red PR. `just hooks-install` is the fix.
+//
+// WHAT IT DELIBERATELY DOES NOT DO
+//
+// It does not run the test suite or golangci-lint. Two reasons, both load-
+// bearing. First, lefthook's `pre-push` already runs that work once per push
+// rather than once per commit, so wiring it here would duplicate a
+// better-targeted layer at a cost of minutes on every commit. Second,
+// golangci-lint invoked from a freshly created agent worktree has been observed
+// reporting "No issues found" without having analysed the tree — a false green
+// is worse than no local check, because it is trusted.
+//
+// THE FULL-CI VARIANT — one environment variable away
+//
+// Setting CERBERUS_PRECOMMIT_FULL_CI=1 makes this guard additionally run
+// `just ci` (lint + test + build) before each commit and push, and block on
+// failure. That is the literal "validate everything before committing"
+// behaviour, kept off by default for the two reasons above. Turn it on for a
+// session with:
+//
+//   export CERBERUS_PRECOMMIT_FULL_CI=1
+//
+// or permanently by adding it to the `env` block of .claude/settings.json. The
+// hook's `timeout` in that file is already sized for a full `just ci` run; for
+// the default fast path the guard returns in milliseconds regardless.
+//
+// Input: the PreToolUse JSON payload on stdin (`tool_name`, `tool_input`).
+// Exit codes: 0 = allow; 2 = block, with the reason on stderr (Claude Code
+// feeds a PreToolUse exit code 2 back to the model as a blocking error).
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { isAbsolute, join } from 'node:path';
+import process from 'node:process';
+
+const ALLOW = 0;
+const BLOCK = 2;
+
+const PROTECTED_BRANCH = 'main';
+const GUARDED_SUBCOMMANDS = new Set(['commit', 'push']);
+const FULL_CI_ENV = 'CERBERUS_PRECOMMIT_FULL_CI';
+
+// Git's own global options that consume the following argument, so the
+// subcommand scanner does not mistake their value for the subcommand.
+const GIT_GLOBAL_OPTS_WITH_VALUE = new Set(['-C', '-c', '--git-dir', '--work-tree', '--namespace']);
+
+// Command wrappers that may precede `git` on the line. `rtk` is this repo's
+// token-reducing CLI proxy, invoked either as `rtk git ...` or `rtk proxy git ...`.
+const COMMAND_WRAPPERS = new Set(['rtk', 'proxy', 'command', 'sudo', 'time', 'nice', 'env']);
+
+function readPayload() {
+  try {
+    return JSON.parse(readFileSync(0, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+// splitSegments — break a shell line into independently-executed segments so a
+// `git commit` buried in a `&&` chain is still seen. Quoting is not modelled;
+// the cost of a rare false positive here is one explanatory message, while a
+// false negative is the failure this guard exists to prevent.
+function splitSegments(command) {
+  return command.split(/&&|\|\||[;\n|]/g);
+}
+
+// gitInvocation — given one segment, return the git subcommand it runs, or null.
+// Skips leading `VAR=value` assignments and known wrappers, then walks git's
+// global options to find the first bare word, which is the subcommand.
+function gitInvocation(segment) {
+  const words = segment.trim().split(/\s+/).filter(Boolean);
+  let i = 0;
+  while (i < words.length && (/^[A-Za-z_][A-Za-z0-9_]*=/.test(words[i]) || COMMAND_WRAPPERS.has(words[i]))) i += 1;
+  if (i >= words.length || (words[i] !== 'git' && !words[i].endsWith('/git'))) return null;
+  i += 1;
+  while (i < words.length) {
+    const w = words[i];
+    if (!w.startsWith('-')) return w;
+    if (GIT_GLOBAL_OPTS_WITH_VALUE.has(w)) i += 2;
+    else i += 1;
+  }
+  return null;
+}
+
+function git(args, cwd) {
+  return execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+}
+
+function currentBranch(cwd) {
+  try {
+    return git(['rev-parse', '--abbrev-ref', 'HEAD'], cwd);
+  } catch {
+    return null;
+  }
+}
+
+// pushesToProtectedBranch — a push from a feature branch can still target
+// `main` via an explicit refspec (`main`, `HEAD:main`, `+HEAD:refs/heads/main`).
+function pushesToProtectedBranch(segment) {
+  const refspecs = segment.trim().split(/\s+/).slice(1).filter((w) => !w.startsWith('-'));
+  return refspecs.some((spec) => {
+    const dst = spec.includes(':') ? spec.slice(spec.lastIndexOf(':') + 1) : spec;
+    return dst === PROTECTED_BRANCH || dst === `refs/heads/${PROTECTED_BRANCH}`;
+  });
+}
+
+// hooksDir — where git will look for hook scripts in THIS working tree.
+// `core.hooksPath` wins when set; otherwise hooks live in the common git dir,
+// which is what makes the check work identically from a linked worktree.
+function hooksDir(cwd) {
+  try {
+    const configured = git(['config', '--get', 'core.hooksPath'], cwd);
+    if (configured) return isAbsolute(configured) ? configured : join(git(['rev-parse', '--show-toplevel'], cwd), configured);
+  } catch {
+    // core.hooksPath unset: `git config --get` exits 1, which is the common case.
+  }
+  return join(git(['rev-parse', '--git-common-dir'], cwd), 'hooks');
+}
+
+// lefthookInstalled — a hook file exists AND delegates to lefthook. The name
+// alone is not enough: an unrelated hook script at that path would satisfy a
+// bare existence check while running none of the repo's gates.
+function lefthookInstalled(cwd, hookNames) {
+  let dir;
+  try {
+    dir = hooksDir(cwd);
+  } catch {
+    return { ok: false, reason: 'not inside a git working tree' };
+  }
+  const missing = hookNames.filter((name) => {
+    const p = join(dir, name);
+    if (!existsSync(p) || !statSync(p).isFile()) return true;
+    return !readFileSync(p, 'utf8').includes('lefthook');
+  });
+  if (missing.length > 0) return { ok: false, reason: `${dir} has no lefthook ${missing.join(' / ')} hook` };
+  return { ok: true };
+}
+
+function runFullCI(cwd) {
+  try {
+    execFileSync('just', ['ci'], { cwd, stdio: ['ignore', 'inherit', 'inherit'] });
+    return { ok: true };
+  } catch (e) {
+    const detail = e.code === 'ENOENT' ? '`just` is not on PATH' : '`just ci` failed';
+    return { ok: false, reason: detail };
+  }
+}
+
+function block(lines) {
+  process.stderr.write(`${lines.join('\n')}\n`);
+  return BLOCK;
+}
+
+function main() {
+  const payload = readPayload();
+  if (!payload || payload.tool_name !== 'Bash') return ALLOW;
+
+  const command = payload?.tool_input?.command;
+  if (typeof command !== 'string' || command.length === 0) return ALLOW;
+
+  const cwd = payload.cwd && existsSync(payload.cwd) ? payload.cwd : process.cwd();
+
+  const guarded = [];
+  for (const segment of splitSegments(command)) {
+    const sub = gitInvocation(segment);
+    if (sub && GUARDED_SUBCOMMANDS.has(sub)) guarded.push({ sub, segment });
+  }
+  if (guarded.length === 0) return ALLOW;
+
+  const branch = currentBranch(cwd);
+  for (const { sub, segment } of guarded) {
+    const targetsMain = branch === PROTECTED_BRANCH || (sub === 'push' && pushesToProtectedBranch(segment));
+    if (targetsMain) {
+      return block([
+        `guard-git: refusing to ${sub} against \`${PROTECTED_BRANCH}\`.`,
+        'This repository is PR-per-change and branch protection rejects direct pushes to main.',
+        'Branch off the current origin/main, then push and `gh pr create` in the same step.',
+      ]);
+    }
+  }
+
+  const hookNames = guarded.some((g) => g.sub === 'push') ? ['pre-commit', 'commit-msg', 'pre-push'] : ['pre-commit', 'commit-msg'];
+  const hooks = lefthookInstalled(cwd, hookNames);
+  if (!hooks.ok) {
+    return block([
+      `guard-git: lefthook's git hooks are not installed — ${hooks.reason}.`,
+      'Without them the formatters, commitlint, and the pre-push mirror of the CI',
+      'check / lint / forbid-skip gates are all silently off.',
+      'Fix with: just hooks-install',
+    ]);
+  }
+
+  if (process.env[FULL_CI_ENV] === '1') {
+    const ci = runFullCI(cwd);
+    if (!ci.ok) {
+      return block([`guard-git: ${FULL_CI_ENV}=1 is set and ${ci.reason}.`, 'Fix the failure, or unset the variable to fall back to the lefthook + CI layers.']);
+    }
+  }
+
+  return ALLOW;
+}
+
+process.exit(main());

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/format-touched-file.mjs\"",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/guard-git.mjs\"",
+            "timeout": 900
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,163 +1,203 @@
 # Cerberus — agent context
 
-Drop-in **Prometheus / Loki / Tempo** HTTP gateway for **ClickHouse**. Parses each query language (PromQL with the upstream Apache prometheus parser; LogQL and TraceQL with cerberus's own in-house Apache reimplementations), lowers into a shared plan IR (`internal/chplan`), applies a small rule-based optimizer, and emits parameterised ClickHouse SQL. The HTTP layer speaks the upstream Prom / Loki / Tempo wire format so Grafana sees cerberus as three drop-in datasources.
+<!-- AGENTS.md is a symlink to this file: both names resolve to these exact bytes, so this
+     context is shared with every agent tool rather than duplicated. There is deliberately no
+     `@AGENTS.md` import line — it would import this file into itself. -->
 
-## Hard rules (non-negotiable)
+Drop-in **Prometheus / Loki / Tempo** HTTP gateway for **ClickHouse**. Each query language is parsed
+(PromQL with the upstream Apache prometheus parser; LogQL and TraceQL with cerberus's own in-house
+Apache reimplementations), lowered into a shared plan IR (`internal/chplan`), rewritten by a
+rule-based optimizer, and emitted as parameterised ClickHouse SQL. The HTTP layer speaks the upstream
+Prom / Loki / Tempo wire format, so Grafana sees cerberus as three drop-in datasources.
 
-- **PR-per-change.** No direct pushes to `main` — branch protection rejects them. Branch protection requires **20** status checks: `check`, `lint`, `forbid-skip`, `forbid-deferral`, `pr-body`, `chart-validate`, `probe`, `roundtrip (promql)`, `roundtrip (logql)`, `roundtrip (traceql)`, `perf-guards`, `compatibility/{prometheus,loki,tempo}`, `compatibility/prometheus-forced-route`, `coverage`, `mutation`, `property (PromQL + LogQL + TraceQL, rapid N=500)`, `strict-scan`, and `CodeQL`. All of them run on pull requests — including the `mutation` lane, a genuine PR gate rather than an informational one (on a PR it runs the gremlins legs whose scope that PR changed, and sweeps the full matrix on push / nightly / dispatch / `release/*` PRs). The three heavy substrate lanes — `compose-smoke`, `dashboard` (k3d + Grafana + Playwright), and `profile` — are **release** gates instead: they short-circuit to a green no-op on an ordinary PR, do their real work on the merge commit, and are named in release.yml's `RELEASE_REQUIRED_CHECKS`, so nothing publishes until each posts green on the commit being shipped (a `release/*` head branch still gets the full lane on the PR). `compose-smoke` narrows that short-circuit: it is the only lane that runs against a real ClickHouse server rather than chDB, so a PR touching `internal/chsql` / `internal/api` / `internal/chclient` / `cmd/cerberus` boots the stack on the PR itself (scope owned by `.github/scripts/compose-smoke-scope.mjs`). Treat `docs/test-strategy.md`'s CI-gate inventory as the canonical per-gate reference, and this API call as the source of truth for the required set itself: `gh api repos/tsouza/cerberus/branches/main/protection --jq '.required_status_checks.contexts[]'`. Every workflow owning one of those contexts also declares `merge_group:`, so the same check-runs — under byte-identical names — report on the projected trunk a merge queue builds, and a queued entry is held to the *pull-request* posture rather than the push posture (same short-circuits, same diff-scoped lane selection, read off the merge group's own `base_sha..head_sha`). `CodeQL` is the one context with no `merge_group` half: code-scanning default setup dispatches on `push` and `pull_request` only. `test/regression/merge_queue_test.go` pins both invariants — every required context posts on the queue, and no `cancel-in-progress:` reachable from a merge-group run can be true there, because GitHub reads a cancelled check-run as a failure and dequeues the PR. See `docs/test-strategy.md` → "Merge-queue posture". Force-push and deletion are off on `main`; the GitHub "Update branch" button (merge-commits) works for stale PRs. **Never use `gh pr merge --admin`** — every PR must merge cleanly with all required checks green. If a required check is failing, fix the code or fix the workflow; don't bypass. Branch protection has `enforce_admins: false`, so the no-`--admin` rule is policy discipline rather than a mechanical block — honour it regardless.
-- **No deferrals in PR prose — out-of-scope work becomes an Issue.** When work surfaces mid-PR that genuinely belongs outside that PR's scope, `gh issue create` it **before** arming auto-merge on the PR that found it. A sentence in a PR body that labels the work as somebody's later problem is not a resting place: the moment the PR merges, that sentence is invisible — it appears in no list, no gate reports on it, and nobody is assigned. An Issue stays open until someone closes it, which is the whole point. Verify the finding first (grep the site, read the function) — filing a phantom is as bad as dropping a real one. The PR body may *reference* the issue (`Follow-up tracked in #NNN`); it may never *substitute* for one. This is the same rule as ["Pre-existing" is not an escape hatch](#hard-rules-non-negotiable) seen from the other end: "adjacent" / "out of scope" decide **which** artefact fixes a bug, never **whether** it gets fixed. Issues are equally open to human contributors for bug reports, design discussions, and feature proposals. This rule is **enforced, not conventional**: the required `forbid-deferral` check (`.github/scripts/forbid-deferral.mjs`) scans a change's own additions — its description, the commit messages in its range, and the `+` lines of its diff — for the marker classes in that module's `DEFERRAL_MARKERS` table, and fails unless each one cites an issue in this repository that is **open** and is an issue rather than a pull request. It deliberately does not scan the tree at large: the same phrases are ordinary architecture prose elsewhere, and a gate that fired on those would get routed around. There is no tolerance file and no exemption list — the only resolution is to file the issue.
-- **A pushed branch gets a PR in the same breath.** The push and the `gh pr create` are one step, not two — never end a turn, hand back to an orchestrator, or continue to the next file with a branch pushed and no PR against it. A branch without a PR is invisible: it is not in `gh pr list`, no CI gate reports on it, no reviewer sees it, and if the work it belongs to merges without it, the commits are silently stranded. This has stranded real work more than once. If the branch genuinely is not ready to review, open it as a draft PR — "not ready" is a reason to mark the PR draft, never a reason to skip creating it. Two corollaries:
-  - **Branch off the current `origin/main`, and re-check the base before pushing.** Never branch off another in-flight branch. If the parent PR squash-merges while you work, your base no longer exists in `main`'s history and a PR from that branch shows a doubled diff — every file the parent touched, replayed. Recovery is to cherry-pick your own commits onto a fresh branch off `origin/main`, so avoid the situation instead.
-  - **Never push to the head branch of a PR that has already merged.** A merged PR is closed: it will not pick up the new commit, its head stops advancing, and the commit reaches no branch anyone reads. Confirm the PR is still open (`gh pr view <n> --json state`) before pushing to its head; if it has merged, cut a fresh branch off `origin/main` and open a follow-up PR.
-- **Conventional Commits**, enforced by `commitlint` (see `.commitlintrc.json`). The `subject-case` rule is relaxed so Dependabot's `Bump X from Y to Z` subjects pass.
-- **Justfile is the canonical task runner.** `just` lists every recipe. Don't reach for `go test ./...` directly when `just test` exists — the recipe sets the race flag, the cover profile, and the right toolchain.
-- **No manual pre-flight; lefthook + CI own it.** Don't run `just test`, `just lint`, `go test`, `golangci-lint run`, `go build`, or `markdownlint-cli2` manually before pushing. The repo's `lefthook.yml` is layered:
-  - `pre-commit` — sub-second formatters on staged files (`gofumpt` / `goimports` / `markdownlint-cli2 --fix`).
-  - `commit-msg` — Conventional-Commits via `commitlint`.
-  - `pre-push` — once-per-push gate that mirrors the CI `check` + `lint` + `forbid-skip` jobs: `golangci-lint run ./...`, `markdownlint-cli2` verify, and the discipline greps (`t.Skip*`, "not implemented" in prod code, soft-assertions / silent recovers, `should_skip` overlays, escape-hatch primitives). Bypass with `LEFTHOOK=0 git push` for WIP branches.
-  - CI runs the full test suite + the compat / e2e / mutation lanes the local hook intentionally doesn't.
-  - New contributors run `just hooks-install` once after cloning; agents trust the hooks + CI and don't pre-flight manually.
-- **Tests assert or are removed — never `t.Skip` / soft-assert / silent-recover / `should_skip` a test.** If a feature can't be exercised on the CI substrate (e.g. a CH function above the chDB floor), gate it at runtime and validate elsewhere (prod / e2e), never skip. The `forbid-skip` gate enforces this behaviourally; honest prose ("deferred", "skipped") describing correct version-gated code is fine — the removed `wording-tests` scan policed words, not behaviour.
-- **Compatibility is the source of truth for all three heads.** The unified `compatibility.yml` workflow runs on pull_request + push-to-main + nightly + manual dispatch. All three jobs — `compatibility/prometheus`, `compatibility/loki`, `compatibility/tempo` — are required status checks on `main` (gate flip completed 2026-05-19; verified on 2026-05-21 with 9/9 consecutive green runs after the standalone `tempo-compatibility.yml` workflow was deleted and consolidated into this one). There are **no allow-lists**: the old `expected-failures.json` mechanism is deleted, and every diff against a reference backend is a real bug to fix at the source. The only pinned exclusion set is `compatibility/loki/upstream-skip-baseline.txt`, which records the corpus entries *upstream itself* marks `skip: true` (no reference baseline exists for them); the harness fails on any drift in that set (see `docs/compatibility.md`).
-- **"Pre-existing" is not an escape hatch.** Diagnosing a bug as "pre-existing" (not introduced by the current change) is *only* a routing/triage step — it decides *which* branch/PR fixes the issue (spin the resolution out to a separate agent/branch/PR), never *whether* it gets fixed. Outside that routing scope an issue either exists or it doesn't; if it exists, it gets fixed. "Not my PR's fault" / "pre-existing" must never be used to skip, tolerate, ignore, or ship a known bug, nor to paper over a real failure as "flake/pre-existing" without evidence and a follow-up fix. Same family as the `t.Skip` / soft-assert and **no allow-lists** rules above — no escape hatch for known-bad behaviour, only an honest decision about where the fix lands.
-- **Non-trivial CI step logic lives in `.github/scripts/*.mjs`, not inline YAML.** Multi-line `bash` / `jq` / `awk` / `perl` embedded in a workflow `run:` block that encodes real logic (discipline greps, threshold gates, baseline/ref resolution, score-summary formatting) belongs in a dependency-light Node ESM module under `.github/scripts/` — env-driven inputs (documented at the top of the file), `::error::` / `::notice::` workflow commands, and `process.exit(1)` on failure / `0` on success, preserving the exact behaviour of the bash it replaces. Import only `node:` builtins (no npm deps, no `@actions/*`); `ubuntu-latest` ships node, so `run: node .github/scripts/<name>.mjs` needs no `setup-node`. Shared `::error::` / `git` / `lsFiles` helpers live in `.github/scripts/lib/gh.mjs`. This keeps step logic testable (run the `.mjs` locally), lintable, and reusable across jobs (e.g. the three compatibility heads share one summary script). **Trivial one-liners and official Actions usage stay inline.** See `.github/scripts/README.md` for the module + env-contract inventory.
-- **No raw SQL strings — typed chsql API only.** Use `internal/chsql.Builder` / `chsql.QueryBuilder` — the custom CH-flavored builder API. Compose clauses via typed `QueryBuilder` slots (`.Select` / `.From` / `.Where` / `.GroupBy` / `.OrderBy` / `.Limit` / `.Prewhere` / `.Join` / `.WithRecursive`) and expressions via typed Frags (`Eq` / `And` / `Or` / `Paren` / `Cast` / `In` / `Like` / `Add` / `Call` / `Array` / `Subscript` / `If` / `Lambda1` / `Subquery` / `BareIdent` / `InlineLit` / etc.). The typed-Frag surface is closed by construction: external packages cannot raw-write SQL. Add new typed constructors when a shape isn't covered; never compose SQL via string concatenation. Reviewer discipline + the typed API are the enforcement.
-  - **CI catches the token-writing primitives; reviewer discipline catches the semantic shape.** The `.github/scripts/forbid-sql-raw.mjs` gate (wired into CI and lefthook pre-push) scans `internal/chsql/` for raw token writes outside the known-good layer and fails the build if any appear. Writing SQL tokens into a `strings.Builder` (`b.sb.Write*`), `b.writeSQL(...)`, `fmt.Sprintf` of SQL, or `+`-concatenating SQL is **forbidden EVERYWHERE EXCEPT the Frag-primitive constructors in `internal/chsql/builder.go`** (`Call` / `binOp` / `Cast` / `Paren` / `InlineLit` / the QueryBuilder clause renderer — these *implement* the typed surface, so they legitimately write tokens). The domain emitters (`range_window.go`, `absent_over_time.go`, `range_lwr.go`, `emit_node.go`, `histogram_over_time.go`, `range_bucket_fanout.go`, `metrics_compare.go`, `histogram_quantile*.go`, `vector_join.go`, `structural_join.go`, …) build query/expression SHAPES and MUST compose Frags — any CH function is `Call("fn", args…)`, arithmetic is `Mul/Add/Sub/Div/Mod/Neg`, comparisons are `Lt/Gt/Eq/…`, lambdas are `Lambda1/Lambda2` with `BareIdent("i")` params. `verbatim(...)` is reserved for emitter-chosen synthetic tokens (alias names, pre-quoted literals, pre-rendered subquery SQL) — never for whole expression shapes.
-  - **Self-check before any chsql change:** `node .github/scripts/forbid-sql-raw.mjs` (run from the repo root) reports any raw token write outside `builder.go`, `emit_node.go`, and `emit.go`. The pre-push hook runs the same script automatically. If you need to inspect the allowlist manually: `grep -rn 'sb.Write\|writeSQL\|strings.Builder' internal/chsql/ | grep -v builder.go | grep -v _test.go` should surface nothing but the pre-rendered-subquery splice in `emit_node.go` (`subqueryFrag`), the emitter's own output-buffer field in `emit.go`, and the regex escaper `regexQuoteMeta`. A non-empty list anywhere else is a regression — recompose it as Frags.
-  - **Before/after** (the `epochAlignedEndFrag` / `durationToStart` shape): raw `b.sb.WriteString("fromUnixTimestamp64Nano(intDiv(toUnixTimestamp64Nano("); end(b); b.sb.WriteString(") / step) * step)")` → `Call("fromUnixTimestamp64Nano", Mul(Call("intDiv", Call("toUnixTimestamp64Nano", end), step), step))`. `Call`/binOp add no parens and `InlineLit(int64)` emits the bare integer, so the typed form is byte-identical to the hand-rolled string — regenerate goldens and confirm zero churn.
-- **No `unsafe.Pointer` / `reflect.FieldByName` against upstream parser internals — fork + accessors instead.** Cerberus's `internal/**` packages must never reach into unexported fields of `prometheus`, `loki`, or `tempo` parser ASTs via `unsafe.Pointer` or `reflect.Value.FieldByName`. When a parser doesn't expose what cerberus needs, add the accessor to the relevant `tsouza/*:cerberus-*` fork (see `docs/upstream-forks.md`), bump the `replace` in `go.mod`, and consume the typed accessor. The `forbidigo` linter enforces both patterns project-wide across `internal/**` (see `.golangci.yml`); the gate started life scoped to `internal/traceql/` + `internal/api/tempo/` (the original shim sites) and was widened to all of `internal/` as forward-looking hygiene — zero current violations exist, the gate exists to keep it that way.
-- **No magic constants.** A meaning-bearing numeric literal sitting inline — `x + 5_000_000_000`, `n > 200`, `now64(9)` — must be lifted to a named `const` with a short name that *is* the explanation. The name carries the meaning; ideally no comment block is needed at all (one terse line max if the value's rationale isn't obvious from the name). If you can't find a short, honest name for the number, that's the signal it's probably wrong or unnecessary — stop and rethink, don't paper over it with a comment. Out of scope: self-evident `+1`/`-1` (next index / 1-based / grid-anchor count), trivial `0`/`1`/`2` loop bounds, slice-capacity hints (`make([]T, 0, 64)`), and literals already named. Before/after: `if n > 200 { n = 200 }` → `const maxSearchRecentLimit = 200` then `if n > maxSearchRecentLimit { … }`.
-- **Subagent worktree isolation — stay in your assigned path.** When the harness dispatches you with an isolated worktree under `.claude/worktrees/agent-<id>/`, every git / filesystem operation you make MUST happen inside that path. **Never `cd /home/thiago/workspace/cerberus`** (or any other cerberus checkout) — the main checkout shares the same `.git` object store but is on a different branch, so a `git commit` or `git checkout` run from there will land your work on whichever branch another concurrent agent has checked out (see "Why this is a hard rule" below). Use the worktree path the runtime gave you verbatim: pass absolute paths to `Bash`, `Read`, `Write`, and `Edit` calls (or `cd` once at the top of a compound command). If a tool call resets cwd between invocations, re-anchor with an absolute path every time — don't trust the inherited cwd. See [Subagent worktree isolation](#subagent-worktree-isolation) for the recovery procedure if you suspect contamination has already happened.
+## Build and test commands
 
-## Architecture map
+`just` is the canonical task runner and lists every recipe. Never reach for a bare `go test ./...`
+when a recipe exists — the recipe sets the race flag, the cover profile, the build tags and the
+toolchain.
 
-```text
-internal/
-  api/{prom,loki,tempo}/    HTTP handlers per upstream API
-  promql/, logql/, traceql/ three heads: parse + lower
-  chplan/                    shared plan IR (Scan, Filter, Project, Aggregate, RangeWindow, Limit + Expr tree)
-  optimizer/                 rule-based, fixpoint driver. Pattern API + analyzer/optimizer rule split; transposes + PREWHERE promotion + late materialisation.
-  chsql/                     plan → ClickHouse SQL emitter
-  chclient/                  CH driver wrapper (clickhouse-go/v2)
-  schema/                    OTel-CH default + override config
-  config/                    runtime config (`cerberus.yaml` + `CERBERUS_*` env, env wins)
-cmd/cerberus/                main entrypoint
-test/spec/                   TXTAR golden tests (input QL → SQL/plan + `-- chplan --` IR snapshots + optional `-- seed --` / `-- expected_rows --` chDB roundtrip). `test/spec/chplan_print.go` is the deterministic IR pretty-printer used by Layer 2a snapshots.
-test/property/               oracle-based property tests (`pgregory.net/rapid` shrinking + chDB execution); `gen/` random data + query generators; `oracle/` from-scratch evaluator.
-test/regression/             meta-tests that pin past CI failures so they can't silently recur — goleak detectors across every handler entrypoint (added by #253), justfile-shape pins, seed-program invariants.
-test/e2e/                    k3d cluster + Grafana playwright smoke
-test/e2e/{k3s,grafana}/      k3d manifests + Grafana provisioning (datasources, dashboards) consumed by the smoke
-compatibility/prometheus/    prometheus/compliance Docker Compose harness — PromQL differential testing
-compatibility/loki/          LogQL differential harness vs reference Loki + vendored `grafana/loki:pkg/logql/bench` corpus
-compatibility/tempo/         TraceQL differential harness vs reference Tempo + vendored `cmd/tempo-vulture` / `pkg/httpclient` snapshot
-docs/                        engine.md, compatibility.md, test-strategy.md, observability.md, operations.md, upstream-forks.md, health.md, …
-```
+- `just` — list every recipe.
+- `just ci` — the CI entry point: `lint` + `test` + `build`.
+- `just test` — `test-unit` (race-detected unit + spec suite) plus `vet-tagged`.
+- `just test-unit` — `go test -race ./...`.
+- `just vet-tagged` — type-check the build-tagged migration lanes no other recipe compiles.
+- `just build` — build cerberus into `./bin`.
+- `just lint` — `golangci-lint run` over both the untagged and the tagged build configurations.
+- `just lint-actions` — `actionlint` over the workflow files.
+- `just lint-md` / `just fmt-md` — markdownlint-cli2 verify / auto-fix.
+- `just fmt` — `gofumpt` + `goimports -local` over the tree.
+- `just update-golden` — regenerate every generated artefact (see invariant 9).
+- `just coverage` — coverage profile + floor check.
+- `just property` — rapid-based property tests (needs chDB).
+- `just mutate` / `just mutate-pkg PATH` — gremlins mutation run.
+- `just chdb-install` — install `libchdb.so`, required by every chdb-tagged lane.
+- `just hooks-install` — one-shot after clone: install lefthook and activate the git hooks.
+- `just e2e` — full k3d + Grafana + Playwright smoke.
+- `just e2e-up` / `e2e-seed` / `e2e-run` / `e2e-down` — the e2e lane, one step at a time.
+- `just compat-promql` / `compat-logql` / `compat-traceql` / `compat-all` — differential harnesses
+  against the reference backends.
+- `just migration-tier1` / `migration-tier2` — the migration lane tiers.
+- `just deps-tidy` — `go mod tidy`.
 
-See [`docs/test-strategy.md`](docs/test-strategy.md) for the canonical 14-layer test map, the CI-gate inventory, the gremlins phased rollout, and the property-test phase plan.
+## Architecture decision tree
 
-Top-level reading order for any new contributor (human or agent):
+Where a change belongs, by the question it answers:
 
-1. `README.md` — what the project is, quick start.
-2. `docs/engine.md` — shared query pipeline (`internal/engine/`), the `Lang` contract, and the extension points each new head plugs into.
-3. `docs/operations.md` — runtime contract: configuration, lifecycle, scaling.
-4. `docs/test-strategy.md` — 14-layer test map + CI gate inventory.
-5. `internal/promql/lower.go` — the canonical lowering pattern; mirror it when adding LogQL / TraceQL slices.
+- **"The query language parses or rejects the wrong thing"** → `internal/promql/`,
+  `internal/logql/`, `internal/traceql/`. PromQL uses the upstream parser; LogQL parses in
+  `internal/logql/lsyntax` (with `internal/logql/logpattern` and `internal/drain`); TraceQL parses
+  in `internal/traceql/ast`.
+- **"The query lowers to the wrong plan"** → the same three packages' `lower.go`.
+  `internal/promql/lower.go` is the canonical pattern; mirror it for the other two heads.
+- **"The plan IR cannot express this"** → `internal/chplan/` (`Scan`, `Filter`, `Project`,
+  `Aggregate`, `RangeWindow`, `Limit`, and the `Expr` tree). Shared by all three heads.
+- **"The plan is correct but slow"** → `internal/optimizer/`, a rule-based fixpoint driver with a
+  Pattern API and an analyzer/optimizer rule split (transposes, PREWHERE promotion, late
+  materialisation).
+- **"The SQL is wrong"** → `internal/chsql/`, the plan → ClickHouse SQL emitter. Typed Frags only
+  (invariant 10).
+- **"The HTTP response shape is wrong"** → `internal/api/prom/`, `internal/api/loki/`,
+  `internal/api/tempo/`.
+- **"It talks to ClickHouse wrong"** → `internal/chclient/` (clickhouse-go/v2 wrapper).
+- **"The table or column layout is wrong"** → `internal/schema/` (OTel-CH default + override config).
+- **"A configuration knob is missing"** → `internal/config/` (`cerberus.yaml` + `CERBERUS_*` env,
+  env wins).
+- **Entrypoint** → `cmd/cerberus/`.
+
+Test layers, by what they pin:
+
+- `test/spec/` — TXTAR goldens: input QL → SQL, `-- chplan --` IR snapshots, optional `-- seed --` /
+  `-- expected_rows --` chDB roundtrip. The promql spec lane runs **pre-optimizer**, so an optimizer
+  rule is verified through the optimizer's own layer, not here.
+- `test/property/` — oracle-based property tests (`pgregory.net/rapid` + chDB execution).
+- `test/regression/` — meta-tests pinning past CI failures so they cannot silently recur.
+- `test/e2e/` — k3d cluster + Grafana Playwright smoke.
+- `compatibility/{prometheus,loki,tempo}/` — differential harnesses against the reference backends.
+
+`docs/test-strategy.md` holds the canonical 14-layer test map, the CI-gate inventory, and the
+per-layer "catches X / misses Y" guidance.
+
+## Hard invariants (non-negotiable)
+
+1. **PR-per-change.** Branch protection rejects direct pushes to `main` and requires a large set of
+   status checks. The source of truth for that set is
+   `gh api repos/tsouza/cerberus/branches/main/protection --jq '.required_status_checks.contexts[]'`;
+   `docs/test-strategy.md` is the per-gate reference. **Never `gh pr merge --admin`** — if a required
+   check is red, fix the code or fix the workflow. Ship with
+   `gh pr merge --squash --delete-branch`.
+2. **A pushed branch gets a PR in the same breath.** The push and the `gh pr create` are one step. A
+   branch with no PR is invisible: no gate reports on it, no reviewer sees it, and its commits get
+   stranded. "Not ready to review" is a reason to open the PR as a draft, never a reason to skip it.
+   Branch off the current `origin/main`, never off another in-flight branch, and never push to the
+   head branch of a PR that has already merged.
+3. **Out-of-scope work becomes a GitHub Issue, filed before the PR that found it merges.** A sentence
+   in a PR body is not a resting place — it is invisible the moment the PR merges. Verify the finding
+   first; a phantom issue is as bad as a dropped one. The required `forbid-deferral` check
+   (`.github/scripts/forbid-deferral.mjs`) scans a change's own additions — its description, the
+   commit messages in its range, and the `+` lines of its diff — and fails unless each deferral
+   marker cites an issue in this repository that is open and is an issue rather than a pull request.
+   There is no tolerance file and no exemption list.
+4. **Conventional Commits**, enforced by `commitlint` (`.commitlintrc.json`). Subject ≤ 100
+   characters.
+5. **No manual pre-flight; lefthook + CI own it.** Do not run `just test`, `just lint`, `go test`,
+   `golangci-lint run`, `go build`, or `markdownlint-cli2` by hand before pushing. `lefthook.yml` is
+   layered: `pre-commit` runs sub-second formatters on staged files, `commit-msg` runs commitlint,
+   and `pre-push` mirrors the CI `check` + `lint` + `forbid-skip` jobs. `LEFTHOOK=0 git push`
+   bypasses for WIP branches. CI runs the full suite plus the compat / e2e / mutation lanes the local
+   hook intentionally does not.
+6. **Tests assert or are removed.** Never `t.Skip`, soft-assert, silent-recover, or `should_skip` a
+   test. A feature that cannot run on the CI substrate (for example a CH function above the chDB
+   floor) is gated at runtime and validated elsewhere, never skipped. `forbid-skip` enforces this
+   behaviourally.
+7. **No allow-lists, no tolerance files, no expected-failure sets.** Compatibility is the source of
+   truth for all three heads, and every diff against a reference backend is a real bug to fix at the
+   source. The single pinned exclusion set is `compatibility/loki/upstream-skip-baseline.txt` — the
+   corpus entries upstream itself marks `skip: true`, for which no reference baseline exists — and
+   the harness fails on any drift in it.
+8. **"Pre-existing" is not an escape hatch.** Diagnosing a bug as pre-existing routes *which*
+   branch or PR fixes it; it never decides *whether* it gets fixed. The same applies to "adjacent"
+   and "out of scope". Never label a real failure a flake without evidence and a fix.
+9. **Never hand-edit a generated artefact — regenerate it.** `just update-golden` rewrites the TXTAR
+   goldens, the migration goldens, the solver decision baseline, the parity ledgers, and the
+   cardinality baseline. It needs `libchdb.so` (`just chdb-install`), without which the chdb-tagged
+   `-- expected_rows --` cells go stale. Every generated path is marked `-merge` in `.gitattributes`
+   precisely because line-merging one produces a file that still parses and is silently wrong.
+   Review `git diff test/spec/ test/e2e/migration/archetypes/ test/perf/ test/surface-parity/
+   test/rejection-parity/` before committing. A few ledgers sit outside `update-golden` because they
+   need Docker or the `agpl_oracle` tag; the recipe's own comments name each one and its regeneration
+   command.
+10. **No raw SQL strings — typed chsql API only.** Compose clauses via `chsql.QueryBuilder` slots and
+    expressions via typed Frags (`Eq` / `And` / `Call` / `Cast` / `Lambda1` / `Subquery` /
+    `InlineLit` and friends). Any CH function is `Call("fn", args…)`; arithmetic is
+    `Mul/Add/Sub/Div/Mod/Neg`. Writing SQL tokens into a `strings.Builder`, through `writeSQL(...)`,
+    through `fmt.Sprintf`, or by `+`-concatenation is forbidden everywhere except the Frag-primitive
+    constructors in `internal/chsql/builder.go`. `verbatim(...)` is for emitter-chosen synthetic
+    tokens (alias names, pre-quoted literals, pre-rendered subquery SQL), never for whole expression
+    shapes. Self-check before any chsql change: `node .github/scripts/forbid-sql-raw.mjs` from the
+    repo root. CI catches the token-writing primitives; reviewer discipline catches the semantic
+    shape.
+11. **No `unsafe.Pointer` / `reflect.FieldByName` against upstream parser internals.** When a parser
+    does not expose what cerberus needs, add the accessor to the relevant `tsouza/*:cerberus-*` fork
+    (`docs/upstream-forks.md`), bump the `replace` in `go.mod`, and consume the typed accessor. The
+    `forbidigo` linter enforces both patterns across all of `internal/**`.
+12. **No caching of query results.** Cerberus never caches the answer to a query. Internal
+    performance caches are acceptable only where staleness is proven output-safe.
+13. **No magic constants.** A meaning-bearing numeric literal must be a named `const` whose name *is*
+    the explanation: `if n > 200` becomes `const maxSearchRecentLimit = 200`. If no short honest name
+    fits, the number is probably wrong. Out of scope: self-evident `+1` / `-1`, trivial `0` / `1` /
+    `2` loop bounds, and slice-capacity hints.
+14. **No AGPL in the binary.** The upstream LogQL and TraceQL parsers are AGPLv3; the in-house
+    reimplementations exist so the Apache-2.0 binary never links them. They survive only as
+    test-only oracles behind the `agpl_oracle` build tag, quarantined in the `test/oracle` nested
+    module. The `agpl-clean` gate fails the build if any AGPL package reaches `cmd/cerberus`.
+15. **Non-trivial CI step logic lives in `.github/scripts/*.mjs`, not inline YAML.**
+    Dependency-light Node ESM, `node:` builtins only, env-driven inputs documented at the top of the
+    file, `::error::` / `::notice::` workflow commands, and `process.exit(1)` on failure. Trivial
+    one-liners and official Actions usage stay inline. See `.github/scripts/README.md`.
+16. **A new `internal/**` package must be declared in `.go-arch-lint.yml`.** The gate is CI-only, so
+    an undeclared package passes locally and fails on the PR.
+17. **Subagent worktree isolation.** Every git and filesystem operation happens inside the assigned
+    worktree path, passed absolutely on every call. Never operate on another checkout of this
+    repository — the object store is shared but the branch is not, so a stray `git commit` lands on
+    somebody else's branch. `docs/agent-workflow.md` has the recovery procedure.
+
+## Workflow for a non-trivial change
+
+Plan first, code last. Plan mode → requirements interview → a spec at `docs/specs/<feature>.md` → a
+numbered task list for owner review → only then implementation. Trivial changes (a typo, a one-line
+fix with an obvious test) skip straight to the PR. `docs/agent-workflow.md` describes each stage and
+what a spec must contain.
 
 ## Common workflows
 
-- **Add a TXTAR fixture** — use the `/cerberus:add-fixture` skill (under `.claude/skills/`). It creates `test/spec/<ql>/<name>.txtar` with the right section headers (`-- input --`, `-- sql --`, `-- chplan --`, optional `-- seed --` / `-- expected_rows --`); run `just update-golden` after the implementation lands to fill in expected sections — it covers both the default-tag text goldens and the chdb-tagged `-- expected_rows --` cells (requires libchdb.so via `just chdb-install`).
-- **Add an optimizer rule** — use the `/cerberus:add-optimizer-rule` skill. Scaffolds `internal/optimizer/<name>.go` + test + TXTAR fixtures.
-- **Add a property test** — add a row to the generator + oracle under `test/property/{gen,oracle}/` and a case to `test/property/promql_test.go`. The framework wires `rapid.Check` → dataset gen → chDB exec → oracle → comparator; you only swap the data shape + oracle. Build-tagged `chdb`; runs in the `chdb` workflow only.
-- **Bump parser deps** — use the `/cerberus:bump-parser-deps` skill. Runs `go get -u` on the three upstream parsers, runs `go mod tidy`, captures the diff for the PR description.
+- **Add a TXTAR fixture** — `.claude/skills/cerberus-add-fixture.md`. Creates
+  `test/spec/<ql>/<name>.txtar` with the right section headers; run `just update-golden` once the
+  implementation lands to fill in the expected sections.
+- **Add an optimizer rule** — `.claude/skills/cerberus-add-optimizer-rule.md`. Scaffolds
+  `internal/optimizer/<name>.go` plus its test and fixtures.
+- **Add a property test** — add a row to `test/property/{gen,oracle}/` and a case to
+  `test/property/promql_test.go`. Build-tagged `chdb`.
+- **Bump parser deps** — `.claude/skills/cerberus-bump-parser-deps.md`.
 - **Run E2E locally** — `just e2e-up && just e2e-seed && just e2e-run && just e2e-down`.
-- **Run the compatibility suite** — `just compat-promql`. Diffs cerberus against reference Prometheus on a deterministic OTel fixture.
-- **Find which test layer covers a class of bug** — see [`docs/test-strategy.md`](docs/test-strategy.md) for the layer map + per-layer "catches X / misses Y" guidance.
+- **Run a compatibility suite** — `just compat-promql` (or `compat-logql` / `compat-traceql`).
 
-## Toolchain notes
+## Reference docs
 
-- **Go version** — `go.mod` may pin a newer Go than what's installed system-wide. `GOTOOLCHAIN=auto` (the default) silently downloads the right version into `~/go/pkg/mod/golang.org/toolchain@...`. The `.envrc` (loaded by `direnv allow`) puts both the system Go and the downloaded toolchains on PATH.
-- **CGO** — left at the platform default so `go test -race` works. Goreleaser pins `CGO_ENABLED=0` for release builds independently.
-- **`golangci-lint` v2** — the config in `.golangci.yml` uses the v2 schema. `gofumpt` + `goimports` are configured under `formatters`, not `linters`. The v2 install path is `github.com/golangci/golangci-lint/v2/cmd/golangci-lint` (note the `/v2/`).
+Read these when the task touches them. They are deliberately linked as paths rather than imported,
+so they cost nothing until something needs them.
 
-## Parser deps — in-house LogQL/TraceQL, two upstream forks for the rest
-
-Cerberus parses its three query languages with a mix of an upstream parser and two in-house ones, and links **no AGPL code** into `cmd/cerberus`:
-
-- **PromQL** — the upstream Apache `prometheus/promql/parser`, consumed through the `tsouza/prometheus` fork (a pure Dependabot watch boundary, zero patches).
-- **LogQL** — cerberus's own clean-room Apache reimplementation: `internal/logql/lsyntax` (parser), `internal/logql/logpattern` (`pattern` parser), `internal/drain` (Drain miner). No upstream parser dep.
-- **TraceQL** — cerberus's own clean-room Apache reimplementation: `internal/traceql/ast`. No upstream parser dep.
-
-The upstream **LogQL** (`grafana/loki/v3/pkg/logql`) and **TraceQL** (`grafana/tempo/pkg/traceql`) parsers are **AGPLv3**; the in-house reimplementations exist so the Apache-2.0 binary never links them. They survive only as test-only oracles (`agpl_oracle`-tagged tests + the `compatibility/{loki,tempo}` harnesses), quarantined in the `test/oracle` nested module. The `agpl-clean` CI gate (`.github/scripts/agpl-clean.mjs`) fails the build if any AGPL package reaches `cmd/cerberus`; it is enforcing. The binary does link the **Apache** `grafana/tempo/pkg/tempopb` wire types.
-
-Two `go.mod` deps still route through `github.com/tsouza/*` forks pinned to **semver tags** (not pseudo-versions); `grafana/loki/v3` and `grafana/tempo` are now plain upstream requires (no fork):
-
-```text
-replace github.com/prometheus/prometheus                                                       => github.com/tsouza/prometheus                                                       v0.0.1-cerberus-parser
-replace github.com/open-telemetry/opentelemetry-collector-contrib/exporter/clickhouseexporter  => github.com/tsouza/opentelemetry-collector-contrib/exporter/clickhouseexporter      v0.0.3-cerberus-ddl
-# (plus three sibling submodule replaces under the same fork)
-```
-
-The fork repos exist primarily as a **Dependabot watch boundary**: cerberus consumes only a narrow subtree of each upstream, so we don't want a Dependabot PR every time upstream cuts a release. Instead, [`tsouza/cerberus-forks-monitor`](https://github.com/tsouza/cerberus-forks-monitor) runs a daily cron that rebases each `cerberus-*` branch onto `upstream/main`, runs subtree tests, and **only mints a new patch tag if commits touched the watched paths**. Dependabot in cerberus then sees a clean stream of "this is a change cerberus actually cares about" tags. See [`docs/upstream-forks.md`](docs/upstream-forks.md) for the full flow.
-
-- **`tsouza/opentelemetry-collector-contrib:cerberus-ddl`** carries the one real patch — it hoists the `sqltemplates` package out of `internal/` so cerberus's `internal/schema/ddl/` can consume the OTel-CH exporter's DDL templates directly.
-- **`tsouza/prometheus:cerberus-parser`** is unpatched — it exists solely as the Dependabot boundary.
-
-The `tsouza/loki` and `tsouza/tempo` parser forks were **retired** when the in-house parsers landed; `go.mod` no longer references them.
-
-## Tooling fork — gremlins (mutation testing)
-
-`mutation.yml` consumes the **`tsouza/gremlins`** fork (installed via `go install github.com/tsouza/gremlins/cmd/gremlins@v0.6.0-cerberus-timeout-max-consume`) instead of upstream `go-gremlins/gremlins@v0.6.0`. The fork carries two fixes on top of `v0.6.0`, both of which exist because a mutation run that dies mid-flight is worse than one that reports a bad number — it reports *nothing*.
-
-**Fix 1 — `--on-shutdown-status` (cancelled-in-flight mutants).** Upstream's signal handler closes the channel that `os/signal` still writes to, so a second signal (typical CI runner sequence: SIGTERM → SIGKILL) panics with `send on closed channel` from `signal.process`. Worse, mutants whose `go test` subprocess is still running at cancellation time fall through `runTests` to the default `return mutator.Lived` branch (the per-test ctx is rooted in `context.Background()`, so only `DeadlineExceeded` is checked). The result on cerberus PR #664 / push-to-main run 26213450154: four untested mutants recorded as LIVED, deflating `test_efficacy`. The fork fixes both: the signal handler no longer self-closes, and the executor threads the engine's run ctx into the per-test ctx so cancelled-in-flight mutants are reported with the status from the new `--on-shutdown-status` flag. Cerberus passes `--on-shutdown-status=not-run` so those mutants land in `NOT_COVERED`, outside the `KILLED / (KILLED + LIVED)` efficacy formula entirely. Upstream PR: <https://github.com/go-gremlins/gremlins/pull/283>.
-
-**Fix 2 — `--timeout-max` (runaway mutants that kill the runner).** Upstream derives a mutant's test timeout as `timeout-coefficient × the package's baseline test duration`, which scales the leash by how *slow* a package's tests are — a quantity unrelated to how much damage a runaway mutant does in that time. A mutant that inverts a scanner's loop-advance (`i++` → `i--`) never terminates and allocates per iteration, so on a slow-baseline package it gets minutes to exhaust the runner's memory; the OOM killer then reaps the runner agent and the job dies with **no verdict at all**. Measured over 91 heavy runs on 2026-07-26: 55 of 55 runner deaths were stalled on a lexer/scanner mutant, and the worst leg failed 4 of its last 13 runs. `--timeout-max` is an absolute ceiling that bounds exposure independently of the baseline; cerberus passes `--timeout-max 15s`.
-
-Do **not** treat a recurrence as "exclude the file the log names" — excluding a file relocates its runaway mutants into whichever leg still owns it *and* burns real mutation coverage. `test/regression/mutation_timeout_max_test.go` pins the flag and the fork tag together, because the failure mode it prevents presents as flake rather than as a missing bound.
-
-The fork ships two parallel branches/tags by design:
-
-- **`cerberus-sigterm-fix` @ `v0.6.0-cerberus-timeout-max`** — the branch the upstream PR is built from. Keeps the upstream module path `github.com/go-gremlins/gremlins` so the diff stays clean and reviewable.
-- **`cerberus-sigterm-fix-consume` @ `v0.6.0-cerberus-timeout-max-consume`** — the branch cerberus's `mutation.yml` installs. Adds a single extra commit that renames the `go.mod` module path to `github.com/tsouza/gremlins` (and rewrites all internal imports), because `go install github.com/tsouza/gremlins/cmd/gremlins@...` rejects the module otherwise with `module declares its path as: github.com/go-gremlins/gremlins`. The fixes themselves are identical to the upstream-PR branch.
-
-Unlike the two upstream-dep forks, this one is not on the Dependabot-watch flow — it's a build-time tool, not a Go module dep, and both branches will be retired once the upstream PR lands and a release tag is cut.
-
-## Transitive-dep gotcha (the one that bit us)
-
-`go.mod` has this entry:
-
-```text
-replace github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-0.20260410131411-8c2f3bdae9db
-```
-
-Grafana's Loki, Tempo, and `dskit` all use a forked memberlist internally (via their own `replace` directives). Those replaces **do not propagate** to consumers. Without our own replace, the build fails with `undefined: memberlist.NodeState`, `mlCfg.NodeSelection`, `mlCfg.PushPullNodes` from `dskit/kv/memberlist`. If you bump Loki / Tempo and the build breaks here, check whether they've updated their pinned memberlist version and bump ours in lock-step.
-
-## Pointers if you're lost
-
-- "How does this PR ship?" → branch + push + `gh pr create` → CI must pass → squash-merge with `gh pr merge --squash --delete-branch`.
-- "How are releases cut / which lines are still supported?" → `docs/operations.md` → "Release ritual (the ordered cycle)" (the canonical six-step cycle: merge everything → backport everything to every line that stays supported → settle the retirement set → audit the delta → publish backport patches → publish the head release last) + "Release pipeline (publish-on-merge)" + "Release support window / EOL policy" (latest 3 minor lines; older lines are EOL — branch deleted, no hotfixes, tags/Releases retained; enforced in `release-preflight.mjs`).
-- "Where do I add this feature?" → match the layer to the head: `internal/{promql,logql,traceql}/` for parse + lowering, `internal/chplan/` for the shared IR, `internal/optimizer/` for rewrites, `internal/chsql/` for SQL emission, `internal/api/{prom,loki,tempo}/` for HTTP handlers. Fixtures live in `test/spec/<head>/`.
-- "Where does work that isn't this PR's job get tracked?" → a GitHub issue, filed before this PR merges. Not a sentence in the PR body, not a doc note, not a Project board.
-
-## Subagent worktree isolation
-
-The dispatcher gives every subagent its own worktree under `.claude/worktrees/agent-<id>/`, on its own per-agent branch (typically `worktree-agent-<id>` or a task-specific branch you create off `origin/main`). The main checkout at `/home/thiago/workspace/cerberus` is itself a worktree of the same repo — it shares the `.git` object DB but is on whatever branch the maintainer last had checked out (often the most recent task branch — `git worktree list` showed e.g. `fix/tempo-search-traceid-zero-pad-emit` while three different subagents were running concurrently on unrelated tasks).
-
-### Why this is a hard rule
-
-Three separate post-mortems (issues #207, #209, #210) reported the same shape: an agent doing work in its isolation worktree somehow saw commits land on the main checkout's branch, or saw an unrelated branch's commits show up in their tree. The investigation under task #213 traced the root cause to subagents using `/home/thiago/workspace/cerberus` (the main checkout path) for git / file operations — the path their briefing pasted in as "the cerberus repo" — instead of their assigned `.claude/worktrees/agent-<id>/` path. When two agents both ran `git commit` from the main checkout, their commits stacked onto whichever branch was currently checked out there, contaminating an unrelated PR. The same root cause hits `Edit` and `Write` tool calls — if you pass `/home/thiago/workspace/cerberus/<file>` as `file_path`, the edit lands in the main checkout's working tree, not your worktree's.
-
-Git's worktree machinery itself does protect against the obvious failure modes — the same branch can't be checked out in two worktrees, and each worktree has its own `.git/worktrees/<id>/HEAD` ref — but **none of that helps if you run git from the wrong path.** The protection is path-based, not agent-based.
-
-### Recovery procedure (if contamination is suspected)
-
-1. `cd` into your assigned worktree path (`/home/thiago/workspace/cerberus/.claude/worktrees/agent-<your-id>/`).
-2. `git worktree list` — verify your worktree shows up with the expected branch name. If it doesn't, you have been operating in the wrong tree the whole time.
-3. From your assigned worktree, run `git log --oneline origin/main..HEAD` and compare against the work you actually did. Any commit you don't recognize is contamination.
-4. From the main checkout (`/home/thiago/workspace/cerberus`), run `git status` and `git log --oneline` on whichever branch is checked out there. Uncommitted edits or commits you authored that don't belong to that branch's PR are the bleed-through.
-5. If the bleed-through is uncommitted: from the main checkout, `git checkout -- <files>` to revert (only when you are certain nothing else is in flight there — when in doubt, ask the maintainer rather than `git checkout --` a shared tree). Then re-apply the change in the correct worktree using the correct absolute path.
-6. If the bleed-through is committed: cherry-pick contaminated commits onto the correct branch (`git cherry-pick <sha>` from inside the right worktree), then revert them from the wrong one (`git revert <sha>` + push). Don't `git reset --hard` a shared branch — that rewrites history other agents may have pushed.
-7. Open a follow-up note on task #213 with the contamination SHAs / file paths + which worktree paths were involved, so the pattern doesn't repeat silently.
-
-### Defence-in-depth (future work)
-
-Documentation is the cheapest fix and the one this section implements. A more durable option is for the dispatcher to use `git worktree add --detach .claude/worktrees/agent-<id>` then have the subagent create its own branch — that way no branch is shared between the main checkout and any worktree, and a stray `git commit` from the wrong path lands on a detached HEAD that's trivially recoverable. That structural change is tracked separately; until it lands, the rule above is the gate.
+- `docs/engine.md` — the shared query pipeline, the `Lang` contract, and the extension points a new
+  head plugs into.
+- `docs/test-strategy.md` — the 14-layer test map, the CI-gate inventory, the gremlins rollout.
+- `docs/operations.md` — runtime contract, configuration, lifecycle, scaling, the release ritual, and
+  the support window.
+- `docs/compatibility.md` — the three differential harnesses and their ratchets.
+- `docs/agent-workflow.md` — the PR ritual in detail, the deferral-to-issue rule, worktree isolation
+  and its recovery procedure, the plan-mode / spec workflow, and the checked-in Claude Code harness
+  (hooks and project subagents).
+- `docs/toolchain.md` — Go toolchain, CGO, golangci-lint v2, the gremlins mutation-testing fork, and
+  the dependency gotchas.
+- `docs/upstream-forks.md` — the `tsouza/*` fork boundary, the parser dependency map, and the
+  transitive-dependency `replace` entries.
+- `docs/observability.md`, `docs/health.md`, `docs/performance.md`, `docs/solver.md`,
+  `docs/coverage.md`, `docs/forbid-skip.md`, `docs/migration.md` — subsystem references.

--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -1,0 +1,190 @@
+# Agent workflow
+
+How a change gets from an idea to a merged PR, and the harness that enforces it. `CLAUDE.md` states
+the invariants in one line each; this document holds the mechanics behind them.
+
+## The change lifecycle
+
+A non-trivial change runs through five stages in order. A trivial change — a typo, a comment, a
+one-line fix with an obvious test — goes straight to the PR.
+
+1. **Plan mode.** Read before writing. Establish where the change belongs using the architecture
+   decision tree in `CLAUDE.md`, and which test layer will pin it using `docs/test-strategy.md`.
+   Produce no edits at this stage.
+2. **Requirements interview.** Resolve the ambiguities that would otherwise be resolved silently at
+   implementation time: which of the three heads is in scope, what the reference backend answers
+   today, whether the change is observable on the wire or only in the plan, and which generated
+   artefacts will need regenerating. When the answer is unavailable — an agent running unattended,
+   for instance — make the call, state it explicitly, and continue rather than blocking.
+3. **Spec at `docs/specs/<feature>.md`.** One file per change, named for the change rather than the
+   issue number so it stays readable. A spec states, in this order: the problem with evidence (file
+   and line, or the reference backend's answer next to cerberus's); the scope boundary, meaning both
+   what is included and what is explicitly not; the design, at the level of which packages gain which
+   behaviour; the verification plan naming the specific test layers and files; and the risks. A spec
+   that cannot name its verification layer is not finished.
+4. **Numbered task list for owner review.** Each task independently reviewable, ordered so the tree
+   is green between any two of them, with its verification named. This is the artefact the owner
+   approves; approval of the spec is not approval of the task list.
+5. **Implementation.** One PR per coherent change, following the shipping ritual below.
+
+Specs are living documents while the change is in flight and archival once it merges. They record the
+decision, not the history of arriving at it.
+
+## Shipping ritual
+
+Branch off the current `origin/main`. Never branch off another in-flight branch: if that parent
+squash-merges while the work proceeds, the base no longer exists in `main`'s history and the PR shows
+a doubled diff — every file the parent touched, replayed. The recovery is to cherry-pick onto a fresh
+branch off `origin/main`, so avoid the situation instead. Re-check the base before pushing.
+
+The push and the `gh pr create` are a single step. A pushed branch with no PR appears in no
+`gh pr list`, gets no check runs, and reaches no reviewer; if the work it belongs to merges without
+it, its commits are stranded. A branch that is not ready for review is a draft PR, not an absent one.
+
+Verify the push landed by SHA rather than by the client's own report:
+
+```bash
+rtk proxy git ls-remote origin <branch>
+```
+
+Never push to the head branch of a PR that has already merged. A merged PR is closed: its head stops
+advancing, and the commit reaches no branch anyone reads. Confirm with
+`gh pr view <n> --json state` first; if it has merged, cut a fresh branch off `origin/main`.
+
+Merge with `gh pr merge --squash --delete-branch` once every required check is green. Never
+`gh pr merge --admin`. Branch protection sets `enforce_admins: false`, which makes this policy
+discipline rather than a mechanical block — honour it regardless. A red required check is fixed at
+the code or at the workflow, never bypassed.
+
+A one-commit PR squashes the **commit** subject, not the PR title, so a `chore:` commit under a
+`feat:` PR title lands in the changelog as a chore.
+
+## Required checks and the gate posture
+
+The authoritative list of required contexts is the API, not any document:
+
+```bash
+gh api repos/tsouza/cerberus/branches/main/protection --jq '.required_status_checks.contexts[]'
+```
+
+`docs/test-strategy.md` carries the per-gate reference: what each context proves, what it cannot see,
+and which layer covers the residue. Three postures are worth knowing:
+
+- **PR gates** run on every pull request, the `mutation` lane among them: on a PR it runs the
+  gremlins legs whose scope that PR changed, and sweeps the full matrix on push, nightly, dispatch,
+  and `release/*` PRs.
+- **Release gates** — `compose-smoke`, `dashboard` (k3d + Grafana + Playwright), and `profile` —
+  short-circuit to a green no-op on an ordinary PR and do their real work on the merge commit. They
+  are named in `release.yml`'s `RELEASE_REQUIRED_CHECKS`, so nothing publishes until each posts green
+  on the commit being shipped. `compose-smoke` narrows that short-circuit: it is the only lane that
+  runs against a real ClickHouse server rather than chDB, so a PR touching `internal/chsql`,
+  `internal/api`, `internal/chclient`, or `cmd/cerberus` boots the stack on the PR itself. The scope
+  rule lives in `.github/scripts/compose-smoke-scope.mjs`.
+- **Merge-queue posture.** Every workflow owning a required context also declares `merge_group:`, so
+  the same check runs report under byte-identical names on the projected trunk, and a queued entry is
+  held to the pull-request posture rather than the push posture — same short-circuits, same
+  diff-scoped lane selection, read off the merge group's own `base_sha..head_sha`. `CodeQL` is the
+  one context with no `merge_group` half, because code-scanning default setup dispatches on `push`
+  and `pull_request` only. `test/regression/merge_queue_test.go` pins both invariants, including that
+  no `cancel-in-progress` reachable from a merge-group run can be true: GitHub reads a cancelled
+  check run as a failure and dequeues the PR.
+
+Force-push and deletion are off on `main`, and linear history is off so the GitHub "Update branch"
+button works for stale PRs.
+
+## Work that belongs outside this change
+
+Work that surfaces mid-change and genuinely belongs elsewhere becomes a GitHub Issue, created before
+the PR that found it merges. Prose in a PR body is not a resting place: once the PR merges, the
+sentence appears in no list, no gate reports on it, and nobody is assigned. An Issue stays open until
+someone closes it, which is the point.
+
+Verify the finding before filing — read the function, grep the site. A phantom issue is as costly as
+a dropped one, and a plausible filename is not evidence. Verify negative verdicts to the same
+standard: "this is already fixed, close it" needs the same check at the issue's own cited file and
+line as "this is real" does.
+
+The PR body may reference the issue; it may never substitute for one. Add `Closes #N` when the PR
+actually resolves that issue, and never for issues spun out of the PR's own findings — those stay
+open.
+
+This is enforced, not conventional. The required `forbid-deferral` check
+(`.github/scripts/forbid-deferral.mjs`) scans the change's own additions — the PR description, the
+commit messages in its range, and the `+` lines of its diff — for the marker classes in that module's
+`DEFERRAL_MARKERS` table, and fails unless each match cites an issue in this repository that is open
+and is an issue rather than a pull request. Citation scope follows the author's own structure: a
+marker on a markdown heading is satisfied anywhere in the section that heading introduces, any other
+prose marker is satisfied within its own paragraph, and a marker in the diff is satisfied within a
+fixed line window. The gate deliberately does not scan the tree at large, because the same phrases
+are ordinary architecture prose elsewhere and a gate that fired on those would get routed around.
+There is no tolerance file and no exemption list.
+
+## Worktree isolation
+
+Each agent gets its own worktree and its own branch. Every git and filesystem operation belongs
+inside that path, passed absolutely on every call — `Bash`, `Read`, `Write`, and `Edit` alike. If a
+tool call resets the working directory between invocations, re-anchor with an absolute path rather
+than trusting the inherited one.
+
+The protection git offers is path-based, not agent-based. The same branch cannot be checked out in
+two worktrees, and each worktree has its own `HEAD` ref, but none of that helps when git is run from
+the wrong path. Every checkout of this repository shares one object store while sitting on a
+different branch, so a `git commit` issued from another checkout stacks onto whichever branch that
+checkout happens to have out — somebody else's PR. Three post-mortems (issues #207, #209, and #210)
+report exactly that shape, and the investigation under task #213 traced every one of them to an agent
+using another checkout's path because a briefing had pasted it in as "the repo".
+
+### Recovery when contamination is suspected
+
+1. Return to the assigned worktree path.
+2. `git worktree list` — confirm the worktree appears with the expected branch. If it does not, the
+   work has been happening in the wrong tree from the start.
+3. From the assigned worktree, `git log --oneline origin/main..HEAD`. Any commit that is not
+   recognisable is contamination.
+4. In the other checkout, `git status` and `git log --oneline` on whatever branch it has out.
+   Uncommitted edits or commits authored elsewhere that do not belong to that branch's PR are the
+   bleed-through.
+5. Uncommitted bleed-through: `git checkout -- <files>` there, but only when nothing else is in
+   flight in that tree. When in doubt, ask rather than reverting a shared tree. Re-apply the change
+   in the correct worktree using the correct absolute path.
+6. Committed bleed-through: `git cherry-pick <sha>` from inside the correct worktree, then
+   `git revert <sha>` and push from the wrong one. Never `git reset --hard` a shared branch — that
+   rewrites history other agents may have pushed.
+7. Record the contamination SHAs, file paths, and worktree paths on task #213 so the pattern does not
+   repeat silently.
+
+## The checked-in Claude Code harness
+
+`.claude/` is version-controlled so every agent and contributor gets the same behaviour. Only
+`.claude/settings.local.json` and `.claude/worktrees/` are ignored.
+
+### Hooks (`.claude/settings.json`)
+
+- **PostToolUse on `Edit` / `Write`** runs `.claude/hooks/format-touched-file.mjs`, which applies
+  `gofumpt -extra -w` and `goimports -w -local github.com/tsouza/cerberus` to the single `.go` file
+  just written. `-extra` is not optional: `.golangci.yml` sets `gofumpt.extra-rules: true`, so the
+  CI `lint` gate enforces the extra rules and a plain `gofumpt` leaves formatting CI will reject.
+  The hook is scoped to one file and runs no repository-wide linter.
+- **PreToolUse on `Bash`** runs `.claude/hooks/guard-git.mjs` for `git commit` and `git push`
+  invocations. It is a fast guard, not a second validation layer: it blocks a commit or push aimed at
+  `main`, and it blocks when lefthook's git hooks are not installed, because lefthook is the layer
+  that genuinely owns pre-commit and pre-push validation. Setting `CERBERUS_PRECOMMIT_FULL_CI=1`
+  additionally runs `just ci` before each commit and push; it is off by default because that
+  duplicates a better-targeted layer at a cost of minutes per commit.
+
+The guard deliberately does not run the test suite or `golangci-lint`. `lefthook.yml` already mirrors
+the CI `check`, `lint`, and `forbid-skip` jobs on `pre-push`, once per push instead of once per
+commit, and a linter invoked from a fresh agent worktree can report a clean tree without having
+analysed it — a false green is worse than no local check, because it is trusted.
+
+### Project subagents (`.claude/agents/`)
+
+- `code-reviewer` — reviews the working diff for regressions, missing tests, and invariant breaches
+  before a commit. Read-only by construction.
+- `explorer` — cheap, fast codebase search, pinned to a small model.
+- `test-runner` — runs a suite and reports failures only.
+- `chsql-emitter` — domain specialist for `internal/chsql`, the typed ClickHouse SQL emitter.
+
+Subagents have no persistent memory between invocations. Each starts from its prompt and whatever the
+caller passes in, which is why each agent file points at the specific documents and scripts it needs
+rather than assuming recall from a previous run.

--- a/docs/specs/compose-crawl-inventory-regeneration.md
+++ b/docs/specs/compose-crawl-inventory-regeneration.md
@@ -1,0 +1,128 @@
+# Spec: CI regeneration path for the compose crawl surface inventory
+
+Tracks issue #1826. This document is the worked example for the plan-first workflow described in
+`docs/agent-workflow.md`; it is a specification, and no part of it has been implemented.
+
+## Problem
+
+`e2e.yml` can regenerate the **k3d** crawl surface inventory from CI. It cannot regenerate the
+**compose** one, even though both files gate on every PR and every push to `main`.
+
+Evidence, all in `.github/workflows/e2e.yml`:
+
+- The `workflow_dispatch` input `update_crawl_inventory` names k3d in its own description and is
+  consumed in exactly two places, both inside the `dashboard` job's k3d crawl step: the
+  `CERBERUS_UPDATE_INVENTORY` assignment, guarded by
+  `if: env.RUN_SHARD == 'true' && matrix.crawlStack == 'k3d'`, and the artifact upload, guarded by
+  `matrix.crawlStack == 'k3d'` and uploading `grafana-surface-inventory.k3d.json` alone.
+- The compose crawl runs in the `compose-smoke-shard-info` lane's `compose-smoke-shard` step. That
+  step sets `SWEEP_DEPTH`, `CRAWL_STACK: compose`, and the three service URLs. It never sets
+  `CERBERUS_UPDATE_INVENTORY`, and no step anywhere in the file uploads
+  `grafana-surface-inventory.compose.json`.
+
+Two properties turn the omission from an inconvenience into a dead end:
+
+- Regeneration requires an exhaustive crawl. `crawl.spec.ts` hard-asserts
+  `expect(depth, 'inventory regeneration requires exhaustive crawl: rerun SWEEP_DEPTH=full').toBe('full')`.
+  The compose lane runs `SWEEP_DEPTH=full` only on the nightly `schedule` event, which carries no
+  dispatch inputs.
+- `test/e2e/playwright/crawl/grafana-surface-inventory.compose.json` is marked `-merge` in
+  `.gitattributes`, so hand-editing it is against repository policy — invariant 9 in `CLAUDE.md`.
+
+The consequence: when Grafana or the stack grows a surface, the compose inventory ratchet goes red on
+`main`, and the only way to produce a correct replacement file is to boot the full compose stack on a
+developer machine and run a full-depth Playwright crawl locally.
+
+## Goals
+
+1. A maintainer can regenerate `grafana-surface-inventory.compose.json` entirely from CI, by a
+   `workflow_dispatch` run, with no local compose stack.
+2. The regenerated file arrives as a downloadable artifact, per stack, so the two inventories can
+   never be confused for one another.
+3. The dispatch surface states which stacks it regenerates, so the k3d-only reading that produced
+   this gap is not available to the next reader.
+
+## Non-goals
+
+- Changing what the crawl visits, how the inventory is shaped, or how either ratchet compares it.
+- Automatically committing a regenerated inventory. The artifact is downloaded and committed through
+  a PR like any other generated file.
+- Anything about issue #1825, the current red state of the k3d inventory ratchet, or issue #1674's
+  per-PR content-exact ratchet. Those are separate changes against separate issues.
+
+## Design
+
+Three coordinated edits, all in `.github/workflows/e2e.yml`.
+
+**1. Widen the dispatch surface to name a stack.** Replace the boolean `update_crawl_inventory` with
+an input that selects which inventories to regenerate — `none`, `k3d`, `compose`, or `both` — with
+`none` as the default so an ordinary dispatch is unaffected. A `choice` input keeps the surface
+self-describing, which is the property whose absence caused the gap. The description must name every
+inventory path it can write.
+
+**2. Force full depth when regenerating.** `SWEEP_DEPTH` for the compose lane currently derives from
+the event alone. It must additionally resolve to `full` when this run is regenerating the compose
+inventory, otherwise `crawl.spec.ts`'s assertion fails by construction and the dispatch is useless.
+The same reasoning applies to the k3d lane, which today gets full depth only incidentally. The
+resolution is a small expression, and if it does not stay a one-liner it belongs in
+`.github/scripts/` per invariant 15.
+
+**3. Set the env var and upload the artifact on the compose lane.** Mirror the two k3d sites onto
+`compose-smoke-shard`: set `CERBERUS_UPDATE_INVENTORY` when the resolved selection includes compose,
+and add an upload step for `grafana-surface-inventory.compose.json`. Keep the artifact names
+stack-qualified.
+
+The compose crawl is sharded. Whether a single shard produces a complete inventory, or the shards
+must be merged, is the one open question in this design, and task 1 below settles it before any
+workflow edit is written. If merging is required, the merge belongs in a `.github/scripts/` module
+with its own unit test, not in inline YAML.
+
+## Verification
+
+- **Structural.** `just lint-actions` (actionlint) over the edited workflow.
+- **Behavioural, and the only verification that actually proves the goal.** A `workflow_dispatch` run
+  on the branch with the compose selection, whose artifact is downloaded and compared against the
+  committed `grafana-surface-inventory.compose.json`. On an unchanged surface the two must be
+  identical. This is the acceptance criterion: a green workflow that uploads a file nobody compared
+  proves nothing.
+- **Negative control.** A dispatch with the default `none` must leave both lanes behaving exactly as
+  they do today — no `CERBERUS_UPDATE_INVENTORY`, no depth change, no inventory artifact.
+- **Regression.** The existing k3d regeneration path must still work after the input is reshaped;
+  exercise it in the same dispatch matrix rather than assuming the rename was lossless.
+
+## Risks
+
+- **Silent no-op.** The failure mode this class of change is most prone to is a gate or a flag that
+  degrades to OFF while every check stays green. The behavioural verification above exists
+  specifically to prove the path activates, not merely that it runs.
+- **Input rename.** Any saved dispatch, documentation reference, or muscle memory using the boolean
+  `update_crawl_inventory` stops working. Grep the tree and the docs for the name and update every
+  hit in the same change.
+- **Depth cost.** A full-depth compose crawl is materially slower than the lean PR default. Gating it
+  behind an explicit dispatch selection keeps that cost off the PR path, which is why the default is
+  `none` rather than inferring intent from the event.
+
+## Task list for owner review
+
+Ordered so the tree is green between any two tasks. Nothing here has been executed.
+
+1. Determine whether one compose shard yields a complete inventory or the shards must be merged. Read
+   `.github/scripts/compose-smoke-matrix.mjs`, `test/e2e/playwright/crawl/stacks.ts`, and
+   `crawl.spec.ts`'s write path. Record the answer in this spec. No code change. This gates tasks 4
+   and 5.
+2. Reshape the `workflow_dispatch` input to a stack-selecting `choice` with default `none`, and
+   rewrite its description to name both inventory paths. Rewire the two existing k3d consumers to the
+   new input. Verify with `just lint-actions`; the k3d path must behave exactly as before.
+3. Resolve `SWEEP_DEPTH` to `full` on both lanes whenever this run regenerates that lane's inventory.
+   Verify with `just lint-actions` plus a reading of the resolved expression for all four selection
+   values.
+4. Set `CERBERUS_UPDATE_INVENTORY` on `compose-smoke-shard` when the selection includes compose.
+   Verify with `just lint-actions`.
+5. Add the stack-qualified artifact upload for `grafana-surface-inventory.compose.json`, including
+   the shard merge if task 1 found one is needed — as a `.github/scripts/` module with a unit test if
+   so.
+6. Run the dispatch on the branch for each of the four selection values. Download the compose
+   artifact and diff it against the committed inventory; attach the result to the PR. This is the
+   acceptance evidence.
+7. Update `docs/test-strategy.md`'s crawl-inventory section to state the regeneration path for both
+   stacks.

--- a/docs/toolchain.md
+++ b/docs/toolchain.md
@@ -1,0 +1,108 @@
+# Toolchain
+
+Build-time environment, linters, and the tooling forks. Dependency policy and the `tsouza/*` fork
+boundary live in `docs/upstream-forks.md`; this document covers the tools that build and check the
+tree rather than the modules it links.
+
+## Go
+
+`go.mod` may pin a newer Go than the system-wide install. `GOTOOLCHAIN=auto`, the default, downloads
+the pinned version into `~/go/pkg/mod/golang.org/toolchain@...` without further ceremony. The
+`.envrc` — loaded by `direnv allow` — puts both the system Go and the downloaded toolchains on
+`PATH`.
+
+CGO is left at the platform default so `go test -race` works. Goreleaser pins `CGO_ENABLED=0` for
+release builds independently of the development setting.
+
+## Linters and formatters
+
+`golangci-lint` v2. `.golangci.yml` uses the v2 schema, in which `gofumpt` and `goimports` are
+configured under `formatters` rather than `linters`. The v2 install path carries the major-version
+element: `github.com/golangci/golangci-lint/v2/cmd/golangci-lint`.
+
+Two settings are load-bearing for anything that formats Go outside `just fmt`:
+
+- `gofumpt.extra-rules: true` — the CI `lint` gate enforces gofumpt's extra rules, so any tool or
+  hook that formats a Go file must pass `-extra`. Plain `gofumpt -w` leaves formatting that CI
+  rejects.
+- `goimports.local-prefixes: github.com/tsouza/cerberus` — import grouping puts cerberus's own
+  packages in their own block, so `goimports` needs `-local github.com/tsouza/cerberus` to match.
+
+`forbidigo` enforces the parser-internals rule across all of `internal/**`: no `unsafe.Pointer` and
+no `reflect.Value.FieldByName` against upstream parser ASTs. The accessor belongs in the fork
+instead.
+
+`.go-arch-lint.yml` declares the allowed dependency graph between `internal/**` packages. The gate is
+CI-only, so a new package that is missing from that file builds and tests clean locally and fails on
+the PR. Declare the package in the same change that creates it.
+
+`actionlint` (`just lint-actions`) validates the workflow files. GitHub rejects an invalid workflow
+file server-side as a zero-job failure run, which prevents required `pull_request` checks from ever
+being scheduled — a PR then sits blocked on contexts that can never report.
+
+`markdownlint-cli2` with `.markdownlint.yaml`. `MD060` pins table-column-style to `aligned`; the
+`pre-commit` hook pads cell widths with `scripts/align-md-tables.py` before the auto-fixer runs,
+because that rule has no auto-fixer of its own.
+
+## Mutation testing — the gremlins fork
+
+`mutation.yml` installs the `tsouza/gremlins` fork rather than upstream `go-gremlins/gremlins@v0.6.0`:
+
+```bash
+go install github.com/tsouza/gremlins/cmd/gremlins@v0.6.0-cerberus-timeout-max-consume
+```
+
+Both fixes it carries exist because a mutation run that dies mid-flight is worse than one that
+reports a bad number: it reports nothing at all.
+
+**`--on-shutdown-status`, for mutants cancelled in flight.** Upstream's signal handler closes the
+channel that `os/signal` still writes to, so a second signal — the typical CI runner sequence of
+SIGTERM then SIGKILL — panics with `send on closed channel` from `signal.process`. Worse, a mutant
+whose `go test` subprocess is still running at cancellation time falls through `runTests` to the
+default `return mutator.Lived` branch, because the per-test context is rooted in `context.Background()`
+and only `DeadlineExceeded` is checked. Untested mutants recorded as LIVED deflate `test_efficacy`.
+The fork stops the handler self-closing and threads the engine's run context into the per-test
+context, so a cancelled-in-flight mutant is reported with the status from the new flag. Cerberus
+passes `--on-shutdown-status=not-run`, which lands those mutants in `NOT_COVERED`, outside the
+`KILLED / (KILLED + LIVED)` efficacy formula entirely. Upstream pull request:
+<https://github.com/go-gremlins/gremlins/pull/283>.
+
+**`--timeout-max`, for runaway mutants that kill the runner.** Upstream derives a mutant's test
+timeout as `timeout-coefficient × the package's baseline test duration`, which scales the leash by how
+slow a package's tests are — a quantity unrelated to how much damage a runaway mutant does in that
+time. A mutant that inverts a scanner's loop advance (`i++` to `i--`) never terminates and allocates
+per iteration, so on a slow-baseline package it gets minutes to exhaust the runner's memory; the OOM
+killer then reaps the runner and the job ends with no verdict. Measured across 91 heavy runs, all 55
+runner deaths were stalled on a lexer or scanner mutant. `--timeout-max` bounds exposure absolutely,
+independent of the baseline; cerberus passes `--timeout-max 15s`.
+
+A recurrence is not fixed by excluding the file the log names. Excluding a file relocates its runaway
+mutants into whichever leg still owns it and burns real mutation coverage at the same time.
+`test/regression/mutation_timeout_max_test.go` pins the flag and the fork tag together, because the
+failure mode it prevents presents as flake rather than as a missing bound.
+
+`.gremlins.yaml`'s `exclude-files` paths are interpreted relative to the run's scope, not the repo
+root, and the matcher is RE2 with no lookahead. A path in the wrong form silently excludes nothing.
+
+The fork ships two branches on purpose. `cerberus-sigterm-fix` at tag `v0.6.0-cerberus-timeout-max`
+is the branch the upstream pull request is built from, and keeps the upstream module path
+`github.com/go-gremlins/gremlins` so the diff stays reviewable.
+`cerberus-sigterm-fix-consume` at tag `v0.6.0-cerberus-timeout-max-consume` is the branch
+`mutation.yml` installs; it adds one commit renaming the `go.mod` module path to
+`github.com/tsouza/gremlins` and rewriting the internal imports, because `go install` otherwise
+rejects the module with `module declares its path as: github.com/go-gremlins/gremlins`. The fixes
+themselves are identical across the two.
+
+Unlike the module forks, this one sits outside the Dependabot watch flow: it is a build-time tool
+rather than a Go module dependency.
+
+## chDB
+
+The chdb-tagged lanes — the `-- expected_rows --` roundtrip cells in `test/spec/`, the property
+tests, and the cardinality baseline — link `libchdb.so`, installed by `just chdb-install`. Without
+it, `just update-golden` refuses to run rather than regenerating a partial corpus.
+
+chDB and a production ClickHouse server differ in scan strictness: chDB coerces some column types
+that the server rejects outright. An emit-type bug can therefore pass every chDB lane and fail
+against a real server, which is why `compose-smoke` runs against a server and is scoped to changes in
+`internal/chsql`, `internal/api`, `internal/chclient`, and `cmd/cerberus`.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -18,15 +18,21 @@ pre-commit:
   parallel: true
   commands:
     gofumpt:
+      # `-extra` matches `.golangci.yml`'s `gofumpt.extra-rules: true`, which
+      # the required `lint` gate applies. Without the flag this hook reports
+      # success over a file CI then rejects — the worst kind of formatter.
       glob: "*.go"
       stage_fixed: true
       run: |
-        gofumpt -w {staged_files}
+        gofumpt -extra -w {staged_files}
     goimports:
+      # `-local` matches `.golangci.yml`'s `goimports.local-prefixes`, so
+      # cerberus's own imports group separately here exactly as the `lint` gate
+      # requires. Same reason as the `-extra` above.
       glob: "*.go"
       stage_fixed: true
       run: |
-        goimports -w {staged_files}
+        goimports -w -local github.com/tsouza/cerberus {staged_files}
     md-table-align:
       # MD060 (table-column-style: aligned) has no auto-fixer in
       # markdownlint-cli2 — pad cell widths before --fix sees the file.


### PR DESCRIPTION
## Summary

- **CLAUDE.md is trimmed from 34.2K to a working reference** — build/test commands read off the
  Justfile, an architecture decision tree keyed on the question a change answers, and the invariants
  as a numbered list of 17. The narrative detail is moved, not dropped.
- **`.claude/` becomes a checked-in harness** — two hooks and four project subagents, so every
  contributor and agent gets the same behaviour instead of whatever their local settings happen to
  say.
- **Two invariants that code comments already cite but CLAUDE.md never stated are now written down**
  — no caching of query results (cited by `internal/api/loki/patterns.go:57`) and never hand-edit a
  generated artefact (regenerate via `just update-golden`; every such path is `-merge` in
  `.gitattributes`).
- **A worked spec opens `docs/specs/`** for issue #1826, as the dry run of the plan-first workflow.
  Specification only — none of it is implemented.

## The CLAUDE.md diff, section by section

Nothing was discarded. Every removed passage landed in one of the two new reference docs.

| Was in CLAUDE.md | Now |
| ------------------------------------------------- | ------------------------------------------------------ |
| One-paragraph project description | Kept, tightened |
| 20-check required list, merge-queue posture, release-gate short-circuits | `docs/agent-workflow.md` → "Required checks and the gate posture" |
| `forbid-deferral` mechanics, citation-scope rules | `docs/agent-workflow.md` → "Work that belongs outside this change" |
| Push/PR ritual, branch-base corollaries | `docs/agent-workflow.md` → "Shipping ritual" |
| Subagent worktree isolation + 7-step recovery | `docs/agent-workflow.md` → "Worktree isolation" |
| Go version / CGO / golangci-lint v2 notes | `docs/toolchain.md` |
| gremlins fork: both fixes, both branch tags | `docs/toolchain.md` → "Mutation testing" |
| memberlist transitive-dep gotcha, parser fork map | Pointer to the existing `docs/upstream-forks.md`, which already documents both |
| Architecture map (ASCII tree) | Rewritten as a decision tree — "the SQL is wrong" → `internal/chsql/` |
| Hard-rules prose (10 long bullets) | 17 numbered invariants, one to five lines each |

Net: CLAUDE.md loses ~159 lines of prose and gains a structure you can answer a question from.

### The one instruction I could not follow literally

The brief asked for `@AGENTS.md` at the top of CLAUDE.md. **`AGENTS.md` in this repo is a symlink to
`CLAUDE.md`** (mode `120000`), so that line would import the file into itself. Breaking the symlink
into two real files needed a file deletion, which my sandbox refuses.

The resolution is better than the literal instruction anyway: the symlink already gives byte-identical
content under both names — stronger than an `@` import, and zero duplication by construction. An HTML
comment at the top of CLAUDE.md states this so the next reader does not "fix" the missing import.

Related: the brief asked for `@docs/...` references so the reference docs "load on demand". A
CLAUDE.md `@file` reference is an **eager import** — it loads at session start — so using it for the
docs would have *increased* per-session context and defeated the trim. They are linked as backticked
paths instead, which is genuinely on demand.

## Enforcement hooks (`.claude/settings.json`)

**PostToolUse on `Edit`/`Write`/`MultiEdit`** → `.claude/hooks/format-touched-file.mjs`. Runs
`gofumpt -extra -w` and `goimports -w -local github.com/tsouza/cerberus` on the single `.go` file just
written. Non-Go files are a no-op; it never blocks.

`-extra` is load-bearing: `.golangci.yml` sets `gofumpt.extra-rules: true`, so the `lint` gate applies
the extra rules and a plain `gofumpt -w` leaves formatting CI rejects.

**PreToolUse on `Bash`** → `.claude/hooks/guard-git.mjs`. Fires only on `git commit` / `git push`
(including inside `&&` chains and behind `rtk`). Blocks with exit 2 when the commit or push targets
`main` — directly, or via an explicit `HEAD:main` refspec — or when lefthook's git hooks are not
installed.

### I did not wire `just ci` into the guard — deliberately

Three reasons: `lefthook.yml`'s `pre-push` already mirrors the CI `check` + `lint` + `forbid-skip`
jobs once per push rather than once per commit; `just ci` costs minutes on every commit; and
golangci-lint run from a fresh agent worktree has been observed reporting "No issues found" without
having analysed the tree, which is a false green.

**The literal behaviour is one variable away**, as requested:

```bash
export CERBERUS_PRECOMMIT_FULL_CI=1
```

or add it to an `env` block in `.claude/settings.json` to make it permanent. The guard's `timeout` is
already sized for a full CI run. The trade-off is documented at the site, in the script's own header.

### Proof both hooks fire

Exercised by piping real hook payloads to each script:

| Case | Result |
| ----------------------------------------------------- | ------------------------------ |
| Guard: `ls -la` (non-git) | exit 0, allowed |
| Guard: `git commit` on a feature branch, hooks present | exit 0, allowed |
| Guard: `rtk git push origin HEAD:main` | **exit 2, blocked** on the main rule |
| Guard: commit buried in `add && commit && push` | detected, same verdict |
| Guard: fresh repo with no lefthook hooks | **exit 2, blocked**, names `just hooks-install` |
| Guard: `CERBERUS_PRECOMMIT_FULL_CI=1`, `just` unreachable | **exit 2, blocked** |
| Formatter: unformatted `.go` file | reformatted |

The formatter case proves `-extra` specifically: plain `gofumpt` left `func Sum(a int, b int) int`,
while the hook produced `func Sum(a, b int) int`, plus goimports reordering.

The lefthook-absent branch was exercised against a throwaway `git init` repo rather than by breaking
anything in this tree.

## Related fix: lefthook's own formatters did not match the lint gate

`pre-commit` ran bare `gofumpt -w` and `goimports -w` — no `-extra`, no `-local` — while
`.golangci.yml` requires both. The hook could report success over a file the required `lint` gate
would reject. Both flags added. The tree is already conformant (CI enforces it), so this is a no-op
on current content and a real fix going forward.

## Project subagents (`.claude/agents/`)

- **`code-reviewer`** — `tools: Read, Grep, Glob, Bash`, opus. Frontmatter cannot scope `Bash` to a
  git subcommand, so the prompt body enumerates the permitted read-only invocations and forbids every
  writing one; it has no `Edit`/`Write` by design. It reviews the diff and explicitly does not re-run
  the gates.
- **`explorer`** — `model: haiku` as specified. Locates code, does not assess it. Carries the
  `rtk proxy grep` rule, since plain `rtk grep` can falsely report absence.
- **`test-runner`** — picks the right `just` recipe, reports failures only, and is told to
  distinguish a failure from a suite that never ran, and never to call a failure a flake without
  evidence.
- **`chsql-emitter`** — the domain specialist, over `internal/chsql`. Chosen over
  `internal/optimizer` / `internal/chplan` because it is the last stage before the database, is
  shared by all three heads, and carries the hardest invariant in the repo. Its prompt carries the
  full typed-Frag constructor list read off `builder.go`, the exact known-good raw-write exceptions,
  the worked `epochAlignedEndFrag` conversion, and `node .github/scripts/forbid-sql-raw.mjs` as a
  mandatory self-check.

Subagents have **no persistent-memory primitive**. Each agent file therefore points at the specific
documents and scripts it needs, and `docs/agent-workflow.md` says so plainly rather than implying
recall exists.

## Plan-mode workflow

`docs/agent-workflow.md` → "The change lifecycle" states the going-forward contract: plan mode →
requirements interview → spec at `docs/specs/<feature>.md` → numbered task list for owner review →
implementation. CLAUDE.md carries the short form.

The dry run is `docs/specs/compose-crawl-inventory-regeneration.md`, for **issue #1826** (the compose
crawl surface inventory has no CI regeneration path while k3d does). Problem with cited evidence,
goals, non-goals, design, verification plan, risks, and a 7-item numbered task list ordered so the
tree is green between any two. **No task in it has been executed.**

## Test plan

- [x] Both hooks exercised across every branch, including both sides of the guard (table above)
- [x] Push verified by SHA: `rtk proxy git ls-remote origin chore/agent-harness-setup` matches local
      `HEAD` at `f3824ed4`
- [x] Checked `.github/scripts/doc-counts.mjs` — it validates the "14-layer test map" claim in
      CLAUDE.md; the phrase is retained with the correct number
- [x] Checked for links to CLAUDE.md anchors elsewhere in the tree (the `link-check` gate validates
      fragments) — there are none
- [x] `lefthook` `pre-commit` and `commit-msg` ran on the commit
- [ ] CI green

## Notes for reviewers

**Please review the CLAUDE.md diff directly** — it is the artefact the owner asked to see, and the
table above is a map of it, not a substitute.

Judgement calls I made rather than blocking on, all reversible:

1. **AGENTS.md stays a symlink** — see above. If you want two real files, deleting the symlink is the
   only step I could not perform.
2. **Reference docs are backticked paths, not `@` imports** — because `@` imports are eager.
3. **The guard blocks on `main` as well as on missing lefthook hooks.** The brief asked only for the
   lefthook check; branch protection rejects a push to `main` anyway, so failing locally is strictly
   cheaper. Remove the `PROTECTED_BRANCH` block if you disagree.
4. **Hooks are Node ESM, not bash** — JSON parsing in bash without a guaranteed `jq` is fragile, and
   `.github/scripts/*.mjs` is already the repo's idiom for dependency-light logic.
5. **`lefthook.yml` was touched** though the brief scoped me to `.claude/`. It is the same defect
   class as the hook I was asked to write, and one flag each.
6. **Spec issue choice** — #1826, avoiding every issue named as in-flight. It is CI-shaped, small, and
   self-contained.

No auto-merge armed; this is yours to review.
