### PR TITLE
fix(e2e): stop the nightly full-depth crawl being cancelled and parameterize the field segment

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -95,6 +95,19 @@ changed"), and segment-wise `underPrefix` / `matchesAny`.
 It exists so the two dangerous parts — the always-full event set and the
 uncomputable-diff fallback — cannot drift between the lanes that use it.
 
+`lib/crawl-budget.mjs` owns the two nested time budgets the Grafana surface
+crawl runs under — the SPEC budget `crawl.spec.ts` sets on itself
+(`testInfo.setTimeout`) and the JOB cap the shard planners put on the runner —
+and the ordering between them: the job cap is always the spec budget plus a
+fixed overhead headroom, so the spec times out first and reports a real
+`failure` with its partial inventory. Get that ordering backwards and the
+runner kills the job instead, which GitHub records as `cancelled` — not a
+verdict, and the state that let the nightly full-depth sweep go unenforced.
+Both `compose-smoke-matrix.mjs` and `dashboard-matrix.mjs` derive their crawl
+caps from `crawlShardTimeoutMinutes(depth)` here, and
+`parseSpecBudgetsFromSource()` lets the guard test read the real spec file so
+the pinned numbers cannot drift away from what the crawl actually asks for.
+
 ## Modules
 
 - **`agpl-clean.mjs`** — `ci.yml`, the `agpl-clean` job. The provably-clean-build
@@ -1137,10 +1150,12 @@ uncomputable-diff fallback — cannot drift between the lanes that use it.
   reported, then `exit 1`. `compose-smoke-matrix.test.mjs` is the `node --test`
   guard (run on the cheap `forbid-skip` job) that pins the invariant + proves the
   detectors fire. Two extra responsibilities: (1) it carries the per-shard
-  `timeoutMinutes` ceiling on each emitted entry — the crawl shard gets a hard
-  30-min cap (`CRAWL_SHARD_TIMEOUT_MIN`; fail fast, release the concurrency
-  slot), non-crawl shards keep 120 (nightly full, `IS_SCHEDULE=true`) / 45
-  (PR/push lean); (2) it splits the partition into a REQUIRED `matrix` and an
+  `timeoutMinutes` ceiling on each emitted entry — the crawl shard's cap is
+  derived from its own spec budget at the depth this event sweeps at
+  (`lib/crawl-budget.mjs`; fail fast, release the concurrency slot, but always
+  ABOVE the spec budget so the spec times out first), non-crawl shards keep 120
+  (nightly full, `IS_SCHEDULE=true`) / 45 (PR/push lean); (2) it splits the
+  partition into a REQUIRED `matrix` and an
   informational `matrix_informational` (the `GATE_EXCLUDED_SHARDS` coverage
   shards — today `shard-crawl`). The required `compose-smoke` aggregator
   `needs:` only the required matrix, so a crawl flake/hang reports its own
@@ -1152,6 +1167,29 @@ uncomputable-diff fallback — cannot drift between the lanes that use it.
     `"true"` selects the full non-crawl timeout), `GITHUB_OUTPUT` (emit: the
     runner file the `matrix` / `matrix_informational` / `has_informational` /
     `gate_excluded` outputs are written to).
+
+- **`assert-crawl-terminal.mjs`** — `e2e.yml`, the `crawl-terminal` job. The
+  de-gated crawl lane's only reader. `compose-smoke-shard-info (shard-crawl)`
+  is deliberately outside the required `compose-smoke` gate so a crawl hang
+  cannot block a PR — which also means nothing was reading its result, and a
+  crawl killed by its own job cap reported `cancelled` and enforced NOTHING
+  while the lane still looked present. This job asserts TERMINALITY, not
+  correctness: the crawl shard must reach `success` or `failure`. `cancelled`
+  (job cap hit, or the runner reclaimed it), `skipped` (never dispatched), and
+  any unknown conclusion all fail with a message naming the depth, which
+  surface pin went unenforced, and the two budgets from `lib/crawl-budget.mjs`
+  to compare. It also fails when the setup job stopped emitting an
+  informational matrix at all — an empty `has_informational` means the shard
+  silently stopped existing, which is coverage loss disguised as a green lane.
+  The one clean no-op is a change out of the crawl lane's scope: setup
+  `skipped` behind a `compose-smoke-scope` that itself succeeded. A scope job
+  that crashed leaves the crawl undecided, and that fails.
+  - Env: `SCOPE_RESULT`, `SETUP_RESULT`, `HAS_INFORMATIONAL` (the setup job's
+    output of the same name), `CRAWL_SHARD_RESULT` (the informational matrix's
+    rolled-up result), `SWEEP_DEPTH` (`full` on schedule, else `lean` — names
+    which pin was at stake in the failure message).
+  - Exit: `0` when the crawl reached a verdict or was legitimately out of
+    scope, `1` on any non-terminal outcome.
   - Exit: `0` clean / matrix emitted, `1` on any coverage violation or bad
     `MODE`.
 
@@ -1289,9 +1327,11 @@ uncomputable-diff fallback — cannot drift between the lanes that use it.
   `node --test` guard (run on the cheap `forbid-skip` job) pinning the invariant +
   proving the detectors fire. k3d is heavy + flaky, so the shard count is kept
   deliberately small. Each emitted entry also carries a per-shard
-  `timeoutMinutes`: the crawl shard gets a hard 30-min cap
-  (`CRAWL_SHARD_TIMEOUT_MIN`; fail fast, release the k3d concurrency slot), the
-  smoke shards keep their 75-min cluster-lifetime bound (`SMOKE_SHARD_TIMEOUT_MIN`).
+  `timeoutMinutes`: the crawl shard gets the FULL-depth cap from
+  `lib/crawl-budget.mjs` (this shard always sweeps `SWEEP_DEPTH=full`; fail fast,
+  release the k3d concurrency slot, but above the spec budget so the spec times
+  out first), the smoke shards keep their 75-min cluster-lifetime bound
+  (`SMOKE_SHARD_TIMEOUT_MIN`).
   The `dashboard` aggregator is a branch-protection required check; the crawl
   shard runs only on schedule, dispatch, and release/* PRs, so it never gates
   an ordinary PR's merge-when-green.

--- a/.github/scripts/assert-crawl-terminal.mjs
+++ b/.github/scripts/assert-crawl-terminal.mjs
@@ -1,0 +1,162 @@
+// assert-crawl-terminal.mjs — assert the Grafana surface-crawl shard reached a
+// TERMINAL test verdict, and fail loudly when it did not.
+//
+// Why this exists
+// ---------------
+// The crawl shard is deliberately de-gated from the required `compose-smoke`
+// aggregate (see GATE_EXCLUDED_SHARDS in compose-smoke-matrix.mjs): it is slow
+// BFS COVERAGE, not a correctness gate, and a coverage flake must not block
+// every PR merge. That de-gate is right, but it left the lane with no reader at
+// all — so when the shard stopped producing verdicts entirely, nothing said so.
+//
+// That is what #1861 was. The nightly `shard-crawl` job was killed by its own
+// `timeout-minutes` on every run, three nights running. GitHub records a
+// `timeout-minutes` kill as conclusion `cancelled`, which is NOT a test result:
+// no assertions ran to completion, no inventory diff was computed, no verdict
+// was produced. Meanwhile the required `compose-smoke` aggregate went green
+// (correctly — it does not need the crawl matrix) while ~237 of the surface
+// pin's rows, the ones only the full-depth nightly sweep can reach, were
+// enforced by nothing. The pin's size implied coverage that was not happening.
+//
+// The contract this script enforces is TERMINALITY, not correctness: the crawl
+// must end in `success` or `failure` — a real verdict, with a report and
+// evidence behind it. `cancelled` (runner kill / infra) and `skipped` (the
+// matrix never fanned out) are not verdicts, and this job goes red on them so
+// the silence is impossible to repeat. A crawl that runs and legitimately FAILS
+// is terminal: it is loud on its own child check, and re-gating it here would
+// undo the de-gate on purpose.
+//
+// Env:
+//   SETUP_RESULT       `needs.compose-smoke-setup.result` — the lane's fan-out
+//                      decision. `skipped` means the change was out of scope
+//                      for the compose stack and nothing should have run.
+//   SCOPE_RESULT       `needs.compose-smoke-scope.result` — a skipped setup is
+//                      only benign when the scope job itself SUCCEEDED.
+//   HAS_INFORMATIONAL  `needs.compose-smoke-setup.outputs.has_informational` —
+//                      "true" when the planner emitted a crawl matrix at all.
+//                      A `false` here means the crawl lane silently stopped
+//                      existing, which is the same hollow green one level up.
+//   CRAWL_SHARD_RESULT `needs.compose-smoke-shard-info.result` — the rolled-up
+//                      conclusion of the informational (crawl) matrix.
+//   SWEEP_DEPTH        `lean` | `full` — the depth this event swept at, used to
+//                      say how much of the pin the outcome covers.
+//
+// Exit: 0 when the crawl reached a terminal verdict (or the lane was correctly
+// short-circuited); 1 otherwise.
+//
+// node: builtins only (via lib/gh.mjs).
+
+import process from 'node:process';
+import { error, notice } from './lib/gh.mjs';
+import { crawlShardTimeoutMinutes, crawlSpecBudgetMinutes } from './lib/crawl-budget.mjs';
+
+/** Conclusions that mean the crawl actually ran to a verdict. */
+const TERMINAL_RESULTS = new Set(['success', 'failure']);
+
+/**
+ * Pure decision over the four `needs` facts. Returns `{ ok, message }`; the
+ * caller turns that into a `::notice::`/`::error::` and an exit code. Kept pure
+ * so the guard test can drive every branch without a workflow run.
+ */
+export function classifyCrawlOutcome({
+  scopeResult,
+  setupResult,
+  hasInformational,
+  crawlResult,
+  depth,
+}) {
+  // The lane short-circuits on a change the compose stack cannot see. That is
+  // benign ONLY on the same two facts the required aggregate checks: the scope
+  // job succeeded, and it is the reason setup skipped. A crashed scope job also
+  // skips setup, and that is a lane that failed to decide.
+  if (setupResult === 'skipped') {
+    if (scopeResult !== 'success') {
+      return {
+        ok: false,
+        message:
+          `compose-smoke-setup skipped because compose-smoke-scope did not succeed (${scopeResult}) — ` +
+          'the lane never decided whether the crawl had work, so its silence proves nothing.',
+      };
+    }
+    return {
+      ok: true,
+      message:
+        'compose lane is out of scope for this change — the crawl shard was not dispatched, and no surface pin was claimed to be enforced.',
+    };
+  }
+
+  if (setupResult !== 'success') {
+    return {
+      ok: false,
+      message: `compose-smoke-setup did not succeed (${setupResult}) — the crawl matrix was never planned.`,
+    };
+  }
+
+  if (hasInformational !== 'true') {
+    return {
+      ok: false,
+      message:
+        'compose-smoke-setup emitted NO informational (crawl) matrix — the surface-crawl coverage lane has silently stopped existing. ' +
+        'GATE_EXCLUDED_SHARDS in .github/scripts/compose-smoke-matrix.mjs must name a shard that is in SHARDS.',
+    };
+  }
+
+  if (TERMINAL_RESULTS.has(crawlResult)) {
+    return {
+      ok: true,
+      message:
+        `surface crawl reached a terminal verdict at depth=${depth}: ${crawlResult}. ` +
+        'Its own `compose-smoke-shard-info (shard-crawl)` check carries that verdict; this gate only asserts the crawl was allowed to produce one.',
+    };
+  }
+
+  if (crawlResult === 'cancelled') {
+    const scope =
+      depth === 'full'
+        ? 'the FULL-depth surface pin — the rows no other lane visits — was enforced by nothing on this run'
+        : 'the lean surface pin was enforced by nothing on this run';
+    return {
+      ok: false,
+      message:
+        `surface crawl shard was CANCELLED at depth=${depth}, which is not a test result: the job was killed mid-flight, ` +
+        `so no inventory diff was computed and ${scope}. ` +
+        `A \`timeout-minutes\` kill reports as \`cancelled\`; at this depth the job cap is ${crawlShardTimeoutMinutes(depth)} min ` +
+        `against a ${crawlSpecBudgetMinutes(depth)} min spec budget (.github/scripts/lib/crawl-budget.mjs), so a cap that no longer ` +
+        'clears the budget is the first thing to check. Otherwise read the shard log for the runner-side kill (disk, OOM, infra).',
+    };
+  }
+
+  if (crawlResult === 'skipped') {
+    return {
+      ok: false,
+      message:
+        'surface crawl shard was SKIPPED although the compose lane fanned out — the coverage lane reported nothing while the pin implies it did.',
+    };
+  }
+
+  return {
+    ok: false,
+    message: `surface crawl shard reported an unrecognised conclusion "${crawlResult}" — treat it as no verdict.`,
+  };
+}
+
+function main() {
+  const verdict = classifyCrawlOutcome({
+    scopeResult: process.env.SCOPE_RESULT ?? '',
+    setupResult: process.env.SETUP_RESULT ?? '',
+    hasInformational: process.env.HAS_INFORMATIONAL ?? '',
+    crawlResult: process.env.CRAWL_SHARD_RESULT ?? '',
+    depth: process.env.SWEEP_DEPTH ?? 'lean',
+  });
+  if (verdict.ok) {
+    notice(`crawl-terminal: ${verdict.message}`);
+    process.exit(0);
+  }
+  error(`crawl-terminal: ${verdict.message}`, { title: 'surface crawl produced no verdict' });
+  process.exit(1);
+}
+
+// Only dispatch when run as a script — importing for the unit test must not
+// exit the test runner.
+const invokedDirectly = process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href;
+if (invokedDirectly) main();

--- a/.github/scripts/assert-crawl-terminal.test.mjs
+++ b/.github/scripts/assert-crawl-terminal.test.mjs
@@ -1,0 +1,95 @@
+// assert-crawl-terminal.test.mjs — node:test guard for the crawl terminality
+// gate.
+//
+// The gate exists because a de-gated lane with no reader went silent for three
+// nights (#1861). A gate that itself degrades to "always ok" would reproduce
+// exactly that, so these tests pin BOTH directions: the benign cases pass, and
+// every not-a-verdict case actually fails.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { classifyCrawlOutcome } from './assert-crawl-terminal.mjs';
+
+const ran = (crawlResult, depth = 'full') =>
+  classifyCrawlOutcome({
+    scopeResult: 'success',
+    setupResult: 'success',
+    hasInformational: 'true',
+    crawlResult,
+    depth,
+  });
+
+test('a crawl that reaches a verdict passes — success and failure are both terminal', () => {
+  assert.equal(ran('success').ok, true);
+  // A red crawl is loud on its own child check; re-gating it here would undo
+  // the deliberate de-gate that keeps a coverage flake from blocking merges.
+  assert.equal(ran('failure').ok, true);
+});
+
+test('a CANCELLED crawl fails, and says the pin was enforced by nothing', () => {
+  const full = ran('cancelled', 'full');
+  assert.equal(full.ok, false);
+  assert.match(full.message, /CANCELLED/);
+  assert.match(full.message, /FULL-depth surface pin/);
+  // The message must point at the cap-vs-budget ordering, the actual cause.
+  assert.match(full.message, /crawl-budget\.mjs/);
+
+  const lean = ran('cancelled', 'lean');
+  assert.equal(lean.ok, false);
+  assert.match(lean.message, /lean surface pin/);
+});
+
+test('a crawl matrix that never fanned out fails rather than reading as coverage', () => {
+  assert.equal(ran('skipped').ok, false);
+  assert.equal(ran('').ok, false);
+  assert.equal(ran('neutral').ok, false);
+});
+
+test('a planner that stopped emitting a crawl matrix at all fails', () => {
+  const verdict = classifyCrawlOutcome({
+    scopeResult: 'success',
+    setupResult: 'success',
+    hasInformational: 'false',
+    crawlResult: 'skipped',
+    depth: 'full',
+  });
+  assert.equal(verdict.ok, false);
+  assert.match(verdict.message, /silently stopped existing/);
+});
+
+test('an out-of-scope change short-circuits cleanly — but only on a scope job that decided', () => {
+  const outOfScope = classifyCrawlOutcome({
+    scopeResult: 'success',
+    setupResult: 'skipped',
+    hasInformational: '',
+    crawlResult: 'skipped',
+    depth: 'lean',
+  });
+  assert.equal(outOfScope.ok, true);
+
+  // A crashed scope job also skips setup. That is a lane that failed to
+  // decide, and its silence must not be read as "nothing to do".
+  const undecided = classifyCrawlOutcome({
+    scopeResult: 'failure',
+    setupResult: 'skipped',
+    hasInformational: '',
+    crawlResult: 'skipped',
+    depth: 'lean',
+  });
+  assert.equal(undecided.ok, false);
+  assert.match(undecided.message, /never decided/);
+});
+
+test('a lane whose setup did not succeed fails', () => {
+  for (const setupResult of ['failure', 'cancelled', '']) {
+    const verdict = classifyCrawlOutcome({
+      scopeResult: 'success',
+      setupResult,
+      hasInformational: 'true',
+      crawlResult: 'skipped',
+      depth: 'full',
+    });
+    assert.equal(verdict.ok, false, `setup=${setupResult} must not read as coverage`);
+  }
+});

--- a/.github/scripts/compose-smoke-matrix.mjs
+++ b/.github/scripts/compose-smoke-matrix.mjs
@@ -39,9 +39,10 @@
 // Env:
 //   MODE            `emit` | `verify` (also argv[2]); default `verify`.
 //   PLAYWRIGHT_DIR  glob root; default `test/e2e/playwright`.
-//   IS_SCHEDULE     (emit) "true" on the nightly schedule — selects the FULL
-//                   per-shard timeout for non-crawl shards (120 vs the 45 lean
-//                   PR/push ceiling). The crawl shard's 30-min cap is constant.
+//   IS_SCHEDULE     (emit) "true" on the nightly schedule — the lane then runs
+//                   SWEEP_DEPTH=full, which selects the FULL per-shard timeout
+//                   for the non-crawl shards (120 vs the 45 lean PR/push
+//                   ceiling) AND the full-depth crawl cap (see lib/crawl-budget.mjs).
 //   GITHUB_OUTPUT   (emit) runner file the matrix JSON is appended to.
 //
 // Exit: 0 clean / matrix emitted; 1 on any coverage violation or bad MODE.
@@ -51,26 +52,29 @@
 import process from 'node:process';
 import { error, notice, log, setOutput, appendStepSummary } from './lib/gh.mjs';
 import { SHARD_NAME_RE, collectShardCoverageViolations, discoverSpecs } from './lib/shard-coverage.mjs';
+import { crawlShardTimeoutMinutes } from './lib/crawl-budget.mjs';
 
 // ---------------------------------------------------------------------------
 // Per-shard wall-clock ceilings (timeout-minutes on the compose-smoke-shard
 // job, interpolated as `matrix.timeoutMinutes`).
 //
-// The CRAWL shard gets a HARD 30-min cap regardless of event. crawl/crawl.spec.ts
-// is a slow BFS COVERAGE lane (NOT a correctness gate — it is de-gated from the
-// required `compose-smoke` aggregate, see GATE_EXCLUDED_SHARDS below) whose single
-// indivisible BFS test() intermittently flakes (the app-init-race 400, #115/#934)
-// and, on a hang, runs out to its long job timeout holding the
-// `cancel-in-progress: false` concurrency slot for ~2h. A 30-min cap makes it FAIL
-// FAST and release the slot instead. The PR/push lean crawl's internal budget is
-// 14min (testInfo.setTimeout in crawl.spec.ts), so 30min is comfortable headroom
-// for a healthy run; a hung/flaking run is cut at 30 instead of riding to 120.
+// The CRAWL shard's cap tracks the DEPTH it runs at, because the cap only does
+// its job while it sits above the spec's own budget. crawl/crawl.spec.ts is a
+// slow BFS COVERAGE lane (NOT a correctness gate — it is de-gated from the
+// required `compose-smoke` aggregate, see GATE_EXCLUDED_SHARDS below) whose
+// single indivisible BFS test() intermittently flakes (the app-init-race 400,
+// #115/#934) and, on a hang, would otherwise ride to a 2h ceiling holding the
+// `cancel-in-progress: false` concurrency slot. The cap makes that fail fast
+// and release the slot — but a cap BELOW the spec budget stops being a
+// fail-fast and becomes a guaranteed runner kill, which GitHub records as
+// `cancelled`: no verdict, no evidence. A constant 30-min cap did exactly that
+// to every nightly SWEEP_DEPTH=full crawl (#1861). lib/crawl-budget.mjs derives
+// both caps from the spec budgets so the ordering holds by construction.
 //
 // NON-CRAWL shards keep their prior effective ceilings: the nightly schedule runs
 // SWEEP_DEPTH=full (the heavier sweep) at 120, PR/push run SWEEP_DEPTH=lean at 45.
 // Those shards are fast (≤~35s lean per spec) so they comfortably fit; the 45/120
 // split is preserved verbatim from the old per-job `timeout-minutes` expression.
-const CRAWL_SHARD_TIMEOUT_MIN = 30;
 const NONCRAWL_SHARD_TIMEOUT_FULL_MIN = 120;
 const NONCRAWL_SHARD_TIMEOUT_LEAN_MIN = 45;
 
@@ -207,11 +211,14 @@ function verify() {
   process.exit(0);
 }
 
-// shardTimeoutMinutes() — the per-shard `timeout-minutes` ceiling. The crawl
-// shard is a constant 30-min hard cap (fail fast, release the concurrency slot);
-// non-crawl shards take the full (nightly) or lean (PR/push) ceiling.
+// shardTimeoutMinutes() — the per-shard `timeout-minutes` ceiling. Both the
+// crawl and the non-crawl ceilings follow the sweep depth this event runs at:
+// the nightly schedule sweeps full, PR/push sweep lean (the SWEEP_DEPTH
+// expression in e2e.yml). The crawl cap is derived from the spec's own budget
+// at that depth so the spec always times out first (lib/crawl-budget.mjs).
 export function shardTimeoutMinutes(shardName, { isSchedule } = {}) {
-  if (GATE_EXCLUDED_SHARDS.includes(shardName)) return CRAWL_SHARD_TIMEOUT_MIN;
+  const depth = isSchedule ? 'full' : 'lean';
+  if (GATE_EXCLUDED_SHARDS.includes(shardName)) return crawlShardTimeoutMinutes(depth);
   return isSchedule ? NONCRAWL_SHARD_TIMEOUT_FULL_MIN : NONCRAWL_SHARD_TIMEOUT_LEAN_MIN;
 }
 
@@ -278,4 +285,4 @@ if (invokedDirectly) {
 }
 
 // Exported for the unit guard (.github/scripts/compose-smoke-matrix.test.mjs).
-export { SHARDS, EXCLUDED, SHARD_NAME_RE, GATE_EXCLUDED_SHARDS, CRAWL_SHARD_TIMEOUT_MIN };
+export { SHARDS, EXCLUDED, SHARD_NAME_RE, GATE_EXCLUDED_SHARDS };

--- a/.github/scripts/crawl-budget.test.mjs
+++ b/.github/scripts/crawl-budget.test.mjs
@@ -1,0 +1,109 @@
+// crawl-budget.test.mjs — node:test guard for the crawl's two-budget ordering.
+//
+// Runs on the CHEAP check lane (`node --test .github/scripts/*.test.mjs`) — no
+// setup-node, no deps, no stack — so the invariant that #1861 violated is
+// caught on a PR rather than three nights later on a cancelled nightly.
+//
+// Guards three things:
+//   1. every crawl job cap sits STRICTLY above the spec budget it must clear
+//      (the real invariant: the spec times out first, with evidence);
+//   2. the budgets in lib/crawl-budget.mjs still match the ones crawl.spec.ts
+//      actually sets, so the two files cannot drift apart in silence;
+//   3. the shard planners hand the crawl shard the depth-appropriate cap — the
+//      nightly full-depth crawl must not be given the lean cap again.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+import {
+  CRAWL_SHARD_TIMEOUT_FULL_MIN,
+  CRAWL_SHARD_TIMEOUT_LEAN_MIN,
+  CRAWL_SPEC_BUDGET_FULL_MIN,
+  CRAWL_SPEC_BUDGET_LEAN_MIN,
+  crawlShardTimeoutMinutes,
+  crawlSpecBudgetMinutes,
+  parseSpecBudgetsFromSource,
+} from './lib/crawl-budget.mjs';
+import { shardTimeoutMinutes as composeShardTimeout } from './compose-smoke-matrix.mjs';
+import { shardTimeoutMinutes as dashboardShardTimeout } from './dashboard-matrix.mjs';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const crawlSpecPath = resolve(repoRoot, 'test/e2e/playwright/crawl/crawl.spec.ts');
+
+test('every job cap clears the spec budget it has to outlive', () => {
+  for (const depth of ['lean', 'full']) {
+    assert.ok(
+      crawlShardTimeoutMinutes(depth) > crawlSpecBudgetMinutes(depth),
+      `depth=${depth}: job cap ${crawlShardTimeoutMinutes(depth)}min must exceed the ` +
+        `${crawlSpecBudgetMinutes(depth)}min spec budget, or the runner kills the job first and ` +
+        'the shard can only ever report `cancelled` (#1861)',
+    );
+  }
+  // The full-depth cap is the one that regressed: it must clear the FULL
+  // budget, not merely the lean one.
+  assert.ok(
+    CRAWL_SHARD_TIMEOUT_FULL_MIN > CRAWL_SPEC_BUDGET_FULL_MIN,
+    'the full-depth cap must clear the full-depth spec budget',
+  );
+  assert.ok(
+    CRAWL_SHARD_TIMEOUT_LEAN_MIN < CRAWL_SHARD_TIMEOUT_FULL_MIN,
+    'the lean cap must stay tighter than the full one — a lean hang still has to fail fast',
+  );
+});
+
+test('the pinned budgets match what crawl.spec.ts actually sets', () => {
+  const budgets = parseSpecBudgetsFromSource(readFileSync(crawlSpecPath, 'utf8'));
+  assert.notEqual(
+    budgets,
+    null,
+    `could not find the depth-keyed testInfo.setTimeout(...) call in ${crawlSpecPath} — ` +
+      'the drift guard cannot read the real budget, which is a failure, not a pass',
+  );
+  assert.equal(
+    budgets.fullMin,
+    CRAWL_SPEC_BUDGET_FULL_MIN,
+    'CRAWL_SPEC_BUDGET_FULL_MIN drifted from crawl.spec.ts',
+  );
+  assert.equal(
+    budgets.leanMin,
+    CRAWL_SPEC_BUDGET_LEAN_MIN,
+    'CRAWL_SPEC_BUDGET_LEAN_MIN drifted from crawl.spec.ts',
+  );
+});
+
+test('the drift guard fires — a changed spec budget is detected, not shrugged off', () => {
+  const tampered = readFileSync(crawlSpecPath, 'utf8').replace(
+    `depth === 'full' ? ${CRAWL_SPEC_BUDGET_FULL_MIN} * 60_000`,
+    `depth === 'full' ? ${CRAWL_SPEC_BUDGET_FULL_MIN + 1} * 60_000`,
+  );
+  const budgets = parseSpecBudgetsFromSource(tampered);
+  assert.notEqual(budgets, null, 'the tampered source must still parse');
+  assert.notEqual(
+    budgets.fullMin,
+    CRAWL_SPEC_BUDGET_FULL_MIN,
+    'the parser must report the tampered budget, otherwise the drift guard is a no-op',
+  );
+});
+
+test('both shard planners give the crawl shard the depth-appropriate cap', () => {
+  // compose-smoke: nightly schedule sweeps full, PR/push sweep lean.
+  assert.equal(
+    composeShardTimeout('shard-crawl', { isSchedule: true }),
+    CRAWL_SHARD_TIMEOUT_FULL_MIN,
+    'the nightly compose crawl shard must get the full-depth cap',
+  );
+  assert.equal(
+    composeShardTimeout('shard-crawl', { isSchedule: false }),
+    CRAWL_SHARD_TIMEOUT_LEAN_MIN,
+    'the PR/push compose crawl shard must get the lean cap',
+  );
+  // dashboard (k3d): the crawl shard always sweeps full.
+  assert.equal(
+    dashboardShardTimeout({ crawlStack: 'k3d' }),
+    CRAWL_SHARD_TIMEOUT_FULL_MIN,
+    'the k3d crawl shard always sweeps full, so it must always get the full-depth cap',
+  );
+});

--- a/.github/scripts/dashboard-matrix.mjs
+++ b/.github/scripts/dashboard-matrix.mjs
@@ -77,6 +77,7 @@
 import process from 'node:process';
 import { error, notice, log, setOutput, appendStepSummary } from './lib/gh.mjs';
 import { SHARD_NAME_RE, collectShardCoverageViolations, discoverSpecs } from './lib/shard-coverage.mjs';
+import { crawlShardTimeoutMinutes } from './lib/crawl-budget.mjs';
 
 // CRAWL_STACK value that selects the k3d crawl-suite config (crawl/stacks.ts).
 // A smoke shard leaves it EMPTY so playwright.config.ts ignores crawl/**
@@ -85,6 +86,12 @@ import { SHARD_NAME_RE, collectShardCoverageViolations, discoverSpecs } from './
 // inventory at SWEEP_DEPTH=full (the old "Run Playwright crawl" step).
 const CRAWL_STACK_K3D = 'k3d';
 const CRAWL_STACK_NONE = '';
+
+// Sweep depth the k3d crawl shard always runs at (SWEEP_DEPTH in e2e.yml's
+// dashboard-shard step is unconditionally `full` for CRAWL_STACK=k3d — this
+// lane exists to do the exhaustive sweep). Named because the crawl shard's job
+// timeout is derived from the spec budget AT THIS DEPTH.
+const CRAWL_SHARD_SWEEP_DEPTH = 'full';
 
 // Chart deployment topologies the smoke lane exercises (E2E_MODE in `just
 // e2e-up`). The SAME Grafana/Playwright smoke runs against both: `monolith`
@@ -107,13 +114,18 @@ const SPLIT_ONLY_SPECS = new Set(['split_isolation.spec.ts']);
 // Per-shard wall-clock ceilings (timeout-minutes on the dashboard-shard job,
 // interpolated as `matrix.timeoutMinutes`).
 //
-// The CRAWL shard gets a HARD 30-min cap. The k3d crawl is a slow BFS COVERAGE
-// lane, not a correctness gate, and it is dispatched only on schedule + manual
-// dispatch + release/* PRs; on a hang it rides the job to its long timeout
-// holding the `cancel-in-progress: false` k3d concurrency slot. A 30-min cap
-// makes it FAIL FAST and release the slot. The smoke shards keep a 75-min job
-// ceiling (k3d bring-up ~3-5min + the non-crawl smoke specs fit comfortably).
-const CRAWL_SHARD_TIMEOUT_MIN = 30;
+// The CRAWL shard's cap comes from lib/crawl-budget.mjs at the FULL depth: this
+// shard always runs SWEEP_DEPTH=full (see SHARDS below), so its spec budget is
+// the 75-min one and the job cap has to clear it. The k3d crawl is a slow BFS
+// COVERAGE lane, not a correctness gate, and it is dispatched only on schedule
+// + manual dispatch + release/* PRs; on a hang it would otherwise ride the job
+// to its long timeout holding the `cancel-in-progress: false` k3d concurrency
+// slot, so the cap is what makes it fail fast and release the slot. A cap BELOW
+// the spec budget inverts that: the runner kills the job before the spec can
+// report, and GitHub records the kill as `cancelled` — no verdict, no evidence,
+// which is what a constant 30-min cap did to every nightly k3d crawl (#1861).
+// The smoke shards keep a 75-min job ceiling (k3d bring-up ~3-5min + the
+// non-crawl smoke specs fit comfortably).
 const SMOKE_SHARD_TIMEOUT_MIN = 75;
 
 // ---------------------------------------------------------------------------
@@ -246,11 +258,14 @@ export function collectViolations(discovered) {
 }
 
 // shardTimeoutMinutes() — the per-shard `timeout-minutes` ceiling. The crawl
-// shard (CRAWL_STACK=k3d) is a constant 30-min hard cap (fail fast, release the
-// k3d concurrency slot); the smoke shards keep the prior effective 75-min job
-// ceiling.
+// shard (CRAWL_STACK=k3d) always sweeps at full depth, so its cap is the
+// full-depth one derived from the spec's own budget (lib/crawl-budget.mjs):
+// the spec times out first, with evidence, and the runner kill stays a genuine
+// last resort. The smoke shards keep the prior effective 75-min job ceiling.
 export function shardTimeoutMinutes(shard) {
-  return shard.crawlStack === CRAWL_STACK_K3D ? CRAWL_SHARD_TIMEOUT_MIN : SMOKE_SHARD_TIMEOUT_MIN;
+  return shard.crawlStack === CRAWL_STACK_K3D
+    ? crawlShardTimeoutMinutes(CRAWL_SHARD_SWEEP_DEPTH)
+    : SMOKE_SHARD_TIMEOUT_MIN;
 }
 
 function assertCoverageOrExit(discovered) {
@@ -387,7 +402,6 @@ export {
   SHARDS,
   EXCLUDED,
   SHARD_NAME_RE,
-  CRAWL_SHARD_TIMEOUT_MIN,
   SMOKE_SHARD_TIMEOUT_MIN,
   CRAWL_STACK_K3D,
   MODE_MONOLITH,

--- a/.github/scripts/lib/crawl-budget.mjs
+++ b/.github/scripts/lib/crawl-budget.mjs
@@ -1,0 +1,90 @@
+// crawl-budget.mjs — single source of truth for the Grafana surface crawl's
+// wall-clock budgets, shared by BOTH e2e shard planners
+// (compose-smoke-matrix.mjs and dashboard-matrix.mjs).
+//
+// Two budgets govern one crawl, they live in two different files, and the
+// ORDER between them is the invariant this module exists to hold:
+//
+//   - the SPEC budget — `testInfo.setTimeout(...)` at the top of
+//     test/e2e/playwright/crawl/crawl.spec.ts — is how long the single
+//     indivisible BFS `test()` may run. Blowing it is a Playwright TEST
+//     FAILURE: a `failure` conclusion, a trace, a screenshot, and the surface
+//     the sweep was parked on.
+//   - the JOB cap — `timeout-minutes` on the shard job — is how long the
+//     runner lets the WHOLE job live (stack boot, browser install, the
+//     Playwright run, the evidence dump, teardown). Blowing it kills the job
+//     mid-flight, and GitHub records a `timeout-minutes` kill with conclusion
+//     `cancelled` — which is not a test result at all.
+//
+// So the job cap must stay strictly ABOVE the spec budget plus everything the
+// job does around it. If it does not, the runner always wins the race and the
+// lane can only ever report `cancelled`: no verdict, no evidence, and a
+// surface pin that nothing enforces.
+//
+// That is exactly what #1861 was. A constant 30-min job cap was sized for the
+// PR/push LEAN crawl (14-min spec budget) but applied unconditionally, while
+// the nightly runs SWEEP_DEPTH=full with a 75-min spec budget. Every nightly
+// full-depth crawl was therefore killed at 30 minutes, on both the compose and
+// the k3d lane, and the ~237 full-depth rows of the surface inventory were
+// enforced by nothing at all.
+//
+// The caps below are DERIVED from the spec budgets rather than typed in, so
+// the ordering holds by construction. crawl-budget.test.mjs reads the real
+// numbers back out of crawl.spec.ts, so the two files cannot drift apart in
+// silence either.
+//
+// Env: none — this is a pure constants/derivation module.
+//
+// node: builtins only.
+
+/** Spec budget for the PR/push lean sweep (crawl.spec.ts `testInfo.setTimeout`). */
+export const CRAWL_SPEC_BUDGET_LEAN_MIN = 14;
+
+/** Spec budget for the nightly full-depth sweep (crawl.spec.ts `testInfo.setTimeout`). */
+export const CRAWL_SPEC_BUDGET_FULL_MIN = 75;
+
+/**
+ * Wall-clock the shard job spends OUTSIDE the Playwright run: disk reclaim,
+ * image pull + stack boot (~4 min measured on the compose lane, ~5 min on
+ * k3d), browser install, the failure-evidence dump, and teardown. Added to the
+ * spec budget to get the job cap, so a crawl that overruns is cut by its OWN
+ * timeout — a `failure` with evidence — before the runner can cut the job.
+ */
+export const CRAWL_JOB_OVERHEAD_HEADROOM_MIN = 15;
+
+/** Job `timeout-minutes` for a lean (PR/push) crawl shard. */
+export const CRAWL_SHARD_TIMEOUT_LEAN_MIN =
+  CRAWL_SPEC_BUDGET_LEAN_MIN + CRAWL_JOB_OVERHEAD_HEADROOM_MIN;
+
+/** Job `timeout-minutes` for a full-depth (nightly / dispatch / k3d) crawl shard. */
+export const CRAWL_SHARD_TIMEOUT_FULL_MIN =
+  CRAWL_SPEC_BUDGET_FULL_MIN + CRAWL_JOB_OVERHEAD_HEADROOM_MIN;
+
+/** The spec's own budget at a depth, in minutes. */
+export function crawlSpecBudgetMinutes(depth) {
+  return depth === 'full' ? CRAWL_SPEC_BUDGET_FULL_MIN : CRAWL_SPEC_BUDGET_LEAN_MIN;
+}
+
+/**
+ * The shard job's `timeout-minutes` at a depth. `depth` is 'full' on the
+ * nightly schedule (and always on the k3d crawl shard, which only ever runs
+ * SWEEP_DEPTH=full), 'lean' on PR/push.
+ */
+export function crawlShardTimeoutMinutes(depth) {
+  return depth === 'full' ? CRAWL_SHARD_TIMEOUT_FULL_MIN : CRAWL_SHARD_TIMEOUT_LEAN_MIN;
+}
+
+/**
+ * Pull the two spec budgets back out of crawl.spec.ts source text. The guard
+ * test uses this to prove the constants above still describe the file they
+ * claim to describe. Returns `null` when the pinned call shape is not found —
+ * which the caller must treat as a failure, not as "no drift".
+ */
+export function parseSpecBudgetsFromSource(source) {
+  const m =
+    /testInfo\.setTimeout\(\s*depth === 'full'\s*\?\s*(\d+)\s*\*\s*60_000\s*:\s*(\d+)\s*\*\s*60_000\s*\)/.exec(
+      source,
+    );
+  if (m === null) return null;
+  return { fullMin: Number(m[1]), leanMin: Number(m[2]) };
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -675,6 +675,17 @@ jobs:
           node --test .github/scripts/compose-smoke-matrix.test.mjs
           node --test .github/scripts/dashboard-matrix.test.mjs
 
+      # The crawl lane reports outside the required gate, so its own budget
+      # ordering and its terminality reader are what stand between a killed
+      # nightly and a pin nobody enforces. Both are pure in-process tests over
+      # the modules (the budget one reads crawl.spec.ts to catch drift), so
+      # they run here rather than waiting for the release lane that would have
+      # discovered the inversion the expensive way.
+      - name: Assert the crawl budget ordering and terminality reader hold
+        run: |
+          node --test .github/scripts/crawl-budget.test.mjs
+          node --test .github/scripts/assert-crawl-terminal.test.mjs
+
       # The subprocess helper every script above runs its commands through.
       # capture() names the spawnSync options it forwards rather than spreading
       # `opts`, so an unsupported key used to vanish without a word — and a

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -34,11 +34,21 @@ name: e2e
 #     visible child check, but its result does NOT gate the required
 #     `compose-smoke` (crawl = coverage, not a correctness gate; it is
 #     slow + intermittently flaky — the app-init-race 400 is #115/#934 —
-#     and must not block PR merges). The crawl shard also carries a hard
-#     30-min `timeout-minutes` so a hang fails fast and releases the
-#     `cancel-in-progress: false` concurrency slot instead of riding to
-#     a 2h ceiling. The split + per-shard timeouts live in the
-#     single-source-of-truth .github/scripts/compose-smoke-matrix.mjs.
+#     and must not block PR merges). The crawl shard also carries a
+#     depth-scaled `timeout-minutes` so a hang fails fast and releases
+#     the `cancel-in-progress: false` concurrency slot instead of riding
+#     to a 2h ceiling — always ABOVE the spec's own budget at that depth,
+#     so the SPEC times out first (a `failure` with evidence) and the
+#     runner kill stays a last resort. The split + per-shard timeouts
+#     live in the single-source-of-truth
+#     .github/scripts/compose-smoke-matrix.mjs +
+#     .github/scripts/lib/crawl-budget.mjs.
+#   - `crawl-terminal` — the de-gated crawl lane's only reader. Asserts
+#     the crawl shard ended in a REAL verdict (`success` or `failure`),
+#     not `cancelled`/`skipped`. A de-gated lane with nobody reading it
+#     went silent for three nights while the pin implied full coverage;
+#     this makes that impossible to repeat. Informational, like the lane
+#     it reads — it does not gate merges.
 #   - `dashboard` — full-stack k3d + cerberus + Grafana + Playwright
 #     smoke, SHARDED across a modest matrix of isolated-k3d-cluster jobs
 #     (dashboard-setup emits the matrix from the single-source-of-truth
@@ -225,9 +235,10 @@ jobs:
 
       # Emit the strategy.matrix JSON to $GITHUB_OUTPUT. emit re-runs the
       # assertions internally, so even without the verify step above it can
-      # never ship a matrix that silently drops a spec. IS_SCHEDULE selects the
-      # FULL (120) vs lean (45) per-shard timeout for the non-crawl shards; the
-      # crawl shard's 30-min cap is constant.
+      # never ship a matrix that silently drops a spec. IS_SCHEDULE says this
+      # event sweeps at full depth, which selects the FULL (120) vs lean (45)
+      # per-shard timeout for the non-crawl shards AND the full- vs lean-depth
+      # crawl cap (lib/crawl-budget.mjs).
       - id: emit
         name: emit shard matrix
         run: node .github/scripts/compose-smoke-matrix.mjs
@@ -253,9 +264,10 @@ jobs:
     # Per-shard wall-clock ceiling, computed in compose-smoke-matrix.mjs and
     # carried on each matrix entry. Non-crawl shards take 120 (nightly full) /
     # 45 (PR/push lean); the crawl shard (now in the SEPARATE informational
-    # matrix below) carries a hard 30-min cap. Keeping the value in the manifest
-    # — the single source of truth for the partition — means the timeout policy
-    # can't drift from the shard it applies to.
+    # matrix below) takes a depth-scaled cap derived from its own spec budget.
+    # Keeping the value in the manifest — the single source of truth for the
+    # partition — means the timeout policy can't drift from the shard it
+    # applies to.
     timeout-minutes: ${{ matrix.timeoutMinutes }}
     concurrency:
       # Per-shard-keyed so sibling shards in the SAME run queue independently
@@ -491,8 +503,14 @@ jobs:
   # Rationale for de-gating crawl: it is slow BFS COVERAGE, not a correctness
   # gate; it is slow + flaky by nature (~6min compose / ~50min k3d at full
   # depth; the app-init-race 400 is #115 / #934), and intermittently runs out to
-  # its timeout holding the cancel-in-progress:false concurrency slot. The hard
-  # 30-min per-shard cap (matrix.timeoutMinutes) makes a hang fail fast.
+  # its timeout holding the cancel-in-progress:false concurrency slot. The
+  # per-shard cap (matrix.timeoutMinutes) makes a hang fail fast.
+  #
+  # De-gated is not unread. `crawl-terminal` below asserts this matrix ended in
+  # a real verdict: a shard the runner killed reports `cancelled`, which is not
+  # a test result, and for three nights running that is exactly what the nightly
+  # full-depth sweep produced while the pin implied it was enforcing ~237 rows
+  # no other lane visits (#1861).
   compose-smoke-shard-info:
     name: compose-smoke-shard-info
     needs: compose-smoke-setup
@@ -504,8 +522,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.compose-smoke-setup.outputs.matrix_informational) }}
-    # Hard 30-min cap (CRAWL_SHARD_TIMEOUT_MIN in the manifest) — fail fast
-    # instead of riding to a 2h hang holding the concurrency slot.
+    # Depth-scaled cap (lib/crawl-budget.mjs, carried on the matrix entry) —
+    # fail fast instead of riding to a 2h hang holding the concurrency slot,
+    # while still sitting above the spec's own budget so the SPEC times out
+    # first and the crawl can report a verdict with evidence.
     timeout-minutes: ${{ matrix.timeoutMinutes }}
     concurrency:
       group: compose-smoke-info-${{ github.ref }}-${{ matrix.name }}
@@ -720,6 +740,42 @@ jobs:
           echo "all required compose-smoke shards passed (crawl coverage shard is informational, de-gated)."
 
   # ---------------------------------------------------------------------------
+  # crawl-terminal — the de-gated crawl lane's reader.
+  #
+  # Splitting the crawl out of the required aggregate (compose-smoke-shard-info)
+  # was right: a slow, flaky COVERAGE sweep must not block PR merges. What it
+  # left behind was a lane nothing read. When the shard stopped producing
+  # verdicts entirely — killed by its own `timeout-minutes`, which GitHub
+  # records as `cancelled` — the required `compose-smoke` went green (correctly;
+  # it does not need that matrix) and the ~237 full-depth rows of the surface
+  # pin were enforced by nothing, three nights running (#1861).
+  #
+  # This job asserts TERMINALITY, not correctness: the crawl must end in
+  # `success` or `failure`, a real verdict with a report behind it. A crawl that
+  # runs and legitimately fails passes THIS gate — it is already loud on its own
+  # child check, and re-gating it here would undo the de-gate on purpose. It is
+  # `cancelled` and `skipped` that this job exists to make impossible to ignore.
+  # Not a branch-protection context, so it reports without blocking merges.
+  crawl-terminal:
+    name: crawl-terminal
+    needs: [compose-smoke-scope, compose-smoke-setup, compose-smoke-shard-info]
+    # always() so a cancelled/skipped crawl matrix still reaches this reader —
+    # a plain `needs:` would skip it in exactly the case it exists to catch.
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+      - name: assert the surface crawl reached a verdict
+        run: node .github/scripts/assert-crawl-terminal.mjs
+        env:
+          SCOPE_RESULT: ${{ needs.compose-smoke-scope.result }}
+          SETUP_RESULT: ${{ needs.compose-smoke-setup.result }}
+          HAS_INFORMATIONAL: ${{ needs.compose-smoke-setup.outputs.has_informational }}
+          CRAWL_SHARD_RESULT: ${{ needs.compose-smoke-shard-info.result }}
+          SWEEP_DEPTH: ${{ github.event_name == 'schedule' && 'full' || 'lean' }}
+
+  # ---------------------------------------------------------------------------
   # dashboard (k3d) lane — SHARDED across a modest matrix of isolated k3d
   # clusters, mirroring the compose-smoke split.
   #
@@ -833,11 +889,13 @@ jobs:
       matrix: ${{ fromJSON(needs.dashboard-setup.outputs.matrix) }}
     # Per-shard wall-clock ceiling, computed in dashboard-matrix.mjs and carried
     # on each matrix entry. Smoke shards keep the prior 75-min cluster-lifetime
-    # bound; the crawl shard gets a HARD 30-min cap (CRAWL_SHARD_TIMEOUT_MIN) so a
-    # hung BFS fails fast and releases the cancel-in-progress:false k3d slot
-    # instead of riding to the long ceiling. The k3d crawl is informational
-    # COVERAGE (the whole dashboard lane is non-gating), so a 30-min cut never
-    # blocks a merge or a release.
+    # bound; the crawl shard gets the FULL-depth cap derived from its own spec
+    # budget (lib/crawl-budget.mjs) — this shard always runs SWEEP_DEPTH=full, so
+    # a cap sized for the lean sweep would kill every run before the BFS could
+    # report, which is what #1861 was. A hung BFS still fails fast and releases
+    # the cancel-in-progress:false k3d slot instead of riding to the long
+    # ceiling; the cut just lands after the spec's own timeout rather than
+    # before it, so the lane produces a verdict with evidence.
     timeout-minutes: ${{ matrix.timeoutMinutes }}
     concurrency:
       # Per-shard-keyed: sibling shards in the SAME run must not cancel each

--- a/test/e2e/playwright/crawl/crawl.spec.ts
+++ b/test/e2e/playwright/crawl/crawl.spec.ts
@@ -611,6 +611,94 @@ test.describe('crawl: canonicalization pins', () => {
         scope,
       ),
     ).toBe('/a/grafana-exploretraces-app/trace/{hex}');
+    expect(
+      canonicalizeURL(
+        '/a/grafana-lokiexplore-app/explore/service/cerberus/label/level',
+        base,
+        scope,
+      ),
+    ).toBe('/a/grafana-lokiexplore-app/explore/service/{service}/label/{label}');
+    expect(
+      canonicalizeURL(
+        '/a/grafana-lokiexplore-app/explore/service/cerberus/field/order_id?visualizationType=%22table%22',
+        base,
+        scope,
+      ),
+    ).toBe(
+      '/a/grafana-lokiexplore-app/explore/service/{service}/field/{field}?visualizationType="table"',
+    );
+  });
+
+  test('parameterizing the field segment absorbs log-field churn but still catches real coverage change', () => {
+    // #1862: the segment after 'field' is a log FIELD name harvested
+    // from whatever the seeded logs happened to carry, so pinning it
+    // pinned the dataset — the same class of defect #1825 was on the
+    // query-parameter axis. Renaming or reordering a log field must
+    // not move the surface key.
+    const asOrderID = canonicalizeURL(
+      '/a/grafana-lokiexplore-app/explore/service/cerberus/field/order_id',
+      base,
+      scope,
+    );
+    const asThread = canonicalizeURL(
+      '/a/grafana-lokiexplore-app/explore/service/cerberus/field/thread',
+      base,
+      scope,
+    );
+    expect(asOrderID).toBe(asThread);
+
+    const stack = activeStack();
+    const fieldSurface = asThread!;
+    const servicePage = '/a/grafana-lokiexplore-app/explore/service/{service}/logs';
+    const inventory = {
+      doc: '',
+      stack: stack.name,
+      surfaces: [
+        { url: servicePage, lean: true },
+        { url: fieldSurface, lean: true },
+      ],
+    };
+    const noExclusions = { doc: '', exclusions: [] };
+
+    // Field churn alone: the ratchet is silent.
+    expect(
+      diffInventory(
+        new Set([servicePage, fieldSurface]),
+        inventory,
+        noExclusions,
+        'lean',
+        stack,
+      ),
+    ).toEqual([]);
+
+    // The gate is NOT dead — if the sweep stopped following the
+    // fields-tab drill entirely, no field name can key fieldSurface,
+    // so the collapse must still report the loss.
+    const shrank = diffInventory(
+      new Set([servicePage]),
+      inventory,
+      noExclusions,
+      'lean',
+      stack,
+    );
+    expect(shrank).toHaveLength(1);
+    expect(shrank[0]).toContain('coverage shrank');
+    expect(shrank[0]).toContain(fieldSurface);
+
+    // …and a genuinely new surface under the same route family still fails.
+    const grew = diffInventory(
+      new Set([
+        servicePage,
+        fieldSurface,
+        `${fieldSurface}?visualizationType="table"`,
+      ]),
+      inventory,
+      noExclusions,
+      'lean',
+      stack,
+    );
+    expect(grew).toHaveLength(1);
+    expect(grew[0]).toContain('coverage grew');
   });
 
   test('committed inventory + exclusions files are internally consistent', () => {

--- a/test/e2e/playwright/crawl/grafana-surface-inventory.compose.json
+++ b/test/e2e/playwright/crawl/grafana-surface-inventory.compose.json
@@ -167,235 +167,79 @@
       "lean": true
     },
     {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/customer?visualizationType=\"json\"",
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/{field}",
       "lean": false
     },
     {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/customer?visualizationType=\"json\"#adhoc[Filter by labels]={rep}",
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/{field}?visualizationType=\"json\"",
       "lean": false
     },
     {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/customer?visualizationType=\"json\"#radio[Grid|Rows]=Rows",
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/{field}?visualizationType=\"json\"#adhoc[Filter by labels]={rep}",
       "lean": false
     },
     {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/customer?visualizationType=\"json\"#select[downshift-{rid}-input]=Exclude",
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/{field}?visualizationType=\"json\"#radio[Grid|Rows]=Grid",
       "lean": false
     },
     {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/customer?visualizationType=\"json\"#select[Filter by fields]=thread",
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/{field}?visualizationType=\"json\"#radio[Grid|Rows]=Rows",
       "lean": false
     },
     {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/customer?visualizationType=\"json\"#select[SortBy direction]=Asc",
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/{field}?visualizationType=\"json\"#select[downshift-{rid}-input]=Exclude",
       "lean": false
     },
     {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/customer?visualizationType=\"json\"#select[SortBy function]=Most relevantSmart ordering of graphs based on the most significant spikes in the data",
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/{field}?visualizationType=\"json\"#select[Filter by fields]=thread",
       "lean": false
     },
     {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/customer?visualizationType=\"table\"",
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/{field}?visualizationType=\"json\"#select[SortBy direction]=Asc",
       "lean": false
     },
     {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/customer?visualizationType=\"table\"#adhoc[Filter by labels]={rep}",
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/{field}?visualizationType=\"json\"#select[SortBy direction]=Desc",
       "lean": false
     },
     {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/customer?visualizationType=\"table\"#radio[Grid|Rows]=Rows",
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/{field}?visualizationType=\"json\"#select[SortBy function]=Most relevantSmart ordering of graphs based on the most significant spikes in the data",
       "lean": false
     },
     {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/customer?visualizationType=\"table\"#select[downshift-{rid}-input]=Exclude",
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/{field}?visualizationType=\"table\"",
       "lean": false
     },
     {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/customer?visualizationType=\"table\"#select[Filter by fields]=thread",
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/{field}?visualizationType=\"table\"#adhoc[Filter by labels]={rep}",
       "lean": false
     },
     {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/customer?visualizationType=\"table\"#select[SortBy direction]=Asc",
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/{field}?visualizationType=\"table\"#radio[Grid|Rows]=Grid",
       "lean": false
     },
     {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/customer?visualizationType=\"table\"#select[SortBy function]=Most relevantSmart ordering of graphs based on the most significant spikes in the data",
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/{field}?visualizationType=\"table\"#radio[Grid|Rows]=Rows",
       "lean": false
     },
     {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/order_id",
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/{field}?visualizationType=\"table\"#select[downshift-{rid}-input]=Exclude",
       "lean": false
     },
     {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/order_id?visualizationType=\"json\"",
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/{field}?visualizationType=\"table\"#select[Filter by fields]=thread",
       "lean": false
     },
     {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/order_id?visualizationType=\"json\"#adhoc[Filter by labels]={rep}",
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/{field}?visualizationType=\"table\"#select[SortBy direction]=Asc",
       "lean": false
     },
     {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/order_id?visualizationType=\"json\"#radio[Grid|Rows]=Grid",
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/{field}?visualizationType=\"table\"#select[SortBy direction]=Desc",
       "lean": false
     },
     {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/order_id?visualizationType=\"json\"#select[downshift-{rid}-input]=Exclude",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/order_id?visualizationType=\"json\"#select[Filter by fields]=thread",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/order_id?visualizationType=\"json\"#select[SortBy direction]=Desc",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/order_id?visualizationType=\"json\"#select[SortBy function]=Most relevantSmart ordering of graphs based on the most significant spikes in the data",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/order_id?visualizationType=\"table\"",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/order_id?visualizationType=\"table\"#adhoc[Filter by labels]={rep}",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/order_id?visualizationType=\"table\"#radio[Grid|Rows]=Grid",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/order_id?visualizationType=\"table\"#select[downshift-{rid}-input]=Exclude",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/order_id?visualizationType=\"table\"#select[Filter by fields]=thread",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/order_id?visualizationType=\"table\"#select[SortBy direction]=Desc",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/order_id?visualizationType=\"table\"#select[SortBy function]=Most relevantSmart ordering of graphs based on the most significant spikes in the data",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/response_latency_ms",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/response_latency_ms?visualizationType=\"json\"",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/response_latency_ms?visualizationType=\"json\"#adhoc[Filter by labels]={rep}",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/response_latency_ms?visualizationType=\"json\"#radio[Grid|Rows]=Rows",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/response_latency_ms?visualizationType=\"json\"#select[downshift-{rid}-input]=Exclude",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/response_latency_ms?visualizationType=\"json\"#select[Filter by fields]=thread",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/response_latency_ms?visualizationType=\"json\"#select[SortBy direction]=Asc",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/response_latency_ms?visualizationType=\"json\"#select[SortBy function]=Most relevantSmart ordering of graphs based on the most significant spikes in the data",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/response_latency_ms?visualizationType=\"table\"",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/response_latency_ms?visualizationType=\"table\"#adhoc[Filter by labels]={rep}",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/response_latency_ms?visualizationType=\"table\"#radio[Grid|Rows]=Rows",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/response_latency_ms?visualizationType=\"table\"#select[downshift-{rid}-input]=Exclude",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/response_latency_ms?visualizationType=\"table\"#select[Filter by fields]=thread",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/response_latency_ms?visualizationType=\"table\"#select[SortBy direction]=Asc",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/response_latency_ms?visualizationType=\"table\"#select[SortBy function]=Most relevantSmart ordering of graphs based on the most significant spikes in the data",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/thread?visualizationType=\"json\"",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/thread?visualizationType=\"json\"#adhoc[Filter by labels]={rep}",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/thread?visualizationType=\"json\"#radio[Grid|Rows]=Grid",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/thread?visualizationType=\"json\"#select[downshift-{rid}-input]=Exclude",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/thread?visualizationType=\"json\"#select[Filter by fields]=thread",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/thread?visualizationType=\"json\"#select[SortBy direction]=Desc",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/thread?visualizationType=\"json\"#select[SortBy function]=Most relevantSmart ordering of graphs based on the most significant spikes in the data",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/thread?visualizationType=\"table\"",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/thread?visualizationType=\"table\"#adhoc[Filter by labels]={rep}",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/thread?visualizationType=\"table\"#radio[Grid|Rows]=Grid",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/thread?visualizationType=\"table\"#select[downshift-{rid}-input]=Exclude",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/thread?visualizationType=\"table\"#select[Filter by fields]=thread",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/thread?visualizationType=\"table\"#select[SortBy direction]=Desc",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/thread?visualizationType=\"table\"#select[SortBy function]=Most relevantSmart ordering of graphs based on the most significant spikes in the data",
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/{field}?visualizationType=\"table\"#select[SortBy function]=Most relevantSmart ordering of graphs based on the most significant spikes in the data",
       "lean": false
     },
     {

--- a/test/e2e/playwright/crawl/lib.ts
+++ b/test/e2e/playwright/crawl/lib.ts
@@ -404,14 +404,21 @@ export function canonicalTarget(
     }
     // Logs-drilldown service pages: the segment AFTER 'service' is the
     // service name harvested from live data; the segment after
-    // 'label' is a label NAME from live data (the labels-tab drill).
-    // Both parameterize to one representative per route family.
+    // 'label' is a label NAME from live data (the labels-tab drill); the
+    // segment after 'field' is a log FIELD name from live data (the
+    // fields-tab drill). All three parameterize to one representative per
+    // route family, so the inventory pins the ROUTE the drill reaches rather
+    // than whichever names happened to be in the seeded logs that day.
     if (i >= 1 && segments[i - 1] === 'service') {
       segments[i] = '{service}';
       continue;
     }
     if (i >= 1 && segments[i - 1] === 'label') {
       segments[i] = '{label}';
+      continue;
+    }
+    if (i >= 1 && segments[i - 1] === 'field') {
+      segments[i] = '{field}';
     }
   }
   path = segments.join('/');


### PR DESCRIPTION
Two defects in the Grafana crawl surface-inventory pipeline.

## The nightly full-depth crawl was killed, not run

`shard-crawl` returned `cancelled` on every scheduled run (`30882664033`,
`30979877568`, `31076025683`). The cause is a job cap below the spec's own
budget: `compose-smoke-matrix.mjs` and `dashboard-matrix.mjs` both carried a
constant, event-independent 30-minute `timeout-minutes`, while
`crawl.spec.ts` gives the full-depth sweep 75 minutes via
`testInfo.setTimeout` and both lanes' comments describe the full crawl as the
~50min long pole. GitHub records a `timeout-minutes` kill as `cancelled`, so
the failure never looked like a failure. Run data, job `92534191138`: BFS
starts `06:07:47` logging `sweep depth: full`, `The operation was canceled.`
at `06:34:10`, job start `06:03:58` — 30.2 minutes.

Ruled out from the run data: `fail-fast` (every crawl matrix sets
`fail-fast: false`), `cancel-in-progress` (every crawl-related concurrency
group sets it `false`, and there is no file-level `concurrency`), and a
workflow-level timeout (none exists).

Because the lean sweep visits ~18 surfaces and the pin holds the rest, the
surfaces only the nightly reaches were enforced by nothing while the lane
still reported a green-looking `compose-smoke`.

### Fix

`lib/crawl-budget.mjs` becomes the single source of truth for the two nested
budgets and, more importantly, the ordering between them: the job cap is the
spec budget plus a fixed overhead headroom, so the spec times out first and
produces a real `failure` with its partial inventory instead of the runner
producing a non-verdict. The compose crawl cap is now depth-aware (90 on
schedule, 29 on a PR); the k3d crawl shard takes the full-depth cap
unconditionally because that shard always sweeps `SWEEP_DEPTH=full`.

A correct cap is not sufficient — it can be wrong again, and a runner can
reclaim a job for reasons no cap controls. The new `crawl-terminal` job is
the de-gated lane's reader and asserts TERMINALITY, not correctness: the
crawl must reach `success` or `failure`. `cancelled`, `skipped`, an unknown
conclusion, and a setup job that stopped emitting the informational matrix at
all each fail loudly, naming the depth, which pin went unenforced, and the two
budgets to compare. A change out of the lane's scope is the one clean no-op;
a scope job that crashed rather than deciding fails.

Ten `node --test` assertions pin both halves, including a drift guard that
parses the real `crawl.spec.ts` so the checked-in numbers cannot drift from
what the crawl actually asks for, and a tamper case proving that guard fires.

## The field segment pinned live log field names

The path segment after `field` is a log field name harvested from whatever the
seeded logs carry — the same class of defect #1825 was on the query-parameter
axis, where one added attribute reshuffled an option list and fired the ratchet
on a pure data change. It now parameterizes to `{field}` alongside the existing
`{service}` and `{label}` rules in the same segment loop.

Following #1855's fold: 255 surfaces become 216. Every previously pinned
surface is preserved; the 58 rows differing only in the field NAME merge into
19. The lean set stays at 18.

The gate is not weakened — a new test drives `diffInventory` three ways against
the parameterized key: field churn alone is silent, an unvisited surface still
reports `coverage shrank`, and an unpinned one still reports `coverage grew`.

## Verification

- `node --test` over the four planner/budget/terminality suites: 24 pass.
- `npx playwright test crawl/ -g "canonicalization pins"` with
  `CRAWL_STACK=compose`: 14 pass, including the byte-for-byte marshal
  round-trip of the folded inventory.
- `npx tsc --noEmit` over the Playwright suite: clean.
- `actionlint` over both touched workflows and `markdownlint-cli2` over the
  scripts README: clean.
- Planner emit smoke: schedule → 120/120/90, PR → 45/45/29, k3d → 75x5/90.

Closes #1861
Closes #1862

🤖 Generated with [Claude Code](https://claude.com/claude-code)
