### PR TITLE
feat(promql): answer rate()/increase() over a native histogram with a histogram-valued result

### DIFF
--- a/internal/chclient/cursor.go
+++ b/internal/chclient/cursor.go
@@ -197,10 +197,16 @@ type rowsCursor struct {
 	// projection carries the nine trailing Histogram*Column columns a
 	// chplan.HistogramProjection subquery publishes (see issue #1926),
 	// so the scan binds thirteen destinations (the base four plus the
-	// nine histogram fields) instead of four. No lowering builds that
-	// plan shape yet, so hasHistogram is false — and the scan
-	// byte-identical to before — on every query today; it exists so the
-	// decode side has a stable contract ready the moment one does.
+	// nine histogram fields) instead of four.
+	//
+	// hasHistogram latches true for the histogram-VALUED PromQL shapes —
+	// a bare exp-histogram selector, `sum()` over one, and
+	// `rate()`/`increase()` over one — and stays false, leaving the scan
+	// byte-identical to before, on every other query. Only this
+	// ROW-based cursor reads those nine columns; the columnar sibling in
+	// columnar.go still binds four and rejects a thirteen-column result
+	// as a matrix mismatch, which makes queryCursorColumnar fall back to
+	// this path rather than mis-decode one (issue #1967).
 	histogramProbed bool
 	hasHistogram    bool
 }
@@ -263,9 +269,9 @@ func (c *rowsCursor) Next() bool {
 	var metadataJSON string
 	// Probe the result-set shape once: the Loki log-stream projection
 	// appends a fifth `Metadata` column, a chplan.HistogramProjection
-	// subquery appends nine Histogram*Column columns (issue #1926 — no
-	// lowering builds that shape yet, so this branch is untaken by
-	// every query today), every other path projects four.
+	// subquery appends nine Histogram*Column columns (issue #1926 —
+	// taken by the histogram-valued PromQL shapes, see hasHistogram),
+	// every other path projects four.
 	// driver.Rows.Columns() is stable across the stream, so latch the
 	// decision on the first row and bind the scan accordingly.
 	if !c.metadataProbed {

--- a/internal/chplan/row_shape.go
+++ b/internal/chplan/row_shape.go
@@ -84,11 +84,20 @@ const (
 	// the existing PromQL forwarders (projectValueOverInner,
 	// projectAttributesOverInner) make, which is correct: neither
 	// forwarder builds a column list a histogram-shaped row satisfies
-	// (both unconditionally reference `Value` by name), so a future
+	// (both unconditionally reference `Value` by name), so a
 	// histogram-valued lowering that needs those forwarders to work
 	// over a HistogramProjection must teach them this shape first — see
-	// the doc comment on HistogramProjection. No lowering builds this
-	// node yet, so no forwarder is called with it today.
+	// the doc comment on HistogramProjection.
+	//
+	// Three lowerings build this node today (internal/promql's
+	// histogram_native_bare.go, histogram_native_sum.go and
+	// histogram_native_rate.go), but no forwarder is reached with it:
+	// each is dispatched only at the ROOT of a query, and every shape
+	// that would wrap one — `label_replace(...)`, `abs(...)`, scalar
+	// arithmetic — is still refused by expHistogramSelectorRouting. The
+	// forwarders are unreachable by that guard rather than adapted, so
+	// teaching them this shape remains a prerequisite for lifting it
+	// (issue #1967).
 	HistogramRowShape
 )
 

--- a/internal/promql/exp_histogram_reject_test.go
+++ b/internal/promql/exp_histogram_reject_test.go
@@ -18,10 +18,12 @@ import (
 // TestLower_ExpHistogram_UnsupportedShapesRejectExplicitly pins issue #1704:
 // every PromQL shape over a pinned exponential-histogram selector OTHER
 // than histogram_quantile() / histogram_count() / histogram_sum(), the
-// `_count` / `_sum` companion selectors, and the two top-level
+// `_count` / `_sum` companion selectors, and the three top-level
 // histogram-VALUED shapes issue #1967 answers — a BARE selector
-// (TestLower_ExpHistogram_BareSelectorIsHistogramValued) and `sum()` over
-// one (TestLower_ExpHistogram_SumIsHistogramValued) — must fail lowering
+// (TestLower_ExpHistogram_BareSelectorIsHistogramValued), `sum()` over
+// one (TestLower_ExpHistogram_SumIsHistogramValued) and `rate()` /
+// `increase()` over one
+// (TestLower_ExpHistogram_RateIsHistogramValued) — must fail lowering
 // with a clear error, never silently resolve against the Gauge/Sum tables
 // and return an empty-but-200 result. Before the fix, TablesFor never
 // yielded ExpHistogramTable for these shapes, so cerberus quietly scanned
@@ -44,10 +46,11 @@ func TestLower_ExpHistogram_UnsupportedShapesRejectExplicitly(t *testing.T) {
 		name  string
 		query string
 	}{
-		{name: "rate", query: `rate(latency_exp_hist[5m])`},
 		{name: "resets", query: `resets(latency_exp_hist[5m])`},
 		{name: "changes", query: `changes(latency_exp_hist[5m])`},
-		{name: "increase", query: `increase(latency_exp_hist[5m])`},
+		{name: "delta", query: `delta(latency_exp_hist[5m])`},
+		{name: "irate", query: `irate(latency_exp_hist[5m])`},
+		{name: "sum_over_time", query: `sum_over_time(latency_exp_hist[5m])`},
 		{name: "absent_over_time", query: `absent_over_time(latency_exp_hist[5m])`},
 		{name: "avg aggregation", query: `avg(latency_exp_hist)`},
 		{name: "min aggregation", query: `min(latency_exp_hist)`},
@@ -72,6 +75,21 @@ func TestLower_ExpHistogram_UnsupportedShapesRejectExplicitly(t *testing.T) {
 		{name: "sum under label_replace", query: `label_replace(sum(latency_exp_hist), "a", "b", "service", "(.*)")`},
 		{name: "sum under topk", query: `topk(3, sum by (service) (latency_exp_hist))`},
 		{name: "sum under abs", query: `abs(sum(latency_exp_hist))`},
+
+		// `rate()` / `increase()` over a range-vector selector ARE answered
+		// (see TestLower_ExpHistogram_RateIsHistogramValued). These are the
+		// shapes that narrowing must NOT reach: a rate under a consumer that
+		// reads a Value, and a rate under an aggregation — which needs the
+		// across-series merge stacked on top of the window reduction, so
+		// answering it with the window reduction alone would silently drop
+		// the sum.
+		{name: "rate under arithmetic", query: `rate(latency_exp_hist[5m]) * 2`},
+		{name: "rate under label_replace", query: `label_replace(rate(latency_exp_hist[5m]), "a", "b", "service", "(.*)")`},
+		{name: "rate under abs", query: `abs(rate(latency_exp_hist[5m]))`},
+		{name: "rate under topk", query: `topk(3, rate(latency_exp_hist[5m]))`},
+		{name: "rate under avg", query: `avg(rate(latency_exp_hist[5m]))`},
+		{name: "increase under arithmetic", query: `increase(latency_exp_hist[5m]) + 1`},
+		{name: "rate over subquery", query: `rate(latency_exp_hist[5m:1m])`},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -413,5 +431,254 @@ func TestLower_ExpHistogram_SumMergesBucketLadders(t *testing.T) {
 		if !strings.Contains(sql, want) {
 			t.Fatalf("emitted SQL does not reach the shared native-histogram merge: missing %q\n%s", want, sql)
 		}
+	}
+}
+
+// TestLower_ExpHistogram_RateIsHistogramValued pins issue #1967's third
+// and last cut: `rate(<exp-histogram selector>[range])` and its
+// `increase` twin are answerable, and the answer is a
+// chplan.HistogramProjection publishing the same thirteen-column
+// contract as the bare and `sum()` siblings.
+//
+// Like `sum()`, and unlike the bare selector, the quartet's first slot
+// must be an EMPTY literal: reference PromQL drops `__name__` from every
+// range-vector function result too.
+func TestLower_ExpHistogram_RateIsHistogramValued(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+
+	cases := []struct {
+		name  string
+		query string
+		lower func(parser.Expr) (chplan.Node, error)
+	}{
+		{
+			name:  "instant rate",
+			query: `rate(latency_exp_hist[5m])`,
+			lower: func(e parser.Expr) (chplan.Node, error) {
+				return promql.LowerAt(context.Background(), e, s, end, end)
+			},
+		},
+		{
+			name:  "instant increase",
+			query: `increase(latency_exp_hist[5m])`,
+			lower: func(e parser.Expr) (chplan.Node, error) {
+				return promql.LowerAt(context.Background(), e, s, end, end)
+			},
+		},
+		{
+			name:  "instant with matchers",
+			query: `rate(latency_exp_hist{service="api"}[10m])`,
+			lower: func(e parser.Expr) (chplan.Node, error) {
+				return promql.LowerAt(context.Background(), e, s, end, end)
+			},
+		},
+		{
+			name:  "parenthesised",
+			query: `(rate(latency_exp_hist[5m]))`,
+			lower: func(e parser.Expr) (chplan.Node, error) {
+				return promql.LowerAt(context.Background(), e, s, end, end)
+			},
+		},
+		{
+			name:  "offset",
+			query: `rate(latency_exp_hist[5m] offset 10m)`,
+			lower: func(e parser.Expr) (chplan.Node, error) {
+				return promql.LowerAt(context.Background(), e, s, end, end)
+			},
+		},
+		{
+			name:  "range",
+			query: `rate(latency_exp_hist[5m])`,
+			lower: func(e parser.Expr) (chplan.Node, error) {
+				return promql.LowerAtRange(context.Background(), e, s, start, end, 30*time.Second)
+			},
+		},
+		{
+			name:  "range increase",
+			query: `increase(latency_exp_hist[5m])`,
+			lower: func(e parser.Expr) (chplan.Node, error) {
+				return promql.LowerAtRange(context.Background(), e, s, start, end, 30*time.Second)
+			},
+		},
+		{
+			name:  "range with absolute @ pin",
+			query: `rate(latency_exp_hist[5m] @ 1767225600)`,
+			lower: func(e parser.Expr) (chplan.Node, error) {
+				return promql.LowerAtRange(context.Background(), e, s, start, end, 30*time.Second)
+			},
+		},
+	}
+
+	wantAliases := []string{
+		s.MetricNameColumn, s.AttributesColumn, s.TimestampColumn, s.ValueColumn,
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			expr, err := p.ParseExpr(tc.query)
+			if err != nil {
+				t.Fatalf("ParseExpr(%q): %v", tc.query, err)
+			}
+			plan, err := tc.lower(expr)
+			if err != nil {
+				t.Fatalf("lower(%q): unexpected error: %v", tc.query, err)
+			}
+			if shape := chplan.RowShapeOf(plan); shape != chplan.HistogramRowShape {
+				t.Fatalf("lower(%q): plan root publishes %s, want histogram", tc.query, shape)
+			}
+			hp, ok := plan.(*chplan.HistogramProjection)
+			if !ok {
+				t.Fatalf("lower(%q): plan root is %T, want *chplan.HistogramProjection", tc.query, plan)
+			}
+			if !slices.Equal(hp.GroupByAliases, wantAliases) {
+				t.Fatalf("lower(%q): leading output aliases = %v, want %v", tc.query, hp.GroupByAliases, wantAliases)
+			}
+			name, ok := hp.GroupBy[0].(*chplan.LitString)
+			if !ok || name.V != "" {
+				t.Fatalf("lower(%q): __name__ projection is %#v, want an empty literal — "+
+					"a range-vector function result carries no metric name", tc.query, hp.GroupBy[0])
+			}
+		})
+	}
+}
+
+// TestLower_ExpHistogram_RateReachesTheWindowFold pins that `rate()`
+// reaches the SHARED exponential-histogram WINDOW fold — the
+// counter-reset differencing plus Prometheus's boundary extrapolation —
+// rather than reducing the histogram columns some other way.
+//
+// This is the assertion that would catch the worst plausible bug in this
+// lowering: a plan that took each series' NEWEST in-window sample (the
+// bare selector's own `argMax(<col>, TimeUnix)` collapse, the easiest
+// thing to copy from the sibling file) would still produce a
+// HistogramProjection, still emit thirteen columns in contract order, and
+// still pass every structural check above — while answering `rate()` with
+// a raw cumulative counter reading.
+//
+// Each marker below is load-bearing:
+//
+//   - `arrayPopBack` / `arrayPopFront` are counterIncreaseFold's
+//     consecutive-pair map, i.e. the counter-reset differencing itself.
+//   - `dateDiff` is secondsBetweenTsExpr, which only the
+//     boundary-extrapolation factor calls — its absence would mean the
+//     window increase ships unextrapolated (the defect #1958 fixed on the
+//     classic path).
+//   - `groupArray(<Sum>)` is the whole-histogram Sum series this lowering
+//     adds; without it the published Sum could only be a single sample's.
+//   - `uniqExact` is the two-sample floor, which reference applies per
+//     series before emitting anything at all.
+//   - the absence of `argMax(<Count>` is the negative half: the bare
+//     path's latest-sample collapse must NOT appear on this one.
+func TestLower_ExpHistogram_RateReachesTheWindowFold(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	expr, err := p.ParseExpr(`rate(latency_exp_hist[5m])`)
+	if err != nil {
+		t.Fatalf("ParseExpr: %v", err)
+	}
+	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	plan, err := promql.LowerAt(context.Background(), expr, s, at, at)
+	if err != nil {
+		t.Fatalf("LowerAt: %v", err)
+	}
+	sql, _, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	for _, want := range []string{
+		"arrayPopBack(",
+		"arrayPopFront(",
+		"dateDiff(",
+		"groupArray(`" + s.SumColumn + "`)",
+		"groupArray(`" + s.CountColumn + "`)",
+		"uniqExact(",
+	} {
+		if !strings.Contains(sql, want) {
+			t.Fatalf("emitted SQL does not reach the shared native-histogram window fold: missing %q\n%s", want, sql)
+		}
+	}
+	if strings.Contains(sql, "argMax(`"+s.CountColumn+"`") {
+		t.Fatalf("emitted SQL collapses to the newest sample per series — that is the BARE selector's "+
+			"reduction, not a window rate:\n%s", sql)
+	}
+}
+
+// TestLower_ExpHistogram_RateDividesByRangeAndIncreaseDoesNot pins the
+// one arithmetic difference between the two functions this file answers.
+//
+// Reference PromQL folds the per-second division into the very scalar the
+// boundary extrapolation produces — `factor /= ms.Range.Seconds()` before
+// a single `Mul(factor)` over the whole histogram — so `rate` is
+// `increase` divided by the range, field for field. The quantile path
+// leaves that division out on purpose (a per-series constant cancels out
+// of every bucket RATIO), which makes "forgot to divide" the single most
+// likely way to ship a plausible-looking wrong answer here: it is
+// invisible to every structural assertion and to `histogram_quantile`
+// itself, and shows up only as a result 300x too large.
+//
+// The assertion reads the plan rather than the SQL because the divisor is
+// a numeric literal, and the emitter parameterises those — `/ ?` in the
+// SQL text tells a reader nothing about which number.
+func TestLower_ExpHistogram_RateDividesByRangeAndIncreaseDoesNot(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// countProjection returns the window-reduced Count expression, i.e. the
+	// projection the histogram row publishes as its total observation count.
+	countProjection := func(t *testing.T, query string) chplan.Expr {
+		t.Helper()
+		expr, err := p.ParseExpr(query)
+		if err != nil {
+			t.Fatalf("ParseExpr(%q): %v", query, err)
+		}
+		plan, err := promql.LowerAt(context.Background(), expr, s, at, at)
+		if err != nil {
+			t.Fatalf("LowerAt(%q): %v", query, err)
+		}
+		hp, ok := plan.(*chplan.HistogramProjection)
+		if !ok {
+			t.Fatalf("lower(%q): plan root is %T, want *chplan.HistogramProjection", query, plan)
+		}
+		reshape, ok := hp.Input.(*chplan.Project)
+		if !ok {
+			t.Fatalf("lower(%q): projection input is %T, want *chplan.Project", query, hp.Input)
+		}
+		for _, proj := range reshape.Projections {
+			if proj.Alias == s.CountColumn {
+				return proj.Expr
+			}
+		}
+		t.Fatalf("lower(%q): reshape publishes no %q projection", query, s.CountColumn)
+		return nil
+	}
+
+	const fiveMinutesInSeconds = 300.0
+
+	rateCount := countProjection(t, `rate(latency_exp_hist[5m])`)
+	div, ok := rateCount.(*chplan.Binary)
+	if !ok || div.Op != chplan.OpDiv {
+		t.Fatalf("rate's Count projection is %#v, want a division by the range — "+
+			"reference folds `factor /= ms.Range.Seconds()` into the same scalar it scales the histogram by", rateCount)
+	}
+	secs, ok := div.Right.(*chplan.LitFloat)
+	if !ok || secs.V != fiveMinutesInSeconds {
+		t.Fatalf("rate over [5m] divides Count by %#v, want the literal %v", div.Right, fiveMinutesInSeconds)
+	}
+
+	increaseCount := countProjection(t, `increase(latency_exp_hist[5m])`)
+	if b, ok := increaseCount.(*chplan.Binary); ok && b.Op == chplan.OpDiv {
+		t.Fatalf("increase's Count projection divides by %#v — increase is the window total, "+
+			"NOT a per-second figure", b.Right)
 	}
 }

--- a/internal/promql/histogram_native_rate.go
+++ b/internal/promql/histogram_native_rate.go
@@ -1,0 +1,361 @@
+package promql
+
+import (
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// histogram_native_rate.go lowers `rate(<selector>[range])` and
+// `increase(<selector>[range])` over an OTel exponential (native)
+// histogram — `<base>_exp_hist` — into a histogram-VALUED result, the
+// third and last lowering of issue #1967 to cap a plan with a
+// [chplan.HistogramProjection] (after the bare selector in
+// histogram_native_bare.go and `sum()` in histogram_native_sum.go).
+//
+// Reference Prometheus answers both with a native histogram, not a
+// float: promql's extrapolatedRate hands a range of native-histogram
+// samples to histogramRate, which returns a *histogram.FloatHistogram,
+// and the caller scales THAT by the boundary-extrapolation factor
+// (`resultHistogram.Mul(factor)`). The whole distribution is the answer;
+// there is no scalar anywhere in it.
+//
+// Two reductions, and only one of them is new here.
+//
+//  1. The window reduction — per series, fold the in-window samples into
+//     one distribution under the counter-reset rule, then stretch it by
+//     the boundary-extrapolation factor. Cerberus already runs exactly
+//     this for `histogram_quantile(phi, <agg>(rate(<sel>_exp_hist[w])))`:
+//     [expHistogramWindowAggs] + [expHistogramWindowReshape] +
+//     [histogramWindowFold], documented against Prometheus's own
+//     histogramRate in histogram_quantile_native_window.go. This file
+//     reuses that stage rather than re-deriving its arithmetic, the same
+//     discipline that let `sum()` land on top of the across-series merge.
+//  2. Publishing it — which the quantile path never does, because it
+//     consumes the folded distribution with an interpolation kernel.
+//
+// What this file adds on top of the shared window stage is therefore
+// small and entirely about being a histogram-VALUED answer:
+//
+//   - Count and Sum, the two whole-histogram scalars the quantile kernel
+//     never reads (it works off the bucket ladder). Reference folds them
+//     with everything else — `h.Sub(prev)` subtracts both, `h.Add(prev)`
+//     adds both back at a reset, and `h.Mul(factor)` scales both — so
+//     they go through the SAME fold as every bucket rather than a
+//     separate rule. See [expHistogramValuedWindowPassthrough].
+//   - `rate`'s per-second division. Reference folds it into the same
+//     scalar: `factor /= ms.Range.Seconds()` before the single
+//     `Mul(factor)`. The quantile path leaves it out deliberately (a
+//     per-series constant cancels out of every bucket RATIO), and a
+//     published histogram is precisely where it stops cancelling. See
+//     [expHistogramValuedWindowFold].
+//
+// ONE factor for the WHOLE histogram. This is the part a plausible-but-
+// wrong implementation gets wrong, so it is worth stating twice:
+// reference's extrapolatedRate computes a single scalar from the
+// series' own in-window sample timestamps against the requested window
+// edges, and multiplies the entire result histogram by it. It does NOT
+// extrapolate each bucket independently. Cerberus's fold gets this right
+// structurally rather than by convention — [histogramExtrapolationFactorExpr]
+// reads only `order` (the per-series timestamp list, which
+// [expHistogramWindowBucketsExpr] passes unfiltered for every bucket) and
+// `countValues` (the whole-histogram Count series, via
+// [expHistogramWindowCountValuesExpr]), so every bucket, the zero bucket,
+// Count and Sum all render the identical factor expression and scale
+// alike.
+//
+// Plan shape (instant mode; the range shapes differ only in the anchor
+// column threaded through the reduction):
+//
+//	HistogramProjection [MetricName='', Attributes, now64(9), Value=0, <nine histogram columns>]
+//	  Project [Attributes, folded Count / Sum / Scale / ZeroCount /
+//	           {Pos,Neg}{Offset,BucketCounts}]
+//	    Filter uniqExact(TimeUnix) >= 2                    ← rate/increase floor
+//	      Aggregate groupBy=[series identity] funcs=<expHistogramValuedWindowAggs>
+//	        Filter <matchers> AND <window bounds>
+//	          Scan(otel_metrics_exponential_histogram)
+//
+// Unlike `sum()`, there is no second grouping stage: `rate()` reduces
+// each series along TIME and emits one row per series, so the across-
+// series merge never enters. `sum(rate(<sel>_exp_hist[w]))` — which
+// stacks both — is a further shape and stays on
+// [expHistogramSelectorRouting]'s explicit rejection.
+//
+// Counter-reset detection is the one place this path is known to differ
+// from reference, and it differs there for the shared window fold's
+// existing reason rather than anything introduced here: reference
+// decides a reset for the WHOLE histogram (`FloatHistogram.DetectReset`
+// — any bucket, the zero bucket, or Count regressing condemns the whole
+// sample) and then adds the entire previous distribution, whereas
+// [counterIncreaseFold] decides per component and adds the previous
+// reading only of the components that themselves regressed. The two
+// agree exactly on a genuine restart, where every component drops
+// together, and drift only where a component recovers past its
+// pre-reset reading within one scrape. Issue #2017 carries the
+// whole-histogram detection for the shared fold, which the quantile path
+// reads through the same code.
+
+// hqWindowSumArrayAlias holds the group's groupArray of each row's Sum —
+// the total observed VALUE, positionally parallel to the counts / scales
+// / offsets / buckets / timestamp lists [expHistogramWindowAggs] already
+// collects. It is the one field a histogram-VALUED window answer needs
+// that no quantile ever reads, which is why it is appended by
+// [expHistogramValuedWindowAggs] rather than added to the shared list:
+// the quantile paths would carry it as a dead column in every emitted
+// SELECT.
+const hqWindowSumArrayAlias = "_hq_sum_list"
+
+// rateWindowFn / increaseWindowFn are the two range-vector functions this
+// file answers, spelled once so the matcher and the per-second division
+// cannot disagree about which is which.
+const (
+	rateWindowFn     = "rate"
+	increaseWindowFn = "increase"
+)
+
+// rateOverExpHistogram reports whether expr is `rate(<bare exp-histogram
+// selector>[range])` or the `increase` twin — the two shapes this file
+// answers — returning the matched [histogramAggShape].
+//
+// Like [bareExpHistogramSelector] and [sumOverExpHistogram] it is asked
+// only of the ROOT of a query (see [lowerRoot]), and for the same reason:
+// the answer is a histogram row, which only the wire can consume.
+// `rate(m_exp_hist[5m]) * 2` or `label_replace(rate(m_exp_hist[5m]), ...)`
+// reaches lowerVectorSelector through the ordinary descent and is still
+// rejected there.
+//
+// An aggregation WRAPPER disqualifies the match: `sum(rate(...))` stacks
+// the window reduction and the across-series merge, and admitting it here
+// would answer it with the window reduction alone — silently dropping the
+// sum. [matchHistogramAggIdiom] captures any such wrapper into
+// shape.agg, so testing that field for nil is the whole of the check.
+//
+// A non-positive `[range]` is refused rather than answered: `rate`
+// divides by it (see [expHistogramValuedWindowFold]), and falling through
+// leaves the shape on the explicit rejection path instead of emitting a
+// division by zero.
+func rateOverExpHistogram(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (histogramAggShape, bool) {
+	if s.ExpHistogramTable == "" || ctx.metadataFullRange {
+		return histogramAggShape{}, false
+	}
+	shape, ok := matchHistogramAggIdiom(expr, s)
+	if !ok || shape.agg != nil || shape.windowRange <= 0 {
+		return histogramAggShape{}, false
+	}
+	if shape.windowFn != rateWindowFn && shape.windowFn != increaseWindowFn {
+		return histogramAggShape{}, false
+	}
+	if !s.IsExpHistogramMetric(metricNameFromMatchers(shape.selector.LabelMatchers)) {
+		return histogramAggShape{}, false
+	}
+	return shape, true
+}
+
+// lowerExpHistogramRate lowers the `rate` / `increase` shape across the
+// three evaluation shapes [rangeGridShapeFor] distinguishes, the same
+// three its two siblings handle — see [lowerExpHistogramBare] for what
+// each one means.
+func lowerExpHistogramRate(shape histogramAggShape, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+	if grid := rangeGridShapeFor(shape.selector, ctx); grid == gridFanout {
+		return lowerExpHistogramRateRange(shape, s, ctx), nil
+	} else if grid == gridBroadcast {
+		windowed, err := expHistogramRateWindowed(shape, s, ctx)
+		if err != nil {
+			return nil, err
+		}
+		// Same broadcast placement as the bare and `sum()` paths': the
+		// cross join goes UNDER the histogram projection so the plan root
+		// stays a HistogramProjection and keeps publishing the
+		// thirteen-column contract. The pinned window is reduced ONCE and
+		// every step reports that one rate at its own timestamp.
+		grid := &chplan.StepGrid{Start: ctx.start.UTC(), End: ctx.end.UTC(), Step: ctx.step}
+		return aggregatedHistogramProjection(
+			&chplan.CrossJoin{Left: grid, Right: windowed},
+			&chplan.ColumnRef{Name: stepGridAnchorColumn},
+			s,
+		), nil
+	}
+	windowed, err := expHistogramRateWindowed(shape, s, ctx)
+	if err != nil {
+		return nil, err
+	}
+	return aggregatedHistogramProjection(windowed, chplan.NowNano(), s), nil
+}
+
+// expHistogramRateWindowed builds the instant-mode subtree beneath the
+// histogram projection: the filtered scan reduced, per series, to that
+// series' window rate. Its prologue is lowerHistogramQuantileNativeAgg's
+// rung for rung — same anchor resolution, same `(anchor - range, anchor]`
+// predicate, and the same two bound expressions handed to the fold — for
+// the reason [fanoutWindowBoundsExpr]'s doc gives about its range-mode
+// twin: the extrapolation correction must read the SAME window edges the
+// Filter selects rows against, or the two drift apart.
+func expHistogramRateWindowed(shape histogramAggShape, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+	vs := shape.selector
+	scan := &chplan.Scan{Table: s.ExpHistogramTable}
+	pred := buildPredicate(vs.LabelMatchers, s)
+
+	anchor, err := anchorFromSelector(vs, ctx)
+	if err != nil {
+		return nil, err
+	}
+	if anchor.End.IsZero() && !ctx.end.IsZero() {
+		anchor.End = ctx.end.UTC()
+	}
+	rangeEnd := windowRightBoundExpr(anchor)
+	rangeStart := windowLeftBoundExpr(anchor, shape.windowRange)
+	pred = andExpr(pred, timeBoundExpr(s.TimestampColumn, anchor))
+	pred = andExpr(pred, stalenessLowerBoundExpr(s.TimestampColumn, anchor, shape.windowRange))
+
+	var input chplan.Node = scan
+	if pred != nil {
+		input = &chplan.Filter{Input: scan, Predicate: pred}
+	}
+	return expHistogramValuedWindowStage(input, shape, rangeStart, rangeEnd, s), nil
+}
+
+// lowerExpHistogramRateRange is the query_range shape: the per-anchor
+// [chplan.RangeBucketFanout] the sibling range paths build — one
+// `[range]` window per step anchor, keyed on SERIES identity — with the
+// window reduction on top and the histogram projection as the cap.
+//
+// The fan-out owns the rate/increase two-sample floor natively through
+// [chplan.RangeBucketFanout.MinSamples] (emitted as a HAVING), which is
+// why this path does not repeat the instant stage's minSamplesFilter.
+func lowerExpHistogramRateRange(shape histogramAggShape, s schema.Metrics, ctx lowerCtx) chplan.Node {
+	scan := &chplan.Scan{Table: s.ExpHistogramTable}
+	pred := buildPredicate(shape.selector.LabelMatchers, s)
+	win := aggWindowFor(shape)
+
+	anchorRef := &chplan.ColumnRef{Name: stepGridAnchorColumn}
+	rangeStart, rangeEnd := fanoutWindowBoundsExpr(anchorRef, win)
+	fold := expHistogramValuedWindowFold(shape, rangeStart, rangeEnd)
+
+	perSeries := expHistogramWindowReshape(
+		buildHistogramBucketFanout(
+			scan, pred, nil, win,
+			[]chplan.Expr{histogramIdentityExpr(s)}, []string{s.AttributesColumn},
+			expHistogramValuedWindowAggs(s), s, ctx,
+		),
+		fold,
+		expHistogramValuedWindowPassthrough([]chplan.Projection{
+			{Expr: anchorRef, Alias: stepGridAnchorColumn},
+			{Expr: &chplan.ColumnRef{Name: s.AttributesColumn}, Alias: s.AttributesColumn},
+		}, fold, s),
+		s,
+	)
+	return aggregatedHistogramProjection(perSeries, anchorRef, s)
+}
+
+// expHistogramValuedWindowStage is [expHistogramWindowStage] widened for
+// a histogram-VALUED answer: the same per-series grouping, the same
+// two-sample floor, the same reshape — with Sum collected alongside the
+// fields the quantile path already collects, and Count / Sum folded into
+// the reshaped row.
+func expHistogramValuedWindowStage(input chplan.Node, shape histogramAggShape, rangeStart, rangeEnd chplan.Expr, s schema.Metrics) chplan.Node {
+	fold := expHistogramValuedWindowFold(shape, rangeStart, rangeEnd)
+	group := &chplan.Aggregate{
+		Input:              input,
+		GroupBy:            []chplan.Expr{histogramIdentityExpr(s)},
+		GroupByAliases:     []string{s.AttributesColumn},
+		AggFuncs:           append(expHistogramValuedWindowAggs(s), windowSampleCountAgg(s)),
+		DropEmptyOnNoGroup: true,
+	}
+	return expHistogramWindowReshape(
+		minSamplesFilter(group, shape.minSamples()),
+		fold,
+		expHistogramValuedWindowPassthrough([]chplan.Projection{
+			{Expr: &chplan.ColumnRef{Name: s.AttributesColumn}, Alias: s.AttributesColumn},
+		}, fold, s),
+		s,
+	)
+}
+
+// expHistogramValuedWindowFold is [histogramWindowFold] over the
+// exponential-histogram window — the counter-increase numerator times
+// Prometheus's boundary-extrapolation factor — carrying `rate`'s
+// per-second division.
+//
+// Reference applies that division to the SAME scalar the extrapolation
+// produces (`factor /= ms.Range.Seconds()`, then one `Mul(factor)` over
+// the whole histogram), so dividing the fold's product is the same
+// arithmetic: every bucket, the zero bucket, Count and Sum all pass
+// through here and are scaled alike. `increase` returns the fold
+// unchanged — it is the same reduction WITHOUT the per-second division,
+// which is the entire difference between the two functions in reference
+// as well.
+//
+// The division wraps the fold's OUTPUT rather than reaching inside it,
+// which is what keeps the durationToZero clamp reading the quantities
+// reference reads: that clamp weighs the first in-window Count against
+// the window's own total increase, both pre-factor and pre-division (see
+// [histogramExtrapolationFactorExpr]).
+//
+// countValues is the whole-histogram Count series rather than any one
+// bucket's counts, and temporality is nil — the two arguments the shared
+// fold takes that this path does not vary. Both match the exponential-
+// histogram window's other call sites exactly: the Count series is what
+// reference's native-histogram durationToZero reads, and a nil
+// temporality applies the CUMULATIVE counter-reset reading, which is the
+// reading every OTel exponential-histogram path in this package uses —
+// the branch issue #1963 covers for this table.
+func expHistogramValuedWindowFold(shape histogramAggShape, rangeStart, rangeEnd chplan.Expr) histogramWindowTimeFold {
+	fold := histogramWindowFold(shape.windowFn, rangeStart, rangeEnd, expHistogramWindowCountValuesExpr(), nil)
+	if shape.windowFn != rateWindowFn {
+		return fold
+	}
+	rangeSeconds := &chplan.LitFloat{V: shape.windowRange.Seconds()}
+	return func(values, order chplan.Expr) chplan.Expr {
+		return &chplan.Binary{Op: chplan.OpDiv, Left: fold(values, order), Right: rangeSeconds}
+	}
+}
+
+// expHistogramValuedWindowAggs is [expHistogramWindowAggs] widened by the
+// one field a histogram-VALUED window answer needs and a quantile does
+// not: the group's Sum readings, collected in the same row order as every
+// other groupArray so the fold can put them in time order. Count is
+// already there — the quantile path collects it for the durationToZero
+// clamp (see [hqWindowCountArrayAlias]).
+func expHistogramValuedWindowAggs(s schema.Metrics) []chplan.AggFunc {
+	return append(expHistogramWindowAggs(s), chplan.AggFunc{
+		Name:  "groupArray",
+		Args:  []chplan.Expr{&chplan.ColumnRef{Name: s.SumColumn}},
+		Alias: hqWindowSumArrayAlias,
+	})
+}
+
+// expHistogramValuedWindowPassthrough is the reshape passthrough for a
+// histogram-VALUED window: the caller's own key projections (Attributes,
+// preceded by the step anchor in range mode) followed by the window-
+// reduced Count and Sum.
+//
+// Both scalars go through the caller's own `fold` — the same one
+// [expHistogramWindowReshape] applies to the zero bucket and to both
+// signed bucket ladders — because reference treats them exactly like a
+// bucket: `h.Sub(prev)` subtracts Count and Sum, the reset iteration's
+// `h.Add(prev)` adds them back, and `h.Mul(factor)` scales them. Folding
+// them any other way (a plain `last - first`, say, or a sum across the
+// window) would leave a published histogram whose Count disagreed with
+// the bucket counts it publishes alongside.
+//
+// Both are cast into the float domain first, for the reason
+// [expHistogramWindowFloatsExpr] documents: the fold differences
+// consecutive readings and a stored UInt64 Count would underflow a
+// legitimate negative difference into a colossal positive one.
+func expHistogramValuedWindowPassthrough(keys []chplan.Projection, fold histogramWindowTimeFold, s schema.Metrics) []chplan.Projection {
+	tsList := &chplan.ColumnRef{Name: hqWindowTsListAlias}
+	projs := make([]chplan.Projection, 0, len(keys)+2)
+	projs = append(projs, keys...)
+	return append(
+		projs,
+		chplan.Projection{
+			Expr:  fold(expHistogramWindowCountValuesExpr(), tsList),
+			Alias: s.CountColumn,
+		},
+		chplan.Projection{
+			Expr:  fold(expHistogramWindowFloatsExpr(&chplan.ColumnRef{Name: hqWindowSumArrayAlias}), tsList),
+			Alias: s.SumColumn,
+		},
+	)
+}

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -171,8 +171,9 @@ func LowerMetadataRange(ctx context.Context, expr parser.Expr, s schema.Metrics,
 // lowerRoot lowers the ROOT of a query expression. It is [lower] plus the
 // dispatches that can only be decided at the root: the shapes over an
 // exponential (native) histogram that return a HISTOGRAM-VALUED sample —
-// a bare selector and `sum [by/without] (<selector>)` — whose answer has
-// a wire representation only when the shape IS the whole query.
+// a bare selector, `sum [by/without] (<selector>)`, and
+// `rate`/`increase` over a range-vector selector — whose answer has a
+// wire representation only when the shape IS the whole query.
 //
 // The distinction cannot be made inside [lowerVectorSelector], because the
 // selector in `sum(m_exp_hist)` and the selector in `m_exp_hist` arrive
@@ -188,10 +189,13 @@ func LowerMetadataRange(ctx context.Context, expr parser.Expr, s schema.Metrics,
 // (issue #1967), and never widens the exemption by accident: a nested
 // selector never reaches this function.
 //
-// The two dispatches are ordered but not mutually exclusive in principle,
-// and the order is arbitrary: [bareExpHistogramSelector] and
-// [sumOverExpHistogram] recognise disjoint root node types (a selector vs
-// an aggregation), so neither can shadow the other.
+// The three dispatches are ordered but not mutually exclusive in
+// principle, and the order is arbitrary: [bareExpHistogramSelector],
+// [sumOverExpHistogram] and [rateOverExpHistogram] recognise disjoint
+// root node types (a selector, an aggregation, a range-vector call), so
+// none can shadow another. [rateOverExpHistogram] additionally refuses an
+// aggregation WRAPPER, so `sum(rate(...))` — which needs both reductions
+// — matches neither it nor [sumOverExpHistogram] and stays rejected.
 //
 // Metadata lowering ([LowerMetadataRange]) deliberately does NOT route
 // through here: it enumerates series and labels rather than evaluating an
@@ -203,6 +207,9 @@ func lowerRoot(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (chplan.Node, e
 	}
 	if agg, vs, ok := sumOverExpHistogram(expr, s, ctx); ok {
 		return lowerExpHistogramSum(agg, vs, s, ctx)
+	}
+	if shape, ok := rateOverExpHistogram(expr, s, ctx); ok {
+		return lowerExpHistogramRate(shape, s, ctx)
 	}
 	return lower(expr, s, ctx)
 }
@@ -411,7 +418,7 @@ func lowerHistogramSelectorInput(
 //
 // When ok is true and err is non-nil, every other shape over a pinned
 // exp-histogram selector — one wrapped in
-// rate()/resets()/changes()/sum()/avg()/arithmetic/etc. — has no scalar
+// resets()/changes()/avg()/arithmetic/etc. — has no scalar
 // Value column to read: the exp-histogram row shape (Sum/Count/Scale/
 // PositiveCounts/NegativeCounts) is disjoint from the Sample contract
 // these functions reduce over. histogram_quantile()/histogram_count()/
@@ -422,15 +429,17 @@ func lowerHistogramSelectorInput(
 // err rejects it explicitly rather than silently matching zero rows
 // against the Gauge/Sum tables.
 //
-// Two shapes no longer reach here at all: a BARE selector, and `sum
-// [by/without] (<selector>)`. Both return a histogram-valued sample,
-// which [lowerRoot] answers with a chplan.HistogramProjection before the
-// recursive descent that leads to lowerVectorSelector ever starts. That
-// is the whole of the narrowing — the selector nested under anything
-// ELSE still arrives here and is still rejected, because nothing above
-// it can consume a histogram row yet (issue #1967). `sum()` is the one
-// reducer exempt so far precisely because it does not read a Value: it
-// adds the bucket ladders themselves.
+// Three shapes no longer reach here at all: a BARE selector, `sum
+// [by/without] (<selector>)`, and `rate`/`increase` over a range-vector
+// selector. All three return a histogram-valued sample, which [lowerRoot]
+// answers with a chplan.HistogramProjection before the recursive descent
+// that leads to lowerVectorSelector ever starts. That is the whole of the
+// narrowing — the selector nested under anything ELSE still arrives here
+// and is still rejected, because nothing above it can consume a histogram
+// row. Each exempt shape earns its exemption by not reading a Value:
+// `sum()` adds the bucket ladders themselves, and `rate`/`increase`
+// difference them across time. `sum(rate(...))`, which stacks the two
+// reductions, is answered by neither and still arrives here.
 //
 // Metadata enumeration (/series, /labels — ctx.metadataFullRange) is
 // exempted: it doesn't consume a Value column, only MetricName +

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -455,8 +455,9 @@ func expHistogramSelectorRouting(metricName string, s schema.Metrics, ctx lowerC
 	if s.IsExpHistogramMetric(metricName) && !ctx.metadataFullRange {
 		return nil, nil, "", "", true, fmt.Errorf(
 			"promql: %q is an exponential histogram metric; only a bare %q selector, "+
-				"sum() over one, histogram_quantile(), histogram_count(), histogram_sum(), "+
-				"and the %q/%q companion selectors are supported",
+				"sum() over one, rate()/increase() over one, histogram_quantile(), "+
+				"histogram_count(), histogram_sum(), and the %q/%q companion selectors "+
+				"are supported",
 			metricName, metricName, metricName+"_count", metricName+"_sum",
 		)
 	}

--- a/test/perf/cardinality-baseline/promql/exp_histogram_increase_boundary.json
+++ b/test/perf/cardinality-baseline/promql/exp_histogram_increase_boundary.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/exp_histogram_increase_boundary",
+  "fan_factor": 1,
+  "scan_rows": 5,
+  "peak_intermediate": 5,
+  "has_cross_join": false,
+  "has_array_join": false,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/cardinality-baseline/promql/exp_histogram_increase_reset.json
+++ b/test/perf/cardinality-baseline/promql/exp_histogram_increase_reset.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/exp_histogram_increase_reset",
+  "fan_factor": 1,
+  "scan_rows": 6,
+  "peak_intermediate": 6,
+  "has_cross_join": false,
+  "has_array_join": false,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/cardinality-baseline/promql/exp_histogram_rate.json
+++ b/test/perf/cardinality-baseline/promql/exp_histogram_rate.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/exp_histogram_rate",
+  "fan_factor": 1,
+  "scan_rows": 2,
+  "peak_intermediate": 2,
+  "has_cross_join": false,
+  "has_array_join": false,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/cardinality-baseline/promql/exp_histogram_rate_range.json
+++ b/test/perf/cardinality-baseline/promql/exp_histogram_rate_range.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/exp_histogram_rate_range",
+  "fan_factor": 6,
+  "scan_rows": 9,
+  "peak_intermediate": 54,
+  "has_cross_join": false,
+  "has_array_join": true,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/solver-decision-baseline/exp_histogram_increase_boundary.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_increase_boundary.json
@@ -1,0 +1,10 @@
+{
+  "query": "exp_histogram_increase_boundary",
+  "routed": false,
+  "k": 0,
+  "reason": "not-sliceable",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "5m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/exp_histogram_increase_reset.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_increase_reset.json
@@ -1,0 +1,10 @@
+{
+  "query": "exp_histogram_increase_reset",
+  "routed": false,
+  "k": 0,
+  "reason": "not-sliceable",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "5m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/exp_histogram_rate.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_rate.json
@@ -1,0 +1,10 @@
+{
+  "query": "exp_histogram_rate",
+  "routed": false,
+  "k": 0,
+  "reason": "not-sliceable",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "5m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/exp_histogram_rate_range.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_rate_range.json
@@ -1,0 +1,10 @@
+{
+  "query": "exp_histogram_rate_range",
+  "routed": false,
+  "k": 0,
+  "reason": "not-sliceable",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "5m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/rejection-parity/catalogue/internal__promql__lower.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__lower.go.json
@@ -73,10 +73,10 @@
     },
     {
       "head": "promql",
-      "site": "internal/promql/lower.go:expHistogramSelectorRouting#554bf4d3",
-      "message": "promql: %q is an exponential histogram metric; only a bare %q selector, sum() over one, histogram_quantile(), histogram_count(), histogram_sum(), and the %q/%q companion selectors are supported",
+      "site": "internal/promql/lower.go:expHistogramSelectorRouting#609f45fd",
+      "message": "promql: %q is an exponential histogram metric; only a bare %q selector, sum() over one, rate()/increase() over one, histogram_quantile(), histogram_count(), histogram_sum(), and the %q/%q companion selectors are supported",
       "class": "divergence",
-      "trigger_query": "rate(demo_latency_exp_hist[5m])",
+      "trigger_query": "avg(demo_latency_exp_hist)",
       "tracking_issue": 1772,
       "evidence": {
         "guard": [

--- a/test/rejection-parity/catalogue/internal__promql__modifiers.go.json
+++ b/test/rejection-parity/catalogue/internal__promql__modifiers.go.json
@@ -13,6 +13,7 @@
         ],
         "callers": [
           "andInstantWindow",
+          "expHistogramRateWindowed",
           "lowerAbsentOverTime",
           "lowerHistogramQuantileAgg",
           "lowerHistogramQuantileNativeAgg",
@@ -42,6 +43,7 @@
         ],
         "callers": [
           "andInstantWindow",
+          "expHistogramRateWindowed",
           "lowerAbsentOverTime",
           "lowerHistogramQuantileAgg",
           "lowerHistogramQuantileNativeAgg",
@@ -70,6 +72,7 @@
         ],
         "callers": [
           "andInstantWindow",
+          "expHistogramRateWindowed",
           "lowerAbsentOverTime",
           "lowerHistogramQuantileAgg",
           "lowerHistogramQuantileNativeAgg",

--- a/test/spec/promql/exp_histogram_increase_boundary.txtar
+++ b/test/spec/promql/exp_histogram_increase_boundary.txtar
@@ -1,0 +1,324 @@
+-- query.promql --
+increase(latency_exp_hist[5m])
+-- seed --
+CREATE TABLE otel_metrics_exponential_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    Scale Int32,
+    ZeroCount UInt64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64),
+    NegativeOffset Int32,
+    NegativeBucketCounts Array(UInt64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+-- The boundary-extrapolation shape, which has caught real bugs twice
+-- (#1958 for the whole correction, then for the durationToZero clamp
+-- inside it). Two series with the SAME window increase but DIFFERENT
+-- scrape cadences, so each computes its OWN factor — a per-query factor
+-- would answer both alike and is exactly what this fixture refuses.
+--
+-- The evaluation anchor is 00:00:01, so [5m] spans (23:55:01, 00:00:01].
+-- Both series increase by Count 8 across their window; only the
+-- extrapolation separates them.
+--
+-- `fast` — three scrapes 30s apart, the THRESHOLD clamp binds:
+--   sampledInterval = 00:00:01 - 23:59:01           = 60s
+--   averageDurationBetweenSamples = 60 / (3-1)      = 30s
+--   extrapolationThreshold = 30 * 1.1               = 33s
+--   durationToStart raw = 23:59:01 - 23:55:01 = 240s >= 33 -> 15s
+--   durationToZero = 60 * (4/8) = 30s, not < 15 -> stays 15s
+--   durationToEnd = 0s
+--   factor = (60 + 15 + 0) / 60                     = 1.25
+--   increase = Count 8*1.25 = 10, Sum 4.0*1.25 = 5,
+--              buckets [2*1.25, 6*1.25] = [2.5, 7.5]
+--
+-- `slow` — two scrapes 240s apart, the ZERO-CROSSING clamp binds. Its
+-- first sample sits well inside the window, so the threshold clamp never
+-- fires (60 < 264) and durationToZero is what caps the extrapolation —
+-- a counter cannot have been negative 60s before a window it entered at
+-- a count of 1:
+--   sampledInterval = 00:00:01 - 23:56:01           = 240s
+--   averageDurationBetweenSamples = 240 / (2-1)     = 240s
+--   extrapolationThreshold = 240 * 1.1              = 264s
+--   durationToStart raw = 23:56:01 - 23:55:01 = 60s < 264 -> stays 60s
+--   durationToZero = 240 * (1/8) = 30s, 30 < 60 -> durationToStart = 30s
+--   durationToEnd = 0s
+--   factor = (240 + 30 + 0) / 240                   = 1.125
+--   increase = Count 8*1.125 = 9, Sum 4.0*1.125 = 4.5,
+--              buckets [4*1.125, 4*1.125] = [4.5, 4.5]
+INSERT INTO otel_metrics_exponential_histogram VALUES
+    ('latency_exp_hist', map('service', 'fast'), toDateTime64('2025-12-31 23:59:01', 9),  4, 2.0, 0, 0, 0, [1, 3], 0, []),
+    ('latency_exp_hist', map('service', 'fast'), toDateTime64('2025-12-31 23:59:31', 9),  8, 4.0, 0, 0, 0, [2, 6], 0, []),
+    ('latency_exp_hist', map('service', 'fast'), toDateTime64('2026-01-01 00:00:01', 9), 12, 6.0, 0, 0, 0, [3, 9], 0, []),
+    ('latency_exp_hist', map('service', 'slow'), toDateTime64('2025-12-31 23:56:01', 9),  1, 0.5, 0, 0, 0, [0, 1], 0, []),
+    ('latency_exp_hist', map('service', 'slow'), toDateTime64('2026-01-01 00:00:01', 9),  9, 4.5, 0, 0, 0, [4, 5], 0, []);
+-- expected_rows --
+[
+  ["", {"service": "fast"}, "2026-01-01T00:00:01Z", 0, 10, 5, 0, 0, 0, 0, [2.5,7.5], 0, []],
+  ["", {"service": "slow"}, "2026-01-01T00:00:01Z", 0, 9, 4.5, 0, 0, 0, 0, [4.5,4.5], 0, []]
+]
+-- args --
+[0] string = ""
+[1] int64 = 9
+[2] float64 = 0
+[3] int64 = 1
+[4] int64 = 0
+[5] int64 = 0
+[6] int64 = 1
+[7] int64 = 0
+[8] int64 = 1
+[9] string = "nanosecond"
+[10] string = "2026-01-01 00:00:01.000000000"
+[11] int64 = 9
+[12] float64 = 1e+09
+[13] float64 = 1.1
+[14] float64 = 2
+[15] string = "nanosecond"
+[16] string = "2026-01-01 00:00:01.000000000"
+[17] int64 = 9
+[18] float64 = 1e+09
+[19] float64 = 1
+[20] int64 = 1
+[21] int64 = 1
+[22] string = "nanosecond"
+[23] string = "2026-01-01 00:00:01.000000000"
+[24] int64 = 9
+[25] int64 = 300000000000
+[26] int64 = 1
+[27] float64 = 1e+09
+[28] float64 = 1.1
+[29] float64 = 2
+[30] string = "nanosecond"
+[31] string = "2026-01-01 00:00:01.000000000"
+[32] int64 = 9
+[33] int64 = 300000000000
+[34] int64 = 1
+[35] float64 = 1e+09
+[36] int64 = 1
+[37] int64 = 1
+[38] int64 = 1
+[39] string = "nanosecond"
+[40] int64 = 1
+[41] float64 = 1e+09
+[42] int64 = 1
+[43] int64 = 1
+[44] int64 = 1
+[45] int64 = 1
+[46] int64 = 1
+[47] int64 = 1
+[48] int64 = 0
+[49] int64 = 0
+[50] int64 = 1
+[51] int64 = 0
+[52] int64 = 1
+[53] string = "nanosecond"
+[54] string = "2026-01-01 00:00:01.000000000"
+[55] int64 = 9
+[56] float64 = 1e+09
+[57] float64 = 1.1
+[58] float64 = 2
+[59] string = "nanosecond"
+[60] string = "2026-01-01 00:00:01.000000000"
+[61] int64 = 9
+[62] float64 = 1e+09
+[63] float64 = 1
+[64] int64 = 1
+[65] int64 = 1
+[66] string = "nanosecond"
+[67] string = "2026-01-01 00:00:01.000000000"
+[68] int64 = 9
+[69] int64 = 300000000000
+[70] int64 = 1
+[71] float64 = 1e+09
+[72] float64 = 1.1
+[73] float64 = 2
+[74] string = "nanosecond"
+[75] string = "2026-01-01 00:00:01.000000000"
+[76] int64 = 9
+[77] int64 = 300000000000
+[78] int64 = 1
+[79] float64 = 1e+09
+[80] int64 = 1
+[81] int64 = 1
+[82] int64 = 1
+[83] string = "nanosecond"
+[84] int64 = 1
+[85] float64 = 1e+09
+[86] int64 = 1
+[87] int64 = 1
+[88] int64 = 1
+[89] int64 = 1
+[90] int64 = 1
+[91] int64 = 1
+[92] int64 = 0
+[93] int64 = 0
+[94] int64 = 1
+[95] int64 = 0
+[96] int64 = 1
+[97] string = "nanosecond"
+[98] string = "2026-01-01 00:00:01.000000000"
+[99] int64 = 9
+[100] float64 = 1e+09
+[101] float64 = 1.1
+[102] float64 = 2
+[103] string = "nanosecond"
+[104] string = "2026-01-01 00:00:01.000000000"
+[105] int64 = 9
+[106] float64 = 1e+09
+[107] float64 = 1
+[108] int64 = 1
+[109] int64 = 1
+[110] string = "nanosecond"
+[111] string = "2026-01-01 00:00:01.000000000"
+[112] int64 = 9
+[113] int64 = 300000000000
+[114] int64 = 1
+[115] float64 = 1e+09
+[116] float64 = 1.1
+[117] float64 = 2
+[118] string = "nanosecond"
+[119] string = "2026-01-01 00:00:01.000000000"
+[120] int64 = 9
+[121] int64 = 300000000000
+[122] int64 = 1
+[123] float64 = 1e+09
+[124] int64 = 1
+[125] int64 = 1
+[126] int64 = 1
+[127] string = "nanosecond"
+[128] int64 = 1
+[129] float64 = 1e+09
+[130] int64 = 1
+[131] int64 = 1
+[132] int64 = 1
+[133] int64 = 1
+[134] int64 = 1
+[135] int64 = 1
+[136] int64 = 0
+[137] int64 = 0
+[138] int64 = 1
+[139] int64 = 0
+[140] int64 = 1
+[141] string = "nanosecond"
+[142] string = "2026-01-01 00:00:01.000000000"
+[143] int64 = 9
+[144] float64 = 1e+09
+[145] float64 = 1.1
+[146] float64 = 2
+[147] string = "nanosecond"
+[148] string = "2026-01-01 00:00:01.000000000"
+[149] int64 = 9
+[150] float64 = 1e+09
+[151] float64 = 1
+[152] int64 = 1
+[153] int64 = 1
+[154] string = "nanosecond"
+[155] string = "2026-01-01 00:00:01.000000000"
+[156] int64 = 9
+[157] int64 = 300000000000
+[158] int64 = 1
+[159] float64 = 1e+09
+[160] float64 = 1.1
+[161] float64 = 2
+[162] string = "nanosecond"
+[163] string = "2026-01-01 00:00:01.000000000"
+[164] int64 = 9
+[165] int64 = 300000000000
+[166] int64 = 1
+[167] float64 = 1e+09
+[168] int64 = 1
+[169] int64 = 1
+[170] int64 = 1
+[171] string = "nanosecond"
+[172] int64 = 1
+[173] float64 = 1e+09
+[174] int64 = 1
+[175] int64 = 1
+[176] int64 = 1
+[177] int64 = 1
+[178] int64 = 1
+[179] int64 = 0
+[180] int64 = 1
+[181] int64 = 0
+[182] int64 = 1
+[183] int64 = 1
+[184] int64 = 1
+[185] int64 = 0
+[186] int64 = 0
+[187] int64 = 1
+[188] int64 = 0
+[189] int64 = 1
+[190] string = "nanosecond"
+[191] string = "2026-01-01 00:00:01.000000000"
+[192] int64 = 9
+[193] float64 = 1e+09
+[194] float64 = 1.1
+[195] float64 = 2
+[196] string = "nanosecond"
+[197] string = "2026-01-01 00:00:01.000000000"
+[198] int64 = 9
+[199] float64 = 1e+09
+[200] float64 = 1
+[201] int64 = 1
+[202] int64 = 1
+[203] string = "nanosecond"
+[204] string = "2026-01-01 00:00:01.000000000"
+[205] int64 = 9
+[206] int64 = 300000000000
+[207] int64 = 1
+[208] float64 = 1e+09
+[209] float64 = 1.1
+[210] float64 = 2
+[211] string = "nanosecond"
+[212] string = "2026-01-01 00:00:01.000000000"
+[213] int64 = 9
+[214] int64 = 300000000000
+[215] int64 = 1
+[216] float64 = 1e+09
+[217] int64 = 1
+[218] int64 = 1
+[219] int64 = 1
+[220] string = "nanosecond"
+[221] int64 = 1
+[222] float64 = 1e+09
+[223] int64 = 1
+[224] int64 = 1
+[225] int64 = 1
+[226] int64 = 1
+[227] int64 = 1
+[228] int64 = 0
+[229] int64 = 1
+[230] int64 = 0
+[231] int64 = 1
+[232] int64 = 1
+[233] string = "service.name"
+[234] string = "service_name"
+[235] string = "service.name"
+[236] string = "service_name"
+[237] string = ""
+[238] string = "service_name"
+[239] string = "latency_exp_hist"
+[240] string = "latency.exp.hist"
+[241] string = "latency.exp/hist"
+[242] string = "latency.exp_hist"
+[243] string = "latency/exp/hist"
+[244] string = "latency/exp_hist"
+[245] string = "latency_exp.hist"
+[246] string = "2026-01-01 00:00:01.000000000"
+[247] int64 = 9
+[248] string = "2026-01-01 00:00:01.000000000"
+[249] int64 = 9
+[250] int64 = 300000000000
+[251] int64 = 2
+-- chplan --
+HistogramProjection project=["" AS MetricName, Attributes AS Attributes, now64(9) AS TimeUnix, 0 AS Value]
+  Project [Attributes AS Attributes, arrayMap(wv -> arrayMap(wo -> (arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wv, wo)))[1] * arrayMap(wcv -> arrayMap(wso -> arrayMap(wsi -> arrayMap(wag -> arrayMap(wtc -> arrayMap(wrc -> if((wsi > 0), (((wsi + if((if((wrc > 0), (wsi * (arraySort((c, t) -> t, wcv, wo)[1] / wrc)), wtc) < wtc), if((wrc > 0), (wsi * (arraySort((c, t) -> t, wcv, wo)[1] / wrc)), wtc), wtc)) + if(((toFloat64(dateDiff("nanosecond", wso[length(wso)], toDateTime64("2026-01-01 00:00:01.000000000", 9))) / 1e+09) >= (1.1 * wag)), (wag / 2), (toFloat64(dateDiff("nanosecond", wso[length(wso)], toDateTime64("2026-01-01 00:00:01.000000000", 9))) / 1e+09))) / wsi), 1), array(arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wcv, wo)))[1]))[1], array(if(((toFloat64(dateDiff("nanosecond", (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000)), wso[1])) / 1e+09) >= (1.1 * wag)), (wag / 2), (toFloat64(dateDiff("nanosecond", (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000)), wso[1])) / 1e+09))))[1], array((wsi / (length(wo) - 1))))[1], array((toFloat64(dateDiff("nanosecond", wso[1], wso[length(wso)])) / 1e+09)))[1], array(arraySort(wo)))[1], array(arrayMap(n -> toFloat64(n), _hq_count_list)))[1]), array(_hq_ts_list))[1], array(arrayMap(n -> toFloat64(n), _hq_count_list)))[1] AS Count, arrayMap(wv -> arrayMap(wo -> (arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wv, wo)))[1] * arrayMap(wcv -> arrayMap(wso -> arrayMap(wsi -> arrayMap(wag -> arrayMap(wtc -> arrayMap(wrc -> if((wsi > 0), (((wsi + if((if((wrc > 0), (wsi * (arraySort((c, t) -> t, wcv, wo)[1] / wrc)), wtc) < wtc), if((wrc > 0), (wsi * (arraySort((c, t) -> t, wcv, wo)[1] / wrc)), wtc), wtc)) + if(((toFloat64(dateDiff("nanosecond", wso[length(wso)], toDateTime64("2026-01-01 00:00:01.000000000", 9))) / 1e+09) >= (1.1 * wag)), (wag / 2), (toFloat64(dateDiff("nanosecond", wso[length(wso)], toDateTime64("2026-01-01 00:00:01.000000000", 9))) / 1e+09))) / wsi), 1), array(arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wcv, wo)))[1]))[1], array(if(((toFloat64(dateDiff("nanosecond", (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000)), wso[1])) / 1e+09) >= (1.1 * wag)), (wag / 2), (toFloat64(dateDiff("nanosecond", (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000)), wso[1])) / 1e+09))))[1], array((wsi / (length(wo) - 1))))[1], array((toFloat64(dateDiff("nanosecond", wso[1], wso[length(wso)])) / 1e+09)))[1], array(arraySort(wo)))[1], array(arrayMap(n -> toFloat64(n), _hq_count_list)))[1]), array(_hq_ts_list))[1], array(arrayMap(n -> toFloat64(n), _hq_sum_list)))[1] AS Sum, _hq_merged_scale AS Scale, arrayMap(wv -> arrayMap(wo -> (arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wv, wo)))[1] * arrayMap(wcv -> arrayMap(wso -> arrayMap(wsi -> arrayMap(wag -> arrayMap(wtc -> arrayMap(wrc -> if((wsi > 0), (((wsi + if((if((wrc > 0), (wsi * (arraySort((c, t) -> t, wcv, wo)[1] / wrc)), wtc) < wtc), if((wrc > 0), (wsi * (arraySort((c, t) -> t, wcv, wo)[1] / wrc)), wtc), wtc)) + if(((toFloat64(dateDiff("nanosecond", wso[length(wso)], toDateTime64("2026-01-01 00:00:01.000000000", 9))) / 1e+09) >= (1.1 * wag)), (wag / 2), (toFloat64(dateDiff("nanosecond", wso[length(wso)], toDateTime64("2026-01-01 00:00:01.000000000", 9))) / 1e+09))) / wsi), 1), array(arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wcv, wo)))[1]))[1], array(if(((toFloat64(dateDiff("nanosecond", (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000)), wso[1])) / 1e+09) >= (1.1 * wag)), (wag / 2), (toFloat64(dateDiff("nanosecond", (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000)), wso[1])) / 1e+09))))[1], array((wsi / (length(wo) - 1))))[1], array((toFloat64(dateDiff("nanosecond", wso[1], wso[length(wso)])) / 1e+09)))[1], array(arraySort(wo)))[1], array(arrayMap(n -> toFloat64(n), _hq_count_list)))[1]), array(_hq_ts_list))[1], array(arrayMap(n -> toFloat64(n), _hq_zero_counts)))[1] AS ZeroCount, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - _hq_merged_scale)), _hq_scales, _hq_pos_offsets)) AS PositiveOffset, arrayMap(tb -> arrayMap(wv -> arrayMap(wo -> (arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wv, wo)))[1] * arrayMap(wcv -> arrayMap(wso -> arrayMap(wsi -> arrayMap(wag -> arrayMap(wtc -> arrayMap(wrc -> if((wsi > 0), (((wsi + if((if((wrc > 0), (wsi * (arraySort((c, t) -> t, wcv, wo)[1] / wrc)), wtc) < wtc), if((wrc > 0), (wsi * (arraySort((c, t) -> t, wcv, wo)[1] / wrc)), wtc), wtc)) + if(((toFloat64(dateDiff("nanosecond", wso[length(wso)], toDateTime64("2026-01-01 00:00:01.000000000", 9))) / 1e+09) >= (1.1 * wag)), (wag / 2), (toFloat64(dateDiff("nanosecond", wso[length(wso)], toDateTime64("2026-01-01 00:00:01.000000000", 9))) / 1e+09))) / wsi), 1), array(arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wcv, wo)))[1]))[1], array(if(((toFloat64(dateDiff("nanosecond", (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000)), wso[1])) / 1e+09) >= (1.1 * wag)), (wag / 2), (toFloat64(dateDiff("nanosecond", (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000)), wso[1])) / 1e+09))))[1], array((wsi / (length(wo) - 1))))[1], array((toFloat64(dateDiff("nanosecond", wso[1], wso[length(wso)])) / 1e+09)))[1], array(arraySort(wo)))[1], array(arrayMap(n -> toFloat64(n), _hq_count_list)))[1]), array(_hq_ts_list))[1], array(arrayMap(n -> toFloat64(n), arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - 1)), (s - _hq_merged_scale)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets)) + tb)), arr[j], 0), arrayEnumerate(arr))), _hq_scales, _hq_pos_offsets, _hq_pos_buckets))))[1], range(toUInt64(greatest(0, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - 1)), (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets, _hq_pos_buckets)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets))) + 1))))) AS PositiveBucketCounts, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - _hq_merged_scale)), _hq_scales, _hq_neg_offsets)) AS NegativeOffset, arrayMap(tb -> arrayMap(wv -> arrayMap(wo -> (arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wv, wo)))[1] * arrayMap(wcv -> arrayMap(wso -> arrayMap(wsi -> arrayMap(wag -> arrayMap(wtc -> arrayMap(wrc -> if((wsi > 0), (((wsi + if((if((wrc > 0), (wsi * (arraySort((c, t) -> t, wcv, wo)[1] / wrc)), wtc) < wtc), if((wrc > 0), (wsi * (arraySort((c, t) -> t, wcv, wo)[1] / wrc)), wtc), wtc)) + if(((toFloat64(dateDiff("nanosecond", wso[length(wso)], toDateTime64("2026-01-01 00:00:01.000000000", 9))) / 1e+09) >= (1.1 * wag)), (wag / 2), (toFloat64(dateDiff("nanosecond", wso[length(wso)], toDateTime64("2026-01-01 00:00:01.000000000", 9))) / 1e+09))) / wsi), 1), array(arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wcv, wo)))[1]))[1], array(if(((toFloat64(dateDiff("nanosecond", (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000)), wso[1])) / 1e+09) >= (1.1 * wag)), (wag / 2), (toFloat64(dateDiff("nanosecond", (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000)), wso[1])) / 1e+09))))[1], array((wsi / (length(wo) - 1))))[1], array((toFloat64(dateDiff("nanosecond", wso[1], wso[length(wso)])) / 1e+09)))[1], array(arraySort(wo)))[1], array(arrayMap(n -> toFloat64(n), _hq_count_list)))[1]), array(_hq_ts_list))[1], array(arrayMap(n -> toFloat64(n), arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - 1)), (s - _hq_merged_scale)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets)) + tb)), arr[j], 0), arrayEnumerate(arr))), _hq_scales, _hq_neg_offsets, _hq_neg_buckets))))[1], range(toUInt64(greatest(0, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - 1)), (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets, _hq_neg_buckets)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets))) + 1))))) AS NegativeBucketCounts]
+    Filter predicate=(_hq_samples >= 2)
+      Aggregate groupBy=[mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes] funcs=[min(Scale) AS _hq_merged_scale, groupArray(Scale) AS _hq_scales, groupArray(ZeroCount) AS _hq_zero_counts, groupArray(Count) AS _hq_count_list, groupArray(PositiveOffset) AS _hq_pos_offsets, groupArray(PositiveBucketCounts) AS _hq_pos_buckets, groupArray(NegativeOffset) AS _hq_neg_offsets, groupArray(NegativeBucketCounts) AS _hq_neg_buckets, groupArray(TimeUnix) AS _hq_ts_list, groupArray(Sum) AS _hq_sum_list, uniqExact(TimeUnix) AS _hq_samples]
+        Filter predicate=(((MetricName IN ("latency_exp_hist", "latency.exp.hist", "latency.exp/hist", "latency.exp_hist", "latency/exp/hist", "latency/exp_hist", "latency_exp.hist")) AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+          Scan(otel_metrics_exponential_histogram)
+-- sql --
+SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, toFloat64(?) AS `Value`, `Count` AS `HistogramCount`, `Sum` AS `HistogramSum`, `Scale` AS `HistogramScale`, 0. AS `HistogramZeroThreshold`, `ZeroCount` AS `HistogramZeroCount`, `PositiveOffset` AS `HistogramPositiveOffset`, `PositiveBucketCounts` AS `HistogramPositiveBucketCounts`, `NegativeOffset` AS `HistogramNegativeOffset`, `NegativeBucketCounts` AS `HistogramNegativeBucketCounts` FROM (SELECT `Attributes` AS `Attributes`, arrayMap(wv -> arrayMap(wo -> (arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wv, wo)))[?] * arrayMap(wcv -> arrayMap(wso -> arrayMap(wsi -> arrayMap(wag -> arrayMap(wtc -> arrayMap(wrc -> if((wsi > ?), (((wsi + if((if((wrc > ?), (wsi * (arraySort((c, t) -> t, wcv, wo)[?] / wrc)), wtc) < wtc), if((wrc > ?), (wsi * (arraySort((c, t) -> t, wcv, wo)[?] / wrc)), wtc), wtc)) + if(((toFloat64(dateDiff(?, wso[length(wso)], toDateTime64(?, ?))) / toFloat64(?)) >= (toFloat64(?) * wag)), (wag / toFloat64(?)), (toFloat64(dateDiff(?, wso[length(wso)], toDateTime64(?, ?))) / toFloat64(?)))) / wsi), toFloat64(?)), array(arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wcv, wo)))[?]))[?], array(if(((toFloat64(dateDiff(?, (toDateTime64(?, ?) - toIntervalNanosecond(?)), wso[?])) / toFloat64(?)) >= (toFloat64(?) * wag)), (wag / toFloat64(?)), (toFloat64(dateDiff(?, (toDateTime64(?, ?) - toIntervalNanosecond(?)), wso[?])) / toFloat64(?)))))[?], array((wsi / (length(wo) - ?))))[?], array((toFloat64(dateDiff(?, wso[?], wso[length(wso)])) / toFloat64(?))))[?], array(arraySort(wo)))[?], array(arrayMap(n -> toFloat64(n), `_hq_count_list`)))[?]), array(`_hq_ts_list`))[?], array(arrayMap(n -> toFloat64(n), `_hq_count_list`)))[?] AS `Count`, arrayMap(wv -> arrayMap(wo -> (arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wv, wo)))[?] * arrayMap(wcv -> arrayMap(wso -> arrayMap(wsi -> arrayMap(wag -> arrayMap(wtc -> arrayMap(wrc -> if((wsi > ?), (((wsi + if((if((wrc > ?), (wsi * (arraySort((c, t) -> t, wcv, wo)[?] / wrc)), wtc) < wtc), if((wrc > ?), (wsi * (arraySort((c, t) -> t, wcv, wo)[?] / wrc)), wtc), wtc)) + if(((toFloat64(dateDiff(?, wso[length(wso)], toDateTime64(?, ?))) / toFloat64(?)) >= (toFloat64(?) * wag)), (wag / toFloat64(?)), (toFloat64(dateDiff(?, wso[length(wso)], toDateTime64(?, ?))) / toFloat64(?)))) / wsi), toFloat64(?)), array(arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wcv, wo)))[?]))[?], array(if(((toFloat64(dateDiff(?, (toDateTime64(?, ?) - toIntervalNanosecond(?)), wso[?])) / toFloat64(?)) >= (toFloat64(?) * wag)), (wag / toFloat64(?)), (toFloat64(dateDiff(?, (toDateTime64(?, ?) - toIntervalNanosecond(?)), wso[?])) / toFloat64(?)))))[?], array((wsi / (length(wo) - ?))))[?], array((toFloat64(dateDiff(?, wso[?], wso[length(wso)])) / toFloat64(?))))[?], array(arraySort(wo)))[?], array(arrayMap(n -> toFloat64(n), `_hq_count_list`)))[?]), array(`_hq_ts_list`))[?], array(arrayMap(n -> toFloat64(n), `_hq_sum_list`)))[?] AS `Sum`, `_hq_merged_scale` AS `Scale`, arrayMap(wv -> arrayMap(wo -> (arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wv, wo)))[?] * arrayMap(wcv -> arrayMap(wso -> arrayMap(wsi -> arrayMap(wag -> arrayMap(wtc -> arrayMap(wrc -> if((wsi > ?), (((wsi + if((if((wrc > ?), (wsi * (arraySort((c, t) -> t, wcv, wo)[?] / wrc)), wtc) < wtc), if((wrc > ?), (wsi * (arraySort((c, t) -> t, wcv, wo)[?] / wrc)), wtc), wtc)) + if(((toFloat64(dateDiff(?, wso[length(wso)], toDateTime64(?, ?))) / toFloat64(?)) >= (toFloat64(?) * wag)), (wag / toFloat64(?)), (toFloat64(dateDiff(?, wso[length(wso)], toDateTime64(?, ?))) / toFloat64(?)))) / wsi), toFloat64(?)), array(arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wcv, wo)))[?]))[?], array(if(((toFloat64(dateDiff(?, (toDateTime64(?, ?) - toIntervalNanosecond(?)), wso[?])) / toFloat64(?)) >= (toFloat64(?) * wag)), (wag / toFloat64(?)), (toFloat64(dateDiff(?, (toDateTime64(?, ?) - toIntervalNanosecond(?)), wso[?])) / toFloat64(?)))))[?], array((wsi / (length(wo) - ?))))[?], array((toFloat64(dateDiff(?, wso[?], wso[length(wso)])) / toFloat64(?))))[?], array(arraySort(wo)))[?], array(arrayMap(n -> toFloat64(n), `_hq_count_list`)))[?]), array(`_hq_ts_list`))[?], array(arrayMap(n -> toFloat64(n), `_hq_zero_counts`)))[?] AS `ZeroCount`, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`)) AS `PositiveOffset`, arrayMap(tb -> arrayMap(wv -> arrayMap(wo -> (arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wv, wo)))[?] * arrayMap(wcv -> arrayMap(wso -> arrayMap(wsi -> arrayMap(wag -> arrayMap(wtc -> arrayMap(wrc -> if((wsi > ?), (((wsi + if((if((wrc > ?), (wsi * (arraySort((c, t) -> t, wcv, wo)[?] / wrc)), wtc) < wtc), if((wrc > ?), (wsi * (arraySort((c, t) -> t, wcv, wo)[?] / wrc)), wtc), wtc)) + if(((toFloat64(dateDiff(?, wso[length(wso)], toDateTime64(?, ?))) / toFloat64(?)) >= (toFloat64(?) * wag)), (wag / toFloat64(?)), (toFloat64(dateDiff(?, wso[length(wso)], toDateTime64(?, ?))) / toFloat64(?)))) / wsi), toFloat64(?)), array(arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wcv, wo)))[?]))[?], array(if(((toFloat64(dateDiff(?, (toDateTime64(?, ?) - toIntervalNanosecond(?)), wso[?])) / toFloat64(?)) >= (toFloat64(?) * wag)), (wag / toFloat64(?)), (toFloat64(dateDiff(?, (toDateTime64(?, ?) - toIntervalNanosecond(?)), wso[?])) / toFloat64(?)))))[?], array((wsi / (length(wo) - ?))))[?], array((toFloat64(dateDiff(?, wso[?], wso[length(wso)])) / toFloat64(?))))[?], array(arraySort(wo)))[?], array(arrayMap(n -> toFloat64(n), `_hq_count_list`)))[?]), array(`_hq_ts_list`))[?], array(arrayMap(n -> toFloat64(n), arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - ?)), (s - `_hq_merged_scale`)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`)) + tb)), arr[j], ?), arrayEnumerate(arr))), `_hq_scales`, `_hq_pos_offsets`, `_hq_pos_buckets`))))[?], range(toUInt64(greatest(?, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - ?)), (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`, `_hq_pos_buckets`)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`))) + ?))))) AS `PositiveBucketCounts`, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`)) AS `NegativeOffset`, arrayMap(tb -> arrayMap(wv -> arrayMap(wo -> (arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wv, wo)))[?] * arrayMap(wcv -> arrayMap(wso -> arrayMap(wsi -> arrayMap(wag -> arrayMap(wtc -> arrayMap(wrc -> if((wsi > ?), (((wsi + if((if((wrc > ?), (wsi * (arraySort((c, t) -> t, wcv, wo)[?] / wrc)), wtc) < wtc), if((wrc > ?), (wsi * (arraySort((c, t) -> t, wcv, wo)[?] / wrc)), wtc), wtc)) + if(((toFloat64(dateDiff(?, wso[length(wso)], toDateTime64(?, ?))) / toFloat64(?)) >= (toFloat64(?) * wag)), (wag / toFloat64(?)), (toFloat64(dateDiff(?, wso[length(wso)], toDateTime64(?, ?))) / toFloat64(?)))) / wsi), toFloat64(?)), array(arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wcv, wo)))[?]))[?], array(if(((toFloat64(dateDiff(?, (toDateTime64(?, ?) - toIntervalNanosecond(?)), wso[?])) / toFloat64(?)) >= (toFloat64(?) * wag)), (wag / toFloat64(?)), (toFloat64(dateDiff(?, (toDateTime64(?, ?) - toIntervalNanosecond(?)), wso[?])) / toFloat64(?)))))[?], array((wsi / (length(wo) - ?))))[?], array((toFloat64(dateDiff(?, wso[?], wso[length(wso)])) / toFloat64(?))))[?], array(arraySort(wo)))[?], array(arrayMap(n -> toFloat64(n), `_hq_count_list`)))[?]), array(`_hq_ts_list`))[?], array(arrayMap(n -> toFloat64(n), arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - ?)), (s - `_hq_merged_scale`)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`)) + tb)), arr[j], ?), arrayEnumerate(arr))), `_hq_scales`, `_hq_neg_offsets`, `_hq_neg_buckets`))))[?], range(toUInt64(greatest(?, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - ?)), (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`, `_hq_neg_buckets`)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`))) + ?))))) AS `NegativeBucketCounts` FROM (SELECT * FROM (SELECT mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, min(`Scale`) AS `_hq_merged_scale`, groupArray(`Scale`) AS `_hq_scales`, groupArray(`ZeroCount`) AS `_hq_zero_counts`, groupArray(`Count`) AS `_hq_count_list`, groupArray(`PositiveOffset`) AS `_hq_pos_offsets`, groupArray(`PositiveBucketCounts`) AS `_hq_pos_buckets`, groupArray(`NegativeOffset`) AS `_hq_neg_offsets`, groupArray(`NegativeBucketCounts`) AS `_hq_neg_buckets`, groupArray(`TimeUnix`) AS `_hq_ts_list`, groupArray(`Sum`) AS `_hq_sum_list`, uniqExact(`TimeUnix`) AS `_hq_samples` FROM (SELECT * FROM `otel_metrics_exponential_histogram` PREWHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?)) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `Attributes`) WHERE (`_hq_samples` >= ?)))

--- a/test/spec/promql/exp_histogram_increase_reset.txtar
+++ b/test/spec/promql/exp_histogram_increase_reset.txtar
@@ -1,0 +1,330 @@
+-- query.promql --
+increase(latency_exp_hist[5m])
+-- seed --
+CREATE TABLE otel_metrics_exponential_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    Scale Int32,
+    ZeroCount UInt64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64),
+    NegativeOffset Int32,
+    NegativeBucketCounts Array(UInt64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+-- Two series over the same three scrapes 60s apart. `api` RESTARTS
+-- between the second and third — every field drops together, which is
+-- what a real process restart looks like — and `web` runs clean, so one
+-- fixture pins both halves of the counter-reset rule.
+--
+-- The evaluation anchor is 00:00:01, so [5m] spans (23:55:01, 00:00:01]
+-- and holds all three scrapes of both series.
+--
+-- The reset rule sums consecutive deltas as `if(c < p, c, c - p)`, which
+-- telescopes to `last - first + <pre-reset reading>` — the same total
+-- reference reaches by subtracting the first sample and then adding the
+-- whole previous distribution back at the reset it detects:
+--
+--   api  Count      (20-10) + 4 = 14   == 4 - 10 + 20
+--        Sum      (10.0-5.0) + 2.0 = 7.0
+--        ZeroCount   (2-1) + 1 = 2
+--        buckets   [(8-4)+1, (10-5)+2] = [5, 7]
+--   web  Count      (12-6) + (18-12) = 12      (no reset: telescopes)
+--        Sum       (6.0-3.0) + (9.0-6.0) = 6.0
+--        ZeroCount  0
+--        buckets   [(4-2)+(6-4), (8-4)+(12-8)] = [4, 8]
+--
+-- Boundary extrapolation, computed per SERIES but identical here since
+-- both share one cadence and one phase:
+--   sampledInterval = 00:00:01 - 23:58:01           = 120s
+--   averageDurationBetweenSamples = 120 / (3-1)     = 60s
+--   extrapolationThreshold = 66s
+--   durationToStart raw = 23:58:01 - 23:55:01 = 180s >= 66 -> 30s
+--   durationToZero  api = 120 * (10/14) = 85.7s, not < 30 -> stays 30s
+--                   web = 120 * ( 6/12) = 60.0s, not < 30 -> stays 30s
+--   durationToEnd  = 0s
+--   factor = (120 + 30 + 0) / 120                   = 1.25
+--
+-- `increase` is the window total, NOT a per-second figure, so unlike
+-- `rate` it does not divide by the range — the factor is the whole of
+-- the scaling:
+--   api  Count 14*1.25 = 17.5, Sum 7.0*1.25 = 8.75,
+--        ZeroCount 2*1.25 = 2.5, buckets [5*1.25, 7*1.25] = [6.25, 8.75]
+--   web  Count 12*1.25 = 15,   Sum 6.0*1.25 = 7.5,
+--        ZeroCount 0,          buckets [4*1.25, 8*1.25] = [5, 10]
+INSERT INTO otel_metrics_exponential_histogram VALUES
+    ('latency_exp_hist', map('service', 'api'), toDateTime64('2025-12-31 23:58:01', 9), 10,  5.0, 0, 1, 0, [4,  5], 0, []),
+    ('latency_exp_hist', map('service', 'api'), toDateTime64('2025-12-31 23:59:01', 9), 20, 10.0, 0, 2, 0, [8, 10], 0, []),
+    ('latency_exp_hist', map('service', 'api'), toDateTime64('2026-01-01 00:00:01', 9),  4,  2.0, 0, 1, 0, [1,  2], 0, []),
+    ('latency_exp_hist', map('service', 'web'), toDateTime64('2025-12-31 23:58:01', 9),  6,  3.0, 0, 0, 0, [2,  4], 0, []),
+    ('latency_exp_hist', map('service', 'web'), toDateTime64('2025-12-31 23:59:01', 9), 12,  6.0, 0, 0, 0, [4,  8], 0, []),
+    ('latency_exp_hist', map('service', 'web'), toDateTime64('2026-01-01 00:00:01', 9), 18,  9.0, 0, 0, 0, [6, 12], 0, []);
+-- expected_rows --
+[
+  ["", {"service": "api"}, "2026-01-01T00:00:01Z", 0, 17.5, 8.75, 0, 0, 2.5, 0, [6.25,8.75], 0, []],
+  ["", {"service": "web"}, "2026-01-01T00:00:01Z", 0, 15, 7.5, 0, 0, 0, 0, [5,10], 0, []]
+]
+-- args --
+[0] string = ""
+[1] int64 = 9
+[2] float64 = 0
+[3] int64 = 1
+[4] int64 = 0
+[5] int64 = 0
+[6] int64 = 1
+[7] int64 = 0
+[8] int64 = 1
+[9] string = "nanosecond"
+[10] string = "2026-01-01 00:00:01.000000000"
+[11] int64 = 9
+[12] float64 = 1e+09
+[13] float64 = 1.1
+[14] float64 = 2
+[15] string = "nanosecond"
+[16] string = "2026-01-01 00:00:01.000000000"
+[17] int64 = 9
+[18] float64 = 1e+09
+[19] float64 = 1
+[20] int64 = 1
+[21] int64 = 1
+[22] string = "nanosecond"
+[23] string = "2026-01-01 00:00:01.000000000"
+[24] int64 = 9
+[25] int64 = 300000000000
+[26] int64 = 1
+[27] float64 = 1e+09
+[28] float64 = 1.1
+[29] float64 = 2
+[30] string = "nanosecond"
+[31] string = "2026-01-01 00:00:01.000000000"
+[32] int64 = 9
+[33] int64 = 300000000000
+[34] int64 = 1
+[35] float64 = 1e+09
+[36] int64 = 1
+[37] int64 = 1
+[38] int64 = 1
+[39] string = "nanosecond"
+[40] int64 = 1
+[41] float64 = 1e+09
+[42] int64 = 1
+[43] int64 = 1
+[44] int64 = 1
+[45] int64 = 1
+[46] int64 = 1
+[47] int64 = 1
+[48] int64 = 0
+[49] int64 = 0
+[50] int64 = 1
+[51] int64 = 0
+[52] int64 = 1
+[53] string = "nanosecond"
+[54] string = "2026-01-01 00:00:01.000000000"
+[55] int64 = 9
+[56] float64 = 1e+09
+[57] float64 = 1.1
+[58] float64 = 2
+[59] string = "nanosecond"
+[60] string = "2026-01-01 00:00:01.000000000"
+[61] int64 = 9
+[62] float64 = 1e+09
+[63] float64 = 1
+[64] int64 = 1
+[65] int64 = 1
+[66] string = "nanosecond"
+[67] string = "2026-01-01 00:00:01.000000000"
+[68] int64 = 9
+[69] int64 = 300000000000
+[70] int64 = 1
+[71] float64 = 1e+09
+[72] float64 = 1.1
+[73] float64 = 2
+[74] string = "nanosecond"
+[75] string = "2026-01-01 00:00:01.000000000"
+[76] int64 = 9
+[77] int64 = 300000000000
+[78] int64 = 1
+[79] float64 = 1e+09
+[80] int64 = 1
+[81] int64 = 1
+[82] int64 = 1
+[83] string = "nanosecond"
+[84] int64 = 1
+[85] float64 = 1e+09
+[86] int64 = 1
+[87] int64 = 1
+[88] int64 = 1
+[89] int64 = 1
+[90] int64 = 1
+[91] int64 = 1
+[92] int64 = 0
+[93] int64 = 0
+[94] int64 = 1
+[95] int64 = 0
+[96] int64 = 1
+[97] string = "nanosecond"
+[98] string = "2026-01-01 00:00:01.000000000"
+[99] int64 = 9
+[100] float64 = 1e+09
+[101] float64 = 1.1
+[102] float64 = 2
+[103] string = "nanosecond"
+[104] string = "2026-01-01 00:00:01.000000000"
+[105] int64 = 9
+[106] float64 = 1e+09
+[107] float64 = 1
+[108] int64 = 1
+[109] int64 = 1
+[110] string = "nanosecond"
+[111] string = "2026-01-01 00:00:01.000000000"
+[112] int64 = 9
+[113] int64 = 300000000000
+[114] int64 = 1
+[115] float64 = 1e+09
+[116] float64 = 1.1
+[117] float64 = 2
+[118] string = "nanosecond"
+[119] string = "2026-01-01 00:00:01.000000000"
+[120] int64 = 9
+[121] int64 = 300000000000
+[122] int64 = 1
+[123] float64 = 1e+09
+[124] int64 = 1
+[125] int64 = 1
+[126] int64 = 1
+[127] string = "nanosecond"
+[128] int64 = 1
+[129] float64 = 1e+09
+[130] int64 = 1
+[131] int64 = 1
+[132] int64 = 1
+[133] int64 = 1
+[134] int64 = 1
+[135] int64 = 1
+[136] int64 = 0
+[137] int64 = 0
+[138] int64 = 1
+[139] int64 = 0
+[140] int64 = 1
+[141] string = "nanosecond"
+[142] string = "2026-01-01 00:00:01.000000000"
+[143] int64 = 9
+[144] float64 = 1e+09
+[145] float64 = 1.1
+[146] float64 = 2
+[147] string = "nanosecond"
+[148] string = "2026-01-01 00:00:01.000000000"
+[149] int64 = 9
+[150] float64 = 1e+09
+[151] float64 = 1
+[152] int64 = 1
+[153] int64 = 1
+[154] string = "nanosecond"
+[155] string = "2026-01-01 00:00:01.000000000"
+[156] int64 = 9
+[157] int64 = 300000000000
+[158] int64 = 1
+[159] float64 = 1e+09
+[160] float64 = 1.1
+[161] float64 = 2
+[162] string = "nanosecond"
+[163] string = "2026-01-01 00:00:01.000000000"
+[164] int64 = 9
+[165] int64 = 300000000000
+[166] int64 = 1
+[167] float64 = 1e+09
+[168] int64 = 1
+[169] int64 = 1
+[170] int64 = 1
+[171] string = "nanosecond"
+[172] int64 = 1
+[173] float64 = 1e+09
+[174] int64 = 1
+[175] int64 = 1
+[176] int64 = 1
+[177] int64 = 1
+[178] int64 = 1
+[179] int64 = 0
+[180] int64 = 1
+[181] int64 = 0
+[182] int64 = 1
+[183] int64 = 1
+[184] int64 = 1
+[185] int64 = 0
+[186] int64 = 0
+[187] int64 = 1
+[188] int64 = 0
+[189] int64 = 1
+[190] string = "nanosecond"
+[191] string = "2026-01-01 00:00:01.000000000"
+[192] int64 = 9
+[193] float64 = 1e+09
+[194] float64 = 1.1
+[195] float64 = 2
+[196] string = "nanosecond"
+[197] string = "2026-01-01 00:00:01.000000000"
+[198] int64 = 9
+[199] float64 = 1e+09
+[200] float64 = 1
+[201] int64 = 1
+[202] int64 = 1
+[203] string = "nanosecond"
+[204] string = "2026-01-01 00:00:01.000000000"
+[205] int64 = 9
+[206] int64 = 300000000000
+[207] int64 = 1
+[208] float64 = 1e+09
+[209] float64 = 1.1
+[210] float64 = 2
+[211] string = "nanosecond"
+[212] string = "2026-01-01 00:00:01.000000000"
+[213] int64 = 9
+[214] int64 = 300000000000
+[215] int64 = 1
+[216] float64 = 1e+09
+[217] int64 = 1
+[218] int64 = 1
+[219] int64 = 1
+[220] string = "nanosecond"
+[221] int64 = 1
+[222] float64 = 1e+09
+[223] int64 = 1
+[224] int64 = 1
+[225] int64 = 1
+[226] int64 = 1
+[227] int64 = 1
+[228] int64 = 0
+[229] int64 = 1
+[230] int64 = 0
+[231] int64 = 1
+[232] int64 = 1
+[233] string = "service.name"
+[234] string = "service_name"
+[235] string = "service.name"
+[236] string = "service_name"
+[237] string = ""
+[238] string = "service_name"
+[239] string = "latency_exp_hist"
+[240] string = "latency.exp.hist"
+[241] string = "latency.exp/hist"
+[242] string = "latency.exp_hist"
+[243] string = "latency/exp/hist"
+[244] string = "latency/exp_hist"
+[245] string = "latency_exp.hist"
+[246] string = "2026-01-01 00:00:01.000000000"
+[247] int64 = 9
+[248] string = "2026-01-01 00:00:01.000000000"
+[249] int64 = 9
+[250] int64 = 300000000000
+[251] int64 = 2
+-- chplan --
+HistogramProjection project=["" AS MetricName, Attributes AS Attributes, now64(9) AS TimeUnix, 0 AS Value]
+  Project [Attributes AS Attributes, arrayMap(wv -> arrayMap(wo -> (arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wv, wo)))[1] * arrayMap(wcv -> arrayMap(wso -> arrayMap(wsi -> arrayMap(wag -> arrayMap(wtc -> arrayMap(wrc -> if((wsi > 0), (((wsi + if((if((wrc > 0), (wsi * (arraySort((c, t) -> t, wcv, wo)[1] / wrc)), wtc) < wtc), if((wrc > 0), (wsi * (arraySort((c, t) -> t, wcv, wo)[1] / wrc)), wtc), wtc)) + if(((toFloat64(dateDiff("nanosecond", wso[length(wso)], toDateTime64("2026-01-01 00:00:01.000000000", 9))) / 1e+09) >= (1.1 * wag)), (wag / 2), (toFloat64(dateDiff("nanosecond", wso[length(wso)], toDateTime64("2026-01-01 00:00:01.000000000", 9))) / 1e+09))) / wsi), 1), array(arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wcv, wo)))[1]))[1], array(if(((toFloat64(dateDiff("nanosecond", (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000)), wso[1])) / 1e+09) >= (1.1 * wag)), (wag / 2), (toFloat64(dateDiff("nanosecond", (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000)), wso[1])) / 1e+09))))[1], array((wsi / (length(wo) - 1))))[1], array((toFloat64(dateDiff("nanosecond", wso[1], wso[length(wso)])) / 1e+09)))[1], array(arraySort(wo)))[1], array(arrayMap(n -> toFloat64(n), _hq_count_list)))[1]), array(_hq_ts_list))[1], array(arrayMap(n -> toFloat64(n), _hq_count_list)))[1] AS Count, arrayMap(wv -> arrayMap(wo -> (arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wv, wo)))[1] * arrayMap(wcv -> arrayMap(wso -> arrayMap(wsi -> arrayMap(wag -> arrayMap(wtc -> arrayMap(wrc -> if((wsi > 0), (((wsi + if((if((wrc > 0), (wsi * (arraySort((c, t) -> t, wcv, wo)[1] / wrc)), wtc) < wtc), if((wrc > 0), (wsi * (arraySort((c, t) -> t, wcv, wo)[1] / wrc)), wtc), wtc)) + if(((toFloat64(dateDiff("nanosecond", wso[length(wso)], toDateTime64("2026-01-01 00:00:01.000000000", 9))) / 1e+09) >= (1.1 * wag)), (wag / 2), (toFloat64(dateDiff("nanosecond", wso[length(wso)], toDateTime64("2026-01-01 00:00:01.000000000", 9))) / 1e+09))) / wsi), 1), array(arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wcv, wo)))[1]))[1], array(if(((toFloat64(dateDiff("nanosecond", (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000)), wso[1])) / 1e+09) >= (1.1 * wag)), (wag / 2), (toFloat64(dateDiff("nanosecond", (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000)), wso[1])) / 1e+09))))[1], array((wsi / (length(wo) - 1))))[1], array((toFloat64(dateDiff("nanosecond", wso[1], wso[length(wso)])) / 1e+09)))[1], array(arraySort(wo)))[1], array(arrayMap(n -> toFloat64(n), _hq_count_list)))[1]), array(_hq_ts_list))[1], array(arrayMap(n -> toFloat64(n), _hq_sum_list)))[1] AS Sum, _hq_merged_scale AS Scale, arrayMap(wv -> arrayMap(wo -> (arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wv, wo)))[1] * arrayMap(wcv -> arrayMap(wso -> arrayMap(wsi -> arrayMap(wag -> arrayMap(wtc -> arrayMap(wrc -> if((wsi > 0), (((wsi + if((if((wrc > 0), (wsi * (arraySort((c, t) -> t, wcv, wo)[1] / wrc)), wtc) < wtc), if((wrc > 0), (wsi * (arraySort((c, t) -> t, wcv, wo)[1] / wrc)), wtc), wtc)) + if(((toFloat64(dateDiff("nanosecond", wso[length(wso)], toDateTime64("2026-01-01 00:00:01.000000000", 9))) / 1e+09) >= (1.1 * wag)), (wag / 2), (toFloat64(dateDiff("nanosecond", wso[length(wso)], toDateTime64("2026-01-01 00:00:01.000000000", 9))) / 1e+09))) / wsi), 1), array(arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wcv, wo)))[1]))[1], array(if(((toFloat64(dateDiff("nanosecond", (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000)), wso[1])) / 1e+09) >= (1.1 * wag)), (wag / 2), (toFloat64(dateDiff("nanosecond", (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000)), wso[1])) / 1e+09))))[1], array((wsi / (length(wo) - 1))))[1], array((toFloat64(dateDiff("nanosecond", wso[1], wso[length(wso)])) / 1e+09)))[1], array(arraySort(wo)))[1], array(arrayMap(n -> toFloat64(n), _hq_count_list)))[1]), array(_hq_ts_list))[1], array(arrayMap(n -> toFloat64(n), _hq_zero_counts)))[1] AS ZeroCount, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - _hq_merged_scale)), _hq_scales, _hq_pos_offsets)) AS PositiveOffset, arrayMap(tb -> arrayMap(wv -> arrayMap(wo -> (arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wv, wo)))[1] * arrayMap(wcv -> arrayMap(wso -> arrayMap(wsi -> arrayMap(wag -> arrayMap(wtc -> arrayMap(wrc -> if((wsi > 0), (((wsi + if((if((wrc > 0), (wsi * (arraySort((c, t) -> t, wcv, wo)[1] / wrc)), wtc) < wtc), if((wrc > 0), (wsi * (arraySort((c, t) -> t, wcv, wo)[1] / wrc)), wtc), wtc)) + if(((toFloat64(dateDiff("nanosecond", wso[length(wso)], toDateTime64("2026-01-01 00:00:01.000000000", 9))) / 1e+09) >= (1.1 * wag)), (wag / 2), (toFloat64(dateDiff("nanosecond", wso[length(wso)], toDateTime64("2026-01-01 00:00:01.000000000", 9))) / 1e+09))) / wsi), 1), array(arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wcv, wo)))[1]))[1], array(if(((toFloat64(dateDiff("nanosecond", (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000)), wso[1])) / 1e+09) >= (1.1 * wag)), (wag / 2), (toFloat64(dateDiff("nanosecond", (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000)), wso[1])) / 1e+09))))[1], array((wsi / (length(wo) - 1))))[1], array((toFloat64(dateDiff("nanosecond", wso[1], wso[length(wso)])) / 1e+09)))[1], array(arraySort(wo)))[1], array(arrayMap(n -> toFloat64(n), _hq_count_list)))[1]), array(_hq_ts_list))[1], array(arrayMap(n -> toFloat64(n), arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - 1)), (s - _hq_merged_scale)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets)) + tb)), arr[j], 0), arrayEnumerate(arr))), _hq_scales, _hq_pos_offsets, _hq_pos_buckets))))[1], range(toUInt64(greatest(0, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - 1)), (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets, _hq_pos_buckets)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets))) + 1))))) AS PositiveBucketCounts, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - _hq_merged_scale)), _hq_scales, _hq_neg_offsets)) AS NegativeOffset, arrayMap(tb -> arrayMap(wv -> arrayMap(wo -> (arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wv, wo)))[1] * arrayMap(wcv -> arrayMap(wso -> arrayMap(wsi -> arrayMap(wag -> arrayMap(wtc -> arrayMap(wrc -> if((wsi > 0), (((wsi + if((if((wrc > 0), (wsi * (arraySort((c, t) -> t, wcv, wo)[1] / wrc)), wtc) < wtc), if((wrc > 0), (wsi * (arraySort((c, t) -> t, wcv, wo)[1] / wrc)), wtc), wtc)) + if(((toFloat64(dateDiff("nanosecond", wso[length(wso)], toDateTime64("2026-01-01 00:00:01.000000000", 9))) / 1e+09) >= (1.1 * wag)), (wag / 2), (toFloat64(dateDiff("nanosecond", wso[length(wso)], toDateTime64("2026-01-01 00:00:01.000000000", 9))) / 1e+09))) / wsi), 1), array(arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wcv, wo)))[1]))[1], array(if(((toFloat64(dateDiff("nanosecond", (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000)), wso[1])) / 1e+09) >= (1.1 * wag)), (wag / 2), (toFloat64(dateDiff("nanosecond", (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000)), wso[1])) / 1e+09))))[1], array((wsi / (length(wo) - 1))))[1], array((toFloat64(dateDiff("nanosecond", wso[1], wso[length(wso)])) / 1e+09)))[1], array(arraySort(wo)))[1], array(arrayMap(n -> toFloat64(n), _hq_count_list)))[1]), array(_hq_ts_list))[1], array(arrayMap(n -> toFloat64(n), arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - 1)), (s - _hq_merged_scale)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets)) + tb)), arr[j], 0), arrayEnumerate(arr))), _hq_scales, _hq_neg_offsets, _hq_neg_buckets))))[1], range(toUInt64(greatest(0, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - 1)), (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets, _hq_neg_buckets)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets))) + 1))))) AS NegativeBucketCounts]
+    Filter predicate=(_hq_samples >= 2)
+      Aggregate groupBy=[mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes] funcs=[min(Scale) AS _hq_merged_scale, groupArray(Scale) AS _hq_scales, groupArray(ZeroCount) AS _hq_zero_counts, groupArray(Count) AS _hq_count_list, groupArray(PositiveOffset) AS _hq_pos_offsets, groupArray(PositiveBucketCounts) AS _hq_pos_buckets, groupArray(NegativeOffset) AS _hq_neg_offsets, groupArray(NegativeBucketCounts) AS _hq_neg_buckets, groupArray(TimeUnix) AS _hq_ts_list, groupArray(Sum) AS _hq_sum_list, uniqExact(TimeUnix) AS _hq_samples]
+        Filter predicate=(((MetricName IN ("latency_exp_hist", "latency.exp.hist", "latency.exp/hist", "latency.exp_hist", "latency/exp/hist", "latency/exp_hist", "latency_exp.hist")) AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+          Scan(otel_metrics_exponential_histogram)
+-- sql --
+SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, toFloat64(?) AS `Value`, `Count` AS `HistogramCount`, `Sum` AS `HistogramSum`, `Scale` AS `HistogramScale`, 0. AS `HistogramZeroThreshold`, `ZeroCount` AS `HistogramZeroCount`, `PositiveOffset` AS `HistogramPositiveOffset`, `PositiveBucketCounts` AS `HistogramPositiveBucketCounts`, `NegativeOffset` AS `HistogramNegativeOffset`, `NegativeBucketCounts` AS `HistogramNegativeBucketCounts` FROM (SELECT `Attributes` AS `Attributes`, arrayMap(wv -> arrayMap(wo -> (arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wv, wo)))[?] * arrayMap(wcv -> arrayMap(wso -> arrayMap(wsi -> arrayMap(wag -> arrayMap(wtc -> arrayMap(wrc -> if((wsi > ?), (((wsi + if((if((wrc > ?), (wsi * (arraySort((c, t) -> t, wcv, wo)[?] / wrc)), wtc) < wtc), if((wrc > ?), (wsi * (arraySort((c, t) -> t, wcv, wo)[?] / wrc)), wtc), wtc)) + if(((toFloat64(dateDiff(?, wso[length(wso)], toDateTime64(?, ?))) / toFloat64(?)) >= (toFloat64(?) * wag)), (wag / toFloat64(?)), (toFloat64(dateDiff(?, wso[length(wso)], toDateTime64(?, ?))) / toFloat64(?)))) / wsi), toFloat64(?)), array(arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wcv, wo)))[?]))[?], array(if(((toFloat64(dateDiff(?, (toDateTime64(?, ?) - toIntervalNanosecond(?)), wso[?])) / toFloat64(?)) >= (toFloat64(?) * wag)), (wag / toFloat64(?)), (toFloat64(dateDiff(?, (toDateTime64(?, ?) - toIntervalNanosecond(?)), wso[?])) / toFloat64(?)))))[?], array((wsi / (length(wo) - ?))))[?], array((toFloat64(dateDiff(?, wso[?], wso[length(wso)])) / toFloat64(?))))[?], array(arraySort(wo)))[?], array(arrayMap(n -> toFloat64(n), `_hq_count_list`)))[?]), array(`_hq_ts_list`))[?], array(arrayMap(n -> toFloat64(n), `_hq_count_list`)))[?] AS `Count`, arrayMap(wv -> arrayMap(wo -> (arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wv, wo)))[?] * arrayMap(wcv -> arrayMap(wso -> arrayMap(wsi -> arrayMap(wag -> arrayMap(wtc -> arrayMap(wrc -> if((wsi > ?), (((wsi + if((if((wrc > ?), (wsi * (arraySort((c, t) -> t, wcv, wo)[?] / wrc)), wtc) < wtc), if((wrc > ?), (wsi * (arraySort((c, t) -> t, wcv, wo)[?] / wrc)), wtc), wtc)) + if(((toFloat64(dateDiff(?, wso[length(wso)], toDateTime64(?, ?))) / toFloat64(?)) >= (toFloat64(?) * wag)), (wag / toFloat64(?)), (toFloat64(dateDiff(?, wso[length(wso)], toDateTime64(?, ?))) / toFloat64(?)))) / wsi), toFloat64(?)), array(arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wcv, wo)))[?]))[?], array(if(((toFloat64(dateDiff(?, (toDateTime64(?, ?) - toIntervalNanosecond(?)), wso[?])) / toFloat64(?)) >= (toFloat64(?) * wag)), (wag / toFloat64(?)), (toFloat64(dateDiff(?, (toDateTime64(?, ?) - toIntervalNanosecond(?)), wso[?])) / toFloat64(?)))))[?], array((wsi / (length(wo) - ?))))[?], array((toFloat64(dateDiff(?, wso[?], wso[length(wso)])) / toFloat64(?))))[?], array(arraySort(wo)))[?], array(arrayMap(n -> toFloat64(n), `_hq_count_list`)))[?]), array(`_hq_ts_list`))[?], array(arrayMap(n -> toFloat64(n), `_hq_sum_list`)))[?] AS `Sum`, `_hq_merged_scale` AS `Scale`, arrayMap(wv -> arrayMap(wo -> (arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wv, wo)))[?] * arrayMap(wcv -> arrayMap(wso -> arrayMap(wsi -> arrayMap(wag -> arrayMap(wtc -> arrayMap(wrc -> if((wsi > ?), (((wsi + if((if((wrc > ?), (wsi * (arraySort((c, t) -> t, wcv, wo)[?] / wrc)), wtc) < wtc), if((wrc > ?), (wsi * (arraySort((c, t) -> t, wcv, wo)[?] / wrc)), wtc), wtc)) + if(((toFloat64(dateDiff(?, wso[length(wso)], toDateTime64(?, ?))) / toFloat64(?)) >= (toFloat64(?) * wag)), (wag / toFloat64(?)), (toFloat64(dateDiff(?, wso[length(wso)], toDateTime64(?, ?))) / toFloat64(?)))) / wsi), toFloat64(?)), array(arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wcv, wo)))[?]))[?], array(if(((toFloat64(dateDiff(?, (toDateTime64(?, ?) - toIntervalNanosecond(?)), wso[?])) / toFloat64(?)) >= (toFloat64(?) * wag)), (wag / toFloat64(?)), (toFloat64(dateDiff(?, (toDateTime64(?, ?) - toIntervalNanosecond(?)), wso[?])) / toFloat64(?)))))[?], array((wsi / (length(wo) - ?))))[?], array((toFloat64(dateDiff(?, wso[?], wso[length(wso)])) / toFloat64(?))))[?], array(arraySort(wo)))[?], array(arrayMap(n -> toFloat64(n), `_hq_count_list`)))[?]), array(`_hq_ts_list`))[?], array(arrayMap(n -> toFloat64(n), `_hq_zero_counts`)))[?] AS `ZeroCount`, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`)) AS `PositiveOffset`, arrayMap(tb -> arrayMap(wv -> arrayMap(wo -> (arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wv, wo)))[?] * arrayMap(wcv -> arrayMap(wso -> arrayMap(wsi -> arrayMap(wag -> arrayMap(wtc -> arrayMap(wrc -> if((wsi > ?), (((wsi + if((if((wrc > ?), (wsi * (arraySort((c, t) -> t, wcv, wo)[?] / wrc)), wtc) < wtc), if((wrc > ?), (wsi * (arraySort((c, t) -> t, wcv, wo)[?] / wrc)), wtc), wtc)) + if(((toFloat64(dateDiff(?, wso[length(wso)], toDateTime64(?, ?))) / toFloat64(?)) >= (toFloat64(?) * wag)), (wag / toFloat64(?)), (toFloat64(dateDiff(?, wso[length(wso)], toDateTime64(?, ?))) / toFloat64(?)))) / wsi), toFloat64(?)), array(arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wcv, wo)))[?]))[?], array(if(((toFloat64(dateDiff(?, (toDateTime64(?, ?) - toIntervalNanosecond(?)), wso[?])) / toFloat64(?)) >= (toFloat64(?) * wag)), (wag / toFloat64(?)), (toFloat64(dateDiff(?, (toDateTime64(?, ?) - toIntervalNanosecond(?)), wso[?])) / toFloat64(?)))))[?], array((wsi / (length(wo) - ?))))[?], array((toFloat64(dateDiff(?, wso[?], wso[length(wso)])) / toFloat64(?))))[?], array(arraySort(wo)))[?], array(arrayMap(n -> toFloat64(n), `_hq_count_list`)))[?]), array(`_hq_ts_list`))[?], array(arrayMap(n -> toFloat64(n), arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - ?)), (s - `_hq_merged_scale`)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`)) + tb)), arr[j], ?), arrayEnumerate(arr))), `_hq_scales`, `_hq_pos_offsets`, `_hq_pos_buckets`))))[?], range(toUInt64(greatest(?, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - ?)), (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`, `_hq_pos_buckets`)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`))) + ?))))) AS `PositiveBucketCounts`, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`)) AS `NegativeOffset`, arrayMap(tb -> arrayMap(wv -> arrayMap(wo -> (arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wv, wo)))[?] * arrayMap(wcv -> arrayMap(wso -> arrayMap(wsi -> arrayMap(wag -> arrayMap(wtc -> arrayMap(wrc -> if((wsi > ?), (((wsi + if((if((wrc > ?), (wsi * (arraySort((c, t) -> t, wcv, wo)[?] / wrc)), wtc) < wtc), if((wrc > ?), (wsi * (arraySort((c, t) -> t, wcv, wo)[?] / wrc)), wtc), wtc)) + if(((toFloat64(dateDiff(?, wso[length(wso)], toDateTime64(?, ?))) / toFloat64(?)) >= (toFloat64(?) * wag)), (wag / toFloat64(?)), (toFloat64(dateDiff(?, wso[length(wso)], toDateTime64(?, ?))) / toFloat64(?)))) / wsi), toFloat64(?)), array(arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wcv, wo)))[?]))[?], array(if(((toFloat64(dateDiff(?, (toDateTime64(?, ?) - toIntervalNanosecond(?)), wso[?])) / toFloat64(?)) >= (toFloat64(?) * wag)), (wag / toFloat64(?)), (toFloat64(dateDiff(?, (toDateTime64(?, ?) - toIntervalNanosecond(?)), wso[?])) / toFloat64(?)))))[?], array((wsi / (length(wo) - ?))))[?], array((toFloat64(dateDiff(?, wso[?], wso[length(wso)])) / toFloat64(?))))[?], array(arraySort(wo)))[?], array(arrayMap(n -> toFloat64(n), `_hq_count_list`)))[?]), array(`_hq_ts_list`))[?], array(arrayMap(n -> toFloat64(n), arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - ?)), (s - `_hq_merged_scale`)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`)) + tb)), arr[j], ?), arrayEnumerate(arr))), `_hq_scales`, `_hq_neg_offsets`, `_hq_neg_buckets`))))[?], range(toUInt64(greatest(?, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - ?)), (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`, `_hq_neg_buckets`)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`))) + ?))))) AS `NegativeBucketCounts` FROM (SELECT * FROM (SELECT mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, min(`Scale`) AS `_hq_merged_scale`, groupArray(`Scale`) AS `_hq_scales`, groupArray(`ZeroCount`) AS `_hq_zero_counts`, groupArray(`Count`) AS `_hq_count_list`, groupArray(`PositiveOffset`) AS `_hq_pos_offsets`, groupArray(`PositiveBucketCounts`) AS `_hq_pos_buckets`, groupArray(`NegativeOffset`) AS `_hq_neg_offsets`, groupArray(`NegativeBucketCounts`) AS `_hq_neg_buckets`, groupArray(`TimeUnix`) AS `_hq_ts_list`, groupArray(`Sum`) AS `_hq_sum_list`, uniqExact(`TimeUnix`) AS `_hq_samples` FROM (SELECT * FROM `otel_metrics_exponential_histogram` PREWHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?)) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `Attributes`) WHERE (`_hq_samples` >= ?)))

--- a/test/spec/promql/exp_histogram_rate.txtar
+++ b/test/spec/promql/exp_histogram_rate.txtar
@@ -33,7 +33,7 @@ CREATE TABLE otel_metrics_exponential_histogram (
 --   sampledInterval = 00:00:01 - 23:59:01           = 60s
 --   averageDurationBetweenSamples = 60 / (2-1)      = 60s
 --   extrapolationThreshold = 60 * 1.1               = 66s
---   durationToStart raw = 23:59:01 - 23:55:01 = 239s+1s = 240s
+--   durationToStart raw = 23:59:01 - 23:55:01           = 240s
 --                       240 >= 66, so clamp to 60/2 = 30s
 --   durationToZero = sampledInterval * first/result
 --                  = 60 * (6 / 24)                  = 15s

--- a/test/spec/promql/exp_histogram_rate.txtar
+++ b/test/spec/promql/exp_histogram_rate.txtar
@@ -1,0 +1,328 @@
+-- query.promql --
+rate(latency_exp_hist[5m])
+-- seed --
+CREATE TABLE otel_metrics_exponential_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    Scale Int32,
+    ZeroCount UInt64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64),
+    NegativeOffset Int32,
+    NegativeBucketCounts Array(UInt64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+-- One series, two in-window scrapes 60s apart, no counter reset. Worked
+-- through exactly as reference Prometheus's extrapolatedRate does, so
+-- the generated cell below can be checked against an independent
+-- calculation rather than against itself.
+--
+-- The evaluation anchor is 00:00:01, so [5m] spans (23:55:01, 00:00:01].
+--
+-- Window increase per field — with no reset the reset-rule sum
+-- telescopes to last - first:
+--   Count      30 -  6 = 24
+--   Sum      15.0 -  3.0 = 12.0
+--   ZeroCount   1 -  1 = 0
+--   buckets  [14-2, 15-3] = [12, 12]     (Scale 0, PositiveOffset 0)
+--
+-- Boundary extrapolation — ONE factor for the whole histogram, from the
+-- series' own sample timestamps against the window edges:
+--   sampledInterval = 00:00:01 - 23:59:01           = 60s
+--   averageDurationBetweenSamples = 60 / (2-1)      = 60s
+--   extrapolationThreshold = 60 * 1.1               = 66s
+--   durationToStart raw = 23:59:01 - 23:55:01 = 239s+1s = 240s
+--                       240 >= 66, so clamp to 60/2 = 30s
+--   durationToZero = sampledInterval * first/result
+--                  = 60 * (6 / 24)                  = 15s
+--                       15 < 30, so durationToStart = 15s
+--   durationToEnd  = 00:00:01 - 00:00:01            = 0s
+--   factor = (60 + 15 + 0) / 60                     = 1.25
+--
+-- `rate` divides that same factor by the range, exactly as reference's
+-- `factor /= ms.Range.Seconds()` does — so every field is scaled by
+-- 1.25 / 300 = 1/240:
+--   Count     24 / 240 = 0.1
+--   Sum       12 / 240 = 0.05
+--   ZeroCount  0 / 240 = 0
+--   buckets  [12/240, 12/240] = [0.05, 0.05]
+--
+-- `rate()` drops __name__ (a derived sample) but KEEPS the series'
+-- labels — it reduces along time, not across series — so the output
+-- series is ["", {service: api}].
+INSERT INTO otel_metrics_exponential_histogram VALUES
+    ('latency_exp_hist', map('service', 'api'), toDateTime64('2025-12-31 23:59:01', 9),  6,  3.0, 0, 1, 0, [ 2,  3], 0, []),
+    ('latency_exp_hist', map('service', 'api'), toDateTime64('2026-01-01 00:00:01', 9), 30, 15.0, 0, 1, 0, [14, 15], 0, []);
+-- expected_rows --
+[
+  ["", {"service": "api"}, "2026-01-01T00:00:01Z", 0, 0.1, 0.05, 0, 0, 0, 0, [0.05,0.05], 0, []]
+]
+-- args --
+[0] string = ""
+[1] int64 = 9
+[2] float64 = 0
+[3] int64 = 1
+[4] int64 = 0
+[5] int64 = 0
+[6] int64 = 1
+[7] int64 = 0
+[8] int64 = 1
+[9] string = "nanosecond"
+[10] string = "2026-01-01 00:00:01.000000000"
+[11] int64 = 9
+[12] float64 = 1e+09
+[13] float64 = 1.1
+[14] float64 = 2
+[15] string = "nanosecond"
+[16] string = "2026-01-01 00:00:01.000000000"
+[17] int64 = 9
+[18] float64 = 1e+09
+[19] float64 = 1
+[20] int64 = 1
+[21] int64 = 1
+[22] string = "nanosecond"
+[23] string = "2026-01-01 00:00:01.000000000"
+[24] int64 = 9
+[25] int64 = 300000000000
+[26] int64 = 1
+[27] float64 = 1e+09
+[28] float64 = 1.1
+[29] float64 = 2
+[30] string = "nanosecond"
+[31] string = "2026-01-01 00:00:01.000000000"
+[32] int64 = 9
+[33] int64 = 300000000000
+[34] int64 = 1
+[35] float64 = 1e+09
+[36] int64 = 1
+[37] int64 = 1
+[38] int64 = 1
+[39] string = "nanosecond"
+[40] int64 = 1
+[41] float64 = 1e+09
+[42] int64 = 1
+[43] int64 = 1
+[44] int64 = 1
+[45] int64 = 1
+[46] int64 = 1
+[47] float64 = 300
+[48] int64 = 1
+[49] int64 = 0
+[50] int64 = 0
+[51] int64 = 1
+[52] int64 = 0
+[53] int64 = 1
+[54] string = "nanosecond"
+[55] string = "2026-01-01 00:00:01.000000000"
+[56] int64 = 9
+[57] float64 = 1e+09
+[58] float64 = 1.1
+[59] float64 = 2
+[60] string = "nanosecond"
+[61] string = "2026-01-01 00:00:01.000000000"
+[62] int64 = 9
+[63] float64 = 1e+09
+[64] float64 = 1
+[65] int64 = 1
+[66] int64 = 1
+[67] string = "nanosecond"
+[68] string = "2026-01-01 00:00:01.000000000"
+[69] int64 = 9
+[70] int64 = 300000000000
+[71] int64 = 1
+[72] float64 = 1e+09
+[73] float64 = 1.1
+[74] float64 = 2
+[75] string = "nanosecond"
+[76] string = "2026-01-01 00:00:01.000000000"
+[77] int64 = 9
+[78] int64 = 300000000000
+[79] int64 = 1
+[80] float64 = 1e+09
+[81] int64 = 1
+[82] int64 = 1
+[83] int64 = 1
+[84] string = "nanosecond"
+[85] int64 = 1
+[86] float64 = 1e+09
+[87] int64 = 1
+[88] int64 = 1
+[89] int64 = 1
+[90] int64 = 1
+[91] int64 = 1
+[92] float64 = 300
+[93] int64 = 1
+[94] int64 = 0
+[95] int64 = 0
+[96] int64 = 1
+[97] int64 = 0
+[98] int64 = 1
+[99] string = "nanosecond"
+[100] string = "2026-01-01 00:00:01.000000000"
+[101] int64 = 9
+[102] float64 = 1e+09
+[103] float64 = 1.1
+[104] float64 = 2
+[105] string = "nanosecond"
+[106] string = "2026-01-01 00:00:01.000000000"
+[107] int64 = 9
+[108] float64 = 1e+09
+[109] float64 = 1
+[110] int64 = 1
+[111] int64 = 1
+[112] string = "nanosecond"
+[113] string = "2026-01-01 00:00:01.000000000"
+[114] int64 = 9
+[115] int64 = 300000000000
+[116] int64 = 1
+[117] float64 = 1e+09
+[118] float64 = 1.1
+[119] float64 = 2
+[120] string = "nanosecond"
+[121] string = "2026-01-01 00:00:01.000000000"
+[122] int64 = 9
+[123] int64 = 300000000000
+[124] int64 = 1
+[125] float64 = 1e+09
+[126] int64 = 1
+[127] int64 = 1
+[128] int64 = 1
+[129] string = "nanosecond"
+[130] int64 = 1
+[131] float64 = 1e+09
+[132] int64 = 1
+[133] int64 = 1
+[134] int64 = 1
+[135] int64 = 1
+[136] int64 = 1
+[137] float64 = 300
+[138] int64 = 1
+[139] int64 = 0
+[140] int64 = 0
+[141] int64 = 1
+[142] int64 = 0
+[143] int64 = 1
+[144] string = "nanosecond"
+[145] string = "2026-01-01 00:00:01.000000000"
+[146] int64 = 9
+[147] float64 = 1e+09
+[148] float64 = 1.1
+[149] float64 = 2
+[150] string = "nanosecond"
+[151] string = "2026-01-01 00:00:01.000000000"
+[152] int64 = 9
+[153] float64 = 1e+09
+[154] float64 = 1
+[155] int64 = 1
+[156] int64 = 1
+[157] string = "nanosecond"
+[158] string = "2026-01-01 00:00:01.000000000"
+[159] int64 = 9
+[160] int64 = 300000000000
+[161] int64 = 1
+[162] float64 = 1e+09
+[163] float64 = 1.1
+[164] float64 = 2
+[165] string = "nanosecond"
+[166] string = "2026-01-01 00:00:01.000000000"
+[167] int64 = 9
+[168] int64 = 300000000000
+[169] int64 = 1
+[170] float64 = 1e+09
+[171] int64 = 1
+[172] int64 = 1
+[173] int64 = 1
+[174] string = "nanosecond"
+[175] int64 = 1
+[176] float64 = 1e+09
+[177] int64 = 1
+[178] int64 = 1
+[179] int64 = 1
+[180] int64 = 1
+[181] int64 = 1
+[182] int64 = 0
+[183] int64 = 1
+[184] float64 = 300
+[185] int64 = 0
+[186] int64 = 1
+[187] int64 = 1
+[188] int64 = 1
+[189] int64 = 0
+[190] int64 = 0
+[191] int64 = 1
+[192] int64 = 0
+[193] int64 = 1
+[194] string = "nanosecond"
+[195] string = "2026-01-01 00:00:01.000000000"
+[196] int64 = 9
+[197] float64 = 1e+09
+[198] float64 = 1.1
+[199] float64 = 2
+[200] string = "nanosecond"
+[201] string = "2026-01-01 00:00:01.000000000"
+[202] int64 = 9
+[203] float64 = 1e+09
+[204] float64 = 1
+[205] int64 = 1
+[206] int64 = 1
+[207] string = "nanosecond"
+[208] string = "2026-01-01 00:00:01.000000000"
+[209] int64 = 9
+[210] int64 = 300000000000
+[211] int64 = 1
+[212] float64 = 1e+09
+[213] float64 = 1.1
+[214] float64 = 2
+[215] string = "nanosecond"
+[216] string = "2026-01-01 00:00:01.000000000"
+[217] int64 = 9
+[218] int64 = 300000000000
+[219] int64 = 1
+[220] float64 = 1e+09
+[221] int64 = 1
+[222] int64 = 1
+[223] int64 = 1
+[224] string = "nanosecond"
+[225] int64 = 1
+[226] float64 = 1e+09
+[227] int64 = 1
+[228] int64 = 1
+[229] int64 = 1
+[230] int64 = 1
+[231] int64 = 1
+[232] int64 = 0
+[233] int64 = 1
+[234] float64 = 300
+[235] int64 = 0
+[236] int64 = 1
+[237] int64 = 1
+[238] string = "service.name"
+[239] string = "service_name"
+[240] string = "service.name"
+[241] string = "service_name"
+[242] string = ""
+[243] string = "service_name"
+[244] string = "latency_exp_hist"
+[245] string = "latency.exp.hist"
+[246] string = "latency.exp/hist"
+[247] string = "latency.exp_hist"
+[248] string = "latency/exp/hist"
+[249] string = "latency/exp_hist"
+[250] string = "latency_exp.hist"
+[251] string = "2026-01-01 00:00:01.000000000"
+[252] int64 = 9
+[253] string = "2026-01-01 00:00:01.000000000"
+[254] int64 = 9
+[255] int64 = 300000000000
+[256] int64 = 2
+-- chplan --
+HistogramProjection project=["" AS MetricName, Attributes AS Attributes, now64(9) AS TimeUnix, 0 AS Value]
+  Project [Attributes AS Attributes, (arrayMap(wv -> arrayMap(wo -> (arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wv, wo)))[1] * arrayMap(wcv -> arrayMap(wso -> arrayMap(wsi -> arrayMap(wag -> arrayMap(wtc -> arrayMap(wrc -> if((wsi > 0), (((wsi + if((if((wrc > 0), (wsi * (arraySort((c, t) -> t, wcv, wo)[1] / wrc)), wtc) < wtc), if((wrc > 0), (wsi * (arraySort((c, t) -> t, wcv, wo)[1] / wrc)), wtc), wtc)) + if(((toFloat64(dateDiff("nanosecond", wso[length(wso)], toDateTime64("2026-01-01 00:00:01.000000000", 9))) / 1e+09) >= (1.1 * wag)), (wag / 2), (toFloat64(dateDiff("nanosecond", wso[length(wso)], toDateTime64("2026-01-01 00:00:01.000000000", 9))) / 1e+09))) / wsi), 1), array(arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wcv, wo)))[1]))[1], array(if(((toFloat64(dateDiff("nanosecond", (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000)), wso[1])) / 1e+09) >= (1.1 * wag)), (wag / 2), (toFloat64(dateDiff("nanosecond", (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000)), wso[1])) / 1e+09))))[1], array((wsi / (length(wo) - 1))))[1], array((toFloat64(dateDiff("nanosecond", wso[1], wso[length(wso)])) / 1e+09)))[1], array(arraySort(wo)))[1], array(arrayMap(n -> toFloat64(n), _hq_count_list)))[1]), array(_hq_ts_list))[1], array(arrayMap(n -> toFloat64(n), _hq_count_list)))[1] / 300) AS Count, (arrayMap(wv -> arrayMap(wo -> (arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wv, wo)))[1] * arrayMap(wcv -> arrayMap(wso -> arrayMap(wsi -> arrayMap(wag -> arrayMap(wtc -> arrayMap(wrc -> if((wsi > 0), (((wsi + if((if((wrc > 0), (wsi * (arraySort((c, t) -> t, wcv, wo)[1] / wrc)), wtc) < wtc), if((wrc > 0), (wsi * (arraySort((c, t) -> t, wcv, wo)[1] / wrc)), wtc), wtc)) + if(((toFloat64(dateDiff("nanosecond", wso[length(wso)], toDateTime64("2026-01-01 00:00:01.000000000", 9))) / 1e+09) >= (1.1 * wag)), (wag / 2), (toFloat64(dateDiff("nanosecond", wso[length(wso)], toDateTime64("2026-01-01 00:00:01.000000000", 9))) / 1e+09))) / wsi), 1), array(arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wcv, wo)))[1]))[1], array(if(((toFloat64(dateDiff("nanosecond", (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000)), wso[1])) / 1e+09) >= (1.1 * wag)), (wag / 2), (toFloat64(dateDiff("nanosecond", (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000)), wso[1])) / 1e+09))))[1], array((wsi / (length(wo) - 1))))[1], array((toFloat64(dateDiff("nanosecond", wso[1], wso[length(wso)])) / 1e+09)))[1], array(arraySort(wo)))[1], array(arrayMap(n -> toFloat64(n), _hq_count_list)))[1]), array(_hq_ts_list))[1], array(arrayMap(n -> toFloat64(n), _hq_sum_list)))[1] / 300) AS Sum, _hq_merged_scale AS Scale, (arrayMap(wv -> arrayMap(wo -> (arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wv, wo)))[1] * arrayMap(wcv -> arrayMap(wso -> arrayMap(wsi -> arrayMap(wag -> arrayMap(wtc -> arrayMap(wrc -> if((wsi > 0), (((wsi + if((if((wrc > 0), (wsi * (arraySort((c, t) -> t, wcv, wo)[1] / wrc)), wtc) < wtc), if((wrc > 0), (wsi * (arraySort((c, t) -> t, wcv, wo)[1] / wrc)), wtc), wtc)) + if(((toFloat64(dateDiff("nanosecond", wso[length(wso)], toDateTime64("2026-01-01 00:00:01.000000000", 9))) / 1e+09) >= (1.1 * wag)), (wag / 2), (toFloat64(dateDiff("nanosecond", wso[length(wso)], toDateTime64("2026-01-01 00:00:01.000000000", 9))) / 1e+09))) / wsi), 1), array(arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wcv, wo)))[1]))[1], array(if(((toFloat64(dateDiff("nanosecond", (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000)), wso[1])) / 1e+09) >= (1.1 * wag)), (wag / 2), (toFloat64(dateDiff("nanosecond", (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000)), wso[1])) / 1e+09))))[1], array((wsi / (length(wo) - 1))))[1], array((toFloat64(dateDiff("nanosecond", wso[1], wso[length(wso)])) / 1e+09)))[1], array(arraySort(wo)))[1], array(arrayMap(n -> toFloat64(n), _hq_count_list)))[1]), array(_hq_ts_list))[1], array(arrayMap(n -> toFloat64(n), _hq_zero_counts)))[1] / 300) AS ZeroCount, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - _hq_merged_scale)), _hq_scales, _hq_pos_offsets)) AS PositiveOffset, arrayMap(tb -> (arrayMap(wv -> arrayMap(wo -> (arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wv, wo)))[1] * arrayMap(wcv -> arrayMap(wso -> arrayMap(wsi -> arrayMap(wag -> arrayMap(wtc -> arrayMap(wrc -> if((wsi > 0), (((wsi + if((if((wrc > 0), (wsi * (arraySort((c, t) -> t, wcv, wo)[1] / wrc)), wtc) < wtc), if((wrc > 0), (wsi * (arraySort((c, t) -> t, wcv, wo)[1] / wrc)), wtc), wtc)) + if(((toFloat64(dateDiff("nanosecond", wso[length(wso)], toDateTime64("2026-01-01 00:00:01.000000000", 9))) / 1e+09) >= (1.1 * wag)), (wag / 2), (toFloat64(dateDiff("nanosecond", wso[length(wso)], toDateTime64("2026-01-01 00:00:01.000000000", 9))) / 1e+09))) / wsi), 1), array(arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wcv, wo)))[1]))[1], array(if(((toFloat64(dateDiff("nanosecond", (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000)), wso[1])) / 1e+09) >= (1.1 * wag)), (wag / 2), (toFloat64(dateDiff("nanosecond", (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000)), wso[1])) / 1e+09))))[1], array((wsi / (length(wo) - 1))))[1], array((toFloat64(dateDiff("nanosecond", wso[1], wso[length(wso)])) / 1e+09)))[1], array(arraySort(wo)))[1], array(arrayMap(n -> toFloat64(n), _hq_count_list)))[1]), array(_hq_ts_list))[1], array(arrayMap(n -> toFloat64(n), arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - 1)), (s - _hq_merged_scale)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets)) + tb)), arr[j], 0), arrayEnumerate(arr))), _hq_scales, _hq_pos_offsets, _hq_pos_buckets))))[1] / 300), range(toUInt64(greatest(0, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - 1)), (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets, _hq_pos_buckets)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets))) + 1))))) AS PositiveBucketCounts, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - _hq_merged_scale)), _hq_scales, _hq_neg_offsets)) AS NegativeOffset, arrayMap(tb -> (arrayMap(wv -> arrayMap(wo -> (arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wv, wo)))[1] * arrayMap(wcv -> arrayMap(wso -> arrayMap(wsi -> arrayMap(wag -> arrayMap(wtc -> arrayMap(wrc -> if((wsi > 0), (((wsi + if((if((wrc > 0), (wsi * (arraySort((c, t) -> t, wcv, wo)[1] / wrc)), wtc) < wtc), if((wrc > 0), (wsi * (arraySort((c, t) -> t, wcv, wo)[1] / wrc)), wtc), wtc)) + if(((toFloat64(dateDiff("nanosecond", wso[length(wso)], toDateTime64("2026-01-01 00:00:01.000000000", 9))) / 1e+09) >= (1.1 * wag)), (wag / 2), (toFloat64(dateDiff("nanosecond", wso[length(wso)], toDateTime64("2026-01-01 00:00:01.000000000", 9))) / 1e+09))) / wsi), 1), array(arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wcv, wo)))[1]))[1], array(if(((toFloat64(dateDiff("nanosecond", (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000)), wso[1])) / 1e+09) >= (1.1 * wag)), (wag / 2), (toFloat64(dateDiff("nanosecond", (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000)), wso[1])) / 1e+09))))[1], array((wsi / (length(wo) - 1))))[1], array((toFloat64(dateDiff("nanosecond", wso[1], wso[length(wso)])) / 1e+09)))[1], array(arraySort(wo)))[1], array(arrayMap(n -> toFloat64(n), _hq_count_list)))[1]), array(_hq_ts_list))[1], array(arrayMap(n -> toFloat64(n), arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - 1)), (s - _hq_merged_scale)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets)) + tb)), arr[j], 0), arrayEnumerate(arr))), _hq_scales, _hq_neg_offsets, _hq_neg_buckets))))[1] / 300), range(toUInt64(greatest(0, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - 1)), (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets, _hq_neg_buckets)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets))) + 1))))) AS NegativeBucketCounts]
+    Filter predicate=(_hq_samples >= 2)
+      Aggregate groupBy=[mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes] funcs=[min(Scale) AS _hq_merged_scale, groupArray(Scale) AS _hq_scales, groupArray(ZeroCount) AS _hq_zero_counts, groupArray(Count) AS _hq_count_list, groupArray(PositiveOffset) AS _hq_pos_offsets, groupArray(PositiveBucketCounts) AS _hq_pos_buckets, groupArray(NegativeOffset) AS _hq_neg_offsets, groupArray(NegativeBucketCounts) AS _hq_neg_buckets, groupArray(TimeUnix) AS _hq_ts_list, groupArray(Sum) AS _hq_sum_list, uniqExact(TimeUnix) AS _hq_samples]
+        Filter predicate=(((MetricName IN ("latency_exp_hist", "latency.exp.hist", "latency.exp/hist", "latency.exp_hist", "latency/exp/hist", "latency/exp_hist", "latency_exp.hist")) AND (TimeUnix <= toDateTime64("2026-01-01 00:00:01.000000000", 9))) AND (TimeUnix > (toDateTime64("2026-01-01 00:00:01.000000000", 9) - toIntervalNanosecond(300000000000))))
+          Scan(otel_metrics_exponential_histogram)
+-- sql --
+SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, now64(?) AS `TimeUnix`, toFloat64(?) AS `Value`, `Count` AS `HistogramCount`, `Sum` AS `HistogramSum`, `Scale` AS `HistogramScale`, 0. AS `HistogramZeroThreshold`, `ZeroCount` AS `HistogramZeroCount`, `PositiveOffset` AS `HistogramPositiveOffset`, `PositiveBucketCounts` AS `HistogramPositiveBucketCounts`, `NegativeOffset` AS `HistogramNegativeOffset`, `NegativeBucketCounts` AS `HistogramNegativeBucketCounts` FROM (SELECT `Attributes` AS `Attributes`, (arrayMap(wv -> arrayMap(wo -> (arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wv, wo)))[?] * arrayMap(wcv -> arrayMap(wso -> arrayMap(wsi -> arrayMap(wag -> arrayMap(wtc -> arrayMap(wrc -> if((wsi > ?), (((wsi + if((if((wrc > ?), (wsi * (arraySort((c, t) -> t, wcv, wo)[?] / wrc)), wtc) < wtc), if((wrc > ?), (wsi * (arraySort((c, t) -> t, wcv, wo)[?] / wrc)), wtc), wtc)) + if(((toFloat64(dateDiff(?, wso[length(wso)], toDateTime64(?, ?))) / toFloat64(?)) >= (toFloat64(?) * wag)), (wag / toFloat64(?)), (toFloat64(dateDiff(?, wso[length(wso)], toDateTime64(?, ?))) / toFloat64(?)))) / wsi), toFloat64(?)), array(arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wcv, wo)))[?]))[?], array(if(((toFloat64(dateDiff(?, (toDateTime64(?, ?) - toIntervalNanosecond(?)), wso[?])) / toFloat64(?)) >= (toFloat64(?) * wag)), (wag / toFloat64(?)), (toFloat64(dateDiff(?, (toDateTime64(?, ?) - toIntervalNanosecond(?)), wso[?])) / toFloat64(?)))))[?], array((wsi / (length(wo) - ?))))[?], array((toFloat64(dateDiff(?, wso[?], wso[length(wso)])) / toFloat64(?))))[?], array(arraySort(wo)))[?], array(arrayMap(n -> toFloat64(n), `_hq_count_list`)))[?]), array(`_hq_ts_list`))[?], array(arrayMap(n -> toFloat64(n), `_hq_count_list`)))[?] / toFloat64(?)) AS `Count`, (arrayMap(wv -> arrayMap(wo -> (arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wv, wo)))[?] * arrayMap(wcv -> arrayMap(wso -> arrayMap(wsi -> arrayMap(wag -> arrayMap(wtc -> arrayMap(wrc -> if((wsi > ?), (((wsi + if((if((wrc > ?), (wsi * (arraySort((c, t) -> t, wcv, wo)[?] / wrc)), wtc) < wtc), if((wrc > ?), (wsi * (arraySort((c, t) -> t, wcv, wo)[?] / wrc)), wtc), wtc)) + if(((toFloat64(dateDiff(?, wso[length(wso)], toDateTime64(?, ?))) / toFloat64(?)) >= (toFloat64(?) * wag)), (wag / toFloat64(?)), (toFloat64(dateDiff(?, wso[length(wso)], toDateTime64(?, ?))) / toFloat64(?)))) / wsi), toFloat64(?)), array(arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wcv, wo)))[?]))[?], array(if(((toFloat64(dateDiff(?, (toDateTime64(?, ?) - toIntervalNanosecond(?)), wso[?])) / toFloat64(?)) >= (toFloat64(?) * wag)), (wag / toFloat64(?)), (toFloat64(dateDiff(?, (toDateTime64(?, ?) - toIntervalNanosecond(?)), wso[?])) / toFloat64(?)))))[?], array((wsi / (length(wo) - ?))))[?], array((toFloat64(dateDiff(?, wso[?], wso[length(wso)])) / toFloat64(?))))[?], array(arraySort(wo)))[?], array(arrayMap(n -> toFloat64(n), `_hq_count_list`)))[?]), array(`_hq_ts_list`))[?], array(arrayMap(n -> toFloat64(n), `_hq_sum_list`)))[?] / toFloat64(?)) AS `Sum`, `_hq_merged_scale` AS `Scale`, (arrayMap(wv -> arrayMap(wo -> (arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wv, wo)))[?] * arrayMap(wcv -> arrayMap(wso -> arrayMap(wsi -> arrayMap(wag -> arrayMap(wtc -> arrayMap(wrc -> if((wsi > ?), (((wsi + if((if((wrc > ?), (wsi * (arraySort((c, t) -> t, wcv, wo)[?] / wrc)), wtc) < wtc), if((wrc > ?), (wsi * (arraySort((c, t) -> t, wcv, wo)[?] / wrc)), wtc), wtc)) + if(((toFloat64(dateDiff(?, wso[length(wso)], toDateTime64(?, ?))) / toFloat64(?)) >= (toFloat64(?) * wag)), (wag / toFloat64(?)), (toFloat64(dateDiff(?, wso[length(wso)], toDateTime64(?, ?))) / toFloat64(?)))) / wsi), toFloat64(?)), array(arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wcv, wo)))[?]))[?], array(if(((toFloat64(dateDiff(?, (toDateTime64(?, ?) - toIntervalNanosecond(?)), wso[?])) / toFloat64(?)) >= (toFloat64(?) * wag)), (wag / toFloat64(?)), (toFloat64(dateDiff(?, (toDateTime64(?, ?) - toIntervalNanosecond(?)), wso[?])) / toFloat64(?)))))[?], array((wsi / (length(wo) - ?))))[?], array((toFloat64(dateDiff(?, wso[?], wso[length(wso)])) / toFloat64(?))))[?], array(arraySort(wo)))[?], array(arrayMap(n -> toFloat64(n), `_hq_count_list`)))[?]), array(`_hq_ts_list`))[?], array(arrayMap(n -> toFloat64(n), `_hq_zero_counts`)))[?] / toFloat64(?)) AS `ZeroCount`, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`)) AS `PositiveOffset`, arrayMap(tb -> (arrayMap(wv -> arrayMap(wo -> (arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wv, wo)))[?] * arrayMap(wcv -> arrayMap(wso -> arrayMap(wsi -> arrayMap(wag -> arrayMap(wtc -> arrayMap(wrc -> if((wsi > ?), (((wsi + if((if((wrc > ?), (wsi * (arraySort((c, t) -> t, wcv, wo)[?] / wrc)), wtc) < wtc), if((wrc > ?), (wsi * (arraySort((c, t) -> t, wcv, wo)[?] / wrc)), wtc), wtc)) + if(((toFloat64(dateDiff(?, wso[length(wso)], toDateTime64(?, ?))) / toFloat64(?)) >= (toFloat64(?) * wag)), (wag / toFloat64(?)), (toFloat64(dateDiff(?, wso[length(wso)], toDateTime64(?, ?))) / toFloat64(?)))) / wsi), toFloat64(?)), array(arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wcv, wo)))[?]))[?], array(if(((toFloat64(dateDiff(?, (toDateTime64(?, ?) - toIntervalNanosecond(?)), wso[?])) / toFloat64(?)) >= (toFloat64(?) * wag)), (wag / toFloat64(?)), (toFloat64(dateDiff(?, (toDateTime64(?, ?) - toIntervalNanosecond(?)), wso[?])) / toFloat64(?)))))[?], array((wsi / (length(wo) - ?))))[?], array((toFloat64(dateDiff(?, wso[?], wso[length(wso)])) / toFloat64(?))))[?], array(arraySort(wo)))[?], array(arrayMap(n -> toFloat64(n), `_hq_count_list`)))[?]), array(`_hq_ts_list`))[?], array(arrayMap(n -> toFloat64(n), arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - ?)), (s - `_hq_merged_scale`)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`)) + tb)), arr[j], ?), arrayEnumerate(arr))), `_hq_scales`, `_hq_pos_offsets`, `_hq_pos_buckets`))))[?] / toFloat64(?)), range(toUInt64(greatest(?, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - ?)), (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`, `_hq_pos_buckets`)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`))) + ?))))) AS `PositiveBucketCounts`, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`)) AS `NegativeOffset`, arrayMap(tb -> (arrayMap(wv -> arrayMap(wo -> (arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wv, wo)))[?] * arrayMap(wcv -> arrayMap(wso -> arrayMap(wsi -> arrayMap(wag -> arrayMap(wtc -> arrayMap(wrc -> if((wsi > ?), (((wsi + if((if((wrc > ?), (wsi * (arraySort((c, t) -> t, wcv, wo)[?] / wrc)), wtc) < wtc), if((wrc > ?), (wsi * (arraySort((c, t) -> t, wcv, wo)[?] / wrc)), wtc), wtc)) + if(((toFloat64(dateDiff(?, wso[length(wso)], toDateTime64(?, ?))) / toFloat64(?)) >= (toFloat64(?) * wag)), (wag / toFloat64(?)), (toFloat64(dateDiff(?, wso[length(wso)], toDateTime64(?, ?))) / toFloat64(?)))) / wsi), toFloat64(?)), array(arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wcv, wo)))[?]))[?], array(if(((toFloat64(dateDiff(?, (toDateTime64(?, ?) - toIntervalNanosecond(?)), wso[?])) / toFloat64(?)) >= (toFloat64(?) * wag)), (wag / toFloat64(?)), (toFloat64(dateDiff(?, (toDateTime64(?, ?) - toIntervalNanosecond(?)), wso[?])) / toFloat64(?)))))[?], array((wsi / (length(wo) - ?))))[?], array((toFloat64(dateDiff(?, wso[?], wso[length(wso)])) / toFloat64(?))))[?], array(arraySort(wo)))[?], array(arrayMap(n -> toFloat64(n), `_hq_count_list`)))[?]), array(`_hq_ts_list`))[?], array(arrayMap(n -> toFloat64(n), arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - ?)), (s - `_hq_merged_scale`)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`)) + tb)), arr[j], ?), arrayEnumerate(arr))), `_hq_scales`, `_hq_neg_offsets`, `_hq_neg_buckets`))))[?] / toFloat64(?)), range(toUInt64(greatest(?, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - ?)), (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`, `_hq_neg_buckets`)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`))) + ?))))) AS `NegativeBucketCounts` FROM (SELECT * FROM (SELECT mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, min(`Scale`) AS `_hq_merged_scale`, groupArray(`Scale`) AS `_hq_scales`, groupArray(`ZeroCount`) AS `_hq_zero_counts`, groupArray(`Count`) AS `_hq_count_list`, groupArray(`PositiveOffset`) AS `_hq_pos_offsets`, groupArray(`PositiveBucketCounts`) AS `_hq_pos_buckets`, groupArray(`NegativeOffset`) AS `_hq_neg_offsets`, groupArray(`NegativeBucketCounts`) AS `_hq_neg_buckets`, groupArray(`TimeUnix`) AS `_hq_ts_list`, groupArray(`Sum`) AS `_hq_sum_list`, uniqExact(`TimeUnix`) AS `_hq_samples` FROM (SELECT * FROM `otel_metrics_exponential_histogram` PREWHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?)) WHERE (`TimeUnix` <= toDateTime64(?, ?)) AND (`TimeUnix` > (toDateTime64(?, ?) - toIntervalNanosecond(?)))) GROUP BY `Attributes`) WHERE (`_hq_samples` >= ?)))

--- a/test/spec/promql/exp_histogram_rate_range.txtar
+++ b/test/spec/promql/exp_histogram_rate_range.txtar
@@ -21,40 +21,58 @@ CREATE TABLE otel_metrics_exponential_histogram (
 -- the grid.
 --
 -- One series scraped every 60s on the minute from 23:56:00 to 00:04:00,
--- with a perfectly linear counter. The grid runs 00:00:00 -> 00:04:30 at
--- 30s, and every anchor's half-open window (anchor - 5m, anchor] holds
--- exactly five of those scrapes:
+-- with a perfectly linear counter: every minute adds Count 60, Sum 30,
+-- and 30 to each of the two buckets. The grid runs 00:00:00 -> 00:05:00
+-- at 30s, so there are eleven anchors and each resolves its own
+-- half-open window (anchor - 5m, anchor].
+--
+-- The first ten anchors hold five scrapes apiece and differ only in
+-- phase:
 --   anchor 00:00:00 -> (23:55:00, 00:00:00] = 23:56:00 .. 00:00:00
 --   anchor 00:00:30 -> (23:55:30, 00:00:30] = 23:56:00 .. 00:00:00
 --   anchor 00:01:00 -> (23:56:00, 00:01:00] = 23:57:00 .. 00:01:00
---   ... and so on, sliding one scrape per two anchors.
---
--- Per-anchor arithmetic, identical at every step because the counter is
--- linear and the geometry repeats:
+--   ... sliding one scrape per two anchors, down to
+--   anchor 00:04:30 -> (23:59:30, 00:04:30] = 00:00:00 .. 00:04:00
+-- for which:
 --   window increase   Count 4*60 = 240, Sum 4*30 = 120,
 --                     ZeroCount 0, buckets [4*30, 4*30] = [120, 120]
 --   sampledInterval = 240s, average gap = 60s, threshold = 66s
---   durationToStart = 60s or 30s depending on the anchor's phase, both
---                     below the 66s threshold, so neither is clamped
---   durationToEnd   = 0s or 30s, the complement of the same phase
---   durationToZero  = 240 * (first/240); first is 600 at the earliest
---                     anchor and rises, so it never falls below 60s and
---                     never binds
---   durationToStart + durationToEnd = 60s at EVERY anchor, so
---   factor = (240 + 60) / 240 = 1.25 uniformly
+--   durationToStart = 60s on an on-the-minute anchor, 30s on a
+--                     half-minute one — both under the 66s threshold,
+--                     so neither is clamped
+--   durationToEnd   = 0s or 30s, the complement of that same phase
+--   durationToZero  = 240 * (first/240); `first` is 600 at the earliest
+--                     anchor and only rises, so it never falls below
+--                     durationToStart and never binds
+--   durationToStart + durationToEnd = 60s at every one of the ten, so
+--   factor = (240 + 60) / 240 = 1.25
+--
+-- The ELEVENTH anchor is the interesting one, and it is why the grid is
+-- worth eleven rows rather than one. Its window (00:00:00, 00:05:00] is
+-- half-open at the left, so it EXCLUDES the 00:00:00 scrape and holds
+-- only four:
+--   window increase   Count 3*60 = 180, Sum 3*30 = 90,
+--                     buckets [3*30, 3*30] = [90, 90]
+--   sampledInterval = 00:04:00 - 00:01:00                = 180s
+--   averageDurationBetweenSamples = 180 / (4-1)          = 60s
+--   durationToStart = 00:01:00 - 00:00:00 = 60s < 66     -> 60s
+--   durationToEnd   = 00:05:00 - 00:04:00 = 60s < 66     -> 60s
+--   factor = (180 + 60 + 60) / 180                       = 5/3
 --
 -- `rate` divides by the range as well, so every field is scaled by
--- 1.25 / 300 = 1/240:
---   Count     240 / 240 = 1
---   Sum       120 / 240 = 0.5
---   ZeroCount   0
---   buckets  [120/240, 120/240] = [0.5, 0.5]
+-- factor / 300 — and the two different factors land on the same answer,
+-- because recovering a linear counter's true slope from a partially
+-- covered window is exactly what the extrapolation is FOR:
+--   ten anchors  Count 240 * 1.25  / 300 = 1, Sum 120 * 1.25  / 300 = 0.5
+--   eleventh     Count 180 * (5/3) / 300 = 1, Sum  90 * (5/3) / 300 = 0.5
+--   buckets      [0.5, 0.5] on both, ZeroCount 0 throughout
 --
--- Every anchor therefore reports the identical rate at its own
--- timestamp — which is what a linear counter should produce, and what a
--- lowering that leaked one window across the whole grid would ALSO
--- produce, so the fixture's job here is the ten distinct timestamps and
--- the retained `service` label, not the value alone.
+-- So every anchor reports the identical rate at its own timestamp. A
+-- lowering that leaked ONE window across the whole grid would produce
+-- that too — which is why the load-bearing part of this fixture is the
+-- eleven distinct timestamps and the retained `service` label, plus the
+-- eleventh anchor's four-sample window agreeing with the other ten
+-- rather than reading 3/4 of their value.
 INSERT INTO otel_metrics_exponential_histogram VALUES
     ('latency_exp_hist', map('service', 'api'), toDateTime64('2025-12-31 23:56:00', 9),  600, 300.0, 0, 0, 0, [200, 400], 0, []),
     ('latency_exp_hist', map('service', 'api'), toDateTime64('2025-12-31 23:57:00', 9),  660, 330.0, 0, 0, 0, [230, 430], 0, []),

--- a/test/spec/promql/exp_histogram_rate_range.txtar
+++ b/test/spec/promql/exp_histogram_rate_range.txtar
@@ -1,0 +1,300 @@
+-- query.promql --
+rate(latency_exp_hist[5m])
+-- range_step --
+30s
+-- seed --
+CREATE TABLE otel_metrics_exponential_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    Scale Int32,
+    ZeroCount UInt64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64),
+    NegativeOffset Int32,
+    NegativeBucketCounts Array(UInt64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+-- The query_range shape: every step anchor resolves its OWN [5m] window
+-- and folds the samples inside it, rather than one window fanned across
+-- the grid.
+--
+-- One series scraped every 60s on the minute from 23:56:00 to 00:04:00,
+-- with a perfectly linear counter. The grid runs 00:00:00 -> 00:04:30 at
+-- 30s, and every anchor's half-open window (anchor - 5m, anchor] holds
+-- exactly five of those scrapes:
+--   anchor 00:00:00 -> (23:55:00, 00:00:00] = 23:56:00 .. 00:00:00
+--   anchor 00:00:30 -> (23:55:30, 00:00:30] = 23:56:00 .. 00:00:00
+--   anchor 00:01:00 -> (23:56:00, 00:01:00] = 23:57:00 .. 00:01:00
+--   ... and so on, sliding one scrape per two anchors.
+--
+-- Per-anchor arithmetic, identical at every step because the counter is
+-- linear and the geometry repeats:
+--   window increase   Count 4*60 = 240, Sum 4*30 = 120,
+--                     ZeroCount 0, buckets [4*30, 4*30] = [120, 120]
+--   sampledInterval = 240s, average gap = 60s, threshold = 66s
+--   durationToStart = 60s or 30s depending on the anchor's phase, both
+--                     below the 66s threshold, so neither is clamped
+--   durationToEnd   = 0s or 30s, the complement of the same phase
+--   durationToZero  = 240 * (first/240); first is 600 at the earliest
+--                     anchor and rises, so it never falls below 60s and
+--                     never binds
+--   durationToStart + durationToEnd = 60s at EVERY anchor, so
+--   factor = (240 + 60) / 240 = 1.25 uniformly
+--
+-- `rate` divides by the range as well, so every field is scaled by
+-- 1.25 / 300 = 1/240:
+--   Count     240 / 240 = 1
+--   Sum       120 / 240 = 0.5
+--   ZeroCount   0
+--   buckets  [120/240, 120/240] = [0.5, 0.5]
+--
+-- Every anchor therefore reports the identical rate at its own
+-- timestamp — which is what a linear counter should produce, and what a
+-- lowering that leaked one window across the whole grid would ALSO
+-- produce, so the fixture's job here is the ten distinct timestamps and
+-- the retained `service` label, not the value alone.
+INSERT INTO otel_metrics_exponential_histogram VALUES
+    ('latency_exp_hist', map('service', 'api'), toDateTime64('2025-12-31 23:56:00', 9),  600, 300.0, 0, 0, 0, [200, 400], 0, []),
+    ('latency_exp_hist', map('service', 'api'), toDateTime64('2025-12-31 23:57:00', 9),  660, 330.0, 0, 0, 0, [230, 430], 0, []),
+    ('latency_exp_hist', map('service', 'api'), toDateTime64('2025-12-31 23:58:00', 9),  720, 360.0, 0, 0, 0, [260, 460], 0, []),
+    ('latency_exp_hist', map('service', 'api'), toDateTime64('2025-12-31 23:59:00', 9),  780, 390.0, 0, 0, 0, [290, 490], 0, []),
+    ('latency_exp_hist', map('service', 'api'), toDateTime64('2026-01-01 00:00:00', 9),  840, 420.0, 0, 0, 0, [320, 520], 0, []),
+    ('latency_exp_hist', map('service', 'api'), toDateTime64('2026-01-01 00:01:00', 9),  900, 450.0, 0, 0, 0, [350, 550], 0, []),
+    ('latency_exp_hist', map('service', 'api'), toDateTime64('2026-01-01 00:02:00', 9),  960, 480.0, 0, 0, 0, [380, 580], 0, []),
+    ('latency_exp_hist', map('service', 'api'), toDateTime64('2026-01-01 00:03:00', 9), 1020, 510.0, 0, 0, 0, [410, 610], 0, []),
+    ('latency_exp_hist', map('service', 'api'), toDateTime64('2026-01-01 00:04:00', 9), 1080, 540.0, 0, 0, 0, [440, 640], 0, []);
+-- expected_rows --
+[
+  ["", {"service": "api"}, "2026-01-01T00:00:00Z", 0, 1, 0.5, 0, 0, 0, 0, [0.5,0.5], 0, []],
+  ["", {"service": "api"}, "2026-01-01T00:00:30Z", 0, 1, 0.5, 0, 0, 0, 0, [0.5,0.5], 0, []],
+  ["", {"service": "api"}, "2026-01-01T00:01:00Z", 0, 1, 0.5, 0, 0, 0, 0, [0.5,0.5], 0, []],
+  ["", {"service": "api"}, "2026-01-01T00:01:30Z", 0, 1, 0.5, 0, 0, 0, 0, [0.5,0.5], 0, []],
+  ["", {"service": "api"}, "2026-01-01T00:02:00Z", 0, 1, 0.5, 0, 0, 0, 0, [0.5,0.5], 0, []],
+  ["", {"service": "api"}, "2026-01-01T00:02:30Z", 0, 1, 0.5, 0, 0, 0, 0, [0.5,0.5], 0, []],
+  ["", {"service": "api"}, "2026-01-01T00:03:00Z", 0, 1, 0.5, 0, 0, 0, 0, [0.5,0.5], 0, []],
+  ["", {"service": "api"}, "2026-01-01T00:03:30Z", 0, 1, 0.5, 0, 0, 0, 0, [0.5,0.5], 0, []],
+  ["", {"service": "api"}, "2026-01-01T00:04:00Z", 0, 1, 0.5, 0, 0, 0, 0, [0.5,0.5], 0, []],
+  ["", {"service": "api"}, "2026-01-01T00:04:30Z", 0, 1, 0.5, 0, 0, 0, 0, [0.5,0.5], 0, []],
+  ["", {"service": "api"}, "2026-01-01T00:05:00Z", 0, 1, 0.5, 0, 0, 0, 0, [0.5,0.5], 0, []]
+]
+-- args --
+[0] string = ""
+[1] float64 = 0
+[2] int64 = 1
+[3] int64 = 0
+[4] int64 = 0
+[5] int64 = 1
+[6] int64 = 0
+[7] int64 = 1
+[8] string = "nanosecond"
+[9] float64 = 1e+09
+[10] float64 = 1.1
+[11] float64 = 2
+[12] string = "nanosecond"
+[13] float64 = 1e+09
+[14] float64 = 1
+[15] int64 = 1
+[16] int64 = 1
+[17] string = "nanosecond"
+[18] int64 = 300000000000
+[19] int64 = 1
+[20] float64 = 1e+09
+[21] float64 = 1.1
+[22] float64 = 2
+[23] string = "nanosecond"
+[24] int64 = 300000000000
+[25] int64 = 1
+[26] float64 = 1e+09
+[27] int64 = 1
+[28] int64 = 1
+[29] int64 = 1
+[30] string = "nanosecond"
+[31] int64 = 1
+[32] float64 = 1e+09
+[33] int64 = 1
+[34] int64 = 1
+[35] int64 = 1
+[36] int64 = 1
+[37] int64 = 1
+[38] float64 = 300
+[39] int64 = 1
+[40] int64 = 0
+[41] int64 = 0
+[42] int64 = 1
+[43] int64 = 0
+[44] int64 = 1
+[45] string = "nanosecond"
+[46] float64 = 1e+09
+[47] float64 = 1.1
+[48] float64 = 2
+[49] string = "nanosecond"
+[50] float64 = 1e+09
+[51] float64 = 1
+[52] int64 = 1
+[53] int64 = 1
+[54] string = "nanosecond"
+[55] int64 = 300000000000
+[56] int64 = 1
+[57] float64 = 1e+09
+[58] float64 = 1.1
+[59] float64 = 2
+[60] string = "nanosecond"
+[61] int64 = 300000000000
+[62] int64 = 1
+[63] float64 = 1e+09
+[64] int64 = 1
+[65] int64 = 1
+[66] int64 = 1
+[67] string = "nanosecond"
+[68] int64 = 1
+[69] float64 = 1e+09
+[70] int64 = 1
+[71] int64 = 1
+[72] int64 = 1
+[73] int64 = 1
+[74] int64 = 1
+[75] float64 = 300
+[76] int64 = 1
+[77] int64 = 0
+[78] int64 = 0
+[79] int64 = 1
+[80] int64 = 0
+[81] int64 = 1
+[82] string = "nanosecond"
+[83] float64 = 1e+09
+[84] float64 = 1.1
+[85] float64 = 2
+[86] string = "nanosecond"
+[87] float64 = 1e+09
+[88] float64 = 1
+[89] int64 = 1
+[90] int64 = 1
+[91] string = "nanosecond"
+[92] int64 = 300000000000
+[93] int64 = 1
+[94] float64 = 1e+09
+[95] float64 = 1.1
+[96] float64 = 2
+[97] string = "nanosecond"
+[98] int64 = 300000000000
+[99] int64 = 1
+[100] float64 = 1e+09
+[101] int64 = 1
+[102] int64 = 1
+[103] int64 = 1
+[104] string = "nanosecond"
+[105] int64 = 1
+[106] float64 = 1e+09
+[107] int64 = 1
+[108] int64 = 1
+[109] int64 = 1
+[110] int64 = 1
+[111] int64 = 1
+[112] float64 = 300
+[113] int64 = 1
+[114] int64 = 0
+[115] int64 = 0
+[116] int64 = 1
+[117] int64 = 0
+[118] int64 = 1
+[119] string = "nanosecond"
+[120] float64 = 1e+09
+[121] float64 = 1.1
+[122] float64 = 2
+[123] string = "nanosecond"
+[124] float64 = 1e+09
+[125] float64 = 1
+[126] int64 = 1
+[127] int64 = 1
+[128] string = "nanosecond"
+[129] int64 = 300000000000
+[130] int64 = 1
+[131] float64 = 1e+09
+[132] float64 = 1.1
+[133] float64 = 2
+[134] string = "nanosecond"
+[135] int64 = 300000000000
+[136] int64 = 1
+[137] float64 = 1e+09
+[138] int64 = 1
+[139] int64 = 1
+[140] int64 = 1
+[141] string = "nanosecond"
+[142] int64 = 1
+[143] float64 = 1e+09
+[144] int64 = 1
+[145] int64 = 1
+[146] int64 = 1
+[147] int64 = 1
+[148] int64 = 1
+[149] int64 = 0
+[150] int64 = 1
+[151] float64 = 300
+[152] int64 = 0
+[153] int64 = 1
+[154] int64 = 1
+[155] int64 = 1
+[156] int64 = 0
+[157] int64 = 0
+[158] int64 = 1
+[159] int64 = 0
+[160] int64 = 1
+[161] string = "nanosecond"
+[162] float64 = 1e+09
+[163] float64 = 1.1
+[164] float64 = 2
+[165] string = "nanosecond"
+[166] float64 = 1e+09
+[167] float64 = 1
+[168] int64 = 1
+[169] int64 = 1
+[170] string = "nanosecond"
+[171] int64 = 300000000000
+[172] int64 = 1
+[173] float64 = 1e+09
+[174] float64 = 1.1
+[175] float64 = 2
+[176] string = "nanosecond"
+[177] int64 = 300000000000
+[178] int64 = 1
+[179] float64 = 1e+09
+[180] int64 = 1
+[181] int64 = 1
+[182] int64 = 1
+[183] string = "nanosecond"
+[184] int64 = 1
+[185] float64 = 1e+09
+[186] int64 = 1
+[187] int64 = 1
+[188] int64 = 1
+[189] int64 = 1
+[190] int64 = 1
+[191] int64 = 0
+[192] int64 = 1
+[193] float64 = 300
+[194] int64 = 0
+[195] int64 = 1
+[196] int64 = 1
+[197] string = "service.name"
+[198] string = "service_name"
+[199] string = "service.name"
+[200] string = "service_name"
+[201] string = ""
+[202] string = "service_name"
+[203] string = "latency_exp_hist"
+[204] string = "latency.exp.hist"
+[205] string = "latency.exp/hist"
+[206] string = "latency.exp_hist"
+[207] string = "latency/exp/hist"
+[208] string = "latency/exp_hist"
+[209] string = "latency_exp.hist"
+-- chplan --
+HistogramProjection project=["" AS MetricName, Attributes AS Attributes, anchor_ts AS TimeUnix, 0 AS Value]
+  Project [anchor_ts AS anchor_ts, Attributes AS Attributes, (arrayMap(wv -> arrayMap(wo -> (arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wv, wo)))[1] * arrayMap(wcv -> arrayMap(wso -> arrayMap(wsi -> arrayMap(wag -> arrayMap(wtc -> arrayMap(wrc -> if((wsi > 0), (((wsi + if((if((wrc > 0), (wsi * (arraySort((c, t) -> t, wcv, wo)[1] / wrc)), wtc) < wtc), if((wrc > 0), (wsi * (arraySort((c, t) -> t, wcv, wo)[1] / wrc)), wtc), wtc)) + if(((toFloat64(dateDiff("nanosecond", wso[length(wso)], anchor_ts)) / 1e+09) >= (1.1 * wag)), (wag / 2), (toFloat64(dateDiff("nanosecond", wso[length(wso)], anchor_ts)) / 1e+09))) / wsi), 1), array(arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wcv, wo)))[1]))[1], array(if(((toFloat64(dateDiff("nanosecond", (anchor_ts - toIntervalNanosecond(300000000000)), wso[1])) / 1e+09) >= (1.1 * wag)), (wag / 2), (toFloat64(dateDiff("nanosecond", (anchor_ts - toIntervalNanosecond(300000000000)), wso[1])) / 1e+09))))[1], array((wsi / (length(wo) - 1))))[1], array((toFloat64(dateDiff("nanosecond", wso[1], wso[length(wso)])) / 1e+09)))[1], array(arraySort(wo)))[1], array(arrayMap(n -> toFloat64(n), _hq_count_list)))[1]), array(_hq_ts_list))[1], array(arrayMap(n -> toFloat64(n), _hq_count_list)))[1] / 300) AS Count, (arrayMap(wv -> arrayMap(wo -> (arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wv, wo)))[1] * arrayMap(wcv -> arrayMap(wso -> arrayMap(wsi -> arrayMap(wag -> arrayMap(wtc -> arrayMap(wrc -> if((wsi > 0), (((wsi + if((if((wrc > 0), (wsi * (arraySort((c, t) -> t, wcv, wo)[1] / wrc)), wtc) < wtc), if((wrc > 0), (wsi * (arraySort((c, t) -> t, wcv, wo)[1] / wrc)), wtc), wtc)) + if(((toFloat64(dateDiff("nanosecond", wso[length(wso)], anchor_ts)) / 1e+09) >= (1.1 * wag)), (wag / 2), (toFloat64(dateDiff("nanosecond", wso[length(wso)], anchor_ts)) / 1e+09))) / wsi), 1), array(arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wcv, wo)))[1]))[1], array(if(((toFloat64(dateDiff("nanosecond", (anchor_ts - toIntervalNanosecond(300000000000)), wso[1])) / 1e+09) >= (1.1 * wag)), (wag / 2), (toFloat64(dateDiff("nanosecond", (anchor_ts - toIntervalNanosecond(300000000000)), wso[1])) / 1e+09))))[1], array((wsi / (length(wo) - 1))))[1], array((toFloat64(dateDiff("nanosecond", wso[1], wso[length(wso)])) / 1e+09)))[1], array(arraySort(wo)))[1], array(arrayMap(n -> toFloat64(n), _hq_count_list)))[1]), array(_hq_ts_list))[1], array(arrayMap(n -> toFloat64(n), _hq_sum_list)))[1] / 300) AS Sum, _hq_merged_scale AS Scale, (arrayMap(wv -> arrayMap(wo -> (arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wv, wo)))[1] * arrayMap(wcv -> arrayMap(wso -> arrayMap(wsi -> arrayMap(wag -> arrayMap(wtc -> arrayMap(wrc -> if((wsi > 0), (((wsi + if((if((wrc > 0), (wsi * (arraySort((c, t) -> t, wcv, wo)[1] / wrc)), wtc) < wtc), if((wrc > 0), (wsi * (arraySort((c, t) -> t, wcv, wo)[1] / wrc)), wtc), wtc)) + if(((toFloat64(dateDiff("nanosecond", wso[length(wso)], anchor_ts)) / 1e+09) >= (1.1 * wag)), (wag / 2), (toFloat64(dateDiff("nanosecond", wso[length(wso)], anchor_ts)) / 1e+09))) / wsi), 1), array(arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wcv, wo)))[1]))[1], array(if(((toFloat64(dateDiff("nanosecond", (anchor_ts - toIntervalNanosecond(300000000000)), wso[1])) / 1e+09) >= (1.1 * wag)), (wag / 2), (toFloat64(dateDiff("nanosecond", (anchor_ts - toIntervalNanosecond(300000000000)), wso[1])) / 1e+09))))[1], array((wsi / (length(wo) - 1))))[1], array((toFloat64(dateDiff("nanosecond", wso[1], wso[length(wso)])) / 1e+09)))[1], array(arraySort(wo)))[1], array(arrayMap(n -> toFloat64(n), _hq_count_list)))[1]), array(_hq_ts_list))[1], array(arrayMap(n -> toFloat64(n), _hq_zero_counts)))[1] / 300) AS ZeroCount, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - _hq_merged_scale)), _hq_scales, _hq_pos_offsets)) AS PositiveOffset, arrayMap(tb -> (arrayMap(wv -> arrayMap(wo -> (arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wv, wo)))[1] * arrayMap(wcv -> arrayMap(wso -> arrayMap(wsi -> arrayMap(wag -> arrayMap(wtc -> arrayMap(wrc -> if((wsi > 0), (((wsi + if((if((wrc > 0), (wsi * (arraySort((c, t) -> t, wcv, wo)[1] / wrc)), wtc) < wtc), if((wrc > 0), (wsi * (arraySort((c, t) -> t, wcv, wo)[1] / wrc)), wtc), wtc)) + if(((toFloat64(dateDiff("nanosecond", wso[length(wso)], anchor_ts)) / 1e+09) >= (1.1 * wag)), (wag / 2), (toFloat64(dateDiff("nanosecond", wso[length(wso)], anchor_ts)) / 1e+09))) / wsi), 1), array(arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wcv, wo)))[1]))[1], array(if(((toFloat64(dateDiff("nanosecond", (anchor_ts - toIntervalNanosecond(300000000000)), wso[1])) / 1e+09) >= (1.1 * wag)), (wag / 2), (toFloat64(dateDiff("nanosecond", (anchor_ts - toIntervalNanosecond(300000000000)), wso[1])) / 1e+09))))[1], array((wsi / (length(wo) - 1))))[1], array((toFloat64(dateDiff("nanosecond", wso[1], wso[length(wso)])) / 1e+09)))[1], array(arraySort(wo)))[1], array(arrayMap(n -> toFloat64(n), _hq_count_list)))[1]), array(_hq_ts_list))[1], array(arrayMap(n -> toFloat64(n), arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - 1)), (s - _hq_merged_scale)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets)) + tb)), arr[j], 0), arrayEnumerate(arr))), _hq_scales, _hq_pos_offsets, _hq_pos_buckets))))[1] / 300), range(toUInt64(greatest(0, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - 1)), (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets, _hq_pos_buckets)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets))) + 1))))) AS PositiveBucketCounts, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - _hq_merged_scale)), _hq_scales, _hq_neg_offsets)) AS NegativeOffset, arrayMap(tb -> (arrayMap(wv -> arrayMap(wo -> (arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wv, wo)))[1] * arrayMap(wcv -> arrayMap(wso -> arrayMap(wsi -> arrayMap(wag -> arrayMap(wtc -> arrayMap(wrc -> if((wsi > 0), (((wsi + if((if((wrc > 0), (wsi * (arraySort((c, t) -> t, wcv, wo)[1] / wrc)), wtc) < wtc), if((wrc > 0), (wsi * (arraySort((c, t) -> t, wcv, wo)[1] / wrc)), wtc), wtc)) + if(((toFloat64(dateDiff("nanosecond", wso[length(wso)], anchor_ts)) / 1e+09) >= (1.1 * wag)), (wag / 2), (toFloat64(dateDiff("nanosecond", wso[length(wso)], anchor_ts)) / 1e+09))) / wsi), 1), array(arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wcv, wo)))[1]))[1], array(if(((toFloat64(dateDiff("nanosecond", (anchor_ts - toIntervalNanosecond(300000000000)), wso[1])) / 1e+09) >= (1.1 * wag)), (wag / 2), (toFloat64(dateDiff("nanosecond", (anchor_ts - toIntervalNanosecond(300000000000)), wso[1])) / 1e+09))))[1], array((wsi / (length(wo) - 1))))[1], array((toFloat64(dateDiff("nanosecond", wso[1], wso[length(wso)])) / 1e+09)))[1], array(arraySort(wo)))[1], array(arrayMap(n -> toFloat64(n), _hq_count_list)))[1]), array(_hq_ts_list))[1], array(arrayMap(n -> toFloat64(n), arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - 1)), (s - _hq_merged_scale)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets)) + tb)), arr[j], 0), arrayEnumerate(arr))), _hq_scales, _hq_neg_offsets, _hq_neg_buckets))))[1] / 300), range(toUInt64(greatest(0, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - 1)), (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets, _hq_neg_buckets)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets))) + 1))))) AS NegativeBucketCounts]
+    RangeBucketFanout step=30s lookback=5m0s minSamples=2 groupBy=[mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapValues(mapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, "[^a-zA-Z0-9_]", "_"), mapKeys(Attributes)), mapValues(Attributes))), mapFilter((k, v) -> (v != ""), map("service_name", toString(ServiceName))))) AS Attributes] funcs=[min(Scale) AS _hq_merged_scale, groupArray(Scale) AS _hq_scales, groupArray(ZeroCount) AS _hq_zero_counts, groupArray(Count) AS _hq_count_list, groupArray(PositiveOffset) AS _hq_pos_offsets, groupArray(PositiveBucketCounts) AS _hq_pos_buckets, groupArray(NegativeOffset) AS _hq_neg_offsets, groupArray(NegativeBucketCounts) AS _hq_neg_buckets, groupArray(TimeUnix) AS _hq_ts_list, groupArray(Sum) AS _hq_sum_list] start=2026-01-01T00:00:00Z end=2026-01-01T00:05:00Z
+      Filter predicate=(MetricName IN ("latency_exp_hist", "latency.exp.hist", "latency.exp/hist", "latency.exp_hist", "latency/exp/hist", "latency/exp_hist", "latency_exp.hist"))
+        Scan(otel_metrics_exponential_histogram)
+-- sql --
+SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, `anchor_ts` AS `TimeUnix`, toFloat64(?) AS `Value`, `Count` AS `HistogramCount`, `Sum` AS `HistogramSum`, `Scale` AS `HistogramScale`, 0. AS `HistogramZeroThreshold`, `ZeroCount` AS `HistogramZeroCount`, `PositiveOffset` AS `HistogramPositiveOffset`, `PositiveBucketCounts` AS `HistogramPositiveBucketCounts`, `NegativeOffset` AS `HistogramNegativeOffset`, `NegativeBucketCounts` AS `HistogramNegativeBucketCounts` FROM (SELECT `anchor_ts` AS `anchor_ts`, `Attributes` AS `Attributes`, (arrayMap(wv -> arrayMap(wo -> (arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wv, wo)))[?] * arrayMap(wcv -> arrayMap(wso -> arrayMap(wsi -> arrayMap(wag -> arrayMap(wtc -> arrayMap(wrc -> if((wsi > ?), (((wsi + if((if((wrc > ?), (wsi * (arraySort((c, t) -> t, wcv, wo)[?] / wrc)), wtc) < wtc), if((wrc > ?), (wsi * (arraySort((c, t) -> t, wcv, wo)[?] / wrc)), wtc), wtc)) + if(((toFloat64(dateDiff(?, wso[length(wso)], `anchor_ts`)) / toFloat64(?)) >= (toFloat64(?) * wag)), (wag / toFloat64(?)), (toFloat64(dateDiff(?, wso[length(wso)], `anchor_ts`)) / toFloat64(?)))) / wsi), toFloat64(?)), array(arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wcv, wo)))[?]))[?], array(if(((toFloat64(dateDiff(?, (`anchor_ts` - toIntervalNanosecond(?)), wso[?])) / toFloat64(?)) >= (toFloat64(?) * wag)), (wag / toFloat64(?)), (toFloat64(dateDiff(?, (`anchor_ts` - toIntervalNanosecond(?)), wso[?])) / toFloat64(?)))))[?], array((wsi / (length(wo) - ?))))[?], array((toFloat64(dateDiff(?, wso[?], wso[length(wso)])) / toFloat64(?))))[?], array(arraySort(wo)))[?], array(arrayMap(n -> toFloat64(n), `_hq_count_list`)))[?]), array(`_hq_ts_list`))[?], array(arrayMap(n -> toFloat64(n), `_hq_count_list`)))[?] / toFloat64(?)) AS `Count`, (arrayMap(wv -> arrayMap(wo -> (arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wv, wo)))[?] * arrayMap(wcv -> arrayMap(wso -> arrayMap(wsi -> arrayMap(wag -> arrayMap(wtc -> arrayMap(wrc -> if((wsi > ?), (((wsi + if((if((wrc > ?), (wsi * (arraySort((c, t) -> t, wcv, wo)[?] / wrc)), wtc) < wtc), if((wrc > ?), (wsi * (arraySort((c, t) -> t, wcv, wo)[?] / wrc)), wtc), wtc)) + if(((toFloat64(dateDiff(?, wso[length(wso)], `anchor_ts`)) / toFloat64(?)) >= (toFloat64(?) * wag)), (wag / toFloat64(?)), (toFloat64(dateDiff(?, wso[length(wso)], `anchor_ts`)) / toFloat64(?)))) / wsi), toFloat64(?)), array(arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wcv, wo)))[?]))[?], array(if(((toFloat64(dateDiff(?, (`anchor_ts` - toIntervalNanosecond(?)), wso[?])) / toFloat64(?)) >= (toFloat64(?) * wag)), (wag / toFloat64(?)), (toFloat64(dateDiff(?, (`anchor_ts` - toIntervalNanosecond(?)), wso[?])) / toFloat64(?)))))[?], array((wsi / (length(wo) - ?))))[?], array((toFloat64(dateDiff(?, wso[?], wso[length(wso)])) / toFloat64(?))))[?], array(arraySort(wo)))[?], array(arrayMap(n -> toFloat64(n), `_hq_count_list`)))[?]), array(`_hq_ts_list`))[?], array(arrayMap(n -> toFloat64(n), `_hq_sum_list`)))[?] / toFloat64(?)) AS `Sum`, `_hq_merged_scale` AS `Scale`, (arrayMap(wv -> arrayMap(wo -> (arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wv, wo)))[?] * arrayMap(wcv -> arrayMap(wso -> arrayMap(wsi -> arrayMap(wag -> arrayMap(wtc -> arrayMap(wrc -> if((wsi > ?), (((wsi + if((if((wrc > ?), (wsi * (arraySort((c, t) -> t, wcv, wo)[?] / wrc)), wtc) < wtc), if((wrc > ?), (wsi * (arraySort((c, t) -> t, wcv, wo)[?] / wrc)), wtc), wtc)) + if(((toFloat64(dateDiff(?, wso[length(wso)], `anchor_ts`)) / toFloat64(?)) >= (toFloat64(?) * wag)), (wag / toFloat64(?)), (toFloat64(dateDiff(?, wso[length(wso)], `anchor_ts`)) / toFloat64(?)))) / wsi), toFloat64(?)), array(arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wcv, wo)))[?]))[?], array(if(((toFloat64(dateDiff(?, (`anchor_ts` - toIntervalNanosecond(?)), wso[?])) / toFloat64(?)) >= (toFloat64(?) * wag)), (wag / toFloat64(?)), (toFloat64(dateDiff(?, (`anchor_ts` - toIntervalNanosecond(?)), wso[?])) / toFloat64(?)))))[?], array((wsi / (length(wo) - ?))))[?], array((toFloat64(dateDiff(?, wso[?], wso[length(wso)])) / toFloat64(?))))[?], array(arraySort(wo)))[?], array(arrayMap(n -> toFloat64(n), `_hq_count_list`)))[?]), array(`_hq_ts_list`))[?], array(arrayMap(n -> toFloat64(n), `_hq_zero_counts`)))[?] / toFloat64(?)) AS `ZeroCount`, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`)) AS `PositiveOffset`, arrayMap(tb -> (arrayMap(wv -> arrayMap(wo -> (arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wv, wo)))[?] * arrayMap(wcv -> arrayMap(wso -> arrayMap(wsi -> arrayMap(wag -> arrayMap(wtc -> arrayMap(wrc -> if((wsi > ?), (((wsi + if((if((wrc > ?), (wsi * (arraySort((c, t) -> t, wcv, wo)[?] / wrc)), wtc) < wtc), if((wrc > ?), (wsi * (arraySort((c, t) -> t, wcv, wo)[?] / wrc)), wtc), wtc)) + if(((toFloat64(dateDiff(?, wso[length(wso)], `anchor_ts`)) / toFloat64(?)) >= (toFloat64(?) * wag)), (wag / toFloat64(?)), (toFloat64(dateDiff(?, wso[length(wso)], `anchor_ts`)) / toFloat64(?)))) / wsi), toFloat64(?)), array(arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wcv, wo)))[?]))[?], array(if(((toFloat64(dateDiff(?, (`anchor_ts` - toIntervalNanosecond(?)), wso[?])) / toFloat64(?)) >= (toFloat64(?) * wag)), (wag / toFloat64(?)), (toFloat64(dateDiff(?, (`anchor_ts` - toIntervalNanosecond(?)), wso[?])) / toFloat64(?)))))[?], array((wsi / (length(wo) - ?))))[?], array((toFloat64(dateDiff(?, wso[?], wso[length(wso)])) / toFloat64(?))))[?], array(arraySort(wo)))[?], array(arrayMap(n -> toFloat64(n), `_hq_count_list`)))[?]), array(`_hq_ts_list`))[?], array(arrayMap(n -> toFloat64(n), arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - ?)), (s - `_hq_merged_scale`)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`)) + tb)), arr[j], ?), arrayEnumerate(arr))), `_hq_scales`, `_hq_pos_offsets`, `_hq_pos_buckets`))))[?] / toFloat64(?)), range(toUInt64(greatest(?, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - ?)), (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`, `_hq_pos_buckets`)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`))) + ?))))) AS `PositiveBucketCounts`, arrayMin(arrayMap((s, off) -> bitShiftRight(off, (s - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`)) AS `NegativeOffset`, arrayMap(tb -> (arrayMap(wv -> arrayMap(wo -> (arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wv, wo)))[?] * arrayMap(wcv -> arrayMap(wso -> arrayMap(wsi -> arrayMap(wag -> arrayMap(wtc -> arrayMap(wrc -> if((wsi > ?), (((wsi + if((if((wrc > ?), (wsi * (arraySort((c, t) -> t, wcv, wo)[?] / wrc)), wtc) < wtc), if((wrc > ?), (wsi * (arraySort((c, t) -> t, wcv, wo)[?] / wrc)), wtc), wtc)) + if(((toFloat64(dateDiff(?, wso[length(wso)], `anchor_ts`)) / toFloat64(?)) >= (toFloat64(?) * wag)), (wag / toFloat64(?)), (toFloat64(dateDiff(?, wso[length(wso)], `anchor_ts`)) / toFloat64(?)))) / wsi), toFloat64(?)), array(arrayMap(wsr -> arraySum(arrayMap((p, c) -> if((c < p), c, (c - p)), arrayPopBack(wsr), arrayPopFront(wsr))), array(arraySort((c, t) -> t, wcv, wo)))[?]))[?], array(if(((toFloat64(dateDiff(?, (`anchor_ts` - toIntervalNanosecond(?)), wso[?])) / toFloat64(?)) >= (toFloat64(?) * wag)), (wag / toFloat64(?)), (toFloat64(dateDiff(?, (`anchor_ts` - toIntervalNanosecond(?)), wso[?])) / toFloat64(?)))))[?], array((wsi / (length(wo) - ?))))[?], array((toFloat64(dateDiff(?, wso[?], wso[length(wso)])) / toFloat64(?))))[?], array(arraySort(wo)))[?], array(arrayMap(n -> toFloat64(n), `_hq_count_list`)))[?]), array(`_hq_ts_list`))[?], array(arrayMap(n -> toFloat64(n), arrayMap((s, off, arr) -> arraySum(arrayMap(j -> if((bitShiftRight((off + (j - ?)), (s - `_hq_merged_scale`)) = (arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`)) + tb)), arr[j], ?), arrayEnumerate(arr))), `_hq_scales`, `_hq_neg_offsets`, `_hq_neg_buckets`))))[?] / toFloat64(?)), range(toUInt64(greatest(?, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - ?)), (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`, `_hq_neg_buckets`)) - arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`))) + ?))))) AS `NegativeBucketCounts` FROM (SELECT anchor_ts AS `anchor_ts`, mapSort(mapConcat(mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, min(`Scale`) AS `_hq_merged_scale`, groupArray(`Scale`) AS `_hq_scales`, groupArray(`ZeroCount`) AS `_hq_zero_counts`, groupArray(`Count`) AS `_hq_count_list`, groupArray(`PositiveOffset`) AS `_hq_pos_offsets`, groupArray(`PositiveBucketCounts`) AS `_hq_pos_buckets`, groupArray(`NegativeOffset`) AS `_hq_neg_offsets`, groupArray(`NegativeBucketCounts`) AS `_hq_neg_buckets`, groupArray(`TimeUnix`) AS `_hq_ts_list`, groupArray(`Sum`) AS `_hq_sum_list` FROM (SELECT *, arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:05:00.000000000', 9) - toIntervalNanosecond(i * 30000000000), range(greatest(0, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 300000000000, toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 300000000000, toInt64(30000000000)) < 0) + 1), least(11, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)), toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)), toInt64(30000000000)) < 0) + 1)))) AS anchor_ts FROM (SELECT * FROM `otel_metrics_exponential_histogram` WHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?))) WHERE `TimeUnix` > toDateTime64('2026-01-01 00:00:00.000000000', 9) - toIntervalNanosecond(300000000000) AND `TimeUnix` <= toDateTime64('2026-01-01 00:05:00.000000000', 9)) GROUP BY anchor_ts, `Attributes` HAVING uniqExact(`TimeUnix`) >= 2))


### PR DESCRIPTION
`rate()` and `increase()` over an OTel exponential (native) histogram return a
histogram-VALUED sample in reference Prometheus: `extrapolatedRate` hands the
range to `histogramRate`, which returns a `*FloatHistogram`, and the caller
scales that whole distribution by one boundary-extrapolation factor
(`resultHistogram.Mul(factor)`). There is no scalar anywhere in the answer.

This is the third and last of #1967's *lowerings*, after the bare selector
(#2006) and `sum()` (#2015), and like both it caps the plan with the
`chplan.HistogramProjection` those PRs built.

Refs #1967

## Reuse, not re-derivation

Almost none of the arithmetic is new. Cerberus already runs this exact window
reduction for `histogram_quantile(phi, <agg>(rate(<sel>_exp_hist[w])))` —
`expHistogramWindowAggs` + `expHistogramWindowReshape` + `histogramWindowFold`,
the counter-reset differencing times Prometheus's extrapolation factor. The
quantile path consumes the folded distribution with an interpolation kernel;
this one publishes it. Sharing one fold is what keeps the two from drifting
apart, the same discipline that let `sum()` land on the shared across-series
merge.

What is new is exactly what being histogram-VALUED costs:

- **Count and Sum**, the two whole-histogram scalars the quantile kernel never
  reads because it works off the bucket ladder. Reference folds them with
  everything else — `h.Sub(prev)` subtracts both, the reset iteration's
  `h.Add(prev)` adds them back, `h.Mul(factor)` scales both — so they go through
  the SAME fold as every bucket rather than a separate rule.
- **`rate`'s per-second division**, which reference folds into the very scalar
  the extrapolation produces (`factor /= ms.Range.Seconds()`). The quantile path
  leaves it out deliberately, since a per-series constant cancels out of every
  bucket RATIO; a published histogram is where it stops cancelling. Getting this
  wrong is invisible to every structural assertion and to `histogram_quantile`
  itself, and shows up only as a result 300x too large — so
  `TestLower_ExpHistogram_RateDividesByRangeAndIncreaseDoesNot` reads the plan
  for the divisor rather than the SQL, where the emitter parameterises it to `?`.

## One factor for the whole histogram

The place a plausible-but-wrong implementation goes wrong is extrapolating each
bucket independently. Reference computes ONE scalar from the series' own
in-window sample timestamps against the requested window edges, and multiplies
the entire result histogram by it.

The structure enforces that rather than convention:
`histogramExtrapolationFactorExpr` reads only `order` — the per-series timestamp
list, which `expHistogramWindowBucketsExpr` passes unfiltered for every bucket —
and the whole-histogram `Count` series. So every bucket, the zero bucket, Count
and Sum render the identical factor expression and scale alike.

## Coverage

All three evaluation shapes `rangeGridShapeFor` distinguishes: instant, the
query_range per-anchor fan-out, and the absolute-`@` broadcast. `__name__` is an
empty literal, because reference drops it from every range-vector function
result.

The narrowing stays honest. `rateOverExpHistogram` refuses an aggregation
WRAPPER, so `sum(rate(...))` — which needs the across-series merge stacked on
the window reduction — matches neither this dispatch nor `sumOverExpHistogram`
and keeps its explicit rejection, as does every shape that reads a `Value` the
histogram row never publishes. Seven new nested cases in the rejection test pin
that.

Four TXTAR fixtures, each with its arithmetic worked out longhand in the seed
comment and checked against the generated cell:

- `exp_histogram_rate` — single series, the durationToZero zero-crossing clamp
  binding (factor 1.25, then ÷300).
- `exp_histogram_increase_reset` — two series over three scrapes, one restarting
  mid-window, so both halves of the counter-reset rule are pinned in one file.
- `exp_histogram_increase_boundary` — two series with the SAME window increase
  but different cadences, computing genuinely different factors (1.25
  threshold-clamped vs 1.125 zero-crossing-clamped). A per-query factor would
  answer both alike, which is what this fixture refuses.
- `exp_histogram_rate_range` — the query_range grid. Its eleventh anchor is the
  load-bearing row: the window is half-open at the left, so it excludes the
  00:00:00 scrape and folds four samples over a 180s span rather than five over
  240s, computing factor 5/3 instead of 1.25 — and still landing on the
  identical rate, because recovering a linear counter's true slope from a
  partially covered window is exactly what the extrapolation is for.

## What is NOT correct yet

Counter-reset detection. Reference decides a reset for the WHOLE histogram
(`FloatHistogram.DetectReset` — any bucket, the zero bucket, the zero threshold,
the schema, or Count regressing condemns the sample) and then adds the entire
previous distribution. `counterIncreaseFold` decides per component and adds the
previous reading only of the components that themselves regressed.

Per component the two are algebraically identical *given the same set of reset
points*: with a reset at index k both compute `v_n - v_0 + v_{k-1}`. The
divergence is entirely in which points count as resets, and the two agree
exactly on a genuine restart, where every component drops together.

They drift where a bucket's post-reset count already exceeds its pre-reset count
at the next scrape (cerberus under-counts that bucket), on `Sum` (which
`DetectReset` never reads), and on a resolution increase. This is the shared
fold's pre-existing behaviour, reached today by the merged
`histogram_quantile(phi, sum(rate(<sel>_exp_hist[w])))` path — where the quantile
partly masks it by reading only bucket RATIOS — and reached without any masking
here. Fixing it needs a per-series reset MASK computed once over the rescaled
rows and threaded into every fold call, which is a new fold signature and a
rows x buckets nested expression whose rendering cost has to be watched against
the cardinality ratchet. #2017 carries it.

## Why this does not close #1967

The four lowerings #1926 step 4 asked for are now all shipped, but #1967's
"what's left" list has three further items, and I checked each rather than
assuming the lowerings were the whole of it:

- **The columnar (ch-go) decode path is still four-column.** `internal/chclient/cursor.go`
  binds the thirteen destinations; `columnar.go`'s `matrixColumns` is still exactly
  `{MetricName, Attributes, TimeUnix, Value}` and `decodeBlock` never sets
  `Sample.Histogram`. This is not a live wrong-answer bug: a thirteen-column result
  fails the `len(d.results) != 4` check, `onResult` returns `errMatrixMismatch`, and
  `queryCursorColumnar` falls back to the row cursor. Histogram queries silently lose
  the columnar fast path rather than mis-decoding.
- **`projectValueOverInner` / `projectAttributesOverInner` still reference `Value`
  unconditionally.** `label_fns.go` projects `s.ValueColumn` by name over any non-sample
  shape, which is the ClickHouse code-47 #1967 predicts. It is unreachable today only
  because `label_replace(...)`, `abs(...)` and arithmetic over an exp-histogram selector
  are all still rejected — unreachable by guard, not adapted.
- **No property-lane or compat-lane coverage.** `test/property/` has no exp-histogram
  generator at all, and every `exp_hist` query in `compatibility/prometheus/cerberus-test-queries.yml`
  is wrapped in a scalar-returning histogram function, so no corpus entry returns a
  histogram-valued result to the wire.

Closing #1967 here would close an issue with three unshipped items, so it stays open
and keeps tracking exactly those. No new issues are filed for them: #1967 already
enumerates all three, and splitting them out would be the same work under new numbers.

## #1772

#1772's catalogue entry does **not** self-clean, and the liveness gate proved it rather
than my guessing: its old trigger `rate(demo_latency_exp_hist[5m])` now lowers, so
`TestRejectionTriggersExerciseSites` failed on "the catalogued rejection is unreachable
via this query". The rejection SITE is still live for `avg()`, `resets()` and arithmetic,
which reference Prometheus answers, so this retargets the trigger at `avg(demo_latency_exp_hist)`
and keeps #1772 open as the entry's tracking issue. #1772 asked for "at minimum `rate()`" —
that bar is met — but the divergence it names is not gone.

Changing the rejection message to name the newly supported shapes also relocates the
catalogue's hashed site key, so class / trigger / tracking issue / since were re-curated
under the new key, along with three `anchorFromSelector` rationales whose caller list
`expHistogramRateWindowed` joined (each re-verified against the unchanged guards).

Three doc comments that claimed "no lowering builds this shape yet" are corrected — they
went stale when #2006 landed and this PR makes them more wrong.
