### PR TITLE
fix(promql): key a computed histogram_quantile scalar on the scope it lands in

### DIFF
--- a/internal/promql/histogram_quantile.go
+++ b/internal/promql/histogram_quantile.go
@@ -192,22 +192,6 @@ func lowerHistogramQuantile(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chp
 	if len(c.Args) != 2 {
 		return nil, fmt.Errorf("promql: histogram_quantile expects 2 arguments, got %d", len(c.Args))
 	}
-	var phi phiArg
-	if lit, ok := tryScalarLiteral(c.Args[0]); ok {
-		phi.lit = lit
-	} else {
-		// Computed phi (`histogram_quantile(scalar(x), b)`): bind phi
-		// as a scalar-subquery expression; the emitters render it in
-		// place of the literal, with the phi-domain branches
-		// (phi <= 0 / phi >= 1 plus a leading isNaN guard) resolved at
-		// runtime instead of compile time.
-		expr, err := lowerScalarArg(c.Args[0], s, ctx)
-		if err != nil {
-			return nil, err
-		}
-		phi.expr = expr
-	}
-
 	// Recognise the canonical Prom idiom — `sum [by/without](rate(...))`
 	// — and dispatch to the aggregated-input path. The walker only accepts
 	// shapes whose underlying terminal is a bare VectorSelector; anything
@@ -217,13 +201,41 @@ func lowerHistogramQuantile(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chp
 	if matched {
 		// The per-`le` rung fold is resolved here rather than in the
 		// matcher because `quantile`'s parameter may be a computed
-		// scalar, which needs the schema + lowering context.
-		fold, err := classicBucketLadderFold(shape.agg, s, ctx)
+		// scalar, which needs the schema + lowering context. The fold is
+		// only ever read by a classic-bucket lowering, so it is bound
+		// under that family's scalar scope; the shaping operators that
+		// leave it nil never read it.
+		fold, err := classicBucketLadderFold(
+			shape.agg, s, histogramScalarArgCtx(shape.selector, ctx),
+		)
 		if err != nil {
 			return nil, err
 		}
 		shape.classicFold = fold
 	}
+
+	// The bare-selector fallthrough is resolved here rather than after the
+	// aggregated dispatch because it, together with the shape above,
+	// decides which scope a computed phi lands in — and that has to be
+	// settled before phi is lowered.
+	vs, isBare := unwrapVectorSelector(c.Args[1])
+
+	var phi phiArg
+	if lit, ok := tryScalarLiteral(c.Args[0]); ok {
+		phi.lit = lit
+	} else {
+		// Computed phi (`histogram_quantile(scalar(x), b)`): bind phi
+		// as a scalar-subquery expression; the emitters render it in
+		// place of the literal, with the phi-domain branches
+		// (phi <= 0 / phi >= 1 plus a leading isNaN guard) resolved at
+		// runtime instead of compile time.
+		expr, err := lowerScalarArg(c.Args[0], s, phiScalarArgCtx(shape, matched, vs, isBare, s, ctx))
+		if err != nil {
+			return nil, err
+		}
+		phi.expr = expr
+	}
+
 	if matched && histogramAggShapeLowerable(shape, s) {
 		if s.IsExpHistogramMetric(shape.selector.Name) {
 			// Range mode: fan the exp-histogram merge + quantile
@@ -272,8 +284,7 @@ func lowerHistogramQuantile(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chp
 		return lowerHistogramQuantileClassicFloat(c.Args[1], phi, s, ctx)
 	}
 
-	vs, ok := unwrapVectorSelector(c.Args[1])
-	if !ok {
+	if !isBare {
 		// Unrecognised inner shape — `histogram_quantile(0.9, sum(up))`,
 		// `histogram_quantile(0.9, vector(1))`, … . Reference Prometheus
 		// accepts any instant-vector second argument: classic-histogram
@@ -342,6 +353,48 @@ func lowerHistogramQuantile(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chp
 		return broadcastHistogramAtPin(inner, s, ctx), nil
 	}
 	return lowerHistogramQuantileClassicBare(vs, phi, s, ctx)
+}
+
+// histogramScalarArgCtx returns the context a computed scalar argument of
+// a histogram_quantile call over vs must be lowered under.
+//
+// A computed scalar compiles to a per-step map subscripted by the column
+// naming the current evaluation step (see lowerCtx.scalarAnchorColumn).
+// The *Range fan-out lowerings evaluate above a per-anchor fan-out, whose
+// scope names the step stepGridAnchorColumn and does NOT carry the Sample
+// timestamp column — that is the projection's own output. Every other
+// shape, instant and `@`-pinned broadcast alike, embeds the scalar in a
+// row position where the Sample timestamp column is in scope.
+func histogramScalarArgCtx(vs *parser.VectorSelector, ctx lowerCtx) lowerCtx {
+	if rangeGridShapeFor(vs, ctx) == gridFanout {
+		return ctx.withStepGridAnchor()
+	}
+	return ctx
+}
+
+// phiScalarArgCtx resolves histogramScalarArgCtx for phi, whose selector
+// depends on which of lowerHistogramQuantile's three dispatch families
+// claims the call: the aggregated idiom, the bare selector, or the
+// float-bucket fallbacks. Both fallbacks — a matched-but-unfoldable
+// shaping aggregation and an unrecognised inner shape — lower their
+// argument through the ordinary sample pipeline, so their scope carries
+// the Sample timestamp column and ctx passes through unchanged.
+func phiScalarArgCtx(
+	shape histogramAggShape,
+	matched bool,
+	vs *parser.VectorSelector,
+	isBare bool,
+	s schema.Metrics,
+	ctx lowerCtx,
+) lowerCtx {
+	switch {
+	case matched && histogramAggShapeLowerable(shape, s):
+		return histogramScalarArgCtx(shape.selector, ctx)
+	case matched, !isBare:
+		return ctx
+	default:
+		return histogramScalarArgCtx(vs, ctx)
+	}
 }
 
 // lowerHistogramQuantileClassicBare is the instant-mode lowering for

--- a/internal/promql/histogram_quantile_range.go
+++ b/internal/promql/histogram_quantile_range.go
@@ -69,8 +69,6 @@ import (
 // row per series stamped at a single anchor, which the matrix pivot
 // renders as a single point for the entire requested range.
 
-const histogramAnchorCol = "anchor_ts"
-
 // stalenessMinSamples is the sample floor for a staleness-lookback window:
 // a bare selector resolves to at most one sample, so one is enough.
 const stalenessMinSamples = 1
@@ -214,7 +212,7 @@ func broadcastHistogramAtPin(inner chplan.Node, s schema.Metrics, ctx lowerCtx) 
 		Projections: []chplan.Projection{
 			{Expr: &chplan.LitString{V: ""}, Alias: s.MetricNameColumn},
 			{Expr: &chplan.ColumnRef{Name: s.AttributesColumn}, Alias: s.AttributesColumn},
-			{Expr: &chplan.ColumnRef{Name: histogramAnchorCol}, Alias: s.TimestampColumn},
+			{Expr: &chplan.ColumnRef{Name: stepGridAnchorColumn}, Alias: s.TimestampColumn},
 			{Expr: &chplan.ColumnRef{Name: s.ValueColumn}, Alias: s.ValueColumn},
 		},
 	}
@@ -284,12 +282,12 @@ func lowerHistogramQuantileClassicAggRange(
 		[]chplan.Expr{histogramIdentityExpr(s)}, []string{s.AttributesColumn},
 		classicBucketWindowAggs(s), s, ctx,
 	)
-	anchorRef := &chplan.ColumnRef{Name: histogramAnchorCol}
+	anchorRef := &chplan.ColumnRef{Name: stepGridAnchorColumn}
 	perSeries := classicBucketWindowReshape(
 		fanout,
 		histogramWindowFold(shape.windowFn),
 		[]chplan.Projection{
-			{Expr: anchorRef, Alias: histogramAnchorCol},
+			{Expr: anchorRef, Alias: stepGridAnchorColumn},
 			{Expr: &chplan.ColumnRef{Name: s.AttributesColumn}, Alias: s.AttributesColumn},
 		},
 		s,
@@ -304,13 +302,13 @@ func lowerHistogramQuantileClassicAggRange(
 	collapse := &chplan.Aggregate{
 		Input:              perSeries,
 		GroupBy:            append([]chplan.Expr{anchorRef}, userGroupBy...),
-		GroupByAliases:     append([]string{histogramAnchorCol}, userAliases...),
+		GroupByAliases:     append([]string{stepGridAnchorColumn}, userAliases...),
 		AggFuncs:           shaping.aggs,
 		DropEmptyOnNoGroup: true,
 	}
 
 	rebuilt, cumulative := shaping.reshape(collapse, []chplan.Projection{
-		{Expr: anchorRef, Alias: histogramAnchorCol},
+		{Expr: anchorRef, Alias: stepGridAnchorColumn},
 		{Expr: attrsRebuild, Alias: s.AttributesColumn},
 	}, s)
 	return histogramRangeQuantileTree(rebuilt, cumulative, phi, s)
@@ -348,7 +346,7 @@ func buildHistogramRangeTree(
 	s schema.Metrics,
 	ctx lowerCtx,
 ) chplan.Node {
-	anchorRef := &chplan.ColumnRef{Name: histogramAnchorCol}
+	anchorRef := &chplan.ColumnRef{Name: stepGridAnchorColumn}
 
 	agg := buildHistogramBucketFanout(scan, pred, leMatchers, win, userGroupBy, userAliases, shaping.aggs, s, ctx)
 
@@ -357,7 +355,7 @@ func buildHistogramRangeTree(
 	// while preserving anchor_ts as a passthrough column so the
 	// downstream HistogramQuantile GroupBy can pick it up.
 	rebuilt, cumulative := shaping.reshape(agg, []chplan.Projection{
-		{Expr: anchorRef, Alias: histogramAnchorCol},
+		{Expr: anchorRef, Alias: stepGridAnchorColumn},
 		{Expr: attrsRebuild, Alias: s.AttributesColumn},
 	}, s)
 	return histogramRangeQuantileTree(rebuilt, cumulative, phi, s)
@@ -384,7 +382,7 @@ func histogramRangeQuantileTree(
 	phi phiArg,
 	s schema.Metrics,
 ) chplan.Node {
-	anchorRef := &chplan.ColumnRef{Name: histogramAnchorCol}
+	anchorRef := &chplan.ColumnRef{Name: stepGridAnchorColumn}
 	hq := &chplan.HistogramQuantile{
 		Input:                  rebuilt,
 		Phi:                    phi.lit,
@@ -396,7 +394,7 @@ func histogramRangeQuantileTree(
 			anchorRef,
 			&chplan.ColumnRef{Name: s.AttributesColumn},
 		},
-		GroupByAliases:   []string{histogramAnchorCol, s.AttributesColumn},
+		GroupByAliases:   []string{stepGridAnchorColumn, s.AttributesColumn},
 		MetricNameColumn: s.MetricNameColumn,
 		AttributesColumn: s.AttributesColumn,
 		TimestampColumn:  s.TimestampColumn,
@@ -532,7 +530,7 @@ func buildHistogramNativeRangeTree(
 	s schema.Metrics,
 	ctx lowerCtx,
 ) chplan.Node {
-	anchorRef := &chplan.ColumnRef{Name: histogramAnchorCol}
+	anchorRef := &chplan.ColumnRef{Name: stepGridAnchorColumn}
 
 	agg := buildHistogramBucketFanout(scan, pred, nil, win, userGroupBy, userAliases, expHistAggs, s, ctx)
 
@@ -540,7 +538,7 @@ func buildHistogramNativeRangeTree(
 	// fields (already aliased to their schema-canonical names by the
 	// fanout).
 	rebuiltProjs := []chplan.Projection{
-		{Expr: anchorRef, Alias: histogramAnchorCol},
+		{Expr: anchorRef, Alias: stepGridAnchorColumn},
 		{Expr: attrsRebuild, Alias: s.AttributesColumn},
 		{Expr: &chplan.ColumnRef{Name: s.ScaleColumn}, Alias: s.ScaleColumn},
 		{Expr: &chplan.ColumnRef{Name: s.ZeroCountColumn}, Alias: s.ZeroCountColumn},
@@ -574,7 +572,7 @@ func buildHistogramNativeRangeTree(
 			anchorRef,
 			&chplan.ColumnRef{Name: s.AttributesColumn},
 		},
-		GroupByAliases:   []string{histogramAnchorCol, s.AttributesColumn},
+		GroupByAliases:   []string{stepGridAnchorColumn, s.AttributesColumn},
 		MetricNameColumn: s.MetricNameColumn,
 		AttributesColumn: s.AttributesColumn,
 		TimestampColumn:  s.TimestampColumn,
@@ -609,14 +607,14 @@ func buildHistogramNativeRangeTreeMerge(
 	s schema.Metrics,
 	ctx lowerCtx,
 ) chplan.Node {
-	anchorRef := &chplan.ColumnRef{Name: histogramAnchorCol}
+	anchorRef := &chplan.ColumnRef{Name: stepGridAnchorColumn}
 
 	agg := buildHistogramBucketFanout(scan, pred, nil, win, userGroupBy, userAliases, mergeAggs, s, ctx)
 
 	// Reshape: fold per-row arrays into a single merged distribution.
 	// Mirrors the inner Project in lowerHistogramQuantileNativeAgg.
 	mergeProjs := []chplan.Projection{
-		{Expr: anchorRef, Alias: histogramAnchorCol},
+		{Expr: anchorRef, Alias: stepGridAnchorColumn},
 		{Expr: attrsRebuild, Alias: s.AttributesColumn},
 		{Expr: &chplan.ColumnRef{Name: hqAggMergedScaleAlias}, Alias: s.ScaleColumn},
 		{Expr: &chplan.ColumnRef{Name: s.ZeroCountColumn}, Alias: s.ZeroCountColumn},
@@ -650,7 +648,7 @@ func buildHistogramNativeRangeTreeMerge(
 			anchorRef,
 			&chplan.ColumnRef{Name: s.AttributesColumn},
 		},
-		GroupByAliases:   []string{histogramAnchorCol, s.AttributesColumn},
+		GroupByAliases:   []string{stepGridAnchorColumn, s.AttributesColumn},
 		MetricNameColumn: s.MetricNameColumn,
 		AttributesColumn: s.AttributesColumn,
 		TimestampColumn:  s.TimestampColumn,
@@ -684,7 +682,7 @@ func buildHistogramNativeRangeTreeMerge(
 // it unchanged.
 //
 // The anchor key is implicit — it is prepended by the fanout node under
-// histogramAnchorCol — so callers pass ONLY the user group keys in
+// stepGridAnchorColumn — so callers pass ONLY the user group keys in
 // userGroupBy / userAliases (the full Attributes column for the bare
 // paths, the `by/without` projection for the aggregated paths).
 func buildHistogramBucketFanout(
@@ -729,7 +727,7 @@ func buildHistogramBucketFanout(
 		GroupByAliases: userAliases,
 		AggFuncs:       aggFuncs,
 		MinSamples:     win.minSamples,
-		AnchorAlias:    histogramAnchorCol,
+		AnchorAlias:    stepGridAnchorColumn,
 		TimestampCol:   s.TimestampColumn,
 	}
 }

--- a/internal/promql/histogram_quantile_scalar_anchor_test.go
+++ b/internal/promql/histogram_quantile_scalar_anchor_test.go
@@ -1,0 +1,250 @@
+package promql_test
+
+import (
+	"context"
+	"regexp"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// stepGridAnchorAlias is the column a per-step fan-out names each
+// evaluation anchor with, mirrored from the lowering's own constant. A
+// test that read the constant through the package under test could not
+// catch the constant itself changing out from under the emitted SQL.
+const stepGridAnchorAlias = "anchor_ts"
+
+// TestHistogramQuantileComputedPhiKeysOnItsOwnScope pins the column a
+// computed phi's per-step lookup is subscripted by against the column the
+// scope it lands in actually exposes.
+//
+// A computed phi (`histogram_quantile(scalar(x), …)`) lowers, in range
+// mode, to a per-step map subscripted by the current evaluation step. The
+// range fan-out lowerings evaluate above a per-anchor fan-out whose scope
+// names the step `anchor_ts` and carries no Sample timestamp column at
+// all, so a lookup keyed on the Sample timestamp column names an
+// identifier that does not exist there. ClickHouse 24.8 — the declared
+// minimum base — rejects that outright; later versions resolve it from an
+// enclosing scope and answer, which is why this has to be asserted on the
+// plan rather than left to a roundtrip.
+func TestHistogramQuantileComputedPhiKeysOnItsOwnScope(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+
+	cases := []struct {
+		name  string
+		query string
+		// wantRange is the column the phi lookup must key on when the
+		// query is evaluated over a step grid.
+		wantRange string
+	}{
+		{
+			name:      "classic agg idiom",
+			query:     `histogram_quantile(scalar(vector(0.9)), sum by(le) (rate(http_duration_bucket[1m])))`,
+			wantRange: stepGridAnchorAlias,
+		},
+		{
+			name:      "classic rate without aggregation",
+			query:     `histogram_quantile(scalar(vector(0.9)), rate(http_duration_bucket[1m]))`,
+			wantRange: stepGridAnchorAlias,
+		},
+		{
+			name:      "classic bare selector",
+			query:     `histogram_quantile(scalar(vector(0.9)), http_duration_bucket)`,
+			wantRange: stepGridAnchorAlias,
+		},
+		{
+			name:      "native bare selector",
+			query:     `histogram_quantile(scalar(vector(0.9)), http_duration_exp_hist)`,
+			wantRange: stepGridAnchorAlias,
+		},
+		{
+			name:      "native agg idiom",
+			query:     `histogram_quantile(scalar(vector(0.9)), sum(rate(http_duration_exp_hist[1m])))`,
+			wantRange: stepGridAnchorAlias,
+		},
+		{
+			// A shaping aggregation has no per-`le` rung fold, so the
+			// argument goes through the ordinary sample pipeline and phi
+			// lands in a row position that carries the Sample timestamp
+			// column.
+			name:      "shaping aggregation falls back to float buckets",
+			query:     `histogram_quantile(scalar(vector(0.9)), topk(2, rate(http_duration_bucket[1m])))`,
+			wantRange: s.TimestampColumn,
+		},
+		{
+			// An absolute `@` pins one window for the whole query, so the
+			// quantile is evaluated once by the instant lowering and
+			// broadcast across the grid. Reference Prometheus still
+			// re-evaluates the scalar argument at every step, so phi stays
+			// per-step — keyed on the instant scope's own Sample timestamp
+			// column.
+			name:      "absolute @ pin evaluates once and broadcasts",
+			query:     `histogram_quantile(scalar(vector(0.9)), rate(http_duration_bucket[1m] @ 1000))`,
+			wantRange: s.TimestampColumn,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			t.Run("range", func(t *testing.T) {
+				t.Parallel()
+				assertPhiScopeColumns(t, tc.query, true, s, []string{tc.wantRange})
+			})
+			t.Run("instant", func(t *testing.T) {
+				t.Parallel()
+				// A single evaluation binds phi once for the whole
+				// statement, so there is no per-step lookup and phi reads
+				// nothing from the scope it lands in.
+				assertPhiScopeColumns(t, tc.query, false, s, nil)
+			})
+		})
+	}
+}
+
+// perStepLookupKey matches every step-key rendering in the emitted SQL,
+// capturing the column that names the evaluation step and, in the second
+// group, the alias clause that marks the one rendering which is NOT a
+// lookup: the key column the per-step map is BUILT from, inside the
+// scalar subquery's own scope.
+var perStepLookupKey = regexp.MustCompile("toUnixTimestamp64Nano\\(`?([A-Za-z_][A-Za-z0-9_]*)`?\\)( AS )?")
+
+// TestHistogramQuantileRungFoldScalarKeysOnTheAnchor covers the OTHER
+// computed scalar a histogram_quantile call can carry: the parameter of a
+// `quantile by(le)(...)` rung fold, which is embedded in the same
+// anchor-keyed fan-out scope as phi. Asserting on the emitted SQL rather
+// than on one plan field catches every per-step binding that reaches that
+// scope, whichever argument put it there.
+func TestHistogramQuantileRungFoldScalarKeysOnTheAnchor(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	const query = `histogram_quantile(0.9, quantile by(le) (scalar(vector(0.5)), rate(http_duration_bucket[1m])))`
+
+	plan := lowerHistogramQuery(t, query, true, s)
+	sql, _, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit(%q): %v", query, err)
+	}
+
+	var lookups int
+	for _, k := range perStepLookupKey.FindAllStringSubmatch(sql, -1) {
+		if k[2] != "" {
+			continue
+		}
+		lookups++
+		if k[1] != stepGridAnchorAlias {
+			t.Errorf("%q: per-step lookup keyed on %q, want %q — the rung fold is evaluated in the "+
+				"fan-out's anchor-keyed scope, which exposes no Sample timestamp column",
+				query, k[1], stepGridAnchorAlias)
+		}
+	}
+	if lookups == 0 {
+		t.Fatalf("%q emitted no per-step scalar lookup — the computed rung-fold parameter "+
+			"stopped binding per step, so this test asserts nothing", query)
+	}
+}
+
+// assertPhiScopeColumns lowers query and asserts that the set of columns
+// the computed phi expression reads from its enclosing scope is exactly
+// want.
+func assertPhiScopeColumns(t *testing.T, query string, rangeMode bool, s schema.Metrics, want []string) {
+	t.Helper()
+
+	plan := lowerHistogramQuery(t, query, rangeMode, s)
+
+	phis := collectPhiExprs(plan)
+	if len(phis) == 0 {
+		t.Fatalf("%q lowered to a plan with no computed phi expression — "+
+			"the lowering stopped exercising the computed-phi path, so this case asserts nothing", query)
+	}
+	for _, phi := range phis {
+		got := scopeColumnsOf(phi)
+		if !slices.Equal(got, want) {
+			t.Errorf("%q (range=%v): phi reads %v from its enclosing scope, want %v — "+
+				"a phi keyed on a column its own scope does not expose is an unknown identifier "+
+				"on the minimum supported ClickHouse base",
+				query, rangeMode, got, want)
+		}
+	}
+}
+
+func lowerHistogramQuery(t *testing.T, query string, rangeMode bool, s schema.Metrics) chplan.Node {
+	t.Helper()
+
+	expr, err := experimentalParser().ParseExpr(query)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", query, err)
+	}
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	if !rangeMode {
+		plan, err := promql.LowerAt(context.Background(), expr, s, start, start)
+		if err != nil {
+			t.Fatalf("LowerAt(%q): %v", query, err)
+		}
+		return plan
+	}
+	plan, err := promql.LowerAtRangeOpts(context.Background(), expr, s,
+		start, start.Add(5*time.Minute), time.Minute, promql.LowerOpts{})
+	if err != nil {
+		t.Fatalf("LowerAtRangeOpts(%q): %v", query, err)
+	}
+	return plan
+}
+
+// collectPhiExprs returns every runtime-computed phi expression in plan,
+// from both the classic and the native quantile nodes.
+func collectPhiExprs(plan chplan.Node) []chplan.Expr {
+	var out []chplan.Expr
+	chplan.WalkDeep(plan, func(n chplan.Node) bool {
+		switch hq := n.(type) {
+		case *chplan.HistogramQuantile:
+			if hq.PhiExpr != nil {
+				out = append(out, hq.PhiExpr)
+			}
+		case *chplan.HistogramQuantileNative:
+			if hq.PhiExpr != nil {
+				out = append(out, hq.PhiExpr)
+			}
+		}
+		return true
+	})
+	return out
+}
+
+// scopeColumnsOf returns the sorted, deduplicated set of columns e reads
+// from the scope it is embedded in. A ScalarSubquery opens a scope of its
+// own, so its body is deliberately not descended into.
+func scopeColumnsOf(e chplan.Expr) []string {
+	seen := map[string]struct{}{}
+	var walk func(chplan.Expr)
+	walk = func(e chplan.Expr) {
+		switch v := e.(type) {
+		case *chplan.ColumnRef:
+			seen[v.Name] = struct{}{}
+		case *chplan.FuncCall:
+			for _, a := range v.Args {
+				walk(a)
+			}
+		case *chplan.ScalarSubquery:
+			// A separate scope — its column references resolve against
+			// its own input, not against the scope phi lands in.
+		}
+	}
+	walk(e)
+
+	out := make([]string, 0, len(seen))
+	for name := range seen {
+		out = append(out, name)
+	}
+	slices.Sort(out)
+	return out
+}

--- a/internal/promql/histogram_value_fns.go
+++ b/internal/promql/histogram_value_fns.go
@@ -272,7 +272,7 @@ func lowerHistogramValueFnRange(
 ) chplan.Node {
 	scan := &chplan.Scan{Table: s.ExpHistogramTable}
 	pred := buildPredicate(vs.LabelMatchers, s)
-	anchorRef := &chplan.ColumnRef{Name: histogramAnchorCol}
+	anchorRef := &chplan.ColumnRef{Name: stepGridAnchorColumn}
 
 	agg := buildHistogramBucketFanout(
 		scan, pred, nil, windowFor(vs, instantLookback),

--- a/internal/promql/synthetic.go
+++ b/internal/promql/synthetic.go
@@ -59,10 +59,11 @@ func lowerQueryContextFold(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chpl
 	return syntheticScalarVector(&chplan.LitFloat{V: val}, nil, s, ctx), nil
 }
 
-// stepGridAnchorColumn is the column a chplan.StepGrid names each
-// evaluation step with. It is the only timestamp in scope directly above
-// a StepGrid — the canonical Sample timestamp column does not exist until
-// a projection aliases this one onto it.
+// stepGridAnchorColumn is the column every per-step fan-out names each
+// evaluation step with — a chplan.StepGrid and the histogram range
+// fan-out alike. It is the only timestamp in scope directly above such a
+// fan-out: the canonical Sample timestamp column does not exist until a
+// projection aliases this one onto it.
 const stepGridAnchorColumn = "anchor_ts"
 
 // syntheticScalarVector builds a Project-over-(OneRow|StepGrid) plan


### PR DESCRIPTION
`compatibility/prometheus-floor` is red on `main` and on every PR branched from it.
The single regressed case is

```
histogram_quantile(scalar(vector(0.9)), rate(demo_api_request_duration_seconds_bucket[1m]))
```

as a range query, answering `server_error: server error: 502` against a genuine ClickHouse 24.8
while the 26.5 lane is clean.

## The defect

A computed scalar argument compiles to a per-step map subscripted by the column that names the
current evaluation step. `lowerHistogramQuantile` bound both of its scalar arguments — phi, and the
parameter of a `quantile by(le)(...)` rung fold — with a plain `ctx`, **before** the dispatch that
decides which of its lowering families claims the call. `scalarStepValue` therefore fell back to the
canonical Sample timestamp column every time.

Four of those families are the range fan-out lowerings. They evaluate above a per-anchor fan-out
whose scope is `GROUP BY anchor_ts, gkey_0` and carries no Sample timestamp column at all — it is the
projection's own output, not something the scope can read. The emitted SQL asked for

```sql
… mapFromArrays(_cerb_sks, …)[toUnixTimestamp64Nano(TimeUnix)] …
FROM (… _hq_window_ladder …) GROUP BY anchor_ts, gkey_0
```

ClickHouse 24.8 — the declared `minCHBase` — rejects that with `code: 47, Unknown expression
identifier 'anchor_ts'`. ClickHouse 26.6 resolves the reference from an enclosing scope and answers
200, which is why the floor lane was the only detector.

## The fix

Resolve the shape first, then lower each scalar under the context of the branch that claims the call:
`withStepGridAnchor()` for the anchor-keyed fan-out families, plain `ctx` for the instant, `@`-pinned
broadcast, and float-bucket fallback families. `histogramScalarArgCtx` states the rule once and
`phiScalarArgCtx` maps the dispatch onto it. The rung fold gets the same treatment — it is a second
computed scalar landing in the same scope, and it had the same defect.

The two constants that named `anchor_ts` from two files are folded into one. Two names for one column
are what let a scalar keyed on the wrong one look plausible.

## Verification

Against a real **ClickHouse 24.8** container, with a binary built from this branch:

| query | before | after |
| --- | --- | --- |
| `histogram_quantile(scalar(vector(0.9)), rate(m_bucket[1m]))` | 502 | 200 |
| `histogram_quantile(scalar(vector(0.9)), sum by(le)(rate(m_bucket[1m])))` | 502 | 200 |
| `histogram_quantile(scalar(vector(0.9)), m_bucket)` | 502 | 200 |
| `histogram_quantile(scalar(vector(0.9)), rate(m_bucket[1m] @ …))` | 200 | 200 |
| `histogram_quantile(0.9, quantile by(le)(scalar(vector(0.5)), rate(m_bucket[1m])))` | 502 | 200 |

The computed-phi answer is point-for-point identical to the literal-phi spelling over the same
window: 31 series, 1736 points, 381 non-NaN, same values.

## Tests

`internal/promql/histogram_quantile_scalar_anchor_test.go`:

- `TestHistogramQuantileComputedPhiKeysOnItsOwnScope` asserts, on the lowered plan, the exact set of
  columns phi reads from the scope it lands in — `anchor_ts` for the five fan-out families,
  the Sample timestamp column for the float-bucket fallback and the `@`-pinned broadcast, and the
  empty set for every instant evaluation (one binding for the whole statement, so no lookup at all).
  Both a negative and a positive expectation per case, so the classifier cannot degenerate.
- `TestHistogramQuantileRungFoldScalarKeysOnTheAnchor` asserts on the emitted SQL that every per-step
  lookup in a `quantile by(le)(scalar(x), …)` fold keys on the anchor — catching any future scalar
  that reaches that scope, whichever argument put it there.

Both fail on the unfixed lowering (five sub-cases and seven assertions respectively) and pass with
it. `go test ./internal/promql/ ./internal/chsql/` and the chdb-tagged
`TestRoundTripChDB ./test/spec/promql/` are green; no golden moved, because the spec corpus has no
range-mode computed-scalar histogram fixture — which is precisely why the compat lane was the only
thing that caught this.
