### PR TITLE
fix(e2e): pin the primarySignal Database option's actual label text

### DIFF
--- a/test/e2e/playwright/crawl/crawl.spec.ts
+++ b/test/e2e/playwright/crawl/crawl.spec.ts
@@ -880,7 +880,7 @@ test.describe('crawl: canonicalization pins', () => {
     const consumerLabel =
       'Consumer spansAnalyze interactions initiated by consumer services';
     const databaseLabel =
-      'Database callsEvaluate performance issues in database interactions';
+      'Database callsEvaluate the performance issues in database interactions';
     const control = {
       kind: 'combobox' as const,
       key: 'select[react-select-{rid}-input]',

--- a/test/e2e/playwright/crawl/interactions.ts
+++ b/test/e2e/playwright/crawl/interactions.ts
@@ -198,7 +198,7 @@ export const COMBOBOX_CARDINALITY_RULES: ReadonlyArray<ComboboxCardinalityRule> 
     values: [
       'Server spansExplore server-specific segments of traces',
       'Consumer spansAnalyze interactions initiated by consumer services',
-      'Database callsEvaluate performance issues in database interactions',
+      'Database callsEvaluate the performance issues in database interactions',
     ],
   },
 ];


### PR DESCRIPTION
## What

`shard-crawl` is red on `main` and has been since #2000 merged, for every change scoped into the lane. One word.

The crawl's `COMBOBOX_CARDINALITY_RULES` closed set for the Traces Drilldown `var-primarySignal` Select declares the Database option as:

```
Database callsEvaluate performance issues in database interactions
```

The pinned `grafana-exploretraces-app@2.1.0` bundle renders:

```
Database callsEvaluate the performance issues in database interactions
```

A closed set compares exactly, so `planInteractions`'s self-check throws on every visit to `/a/grafana-exploretraces-app/explore`:

```
[crawl:/a/grafana-exploretraces-app/explore] interaction-discovery-failed: interaction sweep:
combobox select[react-select-{rid}-input] offers option(s)
"Database callsEvaluate the performance issues in database interactions"
outside its declared closed set [...] in COMBOBOX_CARDINALITY_RULES
```

## Evidence it is the label and not the option set

The oracle's message offers two readings — the app gained an option, or the list is not closed. Neither applies:

- The app offers exactly **three** options, the same three the rule declares. Only the third one's string differs, and only by the word "the".
- It reproduces across **all three** Playwright retries in the same run, so it is not a flake and not a data-dependent render.
- The app version is pinned explicitly (`GF_PLUGINS_PREINSTALL: grafana-exploretraces-app@2.1.0` in `docker-compose.yml`), so this is not the unpinned-preinstall drift #1950 fixed reasserting itself — the bundle is stable and the transcription was off.

## Fix

Both sites that spell the label:

- `test/e2e/playwright/crawl/interactions.ts` — the rule's own `values`, which is what the crawl consults.
- `test/e2e/playwright/crawl/crawl.spec.ts` — the `databaseLabel` const the spec builds its synthetic control from.

The two have to agree: the spec's `expect(comboboxCardinalityRule(control.key)?.mode).toBe('enumerate')` assertion is only covering the real rule while the control it constructs matches the rule's declared set. Correcting one and not the other would leave a green spec over a rule the crawl still rejects.

## Verification

The compose/crawl lane is one of the three CLAUDE.md names as unsettleable locally (it needs Docker, and starting compose from a worktree corrupts any other live run), so this is verified by reading the oracle's own message — which names the exact offered string — and by the change being a literal transcription correction against it. `shard-crawl` on this PR is the check that confirms it.