### PR TITLE
fix: decide from the source, not a proxy — timestamp() argument shape and the spans-scan pass-through

### DIFF
--- a/internal/promql/date_fns.go
+++ b/internal/promql/date_fns.go
@@ -12,8 +12,8 @@ import (
 // lowerDateFn maps PromQL date-component functions to their ClickHouse
 // equivalents. Each function takes one instant-vector argument whose
 // `Value` column is interpreted as a Unix timestamp in seconds — except
-// `timestamp(v)`, which reads each sample's `TimeUnix` column and
-// converts it to float seconds.
+// `timestamp(v)`, which ignores `Value` and reports a timestamp chosen by
+// the argument's parser shape (see [timestampResultExpr]).
 //
 // When called without an argument the PromQL spec defaults the input to
 // `vector(time())` — a single instant-vector entry whose value is the
@@ -36,9 +36,12 @@ import (
 //     because CH has no direct `daysInMonth` builtin; the day-of-month
 //     of the last day in the month is the day count for that month.
 //
-//   - `timestamp(v)` ignores `Value` and reads the sample's TimeUnix
-//     column instead, converting the DateTime64(9) to fractional Unix
-//     seconds via `toUnixTimestamp64Nano(TimeUnix) / 1e9`.
+//   - `timestamp(v)` ignores `Value`. For a VECTOR SELECTOR argument it
+//     reads the sample's own TimeUnix column; for every other argument
+//     shape it reads the evaluation instant instead, matching the two
+//     reference implementations ([timestampResultExpr]). Either way the
+//     chosen DateTime64(9) becomes fractional Unix seconds via
+//     `toUnixTimestamp64Nano(<ts>) / 1e9`.
 //
 // Type-coercion note: every CH date-component function (`toYear`,
 // `toMonth`, `toDayOfMonth`, `toDayOfWeek`, `toHour`, `toMinute`)
@@ -63,7 +66,7 @@ func lowerDateFn(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, e
 	if err != nil {
 		return nil, err
 	}
-	newValue := dateFnExpr(c.Func.Name, valueAsDateTime(s), &chplan.ColumnRef{Name: s.TimestampColumn})
+	newValue := dateFnExpr(c.Func.Name, valueAsDateTime(s), timestampResultExpr(c.Args[0], s, ctx))
 	if newValue == nil {
 		return nil, fmt.Errorf("promql: unknown date function %s", c.Func.Name)
 	}
@@ -110,6 +113,72 @@ func lowerDateFnNoArg(name string, s schema.Metrics, ctx lowerCtx) (chplan.Node,
 	return syntheticScalarVector(asFloat64(expr), nil, s, ctx), nil
 }
 
+// timestampResultExpr returns the expression `timestamp(v)` reports as
+// its result, chosen by the PARSER SHAPE of the argument. Reference
+// Prometheus implements `timestamp` twice and the argument's shape —
+// not its value — picks between them:
+//
+//   - `timestamp(<VectorSelector>)` is special-cased by the reference
+//     engine (promql/engine.go, rangeEvalTimestampFunctionOverVectorSelector),
+//     which stamps each output sample with the RAW sample timestamp
+//     (`F: float64(s.T) / 1000`). That is the sample's own `TimeUnix`.
+//   - EVERY other argument shape falls through to `funcTimestamp`, which
+//     returns `float64(enh.Ts) / 1000` — the EVALUATION instant of the
+//     step being computed, with the input sample's own timestamp
+//     discarded.
+//
+// The two answers coincide only when the selected sample sits exactly on
+// the eval instant; under the default 5m lookback they differ by up to
+// the lookback delta, so `timestamp(abs(m))` and `timestamp(m)` are
+// genuinely different queries.
+//
+// The unwrap is load-bearing and mirrors the reference engine's own:
+// upstream peels ParenExpr and StepInvariantExpr before its type test, so
+// `timestamp((m))` and an `@`-pinned `timestamp(m @ 100)` still take the
+// selector branch. [unwrapVectorSelector] peels exactly that pair.
+//
+// The tsRef slot is only consulted by the `timestamp` arm of
+// [dateFnExpr]; every other date function reads `Value`, so the choice
+// made here is inert for them.
+func timestampResultExpr(arg parser.Expr, s schema.Metrics, ctx lowerCtx) chplan.Expr {
+	if _, isSelector := unwrapVectorSelector(arg); isSelector {
+		return &chplan.ColumnRef{Name: s.TimestampColumn}
+	}
+	return evalInstantExpr(s, ctx)
+}
+
+// evalInstantExpr renders the evaluation instant of the step whose row is
+// being projected — Prometheus's `enh.Ts` — for a projection sitting
+// directly above an already-lowered instant vector.
+//
+// In RANGE mode the answer is the sample timestamp column, and that is a
+// structural property of cerberus's range lowering rather than a
+// coincidence: every range-mode source stamps `TimeUnix` with the STEP
+// ANCHOR, not with the underlying sample's own time. [wrapRangeLatestPerSeries]
+// collapses each (series, anchor) bucket and emits the canonical Sample
+// contract with `TimeUnix = anchor_ts`; [wrapRangeAbsoluteAtBroadcast]
+// projects the StepGrid's `anchor_ts` as `TimeUnix`; a RangeWindow does
+// the same for matrix functions. So above any range lowering the
+// timestamp column already IS the eval instant.
+//
+// In INSTANT mode it is not: the instant LWR emits `max(TimeUnix) AS
+// lwr_ts`, i.e. the newest in-window SAMPLE's own timestamp, which is
+// what makes the selector and non-selector forms differ. There the eval
+// instant is the request anchor, rendered as the same literal
+// `toDateTime64(...)` [anchorBaseExpr] gives every other anchor-reading
+// lowering, falling back to `now64(9)` when no anchor was threaded (a
+// plain [Lower] without range threading) — exactly the fallback `time()`
+// uses in the same situation.
+func evalInstantExpr(s schema.Metrics, ctx lowerCtx) chplan.Expr {
+	if ctx.step > 0 {
+		return &chplan.ColumnRef{Name: s.TimestampColumn}
+	}
+	if !ctx.end.IsZero() {
+		return anchorBaseExpr(evalAnchor{End: ctx.end.UTC()})
+	}
+	return anchorBaseExpr(evalAnchor{})
+}
+
 // asFloat64 wraps e in `toFloat64(...)`. Used by the date-function
 // lowerings to coerce CH integer return types (toYear → UInt16,
 // toMonth/toHour/etc → UInt8) into Float64, matching the Sample.Value
@@ -123,7 +192,10 @@ func asFloat64(e chplan.Expr) chplan.Expr {
 // dateFnExpr returns the CH expression that computes the date-component
 // for the given PromQL function name. valueDT is the DateTime expression
 // derived from the input sample's Value (interpreted as Unix seconds);
-// tsRef is the raw `TimeUnix` column reference used by `timestamp(v)`.
+// tsRef is the timestamp expression `timestamp(v)` reports, chosen by the
+// caller from the argument's shape (see [timestampResultExpr]) — the raw
+// `TimeUnix` column for a vector selector, the evaluation instant
+// otherwise. No other date function reads it.
 //
 // Returns nil when name is not a recognised date function — caller
 // translates that into an "unsupported" error.
@@ -164,10 +236,10 @@ func dateFnExpr(name string, valueDT, tsRef chplan.Expr) chplan.Expr {
 	case "minute":
 		return &chplan.FuncCall{Name: "toMinute", Args: []chplan.Expr{valueDT}}
 	case "timestamp":
-		// `timestamp(v)` returns each sample's TimeUnix as float
-		// seconds — NOT a function of Value. Convert the DateTime64(9)
-		// column to nanoseconds (Int64) and divide by 1e9 to get
-		// fractional seconds.
+		// `timestamp(v)` returns tsRef as float seconds — NOT a
+		// function of Value. Convert the DateTime64(9) expression to
+		// nanoseconds (Int64) and divide by 1e9 to get fractional
+		// seconds.
 		return &chplan.Binary{
 			Op:    chplan.OpDiv,
 			Left:  &chplan.FuncCall{Name: "toUnixTimestamp64Nano", Args: []chplan.Expr{tsRef}},

--- a/internal/spansscan/internal_test.go
+++ b/internal/spansscan/internal_test.go
@@ -301,3 +301,76 @@ func TestTopLevelScopeForwardKeepsBrackets(t *testing.T) {
 		}
 	}
 }
+
+// TestWordEndingAt pins the backward-anchored keyword recogniser, whose only
+// logic of its own is the `start < 0` underflow guard: without it, a keyword
+// longer than the text before j computes a negative slice index. The remaining
+// cases confirm it delegates the standalone-token rules to wordAt rather than
+// re-deriving them.
+func TestWordEndingAt(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		sql  string
+		j    int
+		kw   string
+		want bool
+	}{
+		// Keyword ends exactly at j and starts exactly at 0: start == 0, the
+		// boundary the underflow guard must ADMIT. A `<`→`<=` flip rejects it.
+		{"exact_start", "FROM (", 3, "FROM", true},
+		// j sits before the keyword could fit: start == -1. The guard must
+		// reject rather than index negatively.
+		{"underflow", "ROM (", 2, "FROM", false},
+		// Standalone rules still apply through wordAt: an identifier byte in
+		// front means this is not the keyword.
+		{"preceded_by_ident", "xFROM ", 4, "FROM", false},
+		// j must be the keyword's LAST byte, not any byte inside it.
+		{"anchored_at_last_byte", " FROM ", 3, "FROM", false},
+		{"case_insensitive", " from", 4, "FROM", true},
+	}
+	for _, tc := range cases {
+		if got := wordEndingAt(tc.sql, tc.j, tc.kw); got != tc.want {
+			t.Errorf("%s: wordEndingAt(%q, %d, %q) = %v, want %v", tc.name, tc.sql, tc.j, tc.kw, got, tc.want)
+		}
+	}
+}
+
+// TestOwningSelect pins the backward scope walk that decides which SELECT a
+// clause belongs to. Its three branches are all reachable and all load-bearing
+// for the derived-table verdict: a `)` opens a nested group that must be
+// skipped WHOLE (else a subquery's own SELECT is mistaken for the owner), a `(`
+// at depth zero means the enclosing scope opened with no intervening SELECT
+// (there is no owner), and a depth-zero SELECT is the answer.
+func TestOwningSelect(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		sql  string
+		// i is the offset whose owning SELECT is sought; want is the expected
+		// SELECT offset, or -1 for none.
+		i, want int
+	}{
+		// Plain case: the only SELECT precedes i at the same depth.
+		{"same_depth", "SELECT a FROM t", 9, 0},
+		// A completed subquery sits between i and the real owner. Scanning
+		// back, its `)` must open a skip that swallows its `SELECT` whole —
+		// without the depth counter the inner SELECT (offset 21) would win.
+		{"skips_nested_group", "SELECT a FROM x WHERE (SELECT 1) AND b FROM t", 39, 0},
+		// i sits directly inside a bracket that no SELECT opened — a function
+		// argument list or a bracketed conjunct. The `(` is met at depth 0, so
+		// there is no owning SELECT to report.
+		{"paren_without_select", "SELECT f(a FROM t)", 11, -1},
+		// No SELECT anywhere before i.
+		{"none", "FROM t", 5, -1},
+		// The owning SELECT is at offset 0 — the statement root. This is the
+		// value derivedTableScan must then classify as NOT a derived table,
+		// so it has to be distinguishable from the -1 "no owner" answer.
+		{"root_select", "SELECT * FROM `otel_traces`", 9, 0},
+	}
+	for _, tc := range cases {
+		if got := owningSelect(tc.sql, tc.i); got != tc.want {
+			t.Errorf("%s: owningSelect(%q, %d) = %d, want %d", tc.name, tc.sql, tc.i, got, tc.want)
+		}
+	}
+}

--- a/internal/spansscan/internal_test.go
+++ b/internal/spansscan/internal_test.go
@@ -336,6 +336,47 @@ func TestWordEndingAt(t *testing.T) {
 	}
 }
 
+// TestPrecedingToken pins the backward skip that finds the token introducing a
+// derived table's `SELECT`. Its return value is asserted EXACTLY rather than
+// through derivedTableScan, because two of its branches are invisible from
+// there: an answer of 0 and an answer of -1 both make wordEndingAt reject (a
+// four-byte keyword cannot end at offset 0), so only a direct assertion can tell
+// "the token starts at the very first byte" from "there is no token".
+func TestPrecedingToken(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		sql  string
+		sel  int
+		want int
+	}{
+		// Ordinary case: `FROM (SELECT` — the run of `(` and spaces is skipped
+		// and the `M` ending `FROM` is returned.
+		{"skips_paren_and_space", "FROM (SELECT", 6, 3},
+		// Nested set-op group `FROM ((SELECT` — every opening parenthesis in the
+		// run is skipped, so the outermost bracket is recognised.
+		{"skips_paren_run", "FROM ((SELECT", 7, 3},
+		// Tabs and newlines are skippable too, not just spaces.
+		{"skips_tab_and_newline", "JOIN\t\n(SELECT", 7, 3},
+		// The token ends at the very FIRST byte. Answering 0 rather than -1 is
+		// what a `k >= 0` → `k > 0` boundary would get wrong, and the two are
+		// indistinguishable downstream.
+		{"token_at_offset_zero", "x (SELECT", 3, 0},
+		// Only skippable bytes precede sel → no token.
+		{"only_skippable", " ((SELECT", 3, -1},
+		// sel at the statement root: nothing precedes it at all.
+		{"root_select", "SELECT * FROM t", 0, -1},
+		// owningSelect found no owner; the negative offset passes straight
+		// through rather than indexing out of range.
+		{"no_owning_select", "FROM t", -1, -1},
+	}
+	for _, tc := range cases {
+		if got := precedingToken(tc.sql, tc.sel); got != tc.want {
+			t.Errorf("%s: precedingToken(%q, %d) = %d, want %d", tc.name, tc.sql, tc.sel, got, tc.want)
+		}
+	}
+}
+
 // TestOwningSelect pins the backward scope walk that decides which SELECT a
 // clause belongs to. Its three branches are all reachable and all load-bearing
 // for the derived-table verdict: a `)` opens a nested group that must be

--- a/internal/spansscan/spansscan.go
+++ b/internal/spansscan/spansscan.go
@@ -323,27 +323,34 @@ func opensSubquery(sql string, j int) bool {
 // `SELECT *` carrying a `REPLACE` / `EXCEPT` modifier and any whitespace change
 // all leave the verdict untouched.
 //
-// The owning `SELECT` is located by owningSelect; whitespace and any run of
-// opening parentheses before it are then skipped so a set-op group
-// (`FROM ((SELECT …) UNION ALL (SELECT …))`) is recognised at its outermost
-// bracket — the backward mirror of what opensSubquery does forward. A `SELECT`
-// reached from `AS` (a CTE body, which is every `WITH RECURSIVE` arm) or from
-// the statement root is NOT a derived table: nothing encloses it that ClickHouse
-// could push a window in from.
+// The owning `SELECT` is located by owningSelect and the token in front of it by
+// precedingToken, which skips whitespace and any run of opening parentheses so a
+// set-op group (`FROM ((SELECT …) UNION ALL (SELECT …))`) is recognised at its
+// outermost bracket — the backward mirror of what opensSubquery does forward. A
+// `SELECT` reached from `AS` (a CTE body, which is every `WITH RECURSIVE` arm)
+// or from the statement root is NOT a derived table: nothing encloses it that
+// ClickHouse could push a window in from. Both "no owning SELECT" and "nothing
+// in front of it" arrive as a negative offset, which wordEndingAt rejects, so
+// neither needs a guard of its own.
 func derivedTableScan(sql string, i int) bool {
-	sel := owningSelect(sql, i)
-	if sel < 0 {
-		return false
-	}
+	k := precedingToken(sql, owningSelect(sql, i))
+	return wordEndingAt(sql, k, "FROM") || wordEndingAt(sql, k, "JOIN")
+}
+
+// precedingToken returns the offset of the last byte before sel that is neither
+// whitespace nor an opening parenthesis — the end of the token that introduces
+// the `SELECT` at sel. It returns -1 when sel is not positive, or when only
+// skippable bytes precede it: the same "no keyword here" answer wordEndingAt
+// gives for a negative offset, so callers need no separate empty case.
+func precedingToken(sql string, sel int) int {
 	for k := sel - 1; k >= 0; k-- {
 		switch sql[k] {
 		case ' ', '\t', '\n', '\r', '(':
 			continue
-		default:
-			return wordEndingAt(sql, k, "FROM") || wordEndingAt(sql, k, "JOIN")
 		}
+		return k
 	}
-	return false
+	return -1
 }
 
 // owningSelect returns the byte offset of the `SELECT` keyword that owns the

--- a/internal/spansscan/spansscan.go
+++ b/internal/spansscan/spansscan.go
@@ -67,34 +67,21 @@ var (
 	reTimestampCmp = regexp.MustCompile("`Timestamp`\\s*(>=|<=|>|<|=)|(>=|<=|>|<|=)\\s*`Timestamp`")
 )
 
-// tableRegexps bundles the two spans-table-name-dependent matchers.
-type tableRegexps struct {
-	// spansFrom matches every physical scan of the spans table —
-	// `FROM `otel_traces`` and `FROM `otel_traces` AS t`.
-	spansFrom *regexp.Regexp
-	// passthroughFrom matches the plain pass-through wrapper
-	// `SELECT * FROM `otel_traces`` (submatch 1 = the FROM token). This is the
-	// matrix-family / seed-leaf shape: a Timestamp predicate on the wrapper's
-	// own (or the enclosing) scope DOES push into this scan, so it is excluded.
-	passthroughFrom *regexp.Regexp
-}
-
-// regexpCache memoises the per-table compiled regexps so the emit chokepoint
-// (which runs on every query, almost always with the same default table) does
-// not recompile on each call. Keyed by spans-table name; value is tableRegexps.
+// regexpCache memoises the per-table compiled `FROM <spans table>` matcher so
+// the emit chokepoint (which runs on every query, almost always with the same
+// default table) does not recompile on each call. Keyed by spans-table name;
+// value is *regexp.Regexp.
 var regexpCache sync.Map
 
-func regexpsFor(spansTable string) tableRegexps {
+// spansFromRegexp returns the matcher for every physical scan of the spans
+// table — `FROM `otel_traces“ and `FROM `otel_traces` AS t`.
+func spansFromRegexp(spansTable string) *regexp.Regexp {
 	if v, ok := regexpCache.Load(spansTable); ok {
-		return v.(tableRegexps)
+		return v.(*regexp.Regexp)
 	}
-	q := regexp.QuoteMeta(spansTable)
-	tr := tableRegexps{
-		spansFrom:       regexp.MustCompile("FROM\\s+`" + q + "`"),
-		passthroughFrom: regexp.MustCompile("SELECT\\s+\\*\\s+(FROM\\s+`" + q + "`)"),
-	}
-	regexpCache.Store(spansTable, tr)
-	return tr
+	re := regexp.MustCompile("FROM\\s+`" + regexp.QuoteMeta(spansTable) + "`")
+	regexpCache.Store(spansTable, re)
+	return re
 }
 
 // UnwindowedSpansScans returns every physical scan of spansTable in sql that
@@ -109,9 +96,9 @@ func regexpsFor(spansTable string) tableRegexps {
 //     metrics grid's toDateTime64) — there is nothing to push down, so the
 //     unbounded concern belongs to the resource-bound gate, not this
 //     partition-pruning matcher;
-//   - the scan is a pass-through wrapper (`SELECT * FROM <spans table>`), whose
-//     enclosing-scope Timestamp predicate pushes in and prunes (the validated
-//     matrix-family wrapper shape);
+//   - the scan is the table of a DERIVED TABLE — a subquery in `FROM (…)` /
+//     `JOIN (…)` position — whose enclosing-scope Timestamp predicate pushes in
+//     and prunes (the validated matrix-family wrapper and seed-leaf shape);
 //   - the scan carries a co-scope `Timestamp` comparison (already prunes);
 //   - the SQL contains no scan of spansTable at all.
 //
@@ -147,22 +134,14 @@ func UnwindowedSpansScans(sql, spansTable string) []Finding {
 		return nil
 	}
 
-	tr := regexpsFor(spansTable)
-
-	// Pass-through wrappers (`SELECT * FROM <spans table>`) are pruning-safe;
-	// record their FROM offsets so they are excluded.
-	passthrough := make(map[int]struct{})
-	for _, m := range tr.passthroughFrom.FindAllStringSubmatchIndex(sql, -1) {
-		// m[2] = start of submatch 1 (the FROM token).
-		passthrough[m[2]] = struct{}{}
-	}
-
 	recBodies := recursiveBodySpans(sql)
 
 	var out []Finding
-	for _, m := range tr.spansFrom.FindAllStringIndex(sql, -1) {
+	for _, m := range spansFromRegexp(spansTable).FindAllStringIndex(sql, -1) {
 		from := m[0]
-		if _, ok := passthrough[from]; ok {
+		if derivedTableScan(sql, from) {
+			// A derived table is a bare relational operand: an enclosing-scope
+			// Timestamp predicate pushes through it and prunes. Fine.
 			continue
 		}
 		scope := topLevelScopeForward(sql, from)
@@ -317,6 +296,91 @@ func opensSubquery(sql string, j int) bool {
 		}
 	}
 	return false
+}
+
+// derivedTableScan reports whether the physical scan whose `FROM` token begins
+// at byte offset i belongs to a DERIVED TABLE — a subquery sitting in a table
+// position, `FROM (SELECT …)` or `JOIN (SELECT …)`.
+//
+// That position IS the pruning-safe pass-through shape: a derived table is a
+// bare relational operand, so a `Timestamp` predicate in the ENCLOSING scope
+// pushes through it and prunes this scan's partitions. Deciding it by position
+// replaces an exclusion keyed on ONE literal rendering of that wrapper
+// (`SELECT\s+\*\s+FROM\s+`<table>“), which made the guard's verdict a function
+// of the emitter's projection spelling and was wrong in both directions:
+//
+//   - FALSE POSITIVE. The optimizer's late-materialisation rule rewrote a
+//     wrapper from `SELECT *` into an explicit column list, the exclusion
+//     stopped matching, and a pruning-safe scan was flagged as unbounded — a
+//     500 on a live surface (#1889).
+//   - FALSE NEGATIVE. A genuinely unwindowed scan that KEPT the `SELECT *`
+//     spelling — a `WITH RECURSIVE … AS (SELECT * FROM <table> …)` arm, or a
+//     top-level `SELECT * FROM <table> … GROUP BY …` — was skipped by the guard
+//     entirely, which is the whole-table read it exists to stop (#1109).
+//
+// A projection list is a rendering choice; a table position is structure. Only
+// structure may decide this, so an added alias, an explicit column list, a
+// `SELECT *` carrying a `REPLACE` / `EXCEPT` modifier and any whitespace change
+// all leave the verdict untouched.
+//
+// The owning `SELECT` is located by owningSelect; whitespace and any run of
+// opening parentheses before it are then skipped so a set-op group
+// (`FROM ((SELECT …) UNION ALL (SELECT …))`) is recognised at its outermost
+// bracket — the backward mirror of what opensSubquery does forward. A `SELECT`
+// reached from `AS` (a CTE body, which is every `WITH RECURSIVE` arm) or from
+// the statement root is NOT a derived table: nothing encloses it that ClickHouse
+// could push a window in from.
+func derivedTableScan(sql string, i int) bool {
+	sel := owningSelect(sql, i)
+	if sel < 0 {
+		return false
+	}
+	for k := sel - 1; k >= 0; k-- {
+		switch sql[k] {
+		case ' ', '\t', '\n', '\r', '(':
+			continue
+		default:
+			return wordEndingAt(sql, k, "FROM") || wordEndingAt(sql, k, "JOIN")
+		}
+	}
+	return false
+}
+
+// owningSelect returns the byte offset of the `SELECT` keyword that owns the
+// clause at offset i — the nearest preceding `SELECT` sitting at i's OWN
+// parenthesis depth. Scanning backwards, a `)` opens a nested group that must be
+// skipped whole and a `(` closes one; a `(` met at depth zero means the
+// enclosing scope opened without an intervening `SELECT`, so there is no owning
+// SELECT to report. Returns -1 when none is found.
+func owningSelect(sql string, i int) int {
+	depth := 0
+	for j := i - 1; j >= 0; j-- {
+		switch sql[j] {
+		case ')':
+			depth++
+		case '(':
+			if depth == 0 {
+				return -1
+			}
+			depth--
+		default:
+			if depth == 0 && wordAt(sql, j, "SELECT") {
+				return j
+			}
+		}
+	}
+	return -1
+}
+
+// wordEndingAt reports whether the standalone keyword kw ENDS at sql[j]
+// (inclusive) — the backward-scan counterpart of wordAt, which anchors at a
+// keyword's first byte instead.
+func wordEndingAt(sql string, j int, kw string) bool {
+	start := j - len(kw) + 1
+	if start < 0 {
+		return false
+	}
+	return wordAt(sql, start, kw)
 }
 
 // setOpBoundaryAt reports whether a set-operation arm boundary begins at sql[j]:

--- a/internal/spansscan/spansscan_test.go
+++ b/internal/spansscan/spansscan_test.go
@@ -110,12 +110,12 @@ const metricsWindowRecursiveUnwindowed = "SELECT `anchor_ts`, sum(in_window) AS 
 	"WHERE `Timestamp` > toDateTime64('2026-06-27 14:43:12.000000000', 9) AND `Timestamp` <= toDateTime64('2026-06-27 15:13:12.000000000', 9) " +
 	"GROUP BY `anchor_ts`"
 
-// matrixFamilyWrapper is the CONFIRMED-FINE range-window matrix shape: a plain
-// pass-through `(SELECT * FROM otel_traces WHERE …)` whose Timestamp window sits
-// on the enclosing wrapper — CH pushes it into the scan. The outer GROUP BY must
-// NOT cause a flag, because the scan is a `SELECT *` pass-through. Renders its
-// window as toDateTime64, so it also pins that the broadened precondition does
-// not over-fire on the pass-through shape.
+// matrixFamilyWrapper is the CONFIRMED-FINE range-window matrix shape: a derived
+// table `(SELECT * FROM otel_traces WHERE …)` whose Timestamp window sits on the
+// enclosing wrapper — CH pushes it into the scan. The outer GROUP BY must NOT
+// cause a flag, because the scan sits in a derived table. Renders its window as
+// toDateTime64, so it also pins that the broadened precondition does not
+// over-fire on the derived-table shape.
 const matrixFamilyWrapper = "SELECT `anchor_ts`, toFloat64(sum(in_window)) / 300 AS `Value` " +
 	"FROM (SELECT arrayJoin(range(0, 61)) AS `anchor_ts`, 1 AS `in_window` " +
 	"FROM (SELECT * FROM `otel_traces` WHERE (`ParentSpanId` = ?)) WHERE `Timestamp` > toDateTime64('2026-06-27 14:43:12.000000000', 9) AND `Timestamp` <= toDateTime64('2026-06-27 15:13:12.000000000', 9)) " +
@@ -393,11 +393,10 @@ const recursiveArmBracketedWindow = "WITH RECURSIVE _struct_closure_1 AS (" +
 // columnPrunedSeedInRecursiveBody is the #1889 production shape: the nested-set
 // numbering CTE's `TraceId IN (<seed>)` list holds a union of three seed arms,
 // and the optimizer's late-materialisation rewrite has replaced one arm's
-// `SELECT *` pass-through with an explicit column list. That arm is a fully
-// windowed physical scan carrying its own bracketed `Timestamp` bounds, but it
-// no longer matches the `SELECT *` pass-through exclusion — so the ONLY thing
-// that can clear it is reading its own bracketed WHERE as co-scope. It must NOT
-// be flagged.
+// `SELECT *` projection with an explicit column list. That arm is a fully
+// windowed physical scan carrying its own bracketed `Timestamp` bounds, and it
+// is cleared by reading that bracketed WHERE as co-scope — independently of the
+// derived-table exclusion, which also covers it. It must NOT be flagged.
 const columnPrunedSeedInRecursiveBody = "WITH RECURSIVE _cerberus_ns_paths AS (" +
 	"SELECT `TraceId`, `SpanId`, `ParentSpanId`, 0 AS `_depth` FROM `otel_traces` " +
 	"WHERE `ParentSpanId` = '' AND `TraceId` IN (" +
@@ -514,6 +513,77 @@ func TestUnwindowedSpansScans_BracketingDoesNotChangeVerdict(t *testing.T) {
 						tc.name, depth, got, tc.want, sql)
 				}
 				wrapped = "(" + wrapped + ")"
+			}
+		})
+	}
+}
+
+// The three fixtures below pin that pass-through membership is decided by the
+// scan's TABLE POSITION and never by the wrapper's projection spelling (#1912).
+// Each fails under the superseded `SELECT\s+\*\s+FROM` exclusion, and they fail
+// in OPPOSITE directions, so neither a blanket exclusion nor a blanket flag can
+// satisfy the set.
+
+// columnListedDerivedTableSeed is a recursive anchor arm whose seed derived
+// table carries an EXPLICIT COLUMN LIST and no window of its own; the window
+// sits on the enclosing arm. The scan is a bare relational operand, so CH pushes
+// that window in and prunes — it must NOT be flagged. Under the projection-
+// keyed exclusion the wrapper stopped matching the moment late materialisation
+// dropped the `*`, and this pruning-safe scan was reported as unbounded, taking
+// a live query off the wire (#1889).
+const columnListedDerivedTableSeed = "WITH RECURSIVE _closure AS (" +
+	"SELECT `TraceId`, `SpanId`, 0 AS _depth " +
+	"FROM (SELECT `TraceId`, `SpanId`, `ParentSpanId` FROM `otel_traces`) AS _seed " +
+	"WHERE `Timestamp` >= fromUnixTimestamp64Nano(1782571392000000000) AND `Timestamp` <= fromUnixTimestamp64Nano(1782573192000000000) " +
+	"UNION ALL " +
+	"SELECT t.`TraceId`, t.`SpanId`, c._depth + 1 " +
+	"FROM `otel_traces` AS t INNER JOIN _closure AS c ON t.`TraceId` = c.`TraceId` " +
+	"WHERE c._depth < 128 AND `Timestamp` >= fromUnixTimestamp64Nano(1782571392000000000)" +
+	") SELECT `TraceId`, `SpanId` FROM _closure"
+
+// starProjectedRecursiveArm is the mirror image: a genuinely windowless scan
+// that WEARS the `SELECT *` spelling while sitting as a recursive CTE arm, not
+// as a derived table. Nothing encloses a CTE body that CH could push a window in
+// from, so this closure reads the whole table and MUST be flagged. The
+// projection-keyed exclusion skipped it on the strength of its `*` alone — the
+// whole-table read the guard exists to stop (#1109).
+const starProjectedRecursiveArm = "WITH RECURSIVE _closure AS (" +
+	"SELECT * FROM `otel_traces` WHERE `ParentSpanId` = '' " +
+	"UNION ALL " +
+	"SELECT t.`TraceId`, t.`SpanId`, c._depth + 1 " +
+	"FROM `otel_traces` AS t INNER JOIN _closure AS c ON t.`TraceId` = c.`TraceId` " +
+	"WHERE c._depth < 128 AND `Timestamp` >= fromUnixTimestamp64Nano(1782571392000000000)" +
+	") SELECT `TraceId`, `SpanId` FROM _closure"
+
+// starProjectedRootGroupBy puts the same `SELECT *` spelling at the STATEMENT
+// ROOT, above a `GROUP BY` and a windowed `TraceId IN (<seed>)`. The seed is
+// inert for pruning and the root scan has no enclosing scope at all, so the
+// aggregation runs over the whole table and it MUST be flagged — the GROUP BY
+// leg of the same false negative.
+const starProjectedRootGroupBy = "SELECT * FROM `otel_traces` " +
+	"WHERE `TraceId` IN (SELECT `TraceId` FROM `otel_traces` WHERE `Timestamp` >= fromUnixTimestamp64Nano(1782571392000000000)) " +
+	"GROUP BY `TraceId`"
+
+// TestUnwindowedSpansScans_PassThroughIsPositional pins that the derived-table
+// position, not the projection list, decides the pass-through exclusion.
+func TestUnwindowedSpansScans_PassThroughIsPositional(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		sql  string
+		want int
+	}{
+		{"column_listed_derived_table_seed", columnListedDerivedTableSeed, 0},
+		{"star_projected_recursive_arm", starProjectedRecursiveArm, 1},
+		{"star_projected_root_group_by", starProjectedRootGroupBy, 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := len(spansscan.UnwindowedSpansScans(tc.sql, spansTable))
+			if got != tc.want {
+				t.Fatalf("UnwindowedSpansScans(%s): got %d finding(s), want %d — pass-through membership must follow the scan's table position, not its projection spelling\nSQL:\n%s",
+					tc.name, got, tc.want, tc.sql)
 			}
 		})
 	}

--- a/test/perf/cardinality-baseline/promql/timestamp_of_parenthesised_metric.json
+++ b/test/perf/cardinality-baseline/promql/timestamp_of_parenthesised_metric.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/timestamp_of_parenthesised_metric",
+  "fan_factor": 1,
+  "scan_rows": 1,
+  "peak_intermediate": 1,
+  "has_cross_join": false,
+  "has_array_join": false,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/cardinality-baseline/promql/timestamp_of_transformed_metric.json
+++ b/test/perf/cardinality-baseline/promql/timestamp_of_transformed_metric.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/timestamp_of_transformed_metric",
+  "fan_factor": 1,
+  "scan_rows": 1,
+  "peak_intermediate": 1,
+  "has_cross_join": false,
+  "has_array_join": false,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/solver-decision-baseline/timestamp_of_parenthesised_metric.json
+++ b/test/perf/solver-decision-baseline/timestamp_of_parenthesised_metric.json
@@ -1,0 +1,10 @@
+{
+  "query": "timestamp_of_parenthesised_metric",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "5m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/timestamp_of_transformed_metric.json
+++ b/test/perf/solver-decision-baseline/timestamp_of_transformed_metric.json
@@ -1,0 +1,10 @@
+{
+  "query": "timestamp_of_transformed_metric",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "5m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/spec/promql/timestamp_of_parenthesised_metric.txtar
+++ b/test/spec/promql/timestamp_of_parenthesised_metric.txtar
@@ -1,0 +1,42 @@
+-- query.promql --
+timestamp((any_metric))
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('any_metric', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 42.0);
+-- expected_rows --
+[
+  ["", {"host": "a"}, "2026-01-01T00:00:00Z", 1767225600]
+]
+-- args --
+[0] string = ""
+[1] float64 = 1e+09
+[2] string = "service.name"
+[3] string = "service_name"
+[4] string = "service.name"
+[5] string = "service_name"
+[6] string = ""
+[7] string = "service_name"
+[8] string = "any_metric"
+[9] string = "any.metric"
+[10] string = "any/metric"
+[11] string = "2026-01-01 00:00:01.000000000"
+[12] int64 = 9
+[13] string = "2026-01-01 00:00:01.000000000"
+[14] int64 = 9
+[15] int64 = 300000000000
+-- chplan --
+Project ["" AS MetricName, Attributes, TimeUnix, toFloat64((toUnixTimestamp64Nano(TimeUnix) / 1e+09)) AS Value]
+  Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+    Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+      Filter predicate=((TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9)) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+        Project [MetricName AS MetricName, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, Value AS Value]
+          Filter predicate=(MetricName IN ("any_metric", "any.metric", "any/metric"))
+            Scan(merge(otel_metrics_gauge|otel_metrics_sum))
+-- sql --
+SELECT ? AS `MetricName`, `Attributes`, `TimeUnix`, toFloat64((toUnixTimestamp64Nano(`TimeUnix`) / toFloat64(?))) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') WHERE (`MetricName` IN (?, ?, ?)))) WHERE ((`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?))))) GROUP BY `MetricName`, `Attributes`))

--- a/test/spec/promql/timestamp_of_transformed_metric.txtar
+++ b/test/spec/promql/timestamp_of_transformed_metric.txtar
@@ -1,0 +1,46 @@
+-- query.promql --
+timestamp(abs(any_metric))
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('any_metric', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 42.0);
+-- expected_rows --
+[
+  ["", {"host": "a"}, "2026-01-01T00:00:00Z", 1767225601]
+]
+-- args --
+[0] string = ""
+[1] string = "2026-01-01 00:00:01.000000000"
+[2] int64 = 9
+[3] float64 = 1e+09
+[4] string = ""
+[5] string = "service.name"
+[6] string = "service_name"
+[7] string = "service.name"
+[8] string = "service_name"
+[9] string = ""
+[10] string = "service_name"
+[11] string = "any_metric"
+[12] string = "any.metric"
+[13] string = "any/metric"
+[14] string = "2026-01-01 00:00:01.000000000"
+[15] int64 = 9
+[16] string = "2026-01-01 00:00:01.000000000"
+[17] int64 = 9
+[18] int64 = 300000000000
+-- chplan --
+Project ["" AS MetricName, Attributes, TimeUnix, toFloat64((toUnixTimestamp64Nano(toDateTime64("2026-01-01 00:00:01.000000000", 9)) / 1e+09)) AS Value]
+  Project ["" AS MetricName, Attributes, TimeUnix, abs(Value) AS Value]
+    Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+      Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+        Filter predicate=((TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9)) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+          Project [MetricName AS MetricName, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, Value AS Value]
+            Filter predicate=(MetricName IN ("any_metric", "any.metric", "any/metric"))
+              Scan(merge(otel_metrics_gauge|otel_metrics_sum))
+-- sql --
+SELECT ? AS `MetricName`, `Attributes`, `TimeUnix`, toFloat64((toUnixTimestamp64Nano(toDateTime64(?, ?)) / toFloat64(?))) AS `Value` FROM (SELECT ? AS `MetricName`, `Attributes`, `TimeUnix`, abs(`Value`) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') WHERE (`MetricName` IN (?, ?, ?)))) WHERE ((`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?))))) GROUP BY `MetricName`, `Attributes`)))


### PR DESCRIPTION
Two independent decision bugs, each of which read a proxy for the thing it
actually needed to know.

## `timestamp()` of a non-selector returned the sample instant (#1845)

Reference Prometheus splits `timestamp` in two. A vector-selector argument takes
`rangeEvalTimestampFunctionOverVectorSelector` and reports the raw sample
timestamp; every other argument shape falls through to `funcTimestamp` and
reports the evaluation instant, because the sample it is handed has already been
through a transform and its own timestamp is not the answer.

`lowerDateFn` passed `s.TimestampColumn` as `tsRef` unconditionally, so
`timestamp(abs(m))` reported when the sample was written and disagreed with
Prometheus by the sample's age. The reference is now chosen from the argument's
own parser shape, unwrapped through `ParenExpr` and `StepInvariantExpr` by the
package's existing `unwrapVectorSelector` — the same unwrap upstream performs
before its own type test — so `timestamp((m))` keeps the selector fast path.

The substitution only bites in instant mode. Instant-mode LWR emits
`max(TimeUnix) AS lwr_ts`, the raw sample timestamp, so the column must be
replaced with the eval anchor. Range mode already stamps `TimeUnix` with the
step anchor at every source (`RangeLWR` emits `TimeUnix = anchor_ts`, the
absolute-at broadcast projects `anchor_ts AS TimeUnix`, `RangeWindow` likewise),
so the column already is the eval instant there and is kept.

**Tests.** `test/spec/promql/timestamp_of_transformed_metric.txtar` seeds a
sample at `00:00:00` and evaluates at `00:00:01`, so the two candidate answers
differ by a whole second and the chDB round-trip can discriminate them; it
expects `1767225601`, the eval instant.
`timestamp_of_parenthesised_metric.txtar` expects `1767225600`, the sample
instant, pinning that the unwrap holds. The pre-existing
`timestamp_of_metric.txtar` golden is byte-identical after the change, which is
the evidence that the selector path is untouched.

**Mutation check.** Reverting `timestampResultExpr` to the unconditional
`s.TimestampColumn` makes `timestamp_of_transformed_metric` fail on both its
`chplan` cell and its `expected_rows` cell, reporting `1767225600` where
`1767225601` is expected — it names the defect rather than a shape mismatch.
Reverting the unwrap (testing the raw argument type) makes
`timestamp_of_parenthesised_metric` fail the other way.

## The spans-scan pass-through exclusion was keyed on SQL spelling (#1912)

The unbounded-spans-scan guard excluded pruning-safe wrappers by matching one
literal rendering of them, `SELECT\s+\*\s+FROM\s+`<table>``, making a
partition-pruning verdict a function of the emitter's projection spelling. It was
wrong in both directions: late materialisation rewriting a wrapper's `SELECT *`
into an explicit column list stopped the exclusion matching and took a
pruning-safe query off the wire with a 500 (#1889), while a genuinely windowless
scan that KEPT the `*` — a `WITH RECURSIVE … AS (SELECT * FROM <table> …)` arm,
or a root `SELECT * FROM <table> … GROUP BY …` — was skipped on the strength of
its projection alone, which is the whole-table read the guard exists to stop
(#1109).

**Route taken, and why.** The brief asked for the plan if the call sites can
reach it. They cannot. `spansscan` is a stdlib-only leaf declared in
`.go-arch-lint.yml` with no `mayDependOn`, existing precisely so `chsql` and
`perf/fanout` can both import it without importing each other; adding a `chplan`
dependency would reintroduce the cycle that package was carved out to break. Four
of its five call sites (`GuardEmittedSQL`, `guardedQuerier.guard`,
`lintUnwindowedSpansScan`, `EmitMetricsExemplars`) hold only a SQL string, and
`chsql.Emit` — the one that has the plan — calls the guard after `e.b.String()`.
So the decision stays textual, but it now reads **structure** instead of
spelling: is the scan the table of a derived table, a subquery in `FROM (…)` /
`JOIN (…)` position? That position is what makes the shape pruning-safe — a
derived table is a bare relational operand, so an enclosing-scope `Timestamp`
predicate pushes through it, whereas a `SELECT` reached from `AS` (a CTE body,
which is every recursive arm) or from the statement root has no enclosing scope
to push from. The projection list no longer participates.

**What the corpus said.** Removing the exclusion outright left
`internal/perf/fanout`, `internal/traceql`, `internal/promql`, `internal/logql`,
`internal/chsql` and `internal/optimizer` green but broke
`TestMetricsRecursiveArmWindowed` in `internal/api/tempo` on a real emitted
metrics-exemplars query, whose recursive anchor arm reads
`FROM (SELECT * FROM `otel_traces` WHERE ?) AS _seed` with no Timestamp
predicate. Real seeds are genuinely unwindowed, so the exclusion is load-bearing
for a live shape rather than merely a spelling shortcut — which is why this
change preserves every existing verdict rather than tightening semantics. That
test passes unchanged.

**Tests.** `TestUnwindowedSpansScans_PassThroughIsPositional` fails in **both**
directions, so neither a blanket exclusion nor a blanket flag satisfies it:
`column_listed_derived_table_seed` (a derived table with an explicit column list
and no window of its own) must not be flagged, while `star_projected_recursive_arm`
and `star_projected_root_group_by` (the same `SELECT *` spelling as a recursive
CTE arm and at the statement root above a `GROUP BY`) must be.
`TestOwningSelect` and `TestWordEndingAt` pin the new helpers' branches in
`internal_test.go`, matching the package's existing per-helper style.

**Mutation check.** Replacing `derivedTableScan`'s body with the superseded
`SELECT\s+\*\s+$` spelling test fails all three cases — `got 1 finding(s), want
0` for the derived-table case and `got 0 finding(s), want 1` for the other two —
and the message names the defect ("pass-through membership must follow the scan's
table position, not its projection spelling"). No generated artefact changes,
because the guard inspects emitted SQL and never alters it.

## Found, not fixed here

- #1941 — `timestamp(<selector>)` in a RANGE query returns the step anchor rather
  than the selected sample's own timestamp, the mirror image of #1845. Verified
  against the emitted range-mode SQL, which projects `anchor_ts AS TimeUnix`. It
  is not a one-line change: `argMax(Value, TimeUnix)` discards the sample
  timestamp inside `RangeLWR`, so the emitter and its native grid counterpart
  have to carry it before the lowering can read it. There is also no range-mode
  `timestamp()` fixture at all today.
- #1942 — the structural closure's ANCHOR arm reads the whole spans table: the
  emitted `{ } >> { } | rate()` carries exactly one inline window, on the STEP
  arm, while the anchor arm's `(SELECT * FROM otel_traces WHERE ?) AS _seed`
  has no co-scope Timestamp and sits under a `WITH RECURSIVE` that ClickHouse
  cannot push into. `internal/spansscan` does not report it, correctly: the seed
  IS a derived table, and the rule this PR installs is that a derived table's
  partitions are prunable from its enclosing scope. That rule is what keeps the
  genuinely pruning-safe `AS R` shape in the same statement off the report; the
  emitter is where the anchor arm's window belongs.

The regenerated `test/rejection-parity/divergence-ceiling.json` tightens from
`max_entries: 5` to `3` on a clean `origin/main` regardless of this change, so it
is pre-existing ledger drift and is deliberately left out of this PR to keep it
scoped. Recorded on the rejection-parity epic, #1884.

Closes #1845

Closes #1912
