### PR TITLE
fix(logql): seed both attribute maps so the selector-unchanged fixture can fail

### DIFF
--- a/test/perf/cardinality-baseline/logql/structured_metadata_selector_unchanged.json
+++ b/test/perf/cardinality-baseline/logql/structured_metadata_selector_unchanged.json
@@ -1,8 +1,8 @@
 {
   "fixture": "logql/structured_metadata_selector_unchanged",
-  "fan_factor": 0,
-  "scan_rows": 0,
-  "peak_intermediate": 0,
+  "fan_factor": 1,
+  "scan_rows": 2,
+  "peak_intermediate": 2,
   "has_cross_join": false,
   "has_array_join": false,
   "has_recursive_cte": false,

--- a/test/spec/logql/structured_metadata_selector_unchanged.txtar
+++ b/test/spec/logql/structured_metadata_selector_unchanged.txtar
@@ -4,12 +4,15 @@
 CREATE TABLE otel_logs (
     ServiceName LowCardinality(String) DEFAULT 'clickhouse',
     Body String,
-    ResourceAttributes Map(String, String) MATERIALIZED map('service_name', 'clickhouse'),
-    LogAttributes Map(String, String) MATERIALIZED map('tier', 'gold')
+    ResourceAttributes Map(String, String) MATERIALIZED map('service_name', 'clickhouse', 'tier', 'gold'),
+    LogAttributes Map(String, String) MATERIALIZED map('tier', 'silver')
 ) ENGINE = Memory;
 INSERT INTO otel_logs (Body) VALUES ('a'), ('b');
 -- expected_rows --
-[]
+[
+  ["clickhouse", "a"],
+  ["clickhouse", "b"]
+]
 -- chplan --
 Filter predicate=((coalesce(nullIf(ServiceName, ""), if(mapContains(ResourceAttributes, "service_name"), ResourceAttributes["service_name"], if(mapContains(ResourceAttributes, "service.name"), ResourceAttributes["service.name"], ResourceAttributes["service/name"]))) = "clickhouse") AND (ResourceAttributes["tier"] = "gold"))
   Scan(otel_logs)


### PR DESCRIPTION
## Summary

`test/spec/logql/structured_metadata_selector_unchanged.txtar` seeded `tier`
only into `LogAttributes`, while the emitted SQL for the fixture's query
(`{service_name="clickhouse", tier="gold"}`) reads `ResourceAttributes['tier']`.
Because the seed never populated the column the SQL actually reads,
`-- expected_rows --` was always `[]` no matter what the selector lowering
did — the fixture asserted nothing about the routing decision it's named for.

## Which side was wrong: seed or lowering?

**The routing is correct; the seed was wrong.** The fixture's query,
`{service_name="clickhouse", tier="gold"}`, uses ordinary stream-selector
matcher syntax (the `{...}` braces) for both labels — there is no
structured-metadata-specific construct (e.g. a `| tier="gold"` pipeline
stage) anywhere in it. Per the OTel data model, stream-selector labels are
supposed to resolve against the stream index (`ResourceAttributes`) only,
never against per-record structured metadata (`LogAttributes`) — even when
a same-named key happens to exist there.

This is exactly the invariant `internal/logql/structured_metadata_test.go`'s
`TestStructuredMetadata_SelectorUnchanged` pins directly: "a stream SELECTOR
`{tier=\"gold\"}` must resolve against ResourceAttributes ONLY (the index) —
never the LogAttributes structured-metadata map." That unit test walks the
lowered plan and fails if any `LogAttributes` reference appears anywhere in
a selector lowering. It passes today, confirming the emitted
`ResourceAttributes['tier']` in the txtar fixture is the intended,
already-correct behaviour — not a lowering bug the inert fixture was hiding.

I cross-checked the other structured-metadata fixtures
(`structured_metadata_pipeline_filter`, `structured_metadata_precedence`,
`structured_metadata_stream_fallback`, `structured_metadata_group_by`) —
those exercise genuine structured-metadata syntax (pipeline label filters,
`| unwrap`, group-by keys) and correctly read `LogAttributes` with
coalescing precedence. None of them are affected by this change; only the
one fixture whose query is a pure stream selector needed its seed fixed.

## The fix

Seed `ResourceAttributes` with `tier=gold` — the column the correct routing
reads — and give `LogAttributes` a *different* decoy value (`tier=silver`)
for the same key, so the fixture now genuinely discriminates:

- Correct lowering (reads `ResourceAttributes`) → matches `gold` → returns
  both seeded rows.
- A hypothetical regression that started reading structured metadata
  instead of the stream index → would read `silver` → would produce `[]`
  instead of the two rows, and the fixture would go red.

Regenerated via `just update-golden logql cardinality` per invariant 9:

- `test/spec/logql/structured_metadata_selector_unchanged.txtar`:
  `-- expected_rows --` moved from `[]` to the two seeded rows
  (`["clickhouse","a"]`, `["clickhouse","b"]`); the `-- sql --` / `-- chplan
  --` / `-- args --` sections are byte-identical (the lowering didn't
  change, only the data it now actually matches against).
- `test/perf/cardinality-baseline/logql/structured_metadata_selector_unchanged.json`:
  `scan_rows` 0 → 2, `peak_intermediate` 0 → 2, `fan_factor` 0 → 1 — the
  fixture is no longer a zero-scan row and no longer needs (or has) any
  of the "empty by design" exemptions the other twelve zero-scan rows
  carry.

## Verification

- `go test -tags chdb -race -run '^TestLower$/^structured_metadata_selector_unchanged$' -v ./internal/logql/` — PASS, chDB round-trip now executes against real matching/non-matching data.
- `go test -tags chdb -run '^TestCardinalityRatchet$' -v ./test/perf/` — PASS against the regenerated baseline.
- `go test -race -run '^TestStructuredMetadata_SelectorUnchanged$' -v ./internal/logql/` — PASS, reconfirms the routing invariant this fixture is named for.
- Diff scope is exactly the two files this fixture owns (`git diff --stat`).

## Test plan

- [x] Narrowed chDB roundtrip for the fixed fixture passes
- [x] Cardinality ratchet test passes against the regenerated baseline
- [x] Routing-guard unit test still passes (confirms no lowering change was needed)
- [x] `just update-golden logql cardinality` diff reviewed and scoped to only this fixture's two generated files

Closes #1462
