### PR TITLE
fix(promql,metadata): fan out unpinned selectors to histograms, fail fast on absent metric tables

### DIFF
--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -37,6 +37,7 @@ import (
 	"github.com/tsouza/cerberus/internal/preflight"
 	"github.com/tsouza/cerberus/internal/promql"
 	"github.com/tsouza/cerberus/internal/routememo"
+	"github.com/tsouza/cerberus/internal/schema"
 	"github.com/tsouza/cerberus/internal/schema/ddl"
 	"github.com/tsouza/cerberus/internal/schemaboot"
 	"github.com/tsouza/cerberus/internal/solver"
@@ -1400,59 +1401,17 @@ func runRequirementsCheck(
 	for _, w := range res.Warnings {
 		logger.Warn(w)
 	}
-	if res.Fatal != nil {
-		// Wrong-shape / too-old / unreadable — never self-heals. Exit even if
-		// some tables are also absent: a too-old server won't fix itself by
-		// waiting, and a wrong-shape table is a genuine misconfiguration.
-		return nil, res.Fatal
-	}
 
-	if res.Unreachable {
-		// Transient: ClickHouse is not accepting connections yet (cerberus
-		// booted ahead of the database). A dial / connection-refused error is
-		// NOT a misconfiguration and self-heals once the server appears, so
-		// boot but stay NOT READY; the same background re-probe that waits on
-		// an absent schema also waits out an unreachable server. No restart.
-		reason := res.UnreachableReason()
-		logger.Warn(
-			"clickhouse not reachable at startup; serving unready until it appears (/readyz gates traffic)",
-			"reason", reason,
-		)
-		present := newSchemaPresentSignal(reason)
-		go reprobeSchema(ctx, logger, client, req, present, schemaRetryInterval)
-		return present.Func(), nil
+	outcome := decideRequirementsOutcome(res, cfg.Schema, cfg.ClickHouse.Database)
+	if outcome.fatalErr != nil {
+		return nil, outcome.fatalErr
 	}
-
-	if res.DatabaseAbsent {
-		// Transient: ClickHouse is up but the configured database does not exist
-		// yet (UNKNOWN_DATABASE / code 81). The connection carries the database
-		// as its session default, so even SELECT version() fails until the
-		// database is created — by the collector that owns schema creation, or by
-		// the auto-create hook once it can reach the server. This is the same
-		// class of cold-cluster race as an absent schema, NOT a misconfiguration,
-		// so boot but stay NOT READY; the background re-probe flips readiness once
-		// the database (and its tables) appear. No restart.
-		reason := res.DatabaseAbsentReason(cfg.ClickHouse.Database)
-		logger.Warn(
-			"clickhouse database not yet provisioned; serving unready until it is created (/readyz gates traffic)",
-			"reason", reason,
-		)
-		present := newSchemaPresentSignal(reason)
-		go reprobeSchema(ctx, logger, client, req, present, schemaRetryInterval)
-		return present.Func(), nil
-	}
-
-	if !res.SchemaProvisioned() {
-		// Transient: the schema has not been provisioned yet (cerberus booted
-		// ahead of the collector that owns schema creation). Boot but stay
-		// NOT READY; a background re-probe flips readiness once the writer
-		// creates the schema. No restart.
-		reason := res.AbsentReason()
-		logger.Warn(
-			"schema not yet provisioned; serving unready until an external writer creates it (/readyz gates traffic)",
-			"reason", reason,
-		)
-		present := newSchemaPresentSignal(reason)
+	if outcome.notReadyReason != "" {
+		// Transient: boot but stay NOT READY; the background re-probe (reusing
+		// the auto-create retry cadence) flips readiness once the condition
+		// decideRequirementsOutcome named clears. No restart.
+		logger.Warn(outcome.logMsg, "reason", outcome.notReadyReason)
+		present := newSchemaPresentSignal(outcome.notReadyReason)
 		go reprobeSchema(ctx, logger, client, req, present, schemaRetryInterval)
 		return present.Func(), nil
 	}
@@ -1463,6 +1422,133 @@ func runRequirementsCheck(
 		"native_rate", cfg.ExperimentalTSGridRange,
 	)
 	return nil, nil
+}
+
+// requirementsOutcome is the boot decision decideRequirementsOutcome derives
+// from a preflight.Result. Exactly one of fatalErr (exit non-zero) or
+// notReadyReason (boot proceeds NOT READY until a background re-probe
+// clears it, logged via logMsg) is set; both empty means the check passed
+// outright.
+type requirementsOutcome struct {
+	fatalErr       error
+	notReadyReason string
+	logMsg         string
+}
+
+// decideRequirementsOutcome turns a preflight.Result into the boot
+// decision. It performs no I/O of its own — every branch is a pure
+// function of res, m, and database — which is what makes the ordering
+// unit-testable without a real ClickHouse (see main_test.go).
+//
+// Order is load-bearing: res.Fatal, then res.Unreachable, then
+// res.DatabaseAbsent each short-circuit BEFORE fatalAbsentMetricTablesErr
+// runs, so a genuinely unreachable server or a not-yet-created database
+// never gets misclassified as a fatal missing-table config error — see
+// fatalAbsentMetricTablesErr's own doc for why that reachable-vs-absent
+// boundary matters (#1905). The remaining (non-metrics) AbsentTables stay
+// on preflight's original transient path.
+func decideRequirementsOutcome(res preflight.Result, m schema.Metrics, database string) requirementsOutcome {
+	if res.Fatal != nil {
+		// Wrong-shape / too-old / unreadable — never self-heals. Exit even if
+		// some tables are also absent: a too-old server won't fix itself by
+		// waiting, and a wrong-shape table is a genuine misconfiguration.
+		return requirementsOutcome{fatalErr: res.Fatal}
+	}
+	if res.Unreachable {
+		// Transient: ClickHouse is not accepting connections yet (cerberus
+		// booted ahead of the database). A dial / connection-refused error is
+		// NOT a misconfiguration and self-heals once the server appears.
+		return requirementsOutcome{
+			notReadyReason: res.UnreachableReason(),
+			logMsg:         "clickhouse not reachable at startup; serving unready until it appears (/readyz gates traffic)",
+		}
+	}
+	if res.DatabaseAbsent {
+		// Transient: ClickHouse is up but the configured database does not exist
+		// yet (UNKNOWN_DATABASE / code 81). The connection carries the database
+		// as its session default, so even SELECT version() fails until the
+		// database is created — by the collector that owns schema creation, or by
+		// the auto-create hook once it can reach the server. This is the same
+		// class of cold-cluster race as an absent schema, NOT a misconfiguration.
+		return requirementsOutcome{
+			notReadyReason: res.DatabaseAbsentReason(database),
+			logMsg:         "clickhouse database not yet provisioned; serving unready until it is created (/readyz gates traffic)",
+		}
+	}
+	if err := fatalAbsentMetricTablesErr(m, res.AbsentTables); err != nil {
+		// Fatal, unlike the general AbsentTables tolerance below (#1905): a
+		// misconfigured metric table name never self-heals the way an
+		// unprovisioned schema does, and a silently degraded metadata
+		// surface (empty /api/v1/series responses, never an error) is harder
+		// for an operator to notice than a boot failure that names the table
+		// and the config key.
+		return requirementsOutcome{fatalErr: err}
+	}
+	if !res.SchemaProvisioned() {
+		// Transient: the schema has not been provisioned yet (cerberus booted
+		// ahead of the collector that owns schema creation).
+		return requirementsOutcome{
+			notReadyReason: res.AbsentReason(),
+			logMsg:         "schema not yet provisioned; serving unready until an external writer creates it (/readyz gates traffic)",
+		}
+	}
+	return requirementsOutcome{}
+}
+
+// metricTableBinding pairs a resolved metric-table name with the
+// schema.metrics.* config key that set it (see internal/config/nested.go's
+// schema.metrics.* bindings, the source of truth these key strings mirror).
+type metricTableBinding struct {
+	table     string
+	configKey string
+}
+
+// metricTableBindings lists the metric tables the /api/v1/series,
+// /api/v1/labels, and /api/v1/label/<name>/values handlers union across
+// (schema.Metrics.ConfiguredMetricTables' Gauge/Sum/Histogram set) paired
+// with the config key each came from, for fatalAbsentMetricTablesErr's
+// error text.
+func metricTableBindings(m schema.Metrics) []metricTableBinding {
+	return []metricTableBinding{
+		{table: m.GaugeTable, configKey: "schema.metrics.gaugeTable"},
+		{table: m.SumTable, configKey: "schema.metrics.sumTable"},
+		{table: m.HistogramTable, configKey: "schema.metrics.histogramTable"},
+	}
+}
+
+// fatalAbsentMetricTablesErr turns preflight's already-computed
+// reachable-but-absent table list into a boot-fatal error scoped to the
+// metrics surface (#1905): a cerberus.yaml table name that will never
+// exist — a typo, or a table the operator forgot to provision — must not
+// silently degrade every /api/v1/series, /api/v1/labels, and
+// /api/v1/label/<name>/values request into a ClickHouse UNKNOWN_TABLE
+// error. This is deliberately STRICTER than preflight's own general
+// schema-shape gate, which treats an entirely-absent table as the
+// transient cerberus-boots-before-the-collector race and waits rather than
+// exiting (see internal/preflight's package doc, "Fatal vs transient: the
+// absent-schema race"); the boundary is unchanged, though — the two
+// callers below that already returned before this point cover "ClickHouse
+// unreachable" (res.Unreachable) and "database not yet provisioned"
+// (res.DatabaseAbsent), so neither reaches here, and an unconfigured
+// (empty-string) table name never appears in absentTables in the first
+// place, since preflight's checkSchema skips empty table names before
+// ever probing them. What is left, by construction, is exactly "the
+// server answered and this specific configured table is not there".
+func fatalAbsentMetricTablesErr(m schema.Metrics, absentTables []string) error {
+	absent := make(map[string]bool, len(absentTables))
+	for _, t := range absentTables {
+		absent[t] = true
+	}
+	var problems []string
+	for _, b := range metricTableBindings(m) {
+		if b.table != "" && absent[b.table] {
+			problems = append(problems, fmt.Sprintf("table %q (set via %s) does not exist", b.table, b.configKey))
+		}
+	}
+	if len(problems) == 0 {
+		return nil
+	}
+	return fmt.Errorf("metric table existence check failed: %s", strings.Join(problems, "; "))
 }
 
 // schemaPresentSignal is the concurrency-safe carrier behind the

--- a/cmd/cerberus/main_test.go
+++ b/cmd/cerberus/main_test.go
@@ -1,6 +1,12 @@
 package main
 
-import "testing"
+import (
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/preflight"
+	"github.com/tsouza/cerberus/internal/schema"
+)
 
 // TestIsVersionFlag pins the argv shapes recognized by the
 // `--version` pre-flight. The cerberus container in
@@ -35,3 +41,184 @@ func TestIsVersionFlag(t *testing.T) {
 		})
 	}
 }
+
+// TestFatalAbsentMetricTablesErr pins #1905's core boundary in isolation
+// from any ClickHouse connection: given the reachable-and-absent table
+// names preflight.Run has already computed, exactly the configured
+// Gauge/Sum/Histogram tables that appear there turn into a fatal error
+// naming both the table and the schema.metrics.* config key that set it;
+// everything else (a present table, or an unconfigured/empty-string one)
+// leaves boot alone.
+func TestFatalAbsentMetricTablesErr(t *testing.T) {
+	t.Parallel()
+	m := schema.DefaultOTelMetrics()
+
+	t.Run("table present: no fatal error", func(t *testing.T) {
+		t.Parallel()
+		// Empty absentTables is exactly what preflight reports once every
+		// configured table round-trips a non-zero system.columns row count.
+		if err := fatalAbsentMetricTablesErr(m, nil); err != nil {
+			t.Fatalf("fatalAbsentMetricTablesErr(present) = %v, want nil", err)
+		}
+	})
+
+	t.Run("table absent: fatal error names table and config key", func(t *testing.T) {
+		t.Parallel()
+		err := fatalAbsentMetricTablesErr(m, []string{m.HistogramTable})
+		if err == nil {
+			t.Fatal("fatalAbsentMetricTablesErr(absent) = nil, want an error")
+		}
+		if !strings.Contains(err.Error(), m.HistogramTable) {
+			t.Errorf("error %q does not name the missing table %q", err.Error(), m.HistogramTable)
+		}
+		if !strings.Contains(err.Error(), "schema.metrics.histogramTable") {
+			t.Errorf("error %q does not name the config key schema.metrics.histogramTable", err.Error())
+		}
+	})
+
+	t.Run("empty configured name: absence of an unrelated table is not fatal", func(t *testing.T) {
+		t.Parallel()
+		empty := m
+		empty.HistogramTable = ""
+		// A table name preflight would never even probe (checkSchema skips
+		// empty names) cannot appear in absentTables for the empty field, so
+		// this reports some OTHER absent table to prove the empty binding
+		// specifically never matches.
+		err := fatalAbsentMetricTablesErr(empty, []string{"some_unrelated_table"})
+		if err != nil {
+			t.Fatalf("fatalAbsentMetricTablesErr(empty HistogramTable) = %v, want nil", err)
+		}
+	})
+
+	t.Run("multiple absent tables all named", func(t *testing.T) {
+		t.Parallel()
+		err := fatalAbsentMetricTablesErr(m, []string{m.GaugeTable, m.SumTable})
+		if err == nil {
+			t.Fatal("fatalAbsentMetricTablesErr(multiple absent) = nil, want an error")
+		}
+		for _, want := range []string{m.GaugeTable, m.SumTable, "schema.metrics.gaugeTable", "schema.metrics.sumTable"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("error %q does not contain %q", err.Error(), want)
+			}
+		}
+	})
+}
+
+// TestDecideRequirementsOutcome exercises the four #1905 boot cells against
+// decideRequirementsOutcome directly, with no ClickHouse connection: it
+// constructs the preflight.Result values a real probe would have produced
+// in each scenario and asserts the resulting boot decision. The
+// unreachable cell is the one most likely to regress silently — a naive
+// implementation that fails fast on "any absent table" without checking
+// res.Unreachable first would turn a ClickHouse that simply has not
+// started yet into a boot crash, exactly the crash-loop #1905's fix must
+// not reintroduce.
+func TestDecideRequirementsOutcome(t *testing.T) {
+	t.Parallel()
+	m := schema.DefaultOTelMetrics()
+	const database = "otel"
+
+	t.Run("table present: proceeds ready", func(t *testing.T) {
+		t.Parallel()
+		res := preflight.Result{}
+		got := decideRequirementsOutcome(res, m, database)
+		if got.fatalErr != nil || got.notReadyReason != "" {
+			t.Fatalf("decideRequirementsOutcome(present) = %+v, want a clean pass", got)
+		}
+	})
+
+	t.Run("table absent, server reachable: fails fast naming table and config key", func(t *testing.T) {
+		t.Parallel()
+		res := preflight.Result{AbsentTables: []string{m.HistogramTable}}
+		got := decideRequirementsOutcome(res, m, database)
+		if got.fatalErr == nil {
+			t.Fatal("decideRequirementsOutcome(absent, reachable) fatalErr = nil, want an error")
+		}
+		if got.notReadyReason != "" {
+			t.Errorf("decideRequirementsOutcome(absent, reachable) notReadyReason = %q, want empty (must not ALSO report transient)", got.notReadyReason)
+		}
+		if !strings.Contains(got.fatalErr.Error(), m.HistogramTable) {
+			t.Errorf("fatalErr %q does not name the missing table", got.fatalErr.Error())
+		}
+	})
+
+	t.Run("clickhouse unreachable: proceeds, does not fail boot even with absent tables", func(t *testing.T) {
+		t.Parallel()
+		// A real preflight.Run never populates AbsentTables alongside
+		// Unreachable (checkSchema abandons introspection on the first
+		// transport error), but this test sets both anyway: the ordering
+		// inside decideRequirementsOutcome — Unreachable checked BEFORE
+		// fatalAbsentMetricTablesErr — must be the thing that keeps boot
+		// alive, not an accident of what preflight happens to populate.
+		res := preflight.Result{
+			Unreachable:    true,
+			UnreachableErr: errUnreachableProbe,
+			AbsentTables:   []string{m.GaugeTable, m.SumTable, m.HistogramTable},
+		}
+		got := decideRequirementsOutcome(res, m, database)
+		if got.fatalErr != nil {
+			t.Fatalf("decideRequirementsOutcome(unreachable) fatalErr = %v, want nil (must not block boot)", got.fatalErr)
+		}
+		if got.notReadyReason == "" {
+			t.Error("decideRequirementsOutcome(unreachable) notReadyReason = \"\", want a not-ready reason")
+		}
+	})
+
+	t.Run("empty configured table name: proceeds even though other tables are absent", func(t *testing.T) {
+		t.Parallel()
+		empty := m
+		empty.HistogramTable = ""
+		// HistogramTable is unconfigured; ExpHistogramTable being absent must
+		// not fail boot through the metrics gate at all — ConfiguredMetricTables
+		// (and therefore fatalAbsentMetricTablesErr) never look at
+		// ExpHistogramTable, and the empty HistogramTable can never match.
+		res := preflight.Result{AbsentTables: []string{m.ExpHistogramTable}}
+		got := decideRequirementsOutcome(res, empty, database)
+		if got.fatalErr != nil {
+			t.Fatalf("decideRequirementsOutcome(empty configured name) fatalErr = %v, want nil", got.fatalErr)
+		}
+		// The absent ExpHistogramTable still falls through to the general
+		// transient AbsentTables tolerance (SchemaProvisioned() is false),
+		// which is unchanged, pre-existing preflight behaviour, not a #1905
+		// fatal.
+		if got.notReadyReason == "" {
+			t.Error("decideRequirementsOutcome(empty configured name) notReadyReason = \"\", want the pre-existing transient AbsentTables reason")
+		}
+	})
+
+	t.Run("database absent: proceeds, does not fail boot even with absent tables", func(t *testing.T) {
+		t.Parallel()
+		res := preflight.Result{
+			DatabaseAbsent:    true,
+			DatabaseAbsentErr: errUnreachableProbe,
+			AbsentTables:      []string{m.GaugeTable},
+		}
+		got := decideRequirementsOutcome(res, m, database)
+		if got.fatalErr != nil {
+			t.Fatalf("decideRequirementsOutcome(database absent) fatalErr = %v, want nil (must not block boot)", got.fatalErr)
+		}
+		if got.notReadyReason == "" {
+			t.Error("decideRequirementsOutcome(database absent) notReadyReason = \"\", want a not-ready reason")
+		}
+	})
+
+	t.Run("fatal shape problem still short-circuits everything else", func(t *testing.T) {
+		t.Parallel()
+		res := preflight.Result{
+			Fatal:        errUnreachableProbe,
+			AbsentTables: []string{m.GaugeTable},
+		}
+		got := decideRequirementsOutcome(res, m, database)
+		if got.fatalErr == nil {
+			t.Fatal("decideRequirementsOutcome(fatal shape) fatalErr = nil, want the wrapped Fatal error")
+		}
+	})
+}
+
+// errUnreachableProbe is a stand-in probe error for tests that only need a
+// non-nil error value, never its text.
+var errUnreachableProbe = errTestPlaceholder("simulated probe failure")
+
+type errTestPlaceholder string
+
+func (e errTestPlaceholder) Error() string { return string(e) }

--- a/internal/api/prom/metadata.go
+++ b/internal/api/prom/metadata.go
@@ -1785,13 +1785,13 @@ func labelValueCandidates(name string) []string {
 }
 
 // metricTables returns the configured metric-table names in a stable
-// order, used for UNION construction.
+// order, used for UNION construction. Delegates to schema.Metrics's own
+// resolved table set (#1905) rather than re-deriving it, so this handler
+// and cerberus's boot-time existence check (cmd/cerberus's
+// runRequirementsCheck) always agree on which tables the metrics surface
+// reads.
 func (h *Handler) metricTables() []string {
-	return []string{
-		h.Schema.GaugeTable,
-		h.Schema.SumTable,
-		h.Schema.HistogramTable,
-	}
+	return h.Schema.ConfiguredMetricTables()
 }
 
 // arrayJoinMapKeysFrag emits `arrayJoin(mapKeys(<col>))` — the CH idiom

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -510,7 +510,7 @@ func resolveSelectorRouting(metricName string, s schema.Metrics, ctx lowerCtx, d
 
 func lowerVectorSelector(v *parser.VectorSelector, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
 	metricName := metricNameFromMatchers(v.LabelMatchers)
-	if metricName == "" && hasUnpinnedMetricNameMatcher(v.LabelMatchers) && s.HistogramTable != "" {
+	if hasUnpinnedMetricNameMatcher(v.LabelMatchers) && s.HistogramTable != "" {
 		return lowerRegexHistogramSelector(v, s, ctx)
 	}
 	// Resolve the candidate physical tables for this matcher.
@@ -529,12 +529,18 @@ func lowerVectorSelector(v *parser.VectorSelector, s schema.Metrics, ctx lowerCt
 	// bucket selectors below override to the histogram table without
 	// touching the union path. Existing fixtures stay byte-stable.
 	//
-	// When the selector carries no MatchEqual `__name__` (a regex name
-	// matcher, a negated matcher, or no name matcher at all) the scan
-	// fans across the same (Gauge, Sum) pair the unsuffixed arm uses —
-	// see schema.Metrics.TablesForUnknownName. A gauge-only fallback
-	// here made `{__name__=~".*cerberus_query_inflight.*"}` (the exact
-	// shape Grafana's Metrics Drilldown breakdown tab sends) return
+	// When s.HistogramTable == "", every unsuffixed-name selector lands
+	// here regardless of pin-ness; when a histogram table is configured,
+	// only a pinned selector does, since hasUnpinnedMetricNameMatcher
+	// above already routed anything unpinned (a regex `__name__`
+	// matcher, a negated matcher, or no `__name__` matcher at all)
+	// through lowerRegexHistogramSelector instead, which unions this same
+	// (Gauge, Sum) pair with the histogram companion/bucket arms. Either
+	// way the pair here must stay (Gauge, Sum) rather than gauge-only:
+	// metrics the OTel emitters store as cumulative sums under bare names
+	// (`cerberus_query_inflight`, `system_*`, `otelcol_*`) need the Sum
+	// arm too, or `{__name__=~".*cerberus_query_inflight.*"}` (the exact
+	// shape Grafana's Metrics Drilldown breakdown tab sends) returns
 	// empty for every sum-stored metric.
 	tables := s.TablesForUnknownName()
 	if metricName != "" {

--- a/internal/promql/regex_histogram_lower.go
+++ b/internal/promql/regex_histogram_lower.go
@@ -1,7 +1,6 @@
 package promql
 
 import (
-	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
 
@@ -9,17 +8,19 @@ import (
 	"github.com/tsouza/cerberus/internal/schema"
 )
 
-// hasUnpinnedMetricNameMatcher identifies selectors whose visible metric name
-// is a predicate rather than a literal. Such selectors need the histogram
-// arms below because classic histogram rows store the bare base name while
-// Prometheus exposes only synthetic `_bucket`, `_count`, and `_sum` names.
+// hasUnpinnedMetricNameMatcher identifies selectors whose visible metric
+// name is not pinned to a literal — a regex matcher, a negated matcher, or
+// no `__name__` matcher at all. All three shapes need the histogram arms
+// below because classic histogram rows store the bare base name while
+// Prometheus exposes only synthetic `_bucket`, `_count`, and `_sum` names;
+// "no `__name__` matcher at all" is strictly less pinned than a regex one
+// and must take the same fan-out, not the narrower TablesForUnknownName
+// path a literal absence would otherwise fall through to. Delegates to
+// wireArms's WireNamePinned split (#1756) rather than re-deriving the
+// pinned/unpinned line: a selector is unpinned exactly when it carries no
+// WireArmWireNamePinned matcher.
 func hasUnpinnedMetricNameMatcher(matchers []*labels.Matcher) bool {
-	for _, m := range matchers {
-		if m.Name == model.MetricNameLabel && m.Type != labels.MatchEqual {
-			return true
-		}
-	}
-	return false
+	return len(wireArms(matchers).WireNamePinned()) == 0
 }
 
 // Classification is delegated to wireArms (#1756): the union of

--- a/internal/schema/otel.go
+++ b/internal/schema/otel.go
@@ -584,8 +584,9 @@ func (m Metrics) TablesFor(metricName string) []string {
 // Classic-histogram series under a regex name matcher are surfaced by a
 // separate per-arm UnionAll lowering instead
 // (lowerRegexHistogramSelector in internal/promql/regex_histogram_lower.go,
-// wired from lowerVectorSelector for any selector with an unpinned
-// __name__ matcher): it unions this unknown-name candidate set with a
+// wired from lowerVectorSelector for any selector whose __name__ is not
+// pinned to a literal — a regex matcher, a negated matcher, or no
+// __name__ matcher at all): it unions this unknown-name candidate set with a
 // companion arm per `_count`/`_sum` suffix and a `_bucket` arm, PLUS a
 // `_count`/`_sum` companion arm per suffix reading ExpHistogramTable
 // (#1549 residue 1) — the same pair, mirroring
@@ -599,6 +600,21 @@ func (m Metrics) TablesForUnknownName() []string {
 		return []string{m.GaugeTable, m.SumTable}
 	}
 	return []string{m.GaugeTable}
+}
+
+// ConfiguredMetricTables returns the distinct, non-empty plain-Sample and
+// classic-histogram table names this schema is configured to read — Gauge,
+// Sum, and Histogram, in that order, once duplicates collapse (a schema may
+// point GaugeTable and SumTable at the same physical table). It is the same
+// "which tables back this metric surface" question metricTables()
+// (internal/api/prom/metadata.go) and cerberus's boot-time existence check
+// (cmd/cerberus's runRequirementsCheck, #1905) both need answered; both
+// consume this method instead of re-deriving the set, so the answer stays
+// in exactly one place. ExpHistogramTable is deliberately excluded: the
+// UNION-construction callers this serves project the plain-Sample /
+// classic-histogram row shapes only, matching TableFor/TablesFor above.
+func (m Metrics) ConfiguredMetricTables() []string {
+	return distinctTables(m.GaugeTable, m.SumTable, m.HistogramTable)
 }
 
 // The Prom-convention metric-name suffixes this package routes on.

--- a/test/perf/cardinality-baseline/promql/no_name_matcher_reaches_histogram_tables.json
+++ b/test/perf/cardinality-baseline/promql/no_name_matcher_reaches_histogram_tables.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/no_name_matcher_reaches_histogram_tables",
+  "fan_factor": 1,
+  "scan_rows": 5,
+  "peak_intermediate": 5,
+  "has_cross_join": false,
+  "has_array_join": true,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/cardinality-baseline/promql/not_regex_name_matcher_excludes_dotted.json
+++ b/test/perf/cardinality-baseline/promql/not_regex_name_matcher_excludes_dotted.json
@@ -1,8 +1,8 @@
 {
   "fixture": "promql/not_regex_name_matcher_excludes_dotted",
   "fan_factor": 1,
-  "scan_rows": 5,
-  "peak_intermediate": 5,
+  "scan_rows": 1,
+  "peak_intermediate": 1,
   "has_cross_join": false,
   "has_array_join": true,
   "has_recursive_cte": false,

--- a/test/perf/cardinality-baseline/promql/pinned_name_selector_no_histogram_fanout.json
+++ b/test/perf/cardinality-baseline/promql/pinned_name_selector_no_histogram_fanout.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/pinned_name_selector_no_histogram_fanout",
+  "fan_factor": 1,
+  "scan_rows": 1,
+  "peak_intermediate": 1,
+  "has_cross_join": false,
+  "has_array_join": false,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/solver-decision-baseline/no_name_matcher_reaches_histogram_tables.json
+++ b/test/perf/solver-decision-baseline/no_name_matcher_reaches_histogram_tables.json
@@ -1,0 +1,10 @@
+{
+  "query": "no_name_matcher_reaches_histogram_tables",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "5m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/pinned_name_selector_no_histogram_fanout.json
+++ b/test/perf/solver-decision-baseline/pinned_name_selector_no_histogram_fanout.json
@@ -1,0 +1,10 @@
+{
+  "query": "pinned_name_selector_no_histogram_fanout",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "5m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/spec/promql/no_name_matcher_reaches_histogram_tables.txtar
+++ b/test/spec/promql/no_name_matcher_reaches_histogram_tables.txtar
@@ -1,0 +1,166 @@
+# #1549 residue 2: a selector with NO `__name__` matcher at all (`{job="api"}`)
+# is strictly MORE unpinned than a regex `__name__` matcher, yet used to take
+# the narrower TablesForUnknownName-only path (`merge(gauge|sum)`) instead of
+# fanning across the histogram companion/bucket arms the regex-name path
+# already reaches — silently dropping every histogram-shaped series for a
+# selector that never mentioned `__name__` at all. The seed carries a gauge
+# row and a classic-histogram row under the same `job` label; the fix must
+# surface BOTH — the `svc_latency_count` / `svc_latency_sum` companions and
+# the `svc_latency_bucket` ladder — alongside the gauge series.
+
+-- query.promql --
+{job="api"}
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 1.0);
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+CREATE TABLE otel_metrics_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    ExplicitBounds Array(Float64),
+    BucketCounts Array(UInt64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_histogram VALUES
+    ('svc_latency', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 3, 6.0, [1.0], [1, 2]);
+CREATE TABLE otel_metrics_exponential_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    Scale Int32,
+    ZeroCount UInt64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64),
+    NegativeOffset Int32,
+    NegativeBucketCounts Array(UInt64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+-- expected_rows --
+[
+  ["svc_latency_bucket", {"job": "api", "le": "+Inf"}, "2026-01-01T00:00:00Z", 3],
+  ["svc_latency_bucket", {"job": "api", "le": "1"}, "2026-01-01T00:00:00Z", 1],
+  ["svc_latency_count", {"job": "api"}, "2026-01-01T00:00:00Z", 3],
+  ["svc_latency_sum", {"job": "api"}, "2026-01-01T00:00:00Z", 6],
+  ["up", {"job": "api"}, "2026-01-01T00:00:00Z", 1]
+]
+-- args --
+[0] string = "service.name"
+[1] string = "service_name"
+[2] string = "service.name"
+[3] string = "service_name"
+[4] string = ""
+[5] string = "service_name"
+[6] string = "job"
+[7] string = ""
+[8] string = "job"
+[9] string = ""
+[10] string = ""
+[11] string = "api"
+[12] string = "service.name"
+[13] string = "service_name"
+[14] string = "service.name"
+[15] string = "service_name"
+[16] string = ""
+[17] string = "service_name"
+[18] string = "job"
+[19] string = ""
+[20] string = "job"
+[21] string = ""
+[22] string = ""
+[23] string = "api"
+[24] string = "service.name"
+[25] string = "service_name"
+[26] string = "service.name"
+[27] string = "service_name"
+[28] string = ""
+[29] string = "service_name"
+[30] string = "job"
+[31] string = ""
+[32] string = "job"
+[33] string = ""
+[34] string = ""
+[35] string = "api"
+[36] string = "le"
+[37] string = "+Inf"
+[38] int64 = 1
+[39] string = "service.name"
+[40] string = "service_name"
+[41] string = "service.name"
+[42] string = "service_name"
+[43] string = ""
+[44] string = "service_name"
+[45] string = "job"
+[46] string = ""
+[47] string = "job"
+[48] string = ""
+[49] string = ""
+[50] string = "api"
+[51] string = "service.name"
+[52] string = "service_name"
+[53] string = "service.name"
+[54] string = "service_name"
+[55] string = ""
+[56] string = "service_name"
+[57] string = "job"
+[58] string = ""
+[59] string = "job"
+[60] string = ""
+[61] string = ""
+[62] string = "api"
+[63] string = "service.name"
+[64] string = "service_name"
+[65] string = "service.name"
+[66] string = "service_name"
+[67] string = ""
+[68] string = "service_name"
+[69] string = "job"
+[70] string = ""
+[71] string = "job"
+[72] string = ""
+[73] string = ""
+[74] string = "api"
+[75] string = "2026-01-01 00:00:01.000000000"
+[76] int64 = 9
+[77] string = "2026-01-01 00:00:01.000000000"
+[78] int64 = 9
+[79] int64 = 300000000000
+-- chplan --
+Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+  Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+    Filter predicate=((TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9)) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+      UnionAll arms=6
+        Project [MetricName AS MetricName, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, Value AS Value]
+          Filter predicate=(coalesce(nullIf(Attributes["job"], ""), nullIf(ResourceAttributes["job"], ""), "") = "api")
+            Scan(merge(otel_metrics_gauge|otel_metrics_sum))
+        Project [concat(MetricName, "_count") AS MetricName, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, toFloat64(Count) AS Value]
+          Filter predicate=(coalesce(nullIf(Attributes["job"], ""), nullIf(ResourceAttributes["job"], ""), "") = "api")
+            Scan(otel_metrics_histogram)
+        Project [concat(MetricName, "_sum") AS MetricName, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, toFloat64(Sum) AS Value]
+          Filter predicate=(coalesce(nullIf(Attributes["job"], ""), nullIf(ResourceAttributes["job"], ""), "") = "api")
+            Scan(otel_metrics_histogram)
+        Project [concat(MetricName, "_bucket") AS MetricName, mapConcat(Attributes, map("le", if((le_idx > length(ExplicitBounds)), "+Inf", toString(ExplicitBounds[le_idx])))) AS Attributes, TimeUnix AS TimeUnix, toFloat64(arraySum(arraySlice(BucketCounts, 1, le_idx))) AS Value]
+          Project [MetricName AS MetricName, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, ExplicitBounds AS ExplicitBounds, BucketCounts AS BucketCounts, arrayJoin(arrayEnumerate(BucketCounts)) AS le_idx]
+            Filter predicate=(coalesce(nullIf(Attributes["job"], ""), nullIf(ResourceAttributes["job"], ""), "") = "api")
+              Scan(otel_metrics_histogram)
+        Project [concat(MetricName, "_count") AS MetricName, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, toFloat64(Count) AS Value]
+          Filter predicate=(coalesce(nullIf(Attributes["job"], ""), nullIf(ResourceAttributes["job"], ""), "") = "api")
+            Scan(otel_metrics_exponential_histogram)
+        Project [concat(MetricName, "_sum") AS MetricName, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, toFloat64(Sum) AS Value]
+          Filter predicate=(coalesce(nullIf(Attributes["job"], ""), nullIf(ResourceAttributes["job"], ""), "") = "api")
+            Scan(otel_metrics_exponential_histogram)
+-- sql --
+SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM ((SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') WHERE (coalesce(nullIf(`Attributes`[?], ?), nullIf(`ResourceAttributes`[?], ?), ?) = ?))) UNION ALL (SELECT concat(`MetricName`, '_count') AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, toFloat64(`Count`) AS `Value` FROM (SELECT * FROM `otel_metrics_histogram` WHERE (coalesce(nullIf(`Attributes`[?], ?), nullIf(`ResourceAttributes`[?], ?), ?) = ?))) UNION ALL (SELECT concat(`MetricName`, '_sum') AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, toFloat64(`Sum`) AS `Value` FROM (SELECT * FROM `otel_metrics_histogram` WHERE (coalesce(nullIf(`Attributes`[?], ?), nullIf(`ResourceAttributes`[?], ?), ?) = ?))) UNION ALL (SELECT concat(`MetricName`, '_bucket') AS `MetricName`, mapConcat(`Attributes`, map(?, if((le_idx > length(`ExplicitBounds`)), ?, toString(`ExplicitBounds`[le_idx])))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, toFloat64(arraySum(arraySlice(`BucketCounts`, ?, le_idx))) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `ExplicitBounds` AS `ExplicitBounds`, `BucketCounts` AS `BucketCounts`, arrayJoin(arrayEnumerate(`BucketCounts`)) AS `le_idx` FROM (SELECT * FROM `otel_metrics_histogram` WHERE (coalesce(nullIf(`Attributes`[?], ?), nullIf(`ResourceAttributes`[?], ?), ?) = ?)))) UNION ALL (SELECT concat(`MetricName`, '_count') AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, toFloat64(`Count`) AS `Value` FROM (SELECT * FROM `otel_metrics_exponential_histogram` WHERE (coalesce(nullIf(`Attributes`[?], ?), nullIf(`ResourceAttributes`[?], ?), ?) = ?))) UNION ALL (SELECT concat(`MetricName`, '_sum') AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, toFloat64(`Sum`) AS `Value` FROM (SELECT * FROM `otel_metrics_exponential_histogram` WHERE (coalesce(nullIf(`Attributes`[?], ?), nullIf(`ResourceAttributes`[?], ?), ?) = ?)))) WHERE ((`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?))))) GROUP BY `MetricName`, `Attributes`)

--- a/test/spec/promql/not_regex_name_matcher_excludes_dotted.txtar
+++ b/test/spec/promql/not_regex_name_matcher_excludes_dotted.txtar
@@ -5,12 +5,15 @@
 # underscored negative regex (via the NOT match(<normalised>, re) arm);
 # only the unrelated `up` series survives.
 #
-# A bare `{...}` selector has no metric-name suffix to narrow the table set,
-# so the scan is `merge('^(otel_metrics_gauge|otel_metrics_sum)$')` — BOTH
-# tables. The seed therefore creates otel_metrics_sum EMPTY: without it the
-# fixture reads whatever rows an EARLIER fixture in the shared chDB session
-# happened to leave there, which is a corpus-order dependency, not a round
-# trip (it read native_resets_range_step's http_requests_total rows).
+# A negated `__name__` regex matcher is unpinned (#1549 residue 2), so the
+# plan fans across every physical layout — the (Gauge, Sum) merge scan, the
+# classic-histogram companion/bucket arms, and the exp-histogram companion
+# arms. The seed explicitly creates ALL FOUR tables EMPTY-or-decoy-free: the
+# fixture must round-trip on its own seed, not on whatever row an EARLIER
+# fixture in the shared chDB session happened to leave in a table this one
+# scans but never populates (that would be a corpus-order dependency, not a
+# round trip — see #1549 residue 2's histogram fixtures for the concrete
+# failure mode this once produced for otel_metrics_histogram).
 
 -- query.promql --
 {job="api", __name__!~".*container_cpu_usage.*"}
@@ -30,10 +33,24 @@ CREATE TABLE otel_metrics_sum (
     TimeUnix DateTime64(9),
     Value Float64
 ) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+CREATE TABLE otel_metrics_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    ExplicitBounds Array(Float64),
+    BucketCounts Array(UInt64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+CREATE TABLE otel_metrics_exponential_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
 -- expected_rows --
 [
-  ["mko_exp_hist_count", {"dc": "eu", "job": "api"}, "2026-01-01T00:00:00Z", 25],
-  ["mko_exp_hist_sum", {"dc": "eu", "job": "api"}, "2026-01-01T00:00:00Z", 250],
   ["up", {"job": "api"}, "2026-01-01T00:00:00Z", 1]
 ]
 -- sql --

--- a/test/spec/promql/pinned_name_selector_no_histogram_fanout.txtar
+++ b/test/spec/promql/pinned_name_selector_no_histogram_fanout.txtar
@@ -1,0 +1,69 @@
+# Control for #1549 residue 2: a selector whose `__name__` IS pinned to a
+# literal (`{__name__="up", job="api"}`) must stay on TablesFor's ordinary
+# (Gauge, Sum) resolution — it must NOT take the
+# hasUnpinnedMetricNameMatcher / lowerRegexHistogramSelector fan-out path the
+# sibling no_name_matcher_reaches_histogram_tables.txtar fixture exercises.
+# The decoy `up` row in otel_metrics_histogram proves the histogram table is
+# never scanned for a pinned selector: if it were, `up_count` / `up_sum`
+# companion rows would leak into the result.
+
+-- query.promql --
+{__name__="up", job="api"}
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('up', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 1.0);
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+CREATE TABLE otel_metrics_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    ExplicitBounds Array(Float64),
+    BucketCounts Array(UInt64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_histogram VALUES
+    ('up', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 3, 6.0, [1.0], [1, 2]);
+-- expected_rows --
+[
+  ["up", {"job": "api"}, "2026-01-01T00:00:00Z", 1]
+]
+-- args --
+[0] string = "service.name"
+[1] string = "service_name"
+[2] string = "service.name"
+[3] string = "service_name"
+[4] string = ""
+[5] string = "service_name"
+[6] string = "up"
+[7] string = "job"
+[8] string = ""
+[9] string = "job"
+[10] string = ""
+[11] string = ""
+[12] string = "api"
+[13] string = "2026-01-01 00:00:01.000000000"
+[14] int64 = 9
+[15] string = "2026-01-01 00:00:01.000000000"
+[16] int64 = 9
+[17] int64 = 300000000000
+-- chplan --
+Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+  Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+    Filter predicate=((TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9)) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+      Project [MetricName AS MetricName, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, Value AS Value]
+        Filter predicate=((MetricName = "up") AND (coalesce(nullIf(Attributes["job"], ""), nullIf(ResourceAttributes["job"], ""), "") = "api"))
+          Scan(merge(otel_metrics_gauge|otel_metrics_sum))
+-- sql --
+SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') PREWHERE (`MetricName` = ?) WHERE (coalesce(nullIf(`Attributes`[?], ?), nullIf(`ResourceAttributes`[?], ?), ?) = ?))) WHERE ((`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?))))) GROUP BY `MetricName`, `Attributes`)


### PR DESCRIPTION
## Summary

Two independent bugs in one PR, both in the metrics fan-out path.

**#1549 residue 2** — `hasUnpinnedMetricNameMatcher` only returned true when a
`__name__` matcher was present with a non-equal match type, so `{job="api"}`
(no `__name__` matcher at all) fell through to the narrower
`TablesForUnknownName()` path and never reached the histogram tables. It now
delegates to the existing `wireArms` classifier, so absence, regex, and
negation are all treated as unpinned consistently, and route through the same
fan-out a wildcard `__name__=~".*"` already used.

**#1905** — `metricTables()` unioned the configured Gauge/Sum/Histogram
tables without checking they physically exist, so a `cerberus.yaml` naming a
never-created table turned every metadata request into a ClickHouse
`UNKNOWN_TABLE` error instead of a clear failure. Startup now fails fast for
a genuinely absent-but-reachable table, naming both the table and the
`schema.metrics.*` config key that set it. A ClickHouse that is merely
unreachable, or a database that has not been provisioned yet, still boots
unready rather than crash-looping — that cold-start race is unchanged,
pre-existing `internal/preflight` behaviour.

`metricTables()` (internal/api/prom/metadata.go) now delegates to a new
`schema.Metrics.ConfiguredMetricTables()`, which cerberus's boot-time check
also consumes, so there is a single place that answers "which tables back
the metrics surface" instead of two independent derivations.

## Test plan

- [x] New TXTAR fixtures: `{job="api"}` reaches the histogram tables
  (`no_name_matcher_reaches_histogram_tables.txtar`, 6-arm UnionAll), and a
  pinned-selector control that confirms histogram tables are never scanned
  when `__name__` is pinned (`pinned_name_selector_no_histogram_fanout.txtar`).
- [x] Fixed a pre-existing corpus-order fragility in
  `not_regex_name_matcher_excludes_dotted.txtar`, which scanned the
  histogram/exp-histogram tables in its plan but never seeded them, so it was
  silently reading leftover rows from an earlier-alphabetical fixture in the
  shared chDB session.
- [x] `TestFatalAbsentMetricTablesErr` and `TestDecideRequirementsOutcome`
  (cmd/cerberus) cover all four boot cells with no ClickHouse connection
  required: table present, table absent (server reachable) fails fast naming
  table + config key, ClickHouse unreachable still boots unready, and an
  unconfigured (empty) table name is never treated as absent.
- [x] `go test ./internal/promql/ ./internal/schema/ ./internal/api/prom/ ./internal/chclient/ ./cmd/cerberus/`
- [x] `go test -tags chdb -run 'TestRoundTripChDB' ./test/spec/promql/...`
- [x] `go test -run 'TestNoGeneratedArtifactEscapesTheMergeGate' ./test/regression/...`
- [x] `node .github/scripts/forbid-sql-raw.mjs`

Closes #1549
Closes #1905
