### PR TITLE
ci(e2e): add a dispatch-driven regen path for the compose crawl inventory

### DIFF
--- a/.github/scripts/compose-smoke-scope.mjs
+++ b/.github/scripts/compose-smoke-scope.mjs
@@ -23,8 +23,12 @@
 // So the gate is neither "always" nor "never": a PR that touches the surface
 // this stack can see boots it, and every other PR short-circuits exactly as
 // before. Push, schedule and `release/*` PRs are untouched — they always ran
-// the full lane and still do. `workflow_dispatch` never did, and still does
-// not: see NON_BOOTING_EVENTS.
+// the full lane and still do. `workflow_dispatch` never did and still does
+// not by default — see NON_BOOTING_EVENTS — with one deliberate carve-out: a
+// dispatch that asks to regenerate the compose crawl inventory
+// (UPDATE_CRAWL_INVENTORY resolving to "compose" or "both", tsouza/cerberus
+// #1826) has to boot the stack to produce that artifact, so it boots exactly
+// like push/schedule despite the event otherwise being excluded.
 //
 // Two modes (env MODE, or argv[2]; default `verify`):
 //   - verify : assert every declared path still exists in the tree. A scope
@@ -36,11 +40,16 @@
 //              $GITHUB_OUTPUT.
 //
 // Env:
-//   MODE          `emit` | `verify` (also argv[2]); default `verify`.
-//   EVENT_NAME    github.event_name.
-//   HEAD_REF      github.head_ref (empty off pull_request).
-//   BASE_SHA      (emit, PR) github.event.pull_request.base.sha.
-//   HEAD_SHA      (emit, PR) github.event.pull_request.head.sha.
+//   MODE                    `emit` | `verify` (also argv[2]); default `verify`.
+//   EVENT_NAME               github.event_name.
+//   HEAD_REF                 github.head_ref (empty off pull_request).
+//   BASE_SHA                 (emit, PR) github.event.pull_request.base.sha.
+//   HEAD_SHA                 (emit, PR) github.event.pull_request.head.sha.
+//   UPDATE_CRAWL_INVENTORY   (emit, workflow_dispatch) the resolved
+//                            `inputs.update_crawl_inventory` choice —
+//                            "none" | "k3d" | "compose" | "both". Empty off
+//                            workflow_dispatch. Only "compose"/"both" change
+//                            the decision.
 //   GITHUB_OUTPUT (emit) runner file `in_scope` is appended to.
 //
 // Exit: 0 clean; 1 on a stale path or a bad MODE. A decision this module cannot
@@ -114,11 +123,13 @@ export function stalePaths(paths) {
 }
 
 // Events whose answer comes from the event alone, in the "don't boot"
-// direction. e2e.yml's only `workflow_dispatch` input regenerates the k3d
+// direction. e2e.yml's `workflow_dispatch` input can also regenerate the k3d
 // Grafana crawl inventory — a dashboard-lane artefact that no compose shard can
-// observe — so booting ClickHouse, a collector, a seeder and Grafana for it is
-// pure wall time. The guard this module replaced excluded dispatch for exactly
-// that reason; the exclusion is restated here rather than inherited.
+// observe — so booting ClickHouse, a collector, a seeder and Grafana for THAT
+// selection is pure wall time. The guard this module replaced excluded
+// dispatch for exactly that reason; the exclusion is restated here rather than
+// inherited. `decide()` below carves a single deliberate exception back out of
+// this list: a dispatch that asks to regenerate the COMPOSE inventory.
 //
 // It lives HERE, not in the shared runsFullLane(), for two reasons. The other
 // consumer of that helper is the mutation sweep, which genuinely does want a
@@ -129,8 +140,18 @@ export function stalePaths(paths) {
 // therefore always a named, per-lane decision.
 export const NON_BOOTING_EVENTS = ['workflow_dispatch'];
 
+// regeneratesCompose — does this dispatch selection ask to (re)write
+// grafana-surface-inventory.compose.json? Only "compose" and "both" do;
+// "none" (the default) and "k3d" leave the compose lane untouched.
+export function regeneratesCompose(updateCrawlInventory) {
+  return updateCrawlInventory === 'compose' || updateCrawlInventory === 'both';
+}
+
 // Whether the changed-path diff matters at all, or the event settles it. Used
-// by the driver to skip computing a diff it would only discard.
+// by the driver to skip computing a diff it would only discard. A compose
+// regen dispatch is still settled by the event — decide() below answers it
+// from NON_BOOTING_EVENTS + regeneratesCompose() alone, never from the diff —
+// so this stays a pure function of the event, not the dispatch selection.
 function settledByEvent({ eventName, headRef }) {
   return NON_BOOTING_EVENTS.includes(eventName) || runsFullLane({ eventName, headRef });
 }
@@ -141,8 +162,15 @@ function settledByEvent({ eventName, headRef }) {
 // to true. An uncomputable diff is not evidence that nothing changed, and the
 // cost of guessing wrong in that direction is a release-blocking bug that
 // reached main unexamined.
-export function decide({ eventName, headRef, changed }) {
+export function decide({ eventName, headRef, changed, updateCrawlInventory = 'none' }) {
   if (NON_BOOTING_EVENTS.includes(eventName)) {
+    if (regeneratesCompose(updateCrawlInventory)) {
+      return {
+        inScope: true,
+        reason: `dispatch requests the compose crawl-inventory regen (update_crawl_inventory=${updateCrawlInventory})`,
+      };
+    }
+
     return { inScope: false, reason: `event "${eventName}" exercises no compose-visible surface` };
   }
   if (runsFullLane({ eventName, headRef })) {
@@ -193,11 +221,12 @@ function main() {
 
   const eventName = (process.env.EVENT_NAME || '').trim();
   const headRef = (process.env.HEAD_REF || '').trim();
+  const updateCrawlInventory = (process.env.UPDATE_CRAWL_INVENTORY || 'none').trim() || 'none';
   const changed = settledByEvent({ eventName, headRef })
     ? null
     : changedPaths({ baseSha: process.env.BASE_SHA, headSha: process.env.HEAD_SHA });
 
-  const { inScope, reason } = decide({ eventName, headRef, changed });
+  const { inScope, reason } = decide({ eventName, headRef, changed, updateCrawlInventory });
   notice(`compose-smoke-scope: ${inScope ? 'booting the stack' : 'short-circuiting'} — ${reason}`);
   setOutput('in_scope', String(inScope));
 }

--- a/.github/scripts/compose-smoke-scope.test.mjs
+++ b/.github/scripts/compose-smoke-scope.test.mjs
@@ -10,7 +10,14 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { HARNESS_PATHS, NON_BOOTING_EVENTS, SCOPE_PATHS, decide, stalePaths } from './compose-smoke-scope.mjs';
+import {
+  HARNESS_PATHS,
+  NON_BOOTING_EVENTS,
+  SCOPE_PATHS,
+  decide,
+  regeneratesCompose,
+  stalePaths,
+} from './compose-smoke-scope.mjs';
 
 const pr = { eventName: 'pull_request', headRef: 'fix/whatever' };
 
@@ -110,17 +117,51 @@ test('a merge-queue batch is scoped by its own diff, not swept wholesale', () =>
   assert.equal(decide({ ...inQueue, changed: null }).inScope, true);
 });
 
-test('workflow_dispatch does not boot the stack, whatever the diff says', () => {
+test('workflow_dispatch does not boot the stack by default, whatever the diff says', () => {
   // The guard this module replaced listed push / schedule / release-PR and left
   // workflow_dispatch out, so dispatching e2e.yml never booted compose. That
-  // exclusion is deliberate — the workflow's only dispatch input regenerates the
-  // k3d crawl inventory — and it is easy to lose by accident, because
-  // runsFullLane() answers `true` for every event it does not name. Pinned in
-  // both directions: even a diff that WOULD put a PR in scope must not boot here.
-  for (const changed of [['docs/engine.md'], ['internal/chsql/emit_node.go'], null]) {
-    const { inScope } = decide({ eventName: 'workflow_dispatch', headRef: '', changed });
-    assert.equal(inScope, false, `workflow_dispatch with changed=${JSON.stringify(changed)} must short-circuit`);
+  // exclusion is deliberate — most dispatch selections (none, or a k3d-only
+  // inventory regen) exercise no compose-visible surface — and it is easy to
+  // lose by accident, because runsFullLane() answers `true` for every event it
+  // does not name. Pinned in both directions: even a diff that WOULD put a PR
+  // in scope must not boot here. Covers the default ("none" / unset) and the
+  // k3d-only selection, which must behave identically to "none".
+  for (const updateCrawlInventory of [undefined, 'none', 'k3d']) {
+    for (const changed of [['docs/engine.md'], ['internal/chsql/emit_node.go'], null]) {
+      const { inScope } = decide({ eventName: 'workflow_dispatch', headRef: '', changed, updateCrawlInventory });
+      assert.equal(
+        inScope,
+        false,
+        `workflow_dispatch update_crawl_inventory=${updateCrawlInventory} changed=${JSON.stringify(changed)} must short-circuit`,
+      );
+    }
   }
+});
+
+test('a compose (or both) inventory-regen dispatch boots the stack regardless of the diff', () => {
+  // tsouza/cerberus#1826: the compose lane needs its own dispatch-driven regen
+  // path, mirroring the k3d one. "compose" and "both" must boot the stack even
+  // when the diff is empty or unrelated — the whole point is to run a
+  // full-depth crawl on demand, not because anything changed.
+  for (const updateCrawlInventory of ['compose', 'both']) {
+    for (const changed of [[], ['docs/engine.md'], null]) {
+      const { inScope, reason } = decide({ eventName: 'workflow_dispatch', headRef: '', changed, updateCrawlInventory });
+      assert.equal(
+        inScope,
+        true,
+        `workflow_dispatch update_crawl_inventory=${updateCrawlInventory} changed=${JSON.stringify(changed)} must boot`,
+      );
+      assert.match(reason, /compose crawl-inventory regen/);
+    }
+  }
+});
+
+test('regeneratesCompose is true only for "compose" and "both"', () => {
+  assert.equal(regeneratesCompose('compose'), true);
+  assert.equal(regeneratesCompose('both'), true);
+  assert.equal(regeneratesCompose('k3d'), false);
+  assert.equal(regeneratesCompose('none'), false);
+  assert.equal(regeneratesCompose(undefined), false);
 });
 
 test('the non-booting event list is explicit, never an allow-list', () => {

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -128,17 +128,27 @@ on:
     inputs:
       update_crawl_inventory:
         description: >-
-          Regenerate the k3d crawl surface inventory
-          (CERBERUS_UPDATE_INVENTORY=1) and upload it as an artifact to
-          commit. This is the bootstrap/regen path for
-          test/e2e/playwright/crawl/grafana-surface-inventory.k3d.json —
-          it was bootstrapped in tsouza/cerberus#1539; a future surface-set
-          change is regenerated deliberately the same way (an empty or
-          stale inventory otherwise fails the k3d crawl lane loudly, by
-          design).
-        type: boolean
+          Regenerate one or both Grafana crawl surface inventories
+          (CERBERUS_UPDATE_INVENTORY=1, forced SWEEP_DEPTH=full on the
+          regenerated stack's crawl) and upload the result as an artifact to
+          commit. "k3d" writes
+          test/e2e/playwright/crawl/grafana-surface-inventory.k3d.json (the
+          bootstrap/regen path from tsouza/cerberus#1539); "compose" writes
+          test/e2e/playwright/crawl/grafana-surface-inventory.compose.json
+          (the bootstrap/regen path from tsouza/cerberus#1826); "both"
+          regenerates both stacks in the same run. "none" (the default)
+          leaves every lane behaving exactly as an ordinary dispatch does
+          today. A future surface-set change on either stack is regenerated
+          deliberately the same way (an empty or stale inventory otherwise
+          fails that stack's crawl lane loudly, by design).
+        type: choice
         required: false
-        default: false
+        default: none
+        options:
+          - none
+          - k3d
+          - compose
+          - both
 
 permissions:
   contents: read
@@ -214,6 +224,13 @@ jobs:
           HEAD_REF: ${{ github.head_ref }}
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+          # A workflow_dispatch requesting the compose (or both) inventory
+          # regen must boot the stack despite being on the NON_BOOTING_EVENTS
+          # list otherwise — see the module's own comment on that list. Empty
+          # (not `inputs.update_crawl_inventory`) off a workflow_dispatch
+          # event, which is exactly the "no regen requested" default the
+          # module already treats as short-circuiting.
+          UPDATE_CRAWL_INVENTORY: ${{ github.event_name == 'workflow_dispatch' && inputs.update_crawl_inventory || '' }}
 
   compose-smoke-setup:
     name: compose-smoke-setup
@@ -630,6 +647,16 @@ jobs:
       - name: install Playwright + browsers (cached)
         uses: ./.github/actions/setup-playwright-browsers
 
+      # SWEEP_DEPTH: the nightly `schedule` event always sweeps full, exactly as
+      # before. A `workflow_dispatch` requesting the compose (or both)
+      # inventory regen ALSO forces full — crawl.spec.ts hard-asserts
+      # `depth === 'full'` before it will write
+      # grafana-surface-inventory.compose.json (see the "inventory
+      # regeneration requires the exhaustive crawl" expect() in that file), so
+      # a dispatch that set CERBERUS_UPDATE_INVENTORY without this would fail
+      # by construction. Every other event/selection keeps the lean PR/push
+      # default. See CERBERUS_UPDATE_INVENTORY just below and the k3d
+      # equivalent in dashboard-shard (tsouza/cerberus#1826).
       - name: playwright compose-grafana-smoke (${{ matrix.name }})
         id: playwright_smoke
         working-directory: test/e2e/playwright
@@ -637,9 +664,43 @@ jobs:
           GRAFANA_BASE_URL: http://localhost:3000
           GRAFANA_URL: http://localhost:3000
           CERBERUS_URL: http://localhost:8080
-          SWEEP_DEPTH: ${{ github.event_name == 'schedule' && 'full' || 'lean' }}
+          SWEEP_DEPTH: >-
+            ${{
+              (github.event_name == 'schedule' ||
+               (github.event_name == 'workflow_dispatch' &&
+                (inputs.update_crawl_inventory == 'compose' || inputs.update_crawl_inventory == 'both')))
+              && 'full' || 'lean'
+            }}
           CRAWL_STACK: compose
+          # Regen path for grafana-surface-inventory.compose.json — the
+          # compose-stack equivalent of the k3d dashboard-shard's
+          # CERBERUS_UPDATE_INVENTORY (tsouza/cerberus#1826). Only this shard
+          # (shard-crawl, the sole compose shard that runs crawl/crawl.spec.ts)
+          # can produce it.
+          CERBERUS_UPDATE_INVENTORY: >-
+            ${{
+              github.event_name == 'workflow_dispatch' &&
+              (inputs.update_crawl_inventory == 'compose' || inputs.update_crawl_inventory == 'both') &&
+              '1' || ''
+            }}
         run: npx playwright test ${{ matrix.specs }} --reporter=list,html
+
+      # Bootstrap/regen path for
+      # test/e2e/playwright/crawl/grafana-surface-inventory.compose.json —
+      # dispatch this workflow with update_crawl_inventory=compose (or
+      # =both), then commit the uploaded artifact. Mirrors "Upload
+      # regenerated k3d crawl inventory" in dashboard-shard above; kept
+      # stack-qualified (compose vs k3d) so the two artifacts can never be
+      # confused for one another.
+      - name: Upload regenerated compose crawl inventory
+        if: >-
+          always() && github.event_name == 'workflow_dispatch' &&
+          (inputs.update_crawl_inventory == 'compose' || inputs.update_crawl_inventory == 'both')
+        uses: actions/upload-artifact@v7
+        with:
+          name: grafana-surface-inventory-compose
+          path: test/e2e/playwright/crawl/grafana-surface-inventory.compose.json
+          retention-days: 14
 
       - name: upload Playwright report on failure
         if: steps.playwright_smoke.outcome == 'failure'
@@ -1097,7 +1158,9 @@ jobs:
       # k3d inventory (test/e2e/playwright/crawl/grafana-surface-inventory.k3d.json)
       # was bootstrapped this way in tsouza/cerberus#1539. To deliberately
       # regenerate after surface growth: dispatch this workflow with
-      # update_crawl_inventory=true, then commit the uploaded artifact.
+      # update_crawl_inventory=k3d (or =both), then commit the uploaded
+      # artifact. See compose-smoke-shard-info below for the compose-stack
+      # equivalent (tsouza/cerberus#1826).
       - name: Run Playwright crawl (${{ matrix.name }}, CRAWL_STACK=k3d)
         id: playwright_crawl
         if: env.RUN_SHARD == 'true' && matrix.crawlStack == 'k3d'
@@ -1107,11 +1170,18 @@ jobs:
           CERBERUS_URL: http://localhost:8080
           CRAWL_STACK: ${{ matrix.crawlStack }}
           SWEEP_DEPTH: full
-          CERBERUS_UPDATE_INVENTORY: ${{ github.event_name == 'workflow_dispatch' && inputs.update_crawl_inventory && '1' || '' }}
+          CERBERUS_UPDATE_INVENTORY: >-
+            ${{
+              github.event_name == 'workflow_dispatch' &&
+              (inputs.update_crawl_inventory == 'k3d' || inputs.update_crawl_inventory == 'both') &&
+              '1' || ''
+            }}
         run: npx playwright test ${{ matrix.specs }} --reporter=list,html
 
       - name: Upload regenerated k3d crawl inventory
-        if: always() && matrix.crawlStack == 'k3d' && github.event_name == 'workflow_dispatch' && inputs.update_crawl_inventory
+        if: >-
+          always() && matrix.crawlStack == 'k3d' && github.event_name == 'workflow_dispatch' &&
+          (inputs.update_crawl_inventory == 'k3d' || inputs.update_crawl_inventory == 'both')
         uses: actions/upload-artifact@v7
         with:
           name: grafana-surface-inventory-k3d

--- a/docs/specs/compose-crawl-inventory-regeneration.md
+++ b/docs/specs/compose-crawl-inventory-regeneration.md
@@ -1,7 +1,9 @@
 # Spec: CI regeneration path for the compose crawl surface inventory
 
 Tracks issue #1826. This document is the worked example for the plan-first workflow described in
-`docs/agent-workflow.md`; it is a specification, and no part of it has been implemented.
+`docs/agent-workflow.md`. **Implemented** — see the task list at the bottom for what shipped, where
+it diverged from the original design, and what still needs a real `workflow_dispatch` run to confirm
+end to end.
 
 ## Problem
 
@@ -52,7 +54,18 @@ developer machine and run a full-depth Playwright crawl locally.
 
 ## Design
 
-Three coordinated edits, all in `.github/workflows/e2e.yml`.
+Three coordinated edits, all in `.github/workflows/e2e.yml` — **plus a fourth this design missed**:
+`compose-smoke-scope.mjs` hard-codes `workflow_dispatch` as a `NON_BOOTING_EVENT`, unconditionally
+(the compose lane's only prior dispatch behaviour was "never boots" — the exclusion predates this
+issue and exists because the only dispatch input used to regenerate the k3d inventory alone). Without
+a fourth edit there, `compose-smoke-setup` (and therefore `compose-smoke-shard-info`, which is where
+the crawl actually runs) never fires on a dispatch at all, regardless of what the workflow-level
+`update_crawl_inventory` edits below do — the three-edit plan would ship a dead path. The fix is a
+narrow carve-out in `decide()`: a dispatch selection of `compose` or `both` boots the stack exactly
+like push/schedule; every other dispatch selection (`none`, `k3d`) still short-circuits, preserving
+the existing k3d-only-regen behaviour and its pinned test
+(`compose-smoke-scope.test.mjs`'s "workflow_dispatch does not boot the stack ... whatever the diff
+says").
 
 **1. Widen the dispatch surface to name a stack.** Replace the boolean `update_crawl_inventory` with
 an input that selects which inventories to regenerate — `none`, `k3d`, `compose`, or `both` — with
@@ -104,25 +117,38 @@ with its own unit test, not in inline YAML.
 
 ## Task list for owner review
 
-Ordered so the tree is green between any two tasks. Nothing here has been executed.
+Ordered so the tree is green between any two tasks.
 
-1. Determine whether one compose shard yields a complete inventory or the shards must be merged. Read
-   `.github/scripts/compose-smoke-matrix.mjs`, `test/e2e/playwright/crawl/stacks.ts`, and
-   `crawl.spec.ts`'s write path. Record the answer in this spec. No code change. This gates tasks 4
-   and 5.
-2. Reshape the `workflow_dispatch` input to a stack-selecting `choice` with default `none`, and
-   rewrite its description to name both inventory paths. Rewire the two existing k3d consumers to the
-   new input. Verify with `just lint-actions`; the k3d path must behave exactly as before.
-3. Resolve `SWEEP_DEPTH` to `full` on both lanes whenever this run regenerates that lane's inventory.
-   Verify with `just lint-actions` plus a reading of the resolved expression for all four selection
-   values.
-4. Set `CERBERUS_UPDATE_INVENTORY` on `compose-smoke-shard` when the selection includes compose.
-   Verify with `just lint-actions`.
-5. Add the stack-qualified artifact upload for `grafana-surface-inventory.compose.json`, including
-   the shard merge if task 1 found one is needed — as a `.github/scripts/` module with a unit test if
-   so.
-6. Run the dispatch on the branch for each of the four selection values. Download the compose
-   artifact and diff it against the committed inventory; attach the result to the PR. This is the
-   acceptance evidence.
-7. Update `docs/test-strategy.md`'s crawl-inventory section to state the regeneration path for both
+1. **Done.** One compose shard yields a complete inventory — no merge needed. `SHARDS` in
+   `compose-smoke-matrix.mjs` has exactly one entry in `GATE_EXCLUDED_SHARDS`
+   (`shard-crawl`), so it is also the only entry in `matrix_informational`; that single shard's
+   `crawl/crawl.spec.ts` is the sole spec anywhere in the compose cohort that touches
+   `CERBERUS_UPDATE_INVENTORY` or writes the inventory file. There is exactly one informational shard,
+   so the artifact upload can use a static, non-matrix-suffixed name, mirroring the k3d upload.
+2. **Done, plus the fourth edit this design missed** (see Design above): reshaped
+   `workflow_dispatch.inputs.update_crawl_inventory` to a `choice` (`none` default,
+   `k3d`/`compose`/`both`), rewired the two k3d consumers, and added the `compose-smoke-scope.mjs`
+   carve-out so a `compose`/`both` dispatch actually boots the compose lane in the first place.
+   Verified with `just lint-actions` (clean) and `node --test .github/scripts/compose-smoke-scope.test.mjs`
+   (15/15, including two new tests pinning the carve-out in both directions).
+3. **Done.** `SWEEP_DEPTH` on the compose crawl step (`compose-smoke-shard-info`) now resolves to
+   `full` on `schedule` OR a dispatch selecting `compose`/`both`. The k3d crawl step was already
+   hard-coded to `SWEEP_DEPTH: full` unconditionally, so it needed no change.
+4. **Done.** `CERBERUS_UPDATE_INVENTORY` is set on the `compose-smoke-shard-info` crawl step (the
+   step that actually runs `crawl/crawl.spec.ts`, not `compose-smoke-shard`, which never runs it —
+   see task 1) when the dispatch selection includes compose.
+5. **Done.** Added `Upload regenerated compose crawl inventory`, uploading
+   `grafana-surface-inventory.compose.json` as artifact `grafana-surface-inventory-compose`. No merge
+   step needed per task 1.
+6. **Not done — needs a real dispatch.** This is CLAUDE.md's `compose-smoke` local-verification
+   exception: it needs a real Docker Compose stack, not chDB, so it cannot be proven from an agent
+   worktree. What's confirmed locally: `just lint-actions` is clean; the `compose-smoke-scope.mjs`
+   unit tests pin the boot decision for all four selection values against both a real and a null/empty
+   diff; a manual read of the resolved `SWEEP_DEPTH` / `CERBERUS_UPDATE_INVENTORY` expressions for
+   `none`/`k3d`/`compose`/`both` confirms only `compose`/`both` flip either. What still needs the
+   dispatch: that the uploaded `grafana-surface-inventory-compose` artifact is well-formed and, on an
+   unchanged surface, byte-identical to the committed inventory; that a `none` dispatch is truly an
+   inert no-op end to end; and that the k3d path (re-verified, not merely re-read) still regenerates
+   correctly through the renamed input.
+7. **Done.** Updated `docs/test-strategy.md`'s crawl-inventory section to state the regeneration path for both
    stacks.

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -952,12 +952,25 @@ crawl's inventory is committed; only the regen run itself
 past this now — compose bootstrapped first, and the k3d stack
 bootstrapped in tsouza/cerberus#1539 (booting k3d locally is heavy, so
 that ran against a local `just e2e-up && just e2e-seed-rolling`
-cluster; the same regen also runs by dispatching the `e2e` workflow
-with `update_crawl_inventory=true` and committing the uploaded
-artifact). Deliberately regenerating either stack's inventory after
-surface growth follows the same path — the red crawl lane in the
-interim is deliberate pressure that keeps bootstrap (or a stale
-regen) from silently becoming permanent.
+cluster).
+
+**Regenerating from CI.** Both stacks' inventories can be regenerated
+without booting anything locally: dispatch the `e2e` workflow
+(`workflow_dispatch`) with `update_crawl_inventory` set to `k3d`,
+`compose`, or `both`, then download the matching
+`grafana-surface-inventory-<stack>` artifact and commit it through a
+PR like any other generated file (`grafana-surface-inventory.compose.json`
+is `-merge`-gated in `.gitattributes`, so it is never hand-edited).
+The selected stack(s) get `CERBERUS_UPDATE_INVENTORY=1` and forced
+`SWEEP_DEPTH=full` on their crawl shard — the compose lane otherwise
+runs `SWEEP_DEPTH=full` only on the nightly `schedule` event, and a
+regen dispatch below full depth would fail
+`crawl.spec.ts`'s own exhaustive-crawl assertion by construction. The
+default `none` selection leaves an ordinary dispatch behaving exactly
+as it always has (tsouza/cerberus#1826). Deliberately regenerating
+either stack's inventory after surface growth follows this path — the
+red crawl lane in the interim is deliberate pressure that keeps
+bootstrap (or a stale regen) from silently becoming permanent.
 
 **Doctrine: the AI sweep generates oracle classes; CI runs them.**
 The crawler exists because an off-CI AI screenshot sweep (2026-06-09)

--- a/test/e2e/playwright/crawl/stacks.ts
+++ b/test/e2e/playwright/crawl/stacks.ts
@@ -210,7 +210,9 @@ export const COMPOSE_STACK: CrawlStackConfig = {
     'test/e2e/playwright/crawl/crawl.spec.ts. lean=true rows are the per-PR crawl ' +
     '(root + nav + one representative per drilldown app); every row is crawled nightly. ' +
     'Regenerate deliberately against a healthy compose stack with: ' +
-    'CERBERUS_UPDATE_INVENTORY=1 SWEEP_DEPTH=full CRAWL_STACK=compose npx playwright test crawl/crawl.spec.ts',
+    'CERBERUS_UPDATE_INVENTORY=1 SWEEP_DEPTH=full CRAWL_STACK=compose npx playwright test crawl/crawl.spec.ts ' +
+    '— or dispatch the e2e workflow with update_crawl_inventory=compose (or =both) and commit the ' +
+    'uploaded grafana-surface-inventory-compose artifact (tsouza/cerberus#1826).',
   expectedDatasources: CERBERUS_DATASOURCES,
   lints: {
     // cerberus.json + showcase-promql carry quantile panels; otelcol.json
@@ -242,9 +244,9 @@ export const COMPOSE_STACK: CrawlStackConfig = {
  * assertInventoryBootstrapped until a real inventory was committed,
  * so the bootstrap state could not silently become permanent).
  * Deliberately regenerating after surface growth follows the same
- * path: dispatch the `e2e` workflow with update_crawl_inventory=true
- * and commit the uploaded artifact, or regenerate locally per the
- * command in `inventoryDoc` below.
+ * path: dispatch the `e2e` workflow with update_crawl_inventory=k3d
+ * (or =both) and commit the uploaded artifact, or regenerate locally
+ * per the command in `inventoryDoc` below.
  */
 export const K3D_STACK: CrawlStackConfig = {
   name: 'k3d',
@@ -260,7 +262,8 @@ export const K3D_STACK: CrawlStackConfig = {
     'row is crawled each run; lean=true rows mark the local fast-lane subset only. ' +
     'Regenerate deliberately against a healthy k3d stack (just e2e-up && just e2e-seed-rolling) with: ' +
     'CERBERUS_UPDATE_INVENTORY=1 SWEEP_DEPTH=full CRAWL_STACK=k3d npx playwright test crawl/crawl.spec.ts ' +
-    '— or dispatch the e2e workflow with update_crawl_inventory=true and commit the uploaded artifact.',
+    '— or dispatch the e2e workflow with update_crawl_inventory=k3d (or =both) and commit the uploaded ' +
+    'grafana-surface-inventory-k3d artifact.',
   expectedDatasources: CERBERUS_DATASOURCES,
   lints: {
     // test/e2e/grafana/dashboards/cerberus.json carries one


### PR DESCRIPTION
## Summary

`e2e.yml` could already regenerate the **k3d** crawl surface inventory from CI via `workflow_dispatch`, but had no equivalent path for the **compose** inventory (`grafana-surface-inventory.compose.json`) — the one that actually gates every PR (`compose-smoke-shard-info (shard-crawl, …)`). The only way to regenerate it was booting the full compose stack locally and running a full-depth crawl by hand.

- Reshaped the `update_crawl_inventory` boolean `workflow_dispatch` input into a `none` | `k3d` | `compose` | `both` choice (default `none`, so an ordinary dispatch is unaffected).
- Wired `CERBERUS_UPDATE_INVENTORY` + forced `SWEEP_DEPTH=full` onto the compose crawl step (`compose-smoke-shard-info`, the one shard — `shard-crawl` — that actually runs `crawl/crawl.spec.ts`), mirroring the existing k3d wiring exactly.
- Added an artifact-upload step for `grafana-surface-inventory.compose.json` (stack-qualified name `grafana-surface-inventory-compose`, mirroring the k3d upload).
- **The design's own three-edit plan (`docs/specs/compose-crawl-inventory-regeneration.md`) missed a fourth, load-bearing edit**: `compose-smoke-scope.mjs` hard-codes `workflow_dispatch` as a non-booting event — without a carve-out there, `compose-smoke-setup`/`compose-smoke-shard-info` never even fire on a dispatch, regardless of the workflow-level wiring. Added a narrow `regeneratesCompose()` carve-out: a `compose`/`both` dispatch boots the lane exactly like push/schedule; `none`/`k3d` still short-circuit as before (preserves the existing pinned "workflow_dispatch never boots" test in both directions).
- Updated `docs/test-strategy.md`'s crawl-inventory section and the inline doc-comments in `crawl/stacks.ts` to name the new dispatch path for both stacks.
- `docs/specs/compose-crawl-inventory-regeneration.md` is updated to record the implementation, the fourth-edit finding, and what still needs a live dispatch to confirm.

## Verified locally

- `just lint-actions` (actionlint) — clean, before and after the rebase onto latest `main`.
- `node --test .github/scripts/compose-smoke-scope.test.mjs` — 15/15, including two new tests: the existing "workflow_dispatch never boots" test extended to also cover the `k3d`-only selection (must still short-circuit), and a new test pinning that `compose`/`both` boot the stack regardless of the diff.
- `npx markdownlint-cli2` on both touched docs — clean.
- Manual read of the resolved `SWEEP_DEPTH` / `CERBERUS_UPDATE_INVENTORY` GitHub Actions expressions for all four selection values (`none`, `k3d`, `compose`, `both`) against both the compose and k3d crawl steps.

## Still needs a real dispatch run (cannot be settled locally)

Per `CLAUDE.md`'s `compose-smoke` local-verification exception (needs a real Docker Compose stack, not chDB) — did **not** attempt this locally, and avoided touching Docker/compose in this worktree per the no-concurrent-compose-runs hazard:

- That a `workflow_dispatch` with `update_crawl_inventory=compose` actually boots the compose lane, and the uploaded `grafana-surface-inventory-compose` artifact is well-formed and, on an unchanged surface, byte-identical to the committed inventory.
- That `update_crawl_inventory=none` (the default) is a true end-to-end no-op — no depth change, no `CERBERUS_UPDATE_INVENTORY`, no artifact.
- That the k3d regen path still works correctly through the renamed/reshaped input (re-verified via a real dispatch, not just re-read).

## Test plan

- [x] `just lint-actions`
- [x] `node --test .github/scripts/compose-smoke-scope.test.mjs`
- [x] `npx markdownlint-cli2 docs/test-strategy.md docs/specs/compose-crawl-inventory-regeneration.md`
- [ ] A `workflow_dispatch` run with each of the four `update_crawl_inventory` selections, comparing the uploaded artifact(s) against the committed inventories (needs a maintainer to trigger; documented in the PR body above and in the spec)

Closes #1826