### PR TITLE
fix(test): accept atan2's proven 1-ULP libm divergence in the parity oracle

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -200,6 +200,47 @@ behaviour change after a Prom/Loki/Tempo bump), the fix is to update
 the reference image pin or the seeder — never to add a per-case
 exception.
 
+## Known transcendental-function divergence (PromQL `atan2`)
+
+One proven exception to "every diff is a real bug": PromQL's `atan2`
+binary operator, when it involves a vector (e.g. `2 atan2 up`), lowers
+to ClickHouse's own SQL `atan2`, evaluated by ClickHouse's libm.
+Real Prometheus evaluates the same expression with Go's `math.Atan2`,
+a different IEEE-754 double-precision implementation. IEEE-754
+requires each implementation to be *correctly rounded* for its own
+algorithm, but it does not require two independent implementations to
+agree bit-for-bit on a transcendental function — only "faithfully
+rounded" within a small ULP (unit-in-the-last-place) bound, typically
+one. `test/spec/promql/binop_atan2_scalar_vector.txtar` measured
+exactly that: two of its four series disagree with the reference
+engine by 1 ULP (e.g. reference `1.3734007669450157` vs. cerberus
+`1.373400766945016`) — adjacent `float64` values, not a lowering bug.
+See [issue #1985](https://github.com/tsouza/cerberus/issues/1985) for
+the full evidence and the decision record.
+
+Production pushdown is unchanged: cerberus still evaluates
+vector-involving `atan2` in ClickHouse SQL rather than in Go, because
+buffering results client-side to chase bit-for-bit agreement on the
+17th significant digit would mean abandoning cerberus's
+push-down/never-buffer-unboundedly architecture for a divergence with
+no practical monitoring impact.
+
+The parity oracle (`test/spec/parity_chdb.go`,
+`test/spec/parityoracle/promql/oracle.go`) carries a **narrow, named,
+evidence-based exception** for exactly this case:
+`oracle.EqualAtan2Values` accepts values up to 1 ULP apart, and it is
+selected — automatically, from the fixture's own query text — only for
+a query that invokes the `atan2` operator. Every other fixture,
+including every other PromQL function named as a candidate for the
+same treatment in issue #1985 (`sin`, `cos`, `tan`, `asin`, `acos`,
+`atan`, `exp`, `ln`, `log2`, `log10`, `sqrt`), is still held to exact
+equality. **This does not extend to any other function without
+independent proof**: a function earns this treatment only by being
+enrolled at exact equality, run, and observed to diverge by a genuine
+small ULP distance, exactly as `atan2` was. Widening
+`atan2ULPTolerance`'s scope, or adding a second named tolerance without
+that evidence, defeats the whole point of it being narrow.
+
 ## Upstream-skip baseline (LogQL)
 
 The vendored `loki-bench` corpus contains a handful of queries that

--- a/test/regression/parity_contract_test.go
+++ b/test/regression/parity_contract_test.go
@@ -170,7 +170,7 @@ func TestParityEnrolmentFloor(t *testing.T) {
 
 	// parityEnrolmentFloor is the number of fixtures currently carrying a
 	// `parity:` section. It ratchets UP only.
-	const parityEnrolmentFloor = 450
+	const parityEnrolmentFloor = 451
 
 	enrolled := 0
 	for _, dir := range parityFixtureDirs(t) {

--- a/test/spec/parity_chdb.go
+++ b/test/spec/parity_chdb.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -170,7 +171,46 @@ func RunParity(t *testing.T, c *Case, evalStart, evalEnd time.Time, step time.Du
 		)
 	}
 
-	compareAgainstReference(t, c, p, rt, sc, got, compareTimestamps)
+	compareAgainstReference(t, c, p, rt, sc, got, compareTimestamps, q.Expr)
+}
+
+// atan2QueryPattern matches PromQL's atan2 binary operator (`a atan2 b`) as
+// a whole word in a fixture's query text.
+//
+// # Why detection is automatic, and why it lives here rather than in a new
+// parity.go section key or scope value
+//
+// [oracle.EqualAtan2Values] documents the ONE proven case this tolerance
+// covers: real Prometheus (Go's math.Atan2) and cerberus (ClickHouse's own
+// atan2 libm) can legitimately disagree by 1 ULP. That is a fact about the
+// FUNCTION, not about any one fixture, so any fixture whose query invokes
+// atan2 needs the same tolerance — hand-flagging each one individually
+// would just be a slower, more error-prone way to spell the same rule.
+//
+// A new required `parity:` key was considered and rejected: LoadParity
+// treats every vocabulary key as required on every enrolled fixture (see
+// parity.go), so adding one would force an edit to all ~438 already-enrolled
+// fixtures for a property only one of them has. Reusing `scope:` was
+// rejected too — its own doc comment is explicit that scope excludes a named
+// AXIS of the answer and "is NOT a tolerance knob", which a per-value ULP
+// tolerance plainly is; bending it to fit here would be the exact
+// allow-list-in-disguise shape invariant 7 forbids.
+//
+// Detecting straight off the query text keeps the exception narrow in the
+// way that matters: nothing in a fixture's `-- parity --` section can turn
+// it on, the only trigger is the literal operator name in the query being
+// evaluated, and the regexp below matches nothing but that one operator.
+var atan2QueryPattern = regexp.MustCompile(`\batan2\b`)
+
+// atan2CompareValues resolves to [oracle.EqualAtan2Values] when query is
+// PROVEN — by containing the atan2 operator — to need it, and to the
+// ordinary exact [oracle.EqualValues] otherwise. See [atan2QueryPattern] for
+// why detection happens here instead of via fixture-level configuration.
+func atan2CompareValues(query string) func(a, b float64) bool {
+	if atan2QueryPattern.MatchString(query) {
+		return oracle.EqualAtan2Values
+	}
+	return oracle.EqualValues
 }
 
 // atStartModifier / atEndModifier are the two `@` modifiers whose
@@ -411,7 +451,7 @@ func parityProjectionColumns(db *sql.DB, rt *RoundTripSections) ([]string, error
 
 func compareAgainstReference(
 	t *testing.T, c *Case, p *Parity, rt *RoundTripSections, sc sampleColumns,
-	got []referenceSample, compareTimestamps bool,
+	got []referenceSample, compareTimestamps bool, query string,
 ) {
 	t.Helper()
 
@@ -430,6 +470,15 @@ func compareAgainstReference(
 		)
 	}
 
+	// equalValues is oracle.EqualValues for every fixture except one whose
+	// query is proven to invoke atan2, where it is oracle.EqualAtan2Values.
+	// See atan2CompareValues for why that ULP-bounded relaxation is sound
+	// and narrow. It is resolved once for both heads on purpose: sample
+	// equality is one rule (plus this one named exception), not one per
+	// head, and duplicating it would let the two drift into disagreeing
+	// about what "equal" means.
+	equalValues := atan2CompareValues(query)
+
 	for i := range got {
 		g, w := got[i], want[i]
 		if labelKey(g.Labels) != labelKey(w.Labels) {
@@ -437,11 +486,7 @@ func compareAgainstReference(
 				c.Name, i, g.Labels, w.Labels)
 			continue
 		}
-		// oracle.EqualValues is the promql oracle's NaN-aware float
-		// predicate. It is used for BOTH heads on purpose: sample equality
-		// is one rule, not one per head, and duplicating it would let the
-		// two drift into disagreeing about what "equal" means.
-		if !oracle.EqualValues(g.Value, w.Value) {
+		if !equalValues(g.Value, w.Value) {
 			t.Errorf("fixture %s sample %d (%v): value differs\n  reference: %v\n  cerberus:  %v",
 				c.Name, i, g.Labels, g.Value, w.Value)
 		}

--- a/test/spec/parityoracle/promql/oracle.go
+++ b/test/spec/parityoracle/promql/oracle.go
@@ -282,3 +282,130 @@ func EqualValues(a, b float64) bool {
 	}
 	return a == b
 }
+
+// atan2ULPTolerance is the maximum ULP (unit-in-the-last-place) distance
+// permitted between cerberus's atan2 answer and the reference engine's. It
+// is the ONE relaxation this package makes to EqualValues's exact-equality
+// rule, and it exists for exactly one proven reason — see
+// [EqualAtan2Values].
+const atan2ULPTolerance = 1
+
+// EqualAtan2Values reports whether two float samples PRODUCED BY EVALUATING
+// PROMQL'S atan2 agree within [atan2ULPTolerance] ULPs. NaN==NaN is TRUE
+// here for the same reason it is in EqualValues.
+//
+// # Why atan2 gets a tolerance and nothing else in this package does
+//
+// invariant 7 forbids a tolerance dressed up as a numeric constant, so this
+// one earns its place by being the opposite: a NAMED exception for a SINGLE
+// function, adopted only after that function was independently proven to
+// diverge, not adopted speculatively for a class it might belong to.
+//
+// binop_atan2_scalar_vector.txtar (`2 atan2 up`) evaluates atan2 two
+// different ways: the reference engine calls Go's math.Atan2, and cerberus
+// lowers the vector-involving case to ClickHouse's own SQL atan2, evaluated
+// by ClickHouse's libm. Two of the fixture's four series disagree in the
+// last bit of the mantissa — e.g. reference 1.3734007669450157 versus
+// cerberus 1.373400766945016, and reference 1.2341215074081693 versus
+// cerberus 1.2341215074081695 — which is exactly what IEEE-754 permits: the
+// standard requires each implementation to be correctly rounded for its OWN
+// algorithm, but it does not require two independent libm implementations
+// to agree bit-for-bit on a transcendental function, only "faithfully
+// rounded" within a small ULP bound, typically 1. That is a fact about
+// floating-point arithmetic, not a lowering bug, and no amount of chasing it
+// in cerberus's SQL would close it — the fix would have to live in
+// ClickHouse's libm.
+//
+// This does NOT extend to any other PromQL function. sin, cos, tan, asin,
+// acos, atan, exp, ln, log2, log10 and sqrt are all named as candidates in
+// issue #1985, and NONE of them has been measured to diverge — for all this
+// package knows today, ClickHouse and Go's math package agree on every one
+// of them exactly. A future function earns this same treatment only the
+// same way atan2 did: enrol its fixture at ordinary EqualValues, run it, and
+// observe a genuine small-ULP disagreement. Until that proof exists for a
+// given function, a mismatch on it is a real bug and EqualValues — exact
+// equality — is the correct comparator. Do not widen atan2ULPTolerance's
+// scope, and do not add a second named tolerance without the same evidence
+// this one has (see the issue for the seed values and the exact diffs).
+//
+// Note that PromQL's pure scalar-scalar atan2 (`1 atan2 2`) is unaffected:
+// internal/promql/scalar.go constant-folds it with Go's own math.Atan2, so
+// it already matches the reference engine exactly and needs no tolerance.
+// Only the vector-involving shape, evaluated per-row in ClickHouse SQL,
+// diverges.
+func EqualAtan2Values(a, b float64) bool {
+	if math.IsNaN(a) && math.IsNaN(b) {
+		return true
+	}
+	if math.IsNaN(a) || math.IsNaN(b) {
+		return false
+	}
+	return ulpDistance(a, b) <= atan2ULPTolerance
+}
+
+// ulpDistance returns the number of math.Nextafter steps needed to walk
+// from a to b — the standard definition of ULP distance for IEEE-754
+// doubles, and exactly what "faithfully rounded within N ULPs" means. It is
+// 0 for equal values (including +0 and -0, which compare equal), 1 for
+// adjacent representable values, and so on.
+//
+// # How this works
+//
+// math.Float64bits gives each float's raw IEEE-754 bit pattern, which for
+// non-negative floats already increases monotonically with the value (a
+// deliberate property of the IEEE-754 encoding). monotonicUint64 extends
+// that monotonicity across the sign boundary too, so that once both values
+// are mapped, their ULP distance is simply the unsigned difference between
+// the two representations.
+//
+// This was verified against math.Nextafter itself — not just eyeballed —
+// by walking 5000 consecutive Nextafter steps across the positive/negative
+// boundary and checking ulpDistance agreed with the step count at every
+// one. That check matters because the naive version of this trick (flip
+// every bit for a negative value, flip only the sign bit for a
+// non-negative one — the form most references, including Google Test's
+// comparator, show) treats +0.0 and -0.0 as two DISTINCT adjacent slots.
+// They are not: math.Nextafter — and IEEE-754 equality — treat zero as a
+// single point, so that naive form overcounts by 1 for any pair straddling
+// zero. monotonicUint64 collapses them into one slot instead.
+func ulpDistance(a, b float64) uint64 {
+	if a == b {
+		return 0
+	}
+	ua, ub := monotonicUint64(a), monotonicUint64(b)
+	if ua > ub {
+		ua, ub = ub, ua
+	}
+	return ub - ua
+}
+
+// signBit64 is the sign bit of an IEEE-754 double's raw bit pattern.
+const signBit64 = uint64(1) << 63
+
+// monotonicUint64 maps a float64 onto a uint64 whose ordering agrees with
+// the float's own ordering across the whole range, sign boundary included,
+// with +0.0 and -0.0 mapped to the SAME value. See [ulpDistance] for why
+// that last part matters and how this was checked.
+//
+// The branch is on the float's VALUE (f < 0), not its bit pattern's sign
+// bit, which is what makes -0.0 — value-wise non-negative, despite its sign
+// bit being set — fall into the same branch as +0.0. bits(-0.0) is just the
+// sign bit with no magnitude bits, so ORing it with signBit64 is a no-op
+// and lands it on exactly the same slot as +0.0, with no special case
+// needed for it.
+//
+// For a genuinely negative float, the magnitude bits (its bit pattern with
+// the sign bit cleared) increase as the value gets more negative, so
+// subtracting them from signBit64 maps the value into a mirror range
+// immediately below zero's slot with no gap and no overlap: the smallest
+// magnitude (1, the negative value adjacent to zero) lands one below zero,
+// exactly where the non-negative side's smallest magnitude lands one
+// above it.
+func monotonicUint64(f float64) uint64 {
+	bits := math.Float64bits(f)
+	if f < 0 {
+		magnitude := bits &^ signBit64
+		return signBit64 - magnitude
+	}
+	return bits | signBit64
+}

--- a/test/spec/parityoracle/promql/oracle_atan2_test.go
+++ b/test/spec/parityoracle/promql/oracle_atan2_test.go
@@ -1,0 +1,173 @@
+package promql
+
+import (
+	"math"
+	"testing"
+)
+
+// TestEqualAtan2Values_IssueValues pins the exact pair from issue #1985: the
+// real Prometheus engine (Go math.Atan2) answered 1.3734007669450157 for
+// `2 atan2 up{job="api",instance="a"}` where cerberus (ClickHouse's own
+// atan2) answered 1.373400766945016. These are adjacent float64 values —
+// exactly the 1-ULP libm divergence [EqualAtan2Values] exists to accept —
+// and must compare equal under it.
+func TestEqualAtan2Values_IssueValues(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		reference float64
+		cerberus  float64
+	}{
+		{"api/a series", 1.3734007669450157, 1.373400766945016},
+		{"web/b series", 1.2341215074081693, 1.2341215074081695},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			if dist := ulpDistance(c.reference, c.cerberus); dist != 1 {
+				t.Fatalf(
+					"ulpDistance(%v, %v) = %d, want 1 — the issue's own evidence claims these are "+
+						"adjacent doubles; if this fails, the issue's premise or this math is wrong",
+					c.reference, c.cerberus, dist,
+				)
+			}
+			if !EqualAtan2Values(c.reference, c.cerberus) {
+				t.Fatalf("EqualAtan2Values(%v, %v) = false, want true (1 ULP apart)", c.reference, c.cerberus)
+			}
+			// Symmetry: the comparator must not depend on argument order.
+			if !EqualAtan2Values(c.cerberus, c.reference) {
+				t.Fatalf("EqualAtan2Values is not symmetric for %v, %v", c.cerberus, c.reference)
+			}
+		})
+	}
+}
+
+// TestEqualAtan2Values_RejectsTwoULPs constructs a value exactly 2 ULPs away
+// from a baseline via two chained math.Nextafter steps, and asserts
+// EqualAtan2Values rejects it. Without this, atan2ULPTolerance could silently
+// regress into "always true" and no test would notice.
+func TestEqualAtan2Values_RejectsTwoULPs(t *testing.T) {
+	t.Parallel()
+
+	base := 1.3734007669450157
+	oneULP := math.Nextafter(base, math.Inf(1))
+	twoULP := math.Nextafter(oneULP, math.Inf(1))
+
+	if dist := ulpDistance(base, oneULP); dist != 1 {
+		t.Fatalf("ulpDistance(base, oneULP) = %d, want 1", dist)
+	}
+	if dist := ulpDistance(base, twoULP); dist != 2 {
+		t.Fatalf("ulpDistance(base, twoULP) = %d, want 2", dist)
+	}
+
+	if !EqualAtan2Values(base, oneULP) {
+		t.Fatalf("EqualAtan2Values(base, oneULP) = false, want true")
+	}
+	if EqualAtan2Values(base, twoULP) {
+		t.Fatalf("EqualAtan2Values(base, twoULP) = true, want false — 2 ULPs exceeds the tolerance")
+	}
+}
+
+// TestEqualAtan2Values_NaN pins the same NaN==NaN carve-out EqualValues
+// documents, and asserts a NaN never spuriously agrees with a real number
+// just because ulpDistance is not called on that path.
+func TestEqualAtan2Values_NaN(t *testing.T) {
+	t.Parallel()
+
+	nan := math.NaN()
+	if !EqualAtan2Values(nan, nan) {
+		t.Fatalf("EqualAtan2Values(NaN, NaN) = false, want true")
+	}
+	if EqualAtan2Values(nan, 1.0) || EqualAtan2Values(1.0, nan) {
+		t.Fatalf("EqualAtan2Values must not treat NaN as equal to a real number")
+	}
+}
+
+// TestEqualValues_UnaffectedByAtan2Tolerance is the negative control: an
+// ordinary, non-atan2 comparison one ULP apart must still be EXACT under
+// EqualValues. This is what makes atan2ULPTolerance a narrow exception
+// rather than a change to the package's default equality rule.
+func TestEqualValues_UnaffectedByAtan2Tolerance(t *testing.T) {
+	t.Parallel()
+
+	base := 1.3734007669450157
+	oneULP := math.Nextafter(base, math.Inf(1))
+
+	if EqualValues(base, oneULP) {
+		t.Fatalf(
+			"EqualValues(base, oneULP) = true, want false — EqualValues must stay exact for every " +
+				"fixture that is not atan2; only EqualAtan2Values relaxes it",
+		)
+	}
+}
+
+// TestUlpDistance_Zero asserts equal values (including the a==b fast path
+// and the +0/-0 case, which compare equal under Go's ==) have distance 0.
+func TestUlpDistance_Zero(t *testing.T) {
+	t.Parallel()
+
+	if d := ulpDistance(1.5, 1.5); d != 0 {
+		t.Fatalf("ulpDistance(1.5, 1.5) = %d, want 0", d)
+	}
+	if d := ulpDistance(0.0, math.Copysign(0, -1)); d != 0 {
+		t.Fatalf("ulpDistance(+0, -0) = %d, want 0", d)
+	}
+}
+
+// TestUlpDistance_NegativeRange checks the sign-boundary fold monotonicUint64
+// performs: two adjacent negative doubles must report distance 1, the same
+// as two adjacent positive ones, and a pair straddling zero must report the
+// correct count too.
+func TestUlpDistance_NegativeRange(t *testing.T) {
+	t.Parallel()
+
+	negBase := -1.0
+	negNext := math.Nextafter(negBase, math.Inf(-1)) // more negative, 1 ULP away
+	if d := ulpDistance(negBase, negNext); d != 1 {
+		t.Fatalf("ulpDistance(-1.0, nextMoreNegative) = %d, want 1", d)
+	}
+
+	posBase := 1.0
+	posNext := math.Nextafter(posBase, math.Inf(1))
+	if d := ulpDistance(posBase, posNext); d != 1 {
+		t.Fatalf("ulpDistance(1.0, nextMorePositive) = %d, want 1", d)
+	}
+
+	// Straddling zero: the smallest positive subnormal and the smallest
+	// (in magnitude) negative subnormal are 2 ULPs apart (one step each
+	// side of zero) — verified directly against math.Nextafter's own
+	// walk in TestUlpDistance_MatchesNextafterWalk, since +0.0 and -0.0
+	// are easy to double-count as two slots instead of one.
+	smallestPos := math.Nextafter(0, math.Inf(1))
+	smallestNeg := math.Nextafter(math.Copysign(0, -1), math.Inf(-1))
+	if d := ulpDistance(smallestPos, smallestNeg); d != 2 {
+		t.Fatalf("ulpDistance(smallestPos, smallestNeg) = %d, want 2", d)
+	}
+}
+
+// TestUlpDistance_MatchesNextafterWalk is the ground-truth check for
+// ulpDistance: it walks math.Nextafter one step at a time across the
+// positive/negative boundary and asserts ulpDistance agrees with the
+// running step count at every single step, not just at a couple of
+// hand-picked points. This is what caught the original implementation's
+// off-by-one at the +0.0/-0.0 seam during development — a bit-pattern
+// formula can look right on a spot check and still be wrong at the one
+// place floats behave non-uniformly.
+func TestUlpDistance_MatchesNextafterWalk(t *testing.T) {
+	t.Parallel()
+
+	const steps = 5000
+	const start = -1e-300
+	const target = 1e-300 + 1 // any value above the walked range
+
+	x := start
+	for i := 1; i <= steps; i++ {
+		x = math.Nextafter(x, target)
+		if got := ulpDistance(start, x); got != uint64(i) {
+			t.Fatalf("after %d Nextafter step(s) from %v, ulpDistance = %d, want %d", i, start, got, i)
+		}
+	}
+}

--- a/test/spec/promql/binop_atan2_scalar_vector.txtar
+++ b/test/spec/promql/binop_atan2_scalar_vector.txtar
@@ -1,5 +1,9 @@
 -- query.promql --
 2 atan2 up
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query
+scope: full
 -- seed --
 CREATE TABLE otel_metrics_gauge (
     MetricName String,


### PR DESCRIPTION
## Summary

- ClickHouse's `atan2` and Go's `math.Atan2` (real Prometheus's evaluator) are different IEEE-754
  libm implementations; IEEE-754 requires each to be correctly rounded for its own algorithm but
  does not require bit-identical cross-implementation results on a transcendental function, only
  "faithfully rounded" within ~1 ULP. `binop_atan2_scalar_vector.txtar` (`2 atan2 up`) measured
  exactly that on 2 of its 4 series, which left the fixture unable to carry a `-- parity --`
  section at all under the oracle's exact-equality rule.
- **Decision (this PR implements, does not relitigate): production pushdown is unchanged.**
  Cerberus keeps evaluating vector-involving `atan2` in ClickHouse SQL — matching Prometheus
  bit-for-bit would mean buffering results client-side in Go, a real reversal of the
  push-down/never-buffer architecture, for a divergence in the 17th significant digit with zero
  practical monitoring value. No runtime config knob is added.
- The fix lives entirely in test infra: `oracle.EqualAtan2Values`, a **named, evidence-based
  1-ULP comparator scoped only to `atan2`** — the one function proven to diverge — not
  preemptively applied to the wider transcendental family the issue names as candidates
  (`sin`/`cos`/`tan`/`asin`/`acos`/`atan`/`exp`/`ln`/`log2`/`log10`/`sqrt`). It is selected
  automatically from a fixture's own query text (detects the literal `atan2` operator), never
  from fixture-level configuration, so nothing in a `-- parity --` section can widen it.
- The fixture is now enrolled (`-- parity --`, `scope: full`) and the enrolment floor bumped by
  the 1 fixture gained. `docs/compatibility.md` documents the divergence and its explicit,
  non-extending scope.

## Why this isn't the invariant-7 allow-list it looks like

`EqualValues` (the oracle's default comparator) is untouched — still exact equality everywhere,
with the pre-existing NaN==NaN carve-out. `EqualAtan2Values` is a second, separately-named
function that exists **only** because `atan2`'s divergence was independently measured (the exact
values from #1985 are pinned in a unit test), not adopted speculatively for a function class it
might belong to. A future function earns the same treatment only by going through the same proof:
enrolled at exact equality, run, observed to diverge by a genuine small ULP distance. This
extension contract is spelled out in the doc comments on `oracle.EqualAtan2Values` and
`atan2QueryPattern`, and in `docs/compatibility.md`.

A new required `parity:` section key was considered and rejected — `LoadParity` treats every
vocabulary key as required on every enrolled fixture, so it would force an edit to all ~450
already-enrolled fixtures for a property only one of them has. Reusing `scope:` was rejected too:
its own doc comment is explicit that scope excludes a named *axis* of the answer and is *not* a
tolerance knob, which a per-value ULP tolerance plainly is.

## Live compat harness (`compatibility/prometheus/cerberus-test-queries.yml`)

The 3 existing `atan2` cases there (`demo_memory_usage_bytes atan2 demo_memory_usage_bytes`,
`demo_memory_usage_bytes atan2 2`, `2 atan2 demo_memory_usage_bytes`) already pass cleanly on the
most recent `compatibility` CI run (run 31327827537, head SHA `a6f2a48b`, exactly this branch's
merge-base) — checked via the run's downloaded `compat-cases.json`. Left untouched per the brief:
no live infra here to reproduce a diff that isn't currently showing, and a source patch to the
vendored `promql-compliance-tester` comparer is a bigger, riskier change than this in-house fix
that current evidence doesn't call for.

## Test plan

- [x] `go test -tags chdb -count=1 -run '^TestLower$/^binop_atan2_scalar_vector$' ./internal/promql/`
      — passes with the new comparator.
- [x] Absorption-style proof: temporarily disabled the ULP branch in `atan2CompareValues` and
      reran the same test — it failed on exactly the 2 series #1985 reports
      (`1.3734007669450157` vs `1.373400766945016`, `1.2341215074081693` vs `1.2341215074081695`),
      then restored and reconfirmed green.
- [x] `go test ./test/spec/parityoracle/promql/...` — new unit tests: the issue's own pinned
      values (1 ULP, accepted), a constructed 2-ULP value (rejected), NaN handling, a non-atan2
      pair one ULP apart still rejected by `EqualValues` (negative control), and a 5000-step
      `math.Nextafter` walk across the positive/negative boundary checked against `ulpDistance` at
      every single step (this caught and fixed a real off-by-one in the initial bit-trick
      implementation at the `+0.0`/`-0.0` seam before it shipped).
- [x] `go test -run TestParityEnrolmentFloor ./test/regression/...` — floor bumped 450 → 451,
      confirmed via the test's own failure message before editing the constant.
- [x] `go test -tags chdb -count=1 -run '^TestLower$' ./internal/promql/` — full corpus (800+
      fixtures, all 450 parity-enrolled ones included) still green with the new comparator wired
      into the shared `compareAgainstReference` path.
- [x] `go build -tags chdb ./...`, `go vet -tags chdb ./test/spec/... ./test/regression/...`,
      `gofumpt -extra -l`, `node .github/scripts/forbid-sql-raw.mjs` — all clean.
- [x] `markdownlint-cli2` on `docs/compatibility.md` — clean.
- [ ] CI green (lint / compat lanes per invariant 5 — cannot be settled locally).

## Notes for reviewers

`test/spec/parity_chdb.go`'s `compareAgainstReference` now resolves its float comparator once via
`atan2CompareValues(query)` instead of calling `oracle.EqualValues` inline — this is shared by both
the PromQL and LogQL parity paths on purpose (one equality rule, not one per head), and is a no-op
for LogQL since `atan2` isn't a LogQL construct.

Closes #1985
