### PR TITLE
refactor(chsql): give the compare root leg a renderable boundary

### DIFF
--- a/internal/chsql/builder.go
+++ b/internal/chsql/builder.go
@@ -1912,11 +1912,13 @@ func Spliced(s Subqueryable) Frag {
 // PreRenderedSQL adapts an already-rendered (sql, args) pair into a
 // Subqueryable so it can flow through Subquery without raw-string
 // composition. Holds an opaque CH SQL string plus its positional args;
-// the adapter exists for legacy chsql.Emit output that pre-dates the
-// QueryBuilder migration.
+// it carries legacy chsql.Emit output that pre-dates the QueryBuilder
+// migration, and the emitter's own recursive render (emitter.renderNode →
+// subqueryFrag), whose child statement is text by the time the parent
+// composes it.
 //
-// Don't reach for this for newly written code — compose with
-// QueryBuilder + typed Frags instead.
+// Don't reach for this to BUILD SQL — compose with QueryBuilder + typed
+// Frags instead. Its only legitimate input is emitter-rendered text.
 type PreRenderedSQL struct {
 	SQL  string
 	Args []any

--- a/internal/chsql/emit_node.go
+++ b/internal/chsql/emit_node.go
@@ -7,38 +7,48 @@ import (
 	"github.com/tsouza/cerberus/internal/chplan"
 )
 
+// renderNode renders n as a statement of its own — the same SQL emitNode
+// writes, paired with exactly the args that text binds, in the order it
+// binds them. The render happens against an isolated buffer + arg slice so
+// the pair is self-contained and any chplan error surfaces synchronously,
+// before the result is spliced anywhere.
+//
+// It is the single place that isolated-render dance lives. subqueryFrag
+// below wraps the pair in parens for splicing into an enclosing statement,
+// and compareRootLeg (metrics_compare.go) hands the same pair to
+// EmitCompareRootLeg, which returns it to a caller that runs the relation
+// standalone. Both renderings come from this one function, so a sub-relation
+// rendered on its own is byte-identical to the one the enclosing statement
+// embeds.
+func (e *emitter) renderNode(n chplan.Node) (string, []any, error) {
+	saveB, saveArgs := e.b, e.args
+	e.b = strings.Builder{}
+	e.args = nil
+	err := e.emitNode(n)
+	sql, args := e.b.String(), e.args
+	e.b = saveB
+	e.args = saveArgs
+	if err != nil {
+		return "", nil, err
+	}
+	return sql, args, nil
+}
+
 // subqueryFrag returns a Frag that renders n as a parenthesised
 // subquery into the receiving Builder. Used to plug a child plan into
 // QueryBuilder.From without flattening to a string: the args bound
 // by the recursive emit walk land in the receiving Builder's args
 // slice at the position the Frag is written.
 //
-// Internally it swaps e.b / e.args with a fresh strings.Builder + nil
-// args slice, runs the recursive emit, then splices the rendered SQL
-// + args into the destination Builder. The error path is captured via
-// the closure variable below; emitSubqueryFrag is the wrapper that
-// surfaces it.
+// The child is pre-rendered (renderNode) so a chplan error surfaces here
+// rather than at splice time, and the captured (sql, args) pair replays
+// cheaply on each Frag invocation via the PreRenderedSQL adapter.
 func (e *emitter) subqueryFrag(n chplan.Node) (Frag, error) {
-	// Pre-render the subquery into an isolated emitter so any chplan
-	// error surfaces synchronously (before the Frag is ever spliced
-	// into the outer QueryBuilder). The rendered string + args are
-	// then captured for cheap replay on each Frag invocation.
-	saveB, saveArgs := e.b, e.args
-	e.b = strings.Builder{}
-	e.args = nil
-	if err := e.emitSubquery(n); err != nil {
-		e.b = saveB
-		e.args = saveArgs
+	sql, args, err := e.renderNode(n)
+	if err != nil {
 		return nil, err
 	}
-	sql := e.b.String()
-	args := e.args
-	e.b = saveB
-	e.args = saveArgs
-	return func(b *Builder) {
-		b.sb.WriteString(sql)
-		b.args = append(b.args, args...)
-	}, nil
+	return Subquery(PreRenderedSQL{SQL: sql, Args: args}), nil
 }
 
 // emitSelect runs the assembled QueryBuilder and splices its rendered

--- a/internal/chsql/metrics_compare.go
+++ b/internal/chsql/metrics_compare.go
@@ -1,8 +1,10 @@
 package chsql
 
 import (
+	"context"
 	"fmt"
 
+	"github.com/tsouza/cerberus/internal/cerbtrace"
 	"github.com/tsouza/cerberus/internal/chplan"
 )
 
@@ -140,38 +142,14 @@ func (e *emitter) compareBaseQuery(m *chplan.MetricsCompare, bound *compareScanB
 
 	qb := NewQuery()
 	if m.RootLookup != nil {
-		if m.TraceIDColumn == "" {
-			return nil, fmt.Errorf("%w: MetricsCompare.RootLookup set but TraceIDColumn empty", ErrUnsupported)
-		}
-		root, rerr := e.subqueryFrag(m.RootLookup)
+		root, rerr := e.compareRootLeg(m, bound, inner)
 		if rerr != nil {
 			return nil, rerr
-		}
-		if bound != nil {
-			root = bindRootLookupTraceIDTsEnvelope(root, bound.rootEnvelope)
-		}
-		// Right ('r') leg: bound the per-trace root lookup to the same
-		// windowed cohort the 's' leg scans, restricting root rows to
-		// `TraceId IN (<bounded s trace-ids>)`. When emitRangeWindowCompare
-		// has already pushed that same predicate into RootLookup's own
-		// scan-level Filter (bound.rootSeeded — see
-		// windowRootLookupTraceIDSeed), boundedRootLeg's wrap here would
-		// only re-filter an already-seeded result by the identical
-		// trace-id set, so it's skipped. It stays as the correctness
-		// fallback for the rare RootLookup shape the scan-level pushdown
-		// can't reach (rootLookupSpansTable finds no matching Scan): a
-		// plain Timestamp bound on the root leg would drop enrichment for
-		// traces whose root span straddles the window edge, so seeding by
-		// the cohort's trace-id set is what keeps every root the LEFT
-		// JOIN can match (the join output is determined by s.TraceId,
-		// already windowed) while still scoping the leg to the cohort.
-		if bound != nil && !bound.rootSeeded {
-			root = e.boundedRootLeg(root, m.TraceIDColumn, inner, bound)
 		}
 		qb.From(aliasedFrag(sLeg, compareJoinLeftAlias)).
 			Join(
 				LeftJoin,
-				aliasedFrag(root, compareJoinRightAlias),
+				aliasedFrag(Subquery(root), compareJoinRightAlias),
 				Eq(
 					qualColFrag(compareJoinLeftAlias, m.TraceIDColumn),
 					qualColFrag(compareJoinRightAlias, m.TraceIDColumn),
@@ -192,6 +170,56 @@ func (e *emitter) compareBaseQuery(m *chplan.MetricsCompare, bound *compareScanB
 	return qb, nil
 }
 
+// compareRootLeg composes the join's right ('r') leg — the per-trace root
+// lookup — as a relation in its own right: RootLookup rendered, carrying the
+// trace_id_ts envelope binding its own scan filter reads
+// (bindRootLookupTraceIDTsEnvelope), and wrapped in boundedRootLeg's
+// post-aggregate cohort filter when the scan-level seed did not land.
+//
+// It returns a Subqueryable rather than a Frag because the leg has exactly one
+// composition point and two renderings. Subquery(leg) parenthesises it for the
+// join's right side, which is what compareBaseQuery above does; leg's own
+// subquerySQL() yields the SAME text as a standalone statement together with
+// precisely the args that text binds, which is what EmitCompareRootLeg hands
+// back. One constructor feeding both means a caller that needs the leg alone —
+// to run it, or to EXPLAIN its part pruning without the matrix query around it
+// — asks the emitter for it instead of recovering it from the emitted
+// statement by scanning for a marker and counting parens and `?`s.
+//
+// Why the leg is bounded the way it is: it must see the same windowed cohort
+// the 's' leg scans, restricted to `TraceId IN (<bounded s trace-ids>)`. When
+// emitRangeWindowCompare has already pushed that predicate into RootLookup's
+// own scan-level Filter (bound.rootSeeded — see windowRootLookupTraceIDSeed),
+// boundedRootLeg's wrap here would only re-filter an already-seeded result by
+// the identical trace-id set, so it is skipped. It stays as the correctness
+// fallback for the rare RootLookup shape the scan-level pushdown cannot reach
+// (rootLookupSpansTable finds no matching Scan): a plain Timestamp bound on the
+// root leg would drop enrichment for traces whose root span straddles the
+// window edge, so seeding by the cohort's trace-id set is what keeps every root
+// the LEFT JOIN can match (the join output is determined by s.TraceId, already
+// windowed) while still scoping the leg to the cohort.
+func (e *emitter) compareRootLeg(m *chplan.MetricsCompare, bound *compareScanBound, inner Frag) (Subqueryable, error) {
+	if m.RootLookup == nil {
+		return nil, fmt.Errorf("%w: MetricsCompare.RootLookup is nil (no root leg to render)", ErrUnsupported)
+	}
+	if m.TraceIDColumn == "" {
+		return nil, fmt.Errorf("%w: MetricsCompare.RootLookup set but TraceIDColumn empty", ErrUnsupported)
+	}
+	sql, args, err := e.renderNode(m.RootLookup)
+	if err != nil {
+		return nil, err
+	}
+	var leg Subqueryable = PreRenderedSQL{SQL: sql, Args: args}
+	if bound == nil {
+		return leg, nil
+	}
+	leg = bindRootLookupTraceIDTsEnvelope(leg, bound.rootEnvelope)
+	if !bound.rootSeeded {
+		leg = e.boundedRootLeg(leg, m.TraceIDColumn, inner, bound)
+	}
+	return leg, nil
+}
+
 // boundedRootLeg wraps the RENDERED (post-aggregate) root-lookup subquery,
 // restricting its output rows to
 // `<traceID> IN (SELECT <traceID> FROM (<bounded inner>) AS _cmp_seed)`,
@@ -205,16 +233,15 @@ func (e *emitter) compareBaseQuery(m *chplan.MetricsCompare, bound *compareScanB
 // scan-level OOM windowRootLookupTraceIDSeed exists to fix. _cmp_seed
 // aliases the seed subquery so CH's analyzer resolves the projected
 // trace-id column. See compareScanBound for the why.
-func (e *emitter) boundedRootLeg(root Frag, traceIDCol string, inner Frag, bound *compareScanBound) Frag {
+func (e *emitter) boundedRootLeg(root Subqueryable, traceIDCol string, inner Frag, bound *compareScanBound) Subqueryable {
 	boundedInner := NewQuery().Select(Star()).From(inner).Where(bound.lo, bound.hi)
 	seedIDs := NewQuery().
 		Select(Col(traceIDCol)).
 		From(aliasedFrag(boundedInner.Frag(), "_cmp_seed"))
 	return NewQuery().
 		Select(Star()).
-		From(root).
-		Where(In(Col(traceIDCol), Spliced(seedIDs))).
-		Frag()
+		From(Subquery(root)).
+		Where(In(Col(traceIDCol), Spliced(seedIDs)))
 }
 
 // compareSeedNode builds `SELECT <traceIDCol> FROM (<inner>)` [with
@@ -445,22 +472,22 @@ func rootLookupTraceIDTsBounds(
 // puts them there); declaring the binding at the top left the root leg a
 // fragment that could not be read, reasoned about, or executed without the rest
 // of the statement around it. Declared here, the leg is a complete statement:
-// whatever renders it — the compare join, or a perf guard extracting the leg to
-// EXPLAIN its part pruning in isolation — gets the binding with it.
+// whatever renders it — the compare join, or a perf guard that asks
+// EmitCompareRootLeg for the leg to EXPLAIN its part pruning in isolation —
+// gets the binding with it.
 //
 // The wrapper is a `SELECT * FROM (<root>)`, the same typed shape emitBound
 // uses to attach chplan.BoundedTraceScopeAlias to a rendered plan: `SELECT *`
 // forwards the root lookup's own column names and row shape unchanged, so the
 // join's `ON s.TraceId = r.TraceId` resolves exactly as it did.
-func bindRootLookupTraceIDTsEnvelope(root Frag, envelope *QueryBuilder) Frag {
+func bindRootLookupTraceIDTsEnvelope(root Subqueryable, envelope *QueryBuilder) Subqueryable {
 	if envelope == nil {
 		return root
 	}
 	return NewQuery().
 		WithScalar(chplan.TraceIDTsEnvelopeAlias, envelope).
 		Select(Star()).
-		From(root).
-		Frag()
+		From(Subquery(root))
 }
 
 // pushPredicateToSpansScanFilter walks n in place looking for the Filter
@@ -573,20 +600,13 @@ func (e *emitter) emitMetricsCompare(m *chplan.MetricsCompare) error {
 // scan-bound pushdown); see the package comment at the top of this
 // file for the SQL skeleton.
 func (e *emitter) emitRangeWindowCompare(r *chplan.RangeWindow, m *chplan.MetricsCompare) error {
-	if r.TimestampColumn == "" {
-		return fmt.Errorf("%w: RangeWindow.TimestampColumn unset (required for MetricsCompare input)", ErrUnsupported)
-	}
-	if r.Step <= 0 {
-		return fmt.Errorf("%w: RangeWindow wrapping MetricsCompare requires Step > 0", ErrUnsupported)
+	rangeNS, err := compareMatrixRangeNS(r)
+	if err != nil {
+		return err
 	}
 
 	end := endExprFrag(r)
 	stepNS := r.Step.Nanoseconds()
-	rangeDur := r.Range
-	if rangeDur == 0 {
-		rangeDur = r.Step
-	}
-	rangeNS := rangeDur.Nanoseconds()
 
 	var numAnchors int64
 	switch {
@@ -603,6 +623,66 @@ func (e *emitter) emitRangeWindowCompare(r *chplan.RangeWindow, m *chplan.Metric
 	}
 
 	tsCol := r.TimestampColumn
+	m, bound, err := e.compareWindowedScanBound(r, m, rangeNS)
+	if err != nil {
+		return err
+	}
+	base, err := e.compareBaseQuery(m, bound, tsCol)
+	if err != nil {
+		return err
+	}
+
+	selA, attrA, valA := compareSelOut(m), compareAttrOut(m), compareValOut(m)
+
+	fanout := NewQuery().From(base.Frag())
+	fanout.Select(Col(selA))
+	fanout.SelectAs(compareTupleElementFrag(1), attrA)
+	fanout.SelectAs(compareTupleElementFrag(2), valA)
+	fanout.SelectAs(
+		sampleAnchorFanoutFrag(end, func(b *Builder) { b.Ident(tsCol) }, stepNS, rangeNS, numAnchors),
+		RangeWindowAnchorAlias,
+	)
+
+	outer := NewQuery().From(fanout.Frag())
+	outer.Select(Col(selA), Col(attrA), Col(valA), Col(RangeWindowAnchorAlias))
+	outer.SelectAs(compareCountValueFrag(), compareValueOut(m))
+	outer.GroupBy(Col(selA), Col(attrA), Col(valA), Col(RangeWindowAnchorAlias))
+
+	return e.emitSelect(outer)
+}
+
+// compareMatrixRangeNS validates the matrix wrapper's required fields and
+// returns the anchor lookback in nanoseconds: RangeWindow.Range, defaulting to
+// Step when unset. emitRangeWindowCompare and EmitCompareRootLeg both go
+// through it so the scan window they derive comes from one reading of the same
+// fields.
+func compareMatrixRangeNS(r *chplan.RangeWindow) (int64, error) {
+	if r.TimestampColumn == "" {
+		return 0, fmt.Errorf("%w: RangeWindow.TimestampColumn unset (required for MetricsCompare input)", ErrUnsupported)
+	}
+	if r.Step <= 0 {
+		return 0, fmt.Errorf("%w: RangeWindow wrapping MetricsCompare requires Step > 0", ErrUnsupported)
+	}
+	rangeDur := r.Range
+	if rangeDur == 0 {
+		rangeDur = r.Step
+	}
+	return rangeDur.Nanoseconds(), nil
+}
+
+// compareWindowedScanBound derives the matrix path's scan-bound pushdown: the
+// (Start-range, End] Timestamp window each MergeTree leg of the compare join
+// carries in its own scan, plus — when there is a root lookup — the clone of m
+// whose RootLookup has the windowed cohort seed pushed onto its physical scan.
+// Returns m and a nil bound unchanged when the request carries no window.
+//
+// Split out of emitRangeWindowCompare so EmitCompareRootLeg reaches the exact
+// same bound the matrix statement embeds; a second derivation would be a second
+// source of truth for which window the root leg is read under.
+func (e *emitter) compareWindowedScanBound(
+	r *chplan.RangeWindow, m *chplan.MetricsCompare, rangeNS int64,
+) (*chplan.MetricsCompare, *compareScanBound, error) {
+	tsCol := r.TimestampColumn
 	// Push the (Start-range, End] Timestamp window INTO each scan of the
 	// compare join (the 's' span scan + the seeded root leg) rather than
 	// above the join where CH 24.12 cannot prune it. Gated on both Start
@@ -613,7 +693,7 @@ func (e *emitter) emitRangeWindowCompare(r *chplan.RangeWindow, m *chplan.Metric
 	// Tempo head), so it enforces in prod but is a no-op for an isolated emit
 	// that did not set a spans table.
 	if err := requireInnerSpansScanBound(r, m.Inner, e.spansTable); err != nil {
-		return err
+		return nil, nil, err
 	}
 	var bound *compareScanBound
 	if !r.Start.IsZero() && !r.End.IsZero() {
@@ -691,26 +771,112 @@ func (e *emitter) emitRangeWindowCompare(r *chplan.RangeWindow, m *chplan.Metric
 		bound = &boundCopy
 		m = &windowed
 	}
-	base, err := e.compareBaseQuery(m, bound, tsCol)
+	return m, bound, nil
+}
+
+// EmitCompareRootLeg renders the root-lookup ('r') leg of a compare matrix
+// query on its own: the SQL the compare join splices as its right-hand side,
+// returned as a standalone statement paired with exactly the args that text
+// binds, in the order it binds them.
+//
+// It is the emitter's answer to "give me that sub-relation", and it exists
+// because the leg is worth inspecting and running by itself — the trace_id_ts
+// envelope's whole claim is that this leg partition-prunes (#1443), which is a
+// property of the leg, not of the matrix query wrapped around it. Without a
+// boundary a caller has to recover the leg from the emitted statement by
+// finding a `LEFT JOIN (` marker, counting parens to its match, and counting
+// `?` placeholders to guess which slice of the args belongs to it — three
+// assumptions about emitter internals (that the join side is parenthesised,
+// that this alias opens it, that args are appended in text order) that nothing
+// pins and any clause reordering silently breaks.
+//
+// The leg comes from compareRootLeg, the same constructor compareBaseQuery
+// composes the join from, after the same window derivation
+// (compareWindowedScanBound) and the same emit-chokepoint preparation
+// chsql.Emit applies to the plan. So the returned text is the leg Emit's own
+// statement contains, byte for byte, and running it is running what production
+// runs — not a hand-typed approximation of it.
+//
+// The leg is self-contained: bindRootLookupTraceIDTsEnvelope declares the
+// trace_id_ts scalar binding on the leg itself precisely so it carries its
+// readers' declaration with it.
+//
+// Returns ErrUnsupported when r is not a compare matrix wrapper with a root
+// lookup — a nil RangeWindow, a non-MetricsCompare input, a missing
+// TimestampColumn or Step, a nil Inner, or a MetricsCompare with no RootLookup
+// (there is no root leg to render).
+func EmitCompareRootLeg(ctx context.Context, r *chplan.RangeWindow) (string, []any, error) {
+	_, span := tracer.Start(ctx, cerbtrace.SpanEmit)
+	defer span.End()
+
+	fail := func(err error) (string, []any, error) {
+		span.RecordError(err)
+		return "", nil, err
+	}
+	if r == nil {
+		return fail(fmt.Errorf("%w: RangeWindow is nil", ErrUnsupported))
+	}
+	rangeNS, err := compareMatrixRangeNS(r)
 	if err != nil {
-		return err
+		return fail(err)
 	}
 
-	selA, attrA, valA := compareSelOut(m), compareAttrOut(m), compareValOut(m)
+	// The same chokepoint preparation Emit runs on a plan before rendering it,
+	// so this leg is the one Emit's statement embeds rather than a near-miss
+	// rendered from an unprepared tree.
+	spansTable := spansTableFromCtx(ctx)
+	prepared := chplan.AttachInstantScanTimeBounds(r)
+	if berr := chplan.RequireSpansScansBounded(spansTable, prepared); berr != nil {
+		return fail(berr)
+	}
+	prepared = chplan.CanonicalizeSeriesIdentityKeys(prepared, attributeMapColumns)
+	rw, ok := prepared.(*chplan.RangeWindow)
+	if !ok {
+		return fail(fmt.Errorf("%w: prepared plan root is %T, want *chplan.RangeWindow", ErrUnsupported, prepared))
+	}
+	m, ok := rw.Input.(*chplan.MetricsCompare)
+	if !ok {
+		return fail(fmt.Errorf("%w: RangeWindow.Input is %T, want *chplan.MetricsCompare", ErrUnsupported, rw.Input))
+	}
+	if m.Inner == nil {
+		return fail(fmt.Errorf("%w: MetricsCompare.Inner is nil", ErrUnsupported))
+	}
+	if m.RootLookup == nil {
+		return fail(fmt.Errorf("%w: MetricsCompare.RootLookup is nil (no root leg to render)", ErrUnsupported))
+	}
 
-	fanout := NewQuery().From(base.Frag())
-	fanout.Select(Col(selA))
-	fanout.SelectAs(compareTupleElementFrag(1), attrA)
-	fanout.SelectAs(compareTupleElementFrag(2), valA)
-	fanout.SelectAs(
-		sampleAnchorFanoutFrag(end, func(b *Builder) { b.Ident(tsCol) }, stepNS, rangeNS, numAnchors),
-		RangeWindowAnchorAlias,
-	)
-
-	outer := NewQuery().From(fanout.Frag())
-	outer.Select(Col(selA), Col(attrA), Col(valA), Col(RangeWindowAnchorAlias))
-	outer.SelectAs(compareCountValueFrag(), compareValueOut(m))
-	outer.GroupBy(Col(selA), Col(attrA), Col(valA), Col(RangeWindowAnchorAlias))
-
-	return e.emitSelect(outer)
+	ctxLMTable, ctxLMShape, _ := lateMatShapeFromCtx(ctx)
+	e := &emitter{
+		spansTable:      spansTable,
+		ctxSpansTable:   spansTable,
+		ctxLateMatTable: ctxLMTable,
+		ctxLateMatShape: ctxLMShape,
+	}
+	windowed, bound, err := e.compareWindowedScanBound(rw, m, rangeNS)
+	if err != nil {
+		return fail(err)
+	}
+	// inner is the cohort relation boundedRootLeg seeds its fallback wrap from;
+	// it is the same Frag compareBaseQuery builds the 's' leg out of.
+	inner, err := e.subqueryFrag(windowed.Inner)
+	if err != nil {
+		return fail(err)
+	}
+	leg, err := e.compareRootLeg(windowed, bound, inner)
+	if err != nil {
+		return fail(err)
+	}
+	sql, args, err := leg.subquerySQL()
+	if err != nil {
+		return fail(err)
+	}
+	// The leg is a statement a caller can send to ClickHouse, so it passes the
+	// same universal spans-scan backstop Emit runs on its own output — the rule
+	// GuardEmittedSQL's doc states for every path that builds otel_traces SQL
+	// outside Emit.
+	if gerr := GuardEmittedSQL(ctx, sql); gerr != nil {
+		return fail(gerr)
+	}
+	span.SetAttributes(cerbtrace.AttrSQLLength.Int(len(sql)))
+	return sql, args, nil
 }

--- a/internal/chsql/metrics_compare_test.go
+++ b/internal/chsql/metrics_compare_test.go
@@ -23,34 +23,28 @@ func containsInt64Arg(args []any, want int64) bool {
 	return false
 }
 
-// compareRootLegSpan returns the byte span of the root ('r') leg's own derived
-// table inside sql: the balanced-paren region opened by the `LEFT JOIN (`
-// marker. chsql always parenthesises a join side (subqueryFrag), so that region
-// is a complete SELECT — which is exactly the property under test, and the same
-// extraction test/perf's compare guards use to EXPLAIN the root scan's part
-// pruning in isolation.
-func compareRootLegSpan(t *testing.T, sql string) (start, end int) {
+// compareRootLeg asks the emitter for the root ('r') leg of rw's compare join
+// as a statement of its own, and pins that what it returns really is the leg
+// the join embeds — the emitted matrix statement must contain that exact text.
+//
+// The seam (chsql.EmitCompareRootLeg) replaces what used to be a balanced-paren
+// scan from a `LEFT JOIN (` marker, in this file and again in test/perf: two
+// copies of one algorithm keyed on emitter internals nothing pinned — that a
+// join side is parenthesised, that this marker opens the leg, and (in the perf
+// copy, which has to run the leg) that args are appended in text order so a `?`
+// count yields the leg's arg slice. The emitter now answers all three itself,
+// and the containment check below is the assertion those assumptions never got.
+func compareRootLeg(t *testing.T, rw *chplan.RangeWindow, matrixSQL string) (string, []any) {
 	t.Helper()
-	const joinMarker = "LEFT JOIN ("
-	idx := strings.Index(sql, joinMarker)
-	if idx < 0 {
-		t.Fatalf("expected %q (the s/r join) in emitted SQL:\n%s", joinMarker, sql)
+	legSQL, legArgs, err := chsql.EmitCompareRootLeg(context.Background(), rw)
+	if err != nil {
+		t.Fatalf("EmitCompareRootLeg: %v", err)
 	}
-	start = idx + len(joinMarker)
-	depth := 1
-	for i := start; i < len(sql); i++ {
-		switch sql[i] {
-		case '(':
-			depth++
-		case ')':
-			depth--
-			if depth == 0 {
-				return start, i
-			}
-		}
+	if !strings.Contains(matrixSQL, legSQL) {
+		t.Fatalf("the standalone root leg must be the leg the compare join embeds, verbatim.\nleg:\n%s\nmatrix:\n%s",
+			legSQL, matrixSQL)
 	}
-	t.Fatalf("unbalanced parens extracting the root ('r') leg from:\n%s", sql)
-	return 0, 0
+	return legSQL, legArgs
 }
 
 // compareNode builds a minimal valid MetricsCompare (no root lookup —
@@ -314,7 +308,7 @@ func TestEmitRangeWindowCompare_NonRootTraceIDTsEnrichmentBound(t *testing.T) {
 		End:             time.Date(2026, 5, 12, 10, 3, 0, 0, time.UTC),
 		TimestampColumn: "Timestamp",
 	}
-	sql, args, err := chsql.Emit(context.Background(), rw)
+	sql, _, err := chsql.Emit(context.Background(), rw)
 	if err != nil {
 		t.Fatalf("Emit: %v", err)
 	}
@@ -327,10 +321,9 @@ func TestEmitRangeWindowCompare_NonRootTraceIDTsEnrichmentBound(t *testing.T) {
 	// unresolvable one: a declaration hoisted onto some enclosing SELECT
 	// satisfies the count while leaving the leg a fragment that names an
 	// identifier it does not declare. So assert the placement instead — the
-	// declaration opens the extracted leg, and no reference to the alias
-	// escapes it.
-	legStart, legEnd := compareRootLegSpan(t, sql)
-	rootLeg := sql[legStart:legEnd]
+	// declaration opens the leg the emitter hands back, and no reference to the
+	// alias escapes it.
+	rootLeg, legArgs := compareRootLeg(t, rw, sql)
 	const wantBinding = "WITH (SELECT tuple(min(`Start`), max(`End`)) FROM `otel_traces_trace_id_ts` WHERE "
 	if !strings.HasPrefix(rootLeg, wantBinding) {
 		t.Fatalf("expected the envelope binding to open the root ('r') leg, got:\n%s", rootLeg)
@@ -394,9 +387,12 @@ func TestEmitRangeWindowCompare_NonRootTraceIDTsEnrichmentBound(t *testing.T) {
 	// second for the envelope to stay a superset of the trace's last span.
 	// Nor does tupleElement() alone prove each bound reads the element it
 	// means: reading Start for both would bound the scan to the cohort's
-	// earliest instant. The exact TraceId-IN seed renders last and contributes
-	// exactly the two request-window params, so counting back from the end the
-	// pad is third, the End element fourth and the Start element fifth.
+	// earliest instant. These are read off the leg's OWN args — the pairing the
+	// emitter returns with the leg's SQL, not a slice of the whole statement's
+	// args recovered by counting placeholders. The exact TraceId-IN seed renders
+	// last within the leg and contributes exactly the two request-window params,
+	// so counting back from the end the pad is third, the End element fourth and
+	// the Start element fifth.
 	const wantEndPadSeconds = int64(chplan.TraceIDTsEndPadSeconds)
 	const (
 		padArgsFromEnd        = 3
@@ -404,8 +400,8 @@ func TestEmitRangeWindowCompare_NonRootTraceIDTsEnrichmentBound(t *testing.T) {
 		startElemArgsFromEnd  = 5
 		minTrailingBoundsArgs = startElemArgsFromEnd
 	)
-	if len(args) < minTrailingBoundsArgs {
-		t.Fatalf("expected at least %d args, got %#v", minTrailingBoundsArgs, args)
+	if len(legArgs) < minTrailingBoundsArgs {
+		t.Fatalf("expected at least %d root-leg args, got %#v", minTrailingBoundsArgs, legArgs)
 	}
 	for _, tc := range []struct {
 		name    string
@@ -416,10 +412,123 @@ func TestEmitRangeWindowCompare_NonRootTraceIDTsEnrichmentBound(t *testing.T) {
 		{"End tuple element", endElemArgsFromEnd, chplan.TraceIDTsEnvelopeEndElement},
 		{"Start tuple element", startElemArgsFromEnd, chplan.TraceIDTsEnvelopeStartElement},
 	} {
-		if got := args[len(args)-tc.fromEnd]; got != any(tc.want) {
+		if got := legArgs[len(legArgs)-tc.fromEnd]; got != any(tc.want) {
 			t.Errorf("%s = %#v, want %d", tc.name, got, tc.want)
 		}
 	}
+}
+
+// TestEmitCompareRootLeg pins the seam itself — the boundary that lets a
+// caller ask for the compare join's root ('r') leg instead of parsing the
+// emitted statement for it.
+//
+// Two properties make it a boundary rather than a convenience. The leg is the
+// one the matrix statement embeds, verbatim; and the args it comes with are
+// exactly the args its own text binds, which is the guarantee the previous
+// `?`-counting extraction assumed (args appended in text order) and could
+// never check.
+func TestEmitCompareRootLeg(t *testing.T) {
+	t.Parallel()
+
+	window := func(m *chplan.MetricsCompare) *chplan.RangeWindow {
+		return &chplan.RangeWindow{
+			Input:           m,
+			Range:           time.Minute,
+			Step:            time.Minute,
+			Start:           time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC),
+			End:             time.Date(2026, 5, 12, 10, 3, 0, 0, time.UTC),
+			TimestampColumn: "Timestamp",
+		}
+	}
+	withEnvelope := func() *chplan.MetricsCompare {
+		m := compareNodeWithRoot()
+		m.RootLookupTraceIDTsTable = "otel_traces_trace_id_ts"
+		m.RootLookupTraceIDTsStartColumn = "Start"
+		m.RootLookupTraceIDTsEndColumn = "End"
+		return m
+	}
+	rootScoped := func() *chplan.MetricsCompare {
+		m := compareNodeWithRoot()
+		m.InnerRootScoped = true
+		return m
+	}
+
+	t.Run("isTheLegTheJoinEmbeds", func(t *testing.T) {
+		t.Parallel()
+
+		// All three root-leg shapes the matrix path can produce: #1214's
+		// unbounded-but-lossless leg, the root-scoped leg with its direct
+		// request-window bound, and the non-root leg under the trace_id_ts
+		// envelope. Each must round-trip through the seam identically.
+		for _, tc := range []struct {
+			name string
+			node *chplan.MetricsCompare
+		}{
+			{"unboundedLossless", compareNodeWithRoot()},
+			{"rootScoped", rootScoped()},
+			{"traceIDTsEnvelope", withEnvelope()},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				rw := window(tc.node)
+				matrixSQL, _, err := chsql.Emit(context.Background(), rw)
+				if err != nil {
+					t.Fatalf("Emit: %v", err)
+				}
+				legSQL, legArgs := compareRootLeg(t, rw, matrixSQL)
+
+				// A statement of its own, not a parenthesised fragment: the
+				// caller runs this text directly.
+				if !strings.HasPrefix(legSQL, "SELECT ") && !strings.HasPrefix(legSQL, "WITH ") {
+					t.Errorf("root leg must be a standalone statement, got:\n%s", legSQL)
+				}
+				// The pairing the seam exists to own: one arg per placeholder
+				// in the leg's own text. This counts placeholders to CHECK
+				// that pairing; the extraction this seam replaced counted them
+				// to RECONSTRUCT it — to guess which slice of the whole
+				// statement's args belonged to the leg — which is the
+				// assumption no test makes any more.
+				if placeholders := strings.Count(legSQL, "?"); placeholders != len(legArgs) {
+					t.Errorf("root leg binds %d placeholders but came with %d args (%#v):\n%s",
+						placeholders, len(legArgs), legArgs, legSQL)
+				}
+			})
+		}
+	})
+
+	t.Run("rejectsWhatHasNoRootLeg", func(t *testing.T) {
+		t.Parallel()
+
+		noRoot := compareNode() // RootLookup nil
+		for _, tc := range []struct {
+			name string
+			rw   *chplan.RangeWindow
+			want string
+		}{
+			{"nilRangeWindow", nil, "RangeWindow is nil"},
+			{"noTimestampColumn", &chplan.RangeWindow{Input: compareNodeWithRoot(), Step: time.Minute}, "TimestampColumn unset"},
+			{"zeroStep", &chplan.RangeWindow{Input: compareNodeWithRoot(), TimestampColumn: "Timestamp"}, "requires Step > 0"},
+			{"notACompare", &chplan.RangeWindow{
+				Input:           &chplan.Scan{Table: "otel_traces"},
+				Step:            time.Minute,
+				TimestampColumn: "Timestamp",
+			}, "want *chplan.MetricsCompare"},
+			{"noRootLookup", window(noRoot), "RootLookup is nil"},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				_, _, err := chsql.EmitCompareRootLeg(context.Background(), tc.rw)
+				if err == nil {
+					t.Fatalf("EmitCompareRootLeg should fail for %s", tc.name)
+				}
+				if !strings.Contains(err.Error(), tc.want) {
+					t.Errorf("error %q missing %q", err, tc.want)
+				}
+			})
+		}
+	})
 }
 
 // TestEmitRangeWindowCompare_NonRootTraceIDTsPartialConfig pins that the

--- a/test/perf/compare_window_prune_chdb_test.go
+++ b/test/perf/compare_window_prune_chdb_test.go
@@ -352,25 +352,21 @@ const (
 // chplan.RangeWindow tree for the non-root-selection root-lookup shape
 // (matching TraceIDColumn "TraceId", ParentSpanId-rooted RootLookup over
 // spansTable, optionally gated by the RootLookupTraceIDTsTable envelope) and
-// runs it through the ACTUAL chsql.Emit — the same emitter production
-// requests go through — rather than hand-typing the resulting SQL text (the
-// gap #1439 closes). windowRootLookupTraceIDSeed / rootLookupTraceIDTsBounds
+// runs it through the ACTUAL emitter — the same one production requests go
+// through — rather than hand-typing the resulting SQL text (the gap #1439
+// closes). windowRootLookupTraceIDSeed / rootLookupTraceIDTsBounds
 // (internal/chsql/metrics_compare.go) are unexported, so this only reaches
-// them indirectly via chsql.Emit; nothing here reimplements their predicate
-// shape by hand.
+// them indirectly; nothing here reimplements their predicate shape by hand.
 //
 // The full emitted statement is compare()'s three-layer matrix query (anchor
-// fanout + outer count wrapper) around the `s LEFT JOIN r` join this test
-// doesn't need — only the root ('r') leg's own derived-table subquery is
-// under test. That subquery is a complete, self-contained SELECT (chsql
-// always parenthesises a join side via subqueryFrag), so it is extracted by
-// balanced-paren scanning from the `LEFT JOIN (` marker and returned as a
-// standalone, directly-executable query, together with the exact slice of
-// `?`-bound args it consumes — found by counting placeholders: clickhouse-go
-// binds `?` positionally in left-to-right TEXT order, and chsql.Emit appends
-// each arg to its args slice at the moment its placeholder is written, so
-// counting `?` occurrences up to the extraction point yields the arg offset
-// and counting them inside the extracted text yields the arg count.
+// fanout + outer count wrapper) around the `s LEFT JOIN r` join this test does
+// not need — only the root ('r') leg is under test, since partition-pruning
+// that leg's own scan is what the trace_id_ts envelope claims (#1443).
+// chsql.EmitCompareRootLeg renders exactly that leg as a standalone,
+// directly-executable statement paired with its own args, so this harness asks
+// the emitter for the leg instead of recovering it from the emitted text by
+// scanning for a `LEFT JOIN (` marker, counting parens to its match, and
+// counting `?` placeholders to guess which slice of the args it consumes.
 func compareNonRootRootLookupSQL(t *testing.T, spansTable, lookupTable string, winLo, winHi time.Time, envelope bool) (string, []any) {
 	t.Helper()
 
@@ -416,43 +412,22 @@ func compareNonRootRootLookupSQL(t *testing.T, spansTable, lookupTable string, w
 		End:             winHi,
 		TimestampColumn: "Timestamp",
 	}
-	sql, args, err := chsql.Emit(context.Background(), rw)
+	rootSQL, rootArgs, err := chsql.EmitCompareRootLeg(context.Background(), rw)
+	if err != nil {
+		t.Fatalf("chsql.EmitCompareRootLeg: %v", err)
+	}
+	// The leg the emitter hands back must be the leg the matrix statement
+	// embeds — otherwise this harness would be pruning-checking a query no
+	// request ever runs. chsql pins that containment in its own unit test; here
+	// it is re-asserted against the full statement this exact plan emits.
+	matrixSQL, _, err := chsql.Emit(context.Background(), rw)
 	if err != nil {
 		t.Fatalf("chsql.Emit: %v", err)
 	}
-
-	const joinMarker = "LEFT JOIN ("
-	idx := strings.Index(sql, joinMarker)
-	if idx < 0 {
-		t.Fatalf("expected %q (the s/r join) in emitted SQL:\n%s", joinMarker, sql)
+	if !strings.Contains(matrixSQL, rootSQL) {
+		t.Fatalf("root leg is not the one the compare join embeds.\nleg:\n%s\nmatrix:\n%s", rootSQL, matrixSQL)
 	}
-	start := idx + len(joinMarker)
-	depth := 1
-	end := -1
-	for i := start; i < len(sql); i++ {
-		switch sql[i] {
-		case '(':
-			depth++
-		case ')':
-			depth--
-			if depth == 0 {
-				end = i
-			}
-		}
-		if end >= 0 {
-			break
-		}
-	}
-	if end < 0 {
-		t.Fatalf("unbalanced parens extracting the root ('r') leg from:\n%s", sql)
-	}
-	rootSQL := sql[start:end]
-	argOffset := strings.Count(sql[:start], "?")
-	argCount := strings.Count(rootSQL, "?")
-	if argOffset+argCount > len(args) {
-		t.Fatalf("extracted root leg wants args[%d:%d] but Emit returned only %d args:\n%s", argOffset, argOffset+argCount, len(args), rootSQL)
-	}
-	return rootSQL, args[argOffset : argOffset+argCount]
+	return rootSQL, rootArgs
 }
 
 // TestCompareNonRootRootLookupTraceIDTsEnvelope exercises the case a request


### PR DESCRIPTION
## The gap

The compare emitter's root-lookup (`r`) leg had no boundary, so two test
packages recovered it from the emitted SQL by parsing the text:

- `internal/chsql/metrics_compare_test.go` — `compareRootLegSpan` found the
  literal `"LEFT JOIN ("` and walked the string counting parens to its match.
- `test/perf/compare_window_prune_chdb_test.go` — a second, independent
  `depth`-counting walk from the same marker, with its own "unbalanced parens
  extracting the root ('r') leg" failure message.

Different packages, different return shapes, so neither could call the other:
one algorithm, duplicated, keyed on an emitter internal.

It was more than duplication. The perf harness has to *run* the leg, so it also
reconstructed which args belonged to the extracted span by counting `?`
placeholders up to the extraction point. That worked only because
`subqueryFrag` replays captured args at splice time and the `WITH` clause
happens to render before the `FROM` — an unasserted dependency on args being
appended in text order. Any clause reordering would silently mis-slice the args
and the test would either pass on the wrong query or fail somewhere unrelated to
the cause. The parenthesisation both scanners relied on was no more of a
contract: `subqueryFrag` happens to parenthesise a join side today, and the
`LEFT JOIN (` marker breaks the moment the emitter names that leg or hoists it.

## The seam

`chsql.EmitCompareRootLeg(ctx, *chplan.RangeWindow) (string, []any, error)`
renders the root leg as a statement of its own, paired with exactly the args
that text binds — the same `(sql, args, error)` shape the package's other
exported emit entrypoints use.

Inside, the leg now has one composition point with two renderings:

- `compareRootLeg` builds it as a `Subqueryable` — `RootLookup` rendered,
  carrying the `trace_id_ts` envelope binding its own scan filter reads, and
  wrapped in `boundedRootLeg`'s post-aggregate cohort filter when the
  scan-level seed did not land.
- `Subquery(leg)` parenthesises it for the join's right side (what
  `compareBaseQuery` does); `leg`'s own `subquerySQL()` yields the standalone
  statement (what the seam returns).

Supporting moves, all typed-Frag composition — no raw SQL string is built
anywhere:

- `compareWindowedScanBound` — the window derivation `emitRangeWindowCompare`
  performed inline, extracted so the seam reaches the *same* bound the matrix
  statement embeds rather than deriving a second one.
- `emitter.renderNode` — the isolated-render dance, now in one place;
  `subqueryFrag` is `Subquery(PreRenderedSQL{…})` over it.
- The seam runs the same emit-chokepoint preparation `Emit` runs, and passes
  its output through `GuardEmittedSQL` like every other path that builds
  otel_traces SQL outside `Emit`.

## What the tests do now

Both packages ask for the leg. Neither contains a paren-depth scan, and neither
reconstructs an arg slice:

- `internal/chsql/metrics_compare_test.go` — the envelope-placement assertions
  are unchanged; the trailing-args assertions now read the **leg's own** args
  instead of counting back through the whole statement's.
- `test/perf/compare_window_prune_chdb_test.go` — the Tempo root-enrichment
  parity and the `trace_id_ts` partition-prune assertions are unchanged; only
  the extraction became a call.

Both also assert what the scanners only assumed: the standalone leg must appear
verbatim inside the emitted matrix statement. A new `TestEmitCompareRootLeg`
pins that containment across all three root-leg shapes (unbounded-lossless,
root-scoped, `trace_id_ts` envelope), pins that the leg is a runnable statement
rather than a parenthesised fragment, pins one arg per placeholder in the leg's
own text, and covers the seam's rejections.

## Verification

Emitted bytes unchanged — the goldens did not move:

- `test/spec/promql`, `test/spec/logql`, `test/spec/traceql` (chdb-tagged): green,
  zero fixture churn.
- `internal/chsql` unit + mutation tests, `internal/optimizer`,
  `internal/api/tempo`, whole `./internal/...`: green.
- `test/perf` `TestCompareNonRootRootLookupTraceIDTsEnvelope` (chdb-tagged):
  green — it executes the leg and EXPLAINs its part pruning, so a mis-paired
  arg list would fail it outright.
- `node .github/scripts/forbid-sql-raw.mjs`: clean.

Closes #1928
