### PR TITLE
fix(e2e): recover the stranded crawl mount-order and Drilldown version-pin fixes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -462,6 +462,34 @@ services:
       # home page. Path is the in-container mount location of the JSON,
       # not a Grafana URL or UID.
       GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH: /etc/grafana/provisioning/dashboards/cerberus/cerberus.json
+      # Pin the four Drilldown apps by VERSION, not just by image tag.
+      #
+      # Grafana 12 preinstalls these four from a list hardcoded in its
+      # own binary (pkg/setting/setting_plugins.go), and that list pins
+      # no version: each entry carries `update_strategy = minor`, so a
+      # container start resolves it against grafana.com's catalogue and
+      # downloads whatever is latest THAT DAY. The Grafana image tag
+      # therefore does not pin the app surface — two runs of the same
+      # `grafana/grafana:12.2.9`, days apart, boot different Drilldown
+      # code with different routes, tabs and picker options.
+      #
+      # The crawl asserts a committed inventory of exactly those
+      # surfaces, so an unpinned app makes the pin a race against the
+      # catalogue: Traces Drilldown 1.1.0 restored three primary-signal
+      # options ("Bring back all primary signals"), which is a surface
+      # set the committed inventory had been generated without.
+      #
+      # Naming an id here does NOT replace the built-in list, it merges
+      # with it — an id named with a version resolves to that version,
+      # and one left out still installs at latest. All four are
+      # therefore named, and this list is the whole preinstall set.
+      # Bumping a version here is a deliberate change with an inventory
+      # regeneration attached.
+      GF_PLUGINS_PREINSTALL: >-
+        grafana-exploretraces-app@2.1.0,
+        grafana-lokiexplore-app@2.5.0,
+        grafana-metricsdrilldown-app@2.4.0,
+        grafana-pyroscope-app@2.2.0
     volumes:
       - ./test/e2e/grafana/compose/datasources:/etc/grafana/provisioning/datasources:ro
       # Dashboard provider config tells Grafana to scan the `cerberus`

--- a/test/e2e/k3s/grafana.yaml
+++ b/test/e2e/k3s/grafana.yaml
@@ -143,12 +143,31 @@ spec:
               value: dark
             # Deliberately NO GF_INSTALL_PLUGINS for the drilldown
             # apps: on Grafana 12.x grafana-lokiexplore-app,
-            # grafana-exploretraces-app, and
-            # grafana-metricsdrilldown-app are first-party preinstalled
+            # grafana-exploretraces-app, grafana-metricsdrilldown-app
+            # and grafana-pyroscope-app are first-party preinstalled
             # (hardcoded in Grafana's pkg/setting/setting_plugins.go
             # preinstall list), so installing them again via
             # GF_INSTALL_PLUGINS would only race the built-in flow.
-            # Note: the preinstall is an ASYNC boot-time download from
+            #
+            # That built-in list pins no VERSION — each entry carries
+            # `update_strategy = minor`, so a pod start resolves it
+            # against grafana.com's catalogue and installs whatever is
+            # latest that day. The image tag pins Grafana, not the apps,
+            # and the apps are what the crawl's surface inventory
+            # asserts. GF_PLUGINS_PREINSTALL names each id AT a version
+            # to close that: an id named here resolves to exactly that
+            # version, and the list MERGES with the built-in one rather
+            # than replacing it, so every id has to be named or the
+            # unnamed one still floats. Keep in step with the same pin
+            # in docker-compose.yml; a bump is a deliberate change with
+            # an inventory regeneration attached.
+            - name: GF_PLUGINS_PREINSTALL
+              value: >-
+                grafana-exploretraces-app@2.1.0,
+                grafana-lokiexplore-app@2.5.0,
+                grafana-metricsdrilldown-app@2.4.0,
+                grafana-pyroscope-app@2.2.0
+            # The preinstall is an ASYNC boot-time download from
             # grafana.com that starts after /api/health goes green —
             # the pod needs egress to grafana.com, and
             # /api/plugins/<id>/settings can briefly 404 right after

--- a/test/e2e/playwright/crawl/interactions.ts
+++ b/test/e2e/playwright/crawl/interactions.ts
@@ -317,6 +317,31 @@ const REACT_ID_TOKEN_PATTERN = String.raw`(:r[0-9a-z]+:|«r[0-9a-z]+»)`;
 /** What an erased React `useId` token reads as. */
 const REACT_ID_PLACEHOLDER = '{rid}';
 
+/**
+ * react-select's own element-id prefix (`react-select-<n>-input`,
+ * `react-select-<n>-listbox`), as a source pattern for the same two
+ * consumers as REACT_ID_TOKEN_PATTERN.
+ *
+ * `<n>` is the same kind of token by a different mechanism: a
+ * MODULE-GLOBAL instance counter that react-select increments on every
+ * mount for the lifetime of the page, so the number a given control
+ * carries is a function of how many selects mounted before it — which
+ * varies with the route that mounted it and with how much of an app's
+ * scene had rendered by the time the control appeared. A control keyed
+ * by it is keyed by mount order.
+ *
+ * Traces Drilldown's primary-signal picker is one: it has no testid and
+ * no aria-label, so its key falls all the way through to the element id.
+ */
+const REACT_SELECT_INSTANCE_ID_PATTERN = String.raw`react-select-\d+-`;
+
+/**
+ * What an erased react-select instance counter reads as. The
+ * `react-select-` prefix survives erasure so an inventory row still
+ * names the widget family the key addresses.
+ */
+const REACT_SELECT_INSTANCE_ID_REPLACEMENT = `react-select-${REACT_ID_PLACEHOLDER}-`;
+
 type RawControl = {
   kind: ControlKind;
   key: string;
@@ -346,7 +371,14 @@ type RawControl = {
  */
 async function discoverStaticControls(page: Page): Promise<RawControl[]> {
   return await page.evaluate(
-    ({ chromeSelector, maxClickHops, reactIdPattern, reactIdPlaceholder }) => {
+    ({
+      chromeSelector,
+      maxClickHops,
+      reactIdPattern,
+      reactIdPlaceholder,
+      reactSelectPattern,
+      reactSelectReplacement,
+    }) => {
       const out: Array<{
         kind: string;
         key: string;
@@ -604,17 +636,22 @@ async function discoverStaticControls(page: Page): Promise<RawControl[]> {
             : '') ||
           placeholder ||
           cb.id;
-        // Two render-order / selection-dependent token classes must
+        // Three render-order / selection-dependent token classes must
         // never reach an inventory key:
         //   - React useId tokens (`:rNN:` / React 19's `«rNN»`) —
         //     downshift inputs fall back to them for element ids;
+        //   - react-select instance counters (`react-select-3-input`) —
+        //     the same thing from react-select's own module-global
+        //     counter, reached by any select with neither a testid nor
+        //     an aria-label;
         //   - count-bearing placeholders (`1000 logs`, `500 logs`) —
         //     the line-limit picker's placeholder mirrors the current
         //     selection, so it flickers per surface.
-        // Normalize both to fixed tokens; assignUniqueKeys' DOM-order
-        // `#n` suffix keeps same-page twins distinct.
+        // Normalize all three to fixed tokens; assignUniqueKeys'
+        // DOM-order `#n` suffix keeps same-page twins distinct.
         const key = rawKey
           .replace(new RegExp(reactIdPattern, 'g'), reactIdPlaceholder)
+          .replace(new RegExp(reactSelectPattern, 'g'), reactSelectReplacement)
           .replace(/^\d+ (logs|lines|rows)$/, '{n} $1');
         if (key === '') continue;
         // Resolve the click target and the rendered test in one walk
@@ -690,6 +727,8 @@ async function discoverStaticControls(page: Page): Promise<RawControl[]> {
       maxClickHops: COMBOBOX_CLICK_TARGET_MAX_HOPS,
       reactIdPattern: REACT_ID_TOKEN_PATTERN,
       reactIdPlaceholder: REACT_ID_PLACEHOLDER,
+      reactSelectPattern: REACT_SELECT_INSTANCE_ID_PATTERN,
+      reactSelectReplacement: REACT_SELECT_INSTANCE_ID_REPLACEMENT,
     },
   ) as RawControl[];
 }
@@ -801,6 +840,29 @@ const MENU_MOUNT_TIMEOUT_MS = 8_000;
 
 /** Hard cap on an Escape actually dismissing an open dropdown. */
 const MENU_CLOSE_TIMEOUT_MS = 5_000;
+
+/**
+ * The label Grafana renders as the SOLE item of an option list whose
+ * options are still in flight — its shared `loadingMessage`, used by
+ * core Select, by Combobox and by the scenes ad-hoc filter pickers
+ * (Metrics Drilldown's `+ label = value` is one).
+ *
+ * It is a placeholder, not an option: it carries no value, it is not
+ * clickable to any effect, and — this is what makes it dangerous — a
+ * list showing it holds perfectly still for as long as the fetch takes,
+ * so it settles. Two consecutive crawl runs disagreed on the SAME
+ * control in opposite directions because of it: one discovered the real
+ * option set and then drove against the placeholder, the next
+ * discovered the placeholder and then drove against the real set. Both
+ * died in clickMenuOption, and an interaction that dies takes the
+ * surfaces it would have minted with it.
+ *
+ * Excluding it from "settled" is synchronisation, not tolerance: the
+ * read still has to reach a stable list of REAL options within
+ * MENU_SETTLE_TIMEOUT_MS, and a list that never loads throws with the
+ * placeholder named in the message.
+ */
+const MENU_LOADING_PLACEHOLDER_LABEL = 'Loading options...';
 
 /**
  * How long a page must be watched before an EMPTY control set is
@@ -927,18 +989,21 @@ async function readSettledControls(
   return await sampleUntilStable(
     page,
     async () => assignUniqueKeys(await discoverStaticControls(page)),
-    // React `useId` tokens are erased from the SIGNATURE only: the
-    // returned controls keep the live hints the locators need, but a
-    // remount that changes nothing except a mount counter must not read
-    // as the page still moving. The keys already erase the token, so
-    // leaving it in the signature would compare mount generations the
-    // control model itself declares meaningless — and, when a component
-    // remounts on every render, would make settling impossible.
+    // Mount-counter tokens — React `useId` and react-select's instance
+    // counter alike — are erased from the SIGNATURE only: the returned
+    // controls keep the live hints the locators need, but a remount that
+    // changes nothing except a counter must not read as the page still
+    // moving. The keys already erase both, so leaving them in the
+    // signature would compare mount generations the control model itself
+    // declares meaningless — and, when a component remounts on every
+    // render, would make settling impossible.
     (controls) =>
-      JSON.stringify(controls).replace(
-        new RegExp(REACT_ID_TOKEN_PATTERN, 'g'),
-        REACT_ID_PLACEHOLDER,
-      ),
+      JSON.stringify(controls)
+        .replace(new RegExp(REACT_ID_TOKEN_PATTERN, 'g'), REACT_ID_PLACEHOLDER)
+        .replace(
+          new RegExp(REACT_SELECT_INSTANCE_ID_PATTERN, 'g'),
+          REACT_SELECT_INSTANCE_ID_REPLACEMENT,
+        ),
     CONTROL_SET_SETTLE_TIMEOUT_MS,
     requiredKey === undefined
       ? 'the page control set'
@@ -955,7 +1020,9 @@ async function readSettledControls(
  *
  * Returns `[]` only when NO option mounts within
  * MENU_MOUNT_TIMEOUT_MS — the free-text-input verdict discoverControls
- * acts on. A list that mounts and then keeps changing throws.
+ * acts on. A list that mounts and then keeps changing throws, and so
+ * does one still showing MENU_LOADING_PLACEHOLDER_LABEL at the settle
+ * deadline.
  *
  * Labels are trimmed but NOT filtered: the returned array is
  * positionally aligned with `openMenuOptions(page)`, which is what
@@ -975,6 +1042,11 @@ async function readSettledMenuOptions(page: Page): Promise<string[]> {
     (labels) => JSON.stringify(labels),
     MENU_SETTLE_TIMEOUT_MS,
     'the open dropdown option list',
+    // A list still fetching its options is not the list — see
+    // MENU_LOADING_PLACEHOLDER_LABEL. Failing the readiness test resets
+    // the streak, so the placeholder's own stillness can never be
+    // mistaken for the option set having settled.
+    (labels) => !labels.includes(MENU_LOADING_PLACEHOLDER_LABEL),
   );
 }
 

--- a/test/e2e/playwright/crawl/lib.ts
+++ b/test/e2e/playwright/crawl/lib.ts
@@ -134,7 +134,22 @@ export type StructuralParamRule = {
 );
 
 /**
- * Grafana-12.x structural params, pinned to grafana/grafana:12.2.9.
+ * Grafana-12.x structural params, pinned to grafana/grafana:12.2.9 AND
+ * to the Drilldown app versions named in the stack definitions.
+ *
+ * The image tag alone does not pin the surface this table describes.
+ * Grafana 12 preinstalls the four Drilldown apps from a list hardcoded
+ * in its own binary (`pkg/setting/setting_plugins.go`), and that list
+ * pins no version — every entry carries `update_strategy = minor`, so
+ * each container start resolves it against grafana.com's catalogue and
+ * downloads whatever is latest that day. Two runs of the same
+ * `grafana/grafana:12.2.9`, days apart, boot different Drilldown code
+ * with different routes, tabs and picker options.
+ * `GF_PLUGINS_PREINSTALL` (in `docker-compose.yml` and
+ * `test/e2e/k3s/grafana.yaml`) names each id at a version; the
+ * configured list MERGES with the built-in one rather than replacing
+ * it, so an id left unnamed still floats. This list, and the surface
+ * inventory that pins the products of it, are read against that pin.
  *
  * Every `values` set below is read off the shipped plugin bundle —
  * the literal option array the app itself iterates — NOT off whichever
@@ -165,6 +180,14 @@ export type StructuralParamRule = {
  * the crawl reached first — precisely the coverage #1889 (the Service
  * structure tab 500s on every primary signal but the default) needs
  * the crawl to keep reaching.
+ *
+ * The five, boot `nestedSetParent<0`: Root spans `nestedSetParent<0`,
+ * All spans `true`, Server spans `kind=server`, Consumer spans
+ * `kind=consumer`, Database calls `span.db.system.name!=""`. The app
+ * splits them across TWO controls: a RadioButtonGroup holding the
+ * first two (plus the current value when it is one of the other three)
+ * and a Select holding the rest. The sweep therefore sees one param
+ * written by two independent option sets.
  *
  * `var-groupBy` parameterizes rather than enumerates because its
  * option list is a fact about the DATA, not about the surface: the


### PR DESCRIPTION
Recovers two commits that were pushed to `fix/crawl-inventory-codepoint-primarysignal` eleven minutes **after** #1908 squash-merged that branch. A merged PR's head stops advancing, so neither commit reached any branch anyone reads — they were stranded, and the second one fixes something that is red on `main` right now.

Both are replayed onto current `origin/main`. Nothing here is new work.

## Why they still apply

`main` has moved twice in this territory since (#1919, #1925), so I checked each concern against `origin/main` rather than assuming:

| Concern | In `main`? |
|---|---|
| `Loading options...` placeholder accepted as a settled option set | absent |
| react-select instance-counter (`react-select-<n>-`) erasure | absent — `main` has the React `useId` erasure only, which is the *other* mechanism reaching the same hazard |
| `GF_PLUGINS_PREINSTALL` app-version pinning | absent |

The `var-primarySignal` five-value rule data itself **is** already in `main` via #1925, so only the doc and the version pin were carried over from the second commit — not the values.

## The two fixes

**Mount-order independence.** `readSettledMenuOptions` accepted Grafana's `Loading options...` placeholder as a settled set: a list showing it holds perfectly still while its fetch is outstanding, so it satisfied three identical samples. Two crawl runs disagreed on the Metrics Drilldown ad-hoc filter in opposite directions, and an interaction that dies takes the surfaces it would have minted with it. Separately, react-select derives element ids from a module-global mount counter, so a select carrying neither a testid nor an aria-label keyed off how many selects had mounted before it.

**Drilldown version pinning.** The Grafana image tag does not pin the app surface the crawl audits. Grafana 12 preinstalls the four Drilldown apps from a list hardcoded in its own binary, and every entry carries `update_strategy = minor` — so each container start resolves against grafana.com's catalogue and downloads whatever is latest that day. Two runs of the same `grafana/grafana:12.2.9`, days apart, boot different Drilldown code. That is what turned the surface-inventory ratchet red on `main`: Traces Drilldown restored three primary-signal options, so `var-primarySignal` went from two values to five.

## Conflict resolution

`lib.ts`'s `STRUCTURAL_PARAM_RULES` doc conflicted with #1925. Kept `main`'s stronger "read the option set off the plugin bundle, not off whichever values a crawl reached" doctrine, and folded in the fact that makes it true — the image tag doesn't pin the apps, `GF_PLUGINS_PREINSTALL` does. `main`'s opening line claimed the params were pinned by `grafana/grafana:12.2.9` alone, which this commit disproves, so that line is corrected rather than kept.

## Verification

Comment-block balance checked; the rule table's five values and `defaultValue` are intact and unmodified. The crawl itself is a Docker-substrate lane, so `compose-smoke` / crawl on this PR is the real arbiter.
