### PR TITLE
docs(chsql): pin why resets() staying float-only is correct, not partial

### DIFF
--- a/internal/chsql/range_window.go
+++ b/internal/chsql/range_window.go
@@ -2683,6 +2683,31 @@ func (e *emitter) emitRangeWindowDeriv(r *chplan.RangeWindow) error {
 // Implementation: the standard arrayPopBack/arrayPopFront sandwich
 // gives parallel `prev` / `curr` lists; an arrayMap with a per-pair
 // `if(curr < prev, 1, 0)` indicator + arraySum reduces to the count.
+//
+// Float-only is intentionally complete, not partial. Upstream's
+// funcResets (promql/functions.go, github.com/tsouza/prometheus fork)
+// counts three conditions: a float-float pair with curr < prev (the one
+// this emitter implements), a float<->histogram type transition
+// (always a reset), and a histogram-histogram pair where
+// curr.H.DetectReset(prev.H) fires (bucket count or schema/count
+// regressing). Conditions 2 and 3 need a histogram-shaped sample to
+// ever occur, and no lowering path can produce one here:
+// expHistogramSelectorRouting (internal/promql/lower.go) rejects
+// `resets()` over an exponential-histogram selector at lowering time,
+// before a RangeWindow node exists to reach this emitter (pinned by
+// TestLower_ExpHistogram_UnsupportedShapesRejectExplicitly/resets).
+// Classic-histogram `_bucket{le=...}` selectors don't need the extra
+// conditions either — wrapHistogramBucketFanout already fans each `le`
+// bucket into its own independent float series, so condition 1 alone
+// answers correctly. Every RangeWindow{Func: "resets"} this emitter (and
+// its native-grid counterpart, timeSeriesResetsToGrid in
+// range_window_native.go — itself a ClickHouse builtin with no
+// histogram-valued signature) ever receives is float-only by
+// construction. Tracked as a deliberate, documented divergence (cerberus
+// rejects what reference Prometheus answers) under #1772; extending
+// resets() to histogram input is scoped there alongside rate() (see
+// #1926/#1967) for whenever that lands — see #1493 (closed) for the
+// exact 3-condition kernel spec above.
 func (e *emitter) emitRangeWindowResets(r *chplan.RangeWindow) error {
 	value := Cast(
 		Call(


### PR DESCRIPTION
## Summary

- Investigated #1493 (`resets()` reduces over floats only, missing two of upstream `funcResets`'s three conditions) and confirmed against `github.com/tsouza/prometheus@v0.0.1-cerberus-parser`'s `funcResets` (`promql/functions.go:1949-2018`) that the three conditions the issue names are exactly right: float<prev, float↔histogram type transition (always a reset), and histogram `DetectReset` (bucket/schema/count regression).
- Conditions 2 and 3 are **not reachable in cerberus today, by design**: `expHistogramSelectorRouting` (`internal/promql/lower.go`) rejects `resets()` over an exp-histogram selector at lowering time, before a `chplan.RangeWindow` node is even constructed — pinned by `TestLower_ExpHistogram_UnsupportedShapesRejectExplicitly/resets`. Classic-histogram `_bucket{le=...}` selectors don't need the extra conditions either, since each bucket is already fanned into its own independent float series before it ever reaches `resets()`.
- Extending `resets()` to answer over histograms (rather than reject) is already tracked as a deliberate divergence under #1772, whose "assess `resets()`/`sum()`/bare selectors alongside" `rate()` follow-up list is where this belongs once #1926/#1967's native-histogram-result infrastructure extends past its current `rate()`/`increase()`/`sum()`/bare-selector scope.
- No behavioural change ships here: implementing the bucket-reset/type-transition kernel now would be dead code with no lowering path able to reach it (no real fixture could exercise it). Instead this documents the exact 3-condition kernel spec + reachability chain directly on `emitRangeWindowResets` (`internal/chsql/range_window.go`) so whoever picks up that follow-on work has the spec in hand.
- Closed #1493 as not-planned/superseded by #1772 (comment there has the full writeup); cross-linked from #1772.

## Test plan

- [x] `go build ./internal/chsql/...` — builds clean.
- [x] `go vet ./internal/chsql/...` — clean.
- [x] `node .github/scripts/forbid-sql-raw.mjs` — no raw-SQL violations (doc-only diff).
- [x] `go test ./internal/chsql/...` — all existing `resets`-related unit tests pass unchanged.
- [x] `go test ./internal/promql/ -run '^TestLower_ExpHistogram_UnsupportedShapesRejectExplicitly$/^resets$'` — confirms the rejection this doc comment relies on is still in force on current `main`.

Closes #1493