### PR TITLE
fix(test): anchor the loki tail overflow fixture to the tail's own start

### DIFF
--- a/internal/api/loki/tail_overflow_internal_test.go
+++ b/internal/api/loki/tail_overflow_internal_test.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"sort"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -31,8 +32,54 @@ import (
 // the test catch the overflow-drop bug: when a window holds more than `limit`
 // matching rows, a correct cursor-advance must re-query the truncated tail on
 // the next poll instead of skipping past `end`.
+// The rows are minted lazily, on the first polling query, anchored to that
+// query's own lower bound — which IS the moment the tail was dialled. Fixing
+// the row timestamps to a wall clock read before the server was even started
+// would race: on a loaded runner the dial can land after the anchor, putting
+// every row below the tail's lower bound and delivering nothing at all.
 type cursorAwareQuerier struct {
-	master []chclient.Sample // seeded, sorted ASC by Timestamp
+	// lines are the log lines to mint, in ascending order.
+	lines []string
+	// leadTime places the first row that far after the tail's start, so
+	// the earliest polls see an empty window and the one that follows
+	// covers every row at once.
+	leadTime time.Duration
+	// spacing separates consecutive rows, keeping them unambiguous after
+	// the nanosecond cursor bump.
+	spacing time.Duration
+
+	// mu guards the fields below against the polling goroutine racing the
+	// test goroutine's read.
+	mu     sync.Mutex
+	master []chclient.Sample // minted on first poll, sorted ASC by Timestamp
+	// truncated records whether any single window held more matching rows
+	// than its LIMIT admitted. That window IS the bug's trigger, so a run
+	// that never produced one proves nothing.
+	truncated bool
+}
+
+// sawTruncatedWindow reports whether some poll window overflowed its LIMIT.
+func (q *cursorAwareQuerier) sawTruncatedWindow() bool {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return q.truncated
+}
+
+// mint seeds the row set relative to start, once.
+func (q *cursorAwareQuerier) mint(start time.Time) []chclient.Sample {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.master == nil {
+		q.master = make([]chclient.Sample, len(q.lines))
+		for i, line := range q.lines {
+			q.master[i] = chclient.Sample{
+				MetricName: line,
+				Labels:     map[string]string{"job": "api"},
+				Timestamp:  start.Add(q.leadTime + time.Duration(i)*q.spacing),
+			}
+		}
+	}
+	return q.master
 }
 
 var (
@@ -41,6 +88,15 @@ var (
 )
 
 const dt64Layout = "2006-01-02 15:04:05.000000000"
+
+const (
+	// tailRowLeadTime is how far after the tail's start the seeded rows
+	// begin. It is a whole number of poll intervals so the polls before it
+	// see an empty window, leaving the cursor parked below the rows.
+	tailRowLeadTime = 20 * time.Millisecond
+	// tailRowSpacing separates consecutive seeded rows.
+	tailRowSpacing = time.Millisecond
+)
 
 func (q *cursorAwareQuerier) Query(_ context.Context, sql string, _ ...any) ([]chclient.Sample, error) {
 	bounds := dt64Re.FindAllStringSubmatch(sql, -1)
@@ -67,15 +123,22 @@ func (q *cursorAwareQuerier) Query(_ context.Context, sql string, _ ...any) ([]c
 		limit = n
 	}
 
-	out := make([]chclient.Sample, 0, len(q.master))
-	for _, s := range q.master {
+	master := q.mint(lower)
+	matched := 0
+	out := make([]chclient.Sample, 0, len(master))
+	for _, s := range master {
 		ts := s.Timestamp.UTC()
 		if (ts.Equal(lower) || ts.After(lower)) && (ts.Equal(upper) || ts.Before(upper)) {
-			out = append(out, s)
-			if limit > 0 && len(out) == limit {
-				break
+			matched++
+			if limit <= 0 || len(out) < limit {
+				out = append(out, s)
 			}
 		}
+	}
+	if limit > 0 && matched > limit {
+		q.mu.Lock()
+		q.truncated = true
+		q.mu.Unlock()
 	}
 	return out, nil
 }
@@ -107,8 +170,10 @@ func (q *cursorAwareQuerier) QueryLabelSets(context.Context, string, ...any) ([]
 
 // TestTail_OverflowRowsNotDropped is the regression guard for the
 // poll-window-exceeds-limit data-loss bug. Five rows share ONE poll window
-// (all timestamps in the past, so the very first poll's [cursor, now] covers
-// them all) but the tail is opened with limit=2. A correct cursor-advance
+// (they open one lead time after the tail's start, so the polls before that
+// see nothing and leave the cursor parked below them, and the next poll's
+// [cursor, now] covers them all) but the tail is opened with limit=2. A
+// correct cursor-advance
 // must drain the truncated overflow across subsequent polls and deliver all
 // five lines exactly once, in order. The pre-fix code seeded the cursor at
 // `end` and jumped past the whole window, delivering only the first 2 of 5.
@@ -122,24 +187,15 @@ func TestTail_OverflowRowsNotDropped(t *testing.T) {
 	tailPollInterval = 10 * time.Millisecond
 	t.Cleanup(func() { tailPollInterval = prev })
 
-	// Seed five rows with DISTINCT timestamps clustered just after "now".
-	// The tail's default lower bound (`start`) is the dial moment, so the
-	// rows must sit at/after it; they're packed into a tight 4ms span a few
-	// ms in the future so that within a couple of 10ms polls a single
-	// window's upper bound (`end = now`) covers ALL of them at once — the
-	// over-limit window the bug drops. 1ms spacing keeps them unambiguous
-	// after the nanosecond cursor bump.
-	base := time.Now().UTC().Add(20 * time.Millisecond)
+	// Seed five rows with DISTINCT timestamps packed into a tight 4ms span
+	// that opens tailRowLeadTime after the tail's start, so the earliest
+	// polls see an empty window and the one after covers ALL five at once —
+	// the over-limit window the bug drops. tailRowSpacing keeps them
+	// unambiguous after the nanosecond cursor bump. The querier anchors them
+	// to the start it observes rather than to a wall clock read here, which
+	// setup latency could already have overtaken.
 	want := []string{"line-1", "line-2", "line-3", "line-4", "line-5"}
-	master := make([]chclient.Sample, len(want))
-	for i, line := range want {
-		master[i] = chclient.Sample{
-			MetricName: line,
-			Labels:     map[string]string{"job": "api"},
-			Timestamp:  base.Add(time.Duration(i) * time.Millisecond),
-		}
-	}
-	q := &cursorAwareQuerier{master: master}
+	q := &cursorAwareQuerier{lines: want, leadTime: tailRowLeadTime, spacing: tailRowSpacing}
 
 	h := New(q, schema.DefaultOTelLogs(), nil)
 	mux := http.NewServeMux()
@@ -180,6 +236,10 @@ func TestTail_OverflowRowsNotDropped(t *testing.T) {
 		}
 	}
 
+	if !q.sawTruncatedWindow() {
+		t.Fatalf("no poll window ever exceeded its LIMIT (got=%v) — the rows drained one window "+
+			"at a time, so this run never reached the over-limit path the guard exists for", got)
+	}
 	if len(got) != len(want) {
 		t.Fatalf("overflow rows dropped: received %d of %d lines (got=%v); pre-fix code delivers only the first 2", len(got), len(want), got)
 	}


### PR DESCRIPTION
The `TestTail_OverflowRowsNotDropped` fixture read a wall clock before the test
server was even created and placed its five rows 20ms past it. The tail's lower
bound is the moment the websocket is dialled, so whenever setup plus the
handshake took longer than that lead, every row sat below the bound and the tail
delivered nothing:

```
overflow rows dropped: received 0 of 5 lines (got=[])
```

That is a property of runner load, not of the code under test, so the guard
reddened unrelated PRs at random — most recently the `probe` check on #1911,
whose diff touches only `internal/spansscan` and traceql goldens.

## The fix

The querier now mints its rows lazily on the first polling query, anchored to
that query's own lower bound, so the rows open a fixed interval after whatever
start the tail actually used. The lead time and the row spacing are named
constants rather than inline literals.

## Keeping the guard load-bearing

A fixture that no longer reaches the over-limit window would pass while
asserting nothing — the rows would simply drain one window at a time and the
data-loss path this test exists for would never execute. The querier therefore
records whether any single poll window held more matching rows than its LIMIT
admitted, and the test fails when no window ever did.

## Verification

- New fixture green under `-race -count=10` on the single test, `-count=3` on
  the whole package.
- The ORIGINAL fixture reproduces the exact CI signature under an injected 50ms
  setup delay (`received 0 of 5 lines (got=[])`).
- The NEW fixture survives the identical injection, 5/5 runs.
