### PR TITLE
fix(telemetry): surface rollback failures instead of discarding them

### DIFF
--- a/internal/telemetry/rollback_test.go
+++ b/internal/telemetry/rollback_test.go
@@ -1,0 +1,198 @@
+package telemetry
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	otellog "go.opentelemetry.io/otel/log"
+	lognoop "go.opentelemetry.io/otel/log/noop"
+	"go.opentelemetry.io/otel/metric"
+	metricnoop "go.opentelemetry.io/otel/metric/noop"
+	"go.opentelemetry.io/otel/sdk/resource"
+	"go.opentelemetry.io/otel/trace"
+	tracenoop "go.opentelemetry.io/otel/trace/noop"
+)
+
+// recorder stands in for one provider constructor. It records whether the
+// shutdown it handed back was called, which is how the tests below tell a
+// real rollback from a silently skipped one.
+type recorder struct {
+	// shutdownErr is returned by the shutdown closure, modelling a
+	// teardown that itself fails.
+	shutdownErr error
+
+	shutdownCalls int
+}
+
+func (r *recorder) shutdown(context.Context) error {
+	r.shutdownCalls++
+	return r.shutdownErr
+}
+
+// builders assembles a providerBuilders whose stages succeed until
+// failAt, which fails with failErr. failAt is one of "tracer", "meter",
+// "logger", or "" for an all-succeeding set.
+func builders(tracer, meter, logger *recorder, failAt string, failErr error) providerBuilders {
+	stage := func(name string) error {
+		if name == failAt {
+			return failErr
+		}
+		return nil
+	}
+	return providerBuilders{
+		tracer: func(context.Context, Config, *resource.Resource) (trace.TracerProvider, shutdownFunc, error) {
+			if err := stage("tracer"); err != nil {
+				return nil, nil, err
+			}
+			return tracenoop.NewTracerProvider(), tracer.shutdown, nil
+		},
+		meter: func(context.Context, Config, *resource.Resource) (metric.MeterProvider, shutdownFunc, error) {
+			if err := stage("meter"); err != nil {
+				return nil, nil, err
+			}
+			return metricnoop.NewMeterProvider(), meter.shutdown, nil
+		},
+		logger: func(context.Context, Config, *resource.Resource) (otellog.LoggerProvider, shutdownFunc, error) {
+			if err := stage("logger"); err != nil {
+				return nil, nil, err
+			}
+			return lognoop.NewLoggerProvider(), logger.shutdown, nil
+		},
+	}
+}
+
+// TestNewProviders_RollsBackEarlierStages pins the rollback half of the
+// construction contract: when one stage fails, every stage built before
+// it is torn down exactly once, and no stage after it is built at all.
+func TestNewProviders_RollsBackEarlierStages(t *testing.T) {
+	t.Parallel()
+
+	boom := errors.New("dial refused")
+
+	cases := []struct {
+		failAt string
+		// prefix is the wrapper newProviders puts on the stage error.
+		prefix       string
+		wantTracer   int
+		wantMeter    int
+		wantLogger   int
+		wantShutdown bool
+	}{
+		{failAt: "tracer", prefix: "trace exporter: "},
+		{failAt: "meter", prefix: "metric exporter: ", wantTracer: 1},
+		{failAt: "logger", prefix: "log exporter: ", wantTracer: 1, wantMeter: 1},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.failAt, func(t *testing.T) {
+			t.Parallel()
+
+			tracer, meter, logger := &recorder{}, &recorder{}, &recorder{}
+			p, err := newProviders(t.Context(), Config{Endpoint: "collector:4317"}, resource.Empty(),
+				builders(tracer, meter, logger, tc.failAt, boom))
+			if p != nil {
+				t.Fatalf("providers returned alongside an error: %#v", p)
+			}
+			if !errors.Is(err, boom) {
+				t.Fatalf("error does not wrap the stage failure: %v", err)
+			}
+			if want := tc.prefix + boom.Error(); err.Error() != want {
+				t.Errorf("error = %q, want %q", err, want)
+			}
+			if tracer.shutdownCalls != tc.wantTracer {
+				t.Errorf("tracer shutdown called %d times, want %d", tracer.shutdownCalls, tc.wantTracer)
+			}
+			if meter.shutdownCalls != tc.wantMeter {
+				t.Errorf("meter shutdown called %d times, want %d", meter.shutdownCalls, tc.wantMeter)
+			}
+			// The logger stage is the last one, so its shutdown is never
+			// a rollback target — a call here means a provider was built
+			// after the failure.
+			if logger.shutdownCalls != tc.wantLogger {
+				t.Errorf("logger shutdown called %d times, want %d", logger.shutdownCalls, tc.wantLogger)
+			}
+		})
+	}
+}
+
+// TestNewProviders_RollbackFailureSurfaces is the assertion the discarded
+// `_ = traceShutdown(ctx)` form could not carry: when the rollback itself
+// fails, the goroutine it was meant to stop is still running, so that
+// failure has to reach the caller beside the error that triggered it.
+//
+// Every failing stage that has a stage before it gets its own case. The
+// call-count assertions in TestNewProviders_RollsBackEarlierStages cannot
+// stand in for these: the discarded form still calls each shutdown, so
+// only a rollback that fails distinguishes the two.
+func TestNewProviders_RollbackFailureSurfaces(t *testing.T) {
+	t.Parallel()
+
+	boom := errors.New("dial refused")
+	traceStuck := errors.New("trace batcher still draining")
+	metricStuck := errors.New("metric reader still draining")
+
+	cases := []struct {
+		failAt string
+		// wantWrapped are the errors the returned error must carry: the
+		// cause plus one per rolled-back stage whose teardown failed.
+		wantWrapped []error
+	}{
+		{failAt: "meter", wantWrapped: []error{boom, traceStuck}},
+		{failAt: "logger", wantWrapped: []error{boom, traceStuck, metricStuck}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.failAt, func(t *testing.T) {
+			t.Parallel()
+
+			tracer := &recorder{shutdownErr: traceStuck}
+			meter := &recorder{shutdownErr: metricStuck}
+			logger := &recorder{}
+
+			_, err := newProviders(t.Context(), Config{Endpoint: "collector:4317"}, resource.Empty(),
+				builders(tracer, meter, logger, tc.failAt, boom))
+			if err == nil {
+				t.Fatal("newProviders returned no error")
+			}
+			for _, want := range tc.wantWrapped {
+				if !errors.Is(err, want) {
+					t.Errorf("error %v does not wrap %v", err, want)
+				}
+			}
+			// Each rollback failure is labelled as such, so an operator
+			// reading the startup log can tell them from the cause.
+			wantRollbacks := len(tc.wantWrapped) - 1
+			if got := strings.Count(err.Error(), "rollback: "); got != wantRollbacks {
+				t.Errorf("error %q labels %d rollback failures, want %d", err, got, wantRollbacks)
+			}
+		})
+	}
+}
+
+// TestNewProviders_SuccessKeepsProvidersLive guards the other direction:
+// a fully successful build must not tear anything down, and its Shutdown
+// must reach all three providers.
+func TestNewProviders_SuccessKeepsProvidersLive(t *testing.T) {
+	t.Parallel()
+
+	tracer, meter, logger := &recorder{}, &recorder{}, &recorder{}
+
+	p, err := newProviders(t.Context(), Config{Endpoint: "collector:4317"}, resource.Empty(),
+		builders(tracer, meter, logger, "", nil))
+	if err != nil {
+		t.Fatalf("newProviders: %v", err)
+	}
+	if tracer.shutdownCalls+meter.shutdownCalls+logger.shutdownCalls != 0 {
+		t.Fatalf("a successful build tore providers down: tracer=%d meter=%d logger=%d",
+			tracer.shutdownCalls, meter.shutdownCalls, logger.shutdownCalls)
+	}
+	if err := p.Shutdown(t.Context()); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+	if tracer.shutdownCalls != 1 || meter.shutdownCalls != 1 || logger.shutdownCalls != 1 {
+		t.Errorf("Shutdown reached tracer=%d meter=%d logger=%d, want 1 each",
+			tracer.shutdownCalls, meter.shutdownCalls, logger.shutdownCalls)
+	}
+}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -104,24 +104,70 @@ func New(ctx context.Context, cfg Config) (*Providers, error) {
 		return nil, fmt.Errorf("build resource: %w", err)
 	}
 
-	tp, traceShutdown, err := newTracerProvider(ctx, cfg, res)
+	return newProviders(ctx, cfg, res, defaultProviderBuilders())
+}
+
+// shutdownFunc tears one provider down, flushing whatever it still holds.
+type shutdownFunc func(context.Context) error
+
+// providerBuilders names the three SDK provider constructors newProviders
+// drives, in the order it drives them. New always supplies the real ones;
+// the indirection exists because the OTLP gRPC exporters do not dial
+// eagerly, so a real constructor practically never returns an error and
+// the rollback paths below would otherwise be unreachable from a test.
+type providerBuilders struct {
+	tracer func(context.Context, Config, *resource.Resource) (trace.TracerProvider, shutdownFunc, error)
+	meter  func(context.Context, Config, *resource.Resource) (metric.MeterProvider, shutdownFunc, error)
+	logger func(context.Context, Config, *resource.Resource) (otellog.LoggerProvider, shutdownFunc, error)
+}
+
+// defaultProviderBuilders is the production wiring: real gRPC OTLP
+// exporters behind the SDK providers.
+func defaultProviderBuilders() providerBuilders {
+	return providerBuilders{
+		tracer: newTracerProvider,
+		meter:  newMeterProvider,
+		logger: newLoggerProvider,
+	}
+}
+
+// rollbackProviders tears down the providers built before a later stage
+// failed and folds every teardown failure into cause. A rollback that
+// itself fails leaves running the very goroutine the rollback exists to
+// stop, so that failure has to reach the caller rather than vanish
+// beside the error that triggered it.
+func rollbackProviders(ctx context.Context, cause error, built ...shutdownFunc) error {
+	errs := make([]error, 1, len(built)+1)
+	errs[0] = cause
+	for _, shutdown := range built {
+		if err := shutdown(ctx); err != nil {
+			errs = append(errs, fmt.Errorf("rollback: %w", err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// newProviders builds the three providers in order, rolling back the ones
+// already built as soon as a later one fails so a half-built set never
+// leaks its exporter goroutines.
+func newProviders(
+	ctx context.Context, cfg Config, res *resource.Resource, build providerBuilders,
+) (*Providers, error) {
+	tp, traceShutdown, err := build.tracer(ctx, cfg, res)
 	if err != nil {
 		return nil, fmt.Errorf("trace exporter: %w", err)
 	}
 
-	mp, metricShutdown, err := newMeterProvider(ctx, cfg, res)
+	mp, metricShutdown, err := build.meter(ctx, cfg, res)
 	if err != nil {
-		// Roll back the trace provider so we don't leak a goroutine
-		// when only one of the two could be built.
-		_ = traceShutdown(ctx)
-		return nil, fmt.Errorf("metric exporter: %w", err)
+		return nil, rollbackProviders(ctx, fmt.Errorf("metric exporter: %w", err), traceShutdown)
 	}
 
-	lp, logShutdown, err := newLoggerProvider(ctx, cfg, res)
+	lp, logShutdown, err := build.logger(ctx, cfg, res)
 	if err != nil {
-		_ = traceShutdown(ctx)
-		_ = metricShutdown(ctx)
-		return nil, fmt.Errorf("log exporter: %w", err)
+		return nil, rollbackProviders(
+			ctx, fmt.Errorf("log exporter: %w", err), traceShutdown, metricShutdown,
+		)
 	}
 
 	return &Providers{
@@ -142,7 +188,7 @@ func New(ctx context.Context, cfg Config) (*Providers, error) {
 }
 
 func newTracerProvider(ctx context.Context, cfg Config, res *resource.Resource) (
-	*sdktrace.TracerProvider, func(context.Context) error, error,
+	trace.TracerProvider, shutdownFunc, error,
 ) {
 	opts := []otlptracegrpc.Option{
 		otlptracegrpc.WithEndpoint(cfg.Endpoint),
@@ -169,7 +215,7 @@ func newTracerProvider(ctx context.Context, cfg Config, res *resource.Resource) 
 }
 
 func newMeterProvider(ctx context.Context, cfg Config, res *resource.Resource) (
-	*sdkmetric.MeterProvider, func(context.Context) error, error,
+	metric.MeterProvider, shutdownFunc, error,
 ) {
 	opts := []otlpmetricgrpc.Option{
 		otlpmetricgrpc.WithEndpoint(cfg.Endpoint),
@@ -209,7 +255,7 @@ func newMeterProvider(ctx context.Context, cfg Config, res *resource.Resource) (
 // text format losing structured attributes, and (c) wouldn't work in
 // non-k8s deployments.
 func newLoggerProvider(ctx context.Context, cfg Config, res *resource.Resource) (
-	*sdklog.LoggerProvider, func(context.Context) error, error,
+	otellog.LoggerProvider, shutdownFunc, error,
 ) {
 	opts := []otlploggrpc.Option{
 		otlploggrpc.WithEndpoint(cfg.Endpoint),


### PR DESCRIPTION
When one provider stage of `telemetry.New` failed, the already-built stages were torn down with `_ = traceShutdown(ctx)` — the teardown error went nowhere. A rollback that itself fails leaves running the very exporter goroutine the rollback exists to stop, so that failure has to reach the caller beside the error that triggered it. The `Shutdown` closure a few lines below already got this right with `errors.Join`; the rollback sites now match it.

The sites were also unreachable from a test. The OTLP gRPC exporters do not dial eagerly, so the real constructors practically never return an error. `newProviders` now takes the three constructors as a `providerBuilders` value, and `New` supplies the production wiring — a test can fail a chosen stage and observe the rollback of the stages before it.

**Why the coverage is two tests, not one.** The call-count assertions (`TestNewProviders_RollsBackEarlierStages`) cannot detect the discarded form: `_ = traceShutdown(ctx)` still *calls* the shutdown, it only drops the result. Only a rollback whose teardown fails distinguishes the two, so `TestNewProviders_RollbackFailureSurfaces` carries a case per failing stage that has a stage before it. Verified by mutation: restoring the `_ =` form at the metric site fails the `meter` case, and at the log site fails the `logger` case; restoring both fails both.

A third test pins the other direction — a fully successful build tears nothing down, and its `Shutdown` reaches all three providers.

Closes #1859