### PR TITLE
test(spec): show the parity oracle the labels cerberus promotes from resource columns

### DIFF
--- a/test/regression/parity_contract_test.go
+++ b/test/regression/parity_contract_test.go
@@ -170,7 +170,7 @@ func TestParityEnrolmentFloor(t *testing.T) {
 
 	// parityEnrolmentFloor is the number of fixtures currently carrying a
 	// `parity:` section. It ratchets UP only.
-	const parityEnrolmentFloor = 396
+	const parityEnrolmentFloor = 409
 
 	enrolled := 0
 	for _, dir := range parityFixtureDirs(t) {

--- a/test/spec/parity_chdb.go
+++ b/test/spec/parity_chdb.go
@@ -129,7 +129,7 @@ func RunParity(t *testing.T, c *Case, evalStart, evalEnd time.Time, step time.Du
 	var got []referenceSample
 	switch p.Oracle {
 	case OraclePrometheus:
-		got, err = evaluatePrometheusParity(t, db, c, q)
+		got, err = evaluatePrometheusParity(t, db, c, rt, q)
 	case OracleLoki:
 		if lokiParityEvaluator == nil {
 			t.Fatalf(
@@ -206,11 +206,11 @@ func comparesTimestamps(oracleName string, step time.Duration) bool {
 // evaluatePrometheusParity answers q with the real upstream Prometheus
 // engine over the rows the seed actually landed in chDB.
 func evaluatePrometheusParity(
-	t *testing.T, db *sql.DB, c *Case, q parityQuery,
+	t *testing.T, db *sql.DB, c *Case, rt *RoundTripSections, q parityQuery,
 ) ([]referenceSample, error) {
 	t.Helper()
 
-	series, err := readSeededSeries(db)
+	series, err := readSeededSeries(db, rt, resourceLabelAllowlist(c))
 	if err != nil {
 		return nil, fmt.Errorf("read seeded series back: %w", err)
 	}
@@ -254,19 +254,27 @@ var seededMetricsTables = []string{
 // coercion — instead of as the SQL claims it will land. Otherwise a
 // disagreement about what the seed means would be invisible to exactly the
 // check meant to find disagreements.
-func readSeededSeries(db *sql.DB) ([]oracle.Series, error) {
+func readSeededSeries(
+	db *sql.DB, rt *RoundTripSections, allow resourceAllowlist,
+) ([]oracle.Series, error) {
 	byKey := map[string]*oracle.Series{}
+	seedCols := testsql.SeedTableColumns(rt.Seed)
 
 	for _, table := range seededMetricsTables {
-		//nolint:gosec // table comes from seededMetricsTables, not from fixture text.
-		q := "SELECT MetricName, toJSONString(Attributes), toUnixTimestamp64Milli(TimeUnix), Value " +
+		//nolint:gosec // every fragment is chosen from this file's own
+		// constants, keyed off the seed's declared columns; no fixture
+		// text reaches the query.
+		q := "SELECT MetricName, toJSONString(Attributes), " +
+			resourceAttributesProjection(seedCols[table]) + ", " +
+			serviceNameProjection(seedCols[table]) + ", " +
+			"toUnixTimestamp64Milli(TimeUnix), Value " +
 			"FROM " + table + " ORDER BY MetricName, TimeUnix"
 		rows, err := db.Query(q)
 		if err != nil {
 			// A fixture that never created this table is not an error.
 			continue
 		}
-		if err := scanSeriesRows(rows, byKey); err != nil {
+		if err := scanSeriesRows(rows, byKey, allow); err != nil {
 			_ = rows.Close()
 			return nil, err
 		}
@@ -285,15 +293,17 @@ func readSeededSeries(db *sql.DB) ([]oracle.Series, error) {
 	return out, nil
 }
 
-func scanSeriesRows(rows *sql.Rows, byKey map[string]*oracle.Series) error {
+func scanSeriesRows(rows *sql.Rows, byKey map[string]*oracle.Series, allow resourceAllowlist) error {
 	for rows.Next() {
-		var name, attrsJSON string
+		var name, attrsJSON, resAttrsJSON, serviceName string
 		var tsMillis int64
 		var value float64
-		if err := rows.Scan(&name, &attrsJSON, &tsMillis, &value); err != nil {
+		if err := rows.Scan(
+			&name, &attrsJSON, &resAttrsJSON, &serviceName, &tsMillis, &value,
+		); err != nil {
 			return err
 		}
-		lbls, err := labelsFromAttributesJSON(name, attrsJSON)
+		lbls, err := labelsFromSeededRow(name, attrsJSON, resAttrsJSON, serviceName, allow)
 		if err != nil {
 			return err
 		}
@@ -426,28 +436,168 @@ func labelKey(lbls map[string]string) string {
 	return b.String()
 }
 
-// labelsFromAttributesJSON builds the reference-engine label set for one
-// seeded row: the OTel attribute map plus __name__.
-//
-// The empty-string metric name is dropped rather than written as an empty
-// __name__, because cerberus emits `” AS MetricName` for derived samples
-// (PromQL drops __name__ from a function's output) and Prometheus
-// represents that as the label being ABSENT.
-func labelsFromAttributesJSON(metricName, attrsJSON string) (map[string]string, error) {
-	attrs := map[string]string{}
-	if trimmed := strings.TrimSpace(attrsJSON); trimmed != "" && trimmed != "{}" {
-		if err := json.Unmarshal([]byte(trimmed), &attrs); err != nil {
-			return nil, fmt.Errorf("decode Attributes %q: %w", attrsJSON, err)
+// The OTel-CH columns beyond Attributes that carry Prometheus labels, and
+// the service-name key they resolve to.
+const (
+	colResourceAttributes = "ResourceAttributes"
+	colServiceName        = "ServiceName"
+	serviceNameLabel      = "service_name"
+	serviceNameOTelKey    = "service.name"
+)
+
+// resourceAllowlist narrows which ResourceAttributes keys become labels.
+// A nil allowlist promotes every key, which is the schema default —
+// the allowlist is opt-IN narrowing, not opt-in enabling.
+type resourceAllowlist map[string]bool
+
+// resourceLabelAllowlist reads the fixture's own `resource_labels:`
+// section, the same section the lowering harness uses to override the
+// schema's promotion allowlist. Reading it here keeps the two sides
+// looking at ONE declaration of which resource keys are labels; a fixture
+// that narrows the set for the lowering but not for the reference would
+// diverge on label sets for a reason unrelated to its query.
+func resourceLabelAllowlist(c *Case) resourceAllowlist {
+	body, ok := c.Section("resource_labels")
+	if !ok {
+		return nil
+	}
+	allow := resourceAllowlist{}
+	for _, line := range strings.Split(body, "\n") {
+		if key := strings.TrimSpace(line); key != "" {
+			allow[key] = true
 		}
 	}
-	out := make(map[string]string, len(attrs)+1)
+	return allow
+}
+
+// resourceAttributesProjection / serviceNameProjection select a column the
+// seed may not have declared.
+//
+// The corpus's seeds are minimal — each declares only the columns its own
+// query needs — so a fixture whose gauge table is (MetricName, Attributes,
+// TimeUnix, Value) has no ResourceAttributes and no ServiceName to read.
+// Substituting the empty literal keeps one reader able to serve every
+// seed, and an absent column and an empty one mean the same thing to the
+// promotion below.
+func resourceAttributesProjection(seedCols []string) string {
+	if !hasColumn(seedCols, colResourceAttributes) {
+		return "'{}'"
+	}
+	return "toJSONString(" + colResourceAttributes + ")"
+}
+
+func serviceNameProjection(seedCols []string) string {
+	if !hasColumn(seedCols, colServiceName) {
+		return "''"
+	}
+	return "toString(" + colServiceName + ")"
+}
+
+func hasColumn(cols []string, want string) bool {
+	for _, col := range cols {
+		if strings.EqualFold(col, want) {
+			return true
+		}
+	}
+	return false
+}
+
+// sanitizeLabelName rewrites an OTel key into the Prometheus label name it
+// is exposed as: every character outside [a-zA-Z0-9_] becomes '_', so
+// `k8s.namespace.name` is addressable as `k8s_namespace_name`.
+func sanitizeLabelName(key string) string {
+	var b strings.Builder
+	b.Grow(len(key))
+	for _, r := range key {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '_':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	return b.String()
+}
+
+// labelsFromSeededRow builds the reference-engine label set for one seeded
+// row: the resource labels, overlaid by the metric attributes, plus
+// service_name and __name__.
+//
+// # Why the translator has to do this at all
+//
+// A series' IDENTITY is a data-model fact, not a query-semantics one. OTel
+// spreads a metric's labels across three columns — Attributes,
+// ResourceAttributes and the dedicated ServiceName — while Prometheus has
+// one flat label set and no notion of a resource. Something has to map
+// between them, and both sides must reach the same answer or there is no
+// series to align and every comparison degenerates into "the two engines
+// returned different series".
+//
+// Reading only Attributes, as this did before, was not a neutral choice:
+// it meant the reference engine could not see the labels cerberus promotes
+// from the other two columns, so `sum by (service_name) (...)` grouped
+// three ways on cerberus's side and one way on the reference's. That is
+// not a disagreement about the query — it is the oracle being shown
+// different data.
+//
+// # What this does and does not check
+//
+// The rule below is written out here rather than imported, because the
+// oracle side may not link internal/schema. It is an independent
+// expression of the same documented mapping, not a call into cerberus's,
+// so a cerberus lowering that DEVIATES from that mapping — stops promoting
+// ServiceName, sanitizes a key differently, resolves a collision the other
+// way — makes the two label sets disagree and fails here.
+//
+// What no amount of independence can catch is a misconception SHARED by
+// both: if the documented mapping is itself wrong, both sides implement
+// the same wrong thing and agree. That axis belongs to the live
+// compatibility harness, which compares against a real Prometheus fed by
+// the real exporter rather than against a reading of the same spec.
+func labelsFromSeededRow(
+	metricName, attrsJSON, resAttrsJSON, serviceName string, allow resourceAllowlist,
+) (map[string]string, error) {
+	resAttrs, err := decodeAttributes(resAttrsJSON)
+	if err != nil {
+		return nil, err
+	}
+	attrs, err := decodeAttributes(attrsJSON)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make(map[string]string, len(resAttrs)+len(attrs)+2)
+	// Resource labels first: the metric's own attributes win a collision,
+	// and service_name wins over both.
+	for k, v := range resAttrs {
+		if k == serviceNameOTelKey || k == serviceNameLabel {
+			continue
+		}
+		if allow != nil && !allow[k] {
+			continue
+		}
+		out[sanitizeLabelName(k)] = v
+	}
 	for k, v := range attrs {
-		out[k] = v
+		out[sanitizeLabelName(k)] = v
+	}
+	if serviceName != "" {
+		out[serviceNameLabel] = serviceName
 	}
 	if metricName != "" {
 		out[promNameLabel] = metricName
 	}
 	return out, nil
+}
+
+func decodeAttributes(attrsJSON string) (map[string]string, error) {
+	attrs := map[string]string{}
+	if trimmed := strings.TrimSpace(attrsJSON); trimmed != "" && trimmed != "{}" {
+		if err := json.Unmarshal([]byte(trimmed), &attrs); err != nil {
+			return nil, fmt.Errorf("decode attributes %q: %w", attrsJSON, err)
+		}
+	}
+	return attrs, nil
 }
 
 // promNameLabel is Prometheus's metric-name label.

--- a/test/spec/parity_columns_chdb_test.go
+++ b/test/spec/parity_columns_chdb_test.go
@@ -104,3 +104,127 @@ func TestLocateSampleColumnsRejectsNonSampleProjection(t *testing.T) {
 		})
 	}
 }
+
+// TestLabelsFromSeededRow pins the label set the translator reconstructs
+// from one seeded row, because that reconstruction is what decides which
+// series the two engines' answers are aligned on. A row whose labels are
+// built differently on the two sides produces a "different series"
+// failure that says nothing about the query.
+func TestLabelsFromSeededRow(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name       string
+		attrs      string
+		resAttrs   string
+		service    string
+		metric     string
+		allow      resourceAllowlist
+		want       map[string]string
+		wantAbsent []string
+	}{
+		{
+			name:   "attributes and metric name only",
+			attrs:  `{"job":"api"}`,
+			metric: "up",
+			want:   map[string]string{"job": "api", "__name__": "up"},
+		},
+		{
+			// The ServiceName column is where the exporter puts
+			// service.name, and it is the label cerberus exposes it as.
+			name:    "service name comes from its dedicated column",
+			attrs:   `{"job":"api"}`,
+			service: "checkout",
+			metric:  "up",
+			want: map[string]string{
+				"job": "api", "service_name": "checkout", "__name__": "up",
+			},
+		},
+		{
+			// Dotted OTel keys are addressable underscored.
+			name:     "resource keys are sanitized",
+			attrs:    `{}`,
+			resAttrs: `{"k8s.namespace.name":"prod","deployment/env":"eu"}`,
+			metric:   "up",
+			want: map[string]string{
+				"k8s_namespace_name": "prod", "deployment_env": "eu", "__name__": "up",
+			},
+		},
+		{
+			// A metric attribute wins over a resource attribute of the
+			// same sanitized name.
+			name:     "metric attributes win a collision with resource attributes",
+			attrs:    `{"region":"metric"}`,
+			resAttrs: `{"region":"resource"}`,
+			metric:   "up",
+			want:     map[string]string{"region": "metric", "__name__": "up"},
+		},
+		{
+			// service.name is carried by ServiceName, never duplicated
+			// out of the resource map.
+			name:     "service name in the resource map does not shadow the column",
+			attrs:    `{}`,
+			resAttrs: `{"service.name":"from-map"}`,
+			service:  "from-column",
+			metric:   "up",
+			want:     map[string]string{"service_name": "from-column", "__name__": "up"},
+		},
+		{
+			name:       "an allowlist narrows which resource keys are promoted",
+			attrs:      `{}`,
+			resAttrs:   `{"kept":"yes","dropped":"no"}`,
+			metric:     "up",
+			allow:      resourceAllowlist{"kept": true},
+			want:       map[string]string{"kept": "yes", "__name__": "up"},
+			wantAbsent: []string{"dropped"},
+		},
+		{
+			// A derived sample carries no metric name, and Prometheus
+			// represents that as __name__ being ABSENT.
+			name:       "an empty metric name is absent rather than empty",
+			attrs:      `{"job":"api"}`,
+			want:       map[string]string{"job": "api"},
+			wantAbsent: []string{"__name__"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := labelsFromSeededRow(tc.metric, tc.attrs, tc.resAttrs, tc.service, tc.allow)
+			if err != nil {
+				t.Fatalf("labelsFromSeededRow: %v", err)
+			}
+			if labelKey(got) != labelKey(tc.want) {
+				t.Errorf("labels = %v, want %v", got, tc.want)
+			}
+			for _, k := range tc.wantAbsent {
+				if _, present := got[k]; present {
+					t.Errorf("label %q is present as %q, want absent", k, got[k])
+				}
+			}
+		})
+	}
+}
+
+// TestResourceAttributesProjectionFallsBackWhenUnseeded asserts the reader
+// tolerates the corpus's minimal seeds. Most fixtures declare only the
+// columns their own query needs, so demanding ResourceAttributes and
+// ServiceName would fail to read the majority of the corpus.
+func TestResourceAttributesProjectionFallsBackWhenUnseeded(t *testing.T) {
+	t.Parallel()
+
+	declared := []string{"MetricName", "Attributes", "ResourceAttributes", "ServiceName", "Value"}
+	if got := resourceAttributesProjection(declared); got != "toJSONString(ResourceAttributes)" {
+		t.Errorf("declared ResourceAttributes projected as %q", got)
+	}
+	if got := serviceNameProjection(declared); got != "toString(ServiceName)" {
+		t.Errorf("declared ServiceName projected as %q", got)
+	}
+
+	minimal := []string{"MetricName", "Attributes", "TimeUnix", "Value"}
+	if got := resourceAttributesProjection(minimal); got != "'{}'" {
+		t.Errorf("unseeded ResourceAttributes projected as %q, want the empty-map literal", got)
+	}
+	if got := serviceNameProjection(minimal); got != "''" {
+		t.Errorf("unseeded ServiceName projected as %q, want the empty-string literal", got)
+	}
+}

--- a/test/spec/parity_loki_chdb.go
+++ b/test/spec/parity_loki_chdb.go
@@ -53,12 +53,14 @@ const logsTable = "otel_logs"
 // purpose: an oracle that took its column names from the system under
 // test would agree with it about the layout by construction, and the
 // disjointness gate in test/regression rejects the import outright.
+// colResourceAttributes is shared with the metrics reader in
+// parity_chdb.go, which spells it out for the same reason and is compiled
+// into every lane this file is compiled into.
 const (
-	colTimestamp          = "Timestamp"
-	colBody               = "Body"
-	colResourceAttributes = "ResourceAttributes"
-	colLogAttributes      = "LogAttributes"
-	colSeverityText       = "SeverityText"
+	colTimestamp     = "Timestamp"
+	colBody          = "Body"
+	colLogAttributes = "LogAttributes"
+	colSeverityText  = "SeverityText"
 )
 
 // evaluateLokiParity answers q with the real upstream Loki engine over

--- a/test/spec/promql/agg_by_dotted_source.txtar
+++ b/test/spec/promql/agg_by_dotted_source.txtar
@@ -15,6 +15,10 @@
 
 -- query.promql --
 count by (cerberus_ql) (cerberus_queries_total)
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query
+scope: full
 -- seed --
 CREATE TABLE otel_metrics_sum (
     MetricName String,

--- a/test/spec/promql/agg_by_service_name.txtar
+++ b/test/spec/promql/agg_by_service_name.txtar
@@ -18,6 +18,10 @@
 
 -- query.promql --
 sum by (service_name) (cerberus_queries_total)
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query
+scope: full
 -- seed --
 CREATE TABLE otel_metrics_sum (
     MetricName String,

--- a/test/spec/promql/matcher_and_agg_by_service_name.txtar
+++ b/test/spec/promql/matcher_and_agg_by_service_name.txtar
@@ -27,6 +27,10 @@
 
 -- query.promql --
 sum by (service_name) (cerberus_queries_total{service_name="api"})
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query
+scope: full
 -- seed --
 CREATE TABLE otel_metrics_sum (
     MetricName String,

--- a/test/spec/promql/matcher_dotted_source.txtar
+++ b/test/spec/promql/matcher_dotted_source.txtar
@@ -15,6 +15,10 @@
 
 -- query.promql --
 cerberus_queries_total{cerberus_ql="promql"}
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query
+scope: full
 -- seed --
 CREATE TABLE otel_metrics_sum (
     MetricName String,

--- a/test/spec/promql/matcher_service_name.txtar
+++ b/test/spec/promql/matcher_service_name.txtar
@@ -14,6 +14,10 @@
 
 -- query.promql --
 cerberus_queries_total{service_name="cerberus"}
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query
+scope: full
 -- seed --
 CREATE TABLE otel_metrics_sum (
     MetricName String,

--- a/test/spec/promql/native_rate_recollapse_collision.txtar
+++ b/test/spec/promql/native_rate_recollapse_collision.txtar
@@ -55,6 +55,10 @@
 
 -- query.promql --
 rate(cerberus_queries_total[5m])
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query_range
+scope: full
 -- range_step --
 30s
 -- experimental_ts_grid_range --

--- a/test/spec/promql/native_rate_recollapse_collision_two_level.txtar
+++ b/test/spec/promql/native_rate_recollapse_collision_two_level.txtar
@@ -22,6 +22,10 @@
 
 -- query.promql --
 rate(cerberus_queries_total[5m])
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query_range
+scope: full
 -- range_step --
 30s
 -- experimental_ts_grid_range --

--- a/test/spec/promql/native_rate_recollapse_metric_name_isolation.txtar
+++ b/test/spec/promql/native_rate_recollapse_metric_name_isolation.txtar
@@ -29,6 +29,10 @@
 
 -- query.promql --
 rate(cerberus_queries_total[5m])
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query_range
+scope: full
 -- range_step --
 30s
 -- experimental_ts_grid_range --

--- a/test/spec/promql/resource_attr_bare_selector.txtar
+++ b/test/spec/promql/resource_attr_bare_selector.txtar
@@ -11,6 +11,10 @@
 
 -- query.promql --
 http_requests_total
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query
+scope: full
 -- seed --
 CREATE TABLE otel_metrics_sum (
     MetricName String,

--- a/test/spec/promql/resource_attr_matcher.txtar
+++ b/test/spec/promql/resource_attr_matcher.txtar
@@ -10,6 +10,10 @@
 
 -- query.promql --
 http_requests_total{k8s_namespace_name="prod"}
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query
+scope: full
 -- seed --
 CREATE TABLE otel_metrics_sum (
     MetricName String,

--- a/test/spec/promql/resource_attr_precedence_collision.txtar
+++ b/test/spec/promql/resource_attr_precedence_collision.txtar
@@ -13,6 +13,10 @@
 
 -- query.promql --
 http_requests_total
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query
+scope: full
 -- seed --
 CREATE TABLE otel_metrics_sum (
     MetricName String,

--- a/test/spec/promql/resource_attr_sum_by.txtar
+++ b/test/spec/promql/resource_attr_sum_by.txtar
@@ -8,6 +8,10 @@
 
 -- query.promql --
 sum by (k8s_namespace_name) (http_requests_total)
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query
+scope: full
 -- seed --
 CREATE TABLE otel_metrics_sum (
     MetricName String,

--- a/test/spec/promql/sum_by_underscored_otel_label.txtar
+++ b/test/spec/promql/sum_by_underscored_otel_label.txtar
@@ -14,6 +14,10 @@
 
 -- query.promql --
 sum by (cerberus_ql) (cerberus_queries_total)
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query
+scope: full
 -- seed --
 CREATE TABLE otel_metrics_sum (
     MetricName String,


### PR DESCRIPTION
## What

The translator that feeds the reference engine read only the `Attributes`
column, so the reference could not see the labels cerberus promotes from
`ResourceAttributes` and from the dedicated `ServiceName` column. It now reads
all three. Parity enrolment goes **396 → 409**.

## Why it was not a neutral omission

`sum by (service_name) (cerberus_queries_total)` grouped three ways on
cerberus's side and one way on the reference's, and the comparison reported a
disagreement about the ANSWER when the two engines had simply been shown
different data:

```
reference: [{map[] 151}]
cerberus:  [{map[service_name:api] 99} {map[service_name:cerberus] 10} {map[service_name:db] 42}]
```

Every fixture whose series identity involves a resource label was therefore
unenrollable for a reason that had nothing to do with its query.

## The mapping, and what it does and does not check

A series' identity is a data-model fact. OTel spreads a metric's labels across
three columns while Prometheus has one flat label set and no notion of a
resource, so something has to map between them, and both sides must reach the
same answer or there is no series to align. The reader now selects all three —
substituting empty literals where a fixture's minimal seed never declared them,
which most of the corpus does not — and builds resource labels, overlaid by
metric attributes, plus `service_name` and `__name__`.

The rule is written out in the translator rather than imported, because the
oracle may not link `internal/schema`. It is an independent expression of the
same documented mapping, so a lowering that **deviates** from it fails here —
demonstrated below. What no amount of independence can catch is a
misconception **shared** by both; that axis belongs to the live compatibility
harness, which compares against a real Prometheus fed by the real exporter.

The fixture's own `resource_labels:` section is honoured, so the narrowed
allowlist a fixture declares for the lowering is the one the reference sees.

## Absorption demo

Injected a real promotion regression — dropped the dedicated-column overlay in
`selectorAttributesExpr`, so cerberus stops projecting `service_name`:

1. `GOLDEN_UPDATE=1` on `./internal/promql/` then on `./test/spec/promql/`
   fully absorbed it. `expected_rows` became `["", {}, "...", 151]` — one
   merged series with no labels, re-pinned as the correct answer.
2. With both goldens regenerated, parity is red:

   ```
   fixture agg_by_service_name: reference engine returned 3 sample(s), cerberus 1.
     reference: [{map[service_name:api] 99} {map[service_name:cerberus] 10} {map[service_name:db] 42}]
     cerberus:  [{map[] 151}]

   fixture matcher_and_agg_by_service_name sample 0: labels differ
     reference: map[service_name:api]
     cerberus:  map[]
   ```

Before this PR the reference could not see `service_name` either, so it would
have agreed with the regression.

## Tests

`TestLabelsFromSeededRow` pins the reconstruction: sanitization of dotted keys,
metric attributes winning a collision with resource attributes, `service.name`
in the resource map not shadowing the dedicated column, allowlist narrowing,
and an empty metric name being ABSENT rather than empty.
`TestResourceAttributesProjectionFallsBackWhenUnseeded` pins the minimal-seed
fallback.

## Verification

`go test -tags chdb -count=1 ./internal/promql/` — green with all 409 enrolled
(217s). The injected regression was reverted and every fixture diff verified to
be exactly `+4/-0` lines.

## Not fixed here

The remaining unenrolled promql fixtures are dominated by one blocker, tracked
under epic #1986: **~114 seed `otel_metrics_histogram` /
`otel_metrics_exponential_histogram`**, which `seededMetricsTables` does not
read at all, so the reference sees no series for them. Beyond that: 12
`@ start()` / `@ end()` fixtures the harness lowers with one anchor and
parity-checks with another, ~26 value disagreements (DELTA-temporality
counters, ClickHouse-native `timeSeries*ToGrid` strategies), and 13 metadata /
exemplar fixtures that ask no PromQL expression and can never enrol.

Part of #1986.
