### PR TITLE
test(api): assert the ?timeout= budget reaches the ClickHouse query context

### DIFF
--- a/internal/api/reqctx/reqctx_test.go
+++ b/internal/api/reqctx/reqctx_test.go
@@ -1,12 +1,14 @@
 package reqctx_test
 
 import (
+	"context"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/tsouza/cerberus/internal/api/reqctx"
+	"github.com/tsouza/cerberus/internal/chclient"
 )
 
 const (
@@ -29,6 +31,41 @@ func deadlineWithin(t *testing.T, want time.Duration, dl time.Time, ok bool) {
 	}
 }
 
+// budgetInstalled asserts BOTH halves of what ApplyQueryTimeout owes for a
+// positive budget: the context deadline that unblocks the handler, and the
+// chclient carrier that narrows ClickHouse's max_execution_time so the
+// server stops working on a query nobody awaits.
+//
+// The carrier half needs its own assertion because it is invisible from
+// the outside: drop the chclient.WithQueryTimeout call and the deadline
+// still fires, the handler still returns on time, and only ClickHouse's
+// CPU knows the difference.
+func budgetInstalled(t *testing.T, ctx context.Context, want time.Duration) {
+	t.Helper()
+	dl, ok := ctx.Deadline()
+	deadlineWithin(t, want, dl, ok)
+	got, ok := chclient.QueryTimeoutFromContext(ctx)
+	if !ok {
+		t.Fatalf("no chclient query-timeout carrier on the context for budget %s", want)
+	}
+	if got != want {
+		t.Fatalf("carrier holds %s, want %s", got, want)
+	}
+}
+
+// budgetAbsent is the negative control: with no cap from either side,
+// neither half may be installed. Without it, a version that unconditionally
+// installed the carrier would satisfy every other case here.
+func budgetAbsent(t *testing.T, ctx context.Context) {
+	t.Helper()
+	if _, ok := ctx.Deadline(); ok {
+		t.Fatal("expected no deadline when neither default nor ?timeout= caps")
+	}
+	if d, ok := chclient.QueryTimeoutFromContext(ctx); ok {
+		t.Fatalf("expected no query-timeout carrier when nothing caps, got %s", d)
+	}
+}
+
 func TestApplyQueryTimeout_NoParamNoDefault(t *testing.T) {
 	r := httptest.NewRequest("GET", "/query", nil)
 	ctx, cancel, err := reqctx.ApplyQueryTimeout(r, 0)
@@ -36,9 +73,7 @@ func TestApplyQueryTimeout_NoParamNoDefault(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	defer cancel()
-	if _, ok := ctx.Deadline(); ok {
-		t.Fatal("expected no deadline when neither default nor ?timeout= caps")
-	}
+	budgetAbsent(t, ctx)
 }
 
 func TestApplyQueryTimeout_DefaultApplies(t *testing.T) {
@@ -48,8 +83,7 @@ func TestApplyQueryTimeout_DefaultApplies(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	defer cancel()
-	dl, ok := ctx.Deadline()
-	deadlineWithin(t, defBudget, dl, ok)
+	budgetInstalled(t, ctx, defBudget)
 }
 
 func TestApplyQueryTimeout_RequestSmallerWins(t *testing.T) {
@@ -59,8 +93,7 @@ func TestApplyQueryTimeout_RequestSmallerWins(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	defer cancel()
-	dl, ok := ctx.Deadline()
-	deadlineWithin(t, smallBudget, dl, ok)
+	budgetInstalled(t, ctx, smallBudget)
 }
 
 func TestApplyQueryTimeout_DefaultSmallerWins(t *testing.T) {
@@ -70,8 +103,33 @@ func TestApplyQueryTimeout_DefaultSmallerWins(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	defer cancel()
-	dl, ok := ctx.Deadline()
-	deadlineWithin(t, defBudget, dl, ok)
+	budgetInstalled(t, ctx, defBudget)
+}
+
+// TestApplyQueryTimeout_RequestCapsUncappedDefault covers the deployment
+// with no configured default: the request's own ?timeout= is then the only
+// bound, and both halves must still carry it.
+func TestApplyQueryTimeout_RequestCapsUncappedDefault(t *testing.T) {
+	r := httptest.NewRequest("GET", "/query?timeout=1s", nil)
+	ctx, cancel, err := reqctx.ApplyQueryTimeout(r, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer cancel()
+	budgetInstalled(t, ctx, smallBudget)
+}
+
+// TestApplyQueryTimeout_ZeroRequestKeepsDefault pins the upstream reading
+// of `?timeout=0`: zero means "no cap from this source", so the configured
+// default survives rather than being min'd away to nothing.
+func TestApplyQueryTimeout_ZeroRequestKeepsDefault(t *testing.T) {
+	r := httptest.NewRequest("GET", "/query?timeout=0s", nil)
+	ctx, cancel, err := reqctx.ApplyQueryTimeout(r, defBudget)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer cancel()
+	budgetInstalled(t, ctx, defBudget)
 }
 
 // rejectTimeout drives the rejection path for one `?timeout=` value and

--- a/internal/chclient/timeout.go
+++ b/internal/chclient/timeout.go
@@ -170,11 +170,17 @@ func WithQueryTimeout(ctx context.Context, d time.Duration) context.Context {
 	return context.WithValue(ctx, queryTimeoutKey, d)
 }
 
-// queryTimeoutFromContext returns the per-request override installed by
-// WithQueryTimeout, or 0 when none was set.
-func queryTimeoutFromContext(ctx context.Context) time.Duration {
-	d, _ := ctx.Value(queryTimeoutKey).(time.Duration)
-	return d
+// QueryTimeoutFromContext returns the per-request override installed by
+// WithQueryTimeout, and whether one was installed at all.
+//
+// It is exported so the layer that installs the carrier can prove it did.
+// Without a reader, deleting the WithQueryTimeout call in an HTTP handler
+// changes nothing a test can see — the context deadline installed beside
+// it still fires and the handler still unblocks — while ClickHouse keeps
+// burning CPU on a query nobody is waiting for.
+func QueryTimeoutFromContext(ctx context.Context) (time.Duration, bool) {
+	d, ok := ctx.Value(queryTimeoutKey).(time.Duration)
+	return d, ok
 }
 
 // classifyDriverErr maps a raw clickhouse-go driver error onto the typed
@@ -202,7 +208,7 @@ func (c *Client) classifyDriverErr(ctx context.Context, err error) error {
 // override), so querySettings can omit max_execution_time entirely.
 func (c *Client) effectiveQueryTimeout(ctx context.Context) time.Duration {
 	def := c.queryTimeout
-	override := queryTimeoutFromContext(ctx)
+	override, _ := QueryTimeoutFromContext(ctx)
 	switch {
 	case override <= 0:
 		return def


### PR DESCRIPTION
`ApplyQueryTimeout` installs the resolved `?timeout=` budget two ways — a `context.WithTimeout` deadline, and `chclient.WithQueryTimeout`, which narrows ClickHouse's `max_execution_time` so the server aborts with `TIMEOUT_EXCEEDED` (159) instead of running to completion behind an abandoned request.

Only the deadline half was observable. The reader `queryTimeoutFromContext` and its context key were both unexported, so no test outside `internal/chclient` could see the carrier. Delete the `chclient.WithQueryTimeout` line and every test still passed: the deadline fired, the handler unblocked, and the only difference was ClickHouse burning CPU on a query nobody awaited — in production, under load, invisibly.

`chclient` now exports `QueryTimeoutFromContext(ctx) (time.Duration, bool)`. `effectiveQueryTimeout` reads through it, so the unexported duplicate is gone and there is still exactly one reader.

`reqctx` asserts both halves across the cases that differ from each other:

| case | budget | carrier |
| --- | --- | --- |
| no `?timeout=`, default set | default | default |
| `?timeout=` smaller than default | request | request |
| `?timeout=` larger than default | default | default |
| `?timeout=` set, no configured default | request | request |
| `?timeout=0`, default set | default | default |
| neither side caps | none | **none** |

The last row is the negative control: without it, a version that installed the carrier unconditionally would satisfy every other row.

**Verified by mutation.** Replacing `ctx = chclient.WithQueryTimeout(ctx, budget)` with a discard — the compiling equivalent of deleting the line — fails all five positive cases and leaves the negative control green.

Closes #1864