### PR TITLE
test(compat/tempo): add malformed-q coverage for the v1 tag-name route

### DIFF
--- a/compatibility/parity-baseline.json
+++ b/compatibility/parity-baseline.json
@@ -1101,8 +1101,8 @@
       ]
     },
     "tempo": {
-      "passed": 74,
-      "total": 74,
+      "passed": 75,
+      "total": 75,
       "cases": [
         "metrics_instant | metrics_avg_over_time_instant",
         "metrics_instant | metrics_count_over_time_instant",
@@ -1166,6 +1166,7 @@
         "tag_values_v2 | tag_values_v2_service_name",
         "tag_values_v2 | tag_values_v2_unknown_tag_empty",
         "tags_v1 | tags_v1_all",
+        "tags_v1 | tags_v1_malformed_query",
         "tags_v1 | tags_v1_scoped_by_query",
         "tags_v2 | tags_v2_event",
         "tags_v2 | tags_v2_instrumentation",
@@ -1181,8 +1182,8 @@
       ]
     },
     "tempo-grpc": {
-      "passed": 72,
-      "total": 72,
+      "passed": 73,
+      "total": 73,
       "cases": [
         "metrics_instant | metrics_avg_over_time_instant",
         "metrics_instant | metrics_count_over_time_instant",
@@ -1246,6 +1247,7 @@
         "tag_values_v2 | tag_values_v2_service_name",
         "tag_values_v2 | tag_values_v2_unknown_tag_empty",
         "tags_v1 | tags_v1_all",
+        "tags_v1 | tags_v1_malformed_query",
         "tags_v1 | tags_v1_scoped_by_query",
         "tags_v2 | tags_v2_event",
         "tags_v2 | tags_v2_instrumentation",

--- a/compatibility/tempo/driver/corpus/smoke.txtar
+++ b/compatibility/tempo/driver/corpus/smoke.txtar
@@ -736,6 +736,51 @@ http.target
 child.index
 kind
 
+# `q` that fails to PARSE, not just one that would narrow (#1944). PR
+# #1929 established from upstream's own source
+# (grafana/tempo@v1.5.1-0.20260508211128-2f74ea818de1
+# modules/frontend/tag_handlers.go) that the V1 tag-name route — both
+# the HTTP handler and the streaming gRPC handler — neither parses nor
+# validates `q` at all: LiveStore.SearchTags forwards only the scope
+# into SearchTagsV2, so a malformed `q` never reaches a TraceQL parser
+# on either transport and both answer 200 with the whole window's keys,
+# where the V2 route 400s on the same string (see
+# tags_v2_scope_all_rejected above for that axis). Unit tests
+# (internal/api/tempo/search_tags_filter_test.go's
+# TestSearchTagsV1Query_Ignored and
+# internal/api/tempo/grpc/tags_test.go's TestSearchTagsV1_QueryIgnored)
+# already pin that cerberus behaves this way; this case is what puts
+# reference Tempo on the other side of the same request, which is the
+# one thing a unit test structurally cannot do. "{{{" is the same
+# malformed shape those unit tests use, kept consistent rather than
+# inventing a new invalid-query string. It runs over both transports
+# from the same corpus entry: HTTP via diffCase (diff.go) and gRPC via
+# diffCaseGRPC (grpc_diff.go, grpcSupportsEndpoint already lists
+# tags_v1) — neither declares -- expect_status -- / -- expect_grpc_code
+# --, so this is an ordinary body-diff case, and the assertion IS the
+# parity proof: if either backend rejected the malformed `q` with a
+# non-2xx/non-OK response instead of answering 200, the fetch on that
+# transport would hard-error and the case would fail.
+-- name --
+tags_v1_malformed_query
+-- endpoint --
+tags_v1
+-- query --
+{{{
+-- expected_min_values --
+1
+-- expected_max_values --
+500
+# Same unfiltered-key proof as tags_v1_scoped_by_query: these are
+# carried only by spans a HONOURED query — malformed or not — could
+# never select, so their presence is what shows `q` was dropped on the
+# floor rather than rejected.
+-- expected_values --
+http.method
+http.target
+child.index
+kind
+
 -- name --
 tags_v2_span_scoped_by_query
 -- endpoint --


### PR DESCRIPTION
## Summary

The tempo differential corpus has two `tags_v1` cases —
`tags_v1_all` and `tags_v1_scoped_by_query` — and neither sent a `q` value
that fails to parse.

PR #1929 established from upstream Tempo's own source
(`grafana/tempo@v1.5.1-0.20260508211128-2f74ea818de1`,
`modules/frontend/tag_handlers.go`) that `q` is a v2-only parameter: the v1
HTTP handler and the v1 streaming gRPC handler neither parse nor validate
it, so upstream answers `200` to a malformed `q` on v1 where v2 answers
`400`. Cerberus now matches that, and unit tests
(`internal/api/tempo/search_tags_filter_test.go`'s
`TestSearchTagsV1Query_Ignored`, `internal/api/tempo/grpc/tags_test.go`'s
`TestSearchTagsV1_QueryIgnored`) assert the `200` on both transports — but
a unit test only asserts what cerberus does, not that upstream still
agrees. Only the differential corpus puts the two backends side by side.

## Change

- Added `tags_v1_malformed_query` to
  `compatibility/tempo/driver/corpus/smoke.txtar`, sending `q={{{` — the
  same malformed shape the existing unit tests already use, kept
  consistent rather than inventing a new invalid-query string.
- No `-- expect_status --` / `-- expect_grpc_code --`: this is an
  ordinary body-diff case, and that's deliberate — the parity proof is
  that a non-2xx/non-OK response from either backend on either transport
  hard-errors the fetch and fails the case, so a naive implementation
  that started rejecting a malformed `q` on v1 (or one that started
  parsing it) would be caught.
- The gRPC arm is exercised automatically: `grpcSupportsEndpoint`
  (`compatibility/tempo/driver/grpc_diff.go`) already lists `tags_v1`,
  and `fetchGRPCTagsV1` already forwards `tc.Query` as
  `SearchTagsRequest.Query` regardless of whether it parses — the same
  wiring `tags_v1_scoped_by_query` already relies on for its own gRPC
  coverage.
- Hand-regenerated `compatibility/parity-baseline.json`'s `tempo` and
  `tempo-grpc` rosters with the new case ID (`tags_v1 |
  tags_v1_malformed_query`), bumping `passed`/`total` by one on each
  head. **This is a hand-edit, not a run of
  `compat-baseline-sync.mjs`** — that script consumes a live run's
  `compat-cases.json` artifact, which needs live reference Tempo +
  cerberus and isn't available in this environment. The edit follows the
  existing sorted, one-ID-per-head style exactly.

## Verification

Ran locally:

- `go test ./compatibility/tempo/driver/...` — the TXTAR fixture parses
  cleanly (`TestSmokeCorpus_LoadsAndMeetsFloor`,
  `TestSmokeCorpus_TagEndpointCoverage`, and the full
  `TestParseCorpus_*` suite all pass), and the new case's
  `-- query --`/`-- expected_values --` shape satisfies
  `validateTagNameAssertions`.
- `go build ./...` and `go vet ./compatibility/...` — clean.
- `node .github/scripts/doc-counts.mjs` — passes; confirms no doc
  hand-restates the new `passed`/`total` integers (75/75 for `tempo`,
  73/73 for `tempo-grpc`).
- `python3 -c "import json; json.load(open('compatibility/parity-baseline.json'))"`
  — valid JSON.

**Not verified locally, CI-only per CLAUDE.md invariant 5** (needs live
reference Tempo + cerberus, no local substrate for this lane):

- The actual differential run (`just compat-traceql` / the
  `compatibility.yml` workflow) — that both reference Tempo and cerberus
  genuinely answer `200` to `q={{{` on `/api/search/tags` and its gRPC
  `SearchTags` twin, and that the new case's body/structural diff comes
  back equal.
- The parity-regression ratchet (`compat-ratchet.mjs`) comparing the
  run's `compat-cases.json` against the hand-edited baseline — this is
  the check that will actually confirm the hand-edit's case ID and
  counts are correct.

Closes #1944
