### PR TITLE
docs(engine): record why a subquery is bounded by rejection, not by streaming reduction

### DIFF
--- a/docs/engine.md
+++ b/docs/engine.md
@@ -588,6 +588,20 @@ A short list, because the engine's narrow scope is deliberate:
 - **Not a translator of wire formats.** The handler formats
   `Result.Samples` into the upstream wire shape; the engine never
   touches `http.ResponseWriter`.
+- **Not a streaming subquery reducer.** A PromQL subquery
+  `<reducer>_over_time(<inner>[range:step])` materialises
+  `range/step + 1` anchor rows per series before collapsing them,
+  and the engine bounds that intermediate by refusing the query
+  rather than by fusing the reduction into a single streaming
+  pass. `requireSubquerySampleBudget`
+  (`internal/engine/anchor_budget.go`) measures one series' anchor
+  grid against `Config.MaxQuerySamples` and returns the same
+  Prom-shaped 422 upstream Prometheus returns once a subquery
+  would load more than `query.max-samples` into memory. Fusing the
+  reducer families into streaming passes would serve grids
+  upstream refuses, and a drop-in gateway's answer set is upstream's
+  answer set — so the bound is a rejection, which also keeps one
+  head's grid from exhausting the process the other two share.
 
 These boundaries keep the engine's surface small enough that
 adding a new query head — or a new extension point — is a local


### PR DESCRIPTION
`docs/engine.md`'s **What the engine is not** list answers "why doesn't the engine do X?"
for plan caching, result caching, routing and wire formatting. It did not answer it for the
one boundary a user actually meets at runtime: a PromQL subquery whose anchor grid is too
large comes back as a 422, and nothing in the tree said why that is a rejection rather than
something the engine serves.

The mechanism was already documented at the code — `requireSubquerySampleBudget`
(`internal/engine/anchor_budget.go`) carries a thorough header on how the bound is computed
and why it is per-series. What was missing is the position: the alternative to rejecting is
fusing the reducer families into streaming passes, which would serve grids upstream
Prometheus refuses, and a drop-in gateway's answer set is upstream's answer set.

This adds that as a fifth entry in the same list, in the same voice as the other four, and
points at the function so the rationale and the implementation stay one click apart.

No behaviour change; documentation only.

Closes #1450
