### PR TITLE
fix(harness): resolve the guarded git branch from the directory the command runs in

### DIFF
--- a/.claude/hooks/guard-git.mjs
+++ b/.claude/hooks/guard-git.mjs
@@ -80,6 +80,43 @@ function splitSegments(command) {
   return command.split(/&&|\|\||[;\n|]/g);
 }
 
+// effectiveCwd — the directory the guarded git command actually runs in.
+//
+// The payload's `cwd` is the session's project directory, which is not where
+// the command runs when the line starts by changing directory: agents work in
+// linked worktrees and reach them with `cd <worktree> && git commit ...`. The
+// project directory and the worktree are different checkouts of the same
+// repository on different branches, so reading the branch from the payload's
+// `cwd` answers a question nobody asked — and blocks every commit made from a
+// worktree whenever the main checkout happens to sit on `main`.
+//
+// `git -C <dir>` on the guarded segment itself takes precedence, since it binds
+// tighter than any earlier `cd`.
+function effectiveCwd(command, segment, payloadCwd) {
+  const dirOpt = gitDirOption(segment);
+  if (dirOpt) return resolveDir(dirOpt, payloadCwd);
+  for (const seg of splitSegments(command)) {
+    const words = seg.trim().split(/\s+/).filter(Boolean);
+    if (words[0] === 'cd' && words[1] && !words[1].startsWith('-')) {
+      const resolved = resolveDir(words[1], payloadCwd);
+      if (resolved) return resolved;
+    }
+  }
+  return payloadCwd;
+}
+
+// gitDirOption — the value of `-C <dir>` on a git invocation, or null.
+function gitDirOption(segment) {
+  const words = segment.trim().split(/\s+/).filter(Boolean);
+  const at = words.indexOf('-C');
+  return at >= 0 && words[at + 1] ? words[at + 1] : null;
+}
+
+function resolveDir(dir, base) {
+  const abs = isAbsolute(dir) ? dir : join(base, dir);
+  return existsSync(abs) ? abs : null;
+}
+
 // gitInvocation — given one segment, return the git subcommand it runs, or null.
 // Skips leading `VAR=value` assignments and known wrappers, then walks git's
 // global options to find the first bare word, which is the subcommand.
@@ -174,18 +211,20 @@ function main() {
   const command = payload?.tool_input?.command;
   if (typeof command !== 'string' || command.length === 0) return ALLOW;
 
-  const cwd = payload.cwd && existsSync(payload.cwd) ? payload.cwd : process.cwd();
+  const payloadCwd = payload.cwd && existsSync(payload.cwd) ? payload.cwd : process.cwd();
 
   const guarded = [];
   for (const segment of splitSegments(command)) {
     const sub = gitInvocation(segment);
-    if (sub && GUARDED_SUBCOMMANDS.has(sub)) guarded.push({ sub, segment });
+    if (sub && GUARDED_SUBCOMMANDS.has(sub)) {
+      guarded.push({ sub, segment, cwd: effectiveCwd(command, segment, payloadCwd) });
+    }
   }
   if (guarded.length === 0) return ALLOW;
 
-  const branch = currentBranch(cwd);
-  for (const { sub, segment } of guarded) {
-    const targetsMain = branch === PROTECTED_BRANCH || (sub === 'push' && pushesToProtectedBranch(segment));
+  const cwd = guarded[0].cwd;
+  for (const { sub, segment, cwd: segCwd } of guarded) {
+    const targetsMain = currentBranch(segCwd) === PROTECTED_BRANCH || (sub === 'push' && pushesToProtectedBranch(segment));
     if (targetsMain) {
       return block([
         `guard-git: refusing to ${sub} against \`${PROTECTED_BRANCH}\`.`,

--- a/test/regression/guard_git_hook_test.go
+++ b/test/regression/guard_git_hook_test.go
@@ -1,0 +1,196 @@
+package regression
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// `.claude/hooks/guard-git.mjs` is a PreToolUse hook that refuses a `git
+// commit` / `git push` aimed at `main`, and refuses either while lefthook's
+// git hooks are missing. Its whole value is that it fires on the commands an
+// agent actually types, and its whole cost is that a false positive blocks
+// every commit in the session with no way around it.
+//
+// The command an agent actually types is the part that is easy to get wrong.
+// Agents work in linked worktrees and reach them by changing directory first —
+// `cd <worktree> && git commit …`. The hook payload's `cwd` is the session's
+// project directory, a DIFFERENT checkout of the same repository on a
+// different branch. Resolving the branch from the payload's `cwd` therefore
+// reads the wrong branch, and while the project checkout sits on `main` the
+// guard refuses every commit made from every worktree — work that was never
+// aimed at `main` at all. That regression is invisible to any test that only
+// exercises the plain `git commit` form, because that form happens to resolve
+// to the right directory by accident.
+//
+// So the cases below drive the hook end to end, as the harness does: a JSON
+// payload on stdin, an exit code out. Exit 0 allows, exit 2 blocks.
+const (
+	guardAllow = 0
+	guardBlock = 2
+
+	guardGitHookPath = "../../.claude/hooks/guard-git.mjs"
+)
+
+// lefthookHookNames are the hook files guard-git.mjs looks for. Their contents
+// must mention lefthook — the guard rejects an unrelated script sitting at the
+// same path, since that would satisfy a bare existence check while running
+// none of the repo's gates.
+var lefthookHookNames = []string{"pre-commit", "commit-msg", "pre-push"}
+
+func TestGuardGitHook(t *testing.T) {
+	t.Parallel()
+
+	if _, err := exec.LookPath("node"); err != nil {
+		t.Fatalf("node is required to exercise the PreToolUse hook: %v", err)
+	}
+	hook, err := filepath.Abs(guardGitHookPath)
+	if err != nil {
+		t.Fatalf("resolve hook path: %v", err)
+	}
+
+	onMain := newGuardRepo(t, "main", true)
+	onFeature := newGuardRepo(t, "fix/some-work", true)
+	noHooks := newGuardRepo(t, "fix/other-work", false)
+
+	cases := []struct {
+		name    string
+		cwd     string
+		command string
+		want    int
+	}{
+		{
+			name:    "commit on main is blocked",
+			cwd:     onMain,
+			command: "git commit -m msg",
+			want:    guardBlock,
+		},
+		{
+			// The regression this file exists for.
+			name:    "commit in a worktree reached by cd is allowed from a project dir on main",
+			cwd:     onMain,
+			command: "cd " + onFeature + " && git commit -m msg",
+			want:    guardAllow,
+		},
+		{
+			name:    "commit via git -C is allowed from a project dir on main",
+			cwd:     onMain,
+			command: "git -C " + onFeature + " commit -m msg",
+			want:    guardAllow,
+		},
+		{
+			name:    "cd into a checkout on main is still blocked",
+			cwd:     onFeature,
+			command: "cd " + onMain + " && git commit -m msg",
+			want:    guardBlock,
+		},
+		{
+			name:    "push with an explicit main refspec is blocked from a feature branch",
+			cwd:     onFeature,
+			command: "git push origin HEAD:main",
+			want:    guardBlock,
+		},
+		{
+			name:    "ordinary push from a feature branch is allowed",
+			cwd:     onFeature,
+			command: "git push",
+			want:    guardAllow,
+		},
+		{
+			name:    "commit without lefthook installed is blocked",
+			cwd:     noHooks,
+			command: "git commit -m msg",
+			want:    guardBlock,
+		},
+		{
+			name:    "a non-git command is allowed",
+			cwd:     onMain,
+			command: "ls -la",
+			want:    guardAllow,
+		},
+		{
+			name:    "a read-only git command is allowed on main",
+			cwd:     onMain,
+			command: "git status --short",
+			want:    guardAllow,
+		},
+		{
+			name:    "the rtk wrapper does not hide a commit on main",
+			cwd:     onMain,
+			command: "rtk git commit -m msg",
+			want:    guardBlock,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, stderr := runGuard(t, hook, tc.cwd, tc.command)
+			if got != tc.want {
+				t.Fatalf("exit=%d want=%d\ncommand: %s\nstderr: %s", got, tc.want, tc.command, stderr)
+			}
+			if tc.want == guardBlock && stderr == "" {
+				t.Errorf("guard blocked without explaining why; an agent has nothing to act on")
+			}
+		})
+	}
+}
+
+// runGuard feeds the hook a PreToolUse payload and returns its exit code plus
+// whatever it wrote to stderr, which is the text Claude Code shows the model.
+func runGuard(t *testing.T, hook, cwd, command string) (int, string) {
+	t.Helper()
+	payload, err := json.Marshal(map[string]any{
+		"tool_name":  "Bash",
+		"cwd":        cwd,
+		"tool_input": map[string]any{"command": command},
+	})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	cmd := exec.Command("node", hook)
+	cmd.Stdin = bytes.NewReader(payload)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	cmd.Dir = cwd
+	runErr := cmd.Run()
+	if runErr == nil {
+		return 0, stderr.String()
+	}
+	var exitErr *exec.ExitError
+	if errors.As(runErr, &exitErr) {
+		return exitErr.ExitCode(), stderr.String()
+	}
+	t.Fatalf("run hook: %v (stderr: %s)", runErr, stderr.String())
+	return 0, ""
+}
+
+// newGuardRepo builds a throwaway git repository on the named branch, with or
+// without lefthook's hook files, and returns its path.
+func newGuardRepo(t *testing.T, branch string, withLefthook bool) string {
+	t.Helper()
+	dir := t.TempDir()
+	runGit(t, dir, "init", "--quiet", "--initial-branch", branch)
+	runGit(t, dir, "config", "user.email", "regression@cerberus.invalid")
+	runGit(t, dir, "config", "user.name", "regression")
+	runGit(t, dir, "commit", "--quiet", "--allow-empty", "-m", "root")
+
+	if !withLefthook {
+		return dir
+	}
+	hooks := filepath.Join(dir, ".git", "hooks")
+	if err := os.MkdirAll(hooks, 0o755); err != nil {
+		t.Fatalf("mkdir hooks: %v", err)
+	}
+	for _, name := range lefthookHookNames {
+		script := "#!/bin/sh\nlefthook run " + name + "\n"
+		if err := os.WriteFile(filepath.Join(hooks, name), []byte(script), 0o755); err != nil {
+			t.Fatalf("write %s hook: %v", name, err)
+		}
+	}
+	return dir
+}


### PR DESCRIPTION
## Problem

`.claude/hooks/guard-git.mjs` read the current branch from the PreToolUse payload's `cwd`, which is the session's *project directory*. Agents work in linked worktrees and reach them by changing directory first:

```
cd /path/to/worktree && git commit -m …
```

The project directory and the worktree are different checkouts of the same repository on different branches. So the guard answered a question nobody asked — and while the project checkout sat on `main`, it refused **every** commit made from **every** worktree with `guard-git: refusing to commit against \`main\``, including work that never went near `main`. That is a hard block with no way around it: it stops the agent, not just the bad commit.

Observed live within minutes of the hook merging.

## Fix

Resolve the branch from the directory the guarded segment actually runs in, in precedence order:

1. `git -C <dir>` on the segment itself (binds tighter than any earlier `cd`),
2. a leading `cd <dir>` on the line,
3. the payload's `cwd`, as before.

The lefthook-installed check follows the same directory, so it now inspects the worktree the commit lands in rather than an unrelated checkout.

## Test

`TestGuardGitHook` drives the hook end to end exactly as the harness does — a JSON payload on stdin, an exit code out — across ten cases: both worktree spellings (`cd …` and `git -C …`), the plain-`cwd` forms the hook already handled, `cd` *into* a checkout on `main` (still blocked), the explicit `HEAD:main` refspec, the missing-lefthook path, the `rtk` wrapper, and two commands that must pass through untouched.

Against the previous hook, three of those cases fail:

```
--- FAIL: TestGuardGitHook/commit_via_git_-C_is_allowed_from_a_project_dir_on_main
--- FAIL: TestGuardGitHook/commit_in_a_worktree_reached_by_cd_is_allowed_from_a_project_dir_on_main
--- FAIL: TestGuardGitHook/cd_into_a_checkout_on_main_is_still_blocked
```

Against this one, all ten pass. The hook had no test at all before — it was verified by hand at the time it was written, so nothing pinned the behaviour that regressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)