### PR TITLE
fix(ci): scan untracked-but-not-ignored files in forbid-skip and repo-hygiene

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -171,7 +171,22 @@ the pinned numbers cannot drift away from what the crawl actually asks for.
     `CHECKS` registry in the script is the one list — `all` iterates it, and
     `doc-counts.mjs` asserts every workflow `CHECK:` value names a live entry,
     so a removed scan cannot leave a caller behind.
+  - Every scan derives its file set from `lib/gh.mjs`'s `lsFiles()`, which
+    scans the tracked git INDEX plus every untracked-but-not-`.gitignore`d
+    working-tree path — not the tracked set alone. A bare `git ls-files`
+    made a generated-but-unstaged file locally invisible to every scan here,
+    sound on CI (the runner checks out a committed tree) and sound at push
+    time (lefthook's `pre-push` scans a committed tree too), but a real gap
+    for `node .github/scripts/forbid-skip.mjs` run directly against a local
+    working tree mid-edit — exactly the narrowed local reproduction CLAUDE.md
+    asks for after a red CI check (issue #1938).
   - Exit: `0` clean, `1` on any banned pattern or bad `CHECK`.
+  - `forbid-skip.test.mjs` is the `node --test` guard (run as the first step
+    of the `forbid-skip` job, before any scan): it builds a throwaway git
+    repository and proves `CHECK=t-skip` fails on a `t.Skip` file that is
+    present in the working tree but never `git add`-ed, not only on a
+    committed one, and that the `compatibility/*/upstream/**` exclude
+    pathspec still applies to an untracked path.
 - **`forbid-deferral.mjs`** — `forbid-deferral.yml`, its own workflow. The prose
   sibling of `forbid-skip`: where that one rejects a test that declines to
   assert, this rejects a change that names work it is not doing and walks away.
@@ -308,8 +323,12 @@ the pinned numbers cannot drift away from what the crawl actually asks for.
   list cannot rot into a pre-approval for a future file of the same name. The
   gate fails CLOSED: a tracked blob that cannot be read from the working tree
   is retried out of the object store and, failing that, exits non-zero rather
-  than being assumed to be text. Since `git ls-files` is the input, the
-  companion fix for anything this catches is a `git rm` PLUS a `.gitignore`
+  than being assumed to be text. All three scans' file set is the tracked git
+  INDEX plus every untracked-but-not-`.gitignore`d working-tree path — not
+  the tracked set alone (`pathsInScope()` / `blobsInScope()`; issue #1938),
+  so an untracked entry is scanned straight off disk (it has no object-store
+  blob to fall back on). The companion fix for anything this catches is a
+  `git rm` (or simply deleting an untracked offender) PLUS a `.gitignore`
   rule — the ignore rule is what stops it coming back. `registry-login`
   rejects any workflow step that `uses: docker/login-action`: that Action has
   no retry input, so a login losing one handshake fails the job before it has
@@ -325,7 +344,9 @@ the pinned numbers cannot drift away from what the crawl actually asks for.
   synthetic ELF blob, a stray root file, and a workflow step using
   `docker/login-action`, and asserts a non-zero exit naming each, plus a clean
   exit on a conforming fixture — a gate never shown to fail is
-  indistinguishable from one that does nothing.
+  indistinguishable from one that does nothing. It also plants each of those
+  three fixtures WITHOUT `git add`-ing them, asserting the gate still fires on
+  an untracked violation and not only a committed one (issue #1938).
   - Env: `CHECK` is one of `binary`, `root-allowlist`, `registry-login`;
     `REPO_ROOT` (optional) points the scan at another checkout (the
     self-test's fixture repo).

--- a/.github/scripts/forbid-skip.test.mjs
+++ b/.github/scripts/forbid-skip.test.mjs
@@ -1,0 +1,111 @@
+// forbid-skip.test.mjs — node:test guard for the GA test-discipline gate's
+// CLI, run end-to-end against a real throwaway git repository.
+//
+// forbid-skip.mjs has no importable pure functions (unlike repo-hygiene.mjs):
+// every scan is a closure over `process.env.CHECK` and the module runs its
+// dispatch as a side effect of being loaded, so the only way to exercise it
+// is to spawn the real CLI as a subprocess — exactly as
+// repo-hygiene.test.mjs already does for its own end-to-end assertions.
+//
+// The case this file exists to pin (#1938): every scan derives its file set
+// from lib/gh.mjs's lsFiles(), which used to run a bare `git ls-files` — the
+// git INDEX only. A file a generator just wrote but never `git add`-ed was
+// therefore invisible: the gate reported clean on content it would reject
+// the instant the file was staged. lsFiles() now also reads
+// `--others --exclude-standard`, so an untracked-but-not-ignored violation
+// is caught too, while a `.gitignore`d path stays out of scope exactly as
+// before. gh.test.mjs pins lsFiles() itself directly; this file pins the
+// same gap from the CLI's own vantage point, against the actual scan a
+// contributor runs locally after CI reds (CLAUDE.md's own narrowed-local-
+// repro rule).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const CLI = join(HERE, 'forbid-skip.mjs');
+
+// newFixtureRepo — a throwaway git repo with one committed, clean Go file so
+// `git log` / `git status` behave normally. Returns a `write(relPath,
+// content)` helper that writes a file WITHOUT staging it — the point of
+// every "untracked" case below is that the file is never `git add`-ed.
+function newFixtureRepo() {
+  const dir = mkdtempSync(join(tmpdir(), 'forbid-skip-'));
+  const run = (args) => {
+    const res = spawnSync('git', args, { cwd: dir, encoding: 'utf8' });
+    assert.equal(res.status, 0, `git ${args.join(' ')} failed: ${res.stderr}`);
+  };
+  run(['init', '--quiet']);
+  writeFileSync(join(dir, 'ok_test.go'), 'package main\n\nfunc TestOK(t *testing.T) {}\n');
+  run(['add', 'ok_test.go']);
+  run(['-c', 'user.email=a@a', '-c', 'user.name=a', 'commit', '--quiet', '-m', 'seed']);
+  return {
+    dir,
+    write(relPath, content) {
+      mkdirSync(join(dir, dirname(relPath)), { recursive: true });
+      writeFileSync(join(dir, relPath), content);
+    },
+  };
+}
+
+function runGate(check, cwd) {
+  const res = spawnSync(process.execPath, [CLI], {
+    cwd,
+    encoding: 'utf8',
+    env: { ...process.env, CHECK: check },
+  });
+  return { status: res.status, out: `${res.stdout}${res.stderr}` };
+}
+
+test('the CLI passes CHECK=t-skip on a clean fixture tree', () => {
+  const { dir } = newFixtureRepo();
+  const { status, out } = runGate('t-skip', dir);
+  assert.equal(status, 0, `t-skip must pass on a clean tree; got:\n${out}`);
+});
+
+test('the CLI FAILS CHECK=t-skip on an UNTRACKED violating file, naming it (#1938)', () => {
+  const { dir, write } = newFixtureRepo();
+  // Deliberately not `git add`-ed — this is the exact gap #1938 describes: a
+  // generator wrote the file but nobody staged it yet.
+  write('generated_test.go', 'package main\n\nfunc TestBad(t *testing.T) { t.Skip("flaky") }\n');
+  const { status, out } = runGate('t-skip', dir);
+  assert.notEqual(
+    status,
+    0,
+    `t-skip must fail on an untracked t.Skip file; a bare \`git ls-files\` regression would exit 0 here:\n${out}`,
+  );
+  assert.match(out, /::error::/);
+  assert.match(out, /generated_test\.go/);
+});
+
+test('the CLI still ignores an untracked violating file under the upstream exclude', () => {
+  const { dir, write } = newFixtureRepo();
+  write(
+    'compatibility/promql/upstream/vendored_test.go',
+    'package main\n\nfunc TestVendored(t *testing.T) { t.Skip("upstream") }\n',
+  );
+  const { status, out } = runGate('t-skip', dir);
+  assert.equal(status, 0, `the upstream exclude pathspec must still apply to an untracked path; got:\n${out}`);
+});
+
+test('the CLI FAILS CHECK=t-skip on a TRACKED violating file, same as before', () => {
+  const { dir, write } = newFixtureRepo();
+  write('tracked_test.go', 'package main\n\nfunc TestBad(t *testing.T) { t.Skip("flaky") }\n');
+  const add = spawnSync('git', ['add', 'tracked_test.go'], { cwd: dir, encoding: 'utf8' });
+  assert.equal(add.status, 0, add.stderr);
+  const { status, out } = runGate('t-skip', dir);
+  assert.notEqual(status, 0, `t-skip must still fail on a tracked t.Skip file; got:\n${out}`);
+  assert.match(out, /tracked_test\.go/);
+});
+
+test('the CLI rejects an unknown CHECK rather than passing silently', () => {
+  const { dir } = newFixtureRepo();
+  const { status, out } = runGate('', dir);
+  assert.notEqual(status, 0);
+  assert.match(out, /unknown CHECK/);
+});

--- a/.github/scripts/gh.test.mjs
+++ b/.github/scripts/gh.test.mjs
@@ -13,8 +13,12 @@
 
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
-import { assertSafeArg, capture } from './lib/gh.mjs';
+import { assertSafeArg, capture, lsFiles } from './lib/gh.mjs';
 
 test('capture forwards the options it documents', () => {
   const res = capture('sh', ['-c', 'printf "%s" "$MARKER"'], {
@@ -72,4 +76,59 @@ test('assertSafeArg rejects a value that could be parsed as a flag', () => {
 
 test('assertSafeArg ignores non-string values (the common `undefined` no-override case)', () => {
   assert.equal(assertSafeArg(undefined, 'REV'), undefined);
+});
+
+// lsFiles() — issue #1938. A plain `git ls-files` reads the INDEX only, so a
+// file a generator just wrote but nobody `git add`-ed yet was invisible to
+// every forbid-skip.mjs scan (all of them route through this function): the
+// scan reported clean on content it would reject the moment it was staged.
+// `newRepo()` builds a throwaway git repository so the assertion is against
+// the real CLI, not a mock.
+function newRepo() {
+  const dir = mkdtempSync(join(tmpdir(), 'gh-lsfiles-'));
+  const run = (args) => {
+    const res = spawnSync('git', args, { cwd: dir, encoding: 'utf8' });
+    assert.equal(res.status, 0, `git ${args.join(' ')} failed: ${res.stderr}`);
+  };
+  run(['init', '--quiet']);
+  writeFileSync(join(dir, 'tracked.go'), 'package main\n');
+  run(['add', 'tracked.go']);
+  run(['-c', 'user.email=a@a', '-c', 'user.name=a', 'commit', '--quiet', '-m', 'seed']);
+  return { dir, run };
+}
+
+test('lsFiles includes an untracked-but-not-ignored file, not just the git index', () => {
+  const { dir } = newRepo();
+  // A generator wrote this file but it was never `git add`-ed.
+  writeFileSync(join(dir, 'generated_test.go'), 'package main\n\nfunc TestFoo() {}\n');
+  const files = lsFiles(['*.go'], { cwd: dir });
+  assert.ok(
+    files.includes('generated_test.go'),
+    `expected the untracked file among ${JSON.stringify(files)}`,
+  );
+  assert.ok(files.includes('tracked.go'));
+});
+
+test('lsFiles still excludes a .gitignored file', () => {
+  const { dir, run } = newRepo();
+  writeFileSync(join(dir, '.gitignore'), 'ignored.go\n');
+  run(['add', '.gitignore']);
+  run(['-c', 'user.email=a@a', '-c', 'user.name=a', 'commit', '--quiet', '-m', 'gitignore']);
+  writeFileSync(join(dir, 'ignored.go'), 'package main\n');
+  const files = lsFiles(['*.go'], { cwd: dir });
+  assert.ok(!files.includes('ignored.go'), `.gitignore-d file leaked into ${JSON.stringify(files)}`);
+});
+
+test('lsFiles honours an exclude pathspec against an untracked file, same as a tracked one', () => {
+  const { dir } = newRepo();
+  // Deliberately left untracked (never `git add`-ed) — the exclude pathspec
+  // must still apply to it, not just to indexed paths.
+  const upstream = join(dir, 'compatibility', 'promql', 'upstream');
+  spawnSync('mkdir', ['-p', upstream]);
+  writeFileSync(join(upstream, 'vendored_test.go'), 'package main\n');
+  const files = lsFiles(['*_test.go', ':!:compatibility/*/upstream/**'], { cwd: dir });
+  assert.ok(
+    !files.some((f) => f.includes('upstream')),
+    `exclude pathspec did not apply to an untracked path: ${JSON.stringify(files)}`,
+  );
 });

--- a/.github/scripts/lib/gh.mjs
+++ b/.github/scripts/lib/gh.mjs
@@ -157,11 +157,24 @@ export function git(args, opts = {}) {
   return capture('git', args, opts);
 }
 
-// lsFiles() — `git ls-files -z <pathspecs>` -> string[] of tracked paths.
+// lsFiles() — `git ls-files -z <pathspecs>` -> string[] of paths in scope.
 // Honours include globs and `:!:`/`:(exclude)` exclude pathspecs exactly
-// as the extracted bash did (git ls-files already drops .gitignored paths).
+// as the extracted bash did.
+//
+// `--cached --others --exclude-standard` rather than the bare tracked-only
+// default: a file a generator just wrote but nobody `git add`-ed yet is
+// invisible to a plain `git ls-files`, which reads the INDEX and nothing
+// else. That is sound in CI (the runner checks out a committed tree, so
+// nothing in scope is ever untracked) and sound in the pre-push hook (by
+// push time everything scanned is committed), but it is a real gap for a
+// scan run directly against a local working tree mid-edit — exactly the
+// narrowed local reproduction CLAUDE.md's contribution rules ask for after
+// a red CI check (issue #1938). `--exclude-standard` keeps `.gitignore`d
+// paths out of scope exactly as before; only the untracked-but-NOT-ignored
+// subset is newly included, and it is included for every caller (every
+// `forbid-skip.mjs` scan routes through this one function).
 export function lsFiles(pathspecs, opts = {}) {
-  const res = git(['ls-files', '-z', '--', ...pathspecs], opts);
+  const res = git(['ls-files', '-z', '--cached', '--others', '--exclude-standard', '--', ...pathspecs], opts);
   if (res.status !== 0) {
     error(`git ls-files failed: ${res.stderr.trim()}`);
     process.exit(res.status);

--- a/.github/scripts/repo-hygiene.mjs
+++ b/.github/scripts/repo-hygiene.mjs
@@ -38,10 +38,17 @@
 //                         `uses:` form only, so prose that NAMES the Action
 //                         (this comment included) stays legal.
 //
-// All three scans read the tracked set from `git ls-files`, so .gitignored
-// paths are out of scope by construction: the companion fix for an artefact
-// this gate catches is usually a `git rm` PLUS a .gitignore rule, and the
-// ignore rule alone is what keeps it from coming back.
+// All three scans read their file set from `git ls-files`, restricted to the
+// tracked INDEX plus every untracked-but-NOT-ignored working-tree path
+// (`pathsInScope()` / `blobsInScope()` below) — so a `.gitignore`d path stays
+// out of scope by construction (the companion fix for an artefact this gate
+// catches is usually a `git rm` PLUS a .gitignore rule, and the ignore rule
+// alone is what keeps it from coming back), but a file that merely has not
+// been `git add`-ed yet does not. Reading the INDEX alone would miss exactly
+// that case: a generator writes a new file and nobody has staged it, which is
+// sound on CI (the runner checks out a committed tree) but a real gap for
+// `node .github/scripts/repo-hygiene.mjs` run directly against a local
+// working tree mid-edit (issue #1938).
 //
 // The gate fails CLOSED. A tracked blob whose content cannot be read is an
 // error, not a pass: we retry it out of the object store via `git cat-file`
@@ -55,7 +62,7 @@
 //
 // Exit codes: 0 = clean, 1 = a violation was found (or bad $CHECK).
 
-import { closeSync, openSync, readFileSync, readSync } from 'node:fs';
+import { closeSync, lstatSync, openSync, readFileSync, readSync } from 'node:fs';
 import process from 'node:process';
 
 import { capture, error, git, log, notice } from './lib/gh.mjs';
@@ -198,16 +205,51 @@ export function loginActionUses(source) {
   return hits;
 }
 
-// trackedBlobs — `git ls-files -s` -> [{ mode, sha, path }] for the entries
-// that carry sniffable content. Submodule gitlinks and symlinks are dropped
-// here (they have no blob in this repository / store a path, not content).
-function trackedBlobs() {
+// pathsInScope — `git ls-files` restricted to CONTENT this gate should ever
+// see: every tracked path (the git INDEX) PLUS every untracked path git
+// itself would not ignore (`--others --exclude-standard`). `--exclude-standard`
+// keeps `.gitignore`d paths out of scope exactly as before; only the
+// untracked-but-NOT-ignored subset is newly in scope (issue #1938). Shared by
+// the root-allowlist and registry-login scans, which only need paths.
+function pathsInScope(pathspecs = []) {
+  const res = git(['ls-files', '-z', '--cached', '--others', '--exclude-standard', '--', ...pathspecs]);
+  if (res.status !== 0) {
+    error(`git ls-files failed: ${res.stderr.trim()}`);
+    process.exit(res.status);
+  }
+  return res.stdout.split('\0').filter((p) => p.length > 0);
+}
+
+// untrackedPaths — the `--others` half of pathsInScope() in isolation, as
+// bare paths with no mode/sha (untracked paths carry no index record).
+// blobsInScope() below is the only caller: it needs the tracked and
+// untracked halves separately, because only the tracked half has a blob SHA
+// to fall back on.
+function untrackedPaths() {
+  const res = git(['ls-files', '-z', '--others', '--exclude-standard']);
+  if (res.status !== 0) {
+    error(`git ls-files failed: ${res.stderr.trim()}`);
+    process.exit(res.status);
+  }
+  return res.stdout.split('\0').filter((p) => p.length > 0);
+}
+
+// blobsInScope — [{ mode, sha, path }] for every entry that carries
+// sniffable content: every tracked blob (`git ls-files -s`, mode + blob SHA)
+// PLUS every untracked-but-not-ignored working-tree file (`sha: null` — the
+// working tree is the ONLY source of its content, since it was never
+// written to the object store). Submodule gitlinks and symlinks are dropped
+// for the tracked half (they have no blob in this repository / store a
+// path, not content); an untracked symlink is dropped the same way, by
+// `lstat`ing it directly since it carries no index mode to read.
+function blobsInScope() {
   const res = git(['ls-files', '-s', '-z']);
   if (res.status !== 0) {
     error(`git ls-files failed: ${res.stderr.trim()}`);
     process.exit(res.status);
   }
   const out = [];
+  const tracked = new Set();
   for (const record of res.stdout.split('\0')) {
     if (record.length === 0) continue;
     // Format: `<mode> <sha> <stage>\t<path>`
@@ -217,16 +259,31 @@ function trackedBlobs() {
       process.exit(1);
     }
     const [mode, sha] = record.slice(0, tab).split(/\s+/);
-    out.push({ mode, sha, path: record.slice(tab + 1) });
+    const path = record.slice(tab + 1);
+    tracked.add(path);
+    out.push({ mode, sha, path });
+  }
+  for (const path of untrackedPaths()) {
+    if (tracked.has(path)) continue; // defensive; --others never reports a tracked path
+    let stat;
+    try {
+      stat = lstatSync(path);
+    } catch {
+      continue; // vanished between the listing and the stat — nothing left to scan
+    }
+    if (!stat.isFile()) continue; // symlink (or anything else that isn't a plain file)
+    out.push({ mode: modeRegularFile, sha: null, path });
   }
   return out;
 }
 
-// readHead — the leading sniff block of a tracked blob. Prefers the working
+// readHead — the leading sniff block of a blob in scope. Prefers the working
 // tree (one bounded read, no subprocess) and falls back to the object store
-// when the file is absent or unreadable there. Exits non-zero if neither
-// route yields content: an unreadable tracked blob is a gate failure, never
-// an implicit pass.
+// when the file is absent or unreadable there AND a blob SHA exists to read
+// it from — an untracked entry (`sha: null`) has no object-store copy at
+// all, so the working tree is its only possible source. Exits non-zero if no
+// route yields content: an unreadable entry is a gate failure, never an
+// implicit pass.
 function readHead({ sha, path }) {
   const buf = Buffer.alloc(gitBinarySniffBytes);
   try {
@@ -241,6 +298,10 @@ function readHead({ sha, path }) {
     // Fall through to the object store: a tracked path can legitimately be
     // missing from the working tree (sparse checkout, mid-rebase).
   }
+  if (!sha) {
+    error(`repo-hygiene: cannot read untracked file ${path} from the working tree — refusing to classify it as text`);
+    process.exit(1);
+  }
   const res = capture('git', ['cat-file', 'blob', sha], { encoding: 'buffer' });
   if (res.status !== 0) {
     error(
@@ -254,7 +315,7 @@ function readHead({ sha, path }) {
 
 function scanBinary() {
   const violations = [];
-  for (const entry of trackedBlobs()) {
+  for (const entry of blobsInScope()) {
     if (entry.mode !== modeRegularFile && entry.mode !== modeExecutableFile) continue;
     const { binary, format } = classifyBlob(readHead(entry));
     if (binary) violations.push({ path: entry.path, format });
@@ -274,12 +335,7 @@ function scanBinary() {
 }
 
 function scanRootAllowlist() {
-  const res = git(['ls-files', '-z']);
-  if (res.status !== 0) {
-    error(`git ls-files failed: ${res.stderr.trim()}`);
-    process.exit(res.status);
-  }
-  const entries = rootEntriesOf(res.stdout.split('\0').filter((p) => p.length > 0));
+  const entries = rootEntriesOf(pathsInScope());
   const { unexpected, stale } = diffAllowlist(entries, ROOT_ALLOWLIST);
   for (const e of unexpected) log(`${e}: untracked-by-policy entry at the repository root`);
   for (const e of stale) log(`${e}: allow-listed root entry that is no longer tracked`);
@@ -305,13 +361,7 @@ function scanRootAllowlist() {
 }
 
 function scanRegistryLogin() {
-  const res = git(['ls-files', '-z', '.github/workflows']);
-  if (res.status !== 0) {
-    error(`git ls-files failed: ${res.stderr.trim()}`);
-    process.exit(res.status);
-  }
-  const workflows = res.stdout
-    .split('\0')
+  const workflows = pathsInScope(['.github/workflows'])
     .filter((p) => p.endsWith('.yml') || p.endsWith('.yaml'))
     .sort();
   const violations = [];

--- a/.github/scripts/repo-hygiene.test.mjs
+++ b/.github/scripts/repo-hygiene.test.mjs
@@ -149,12 +149,43 @@ test('the CLI FAILS on a committed binary, naming the file and the format', () =
   assert.match(out, /perf-profile: ELF executable/);
 });
 
+// #1938: every scan used to read the tracked INDEX only (`git ls-files`),
+// so a file present in the working tree but never `git add`-ed was invisible
+// — the gate reported clean on content it would reject the instant the file
+// was staged. Deliberately NOT calling stage() here is the point: these two
+// cases pin that an UNTRACKED violation is still caught.
+test('the CLI FAILS on an UNTRACKED binary, naming the file and the format (#1938)', () => {
+  const { dir } = newFixtureRepo();
+  writeFileSync(join(dir, 'perf-profile'), syntheticElf());
+  const { status, out } = runGate('binary', dir);
+  assert.notEqual(
+    status,
+    0,
+    `the binary scan must fail on an untracked binary; a tracked-only regression would exit 0 here:\n${out}`,
+  );
+  assert.match(out, /::error::/);
+  assert.match(out, /perf-profile: ELF executable/);
+});
+
 test('the CLI FAILS on a stray root file, naming it', () => {
   const { dir, stage } = newFixtureRepo();
   writeFileSync(join(dir, 'release-pr-body.md'), fixtureContent);
   stage();
   const { status, out } = runGate('root-allowlist', dir);
   assert.notEqual(status, 0, `the root scan must fail; got:\n${out}`);
+  assert.match(out, /::error::/);
+  assert.match(out, /release-pr-body\.md/);
+});
+
+test('the CLI FAILS on an UNTRACKED stray root file, naming it (#1938)', () => {
+  const { dir } = newFixtureRepo();
+  writeFileSync(join(dir, 'release-pr-body.md'), fixtureContent);
+  const { status, out } = runGate('root-allowlist', dir);
+  assert.notEqual(
+    status,
+    0,
+    `the root scan must fail on an untracked stray file; a tracked-only regression would exit 0 here:\n${out}`,
+  );
   assert.match(out, /::error::/);
   assert.match(out, /release-pr-body\.md/);
 });
@@ -166,13 +197,14 @@ test('the CLI rejects an unknown CHECK rather than passing silently', () => {
   assert.match(out, /unknown CHECK/);
 });
 
-// newWorkflowFixtureRepo — a throwaway repo carrying one tracked workflow.
-// Deliberately NOT newFixtureRepo(): that helper materialises every
+// newWorkflowFixtureRepo — a throwaway repo carrying one workflow, tracked by
+// default. Deliberately NOT newFixtureRepo(): that helper materialises every
 // ROOT_ALLOWLIST entry as a plain FILE, so `.github` there is a file and
 // could never hold `.github/workflows/*.yml`. The registry-login scan reads
-// the tracked workflow set and ignores the rest of the root, so a minimal
+// the workflow set in scope and ignores the rest of the root, so a minimal
 // repo is both sufficient and honest about what the scan actually looks at.
-function newWorkflowFixtureRepo(workflowYaml) {
+// Pass `stage: false` to leave the workflow file untracked (#1938 case).
+function newWorkflowFixtureRepo(workflowYaml, { stage = true } = {}) {
   const dir = mkdtempSync(join(tmpdir(), 'repo-hygiene-wf-'));
   const run = (args) => {
     const res = spawnSync('git', args, { cwd: dir, encoding: 'utf8' });
@@ -181,7 +213,7 @@ function newWorkflowFixtureRepo(workflowYaml) {
   run(['init', '--quiet']);
   mkdirSync(join(dir, '.github', 'workflows'), { recursive: true });
   writeFileSync(join(dir, '.github', 'workflows', 'probe.yml'), workflowYaml);
-  run(['add', '-A']);
+  if (stage) run(['add', '-A']);
   return dir;
 }
 
@@ -213,6 +245,21 @@ test('the CLI FAILS on a workflow that uses docker/login-action, naming file:lin
   assert.match(out, /::error::/);
   assert.match(out, /\.github\/workflows\/probe\.yml:4/);
   assert.match(out, /registry-login\.mjs/);
+});
+
+test('the CLI FAILS on an UNTRACKED workflow that uses docker/login-action (#1938)', () => {
+  const dir = newWorkflowFixtureRepo(
+    ['jobs:', '  a:', '    steps:', '      - uses: docker/login-action@v4', ''].join('\n'),
+    { stage: false },
+  );
+  const { status, out } = runGate('registry-login', dir);
+  assert.notEqual(
+    status,
+    0,
+    `the registry-login scan must fail on an untracked workflow; a tracked-only regression would exit 0 here:\n${out}`,
+  );
+  assert.match(out, /::error::/);
+  assert.match(out, /\.github\/workflows\/probe\.yml:4/);
 });
 
 test('the CLI PASSES on a workflow that runs the retrying login script', () => {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -561,6 +561,15 @@ jobs:
       # `.github/scripts/README.md` for the convention. The regexes are
       # kept byte-identical to scripts/test-forbid-skip.sh (the self-test
       # step at the end of this job pins them).
+      #
+      # This CLI-level self-test runs FIRST: it builds a throwaway git repo
+      # and proves each scan fires on an UNTRACKED violating file (present in
+      # the working tree, never `git add`-ed), not only a committed one —
+      # every scan derives its file set from lib/gh.mjs's lsFiles(), which
+      # used to read the git INDEX only and so reported clean on exactly this
+      # shape locally (issue #1938).
+      - name: Self-test the forbid-skip CLI
+        run: node --test .github/scripts/forbid-skip.test.mjs
       - name: Reject t.Skip in test files
         run: node .github/scripts/forbid-skip.mjs
         env:


### PR DESCRIPTION
## The bug

`forbid-skip` and `repo-hygiene` both derive their file set from `git ls-files`, which lists git INDEX entries only. A file present in the working tree but never `git add`-ed is invisible to both gates, so they report clean on content that would be rejected the instant the file is staged.

- `.github/scripts/lib/gh.mjs`'s `lsFiles()` — the shared helper every `forbid-skip.mjs` scan (and `forbid-sql-raw.mjs` / `doc-refs.mjs`) routes through — ran a bare `git ls-files -z`.
- `.github/scripts/repo-hygiene.mjs`'s three scans each read their own `git ls-files` call directly (`trackedBlobs()` for the binary scan, and two inline calls for the root-allowlist and registry-login scans).

This is sound on CI (the runner checks out a committed tree, so nothing in scope is ever untracked) and sound in the `lefthook.yml` `pre-push` hook path (by push time everything scanned is committed). The gap is purely local: running `node .github/scripts/forbid-skip.mjs` directly after a generator writes a new file, before it's staged, scans a file set that doesn't include it — which matters because CLAUDE.md's own contribution rules require reproducing a red check locally, narrowed, before the next push, and a local gate that can silently omit a new file undercuts exactly that.

## The fix

`lsFiles()` now runs `git ls-files -z --cached --others --exclude-standard -- <pathspecs>` in one call — the untracked-but-not-ignored subset joins the tracked set, while `--exclude-standard` keeps `.gitignore`d paths out of scope exactly as before. Fixing it once in `lib/gh.mjs` closes the gap for every `forbid-skip.mjs` scan (and, incidentally, `forbid-sql-raw.mjs` and `doc-refs.mjs`, which share the same helper).

`repo-hygiene.mjs` doesn't use `lsFiles()`, and its binary scan needs blob SHAs (`git ls-files -s`) that an untracked file simply doesn't have, so it gets its own handling:

- `pathsInScope(pathspecs)` — tracked + untracked-not-ignored paths, for the root-allowlist and registry-login scans (which only need paths; registry-login already reads workflow content straight off disk via `readFileSync`).
- `blobsInScope()` — replaces `trackedBlobs()`. Tracked entries keep their `{ mode, sha, path }` shape; untracked entries get `{ mode: modeRegularFile, sha: null, path }` (an `lstat` drops symlinks, mirroring how the tracked half already drops them). `readHead()` now treats a null `sha` as "no object-store fallback exists" — the working-tree read is the ONLY possible source for an untracked file's content, and a failure there is a hard error rather than an implicit pass.

## Verification

- `forbid-skip.test.mjs` (new) drives the real CLI against a throwaway git repo and proves `CHECK=t-skip` fails on an untracked `t.Skip` file (not only a committed one), that the `compatibility/*/upstream/**` exclude pathspec still applies to an untracked path, and that a tracked violation still fails as before.
- `repo-hygiene.test.mjs` gains three untracked-file cases — one per scan (binary / root-allowlist / registry-login) — alongside the existing tracked-file cases.
- `gh.test.mjs` gains direct `lsFiles()` cases: picks up an untracked file, still excludes a `.gitignore`d one, and still honours an exclude pathspec against an untracked path.
- Confirmed every new case fails when the corresponding fix is temporarily reverted, and passes with it restored.
- Full local repro of the two lanes on the live tree: `node --test .github/scripts/repo-hygiene.test.mjs .github/scripts/forbid-skip.test.mjs .github/scripts/gh.test.mjs` (30/30 green), plus every `CHECK` arm of both `forbid-skip.mjs` and `repo-hygiene.mjs`, `scripts/test-forbid-skip.sh`, `doc-refs.mjs`, `forbid-sql-raw.mjs`, `doc-counts.mjs --self-test` + gate, `actionlint`, and `just lint-md` — all green.
- `lefthook`'s `pre-push` hook (which runs a subset of these same scans) passed on its own when this branch was pushed.

Closes #1938