### PR TITLE
fix(chdb): stop a session's exception from corrupting the next query's Parquet decode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -234,7 +234,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.1-0.20220228012449-10b1cf09e00b // indirect
 	github.com/parquet-go/bitpack v1.0.0 // indirect
 	github.com/parquet-go/jsonlite v1.0.0 // indirect
-	github.com/parquet-go/parquet-go v0.29.0 // indirect
+	github.com/parquet-go/parquet-go v0.30.1 // indirect
 	github.com/pascaldekloe/name v1.0.1 // indirect
 	github.com/paulmach/orb v0.13.0 // indirect
 	github.com/pb33f/jsonpath v0.8.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -578,8 +578,8 @@ github.com/parquet-go/bitpack v1.0.0 h1:AUqzlKzPPXf2bCdjfj4sTeacrUwsT7NlcYDMUQxP
 github.com/parquet-go/bitpack v1.0.0/go.mod h1:XnVk9TH+O40eOOmvpAVZ7K2ocQFrQwysLMnc6M/8lgs=
 github.com/parquet-go/jsonlite v1.0.0 h1:87QNdi56wOfsE5bdgas0vRzHPxfJgzrXGml1zZdd7VU=
 github.com/parquet-go/jsonlite v1.0.0/go.mod h1:nDjpkpL4EOtqs6NQugUsi0Rleq9sW/OtC1NnZEnxzF0=
-github.com/parquet-go/parquet-go v0.29.0 h1:xXlPtFVR51jpSVzf+cgHnNIcb7Xet+iuvkbe0HIm90Y=
-github.com/parquet-go/parquet-go v0.29.0/go.mod h1:navtkAYr2LGoJVp141oXPlO/sxLvaOe3la2JEoD8+rg=
+github.com/parquet-go/parquet-go v0.30.1 h1:Oy6ganNrAdFiVwy7wNmWagfPTWA2X9Z3tVHBc7JtuX8=
+github.com/parquet-go/parquet-go v0.30.1/go.mod h1:navtkAYr2LGoJVp141oXPlO/sxLvaOe3la2JEoD8+rg=
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/name v1.0.1 h1:9lnXOHeqeHHnWLbKfH6X98+4+ETVqFqxN09UXSjcMb0=

--- a/internal/chclienttest/client.go
+++ b/internal/chclienttest/client.go
@@ -47,17 +47,21 @@ type Client struct {
 // interfaces. Each test gets an isolated session — there is no
 // process-wide shared state.
 //
-// One session carries at most one FAILING query. chDB hands results back
-// as Parquet, and chdb-go v1.12.0 emits an undecodable page index for the
-// first query that SUCCEEDS on a session where an earlier query raised a
-// ClickHouse exception; parquet-go v0.29.0 panics inside NewGenericReader
-// rather than returning an error, so the handler under test answers 500
-// and the assertion reads as a cerberus regression. A test that asserts a
-// rejection and a success — the guard tests, which raise through throwIf —
-// therefore opens a session per phase. Sessions are independent: a fresh
-// one is unaffected by any earlier session's exception. Real ClickHouse
-// speaks the native protocol and has no such coupling, so this binds the
-// chdb lane only.
+// A test that asserts a rejection followed by a success on the SAME
+// session (the guard tests, which raise through throwIf) does not need
+// to split that into two sessions. chDB hands results back as Parquet,
+// and chdb-go v1.12.0 emits an undecodable page index for the first
+// query that SUCCEEDS on a session where an earlier query raised a
+// ClickHouse exception; parquet-go v0.30.1 panics inside NewGenericReader
+// rather than returning an error (issue #1917). queryContext (see below)
+// contains this at the source: it recovers the panic as a plain error
+// and, after any query error, flushes the session with a trivial Exec
+// that empirically prevents the corruption from reaching the next
+// query — proven by TestSessionSurvivesErrorThenSuccess in
+// session_recovery_test.go. Opening a fresh session per phase (as
+// several existing chdb-tagged tests do) still works and remains
+// harmless, just no longer necessary. Real ClickHouse speaks the native
+// protocol and has no such coupling, so this binds the chdb lane only.
 func NewChDB(t testing.TB) *Client {
 	t.Helper()
 	// Empty DSN -> chdb-go provisions a temp-dir-backed session that
@@ -84,6 +88,77 @@ func NewChDBWithError(_ *testing.T, err error) *Client {
 		err = fmt.Errorf("chclienttest: injected error")
 	}
 	return &Client{err: err}
+}
+
+// queryContext is the single choke point every Querier method routes
+// its QueryContext call through. It exists to contain issue #1917: a
+// chDB session that raised a ClickHouse exception corrupts the Parquet
+// page index of the NEXT query's result set, and chdb-go v1.12.0 /
+// parquet-go v0.30.1 (both current as of the fix) still exhibit it —
+// parquet-go panics inside NewGenericReader decoding the corrupted
+// index instead of returning an error.
+//
+// Two independent layers address it:
+//
+//  1. flushSessionAfterError: measured empirically, issuing a trivial
+//     ExecContext (a statement that never goes through the Parquet
+//     decode path at all — Exec, not Query) on the SAME session
+//     immediately after ANY query error reliably prevents the
+//     corruption from reaching the next query. This is the real fix:
+//     it is what makes the NEXT query come back with a genuine 200
+//     instead of a spurious failure, which a recover() alone cannot
+//     do (recover only stops a crash; it can't manufacture the correct
+//     result). Best-effort: the flush's own error is discarded, since
+//     if it fails there is nothing more we can do here and the
+//     caller's original error is already on its way.
+//  2. The recover in safeQueryContext converts the parquet-go panic
+//     into a normal Go error rather than letting it unwind past this
+//     package into the panic-recovery middleware, where it would read
+//     as a genuine handler regression. This is defense-in-depth for
+//     any sequence the flush does not fully cover (multiple pooled
+//     connections, a caller that bypasses Seed) — it guarantees a
+//     *caller-visible error*, never a guarantee of a correct result;
+//     recovering a panic cannot undo corrupted bytes that already
+//     decoded wrong.
+//
+// Both are test-harness-only mitigations for a third-party decoder
+// that must not assume its input is well-formed; they narrowly recover
+// from ONE documented panic site and never suppress a genuine cerberus
+// bug — a real handler regression still surfaces as its own error or
+// wrong-shaped response, not as this recovered panic.
+func (c *Client) queryContext(ctx context.Context, queryText string, args ...any) (*sql.Rows, error) {
+	rows, err := safeQueryContext(ctx, c.db, queryText, args...)
+	if err != nil {
+		flushSessionAfterError(ctx, c.db)
+	}
+	return rows, err
+}
+
+// safeQueryContext runs db.QueryContext and converts a parquet-go
+// decode panic (issue #1917) into a plain error. The panic surfaces
+// synchronously from inside QueryContext itself (chdb-go's PARQUET
+// driver decodes the page index eagerly, before returning rows), so
+// wrapping this one call site is sufficient — there is no rows object
+// in flight yet when the panic fires.
+func safeQueryContext(ctx context.Context, db *sql.DB, queryText string, args ...any) (rows *sql.Rows, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("chclienttest: recovered chdb/parquet-go decode panic on corrupted "+
+				"Parquet page index (see #1917): %v", r)
+		}
+	}()
+	return db.QueryContext(ctx, queryText, args...)
+}
+
+// flushSessionAfterError issues a trivial statement on db that never
+// touches the Parquet decode path (Exec, not Query). Measured
+// empirically against chdb-go v1.12.0 / parquet-go v0.30.1: this is
+// what actually prevents issue #1917's corruption from reaching the
+// next query on the same session. Best-effort — its own error is
+// discarded because the caller's real error from the query that
+// triggered it is already the one being returned.
+func flushSessionAfterError(ctx context.Context, db *sql.DB) {
+	_, _ = db.ExecContext(ctx, "SELECT 1")
 }
 
 // Seed runs ddl (a multi-statement script of `CREATE …; INSERT …;` etc)
@@ -129,7 +204,7 @@ func (c *Client) Query(ctx context.Context, query string, args ...any) ([]chclie
 		return nil, c.err
 	}
 	rewritten := withQuerySettings(ctx, testsql.RewriteMapProjections(query))
-	rows, err := c.db.QueryContext(ctx, rewritten, args...)
+	rows, err := c.queryContext(ctx, rewritten, args...)
 	if err != nil {
 		return nil, fmt.Errorf("chclienttest: query: %w", err)
 	}
@@ -208,7 +283,7 @@ func (c *Client) QueryStrings(ctx context.Context, query string, args ...any) ([
 	if c.err != nil {
 		return nil, c.err
 	}
-	rows, err := c.db.QueryContext(ctx, query, args...)
+	rows, err := c.queryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("chclienttest: query: %w", err)
 	}
@@ -242,7 +317,7 @@ func (c *Client) QueryDetectedFieldRows(ctx context.Context, query string, args 
 		return nil, c.err
 	}
 	rewritten := testsql.RewriteMapProjections(query)
-	rows, err := c.db.QueryContext(ctx, rewritten, args...)
+	rows, err := c.queryContext(ctx, rewritten, args...)
 	if err != nil {
 		return nil, fmt.Errorf("chclienttest: query: %w", err)
 	}
@@ -297,7 +372,7 @@ func (c *Client) QueryTimestampedLines(ctx context.Context, query string, args .
 	if c.err != nil {
 		return nil, c.err
 	}
-	rows, err := c.db.QueryContext(ctx, query, args...)
+	rows, err := c.queryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("chclienttest: query: %w", err)
 	}
@@ -332,7 +407,7 @@ func (c *Client) QueryExemplars(ctx context.Context, query string, args ...any) 
 		return nil, c.err
 	}
 	rewritten := testsql.RewriteMapProjections(query)
-	rows, err := c.db.QueryContext(ctx, rewritten, args...)
+	rows, err := c.queryContext(ctx, rewritten, args...)
 	if err != nil {
 		return nil, fmt.Errorf("chclienttest: query: %w", err)
 	}
@@ -383,7 +458,7 @@ func (c *Client) QueryLabelSets(ctx context.Context, query string, args ...any) 
 		return nil, c.err
 	}
 	rewritten := testsql.RewriteMapProjections(query)
-	rows, err := c.db.QueryContext(ctx, rewritten, args...)
+	rows, err := c.queryContext(ctx, rewritten, args...)
 	if err != nil {
 		return nil, fmt.Errorf("chclienttest: query: %w", err)
 	}
@@ -417,7 +492,7 @@ func (c *Client) QueryMetricMeta(
 	if c.err != nil {
 		return nil, c.err
 	}
-	rows, err := c.db.QueryContext(ctx, query, args...)
+	rows, err := c.queryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("chclienttest: query: %w", err)
 	}
@@ -445,7 +520,7 @@ func (c *Client) QueryIndexStats(ctx context.Context, query string, args ...any)
 	if c.err != nil {
 		return chclient.IndexStatsRow{}, c.err
 	}
-	rows, err := c.db.QueryContext(ctx, query, args...)
+	rows, err := c.queryContext(ctx, query, args...)
 	if err != nil {
 		return chclient.IndexStatsRow{}, fmt.Errorf("chclienttest: query: %w", err)
 	}
@@ -470,7 +545,7 @@ func (c *Client) QueryIndexVolume(ctx context.Context, query string, args ...any
 		return nil, c.err
 	}
 	rewritten := testsql.RewriteMapProjections(query)
-	rows, err := c.db.QueryContext(ctx, rewritten, args...)
+	rows, err := c.queryContext(ctx, rewritten, args...)
 	if err != nil {
 		return nil, fmt.Errorf("chclienttest: query: %w", err)
 	}

--- a/internal/chclienttest/session_recovery_test.go
+++ b/internal/chclienttest/session_recovery_test.go
@@ -1,0 +1,111 @@
+//go:build chdb
+
+package chclienttest
+
+import (
+	"context"
+	"testing"
+)
+
+// sessionRecoverySeedDDL mirrors the production Map-column projection
+// shape (an `Attributes` column, one of the names testsql.IsMapColumn
+// recognises) so the query below rides the same toJSONString(...)
+// rewrite production queries do, rather than an unwrapped Map column —
+// which chdb-go's parquet driver cannot decode under any circumstance
+// (a separate, pre-existing, unconditional bug) and would make this
+// test conflate two different failure modes.
+const sessionRecoverySeedDDL = `CREATE TABLE session_recovery_probe (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = Memory;
+INSERT INTO session_recovery_probe VALUES ('probe', map('k', 'v'), now64(9), 1.0);`
+
+const sessionRecoveryPlainQuery = `SELECT MetricName, Attributes, TimeUnix, Value FROM session_recovery_probe`
+
+// sessionRecoveryBoomQuery raises a ClickHouse exception via throwIf —
+// the same guard idiom internal/promql's duplicate-labelset and
+// many-to-many guards plant in real emitted SQL (see
+// internal/promql/duplicate_labelset_guard.go, internal/promql/info_fn.go).
+const sessionRecoveryBoomQuery = sessionRecoveryPlainQuery + ` WHERE throwIf(1 = 1, 'boom') = 0`
+
+// TestSessionSurvivesErrorThenSuccess is the regression test for issue
+// #1917: a chDB session that raised a ClickHouse exception used to
+// corrupt the Parquet page index of the NEXT query's result set,
+// crashing parquet-go's NewGenericReader with a panic instead of
+// returning an error. Left unrecovered, that panic propagates through
+// a handler under test as a spurious 500 — indistinguishable from a
+// real cerberus regression — even though the query that panicked was
+// syntactically and semantically fine on its own.
+//
+// This runs the exact boom-then-plain sequence on ONE session (no
+// second Client, no fresh session) and asserts the second query
+// SUCCEEDS with its real row back — not merely "does not panic". A
+// bare recover() that converted the panic into an error would satisfy
+// a weaker test but not this one: it would still leave the plain query
+// spuriously failing. The actual fix is queryContext's flush-after-error
+// (see client.go), which keeps the session itself usable; the recover
+// in safeQueryContext is the defense-in-depth layer that guarantees the
+// failure mode is at worst a Go error, never an unrecovered panic,
+// for any case the flush doesn't fully cover.
+func TestSessionSurvivesErrorThenSuccess(t *testing.T) {
+	c := NewChDB(t)
+	ctx := context.Background()
+	c.Seed(t, sessionRecoverySeedDDL)
+
+	if _, err := c.Query(ctx, sessionRecoveryBoomQuery); err == nil {
+		t.Fatalf("boom query: expected a ClickHouse exception, got nil error")
+	}
+
+	// The corruption in #1917 hits the very next query on the SAME
+	// session. This must come back as a genuine success, not a panic
+	// and not a spurious error — that's the whole point of the fix.
+	rows, err := c.Query(ctx, sessionRecoveryPlainQuery)
+	if err != nil {
+		t.Fatalf("plain query after a prior exception on the same session: got error %v, want success", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("plain query after a prior exception: got %d rows, want 1", len(rows))
+	}
+	if got := rows[0].MetricName; got != "probe" {
+		t.Errorf("plain query row: MetricName = %q, want %q", got, "probe")
+	}
+	if got := rows[0].Labels["k"]; got != "v" {
+		t.Errorf("plain query row: Attributes[%q] = %q, want %q", "k", got, "v")
+	}
+
+	// A third query on the same session, past the immediately-next one,
+	// must also stay healthy — the fix must not merely paper over the
+	// FIRST post-exception query.
+	rows2, err := c.Query(ctx, sessionRecoveryPlainQuery)
+	if err != nil {
+		t.Fatalf("second plain query after a prior exception: got error %v, want success", err)
+	}
+	if len(rows2) != 1 {
+		t.Fatalf("second plain query after a prior exception: got %d rows, want 1", len(rows2))
+	}
+}
+
+// TestSessionSurvivesRepeatedErrorThenSuccess pins the same behaviour
+// across repeated error/success alternation on one session, since a
+// fix that only accounts for a single error would still leave later
+// alternations vulnerable.
+func TestSessionSurvivesRepeatedErrorThenSuccess(t *testing.T) {
+	c := NewChDB(t)
+	ctx := context.Background()
+	c.Seed(t, sessionRecoverySeedDDL)
+
+	for i := 0; i < 3; i++ {
+		if _, err := c.Query(ctx, sessionRecoveryBoomQuery); err == nil {
+			t.Fatalf("round %d: boom query: expected a ClickHouse exception, got nil error", i)
+		}
+		rows, err := c.Query(ctx, sessionRecoveryPlainQuery)
+		if err != nil {
+			t.Fatalf("round %d: plain query after a prior exception: got error %v, want success", i, err)
+		}
+		if len(rows) != 1 {
+			t.Fatalf("round %d: plain query after a prior exception: got %d rows, want 1", i, len(rows))
+		}
+	}
+}


### PR DESCRIPTION
## What was wrong

A chDB session that raised a ClickHouse exception corrupted the Parquet page index of the NEXT
successful query's result set on that SAME session. `parquet-go` panicked inside `NewGenericReader`
instead of returning an error, so a handler under test answered `500` through the panic-recovery
middleware — indistinguishable from a real cerberus regression (#1917).

## Investigation

1. **Version bump first, as the issue directs.** `chdb-io/chdb-go` is already at the latest release
   (`v1.12.0`); bumped `parquet-go/parquet-go` `v0.29.0 -> v0.30.1` (also latest). Re-measured the
   exact `boom, plain` sequence on one session: the corruption survives the bump (different decode
   error message, same panic). Confirmed with a direct repro before touching any application code.
2. **Root-caused past the panic.** The corrupted state is genuinely session-scoped (not
   connection-pool-scoped), matching the issue's own finding. Empirically (repeated, reliable across
   many runs): issuing a trivial `ExecContext` (a statement that never touches the Parquet decode
   path at all — `Exec`, not `Query`) on the SAME session, immediately after any query error,
   reliably prevents the corruption from reaching the next query. Reopening a whole fresh session
   works too but throws away the session's seeded data unless it's replayed; the trivial-Exec flush
   is the narrower fix and needs neither.

## Fix

- `internal/chclienttest.Client` routes every `QueryContext` call through a new `queryContext`
  helper (`internal/chclienttest/client.go`). After any query error, it flushes the session with
  `ExecContext(ctx, "SELECT 1")` — the empirically verified mitigation.
- `safeQueryContext` wraps the raw `QueryContext` call in a `recover`, converting the parquet-go
  panic into a plain Go error. This is defense-in-depth for any sequence the flush doesn't fully
  cover, narrowly scoped to this one documented third-party decoder defect (a decoder should never
  assume its input is well-formed) — never a general error-hiding mechanism.
- Updated `NewChDB`'s doc comment: opening a fresh session per phase (several existing chdb-tagged
  tests do this) still works and remains harmless, it's just no longer necessary.

## Verification

`internal/chclienttest/session_recovery_test.go` is the regression test the issue's own definition
of done asks for:

- `TestSessionSurvivesErrorThenSuccess` — the exact `boom, plain` sequence on ONE session, asserting
  the second query actually **succeeds with its real row back** (not merely "does not panic"), plus
  a third query past the immediately-next one to prove the fix isn't a one-shot patch.
- `TestSessionSurvivesRepeatedErrorThenSuccess` — three rounds of error/success alternation on one
  session.

Both pass reliably (5/5 local runs each). The full chdb-tagged lane is green:

```
$ just test-chdb
ok  	github.com/tsouza/cerberus/internal/chclienttest	0.734s
ok  	github.com/tsouza/cerberus/internal/api/admit	2.023s
ok  	github.com/tsouza/cerberus/internal/api/loki	5.414s
ok  	github.com/tsouza/cerberus/internal/api/prom	128.884s
ok  	github.com/tsouza/cerberus/internal/api/tempo	3.561s
... (all packages ok)
```

`go vet -tags chdb`, `gofumpt -extra`, and `goimports` are clean on the changed files.

## Out-of-scope finding, filed separately

While investigating, I reproduced a **second, distinct** bug a comment on #1917 had already flagged:
`go test -race -tags chdb ./internal/api/...` SIGSEGVs in `runtime.racefini()` during process exit,
after every test in the run has already passed. Same root cause class (libchdb's process-global
session has no lifecycle discipline on the Go side) but a different symptom (a CGO teardown-ordering
crash under the race detector, not Parquet corruption) and no local Go-side fix — it needs an
upstream reproducer or an explicit, documented `-race`-exemption decision. Filed as #1971 rather than
left as a comment that would go stale once #1917 closes.

Closes #1917