### PR TITLE
fix(qlcommon): answer label_replace over non-nullable shared capture names

### DIFF
--- a/internal/chplan/clone.go
+++ b/internal/chplan/clone.go
@@ -465,14 +465,28 @@ func cloneStrings(in []string) []string {
 	return out
 }
 
-// cloneLabelReplaceSegments copies a replacement decomposition. The
-// elements are value types carrying no pointers, so a shallow copy of the
-// backing array is a deep copy of the slice.
+// cloneLabelReplaceSegments copies a replacement decomposition. Each
+// element carries its own Fallbacks slice, so the backing arrays are
+// copied too — a shallow copy would leave the clone aliasing the
+// original's index lists.
 func cloneLabelReplaceSegments(in []LabelReplaceSegment) []LabelReplaceSegment {
 	if in == nil {
 		return nil
 	}
 	out := make([]LabelReplaceSegment, len(in))
+	copy(out, in)
+	for i := range out {
+		out[i].Fallbacks = cloneInts(in[i].Fallbacks)
+	}
+	return out
+}
+
+// cloneInts copies a slice of capture-group indices.
+func cloneInts(in []int) []int {
+	if in == nil {
+		return nil
+	}
+	out := make([]int, len(in))
 	copy(out, in)
 	return out
 }

--- a/internal/chplan/label_replace.go
+++ b/internal/chplan/label_replace.go
@@ -52,6 +52,11 @@ package chplan
 // arbitrary group index is an ordinary array subscript and the ceiling
 // disappears. `Segments` and `Replacement` are alternatives: exactly one
 // of them describes the value.
+//
+// The same decomposition also carries a `$name` reference that binds to
+// several like-named capture groups, which no `replaceRegexpOne`
+// substitution string can express either — the emitter selects among
+// their subscripts with `arrayFirst`. See [LabelReplaceSegment.Fallbacks].
 type LabelReplace struct {
 	Map              Expr
 	Dst              string
@@ -75,11 +80,27 @@ const NoCaptureGroup = -1
 const WholeMatchGroup = 0
 
 // LabelReplaceSegment is one piece of a decomposed replacement template:
-// either a run of literal text or a reference to one capture group.
+// a run of literal text, a reference to one capture group, or a reference
+// to a NAME that several capture groups share.
 type LabelReplaceSegment struct {
 	// Literal is the text this segment contributes when Group is
 	// [NoCaptureGroup].
 	Literal string
+	// Fallbacks holds the further capture-group indices sharing the
+	// referenced name, in regex order, when a `$name` reference binds to
+	// several groups; it is empty for every other segment shape. The
+	// segment then contributes the first of Group followed by Fallbacks
+	// whose capture is non-empty, which the emitter renders as
+	//
+	//	arrayFirst(x -> x != '', [<group>, <fallback>, …])
+	//
+	// Go's `ExpandString` picks the first of the like-named groups that
+	// TOOK PART in the match, and ClickHouse cannot see participation
+	// directly — but for a group whose subpattern cannot match the empty
+	// string, "took part" and "captured something non-empty" coincide.
+	// The lowering only ever populates Fallbacks once it has established
+	// that of every carrier; see qlcommon's captureGroups.resolve.
+	Fallbacks []int
 	// Group is the capture-group index to substitute, or [NoCaptureGroup]
 	// when this segment is literal text.
 	Group int
@@ -87,6 +108,14 @@ type LabelReplaceSegment struct {
 
 // Equal reports whether two segments describe the same contribution.
 func (s LabelReplaceSegment) Equal(o LabelReplaceSegment) bool {
+	if len(s.Fallbacks) != len(o.Fallbacks) {
+		return false
+	}
+	for i := range s.Fallbacks {
+		if s.Fallbacks[i] != o.Fallbacks[i] {
+			return false
+		}
+	}
 	return s.Literal == o.Literal && s.Group == o.Group
 }
 

--- a/internal/chsql/builder.go
+++ b/internal/chsql/builder.go
@@ -1062,6 +1062,20 @@ func (b *Builder) labelReplaceSubstitution(l *chplan.LabelReplace, anchored stri
 // source value directly — the regex is anchored, so a match spans the
 // entire source string, and `extractGroups` numbers from the first real
 // group.
+//
+// A segment carrying Fallbacks references a NAME that several capture
+// groups share. Go's ExpandString expands it to the first of those groups
+// that took part in the match, and the lowering only produces this shape
+// once it has proved none of the groups can match the empty string — so
+// "took part" is exactly "captured something non-empty", and the choice
+// becomes an ordinary array search:
+//
+//	arrayFirst(x -> x != '', [<subscript>, <subscript>, …])
+//
+// `arrayFirst` returns the element type's default — the empty string —
+// when no element qualifies, which is what ExpandString substitutes when
+// none of the like-named groups took part. See
+// chplan.LabelReplaceSegment.Fallbacks.
 func (b *Builder) labelReplaceSegment(l *chplan.LabelReplace, seg chplan.LabelReplaceSegment, anchored string) error {
 	switch seg.Group {
 	case chplan.NoCaptureGroup:
@@ -1070,16 +1084,45 @@ func (b *Builder) labelReplaceSegment(l *chplan.LabelReplace, seg chplan.LabelRe
 	case chplan.WholeMatchGroup:
 		return b.srcValue(l)
 	}
-	b.sb.WriteString("extractGroups(")
-	if err := b.srcValue(l); err != nil {
-		return err
+	// srcValue renders a plan sub-expression and can fail, while a Frag
+	// cannot report an error. The closure records the first failure and
+	// the caller surfaces it once rendering is done.
+	var srcErr error
+	src := Frag(func(fb *Builder) {
+		if err := fb.srcValue(l); err != nil && srcErr == nil {
+			srcErr = err
+		}
+	})
+	if len(seg.Fallbacks) == 0 {
+		captureGroupAt(src, anchored, seg.Group)(b)
+		return srcErr
 	}
-	b.sb.WriteString(", ")
-	b.Arg(anchored)
-	b.sb.WriteString(")[")
-	b.Arg(int64(seg.Group))
-	b.sb.WriteByte(']')
-	return nil
+	candidates := make([]Frag, 0, 1+len(seg.Fallbacks))
+	candidates = append(candidates, captureGroupAt(src, anchored, seg.Group))
+	for _, idx := range seg.Fallbacks {
+		candidates = append(candidates, captureGroupAt(src, anchored, idx))
+	}
+	Call(
+		"arrayFirst",
+		Lambda1(labelReplaceCandidateParam, Neq(BareIdent(labelReplaceCandidateParam), Lit(""))),
+		Array(candidates...),
+	)(b)
+	return srcErr
+}
+
+// labelReplaceCandidateParam is the lambda parameter naming one
+// like-named capture group's capture inside the `arrayFirst` search
+// labelReplaceSegment emits. It is emitter-chosen and never collides with
+// a column: CH resolves a lambda parameter ahead of any outer name.
+const labelReplaceCandidateParam = "x"
+
+// captureGroupAt returns a Frag for one capture group's value:
+// `extractGroups(<src>, <anchored>)[<group>]`.
+func captureGroupAt(src Frag, anchored string, group int) Frag {
+	return Subscript(
+		Call("extractGroups", src, Lit(anchored)),
+		Lit(int64(group)),
+	)
 }
 
 // srcValue renders the source label's value: `<map>[<src>]`. CH map

--- a/internal/chsql/label_rewrite_mutation_test.go
+++ b/internal/chsql/label_rewrite_mutation_test.go
@@ -127,6 +127,55 @@ func TestMutation_ExprLabelReplace_SegmentForm(t *testing.T) {
 	)
 }
 
+// TestMutation_ExprLabelReplace_SharedCaptureNameForm pins the
+// `arrayFirst` selection a segment carrying Fallbacks renders — the shape
+// a `$name` reference takes when several capture groups share that name
+// and none of them can match the empty string (#1768).
+//
+// Go's ExpandString picks the first like-named group that took part in
+// the match; over non-nullable groups that is the first with a non-empty
+// capture, so the emitted SQL searches the carriers' `extractGroups`
+// subscripts IN ORDER. Pinning the whole string is what makes the order
+// an assertion: a renderer that emitted the fallbacks first, dropped one,
+// or reused a single subscript changes it.
+//
+// Kills labelReplaceSegment's `len(seg.Fallbacks) == 0` guard, which under
+// negation renders the bare subscript for a selection (silently answering
+// with whichever group happens to be first) and the whole search for a
+// plain reference.
+func TestMutation_ExprLabelReplace_SharedCaptureNameForm(t *testing.T) {
+	t.Parallel()
+
+	sql, args := renderExpr(t, &chplan.LabelReplace{
+		Map:              attrsMap(),
+		Dst:              "dst",
+		Src:              "src",
+		Regex:            "(a)|(b)",
+		EmptyReplacement: "",
+		Segments: []chplan.LabelReplaceSegment{
+			{Literal: "v=", Group: chplan.NoCaptureGroup},
+			{Group: 1, Fallbacks: []int{2, 3}},
+		},
+	})
+
+	assertRender(
+		t, sql, args,
+		"mapFilter((k, v) -> v != '', if(match(`Attributes`[?], ?), "+
+			"mapUpdate(`Attributes`, map(?, if(empty(`Attributes`[?]), ?, "+
+			"concat(?, arrayFirst(x -> x != ?, ["+
+			"extractGroups(`Attributes`[?], ?)[?], "+
+			"extractGroups(`Attributes`[?], ?)[?], "+
+			"extractGroups(`Attributes`[?], ?)[?]]))))), `Attributes`))",
+		[]any{
+			"src", "^(a)|(b)$", "dst", "src", "",
+			"v=", "",
+			"src", "^(a)|(b)$", int64(1),
+			"src", "^(a)|(b)$", int64(2),
+			"src", "^(a)|(b)$", int64(3),
+		},
+	)
+}
+
 // TestMutation_ExprLabelReplace_MapErrorPropagates pins that an unrenderable
 // Map reaches the caller rather than rendering as silently truncated SQL.
 // Paired with the shape assertions above so it cannot pass by rejecting every

--- a/internal/logql/label_fns_test.go
+++ b/internal/logql/label_fns_test.go
@@ -18,9 +18,32 @@ import (
 func TestLowerLabelReplace_RejectsInexpressibleBackref(t *testing.T) {
 	t.Parallel()
 
-	// A capture-group NAME two capture groups share: Go's ExpandString
-	// picks whichever of them took part in the row's match, and SQL cannot
-	// observe participation.
+	// A capture-group NAME two capture groups share, one of which can
+	// match the empty string: Go's ExpandString picks whichever of them
+	// took part in the row's match, and `extractGroups` renders "took part
+	// matching empty" exactly like "took no part", so SQL cannot observe
+	// which.
+	const q = `label_replace(sum by (host) (count_over_time({app="a"}[5m])), ` +
+		`"service", "$dup", "host", "(?P<dup>a?)|(?P<dup>b)")`
+
+	expr, err := syntax.ParseExpr(q)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if _, err := Lower(context.Background(), expr, schema.DefaultOTelLogs()); err == nil {
+		t.Fatal("lowering accepted a nullable capture group sharing a name; want an error")
+	} else if !strings.Contains(err.Error(), "label_replace") {
+		t.Fatalf("error does not name the function that failed: %v", err)
+	}
+}
+
+// TestLowerLabelReplace_AcceptsSharedCaptureName is the LogQL twin of the
+// PromQL test with the same name: when every group sharing the name is
+// non-nullable, participation and a non-empty capture coincide, so the
+// reference is expressible and this head must lower it.
+func TestLowerLabelReplace_AcceptsSharedCaptureName(t *testing.T) {
+	t.Parallel()
+
 	const q = `label_replace(sum by (host) (count_over_time({app="a"}[5m])), ` +
 		`"service", "$dup", "host", "(?P<dup>a)|(?P<dup>b)")`
 
@@ -28,10 +51,8 @@ func TestLowerLabelReplace_RejectsInexpressibleBackref(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
-	if _, err := Lower(context.Background(), expr, schema.DefaultOTelLogs()); err == nil {
-		t.Fatal("lowering accepted a capture-group name two groups share; want an error")
-	} else if !strings.Contains(err.Error(), "label_replace") {
-		t.Fatalf("error does not name the function that failed: %v", err)
+	if _, err := Lower(context.Background(), expr, schema.DefaultOTelLogs()); err != nil {
+		t.Fatalf("lowering rejected a shared capture-group name whose carriers are all non-nullable: %v", err)
 	}
 }
 

--- a/internal/promql/label_fns_test.go
+++ b/internal/promql/label_fns_test.go
@@ -13,11 +13,37 @@ import (
 // TestLowerLabelReplace_RejectsInexpressibleBackref pins the head's
 // error path. `qlcommon.ReplacementToCH` refuses the one replacement
 // template no ClickHouse expression can carry — a capture-group NAME
-// several groups share, where Go picks the first group that took part in
-// the row's match and SQL cannot see which did. Lowering must surface
-// that as a query error rather than fall through and emit a plan whose
-// destination label silently holds the wrong text.
+// several groups share where at least one of them can match the empty
+// string. Go picks the first carrier that took part in the row's match,
+// and `extractGroups` renders "took part matching empty" and "took no
+// part" identically, so which one Go would pick is unobservable from
+// SQL. Lowering must surface that as a query error rather than fall
+// through and emit a plan whose destination label silently holds the
+// wrong text.
 func TestLowerLabelReplace_RejectsInexpressibleBackref(t *testing.T) {
+	t.Parallel()
+
+	const q = `label_replace(temperature, "service", "$dup", "host", "(?P<dup>a?)|(?P<dup>b)")`
+
+	expr, err := parser.NewParser(parser.Options{}).ParseExpr(q)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if _, err := Lower(context.Background(), expr, schema.DefaultOTelMetrics()); err == nil {
+		t.Fatal("lowering accepted a nullable capture group sharing a name; want an error")
+	} else if !strings.Contains(err.Error(), "label_replace") {
+		t.Fatalf("error does not name the function that failed: %v", err)
+	}
+}
+
+// TestLowerLabelReplace_AcceptsSharedCaptureName is the boundary's other
+// side. When EVERY group sharing the name is non-nullable, taking part
+// in the match and capturing a non-empty string are the same event, so
+// "the first carrier Go picks" is exactly "the first carrier whose
+// capture is non-empty" — which `arrayFirst` over `extractGroups` says
+// directly. This shape must lower rather than be refused along with the
+// nullable one.
+func TestLowerLabelReplace_AcceptsSharedCaptureName(t *testing.T) {
 	t.Parallel()
 
 	const q = `label_replace(temperature, "service", "$dup", "host", "(?P<dup>a)|(?P<dup>b)")`
@@ -26,10 +52,8 @@ func TestLowerLabelReplace_RejectsInexpressibleBackref(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
-	if _, err := Lower(context.Background(), expr, schema.DefaultOTelMetrics()); err == nil {
-		t.Fatal("lowering accepted a capture-group name two groups share; want an error")
-	} else if !strings.Contains(err.Error(), "label_replace") {
-		t.Fatalf("error does not name the function that failed: %v", err)
+	if _, err := Lower(context.Background(), expr, schema.DefaultOTelMetrics()); err != nil {
+		t.Fatalf("lowering rejected a shared capture-group name whose carriers are all non-nullable: %v", err)
 	}
 }
 

--- a/internal/qlcommon/label_replace.go
+++ b/internal/qlcommon/label_replace.go
@@ -8,6 +8,7 @@ package qlcommon
 import (
 	"fmt"
 	"regexp"
+	"regexp/syntax"
 	"strconv"
 	"strings"
 	"unicode"
@@ -75,12 +76,15 @@ const unresolvedGroup = -1
 //   - A `$` that starts no reference at all (end of string, `$-`,
 //     `${unclosed`) is emitted verbatim, again as ExpandString does.
 //
-// A reference to a capture group above CH's `\9` substitution ceiling is
-// expressible, just not as a `replaceRegexpOne` template: the result
-// carries [CHReplacement.Segments] instead, which the emitter renders as
-// a `concat` of literal runs and `extractGroups` subscripts. The single
-// shape with no faithful translation at all is a reference to a name
-// several capture groups share — see [captureGroups.resolve].
+// Two shapes are expressible, just not as a `replaceRegexpOne` template:
+// a reference to a capture group above CH's `\9` substitution ceiling,
+// and a reference to a name several capture groups share. Both carry
+// [CHReplacement.Segments] instead, which the emitter renders as a
+// `concat` of literal runs and `extractGroups` subscripts — the second
+// selecting among the like-named groups' subscripts with `arrayFirst`.
+// The single shape with no faithful translation at all is that second one
+// when any of the like-named groups can match the EMPTY STRING — see
+// [captureGroups.resolve].
 //
 // regex is the regex string the replacement is applied against; it is
 // compiled to resolve capture-group names and to count groups so
@@ -99,7 +103,12 @@ func ReplacementToCH(repl, regex string) (CHReplacement, error) {
 		return CHReplacement{}, err
 	}
 	for _, seg := range segments {
-		if seg.Group > maxCHBackref {
+		// A group above CH's `\9` ceiling has no `\N` spelling, and a
+		// reference to a name several groups share is a SELECTION among
+		// indices rather than one index — neither fits a
+		// `replaceRegexpOne` substitution string, and both are expressible
+		// over the `extractGroups` decomposition.
+		if seg.Group > maxCHBackref || len(seg.Fallbacks) > 0 {
 			return CHReplacement{Segments: segments}, nil
 		}
 	}
@@ -108,8 +117,10 @@ func ReplacementToCH(repl, regex string) (CHReplacement, error) {
 
 // CHReplacement is the ClickHouse-side form of a Go replacement template.
 // Exactly one of its fields describes the substituted value: Template
-// when every referenced capture group fits CH's `\0`–`\9` substitution
-// syntax, Segments when one does not.
+// when every reference resolves to a single capture group that fits CH's
+// `\0`–`\9` substitution syntax, Segments when one does not — because it
+// names a group above the ceiling, or because it names a group NAME
+// several groups share and so denotes a selection rather than an index.
 type CHReplacement struct {
 	// Template is the `replaceRegexpOne` substitution string.
 	Template string
@@ -158,13 +169,16 @@ func ReplacementSegments(repl, regex string) ([]chplan.LabelReplaceSegment, erro
 	// #499 (the mutant-kill tests) and the follow-up PR that landed this
 	// refactor for the full diagnosis.
 	for i := 0; i < len(repl); {
-		idx, step, err := replacementStep(&literal, repl, i, groups)
+		ref, step, err := replacementStep(&literal, repl, i, groups)
 		if err != nil {
 			return nil, err
 		}
-		if idx != unresolvedGroup {
+		if ref.group != unresolvedGroup {
 			flush()
-			segments = append(segments, chplan.LabelReplaceSegment{Group: idx})
+			segments = append(segments, chplan.LabelReplaceSegment{
+				Group:     ref.group,
+				Fallbacks: ref.fallbacks,
+			})
 		}
 		i += step
 	}
@@ -209,6 +223,13 @@ type captureGroups struct {
 	// slice rather than a single index. Empty when the regex did not
 	// compile, so every named reference then binds to nothing.
 	byName map[string][]int
+	// nullable reports, per capture-group index, whether that group's
+	// subpattern can match the empty string. It is what makes a
+	// shared-name reference expressible or not — see
+	// [captureGroups.resolve]. A group missing from the map is treated as
+	// nullable, so an unparseable or unclassifiable regex keeps the
+	// rejection rather than risking a wrong answer.
+	nullable map[int]bool
 }
 
 // newCaptureGroups compiles regex for its capture-group metadata.
@@ -221,11 +242,16 @@ type captureGroups struct {
 func newCaptureGroups(regex string) captureGroups {
 	// Anchored to mirror the SQL emitter. Anchoring shifts no group
 	// index, so the metadata read back is the unanchored regex's.
-	compiled, err := regexp.Compile("^" + regex + "$")
+	anchored := "^" + regex + "$"
+	compiled, err := regexp.Compile(anchored)
 	if err != nil {
 		return captureGroups{count: maxCHBackref}
 	}
-	g := captureGroups{count: compiled.NumSubexp(), byName: map[string][]int{}}
+	g := captureGroups{
+		count:    compiled.NumSubexp(),
+		byName:   map[string][]int{},
+		nullable: nullableGroups(anchored),
+	}
 	for i, name := range compiled.SubexpNames() {
 		if name == "" {
 			continue
@@ -235,89 +261,236 @@ func newCaptureGroups(regex string) captureGroups {
 	return g
 }
 
-// resolve maps one extracted reference to its capture-group index, or
-// [unresolvedGroup] when the reference binds to nothing. It errors on the
-// one reference shape no ClickHouse form can express.
+// nullableGroups reports, per capture-group index, whether that group's
+// subpattern can match the empty string.
+//
+// It re-parses regex with the same syntax flags `regexp.Compile` uses, so
+// the `OpCapture.Cap` indices it walks are the very indices
+// `Regexp.SubexpNames` reports. An unparseable regex yields a nil map —
+// every group then reads as nullable, which is the conservative answer.
+func nullableGroups(regex string) map[int]bool {
+	parsed, err := syntax.Parse(regex, syntax.Perl)
+	if err != nil {
+		return nil
+	}
+	out := map[int]bool{}
+	collectNullableGroups(parsed, out)
+	return out
+}
+
+// collectNullableGroups walks re, recording each capture group's
+// nullability into out.
+func collectNullableGroups(re *syntax.Regexp, out map[int]bool) {
+	if re.Op == syntax.OpCapture {
+		out[re.Cap] = matchesEmpty(re.Sub[0])
+	}
+	for _, sub := range re.Sub {
+		collectNullableGroups(sub, out)
+	}
+}
+
+// matchesEmpty reports whether re's language contains the empty string.
+//
+// This is the hinge the shared-capture-group-name translation rests on
+// ([captureGroups.resolve]): a capture group whose subpattern CANNOT
+// match the empty string captures at least one character whenever it
+// takes part in a match, so ClickHouse's `extractGroups` — which reports
+// "did not take part" and "took part, matched empty" identically, as `”`
+// — tells the two apart after all, by non-emptiness.
+//
+// Deliberately conservative: any operator this switch does not classify
+// falls through to `true` (nullable), which keeps today's rejection
+// rather than emitting SQL whose answer might be wrong.
+func matchesEmpty(re *syntax.Regexp) bool {
+	switch re.Op {
+	case syntax.OpLiteral:
+		// A parsed literal is normally non-empty; the zero-rune form is
+		// the empty string and matches it.
+		return len(re.Rune) == 0
+	case syntax.OpCharClass, syntax.OpAnyChar, syntax.OpAnyCharNotNL:
+		// Every member of a character class is exactly one rune wide.
+		return false
+	case syntax.OpEmptyMatch,
+		syntax.OpBeginLine, syntax.OpEndLine,
+		syntax.OpBeginText, syntax.OpEndText,
+		syntax.OpWordBoundary, syntax.OpNoWordBoundary:
+		// Zero-width: matches the empty string (subject, for the
+		// assertions, to a condition on the surrounding text).
+		return true
+	case syntax.OpCapture:
+		return matchesEmpty(re.Sub[0])
+	case syntax.OpStar, syntax.OpQuest:
+		// Zero repetitions is always in the language.
+		return true
+	case syntax.OpPlus:
+		// At least one repetition, so nullable exactly when the body is.
+		return matchesEmpty(re.Sub[0])
+	case syntax.OpRepeat:
+		if re.Min == 0 {
+			return true
+		}
+		return matchesEmpty(re.Sub[0])
+	case syntax.OpConcat:
+		// Every part must be able to contribute nothing.
+		for _, sub := range re.Sub {
+			if !matchesEmpty(sub) {
+				return false
+			}
+		}
+		return true
+	case syntax.OpAlternate:
+		// One nullable branch is enough.
+		for _, sub := range re.Sub {
+			if matchesEmpty(sub) {
+				return true
+			}
+		}
+		return false
+	}
+	return true
+}
+
+// resolvedRef is where one template reference points in the regex.
+type resolvedRef struct {
+	// group is the capture-group index the reference resolves to, or
+	// [unresolvedGroup] when it binds to nothing.
+	group int
+	// fallbacks holds the FURTHER capture-group indices that share the
+	// referenced name, in regex order, when several groups carry it. It
+	// is empty for every other reference shape. The value contributed is
+	// the first of `group` followed by `fallbacks` whose capture is
+	// non-empty — see [captureGroups.resolve] for why that reproduces
+	// Go's choice exactly.
+	fallbacks []int
+}
+
+// resolve maps one extracted reference to the capture group(s) it points
+// at, or to [unresolvedGroup] when the reference binds to nothing. It
+// errors on the one reference shape no ClickHouse form can express.
 //
 // A group index above CH's `\9` ceiling is NOT such a shape: it is
 // returned like any other, and [ReplacementToCH] switches the whole
 // template to the ceiling-free `extractGroups` decomposition.
-func (g captureGroups) resolve(ref templateRef) (int, error) {
-	idx := unresolvedGroup
+//
+// # Names several groups share
+//
+// Go's regexp permits several capture groups to share one name, and
+// ExpandString then picks the first of them that TOOK PART in the row's
+// match (its start offset is not -1), regardless of which alternation
+// branch matched. Participation is not directly observable from SQL:
+// `extractGroups` reports a group that did not take part and a group that
+// took part matching the empty string identically, as `”` (verified
+// against ClickHouse: `extractGroups('b', '^(a)|(b)$')` → `[”, 'b']`,
+// and `extractGroups(”, '^(x?)$')` → `[”]`).
+//
+// Note what separates those two ClickHouse results: only the second has a
+// group whose subpattern can match the empty string. That is the whole
+// hinge. For a group whose subpattern CANNOT match the empty string,
+// "took part" and "captured something non-empty" are the same predicate:
+//
+//   - a group that took part matched a string in its subpattern's
+//     language, and the empty string is not in that language, so the
+//     capture is non-empty;
+//   - a group that did not take part reports `”`.
+//
+// So when EVERY group sharing the name is non-nullable, "the first
+// carrier with a non-empty capture" is exactly Go's "the first carrier
+// that took part", and the reference is expressible — as
+// `arrayFirst(x -> x != ”, [g[i], g[j], …])` over the same
+// `extractGroups` decomposition the ceiling-free form already uses.
+// (`arrayFirst` yields `”` when no element qualifies, which is what
+// ExpandString substitutes when no carrier took part.)
+//
+// The condition is ALL carriers, not just the first: a nullable earlier
+// carrier that takes part matching the empty string is one Go picks (and
+// expands to `”`), while "first non-empty" would wrongly skip past it to
+// a later carrier. So a single nullable carrier keeps the rejection.
+func (g captureGroups) resolve(ref templateRef) (resolvedRef, error) {
+	out := resolvedRef{group: unresolvedGroup}
 	switch carriers := g.byName[ref.name]; {
 	case ref.num != unresolvedGroup:
 		// A numbered reference past the regex's group count binds to
 		// nothing, which is the empty string — not an error.
 		if ref.num <= g.count {
-			idx = ref.num
+			out.group = ref.num
 		}
 	case len(carriers) > 1:
-		// Go's regexp permits several groups to share one name, and
-		// ExpandString then picks the first of them that TOOK PART in the
-		// row's match. Participation is not observable from SQL:
-		// `extractGroups` reports a group that did not participate and a
-		// group that matched the empty string identically, as `''`
-		// (verified against ClickHouse: `extractGroups('b', '^(a)|(b)$')`
-		// → `['', 'b']`, and `extractGroups('', '^(x?)$')` → `['']`). With
-		// the two indistinguishable there is no expression that reproduces
-		// Go's choice, so this stays a rejection.
-		return 0, fmt.Errorf(
-			"references capture-group name %q, which %d capture groups share — "+
-				"which one contributes depends on the per-row match, "+
-				"and ClickHouse cannot observe which groups took part",
-			ref.name, len(carriers),
-		)
+		if nullable, ok := g.firstNullable(carriers); ok {
+			return resolvedRef{}, fmt.Errorf(
+				"references capture-group name %q, which %d capture groups share, "+
+					"and capture group %d among them can match the empty string — "+
+					"ClickHouse's extractGroups reports a group that matched empty and "+
+					"a group that took no part in the match identically, so which one "+
+					"Go's expansion would pick is not observable from SQL",
+				ref.name, len(carriers), nullable,
+			)
+		}
+		out.group, out.fallbacks = carriers[0], carriers[1:]
 	case len(carriers) == 1:
-		idx = carriers[0]
+		out.group = carriers[0]
 	}
-	return idx, nil
+	return out, nil
+}
+
+// firstNullable returns the first of carriers whose subpattern can match
+// the empty string, and whether there was one. A carrier the nullability
+// walk could not classify counts as nullable, so an unrecognised regex
+// shape keeps the rejection.
+func (g captureGroups) firstNullable(carriers []int) (int, bool) {
+	for _, idx := range carriers {
+		if nullable, known := g.nullable[idx]; nullable || !known {
+			return idx, true
+		}
+	}
+	return 0, false
 }
 
 // replacementStep handles a single dispatch step of
 // [ReplacementSegments] at offset `i` of `repl`. Literal text is appended
-// to `b`; a resolved capture reference is returned as its group index
-// (and [unresolvedGroup] otherwise, which covers both "this step was
-// literal text" and "this reference binds to nothing"). The second return
-// is the number of input bytes consumed — always >= 1 on the success
-// path, so the outer loop always makes progress.
+// to `b`; a resolved capture reference is returned as a [resolvedRef]
+// (whose group is [unresolvedGroup] otherwise, which covers both "this
+// step was literal text" and "this reference binds to nothing"). The
+// second return is the number of input bytes consumed — always >= 1 on
+// the success path, so the outer loop always makes progress.
 //
 // Splitting this out of the loop body keeps the per-iteration consumed
 // count observable in the caller's iterator clause, so the gremlins
 // INVERT_LOOPCTRL operator can't swap `continue` ↔ `break` and produce
 // an equivalent mutant — the dispatch keywords don't live in a `for`
 // scope at all here.
-func replacementStep(b *strings.Builder, repl string, i int, groups captureGroups) (int, int, error) {
+func replacementStep(b *strings.Builder, repl string, i int, groups captureGroups) (resolvedRef, int, error) {
+	unbound := resolvedRef{group: unresolvedGroup}
 	c := repl[i]
 	if c != '$' {
 		// Backslashes are kept verbatim here; each output form escapes
 		// them the way its own syntax requires.
 		b.WriteByte(c)
-		return unresolvedGroup, 1, nil
+		return unbound, 1, nil
 	}
 	// Lone `$` at end of string — ExpandString emits it verbatim.
 	if i+1 >= len(repl) {
 		b.WriteByte('$')
-		return unresolvedGroup, 1, nil
+		return unbound, 1, nil
 	}
 	if repl[i+1] == '$' {
 		// `$$` → literal `$`.
 		b.WriteByte('$')
-		return unresolvedGroup, 2, nil
+		return unbound, 2, nil
 	}
 	ref, ok := extractRef(repl[i+1:])
 	if !ok {
 		// Not a reference at all (`$-`, `${unclosed`) — ExpandString
 		// emits the `$` verbatim and resumes at the next byte.
 		b.WriteByte('$')
-		return unresolvedGroup, 1, nil
+		return unbound, 1, nil
 	}
-	idx, err := groups.resolve(ref)
+	resolved, err := groups.resolve(ref)
 	if err != nil {
-		return 0, 0, fmt.Errorf("replacement %q %w", repl, err)
+		return resolvedRef{}, 0, fmt.Errorf("replacement %q %w", repl, err)
 	}
 	// An unresolved reference binds to nothing; ExpandString substitutes
 	// the empty string for it, so it contributes no segment either.
-	return idx, 1 + ref.width, nil
+	return resolved, 1 + ref.width, nil
 }
 
 // templateRef is one `$…` reference split off the front of a Go

--- a/internal/qlcommon/label_replace_segments_test.go
+++ b/internal/qlcommon/label_replace_segments_test.go
@@ -95,6 +95,222 @@ func TestReplacementToCHSegmentsAboveCeiling(t *testing.T) {
 	}
 }
 
+// TestReplacementToCHSegmentsSharedCaptureName pins the decomposition for
+// a `$name` reference that several capture groups carry — the shape #1768
+// reported cerberus rejecting outright.
+//
+// Go's ExpandString picks the first carrier that took part in the match.
+// When no carrier's subpattern can match the empty string, "took part"
+// and "captured something non-empty" are the same predicate, so the
+// reference becomes a selection among the carriers' `extractGroups`
+// subscripts. The decomposition records that as the first carrier in
+// Group with the rest in Fallbacks, in regex order — the order is
+// load-bearing, because Go picks the FIRST participant.
+func TestReplacementToCHSegmentsSharedCaptureName(t *testing.T) {
+	t.Parallel()
+
+	lit := func(s string) chplan.LabelReplaceSegment {
+		return chplan.LabelReplaceSegment{Literal: s, Group: chplan.NoCaptureGroup}
+	}
+
+	cases := []struct {
+		name  string
+		in    string
+		regex string
+		want  []chplan.LabelReplaceSegment
+	}{
+		{
+			"two_carriers",
+			"$dup",
+			`(?P<dup>a)|(?P<dup>b)`,
+			[]chplan.LabelReplaceSegment{{Group: 1, Fallbacks: []int{2}}},
+		},
+		{
+			"three_carriers",
+			"${dup}",
+			`(?P<dup>a)|(?P<dup>b)|(?P<dup>c)`,
+			[]chplan.LabelReplaceSegment{{Group: 1, Fallbacks: []int{2, 3}}},
+		},
+		{
+			// Carriers need not be adjacent indices: an unrelated group
+			// between them keeps its own index and is not a carrier.
+			"carriers_straddling_an_unrelated_group",
+			"$dup",
+			`(?P<dup>a)|(?P<other>o)|(?P<dup>b)`,
+			[]chplan.LabelReplaceSegment{{Group: 1, Fallbacks: []int{3}}},
+		},
+		{
+			// Literal runs and single-group references coexist with the
+			// shared-name selection in one decomposition.
+			"mixed_with_literals_and_a_plain_group",
+			"pre-$dup/$other",
+			`(?P<dup>a)|(?P<other>o)|(?P<dup>b)`,
+			[]chplan.LabelReplaceSegment{
+				lit("pre-"),
+				{Group: 1, Fallbacks: []int{3}},
+				lit("/"),
+				{Group: 2},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ReplacementToCH(tc.in, tc.regex)
+			if err != nil {
+				t.Fatalf("ReplacementToCH(%q, %q): unexpected error: %v", tc.in, tc.regex, err)
+			}
+			// A selection among indices has no `\N` spelling, so the
+			// whole template must take the segments path even though
+			// every index here sits below CH's `\9` ceiling.
+			if got.Template != "" {
+				t.Fatalf("ReplacementToCH(%q, %q): want the segments form, got template %q",
+					tc.in, tc.regex, got.Template)
+			}
+			if len(got.Segments) != len(tc.want) {
+				t.Fatalf("ReplacementToCH(%q, %q): got %d segments %+v, want %d %+v",
+					tc.in, tc.regex, len(got.Segments), got.Segments, len(tc.want), tc.want)
+			}
+			for i := range tc.want {
+				if !got.Segments[i].Equal(tc.want[i]) {
+					t.Fatalf("ReplacementToCH(%q, %q): segment %d: got %+v, want %+v",
+						tc.in, tc.regex, i, got.Segments[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestSharedCaptureNameSegmentsAgreeWithExpandString is the differential
+// that makes the #1768 narrowing trustworthy. The claim being narrowed is
+// a semantic equivalence — "first carrier with a non-empty capture" ==
+// "first carrier that took part" — and only running both against real
+// matches can establish it.
+//
+// evaluate here implements the SQL side EXACTLY as the emitter spells it:
+// `arrayFirst(x -> x != ”, [g[i], g[j], …])`, over the same
+// `extractGroups` values ClickHouse would see (Go's FindStringSubmatch
+// reports a non-participating group as "" too, which is precisely the
+// conflation the rejection used to be about). The oracle is Go's own
+// ExpandString.
+//
+// The source strings are chosen so the first carrier does NOT participate
+// in some of them — that is the case a naive "always take the first
+// carrier" translation would get wrong, and it must be covered or the
+// differential proves nothing about the ordering.
+func TestSharedCaptureNameSegmentsAgreeWithExpandString(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		regex string
+		repl  string
+		srcs  []string
+	}{
+		{
+			// "a" matches via carrier 1; "b" matches via carrier 2 with
+			// carrier 1 absent — the skip-the-first-carrier case.
+			name:  "two_carriers",
+			regex: `(?P<dup>a)|(?P<dup>b)`,
+			repl:  "$dup",
+			srcs:  []string{"a", "b"},
+		},
+		{
+			name:  "three_carriers",
+			regex: `(?P<dup>a)|(?P<dup>b)|(?P<dup>c)`,
+			repl:  "v=$dup",
+			srcs:  []string{"a", "b", "c"},
+		},
+		{
+			// Both carriers participate at once. Go takes the first, and
+			// so must the array search — here the two captures differ, so
+			// picking the wrong one is visible.
+			name:  "both_carriers_participate",
+			regex: `(?P<dup>a)(?P<dup>b)`,
+			repl:  "$dup",
+			srcs:  []string{"ab"},
+		},
+		{
+			// Prefixed branches: the carrier is not at the start of its
+			// branch, so its index and its participation come apart from
+			// the branch order in the source text.
+			name:  "prefixed_branches",
+			regex: `x(?P<dup>a)|y(?P<dup>b)`,
+			repl:  "pre-$dup-post",
+			srcs:  []string{"xa", "yb"},
+		},
+		{
+			// A non-carrier group sits between the carriers, so the
+			// carrier indices are 1 and 3 rather than 1 and 2.
+			name:  "carriers_straddling_an_unrelated_group",
+			regex: `(?P<dup>a)|(?P<other>o)|(?P<dup>b)`,
+			repl:  "$dup/$other",
+			srcs:  []string{"a", "o", "b"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ReplacementToCH(tc.repl, tc.regex)
+			if err != nil {
+				t.Fatalf("ReplacementToCH(%q, %q): unexpected error: %v", tc.repl, tc.regex, err)
+			}
+			re := regexp.MustCompile("^" + tc.regex + "$")
+			for _, src := range tc.srcs {
+				match := re.FindStringSubmatchIndex(src)
+				if match == nil {
+					t.Fatalf("regex %q does not match %q — the oracle needs a match", tc.regex, src)
+				}
+				want := string(re.ExpandString(nil, tc.repl, src, match))
+				groups := re.FindStringSubmatch(src)
+
+				evaluated := evaluateSegments(got.Segments, src, groups)
+				if evaluated != want {
+					t.Fatalf("regex %q repl %q src %q: segments %+v evaluate to %q; "+
+						"Go's ExpandString gives %q",
+						tc.regex, tc.repl, src, got.Segments, evaluated, want)
+				}
+			}
+		})
+	}
+}
+
+// evaluateSegments renders a decomposition the way the emitted SQL does:
+// a literal run contributes its text, the whole-match group contributes
+// the source value, a plain reference contributes its `extractGroups`
+// subscript, and a shared-name reference contributes the FIRST of its
+// carriers whose subscript is non-empty — CH's
+// `arrayFirst(x -> x != ”, […])`, whose no-match result is the empty
+// string.
+func evaluateSegments(segments []chplan.LabelReplaceSegment, src string, groups []string) string {
+	var out string
+	for _, seg := range segments {
+		switch seg.Group {
+		case chplan.NoCaptureGroup:
+			out += seg.Literal
+			continue
+		case chplan.WholeMatchGroup:
+			out += src
+			continue
+		}
+		if len(seg.Fallbacks) == 0 {
+			out += groups[seg.Group]
+			continue
+		}
+		// arrayFirst(x -> x != '', [...]) — and the empty string when no
+		// candidate qualifies, which adds nothing.
+		for _, idx := range append([]int{seg.Group}, seg.Fallbacks...) {
+			if groups[idx] != "" {
+				out += groups[idx]
+				break
+			}
+		}
+	}
+	return out
+}
+
 // TestReplacementSegmentsAgreeWithExpandString is the differential that
 // makes the decomposition trustworthy: for each template, the segments
 // evaluated against a real match must equal what Go's ExpandString — the

--- a/internal/qlcommon/label_replace_test.go
+++ b/internal/qlcommon/label_replace_test.go
@@ -152,11 +152,20 @@ func TestReplacementToCH(t *testing.T) {
 
 // TestReplacementToCHRejectsInexpressibleBackrefs pins the one shape that
 // Go's ExpandString resolves to a real capture but no ClickHouse
-// expression can reproduce: a name several capture groups share.
-// ExpandString picks the first of them that TOOK PART in the row's match,
-// and participation is not observable from SQL — `extractGroups` reports a
-// group that did not participate and a group that matched the empty
-// string identically, as `”`.
+// expression can reproduce: a name several capture groups share where at
+// least one of them can match the EMPTY STRING. ExpandString picks the
+// first carrier that TOOK PART in the row's match, and participation is
+// not observable from SQL — `extractGroups` reports a group that did not
+// participate and a group that matched the empty string identically, as
+// `”`. A nullable carrier is exactly the case where those two states can
+// both occur, so the choice is unrecoverable.
+//
+// Carriers that CANNOT match the empty string are a different matter, and
+// are translated rather than rejected — see
+// TestReplacementToCHSegmentsSharedCaptureName. That is why every case
+// here has a nullable carrier: without one the guard does not fire, so a
+// case whose carriers are all non-nullable would pass this test for the
+// wrong reason.
 //
 // It used to be emitted as literal template text — a 200 carrying a label
 // whose value was the template rather than an expansion of it, which is
@@ -171,13 +180,40 @@ func TestReplacementToCHRejectsInexpressibleBackrefs(t *testing.T) {
 		regex    string
 		wantErrs []string
 	}{
-		// Go permits several groups to share a name and picks the first
-		// that took part in the row's match; SQL cannot see which did.
 		{
-			"ambiguous_named_capture",
+			// Carrier 1 is `a?`, which matches the empty string: it can
+			// take part AND report `''`, which is also what a carrier that
+			// took no part reports.
+			"nullable_first_carrier",
 			"$dup",
-			`(?P<dup>a)|(?P<dup>b)`,
-			[]string{`"dup"`, "2 capture groups"},
+			`(?P<dup>a?)|(?P<dup>b)`,
+			[]string{`"dup"`, "2 capture groups", "empty string", "capture group 1"},
+		},
+		{
+			// Nullability anywhere in the carrier set is disqualifying,
+			// not just at the front: Go picks the FIRST participant, so a
+			// later nullable carrier that matched empty must not be
+			// skipped over by a "first non-empty" search either.
+			"nullable_later_carrier",
+			"$dup",
+			`(?P<dup>a)|(?P<dup>b*)`,
+			[]string{`"dup"`, "2 capture groups", "empty string", "capture group 2"},
+		},
+		{
+			// Nullability is a property of the whole subpattern, not of
+			// its outermost operator: `x*y*` is a concat of two nullable
+			// parts and so is itself nullable.
+			"nullable_via_concatenation",
+			"$dup",
+			`(?P<dup>x*y*)|(?P<dup>b)`,
+			[]string{`"dup"`, "2 capture groups", "empty string"},
+		},
+		{
+			// One nullable branch makes the alternation nullable.
+			"nullable_via_alternation_branch",
+			"$dup",
+			`(?P<dup>ab|)|(?P<dup>c)`,
+			[]string{`"dup"`, "2 capture groups", "empty string"},
 		},
 	}
 	for _, tc := range cases {

--- a/test/perf/cardinality-baseline/promql/label_replace_shared_capture_name.json
+++ b/test/perf/cardinality-baseline/promql/label_replace_shared_capture_name.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/label_replace_shared_capture_name",
+  "fan_factor": 1,
+  "scan_rows": 2,
+  "peak_intermediate": 2,
+  "has_cross_join": false,
+  "has_array_join": false,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/solver-decision-baseline/label_replace_shared_capture_name.json
+++ b/test/perf/solver-decision-baseline/label_replace_shared_capture_name.json
@@ -1,0 +1,10 @@
+{
+  "query": "label_replace_shared_capture_name",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "5m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/rejection-parity/catalogue/internal__logql__label_fns.go.json
+++ b/test/rejection-parity/catalogue/internal__logql__label_fns.go.json
@@ -5,7 +5,7 @@
       "site": "internal/logql/label_fns.go:lowerLabelReplace#8cd9f67b",
       "message": "logql: label_replace: %w",
       "class": "divergence",
-      "trigger_query": "label_replace(rate({app=\"x\"}[5m]), \"d\", \"$dup\", \"src\", \"(?P\u003cdup\u003ea)|(?P\u003cdup\u003eb)\")",
+      "trigger_query": "label_replace(rate({app=\"x\"}[5m]), \"d\", \"$dup\", \"src\", \"(?P\u003cdup\u003ea?)|(?P\u003cdup\u003eb)\")",
       "tracking_issue": 1768,
       "evidence": {
         "guard": [

--- a/test/rejection-parity/catalogue/internal__promql__label_fns.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__label_fns.go.json
@@ -35,7 +35,7 @@
       "site": "internal/promql/label_fns.go:lowerLabelReplace#d11e3df4",
       "message": "promql: label_replace: %w",
       "class": "divergence",
-      "trigger_query": "label_replace(up, \"d\", \"$dup\", \"src\", \"(?P\u003cdup\u003ea)|(?P\u003cdup\u003eb)\")",
+      "trigger_query": "label_replace(up, \"d\", \"$dup\", \"src\", \"(?P\u003cdup\u003ea?)|(?P\u003cdup\u003eb)\")",
       "tracking_issue": 1768,
       "evidence": {
         "guard": [

--- a/test/spec/chplan_print.go
+++ b/test/spec/chplan_print.go
@@ -752,9 +752,13 @@ func formatGroupByEntry(expr, alias, display string) string {
 
 // printLabelReplaceSegments renders the replacement decomposition a
 // label_replace carries when its template references a capture group
-// above ClickHouse's `\9` substitution ceiling, and nothing at all
-// otherwise — so the fixtures that take the replaceRegexpOne path keep
-// their existing golden line unchanged.
+// above ClickHouse's `\9` substitution ceiling, or a name several capture
+// groups share, and nothing at all otherwise — so the fixtures that take
+// the replaceRegexpOne path keep their existing golden line unchanged.
+//
+// A shared-name reference prints as its carrier indices joined by `|`
+// (`$1|$2`), the "first of these with a non-empty capture" selection
+// chplan.LabelReplaceSegment.Fallbacks describes.
 func printLabelReplaceSegments(segments []chplan.LabelReplaceSegment) string {
 	if len(segments) == 0 {
 		return ""
@@ -765,7 +769,11 @@ func printLabelReplaceSegments(segments []chplan.LabelReplaceSegment) string {
 			parts = append(parts, fmt.Sprintf("%q", seg.Literal))
 			continue
 		}
-		parts = append(parts, fmt.Sprintf("$%d", seg.Group))
+		indices := []string{fmt.Sprintf("$%d", seg.Group)}
+		for _, idx := range seg.Fallbacks {
+			indices = append(indices, fmt.Sprintf("$%d", idx))
+		}
+		parts = append(parts, strings.Join(indices, "|"))
 	}
 	return ", segments=[" + strings.Join(parts, ", ") + "]"
 }

--- a/test/spec/promql/label_replace_shared_capture_name.txtar
+++ b/test/spec/promql/label_replace_shared_capture_name.txtar
@@ -1,0 +1,86 @@
+# A replacement referencing a capture-group NAME that TWO groups carry.
+# Go's ExpandString — the engine reference Prometheus runs label_replace's
+# replacement through — resolves `$dup` to the first group named `dup`
+# that TOOK PART in the row's match, whichever alternation branch that
+# was.
+#
+# ClickHouse's `extractGroups` cannot report participation: a group that
+# took no part and a group that took part matching the empty string are
+# both `''`. But neither group here CAN match the empty string (`[a-z]+`
+# and `[0-9]+` are both at least one character wide), so for these two
+# "took part" and "captured something non-empty" are the same predicate,
+# and the choice becomes an ordinary array search —
+# `arrayFirst(x -> x != '', [g[1], g[2]])`. That equivalence is why this
+# query is answered rather than rejected (#1768); a nullable group among
+# the carriers is still rejected, because then the two states really are
+# indistinguishable.
+#
+# The two seeded series cover both directions of the search. `web-alpha`
+# matches through the FIRST branch, so group one carries `alpha` and the
+# search stops immediately. `api-77` matches through the SECOND, so group
+# one is empty and the search must SKIP it — the case a translation that
+# simply took the first like-named group would answer with an empty
+# `service` label (and the outer mapFilter would then drop the label
+# entirely).
+#
+# Cross-checked against Go's own regexp: for `^web-(?P<dup>[a-z]+)|api-(?P<dup>[0-9]+)$`,
+# ExpandString gives `svc-alpha` for `web-alpha` (match offsets [0 9 4 9 -1 -1])
+# and `svc-77` for `api-77` (match offsets [0 6 -1 -1 4 6]).
+
+-- query.promql --
+label_replace(temperature, "service", "svc-$dup", "host", "web-(?P<dup>[a-z]+)|api-(?P<dup>[0-9]+)")
+-- seed --
+CREATE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge VALUES
+    ('temperature', map('host', 'web-alpha'), toDateTime64('2026-01-01 00:00:00', 9), 22.5),
+    ('temperature', map('host', 'api-77'), toDateTime64('2026-01-01 00:00:00', 9), 19.5);
+-- expected_rows --
+[
+  ["temperature", {"host": "api-77", "service": "svc-77"}, "2026-01-01T00:00:00Z", 19.5],
+  ["temperature", {"host": "web-alpha", "service": "svc-alpha"}, "2026-01-01T00:00:00Z", 22.5]
+]
+-- args --
+[0] string = "host"
+[1] string = "^web-(?P<dup>[a-z]+)|api-(?P<dup>[0-9]+)$"
+[2] string = "service"
+[3] string = "host"
+[4] string = "svc-"
+[5] string = "svc-"
+[6] string = ""
+[7] string = "host"
+[8] string = "^web-(?P<dup>[a-z]+)|api-(?P<dup>[0-9]+)$"
+[9] int64 = 1
+[10] string = "host"
+[11] string = "^web-(?P<dup>[a-z]+)|api-(?P<dup>[0-9]+)$"
+[12] int64 = 2
+[13] string = "service.name"
+[14] string = "service_name"
+[15] string = "service.name"
+[16] string = "service_name"
+[17] string = ""
+[18] string = "service_name"
+[19] string = "temperature"
+[20] string = "2026-01-01 00:00:01.000000000"
+[21] int64 = 9
+[22] string = "2026-01-01 00:00:01.000000000"
+[23] int64 = 9
+[24] int64 = 300000000000
+[25] int64 = 1
+[26] int64 = 0
+-- chplan --
+Project [MetricName, Attributes, TimeUnix, Value]
+  Aggregate groupBy=[Attributes AS Attributes, MetricName AS MetricName] funcs=[any(Value) AS Value, any(TimeUnix) AS TimeUnix] having=(throwIf((count() > 1), "vector cannot contain metrics with the same labelset") = 0)
+    Project [MetricName, labelReplace(Attributes, dst="service", replacement="", src="host", regex="web-(?P<dup>[a-z]+)|api-(?P<dup>[0-9]+)", emptyReplacement="svc-", segments=["svc-", $1|$2]) AS Attributes, TimeUnix, Value]
+      Project [MetricName AS MetricName, Attributes AS Attributes, lwr_ts AS TimeUnix, lwr_value AS Value]
+        Aggregate groupBy=[MetricName AS MetricName, Attributes AS Attributes] funcs=[max(TimeUnix) AS lwr_ts, argMax(Value, TimeUnix) AS lwr_value]
+          Filter predicate=((TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9)) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+            Project [MetricName AS MetricName, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, Value AS Value]
+              Filter predicate=(MetricName = "temperature")
+                Scan(merge(otel_metrics_gauge|otel_metrics_sum))
+-- sql --
+SELECT `MetricName`, `Attributes`, `TimeUnix`, `Value` FROM (SELECT `Attributes` AS `Attributes`, `MetricName` AS `MetricName`, any(`Value`) AS `Value`, any(`TimeUnix`) AS `TimeUnix` FROM (SELECT `MetricName`, mapFilter((k, v) -> v != '', if(match(`Attributes`[?], ?), mapUpdate(`Attributes`, map(?, if(empty(`Attributes`[?]), ?, concat(?, arrayFirst(x -> x != ?, [extractGroups(`Attributes`[?], ?)[?], extractGroups(`Attributes`[?], ?)[?]]))))), `Attributes`)) AS `Attributes`, `TimeUnix`, `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') PREWHERE (`MetricName` = ?))) WHERE ((`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?))))) GROUP BY `MetricName`, `Attributes`))) GROUP BY `Attributes`, `MetricName` HAVING (throwIf((count() > ?), 'vector cannot contain metrics with the same labelset') = ?))


### PR DESCRIPTION
Closes #1768

#1768 reads the rejection of a `label_replace` replacement referencing a capture-group NAME that several groups carry as a permanent ClickHouse expressiveness gap. It is not one — the rejection was over-broad.

## Why the premise is wrong

Go's `Regexp.ExpandString` — the reference both Prometheus and Loki run the replacement through — resolves `$name` to the first subexpression carrying that name whose submatch PARTICIPATED (start offset `!= -1`).

SQL cannot observe participation. ClickHouse's `extractGroups` reports a group that took no part and a group that took part matching the empty string identically, as `''`. Probed on chDB, this is exactly the pair the old code comment cited as evidence:

```
extractGroups('b', '^(a)|(b)$')  ->  ['','b']     -- group 1 took no part
extractGroups('',  '^(x?)$')     ->  ['']         -- group 1 took part, matched empty
```

Only the second is ambiguous. **If a carrier's subpattern cannot match epsilon, then `participated <=> non-empty capture`.** So when EVERY group sharing the name is non-nullable, "first carrier with a non-empty capture" reproduces Go's "first participating carrier" exactly, and the choice is an ordinary ordered array search. The condition the code needed was ALL carriers non-nullable; it had no condition at all.

The counter-example that pins the boundary: `(?P<dup>a?)|(?P<dup>b)` against `b` gives Go the match offsets `[0 0 0 0 -1 -1]` — carrier one PARTICIPATES matching empty, so `$dup` expands to `""`, not `"b"`. That case stays rejected.

## What changed

- **`internal/qlcommon/label_replace.go`** — a nullability predicate over `regexp/syntax` classifies each capture group (`OpEmptyMatch`, `OpStar`/`OpQuest`, `OpRepeat` with `Min==0`, `OpAlternate` nullable if ANY branch is, `OpConcat` nullable only if ALL children are, `OpCapture` delegating, literals and char-classes not nullable; anything unclassifiable counts as nullable). `resolve` returns a `resolvedRef` carrying the primary index plus the further like-named carriers, and errors only when some carrier is nullable — with a message that names that group as the reason.
- **`internal/chplan/label_replace.go`** — `LabelReplaceSegment` gains `Fallbacks []int`, with `Equal` and the clone path extended.
- **`internal/chsql/builder.go`** — the selection renders as `arrayFirst(x -> x != '', [extractGroups(src, rx)[i], ...])` in typed Frags (`Call` / `Array` / `Lambda1` / `BareIdent` / `Subscript`). `node .github/scripts/forbid-sql-raw.mjs` passes.

## Test evidence

- `internal/qlcommon` — a differential test expands 5 shared-name regexes through Go's own `re.ExpandString` and asserts the segment evaluation agrees, including a case where the FIRST carrier does not participate and one where both do. Four negative cases cover each nullability route (`a?`, `b*`, `x*y*` concatenation, `ab|` alternation branch).
- The negative guard was mutation-checked: forcing the nullability test false made all four negative subtests fail, e.g. `ReplacementToCH("$dup", "(?P<dup>a?)|(?P<dup>b)"): want error, got {Segments:[{Fallbacks:[2] Group:1}]}`.
- `internal/chsql` — `TestMutation_ExprLabelReplace_SharedCaptureNameForm` pins the whole emitted string and its bound args, so carrier ORDER is an assertion.
- `test/spec/promql/label_replace_shared_capture_name.txtar` — a chDB roundtrip over `web-(?P<dup>[a-z]+)|api-(?P<dup>[0-9]+)`, seeding one row that matches through each branch. Regenerated `expected_rows` are `svc-alpha` and `svc-77`, matching the Go oracle. The `api-77` row is the one that forces the search to SKIP the empty first carrier.
- Both rejection-parity catalogue shards move their trigger query to the still-rejected nullable form, since the old trigger now lowers successfully.

```
forbid-sql-raw: no raw SQL token writes outside the approved layer.
ok  github.com/tsouza/cerberus/internal/qlcommon        (72 tests)
ok  github.com/tsouza/cerberus/internal/chsql           (6 tests)
ok  github.com/tsouza/cerberus/test/rejection-parity    (20 tests)
```

Generated artefacts come from `just update-golden migration parity solver promql logql traceql chsql optimizer codegen cardinality` (the shard set the recipe derived from this diff); none was hand-edited.

Follow-up tracked in #1951 — both heads anchor the user regex as `^regex$` where the reference uses `^(?s:regex)$`, which lets a top-level alternation escape the anchors and stops `.` matching a newline. Independent of shared capture names.