### PR TITLE
test(promql): make each chdb fixture seed its own merge() fan-out, and assert it structurally

### DIFF
--- a/internal/promql/fixture_chdb_test.go
+++ b/internal/promql/fixture_chdb_test.go
@@ -1,0 +1,91 @@
+//go:build chdb
+
+// Shared chDB fixture plumbing for the package's chdb-tagged parity
+// tests, and the structural guard that keeps them independent of each
+// other.
+//
+// Every `sql.Open("chdb", "")` in this process resolves to ONE in-process
+// ClickHouse session, so the whole package shares a single catalog. That
+// makes each fixture's seed visible to every other fixture's query, and
+// the metrics read path scans a `merge(currentDatabase(), '^(…)$')`
+// fan-out whose column set is the UNION of whatever tables match. A
+// fixture that seeds only some of the arms therefore still passes in a
+// whole-package run — and fails on its own, with an UNKNOWN_IDENTIFIER
+// that reads exactly like a real SQL-lowering bug, under the narrowed
+// `go test -run '^TestName$'` invocation the repo mandates for
+// reproducing a red check.
+//
+// [chdbFixture] closes that hole by construction rather than by
+// convention: it binds the session to the seed script that populated it,
+// and every emitted statement executed through it is first checked
+// against that seed alone ([testsql.CheckSeedCoversFanOut]). A fixture
+// that leans on a sibling's tables fails immediately, with the arm and
+// the column named, instead of passing until someone narrows the run.
+package promql_test
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+
+	_ "github.com/chdb-io/chdb-go/chdb/driver"
+
+	"github.com/tsouza/cerberus/internal/testsql"
+)
+
+// chdbFixture pairs the process-shared chDB session with the seed script
+// that is allowed to satisfy the queries run against it.
+type chdbFixture struct {
+	db   *sql.DB
+	seed string
+}
+
+// newChDBFixture opens the shared in-process chDB session and applies
+// seed to it. Seeds spell their tables `CREATE OR REPLACE TABLE` — the
+// session outlives any one test, so a bare `CREATE TABLE` would trip
+// TABLE_ALREADY_EXISTS on the second fixture to declare the same table.
+func newChDBFixture(t *testing.T, seed string) *chdbFixture {
+	t.Helper()
+	db, err := sql.Open("chdb", "")
+	if err != nil {
+		t.Fatalf("open chdb: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := db.Ping(); err != nil {
+		t.Fatalf("ping chdb: %v", err)
+	}
+	for _, stmt := range testsql.SplitStatements(seed) {
+		stmt = strings.TrimSpace(stmt)
+		if stmt == "" {
+			continue
+		}
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("seed %q: %v", stmt, err)
+		}
+	}
+	return &chdbFixture{db: db, seed: seed}
+}
+
+// queryOverEmitted runs `SELECT <projection> FROM (<emitted>)` and
+// returns the rows for the caller to close.
+//
+// The wrap exists because chdb-go's parquet driver cannot decode a `Map`
+// cell into a Go destination, so the sort-key / label values are read out
+// as plain String columns over the emitted (ORDER BY-bearing) statement,
+// preserving the row order the inner query produced.
+//
+// Before executing anything it asserts the fixture's own seed is
+// self-sufficient for the emitted fan-out. That assertion is what makes a
+// narrowed single-test run mean the same thing as a whole-package run.
+func (f *chdbFixture) queryOverEmitted(t *testing.T, projection, emitted string, args []any) *sql.Rows {
+	t.Helper()
+	if err := testsql.CheckSeedCoversFanOut(f.seed, emitted); err != nil {
+		t.Fatalf("this fixture's seed does not stand on its own — it would pass only while a sibling fixture's tables happen to be present in the shared chDB session: %v\nemitted SQL: %s", err, emitted)
+	}
+	wrapped := "SELECT " + projection + " FROM (" + emitted + ")"
+	rows, err := f.db.Query(wrapped, args...)
+	if err != nil {
+		t.Fatalf("query: %v\nSQL: %s", err, wrapped)
+	}
+	return rows
+}

--- a/internal/promql/limit_ratio_chdb_test.go
+++ b/internal/promql/limit_ratio_chdb_test.go
@@ -22,8 +22,8 @@
 // chdb-go parquet driver, and that rewrite is incompatible with the
 // WHERE-clause map operations the ratio offset needs (CH mis-dispatches
 // `concat` to `arrayConcat`). Instead it lowers + emits the production
-// SQL directly, runs it against an ephemeral chDB session seeded with a
-// known series set, and asserts the surviving `instance` label set
+// SQL directly, runs it against the package-shared chDB session seeded
+// with a known series set, and asserts the surviving `instance` label set
 // matches the set computed independently in Go via the real
 // `prometheus/model/labels` Hash — the reference behaviour itself.
 //
@@ -33,7 +33,6 @@ package promql_test
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"math"
 	"sort"
@@ -41,7 +40,6 @@ import (
 	"testing"
 	"time"
 
-	_ "github.com/chdb-io/chdb-go/chdb/driver"
 	prommodel "github.com/prometheus/prometheus/model/labels"
 	promparser "github.com/prometheus/prometheus/promql/parser"
 
@@ -80,16 +78,7 @@ func refSelected(ratio float64) []string {
 }
 
 func TestLimitRatio_ChDBParity(t *testing.T) {
-	db, err := sql.Open("chdb", "")
-	if err != nil {
-		t.Fatalf("open chdb: %v", err)
-	}
-	t.Cleanup(func() { _ = db.Close() })
-	if err := db.Ping(); err != nil {
-		t.Fatalf("ping chdb: %v", err)
-	}
-
-	seedLimitRatioCorpus(t, db)
+	fixture := newChDBFixture(t, limitRatioSeed())
 
 	s := schema.DefaultOTelMetrics()
 	p := promparser.NewParser(promparser.Options{EnableExperimentalFunctions: true})
@@ -111,7 +100,7 @@ func TestLimitRatio_ChDBParity(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Emit(%q): %v", query, err)
 			}
-			got := selectInstances(t, db, sqlStr, args)
+			got := selectInstances(t, fixture, sqlStr, args)
 			want := refSelected(ratio)
 			if strings.Join(got, ",") != strings.Join(want, ",") {
 				t.Errorf("limit_ratio(%g) selected %v; reference HashRatioSampler selects %v\n(offsets: %s)",
@@ -136,15 +125,7 @@ func offsetsDebug() string {
 // `(r>=0 AND off<r) OR (r<0 AND off>=1+r)` runtime predicate. The
 // selected set must match the literal-ratio reference for the same r.
 func TestLimitRatio_ChDBParity_ComputedRatio(t *testing.T) {
-	db, err := sql.Open("chdb", "")
-	if err != nil {
-		t.Fatalf("open chdb: %v", err)
-	}
-	t.Cleanup(func() { _ = db.Close() })
-	if err := db.Ping(); err != nil {
-		t.Fatalf("ping chdb: %v", err)
-	}
-	seedLimitRatioCorpus(t, db)
+	fixture := newChDBFixture(t, limitRatioSeed())
 
 	s := schema.DefaultOTelMetrics()
 	p := promparser.NewParser(promparser.Options{EnableExperimentalFunctions: true})
@@ -172,7 +153,7 @@ func TestLimitRatio_ChDBParity_ComputedRatio(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Emit(%q): %v", tc.query, err)
 			}
-			got := selectInstances(t, db, sqlStr, args)
+			got := selectInstances(t, fixture, sqlStr, args)
 			want := refSelected(tc.ratio)
 			if strings.Join(got, ",") != strings.Join(want, ",") {
 				t.Errorf("%s selected %v; reference (r=%g) selects %v\n(offsets: %s)",
@@ -182,40 +163,45 @@ func TestLimitRatio_ChDBParity_ComputedRatio(t *testing.T) {
 	}
 }
 
-// seedLimitRatioCorpus creates the gauge + sum metric tables and inserts
-// the five-instance `up` corpus into the gauge table.
-func seedLimitRatioCorpus(t *testing.T, db *sql.DB) {
-	t.Helper()
-	// ResourceAttributes (DEFAULT map()) mirrors the OTel-CH default schema:
-	// the rc.5 read path projects mapUpdate(sanitize(ResourceAttributes), …),
-	// so the seed tables must carry the column or the chDB round-trip 502s
-	// with UNKNOWN_IDENTIFIER. The INSERTs stay column-explicit (sans
-	// ResourceAttributes) so the empty default fills it.
-	if _, err := db.Exec("CREATE OR REPLACE TABLE otel_metrics_gauge (`MetricName` String, `Attributes` Map(String, String), `ResourceAttributes` Map(String, String) DEFAULT map(), `ServiceName` LowCardinality(String) DEFAULT '', `TimeUnix` DateTime64(9), `Value` Float64) ENGINE = MergeTree ORDER BY (`MetricName`, `Attributes`, `TimeUnix`)"); err != nil {
-		t.Fatalf("create gauge: %v", err)
-	}
-	if _, err := db.Exec("CREATE OR REPLACE TABLE otel_metrics_sum (`MetricName` String, `Attributes` Map(String, String), `ResourceAttributes` Map(String, String) DEFAULT map(), `ServiceName` LowCardinality(String) DEFAULT '', `TimeUnix` DateTime64(9), `Value` Float64) ENGINE = MergeTree ORDER BY (`MetricName`, `Attributes`, `TimeUnix`)"); err != nil {
-		t.Fatalf("create sum: %v", err)
-	}
+// limitRatioSeed declares BOTH arms of the metrics fan-out the emitted
+// SQL scans — `merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$')`
+// — even though every `up` row lands in the gauge table. merge() takes
+// its column set from the union of the tables that match, so a seed
+// missing an arm silently borrows that arm from whichever sibling fixture
+// last ran in the process-shared chDB session, and the fixture then fails
+// on its own under a narrowed `-run`.
+// [chdbFixture.queryOverEmitted] asserts the arms are all present here.
+//
+// ResourceAttributes (DEFAULT map()) mirrors the OTel-CH default schema:
+// the read path projects mapUpdate(sanitize(ResourceAttributes), …) and
+// toString(ServiceName) unconditionally, so both columns must exist or
+// the chDB round-trip fails with UNKNOWN_IDENTIFIER. The INSERTs stay
+// column-explicit (naming neither) so the DEFAULTs fill them.
+//
+// CREATE OR REPLACE keeps the seed idempotent against that shared
+// session, which outlives any single test.
+const limitRatioSeedDDL = "" +
+	"CREATE OR REPLACE TABLE otel_metrics_gauge (`MetricName` String, `Attributes` Map(String, String), `ResourceAttributes` Map(String, String) DEFAULT map(), `ServiceName` LowCardinality(String) DEFAULT '', `TimeUnix` DateTime64(9), `Value` Float64) ENGINE = MergeTree ORDER BY (`MetricName`, `Attributes`, `TimeUnix`);\n" +
+	"CREATE OR REPLACE TABLE otel_metrics_sum (`MetricName` String, `Attributes` Map(String, String), `ResourceAttributes` Map(String, String) DEFAULT map(), `ServiceName` LowCardinality(String) DEFAULT '', `TimeUnix` DateTime64(9), `Value` Float64) ENGINE = MergeTree ORDER BY (`MetricName`, `Attributes`, `TimeUnix`);\n"
+
+// limitRatioSeed is the DDL plus the five-instance `up` corpus, all of
+// which lands in the gauge table.
+func limitRatioSeed() string {
+	var b strings.Builder
+	b.WriteString(limitRatioSeedDDL)
 	for _, inst := range seriesInstances {
-		ins := fmt.Sprintf(
-			"INSERT INTO otel_metrics_gauge (MetricName, Attributes, TimeUnix, Value) VALUES ('up', map('instance', '%s', 'job', 'demo'), toDateTime64('2026-01-01 00:00:00', 9), 1.0)", inst,
-		)
-		if _, err := db.Exec(ins); err != nil {
-			t.Fatalf("seed %s: %v", inst, err)
-		}
+		fmt.Fprintf(&b,
+			"INSERT INTO otel_metrics_gauge (MetricName, Attributes, TimeUnix, Value) VALUES ('up', map('instance', '%s', 'job', 'demo'), toDateTime64('2026-01-01 00:00:00', 9), 1.0);\n",
+			inst)
 	}
+	return b.String()
 }
 
 // selectInstances runs the lowered Sample-shape SQL and returns the
 // sorted set of surviving `instance` labels.
-func selectInstances(t *testing.T, db *sql.DB, sqlStr string, args []any) []string {
+func selectInstances(t *testing.T, fixture *chdbFixture, sqlStr string, args []any) []string {
 	t.Helper()
-	wrapped := "SELECT `Attributes`['instance'] FROM (" + sqlStr + ")"
-	rows, err := db.Query(wrapped, args...)
-	if err != nil {
-		t.Fatalf("query: %v\nSQL: %s", err, wrapped)
-	}
+	rows := fixture.queryOverEmitted(t, "`Attributes`['instance']", sqlStr, args)
 	defer func() { _ = rows.Close() }()
 	var got []string
 	for rows.Next() {

--- a/internal/promql/sort_by_label_chdb_test.go
+++ b/internal/promql/sort_by_label_chdb_test.go
@@ -9,8 +9,8 @@
 // functions exist to produce: a stable ROW ORDER keyed on label values.
 // This test closes that gap. It lowers each function through the real
 // promql.Lower → chsql.Emit pipeline, executes the emitted SQL against
-// an ephemeral chDB session seeded with a Map-typed Attributes column,
-// and asserts the resulting handler/method label order matches what
+// the package-shared chDB session seeded with a Map-typed Attributes
+// column, and asserts the resulting handler/method label order matches what
 // reference Prometheus's funcSortByLabel / funcSortByLabelDesc produce:
 // a NATURAL-ORDER sort (github.com/facette/natsort) on the named label
 // value(s), ascending for `sort_by_label` and descending for
@@ -31,12 +31,9 @@ package promql_test
 
 import (
 	"context"
-	"database/sql"
-	"strings"
 	"testing"
 	"time"
 
-	_ "github.com/chdb-io/chdb-go/chdb/driver"
 	"github.com/prometheus/prometheus/promql/parser"
 
 	"github.com/tsouza/cerberus/internal/chsql"
@@ -55,17 +52,37 @@ import (
 // are the natural-vs-lexicographic discriminators: byte order ranks
 // `v10` before `v2`, natural order ranks `v2` before `v10`. They are
 // inserted in a scrambled order that matches neither target ordering.
+// The seed declares BOTH arms of the metrics fan-out these queries scan
+// — `merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$')`
+// — even though every row lands in the gauge table. merge() takes its
+// column set from the union of the tables that match, so a seed that
+// declares only the gauge arm resolves `toString(ServiceName)` off
+// whatever otel_metrics_sum a sibling fixture happened to leave in the
+// shared session: green for the whole package, UNKNOWN_IDENTIFIER for a
+// narrowed `-run` of this test alone. Both arms carry the full read-path
+// column set (ResourceAttributes for the resource merge, ServiceName for
+// the dedicated-column overlay) so the fixture stands on its own.
+// [chdbFixture.queryOverEmitted] asserts exactly that before executing.
+//
 // CREATE OR REPLACE so re-running against the process-shared in-process
-// chDB session (every openChDB uses the empty DSN → one global session)
-// is idempotent: a sibling fixture (limit_ratio_chdb_test.go) already
-// materialises otel_metrics_gauge, and a bare CREATE TABLE trips
-// TABLE_ALREADY_EXISTS when the package's chDB tests share the session.
-// Mirrors the OR-REPLACE limit_ratio_chdb_test.go already uses.
+// chDB session (every sql.Open("chdb", "") uses the empty DSN → one
+// global session) is idempotent: a sibling fixture
+// (limit_ratio_chdb_test.go) declares the same two tables, and a bare
+// CREATE TABLE would trip TABLE_ALREADY_EXISTS on whichever ran second.
 const sortByLabelSeed = `
 CREATE OR REPLACE TABLE otel_metrics_gauge (
     MetricName String,
     Attributes Map(String, String),
     ResourceAttributes Map(String, String) DEFAULT map(),
+    ServiceName LowCardinality(String) DEFAULT '',
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+CREATE OR REPLACE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    ResourceAttributes Map(String, String) DEFAULT map(),
+    ServiceName LowCardinality(String) DEFAULT '',
     TimeUnix DateTime64(9),
     Value Float64
 ) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
@@ -81,23 +98,7 @@ INSERT INTO otel_metrics_gauge (MetricName, Attributes, TimeUnix, Value) VALUES
     ('node_load', map('instance', 'v2',  'rack', 'r10'), toDateTime64('2026-01-01 00:00:00', 9), 21.0);`
 
 func TestSortByLabel_OrderParityVsPrometheus(t *testing.T) {
-	db, err := sql.Open("chdb", "")
-	if err != nil {
-		t.Fatalf("open chdb: %v", err)
-	}
-	t.Cleanup(func() { _ = db.Close() })
-	if err := db.Ping(); err != nil {
-		t.Fatalf("ping chdb: %v", err)
-	}
-	for _, stmt := range strings.Split(strings.TrimSpace(sortByLabelSeed), ";") {
-		stmt = strings.TrimSpace(stmt)
-		if stmt == "" {
-			continue
-		}
-		if _, err := db.Exec(stmt); err != nil {
-			t.Fatalf("seed %q: %v", stmt, err)
-		}
-	}
+	fixture := newChDBFixture(t, sortByLabelSeed)
 
 	s := schema.DefaultOTelMetrics()
 	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
@@ -193,20 +194,17 @@ func TestSortByLabel_OrderParityVsPrometheus(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Emit: %v", err)
 			}
-			// Read the sort-key label values out as plain String columns —
+			// Read the sort-key label values out as plain String columns:
 			// projecting `Attributes[<primary>]` / `Attributes[<secondary>]`
-			// over the emitted (ORDER BY-bearing) subquery sidesteps the
+			// over the emitted (ORDER BY-bearing) statement sidesteps the
 			// chdb-go parquet Map-scan panic while preserving the row order
 			// the inner ORDER BY produced.
 			secCol := tc.secondary
 			if secCol == "" {
 				secCol = tc.primary // harmless duplicate read; m is ignored
 			}
-			wrapped := "SELECT `Attributes`['" + tc.primary + "'] AS h, `Attributes`['" + secCol + "'] AS m FROM (" + sqlStr + ")"
-			rows, err := db.Query(wrapped, args...)
-			if err != nil {
-				t.Fatalf("query: %v\nSQL: %s", err, wrapped)
-			}
+			projection := "`Attributes`['" + tc.primary + "'] AS h, `Attributes`['" + secCol + "'] AS m"
+			rows := fixture.queryOverEmitted(t, projection, sqlStr, args)
 			defer func() { _ = rows.Close() }()
 
 			var got []string

--- a/internal/testsql/fanout.go
+++ b/internal/testsql/fanout.go
@@ -1,0 +1,352 @@
+package testsql
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"unicode"
+)
+
+// CheckSeedCoversFanOut asserts that a fixture's own seed script is
+// self-sufficient for an emitted statement that scans a ClickHouse
+// `merge()` table-function fan-out.
+//
+// # Why a fan-out needs its own gate
+//
+// `merge(<db>, '<regex>')` resolves against whatever tables happen to
+// exist in the session at query time, and its column set is the UNION of
+// the matched tables' columns. Both halves are silent: an arm the seed
+// never created simply drops out of the union, and a column the seed
+// never declared still resolves as long as SOME other table matching the
+// regex carries it. A test substrate that shares one session across
+// fixtures — every `sql.Open("chdb", "")` resolves to a single in-process
+// session, so every chdb-tagged test in a package shares one catalog —
+// therefore lets one fixture's seed silently satisfy another's query.
+//
+// The failure mode is not a flaky test; it is worse. The whole-package
+// run passes and the narrowed `go test -run '^TestName$'` run — the
+// invocation the repo mandates for reproducing a red check — fails with
+// an UNKNOWN_IDENTIFIER that reads exactly like a real SQL-lowering bug.
+// This check turns that into a named, deterministic assertion made
+// against the fixture's own seed text, with no dependence on which
+// sibling ran first.
+//
+// A single-table scan (`FROM <table>`) needs no such gate: an unseeded
+// table fails with UNKNOWN_TABLE, which nobody mistakes for a lowering
+// bug. `merge()` is the shape that fails confusingly, so it is the shape
+// checked here.
+//
+// # What it asserts
+//
+// For every `merge()` fan-out in emittedSQL:
+//
+//  1. every arm named by the fan-out regex is CREATEd by seed itself;
+//  2. every column emittedSQL references off a base relation is declared
+//     by at least one of those arms — "at least one" rather than "all"
+//     because `merge()` unions columns, and production's metric tables
+//     legitimately differ (only the histogram tables carry `Count` /
+//     `Sum`, and inventing them on the gauge table would mask a real
+//     bug).
+//
+// A fan-out regex this function cannot decompose is an error, never a
+// pass: a check that quietly skips what it does not understand is a gap
+// wearing a green tick.
+//
+// The referenced-column set is derived textually and is deliberately
+// UNDER-approximate: an identifier that appears anywhere as an `AS`
+// target, as a `FROM`/`JOIN` operand, or as a `WITH <name> AS (…)` CTE
+// head is dropped wholesale, because those are alias/relation names
+// rather than base columns. In practice that discards exactly the four
+// canonical output names the emitter aliases to (`MetricName`,
+// `Attributes`, `TimeUnix`, `Value`) — the columns no seed omits — and
+// keeps the ones seeds do omit (`ResourceAttributes`, `ServiceName`,
+// `Count`, `Sum`). Under-approximating is the safe direction: it can
+// only fail to flag, never flag something the query does not need.
+func CheckSeedCoversFanOut(seed, emittedSQL string) error {
+	fanOuts, err := fanOutArms(emittedSQL)
+	if err != nil {
+		return err
+	}
+	if len(fanOuts) == 0 {
+		return nil
+	}
+	seeded := seededTables(seed)
+	referenced := referencedColumns(emittedSQL)
+
+	var problems []string
+	for _, arms := range fanOuts {
+		problems = append(problems, fanOutProblems(arms, seeded, referenced)...)
+	}
+	if len(problems) == 0 {
+		return nil
+	}
+	slices.Sort(problems)
+	return fmt.Errorf("seed is not self-sufficient for the emitted merge() fan-out:\n  %s",
+		strings.Join(slices.Compact(problems), "\n  "))
+}
+
+// fanOutProblems reports every way `seed` fails to stand alone for one
+// fan-out: arms it never created, and referenced columns no created arm
+// declares.
+func fanOutProblems(arms []string, seeded map[string][]string, referenced []string) []string {
+	var problems []string
+	covered := map[string]bool{}
+	for _, arm := range arms {
+		cols, ok := seeded[arm]
+		if !ok {
+			problems = append(problems, fmt.Sprintf(
+				"fan-out arm %q is scanned but never created by this seed — it resolves only because a sibling fixture created it in the shared session",
+				arm,
+			))
+			continue
+		}
+		for _, c := range cols {
+			covered[c] = true
+		}
+	}
+	for _, col := range referenced {
+		if covered[col] {
+			continue
+		}
+		problems = append(problems, fmt.Sprintf(
+			"column %q is referenced by the emitted SQL but declared by none of the fan-out arms this seed creates (%s)",
+			col, strings.Join(arms, ", "),
+		))
+	}
+	return problems
+}
+
+// mergeCall is the ClickHouse table function whose regex argument names
+// the fan-out arms.
+const mergeCall = "merge"
+
+// fanOutArms returns one entry per `merge(<db>, '<regex>')` call in sql,
+// each holding that call's arm table names in regex order.
+func fanOutArms(sql string) ([][]string, error) {
+	var out [][]string
+	for i := 0; i < len(sql); i++ {
+		if sql[i] == '\'' {
+			// A `merge(` spelled inside a SQL string literal is data, not
+			// a call; skip the whole literal.
+			i = skipStringLiteral(sql, i)
+			continue
+		}
+		start, ok := mergeCallAt(sql, i)
+		if !ok {
+			continue
+		}
+		open := start + len(mergeCall)
+		closeParen := matchParen(sql, open)
+		if closeParen < 0 {
+			return nil, fmt.Errorf("unbalanced merge() call at offset %d in emitted SQL", start)
+		}
+		args := splitTopLevelCommas(sql[open+1 : closeParen])
+		const wantArgs = 2 // merge(<database>, '<table-name regex>')
+		if len(args) != wantArgs {
+			return nil, fmt.Errorf("merge() at offset %d takes %d arguments, want %d: %q",
+				start, len(args), wantArgs, sql[start:closeParen+1])
+		}
+		arms, err := armsFromPattern(strings.TrimSpace(args[1]))
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, arms)
+		i = closeParen
+	}
+	return out, nil
+}
+
+// mergeCallAt reports whether a `merge(` call token starts at index i —
+// i.e. the keyword is not the tail of a longer identifier such as
+// `arrayMerge(`.
+func mergeCallAt(sql string, i int) (int, bool) {
+	if !strings.HasPrefix(sql[i:], mergeCall+"(") {
+		return 0, false
+	}
+	if i > 0 && isIdentByte(sql[i-1]) {
+		return 0, false
+	}
+	return i, true
+}
+
+// armsFromPattern decomposes the single-quoted RE2 literal chsql's
+// mergeTableFrag emits — `'^(a|b|c)$'`, each arm regex-escaped — back
+// into its arm names. Anything it cannot decompose is an error rather
+// than an empty result, so an emitter change to the fan-out shape
+// breaks this check loudly instead of silently disarming it.
+func armsFromPattern(lit string) ([]string, error) {
+	if len(lit) < 2 || lit[0] != '\'' || lit[len(lit)-1] != '\'' {
+		return nil, fmt.Errorf("merge() table pattern %q is not a single-quoted literal", lit)
+	}
+	pattern := strings.ReplaceAll(lit[1:len(lit)-1], "''", "'")
+	body, ok := strings.CutPrefix(pattern, "^")
+	if !ok {
+		return nil, fmt.Errorf("merge() table pattern %q is not anchored at ^", pattern)
+	}
+	body, ok = strings.CutSuffix(body, "$")
+	if !ok {
+		return nil, fmt.Errorf("merge() table pattern %q is not anchored at $", pattern)
+	}
+	if inner, ok := strings.CutPrefix(body, "("); ok {
+		body, ok = strings.CutSuffix(inner, ")")
+		if !ok {
+			return nil, fmt.Errorf("merge() table pattern %q has an unbalanced alternation group", pattern)
+		}
+	}
+	var arms []string
+	for _, raw := range strings.Split(body, "|") {
+		arm := strings.ReplaceAll(raw, `\`, "")
+		if arm == "" || strings.ContainsFunc(arm, func(r rune) bool { return r > unicode.MaxASCII || !isIdentByte(byte(r)) }) {
+			return nil, fmt.Errorf("merge() table pattern %q holds a non-literal arm %q that this check cannot resolve to a table name", pattern, raw)
+		}
+		arms = append(arms, arm)
+	}
+	return arms, nil
+}
+
+// seededTables maps each table a seed script CREATEs to its declared
+// column names, lower-cased on the table name to match the fan-out arms
+// (ClickHouse table names are case-sensitive, but the seeds and the
+// schema both spell them lower-case; normalising avoids a spurious miss
+// on a differently-cased seed).
+func seededTables(seed string) map[string][]string {
+	out := map[string][]string{}
+	for _, stmt := range SplitStatements(seed) {
+		trimmed := stripLeadingNoise(stmt)
+		rest, ok := createTableTail(trimmed)
+		if !ok {
+			continue
+		}
+		name := strings.ToLower(unquoteIdent(strings.TrimSpace(firstToken(rest))))
+		open := strings.IndexByte(stmt, '(')
+		if open < 0 {
+			continue
+		}
+		closeParen := matchParen(stmt, open)
+		if closeParen < 0 {
+			continue
+		}
+		var cols []string
+		for _, def := range splitTopLevelCommas(stmt[open+1 : closeParen]) {
+			if cn := unquoteIdent(firstToken(strings.TrimSpace(def))); cn != "" {
+				cols = append(cols, cn)
+			}
+		}
+		out[name] = cols
+	}
+	return out
+}
+
+// referencedColumns returns the sorted set of backtick-quoted
+// identifiers in sql that name a base-relation column: every quoted
+// identifier, minus those that appear anywhere as an `AS` target, as a
+// `FROM`/`JOIN` operand, or as a `WITH <name> AS (…)` CTE head. See
+// [CheckSeedCoversFanOut] for why the subtraction is applied globally
+// (and is therefore under-approximate).
+func referencedColumns(sql string) []string {
+	seen := map[string]bool{}
+	notColumn := map[string]bool{}
+	for i := 0; i < len(sql); i++ {
+		switch sql[i] {
+		case '\'':
+			i = skipStringLiteral(sql, i)
+		case '`':
+			end := strings.IndexByte(sql[i+1:], '`')
+			if end < 0 {
+				return sortedKeys(seen, notColumn)
+			}
+			name := sql[i+1 : i+1+end]
+			seen[name] = true
+			if precededByKeyword(sql[:i]) || isCTEHead(sql[i+1+end+1:]) {
+				notColumn[name] = true
+			}
+			i += end + 1
+		}
+	}
+	return sortedKeys(seen, notColumn)
+}
+
+// relationKeywords introduce a name that is an alias or a relation
+// rather than a base column.
+var relationKeywords = []string{"AS", "FROM", "JOIN"}
+
+// precededByKeyword reports whether the text immediately before a quoted
+// identifier ends with one of [relationKeywords].
+func precededByKeyword(before string) bool {
+	trimmed := strings.TrimRight(before, " \t\n\r")
+	if len(trimmed) == len(before) {
+		return false // the identifier is glued to the previous token
+	}
+	upper := strings.ToUpper(trimmed)
+	for _, kw := range relationKeywords {
+		if !strings.HasSuffix(upper, kw) {
+			continue
+		}
+		head := upper[:len(upper)-len(kw)]
+		if head == "" || !isIdentByte(head[len(head)-1]) {
+			return true
+		}
+	}
+	return false
+}
+
+// isCTEHead reports whether the text immediately after a quoted
+// identifier opens a `AS (` CTE body — ClickHouse's `WITH <name> AS
+// (<body>)` form, where the name precedes the AS.
+func isCTEHead(after string) bool {
+	rest := strings.TrimLeft(after, " \t\n\r")
+	rest, ok := strings.CutPrefix(strings.ToUpper(rest), "AS")
+	if !ok {
+		return false
+	}
+	trimmed := strings.TrimLeft(rest, " \t\n\r")
+	return len(trimmed) != len(rest) && strings.HasPrefix(trimmed, "(")
+}
+
+// sortedKeys returns the members of seen absent from excluded, sorted.
+func sortedKeys(seen, excluded map[string]bool) []string {
+	out := make([]string, 0, len(seen))
+	for name := range seen {
+		if !excluded[name] {
+			out = append(out, name)
+		}
+	}
+	slices.Sort(out)
+	return out
+}
+
+// skipStringLiteral returns the index of the quote closing the SQL string
+// literal that opens at start (which must index a `'`), or len(s)-1 when
+// the literal is unterminated. Both escape conventions chsql emits are
+// honoured: SQL-standard `”` doubling (escapeSingleQuotes, used for the
+// merge() regex) and backslash escaping (InlineLit).
+func skipStringLiteral(s string, start int) int {
+	for i := start + 1; i < len(s); i++ {
+		switch s[i] {
+		case '\\':
+			i++
+		case '\'':
+			if i+1 < len(s) && s[i+1] == '\'' {
+				i++
+				continue
+			}
+			return i
+		}
+	}
+	return len(s) - 1
+}
+
+// unquoteIdent strips the backtick quoting a seed may wrap an identifier
+// in.
+func unquoteIdent(s string) string {
+	return strings.Trim(strings.TrimSpace(s), "`")
+}
+
+// isIdentByte reports whether c may appear inside an unquoted SQL
+// identifier.
+func isIdentByte(c byte) bool {
+	return c == '_' ||
+		(c >= 'a' && c <= 'z') ||
+		(c >= 'A' && c <= 'Z') ||
+		(c >= '0' && c <= '9')
+}

--- a/internal/testsql/fanout.go
+++ b/internal/testsql/fanout.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"slices"
 	"strings"
-	"unicode"
 )
 
 // CheckSeedCoversFanOut asserts that a fixture's own seed script is
@@ -196,7 +195,7 @@ func armsFromPattern(lit string) ([]string, error) {
 	var arms []string
 	for _, raw := range strings.Split(body, "|") {
 		arm := strings.ReplaceAll(raw, `\`, "")
-		if arm == "" || strings.ContainsFunc(arm, func(r rune) bool { return r > unicode.MaxASCII || !isIdentByte(byte(r)) }) {
+		if arm == "" || !isIdentWord(arm) {
 			return nil, fmt.Errorf("merge() table pattern %q holds a non-literal arm %q that this check cannot resolve to a table name", pattern, raw)
 		}
 		arms = append(arms, arm)
@@ -340,6 +339,25 @@ func skipStringLiteral(s string, start int) int {
 // in.
 func unquoteIdent(s string) string {
 	return strings.Trim(strings.TrimSpace(s), "`")
+}
+
+// isIdentWord reports whether every byte of s may appear inside an
+// unquoted SQL identifier — that is, whether s is a bare table name
+// rather than a pattern arm this check cannot resolve.
+//
+// It scans BYTES rather than runes deliberately. Every byte of a
+// multi-byte UTF-8 rune is >= 0x80, so [isIdentByte] rejects it anyway,
+// and the byte scan reaches the same verdict without narrowing a rune
+// to a byte — a conversion that is provably safe here only because of a
+// short-circuited guard, which is exactly the shape a reader (and
+// gosec's G115) cannot check locally.
+func isIdentWord(s string) bool {
+	for i := range len(s) {
+		if !isIdentByte(s[i]) {
+			return false
+		}
+	}
+	return true
 }
 
 // isIdentByte reports whether c may appear inside an unquoted SQL

--- a/internal/testsql/fanout_test.go
+++ b/internal/testsql/fanout_test.go
@@ -1,0 +1,173 @@
+package testsql
+
+import (
+	"strings"
+	"testing"
+)
+
+// fanOutSQL is the shape internal/promql's chdb fixtures emit: a
+// `SELECT *` off a two-arm metrics fan-out, wrapped in the projection
+// that reads ServiceName and ResourceAttributes off the merged relation.
+// Trimmed to the identifiers that matter; the real statement is the same
+// shape with more arithmetic.
+const fanOutSQL = "SELECT `MetricName` AS `MetricName`, " +
+	"mapUpdate(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`), map(?, toString(`ServiceName`))) AS `Attributes`, " +
+	"`TimeUnix` AS `TimeUnix`, `Value` AS `Value` " +
+	"FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') WHERE (`MetricName` IN (?)))"
+
+// gaugeOnlySeed is the pre-fix internal/promql/sort_by_label_chdb_test.go
+// seed: it creates only one of the two arms the fan-out scans, and that
+// arm carries no ServiceName.
+const gaugeOnlySeed = `
+CREATE OR REPLACE TABLE otel_metrics_gauge (
+    MetricName String,
+    Attributes Map(String, String),
+    ResourceAttributes Map(String, String) DEFAULT map(),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_gauge (MetricName, Attributes, TimeUnix, Value) VALUES
+    ('http_requests', map('handler', 'b'), toDateTime64('2026-01-01 00:00:00', 9), 30.0);`
+
+// bothArmsSeed materialises both arms with the full projected column set.
+const bothArmsSeed = `
+CREATE OR REPLACE TABLE otel_metrics_gauge (
+    ` + "`MetricName`" + ` String,
+    ` + "`Attributes`" + ` Map(String, String),
+    ` + "`ResourceAttributes`" + ` Map(String, String) DEFAULT map(),
+    ` + "`ServiceName`" + ` LowCardinality(String) DEFAULT '',
+    ` + "`TimeUnix`" + ` DateTime64(9),
+    ` + "`Value`" + ` Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+CREATE OR REPLACE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    ResourceAttributes Map(String, String) DEFAULT map(),
+    ServiceName LowCardinality(String) DEFAULT '',
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);`
+
+// TestCheckSeedCoversFanOut_MissingArm pins the exact coupling issue
+// #1910 records: the seed creates one arm of the fan-out and relies on a
+// sibling fixture in the shared chDB session for the other.
+func TestCheckSeedCoversFanOut_MissingArm(t *testing.T) {
+	err := CheckSeedCoversFanOut(gaugeOnlySeed, fanOutSQL)
+	if err == nil {
+		t.Fatal("a seed that creates only otel_metrics_gauge must not pass a fan-out over gauge AND sum")
+	}
+	if !strings.Contains(err.Error(), "otel_metrics_sum") {
+		t.Errorf("error must name the uncreated arm; got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "ServiceName") {
+		t.Errorf("error must name the column no created arm declares; got: %v", err)
+	}
+}
+
+// TestCheckSeedCoversFanOut_MissingColumn pins the second half: both arms
+// exist, but neither declares a column the emitted SQL projects, so the
+// query would resolve it only off some other table a sibling created.
+func TestCheckSeedCoversFanOut_MissingColumn(t *testing.T) {
+	seed := strings.ReplaceAll(bothArmsSeed, "ServiceName", "SomeOtherColumn")
+	err := CheckSeedCoversFanOut(seed, fanOutSQL)
+	if err == nil {
+		t.Fatal("a seed whose arms omit a projected column must not pass")
+	}
+	if !strings.Contains(err.Error(), `column "ServiceName"`) {
+		t.Errorf("error must name the missing column; got: %v", err)
+	}
+	if strings.Contains(err.Error(), "never created by this seed") {
+		t.Errorf("both arms exist, so no arm should be reported missing; got: %v", err)
+	}
+}
+
+// TestCheckSeedCoversFanOut_SelfSufficient is the positive direction: a
+// seed that materialises every arm with every projected column passes.
+func TestCheckSeedCoversFanOut_SelfSufficient(t *testing.T) {
+	if err := CheckSeedCoversFanOut(bothArmsSeed, fanOutSQL); err != nil {
+		t.Fatalf("a self-sufficient seed must pass: %v", err)
+	}
+}
+
+// TestCheckSeedCoversFanOut_ColumnUnionAcrossArms pins that the column
+// half honours merge()'s UNION semantics: a column carried by one arm and
+// not the other is satisfied, because that is how production's metric
+// tables genuinely differ (only the histogram tables carry Count / Sum).
+func TestCheckSeedCoversFanOut_ColumnUnionAcrossArms(t *testing.T) {
+	seed := strings.Replace(bothArmsSeed, "`ServiceName` LowCardinality(String) DEFAULT '',", "", 1)
+	if err := CheckSeedCoversFanOut(seed, fanOutSQL); err != nil {
+		t.Fatalf("ServiceName on the sum arm alone must satisfy a merge() fan-out: %v", err)
+	}
+}
+
+// TestCheckSeedCoversFanOut_NoFanOut keeps a single-table scan out of
+// scope: an unseeded plain table fails with UNKNOWN_TABLE, which is not
+// the confusable failure this check exists for.
+func TestCheckSeedCoversFanOut_NoFanOut(t *testing.T) {
+	sqlText := "SELECT `Value` FROM `otel_metrics_gauge` WHERE (`ServiceName` = ?)"
+	if err := CheckSeedCoversFanOut("", sqlText); err != nil {
+		t.Fatalf("a statement with no merge() fan-out must pass: %v", err)
+	}
+}
+
+// TestCheckSeedCoversFanOut_UndecodablePattern pins that an unfamiliar
+// fan-out regex errors rather than silently passing — a check that skips
+// what it cannot parse is a gap wearing a green tick.
+func TestCheckSeedCoversFanOut_UndecodablePattern(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		sql  string
+	}{
+		{"unanchored", "SELECT * FROM merge(currentDatabase(), 'otel_metrics_.*')"},
+		{"wildcard_arm", "SELECT * FROM merge(currentDatabase(), '^(otel_metrics_.*)$')"},
+		{"one_argument", "SELECT * FROM merge('^(otel_metrics_gauge)$')"},
+		{"unquoted_pattern", "SELECT * FROM merge(currentDatabase(), pattern)"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := CheckSeedCoversFanOut(bothArmsSeed, tc.sql); err == nil {
+				t.Fatalf("pattern this check cannot decompose must error, not pass: %s", tc.sql)
+			}
+		})
+	}
+}
+
+// TestCheckSeedCoversFanOut_SingleArmAndQuotedDB covers the two shapes
+// chsql's mergeTableFrag emits besides the common one: a one-member
+// fan-out (still parenthesised) and an explicitly named database.
+func TestCheckSeedCoversFanOut_SingleArmAndQuotedDB(t *testing.T) {
+	sqlText := "SELECT `ServiceName` AS `s` FROM merge('otel', '^(otel_metrics_sum)$')"
+	if err := CheckSeedCoversFanOut(bothArmsSeed, sqlText); err != nil {
+		t.Fatalf("single-arm fan-out against a named database must pass: %v", err)
+	}
+}
+
+// TestCheckSeedCoversFanOut_IgnoresNonColumnIdentifiers pins the
+// identifier classifier: CTE heads, relation operands and AS targets are
+// names, not base columns, and must not be demanded of the arms.
+func TestCheckSeedCoversFanOut_IgnoresNonColumnIdentifiers(t *testing.T) {
+	sqlText := "WITH `roots` AS (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$')) " +
+		"SELECT `Value` AS `depth` FROM `roots` JOIN `otel_metrics_sum` ON ?"
+	if err := CheckSeedCoversFanOut(bothArmsSeed, sqlText); err != nil {
+		t.Fatalf("CTE / relation / alias names must not be treated as base columns: %v", err)
+	}
+}
+
+// TestCheckSeedCoversFanOut_IgnoresStringLiterals pins that a `merge(`
+// or a backtick inside a SQL string literal is inert.
+func TestCheckSeedCoversFanOut_IgnoresStringLiterals(t *testing.T) {
+	sqlText := "SELECT `Value` AS `Value`, 'merge(currentDatabase(), ''^(nope)$'')' AS `lit` " +
+		"FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$')"
+	if err := CheckSeedCoversFanOut(bothArmsSeed, sqlText); err != nil {
+		t.Fatalf("string-literal content must not be parsed as SQL: %v", err)
+	}
+}
+
+// TestCheckSeedCoversFanOut_MergeSuffixIsNotACall pins that an identifier
+// merely ending in `merge` — CH has plenty — is not read as the merge()
+// table function.
+func TestCheckSeedCoversFanOut_MergeSuffixIsNotACall(t *testing.T) {
+	sqlText := "SELECT arrayMerge(`Value`) FROM `otel_metrics_gauge`"
+	if err := CheckSeedCoversFanOut("", sqlText); err != nil {
+		t.Fatalf("arrayMerge() must not be read as merge(): %v", err)
+	}
+}


### PR DESCRIPTION
Closes #1910

## The coupling

Every `sql.Open("chdb", "")` in a process resolves to one in-process ClickHouse session, so the
whole of `internal/promql`'s chdb-tagged lane shares a single catalog.

`sort_by_label_chdb_test.go` seeded only `otel_metrics_gauge`, but its emitted SQL scans the
metrics fan-out `merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$')` and projects
`toString(ServiceName)` off it. `merge()` takes its column set from the UNION of the tables that
match, so `ServiceName` resolved only because `limit_ratio_chdb_test.go` had already materialised
an `otel_metrics_sum` carrying that column.

The whole-package run passed. The narrowed run — the invocation CLAUDE.md invariant 5 mandates for
reproducing a red check — did not:

```
go test -tags chdb -run '^TestSortByLabel_OrderParityVsPrometheus$' ./internal/promql/
--- FAIL: TestSortByLabel_OrderParityVsPrometheus
    Code: 47. DB::Exception: Unknown expression identifier 'ServiceName' ... Maybe meant: ['MetricName']
```

A fabricated SQL-lowering bug, indistinguishable from a real one, for anyone following the
documented workflow.

## The fixture fix

`sortByLabelSeed` now declares both arms of the fan-out with the full read-path column set
(`ResourceAttributes` for the resource merge, `ServiceName` for the dedicated-column overlay), so
it stands alone in a cold session. The file's doc comment recorded half of this insight already —
it named the sibling as the materialiser of `otel_metrics_gauge` without following through to the
`otel_metrics_sum` arm — and now matches reality.

## The class fix

`testsql.CheckSeedCoversFanOut(seed, emittedSQL)` makes the property structural instead of a
convention someone has to remember. Given a fixture's own seed text and one emitted statement it:

1. decomposes every `merge(<db>, '^(a|b)$')` regex back into its arm table names;
2. fails unless the seed itself CREATEs every arm;
3. fails unless some arm the seed creates declares every base-relation column the statement
   references — "some" rather than "every", because `merge()` unions columns and production's
   metric tables legitimately differ (only the histogram tables carry `Count` / `Sum`, and
   inventing those on the gauge table would mask a real bug);
4. errors on a fan-out pattern it cannot decompose, so an emitter change breaks it loudly rather
   than silently disarming it.

A single-table `FROM <table>` scan is deliberately out of scope: an unseeded plain table fails with
UNKNOWN_TABLE, which nobody mistakes for a lowering bug. `merge()` is the shape that fails
confusingly, so it is the shape checked.

`chdbFixture` (`internal/promql/fixture_chdb_test.go`) binds the session to the seed that populated
it and runs the check before executing anything, so the guarantee holds by construction for any
fixture added later. It also folds away three copies of the open / ping / seed / wrap boilerplate.
`limit_ratio_chdb_test.go`'s seed becomes a script constant so the same check applies to it. Those
two files are the package's only chdb-tagged fixtures; both are now covered.

## Evidence the gate can fail

`internal/testsql/fanout_test.go` runs in the untagged lane and pins both directions, including the
exact pre-fix seed shape. Deleting the `otel_metrics_sum` arm from `sortByLabelSeed` and running
both fixtures in ONE process — the ordering that used to hide the bug, with `limit_ratio` seeding
`otel_metrics_sum` first — now fails:

```
--- FAIL: TestSortByLabel_OrderParityVsPrometheus/asc_single_label
    this fixture's seed does not stand on its own — it would pass only while a sibling fixture's
    tables happen to be present in the shared chDB session: seed is not self-sufficient for the
    emitted merge() fan-out:
      column "ServiceName" is referenced by the emitted SQL but declared by none of the fan-out
        arms this seed creates (otel_metrics_gauge, otel_metrics_sum)
      fan-out arm "otel_metrics_sum" is scanned but never created by this seed — it resolves only
        because a sibling fixture created it in the shared session
```

## Verified both directions

- `go test -tags chdb -run '^TestSortByLabel_OrderParityVsPrometheus$' ./internal/promql/` — ok
- `go test -tags chdb -run '^TestLimitRatio_ChDBParity$' ./internal/promql/` — ok
- `go test -tags chdb -run '^TestLimitRatio_ChDBParity_ComputedRatio$' ./internal/promql/` — ok
- `go test -tags chdb ./internal/promql/` — ok, 129s
- `go test ./internal/testsql/` — ok
