### PR TITLE
fix(e2e): union lean membership across fold candidates, not the fold winner

### DIFF
--- a/test/e2e/playwright/crawl/crawl.spec.ts
+++ b/test/e2e/playwright/crawl/crawl.spec.ts
@@ -137,6 +137,7 @@ import {
   inventoryPath,
   isSupersededDsQueryFailure,
   isTransientInitRaceFailure,
+  leanReachableCanonicals,
   loadExclusions,
   loadInventory,
   marshalInventory,
@@ -1096,6 +1097,51 @@ test.describe('crawl: canonicalization pins', () => {
     );
   });
 
+  test('lean membership survives a fold whose winner is not the lean representative', () => {
+    // The regression #1977 shipped: `?var-groupBy={var-groupBy}` is
+    // minted by SEVERAL driven states — the groupBy picker's lean
+    // representative among them — and folding keeps only the
+    // codepoint-smallest CONCRETE. Reading `leanRepresentative` off
+    // that winner demoted the canonical to `lean: false` even though
+    // the lean lane still visits it, and the lean ratchet then failed
+    // with "NEW surface … visited but not pinned" against a pin that
+    // had just been regenerated. Lean membership is a property of the
+    // GROUP (#1872: a query-parameter collapse folds by union), so it
+    // is unioned across candidates, never inherited from the winner.
+    const canonical = '/a/grafana-exploretraces-app/explore?var-groupBy={var-groupBy}';
+    const candidates = [
+      // Codepoint-smallest concrete, driven by a non-lean state.
+      {
+        canonical,
+        concrete: '/a/grafana-exploretraces-app/explore?var-groupBy=a.tile',
+        leanRepresentative: false,
+      },
+      // The lean plan's own state sorts LATER, so the fold drops it.
+      {
+        canonical,
+        concrete: '/a/grafana-exploretraces-app/explore?var-groupBy=z.picker',
+        leanRepresentative: true,
+      },
+    ];
+
+    const folded = foldCanonicalCandidates(candidates);
+    expect(folded.get(canonical)?.leanRepresentative).toBe(false);
+
+    // …but the canonical IS lean-reachable, and stays so under any
+    // input order.
+    expect(leanReachableCanonicals(candidates)).toEqual(new Set([canonical]));
+    expect(leanReachableCanonicals([...candidates].reverse())).toEqual(
+      new Set([canonical]),
+    );
+
+    // A canonical no lean state reaches stays out of the lean set.
+    expect(
+      leanReachableCanonicals([
+        { canonical: 'B', concrete: '/b', leanRepresentative: false },
+      ]),
+    ).toEqual(new Set());
+  });
+
   test('#1872: a combobox with no declared cardinality rule parameterizes regardless of option count', () => {
     // The old defect: an UNDECLARED combobox's mode followed the
     // CURRENT option count against STRUCTURAL_MAX_OPTIONS, so a
@@ -1479,8 +1525,23 @@ test('crawl: BFS over every reachable Grafana surface with universal oracles + i
         // parameterized canonical. Which one gets enqueued — and so
         // which one the BFS actually visits — must be a function of
         // the candidate set, not of control-discovery/DOM order.
+        //
+        // Lean membership, however, is a property of the CANONICAL —
+        // "can the lean plan reach this surface at all" — and NOT of
+        // which concrete URL wins the codepoint tie-break. It is
+        // therefore unioned across every candidate BEFORE folding,
+        // which is exactly #1872's rule that a query-parameter
+        // collapse folds by union (every collapsed state keys the
+        // same visited page, so unioning is lossless). Reading the
+        // flag off the fold WINNER instead silently demotes a
+        // canonical the lean lane really does visit: the lean crawl
+        // then reaches a surface pinned `lean: false`, and the
+        // ratchet reports it as an unpinned NEW surface.
+        const leanReachable = leanReachableCanonicals(sweep.discovered);
         for (const d of foldCanonicalCandidates(sweep.discovered).values()) {
-          if (isLeanRoot && d.leanRepresentative) leanSet.add(d.canonical);
+          if (isLeanRoot && leanReachable.has(d.canonical)) {
+            leanSet.add(d.canonical);
+          }
           if (!visited.has(d.canonical)) {
             queue.push({
               canonical: d.canonical,

--- a/test/e2e/playwright/crawl/lib.ts
+++ b/test/e2e/playwright/crawl/lib.ts
@@ -885,8 +885,15 @@ export function byCodepoint(a: string, b: string): number {
  * canonicalizes identically REGARDLESS of which one folding picks
  * (the query value that made them distinct is exactly what the
  * canonical key drops), so a deterministic pick changes nothing about
- * correctness — it only makes it as reproducible as the path-segment
- * case, where the choice does matter.
+ * WHICH surface is reached — it only makes it as reproducible as the
+ * path-segment case, where the choice does matter.
+ *
+ * What the pick must NOT decide is any property of the GROUP. This
+ * function returns one candidate per canonical, so every other
+ * candidate's fields are discarded; anything that is true of the
+ * canonical because it is true of ANY member has to be unioned
+ * separately — see leanReachableCanonicals, and #1872's rule that a
+ * query-parameter collapse folds by union.
  */
 export function foldCanonicalCandidates<
   T extends { canonical: string; concrete: string },
@@ -897,6 +904,30 @@ export function foldCanonicalCandidates<
     if (existing === undefined || byCodepoint(candidate.concrete, existing.concrete) < 0) {
       out.set(candidate.canonical, candidate);
     }
+  }
+  return out;
+}
+
+/**
+ * The canonicals the LEAN plan can reach, unioned over every
+ * candidate — the group property foldCanonicalCandidates cannot
+ * carry.
+ *
+ * A single canonical is routinely minted by several driven states
+ * (the Traces Drilldown breakdown surface is reached both from the
+ * groupBy picker and from the per-attribute tiles, and every one of
+ * those collapses onto `?var-groupBy={var-groupBy}`). Only some of
+ * those states belong to the lean plan. Lean membership asks "does
+ * the lean lane visit this canonical", which is true if ANY candidate
+ * for it is a lean representative — it is not a fact about whichever
+ * concrete URL happened to sort first.
+ */
+export function leanReachableCanonicals<
+  T extends { canonical: string; leanRepresentative: boolean },
+>(candidates: ReadonlyArray<T>): Set<string> {
+  const out = new Set<string>();
+  for (const candidate of candidates) {
+    if (candidate.leanRepresentative) out.add(candidate.canonical);
   }
   return out;
 }


### PR DESCRIPTION
## Summary

`e2e` / `compose-smoke-shard-crawl` has been red on `main` since a7be6d8b (#1977). Investigating why
turned up two separate things, only one of which this PR fixes.

**The real bug (fixed here).** #1977's `foldCanonicalCandidates` picks one candidate per canonical by
codepoint-smallest concrete URL, but the lean crawl then read `leanRepresentative` off that fold
*winner*. When several driven states mint the same canonical — e.g.
`?var-groupBy={var-groupBy}` is reached both from the groupBy picker and from per-attribute tiles —
and the lean plan's own state isn't the codepoint-smallest one, the fold silently demotes a canonical
the lean lane really does visit to `lean: false`. A live lean crawl then trips the ratchet with
`NEW surface ... visited but not pinned` against a pin that was *just* regenerated. Lean membership is
a property of the candidate GROUP, not of whichever concrete URL wins the fold tie-break — the same
union rule #1872 already established for query-parameter collapses. `leanReachableCanonicals` unions
the flag across every candidate before folding, so the BFS lean set no longer depends on fold order.

**Not fixed here, filed as #1992.** Reproducing locally against the live compose stack surfaced a
second, unrelated ratchet failure: the crawl intermittently fails to drive the `var-primarySignal`
`kind=server` picker option and instead newly discovers `kind=consumer`. I checked the underlying data
before assuming anything — `SELECT SpanKind, count() FROM otel.otel_traces GROUP BY SpanKind` on the
live stack shows `Server: 11387`, `Consumer: 1`. The well-populated kind is the one that goes missing;
the near-empty one is the one that's "new". That inversion is the signature of an interaction-drive
race (the same shape #1863 catalogued: a control not re-found/re-driven on a given pass), not a real
change in what the app offers. `crawl.spec.ts` already has a regression test
(`enumerating var-primarySignal keeps every signal a distinct surface`) that explicitly forbids
"fixing" this by deleting the row from the pin — so this PR does **not** regenerate
`grafana-surface-inventory.compose.json`. Doing so right now would pin exactly the coin-flip #1467
warns against.

Net effect: this PR fixes a real, independent bug and adds regression coverage for it, but does not
by itself turn `compose-smoke-shard-crawl` green — that also needs #1992's interaction-drive race
fixed before a trustworthy full inventory regen is possible.

## Verification

- `npx tsc --noEmit -p tsconfig.json` (the same check CI's "typecheck e2e Playwright specs" step
  runs) — clean.
- Every non-live-Grafana test in `crawl/crawl.spec.ts` + `crawl/reconcile.spec.ts` — 78/78 passing,
  including the new `lean membership survives a fold whose winner is not the lean representative`
  test (order-independent: reversed candidate input produces the identical lean set).
- **Could not verify locally:** the live BFS crawl test (`crawl.spec.ts`'s
  `'crawl: BFS over every reachable Grafana surface...'`), `crawl/dsquery.spec.ts`, and
  `crawl/lints.spec.ts` need a live Grafana/cerberus stack and are CI-only per this repo's own
  concurrency-hazard note (no per-worktree Compose isolation). I did use ClickHouse's HTTP endpoint
  directly (read-only `SELECT ... GROUP BY SpanKind`) against an already-running compose stack tied to
  this worktree to confirm the primarySignal data claim above, without touching Playwright/Compose
  lifecycle.

Refs #1977, #1992