### PR TITLE
feat(compat/tempo-grpc): add the gRPC-side status-parity axis

### DIFF
--- a/.github/scripts/compat-ratchet.mjs
+++ b/.github/scripts/compat-ratchet.mjs
@@ -27,13 +27,17 @@
 // its count down a second time buys nothing a reader cannot get from the
 // baseline while costing every corpus-adding PR a merge conflict in this
 // file. doc-counts.mjs asserts the absence, so the restatement cannot
-// come back. tempo-grpc's floor is 3 below tempo's, and that difference
+// come back. tempo-grpc's floor is 2 below tempo's, and that difference
 // IS worth stating because it is structural rather than a count: traces
 // / traces_v2 have no StreamingQuerier RPC
-// (see compatibility/tempo/driver/grpc_diff.go), so those 2 corpus
-// cases never enter its roster, and one more (a -- expect_status --
-// rejection-parity case) is excluded pending #1714 (gRPC has no status
-// axis yet — see grpc_diff.go's skippedStatusParity).
+// (see compatibility/tempo/driver/grpc_diff.go), so those 2 corpus cases
+// never enter its roster. A corpus case that carries -- expect_status --
+// (the HTTP-only rejection-parity axis) without a sibling
+// -- expect_grpc_code -- (#1714's gRPC-side rejection-parity axis) is
+// excluded from the tempo-grpc roster the same way — see
+// grpc_diff.go's skippedStatusParity — but every case in THIS corpus
+// declares both, so today that exclusion is structural coverage rather
+// than an active gap.
 //
 // This is NOT an allow-list. An allow-list names the cases you are
 // permitted to fail; the roster names the cases that must pass, and

--- a/compatibility/parity-baseline.json
+++ b/compatibility/parity-baseline.json
@@ -1181,8 +1181,8 @@
       ]
     },
     "tempo-grpc": {
-      "passed": 71,
-      "total": 71,
+      "passed": 72,
+      "total": 72,
       "cases": [
         "metrics_instant | metrics_avg_over_time_instant",
         "metrics_instant | metrics_count_over_time_instant",
@@ -1252,6 +1252,7 @@
         "tags_v2 | tags_v2_intrinsic",
         "tags_v2 | tags_v2_link",
         "tags_v2 | tags_v2_resource",
+        "tags_v2 | tags_v2_scope_all_rejected",
         "tags_v2 | tags_v2_span",
         "tags_v2 | tags_v2_span_scoped_by_query",
         "tags_v2 | tags_v2_trace"

--- a/compatibility/tempo/driver/corpus.go
+++ b/compatibility/tempo/driver/corpus.go
@@ -73,6 +73,27 @@
 //	                            endpoint=traces / traces_v2 (those two run
 //	                            through the proto-aware differ in
 //	                            proto_fetch.go, which this axis does not cover).
+//	-- expect_grpc_code --      the gRPC-transport SIBLING of expect_status
+//	                            (#1714) — a google.golang.org/grpc/codes.Code
+//	                            both backends' StreamingQuerier RPC must fail
+//	                            with (status-parity axis — see
+//	                            grpc_diff.go::diffStatusParityCaseGRPC). Named
+//	                            either by the code's canonical String() form
+//	                            (e.g. "InvalidArgument") or its small integer
+//	                            value (e.g. "3"); "OK"/"0" is rejected — this
+//	                            axis exists for rejection parity, and the
+//	                            ordinary body-diff path already covers success.
+//	                            Independent of expect_status: HTTP status ints
+//	                            and gRPC codes are different domains with no
+//	                            canonical mapping between them, so a case
+//	                            wanting rejection-parity coverage on both
+//	                            transports sets both fields explicitly rather
+//	                            than one being derived from the other. Same
+//	                            mutual-exclusion rules as expect_status
+//	                            (no body-shape assertion), plus it is only
+//	                            valid on an endpoint grpcSupportsEndpoint
+//	                            recognizes (grpc_diff.go) — there is no RPC to
+//	                            fail on the others.
 //
 // There is intentionally no opt-out marker on a per-case basis: a case
 // that can't run is removed from the corpus, not flagged. Keeping the
@@ -102,6 +123,8 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+
+	"google.golang.org/grpc/codes"
 )
 
 // CorpusCase is one entry parsed out of the TXTAR file.
@@ -247,6 +270,25 @@ type CorpusCase struct {
 	// beyond both sides answering the usual way" and leaves the
 	// pre-existing 2xx-required behaviour untouched.
 	ExpectedStatus int
+
+	// ExpectedGRPCCode, when non-OK (the zero value, and the default),
+	// switches the case onto the gRPC transport's status-parity axis
+	// (grpc_diff.go::diffStatusParityCaseGRPC): the differ asserts BOTH
+	// backends' StreamingQuerier RPC fails with exactly this
+	// google.golang.org/grpc/codes.Code instead of requiring a clean
+	// response + running the body diff. This is the gRPC-transport
+	// SIBLING of ExpectedStatus (#1714), not a replacement for it — HTTP
+	// status ints and gRPC codes are different domains with no canonical
+	// 1:1 mapping, so a case wanting rejection-parity coverage on both
+	// transports sets BOTH fields independently. A case that sets only
+	// ExpectedStatus is HTTP-transport-only and is excluded from the
+	// tempo-grpc score (grpc_diff.go's skippedStatusParity accounting,
+	// documented in its report); one that sets only ExpectedGRPCCode
+	// runs the ordinary 2xx-required body-diff path on HTTP and the
+	// status-parity path on gRPC. parseGRPCCode (corpus.go) refuses to
+	// ever parse codes.OK, so the zero value is unambiguous: it can only
+	// mean "section absent," never "explicitly expects success."
+	ExpectedGRPCCode codes.Code
 }
 
 // LoadCorpus opens a corpus file and parses it into CorpusCases.
@@ -287,6 +329,7 @@ const (
 	secSamplesPerSeries = "expected_samples_per_series"
 	secSemanticChecks   = "semantic_checks"
 	secExpectStatus     = "expect_status"
+	secExpectGRPCCode   = "expect_grpc_code"
 )
 
 // stripCommentLines returns the body with comment-only lines (`# ...`
@@ -364,8 +407,90 @@ func applySection(cur *CorpusCase, section, body string) error {
 		appendNonEmptyLines(body, &cur.SemanticChecks)
 	case secExpectStatus:
 		return applyIntSection(body, "expect_status", &cur.ExpectedStatus)
+	case secExpectGRPCCode:
+		return applyGRPCCodeSection(body, &cur.ExpectedGRPCCode)
 	}
 	return nil
+}
+
+// applyGRPCCodeSection parses a -- expect_grpc_code -- body via
+// parseGRPCCode and stores it. An empty body (a header with no content)
+// is a no-op, matching applyIntSection's convention for the other
+// optional integer sections.
+func applyGRPCCodeSection(body string, dst *codes.Code) error {
+	if body == "" {
+		return nil
+	}
+	code, err := parseGRPCCode(body)
+	if err != nil {
+		return fmt.Errorf("expect_grpc_code: %w", err)
+	}
+	*dst = code
+	return nil
+}
+
+// grpcCodeByName maps every documented grpc/codes.Code's canonical
+// String() spelling (e.g. "InvalidArgument") back to its Code value, so
+// -- expect_grpc_code -- can name a code the way test failures and
+// grpcurl output already print it instead of forcing a corpus author to
+// memorise the small integer wire value. Built from the codes package's
+// own constants + their own String() method, rather than a hand-typed
+// string table, so it can never drift from what codes.Code.String()
+// actually produces.
+var grpcCodeByName = buildGRPCCodeByName()
+
+func buildGRPCCodeByName() map[string]codes.Code {
+	known := []codes.Code{
+		codes.OK, codes.Canceled, codes.Unknown, codes.InvalidArgument,
+		codes.DeadlineExceeded, codes.NotFound, codes.AlreadyExists,
+		codes.PermissionDenied, codes.ResourceExhausted, codes.FailedPrecondition,
+		codes.Aborted, codes.OutOfRange, codes.Unimplemented, codes.Internal,
+		codes.Unavailable, codes.DataLoss, codes.Unauthenticated,
+	}
+	m := make(map[string]codes.Code, len(known))
+	for _, c := range known {
+		m[c.String()] = c
+	}
+	return m
+}
+
+// maxKnownGRPCCode bounds the integer form -- expect_grpc_code -- accepts.
+// codes.Unauthenticated (16) is the highest code the grpc/codes package
+// defines as of the pinned dependency version — see buildGRPCCodeByName's
+// list, the single source of truth this is derived from rather than a
+// separately hand-typed number.
+const maxKnownGRPCCode = codes.Unauthenticated
+
+// parseGRPCCode parses a -- expect_grpc_code -- body as either an
+// explicit codes.Code name (its canonical String() spelling, e.g.
+// "InvalidArgument") or the equivalent small integer (e.g. "3"). Mirrors
+// -- expect_status --'s int-only parsing, adjusted for gRPC's status-code
+// domain: unlike HTTP status ints, codes.Code values are single small
+// digits with no memorable convention of their own, so the name form is
+// the one a corpus author will actually reach for.
+//
+// codes.OK is always rejected, regardless of which spelling names it —
+// this axis exists to express rejection parity, and the ordinary
+// body-diff path already covers the success case. That refusal is also
+// what keeps CorpusCase.ExpectedGRPCCode's zero value unambiguous: it can
+// only mean "section absent," never "explicitly expects OK."
+func parseGRPCCode(body string) (codes.Code, error) {
+	trimmed := strings.TrimSpace(body)
+	var code codes.Code
+	if n, err := strconv.Atoi(trimmed); err == nil {
+		if n < 0 || n > int(maxKnownGRPCCode) {
+			return 0, fmt.Errorf("integer code %d is outside the known range 0-%d", n, maxKnownGRPCCode)
+		}
+		code = codes.Code(n) //nolint:gosec // n is bounds-checked immediately above
+	} else if c, ok := grpcCodeByName[trimmed]; ok {
+		code = c
+	} else {
+		return 0, fmt.Errorf("unrecognised gRPC code %q (want an integer 0-%d or a codes.Code name like %q)", trimmed, maxKnownGRPCCode, codes.InvalidArgument)
+	}
+	if code == codes.OK {
+		return 0, fmt.Errorf("OK is not a valid expectation — this axis exists to express rejection parity, not success parity, which the ordinary body-diff path already covers")
+	}
+	return code, nil
 }
 
 // appendNonEmptyLines splits `body` on newlines and appends every
@@ -439,6 +564,9 @@ func validateCase(cur CorpusCase, ord int) (CorpusCase, error) {
 	if err := validateExpectedStatus(cur); err != nil {
 		return cur, err
 	}
+	if err := validateExpectedGRPCCode(cur); err != nil {
+		return cur, err
+	}
 	return cur, nil
 }
 
@@ -493,11 +621,41 @@ func validateExpectedStatus(cur CorpusCase) error {
 	if cur.Endpoint == "traces" || cur.Endpoint == "traces_v2" {
 		return fmt.Errorf("case %q: -- expect_status -- is not supported on endpoint=%s (that endpoint runs through the proto-aware differ, which this axis does not cover)", cur.Name, cur.Endpoint)
 	}
-	// Every field below is a body-shape assertion; diffStatusParityCase
-	// never parses the body, so any of these set alongside expect_status
-	// would be silently dead corpus weight — parsed but never checked.
-	// Rejecting the combination at load time beats a passing assertion
-	// that isn't actually asserting anything.
+	if hasBodyShapeAssertion(cur) {
+		return fmt.Errorf("case %q: -- expect_status -- cannot be combined with a body-shape assertion (expected_*/semantic_checks) — the status-parity path never parses the body", cur.Name)
+	}
+	return nil
+}
+
+// validateExpectedGRPCCode enforces the gRPC transport's status-parity
+// axis's invariants (#1714) — the sibling of validateExpectedStatus. A
+// zero ExpectedGRPCCode (the default, and the only value parseGRPCCode
+// will ever accept for codes.OK, which it refuses) skips every check
+// below — the case has no gRPC-side rejection expectation and none of
+// this applies.
+func validateExpectedGRPCCode(cur CorpusCase) error {
+	if cur.ExpectedGRPCCode == codes.OK {
+		return nil
+	}
+	if !grpcSupportsEndpoint(cur.Endpoint) {
+		return fmt.Errorf("case %q: -- expect_grpc_code -- is not supported on endpoint=%s (no StreamingQuerier RPC exists for it — see grpc_diff.go's grpcSupportsEndpoint)", cur.Name, cur.Endpoint)
+	}
+	// Same rationale as validateExpectedStatus: diffStatusParityCaseGRPC
+	// never parses either body, so a body-shape assertion alongside
+	// expect_grpc_code would be silently dead corpus weight.
+	if hasBodyShapeAssertion(cur) {
+		return fmt.Errorf("case %q: -- expect_grpc_code -- cannot be combined with a body-shape assertion (expected_*/semantic_checks) — the gRPC status-parity path never parses the body", cur.Name)
+	}
+	return nil
+}
+
+// hasBodyShapeAssertion reports whether the case carries any assertion
+// that requires a parsed response body. Shared by validateExpectedStatus
+// and validateExpectedGRPCCode: both status-parity axes short-circuit
+// before either body is ever parsed (diff.go's diffStatusParityCase,
+// grpc_diff.go's diffStatusParityCaseGRPC), so any of these fields set
+// alongside either axis would be an assertion that never runs.
+func hasBodyShapeAssertion(cur CorpusCase) bool {
 	switch {
 	case cur.ExpectedMinTraces != 0, cur.ExpectedMaxTraces != 0,
 		cur.ExpectedMinValues != 0, cur.ExpectedMaxValues != 0,
@@ -506,9 +664,9 @@ func validateExpectedStatus(cur CorpusCase) error {
 		len(cur.ExpectedServices) != 0, cur.ExpectedRootNameRE != nil,
 		cur.ExpectedMinSeries != 0, cur.ExpectedMaxSeries != 0,
 		cur.ExpectedSamplesPerSeries != 0, len(cur.SemanticChecks) != 0:
-		return fmt.Errorf("case %q: -- expect_status -- cannot be combined with a body-shape assertion (expected_*/semantic_checks) — the status-parity path never parses the body", cur.Name)
+		return true
 	}
-	return nil
+	return false
 }
 
 // isTagEndpoint reports whether the given endpoint is one of the four
@@ -533,7 +691,7 @@ func isKnownSection(name string) bool {
 		secMinTraces, secMaxTraces, secMinValues, secMaxValues,
 		secValues, secAbsentValues, secScopes, secServices, secRootNameRE,
 		secMinSeries, secMaxSeries, secSamplesPerSeries, secSemanticChecks,
-		secExpectStatus:
+		secExpectStatus, secExpectGRPCCode:
 		return true
 	}
 	return false

--- a/compatibility/tempo/driver/corpus/smoke.txtar
+++ b/compatibility/tempo/driver/corpus/smoke.txtar
@@ -790,8 +790,19 @@ all
 # reject with "invalid scope: all", so this proves the axis end-to-end.
 # The four cases below pin the other direction: every scope upstream
 # *does* accept is a 200 here too.
+#
+# Also carries the gRPC-side sibling (#1714): -- expect_grpc_code --.
+# Grounded by reading both implementations rather than guessed —
+# cerberus's SearchTagsV2 (internal/api/tempo/grpc/tags.go) wraps a
+# ParseTagScope failure as status.Error(codes.InvalidArgument, ...);
+# reference Tempo's streaming combiner
+# (modules/frontend/combiner/common.go's erroredResponse) maps its own
+# HTTP 400 sub-response to the identical codes.InvalidArgument. Both
+# sides agree without a mapping function existing anywhere.
 -- expect_status --
 400
+-- expect_grpc_code --
+InvalidArgument
 
 -- name --
 tags_v2_event

--- a/compatibility/tempo/driver/corpus_test.go
+++ b/compatibility/tempo/driver/corpus_test.go
@@ -5,6 +5,8 @@ import (
 	"slices"
 	"strings"
 	"testing"
+
+	"google.golang.org/grpc/codes"
 )
 
 func TestParseCorpus_Basic(t *testing.T) {
@@ -487,6 +489,160 @@ search
 `
 	if _, err := parseCorpus(strings.NewReader(in), "test"); err == nil {
 		t.Fatal("expect_status combined with a body-shape assertion should fail — the status-parity path never parses the body, so expected_min_traces would silently never run")
+	}
+}
+
+func TestParseCorpus_ExpectGRPCCodeByName(t *testing.T) {
+	t.Parallel()
+	in := `-- name --
+bad_scope
+-- endpoint --
+tags_v2
+-- scope --
+all
+-- expect_grpc_code --
+InvalidArgument
+`
+	got, err := parseCorpus(strings.NewReader(in), "test")
+	if err != nil {
+		t.Fatalf("parseCorpus: %v", err)
+	}
+	if got[0].ExpectedGRPCCode != codes.InvalidArgument {
+		t.Fatalf("ExpectedGRPCCode = %s, want InvalidArgument", got[0].ExpectedGRPCCode)
+	}
+}
+
+func TestParseCorpus_ExpectGRPCCodeByInt(t *testing.T) {
+	t.Parallel()
+	in := `-- name --
+bad_scope
+-- endpoint --
+tags_v2
+-- scope --
+all
+-- expect_grpc_code --
+3
+`
+	got, err := parseCorpus(strings.NewReader(in), "test")
+	if err != nil {
+		t.Fatalf("parseCorpus: %v", err)
+	}
+	if got[0].ExpectedGRPCCode != codes.InvalidArgument {
+		t.Fatalf("ExpectedGRPCCode = %s, want InvalidArgument (int form)", got[0].ExpectedGRPCCode)
+	}
+}
+
+func TestParseCorpus_ExpectGRPCCodeRejectsOK(t *testing.T) {
+	t.Parallel()
+	for _, body := range []string{"OK", "0"} {
+		body := body
+		t.Run(body, func(t *testing.T) {
+			t.Parallel()
+			in := `-- name --
+bad
+-- query --
+{ x = 1 }
+-- endpoint --
+search
+-- expect_grpc_code --
+` + body + "\n"
+			if _, err := parseCorpus(strings.NewReader(in), "test"); err == nil {
+				t.Fatal("expect_grpc_code OK should fail — this axis exists to express rejection parity, not success parity")
+			}
+		})
+	}
+}
+
+func TestParseCorpus_ExpectGRPCCodeRejectsUnrecognisedName(t *testing.T) {
+	t.Parallel()
+	in := `-- name --
+bad
+-- query --
+{ x = 1 }
+-- endpoint --
+search
+-- expect_grpc_code --
+NotACode
+`
+	if _, err := parseCorpus(strings.NewReader(in), "test"); err == nil {
+		t.Fatal("expect_grpc_code with an unrecognised name should fail")
+	}
+}
+
+func TestParseCorpus_ExpectGRPCCodeRejectsOutOfRangeInt(t *testing.T) {
+	t.Parallel()
+	in := `-- name --
+bad
+-- query --
+{ x = 1 }
+-- endpoint --
+search
+-- expect_grpc_code --
+999
+`
+	if _, err := parseCorpus(strings.NewReader(in), "test"); err == nil {
+		t.Fatal("expect_grpc_code with an out-of-range int should fail")
+	}
+}
+
+func TestParseCorpus_ExpectGRPCCodeRejectsEndpointWithNoRPC(t *testing.T) {
+	t.Parallel()
+	in := `-- name --
+bad
+-- endpoint --
+traces
+-- traceid_template --
+svc/0
+-- expect_grpc_code --
+InvalidArgument
+`
+	if _, err := parseCorpus(strings.NewReader(in), "test"); err == nil {
+		t.Fatal("expect_grpc_code on endpoint=traces should fail — no StreamingQuerier RPC exists for it")
+	}
+}
+
+func TestParseCorpus_ExpectGRPCCodeRejectsBodyAssertionCombo(t *testing.T) {
+	t.Parallel()
+	in := `-- name --
+bad
+-- query --
+{ x = 1 }
+-- endpoint --
+search
+-- expect_grpc_code --
+InvalidArgument
+-- expected_min_traces --
+1
+`
+	if _, err := parseCorpus(strings.NewReader(in), "test"); err == nil {
+		t.Fatal("expect_grpc_code combined with a body-shape assertion should fail — the gRPC status-parity path never parses the body")
+	}
+}
+
+// TestParseCorpus_ExpectGRPCCodeIndependentOfExpectStatus pins the
+// sibling relationship (#1714): a case may carry expect_grpc_code
+// without expect_status (HTTP-transport runs the ordinary body-diff
+// path; only the gRPC transport treats this case as a rejection).
+func TestParseCorpus_ExpectGRPCCodeIndependentOfExpectStatus(t *testing.T) {
+	t.Parallel()
+	in := `-- name --
+bad_scope
+-- endpoint --
+tags_v2
+-- scope --
+all
+-- expect_grpc_code --
+InvalidArgument
+`
+	got, err := parseCorpus(strings.NewReader(in), "test")
+	if err != nil {
+		t.Fatalf("parseCorpus: %v", err)
+	}
+	if got[0].ExpectedStatus != 0 {
+		t.Fatalf("ExpectedStatus = %d, want 0 (unset)", got[0].ExpectedStatus)
+	}
+	if got[0].ExpectedGRPCCode != codes.InvalidArgument {
+		t.Fatalf("ExpectedGRPCCode = %s, want InvalidArgument", got[0].ExpectedGRPCCode)
 	}
 }
 

--- a/compatibility/tempo/driver/grpc_diff.go
+++ b/compatibility/tempo/driver/grpc_diff.go
@@ -63,7 +63,9 @@ import (
 
 	"github.com/grafana/tempo/pkg/tempopb"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	grpcstatus "google.golang.org/grpc/status"
 
 	"github.com/tsouza/cerberus/compatibility/internal/score"
 )
@@ -204,17 +206,18 @@ func runDiffGRPC(args []string) error {
 		case !grpcSupportsEndpoint(tc.Endpoint):
 			skippedNoRPC = append(skippedNoRPC, tc)
 			continue
-		case tc.ExpectedStatus != 0:
-			// The status-parity axis (-- expect_status --, diff.go's
-			// diffStatusParityCase) compares HTTP status ints. gRPC
-			// surfaces failures as codes.Code via status.FromError — a
-			// different domain with no canonical mapping — and
-			// diffCaseGRPC treats any non-nil RPC error as an
-			// unconditional HardError, so running an ExpectedStatus case
-			// through this transport unmodified would silently mis-grade
-			// it. Tracked as a distinct gRPC-side axis in #1714; until
-			// that lands, these cases are HTTP-transport-only, reported
-			// here rather than dropped.
+		case tc.ExpectedStatus != 0 && tc.ExpectedGRPCCode == codes.OK:
+			// The HTTP-only status-parity axis (-- expect_status --,
+			// diff.go's diffStatusParityCase) compares HTTP status ints.
+			// gRPC surfaces failures as codes.Code via status.FromError —
+			// a different domain with no canonical mapping — so a case
+			// with no -- expect_grpc_code -- sibling (#1714) has nothing
+			// for this transport to grade against. Running it through
+			// diffCaseGRPC unmodified would silently mis-grade a genuine
+			// rejection-parity case as a HardError, so it's skipped and
+			// reported here instead. A case that DOES carry
+			// -- expect_grpc_code -- falls through to diffCaseGRPC below,
+			// which routes it to diffStatusParityCaseGRPC.
 			skippedStatusParity = append(skippedStatusParity, tc)
 			continue
 		}
@@ -265,6 +268,15 @@ func diffCaseGRPC(ctx context.Context, tempoClient, cerbClient tempopb.Streaming
 
 	tempoBody, terr := fetchGRPCForEndpoint(ctx, tempoClient, tc, opts)
 	cerbBody, cerr := fetchGRPCForEndpoint(ctx, cerbClient, tc, opts)
+
+	// gRPC-side status-parity axis (#1714), the sibling of diff.go's
+	// ExpectedStatus branch: a case declaring -- expect_grpc_code --
+	// never reaches the body-diff path below — the whole point is that
+	// an RPC error IS the correct outcome here, not a hard error.
+	if tc.ExpectedGRPCCode != codes.OK {
+		return diffStatusParityCaseGRPC(tc, terr, cerr)
+	}
+
 	if terr != nil {
 		res.HardError = fmt.Sprintf("tempo grpc: %v", terr)
 	}
@@ -313,6 +325,53 @@ func diffCaseGRPC(ctx context.Context, tempoClient, cerbClient tempopb.Streaming
 		return res
 	}
 	res.Diff = d
+	return res
+}
+
+// diffStatusParityCaseGRPC is diffCaseGRPC's status-parity branch, taken
+// when the corpus case sets ExpectedGRPCCode (#1714). It is the gRPC
+// transport's sibling of diff.go's diffStatusParityCase: gRPC surfaces
+// failures as a google.golang.org/grpc/codes.Code via status.FromError
+// rather than an HTTP status int, so this compares that instead — the
+// same rejection-parity shape as the HTTP axis, on a different wire
+// domain, deliberately not mapped onto it (see corpus.go's
+// ExpectedGRPCCode doc for why the two axes stay independent).
+//
+// status.FromError's `ok` return is the signal this uses to tell "the
+// RPC completed with a real status" from "no usable response at all":
+// per its doc, ok is true whenever err is nil (codes.OK) or err carries
+// an actual gRPC Status, and false only for a non-status error (a
+// transport-level failure such as a refused dial before any RPC frame
+// was exchanged). The latter is a genuine hard error — there is no code
+// to grade — exactly like diffStatusParityCase's zero-HTTP-status case.
+func diffStatusParityCaseGRPC(tc CorpusCase, terr, cerr error) CaseResult {
+	tempoSt, tempoOK := grpcstatus.FromError(terr)
+	if !tempoOK {
+		return CaseResult{Case: tc, HardError: fmt.Sprintf("tempo grpc: %v", terr)}
+	}
+	cerbSt, cerbOK := grpcstatus.FromError(cerr)
+	if !cerbOK {
+		return CaseResult{Case: tc, HardError: fmt.Sprintf("cerberus grpc: %v", cerr)}
+	}
+
+	res := CaseResult{Case: tc, TempoStatus: int(tempoSt.Code()), CerberusStatus: int(cerbSt.Code())}
+	if tempoSt.Code() != tc.ExpectedGRPCCode {
+		res.Assertions = append(res.Assertions, DiffReason{
+			Kind:   "grpc_code_mismatch",
+			Detail: fmt.Sprintf("tempo returned gRPC code %s, corpus -- expect_grpc_code -- says %s", tempoSt.Code(), tc.ExpectedGRPCCode),
+		})
+	}
+	if cerbSt.Code() != tc.ExpectedGRPCCode {
+		res.Assertions = append(res.Assertions, DiffReason{
+			Kind:   "grpc_code_mismatch",
+			Detail: fmt.Sprintf("cerberus returned gRPC code %s, corpus -- expect_grpc_code -- says %s", cerbSt.Code(), tc.ExpectedGRPCCode),
+		})
+	}
+	// No body was parsed, so there is no structural diff to compute —
+	// mark it trivially Equal so passed() (HardError=="" && Diff.Equal &&
+	// len(Assertions)==0) reduces to "did the codes match", mirroring
+	// diffStatusParityCase.
+	res.Diff = Diff{Equal: true}
 	return res
 }
 
@@ -607,7 +666,9 @@ func metricsSeriesFromProtoRange(ts *tempopb.TimeSeries) MetricsSeriesEntry {
 // transport genuinely can't run — documented, not silently dropped.
 // skippedNoRPC is endpoints with no StreamingQuerier RPC counterpart at
 // all (traces/traces_v2); skippedStatusParity is expect_status cases
-// this transport doesn't yet grade (tracked in #1714).
+// with no -- expect_grpc_code -- sibling declared (#1714 built the axis,
+// but a case must opt into gRPC-side grading explicitly — HTTP status
+// ints and gRPC codes are different domains with no canonical mapping).
 func writeReportGRPC(path string, results []CaseResult, skippedNoRPC, skippedStatusParity []CorpusCase) error {
 	if err := writeReport(path, grpcReportTitle, grpcStatusLabel, results); err != nil {
 		return err
@@ -637,13 +698,15 @@ func writeReportGRPC(path string, results []CaseResult, skippedNoRPC, skippedSta
 	if len(skippedStatusParity) > 0 {
 		if err := renderSkippedSection(
 			f, skippedStatusParity,
-			"## Skipped — expect_status axis not yet implemented for gRPC",
-			"These corpus cases carry -- expect_status --, a rejection-parity "+
-				"axis compared against the HTTP status int (diff.go's "+
-				"diffStatusParityCase). gRPC surfaces failures as "+
-				"codes.Code via status.FromError, a different domain with no "+
-				"canonical mapping to HTTP status, and this transport doesn't "+
-				"grade that yet (tracked in #1714). The %d case(s) below are "+
+			"## Skipped — expect_status has no gRPC-side expect_grpc_code",
+			"These corpus cases carry -- expect_status --, the HTTP-only "+
+				"rejection-parity axis compared against the HTTP status int "+
+				"(diff.go's diffStatusParityCase), but no -- expect_grpc_code -- "+
+				"sibling (#1714) declaring what this transport should see "+
+				"instead. HTTP status ints and gRPC codes.Code values are "+
+				"different domains with no canonical mapping between them, so a "+
+				"case wanting gRPC-side rejection-parity coverage must declare "+
+				"its own expectation explicitly. The %d case(s) below are "+
 				"excluded from the score denominator rather than counted as "+
 				"failures:\n\n",
 		); err != nil {

--- a/compatibility/tempo/driver/grpc_diff_test.go
+++ b/compatibility/tempo/driver/grpc_diff_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/grafana/tempo/pkg/tempopb"
 	v1 "github.com/grafana/tempo/pkg/tempopb/common/v1"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
 )
 
 // The gRPC transport's whole claim is that it is a transport-only
@@ -632,6 +634,89 @@ func TestDiffCaseGRPC_HardErrorsNameTheFailingSide(t *testing.T) {
 	}
 }
 
+func TestDiffStatusParityCaseGRPC_BothMatchExpectation_Passes(t *testing.T) {
+	t.Parallel()
+	tc := CorpusCase{Name: "bad_scope", ExpectedGRPCCode: codes.InvalidArgument}
+	terr := grpcstatus.Error(codes.InvalidArgument, "invalid scope: all")
+	cerr := grpcstatus.Error(codes.InvalidArgument, "invalid scope: all")
+	res := diffStatusParityCaseGRPC(tc, terr, cerr)
+	if !res.passed() {
+		t.Fatalf("expected passed()==true, got HardError=%q Assertions=%v Diff=%+v", res.HardError, res.Assertions, res.Diff)
+	}
+	if len(res.Assertions) != 0 {
+		t.Fatalf("expected no assertions, got %v", res.Assertions)
+	}
+	if res.TempoStatus != int(codes.InvalidArgument) || res.CerberusStatus != int(codes.InvalidArgument) {
+		t.Fatalf("TempoStatus/CerberusStatus = %d/%d, want both %d", res.TempoStatus, res.CerberusStatus, codes.InvalidArgument)
+	}
+}
+
+// TestDiffStatusParityCaseGRPC_MismatchCaught proves the axis is
+// non-vacuous: a corpus case declaring expect_grpc_code must actually
+// FAIL when either backend's real code diverges from the declaration.
+func TestDiffStatusParityCaseGRPC_MismatchCaught(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name               string
+		terr               error
+		cerr               error
+		wantAssertionCount int
+	}{
+		{"tempo returns OK instead of the declared code", nil, grpcstatus.Error(codes.InvalidArgument, "x"), 1},
+		{"cerberus returns OK instead of the declared code", grpcstatus.Error(codes.InvalidArgument, "x"), nil, 1},
+		{"both sides diverge from the declaration", grpcstatus.Error(codes.Internal, "x"), nil, 2},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			tc := CorpusCase{Name: "bad_scope", ExpectedGRPCCode: codes.InvalidArgument}
+			res := diffStatusParityCaseGRPC(tc, c.terr, c.cerr)
+			if res.passed() {
+				t.Fatalf("expected passed()==false for terr=%v cerr=%v expect=%s", c.terr, c.cerr, codes.InvalidArgument)
+			}
+			if res.HardError != "" {
+				t.Fatalf("a code mismatch is a real outcome, not a hard error; got HardError=%q", res.HardError)
+			}
+			if len(res.Assertions) != c.wantAssertionCount {
+				t.Fatalf("Assertions = %v, want %d entries", res.Assertions, c.wantAssertionCount)
+			}
+			for _, a := range res.Assertions {
+				if a.Kind != "grpc_code_mismatch" {
+					t.Errorf("assertion Kind = %q, want grpc_code_mismatch", a.Kind)
+				}
+			}
+		})
+	}
+}
+
+func TestDiffStatusParityCaseGRPC_NonStatusErrorIsHardError(t *testing.T) {
+	t.Parallel()
+	tc := CorpusCase{Name: "bad_scope", ExpectedGRPCCode: codes.InvalidArgument}
+	res := diffStatusParityCaseGRPC(tc, errors.New("dial tcp: connection refused"), grpcstatus.Error(codes.InvalidArgument, "x"))
+	if res.HardError == "" {
+		t.Fatal("a non-status error (no real gRPC response at all) must hard-error rather than being graded as a mismatch")
+	}
+	if res.passed() {
+		t.Fatal("a hard error must never pass")
+	}
+}
+
+// TestDiffCaseGRPC_RoutesExpectedGRPCCodeToStatusParity proves the
+// wiring end-to-end: a case carrying ExpectedGRPCCode never reaches the
+// ordinary body-diff path even though fetchGRPCForEndpoint's open-stream
+// error is what actually carries the code.
+func TestDiffCaseGRPC_RoutesExpectedGRPCCodeToStatusParity(t *testing.T) {
+	t.Parallel()
+	tc := CorpusCase{Name: "bad_scope", Endpoint: "tags_v2", Scope: "all", ExpectedGRPCCode: codes.InvalidArgument}
+	rejecting := func() *fakeQuerier {
+		return &fakeQuerier{openErr: grpcstatus.Error(codes.InvalidArgument, "invalid scope: all")}
+	}
+	res := diffCaseGRPC(context.Background(), rejecting(), rejecting(), tc, testOpts())
+	if !res.passed() {
+		t.Fatalf("expected passed()==true for two agreeing rejections, got HardError=%q Assertions=%v", res.HardError, res.Assertions)
+	}
+}
+
 func TestWriteReportGRPC_DocumentsSkippedCases(t *testing.T) {
 	t.Parallel()
 	path := filepath.Join(t.TempDir(), "nested", "report.md")
@@ -657,7 +742,7 @@ func TestWriteReportGRPC_DocumentsSkippedCases(t *testing.T) {
 	if !strings.Contains(report, "## Skipped — no StreamingQuerier RPC for this endpoint") {
 		t.Fatalf("no-RPC skip section missing:\n%s", report)
 	}
-	if !strings.Contains(report, "## Skipped — expect_status axis not yet implemented for gRPC") {
+	if !strings.Contains(report, "## Skipped — expect_status has no gRPC-side expect_grpc_code") {
 		t.Fatalf("status-parity skip section missing:\n%s", report)
 	}
 	// The count in the explanation is the section's own case count.


### PR DESCRIPTION
## Summary

Closes #1714 by building the gRPC transport's sibling of the HTTP `-- expect_status --` rejection-parity axis (landed on main via `diffStatusParityCase` / `CorpusCase.ExpectedStatus`).

- **New TXTAR axis**: `-- expect_grpc_code --` (`corpus.go`), parsed into `CorpusCase.ExpectedGRPCCode` (a `codes.Code`, named either by its canonical `String()` spelling — e.g. `InvalidArgument` — or its small integer value). `codes.OK` is always rejected (this axis expresses rejection parity only), which is also what keeps the field's zero value unambiguous as "section absent." Independent of `-- expect_status --` by design — HTTP status ints and gRPC codes are different domains with no canonical 1:1 mapping, so a case wanting coverage on both transports declares both explicitly.
- **`diffStatusParityCaseGRPC`** (`grpc_diff.go`), the sibling of `diffStatusParityCase`, reusing the same `Assertions`/`DiffReason` mechanism (`grpc_code_mismatch`). Uses `status.FromError`'s `ok` return to distinguish "the RPC completed with a real status" (grade it) from "no usable response at all" (hard error) — the gRPC-domain equivalent of the HTTP axis's zero-status check.
- **Scoping**: `runDiffGRPC`'s existing `skippedStatusParity` exclusion (previously "any `-- expect_status --` case, unconditionally") now only fires when a case carries `-- expect_status --` **without** a `-- expect_grpc_code --` sibling — it still reports in the same documented "skipped, and why" section and stays out of the score denominator, exactly mirroring the pre-existing `traces`/`traces_v2` exclusion pattern. A case with both falls through to `diffCaseGRPC`, which now routes `ExpectedGRPCCode`-bearing cases to the new path before ever reaching the ordinary body-diff branch.
- **Fixture**: augmented the existing `tags_v2_scope_all_rejected` case (`corpus/smoke.txtar`) with `-- expect_grpc_code --\nInvalidArgument`.
- **`compatibility/parity-baseline.json`**: added `tags_v2 | tags_v2_scope_all_rejected` to `heads.tempo-grpc.cases` (72/72, was 71/71). Updated `compat-ratchet.mjs`'s header comment (tempo-grpc's floor is now 2 below tempo's — `traces`/`traces_v2` only — instead of 3).

## Design note (judgment call, since live verification is CI-only)

The issue explicitly acknowledges live-infra verification can't happen before merge. Rather than guess at a status-code mapping, I grounded the one fixture by reading the actual implementations on both sides:

- **cerberus**: `internal/api/tempo/grpc/tags.go`'s `SearchTagsV2` wraps a `tempo.ParseTagScope` failure as `status.Error(codes.InvalidArgument, ...)` — consistent with the documented HTTP↔gRPC correspondence table in `internal/api/tempo/grpc/errclass.go` (`ErrClassParse` → 400 / `InvalidArgument`).
- **reference Tempo** (`github.com/grafana/tempo`, already vendored in `go.mod` for `tempopb`): the streaming-gRPC path builds an internal HTTP request and round-trips it through the *same* query-frontend pipeline as the HTTP handler; `modules/frontend/combiner/common.go`'s `genericCombiner.erroredResponse()` explicitly maps `http.StatusBadRequest` → `status.Error(codes.InvalidArgument, ...)` for the gRPC arm.

Both sides land on `codes.InvalidArgument` for this exact request shape without any mapping function existing between the two axes anywhere — grounded in source, not guessed. If CI's `compat-tempo-grpc` run (real containers) disagrees, that's the one thing only CI can confirm, and I'll push a follow-up fix from the actual failure.

Also hit and fixed an unrelated footgun along the way: `goimports` in this environment kept resolving the bare `status` identifier to `github.com/gogo/status` (a real transitive dependency of `grafana/tempo`) instead of `google.golang.org/grpc/status` — a different, non-interoperable implementation whose `FromError` doesn't unwrap `%w`-wrapped errors the way grpc-go's does. Fixed by aliasing the import (`grpcstatus "google.golang.org/grpc/status"`) in both `grpc_diff.go` and `grpc_diff_test.go`, which removes the ambiguity goimports was resolving incorrectly.

## Verified locally

- `go build ./...`, `go vet ./compatibility/...` — clean.
- `go test -race ./compatibility/tempo/driver/...` — all pass, including new tests: corpus parsing/validation (`TestParseCorpus_ExpectGRPCCode*`, 8 cases covering name/int parsing, OK-rejection, unknown-name/out-of-range rejection, endpoint-scoping rejection, body-assertion-combo rejection, independence from `expect_status`), `diffStatusParityCaseGRPC` (match/mismatch/non-status-hard-error, mirroring the existing `diffStatusParityCase` test shape), and an end-to-end `diffCaseGRPC` routing test.
- `gofumpt -extra -l` — clean.
- `node .github/scripts/forbid-sql-raw.mjs`, `doc-counts.mjs`, `generated-baseline-structural-guard.mjs`, `compat-ratchet.mjs`'s and `compat-baseline-sync.mjs`'s own `node --test` suites — all clean/passing.
- Confirmed via a throwaway test that `LoadCorpus` on the real `corpus/smoke.txtar` parses the augmented fixture with both `ExpectedStatus: 400` and `ExpectedGRPCCode: InvalidArgument` set correctly.

## Only CI can confirm

- `compatibility/tempo` job's gRPC arm (`compat-tempo-grpc`) actually running the new fixture against live reference Tempo + cerberus gRPC listeners and getting `codes.InvalidArgument` on both sides, per the design note above.
- `lint` (golangci-lint) — per this repo's CLAUDE.md, an agent-worktree run isn't evidence.

## Test plan

- [ ] CI's `compatibility/tempo` job (gRPC arm) confirms the new fixture passes against live containers
- [ ] `lint` green

Closes #1714