### PR TITLE
ci(crawl): ratchet the Grafana surface inventories to their canonical form

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -202,6 +202,9 @@ test/surface-parity/traceql-reference-verdicts.json  -merge
 #   (compose: the local compose stack; k3d: `just e2e-up && just e2e-seed-rolling`,
 #   or dispatch the e2e workflow with update_crawl_inventory=true and commit the
 #   uploaded artefact). `surfaces` is a flat array sorted by URL.
+#   Ratcheted per PR by .github/scripts/crawl-surface-inventory-guard.mjs
+#   (`forbid-skip`), which rebuilds each file's canonical bytes offline and
+#   demands equality — see #1674.
 test/e2e/playwright/crawl/grafana-surface-inventory.compose.json  -merge
 test/e2e/playwright/crawl/grafana-surface-inventory.k3d.json      -merge
 

--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -129,6 +129,26 @@ the pinned numbers cannot drift away from what the crawl actually asks for.
   files (`emit_node.go`, `emit.go`). See CLAUDE.md § "No raw SQL strings" and
   #1441. No env inputs; always runs the full scan.
   - Exit: `0` clean, `1` on any raw-write violation.
+- **`crawl-surface-inventory-guard.mjs`** — `ci.yml`, the `forbid-skip` job
+  step "Crawl surface inventory canonical-form ratchet (#1674)". The PR-time
+  content ratchet over
+  `test/e2e/playwright/crawl/grafana-surface-inventory.<stack>.json`, the one
+  `-merge` family that had none: full depth reaches them only on the
+  release-gated `dashboard` lane (which runs on the merge commit), and an
+  ordinary PR sees only the compose file's `lean` subset, only when
+  compose-smoke's scope triggers. Their committed FORM is a pure function of
+  their content (`marshalInventory` in `crawl/lib.ts`), so the canonical bytes
+  are rebuilt offline and compared exactly — no stack, no browser. Stacks are
+  discovered by filename pattern, so a third one is covered the day it
+  registers, and discovering none is itself a failure. It cannot see a `lean`
+  bit paired with the wrong `url`; that residue is on-stack `diffInventory`
+  work and the script's header says so.
+  - Env: `CRAWL_DIR` (default `test/e2e/playwright/crawl`).
+  - Exit: `0` every discovered inventory is canonical, `1` on a violation, an
+    unreadable/unparseable file, or an empty discovery.
+  - Pins: `crawl-surface-inventory-guard.test.mjs` (`node --test`), which
+    drives the real script over temp fixtures with a negative control per
+    check, plus a positive control over the real committed files.
 - **`generated-baseline-structural-guard.mjs`** — `ci.yml`, the `forbid-skip`
   job step "Structural sanity check over generated baseline shapes (#1568)".
   A fast, dependency-free structural pre-filter (unique key, sorted order,

--- a/.github/scripts/crawl-surface-inventory-guard.mjs
+++ b/.github/scripts/crawl-surface-inventory-guard.mjs
@@ -1,0 +1,342 @@
+// crawl-surface-inventory-guard.mjs — the PR-time content ratchet over the
+// Grafana crawl surface inventories,
+// test/e2e/playwright/crawl/grafana-surface-inventory.<stack>.json.
+//
+// # Why this exists
+//
+// #1567 marked ~28 generated baselines `-merge` in .gitattributes so a LOCAL
+// `git merge` refuses to silently blend two branches that each insert a record
+// at a nearby offset (the #1422 corruption class: record boundaries shift, a
+// name ends up paired with the next record's values, and the result still
+// parses as valid JSON with a plausible length while every entry in the
+// blended region is wrong). #1568 then established EMPIRICALLY that GitHub's
+// server-side merge does not honour that attribute at all — so the attribute
+// alone protects nothing on the path that actually lands code.
+//
+// What made that survivable everywhere else is that nearly every `-merge`
+// artefact carries a required, content-exact regenerate-and-diff ratchet:
+// TestCardinalityRatchet / TestSolverDecisionRatchet / TestScaleWallPin
+// (`perf-guards`), TestCatalogueIsRegenerable + the surface-parity inventory
+// tests (`check`), compat-ratchet.mjs (`compatibility/*`),
+// coverage-summary.mjs (`coverage`), the Tier-0 migration goldens (`lint`).
+//
+// These two files were the one family left without one (#1674). They are
+// exercised at full depth only by the release-gated `dashboard` (k3d) lane,
+// which runs its real work on the MERGE commit rather than blocking the PR;
+// on an ordinary PR `compose-smoke` walks only the `lean: true` subset of the
+// `.compose.json` rows (SWEEP_DEPTH=lean), and only when its own scope
+// triggers (internal/chsql, internal/api, internal/chclient, cmd/cerberus).
+// So a blended merge of either file could reach `main` with no PR-time check
+// having read the merged bytes.
+//
+// # Why a content-exact check is possible here at all
+//
+// The inventory content IS a live crawl result, so nothing offline can
+// re-derive WHICH surfaces belong in it. But the committed FORM is not a live
+// result: lib.ts's marshalInventory (test/e2e/playwright/crawl/lib.ts) renders
+// every inventory through one canonical serialization — top-level keys
+// {doc, stack, surfaces} in that order, rows {url, lean} in that order, rows
+// sorted by byCodepoint on `url`, two-space indent, trailing newline — and
+// crawl.spec.ts writes the file with exactly that function. The canonical form
+// is therefore a PURE function of the file's own content, which means this
+// gate can rebuild it offline and demand byte equality.
+//
+// That is what makes this a ratchet rather than a shape heuristic: it is not a
+// sample of properties that happen to hold, it is the complete set of bytes
+// the generator could have emitted for this content. Anything else — a row out
+// of order, a duplicate row, a row missing `lean`, a row carrying an extra
+// field, a reordered key, a re-indent, a dropped trailing newline, a
+// JSON-duplicate key that JSON.parse silently collapsed — changes the bytes and
+// fails here.
+//
+// generated-baseline-structural-guard.mjs deliberately excluded these two
+// files when it was written: their row order had been checked by hand against
+// a plain lexical sort and did not match, so folding them into that guard's
+// generic sorted/unique check would have encoded a false invariant. That
+// finding was true of the crawl as it then behaved. #1863 fixed the crawl's
+// non-determinism (localeCompare → byCodepoint, and order-independent
+// canonical folding), #1539/#1467 bootstrapped the k3d file and #1826 gave
+// compose a CI regeneration path; both committed files are now exactly
+// marshalInventory's output, verified against the real bytes. This gate is the
+// last member of that epic (#1467).
+//
+// # What this gate CANNOT see — stated plainly, because it matters
+//
+// A `lean` boolean paired with the WRONG `url`, where the result is still
+// sorted, still unique, and still well-shaped, is invisible here. `lean` is a
+// live crawl property with no offline source of truth, so no PR-time check can
+// derive it; a blend that swapped two rows' `lean` bits produces bytes this
+// gate accepts. That residue is caught on-stack by diffInventory (lib.ts) —
+// the compose-smoke lean crawl and the k3d `dashboard` full crawl — and
+// nowhere else. This gate closes the FORM, not the last bit of the content;
+// pretending otherwise is how a ratchet becomes a rubber stamp.
+//
+// Env:
+//   CRAWL_DIR  directory holding the inventories
+//              (default: test/e2e/playwright/crawl)
+//
+// Usage:
+//   node .github/scripts/crawl-surface-inventory-guard.mjs
+//
+// Exit codes:
+//   0  every discovered inventory is byte-identical to its canonical form.
+//   1  a violation, an unreadable/unparseable file, or no inventory found at
+//      all (a guard that reads nothing checks nothing).
+
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+import { error, log, notice } from './lib/gh.mjs';
+
+/** Default location of the crawl suite's committed inventories. */
+const DEFAULT_CRAWL_DIR = 'test/e2e/playwright/crawl';
+
+/** Filename shape: grafana-surface-inventory.<stack>.json. */
+const INVENTORY_PREFIX = 'grafana-surface-inventory.';
+const INVENTORY_SUFFIX = '.json';
+
+/**
+ * The crawl's seed surface. lib.ts defines the lean plan as "the root page,
+ * the nav links harvested from it, and one representative per drilldown app",
+ * so the root is lean by construction on every stack — a lean set that has
+ * lost it has lost the page the whole lean walk starts from.
+ */
+const ROOT_SURFACE = '/';
+
+/** marshalInventory's indent (lib.ts: JSON.stringify(…, null, 2)). */
+const CANONICAL_INDENT = 2;
+
+/** The exact field set of an inventory row, in the order it is emitted. */
+const ROW_KEYS = ['url', 'lean'];
+
+/**
+ * Order two strings by UTF-16 code unit — the ordering JS `<` gives. This
+ * MIRRORS byCodepoint in test/e2e/playwright/crawl/lib.ts, which the crawl
+ * uses for everything its OUTPUT order depends on (localeCompare is not
+ * reproducible across locales or ICU versions). The two definitions must stay
+ * identical; if lib.ts's canonical form ever changes, this gate goes red on
+ * the next regenerated file, which is the intended signal rather than a
+ * surprise.
+ */
+export function byCodepoint(a, b) {
+  if (a < b) return -1;
+  return a > b ? 1 : 0;
+}
+
+/**
+ * Render the canonical serialized form of an inventory — the bytes
+ * marshalInventory (lib.ts) would have written for this content.
+ *
+ * Every field is REBUILT rather than passed through, which is what gives the
+ * byte comparison its reach: an extra field, a missing field, a reordered key
+ * or an unexpected top-level entry cannot survive the rebuild, so it shows up
+ * as a byte difference instead of round-tripping unnoticed.
+ */
+export function canonicalize(inv) {
+  const surfaces = [...inv.surfaces]
+    .sort((a, b) => byCodepoint(a.url, b.url))
+    .map(({ url, lean }) => ({ url, lean }));
+  const doc = { doc: inv.doc, stack: inv.stack, surfaces };
+  return `${JSON.stringify(doc, null, CANONICAL_INDENT)}\n`;
+}
+
+/**
+ * Check one committed inventory. Returns a list of human-readable problems;
+ * an empty list means the file is byte-identical to its canonical form.
+ *
+ * `filename` is used both for the label and as the source of truth for which
+ * stack the file claims to pin — the field and the name are two independent
+ * statements of the same fact, so they can contradict each other.
+ */
+export function checkInventory({ filename, raw }) {
+  const problems = [];
+  const label = filename;
+
+  let inv;
+  try {
+    inv = JSON.parse(raw);
+  } catch (e) {
+    return [`${label}: is not parseable JSON — ${e.message}`];
+  }
+
+  if (inv === null || typeof inv !== 'object' || Array.isArray(inv)) {
+    return [`${label}: expected a JSON object at the top level, got ${Array.isArray(inv) ? 'an array' : typeof inv}`];
+  }
+
+  const stackFromName = filename.slice(
+    INVENTORY_PREFIX.length,
+    filename.length - INVENTORY_SUFFIX.length,
+  );
+
+  if (typeof inv.doc !== 'string' || inv.doc === '') {
+    problems.push(`${label}: "doc" must be a non-empty string documenting the regen convention`);
+  }
+  if (typeof inv.stack !== 'string' || inv.stack === '') {
+    problems.push(`${label}: "stack" must be a non-empty string`);
+  } else if (inv.stack !== stackFromName) {
+    problems.push(
+      `${label}: pins stack ${JSON.stringify(inv.stack)} but its filename says ` +
+        `${JSON.stringify(stackFromName)} — the file and the field disagree about which stack this inventory ` +
+        'describes, which is what a merge that crossed two stacks\' files produces.',
+    );
+  }
+  if (!Array.isArray(inv.surfaces)) {
+    problems.push(`${label}: "surfaces" must be an array, got ${typeof inv.surfaces}`);
+    return problems;
+  }
+
+  // Row shape. Checked before order and before the byte comparison: a
+  // malformed row makes both of those report something misleading.
+  inv.surfaces.forEach((row, i) => {
+    if (row === null || typeof row !== 'object' || Array.isArray(row)) {
+      problems.push(`${label}: surfaces[${i}] is not an object`);
+      return;
+    }
+    const keys = Object.keys(row);
+    if (keys.length !== ROW_KEYS.length || keys.some((k, j) => k !== ROW_KEYS[j])) {
+      problems.push(
+        `${label}: surfaces[${i}] has fields ${JSON.stringify(keys)}, expected exactly ` +
+          `${JSON.stringify(ROW_KEYS)} in that order. A blend that spliced one row's trailing fields onto ` +
+          'another\'s leading fields produces exactly this.',
+      );
+    }
+    if (typeof row.url !== 'string' || row.url === '') {
+      problems.push(`${label}: surfaces[${i}].url must be a non-empty string`);
+    }
+    if (typeof row.lean !== 'boolean') {
+      problems.push(
+        `${label}: surfaces[${i}].lean must be a boolean, got ${JSON.stringify(row.lean)}`,
+      );
+    }
+  });
+  if (problems.length > 0) return problems;
+
+  const urls = inv.surfaces.map((r) => r.url);
+
+  const firstSeenAt = new Map();
+  urls.forEach((u, i) => {
+    if (firstSeenAt.has(u)) {
+      problems.push(
+        `${label}: duplicate url ${JSON.stringify(u)} at index ${firstSeenAt.get(u)} and ${i} — ` +
+          'the inventory pins a SET of surfaces, so a repeated url means two branches inserted the same row.',
+      );
+    } else {
+      firstSeenAt.set(u, i);
+    }
+  });
+
+  for (let i = 1; i < urls.length; i++) {
+    if (byCodepoint(urls[i - 1], urls[i]) >= 0) {
+      problems.push(
+        `${label}: out of canonical order at index ${i} — ${JSON.stringify(urls[i - 1])} then ` +
+          `${JSON.stringify(urls[i])}. marshalInventory emits rows sorted by byCodepoint on url; a merge that ` +
+          'silently interleaved two branches\' insertions (the #1422 shape) lands a row next to the wrong ' +
+          'neighbour and breaks exactly this.',
+      );
+    }
+  }
+
+  const root = inv.surfaces.find((r) => r.url === ROOT_SURFACE);
+  if (root === undefined) {
+    problems.push(
+      `${label}: no ${JSON.stringify(ROOT_SURFACE)} surface — the crawl's BFS is seeded from the root page, ` +
+        'so an inventory without it does not describe a reachable surface set.',
+    );
+  } else if (root.lean !== true) {
+    problems.push(
+      `${label}: the ${JSON.stringify(ROOT_SURFACE)} surface is not lean. The lean (per-PR) plan is defined as ` +
+        'the root page plus the nav links harvested from it plus one representative per drilldown app, so a ' +
+        'non-lean root would leave the lean crawl with nothing to walk from.',
+    );
+  }
+
+  if (problems.length > 0) return problems;
+
+  const canonical = canonicalize(inv);
+  if (canonical !== raw) {
+    problems.push(
+      `${label}: does NOT match its canonical serialized form. This file is generated — regenerate it rather ` +
+        'than hand-editing it:\n' +
+        `  CERBERUS_UPDATE_INVENTORY=1 SWEEP_DEPTH=full CRAWL_STACK=${stackFromName} npx playwright test crawl/crawl.spec.ts\n` +
+        '  (or dispatch the e2e workflow with update_crawl_inventory=true)\n' +
+        'The canonical form is marshalInventory in test/e2e/playwright/crawl/lib.ts: keys {doc, stack, ' +
+        `surfaces}, rows {url, lean}, rows sorted by byCodepoint on url, ${CANONICAL_INDENT}-space indent, ` +
+        `trailing newline. Committed ${raw.length} byte(s), canonical ${canonical.length} byte(s); first ` +
+        `difference at byte ${firstDifference(raw, canonical)}.`,
+    );
+  }
+
+  return problems;
+}
+
+/** Byte offset of the first difference between two strings, for the message. */
+function firstDifference(a, b) {
+  const n = Math.min(a.length, b.length);
+  for (let i = 0; i < n; i++) {
+    if (a[i] !== b[i]) return i;
+  }
+  return n;
+}
+
+export function main() {
+  const dir = process.env.CRAWL_DIR || DEFAULT_CRAWL_DIR;
+
+  let names;
+  try {
+    names = readdirSync(dir)
+      .filter((n) => n.startsWith(INVENTORY_PREFIX) && n.endsWith(INVENTORY_SUFFIX))
+      .sort();
+  } catch (e) {
+    error(`crawl-surface-inventory-guard: cannot read ${dir} — ${e.message}`, {
+      title: 'crawl-surface-inventory-guard',
+    });
+    process.exit(1);
+  }
+
+  // A guard that discovers nothing reports green while checking nothing —
+  // the failure mode this whole family exists to close. Discovery is by
+  // pattern rather than a hard-coded pair so a third stack is covered the day
+  // it registers, with no list to forget to update.
+  if (names.length === 0) {
+    error(
+      `crawl-surface-inventory-guard: no ${INVENTORY_PREFIX}*${INVENTORY_SUFFIX} file under ${dir} — the guard ` +
+        'read nothing, so it checked nothing. Either the inventories moved and this gate must follow them, or ' +
+        'CRAWL_DIR is pointed at the wrong tree.',
+      { title: 'crawl-surface-inventory-guard' },
+    );
+    process.exit(1);
+  }
+
+  const problems = [];
+  for (const name of names) {
+    try {
+      problems.push(
+        ...checkInventory({ filename: name, raw: readFileSync(path.join(dir, name), 'utf8') }),
+      );
+    } catch (e) {
+      problems.push(`${name}: ${e.message}`);
+    }
+  }
+
+  if (problems.length > 0) {
+    for (const p of problems) error(p, { title: 'crawl-surface-inventory-guard' });
+    log(
+      `\n${problems.length} violation(s) across ${names.length} crawl surface inventory file(s). These files are ` +
+        '`-merge`-marked in .gitattributes, and #1568 established that GitHub\'s server-side merge ignores that ' +
+        'attribute — so a blended merge reaches this gate looking like valid JSON. Regenerate from a real crawl ' +
+        'rather than hand-editing.\n' +
+        'Note what this gate does NOT prove: a `lean` boolean paired with the wrong `url`, still sorted and ' +
+        'unique, passes here. `lean` is a live crawl property with no offline source of truth; that residue is ' +
+        'caught on-stack by diffInventory in the compose-smoke lean crawl and the k3d `dashboard` full crawl.',
+    );
+    process.exit(1);
+  }
+
+  notice(
+    `crawl-surface-inventory-guard: ${names.length} inventory file(s) byte-identical to their canonical form ` +
+      `(${names.join(', ')}).`,
+  );
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) main();

--- a/.github/scripts/crawl-surface-inventory-guard.test.mjs
+++ b/.github/scripts/crawl-surface-inventory-guard.test.mjs
@@ -1,0 +1,318 @@
+// crawl-surface-inventory-guard.test.mjs — pins for the crawl surface
+// inventory ratchet.
+//
+// A ratchet is only worth its runtime if it goes RED on the corruption it
+// claims to catch. This gate's whole reason to exist is #1568's finding that
+// GitHub's server-side merge ignores `.gitattributes`' `-merge` driver, which
+// means the only thing standing between a blended
+// grafana-surface-inventory.<stack>.json and `main` is the gate itself — and a
+// gate that always says "clean" is indistinguishable from a repository with no
+// corruption. So every check it advertises gets a negative control here.
+//
+// The fixtures are hand-written canonical bytes rather than output of the
+// script's own canonicalize(): generating the expected form from the code
+// under test would make the positive control tautological — it would pass for
+// any canonicalize() whatsoever, including a broken one. Stating the bytes
+// independently is what makes "this file is canonical" a claim the test can
+// falsify.
+//
+// The real script is driven as a subprocess over a temp CRAWL_DIR, so what is
+// pinned is the gate as CI invokes it (discovery, exit code, message), not a
+// hand-picked internal function.
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { test } from 'node:test';
+
+const SCRIPT = fileURLToPath(new URL('./crawl-surface-inventory-guard.mjs', import.meta.url));
+const REPO_ROOT = fileURLToPath(new URL('../..', import.meta.url));
+
+const FIXTURE_STACK = 'fixture';
+const FIXTURE_NAME = `grafana-surface-inventory.${FIXTURE_STACK}.json`;
+
+// The canonical bytes, written out by hand: keys {doc, stack, surfaces}, rows
+// {url, lean}, rows in byCodepoint order on url, two-space indent, trailing
+// newline. This is marshalInventory's contract stated independently of the
+// code that checks it.
+const CANONICAL = `{
+  "doc": "fixture inventory",
+  "stack": "${FIXTURE_STACK}",
+  "surfaces": [
+    {
+      "url": "/",
+      "lean": true
+    },
+    {
+      "url": "/a/app/explore",
+      "lean": true
+    },
+    {
+      "url": "/d/uid",
+      "lean": false
+    }
+  ]
+}
+`;
+
+/** Run the real gate over a temp directory holding the given files. */
+function runGuard(files) {
+  const dir = mkdtempSync(path.join(tmpdir(), 'crawl-inv-guard-'));
+  try {
+    for (const [name, body] of Object.entries(files)) {
+      writeFileSync(path.join(dir, name), body);
+    }
+    const res = spawnSync(process.execPath, [SCRIPT], {
+      cwd: REPO_ROOT,
+      env: { ...process.env, CRAWL_DIR: dir },
+      encoding: 'utf8',
+    });
+    return { status: res.status, out: `${res.stdout}${res.stderr}` };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+/** Assert the gate rejects `body`, and that it says why in recognisable terms. */
+function assertRejected(body, expectedFragment, label) {
+  const { status, out } = runGuard({ [FIXTURE_NAME]: body });
+  assert.equal(status, 1, `${label}: expected a non-zero exit, got ${status}\n${out}`);
+  assert.match(out, expectedFragment, `${label}: message did not name the violation\n${out}`);
+}
+
+// ---------------------------------------------------------------------------
+// Positive controls
+// ---------------------------------------------------------------------------
+
+test('accepts a canonical inventory', () => {
+  const { status, out } = runGuard({ [FIXTURE_NAME]: CANONICAL });
+  assert.equal(status, 0, `expected a clean exit\n${out}`);
+  assert.match(out, /byte-identical to their canonical form/);
+});
+
+test('the committed inventories are canonical (the gate matches reality)', () => {
+  // No CRAWL_DIR: the gate reads the real test/e2e/playwright/crawl tree. If
+  // this ever fails, either a committed inventory was hand-edited or the
+  // gate's notion of canonical has drifted from lib.ts's marshalInventory.
+  const res = spawnSync(process.execPath, [SCRIPT], { cwd: REPO_ROOT, encoding: 'utf8' });
+  const out = `${res.stdout}${res.stderr}`;
+  assert.equal(res.status, 0, `the committed inventories are not canonical\n${out}`);
+  assert.match(out, /grafana-surface-inventory\.compose\.json/);
+  assert.match(out, /grafana-surface-inventory\.k3d\.json/);
+});
+
+test('covers every discovered stack, not a hard-coded pair', () => {
+  const second = 'grafana-surface-inventory.other.json';
+  const { status, out } = runGuard({
+    [FIXTURE_NAME]: CANONICAL,
+    [second]: CANONICAL.replace(`"${FIXTURE_STACK}"`, '"other"'),
+  });
+  assert.equal(status, 0, `expected both files to pass\n${out}`);
+  assert.match(out, /2 inventory file\(s\)/);
+});
+
+// ---------------------------------------------------------------------------
+// Negative controls — the #1422 blend shapes
+// ---------------------------------------------------------------------------
+
+test('rejects rows that are out of canonical order (the blend shape)', () => {
+  // Two rows transposed: still valid JSON, still the same row SET, still the
+  // same length — the signature of a merge that interleaved two branches.
+  const swapped = CANONICAL.replace(
+    `    {
+      "url": "/a/app/explore",
+      "lean": true
+    },
+    {
+      "url": "/d/uid",
+      "lean": false
+    }`,
+    `    {
+      "url": "/d/uid",
+      "lean": false
+    },
+    {
+      "url": "/a/app/explore",
+      "lean": true
+    }`,
+  );
+  assert.notEqual(swapped, CANONICAL, 'fixture edit did not apply');
+  assertRejected(swapped, /out of canonical order/, 'transposed rows');
+});
+
+test('rejects a duplicate url', () => {
+  const dup = CANONICAL.replace(
+    `    {
+      "url": "/d/uid",
+      "lean": false
+    }`,
+    `    {
+      "url": "/a/app/explore",
+      "lean": false
+    }`,
+  );
+  assertRejected(dup, /duplicate url/, 'duplicate row');
+});
+
+test('rejects a row missing the lean field', () => {
+  const missing = CANONICAL.replace(
+    `    {
+      "url": "/d/uid",
+      "lean": false
+    }`,
+    `    {
+      "url": "/d/uid"
+    }`,
+  );
+  assertRejected(missing, /expected exactly \["url","lean"\]/, 'missing lean');
+});
+
+test('rejects a row carrying an extra field', () => {
+  const extra = CANONICAL.replace(
+    `      "url": "/d/uid",
+      "lean": false`,
+    `      "url": "/d/uid",
+      "lean": false,
+      "depth": "full"`,
+  );
+  assertRejected(extra, /expected exactly \["url","lean"\]/, 'extra field');
+});
+
+test('rejects reordered row keys', () => {
+  const reordered = CANONICAL.replace(
+    `      "url": "/d/uid",
+      "lean": false`,
+    `      "lean": false,
+      "url": "/d/uid"`,
+  );
+  assertRejected(reordered, /expected exactly \["url","lean"\]/, 'reordered keys');
+});
+
+test('rejects a non-boolean lean', () => {
+  const stringy = CANONICAL.replace('"lean": false', '"lean": "false"');
+  assertRejected(stringy, /lean must be a boolean/, 'stringified lean');
+});
+
+// ---------------------------------------------------------------------------
+// Negative controls — serialization drift the row checks alone would miss
+// ---------------------------------------------------------------------------
+
+test('rejects a re-indented file', () => {
+  const reindented = `${JSON.stringify(JSON.parse(CANONICAL), null, 4)}\n`;
+  assertRejected(reindented, /does NOT match its canonical serialized form/, 're-indent');
+});
+
+test('rejects a missing trailing newline', () => {
+  assertRejected(
+    CANONICAL.trimEnd(),
+    /does NOT match its canonical serialized form/,
+    'no trailing newline',
+  );
+});
+
+test('rejects an extra top-level field', () => {
+  const extra = CANONICAL.replace('  "doc":', '  "generatedAt": "2026-08-09",\n  "doc":');
+  assertRejected(extra, /does NOT match its canonical serialized form/, 'extra top-level key');
+});
+
+test('rejects a duplicated JSON key that JSON.parse silently collapses', () => {
+  // A blend can produce two "doc" members. JSON.parse keeps the last and the
+  // structure looks clean; only the BYTES disagree.
+  const doubled = CANONICAL.replace('  "doc":', '  "doc": "stale",\n  "doc":');
+  assertRejected(doubled, /does NOT match its canonical serialized form/, 'duplicate JSON key');
+});
+
+// ---------------------------------------------------------------------------
+// Negative controls — file identity and the crawl's own preconditions
+// ---------------------------------------------------------------------------
+
+test('rejects a stack field that disagrees with the filename', () => {
+  const crossed = CANONICAL.replace(`"stack": "${FIXTURE_STACK}"`, '"stack": "k3d"');
+  assertRejected(crossed, /the file and the field disagree/, 'crossed stacks');
+});
+
+test('rejects an inventory with no root surface', () => {
+  const rootless = CANONICAL.replace(
+    `    {
+      "url": "/",
+      "lean": true
+    },
+`,
+    '',
+  );
+  assertRejected(rootless, /no "\/" surface/, 'missing root');
+});
+
+test('rejects a non-lean root surface', () => {
+  const notLean = CANONICAL.replace(
+    `      "url": "/",
+      "lean": true`,
+    `      "url": "/",
+      "lean": false`,
+  );
+  assertRejected(notLean, /is not lean/, 'non-lean root');
+});
+
+test('rejects unparseable JSON', () => {
+  assertRejected(`${CANONICAL.trimEnd()},\n`, /not parseable JSON/, 'trailing comma');
+});
+
+// ---------------------------------------------------------------------------
+// Negative control — vacuity
+// ---------------------------------------------------------------------------
+
+test('fails when it discovers no inventory at all', () => {
+  // The failure this whole family exists to close: a gate that reads nothing
+  // reports clean forever. Moving or renaming the inventories must break the
+  // gate loudly rather than silently disarm it.
+  const { status, out } = runGuard({ 'unrelated.json': '{}\n' });
+  assert.equal(status, 1, `expected a non-zero exit over an empty discovery\n${out}`);
+  assert.match(out, /read nothing, so it checked nothing/);
+});
+
+test('fails when CRAWL_DIR does not exist', () => {
+  const dir = mkdtempSync(path.join(tmpdir(), 'crawl-inv-guard-gone-'));
+  const missing = path.join(dir, 'nope');
+  try {
+    const res = spawnSync(process.execPath, [SCRIPT], {
+      cwd: REPO_ROOT,
+      env: { ...process.env, CRAWL_DIR: missing },
+      encoding: 'utf8',
+    });
+    assert.equal(res.status, 1);
+    assert.match(`${res.stdout}${res.stderr}`, /cannot read/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// The gate's stated blind spot, pinned so it stays honest
+// ---------------------------------------------------------------------------
+
+test('a swapped lean bit passes — the limit the gate documents', () => {
+  // Two rows exchange their `lean` values. Still sorted, still unique, still
+  // canonical: the bytes are exactly what the generator would emit for this
+  // content, so nothing offline can tell this from a legitimate crawl result.
+  // Pinned deliberately — if a future change makes this detectable, the gate's
+  // "what this CANNOT see" paragraph must lose it rather than keep overclaiming
+  // in the other direction.
+  const swappedLean = CANONICAL.replace(
+    `      "url": "/a/app/explore",
+      "lean": true`,
+    `      "url": "/a/app/explore",
+      "lean": false`,
+  ).replace(
+    `      "url": "/d/uid",
+      "lean": false`,
+    `      "url": "/d/uid",
+      "lean": true`,
+  );
+  assert.notEqual(swappedLean, CANONICAL, 'fixture edit did not apply');
+  const { status } = runGuard({ [FIXTURE_NAME]: swappedLean });
+  assert.equal(status, 0, 'the gate claims not to catch this; if it now does, update its header');
+});

--- a/.github/scripts/generated-baseline-structural-guard.mjs
+++ b/.github/scripts/generated-baseline-structural-guard.mjs
@@ -75,11 +75,19 @@
 // exercised at full depth only by the release-gated `dashboard` (k3d) lane,
 // which runs on the merge commit rather than blocking the PR; `compose-smoke`
 // only walks the `lean: true` subset of the `.compose.json` file's rows when
-// its own scope triggers. That gap is tracked separately (see the PR body /
-// the follow-up issue it filed) rather than guessed at here — the file's
-// row order was checked by hand and is NOT a simple lexical sort (it groups
-// by base path in crawl-discovery order), so folding it into this guard's
-// generic sorted/unique check would have been a false invariant.
+// its own scope triggers. That gap was tracked as #1674 rather than guessed at
+// here, because at the time the files' row order had been checked by hand
+// against a plain lexical sort and did not match — folding them into this
+// guard's generic check would have encoded a false invariant.
+//
+// It no longer would, and they are no longer this guard's business either way.
+// #1863 made the crawl deterministic (localeCompare → byCodepoint, plus
+// order-independent canonical folding), so both files are now exactly
+// marshalInventory's output. #1674 closed the gap with a dedicated,
+// content-EXACT ratchet — crawl-surface-inventory-guard.mjs, which rebuilds
+// each file's canonical bytes offline and demands equality. That is a stronger
+// claim than this guard's structural pre-filter makes about anything, so the
+// two files stay out of TARGETS below and live there instead.
 //
 // # What THIS script adds
 //

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -899,6 +899,20 @@ jobs:
           node .github/scripts/generated-baseline-structural-guard.mjs --self-test
           node .github/scripts/generated-baseline-structural-guard.mjs
 
+      # #1674: the crawl surface inventories were the one `-merge` family with
+      # no PR-time content ratchet — full depth only on the release-gated
+      # `dashboard` (k3d) lane, which runs on the merge commit, and on an
+      # ordinary PR only the `lean` subset of the compose file, and only when
+      # compose-smoke's scope triggers. Their committed FORM is a pure function
+      # of their content (marshalInventory in crawl/lib.ts), so the canonical
+      # bytes can be rebuilt offline and compared exactly — no stack, no
+      # browser, milliseconds. The self-test runs first because a gate over a
+      # generated baseline is worthless unless it demonstrably goes red.
+      - name: Crawl surface inventory canonical-form ratchet (#1674)
+        run: |
+          node --test .github/scripts/crawl-surface-inventory-guard.test.mjs
+          node .github/scripts/crawl-surface-inventory-guard.mjs
+
       # #1877: post-merge-drift.yml is the ONLY lane that ever looks at the
       # bytes a squash-merge actually produced, and it reports on `main` where
       # no PR check can gate it. That makes a silent break in it invisible — a

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -1073,10 +1073,31 @@ shard's key field equals the path it is filed under — and, on both shapes
 where the records were verified uniform, one consistent field set. It is a cheap, always-on second
 signal, not a replacement for the content-exact ratchets above — a
 structural check cannot tell a value that is merely out of place from one
-that is subtly wrong. One family was found to have weaker per-PR coverage:
+that is subtly wrong.
+
 `test/e2e/playwright/crawl/grafana-surface-inventory.{compose,k3d}.json` are
-exercised at full depth only by the release-gated `dashboard` (k3d) lane
-(the merge commit, not the PR), with `compose-smoke` walking only the
-`lean: true` subset of the `.compose.json` rows when its own scope triggers;
-that gap is tracked as a follow-up issue rather than papered over with an
-unverified invariant.
+the one `-merge` family that lands outside that list. Full depth reaches them
+only through the release-gated `dashboard` (k3d) lane, which runs on the merge
+commit rather than the PR, and an ordinary PR sees only the `lean: true`
+subset of the `.compose.json` rows, only when `compose-smoke`'s own scope
+triggers. `.github/scripts/crawl-surface-inventory-guard.mjs` closes that in
+the required `forbid-skip` job. The inventory's content is a live crawl result
+that nothing offline can re-derive, but its committed FORM is not: every
+inventory is written through `marshalInventory`
+(`test/e2e/playwright/crawl/lib.ts`), whose output — keys `{doc, stack,
+surfaces}`, rows `{url, lean}`, rows sorted by `byCodepoint` on `url`,
+two-space indent, trailing newline — is a pure function of the content. The
+guard rebuilds those bytes and demands equality, so a row out of order, a
+duplicate row, a missing or extra field, a reordered key, a re-indent, a
+dropped newline or a JSON-duplicate key all fail it. Stacks are discovered by
+filename pattern, and discovering none is itself a failure, so the gate cannot
+quietly disarm itself when a file moves.
+
+What it does not prove is worth stating: a `lean` boolean paired with the
+wrong `url`, still sorted and unique, is bytes the generator could legitimately
+have emitted. `lean` has no offline source of truth, so that residue belongs to
+`diffInventory` on a live stack — the `compose-smoke` lean crawl and the k3d
+`dashboard` full crawl — and the guard's own header and failure text say so.
+`crawl-surface-inventory-guard.test.mjs` carries a negative control per check
+plus a pin on the documented blind spot, so the gate cannot rot into a rubber
+stamp in either direction.


### PR DESCRIPTION
## What

`test/e2e/playwright/crawl/grafana-surface-inventory.compose.json` and
`.k3d.json` are `-merge`-marked generated baselines with **no PR-time content
ratchet** — the last member of #1467's epic. This adds one:
`.github/scripts/crawl-surface-inventory-guard.mjs`, wired into the required
`forbid-skip` job.

## The gap, with evidence

- Full depth reaches these files only through the release-gated `dashboard`
  (k3d) lane, which runs its real work on the **merge commit**, not the PR —
  `.github/workflows/e2e.yml:1148-1188`.
- On an ordinary PR, `compose-smoke` walks only the `lean: true` subset of the
  compose file (`SWEEP_DEPTH=lean`), and only when its own scope triggers —
  `.github/workflows/e2e.yml:678-702`.
- #1568 established empirically that GitHub's server-side merge ignores
  `.gitattributes`' `-merge` driver entirely.

So a #1422-shape blend of either file could land on `main` with nothing having
read the merged bytes.

## Why a content-exact check is possible offline

The inventory *content* is a live crawl result nothing offline can re-derive.
Its committed *form* is not. `crawl.spec.ts:1673` writes every inventory
through `marshalInventory` (`crawl/lib.ts:941`), whose output — keys
`{doc, stack, surfaces}`, rows `{url, lean}`, rows sorted by `byCodepoint` on
`url`, two-space indent, trailing newline — is a pure function of the content.
The guard rebuilds those bytes and demands equality. No stack, no browser,
milliseconds.

Rebuilding rather than passing fields through is what gives it reach. A row out
of order, a duplicate row, a missing or extra field, a reordered key, a
re-indent, a dropped trailing newline, or a JSON-duplicate key that
`JSON.parse` silently collapsed all change the bytes and fail. Stacks are
discovered by filename pattern, so a third stack is covered the day it
registers — and discovering *none* is itself a failure, so the gate cannot
quietly disarm itself if the files move.

## Why option 1 (this) over options 2 and 3

The issue offered three shapes. This is option 1, narrowed to what is genuinely
invariant — and it turned out to be a full byte-exact ratchet rather than the
weaker structural fallback the issue expected.

- **Option 2** (extend compose-smoke's lean crawl to 100% of rows) buys full
  coverage of one file at the cost of PR latency, still leaves `.k3d.json`
  uncovered, and still only fires when compose-smoke's scope triggers. It
  answers less, on fewer PRs, for more minutes.
- **Option 3** (best-effort structural check) is strictly weaker than what
  turned out to be available: byte equality subsumes unique-`url` and uniform
  key shape, and adds indentation, key order, top-level shape and
  JSON-duplicate detection that a structural check cannot see.

The issue's line-18 caveat — that row order "is NOT a simple lexical sort" — was
true when #1568 wrote it and is not true now. #1863 fixed the crawl's
non-determinism (`localeCompare` → `byCodepoint`, order-independent canonical
folding); both committed files are byte-identical to `marshalInventory`'s
output today, verified against the real bytes. That is exactly the ordering
#1467 requires: determinism (#1863) → bootstrap (#1539/#1467) → regeneration
(#1826) → ratchet (this). All three predecessors are closed.

`generated-baseline-structural-guard.mjs`'s header carried the stale premise
and is corrected here.

## False invariants tested and rejected

Two plausible checks were tested against the committed content before being
written, and **rejected as false**: "every app group has a lean
representative" fails for `/a/grafana-pyroscope-app` and `/d` on *both*
stacks. Only what actually holds is asserted — encoding either would have been
the exact false-invariant trap the issue warns about.

## What this does NOT catch — stated in the gate itself

A `lean` boolean paired with the wrong `url`, still sorted and unique, is bytes
the generator could legitimately have emitted. `lean` is a live crawl property
with no offline source of truth, so no PR-time check can derive it. That
residue stays with `diffInventory` on a live stack (the compose-smoke lean
crawl, the k3d `dashboard` full crawl). This limit is written into the script
header, its failure text, and `docs/test-strategy.md` — a ratchet that
overclaims becomes a rubber stamp.

## Verification

`crawl-surface-inventory-guard.test.mjs` drives the real script as a subprocess
over temp fixtures — 20 tests, all passing locally:

- **16 negative controls**, one per advertised check: transposed rows (the
  #1422 shape), duplicate `url`, missing `lean`, extra field, reordered keys,
  non-boolean `lean`, re-indent, missing trailing newline, extra top-level
  field, duplicated JSON key, stack/filename disagreement, missing root,
  non-lean root, unparseable JSON, empty discovery, missing `CRAWL_DIR`.
- **Positive controls**: a hand-written canonical fixture (written out by hand,
  not generated by the code under test, so the positive control is not
  tautological), and the real committed files.
- **A pin on the documented blind spot**, so the gate stays honest in both
  directions.

Additionally, transposing two rows in the *real* committed compose inventory
made the gate go red naming the exact adjacent pair; reverting restored green.

Fixture files were untouched — no generated artefact was hand-edited.

Closes #1674
