### PR TITLE
fix(e2e): classify the anonymous primarySignal Select as enumerate

### DIFF
--- a/test/e2e/playwright/crawl/crawl.spec.ts
+++ b/test/e2e/playwright/crawl/crawl.spec.ts
@@ -876,7 +876,7 @@ test.describe('crawl: canonicalization pins', () => {
     // "Server spans…" — is the lean representative, matching the
     // committed `kind=server` baseline row.
     const serverLabel =
-      'Server spansExplore server-specific segments traces';
+      'Server spansExplore server-specific segments of traces';
     const consumerLabel =
       'Consumer spansAnalyze interactions initiated by consumer services';
     const databaseLabel =

--- a/test/e2e/playwright/crawl/crawl.spec.ts
+++ b/test/e2e/playwright/crawl/crawl.spec.ts
@@ -858,6 +858,82 @@ test.describe('crawl: canonicalization pins', () => {
     ).toThrow(/exceeding the pairwise cap/);
   });
 
+  test('the anonymous primarySignal Select enumerates every option, never one representative', () => {
+    // The Traces Drilldown primary-signal picker's Select half carries
+    // no testid, no aria-label and no placeholder (verified live
+    // against a compose stack — a plugin-side accessibility gap), so
+    // discovery's key derivation falls through to the react-select
+    // mount-order id, normalized to the generic
+    // `select[react-select-{rid}-input]` shape. Left unrecognised, that
+    // key matches no COMBOBOX_CARDINALITY_RULES entry, so planInteractions
+    // treats it as high-cardinality and representativeOption's
+    // codepoint-order pick lands on "Consumer spans…" every run
+    // ('C' < 'D' < 'S') — the app never shows the crawl "Server spans…",
+    // no matter how much backing data Server carries in ClickHouse
+    // (#1992). The rule this pins fixes the classification, not the
+    // pick: once correctly 'enumerate', the control drives all three
+    // signals, and the FIRST one in the app's own bundle order —
+    // "Server spans…" — is the lean representative, matching the
+    // committed `kind=server` baseline row.
+    const serverLabel =
+      'Server spansExplore server-specific segments traces';
+    const consumerLabel =
+      'Consumer spansAnalyze interactions initiated by consumer services';
+    const databaseLabel =
+      'Database callsEvaluate performance issues in database interactions';
+    const control = {
+      kind: 'combobox' as const,
+      key: 'select[react-select-{rid}-input]',
+      options: [serverLabel, consumerLabel, databaseLabel],
+      selectedIndex: -1,
+      forcedHighCardinality: false,
+      optionHints: [serverLabel, consumerLabel, databaseLabel],
+      controlHint: 'id=react-select-3-input',
+      clickHops: 3,
+    };
+
+    expect(comboboxCardinalityRule(control.key)?.mode).toBe('enumerate');
+
+    const plan = planInteractions([control], 0);
+    expect(plan.map((p) => p.option)).toEqual([
+      serverLabel,
+      consumerLabel,
+      databaseLabel,
+    ]);
+    expect(plan.map((p) => p.stateValue)).toEqual([
+      serverLabel,
+      consumerLabel,
+      databaseLabel,
+    ]);
+    expect(plan.map((p) => p.leanRepresentative)).toEqual([
+      true,
+      false,
+      false,
+    ]);
+    // A pinned-param (representative-only) surface still drives exactly
+    // the lean pick, never the codepoint-smallest label.
+    expect(planInteractions([control], 1).map((p) => p.option)).toEqual([
+      serverLabel,
+    ]);
+
+    // The declared option set is a safety net, not a rubber stamp for
+    // every anonymous react-select: a DIFFERENT unlabeled control that
+    // happens to collide on the same generic key but carries options
+    // outside this bundle-read set must fail loudly, not silently
+    // borrow the classification and enumerate a data-derived list.
+    const impostor = {
+      ...control,
+      options: [serverLabel, 'A seeded label the picker never declared'],
+      optionHints: [serverLabel, 'A seeded label the picker never declared'],
+    };
+    expect(() => planInteractions([impostor], 0)).toThrow(
+      /select\[react-select-\{rid\}-input\]/,
+    );
+    expect(() => planInteractions([impostor], 0)).toThrow(
+      /outside its declared closed set/,
+    );
+  });
+
   test('the high-cardinality representative is a function of the option SET, not its order', () => {
     // The pick must not move when the app renders the same options in a
     // different order — a data-backed list (label names, tag values,

--- a/test/e2e/playwright/crawl/interactions.ts
+++ b/test/e2e/playwright/crawl/interactions.ts
@@ -196,7 +196,7 @@ export const COMBOBOX_CARDINALITY_RULES: ReadonlyArray<ComboboxCardinalityRule> 
     keyPattern: /^select\[react-select-\{rid\}-input\](#\d+)?$/,
     mode: 'enumerate',
     values: [
-      'Server spansExplore server-specific segments traces',
+      'Server spansExplore server-specific segments of traces',
       'Consumer spansAnalyze interactions initiated by consumer services',
       'Database callsEvaluate performance issues in database interactions',
     ],

--- a/test/e2e/playwright/crawl/interactions.ts
+++ b/test/e2e/playwright/crawl/interactions.ts
@@ -169,6 +169,38 @@ export const COMBOBOX_CARDINALITY_RULES: ReadonlyArray<ComboboxCardinalityRule> 
   },
   // Dashboard-browse "sort by": a fixed alphabetical/recency menu.
   { keyPattern: /^select\[Sort\](#\d+)?$/, mode: 'enumerate' },
+  // Traces Drilldown "primary signal" picker (the Select half — the
+  // RadioButtonGroup half carrying "Root spans" / "All spans" is a
+  // separate 'radio' control, already structural by size). The widget
+  // carries NEITHER a testid NOR an aria-label NOR a placeholder — a
+  // plugin-side accessibility gap verified live against
+  // grafana-exploretraces-app, so discovery's identity chain falls all
+  // the way through to the react-select mount-order id, normalized to
+  // the generic `react-select-{rid}-input` every unlabeled react-select
+  // on ANY page shares. That generic pattern is deliberately NOT enough
+  // on its own to earn 'enumerate' — a coincidentally-anonymous,
+  // genuinely data-derived select elsewhere must not inherit it. The
+  // `values` set closes that gap: it is the SAME three primarySignal
+  // labels lib.ts's `var-primarySignal` StructuralParamRule already
+  // declares (`kind=server` / `kind=consumer` /
+  // `span.db.system.name!=""`, minus the two the RadioButtonGroup
+  // holds), read off the plugin bundle rather than a seed. A control
+  // that matches the key but NOT this option set throws in
+  // planInteractions's self-check below instead of silently borrowing
+  // the classification — the crawl was reaching this exact set,
+  // uncatalogued, before: `representativeOption`'s codepoint-order pick
+  // landed on "Consumer spans…" ('C' < 'D' < 'S'), so the sweep drove
+  // Consumer every run and never Server, no matter how much backing
+  // data Server carried (#1992).
+  {
+    keyPattern: /^select\[react-select-\{rid\}-input\](#\d+)?$/,
+    mode: 'enumerate',
+    values: [
+      'Server spansExplore server-specific segments traces',
+      'Consumer spansAnalyze interactions initiated by consumer services',
+      'Database callsEvaluate performance issues in database interactions',
+    ],
+  },
 ];
 
 export function comboboxCardinalityRule(


### PR DESCRIPTION
## Summary

Root-causes and fixes #1992: `compose-smoke-shard-crawl`'s intermittent
surface-inventory ratchet violation on `var-primarySignal` (pinned
`kind=server` never visited, unpinned `kind=consumer` discovered as new).

`test/e2e/playwright/crawl/interactions.ts`'s `COMBOBOX_CARDINALITY_RULES`
had no entry matching the Traces Drilldown primary-signal picker's Select
control. Verified live against a running compose stack (read-only
Playwright inspection, no crawl mutation): the control carries no
`data-testid`, no `aria-label`, no `placeholder` and no identifiable
ancestor testid — a plugin-side accessibility gap in
`grafana-exploretraces-app`. Discovery's key derivation therefore falls
all the way through to the react-select mount-order id, normalized to the
generic `select[react-select-{rid}-input]` shape.

With no `COMBOBOX_CARDINALITY_RULES` entry matching that key,
`planInteractions` treated the control as high-cardinality, and
`representativeOption`'s codepoint-order pick (the #1891 fix for
order-independent representative selection) deterministically landed on
`"Consumer spans…"` — `'C' < 'D' < 'S'` — every single run. The sweep
therefore drove `kind=consumer` and never `kind=server`, independent of
how much backing data Server carried in ClickHouse (11,387 spans vs
Consumer's 1), exactly matching the issue's own live-ClickHouse
cross-check.

## Fix

Add a `COMBOBOX_CARDINALITY_RULES` entry matching the generic anonymous
key, gated by the exact three option labels the plugin bundle renders
(the same primary-signal set `lib.ts`'s `var-primarySignal`
`StructuralParamRule` already declares as a closed, bundle-read set). The
option-set gate is the safety net against over-generalizing: a
coincidentally-anonymous but genuinely data-derived react-select
elsewhere in the app would not match this rule's declared values, and
would fail loudly via the existing "outside its declared closed set"
self-check in `planInteractions` rather than silently inheriting the
`enumerate` classification.

Once correctly classified `enumerate`, the control drives all three
signals at full depth, and the lean representative is deterministically
`"Server spans…"` (first in the app's own bundle order) — matching the
committed `kind=server` baseline row exactly.

This is a control-classification fix, not a value allow-list: it does not
special-case `kind=server`, and it does not touch the ratchet, the
inventory, or the ordering/representative-pick logic `#1891` already
fixed for the timing-race class.

## Verification

- Reproduced the actual DOM shape live against a running compose stack
  (another agent's in-progress stack on `localhost:3000`, inspected
  read-only — no compose stack started or torn down, per the worktree
  concurrency hazard) to confirm the control's identity, its three
  option labels verbatim, and their render order.
- Added a unit test pinning: (1) the new rule's `enumerate`
  classification for the anonymous key, (2) `planInteractions` producing
  all three interactions with `"Server spans…"` as the lean
  representative at both 0 and 1 pinned structural params, and (3) an
  "impostor" control sharing the same generic key but different options
  still throws the closed-set violation rather than silently matching.
- Confirmed the new test fails (`undefined` classification) against the
  pre-fix code and passes against the fix.
- `npx tsc --noEmit` clean; the full pure-logic `crawl: canonicalization
  pins` describe block (26 tests) passes.
- `compose-smoke-shard-crawl` itself needs a live k3d/compose run to
  fully settle per CLAUDE.md invariant 5 — this PR's own CI run is that
  confirmation.

## Test plan

- [ ] CI `compose-smoke-shard-crawl` goes green and the surface-inventory
      ratchet reports no violation for `var-primarySignal`.

Closes #1992