### PR TITLE
fix(e2e): make the compose surface inventory canonical and its enumerated params exhaustive

### DIFF
--- a/test/e2e/playwright/crawl/grafana-surface-inventory.compose.json
+++ b/test/e2e/playwright/crawl/grafana-surface-inventory.compose.json
@@ -11,6 +11,30 @@
       "lean": true
     },
     {
+      "url": "/a/grafana-exploretraces-app/explore#adhoc[+ label = value]={rep}",
+      "lean": true
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore#radio[Single|Grid|Rows]=Rows",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore#radio[Single|Grid|Rows]=Single",
+      "lean": true
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore#tabs[Favorites|All|Resource|Span]=All",
+      "lean": true
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore#tabs[Favorites|All|Resource|Span]=Resource",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore#tabs[Favorites|All|Resource|Span]=Span",
+      "lean": false
+    },
+    {
       "url": "/a/grafana-exploretraces-app/explore?actionView=comparison&var-groupBy={var-groupBy}",
       "lean": false
     },
@@ -47,6 +71,14 @@
       "lean": false
     },
     {
+      "url": "/a/grafana-exploretraces-app/explore?actionView=traceList#attribute-list=service.name",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?actionView=traceList#tabs[Favorites|All|Resource|Span]=All",
+      "lean": false
+    },
+    {
       "url": "/a/grafana-exploretraces-app/explore?actionView=traceList&var-groupBy={var-groupBy}&var-metric=duration",
       "lean": false
     },
@@ -59,16 +91,16 @@
       "lean": false
     },
     {
-      "url": "/a/grafana-exploretraces-app/explore?actionView=traceList#attribute-list=service.name",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-exploretraces-app/explore?actionView=traceList#tabs[Favorites|All|Resource|Span]=All",
-      "lean": false
-    },
-    {
       "url": "/a/grafana-exploretraces-app/explore?var-groupBy={var-groupBy}",
       "lean": true
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?var-groupBy={var-groupBy}#radio[Single|Grid|Rows]=Single",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?var-groupBy={var-groupBy}#tabs[Favorites|All|Resource|Span]=All",
+      "lean": false
     },
     {
       "url": "/a/grafana-exploretraces-app/explore?var-groupBy={var-groupBy}&var-metric=duration",
@@ -83,20 +115,8 @@
       "lean": false
     },
     {
-      "url": "/a/grafana-exploretraces-app/explore?var-groupBy={var-groupBy}#radio[Single|Grid|Rows]=Single",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-exploretraces-app/explore?var-groupBy={var-groupBy}#tabs[Favorites|All|Resource|Span]=All",
-      "lean": false
-    },
-    {
       "url": "/a/grafana-exploretraces-app/explore?var-metric=duration",
       "lean": true
-    },
-    {
-      "url": "/a/grafana-exploretraces-app/explore?var-metric=duration&var-primarySignal=true",
-      "lean": false
     },
     {
       "url": "/a/grafana-exploretraces-app/explore?var-metric=duration#radio[Single|Grid|Rows]=Single",
@@ -111,12 +131,12 @@
       "lean": false
     },
     {
-      "url": "/a/grafana-exploretraces-app/explore?var-metric=errors",
-      "lean": true
+      "url": "/a/grafana-exploretraces-app/explore?var-metric=duration&var-primarySignal=true",
+      "lean": false
     },
     {
-      "url": "/a/grafana-exploretraces-app/explore?var-metric=errors&var-primarySignal=true",
-      "lean": false
+      "url": "/a/grafana-exploretraces-app/explore?var-metric=errors",
+      "lean": true
     },
     {
       "url": "/a/grafana-exploretraces-app/explore?var-metric=errors#radio[Single|Grid|Rows]=Single",
@@ -124,6 +144,10 @@
     },
     {
       "url": "/a/grafana-exploretraces-app/explore?var-metric=errors#tabs[Favorites|All|Resource|Span]=All",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-exploretraces-app/explore?var-metric=errors&var-primarySignal=true",
       "lean": false
     },
     {
@@ -139,31 +163,11 @@
       "lean": false
     },
     {
-      "url": "/a/grafana-exploretraces-app/explore#adhoc[+ label = value]={rep}",
-      "lean": true
-    },
-    {
-      "url": "/a/grafana-exploretraces-app/explore#radio[Single|Grid|Rows]=Rows",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-exploretraces-app/explore#radio[Single|Grid|Rows]=Single",
-      "lean": true
-    },
-    {
-      "url": "/a/grafana-exploretraces-app/explore#tabs[Favorites|All|Resource|Span]=All",
-      "lean": true
-    },
-    {
-      "url": "/a/grafana-exploretraces-app/explore#tabs[Favorites|All|Resource|Span]=Resource",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-exploretraces-app/explore#tabs[Favorites|All|Resource|Span]=Span",
-      "lean": false
-    },
-    {
       "url": "/a/grafana-lokiexplore-app/explore",
+      "lean": true
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore#adhoc[Filter by labels]={rep}",
       "lean": true
     },
     {
@@ -187,10 +191,6 @@
       "lean": false
     },
     {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/{field}?visualizationType=\"json\"#select[downshift-{rid}-input]=Exclude",
-      "lean": false
-    },
-    {
       "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/{field}?visualizationType=\"json\"#select[Filter by fields]=thread",
       "lean": false
     },
@@ -204,6 +204,10 @@
     },
     {
       "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/{field}?visualizationType=\"json\"#select[SortBy function]=Most relevantSmart ordering of graphs based on the most significant spikes in the data",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/{field}?visualizationType=\"json\"#select[downshift-{rid}-input]=Exclude",
       "lean": false
     },
     {
@@ -223,10 +227,6 @@
       "lean": false
     },
     {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/{field}?visualizationType=\"table\"#select[downshift-{rid}-input]=Exclude",
-      "lean": false
-    },
-    {
       "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/{field}?visualizationType=\"table\"#select[Filter by fields]=thread",
       "lean": false
     },
@@ -243,55 +243,11 @@
       "lean": false
     },
     {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/field/{field}?visualizationType=\"table\"#select[downshift-{rid}-input]=Exclude",
+      "lean": false
+    },
+    {
       "url": "/a/grafana-lokiexplore-app/explore/service/{service}/fields",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/fields?visualizationType=\"json\"",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/fields?visualizationType=\"json\"#adhoc[Filter by labels]={rep}",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/fields?visualizationType=\"json\"#radio[Grid|Rows]=Rows",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/fields?visualizationType=\"json\"#radio[Volume|Names]=Names",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/fields?visualizationType=\"json\"#select[downshift-{rid}-input]=Exclude",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/fields?visualizationType=\"json\"#select[Filter by fields]=thread",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/fields?visualizationType=\"table\"",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/fields?visualizationType=\"table\"#adhoc[Filter by labels]={rep}",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/fields?visualizationType=\"table\"#radio[Grid|Rows]=Rows",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/fields?visualizationType=\"table\"#radio[Volume|Names]=Names",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/fields?visualizationType=\"table\"#select[downshift-{rid}-input]=Exclude",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/fields?visualizationType=\"table\"#select[Filter by fields]=thread",
       "lean": false
     },
     {
@@ -304,10 +260,6 @@
     },
     {
       "url": "/a/grafana-lokiexplore-app/explore/service/{service}/fields#radio[Volume|Names]=Names",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/fields#select[downshift-{rid}-input]=Exclude",
       "lean": false
     },
     {
@@ -339,6 +291,58 @@
       "lean": false
     },
     {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/fields#select[downshift-{rid}-input]=Exclude",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/fields?visualizationType=\"json\"",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/fields?visualizationType=\"json\"#adhoc[Filter by labels]={rep}",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/fields?visualizationType=\"json\"#radio[Grid|Rows]=Rows",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/fields?visualizationType=\"json\"#radio[Volume|Names]=Names",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/fields?visualizationType=\"json\"#select[Filter by fields]=thread",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/fields?visualizationType=\"json\"#select[downshift-{rid}-input]=Exclude",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/fields?visualizationType=\"table\"",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/fields?visualizationType=\"table\"#adhoc[Filter by labels]={rep}",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/fields?visualizationType=\"table\"#radio[Grid|Rows]=Rows",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/fields?visualizationType=\"table\"#radio[Volume|Names]=Names",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/fields?visualizationType=\"table\"#select[Filter by fields]=thread",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/fields?visualizationType=\"table\"#select[downshift-{rid}-input]=Exclude",
+      "lean": false
+    },
+    {
       "url": "/a/grafana-lokiexplore-app/explore/service/{service}/label/{label}",
       "lean": false
     },
@@ -355,10 +359,6 @@
       "lean": false
     },
     {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/label/{label}?visualizationType=\"json\"#select[downshift-{rid}-input]=Exclude",
-      "lean": false
-    },
-    {
       "url": "/a/grafana-lokiexplore-app/explore/service/{service}/label/{label}?visualizationType=\"json\"#select[Filter by fields]=thread",
       "lean": false
     },
@@ -368,6 +368,10 @@
     },
     {
       "url": "/a/grafana-lokiexplore-app/explore/service/{service}/label/{label}?visualizationType=\"json\"#select[SortBy function]=Most relevantSmart ordering of graphs based on the most significant spikes in the data",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/label/{label}?visualizationType=\"json\"#select[downshift-{rid}-input]=Exclude",
       "lean": false
     },
     {
@@ -383,10 +387,6 @@
       "lean": false
     },
     {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/label/{label}?visualizationType=\"table\"#select[downshift-{rid}-input]=Exclude",
-      "lean": false
-    },
-    {
       "url": "/a/grafana-lokiexplore-app/explore/service/{service}/label/{label}?visualizationType=\"table\"#select[Filter by fields]=thread",
       "lean": false
     },
@@ -399,47 +399,11 @@
       "lean": false
     },
     {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/label/{label}?visualizationType=\"table\"#select[downshift-{rid}-input]=Exclude",
+      "lean": false
+    },
+    {
       "url": "/a/grafana-lokiexplore-app/explore/service/{service}/labels",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/labels?visualizationType=\"json\"",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/labels?visualizationType=\"json\"#adhoc[Filter by labels]={rep}",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/labels?visualizationType=\"json\"#radio[Grid|Rows]=Grid",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/labels?visualizationType=\"json\"#select[downshift-{rid}-input]=Exclude",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/labels?visualizationType=\"json\"#select[Filter by fields]=thread",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/labels?visualizationType=\"table\"",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/labels?visualizationType=\"table\"#adhoc[Filter by labels]={rep}",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/labels?visualizationType=\"table\"#radio[Grid|Rows]=Grid",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/labels?visualizationType=\"table\"#select[downshift-{rid}-input]=Exclude",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/labels?visualizationType=\"table\"#select[Filter by fields]=thread",
       "lean": false
     },
     {
@@ -448,10 +412,6 @@
     },
     {
       "url": "/a/grafana-lokiexplore-app/explore/service/{service}/labels#radio[Grid|Rows]=Rows",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/labels#select[downshift-{rid}-input]=Exclude",
       "lean": false
     },
     {
@@ -483,6 +443,50 @@
       "lean": false
     },
     {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/labels#select[downshift-{rid}-input]=Exclude",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/labels?visualizationType=\"json\"",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/labels?visualizationType=\"json\"#adhoc[Filter by labels]={rep}",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/labels?visualizationType=\"json\"#radio[Grid|Rows]=Grid",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/labels?visualizationType=\"json\"#select[Filter by fields]=thread",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/labels?visualizationType=\"json\"#select[downshift-{rid}-input]=Exclude",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/labels?visualizationType=\"table\"",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/labels?visualizationType=\"table\"#adhoc[Filter by labels]={rep}",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/labels?visualizationType=\"table\"#radio[Grid|Rows]=Grid",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/labels?visualizationType=\"table\"#select[Filter by fields]=thread",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/labels?visualizationType=\"table\"#select[downshift-{rid}-input]=Exclude",
+      "lean": false
+    },
+    {
       "url": "/a/grafana-lokiexplore-app/explore/service/{service}/logs",
       "lean": false
     },
@@ -499,11 +503,11 @@
       "lean": false
     },
     {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/logs?visualizationType=\"json\"#select[downshift-{rid}-input]=Exclude",
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/logs?visualizationType=\"json\"#select[Filter by fields]=thread",
       "lean": false
     },
     {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/logs?visualizationType=\"json\"#select[Filter by fields]=thread",
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/logs?visualizationType=\"json\"#select[downshift-{rid}-input]=Exclude",
       "lean": false
     },
     {
@@ -523,11 +527,11 @@
       "lean": false
     },
     {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/logs?visualizationType=\"table\"#select[downshift-{rid}-input]=Exclude",
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/logs?visualizationType=\"table\"#select[Filter by fields]=thread",
       "lean": false
     },
     {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/logs?visualizationType=\"table\"#select[Filter by fields]=thread",
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/logs?visualizationType=\"table\"#select[downshift-{rid}-input]=Exclude",
       "lean": false
     },
     {
@@ -535,43 +539,7 @@
       "lean": false
     },
     {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/patterns?visualizationType=\"json\"",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/patterns?visualizationType=\"json\"#adhoc[Filter by labels]={rep}",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/patterns?visualizationType=\"json\"#select[downshift-{rid}-input]=Exclude",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/patterns?visualizationType=\"json\"#select[Filter by fields]=thread",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/patterns?visualizationType=\"table\"",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/patterns?visualizationType=\"table\"#adhoc[Filter by labels]={rep}",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/patterns?visualizationType=\"table\"#select[downshift-{rid}-input]=Exclude",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/patterns?visualizationType=\"table\"#select[Filter by fields]=thread",
-      "lean": false
-    },
-    {
       "url": "/a/grafana-lokiexplore-app/explore/service/{service}/patterns#adhoc[Filter by labels]={rep}",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/patterns#select[downshift-{rid}-input]=Exclude",
       "lean": false
     },
     {
@@ -603,32 +571,44 @@
       "lean": false
     },
     {
-      "url": "/a/grafana-lokiexplore-app/explore#adhoc[Filter by labels]={rep}",
-      "lean": true
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/patterns#select[downshift-{rid}-input]=Exclude",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/patterns?visualizationType=\"json\"",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/patterns?visualizationType=\"json\"#adhoc[Filter by labels]={rep}",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/patterns?visualizationType=\"json\"#select[Filter by fields]=thread",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/patterns?visualizationType=\"json\"#select[downshift-{rid}-input]=Exclude",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/patterns?visualizationType=\"table\"",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/patterns?visualizationType=\"table\"#adhoc[Filter by labels]={rep}",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/patterns?visualizationType=\"table\"#select[Filter by fields]=thread",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-lokiexplore-app/explore/service/{service}/patterns?visualizationType=\"table\"#select[downshift-{rid}-input]=Exclude",
+      "lean": false
     },
     {
       "url": "/a/grafana-metricsdrilldown-app/drilldown",
       "lean": true
-    },
-    {
-      "url": "/a/grafana-metricsdrilldown-app/drilldown?actionView=related&metric={metric}",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-metricsdrilldown-app/drilldown?metric={metric}",
-      "lean": true
-    },
-    {
-      "url": "/a/grafana-metricsdrilldown-app/drilldown?metric={metric}&var-groupby=cerberus_ql",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-metricsdrilldown-app/drilldown?metric={metric}#adhoc[+ label = value]={rep}",
-      "lean": false
-    },
-    {
-      "url": "/a/grafana-metricsdrilldown-app/drilldown?metric={metric}#radio[Grid|Rows]=Rows",
-      "lean": false
     },
     {
       "url": "/a/grafana-metricsdrilldown-app/drilldown#adhoc[+ label = value]={rep}",
@@ -652,6 +632,26 @@
     },
     {
       "url": "/a/grafana-metricsdrilldown-app/drilldown#select[datasource-picker]#1=Dashboard Usage",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-metricsdrilldown-app/drilldown?actionView=related&metric={metric}",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-metricsdrilldown-app/drilldown?metric={metric}",
+      "lean": true
+    },
+    {
+      "url": "/a/grafana-metricsdrilldown-app/drilldown?metric={metric}#adhoc[+ label = value]={rep}",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-metricsdrilldown-app/drilldown?metric={metric}#radio[Grid|Rows]=Rows",
+      "lean": false
+    },
+    {
+      "url": "/a/grafana-metricsdrilldown-app/drilldown?metric={metric}&var-groupby=cerberus_ql",
       "lean": false
     },
     {
@@ -695,35 +695,63 @@
       "lean": true
     },
     {
+      "url": "/dashboards#radio[folders|list]=folders",
+      "lean": false
+    },
+    {
+      "url": "/dashboards#select[Sort]=Alphabetically (A–Z)",
+      "lean": false
+    },
+    {
+      "url": "/dashboards#select[Sort]=Alphabetically (Z–A)",
+      "lean": false
+    },
+    {
+      "url": "/dashboards#select[Tag filter]=cerberus (7)",
+      "lean": false
+    },
+    {
+      "url": "/dashboards#select[Tag filter]=clickhouse (1)",
+      "lean": false
+    },
+    {
+      "url": "/dashboards#select[Tag filter]=dogfood (1)",
+      "lean": false
+    },
+    {
+      "url": "/dashboards#select[Tag filter]=host (1)",
+      "lean": false
+    },
+    {
+      "url": "/dashboards#select[Tag filter]=infra (3)",
+      "lean": false
+    },
+    {
+      "url": "/dashboards#select[Tag filter]=logql (1)",
+      "lean": false
+    },
+    {
+      "url": "/dashboards#select[Tag filter]=otelcol (1)",
+      "lean": false
+    },
+    {
+      "url": "/dashboards#select[Tag filter]=promql (1)",
+      "lean": false
+    },
+    {
+      "url": "/dashboards#select[Tag filter]=self-observability (1)",
+      "lean": false
+    },
+    {
+      "url": "/dashboards#select[Tag filter]=showcase (3)",
+      "lean": false
+    },
+    {
+      "url": "/dashboards#select[Tag filter]=traceql (1)",
+      "lean": false
+    },
+    {
       "url": "/dashboards/f/{folder}",
-      "lean": false
-    },
-    {
-      "url": "/dashboards/f/{folder}/alerting",
-      "lean": false
-    },
-    {
-      "url": "/dashboards/f/{folder}/alerting#select[Sort]=Alphabetically [A-Z]",
-      "lean": false
-    },
-    {
-      "url": "/dashboards/f/{folder}/alerting#select[Sort]=Alphabetically [Z-A]",
-      "lean": false
-    },
-    {
-      "url": "/dashboards/f/{folder}/library-panels",
-      "lean": false
-    },
-    {
-      "url": "/dashboards/f/{folder}/library-panels#select[Panel type filter]={rep}",
-      "lean": false
-    },
-    {
-      "url": "/dashboards/f/{folder}/library-panels#select[Sort]=Alphabetically (A–Z)",
-      "lean": false
-    },
-    {
-      "url": "/dashboards/f/{folder}/library-panels#select[Sort]=Alphabetically (Z–A)",
       "lean": false
     },
     {
@@ -783,59 +811,31 @@
       "lean": false
     },
     {
-      "url": "/dashboards#radio[folders|list]=folders",
+      "url": "/dashboards/f/{folder}/alerting",
       "lean": false
     },
     {
-      "url": "/dashboards#select[Sort]=Alphabetically (A–Z)",
+      "url": "/dashboards/f/{folder}/alerting#select[Sort]=Alphabetically [A-Z]",
       "lean": false
     },
     {
-      "url": "/dashboards#select[Sort]=Alphabetically (Z–A)",
+      "url": "/dashboards/f/{folder}/alerting#select[Sort]=Alphabetically [Z-A]",
       "lean": false
     },
     {
-      "url": "/dashboards#select[Tag filter]=cerberus (7)",
+      "url": "/dashboards/f/{folder}/library-panels",
       "lean": false
     },
     {
-      "url": "/dashboards#select[Tag filter]=clickhouse (1)",
+      "url": "/dashboards/f/{folder}/library-panels#select[Panel type filter]={rep}",
       "lean": false
     },
     {
-      "url": "/dashboards#select[Tag filter]=dogfood (1)",
+      "url": "/dashboards/f/{folder}/library-panels#select[Sort]=Alphabetically (A–Z)",
       "lean": false
     },
     {
-      "url": "/dashboards#select[Tag filter]=host (1)",
-      "lean": false
-    },
-    {
-      "url": "/dashboards#select[Tag filter]=infra (3)",
-      "lean": false
-    },
-    {
-      "url": "/dashboards#select[Tag filter]=logql (1)",
-      "lean": false
-    },
-    {
-      "url": "/dashboards#select[Tag filter]=otelcol (1)",
-      "lean": false
-    },
-    {
-      "url": "/dashboards#select[Tag filter]=promql (1)",
-      "lean": false
-    },
-    {
-      "url": "/dashboards#select[Tag filter]=self-observability (1)",
-      "lean": false
-    },
-    {
-      "url": "/dashboards#select[Tag filter]=showcase (3)",
-      "lean": false
-    },
-    {
-      "url": "/dashboards#select[Tag filter]=traceql (1)",
+      "url": "/dashboards/f/{folder}/library-panels#select[Sort]=Alphabetically (Z–A)",
       "lean": false
     },
     {


### PR DESCRIPTION
## What is red

`compose-smoke-shard-info (shard-crawl, …)` fails on `main` and therefore on every open
PR. Three test failures, two root causes, both reproducible with no Docker:

```
CRAWL_STACK=compose npx playwright test crawl/crawl.spec.ts -g "canonicalization pins"
```

### A — the committed compose inventory is not in canonical marshalled form

`crawl.spec.ts:371` and `:835` both assert
`readFileSync(inventoryPath(cfg)) === marshalInventory(loadInventory(cfg))`.
`marshalInventory` sorts by `byCodepoint`; the committed file was still in the
`localeCompare` order that `byCodepoint` replaced, so every `#`-fragment surface sat
after its `?`-query sibling instead of before it (`0x23 < 0x3F`). 172 lines move.

Regenerated through the inventory's own `marshalInventory`, not by hand. The surface
SET is untouched: 216 surfaces before and after, identical `url`/`lean` pairs,
identical `doc` and `stack`. Both pins go 16/16 green locally.

### B — `var-primarySignal` values are reached by luck, not by rule

`crawl.spec.ts:1206` reports

```
NEW surface "/a/grafana-exploretraces-app/explore?var-primarySignal=kind=server"
visited but not pinned — coverage grew
```

`var-primarySignal` is registered `mode: 'enumerate'` (`crawl/lib.ts:171-176`) with the
app's five static Primary signal options. The committed inventory pins exactly one of
them (`=true`), plus the dropped boot default. Driving the radio rewrites the scene
variable into the URL, so each option the sweep happens to reach within
`PAIRWISE_SWEEP_CAP` becomes its own canonical surface — which options those are is a
function of the BFS budget, not of the app. An `enumerate`d param is only pinnable if
every one of its options is driven on every run.

## Scope

Root cause A is fixed here. Root cause B is fixed on this branch in the following
commits.
