### PR TITLE
fix(prom): fan exemplar lookup across every table the schema resolves

### DIFF
--- a/internal/api/prom/exemplars.go
+++ b/internal/api/prom/exemplars.go
@@ -44,8 +44,11 @@ type Exemplar struct {
 //
 // Required params: `query` (PromQL string), `start` and `end` (RFC3339 or
 // unix seconds). The `query` must be a single VectorSelector (Prom rejects
-// anything else); cerberus mirrors that. The response is the canonical
-// Prom envelope with `data` shaped as []ExemplarSeries.
+// anything else); cerberus mirrors that. Every matcher shape a selector
+// can carry is answered — a regex `__name__`, or no `__name__` at all —
+// because the table fan-out is resolved from the matcher set rather than
+// from a literal metric name. The response is the canonical Prom envelope
+// with `data` shaped as []ExemplarSeries.
 //
 // Implementation flow:
 //
@@ -53,15 +56,18 @@ type Exemplar struct {
 //  2. Parse the PromQL, walk through any ParenExpr, and require a single
 //     `*parser.VectorSelector`. Anything more complex returns ErrBadData —
 //     upstream Prometheus also restricts this endpoint to one selector.
-//  3. Resolve the target table via [exemplarsTableFor]. Summary metrics
-//     short-circuit with `data:[]` since the OTel-CH summary table has
-//     no Exemplars column upstream — exemplars are a histogram concept
-//     and clients should not see an error for a legitimately
-//     exemplar-free metric type.
-//  4. Build the matcher predicate via the same
+//  3. Resolve the candidate tables and their per-table row keys via
+//     [exemplarArms], which routes through
+//     [schema.Metrics.ExemplarSources]. An empty candidate set (a
+//     summary-only deployment — the OTel-CH summary table has no
+//     Exemplars column upstream) short-circuits with `data:[]`:
+//     exemplars are a histogram concept and clients should not see an
+//     error for a legitimately exemplar-free metric type.
+//  4. Build each arm's matcher predicate via the same
 //     [promql.BuildMatcherPredicate] helper PromQL `handleQuery` /
 //     `handleQueryRange` use.
-//  5. Call [chsql.EmitQueryExemplars] to render the SQL + args.
+//  5. Call [chsql.EmitQueryExemplarsUnion] to render the SQL + args —
+//     one arm per candidate table, unioned.
 //  6. Run the SQL via Querier.QueryExemplars; decode each row positionally
 //     into a [chclient.ExemplarRow].
 //  7. Group rows by `(MetricName, Attributes, ServiceName)` into one
@@ -111,20 +117,18 @@ func (h *Handler) handleQueryExemplars(w http.ResponseWriter, r *http.Request) {
 	}
 
 	metricName := exemplarMetricName(vs.LabelMatchers)
-	if metricName == "" {
-		// Prom requires a concrete `__name__=...` matcher on this
-		// endpoint. Mirror the upstream behaviour rather than fan out
-		// across every metrics table.
-		writeError(w, http.StatusBadRequest, ErrBadData, errors.New("metric name is required"))
+
+	arms, err := exemplarArms(vs.LabelMatchers, metricName, h.Schema)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, ErrInternal, err)
 		return
 	}
-
-	table, ok := exemplarsTableFor(metricName, h.Schema)
-	if !ok {
-		// Summary metrics (or any other family the upstream OTel-CH
-		// schema doesn't carry exemplars for) return an empty data
-		// array — matches Prom's behaviour for exemplar-free metric
-		// types. No ClickHouse round-trip.
+	if len(arms) == 0 {
+		// No configured table can carry exemplars for this selector —
+		// a summary-only deployment, or a schema with every
+		// exemplar-carrying table elided. Return an empty data array,
+		// which is Prom's answer for an exemplar-free metric type, with
+		// no ClickHouse round-trip.
 		writeJSON(w, http.StatusOK, Response{
 			Status: "success",
 			Data:   []ExemplarSeries{},
@@ -132,13 +136,7 @@ func (h *Handler) handleQueryExemplars(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	predicate, err := buildExemplarsPredicate(vs.LabelMatchers, h.Schema)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, ErrInternal, err)
-		return
-	}
-
-	sql, args, err := chsql.EmitQueryExemplars(r.Context(), table, predicate, start, end, h.Schema)
+	sql, args, err := chsql.EmitQueryExemplarsUnion(r.Context(), arms, start, end, h.Schema)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, ErrInternal, err)
 		return
@@ -181,11 +179,13 @@ func singleVectorSelector(expr promparser.Expr) (*promparser.VectorSelector, err
 }
 
 // exemplarMetricName returns the value of the `__name__` equality
-// matcher (if any) — same heuristic the PromQL lowering applies to
-// pick the target metrics table. Returns "" when the selector relies
-// purely on regex / non-name matchers; the exemplars handler treats
-// that as `ErrBadData` because Prom's contract requires a concrete
-// metric name.
+// matcher (if any) — the same heuristic the PromQL lowering applies to
+// pick the target metrics tables. Returns "" when the selector pins no
+// literal name: a regex matcher (`{__name__=~"http_.*"}`), a negated
+// one, or no `__name__` matcher at all (`{job="api"}`). Those selectors
+// are answered, not rejected — the candidate set widens to
+// [schema.Metrics.ExemplarSources]'s unpinned-name fan-out and the
+// matchers themselves do the filtering, exactly as on `/query`.
 //
 // Mirrors `metricNameFromMatchers` in internal/promql/lower.go (kept
 // in-package there to avoid the cross-package import in the PromQL hot
@@ -199,63 +199,42 @@ func exemplarMetricName(ms []*labels.Matcher) string {
 	return ""
 }
 
-// exemplarsTableFor picks the OTel-CH metrics table whose Exemplars
-// Nested column carries the queried metric's exemplars. The OTel-CH
-// summary table has no Exemplars column; the boolean return is `false`
-// for summary metrics (and any other case where no exemplars-carrying
-// table is configured) so the handler short-circuits with empty data
-// rather than emitting SQL against a missing column.
+// exemplarArms turns a selector into the per-table arms
+// [chsql.EmitQueryExemplarsUnion] reads.
 //
-// Routing heuristic (extends [schema.Metrics.TableFor], which only
-// returns Gauge or Sum):
+// Table resolution is [schema.Metrics.ExemplarSources] — the same
+// schema-owned resolver the PromQL sample path consults through
+// [schema.Metrics.TablesFor], so a metric name that is ambiguous across
+// physical layouts (`<x>_count` can be a histogram companion, a
+// hostmetrics cumulative Sum, or a standalone gauge) is read from every
+// layout that can hold it instead of one guessed branch.
 //
-//   - [schema.Metrics.IsExpHistogramMetric] hit → ExpHistogramTable.
-//   - `_bucket` suffix → HistogramTable. Buckets carry the per-bound
-//     observation counts for classic histograms; exemplars there are
-//     written on the histogram table by the OTel SDK.
-//   - `_count` / `_sum` suffix → HistogramTable when configured,
-//     otherwise SumTable. The PromQL `TableFor` heuristic groups
-//     `_count` / `_sum` with the sum table, but for exemplars they
-//     more often belong to the histogram family (the SDK writes
-//     `_count` / `_sum` synthetic series alongside `_bucket`).
-//   - `_total` suffix → SumTable (counter convention).
-//   - Otherwise → GaugeTable.
-func exemplarsTableFor(metricName string, s schema.Metrics) (string, bool) {
-	if s.IsExpHistogramMetric(metricName) {
-		if s.ExpHistogramTable == "" {
-			return "", false
+// Each source also carries the MetricName its rows are keyed by, which
+// differs from the queried name on the histogram-shaped tables: the
+// OTel-CH exporter serves `<base>_count` / `<base>_sum` / `<base>_bucket`
+// off the columns of a row written under the bare `<base>` name. That
+// arm therefore gets its `__name__` matcher retargeted through
+// [promql.RewriteMetricName] — the same rewrite the sample lowering
+// applies — or it would filter on a name no row carries and contribute
+// nothing.
+//
+// An empty result means no configured table can carry exemplars for the
+// selector; the caller answers with an empty data array.
+func exemplarArms(matchers []*labels.Matcher, metricName string, s schema.Metrics) ([]chsql.ExemplarArm, error) {
+	sources := s.ExemplarSources(metricName)
+	arms := make([]chsql.ExemplarArm, 0, len(sources))
+	for _, src := range sources {
+		armMatchers := matchers
+		if src.MetricName != "" && src.MetricName != metricName {
+			armMatchers = promql.RewriteMetricName(matchers, src.MetricName)
 		}
-		return s.ExpHistogramTable, true
-	}
-	if hasExemplarSuffix(metricName, "_bucket") {
-		if s.HistogramTable == "" {
-			return "", false
+		predicate, err := buildExemplarsPredicate(armMatchers, s)
+		if err != nil {
+			return nil, err
 		}
-		return s.HistogramTable, true
+		arms = append(arms, chsql.ExemplarArm{Table: src.Table, Predicate: predicate})
 	}
-	if hasExemplarSuffix(metricName, "_count") || hasExemplarSuffix(metricName, "_sum") {
-		if s.HistogramTable != "" {
-			return s.HistogramTable, true
-		}
-		if s.SumTable != "" {
-			return s.SumTable, true
-		}
-		return "", false
-	}
-	if hasExemplarSuffix(metricName, "_total") {
-		if s.SumTable == "" {
-			return "", false
-		}
-		return s.SumTable, true
-	}
-	if s.GaugeTable == "" {
-		return "", false
-	}
-	return s.GaugeTable, true
-}
-
-func hasExemplarSuffix(s, suffix string) bool {
-	return len(s) >= len(suffix) && s[len(s)-len(suffix):] == suffix
+	return arms, nil
 }
 
 // buildExemplarsPredicate AND-folds the matcher list into a single
@@ -291,10 +270,14 @@ func buildExemplarsPredicate(matchers []*labels.Matcher, s schema.Metrics) (chsq
 // is deterministically ordered by the canonical series-key so two runs
 // against the same row set produce identical wire envelopes.
 //
-// metricName is the resolved `__name__` matcher value; row.MetricName
-// is the authoritative source — they match in normal operation, but
-// the matcher value is the fallback when the row carries a blank
-// MetricName for any reason.
+// metricName is the resolved `__name__` equality-matcher value, and it
+// wins over row.MetricName whenever the selector pinned one: the caller
+// asked for exactly that series name, while the row can be keyed by the
+// bare base name of a classic histogram (the arm that serves
+// `<base>_count` reads the `<base>` row) or by the dotted OTel spelling
+// of the same name. An unpinned selector has no such name, and
+// row.MetricName — which then varies row to row across the fan-out — is
+// the only truth available.
 //
 // Per-exemplar Labels: ExemplarAttributes (the SDK-recorded
 // FilteredAttributes map) is the base, then `trace_id` / `span_id`
@@ -314,9 +297,9 @@ func groupExemplars(rows []chclient.ExemplarRow, metricName string) []ExemplarSe
 	keys := make([]string, 0, len(rows))
 
 	for _, r := range rows {
-		name := r.MetricName
+		name := metricName
 		if name == "" {
-			name = metricName
+			name = r.MetricName
 		}
 		seriesLabels := format.WithMetricName(r.Attributes, name)
 		if r.ServiceName != "" {

--- a/internal/api/prom/exemplars_chdb_test.go
+++ b/internal/api/prom/exemplars_chdb_test.go
@@ -46,12 +46,12 @@ import (
 	"github.com/tsouza/cerberus/internal/schema"
 )
 
-// sumExemplarsDDL is the OTel-metrics-sum-shaped table the chDB-backed
-// exemplars test seeds. The full upstream OTel exporter DDL has many
-// more columns than the handler reads (see
+// exemplarTableDDL renders the OTel-metrics-shaped table the chDB-backed
+// exemplars tests seed, for one table name. The full upstream OTel
+// exporter DDL has many more columns than the handler reads (see
 // $GOMODCACHE/github.com/tsouza/opentelemetry-collector-contrib/exporter/
 // clickhouseexporter@.../sqltemplates/metrics_sum_table.sql); this
-// minimal shape carries exactly the columns chsql.EmitQueryExemplars
+// minimal shape carries exactly the columns the exemplars emitter
 // projects (MetricName / Attributes / ServiceName / TimeUnix) plus the
 // Nested `Exemplars` column with its five sub-fields (TimeUnix /
 // Value / TraceId / SpanId / FilteredAttributes).
@@ -59,11 +59,12 @@ import (
 // `flatten_nested = 1` is the ClickHouse default; under it the Nested
 // column surfaces server-side as a set of parallel `Array(...)`
 // columns accessed via `Exemplars.TimeUnix`, `Exemplars.Value`, etc.
-// The SQL chsql.EmitQueryExemplars renders targets that parallel-array
-// form (the cerberus whole-codebase invariant). Engine = Memory keeps
-// the seed fast and avoids MergeTree's PREWHERE / sort-key
-// constraints; the exemplars SQL does not depend on either.
-const sumExemplarsDDL = `CREATE TABLE otel_metrics_sum (
+// The emitted SQL targets that parallel-array form (the cerberus
+// whole-codebase invariant). Engine = Memory keeps the seed fast and
+// avoids MergeTree's PREWHERE / sort-key constraints; the exemplars SQL
+// does not depend on either.
+func exemplarTableDDL(table string) string {
+	return `CREATE TABLE ` + table + ` (
     MetricName String,
     Attributes Map(String, String),
     ServiceName String,
@@ -77,6 +78,24 @@ const sumExemplarsDDL = `CREATE TABLE otel_metrics_sum (
         TraceId String
     )
 ) ENGINE = Memory;`
+}
+
+// exemplarsDDL creates every exemplar-carrying table of the default
+// schema. A single lookup reads more than one of them — a `_total` name
+// resolves to the sum table plus both histogram layouts
+// (schema.Metrics.ExemplarSources), unioned into one statement — so all
+// of them must exist even though only otel_metrics_sum carries rows.
+// The empty arms are what the fan-out relies on being cost-free, and
+// running them through chDB is what proves the Map-typed projection
+// still casts back across a UNION ALL boundary.
+func exemplarsDDL() string {
+	s := schema.DefaultOTelMetrics()
+	var b strings.Builder
+	for _, table := range []string{s.GaugeTable, s.SumTable, s.HistogramTable, s.ExpHistogramTable} {
+		b.WriteString(exemplarTableDDL(table))
+	}
+	return b.String()
+}
 
 // newChDBExemplarsServer wires a chDB-backed prom handler with the
 // exemplars seed already applied. Mirrors newChDBServer in
@@ -133,7 +152,7 @@ func TestQueryExemplars_ChDB_Roundtrip(t *testing.T) {
 	tsEx2 := base.Add(250 * time.Millisecond).Format(tsFmt)
 	tsEx3 := base.Add(500 * time.Millisecond).Format(tsFmt)
 
-	seed := sumExemplarsDDL + fmt.Sprintf(
+	seed := exemplarsDDL() + fmt.Sprintf(
 		`
 INSERT INTO otel_metrics_sum (
     MetricName, Attributes, ServiceName, TimeUnix, Value,
@@ -323,7 +342,7 @@ func TestQueryExemplars_ChDB_EmptyWindow(t *testing.T) {
 	tsBase := base.Format(tsFmt)
 	tsEx1 := base.Add(10 * time.Millisecond).Format(tsFmt)
 
-	seed := sumExemplarsDDL + fmt.Sprintf(`
+	seed := exemplarsDDL() + fmt.Sprintf(`
 INSERT INTO otel_metrics_sum (
     MetricName, Attributes, ServiceName, TimeUnix, Value,
     Exemplars.FilteredAttributes, Exemplars.TimeUnix, Exemplars.Value,
@@ -361,6 +380,102 @@ INSERT INTO otel_metrics_sum (
 	body := readBody(t, resp)
 	if !strings.Contains(body, `"data":[]`) {
 		t.Errorf("expected data:[] (non-nil empty array) on empty-window response; got %s", body)
+	}
+}
+
+// TestQueryExemplars_ChDB_CompanionSuffixReadsHistogramRow — the
+// end-to-end proof that the `_count` fan-out is live rather than a wider
+// set of arms that can never match (issue #1705).
+//
+// The OTel-CH histogram exporter writes a classic histogram as ONE row
+// keyed by the BARE `<base>` name and serves Prom's `<base>_count` /
+// `<base>_sum` / `<base>_bucket` companion series off that row's
+// columns. So a request for `<base>_count` finds the exemplars only if
+// (a) the histogram table is among the candidate tables and (b) that
+// arm filters on the bare name. Get either half wrong and the response
+// is an empty array — which is exactly what a single-table resolver
+// keyed on the suffixed name returned.
+//
+// The seed puts the exemplars ONLY on the histogram row: no
+// otel_metrics_sum or otel_metrics_gauge row carries `<base>_count`, so
+// nothing but the histogram arm can produce the assertion below.
+//
+// The wire `__name__` stays the queried `<base>_count`: the client asked
+// for that series and Grafana's exemplar overlay matches on it, even
+// though the row it came from is keyed `<base>`.
+func TestQueryExemplars_ChDB_CompanionSuffixReadsHistogramRow(t *testing.T) {
+	base := time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC)
+	const tsFmt = "2006-01-02 15:04:05.000000000"
+	tsBase := base.Format(tsFmt)
+	tsEx := base.Add(10 * time.Millisecond).Format(tsFmt)
+
+	seed := exemplarsDDL() + fmt.Sprintf(`
+INSERT INTO otel_metrics_histogram (
+    MetricName, Attributes, ServiceName, TimeUnix, Value,
+    Exemplars.FilteredAttributes, Exemplars.TimeUnix, Exemplars.Value,
+    Exemplars.SpanId, Exemplars.TraceId
+) VALUES (
+    'http_request_duration_seconds',
+    map('job', 'api'),
+    'checkout',
+    toDateTime64('%s', 9),
+    0.0,
+    [map('request_id', 'req-h1')],
+    [toDateTime64('%s', 9)],
+    [0.042],
+    ['span-h1'],
+    ['trace-h1']
+);`, tsBase, tsEx)
+
+	srv, _ := newChDBExemplarsServer(t, seed)
+
+	startUnix := base.Add(-1 * time.Minute).Unix()
+	endUnix := base.Add(1 * time.Minute).Unix()
+	url := fmt.Sprintf(
+		`%s/api/v1/query_exemplars?query=http_request_duration_seconds_count%%7Bjob%%3D%%22api%%22%%7D&start=%d&end=%d`,
+		srv.URL, startUnix, endUnix,
+	)
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+
+	var out struct {
+		Status string                `json:"status"`
+		Data   []prom.ExemplarSeries `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out.Status != "success" {
+		t.Fatalf("status=%q want success", out.Status)
+	}
+	if len(out.Data) != 1 {
+		t.Fatalf("data has %d series; want 1 (the histogram-row companion): %+v", len(out.Data), out.Data)
+	}
+	series := out.Data[0]
+	if got := series.SeriesLabels["__name__"]; got != "http_request_duration_seconds_count" {
+		t.Errorf("__name__=%q; want the queried companion name", got)
+	}
+	if got := series.SeriesLabels["job"]; got != "api" {
+		t.Errorf("job=%q; want api", got)
+	}
+	if len(series.Exemplars) != 1 {
+		t.Fatalf("series carries %d exemplars; want 1: %+v", len(series.Exemplars), series.Exemplars)
+	}
+	ex := series.Exemplars[0]
+	if ex.Labels["trace_id"] != "trace-h1" || ex.Labels["span_id"] != "span-h1" {
+		t.Errorf("exemplar labels=%v; want trace-h1 / span-h1", ex.Labels)
+	}
+	if ex.Labels["request_id"] != "req-h1" {
+		t.Errorf("exemplar labels=%v; want the seeded request_id", ex.Labels)
+	}
+	if ex.Value != 0.042 {
+		t.Errorf("exemplar value=%v; want the seeded 0.042", ex.Value)
 	}
 }
 

--- a/internal/api/prom/exemplars_test.go
+++ b/internal/api/prom/exemplars_test.go
@@ -182,9 +182,10 @@ func TestQueryExemplars(t *testing.T) {
 // newServerWithSchema mounts a prom handler against a caller-supplied
 // schema.Metrics rather than the fixed schema.DefaultOTelMetrics() that
 // newServer wires — needed to exercise routing decisions
-// (exemplarsTableFor's per-family short-circuit) that only trigger when
-// a specific table isn't configured. Mirrors the newServerWith* family
-// in handler_subquery_budget_test.go / handler_query_timeout_test.go.
+// (schema.Metrics.ExemplarSources's candidate-set resolution) that only
+// trigger when a specific table isn't configured. Mirrors the
+// newServerWith* family in handler_subquery_budget_test.go /
+// handler_query_timeout_test.go.
 func newServerWithSchema(q prom.Querier, s schema.Metrics) *httptest.Server {
 	h := prom.New(q, s, nil)
 	mux := http.NewServeMux()
@@ -192,38 +193,26 @@ func newServerWithSchema(q prom.Querier, s schema.Metrics) *httptest.Server {
 	return httptest.NewServer(mux)
 }
 
-// TestQueryExemplars_SummaryMetricShortCircuit pins the
-// exemplarsTableFor short-circuit documented at
-// internal/api/prom/exemplars.go:121-127 ("Summary metrics short-
-// circuit with data:[] since the OTel-CH summary table has no
-// Exemplars column upstream"). Nothing at the handler level asserted
-// this branch before (see issue #1436): exemplars_basic.txtar only
-// carries -- sql -- / -- args -- sections (never executes), and
-// neither exemplars_test.go nor exemplars_chdb_test.go mentioned
-// "summary".
+// TestQueryExemplars_NoExemplarCarryingTableShortCircuit pins the
+// empty-candidate-set short-circuit: a deployment whose only configured
+// metrics table is the summary table (the OTel-CH summary DDL has no
+// Exemplars column upstream) answers `data:[]` without a ClickHouse
+// round-trip, rather than erroring on a metric family that legitimately
+// has no exemplars.
 //
-// exemplarsTableFor has no dedicated SummaryTable case — the OTel-CH
-// summary table is never wired into the routing table at all, so a
-// summary metric's bare quantile-series name (no _bucket/_count/_sum/
-// _total suffix — summaries expose "quantile" as a LABEL, not a name
-// suffix) falls through to the GaugeTable branch. This test wires a
-// schema whose GaugeTable is unconfigured (the shape an operator
-// running only summary + counter instrumentation would have) so that
-// fallthrough resolves to `ok=false` and the handler takes the
-// short-circuit — the same outcome the doc comment promises for
-// summary metrics.
-//
-// The assertion that actually proves the short-circuit fired (rather
-// than a round-trip to CH that just happened to return zero rows,
-// which is what the other "empty result" cases in TestQueryExemplars
-// exercise) is that the stub Querier's QueryExemplars is never
-// invoked: q.lastSQL stays empty because handleQueryExemplars returns
-// before calling chsql.EmitQueryExemplars / h.Client.QueryExemplars.
-func TestQueryExemplars_SummaryMetricShortCircuit(t *testing.T) {
+// The load-bearing assertion is that the stub Querier's QueryExemplars
+// is never invoked: q.lastSQL stays empty because handleQueryExemplars
+// returns before reaching chsql.EmitQueryExemplarsUnion. The ordinary
+// empty-result path in TestQueryExemplars asserts the opposite (lastSQL
+// non-empty), so a regression in either direction is caught.
+func TestQueryExemplars_NoExemplarCarryingTableShortCircuit(t *testing.T) {
 	t.Parallel()
 
 	s := schema.DefaultOTelMetrics()
 	s.GaugeTable = ""
+	s.SumTable = ""
+	s.HistogramTable = ""
+	s.ExpHistogramTable = ""
 
 	q := &stubQuerier{}
 	srv := newServerWithSchema(q, s)
@@ -251,20 +240,186 @@ func TestQueryExemplars_SummaryMetricShortCircuit(t *testing.T) {
 		t.Fatalf("status: got %q, want success; err=%s", parsed.Status, parsed.Error)
 	}
 	if len(parsed.Data) != 0 {
-		t.Fatalf("expected empty data slice for a summary-family metric, got %d entries", len(parsed.Data))
+		t.Fatalf("expected empty data slice, got %d entries", len(parsed.Data))
 	}
 	if !strings.Contains(body, `"data":[]`) {
 		t.Errorf("expected JSON to contain `\"data\":[]`; got %s", body)
 	}
-
-	// The load-bearing assertion: the short-circuit returns before ever
-	// calling QueryExemplars. If exemplarsTableFor's routing regressed
-	// to resolve a table for this schema/metric combination, the
-	// handler would instead reach CH (as the ordinary empty-result path
-	// does — see the "lastSQL is empty" check above) and this would
-	// fail even though the response body still looks like data:[].
 	if q.lastSQL != "" {
-		t.Errorf("expected the summary-metric short-circuit to skip CH entirely; got lastSQL=%q", q.lastSQL)
+		t.Errorf("expected the empty-candidate-set short-circuit to skip CH entirely; got lastSQL=%q", q.lastSQL)
+	}
+}
+
+// TestQueryExemplars_NeverReadsSummaryTable — the summary table carries
+// no Exemplars column, so no arm of the fan-out may name it whatever the
+// selector looks like. A summary metric's series name has no
+// _bucket/_count/_sum/_total suffix (summaries expose "quantile" as a
+// LABEL, not a name suffix), so it takes the widest candidate set there
+// is — the exact shape most at risk of sweeping the summary table in.
+func TestQueryExemplars_NeverReadsSummaryTable(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	if s.SummaryTable == "" {
+		t.Fatal("default schema has no SummaryTable; the assertion below would be vacuous")
+	}
+
+	q := &stubQuerier{}
+	srv := newServerWithSchema(q, s)
+	t.Cleanup(srv.Close)
+
+	query := url.Values{
+		"query": {`http_request_duration_seconds{quantile="0.99"}`},
+		"start": {"1717995600"},
+		"end":   {"1717999200"},
+	}
+	resp, err := http.Get(srv.URL + "/api/v1/query_exemplars?" + query.Encode())
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", resp.StatusCode, body)
+	}
+	if q.lastSQL == "" {
+		t.Fatal("exemplars handler did not reach CH; lastSQL is empty")
+	}
+	if strings.Contains(q.lastSQL, s.SummaryTable) {
+		t.Errorf("SQL reads the summary table %q, which has no Exemplars column:\n%s", s.SummaryTable, q.lastSQL)
+	}
+}
+
+// TestQueryExemplars_UnpinnedMetricName — a selector that pins no
+// `__name__` equality matcher is answered, not rejected. Before the
+// table fan-out, both shapes below returned 400 "metric name is
+// required" (issue #1435): resolution was keyed on a literal metric name
+// because a single table had to be guessed from it. Upstream Prometheus
+// queries its exemplar store with whatever matchers the request carries,
+// and so does cerberus now — the matchers do the filtering and the scan
+// fans across every exemplar-carrying table.
+func TestQueryExemplars_UnpinnedMetricName(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		query string
+	}{
+		{name: "no __name__ matcher at all", query: `{job="api"}`},
+		{name: "regex __name__ matcher", query: `{__name__=~"http_.*"}`},
+		{name: "negated __name__ matcher", query: `{__name__!="up",job="api"}`},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			q := &stubQuerier{}
+			srv := newServer(q)
+			t.Cleanup(srv.Close)
+
+			query := url.Values{
+				"query": {tc.query},
+				"start": {"1717995600"},
+				"end":   {"1717999200"},
+			}
+			resp, err := http.Get(srv.URL + "/api/v1/query_exemplars?" + query.Encode())
+			if err != nil {
+				t.Fatalf("GET: %v", err)
+			}
+			body := readBody(t, resp)
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status: got %d, want 200; body=%s", resp.StatusCode, body)
+			}
+
+			var parsed exemplarsResponse
+			if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+				t.Fatalf("unmarshal: %v\nbody=%s", err, body)
+			}
+			if parsed.Status != "success" {
+				t.Fatalf("status: got %q, want success; err=%s", parsed.Status, parsed.Error)
+			}
+			// The query must actually be asked of ClickHouse — a 200
+			// produced by short-circuiting to data:[] would be the same
+			// rejection wearing a different status code.
+			if q.lastSQL == "" {
+				t.Fatal("exemplars handler did not reach CH; lastSQL is empty")
+			}
+			for _, table := range []string{
+				schema.DefaultOTelMetrics().GaugeTable,
+				schema.DefaultOTelMetrics().SumTable,
+				schema.DefaultOTelMetrics().HistogramTable,
+				schema.DefaultOTelMetrics().ExpHistogramTable,
+			} {
+				if !strings.Contains(q.lastSQL, table) {
+					t.Errorf("unpinned-name scan misses table %q:\n%s", table, q.lastSQL)
+				}
+			}
+		})
+	}
+}
+
+// TestQueryExemplars_CompanionSuffixFansOutAcrossLayouts — a
+// `<base>_count` name is ambiguous across three physical layouts (issue
+// #1705): the classic-histogram companion columns on the bare-named
+// histogram row, an OTel-hostmetrics cumulative Sum under the suffixed
+// name, and a standalone gauge literally named `<x>_count`. The scan
+// must read every one of them — the same candidate set
+// schema.Metrics.TablesFor resolves for the sample path — instead of
+// answering from whichever branch a suffix chain happened to pick.
+//
+// The histogram arm also has to filter on the BARE name: the OTel-CH
+// exporter writes no row under `<base>_count`, so an arm carrying the
+// suffixed matcher would be an inert arm that can never match.
+func TestQueryExemplars_CompanionSuffixFansOutAcrossLayouts(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	q := &stubQuerier{}
+	srv := newServerWithSchema(q, s)
+	t.Cleanup(srv.Close)
+
+	query := url.Values{
+		"query": {`http_request_duration_seconds_count{job="api"}`},
+		"start": {"1717995600"},
+		"end":   {"1717999200"},
+	}
+	resp, err := http.Get(srv.URL + "/api/v1/query_exemplars?" + query.Encode())
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", resp.StatusCode, body)
+	}
+	if q.lastSQL == "" {
+		t.Fatal("exemplars handler did not reach CH; lastSQL is empty")
+	}
+
+	// Every table the sample path resolves for this name must appear in
+	// the exemplar scan — the two resolvers share the suffix heuristic.
+	for _, table := range s.TablesFor("http_request_duration_seconds_count") {
+		if !strings.Contains(q.lastSQL, table) {
+			t.Errorf("`_count` scan misses candidate table %q:\n%s", table, q.lastSQL)
+		}
+	}
+
+	// The histogram arm reads the bare-named row: the suffixed name is
+	// bound on the value-table arms, the bare name on the histogram arm.
+	var sawBare, sawSuffixed bool
+	for _, a := range q.lastArgs {
+		switch a {
+		case "http_request_duration_seconds":
+			sawBare = true
+		case "http_request_duration_seconds_count":
+			sawSuffixed = true
+		}
+	}
+	if !sawBare {
+		t.Errorf("no arm filters on the bare histogram row key; args=%v", q.lastArgs)
+	}
+	if !sawSuffixed {
+		t.Errorf("no arm filters on the queried suffixed name; args=%v", q.lastArgs)
 	}
 }
 

--- a/internal/chsql/query_exemplars.go
+++ b/internal/chsql/query_exemplars.go
@@ -106,46 +106,150 @@ func EmitQueryExemplars(
 	_, span := tracer.Start(ctx, cerbtrace.SpanEmit)
 	defer span.End()
 
-	if exemplarsTable == "" {
-		err := fmt.Errorf("%w: exemplarsTable is empty", ErrUnsupported)
+	sql, args, err := emitQueryExemplarsArm(ExemplarArm{Table: exemplarsTable, Predicate: predicate}, start, end, s)
+	if err != nil {
 		span.RecordError(err)
 		return "", nil, err
+	}
+	span.SetAttributes(cerbtrace.AttrSQLLength.Int(len(sql)))
+	return sql, args, nil
+}
+
+// ExemplarArm is one arm of an exemplar fan-out: the candidate table to
+// read, paired with the matcher predicate that resolves the queried
+// series ON THAT table.
+//
+// The predicate is per-arm rather than shared because the row key is
+// per-arm: a `<base>_count` selector filters `MetricName = '<base>_count'`
+// on the Sum and Gauge tables but `MetricName = '<base>'` on the
+// histogram table, where the OTel-CH exporter serves the companion series
+// off the bare-named row's columns. See [schema.Metrics.ExemplarSources],
+// which resolves the (table, row key) pairs the caller turns into arms.
+type ExemplarArm struct {
+	Table     string
+	Predicate Frag
+}
+
+// EmitQueryExemplarsUnion renders one statement reading every arm in
+// arms, in order, as `(<arm>) UNION ALL (<arm>) …`. Each arm is the exact
+// SELECT [EmitQueryExemplars] renders for a single table, so the column
+// contract the handler decodes positionally is identical across arms and
+// the union is row-compatible by construction. A single arm renders
+// byte-identically to [EmitQueryExemplars] — no parentheses, no UNION
+// keyword.
+//
+// The union is the TOP-LEVEL statement rather than the FROM of a
+// wrapping SELECT: the projection carries two Map-typed columns
+// (Attributes, ExemplarAttributes) and a redundant `SELECT * FROM (…)`
+// boundary makes some ClickHouse drivers refuse to cast a Map back
+// (see [Render]).
+//
+// Each arm's args bind in emit order — arm 0's predicate literal, arm 0's
+// two time bounds, then arm 1's, and so on.
+//
+// Returns ErrUnsupported for an empty arm list: a caller with no candidate
+// table must answer with an empty result rather than ask for SQL, and the
+// same per-arm schema guards [EmitQueryExemplars] applies (summary table,
+// missing identity columns, exemplars elided from the schema) reject here
+// too.
+func EmitQueryExemplarsUnion(
+	ctx context.Context,
+	arms []ExemplarArm,
+	start, end time.Time,
+	s schema.Metrics,
+) (string, []any, error) {
+	_, span := tracer.Start(ctx, cerbtrace.SpanEmit)
+	defer span.End()
+
+	if len(arms) == 0 {
+		err := fmt.Errorf("%w: no exemplars table to read", ErrUnsupported)
+		span.RecordError(err)
+		return "", nil, err
+	}
+	if len(arms) == 1 {
+		sql, args, err := emitQueryExemplarsArm(arms[0], start, end, s)
+		if err != nil {
+			span.RecordError(err)
+			return "", nil, err
+		}
+		span.SetAttributes(cerbtrace.AttrSQLLength.Int(len(sql)))
+		return sql, args, nil
+	}
+
+	parts := make([]Frag, 0, len(arms))
+	for _, arm := range arms {
+		q, err := queryExemplarsSelect(arm, start, end, s)
+		if err != nil {
+			span.RecordError(err)
+			return "", nil, err
+		}
+		parts = append(parts, q.Frag())
+	}
+
+	b := NewBuilder()
+	UnionAll(parts...)(b)
+	sql, args, err := b.Build()
+	if err != nil {
+		span.RecordError(err)
+		return "", nil, err
+	}
+	span.SetAttributes(cerbtrace.AttrSQLLength.Int(len(sql)))
+	return sql, args, nil
+}
+
+// emitQueryExemplarsArm renders one arm as a standalone statement — the
+// unparenthesised SELECT both single-table entry points return.
+func emitQueryExemplarsArm(arm ExemplarArm, start, end time.Time, s schema.Metrics) (string, []any, error) {
+	q, err := queryExemplarsSelect(arm, start, end, s)
+	if err != nil {
+		return "", nil, err
+	}
+	return q.subquerySQL()
+}
+
+// queryExemplarsSelect builds the outer SELECT for one arm, validating
+// the arm's table and the schema columns the projection needs. See
+// [EmitQueryExemplars] for the emitted shape and the rejection cases.
+func queryExemplarsSelect(
+	arm ExemplarArm,
+	start, end time.Time,
+	s schema.Metrics,
+) (*QueryBuilder, error) {
+	exemplarsTable, predicate := arm.Table, arm.Predicate
+
+	if exemplarsTable == "" {
+		err := fmt.Errorf("%w: exemplarsTable is empty", ErrUnsupported)
+		return nil, err
 	}
 	// The OTel-CH summary table has no Exemplars Nested column upstream.
 	// Routing summary-shaped queries here would emit SQL that references
-	// a non-existent column and fail at run time. The handler picks
-	// metric→table via schema.Metrics.TableFor (and the upcoming
-	// ExemplarsTableFor wrapper); both must skip summary names. We
+	// a non-existent column and fail at run time.
+	// schema.Metrics.ExemplarSources — the resolver the handler routes
+	// through — filters the summary table out of every candidate set; we
 	// guard defensively in case a future caller bypasses that routing.
 	if s.SummaryTable != "" && exemplarsTable == s.SummaryTable {
 		err := fmt.Errorf("%w: exemplars not supported on summary table %q", ErrUnsupported, exemplarsTable)
-		span.RecordError(err)
-		return "", nil, err
+		return nil, err
 	}
 	if s.ExemplarsColumn == "" {
 		err := fmt.Errorf("%w: schema.Metrics.ExemplarsColumn is empty (exporter version pre-dates exemplars?)", ErrUnsupported)
-		span.RecordError(err)
-		return "", nil, err
+		return nil, err
 	}
 	if s.MetricNameColumn == "" {
 		err := fmt.Errorf("%w: schema.Metrics.MetricNameColumn is empty", ErrUnsupported)
-		span.RecordError(err)
-		return "", nil, err
+		return nil, err
 	}
 	if s.AttributesColumn == "" {
 		err := fmt.Errorf("%w: schema.Metrics.AttributesColumn is empty", ErrUnsupported)
-		span.RecordError(err)
-		return "", nil, err
+		return nil, err
 	}
 	if s.ServiceNameColumn == "" {
 		err := fmt.Errorf("%w: schema.Metrics.ServiceNameColumn is empty", ErrUnsupported)
-		span.RecordError(err)
-		return "", nil, err
+		return nil, err
 	}
 	if s.TimestampColumn == "" {
 		err := fmt.Errorf("%w: schema.Metrics.TimestampColumn is empty", ErrUnsupported)
-		span.RecordError(err)
-		return "", nil, err
+		return nil, err
 	}
 
 	// Inner SELECT — fans out via `arrayJoin(arrayEnumerate(...))` and
@@ -214,12 +318,7 @@ func EmitQueryExemplars(
 		).
 		From(inner.Frag())
 
-	sql, args, err := outer.subquerySQL()
-	if err != nil {
-		return "", nil, err
-	}
-	span.SetAttributes(cerbtrace.AttrSQLLength.Int(len(sql)))
-	return sql, args, nil
+	return outer, nil
 }
 
 // dateTime64Frag returns a Frag emitting `toDateTime64(?, ?)` with the

--- a/internal/chsql/query_exemplars_spec_test.go
+++ b/internal/chsql/query_exemplars_spec_test.go
@@ -28,7 +28,7 @@ var queryExemplarsFixtureDir = filepath.Join("..", "..", "test", "spec", "promql
 // shape. Mirrors the pattern in emit_test.go's plans map — adding a
 // fixture is:
 //  1. Create the .txtar with at least an empty `-- sql --` section.
-//  2. Register an entry here.
+//  2. Register an entry here — one ExemplarArm per candidate table.
 //  3. Run `GOLDEN_UPDATE=1 just test-spec` to materialise the SQL.
 //  4. Review the diff and commit both files.
 //
@@ -36,18 +36,53 @@ var queryExemplarsFixtureDir = filepath.Join("..", "..", "test", "spec", "promql
 // summary short-circuit) live in PR B's handler tests; this layer-2a
 // harness asserts only the SQL shape the emitter produces.
 var queryExemplarsCases = map[string]struct {
-	table     string
-	predicate chsql.Frag
-	start     time.Time
-	end       time.Time
-	schema    schema.Metrics
+	arms   []chsql.ExemplarArm
+	start  time.Time
+	end    time.Time
+	schema schema.Metrics
 }{
 	"exemplars_basic": {
-		table: schema.DefaultOTelMetrics().SumTable,
-		predicate: chsql.Eq(
-			chsql.Col(schema.DefaultOTelMetrics().MetricNameColumn),
-			chsql.Lit("http_request_duration_seconds"),
-		),
+		arms: []chsql.ExemplarArm{{
+			Table: schema.DefaultOTelMetrics().SumTable,
+			Predicate: chsql.Eq(
+				chsql.Col(schema.DefaultOTelMetrics().MetricNameColumn),
+				chsql.Lit("http_request_duration_seconds"),
+			),
+		}},
+		start:  time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		end:    time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC),
+		schema: schema.DefaultOTelMetrics(),
+	},
+	// The `<base>_count` fan-out: one arm per physical layout that can
+	// carry the name, each with its own row key — bare on the
+	// histogram arm (the OTel-CH exporter writes the companion series as
+	// columns of the bare-named row), suffixed on the sum and gauge arms.
+	// The arm list mirrors what schema.Metrics.ExemplarSources resolves
+	// and internal/api/prom/exemplars.go hands the emitter.
+	"exemplars_companion_fanout": {
+		arms: []chsql.ExemplarArm{
+			{
+				Table: schema.DefaultOTelMetrics().HistogramTable,
+				Predicate: chsql.Eq(
+					chsql.Col(schema.DefaultOTelMetrics().MetricNameColumn),
+					chsql.Lit("http_request_duration_seconds"),
+				),
+			},
+			{
+				Table: schema.DefaultOTelMetrics().SumTable,
+				Predicate: chsql.Eq(
+					chsql.Col(schema.DefaultOTelMetrics().MetricNameColumn),
+					chsql.Lit("http_request_duration_seconds_count"),
+				),
+			},
+			{
+				Table: schema.DefaultOTelMetrics().GaugeTable,
+				Predicate: chsql.Eq(
+					chsql.Col(schema.DefaultOTelMetrics().MetricNameColumn),
+					chsql.Lit("http_request_duration_seconds_count"),
+				),
+			},
+		},
 		start:  time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
 		end:    time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC),
 		schema: schema.DefaultOTelMetrics(),
@@ -86,16 +121,15 @@ func TestEmitQueryExemplars_Fixtures(t *testing.T) {
 				t.Fatalf("no case registered for fixture %s; add it to queryExemplarsCases in query_exemplars_spec_test.go", c.Name)
 			}
 
-			sql, args, err := chsql.EmitQueryExemplars(
+			sql, args, err := chsql.EmitQueryExemplarsUnion(
 				context.Background(),
-				tc.table,
-				tc.predicate,
+				tc.arms,
 				tc.start,
 				tc.end,
 				tc.schema,
 			)
 			if err != nil {
-				t.Fatalf("EmitQueryExemplars: %v", err)
+				t.Fatalf("EmitQueryExemplarsUnion: %v", err)
 			}
 
 			spec.Match(t, c, map[string]string{

--- a/internal/chsql/query_exemplars_test.go
+++ b/internal/chsql/query_exemplars_test.go
@@ -320,3 +320,155 @@ func TestEmitQueryExemplars_NilPredicate(t *testing.T) {
 		}
 	}
 }
+
+// TestEmitQueryExemplarsUnion_SingleArmIsByteStable — one arm renders
+// exactly what the single-table emitter renders: no parentheses, no
+// UNION keyword, same args. A gauge-only deployment must not pay a SQL
+// shape change for a fan-out it never needs.
+func TestEmitQueryExemplarsUnion_SingleArmIsByteStable(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC)
+	predicate := func() chsql.Frag {
+		return chsql.Eq(chsql.Col(s.MetricNameColumn), chsql.Lit("http_request_duration_seconds"))
+	}
+
+	wantSQL, wantArgs, err := chsql.EmitQueryExemplars(context.Background(), s.GaugeTable, predicate(), start, end, s)
+	if err != nil {
+		t.Fatalf("EmitQueryExemplars: %v", err)
+	}
+	gotSQL, gotArgs, err := chsql.EmitQueryExemplarsUnion(
+		context.Background(),
+		[]chsql.ExemplarArm{{Table: s.GaugeTable, Predicate: predicate()}},
+		start, end, s,
+	)
+	if err != nil {
+		t.Fatalf("EmitQueryExemplarsUnion: %v", err)
+	}
+	if gotSQL != wantSQL {
+		t.Errorf("SQL mismatch\nwant: %s\n got: %s", wantSQL, gotSQL)
+	}
+	if len(gotArgs) != len(wantArgs) {
+		t.Fatalf("Args = %v; want %v", gotArgs, wantArgs)
+	}
+	for i := range gotArgs {
+		if gotArgs[i] != wantArgs[i] {
+			t.Errorf("Args[%d] = %v; want %v", i, gotArgs[i], wantArgs[i])
+		}
+	}
+}
+
+// TestEmitQueryExemplarsUnion_JoinsArms — every arm reaches the emitted
+// SQL, in order, joined by UNION ALL at the TOP level (no wrapping
+// SELECT: the projection carries Map-typed columns some drivers refuse
+// to cast back through a redundant subquery boundary). Each arm keeps
+// its own predicate, so the per-table row key a classic-histogram
+// companion needs binds independently of the other arms.
+func TestEmitQueryExemplarsUnion_JoinsArms(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC)
+
+	arms := []chsql.ExemplarArm{
+		{
+			Table:     s.HistogramTable,
+			Predicate: chsql.Eq(chsql.Col(s.MetricNameColumn), chsql.Lit("http_request_duration_seconds")),
+		},
+		{
+			Table:     s.SumTable,
+			Predicate: chsql.Eq(chsql.Col(s.MetricNameColumn), chsql.Lit("http_request_duration_seconds_count")),
+		},
+		{
+			Table:     s.GaugeTable,
+			Predicate: chsql.Eq(chsql.Col(s.MetricNameColumn), chsql.Lit("http_request_duration_seconds_count")),
+		},
+	}
+
+	sql, args, err := chsql.EmitQueryExemplarsUnion(context.Background(), arms, start, end, s)
+	if err != nil {
+		t.Fatalf("EmitQueryExemplarsUnion: %v", err)
+	}
+
+	if got := strings.Count(sql, " UNION ALL "); got != len(arms)-1 {
+		t.Errorf("UNION ALL count = %d; want %d\n%s", got, len(arms)-1, sql)
+	}
+	if !strings.HasPrefix(sql, "(SELECT ") {
+		t.Errorf("union arms must render parenthesised at the top level; got %s", sql)
+	}
+	for _, arm := range arms {
+		if !strings.Contains(sql, "FROM `"+arm.Table+"`") {
+			t.Errorf("arm table %q missing from SQL:\n%s", arm.Table, sql)
+		}
+	}
+	if idx := strings.Index(sql, "FROM `"+s.SumTable+"`"); idx < strings.Index(sql, "FROM `"+s.HistogramTable+"`") {
+		t.Errorf("arms rendered out of order:\n%s", sql)
+	}
+
+	// Args bind in arm order: each arm contributes its predicate literal
+	// followed by its two time bounds (formatted string + precision 9).
+	wantArgs := []any{
+		"http_request_duration_seconds",
+		"2026-01-01 00:00:00.000000000", int64(9),
+		"2026-01-01 01:00:00.000000000", int64(9),
+		"http_request_duration_seconds_count",
+		"2026-01-01 00:00:00.000000000", int64(9),
+		"2026-01-01 01:00:00.000000000", int64(9),
+		"http_request_duration_seconds_count",
+		"2026-01-01 00:00:00.000000000", int64(9),
+		"2026-01-01 01:00:00.000000000", int64(9),
+	}
+	if len(args) != len(wantArgs) {
+		t.Fatalf("Args length = %d; want %d (args=%v)", len(args), len(wantArgs), args)
+	}
+	for i, want := range wantArgs {
+		if args[i] != want {
+			t.Errorf("Args[%d] = %v (%T); want %v (%T)", i, args[i], args[i], want, want)
+		}
+	}
+}
+
+// TestEmitQueryExemplarsUnion_RejectsEmptyArms — a caller with no
+// candidate table must answer with an empty result rather than ask for
+// SQL. Rendering "no arms" as an empty statement would reach ClickHouse
+// as a syntax error.
+func TestEmitQueryExemplarsUnion_RejectsEmptyArms(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := chsql.EmitQueryExemplarsUnion(
+		context.Background(),
+		nil,
+		time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC),
+		schema.DefaultOTelMetrics(),
+	)
+	if !errors.Is(err, chsql.ErrUnsupported) {
+		t.Fatalf("err = %v; want ErrUnsupported", err)
+	}
+}
+
+// TestEmitQueryExemplarsUnion_RejectsSummaryArm — the per-arm schema
+// guards still fire inside the fan-out: one summary arm rejects the
+// whole statement rather than emitting SQL against a table with no
+// Exemplars column.
+func TestEmitQueryExemplarsUnion_RejectsSummaryArm(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	_, _, err := chsql.EmitQueryExemplarsUnion(
+		context.Background(),
+		[]chsql.ExemplarArm{
+			{Table: s.GaugeTable},
+			{Table: s.SummaryTable},
+		},
+		time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC),
+		s,
+	)
+	if !errors.Is(err, chsql.ErrUnsupported) {
+		t.Fatalf("err = %v; want ErrUnsupported", err)
+	}
+}

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -459,8 +459,8 @@ func resolveSelectorRouting(metricName string, s schema.Metrics, ctx lowerCtx, d
 	// `<base>` name in the histogram table. Reroute the scan + strip the
 	// suffix off the `__name__` matcher + alias the column as `Value` so
 	// the downstream Sample-row contract holds. Mirrors stripBucketSuffix
-	// (PR #637) for the `_bucket` companion, and the exemplars handler's
-	// routing in internal/api/prom/exemplars.go::exemplarsTableFor.
+	// (PR #637) for the `_bucket` companion, and the per-arm row-key
+	// rewrite schema.Metrics.ExemplarSources drives on the exemplars path.
 	//
 	// Two physical layouts may carry the matching rows:
 	//
@@ -1571,6 +1571,17 @@ func buildPredicate(matchers []*labels.Matcher, s schema.Metrics) chplan.Expr {
 // equivalent.
 func BuildMatcherPredicate(matchers []*labels.Matcher, s schema.Metrics) chplan.Expr {
 	return buildPredicate(matchers, s)
+}
+
+// RewriteMetricName is the exported wrapper around [rewriteMetricName] for
+// callers outside the promql package — the `/api/v1/query_exemplars`
+// handler in internal/api/prom, which retargets a companion selector at
+// the bare-named histogram row exactly the way the sample lowering does.
+//
+// Returns a copy: the input matcher slice is never mutated, and matchers
+// other than the pinned `__name__` equality pass through untouched.
+func RewriteMetricName(matchers []*labels.Matcher, name string) []*labels.Matcher {
+	return rewriteMetricName(matchers, name)
 }
 
 // matcherToExpr resolves a single PromQL label matcher into the

--- a/internal/schema/otel.go
+++ b/internal/schema/otel.go
@@ -405,12 +405,10 @@ func (m Metrics) IsExpHistogramMetric(metricName string) bool {
 // Disambiguation: in principle a deployment could expose a counter
 // under a name that happens to end in `_count` or `_sum`. The OTel-CH
 // counter convention uses `_total`, so the collision is rare in
-// practice, and the exemplars handler already adopts the same routing
-// (see internal/api/prom/exemplars.go::exemplarsTableFor). If
-// `_count` / `_sum` ever needs to fall back to the sum-table reading
-// for a deployment that doesn't follow OTel-CH conventions, that's a
-// future config-driven extension; for the v0.1 seed the routing is
-// unconditional.
+// practice. Both read paths resolve the ambiguity by fanning across
+// every physical layout that can carry the name rather than by
+// committing to one: [Metrics.TablesFor] for samples,
+// [Metrics.ExemplarSources] for exemplars.
 func (m Metrics) HistogramCompanionColumn(metricName string) (bareName, valueColumn string, ok bool) {
 	for _, c := range m.histogramCompanions() {
 		if hasSuffix(metricName, c.suffix) {
@@ -555,7 +553,7 @@ func (m Metrics) TablesFor(metricName string) []string {
 	// bucket-companion suffix the bucket-fan-out path rewrites at the
 	// lowering layer (which overrides the table to HistogramTable
 	// before emit; see isClassicBucketSelector).
-	for _, suf := range []string{"_total", "_bucket"} {
+	for _, suf := range []string{totalSuffix, bucketSuffix} {
 		if hasSuffix(metricName, suf) {
 			return []string{m.SumTable}
 		}
@@ -601,6 +599,135 @@ func (m Metrics) TablesForUnknownName() []string {
 		return []string{m.GaugeTable, m.SumTable}
 	}
 	return []string{m.GaugeTable}
+}
+
+// The Prom-convention metric-name suffixes this package routes on.
+// `_count` / `_sum` live in [Metrics.histogramCompanions] instead,
+// because each of those pairs a suffix with the histogram-row column
+// that serves it; `_total` and `_bucket` carry no column pairing.
+const (
+	totalSuffix  = "_total"
+	bucketSuffix = "_bucket"
+)
+
+// ExemplarSource is one candidate physical source for an exemplar lookup:
+// the table whose `Exemplars` Nested column may carry the rows, paired
+// with the MetricName those rows are keyed by IN THAT table.
+//
+// MetricName is not always the name the caller queried. The OTel-CH
+// histogram exporter writes a classic histogram as ONE row under the bare
+// `<base>` name and serves the Prom-convention `<base>_bucket` /
+// `<base>_count` / `<base>_sum` companion series off that row's columns —
+// so on a histogram-shaped table the row key is the bare name while on a
+// Sum or Gauge table it is the suffixed name the caller typed. A caller
+// that filters on `MetricName` must use the per-source value or the arm
+// matches nothing.
+//
+// MetricName is empty when the selector pinned no `__name__` equality
+// matcher; there is no name to rewrite to, and the caller's matchers pass
+// through to every source unchanged.
+type ExemplarSource struct {
+	Table      string
+	MetricName string
+}
+
+// ExemplarSources returns every (table, row key) pair an exemplar lookup
+// for metricName must read. Pass "" for a selector that pins no
+// `__name__` equality matcher — a regex name matcher, a negated one, or
+// no name matcher at all.
+//
+// This is the exemplar counterpart of [Metrics.TablesFor] /
+// [Metrics.TablesForUnknownName], and it delegates to them for the shared
+// suffix heuristics so the two read paths cannot drift. It differs in two
+// ways, both forced by what an exemplar row is:
+//
+//   - The histogram and exp-histogram tables join every non-bucket
+//     candidate set. They are absent from the plain-Sample candidate set
+//     because their row shape has no Value column, which the `merge()`
+//     fan-out requires — a constraint the exemplar projection does not
+//     share, since it reads the `Exemplars` Nested column that every
+//     non-summary table carries identically. Exemplars are predominantly
+//     a histogram concept and the histogram row is keyed by the BARE
+//     metric name, so leaving those tables out is what makes an
+//     unsuffixed histogram name (`http_server_duration`) answer empty.
+//   - The summary table is dropped: the upstream OTel-CH summary table
+//     has no `Exemplars` column at all, so a summary-only deployment
+//     yields an empty candidate set and the caller answers `data:[]`
+//     without a ClickHouse round trip.
+//
+// Two name shapes resolve to exactly one physical layout and skip the
+// fan-out: an exp-histogram name (only the exp-histogram table stores a
+// row under it) and a `<base>_bucket` name (buckets exist only on the
+// classic-histogram row, which carries the exemplars for every bucket of
+// the series).
+func (m Metrics) ExemplarSources(metricName string) []ExemplarSource {
+	tables := m.exemplarTablesFor(metricName)
+	out := make([]ExemplarSource, 0, len(tables))
+	for _, t := range tables {
+		out = append(out, ExemplarSource{Table: t, MetricName: m.exemplarRowName(metricName, t)})
+	}
+	return out
+}
+
+// exemplarTablesFor resolves the candidate table set behind
+// [Metrics.ExemplarSources]; see that method's doc for the rationale of
+// each branch.
+func (m Metrics) exemplarTablesFor(metricName string) []string {
+	if metricName != "" && m.IsExpHistogramMetric(metricName) {
+		return m.exemplarCarrying(m.ExpHistogramTable)
+	}
+	if metricName != "" && hasSuffix(metricName, bucketSuffix) {
+		return m.exemplarCarrying(m.HistogramTable)
+	}
+	sampleTables := m.TablesForUnknownName()
+	if metricName != "" {
+		sampleTables = m.TablesFor(metricName)
+	}
+	candidates := make([]string, 0, len(sampleTables)+2)
+	candidates = append(candidates, sampleTables...)
+	candidates = append(candidates, m.HistogramTable, m.ExpHistogramTable)
+	return m.exemplarCarrying(candidates...)
+}
+
+// exemplarCarrying keeps the configured, distinct, exemplar-carrying
+// tables among its arguments, in argument order. The summary table is
+// filtered out wherever it appears: the upstream OTel-CH summary DDL has
+// no `Exemplars` column, so reading exemplars from it is not a thin
+// result but a SQL error against a missing column.
+func (m Metrics) exemplarCarrying(tables ...string) []string {
+	candidates := distinctTables(tables...)
+	if m.SummaryTable == "" {
+		return candidates
+	}
+	out := make([]string, 0, len(candidates))
+	for _, t := range candidates {
+		if t == m.SummaryTable {
+			continue
+		}
+		out = append(out, t)
+	}
+	return out
+}
+
+// exemplarRowName returns the MetricName that rows for the queried
+// metricName are keyed by in table — the bare base name on the
+// histogram-shaped tables for a Prom-convention companion name, the
+// queried name everywhere else. Returns "" for an unpinned name, which
+// leaves the caller's matchers untouched.
+func (m Metrics) exemplarRowName(metricName, table string) string {
+	if metricName == "" {
+		return ""
+	}
+	if table != m.HistogramTable && table != m.ExpHistogramTable {
+		return metricName
+	}
+	if bare, _, ok := m.HistogramCompanionColumn(metricName); ok {
+		return bare
+	}
+	if table == m.HistogramTable && hasSuffix(metricName, bucketSuffix) {
+		return metricName[:len(metricName)-len(bucketSuffix)]
+	}
+	return metricName
 }
 
 // distinctTables returns the non-empty table names in argument order with

--- a/internal/schema/otel_test.go
+++ b/internal/schema/otel_test.go
@@ -197,10 +197,9 @@ func TestDefaultOTelMetricsTablesFor(t *testing.T) {
 // `_total` (the OTel-CH counter convention) is explicitly NOT routed
 // here — counter routing stays on the existing TableFor heuristic.
 //
-// Mirrors the precedent in
-// internal/api/prom/exemplars.go::exemplarsTableFor, which already
-// adopts the same `_count`/`_sum` → histogram-table routing for the
-// exemplars endpoint.
+// [Metrics.ExemplarSources] reads the same companion pairing for the
+// exemplars endpoint, so `<X>_count` resolves to the bare-named
+// histogram row on both read paths.
 func TestHistogramCompanionColumn(t *testing.T) {
 	t.Parallel()
 	m := DefaultOTelMetrics()
@@ -332,5 +331,138 @@ func TestDefaultOTelMetricsRollups(t *testing.T) {
 	gaugeOnly := m.RollupsFor(m.GaugeTable)
 	if len(gaugeOnly) != 0 {
 		t.Errorf("RollupsFor(GaugeTable): expected 0 rollups (no gauge rollups in default schema), got %d", len(gaugeOnly))
+	}
+}
+
+// TestExemplarSources pins the candidate (table, row key) pairs the
+// `/api/v1/query_exemplars` fan-out reads. Three properties matter, and
+// each is a bug the single-table predecessor shipped:
+//
+//  1. An ambiguous name is read from EVERY layout that can hold it —
+//     the same candidate set [Metrics.TablesFor] resolves for samples,
+//     plus the two histogram-shaped tables the Sample contract excludes
+//     for want of a Value column (the exemplar projection reads the
+//     Exemplars Nested column instead, which every non-summary table
+//     carries identically).
+//  2. On a histogram-shaped table the row key is the BARE base name:
+//     the OTel-CH exporter writes no row under `<base>_count` /
+//     `<base>_sum` / `<base>_bucket`, so an arm filtering on the
+//     suffixed name there can never match.
+//  3. The summary table never appears: its upstream DDL has no
+//     Exemplars column, so reading it is a SQL error, not a thin result.
+func TestExemplarSources(t *testing.T) {
+	t.Parallel()
+	m := DefaultOTelMetrics()
+
+	cases := []struct {
+		name   string
+		metric string
+		want   []ExemplarSource
+	}{
+		{
+			name:   "count suffix fans across all three value layouts plus exp histogram",
+			metric: "http_server_request_duration_count",
+			want: []ExemplarSource{
+				{Table: m.HistogramTable, MetricName: "http_server_request_duration"},
+				{Table: m.SumTable, MetricName: "http_server_request_duration_count"},
+				{Table: m.GaugeTable, MetricName: "http_server_request_duration_count"},
+				{Table: m.ExpHistogramTable, MetricName: "http_server_request_duration"},
+			},
+		},
+		{
+			name:   "sum suffix fans the same way",
+			metric: "http_server_request_duration_sum",
+			want: []ExemplarSource{
+				{Table: m.HistogramTable, MetricName: "http_server_request_duration"},
+				{Table: m.SumTable, MetricName: "http_server_request_duration_sum"},
+				{Table: m.GaugeTable, MetricName: "http_server_request_duration_sum"},
+				{Table: m.ExpHistogramTable, MetricName: "http_server_request_duration"},
+			},
+		},
+		{
+			name:   "bucket suffix pins the classic histogram row",
+			metric: "http_server_request_duration_bucket",
+			want: []ExemplarSource{
+				{Table: m.HistogramTable, MetricName: "http_server_request_duration"},
+			},
+		},
+		{
+			name:   "exp histogram name pins the exp histogram table",
+			metric: "http_server_request_duration" + m.ExpHistogramSuffix,
+			want: []ExemplarSource{
+				{Table: m.ExpHistogramTable, MetricName: "http_server_request_duration" + m.ExpHistogramSuffix},
+			},
+		},
+		{
+			name:   "total suffix reads the sum table and both histogram layouts",
+			metric: "http_server_requests_total",
+			want: []ExemplarSource{
+				{Table: m.SumTable, MetricName: "http_server_requests_total"},
+				{Table: m.HistogramTable, MetricName: "http_server_requests_total"},
+				{Table: m.ExpHistogramTable, MetricName: "http_server_requests_total"},
+			},
+		},
+		{
+			name:   "unsuffixed name reads every exemplar-carrying table",
+			metric: "http_server_request_duration",
+			want: []ExemplarSource{
+				{Table: m.GaugeTable, MetricName: "http_server_request_duration"},
+				{Table: m.SumTable, MetricName: "http_server_request_duration"},
+				{Table: m.HistogramTable, MetricName: "http_server_request_duration"},
+				{Table: m.ExpHistogramTable, MetricName: "http_server_request_duration"},
+			},
+		},
+		{
+			name:   "unpinned name reads every table and rewrites nothing",
+			metric: "",
+			want: []ExemplarSource{
+				{Table: m.GaugeTable},
+				{Table: m.SumTable},
+				{Table: m.HistogramTable},
+				{Table: m.ExpHistogramTable},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := m.ExemplarSources(tc.metric)
+			if len(got) != len(tc.want) {
+				t.Fatalf("ExemplarSources(%q) = %+v; want %+v", tc.metric, got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("ExemplarSources(%q)[%d] = %+v; want %+v", tc.metric, i, got[i], tc.want[i])
+				}
+			}
+			for _, src := range got {
+				if src.Table == m.SummaryTable {
+					t.Errorf("ExemplarSources(%q) includes the summary table %q, which has no Exemplars column", tc.metric, m.SummaryTable)
+				}
+			}
+		})
+	}
+}
+
+// TestExemplarSources_SummaryOnlyDeploymentIsEmpty — when no
+// exemplar-carrying table is configured the candidate set is empty, which
+// is the handler's cue to answer `data:[]` without a ClickHouse round
+// trip. A non-empty set here would mean SQL against an unconfigured
+// (empty-named) table.
+func TestExemplarSources_SummaryOnlyDeploymentIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	m := DefaultOTelMetrics()
+	m.GaugeTable = ""
+	m.SumTable = ""
+	m.HistogramTable = ""
+	m.ExpHistogramTable = ""
+
+	for _, metric := range []string{"", "http_server_request_duration", "http_server_request_duration_count"} {
+		if got := m.ExemplarSources(metric); len(got) != 0 {
+			t.Errorf("ExemplarSources(%q) = %+v; want empty", metric, got)
+		}
 	}
 }

--- a/test/spec/promql/exemplars_companion_fanout.txtar
+++ b/test/spec/promql/exemplars_companion_fanout.txtar
@@ -1,0 +1,18 @@
+-- sql --
+(SELECT `MetricName`, `Attributes`, `ServiceName`, ts[i] AS `Timestamp`, val[i] AS `Value`, tid[i] AS `TraceID`, sid[i] AS `SpanID`, attrs_arr[i] AS `ExemplarAttributes` FROM (SELECT `MetricName`, `Attributes`, `ServiceName`, `Exemplars`.`TimeUnix` AS `ts`, `Exemplars`.`Value` AS `val`, `Exemplars`.`TraceId` AS `tid`, `Exemplars`.`SpanId` AS `sid`, `Exemplars`.`FilteredAttributes` AS `attrs_arr`, arrayJoin(arrayEnumerate(`Exemplars`.`TimeUnix`)) AS `i` FROM `otel_metrics_histogram` WHERE (`MetricName` = ?) AND `TimeUnix` >= toDateTime64(?, ?) AND `TimeUnix` <= toDateTime64(?, ?) AND length(`Exemplars`.`TimeUnix`) > 0)) UNION ALL (SELECT `MetricName`, `Attributes`, `ServiceName`, ts[i] AS `Timestamp`, val[i] AS `Value`, tid[i] AS `TraceID`, sid[i] AS `SpanID`, attrs_arr[i] AS `ExemplarAttributes` FROM (SELECT `MetricName`, `Attributes`, `ServiceName`, `Exemplars`.`TimeUnix` AS `ts`, `Exemplars`.`Value` AS `val`, `Exemplars`.`TraceId` AS `tid`, `Exemplars`.`SpanId` AS `sid`, `Exemplars`.`FilteredAttributes` AS `attrs_arr`, arrayJoin(arrayEnumerate(`Exemplars`.`TimeUnix`)) AS `i` FROM `otel_metrics_sum` WHERE (`MetricName` = ?) AND `TimeUnix` >= toDateTime64(?, ?) AND `TimeUnix` <= toDateTime64(?, ?) AND length(`Exemplars`.`TimeUnix`) > 0)) UNION ALL (SELECT `MetricName`, `Attributes`, `ServiceName`, ts[i] AS `Timestamp`, val[i] AS `Value`, tid[i] AS `TraceID`, sid[i] AS `SpanID`, attrs_arr[i] AS `ExemplarAttributes` FROM (SELECT `MetricName`, `Attributes`, `ServiceName`, `Exemplars`.`TimeUnix` AS `ts`, `Exemplars`.`Value` AS `val`, `Exemplars`.`TraceId` AS `tid`, `Exemplars`.`SpanId` AS `sid`, `Exemplars`.`FilteredAttributes` AS `attrs_arr`, arrayJoin(arrayEnumerate(`Exemplars`.`TimeUnix`)) AS `i` FROM `otel_metrics_gauge` WHERE (`MetricName` = ?) AND `TimeUnix` >= toDateTime64(?, ?) AND `TimeUnix` <= toDateTime64(?, ?) AND length(`Exemplars`.`TimeUnix`) > 0))
+-- args --
+[0] string = "http_request_duration_seconds"
+[1] string = "2026-01-01 00:00:00.000000000"
+[2] int64 = 9
+[3] string = "2026-01-01 01:00:00.000000000"
+[4] int64 = 9
+[5] string = "http_request_duration_seconds_count"
+[6] string = "2026-01-01 00:00:00.000000000"
+[7] int64 = 9
+[8] string = "2026-01-01 01:00:00.000000000"
+[9] int64 = 9
+[10] string = "http_request_duration_seconds_count"
+[11] string = "2026-01-01 00:00:00.000000000"
+[12] int64 = 9
+[13] string = "2026-01-01 01:00:00.000000000"
+[14] int64 = 9


### PR DESCRIPTION
## The single root cause

`internal/api/prom/exemplars.go` carried its **own** private metrics-table resolver — a fixed
if/else chain over Go string suffixes — instead of the schema's. That one duplication produced both
filed bugs:

- **#1435** — because resolution was keyed on a metric-name *string*, the handler answered
  `400 "metric name is required"` whenever no `__name__` **equality** matcher was present. So
  `{job="api"}` (no `__name__` at all) and `{__name__=~"http_.*"}` (regex, not equality) were both
  rejected. The in-code comment claimed this mirrored upstream; it did not — upstream Prometheus
  queries its exemplar store with whatever matchers are present. This was cerberus's single-table
  routing constraint leaking into the wire contract.
- **#1705** — `exemplarsTableFor` picked **exactly one** table. For the identical `_count` / `_sum`
  suffix case, `schema.Metrics.TablesFor` on the ordinary query path fans out across
  histogram / sum / gauge precisely because the name is genuinely ambiguous across three physical
  layouts. Exemplars answered from one arbitrary branch.

## The fix

Resolution now lives once, in the schema layer.

`schema.Metrics.ExemplarSources` reuses `TablesFor` / `TablesForUnknownName` and returns one source
per exemplar-carrying table, each paired with **the row key that table actually stores the series
under**. That pairing is what makes the fan-out real rather than decorative: on the histogram and
exp-histogram layouts the OTel-CH exporter writes `_count` / `_sum` / `_bucket` as *columns of a
single bare-named row*, so a histogram arm filtering on the suffixed name would match nothing. The
summary table has no `Exemplars` column at all and is dropped from every result.

`chsql.EmitQueryExemplarsUnion` joins the per-table arms with `UNION ALL` at the **top level** —
wrapping the arms in an enclosing `SELECT * FROM (…)` breaks the casts on the Map-typed projections.
A single arm emits byte-identical SQL to before, so the existing golden is untouched.

The handler rewrites the `__name__` matcher per arm through `promql.RewriteMetricName`, and an empty
source set short-circuits to an empty `200` without touching ClickHouse. With the name no longer
load-bearing for routing, the `400` branch, `exemplarsTableFor` and `hasExemplarSuffix` are gone,
along with the false comment.

## Tests — each fails before, passes after

Wire shape, `internal/api/prom/`:

- `TestQueryExemplars_UnpinnedMetricName` — no `__name__`, regex `__name__=~`, and negated
  `__name__!=` each answer `200` and reach ClickHouse against all four exemplar-carrying tables.
  Before: `400 {"errorType":"bad_data","error":"metric name is required"}`.
- `TestQueryExemplars_CompanionSuffixFansOutAcrossLayouts` — every table `TablesFor` returns for a
  `_count` name appears in the emitted SQL, with both the bare and the suffixed row key bound.
  Before: the scan missed `otel_metrics_sum` and `otel_metrics_gauge`.
- `TestQueryExemplars_NoExemplarCarryingTableShortCircuit` and
  `TestQueryExemplars_NeverReadsSummaryTable` replace the old summary short-circuit test, whose
  premise (one candidate table) the fan-out retires. The wire answer for a summary metric is
  unchanged: `data: []`.

Real-engine roundtrip, chdb-tagged: `TestQueryExemplars_ChDB_CompanionSuffixReadsHistogramRow` seeds
exemplars **only** on the bare-named `otel_metrics_histogram` row and queries
`http_request_duration_seconds_count{job="api"}`. Before: 0 series. This is also the proof that the
Map-typed columns survive the top-level `UNION ALL` on a real engine.

SQL shape, `test/spec/promql/exemplars_companion_fanout.txtar` — a generated TXTAR golden pinning
the three-arm union and, in `-- args --`, the bare key on the histogram arm against the suffixed key
on the sum and gauge arms.

Resolver units in `internal/schema/otel_test.go` (`TestExemplarSources`, seven cases) and emitter
units in `internal/chsql/query_exemplars_test.go` (single-arm byte stability, arm joining, empty-arm
and summary-arm rejection).

## Verification

Actions is queueing during the outage, so this was verified locally, narrowed to the affected
packages. `test/rejection-parity/catalogue.json` holds no entry for this site, so nothing there
needed re-deriving; the only golden regenerated was the new fixture above, via the narrowest shard
(`GOLDEN_UPDATE=1 go test -run TestEmitQueryExemplars_Fixtures ./internal/chsql/`, no chDB
involved). `node .github/scripts/forbid-sql-raw.mjs` is clean.

Closes #1435

Closes #1705
