### PR TITLE
feat(promql): answer a bare native-histogram selector with a histogram-valued result

### DIFF
--- a/internal/api/prom/handler.go
+++ b/internal/api/prom/handler.go
@@ -1213,6 +1213,17 @@ func errContainsStage(msg, stage string) bool {
 // Projects from the canonical-shape Projects upstream lowerings (LWR,
 // instant fns over `temperature`, etc.) emit.
 func wrapWithSampleProjection(plan chplan.Node, s schema.Metrics) chplan.Node {
+	// A histogram-VALUED plan already publishes the full wire contract:
+	// the canonical quartet FIRST, then the nine chplan.Histogram*Column
+	// outputs that internal/chclient's cursor binds when it probes the
+	// result set's final column. Re-projecting the quartet on top would
+	// drop those nine, un-latch the probe, and hand every native-histogram
+	// answer back as the placeholder float — so the correct wrapper here
+	// is no wrapper at all. RowShapeOf is the one classifier for "what
+	// does this node publish"; see chplan.HistogramRowShape.
+	if chplan.RowShapeOf(plan) == chplan.HistogramRowShape {
+		return plan
+	}
 	projections := []chplan.Projection{
 		{Expr: &chplan.ColumnRef{Name: s.MetricNameColumn}},
 		{Expr: &chplan.ColumnRef{Name: s.AttributesColumn}},

--- a/internal/api/prom/native_projection_test.go
+++ b/internal/api/prom/native_projection_test.go
@@ -123,3 +123,48 @@ func TestWrapSampleProjection_NativeRangeWindowOffsetNotReshifted(t *testing.T) 
 			ts.Expr, chplan.RangeWindowAnchorColumn)
 	}
 }
+
+// TestWrapSampleProjection_HistogramProjectionPassesThrough pins the
+// HTTP-layer wrapper's handling of a histogram-VALUED plan root (issue
+// #1967: a bare selector over an exponential histogram).
+//
+// chplan.HistogramProjection already publishes the complete wire contract
+// — the canonical sample quartet followed by the nine
+// chplan.Histogram*Column outputs — because internal/chclient's row cursor
+// decides how many destinations to bind by probing the result set's LAST
+// column name. Wrapping it in the usual four-column Project would emit
+// valid SQL that silently deletes those nine columns, un-latching the
+// probe and turning every native-histogram answer back into the
+// placeholder float. The correct wrapper is therefore no wrapper: this
+// test fails the moment someone re-adds one.
+func TestWrapSampleProjection_HistogramProjectionPassesThrough(t *testing.T) {
+	s := schema.DefaultOTelMetrics()
+
+	hp := &chplan.HistogramProjection{
+		Input:                      &chplan.Scan{Table: s.ExpHistogramTable},
+		CountColumn:                s.CountColumn,
+		SumColumn:                  s.SumColumn,
+		ScaleColumn:                s.ScaleColumn,
+		ZeroCountColumn:            s.ZeroCountColumn,
+		PositiveOffsetColumn:       s.PositiveOffsetColumn,
+		PositiveBucketCountsColumn: s.PositiveBucketCountsColumn,
+		NegativeOffsetColumn:       s.NegativeOffsetColumn,
+		NegativeBucketCountsColumn: s.NegativeBucketCountsColumn,
+		GroupBy: []chplan.Expr{
+			&chplan.ColumnRef{Name: s.MetricNameColumn},
+			&chplan.ColumnRef{Name: s.AttributesColumn},
+			&chplan.ColumnRef{Name: s.TimestampColumn},
+			&chplan.LitFloat{V: 0},
+		},
+		GroupByAliases: []string{
+			s.MetricNameColumn, s.AttributesColumn, s.TimestampColumn, s.ValueColumn,
+		},
+	}
+
+	if got := chplan.RowShapeOf(hp); got != chplan.HistogramRowShape {
+		t.Fatalf("RowShapeOf(HistogramProjection) = %s, want histogram", got)
+	}
+	if wrapped := wrapWithSampleProjection(hp, s); wrapped != chplan.Node(hp) {
+		t.Fatalf("wrapWithSampleProjection wrapped a histogram-shaped root in %T; it must pass through unchanged", wrapped)
+	}
+}

--- a/internal/promql/exp_histogram_reject_test.go
+++ b/internal/promql/exp_histogram_reject_test.go
@@ -2,23 +2,34 @@ package promql_test
 
 import (
 	"context"
+	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/prometheus/prometheus/promql/parser"
 
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
 	"github.com/tsouza/cerberus/internal/promql"
 	"github.com/tsouza/cerberus/internal/schema"
 )
 
 // TestLower_ExpHistogram_UnsupportedShapesRejectExplicitly pins issue #1704:
 // every PromQL shape over a pinned exponential-histogram selector OTHER
-// than histogram_quantile() / histogram_count() / histogram_sum() and the
-// `_count` / `_sum` companion selectors must fail lowering with a clear
-// error, never silently resolve against the Gauge/Sum tables and return an
-// empty-but-200 result. Before the fix, TablesFor never yielded
-// ExpHistogramTable for these shapes, so cerberus quietly scanned the
-// wrong tables and matched zero rows.
+// than histogram_quantile() / histogram_count() / histogram_sum(), the
+// `_count` / `_sum` companion selectors, and a top-level BARE selector
+// (issue #1967 — see TestLower_ExpHistogram_BareSelectorIsHistogramValued)
+// must fail lowering with a clear error, never silently resolve against
+// the Gauge/Sum tables and return an empty-but-200 result. Before the fix,
+// TablesFor never yielded ExpHistogramTable for these shapes, so cerberus
+// quietly scanned the wrong tables and matched zero rows.
+//
+// The nested cases are what keeps the #1967 narrowing HONEST: a bare
+// selector is answerable because nothing consumes it, and each of these
+// wraps that same selector in a consumer that reads a `Value` column the
+// histogram row shape does not publish. They stay rejected until each
+// grows its own histogram-aware lowering.
 func TestLower_ExpHistogram_UnsupportedShapesRejectExplicitly(t *testing.T) {
 	t.Parallel()
 
@@ -29,8 +40,6 @@ func TestLower_ExpHistogram_UnsupportedShapesRejectExplicitly(t *testing.T) {
 		name  string
 		query string
 	}{
-		{name: "bare selector", query: `latency_exp_hist`},
-		{name: "bare selector with label matcher", query: `latency_exp_hist{service="api"}`},
 		{name: "rate", query: `rate(latency_exp_hist[5m])`},
 		{name: "resets", query: `resets(latency_exp_hist[5m])`},
 		{name: "changes", query: `changes(latency_exp_hist[5m])`},
@@ -38,6 +47,14 @@ func TestLower_ExpHistogram_UnsupportedShapesRejectExplicitly(t *testing.T) {
 		{name: "sum aggregation", query: `sum(latency_exp_hist)`},
 		{name: "sum by", query: `sum by (service) (latency_exp_hist)`},
 		{name: "absent_over_time", query: `absent_over_time(latency_exp_hist[5m])`},
+		{name: "avg aggregation", query: `avg(latency_exp_hist)`},
+		{name: "scalar arithmetic", query: `latency_exp_hist * 2`},
+		{name: "parenthesised scalar arithmetic", query: `(latency_exp_hist) + 1`},
+		{name: "label_replace", query: `label_replace(latency_exp_hist, "a", "b", "service", "(.*)")`},
+		{name: "abs", query: `abs(latency_exp_hist)`},
+		{name: "topk", query: `topk(3, latency_exp_hist)`},
+		{name: "raw range vector", query: `latency_exp_hist[5m]`},
+		{name: "subquery", query: `max_over_time(latency_exp_hist[5m:1m])`},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -88,5 +105,146 @@ func TestLower_ExpHistogram_DedicatedFunctionsStillWork(t *testing.T) {
 				t.Fatalf("Lower(%q): unexpected error: %v", q, err)
 			}
 		})
+	}
+}
+
+// TestLower_ExpHistogram_BareSelectorIsHistogramValued pins issue #1967's
+// first cut: a bare exp-histogram selector is answerable, and the answer
+// is a chplan.HistogramProjection whose output columns are the canonical
+// sample quartet followed by the nine chplan.Histogram*Column aliases.
+//
+// The column ORDER and the leading quartet are the load-bearing part, not
+// decoration: internal/chclient's row cursor probes the result set's LAST
+// column for HistogramNegativeBucketCounts and then binds thirteen scan
+// destinations positionally. A projection that published the nine columns
+// in a different order, or that omitted MetricName, would still emit valid
+// SQL and still latch the probe — and hand back scrambled histograms.
+func TestLower_ExpHistogram_BareSelectorIsHistogramValued(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+
+	cases := []struct {
+		name  string
+		query string
+		lower func(parser.Expr) (chplan.Node, error)
+	}{
+		{
+			name:  "instant",
+			query: `latency_exp_hist`,
+			lower: func(e parser.Expr) (chplan.Node, error) {
+				return promql.LowerAt(context.Background(), e, s, end, end)
+			},
+		},
+		{
+			name:  "instant with matchers",
+			query: `latency_exp_hist{service="api"}`,
+			lower: func(e parser.Expr) (chplan.Node, error) {
+				return promql.LowerAt(context.Background(), e, s, end, end)
+			},
+		},
+		{
+			name:  "range",
+			query: `latency_exp_hist`,
+			lower: func(e parser.Expr) (chplan.Node, error) {
+				return promql.LowerAtRange(context.Background(), e, s, start, end, 30*time.Second)
+			},
+		},
+		{
+			name:  "range with absolute @ pin",
+			query: `latency_exp_hist @ 1767225600`,
+			lower: func(e parser.Expr) (chplan.Node, error) {
+				return promql.LowerAtRange(context.Background(), e, s, start, end, 30*time.Second)
+			},
+		},
+	}
+
+	wantAliases := []string{
+		s.MetricNameColumn, s.AttributesColumn, s.TimestampColumn, s.ValueColumn,
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			expr, err := p.ParseExpr(tc.query)
+			if err != nil {
+				t.Fatalf("ParseExpr(%q): %v", tc.query, err)
+			}
+			plan, err := tc.lower(expr)
+			if err != nil {
+				t.Fatalf("lower(%q): unexpected error: %v", tc.query, err)
+			}
+			if shape := chplan.RowShapeOf(plan); shape != chplan.HistogramRowShape {
+				t.Fatalf("lower(%q): plan root publishes %s, want histogram", tc.query, shape)
+			}
+			hp, ok := plan.(*chplan.HistogramProjection)
+			if !ok {
+				t.Fatalf("lower(%q): plan root is %T, want *chplan.HistogramProjection", tc.query, plan)
+			}
+			if !slices.Equal(hp.GroupByAliases, wantAliases) {
+				t.Fatalf("lower(%q): leading output aliases = %v, want %v", tc.query, hp.GroupByAliases, wantAliases)
+			}
+			if len(hp.GroupBy) != len(wantAliases) {
+				t.Fatalf("lower(%q): %d leading projections for %d aliases", tc.query, len(hp.GroupBy), len(wantAliases))
+			}
+			if hp.CountColumn != s.CountColumn || hp.SumColumn != s.SumColumn {
+				t.Fatalf("lower(%q): Count/Sum bound to %q/%q, want %q/%q",
+					tc.query, hp.CountColumn, hp.SumColumn, s.CountColumn, s.SumColumn)
+			}
+		})
+	}
+}
+
+// TestLower_ExpHistogram_BareSelectorEmitsThirteenColumns pins the emitted
+// SQL's projection width end to end — the property the chclient probe
+// depends on and the one a plan-level assertion cannot see, because the
+// nine histogram aliases are supplied by the emitter rather than by the
+// lowering.
+func TestLower_ExpHistogram_BareSelectorEmitsThirteenColumns(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	expr, err := p.ParseExpr(`latency_exp_hist`)
+	if err != nil {
+		t.Fatalf("ParseExpr: %v", err)
+	}
+	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	plan, err := promql.LowerAt(context.Background(), expr, s, at, at)
+	if err != nil {
+		t.Fatalf("LowerAt: %v", err)
+	}
+	sql, _, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	// The outermost SELECT list, up to the first FROM.
+	head, _, ok := strings.Cut(sql, " FROM ")
+	if !ok {
+		t.Fatalf("emitted SQL has no FROM: %s", sql)
+	}
+	wantSuffix := []string{
+		chplan.HistogramCountColumn, chplan.HistogramSumColumn, chplan.HistogramScaleColumn,
+		chplan.HistogramZeroThresholdColumn, chplan.HistogramZeroCountColumn,
+		chplan.HistogramPositiveOffsetColumn, chplan.HistogramPositiveBucketCountsColumn,
+		chplan.HistogramNegativeOffsetColumn, chplan.HistogramNegativeBucketCountsColumn,
+	}
+	prev := -1
+	for _, alias := range append([]string{s.MetricNameColumn, s.AttributesColumn, s.TimestampColumn, s.ValueColumn}, wantSuffix...) {
+		at := strings.Index(head, "AS `"+alias+"`")
+		if at < 0 {
+			t.Fatalf("emitted projection is missing the %q output alias: %s", alias, head)
+		}
+		if at <= prev {
+			t.Fatalf("emitted projection has %q out of contract order: %s", alias, head)
+		}
+		prev = at
+	}
+	last := wantSuffix[len(wantSuffix)-1]
+	if !strings.HasSuffix(strings.TrimSpace(head), "AS `"+last+"`") {
+		t.Fatalf("emitted projection does not END with %q — chclient's probe reads the LAST column: %s", last, head)
 	}
 }

--- a/internal/promql/histogram_native_bare.go
+++ b/internal/promql/histogram_native_bare.go
@@ -1,0 +1,210 @@
+package promql
+
+import (
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// histogram_native_bare.go lowers a BARE selector over an OTel
+// exponential (native) histogram — `<base>_exp_hist`, with no wrapping
+// function — into a histogram-VALUED result.
+//
+// Reference Prometheus answers such a selector with a native-histogram
+// sample: `Sample{H: *histogram.FloatHistogram}`, no float value. Every
+// other cerberus lowering reduces a histogram row to a scalar before it
+// reaches the wire (histogram_quantile / histogram_count /
+// histogram_sum), which is why [expHistogramSelectorRouting] rejects the
+// bare shape wherever it is NOT the whole query: an inner reducer
+// (`sum(...)`, `rate(...[5m])`, `avg(...)`, arithmetic) would read a
+// `Value` column the histogram row shape does not carry, and answering
+// it with the placeholder value would be silently wrong. Those shapes
+// keep their explicit rejection until each grows its own correct
+// lowering (issue #1967).
+//
+// The plan shape mirrors the native-quantile siblings in
+// histogram_quantile.go / histogram_quantile_range.go rung for rung —
+// same Scan, same matcher predicate, same per-series `argMax(<col>,
+// TimeUnix)` collapse, same [chplan.RangeBucketFanout] in range mode —
+// and differs in exactly one place: the cap is a
+// [chplan.HistogramProjection], which publishes the nine raw structural
+// columns as final output instead of folding them into a quantile.
+//
+// Output-column contract. The projection's GroupBy/GroupByAliases carry
+// the canonical sample quartet `(MetricName, Attributes, Timestamp,
+// Value)` FIRST, so the emitted SELECT is those four followed by the
+// nine `chplan.Histogram*Column` aliases — precisely the thirteen
+// destinations internal/chclient's row cursor binds when it probes the
+// final column for `HistogramNegativeBucketCounts`. That is also why
+// api/prom's wrapWithSampleProjection leaves a histogram-shaped plan
+// root alone: re-projecting the quartet on top would drop the nine
+// columns the cursor is probing for.
+
+// histogramSampleValuePlaceholder is the `Value` a histogram-valued row
+// carries. A native-histogram sample has no float value — reference
+// Prometheus's Sample keeps `H` set and leaves `F` unread, and
+// api/prom's wire marshalling makes `value` and `histogram` mutually
+// exclusive — but the canonical four-column sample contract (and the
+// chclient scan built on it) always binds a Value destination, so the
+// projection supplies an unread constant rather than leaving a hole.
+const histogramSampleValuePlaceholder = 0.0
+
+// bareExpHistogramSelector reports whether expr is a bare selector over
+// an exp-histogram metric, i.e. the one shape this file answers.
+//
+// It is deliberately asked only of the ROOT of a query (see [lowerRoot]).
+// A selector nested under anything else — a reducer, a range-vector
+// function, arithmetic, `label_replace` — reaches lowerVectorSelector
+// instead and is rejected there, because its consumer reads a `Value`
+// column a histogram row does not publish.
+//
+// Metadata enumeration (/series, /labels) is excluded: it consumes only
+// MetricName + Attributes and has its own full-range lowering, which
+// expHistogramSelectorRouting already exempts from rejection.
+func bareExpHistogramSelector(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (*parser.VectorSelector, bool) {
+	if s.ExpHistogramTable == "" || ctx.metadataFullRange {
+		return nil, false
+	}
+	vs, ok := unwrapVectorSelector(expr)
+	if !ok {
+		return nil, false
+	}
+	if !s.IsExpHistogramMetric(metricNameFromMatchers(vs.LabelMatchers)) {
+		return nil, false
+	}
+	return vs, true
+}
+
+// lowerExpHistogramBare lowers a bare exp-histogram selector across the
+// three evaluation shapes [rangeGridShapeFor] distinguishes, the same
+// three the native-quantile bare path handles:
+//
+//   - gridFanout — a query_range with no `@` pin: one row per (series,
+//     anchor), each anchor resolving its own staleness lookback.
+//   - gridBroadcast — a query_range whose selector carries an absolute
+//     `@`: the pinned window is resolved ONCE and fanned across the step
+//     grid, so every step reports the same histogram at its own
+//     timestamp.
+//   - gridSingleAnchor — an instant query: one row per series at
+//     `now64(9)`.
+func lowerExpHistogramBare(vs *parser.VectorSelector, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+	if shape := rangeGridShapeFor(vs, ctx); shape == gridFanout {
+		return lowerExpHistogramBareRange(vs, s, ctx), nil
+	} else if shape == gridBroadcast {
+		latest, err := expHistogramBareLatest(vs, s, ctx)
+		if err != nil {
+			return nil, err
+		}
+		// Same broadcast shape as broadcastHistogramAtPin, built one
+		// rung LOWER: the cross join goes UNDER the histogram
+		// projection rather than over it, so the plan root stays a
+		// HistogramProjection and keeps publishing the thirteen-column
+		// contract. Capping with a Project instead would re-project the
+		// quartet alone and delete the nine histogram columns.
+		grid := &chplan.StepGrid{Start: ctx.start.UTC(), End: ctx.end.UTC(), Step: ctx.step}
+		return nativeHistogramProjection(
+			&chplan.CrossJoin{Left: grid, Right: latest},
+			&chplan.ColumnRef{Name: stepGridAnchorColumn},
+			s,
+		), nil
+	}
+	latest, err := expHistogramBareLatest(vs, s, ctx)
+	if err != nil {
+		return nil, err
+	}
+	return nativeHistogramProjection(latest, chplan.NowNano(), s), nil
+}
+
+// expHistogramBareLatest builds the instant-mode subtree beneath the
+// histogram projection: the filtered exp-histogram scan collapsed to the
+// newest in-window sample per series. Identical to
+// lowerHistogramQuantileNative's own input rung apart from the wider
+// aggregate list — see [nativeExpHistBareAggs].
+func expHistogramBareLatest(vs *parser.VectorSelector, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+	scan := &chplan.Scan{Table: s.ExpHistogramTable}
+	pred := buildPredicate(vs.LabelMatchers, s)
+	pred, err := andInstantWindow(pred, vs, s.TimestampColumn, ctx)
+	if err != nil {
+		return nil, err
+	}
+	var input chplan.Node = scan
+	if pred != nil {
+		input = &chplan.Filter{Input: scan, Predicate: pred}
+	}
+	return latestSampleAgg(input, nativeExpHistBareAggs(s), s), nil
+}
+
+// lowerExpHistogramBareRange is the query_range shape: the same
+// per-anchor [chplan.RangeBucketFanout] lowerHistogramQuantileNativeBareRange
+// builds — one staleness window per step anchor, keyed on series
+// identity — capped with the histogram projection instead of the
+// quantile node. The timestamp comes from the fan-out's anchor column,
+// so each step reports at its own grid time.
+func lowerExpHistogramBareRange(vs *parser.VectorSelector, s schema.Metrics, ctx lowerCtx) chplan.Node {
+	scan := &chplan.Scan{Table: s.ExpHistogramTable}
+	pred := buildPredicate(vs.LabelMatchers, s)
+	fanout := buildHistogramBucketFanout(
+		scan, pred, nil, windowFor(vs, instantLookback),
+		[]chplan.Expr{histogramIdentityExpr(s)}, []string{s.AttributesColumn},
+		nativeExpHistBareAggs(s), s, ctx,
+	)
+	return nativeHistogramProjection(fanout, &chplan.ColumnRef{Name: stepGridAnchorColumn}, s)
+}
+
+// nativeExpHistBareAggs is [nativeExpHistLatestAggs] widened by the three
+// fields a histogram-VALUED answer needs that a quantile does not:
+//
+//   - MetricName, because PromQL keeps `__name__` on a bare selector
+//     (only DERIVED samples drop it). Reading it as `argMax(MetricName,
+//     TimeUnix)` rather than adding it to the group keys is deliberate:
+//     the metric-name predicate fans out across the OTel dot/slash/
+//     underscore name variants, and grouping on the column would split
+//     one logical series into one group per stored spelling.
+//   - Count and Sum, which the quantile kernel never reads because it
+//     works off the bucket ladder, but which are part of the native
+//     histogram's wire shape.
+func nativeExpHistBareAggs(s schema.Metrics) []chplan.AggFunc {
+	aggs := []chplan.AggFunc{
+		latestArgMax(s.MetricNameColumn, s),
+		latestArgMax(s.CountColumn, s),
+		latestArgMax(s.SumColumn, s),
+	}
+	return append(aggs, nativeExpHistLatestAggs(s)...)
+}
+
+// nativeHistogramProjection caps input with the
+// [chplan.HistogramProjection] that publishes the thirteen-column
+// histogram row: the canonical sample quartet first — with tsExpr
+// supplying the timestamp, which is `now64(9)` for an instant query and
+// the grid anchor column for a range one — then the nine raw structural
+// columns under their fixed chplan.Histogram*Column aliases.
+func nativeHistogramProjection(input chplan.Node, tsExpr chplan.Expr, s schema.Metrics) *chplan.HistogramProjection {
+	return &chplan.HistogramProjection{
+		Input:                      input,
+		CountColumn:                s.CountColumn,
+		SumColumn:                  s.SumColumn,
+		ScaleColumn:                s.ScaleColumn,
+		ZeroCountColumn:            s.ZeroCountColumn,
+		ZeroThresholdColumn:        s.ZeroThresholdColumn,
+		PositiveOffsetColumn:       s.PositiveOffsetColumn,
+		PositiveBucketCountsColumn: s.PositiveBucketCountsColumn,
+		NegativeOffsetColumn:       s.NegativeOffsetColumn,
+		NegativeBucketCountsColumn: s.NegativeBucketCountsColumn,
+		GroupBy: []chplan.Expr{
+			&chplan.ColumnRef{Name: s.MetricNameColumn},
+			&chplan.ColumnRef{Name: s.AttributesColumn},
+			tsExpr,
+			&chplan.LitFloat{V: histogramSampleValuePlaceholder},
+		},
+		GroupByAliases: []string{
+			s.MetricNameColumn,
+			s.AttributesColumn,
+			s.TimestampColumn,
+			s.ValueColumn,
+		},
+		MetricNameColumn: s.MetricNameColumn,
+		AttributesColumn: s.AttributesColumn,
+		TimestampColumn:  s.TimestampColumn,
+	}
+}

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -42,7 +42,7 @@ var tracer = otel.Tracer("github.com/tsouza/cerberus/internal/promql")
 func Lower(ctx context.Context, expr parser.Expr, s schema.Metrics) (chplan.Node, error) {
 	_, span := tracer.Start(ctx, cerbtrace.SpanLower, trace.WithAttributes(cerbtrace.AttrQL.String("promql")))
 	defer span.End()
-	plan, err := lower(expr, s, lowerCtx{lowerers: RangeLowerers{}.withDefaults()})
+	plan, err := lowerRoot(expr, s, lowerCtx{lowerers: RangeLowerers{}.withDefaults()})
 	if err != nil {
 		span.RecordError(err)
 		return nil, err
@@ -124,7 +124,7 @@ type LowerOpts struct {
 func LowerAtRangeOpts(ctx context.Context, expr parser.Expr, s schema.Metrics, start, end time.Time, step time.Duration, opts LowerOpts) (chplan.Node, error) {
 	_, span := tracer.Start(ctx, cerbtrace.SpanLower, trace.WithAttributes(cerbtrace.AttrQL.String("promql")))
 	defer span.End()
-	plan, err := lower(expr, s, lowerCtx{
+	plan, err := lowerRoot(expr, s, lowerCtx{
 		start:    start,
 		end:      end,
 		step:     step,
@@ -166,6 +166,36 @@ func LowerMetadataRange(ctx context.Context, expr parser.Expr, s schema.Metrics,
 	}
 	span.SetAttributes(cerbtrace.AttrPlanNodeCount.Int(cerbtrace.CountNodes(plan)))
 	return plan, nil
+}
+
+// lowerRoot lowers the ROOT of a query expression. It is [lower] plus the
+// one dispatch that can only be decided at the root: a bare selector over
+// an exponential (native) histogram returns a HISTOGRAM-VALUED sample, and
+// that answer has a wire representation only when the selector IS the whole
+// query.
+//
+// The distinction cannot be made inside [lowerVectorSelector], because the
+// selector in `sum(m_exp_hist)` and the selector in `m_exp_hist` arrive
+// there identically — same node, same instant-mode context. Every consumer
+// PromQL can wrap around a selector (a reducer, arithmetic,
+// `label_replace`, a range-vector function) reads a `Value` column that a
+// histogram row does not publish, so answering the nested shape with a
+// histogram projection would either fail in ClickHouse with code 47 or,
+// worse, silently reduce the placeholder Value. Deciding here — where the
+// absence of a parent is a fact rather than an inference — keeps those
+// shapes on [expHistogramSelectorRouting]'s explicit rejection until each
+// grows its own correct lowering (issue #1967), and never widens the
+// exemption by accident: a nested selector never reaches this function.
+//
+// Metadata lowering ([LowerMetadataRange]) deliberately does NOT route
+// through here: it enumerates series and labels rather than evaluating an
+// expression, consumes no Value column, and already has its own
+// full-range bare-selector path.
+func lowerRoot(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+	if vs, ok := bareExpHistogramSelector(expr, s, ctx); ok {
+		return lowerExpHistogramBare(vs, s, ctx)
+	}
+	return lower(expr, s, ctx)
 }
 
 func lower(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
@@ -371,17 +401,24 @@ func lowerHistogramSelectorInput(
 // the multi-table companion union).
 //
 // When ok is true and err is non-nil, every other shape over a pinned
-// exp-histogram selector — a bare selector, or one wrapped in
-// rate()/resets()/changes()/sum()/etc. — has no scalar Value column to
-// read: the exp-histogram row shape (Sum/Count/Scale/PositiveCounts/
-// NegativeCounts) is disjoint from the Sample contract these functions
-// reduce over. histogram_quantile()/histogram_count()/histogram_sum()
-// detect this shape themselves before ever reaching lowerVectorSelector
-// (see their own s.IsExpHistogramMetric checks), and the companion arm
-// above is the one column-backed exception — so any selector that
-// reaches here is a shape none of those paths recognise. err rejects it
-// explicitly rather than silently matching zero rows against the
-// Gauge/Sum tables.
+// exp-histogram selector — one wrapped in
+// rate()/resets()/changes()/sum()/avg()/arithmetic/etc. — has no scalar
+// Value column to read: the exp-histogram row shape (Sum/Count/Scale/
+// PositiveCounts/NegativeCounts) is disjoint from the Sample contract
+// these functions reduce over. histogram_quantile()/histogram_count()/
+// histogram_sum() detect this shape themselves before ever reaching
+// lowerVectorSelector (see their own s.IsExpHistogramMetric checks), and
+// the companion arm above is the one column-backed exception — so any
+// selector that reaches here is a shape none of those paths recognise.
+// err rejects it explicitly rather than silently matching zero rows
+// against the Gauge/Sum tables.
+//
+// A BARE selector no longer reaches here at all: it returns a
+// histogram-valued sample, which [lowerRoot] answers with a
+// chplan.HistogramProjection before the recursive descent that leads to
+// lowerVectorSelector ever starts. That is the whole of the narrowing —
+// a nested selector still arrives here and is still rejected, because
+// nothing above it can consume a histogram row yet (issue #1967).
 //
 // Metadata enumeration (/series, /labels — ctx.metadataFullRange) is
 // exempted: it doesn't consume a Value column, only MetricName +
@@ -396,9 +433,10 @@ func expHistogramSelectorRouting(metricName string, s schema.Metrics, ctx lowerC
 	}
 	if s.IsExpHistogramMetric(metricName) && !ctx.metadataFullRange {
 		return nil, nil, "", "", true, fmt.Errorf(
-			"promql: %q is an exponential histogram metric; only histogram_quantile(), "+
-				"histogram_count(), histogram_sum(), and the %q/%q companion selectors are supported",
-			metricName, metricName+"_count", metricName+"_sum",
+			"promql: %q is an exponential histogram metric; only a bare %q selector, "+
+				"histogram_quantile(), histogram_count(), histogram_sum(), and the %q/%q "+
+				"companion selectors are supported",
+			metricName, metricName, metricName+"_count", metricName+"_sum",
 		)
 	}
 	return nil, nil, "", "", false, nil

--- a/internal/testsql/query_rewrite.go
+++ b/internal/testsql/query_rewrite.go
@@ -73,6 +73,44 @@ func IsMapColumn(name string) bool {
 	return slices.Contains(mapColumnNames, name)
 }
 
+// arrayColumnNames are the ARRAY-typed output aliases that reach the
+// driver as a final projection column. chdb-go's parquet driver decodes
+// an `Array(UInt64)` cell to nil — not an error, just a silently empty
+// value — so a golden written over the raw projection would pin `null`
+// where the bucket layout belongs and assert nothing about the one field
+// the fixture exists to cover. They get the same toJSONString wrap the
+// Map columns get, and [DecodeCell]'s bracket-prefixed JSON path decodes
+// the string back into a slice.
+//
+// The list is deliberately the OUTPUT aliases of
+// chplan.HistogramProjection rather than the physical column names: an
+// array column that stays inside a subquery is consumed server-side by
+// ClickHouse and never crosses the driver boundary, so wrapping it would
+// change nothing and risk shadowing a raw reference the way the Map
+// comment above describes. Only these two are published as final output.
+var arrayColumnNames = []string{
+	"HistogramNegativeBucketCounts",
+	"HistogramPositiveBucketCounts",
+}
+
+// IsArrayColumn reports whether name — a projection alias, already
+// stripped of its backticks — is one of the known Array-typed output
+// columns.
+func IsArrayColumn(name string) bool {
+	return slices.Contains(arrayColumnNames, name)
+}
+
+// IsDriverOpaqueColumn reports whether a projection under this alias
+// must be wrapped in `toJSONString(...)` before the chdb-go driver sees
+// it. It is the union of the two families the driver cannot decode —
+// Map cells (which surface as NULL or panic outright) and Array cells
+// (which surface as nil) — and is what [RewriteMapProjections] tests, so
+// a new opaque type is added in one place rather than at every rewrite
+// site.
+func IsDriverOpaqueColumn(name string) bool {
+	return IsMapColumn(name) || IsArrayColumn(name)
+}
+
 // NestMapOrderBy guards the Map-wrap output against an outer ORDER BY
 // clause that still references a raw Map column — either subscripted
 // (the `sort_by_label` / `sort_by_label_desc` lowering's `SELECT * FROM
@@ -559,7 +597,9 @@ func isGeneratedColumnDef(def string) bool {
 }
 
 // RewriteMapProjections wraps every top-level SELECT projection whose
-// alias names a known Map column (see [IsMapColumn]) in
+// alias names a column the driver cannot decode (see
+// [IsDriverOpaqueColumn] — the Map columns below and the Array-typed
+// histogram bucket outputs) in
 // `toJSONString(...)`. Only the OUTERMOST SELECT is touched — subqueries
 // and CTE bodies keep their Map columns raw, because ClickHouse consumes
 // those server-side and never hands them to the driver.
@@ -630,7 +670,7 @@ func RewriteMapProjections(query string) string {
 		if alias == "" {
 			alias = mapColAlias(strings.TrimSpace(expr))
 		}
-		if !IsMapColumn(alias) {
+		if !IsDriverOpaqueColumn(alias) {
 			continue
 		}
 		projs[i] = "toJSONString(" + expr + ") AS `" + alias + "`"

--- a/test/perf/cardinality-baseline/promql/exp_histogram_bare_selector.json
+++ b/test/perf/cardinality-baseline/promql/exp_histogram_bare_selector.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/exp_histogram_bare_selector",
+  "fan_factor": 1,
+  "scan_rows": 1,
+  "peak_intermediate": 1,
+  "has_cross_join": false,
+  "has_array_join": false,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/cardinality-baseline/promql/exp_histogram_bare_selector_range.json
+++ b/test/perf/cardinality-baseline/promql/exp_histogram_bare_selector_range.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/exp_histogram_bare_selector_range",
+  "fan_factor": 10,
+  "scan_rows": 1,
+  "peak_intermediate": 10,
+  "has_cross_join": false,
+  "has_array_join": true,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/solver-decision-baseline/exp_histogram_bare_selector.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_bare_selector.json
@@ -1,0 +1,10 @@
+{
+  "query": "exp_histogram_bare_selector",
+  "routed": false,
+  "k": 0,
+  "reason": "not-sliceable",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "5m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/exp_histogram_bare_selector_range.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_bare_selector_range.json
@@ -1,0 +1,10 @@
+{
+  "query": "exp_histogram_bare_selector_range",
+  "routed": false,
+  "k": 0,
+  "reason": "not-sliceable",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "5m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/rejection-parity/catalogue/internal__promql__lower.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__lower.go.json
@@ -73,8 +73,8 @@
     },
     {
       "head": "promql",
-      "site": "internal/promql/lower.go:expHistogramSelectorRouting#bcc398d7",
-      "message": "promql: %q is an exponential histogram metric; only histogram_quantile(), histogram_count(), histogram_sum(), and the %q/%q companion selectors are supported",
+      "site": "internal/promql/lower.go:expHistogramSelectorRouting#367e416d",
+      "message": "promql: %q is an exponential histogram metric; only a bare %q selector, histogram_quantile(), histogram_count(), histogram_sum(), and the %q/%q companion selectors are supported",
       "class": "divergence",
       "trigger_query": "rate(demo_exp_hist[5m])",
       "tracking_issue": 1772,
@@ -111,14 +111,12 @@
       "site": "internal/promql/lower.go:lower#d33d0084",
       "message": "promql: unsupported expression %T",
       "class": "internal",
-      "rationale": "Every expression shape reaching lower() through the HTTP handlers is dispatched (top-level matrix selectors included). The remaining inhabitants — NumberLiteral and StringLiteral, answered by the handler's constant fold / string shortcut before the engine runs, and StepInvariantExpr, which only parser.PreprocessExpr mints and cerberus never calls — cannot arrive here from the wire. Re-verified across the in-package callers that re-enter lower() with a sub-expression, lowerHistogramQuantileClassicFloat included: each passes an operand of an already-parsed query whose position the upstream typechecker constrains to a vector, so no caller widens the set of shapes that reach the default arm.",
+      "rationale": "Every expression shape reaching lower() through the HTTP handlers is dispatched (top-level matrix selectors included). The remaining inhabitants — NumberLiteral and StringLiteral, answered by the handler's constant fold / string shortcut before the engine runs, and StepInvariantExpr, which only parser.PreprocessExpr mints and cerberus never calls — cannot arrive here from the wire. The query entry points now reach this switch through lowerRoot, which peels off exactly one shape (a bare exp-histogram selector, answered by a histogram-valued lowering) and otherwise delegates unchanged, so it narrows the set of expressions that arrive rather than widening it. Re-verified across the in-package callers that re-enter lower() with a sub-expression, lowerHistogramQuantileClassicFloat included: each passes an operand of an already-parsed query whose position the upstream typechecker constrains to a vector, so no caller widens the set of shapes that reach the default arm.",
       "evidence": {
         "guard": [
           "default of switch e := expr.(type) over [case *parser.VectorSelector; case *parser.Call; case *parser.AggregateExpr; case *parser.ParenExpr; case *parser.BinaryExpr; case *parser.SubqueryExpr; case *parser.MatrixSelector; case *parser.UnaryExpr; default]"
         ],
         "callers": [
-          "Lower",
-          "LowerAtRangeOpts",
           "LowerMetadataRange",
           "lower",
           "lowerAbsent",
@@ -136,6 +134,7 @@
           "lowerLimitK",
           "lowerLimitRatio",
           "lowerMetadataCatalog",
+          "lowerRoot",
           "lowerRoundToNearest",
           "lowerScalarArg",
           "lowerSort",
@@ -149,7 +148,8 @@
         ],
         "cited": [
           "lower",
-          "lowerHistogramQuantileClassicFloat"
+          "lowerHistogramQuantileClassicFloat",
+          "lowerRoot"
         ]
       }
     },

--- a/test/spec/chplan_print.go
+++ b/test/spec/chplan_print.go
@@ -553,6 +553,27 @@ func printNode(b *strings.Builder, n chplan.Node, depth int) {
 		}
 		b.WriteString("\n")
 		printNode(b, v.Input, depth+1)
+	case *chplan.HistogramProjection:
+		// Only the projection's own output list is printed. The nine
+		// Histogram*Column source names are a mechanical function of the
+		// schema (and their output aliases are fixed constants), so
+		// spelling them in every golden would bury the one thing that
+		// varies between two histogram-valued plans: which columns the
+		// canonical quartet is bound from.
+		gb := make([]string, len(v.GroupBy))
+		for i, e := range v.GroupBy {
+			if i < len(v.GroupByAliases) && v.GroupByAliases[i] != "" {
+				gb[i] = fmt.Sprintf("%s AS %s", printExpr(e), v.GroupByAliases[i])
+			} else {
+				gb[i] = printExpr(e)
+			}
+		}
+		fmt.Fprintf(b, "%sHistogramProjection", indent)
+		if len(gb) > 0 {
+			fmt.Fprintf(b, " project=[%s]", strings.Join(gb, ", "))
+		}
+		b.WriteString("\n")
+		printNode(b, v.Input, depth+1)
 	default:
 		fmt.Fprintf(b, "%s<unknown:%T>\n", indent, n)
 	}

--- a/test/spec/promql/exp_histogram_bare_selector.txtar
+++ b/test/spec/promql/exp_histogram_bare_selector.txtar
@@ -1,0 +1,69 @@
+-- query.promql --
+http_server_duration_exp_hist
+-- seed --
+CREATE TABLE otel_metrics_exponential_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    Scale Int32,
+    ZeroCount UInt64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64),
+    NegativeOffset Int32,
+    NegativeBucketCounts Array(UInt64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_exponential_histogram VALUES
+    ('http_server_duration_exp_hist', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 6, 42.5, 0, 0, 0, [1, 2, 3], 0, []);
+-- expected_rows --
+[
+  ["http_server_duration_exp_hist", {"service": "api"}, "2026-01-01T00:00:01Z", 0, 6, 42.5, 0, 0, 0, 0, [1,2,3], 0, []]
+]
+-- args --
+[0] int64 = 9
+[1] float64 = 0
+[2] string = "service.name"
+[3] string = "service_name"
+[4] string = "service.name"
+[5] string = "service_name"
+[6] string = ""
+[7] string = "service_name"
+[8] string = "http_server_duration_exp_hist"
+[9] string = "http.server.duration.exp.hist"
+[10] string = "http.server.duration.exp/hist"
+[11] string = "http.server.duration.exp_hist"
+[12] string = "http.server.duration/exp/hist"
+[13] string = "http.server.duration/exp_hist"
+[14] string = "http.server.duration_exp.hist"
+[15] string = "http.server.duration_exp_hist"
+[16] string = "http.server/duration/exp/hist"
+[17] string = "http.server/duration/exp_hist"
+[18] string = "http.server/duration_exp_hist"
+[19] string = "http.server_duration.exp.hist"
+[20] string = "http.server_duration.exp_hist"
+[21] string = "http.server_duration_exp.hist"
+[22] string = "http.server_duration_exp_hist"
+[23] string = "http/server/duration/exp/hist"
+[24] string = "http/server/duration/exp_hist"
+[25] string = "http/server/duration_exp_hist"
+[26] string = "http/server_duration_exp_hist"
+[27] string = "http_server.duration.exp.hist"
+[28] string = "http_server.duration.exp_hist"
+[29] string = "http_server.duration_exp.hist"
+[30] string = "http_server.duration_exp_hist"
+[31] string = "http_server_duration.exp.hist"
+[32] string = "http_server_duration.exp_hist"
+[33] string = "http_server_duration_exp.hist"
+[34] string = "2026-01-01 00:00:01.000000000"
+[35] int64 = 9
+[36] string = "2026-01-01 00:00:01.000000000"
+[37] int64 = 9
+[38] int64 = 300000000000
+-- chplan --
+HistogramProjection project=[MetricName AS MetricName, Attributes AS Attributes, now64(9) AS TimeUnix, 0 AS Value]
+  Aggregate groupBy=[mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes] funcs=[argMax(MetricName, TimeUnix) AS MetricName, argMax(Count, TimeUnix) AS Count, argMax(Sum, TimeUnix) AS Sum, argMax(Scale, TimeUnix) AS Scale, argMax(ZeroCount, TimeUnix) AS ZeroCount, argMax(PositiveOffset, TimeUnix) AS PositiveOffset, argMax(PositiveBucketCounts, TimeUnix) AS PositiveBucketCounts, argMax(NegativeOffset, TimeUnix) AS NegativeOffset, argMax(NegativeBucketCounts, TimeUnix) AS NegativeBucketCounts]
+    Filter predicate=(((MetricName IN ("http_server_duration_exp_hist", "http.server.duration.exp.hist", "http.server.duration.exp/hist", "http.server.duration.exp_hist", "http.server.duration/exp/hist", "http.server.duration/exp_hist", "http.server.duration_exp.hist", "http.server.duration_exp_hist", "http.server/duration/exp/hist", "http.server/duration/exp_hist", "http.server/duration_exp_hist", "http.server_duration.exp.hist", "http.server_duration.exp_hist", "http.server_duration_exp.hist", "http.server_duration_exp_hist", "http/server/duration/exp/hist", "http/server/duration/exp_hist", "http/server/duration_exp_hist", "http/server_duration_exp_hist", "http_server.duration.exp.hist", "http_server.duration.exp_hist", "http_server.duration_exp.hist", "http_server.duration_exp_hist", "http_server_duration.exp.hist", "http_server_duration.exp_hist", "http_server_duration_exp.hist")) AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+      Scan(otel_metrics_exponential_histogram)
+-- sql --
+SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, toFloat64(?) AS `Value`, `Count` AS `HistogramCount`, `Sum` AS `HistogramSum`, `Scale` AS `HistogramScale`, 0. AS `HistogramZeroThreshold`, `ZeroCount` AS `HistogramZeroCount`, `PositiveOffset` AS `HistogramPositiveOffset`, `PositiveBucketCounts` AS `HistogramPositiveBucketCounts`, `NegativeOffset` AS `HistogramNegativeOffset`, `NegativeBucketCounts` AS `HistogramNegativeBucketCounts` FROM (SELECT mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Count`, `TimeUnix`) AS `Count`, argMax(`Sum`, `TimeUnix`) AS `Sum`, argMax(`Scale`, `TimeUnix`) AS `Scale`, argMax(`ZeroCount`, `TimeUnix`) AS `ZeroCount`, argMax(`PositiveOffset`, `TimeUnix`) AS `PositiveOffset`, argMax(`PositiveBucketCounts`, `TimeUnix`) AS `PositiveBucketCounts`, argMax(`NegativeOffset`, `TimeUnix`) AS `NegativeOffset`, argMax(`NegativeBucketCounts`, `TimeUnix`) AS `NegativeBucketCounts` FROM (SELECT * FROM `otel_metrics_exponential_histogram` PREWHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `Attributes`)

--- a/test/spec/promql/exp_histogram_bare_selector_range.txtar
+++ b/test/spec/promql/exp_histogram_bare_selector_range.txtar
@@ -1,0 +1,80 @@
+-- query.promql --
+http_server_duration_exp_hist{service="api"}
+-- range_step --
+30s
+-- seed --
+CREATE TABLE otel_metrics_exponential_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    Scale Int32,
+    ZeroCount UInt64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64),
+    NegativeOffset Int32,
+    NegativeBucketCounts Array(UInt64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_exponential_histogram VALUES
+    ('http_server_duration_exp_hist', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 6, 42.5, 0, 0, 0, [1, 2, 3], 0, []);
+-- expected_rows --
+[
+  ["http_server_duration_exp_hist", {"service": "api"}, "2026-01-01T00:00:00Z", 0, 6, 42.5, 0, 0, 0, 0, [1,2,3], 0, []],
+  ["http_server_duration_exp_hist", {"service": "api"}, "2026-01-01T00:00:30Z", 0, 6, 42.5, 0, 0, 0, 0, [1,2,3], 0, []],
+  ["http_server_duration_exp_hist", {"service": "api"}, "2026-01-01T00:01:00Z", 0, 6, 42.5, 0, 0, 0, 0, [1,2,3], 0, []],
+  ["http_server_duration_exp_hist", {"service": "api"}, "2026-01-01T00:01:30Z", 0, 6, 42.5, 0, 0, 0, 0, [1,2,3], 0, []],
+  ["http_server_duration_exp_hist", {"service": "api"}, "2026-01-01T00:02:00Z", 0, 6, 42.5, 0, 0, 0, 0, [1,2,3], 0, []],
+  ["http_server_duration_exp_hist", {"service": "api"}, "2026-01-01T00:02:30Z", 0, 6, 42.5, 0, 0, 0, 0, [1,2,3], 0, []],
+  ["http_server_duration_exp_hist", {"service": "api"}, "2026-01-01T00:03:00Z", 0, 6, 42.5, 0, 0, 0, 0, [1,2,3], 0, []],
+  ["http_server_duration_exp_hist", {"service": "api"}, "2026-01-01T00:03:30Z", 0, 6, 42.5, 0, 0, 0, 0, [1,2,3], 0, []],
+  ["http_server_duration_exp_hist", {"service": "api"}, "2026-01-01T00:04:00Z", 0, 6, 42.5, 0, 0, 0, 0, [1,2,3], 0, []],
+  ["http_server_duration_exp_hist", {"service": "api"}, "2026-01-01T00:04:30Z", 0, 6, 42.5, 0, 0, 0, 0, [1,2,3], 0, []]
+]
+-- args --
+[0] float64 = 0
+[1] string = "service.name"
+[2] string = "service_name"
+[3] string = "service.name"
+[4] string = "service_name"
+[5] string = ""
+[6] string = "service_name"
+[7] string = "http_server_duration_exp_hist"
+[8] string = "http.server.duration.exp.hist"
+[9] string = "http.server.duration.exp/hist"
+[10] string = "http.server.duration.exp_hist"
+[11] string = "http.server.duration/exp/hist"
+[12] string = "http.server.duration/exp_hist"
+[13] string = "http.server.duration_exp.hist"
+[14] string = "http.server.duration_exp_hist"
+[15] string = "http.server/duration/exp/hist"
+[16] string = "http.server/duration/exp_hist"
+[17] string = "http.server/duration_exp_hist"
+[18] string = "http.server_duration.exp.hist"
+[19] string = "http.server_duration.exp_hist"
+[20] string = "http.server_duration_exp.hist"
+[21] string = "http.server_duration_exp_hist"
+[22] string = "http/server/duration/exp/hist"
+[23] string = "http/server/duration/exp_hist"
+[24] string = "http/server/duration_exp_hist"
+[25] string = "http/server_duration_exp_hist"
+[26] string = "http_server.duration.exp.hist"
+[27] string = "http_server.duration.exp_hist"
+[28] string = "http_server.duration_exp.hist"
+[29] string = "http_server.duration_exp_hist"
+[30] string = "http_server_duration.exp.hist"
+[31] string = "http_server_duration.exp_hist"
+[32] string = "http_server_duration_exp.hist"
+[33] string = "service"
+[34] string = ""
+[35] string = "service"
+[36] string = ""
+[37] string = ""
+[38] string = "api"
+-- chplan --
+HistogramProjection project=[MetricName AS MetricName, Attributes AS Attributes, anchor_ts AS TimeUnix, 0 AS Value]
+  RangeBucketFanout step=30s lookback=5m0s groupBy=[mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes] funcs=[argMax(MetricName, TimeUnix) AS MetricName, argMax(Count, TimeUnix) AS Count, argMax(Sum, TimeUnix) AS Sum, argMax(Scale, TimeUnix) AS Scale, argMax(ZeroCount, TimeUnix) AS ZeroCount, argMax(PositiveOffset, TimeUnix) AS PositiveOffset, argMax(PositiveBucketCounts, TimeUnix) AS PositiveBucketCounts, argMax(NegativeOffset, TimeUnix) AS NegativeOffset, argMax(NegativeBucketCounts, TimeUnix) AS NegativeBucketCounts] start=2026-01-01T00:00:00Z end=2026-01-01T00:05:00Z
+    Filter predicate=((coalesce(nullIf(Attributes["service"], ""), nullIf(ResourceAttributes["service"], ""), "") = "api") AND (MetricName IN ("http_server_duration_exp_hist", "http.server.duration.exp.hist", "http.server.duration.exp/hist", "http.server.duration.exp_hist", "http.server.duration/exp/hist", "http.server.duration/exp_hist", "http.server.duration_exp.hist", "http.server.duration_exp_hist", "http.server/duration/exp/hist", "http.server/duration/exp_hist", "http.server/duration_exp_hist", "http.server_duration.exp.hist", "http.server_duration.exp_hist", "http.server_duration_exp.hist", "http.server_duration_exp_hist", "http/server/duration/exp/hist", "http/server/duration/exp_hist", "http/server/duration_exp_hist", "http/server_duration_exp_hist", "http_server.duration.exp.hist", "http_server.duration.exp_hist", "http_server.duration_exp.hist", "http_server.duration_exp_hist", "http_server_duration.exp.hist", "http_server_duration.exp_hist", "http_server_duration_exp.hist")))
+      Scan(otel_metrics_exponential_histogram)
+-- sql --
+SELECT `MetricName` AS `MetricName`, `Attributes` AS `Attributes`, `anchor_ts` AS `TimeUnix`, toFloat64(?) AS `Value`, `Count` AS `HistogramCount`, `Sum` AS `HistogramSum`, `Scale` AS `HistogramScale`, 0. AS `HistogramZeroThreshold`, `ZeroCount` AS `HistogramZeroCount`, `PositiveOffset` AS `HistogramPositiveOffset`, `PositiveBucketCounts` AS `HistogramPositiveBucketCounts`, `NegativeOffset` AS `HistogramNegativeOffset`, `NegativeBucketCounts` AS `HistogramNegativeBucketCounts` FROM (SELECT anchor_ts AS `anchor_ts`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, argMax(`MetricName`, `TimeUnix`) AS `MetricName`, argMax(`Count`, `TimeUnix`) AS `Count`, argMax(`Sum`, `TimeUnix`) AS `Sum`, argMax(`Scale`, `TimeUnix`) AS `Scale`, argMax(`ZeroCount`, `TimeUnix`) AS `ZeroCount`, argMax(`PositiveOffset`, `TimeUnix`) AS `PositiveOffset`, argMax(`PositiveBucketCounts`, `TimeUnix`) AS `PositiveBucketCounts`, argMax(`NegativeOffset`, `TimeUnix`) AS `NegativeOffset`, argMax(`NegativeBucketCounts`, `TimeUnix`) AS `NegativeBucketCounts` FROM (SELECT *, arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:05:00.000000000', 9) - toIntervalNanosecond(i * 30000000000), range(greatest(0, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 300000000000, toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 300000000000, toInt64(30000000000)) < 0) + 1), least(11, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)), toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)), toInt64(30000000000)) < 0) + 1)))) AS anchor_ts FROM (SELECT * FROM `otel_metrics_exponential_histogram` PREWHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)) WHERE (coalesce(nullIf(`Attributes`[?], ?), nullIf(`ResourceAttributes`[?], ?), ?) = ?)) WHERE `TimeUnix` > toDateTime64('2026-01-01 00:00:00.000000000', 9) - toIntervalNanosecond(300000000000) AND `TimeUnix` <= toDateTime64('2026-01-01 00:05:00.000000000', 9)) GROUP BY anchor_ts, `Attributes`)


### PR DESCRIPTION
## What

Lands the first of the four lowerings #1967 asks for: a **bare selector over an OTel exponential (native) histogram**, answered with a histogram-valued result instead of an explicit rejection.

#1926 landed the three layers such an answer needs — `chclient.Sample.Histogram`, `chplan.HistogramProjection` plus its chsql emitter, and api/prom's `histogram` / `histograms` wire keys — but no lowering ever built the node, so all three were reachable only from hand-constructed test data. This is the producer that makes the whole path live end to end for the first time: lowering → chplan → chsql → chclient → api/prom JSON.

Three evaluation shapes, the same three `rangeGridShapeFor` distinguishes for the native-quantile path:

- **instant** — one row per series at `now64(9)`.
- **query_range fan-out** — one row per (series, anchor) via `chplan.RangeBucketFanout`, each anchor resolving its own staleness lookback.
- **absolute `@` broadcast** — the pinned window resolved once and cross-joined across the step grid.

The plan mirrors the native-quantile siblings rung for rung — same Scan, same matcher predicate, same per-series `argMax(<col>, TimeUnix)` collapse — and differs in exactly one place: the cap is a `chplan.HistogramProjection`, which publishes the canonical sample quartet followed by the nine `Histogram*Column` aliases. That order is load-bearing: `internal/chclient`'s row cursor probes the result set's LAST column for `HistogramNegativeBucketCounts` and then binds thirteen destinations positionally.

`MetricName` is read as `argMax(MetricName, TimeUnix)` rather than added to the group keys — PromQL keeps `__name__` on a bare selector, and the metric-name predicate fans out across the OTel dot/slash/underscore name variants, so grouping on the column would split one logical series into one group per stored spelling.

## How the rejection guard is narrowed

By **placement**, not by condition — which is what makes the narrowing exactly as wide as the implementation and no wider.

A bare selector is answerable precisely because nothing consumes it. `lowerVectorSelector` cannot tell `m_exp_hist` from the selector inside `sum(m_exp_hist)`: same node, same instant-mode context. So the dispatch moved to a new `lowerRoot` seam at the query entry points, where the absence of a parent is a fact rather than an inference. Every other shape still descends into `lowerVectorSelector` and still hits `expHistogramSelectorRouting`'s error. `TestLower_ExpHistogram_UnsupportedShapesRejectExplicitly` pins fifteen of them — `rate` / `increase` / `resets` / `changes` / `sum` / `sum by` / `avg` / `topk` / `abs` / `label_replace` / `absent_over_time` / scalar arithmetic / parenthesised arithmetic / a raw range vector / a subquery.

`LowerMetadataRange` deliberately does not route through `lowerRoot`: it enumerates series and labels rather than evaluating an expression, and already has its own full-range bare-selector path.

## Two seams the new plan root reaches for the first time

- **`wrapWithSampleProjection` (`internal/api/prom/handler.go`)** now returns a histogram-shaped root unchanged, keyed off `chplan.RowShapeOf`. Wrapping it in the usual four-column Project emits perfectly valid SQL that silently deletes the nine histogram columns — un-latching the cursor probe and turning every native-histogram answer back into the placeholder float. `TestWrapSampleProjection_HistogramProjectionPassesThrough` fails the moment someone re-adds a wrapper.
- **`testsql.RewriteMapProjections`** now wraps Array-typed output aliases in `toJSONString(...)` alongside the Map columns, behind a new `IsDriverOpaqueColumn`. chdb-go's parquet driver decodes an `Array(UInt64)` cell to nil — not an error, just a silently empty value — so without this the new goldens would have pinned `null` where the bucket layout belongs and asserted nothing about the one field they exist to cover. Verified by probe before and after: the `-- expected_rows --` cells now carry real `[1, 2, 3]` / `[]` bucket arrays.

## Tests

- `test/spec/promql/exp_histogram_bare_selector.txtar` and `..._range.txtar` — SQL + `-- chplan --` + a seeded chDB roundtrip whose thirteen-cell rows assert the decoded Count / Sum / Scale / ZeroThreshold / ZeroCount / ±Offset / ±BucketCounts end to end.
- `TestLower_ExpHistogram_BareSelectorIsHistogramValued` — all four query shapes produce a `HistogramProjection` root with the quartet-first alias contract.
- `TestLower_ExpHistogram_BareSelectorEmitsThirteenColumns` — the emitted SELECT's alias ORDER, and that it ENDS with `HistogramNegativeBucketCounts`. A plan-level assertion cannot see this: the nine aliases come from the emitter, not the lowering.
- `test/spec/chplan_print.go` grew a `HistogramProjection` printer (it was rendering `<unknown:*chplan.HistogramProjection>`).
- Regenerated: promql / chsql / solver / cardinality / parity goldens, plus the `#1772` rejection-parity catalogue entry (its message changed; the site is still a live divergence for the nested shapes, so the entry stays and was re-curated rather than removed).

## What is NOT in this PR, and why

**`sum()` / `sum by(...)` and `rate()` / `increase()` stay under #1967**, which remains open. They are not a smaller version of this change: `sum` needs element-wise bucket addition across series at differing scales (the downscale-to-`min(Scale)` reconciliation `histogram_quantile_native_window.go` already implements for the quantile path), and `rate` / `increase` need Prometheus's `extrapolatedRate` transcribed into the bucket-array domain. Shipping the identity lowering first is what the issue itself proposes, and it is what proves the wire path before the arithmetic lands on top of it.

**Neither new fixture carries a `-- parity --` section.** `test/spec/parityoracle/promql/oracle.go`'s `flatten()` rejects a histogram-valued reference answer outright (`histogramValuedErr`), so a fixture whose RESULT is a histogram cannot be parity-enrolled at all today. That is exactly the gap #1986 tracks, and extending the oracle to encode reference native histograms is that issue's work, not this one's — flagging it plainly rather than trimming the fixture set to dodge it.

**Also still open under #1967**, untouched here and unreachable from a bare selector: the ch-go columnar decode path (only the row cursor was extended), and `projectValueOverInner` / `projectAttributesOverInner`'s `HistogramRowShape` handling — both forwarders reference `Value` unconditionally, which is precisely why `label_replace(m_exp_hist, ...)` and `abs(m_exp_hist)` remain in the rejection set above rather than emitting a code-47.

Part of #1967.