### PR TITLE
test(ci): run the post-optimizer round-trip that GOLDEN_UPDATE cannot launder

### DIFF
--- a/.github/workflows/chdb.yml
+++ b/.github/workflows/chdb.yml
@@ -264,9 +264,26 @@ jobs:
         if: needs.changes.outputs.docs_only != 'true'
         run: just chdb-install
 
+      # Two packages, not one, because they run DIFFERENT checks over the
+      # same fixtures.
+      #
+      #   ./test/spec/<ql>/   — RunRoundTrip, the PRE-optimizer execution
+      #                         that produces `expected_rows` and, under
+      #                         GOLDEN_UPDATE=1, rewrites it.
+      #   ./internal/<ql>/    — RunRoundTripSQL, the POST-optimizer twin.
+      #                         It passes allowGoldenUpdate=false, so a
+      #                         mismatch FAILS instead of being re-pinned
+      #                         (see test/spec/runner_chdb.go:222-256).
+      #
+      # That makes the second one the only comparison in this lane
+      # GOLDEN_UPDATE cannot launder — and until now no CI job ran it.
+      # `just test-chdb` (Justfile:199) lists neither internal/promql,
+      # internal/logql nor internal/traceql, and this step ran only the
+      # test/spec side, so an optimizer bug that rewrote a fixture's
+      # answer had nothing standing in its way.
       - name: Run TXTAR round-trip (${{ matrix.ql }})
         if: needs.changes.outputs.docs_only != 'true'
-        run: go test -tags chdb -count=1 ./test/spec/${{ matrix.ql }}/...
+        run: go test -tags chdb -count=1 ./test/spec/${{ matrix.ql }}/... ./internal/${{ matrix.ql }}/...
 
   # `perf-guards` runs the chDB-tagged deterministic perf-regression
   # ASSERTIONS under test/perf/ — the load-bearing fix for task #73.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -960,9 +960,16 @@ jobs:
   # internal/drain, internal/traceql/ast), and PromQL uses the upstream Apache
   # prometheus parser — so no AGPLv3 grafana/loki or grafana/tempo code reaches
   # the binary. The only grafana/tempo subtree the binary may link is the
-  # Apache-licensed pkg/tempopb wire types. Test-only AGPL oracles + the
-  # compatibility harnesses are quarantined in the test/oracle nested module
-  # and never enter the binary graph.
+  # Apache-licensed pkg/tempopb wire types.
+  #
+  # Where the AGPL actually lives, precisely: the root go.mod DOES require
+  # grafana/loki/v3, and compatibility/ has no go.mod of its own, so the
+  # compatibility harnesses are ROOT-MODULE packages — not, as this comment
+  # previously claimed, quarantined in test/oracle. What keeps the binary
+  # clean is REACHABILITY, not module membership: nothing under
+  # compatibility/ or behind the agpl_oracle build tag is imported from
+  # ./cmd/cerberus. The test/oracle nested module is a second, stronger
+  # boundary used where a hard module break is wanted, not the only one.
   #
   # ENFORCING: the gate runs `go list -deps ./cmd/cerberus` and FAILS (exit 1)
   # if any AGPL package is reachable from the binary (grafana/loki/* or

--- a/test/integration/promql/matrix.go
+++ b/test/integration/promql/matrix.go
@@ -43,8 +43,12 @@ func (c exoticCase) ts() int64 {
 // edge_increase_at_start.txtar, edge_at_then_offset_neg.txtar for @;
 // quantile_scalar_phi_nan.txtar, lwr_bare_selector_staleness_window.txtar,
 // scalar_many_series_nan.txtar, vector_scalar_multi_series_nan.txtar,
-// clamp_min_scalar_nan_bound.txtar for stale/NaN) rather than by any
-// "promqltest" package — no such package exists in this repo.
+// clamp_min_scalar_nan_bound.txtar for stale/NaN) rather than by the
+// upstream "promqltest" package. That package is not vendored INTO this
+// repo, but it does resolve from the pinned prometheus fork, and
+// test/spec/parityoracle/promql uses it to evaluate fixtures on the real
+// Prometheus engine — so "no such package exists" (as this comment used
+// to say) is the wrong reason to reach for a txtar golden here.
 //
 // CAT 1 is the priority class: vector-vector binary ops over
 // rate/irate/increase/delta. It is the explicit regression net for the


### PR DESCRIPTION
First step of giving the txtar corpus a real oracle. It ships on its own because it costs one workflow line and closes a gap that already exists in code.

## The gap

`spec.RunRoundTripSQL` (`test/spec/runner_chdb.go:222-256`) is the post-optimizer twin of `RunRoundTrip`. It passes `allowGoldenUpdate=false` deliberately, and its own doc comment explains why:

> a mismatch there must never silently become the new "expected", since that would launder a real optimizer bug into a passing golden

It is called from all three heads' `lower_test.go`. **No CI job ran it.** The `roundtrip` matrix step ran only `./test/spec/<ql>/...`, and `just test-chdb` (`Justfile:199`) lists none of `internal/{promql,logql,traceql}`.

So the one comparison in the whole chDB lane that `GOLDEN_UPDATE` *cannot* launder was gating nothing — while the comparison that *is* regenerated from cerberus's own output ran on every commit.

## The fix

Add `./internal/${{ matrix.ql }}/...` to the existing step. The matrix is already keyed by head, so each leg gains exactly its own package.

All three pass today, so this **turns a gate on rather than fixing a bug behind it**. Measured locally: promql 160s, logql 30s, traceql 7s, against the job's existing 20-minute budget.

## Two comments corrected

Both asserted things that are not true, and both would mislead the next person to touch this area:

- `.github/workflows/ci.yml` claimed the compatibility harnesses are *"quarantined in the test/oracle nested module"*. They are not — `compatibility/` has no `go.mod` of its own and the root `go.mod:18` requires `grafana/loki/v3` directly, so they are root-module packages. What keeps the binary clean is **reachability from `./cmd/cerberus`**, which is exactly what `agpl-clean` measures, not module membership.
- `test/integration/promql/matrix.go` justified reaching for a txtar golden on the grounds that *"no such package exists in this repo"* for `promqltest`. It is not vendored into the tree, but it does resolve from the pinned prometheus fork.

## Why this matters beyond itself

`-- expected_rows --` is regenerated by `just update-golden` from cerberus's own pipeline (`test/spec/runner.go:106-109` does not even compare under `GOLDEN_UPDATE=1`). Two real semantic bugs were recently caught only by the live compat harness while the txtar goldens for those exact shapes had been re-pinned to the wrong values and were green. This PR does not fix that — it stops the one existing anti-laundering check from being inert while the rest is built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)