### PR TITLE
ci(forbid-deferral): stop reading a description the change's author did not write

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -178,7 +178,26 @@ the pinned numbers cannot drift away from what the crawl actually asks for.
   The tree at large is deliberately NOT scanned — the same phrases are ordinary
   architecture prose in `internal/**`, and a gate that fired on those would be
   routed around. That is scoping, not an allow-list: there is no tolerance file
-  and no way to park a violation. Anti-vacuity is explicit — a missing
+  and no way to park a violation.
+  The description surface carries one narrowing on the same grounds: a pull
+  request opened by `dependabot[bot]` has its DESCRIPTION left unread, because
+  that body is written by the bot and consists of a `<details>` block per bumped
+  module holding the module's upstream changelog and commit subjects verbatim.
+  That is quoted third-party material in exactly the sense `stripFencedBlocks`
+  already means, and scanning it reports the quotation rather than the change's
+  own commitment — an upstream commit titled "remove obsolete `<marker>`" was
+  reported four times, once per bumped module, as the bump parking work. The
+  commit-message and diff surfaces are read on **every** change from every
+  author with no exception, which is what keeps this scoping rather than an
+  exemption: the surface a marker must survive to reach the tree is the diff,
+  and nothing narrows it. The accepted cost, stated rather than sold: a human
+  who edits a bot pull request's description gets that prose unread; their
+  commits and their diff are still read. The author is resolved from
+  `GITHUB_EVENT_PATH`'s payload rather than a workflow-interpolated string, and
+  every failure to resolve it — no path, no file, unparseable JSON, no `login`
+  — scans the description as normal, so the gate never stops reading a surface
+  because it could not determine something.
+  Anti-vacuity is explicit — a missing
   description surface, an unresolvable commit range, an empty commit list, an
   empty file set or an empty marker table each fail LOUDLY rather than passing
   A citation the API cannot resolve is never read as a citation that names
@@ -208,7 +227,9 @@ the pinned numbers cannot drift away from what the crawl actually asks for.
     `pull-requests: read`; a token without either fails the run with a
     permission diagnostic rather than a verdict about the author's prose),
     `GITHUB_EVENT_NAME`, `PR_BODY` (required on a `pull_request` run; may be
-    empty, may not be unset), `BASE_SHA`, `HEAD_SHA`, `GITHUB_API_URL`
+    empty, may not be unset), `GITHUB_EVENT_PATH` (runner-provided; read for
+    `pull_request.user.login` only, and an unreadable payload scans the
+    description as normal), `BASE_SHA`, `HEAD_SHA`, `GITHUB_API_URL`
     (optional; runner-provided).
   - Exit: `0` when every marker is tracked by an open issue (or none were
     found); `1` on an untracked deferral or a malformed input. ENFORCING and a

--- a/.github/scripts/forbid-deferral.mjs
+++ b/.github/scripts/forbid-deferral.mjs
@@ -21,6 +21,12 @@
 // This is SCOPING, not an allow-list: there is no tolerance file, no exemption
 // list, and no way to park a violation.
 //
+// Surface 1 carries ONE narrowing, on the same grounds — see
+// GENERATED_DESCRIPTION_AUTHOR and scansDescription() below. Surfaces 2 and 3
+// are read on every change without exception, and that is what keeps the
+// narrowing scoping rather than an exemption: nothing reaches the tree behind
+// it.
+//
 // WHAT COUNTS — see DEFERRAL_MARKERS below, the single exported table. Each row
 // matches "work this change is postponing", never "a system boundary being
 // described". The distinction is why the table's last row carries a qualifier:
@@ -86,6 +92,16 @@
 //                      via env and never interpolated into a shell `run:` line
 //                      (bodies are attacker-controlled). May be empty; may not
 //                      be unset, which would mean the surface went uninspected.
+//   GITHUB_EVENT_PATH  Runner-provided path to the event payload JSON. Read for
+//                      ONE field, `pull_request.user.login`, which decides
+//                      whether the description surface is the author's own
+//                      prose (see scansDescription). Deliberately NOT a
+//                      workflow-interpolated author string: an input the caller
+//                      supplies is an input the caller can get wrong, and this
+//                      one decides whether a surface is read at all. Unset,
+//                      unreadable or malformed yields no author, and no author
+//                      means the description IS scanned — the fail-closed
+//                      direction.
 //   BASE_SHA           Range start. Falls back to `HEAD_SHA^` when unset or
 //                      unresolvable (a branch-creation push sends all-zeroes).
 //   HEAD_SHA           Range end. Falls back to `HEAD`.
@@ -107,6 +123,7 @@
 // regex rather than a literal call. Prose in this file, its test, and the docs
 // therefore names marker CLASSES rather than reproducing marker text.
 
+import { readFileSync } from 'node:fs';
 import process from 'node:process';
 import { pathToFileURL } from 'node:url';
 
@@ -292,6 +309,85 @@ export function stripFencedBlocks(text) {
     .join('\n');
 }
 
+// GENERATED_DESCRIPTION_AUTHOR — the one account whose pull request DESCRIPTION
+// this gate does not read.
+//
+// The reasoning is stripFencedBlocks's, one level up. Dependabot writes its own
+// description, and what it writes is a paste of somebody else's release notes:
+// a `<details>` block per bumped module, each holding that module's changelog
+// and its upstream commit subjects verbatim. That is QUOTED material in exactly
+// the sense the comment above means — a report of what other people wrote, not
+// a commitment this change is making — and scanning it reports the quotation
+// rather than the author's own promise. It is not hypothetical: a bump whose
+// generated body quoted an upstream commit titled "remove obsolete <marker>"
+// was reported four times, once per bumped module, as this change parking work.
+// The upstream commit was DELETING a marker.
+//
+// WHAT THIS GIVES UP, stated plainly. A human who edits a bot pull request's
+// description gets that prose unread — and that happens: the bump this rule was
+// written for grew a hand-written repair section after a human took the branch
+// over. Their commit messages and their diff are still read, so the loss is one
+// surface on one class of pull request, and the surface a marker would have to
+// survive to reach the repository is not it.
+//
+// WHY THIS IS SCOPING AND NOT AN ALLOW-LIST, against the header's own test at
+// the top of this file: nothing here can park a violation. There is no tolerance
+// file, no number to add, no per-change escape. The commit-message surface and
+// the diff surface are read on every change from every author, and the diff
+// surface is the one that decides what lands in the tree. What changes is WHICH
+// SURFACE is read, on the ground that the text in it was written by neither the
+// change nor its author.
+const GENERATED_DESCRIPTION_AUTHOR = 'dependabot[bot]';
+
+// scansDescription — is this pull request's description the author's own prose?
+//
+// Fail-closed by construction: only a login that positively matches the
+// generated-description account suppresses the surface, so an absent, empty or
+// unreadable author scans as normal. A gate that stopped reading a surface
+// because it could not determine something is the failure this ordering avoids.
+export function scansDescription(author) {
+  const login = String(author ?? '').trim().toLowerCase();
+  if (login === '') return true;
+  return login !== GENERATED_DESCRIPTION_AUTHOR;
+}
+
+// eventPayloadAuthor — the login that opened this pull request, read out of the
+// payload JSON the runner wrote for the event.
+//
+// Every failure mode collapses to null (no path, no file, unparseable JSON, a
+// payload with no pull request, a login that is not a non-empty string), which
+// scansDescription reads as "scan it". The read is therefore allowed to be
+// total: there is no error state in which this function's answer widens what
+// the gate accepts.
+export function eventPayloadAuthor(eventPath) {
+  if (!eventPath) return null;
+  let payload;
+  try {
+    payload = JSON.parse(readFileSync(eventPath, 'utf8'));
+  } catch {
+    return null;
+  }
+  const login = payload?.pull_request?.user?.login;
+  return typeof login === 'string' && login.trim() !== '' ? login.trim() : null;
+}
+
+// sharedAuthor — the single login behind a set of pull requests, or null when
+// they do not agree on one.
+//
+// The push and merge-queue paths resolve the description surface from the head
+// commit's associated pull requests, which is a LIST. Concatenating two bodies
+// and attributing them to one author would be a guess; disagreement therefore
+// yields null, and null scans. An empty list likewise: there is no author to
+// read, so there is nothing to narrow.
+export function sharedAuthor(pulls) {
+  const logins = new Set(
+    (Array.isArray(pulls) ? pulls : [])
+      .map((p) => (typeof p?.user?.login === 'string' ? p.user.login.trim() : ''))
+      .filter((l) => l !== ''),
+  );
+  return logins.size === 1 ? [...logins][0] : null;
+}
+
 // paragraphs — split prose into blank-line-separated blocks, each carrying the
 // 1-based line at which it starts. The paragraph is the citation scope for
 // prose: an issue named three paragraphs away tracks something else.
@@ -455,6 +551,39 @@ export function scanDiff(diffText, repoSlug) {
     }
   }
   return candidates;
+}
+
+// --- surface composition -----------------------------------------------------
+
+// candidatesFor — every candidate violation across all three surfaces.
+//
+// Composed here rather than inline in the runner so the surface scoping is a
+// pure function a test can pin. The claim scansDescription makes is not "a
+// description is skipped" but "a description is skipped AND the other two
+// surfaces are not", and that is a statement about all three at once: a test
+// that only exercised the description could not tell scoping apart from an
+// exemption. The tests that matter are the ones asserting a marker in a bot
+// pull request's COMMIT MESSAGE and in its DIFF is still reported.
+export function candidatesFor({ description, author, commits, diffText, repoSlug }) {
+  return [
+    ...(scansDescription(author)
+      ? scanProse({
+          text: description,
+          surface: 'pr-body',
+          locate: (line) => `PR description line ${line}`,
+          repoSlug,
+        })
+      : []),
+    ...(Array.isArray(commits) ? commits : []).flatMap((c) =>
+      scanProse({
+        text: c.message,
+        surface: 'commit',
+        locate: (line) => `commit ${c.sha.slice(0, 12)} message line ${line}`,
+        repoSlug,
+      }),
+    ),
+    ...scanDiff(diffText, repoSlug),
+  ];
 }
 
 // --- verdict ----------------------------------------------------------------
@@ -672,7 +801,11 @@ export async function descriptionSurface({ eventName, repo, head, token, apiBase
           'Wire `PR_BODY: ${{ github.event.pull_request.body }}` into the step env.',
       );
     }
-    return { text: process.env.PR_BODY, origin: 'the pull_request event payload' };
+    return {
+      text: process.env.PR_BODY,
+      origin: 'the pull_request event payload',
+      author: eventPayloadAuthor(process.env.GITHUB_EVENT_PATH),
+    };
   }
   const pulls = await apiJson(
     `${apiBase}/repos/${repo}/commits/${head}/pulls`,
@@ -693,11 +826,16 @@ export async function descriptionSurface({ eventName, repo, head, token, apiBase
     );
   }
   if (pulls.length === 0) {
-    return { text: '', origin: `explicitly empty: no pull request is associated with ${head.slice(0, 12)}` };
+    return {
+      text: '',
+      origin: `explicitly empty: no pull request is associated with ${head.slice(0, 12)}`,
+      author: null,
+    };
   }
   return {
     text: pulls.map((p) => p.body ?? '').join('\n\n'),
     origin: `the description of ${pulls.map((p) => `#${p.number}`).join(', ')}`,
+    author: sharedAuthor(pulls),
   };
 }
 
@@ -780,30 +918,29 @@ async function main() {
 
   const description = await descriptionSurface({ eventName, repo, head, token, apiBase });
 
-  const candidates = [
-    ...scanProse({
-      text: description.text,
-      surface: 'pr-body',
-      locate: (line) => `PR description line ${line}`,
-      repoSlug: repo,
-    }),
-    ...commits.flatMap((c) =>
-      scanProse({
-        text: c.message,
-        surface: 'commit',
-        locate: (line) => `commit ${c.sha.slice(0, 12)} message line ${line}`,
-        repoSlug: repo,
-      }),
-    ),
-    ...scanDiff(diffText, repo),
-  ];
+  const candidates = candidatesFor({
+    description: description.text,
+    author: description.author,
+    commits,
+    diffText,
+    repoSlug: repo,
+  });
 
   const cited = [...new Set(candidates.flatMap((c) => c.refs))].sort((a, b) => a - b);
   const resolved = await resolveRefs(cited, { repo, token, apiBase });
   const violations = evaluate(candidates, resolved);
 
+  // The anti-vacuity contract in the header says every run states what it
+  // inspected. A surface that was resolved but deliberately not read has to say
+  // so in the same breath, or the summary claims a scan that did not happen.
+  const descriptionRead = scansDescription(description.author);
   const inspected = [
-    `- description: ${description.origin} (${description.text.length} chars)`,
+    `- description: ${description.origin} (${description.text.length} chars)` +
+      (descriptionRead
+        ? ''
+        : ` — NOT scanned: written by ${GENERATED_DESCRIPTION_AUTHOR}, whose body quotes ` +
+          'upstream release notes rather than stating this change\'s own commitment. Its ' +
+          'commit messages and its diff were scanned as normal.'),
     `- commits: **${commits.length}** in \`${base.slice(0, 12)}..${head.slice(0, 12)}\``,
     `- diff: **${files.length}** file(s) at \`--unified=${CITATION_WINDOW_LINES}\``,
     `- marker table: **${DEFERRAL_MARKERS.length}** rows`,

--- a/.github/scripts/forbid-deferral.test.mjs
+++ b/.github/scripts/forbid-deferral.test.mjs
@@ -24,9 +24,14 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
 import {
   CITATION_WINDOW_LINES,
   DEFERRAL_MARKERS,
+  candidatesFor,
   citationVerdict,
   evaluate,
   findMarkers,
@@ -36,8 +41,11 @@ import {
   paragraphs,
   parseDiff,
   scanDiff,
+  eventPayloadAuthor,
   scanProse,
+  scansDescription,
   sectionAt,
+  sharedAuthor,
   stripFencedBlocks,
 } from './forbid-deferral.mjs';
 
@@ -594,4 +602,163 @@ test('evaluate keeps only the candidates no citation rescues', () => {
     violations.map((v) => v.location),
     ['line 1', 'line 5', 'line 7'],
   );
+});
+
+// --- surface scoping: a generated description ---------------------------------
+//
+// Every test below is a pair with the ones after it, and the pairing IS the
+// claim. "A bot's description is not read" on its own is indistinguishable from
+// an exemption; it becomes scoping only alongside "its commit messages are
+// read" and "its diff is read". So the suppression test is one of five, and the
+// other four are the ones that would catch this rule widening into a bypass.
+
+const BOT = 'dependabot[bot]';
+const HUMAN = 'tsouza';
+
+// A description carrying one marker and citing nothing, so the only reason it
+// could come back clean is that the surface was not read.
+const GENERATED_BODY = [
+  'Bumps go.opentelemetry.io/otel from 1.40.0 to 1.41.0.',
+  '',
+  `<li><code>223f9fd</code> sdk/metric: remove obsolete randomFloat64 ${TODO_WORD} (#7469)</li>`,
+].join('\n');
+
+const COMMITS_WITH_MARKER = [
+  { sha: 'a'.repeat(40), message: `chore(deps): bump otel\n\n${FOLLOWUP_WORD}: re-pin the oracle module` },
+];
+
+const DIFF_WITH_MARKER = [
+  'diff --git a/internal/chsql/emit.go b/internal/chsql/emit.go',
+  '--- a/internal/chsql/emit.go',
+  '+++ b/internal/chsql/emit.go',
+  '@@ -20,4 +20,6 @@ func emit() {',
+  ' func emit() {',
+  `+\t// ${TODO_WORD}: fold the grid`,
+  ' }',
+].join('\n');
+
+const EMPTY_DIFF = [
+  'diff --git a/go.mod b/go.mod',
+  '--- a/go.mod',
+  '+++ b/go.mod',
+  '@@ -3,3 +3,3 @@ module github.com/tsouza/cerberus',
+  '-\tgo.opentelemetry.io/otel v1.40.0',
+  '+\tgo.opentelemetry.io/otel v1.41.0',
+].join('\n');
+
+const surfacesOf = (candidates) => candidates.map((c) => c.surface).sort();
+
+test('a generated description is quoted release notes, not this change’s commitment', () => {
+  const found = candidatesFor({
+    description: GENERATED_BODY,
+    author: BOT,
+    commits: [{ sha: 'b'.repeat(40), message: 'chore(deps): bump otel' }],
+    diffText: EMPTY_DIFF,
+    repoSlug: REPO,
+  });
+  assert.deepEqual(found, [], 'the body quotes an upstream subject; nothing here is authored');
+});
+
+test('the same description on an ordinary pull request is still read', () => {
+  const found = candidatesFor({
+    description: GENERATED_BODY,
+    author: HUMAN,
+    commits: [{ sha: 'b'.repeat(40), message: 'chore(deps): bump otel' }],
+    diffText: EMPTY_DIFF,
+    repoSlug: REPO,
+  });
+  assert.deepEqual(surfacesOf(found), ['pr-body']);
+  assert.equal(found[0].location, 'PR description line 3');
+});
+
+test('a marker in a generated pull request’s COMMIT MESSAGE is still reported', () => {
+  const found = candidatesFor({
+    description: GENERATED_BODY,
+    author: BOT,
+    commits: COMMITS_WITH_MARKER,
+    diffText: EMPTY_DIFF,
+    repoSlug: REPO,
+  });
+  assert.deepEqual(surfacesOf(found), ['commit']);
+  assert.equal(found[0].markerId, 'followup-label');
+  assert.deepEqual(found[0].refs, [], 'it cites nothing, so the verdict stays untracked');
+});
+
+test('a marker in a generated pull request’s DIFF is still reported', () => {
+  const found = candidatesFor({
+    description: GENERATED_BODY,
+    author: BOT,
+    commits: [{ sha: 'b'.repeat(40), message: 'chore(deps): bump otel' }],
+    diffText: DIFF_WITH_MARKER,
+    repoSlug: REPO,
+  });
+  assert.deepEqual(surfacesOf(found), ['diff']);
+  assert.equal(found[0].location, 'internal/chsql/emit.go:21');
+});
+
+test('an unknown author scans the description as normal', () => {
+  for (const author of [null, undefined, '', '   ']) {
+    const found = candidatesFor({
+      description: GENERATED_BODY,
+      author,
+      commits: [{ sha: 'b'.repeat(40), message: 'chore(deps): bump otel' }],
+      diffText: EMPTY_DIFF,
+      repoSlug: REPO,
+    });
+    assert.deepEqual(
+      surfacesOf(found),
+      ['pr-body'],
+      `author ${JSON.stringify(author)} must not suppress a surface`,
+    );
+  }
+});
+
+test('scansDescription narrows on exactly one login and nothing near it', () => {
+  assert.equal(scansDescription(BOT), false);
+  assert.equal(scansDescription('Dependabot[bot]'), false, 'a login is not case-sensitive');
+  for (const near of ['dependabot', 'dependabot-preview[bot]', 'notdependabot[bot]', 'renovate[bot]', HUMAN]) {
+    assert.equal(scansDescription(near), true, `${near} is not the generated-description account`);
+  }
+});
+
+// --- resolving the author ------------------------------------------------------
+
+const withPayload = (contents) => {
+  const path = join(mkdtempSync(join(tmpdir(), 'forbid-deferral-')), 'event.json');
+  writeFileSync(path, contents);
+  return path;
+};
+
+test('the author is read from the event payload, not from a caller-supplied string', () => {
+  const path = withPayload(JSON.stringify({ pull_request: { user: { login: BOT } } }));
+  assert.equal(eventPayloadAuthor(path), BOT);
+});
+
+test('every unreadable payload yields no author, which scans the description', () => {
+  const cases = {
+    'no path at all': undefined,
+    'a path that does not exist': join(tmpdir(), 'forbid-deferral-absent', 'event.json'),
+    'a file that is not JSON': withPayload('not json {'),
+    'a payload with no pull request': withPayload(JSON.stringify({ ref: 'refs/heads/main' })),
+    'a pull request with no user': withPayload(JSON.stringify({ pull_request: {} })),
+    'a login that is not a string': withPayload(JSON.stringify({ pull_request: { user: { login: 7 } } })),
+    'a blank login': withPayload(JSON.stringify({ pull_request: { user: { login: '  ' } } })),
+  };
+  for (const [what, path] of Object.entries(cases)) {
+    assert.equal(eventPayloadAuthor(path), null, what);
+    assert.equal(scansDescription(eventPayloadAuthor(path)), true, `${what} must still scan`);
+  }
+});
+
+test('a push-resolved surface takes its author only when the pull requests agree', () => {
+  assert.equal(sharedAuthor([{ user: { login: BOT } }]), BOT);
+  assert.equal(sharedAuthor([{ user: { login: BOT } }, { user: { login: BOT } }]), BOT);
+  assert.equal(
+    sharedAuthor([{ user: { login: BOT } }, { user: { login: HUMAN } }]),
+    null,
+    'two authors, one concatenated body — attributing it to either would be a guess',
+  );
+  for (const empty of [[], null, undefined, [{}], [{ user: {} }]]) {
+    assert.equal(sharedAuthor(empty), null, 'no author means nothing to narrow');
+  }
 });


### PR DESCRIPTION
## What

`forbid-deferral` no longer reads the **description** surface of a pull request opened by
`dependabot[bot]`. Its commit messages and the `+` lines of its diff are read exactly as before,
as they are for every author with no exception.

## Why

A bump's description is written by the bot, and its body is a `<details>` block per bumped module
holding that module's upstream changelog and commit subjects verbatim. Scanning it reports the
quotation rather than the change's own commitment.

That is not hypothetical. #1937 fails this gate four times — once per bumped module — on one
upstream commit subject:

```
<li><a href="…"><code>223f9fd</code></a> sdk/metric: remove obsolete randomFloat64 <marker> (…)
```

An upstream commit that *removes* a work marker, reported as this change parking work.

This is `stripFencedBlocks`'s reasoning one level up. That function already blanks fenced blocks on
prose surfaces because a fence in a description is quoted material — a log excerpt, a diff hunk, a
paste of this very gate's output — and "reporting the quotation of a violation as a violation is how
a gate earns a reputation for crying wolf".

## Why this is scoping, not an allow-list

The module header's own test at `forbid-deferral.mjs:11-22` draws the line, and this falls on the
scoping side of it:

- Nothing here can park a violation. No tolerance file, no number to add, no per-change escape.
- The commit-message surface and the diff surface are read on **every** change from **every** author.
  The surface a marker must survive to reach the repository is the diff, and nothing narrows it.
- What changes is *which surface* is read, on the ground that the text in it was written by neither
  the change nor its author.

## The cost, stated rather than sold

A human who edits a bot pull request's description gets that prose unread. That happens — #1937 has
a hand-written `## Repair` section. Their commit messages and their diff are still read. The comment
and the README both say so plainly.

## Resolving the author

From `GITHUB_EVENT_PATH`'s payload, not a workflow-interpolated string: an input the caller supplies
is an input the caller can get wrong, and this one decides whether a surface is read at all. Every
failure to resolve it — no path, no file, unparseable JSON, no `login` — scans the description as
normal. The gate never stops reading a surface because it could not determine something. The run
summary names the surface it did not read, so the module's anti-vacuity contract stays honest.

## Tests

Surface composition moved out of `main()` into the exported `candidatesFor`, so the claim is
testable as one statement about all three surfaces at once — a test that only exercised the
description could not tell scoping from an exemption.

Nine tests, each shown to fail against a mutant of the module that breaks the specific behaviour it
pins:

| mutant | tests it breaks |
|---|---|
| `scansDescription` always true (rule absent) | bot description unread; the login-boundary test |
| `scansDescription` always false (rule widened to every author) | ordinary description still read; unknown author scans; login boundary; payload fail-closed |
| the narrowing leaks to all three surfaces | commit-message still reported; diff still reported |
| `eventPayloadAuthor` returns a login unconditionally | payload fail-closed |
| `eventPayloadAuthor` never resolves | payload is read at all |
| `sharedAuthor` takes the first login without requiring agreement | push-resolved author agreement |

Verified locally: `node --test .github/scripts/forbid-deferral.test.mjs` (45 pass),
`node --test .github/scripts/pr-body-check.test.mjs` (the other consumer of `descriptionSurface`,
5 pass), and `go test -run TestForbidDeferral ./test/regression/` (5 pass, including the lane that
executes the module end to end).

## Scope

Two adjacent CI-configuration questions were investigated and deliberately produced no change: the
mutation lane's path scoping, and an incomplete `setup-go` module-cache entry. Both concluded that
the change available is unsound or a measured net loss; the numbers are in the task report rather
than here, since neither is part of this diff.
