### PR TITLE
fix(e2e): parameterize var-groupBy in the crawl's canonical surface key

### DIFF
--- a/test/e2e/playwright/crawl/crawl.spec.ts
+++ b/test/e2e/playwright/crawl/crawl.spec.ts
@@ -390,8 +390,9 @@ test.describe('crawl: canonicalization pins', () => {
 
   test('structural params join the canonical key; defaults and session params drop', () => {
     // The maintainer-found gap: var-groupBy selects WHICH query the
-    // breakdown fires — a consumption mode, hence a surface. Boot
-    // defaults (actionView=breakdown, var-metric=rate,
+    // breakdown fires — a consumption mode, hence a surface. The
+    // ATTRIBUTE NAME is data-derived, so the value parameterizes.
+    // Boot defaults (actionView=breakdown, var-metric=rate,
     // var-groupBy=resource.service.name) drop so the app rewriting
     // its defaults into the URL can't re-key the bare surface.
     expect(
@@ -400,7 +401,7 @@ test.describe('crawl: canonicalization pins', () => {
         base,
         scope,
       ),
-    ).toBe('/a/grafana-exploretraces-app/explore?var-groupBy=kind');
+    ).toBe('/a/grafana-exploretraces-app/explore?var-groupBy={var-groupBy}');
     // Two pinned params sort by name — pairwise-terminal state.
     expect(
       canonicalizeURL(
@@ -409,7 +410,7 @@ test.describe('crawl: canonicalization pins', () => {
         scope,
       ),
     ).toBe(
-      '/a/grafana-exploretraces-app/explore?actionView=comparison&var-groupBy=kind',
+      '/a/grafana-exploretraces-app/explore?actionView=comparison&var-groupBy={var-groupBy}',
     );
     // All-defaults URL keys the bare surface.
     expect(
@@ -448,18 +449,90 @@ test.describe('crawl: canonicalization pins', () => {
     ).toBe('/a/grafana-lokiexplore-app/explore/service/{service}/logs');
   });
 
+  test('parameterizing var-groupBy absorbs data churn but still catches real coverage change', () => {
+    // #1825: one added resource attribute reshuffled the breakdown's
+    // option list, so the sweep's representative moved from
+    // resource.service.version to resource.service.namespace and the
+    // ratchet fired BOTH halves at once for a pure data change. Under
+    // the parameterized rule the two states key one surface.
+    const asVersion = canonicalizeURL(
+      '/a/grafana-exploretraces-app/explore?var-groupBy=resource.service.version',
+      base,
+      scope,
+    );
+    const asNamespace = canonicalizeURL(
+      '/a/grafana-exploretraces-app/explore?var-groupBy=resource.service.namespace',
+      base,
+      scope,
+    );
+    expect(asVersion).toBe(asNamespace);
+
+    const stack = activeStack();
+    const groupBySurface = asNamespace!;
+    const inventory = {
+      doc: '',
+      stack: stack.name,
+      surfaces: [
+        { url: '/a/grafana-exploretraces-app/explore', lean: true },
+        { url: groupBySurface, lean: true },
+      ],
+    };
+    const noExclusions = { doc: '', exclusions: [] };
+
+    // Data churn alone: the ratchet is silent.
+    expect(
+      diffInventory(
+        new Set(['/a/grafana-exploretraces-app/explore', groupBySurface]),
+        inventory,
+        noExclusions,
+        'lean',
+        stack,
+      ),
+    ).toEqual([]);
+
+    // The gate is NOT dead — a genuinely unvisited surface still fails.
+    // If the sweep stopped driving the groupBy control entirely, no
+    // value of it can key groupBySurface, so this is exactly the
+    // regression the collapse must still catch.
+    const shrank = diffInventory(
+      new Set(['/a/grafana-exploretraces-app/explore']),
+      inventory,
+      noExclusions,
+      'lean',
+      stack,
+    );
+    expect(shrank).toHaveLength(1);
+    expect(shrank[0]).toContain('coverage shrank');
+    expect(shrank[0]).toContain(groupBySurface);
+
+    // …and a genuinely new surface still fails.
+    const grew = diffInventory(
+      new Set([
+        '/a/grafana-exploretraces-app/explore',
+        groupBySurface,
+        '/a/grafana-exploretraces-app/explore?actionView=comparison',
+      ]),
+      inventory,
+      noExclusions,
+      'lean',
+      stack,
+    );
+    expect(grew).toHaveLength(1);
+    expect(grew[0]).toContain('coverage grew');
+  });
+
   test('pinned structural-param counting (the pairwise depth bound)', () => {
     expect(
       pinnedStructuralParamCount('/a/grafana-exploretraces-app/explore'),
     ).toBe(0);
     expect(
       pinnedStructuralParamCount(
-        '/a/grafana-exploretraces-app/explore?var-groupBy=kind',
+        '/a/grafana-exploretraces-app/explore?var-groupBy={var-groupBy}',
       ),
     ).toBe(1);
     expect(
       pinnedStructuralParamCount(
-        '/a/grafana-exploretraces-app/explore?actionView=comparison&var-groupBy=kind',
+        '/a/grafana-exploretraces-app/explore?actionView=comparison&var-groupBy={var-groupBy}',
       ),
     ).toBe(2);
     expect(

--- a/test/e2e/playwright/crawl/crawl.spec.ts
+++ b/test/e2e/playwright/crawl/crawl.spec.ts
@@ -119,6 +119,7 @@ import {
   resolveInitRaceConsoleTwins,
   sweepDepth,
   tolerateRepaintFlicker,
+  UNREADABLE_BODY_SENTINEL,
 } from '../helpers/index.js';
 import {
   ALERT_ERROR_PATTERNS,
@@ -589,6 +590,51 @@ test.describe('crawl: canonicalization pins', () => {
   });
 });
 
+/**
+ * The wire capture reads response bodies to feed oracles 2a/2b. Grafana's
+ * Drilldown apps leave streaming responses open across a navigation, so a
+ * body read can never complete — and the capture's `stop()` awaits every
+ * read before the crawl advances. Without a bound the crawl parks on that
+ * one response until the test timeout and emits no inventory at all.
+ */
+test.describe('crawl: wire-capture body reads are bounded', () => {
+  /** Short enough to keep the unit lane fast; the production bound is
+   * WIRE_BODY_READ_TIMEOUT_MS. */
+  const PROBE_BOUND_MS = 50;
+
+  test('a body that never settles rejects at the bound instead of hanging', async () => {
+    const neverSettles = {
+      text: () => new Promise<string>(() => {}),
+    } as unknown as Response;
+
+    await expect(
+      readBodyWithin(neverSettles, PROBE_BOUND_MS),
+    ).rejects.toThrow(/did not settle/);
+  });
+
+  test('a body that settles is returned unchanged', async () => {
+    const settles = {
+      text: async () => '{"results":{}}',
+    } as unknown as Response;
+
+    expect(await readBodyWithin(settles, PROBE_BOUND_MS)).toBe(
+      '{"results":{}}',
+    );
+  });
+
+  test('a body read that throws propagates so the caller records the sentinel', async () => {
+    const throws = {
+      text: async () => {
+        throw new Error('target page closed');
+      },
+    } as unknown as Response;
+
+    await expect(readBodyWithin(throws, PROBE_BOUND_MS)).rejects.toThrow(
+      /target page closed/,
+    );
+  });
+});
+
 // ---------------------------------------------------------------------------
 // The crawl
 // ---------------------------------------------------------------------------
@@ -929,6 +975,38 @@ type CapturedDsResponse = {
 };
 
 /**
+ * Ceiling on one captured response-body read. Grafana's Drilldown apps
+ * leave streaming responses open across a navigation, and `resp.text()`
+ * on one of those never settles: an unbounded `Promise.all` over the
+ * reads then parks the whole crawl until the test timeout, which yields
+ * NO inventory and NO verdict rather than a bad one. A read that blows
+ * the ceiling records the same UNREADABLE_BODY_SENTINEL a read that
+ * throws already records, so the reconciler's semantics are unchanged.
+ */
+const WIRE_BODY_READ_TIMEOUT_MS = 15_000;
+
+/**
+ * `resp.text()` bounded by `ms` — rejects rather than hanging when the
+ * response body never completes.
+ */
+async function readBodyWithin(resp: Response, ms: number): Promise<string> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      resp.text(),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`response body did not settle within ${ms}ms`)),
+          ms,
+        );
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
  * Wire the datasource-API response capture — the same surface
  * families every existing sweep watches. Deliberately NOT all of
  * /api/: e.g. Grafana fires /api/datasources/uid/cerberus-tempo/health
@@ -938,7 +1016,9 @@ type CapturedDsResponse = {
  * compose_grafana_smoke.spec.ts).
  *
  * Returns the live capture array and an async stop that detaches the
- * listener and settles every in-flight body read.
+ * listener and settles every in-flight body read — each one bounded by
+ * WIRE_BODY_READ_TIMEOUT_MS, so a response that never finishes cannot
+ * wedge the crawl.
  */
 function startWireCapture(
   page: Page,
@@ -967,9 +1047,9 @@ function startWireCapture(
         // (the tunneled-error oracle needs them).
         if (status < 200 || status > 299 || isDsQuery) {
           try {
-            body = await resp.text();
+            body = await readBodyWithin(resp, WIRE_BODY_READ_TIMEOUT_MS);
           } catch {
-            body = '<unreadable>';
+            body = UNREADABLE_BODY_SENTINEL;
           }
         }
         captured.push({

--- a/test/e2e/playwright/crawl/grafana-surface-inventory.compose.json
+++ b/test/e2e/playwright/crawl/grafana-surface-inventory.compose.json
@@ -11,7 +11,7 @@
       "lean": true
     },
     {
-      "url": "/a/grafana-exploretraces-app/explore?actionView=comparison&var-groupBy=All",
+      "url": "/a/grafana-exploretraces-app/explore?actionView=comparison&var-groupBy={var-groupBy}",
       "lean": false
     },
     {
@@ -19,47 +19,15 @@
       "lean": true
     },
     {
-      "url": "/a/grafana-exploretraces-app/explore?actionView=structure&var-groupBy=All&var-metric=duration",
+      "url": "/a/grafana-exploretraces-app/explore?actionView=structure&var-groupBy={var-groupBy}",
       "lean": false
     },
     {
-      "url": "/a/grafana-exploretraces-app/explore?actionView=structure&var-groupBy=All&var-metric=errors",
+      "url": "/a/grafana-exploretraces-app/explore?actionView=structure&var-groupBy={var-groupBy}&var-metric=duration",
       "lean": false
     },
     {
-      "url": "/a/grafana-exploretraces-app/explore?actionView=structure&var-groupBy=kind",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-exploretraces-app/explore?actionView=structure&var-groupBy=name",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-exploretraces-app/explore?actionView=structure&var-groupBy=resource.deployment.environment",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-exploretraces-app/explore?actionView=structure&var-groupBy=resource.service.version",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-exploretraces-app/explore?actionView=structure&var-groupBy=rootName",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-exploretraces-app/explore?actionView=structure&var-groupBy=rootServiceName",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-exploretraces-app/explore?actionView=structure&var-groupBy=span.http.status_code",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-exploretraces-app/explore?actionView=structure&var-groupBy=status",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-exploretraces-app/explore?actionView=structure&var-groupBy=statusMessage",
+      "url": "/a/grafana-exploretraces-app/explore?actionView=structure&var-groupBy={var-groupBy}&var-metric=errors",
       "lean": false
     },
     {
@@ -79,11 +47,11 @@
       "lean": false
     },
     {
-      "url": "/a/grafana-exploretraces-app/explore?actionView=traceList&var-groupBy=All&var-metric=duration",
+      "url": "/a/grafana-exploretraces-app/explore?actionView=traceList&var-groupBy={var-groupBy}&var-metric=duration",
       "lean": false
     },
     {
-      "url": "/a/grafana-exploretraces-app/explore?actionView=traceList&var-groupBy=All&var-metric=errors",
+      "url": "/a/grafana-exploretraces-app/explore?actionView=traceList&var-groupBy={var-groupBy}&var-metric=errors",
       "lean": false
     },
     {
@@ -99,155 +67,27 @@
       "lean": false
     },
     {
-      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=kind",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=kind&var-primarySignal=true",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=kind#radio[Single|Grid|Rows]=Single",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=kind#tabs[Favorites|All|Resource|Span]=All",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=name",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=name&var-primarySignal=true",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=name#radio[Single|Grid|Rows]=Single",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=name#tabs[Favorites|All|Resource|Span]=All",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=resource.deployment.environment",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=resource.deployment.environment&var-primarySignal=true",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=resource.deployment.environment#radio[Single|Grid|Rows]=Single",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=resource.deployment.environment#tabs[Favorites|All|Resource|Span]=All",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=resource.service.version",
+      "url": "/a/grafana-exploretraces-app/explore?var-groupBy={var-groupBy}",
       "lean": true
     },
     {
-      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=resource.service.version&var-metric=duration",
+      "url": "/a/grafana-exploretraces-app/explore?var-groupBy={var-groupBy}&var-metric=duration",
       "lean": false
     },
     {
-      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=resource.service.version&var-metric=errors",
+      "url": "/a/grafana-exploretraces-app/explore?var-groupBy={var-groupBy}&var-metric=errors",
       "lean": false
     },
     {
-      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=resource.service.version&var-primarySignal=true",
+      "url": "/a/grafana-exploretraces-app/explore?var-groupBy={var-groupBy}&var-primarySignal=true",
       "lean": false
     },
     {
-      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=resource.service.version#radio[Single|Grid|Rows]=Single",
+      "url": "/a/grafana-exploretraces-app/explore?var-groupBy={var-groupBy}#radio[Single|Grid|Rows]=Single",
       "lean": false
     },
     {
-      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=resource.service.version#tabs[Favorites|All|Resource|Span]=All",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=rootName",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=rootName&var-primarySignal=true",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=rootName#radio[Single|Grid|Rows]=Single",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=rootName#tabs[Favorites|All|Resource|Span]=All",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=rootServiceName",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=rootServiceName&var-primarySignal=true",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=rootServiceName#radio[Single|Grid|Rows]=Single",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=rootServiceName#tabs[Favorites|All|Resource|Span]=All",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=span.http.status_code",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=span.http.status_code&var-primarySignal=true",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=span.http.status_code#radio[Single|Grid|Rows]=Single",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=span.http.status_code#tabs[Favorites|All|Resource|Span]=All",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=status",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=status&var-primarySignal=true",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=status#radio[Single|Grid|Rows]=Single",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=status#tabs[Favorites|All|Resource|Span]=All",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=statusMessage",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=statusMessage&var-primarySignal=true",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=statusMessage#radio[Single|Grid|Rows]=Single",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-exploretraces-app/explore?var-groupBy=statusMessage#tabs[Favorites|All|Resource|Span]=All",
+      "url": "/a/grafana-exploretraces-app/explore?var-groupBy={var-groupBy}#tabs[Favorites|All|Resource|Span]=All",
       "lean": false
     },
     {

--- a/test/e2e/playwright/crawl/lib.ts
+++ b/test/e2e/playwright/crawl/lib.ts
@@ -103,7 +103,7 @@ export type StructuralParamRule = {
   /** Exact query param name. */
   param: string;
   mode: 'enumerate' | 'parameterize';
-  /** 'enumerate' only: the app's cold-boot value, dropped from keys. */
+  /** The app's cold-boot value, dropped from keys in either mode. */
   defaultValue?: string;
 };
 
@@ -115,10 +115,27 @@ export type StructuralParamRule = {
  *   - Traces Drilldown (`grafana-exploretraces-app`): `actionView`
  *     (Breakdown | Service structure | Comparison | Traces tabs,
  *     boot value `breakdown`), `var-metric` (rate | errors |
- *     duration, boot `rate`), `var-groupBy` (the breakdown attribute,
- *     boot `resource.service.name` — `kind` is the maintainer-found
- *     422), `var-primarySignal` (Root spans | All spans, boot
+ *     duration, boot `rate`), `var-groupBy` (the breakdown ATTRIBUTE
+ *     NAME, boot `resource.service.name` — high-cardinality and
+ *     data-derived, so it parameterizes; see below),
+ *     `var-primarySignal` (Root spans | All spans, boot
  *     `nestedSetParent<0`).
+ *
+ * `var-groupBy` parameterizes rather than enumerates because its
+ * option list is a fact about the DATA, not about the surface: the
+ * app offers whichever span and resource attributes the ingested
+ * traces carry, capped at the combobox's first N. Pinning the values
+ * pinned the dataset — adding one resource attribute to the compose
+ * stack (#1822 added `service.namespace` / `deployment.environment`)
+ * reshuffled the list, evicted `rootName` / `rootServiceName` past
+ * the cap, and moved the sweep's representative from
+ * `resource.service.version` to `resource.service.namespace`. The
+ * ratchet then reported that pure data change as coverage growing AND
+ * shrinking at once (#1825), which is noise, not a regression. The
+ * surface is "the breakdown is grouped by SOME attribute"; the sweep
+ * still DRIVES every option at full depth, exactly as before — only
+ * the inventory key collapses. Same doctrine as the metrics-drilldown
+ * `metric` name and the `{service}` path segment.
  *   - Metrics Drilldown (`grafana-metricsdrilldown-app`): `metric`
  *     (the selected metric NAME — one per series family in the
  *     stack, high-cardinality → parameterize), `actionView`
@@ -148,7 +165,7 @@ export const STRUCTURAL_PARAM_RULES: ReadonlyArray<StructuralParamRule> = [
   {
     pathPattern: /^\/a\/grafana-exploretraces-app\/explore$/,
     param: 'var-groupBy',
-    mode: 'enumerate',
+    mode: 'parameterize',
     defaultValue: 'resource.service.name',
   },
   {
@@ -414,8 +431,10 @@ export function canonicalTarget(
     if (!rule.pathPattern.test(path)) continue;
     const value = url.searchParams.get(rule.param);
     if (value === null || value === '') continue;
+    // The app's cold-boot value keys the BARE surface in both modes —
+    // the default state is not a distinct surface.
+    if (value === rule.defaultValue) continue;
     if (rule.mode === 'enumerate') {
-      if (value === rule.defaultValue) continue;
       retained.push(`${rule.param}=${value}`);
     } else {
       retained.push(`${rule.param}={${rule.param}}`);


### PR DESCRIPTION
Closes #1825.

Two commits: the class fix for the ratchet churn, and the bound that made the
full-depth crawl able to finish at all (found while investigating).

## 1. `var-groupBy` parameterizes instead of enumerating

`compose-smoke-shard-info (shard-crawl, …)` went red on `main` at 4e79a37d
(#1822) with the inventory ratchet firing **both** halves at once:

```
- NEW surface "…/explore?var-groupBy=resource.service.namespace" visited but not pinned — coverage grew
- pinned surface "…/explore?var-groupBy=resource.service.version" (lean set) was NOT visited — coverage shrank
```

The same Traces Drilldown page under two groupBy values.

**Why it moved.** `lib.ts` declared `var-groupBy` as `mode: 'enumerate'`, so the
attribute NAME joined the canonical surface key verbatim. But that option list
is a fact about the DATA, not about the surface: the app offers whichever span
and resource attributes the ingested traces carry, capped at the combobox's
first N. #1822 added `service.namespace` / `deployment.environment` to
`OTEL_RESOURCE_ATTRIBUTES`; the list reshuffled, `rootName` / `rootServiceName`
were evicted past the cap, and the sweep's representative moved from
`resource.service.version` to `resource.service.namespace`. Pinning the values
pinned the dataset.

**The fix.** `var-groupBy` now parameterizes to `{var-groupBy}`, exactly the
doctrine already applied in the same rule table to the metrics-drilldown
`metric` name ("the selected metric NAME … high-cardinality → parameterize")
and to the `{service}` / `{label}` path segments. The surface is "the breakdown
is grouped by SOME attribute".

The cold-boot default now drops in **both** modes rather than only in
`enumerate`, which is what `canonicalTarget`'s own doc already described ("with
the app's cold-boot default dropped so the default state keys the bare
surface"). No existing `parameterize` rule declares a `defaultValue`, so this
changes nothing for `metric`.

**Coverage is not reduced.** `depth` changes STATES, never RULES: the sweep
still drives every groupBy option at full depth and one representative at lean
depth, before and after. Only the inventory KEY collapses.

**The gate is not weakened.** A new test drives `diffInventory` three ways
against the parameterized key:

- both #1825 URLs canonicalize to the same string, and the ratchet is silent —
  the pure data churn is absorbed;
- an unvisited pinned surface still reports `coverage shrank`;
- a visited unpinned surface still reports `coverage grew`.

If the sweep ever stopped driving the groupBy control, no value of it could key
`?var-groupBy={var-groupBy}`, so the shrink half still fires. That is the
difference between a collapsed key and a dead gate.

**The pin.** `grafana-surface-inventory.compose.json` folds 295 → 255 surfaces.
Every previously pinned surface is preserved; the 40 rows that differed only in
the groupBy VALUE merge into their canonical form. The lean set stays at 18,
with the single row `…/explore?var-groupBy={var-groupBy}`. This is a one-time
convergence, not a regeneration — no surface is dropped, so no coverage can be
laundered out of the baseline.

`OTEL_RESOURCE_ATTRIBUTES` in `docker-compose.yml` is untouched and stays in
lock-step with `test/e2e/k3s/cerberus-values.yaml`, as `k3s_env_test.go` pins.
Reverting it would reintroduce #1818.

## 2. The wire-capture body reads are bounded

Found while trying to run a full-depth crawl: it wedged indefinitely. At
`crawl.spec.ts`:

```ts
stop: async () => {
  page.off('response', onResponse);
  await Promise.all(captureReads);   // unbounded
},
```

Each entry is an unbounded `await resp.text()`. Grafana's Drilldown apps leave
streaming responses open across a navigation, so `resp.text()` on one never
settles and `stop()` never returns. The crawl parks on a single page until the
test timeout and emits **no inventory and no verdict** — strictly worse than a
bad one.

Measured locally at full depth: after 40 idle minutes the log showed 158
`response.text` calls started against 151 succeeded + 5 failed — 2 reads still
outstanding — with the browser parked on the Loki Explore surface and
ClickHouse's `system.query_log` recording zero cerberus data-plane queries over
the preceding 5 minutes. With the bound in place the same crawl walked 535
navigations and all 656 body reads settled.

Each read is now bounded by `WIRE_BODY_READ_TIMEOUT_MS`. A read that blows the
ceiling records the same `UNREADABLE_BODY_SENTINEL` that a read which *throws*
already records, so the reconciler's semantics are unchanged; the callsite also
stops hard-coding that sentinel and imports it. Three tests cover the bound —
the never-settles case hangs to the test timeout without the fix.

This is very likely the same defect behind `e2e.yml`'s own note that this lane
"intermittently runs out to its timeout".

## Verification

- `crawl: canonicalization pins` — 13/13 green, including the new
  three-way `diffInventory` test and `committed inventory + exclusions files
  are internally consistent` against the folded pin.
- A `SWEEP_DEPTH=lean CRAWL_STACK=compose` crawl against a live compose stack
  audited all 18 lean states green, visiting
  `?var-groupBy=resource.service.namespace` — the state that is red on `main`.
