### PR TITLE
fix(ci): pair every go test timeout with the CI job budget that runs it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,12 @@ jobs:
     needs: changes
     if: needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
+    # The lane settles around 5m30s. This budget is the outer bound the
+    # runner enforces; the inner one is `just test-unit`'s own `-timeout`,
+    # deliberately shorter so a hang is a Go panic with every goroutine's
+    # stack rather than a killed container with no artefact. An undeclared
+    # budget here would be GitHub's 360-minute default, which says nothing.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
 
@@ -133,6 +139,10 @@ jobs:
     needs: changes
     if: needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
+    # Settles around 3 minutes; same budget as `check-test` because the two
+    # halves are interchangeable in what a stall costs, and a single number
+    # is one fewer thing to keep in sync.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
 

--- a/Justfile
+++ b/Justfile
@@ -107,6 +107,22 @@ migrate *ARGS:
 
 # === Test ===
 
+# Every `go test` below that CI runs carries an explicit `-timeout`, and it is
+# always shorter than the `timeout-minutes` of the job that runs it.
+#
+# Both halves matter. `go test` stops a binary after 10 minutes when the command
+# line does not say otherwise, so a job declaring a longer budget advertises
+# headroom the tests can never reach — the binary panics at 10:00 and the job
+# fails at half its stated budget with nothing in the log explaining the gap.
+# Raising the job's number looks like a fix and is not. And the ordering is what
+# makes a red lane useful: Go's abort dumps every goroutine's stack, naming the
+# test that hung; the runner's kill takes the container away and uploads
+# nothing.
+#
+# `test/regression/go_test_timeout_budget_test.go` derives the pairing from
+# these recipes and the workflows and fails on any drift, so the numbers below
+# do not have to be remembered.
+
 # Run unit + spec tests with race detector, then type-check the build-tagged
 # lanes no other recipe compiles. This is the whole `check` gate in one
 # command, which is what you want locally; CI splits it across two concurrent
@@ -119,7 +135,7 @@ test: test-unit vet-tagged
 # quick type-check/build work would serialise two things that have no reason to
 # wait on each other.
 test-unit:
-    go test -race ./...
+    go test -timeout 15m -race ./...
 
 # Type-check the build-tagged migration lanes no other recipe compiles. `go vet`
 # typechecks, so a rename in an untagged package that breaks a `migration_tier1`
@@ -150,7 +166,7 @@ test-agpl-oracle:
 # Docker.
 schema-ddl-test:
     @just _pull-retry {{CH_TEST_IMAGE}} {{CH_TEST_IMAGE_PRIOR}}
-    go test -race -tags=integration ./internal/schema/ddl/...
+    go test -timeout 20m -race -tags=integration ./internal/schema/ddl/...
 
 # Run the TXTAR spec suite with the chDB-backed round-trip assertion
 # layer enabled. Requires libchdb.so (see `just chdb-install`). The
@@ -181,7 +197,7 @@ spec-chdb:
 # of how a real engine resolves a name against an Enum8, and no shape assertion
 # over the emitted SQL can prove that.
 test-chdb:
-    go test -tags chdb -count=1 ./internal/chclienttest/... ./internal/api/... ./internal/optcorpus/... ./internal/routerrules/... ./internal/schema/ddl/... ./internal/solver/... ./test/consumer-corpus/...
+    go test -timeout 10m -tags chdb -count=1 ./internal/chclienttest/... ./internal/api/... ./internal/optcorpus/... ./internal/routerrules/... ./internal/schema/ddl/... ./internal/solver/... ./test/consumer-corpus/...
 
 # Run the chDB-tagged property tests (rapid + from-scratch oracle).
 # Requires libchdb.so (see `just chdb-install`). Local default is rapid's
@@ -196,9 +212,11 @@ property:
 # fan-out round-trip baseline. Requires libchdb.so (see `just chdb-install`).
 # Mirrors the `perf-guards` CI job in chdb.yml. Distinct from the
 # informational `perf-benchmark.yml` lane, which only reports benchstat
-# deltas and never gates.
+# deltas and never gates. The lane sits around 8 minutes and the ratchet grows
+# with the corpus, so the `-timeout` is the one number here with real slack
+# behind it: `perf-guards` budgets 20 minutes and this takes 15 of them.
 perf-chdb:
-    go test -tags chdb -count=1 ./test/perf/...
+    go test -timeout 15m -tags chdb -count=1 ./test/perf/...
 
 # Profile the WHOLE TXTAR corpus for compute fan-out (perf-assessment
 # Component B). Walks every executable fixture under test/spec/** (those
@@ -218,7 +236,7 @@ perf-profile OUT="perf-profile.json" TOP="40":
 # build tag so regular `just test` doesn't pull in Docker.
 chclient-integration:
     @just _pull-retry {{CH_TEST_IMAGE}}
-    go test -race -tags=integration ./internal/chclient/...
+    go test -timeout 15m -race -tags=integration ./internal/chclient/...
 
 # Run the strict-scan differential: execute the matrix-shaped spec golden
 # SQL corpus against a REAL ClickHouse (testcontainers-go) through the
@@ -230,7 +248,7 @@ chclient-integration:
 # .github/workflows/strict-scan.yml.
 strict-scan-test:
     @just _pull-retry {{CH_STRICT_SCAN_IMAGE}}
-    go test -tags=integration -count=1 -run TestStrictScanDifferential ./test/spec/...
+    go test -timeout 15m -tags=integration -count=1 -run TestStrictScanDifferential ./test/spec/...
 
 # Run the router-corpus real-CH integration tests: the offline corpus WRITE
 # path (optcorpus.CHTableSink: real CREATE DDL + columnar Enum8 batch) and READ
@@ -243,7 +261,7 @@ strict-scan-test:
 # internal/routerrules/realch_integration_test.go and strict-scan.yml.
 router-corpus-integration:
     @just _pull-retry {{CH_TEST_IMAGE}}
-    go test -tags=integration -count=1 -run 'RealClickHouse' ./internal/routerrules/... ./internal/optcorpus/...
+    go test -timeout 15m -tags=integration -count=1 -run 'RealClickHouse' ./internal/routerrules/... ./internal/optcorpus/...
 
 # Run the TraceQL spans-scan resource-bound real-CH guard (PR #1154): lowers +
 # emits the Grafana Traces Drilldown Structure + Comparison queries through the
@@ -256,7 +274,7 @@ router-corpus-integration:
 # test/spec/traces_scan_resource_bound_integration_test.go and strict-scan.yml.
 traces-scan-bound-integration:
     @just _pull-retry {{CH_TEST_IMAGE}}
-    go test -tags=integration -count=1 -run TestTracesScanResourceBoundRealCH ./test/spec/...
+    go test -timeout 15m -tags=integration -count=1 -run TestTracesScanResourceBoundRealCH ./test/spec/...
 
 # Run the Tempo HTTP traces-scan WINDOW real-CH guard (#1509): drives the
 # real /api/search + /api/metrics/query_range handlers against a REAL
@@ -274,7 +292,7 @@ traces-scan-bound-integration:
 # strict-scan.yml.
 traces-scan-window-integration:
     @just _pull-retry {{CH_TEST_IMAGE}}
-    go test -tags=integration -count=1 -run TestTracesScanWindowRealCH ./internal/api/tempo/...
+    go test -timeout 15m -tags=integration -count=1 -run TestTracesScanWindowRealCH ./internal/api/tempo/...
 
 # Run the solver's mandatory per-shard memory-apportionment real-CH guard:
 # proves Executor.runShard's max_memory_usage WithQuerySetting override is
@@ -287,7 +305,7 @@ traces-scan-window-integration:
 # internal/solver/executor_realch_integration_test.go and strict-scan.yml.
 solver-memory-apportion-integration:
     @just _pull-retry {{CH_TEST_IMAGE}}
-    go test -tags=integration -count=1 -run TestExecutor_PerShardMaxMemoryUsage_RealClickHouse ./internal/solver/...
+    go test -timeout 15m -tags=integration -count=1 -run TestExecutor_PerShardMaxMemoryUsage_RealClickHouse ./internal/solver/...
 
 # Run the route-B real-CH result differential: the IDENTICAL query_range
 # request answered through the REAL production PromQL lowering + emitter,
@@ -303,7 +321,7 @@ solver-memory-apportion-integration:
 # strict-scan.yml.
 route-b-differential-integration:
     @just _pull-retry {{CH_TEST_IMAGE}}
-    go test -tags=integration -count=1 -run TestRouteB_MatchesRouteA_RealClickHouse ./internal/api/prom/...
+    go test -timeout 15m -tags=integration -count=1 -run TestRouteB_MatchesRouteA_RealClickHouse ./internal/api/prom/...
 
 # Run the Loki + Prometheus metadata/label-values endpoints real-CH
 # differential: /loki/api/v1/{series,labels,label/*/values,index/stats,
@@ -322,7 +340,7 @@ route-b-differential-integration:
 # and strict-scan.yml.
 metadata-endpoints-integration:
     @just _pull-retry {{CH_TEST_IMAGE}}
-    go test -tags=integration -count=1 -run TestMetadataEndpoints_RealClickHouse ./test/spec/...
+    go test -timeout 15m -tags=integration -count=1 -run TestMetadataEndpoints_RealClickHouse ./test/spec/...
 
 # Run the histogram real-exporter-schema differential (#1642): provisions the
 # table shapes the REAL upstream clickhouseexporter creates — LowCardinality-
@@ -339,7 +357,7 @@ metadata-endpoints-integration:
 # internal/api/prom/handler_histogram_integration_test.go and strict-scan.yml.
 histogram-realexporter-integration:
     @just _pull-retry {{CH_TEST_IMAGE}}
-    go test -tags=integration -count=1 -run TestHistogram_RealExporterSchema_Integration ./internal/api/prom/...
+    go test -timeout 15m -tags=integration -count=1 -run TestHistogram_RealExporterSchema_Integration ./internal/api/prom/...
 
 # Run the FuzzParse target for one parser head for a bounded duration.
 # Usage: `just fuzz QL=promql DURATION=60s` (defaults).
@@ -370,11 +388,11 @@ coverage:
     # require the `covdata` tool on toolchains that ship without it).
     # The cover.out profile is still written for every package that
     # compiled, which is all production code in internal/**.
-    go test -coverprofile=cover.out ./... || true
+    go test -timeout 25m -coverprofile=cover.out ./... || true
     @test -s cover.out
     @if [ -e /usr/local/lib/libchdb.so ]; then \
         echo "==> chdb-tagged coverage"; \
-        go test -tags chdb -coverprofile=cover-chdb.out ./... || true; \
+        go test -timeout 25m -tags chdb -coverprofile=cover-chdb.out ./... || true; \
         echo "==> merging profiles"; \
         { echo "mode: set"; \
           awk 'FNR==1{next} { k=$1" "$2; if (!(k in m) || $3>m[k]) m[k]=$3 } END { for (k in m) print k, m[k] }' cover.out cover-chdb.out | sort; \
@@ -1263,7 +1281,7 @@ e2e-run:
         CH_DATABASE=otel \
         CH_USERNAME=cerberus \
         CH_PASSWORD=cerberus \
-        go test -tags=e2e ./test/e2e/...
+        go test -timeout 35m -tags=e2e ./test/e2e/...
 
 # A godog suite driving `cerberus migrate` over committed fixtures — no
 # Docker, no backend, seconds.

--- a/test/regression/go_test_timeout_budget_test.go
+++ b/test/regression/go_test_timeout_budget_test.go
@@ -1,0 +1,304 @@
+package regression
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// A CI job and the `go test` it runs each carry their own clock, and only one
+// of them is written down where a reviewer looks.
+//
+// `go test` defaults to aborting a test binary after 10 minutes. A job that
+// declares `timeout-minutes: 20` therefore advertises twenty minutes of
+// headroom the tests can never reach: at 10:00 the binary panics with
+// "test timed out", the job fails at half its stated budget, and the log says
+// nothing about where the missing ten minutes went. A job that declares no
+// budget at all is the same bug with the sign flipped — it inherits GitHub's
+// 360-minute default, so a genuinely hung test burns six hours of runner time
+// before anything notices, except that it does not, because Go still stops it
+// at 10.
+//
+// The mismatch is invisible in a diff. Raising a job's `timeout-minutes`
+// because the lane got slower looks like it worked — the number went up — and
+// changes nothing. #1847 was exactly that: `perf-guards` declared 20 minutes
+// while `just perf-chdb` ran under the silent 10-minute default, with the lane
+// already at 7m57s.
+//
+// So this file derives the pairing rather than restating it. It reads every
+// workflow job, finds the `just` recipes that job runs, walks each recipe
+// (dependencies included) for `go test` invocations, and requires that:
+//
+//   - a job running Go tests declares a budget at all;
+//   - each `go test` in such a recipe declares its own `-timeout`; and
+//   - that `-timeout` fits inside the smallest job budget that runs it, with
+//     room for the abort to be written down.
+//
+// The last one is the point. Go's timeout is the useful one: it panics and
+// dumps every goroutine's stack, which is the difference between "the perf
+// lane is slow" and "TestCardinalityRatchet is blocked on chDB". The runner's
+// timeout kills the process and uploads nothing. Ordering them so Go always
+// fires first is what turns a red lane into a diagnosis.
+const (
+	// goDefaultTestTimeout is the timeout `go test` applies when the command
+	// line does not. A job budget at or below it cannot be silently capped:
+	// the runner is the shorter clock, which is visible in the job log.
+	goDefaultTestTimeout = 10 * time.Minute
+
+	// abortReportingMargin is the gap a recipe's `-timeout` must leave under
+	// its job's budget. The panic-and-dump has to finish, and the job's
+	// remaining steps have to upload it, before the runner's own timeout
+	// takes the container away — so the two clocks are ordered, not merely
+	// different.
+	abortReportingMargin = 3 * time.Minute
+)
+
+var (
+	// jobHeaderRe matches a workflow job key: exactly two spaces of indent,
+	// a name, a colon, nothing else. Steps and `with:` keys sit deeper.
+	jobHeaderRe = regexp.MustCompile(`^  ([A-Za-z0-9_-]+):\s*$`)
+
+	timeoutMinutesRe = regexp.MustCompile(`^\s+timeout-minutes:\s*(\S+)`)
+
+	// justInvocationRe matches a `just <recipe>` call. The recipe name is
+	// checked against the Justfile's own recipe set afterwards, so a `just`
+	// appearing in English prose ("just the pushed tag") cannot masquerade
+	// as an invocation.
+	justInvocationRe = regexp.MustCompile(`\bjust\s+([a-z0-9][a-z0-9-]*)`)
+
+	// justRecipeHeaderRe matches a Justfile recipe header at column 0. A
+	// recipe may take parameters, so the name is followed by a space or the
+	// colon that closes the header.
+	justRecipeHeaderRe = regexp.MustCompile(`^([a-z0-9][a-z0-9-]*)(\s+[^:]*)?:`)
+
+	goTestRe = regexp.MustCompile(`\bgo test\b`)
+
+	// goTestTimeoutRe captures the argument of a `-timeout` flag, which is
+	// either a Go duration or a `{{VAR}}` reference to a Justfile variable.
+	goTestTimeoutRe = regexp.MustCompile(`-timeout[= ]+(\S+)`)
+
+	justVarRe = regexp.MustCompile(`^([A-Z0-9_]+)\s*:=\s*["']?([^"'\s#]+)`)
+)
+
+// workflowJob is one job's two relevant facts: how long the runner will wait,
+// and which Justfile recipes it runs.
+type workflowJob struct {
+	workflow string
+	name     string
+	// budget is the declared `timeout-minutes`. Zero means undeclared,
+	// which is a finding rather than a value.
+	budget time.Duration
+	// budgetIsExpression records a `timeout-minutes:` whose value is a
+	// `${{ … }}` expression — the sharded lanes take theirs from the
+	// matrix their generator script builds. The budget is declared, so the
+	// lane is not running on GitHub's 360-minute default, but its number
+	// is not in the file. Such a job still has to see a `-timeout`; only
+	// the fits-inside comparison is unavailable.
+	budgetIsExpression bool
+	recipes            []string
+}
+
+// TestGoTestTimeoutFitsItsJobBudget is the whole gate. It fails with one line
+// per offending (job, recipe, command) triple rather than at the first, so a
+// sweep is one read of the output.
+func TestGoTestTimeoutFitsItsJobBudget(t *testing.T) {
+	t.Parallel()
+
+	justfile := readFileString(t, justfilePath)
+	recipeNames := justRecipeNames(justfile)
+	justVars := justVariables(justfile)
+
+	var problems []string
+	for _, job := range workflowJobsRunningJust(t, recipeNames) {
+		for _, recipe := range job.recipes {
+			for _, cmd := range goTestCommands(t, justfile, recipe) {
+				problems = append(problems,
+					checkGoTestCommand(t, job, recipe, cmd, justVars)...)
+			}
+		}
+	}
+
+	if len(problems) > 0 {
+		sort.Strings(problems)
+		t.Errorf("%d `go test` invocation(s) whose clock does not match the CI job budget that runs "+
+			"them. `go test` stops a binary after %s unless told otherwise, and it is the abort that "+
+			"dumps goroutine stacks — so it must always fire first, and the job's declared budget must "+
+			"be the number a reader can trust:\n\n%s",
+			len(problems), goDefaultTestTimeout, strings.Join(problems, "\n"))
+	}
+}
+
+// checkGoTestCommand applies the three rules to one `go test` line.
+func checkGoTestCommand(t *testing.T, job workflowJob, recipe, cmd string, justVars map[string]string) []string {
+	t.Helper()
+	where := fmt.Sprintf("%s job %q -> `just %s`", job.workflow, job.name, recipe)
+
+	if job.budget == 0 && !job.budgetIsExpression {
+		return []string{fmt.Sprintf("%s: job declares no `timeout-minutes`, so the runner waits out "+
+			"GitHub's 360-minute default while `go test` stops at %s. Declare the budget the lane "+
+			"actually needs.\n      %s", where, goDefaultTestTimeout, strings.TrimSpace(cmd))}
+	}
+
+	match := goTestTimeoutRe.FindStringSubmatch(cmd)
+	if match == nil {
+		if job.budget > 0 && job.budget <= goDefaultTestTimeout {
+			// The runner is the shorter clock. Nothing is hidden: the job
+			// log names the timeout that fired.
+			return nil
+		}
+		budget := job.budget.String()
+		if job.budgetIsExpression {
+			budget = "matrix-supplied"
+		}
+		return []string{fmt.Sprintf("%s: job budget is %s but the command declares no `-timeout`, so it "+
+			"silently runs under Go's %s default and the extra budget is unreachable.\n      %s",
+			where, budget, goDefaultTestTimeout, strings.TrimSpace(cmd))}
+	}
+	if job.budgetIsExpression {
+		// The number lives in the matrix generator, not here; a `-timeout`
+		// is declared, which is all this file can check.
+		return nil
+	}
+
+	declared, err := resolveGoTestTimeout(match[1], justVars)
+	if err != nil {
+		return []string{fmt.Sprintf("%s: cannot read the declared `-timeout` %q: %v.\n      %s",
+			where, match[1], err, strings.TrimSpace(cmd))}
+	}
+	if declared+abortReportingMargin > job.budget {
+		return []string{fmt.Sprintf("%s: `-timeout %s` leaves less than %s under the job's %s budget, so "+
+			"the runner can kill the container mid-panic and the goroutine dump — the only artefact that "+
+			"says WHERE it hung — never reaches the log.\n      %s",
+			where, declared, abortReportingMargin, job.budget, strings.TrimSpace(cmd))}
+	}
+	return nil
+}
+
+// resolveGoTestTimeout parses a `-timeout` argument, following a `{{VAR}}`
+// reference back to the Justfile variable it names.
+func resolveGoTestTimeout(raw string, justVars map[string]string) (time.Duration, error) {
+	if strings.HasPrefix(raw, "{{") && strings.HasSuffix(raw, "}}") {
+		name := strings.TrimSpace(strings.Trim(raw, "{}"))
+		value, ok := justVars[name]
+		if !ok {
+			return 0, fmt.Errorf("Justfile has no variable %q", name)
+		}
+		raw = value
+	}
+	return time.ParseDuration(raw)
+}
+
+// workflowJobsRunningJust returns every workflow job that invokes at least one
+// of the named recipes, with the budget it declares.
+func workflowJobsRunningJust(t *testing.T, recipeNames map[string]bool) []workflowJob {
+	t.Helper()
+
+	entries, err := os.ReadDir(workflowsDir)
+	if err != nil {
+		t.Fatalf("read %s: %v", workflowsDir, err)
+	}
+
+	var jobs []workflowJob
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || (!strings.HasSuffix(name, ".yml") && !strings.HasSuffix(name, ".yaml")) {
+			continue
+		}
+		jobs = append(jobs, jobsInWorkflow(readFileString(t, filepath.Join(workflowsDir, name)), name, recipeNames)...)
+	}
+	return jobs
+}
+
+// jobsInWorkflow scans one workflow file. It is a line scanner rather than a
+// YAML parse because the only structure it needs is "which job am I inside",
+// which the two-space job header gives directly — and because a dependency-free
+// scanner cannot disagree with the YAML the runner actually reads about
+// anything subtler than that.
+func jobsInWorkflow(workflow, filename string, recipeNames map[string]bool) []workflowJob {
+	var (
+		jobs    []workflowJob
+		current *workflowJob
+	)
+	flush := func() {
+		if current != nil && len(current.recipes) > 0 {
+			jobs = append(jobs, *current)
+		}
+	}
+	for _, line := range strings.Split(workflow, "\n") {
+		if header := jobHeaderRe.FindStringSubmatch(line); header != nil {
+			flush()
+			current = &workflowJob{workflow: filename, name: header[1]}
+			continue
+		}
+		if current == nil {
+			continue
+		}
+		if strings.HasPrefix(strings.TrimSpace(line), "#") {
+			continue
+		}
+		if minutes := timeoutMinutesRe.FindStringSubmatch(line); minutes != nil &&
+			current.budget == 0 && !current.budgetIsExpression {
+			if n, err := strconv.Atoi(minutes[1]); err == nil {
+				current.budget = time.Duration(n) * time.Minute
+			} else {
+				current.budgetIsExpression = true
+			}
+		}
+		for _, invocation := range justInvocationRe.FindAllStringSubmatch(line, -1) {
+			recipe := invocation[1]
+			if recipeNames[recipe] && !contains(current.recipes, recipe) {
+				current.recipes = append(current.recipes, recipe)
+			}
+		}
+	}
+	flush()
+	return jobs
+}
+
+// goTestCommands returns the `go test` lines a recipe runs, its dependencies
+// included, with comment lines dropped.
+func goTestCommands(t *testing.T, justfile, recipe string) []string {
+	t.Helper()
+	var out []string
+	for _, line := range strings.Split(justRecipeBodyWithDeps(t, justfile, recipe), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "#") || !goTestRe.MatchString(trimmed) {
+			continue
+		}
+		out = append(out, trimmed)
+	}
+	return out
+}
+
+// justRecipeNames returns every recipe the Justfile declares, so a `just` in
+// prose cannot be mistaken for an invocation.
+func justRecipeNames(justfile string) map[string]bool {
+	names := map[string]bool{}
+	for _, line := range strings.Split(justfile, "\n") {
+		if strings.HasPrefix(line, " ") || strings.HasPrefix(line, "\t") || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if header := justRecipeHeaderRe.FindStringSubmatch(line); header != nil {
+			names[header[1]] = true
+		}
+	}
+	return names
+}
+
+// justVariables returns the Justfile's top-level `NAME := value` assignments,
+// which is how a timeout long enough to deserve a name is written down.
+func justVariables(justfile string) map[string]string {
+	vars := map[string]string{}
+	for _, line := range strings.Split(justfile, "\n") {
+		if assignment := justVarRe.FindStringSubmatch(line); assignment != nil {
+			vars[assignment[1]] = assignment[2]
+		}
+	}
+	return vars
+}


### PR DESCRIPTION
## What

`go test` stops a test binary after **10 minutes** unless the command line says otherwise. `perf-guards` declares `timeout-minutes: 20` and ran `just perf-chdb` with no `-timeout`, so half its stated budget was unreachable — with the lane already at 7m57s and a cardinality ratchet that grows with the corpus. Raising the job budget would have looked like a fix and changed nothing.

## The class, not the leaf

Sweeping for the same shape found **17 sites across six workflows**:

| workflow | job | budget | recipes |
|---|---|---|---|
| `chdb.yml` | `perf-guards` | 20m | `perf-chdb` |
| `chdb.yml` | `probe` | 15m | `test-chdb` |
| `coverage.yml` | `coverage` | 30m | `coverage` (×2) |
| `e2e.yml` | `bwc-minio` | 40m | `e2e-run` |
| `schema-integration.yml` | `schema-ddl` | 25m | `schema-ddl-test` |
| `strict-scan.yml` | `strict-scan` | 20m | 8 integration recipes |
| `ci.yml` | `check-test`, `check-build` | **none** | `test-unit` |

The last row is the same bug with the sign flipped: no `timeout-minutes` means GitHub's 360-minute default, so the number a reader sees is nowhere.

## Fix

Every affected recipe declares a `-timeout` that fits inside the smallest job budget that runs it, and the two `ci.yml` jobs declare a budget (20m; they settle around 5m30s and 3m).

The ordering is the point: **Go's abort panics and dumps every goroutine's stack**, naming the test that hung. The runner's kill takes the container away and uploads nothing. So Go must always be the shorter clock, by enough margin for the dump to reach the log.

## Gate

`test/regression/go_test_timeout_budget_test.go` derives the pairing rather than restating it — it reads every workflow job, resolves the `just` recipes that job runs *against the Justfile's own recipe set* (so a `just` in English prose cannot masquerade as an invocation), walks each recipe and its dependencies for `go test` lines, and fails when:

1. a job running Go tests declares no `timeout-minutes`;
2. a command under a longer-than-default budget declares no `-timeout`;
3. a declared `-timeout` leaves less than three minutes of reporting room under the budget.

Sharded lanes take their budget from a matrix expression built by a generator script, so for those the comparison is unavailable and only the presence of a `-timeout` is checked.

**Not hollow** — verified the gate fires on each violation shape and goes green when undone:

- dropping `perf-chdb`'s `-timeout` → *"job budget is 20m0s but the command declares no `-timeout`"*
- setting it to `19m` → *"leaves less than 3m0s under the job's 20m0s budget"*
- deleting `perf-guards`' `timeout-minutes` → *"job declares no `timeout-minutes`, so the runner waits out GitHub's 360-minute default"*

Closes #1847