### PR TITLE
feat(compat/prometheus): differential parity for the metadata match[] grammar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,12 +76,14 @@ test/e2e/playwright/playwright-report/
 # these next to the config; they're per-run artifacts uploaded by CI, not
 # source). The prometheus harness emits the tester report + the
 # shields.io badge score + the per-case roster the parity ratchet gates
-# on + the rejection-parity report. The roster's committed counterpart is
-# heads.prometheus.cases in compatibility/parity-baseline.json.
+# on + the rejection-parity report + the metadata match[] parity report.
+# The roster's committed counterpart is heads.prometheus.cases in
+# compatibility/parity-baseline.json.
 /compatibility/prometheus/report.json
 /compatibility/prometheus/compat-score.json
 /compatibility/prometheus/compat-cases.json
 /compatibility/prometheus/rejection-parity.json
+/compatibility/prometheus/metadata-parity.json
 /compatibility/prometheus/upstream/promql/cmd/promql-compliance-tester/promql-compliance-tester
 
 # Tier-1 migration substrate: the seeder's manifest is a per-run artifact

--- a/compatibility/prometheus/cmd/metadata-parity/main.go
+++ b/compatibility/prometheus/cmd/metadata-parity/main.go
@@ -1,0 +1,317 @@
+// Command metadata-parity is the differential harness for the
+// Prometheus metadata endpoints' `match[]` selector grammar
+// (`/api/v1/series`, `/api/v1/labels`, `/api/v1/label/<name>/values`).
+//
+// #1487 fixed cerberus's `match[]` parsing on these endpoints to use
+// upstream's ParseMetricSelector grammar (a bare instant-vector
+// selector only) instead of the general ParseExpr grammar, so a
+// selector upstream rejects — a range-vector call, `offset`, `@`, an
+// aggregation, or the empty `{}` selector — now 400s in cerberus too
+// (internal/api/prom/handler.go's parseMatchSelector +
+// requireNonEmptyMatcher). That fix is pinned by
+// internal/api/prom/metadata_test.go's matchSelectorRejectedShapes
+// table, but ONLY as a handler-level unit test against the documented
+// upstream contract — not as a live differential diff against a real
+// reference Prometheus. #1729 closes that gap: this driver fires the
+// SAME shape set the unit tests pin at both a reference Prometheus and
+// cerberus, so a future regression (someone reverting to ParseExpr, or
+// a new metadata endpoint acquiring the same bug) fails a compatibility
+// gate instead of passing every currently-required one.
+//
+// This mirrors compatibility/loki/cmd/loki-compliance-tester/
+// status_parity.go's comparison granularity — a small, fixed case
+// table, each entry asserting BOTH backends return the exact SAME
+// expected status for a given request shape — but is packaged as its
+// own hard-failing driver (mirroring
+// compatibility/cmd/rejection-parity's exit semantics) rather than
+// folded into a report-only corpus pass: there is no cerberus-owned
+// "compliance-tester" binary on the Prometheus side to fold into (the
+// Prometheus lane drives the upstream-owned promql-compliance-tester
+// for the noisy /query and /query_range corpus), and the whole point
+// of this gap is a small, deliberately-chosen, uncontroversial case set
+// that should fail the build the moment it regresses.
+//
+// query_exemplars (also named in #1729's title) is deliberately NOT
+// covered here: its parse boundary is a structurally different
+// contract (a `query=` parameter walked through the general ParseExpr
+// grammar and the post-parse singleVectorSelector check in
+// internal/api/prom/exemplars.go, not match[]'s ParseMetricSelector),
+// its required-parameter shape differs (mandatory `start`/`end`, no
+// bare-window default), and — unlike the map[] endpoints — `offset`
+// and `@` are valid there on both backends (they set fields on the
+// same *parser.VectorSelector node, so singleVectorSelector's type
+// assertion accepts them same as upstream's identical check), so the
+// case table this driver deliberately keeps in lock-step with the
+// match[] unit tests does not transfer. Exercising it soundly would
+// also need the reference container's exemplar-storage feature state
+// confirmed live — this environment cannot run the compose stack (see
+// docs/test-strategy.md's CI-only compat lanes). #1729 stays open for
+// that endpoint.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "metadata-parity: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// metadataEndpoint is one of the three match[]-driven metadata routes
+// this driver targets.
+type metadataEndpoint struct {
+	desc string
+	path string
+}
+
+// metadataEndpoints are the three endpoints #1487 fixed match[] parsing
+// on. label_values targets an arbitrary label name ("job") — the
+// selector grammar rejection happens before the name is ever resolved
+// against data, so which name is used doesn't matter, mirroring
+// TestLabelValues_MatchSelectorRejectsNonSelector's choice.
+func metadataEndpoints() []metadataEndpoint {
+	return []metadataEndpoint{
+		{desc: "series", path: "/api/v1/series"},
+		{desc: "labels", path: "/api/v1/labels"},
+		{desc: "label_values", path: "/api/v1/label/job/values"},
+	}
+}
+
+// matchShape is one match[] value this driver fires at every endpoint,
+// paired with the status BOTH backends must answer with.
+type matchShape struct {
+	desc   string
+	value  string
+	expect int
+}
+
+// matchShapes is kept in lock-step with
+// internal/api/prom/metadata_test.go's matchSelectorRejectedShapes
+// table (the range-vector call, offset, @, and aggregation shapes) plus
+// the empty `{}` selector handler.go's requireNonEmptyMatcher rejects
+// and one syntactically valid selector that must be ACCEPTED — so this
+// driver's shape set and the unit tests' shape set can't silently
+// drift apart. None of these shapes' outcomes depend on the seeded
+// fixture: both backends decide at the parse/matcher-emptiness boundary
+// before ever touching storage, exactly like status_parity.go's two
+// cases.
+func matchShapes() []matchShape {
+	return []matchShape{
+		{
+			desc:   "valid selector",
+			value:  "cerberus_metadata_parity_probe",
+			expect: http.StatusOK,
+		},
+		{
+			desc:   "empty {} selector",
+			value:  "{}",
+			expect: http.StatusBadRequest,
+		},
+		{
+			desc:   "range-vector call",
+			value:  "rate(http_requests_total[5m])",
+			expect: http.StatusBadRequest,
+		},
+		{
+			desc:   "offset modifier",
+			value:  "foo offset 1h",
+			expect: http.StatusBadRequest,
+		},
+		{
+			desc:   "@ modifier",
+			value:  "foo @ 1600000000",
+			expect: http.StatusBadRequest,
+		},
+		{
+			desc:   "aggregation",
+			value:  "sum(foo)",
+			expect: http.StatusBadRequest,
+		},
+	}
+}
+
+// CaseResult is one (endpoint, shape) pair's outcome on both backends.
+type CaseResult struct {
+	Endpoint string `json:"endpoint"`
+	Shape    string `json:"shape"`
+	Match    string `json:"match"`
+
+	RefStatus      int `json:"refStatus"`
+	CerberusStatus int `json:"cerberusStatus"`
+	Expect         int `json:"expect"`
+
+	// Verdict: "parity" (both backends answered `expect`), "mismatch"
+	// (at least one backend diverged from `expect` — a real bug, never
+	// an allow-list entry), or "hard_error" (transport failure or a 5xx
+	// on either side — infrastructure, not a parity verdict).
+	Verdict string `json:"verdict"`
+	Detail  string `json:"detail,omitempty"`
+}
+
+// Report is the on-disk JSON artifact.
+type Report struct {
+	Total     int          `json:"total"`
+	Parity    int          `json:"parity"`
+	Mismatch  int          `json:"mismatch"`
+	HardError int          `json:"hardError"`
+	Cases     []CaseResult `json:"cases"`
+}
+
+// Fatal reports whether any case mismatched its expected status on
+// either backend — the exact blind spot #1729 describes: a future
+// regression that would otherwise pass every currently-required
+// compatibility gate.
+func (r Report) Fatal() bool {
+	return r.Mismatch > 0
+}
+
+func run() error {
+	var (
+		refURL  = flag.String("ref", "", "reference backend base URL")
+		cerbURL = flag.String("cerberus", "", "cerberus base URL")
+		report  = flag.String("report", "", "JSON report output path")
+		timeout = flag.Duration("timeout", 30*time.Second, "per-request HTTP timeout")
+	)
+	flag.Parse()
+	if *refURL == "" || *cerbURL == "" || *report == "" {
+		return fmt.Errorf("-ref, -cerberus and -report are all required")
+	}
+
+	client := &http.Client{Timeout: *timeout}
+	var rep Report
+	for _, ep := range metadataEndpoints() {
+		for _, sh := range matchShapes() {
+			res := runCase(client, *refURL, *cerbURL, ep, sh)
+			rep.Total++
+			switch res.Verdict {
+			case "parity":
+				rep.Parity++
+			case "mismatch":
+				rep.Mismatch++
+			default:
+				rep.HardError++
+			}
+			rep.Cases = append(rep.Cases, res)
+		}
+	}
+
+	if err := writeReport(*report, rep); err != nil {
+		return fmt.Errorf("write report: %w", err)
+	}
+	fmt.Fprintf(os.Stderr,
+		"==> metadata-parity: total=%d parity=%d mismatch=%d hard_error=%d -> %s\n",
+		rep.Total, rep.Parity, rep.Mismatch, rep.HardError, *report)
+	for _, c := range rep.Cases {
+		if c.Verdict != "parity" {
+			fmt.Fprintf(os.Stderr, "    [%s] %s match[]=%q (want %d): ref=%d cerberus=%d %s\n",
+				c.Verdict, c.Endpoint, c.Match, c.Expect, c.RefStatus, c.CerberusStatus, c.Detail)
+		}
+	}
+
+	// A mismatch means at least one backend answered a status other
+	// than the shape's expected one — the report above already landed
+	// on disk so the artifact survives this branch. Only hard_error
+	// (transport failure, 5xx) stays non-fatal: that's infrastructure,
+	// not a parity verdict.
+	if rep.Fatal() {
+		return fmt.Errorf(
+			"metadata-parity: %d mismatch(es) — see %s for detail; a mismatch is a real match[]-grammar "+
+				"parity bug to fix at internal/api/prom/handler.go's parseMatchSelector, never an allow-list entry",
+			rep.Mismatch, *report,
+		)
+	}
+	return nil
+}
+
+// runCase fires the endpoint+shape's request at both backends and
+// classifies the status pair against the shape's expected status.
+func runCase(client *http.Client, refURL, cerbURL string, ep metadataEndpoint, sh matchShape) CaseResult {
+	res := CaseResult{Endpoint: ep.desc, Shape: sh.desc, Match: sh.value, Expect: sh.expect}
+
+	params := url.Values{}
+	params.Set("match[]", sh.value)
+
+	refStatus, refBody, refErr := fetch(client, refURL, ep.path, params)
+	cerbStatus, cerbBody, cerbErr := fetch(client, cerbURL, ep.path, params)
+	res.RefStatus, res.CerberusStatus = refStatus, cerbStatus
+
+	switch {
+	case refErr != nil:
+		res.Verdict = "hard_error"
+		res.Detail = "reference fetch: " + refErr.Error()
+	case cerbErr != nil:
+		res.Verdict = "hard_error"
+		res.Detail = "cerberus fetch: " + cerbErr.Error()
+	case refStatus/100 == 5 || cerbStatus/100 == 5:
+		res.Verdict = "hard_error"
+		res.Detail = fmt.Sprintf("5xx: ref=%q cerberus=%q", snippet(refBody), snippet(cerbBody))
+	case refStatus == sh.expect && cerbStatus == sh.expect:
+		res.Verdict = "parity"
+	case refStatus != sh.expect && cerbStatus != sh.expect:
+		res.Verdict = "mismatch"
+		res.Detail = fmt.Sprintf("both diverged from expected %d (ref body=%q; cerberus body=%q)",
+			sh.expect, snippet(refBody), snippet(cerbBody))
+	case refStatus != sh.expect:
+		res.Verdict = "mismatch"
+		res.Detail = fmt.Sprintf("reference diverged from expected %d (body=%q)", sh.expect, snippet(refBody))
+	default:
+		res.Verdict = "mismatch"
+		res.Detail = fmt.Sprintf("cerberus diverged from expected %d (body=%q)", sh.expect, snippet(cerbBody))
+	}
+	return res
+}
+
+func fetch(client *http.Client, base, path string, params url.Values) (int, []byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), client.Timeout)
+	defer cancel()
+
+	u := strings.TrimRight(base, "/") + path + "?" + params.Encode()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return 0, nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return resp.StatusCode, nil, fmt.Errorf("read body: %w", err)
+	}
+	return resp.StatusCode, body, nil
+}
+
+func snippet(b []byte) string {
+	const maxSnippetLen = 300
+	s := strings.TrimSpace(string(b))
+	if len(s) > maxSnippetLen {
+		s = s[:maxSnippetLen] + "…"
+	}
+	return s
+}
+
+func writeReport(path string, rep Report) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return err
+	}
+	out, err := json.MarshalIndent(rep, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, append(out, '\n'), 0o600)
+}

--- a/compatibility/prometheus/cmd/metadata-parity/main_test.go
+++ b/compatibility/prometheus/cmd/metadata-parity/main_test.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// statusServer starts a test server that always answers the given
+// status code, ignoring the request entirely — the driver only cares
+// about the status class it gets back.
+func statusServer(t *testing.T, status int) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(`{"status":"error","message":"boom"}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestMatchShapes_LockstepWithUnitTests pins the driver's shape table
+// against the exact set internal/api/prom/metadata_test.go's
+// matchSelectorRejectedShapes pins — a range-vector call, offset, @,
+// and an aggregation — plus the empty {} selector and one accepted
+// selector, so a future edit can't silently let the two tables drift
+// apart.
+func TestMatchShapes_LockstepWithUnitTests(t *testing.T) {
+	wantRejected := map[string]bool{
+		"rate(http_requests_total[5m])": true,
+		"foo offset 1h":                 true,
+		"foo @ 1600000000":              true,
+		"sum(foo)":                      true,
+		"{}":                            true,
+	}
+
+	shapes := matchShapes()
+	gotRejected := map[string]bool{}
+	sawAccepted := false
+	for _, sh := range shapes {
+		switch sh.expect {
+		case http.StatusBadRequest:
+			gotRejected[sh.value] = true
+		case http.StatusOK:
+			sawAccepted = true
+		default:
+			t.Errorf("shape %q: unexpected expect=%d, want 200 or 400", sh.desc, sh.expect)
+		}
+	}
+	if !sawAccepted {
+		t.Error("expected at least one shape asserting a 200 (a syntactically valid selector must be accepted)")
+	}
+	for v := range wantRejected {
+		if !gotRejected[v] {
+			t.Errorf("expected match[]=%q among the rejected shapes, got %v", v, gotRejected)
+		}
+	}
+	for v := range gotRejected {
+		if !wantRejected[v] {
+			t.Errorf("unexpected rejected shape %q not present in the unit-test lockstep set", v)
+		}
+	}
+}
+
+// TestMetadataEndpoints_MatchesFixedPromEndpoints pins the three routes
+// #1487 fixed match[] parsing on.
+func TestMetadataEndpoints_MatchesFixedPromEndpoints(t *testing.T) {
+	want := map[string]string{
+		"series":       "/api/v1/series",
+		"labels":       "/api/v1/labels",
+		"label_values": "/api/v1/label/job/values",
+	}
+	got := metadataEndpoints()
+	if len(got) != len(want) {
+		t.Fatalf("expected %d endpoints, got %d: %+v", len(want), len(got), got)
+	}
+	for _, ep := range got {
+		if want[ep.desc] != ep.path {
+			t.Errorf("endpoint %q: path=%q, want %q", ep.desc, ep.path, want[ep.desc])
+		}
+	}
+}
+
+// TestRunCase_BothMatchExpectation_Passes is the case this driver
+// exists to make representable: both backends answer the shape's
+// expected status, and it's recorded as parity.
+func TestRunCase_BothMatchExpectation_Passes(t *testing.T) {
+	ref := statusServer(t, http.StatusBadRequest)
+	test := statusServer(t, http.StatusBadRequest)
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	sh := matchShape{desc: "empty {} selector", value: "{}", expect: http.StatusBadRequest}
+	ep := metadataEndpoint{desc: "labels", path: "/api/v1/labels"}
+
+	res := runCase(client, ref.URL, test.URL, ep, sh)
+	if res.Verdict != "parity" {
+		t.Fatalf("expected parity, got %+v", res)
+	}
+}
+
+// TestRunCase_MismatchCaught is the exact blind spot #1729 describes:
+// one backend accepts a shape the other rejects. Both divergence
+// directions, and a both-wrong-status case, must surface as
+// "mismatch", never a silent pass.
+func TestRunCase_MismatchCaught(t *testing.T) {
+	tests := []struct {
+		name       string
+		refStatus  int
+		testStatus int
+		wantSubstr string
+	}{
+		{"reference accepts, cerberus rejects", http.StatusOK, http.StatusBadRequest, "reference diverged"},
+		{"reference rejects, cerberus accepts", http.StatusBadRequest, http.StatusOK, "cerberus diverged"},
+		{"both wrong status", http.StatusNotFound, http.StatusOK, "both diverged"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ref := statusServer(t, tc.refStatus)
+			test := statusServer(t, tc.testStatus)
+
+			client := &http.Client{Timeout: 5 * time.Second}
+			sh := matchShape{desc: "empty {} selector", value: "{}", expect: http.StatusBadRequest}
+			ep := metadataEndpoint{desc: "labels", path: "/api/v1/labels"}
+
+			res := runCase(client, ref.URL, test.URL, ep, sh)
+			if res.Verdict != "mismatch" {
+				t.Fatalf("expected mismatch, got: %+v", res)
+			}
+			if !strings.Contains(res.Detail, tc.wantSubstr) {
+				t.Fatalf("Detail = %q, want substring %q", res.Detail, tc.wantSubstr)
+			}
+		})
+	}
+}
+
+// TestRunCase_FetchFailureDistinctFromMismatch pins that an unreachable
+// backend is attributed to the side that failed, never silently
+// reinterpreted as a status-0 mismatch.
+func TestRunCase_FetchFailureDistinctFromMismatch(t *testing.T) {
+	test := statusServer(t, http.StatusBadRequest)
+
+	client := &http.Client{Timeout: 2 * time.Second}
+	sh := matchShape{desc: "empty {} selector", value: "{}", expect: http.StatusBadRequest}
+	ep := metadataEndpoint{desc: "labels", path: "/api/v1/labels"}
+
+	res := runCase(client, "http://127.0.0.1:1", test.URL, ep, sh)
+	if res.Verdict != "hard_error" {
+		t.Fatalf("expected hard_error on unreachable reference, got: %+v", res)
+	}
+	if !strings.Contains(res.Detail, "reference") {
+		t.Fatalf("Detail should name the reference side: %q", res.Detail)
+	}
+}
+
+// TestReport_Fatal pins the exit-semantics contract: only a mismatch
+// fails the driver, a hard_error alone does not.
+func TestReport_Fatal(t *testing.T) {
+	cases := []struct {
+		name string
+		rep  Report
+		want bool
+	}{
+		{"all parity", Report{Total: 3, Parity: 3}, false},
+		{"one hard_error only", Report{Total: 3, Parity: 2, HardError: 1}, false},
+		{"one mismatch", Report{Total: 3, Parity: 2, Mismatch: 1}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.rep.Fatal(); got != tc.want {
+				t.Errorf("Fatal() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/compatibility/prometheus/scripts/run-prometheus-compatibility.sh
+++ b/compatibility/prometheus/scripts/run-prometheus-compatibility.sh
@@ -283,6 +283,25 @@ echo "==> running rejection-parity driver (promql)"
     -report "$ROOT_DIR/rejection-parity.json")
 echo "==> rejection-parity report written to $ROOT_DIR/rejection-parity.json"
 
+# Metadata match[] parity pass: the differential sibling of
+# internal/api/prom/metadata_test.go's matchSelectorRejectedShapes
+# table. #1487 fixed the metadata endpoints (/api/v1/series,
+# /api/v1/labels, /api/v1/label/<name>/values) to parse match[] with
+# upstream's ParseMetricSelector grammar, but the fix was only ever
+# pinned as a handler-level unit test against the documented upstream
+# contract — never diffed live against a reference Prometheus. This
+# driver fires the same fixed shape set (a valid selector, the empty
+# {} selector, a range-vector call, offset, @, and an aggregation) at
+# both backends across all three endpoints and asserts they agree on
+# the expected status, closing the gap #1729 describes. See
+# compatibility/prometheus/cmd/metadata-parity/main.go's package doc.
+echo "==> running metadata-parity driver"
+(cd "$ROOT_DIR/../.." && go run ./compatibility/prometheus/cmd/metadata-parity \
+    -ref http://localhost:29090 \
+    -cerberus http://localhost:29091 \
+    -report "$ROOT_DIR/metadata-parity.json")
+echo "==> metadata-parity report written to $ROOT_DIR/metadata-parity.json"
+
 # Build + run the in-tree scorer. The scorer reads report.json and
 # writes the shields.io endpoint-badge compat-score JSON to $SCORE plus
 # the per-case parity roster to $CASES.


### PR DESCRIPTION
## The gap

#1487 fixed cerberus's `match[]` parsing on `/api/v1/series`, `/api/v1/labels`, and
`/api/v1/label/<name>/values` to use upstream's `ParseMetricSelector` grammar instead of the
general `ParseExpr` grammar, so a selector upstream rejects (a range-vector call, `offset`, `@`,
an aggregation, or the empty `{}` selector) now 400s in cerberus too
(`internal/api/prom/handler.go`'s `parseMatchSelector` + `requireNonEmptyMatcher`). That fix is
pinned by `internal/api/prom/metadata_test.go`'s `matchSelectorRejectedShapes` table — but only as
a handler-level unit test against the documented upstream contract, never as a live differential
diff against a real reference Prometheus.

Neither live-diff mechanism in this repo reaches these endpoints:

- `compatibility/prometheus` (`promql-compliance-tester` + `cerberus-test-queries.yml`) only
  drives `/api/v1/query` and `/api/v1/query_range` — it has no concept of the metadata endpoints.
- `compatibility/cmd/rejection-parity` is scoped to error-construction sites inside the lowering
  packages (`internal/{promql,logql,traceql}`) via `rejectionparity.ScanSites`; the match[]
  rejection lives in `internal/api/prom/handler.go`, an HTTP-layer parse boundary the scanner
  never visits.

So a future regression (reverting to `ParseExpr`, or a new metadata endpoint acquiring the same
bug) would pass every currently-required compatibility gate.

## The fix

`compatibility/prometheus/cmd/metadata-parity/main.go` is a new standalone driver mirroring
`compatibility/loki/cmd/loki-compliance-tester/status_parity.go`'s comparison granularity: a
fixed case table, each entry asserting both backends answer the exact same expected status for a
given request shape.

The shape table is deliberately kept in lock-step with
`internal/api/prom/metadata_test.go`'s `matchSelectorRejectedShapes` (range-vector call, `offset`,
`@`, aggregation) plus the `{}` empty-selector rejection and one syntactically valid selector that
must be accepted — six shapes fired across all three endpoints (18 cases total). None of the
outcomes depend on seeded data: both backends decide at the parse/matcher-emptiness boundary
before ever touching storage, same as `status_parity.go`'s own two cases.

Unlike `status_parity.go` (folded into the report-only Loki compliance-tester binary per task
#68), this ships as its own hard-failing driver modeled on
`compatibility/cmd/rejection-parity`'s exit semantics: there's no cerberus-owned
"compliance-tester" binary on the Prometheus side to fold into, and the whole point of this case
set is that it's small, deliberate, and uncontroversial — it should fail the build the moment it
regresses, not get lost in report-only drift. It's wired into
`run-prometheus-compatibility.sh` right after the existing rejection-parity driver, same `set -e`
propagation.

## query_exemplars — not in this PR

#1729's title also names `query_exemplars` as undriven; I judged that part of #1729 out of scope
for this PR: its parse boundary is a structurally different contract from match[] — `query=`
walked through the general `ParseExpr` grammar plus a post-parse `singleVectorSelector` check
(`internal/api/prom/exemplars.go`), not `ParseMetricSelector`. Critically, `offset` and `@` are
*valid* there on both backends (they're fields on the same `*parser.VectorSelector` node, so the
type-assertion check accepts them identically to upstream), so the match[] shape table doesn't
transfer as-is. It also needs mandatory `start`/`end` params with no bare-window default, and
verifying it soundly would need the reference container's exemplar-storage feature state
confirmed live — this environment has no live compose/reference-Prometheus access to check that
against. Building a second, materially different case table plus confirming the reference's
feature-flag behavior would have blown up this PR's scope, so #1729 stays open and tracks that
remainder.

## Verification

- `go build ./...` — clean.
- `go vet ./compatibility/...` — clean.
- `gofumpt -extra -l compatibility/prometheus/cmd/metadata-parity/` — clean.
- New unit tests in `compatibility/prometheus/cmd/metadata-parity/main_test.go` (case-table
  lock-step with `metadata_test.go`, endpoint table, match/mismatch/hard-error classification,
  fetch-failure distinctness) — all pass.
- Existing `internal/api/prom/metadata_test.go` match[]-rejection tests (`TestLabels_*`,
  `TestLabelValues_*`, `TestSeries_MatchSelectorRejectsNonSelector`) — unchanged, still pass.
- `bash -n compatibility/prometheus/scripts/run-prometheus-compatibility.sh` — syntax OK.

Not locally verifiable — no live reference Prometheus / compose stack in this environment (see
CLAUDE.md invariant 5, compat lanes are CI-only): the actual differential run of the new driver
against a real reference Prometheus + cerberus. CI's `compatibility/prometheus` job is the first
real signal on that.

This PR does not close #1729 — the `query_exemplars` differential gap #1729 also names is
deliberately left for a follow-up (see the "query_exemplars — not in this PR" section above).
#1729 stays open to track that remainder.

