### PR TITLE
refactor(test): hoist duplicated instant-query wire helper into test/spec/wire

### DIFF
--- a/test/integration/promql/exotic_test.go
+++ b/test/integration/promql/exotic_test.go
@@ -3,13 +3,9 @@
 package promql
 
 import (
-	"context"
-	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/http/httptest"
-	"strconv"
 	"testing"
 
 	"github.com/tsouza/cerberus/internal/api/prom"
@@ -17,7 +13,22 @@ import (
 	"github.com/tsouza/cerberus/internal/schema"
 	"github.com/tsouza/cerberus/test/property"
 	oraclepromql "github.com/tsouza/cerberus/test/property/oracle/promql"
+	"github.com/tsouza/cerberus/test/spec/wire"
 )
+
+// exoticExtraEscapeChars are the punctuation bytes the exotic matrix's
+// richer expressions carry beyond wire's base escape set — arithmetic and
+// comparison operators, the `@` timestamp modifier, `:` in duration
+// literals, etc.
+const exoticExtraEscapeChars = "@:/*%^><!'"
+
+// exoticInstantOpts is the wire.InstantOptions this suite runs every
+// request with: the matrix deliberately includes top-level scalar
+// expressions (e.g. `-2^2`, `scalar(...)`), so AllowScalar is true.
+var exoticInstantOpts = wire.InstantOptions{
+	AllowScalar:      true,
+	ExtraEscapeChars: exoticExtraEscapeChars,
+}
 
 // TestExoticPromQL is the chDB-backed exotic-PromQL integration suite.
 //
@@ -63,7 +74,7 @@ func TestExoticPromQL(t *testing.T) {
 			EvalTs: EvalTs,
 		}
 		oracleOut := oraclepromql.Evaluate(ds, q, oraclepromql.Options{})
-		cerberusOut := runCerberusInstant(t.Context(), srv.URL, q)
+		cerberusOut := wire.RunInstant(t.Context(), srv.URL, q, exoticInstantOpts)
 		if oracleOut.Err != nil {
 			t.Fatalf("seed self-check: oracle errored: %v", oracleOut.Err)
 		}
@@ -83,7 +94,7 @@ func TestExoticPromQL(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			q := property.Query{String: tc.promql, EvalTs: tc.ts()}
 			oracleOut := oraclepromql.Evaluate(ds, q, oraclepromql.Options{})
-			cerberusOut := runCerberusInstant(t.Context(), srv.URL, q)
+			cerberusOut := wire.RunInstant(t.Context(), srv.URL, q, exoticInstantOpts)
 			// Instant queries stamp every row at the single eval instant,
 			// so the timestamp carries no information to assert on. The
 			// oracle stamps a top-level SCALAR at ts=0 while cerberus
@@ -98,158 +109,6 @@ func TestExoticPromQL(t *testing.T) {
 			}
 		})
 	}
-}
-
-// runCerberusInstant POSTs to /api/v1/query and decodes the Prom-shaped
-// response into a property.Outcome. It handles both the "vector"
-// resultType (the common case) and "scalar" (top-level scalar expressions
-// like scalar(...) and -2^2), reshaping the latter into the same
-// label-less single-row form the oracle's outcomeFromValue emits.
-//
-// Replicated from test/property/promql_test.go::runCerberusInstant (that
-// helper lives in package property_test and isn't importable) with the
-// scalar branch added for the exotic matrix.
-func runCerberusInstant(ctx context.Context, baseURL string, q property.Query) property.Outcome {
-	u := fmt.Sprintf("%s/api/v1/query?query=%s&time=%d", baseURL, urlEscape(q.String), q.EvalTs)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
-	if err != nil {
-		return property.Outcome{Err: fmt.Errorf("exotic: build request: %w", err)}
-	}
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return property.Outcome{Err: fmt.Errorf("exotic: query roundtrip: %w", err)}
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return property.Outcome{Err: fmt.Errorf("exotic: read body: %w", err)}
-	}
-
-	var parsed struct {
-		Status    string `json:"status"`
-		ErrorType string `json:"errorType"`
-		Error     string `json:"error"`
-		Data      struct {
-			ResultType string          `json:"resultType"`
-			Result     json.RawMessage `json:"result"`
-		} `json:"data"`
-	}
-	if err := json.Unmarshal(body, &parsed); err != nil {
-		return property.Outcome{Err: fmt.Errorf("exotic: decode body: %w; status=%d body=%s", err, resp.StatusCode, body)}
-	}
-	if parsed.Status != "success" {
-		// A failed status is a legitimate outcome — the oracle may fail on
-		// the same query too; CompareOutcomes treats both-erroring as
-		// agreement.
-		return property.Outcome{Err: fmt.Errorf("cerberus status=%q errorType=%q err=%q",
-			parsed.Status, parsed.ErrorType, parsed.Error)}
-	}
-
-	switch parsed.Data.ResultType {
-	case "vector":
-		return decodeVector(parsed.Data.Result)
-	case "scalar":
-		return decodeScalar(parsed.Data.Result)
-	default:
-		return property.Outcome{Err: fmt.Errorf("cerberus resultType=%q, want vector or scalar", parsed.Data.ResultType)}
-	}
-}
-
-func decodeVector(raw json.RawMessage) property.Outcome {
-	var result []prom.VectorSample
-	if err := json.Unmarshal(raw, &result); err != nil {
-		return property.Outcome{Err: fmt.Errorf("exotic: decode vector: %w", err)}
-	}
-	out := property.Outcome{Rows: make([]property.OutcomeRow, 0, len(result))}
-	for _, s := range result {
-		stripped := make(map[string]string, len(s.Metric))
-		for k, v := range s.Metric {
-			if k == "__name__" {
-				continue
-			}
-			stripped[k] = v
-		}
-		if s.Value == nil {
-			// A histogram-valued sample (s.Histogram set instead) has no
-			// float Value; this harness only exercises float-valued PromQL
-			// shapes today, so treat it as a decode error rather than a
-			// nil-pointer panic.
-			return property.Outcome{Err: fmt.Errorf("exotic: vector sample %v has no float value (histogram-valued?)", s.Metric)}
-		}
-		ts, val, perr := parseSample(*s.Value)
-		if perr != nil {
-			return property.Outcome{Err: fmt.Errorf("exotic: parse sample: %w", perr)}
-		}
-		out.Rows = append(out.Rows, property.OutcomeRow{Labels: stripped, TimestampMs: ts, Value: val})
-	}
-	return out
-}
-
-// decodeScalar reshapes a "scalar" resultType ([ts, "value"]) into the same
-// single label-less row at TimestampMs=0 the oracle emits for a top-level
-// scalar (see oracle/promql.outcomeFromValue).
-func decodeScalar(raw json.RawMessage) property.Outcome {
-	var s prom.Sample
-	if err := json.Unmarshal(raw, &s); err != nil {
-		return property.Outcome{Err: fmt.Errorf("exotic: decode scalar: %w", err)}
-	}
-	_, val, perr := parseSample(s)
-	if perr != nil {
-		return property.Outcome{Err: fmt.Errorf("exotic: parse scalar: %w", perr)}
-	}
-	return property.Outcome{Rows: []property.OutcomeRow{
-		{Labels: map[string]string{}, TimestampMs: 0, Value: val},
-	}}
-}
-
-// parseSample turns Prom's [seconds_float, value_string] shape into
-// (unix_milliseconds, float64). The value string may be "NaN" / "+Inf" /
-// "-Inf" — strconv.ParseFloat handles all three.
-func parseSample(s prom.Sample) (int64, float64, error) {
-	if len(s) < 2 {
-		return 0, 0, fmt.Errorf("expected 2-element sample, got %d", len(s))
-	}
-	tsSec, ok := s[0].(float64)
-	if !ok {
-		return 0, 0, fmt.Errorf("sample[0]: want float64, got %T (%v)", s[0], s[0])
-	}
-	valStr, ok := s[1].(string)
-	if !ok {
-		return 0, 0, fmt.Errorf("sample[1]: want string, got %T (%v)", s[1], s[1])
-	}
-	v, err := strconv.ParseFloat(valStr, 64)
-	if err != nil {
-		return 0, 0, fmt.Errorf("sample[1]: parse float %q: %w", valStr, err)
-	}
-	return int64(tsSec * 1000), v, nil
-}
-
-// urlEscape escapes the punctuation PromQL queries carry. Replicated from
-// the property test's helper (same character set, plus `@`, `:`, `/`, `*`,
-// `%`, `^`, `-`, `>`, `<`, `!`, `'` for the exotic matrix's richer
-// expressions).
-func urlEscape(s string) string {
-	const hex = "0123456789ABCDEF"
-	var out []byte
-	for i := 0; i < len(s); i++ {
-		c := s[i]
-		if shouldEscape(c) {
-			out = append(out, '%', hex[c>>4], hex[c&0xF])
-		} else {
-			out = append(out, c)
-		}
-	}
-	return string(out)
-}
-
-func shouldEscape(c byte) bool {
-	switch c {
-	case '{', '}', '"', '=', ',', '(', ')', '[', ']', ' ', '\n',
-		'+', '&', '@', ':', '/', '*', '%', '^', '>', '<', '!', '\'':
-		return true
-	}
-	return false
 }
 
 // zeroTimestamps sets every row's TimestampMs to 0 in place. Used to make

--- a/test/property/instant_window_test.go
+++ b/test/property/instant_window_test.go
@@ -24,7 +24,7 @@
 // # How it catches the bug
 //
 // Cerberus is driven through its REAL Prom HTTP handler with `time=T`
-// (the same runCerberusInstant the existing lane uses). WITH the fix the
+// (the same wire.RunInstant the existing lane uses). WITH the fix the
 // emitted window bound is a literal toDateTime64(T...) so the window
 // tracks T; WITHOUT the fix it is now64(9) — chDB wall-clock at execution
 // (~weeks after the 2026-05-13 seed anchor), so the (serverNow-range,
@@ -56,6 +56,7 @@ import (
 	"github.com/tsouza/cerberus/internal/schema"
 	"github.com/tsouza/cerberus/test/property"
 	"github.com/tsouza/cerberus/test/property/gen"
+	"github.com/tsouza/cerberus/test/spec/wire"
 )
 
 // minWindowSamplesFor is the minimum sample count the (T-range, T]
@@ -171,7 +172,7 @@ func TestPromQL_InstantWindowSweep_FromScratch(t *testing.T) {
 
 		wantVal, wantOK, valueExact := oracleInstantWindow(c)
 
-		got := runCerberusInstant(context.Background(), srv.URL, c.Query)
+		got := wire.RunInstant(context.Background(), srv.URL, c.Query, wire.InstantOptions{})
 		if got.Err != nil {
 			rt.Fatalf("instant-window sweep: cerberus error\nquery=%s evalTs=%d offset=%ds range=%ds scrape=%ds\nerr=%v",
 				c.Query.String, c.Query.EvalTs, c.EvalOffset, c.RangeSec, c.ScrapeSec, got.Err)

--- a/test/property/logql_test.go
+++ b/test/property/logql_test.go
@@ -78,6 +78,7 @@ import (
 	"github.com/tsouza/cerberus/test/property"
 	"github.com/tsouza/cerberus/test/property/gen"
 	oraclelogql "github.com/tsouza/cerberus/test/property/oracle/logql"
+	"github.com/tsouza/cerberus/test/spec/wire"
 )
 
 // TestLogQL_Property wires every layer together for the log-stream
@@ -154,7 +155,7 @@ func runCerberusLogQLInstant(ctx context.Context, baseURL string, q property.Que
 	u := fmt.Sprintf(
 		"%s/loki/api/v1/query_range?query=%s&start=%d&end=%d&step=60",
 		baseURL,
-		urlEscape(q.String),
+		wire.EscapeQuery(q.String, ""),
 		startTs,
 		endTs,
 	)

--- a/test/property/promql_test.go
+++ b/test/property/promql_test.go
@@ -89,13 +89,8 @@
 package property_test
 
 import (
-	"context"
-	"encoding/json"
-	"fmt"
-	"io"
 	"net/http"
 	"net/http/httptest"
-	"strconv"
 	"testing"
 
 	"pgregory.net/rapid"
@@ -106,6 +101,7 @@ import (
 	"github.com/tsouza/cerberus/test/property"
 	"github.com/tsouza/cerberus/test/property/gen"
 	oraclepromql "github.com/tsouza/cerberus/test/property/oracle/promql"
+	"github.com/tsouza/cerberus/test/spec/wire"
 )
 
 // TestPromQL_Property_FromScratch wires every layer together for the
@@ -141,7 +137,7 @@ func TestPromQL_Property_FromScratch(t *testing.T) {
 	// runs the query via the real Prom HTTP handler.
 	cerberusFn := func(d property.Dataset, q property.Query) property.Outcome {
 		cli.Seed(t, d.DDL)
-		return runCerberusInstant(t.Context(), srv.URL, q)
+		return wire.RunInstant(t.Context(), srv.URL, q, wire.InstantOptions{})
 	}
 
 	oracleFn := func(d property.Dataset, q property.Query) property.Outcome {
@@ -149,147 +145,4 @@ func TestPromQL_Property_FromScratch(t *testing.T) {
 	}
 
 	property.Run(t, property.Config{}, dgen, qgen, oracleFn, cerberusFn)
-}
-
-// runCerberusInstant POSTs to /api/v1/query and decodes the
-// Prom-shaped response into the framework's property.Outcome.
-//
-// Cerberus's instant-query response surfaces every series at the
-// requested eval timestamp (Prom convention — see prom/handler.go's
-// toVector); we extract that pair per series and reshape into the
-// canonical OutcomeRow shape.
-func runCerberusInstant(ctx context.Context, baseURL string, q property.Query) property.Outcome {
-	u := fmt.Sprintf(
-		"%s/api/v1/query?query=%s&time=%d",
-		baseURL,
-		urlEscape(q.String),
-		q.EvalTs,
-	)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
-	if err != nil {
-		return property.Outcome{Err: fmt.Errorf("property: build request: %w", err)}
-	}
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return property.Outcome{Err: fmt.Errorf("property: query roundtrip: %w", err)}
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return property.Outcome{Err: fmt.Errorf("property: read body: %w", err)}
-	}
-
-	var parsed struct {
-		Status    string `json:"status"`
-		ErrorType string `json:"errorType"`
-		Error     string `json:"error"`
-		Data      struct {
-			ResultType string              `json:"resultType"`
-			Result     []prom.VectorSample `json:"result"`
-		} `json:"data"`
-	}
-	if err := json.Unmarshal(body, &parsed); err != nil {
-		return property.Outcome{
-			Err: fmt.Errorf("property: decode body: %w; status=%d body=%s",
-				err, resp.StatusCode, body),
-		}
-	}
-	if parsed.Status != "success" {
-		// A failed-status response is a legitimate outcome — the
-		// bridge oracle may also fail on the same query. Surface
-		// the error to the comparator; both sides erroring still
-		// counts as agreement.
-		return property.Outcome{
-			Err: fmt.Errorf("cerberus returned status=%q errorType=%q err=%q",
-				parsed.Status, parsed.ErrorType, parsed.Error),
-		}
-	}
-	if parsed.Data.ResultType != "vector" {
-		// PR 1 generates instant-only queries, so cerberus must
-		// answer with vector. Treat anything else as a mismatch so
-		// the framework reports.
-		return property.Outcome{
-			Err: fmt.Errorf("cerberus returned resultType=%q, want vector",
-				parsed.Data.ResultType),
-		}
-	}
-
-	out := property.Outcome{Rows: make([]property.OutcomeRow, 0, len(parsed.Data.Result))}
-	for _, s := range parsed.Data.Result {
-		// Strip __name__ so the comparator's labelKey() compares
-		// only the user-defined labels (the oracle strips it too).
-		stripped := make(map[string]string, len(s.Metric))
-		for k, v := range s.Metric {
-			if k == "__name__" {
-				continue
-			}
-			stripped[k] = v
-		}
-
-		if s.Value == nil {
-			// A histogram-valued sample (s.Histogram set instead) has no
-			// float Value; this harness only exercises float-valued PromQL
-			// shapes today, so treat it as a decode error rather than a
-			// nil-pointer panic.
-			return property.Outcome{Err: fmt.Errorf("property: vector sample %v has no float value (histogram-valued?)", s.Metric)}
-		}
-		ts, val, perr := parseSample(*s.Value)
-		if perr != nil {
-			return property.Outcome{Err: fmt.Errorf("property: parse sample: %w", perr)}
-		}
-		out.Rows = append(out.Rows, property.OutcomeRow{
-			Labels:      stripped,
-			TimestampMs: ts,
-			Value:       val,
-		})
-	}
-	return out
-}
-
-// parseSample turns Prom's [seconds_float, value_string] wire shape
-// into (unix_milliseconds, float64).
-func parseSample(s prom.Sample) (int64, float64, error) {
-	if len(s) < 2 {
-		return 0, 0, fmt.Errorf("expected 2-element sample, got %d", len(s))
-	}
-	tsSec, ok := s[0].(float64)
-	if !ok {
-		return 0, 0, fmt.Errorf("sample[0]: want float64, got %T (%v)", s[0], s[0])
-	}
-	valStr, ok := s[1].(string)
-	if !ok {
-		return 0, 0, fmt.Errorf("sample[1]: want string, got %T (%v)", s[1], s[1])
-	}
-	v, err := strconv.ParseFloat(valStr, 64)
-	if err != nil {
-		return 0, 0, fmt.Errorf("sample[1]: parse float %q: %w", valStr, err)
-	}
-	return int64(tsSec * 1000), v, nil
-}
-
-// urlEscape is a minimal URL escape that covers the characters PromQL
-// queries actually carry — `{`, `}`, `"`, `=`, `,`, parens, brackets,
-// spaces. The full net/url package would do the same but pulling it
-// in to escape a handful of punctuation marks would be overkill.
-func urlEscape(s string) string {
-	const hex = "0123456789ABCDEF"
-	var out []byte
-	for i := 0; i < len(s); i++ {
-		c := s[i]
-		if shouldEscape(c) {
-			out = append(out, '%', hex[c>>4], hex[c&0xF])
-		} else {
-			out = append(out, c)
-		}
-	}
-	return string(out)
-}
-
-func shouldEscape(c byte) bool {
-	switch c {
-	case '{', '}', '"', '=', ',', '(', ')', '[', ']', ' ', '\n', '+', '&':
-		return true
-	}
-	return false
 }

--- a/test/property/rate_dup_timestamp_test.go
+++ b/test/property/rate_dup_timestamp_test.go
@@ -66,6 +66,7 @@ import (
 	"github.com/tsouza/cerberus/test/property"
 	"github.com/tsouza/cerberus/test/property/gen"
 	oraclepromql "github.com/tsouza/cerberus/test/property/oracle/promql"
+	"github.com/tsouza/cerberus/test/spec/wire"
 )
 
 // nativeRateAggregate is the ClickHouse-native aggregate the ts_grid_range
@@ -325,7 +326,7 @@ func runCerberusRange(
 ) property.Outcome {
 	u := fmt.Sprintf(
 		"%s/api/v1/query_range?query=%s&start=%d&end=%d&step=%d",
-		baseURL, urlEscape(query), startSec, endSec, stepSec,
+		baseURL, wire.EscapeQuery(query, ""), startSec, endSec, stepSec,
 	)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
 	if err != nil {
@@ -379,7 +380,7 @@ func runCerberusRange(
 			stripped[k] = v
 		}
 		for _, sample := range s.Values {
-			ts, val, perr := parseSample(sample)
+			ts, val, perr := wire.ParseSample(sample)
 			if perr != nil {
 				return property.Outcome{Err: fmt.Errorf("property: parse range sample: %w", perr)}
 			}

--- a/test/property/traceql_test.go
+++ b/test/property/traceql_test.go
@@ -87,6 +87,7 @@ import (
 	"github.com/tsouza/cerberus/test/property"
 	"github.com/tsouza/cerberus/test/property/gen"
 	oracletraceql "github.com/tsouza/cerberus/test/property/oracle/traceql"
+	"github.com/tsouza/cerberus/test/spec/wire"
 )
 
 // TestTraceQL_Property wires every layer together for the TraceQL
@@ -171,7 +172,7 @@ func runCerberusTraceQL(ctx context.Context, baseURL string, q property.Query) p
 	// safe). Tests what Grafana's Traces Drilldown actually sends — a window.
 	anchorSec := gen.TraceQLAnchorTime().Unix()
 	startSec, endSec := anchorSec-propertyWindowMarginSec, anchorSec+propertyWindowMarginSec
-	u := fmt.Sprintf("%s/api/search?q=%s&start=%d&end=%d", baseURL, urlEscape(q.String), startSec, endSec)
+	u := fmt.Sprintf("%s/api/search?q=%s&start=%d&end=%d", baseURL, wire.EscapeQuery(q.String, ""), startSec, endSec)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
 	if err != nil {
 		return property.Outcome{Err: fmt.Errorf("property: build request: %w", err)}

--- a/test/spec/wire/wire.go
+++ b/test/spec/wire/wire.go
@@ -1,0 +1,235 @@
+// Package wire hosts the shared "issue an instant PromQL query against a
+// cerberus test server and decode the response into a property.Outcome"
+// helper.
+//
+// test/property/promql_test.go and test/integration/promql/exotic_test.go
+// both drive the real HTTP handler (parse -> lower -> optimize -> emit ->
+// execute) via an httptest.Server and need the same request-build /
+// response-decode logic; this package is the single copy both call.
+package wire
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/tsouza/cerberus/internal/api/prom"
+	"github.com/tsouza/cerberus/test/property"
+)
+
+// InstantOptions configures RunInstant's request encoding and response
+// decoding. The two call sites need genuinely different behaviour along two
+// axes; both are explicit knobs here rather than folded into one behaviour,
+// so hoisting the duplicated code doesn't change what either suite asserts.
+type InstantOptions struct {
+	// ExtraEscapeChars are additional punctuation bytes to percent-encode in
+	// the query string, on top of the base set (`{}"=,()[] `+"\n"+`+&`
+	// every generated PromQL query might carry). Percent-encoding an extra
+	// byte never changes the decoded query string the server sees (Go's
+	// query-string decoder unescapes it back to the exact original byte),
+	// so widening this set is always safe; it exists purely so each call
+	// site documents which punctuation its own query shapes can carry.
+	// test/integration/promql/exotic_test.go's richer expressions need
+	// `@:/*%^><!'` in addition to the base set.
+	ExtraEscapeChars string
+	// AllowScalar, when true, also accepts a "scalar" resultType response
+	// (decoded into a single label-less row at TimestampMs=0), in addition
+	// to "vector". When false, any non-"vector" resultType is a decode
+	// error.
+	//
+	// test/property/promql_test.go's generator (gen.PromQLQuery) only ever
+	// emits vector-shaped queries — bare selector / sum / sum-by / rate /
+	// sum-rate — never a top-level scalar expression, so it leaves this
+	// false: a future generator widening that starts producing a
+	// scalar-evaluating query fails loudly here rather than being silently
+	// decoded. test/integration/promql/exotic_test.go's matrix deliberately
+	// includes top-level scalar expressions (e.g. `-2^2`, `scalar(...)`),
+	// so it sets this true.
+	AllowScalar bool
+}
+
+// RunInstant GETs /api/v1/query and decodes the Prom-shaped response into
+// the framework's property.Outcome.
+//
+// Cerberus's instant-query response surfaces every series at the requested
+// eval timestamp (Prom convention — see prom/handler.go's toVector); we
+// extract that pair per series and reshape into the canonical OutcomeRow
+// shape.
+func RunInstant(ctx context.Context, baseURL string, q property.Query, opts InstantOptions) property.Outcome {
+	u := fmt.Sprintf(
+		"%s/api/v1/query?query=%s&time=%d",
+		baseURL,
+		EscapeQuery(q.String, opts.ExtraEscapeChars),
+		q.EvalTs,
+	)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return property.Outcome{Err: fmt.Errorf("wire: build request: %w", err)}
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return property.Outcome{Err: fmt.Errorf("wire: query roundtrip: %w", err)}
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return property.Outcome{Err: fmt.Errorf("wire: read body: %w", err)}
+	}
+
+	var parsed struct {
+		Status    string `json:"status"`
+		ErrorType string `json:"errorType"`
+		Error     string `json:"error"`
+		Data      struct {
+			ResultType string          `json:"resultType"`
+			Result     json.RawMessage `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return property.Outcome{
+			Err: fmt.Errorf("wire: decode body: %w; status=%d body=%s",
+				err, resp.StatusCode, body),
+		}
+	}
+	if parsed.Status != "success" {
+		// A failed-status response is a legitimate outcome — the oracle may
+		// also fail on the same query. Surface the error to the
+		// comparator; both sides erroring still counts as agreement.
+		return property.Outcome{
+			Err: fmt.Errorf("wire: cerberus returned status=%q errorType=%q err=%q",
+				parsed.Status, parsed.ErrorType, parsed.Error),
+		}
+	}
+
+	if parsed.Data.ResultType == "vector" {
+		return decodeVector(parsed.Data.Result)
+	}
+	if opts.AllowScalar && parsed.Data.ResultType == "scalar" {
+		return decodeScalar(parsed.Data.Result)
+	}
+	want := "vector"
+	if opts.AllowScalar {
+		want = "vector or scalar"
+	}
+	return property.Outcome{
+		Err: fmt.Errorf("wire: cerberus returned resultType=%q, want %s",
+			parsed.Data.ResultType, want),
+	}
+}
+
+// decodeVector reshapes a "vector" resultType payload into a
+// property.Outcome, one row per series.
+func decodeVector(raw json.RawMessage) property.Outcome {
+	var result []prom.VectorSample
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return property.Outcome{Err: fmt.Errorf("wire: decode vector: %w", err)}
+	}
+	out := property.Outcome{Rows: make([]property.OutcomeRow, 0, len(result))}
+	for _, s := range result {
+		// Strip __name__ so the comparator's labelKey() compares only the
+		// user-defined labels (the oracle strips it too).
+		stripped := make(map[string]string, len(s.Metric))
+		for k, v := range s.Metric {
+			if k == "__name__" {
+				continue
+			}
+			stripped[k] = v
+		}
+
+		if s.Value == nil {
+			// A histogram-valued sample (s.Histogram set instead) has no
+			// float Value; this harness only exercises float-valued PromQL
+			// shapes today, so treat it as a decode error rather than a
+			// nil-pointer panic.
+			return property.Outcome{Err: fmt.Errorf("wire: vector sample %v has no float value (histogram-valued?)", s.Metric)}
+		}
+		ts, val, perr := ParseSample(*s.Value)
+		if perr != nil {
+			return property.Outcome{Err: fmt.Errorf("wire: parse sample: %w", perr)}
+		}
+		out.Rows = append(out.Rows, property.OutcomeRow{
+			Labels:      stripped,
+			TimestampMs: ts,
+			Value:       val,
+		})
+	}
+	return out
+}
+
+// decodeScalar reshapes a "scalar" resultType ([ts, "value"]) into a single
+// label-less row at TimestampMs=0 — the same shape the from-scratch oracle
+// emits for a top-level scalar (see oracle/promql.outcomeFromValue).
+func decodeScalar(raw json.RawMessage) property.Outcome {
+	var s prom.Sample
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return property.Outcome{Err: fmt.Errorf("wire: decode scalar: %w", err)}
+	}
+	_, val, perr := ParseSample(s)
+	if perr != nil {
+		return property.Outcome{Err: fmt.Errorf("wire: parse scalar: %w", perr)}
+	}
+	return property.Outcome{Rows: []property.OutcomeRow{
+		{Labels: map[string]string{}, TimestampMs: 0, Value: val},
+	}}
+}
+
+// ParseSample turns Prom's [seconds_float, value_string] wire shape into
+// (unix_milliseconds, float64). The value string may be "NaN" / "+Inf" /
+// "-Inf" — strconv.ParseFloat handles all three.
+//
+// Exported so other test/property call sites decoding a different Prom
+// response shape (e.g. a query_range matrix's per-point samples) can reuse
+// the same parse without redeclaring it.
+func ParseSample(s prom.Sample) (int64, float64, error) {
+	if len(s) < 2 {
+		return 0, 0, fmt.Errorf("expected 2-element sample, got %d", len(s))
+	}
+	tsSec, ok := s[0].(float64)
+	if !ok {
+		return 0, 0, fmt.Errorf("sample[0]: want float64, got %T (%v)", s[0], s[0])
+	}
+	valStr, ok := s[1].(string)
+	if !ok {
+		return 0, 0, fmt.Errorf("sample[1]: want string, got %T (%v)", s[1], s[1])
+	}
+	v, err := strconv.ParseFloat(valStr, 64)
+	if err != nil {
+		return 0, 0, fmt.Errorf("sample[1]: parse float %q: %w", valStr, err)
+	}
+	return int64(tsSec * 1000), v, nil
+}
+
+// baseEscapeChars are punctuation marks every generated PromQL query might
+// carry that need percent-encoding to survive the request URL: `{`, `}`,
+// `"`, `=`, `,`, parens, brackets, spaces, `+`, `&`.
+const baseEscapeChars = "{}\"=,()[] \n+&"
+
+// EscapeQuery is a minimal URL escape covering baseEscapeChars plus any
+// caller-supplied extra bytes. The full net/url package would do the same
+// but pulling it in to escape a handful of punctuation marks would be
+// overkill.
+func EscapeQuery(s, extra string) string {
+	const hex = "0123456789ABCDEF"
+	var out []byte
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if shouldEscape(c, extra) {
+			out = append(out, '%', hex[c>>4], hex[c&0xF])
+		} else {
+			out = append(out, c)
+		}
+	}
+	return string(out)
+}
+
+func shouldEscape(c byte, extra string) bool {
+	if strings.IndexByte(baseEscapeChars, c) >= 0 {
+		return true
+	}
+	return extra != "" && strings.IndexByte(extra, c) >= 0
+}


### PR DESCRIPTION
## Summary

- `test/property/promql_test.go` and `test/integration/promql/exotic_test.go` each carried their own copy of the same helper: issue an HTTP instant query against the cerberus test server and decode the response into a `property.Outcome`. The latter's own comment admitted the duplication.
- Hoisted into a new package `test/spec/wire` (no build tag — reachable from both build-tag configurations without widening what any binary links). Repointed six call sites total: the two originals plus four more (`instant_window_test.go`, `rate_dup_timestamp_test.go`, `logql_test.go`, `traceql_test.go`) that called the same package-private helpers.
- The two original copies had genuinely DRIFTED (scalar-resultType handling, escape-charset width). Rather than silently picking one, this preserves both behaviors exactly via `wire.InstantOptions{AllowScalar, ExtraEscapeChars}` — verified byte-identical to the pre-refactor behavior at both call sites.

## Test plan

- [x] `go build -tags chdb ./test/property/... ./test/integration/promql/... ./test/spec/...` and untagged `go build ./...` both clean
- [x] `gofumpt -extra -l` clean on all touched/new files
- [x] `go vet -tags chdb,agpl_oracle,chdb_agpl_oracle ...` clean
- [x] `TestExoticPromQL`, `TestPromQL_Property_FromScratch`, `TestPromQL_InstantWindowSweep_FromScratch`, `TestTraceQL_Property`, `TestPromQL_RateDupTimestamp_RowAndNative`, `TestLogQL_Property` all pass
- [x] No third copy of the helper left anywhere (verified via grep)
- [x] Independently reviewed — see review notes on the InstantOptions seam and the four-file scope expansion, both confirmed justified

Part of the txtar-corpus-oracle plan (SDD Task 1, Phase 0b).

🤖 Generated with [Claude Code](https://claude.com/claude-code)