### PR TITLE
fix(ci): narrow forbid-deferral's bare "deferred" match to predicate grammar

### DIFF
--- a/.github/scripts/forbid-deferral.mjs
+++ b/.github/scripts/forbid-deferral.mjs
@@ -191,10 +191,25 @@ export const DEFERRAL_MARKERS = [
     // source of raw regex hits in this repository, and an unanchored
     // `defer(red|ring)?` would fire on `defer rows.Close()` in every file it
     // appears in. `defer` / `defers` / `defer func()` must not match; only the
-    // English participle does.
+    // English participle does, and only in PREDICATE position: right after a
+    // linking or passive-voice verb (a form of "to be", "remain", "stay",
+    // "get", or "left"), which is the grammar of a sentence whose whole point
+    // is that something did not happen. A bare, unconditional match on the
+    // participle is broader than that — it also matches ATTRIBUTIVE use,
+    // where the identical word modifies a noun to name an existing,
+    // already-shipped stage of a pipeline rather than postponed work. "the
+    // deferred label-shaping (-State/-Merge) shape" describes a feature that
+    // is fully built, not one whose work was put off, and reached a real diff
+    // (#1955) as exactly that false positive: a correct comment had to be
+    // reworded to get a clean run. Requiring the verb strips the attributive
+    // shape without losing the predicate one, which is the only shape the
+    // calibration corpus and this file's own test pin. A colon-suffixed label
+    // is kept as its own arm — the heading style commit messages on this repo
+    // used for a genuinely postponed test case before this gate existed —
+    // mirroring `followup-label` below.
     id: 'deferral-to-later',
     description: 'work postponed instead of done',
-    pattern: String.raw`\bdeferred\b|\bdefer(?:ring|red)\s+to\s+(?:a\s+)?(?:later|future|separate)\b`,
+    pattern: String.raw`\b(?:is|was|were|remains?|stays?|gets?|being|left)\s+deferred\b|\bdeferred[ \t]*:|\bdefer(?:ring|red)\s+to\s+(?:a\s+)?(?:later|future|separate)\b`,
   },
   {
     id: 'left-for-later',

--- a/.github/scripts/forbid-deferral.test.mjs
+++ b/.github/scripts/forbid-deferral.test.mjs
@@ -55,6 +55,7 @@ const TODO_WORD = lit('TO', 'DO');
 const FIXME_WORD = lit('FIX', 'ME');
 const XXX_WORD = lit('XX', 'X');
 const DEFERRED_WORD = lit('defer', 'red');
+const DEFERRED_COLON = lit('DEFER', 'RED:');
 const REVISIT_WORD = lit('re', 'visit');
 const FOLLOWUP_WORD = lit('Follow', '-up');
 const OUT_OF_SCOPE_PR = lit('out of scope ', 'for this PR');
@@ -148,6 +149,35 @@ test("Go's defer statement is not a deferral", () => {
   }
   // …while the English participle still does match.
   assert.deepEqual(ids(`the hoist is ${DEFERRED_WORD}`), ['deferral-to-later']);
+});
+
+test('attributive "deferred NOUN" describing already-shipped work is not a deferral', () => {
+  // The exact false-positive class found in a real, in-flight pull request
+  // (#1955): the participle modifying a noun to NAME an existing pipeline
+  // stage, not a verb complement saying the work was put off. The bare
+  // `\bdeferred\b` alternative used to fire on all three of these; only the
+  // PREDICATE form — right after a linking or passive-voice verb — should.
+  for (const line of [
+    'the deferred label-shaping (-State/-Merge) shape only exists on top of ' +
+      'a native rate grid, so it is read only where one is being built.',
+    'recollapseTower is the deferred-label-shaping expression the lowering assembles.',
+    'Deferred label shaping on the native grid keeps the rate node byte-identical.',
+    'the deferred close runs after the scan tears down its cursor.',
+  ]) {
+    assert.deepEqual(ids(line), [], `matched on: ${line}`);
+  }
+  // The predicate form the row exists to catch is the regression guard: it
+  // must still fire after the narrowing.
+  assert.deepEqual(ids(`the hoist is ${DEFERRED_WORD}`), ['deferral-to-later']);
+});
+
+test('a colon-suffixed label still matches, mirroring the follow-up heading form', () => {
+  // A real pre-gate example: a test case excluded with a leading label
+  // naming genuinely postponed work, rather than a predicate sentence.
+  assert.deepEqual(
+    ids(`${DEFERRED_COLON} the broadcast semantics divergence, a real gap`),
+    ['deferral-to-later'],
+  );
 });
 
 test('recording completed work is not deferring it', () => {


### PR DESCRIPTION
## Summary

`forbid-deferral.mjs`'s `deferral-to-later` marker had a bare bare-participle
alternative that matched the English word for "postponed" in ANY grammatical
position — including ATTRIBUTIVE use, where the word modifies a noun to name
an existing, already-shipped pipeline stage, not a verb complement saying
work was postponed. PR #1955 hit this false positive: a comment describing
the label-shaping (-State/-Merge) shape as an existing, already-built
pipeline stage was flagged as an untracked work marker, even though it
describes a feature that is fully implemented. That PR worked around it by
rewording the comment, which fixes one instance but not the underlying
scanner — the next legitimate use of the same participle ("deferred
execution", "deferred initialization", "deferred garbage collection")
anywhere in the repo would trip the same false positive.

## The fix

Require the bare participle to sit in PREDICATE position — right after a
linking or passive-voice verb (`is`/`was`/`were`/`remains`/`stays`/`gets`/
`being`/`left`) — which is the grammar of a sentence like "the hoist [verb]
[participle]", the only shape the calibration corpus and the file's own
pinned test (`forbid-deferral.test.mjs`'s `DEFERRED_WORD` case) exercise.
This strips the attributive shape (the participle directly modifying a noun)
without losing the predicate one.

I also grepped this repo's own history for real prior usage of the word to
check the narrowing doesn't drop legitimate coverage, and found one
colon-suffixed heading style used pre-gate for a genuinely postponed test
case — kept as an explicit additional alternative, mirroring
`followup-label`'s own heading/colon form below it in the same table.

## Tests added (`forbid-deferral.test.mjs`)

- A negative case pinning the exact false-positive shape from #1955 (plus a
  couple of related attributive constructions) — asserts none of them are
  flagged.
- The pre-existing positive test pinning the predicate shape is unchanged and
  still passes — the regression guard proving the narrowing isn't
  over-broad.
- A positive test for the new colon-suffixed label alternative.

## Verification

```
node --test .github/scripts/forbid-deferral.test.mjs
```

47/47 pass locally, including both new cases. Also confirmed the new pattern
doesn't self-match this PR's own diff (comments + commit message) by running
`findMarkers()` over the changed files and the commit message directly.

This is an internal CI-tooling correctness fix discovered as a side effect of
other work; it does not close any existing issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
