### PR TITLE
feat(spec): check LogQL txtar fixtures against the real Loki engine

### DIFF
--- a/.github/workflows/agpl-oracle.yml
+++ b/.github/workflows/agpl-oracle.yml
@@ -25,6 +25,7 @@ name: agpl-oracle
 #   test/surface-parity/traceql_reference_agpl_test.go
 #   test/property/oracle/logql/evaluator.go
 #   test/property/oracle/logql/line_filters.go
+#   test/spec/parityoracle/logql/oracle.go
 #
 # The tests do NOT require CGO, Docker, or libchdb — they are pure Go and
 # compile with a stock Go toolchain against the root-module deps. (The last
@@ -50,7 +51,11 @@ name: agpl-oracle
 # libchdb.so. This lane still compiles the sibling
 # test/property/oracle/logql package (evaluator.go / line_filters.go),
 # proving the agpl_oracle-tagged code itself builds, without taking on a
-# chdb dependency this lane doesn't otherwise need.
+# chdb dependency this lane doesn't otherwise need. The same applies to
+# test/spec/parity_loki_chdb.go, the runner half of the LogQL parity
+# oracle: it compiles OUT here and is exercised by chdb.yml's
+# `roundtrip (logql)` leg, which passes all three tags. This lane still
+# compiles test/spec/parityoracle/logql (the oracle itself).
 #
 # test/surface-parity/logql.go and traceql.go read pinned reference-verdict
 # artifacts (logql-reference-verdicts.json / traceql-reference-verdicts.json)
@@ -149,7 +154,7 @@ jobs:
 
       - name: Run agpl_oracle differential oracle tests
         if: needs.changes.outputs.docs_only != 'true'
-        run: go test -race -tags agpl_oracle -count=1 ./internal/... ./test/agpl_oracle/... ./test/surface-parity/... ./test/property/...
+        run: go test -race -tags agpl_oracle -count=1 ./internal/... ./test/agpl_oracle/... ./test/spec/... ./test/surface-parity/... ./test/property/...
 
       - name: Verify agpl_oracle tag set coverage (regression)
         if: needs.changes.outputs.docs_only != 'true'

--- a/.github/workflows/chdb.yml
+++ b/.github/workflows/chdb.yml
@@ -244,7 +244,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ql: [promql, logql, traceql]
+        # `tags` is per-leg because the LogQL leg additionally runs the
+        # parity check against the REAL upstream Loki engine, which is
+        # AGPLv3 and therefore lives behind `agpl_oracle` (invariant 14).
+        # Every `//go:build` line in this tree is a single term, so the
+        # composition `chdb && agpl_oracle` is carried by the synthetic
+        # `chdb_agpl_oracle` tag — the same three-tag set property.yml
+        # already passes. Without them the Loki oracle compiles out and
+        # RunParity FAILS rather than silently checking nothing; see
+        # test/spec/parity_chdb.go's lokiParityEvaluator.
+        include:
+          - ql: promql
+            tags: chdb
+          - ql: logql
+            tags: chdb,agpl_oracle,chdb_agpl_oracle
+          - ql: traceql
+            tags: chdb
     steps:
       - uses: actions/checkout@v7
         if: needs.changes.outputs.docs_only != 'true'
@@ -281,9 +296,13 @@ jobs:
       # internal/logql nor internal/traceql, and this step ran only the
       # test/spec side, so an optimizer bug that rewrote a fixture's
       # answer had nothing standing in its way.
+      #
+      # ./internal/<ql>/ additionally runs RunParity for every fixture
+      # carrying a `parity:` section — the reference-engine comparison
+      # that has no GOLDEN_UPDATE branch at all (test/spec/parity.go).
       - name: Run TXTAR round-trip (${{ matrix.ql }})
         if: needs.changes.outputs.docs_only != 'true'
-        run: go test -tags chdb -count=1 ./test/spec/${{ matrix.ql }}/... ./internal/${{ matrix.ql }}/...
+        run: go test -tags ${{ matrix.tags }} -count=1 ./test/spec/${{ matrix.ql }}/... ./internal/${{ matrix.ql }}/...
 
   # `perf-guards` runs the chDB-tagged deterministic perf-regression
   # ASSERTIONS under test/perf/ — the load-bearing fix for task #73.

--- a/go.mod
+++ b/go.mod
@@ -12,9 +12,11 @@ require (
 	github.com/cucumber/godog v0.16.0
 	github.com/cucumber/messages/go/v34 v34.2.0
 	github.com/dustin/go-humanize v1.0.1
+	github.com/go-kit/log v0.2.1
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/snappy v1.0.0
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
+	github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3
 	github.com/grafana/loki/v3 v3.7.1
 	github.com/grafana/tempo v1.5.1-0.20260508211128-2f74ea818de1
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/clickhouseexporter v0.152.0
@@ -119,7 +121,6 @@ require (
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/go-faster/city v1.0.1 // indirect
 	github.com/go-faster/errors v0.7.1 // indirect
-	github.com/go-kit/log v0.2.1 // indirect
 	github.com/go-logfmt/logfmt v0.6.1 // indirect
 	github.com/go-logr/logr v1.4.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
@@ -157,7 +158,6 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.3.15 // indirect
 	github.com/googleapis/gax-go/v2 v2.22.0 // indirect
 	github.com/gorilla/mux v1.8.1 // indirect
-	github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3 // indirect
 	github.com/grafana/gomemcache v0.0.0-20251127154401-74f93547077b // indirect
 	github.com/grafana/jsonparser v0.0.0-20241004153430-023329977675 // indirect
 	github.com/grafana/loki/pkg/push v0.0.0-20250630054201-94c0ba7b0952 // indirect

--- a/internal/logql/lower_test.go
+++ b/internal/logql/lower_test.go
@@ -95,7 +95,45 @@ func TestLower(t *testing.T) {
 			t.Fatalf("Emit(optimized plan): %v", err)
 		}
 		spec.RunRoundTripSQL(t, c, optSQL, optArgs)
+
+		// A fixture carrying a `parity:` section is additionally answered
+		// by the REAL upstream Loki engine over the same seeded data, and
+		// the two answers are compared. Unlike every other assertion in
+		// this function, that one has no GOLDEN_UPDATE branch: the
+		// reference answer is computed on each run rather than stored, so
+		// there is nothing for regeneration to overwrite. See
+		// test/spec/parity.go for why the fixture stores the parity
+		// CONTRACT and not the parity ANSWER.
+		parityStart, parityEnd, parityStep := parityWindow(start, end, step)
+		spec.RunParity(t, c, parityStart, parityEnd, parityStep)
 	})
+}
+
+// fixtureInstantAnchor is the eval instant a fixture without `start:` /
+// `end:` sections is answered at. It is the same instant the round-trip
+// runner splices in for `now64(...)` (test/spec/runner_chdb.go's
+// defaultNowAnchor), because the reference engine has to be asked the
+// question cerberus's emitted SQL was actually executed with — a
+// different instant would move the range window and diverge for a reason
+// that has nothing to do with the lowering.
+var fixtureInstantAnchor = time.Date(2026, 1, 1, 0, 0, 1, 0, time.UTC)
+
+// parityWindow maps a fixture's optional window sections onto the
+// evaluation the reference engine runs.
+//
+// A fixture with a `step:` is a range query over [start, end]. One with
+// `start:` / `end:` but no step lowers through LowerAt, which evaluates a
+// single instant at the window's END. One with no window sections at all
+// is answered at [fixtureInstantAnchor].
+func parityWindow(start, end time.Time, step time.Duration) (time.Time, time.Time, time.Duration) {
+	switch {
+	case start.IsZero() && end.IsZero():
+		return fixtureInstantAnchor, fixtureInstantAnchor, 0
+	case step > 0:
+		return start, end, step
+	default:
+		return end, end, 0
+	}
 }
 
 // readWindowSections pulls optional `start:` / `end:` (RFC3339Nano) and

--- a/test/regression/agpl_oracle_tag_set_test.go
+++ b/test/regression/agpl_oracle_tag_set_test.go
@@ -34,6 +34,7 @@ func TestAGPLOracleTagSetCoverage(t *testing.T) {
 	agplOracleLaneScopes := []string{
 		"internal/",
 		"test/agpl_oracle/",
+		"test/spec/",
 		"test/surface-parity/",
 		"test/property/",
 	}

--- a/test/regression/parity_contract_test.go
+++ b/test/regression/parity_contract_test.go
@@ -10,11 +10,29 @@ import (
 	"github.com/tsouza/cerberus/test/spec"
 )
 
-// parityOraclePkgs are the reference-engine packages whose independence
-// from cerberus is the load-bearing property of the whole parity layer.
-var parityOraclePkgs = []string{
-	"./test/spec/parityoracle/...",
+// parityOraclePkgs is the pattern covering every reference-engine
+// package whose independence from cerberus is the load-bearing property
+// of the whole parity layer.
+const parityOraclePkgs = "./test/spec/parityoracle/..."
+
+// parityOraclePackages is the import path of every oracle that must be
+// REACHED by the scan below.
+//
+// Naming them is not redundant with the `...` pattern: an oracle behind a
+// build tag the scan does not set is silently absent from `go list`'s
+// output — the command still exits 0 — so the gate would report clean
+// over a package it never read. That is the same hollow green the parity
+// layer itself exists to eliminate, so a missing oracle is a failure.
+var parityOraclePackages = []string{
+	"github.com/tsouza/cerberus/test/spec/parityoracle/promql",
+	"github.com/tsouza/cerberus/test/spec/parityoracle/logql",
 }
+
+// parityOracleBuildConfigs are the build configurations the scan runs
+// under. Together they must cover every oracle in
+// [parityOraclePackages]; the LogQL oracle links the AGPLv3 Loki engine
+// and so exists only under `agpl_oracle` (invariant 14).
+var parityOracleBuildConfigs = []string{"", "agpl_oracle"}
 
 // forbiddenOracleDeps are the cerberus packages an oracle may never
 // import, directly or transitively.
@@ -53,33 +71,56 @@ func TestParityOracleImportsNoCerberusLowering(t *testing.T) {
 	t.Parallel()
 
 	root := repoRootForParity(t)
+	reached := map[string]bool{}
 
-	for _, pkg := range parityOraclePkgs {
+	for _, tags := range parityOracleBuildConfigs {
 		// -test includes the test files' own imports, so an oracle cannot
 		// smuggle a forbidden dependency in through its _test.go either.
-		cmd := exec.Command("go", "list", "-deps", "-test", pkg)
+		args := []string{"list", "-deps", "-test"}
+		if tags != "" {
+			args = append(args, "-tags", tags)
+		}
+		args = append(args, parityOraclePkgs)
+
+		cmd := exec.Command("go", args...)
 		cmd.Dir = root
 		out, err := cmd.Output()
 		if err != nil {
-			t.Fatalf("go list -deps -test %s: %v", pkg, err)
+			t.Fatalf("go %s: %v", strings.Join(args, " "), err)
 		}
 
-		deps := strings.Split(strings.TrimSpace(string(out)), "\n")
-		for _, dep := range deps {
+		config := tags
+		if config == "" {
+			config = "(default build)"
+		}
+		for _, dep := range strings.Split(strings.TrimSpace(string(out)), "\n") {
 			dep = strings.TrimSpace(dep)
+			reached[dep] = true
 			for _, forbidden := range forbiddenOracleDeps {
 				if dep == forbidden || strings.HasPrefix(dep, forbidden+"/") {
 					t.Errorf(
-						"parity oracle %s transitively imports %s.\n"+
+						"parity oracle %s transitively imports %s under build config %s.\n"+
 							"An oracle that shares code with the system under test cannot disagree "+
 							"with it about the thing they share, so this import silently converts "+
 							"the oracle into a mirror — and the parity check would then pass while "+
 							"proving nothing. Reimplement whatever was needed inside the oracle "+
 							"package instead of importing it.",
-						pkg, dep,
+						parityOraclePkgs, dep, config,
 					)
 				}
 			}
+		}
+	}
+
+	for _, pkg := range parityOraclePackages {
+		if !reached[pkg] {
+			t.Errorf(
+				"the disjointness scan never reached %s under any of the build configurations %q.\n"+
+					"`go list` exits 0 for a package whose build constraints exclude every file, so "+
+					"the scan above reported clean over a package it never read. Add the tag that "+
+					"compiles it to parityOracleBuildConfigs.",
+				pkg, parityOracleBuildConfigs,
+			)
 		}
 	}
 }
@@ -129,7 +170,7 @@ func TestParityEnrolmentFloor(t *testing.T) {
 
 	// parityEnrolmentFloor is the number of fixtures currently carrying a
 	// `parity:` section. It ratchets UP only.
-	const parityEnrolmentFloor = 215
+	const parityEnrolmentFloor = 233
 
 	enrolled := 0
 	for _, dir := range parityFixtureDirs(t) {

--- a/test/spec/logql/absent_over_time_instant.txtar
+++ b/test/spec/logql/absent_over_time_instant.txtar
@@ -1,5 +1,9 @@
 -- query.logql --
 absent_over_time({job="api", env="prod"}[5m])
+-- parity --
+oracle: loki
+endpoint: /api/v1/query
+scope: full
 -- seed --
 CREATE TABLE otel_logs (
     Timestamp DateTime64(9),

--- a/test/spec/logql/absent_over_time_range.txtar
+++ b/test/spec/logql/absent_over_time_range.txtar
@@ -1,5 +1,9 @@
 -- query.logql --
 absent_over_time({job="api"}[1m])
+-- parity --
+oracle: loki
+endpoint: /api/v1/query_range
+scope: full
 -- start --
 2026-01-01T00:00:00Z
 -- end --

--- a/test/spec/logql/avg_count_over_time.txtar
+++ b/test/spec/logql/avg_count_over_time.txtar
@@ -1,5 +1,9 @@
 -- query.logql --
 avg(count_over_time({job="api"}[5m]))
+-- parity --
+oracle: loki
+endpoint: /api/v1/query
+scope: full
 -- seed --
 CREATE TABLE otel_logs (
     Timestamp DateTime64(9),

--- a/test/spec/logql/binop_literal_vector.txtar
+++ b/test/spec/logql/binop_literal_vector.txtar
@@ -1,5 +1,9 @@
 -- query.logql --
 vector(5) * on() count_over_time({service_name="api"}[5m])
+-- parity --
+oracle: loki
+endpoint: /api/v1/query
+scope: full
 -- seed --
 CREATE TABLE otel_logs (
     Timestamp DateTime64(9),

--- a/test/spec/logql/binop_scalar_vector_agg.txtar
+++ b/test/spec/logql/binop_scalar_vector_agg.txtar
@@ -1,5 +1,9 @@
 -- query.logql --
 sum by (svc) (count_over_time({app="x"}[5m])) * 2
+-- parity --
+oracle: loki
+endpoint: /api/v1/query
+scope: full
 -- seed --
 CREATE TABLE otel_logs (
     Timestamp DateTime64(9),

--- a/test/spec/logql/binop_vv_add_bool_ignored.txtar
+++ b/test/spec/logql/binop_vv_add_bool_ignored.txtar
@@ -1,5 +1,9 @@
 -- query.logql --
 sum by (env) (count_over_time({job="api"}[5m])) + bool sum by (env) (count_over_time({job="api"}[5m]))
+-- parity --
+oracle: loki
+endpoint: /api/v1/query
+scope: full
 -- seed --
 CREATE TABLE otel_logs (
     LogAttributes Map(String, String),

--- a/test/spec/logql/binop_vv_add_on.txtar
+++ b/test/spec/logql/binop_vv_add_on.txtar
@@ -1,5 +1,9 @@
 -- query.logql --
 rate({service_name="api"}[5m]) + on(service_name) rate({service_name="api"}[5m])
+-- parity --
+oracle: loki
+endpoint: /api/v1/query
+scope: full
 -- seed --
 CREATE TABLE otel_logs (
     Timestamp DateTime64(9),

--- a/test/spec/logql/binop_vv_compare_filter.txtar
+++ b/test/spec/logql/binop_vv_compare_filter.txtar
@@ -4,6 +4,10 @@
 
 -- query.logql --
 rate({service_name="api"}[5m]) > rate({service_name="api"}[5m])
+-- parity --
+oracle: loki
+endpoint: /api/v1/query
+scope: full
 -- seed --
 CREATE TABLE otel_logs (
     Timestamp DateTime64(9),

--- a/test/spec/logql/binop_vv_group_left_with_agg_legs.txtar
+++ b/test/spec/logql/binop_vv_group_left_with_agg_legs.txtar
@@ -1,5 +1,9 @@
 -- query.logql --
 sum by (svc) (count_over_time({app="x"}[5m])) / on(svc) group_left(env) sum by (svc) (count_over_time({app="y"}[5m]))
+-- parity --
+oracle: loki
+endpoint: /api/v1/query
+scope: full
 -- seed --
 CREATE TABLE otel_logs (
     LogAttributes Map(String, String),

--- a/test/spec/logql/label_replace_backref_above_ch_ceiling.txtar
+++ b/test/spec/logql/label_replace_backref_above_ch_ceiling.txtar
@@ -1,5 +1,9 @@
 -- query.logql --
 label_replace(sum by (host) (count_over_time({job="api"}[5m])), "tenth", "g-$10-tail", "host", "(.)(.)(.)(.)(.)(.)(.)(.)(.)(.)")
+-- parity --
+oracle: loki
+endpoint: /api/v1/query
+scope: full
 -- seed --
 CREATE TABLE otel_logs (
     Timestamp DateTime64(9),

--- a/test/spec/logql/range_agg_without_grouping_unwrap.txtar
+++ b/test/spec/logql/range_agg_without_grouping_unwrap.txtar
@@ -1,5 +1,9 @@
 -- query.logql --
 max by (tier) (avg_over_time({job="api"} | logfmt | unwrap latency [5m]) without (pod))
+-- parity --
+oracle: loki
+endpoint: /api/v1/query
+scope: full
 -- seed --
 CREATE TABLE otel_logs (
     LogAttributes Map(String, String),

--- a/test/spec/logql/range_mode_sum_count_over_time.txtar
+++ b/test/spec/logql/range_mode_sum_count_over_time.txtar
@@ -1,5 +1,9 @@
 -- query.logql --
 sum(count_over_time({service_name="web-server"}[5m]))
+-- parity --
+oracle: loki
+endpoint: /api/v1/query_range
+scope: full
 -- start --
 2026-01-01T00:00:00Z
 -- end --

--- a/test/spec/logql/range_mode_sum_rate_sparse_trim.txtar
+++ b/test/spec/logql/range_mode_sum_rate_sparse_trim.txtar
@@ -1,5 +1,9 @@
 -- query.logql --
 sum(rate({service_name="web-server"}[5m]))
+-- parity --
+oracle: loki
+endpoint: /api/v1/query_range
+scope: full
 -- start --
 2026-01-01T00:00:00Z
 -- end --

--- a/test/spec/logql/sum_by_job_rate.txtar
+++ b/test/spec/logql/sum_by_job_rate.txtar
@@ -1,5 +1,9 @@
 -- query.logql --
 sum by (job) (rate({app="api"}[5m]))
+-- parity --
+oracle: loki
+endpoint: /api/v1/query
+scope: full
 -- seed --
 CREATE TABLE otel_logs (
     LogAttributes Map(String, String),

--- a/test/spec/logql/sum_count_over_time.txtar
+++ b/test/spec/logql/sum_count_over_time.txtar
@@ -1,5 +1,9 @@
 -- query.logql --
 sum(count_over_time({service_name="web-server"}[5m]))
+-- parity --
+oracle: loki
+endpoint: /api/v1/query
+scope: full
 -- seed --
 CREATE TABLE otel_logs (
     Timestamp DateTime64(9),

--- a/test/spec/logql/sum_count_over_time_line_filter.txtar
+++ b/test/spec/logql/sum_count_over_time_line_filter.txtar
@@ -1,5 +1,9 @@
 -- query.logql --
 sum(count_over_time({service_name="web-server"} |= "level" [5m]))
+-- parity --
+oracle: loki
+endpoint: /api/v1/query
+scope: full
 -- seed --
 CREATE TABLE otel_logs (
     Timestamp DateTime64(9),

--- a/test/spec/logql/sum_rate.txtar
+++ b/test/spec/logql/sum_rate.txtar
@@ -1,5 +1,9 @@
 -- query.logql --
 sum(rate({job="api"}[1m]))
+-- parity --
+oracle: loki
+endpoint: /api/v1/query
+scope: full
 -- seed --
 CREATE TABLE otel_logs (
     Timestamp DateTime64(9),

--- a/test/spec/logql/variants_grouped.txtar
+++ b/test/spec/logql/variants_grouped.txtar
@@ -1,5 +1,9 @@
 -- query.logql --
 variants(sum by (app) (count_over_time({app="foo"}[5m])), sum by (app) (bytes_over_time({app="foo"}[5m]))) of ({app="foo"}[5m])
+-- parity --
+oracle: loki
+endpoint: /api/v1/query
+scope: full
 -- seed --
 CREATE TABLE otel_logs (
     Timestamp DateTime64(9),

--- a/test/spec/parity_chdb.go
+++ b/test/spec/parity_chdb.go
@@ -15,13 +15,57 @@ import (
 	oracle "github.com/tsouza/cerberus/test/spec/parityoracle/promql"
 )
 
+// parityQuery is one evaluation to run against a reference engine,
+// independent of which engine answers it.
+type parityQuery struct {
+	// Expr is the query text, verbatim from the fixture.
+	Expr string
+
+	// Start is the instant for an instant query, or the range start.
+	Start time.Time
+
+	// End equals Start for an instant query.
+	End time.Time
+
+	// Step is zero for an instant query, and the range step otherwise.
+	Step time.Duration
+}
+
+// referenceSample is one output sample, in the single shape both oracles
+// are flattened into so one comparator can serve every head.
+type referenceSample struct {
+	Labels  map[string]string
+	TMillis int64
+	Value   float64
+}
+
+// lokiParityEvaluator is the seam onto the AGPL-licensed Loki oracle.
+//
+// It is nil unless the `chdb_agpl_oracle` build tag is set, which is what
+// compiles parity_loki_chdb.go and its init(). The indirection is not
+// decoration: `github.com/grafana/loki/v3/pkg/logql` is AGPLv3 and this
+// file is in the plain `chdb` build configuration, so a direct import
+// here would drag AGPL code into every chdb-tagged lane. Every
+// `//go:build` line in this tree is a single term (see
+// test/regression/lint_build_tags_test.go), so `chdb && agpl_oracle`
+// cannot be spelled directly and `chdb_agpl_oracle` — the synthetic tag
+// CI already sets alongside both — carries the composition.
+//
+// A nil evaluator with a Loki-enrolled fixture is a hard failure, never a
+// skip: it means the fixture's oracle was compiled out of the lane that
+// was supposed to run it, which is exactly the silent non-check this
+// whole mechanism exists to prevent.
+var lokiParityEvaluator func(
+	t *testing.T, db *sql.DB, c *Case, q parityQuery,
+) ([]referenceSample, error)
+
 // RunParity checks a fixture's answer against a REAL reference engine.
 //
 // It is the half of the parity layer that must live in package spec,
 // because it touches the chDB session and therefore chdbEngineMu. The
-// evaluation itself lives in test/spec/parityoracle/promql, which imports
-// nothing from cerberus — see that package's doc comment, and the
-// disjointness gate in test/regression that enforces it.
+// evaluation itself lives in test/spec/parityoracle/{promql,logql}, which
+// import nothing from cerberus — see those packages' doc comments, and
+// the disjointness gate in test/regression that enforces it.
 //
 // # There is no update path here, on purpose
 //
@@ -45,9 +89,6 @@ func RunParity(t *testing.T, c *Case, evalStart, evalEnd time.Time, step time.Du
 	if !enrolled {
 		return
 	}
-	if p.Oracle != OraclePrometheus {
-		t.Fatalf("fixture %s: oracle %q has no runner in this lane", c.Name, p.Oracle)
-	}
 
 	rt, err := LoadRoundTrip(c)
 	if err != nil {
@@ -61,9 +102,13 @@ func RunParity(t *testing.T, c *Case, evalStart, evalEnd time.Time, step time.Du
 		)
 	}
 
-	query, ok := c.Section("query.promql")
+	querySection := parityQuerySections[p.Oracle]
+	if querySection == "" {
+		t.Fatalf("fixture %s: oracle %q has no runner in this lane", c.Name, p.Oracle)
+	}
+	query, ok := c.Section(querySection)
 	if !ok {
-		t.Fatalf("fixture %s: `parity:` requires a query.promql section", c.Name)
+		t.Fatalf("fixture %s: oracle %q requires a %s section", c.Name, p.Oracle, querySection)
 	}
 
 	// Serialize the whole engine span, same contract RunRoundTrip honours.
@@ -73,28 +118,101 @@ func RunParity(t *testing.T, c *Case, evalStart, evalEnd time.Time, step time.Du
 	db := OpenChDB(t)
 	ApplySeed(t, db, rt.Seed)
 
+	q := parityQuery{
+		Expr:  strings.TrimSpace(query),
+		Start: evalStart,
+		End:   evalEnd,
+		Step:  step,
+	}
+
+	var got []referenceSample
+	switch p.Oracle {
+	case OraclePrometheus:
+		got, err = evaluatePrometheusParity(t, db, c, q)
+	case OracleLoki:
+		if lokiParityEvaluator == nil {
+			t.Fatalf(
+				"fixture %s is enrolled against the %q oracle, but this lane was built without "+
+					"the `chdb_agpl_oracle` build tag, so the Loki oracle is compiled out and the "+
+					"fixture would be checked against nothing. Run this package with "+
+					"`-tags chdb,agpl_oracle,chdb_agpl_oracle`.", c.Name, p.Oracle,
+			)
+		}
+		got, err = lokiParityEvaluator(t, db, c, q)
+	default:
+		t.Fatalf("fixture %s: oracle %q has no runner in this lane", c.Name, p.Oracle)
+	}
+	if err != nil {
+		t.Fatalf("fixture %s: %v", c.Name, err)
+	}
+
+	compareAgainstReference(t, c, p, rt, got, comparesTimestamps(p.Oracle, step))
+}
+
+// parityQuerySections maps an oracle to the TXTAR section holding the
+// query it answers. A missing entry is what makes an oracle with no
+// runner in this lane fail loudly rather than evaluate nothing.
+var parityQuerySections = map[string]string{
+	OraclePrometheus: "query.promql",
+	OracleLoki:       "query.logql",
+}
+
+// comparesTimestamps decides whether the output timestamps participate in
+// the comparison, and the answer differs by head because the two heads
+// stamp an INSTANT result differently.
+//
+// Prometheus stamps an instant result at the EVALUATION INSTANT, while
+// cerberus's PromQL row carries the source sample time (`max(TimeUnix) AS
+// lwr_ts`) and the HTTP layer is what re-presents it at eval time.
+// Comparing those two numbers would compare two different quantities and
+// fail every sparse fixture for a reason unrelated to the query. Nothing
+// is lost from the bug classes this exists to catch: `timestamp()`
+// reports the sample's time as a VALUE.
+//
+// The LogQL instant lowering has no such asymmetry — cerberus projects
+// `now64(?) AS TimeUnix`, the eval instant itself, which is exactly what
+// Loki stamps — so its timestamps ARE compared, and a fixture that
+// anchored its answer to the wrong instant fails here.
+//
+// A RANGE query on either head stamps at step anchors on both sides, so
+// timestamps are always compared there.
+func comparesTimestamps(oracleName string, step time.Duration) bool {
+	return step > 0 || oracleName == OracleLoki
+}
+
+// evaluatePrometheusParity answers q with the real upstream Prometheus
+// engine over the rows the seed actually landed in chDB.
+func evaluatePrometheusParity(
+	t *testing.T, db *sql.DB, c *Case, q parityQuery,
+) ([]referenceSample, error) {
+	t.Helper()
+
 	series, err := readSeededSeries(db)
 	if err != nil {
-		t.Fatalf("read seeded series back: %v", err)
+		return nil, fmt.Errorf("read seeded series back: %w", err)
 	}
 	if len(series) == 0 {
-		t.Fatalf(
+		return nil, fmt.Errorf(
 			"fixture %s: seed produced no readable series, so the reference engine would "+
 				"trivially agree with any answer", c.Name,
 		)
 	}
 
 	got, err := oracle.Evaluate(t, series, oracle.Query{
-		Expr:  trimQuery(query),
-		Start: evalStart,
-		End:   evalEnd,
-		Step:  step,
+		Expr:  q.Expr,
+		Start: q.Start,
+		End:   q.End,
+		Step:  q.Step,
 	})
 	if err != nil {
-		t.Fatalf("fixture %s: %v", c.Name, err)
+		return nil, err
 	}
 
-	compareAgainstReference(t, c, p, rt, got, step > 0)
+	out := make([]referenceSample, 0, len(got))
+	for _, r := range got {
+		out = append(out, referenceSample{Labels: r.Labels, TMillis: r.TMillis, Value: r.Value})
+	}
+	return out, nil
 }
 
 // seededMetricsTables are the metric tables a PromQL fixture's seed may
@@ -167,27 +285,11 @@ func scanSeriesRows(rows *sql.Rows, byKey map[string]*oracle.Series) error {
 	return rows.Err()
 }
 
-// compareAgainstReference is the assertion itself.
-//
-// # Why an instant query does not compare timestamps
-//
-// Prometheus stamps an INSTANT query's output at the EVALUATION INSTANT,
-// not at the source sample's own time. Cerberus's SQL row carries the
-// source sample time (`max(TimeUnix) AS lwr_ts`), and the HTTP layer is
-// what presents it at eval time. Comparing those two numbers at this layer
-// would compare two different quantities and fail every sparse fixture for
-// a reason unrelated to the query — so for an instant query the comparison
-// is over label sets and VALUES, and the reference's own timestamps are
-// asserted to be the eval instant instead.
-//
-// Nothing is lost from the bug classes this exists to catch: `timestamp()`
-// reports the sample's time as a VALUE, so a wrong sample-time selection
-// still shows up in the value comparison.
-//
-// A RANGE query is different — both sides stamp at step anchors — so
-// timestamps ARE compared there.
+// compareAgainstReference is the assertion itself. See
+// [comparesTimestamps] for which axes participate and why.
 func compareAgainstReference(
-	t *testing.T, c *Case, p *Parity, rt *RoundTripSections, got []oracle.Result, isRange bool,
+	t *testing.T, c *Case, p *Parity, rt *RoundTripSections,
+	got []referenceSample, compareTimestamps bool,
 ) {
 	t.Helper()
 
@@ -213,11 +315,15 @@ func compareAgainstReference(
 				c.Name, i, g.Labels, w.Labels)
 			continue
 		}
+		// oracle.EqualValues is the promql oracle's NaN-aware float
+		// predicate. It is used for BOTH heads on purpose: sample equality
+		// is one rule, not one per head, and duplicating it would let the
+		// two drift into disagreeing about what "equal" means.
 		if !oracle.EqualValues(g.Value, w.Value) {
 			t.Errorf("fixture %s sample %d (%v): value differs\n  reference: %v\n  cerberus:  %v",
 				c.Name, i, g.Labels, g.Value, w.Value)
 		}
-		if isRange && g.TMillis != w.TMillis {
+		if compareTimestamps && g.TMillis != w.TMillis {
 			t.Errorf("fixture %s sample %d (%v): timestamp differs\n  reference: %d\n  cerberus:  %d",
 				c.Name, i, g.Labels, g.TMillis, w.TMillis)
 		}
@@ -227,8 +333,6 @@ func compareAgainstReference(
 		t.Logf("fixture %s compared with scope %q", c.Name, p.Scope)
 	}
 }
-
-func trimQuery(q string) string { return strings.TrimSpace(q) }
 
 // labelKey renders a label set as a stable, comparable string. Both sides
 // are keyed through this one function so series identity can never differ
@@ -298,8 +402,8 @@ const (
 // whose projection is not the canonical four-column Sample shape cannot be
 // parity-checked at this layer, and silently comparing nothing would be
 // the hollow green this mechanism exists to prevent.
-func referenceShapeOfExpectedRows(rt *RoundTripSections) ([]oracle.Result, error) {
-	out := make([]oracle.Result, 0, len(rt.ExpectedRows))
+func referenceShapeOfExpectedRows(rt *RoundTripSections) ([]referenceSample, error) {
+	out := make([]referenceSample, 0, len(rt.ExpectedRows))
 	for i, row := range rt.ExpectedRows {
 		if len(row) != expectedRowArity {
 			return nil, fmt.Errorf(
@@ -332,7 +436,7 @@ func referenceShapeOfExpectedRows(rt *RoundTripSections) ([]oracle.Result, error
 		if name != "" {
 			lbls[promNameLabel] = name
 		}
-		out = append(out, oracle.Result{Labels: lbls, TMillis: ts, Value: value})
+		out = append(out, referenceSample{Labels: lbls, TMillis: ts, Value: value})
 	}
 
 	sort.SliceStable(out, func(i, j int) bool {

--- a/test/spec/parity_loki_chdb.go
+++ b/test/spec/parity_loki_chdb.go
@@ -1,0 +1,271 @@
+//go:build chdb_agpl_oracle
+
+// Package spec — the Loki half of the parity layer.
+//
+// This file is the ONLY thing in package spec that reaches the AGPLv3
+// Loki engine, and it is compiled only under the synthetic
+// `chdb_agpl_oracle` tag that CI sets alongside `chdb` and `agpl_oracle`
+// (see .github/workflows/chdb.yml's roundtrip matrix). parity_chdb.go
+// reaches it through a nil-by-default function variable, so the plain
+// `chdb` build configuration links no AGPL code at all and a
+// Loki-enrolled fixture in a lane without the tag fails loudly instead
+// of being silently unchecked.
+//
+// # What the reference can see, and what it cannot
+//
+// Upstream's in-process querier (logql.NewMockQuerier) processes every
+// entry with `labels.EmptyLabels()` for structured metadata, so entry
+// StructuredMetadata is DISCARDED before the pipeline ever runs. A
+// fixture whose seed populates LogAttributes — cerberus's
+// structured-metadata carrier — would therefore have the two engines
+// answering over different data, and so would one that populates
+// SeverityText, which cerberus folds into the synthesised
+// `detected_level` label and into `level` grouping keys. Neither has any
+// counterpart the reference can be handed.
+//
+// [readSeededStreams] refuses such a fixture with a named error rather
+// than translating a subset of the row and comparing anyway. A quiet
+// subset comparison is the exact hollow green the parity layer exists to
+// eliminate: it would run, pass, and prove nothing about the columns it
+// dropped.
+package spec
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+
+	oracle "github.com/tsouza/cerberus/test/spec/parityoracle/logql"
+)
+
+func init() { lokiParityEvaluator = evaluateLokiParity }
+
+// logsTable is the single table a LogQL fixture's seed populates. LogQL
+// has one source relation, unlike PromQL's per-type metric tables, so the
+// reader names it directly rather than unioning a set.
+const logsTable = "otel_logs"
+
+// Column names in the OTel-CH logs layout that this reader understands.
+// They are spelled here rather than imported from internal/schema on
+// purpose: an oracle that took its column names from the system under
+// test would agree with it about the layout by construction, and the
+// disjointness gate in test/regression rejects the import outright.
+const (
+	colTimestamp          = "Timestamp"
+	colBody               = "Body"
+	colResourceAttributes = "ResourceAttributes"
+	colLogAttributes      = "LogAttributes"
+	colSeverityText       = "SeverityText"
+)
+
+// evaluateLokiParity answers q with the real upstream Loki engine over
+// the rows the seed actually landed in chDB.
+func evaluateLokiParity(
+	t *testing.T, db *sql.DB, c *Case, q parityQuery,
+) ([]referenceSample, error) {
+	t.Helper()
+
+	streams, err := readSeededStreams(db)
+	if err != nil {
+		return nil, err
+	}
+	if len(streams) == 0 {
+		return nil, fmt.Errorf(
+			"fixture %s: seed produced no readable streams, so the reference engine would "+
+				"trivially agree with any answer", c.Name,
+		)
+	}
+
+	got, err := oracle.Evaluate(t, streams, oracle.Query{
+		Expr:  q.Expr,
+		Start: q.Start,
+		End:   q.End,
+		Step:  q.Step,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]referenceSample, 0, len(got))
+	for _, r := range got {
+		out = append(out, referenceSample{Labels: r.Labels, TMillis: r.TMillis, Value: r.Value})
+	}
+	return out, nil
+}
+
+// readSeededStreams reads the seeded rows back OUT of chDB and groups
+// them into reference-engine streams.
+//
+// Reading back rather than re-parsing the `seed:` text is deliberate: it
+// shows the oracle the data as it ACTUALLY LANDED — after DEFAULTs, after
+// coercion — instead of as the SQL claims it will land. Otherwise a
+// disagreement about what the seed means would be invisible to exactly
+// the check meant to find disagreements.
+func readSeededStreams(db *sql.DB) ([]oracle.Stream, error) {
+	present, err := logsTableColumns(db)
+	if err != nil {
+		return nil, err
+	}
+	for _, required := range []string{colTimestamp, colBody, colResourceAttributes} {
+		if !present[required] {
+			return nil, fmt.Errorf(
+				"fixture seeds %s without a %s column, so its rows cannot be expressed as Loki "+
+					"streams (label set, timestamp, line). This fixture cannot be parity-checked "+
+					"against the Loki engine", logsTable, required,
+			)
+		}
+	}
+
+	// The Map column round-trips through toJSONString because chdb-go's
+	// native Map scan panics inside parquet-go (see roundtrip.go).
+	projection := []string{
+		"toUnixTimestamp64Milli(`" + colTimestamp + "`)",
+		"`" + colBody + "`",
+		"toJSONString(`" + colResourceAttributes + "`)",
+	}
+	opaque := []string{}
+	for _, col := range []string{colLogAttributes, colSeverityText} {
+		if !present[col] {
+			continue
+		}
+		opaque = append(opaque, col)
+		projection = append(projection, "toString(`"+col+"`)")
+	}
+
+	//nolint:gosec // every fragment comes from the constants above, not from fixture text.
+	query := "SELECT " + strings.Join(projection, ", ") +
+		" FROM `" + logsTable + "` ORDER BY `" + colTimestamp + "`"
+	rows, err := db.Query(query)
+	if err != nil {
+		return nil, fmt.Errorf("read seeded rows back: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	byKey := map[string]*oracle.Stream{}
+	for rows.Next() {
+		var tsMillis int64
+		var body, attrsJSON string
+		opaqueVals := make([]string, len(opaque))
+		dest := []any{&tsMillis, &body, &attrsJSON}
+		for i := range opaqueVals {
+			dest = append(dest, &opaqueVals[i])
+		}
+		if err := rows.Scan(dest...); err != nil {
+			return nil, fmt.Errorf("scan seeded row: %w", err)
+		}
+		for i, col := range opaque {
+			if err := rejectOpaqueColumn(col, opaqueVals[i]); err != nil {
+				return nil, err
+			}
+		}
+
+		lbls, err := labelsFromResourceAttributes(attrsJSON)
+		if err != nil {
+			return nil, err
+		}
+		key := labelKey(lbls)
+		s, ok := byKey[key]
+		if !ok {
+			s = &oracle.Stream{Labels: lbls}
+			byKey[key] = s
+		}
+		s.Entries = append(s.Entries, oracle.Entry{TMillis: tsMillis, Line: body})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read seeded rows back: %w", err)
+	}
+
+	out := make([]oracle.Stream, 0, len(byKey))
+	for _, s := range byKey {
+		out = append(out, *s)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return labelKey(out[i].Labels) < labelKey(out[j].Labels)
+	})
+	return out, nil
+}
+
+// emptyMapJSON is what `toJSONString` renders an empty CH Map as. A
+// column holding it carries no information, so it is not an obstacle to
+// parity.
+const emptyMapJSON = "{}"
+
+// rejectOpaqueColumn fails a fixture whose seed populated a column the
+// reference engine cannot be shown.
+//
+// This is not a scope knob and there is no way to wave it through: the
+// data is genuinely unreachable from upstream's in-process querier, so a
+// comparison over the remaining columns would be a comparison of two
+// different questions.
+func rejectOpaqueColumn(column, value string) error {
+	if value == "" || value == emptyMapJSON {
+		return nil
+	}
+	return fmt.Errorf(
+		"seeded rows carry a non-empty %s (%q), which the reference engine cannot observe: "+
+			"upstream's in-process querier processes every entry with an EMPTY structured-metadata "+
+			"label set, and cerberus additionally folds %s into the synthesised `detected_level` "+
+			"label. Comparing the two answers would compare two different questions, so this "+
+			"fixture cannot be enrolled against the Loki oracle",
+		column, value, colSeverityText,
+	)
+}
+
+// labelsFromResourceAttributes builds the reference-engine stream label
+// set for one seeded row.
+//
+// ResourceAttributes is the whole of it. The OTel-CH top-level columns
+// (SeverityText, TraceId, ServiceName and friends) are deliberately NOT
+// synthesised into labels here: deciding which column becomes which label
+// is precisely the schema mapping cerberus's lowering makes, and
+// reproducing that decision inside the oracle would make the oracle agree
+// with the lowering by construction on exactly the axis a schema bug
+// would move.
+func labelsFromResourceAttributes(attrsJSON string) (map[string]string, error) {
+	out := map[string]string{}
+	trimmed := strings.TrimSpace(attrsJSON)
+	if trimmed == "" || trimmed == emptyMapJSON {
+		return out, nil
+	}
+	if err := json.Unmarshal([]byte(trimmed), &out); err != nil {
+		return nil, fmt.Errorf("decode %s %q: %w", colResourceAttributes, attrsJSON, err)
+	}
+	return out, nil
+}
+
+// logsTableColumns reports which columns the fixture's seed DDL actually
+// declared. Seeds declare only the columns their own query needs, so the
+// reader adapts to the table in front of it rather than assuming the full
+// OTel-CH layout.
+func logsTableColumns(db *sql.DB) (map[string]bool, error) {
+	rows, err := db.Query(
+		"SELECT name FROM system.columns WHERE database = currentDatabase() AND table = ?",
+		logsTable,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("read %s column list: %w", logsTable, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := map[string]bool{}
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, fmt.Errorf("scan %s column name: %w", logsTable, err)
+		}
+		out[name] = true
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read %s column list: %w", logsTable, err)
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf(
+			"seed created no %s table, so there is nothing for the reference engine to read",
+			logsTable,
+		)
+	}
+	return out, nil
+}

--- a/test/spec/parityoracle/logql/oracle.go
+++ b/test/spec/parityoracle/logql/oracle.go
@@ -1,0 +1,331 @@
+//go:build agpl_oracle
+
+// Package logql evaluates a fixture's query on the REAL upstream Loki
+// query engine, so a TXTAR fixture's answer can be checked against
+// something other than cerberus's own output.
+//
+// It is the LogQL sibling of test/spec/parityoracle/promql and exists
+// for the same reason: `expected_rows:` is regenerated FROM cerberus's
+// own output, so a wrong lowering gets its wrong answer re-pinned and
+// passes forever. The reference answer here is computed live on every
+// run and stored nowhere, so there is no artefact for `just
+// update-golden` to overwrite.
+//
+// # The one rule this package exists to enforce
+//
+// It imports NOTHING from internal/{promql,logql,traceql,chplan,chsql,
+// optimizer,schema}. An oracle that shares code with the system under
+// test cannot disagree with it about the thing they share, so any such
+// import silently converts this package from an oracle into a mirror —
+// and a mirror always agrees. test/regression's parity contract test
+// enforces the rule mechanically with `go list -deps -test`, under this
+// package's own build configuration, because a rule this easy to break
+// by accident and this invisible when broken cannot be left to review.
+//
+// The same reasoning rules out reusing compatibility/loki/cmd/seed's
+// row-to-stream conversion, which is otherwise exactly this translation:
+// it imports internal/logql and internal/schema. Being equal by
+// construction is right for the compat MIRROR, whose job is to put
+// identical data into both backends, and disqualifying here.
+//
+// # Why this is behind the agpl_oracle build tag
+//
+// github.com/grafana/loki/v3/pkg/logql is AGPLv3 and cerberus ships
+// under Apache-2.0 (invariant 14). What protects the binary is
+// REACHABILITY from ./cmd/cerberus, which .github/scripts/agpl-clean.mjs
+// measures; the `agpl_oracle` tag keeps this package out of every normal
+// build, and the gate asserts the binary's dependency closure stays
+// AGPL-free.
+//
+// # What the reference can and cannot see
+//
+// [logql.NewMockQuerier] is the upstream in-process Querier. Its
+// processStream/processSeries helpers call the pipeline with
+// `labels.EmptyLabels()` for structured metadata, so entries'
+// StructuredMetadata is DISCARDED by the reference engine. That is a
+// hard boundary rather than an inconvenience: a fixture whose seed
+// populates LogAttributes (cerberus's structured-metadata carrier) or
+// SeverityText would have the two engines answering over different data,
+// and the caller must refuse such a fixture loudly rather than compare
+// two different questions. [Stream] therefore models only what the
+// reference can actually observe — stream labels, timestamp, line.
+package logql
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/user"
+	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/grafana/loki/v3/pkg/logql"
+	"github.com/grafana/loki/v3/pkg/logqlmodel"
+	"github.com/grafana/loki/v3/pkg/util/validation"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/promql/parser"
+)
+
+// mockQuerierShards is the shard count handed to [logql.NewMockQuerier].
+// Zero means "do not shard": the fixture corpus asks unsharded queries,
+// and sharding would change which streams a query observes for a reason
+// that has nothing to do with the lowering under test.
+const mockQuerierShards = 0
+
+// entryLimit bounds the number of log entries the reference engine will
+// return for a log query. It is deliberately far above any fixture's
+// working set — the corpus seeds a handful of lines per stream — so a
+// fixture can never pass or fail because of the limit rather than
+// because of the query.
+const entryLimit = 1_000_000
+
+// referenceTenant is the org id injected into the evaluation context.
+// Loki's engine resolves a tenant on every Exec and fails with "no org
+// id" without one; the corpus is single-tenant, so the value only has to
+// exist.
+const referenceTenant = "cerberus-parity"
+
+// maxSeries bounds how many series one evaluation may produce, and
+// queryTimeout bounds how long it may take. Both are deliberately far
+// beyond any fixture's working set, for the same reason as [entryLimit]:
+// a limit that can bite is a second thing a fixture might be failing on.
+const (
+	maxSeries    = math.MaxInt32
+	queryTimeout = time.Hour
+)
+
+// referenceLimits is the per-tenant limit set the reference engine runs
+// under.
+//
+// Upstream ships logql.NoLimits, and this type exists because that value
+// hard-disables multi-variant queries (`variants(...)`) through an
+// unexported field. Inheriting that would exclude a whole LogQL surface
+// from parity for an INSTANCE-CONFIGURATION reason rather than a
+// semantic one — the reference engine implements variants perfectly well
+// — and an exclusion nobody can lift is exactly the shape invariant 7
+// forbids. Every knob here is therefore set explicitly, at a value that
+// cannot decide a fixture's answer.
+type referenceLimits struct{}
+
+func (referenceLimits) MaxQuerySeries(context.Context, string) int { return maxSeries }
+
+func (referenceLimits) MaxQueryRange(context.Context, string) time.Duration { return 0 }
+
+func (referenceLimits) QueryTimeout(context.Context, string) time.Duration { return queryTimeout }
+
+func (referenceLimits) BlockedQueries(context.Context, string) []*validation.BlockedQuery {
+	return nil
+}
+
+func (referenceLimits) EnableMultiVariantQueries(string) bool { return true }
+
+func (referenceLimits) MaxScanTaskParallelism(string) int { return 0 }
+
+func (referenceLimits) DebugEngineTasks(string) bool { return false }
+
+func (referenceLimits) DebugEngineStreams(string) bool { return false }
+
+// Stream is one input log stream: an identifying label set plus its
+// entries, exactly as they were read back out of ClickHouse.
+type Stream struct {
+	// Labels is the stream's full label set.
+	Labels map[string]string
+
+	// Entries are the log lines, which need not be evenly spaced.
+	Entries []Entry
+}
+
+// Entry is one log line at an exact millisecond timestamp.
+type Entry struct {
+	// TMillis is the entry time in Unix milliseconds.
+	TMillis int64
+
+	// Line is the log line itself.
+	Line string
+}
+
+// Result is one output sample from the reference engine, flattened so
+// the caller can compare without depending on Loki's own types.
+type Result struct {
+	// Labels is the output series' label set.
+	Labels map[string]string
+
+	// TMillis is the output timestamp in Unix milliseconds.
+	TMillis int64
+
+	// Value is the output value.
+	Value float64
+}
+
+// Query describes one evaluation to run.
+type Query struct {
+	// Expr is the LogQL expression, verbatim from the fixture.
+	Expr string
+
+	// Start is the instant for an instant query, or the range start.
+	Start time.Time
+
+	// End equals Start for an instant query.
+	End time.Time
+
+	// Step is zero for an instant query, and the range step otherwise.
+	Step time.Duration
+}
+
+// IsRange reports whether this is a range query.
+func (q Query) IsRange() bool { return q.Step > 0 }
+
+// Evaluate runs q against the real Loki engine over streams, and returns
+// the resulting samples sorted deterministically.
+//
+// It returns an error rather than failing the test so the caller can
+// attribute a failure precisely: a Loki PARSE error on a fixture's query
+// usually means the fixture exercises a cerberus extension that upstream
+// does not accept, which is a fact about the fixture and not a parity
+// failure.
+func Evaluate(tb testing.TB, streams []Stream, q Query) ([]Result, error) {
+	tb.Helper()
+
+	engine := logql.NewEngine(
+		logql.EngineOpts{},
+		logql.NewMockQuerier(mockQuerierShards, toLokiStreams(streams)),
+		referenceLimits{},
+		log.NewNopLogger(),
+	)
+
+	step, interval := q.Step, time.Duration(0)
+	params, err := logql.NewLiteralParams(
+		q.Expr, q.Start, q.End, step, interval, logproto.FORWARD, entryLimit, nil, nil,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("reference engine rejected the query: %w", err)
+	}
+
+	ctx := user.InjectOrgID(context.Background(), referenceTenant)
+	res, err := engine.Query(params).Exec(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("reference engine evaluation failed: %w", err)
+	}
+	return flatten(res.Data)
+}
+
+// toLokiStreams converts the transport-free [Stream] shape into Loki's
+// own push type.
+//
+// The label set is rendered through prometheus/model/labels because that
+// is the exact form MockQuerier parses back — building the `{k="v"}`
+// text by hand would introduce a second, subtly different quoting rule
+// between the two halves of one round trip.
+//
+// StructuredMetadata is deliberately never populated: MockQuerier
+// discards it (see the package doc), so writing it here would make the
+// input look richer than what the engine actually evaluates.
+func toLokiStreams(streams []Stream) []logproto.Stream {
+	out := make([]logproto.Stream, 0, len(streams))
+	for _, s := range streams {
+		entries := make([]logproto.Entry, 0, len(s.Entries))
+		for _, e := range s.Entries {
+			entries = append(entries, logproto.Entry{
+				Timestamp: time.UnixMilli(e.TMillis).UTC(),
+				Line:      e.Line,
+			})
+		}
+		out = append(out, logproto.Stream{
+			Labels:  labels.FromMap(s.Labels).String(),
+			Entries: entries,
+		})
+	}
+	return out
+}
+
+// flatten converts Loki's result value into the transport-free Result
+// shape, sorted by (labels, timestamp) so comparison never depends on
+// the engine's internal ordering.
+//
+// A LOG query's answer ([logqlmodel.Streams]) is rejected rather than
+// coerced. Its shape is lines, not samples, and cerberus's own answer
+// for such a fixture is a `SELECT *` row set whose column layout is
+// whatever the fixture's seed DDL happened to declare — there is no
+// honest element-wise comparison between the two, and manufacturing one
+// would manufacture a green. A fixture enrolled with a log query fails
+// here, loudly, rather than being quietly compared against nothing.
+func flatten(v parser.Value) ([]Result, error) {
+	var out []Result
+
+	switch val := v.(type) {
+	case promql.Matrix:
+		for _, s := range val {
+			if len(s.Histograms) > 0 {
+				return nil, histogramValuedErr(s.Metric)
+			}
+			for _, p := range s.Floats {
+				out = append(out, Result{Labels: s.Metric.Map(), TMillis: p.T, Value: p.F})
+			}
+		}
+	case promql.Vector:
+		for _, s := range val {
+			if s.H != nil {
+				return nil, histogramValuedErr(s.Metric)
+			}
+			out = append(out, Result{Labels: s.Metric.Map(), TMillis: s.T, Value: s.F})
+		}
+	case promql.Scalar:
+		out = append(out, Result{Labels: map[string]string{}, TMillis: val.T, Value: val.V})
+	case logqlmodel.Streams:
+		return nil, fmt.Errorf(
+			"reference answer is %d log stream(s), not samples; a log query's answer cannot be "+
+				"compared element-wise against a fixture's `expected_rows:`, whose column layout "+
+				"is the fixture's own `SELECT *` projection. Enrol metric queries only",
+			len(val),
+		)
+	default:
+		return nil, fmt.Errorf("reference engine returned unsupported value type %T", v)
+	}
+
+	sortResults(out)
+	return out, nil
+}
+
+func histogramValuedErr(m labels.Labels) error {
+	return fmt.Errorf(
+		"reference answer for %s is histogram-valued; cerberus's result path is float-only, "+
+			"so this fixture cannot be parity-checked until native-histogram encoding lands",
+		m.String(),
+	)
+}
+
+// sortResults orders by label set then timestamp. Deterministic ordering
+// is what lets the caller compare element-wise without re-deriving
+// series identity.
+func sortResults(rs []Result) {
+	sort.SliceStable(rs, func(i, j int) bool {
+		li, lj := labels.FromMap(rs[i].Labels).String(), labels.FromMap(rs[j].Labels).String()
+		if li != lj {
+			return li < lj
+		}
+		return rs[i].TMillis < rs[j].TMillis
+	})
+}
+
+// EqualValues reports whether two float samples agree.
+//
+// NaN==NaN is TRUE here. LogQL produces NaN as a legitimate answer
+// (0/0, a quantile over an empty window), and Go's float comparison
+// would call two such answers different, failing fixtures that actually
+// agree.
+//
+// Everything else is EXACT. This is deliberate and is the reason no
+// epsilon appears anywhere in this package: cerberus and Loki evaluate
+// the same IEEE-754 doubles, so a real disagreement is a real bug, and
+// an epsilon would be a tolerance — the shape invariant 7 forbids —
+// dressed up as a numeric constant.
+func EqualValues(a, b float64) bool {
+	if math.IsNaN(a) && math.IsNaN(b) {
+		return true
+	}
+	return a == b
+}


### PR DESCRIPTION
## Follow-on to #1983

Work started while #1983 was still open, so this branched off its head. #1983 merged mid-flight and
this branch was rebased onto `origin/main`; the diff below is the LogQL half only.

## What this is

The LogQL sibling of the PromQL parity layer #1983 introduced.

`expected_rows` is not an oracle. `RunRoundTrip` executes cerberus's own emitted SQL and, under
`GOLDEN_UPDATE=1`, writes the result straight back into the fixture. A fixture's "expected" answer
is therefore whatever cerberus most recently produced, so a wrong lowering gets its wrong answer
re-pinned and passes forever.

`test/spec/parityoracle/logql` evaluates a fixture's query on the actual upstream Loki
`QueryEngine`, in-process, over the same seeded rows read back out of chDB. The reference answer is
**computed on every run and stored nowhere**, so there is no artefact for regeneration to
overwrite: absorption is not detected, it is impossible. What the fixture stores is the CONTRACT
(`-- parity --`: oracle, endpoint, scope).

## The AGPL boundary

`grafana/loki/v3/pkg/logql` is AGPLv3 and cerberus ships Apache-2.0 (invariant 14). What protects
the binary is REACHABILITY from `./cmd/cerberus`, which `agpl-clean.mjs` measures.

- The oracle sits behind `agpl_oracle`.
- The runner half (`test/spec/parity_loki_chdb.go`) sits behind the synthetic single-term
  `chdb_agpl_oracle` tag CI already sets alongside `chdb` + `agpl_oracle` — every `//go:build` line
  in this tree is one term, so `chdb && agpl_oracle` cannot be spelled directly.
- `parity_chdb.go` reaches it through a nil-by-default function variable, so the **plain `chdb`
  build links no AGPL code at all**, and a Loki-enrolled fixture in a lane without the tag FAILS
  loudly instead of being silently unchecked (demonstrated below).

`node .github/scripts/agpl-clean.mjs` still reports *0 AGPL packages across cmd/cerberus's 662
build deps — binary is licence-clean*.

## Where it runs

`chdb.yml`'s `roundtrip (logql)` leg — a required status check — now passes
`-tags chdb,agpl_oracle,chdb_agpl_oracle` via a per-leg matrix `include`. The property lane was the
other candidate, but it is a green no-op on non-release PRs, so wiring the check there would have
been a check that never runs on the PRs that need it.

`agpl-oracle.yml` gains `./test/spec/...` so the oracle package itself is compiled on every PR, and
`agpl_oracle_tag_set_test.go` gains the matching `test/spec/` scope so a future tagged file there
cannot arrive without lane coverage.

## Enrolment: 18 LogQL fixtures (floor 215 → 233)

`absent_over_time_instant`, `absent_over_time_range`, `avg_count_over_time`, `binop_literal_vector`,
`binop_scalar_vector_agg`, `binop_vv_add_bool_ignored`, `binop_vv_add_on`, `binop_vv_compare_filter`,
`binop_vv_group_left_with_agg_legs`, `label_replace_backref_above_ch_ceiling`,
`range_agg_without_grouping_unwrap`, `range_mode_sum_count_over_time`,
`range_mode_sum_rate_sparse_trim`, `sum_by_job_rate`, `sum_count_over_time`,
`sum_count_over_time_line_filter`, `sum_rate`, `variants_grouped`.

Three of those are range queries, so step-anchored timestamps are compared too. LogQL **instant**
queries compare timestamps as well, unlike the PromQL path: cerberus projects `now64(?) AS TimeUnix`
— the eval instant itself — which is exactly what Loki stamps, so there is no asymmetry to excuse.

## What could NOT be enrolled, and why

Stated plainly rather than quietly skipped.

**98 fixtures ask LOG queries.** Loki answers those with `logqlmodel.Streams`; cerberus's answer is
a `SELECT *` row set whose column layout is whatever the fixture's seed DDL happened to declare
(`decolorize.txtar`'s `expected_rows` is a single cell, because its table has one non-materialised
column). There is no honest element-wise comparison between the two shapes. The oracle therefore
**rejects a stream-valued answer with a named error** rather than manufacturing one — a fixture
enrolled with a log query fails loudly.

**13 fixtures' answers carry `detected_level`.** Upstream Loki attaches that at INGEST as structured
metadata when level discovery is on; cerberus synthesises it at QUERY time from the OTel columns.
The reference engine has no counterpart and — see the next paragraph — cannot be handed one. This is
a real, deliberate, documented behavioural difference in the data model, not a tolerance.

**12 fixtures seed `SeverityText`, `LogAttributes` or `TraceId`.** Upstream's in-process querier
(`logql.NewMockQuerier`) processes every entry with `labels.EmptyLabels()` for structured metadata —
`processStream` / `processSeries` in `pkg/logql/test_utils.go` — so entry `StructuredMetadata` is
discarded before the pipeline ever runs. Those columns are simply unreachable from the reference.
`readSeededStreams` refuses such a fixture **by name** rather than translating a subset and comparing
anyway.

That guard is deliberately **data-shaped, not answer-shaped**: it fires on the column being
populated, not on the two answers happening to differ. Some of those 12 would in fact agree today
(`map_key_order_count_over_time` seeds a uniform `SeverityText='INFO'`, which collapses to a single
stream on both sides). Refusing them anyway is the conservative reading, and it is the only one that
is mechanically checkable — an answer-shaped guard would be a judgement call per fixture, which is
how allow-lists start.

The remaining exclusions are fixtures whose emitted projection is not the canonical four-column
`(MetricName, Attributes, TimeUnix, Value)` Sample shape, which the row-layer comparator errors on
by name (inherited from #1983).

## Verification — the absorption demo

Injected a real bug: `emitRangeWindowLogRate` emitting `arrayMax` instead of `arraySum`, so
`rate({...}[r])` reports the max sample per window rather than the count. Fully self-consistent,
completely wrong.

**1. `just update-golden` absorbed it.** Bare invocation printed the derived shard list; running
exactly what it printed re-pinned 24 fixtures:

```
 test/spec/logql/sum_by_job_rate.txtar
-  ["", {"job": "billing"}, "2026-01-01T00:00:01Z", 0.01],
-  ["", {"job": "orders"},  "2026-01-01T00:00:01Z", 0.006666666666666667]
+  ["", {"job": "billing"}, "2026-01-01T00:00:01Z", 0.0033333333333333335],
+  ["", {"job": "orders"},  "2026-01-01T00:00:01Z", 0.0033333333333333335]

 test/spec/logql/sum_rate.txtar
-  ["", {}, "2026-01-01T00:00:01Z", 0.1]
+  ["", {}, "2026-01-01T00:00:01Z", 0.016666666666666666]
```

**2. The ordinary round-trip lane then reported ok** — green, self-consistent, and wrong:

```
$ go test -tags chdb -count=1 ./test/spec/logql/...
ok  	github.com/tsouza/cerberus/test/spec/logql	35.816s
```

**3. The parity check FAILED against the real Loki engine:**

```
$ go test -tags chdb,agpl_oracle,chdb_agpl_oracle -run 'TestLower/(sum_rate|sum_by_job_rate|range_mode_sum_rate_sparse_trim)$' ./internal/logql/
--- FAIL: TestLower/range_mode_sum_rate_sparse_trim
    fixture range_mode_sum_rate_sparse_trim sample 1 (map[]): value differs
      reference: 0.006666666666666667
      cerberus:  0.0033333333333333335
    ... (samples 2, 3, 4 likewise)
--- FAIL: TestLower/sum_by_job_rate
    fixture sum_by_job_rate sample 0 (map[job:billing]): value differs
      reference: 0.01
      cerberus:  0.0033333333333333335
    fixture sum_by_job_rate sample 1 (map[job:orders]): value differs
      reference: 0.006666666666666667
      cerberus:  0.0033333333333333335
--- FAIL: TestLower/sum_rate
    fixture sum_rate sample 0 (map[]): value differs
      reference: 0.1
      cerberus:  0.016666666666666666
FAIL
```

**4. `GOLDEN_UPDATE=1` could not turn it green** — the check has no update branch at all:

```
$ GOLDEN_UPDATE=1 go test -tags chdb,agpl_oracle,chdb_agpl_oracle -run 'TestLower/sum_rate$' ./internal/logql/
--- FAIL: TestLower/sum_rate
    fixture sum_rate sample 0 (map[]): value differs
      reference: 0.1
      cerberus:  0.016666666666666666
FAIL
```

**5. Reverted cleanly; the tree is green:**

```
$ git checkout -- . && git status --short     # (empty)
$ go test -tags chdb,agpl_oracle,chdb_agpl_oracle -run TestLower ./internal/logql/
ok  	github.com/tsouza/cerberus/internal/logql	33.028s
```

### Bonus: the nil-evaluator guard is not decorative

Running the enrolled fixtures in the plain `chdb` configuration — the one the LogQL leg used before
this PR — fails loudly rather than checking nothing:

```
$ go test -tags chdb -run 'TestLower/(sum_rate|sum_by_job_rate)$' ./internal/logql/
--- FAIL: TestLower/sum_rate
    fixture sum_rate is enrolled against the "loki" oracle, but this lane was built without the
    `chdb_agpl_oracle` build tag, so the Loki oracle is compiled out and the fixture would be
    checked against nothing. Run this package with `-tags chdb,agpl_oracle,chdb_agpl_oracle`.
```

### The disjointness gate fires for the new package

Adding `_ "github.com/tsouza/cerberus/internal/logql"` to the oracle:

```
--- FAIL: TestParityOracleImportsNoCerberusLowering
    parity oracle ./test/spec/parityoracle/... transitively imports
      github.com/tsouza/cerberus/internal/chplan            under build config agpl_oracle
      github.com/tsouza/cerberus/internal/schema            under build config agpl_oracle
      github.com/tsouza/cerberus/internal/chsql             under build config agpl_oracle
      github.com/tsouza/cerberus/internal/optimizer         under build config agpl_oracle
      github.com/tsouza/cerberus/internal/logql/logpattern  under build config agpl_oracle
      github.com/tsouza/cerberus/internal/logql/lsyntax     under build config agpl_oracle
      github.com/tsouza/cerberus/internal/logql             under build config agpl_oracle
```

The transitive pulls, not just the direct one.

### The scan had a hole, and it is now closed

`go list -deps -test ./test/spec/parityoracle/...` **exits 0** for a package whose build constraints
exclude every file — it silently omits it. Left alone, the gate would have reported clean over the
LogQL oracle it never read: the exact hollow green this layer exists to eliminate. The scan now runs
under both build configurations AND asserts each named oracle package was actually reached.
Verified by dropping `agpl_oracle` from the config list:

```
--- FAIL: TestParityOracleImportsNoCerberusLowering
    the disjointness scan never reached github.com/tsouza/cerberus/test/spec/parityoracle/logql
    under any of the build configurations [""].
```

## Files

- `test/spec/parityoracle/logql/oracle.go` — the reference evaluator (`agpl_oracle`). Imports
  nothing from cerberus. Declares its own `Limits` rather than inheriting `logql.NoLimits`, which
  hard-disables `variants(...)` through an unexported field — an instance-configuration exclusion
  nobody could lift.
- `test/spec/parity_loki_chdb.go` — the runner half (`chdb_agpl_oracle`): CH rows → Loki streams,
  written independently of cerberus's own lowering, plus the opaque-column refusal.
- `test/spec/parity_chdb.go` — oracle routing, one flattened `referenceSample` shape, one comparator.
- `internal/logql/lower_test.go` — `spec.RunParity` wiring and the eval-window mapping.
- `test/regression/parity_contract_test.go` — two-configuration scan, reachability assertion, floor
  215 → 233.
- `go.mod` — `go-kit/log` and `grafana/dskit` promoted from indirect to direct (the oracle names
  `log.NewNopLogger` and `user.InjectOrgID`; Loki's engine resolves a tenant on every `Exec`).
  Neither reaches `./cmd/cerberus`.

## Rebase note

#1989 (the 214-fixture PromQL enrolment wave) merged mid-flight and touched the same harness. This
branch was rebased onto it, the floor was resolved to 215 + 18 = 233 rather than replaced, and the
absorption demo above was **re-run after the rebase** — the roundtrip lane still reports `ok` on the
absorbed answer and the parity lane still fails with the same numbers.
