### PR TITLE
fix(e2e): derive structural-param retention from a declared closed option set

### DIFF
--- a/test/e2e/playwright/crawl/crawl.spec.ts
+++ b/test/e2e/playwright/crawl/crawl.spec.ts
@@ -124,6 +124,7 @@ import {
 import {
   ALERT_ERROR_PATTERNS,
   PAGE_CRASH_PATTERNS,
+  STRUCTURAL_PARAM_RULES,
   assertInventoryBootstrapped,
   byCodepoint,
   canonicalTarget,
@@ -566,6 +567,223 @@ test.describe('crawl: canonicalization pins', () => {
     );
     expect(grew).toHaveLength(1);
     expect(grew[0]).toContain('coverage grew');
+  });
+
+  test('parameterizing metrics-drilldown var-groupby absorbs label churn but still catches real coverage change', () => {
+    // Same derivation as the traces var-groupBy, reached by asking the
+    // one question rather than by waiting for a red: the Group by
+    // control is a QueryVariable over `label_names(<metric>)`, so its
+    // options are the label names of whichever series the stack
+    // ingested. No closed set exists, so it cannot enumerate — and
+    // enumerating it meant every label added to the seeded metrics
+    // would have re-keyed a surface and reported churn as coverage.
+    const asJob = canonicalizeURL(
+      '/a/grafana-metricsdrilldown-app/drilldown?metric=cerberus_http_requests_total&var-groupby=job',
+      base,
+      scope,
+    );
+    const asInstance = canonicalizeURL(
+      '/a/grafana-metricsdrilldown-app/drilldown?metric=cerberus_http_requests_total&var-groupby=instance',
+      base,
+      scope,
+    );
+    expect(asJob).toBe(asInstance);
+    expect(asJob).toBe(
+      '/a/grafana-metricsdrilldown-app/drilldown?metric={metric}&var-groupby={var-groupby}',
+    );
+    // The includeAll sentinel is the cold-boot value and still drops.
+    expect(
+      canonicalizeURL(
+        '/a/grafana-metricsdrilldown-app/drilldown?metric=cerberus_http_requests_total&var-groupby=%24__all',
+        base,
+        scope,
+      ),
+    ).toBe('/a/grafana-metricsdrilldown-app/drilldown?metric={metric}');
+
+    // The collapse is not a hole: losing the grouped surface entirely
+    // — the sweep no longer driving the Group by control at all — is
+    // still a coverage loss the ratchet reports.
+    const stack = activeStack();
+    const bare = '/a/grafana-metricsdrilldown-app/drilldown?metric={metric}';
+    const grouped = asJob!;
+    const inventory = {
+      doc: '',
+      stack: stack.name,
+      surfaces: [
+        { url: bare, lean: true },
+        { url: grouped, lean: true },
+      ],
+    };
+    const noExclusions = { doc: '', exclusions: [] };
+
+    expect(
+      diffInventory(
+        new Set([bare, grouped]),
+        inventory,
+        noExclusions,
+        'lean',
+        stack,
+      ),
+    ).toEqual([]);
+
+    const shrank = diffInventory(
+      new Set([bare]),
+      inventory,
+      noExclusions,
+      'lean',
+      stack,
+    );
+    expect(shrank).toHaveLength(1);
+    expect(shrank[0]).toContain('coverage shrank');
+    expect(shrank[0]).toContain(grouped);
+  });
+
+  test('every enumerated structural param declares a closed option set holding its default', () => {
+    // The mode is chosen by ONE question — "can the complete option
+    // set be written down from the pinned app version?" — and this is
+    // where the answer is held to account. An enumerate rule with no
+    // set, or whose cold-boot value is not one of its own options, is
+    // a rule written from observation rather than from the bundle:
+    // exactly the defect that recorded var-primarySignal as two
+    // options when its bundle array carries five.
+    const enumerated = STRUCTURAL_PARAM_RULES.filter(
+      (r) => r.mode === 'enumerate',
+    );
+    expect(enumerated.length).toBeGreaterThan(0);
+    for (const rule of enumerated) {
+      const where = `${rule.param} on ${rule.pathPattern.source}`;
+      expect(rule.values.length, `${where}: empty option set`).toBeGreaterThan(
+        0,
+      );
+      expect(
+        new Set(rule.values).size,
+        `${where}: duplicate options`,
+      ).toBe(rule.values.length);
+      // A canonical key is `param=value` joined by '&'; a value
+      // carrying '&' would silently split into two pinned params.
+      for (const v of rule.values) {
+        expect(v, `${where}: option ${JSON.stringify(v)} carries '&'`).not.toContain(
+          '&',
+        );
+      }
+      if (rule.defaultValue !== undefined) {
+        expect(
+          rule.values,
+          `${where}: cold-boot default ${JSON.stringify(rule.defaultValue)} is not one of its own options`,
+        ).toContain(rule.defaultValue);
+      }
+    }
+  });
+
+  test('an enumerated value outside the declared set fails loudly instead of minting a surface', () => {
+    // Without this the same story replays every time: the app offers
+    // an option the rule never catalogued, the crawl reaches it, and
+    // the only symptom is an anonymous "coverage grew" row 40 minutes
+    // into the compose lane naming neither the param nor the cause.
+    // Here it fails in microseconds, naming both, and states the two
+    // possible fixes.
+    let thrown: Error | undefined;
+    try {
+      canonicalizeURL(
+        '/a/grafana-exploretraces-app/explore?var-primarySignal=kind=producer',
+        base,
+        scope,
+      );
+    } catch (e) {
+      thrown = e as Error;
+    }
+    expect(thrown, 'undeclared option was silently accepted').toBeDefined();
+    expect(thrown!.message).toContain('var-primarySignal');
+    expect(thrown!.message).toContain('kind=producer');
+    expect(thrown!.message).toContain('parameterize');
+
+    // The check is not a blanket rejection of unfamiliar text: a value
+    // the bundle really does offer canonicalizes normally.
+    expect(
+      canonicalizeURL(
+        '/a/grafana-exploretraces-app/explore?var-primarySignal=kind=consumer',
+        base,
+        scope,
+      ),
+    ).toBe('/a/grafana-exploretraces-app/explore?var-primarySignal=kind=consumer');
+  });
+
+  test('enumerating var-primarySignal keeps every signal a distinct surface', () => {
+    // The mirror image of the var-groupBy case, and the reason the
+    // collapse doctrine is NOT "every var-* parameterizes". The five
+    // primary signals are a literal array in the plugin bundle, each
+    // splicing a DIFFERENT TraceQL fragment into every query the page
+    // fires. Collapsing them would key five query families as one
+    // surface and pin whichever the crawl reached first — which is
+    // precisely how #1889 (Service structure 500s on every primary
+    // signal but the default) would go unseen.
+    const rule = STRUCTURAL_PARAM_RULES.find(
+      (r) =>
+        r.param === 'var-primarySignal' &&
+        r.pathPattern.test('/a/grafana-exploretraces-app/explore'),
+    );
+    if (rule === undefined || rule.mode !== 'enumerate') {
+      throw new Error(
+        'var-primarySignal must remain an enumerate rule: each signal is a ' +
+          'distinct TraceQL filter, hence a distinct query family',
+      );
+    }
+
+    const keys = rule.values.map(
+      (v) =>
+        canonicalizeURL(
+          `/a/grafana-exploretraces-app/explore?var-primarySignal=${encodeURIComponent(v)}`,
+          base,
+          scope,
+        )!,
+    );
+    // Every non-default signal keys its own surface; the cold-boot
+    // signal keys the bare one. No two collapse together.
+    expect(new Set(keys).size).toBe(rule.values.length);
+    expect(keys).toContain('/a/grafana-exploretraces-app/explore');
+
+    // …and dropping one is a coverage LOSS the ratchet still reports.
+    // Today's red was `kind=server` arriving as new coverage; this
+    // pins the other half — that losing it again is caught.
+    const stack = activeStack();
+    const serverSignal =
+      '/a/grafana-exploretraces-app/explore?var-primarySignal=kind=server';
+    const allSpans = '/a/grafana-exploretraces-app/explore?var-primarySignal=true';
+    const inventory = {
+      doc: '',
+      stack: stack.name,
+      surfaces: [
+        { url: '/a/grafana-exploretraces-app/explore', lean: true },
+        { url: allSpans, lean: true },
+        { url: serverSignal, lean: true },
+      ],
+    };
+    const noExclusions = { doc: '', exclusions: [] };
+
+    expect(
+      diffInventory(
+        new Set([
+          '/a/grafana-exploretraces-app/explore',
+          allSpans,
+          serverSignal,
+        ]),
+        inventory,
+        noExclusions,
+        'lean',
+        stack,
+      ),
+    ).toEqual([]);
+
+    const shrank = diffInventory(
+      new Set(['/a/grafana-exploretraces-app/explore', allSpans]),
+      inventory,
+      noExclusions,
+      'lean',
+      stack,
+    );
+    expect(shrank).toHaveLength(1);
+    expect(shrank[0]).toContain('coverage shrank');
+    expect(shrank[0]).toContain(serverSignal);
   });
 
   test('pinned structural-param counting (the pairwise depth bound)', () => {

--- a/test/e2e/playwright/crawl/lib.ts
+++ b/test/e2e/playwright/crawl/lib.ts
@@ -85,41 +85,86 @@ export type ScopeRules = {
  * stayed green. Params that change the queries a page issues are
  * distinct consumption modes, hence distinct surfaces.
  *
- * Two retention modes mirror the path rules:
- *   - 'enumerate' — low-cardinality structural params (actionView
- *     tabs, groupBy attribute, metric type): every value keys its own
- *     surface. `defaultValue` names the value the app writes on a
- *     cold boot; it is DROPPED from the canonical so the default
- *     state stays keyed by the bare surface (the app rewriting its
- *     defaults into the URL must not re-key the surface).
- *   - 'parameterize' — high-cardinality structural params (the
- *     metrics-drilldown `metric` name): the value collapses to
- *     `{param}`, one representative surface family — the same
- *     doctrine as the `{service}` path segment.
+ * Which retention mode applies is NOT a per-param taste call, and NOT
+ * a list of names someone extends each time the ratchet goes red. It
+ * is forced by one question with a checkable answer: **can the param's
+ * complete option set be written down from the pinned app version
+ * alone?**
+ *
+ *   - 'enumerate' — the option set is a fact about the APP: a literal
+ *     array in the plugin bundle, fixed by the pinned plugin version
+ *     (actionView tabs, metric type, primary signal). Every value keys
+ *     its own surface, because each drives a structurally different
+ *     query. The rule must DECLARE that set in `values`, and the
+ *     canonicalizer rejects any value outside it.
+ *   - 'parameterize' — the option set is a fact about the DATA: the
+ *     app offers whichever attribute / metric / label names the
+ *     ingested telemetry happens to carry, so no closed set exists.
+ *     The value collapses to `{param}`, one representative surface
+ *     family — the same doctrine as the `{service}` path segment.
+ *
+ * There is no third mode and no escape hatch: a param whose options
+ * come from data cannot produce a `values` set, so the type itself
+ * forces it to parameterize. That is what stops the doctrine decaying
+ * into an enumeration of param names.
+ *
+ * `defaultValue` names the value the app writes on a cold boot; it is
+ * DROPPED from the canonical in either mode, so the default state
+ * stays keyed by the bare surface (the app rewriting its own defaults
+ * into the URL must not re-key the surface).
  */
 export type StructuralParamRule = {
   /** Canonical-path family the rule applies to (post path-rewrite). */
   pathPattern: RegExp;
   /** Exact query param name. */
   param: string;
-  mode: 'enumerate' | 'parameterize';
   /** The app's cold-boot value, dropped from keys in either mode. */
   defaultValue?: string;
-};
+} & (
+  | {
+      mode: 'enumerate';
+      /**
+       * The COMPLETE option set the pinned app version offers, read
+       * off the plugin bundle rather than off whichever values some
+       * crawl happened to reach. `defaultValue` must be a member.
+       */
+      values: ReadonlyArray<string>;
+    }
+  | { mode: 'parameterize' }
+);
 
 /**
- * Grafana-12.x structural params, verified live against
- * grafana/grafana:12.2.9 (2026-06-11) by driving each control and
- * reading the URL the app wrote:
+ * Grafana-12.x structural params, pinned to grafana/grafana:12.2.9.
+ *
+ * Every `values` set below is read off the shipped plugin bundle —
+ * the literal option array the app itself iterates — NOT off whichever
+ * values a crawl happened to reach. That distinction is the whole
+ * point of the closed set. Cataloguing options by observation is how
+ * this rule table went wrong before: `var-primarySignal` was recorded
+ * as "Root spans | All spans" because those were the two states a
+ * crawl had produced, while the bundle's array carries five. The crawl
+ * later reached a third (`kind=server`) and the ratchet reported it as
+ * new coverage, which it was — but one option at a time, each a fresh
+ * red on `main`, with two more still queued behind it.
  *
  *   - Traces Drilldown (`grafana-exploretraces-app`): `actionView`
- *     (Breakdown | Service structure | Comparison | Traces tabs,
- *     boot value `breakdown`), `var-metric` (rate | errors |
- *     duration, boot `rate`), `var-groupBy` (the breakdown ATTRIBUTE
- *     NAME, boot `resource.service.name` — high-cardinality and
- *     data-derived, so it parameterizes; see below),
- *     `var-primarySignal` (Root spans | All spans, boot
- *     `nestedSetParent<0`).
+ *     (six tabs, boot `breakdown`), `var-metric` (rate | errors |
+ *     duration, boot `rate`), `var-primarySignal` (five signals, boot
+ *     `nestedSetParent<0`), `var-groupBy` (the breakdown ATTRIBUTE
+ *     NAME, boot `resource.service.name` — data-derived, so it
+ *     parameterizes; see below).
+ *
+ * `var-primarySignal` enumerates rather than parameterizes, and the
+ * reason is the mirror image of `var-groupBy`'s. Its five options are
+ * a literal array in the plugin bundle, each pairing a label with a
+ * fixed TraceQL fragment the app splices into EVERY query the page
+ * fires (`{nestedSetParent<0 && …}` vs `{kind=server && …}` vs
+ * `{span.db.system.name!="" && …}`). Adding a span attribute to the
+ * seeded stack cannot change that list. Collapsing it would key five
+ * genuinely different query families as one surface and pin whichever
+ * the crawl reached first — precisely the coverage #1889 (the Service
+ * structure tab 500s on every primary signal but the default) needs
+ * the crawl to keep reaching.
  *
  * `var-groupBy` parameterizes rather than enumerates because its
  * option list is a fact about the DATA, not about the surface: the
@@ -138,12 +183,15 @@ export type StructuralParamRule = {
  * `metric` name and the `{service}` path segment.
  *   - Metrics Drilldown (`grafana-metricsdrilldown-app`): `metric`
  *     (the selected metric NAME — one per series family in the
- *     stack, high-cardinality → parameterize), `actionView`
- *     (breakdown | related, written as `breakdown` on metric select),
- *     `var-groupby` (boot `$__all`).
+ *     stack, data-derived → parameterize), `actionView` (four tabs,
+ *     written as `breakdown` on metric select), `var-groupby` (the
+ *     breakdown LABEL NAME — a QueryVariable over
+ *     `label_names(<metric>)`, so data-derived → parameterize; boot
+ *     `$__all`, its includeAll sentinel).
  *   - Logs Drilldown service pages (`grafana-lokiexplore-app`):
  *     `visualizationType` (logs | table | json — JSON-string-quoted
- *     in the URL, boot `"logs"`), `sortOrder` (boot `"Descending"`).
+ *     in the URL, boot `"logs"`), `sortOrder` (Descending |
+ *     Ascending, likewise quoted, boot `"Descending"`).
  *
  * Time params (`from`/`to`), filters (`var-filters`), display state
  * (`displayedFields`, `urlColumns`, `patterns`, …) stay stripped —
@@ -154,12 +202,26 @@ export const STRUCTURAL_PARAM_RULES: ReadonlyArray<StructuralParamRule> = [
     pathPattern: /^\/a\/grafana-exploretraces-app\/explore$/,
     param: 'actionView',
     mode: 'enumerate',
+    // Bundle: the tab array the app maps over to build its TabsBar.
+    // `exceptions` and `adaptiveTraces` mount conditionally (feature
+    // flag / sibling plugin), so a crawl need not reach them — but
+    // they are options of the pinned version, so they belong to the
+    // declared set rather than becoming a future surprise red.
+    values: [
+      'breakdown',
+      'structure',
+      'comparison',
+      'exceptions',
+      'traceList',
+      'adaptiveTraces',
+    ],
     defaultValue: 'breakdown',
   },
   {
     pathPattern: /^\/a\/grafana-exploretraces-app\/explore$/,
     param: 'var-metric',
     mode: 'enumerate',
+    values: ['rate', 'errors', 'duration'],
     defaultValue: 'rate',
   },
   {
@@ -172,6 +234,16 @@ export const STRUCTURAL_PARAM_RULES: ReadonlyArray<StructuralParamRule> = [
     pathPattern: /^\/a\/grafana-exploretraces-app\/explore$/,
     param: 'var-primarySignal',
     mode: 'enumerate',
+    // Bundle: the literal `[{label, value, filter, description}, …]`
+    // array, in its declared order. Each `value` is the TraceQL
+    // fragment the app splices into every query the page fires.
+    values: [
+      'nestedSetParent<0',
+      'true',
+      'kind=server',
+      'kind=consumer',
+      'span.db.system.name!=""',
+    ],
     defaultValue: 'nestedSetParent<0',
   },
   {
@@ -183,24 +255,39 @@ export const STRUCTURAL_PARAM_RULES: ReadonlyArray<StructuralParamRule> = [
     pathPattern: /^\/a\/grafana-metricsdrilldown-app\/(drilldown|trail)$/,
     param: 'actionView',
     mode: 'enumerate',
+    // Bundle: the tab-value enum. Note `relatedLogs` and
+    // `queryResults` write `logs` / `results`, not their key names.
+    values: ['breakdown', 'related', 'logs', 'results'],
     defaultValue: 'breakdown',
   },
   {
     pathPattern: /^\/a\/grafana-metricsdrilldown-app\/(drilldown|trail)$/,
     param: 'var-groupby',
-    mode: 'enumerate',
+    // Data-derived, so it cannot enumerate. The Group by control is a
+    // QueryVariable whose options are `label_names(<selected metric>)`
+    // resolved against the datasource — the LABEL NAMES the ingested
+    // series carry. `$__all` is its includeAll sentinel, not an option
+    // set. No closed set can be written down, which is exactly the
+    // signal that the value is churn rather than coverage: pinning it
+    // would pin the seeded label schema, the same defect #1825 hit
+    // with the traces `var-groupBy`.
+    mode: 'parameterize',
     defaultValue: '$__all',
   },
   {
     pathPattern: /^\/a\/grafana-lokiexplore-app\/explore\/service\/\{service\}\//,
     param: 'visualizationType',
     mode: 'enumerate',
+    // JSON-string-quoted by the app, quotes included, as written.
+    values: ['"logs"', '"table"', '"json"'],
     defaultValue: '"logs"',
   },
   {
     pathPattern: /^\/a\/grafana-lokiexplore-app\/explore\/service\/\{service\}\//,
     param: 'sortOrder',
     mode: 'enumerate',
+    // Grafana core's LogsSortOrder enum, JSON-string-quoted as above.
+    values: ['"Descending"', '"Ascending"'],
     defaultValue: '"Descending"',
   },
 ];
@@ -442,6 +529,27 @@ export function canonicalTarget(
     // the default state is not a distinct surface.
     if (value === rule.defaultValue) continue;
     if (rule.mode === 'enumerate') {
+      // An enumerated param's option set is a CLAIM about the pinned
+      // app version, and this is where the claim gets checked. A value
+      // outside it means exactly one of two things, and both need a
+      // human: either the app version gained an option (real coverage
+      // change, pin it deliberately) or the param's options actually
+      // come from the data and the rule is miscategorised (it must
+      // become 'parameterize'). Failing here names the param and the
+      // value; letting it through instead surfaces as an anonymous
+      // "coverage grew" row 40 minutes into the compose lane.
+      if (!rule.values.includes(value)) {
+        throw new Error(
+          `canonical surface key: ${rule.param}=${JSON.stringify(value)} on ` +
+            `${path} is outside the rule's declared option set ` +
+            `[${rule.values.map((v) => JSON.stringify(v)).join(', ')}]. ` +
+            `Either the pinned app version gained an option — add it to ` +
+            `STRUCTURAL_PARAM_RULES and regenerate the inventory — or the ` +
+            `option list comes from the seeded data, in which case the rule ` +
+            `must be mode 'parameterize' so the value collapses to ` +
+            `{${rule.param}}.`,
+        );
+      }
       retained.push(`${rule.param}=${value}`);
     } else {
       retained.push(`${rule.param}={${rule.param}}`);


### PR DESCRIPTION
## Summary

- `main` is red on `compose-smoke-shard-info (shard-crawl, …)`: the crawl reached
  `/a/grafana-exploretraces-app/explore?var-primarySignal=kind=server` and the ratchet
  reported it as unpinned coverage. That is real coverage growth, not data churn — but it
  arrived as an anonymous row 40 minutes into the compose lane, and two more primary-signal
  options are still queued behind it, one red each.
- The cause is upstream of that surface: a structural param's retention mode
  (`enumerate` its values vs collapse them to `{param}`) was a per-param judgement made from
  the values a crawl had happened to produce. `var-primarySignal` was catalogued as
  "Root spans | All spans" while the plugin bundle's option array carries **five**.
- This makes the mode follow from a question with a checkable answer: **can the param's
  complete option set be written down from the pinned app version alone?** `enumerate` must
  now declare that set, and the canonicalizer rejects any value outside it, naming the param,
  the value, and the two possible fixes. A param whose options come from a datasource query
  cannot produce such a set, so the type forces it to `parameterize`. That is the general
  rule — it needs no list of param names, and it is what a new Grafana template variable
  gets measured against.
- Every declared set is read off the shipped bundle rather than observed.

## What stays literal, and what each protects

`var-primarySignal` deliberately does **not** collapse. Its five options are a literal
`[{label, value, filter}, …]` array in `grafana-exploretraces-app`, each splicing a different
TraceQL fragment into every query the page fires (`{nestedSetParent<0 && …}` vs
`{kind=server && …}` vs `{span.db.system.name!="" && …}`). Seeding more spans cannot change
that list. Collapsing it would key five query families as one surface and pin whichever the
crawl reached first — which is exactly the coverage #1889 (Service structure 500s on every
primary signal but the default) needs the crawl to keep reaching. Same reasoning keeps
`actionView`, `var-metric`, `visualizationType` and `sortOrder` enumerated.

Moving the other way: metrics-drilldown `var-groupby` was `enumerate` and should never have
been. It is a `QueryVariable` over `label_names(<selected metric>)`, so its options are the
label names of whichever series the stack ingested; `$__all` is its includeAll sentinel, not
an option set. Enumerating it pinned the seeded label schema — the same defect #1825 hit on
the traces `var-groupBy`. It now parameterizes.

Traces `actionView` also gains `exceptions` and `adaptiveTraces`. They mount conditionally
(feature flag / sibling plugin) so a crawl need not reach them, but they are options of the
pinned version and belong in the declared set rather than becoming a later surprise.

## Test plan

- [x] `npx tsc --noEmit` clean over `test/e2e/playwright`
- [x] `CRAWL_STACK=compose npx playwright test crawl/ --grep "canonicalization pins"` — 20 passed
      (these are pure-function pins; they need no stack)
- [ ] Inventory regenerated with `CERBERUS_UPDATE_INVENTORY=1 SWEEP_DEPTH=full CRAWL_STACK=compose`
- [ ] CI green

New pins, and what each catches:

| Test | Fails when |
| --- | --- |
| `every enumerated structural param declares a closed option set holding its default` | a rule is added with an empty/duplicated set, an option containing `&` (which would split into two pinned params), or a cold-boot default that is not one of its own options |
| `an enumerated value outside the declared set fails loudly instead of minting a surface` | the guard stops firing — and it asserts the message names the param, the value and `parameterize`, plus that a genuinely declared value still canonicalizes normally, so it is not a blanket rejection |
| `enumerating var-primarySignal keeps every signal a distinct surface` | any two signals collapse together, the rule is flipped to `parameterize`, or a signal is dropped from the inventory (the `coverage shrank` half) |
| `parameterizing metrics-drilldown var-groupby absorbs label churn but still catches real coverage change` | two different label names stop collapsing, `$__all` stops dropping, or the collapse goes hollow — losing the grouped surface entirely is still reported |

## Notes for reviewers

The `values` guard throws rather than degrading, and that is the intent: an undeclared value
means either the app version gained an option (real coverage change, pin it deliberately) or
the rule is miscategorised and must parameterize. Both need a human, and both are cheaper to
see in microseconds than as an unattributed ratchet row.

This does not carry a `Closes` line. #1873 is a different defect (path-segment folds taking
the union across collapsed pages), and #1872's own axis is interaction fragments pinning live
log field names — neither is what this changes, so closing either would hide an open bug.
The `var-primarySignal` / undeclared-option-set defect has no issue of its own.

The pinned inventory still needs its deliberate regeneration for `kind=server`; that lands on
this branch before it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Closes #1873
