### PR TITLE
feat(spec): check txtar fixtures against the real Prometheus engine

### DIFF
--- a/internal/promql/lower_test.go
+++ b/internal/promql/lower_test.go
@@ -165,6 +165,24 @@ func TestLower(t *testing.T) {
 			t.Fatalf("Emit(optimized plan): %v", err)
 		}
 		spec.RunRoundTripSQL(t, c, optSQL, optArgs)
+
+		// A fixture carrying a `parity:` section is additionally answered
+		// by the REAL upstream Prometheus engine over the same seeded
+		// data, and the two answers are compared. Unlike every other
+		// assertion in this function, that one has no GOLDEN_UPDATE
+		// branch: the reference answer is computed on each run rather
+		// than stored, so there is nothing for regeneration to overwrite.
+		// See test/spec/parity.go for why the fixture stores the parity
+		// CONTRACT and not the parity ANSWER.
+		parityStart, parityEnd, parityStep := instantEval, instantEval, time.Duration(0)
+		if rs, ok := c.Section("range_step"); ok {
+			d, perr := time.ParseDuration(strings.TrimSpace(rs))
+			if perr != nil {
+				t.Fatalf("fixture %s: parse range_step %q: %v", c.Name, rs, perr)
+			}
+			parityStart, parityEnd, parityStep = rangeStart, rangeEnd, d
+		}
+		spec.RunParity(t, c, parityStart, parityEnd, parityStep)
 	})
 }
 

--- a/test/regression/parity_contract_test.go
+++ b/test/regression/parity_contract_test.go
@@ -1,0 +1,224 @@
+package regression
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/test/spec"
+)
+
+// parityOraclePkgs are the reference-engine packages whose independence
+// from cerberus is the load-bearing property of the whole parity layer.
+var parityOraclePkgs = []string{
+	"./test/spec/parityoracle/...",
+}
+
+// forbiddenOracleDeps are the cerberus packages an oracle may never
+// import, directly or transitively.
+//
+// The list is the SYSTEM UNDER TEST: everything that decides what SQL a
+// query becomes. An oracle sharing any of it cannot disagree with cerberus
+// about the thing they share, which silently turns the oracle into a
+// mirror — and a mirror always agrees, so the parity check would pass
+// while proving nothing.
+var forbiddenOracleDeps = []string{
+	"github.com/tsouza/cerberus/internal/promql",
+	"github.com/tsouza/cerberus/internal/logql",
+	"github.com/tsouza/cerberus/internal/traceql",
+	"github.com/tsouza/cerberus/internal/chplan",
+	"github.com/tsouza/cerberus/internal/chsql",
+	"github.com/tsouza/cerberus/internal/optimizer",
+	"github.com/tsouza/cerberus/internal/schema",
+}
+
+// TestParityOracleImportsNoCerberusLowering is the mechanical enforcement
+// of the one rule the parity oracle exists under: it must not import the
+// system it checks.
+//
+// This is a `go list -deps -test` scan rather than a source grep because
+// the dangerous import is the TRANSITIVE one. A helper that looks
+// perfectly innocent — a label-mapping utility, a column-name constant —
+// can pull internal/schema in behind it, and nobody reviewing that helper
+// would see the oracle lose its independence.
+//
+// It is also why compatibility/prometheus/cmd/seed's readFixtureSeries is
+// NOT reused as the translator even though it does the same CH-rows to
+// series conversion: it imports internal/promql and internal/schema. Being
+// equal-by-construction is correct for the compat mirror, whose job is to
+// put identical data into both backends, and disqualifying for an oracle.
+func TestParityOracleImportsNoCerberusLowering(t *testing.T) {
+	t.Parallel()
+
+	root := repoRootForParity(t)
+
+	for _, pkg := range parityOraclePkgs {
+		// -test includes the test files' own imports, so an oracle cannot
+		// smuggle a forbidden dependency in through its _test.go either.
+		cmd := exec.Command("go", "list", "-deps", "-test", pkg)
+		cmd.Dir = root
+		out, err := cmd.Output()
+		if err != nil {
+			t.Fatalf("go list -deps -test %s: %v", pkg, err)
+		}
+
+		deps := strings.Split(strings.TrimSpace(string(out)), "\n")
+		for _, dep := range deps {
+			dep = strings.TrimSpace(dep)
+			for _, forbidden := range forbiddenOracleDeps {
+				if dep == forbidden || strings.HasPrefix(dep, forbidden+"/") {
+					t.Errorf(
+						"parity oracle %s transitively imports %s.\n"+
+							"An oracle that shares code with the system under test cannot disagree "+
+							"with it about the thing they share, so this import silently converts "+
+							"the oracle into a mirror — and the parity check would then pass while "+
+							"proving nothing. Reimplement whatever was needed inside the oracle "+
+							"package instead of importing it.",
+						pkg, dep,
+					)
+				}
+			}
+		}
+	}
+}
+
+// TestParitySectionsParse asserts every fixture carrying a `parity:`
+// section has a WELL-FORMED one.
+//
+// LoadParity deliberately errors rather than skipping on a malformed body,
+// because a typo'd key would otherwise un-enrol a fixture from its oracle
+// while still looking enrolled in the diff — the fixture would keep its
+// `-- parity --` header, keep passing, and check nothing. This test is
+// what makes that error reachable in the fast, untagged lane rather than
+// only in the chdb-tagged one.
+func TestParitySectionsParse(t *testing.T) {
+	t.Parallel()
+
+	for _, dir := range parityFixtureDirs(t) {
+		for _, path := range txtarFilesForParity(t, dir) {
+			c, err := spec.Load(path)
+			if err != nil {
+				t.Fatalf("load %s: %v", path, err)
+			}
+			if _, _, err := spec.LoadParity(c); err != nil {
+				t.Errorf("%s: %v", filepath.Base(path), err)
+			}
+		}
+	}
+}
+
+// TestParityEnrolmentFloor is the ratchet.
+//
+// Enrolment is incremental — a fixture is enrolled by hand when its seed
+// carries what the reference engine needs — so this cannot assert that
+// every fixture is enrolled. What it CAN do is make the count monotonic:
+// enrolment may only ever grow, and un-enrolling a fixture requires
+// editing this constant, which is a visible line in the diff that a
+// reviewer must accept.
+//
+// That is deliberately weaker than the all-or-nothing enrolment a closed
+// corpus would allow, and it is the honest trade: PromQL fixtures include
+// metadata and exemplar shapes that ask no PromQL expression at all, so
+// "every fixture must enrol" is unattainable, and forcing it would require
+// a per-fixture exemption vocabulary — precisely the allow-list shape
+// invariant 7 forbids.
+func TestParityEnrolmentFloor(t *testing.T) {
+	t.Parallel()
+
+	// parityEnrolmentFloor is the number of fixtures currently carrying a
+	// `parity:` section. It ratchets UP only.
+	const parityEnrolmentFloor = 1
+
+	enrolled := 0
+	for _, dir := range parityFixtureDirs(t) {
+		for _, path := range txtarFilesForParity(t, dir) {
+			c, err := spec.Load(path)
+			if err != nil {
+				t.Fatalf("load %s: %v", path, err)
+			}
+			if _, ok, err := spec.LoadParity(c); err == nil && ok {
+				enrolled++
+			}
+		}
+	}
+
+	if enrolled < parityEnrolmentFloor {
+		t.Errorf(
+			"parity enrolment fell to %d, below the committed floor of %d.\n"+
+				"A fixture lost its `-- parity --` section, which silently returns it to being "+
+				"checked only against cerberus's own regenerated output. If the un-enrolment is "+
+				"intentional, lower the floor in this test and say why in the commit message.",
+			enrolled, parityEnrolmentFloor,
+		)
+	}
+	if enrolled > parityEnrolmentFloor {
+		t.Errorf(
+			"parity enrolment rose to %d, above the committed floor of %d.\n"+
+				"Raise parityEnrolmentFloor to %d so the gain cannot be silently lost again.",
+			enrolled, parityEnrolmentFloor, enrolled,
+		)
+	}
+}
+
+// TestParityVocabulariesAreClosed asserts the accepted values are a closed
+// set with no empty members — the property LoadParity's rejection path
+// depends on.
+func TestParityVocabulariesAreClosed(t *testing.T) {
+	t.Parallel()
+
+	keys := spec.ParityKeys()
+	if len(keys) == 0 {
+		t.Fatal("parity vocabulary is empty; LoadParity would accept any section body")
+	}
+	for _, key := range keys {
+		values := spec.ParityValues(key)
+		if len(values) == 0 {
+			t.Errorf("parity key %q has no accepted values, so no fixture can ever satisfy it", key)
+		}
+		for _, v := range values {
+			if strings.TrimSpace(v) == "" {
+				t.Errorf("parity key %q accepts an empty value", key)
+			}
+		}
+	}
+}
+
+// --- helpers ---------------------------------------------------------
+
+func repoRootForParity(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	// test/regression -> repo root
+	return filepath.Dir(filepath.Dir(wd))
+}
+
+func parityFixtureDirs(t *testing.T) []string {
+	t.Helper()
+	root := repoRootForParity(t)
+	return []string{
+		filepath.Join(root, "test", "spec", "promql"),
+		filepath.Join(root, "test", "spec", "logql"),
+		filepath.Join(root, "test", "spec", "traceql"),
+	}
+}
+
+func txtarFilesForParity(t *testing.T, dir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read fixture dir %s: %v", dir, err)
+	}
+	var out []string
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".txtar") {
+			continue
+		}
+		out = append(out, filepath.Join(dir, e.Name()))
+	}
+	return out
+}

--- a/test/spec/parity.go
+++ b/test/spec/parity.go
@@ -1,0 +1,224 @@
+// Package spec — parity extension.
+//
+// This file defines the optional `parity:` section, which opts a TXTAR
+// fixture into evaluation against a REAL reference query engine.
+//
+// # Why this exists
+//
+// `expected_rows:` is not an oracle. [RunRoundTrip] executes cerberus's
+// own emitted SQL against chDB and, under GOLDEN_UPDATE=1, writes the
+// result straight back into the fixture (runner.go's Match does not even
+// compare in that mode). So a fixture's "expected" answer is whatever
+// cerberus most recently produced. If a lowering emits semantically wrong
+// SQL, `just update-golden` re-pins the wrong answer and the fixture
+// passes forever — the regression is absorbed rather than caught. Two real
+// semantic bugs have reached main that way, both eventually caught by the
+// live compatibility harness rather than by this corpus.
+//
+// The `parity:` section is the fix. A fixture carrying one is additionally
+// evaluated by the reference engine itself — the actual upstream
+// Prometheus evaluator, in-process — over the same seeded data, and the
+// two answers are compared.
+//
+// # Why the section carries a CONTRACT and not an ANSWER
+//
+// The obvious design is to store the reference engine's answer in a
+// section beside `expected_rows:`. That does not work here, and the reason
+// is mechanical rather than aesthetic: `just update-golden` grants each
+// shard ownership of a whole DIRECTORY (see the `goldens` field in
+// .github/scripts/lib/golden-shards.mjs), and its generators rewrite
+// whatever sections they please inside it. A stored reference answer would
+// sit inside the `promql` shard's blast radius, regenerable by the very
+// cerberus-driven generator whose output it exists to check. Protecting it
+// would take a reserved-key guard, an input fingerprint, a drift check and
+// an engine-version manifest — machinery whose whole purpose is to make a
+// stored answer behave like a computed one.
+//
+// So the answer is computed live, at test time, and nothing is stored.
+// There is no artefact for regeneration to overwrite: absorption is not
+// detected, it is impossible. GOLDEN_UPDATE=1 has no effect on the parity
+// check because that code path has no update branch at all.
+//
+// What the fixture stores is the CONTRACT — which oracle answers for it,
+// through which endpoint, and how much of the answer is in honest scope.
+// That is hand-authored, reviewed like any other source line, and is what
+// eventually lets the compatibility driver enumerate fixtures instead of
+// maintaining a parallel query corpus.
+//
+// # Section contract
+//
+//	-- parity --
+//	oracle: prometheus
+//	endpoint: /api/v1/query
+//	scope: full
+//
+// Every key is required and every value comes from a CLOSED vocabulary.
+// An unknown key or value is an error, never a silent skip: a typo must
+// fail loudly rather than quietly un-enrol a fixture from its oracle.
+//
+// `scope` exists for one narrow, real case and is deliberately hard to
+// abuse — see [ScopeExceptZeroBucket]. It is NOT a tolerance knob and
+// carries no numeric field; a fixture is either compared in full or has
+// one named, machine-checked axis excluded.
+package spec
+
+import (
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+)
+
+// SectionParity is the TXTAR section name a fixture carries to opt into
+// reference-engine evaluation.
+const SectionParity = "parity"
+
+// Parity vocabularies. Each is closed; [LoadParity] rejects anything else.
+const (
+	// OraclePrometheus evaluates the fixture with the upstream Prometheus
+	// engine (Apache-2.0, resolved from the pinned prometheus fork).
+	OraclePrometheus = "prometheus"
+
+	// OracleLoki evaluates the fixture with the upstream Loki engine.
+	// AGPLv3, so it runs only under the agpl_oracle build tag.
+	OracleLoki = "loki"
+)
+
+const (
+	// EndpointInstant is Prometheus's instant-query endpoint. The fixture
+	// is evaluated at a single instant.
+	EndpointInstant = "/api/v1/query"
+
+	// EndpointRange is Prometheus's range-query endpoint. The fixture must
+	// also carry a `range_step:` section.
+	EndpointRange = "/api/v1/query_range"
+)
+
+const (
+	// ScopeFull compares every value the reference engine returns. This is
+	// the default posture and what almost every fixture should carry.
+	ScopeFull = "full"
+
+	// ScopeExceptZeroBucket excludes the zero-bucket boundary of an
+	// exponential-histogram quantile from the comparison.
+	//
+	// This is not a tolerance. It records a fact about the data model:
+	// internal/schema/otel.go sets ZeroThresholdColumn to the empty string
+	// because upstream OTel-CH persists no zero-threshold column at all. A
+	// reference histogram reconstructed from ClickHouse rows must
+	// therefore INVENT a zero threshold, and the only honest value to
+	// invent is 0 — which is exactly what cerberus's own native-quantile
+	// emitter assumes. Comparing that axis would compare cerberus's
+	// assumption against itself, which is the hollow green this whole
+	// mechanism exists to prevent.
+	//
+	// Fixtures carrying this scope are excluded from every parity coverage
+	// figure, so the limitation cannot disappear into a headline number.
+	ScopeExceptZeroBucket = "except-zero-bucket"
+)
+
+// Parity is the parsed `parity:` section.
+type Parity struct {
+	// Oracle names the reference engine that answers for this fixture.
+	Oracle string
+
+	// Endpoint is the query endpoint whose semantics the comparison uses.
+	Endpoint string
+
+	// Scope is how much of the reference answer is in honest scope.
+	Scope string
+}
+
+// ComparesInFull reports whether every returned value participates in the
+// comparison. Coverage accounting counts only these fixtures.
+func (p *Parity) ComparesInFull() bool { return p.Scope == ScopeFull }
+
+// parityVocabularies is the single source of truth for every accepted key
+// and its accepted values. [LoadParity] and the contract test both read
+// it, so a new key cannot be added to one without the other.
+var parityVocabularies = map[string][]string{
+	"oracle":   {OraclePrometheus, OracleLoki},
+	"endpoint": {EndpointInstant, EndpointRange},
+	"scope":    {ScopeFull, ScopeExceptZeroBucket},
+}
+
+// ParityKeys returns the required keys, sorted. Exported for the contract
+// test, which asserts the fixture corpus and this vocabulary agree.
+func ParityKeys() []string {
+	keys := make([]string, 0, len(parityVocabularies))
+	for k := range parityVocabularies {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// ParityValues returns the accepted values for one key, sorted.
+func ParityValues(key string) []string {
+	vals := append([]string(nil), parityVocabularies[key]...)
+	sort.Strings(vals)
+	return vals
+}
+
+// LoadParity parses a fixture's `parity:` section.
+//
+// The bool reports whether the fixture opted in at all. A fixture without
+// the section is not an error — enrolment is incremental by design, and
+// the corpus-wide floor is enforced separately by the contract test rather
+// than by failing every unenrolled fixture here.
+//
+// A fixture WITH the section but with a malformed body IS an error. A
+// silent skip on a typo'd key would un-enrol a fixture from its oracle
+// while still looking enrolled in the diff, which is the failure mode this
+// whole file exists to prevent.
+func LoadParity(c *Case) (*Parity, bool, error) {
+	body, ok := c.Section(SectionParity)
+	if !ok {
+		return nil, false, nil
+	}
+
+	got := map[string]string{}
+	for i, line := range strings.Split(body, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		key, value, found := strings.Cut(line, ":")
+		if !found {
+			return nil, false, fmt.Errorf(
+				"%s section line %d: %q is not `key: value`", SectionParity, i+1, line,
+			)
+		}
+		key, value = strings.TrimSpace(key), strings.TrimSpace(value)
+
+		accepted, known := parityVocabularies[key]
+		if !known {
+			return nil, false, fmt.Errorf(
+				"%s section: unknown key %q (accepted: %s)",
+				SectionParity, key, strings.Join(ParityKeys(), ", "),
+			)
+		}
+		if _, dup := got[key]; dup {
+			return nil, false, fmt.Errorf("%s section: key %q appears twice", SectionParity, key)
+		}
+		if !slices.Contains(accepted, value) {
+			return nil, false, fmt.Errorf(
+				"%s section: key %q has value %q (accepted: %s)",
+				SectionParity, key, value, strings.Join(ParityValues(key), ", "),
+			)
+		}
+		got[key] = value
+	}
+
+	for _, key := range ParityKeys() {
+		if _, present := got[key]; !present {
+			return nil, false, fmt.Errorf("%s section: missing required key %q", SectionParity, key)
+		}
+	}
+
+	return &Parity{
+		Oracle:   got["oracle"],
+		Endpoint: got["endpoint"],
+		Scope:    got["scope"],
+	}, true, nil
+}

--- a/test/spec/parity_chdb.go
+++ b/test/spec/parity_chdb.go
@@ -1,0 +1,395 @@
+//go:build chdb
+
+package spec
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	oracle "github.com/tsouza/cerberus/test/spec/parityoracle/promql"
+)
+
+// RunParity checks a fixture's answer against a REAL reference engine.
+//
+// It is the half of the parity layer that must live in package spec,
+// because it touches the chDB session and therefore chdbEngineMu. The
+// evaluation itself lives in test/spec/parityoracle/promql, which imports
+// nothing from cerberus — see that package's doc comment, and the
+// disjointness gate in test/regression that enforces it.
+//
+// # There is no update path here, on purpose
+//
+// [RunRoundTrip] rewrites `expected_rows` under GOLDEN_UPDATE=1. This
+// function has no such branch and never will: the value it compares
+// against is computed by the reference engine on every run, so there is no
+// artefact for regeneration to overwrite. That is the whole design.
+// GOLDEN_UPDATE=1 changes nothing about this check, which is what makes a
+// semantic regression impossible to absorb rather than merely likely to be
+// noticed.
+//
+// A fixture with no `parity:` section is a no-op, exactly as RunRoundTrip
+// is for a fixture with no `seed:`.
+func RunParity(t *testing.T, c *Case, evalStart, evalEnd time.Time, step time.Duration) {
+	t.Helper()
+
+	p, enrolled, err := LoadParity(c)
+	if err != nil {
+		t.Fatalf("LoadParity: %v", err)
+	}
+	if !enrolled {
+		return
+	}
+	if p.Oracle != OraclePrometheus {
+		t.Fatalf("fixture %s: oracle %q has no runner in this lane", c.Name, p.Oracle)
+	}
+
+	rt, err := LoadRoundTrip(c)
+	if err != nil {
+		t.Fatalf("LoadRoundTrip: %v", err)
+	}
+	if !rt.IsRoundTrip() {
+		t.Fatalf(
+			"fixture %s carries a `parity:` section but no executable round-trip. "+
+				"The parity check reads the seeded rows back out of chDB, so it needs the same "+
+				"`seed:` + `expected_rows:` opt-in RunRoundTrip needs.", c.Name,
+		)
+	}
+
+	query, ok := c.Section("query.promql")
+	if !ok {
+		t.Fatalf("fixture %s: `parity:` requires a query.promql section", c.Name)
+	}
+
+	// Serialize the whole engine span, same contract RunRoundTrip honours.
+	chdbEngineMu.Lock()
+	defer chdbEngineMu.Unlock()
+
+	db := OpenChDB(t)
+	ApplySeed(t, db, rt.Seed)
+
+	series, err := readSeededSeries(db)
+	if err != nil {
+		t.Fatalf("read seeded series back: %v", err)
+	}
+	if len(series) == 0 {
+		t.Fatalf(
+			"fixture %s: seed produced no readable series, so the reference engine would "+
+				"trivially agree with any answer", c.Name,
+		)
+	}
+
+	got, err := oracle.Evaluate(t, series, oracle.Query{
+		Expr:  trimQuery(query),
+		Start: evalStart,
+		End:   evalEnd,
+		Step:  step,
+	})
+	if err != nil {
+		t.Fatalf("fixture %s: %v", c.Name, err)
+	}
+
+	compareAgainstReference(t, c, p, rt, got, step > 0)
+}
+
+// seededMetricsTables are the metric tables a PromQL fixture's seed may
+// create. The reader unions whichever ones exist, because a fixture seeds
+// only the tables its own query needs.
+var seededMetricsTables = []string{
+	"otel_metrics_gauge",
+	"otel_metrics_sum",
+}
+
+// readSeededSeries reads the seeded rows back OUT of chDB and groups them
+// into reference-engine series.
+//
+// Reading back rather than re-parsing the `seed:` text is deliberate: it
+// shows the oracle the data as it ACTUALLY LANDED — after DEFAULTs, after
+// coercion — instead of as the SQL claims it will land. Otherwise a
+// disagreement about what the seed means would be invisible to exactly the
+// check meant to find disagreements.
+func readSeededSeries(db *sql.DB) ([]oracle.Series, error) {
+	byKey := map[string]*oracle.Series{}
+
+	for _, table := range seededMetricsTables {
+		//nolint:gosec // table comes from seededMetricsTables, not from fixture text.
+		q := "SELECT MetricName, toJSONString(Attributes), toUnixTimestamp64Milli(TimeUnix), Value " +
+			"FROM " + table + " ORDER BY MetricName, TimeUnix"
+		rows, err := db.Query(q)
+		if err != nil {
+			// A fixture that never created this table is not an error.
+			continue
+		}
+		if err := scanSeriesRows(rows, byKey); err != nil {
+			_ = rows.Close()
+			return nil, err
+		}
+		if err := rows.Close(); err != nil {
+			return nil, err
+		}
+	}
+
+	out := make([]oracle.Series, 0, len(byKey))
+	for _, s := range byKey {
+		out = append(out, *s)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return labelKey(out[i].Labels) < labelKey(out[j].Labels)
+	})
+	return out, nil
+}
+
+func scanSeriesRows(rows *sql.Rows, byKey map[string]*oracle.Series) error {
+	for rows.Next() {
+		var name, attrsJSON string
+		var tsMillis int64
+		var value float64
+		if err := rows.Scan(&name, &attrsJSON, &tsMillis, &value); err != nil {
+			return err
+		}
+		lbls, err := labelsFromAttributesJSON(name, attrsJSON)
+		if err != nil {
+			return err
+		}
+		key := labelKey(lbls)
+		s, ok := byKey[key]
+		if !ok {
+			s = &oracle.Series{Labels: lbls}
+			byKey[key] = s
+		}
+		s.Points = append(s.Points, oracle.Point{TMillis: tsMillis, Value: value})
+	}
+	return rows.Err()
+}
+
+// compareAgainstReference is the assertion itself.
+//
+// # Why an instant query does not compare timestamps
+//
+// Prometheus stamps an INSTANT query's output at the EVALUATION INSTANT,
+// not at the source sample's own time. Cerberus's SQL row carries the
+// source sample time (`max(TimeUnix) AS lwr_ts`), and the HTTP layer is
+// what presents it at eval time. Comparing those two numbers at this layer
+// would compare two different quantities and fail every sparse fixture for
+// a reason unrelated to the query — so for an instant query the comparison
+// is over label sets and VALUES, and the reference's own timestamps are
+// asserted to be the eval instant instead.
+//
+// Nothing is lost from the bug classes this exists to catch: `timestamp()`
+// reports the sample's time as a VALUE, so a wrong sample-time selection
+// still shows up in the value comparison.
+//
+// A RANGE query is different — both sides stamp at step anchors — so
+// timestamps ARE compared there.
+func compareAgainstReference(
+	t *testing.T, c *Case, p *Parity, rt *RoundTripSections, got []oracle.Result, isRange bool,
+) {
+	t.Helper()
+
+	want, err := referenceShapeOfExpectedRows(rt)
+	if err != nil {
+		t.Fatalf("fixture %s: %v", c.Name, err)
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf(
+			"fixture %s: reference engine returned %d sample(s), cerberus %d.\n"+
+				"  reference: %v\n  cerberus:  %v\n"+
+				"This is a real disagreement about the answer, not a golden to regenerate — "+
+				"there is no update path for this check.",
+			c.Name, len(got), len(want), got, want,
+		)
+	}
+
+	for i := range got {
+		g, w := got[i], want[i]
+		if labelKey(g.Labels) != labelKey(w.Labels) {
+			t.Errorf("fixture %s sample %d: labels differ\n  reference: %v\n  cerberus:  %v",
+				c.Name, i, g.Labels, w.Labels)
+			continue
+		}
+		if !oracle.EqualValues(g.Value, w.Value) {
+			t.Errorf("fixture %s sample %d (%v): value differs\n  reference: %v\n  cerberus:  %v",
+				c.Name, i, g.Labels, g.Value, w.Value)
+		}
+		if isRange && g.TMillis != w.TMillis {
+			t.Errorf("fixture %s sample %d (%v): timestamp differs\n  reference: %d\n  cerberus:  %d",
+				c.Name, i, g.Labels, g.TMillis, w.TMillis)
+		}
+	}
+
+	if !p.ComparesInFull() {
+		t.Logf("fixture %s compared with scope %q", c.Name, p.Scope)
+	}
+}
+
+func trimQuery(q string) string { return strings.TrimSpace(q) }
+
+// labelKey renders a label set as a stable, comparable string. Both sides
+// are keyed through this one function so series identity can never differ
+// by map iteration order or by formatting.
+func labelKey(lbls map[string]string) string {
+	keys := make([]string, 0, len(lbls))
+	for k := range lbls {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	for i, k := range keys {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(k)
+		b.WriteByte('=')
+		b.WriteString(lbls[k])
+	}
+	return b.String()
+}
+
+// labelsFromAttributesJSON builds the reference-engine label set for one
+// seeded row: the OTel attribute map plus __name__.
+//
+// The empty-string metric name is dropped rather than written as an empty
+// __name__, because cerberus emits `” AS MetricName` for derived samples
+// (PromQL drops __name__ from a function's output) and Prometheus
+// represents that as the label being ABSENT.
+func labelsFromAttributesJSON(metricName, attrsJSON string) (map[string]string, error) {
+	attrs := map[string]string{}
+	if trimmed := strings.TrimSpace(attrsJSON); trimmed != "" && trimmed != "{}" {
+		if err := json.Unmarshal([]byte(trimmed), &attrs); err != nil {
+			return nil, fmt.Errorf("decode Attributes %q: %w", attrsJSON, err)
+		}
+	}
+	out := make(map[string]string, len(attrs)+1)
+	for k, v := range attrs {
+		out[k] = v
+	}
+	if metricName != "" {
+		out[promNameLabel] = metricName
+	}
+	return out, nil
+}
+
+// promNameLabel is Prometheus's metric-name label.
+const promNameLabel = "__name__"
+
+// expectedRowNameIdx / expectedRowAttrsIdx / expectedRowTimeIdx /
+// expectedRowValueIdx are the positions of the four canonical Sample
+// columns inside an `expected_rows:` row. The projection order is fixed by
+// the Sample contract (MetricName, Attributes, TimeUnix, Value).
+const (
+	expectedRowNameIdx  = 0
+	expectedRowAttrsIdx = 1
+	expectedRowTimeIdx  = 2
+	expectedRowValueIdx = 3
+	expectedRowArity    = 4
+)
+
+// referenceShapeOfExpectedRows converts cerberus's `expected_rows:` into
+// the same flat shape the oracle returns, so the two can be compared
+// element-wise.
+//
+// It errors rather than skipping on a row it cannot interpret. A fixture
+// whose projection is not the canonical four-column Sample shape cannot be
+// parity-checked at this layer, and silently comparing nothing would be
+// the hollow green this mechanism exists to prevent.
+func referenceShapeOfExpectedRows(rt *RoundTripSections) ([]oracle.Result, error) {
+	out := make([]oracle.Result, 0, len(rt.ExpectedRows))
+	for i, row := range rt.ExpectedRows {
+		if len(row) != expectedRowArity {
+			return nil, fmt.Errorf(
+				"expected_rows[%d] has %d column(s), not the canonical Sample shape "+
+					"(MetricName, Attributes, TimeUnix, Value); this fixture's projection cannot "+
+					"be parity-checked at the row layer", i, len(row),
+			)
+		}
+		name, err := rowString(row[expectedRowNameIdx], i, "MetricName")
+		if err != nil {
+			return nil, err
+		}
+		attrs, err := rowAttrs(row[expectedRowAttrsIdx], i)
+		if err != nil {
+			return nil, err
+		}
+		ts, err := rowTimeMillis(row[expectedRowTimeIdx], i)
+		if err != nil {
+			return nil, err
+		}
+		value, err := rowFloat(row[expectedRowValueIdx], i)
+		if err != nil {
+			return nil, err
+		}
+
+		lbls := make(map[string]string, len(attrs)+1)
+		for k, v := range attrs {
+			lbls[k] = v
+		}
+		if name != "" {
+			lbls[promNameLabel] = name
+		}
+		out = append(out, oracle.Result{Labels: lbls, TMillis: ts, Value: value})
+	}
+
+	sort.SliceStable(out, func(i, j int) bool {
+		if ki, kj := labelKey(out[i].Labels), labelKey(out[j].Labels); ki != kj {
+			return ki < kj
+		}
+		return out[i].TMillis < out[j].TMillis
+	})
+	return out, nil
+}
+
+func rowString(cell any, row int, col string) (string, error) {
+	s, ok := cell.(string)
+	if !ok {
+		return "", fmt.Errorf("expected_rows[%d].%s is %T, want string", row, col, cell)
+	}
+	return s, nil
+}
+
+func rowAttrs(cell any, row int) (map[string]string, error) {
+	m, ok := cell.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("expected_rows[%d].Attributes is %T, want an object", row, cell)
+	}
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		s, ok := v.(string)
+		if !ok {
+			return nil, fmt.Errorf("expected_rows[%d].Attributes[%q] is %T, want string", row, k, v)
+		}
+		out[k] = s
+	}
+	return out, nil
+}
+
+func rowTimeMillis(cell any, row int) (int64, error) {
+	s, ok := cell.(string)
+	if !ok {
+		return 0, fmt.Errorf("expected_rows[%d].TimeUnix is %T, want an RFC3339 string", row, cell)
+	}
+	ts, err := time.Parse(time.RFC3339Nano, s)
+	if err != nil {
+		return 0, fmt.Errorf("expected_rows[%d].TimeUnix %q: %w", row, s, err)
+	}
+	return ts.UnixMilli(), nil
+}
+
+func rowFloat(cell any, row int) (float64, error) {
+	switch v := cell.(type) {
+	case float64:
+		return v, nil
+	case json.Number:
+		f, err := v.Float64()
+		if err != nil {
+			return 0, fmt.Errorf("expected_rows[%d].Value %q: %w", row, v.String(), err)
+		}
+		return f, nil
+	default:
+		return 0, fmt.Errorf("expected_rows[%d].Value is %T, want a number", row, cell)
+	}
+}

--- a/test/spec/parity_nochdb.go
+++ b/test/spec/parity_nochdb.go
@@ -1,0 +1,27 @@
+//go:build !chdb
+
+// Package spec — parity stub when the `chdb` build tag is unset.
+//
+// The default `just test` lane stays pure Go / CGO_ENABLED=0 and must not
+// pull in chdb-go (which links libchdb.so via cgo), nor the reference
+// query engine. This file provides a no-op RunParity so the per-head
+// lower_test.go files can call spec.RunParity unconditionally; the
+// `parity:` section is then inert.
+//
+// The section's GRAMMAR is still checked in this lane —
+// test/regression's parity contract test calls LoadParity, which is
+// build-tag-free — so a malformed `parity:` body fails fast on every
+// commit rather than only under the chdb-tagged lane.
+package spec
+
+import (
+	"testing"
+	"time"
+)
+
+// RunParity is a no-op when the `chdb` build tag is not set. The real
+// implementation lives in parity_chdb.go.
+func RunParity(t *testing.T, c *Case, evalStart, evalEnd time.Time, step time.Duration) {
+	t.Helper()
+	_, _, _, _, _ = c, evalStart, evalEnd, step, t
+}

--- a/test/spec/parityoracle/promql/oracle.go
+++ b/test/spec/parityoracle/promql/oracle.go
@@ -1,0 +1,254 @@
+// Package promql evaluates a fixture's query on the REAL upstream
+// Prometheus engine, so a TXTAR fixture's answer can be checked against
+// something other than cerberus's own output.
+//
+// # The one rule this package exists to enforce
+//
+// It imports NOTHING from internal/{promql,logql,traceql,chplan,chsql,
+// optimizer}. That is not a style preference — it is the entire point. An
+// oracle that shares code with the system under test cannot disagree with
+// it about the thing they share, so any such import silently converts this
+// package from an oracle into a mirror. test/regression's parity contract
+// test enforces the rule mechanically with `go list -deps -test`, because
+// a rule this easy to break by accident and this invisible when broken
+// cannot be left to review.
+//
+// The same reasoning rules out reusing compatibility/prometheus/cmd/seed's
+// readFixtureSeries, which is otherwise a perfectly good CH-rows-to-series
+// translator: it imports internal/promql and internal/schema. Being equal
+// by construction is exactly right for the compat MIRROR (whose job is to
+// put identical data in both backends) and disqualifying here.
+//
+// # Why the input is rows, not a seed
+//
+// Evaluate takes rows already read back out of the seeded chDB session
+// rather than the fixture's `-- seed --` SQL. Two reasons. It keeps every
+// chDB and engine-serialisation concern in package spec, where the session
+// mutex lives. And it means the oracle sees the data as it ACTUALLY LANDED
+// in ClickHouse — after DEFAULTs, after type coercion — rather than as the
+// seed text claims it will land, which is the difference between checking
+// cerberus against Prometheus and checking two readings of a SQL string.
+//
+// # Why not the promqltest load DSL
+//
+// promqltest's `load <step>` command lays samples on a FIXED step from a
+// fixed start, and the corpus is not on a fixed step: binop_rate_plus_rate
+// has a 29-second inter-sample gap, which is precisely the irregular
+// cadence that surfaced the boundary-extrapolation bug this mechanism is
+// meant to catch. Samples are therefore appended directly at their exact
+// millisecond timestamps.
+package promql
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/promql/promqltest"
+	"github.com/prometheus/prometheus/util/teststorage"
+)
+
+// lookbackDelta is Prometheus's own default staleness lookback, and the
+// window cerberus's instant-selector lowering applies. The two must agree
+// or every sparse-seed fixture diverges for a reason that has nothing to
+// do with the query under test.
+const lookbackDelta = 5 * time.Minute
+
+// maxSamples bounds one evaluation. It is deliberately far above any
+// fixture's working set — the corpus seeds a handful of samples per series
+// — so that a fixture can never pass or fail because of the limit rather
+// than because of the query.
+const maxSamples = 1_000_000
+
+// Series is one input time series: an identifying label set plus its
+// samples, exactly as they were read back out of ClickHouse.
+type Series struct {
+	// Labels is the series' full label set INCLUDING __name__.
+	Labels map[string]string
+
+	// Points are the samples, which need not be evenly spaced.
+	Points []Point
+}
+
+// Point is one sample at an exact millisecond timestamp.
+type Point struct {
+	// TMillis is the sample time in Unix milliseconds — Prometheus's
+	// native resolution.
+	TMillis int64
+
+	// Value is the sample value.
+	Value float64
+}
+
+// Result is one output sample from the reference engine, flattened so the
+// caller can compare without depending on Prometheus's own types.
+type Result struct {
+	// Labels is the output series' label set.
+	Labels map[string]string
+
+	// TMillis is the output timestamp in Unix milliseconds.
+	TMillis int64
+
+	// Value is the output value.
+	Value float64
+}
+
+// Query describes one evaluation to run.
+type Query struct {
+	// Expr is the PromQL expression, verbatim from the fixture.
+	Expr string
+
+	// Start is the instant for an instant query, or the range start.
+	Start time.Time
+
+	// End equals Start for an instant query.
+	End time.Time
+
+	// Step is zero for an instant query, and the range step otherwise.
+	Step time.Duration
+}
+
+// IsRange reports whether this is a range query.
+func (q Query) IsRange() bool { return q.Step > 0 }
+
+// Evaluate runs q against the real Prometheus engine over series, and
+// returns the resulting samples sorted deterministically.
+//
+// It returns an error rather than failing the test so the caller can
+// attribute a failure precisely: a Prometheus PARSE error on a fixture's
+// query usually means the fixture exercises a cerberus extension that
+// upstream does not accept, which is a fact about the fixture and not a
+// parity failure.
+func Evaluate(tb testing.TB, series []Series, q Query) ([]Result, error) {
+	tb.Helper()
+
+	storage := teststorage.New(tb)
+	tb.Cleanup(func() { _ = storage.Close() })
+
+	if err := appendSeries(storage, series); err != nil {
+		return nil, err
+	}
+
+	engine := promqltest.NewTestEngine(tb, false, lookbackDelta, maxSamples)
+	ctx := context.Background()
+
+	var query promql.Query
+	var err error
+	if q.IsRange() {
+		query, err = engine.NewRangeQuery(ctx, storage, nil, q.Expr, q.Start, q.End, q.Step)
+	} else {
+		query, err = engine.NewInstantQuery(ctx, storage, nil, q.Expr, q.Start)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reference engine rejected the query: %w", err)
+	}
+	defer query.Close()
+
+	res := query.Exec(ctx)
+	if res.Err != nil {
+		return nil, fmt.Errorf("reference engine evaluation failed: %w", res.Err)
+	}
+	return flatten(res.Value)
+}
+
+// appendSeries writes every sample into the reference storage at its exact
+// timestamp.
+func appendSeries(storage *teststorage.TestStorage, series []Series) error {
+	app := storage.Appender(context.Background())
+	for _, s := range series {
+		lbls := labels.FromMap(s.Labels)
+		for _, p := range s.Points {
+			if _, err := app.Append(0, lbls, p.TMillis, p.Value); err != nil {
+				return fmt.Errorf("append %s at %d: %w", lbls.String(), p.TMillis, err)
+			}
+		}
+	}
+	if err := app.Commit(); err != nil {
+		return fmt.Errorf("commit reference samples: %w", err)
+	}
+	return nil
+}
+
+// flatten converts Prometheus's result value into the transport-free
+// Result shape, sorted by (labels, timestamp) so comparison never depends
+// on the engine's internal ordering.
+//
+// Histogram-valued samples are rejected rather than silently coerced to
+// their float field: a fixture whose reference answer is a native
+// histogram cannot be compared against cerberus's float-only result path,
+// and quietly comparing the wrong field would manufacture a green.
+func flatten(v parser.Value) ([]Result, error) {
+	var out []Result
+
+	switch val := v.(type) {
+	case promql.Matrix:
+		for _, s := range val {
+			if len(s.Histograms) > 0 {
+				return nil, histogramValuedErr(s.Metric)
+			}
+			for _, p := range s.Floats {
+				out = append(out, Result{Labels: s.Metric.Map(), TMillis: p.T, Value: p.F})
+			}
+		}
+	case promql.Vector:
+		for _, s := range val {
+			if s.H != nil {
+				return nil, histogramValuedErr(s.Metric)
+			}
+			out = append(out, Result{Labels: s.Metric.Map(), TMillis: s.T, Value: s.F})
+		}
+	case promql.Scalar:
+		out = append(out, Result{Labels: map[string]string{}, TMillis: val.T, Value: val.V})
+	default:
+		return nil, fmt.Errorf("reference engine returned unsupported value type %T", v)
+	}
+
+	sortResults(out)
+	return out, nil
+}
+
+func histogramValuedErr(m labels.Labels) error {
+	return fmt.Errorf(
+		"reference answer for %s is histogram-valued; cerberus's result path is float-only, "+
+			"so this fixture cannot be parity-checked until native-histogram encoding lands",
+		m.String(),
+	)
+}
+
+// sortResults orders by label set then timestamp. Deterministic ordering
+// is what lets the caller compare element-wise without re-deriving series
+// identity.
+func sortResults(rs []Result) {
+	sort.SliceStable(rs, func(i, j int) bool {
+		li, lj := labels.FromMap(rs[i].Labels).String(), labels.FromMap(rs[j].Labels).String()
+		if li != lj {
+			return li < lj
+		}
+		return rs[i].TMillis < rs[j].TMillis
+	})
+}
+
+// EqualValues reports whether two float samples agree.
+//
+// NaN==NaN is TRUE here. PromQL produces NaN as a legitimate answer
+// (0/0, quantile over an empty window, a stale marker's fold), and Go's
+// float comparison would call two such answers different, failing
+// fixtures that actually agree.
+//
+// Everything else is EXACT. This is deliberate and is the reason no
+// epsilon appears anywhere in this package: cerberus and Prometheus
+// evaluate the same IEEE-754 doubles, so a real disagreement is a real
+// bug, and an epsilon would be a tolerance — the shape invariant 7
+// forbids — dressed up as a numeric constant.
+func EqualValues(a, b float64) bool {
+	if math.IsNaN(a) && math.IsNaN(b) {
+		return true
+	}
+	return a == b
+}

--- a/test/spec/promql/clamp_max.txtar
+++ b/test/spec/promql/clamp_max.txtar
@@ -1,5 +1,9 @@
 -- query.promql --
 clamp_max(temperature, 100)
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query
+scope: full
 -- sql --
 SELECT ? AS `MetricName`, `Attributes`, `TimeUnix`, least(`Value`, toFloat64(?)) AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `lwr_ts` AS `TimeUnix`, `lwr_value` AS `Value` FROM (SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, max(`TimeUnix`) AS `lwr_ts`, argMax(`Value`, `TimeUnix`) AS `lwr_value` FROM (SELECT * FROM (SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT * FROM merge(currentDatabase(), '^(otel_metrics_gauge|otel_metrics_sum)$') PREWHERE (`MetricName` = ?))) WHERE ((`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?))))) GROUP BY `MetricName`, `Attributes`))
 -- args --


### PR DESCRIPTION
`expected_rows` is not an oracle. `RunRoundTrip` executes cerberus's own emitted SQL and, under `GOLDEN_UPDATE=1`, writes the result straight back into the fixture — `runner.go`'s `Match` does not even compare in that mode. A fixture's "expected" answer is therefore whatever cerberus most recently produced, so a wrong lowering gets its wrong answer re-pinned and passes forever.

Two real semantic bugs reached `main` exactly that way this month (the `histogram_quantile(sum(rate(...)))` boundary-extrapolation clamps, and the `AggregationTemporality` DELTA double-count). Both were caught by the live compat harness; the txtar goldens for those very shapes had been re-pinned to the wrong values and were green.

This adds a second, **independent** answer: the actual upstream Prometheus evaluator, in-process, over the same seeded rows.

## The reference answer is computed, never stored

Storing it was the obvious design and it does not work here. `just update-golden` grants each shard ownership of a whole **directory** (`goldens: ['test/spec/promql']` in `golden-shards.mjs`), not a section — so a stored reference answer would sit inside the `promql` shard's blast radius, regenerable by the very cerberus-driven generator it exists to check. Protecting it would need a write guard, an input fingerprint, a drift check and an engine-version manifest.

Computing it live removes the artefact entirely. There is nothing for regeneration to overwrite, so absorption is not *detected* — it is *impossible*. What the fixture stores is the **contract**:

```
-- parity --
oracle: prometheus
endpoint: /api/v1/query
scope: full
```

## The oracle may not import the system it checks

`test/spec/parityoracle/promql` imports nothing from `internal/{promql,logql,traceql,chplan,chsql,optimizer,schema}`. An oracle sharing code with the system under test cannot disagree with it about the thing they share — such an import silently turns the oracle into a mirror, and a mirror always agrees.

`test/regression` enforces this with `go list -deps -test`, which catches the **transitive** case a source grep would miss. It is also why `prom_remote.go`'s `readFixtureSeries` is not reused despite doing the same CH-rows→series conversion: it imports `internal/promql` and `internal/schema`. Equal-by-construction is right for the compat *mirror* and disqualifying for an *oracle*.

## Verified by injecting a real bug

`clamp_max` was made to emit `greatest` (so it never caps), then the corpus was allowed to absorb it:

| step | result |
|---|---|
| `update-golden` | re-pinned `expected_rows` **100 → 150**, the wrong answer |
| pre-optimizer roundtrip lane | **ok** — fully self-consistent, green, and wrong |
| **parity check** | **FAIL** — `value differs / reference: 100` |
| same run with `GOLDEN_UPDATE=1` | still FAIL — the check has no update branch |

The disjointness gate was verified the same way: adding an `internal/promql` import to the oracle failed the contract test naming `chplan`, `schema` *and* `promql` — the transitive pulls, not just the direct one.

## One deliberate asymmetry

Instant queries compare labels and values but **not** timestamps: Prometheus stamps an instant result at the eval instant while cerberus's row carries the source sample time, so comparing them would compare two different quantities. Range queries do compare timestamps, since both sides stamp at step anchors. No bug class is lost — `timestamp()` reports sample time as a *value*.

## Scope

One fixture (`clamp_max`) is enrolled; a floor test ratchets enrolment so it can only grow. Enrolment waves, the exp-histogram scope carve-out, and the LogQL oracle are separate follow-ups — this PR is the mechanism and its proofs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)