### PR TITLE
feat(promql): answer sum() over a native-histogram selector with a histogram-valued result

### DIFF
--- a/internal/chplan/histogram_projection.go
+++ b/internal/chplan/histogram_projection.go
@@ -40,17 +40,15 @@ const (
 // had nowhere to put that answer — every existing node either emits a
 // scalar Value or, like HistogramQuantileNative, folds the bucket
 // structure away before it ever reaches a projection. This node is the
-// shared shape a future rate()/sum()/bare-selector lowering (issue
-// #1926 step 4, tracked separately — see docs/specs or the tracking
-// issue referenced from the PR that added this node) will wrap its
-// Input with once it exists, so its answer has a correct plan-level
-// home from day one.
+// shared shape every such lowering caps its Input with, so all of them
+// publish one output contract.
 //
-// No lowering builds this node yet. It is reachable only from
-// hand-constructed test plans until #1926 step 4 lands; see
-// internal/chclient.Sample.Histogram (the decode-side landing spot)
-// and internal/api/prom's `histogram` / `histograms` wire keys (the
-// HTTP-side landing spot) for the rest of the shared prerequisite.
+// internal/promql builds it from two lowerings today — a bare selector
+// (histogram_native_bare.go) and `sum [by/without] (<selector>)`
+// (histogram_native_sum.go). internal/chclient.Sample.Histogram is the
+// decode-side landing spot for the columns it publishes, and
+// internal/api/prom's `histogram` / `histograms` wire keys the HTTP-side
+// one.
 //
 // Column-name contract: every *Column field is REQUIRED except
 // ZeroThresholdColumn, mirroring HistogramQuantileNative — an empty

--- a/internal/chsql/histogram_projection.go
+++ b/internal/chsql/histogram_projection.go
@@ -6,10 +6,10 @@
 // to the fixed chplan.Histogram*Column names, rather than collapsed to
 // a scalar the way histogram_quantile_native.go's emitter is.
 //
-// No lowering builds a chplan.HistogramProjection today; see that
-// type's doc comment for the shared-prerequisite rationale (#1926).
-// This file's only consumer today is internal/chsql's own tests,
-// exercising the emitter directly against a hand-built plan node.
+// internal/promql's native-histogram lowerings — a bare selector and
+// `sum [by/without] (<selector>)` — are what build the node this emits;
+// see that type's doc comment for the output contract their shared cap
+// guarantees (#1926 / #1967).
 package chsql
 
 import (

--- a/internal/promql/exp_histogram_reject_test.go
+++ b/internal/promql/exp_histogram_reject_test.go
@@ -18,18 +18,22 @@ import (
 // TestLower_ExpHistogram_UnsupportedShapesRejectExplicitly pins issue #1704:
 // every PromQL shape over a pinned exponential-histogram selector OTHER
 // than histogram_quantile() / histogram_count() / histogram_sum(), the
-// `_count` / `_sum` companion selectors, and a top-level BARE selector
-// (issue #1967 — see TestLower_ExpHistogram_BareSelectorIsHistogramValued)
-// must fail lowering with a clear error, never silently resolve against
-// the Gauge/Sum tables and return an empty-but-200 result. Before the fix,
-// TablesFor never yielded ExpHistogramTable for these shapes, so cerberus
-// quietly scanned the wrong tables and matched zero rows.
+// `_count` / `_sum` companion selectors, and the two top-level
+// histogram-VALUED shapes issue #1967 answers — a BARE selector
+// (TestLower_ExpHistogram_BareSelectorIsHistogramValued) and `sum()` over
+// one (TestLower_ExpHistogram_SumIsHistogramValued) — must fail lowering
+// with a clear error, never silently resolve against the Gauge/Sum tables
+// and return an empty-but-200 result. Before the fix, TablesFor never
+// yielded ExpHistogramTable for these shapes, so cerberus quietly scanned
+// the wrong tables and matched zero rows.
 //
-// The nested cases are what keeps the #1967 narrowing HONEST: a bare
-// selector is answerable because nothing consumes it, and each of these
-// wraps that same selector in a consumer that reads a `Value` column the
-// histogram row shape does not publish. They stay rejected until each
-// grows its own histogram-aware lowering.
+// The nested cases are what keeps the #1967 narrowing HONEST. Each
+// answerable shape is answerable because of what sits ABOVE it — nothing,
+// for a bare selector; a bucket-ladder merge rather than a `Value` read,
+// for `sum()` — so each case here wraps one of them in a consumer that
+// does read a `Value` column the histogram row shape never publishes, or
+// hands `sum()` an aggregand that is not a bare selector. They stay
+// rejected until each grows its own histogram-aware lowering.
 func TestLower_ExpHistogram_UnsupportedShapesRejectExplicitly(t *testing.T) {
 	t.Parallel()
 
@@ -44,10 +48,11 @@ func TestLower_ExpHistogram_UnsupportedShapesRejectExplicitly(t *testing.T) {
 		{name: "resets", query: `resets(latency_exp_hist[5m])`},
 		{name: "changes", query: `changes(latency_exp_hist[5m])`},
 		{name: "increase", query: `increase(latency_exp_hist[5m])`},
-		{name: "sum aggregation", query: `sum(latency_exp_hist)`},
-		{name: "sum by", query: `sum by (service) (latency_exp_hist)`},
 		{name: "absent_over_time", query: `absent_over_time(latency_exp_hist[5m])`},
 		{name: "avg aggregation", query: `avg(latency_exp_hist)`},
+		{name: "min aggregation", query: `min(latency_exp_hist)`},
+		{name: "max aggregation", query: `max(latency_exp_hist)`},
+		{name: "count aggregation", query: `count(latency_exp_hist)`},
 		{name: "scalar arithmetic", query: `latency_exp_hist * 2`},
 		{name: "parenthesised scalar arithmetic", query: `(latency_exp_hist) + 1`},
 		{name: "label_replace", query: `label_replace(latency_exp_hist, "a", "b", "service", "(.*)")`},
@@ -55,6 +60,18 @@ func TestLower_ExpHistogram_UnsupportedShapesRejectExplicitly(t *testing.T) {
 		{name: "topk", query: `topk(3, latency_exp_hist)`},
 		{name: "raw range vector", query: `latency_exp_hist[5m]`},
 		{name: "subquery", query: `max_over_time(latency_exp_hist[5m:1m])`},
+
+		// `sum()` over a bare selector IS answered (see
+		// TestLower_ExpHistogram_SumIsHistogramValued). These are the
+		// shapes the narrowing must NOT reach: a `sum` whose aggregand is
+		// not a bare selector, and a `sum` that is not the root.
+		{name: "sum over rate", query: `sum(rate(latency_exp_hist[5m]))`},
+		{name: "sum over increase", query: `sum(increase(latency_exp_hist[5m]))`},
+		{name: "sum of sum", query: `sum(sum(latency_exp_hist))`},
+		{name: "sum under arithmetic", query: `sum(latency_exp_hist) + 1`},
+		{name: "sum under label_replace", query: `label_replace(sum(latency_exp_hist), "a", "b", "service", "(.*)")`},
+		{name: "sum under topk", query: `topk(3, sum by (service) (latency_exp_hist))`},
+		{name: "sum under abs", query: `abs(sum(latency_exp_hist))`},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -246,5 +263,155 @@ func TestLower_ExpHistogram_BareSelectorEmitsThirteenColumns(t *testing.T) {
 	last := wantSuffix[len(wantSuffix)-1]
 	if !strings.HasSuffix(strings.TrimSpace(head), "AS `"+last+"`") {
 		t.Fatalf("emitted projection does not END with %q — chclient's probe reads the LAST column: %s", last, head)
+	}
+}
+
+// TestLower_ExpHistogram_SumIsHistogramValued pins issue #1967's second
+// cut: `sum [by/without] (<exp-histogram selector>)` is answerable, and
+// the answer is a chplan.HistogramProjection publishing the same
+// thirteen-column contract as the bare sibling.
+//
+// The `__name__` assertion is the load-bearing difference from the bare
+// path and the one a reader is most likely to get wrong by copying it:
+// reference PromQL drops `__name__` from every aggregation result, so the
+// quartet's first slot must be an EMPTY literal, not the MetricName
+// column the bare path carries up. Reading the column here would report a
+// merged series under whichever member's stored name argMax happened to
+// pick.
+func TestLower_ExpHistogram_SumIsHistogramValued(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+
+	cases := []struct {
+		name  string
+		query string
+		lower func(parser.Expr) (chplan.Node, error)
+	}{
+		{
+			name:  "instant",
+			query: `sum(latency_exp_hist)`,
+			lower: func(e parser.Expr) (chplan.Node, error) {
+				return promql.LowerAt(context.Background(), e, s, end, end)
+			},
+		},
+		{
+			name:  "instant by",
+			query: `sum by (service) (latency_exp_hist)`,
+			lower: func(e parser.Expr) (chplan.Node, error) {
+				return promql.LowerAt(context.Background(), e, s, end, end)
+			},
+		},
+		{
+			name:  "instant without",
+			query: `sum without (pod) (latency_exp_hist{service="api"})`,
+			lower: func(e parser.Expr) (chplan.Node, error) {
+				return promql.LowerAt(context.Background(), e, s, end, end)
+			},
+		},
+		{
+			name:  "parenthesised",
+			query: `(sum(latency_exp_hist))`,
+			lower: func(e parser.Expr) (chplan.Node, error) {
+				return promql.LowerAt(context.Background(), e, s, end, end)
+			},
+		},
+		{
+			name:  "range",
+			query: `sum by (service) (latency_exp_hist)`,
+			lower: func(e parser.Expr) (chplan.Node, error) {
+				return promql.LowerAtRange(context.Background(), e, s, start, end, 30*time.Second)
+			},
+		},
+		{
+			name:  "range with absolute @ pin",
+			query: `sum(latency_exp_hist @ 1767225600)`,
+			lower: func(e parser.Expr) (chplan.Node, error) {
+				return promql.LowerAtRange(context.Background(), e, s, start, end, 30*time.Second)
+			},
+		},
+	}
+
+	wantAliases := []string{
+		s.MetricNameColumn, s.AttributesColumn, s.TimestampColumn, s.ValueColumn,
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			expr, err := p.ParseExpr(tc.query)
+			if err != nil {
+				t.Fatalf("ParseExpr(%q): %v", tc.query, err)
+			}
+			plan, err := tc.lower(expr)
+			if err != nil {
+				t.Fatalf("lower(%q): unexpected error: %v", tc.query, err)
+			}
+			if shape := chplan.RowShapeOf(plan); shape != chplan.HistogramRowShape {
+				t.Fatalf("lower(%q): plan root publishes %s, want histogram", tc.query, shape)
+			}
+			hp, ok := plan.(*chplan.HistogramProjection)
+			if !ok {
+				t.Fatalf("lower(%q): plan root is %T, want *chplan.HistogramProjection", tc.query, plan)
+			}
+			if !slices.Equal(hp.GroupByAliases, wantAliases) {
+				t.Fatalf("lower(%q): leading output aliases = %v, want %v", tc.query, hp.GroupByAliases, wantAliases)
+			}
+			name, ok := hp.GroupBy[0].(*chplan.LitString)
+			if !ok || name.V != "" {
+				t.Fatalf("lower(%q): __name__ projection is %#v, want an empty literal — "+
+					"an aggregation result carries no metric name", tc.query, hp.GroupBy[0])
+			}
+		})
+	}
+}
+
+// TestLower_ExpHistogram_SumMergesBucketLadders pins that `sum()` reaches
+// the SHARED native-histogram merge — the scale-fold + offset-align +
+// zero-pad that mirrors Prometheus's FloatHistogram.Add — rather than
+// reducing the histogram columns some other way.
+//
+// This is the assertion that would catch the worst plausible bug in this
+// lowering: a plan that carried ONE member series' ladder straight
+// through (an argMax, say, or a groupArray never folded) would still
+// produce a HistogramProjection, still emit thirteen columns in contract
+// order, and still pass every structural check above — while silently
+// answering `sum()` with one of its operands.
+//
+// `min(Scale)` is the fold's signature: it is the merged scale every
+// per-row ladder is downshifted to, and nothing else in the plan emits
+// it. The three `sum(...)` folds are the scalars that must add across the
+// group rather than be picked from it.
+func TestLower_ExpHistogram_SumMergesBucketLadders(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	expr, err := p.ParseExpr(`sum by (service) (latency_exp_hist)`)
+	if err != nil {
+		t.Fatalf("ParseExpr: %v", err)
+	}
+	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	plan, err := promql.LowerAt(context.Background(), expr, s, at, at)
+	if err != nil {
+		t.Fatalf("LowerAt: %v", err)
+	}
+	sql, _, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	for _, want := range []string{
+		"min(`" + s.ScaleColumn + "`)",
+		"sum(`" + s.CountColumn + "`) AS `" + s.CountColumn + "`",
+		"sum(`" + s.SumColumn + "`) AS `" + s.SumColumn + "`",
+		"sum(`" + s.ZeroCountColumn + "`) AS `" + s.ZeroCountColumn + "`",
+		"bitShiftRight",
+	} {
+		if !strings.Contains(sql, want) {
+			t.Fatalf("emitted SQL does not reach the shared native-histogram merge: missing %q\n%s", want, sql)
+		}
 	}
 }

--- a/internal/promql/histogram_native_bare.go
+++ b/internal/promql/histogram_native_bare.go
@@ -16,12 +16,12 @@ import (
 // other cerberus lowering reduces a histogram row to a scalar before it
 // reaches the wire (histogram_quantile / histogram_count /
 // histogram_sum), which is why [expHistogramSelectorRouting] rejects the
-// bare shape wherever it is NOT the whole query: an inner reducer
-// (`sum(...)`, `rate(...[5m])`, `avg(...)`, arithmetic) would read a
-// `Value` column the histogram row shape does not carry, and answering
-// it with the placeholder value would be silently wrong. Those shapes
-// keep their explicit rejection until each grows its own correct
-// lowering (issue #1967).
+// bare shape wherever it is NOT the whole query: a consumer that reads a
+// `Value` column the histogram row shape does not carry would silently
+// reduce the placeholder value. Such shapes keep their explicit
+// rejection until each grows its own histogram-AWARE lowering — the one
+// that exists so far is `sum()`, in histogram_native_sum.go, which
+// consumes the bucket ladders rather than a Value (issue #1967).
 //
 // The plan shape mirrors the native-quantile siblings in
 // histogram_quantile.go / histogram_quantile_range.go rung for rung —
@@ -105,6 +105,7 @@ func lowerExpHistogramBare(vs *parser.VectorSelector, s schema.Metrics, ctx lowe
 		grid := &chplan.StepGrid{Start: ctx.start.UTC(), End: ctx.end.UTC(), Step: ctx.step}
 		return nativeHistogramProjection(
 			&chplan.CrossJoin{Left: grid, Right: latest},
+			bareExpHistogramNameExpr(s),
 			&chplan.ColumnRef{Name: stepGridAnchorColumn},
 			s,
 		), nil
@@ -113,7 +114,16 @@ func lowerExpHistogramBare(vs *parser.VectorSelector, s schema.Metrics, ctx lowe
 	if err != nil {
 		return nil, err
 	}
-	return nativeHistogramProjection(latest, chplan.NowNano(), s), nil
+	return nativeHistogramProjection(latest, bareExpHistogramNameExpr(s), chplan.NowNano(), s), nil
+}
+
+// bareExpHistogramNameExpr is the `__name__` a BARE selector reports: the
+// series' own metric name, carried up from [nativeExpHistBareAggs]'s
+// argMax. Only DERIVED samples drop the name — which is why the `sum()`
+// sibling in histogram_native_sum.go passes an empty literal here
+// instead.
+func bareExpHistogramNameExpr(s schema.Metrics) chplan.Expr {
+	return &chplan.ColumnRef{Name: s.MetricNameColumn}
 }
 
 // expHistogramBareLatest builds the instant-mode subtree beneath the
@@ -149,7 +159,7 @@ func lowerExpHistogramBareRange(vs *parser.VectorSelector, s schema.Metrics, ctx
 		[]chplan.Expr{histogramIdentityExpr(s)}, []string{s.AttributesColumn},
 		nativeExpHistBareAggs(s), s, ctx,
 	)
-	return nativeHistogramProjection(fanout, &chplan.ColumnRef{Name: stepGridAnchorColumn}, s)
+	return nativeHistogramProjection(fanout, bareExpHistogramNameExpr(s), &chplan.ColumnRef{Name: stepGridAnchorColumn}, s)
 }
 
 // nativeExpHistBareAggs is [nativeExpHistLatestAggs] widened by the three
@@ -165,21 +175,45 @@ func lowerExpHistogramBareRange(vs *parser.VectorSelector, s schema.Metrics, ctx
 //     works off the bucket ladder, but which are part of the native
 //     histogram's wire shape.
 func nativeExpHistBareAggs(s schema.Metrics) []chplan.AggFunc {
-	aggs := []chplan.AggFunc{
-		latestArgMax(s.MetricNameColumn, s),
-		latestArgMax(s.CountColumn, s),
-		latestArgMax(s.SumColumn, s),
-	}
-	return append(aggs, nativeExpHistLatestAggs(s)...)
+	return append(
+		[]chplan.AggFunc{latestArgMax(s.MetricNameColumn, s)},
+		nativeExpHistValuedLatestAggs(s)...,
+	)
+}
+
+// nativeExpHistValuedLatestAggs is [nativeExpHistLatestAggs] widened by
+// Count and Sum — the two whole-histogram scalars the quantile kernel
+// never reads (it works off the bucket ladder) but which are part of the
+// native histogram's wire shape, so any histogram-VALUED answer owes
+// them.
+//
+// It stops short of MetricName because that field's correct value is not
+// a property of the row: a bare selector keeps `__name__` and an
+// aggregation drops it, so each caller supplies its own — see
+// [bareExpHistogramNameExpr].
+func nativeExpHistValuedLatestAggs(s schema.Metrics) []chplan.AggFunc {
+	return append(
+		[]chplan.AggFunc{
+			latestArgMax(s.CountColumn, s),
+			latestArgMax(s.SumColumn, s),
+		},
+		nativeExpHistLatestAggs(s)...,
+	)
 }
 
 // nativeHistogramProjection caps input with the
 // [chplan.HistogramProjection] that publishes the thirteen-column
-// histogram row: the canonical sample quartet first — with tsExpr
-// supplying the timestamp, which is `now64(9)` for an instant query and
-// the grid anchor column for a range one — then the nine raw structural
-// columns under their fixed chplan.Histogram*Column aliases.
-func nativeHistogramProjection(input chplan.Node, tsExpr chplan.Expr, s schema.Metrics) *chplan.HistogramProjection {
+// histogram row: the canonical sample quartet first — with nameExpr
+// supplying `__name__` (the series' own name for a bare selector, an
+// empty literal for a derived sample) and tsExpr the timestamp, which is
+// `now64(9)` for an instant query and the grid anchor column for a range
+// one — then the nine raw structural columns under their fixed
+// chplan.Histogram*Column aliases.
+//
+// Shared with the `sum()` lowering in histogram_native_sum.go, which
+// differs from the bare path in exactly those two expressions and in the
+// subtree it caps.
+func nativeHistogramProjection(input chplan.Node, nameExpr, tsExpr chplan.Expr, s schema.Metrics) *chplan.HistogramProjection {
 	return &chplan.HistogramProjection{
 		Input:                      input,
 		CountColumn:                s.CountColumn,
@@ -192,7 +226,7 @@ func nativeHistogramProjection(input chplan.Node, tsExpr chplan.Expr, s schema.M
 		NegativeOffsetColumn:       s.NegativeOffsetColumn,
 		NegativeBucketCountsColumn: s.NegativeBucketCountsColumn,
 		GroupBy: []chplan.Expr{
-			&chplan.ColumnRef{Name: s.MetricNameColumn},
+			nameExpr,
 			&chplan.ColumnRef{Name: s.AttributesColumn},
 			tsExpr,
 			&chplan.LitFloat{V: histogramSampleValuePlaceholder},

--- a/internal/promql/histogram_native_sum.go
+++ b/internal/promql/histogram_native_sum.go
@@ -1,0 +1,266 @@
+package promql
+
+import (
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// histogram_native_sum.go lowers `sum [by/without] (<selector>)` over an
+// OTel exponential (native) histogram — `<base>_exp_hist` — into a
+// histogram-VALUED result, the second lowering (after the bare selector
+// in histogram_native_bare.go) to cap a plan with a
+// [chplan.HistogramProjection].
+//
+// Reference Prometheus answers `sum()` over native-histogram samples
+// with a native histogram, not a float: promql's aggregation walks the
+// group calling `histogram.FloatHistogram.Add` on each member, so the
+// result is the element-wise ADDITION of the members' distributions.
+// That is a genuinely different operation from the float path's
+// `sum(Value)` — the operands are bucket LADDERS whose absolute bucket
+// indices only line up after their scales and offsets are reconciled.
+//
+// Reusing the reconciliation rather than re-deriving it is the whole
+// point of this file's shape. The across-series merge cerberus already
+// runs for `histogram_quantile(phi, sum(rate(...)))` —
+// [expHistogramMergeAggs] + [expHistogramMergeProjections], documented
+// against Prometheus's FloatHistogram.Add in
+// lowerHistogramQuantileNativeAgg — IS histogram addition; the quantile
+// path just happens to consume its output with an interpolation kernel
+// instead of publishing it. `sum()` publishes it, so the two paths share
+// one merge and cannot drift apart in their arithmetic.
+//
+// What this file adds on top of that shared merge is the pair of
+// whole-histogram scalars the quantile kernel never reads — Count and
+// Sum — which add plainly across the group, and the
+// [chplan.HistogramProjection] cap.
+//
+// Plan shape (instant mode; the range shapes differ only in the anchor
+// column threaded through both reductions):
+//
+//	HistogramProjection [MetricName='', Attributes, now64(9), Value=0, <nine histogram columns>]
+//	  Project [Attributes (rebuilt from gkeys), merged Scale / ZeroCount /
+//	           ZeroThreshold / {Pos,Neg}{Offset,BucketCounts}, Count, Sum]
+//	    Aggregate groupBy=[<user by/without labels>] funcs=<expHistogramSumMergeAggs>
+//	      Aggregate groupBy=[series identity] funcs=<nativeExpHistValuedLatestAggs>  ← per series
+//	        Filter <matchers> AND <staleness window>
+//	          Scan(otel_metrics_exponential_histogram)
+//
+// The two stages are the same split every native-histogram aggregation
+// in this package uses, and for the same reason: the inner one resolves
+// each SERIES to a single sample (a selector under an aggregation is
+// still subject to staleness lookback — one sample per series, the
+// newest in the window), and only then does the outer one add
+// distributions ACROSS series. Collapsing them into one grouping would
+// add a series' own consecutive scrapes to each other.
+
+// sumOverExpHistogram reports whether expr is `sum [by/without] (<bare
+// exp-histogram selector>)` — the one shape this file answers.
+//
+// Like [bareExpHistogramSelector] it is asked only of the ROOT of a
+// query (see [lowerRoot]), and for the same reason: the answer is a
+// histogram row, which only the wire can consume. `sum(m_exp_hist) + 1`
+// or `topk(3, sum(m_exp_hist))` reaches lowerVectorSelector through the
+// ordinary descent and is still rejected there.
+//
+// The inner expression must unwrap to a bare selector. `sum(rate(
+// m_exp_hist[5m]))` does not: its aggregand is a range-vector function
+// with its own histogram-valued lowering to grow (issue #1967), and
+// admitting it here would silently drop the rate.
+func sumOverExpHistogram(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (*parser.AggregateExpr, *parser.VectorSelector, bool) {
+	if s.ExpHistogramTable == "" || ctx.metadataFullRange {
+		return nil, nil, false
+	}
+	agg, ok := unwrapAggregateExpr(expr)
+	// Param is nil for every SUM the parser produces (only the topk /
+	// bottomk / quantile / count_values family carries one); the check
+	// states the assumption rather than relying on it.
+	if !ok || agg.Op != parser.SUM || agg.Param != nil {
+		return nil, nil, false
+	}
+	vs, ok := unwrapVectorSelector(agg.Expr)
+	if !ok {
+		return nil, nil, false
+	}
+	if !s.IsExpHistogramMetric(metricNameFromMatchers(vs.LabelMatchers)) {
+		return nil, nil, false
+	}
+	return agg, vs, true
+}
+
+// unwrapAggregateExpr peels the transparent wrappers the parser can put
+// between the root and an aggregation — `(sum(m))` and the
+// step-invariance marker — and reports the aggregation underneath.
+// Mirrors [unwrapVectorSelector], which does the same for a selector.
+func unwrapAggregateExpr(e parser.Expr) (*parser.AggregateExpr, bool) {
+	for {
+		switch v := e.(type) {
+		case *parser.AggregateExpr:
+			return v, true
+		case *parser.ParenExpr:
+			e = v.Expr
+		case *parser.StepInvariantExpr:
+			e = v.Expr
+		default:
+			return nil, false
+		}
+	}
+}
+
+// lowerExpHistogramSum lowers the `sum()` shape across the three
+// evaluation shapes [rangeGridShapeFor] distinguishes, the same three
+// the bare sibling handles — see [lowerExpHistogramBare] for what each
+// one means.
+func lowerExpHistogramSum(agg *parser.AggregateExpr, vs *parser.VectorSelector, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+	if shape := rangeGridShapeFor(vs, ctx); shape == gridFanout {
+		return lowerExpHistogramSumRange(agg, vs, s, ctx), nil
+	} else if shape == gridBroadcast {
+		merged, err := expHistogramSumMergedInstant(agg, vs, s, ctx)
+		if err != nil {
+			return nil, err
+		}
+		// Same broadcast placement as the bare path's: the cross join goes
+		// UNDER the histogram projection so the plan root stays a
+		// HistogramProjection and keeps publishing the thirteen-column
+		// contract. The pinned window is merged ONCE and every step
+		// reports that one distribution at its own timestamp.
+		grid := &chplan.StepGrid{Start: ctx.start.UTC(), End: ctx.end.UTC(), Step: ctx.step}
+		return aggregatedHistogramProjection(
+			&chplan.CrossJoin{Left: grid, Right: merged},
+			&chplan.ColumnRef{Name: stepGridAnchorColumn},
+			s,
+		), nil
+	}
+	merged, err := expHistogramSumMergedInstant(agg, vs, s, ctx)
+	if err != nil {
+		return nil, err
+	}
+	return aggregatedHistogramProjection(merged, chplan.NowNano(), s), nil
+}
+
+// expHistogramSumMergedInstant builds the instant-mode subtree beneath
+// the histogram projection: the filtered scan collapsed to the newest
+// in-window sample per series, then merged across series by the user's
+// grouping. Its output is one row per output series carrying the merged
+// distribution under the schema's own column names.
+func expHistogramSumMergedInstant(agg *parser.AggregateExpr, vs *parser.VectorSelector, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+	scan := &chplan.Scan{Table: s.ExpHistogramTable}
+	pred := buildPredicate(vs.LabelMatchers, s)
+	pred, err := andInstantWindow(pred, vs, s.TimestampColumn, ctx)
+	if err != nil {
+		return nil, err
+	}
+	var input chplan.Node = scan
+	if pred != nil {
+		input = &chplan.Filter{Input: scan, Predicate: pred}
+	}
+	perSeries := latestSampleAgg(input, nativeExpHistValuedLatestAggs(s), s)
+	return expHistogramSumMerge(perSeries, nil, agg, s), nil
+}
+
+// lowerExpHistogramSumRange is the query_range shape. Stage 1 is the
+// per-anchor [chplan.RangeBucketFanout] the bare range path builds — one
+// staleness window per step anchor, keyed on SERIES identity — and stage
+// 2 is the across-series merge within each anchor, exactly as
+// buildHistogramNativeRangeTreeMerge stacks the two for the quantile.
+//
+// Keying stage 1 on series identity rather than on the user's
+// `by/without` labels is what makes the per-anchor collapse mean what
+// reference PromQL means: `sum by(service)` over three pods must take
+// each pod's own newest sample and add the three, not take one newest
+// sample per service.
+func lowerExpHistogramSumRange(agg *parser.AggregateExpr, vs *parser.VectorSelector, s schema.Metrics, ctx lowerCtx) chplan.Node {
+	scan := &chplan.Scan{Table: s.ExpHistogramTable}
+	pred := buildPredicate(vs.LabelMatchers, s)
+	perSeries := buildHistogramBucketFanout(
+		scan, pred, nil, windowFor(vs, instantLookback),
+		[]chplan.Expr{histogramIdentityExpr(s)}, []string{s.AttributesColumn},
+		nativeExpHistValuedLatestAggs(s), s, ctx,
+	)
+	anchor := &chplan.ColumnRef{Name: stepGridAnchorColumn}
+	return aggregatedHistogramProjection(expHistogramSumMerge(perSeries, anchor, agg, s), anchor, s)
+}
+
+// expHistogramSumMerge is the across-SERIES stage: it adds the per-series
+// distributions perSeries hands up, grouped by the user's `by/without`
+// clause, and reshapes the result back into the exp-histogram row
+// contract under the schema's own column names.
+//
+// anchor is nil in instant mode and the fan-out's anchor column in range
+// mode, where it prepends both the grouping key (each step anchor merges
+// independently) and the reshape projection (the projection above reads
+// it back for the output timestamp).
+//
+// The grouping keys bind from the per-series stage's already-canonical
+// Attributes column rather than from the raw table, which is no longer
+// in scope above stage 1 — the same binding [histogramAggGroupBy]'s doc
+// describes for the quantile paths, and the reason they must not be
+// re-wrapped in [canonicalGroupKeyExpr].
+func expHistogramSumMerge(perSeries chplan.Node, anchor *chplan.ColumnRef, agg *parser.AggregateExpr, s schema.Metrics) chplan.Node {
+	groupBy, groupByAliases, attrsRebuild := histogramAggGroupBy(
+		agg, &chplan.ColumnRef{Name: s.AttributesColumn}, s,
+	)
+	var projs []chplan.Projection
+	if anchor != nil {
+		groupBy = append([]chplan.Expr{anchor}, groupBy...)
+		groupByAliases = append([]string{stepGridAnchorColumn}, groupByAliases...)
+		projs = append(projs, chplan.Projection{Expr: anchor, Alias: stepGridAnchorColumn})
+	}
+	merged := &chplan.Aggregate{
+		Input:              perSeries,
+		GroupBy:            groupBy,
+		GroupByAliases:     groupByAliases,
+		AggFuncs:           expHistogramSumMergeAggs(s),
+		DropEmptyOnNoGroup: true,
+	}
+	projs = append(projs, chplan.Projection{Expr: attrsRebuild, Alias: s.AttributesColumn})
+	projs = append(projs, expHistogramSumMergeProjections(s)...)
+	return &chplan.Project{Input: merged, Projections: projs}
+}
+
+// expHistogramSumMergeAggs is [expHistogramMergeAggs] — the shared
+// scale-fold + offset-align + zero-pad collection, the arithmetic of
+// FloatHistogram.Add — widened by the two whole-histogram scalars a
+// histogram-VALUED answer must also publish.
+//
+// Count and Sum add plainly: they are the group's total observation
+// count and total observed value, and neither depends on bucket
+// alignment. `sum(<col>) AS <col>` reuses the source column's own name,
+// the same aliasing expHistogramMergeAggs already applies to ZeroCount.
+func expHistogramSumMergeAggs(s schema.Metrics) []chplan.AggFunc {
+	return append(
+		[]chplan.AggFunc{
+			{Name: "sum", Args: []chplan.Expr{&chplan.ColumnRef{Name: s.CountColumn}}, Alias: s.CountColumn},
+			{Name: "sum", Args: []chplan.Expr{&chplan.ColumnRef{Name: s.SumColumn}}, Alias: s.SumColumn},
+		},
+		expHistogramMergeAggs(s)...,
+	)
+}
+
+// expHistogramSumMergeProjections is [expHistogramMergeProjections] plus
+// the Count / Sum pass-through, so the reshaped row carries all nine
+// fields [chplan.HistogramProjection] reads by name rather than the
+// seven the quantile kernel needs.
+func expHistogramSumMergeProjections(s schema.Metrics) []chplan.Projection {
+	return append(
+		[]chplan.Projection{
+			{Expr: &chplan.ColumnRef{Name: s.CountColumn}, Alias: s.CountColumn},
+			{Expr: &chplan.ColumnRef{Name: s.SumColumn}, Alias: s.SumColumn},
+		},
+		expHistogramMergeProjections(s)...,
+	)
+}
+
+// aggregatedHistogramProjection caps a merged subtree with the
+// thirteen-column [chplan.HistogramProjection], reporting an EMPTY
+// `__name__`.
+//
+// The empty name is PromQL's rule, not a shortcut: an aggregation
+// produces a derived sample, and reference Prometheus drops `__name__`
+// from every aggregation result. It is also why the merge stage never
+// collects MetricName — there is no per-group answer to collect, since
+// one group can span several stored spellings of the metric name.
+func aggregatedHistogramProjection(input chplan.Node, tsExpr chplan.Expr, s schema.Metrics) *chplan.HistogramProjection {
+	return nativeHistogramProjection(input, &chplan.LitString{V: ""}, tsExpr, s)
+}

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -169,23 +169,29 @@ func LowerMetadataRange(ctx context.Context, expr parser.Expr, s schema.Metrics,
 }
 
 // lowerRoot lowers the ROOT of a query expression. It is [lower] plus the
-// one dispatch that can only be decided at the root: a bare selector over
-// an exponential (native) histogram returns a HISTOGRAM-VALUED sample, and
-// that answer has a wire representation only when the selector IS the whole
-// query.
+// dispatches that can only be decided at the root: the shapes over an
+// exponential (native) histogram that return a HISTOGRAM-VALUED sample —
+// a bare selector and `sum [by/without] (<selector>)` — whose answer has
+// a wire representation only when the shape IS the whole query.
 //
 // The distinction cannot be made inside [lowerVectorSelector], because the
 // selector in `sum(m_exp_hist)` and the selector in `m_exp_hist` arrive
-// there identically — same node, same instant-mode context. Every consumer
-// PromQL can wrap around a selector (a reducer, arithmetic,
-// `label_replace`, a range-vector function) reads a `Value` column that a
-// histogram row does not publish, so answering the nested shape with a
-// histogram projection would either fail in ClickHouse with code 47 or,
-// worse, silently reduce the placeholder Value. Deciding here — where the
-// absence of a parent is a fact rather than an inference — keeps those
-// shapes on [expHistogramSelectorRouting]'s explicit rejection until each
-// grows its own correct lowering (issue #1967), and never widens the
-// exemption by accident: a nested selector never reaches this function.
+// there identically — same node, same instant-mode context. Most consumers
+// PromQL can wrap around a selector (arithmetic, `label_replace`, a
+// range-vector function, every reducer other than `sum`) read a `Value`
+// column that a histogram row does not publish, so answering the nested
+// shape with a histogram projection would either fail in ClickHouse with
+// code 47 or, worse, silently reduce the placeholder Value. Deciding
+// here — where the absence of a parent is a fact rather than an
+// inference — keeps those shapes on [expHistogramSelectorRouting]'s
+// explicit rejection until each grows its own histogram-AWARE lowering
+// (issue #1967), and never widens the exemption by accident: a nested
+// selector never reaches this function.
+//
+// The two dispatches are ordered but not mutually exclusive in principle,
+// and the order is arbitrary: [bareExpHistogramSelector] and
+// [sumOverExpHistogram] recognise disjoint root node types (a selector vs
+// an aggregation), so neither can shadow the other.
 //
 // Metadata lowering ([LowerMetadataRange]) deliberately does NOT route
 // through here: it enumerates series and labels rather than evaluating an
@@ -194,6 +200,9 @@ func LowerMetadataRange(ctx context.Context, expr parser.Expr, s schema.Metrics,
 func lowerRoot(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
 	if vs, ok := bareExpHistogramSelector(expr, s, ctx); ok {
 		return lowerExpHistogramBare(vs, s, ctx)
+	}
+	if agg, vs, ok := sumOverExpHistogram(expr, s, ctx); ok {
+		return lowerExpHistogramSum(agg, vs, s, ctx)
 	}
 	return lower(expr, s, ctx)
 }
@@ -413,12 +422,15 @@ func lowerHistogramSelectorInput(
 // err rejects it explicitly rather than silently matching zero rows
 // against the Gauge/Sum tables.
 //
-// A BARE selector no longer reaches here at all: it returns a
-// histogram-valued sample, which [lowerRoot] answers with a
-// chplan.HistogramProjection before the recursive descent that leads to
-// lowerVectorSelector ever starts. That is the whole of the narrowing —
-// a nested selector still arrives here and is still rejected, because
-// nothing above it can consume a histogram row yet (issue #1967).
+// Two shapes no longer reach here at all: a BARE selector, and `sum
+// [by/without] (<selector>)`. Both return a histogram-valued sample,
+// which [lowerRoot] answers with a chplan.HistogramProjection before the
+// recursive descent that leads to lowerVectorSelector ever starts. That
+// is the whole of the narrowing — the selector nested under anything
+// ELSE still arrives here and is still rejected, because nothing above
+// it can consume a histogram row yet (issue #1967). `sum()` is the one
+// reducer exempt so far precisely because it does not read a Value: it
+// adds the bucket ladders themselves.
 //
 // Metadata enumeration (/series, /labels — ctx.metadataFullRange) is
 // exempted: it doesn't consume a Value column, only MetricName +
@@ -434,8 +446,8 @@ func expHistogramSelectorRouting(metricName string, s schema.Metrics, ctx lowerC
 	if s.IsExpHistogramMetric(metricName) && !ctx.metadataFullRange {
 		return nil, nil, "", "", true, fmt.Errorf(
 			"promql: %q is an exponential histogram metric; only a bare %q selector, "+
-				"histogram_quantile(), histogram_count(), histogram_sum(), and the %q/%q "+
-				"companion selectors are supported",
+				"sum() over one, histogram_quantile(), histogram_count(), histogram_sum(), "+
+				"and the %q/%q companion selectors are supported",
 			metricName, metricName, metricName+"_count", metricName+"_sum",
 		)
 	}

--- a/test/perf/cardinality-baseline/promql/exp_histogram_sum.json
+++ b/test/perf/cardinality-baseline/promql/exp_histogram_sum.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/exp_histogram_sum",
+  "fan_factor": 1,
+  "scan_rows": 2,
+  "peak_intermediate": 2,
+  "has_cross_join": false,
+  "has_array_join": false,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/cardinality-baseline/promql/exp_histogram_sum_by.json
+++ b/test/perf/cardinality-baseline/promql/exp_histogram_sum_by.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/exp_histogram_sum_by",
+  "fan_factor": 1,
+  "scan_rows": 3,
+  "peak_intermediate": 3,
+  "has_cross_join": false,
+  "has_array_join": false,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/cardinality-baseline/promql/exp_histogram_sum_mixed_scale.json
+++ b/test/perf/cardinality-baseline/promql/exp_histogram_sum_mixed_scale.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/exp_histogram_sum_mixed_scale",
+  "fan_factor": 1,
+  "scan_rows": 2,
+  "peak_intermediate": 2,
+  "has_cross_join": false,
+  "has_array_join": false,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/cardinality-baseline/promql/exp_histogram_sum_range.json
+++ b/test/perf/cardinality-baseline/promql/exp_histogram_sum_range.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/exp_histogram_sum_range",
+  "fan_factor": 10,
+  "scan_rows": 2,
+  "peak_intermediate": 20,
+  "has_cross_join": false,
+  "has_array_join": true,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/solver-decision-baseline/exp_histogram_sum.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_sum.json
@@ -1,0 +1,10 @@
+{
+  "query": "exp_histogram_sum",
+  "routed": false,
+  "k": 0,
+  "reason": "not-sliceable",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "5m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/exp_histogram_sum_by.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_sum_by.json
@@ -1,0 +1,10 @@
+{
+  "query": "exp_histogram_sum_by",
+  "routed": false,
+  "k": 0,
+  "reason": "not-sliceable",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "5m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/exp_histogram_sum_mixed_scale.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_sum_mixed_scale.json
@@ -1,0 +1,10 @@
+{
+  "query": "exp_histogram_sum_mixed_scale",
+  "routed": false,
+  "k": 0,
+  "reason": "not-sliceable",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "5m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/exp_histogram_sum_range.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_sum_range.json
@@ -1,0 +1,10 @@
+{
+  "query": "exp_histogram_sum_range",
+  "routed": false,
+  "k": 0,
+  "reason": "not-sliceable",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "5m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/rejection-parity/catalogue/internal__promql__lower.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__lower.go.json
@@ -73,8 +73,8 @@
     },
     {
       "head": "promql",
-      "site": "internal/promql/lower.go:expHistogramSelectorRouting#367e416d",
-      "message": "promql: %q is an exponential histogram metric; only a bare %q selector, histogram_quantile(), histogram_count(), histogram_sum(), and the %q/%q companion selectors are supported",
+      "site": "internal/promql/lower.go:expHistogramSelectorRouting#554bf4d3",
+      "message": "promql: %q is an exponential histogram metric; only a bare %q selector, sum() over one, histogram_quantile(), histogram_count(), histogram_sum(), and the %q/%q companion selectors are supported",
       "class": "divergence",
       "trigger_query": "rate(demo_latency_exp_hist[5m])",
       "tracking_issue": 1772,

--- a/test/spec/promql/exp_histogram_sum.txtar
+++ b/test/spec/promql/exp_histogram_sum.txtar
@@ -1,0 +1,100 @@
+-- query.promql --
+sum(http_server_duration_exp_hist)
+-- seed --
+CREATE TABLE otel_metrics_exponential_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    Scale Int32,
+    ZeroCount UInt64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64),
+    NegativeOffset Int32,
+    NegativeBucketCounts Array(UInt64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+-- Two series at the SAME Scale but DIFFERENT PositiveOffsets, so the
+-- merge has to offset-align before it can add. Both ladders are read at
+-- absolute bucket indices: `api` covers idx 0,1,2 with [1,2,3]; `web`
+-- covers idx 1,2 with [4,5] (offset 1).
+--
+-- merged offset = min(0, 1)               = 0
+-- merged span   = max(0+3-1, 1+2-1) - 0+1 = 3
+--   idx 0: api 1 +  web —  = 1
+--   idx 1: api 2 +  web 4  = 6
+--   idx 2: api 3 +  web 5  = 8
+-- so PositiveBucketCounts = [1, 6, 8] at PositiveOffset 0, Scale 0.
+--
+-- The three whole-histogram scalars add plainly: Count 6+9 = 15,
+-- Sum 42.5+10.5 = 53, ZeroCount 1+2 = 3. `sum()` drops __name__ and
+-- (with no by/without clause) every label, so the output series is
+-- ["", {}].
+INSERT INTO otel_metrics_exponential_histogram VALUES
+    ('http_server_duration_exp_hist', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 6, 42.5, 0, 1, 0, [1, 2, 3], 0, []),
+    ('http_server_duration_exp_hist', map('service', 'web'), toDateTime64('2026-01-01 00:00:00', 9), 9, 10.5, 0, 2, 1, [4, 5],    0, []);
+-- expected_rows --
+[
+  ["", {}, "2026-01-01T00:00:01Z", 0, 15, 53, 0, 0, 3, 0, [1,6,8], 0, []]
+]
+-- args --
+[0] string = ""
+[1] int64 = 9
+[2] float64 = 0
+[3] string = "Map(String,String)"
+[4] int64 = 1
+[5] int64 = 0
+[6] int64 = 0
+[7] int64 = 1
+[8] int64 = 1
+[9] int64 = 1
+[10] int64 = 0
+[11] int64 = 0
+[12] int64 = 1
+[13] int64 = 1
+[14] string = "service.name"
+[15] string = "service_name"
+[16] string = "service.name"
+[17] string = "service_name"
+[18] string = ""
+[19] string = "service_name"
+[20] string = "http_server_duration_exp_hist"
+[21] string = "http.server.duration.exp.hist"
+[22] string = "http.server.duration.exp/hist"
+[23] string = "http.server.duration.exp_hist"
+[24] string = "http.server.duration/exp/hist"
+[25] string = "http.server.duration/exp_hist"
+[26] string = "http.server.duration_exp.hist"
+[27] string = "http.server.duration_exp_hist"
+[28] string = "http.server/duration/exp/hist"
+[29] string = "http.server/duration/exp_hist"
+[30] string = "http.server/duration_exp_hist"
+[31] string = "http.server_duration.exp.hist"
+[32] string = "http.server_duration.exp_hist"
+[33] string = "http.server_duration_exp.hist"
+[34] string = "http.server_duration_exp_hist"
+[35] string = "http/server/duration/exp/hist"
+[36] string = "http/server/duration/exp_hist"
+[37] string = "http/server/duration_exp_hist"
+[38] string = "http/server_duration_exp_hist"
+[39] string = "http_server.duration.exp.hist"
+[40] string = "http_server.duration.exp_hist"
+[41] string = "http_server.duration_exp.hist"
+[42] string = "http_server.duration_exp_hist"
+[43] string = "http_server_duration.exp.hist"
+[44] string = "http_server_duration.exp_hist"
+[45] string = "http_server_duration_exp.hist"
+[46] string = "2026-01-01 00:00:01.000000000"
+[47] int64 = 9
+[48] string = "2026-01-01 00:00:01.000000000"
+[49] int64 = 9
+[50] int64 = 300000000000
+-- chplan --
+HistogramProjection project=["" AS MetricName, Attributes AS Attributes, now64(9) AS TimeUnix, 0 AS Value]
+  Project [CAST(map(), "Map(String,String)") AS Attributes, Count AS Count, Sum AS Sum, _hq_merged_scale AS Scale, ZeroCount AS ZeroCount, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - _hq_merged_scale)), _hq_scales, _hq_pos_offsets)) AS PositiveOffset, arrayMap(t -> arraySum(arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - 1)), (s - _hq_merged_scale)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets)) + t)), arr[j], 0), arrayEnumerate(arr))), _hq_scales, _hq_pos_offsets, _hq_pos_buckets)), range(toUInt64(greatest(0, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - 1)), (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets, _hq_pos_buckets)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets))) + 1))))) AS PositiveBucketCounts, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - _hq_merged_scale)), _hq_scales, _hq_neg_offsets)) AS NegativeOffset, arrayMap(t -> arraySum(arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - 1)), (s - _hq_merged_scale)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets)) + t)), arr[j], 0), arrayEnumerate(arr))), _hq_scales, _hq_neg_offsets, _hq_neg_buckets)), range(toUInt64(greatest(0, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - 1)), (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets, _hq_neg_buckets)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets))) + 1))))) AS NegativeBucketCounts]
+    Aggregate groupBy=[] funcs=[sum(Count) AS Count, sum(Sum) AS Sum, min(Scale) AS _hq_merged_scale, sum(ZeroCount) AS ZeroCount, groupArray(Scale) AS _hq_scales, groupArray(PositiveOffset) AS _hq_pos_offsets, groupArray(PositiveBucketCounts) AS _hq_pos_buckets, groupArray(NegativeOffset) AS _hq_neg_offsets, groupArray(NegativeBucketCounts) AS _hq_neg_buckets]
+      Aggregate groupBy=[mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes] funcs=[argMax(Count, TimeUnix) AS Count, argMax(Sum, TimeUnix) AS Sum, argMax(Scale, TimeUnix) AS Scale, argMax(ZeroCount, TimeUnix) AS ZeroCount, argMax(PositiveOffset, TimeUnix) AS PositiveOffset, argMax(PositiveBucketCounts, TimeUnix) AS PositiveBucketCounts, argMax(NegativeOffset, TimeUnix) AS NegativeOffset, argMax(NegativeBucketCounts, TimeUnix) AS NegativeBucketCounts]
+        Filter predicate=(((MetricName IN ("http_server_duration_exp_hist", "http.server.duration.exp.hist", "http.server.duration.exp/hist", "http.server.duration.exp_hist", "http.server.duration/exp/hist", "http.server.duration/exp_hist", "http.server.duration_exp.hist", "http.server.duration_exp_hist", "http.server/duration/exp/hist", "http.server/duration/exp_hist", "http.server/duration_exp_hist", "http.server_duration.exp.hist", "http.server_duration.exp_hist", "http.server_duration_exp.hist", "http.server_duration_exp_hist", "http/server/duration/exp/hist", "http/server/duration/exp_hist", "http/server/duration_exp_hist", "http/server_duration_exp_hist", "http_server.duration.exp.hist", "http_server.duration.exp_hist", "http_server.duration_exp.hist", "http_server.duration_exp_hist", "http_server_duration.exp.hist", "http_server_duration.exp_hist", "http_server_duration_exp.hist")) AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+          Scan(otel_metrics_exponential_histogram)
+-- sql --
+SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, toFloat64(?) AS `Value`, `Count` AS `HistogramCount`, `Sum` AS `HistogramSum`, `Scale` AS `HistogramScale`, 0. AS `HistogramZeroThreshold`, `ZeroCount` AS `HistogramZeroCount`, `PositiveOffset` AS `HistogramPositiveOffset`, `PositiveBucketCounts` AS `HistogramPositiveBucketCounts`, `NegativeOffset` AS `HistogramNegativeOffset`, `NegativeBucketCounts` AS `HistogramNegativeBucketCounts` FROM (SELECT CAST(map(), ?) AS `Attributes`, `Count` AS `Count`, `Sum` AS `Sum`, `_hq_merged_scale` AS `Scale`, `ZeroCount` AS `ZeroCount`, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`)) AS `PositiveOffset`, arrayMap(t -> arraySum(arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - ?)), (s - `_hq_merged_scale`)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`)) + t)), arr[j], ?), arrayEnumerate(arr))), `_hq_scales`, `_hq_pos_offsets`, `_hq_pos_buckets`)), range(toUInt64(greatest(?, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - ?)), (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`, `_hq_pos_buckets`)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`))) + ?))))) AS `PositiveBucketCounts`, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`)) AS `NegativeOffset`, arrayMap(t -> arraySum(arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - ?)), (s - `_hq_merged_scale`)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`)) + t)), arr[j], ?), arrayEnumerate(arr))), `_hq_scales`, `_hq_neg_offsets`, `_hq_neg_buckets`)), range(toUInt64(greatest(?, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - ?)), (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`, `_hq_neg_buckets`)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`))) + ?))))) AS `NegativeBucketCounts` FROM (SELECT `Count`, `Sum`, `_hq_merged_scale`, `ZeroCount`, `_hq_scales`, `_hq_pos_offsets`, `_hq_pos_buckets`, `_hq_neg_offsets`, `_hq_neg_buckets` FROM (SELECT sum(`Count`) AS `Count`, sum(`Sum`) AS `Sum`, min(`Scale`) AS `_hq_merged_scale`, sum(`ZeroCount`) AS `ZeroCount`, groupArray(`Scale`) AS `_hq_scales`, groupArray(`PositiveOffset`) AS `_hq_pos_offsets`, groupArray(`PositiveBucketCounts`) AS `_hq_pos_buckets`, groupArray(`NegativeOffset`) AS `_hq_neg_offsets`, groupArray(`NegativeBucketCounts`) AS `_hq_neg_buckets`, count() AS `_cerb_n` FROM (SELECT mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, argMax(`Count`, `TimeUnix`) AS `Count`, argMax(`Sum`, `TimeUnix`) AS `Sum`, argMax(`Scale`, `TimeUnix`) AS `Scale`, argMax(`ZeroCount`, `TimeUnix`) AS `ZeroCount`, argMax(`PositiveOffset`, `TimeUnix`) AS `PositiveOffset`, argMax(`PositiveBucketCounts`, `TimeUnix`) AS `PositiveBucketCounts`, argMax(`NegativeOffset`, `TimeUnix`) AS `NegativeOffset`, argMax(`NegativeBucketCounts`, `TimeUnix`) AS `NegativeBucketCounts` FROM (SELECT * FROM `otel_metrics_exponential_histogram` PREWHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `Attributes`)) WHERE `_cerb_n` > 0))

--- a/test/spec/promql/exp_histogram_sum_by.txtar
+++ b/test/spec/promql/exp_histogram_sum_by.txtar
@@ -1,0 +1,96 @@
+-- query.promql --
+sum by (service) (http_server_duration_exp_hist)
+-- seed --
+CREATE TABLE otel_metrics_exponential_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    Scale Int32,
+    ZeroCount UInt64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64),
+    NegativeOffset Int32,
+    NegativeBucketCounts Array(UInt64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+-- Three series over two services: the `by (service)` grouping must add
+-- the two `api` pods to each other and leave `web` alone, keeping only
+-- the `service` label on each output series.
+--
+--   {service=api}: [1,1] + [2,1] = [3,2], Count 2+3 = 5, Sum 1+2 = 3
+--   {service=web}: [4]           = [4],   Count 4,       Sum 3
+--
+-- Both output offsets stay 0. `pod` is dropped by the grouping, and
+-- __name__ by the aggregation.
+INSERT INTO otel_metrics_exponential_histogram VALUES
+    ('http_server_duration_exp_hist', map('service', 'api', 'pod', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 2, 1.0, 0, 0, 0, [1, 1], 0, []),
+    ('http_server_duration_exp_hist', map('service', 'api', 'pod', 'b'), toDateTime64('2026-01-01 00:00:00', 9), 3, 2.0, 0, 0, 0, [2, 1], 0, []),
+    ('http_server_duration_exp_hist', map('service', 'web', 'pod', 'c'), toDateTime64('2026-01-01 00:00:00', 9), 4, 3.0, 0, 0, 0, [4],    0, []);
+-- expected_rows --
+[
+  ["", {"service": "api"}, "2026-01-01T00:00:01Z", 0, 5, 3, 0, 0, 0, 0, [3,2], 0, []],
+  ["", {"service": "web"}, "2026-01-01T00:00:01Z", 0, 4, 3, 0, 0, 0, 0, [4], 0, []]
+]
+-- args --
+[0] string = ""
+[1] int64 = 9
+[2] float64 = 0
+[3] string = "service"
+[4] int64 = 1
+[5] int64 = 0
+[6] int64 = 0
+[7] int64 = 1
+[8] int64 = 1
+[9] int64 = 1
+[10] int64 = 0
+[11] int64 = 0
+[12] int64 = 1
+[13] int64 = 1
+[14] string = "service"
+[15] string = "service.name"
+[16] string = "service_name"
+[17] string = "service.name"
+[18] string = "service_name"
+[19] string = ""
+[20] string = "service_name"
+[21] string = "http_server_duration_exp_hist"
+[22] string = "http.server.duration.exp.hist"
+[23] string = "http.server.duration.exp/hist"
+[24] string = "http.server.duration.exp_hist"
+[25] string = "http.server.duration/exp/hist"
+[26] string = "http.server.duration/exp_hist"
+[27] string = "http.server.duration_exp.hist"
+[28] string = "http.server.duration_exp_hist"
+[29] string = "http.server/duration/exp/hist"
+[30] string = "http.server/duration/exp_hist"
+[31] string = "http.server/duration_exp_hist"
+[32] string = "http.server_duration.exp.hist"
+[33] string = "http.server_duration.exp_hist"
+[34] string = "http.server_duration_exp.hist"
+[35] string = "http.server_duration_exp_hist"
+[36] string = "http/server/duration/exp/hist"
+[37] string = "http/server/duration/exp_hist"
+[38] string = "http/server/duration_exp_hist"
+[39] string = "http/server_duration_exp_hist"
+[40] string = "http_server.duration.exp.hist"
+[41] string = "http_server.duration.exp_hist"
+[42] string = "http_server.duration_exp.hist"
+[43] string = "http_server.duration_exp_hist"
+[44] string = "http_server_duration.exp.hist"
+[45] string = "http_server_duration.exp_hist"
+[46] string = "http_server_duration_exp.hist"
+[47] string = "2026-01-01 00:00:01.000000000"
+[48] int64 = 9
+[49] string = "2026-01-01 00:00:01.000000000"
+[50] int64 = 9
+[51] int64 = 300000000000
+-- chplan --
+HistogramProjection project=["" AS MetricName, Attributes AS Attributes, now64(9) AS TimeUnix, 0 AS Value]
+  Project [map("service", gkey_0) AS Attributes, Count AS Count, Sum AS Sum, _hq_merged_scale AS Scale, ZeroCount AS ZeroCount, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - _hq_merged_scale)), _hq_scales, _hq_pos_offsets)) AS PositiveOffset, arrayMap(t -> arraySum(arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - 1)), (s - _hq_merged_scale)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets)) + t)), arr[j], 0), arrayEnumerate(arr))), _hq_scales, _hq_pos_offsets, _hq_pos_buckets)), range(toUInt64(greatest(0, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - 1)), (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets, _hq_pos_buckets)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets))) + 1))))) AS PositiveBucketCounts, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - _hq_merged_scale)), _hq_scales, _hq_neg_offsets)) AS NegativeOffset, arrayMap(t -> arraySum(arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - 1)), (s - _hq_merged_scale)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets)) + t)), arr[j], 0), arrayEnumerate(arr))), _hq_scales, _hq_neg_offsets, _hq_neg_buckets)), range(toUInt64(greatest(0, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - 1)), (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets, _hq_neg_buckets)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets))) + 1))))) AS NegativeBucketCounts]
+    Aggregate groupBy=[Attributes["service"] AS gkey_0] funcs=[sum(Count) AS Count, sum(Sum) AS Sum, min(Scale) AS _hq_merged_scale, sum(ZeroCount) AS ZeroCount, groupArray(Scale) AS _hq_scales, groupArray(PositiveOffset) AS _hq_pos_offsets, groupArray(PositiveBucketCounts) AS _hq_pos_buckets, groupArray(NegativeOffset) AS _hq_neg_offsets, groupArray(NegativeBucketCounts) AS _hq_neg_buckets]
+      Aggregate groupBy=[mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes] funcs=[argMax(Count, TimeUnix) AS Count, argMax(Sum, TimeUnix) AS Sum, argMax(Scale, TimeUnix) AS Scale, argMax(ZeroCount, TimeUnix) AS ZeroCount, argMax(PositiveOffset, TimeUnix) AS PositiveOffset, argMax(PositiveBucketCounts, TimeUnix) AS PositiveBucketCounts, argMax(NegativeOffset, TimeUnix) AS NegativeOffset, argMax(NegativeBucketCounts, TimeUnix) AS NegativeBucketCounts]
+        Filter predicate=(((MetricName IN ("http_server_duration_exp_hist", "http.server.duration.exp.hist", "http.server.duration.exp/hist", "http.server.duration.exp_hist", "http.server.duration/exp/hist", "http.server.duration/exp_hist", "http.server.duration_exp.hist", "http.server.duration_exp_hist", "http.server/duration/exp/hist", "http.server/duration/exp_hist", "http.server/duration_exp_hist", "http.server_duration.exp.hist", "http.server_duration.exp_hist", "http.server_duration_exp.hist", "http.server_duration_exp_hist", "http/server/duration/exp/hist", "http/server/duration/exp_hist", "http/server/duration_exp_hist", "http/server_duration_exp_hist", "http_server.duration.exp.hist", "http_server.duration.exp_hist", "http_server.duration_exp.hist", "http_server.duration_exp_hist", "http_server_duration.exp.hist", "http_server_duration.exp_hist", "http_server_duration_exp.hist")) AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+          Scan(otel_metrics_exponential_histogram)
+-- sql --
+SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, toFloat64(?) AS `Value`, `Count` AS `HistogramCount`, `Sum` AS `HistogramSum`, `Scale` AS `HistogramScale`, 0. AS `HistogramZeroThreshold`, `ZeroCount` AS `HistogramZeroCount`, `PositiveOffset` AS `HistogramPositiveOffset`, `PositiveBucketCounts` AS `HistogramPositiveBucketCounts`, `NegativeOffset` AS `HistogramNegativeOffset`, `NegativeBucketCounts` AS `HistogramNegativeBucketCounts` FROM (SELECT map(?, `gkey_0`) AS `Attributes`, `Count` AS `Count`, `Sum` AS `Sum`, `_hq_merged_scale` AS `Scale`, `ZeroCount` AS `ZeroCount`, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`)) AS `PositiveOffset`, arrayMap(t -> arraySum(arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - ?)), (s - `_hq_merged_scale`)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`)) + t)), arr[j], ?), arrayEnumerate(arr))), `_hq_scales`, `_hq_pos_offsets`, `_hq_pos_buckets`)), range(toUInt64(greatest(?, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - ?)), (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`, `_hq_pos_buckets`)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`))) + ?))))) AS `PositiveBucketCounts`, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`)) AS `NegativeOffset`, arrayMap(t -> arraySum(arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - ?)), (s - `_hq_merged_scale`)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`)) + t)), arr[j], ?), arrayEnumerate(arr))), `_hq_scales`, `_hq_neg_offsets`, `_hq_neg_buckets`)), range(toUInt64(greatest(?, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - ?)), (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`, `_hq_neg_buckets`)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`))) + ?))))) AS `NegativeBucketCounts` FROM (SELECT `Attributes`[?] AS `gkey_0`, sum(`Count`) AS `Count`, sum(`Sum`) AS `Sum`, min(`Scale`) AS `_hq_merged_scale`, sum(`ZeroCount`) AS `ZeroCount`, groupArray(`Scale`) AS `_hq_scales`, groupArray(`PositiveOffset`) AS `_hq_pos_offsets`, groupArray(`PositiveBucketCounts`) AS `_hq_pos_buckets`, groupArray(`NegativeOffset`) AS `_hq_neg_offsets`, groupArray(`NegativeBucketCounts`) AS `_hq_neg_buckets` FROM (SELECT mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, argMax(`Count`, `TimeUnix`) AS `Count`, argMax(`Sum`, `TimeUnix`) AS `Sum`, argMax(`Scale`, `TimeUnix`) AS `Scale`, argMax(`ZeroCount`, `TimeUnix`) AS `ZeroCount`, argMax(`PositiveOffset`, `TimeUnix`) AS `PositiveOffset`, argMax(`PositiveBucketCounts`, `TimeUnix`) AS `PositiveBucketCounts`, argMax(`NegativeOffset`, `TimeUnix`) AS `NegativeOffset`, argMax(`NegativeBucketCounts`, `TimeUnix`) AS `NegativeBucketCounts` FROM (SELECT * FROM `otel_metrics_exponential_histogram` PREWHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `Attributes`) GROUP BY `gkey_0`))

--- a/test/spec/promql/exp_histogram_sum_mixed_scale.txtar
+++ b/test/spec/promql/exp_histogram_sum_mixed_scale.txtar
@@ -1,0 +1,100 @@
+-- query.promql --
+sum(http_server_duration_exp_hist)
+-- seed --
+CREATE TABLE otel_metrics_exponential_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    Scale Int32,
+    ZeroCount UInt64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64),
+    NegativeOffset Int32,
+    NegativeBucketCounts Array(UInt64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+-- Two series at DIFFERENT Scales. Prometheus's FloatHistogram.Add
+-- reduces the finer histogram's resolution to the coarser one's before
+-- adding, and so does the merge here: the group's Scale is min(Scale),
+-- and each row's absolute bucket index maps to `idx >> (rowScale -
+-- mergedScale)`.
+--
+-- At Scale=1 the `fine` series's [1, 2, 3, 4] at offset 0 sits at
+-- absolute indices 0..3; downscaling to Scale=0 halves each index
+-- (0,0,1,1), so adjacent pairs merge: [1+2, 3+4] = [3, 7] at offset 0.
+-- The `coarse` series is already at Scale=0 with [5, 10] at offset 0.
+--
+-- merged = [3+5, 7+10] = [8, 17] at PositiveOffset 0, Scale 0.
+--
+-- Count 10+15 = 25 and Sum 1+2 = 3 are scale-independent — they are the
+-- group's total observation count and total observed value, and neither
+-- depends on how the bucket ladders line up.
+INSERT INTO otel_metrics_exponential_histogram VALUES
+    ('http_server_duration_exp_hist', map('series', 'fine'),   toDateTime64('2026-01-01 00:00:00', 9), 10, 1.0, 1, 0, 0, [1, 2, 3, 4], 0, []),
+    ('http_server_duration_exp_hist', map('series', 'coarse'), toDateTime64('2026-01-01 00:00:00', 9), 15, 2.0, 0, 0, 0, [5, 10],      0, []);
+-- expected_rows --
+[
+  ["", {}, "2026-01-01T00:00:01Z", 0, 25, 3, 0, 0, 0, 0, [8,17], 0, []]
+]
+-- args --
+[0] string = ""
+[1] int64 = 9
+[2] float64 = 0
+[3] string = "Map(String,String)"
+[4] int64 = 1
+[5] int64 = 0
+[6] int64 = 0
+[7] int64 = 1
+[8] int64 = 1
+[9] int64 = 1
+[10] int64 = 0
+[11] int64 = 0
+[12] int64 = 1
+[13] int64 = 1
+[14] string = "service.name"
+[15] string = "service_name"
+[16] string = "service.name"
+[17] string = "service_name"
+[18] string = ""
+[19] string = "service_name"
+[20] string = "http_server_duration_exp_hist"
+[21] string = "http.server.duration.exp.hist"
+[22] string = "http.server.duration.exp/hist"
+[23] string = "http.server.duration.exp_hist"
+[24] string = "http.server.duration/exp/hist"
+[25] string = "http.server.duration/exp_hist"
+[26] string = "http.server.duration_exp.hist"
+[27] string = "http.server.duration_exp_hist"
+[28] string = "http.server/duration/exp/hist"
+[29] string = "http.server/duration/exp_hist"
+[30] string = "http.server/duration_exp_hist"
+[31] string = "http.server_duration.exp.hist"
+[32] string = "http.server_duration.exp_hist"
+[33] string = "http.server_duration_exp.hist"
+[34] string = "http.server_duration_exp_hist"
+[35] string = "http/server/duration/exp/hist"
+[36] string = "http/server/duration/exp_hist"
+[37] string = "http/server/duration_exp_hist"
+[38] string = "http/server_duration_exp_hist"
+[39] string = "http_server.duration.exp.hist"
+[40] string = "http_server.duration.exp_hist"
+[41] string = "http_server.duration_exp.hist"
+[42] string = "http_server.duration_exp_hist"
+[43] string = "http_server_duration.exp.hist"
+[44] string = "http_server_duration.exp_hist"
+[45] string = "http_server_duration_exp.hist"
+[46] string = "2026-01-01 00:00:01.000000000"
+[47] int64 = 9
+[48] string = "2026-01-01 00:00:01.000000000"
+[49] int64 = 9
+[50] int64 = 300000000000
+-- chplan --
+HistogramProjection project=["" AS MetricName, Attributes AS Attributes, now64(9) AS TimeUnix, 0 AS Value]
+  Project [CAST(map(), "Map(String,String)") AS Attributes, Count AS Count, Sum AS Sum, _hq_merged_scale AS Scale, ZeroCount AS ZeroCount, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - _hq_merged_scale)), _hq_scales, _hq_pos_offsets)) AS PositiveOffset, arrayMap(t -> arraySum(arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - 1)), (s - _hq_merged_scale)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets)) + t)), arr[j], 0), arrayEnumerate(arr))), _hq_scales, _hq_pos_offsets, _hq_pos_buckets)), range(toUInt64(greatest(0, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - 1)), (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets, _hq_pos_buckets)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets))) + 1))))) AS PositiveBucketCounts, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - _hq_merged_scale)), _hq_scales, _hq_neg_offsets)) AS NegativeOffset, arrayMap(t -> arraySum(arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - 1)), (s - _hq_merged_scale)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets)) + t)), arr[j], 0), arrayEnumerate(arr))), _hq_scales, _hq_neg_offsets, _hq_neg_buckets)), range(toUInt64(greatest(0, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - 1)), (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets, _hq_neg_buckets)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets))) + 1))))) AS NegativeBucketCounts]
+    Aggregate groupBy=[] funcs=[sum(Count) AS Count, sum(Sum) AS Sum, min(Scale) AS _hq_merged_scale, sum(ZeroCount) AS ZeroCount, groupArray(Scale) AS _hq_scales, groupArray(PositiveOffset) AS _hq_pos_offsets, groupArray(PositiveBucketCounts) AS _hq_pos_buckets, groupArray(NegativeOffset) AS _hq_neg_offsets, groupArray(NegativeBucketCounts) AS _hq_neg_buckets]
+      Aggregate groupBy=[mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes] funcs=[argMax(Count, TimeUnix) AS Count, argMax(Sum, TimeUnix) AS Sum, argMax(Scale, TimeUnix) AS Scale, argMax(ZeroCount, TimeUnix) AS ZeroCount, argMax(PositiveOffset, TimeUnix) AS PositiveOffset, argMax(PositiveBucketCounts, TimeUnix) AS PositiveBucketCounts, argMax(NegativeOffset, TimeUnix) AS NegativeOffset, argMax(NegativeBucketCounts, TimeUnix) AS NegativeBucketCounts]
+        Filter predicate=(((MetricName IN ("http_server_duration_exp_hist", "http.server.duration.exp.hist", "http.server.duration.exp/hist", "http.server.duration.exp_hist", "http.server.duration/exp/hist", "http.server.duration/exp_hist", "http.server.duration_exp.hist", "http.server.duration_exp_hist", "http.server/duration/exp/hist", "http.server/duration/exp_hist", "http.server/duration_exp_hist", "http.server_duration.exp.hist", "http.server_duration.exp_hist", "http.server_duration_exp.hist", "http.server_duration_exp_hist", "http/server/duration/exp/hist", "http/server/duration/exp_hist", "http/server/duration_exp_hist", "http/server_duration_exp_hist", "http_server.duration.exp.hist", "http_server.duration.exp_hist", "http_server.duration_exp.hist", "http_server.duration_exp_hist", "http_server_duration.exp.hist", "http_server_duration.exp_hist", "http_server_duration_exp.hist")) AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+          Scan(otel_metrics_exponential_histogram)
+-- sql --
+SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, toFloat64(?) AS `Value`, `Count` AS `HistogramCount`, `Sum` AS `HistogramSum`, `Scale` AS `HistogramScale`, 0. AS `HistogramZeroThreshold`, `ZeroCount` AS `HistogramZeroCount`, `PositiveOffset` AS `HistogramPositiveOffset`, `PositiveBucketCounts` AS `HistogramPositiveBucketCounts`, `NegativeOffset` AS `HistogramNegativeOffset`, `NegativeBucketCounts` AS `HistogramNegativeBucketCounts` FROM (SELECT CAST(map(), ?) AS `Attributes`, `Count` AS `Count`, `Sum` AS `Sum`, `_hq_merged_scale` AS `Scale`, `ZeroCount` AS `ZeroCount`, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`)) AS `PositiveOffset`, arrayMap(t -> arraySum(arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - ?)), (s - `_hq_merged_scale`)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`)) + t)), arr[j], ?), arrayEnumerate(arr))), `_hq_scales`, `_hq_pos_offsets`, `_hq_pos_buckets`)), range(toUInt64(greatest(?, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - ?)), (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`, `_hq_pos_buckets`)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`))) + ?))))) AS `PositiveBucketCounts`, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`)) AS `NegativeOffset`, arrayMap(t -> arraySum(arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - ?)), (s - `_hq_merged_scale`)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`)) + t)), arr[j], ?), arrayEnumerate(arr))), `_hq_scales`, `_hq_neg_offsets`, `_hq_neg_buckets`)), range(toUInt64(greatest(?, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - ?)), (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`, `_hq_neg_buckets`)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`))) + ?))))) AS `NegativeBucketCounts` FROM (SELECT `Count`, `Sum`, `_hq_merged_scale`, `ZeroCount`, `_hq_scales`, `_hq_pos_offsets`, `_hq_pos_buckets`, `_hq_neg_offsets`, `_hq_neg_buckets` FROM (SELECT sum(`Count`) AS `Count`, sum(`Sum`) AS `Sum`, min(`Scale`) AS `_hq_merged_scale`, sum(`ZeroCount`) AS `ZeroCount`, groupArray(`Scale`) AS `_hq_scales`, groupArray(`PositiveOffset`) AS `_hq_pos_offsets`, groupArray(`PositiveBucketCounts`) AS `_hq_pos_buckets`, groupArray(`NegativeOffset`) AS `_hq_neg_offsets`, groupArray(`NegativeBucketCounts`) AS `_hq_neg_buckets`, count() AS `_cerb_n` FROM (SELECT mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, argMax(`Count`, `TimeUnix`) AS `Count`, argMax(`Sum`, `TimeUnix`) AS `Sum`, argMax(`Scale`, `TimeUnix`) AS `Scale`, argMax(`ZeroCount`, `TimeUnix`) AS `ZeroCount`, argMax(`PositiveOffset`, `TimeUnix`) AS `PositiveOffset`, argMax(`PositiveBucketCounts`, `TimeUnix`) AS `PositiveBucketCounts`, argMax(`NegativeOffset`, `TimeUnix`) AS `NegativeOffset`, argMax(`NegativeBucketCounts`, `TimeUnix`) AS `NegativeBucketCounts` FROM (SELECT * FROM `otel_metrics_exponential_histogram` PREWHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `Attributes`)) WHERE `_cerb_n` > 0))

--- a/test/spec/promql/exp_histogram_sum_range.txtar
+++ b/test/spec/promql/exp_histogram_sum_range.txtar
@@ -1,0 +1,99 @@
+-- query.promql --
+sum(http_server_duration_exp_hist)
+-- range_step --
+30s
+-- seed --
+CREATE TABLE otel_metrics_exponential_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    Scale Int32,
+    ZeroCount UInt64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64),
+    NegativeOffset Int32,
+    NegativeBucketCounts Array(UInt64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+-- query_range shape: each step anchor resolves its own staleness
+-- lookback per SERIES first, and only then adds the two series'
+-- distributions within that anchor. The single sample per series sits at
+-- the window's start, so every anchor in the 5m grid reports the same
+-- merged histogram at its own timestamp — the same per-anchor
+-- broadcast the bare-selector range fixture shows, with the merge on
+-- top.
+--
+--   merged = [1,2,3] + [4,5]@offset 1 = [1, 6, 8] at offset 0
+--   Count 6+9 = 15, Sum 42.5+10.5 = 53, ZeroCount 1+2 = 3
+INSERT INTO otel_metrics_exponential_histogram VALUES
+    ('http_server_duration_exp_hist', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 6, 42.5, 0, 1, 0, [1, 2, 3], 0, []),
+    ('http_server_duration_exp_hist', map('service', 'web'), toDateTime64('2026-01-01 00:00:00', 9), 9, 10.5, 0, 2, 1, [4, 5],    0, []);
+-- expected_rows --
+[
+  ["", {}, "2026-01-01T00:00:00Z", 0, 15, 53, 0, 0, 3, 0, [1,6,8], 0, []],
+  ["", {}, "2026-01-01T00:00:30Z", 0, 15, 53, 0, 0, 3, 0, [1,6,8], 0, []],
+  ["", {}, "2026-01-01T00:01:00Z", 0, 15, 53, 0, 0, 3, 0, [1,6,8], 0, []],
+  ["", {}, "2026-01-01T00:01:30Z", 0, 15, 53, 0, 0, 3, 0, [1,6,8], 0, []],
+  ["", {}, "2026-01-01T00:02:00Z", 0, 15, 53, 0, 0, 3, 0, [1,6,8], 0, []],
+  ["", {}, "2026-01-01T00:02:30Z", 0, 15, 53, 0, 0, 3, 0, [1,6,8], 0, []],
+  ["", {}, "2026-01-01T00:03:00Z", 0, 15, 53, 0, 0, 3, 0, [1,6,8], 0, []],
+  ["", {}, "2026-01-01T00:03:30Z", 0, 15, 53, 0, 0, 3, 0, [1,6,8], 0, []],
+  ["", {}, "2026-01-01T00:04:00Z", 0, 15, 53, 0, 0, 3, 0, [1,6,8], 0, []],
+  ["", {}, "2026-01-01T00:04:30Z", 0, 15, 53, 0, 0, 3, 0, [1,6,8], 0, []]
+]
+-- args --
+[0] string = ""
+[1] float64 = 0
+[2] string = "Map(String,String)"
+[3] int64 = 1
+[4] int64 = 0
+[5] int64 = 0
+[6] int64 = 1
+[7] int64 = 1
+[8] int64 = 1
+[9] int64 = 0
+[10] int64 = 0
+[11] int64 = 1
+[12] int64 = 1
+[13] string = "service.name"
+[14] string = "service_name"
+[15] string = "service.name"
+[16] string = "service_name"
+[17] string = ""
+[18] string = "service_name"
+[19] string = "http_server_duration_exp_hist"
+[20] string = "http.server.duration.exp.hist"
+[21] string = "http.server.duration.exp/hist"
+[22] string = "http.server.duration.exp_hist"
+[23] string = "http.server.duration/exp/hist"
+[24] string = "http.server.duration/exp_hist"
+[25] string = "http.server.duration_exp.hist"
+[26] string = "http.server.duration_exp_hist"
+[27] string = "http.server/duration/exp/hist"
+[28] string = "http.server/duration/exp_hist"
+[29] string = "http.server/duration_exp_hist"
+[30] string = "http.server_duration.exp.hist"
+[31] string = "http.server_duration.exp_hist"
+[32] string = "http.server_duration_exp.hist"
+[33] string = "http.server_duration_exp_hist"
+[34] string = "http/server/duration/exp/hist"
+[35] string = "http/server/duration/exp_hist"
+[36] string = "http/server/duration_exp_hist"
+[37] string = "http/server_duration_exp_hist"
+[38] string = "http_server.duration.exp.hist"
+[39] string = "http_server.duration.exp_hist"
+[40] string = "http_server.duration_exp.hist"
+[41] string = "http_server.duration_exp_hist"
+[42] string = "http_server_duration.exp.hist"
+[43] string = "http_server_duration.exp_hist"
+[44] string = "http_server_duration_exp.hist"
+-- chplan --
+HistogramProjection project=["" AS MetricName, Attributes AS Attributes, anchor_ts AS TimeUnix, 0 AS Value]
+  Project [anchor_ts AS anchor_ts, CAST(map(), "Map(String,String)") AS Attributes, Count AS Count, Sum AS Sum, _hq_merged_scale AS Scale, ZeroCount AS ZeroCount, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - _hq_merged_scale)), _hq_scales, _hq_pos_offsets)) AS PositiveOffset, arrayMap(t -> arraySum(arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - 1)), (s - _hq_merged_scale)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets)) + t)), arr[j], 0), arrayEnumerate(arr))), _hq_scales, _hq_pos_offsets, _hq_pos_buckets)), range(toUInt64(greatest(0, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - 1)), (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets, _hq_pos_buckets)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets))) + 1))))) AS PositiveBucketCounts, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - _hq_merged_scale)), _hq_scales, _hq_neg_offsets)) AS NegativeOffset, arrayMap(t -> arraySum(arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - 1)), (s - _hq_merged_scale)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets)) + t)), arr[j], 0), arrayEnumerate(arr))), _hq_scales, _hq_neg_offsets, _hq_neg_buckets)), range(toUInt64(greatest(0, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - 1)), (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets, _hq_neg_buckets)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets))) + 1))))) AS NegativeBucketCounts]
+    Aggregate groupBy=[anchor_ts AS anchor_ts] funcs=[sum(Count) AS Count, sum(Sum) AS Sum, min(Scale) AS _hq_merged_scale, sum(ZeroCount) AS ZeroCount, groupArray(Scale) AS _hq_scales, groupArray(PositiveOffset) AS _hq_pos_offsets, groupArray(PositiveBucketCounts) AS _hq_pos_buckets, groupArray(NegativeOffset) AS _hq_neg_offsets, groupArray(NegativeBucketCounts) AS _hq_neg_buckets]
+      RangeBucketFanout step=30s lookback=5m0s groupBy=[mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes] funcs=[argMax(Count, TimeUnix) AS Count, argMax(Sum, TimeUnix) AS Sum, argMax(Scale, TimeUnix) AS Scale, argMax(ZeroCount, TimeUnix) AS ZeroCount, argMax(PositiveOffset, TimeUnix) AS PositiveOffset, argMax(PositiveBucketCounts, TimeUnix) AS PositiveBucketCounts, argMax(NegativeOffset, TimeUnix) AS NegativeOffset, argMax(NegativeBucketCounts, TimeUnix) AS NegativeBucketCounts] start=2026-01-01T00:00:00Z end=2026-01-01T00:05:00Z
+        Filter predicate=(MetricName IN ("http_server_duration_exp_hist", "http.server.duration.exp.hist", "http.server.duration.exp/hist", "http.server.duration.exp_hist", "http.server.duration/exp/hist", "http.server.duration/exp_hist", "http.server.duration_exp.hist", "http.server.duration_exp_hist", "http.server/duration/exp/hist", "http.server/duration/exp_hist", "http.server/duration_exp_hist", "http.server_duration.exp.hist", "http.server_duration.exp_hist", "http.server_duration_exp.hist", "http.server_duration_exp_hist", "http/server/duration/exp/hist", "http/server/duration/exp_hist", "http/server/duration_exp_hist", "http/server_duration_exp_hist", "http_server.duration.exp.hist", "http_server.duration.exp_hist", "http_server.duration_exp.hist", "http_server.duration_exp_hist", "http_server_duration.exp.hist", "http_server_duration.exp_hist", "http_server_duration_exp.hist"))
+          Scan(otel_metrics_exponential_histogram)
+-- sql --
+SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, `anchor_ts` AS `TimeUnix`, toFloat64(?) AS `Value`, `Count` AS `HistogramCount`, `Sum` AS `HistogramSum`, `Scale` AS `HistogramScale`, 0. AS `HistogramZeroThreshold`, `ZeroCount` AS `HistogramZeroCount`, `PositiveOffset` AS `HistogramPositiveOffset`, `PositiveBucketCounts` AS `HistogramPositiveBucketCounts`, `NegativeOffset` AS `HistogramNegativeOffset`, `NegativeBucketCounts` AS `HistogramNegativeBucketCounts` FROM (SELECT `anchor_ts` AS `anchor_ts`, CAST(map(), ?) AS `Attributes`, `Count` AS `Count`, `Sum` AS `Sum`, `_hq_merged_scale` AS `Scale`, `ZeroCount` AS `ZeroCount`, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`)) AS `PositiveOffset`, arrayMap(t -> arraySum(arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - ?)), (s - `_hq_merged_scale`)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`)) + t)), arr[j], ?), arrayEnumerate(arr))), `_hq_scales`, `_hq_pos_offsets`, `_hq_pos_buckets`)), range(toUInt64(greatest(?, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - ?)), (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`, `_hq_pos_buckets`)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`))) + ?))))) AS `PositiveBucketCounts`, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`)) AS `NegativeOffset`, arrayMap(t -> arraySum(arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - ?)), (s - `_hq_merged_scale`)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`)) + t)), arr[j], ?), arrayEnumerate(arr))), `_hq_scales`, `_hq_neg_offsets`, `_hq_neg_buckets`)), range(toUInt64(greatest(?, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - ?)), (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`, `_hq_neg_buckets`)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`))) + ?))))) AS `NegativeBucketCounts` FROM (SELECT `anchor_ts` AS `anchor_ts`, sum(`Count`) AS `Count`, sum(`Sum`) AS `Sum`, min(`Scale`) AS `_hq_merged_scale`, sum(`ZeroCount`) AS `ZeroCount`, groupArray(`Scale`) AS `_hq_scales`, groupArray(`PositiveOffset`) AS `_hq_pos_offsets`, groupArray(`PositiveBucketCounts`) AS `_hq_pos_buckets`, groupArray(`NegativeOffset`) AS `_hq_neg_offsets`, groupArray(`NegativeBucketCounts`) AS `_hq_neg_buckets` FROM (SELECT anchor_ts AS `anchor_ts`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, argMax(`Count`, `TimeUnix`) AS `Count`, argMax(`Sum`, `TimeUnix`) AS `Sum`, argMax(`Scale`, `TimeUnix`) AS `Scale`, argMax(`ZeroCount`, `TimeUnix`) AS `ZeroCount`, argMax(`PositiveOffset`, `TimeUnix`) AS `PositiveOffset`, argMax(`PositiveBucketCounts`, `TimeUnix`) AS `PositiveBucketCounts`, argMax(`NegativeOffset`, `TimeUnix`) AS `NegativeOffset`, argMax(`NegativeBucketCounts`, `TimeUnix`) AS `NegativeBucketCounts` FROM (SELECT *, arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:05:00.000000000', 9) - toIntervalNanosecond(i * 30000000000), range(greatest(0, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 300000000000, toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 300000000000, toInt64(30000000000)) < 0) + 1), least(11, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)), toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)), toInt64(30000000000)) < 0) + 1)))) AS anchor_ts FROM (SELECT * FROM `otel_metrics_exponential_histogram` WHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?))) WHERE `TimeUnix` > toDateTime64('2026-01-01 00:00:00.000000000', 9) - toIntervalNanosecond(300000000000) AND `TimeUnix` <= toDateTime64('2026-01-01 00:05:00.000000000', 9)) GROUP BY anchor_ts, `Attributes`) GROUP BY `anchor_ts`))


### PR DESCRIPTION
`sum()` over an OTel exponential (native) histogram returns a
histogram-VALUED sample in reference Prometheus — the group's member
distributions added element-wise, not a float. #2006 landed the first of
#1967's four lowerings (the bare selector) plus the
chplan.HistogramProjection cap it publishes; this lands the second.

The arithmetic is not new code. The across-series merge cerberus already
runs for `histogram_quantile(phi, sum(rate(...)))` —
expHistogramMergeAggs + expHistogramMergeProjections — IS Prometheus's
FloatHistogram.Add: fold every row to min(Scale), map each absolute
bucket index through `idx >> (rowScale - mergedScale)`, offset-align,
zero-pad, add. The quantile path consumes that merged distribution with
an interpolation kernel; `sum()` publishes it. Sharing the one merge is
what keeps the two paths from drifting apart in their bucket arithmetic,
and it is why mixed-scale groups are answered here rather than in a
second cut.

What this adds on top is the pair of whole-histogram scalars the quantile
kernel never reads — Count and Sum, which add plainly across the group —
and the HistogramProjection cap.

All three evaluation shapes rangeGridShapeFor distinguishes are covered:
instant, the query_range per-anchor fan-out, and the absolute-`@`
broadcast. In range mode the fan-out keys on SERIES identity and the
merge on the user's `by/without` labels, the same two-stage split
buildHistogramNativeRangeTreeMerge uses. Keying the per-anchor collapse
on the user's labels instead would make `sum by(service)` over three pods
take one newest sample per service rather than each pod's own.

`__name__` is an empty literal rather than the MetricName column the bare
path carries up: PromQL drops the name from every aggregation result, and
reading the column would report a merged series under whichever member's
stored spelling argMax happened to pick.

Narrowing stays placement-based, as in #2006: lowerRoot recognises the
shape before the descent that reaches lowerVectorSelector, so every
nested shape is still rejected there. The test pins twenty of them,
seven probing this narrowing's own edge — `sum(rate(...))`,
`sum(sum(...))`, `sum(...) + 1`, and `sum()` under label_replace / topk /
abs.

The rejection message enumerated the supported shapes without mentioning
`sum()`, so `avg(m_exp_hist)` pointed the user at a bare selector or
histogram_quantile() while omitting the one reducer that would have
worked. Updated. That relocates the rejection-parity catalogue key (it
hashes the message), so the entry is re-curated with its class, trigger
query and tracking issue intact; its trigger is `rate(...)`, which this
change still rejects, so the #1772 divergence entry stays live.

Four TXTAR fixtures cover multi-series offset alignment, `by(service)`
grouping, mixed-scale reconciliation and the query_range grid, each with
its bucket arithmetic worked out in the seed comment and checked against
the generated chDB cell. They are not enrolled in the parity comparator,
which reads only the canonical four-column Sample shape and so cannot
interpret a thirteen-column histogram row; the epic tracking that
comparator gap is #1986.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
