### PR TITLE
fix(test): close the generated-artefact merge-gate net and correct the topk-computed K-cast doc

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -28,8 +28,16 @@
 #
 # Adding a new generated artefact? Add it here. The gate is pinned from both
 # directions by test/regression/generated_artifact_merge_gate_test.go, which
-# also fails on any tracked data file NAMED like a generated artefact that is
-# neither gated here nor recorded in the hand-authored section at the bottom.
+# also fails on any tracked data file that is UNCLASSIFIED — neither gated here
+# nor recorded, with a reason, in the hand-authored section at the bottom. The
+# scan reaches a file two ways: because it is named like an artefact, and —
+# the half that fails closed — because it sits in "generated territory", a
+# directory holding either a known artefact or a source file that gates an
+# os.WriteFile / writeFileSync on a regeneration mode (CERBERUS_UPDATE_*,
+# GOLDEN_UPDATE, UPDATE_*_BASELINE, REGENERATE and friends). Naming an artefact
+# outside the four historical families is therefore no longer enough to escape
+# the gate, which is how test/rejection-parity/divergence-ceiling.json and the
+# two reference-verdict ledgers sat here ungated (#1868).
 #
 # `-merge` protects a LOCAL `git merge` / `git rebase` / `git pull`, which
 # reads this file. Whether GitHub's SERVER-SIDE merge (the "Update branch"
@@ -130,7 +138,8 @@ compatibility/loki/upstream-skip-baseline.txt  -merge
 #   a golden is a reviewed artefact, never rewritten by the lane asserting it.
 # Matched by basename so a new archetype's goldens are gated on arrival.
 # Deliberately NOT gated: expected/compliance-retention.json and
-# expected/tier1.json are hand-authored fixtures that are read, never written.
+# expected/tier1.json are hand-authored fixtures that are read, never written —
+# recorded as such in the hand-authored section at the bottom.
 test/e2e/migration/archetypes/*/expected/corpus.json     -merge
 test/e2e/migration/archetypes/*/expected/explain.txt     -merge
 test/e2e/migration/archetypes/*/expected/gate.json       -merge
@@ -157,12 +166,29 @@ test/e2e/grafana/ql-inventory/traceql-feature-inventory.json  -merge
 # guards in different files write different shards and never blend; `-merge`
 # still covers the residual case of two branches touching the same shard.
 test/rejection-parity/catalogue/*.json       -merge
+# The divergence ceiling is the catalogue's monotonic-count leg, written by the
+# same env gate: CERBERUS_UPDATE_INVENTORY=1 go test ./test/rejection-parity/
+# tightens it to match a decrease. It holds one key today, so a blend collides
+# on the same line — that is the file's shape, not a protection, and the shape
+# changes the first time a second key lands.
+test/rejection-parity/divergence-ceiling.json  -merge
 # CERBERUS_UPDATE_INVENTORY=1 go test ./test/surface-parity/
 test/surface-parity/inventory.json           -merge
 # Regenerate: REGENERATE=1 node .github/scripts/promql-surface-gate.mjs
 #   (starts a local reference Prometheus in Docker; normally produced by the
 #    compatibility/promql-surface job)
 test/surface-parity/promql-reference-verdicts.json  -merge
+# Regenerate: CERBERUS_UPDATE_LOGQL_REFERENCE_VERDICTS=1 go test -tags agpl_oracle
+#   -run TestLogQLReferenceVerdictsAreCurrent ./test/surface-parity/
+#   One `"<symbol>": "<verdict>"` entry per probed surface symbol, re-probed
+#   through upstream Loki's AGPL parser. The default build reads the ledger
+#   instead of linking that parser, so a blended verdict silently changes what
+#   parity means for a symbol nobody re-probed.
+test/surface-parity/logql-reference-verdicts.json    -merge
+# Regenerate: CERBERUS_UPDATE_TRACEQL_REFERENCE_VERDICTS=1 go test -tags agpl_oracle
+#   -run TestTraceQLReferenceVerdictsAreCurrent ./test/surface-parity/
+#   Same shape and same hazard, against upstream Tempo's AGPL parser.
+test/surface-parity/traceql-reference-verdicts.json  -merge
 
 # --- Grafana surface crawl inventories --------------------------------------
 # Regenerate: CERBERUS_UPDATE_INVENTORY=1 SWEEP_DEPTH=full CRAWL_STACK=<stack>
@@ -173,11 +199,14 @@ test/surface-parity/promql-reference-verdicts.json  -merge
 test/e2e/playwright/crawl/grafana-surface-inventory.compose.json  -merge
 test/e2e/playwright/crawl/grafana-surface-inventory.k3d.json      -merge
 
-# --- Named like a generated artefact, but HAND-AUTHORED ---------------------
+# --- In generated territory, but HAND-AUTHORED ------------------------------
 # These are recorded rather than gated. Each is hand-maintained, and each is
-# self-checking: its consumer recomputes the value it pins, so a bad blend fails
-# loudly instead of silently widening a tolerance — which is the property that
-# makes `-merge` necessary for everything above and unnecessary here.
+# self-checking: its consumer recomputes or re-derives what it pins, so a bad
+# blend fails loudly instead of silently widening a tolerance — which is the
+# property that makes `-merge` necessary for everything above and unnecessary
+# here. A record counts only while it STATES that reason; the gate rejects one
+# that names a path and argues nothing, because a list of paths with no argument
+# is an exemption set rather than a classification.
 # hand-authored: test/e2e/migration/coverage-baseline.json — raise-only counts;
 #   migration-e2e.mjs only reads it and errors telling you to reconcile.
 # hand-authored: test/e2e/migration/pass-assertions.pin.json — deliberately has
@@ -189,6 +218,26 @@ test/e2e/playwright/crawl/grafana-surface-inventory.k3d.json      -merge
 #   same, for the LogQL crawl.
 # hand-authored: test/e2e/grafana/ql-inventory/traceql-feature-exclusions.json —
 #   same, for the TraceQL crawl.
+# hand-authored: test/e2e/playwright/crawl/grafana-surface-exclusions.compose.json —
+#   curated, empty by design and shrink-biased; the crawl fails on any URL that
+#   appears both here and in the stack's inventory, so a blend that invents an
+#   entry is caught by the crawl it guards rather than quietly skipping a page.
+# hand-authored: test/e2e/playwright/crawl/grafana-surface-exclusions.k3d.json —
+#   same, for the k3d stack.
+# hand-authored: compatibility/loki/dataset_metadata.json —
+#   pinned by hand from the deterministic fixture cmd/seed/ pushes (it carries a
+#   `_comment` field the bench metadata struct does not even model, so nothing
+#   writes it). The compliance driver substitutes it into every corpus query and
+#   reports `baseline returned empty` as an unexpected failure, so a blended
+#   selector breaks the reference side loudly instead of scoring a hollow pass.
+# hand-authored: test/e2e/migration/archetypes/regulated-airgapped/expected/compliance-retention.json —
+#   a declared mandate the tier-1 lane reads and never writes; the step that
+#   consumes it rejects a mandate that "bounds nothing", so a blend fails the
+#   scenario rather than weakening it.
+# hand-authored: test/e2e/migration/archetypes/three-signal/expected/tier1.json —
+#   the hand-declared tier-1 parity expectation, read and never written; the
+#   parity test compares live results against it, so a blended row fails the
+#   comparison it exists to drive.
 #
 # Two further families are deliberately left ungated, for the same "a blend is
 # loud, not silent" reason:

--- a/internal/chsql/emit_node.go
+++ b/internal/chsql/emit_node.go
@@ -717,7 +717,7 @@ func (e *emitter) emitTopK(t *chplan.TopK) error {
 //	SELECT <Columns> FROM (
 //	  SELECT *, row_number() OVER (PARTITION BY <By> ORDER BY <SortExpr> [DESC]) AS _rn
 //	  FROM (<input>)
-//	) WHERE _rn <= (SELECT toUInt64(`Value`) FROM (<KExpr>) LIMIT 1)
+//	) WHERE toFloat64(_rn) <= (SELECT toFloat64(`Value`) FROM (<KExpr>) LIMIT 1)
 //
 // `By` empty omits PARTITION BY (the rank fires across the whole
 // result). `_rn` is a CH-safe synthetic alias the emitter pins; the
@@ -725,13 +725,14 @@ func (e *emitter) emitTopK(t *chplan.TopK) error {
 // does not use leading-underscore columns, so the alias does not
 // collide with the inner subquery's columns.
 //
-// The K subquery is wrapped in `toUInt64(...)` so a non-integer scalar
-// (PromQL semantics permit a float K, truncated to int) does not
-// surface as a CH "cannot compare UInt64 and Float64" error. The
-// trailing `LIMIT 1` guards against the unusual case where the scalar
-// subtree returns multiple rows — CH's scalar-subquery binding refuses
-// non-unique results, and PromQL's `scalar()` is documented to return
-// NaN in that case (which would coerce to 0 here and reject every row).
+// Both sides of the comparison are `toFloat64(...)`, deliberately: K is
+// never cast to an integer, for the correctness reason spelled out at
+// the kSelect below — a UInt64 cast wraps a negative K to ~1.8e19 and
+// lets every row through, where PromQL requires any K below 1 to select
+// nothing. The trailing `LIMIT 1` guards against the unusual case where
+// the scalar subtree returns multiple rows — CH's scalar-subquery
+// binding refuses non-unique results, and PromQL's `scalar()` is
+// documented to return NaN in that case, which selects no row here.
 func (e *emitter) emitTopKComputed(t *chplan.TopK) error {
 	sub, err := e.subqueryFrag(t.Input)
 	if err != nil {

--- a/test/regression/generated_artifact_merge_gate_test.go
+++ b/test/regression/generated_artifact_merge_gate_test.go
@@ -4,7 +4,10 @@ import (
 	"io/fs"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
+	"regexp"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -42,11 +45,24 @@ const mergeAttrUnset = "unset"
 // separator rather than by splitting into a fixed field count.
 const checkAttrSeparator = ": "
 
-// handAuthoredMarker records, inside the gate itself, a file that is NAMED like
-// a generated artefact but is maintained by hand. Writing the exemption next to
-// the rule is what keeps the classification a decision someone made rather than
-// a gap nobody noticed.
+// handAuthoredMarker records, inside the gate itself, a committed data file
+// that sits in generated territory but is maintained by hand. Writing the
+// classification next to the rule is what keeps it a decision someone made
+// rather than a gap nobody noticed — and a record counts only when it STATES
+// the reason a bad merge of that file would fail loudly, so the section can
+// never decay into a bare list of paths the gate has agreed to ignore.
 const handAuthoredMarker = "# hand-authored: "
+
+// handAuthoredContinuation is the prefix of a comment line that continues the
+// previous hand-authored record's reason. The records are wrapped prose, so the
+// reason routinely starts on the line below the path; a continuation is
+// indented past the `# ` every other comment in the file uses.
+const handAuthoredContinuation = "#  "
+
+// reasonPunctuation is trimmed off a parsed reason before it is checked for
+// emptiness — a record whose stated reason is nothing but the em dash that
+// introduces it has stated nothing.
+const reasonPunctuation = " —-"
 
 // generatedArtifact is one committed file written by a regeneration command
 // rather than by hand, together with the distinctive fragment of that command
@@ -77,6 +93,16 @@ const inventoryUpdateEnv = "CERBERUS_UPDATE_INVENTORY=1"
 // inventories; it needs the named stack healthy, so the resolution is heavier
 // than a `go test` and the gate says so.
 const crawlInventorySpec = "npx playwright test crawl/crawl.spec.ts"
+
+// logqlReferenceVerdictsEnv and traceqlReferenceVerdictsEnv are the env gates
+// that re-probe every LogQL / TraceQL surface symbol through the AGPL reference
+// parser and rewrite the checked-in verdict ledger. They need the `agpl_oracle`
+// build tag, which is why each has its own gate rather than riding
+// CERBERUS_UPDATE_INVENTORY.
+const (
+	logqlReferenceVerdictsEnv   = "CERBERUS_UPDATE_LOGQL_REFERENCE_VERDICTS=1"
+	traceqlReferenceVerdictsEnv = "CERBERUS_UPDATE_TRACEQL_REFERENCE_VERDICTS=1"
+)
 
 // parityBaselineSync is the ONLY entry here that is not a local command. It
 // rewrites a head's entry from that head's compat-cases.json RUN ARTEFACT,
@@ -132,6 +158,10 @@ var generatedArtifacts = []generatedArtifact{
 	{"test/e2e/grafana/ql-inventory/traceql-feature-inventory.json", inventoryUpdateEnv},
 	{"test/surface-parity/inventory.json", inventoryUpdateEnv},
 	{"test/surface-parity/promql-reference-verdicts.json", "promql-surface-gate.mjs"},
+	{"test/surface-parity/logql-reference-verdicts.json", logqlReferenceVerdictsEnv},
+	{"test/surface-parity/traceql-reference-verdicts.json", traceqlReferenceVerdictsEnv},
+
+	{"test/rejection-parity/divergence-ceiling.json", inventoryUpdateEnv},
 
 	{"test/e2e/playwright/crawl/grafana-surface-inventory.compose.json", crawlInventorySpec},
 	{"test/e2e/playwright/crawl/grafana-surface-inventory.k3d.json", crawlInventorySpec},
@@ -260,42 +290,242 @@ func TestGeneratedArtifactsRefuseLineMerge(t *testing.T) {
 }
 
 // generatedNameMarkers are the naming families cerberus gives its generated data
-// artefacts. They are the net for artefacts added AFTER this gate landed: the
-// roster above can only cover what its author knew about, so anything committed
-// under one of these names has to be classified here one way or the other. A
-// family name on the DIRECTORY counts — see looksGenerated.
+// artefacts. They are a SECOND, independent signal, and no longer the load
+// bearing one: a substring list of naming families protects only artefacts whose
+// author happened to pick one of these words, so it caught neither
+// test/rejection-parity/divergence-ceiling.json nor the two AGPL-oracle
+// reference-verdict ledgers (#1868). The classification that fails closed is the
+// territory inversion below; this list stays because it reaches artefacts
+// OUTSIDE any generated directory, which the inversion by construction does not.
+// A family name on the DIRECTORY counts — see looksGenerated.
 var generatedNameMarkers = []string{"baseline", "inventory", "catalogue", ".pin."}
 
-// generatedDataExtensions restrict the net to DATA files. The same words appear
-// in the names of the Go and Node sources that PRODUCE these artefacts
+// generatedDataExtensions restrict both nets to DATA files. The same words
+// appear in the names of the Go and Node sources that PRODUCE these artefacts
 // (compat-baseline-sync.mjs, inventory.go, catalogue.go); those are hand-written
 // code, and code is line-mergeable.
-var generatedDataExtensions = []string{".json", ".txt"}
+var generatedDataExtensions = []string{".json", ".txt", ".sql"}
+
+// generatorSourceExtensions are the languages cerberus writes its generators in.
+// A generator is found by reading source, not by compiling it, so the
+// build-tagged ones (`agpl_oracle`, `chdb`, `migration`) are seen by this gate
+// exactly like any other file — which matters, because two of the artefacts the
+// name net missed are written from behind `agpl_oracle`.
+var generatorSourceExtensions = []string{".go", ".mjs", ".ts", ".js"}
+
+// updateModeWriteCall matches the two file-write calls cerberus's generators
+// make. A generated artefact exists because something wrote it; that is the fact
+// the classification hangs on, rather than on what the artefact was named.
+var updateModeWriteCall = regexp.MustCompile(`os\.WriteFile\(|writeFileSync\(`)
+
+// updateModeGate matches the SHOUTING env-var or flag name a regeneration mode
+// is gated on — CERBERUS_UPDATE_INVENTORY, GOLDEN_UPDATE, MIGRATION_UPDATE_GOLDENS,
+// UPDATE_CARDINALITY_BASELINE, COVERAGE_UPDATE_FLOORS, REGENERATE and their
+// siblings all carry one of these three words. Pairing it with a write call is
+// what separates a generator from the many tests that write a scratch file into
+// a t.TempDir().
+var updateModeGate = regexp.MustCompile(`[A-Z0-9_]*(?:UPDATE|REGEN|GOLDEN)[A-Z0-9_]*`)
+
+// updateModeWriters returns every tracked source file that gates a file write on
+// a regeneration mode. These are the generators, read off the tree rather than
+// listed by hand: adding one is how a new generated artefact comes into
+// existence, and the directory it sits in becomes generated territory the moment
+// it lands.
+func updateModeWriters(t *testing.T, tracked []string) []string {
+	t.Helper()
+
+	var writers []string
+	for _, file := range tracked {
+		if !hasExtension(file, generatorSourceExtensions) {
+			continue
+		}
+		body, err := os.ReadFile(filepath.Join(repoRoot, filepath.FromSlash(file)))
+		if err != nil {
+			t.Fatalf("read %s: %v. It is tracked, so it must be readable from the repository root "+
+				"this gate resolves against.", file, err)
+		}
+		if updateModeWriteCall.Match(body) && updateModeGate.Match(body) {
+			writers = append(writers, file)
+		}
+	}
+
+	if len(writers) == 0 {
+		t.Fatalf("no tracked source file pairs a file write with a regeneration-mode gate. Every "+
+			"generated artefact in this repository is written by one, so an empty set means the "+
+			"scan stopped reading the tree — check that this gate runs with the repository root "+
+			"at %s.", repoRoot)
+	}
+
+	return writers
+}
+
+// generatedTerritory is the set of directories in which a committed data file
+// has to be classified. It is DERIVED, never listed:
+//
+//   - the directory of every update-mode writer, because a generator almost
+//     always writes next to itself;
+//   - the directory of every rostered artefact, so a generated artefact's
+//     siblings are policed by its presence;
+//   - the directory of every hand-authored record, for the same reason from the
+//     other side.
+//
+// The inversion is the point. The name net asks "is this file named like an
+// artefact?" and lets everything else through; territory asks "is this file
+// sitting where artefacts are made?" and lets NOTHING through unclassified. A
+// new artefact dropped next to its generator is therefore loud on arrival
+// whatever it is called, which is exactly what divergence-ceiling.json was not
+// (#1868).
+func generatedTerritory(roster []generatedArtifact, records map[string]string, writers []string) map[string]struct{} {
+	territory := make(map[string]struct{})
+	for _, writer := range writers {
+		territory[path.Dir(writer)] = struct{}{}
+	}
+	for _, artifact := range roster {
+		territory[path.Dir(artifact.path)] = struct{}{}
+	}
+	for recorded := range records {
+		territory[path.Dir(recorded)] = struct{}{}
+	}
+
+	return territory
+}
+
+// hasExtension reports whether a slash-separated path's basename ends in one of
+// the given extensions.
+func hasExtension(file string, extensions []string) bool {
+	base := strings.ToLower(path.Base(file))
+	for _, ext := range extensions {
+		if strings.HasSuffix(base, ext) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// handAuthoredRecords parses the hand-authored section of `.gitattributes` into
+// path -> stated reason, folding each record's wrapped continuation lines into
+// the reason. A record that names a path without arguing for it is rejected: an
+// entry with no reason is an expected-failure list wearing a comment's clothes,
+// and the classification only means something while every "not generated" is a
+// position someone took.
+func handAuthoredRecords(t *testing.T, attrBody string) map[string]string {
+	t.Helper()
+
+	lines := strings.Split(attrBody, "\n")
+	records := make(map[string]string)
+	for i, line := range lines {
+		rest, found := strings.CutPrefix(line, handAuthoredMarker)
+		if !found {
+			continue
+		}
+
+		recorded, reason, _ := strings.Cut(strings.TrimSpace(rest), " ")
+		for _, cont := range lines[i+1:] {
+			if !strings.HasPrefix(cont, handAuthoredContinuation) {
+				break
+			}
+			reason += " " + strings.TrimSpace(strings.TrimPrefix(cont, "#"))
+		}
+
+		reason = strings.Trim(reason, reasonPunctuation)
+		if reason == "" {
+			t.Errorf("%s records %s as hand-authored but states no reason. A record with no reason "+
+				"is an exemption, not a classification: say what regenerates nothing here and why a "+
+				"bad merge of it fails loudly instead of silently.", gitattributesPath, recorded)
+		}
+		records[recorded] = reason
+	}
+
+	return records
+}
 
 // TestNoGeneratedArtifactEscapesTheMergeGate walks every tracked file and fails
-// on one that is named like a generated artefact yet is neither `-merge` gated
-// nor recorded as hand-authored in the gate. Without this the gate decays the
-// moment someone adds the next baseline: the roster above would still pass while
-// the new file merges silently, which is the shape of the bug rather than a fix
-// for it.
+// on a committed data file that is UNCLASSIFIED: one sitting in generated
+// territory, or named like a generated artefact, that is neither `-merge` gated
+// and rostered nor recorded as hand-authored with a reason. Without this the
+// gate decays the moment someone adds the next artefact: the roster above would
+// still pass while the new file merges silently, which is the shape of the bug
+// rather than a fix for it.
+//
+// The two nets fail in opposite directions on purpose. The name net is
+// permissive — everything it does not recognise is allowed through — which is
+// how divergence-ceiling.json and the two reference-verdict ledgers went
+// unprotected under four naming families that happened not to describe them
+// (#1868). Territory is the closed half: inside a directory where artefacts are
+// made, a data file is unclassified until someone classifies it, so the default
+// for a new file is loud rather than silent.
 func TestNoGeneratedArtifactEscapesTheMergeGate(t *testing.T) {
 	t.Parallel()
 
 	attrBody := readGitattributes(t)
+	records := handAuthoredRecords(t, attrBody)
 
-	// The net is name-based, so it sees only the subset of the roster that is
-	// actually NAMED like a generated artefact — the migration goldens are
-	// gated by path pattern instead and never match it. Counting that subset
-	// here is what makes the reachability check below compare like with like.
 	roster := rosterArtifacts(t)
 	rostered := make(map[string]struct{}, len(roster))
-	var rosteredMatchingNet int
 	for _, artifact := range roster {
 		rostered[artifact.path] = struct{}{}
-		if looksGenerated(artifact.path) {
-			rosteredMatchingNet++
+	}
+
+	tracked := trackedFiles(t)
+	territory := generatedTerritory(roster, records, updateModeWriters(t, tracked))
+
+	var candidates []string
+	for _, file := range tracked {
+		if !hasExtension(file, generatedDataExtensions) {
+			continue
+		}
+		if _, inTerritory := territory[path.Dir(file)]; !inTerritory && !looksGenerated(file) {
+			continue
+		}
+		candidates = append(candidates, file)
+	}
+	states := mergeAttrs(t, candidates)
+
+	scanned := make(map[string]struct{}, len(candidates))
+	for _, file := range candidates {
+		scanned[file] = struct{}{}
+
+		gated := states[file] == mergeAttrUnset
+		if _, ok := rostered[file]; ok {
+			// The per-artefact test above reports an ungated roster entry in
+			// full; repeating it here would only duplicate the failure.
+			continue
+		}
+
+		if gated {
+			t.Errorf("%s is `-merge` gated in %s but is missing from generatedArtifacts. The "+
+				"roster is what pins the regeneration command next to the rule, so an entry "+
+				"only in %s leaves the conflict undiagnosable. Add it, with the command that "+
+				"regenerates it.", file, gitattributesPath, gitattributesPath)
+
+			continue
+		}
+
+		if _, recorded := records[file]; !recorded {
+			t.Errorf("%s is an unclassified data file in generated territory (%s holds a "+
+				"generator or a known generated artefact). If a command regenerates it, gate it "+
+				"`-merge` in %s and add it to generatedArtifacts — an ungated generated baseline "+
+				"is how PR #1422's silent blend got in. If it really is hand-maintained, say so "+
+				"in %s with a %q%s line and the reason a bad merge of it would fail loudly.",
+				file, path.Dir(file), gitattributesPath, gitattributesPath, handAuthoredMarker, file)
 		}
 	}
+
+	for _, artifact := range roster {
+		if _, ok := scanned[artifact.path]; !ok {
+			t.Fatalf("the classification scan never reached %s, which this gate's own roster names "+
+				"as a generated artefact. Every rostered artefact is a data file in generated "+
+				"territory by construction, so missing one means the scan is not reading the tree "+
+				"it polices — check that this test runs with the repository root at %s.",
+				artifact.path, repoRoot)
+		}
+	}
+}
+
+// trackedFiles lists every file git tracks, slash-separated and repo-root-relative.
+func trackedFiles(t *testing.T) []string {
+	t.Helper()
 
 	cmd := exec.Command("git", "ls-files")
 	cmd.Dir = repoRoot
@@ -304,51 +534,43 @@ func TestNoGeneratedArtifactEscapesTheMergeGate(t *testing.T) {
 		t.Fatalf("git ls-files: %v", err)
 	}
 
-	var candidates []string
-	for _, tracked := range strings.Split(strings.TrimSpace(string(out)), "\n") {
-		if looksGenerated(tracked) {
-			candidates = append(candidates, tracked)
-		}
-	}
-	states := mergeAttrs(t, candidates)
+	return strings.Split(strings.TrimSpace(string(out)), "\n")
+}
 
-	matched := len(candidates)
-	for _, tracked := range candidates {
-		gated := states[tracked] == mergeAttrUnset
-		if _, ok := rostered[tracked]; ok {
-			if !gated {
-				// The per-artefact test above reports this in full; counting it
-				// here too would only duplicate the failure.
-				continue
-			}
+// TestTerritoryCatchesWhatTheNameNetCannot pins the #1868 defect itself. The
+// ceiling ratchet's artefact is named after neither a baseline, an inventory, a
+// catalogue nor a pin, so the name net classified it as "not a generated file"
+// and it sat ungated. What makes it generated is that the ratchet WRITES it
+// under CERBERUS_UPDATE_INVENTORY, and that is what territory reads. Pinning
+// both halves stops a future simplification from dropping the derivation back
+// to naming, where the same class of file escapes again under a fifth word.
+func TestTerritoryCatchesWhatTheNameNetCannot(t *testing.T) {
+	t.Parallel()
 
-			continue
-		}
+	const (
+		ceiling = "test/rejection-parity/divergence-ceiling.json"
+		ratchet = "test/rejection-parity/divergence_ratchet_test.go"
+	)
 
-		if gated {
-			t.Errorf("%s is `-merge` gated in %s but is missing from generatedArtifacts. The "+
-				"roster is what pins the regeneration command next to the rule, so an entry "+
-				"only in %s leaves the conflict undiagnosable. Add it, with the command that "+
-				"regenerates it.", tracked, gitattributesPath, gitattributesPath)
-
-			continue
-		}
-
-		if !strings.Contains(attrBody, handAuthoredMarker+tracked) {
-			t.Errorf("%s is named like a generated artefact but is neither `-merge` gated nor "+
-				"recorded as hand-authored in %s. If a command regenerates it, gate it and add "+
-				"it to generatedArtifacts — an ungated generated baseline is how PR #1422's "+
-				"silent blend got in. If it really is hand-maintained, say so there with a "+
-				"%q%s line and the reason a bad merge of it would fail loudly.",
-				tracked, gitattributesPath, handAuthoredMarker, tracked)
-		}
+	if looksGenerated(ceiling) {
+		t.Errorf("looksGenerated(%q) = true. This test exists because it is FALSE: the name net "+
+			"cannot see this artefact, which is why the classification may not rest on naming.",
+			ceiling)
 	}
 
-	if matched < rosteredMatchingNet {
-		t.Fatalf("the generated-name net matched only %d tracked files, fewer than the %d rostered "+
-			"artefacts whose own names match it. The net is no longer reaching the tree it "+
-			"polices — check that this test runs with the repository root at %s.",
-			matched, rosteredMatchingNet, repoRoot)
+	writers := updateModeWriters(t, trackedFiles(t))
+	if !slices.Contains(writers, ratchet) {
+		t.Fatalf("%s is not among the %d update-mode writers this gate derives territory from, yet "+
+			"it writes %s under CERBERUS_UPDATE_INVENTORY. Without it %s is in no directory the "+
+			"gate polices and goes back to being silently line-merged (#1868).",
+			ratchet, len(writers), ceiling, ceiling)
+	}
+
+	if _, ok := generatedTerritory(nil, nil, writers)[path.Dir(ceiling)]; !ok {
+		t.Errorf("%s is not generated territory even though %s writes into it. Territory derived "+
+			"from the writers alone is what has to reach this directory — deriving it from the "+
+			"roster instead would only ever confirm what someone already classified.",
+			path.Dir(ceiling), ratchet)
 	}
 }
 


### PR DESCRIPTION
## What

Two fully-verified defects, one PR.

### #1868 — the merge gate classified artefacts by their NAME

`test/regression/generated_artifact_merge_gate_test.go` netted post-hoc artefacts
with four naming families matched against the whole path — `baseline`,
`inventory`, `catalogue`, `.pin.`. Anything named otherwise was classified as
"not a generated file" and sat unprotected while `TestNoGeneratedArtifactEscapesTheMergeGate`
reported green. `test/rejection-parity/divergence-ceiling.json` is written by the
divergence ratchet under `CERBERUS_UPDATE_INVENTORY` and matched none of the four.

Adding a fifth word would have moved the hole. This inverts the classification so
it fails closed:

- A directory is **generated territory** when it holds a known artefact, a
  hand-authored record, or a source file that gates an `os.WriteFile` /
  `writeFileSync` on a regeneration mode (`CERBERUS_UPDATE_*`, `GOLDEN_UPDATE`,
  `UPDATE_*_BASELINE`, `MIGRATION_UPDATE_GOLDENS`, `COVERAGE_UPDATE_FLOORS`,
  `REGENERATE`). The writer set is read off the tree, never listed — a generated
  artefact exists because something wrote it, and that is the fact the gate hangs on.
- Every committed data file in territory must be **either** `-merge` gated and
  rostered with its regeneration command, **or** recorded hand-authored **with the
  reason** a bad merge of it fails loudly. A record that names a path and argues
  nothing is now rejected outright, so the section cannot decay into a list of
  paths the gate agrees to ignore.
- The name net stays as a second, independent signal: it reaches artefacts
  *outside* any generated directory, which territory by construction does not.

Sources are read, not compiled, so `agpl_oracle` / `chdb` / `migration`-tagged
generators are visible to the gate like any other file.

The inversion immediately surfaced two more unprotected generated ledgers written
from behind `agpl_oracle`: `test/surface-parity/logql-reference-verdicts.json` and
`test/surface-parity/traceql-reference-verdicts.json`. All three artefacts are now
`-merge` gated in `.gitattributes` and rostered with their regeneration commands.
Five files in territory that really are hand-written gained records stating why a
blend of each fails loudly.

`TestTerritoryCatchesWhatTheNameNetCannot` pins the defect itself: it asserts
`looksGenerated("…/divergence-ceiling.json")` is **false** and that the writer scan
nevertheless reaches `divergence_ratchet_test.go`, so a future simplification cannot
quietly put the classification back on naming.

### #1869 — `emitTopKComputed`'s doc claimed a cast the code refuses to make

`internal/chsql/emit_node.go:720`/`:728` documented the K subquery as wrapped in
`toUInt64(...)`. The paragraph 50 lines below, the comment at `:640`, and the code
at `:784`/`:789` all say `toFloat64` on both sides — deliberately, because a UInt64
cast wraps a negative K to ~1.8e19 and lets **every** row through, where PromQL
requires any K below 1 to select nothing. Someone "restoring consistency" the other
way would have reintroduced that bug with the comment vouching for them. The SQL
sketch and the paragraph now state `toFloat64` and point at the rationale. No
behaviour change.

## Verification

The new gate was proven to **activate** before it was made to pass: run against the
unclassified tree it failed with five `is an unclassified data file in generated
territory` errors (`compatibility/loki/dataset_metadata.json`, the two
`grafana-surface-exclusions.*.json`, `compliance-retention.json`, `tier1.json`),
plus the three newly-rostered artefacts failing the `-merge` leg. After
classification, all four gate tests pass.

Closes #1868
Closes #1869

🤖 Generated with [Claude Code](https://claude.com/claude-code)