### PR TITLE
docs(process): require local reproduction of a red check before the next push

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,12 +99,29 @@ per-layer "catches X / misses Y" guidance.
    There is no tolerance file and no exemption list.
 4. **Conventional Commits**, enforced by `commitlint` (`.commitlintrc.json`). Subject ≤ 100
    characters.
-5. **No manual pre-flight; lefthook + CI own it.** Do not run `just test`, `just lint`, `go test`,
-   `golangci-lint run`, `go build`, or `markdownlint-cli2` by hand before pushing. `lefthook.yml` is
-   layered: `pre-commit` runs sub-second formatters on staged files, `commit-msg` runs commitlint,
-   and `pre-push` mirrors the CI `check` + `lint` + `forbid-skip` jobs. `LEFTHOOK=0 git push`
-   bypasses for WIP branches. CI runs the full suite plus the compat / e2e / mutation lanes the local
-   hook intentionally does not.
+5. **No speculative pre-flight, but a red check is reproduced locally before the next push.** These
+   are two halves of one rule, and the second half wins wherever they meet.
+   - *Before* a push, do not run `just test`, `just lint`, `go test`, `golangci-lint run`,
+     `go build`, or `markdownlint-cli2` as a ritual over the whole tree. `lefthook.yml` is layered:
+     `pre-commit` runs sub-second formatters on staged files, `commit-msg` runs commitlint, and
+     `pre-push` mirrors the CI `check` + `lint` + `forbid-skip` jobs. `LEFTHOOK=0 git push` bypasses
+     for WIP branches.
+   - *After* CI reports a red check, **reproduce that exact failure locally, narrowed to the thing
+     that failed**, and confirm the fix locally before pushing again. Pushing a speculative fix and
+     waiting on CI to find out is forbidden: a full run is ~19 checks and ~40 minutes, so a
+     guess-and-wait loop burns CI credits and wall-clock for feedback a targeted local run gives in
+     seconds. Narrow to the failing unit — `go test -run '^TestName$/^subtest$' ./internal/<pkg>/`,
+     or the single `node .github/scripts/<gate>.mjs`. Never re-run a whole recipe to check one test,
+     and never invoke `go test` directly where a recipe exists; the recipe carries the build tags,
+     the race flag and the timeouts, and bypassing it produces failures the recipe would not have.
+
+   Three lanes genuinely cannot be settled locally, and only these three justify a CI round-trip:
+   `lint` (golangci-lint in an agent worktree reports "No issues found" without analysing — a local
+   green is not evidence), `strict-scan` and the compat lanes (need a real ClickHouse, not chDB), and
+   `e2e` / `compose-smoke` / crawl (need k3d or Docker Compose). For those, read the CI log for the
+   exact rule, `file:line`, or assertion and reason about it directly. Concurrency hazard: this repo
+   has no per-worktree Docker Compose project-name isolation, so a compose run from one worktree
+   corrupts another's containers — never start compose while another agent is live.
 6. **Tests assert or are removed.** Never `t.Skip`, soft-assert, silent-recover, or `should_skip` a
    test. A feature that cannot run on the CI substrate (for example a CH function above the chDB
    floor) is gated at runtime and validated elsewhere, never skipped. `forbid-skip` enforces this

--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -177,6 +177,38 @@ the CI `check`, `lint`, and `forbid-skip` jobs on `pre-push`, once per push inst
 commit, and a linter invoked from a fresh agent worktree can report a clean tree without having
 analysed it — a false green is worse than no local check, because it is trusted.
 
+### Reproducing a red check
+
+A speculative pre-flight over the whole tree is waste; reproducing a *known* red check is not. Once
+CI names a failure, that failure is reproduced locally, narrowed to the thing that failed, and the
+fix is confirmed locally before the next push. A full run is roughly nineteen checks and forty
+minutes, so pushing a guess and waiting to find out spends CI credits and wall-clock on feedback a
+targeted local run returns in seconds.
+
+Narrowing means the failing unit and nothing around it:
+
+| Red check                                                         | Local reproduction                                       |
+| ----------------------------------------------------------------- | -------------------------------------------------------- |
+| `check-test`                                                      | `go test -run '^TestName$/^subtest$' ./internal/<pkg>/`  |
+| `forbid-skip`, `forbid-deferral`, `forbid-sql-raw`, `config-docs` | `node .github/scripts/<gate>.mjs` from the worktree root |
+| `check-build`                                                     | `go build ./<pkg>/` for the package named in the log     |
+
+Where a recipe exists, invoke the recipe rather than the underlying command: the recipe carries the
+build tags, the race flag and the timeouts, and a direct `go test` inherits Go's own ten-minute
+default instead — a bypass that manufactures a timeout the recipe would never have hit.
+
+Three lanes genuinely resist local reproduction, and only these justify a CI round-trip:
+
+- **`lint`** — golangci-lint run from an agent worktree reports "No issues found" without analysing.
+  Read the CI log for the linter, the rule, and the `file:line`, then reason about that line.
+- **`strict-scan` and the compatibility lanes** — these need a real ClickHouse. chDB coerces column
+  types production rejects, so a green chDB golden is not evidence for either.
+- **`e2e`, `compose-smoke`, and the crawl ratchet** — these need k3d or Docker Compose.
+
+The Compose lanes carry a concurrency hazard: there is no per-worktree Compose project-name
+isolation, so a compose run started from one worktree corrupts another's containers. Compose stays
+down while any other agent is live.
+
 ### Project subagents (`.claude/agents/`)
 
 - `code-reviewer` — reviews the working diff for regressions, missing tests, and invariant breaches


### PR DESCRIPTION
## Problem

"No manual pre-flight" was doing two jobs at once, and the second one was wrong.

Not running the whole suite as a ritual before every push is correct — lefthook already covers the staged-file formatters and the `check` + `lint` + `forbid-skip` mirror, and a speculative full run costs minutes for nothing.

But the same rule was being read as "do not run anything locally, let CI tell you", which produced a guess-and-wait loop: push a speculative fix → wait roughly forty minutes for roughly nineteen checks → read the red log → push another guess. Agents in a single session spent multiple hours inside that loop. The cost is CI credits and wall-clock, and it buys feedback that a targeted local run returns in seconds.

## Change

Invariant 5 in `CLAUDE.md` now states both halves explicitly and says which one wins where they meet:

- *before* a push — no speculative whole-tree pre-flight, unchanged;
- *after* CI names a red check — reproduce **that exact failure**, narrowed to the failing unit, and confirm the fix locally before pushing again.

`docs/agent-workflow.md` gains a `Reproducing a red check` section with the mapping from red check to narrowed local command, plus two things that were being got wrong in practice:

- **Prefer the recipe to the underlying command.** The recipe carries the build tags, the race flag and the timeouts. Invoking `go test` directly inherits Go's own ten-minute default and manufactures a timeout the recipe would never have hit — this exact confusion produced a bogus bug report against `update-cardinality-baseline`, which does pass `-timeout 60m`.
- **Three lanes genuinely resist local reproduction**, and only those justify a CI round-trip: `lint` (golangci-lint from an agent worktree reports "No issues found" without analysing, so a local green is not evidence), `strict-scan` and the compat lanes (need a real ClickHouse — chDB coerces column types production rejects), and `e2e` / `compose-smoke` / crawl (need k3d or Compose).

The Compose concurrency hazard is recorded alongside it: there is no per-worktree Compose project-name isolation, so a compose run from one worktree corrupts another's containers.

## Verification

Documentation only — no code, no generated artefacts. `markdownlint-cli2` and `commitlint` are the applicable gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)