### PR TITLE
fix(qlcommon): re-cite the label_replace divergence and close the nullability coverage gap

### DIFF
--- a/internal/qlcommon/label_replace_nullability_test.go
+++ b/internal/qlcommon/label_replace_nullability_test.go
@@ -1,0 +1,182 @@
+package qlcommon
+
+import (
+	"regexp/syntax"
+	"testing"
+)
+
+// TestNullableGroups pins the per-operator nullability verdict that
+// decides whether a shared capture-group name is expressible in SQL.
+//
+// The verdict is not cosmetic. [captureGroups.resolve] translates a
+// shared name into `arrayFirst(x -> x != ”, …)` exactly when every
+// carrier is NON-nullable, because only then does "first non-empty"
+// coincide with Go's "first that took part in the match". Call a
+// nullable group non-nullable and cerberus emits SQL that silently
+// answers with a later carrier's capture where Prometheus answers with
+// the empty string; call a non-nullable group nullable and a query
+// Prometheus answers gets rejected. So each row below is one operator's
+// contribution to that boundary.
+//
+// Every case drives the real entry point — a regex STRING — rather than
+// a hand-built syntax tree, so the operator each one is claimed to
+// exercise is the operator Go's parser actually produces for it. Several
+// obvious spellings do NOT survive parsing: `(a|b)` is folded to a
+// character class, so the alternation cases spell out multi-rune arms.
+func TestNullableGroups(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		regex string
+		// want is the nullability of capture group 1.
+		want bool
+	}{
+		// Single-width shapes: a group that takes part consumes at
+		// least one rune, which is what makes the shared-name form
+		// expressible at all.
+		{"literal", "(a)", false},
+		{"multi_rune_literal", "(ab)", false},
+		{"char_class", "([a-z])", false},
+		{"any_char", "(?s)(.)", false},
+		{"any_char_not_nl", "(.)", false},
+
+		// Zero-width shapes. The assertions match the empty string
+		// subject to a condition on the surrounding text, which is
+		// still a match of width zero.
+		{"empty_match", "()", true},
+		{"begin_line", "(?m)(^)", true},
+		{"end_line", "(?m)($)", true},
+		{"begin_text", `(\A)`, true},
+		{"end_text", `(\z)`, true},
+		{"word_boundary", `(\b)`, true},
+		{"no_word_boundary", `(\B)`, true},
+
+		// Repetition. Star and quest admit zero repetitions
+		// unconditionally; plus and a min>0 repeat are nullable exactly
+		// when their body is, which is why the two `plus_*` rows differ.
+		{"star", "(a*)", true},
+		{"quest", "(a?)", true},
+		{"plus_of_non_nullable", "(a+)", false},
+		{"plus_of_nullable", "((?:a?)+)", true},
+		{"repeat_min_zero", "(a{0,2})", true},
+		{"repeat_min_positive", "(a{2,3})", false},
+		{"repeat_min_positive_unbounded", "(a{2,})", false},
+		{"repeat_min_positive_of_nullable", "((?:a?){2,3})", true},
+
+		// Concatenation is nullable only when EVERY part can
+		// contribute nothing, so one non-nullable part settles it.
+		{"concat_all_nullable", "(a?b?)", true},
+		{"concat_one_non_nullable", "(a?bc?)", false},
+
+		// Alternation is the mirror image: ONE nullable branch is
+		// enough. Both arms are multi-rune so the parser leaves the
+		// alternation standing instead of folding it to a char class.
+		{"alternate_none_nullable", "(ab|cd)", false},
+		{"alternate_one_nullable", "(ab|)", true},
+
+		// A group wrapping another group defers to the inner one.
+		{"nested_capture_non_nullable", "((a))", false},
+		{"nested_capture_nullable", "((a?))", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := nullableGroups(tc.regex)
+			if got == nil {
+				t.Fatalf("nullableGroups(%q) = nil, want a map — the regex must parse", tc.regex)
+			}
+			nullable, ok := got[1]
+			if !ok {
+				t.Fatalf("nullableGroups(%q) recorded no verdict for capture group 1; got %v",
+					tc.regex, got)
+			}
+			if nullable != tc.want {
+				t.Errorf("nullableGroups(%q)[1] = %v, want %v", tc.regex, nullable, tc.want)
+			}
+		})
+	}
+}
+
+// TestNullableGroupsWalksEveryGroup checks that the walk records a
+// verdict per group rather than only for the outermost or the last one.
+// The indices have to line up with `Regexp.SubexpNames`, because
+// [captureGroups] resolves a name to indices through SubexpNames and
+// then looks those indices up in this map — an off-by-one between the
+// two would read a neighbouring group's nullability and decide the
+// expressibility question about the wrong group.
+func TestNullableGroupsWalksEveryGroup(t *testing.T) {
+	t.Parallel()
+
+	// Group 1 wraps 2 and 3. Its own verdict is neither group's: the
+	// concatenation is non-nullable because group 3 is, even though
+	// group 2 — the one a "record the first group you meet" walk would
+	// reach first — is nullable. So the three verdicts alternate, and a
+	// walk that recorded only the outermost, only the innermost, or the
+	// last one it saw would disagree with at least one row here.
+	const regex = "((a?)(b))"
+
+	got := nullableGroups(regex)
+	want := map[int]bool{1: false, 2: true, 3: false}
+	if len(got) != len(want) {
+		t.Fatalf("nullableGroups(%q) recorded %d group(s), want %d: %v",
+			regex, len(got), len(want), got)
+	}
+	for idx, w := range want {
+		if got[idx] != w {
+			t.Errorf("nullableGroups(%q)[%d] = %v, want %v", regex, idx, got[idx], w)
+		}
+	}
+}
+
+// TestNullableGroupsUnparseableRegexIsConservative pins the nil return.
+//
+// A nil map reads as "no verdict for any group", and every consumer
+// treats a missing verdict as nullable, so an unparseable regex keeps
+// the rejection. That is the safe direction: the alternative — assuming
+// non-nullable and emitting the `arrayFirst` form — would answer a query
+// whose regex cerberus could not even analyse.
+func TestNullableGroupsUnparseableRegexIsConservative(t *testing.T) {
+	t.Parallel()
+
+	for _, regex := range []string{"(", "a{2,1}", `[z-a]`, `(?P<n>a)(?P<`} {
+		if got := nullableGroups(regex); got != nil {
+			t.Errorf("nullableGroups(%q) = %v, want nil for an unparseable regex", regex, got)
+		}
+	}
+}
+
+// TestMatchesEmptyUnclassifiedOperatorIsNullable covers the switch's
+// final fallthrough, which no regex string can reach: every operator
+// Go's parser emits from a well-formed pattern is named by a case above
+// it. [syntax.OpNoMatch] is constructed directly here for that reason.
+//
+// The arm is not dead weight. It is the guarantee that a FUTURE
+// operator — one a newer Go regexp/syntax introduces, or one a
+// simplification pass produces — defaults to nullable and therefore to
+// rejection, instead of falling through to a verdict that would let
+// cerberus emit the expressible form for a group it never analysed.
+func TestMatchesEmptyUnclassifiedOperatorIsNullable(t *testing.T) {
+	t.Parallel()
+
+	if !matchesEmpty(&syntax.Regexp{Op: syntax.OpNoMatch}) {
+		t.Error("matchesEmpty(OpNoMatch) = false, want true — an operator the switch does " +
+			"not classify must read as nullable so the shared-name rejection is kept")
+	}
+}
+
+// TestMatchesEmptyZeroRuneLiteral pins the one literal shape that IS
+// nullable. `OpLiteral` normally carries at least one rune, and the
+// length check is what keeps a zero-rune literal — reachable by
+// constructing or simplifying rather than by parsing — from being read
+// as "consumes a character" and wrongly making its group expressible.
+func TestMatchesEmptyZeroRuneLiteral(t *testing.T) {
+	t.Parallel()
+
+	if !matchesEmpty(&syntax.Regexp{Op: syntax.OpLiteral}) {
+		t.Error("matchesEmpty(zero-rune OpLiteral) = false, want true — it matches only " +
+			"the empty string")
+	}
+}

--- a/test/rejection-parity/catalogue/internal__logql__label_fns.go.json
+++ b/test/rejection-parity/catalogue/internal__logql__label_fns.go.json
@@ -6,7 +6,7 @@
       "message": "logql: label_replace: %w",
       "class": "divergence",
       "trigger_query": "label_replace(rate({app=\"x\"}[5m]), \"d\", \"$dup\", \"src\", \"(?P\u003cdup\u003ea?)|(?P\u003cdup\u003eb)\")",
-      "tracking_issue": 1768,
+      "tracking_issue": 1956,
       "evidence": {
         "guard": [
           "past returning if e.Left == nil",

--- a/test/rejection-parity/catalogue/internal__promql__label_fns.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__label_fns.go.json
@@ -36,7 +36,7 @@
       "message": "promql: label_replace: %w",
       "class": "divergence",
       "trigger_query": "label_replace(up, \"d\", \"$dup\", \"src\", \"(?P\u003cdup\u003ea?)|(?P\u003cdup\u003eb)\")",
-      "tracking_issue": 1768,
+      "tracking_issue": 1956,
       "evidence": {
         "guard": [
           "past returning if len(c.Args) != 5",


### PR DESCRIPTION
`main` has been red on two checks since #1952 merged. Both are that PR's own fallout, and both are fixed here.

## `forbid-deferral` — a divergence entry citing a closed issue

#1952 answered `label_replace` over non-nullable shared capture names and closed #1768 with it. The rejection-parity catalogue's two divergence entries — `internal/promql/label_fns.go:lowerLabelReplace#d11e3df4` and its LogQL twin — still cited #1768.

That is a build failure by design, and it is the load-bearing reason `divergence` is not the allow-list `test/rejection-parity/doc.go` forbids: an allow-list entry, once accepted, asks nothing further of anyone, while a divergence entry has to keep an open issue pointed at it forever.

The gap itself is unchanged and still real. A nullable carrier that takes part matching the empty string is one Go's `expand` picks — it scans `SubexpNames()` for the first index where `match[2*i] >= 0` — whereas `arrayFirst(x -> x != '', …)` would skip past it to a later carrier and substitute the wrong text. ClickHouse's `extractGroups` renders "did not take part" and "took part, matched empty" identically as `''`, so the two are not tellable apart from SQL. Re-filed as #1956 with the reasoning and the three rewrites that do *not* recover participation, and both entries repointed. The trigger queries were already re-pinned to the nullable form by #1952, so only the citation moved.

Verified with the gate itself: `rejection-parity-divergence-liveness.mjs` now reports 3 divergence entries, 0 violations.

## `coverage` — internal/qlcommon at 94.34% against a floor of 99%

The nullability analysis #1952 added arrived with no direct tests. `matchesEmpty` sat at 57.9%, which means most of the per-operator verdicts the whole expressibility boundary rests on were unpinned — and the verdict is not cosmetic in either direction. Call a nullable group non-nullable and cerberus emits SQL that silently answers with a later carrier's capture where Prometheus answers with the empty string; call a non-nullable group nullable and a query Prometheus answers gets rejected.

Every case drives the real entry point — a regex **string** — rather than a hand-built syntax tree, so the operator each case claims to exercise is the operator Go's parser actually produces for it. That distinction earns its keep: several obvious spellings do not survive parsing, and `(a|b)` folds to a character class rather than staying an alternation, so the alternation rows spell out multi-rune arms.

Two arms no well-formed pattern can reach are constructed directly, because both exist precisely to keep an unanalysed group on the rejecting side: the unclassified-operator fallthrough (a future `regexp/syntax` operator must default to nullable, not fall through to a verdict about a group it never analysed) and the zero-rune literal.

internal/qlcommon is back to 100%. The floor is left at 99 — it ratchets up only, and raising it needs the merged default-tag + chdb-tagged profile the CI job builds, not a single-package run.

No closing keyword is claimed for #1956 on purpose: it tracks the divergence itself, which stays open for as long as the catalogue entries cite it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
