### PR TITLE
fix(ci): scan a merge-queue batch's PR descriptions per pull request

### DIFF
--- a/.github/scripts/forbid-deferral.mjs
+++ b/.github/scripts/forbid-deferral.mjs
@@ -366,6 +366,19 @@ export function scansDescription(author) {
   return login !== GENERATED_DESCRIPTION_AUTHOR;
 }
 
+// readEventPayload — the event payload JSON the runner wrote for this run, or
+// null on any failure to read it (no path, no file, unparseable JSON). Shared
+// by eventPayloadAuthor and eventPayloadNumber so both read the same file the
+// same way.
+function readEventPayload(eventPath) {
+  if (!eventPath) return null;
+  try {
+    return JSON.parse(readFileSync(eventPath, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
 // eventPayloadAuthor — the login that opened this pull request, read out of the
 // payload JSON the runner wrote for the event.
 //
@@ -375,32 +388,17 @@ export function scansDescription(author) {
 // total: there is no error state in which this function's answer widens what
 // the gate accepts.
 export function eventPayloadAuthor(eventPath) {
-  if (!eventPath) return null;
-  let payload;
-  try {
-    payload = JSON.parse(readFileSync(eventPath, 'utf8'));
-  } catch {
-    return null;
-  }
-  const login = payload?.pull_request?.user?.login;
+  const login = readEventPayload(eventPath)?.pull_request?.user?.login;
   return typeof login === 'string' && login.trim() !== '' ? login.trim() : null;
 }
 
-// sharedAuthor — the single login behind a set of pull requests, or null when
-// they do not agree on one.
-//
-// The push and merge-queue paths resolve the description surface from the head
-// commit's associated pull requests, which is a LIST. Concatenating two bodies
-// and attributing them to one author would be a guess; disagreement therefore
-// yields null, and null scans. An empty list likewise: there is no author to
-// read, so there is nothing to narrow.
-export function sharedAuthor(pulls) {
-  const logins = new Set(
-    (Array.isArray(pulls) ? pulls : [])
-      .map((p) => (typeof p?.user?.login === 'string' ? p.user.login.trim() : ''))
-      .filter((l) => l !== ''),
-  );
-  return logins.size === 1 ? [...logins][0] : null;
+// eventPayloadNumber — the number of the pull request this event is about, or
+// null on the same failure modes as eventPayloadAuthor. Used only to label a
+// single-PR pull_request-event surface the same way a multi-PR batch's parts
+// are labelled; never load-bearing for a verdict.
+export function eventPayloadNumber(eventPath) {
+  const number = readEventPayload(eventPath)?.pull_request?.number;
+  return typeof number === 'number' && Number.isInteger(number) ? number : null;
 }
 
 // paragraphs — split prose into blank-line-separated blocks, each carrying the
@@ -579,16 +577,31 @@ export function scanDiff(diffText, repoSlug) {
 // that only exercised the description could not tell scoping apart from an
 // exemption. The tests that matter are the ones asserting a marker in a bot
 // pull request's COMMIT MESSAGE and in its DIFF is still reported.
-export function candidatesFor({ description, author, commits, diffText, repoSlug }) {
+//
+// descriptionParts is a LIST, not one merged blob: a merge-queue batch or a
+// push resolves to every pull request associated with the head commit, each
+// with its OWN author, and scanning them as one concatenated string would
+// scan a bot's generated changelog under whatever author the OTHER pulls in
+// the batch happen to carry (or under no author at all, once they disagree —
+// see #1943). Each part is scanned under its own author, independently of
+// every other part in the batch, so a Dependabot pull request riding in the
+// same merge group as a human one is exempted on its own merits and cannot
+// suppress or inherit the human pull request's scan.
+export function candidatesFor({ descriptionParts, commits, diffText, repoSlug }) {
   return [
-    ...(scansDescription(author)
-      ? scanProse({
-          text: description,
-          surface: 'pr-body',
-          locate: (line) => `PR description line ${line}`,
-          repoSlug,
-        })
-      : []),
+    ...(Array.isArray(descriptionParts) ? descriptionParts : []).flatMap((part) =>
+      scansDescription(part.author)
+        ? scanProse({
+            text: part.text,
+            surface: 'pr-body',
+            locate: (line) =>
+              part.number == null
+                ? `PR description line ${line}`
+                : `PR #${part.number} description line ${line}`,
+            repoSlug,
+          })
+        : [],
+    ),
     ...(Array.isArray(commits) ? commits : []).flatMap((c) =>
       scanProse({
         text: c.message,
@@ -803,11 +816,24 @@ async function apiJson(url, token, what) {
   return res.json();
 }
 
-// descriptionSurface — the PR description, however this event can reach it.
-// On a pull_request run it is the event payload. On a push there is no payload
-// body, so the associated pull request is resolved from the head commit; a
-// commit with none (a maintenance cherry-pick) yields an EXPLICITLY empty
-// surface, recorded as such rather than silently skipped.
+// descriptionSurface — the PR description(s), however this event can reach
+// them. On a pull_request run it is the event payload, one pull request. On a
+// push or a merge-queue run there is no payload body, so every pull request
+// associated with the head commit is resolved from the API — a merge-queue
+// batch groups several, so this is a LIST; a commit with none (a maintenance
+// cherry-pick) yields an EXPLICITLY empty surface, recorded as such rather
+// than silently skipped.
+//
+// Returns `{ text, origin, parts }`. `parts` is the shape this gate's own
+// scan reads: one entry per pull request, each carrying its OWN `text`,
+// `author` and `number`, so a Dependabot pull request's generated changelog
+// is scanned under Dependabot's own identity and a human pull request's body
+// under that human's, regardless of what else rode along in the same batch —
+// see candidatesFor's own comment for why concatenating them was the bug
+// (#1943). `text` and `origin` are the pre-existing single-blob view, kept
+// for pr-body-check.mjs: that gate asks only "is there SOME substantive
+// description across this batch", not "who wrote which part", so it has no
+// need of per-part attribution and stays on the shape it already pins.
 export async function descriptionSurface({ eventName, repo, head, token, apiBase }) {
   if (eventName === 'pull_request' || eventName === 'pull_request_target') {
     if (process.env.PR_BODY === undefined) {
@@ -816,11 +842,15 @@ export async function descriptionSurface({ eventName, repo, head, token, apiBase
           'Wire `PR_BODY: ${{ github.event.pull_request.body }}` into the step env.',
       );
     }
-    return {
-      text: process.env.PR_BODY,
-      origin: 'the pull_request event payload',
+    const text = process.env.PR_BODY;
+    const origin = 'the pull_request event payload';
+    const part = {
+      text,
+      origin,
       author: eventPayloadAuthor(process.env.GITHUB_EVENT_PATH),
+      number: eventPayloadNumber(process.env.GITHUB_EVENT_PATH),
     };
+    return { text, origin, parts: [part] };
   }
   const pulls = await apiJson(
     `${apiBase}/repos/${repo}/commits/${head}/pulls`,
@@ -844,13 +874,19 @@ export async function descriptionSurface({ eventName, repo, head, token, apiBase
     return {
       text: '',
       origin: `explicitly empty: no pull request is associated with ${head.slice(0, 12)}`,
-      author: null,
+      parts: [],
     };
   }
+  const parts = pulls.map((p) => ({
+    text: p.body ?? '',
+    origin: `the description of #${p.number}`,
+    author: typeof p?.user?.login === 'string' && p.user.login.trim() !== '' ? p.user.login.trim() : null,
+    number: p.number,
+  }));
   return {
-    text: pulls.map((p) => p.body ?? '').join('\n\n'),
+    text: parts.map((p) => p.text).join('\n\n'),
     origin: `the description of ${pulls.map((p) => `#${p.number}`).join(', ')}`,
-    author: sharedAuthor(pulls),
+    parts,
   };
 }
 
@@ -934,8 +970,7 @@ async function main() {
   const description = await descriptionSurface({ eventName, repo, head, token, apiBase });
 
   const candidates = candidatesFor({
-    description: description.text,
-    author: description.author,
+    descriptionParts: description.parts,
     commits,
     diffText,
     repoSlug: repo,
@@ -947,15 +982,27 @@ async function main() {
 
   // The anti-vacuity contract in the header says every run states what it
   // inspected. A surface that was resolved but deliberately not read has to say
-  // so in the same breath, or the summary claims a scan that did not happen.
-  const descriptionRead = scansDescription(description.author);
+  // so in the same breath, or the summary claims a scan that did not happen. One
+  // bullet per pull request in the batch, not one for the whole surface: each
+  // part was scanned (or exempted) under its own author, independently of every
+  // other part, and the summary has to be legible about which is which.
+  const descriptionLines =
+    description.parts.length === 0
+      ? [`- description: ${description.origin} (0 chars)`]
+      : description.parts.map((part) => {
+          const read = scansDescription(part.author);
+          const label = part.number == null ? part.origin : `#${part.number}`;
+          return (
+            `- description (${label}): ${part.text.length} chars` +
+            (read
+              ? ''
+              : ` — NOT scanned: written by ${GENERATED_DESCRIPTION_AUTHOR}, whose body quotes ` +
+                'upstream release notes rather than stating this change\'s own commitment. Its ' +
+                'commit messages and its diff were scanned as normal.')
+          );
+        });
   const inspected = [
-    `- description: ${description.origin} (${description.text.length} chars)` +
-      (descriptionRead
-        ? ''
-        : ` — NOT scanned: written by ${GENERATED_DESCRIPTION_AUTHOR}, whose body quotes ` +
-          'upstream release notes rather than stating this change\'s own commitment. Its ' +
-          'commit messages and its diff were scanned as normal.'),
+    ...descriptionLines,
     `- commits: **${commits.length}** in \`${base.slice(0, 12)}..${head.slice(0, 12)}\``,
     `- diff: **${files.length}** file(s) at \`--unified=${CITATION_WINDOW_LINES}\``,
     `- marker table: **${DEFERRAL_MARKERS.length}** rows`,

--- a/.github/scripts/forbid-deferral.test.mjs
+++ b/.github/scripts/forbid-deferral.test.mjs
@@ -33,6 +33,7 @@ import {
   DEFERRAL_MARKERS,
   candidatesFor,
   citationVerdict,
+  descriptionSurface,
   evaluate,
   findMarkers,
   headingLevel,
@@ -42,10 +43,10 @@ import {
   parseDiff,
   scanDiff,
   eventPayloadAuthor,
+  eventPayloadNumber,
   scanProse,
   scansDescription,
   sectionAt,
-  sharedAuthor,
   stripFencedBlocks,
 } from './forbid-deferral.mjs';
 
@@ -680,8 +681,7 @@ const surfacesOf = (candidates) => candidates.map((c) => c.surface).sort();
 
 test('a generated description is quoted release notes, not this change’s commitment', () => {
   const found = candidatesFor({
-    description: GENERATED_BODY,
-    author: BOT,
+    descriptionParts: [{ text: GENERATED_BODY, author: BOT, number: 100 }],
     commits: [{ sha: 'b'.repeat(40), message: 'chore(deps): bump otel' }],
     diffText: EMPTY_DIFF,
     repoSlug: REPO,
@@ -691,20 +691,20 @@ test('a generated description is quoted release notes, not this change’s commi
 
 test('the same description on an ordinary pull request is still read', () => {
   const found = candidatesFor({
-    description: GENERATED_BODY,
-    author: HUMAN,
+    descriptionParts: [{ text: GENERATED_BODY, author: HUMAN, number: null }],
     commits: [{ sha: 'b'.repeat(40), message: 'chore(deps): bump otel' }],
     diffText: EMPTY_DIFF,
     repoSlug: REPO,
   });
   assert.deepEqual(surfacesOf(found), ['pr-body']);
+  // No number on the part (the shape a pull_request-event run with an
+  // unresolvable payload produces) falls back to the un-numbered location.
   assert.equal(found[0].location, 'PR description line 3');
 });
 
 test('a marker in a generated pull request’s COMMIT MESSAGE is still reported', () => {
   const found = candidatesFor({
-    description: GENERATED_BODY,
-    author: BOT,
+    descriptionParts: [{ text: GENERATED_BODY, author: BOT, number: 100 }],
     commits: COMMITS_WITH_MARKER,
     diffText: EMPTY_DIFF,
     repoSlug: REPO,
@@ -716,8 +716,7 @@ test('a marker in a generated pull request’s COMMIT MESSAGE is still reported'
 
 test('a marker in a generated pull request’s DIFF is still reported', () => {
   const found = candidatesFor({
-    description: GENERATED_BODY,
-    author: BOT,
+    descriptionParts: [{ text: GENERATED_BODY, author: BOT, number: 100 }],
     commits: [{ sha: 'b'.repeat(40), message: 'chore(deps): bump otel' }],
     diffText: DIFF_WITH_MARKER,
     repoSlug: REPO,
@@ -729,8 +728,7 @@ test('a marker in a generated pull request’s DIFF is still reported', () => {
 test('an unknown author scans the description as normal', () => {
   for (const author of [null, undefined, '', '   ']) {
     const found = candidatesFor({
-      description: GENERATED_BODY,
-      author,
+      descriptionParts: [{ text: GENERATED_BODY, author, number: 100 }],
       commits: [{ sha: 'b'.repeat(40), message: 'chore(deps): bump otel' }],
       diffText: EMPTY_DIFF,
       repoSlug: REPO,
@@ -748,6 +746,110 @@ test('scansDescription narrows on exactly one login and nothing near it', () => 
   assert.equal(scansDescription('Dependabot[bot]'), false, 'a login is not case-sensitive');
   for (const near of ['dependabot', 'dependabot-preview[bot]', 'notdependabot[bot]', 'renovate[bot]', HUMAN]) {
     assert.equal(scansDescription(near), true, `${near} is not the generated-description account`);
+  }
+});
+
+// --- the merge-queue batching bug (#1943) ------------------------------------
+//
+// A merge-queue batch or a push resolves its description surface from EVERY
+// pull request associated with the head commit — a LIST, not one pull
+// request. The bug: descriptionSurface used to concatenate every pull's body
+// into one string and average their authors into a single `sharedAuthor`,
+// which is null the moment the batch disagrees on one — a Dependabot pull
+// request riding beside any human pull request. A null author scans as an
+// ordinary surface, so Dependabot's generated changelog (which quotes
+// upstream commit subjects verbatim, and upstream commit subjects are
+// ordinary prose that can accidentally contain marker vocabulary — this is
+// what made #1937 go red) got scanned as if a human had written it, and the
+// required check failed the WHOLE batch on a marker nobody in it wrote.
+//
+// The fix scans PER PULL REQUEST: candidatesFor takes `descriptionParts`, one
+// entry per pull request, each carrying its own text/author/number, so a
+// bot's part is exempted on its own authorship regardless of what rides
+// alongside it, and a human's part is scanned under that human's own
+// authorship, unaffected by any bot in the same batch.
+const MIXED_BATCH_BOT_PART = { text: GENERATED_BODY, author: BOT, number: 100 };
+
+test('a merge-queue batch with a Dependabot PR and a clean human PR passes', () => {
+  const humanBody =
+    'Adds a guardrail around the offset modifier so slicing never crosses a partial window.';
+  const found = candidatesFor({
+    descriptionParts: [MIXED_BATCH_BOT_PART, { text: humanBody, author: HUMAN, number: 101 }],
+    commits: [{ sha: 'c'.repeat(40), message: 'chore(deps): bump otel' }],
+    diffText: EMPTY_DIFF,
+    repoSlug: REPO,
+  });
+  assert.deepEqual(
+    found,
+    [],
+    'the bot part is exempted on its own authorship and the human part carries no marker',
+  );
+});
+
+test('a merge-queue batch fails on the human PR’s own untracked deferral, attributed to that PR', () => {
+  // Same batch, but the human pull request's body genuinely defers work and
+  // cites nothing. The gate must still fail — the fix is about WHO a marker is
+  // attributed to, never about weakening the scan — and the reported location
+  // and author must name the human pull request, not the bot riding beside it.
+  const humanBody = `Adds the guardrail. The retry-budget rework is ${DEFERRED_WORD}.`;
+  const found = candidatesFor({
+    descriptionParts: [MIXED_BATCH_BOT_PART, { text: humanBody, author: HUMAN, number: 101 }],
+    commits: [{ sha: 'c'.repeat(40), message: 'chore(deps): bump otel' }],
+    diffText: EMPTY_DIFF,
+    repoSlug: REPO,
+  });
+  assert.equal(found.length, 1, "only the human PR's marker surfaces; the bot PR stays exempt");
+  assert.equal(found[0].location, 'PR #101 description line 1');
+  assert.equal(found[0].markerId, 'deferral-to-later');
+  const violations = evaluate(found, RESOLVED);
+  assert.equal(violations.length, 1);
+  assert.match(violations[0].location, /#101/, 'the violation must point at the PR that wrote it');
+});
+
+test('descriptionSurface resolves a merge-queue batch into one part per pull request', async () => {
+  // The end-to-end wiring: a batch of two associated pull requests with
+  // different authors used to collapse to a single concatenated blob and a
+  // null shared author. It must now come back as independent parts, each
+  // carrying its own author and number, with the pre-existing combined
+  // text/origin kept alongside for pr-body-check.mjs.
+  const head = '0123456789abcdef0123456789abcdef01234567';
+  const apiBase = 'https://api.github.test';
+  const real = globalThis.fetch;
+  globalThis.fetch = async (url) => {
+    assert.equal(url, `${apiBase}/repos/${REPO}/commits/${head}/pulls`);
+    return {
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => [
+        { number: 100, body: GENERATED_BODY, user: { login: BOT } },
+        { number: 101, body: 'Adds a guardrail.', user: { login: HUMAN } },
+      ],
+    };
+  };
+  try {
+    const description = await descriptionSurface({
+      eventName: 'merge_group',
+      repo: REPO,
+      head,
+      token: 't',
+      apiBase,
+    });
+    assert.equal(description.parts.length, 2);
+    assert.deepEqual(
+      description.parts.map((p) => [p.number, p.author]),
+      [
+        [100, BOT],
+        [101, HUMAN],
+      ],
+    );
+    assert.equal(description.parts[0].text, GENERATED_BODY);
+    assert.equal(description.parts[1].text, 'Adds a guardrail.');
+    // The combined view pr-body-check.mjs reads survives unchanged.
+    assert.match(description.origin, /#100, #101/);
+    assert.equal(description.text, `${GENERATED_BODY}\n\nAdds a guardrail.`);
+  } finally {
+    globalThis.fetch = real;
   }
 });
 
@@ -780,15 +882,21 @@ test('every unreadable payload yields no author, which scans the description', (
   }
 });
 
-test('a push-resolved surface takes its author only when the pull requests agree', () => {
-  assert.equal(sharedAuthor([{ user: { login: BOT } }]), BOT);
-  assert.equal(sharedAuthor([{ user: { login: BOT } }, { user: { login: BOT } }]), BOT);
-  assert.equal(
-    sharedAuthor([{ user: { login: BOT } }, { user: { login: HUMAN } }]),
-    null,
-    'two authors, one concatenated body — attributing it to either would be a guess',
-  );
-  for (const empty of [[], null, undefined, [{}], [{ user: {} }]]) {
-    assert.equal(sharedAuthor(empty), null, 'no author means nothing to narrow');
+test('the pull request number is read from the event payload alongside the author', () => {
+  const path = withPayload(JSON.stringify({ pull_request: { number: 101, user: { login: HUMAN } } }));
+  assert.equal(eventPayloadNumber(path), 101);
+});
+
+test('every unreadable payload yields no number either', () => {
+  const cases = {
+    'no path at all': undefined,
+    'a path that does not exist': join(tmpdir(), 'forbid-deferral-absent', 'event.json'),
+    'a file that is not JSON': withPayload('not json {'),
+    'a payload with no pull request': withPayload(JSON.stringify({ ref: 'refs/heads/main' })),
+    'a pull request with no number': withPayload(JSON.stringify({ pull_request: {} })),
+    'a number that is not a number': withPayload(JSON.stringify({ pull_request: { number: '101' } })),
+  };
+  for (const [what, path] of Object.entries(cases)) {
+    assert.equal(eventPayloadNumber(path), null, what);
   }
 });


### PR DESCRIPTION
## The bug

`forbid-deferral`'s `descriptionSurface()` resolves the merge-queue description surface from the head commit's associated pull requests — a LIST, since a merge-queue batch groups several PRs. It used to concatenate every pull's body into one string and average their authors into a single `sharedAuthor()`, which returns `null` the moment the batch disagrees on one author — a Dependabot PR riding beside any human PR.

A `null` author scans as an ordinary (non-bot) surface, so `GENERATED_DESCRIPTION_AUTHOR`'s narrowing never kicked in for the batch: Dependabot's generated `<details>` changelog block — which quotes upstream commit subjects verbatim, and upstream commit subjects are exactly the kind of prose that can accidentally contain deferral-marker vocabulary (this is what made #1937 go red) — got scanned as if a human had written it. The required `forbid-deferral` check then failed the **whole batch** on a marker nobody in it actually wrote, holding every PR in the batch behind a violation none of their authors owned.

This was latent: `forbid-deferral.yml` declares a `merge_group` trigger, but no `merge_group` run has exercised this exact path since the author-keyed narrowing landed. It's not a regression — a mixed batch was equally exposed before that rule existed — the fix that made single-author bot PRs pass cleanly just never reached the multi-PR batch case.

## The fix

The concatenation was the root cause, not the narrowing logic itself. A merge-queue batch is a SET of independent pull requests, each with its own author — scanning them as one string can't correctly attribute authorship, and a reported line number doesn't say which PR it came from.

`descriptionSurface()` now also returns `parts`: one entry per associated pull request, each carrying its own `text`, `author`, and `number`. `candidatesFor()` takes `descriptionParts` and scans each part independently against `scansDescription(part.author)`, so:

- A Dependabot PR's generated changelog is scanned under Dependabot's own author identity — correctly triggering the exemption for it specifically — regardless of what else rides in the same batch.
- A human PR's body is scanned under that human's own authorship, unaffected by any bot PR alongside it.
- A reported violation's location now points at the actual PR it came from (`PR #<n> description line <n>`), not an offset into a multi-PR concatenation.

`sharedAuthor()` is gone — no longer needed once every part carries its own author. `descriptionSurface()` keeps its pre-existing combined `text`/`origin` view alongside `parts`, since `pr-body-check.mjs` (the other consumer, checking only "is there some substantive description across the batch") has no need of per-part attribution and stays on the shape it already pins.

## Testing

Added to `.github/scripts/forbid-deferral.test.mjs`:
- a mixed batch (Dependabot PR with a bot-generated changelog quoting marker-adjacent vocabulary + a clean human PR) passes;
- the same batch with the human PR's body containing a real untracked deferral marker still fails, with the violation correctly attributed to the human PR's number and author, not the bot's;
- end-to-end coverage of `descriptionSurface()` resolving a mocked two-PR batch into independent parts with the right per-PR author/number, while its combined `text`/`origin` view is preserved for `pr-body-check.mjs`.

Ran locally per CLAUDE.md invariant 5's single-file convention:
```
node --test .github/scripts/forbid-deferral.test.mjs .github/scripts/pr-body-check.test.mjs
```
56/56 pass, including both new scenarios.

Closes #1943