### PR TITLE
fix(compat/loki): restore the loki-compliance-tester coverage floor with real behaviour tests

### DIFF
--- a/compatibility/loki/cmd/loki-compliance-tester/burndown_value_parity_test.go
+++ b/compatibility/loki/cmd/loki-compliance-tester/burndown_value_parity_test.go
@@ -1,0 +1,235 @@
+package main
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/grafana/loki/v3/pkg/logproto"
+
+	bench "github.com/tsouza/cerberus/compatibility/loki/upstream/loki-bench"
+)
+
+// The burndown pass is the only value-level coverage the wrong-rejection
+// operators have: the vendored corpus exercises none of them. Its case
+// list is therefore load-bearing in a way a query list usually is not —
+// a selector picked non-deterministically, a window that drifts off the
+// seed grid, or a metric case that lost its step all turn a real
+// operator divergence into a spurious diff (or, worse, into a pass).
+
+// burndownMetadata builds the minimal dataset metadata burndownCases
+// reads: a web-server selector for the ip()/pattern arms and a logfmt
+// selector carrying an unwrappable `duration` for the first/last arms.
+func burndownMetadata() *bench.DatasetMetadata {
+	return &bench.DatasetMetadata{
+		ByServiceName: map[string][]string{
+			"web-server": {`{service_name="web-server"}`, `{service_name="web-server", env="b"}`},
+		},
+		ByFormat: map[bench.LogFormat][]string{
+			bench.LogFormatLogfmt: {`{service_name="zeta"}`, `{service_name="alpha"}`, `{service_name="unrelated"}`},
+		},
+		ByUnwrappableField: map[string][]string{
+			"duration": {`{service_name="alpha"}`, `{service_name="zeta"}`},
+		},
+		TimeRange: bench.TimeRange{
+			Start: time.Unix(1700000000, 0).UTC(),
+			End:   time.Unix(1700086400, 0).UTC(),
+		},
+	}
+}
+
+// TestIntersectSorted pins the deterministic selector pick. The metadata
+// maps carry generator-ordered slices, so an unsorted intersection would
+// make the burndown query set depend on the fixture's serialisation
+// order — the diff would move between runs.
+func TestIntersectSorted(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		a, b []string
+		want []string
+	}{
+		{"overlap-is-sorted", []string{"c", "a", "b"}, []string{"b", "c"}, []string{"b", "c"}},
+		{"disjoint", []string{"a"}, []string{"b"}, nil},
+		{"empty-left", nil, []string{"a"}, nil},
+		{"empty-right", []string{"a"}, nil, nil},
+		{"duplicates-in-a-are-kept", []string{"a", "a"}, []string{"a"}, []string{"a", "a"}},
+		{"b-order-does-not-leak", []string{"a", "b"}, []string{"b", "a"}, []string{"a", "b"}},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := intersectSorted(tc.a, tc.b)
+			if len(got) != len(tc.want) {
+				t.Fatalf("intersectSorted(%v, %v) = %v, want %v", tc.a, tc.b, got, tc.want)
+			}
+			for i := range tc.want {
+				if got[i] != tc.want[i] {
+					t.Fatalf("entry %d = %q, want %q (full: %v)", i, got[i], tc.want[i], got)
+				}
+			}
+		})
+	}
+}
+
+// TestBurndownCases_Shape pins the case list's structure: the selector
+// picks, the metric/log window split, the direction and the step. Each
+// of these is a precondition for the value diff meaning what it claims.
+func TestBurndownCases_Shape(t *testing.T) {
+	t.Parallel()
+	md := burndownMetadata()
+	cases, err := burndownCases(md)
+	if err != nil {
+		t.Fatalf("burndownCases: %v", err)
+	}
+	if len(cases) == 0 {
+		t.Fatal("burndownCases returned no cases")
+	}
+
+	start := md.TimeRange.Start
+	var metrics, logs int
+	for _, tc := range cases {
+		if tc.Source != burndownSource {
+			t.Fatalf("case %q source = %q, want %q", tc.QueryDesc, tc.Source, burndownSource)
+		}
+		if len(tc.Tags) != 1 || tc.Tags[0] != "wrong-rejection-burndown" {
+			t.Fatalf("case %q tags = %v", tc.QueryDesc, tc.Tags)
+		}
+		if tc.QueryDesc == "" {
+			t.Fatalf("case with query %q carries no description", tc.Query)
+		}
+		switch tc.Kind() {
+		case "metric":
+			metrics++
+			if tc.Step != burndownStep {
+				t.Fatalf("metric case %q step = %v, want %v", tc.QueryDesc, tc.Step, burndownStep)
+			}
+			if !tc.Start.Equal(start) || !tc.End.Equal(start.Add(burndownLength)) {
+				t.Fatalf("metric case %q window = [%v, %v], want the anchor-aligned [start, start+%v]", tc.QueryDesc, tc.Start, tc.End, burndownLength)
+			}
+			if tc.Direction != logproto.FORWARD {
+				t.Fatalf("metric case %q direction = %v, want FORWARD", tc.QueryDesc, tc.Direction)
+			}
+		case "log":
+			logs++
+			if tc.Step != 0 {
+				t.Fatalf("log case %q carries step %v; a log query has no step grid", tc.QueryDesc, tc.Step)
+			}
+			// The log window sits OFF the per-minute seed grid on both
+			// edges so reference Loki's exclusive `end` cannot turn into
+			// a spurious one-entry diff.
+			const logWindowOffset = 30 * time.Second
+			if !tc.Start.Equal(start.Add(logWindowOffset)) || !tc.End.Equal(start.Add(burndownLength).Add(logWindowOffset)) {
+				t.Fatalf("log case %q window = [%v, %v], want both edges shifted %v off the seed grid", tc.QueryDesc, tc.Start, tc.End, logWindowOffset)
+			}
+			if tc.Direction != logproto.BACKWARD {
+				t.Fatalf("log case %q direction = %v, want BACKWARD", tc.QueryDesc, tc.Direction)
+			}
+		default:
+			t.Fatalf("case %q has kind %q; the query does not parse: %s", tc.QueryDesc, tc.Kind(), tc.Query)
+		}
+	}
+	if metrics == 0 || logs == 0 {
+		t.Fatalf("case kinds = (metric=%d, log=%d); the pass must carry both shapes", metrics, logs)
+	}
+}
+
+// TestBurndownCases_CoversEveryBurnedDownOperator is the closure check:
+// each operator family the pass exists for must appear in some query.
+// Without it a refactor could silently drop an operator's only
+// value-level coverage and the pass would still look healthy.
+func TestBurndownCases_CoversEveryBurnedDownOperator(t *testing.T) {
+	t.Parallel()
+	cases, err := burndownCases(burndownMetadata())
+	if err != nil {
+		t.Fatalf("burndownCases: %v", err)
+	}
+	var joined strings.Builder
+	for _, tc := range cases {
+		joined.WriteString(tc.Query)
+		joined.WriteString("\n")
+	}
+	all := joined.String()
+	for _, op := range []string{
+		") and ", ") or ", ") unless ", "+ bool ",
+		"first_over_time", "last_over_time", "absent_over_time",
+		"topk(", "bottomk(", "sort(", "sort_desc(",
+		`|= ip(`, `!= ip(`, `= ip(`, `|> "`, `!> "`,
+	} {
+		if !strings.Contains(all, op) {
+			t.Fatalf("no burndown case exercises %q; the operator has no value-level coverage", op)
+		}
+	}
+}
+
+// TestBurndownCases_UsesTheSortedDurationSelector — the logfmt/duration
+// selector is chosen through intersectSorted, so it must be the
+// lexicographically-first member of the intersection rather than the
+// first entry of either input slice.
+func TestBurndownCases_UsesTheSortedDurationSelector(t *testing.T) {
+	t.Parallel()
+	cases, err := burndownCases(burndownMetadata())
+	if err != nil {
+		t.Fatalf("burndownCases: %v", err)
+	}
+	var found bool
+	for _, tc := range cases {
+		if !strings.Contains(tc.Query, "first_over_time") {
+			continue
+		}
+		found = true
+		if !strings.Contains(tc.Query, `{service_name="alpha"}`) {
+			t.Fatalf("first_over_time case uses %q; want the sorted intersection's first selector {service_name=\"alpha\"}", tc.Query)
+		}
+	}
+	if !found {
+		t.Fatal("no first_over_time case in the list")
+	}
+}
+
+// TestBurndownCases_MissingPreconditions — a dataset that cannot support
+// the pass fails loudly and names what is missing, rather than quietly
+// emitting fewer cases and shrinking the score denominator.
+func TestBurndownCases_MissingPreconditions(t *testing.T) {
+	t.Parallel()
+
+	noWeb := burndownMetadata()
+	noWeb.ByServiceName = map[string][]string{"api": {`{service_name="api"}`}}
+	_, err := burndownCases(noWeb)
+	if err == nil {
+		t.Fatal("metadata without a web-server selector produced no error")
+	}
+	if !strings.Contains(err.Error(), "web-server") {
+		t.Fatalf("error %q should name the missing service", err.Error())
+	}
+
+	noDuration := burndownMetadata()
+	noDuration.ByUnwrappableField = map[string][]string{"bytes": {`{service_name="alpha"}`}}
+	_, err = burndownCases(noDuration)
+	if err == nil {
+		t.Fatal("metadata without an unwrappable duration produced no error")
+	}
+	if !strings.Contains(err.Error(), "duration") {
+		t.Fatalf("error %q should name the missing field", err.Error())
+	}
+}
+
+// TestCompareBurndownValueParity_ReportsBrokenPreconditions — the pass
+// surfaces a construction failure as one UnexpectedFailure result. That
+// keeps the broken precondition visible instead of letting the pass
+// contribute zero rows to a denominator nobody re-checks.
+func TestCompareBurndownValueParity_ReportsBrokenPreconditions(t *testing.T) {
+	t.Parallel()
+	results := compareBurndownValueParity(&http.Client{Timeout: time.Second}, flags{}, &bench.DatasetMetadata{})
+	if len(results) != 1 {
+		t.Fatalf("results = %d, want exactly 1 construction-failure row", len(results))
+	}
+	if results[0].UnexpectedFailure == "" {
+		t.Fatalf("construction failure produced a passing row: %+v", results[0])
+	}
+	if results[0].TestCase.Source != burndownSource {
+		t.Fatalf("source = %q, want %q so the row lands in this pass", results[0].TestCase.Source, burndownSource)
+	}
+}

--- a/compatibility/loki/cmd/loki-compliance-tester/compare_test.go
+++ b/compatibility/loki/cmd/loki-compliance-tester/compare_test.go
@@ -1,0 +1,646 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/grafana/loki/v3/pkg/logproto"
+
+	bench "github.com/tsouza/cerberus/compatibility/loki/upstream/loki-bench"
+)
+
+// compareOne is where a pair of HTTP responses becomes a parity verdict,
+// and it carries the harness's only branch-heavy policy: which side's
+// emptiness is a pass, which is a harness fault, and which is a real
+// diff. Getting one of those arms backwards is invisible in a green run
+// — the row simply lands in a different column. The tests below stand up
+// two httptest backends and drive every arm.
+
+// stubLoki serves one canned body per query endpoint. status 0 means 200.
+type stubLoki struct {
+	body    string
+	status  int
+	lastURL *url.URL
+}
+
+func newStubLoki(t *testing.T, s *stubLoki) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		u := *r.URL
+		s.lastURL = &u
+		if s.status != 0 {
+			w.WriteHeader(s.status)
+		}
+		_, _ = w.Write([]byte(s.body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+const (
+	streamsBodyOne = `{"status":"success","data":{"resultType":"streams","result":[` +
+		`{"stream":{"service_name":"api"},"values":[["1700000000000000001","hello"]]}]}}`
+	streamsBodyEmpty  = `{"status":"success","data":{"resultType":"streams","result":[]}}`
+	streamsBodyOther  = `{"status":"success","data":{"resultType":"streams","result":[` + `{"stream":{"service_name":"api"},"values":[["1700000000000000001","goodbye"]]}]}}`
+	vectorBodyOneItem = `{"status":"success","data":{"resultType":"vector","result":[` +
+		`{"metric":{"level":"info"},"value":[1700000000,"3"]}]}}`
+)
+
+func logTestCase(tags ...string) bench.TestCase {
+	return bench.TestCase{
+		Query:     `{service_name="api"}`,
+		Start:     time.Unix(1700000000, 0).UTC(),
+		End:       time.Unix(1700000060, 0).UTC(),
+		Direction: logproto.BACKWARD,
+		QueryDesc: "log case",
+		Tags:      tags,
+	}
+}
+
+func metricTestCase() bench.TestCase {
+	return bench.TestCase{
+		Query:     `sum(count_over_time({service_name="api"}[5m]))`,
+		Start:     time.Unix(1700000000, 0).UTC(),
+		End:       time.Unix(1700000060, 0).UTC(),
+		Direction: logproto.FORWARD,
+		Step:      time.Minute,
+		QueryDesc: "metric case",
+	}
+}
+
+func flagsFor(addr1, addr2 string) flags {
+	return flags{addr1: addr1, addr2: addr2, timeout: 5 * time.Second, tolerance: 1e-5, parallelism: 2}
+}
+
+// TestCompareOne_Agreement — identical bodies on both endpoints produce a
+// clean Result, and the TestCase envelope carries the case's identity.
+func TestCompareOne_Agreement(t *testing.T) {
+	t.Parallel()
+	ref := newStubLoki(t, &stubLoki{body: streamsBodyOne})
+	test := newStubLoki(t, &stubLoki{body: streamsBodyOne})
+
+	got := compareOne(&http.Client{Timeout: 5 * time.Second}, flagsFor(ref, test), logTestCase(), "fast/basic.yaml", false)
+	if !got.success() {
+		t.Fatalf("identical responses did not pass: %+v", got)
+	}
+	if got.TestCase.Source != "fast/basic.yaml" || got.TestCase.Kind != "log" {
+		t.Fatalf("test case envelope = %+v", got.TestCase)
+	}
+}
+
+// TestCompareOne_Divergence — differing lines land in Diff, not in
+// UnexpectedFailure: a value divergence is a cerberus bug, not a harness
+// fault, and the two columns are graded differently downstream.
+func TestCompareOne_Divergence(t *testing.T) {
+	t.Parallel()
+	ref := newStubLoki(t, &stubLoki{body: streamsBodyOne})
+	test := newStubLoki(t, &stubLoki{body: streamsBodyOther})
+
+	got := compareOne(&http.Client{Timeout: 5 * time.Second}, flagsFor(ref, test), logTestCase(), "fast/basic.yaml", false)
+	if got.Diff == "" {
+		t.Fatal("differing lines produced no diff")
+	}
+	if got.UnexpectedFailure != "" {
+		t.Fatalf("a value divergence must not be reported as a failure: %q", got.UnexpectedFailure)
+	}
+	if !strings.Contains(got.Diff, "line differs") {
+		t.Fatalf("diff = %q, want the line dimension named", got.Diff)
+	}
+}
+
+// TestCompareOne_ReferenceFailure — a broken baseline is a harness
+// glitch: reported as UnexpectedFailure, never as Unsupported (which is
+// reserved for cerberus answering "not implemented").
+func TestCompareOne_ReferenceFailure(t *testing.T) {
+	t.Parallel()
+	ref := newStubLoki(t, &stubLoki{body: "boom", status: http.StatusInternalServerError})
+	test := newStubLoki(t, &stubLoki{body: streamsBodyOne})
+
+	got := compareOne(&http.Client{Timeout: 5 * time.Second}, flagsFor(ref, test), logTestCase(), "fast/basic.yaml", false)
+	if !strings.Contains(got.UnexpectedFailure, "reference (-addr-1) failed") {
+		t.Fatalf("UnexpectedFailure = %q, want the reference named", got.UnexpectedFailure)
+	}
+	if got.Unsupported {
+		t.Fatal("a reference-side failure must not be flagged Unsupported")
+	}
+}
+
+// TestCompareOne_TestEndpointUnsupported — a 501 from cerberus is both a
+// failure AND flagged Unsupported, which is what separates "cannot yet
+// answer" from "answered wrongly" in the report.
+func TestCompareOne_TestEndpointUnsupported(t *testing.T) {
+	t.Parallel()
+	ref := newStubLoki(t, &stubLoki{body: streamsBodyOne})
+	test := newStubLoki(t, &stubLoki{body: "not implemented", status: http.StatusNotImplemented})
+
+	got := compareOne(&http.Client{Timeout: 5 * time.Second}, flagsFor(ref, test), logTestCase(), "fast/basic.yaml", false)
+	if got.UnexpectedFailure == "" {
+		t.Fatal("a 501 from the test endpoint produced no failure")
+	}
+	if !got.Unsupported {
+		t.Fatalf("501 not flagged Unsupported: %q", got.UnexpectedFailure)
+	}
+}
+
+// TestCompareOne_TestEndpointErrorIsNotUnsupported — a 500 is a plain
+// failure. Without this arm the Unsupported flag could be hard-wired on
+// and every failure would read as a feature gap.
+func TestCompareOne_TestEndpointErrorIsNotUnsupported(t *testing.T) {
+	t.Parallel()
+	ref := newStubLoki(t, &stubLoki{body: streamsBodyOne})
+	test := newStubLoki(t, &stubLoki{body: "internal", status: http.StatusInternalServerError})
+
+	got := compareOne(&http.Client{Timeout: 5 * time.Second}, flagsFor(ref, test), logTestCase(), "fast/basic.yaml", false)
+	if got.UnexpectedFailure == "" {
+		t.Fatal("a 500 from the test endpoint produced no failure")
+	}
+	if got.Unsupported {
+		t.Fatalf("500 wrongly flagged Unsupported: %q", got.UnexpectedFailure)
+	}
+}
+
+// TestCompareOne_EmptyResultTagArms pins the three-way branch behind the
+// upstream `empty-result` tag. Both-empty is the pass the tag exists
+// for; cerberus-returning-rows flips into a Diff (a shape mismatch the
+// corpus author says cannot happen); cerberus-empty-while-reference-has-
+// rows stays a failure.
+func TestCompareOne_EmptyResultTagArms(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name        string
+		refBody     string
+		testBody    string
+		wantPass    bool
+		wantDiff    string
+		wantFailure string
+	}{
+		{
+			name:     "both-empty-passes",
+			refBody:  streamsBodyEmpty,
+			testBody: streamsBodyEmpty,
+			wantPass: true,
+		},
+		{
+			name:     "test-returned-rows-is-a-diff",
+			refBody:  streamsBodyEmpty,
+			testBody: streamsBodyOne,
+			wantDiff: "baseline empty (expected) but test endpoint returned rows",
+		},
+		{
+			name:        "test-empty-while-reference-has-rows",
+			refBody:     streamsBodyOne,
+			testBody:    streamsBodyEmpty,
+			wantFailure: "test endpoint returned empty",
+		},
+		{
+			// Both sides carry rows: the tag does not short-circuit, the
+			// normal value diff runs. The corpus attaches `empty-result`
+			// to cache-exercise cases too, so a tagged case with data
+			// must still be compared rather than auto-passed.
+			name:     "both-non-empty-falls-through-to-the-value-diff",
+			refBody:  streamsBodyOne,
+			testBody: streamsBodyOther,
+			wantDiff: "line differs",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ref := newStubLoki(t, &stubLoki{body: tc.refBody})
+			test := newStubLoki(t, &stubLoki{body: tc.testBody})
+			got := compareOne(&http.Client{Timeout: 5 * time.Second}, flagsFor(ref, test), logTestCase("empty-result"), "fast/basic.yaml", false)
+			switch {
+			case tc.wantPass:
+				if !got.success() {
+					t.Fatalf("want pass, got %+v", got)
+				}
+			case tc.wantDiff != "":
+				if !strings.Contains(got.Diff, tc.wantDiff) {
+					t.Fatalf("Diff = %q, want it to contain %q (failure=%q)", got.Diff, tc.wantDiff, got.UnexpectedFailure)
+				}
+			default:
+				if !strings.Contains(got.UnexpectedFailure, tc.wantFailure) {
+					t.Fatalf("UnexpectedFailure = %q, want it to contain %q", got.UnexpectedFailure, tc.wantFailure)
+				}
+			}
+		})
+	}
+}
+
+// TestCompareOne_UntaggedEmptyBaselineIsAFailure — without the tag, an
+// empty baseline is a seed/config problem and is reported as one rather
+// than passing as "both agree on nothing".
+func TestCompareOne_UntaggedEmptyBaselineIsAFailure(t *testing.T) {
+	t.Parallel()
+	ref := newStubLoki(t, &stubLoki{body: streamsBodyEmpty})
+	test := newStubLoki(t, &stubLoki{body: streamsBodyEmpty})
+
+	got := compareOne(&http.Client{Timeout: 5 * time.Second}, flagsFor(ref, test), logTestCase(), "fast/basic.yaml", false)
+	if got.UnexpectedFailure != "baseline returned empty" {
+		t.Fatalf("UnexpectedFailure = %q, want \"baseline returned empty\"", got.UnexpectedFailure)
+	}
+}
+
+// TestCompareOne_UntaggedEmptyTestSideIsAFailure — the mirror arm: the
+// reference has rows and cerberus does not.
+func TestCompareOne_UntaggedEmptyTestSideIsAFailure(t *testing.T) {
+	t.Parallel()
+	ref := newStubLoki(t, &stubLoki{body: streamsBodyOne})
+	test := newStubLoki(t, &stubLoki{body: streamsBodyEmpty})
+
+	got := compareOne(&http.Client{Timeout: 5 * time.Second}, flagsFor(ref, test), logTestCase(), "fast/basic.yaml", false)
+	if got.UnexpectedFailure != "test endpoint returned empty" {
+		t.Fatalf("UnexpectedFailure = %q, want \"test endpoint returned empty\"", got.UnexpectedFailure)
+	}
+}
+
+// TestQueryOne_RangeRoute pins the wire contract of the range call: the
+// /query_range path, nanosecond start/end, the direction, and the step
+// rendered in SECONDS (Loki rejects a Go duration string here).
+func TestQueryOne_RangeRoute(t *testing.T) {
+	t.Parallel()
+	stub := &stubLoki{body: vectorBodyOneItem}
+	addr := newStubLoki(t, stub)
+
+	tc := metricTestCase()
+	if _, err := queryOne(&http.Client{Timeout: 5 * time.Second}, addr+"/", tc, false); err != nil {
+		t.Fatalf("queryOne: %v", err)
+	}
+	if stub.lastURL.Path != "/loki/api/v1/query_range" {
+		t.Fatalf("path = %q, want /loki/api/v1/query_range", stub.lastURL.Path)
+	}
+	q := stub.lastURL.Query()
+	if q.Get("query") != tc.Query {
+		t.Fatalf("query param = %q", q.Get("query"))
+	}
+	if q.Get("start") != "1700000000000000000" || q.Get("end") != "1700000060000000000" {
+		t.Fatalf("window params = (%q, %q), want unix nanos", q.Get("start"), q.Get("end"))
+	}
+	if q.Get("step") != "60" {
+		t.Fatalf("step = %q, want 60 (seconds)", q.Get("step"))
+	}
+	if q.Get("direction") != "FORWARD" {
+		t.Fatalf("direction = %q, want FORWARD", q.Get("direction"))
+	}
+	if q.Get("time") != "" {
+		t.Fatalf("range call must not carry a `time` param, got %q", q.Get("time"))
+	}
+}
+
+// TestQueryOne_InstantRoute — an instant metric case (start == end)
+// routes to /query with a `time` anchor and no step.
+func TestQueryOne_InstantRoute(t *testing.T) {
+	t.Parallel()
+	stub := &stubLoki{body: vectorBodyOneItem}
+	addr := newStubLoki(t, stub)
+
+	tc := metricTestCase()
+	tc.Start = tc.End
+	tc.Step = 0
+	if _, err := queryOne(&http.Client{Timeout: 5 * time.Second}, addr, tc, true); err != nil {
+		t.Fatalf("queryOne: %v", err)
+	}
+	if stub.lastURL.Path != "/loki/api/v1/query" {
+		t.Fatalf("path = %q, want /loki/api/v1/query", stub.lastURL.Path)
+	}
+	q := stub.lastURL.Query()
+	if q.Get("time") != "1700000060000000000" {
+		t.Fatalf("time = %q, want the end anchor in unix nanos", q.Get("time"))
+	}
+	if q.Get("start") != "" || q.Get("step") != "" {
+		t.Fatalf("instant call carried range params: start=%q step=%q", q.Get("start"), q.Get("step"))
+	}
+}
+
+// TestQueryOne_LogCaseStaysOnRangeEvenInInstantMode — a log query has no
+// instant flavour, so the instant lane must still route it to
+// /query_range. This mirrors upstream's queryRemote().
+func TestQueryOne_LogCaseStaysOnRangeEvenInInstantMode(t *testing.T) {
+	t.Parallel()
+	stub := &stubLoki{body: streamsBodyOne}
+	addr := newStubLoki(t, stub)
+
+	tc := logTestCase()
+	tc.Start = tc.End
+	if _, err := queryOne(&http.Client{Timeout: 5 * time.Second}, addr, tc, true); err != nil {
+		t.Fatalf("queryOne: %v", err)
+	}
+	if stub.lastURL.Path != "/loki/api/v1/query_range" {
+		t.Fatalf("path = %q, want /loki/api/v1/query_range for a log case", stub.lastURL.Path)
+	}
+}
+
+// TestDoQuery_NonOKCarriesStatusAndTruncatedBody — the error text is what
+// isUnsupportedErr keys on, so it must carry the status code; and the
+// body is truncated so an upstream stack trace cannot swamp the report.
+func TestDoQuery_NonOKCarriesStatusAndTruncatedBody(t *testing.T) {
+	t.Parallel()
+	const bodyLen = 5000
+	stub := &stubLoki{body: strings.Repeat("x", bodyLen), status: http.StatusBadRequest}
+	addr := newStubLoki(t, stub)
+
+	_, err := doQuery(&http.Client{Timeout: 5 * time.Second}, addr+"/loki/api/v1/query_range", url.Values{})
+	if err == nil {
+		t.Fatal("doQuery over a 400 returned no error")
+	}
+	if !strings.Contains(err.Error(), "status=400") {
+		t.Fatalf("error %q missing the status code", err.Error())
+	}
+	if len(err.Error()) >= bodyLen {
+		t.Fatalf("error body was not truncated (len=%d)", len(err.Error()))
+	}
+	if !strings.HasSuffix(err.Error(), "…") {
+		t.Fatalf("truncated error should end in an ellipsis: %q", err.Error()[max(0, len(err.Error())-20):])
+	}
+}
+
+// TestDoQuery_UnreachableHost — a transport failure is wrapped rather
+// than surfacing as a zero-value result that would read as "empty".
+func TestDoQuery_UnreachableHost(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	addr := srv.URL
+	srv.Close() // nothing listens on this port any more
+
+	_, err := doQuery(&http.Client{Timeout: 2 * time.Second}, addr+"/loki/api/v1/query_range", url.Values{})
+	if err == nil {
+		t.Fatal("doQuery against a closed listener returned no error")
+	}
+	if !strings.Contains(err.Error(), "http call") {
+		t.Fatalf("error %q should be the wrapped transport failure", err.Error())
+	}
+}
+
+// TestCompareAll_ExpansionErrorsBypassTheWire — a case that failed to
+// expand never reaches an endpoint; it still contributes a result row,
+// built from the QueryDefinition, so the denominator does not shrink.
+func TestCompareAll_ExpansionErrorsBypassTheWire(t *testing.T) {
+	t.Parallel()
+	// compareAll fans out, and compareOne calls both endpoints
+	// concurrently, so the handler counter is shared across goroutines.
+	var hits atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write([]byte(streamsBodyOne))
+	}))
+	t.Cleanup(srv.Close)
+
+	cases := []loadedCase{
+		{
+			def: bench.QueryDefinition{
+				Query:       `{bad="selector"}`,
+				Source:      "fast/broken.yaml:9",
+				Description: "unexpandable",
+				Kind:        "log",
+				Directions:  "both",
+			},
+			expandErr: errUnexpandable{},
+		},
+		{def: bench.QueryDefinition{Source: "fast/basic.yaml:1"}, tc: logTestCase()},
+	}
+	results := compareAll(cases, flagsFor(srv.URL, srv.URL), false)
+	if len(results) != 2 {
+		t.Fatalf("results = %d, want one per loaded case", len(results))
+	}
+	if !strings.HasPrefix(results[0].UnexpectedFailure, "expansion: ") {
+		t.Fatalf("expansion failure = %q, want the `expansion: ` prefix", results[0].UnexpectedFailure)
+	}
+	if results[0].TestCase.Source != "fast/broken.yaml" {
+		t.Fatalf("source = %q, want the line suffix stripped", results[0].TestCase.Source)
+	}
+	if results[0].TestCase.Direction != "both" {
+		t.Fatalf("direction = %q, want the definition's Directions", results[0].TestCase.Direction)
+	}
+	if !results[1].success() {
+		t.Fatalf("the expandable case did not pass: %+v", results[1])
+	}
+	if got := hits.Load(); got != 2 {
+		t.Fatalf("endpoint hits = %d, want 2 (one case × two endpoints); the unexpandable case must not reach the wire", got)
+	}
+}
+
+type errUnexpandable struct{}
+
+func (errUnexpandable) Error() string { return "no such label in the dataset" }
+
+// TestSummarise pins the four headline counters, including the two
+// places a naive tally goes wrong: an unsupported case counts in BOTH
+// the failure and the unsupported column, and an unexpected success
+// counts as a diff rather than a pass.
+func TestSummarise(t *testing.T) {
+	t.Parallel()
+	results := []Result{
+		{},
+		{},
+		{Diff: "values differ"},
+		{UnexpectedSuccess: true},
+		{UnexpectedFailure: "boom"},
+		{UnexpectedFailure: "status=501", Unsupported: true},
+		// A failure outranks a diff: a case that could not be answered
+		// is not evidence about values.
+		{Diff: "values differ", UnexpectedFailure: "boom"},
+	}
+	pass, diffs, unfail, unsupp := summarise(results)
+	if pass != 2 {
+		t.Fatalf("pass = %d, want 2", pass)
+	}
+	if diffs != 2 {
+		t.Fatalf("diffs = %d, want 2 (one real diff + one unexpected success)", diffs)
+	}
+	if unfail != 3 {
+		t.Fatalf("unfail = %d, want 3", unfail)
+	}
+	if unsupp != 1 {
+		t.Fatalf("unsupp = %d, want 1", unsupp)
+	}
+}
+
+// TestCaseSet pins the roster the parity ratchet reads: one entry per
+// result, in order, carrying the case identity and its verdict.
+// Diverging cases stay in — the ratchet gates on WHICH cases failed.
+func TestCaseSet(t *testing.T) {
+	t.Parallel()
+	results := []Result{
+		{TestCase: TestCase{Source: "fast/a.yaml", Kind: "log", Direction: "FORWARD", Query: "{a=\"b\"}"}},
+		{TestCase: TestCase{Source: "fast/b.yaml", Kind: "metric", Direction: "FORWARD", Query: "sum(x)"}, Diff: "boom"},
+	}
+	cases := caseSet(results)
+	if len(cases) != 2 {
+		t.Fatalf("cases = %d, want 2 (a failing case still appears)", len(cases))
+	}
+	if !cases[0].Passed {
+		t.Fatal("cases[0] should be passing")
+	}
+	if cases[1].Passed {
+		t.Fatal("cases[1] diffed and must not be marked passed")
+	}
+	if cases[0].ID != results[0].TestCase.id() {
+		t.Fatalf("cases[0].ID = %q, want the TestCase identity", cases[0].ID)
+	}
+	if cases[0].ID == cases[1].ID {
+		t.Fatal("two distinct cases collapsed to one identity")
+	}
+}
+
+// TestTestCaseID pins the identity the roster keys on. Start / End are
+// deliberately absent (they identify the RUN), while the lane, step and
+// description are present — an instant and a range flavour of the same
+// query are different cases.
+func TestTestCaseID(t *testing.T) {
+	t.Parallel()
+	base := TestCase{
+		Query:       `{service_name="api"}`,
+		Source:      "fast/basic.yaml",
+		Kind:        "log",
+		Direction:   "BACKWARD",
+		Start:       "2023-11-14T22:13:20Z",
+		End:         "2023-11-14T22:14:20Z",
+		Description: "basic selector",
+	}
+	id := base.id()
+	for _, want := range []string{"fast/basic.yaml", "log", "range", "BACKWARD", `{service_name="api"}`, "basic selector"} {
+		if !strings.Contains(id, want) {
+			t.Fatalf("id %q missing %q", id, want)
+		}
+	}
+	for _, unwanted := range []string{base.Start, base.End} {
+		if strings.Contains(id, unwanted) {
+			t.Fatalf("id %q carries the wall-clock field %q; the identity must be run-independent", id, unwanted)
+		}
+	}
+
+	instant := base
+	instant.Instant = true
+	if instant.id() == id {
+		t.Fatal("instant and range flavours produced the same identity")
+	}
+	if !strings.Contains(instant.id(), "instant") {
+		t.Fatalf("instant id %q does not name the lane", instant.id())
+	}
+
+	stepped := base
+	stepped.Step = "1m0s"
+	if stepped.id() == id {
+		t.Fatal("a step-carrying case produced the same identity as a step-less one")
+	}
+	if !strings.Contains(stepped.id(), "step=1m0s") {
+		t.Fatalf("stepped id %q does not carry the step", stepped.id())
+	}
+
+	undescribed := base
+	undescribed.Description = ""
+	if strings.HasSuffix(undescribed.id(), " | ") {
+		t.Fatalf("an empty description left a dangling separator: %q", undescribed.id())
+	}
+}
+
+// TestNewTestCase pins the wire envelope: RFC3339Nano UTC timestamps, the
+// derived kind, the instant flag, and a step that is present only when
+// the case has one.
+func TestNewTestCase(t *testing.T) {
+	t.Parallel()
+	tc := metricTestCase()
+	tc.Tags = []string{"aggregation"}
+	out := newTestCase(tc, "fast/metrics.yaml", true)
+
+	if out.Kind != "metric" {
+		t.Fatalf("Kind = %q, want metric (derived from the query)", out.Kind)
+	}
+	if out.Start != "2023-11-14T22:13:20Z" || out.End != "2023-11-14T22:14:20Z" {
+		t.Fatalf("window = (%q, %q), want RFC3339Nano UTC", out.Start, out.End)
+	}
+	if out.Step != "1m0s" {
+		t.Fatalf("Step = %q, want 1m0s", out.Step)
+	}
+	if !out.Instant {
+		t.Fatal("Instant flag not propagated")
+	}
+	if out.Direction != "FORWARD" || out.Source != "fast/metrics.yaml" || out.Description != "metric case" {
+		t.Fatalf("envelope = %+v", out)
+	}
+	if len(out.Tags) != 1 || out.Tags[0] != "aggregation" {
+		t.Fatalf("Tags = %v", out.Tags)
+	}
+
+	stepless := logTestCase()
+	if got := newTestCase(stepless, "fast/basic.yaml", false); got.Step != "" {
+		t.Fatalf("a step-less case rendered Step = %q, want empty", got.Step)
+	}
+}
+
+// TestIsUnsupportedErr pins the conservative predicate: only the three
+// documented markers classify as unsupported, and a nil error never
+// does.
+func TestIsUnsupportedErr(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"501", errText("status=501 body=nope"), true},
+		{"not-implemented", errText("status=400 body=not implemented: ip()"), true},
+		{"unsupported", errText("unsupported aggregation"), true},
+		{"plain-400", errText("status=400 body=parse error at line 1"), false},
+		{"500", errText("status=500 body=internal"), false},
+		{"transport", errText("http call: connection refused"), false},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isUnsupportedErr(tc.err); got != tc.want {
+				t.Fatalf("isUnsupportedErr(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+type errText string
+
+func (e errText) Error() string { return string(e) }
+
+// TestWriteReport_ToFile — the report path writes the exact payload, so a
+// downstream consumer parses what the driver built.
+func TestWriteReport_ToFile(t *testing.T) {
+	t.Parallel()
+	payload, err := json.Marshal(Report{TotalResults: 2, IncludePassing: true, Results: []Result{{}, {Diff: "d"}}})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "report.json")
+	if err := writeReport(path, payload); err != nil {
+		t.Fatalf("writeReport: %v", err)
+	}
+	got, err := os.ReadFile(path) //nolint:gosec // test-local temp path
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	var back Report
+	if err := json.Unmarshal(got, &back); err != nil {
+		t.Fatalf("the written file is not the payload we handed in: %v", err)
+	}
+	if back.TotalResults != 2 || len(back.Results) != 2 || back.Results[1].Diff != "d" {
+		t.Fatalf("round-tripped report = %+v", back)
+	}
+}
+
+// TestWriteReport_UnwritablePathErrors — a write failure must surface, or
+// a CI run would report success having produced no artefact.
+func TestWriteReport_UnwritablePathErrors(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "no-such-dir", "report.json")
+	if err := writeReport(path, []byte("{}")); err == nil {
+		t.Fatal("writeReport into a missing directory returned nil error")
+	}
+}

--- a/compatibility/loki/cmd/loki-compliance-tester/decode_test.go
+++ b/compatibility/loki/cmd/loki-compliance-tester/decode_test.go
@@ -1,0 +1,278 @@
+package main
+
+import (
+	"math"
+	"strings"
+	"testing"
+)
+
+// The decoder is the harness's only reading of a Loki response body, so
+// every parity verdict downstream is a statement about what these
+// functions produced. A decoder that silently drops an entry, rounds a
+// timestamp to the wrong unit, or swallows a non-`success` envelope
+// turns a real divergence into a green row — the failure mode is a
+// harness that agrees with itself. The tests below pin each shape's
+// field mapping and each error path's message.
+
+// TestDecodeResponse_Streams pins the streams shape: the `stream` object
+// becomes the label set, and each `[ts, line]` pair becomes an entry
+// with the timestamp parsed as unix NANOS (streams are the one shape
+// Loki serialises in nanoseconds).
+func TestDecodeResponse_Streams(t *testing.T) {
+	t.Parallel()
+	body := []byte(`{"status":"success","data":{"resultType":"streams","result":[
+		{"stream":{"service_name":"api","level":"info"},"values":[["1700000000000000001","first line"],["1700000000000000002","second line"]]},
+		{"stream":{"service_name":"web"},"values":[]}
+	]}}`)
+	got, err := decodeResponse(body)
+	if err != nil {
+		t.Fatalf("decodeResponse: %v", err)
+	}
+	if got.kind != "streams" {
+		t.Fatalf("kind = %q, want streams", got.kind)
+	}
+	if len(got.streams) != 2 {
+		t.Fatalf("streams = %d, want 2", len(got.streams))
+	}
+	if got.streams[0].Labels["service_name"] != "api" || got.streams[0].Labels["level"] != "info" {
+		t.Fatalf("stream[0] labels = %v", got.streams[0].Labels)
+	}
+	if len(got.streams[0].Entries) != 2 {
+		t.Fatalf("stream[0] entries = %d, want 2", len(got.streams[0].Entries))
+	}
+	if got.streams[0].Entries[0].Timestamp != 1700000000000000001 {
+		t.Fatalf("entry[0] timestamp = %d, want 1700000000000000001 (unix nanos, verbatim)", got.streams[0].Entries[0].Timestamp)
+	}
+	if got.streams[0].Entries[0].Line != "first line" {
+		t.Fatalf("entry[0] line = %q", got.streams[0].Entries[0].Line)
+	}
+	if len(got.streams[1].Entries) != 0 {
+		t.Fatalf("stream[1] entries = %d, want 0", len(got.streams[1].Entries))
+	}
+}
+
+// TestDecodeResponse_StreamsBadTimestamp — a stream timestamp that is
+// not an integer is a hard decode error naming the offending token, not
+// a silently dropped entry.
+func TestDecodeResponse_StreamsBadTimestamp(t *testing.T) {
+	t.Parallel()
+	body := []byte(`{"data":{"resultType":"streams","result":[{"stream":{"a":"b"},"values":[["not-a-number","line"]]}]}}`)
+	_, err := decodeResponse(body)
+	if err == nil {
+		t.Fatal("decodeResponse = nil error, want a stream-timestamp parse failure")
+	}
+	if !strings.Contains(err.Error(), "not-a-number") {
+		t.Fatalf("error %q should name the unparseable timestamp", err.Error())
+	}
+}
+
+// TestDecodeResponse_Vector pins the vector shape and the sample-pair
+// unit conversion: Loki serialises the sample timestamp as float
+// SECONDS, and the comparator deals in unix MILLIS.
+func TestDecodeResponse_Vector(t *testing.T) {
+	t.Parallel()
+	body := []byte(`{"status":"success","data":{"resultType":"vector","result":[
+		{"metric":{"level":"error"},"value":[1700000000.5,"42.25"]}
+	]}}`)
+	got, err := decodeResponse(body)
+	if err != nil {
+		t.Fatalf("decodeResponse: %v", err)
+	}
+	if got.kind != "vector" || len(got.vector) != 1 {
+		t.Fatalf("kind=%q len=%d, want vector/1", got.kind, len(got.vector))
+	}
+	if got.vector[0].T != 1700000000500 {
+		t.Fatalf("T = %d, want 1700000000500 (float seconds converted to unix millis)", got.vector[0].T)
+	}
+	if got.vector[0].F != 42.25 {
+		t.Fatalf("F = %v, want 42.25", got.vector[0].F)
+	}
+	if got.vector[0].Metric["level"] != "error" {
+		t.Fatalf("metric = %v", got.vector[0].Metric)
+	}
+}
+
+// TestDecodeResponse_Matrix pins the matrix shape: one entry per series,
+// each carrying its own point list in order.
+func TestDecodeResponse_Matrix(t *testing.T) {
+	t.Parallel()
+	body := []byte(`{"status":"success","data":{"resultType":"matrix","result":[
+		{"metric":{"level":"warn"},"values":[[1700000000,"1"],[1700000060,"2"]]}
+	]}}`)
+	got, err := decodeResponse(body)
+	if err != nil {
+		t.Fatalf("decodeResponse: %v", err)
+	}
+	if got.kind != "matrix" || len(got.matrix) != 1 {
+		t.Fatalf("kind=%q len=%d, want matrix/1", got.kind, len(got.matrix))
+	}
+	pts := got.matrix[0].Floats
+	if len(pts) != 2 {
+		t.Fatalf("points = %d, want 2", len(pts))
+	}
+	if pts[0].T != 1700000000000 || pts[1].T != 1700000060000 {
+		t.Fatalf("point timestamps = %d,%d, want 1700000000000,1700000060000", pts[0].T, pts[1].T)
+	}
+	if pts[0].F != 1 || pts[1].F != 2 {
+		t.Fatalf("point values = %v,%v, want 1,2", pts[0].F, pts[1].F)
+	}
+}
+
+// TestDecodeResponse_StringTimestamps — Loki's own convention is to
+// serialise a sample timestamp as a quoted decimal, so decodeSamplePair
+// carries a string arm alongside the JSON-number arm. Both must apply
+// the same seconds → unix-millis conversion; a string arm that skipped
+// the scaling would put every point a thousand times too early on the
+// axis while the number arm looked correct.
+func TestDecodeResponse_StringTimestamps(t *testing.T) {
+	t.Parallel()
+	body := []byte(`{"status":"success","data":{"resultType":"matrix","result":[
+		{"metric":{"level":"warn"},"values":[["1700000000.5","1"],["1700000060","2"]]}
+	]}}`)
+	got, err := decodeResponse(body)
+	if err != nil {
+		t.Fatalf("decodeResponse: %v", err)
+	}
+	pts := got.matrix[0].Floats
+	if len(pts) != 2 {
+		t.Fatalf("points = %d, want 2", len(pts))
+	}
+	if pts[0].T != 1700000000500 {
+		t.Fatalf("T = %d, want 1700000000500 (string float seconds converted to unix millis)", pts[0].T)
+	}
+	if pts[1].T != 1700000060000 {
+		t.Fatalf("T = %d, want 1700000060000", pts[1].T)
+	}
+	if pts[0].F != 1 || pts[1].F != 2 {
+		t.Fatalf("point values = %v,%v, want 1,2", pts[0].F, pts[1].F)
+	}
+}
+
+// TestDecodeResponse_Scalar pins the scalar shape, including the
+// hasValue flag isEmpty keys on: a decoded scalar is never "empty",
+// however small its value.
+func TestDecodeResponse_Scalar(t *testing.T) {
+	t.Parallel()
+	body := []byte(`{"status":"success","data":{"resultType":"scalar","result":[1700000000,"0"]}}`)
+	got, err := decodeResponse(body)
+	if err != nil {
+		t.Fatalf("decodeResponse: %v", err)
+	}
+	if got.kind != "scalar" {
+		t.Fatalf("kind = %q, want scalar", got.kind)
+	}
+	if !got.hasValue {
+		t.Fatal("hasValue = false; a decoded scalar carries a value even when it is zero")
+	}
+	if got.scalar.T != 1700000000000 || got.scalar.F != 0 {
+		t.Fatalf("scalar = (T=%d, F=%v), want (1700000000000, 0)", got.scalar.T, got.scalar.F)
+	}
+}
+
+// TestDecodeResponse_SpecialFloats — NaN and the infinities survive the
+// string-encoded value round-trip. floatEqual gives NaN==NaN special
+// handling, which is only reachable if the decoder produced a NaN in
+// the first place.
+func TestDecodeResponse_SpecialFloats(t *testing.T) {
+	t.Parallel()
+	body := []byte(`{"data":{"resultType":"matrix","result":[
+		{"metric":{},"values":[[1,"NaN"],[2,"+Inf"],[3,"-Inf"]]}
+	]}}`)
+	got, err := decodeResponse(body)
+	if err != nil {
+		t.Fatalf("decodeResponse: %v", err)
+	}
+	pts := got.matrix[0].Floats
+	if !math.IsNaN(pts[0].F) {
+		t.Fatalf("point[0] = %v, want NaN", pts[0].F)
+	}
+	if !math.IsInf(pts[1].F, 1) {
+		t.Fatalf("point[1] = %v, want +Inf", pts[1].F)
+	}
+	if !math.IsInf(pts[2].F, -1) {
+		t.Fatalf("point[2] = %v, want -Inf", pts[2].F)
+	}
+}
+
+// TestDecodeResponse_ErrorPaths pins each refusal: a body that is not
+// JSON, a non-`success` status, an unknown resultType, a sample value
+// that is not a string-encoded float, and a sample timestamp that is
+// neither a number nor a string-of-number.
+func TestDecodeResponse_ErrorPaths(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name     string
+		body     string
+		wantFrag string
+	}{
+		{"not-json", `{"data":`, "decode envelope"},
+		{"status-error", `{"status":"error","data":{"resultType":"vector","result":[]}}`, `loki status="error"`},
+		{"unknown-result-type", `{"status":"success","data":{"resultType":"histogram","result":[]}}`, `unknown resultType "histogram"`},
+		{"vector-result-not-array", `{"data":{"resultType":"vector","result":{}}}`, "decode vector"},
+		{"matrix-result-not-array", `{"data":{"resultType":"matrix","result":{}}}`, "decode matrix"},
+		{"streams-result-not-array", `{"data":{"resultType":"streams","result":{}}}`, "decode streams"},
+		{"scalar-result-not-pair", `{"data":{"resultType":"scalar","result":{}}}`, "decode scalar"},
+		{"value-not-string", `{"data":{"resultType":"vector","result":[{"metric":{},"value":[1,2]}]}}`, "value decode"},
+		{"value-not-float", `{"data":{"resultType":"vector","result":[{"metric":{},"value":[1,"abc"]}]}}`, `value parse "abc"`},
+		{"ts-string-not-float", `{"data":{"resultType":"vector","result":[{"metric":{},"value":["abc","1"]}]}}`, `ts parse "abc"`},
+		{"ts-neither-number-nor-string", `{"data":{"resultType":"vector","result":[{"metric":{},"value":[{},"1"]}]}}`, "ts decode"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := decodeResponse([]byte(tc.body))
+			if err == nil {
+				t.Fatalf("decodeResponse(%s) = nil error, want %q", tc.body, tc.wantFrag)
+			}
+			if !strings.Contains(err.Error(), tc.wantFrag) {
+				t.Fatalf("error %q missing %q", err.Error(), tc.wantFrag)
+			}
+		})
+	}
+}
+
+// TestTypedResultIsEmpty pins the emptiness predicate compareOne routes
+// on. The matrix arm is the interesting one: upstream treats a matrix
+// carrying series-but-no-points as empty, so a backend answering with
+// bare series headers cannot pass as "rows returned".
+func TestTypedResultIsEmpty(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   typedResult
+		want bool
+	}{
+		{"zero-value", typedResult{}, true},
+		{"streams-none", typedResult{kind: "streams"}, true},
+		{"streams-some", typedResult{kind: "streams", streams: []decodedStream{{}}}, false},
+		{"vector-none", typedResult{kind: "vector"}, true},
+		{"vector-some", typedResult{kind: "vector", vector: []decodedSample{{}}}, false},
+		{"matrix-none", typedResult{kind: "matrix"}, true},
+		{
+			"matrix-series-without-points",
+			typedResult{kind: "matrix", matrix: []decodedSeries{{Metric: map[string]string{"a": "b"}}}},
+			true,
+		},
+		{
+			"matrix-second-series-carries-points",
+			typedResult{kind: "matrix", matrix: []decodedSeries{
+				{},
+				{Floats: []decodedPoint{{T: 1, F: 1}}},
+			}},
+			false,
+		},
+		{"scalar-without-value", typedResult{kind: "scalar"}, true},
+		{"scalar-with-value", typedResult{kind: "scalar", hasValue: true}, false},
+		{"unknown-kind", typedResult{kind: "histogram"}, true},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tc.in.isEmpty(); got != tc.want {
+				t.Fatalf("isEmpty() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/compatibility/loki/cmd/loki-compliance-tester/detected_field_values.go
+++ b/compatibility/loki/cmd/loki-compliance-tester/detected_field_values.go
@@ -173,11 +173,7 @@ func fetchDetectedFieldValues(c *http.Client, addr, field, selector string, star
 		return detectedFieldValuesWire{}, fmt.Errorf("read body: %w", readErr)
 	}
 	if resp.StatusCode != http.StatusOK {
-		snippet := strings.TrimSpace(string(body))
-		if len(snippet) > 400 {
-			snippet = snippet[:400] + "…"
-		}
-		return detectedFieldValuesWire{}, fmt.Errorf("status=%d body=%s", resp.StatusCode, snippet)
+		return detectedFieldValuesWire{}, fmt.Errorf("status=%d body=%s", resp.StatusCode, errorBodySnippet(string(body)))
 	}
 
 	// Consumer-grade decode, same contract as the fields route: the
@@ -217,6 +213,17 @@ func diffDetectedFieldValues(expected, actual detectedFieldValuesWire) string {
 			if !slices.Contains(exp, v) {
 				diffs = append(diffs, fmt.Sprintf("value %q unexpected on test endpoint", v))
 			}
+		}
+		if len(diffs) == 0 {
+			// The two membership loops answer "which values are on one
+			// side only", which is silent when the lists differ solely
+			// in how many times a value appears. Reporting the sorted
+			// lists keeps the sorted-slice inequality this branch was
+			// entered on from resolving to "no diff": a backend
+			// repeating a value where the reference emits it once is a
+			// real wire-shape divergence, and Grafana renders the
+			// duplicate.
+			diffs = append(diffs, fmt.Sprintf("value multiplicity: expected=%v actual=%v", exp, act))
 		}
 	}
 	if expected.Limit != actual.Limit {

--- a/compatibility/loki/cmd/loki-compliance-tester/detected_field_values_test.go
+++ b/compatibility/loki/cmd/loki-compliance-tester/detected_field_values_test.go
@@ -1,0 +1,443 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	bench "github.com/tsouza/cerberus/compatibility/loki/upstream/loki-bench"
+)
+
+// The values pass exists because Logs Drilldown populates its filter
+// menu from one route and filters against another: a field advertised by
+// /detected_fields whose /values route answers differently is the same
+// class of bug as an unqueryable field name. The pass is driven by the
+// REFERENCE backend's own field list, so its enumeration step is part of
+// the contract — a service whose fields cannot be enumerated must
+// produce a visible failure row, never a silently skipped service.
+
+// fieldValuesStub serves both routes the pass calls: the fields
+// enumeration and the per-field values lookup.
+type fieldValuesStub struct {
+	fieldsBody     string
+	valuesBody     map[string]string
+	valuesFallback string
+	status         int
+
+	requestedFields []string
+	requestedPaths  []string
+	requestedQuery  string
+	requestedLimit  string
+}
+
+func newFieldValuesStub(t *testing.T, s *fieldValuesStub) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if s.status != 0 {
+			w.WriteHeader(s.status)
+			_, _ = w.Write([]byte("backend said no"))
+			return
+		}
+		if r.URL.Path == "/loki/api/v1/detected_fields" {
+			_, _ = w.Write([]byte(s.fieldsBody))
+			return
+		}
+		// /loki/api/v1/detected_field/<name>/values
+		name := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/loki/api/v1/detected_field/"), "/values")
+		decoded, err := url.PathUnescape(name)
+		if err != nil {
+			decoded = name
+		}
+		s.requestedFields = append(s.requestedFields, decoded)
+		// EscapedPath is the path as it travelled the wire, which is
+		// what the escaping contract is actually about — r.URL.Path is
+		// already decoded and so cannot distinguish an escaped name
+		// from an unescaped one.
+		s.requestedPaths = append(s.requestedPaths, r.URL.EscapedPath())
+		s.requestedQuery = r.URL.Query().Get("query")
+		s.requestedLimit = r.URL.Query().Get("line_limit")
+		if body, ok := s.valuesBody[decoded]; ok {
+			_, _ = w.Write([]byte(body))
+			return
+		}
+		_, _ = w.Write([]byte(s.valuesFallback))
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+const (
+	fieldsBodyTwo  = `{"fields":[{"label":"status","type":"int","cardinality":3},{"label":"path","type":"string","cardinality":9}],"limit":1000}`
+	valuesBodyABC  = `{"values":["a","b","c"],"limit":1000}`
+	valuesBodyCBA  = `{"values":["c","b","a"],"limit":1000}`
+	valuesBodyNone = `{"values":[],"limit":1000}`
+)
+
+func fieldValuesMetadata() *bench.DatasetMetadata {
+	return &bench.DatasetMetadata{
+		ByServiceName: map[string][]string{
+			"api": {`{service_name="api"}`},
+		},
+		TimeRange: bench.TimeRange{
+			Start: time.Unix(1700000000, 0).UTC(),
+			End:   time.Unix(1700086400, 0).UTC(),
+		},
+	}
+}
+
+// TestDiffDetectedFieldValues_OrderInsensitiveMatch — upstream ranges a
+// Go map to build the list, so its order is random per request. A
+// comparator that were order-sensitive would report a diff on every run
+// of a perfectly correct backend.
+func TestDiffDetectedFieldValues_OrderInsensitiveMatch(t *testing.T) {
+	t.Parallel()
+	expected := detectedFieldValuesWire{Values: []string{"a", "b", "c"}, Limit: 1000}
+	actual := detectedFieldValuesWire{Values: []string{"c", "a", "b"}, Limit: 1000}
+	if diff := diffDetectedFieldValues(expected, actual); diff != "" {
+		t.Fatalf("re-ordered identical value sets diffed: %s", diff)
+	}
+	// The comparator must not mutate its inputs — the caller keeps the
+	// decoded bodies for the report.
+	if expected.Values[0] != "a" || actual.Values[0] != "c" {
+		t.Fatalf("diffDetectedFieldValues sorted its arguments in place: expected=%v actual=%v", expected.Values, actual.Values)
+	}
+}
+
+// TestDiffDetectedFieldValues_Divergences — a missing value, an extra
+// value and a limit disagreement each surface, and all three are
+// reported together rather than short-circuiting on the first.
+func TestDiffDetectedFieldValues_Divergences(t *testing.T) {
+	t.Parallel()
+	expected := detectedFieldValuesWire{Values: []string{"a", "b"}, Limit: 1000}
+	actual := detectedFieldValuesWire{Values: []string{"a", "z"}, Limit: 500}
+	diff := diffDetectedFieldValues(expected, actual)
+	for _, want := range []string{
+		`value "b" missing from test endpoint`,
+		`value "z" unexpected on test endpoint`,
+		"limit: expected=1000 actual=500",
+	} {
+		if !strings.Contains(diff, want) {
+			t.Fatalf("diff %q missing %q", diff, want)
+		}
+	}
+}
+
+// TestDiffDetectedFieldValues_DuplicateCountsMatter — the same value set
+// with a repeated entry is NOT equal: a backend emitting a value twice
+// where the reference emits it once is a real wire-shape divergence, and
+// a set-membership-only comparison would miss it.
+func TestDiffDetectedFieldValues_DuplicateCountsMatter(t *testing.T) {
+	t.Parallel()
+	expected := detectedFieldValuesWire{Values: []string{"a", "b"}, Limit: 1}
+	actual := detectedFieldValuesWire{Values: []string{"a", "a", "b"}, Limit: 1}
+	if diff := diffDetectedFieldValues(expected, actual); diff == "" {
+		t.Fatal("a duplicated value compared equal to the single-occurrence set")
+	}
+}
+
+// TestDetectedFieldValuesCase pins the report envelope: the identity a
+// reviewer reads and the ratchet keys on.
+func TestDetectedFieldValuesCase(t *testing.T) {
+	t.Parallel()
+	start := time.Unix(1700000000, 0).UTC()
+	end := time.Unix(1700086400, 0).UTC()
+	got := detectedFieldValuesCase("api", "status", `{service_name="api"}`, start, end)
+	if got.Kind != "detected_field_values" {
+		t.Fatalf("Kind = %q", got.Kind)
+	}
+	if got.Source != "detected-field-values" {
+		t.Fatalf("Source = %q", got.Source)
+	}
+	if !strings.Contains(got.Description, "service=api") || !strings.Contains(got.Description, "field=status") {
+		t.Fatalf("Description = %q, want both the service and the field named", got.Description)
+	}
+	if got.Query != `{service_name="api"}` {
+		t.Fatalf("Query = %q", got.Query)
+	}
+	if got.Start != "2023-11-14T22:13:20Z" || got.End != "2023-11-15T22:13:20Z" {
+		t.Fatalf("window = (%q, %q), want RFC3339Nano UTC", got.Start, got.End)
+	}
+}
+
+// TestFetchDetectedFieldValues_DecodesBareShape — the route serialises
+// the BARE DetectedFieldsResponse, and the request must carry the
+// line_limit that makes both backends read every seeded row.
+func TestFetchDetectedFieldValues_DecodesBareShape(t *testing.T) {
+	t.Parallel()
+	stub := &fieldValuesStub{valuesFallback: valuesBodyABC}
+	addr := newFieldValuesStub(t, stub)
+
+	got, err := fetchDetectedFieldValues(&http.Client{Timeout: 5 * time.Second}, addr+"/", "status",
+		`{service_name="api"}`, time.Unix(0, 0), time.Unix(60, 0))
+	if err != nil {
+		t.Fatalf("fetchDetectedFieldValues: %v", err)
+	}
+	if len(got.Values) != 3 || got.Limit != 1000 {
+		t.Fatalf("decoded = %+v", got)
+	}
+	if stub.requestedQuery != `{service_name="api"}` {
+		t.Fatalf("query param = %q", stub.requestedQuery)
+	}
+	if stub.requestedLimit != "2000" {
+		t.Fatalf("line_limit = %q, want 2000 (must exceed the seeded rows per service)", stub.requestedLimit)
+	}
+}
+
+// TestFetchDetectedFieldValues_EscapesTheFieldName — a field name with a
+// slash or a space must reach the backend intact, or the pass would
+// query a different field than the one the reference advertised.
+func TestFetchDetectedFieldValues_EscapesTheFieldName(t *testing.T) {
+	t.Parallel()
+	stub := &fieldValuesStub{valuesFallback: valuesBodyABC}
+	addr := newFieldValuesStub(t, stub)
+
+	const awkward = "http/status code"
+	if _, err := fetchDetectedFieldValues(&http.Client{Timeout: 5 * time.Second}, addr, awkward,
+		`{service_name="api"}`, time.Unix(0, 0), time.Unix(60, 0)); err != nil {
+		t.Fatalf("fetchDetectedFieldValues: %v", err)
+	}
+	if len(stub.requestedFields) != 1 || stub.requestedFields[0] != awkward {
+		t.Fatalf("backend saw field %v, want %q intact", stub.requestedFields, awkward)
+	}
+	// The decoded name round-trips even when the slash was NOT escaped,
+	// because the extra path segment lands back inside the same
+	// prefix/suffix trim. Only the on-the-wire path distinguishes the
+	// two, and an unescaped slash is a different route to the backend.
+	const wantPath = "/loki/api/v1/detected_field/http%2Fstatus%20code/values"
+	if stub.requestedPaths[0] != wantPath {
+		t.Fatalf("wire path = %q, want %q", stub.requestedPaths[0], wantPath)
+	}
+}
+
+// TestFetchDetectedFieldValues_RejectsEnvelope — an enveloped body would
+// otherwise decode to zero values and read as "the field has no values",
+// which is exactly the bug class this pass exists to catch.
+func TestFetchDetectedFieldValues_RejectsEnvelope(t *testing.T) {
+	t.Parallel()
+	stub := &fieldValuesStub{valuesFallback: `{"status":"success","data":{"values":["a"],"limit":1000}}`}
+	addr := newFieldValuesStub(t, stub)
+
+	_, err := fetchDetectedFieldValues(&http.Client{Timeout: 5 * time.Second}, addr, "status",
+		`{service_name="api"}`, time.Unix(0, 0), time.Unix(60, 0))
+	if err == nil {
+		t.Fatal("an enveloped body was accepted")
+	}
+	if !strings.Contains(err.Error(), "envelope") {
+		t.Fatalf("error %q should name the envelope", err.Error())
+	}
+}
+
+// TestFetchDetectedFieldValues_ErrorPaths — a non-200 carries the status
+// code, and a body that is not a JSON object is a decode error rather
+// than an empty value set.
+func TestFetchDetectedFieldValues_ErrorPaths(t *testing.T) {
+	t.Parallel()
+
+	failing := newFieldValuesStub(t, &fieldValuesStub{status: http.StatusServiceUnavailable})
+	_, err := fetchDetectedFieldValues(&http.Client{Timeout: 5 * time.Second}, failing, "status",
+		`{service_name="api"}`, time.Unix(0, 0), time.Unix(60, 0))
+	if err == nil || !strings.Contains(err.Error(), "status=503") {
+		t.Fatalf("error = %v, want it to carry status=503", err)
+	}
+
+	garbage := newFieldValuesStub(t, &fieldValuesStub{valuesFallback: `["a","b"]`})
+	_, err = fetchDetectedFieldValues(&http.Client{Timeout: 5 * time.Second}, garbage, "status",
+		`{service_name="api"}`, time.Unix(0, 0), time.Unix(60, 0))
+	if err == nil || !strings.Contains(err.Error(), "decode top-level object") {
+		t.Fatalf("error = %v, want a top-level decode failure", err)
+	}
+}
+
+// TestCompareDetectedFieldValuesOne_Arms drives the per-field verdict:
+// agreement, divergence, an empty baseline (a seed problem, not a parity
+// datapoint), and a failure on each side.
+func TestCompareDetectedFieldValuesOne_Arms(t *testing.T) {
+	t.Parallel()
+	start := time.Unix(1700000000, 0).UTC()
+	end := time.Unix(1700086400, 0).UTC()
+
+	cases := []struct {
+		name        string
+		ref         *fieldValuesStub
+		test        *fieldValuesStub
+		wantPass    bool
+		wantDiff    string
+		wantFailure string
+	}{
+		{
+			name:     "agreement-ignores-order",
+			ref:      &fieldValuesStub{valuesFallback: valuesBodyABC},
+			test:     &fieldValuesStub{valuesFallback: valuesBodyCBA},
+			wantPass: true,
+		},
+		{
+			name:     "divergence",
+			ref:      &fieldValuesStub{valuesFallback: valuesBodyABC},
+			test:     &fieldValuesStub{valuesFallback: `{"values":["a","b"],"limit":1000}`},
+			wantDiff: `value "c" missing from test endpoint`,
+		},
+		{
+			name:        "empty-baseline-is-a-harness-problem",
+			ref:         &fieldValuesStub{valuesFallback: valuesBodyNone},
+			test:        &fieldValuesStub{valuesFallback: valuesBodyABC},
+			wantFailure: "baseline returned empty",
+		},
+		{
+			name:        "reference-side-failure",
+			ref:         &fieldValuesStub{status: http.StatusInternalServerError},
+			test:        &fieldValuesStub{valuesFallback: valuesBodyABC},
+			wantFailure: "reference (-addr-1)",
+		},
+		{
+			name:        "test-side-failure",
+			ref:         &fieldValuesStub{valuesFallback: valuesBodyABC},
+			test:        &fieldValuesStub{status: http.StatusInternalServerError},
+			wantFailure: "status=500",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			f := flagsFor(newFieldValuesStub(t, tc.ref), newFieldValuesStub(t, tc.test))
+			got := compareDetectedFieldValuesOne(&http.Client{Timeout: 5 * time.Second}, f, "api", "status", `{service_name="api"}`, start, end)
+			switch {
+			case tc.wantPass:
+				if !got.success() {
+					t.Fatalf("want pass, got %+v", got)
+				}
+			case tc.wantDiff != "":
+				if !strings.Contains(got.Diff, tc.wantDiff) {
+					t.Fatalf("Diff = %q, want %q (failure=%q)", got.Diff, tc.wantDiff, got.UnexpectedFailure)
+				}
+			default:
+				if !strings.Contains(got.UnexpectedFailure, tc.wantFailure) {
+					t.Fatalf("UnexpectedFailure = %q, want it to contain %q", got.UnexpectedFailure, tc.wantFailure)
+				}
+			}
+		})
+	}
+}
+
+// TestCompareDetectedFieldValuesAll_DrivenByTheReferenceInventory — the
+// pass asks the reference which fields exist and diffs each of them, in
+// sorted order. Driving it from a fixed name list instead would let a
+// field the reference advertises go untested forever.
+func TestCompareDetectedFieldValuesAll_DrivenByTheReferenceInventory(t *testing.T) {
+	t.Parallel()
+	ref := &fieldValuesStub{fieldsBody: fieldsBodyTwo, valuesFallback: valuesBodyABC}
+	test := &fieldValuesStub{fieldsBody: fieldsBodyTwo, valuesFallback: valuesBodyABC}
+	f := flagsFor(newFieldValuesStub(t, ref), newFieldValuesStub(t, test))
+
+	results := compareDetectedFieldValuesAll(&http.Client{Timeout: 5 * time.Second}, f, fieldValuesMetadata())
+	if len(results) != 2 {
+		t.Fatalf("results = %d, want one per advertised field", len(results))
+	}
+	for _, r := range results {
+		if !r.success() {
+			t.Fatalf("agreeing backends produced a non-passing row: %+v", r)
+		}
+	}
+	// sortedFieldLabels drives the order, so the roster is stable across
+	// runs rather than dependent on upstream's map iteration.
+	if len(ref.requestedFields) != 2 || ref.requestedFields[0] != "path" || ref.requestedFields[1] != "status" {
+		t.Fatalf("reference queried fields %v, want [path status] in sorted order", ref.requestedFields)
+	}
+}
+
+// TestCompareDetectedFieldValuesAll_CapsFieldsPerService — the sampled
+// set is bounded, and the cap takes the SORTED prefix so the sample is
+// stable rather than whichever fields upstream's map happened to yield.
+func TestCompareDetectedFieldValuesAll_CapsFieldsPerService(t *testing.T) {
+	t.Parallel()
+	var b strings.Builder
+	b.WriteString(`{"fields":[`)
+	// Names are emitted in descending order so a cap applied before the
+	// sort would keep a different set than a cap applied after it.
+	const wideFieldCount = detectedFieldValuesPerService + 4
+	for i := wideFieldCount - 1; i >= 0; i-- {
+		if i != wideFieldCount-1 {
+			b.WriteString(",")
+		}
+		b.WriteString(`{"label":"f`)
+		b.WriteByte(byte('0' + i))
+		b.WriteString(`","type":"string","cardinality":1}`)
+	}
+	b.WriteString(`],"limit":1000}`)
+
+	ref := &fieldValuesStub{fieldsBody: b.String(), valuesFallback: valuesBodyABC}
+	test := &fieldValuesStub{fieldsBody: b.String(), valuesFallback: valuesBodyABC}
+	f := flagsFor(newFieldValuesStub(t, ref), newFieldValuesStub(t, test))
+
+	results := compareDetectedFieldValuesAll(&http.Client{Timeout: 5 * time.Second}, f, fieldValuesMetadata())
+	if len(results) != detectedFieldValuesPerService {
+		t.Fatalf("results = %d, want the per-service cap of %d", len(results), detectedFieldValuesPerService)
+	}
+	for i, name := range ref.requestedFields {
+		want := "f" + string(rune('0'+i))
+		if name != want {
+			t.Fatalf("sampled field %d = %q, want %q (the sorted prefix)", i, name, want)
+		}
+	}
+}
+
+// TestCompareDetectedFieldValuesAll_EnumerationFailuresAreVisible — a
+// service whose fields cannot be enumerated, or for which the reference
+// advertises none, produces a failure row rather than vanishing from the
+// report.
+func TestCompareDetectedFieldValuesAll_EnumerationFailuresAreVisible(t *testing.T) {
+	t.Parallel()
+
+	broken := flagsFor(
+		newFieldValuesStub(t, &fieldValuesStub{status: http.StatusInternalServerError}),
+		newFieldValuesStub(t, &fieldValuesStub{fieldsBody: fieldsBodyTwo, valuesFallback: valuesBodyABC}),
+	)
+	results := compareDetectedFieldValuesAll(&http.Client{Timeout: 5 * time.Second}, broken, fieldValuesMetadata())
+	if len(results) != 1 {
+		t.Fatalf("results = %d, want one enumeration-failure row", len(results))
+	}
+	if !strings.Contains(results[0].UnexpectedFailure, "cannot enumerate fields") {
+		t.Fatalf("UnexpectedFailure = %q", results[0].UnexpectedFailure)
+	}
+	if !strings.Contains(results[0].TestCase.Description, "field=*") {
+		t.Fatalf("Description = %q, want the wildcard field marker", results[0].TestCase.Description)
+	}
+
+	empty := flagsFor(
+		newFieldValuesStub(t, &fieldValuesStub{fieldsBody: `{"fields":[],"limit":1000}`}),
+		newFieldValuesStub(t, &fieldValuesStub{fieldsBody: fieldsBodyTwo, valuesFallback: valuesBodyABC}),
+	)
+	results = compareDetectedFieldValuesAll(&http.Client{Timeout: 5 * time.Second}, empty, fieldValuesMetadata())
+	if len(results) != 1 {
+		t.Fatalf("results = %d, want one no-fields row", len(results))
+	}
+	if results[0].UnexpectedFailure != "reference advertised no fields for this service" {
+		t.Fatalf("UnexpectedFailure = %q", results[0].UnexpectedFailure)
+	}
+}
+
+// TestCompareDetectedFieldValuesAll_SkipsSelectorlessServices — a
+// metadata entry with no selector cannot be queried, so it contributes
+// no row at all (as opposed to a failure row, which would blame the
+// backend for a fixture gap).
+func TestCompareDetectedFieldValuesAll_SkipsSelectorlessServices(t *testing.T) {
+	t.Parallel()
+	md := fieldValuesMetadata()
+	md.ByServiceName["ghost"] = nil
+
+	ref := &fieldValuesStub{fieldsBody: fieldsBodyTwo, valuesFallback: valuesBodyABC}
+	f := flagsFor(newFieldValuesStub(t, ref), newFieldValuesStub(t, &fieldValuesStub{fieldsBody: fieldsBodyTwo, valuesFallback: valuesBodyABC}))
+
+	results := compareDetectedFieldValuesAll(&http.Client{Timeout: 5 * time.Second}, f, md)
+	if len(results) != 2 {
+		t.Fatalf("results = %d, want the 2 rows of the one queryable service", len(results))
+	}
+	for _, r := range results {
+		if strings.Contains(r.TestCase.Description, "ghost") {
+			t.Fatalf("the selector-less service produced a row: %+v", r.TestCase)
+		}
+	}
+}

--- a/compatibility/loki/cmd/loki-compliance-tester/detected_fields.go
+++ b/compatibility/loki/cmd/loki-compliance-tester/detected_fields.go
@@ -162,11 +162,7 @@ func fetchDetectedFields(c *http.Client, addr, selector string, start, end time.
 		return detectedFieldsWire{}, fmt.Errorf("read body: %w", readErr)
 	}
 	if resp.StatusCode != http.StatusOK {
-		snippet := strings.TrimSpace(string(body))
-		if len(snippet) > 400 {
-			snippet = snippet[:400] + "…"
-		}
-		return detectedFieldsWire{}, fmt.Errorf("status=%d body=%s", resp.StatusCode, snippet)
+		return detectedFieldsWire{}, fmt.Errorf("status=%d body=%s", resp.StatusCode, errorBodySnippet(string(body)))
 	}
 
 	// Consumer-grade decode: the response must be the BARE

--- a/compatibility/loki/cmd/loki-compliance-tester/diff_test.go
+++ b/compatibility/loki/cmd/loki-compliance-tester/diff_test.go
@@ -1,0 +1,381 @@
+package main
+
+import (
+	"math"
+	"strings"
+	"testing"
+)
+
+// The normalise + diff layer IS the parity verdict: `diffTyped`
+// returning "" is what makes a case pass. A comparator that under-reports
+// (missing a divergent point) launders a real cerberus bug into a green
+// score, and one that over-reports buries the real ones in noise. Each
+// test below drives one comparison dimension and asserts BOTH directions
+// — the equal case returns "", the divergent case names the offending
+// index.
+
+// TestLabelsCmp pins the total order the normaliser and every diff
+// function key on. Equal sets compare 0; otherwise the first differing
+// key wins, then the first differing value, then the shorter set sorts
+// first.
+func TestLabelsCmp(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		a, b map[string]string
+		want int // sign
+	}{
+		{"both-empty", map[string]string{}, map[string]string{}, 0},
+		{"identical", map[string]string{"a": "1", "b": "2"}, map[string]string{"b": "2", "a": "1"}, 0},
+		{"key-differs", map[string]string{"a": "1"}, map[string]string{"b": "1"}, -1},
+		{"value-differs", map[string]string{"a": "1"}, map[string]string{"a": "2"}, -1},
+		{"prefix-is-shorter", map[string]string{"a": "1"}, map[string]string{"a": "1", "b": "2"}, -1},
+		{"longer-sorts-after", map[string]string{"a": "1", "b": "2"}, map[string]string{"a": "1"}, 1},
+		{"nil-vs-populated", nil, map[string]string{"a": "1"}, -1},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := labelsCmp(tc.a, tc.b)
+			if sign(got) != tc.want {
+				t.Fatalf("labelsCmp(%v, %v) = %d, want sign %d", tc.a, tc.b, got, tc.want)
+			}
+			// Antisymmetry: swapping the operands must flip the sign,
+			// or the sort the comparator feeds is not a total order.
+			if rev := labelsCmp(tc.b, tc.a); sign(rev) != -tc.want {
+				t.Fatalf("labelsCmp(b, a) = %d, want sign %d (antisymmetry)", rev, -tc.want)
+			}
+		})
+	}
+}
+
+func sign(n int) int {
+	switch {
+	case n < 0:
+		return -1
+	case n > 0:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// TestNormaliseTypedResult_ReordersToAgreement is the normaliser's whole
+// reason to exist: two backends that return the same data in different
+// order must diff clean. Feeding both orderings through the normaliser
+// and asserting the diff is empty pins that end to end, and the
+// pre-normalisation assertion confirms the input really was scrambled.
+func TestNormaliseTypedResult_ReordersToAgreement(t *testing.T) {
+	t.Parallel()
+
+	forward := typedResult{kind: "vector", vector: []decodedSample{
+		{Metric: map[string]string{"level": "error"}, T: 1000, F: 1},
+		{Metric: map[string]string{"level": "info"}, T: 1000, F: 2},
+	}}
+	reversed := typedResult{kind: "vector", vector: []decodedSample{
+		{Metric: map[string]string{"level": "info"}, T: 1000, F: 2},
+		{Metric: map[string]string{"level": "error"}, T: 1000, F: 1},
+	}}
+	if diffTyped(forward, reversed, 0) == "" {
+		t.Fatal("un-normalised vectors in opposite order diffed clean; the fixture does not exercise the sort")
+	}
+	if diff := diffTyped(normaliseTypedResult(forward), normaliseTypedResult(reversed), 0); diff != "" {
+		t.Fatalf("normalised vectors still diff: %s", diff)
+	}
+
+	matrixA := typedResult{kind: "matrix", matrix: []decodedSeries{
+		{Metric: map[string]string{"level": "warn"}, Floats: []decodedPoint{{T: 1, F: 1}}},
+		{Metric: map[string]string{"level": "debug"}, Floats: []decodedPoint{{T: 1, F: 2}}},
+	}}
+	matrixB := typedResult{kind: "matrix", matrix: []decodedSeries{
+		{Metric: map[string]string{"level": "debug"}, Floats: []decodedPoint{{T: 1, F: 2}}},
+		{Metric: map[string]string{"level": "warn"}, Floats: []decodedPoint{{T: 1, F: 1}}},
+	}}
+	if diff := diffTyped(normaliseTypedResult(matrixA), normaliseTypedResult(matrixB), 0); diff != "" {
+		t.Fatalf("normalised matrices still diff: %s", diff)
+	}
+	if got := matrixA.matrix[0].Metric["level"]; got != "debug" {
+		t.Fatalf("matrix series[0] = %q after normalise, want debug (label order)", got)
+	}
+}
+
+// TestNormaliseTypedResult_SortsStreamsAndEntries — streams sort by
+// label set, and entries WITHIN a stream sort by timestamp then line.
+// The line tie-break matters: two entries sharing a nanosecond
+// timestamp would otherwise order by arrival and diff spuriously.
+func TestNormaliseTypedResult_SortsStreamsAndEntries(t *testing.T) {
+	t.Parallel()
+	in := typedResult{kind: "streams", streams: []decodedStream{
+		{Labels: map[string]string{"svc": "web"}, Entries: []logEntry{{Timestamp: 5, Line: "e"}}},
+		{Labels: map[string]string{"svc": "api"}, Entries: []logEntry{
+			{Timestamp: 9, Line: "third"},
+			{Timestamp: 3, Line: "zebra"},
+			{Timestamp: 3, Line: "alpha"},
+		}},
+	}}
+	got := normaliseTypedResult(in)
+	if got.streams[0].Labels["svc"] != "api" {
+		t.Fatalf("streams[0] = %v, want the api stream first", got.streams[0].Labels)
+	}
+	entries := got.streams[0].Entries
+	wantLines := []string{"alpha", "zebra", "third"}
+	for i, want := range wantLines {
+		if entries[i].Line != want {
+			t.Fatalf("entry[%d] line = %q, want %q (timestamp then line order)", i, entries[i].Line, want)
+		}
+	}
+}
+
+// TestNormaliseTypedResult_LeavesScalarUntouched — the scalar arm has no
+// ordering to canonicalise, so the value must pass through unchanged.
+func TestNormaliseTypedResult_LeavesScalarUntouched(t *testing.T) {
+	t.Parallel()
+	in := typedResult{kind: "scalar", scalar: decodedSample{T: 7, F: 3.5}, hasValue: true}
+	got := normaliseTypedResult(in)
+	if got.scalar.T != 7 || got.scalar.F != 3.5 || !got.hasValue {
+		t.Fatalf("scalar changed under normalise: %+v", got.scalar)
+	}
+}
+
+// TestDiffTyped_KindMismatch — a resultType disagreement is reported as
+// such rather than falling through to a shape-specific comparator that
+// would read the wrong (empty) slice and pass.
+func TestDiffTyped_KindMismatch(t *testing.T) {
+	t.Parallel()
+	diff := diffTyped(typedResult{kind: "matrix"}, typedResult{kind: "streams"}, 0)
+	if !strings.Contains(diff, "resultType differs") ||
+		!strings.Contains(diff, "expected=matrix") ||
+		!strings.Contains(diff, "actual=streams") {
+		t.Fatalf("diff = %q, want a resultType mismatch naming both kinds", diff)
+	}
+}
+
+// TestDiffTyped_UnknownKindComparesClean pins the fall-through: an
+// unrecognised (or zero) kind has no comparator, so two such results
+// agree. compareOne never reaches it — isEmpty() rejects the zero kind
+// first — and this asserts the fall-through stays a no-op rather than
+// panicking on a nil slice.
+func TestDiffTyped_UnknownKindComparesClean(t *testing.T) {
+	t.Parallel()
+	if diff := diffTyped(typedResult{}, typedResult{}, 0); diff != "" {
+		t.Fatalf("diffTyped over two zero results = %q, want empty", diff)
+	}
+}
+
+// TestDiffVector drives every dimension the vector comparator checks.
+func TestDiffVector(t *testing.T) {
+	t.Parallel()
+	base := []decodedSample{
+		{Metric: map[string]string{"level": "info"}, T: 1000, F: 5},
+		{Metric: map[string]string{"level": "warn"}, T: 1000, F: 6},
+	}
+	if diff := diffVector(base, base, 0); diff != "" {
+		t.Fatalf("identical vectors diff: %s", diff)
+	}
+
+	cases := []struct {
+		name     string
+		actual   []decodedSample
+		wantFrag string
+	}{
+		{"length", base[:1], "vector length: expected=2 actual=1"},
+		{
+			"metric",
+			[]decodedSample{base[0], {Metric: map[string]string{"level": "error"}, T: 1000, F: 6}},
+			"vector[1] metric differs",
+		},
+		{
+			"timestamp",
+			[]decodedSample{base[0], {Metric: map[string]string{"level": "warn"}, T: 2000, F: 6}},
+			"vector[1] timestamp differs: expected=1000 actual=2000",
+		},
+		{
+			"value",
+			[]decodedSample{base[0], {Metric: map[string]string{"level": "warn"}, T: 1000, F: 99}},
+			"vector[1] value differs: expected=6 actual=99",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			diff := diffVector(base, tc.actual, 0)
+			if !strings.Contains(diff, tc.wantFrag) {
+				t.Fatalf("diff = %q, want it to contain %q", diff, tc.wantFrag)
+			}
+		})
+	}
+}
+
+// TestDiffMatrix drives the matrix comparator, including the per-series
+// point-list dimensions a series-level-only comparison would miss.
+func TestDiffMatrix(t *testing.T) {
+	t.Parallel()
+	base := []decodedSeries{{
+		Metric: map[string]string{"level": "info"},
+		Floats: []decodedPoint{{T: 1000, F: 1}, {T: 2000, F: 2}},
+	}}
+	if diff := diffMatrix(base, base, 0); diff != "" {
+		t.Fatalf("identical matrices diff: %s", diff)
+	}
+
+	cases := []struct {
+		name     string
+		actual   []decodedSeries
+		wantFrag string
+	}{
+		{"series-count", nil, "matrix length: expected=1 actual=0"},
+		{
+			"metric",
+			[]decodedSeries{{Metric: map[string]string{"level": "warn"}, Floats: base[0].Floats}},
+			"matrix[0] metric differs",
+		},
+		{
+			"point-count",
+			[]decodedSeries{{Metric: base[0].Metric, Floats: base[0].Floats[:1]}},
+			"matrix[0] series length: expected=2 actual=1",
+		},
+		{
+			"point-timestamp",
+			[]decodedSeries{{Metric: base[0].Metric, Floats: []decodedPoint{{T: 1000, F: 1}, {T: 2500, F: 2}}}},
+			"matrix[0].points[1] timestamp differs: expected=2000 actual=2500",
+		},
+		{
+			"point-value",
+			[]decodedSeries{{Metric: base[0].Metric, Floats: []decodedPoint{{T: 1000, F: 1}, {T: 2000, F: 7}}}},
+			"matrix[0].points[1] value differs: expected=2 actual=7",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			diff := diffMatrix(base, tc.actual, 0)
+			if !strings.Contains(diff, tc.wantFrag) {
+				t.Fatalf("diff = %q, want it to contain %q", diff, tc.wantFrag)
+			}
+		})
+	}
+}
+
+// TestDiffScalar covers both scalar dimensions.
+func TestDiffScalar(t *testing.T) {
+	t.Parallel()
+	base := decodedSample{T: 1000, F: 4}
+	if diff := diffScalar(base, base, 0); diff != "" {
+		t.Fatalf("identical scalars diff: %s", diff)
+	}
+	if diff := diffScalar(base, decodedSample{T: 2000, F: 4}, 0); !strings.Contains(diff, "scalar timestamp differs: expected=1000 actual=2000") {
+		t.Fatalf("timestamp diff = %q", diff)
+	}
+	if diff := diffScalar(base, decodedSample{T: 1000, F: 9}, 0); !strings.Contains(diff, "scalar value differs: expected=4 actual=9") {
+		t.Fatalf("value diff = %q", diff)
+	}
+}
+
+// TestDiffStreams drives the log-shape comparator. The line dimension is
+// the one that catches a wrong parser stage: same labels, same
+// timestamps, different text.
+func TestDiffStreams(t *testing.T) {
+	t.Parallel()
+	base := []decodedStream{{
+		Labels:  map[string]string{"svc": "api"},
+		Entries: []logEntry{{Timestamp: 1, Line: "one"}, {Timestamp: 2, Line: "two"}},
+	}}
+	if diff := diffStreams(base, base); diff != "" {
+		t.Fatalf("identical streams diff: %s", diff)
+	}
+
+	cases := []struct {
+		name     string
+		actual   []decodedStream
+		wantFrag string
+	}{
+		{"stream-count", nil, "streams length: expected=1 actual=0"},
+		{
+			"labels",
+			[]decodedStream{{Labels: map[string]string{"svc": "web"}, Entries: base[0].Entries}},
+			"streams[0] labels differ",
+		},
+		{
+			"entry-count",
+			[]decodedStream{{Labels: base[0].Labels, Entries: base[0].Entries[:1]}},
+			"streams[0] entry count: expected=2 actual=1",
+		},
+		{
+			"entry-timestamp",
+			[]decodedStream{{Labels: base[0].Labels, Entries: []logEntry{{Timestamp: 1, Line: "one"}, {Timestamp: 5, Line: "two"}}}},
+			"streams[0].entries[1] timestamp differs: expected=2 actual=5",
+		},
+		{
+			"entry-line",
+			[]decodedStream{{Labels: base[0].Labels, Entries: []logEntry{{Timestamp: 1, Line: "one"}, {Timestamp: 2, Line: "TWO"}}}},
+			`streams[0].entries[1] line differs: expected="two" actual="TWO"`,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			diff := diffStreams(base, tc.actual)
+			if !strings.Contains(diff, tc.wantFrag) {
+				t.Fatalf("diff = %q, want it to contain %q", diff, tc.wantFrag)
+			}
+		})
+	}
+}
+
+// TestFloatEqual pins the tolerance semantics the whole value diff rests
+// on: NaN equals NaN, an infinity equals only the same infinity (the
+// tolerance never applies to one), and a positive tolerance is an
+// inclusive absolute bound.
+func TestFloatEqual(t *testing.T) {
+	t.Parallel()
+	const tol = 1e-5
+	cases := []struct {
+		name string
+		a, b float64
+		tol  float64
+		want bool
+	}{
+		{"nan-nan", math.NaN(), math.NaN(), tol, true},
+		{"nan-vs-number", math.NaN(), 1, tol, false},
+		{"pos-inf-pair", math.Inf(1), math.Inf(1), tol, true},
+		{"neg-inf-pair", math.Inf(-1), math.Inf(-1), tol, true},
+		{"opposite-infinities", math.Inf(1), math.Inf(-1), tol, false},
+		{"inf-vs-huge-number", math.Inf(1), math.MaxFloat64, tol, false},
+		{"within-tolerance", 1.0, 1.0 + tol/2, tol, true},
+		// The bound is inclusive. The operands are binary-exact so the
+		// difference is exactly the tolerance rather than one ulp above
+		// it, which is what `1.0 + 1e-5` would actually produce.
+		{"exactly-at-tolerance", 1.0, 1.25, 0.25, true},
+		{"outside-tolerance", 1.0, 1.0 + tol*10, tol, false},
+		{"zero-tolerance-exact", 1.5, 1.5, 0, true},
+		{"zero-tolerance-inexact", 1.5, 1.5000001, 0, false},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := floatEqual(tc.a, tc.b, tc.tol); got != tc.want {
+				t.Fatalf("floatEqual(%v, %v, %v) = %v, want %v", tc.a, tc.b, tc.tol, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDiffTyped_ToleranceIsApplied confirms the tolerance argument
+// actually reaches the leaf comparison rather than being dropped on the
+// way through diffTyped.
+func TestDiffTyped_ToleranceIsApplied(t *testing.T) {
+	t.Parallel()
+	expected := typedResult{kind: "vector", vector: []decodedSample{{Metric: map[string]string{}, T: 1, F: 1.0}}}
+	actual := typedResult{kind: "vector", vector: []decodedSample{{Metric: map[string]string{}, T: 1, F: 1.000001}}}
+	if diff := diffTyped(expected, actual, 1e-5); diff != "" {
+		t.Fatalf("within-tolerance vectors diff: %s", diff)
+	}
+	if diff := diffTyped(expected, actual, 0); diff == "" {
+		t.Fatal("zero-tolerance comparison of unequal values returned no diff")
+	}
+}

--- a/compatibility/loki/cmd/loki-compliance-tester/main.go
+++ b/compatibility/loki/cmd/loki-compliance-tester/main.go
@@ -857,16 +857,29 @@ func doQuery(c *http.Client, u string, params url.Values) (typedResult, error) {
 		return typedResult{}, fmt.Errorf("read body: %w", readErr)
 	}
 	if resp.StatusCode != http.StatusOK {
-		// Truncate the error body so a wall-of-text upstream stack
-		// trace doesn't dominate the diff column.
-		snippet := strings.TrimSpace(string(body))
-		if len(snippet) > 400 {
-			snippet = snippet[:400] + "…"
-		}
-		return typedResult{}, fmt.Errorf("status=%d body=%s", resp.StatusCode, snippet)
+		return typedResult{}, fmt.Errorf("status=%d body=%s", resp.StatusCode, errorBodySnippet(string(body)))
 	}
 
 	return decodeResponse(body)
+}
+
+// errorBodySnippetMaxLen bounds how much of a failing response body the
+// harness quotes back. Upstream answers a rejected request with an HTML
+// page or a full Go stack trace; unbounded, either dominates the
+// report's diff column and buries the status code that actually carries
+// the signal.
+const errorBodySnippetMaxLen = 400
+
+// errorBodySnippet trims and bounds a failing response body for use in
+// an error message or a mismatch report. Every fetch path in this
+// driver quotes bodies through here so the bound is one number rather
+// than one per call site.
+func errorBodySnippet(body string) string {
+	trimmed := strings.TrimSpace(body)
+	if len(trimmed) <= errorBodySnippetMaxLen {
+		return trimmed
+	}
+	return trimmed[:errorBodySnippetMaxLen] + "…"
 }
 
 // ----- response decoder ---------------------------------------------

--- a/compatibility/loki/cmd/loki-compliance-tester/passes_test.go
+++ b/compatibility/loki/cmd/loki-compliance-tester/passes_test.go
@@ -1,0 +1,300 @@
+package main
+
+import (
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	bench "github.com/tsouza/cerberus/compatibility/loki/upstream/loki-bench"
+)
+
+// The driver-level fan-out: the detected-fields differential, the
+// status-parity differential, and the corpus split that feeds the
+// upstream-skip baseline. Each decides what lands in the report without
+// any per-case oracle behind it, so a wrong branch here is a wrong
+// parity verdict nothing downstream re-checks.
+
+// TestCompareDetectedFieldsOne_Arms drives the per-service fields
+// verdict. The two emptiness arms matter most: an empty list on either
+// side is a harness/seed problem, and reporting it as a clean pass would
+// make a service with no seeded data look like agreement.
+func TestCompareDetectedFieldsOne_Arms(t *testing.T) {
+	t.Parallel()
+	start := time.Unix(1700000000, 0).UTC()
+	end := time.Unix(1700086400, 0).UTC()
+
+	cases := []struct {
+		name        string
+		ref         *fieldValuesStub
+		test        *fieldValuesStub
+		wantPass    bool
+		wantDiff    string
+		wantFailure string
+	}{
+		{
+			name:     "agreement",
+			ref:      &fieldValuesStub{fieldsBody: fieldsBodyTwo},
+			test:     &fieldValuesStub{fieldsBody: fieldsBodyTwo},
+			wantPass: true,
+		},
+		{
+			name:     "cardinality-divergence",
+			ref:      &fieldValuesStub{fieldsBody: fieldsBodyTwo},
+			test:     &fieldValuesStub{fieldsBody: `{"fields":[{"label":"status","type":"int","cardinality":4},{"label":"path","type":"string","cardinality":9}],"limit":1000}`},
+			wantDiff: `field "status" cardinality`,
+		},
+		{
+			name:        "empty-baseline",
+			ref:         &fieldValuesStub{fieldsBody: `{"fields":[],"limit":1000}`},
+			test:        &fieldValuesStub{fieldsBody: fieldsBodyTwo},
+			wantFailure: "baseline returned empty",
+		},
+		{
+			name:        "empty-test-endpoint",
+			ref:         &fieldValuesStub{fieldsBody: fieldsBodyTwo},
+			test:        &fieldValuesStub{fieldsBody: `{"fields":[],"limit":1000}`},
+			wantFailure: "test endpoint returned empty",
+		},
+		{
+			name:        "reference-side-failure",
+			ref:         &fieldValuesStub{status: http.StatusInternalServerError},
+			test:        &fieldValuesStub{fieldsBody: fieldsBodyTwo},
+			wantFailure: "reference (-addr-1) failed",
+		},
+		{
+			name:        "test-side-failure",
+			ref:         &fieldValuesStub{fieldsBody: fieldsBodyTwo},
+			test:        &fieldValuesStub{status: http.StatusInternalServerError},
+			wantFailure: "status=500",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			f := flagsFor(newFieldValuesStub(t, tc.ref), newFieldValuesStub(t, tc.test))
+			got := compareDetectedFieldsOne(&http.Client{Timeout: 5 * time.Second}, f, "api", `{service_name="api"}`, start, end)
+			if got.TestCase.Kind != "detected_fields" || !strings.Contains(got.TestCase.Description, "service=api") {
+				t.Fatalf("envelope = %+v", got.TestCase)
+			}
+			switch {
+			case tc.wantPass:
+				if !got.success() {
+					t.Fatalf("want a pass, got %+v", got)
+				}
+			case tc.wantDiff != "":
+				if !strings.Contains(got.Diff, tc.wantDiff) {
+					t.Fatalf("Diff = %q, want it to contain %q (failure=%q)", got.Diff, tc.wantDiff, got.UnexpectedFailure)
+				}
+			default:
+				if !strings.Contains(got.UnexpectedFailure, tc.wantFailure) {
+					t.Fatalf("UnexpectedFailure = %q, want it to contain %q", got.UnexpectedFailure, tc.wantFailure)
+				}
+			}
+		})
+	}
+}
+
+// TestCompareDetectedFieldsAll_OnePerQueryableService — one row per
+// seeded service in sorted service order, and a service carrying no
+// selector contributes none rather than a bogus empty-query row.
+func TestCompareDetectedFieldsAll_OnePerQueryableService(t *testing.T) {
+	t.Parallel()
+	md := fieldValuesMetadata()
+	md.ByServiceName["zulu"] = []string{`{service_name="zulu"}`}
+	md.ByServiceName["ghost"] = nil
+
+	f := flagsFor(
+		newFieldValuesStub(t, &fieldValuesStub{fieldsBody: fieldsBodyTwo}),
+		newFieldValuesStub(t, &fieldValuesStub{fieldsBody: fieldsBodyTwo}),
+	)
+	results := compareDetectedFieldsAll(&http.Client{Timeout: 5 * time.Second}, f, md)
+	if len(results) != 2 {
+		t.Fatalf("results = %d, want one per queryable service", len(results))
+	}
+	if !strings.Contains(results[0].TestCase.Description, "service=api") ||
+		!strings.Contains(results[1].TestCase.Description, "service=zulu") {
+		t.Fatalf("service order = [%q, %q], want it sorted", results[0].TestCase.Description, results[1].TestCase.Description)
+	}
+	for _, r := range results {
+		if !r.success() {
+			t.Fatalf("agreeing backends produced a non-passing row: %+v", r)
+		}
+	}
+}
+
+// TestCompareStatusParityAll_RunsEveryFixedCase — the fan-out over the
+// fixed case table. Every case must reach the report: a loop that
+// dropped one would shrink the denominator invisibly, the same failure
+// mode the zero-expansion rail exists to prevent on the corpus side.
+func TestCompareStatusParityAll_RunsEveryFixedCase(t *testing.T) {
+	ref := statusServer(t, http.StatusBadRequest)
+	test := statusServer(t, http.StatusBadRequest)
+
+	results := compareStatusParityAll(&http.Client{Timeout: 5 * time.Second}, flags{addr1: ref.URL, addr2: test.URL})
+	want := statusParityCases()
+	if len(results) != len(want) {
+		t.Fatalf("results = %d, want one per fixed case (%d)", len(results), len(want))
+	}
+	for i, r := range results {
+		if !r.success() {
+			t.Fatalf("agreeing rejection produced a non-passing row: %+v", r)
+		}
+		if r.TestCase.Source != statusParitySource || r.TestCase.Kind != "status_parity" {
+			t.Fatalf("row %d envelope = %+v", i, r.TestCase)
+		}
+		if r.TestCase.Description != want[i].desc {
+			t.Fatalf("row %d description = %q, want %q", i, r.TestCase.Description, want[i].desc)
+		}
+	}
+}
+
+// TestErrorBodySnippet — every fetch path quotes a failing body through
+// this one helper, so its bound is the single thing standing between an
+// upstream HTML error page and the report's diff column.
+func TestErrorBodySnippet(t *testing.T) {
+	t.Parallel()
+	if got := errorBodySnippet("  short  "); got != "short" {
+		t.Fatalf("snippet = %q, want the body trimmed and otherwise unchanged", got)
+	}
+	atBound := strings.Repeat("y", errorBodySnippetMaxLen)
+	if got := errorBodySnippet(atBound); got != atBound {
+		t.Fatalf("a body exactly at the bound was truncated (len=%d)", len(got))
+	}
+	got := errorBodySnippet(atBound + "overflow")
+	if !strings.HasSuffix(got, "…") {
+		t.Fatalf("the truncated snippet does not end in an ellipsis: %q", got[len(got)-5:])
+	}
+	if trimmed := strings.TrimSuffix(got, "…"); trimmed != atBound {
+		t.Fatalf("the truncated snippet carries %d chars of body, want %d", len(trimmed), errorBodySnippetMaxLen)
+	}
+}
+
+// TestLoadAllQueriesAndSplit_PartitionsTheRealCorpus runs the real
+// vendored corpus through the split that feeds the upstream-skip
+// baseline. Both partitions must be non-empty and disjoint: a split that
+// dumped everything into one side would make the baseline rail either
+// vacuous or a whole-corpus dump, and neither is visible from the
+// baseline file alone.
+func TestLoadAllQueriesAndSplit_PartitionsTheRealCorpus(t *testing.T) {
+	t.Parallel()
+	f := flags{corpusDir: filepath.Join("..", "..", "upstream", "loki-bench", "queries")}
+	runnable, skipped, err := loadAllQueriesAndSplit(f)
+	if err != nil {
+		t.Fatalf("loadAllQueriesAndSplit: %v", err)
+	}
+	if len(runnable) == 0 {
+		t.Fatal("no runnable definitions; the compare path would have nothing to do")
+	}
+	if len(skipped) == 0 {
+		t.Fatal("no upstream-skipped definitions; the baseline rail would be vacuous")
+	}
+	seen := make(map[string]struct{}, len(runnable))
+	for _, def := range runnable {
+		if def.Skip {
+			t.Fatalf("definition %q is marked Skip but landed in the runnable partition", baselineKey(def))
+		}
+		seen[baselineKey(def)] = struct{}{}
+	}
+	for _, def := range skipped {
+		if !def.Skip {
+			t.Fatalf("definition %q is not marked Skip but landed in the skipped partition", baselineKey(def))
+		}
+		if _, dup := seen[baselineKey(def)]; dup {
+			t.Fatalf("definition %q appears in both partitions", baselineKey(def))
+		}
+	}
+
+	// The committed baseline is what the skipped partition is diffed
+	// against, so the two must agree on the real corpus.
+	if err := checkSkipBaseline(filepath.Join("..", "..", "upstream-skip-baseline.txt"), skipped); err != nil {
+		t.Fatalf("the corpus's skip set has drifted from the committed baseline: %v", err)
+	}
+}
+
+// TestLoadAllQueriesAndSplit_MissingCorpusErrors — a bad -corpus path is
+// a hard error, not an empty (and therefore vacuously clean) split.
+func TestLoadAllQueriesAndSplit_MissingCorpusErrors(t *testing.T) {
+	t.Parallel()
+	_, _, err := loadAllQueriesAndSplit(flags{corpusDir: filepath.Join(t.TempDir(), "nope")})
+	if err == nil {
+		t.Fatal("loadAllQueriesAndSplit over a missing directory returned no error")
+	}
+	if !strings.Contains(err.Error(), "registry.Load") {
+		t.Fatalf("error %q should name the failing load", err.Error())
+	}
+}
+
+// TestLoadCerberusQueries_MissingDirErrors — the additive corpus is
+// mandatory once configured; a typo'd path must fail rather than
+// silently contributing zero extra cases to the score.
+func TestLoadCerberusQueries_MissingDirErrors(t *testing.T) {
+	t.Parallel()
+	suites := []bench.Suite{bench.SuiteFast, bench.SuiteRegression, bench.SuiteExhaustive}
+	_, err := loadCerberusQueries(flags{cerberusQueriesDir: filepath.Join(t.TempDir(), "nope")}, suites)
+	if err == nil {
+		t.Fatal("loadCerberusQueries over a missing directory returned no error")
+	}
+	if !strings.Contains(err.Error(), "cerberus query registry.Load") {
+		t.Fatalf("error %q should name the cerberus registry", err.Error())
+	}
+}
+
+// TestLoadCases_MissingMetadataErrors — without dataset metadata the
+// template resolver cannot expand a single query, so the load fails
+// instead of producing a silently empty corpus.
+func TestLoadCases_MissingMetadataErrors(t *testing.T) {
+	t.Parallel()
+	f := flags{
+		corpusDir:          filepath.Join("..", "..", "upstream", "loki-bench", "queries"),
+		cerberusQueriesDir: filepath.Join("..", "..", "cerberus-queries"),
+		metadataDir:        filepath.Join(t.TempDir(), "nope"),
+	}
+	if _, err := loadCases(f, false); err == nil {
+		t.Fatal("loadCases without dataset metadata returned no error")
+	}
+}
+
+// TestLoadCases_InstantModeKeepsMetricQueriesOnly mirrors upstream's
+// remote_test.go: the instant lane drops log queries and collapses each
+// surviving metric case to a point. A lane that kept log queries would
+// send them to /query_range anyway and double-count them in the score.
+func TestLoadCases_InstantModeKeepsMetricQueriesOnly(t *testing.T) {
+	t.Parallel()
+	f := flags{
+		corpusDir:          filepath.Join("..", "..", "upstream", "loki-bench", "queries"),
+		cerberusQueriesDir: filepath.Join("..", "..", "cerberus-queries"),
+		metadataDir:        filepath.Join("..", ".."),
+		seed:               1,
+	}
+	rangeCases, err := loadCases(f, false)
+	if err != nil {
+		t.Fatalf("loadCases(range): %v", err)
+	}
+	instantCases, err := loadCases(f, true)
+	if err != nil {
+		t.Fatalf("loadCases(instant): %v", err)
+	}
+	if len(instantCases) == 0 {
+		t.Fatal("the instant lane produced no cases")
+	}
+	if len(instantCases) >= len(rangeCases) {
+		t.Fatalf("instant cases = %d, range cases = %d; the instant lane must drop the log queries", len(instantCases), len(rangeCases))
+	}
+	for _, lc := range instantCases {
+		if lc.expandErr != nil {
+			continue
+		}
+		if lc.tc.Kind() != "metric" {
+			t.Fatalf("the instant lane kept a %q case: %s", lc.tc.Kind(), lc.tc.Query)
+		}
+		if !lc.tc.Start.Equal(lc.tc.End) {
+			t.Fatalf("instant case %q was not collapsed to a point: [%v, %v]", lc.tc.Query, lc.tc.Start, lc.tc.End)
+		}
+		if lc.tc.Step != 0 {
+			t.Fatalf("instant case %q kept step %v", lc.tc.Query, lc.tc.Step)
+		}
+	}
+}

--- a/compatibility/loki/cmd/loki-compliance-tester/status_parity.go
+++ b/compatibility/loki/cmd/loki-compliance-tester/status_parity.go
@@ -158,17 +158,17 @@ func compareStatusParityOne(c *http.Client, f flags, sc statusParityCase, start,
 	case refStatus != sc.expect && testStatus != sc.expect:
 		result.UnexpectedFailure = fmt.Sprintf(
 			"status parity: reference status=%d test status=%d, both expected %d (ref body=%s; test body=%s)",
-			refStatus, testStatus, sc.expect, statusParitySnippet(out[0].body), statusParitySnippet(out[1].body),
+			refStatus, testStatus, sc.expect, errorBodySnippet(out[0].body), errorBodySnippet(out[1].body),
 		)
 	case refStatus != sc.expect:
 		result.UnexpectedFailure = fmt.Sprintf(
 			"status parity: reference (-addr-1) returned status=%d, expected %d (body=%s)",
-			refStatus, sc.expect, statusParitySnippet(out[0].body),
+			refStatus, sc.expect, errorBodySnippet(out[0].body),
 		)
 	case testStatus != sc.expect:
 		result.UnexpectedFailure = fmt.Sprintf(
 			"status parity: test endpoint (-addr-2) returned status=%d, expected %d (body=%s)",
-			testStatus, sc.expect, statusParitySnippet(out[1].body),
+			testStatus, sc.expect, errorBodySnippet(out[1].body),
 		)
 	}
 	return result
@@ -203,16 +203,4 @@ func fetchRawStatus(c *http.Client, addr, path string, params url.Values) (int, 
 		return 0, "", fmt.Errorf("read body: %w", readErr)
 	}
 	return resp.StatusCode, strings.TrimSpace(string(body)), nil
-}
-
-// statusParitySnippetMaxLen bounds the body snippet embedded in a
-// mismatch message so a wall-of-text error page doesn't dominate the
-// report, mirroring doQuery's / fetchDetectedFields's truncation.
-const statusParitySnippetMaxLen = 400
-
-func statusParitySnippet(body string) string {
-	if len(body) <= statusParitySnippetMaxLen {
-		return body
-	}
-	return body[:statusParitySnippetMaxLen] + "…"
 }


### PR DESCRIPTION
## What broke

The `coverage` lane is red on `main`:

```
compatibility/loki/cmd/loki-compliance-tester: 25.28% (floor 27.7%) 204 / 807
```

The drop is not from the commit CI happened to report on. `83f77778` (#1903) landed
`detected_field_values.go` — 226 lines, 97 statements — with no tests of its own, and the
package's own tests were never measuring the harness's verdict logic to begin with. The
response decoder, the order-normalising comparator, the per-case compare arms, the burndown
case list and both detected-field passes each decided what lands in the parity report with
nothing asserting on the decision.

## What this does

Six new test files take the package from **25.3% to 86.4%**. The floor ledger is
**untouched** — the package now clears 27.7 with room to spare. Nothing was lowered and no
tolerance file was added.

The tests drive the passes end to end through `httptest` stubs rather than calling internals
with hand-built structs, so the wire shape is part of what is pinned: the request paths and
parameters each pass emits, the bare-vs-enveloped body contract, the seconds-to-millis
conversion on *both* the string and the JSON-number timestamp arms, the `empty-result` tag's
three-way branch, the burndown window's deliberate offset off the seed grid, and the
sorted-then-capped field sampling.

## A real bug the tests found

`diffDetectedFieldValues` enters its divergence branch on a sorted-slice inequality, then
answers it with two membership loops. Those loops are silent when the lists differ only in
how many times a value appears, so `["a","b"]` against `["a","a","b"]` entered the branch,
emitted nothing, and the pass reported **clean**. A backend repeating a value where the
reference emits it once is a real wire-shape divergence — Grafana renders the duplicate in
the Drilldown filter menu — and this comparator was the only thing between it and a green
parity score.

The fallback cannot produce a false positive: it is reachable only where `slices.Equal` on
the sorted clones already reported inequality.

The same commit folds three copies of "trim the body, truncate at 400, append an ellipsis"
into one `errorBodySnippet` behind a named `errorBodySnippetMaxLen`. The bound was a bare
literal at each site, and the status-parity copy's own comment described itself as mirroring
the other two.

## Evidence each test detects its regression

Coverage that runs a line without asserting on it pins nothing, so every assertion was
verified against a deliberately broken build. **27 mutations** of the covered behaviour were
applied one at a time, each with the narrowed test run against it, and **all 27 turned the
target test red**:

| Mutation | Killed by |
|---|---|
| `decodeSamplePair` drops the seconds→millis scaling (string arm) | `TestDecodeResponse_StringTimestamps` |
| `decodeSamplePair` drops the scaling (JSON-number arm) | `TestDecodeResponse_Vector` |
| `decodeResponse` ignores a non-success `status` field | `TestDecodeResponse_ErrorPaths` |
| `isEmpty` reports a point-less matrix as non-empty | `TestTypedResultIsEmpty` |
| `labelsCmp` compares keys only, ignoring values | `TestNormaliseTypedResult_ReordersToAgreement` |
| `sortedKeys` leaves map order alone | `TestLabelsCmp` |
| `normaliseTypedResult` stops sorting stream entries | `TestNormaliseTypedResult_SortsStreamsAndEntries` |
| `floatEqual` ignores the tolerance | `TestDiffTyped_ToleranceIsApplied` |
| `diffTyped` stops checking the result kind | `TestDiffTyped_KindMismatch` |
| `compareOne` treats an empty-tagged case's extra rows as a pass | `TestCompareOne_EmptyResultTagArms` |
| `compareOne` stops reporting an empty baseline | `TestCompareOne_UntaggedEmptyBaselineIsAFailure` |
| `queryOne` sends a log query to the instant route | `TestQueryOne_LogCaseStaysOnRangeEvenInInstantMode` |
| `doQuery` drops the status code from the error | `TestDoQuery_NonOKCarriesStatusAndTruncatedBody` |
| `compareAll` dials the wire for a case that failed to expand | `TestCompareAll_ExpansionErrorsBypassTheWire` |
| `summarise` stops counting unsupported cases | `TestSummarise` |
| `loadAllQueriesAndSplit` puts skipped definitions in the runnable set | `TestLoadAllQueriesAndSplit_PartitionsTheRealCorpus` |
| `loadCases` keeps the step on an instant case | `TestLoadCases_InstantModeKeepsMetricQueriesOnly` |
| `writeReport` swallows the write error | `TestWriteReport_UnwritablePathErrors` |
| `intersectSorted` returns the intersection unsorted | `TestBurndownCases_UsesTheSortedDurationSelector` |
| `burndownCases` puts the log window back on the seed grid | `TestBurndownCases_Shape` |
| `diffDetectedFieldValues` loses the multiplicity divergence | `TestDiffDetectedFieldValues_DuplicateCountsMatter` |
| `sortedFieldLabels` orders descending, so the cap keeps a different set | `TestCompareDetectedFieldValuesAll_CapsFieldsPerService` |
| `fetchDetectedFieldValues` stops escaping the field name | `TestFetchDetectedFieldValues_EscapesTheFieldName` |
| `fetchDetectedFieldValues` accepts a `{status,data}` envelope | `TestFetchDetectedFieldValues_RejectsEnvelope` |
| `compareDetectedFieldsOne` passes an empty test-endpoint field list | `TestCompareDetectedFieldsOne_Arms` |
| `compareStatusParityAll` runs only the first fixed case | `TestCompareStatusParityAll_RunsEveryFixedCase` |
| `errorBodySnippet` stops bounding the body | `TestErrorBodySnippet` |

Two mutants survived the first pass, and both were genuine gaps rather than harness noise:
the string-timestamp arm of `decodeSamplePair` had no test at all, and the field-escaping
test asserted on `r.URL.Path` — already decoded, so it could not distinguish an escaped name
from an unescaped one. Both tests were strengthened (`TestDecodeResponse_StringTimestamps`,
and an assertion on `EscapedPath()`) until the mutants died.

## Notes

- Issue #1921 (no `-coverpkg`, so a package with no tests of its own floors at 0) is a
  separate defect about the instrumentation and is deliberately not folded in here. This
  package had tests; it simply had far too few. Nothing found here changes that issue's
  analysis.
- `main`, `parseFlags` and `run` remain at 0%: they are `flag.Parse` / `os.Exit` wiring
  reachable only through the CLI entrypoint, and every function they call is covered.
- The floor ledger is a manual ratchet raised tree-wide by `just update-coverage-floor`;
  bumping it for one package does not belong in this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)