### PR TITLE
fix(e2e): derive the crawl canonical key from control identity, not data or order

### DIFF
--- a/test/e2e/playwright/crawl/crawl.spec.ts
+++ b/test/e2e/playwright/crawl/crawl.spec.ts
@@ -132,6 +132,7 @@ import {
   collectVisibleAlertBanners,
   diffInventory,
   expandSiblingTabs,
+  foldCanonicalCandidates,
   harvestLinks,
   inventoryPath,
   isSupersededDsQueryFailure,
@@ -147,6 +148,7 @@ import {
   type SurfaceInventory,
 } from './lib.js';
 import {
+  comboboxCardinalityRule,
   discoverControls,
   driveInteraction,
   interactionStateKey,
@@ -1027,6 +1029,137 @@ test.describe('crawl: canonicalization pins', () => {
     expect(grew[0]).toContain('coverage grew');
   });
 
+  test('#1873: the canonical-collapse representative is a function of the candidate SET, not of arrival order', () => {
+    // Four Logs Drilldown field pages all canonicalize to the SAME
+    // {field} surface (see the test above); which one is "the" visit
+    // must not depend on the order the crawler harvested their links
+    // in, or a Grafana render-order change (or simply reversing the
+    // visit order, per the epic's own gate) silently swaps which
+    // page's states end up pinned.
+    const candidates = [
+      { canonical: 'A', concrete: '/field/thread' },
+      { canonical: 'A', concrete: '/field/order_id' },
+      { canonical: 'A', concrete: '/field/customer' },
+      { canonical: 'A', concrete: '/field/response_latency_ms' },
+      { canonical: 'B', concrete: '/field/level' },
+    ];
+    const forward = foldCanonicalCandidates(candidates);
+    const reversed = foldCanonicalCandidates([...candidates].reverse());
+    expect(forward).toEqual(reversed);
+    // The winner is the codepoint-smallest concrete URL — a pure
+    // function of the SET, same doctrine as representativeOption.
+    expect(forward.get('A')?.concrete).toBe('/field/customer');
+    expect(forward.get('B')?.concrete).toBe('/field/level');
+
+    // The gate requirement, made concrete: swap the winning field for
+    // a DIFFERENT one entirely (a "different seed") — the CANONICAL
+    // set folding produces is unaffected; only the chosen concrete
+    // representative moves, which is exactly what "the pin is a
+    // function of the app, not of the data" requires.
+    const differentSeed = [
+      { canonical: 'A', concrete: '/field/zzz_new_column' },
+      { canonical: 'A', concrete: '/field/aaa_new_column' },
+      { canonical: 'B', concrete: '/field/level' },
+    ];
+    expect([...foldCanonicalCandidates(differentSeed).keys()].sort()).toEqual(
+      [...forward.keys()].sort(),
+    );
+
+    // A single-candidate canonical is untouched (no collapse to fold).
+    expect(forward.size).toBe(2);
+  });
+
+  test('#1873: query-parameter collapses fold identically regardless of visit order too', () => {
+    // #1855's var-groupBy collapse is the OTHER member of the
+    // asymmetry the epic names: every candidate already canonicalizes
+    // to the identical string once the query value drops, so folding
+    // is a no-op beyond picking a deterministic concrete URL to
+    // navigate — safe precisely because the thing that made the
+    // candidates distinct is exactly what the canonical key discards.
+    const a = canonicalizeURL(
+      '/a/grafana-exploretraces-app/explore?var-groupBy=resource.service.version',
+      base,
+      scope,
+    )!;
+    const b = canonicalizeURL(
+      '/a/grafana-exploretraces-app/explore?var-groupBy=resource.service.namespace',
+      base,
+      scope,
+    )!;
+    expect(a).toBe(b);
+    const candidates = [
+      { canonical: a, concrete: '/a/grafana-exploretraces-app/explore?var-groupBy=resource.service.version' },
+      { canonical: b, concrete: '/a/grafana-exploretraces-app/explore?var-groupBy=resource.service.namespace' },
+    ];
+    expect(foldCanonicalCandidates(candidates)).toEqual(
+      foldCanonicalCandidates([...candidates].reverse()),
+    );
+  });
+
+  test('#1872: a combobox with no declared cardinality rule parameterizes regardless of option count', () => {
+    // The old defect: an UNDECLARED combobox's mode followed the
+    // CURRENT option count against STRUCTURAL_MAX_OPTIONS, so a
+    // data-derived list (dashboard tags, detected field names) pinned
+    // literal seeded values whenever the seed happened to produce
+    // ≤12 of them — real, live rows in the committed compose
+    // inventory (`Tag filter=cerberus (7)`, `group-by-selector-
+    // combobox=cerberus_ql`) despite being unambiguously DATA, not
+    // app structure. An undeclared key must now parameterize no
+    // matter how small the option set is.
+    const combobox = (key: string, options: string[]) => ({
+      kind: 'combobox' as const,
+      key,
+      options,
+      selectedIndex: -1,
+      forcedHighCardinality: false,
+      optionHints: options,
+      controlHint: '',
+      clickHops: 0,
+    });
+    const smallUndeclared = planInteractions(
+      [combobox('select[Tag filter]', ['cerberus (7)', 'dogfood (1)'])],
+      0,
+    );
+    expect(smallUndeclared.map((p) => p.stateValue)).toEqual(['{rep}']);
+    expect(comboboxCardinalityRule('select[Tag filter]')).toBeUndefined();
+
+    // A DECLARED enumerate key still drives every option, however few.
+    const declared = planInteractions(
+      [combobox('select[SortBy direction]', ['Asc', 'Desc'])],
+      0,
+    );
+    expect(declared.map((p) => p.stateValue)).toEqual(['Asc', 'Desc']);
+    expect(comboboxCardinalityRule('select[SortBy direction]')?.mode).toBe(
+      'enumerate',
+    );
+
+    // The disambiguation suffix a duplicate control on one page gets
+    // (assignUniqueKeys) does not escape the declared rule.
+    expect(comboboxCardinalityRule('select[Sort]#1')?.mode).toBe('enumerate');
+  });
+
+  test('#1872: a closed-set rule rejects an option outside its declared values', () => {
+    const combobox = (key: string, options: string[]) => ({
+      kind: 'combobox' as const,
+      key,
+      options,
+      selectedIndex: -1,
+      forcedHighCardinality: false,
+      optionHints: options,
+      controlHint: '',
+      clickHops: 0,
+    });
+    // 'Select match operator' declares the closed 4-symbol matcher set
+    // — a value outside it means either the app gained a real new
+    // operator (pin it deliberately) or the rule is miscategorised.
+    expect(() =>
+      planInteractions(
+        [combobox('select[Select match operator]', ['=', '!=', 'contains'])],
+        0,
+      ),
+    ).toThrow(/outside its declared closed set/);
+  });
+
   test('committed inventory + exclusions files are internally consistent', () => {
     // Live-stack-free meta-checks (the live diff runs at the end of
     // the crawl): the active stack's inventory round-trips
@@ -1287,15 +1420,21 @@ test('crawl: BFS over every reachable Grafana surface with universal oracles + i
       // root page only; full expands from every page. Same harvest
       // RULE, fewer expansion states (depth doctrine).
       if (depth === 'full' || entry.canonical === '/') {
-        const canonicals = new Map<string, string>();
-        for (const href of harvested) {
-          const target = canonicalTarget(href, baseURL, stack.scope);
-          if (target === null || visited.has(target.canonical)) continue;
-          if (!canonicals.has(target.canonical)) {
-            canonicals.set(target.canonical, target.concrete);
-          }
-        }
-        for (const [canonical, concrete] of [...canonicals.entries()].sort(
+        // A path-segment collapse (`{field}`, `{service}`, …) folds
+        // several DISTINCT hrefs harvested from THIS page onto one
+        // canonical — see foldCanonicalCandidates (#1873). The winner
+        // must be a function of the candidate SET, not of the DOM
+        // order the links happened to render in, or the pinned state
+        // (whichever field/service/label the winner turns out to be)
+        // silently changes with an unrelated render-order shuffle.
+        const candidates = harvested
+          .map((href) => canonicalTarget(href, baseURL, stack.scope))
+          .filter(
+            (t): t is { canonical: string; concrete: string } =>
+              t !== null && !visited.has(t.canonical),
+          );
+        const canonicals = foldCanonicalCandidates(candidates);
+        for (const [canonical, { concrete }] of [...canonicals.entries()].sort(
           ([a], [b]) => byCodepoint(a, b),
         )) {
           queue.push({ canonical, concrete, via: entry.canonical });
@@ -1333,7 +1472,14 @@ test('crawl: BFS over every reachable Grafana surface with universal oracles + i
           inPlaceVisited.set(stateKey, state.concrete);
           if (isLeanRoot && state.leanRepresentative) leanSet.add(stateKey);
         }
-        for (const d of sweep.discovered) {
+        // Same fold as the link-harvest loop above: several driven
+        // interaction values (e.g. every structurally-enumerated
+        // attribute a groupBy picker offers) can each URL-encode to a
+        // DIFFERENT concrete surface that still collapses to the SAME
+        // parameterized canonical. Which one gets enqueued — and so
+        // which one the BFS actually visits — must be a function of
+        // the candidate set, not of control-discovery/DOM order.
+        for (const d of foldCanonicalCandidates(sweep.discovered).values()) {
           if (isLeanRoot && d.leanRepresentative) leanSet.add(d.canonical);
           if (!visited.has(d.canonical)) {
             queue.push({

--- a/test/e2e/playwright/crawl/interactions.ts
+++ b/test/e2e/playwright/crawl/interactions.ts
@@ -72,8 +72,110 @@ import type { Locator, Page } from '@playwright/test';
  * (the largest, the Traces Drilldown favorites attribute list,
  * carries 10) while excluding the data-derived lists (the "All"
  * attributes scope renders 51).
+ *
+ * Applies to 'tab' / 'radio' / 'option-list' controls only — Grafana
+ * core's TabsBar and RadioButtonGroup iterate a literal array baked
+ * into the plugin bundle at build time, so their SIZE really is a
+ * fact about the app. 'combobox' controls get no such guarantee (see
+ * COMBOBOX_CARDINALITY_RULES below): a react-select/downshift input
+ * can be bound to either a bundle-fixed menu (sort direction) or a
+ * datasource query result (field names, tag values), and nothing
+ * about ITS SIZE tells the two apart — an 11-tag dashboard-browse
+ * "Tag filter" and a 13-field Logs Drilldown "Filter by fields" are
+ * on OPPOSITE sides of this threshold despite both being data.
  */
 export const STRUCTURAL_MAX_OPTIONS = 12;
+
+/**
+ * Which sweep mode a 'combobox' control's option set gets, decided by
+ * CONTROL IDENTITY (its discovery `key` — a testid/aria-label/
+ * placeholder-derived string, fixed by the pinned app version) rather
+ * than by how many options happen to render today. Same doctrine as
+ * lib.ts's StructuralParamRule, generalized from URL query params to
+ * in-place interaction fragments (`#control=value`):
+ *
+ *   - 'enumerate' — the option set is a fact about the APP: a fixed
+ *     menu (sort direction, sort function, result-count picker, log
+ *     severity levels, matcher operators, …) baked into the widget's
+ *     own contract. Every option keys its own state.
+ *   - 'parameterize' — the DEFAULT for every combobox key this table
+ *     does not name. A control whose options come from a datasource
+ *     query (detected field/label/tag names, metric names, dashboard
+ *     tags, …) collapses to one representative (`{rep}`) regardless
+ *     of how many options the CURRENT seed happens to produce — #1872
+ *     was `Filter by fields` and `Tag filter` pinning literal seeded
+ *     names purely because their count landed on the wrong side of
+ *     STRUCTURAL_MAX_OPTIONS that day.
+ *
+ * A key with no matching rule parameterizes — the safe default. A
+ * control genuinely misclassified 'parameterize' loses enumeration
+ * (a coverage gap the interaction-count ratchet can catch and a
+ * reviewer can promote to 'enumerate' deliberately); one
+ * misclassified 'enumerate' pins the seeded dataset into the key,
+ * which is the defect class this table exists to close. The two
+ * failure modes are not symmetric, so the default favors the safe
+ * one.
+ */
+export type ComboboxCardinalityRule = {
+  /** Matched against the control's discovery KEY — its identity,
+   * never an option VALUE. */
+  keyPattern: RegExp;
+  mode: 'enumerate' | 'parameterize';
+  /**
+   * Optional closed option set. When present, a discovered option
+   * outside it fails the crawl loudly instead of silently mining the
+   * value into the plan — the same self-check StructuralParamRule
+   * runs for 'enumerate' query params: either the app gained an
+   * option (add it here deliberately) or the list is not actually
+   * closed (the rule is miscategorised; make it 'parameterize').
+   */
+  values?: ReadonlyArray<string>;
+};
+
+// Every pattern tolerates assignUniqueKeys' `#<n>` disambiguation
+// suffix (two same-family controls on one page) so a duplicate sibling
+// doesn't silently fall through to the default.
+export const COMBOBOX_CARDINALITY_RULES: ReadonlyArray<ComboboxCardinalityRule> = [
+  // Logs/Traces Drilldown table controls: layout, sort and page-size
+  // menus are fixed UI vocabulary, not data — how a table SORTS or how
+  // many rows it FETCHES does not depend on what the seeded logs say.
+  { keyPattern: /^select\[SortBy direction\](#\d+)?$/, mode: 'enumerate' },
+  { keyPattern: /^select\[SortBy function\](#\d+)?$/, mode: 'enumerate' },
+  {
+    keyPattern: /^select\[\{n\} (logs|lines|rows)\](#\d+)?$/,
+    mode: 'enumerate',
+  },
+  // Loki's OWN normalized severity vocabulary (critical/error/warn/
+  // info/debug/trace/unknown), not a set of arbitrary detected values.
+  { keyPattern: /^select\[detected_level\](#\d+)?$/, mode: 'enumerate' },
+  // A downshift input with neither a testid nor an aria-label falls
+  // back to its bare React useId-derived element id (erased to the
+  // shared `{rid}` placeholder — see REACT_ID_PLACEHOLDER), so this ONE
+  // key pattern addresses two different, both fixed-vocabulary, widgets
+  // verified live: the Logs Drilldown per-value operator step
+  // (Include | Exclude) and the Traces Drilldown duration-metric
+  // percentile picker (p50 | p90 | p99).
+  {
+    keyPattern: /^select\[downshift-\{rid\}-input\](#\d+)?$/,
+    mode: 'enumerate',
+  },
+  // Prometheus/Loki adhoc-filter matcher operator: exactly the four
+  // matcher symbols the query languages define — a protocol constant,
+  // not app or data state.
+  {
+    keyPattern: /^select\[Select match operator\](#\d+)?$/,
+    mode: 'enumerate',
+    values: ['=', '!=', '=~', '!~'],
+  },
+  // Dashboard-browse "sort by": a fixed alphabetical/recency menu.
+  { keyPattern: /^select\[Sort\](#\d+)?$/, mode: 'enumerate' },
+];
+
+export function comboboxCardinalityRule(
+  key: string,
+): ComboboxCardinalityRule | undefined {
+  return COMBOBOX_CARDINALITY_RULES.find((r) => r.keyPattern.test(key));
+}
 
 /**
  * Hard cap on a base surface's (0 pinned structural params)
@@ -212,9 +314,37 @@ export function planInteractions(
 
   const plan: PlannedInteraction[] = [];
   for (const control of controls) {
-    const structural =
-      !control.forcedHighCardinality &&
-      control.options.length <= STRUCTURAL_MAX_OPTIONS;
+    // 'combobox' controls decide structural-vs-data-derived by
+    // DECLARED identity (COMBOBOX_CARDINALITY_RULES), never by how
+    // many options the current seed happens to render — see #1872.
+    // Every other kind keeps the size-based check: Grafana core's
+    // TabsBar / RadioButtonGroup / option-list widgets iterate a
+    // bundle-fixed array, so their SIZE is a fact about the app (see
+    // STRUCTURAL_MAX_OPTIONS).
+    let structural: boolean;
+    if (control.kind === 'combobox') {
+      const rule = comboboxCardinalityRule(control.key);
+      if (rule?.mode === 'enumerate' && rule.values !== undefined) {
+        const unknown = control.options.filter(
+          (o) => !rule.values!.includes(o),
+        );
+        if (unknown.length > 0) {
+          throw new Error(
+            `interaction sweep: combobox ${control.key} offers option(s) ` +
+              `${unknown.map((o) => JSON.stringify(o)).join(', ')} outside its declared ` +
+              `closed set [${rule.values.map((v) => JSON.stringify(v)).join(', ')}] in ` +
+              `COMBOBOX_CARDINALITY_RULES — either the pinned app version gained an option ` +
+              `(add it to the rule's values deliberately) or the option list is not actually ` +
+              `closed, in which case the rule must become mode 'parameterize'.`,
+          );
+        }
+      }
+      structural = rule?.mode === 'enumerate';
+    } else {
+      structural =
+        !control.forcedHighCardinality &&
+        control.options.length <= STRUCTURAL_MAX_OPTIONS;
+    }
     const drivable = control.options.filter(
       (_, i) => i !== control.selectedIndex,
     );

--- a/test/e2e/playwright/crawl/lib.ts
+++ b/test/e2e/playwright/crawl/lib.ts
@@ -859,6 +859,49 @@ export function byCodepoint(a: string, b: string): number {
 }
 
 /**
+ * Fold a batch of {canonical, concrete} candidates down to ONE
+ * concrete representative per canonical — a PURE function of the
+ * candidate SET, never of the order the caller happened to encounter
+ * them in.
+ *
+ * This is the general form of #1873's fix. A PATH-SEGMENT
+ * parameterization (`{field}`, `{service}`, `{label}`, …) folds
+ * several genuinely DISTINCT pages onto one canonical, and the BFS
+ * (crawl.spec.ts) only ever visits ONE of them — `visited.has` skips
+ * every later arrival at dequeue time. Before this function, "the
+ * one" was whichever candidate happened to be first in DOM/harvest
+ * order (a[href] order on the listing page, or control-discovery
+ * order for a sweep-discovered surface) — so a Grafana render-order
+ * change, or simply reversing the visit order, could silently swap
+ * WHICH page's states end up pinned under the shared canonical, with
+ * nothing about the canonical KEY itself moving to explain why.
+ *
+ * The fix is the same doctrine `representativeOption` already applies
+ * to a high-cardinality CONTROL's option set (interactions.ts):
+ * derive the pick from the candidate SET (codepoint order on the
+ * concrete URL) instead of from arrival order. It is safe to apply
+ * uniformly to every collapse, including a QUERY-PARAMETER collapse
+ * (#1855's var-groupBy, var-groupby, metric): there every candidate
+ * canonicalizes identically REGARDLESS of which one folding picks
+ * (the query value that made them distinct is exactly what the
+ * canonical key drops), so a deterministic pick changes nothing about
+ * correctness — it only makes it as reproducible as the path-segment
+ * case, where the choice does matter.
+ */
+export function foldCanonicalCandidates<
+  T extends { canonical: string; concrete: string },
+>(candidates: ReadonlyArray<T>): Map<string, T> {
+  const out = new Map<string, T>();
+  for (const candidate of candidates) {
+    const existing = out.get(candidate.canonical);
+    if (existing === undefined || byCodepoint(candidate.concrete, existing.concrete) < 0) {
+      out.set(candidate.canonical, candidate);
+    }
+  }
+  return out;
+}
+
+/**
  * Render the canonical serialized form of an inventory — sorted by
  * URL, two-space indent, trailing newline — so regeneration is
  * byte-for-byte reproducible (mirrors test/inventory/'s


### PR DESCRIPTION
## Summary

The crawl surface-inventory ratchet only means anything if a crawled surface is a pure function of the Grafana application. This closes two of the axes the epic names.

- **#1872 (data axis).** An in-place interaction control's cardinality (enumerate every option vs. collapse to one `{rep}`) was decided by counting the *current* option set against `STRUCTURAL_MAX_OPTIONS`, not by what the options actually *are*. That heuristic already reads wrong live in the committed compose inventory: `Tag filter=cerberus (7)` (11 dashboard tags) and `group-by-selector-combobox=cerberus_ql` (a label name) are both unambiguously data, pinned as literals purely because their count landed on the "structural" side of 12 that day — the same failure `Filter by fields` hit before it happened to cross 12 the other way. Comboboxes now classify by **declared control identity** (`COMBOBOX_CARDINALITY_RULES` in `interactions.ts`, mirroring `lib.ts`'s `StructuralParamRule` doctrine already used for URL params): a fixed menu (sort direction, sort function, result-count picker, matcher operators, …) enumerates because it's a fact about the widget; anything undeclared parameterizes to `{rep}` by default, so a future data-derived field needs zero code changes to stay safe. Non-combobox kinds (tab, radio, option-list) keep the size-based check unchanged — nothing found contradicts that Grafana core's TabsBar/RadioButtonGroup genuinely iterate a bundle-fixed array.

- **#1873 (visit-order axis).** A path-segment collapse (`{field}`, `{service}`, …) folds several genuinely distinct pages onto one canonical, and the BFS only ever visits one of them. Which one was "whichever candidate happened to be first in DOM/harvest order" — so a Grafana render-order change, or reversing the visit order, could silently swap which page's interaction states end up pinned, with nothing about the canonical key itself moving to explain why. `foldCanonicalCandidates` (`lib.ts`) makes the pick a pure function of the candidate *set* (codepoint-smallest concrete URL — the same doctrine `representativeOption` already applies to a control's option set) and replaces the two "first one wins" dedup sites in `crawl.spec.ts` (the per-page link harvest, and the interaction sweep's discovered-surface list). Applied uniformly, including to #1855's query-parameter collapses, where it's a no-op for correctness (every candidate there already canonicalizes identically) and only adds the same reproducibility.

Both are **derive, don't enumerate** fixes: neither hardcodes a literal data value (no field/tag/label name appears as a special-cased string anywhere), and both generalize to a future control/value with zero code changes.

## Verification

- `npx tsc --noEmit -p tsconfig.json` (the same check CI's "typecheck e2e Playwright specs" step runs) — clean.
- Every non-live-Grafana test in `crawl/crawl.spec.ts` (27) and `crawl/reconcile.spec.ts` (50) passes locally — 77/77, including four new tests covering: `foldCanonicalCandidates` order-independence (reversed input, byte-identical output; the gate's own "different seed / reversed order" requirement made concrete), an undeclared combobox parameterizing regardless of option count, a declared closed set still enumerating fully (with the `#n` disambiguation suffix), and a value outside a declared closed set failing loudly.
- **CI-only:** `crawl/dsquery.spec.ts` and `crawl/lints.spec.ts` need a live Grafana/cerberus stack and are not runnable here; the live BFS crawl test (`crawl.spec.ts`'s `'crawl: BFS over every reachable Grafana surface...'`) is the same. I checked `docker ps` before touching anything compose-related — no compose/e2e/grafana stack is running in this environment (only an unrelated `cerberus-migration-tier1-*` stack and personal-project containers), so I did not attempt to start one, per the concurrency-hazard note.
- **Follow-up required before the compose-smoke crawl gate is green:** the committed `test/e2e/playwright/crawl/grafana-surface-inventory.compose.json` still pins the *old* literal `Tag filter=…` / `group-by-selector-combobox=cerberus_ql` rows this change makes unreachable. Regenerating it needs a live compose stack (`CERBERUS_UPDATE_INVENTORY=1 SWEEP_DEPTH=full CRAWL_STACK=compose npx playwright test crawl/crawl.spec.ts`) — the same two-step shape #1919 (code) → #1925 (regen) already used for this exact class of change. Per invariant 9 I did not hand-edit the generated artefact.

## Scope

Per the epic (#1872) and the task: this PR is the derivation fix for both members. `Closes #1873` (a fully scoped, concrete, checkable fix). #1872 itself stays open — its own text ties full closure to #1467's enforcement machinery (empty k3d inventory, no compose regen path), which is out of scope here; #1539/#1826/#1674 are untouched.

Closes #1873

🤖 Generated with [Claude Code](https://claude.com/claude-code)