### PR TITLE
fix(preflight): scope requirements + Prom metadata to enabled signals

### DIFF
--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -1377,6 +1377,29 @@ const (
 //
 // When the check is disabled, both gates are bypassed (one log line) and a
 // nil SchemaPresentFunc is returned — readiness does not gate on the schema.
+// preflightRequirementsFromConfig translates the resolved config into
+// preflight.Requirements, including the enabled-head -> Signal mapping
+// (#1949): a Head maps 1:1 onto a Signal (prom -> Metrics, loki -> Logs,
+// tempo -> Traces), so a deployment that narrows CERBERUS_ENABLED_HEADS
+// (e.g. a Loki-only split-mode pod) never gates readiness — or spends
+// boot-time introspection — on a signal's tables it will never ingest. Pure
+// function of cfg so it is unit-testable without a real ClickHouse client;
+// runRequirementsCheck is the only caller.
+func preflightRequirementsFromConfig(cfg config.Config) preflight.Requirements {
+	return preflight.Requirements{
+		Database:          cfg.ClickHouse.Database,
+		NativeRateEnabled: cfg.ExperimentalTSGridRange,
+		Metrics:           cfg.Schema,
+		Logs:              cfg.Logs,
+		Traces:            cfg.Traces,
+		Signals: preflight.Signals{
+			Metrics: cfg.HeadEnabled(config.HeadProm),
+			Logs:    cfg.HeadEnabled(config.HeadLoki),
+			Traces:  cfg.HeadEnabled(config.HeadTempo),
+		},
+	}
+}
+
 func runRequirementsCheck(
 	ctx context.Context,
 	logger *slog.Logger,
@@ -1387,13 +1410,7 @@ func runRequirementsCheck(
 		logger.Info("requirements check disabled (CERBERUS_REQUIREMENTS_CHECK=false)")
 		return nil, nil
 	}
-	req := preflight.Requirements{
-		Database:          cfg.ClickHouse.Database,
-		NativeRateEnabled: cfg.ExperimentalTSGridRange,
-		Metrics:           cfg.Schema,
-		Logs:              cfg.Logs,
-		Traces:            cfg.Traces,
-	}
+	req := preflightRequirementsFromConfig(cfg)
 	res := preflight.RunIfEnabled(ctx, cfg.RequirementsCheck, client, req)
 	// Logged BEFORE the fatal check: a warning describes the server cerberus is
 	// pointed at, and an operator debugging a failed boot needs it just as much

--- a/cmd/cerberus/main_test.go
+++ b/cmd/cerberus/main_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/tsouza/cerberus/internal/config"
 	"github.com/tsouza/cerberus/internal/preflight"
 	"github.com/tsouza/cerberus/internal/schema"
 )
@@ -295,3 +296,85 @@ var errUnreachableProbe = errTestPlaceholder("simulated probe failure")
 type errTestPlaceholder string
 
 func (e errTestPlaceholder) Error() string { return string(e) }
+
+// TestPreflightRequirementsFromConfig_SignalsMapping (#1949) pins the
+// Head -> Signal translation in isolation from any ClickHouse connection:
+// each of the eight CERBERUS_ENABLED_HEADS subsets yields exactly the
+// matching Signals bits, so a Loki-only split-mode pod's preflight
+// Requirements never asks for the metrics/traces tables it will never
+// ingest, while the full default (all three heads, the zero-config case)
+// keeps requiring all three — preserving every deployment's behaviour from
+// before this field existed.
+func TestPreflightRequirementsFromConfig_SignalsMapping(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		heads config.EnabledHeads
+		want  preflight.Signals
+	}{
+		{
+			"all three heads (the default)",
+			config.EnabledHeads{config.HeadProm: {}, config.HeadLoki: {}, config.HeadTempo: {}},
+			preflight.Signals{Metrics: true, Logs: true, Traces: true},
+		},
+		{
+			"loki-only split-mode pod",
+			config.EnabledHeads{config.HeadLoki: {}},
+			preflight.Signals{Metrics: false, Logs: true, Traces: false},
+		},
+		{
+			"prom-only split-mode pod",
+			config.EnabledHeads{config.HeadProm: {}},
+			preflight.Signals{Metrics: true, Logs: false, Traces: false},
+		},
+		{
+			"tempo-only split-mode pod",
+			config.EnabledHeads{config.HeadTempo: {}},
+			preflight.Signals{Metrics: false, Logs: false, Traces: true},
+		},
+		{
+			"logs + traces, no metrics",
+			config.EnabledHeads{config.HeadLoki: {}, config.HeadTempo: {}},
+			preflight.Signals{Metrics: false, Logs: true, Traces: true},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := config.Config{EnabledHeads: tc.heads}
+			got := preflightRequirementsFromConfig(cfg).Signals
+			if got != tc.want {
+				t.Errorf("Signals = %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPreflightRequirementsFromConfig_ThreadsSchemaAndDatabase pins that the
+// translation carries the resolved database + schema shapes through
+// verbatim (the Signals mapping is the new #1949 behaviour; the rest must
+// stay byte-identical to what runRequirementsCheck built inline before the
+// extraction).
+func TestPreflightRequirementsFromConfig_ThreadsSchemaAndDatabase(t *testing.T) {
+	t.Parallel()
+	m := configuredMetrics()
+	cfg := config.Config{
+		EnabledHeads:            config.EnabledHeads{config.HeadProm: {}, config.HeadLoki: {}, config.HeadTempo: {}},
+		Schema:                  m,
+		Logs:                    schema.DefaultOTelLogs(),
+		Traces:                  schema.DefaultOTelTraces(),
+		ExperimentalTSGridRange: true,
+	}
+	cfg.ClickHouse.Database = "otel"
+
+	got := preflightRequirementsFromConfig(cfg)
+	if got.Database != "otel" {
+		t.Errorf("Database = %q, want %q", got.Database, "otel")
+	}
+	if !got.NativeRateEnabled {
+		t.Error("NativeRateEnabled = false, want true (mirrors cfg.ExperimentalTSGridRange)")
+	}
+	if got.Metrics.GaugeTable != m.GaugeTable {
+		t.Errorf("Metrics.GaugeTable = %q, want %q", got.Metrics.GaugeTable, m.GaugeTable)
+	}
+}

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1022,6 +1022,19 @@ opaque query-time errors into a precise, fail-fast boot error:
   (and its tables) appear, with no restart. Treating it as fatal would
   crash-loop a gateway pointed at a database its collector hasn't created yet.
 
+**Scoped to the enabled heads.** Every requirement above is scoped by
+`CERBERUS_ENABLED_HEADS`: a Head maps 1:1 onto a telemetry signal (`prom` →
+metrics, `loki` → logs, `tempo` → traces), and a table's checks — the
+wrong-shape gate, the absent-table wait-and-reprobe, and the explicit-name
+fail-fast — run **only** for the signals this process actually serves. A
+`CERBERUS_ENABLED_HEADS=loki` split-mode pod (see
+[`health.md`](health.md#per-head-readiness)) never validates or waits on
+`otel_metrics_*` / `otel_traces` existing, so `/readyz` goes ready as soon as
+`otel_logs` is provisioned — a logs-only pipeline no longer keeps a
+fully-functional pod out of its Service forever waiting on tables it will
+never ingest. The unset default (`prom,loki,tempo`) preserves the
+all-three-signals behaviour every deployment had before this scoping existed.
+
 The ordering is deliberate: running the preflight **after** auto-create
 means a fresh database where cerberus just created the tables passes the
 schema gate (it would fail against tables that don't exist yet if the order

--- a/internal/api/prom/handler_absent_table_test.go
+++ b/internal/api/prom/handler_absent_table_test.go
@@ -1,0 +1,357 @@
+package prom_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+
+	"github.com/tsouza/cerberus/internal/api/prom"
+	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// This file pins symptom 2 of #1949: the Prom metadata surface must
+// degrade gracefully (answer a real, possibly-empty result) when one of
+// its configured metric tables is absent from ClickHouse — because this
+// deployment does not ingest that signal (e.g. no classic histograms, so
+// otel_metrics_histogram was never provisioned), or because a table went
+// missing after boot — instead of 502ing the whole request.
+
+// unknownTableErr builds the typed ClickHouse exception (code 60,
+// UNKNOWN_TABLE) the driver raises when a query names a table that does
+// not exist.
+func unknownTableErr(table string) error {
+	return &clickhouse.Exception{
+		Code:    60,
+		Name:    "UNKNOWN_TABLE",
+		Message: "Table default." + table + " doesn't exist",
+	}
+}
+
+// absentTableQuerier simulates a deployment where absentTable is
+// configured (the schema resolver defaulted it) but was never provisioned
+// in ClickHouse. Any QueryStrings call whose SQL names absentTable in a
+// FROM clause fails with UNKNOWN_TABLE; the system.tables existence probe
+// (queryStringsDegradingUnknownTable's recovery step) reports every OTHER
+// configured metric table as present; any other query succeeds and
+// returns the stubbed rows.
+type absentTableQuerier struct {
+	absentTable string
+	rows        []string
+
+	systemTablesCalls int
+	queryCalls        []string
+}
+
+func (q *absentTableQuerier) QueryStrings(_ context.Context, sql string, _ ...any) ([]string, error) {
+	q.queryCalls = append(q.queryCalls, sql)
+	if strings.Contains(sql, "`tables`") {
+		q.systemTablesCalls++
+		var existing []string
+		for _, t := range schema.DefaultOTelMetrics().ConfiguredMetricTables() {
+			if t != q.absentTable {
+				existing = append(existing, t)
+			}
+		}
+		return existing, nil
+	}
+	if strings.Contains(sql, q.absentTable) {
+		return nil, unknownTableErr(q.absentTable)
+	}
+	return q.rows, nil
+}
+
+func (q *absentTableQuerier) Query(context.Context, string, ...any) ([]chclient.Sample, error) {
+	return nil, nil
+}
+
+func (q *absentTableQuerier) QueryCursor(context.Context, string, ...any) (chclient.Cursor, error) {
+	return newSliceCursor(nil), nil
+}
+
+func (q *absentTableQuerier) QueryLabelSets(context.Context, string, ...any) ([]map[string]string, error) {
+	return nil, nil
+}
+
+func (q *absentTableQuerier) QueryMetricMeta(context.Context, string, string, ...any) ([]chclient.MetricMetaRow, error) {
+	return nil, nil
+}
+
+func (q *absentTableQuerier) QueryExemplars(context.Context, string, ...any) ([]chclient.ExemplarRow, error) {
+	return nil, nil
+}
+
+var _ prom.Querier = (*absentTableQuerier)(nil)
+
+// allTablesAbsentQuerier simulates the extreme case: every configured
+// metric table is absent (e.g. a deployment that ingests only logs and
+// traces but never disabled the prom head, so it still defaults
+// otel_metrics_gauge/_sum/_histogram — none of which will ever be
+// provisioned). Every non-probe QueryStrings call fails UNKNOWN_TABLE; the
+// existence probe finds nothing.
+type allTablesAbsentQuerier struct {
+	systemTablesCalls int
+}
+
+func (q *allTablesAbsentQuerier) QueryStrings(_ context.Context, sql string, _ ...any) ([]string, error) {
+	if strings.Contains(sql, "`tables`") {
+		q.systemTablesCalls++
+		return nil, nil
+	}
+	return nil, unknownTableErr("otel_metrics_gauge")
+}
+
+func (q *allTablesAbsentQuerier) Query(context.Context, string, ...any) ([]chclient.Sample, error) {
+	return nil, nil
+}
+
+func (q *allTablesAbsentQuerier) QueryCursor(context.Context, string, ...any) (chclient.Cursor, error) {
+	return newSliceCursor(nil), nil
+}
+
+func (q *allTablesAbsentQuerier) QueryLabelSets(context.Context, string, ...any) ([]map[string]string, error) {
+	return nil, nil
+}
+
+func (q *allTablesAbsentQuerier) QueryMetricMeta(context.Context, string, string, ...any) ([]chclient.MetricMetaRow, error) {
+	return nil, nil
+}
+
+func (q *allTablesAbsentQuerier) QueryExemplars(context.Context, string, ...any) ([]chclient.ExemplarRow, error) {
+	return nil, nil
+}
+
+var _ prom.Querier = (*allTablesAbsentQuerier)(nil)
+
+func absentTableServer(q prom.Querier) *httptest.Server {
+	h := prom.New(q, schema.DefaultOTelMetrics(), nil)
+	mux := http.NewServeMux()
+	h.Mount(mux)
+	return httptest.NewServer(mux)
+}
+
+// probeFailsQuerier simulates the union query hitting UNKNOWN_TABLE, and
+// then the RECOVERY existence probe itself failing (e.g. a transport blip
+// hitting system.tables right after the rejection). Belt-and-suspenders
+// (#1949): this must still degrade to an empty result, never a 502 — the
+// probe failing is not a reason to surface the original rejection either.
+type probeFailsQuerier struct{}
+
+func (q *probeFailsQuerier) QueryStrings(_ context.Context, sql string, _ ...any) ([]string, error) {
+	if strings.Contains(sql, "`tables`") {
+		return nil, errors.New("dial tcp: connection refused")
+	}
+	return nil, unknownTableErr("otel_metrics_gauge")
+}
+
+func (q *probeFailsQuerier) Query(context.Context, string, ...any) ([]chclient.Sample, error) {
+	return nil, nil
+}
+
+func (q *probeFailsQuerier) QueryCursor(context.Context, string, ...any) (chclient.Cursor, error) {
+	return newSliceCursor(nil), nil
+}
+
+func (q *probeFailsQuerier) QueryLabelSets(context.Context, string, ...any) ([]map[string]string, error) {
+	return nil, nil
+}
+
+func (q *probeFailsQuerier) QueryMetricMeta(context.Context, string, string, ...any) ([]chclient.MetricMetaRow, error) {
+	return nil, nil
+}
+
+func (q *probeFailsQuerier) QueryExemplars(context.Context, string, ...any) ([]chclient.ExemplarRow, error) {
+	return nil, nil
+}
+
+var _ prom.Querier = (*probeFailsQuerier)(nil)
+
+// doubleVanishQuerier simulates a SECOND table vanishing between the
+// existence probe and the narrowed retry: the probe reports only
+// otel_metrics_sum as present (both gauge and histogram absent), but the
+// retried query against just otel_metrics_sum ALSO hits UNKNOWN_TABLE.
+// Belt-and-suspenders (#1949): this must still degrade to empty, never a
+// 502, even though the recovery attempt itself failed.
+type doubleVanishQuerier struct {
+	systemTablesCalls int
+}
+
+func (q *doubleVanishQuerier) QueryStrings(_ context.Context, sql string, _ ...any) ([]string, error) {
+	if strings.Contains(sql, "`tables`") {
+		q.systemTablesCalls++
+		return []string{schema.DefaultOTelMetrics().SumTable}, nil
+	}
+	return nil, unknownTableErr("otel_metrics_gauge")
+}
+
+func (q *doubleVanishQuerier) Query(context.Context, string, ...any) ([]chclient.Sample, error) {
+	return nil, nil
+}
+
+func (q *doubleVanishQuerier) QueryCursor(context.Context, string, ...any) (chclient.Cursor, error) {
+	return newSliceCursor(nil), nil
+}
+
+func (q *doubleVanishQuerier) QueryLabelSets(context.Context, string, ...any) ([]map[string]string, error) {
+	return nil, nil
+}
+
+func (q *doubleVanishQuerier) QueryMetricMeta(context.Context, string, string, ...any) ([]chclient.MetricMetaRow, error) {
+	return nil, nil
+}
+
+func (q *doubleVanishQuerier) QueryExemplars(context.Context, string, ...any) ([]chclient.ExemplarRow, error) {
+	return nil, nil
+}
+
+var _ prom.Querier = (*doubleVanishQuerier)(nil)
+
+// TestLabels_ExistenceProbeFailureDegradesToEmpty pins the first
+// belt-and-suspenders branch: the recovery probe itself failing must not
+// surface the original UNKNOWN_TABLE as a 502.
+func TestLabels_ExistenceProbeFailureDegradesToEmpty(t *testing.T) {
+	t.Parallel()
+	srv := absentTableServer(&probeFailsQuerier{})
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v1/labels")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (an existence-probe failure must not surface the original UNKNOWN_TABLE as a 502); body=%s", resp.StatusCode, body)
+	}
+}
+
+// TestLabels_SecondUnknownTableOnRetryDegradesToEmpty pins the second
+// belt-and-suspenders branch: a table vanishing a second time, between the
+// existence probe and the narrowed retry, must also degrade to empty
+// rather than surface as a 502.
+func TestLabels_SecondUnknownTableOnRetryDegradesToEmpty(t *testing.T) {
+	t.Parallel()
+	q := &doubleVanishQuerier{}
+	srv := absentTableServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v1/labels")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (a second UNKNOWN_TABLE on the narrowed retry must not surface as a 502); body=%s", resp.StatusCode, body)
+	}
+	if q.systemTablesCalls == 0 {
+		t.Error("existence probe never called")
+	}
+}
+
+// TestLabels_DegradesOnAbsentMetricTable is the direct regression test for
+// symptom 2: before the fix, unionLabelNamesSQL unconditionally unioned
+// all three metric tables with no existence guard, so ClickHouse's
+// UNKNOWN_TABLE on the histogram table failed the whole combined query and
+// the handler wrapped it as a 502. It must now answer 200 with the names
+// the surviving tables produce.
+func TestLabels_DegradesOnAbsentMetricTable(t *testing.T) {
+	t.Parallel()
+	m := schema.DefaultOTelMetrics()
+	q := &absentTableQuerier{absentTable: m.HistogramTable, rows: []string{"instance", "job"}}
+	srv := absentTableServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v1/labels")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (must degrade, not 502); body=%s", resp.StatusCode, body)
+	}
+	var parsed metadataResponse
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		t.Fatalf("body not JSON: %v; body=%s", err, body)
+	}
+	if parsed.Status != "success" {
+		t.Fatalf("status = %q, want success; body=%s", parsed.Status, body)
+	}
+	if q.systemTablesCalls == 0 {
+		t.Error("existence probe (system.tables) never called; want it consulted after the UNKNOWN_TABLE rejection")
+	}
+	if strings.Contains(body, `"error"`) {
+		t.Errorf("body carries an error field on a degraded (still-successful) response: %s", body)
+	}
+}
+
+// TestLabels_AllMetricTablesAbsent covers the deployment-wide case named in
+// the issue: a prom head left enabled by default over a logs+traces-only
+// ingestion pipeline, where NONE of the three metric tables ever get
+// provisioned. The endpoint must still answer 200 with the synthetic
+// __name__ label alone, never a 502 — and it must not issue a zero-arm
+// UNION (queryStringsDegradingUnknownTable short-circuits once the
+// existence probe narrows the candidate set to nothing).
+func TestLabels_AllMetricTablesAbsent(t *testing.T) {
+	t.Parallel()
+	q := &allTablesAbsentQuerier{}
+	srv := absentTableServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v1/labels")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (an all-absent metrics surface must answer empty, like reference Prometheus, not 502); body=%s", resp.StatusCode, body)
+	}
+	var parsed metadataResponse
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		t.Fatalf("body not JSON: %v; body=%s", err, body)
+	}
+	var names []string
+	if err := json.Unmarshal(parsed.Data, &names); err != nil {
+		t.Fatalf("data not a string array: %v; body=%s", err, body)
+	}
+	if len(names) != 1 || names[0] != "__name__" {
+		t.Errorf("names = %v, want exactly [\"__name__\"] (no metric table contributes any real label)", names)
+	}
+	if q.systemTablesCalls == 0 {
+		t.Error("existence probe never called")
+	}
+}
+
+// TestLabelValues_DegradesOnAbsentMetricTable covers unionLabelValuesSQL —
+// the /api/v1/label/<name>/values arm named explicitly in #1949 — with the
+// same absent-histogram-table scenario as TestLabels_DegradesOnAbsentMetricTable.
+func TestLabelValues_DegradesOnAbsentMetricTable(t *testing.T) {
+	t.Parallel()
+	m := schema.DefaultOTelMetrics()
+	q := &absentTableQuerier{absentTable: m.HistogramTable, rows: []string{"prod", "staging"}}
+	srv := absentTableServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v1/label/environment/values")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (must degrade, not 502); body=%s", resp.StatusCode, body)
+	}
+	var parsed metadataResponse
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		t.Fatalf("body not JSON: %v; body=%s", err, body)
+	}
+	if parsed.Status != "success" {
+		t.Fatalf("status = %q, want success; body=%s", parsed.Status, body)
+	}
+	if q.systemTablesCalls == 0 {
+		t.Error("existence probe (system.tables) never called; want it consulted after the UNKNOWN_TABLE rejection")
+	}
+}

--- a/internal/api/prom/metadata.go
+++ b/internal/api/prom/metadata.go
@@ -766,9 +766,10 @@ func (h *Handler) handleSeries(w http.ResponseWriter, r *http.Request) {
 // grammar forbids in identifier position; without the rewrite, panels
 // doing `sum by (service_name)` silently produce empty matrices.
 func (h *Handler) fetchLabelNames(ctx context.Context, start, end time.Time, nowAnchored bool) ([]string, error) {
-	sql := h.unionLabelNamesSQL(start, end, nowAnchored)
 	names, err := timeCH(ctx, func() ([]string, error) {
-		return h.Client.QueryStrings(ctx, sql)
+		return h.queryStringsDegradingUnknownTable(ctx, h.metricTables(), func(tables []string) (string, []any) {
+			return h.unionLabelNamesSQL(tables, start, end, nowAnchored), nil
+		})
 	})
 	if err != nil {
 		return nil, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusBadGateway}
@@ -794,7 +795,9 @@ func (h *Handler) fetchLabelNames(ctx context.Context, start, end time.Time, now
 // the /labels listing alongside the Attributes keys + __name__.
 func (h *Handler) fetchResourceLabelNames(ctx context.Context, start, end time.Time) ([]string, error) {
 	resNames, err := timeCH(ctx, func() ([]string, error) {
-		return h.Client.QueryStrings(ctx, h.unionResourceLabelNamesSQL(start, end))
+		return h.queryStringsDegradingUnknownTable(ctx, h.metricTables(), func(tables []string) (string, []any) {
+			return h.unionResourceLabelNamesSQL(tables, start, end), nil
+		})
 	})
 	if err != nil {
 		return nil, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusBadGateway}
@@ -823,9 +826,10 @@ func (h *Handler) fetchLabelValues(ctx context.Context, name string, start, end 
 	if name == model.MetricNameLabel {
 		return h.fetchMetricNameValues(ctx, start, end, nowAnchored)
 	}
-	sql, args := h.unionLabelValuesSQL(name, start, end, nowAnchored)
 	values, err := timeCH(ctx, func() ([]string, error) {
-		return h.Client.QueryStrings(ctx, sql, args...)
+		return h.queryStringsDegradingUnknownTable(ctx, h.metricTables(), func(tables []string) (string, []any) {
+			return h.unionLabelValuesSQL(tables, name, start, end, nowAnchored)
+		})
 	})
 	if err != nil {
 		return nil, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusBadGateway}
@@ -871,9 +875,10 @@ func (h *Handler) fetchMetricNameValues(ctx context.Context, start, end time.Tim
 	bareTables, histogramTable := h.catalogNameTables()
 	var values []string
 	if len(bareTables) > 0 {
-		sql := h.metricNamesSQL(bareTables, start, end, nowAnchored)
 		bare, err := timeCH(ctx, func() ([]string, error) {
-			return h.Client.QueryStrings(ctx, sql)
+			return h.queryStringsDegradingUnknownTable(ctx, bareTables, func(tables []string) (string, []any) {
+				return h.metricNamesSQL(tables, start, end, nowAnchored), nil
+			})
 		})
 		if err != nil {
 			return nil, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusBadGateway}
@@ -928,9 +933,10 @@ func (h *Handler) histogramBaseNames(ctx context.Context, start, end time.Time, 
 	if histogramTable == "" {
 		return nil, nil
 	}
-	sql := h.metricNamesSQL([]string{histogramTable}, start, end, nowAnchored)
 	names, err := timeCH(ctx, func() ([]string, error) {
-		return h.Client.QueryStrings(ctx, sql)
+		return h.queryStringsDegradingUnknownTable(ctx, []string{histogramTable}, func(tables []string) (string, []any) {
+			return h.metricNamesSQL(tables, start, end, nowAnchored), nil
+		})
 	})
 	if err != nil {
 		return nil, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusBadGateway}
@@ -1510,15 +1516,17 @@ func (h *Handler) resourceLabelValueArmActive(promLabel string) bool {
 	return false
 }
 
-// unionLabelNamesSQL builds a UNION of all metric tables' label keys. In the
+// unionLabelNamesSQL builds a UNION of tables' label keys — one arm per
+// entry in tables, the candidate set the caller passes in (normally
+// h.metricTables(), narrowed to the tables confirmed to exist when a prior
+// attempt hit UNKNOWN_TABLE; see queryStringsDegradingUnknownTable). In the
 // now-anchored case each arm emits the grouped form
 // `arrayJoin(mapKeys(Attributes)) ... GROUP BY MetricName, Attributes HAVING
 // max(TimeUnix) >= start`, so the key fan-out routes onto the proj_series
 // aggregating projection (Attributes is a grouping key, the time bound an
 // aggregate predicate). A user-supplied finite window keeps the exact
 // WHERE-bounded scan.
-func (h *Handler) unionLabelNamesSQL(start, end time.Time, nowAnchored bool) string {
-	tables := h.metricTables()
+func (h *Handler) unionLabelNamesSQL(tables []string, start, end time.Time, nowAnchored bool) string {
 	attrsCol := h.Schema.AttributesColumn
 	metricCol := h.Schema.MetricNameColumn
 	tsCol := h.Schema.TimestampColumn
@@ -1552,8 +1560,7 @@ func (h *Handler) unionLabelNamesSQL(start, end time.Time, nowAnchored bool) str
 // sanitizes + allowlist-filters in Go (cheaper than an N-key SQL IN over
 // every row's map, and it keeps the Attributes union byte-identical so the
 // promote-all default adds no churn to existing fixtures).
-func (h *Handler) unionResourceLabelNamesSQL(start, end time.Time) string {
-	tables := h.metricTables()
+func (h *Handler) unionResourceLabelNamesSQL(tables []string, start, end time.Time) string {
 	resCol := h.Schema.ResourceAttributesColumn
 	pred := h.metadataWindowPred(start, end)
 	parts := make([]chsql.Frag, 0, len(tables))
@@ -1691,8 +1698,7 @@ func (h *Handler) metricNamesSQL(tables []string, start, end time.Time, nowAncho
 // Mirrors the matcher-side `attributeLookup` chain in
 // `internal/promql/lower.go`: both query and listing surfaces now
 // resolve the same Prom-grammar → OTel-key candidates the same way.
-func (h *Handler) unionLabelValuesSQL(name string, start, end time.Time, nowAnchored bool) (string, []any) {
-	tables := h.metricTables()
+func (h *Handler) unionLabelValuesSQL(tables []string, name string, start, end time.Time, nowAnchored bool) (string, []any) {
 	attrsCol := h.Schema.AttributesColumn
 	metricCol := h.Schema.MetricNameColumn
 	tsCol := h.Schema.TimestampColumn
@@ -1792,6 +1798,95 @@ func labelValueCandidates(name string) []string {
 // reads.
 func (h *Handler) metricTables() []string {
 	return h.Schema.ConfiguredMetricTables()
+}
+
+// queryStringsDegradingUnknownTable executes buildSQL(tables) via
+// h.Client.QueryStrings, where tables is the FULL candidate set a metadata
+// UNION would normally read from (e.g. h.metricTables()) — every physical
+// table this surface unions across, whether or not this deployment
+// actually populates all of them. On success it returns the result
+// unchanged: the common case (every candidate exists) pays exactly the one
+// round trip the surface always has.
+//
+// On ClickHouse's UNKNOWN_TABLE rejection (code 60 — a table this
+// deployment never provisioned, most often because it does not ingest
+// that signal, or one dropped externally after boot; see #1949) it
+// re-derives which candidates currently exist via [Handler.existingTables]
+// (one extra system.tables lookup, paid ONLY on this failure path) and
+// retries buildSQL against the narrowed set, so the surviving tables still
+// answer the request instead of the whole UNION failing.
+//
+// An UNKNOWN_TABLE outcome NEVER escapes this function as an error, by
+// design (belt-and-suspenders, #1949): narrowing to zero tables, the
+// existence probe itself failing, narrowing finding nothing to drop (a
+// race between the original rejection and the recheck), or the retried
+// query hitting UNKNOWN_TABLE again (a second table vanishing between the
+// probe and the retry) all degrade to an EMPTY result rather than a 502 —
+// the same answer reference Prometheus gives for a label surface with no
+// data. Only a non-UNKNOWN_TABLE failure (a real ClickHouse error) is
+// returned to the caller.
+//
+// tables is never queried directly if empty (no configured tables at all —
+// an edge no live deployment hits, since the schema resolvers always
+// default every table name, but degrading to "no rows" rather than a
+// zero-arm UNION keeps the surface correct if it ever is).
+func (h *Handler) queryStringsDegradingUnknownTable(
+	ctx context.Context,
+	tables []string,
+	buildSQL func([]string) (string, []any),
+) ([]string, error) {
+	if len(tables) == 0 {
+		return nil, nil
+	}
+	sql, args := buildSQL(tables)
+	out, err := h.Client.QueryStrings(ctx, sql, args...)
+	if err == nil {
+		return out, nil
+	}
+	if !chclient.IsUnknownTable(err) {
+		return nil, err
+	}
+	existing, probeErr := h.existingTables(ctx, tables)
+	if probeErr != nil || len(existing) == 0 || len(existing) == len(tables) {
+		// A probe failure, nothing left to narrow to, or nothing narrowed
+		// away (a race with the recheck) — in every case the surface has
+		// no reliable data to answer from, so degrade to empty rather than
+		// surface the rejection as a 502.
+		return nil, nil
+	}
+	sql, args = buildSQL(existing)
+	out, err = h.Client.QueryStrings(ctx, sql, args...)
+	if err == nil {
+		return out, nil
+	}
+	if chclient.IsUnknownTable(err) {
+		return nil, nil
+	}
+	return nil, err
+}
+
+// existingTables narrows candidates to the ones currently present in
+// ClickHouse, via one system.tables lookup keyed by name and the
+// connection's own default database (currentDatabase() — the same
+// database context every metadata query already reads bare table names
+// against). It is called only as the recovery step after an UNKNOWN_TABLE
+// rejection (see queryStringsDegradingUnknownTable), never on the metadata
+// happy path, so a fully-provisioned deployment never pays this extra
+// round trip.
+func (h *Handler) existingTables(ctx context.Context, candidates []string) ([]string, error) {
+	lits := make([]chsql.Frag, 0, len(candidates))
+	for _, t := range candidates {
+		lits = append(lits, chsql.Lit(t))
+	}
+	sql, args := chsql.NewQuery().
+		Select(chsql.Col("name")).
+		From(chsql.Qual("system", "tables")).
+		Where(chsql.And(
+			chsql.Eq(chsql.Col("database"), chsql.Call("currentDatabase")),
+			chsql.In(chsql.Col("name"), lits...),
+		)).
+		Build()
+	return h.Client.QueryStrings(ctx, sql, args...)
 }
 
 // arrayJoinMapKeysFrag emits `arrayJoin(mapKeys(<col>))` — the CH idiom

--- a/internal/chclient/unknowntable.go
+++ b/internal/chclient/unknowntable.go
@@ -1,0 +1,56 @@
+package chclient
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+)
+
+// chCodeUnknownTable is ClickHouse's UNKNOWN_TABLE server error code
+// (ErrorCodes.cpp: 60), raised as "Table <db>.<table> doesn't exist." A
+// query that names a table this deployment never provisioned (most often
+// because it doesn't ingest that signal — see the Prom metadata surface's
+// per-metric-type table union, #1949) or a table dropped externally after
+// boot both surface here.
+const chCodeUnknownTable = 60
+
+// IsUnknownTable reports whether err is ClickHouse's UNKNOWN_TABLE
+// rejection (code 60) anywhere in its chain. Unlike a memory-limit or
+// timeout rejection this is not a resource-exhaustion signal — the table
+// named in the query simply does not exist — so a caller that unions
+// across a configured-but-optional set of tables (a deployment that does
+// not ingest every telemetry signal) can catch it and degrade to "no rows
+// from that table" instead of failing the whole request with a generic
+// 502.
+//
+// Detection is typed first — errors.As against *clickhouse.Exception,
+// mirroring isDatabaseAbsent / isMemoryLimitExceeded / IsQueryTimeout — with
+// a narrow string-matching fallback for the case where the driver wraps the
+// exception opaquely enough to defeat errors.As. The phrases are
+// deliberately narrow to the UNKNOWN_TABLE vocabulary so a successful query
+// whose result data merely mentions a table name is never misclassified.
+func IsUnknownTable(err error) bool {
+	if err == nil {
+		return false
+	}
+	var ex *clickhouse.Exception
+	if errors.As(err, &ex) && ex.Code == chCodeUnknownTable {
+		return true
+	}
+	return matchesUnknownTablePhrase(err)
+}
+
+// matchesUnknownTablePhrase is the string-matching fallback for
+// IsUnknownTable. "unknown_table" is the distinctive code name the server
+// appends; the "table … doesn't exist" pair covers a wrapper that drops the
+// code name but keeps the message. ClickHouse phrases this rejection with
+// the contraction "doesn't exist" (as opposed to UNKNOWN_DATABASE's "does
+// not exist"), so the two never collide.
+func matchesUnknownTablePhrase(err error) bool {
+	msg := strings.ToLower(err.Error())
+	if strings.Contains(msg, "unknown_table") {
+		return true
+	}
+	return strings.Contains(msg, "table") && strings.Contains(msg, "doesn't exist")
+}

--- a/internal/chclient/unknowntable_test.go
+++ b/internal/chclient/unknowntable_test.go
@@ -1,0 +1,79 @@
+package chclient
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+)
+
+// chUnknownTableException builds the typed driver exception ClickHouse
+// raises for UNKNOWN_TABLE — the shape a metadata query naming a table
+// this deployment never provisioned (or one dropped externally after
+// boot; see #1949) surfaces.
+func chUnknownTableException() *clickhouse.Exception {
+	return &clickhouse.Exception{
+		Code:    60,
+		Name:    "UNKNOWN_TABLE",
+		Message: "Table default.otel_metrics_histogram doesn't exist",
+	}
+}
+
+// TestIsUnknownTable_Code60 — a typed *clickhouse.Exception carrying code
+// 60 is recognised via errors.As, mirroring isMemoryLimitExceeded /
+// IsQueryTimeout.
+func TestIsUnknownTable_Code60(t *testing.T) {
+	t.Parallel()
+
+	if !IsUnknownTable(chUnknownTableException()) {
+		t.Error("IsUnknownTable(code 60 exception) = false; want true")
+	}
+	// Still reachable through an fmt.Errorf %w wrap, matching how
+	// classifyDriverErr's callers surface it (e.g. "chclient: query: %w").
+	wrapped := fmt.Errorf("chclient: query: %w", chUnknownTableException())
+	if !IsUnknownTable(wrapped) {
+		t.Error("IsUnknownTable(wrapped code 60 exception) = false; want true")
+	}
+}
+
+// TestIsUnknownTable_PassThrough — nil, non-exception errors, and
+// exceptions with OTHER codes must not classify as UNKNOWN_TABLE:
+// classification is typed-code-60-first, never loose string matching.
+func TestIsUnknownTable_PassThrough(t *testing.T) {
+	t.Parallel()
+
+	if IsUnknownTable(nil) {
+		t.Error("IsUnknownTable(nil) = true; want false")
+	}
+
+	otherCode := &clickhouse.Exception{Code: 241, Name: "MEMORY_LIMIT_EXCEEDED", Message: "Memory limit exceeded"}
+	if IsUnknownTable(otherCode) {
+		t.Error("IsUnknownTable(code 241 exception) = true; want false (only code 60 matches)")
+	}
+
+	plain := errors.New("read: connection reset by peer")
+	if IsUnknownTable(plain) {
+		t.Error("IsUnknownTable(unrelated plain error) = true; want false")
+	}
+}
+
+// TestIsUnknownTable_StringFallback — the narrow phrase fallback catches
+// the rejection even when the driver wraps the exception opaquely enough
+// to defeat errors.As, but must not fire on an UNKNOWN_DATABASE message
+// (preflight's own "does not exist" phrasing) — the two are phrased
+// differently by ClickHouse ("doesn't exist" vs "does not exist") and must
+// never collide.
+func TestIsUnknownTable_StringFallback(t *testing.T) {
+	t.Parallel()
+
+	tableMsg := errors.New("code: 60, message: Table default.otel_metrics_histogram doesn't exist. (UNKNOWN_TABLE)")
+	if !IsUnknownTable(tableMsg) {
+		t.Error("IsUnknownTable(opaque UNKNOWN_TABLE message) = false; want true")
+	}
+
+	dbMsg := errors.New("code: 81, message: Database otel does not exist. (UNKNOWN_DATABASE)")
+	if IsUnknownTable(dbMsg) {
+		t.Error("IsUnknownTable(UNKNOWN_DATABASE message) = true; want false (must not collide with 'does not exist')")
+	}
+}

--- a/internal/preflight/preflight.go
+++ b/internal/preflight/preflight.go
@@ -154,6 +154,48 @@ type Requirements struct {
 	Metrics schema.Metrics
 	Logs    schema.Logs
 	Traces  schema.Traces
+
+	// Signals reports which of the three telemetry signals this cerberus
+	// process actually SERVES, so requiredTables only contributes a
+	// signal's tables when its bit is set (#1949). Without it, a
+	// Loki-only deployment (CERBERUS_ENABLED_HEADS=loki) was validated
+	// and gated on otel_metrics_*/otel_traces existing, which they never
+	// will — /readyz never went ready even though the served head was
+	// fully functional, and every boot paid the introspection cost of
+	// two signals it never reads.
+	//
+	// The zero value (Signals{}) is treated as "every signal required" —
+	// see effectiveSignals — so every existing caller that predates this
+	// field (including the many tests in this package that build a bare
+	// Requirements{}) keeps validating all three signals exactly as
+	// before. cmd/cerberus's runRequirementsCheck is the only caller that
+	// derives a real, narrowed value, from cfg.EnabledHeads; because that
+	// set defaults to all three heads (config.defaultEnabledHeads), an
+	// unconfigured deployment resolves to the same all-three Signals the
+	// zero value already produces — this field only ever narrows what an
+	// operator explicitly narrowed via CERBERUS_ENABLED_HEADS.
+	Signals Signals
+}
+
+// Signals is the per-telemetry-type on/off switch requiredTables consults.
+// A Head maps 1:1 onto a Signal (prom -> Metrics, loki -> Logs,
+// tempo -> Traces); cmd/cerberus is the only place that performs that
+// mapping, from the resolved cfg.EnabledHeads.
+type Signals struct {
+	Metrics bool
+	Logs    bool
+	Traces  bool
+}
+
+// effectiveSignals resolves the zero value of Requirements.Signals to
+// "every signal required" — see the field's own doc for why that keeps
+// every pre-#1949 caller (a bare Requirements{} with Signals unset)
+// behaviourally unchanged.
+func (r Requirements) effectiveSignals() Signals {
+	if r.Signals == (Signals{}) {
+		return Signals{Metrics: true, Logs: true, Traces: true}
+	}
+	return r.Signals
 }
 
 // minVersion computes the effective version floor: the base minimum,
@@ -489,57 +531,70 @@ type tableReq struct {
 // requirements. Only the columns the emitters actually read are listed —
 // the essential keys (timestamp / value / identity columns) plus the
 // attribute maps, validated against the override-resolved names.
+//
+// A signal contributes its tables only when req.effectiveSignals() reports
+// it enabled (#1949): a process that does not serve a head never gates
+// boot-time introspection, the fatal shape gate, or /readyz on that head's
+// tables existing, since a deployment that never ingests that signal will
+// never provision them.
 func requiredTables(req Requirements) []tableReq {
-	m := req.Metrics
+	signals := req.effectiveSignals()
 	var tables []tableReq
 
-	// Gauge + Sum share the plain-sample shape: name, timestamp, value,
-	// service, and the two attribute maps. These are the columns the
-	// PromQL emitter projects for a Sample.
-	for _, t := range []string{m.GaugeTable, m.SumTable} {
-		tables = append(tables, tableReq{
-			name: t,
-			columns: nonEmpty(
-				m.MetricNameColumn, m.TimestampColumn, m.ValueColumn,
-				m.ServiceNameColumn, m.AttributesColumn, m.ResourceAttributesColumn,
-			),
-			attrMap: nonEmpty(m.AttributesColumn, m.ResourceAttributesColumn, m.ScopeAttributesColumn),
-		})
+	if signals.Metrics {
+		m := req.Metrics
+		// Gauge + Sum share the plain-sample shape: name, timestamp, value,
+		// service, and the two attribute maps. These are the columns the
+		// PromQL emitter projects for a Sample.
+		for _, t := range []string{m.GaugeTable, m.SumTable} {
+			tables = append(tables, tableReq{
+				name: t,
+				columns: nonEmpty(
+					m.MetricNameColumn, m.TimestampColumn, m.ValueColumn,
+					m.ServiceNameColumn, m.AttributesColumn, m.ResourceAttributesColumn,
+				),
+				attrMap: nonEmpty(m.AttributesColumn, m.ResourceAttributesColumn, m.ScopeAttributesColumn),
+			})
+		}
+		// Histogram + exp-histogram carry the decomposed observation columns
+		// instead of a Value: Count / Sum live on the row keyed by the bare
+		// metric name. The attribute maps still apply.
+		for _, t := range []string{m.HistogramTable, m.ExpHistogramTable} {
+			tables = append(tables, tableReq{
+				name: t,
+				columns: nonEmpty(
+					m.MetricNameColumn, m.TimestampColumn, m.CountColumn, m.SumColumn,
+					m.AttributesColumn, m.ResourceAttributesColumn,
+				),
+				attrMap: nonEmpty(m.AttributesColumn, m.ResourceAttributesColumn, m.ScopeAttributesColumn),
+			})
+		}
 	}
-	// Histogram + exp-histogram carry the decomposed observation columns
-	// instead of a Value: Count / Sum live on the row keyed by the bare
-	// metric name. The attribute maps still apply.
-	for _, t := range []string{m.HistogramTable, m.ExpHistogramTable} {
+
+	if signals.Logs {
+		l := req.Logs
 		tables = append(tables, tableReq{
-			name: t,
+			name: l.LogsTable,
 			columns: nonEmpty(
-				m.MetricNameColumn, m.TimestampColumn, m.CountColumn, m.SumColumn,
-				m.AttributesColumn, m.ResourceAttributesColumn,
+				l.TimestampColumn, l.BodyColumn, l.ServiceNameColumn,
+				l.AttributesColumn, l.ResourceAttributesColumn,
 			),
-			attrMap: nonEmpty(m.AttributesColumn, m.ResourceAttributesColumn, m.ScopeAttributesColumn),
+			attrMap: nonEmpty(l.AttributesColumn, l.ResourceAttributesColumn, l.ScopeAttributesColumn),
 		})
 	}
 
-	l := req.Logs
-	tables = append(tables, tableReq{
-		name: l.LogsTable,
-		columns: nonEmpty(
-			l.TimestampColumn, l.BodyColumn, l.ServiceNameColumn,
-			l.AttributesColumn, l.ResourceAttributesColumn,
-		),
-		attrMap: nonEmpty(l.AttributesColumn, l.ResourceAttributesColumn, l.ScopeAttributesColumn),
-	})
-
-	tr := req.Traces
-	tables = append(tables, tableReq{
-		name: tr.SpansTable,
-		columns: nonEmpty(
-			tr.TraceIDColumn, tr.SpanIDColumn, tr.SpanNameColumn, tr.ServiceNameColumn,
-			tr.DurationColumn, tr.StartTimeColumn,
-			tr.AttributesColumn, tr.ResourceAttributesColumn,
-		),
-		attrMap: nonEmpty(tr.AttributesColumn, tr.ResourceAttributesColumn, tr.ScopeAttributesColumn),
-	})
+	if signals.Traces {
+		tr := req.Traces
+		tables = append(tables, tableReq{
+			name: tr.SpansTable,
+			columns: nonEmpty(
+				tr.TraceIDColumn, tr.SpanIDColumn, tr.SpanNameColumn, tr.ServiceNameColumn,
+				tr.DurationColumn, tr.StartTimeColumn,
+				tr.AttributesColumn, tr.ResourceAttributesColumn,
+			),
+			attrMap: nonEmpty(tr.AttributesColumn, tr.ResourceAttributesColumn, tr.ScopeAttributesColumn),
+		})
+	}
 
 	return tables
 }

--- a/internal/preflight/preflight_test.go
+++ b/internal/preflight/preflight_test.go
@@ -490,6 +490,88 @@ func TestRunAllTablesAbsentTransient(t *testing.T) {
 	}
 }
 
+// TestRunSignalsScopeRequiredTables (#1949): a Loki-only deployment
+// (Signals{Logs: true}, metrics + traces disabled) reaches
+// SchemaProvisioned() == true with NOTHING but the logs table present —
+// the metric and trace tables are never probed, so their absence (they
+// are not even in Columns here) never blocks readiness. This is the
+// single-signal deployment the issue names: before the fix, a Loki-only
+// process gated /readyz on otel_metrics_*/otel_traces existing, which a
+// logs-only ingestion pipeline never provisions.
+func TestRunSignalsScopeRequiredTables(t *testing.T) {
+	t.Parallel()
+	l := schema.DefaultOTelLogs()
+	cols := map[string][]chclient.NameTypePair{
+		l.LogsTable: healthyColumns()[l.LogsTable],
+	}
+	req := defaultReq()
+	req.Signals = Signals{Logs: true}
+	q := &stubQuerier{Version: "25.8.2.1", Columns: cols}
+	res := Run(context.Background(), q, req)
+	if res.Fatal != nil {
+		t.Fatalf("loki-only preflight must not fail, got fatal: %v", res.Fatal)
+	}
+	if len(res.AbsentTables) != 0 {
+		t.Errorf("AbsentTables = %v, want empty (metrics/traces tables must never be probed when their signal is disabled)", res.AbsentTables)
+	}
+	if !res.SchemaProvisioned() {
+		t.Error("SchemaProvisioned() = false, want true (only the enabled signal's table need exist)")
+	}
+}
+
+// TestRunSignalsZeroValueRequiresAllThree: the zero value of
+// Requirements.Signals (every pre-#1949 caller, including every other test
+// in this file via defaultReq()) must keep validating all three signals —
+// see Requirements.Signals's own doc for why an unset Signals defaults to
+// "everything required" rather than "nothing required".
+func TestRunSignalsZeroValueRequiresAllThree(t *testing.T) {
+	t.Parallel()
+	l := schema.DefaultOTelLogs()
+	cols := map[string][]chclient.NameTypePair{
+		l.LogsTable: healthyColumns()[l.LogsTable],
+	}
+	req := defaultReq() // Signals left at the zero value.
+	q := &stubQuerier{Version: "25.8.2.1", Columns: cols}
+	res := Run(context.Background(), q, req)
+	if res.SchemaProvisioned() {
+		t.Fatal("SchemaProvisioned() = true with only the logs table present; want false (metrics + traces still required by default)")
+	}
+	if len(res.AbsentTables) == 0 {
+		t.Error("AbsentTables is empty; want the metric + trace tables reported absent")
+	}
+}
+
+// TestRunSignalsDisabledMetricsNeverFatalOnExplicitName: even an EXPLICITLY
+// configured (TableOverrides-set) metric table name is never fatal when the
+// metrics signal is disabled — a disabled head is never probed at all, so
+// fatalAbsentMetricTablesErr's caller (cmd/cerberus) never sees it in
+// AbsentTables in the first place. This pins requiredTables' filtering as
+// the single gate cmd/cerberus's stricter explicit-name check sits behind.
+func TestRunSignalsDisabledMetricsNeverFatalOnExplicitName(t *testing.T) {
+	t.Parallel()
+	tr := schema.DefaultOTelTraces()
+	cols := map[string][]chclient.NameTypePair{
+		tr.SpansTable: healthyColumns()[tr.SpansTable],
+	}
+	m := schema.DefaultOTelMetrics()
+	m.TableOverrides.Gauge = true // an operator-typed name, but metrics is disabled
+	req := Requirements{
+		Database: "otel",
+		Metrics:  m,
+		Logs:     schema.DefaultOTelLogs(),
+		Traces:   schema.DefaultOTelTraces(),
+		Signals:  Signals{Traces: true},
+	}
+	q := &stubQuerier{Version: "25.8.2.1", Columns: cols}
+	res := Run(context.Background(), q, req)
+	if res.Fatal != nil {
+		t.Fatalf("disabled-metrics preflight must not fail on an explicit-but-unprobed metric table, got: %v", res.Fatal)
+	}
+	if !res.SchemaProvisioned() {
+		t.Errorf("SchemaProvisioned() = false, want true; AbsentTables=%v", res.AbsentTables)
+	}
+}
+
 // TestRunWrongShapeFatalEvenIfOtherTableAbsent: an EXISTING table with a
 // wrong shape is fatal (never self-heals) even when a different table is
 // merely absent — the fatal bucket wins, the caller exits.


### PR DESCRIPTION
## Summary

Issue #1949 identified one root cause behind three symptoms: nothing in
preflight or the Prom metadata surface modeled "this deployment does not
carry that signal." A table's absence was always read as "not yet
provisioned," and the tables probed were derived from the schema shape
alone, never from which heads the process actually serves.

**One fix, two independent pieces, because the two surfaces need the
answer at different times:**

1. **`preflight.Requirements` gains a `Signals` field.** `requiredTables`
   now contributes a signal's tables (metrics / logs / traces) only when
   its bit is set. `cmd/cerberus` derives `Signals` from `cfg.EnabledHeads`
   (a Head maps 1:1 onto a Signal: `prom`→Metrics, `loki`→Logs,
   `tempo`→Traces) via the new `preflightRequirementsFromConfig` — a small
   extraction that makes the mapping independently unit-testable without a
   real ClickHouse client. The zero value of `Signals` still means "every
   signal required," so every pre-existing caller (including the many
   `preflight` tests that build a bare `Requirements{}`) keeps validating
   all three signals unchanged, and the unset `CERBERUS_ENABLED_HEADS`
   default (`prom,loki,tempo`) resolves to the same all-three `Signals` the
   zero value already produced.

   **Fixes symptom 1** (a single-signal deployment never becomes ready — a
   Loki-only pod no longer gates `/readyz` on `otel_metrics_*`/`otel_traces`
   ever existing) **and symptom 3** (wasted boot-time introspection on
   disabled signals falls out for free, since `checkSchema` only iterates
   the now-filtered `requiredTables` set).

2. **The Prom metadata UNION builders degrade gracefully on an absent
   table**, regardless of *why* it's absent (a disabled head, a signal not
   yet provisioned, or a table dropped externally after boot).
   `unionLabelNamesSQL` / `unionResourceLabelNamesSQL` / `unionLabelValuesSQL`
   / `metricNamesSQL` are now called through the new
   `Handler.queryStringsDegradingUnknownTable`: on ClickHouse's
   `UNKNOWN_TABLE` (code 60 — newly classified via `chclient.IsUnknownTable`,
   mirroring the existing `chCodeMemoryLimitExceeded` /
   `chCodeTimeoutExceeded` / `chCodeUnknownDatabase` pattern) it re-probes
   which candidate tables currently exist (one extra `system.tables` lookup,
   paid *only* on this failure path — the happy path is still exactly one
   round trip) and retries against the narrowed set, so the surviving
   tables still answer the request instead of the whole UNION failing.
   Belt-and-suspenders: *any* residual `UNKNOWN_TABLE` — the existence probe
   itself failing, narrowing to zero tables, or a second table vanishing
   between the probe and the retry — also degrades to an empty result
   rather than an error, matching what reference Prometheus answers for a
   label surface with no data. No caller ever sees `UNKNOWN_TABLE` escape as
   a 502 from this path.

   **Fixes symptom 2** (the Prom metadata endpoints no longer 502 when one
   metric table is absent — they answer whatever the other tables produce,
   or an empty list).

## Test plan

- [x] `internal/preflight`: `TestRunSignalsScopeRequiredTables` (a
  Loki-only `Signals{Logs: true}` config reaches `SchemaProvisioned() ==
  true` with only the logs table present),
  `TestRunSignalsZeroValueRequiresAllThree` (backward-compat pin),
  `TestRunSignalsDisabledMetricsNeverFatalOnExplicitName` (a disabled
  signal's explicitly-configured table is never even probed, so it can
  never trip the stricter #1905 fatal check).
- [x] `cmd/cerberus`: `TestPreflightRequirementsFromConfig_SignalsMapping`
  (all 5 `CERBERUS_ENABLED_HEADS` combinations map to the right `Signals`,
  isolated from any ClickHouse connection),
  `TestPreflightRequirementsFromConfig_ThreadsSchemaAndDatabase`.
- [x] `internal/chclient`: `TestIsUnknownTable_Code60` /
  `_PassThrough` / `_StringFallback` pin the new code-60 classification.
- [x] `internal/api/prom`: `TestLabels_DegradesOnAbsentMetricTable` and
  `TestLabelValues_DegradesOnAbsentMetricTable` are the direct regression
  tests for symptom 2 (one metric table absent → 200 with the surviving
  tables' data, not 502). `TestLabels_AllMetricTablesAbsent` covers the
  deployment-wide case named in the issue (a prom head left enabled by
  default over a logs+traces-only pipeline never provisions any metric
  table → 200 with just `__name__`). `TestLabels_ExistenceProbeFailureDegradesToEmpty`
  and `TestLabels_SecondUnknownTableOnRetryDegradesToEmpty` pin the two
  belt-and-suspenders branches.
- [x] `go build ./...` clean; `go vet` clean on every touched package;
  `go test -race` green on `internal/preflight`, `internal/chclient`,
  `internal/api/prom`, `cmd/cerberus`.
- [x] `node .github/scripts/forbid-sql-raw.mjs` clean (the new
  `existingTables` probe is built entirely from typed chsql Frags).
- [x] `gofumpt -extra`, `goimports -local`, `markdownlint-cli2` clean on
  every touched file.

Closes #1949