### PR TITLE
fix(boot): gate the metric-table existence check on configuration, not the resolved name

### DIFF
--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -1445,8 +1445,9 @@ type requirementsOutcome struct {
 // runs, so a genuinely unreachable server or a not-yet-created database
 // never gets misclassified as a fatal missing-table config error — see
 // fatalAbsentMetricTablesErr's own doc for why that reachable-vs-absent
-// boundary matters (#1905). The remaining (non-metrics) AbsentTables stay
-// on preflight's original transient path.
+// boundary matters (#1905). Every other AbsentTables entry — including a
+// metric table whose name cerberus defaulted rather than the operator
+// setting it — stays on preflight's original transient path.
 func decideRequirementsOutcome(res preflight.Result, m schema.Metrics, database string) requirementsOutcome {
 	if res.Fatal != nil {
 		// Wrong-shape / too-old / unreadable — never self-heals. Exit even if
@@ -1476,12 +1477,12 @@ func decideRequirementsOutcome(res preflight.Result, m schema.Metrics, database 
 		}
 	}
 	if err := fatalAbsentMetricTablesErr(m, res.AbsentTables); err != nil {
-		// Fatal, unlike the general AbsentTables tolerance below (#1905): a
-		// misconfigured metric table name never self-heals the way an
-		// unprovisioned schema does, and a silently degraded metadata
-		// surface (empty /api/v1/series responses, never an error) is harder
-		// for an operator to notice than a boot failure that names the table
-		// and the config key.
+		// Fatal, unlike the general AbsentTables tolerance below (#1905): an
+		// explicitly configured metric table name that is absent never
+		// self-heals the way an unprovisioned schema does, and a silently
+		// degraded metadata surface (empty /api/v1/series responses, never
+		// an error) is harder for an operator to notice than a boot failure
+		// that names the table and the config key.
 		return requirementsOutcome{fatalErr: err}
 	}
 	if !res.SchemaProvisioned() {
@@ -1496,23 +1497,29 @@ func decideRequirementsOutcome(res preflight.Result, m schema.Metrics, database 
 }
 
 // metricTableBinding pairs a resolved metric-table name with the
-// schema.metrics.* config key that set it (see internal/config/nested.go's
-// schema.metrics.* bindings, the source of truth these key strings mirror).
+// schema.metrics.* config key that would set it (see
+// internal/config/nested.go's schema.metrics.* bindings, the source of truth
+// these key strings mirror) and with whether that key actually did.
 type metricTableBinding struct {
 	table     string
 	configKey string
+	// explicit reports whether configuration set this table name, as
+	// opposed to it defaulting. Only an explicit name is an operator
+	// assertion that the table exists, and only an assertion can be
+	// falsified — see fatalAbsentMetricTablesErr.
+	explicit bool
 }
 
 // metricTableBindings lists the metric tables the /api/v1/series,
 // /api/v1/labels, and /api/v1/label/<name>/values handlers union across
 // (schema.Metrics.ConfiguredMetricTables' Gauge/Sum/Histogram set) paired
 // with the config key each came from, for fatalAbsentMetricTablesErr's
-// error text.
+// decision and error text.
 func metricTableBindings(m schema.Metrics) []metricTableBinding {
 	return []metricTableBinding{
-		{table: m.GaugeTable, configKey: "schema.metrics.gaugeTable"},
-		{table: m.SumTable, configKey: "schema.metrics.sumTable"},
-		{table: m.HistogramTable, configKey: "schema.metrics.histogramTable"},
+		{table: m.GaugeTable, configKey: "schema.metrics.gaugeTable", explicit: m.TableOverrides.Gauge},
+		{table: m.SumTable, configKey: "schema.metrics.sumTable", explicit: m.TableOverrides.Sum},
+		{table: m.HistogramTable, configKey: "schema.metrics.histogramTable", explicit: m.TableOverrides.Histogram},
 	}
 }
 
@@ -1526,14 +1533,30 @@ func metricTableBindings(m schema.Metrics) []metricTableBinding {
 // schema-shape gate, which treats an entirely-absent table as the
 // transient cerberus-boots-before-the-collector race and waits rather than
 // exiting (see internal/preflight's package doc, "Fatal vs transient: the
-// absent-schema race"); the boundary is unchanged, though — the two
-// callers below that already returned before this point cover "ClickHouse
-// unreachable" (res.Unreachable) and "database not yet provisioned"
-// (res.DatabaseAbsent), so neither reaches here, and an unconfigured
-// (empty-string) table name never appears in absentTables in the first
-// place, since preflight's checkSchema skips empty table names before
-// ever probing them. What is left, by construction, is exactly "the
-// server answered and this specific configured table is not there".
+// absent-schema race"); the two callers before this point keep that
+// boundary intact by covering "ClickHouse unreachable" (res.Unreachable)
+// and "database not yet provisioned" (res.DatabaseAbsent), so neither
+// reaches here.
+//
+// The gate is scoped to EXPLICITLY CONFIGURED names, which is what makes
+// the extra strictness sound. Only a name configuration set is an operator
+// asserting that a table exists under exactly that spelling; a defaulted
+// name is nothing more than cerberus's built-in guess at where a stock
+// OTel-CH deployment writes metrics. A deployment that ingests only logs
+// and traces never provisions otel_metrics_gauge / _sum / _histogram and is
+// not misconfigured for it, and one whose collector has not written its
+// first metric yet has not provisioned them YET — treating either as fatal
+// turns the ordinary cerberus-before-the-collector race into a crash loop
+// for every metrics-less deployment, which is the exact failure this gate
+// exists to keep OUT of the metadata surface. Defaulted-and-absent
+// therefore falls through to the transient not-ready path below, where an
+// absent table has always belonged. schema.MetricTableOverrides carries the
+// provenance here because the two cases are identical strings by the time
+// they reach this function.
+//
+// An empty table name is never explicit (the resolvers treat unset and
+// whitespace-only alike) and is never probed either, since preflight's
+// checkSchema skips empty names before ever reaching system.columns.
 func fatalAbsentMetricTablesErr(m schema.Metrics, absentTables []string) error {
 	absent := make(map[string]bool, len(absentTables))
 	for _, t := range absentTables {
@@ -1541,7 +1564,7 @@ func fatalAbsentMetricTablesErr(m schema.Metrics, absentTables []string) error {
 	}
 	var problems []string
 	for _, b := range metricTableBindings(m) {
-		if b.table != "" && absent[b.table] {
+		if b.explicit && absent[b.table] {
 			problems = append(problems, fmt.Sprintf("table %q (set via %s) does not exist", b.table, b.configKey))
 		}
 	}

--- a/cmd/cerberus/main_test.go
+++ b/cmd/cerberus/main_test.go
@@ -42,16 +42,41 @@ func TestIsVersionFlag(t *testing.T) {
 	}
 }
 
+// metricsFrom resolves a schema.Metrics through the real configuration
+// resolver over the given settings, so a test exercises the same
+// default-vs-configured provenance a deployment gets from its environment or
+// its cerberus.yaml (both lower to these CERBERUS_SCHEMA_METRICS_*_TABLE
+// keys — see internal/config/nested.go). Passing no settings yields the
+// stock schema a deployment that configured no metric table gets.
+func metricsFrom(settings map[string]string) schema.Metrics {
+	return schema.DefaultOTelMetricsFrom(func(key string) string { return settings[key] })
+}
+
+// configuredMetrics is the schema of a deployment that spelled out all three
+// metric tables. The names are the stock ones deliberately: an operator who
+// types the default spelling has still ASSERTED the table exists, so the
+// value alone can never stand in for the provenance.
+func configuredMetrics() schema.Metrics {
+	def := schema.DefaultOTelMetrics()
+	return metricsFrom(map[string]string{
+		schema.EnvMetricsGaugeTable:     def.GaugeTable,
+		schema.EnvMetricsSumTable:       def.SumTable,
+		schema.EnvMetricsHistogramTable: def.HistogramTable,
+	})
+}
+
 // TestFatalAbsentMetricTablesErr pins #1905's core boundary in isolation
 // from any ClickHouse connection: given the reachable-and-absent table
-// names preflight.Run has already computed, exactly the configured
-// Gauge/Sum/Histogram tables that appear there turn into a fatal error
-// naming both the table and the schema.metrics.* config key that set it;
-// everything else (a present table, or an unconfigured/empty-string one)
-// leaves boot alone.
+// names preflight.Run has already computed, exactly the EXPLICITLY
+// CONFIGURED Gauge/Sum/Histogram tables that appear there turn into a fatal
+// error naming both the table and the schema.metrics.* config key that set
+// it. Everything else leaves boot alone — a present table, an
+// empty-string one, and above all a table whose name cerberus DEFAULTED,
+// which is an assumption about where a stock OTel-CH deployment writes
+// metrics rather than an operator assertion that it exists.
 func TestFatalAbsentMetricTablesErr(t *testing.T) {
 	t.Parallel()
-	m := schema.DefaultOTelMetrics()
+	m := configuredMetrics()
 
 	t.Run("table present: no fatal error", func(t *testing.T) {
 		t.Parallel()
@@ -62,7 +87,7 @@ func TestFatalAbsentMetricTablesErr(t *testing.T) {
 		}
 	})
 
-	t.Run("table absent: fatal error names table and config key", func(t *testing.T) {
+	t.Run("configured table absent: fatal error names table and config key", func(t *testing.T) {
 		t.Parallel()
 		err := fatalAbsentMetricTablesErr(m, []string{m.HistogramTable})
 		if err == nil {
@@ -76,17 +101,45 @@ func TestFatalAbsentMetricTablesErr(t *testing.T) {
 		}
 	})
 
-	t.Run("empty configured name: absence of an unrelated table is not fatal", func(t *testing.T) {
+	t.Run("defaulted tables absent: not fatal", func(t *testing.T) {
 		t.Parallel()
-		empty := m
-		empty.HistogramTable = ""
-		// A table name preflight would never even probe (checkSchema skips
-		// empty names) cannot appear in absentTables for the empty field, so
-		// this reports some OTHER absent table to prove the empty binding
-		// specifically never matches.
-		err := fatalAbsentMetricTablesErr(empty, []string{"some_unrelated_table"})
+		// A deployment that never configured a metric table: the names are
+		// cerberus's built-in defaults, and a ClickHouse carrying only logs
+		// and traces (or one whose collector has not written its first
+		// metric yet) simply does not have them. That is the ordinary
+		// not-yet-provisioned schema race, so boot must survive it and let
+		// the transient path re-probe.
+		def := metricsFrom(nil)
+		err := fatalAbsentMetricTablesErr(def, []string{def.GaugeTable, def.SumTable, def.HistogramTable})
 		if err != nil {
-			t.Fatalf("fatalAbsentMetricTablesErr(empty HistogramTable) = %v, want nil", err)
+			t.Fatalf("fatalAbsentMetricTablesErr(all three defaulted and absent) = %v, want nil", err)
+		}
+	})
+
+	t.Run("configured and defaulted mixed: only the configured one is fatal", func(t *testing.T) {
+		t.Parallel()
+		def := schema.DefaultOTelMetrics()
+		mixed := metricsFrom(map[string]string{schema.EnvMetricsGaugeTable: "custom_gauge"})
+		err := fatalAbsentMetricTablesErr(mixed, []string{mixed.GaugeTable, mixed.SumTable})
+		if err == nil {
+			t.Fatal("fatalAbsentMetricTablesErr(configured gauge absent) = nil, want an error")
+		}
+		if !strings.Contains(err.Error(), "custom_gauge") {
+			t.Errorf("error %q does not name the configured absent table", err.Error())
+		}
+		if strings.Contains(err.Error(), def.SumTable) {
+			t.Errorf("error %q names the DEFAULTED absent table %q; only a configured name is an assertion", err.Error(), def.SumTable)
+		}
+	})
+
+	t.Run("unrelated absent table is not fatal", func(t *testing.T) {
+		t.Parallel()
+		// Only the three tables the metrics metadata surface unions across
+		// are decided here; an absent table outside that set is preflight's
+		// ordinary transient finding.
+		err := fatalAbsentMetricTablesErr(m, []string{m.ExpHistogramTable, "some_unrelated_table"})
+		if err != nil {
+			t.Fatalf("fatalAbsentMetricTablesErr(unrelated absent) = %v, want nil", err)
 		}
 	})
 
@@ -104,18 +157,24 @@ func TestFatalAbsentMetricTablesErr(t *testing.T) {
 	})
 }
 
-// TestDecideRequirementsOutcome exercises the four #1905 boot cells against
+// TestDecideRequirementsOutcome exercises each #1905 boot cell against
 // decideRequirementsOutcome directly, with no ClickHouse connection: it
 // constructs the preflight.Result values a real probe would have produced
-// in each scenario and asserts the resulting boot decision. The
-// unreachable cell is the one most likely to regress silently — a naive
-// implementation that fails fast on "any absent table" without checking
-// res.Unreachable first would turn a ClickHouse that simply has not
-// started yet into a boot crash, exactly the crash-loop #1905's fix must
-// not reintroduce.
+// in each scenario and asserts the resulting boot decision. Two cells carry
+// the crash-loop history. The unreachable one is the most likely to regress
+// silently — a naive implementation that fails fast on "any absent table"
+// without checking res.Unreachable first would turn a ClickHouse that
+// simply has not started yet into a boot crash. The defaulted-tables one is
+// the same failure reached from the other side: a gate that reads the
+// resolved table NAME instead of its provenance cannot tell a metrics-less
+// deployment apart from a typo, and crash-loops every deployment that never
+// asked for metrics.
 func TestDecideRequirementsOutcome(t *testing.T) {
 	t.Parallel()
-	m := schema.DefaultOTelMetrics()
+	// Every cell below that must NOT be fatal is exercised against an
+	// explicitly configured schema, so it is the branch under test that
+	// keeps boot alive rather than the defaulted-name tolerance.
+	m := configuredMetrics()
 	const database = "otel"
 
 	t.Run("table present: proceeds ready", func(t *testing.T) {
@@ -127,7 +186,25 @@ func TestDecideRequirementsOutcome(t *testing.T) {
 		}
 	})
 
-	t.Run("table absent, server reachable: fails fast naming table and config key", func(t *testing.T) {
+	t.Run("defaulted metric tables absent, server reachable: boots NOT READY", func(t *testing.T) {
+		t.Parallel()
+		// The metrics-less deployment: a reachable ClickHouse that carries
+		// no metric tables, and a cerberus that was never told to expect
+		// any. Boot must survive on the transient re-probe path — /healthz
+		// answers 200 and only /readyz gates — exactly as it does for an
+		// absent logs or traces table.
+		def := metricsFrom(nil)
+		res := preflight.Result{AbsentTables: []string{def.GaugeTable, def.SumTable, def.HistogramTable}}
+		got := decideRequirementsOutcome(res, def, database)
+		if got.fatalErr != nil {
+			t.Fatalf("decideRequirementsOutcome(defaulted absent) fatalErr = %v, want nil (must not block boot)", got.fatalErr)
+		}
+		if got.notReadyReason == "" {
+			t.Error("decideRequirementsOutcome(defaulted absent) notReadyReason = \"\", want the transient AbsentTables reason")
+		}
+	})
+
+	t.Run("configured table absent, server reachable: fails fast naming table and config key", func(t *testing.T) {
 		t.Parallel()
 		res := preflight.Result{AbsentTables: []string{m.HistogramTable}}
 		got := decideRequirementsOutcome(res, m, database)
@@ -164,25 +241,21 @@ func TestDecideRequirementsOutcome(t *testing.T) {
 		}
 	})
 
-	t.Run("empty configured table name: proceeds even though other tables are absent", func(t *testing.T) {
+	t.Run("table outside the metrics gate absent: proceeds NOT READY", func(t *testing.T) {
 		t.Parallel()
-		empty := m
-		empty.HistogramTable = ""
-		// HistogramTable is unconfigured; ExpHistogramTable being absent must
-		// not fail boot through the metrics gate at all — ConfiguredMetricTables
-		// (and therefore fatalAbsentMetricTablesErr) never look at
-		// ExpHistogramTable, and the empty HistogramTable can never match.
+		// ExpHistogramTable is probed by preflight but is not part of the
+		// set the metrics metadata surface unions across, so its absence
+		// must not fail boot through the metrics gate at all — it falls
+		// through to the general transient AbsentTables tolerance
+		// (SchemaProvisioned() is false), which is unchanged, pre-existing
+		// preflight behaviour, not a #1905 fatal.
 		res := preflight.Result{AbsentTables: []string{m.ExpHistogramTable}}
-		got := decideRequirementsOutcome(res, empty, database)
+		got := decideRequirementsOutcome(res, m, database)
 		if got.fatalErr != nil {
-			t.Fatalf("decideRequirementsOutcome(empty configured name) fatalErr = %v, want nil", got.fatalErr)
+			t.Fatalf("decideRequirementsOutcome(non-gated table absent) fatalErr = %v, want nil", got.fatalErr)
 		}
-		// The absent ExpHistogramTable still falls through to the general
-		// transient AbsentTables tolerance (SchemaProvisioned() is false),
-		// which is unchanged, pre-existing preflight behaviour, not a #1905
-		// fatal.
 		if got.notReadyReason == "" {
-			t.Error("decideRequirementsOutcome(empty configured name) notReadyReason = \"\", want the pre-existing transient AbsentTables reason")
+			t.Error("decideRequirementsOutcome(non-gated table absent) notReadyReason = \"\", want the transient AbsentTables reason")
 		}
 	})
 

--- a/docs/health.md
+++ b/docs/health.md
@@ -294,7 +294,10 @@ server, a not-yet-created database (`UNKNOWN_DATABASE`, surfaced even by the
 `version()` probe because the connection carries the database as its session
 default), or an absent schema — re-probing until the dependency appears. What
 it converts into a fail-fast boot **error** is a *reachable* server that fails
-the contract: a too-old / unparseable version, or a wrong-shape table. Set
+the contract: a too-old / unparseable version, a wrong-shape table, or a
+missing metric table the deployment named itself through
+`schema.metrics.*` / `CERBERUS_SCHEMA_METRICS_*_TABLE` (a name nobody typed
+is the transient absent-schema case above). Set
 `CERBERUS_REQUIREMENTS_CHECK=false` to skip the gate entirely.
 
 ## Implementation pointers

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -994,6 +994,22 @@ opaque query-time errors into a precise, fail-fast boot error:
   external writer (the collector, or cerberus' own `CERBERUS_AUTO_CREATE_SCHEMA`)
   provisions the schema, `/readyz` flips ready **without a restart**.
   `/healthz` (liveness) stays **200** throughout — only readiness gates.
+- **Absent *configured* metric table.** The one exception to the tolerance
+  above, and it turns on **who chose the name**. When a deployment sets
+  `schema.metrics.gaugeTable` / `sumTable` / `histogramTable` (or the
+  equivalent `CERBERUS_SCHEMA_METRICS_*_TABLE` variable) and a **reachable**
+  ClickHouse does not have that table, startup **fails fast** with a message
+  naming both the table and the config key that set it. Naming a table is an
+  assertion that it exists, and a typo'd or unprovisioned one never
+  self-heals — it would instead silently degrade every `/api/v1/series`,
+  `/api/v1/labels`, and `/api/v1/label/<name>/values` request into a
+  ClickHouse `UNKNOWN_TABLE` error. A metric table whose name cerberus
+  **defaulted** carries no such assertion: a deployment that ingests only logs
+  and traces never provisions `otel_metrics_gauge` / `_sum` / `_histogram` and
+  is not misconfigured for it, so their absence is the ordinary
+  not-yet-provisioned race above — cerberus boots, reports NOT READY, and
+  re-probes. Spelling a stock name out explicitly opts that table into the
+  fail-fast check.
 - **Absent (not-yet-created) database.** A step earlier than an absent table:
   the configured **database** itself does not exist yet. Because the connection
   carries the database as its session default, even the version probe's
@@ -1023,8 +1039,9 @@ read the version and column metadata, but a server that is unreachable at the
 preflight point is itself classified transient (a dial / connection-refused
 error boots unready and re-probes, exactly like the connectivity ping above) —
 **not** a fatal exit. What stays fatal is a *reachable* server that fails the
-contract: a too-old / unparseable version, a wrong-shape table, or an
-introspection *error* (as opposed to a clean zero-row absence, or the
+contract: a too-old / unparseable version, a wrong-shape table, a missing
+metric table the deployment named itself, or an introspection *error* (as
+opposed to a clean zero-row absence of a table nobody named, or the
 `UNKNOWN_DATABASE` not-yet-created-database case).
 
 ### Schema divergence: MetricName-first metrics sort key

--- a/internal/config/nested_test.go
+++ b/internal/config/nested_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/tsouza/cerberus/internal/schema"
 )
 
 // writeConfigFile stages a cerberus.yaml in a fresh temp dir and makes it the
@@ -213,6 +215,31 @@ prom:
 	}
 	if got, want := cfg.Schema.PromResourceLabels, []string{"service.name", "k8s.namespace.name"}; !reflect.DeepEqual(got, want) {
 		t.Errorf("prom.resourceLabels = %v, want %v", got, want)
+	}
+	// The file must reach the schema shape carrying its PROVENANCE too, not
+	// just its values: cerberus's boot-time metric-table existence check
+	// exits on a configured-but-absent table and waits on a defaulted one
+	// (cmd/cerberus's fatalAbsentMetricTablesErr), so a resolver refactor
+	// here that assigned the names without recording where they came from
+	// would silently make that gate unreachable for every deployment.
+	if want := (schema.MetricTableOverrides{Gauge: true}); cfg.Schema.TableOverrides != want {
+		t.Errorf("schema.metrics table provenance = %+v, want %+v", cfg.Schema.TableOverrides, want)
+	}
+}
+
+// The negative half of the provenance assertion above: a config file that
+// names no metric table leaves every name defaulted, so nothing in it may
+// read as operator-set.
+func TestFromEnv_NestedConfigFileNoSchemaShapeSetsNoProvenance(t *testing.T) {
+	clearAllEnv(t)
+	writeConfigFile(t, "clickhouse:\n  database: otel\n")
+
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	if got := cfg.Schema.TableOverrides; got != (schema.MetricTableOverrides{}) {
+		t.Errorf("no schema.metrics.* configured: provenance = %+v, want the zero value", got)
 	}
 }
 

--- a/internal/schema/env.go
+++ b/internal/schema/env.go
@@ -69,12 +69,18 @@ func envBool(get Getenv, key string) bool {
 // as unset — operators paste values with stray newlines often enough that
 // silently honouring them would produce table names like
 // "otel_metrics_sum\n" that fail at query time with cryptic CH errors.
-func envOverride(get Getenv, key, def string) string {
+//
+// The second return value reports which of the two happened: true when the
+// setting was configured and its value is what came back, false when the
+// caller got its own default. Callers that must tell an operator's
+// assertion apart from cerberus's assumption keep it (see
+// MetricTableOverrides); callers that only need the value discard it.
+func envOverride(get Getenv, key, def string) (string, bool) {
 	v := strings.TrimSpace(get(key))
 	if v == "" {
-		return def
+		return def, false
 	}
-	return v
+	return v, true
 }
 
 // DefaultOTelMetricsFromEnv returns DefaultOTelMetrics() with any
@@ -87,14 +93,17 @@ func DefaultOTelMetricsFromEnv() Metrics { return DefaultOTelMetricsFrom(os.Gete
 
 // DefaultOTelMetricsFrom is DefaultOTelMetricsFromEnv over an arbitrary
 // resolver, so a caller that also reads cerberus.yaml applies the same
-// overrides from either source.
+// overrides from either source. Each table name records whether it came
+// from the resolver or from the default in Metrics.TableOverrides, so a
+// consumer downstream can still tell the two apart once they have both
+// collapsed into the same string.
 func DefaultOTelMetricsFrom(get Getenv) Metrics {
 	m := DefaultOTelMetrics()
-	m.GaugeTable = envOverride(get, EnvMetricsGaugeTable, m.GaugeTable)
-	m.SumTable = envOverride(get, EnvMetricsSumTable, m.SumTable)
-	m.HistogramTable = envOverride(get, EnvMetricsHistogramTable, m.HistogramTable)
-	m.ExpHistogramTable = envOverride(get, EnvMetricsExpHistogramTable, m.ExpHistogramTable)
-	m.SummaryTable = envOverride(get, EnvMetricsSummaryTable, m.SummaryTable)
+	m.GaugeTable, m.TableOverrides.Gauge = envOverride(get, EnvMetricsGaugeTable, m.GaugeTable)
+	m.SumTable, m.TableOverrides.Sum = envOverride(get, EnvMetricsSumTable, m.SumTable)
+	m.HistogramTable, m.TableOverrides.Histogram = envOverride(get, EnvMetricsHistogramTable, m.HistogramTable)
+	m.ExpHistogramTable, m.TableOverrides.ExpHistogram = envOverride(get, EnvMetricsExpHistogramTable, m.ExpHistogramTable)
+	m.SummaryTable, m.TableOverrides.Summary = envOverride(get, EnvMetricsSummaryTable, m.SummaryTable)
 	m.PromResourceLabels = envCSVList(get, EnvPromResourceLabels)
 	return m
 }
@@ -191,7 +200,10 @@ func DefaultOTelLogsFromEnv() Logs { return DefaultOTelLogsFrom(os.Getenv) }
 // DefaultOTelLogsFrom is DefaultOTelLogsFromEnv over an arbitrary resolver.
 func DefaultOTelLogsFrom(get Getenv) Logs {
 	l := DefaultOTelLogs()
-	l.LogsTable = envOverride(get, EnvLogsTable, l.LogsTable)
+	// The override's provenance is discarded: an absent logs table is the
+	// not-yet-provisioned schema race on either source (preflight's
+	// transient AbsentTables path), so nothing downstream asks which it was.
+	l.LogsTable, _ = envOverride(get, EnvLogsTable, l.LogsTable)
 	return l
 }
 
@@ -202,7 +214,8 @@ func DefaultOTelTracesFromEnv() Traces { return DefaultOTelTracesFrom(os.Getenv)
 // DefaultOTelTracesFrom is DefaultOTelTracesFromEnv over an arbitrary resolver.
 func DefaultOTelTracesFrom(get Getenv) Traces {
 	t := DefaultOTelTraces()
-	t.SpansTable = envOverride(get, EnvTracesTable, t.SpansTable)
+	// Provenance discarded for the same reason as the logs table above.
+	t.SpansTable, _ = envOverride(get, EnvTracesTable, t.SpansTable)
 	// The lookup table name tracks the spans table: the OTel-CH DDL
 	// template hard-codes the `_trace_id_ts` suffix, so when the operator
 	// overrides the spans table the lookup table is `<spans>_trace_id_ts`.

--- a/internal/schema/env_test.go
+++ b/internal/schema/env_test.go
@@ -83,6 +83,105 @@ func TestDefaultOTelMetricsFromEnv_TrimsValue(t *testing.T) {
 	}
 }
 
+// TestDefaultOTelMetricsFromEnv_TableOverrides pins the provenance the
+// resolver records alongside each table name: which of the five names an
+// operator SET, as opposed to inheriting from DefaultOTelMetrics. Cerberus's
+// boot-time metric-table existence check is fatal for the first and
+// wait-and-re-probe for the second (cmd/cerberus's
+// fatalAbsentMetricTablesErr), so losing this bit here silently converts
+// every metrics-less deployment's ordinary absent-schema race into a boot
+// crash.
+//
+// The value-equals-default case is the load-bearing one: an operator who
+// spells out the stock table name has still asserted it exists, so
+// provenance can never be reconstructed by comparing against the default.
+func TestDefaultOTelMetricsFromEnv_TableOverrides(t *testing.T) {
+	def := DefaultOTelMetrics()
+	cases := []struct {
+		name string
+		env  string
+		val  string
+		pick func(MetricTableOverrides) bool
+		want bool
+	}{
+		{"gauge set", EnvMetricsGaugeTable, "custom_gauge", func(o MetricTableOverrides) bool { return o.Gauge }, true},
+		{"sum set", EnvMetricsSumTable, "custom_sum", func(o MetricTableOverrides) bool { return o.Sum }, true},
+		{"histogram set", EnvMetricsHistogramTable, "custom_hist", func(o MetricTableOverrides) bool { return o.Histogram }, true},
+		{"exp histogram set", EnvMetricsExpHistogramTable, "custom_exp", func(o MetricTableOverrides) bool { return o.ExpHistogram }, true},
+		{"summary set", EnvMetricsSummaryTable, "custom_summary", func(o MetricTableOverrides) bool { return o.Summary }, true},
+		{
+			"set to the built-in default value is still set",
+			EnvMetricsGaugeTable, def.GaugeTable,
+			func(o MetricTableOverrides) bool { return o.Gauge }, true,
+		},
+		{
+			"whitespace-only is unset",
+			EnvMetricsGaugeTable, "  \n\t ",
+			func(o MetricTableOverrides) bool { return o.Gauge }, false,
+		},
+		{
+			"empty is unset",
+			EnvMetricsGaugeTable, "",
+			func(o MetricTableOverrides) bool { return o.Gauge }, false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(tc.env, tc.val)
+			if got := tc.pick(DefaultOTelMetricsFromEnv().TableOverrides); got != tc.want {
+				t.Errorf("%s=%q: override flag = %v, want %v", tc.env, tc.val, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDefaultOTelMetricsFromEnv_NoOverridesRecordsNothing is the negative
+// half of TestDefaultOTelMetricsFromEnv_TableOverrides: a deployment that
+// configures no metric table at all must leave every provenance flag false,
+// including for the four tables the sibling case never touches. A resolver
+// that marked a defaulted name as set would make the boot check fatal for
+// every stock deployment.
+func TestDefaultOTelMetricsFromEnv_NoOverridesRecordsNothing(t *testing.T) {
+	for _, key := range []string{
+		EnvMetricsGaugeTable,
+		EnvMetricsSumTable,
+		EnvMetricsHistogramTable,
+		EnvMetricsExpHistogramTable,
+		EnvMetricsSummaryTable,
+	} {
+		t.Setenv(key, "")
+	}
+	if got := DefaultOTelMetricsFromEnv().TableOverrides; got != (MetricTableOverrides{}) {
+		t.Errorf("no overrides set: TableOverrides = %+v, want the zero value", got)
+	}
+	// DefaultOTelMetrics takes no configuration at all, so it can never
+	// carry provenance either.
+	if got := DefaultOTelMetrics().TableOverrides; got != (MetricTableOverrides{}) {
+		t.Errorf("DefaultOTelMetrics(): TableOverrides = %+v, want the zero value", got)
+	}
+}
+
+// TestDefaultOTelMetricsFromEnv_OverrideIsPerTable confirms the provenance
+// is per-table rather than a single "anything was configured" flag: setting
+// one table must not mark the other four.
+func TestDefaultOTelMetricsFromEnv_OverrideIsPerTable(t *testing.T) {
+	for _, key := range []string{
+		EnvMetricsGaugeTable,
+		EnvMetricsSumTable,
+		EnvMetricsHistogramTable,
+		EnvMetricsExpHistogramTable,
+		EnvMetricsSummaryTable,
+	} {
+		t.Setenv(key, "")
+	}
+	t.Setenv(EnvMetricsSumTable, "custom_sum")
+	got := DefaultOTelMetricsFromEnv().TableOverrides
+	want := MetricTableOverrides{Sum: true}
+	if got != want {
+		t.Errorf("only the sum table configured: TableOverrides = %+v, want %+v", got, want)
+	}
+}
+
 // TestDefaultOTelMetricsFromEnv_PromResourceLabels pins the
 // CERBERUS_PROM_RESOURCE_LABELS allowlist parse: comma-separated OTel
 // dotted keys split into a trimmed, empty-dropped slice; unset /

--- a/internal/schema/otel.go
+++ b/internal/schema/otel.go
@@ -29,6 +29,14 @@ type Metrics struct {
 	// (Prometheus-style quantile samples).
 	SummaryTable string
 
+	// TableOverrides records which of the five table names above an
+	// operator SET, as opposed to inheriting from DefaultOTelMetrics.
+	// Only the configuration-reading resolvers populate it
+	// (DefaultOTelMetricsFrom and its FromEnv wrapper); a Metrics built by
+	// DefaultOTelMetrics alone leaves it zero, which reads correctly as
+	// "every table name here is a built-in default".
+	TableOverrides MetricTableOverrides
+
 	// MetricNameColumn names the column holding the metric name.
 	MetricNameColumn string
 	// AttributesColumn names the column holding metric labels (Map(String, String)).
@@ -615,6 +623,51 @@ func (m Metrics) TablesForUnknownName() []string {
 // classic-histogram row shapes only, matching TableFor/TablesFor above.
 func (m Metrics) ConfiguredMetricTables() []string {
 	return distinctTables(m.GaugeTable, m.SumTable, m.HistogramTable)
+}
+
+// MetricTableOverrides records, per metrics table, whether the name carried
+// by the corresponding Metrics field was SET by configuration — a
+// CERBERUS_SCHEMA_METRICS_*_TABLE variable, or the `schema.metrics.*` path
+// of a cerberus.yaml, which lowers to the same variable — rather than
+// inherited from DefaultOTelMetrics.
+//
+// The distinction is not cosmetic: it is the difference between an
+// ASSERTION and an ASSUMPTION. A name an operator typed is a claim that the
+// table exists under exactly that name, so a reachable ClickHouse that does
+// not have it is a misconfiguration (a typo, or a table nobody provisioned)
+// that never self-heals. A name nobody typed is only cerberus's built-in
+// guess at where a stock OTel-CH deployment writes metrics; a deployment
+// that ingests logs and traces alone never provisions those tables and is
+// not misconfigured for it, so their absence is the ordinary
+// not-yet-provisioned schema race. Resolving both to the same string makes
+// them indistinguishable at the point of decision, which is why the
+// provenance travels with the value.
+//
+// cmd/cerberus's fatalAbsentMetricTablesErr is the only consumer, and it
+// decides on Gauge / Sum / Histogram alone — the three tables the Prom
+// metadata surface unions across (see ConfiguredMetricTables): configured
+// and absent exits the boot, defaulted and absent boots NOT READY and
+// re-probes. ExpHistogram and Summary are recorded for uniformity across
+// the five names the resolver manages, so that whichever surface needs them
+// next reads the same provenance rather than re-deriving a second, subtly
+// different answer; nothing consumes them today.
+//
+// A whitespace-only configured value counts as UNSET, matching how the
+// resolvers treat it: the field keeps its default and the flag stays false.
+type MetricTableOverrides struct {
+	// Gauge reports whether Metrics.GaugeTable was set by configuration.
+	Gauge bool
+	// Sum reports whether Metrics.SumTable was set by configuration.
+	Sum bool
+	// Histogram reports whether Metrics.HistogramTable was set by
+	// configuration.
+	Histogram bool
+	// ExpHistogram reports whether Metrics.ExpHistogramTable was set by
+	// configuration.
+	ExpHistogram bool
+	// Summary reports whether Metrics.SummaryTable was set by
+	// configuration.
+	Summary bool
 }
 
 // The Prom-convention metric-name suffixes this package routes on.


### PR DESCRIPTION
## The red lane

Two lanes on `main` die at cerberus startup, and a third fails as a
consequence:

- **`e2e` / `startup-bench`** — the process exits before binding its listener,
  so `TestStartupSpeed_HealthzUnder2s` polls a refused connection.
- **`migration-e2e` / `migration-tier1`** — the `cerberus-1` container exits, so
  `docker compose ... up --wait` never completes and `just migration-tier1-up`
  returns 1.
- **`migration-e2e` / `migration-e2e`** then reports 23 attestation violations
  ("MIG-NN is counted as covered at tier1 but NEVER RAN"). That gate is correct
  and is untouched here — the scenarios genuinely did not run, and it goes
  green once tier1 comes up.

All three trace back to one startup error:

```text
metric table existence check failed: table "otel_metrics_gauge"
  (set via schema.metrics.gaugeTable) does not exist; ...
```

## Root cause

The boot-time metric-table existence check (#1905) decided on the resolved
table **name**, and `fatalAbsentMetricTablesErr`'s doc comment justified that
with a premise that does not hold:

> an unconfigured (empty-string) table name never appears in absentTables

A deployment that never asked for metrics does not carry empty strings — it
carries the built-in defaults from `internal/schema`. So by the time the check
ran, "the operator named this table and got the name wrong" and "this is a
default nobody asked for and nobody provisioned" were the same string, and both
exited the process. Every deployment whose ClickHouse has no metric tables was
unbootable: a warm CH with no provisioned schema (startup-bench, whose own doc
comment says that case must boot NOT READY), a stack whose collector creates
the tables only once metrics flow (tier1), a gateway pointed at a
logs-and-traces-only cluster.

Neither failing lane configures a metric table: `test/e2e/startup_bench_test.go`
sets no `CERBERUS_SCHEMA_METRICS_*`, and
`test/e2e/migration/tiers/tier1-dual/cerberus.yaml` has no `schema.metrics.*`
key. Both heads are enabled in both lanes, so the bug is the defaulted name
being read as an operator assertion, not the probing of a disabled head.

## The fix

The distinction the check needs is *provenance*, so provenance now travels with
the value. `schema.MetricTableOverrides` records, per metrics table, whether the
resolver took the name from configuration — a `CERBERUS_SCHEMA_METRICS_*_TABLE`
variable, or the `schema.metrics.*` config path that lowers to it — or from
`DefaultOTelMetrics`. `envOverride` already distinguished the two internally;
it now returns that bit instead of discarding it.

Only a configured name is an operator asserting the table exists, and only that
stays boot-fatal. A defaulted name is cerberus's own guess at where a stock
OTel-CH deployment writes metrics, so its absence rejoins the transient
not-yet-provisioned path where an absent table has always belonged: boot, NOT
READY on `/readyz`, background re-probe, `/healthz` 200 throughout.

There is no lane special-case, no env-var carve-out, no table-name list and no
tolerance file — one decision, taken from the source that knows the answer.

## #1905's guarantee, pinned in both directions

- configured + absent → still fatal, still naming the table and the config key
- defaulted + absent → boots NOT READY and re-probes
- mixed → the error names the configured table and **not** the defaulted one
- provenance survives the real construction site (`config.FromEnv` over a
  `cerberus.yaml`), asserted positively and negatively

The `cmd/cerberus` fixtures spell the **stock** table names out explicitly, so
a gate that compared the value against the default rather than reading
provenance fails them. Each new cell was confirmed red against the previous
condition before the fix went in.

Two subtests that pinned an emptied table name are recast: the resolver cannot
produce an empty metric-table name, so the old fixture was unreachable, and
"an unset name is never marked configured" is now asserted where it is true —
in `internal/schema`, over the resolver itself.

## Docs

`docs/operations.md` and `docs/health.md` described the preflight's fatal set
without this case at all. Both now state the rule, including which half of it
an operator opts into by spelling a table name out.
