### PR TITLE
test(spec): parity-check @ start() / @ end() fixtures at the window they lowered with

### DIFF
--- a/internal/promql/lower_test.go
+++ b/internal/promql/lower_test.go
@@ -175,6 +175,16 @@ func TestLower(t *testing.T) {
 		// See test/spec/parity.go for why the fixture stores the parity
 		// CONTRACT and not the parity ANSWER.
 		parityStart, parityEnd, parityStep := instantEval, instantEval, time.Duration(0)
+		if strings.Contains(query, "@ start()") || strings.Contains(query, "@ end()") {
+			// These fixtures lower with the fixed [start, end] window
+			// above, not with instantEval, because that is the only way
+			// `start()` and `end()` resolve to distinguishable instants.
+			// Handing the reference engine instantEval instead would ask
+			// it a different question than the one cerberus was lowered
+			// for, and every such fixture would "disagree" for a reason
+			// that has nothing to do with its query.
+			parityStart, parityEnd = start, end
+		}
 		if rs, ok := c.Section("range_step"); ok {
 			d, perr := time.ParseDuration(strings.TrimSpace(rs))
 			if perr != nil {

--- a/test/regression/parity_contract_test.go
+++ b/test/regression/parity_contract_test.go
@@ -170,7 +170,7 @@ func TestParityEnrolmentFloor(t *testing.T) {
 
 	// parityEnrolmentFloor is the number of fixtures currently carrying a
 	// `parity:` section. It ratchets UP only.
-	const parityEnrolmentFloor = 438
+	const parityEnrolmentFloor = 450
 
 	enrolled := 0
 	for _, dir := range parityFixtureDirs(t) {

--- a/test/spec/parity_chdb.go
+++ b/test/spec/parity_chdb.go
@@ -121,7 +121,7 @@ func RunParity(t *testing.T, c *Case, evalStart, evalEnd time.Time, step time.Du
 	ApplySeed(t, db, rt.Seed)
 
 	q := parityQuery{
-		Expr:  strings.TrimSpace(query),
+		Expr:  resolveAtModifiers(strings.TrimSpace(query), evalStart, evalEnd, step),
 		Start: evalStart,
 		End:   evalEnd,
 		Step:  step,
@@ -171,6 +171,54 @@ func RunParity(t *testing.T, c *Case, evalStart, evalEnd time.Time, step time.Du
 	}
 
 	compareAgainstReference(t, c, p, rt, sc, got, compareTimestamps)
+}
+
+// atStartModifier / atEndModifier are the two `@` modifiers whose
+// resolved instant depends on the query's own window rather than on a
+// literal in the expression.
+const (
+	atStartModifier = "@ start()"
+	atEndModifier   = "@ end()"
+)
+
+// resolveAtModifiers rewrites `@ start()` / `@ end()` into the instants
+// they resolve to over [start, end].
+//
+// # Why the reference engine cannot just be handed the query
+//
+// A fixture exercising `start()` and `end()` has to be lowered over a
+// window whose two ends DIFFER, or the two modifiers resolve to the same
+// instant and the fixture tests nothing. The lowering harness does that
+// with a fixed [start, end] pair, and cerberus answers with a single
+// sample taken at the resolved anchor.
+//
+// Prometheus has no query shape with that combination. An instant query
+// has start == end, so both modifiers collapse; a range query over
+// [start, end] resolves them correctly but answers with a sample at every
+// step, which is not the single sample cerberus was asked for. Handing
+// the reference either one compares two different questions.
+//
+// Substituting the resolved literal is the definition of the modifier at
+// that window, not a reimplementation of cerberus's lowering: `start()`
+// over a query starting at 100 IS `@ 100`, per the PromQL specification.
+// The reference then evaluates the substituted query as an instant query
+// at End, and everything about the expression other than the anchor is
+// still evaluated independently. A cerberus lowering that resolved the
+// anchor to the WRONG instant reads a different sample than the reference
+// does and fails here, which is precisely the bug class the modifier has.
+//
+// A range query needs no substitution: its window reaches the reference
+// engine intact, so Prometheus resolves both modifiers itself.
+func resolveAtModifiers(expr string, start, end time.Time, step time.Duration) string {
+	if step > 0 || start.Equal(end) {
+		return expr
+	}
+	expr = strings.ReplaceAll(expr, atStartModifier, atInstant(start))
+	return strings.ReplaceAll(expr, atEndModifier, atInstant(end))
+}
+
+func atInstant(t time.Time) string {
+	return "@ " + strconv.FormatInt(t.Unix(), 10)
 }
 
 // parityQuerySections maps an oracle to the TXTAR section holding the

--- a/test/spec/promql/at_end_basic.txtar
+++ b/test/spec/promql/at_end_basic.txtar
@@ -1,5 +1,9 @@
 -- query.promql --
 rate(http_requests_total[5m] @ end())
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query
+scope: full
 -- args --
 [0] string = "service.name"
 [1] string = "service_name"

--- a/test/spec/promql/at_start_basic.txtar
+++ b/test/spec/promql/at_start_basic.txtar
@@ -1,5 +1,9 @@
 -- query.promql --
 up @ start()
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query
+scope: full
 -- seed --
 CREATE TABLE otel_metrics_gauge (
     MetricName String,

--- a/test/spec/promql/delta_window.txtar
+++ b/test/spec/promql/delta_window.txtar
@@ -1,5 +1,9 @@
 -- query.promql --
 delta(temperature[5m] @ end())
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query
+scope: full
 -- seed --
 CREATE TABLE otel_metrics_gauge (
     MetricName String,

--- a/test/spec/promql/edge_at_start_range.txtar
+++ b/test/spec/promql/edge_at_start_range.txtar
@@ -1,5 +1,9 @@
 -- query.promql --
 rate(http_requests_total[5m] @ start())
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query
+scope: full
 -- args --
 [0] string = "service.name"
 [1] string = "service_name"

--- a/test/spec/promql/edge_increase_at_start.txtar
+++ b/test/spec/promql/edge_increase_at_start.txtar
@@ -1,5 +1,9 @@
 -- query.promql --
 increase(http_requests_total[5m] @ start())
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query
+scope: full
 -- args --
 [0] string = "service.name"
 [1] string = "service_name"

--- a/test/spec/promql/idelta_two_samples.txtar
+++ b/test/spec/promql/idelta_two_samples.txtar
@@ -1,5 +1,9 @@
 -- query.promql --
 idelta(temperature[5m] @ end())
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query
+scope: full
 -- seed --
 CREATE TABLE otel_metrics_gauge (
     MetricName String,

--- a/test/spec/promql/irate_two_samples.txtar
+++ b/test/spec/promql/irate_two_samples.txtar
@@ -1,5 +1,9 @@
 -- query.promql --
 irate(http_requests_total[5m] @ end())
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query
+scope: full
 -- seed --
 CREATE TABLE otel_metrics_sum (
     MetricName String,

--- a/test/spec/promql/quantile_over_time_p95.txtar
+++ b/test/spec/promql/quantile_over_time_p95.txtar
@@ -1,5 +1,9 @@
 -- query.promql --
 quantile_over_time(0.95, latency_ms[5m] @ end())
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query
+scope: full
 -- seed --
 CREATE TABLE otel_metrics_gauge (
     MetricName String,

--- a/test/spec/promql/quantile_over_time_p95_exact_interp.txtar
+++ b/test/spec/promql/quantile_over_time_p95_exact_interp.txtar
@@ -1,5 +1,9 @@
 -- query.promql --
 quantile_over_time(0.95, latency_ms[5m] @ end())
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query
+scope: full
 -- seed --
 CREATE TABLE otel_metrics_gauge (
     MetricName String,

--- a/test/spec/promql/quantile_over_time_q_above_one.txtar
+++ b/test/spec/promql/quantile_over_time_q_above_one.txtar
@@ -6,6 +6,10 @@
 # Value column to +Inf.
 -- query.promql --
 quantile_over_time(1.5, latency_ms[5m] @ end())
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query
+scope: full
 -- seed --
 CREATE TABLE otel_metrics_gauge (
     MetricName String,

--- a/test/spec/promql/quantile_over_time_q_negative.txtar
+++ b/test/spec/promql/quantile_over_time_q_negative.txtar
@@ -6,6 +6,10 @@
 # Value column to -Inf.
 -- query.promql --
 quantile_over_time(-0.5, latency_ms[5m] @ end())
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query
+scope: full
 -- seed --
 CREATE TABLE otel_metrics_gauge (
     MetricName String,

--- a/test/spec/promql/stddev_over_time_window.txtar
+++ b/test/spec/promql/stddev_over_time_window.txtar
@@ -1,5 +1,9 @@
 -- query.promql --
 stddev_over_time(temperature[5m] @ end())
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query
+scope: full
 -- seed --
 CREATE TABLE otel_metrics_gauge (
     MetricName String,


### PR DESCRIPTION
## What

Fixes a harness bug that made all twelve `@ start()` / `@ end()` fixtures
disagree with the reference engine for a reason unrelated to their query, then
enrols them. Parity enrolment goes **438 → 450**.

## The bug

A fixture whose query carries `@ start()` or `@ end()` is lowered over the
harness's fixed `[Unix(100), Unix(500)]` pair, because that is the only way the
two modifiers resolve to distinguishable instants — an instant query has
`start == end` and collapses them.

`RunParity` was handed `instantEval` (2026-01-01T00:00:01) regardless. The
reference engine was therefore asked a *different question* than the one
cerberus had been lowered for, and reported disagreements like:

```
fixture at_start_basic: reference engine returned 0 sample(s), cerberus 1.
  reference: []
  cerberus:  [{map[__name__:up instance:a] 100000 1}]
```

The call site now passes the same window the lowering used.

## Why that alone is not enough

Prometheus has no query shape with that combination. An instant query has
`start == end` and collapses both modifiers; a range query over the window
resolves them correctly but answers with a sample at *every step*, not the
single sample cerberus was asked for. Handing the reference either one still
compares two different questions.

The parity path therefore substitutes the instants the modifiers resolve to and
evaluates as an instant query at `End`.

**This is not reimplementing cerberus's lowering.** `start()` over a query
starting at 100 *is* `@ 100`, per the PromQL specification — the substitution
is the modifier's definition at that window. Everything else in the expression
is still evaluated independently by the real engine, and a lowering that
resolved the anchor to the **wrong** instant reads a different sample than the
reference and fails.

A range query needs no substitution: its window reaches the reference engine
intact, so Prometheus resolves both modifiers itself.

## Absorption demo

Resolved `start()` to `ctx.end` in `anchorFromSelector` — a plausible one-token
slip — and regenerated both goldens under it:

```
fixture at_start_basic: reference engine returned 1 sample(s), cerberus 0.
  reference: [{map[__name__:up instance:a] 100000 1}]
  cerberus:  []
```

Red after full `GOLDEN_UPDATE=1` regeneration of `-- sql --` and
`-- expected_rows --`, which is the point: nothing about the anchor was
checkable by this corpus before.

## Verification

`go test -tags chdb -count=1 ./internal/promql/` — green with all 450 enrolled
(211s). `go vet -tags chdb,agpl_oracle,chdb_agpl_oracle` clean over
`./test/spec/...` and `./internal/promql/`. The injected slip was reverted and
every fixture diff verified to be exactly `+4/-0` lines.

## Remaining work

The full corrected accounting of the 127 still-unenrolled promql fixtures is on
#1986. The largest remaining class is native / exponential histograms (53),
which need `oracle.Result` to carry a `FloatHistogram`.

Part of #1986.
