### PR TITLE
fix(rejection-parity): admit reference-verbatim guard messages into the catalogue

### DIFF
--- a/internal/promql/scalar_domain.go
+++ b/internal/promql/scalar_domain.go
@@ -5,6 +5,25 @@ import (
 	"math"
 )
 
+// verbatimErrorf constructs an error whose message reproduces a
+// reference backend's own wording byte for byte — never prefixed with
+// "promql: " the way every other lowering error is, because the prefix
+// would be cerberus's own annotation on a sentence reference itself
+// wrote.
+//
+// It exists as a named wrapper, rather than a bare fmt.Errorf call,
+// so the rejection-parity scanner (isErrorConstructor in
+// test/rejection-parity/catalogue.go) can recognise these five call
+// sites by name and admit them into the catalogue despite the missing
+// prefix its normal filter requires. That recognition is scoped to
+// calls written exactly this way — the five domain-violation sites in
+// this file are the only ones in the package that should ever call it;
+// see the doc comment on this file for why their wording cannot be
+// cerberus's own.
+func verbatimErrorf(format string, args ...any) error {
+	return fmt.Errorf(format, args...)
+}
+
 // Reference Prometheus rejects a handful of scalar *parameter* values at
 // evaluation time rather than at parse time: a topk K that is NaN or too
 // large to become an int64, a limit_ratio ratio that is NaN, a
@@ -77,11 +96,11 @@ func aggregationParamDomain(values []float64) (empty bool, err error) {
 	case mx < aggregationParamMinK:
 		return true, nil
 	case hasAnyNaN(values):
-		return false, fmt.Errorf("Parameter value is NaN") //nolint:staticcheck,revive // reference Prometheus's own error text, reproduced verbatim
+		return false, verbatimErrorf("Parameter value is NaN")
 	case mn <= aggParamMinInt64:
-		return false, fmt.Errorf("Scalar value %v underflows int64", mn) //nolint:staticcheck,revive // reference Prometheus's own error text, reproduced verbatim
+		return false, verbatimErrorf("Scalar value %v underflows int64", mn)
 	case mx >= aggParamMaxInt64:
-		return false, fmt.Errorf("Scalar value %v overflows int64", mx) //nolint:staticcheck,revive // reference Prometheus's own error text, reproduced verbatim
+		return false, verbatimErrorf("Scalar value %v overflows int64", mx)
 	}
 	return false, nil
 }
@@ -103,7 +122,7 @@ func limitRatioParamDomain(values []float64) (empty bool, err error) {
 	case mx == 0 && mn == 0:
 		return true, nil
 	case hasAnyNaN(values):
-		return false, fmt.Errorf("Ratio value is NaN") //nolint:staticcheck,revive // reference Prometheus's own error text, reproduced verbatim
+		return false, verbatimErrorf("Ratio value is NaN")
 	}
 	return false, nil
 }
@@ -149,7 +168,7 @@ var (
 func holtWintersFactorDomain(kind holtWintersFactorKind, values []float64) error {
 	for _, v := range values {
 		if v <= 0 || v >= 1 {
-			return fmt.Errorf( //nolint:staticcheck,revive // reference Prometheus's own error text, reproduced verbatim
+			return verbatimErrorf(
 				"invalid %s factor. Expected: 0 < %s < 1, got: %f", kind.noun, kind.symbol, v,
 			)
 		}

--- a/test/rejection-parity/catalogue.go
+++ b/test/rejection-parity/catalogue.go
@@ -18,7 +18,10 @@ import (
 // heads maps each lowering package directory (relative to the repo
 // root) to its head identifier. The head identifier doubles as the
 // required error-message prefix ("promql: ..."), which every error
-// site in the three packages carries by convention.
+// site in the three packages carries by convention — except a site
+// built through [verbatimErrorConstructor], whose message is a
+// reference backend's own wording and is exempt; see
+// isErrorConstructor.
 var heads = map[string]string{
 	"internal/promql":  "promql",
 	"internal/logql":   "logql",
@@ -93,6 +96,23 @@ type Entry struct {
 	// rejections set "traceql_metrics" because /api/search does not
 	// accept metrics expressions.
 	Endpoint string `json:"endpoint,omitempty"`
+
+	// GuardValues (class=rejection only, promql head only) is the
+	// per-step value series fed directly to a registered
+	// promql.ScalarGuard's Check when TriggerQuery alone cannot reach
+	// the site: a lowering-time rejection is proved by lowering and
+	// requiring an error (the TestRejectionTriggersExerciseSites
+	// default), but an execution-time guard's Check only ever runs
+	// against values ClickHouse would have produced, and some domain
+	// branches (the int64-underflow arm of aggregationParamDomain) are
+	// reachable only by a multi-step series a single lowering call can
+	// never produce. When GuardValues is set, the exerciser instead
+	// lowers TriggerQuery with a guard sink, requires lowering to
+	// SUCCEED with exactly one registered guard, and applies that
+	// guard's Check to GuardValues — mirroring the call shape
+	// internal/engine/engine.go's runGuards uses in production, minus
+	// the ClickHouse round trip.
+	GuardValues []float64 `json:"guard_values,omitempty"`
 
 	// Rationale (class=internal) documents why the site is not a
 	// wire-reachable semantic rejection.
@@ -406,11 +426,15 @@ func scanFunc(sc *astScope, fn *ast.FuncDecl, relPath, head, prefix string) ([]S
 		if !ok || len(call.Args) == 0 {
 			return true
 		}
-		if !isErrorConstructor(call.Fun) {
+		verbatim, ok := isErrorConstructor(call.Fun)
+		if !ok {
 			return true
 		}
 		msg, ok := stringLiteral(call.Args[0])
-		if !ok || !strings.HasPrefix(msg, prefix) {
+		if !ok {
+			return true
+		}
+		if !verbatim && !strings.HasPrefix(msg, prefix) {
 			return true
 		}
 		seen[msg]++
@@ -429,23 +453,51 @@ func scanFunc(sc *astScope, fn *ast.FuncDecl, relPath, head, prefix string) ([]S
 	return out, evidence
 }
 
-// isErrorConstructor matches fmt.Errorf and errors.New selector calls.
-func isErrorConstructor(fun ast.Expr) bool {
-	sel, ok := fun.(*ast.SelectorExpr)
-	if !ok {
-		return false
+// verbatimErrorConstructor is the identifier of the package-local
+// wrapper a lowering package calls to construct an error whose message
+// reproduces a reference backend's own wording byte for byte — see
+// promql.verbatimErrorf, the one definition today. Matched by name only,
+// the same way fmt.Errorf and errors.New are matched below: the scanner
+// does not type-check or resolve imports, so any lowering package that
+// declares a same-named function opts its calls into the catalogue on
+// the same terms. That is deliberate — the exemption from the head
+// prefix belongs to the call site that asks for it, not to a blanket
+// rule over unprefixed errors, which would admit every accidental typo
+// of the "<head>: " convention along with the handful of sites that
+// truly need it.
+const verbatimErrorConstructor = "verbatimErrorf"
+
+// isErrorConstructor reports whether fun is a call shape the scanner
+// treats as an error-construction site (ok), and — when it is — whether
+// the site's message is exempt from the head-prefix requirement
+// scanFunc otherwise enforces (verbatim).
+//
+// fmt.Errorf and errors.New sites carry cerberus's own words and must
+// start with "<head>: " by convention (see the heads map's doc
+// comment). A verbatimErrorConstructor site is the deliberate exception:
+// its message is a reference backend's own wording, reproduced so the
+// parity harness can diff against the exact string reference itself
+// reports, and prefixing it would fabricate an annotation reference
+// never wrote.
+func isErrorConstructor(fun ast.Expr) (verbatim, ok bool) {
+	if id, isIdent := fun.(*ast.Ident); isIdent {
+		return id.Name == verbatimErrorConstructor, id.Name == verbatimErrorConstructor
 	}
-	pkg, ok := sel.X.(*ast.Ident)
-	if !ok {
-		return false
+	sel, isSel := fun.(*ast.SelectorExpr)
+	if !isSel {
+		return false, false
+	}
+	pkg, isPkgIdent := sel.X.(*ast.Ident)
+	if !isPkgIdent {
+		return false, false
 	}
 	switch {
 	case pkg.Name == "fmt" && sel.Sel.Name == "Errorf":
-		return true
+		return false, true
 	case pkg.Name == "errors" && sel.Sel.Name == "New":
-		return true
+		return false, true
 	}
-	return false
+	return false, false
 }
 
 // stringLiteral folds an expression into its constant string value:
@@ -509,6 +561,7 @@ func Generate(repoRoot string, prev *Catalogue) (*Catalogue, error) {
 			e.Class = p.Class
 			e.TriggerQuery = p.TriggerQuery
 			e.Endpoint = p.Endpoint
+			e.GuardValues = p.GuardValues
 			e.Rationale = p.Rationale
 			e.TrackingIssue = p.TrackingIssue
 			e.Since = p.Since

--- a/test/rejection-parity/catalogue/internal__promql__scalar_domain.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__scalar_domain.go.json
@@ -1,0 +1,89 @@
+{
+  "entries": [
+    {
+      "head": "promql",
+      "site": "internal/promql/scalar_domain.go:aggregationParamDomain#6dad295b",
+      "message": "Scalar value %v overflows int64",
+      "class": "rejection",
+      "trigger_query": "topk(1e300, up)",
+      "evidence": {
+        "guard": [
+          "case mx \u003e= aggParamMaxInt64 of switch"
+        ],
+        "callers": [
+          "lowerSubqueryOverTopK",
+          "lowerTopKComputed",
+          "topKDomain"
+        ]
+      }
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/scalar_domain.go:aggregationParamDomain#8c61644b",
+      "message": "Scalar value %v underflows int64",
+      "class": "rejection",
+      "trigger_query": "topk(scalar(up), demo_http_requests_total)",
+      "guard_values": [
+        1,
+        -9223372036854776000
+      ],
+      "evidence": {
+        "guard": [
+          "case mn \u003c= aggParamMinInt64 of switch"
+        ],
+        "callers": [
+          "lowerSubqueryOverTopK",
+          "lowerTopKComputed",
+          "topKDomain"
+        ]
+      }
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/scalar_domain.go:aggregationParamDomain#93e796ca",
+      "message": "Parameter value is NaN",
+      "class": "rejection",
+      "trigger_query": "topk(NaN, up)",
+      "evidence": {
+        "guard": [
+          "case hasAnyNaN(values) of switch"
+        ],
+        "callers": [
+          "lowerSubqueryOverTopK",
+          "lowerTopKComputed",
+          "topKDomain"
+        ]
+      }
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/scalar_domain.go:holtWintersFactorDomain#fd482ce3",
+      "message": "invalid %s factor. Expected: 0 \u003c %s \u003c 1, got: %f",
+      "class": "rejection",
+      "trigger_query": "double_exponential_smoothing(up[5m], 1.5, 0.3)",
+      "evidence": {
+        "guard": [
+          "if v \u003c= 0 || v \u003e= 1"
+        ],
+        "callers": [
+          "holtWintersFactors"
+        ]
+      }
+    },
+    {
+      "head": "promql",
+      "site": "internal/promql/scalar_domain.go:limitRatioParamDomain#4b08e802",
+      "message": "Ratio value is NaN",
+      "class": "rejection",
+      "trigger_query": "limit_ratio(NaN, up)",
+      "evidence": {
+        "guard": [
+          "case hasAnyNaN(values) of switch"
+        ],
+        "callers": [
+          "limitRatioPredicate"
+        ]
+      }
+    }
+  ]
+}

--- a/test/rejection-parity/catalogue_test.go
+++ b/test/rejection-parity/catalogue_test.go
@@ -256,6 +256,9 @@ func TestCatalogueEntriesAreClassified(t *testing.T) {
 			if e.Since != "" {
 				t.Errorf("rejection entry %s carries a since date — since dates belong to divergence entries", e.Site.Site)
 			}
+			if len(e.GuardValues) > 0 && e.Head != "promql" {
+				t.Errorf("rejection entry %s carries guard_values but head %s has no ScalarGuard mechanism — guard_values is promql-only", e.Site.Site, e.Head)
+			}
 		case ClassInternal:
 			if e.Evidence == nil {
 				t.Errorf("internal entry %s carries no evidence block — a rationale with nothing derived beneath it is an unchecked assertion; regenerate with CERBERUS_UPDATE_INVENTORY=1", e.Site.Site)
@@ -272,6 +275,9 @@ func TestCatalogueEntriesAreClassified(t *testing.T) {
 			if e.Since != "" {
 				t.Errorf("internal entry %s carries a since date — since dates belong to divergence entries", e.Site.Site)
 			}
+			if len(e.GuardValues) > 0 {
+				t.Errorf("internal entry %s carries guard_values — guard_values belongs to rejection entries", e.Site.Site)
+			}
 		case ClassDivergence:
 			if strings.TrimSpace(e.TriggerQuery) == "" {
 				t.Errorf("divergence entry %s has no trigger query", e.Site.Site)
@@ -282,6 +288,9 @@ func TestCatalogueEntriesAreClassified(t *testing.T) {
 			}
 			if !ValidEndpoint(e.Head, ep) {
 				t.Errorf("divergence entry %s: endpoint %q invalid for head %s", e.Site.Site, ep, e.Head)
+			}
+			if len(e.GuardValues) > 0 {
+				t.Errorf("divergence entry %s carries guard_values — the guard exerciser is only wired for rejection entries", e.Site.Site)
 			}
 			if e.Rationale != "" {
 				t.Errorf("divergence entry %s carries a rationale — rationales belong to internal entries; a divergence justifies itself via its trigger query + tracking issue", e.Site.Site)
@@ -651,13 +660,17 @@ func evidenceOfFixture(t *testing.T, src string) map[string]*Evidence {
 // TestRejectionTriggersExerciseSites is the centrepiece pin: for every
 // class=rejection or class=divergence entry, the trigger query (a)
 // parses with the head's reference parser — proving the rejection is
-// semantic, not a parse error — and (b) fails the head's lowering with
-// an error matching the site's message — proving the trigger actually
-// exercises the catalogued site, so the parity corpus diffs the claim
-// the site makes and not some other failure. Divergence entries share
-// this reachability proof with rejection entries — the two classes
-// only disagree about what the REFERENCE backend does with the same
-// trigger, never about whether cerberus itself rejects it.
+// semantic, not a parse error — and (b) reaches an error matching the
+// site's message — proving the trigger actually exercises the
+// catalogued site, so the parity corpus diffs the claim the site makes
+// and not some other failure. For the overwhelming majority that error
+// comes from lowering itself; a GuardValues entry reaches it instead by
+// lowering cleanly and applying the registered guard's Check (see
+// lowerGuardTrigger) — a different WHEN, not a different WHAT, so both
+// still land in the one ErrorMatchesMessage comparison below. Divergence
+// entries share this reachability proof with rejection entries — the
+// two classes only disagree about what the REFERENCE backend does with
+// the same trigger, never about whether cerberus itself rejects it.
 func TestRejectionTriggersExerciseSites(t *testing.T) {
 	t.Parallel()
 
@@ -719,14 +732,29 @@ func TestParityCorpusMatchesCatalogue(t *testing.T) {
 }
 
 // lowerTrigger parses + lowers one trigger query through the same
-// entrypoints the HTTP handlers use and returns the lowering error
-// string. Parse failures and lowering successes are both fatal — a
-// trigger must be a valid-language query that the lowering rejects.
+// entrypoints the HTTP handlers use and returns the error string that
+// proves the site is reachable. For every class it handles except one,
+// that proof is a lowering failure — parse failures and lowering
+// successes are both fatal, because a trigger must be a valid-language
+// query that lowering itself rejects.
+//
+// An entry carrying GuardValues proves reachability differently: its
+// rejection exists only once ClickHouse has produced a value
+// [internal/promql.ScalarGuard]'s Check inspects, so lowering the
+// trigger must SUCCEED (with the guard registered, not raised) and
+// lowerGuardTrigger applies Check to the entry's own value series —
+// see that function's doc comment for why this mirrors
+// internal/engine/engine.go's runGuards rather than inventing a
+// different call shape.
 func lowerTrigger(t *testing.T, e Entry) string {
 	t.Helper()
 	ctx := context.Background()
 	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	end := start.Add(5 * time.Minute)
+
+	if len(e.GuardValues) > 0 {
+		return lowerGuardTrigger(t, e, ctx, end)
+	}
 
 	switch e.Head {
 	case "promql":
@@ -767,6 +795,49 @@ func lowerTrigger(t *testing.T, e Entry) string {
 		return lerr.Error()
 	}
 	t.Fatalf("entry %s has unknown head %q", e.Site.Site, e.Head)
+	return ""
+}
+
+// lowerGuardTrigger proves reachability for a class=rejection entry
+// whose site only ever raises once ClickHouse has run — an
+// [internal/promql.ScalarGuard]'s Check applied to a value series, not
+// a lowering-time error.
+//
+// The shape mirrors internal/engine/engine.go's runGuards: lower with a
+// guard sink, then run each registered guard's Check on the values its
+// plan would have produced. The difference is where the values come
+// from — runGuards gets them from ClickHouse; this exerciser gets them
+// from the entry's own GuardValues, so the site is proved without a
+// database. Requiring exactly one registered guard keeps the mapping
+// from GuardValues to "the guard it checks" unambiguous; an entry whose
+// trigger registers more than one would need a name to disambiguate,
+// which is unneeded by every site GuardValues covers today.
+func lowerGuardTrigger(t *testing.T, e Entry, ctx context.Context, end time.Time) string {
+	t.Helper()
+	if e.Head != "promql" {
+		t.Fatalf("entry %s: guard_values is only meaningful for promql, the only head with a ScalarGuard mechanism", e.Site.Site)
+	}
+	p := promparser.NewParser(promparser.Options{EnableExperimentalFunctions: true})
+	expr, err := p.ParseExpr(e.TriggerQuery)
+	if err != nil {
+		t.Fatalf("trigger %q does not parse as PromQL: %v", e.TriggerQuery, err)
+	}
+	var guards []promql.ScalarGuard
+	// Instant query shape, matching the non-guard promql path above;
+	// the guard's own Plan projects one value per evaluation step
+	// regardless, and the exerciser never runs that Plan — it feeds
+	// GuardValues to Check directly.
+	_, lerr := promql.LowerAtRangeOpts(ctx, expr, schema.DefaultOTelMetrics(), end, end, 0, promql.LowerOpts{Guards: &guards})
+	if lerr != nil {
+		t.Fatalf("trigger %q failed lowering with %v — a guard-only rejection must lower cleanly; the guard's Check is what rejects, at execution time", e.TriggerQuery, lerr)
+	}
+	if len(guards) != 1 {
+		t.Fatalf("trigger %q registered %d scalar guards, want exactly 1 — the exerciser cannot tell which one guard_values checks", e.TriggerQuery, len(guards))
+	}
+	if cerr := guards[0].Check(e.GuardValues); cerr != nil {
+		return cerr.Error()
+	}
+	t.Fatalf("trigger %q's guard %q accepted %v — the catalogued rejection is unreachable via this value series", e.TriggerQuery, guards[0].Name, e.GuardValues)
 	return ""
 }
 

--- a/test/rejection-parity/doc.go
+++ b/test/rejection-parity/doc.go
@@ -16,7 +16,11 @@
 //  1. ScanSites enumerates every `fmt.Errorf("<head>: ...")` /
 //     `errors.New("<head>: ...")` construction site in the three
 //     lowering packages via go/ast — the mechanical universe of
-//     rejection candidates.
+//     rejection candidates — plus every site built through a
+//     package-local `verbatimErrorf` wrapper (promql.verbatimErrorf is
+//     the one definition today), the deliberate, opt-in exception for a
+//     message that reproduces a reference backend's own wording and so
+//     carries no head prefix to scan for. See isErrorConstructor.
 //  2. The catalogue/ shard directory classifies every site into one of
 //     three classes — `rejection`, `internal`, or `divergence` (see
 //     below). It is stored as one shard per lowering SOURCE FILE
@@ -28,11 +32,16 @@
 //  3. The meta-tests in catalogue_test.go pin the three-way ratchet:
 //     scanned-site set == catalogue set (regenerable via
 //     CERBERUS_UPDATE_INVENTORY=1), every `rejection`/`divergence`
-//     entry's trigger query parses AND fails lowering with the site's
-//     message, the parity-corpus case set is derived 1:1 from the
-//     `rejection` + `divergence` entries via BuildCases, and every
-//     entry's reachability evidence still matches what evidence.go
-//     derives from the lowering source today (see below).
+//     entry's trigger query parses AND reaches an error matching the
+//     site's message — lowering itself for the overwhelming majority,
+//     or (an entry carrying GuardValues) lowering cleanly and applying
+//     the registered execution-time guard's Check, for the handful of
+//     sites reference Prometheus itself only rejects once a value
+//     exists to judge (see lowerGuardTrigger) — the parity-corpus case
+//     set is derived 1:1 from the `rejection` + `divergence` entries via
+//     BuildCases, and every entry's reachability evidence still matches
+//     what evidence.go derives from the lowering source today (see
+//     below).
 //  4. compatibility/cmd/rejection-parity consumes BuildCases inside
 //     each compat harness and, per case, asserts the class's claim:
 //     for `rejection`, that the REFERENCE backend also rejects the


### PR DESCRIPTION
## Summary

Closes issue #1884's "When" axis: the rejection-parity catalogue only ever saw a
rejection if it (a) carried the `"<head>: "` prefix and (b) was raised synchronously
by lowering. Both assumptions broke when PromQL's scalar-parameter domain checks
(`topk`/`bottomk`/`limitk` K, `limit_ratio`'s ratio, `double_exponential_smoothing`'s
sf/tf) moved onto an execution-time `ScalarGuard`: their messages are reference
Prometheus's own wording, reproduced byte for byte so the parity harness diffs
against the same string reference reports — which means they carry no `promql: `
prefix by design. The scanner's prefix filter silently dropped five catalogued
sites, and a sixth (the int64-underflow branch of `aggregationParamDomain`) never
had an entry at all, because it's reachable only from a multi-step value series a
single lowering call can never produce.

## What changed

1. **Scanner**: `internal/promql/scalar_domain.go` gets a `verbatimErrorf` wrapper
   around its five domain-violation constructors. `isErrorConstructor` in
   `test/rejection-parity/catalogue.go` recognises calls to it by name and admits
   the site without the head-prefix requirement. This is a deliberate, scoped
   opt-in — a call has to be written `verbatimErrorf(...)` to be admitted — not a
   blanket loosening of the filter over every unprefixed error in the three
   lowering packages, which would also swallow accidental typos of the `"<head>: "`
   convention.
2. **Exerciser**: `lowerTrigger` (in `catalogue_test.go`) gains a second reachability
   proof for an entry carrying the new `Entry.GuardValues` field. Instead of
   requiring lowering itself to fail, it lowers with a guard sink, requires exactly
   one `promql.ScalarGuard` to register, and applies that guard's `Check` to the
   entry's own value series — the same call shape `engine.runGuards` uses in
   production, minus the ClickHouse round trip. This is what lets the int64-underflow
   site be classified `rejection` honestly instead of `internal` (which would claim
   the site is unreachable from the wire — false; it's reachable from a real
   `query_range` request with a computed K that drifts out of domain over the
   window, just not provable by a single-shot lowering call).

## Catalogue diff

Regenerated via `just update-golden parity`. Five sites reappear plus the
previously-uncatalogued sixth, all in `internal__promql__scalar_domain.go.json`,
all `class: rejection`:

| Site | Trigger | Reachability proof |
|---|---|---|
| `aggregationParamDomain#93e796ca` (NaN) | `topk(NaN, up)` | lowering (literal fold) |
| `aggregationParamDomain#6dad295b` (overflow) | `topk(1e300, up)` | lowering (literal fold) |
| `aggregationParamDomain#8c61644b` (underflow) | `topk(scalar(up), demo_http_requests_total)` | `GuardValues` |
| `limitRatioParamDomain#4b08e802` | `limit_ratio(NaN, up)` | lowering (literal fold) |
| `holtWintersFactorDomain#fd482ce3` | `double_exponential_smoothing(up[5m], 1.5, 0.3)` | lowering (literal fold) |

The five that disappeared collapse to four distinct sites plus the new one: after
`internal/promql/scalar_domain.go` was introduced, `holtWintersFactorDomain` unified
what used to be two separate hardcoded messages (smoothing/trend) into one
parameterised format string — one AST call site, one catalogue entry, covering
both factors — so the count is five sites for six historically-named scenarios,
not six.

## Bundled fix: divergence-ceiling.json

The issue's second comment reported `divergence-ceiling.json` checked in at
`max_entries: 5` while a clean regenerate yields 3. Verified against this branch:
the checked-in value is already 3 (the drift was independently closed by an
unrelated PR's own golden regeneration before this branch was cut off `main`).
Regenerating again post-Part-1 (which only adds `class=rejection` entries, so it
can't move the divergence count) confirms `divergence-ceiling.json` is unchanged —
nothing to bundle here beyond having re-verified it.

## Verification

- Local (narrowed, per invariant 5): `go test -race -count=1 ./test/rejection-parity/...`,
  `go test -race -count=1 ./internal/promql/...`, `go test -race ./internal/api/prom/...` — all pass.
  `TestRejectionTriggersExerciseSites` passes for all five new sites, including the
  `GuardValues`-driven underflow one; `TestCatalogueEntriesAreClassified`,
  `TestParityCorpusMatchesCatalogue`, `TestInternalRationalesRestOnCurrentEvidence`,
  `TestInternalRationaleCitationsStillDispatch` all pass.
- `just update-golden migration parity solver promql chsql codegen cardinality` (the
  full shard set the branch's own diff to `internal/promql` implied stale) reports
  zero diff on every shard except the intended `test/rejection-parity/catalogue/`
  addition — confirming the `verbatimErrorf` wrapper is behaviourally neutral.
- `gofumpt -extra -l` clean, `go vet` clean, `forbid-sql-raw.mjs` clean.
- CI-only: `lint` (golangci-lint), and the `compatibility/prometheus` differential
  harness, which is what actually sends these five trigger queries to reference
  Prometheus and checks status-class parity (message text is never compared) —
  can't be run locally without a live ClickHouse + reference Prometheus, and another
  agent's process was active against this repo's shared compose stack during this
  session, so starting a compose run here was avoided per the worktree-isolation
  hazard in `CLAUDE.md`.

Closes #1884