### PR TITLE
test(promql): make the spec lane's native-strategy wiring a reflected ratchet

### DIFF
--- a/internal/promql/lower_test.go
+++ b/internal/promql/lower_test.go
@@ -126,50 +126,14 @@ func TestLower(t *testing.T) {
 				if perr != nil {
 					t.Fatalf("fixture %s: parse range_step %q: %v", c.Name, rs, perr)
 				}
-				// An `experimental_ts_grid_range:` section (any non-empty
-				// body) wires the boot-decided native-rate strategy into the
-				// fixture's lowering — the always-on SQL-shape coverage floor
-				// for the native timeSeriesRateToGrid path. An
-				// `experimental_ts_grid_resample:` section wires the
-				// native-staleness strategy (timeSeriesResampleToGridWithStaleness);
-				// `experimental_ts_grid_changes:` wires NativeChangesLowerer
-				// (timeSeriesChangesToGrid); `experimental_ts_grid_resets:` wires
-				// NativeResetsLowerer (timeSeriesResetsToGrid);
-				// `experimental_ts_grid_deriv:` wires NativeDerivLowerer
-				// (timeSeriesDerivToGrid); `experimental_ts_grid_predict_linear:`
-				// wires NativePredictLinearLowerer (timeSeriesPredictLinearToGrid).
-				// An `experimental_ts_grid_recollapse:` section additionally turns on
-				// the deferred label-shaping (-State/-Merge) shape, and is only read
-				// alongside `experimental_ts_grid_range:`.
-				// Without any of these sections the default all-fan-out table is
-				// used, so every existing fixture stays byte-identical.
-				var lowerers promql.RangeLowerers
-				if _, native := c.Section("experimental_ts_grid_range"); native {
-					// `experimental_ts_grid_recollapse:` nests INSIDE this section
-					// (mirroring the boot wiring in cmd/cerberus): the deferred
-					// label-shaping shape only exists on top of a native rate grid,
-					// so it is read only where one is being built.
-					_, recollapse := c.Section("experimental_ts_grid_recollapse")
-					lowerers.Rate = promql.NativeRateLowerer{
-						Fallback:   promql.FanoutRateLowerer{},
-						Recollapse: recollapse,
-					}
-				}
-				if _, resample := c.Section("experimental_ts_grid_resample"); resample {
-					lowerers.Staleness = promql.NativeStalenessLowerer{Fallback: promql.FanoutStalenessLowerer{}}
-				}
-				if _, changes := c.Section("experimental_ts_grid_changes"); changes {
-					lowerers.Changes = promql.NativeChangesLowerer{Fallback: promql.FanoutChangesLowerer{}}
-				}
-				if _, resets := c.Section("experimental_ts_grid_resets"); resets {
-					lowerers.Resets = promql.NativeResetsLowerer{Fallback: promql.FanoutResetsLowerer{}}
-				}
-				if _, deriv := c.Section("experimental_ts_grid_deriv"); deriv {
-					lowerers.Deriv = promql.NativeDerivLowerer{Fallback: promql.FanoutDerivLowerer{}}
-				}
-				if _, predict := c.Section("experimental_ts_grid_predict_linear"); predict {
-					lowerers.PredictLinear = promql.NativePredictLinearLowerer{Fallback: promql.FanoutPredictLinearLowerer{}}
-				}
+				// Each row of [nativeStrategies] binds one RangeLowerers
+				// field to the marker section that opts a fixture into
+				// that field's ClickHouse-native strategy; carrying no
+				// marker section leaves the all-fan-out default, so every
+				// fixture without one stays byte-identical.
+				lowerers := wireNativeStrategies(func(name string) bool {
+					return hasSection(c, name)
+				})
 				plan, err = promql.LowerAtRangeOpts(context.Background(), expr, fixtureSchema, rangeStart, rangeEnd, stepDur,
 					promql.LowerOpts{Lowerers: lowerers})
 			} else {

--- a/internal/promql/native_strategy_coverage_test.go
+++ b/internal/promql/native_strategy_coverage_test.go
@@ -57,9 +57,9 @@ var nativeStrategies = []nativeStrategy{
 		wire: func(l *promql.RangeLowerers, has func(string) bool) {
 			// `experimental_ts_grid_recollapse:` nests INSIDE this
 			// section (mirroring the boot wiring in cmd/cerberus): the
-			// deferred label-shaping (-State/-Merge) shape only exists on
-			// top of a native rate grid, so it is read only where one is
-			// being built.
+			// two-stage label-shaping (-State/-Merge) shape only exists
+			// on top of a native rate grid, so it is read only where one
+			// is being built.
 			l.Rate = promql.NativeRateLowerer{
 				Fallback:   promql.FanoutRateLowerer{},
 				Recollapse: has("experimental_ts_grid_recollapse"),

--- a/internal/promql/native_strategy_coverage_test.go
+++ b/internal/promql/native_strategy_coverage_test.go
@@ -1,0 +1,229 @@
+package promql_test
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/test/spec"
+)
+
+// nativeStrategy binds ONE field of [promql.RangeLowerers] to the TXTAR
+// marker section a fixture carries to opt into that field's
+// ClickHouse-native strategy.
+//
+// The table this type builds is the spec lane's whole answer to a
+// structural problem: `RangeLowerers` is a boot-wired dispatch table, and
+// the TXTAR harness reaches only the strategy set some caller wired for
+// it. A field with no row here is a strategy the golden corpus can never
+// emit SQL for — its production shape is untested no matter how many
+// fixtures exist, because every one of them lowers through the fan-out
+// impl. That is the hollow-green shape where a feature turned OFF in the
+// test lane lets the lane pass while proving nothing about the feature.
+//
+// So the table is not a convenience: it is the thing
+// [TestNativeStrategies_CoverEveryRangeLowerersField] can reflect over.
+// A hand-written `if` ladder cannot be enumerated, so a new field added
+// without a matching arm would silently widen the hole. This can.
+type nativeStrategy struct {
+	// field is the RangeLowerers field this row wires, by name. The
+	// completeness ratchet resolves it by reflection, so a typo or a
+	// renamed field fails loudly rather than covering nothing.
+	field string
+
+	// section is the TXTAR marker section (any body, including empty) a
+	// fixture carries to opt in.
+	section string
+
+	// wire sets this row's field on l to its native impl. It reads
+	// `has` rather than the fixture itself so a strategy that composes
+	// with a NESTED marker section can consult it — mirroring the boot
+	// wiring in cmd/cerberus, where the same nesting decides the shape.
+	wire func(l *promql.RangeLowerers, has func(section string) bool)
+}
+
+// nativeStrategies is the one place the spec lane's native-strategy
+// wiring lives. Adding a field to [promql.RangeLowerers] without adding
+// its row here fails [TestNativeStrategies_CoverEveryRangeLowerersField];
+// adding a row whose section no fixture carries fails
+// [TestNativeStrategies_HaveNativeSideFixtures].
+var nativeStrategies = []nativeStrategy{
+	{
+		field:   "Rate",
+		section: "experimental_ts_grid_range",
+		wire: func(l *promql.RangeLowerers, has func(string) bool) {
+			// `experimental_ts_grid_recollapse:` nests INSIDE this
+			// section (mirroring the boot wiring in cmd/cerberus): the
+			// deferred label-shaping (-State/-Merge) shape only exists on
+			// top of a native rate grid, so it is read only where one is
+			// being built.
+			l.Rate = promql.NativeRateLowerer{
+				Fallback:   promql.FanoutRateLowerer{},
+				Recollapse: has("experimental_ts_grid_recollapse"),
+			}
+		},
+	},
+	{
+		field:   "Staleness",
+		section: "experimental_ts_grid_resample",
+		wire: func(l *promql.RangeLowerers, _ func(string) bool) {
+			l.Staleness = promql.NativeStalenessLowerer{Fallback: promql.FanoutStalenessLowerer{}}
+		},
+	},
+	{
+		field:   "Changes",
+		section: "experimental_ts_grid_changes",
+		wire: func(l *promql.RangeLowerers, _ func(string) bool) {
+			l.Changes = promql.NativeChangesLowerer{Fallback: promql.FanoutChangesLowerer{}}
+		},
+	},
+	{
+		field:   "Resets",
+		section: "experimental_ts_grid_resets",
+		wire: func(l *promql.RangeLowerers, _ func(string) bool) {
+			l.Resets = promql.NativeResetsLowerer{Fallback: promql.FanoutResetsLowerer{}}
+		},
+	},
+	{
+		field:   "Deriv",
+		section: "experimental_ts_grid_deriv",
+		wire: func(l *promql.RangeLowerers, _ func(string) bool) {
+			l.Deriv = promql.NativeDerivLowerer{Fallback: promql.FanoutDerivLowerer{}}
+		},
+	},
+	{
+		field:   "PredictLinear",
+		section: "experimental_ts_grid_predict_linear",
+		wire: func(l *promql.RangeLowerers, _ func(string) bool) {
+			l.PredictLinear = promql.NativePredictLinearLowerer{Fallback: promql.FanoutPredictLinearLowerer{}}
+		},
+	},
+}
+
+// wireNativeStrategies builds the dispatch table for a fixture from the
+// marker sections it carries. Any field left nil is resolved to its
+// concrete fan-out impl at the lowering entry, so a fixture with no
+// marker section lowers exactly as it did before the table existed.
+func wireNativeStrategies(has func(section string) bool) promql.RangeLowerers {
+	var l promql.RangeLowerers
+	for _, ns := range nativeStrategies {
+		if has(ns.section) {
+			ns.wire(&l, has)
+		}
+	}
+	return l
+}
+
+// TestNativeStrategies_CoverEveryRangeLowerersField is the ratchet: it
+// fails when [promql.RangeLowerers] gains a strategy field the spec lane
+// has no way to select.
+//
+// It checks the binding in BOTH directions, and by BEHAVIOUR rather than
+// by name list. Each row is applied to a zero table and the result read
+// back by reflection: the row's named field must have become non-nil and
+// every other field must have stayed nil. So a row that names a field it
+// does not actually set — the copy-paste failure this table's shape
+// invites — fails here rather than silently wiring the wrong strategy
+// into every fixture that carries its section.
+func TestNativeStrategies_CoverEveryRangeLowerersField(t *testing.T) {
+	t.Parallel()
+
+	tableType := reflect.TypeOf(promql.RangeLowerers{})
+
+	fields := make(map[string]bool, tableType.NumField())
+	for i := range tableType.NumField() {
+		fields[tableType.Field(i).Name] = false
+	}
+
+	for _, ns := range nativeStrategies {
+		covered, known := fields[ns.field]
+		if !known {
+			t.Errorf("nativeStrategies row %q names no field of promql.RangeLowerers", ns.field)
+			continue
+		}
+		if covered {
+			t.Errorf("field %s is claimed by more than one nativeStrategies row", ns.field)
+			continue
+		}
+		fields[ns.field] = true
+
+		// Apply this row alone, with no nested section present, and read
+		// the result back: exactly its own field must be set.
+		var got promql.RangeLowerers
+		ns.wire(&got, func(string) bool { return false })
+		v := reflect.ValueOf(got)
+		for i := range tableType.NumField() {
+			name := tableType.Field(i).Name
+			set := !v.Field(i).IsNil()
+			switch {
+			case name == ns.field && !set:
+				t.Errorf("nativeStrategies row %q (section %q) left field %s nil",
+					ns.field, ns.section, name)
+			case name != ns.field && set:
+				t.Errorf("nativeStrategies row %q (section %q) also set unrelated field %s",
+					ns.field, ns.section, name)
+			}
+		}
+	}
+
+	for name, covered := range fields {
+		if !covered {
+			t.Errorf("promql.RangeLowerers.%s has no nativeStrategies row, so no TXTAR fixture "+
+				"can lower through it — every spec fixture would exercise the fan-out impl "+
+				"instead, and the SQL this strategy emits in production would go unpinned. "+
+				"Add a row naming the marker section, and a fixture under %s carrying it.",
+				name, fixtureDir)
+		}
+	}
+}
+
+// TestNativeStrategies_HaveNativeSideFixtures is the other half of the
+// ratchet. A wired strategy nothing opts into is still unpinned SQL, so
+// having a row is not enough — some fixture must actually carry its
+// marker section.
+//
+// This is what makes `RangeLowerers` gaining a field a build failure
+// rather than a silent widening: the field needs a row (test above) AND
+// the row needs a fixture (here), which together mean the new strategy's
+// emitted SQL lands in the golden corpus.
+func TestNativeStrategies_HaveNativeSideFixtures(t *testing.T) {
+	t.Parallel()
+
+	carried := sectionsCarriedByFixtures(t, fixtureDir)
+
+	for _, ns := range nativeStrategies {
+		if n := carried[ns.section]; n == 0 {
+			t.Errorf("no fixture under %s carries the %q section, so promql.RangeLowerers.%s "+
+				"is wired but never selected and the SQL it emits is unpinned",
+				fixtureDir, ns.section, ns.field)
+		}
+	}
+}
+
+// sectionsCarriedByFixtures returns, per section name, how many fixtures
+// under dir carry it.
+func sectionsCarriedByFixtures(t *testing.T, dir string) map[string]int {
+	t.Helper()
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read fixture dir %s: %v", dir, err)
+	}
+	out := map[string]int{}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".txtar") {
+			continue
+		}
+		c, err := spec.Load(filepath.Join(dir, e.Name()))
+		if err != nil {
+			t.Fatalf("load fixture %s: %v", e.Name(), err)
+		}
+		for name := range c.Sections() {
+			out[name]++
+		}
+	}
+	return out
+}

--- a/test/perf/cardinality-baseline/promql/label_replace_over_native_rate_range_step.json
+++ b/test/perf/cardinality-baseline/promql/label_replace_over_native_rate_range_step.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/label_replace_over_native_rate_range_step",
+  "fan_factor": 1.5,
+  "scan_rows": 12,
+  "peak_intermediate": 18,
+  "has_cross_join": false,
+  "has_array_join": true,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/cardinality-baseline/promql/label_replace_over_rate_range_step.json
+++ b/test/perf/cardinality-baseline/promql/label_replace_over_rate_range_step.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/label_replace_over_rate_range_step",
+  "fan_factor": 5.833333333333333,
+  "scan_rows": 12,
+  "peak_intermediate": 70,
+  "has_cross_join": false,
+  "has_array_join": true,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/solver-decision-baseline/label_replace_over_native_rate_range_step.json
+++ b/test/perf/solver-decision-baseline/label_replace_over_native_rate_range_step.json
@@ -1,0 +1,10 @@
+{
+  "query": "label_replace_over_native_rate_range_step",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "5m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/label_replace_over_rate_range_step.json
+++ b/test/perf/solver-decision-baseline/label_replace_over_rate_range_step.json
@@ -1,0 +1,10 @@
+{
+  "query": "label_replace_over_rate_range_step",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "5m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/spec/promql/label_replace_over_native_rate_range_step.txtar
+++ b/test/spec/promql/label_replace_over_native_rate_range_step.txtar
@@ -43,6 +43,26 @@ INSERT INTO otel_metrics_sum VALUES
     ('cerberus_queries_total', map('cerberus_ql', 'logql'), toDateTime64('2026-01-01 00:04:00', 9), 24.0),
     ('cerberus_queries_total', map('cerberus_ql', 'logql'), toDateTime64('2026-01-01 00:05:00', 9), 30.0);
 -- expected_rows --
+[
+  [{"cerberus_ql": "logql", "engine": "engine-logql"}, "2026-01-01T00:01:00Z", "2026-01-01T00:01:00Z", 0.02],
+  [{"cerberus_ql": "logql", "engine": "engine-logql"}, "2026-01-01T00:01:30Z", "2026-01-01T00:01:30Z", 0.03],
+  [{"cerberus_ql": "logql", "engine": "engine-logql"}, "2026-01-01T00:02:00Z", "2026-01-01T00:02:00Z", 0.04],
+  [{"cerberus_ql": "logql", "engine": "engine-logql"}, "2026-01-01T00:02:30Z", "2026-01-01T00:02:30Z", 0.05],
+  [{"cerberus_ql": "logql", "engine": "engine-logql"}, "2026-01-01T00:03:00Z", "2026-01-01T00:03:00Z", 0.060000000000000005],
+  [{"cerberus_ql": "logql", "engine": "engine-logql"}, "2026-01-01T00:03:30Z", "2026-01-01T00:03:30Z", 0.07],
+  [{"cerberus_ql": "logql", "engine": "engine-logql"}, "2026-01-01T00:04:00Z", "2026-01-01T00:04:00Z", 0.08],
+  [{"cerberus_ql": "logql", "engine": "engine-logql"}, "2026-01-01T00:04:30Z", "2026-01-01T00:04:30Z", 0.09],
+  [{"cerberus_ql": "logql", "engine": "engine-logql"}, "2026-01-01T00:05:00Z", "2026-01-01T00:05:00Z", 0.1],
+  [{"cerberus_ql": "promql", "engine": "engine-promql"}, "2026-01-01T00:01:00Z", "2026-01-01T00:01:00Z", 0.04],
+  [{"cerberus_ql": "promql", "engine": "engine-promql"}, "2026-01-01T00:01:30Z", "2026-01-01T00:01:30Z", 0.06],
+  [{"cerberus_ql": "promql", "engine": "engine-promql"}, "2026-01-01T00:02:00Z", "2026-01-01T00:02:00Z", 0.08],
+  [{"cerberus_ql": "promql", "engine": "engine-promql"}, "2026-01-01T00:02:30Z", "2026-01-01T00:02:30Z", 0.1],
+  [{"cerberus_ql": "promql", "engine": "engine-promql"}, "2026-01-01T00:03:00Z", "2026-01-01T00:03:00Z", 0.12000000000000001],
+  [{"cerberus_ql": "promql", "engine": "engine-promql"}, "2026-01-01T00:03:30Z", "2026-01-01T00:03:30Z", 0.14],
+  [{"cerberus_ql": "promql", "engine": "engine-promql"}, "2026-01-01T00:04:00Z", "2026-01-01T00:04:00Z", 0.16],
+  [{"cerberus_ql": "promql", "engine": "engine-promql"}, "2026-01-01T00:04:30Z", "2026-01-01T00:04:30Z", 0.18],
+  [{"cerberus_ql": "promql", "engine": "engine-promql"}, "2026-01-01T00:05:00Z", "2026-01-01T00:05:00Z", 0.2]
+]
 -- args --
 [0] string = "cerberus_ql"
 [1] string = "^(.*)$"

--- a/test/spec/promql/label_replace_over_native_rate_range_step.txtar
+++ b/test/spec/promql/label_replace_over_native_rate_range_step.txtar
@@ -1,0 +1,78 @@
+# `label_replace` wrapped around a range-mode `rate(...)`, lowered through
+# the ClickHouse-NATIVE timeSeriesRateToGrid table: the
+# `experimental_ts_grid_range` section wires NativeRateLowerer, so the
+# inner windowed node is a chplan.RangeWindowNative rather than the
+# fan-out chplan.RangeWindow.
+#
+# This is the half that pins the shape of the live 502. The two node
+# kinds carry the SAME row shape (one row per (series, anchor), the
+# anchor published as `anchor_ts AS TimeUnix`, MetricName already grouped
+# away), so the label rewrite must forward the anchor and must NOT list
+# MetricName — a decision that has to be read off the derived row shape,
+# because the kind differs between the two arms while the correct answer
+# does not.
+#
+# The query, seed and grid are IDENTICAL to
+# label_replace_over_rate_range_step.txtar, so `expected_rows` matching
+# between the two files is the assertion: whichever table a deployment
+# wires, `label_replace(rate(...), …)` answers the same.
+
+-- query.promql --
+label_replace(rate(cerberus_queries_total[5m]), "engine", "engine-$1", "cerberus_ql", "(.*)")
+-- range_step --
+30s
+-- experimental_ts_grid_range --
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_sum VALUES
+    ('cerberus_queries_total', map('cerberus_ql', 'promql'), toDateTime64('2026-01-01 00:00:00', 9), 0.0),
+    ('cerberus_queries_total', map('cerberus_ql', 'promql'), toDateTime64('2026-01-01 00:01:00', 9), 12.0),
+    ('cerberus_queries_total', map('cerberus_ql', 'promql'), toDateTime64('2026-01-01 00:02:00', 9), 24.0),
+    ('cerberus_queries_total', map('cerberus_ql', 'promql'), toDateTime64('2026-01-01 00:03:00', 9), 36.0),
+    ('cerberus_queries_total', map('cerberus_ql', 'promql'), toDateTime64('2026-01-01 00:04:00', 9), 48.0),
+    ('cerberus_queries_total', map('cerberus_ql', 'promql'), toDateTime64('2026-01-01 00:05:00', 9), 60.0),
+    ('cerberus_queries_total', map('cerberus_ql', 'logql'), toDateTime64('2026-01-01 00:00:00', 9), 0.0),
+    ('cerberus_queries_total', map('cerberus_ql', 'logql'), toDateTime64('2026-01-01 00:01:00', 9), 6.0),
+    ('cerberus_queries_total', map('cerberus_ql', 'logql'), toDateTime64('2026-01-01 00:02:00', 9), 12.0),
+    ('cerberus_queries_total', map('cerberus_ql', 'logql'), toDateTime64('2026-01-01 00:03:00', 9), 18.0),
+    ('cerberus_queries_total', map('cerberus_ql', 'logql'), toDateTime64('2026-01-01 00:04:00', 9), 24.0),
+    ('cerberus_queries_total', map('cerberus_ql', 'logql'), toDateTime64('2026-01-01 00:05:00', 9), 30.0);
+-- expected_rows --
+-- args --
+[0] string = "cerberus_ql"
+[1] string = "^(.*)$"
+[2] string = "engine"
+[3] string = "cerberus_ql"
+[4] string = "engine-"
+[5] string = "cerberus_ql"
+[6] string = "^(.*)$"
+[7] string = "engine-\\1"
+[8] string = "service.name"
+[9] string = "service_name"
+[10] string = "service.name"
+[11] string = "service_name"
+[12] string = ""
+[13] string = "service_name"
+[14] string = "cerberus_queries_total"
+[15] string = "cerberus.queries.total"
+[16] string = "cerberus.queries/total"
+[17] string = "cerberus.queries_total"
+[18] string = "cerberus/queries/total"
+[19] string = "cerberus/queries_total"
+[20] string = "cerberus_queries.total"
+[21] int64 = 1
+[22] int64 = 0
+-- chplan --
+Aggregate groupBy=[Attributes AS Attributes, anchor_ts AS anchor_ts, TimeUnix AS TimeUnix] funcs=[any(Value) AS Value] having=(throwIf((count() > 1), "vector cannot contain metrics with the same labelset") = 0)
+  Project [labelReplace(Attributes, dst="engine", replacement="engine-\\1", src="cerberus_ql", regex="(.*)", emptyReplacement="engine-") AS Attributes, anchor_ts, TimeUnix AS TimeUnix, Value]
+    RangeWindowNative func=rate range=5m0s step=30s ts=TimeUnix value=Value groupBy=[Attributes] start=2026-01-01T00:00:00Z end=2026-01-01T00:05:00Z
+      Project [MetricName AS MetricName, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, Value AS Value]
+        Filter predicate=(MetricName IN ("cerberus_queries_total", "cerberus.queries.total", "cerberus.queries/total", "cerberus.queries_total", "cerberus/queries/total", "cerberus/queries_total", "cerberus_queries.total"))
+          Scan(otel_metrics_sum)
+-- sql --
+SELECT `Attributes` AS `Attributes`, `anchor_ts` AS `anchor_ts`, `TimeUnix` AS `TimeUnix`, any(`Value`) AS `Value` FROM (SELECT mapFilter((k, v) -> v != '', if(match(`Attributes`[?], ?), mapUpdate(`Attributes`, map(?, if(empty(`Attributes`[?]), ?, replaceRegexpOne(`Attributes`[?], ?, ?)))), `Attributes`)) AS `Attributes`, `anchor_ts`, `TimeUnix` AS `TimeUnix`, `Value` FROM (SELECT `Attributes`, toDateTime64(`anchor_ts`, 9) AS `anchor_ts`, toDateTime64(`anchor_ts`, 9) AS `TimeUnix`, toFloat64(assumeNotNull(`grid_val`)) AS `Value` FROM (SELECT `Attributes`, timeSeriesRateToGrid(toDateTime(1767225600, 'UTC'), toDateTime(1767225900, 'UTC'), 30, 300)(`TimeUnix`, `Value`) AS `grid`, timeSeriesRange(toDateTime(1767225600, 'UTC'), toDateTime(1767225900, 'UTC'), 30) AS `grid_ts` FROM (SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?)))) WHERE `TimeUnix` > toDateTime64('2026-01-01 00:00:00.000000000', 9) - toIntervalNanosecond(300000000000) AND `TimeUnix` <= toDateTime64('2026-01-01 00:05:00.000000000', 9) GROUP BY `Attributes`) ARRAY JOIN `grid` AS `grid_val`, `grid_ts` AS `anchor_ts` WHERE `grid_val` IS NOT NULL)) GROUP BY `Attributes`, `anchor_ts`, `TimeUnix` HAVING (throwIf((count() > ?), 'vector cannot contain metrics with the same labelset') = ?)

--- a/test/spec/promql/label_replace_over_rate_range_step.txtar
+++ b/test/spec/promql/label_replace_over_rate_range_step.txtar
@@ -1,0 +1,76 @@
+# `label_replace` wrapped around a range-mode `rate(...)`, lowered through
+# the DEFAULT all-fan-out table. This is the fan-out half of a pair; the
+# native half is label_replace_over_native_rate_range_step.txtar, which
+# carries the identical query, seed and grid so the two `expected_rows`
+# blocks can be compared by eye.
+#
+# The pair exists because an instant label-rewrite over a windowed inner
+# node has to decide what columns its input exposes, and the fan-out and
+# native lowerings build DIFFERENT node kinds for the same row shape
+# (chplan.RangeWindow vs chplan.RangeWindowNative). A classifier that
+# answers that question from the node KIND rather than from the derived
+# row shape sends the native arm down the full-Sample-row branch and
+# emits `SELECT MetricName, … FROM (<grid subquery>)`, which ClickHouse
+# rejects with `code: 47, Unknown expression identifier MetricName`. That
+# was a live 502 on /api/v1/query_range with the ts_grid_range lowering
+# on, invisible to every fixture here, because every fixture here lowered
+# through the fan-out table.
+
+-- query.promql --
+label_replace(rate(cerberus_queries_total[5m]), "engine", "engine-$1", "cerberus_ql", "(.*)")
+-- range_step --
+30s
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_sum VALUES
+    ('cerberus_queries_total', map('cerberus_ql', 'promql'), toDateTime64('2026-01-01 00:00:00', 9), 0.0),
+    ('cerberus_queries_total', map('cerberus_ql', 'promql'), toDateTime64('2026-01-01 00:01:00', 9), 12.0),
+    ('cerberus_queries_total', map('cerberus_ql', 'promql'), toDateTime64('2026-01-01 00:02:00', 9), 24.0),
+    ('cerberus_queries_total', map('cerberus_ql', 'promql'), toDateTime64('2026-01-01 00:03:00', 9), 36.0),
+    ('cerberus_queries_total', map('cerberus_ql', 'promql'), toDateTime64('2026-01-01 00:04:00', 9), 48.0),
+    ('cerberus_queries_total', map('cerberus_ql', 'promql'), toDateTime64('2026-01-01 00:05:00', 9), 60.0),
+    ('cerberus_queries_total', map('cerberus_ql', 'logql'), toDateTime64('2026-01-01 00:00:00', 9), 0.0),
+    ('cerberus_queries_total', map('cerberus_ql', 'logql'), toDateTime64('2026-01-01 00:01:00', 9), 6.0),
+    ('cerberus_queries_total', map('cerberus_ql', 'logql'), toDateTime64('2026-01-01 00:02:00', 9), 12.0),
+    ('cerberus_queries_total', map('cerberus_ql', 'logql'), toDateTime64('2026-01-01 00:03:00', 9), 18.0),
+    ('cerberus_queries_total', map('cerberus_ql', 'logql'), toDateTime64('2026-01-01 00:04:00', 9), 24.0),
+    ('cerberus_queries_total', map('cerberus_ql', 'logql'), toDateTime64('2026-01-01 00:05:00', 9), 30.0);
+-- expected_rows --
+-- args --
+[0] string = "cerberus_ql"
+[1] string = "^(.*)$"
+[2] string = "engine"
+[3] string = "cerberus_ql"
+[4] string = "engine-"
+[5] string = "cerberus_ql"
+[6] string = "^(.*)$"
+[7] string = "engine-\\1"
+[8] string = "service.name"
+[9] string = "service_name"
+[10] string = "service.name"
+[11] string = "service_name"
+[12] string = ""
+[13] string = "service_name"
+[14] string = "cerberus_queries_total"
+[15] string = "cerberus.queries.total"
+[16] string = "cerberus.queries/total"
+[17] string = "cerberus.queries_total"
+[18] string = "cerberus/queries/total"
+[19] string = "cerberus/queries_total"
+[20] string = "cerberus_queries.total"
+[21] int64 = 1
+[22] int64 = 0
+-- chplan --
+Aggregate groupBy=[Attributes AS Attributes, anchor_ts AS anchor_ts, TimeUnix AS TimeUnix] funcs=[any(Value) AS Value] having=(throwIf((count() > 1), "vector cannot contain metrics with the same labelset") = 0)
+  Project [labelReplace(Attributes, dst="engine", replacement="engine-\\1", src="cerberus_ql", regex="(.*)", emptyReplacement="engine-") AS Attributes, anchor_ts, TimeUnix AS TimeUnix, Value]
+    RangeWindow func=rate range=5m0s step=30s outerRange=5m0s ts=TimeUnix value=Value groupBy=[Attributes] start=2026-01-01T00:00:00Z end=2026-01-01T00:05:00Z
+      Project [MetricName AS MetricName, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, Value AS Value]
+        Filter predicate=(MetricName IN ("cerberus_queries_total", "cerberus.queries.total", "cerberus.queries/total", "cerberus.queries_total", "cerberus/queries/total", "cerberus/queries_total", "cerberus_queries.total"))
+          Scan(otel_metrics_sum)
+-- sql --
+SELECT `Attributes` AS `Attributes`, `anchor_ts` AS `anchor_ts`, `TimeUnix` AS `TimeUnix`, any(`Value`) AS `Value` FROM (SELECT mapFilter((k, v) -> v != '', if(match(`Attributes`[?], ?), mapUpdate(`Attributes`, map(?, if(empty(`Attributes`[?]), ?, replaceRegexpOne(`Attributes`[?], ?, ?)))), `Attributes`)) AS `Attributes`, `anchor_ts`, `TimeUnix` AS `TimeUnix`, `Value` FROM (SELECT `Attributes`, `anchor_ts`, anchor_ts AS `TimeUnix`, if(sampled_interval > 0, counter_delta * (sampled_interval + if(counter_delta > 0 AND first_val >= 0, least(duration_to_start, sampled_interval * first_val / counter_delta), duration_to_start) + duration_to_end) / sampled_interval / 300, nan) AS `Value` FROM (SELECT `Attributes`, `anchor_ts`, `window_vals`, `counter_delta`, `first_val`, toFloat64(dateDiff('nanosecond', first_ts, last_ts)) / 1e9 AS `sampled_interval`, if(toFloat64(dateDiff('nanosecond', anchor_ts - toIntervalNanosecond(300000000000), first_ts)) / 1e9 >= 1.1 * sampled_interval / (length(window_vals) - 1), sampled_interval / (length(window_vals) - 1) / 2, toFloat64(dateDiff('nanosecond', anchor_ts - toIntervalNanosecond(300000000000), first_ts)) / 1e9) AS `duration_to_start`, if(toFloat64(dateDiff('nanosecond', last_ts, anchor_ts)) / 1e9 >= 1.1 * sampled_interval / (length(window_vals) - 1), sampled_interval / (length(window_vals) - 1) / 2, toFloat64(dateDiff('nanosecond', last_ts, anchor_ts)) / 1e9) AS `duration_to_end` FROM (SELECT `Attributes`, `anchor_ts`, arrayMap(p -> tupleElement(p, 2), window_pairs) AS `window_vals`, arraySum(arrayMap((p, c) -> if(c < p, c, c - p), arrayPopBack(arrayMap(x -> tupleElement(x, 2), window_pairs)), arrayPopFront(arrayMap(x -> tupleElement(x, 2), window_pairs)))) AS `counter_delta`, tupleElement(window_pairs[1], 1) AS `first_ts`, tupleElement(window_pairs[length(window_pairs)], 1) AS `last_ts`, tupleElement(window_pairs[1], 2) AS `first_val` FROM (SELECT `Attributes`, `anchor_ts`, arrayReverse(arrayCompact(p -> tupleElement(p, 1), arrayReverse(window_pairs))) AS `window_pairs` FROM (SELECT `Attributes`, `anchor_ts`, arraySort(groupArray((`TimeUnix`, `Value`))) AS `window_pairs` FROM (SELECT `Attributes`, `TimeUnix`, `Value`, arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:05:00.000000000', 9) - toIntervalNanosecond(i * 30000000000), range(greatest(0, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 300000000000, toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 300000000000, toInt64(30000000000)) < 0) + 1), least(11, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)), toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)), toInt64(30000000000)) < 0) + 1)))) AS `anchor_ts` FROM (SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?)))) WHERE `TimeUnix` > toDateTime64('2026-01-01 00:00:00.000000000', 9) - toIntervalNanosecond(300000000000) AND `TimeUnix` <= toDateTime64('2026-01-01 00:05:00.000000000', 9)) GROUP BY `Attributes`, `anchor_ts`)))) WHERE length(`window_vals`) >= 2)) GROUP BY `Attributes`, `anchor_ts`, `TimeUnix` HAVING (throwIf((count() > ?), 'vector cannot contain metrics with the same labelset') = ?)

--- a/test/spec/promql/label_replace_over_rate_range_step.txtar
+++ b/test/spec/promql/label_replace_over_rate_range_step.txtar
@@ -41,6 +41,26 @@ INSERT INTO otel_metrics_sum VALUES
     ('cerberus_queries_total', map('cerberus_ql', 'logql'), toDateTime64('2026-01-01 00:04:00', 9), 24.0),
     ('cerberus_queries_total', map('cerberus_ql', 'logql'), toDateTime64('2026-01-01 00:05:00', 9), 30.0);
 -- expected_rows --
+[
+  [{"cerberus_ql": "logql", "engine": "engine-logql"}, "2026-01-01T00:01:00Z", "2026-01-01T00:01:00Z", 0.02],
+  [{"cerberus_ql": "logql", "engine": "engine-logql"}, "2026-01-01T00:01:30Z", "2026-01-01T00:01:30Z", 0.03],
+  [{"cerberus_ql": "logql", "engine": "engine-logql"}, "2026-01-01T00:02:00Z", "2026-01-01T00:02:00Z", 0.04],
+  [{"cerberus_ql": "logql", "engine": "engine-logql"}, "2026-01-01T00:02:30Z", "2026-01-01T00:02:30Z", 0.05],
+  [{"cerberus_ql": "logql", "engine": "engine-logql"}, "2026-01-01T00:03:00Z", "2026-01-01T00:03:00Z", 0.06],
+  [{"cerberus_ql": "logql", "engine": "engine-logql"}, "2026-01-01T00:03:30Z", "2026-01-01T00:03:30Z", 0.07],
+  [{"cerberus_ql": "logql", "engine": "engine-logql"}, "2026-01-01T00:04:00Z", "2026-01-01T00:04:00Z", 0.08],
+  [{"cerberus_ql": "logql", "engine": "engine-logql"}, "2026-01-01T00:04:30Z", "2026-01-01T00:04:30Z", 0.09],
+  [{"cerberus_ql": "logql", "engine": "engine-logql"}, "2026-01-01T00:05:00Z", "2026-01-01T00:05:00Z", 0.1],
+  [{"cerberus_ql": "promql", "engine": "engine-promql"}, "2026-01-01T00:01:00Z", "2026-01-01T00:01:00Z", 0.04],
+  [{"cerberus_ql": "promql", "engine": "engine-promql"}, "2026-01-01T00:01:30Z", "2026-01-01T00:01:30Z", 0.06],
+  [{"cerberus_ql": "promql", "engine": "engine-promql"}, "2026-01-01T00:02:00Z", "2026-01-01T00:02:00Z", 0.08],
+  [{"cerberus_ql": "promql", "engine": "engine-promql"}, "2026-01-01T00:02:30Z", "2026-01-01T00:02:30Z", 0.1],
+  [{"cerberus_ql": "promql", "engine": "engine-promql"}, "2026-01-01T00:03:00Z", "2026-01-01T00:03:00Z", 0.12],
+  [{"cerberus_ql": "promql", "engine": "engine-promql"}, "2026-01-01T00:03:30Z", "2026-01-01T00:03:30Z", 0.14],
+  [{"cerberus_ql": "promql", "engine": "engine-promql"}, "2026-01-01T00:04:00Z", "2026-01-01T00:04:00Z", 0.16],
+  [{"cerberus_ql": "promql", "engine": "engine-promql"}, "2026-01-01T00:04:30Z", "2026-01-01T00:04:30Z", 0.18],
+  [{"cerberus_ql": "promql", "engine": "engine-promql"}, "2026-01-01T00:05:00Z", "2026-01-01T00:05:00Z", 0.2]
+]
 -- args --
 [0] string = "cerberus_ql"
 [1] string = "^(.*)$"


### PR DESCRIPTION
The TXTAR harness reaches only the strategy set some caller wires for it, and it wired six fields through a hand-written `if` ladder. A ladder cannot be enumerated, so a seventh field on `RangeLowerers` would lower through the fan-out default in every fixture, and the SQL its native strategy emits in production would go unpinned — a green lane proving nothing about the feature it was built to cover.

## The ratchet

`nativeStrategies` binds each `RangeLowerers` field to the marker section a fixture carries to opt into it. Two tests close it from both ends:

- `TestNativeStrategies_CoverEveryRangeLowerersField` reflects over `RangeLowerers` and fails any field with no row. It checks each row **behaviourally** rather than by name list: apply the row to a zero table and assert exactly its own field became non-nil. A row that names a field it does not actually set — the copy-paste failure this table's shape invites — fails here, rather than silently wiring the wrong strategy into every fixture carrying its section.
- `TestNativeStrategies_HaveNativeSideFixtures` fails any row whose section no fixture carries. A wired strategy nothing opts into is still unpinned SQL.

Together, adding a field to `RangeLowerers` is a test failure until both the wiring and a fixture exist.

I verified the ratchet is not neutralized: three independent mutations — a missing row, a row naming the wrong field, and a typo'd section — each produced a distinct, correctly-worded failure, and the tree returned to green after each.

## The fixture pair

The ladder made the label-rewrite-over-native shape unreachable, so it had no fixture. The fan-out and native lowerings build *different node kinds for the identical row shape* (`chplan.RangeWindow` vs `chplan.RangeWindowNative`). A classifier that answers "what columns does my input expose?" from the node kind rather than from the derived row shape sends the native arm down the full-Sample-row branch and emits `SELECT MetricName, … FROM (<grid subquery>)`, which ClickHouse rejects with `code: 47, Unknown expression identifier MetricName`. That was a live 502 on `/api/v1/query_range` with the `ts_grid_range` lowering on, invisible to every fixture in the corpus because every one of them lowered through the fan-out table.

`label_replace_over_rate_range_step.txtar` and `label_replace_over_native_rate_range_step.txtar` carry the same query, seed and grid, so the pair reads as one comparison and the two `expected_rows` blocks can be checked by eye.

Closes #1927

🤖 Generated with [Claude Code](https://claude.com/claude-code)