### PR TITLE
fix(e2e): resync both crawl inventories' doc field with stacks.ts

### DIFF
--- a/test/e2e/playwright/crawl/grafana-surface-inventory.compose.json
+++ b/test/e2e/playwright/crawl/grafana-surface-inventory.compose.json
@@ -1,5 +1,5 @@
 {
-  "doc": "Pinned canonical Grafana surface set for the compose stack, emitted by test/e2e/playwright/crawl/crawl.spec.ts. lean=true rows are the per-PR crawl (root + nav + one representative per drilldown app); every row is crawled nightly. Regenerate deliberately against a healthy compose stack with: CERBERUS_UPDATE_INVENTORY=1 SWEEP_DEPTH=full CRAWL_STACK=compose npx playwright test crawl/crawl.spec.ts",
+  "doc": "Pinned canonical Grafana surface set for the compose stack, emitted by test/e2e/playwright/crawl/crawl.spec.ts. lean=true rows are the per-PR crawl (root + nav + one representative per drilldown app); every row is crawled nightly. Regenerate deliberately against a healthy compose stack with: CERBERUS_UPDATE_INVENTORY=1 SWEEP_DEPTH=full CRAWL_STACK=compose npx playwright test crawl/crawl.spec.ts — or dispatch the e2e workflow with update_crawl_inventory=compose (or =both) and commit the uploaded grafana-surface-inventory-compose artifact (tsouza/cerberus#1826).",
   "stack": "compose",
   "surfaces": [
     {

--- a/test/e2e/playwright/crawl/grafana-surface-inventory.k3d.json
+++ b/test/e2e/playwright/crawl/grafana-surface-inventory.k3d.json
@@ -1,5 +1,5 @@
 {
-  "doc": "Pinned canonical Grafana surface set for the k3d stack, emitted by test/e2e/playwright/crawl/crawl.spec.ts. The k3d crawl lane (dashboard job, .github/workflows/e2e.yml) runs nightly + on manual dispatch at SWEEP_DEPTH=full, so every row is crawled each run; lean=true rows mark the local fast-lane subset only. Regenerate deliberately against a healthy k3d stack (just e2e-up && just e2e-seed-rolling) with: CERBERUS_UPDATE_INVENTORY=1 SWEEP_DEPTH=full CRAWL_STACK=k3d npx playwright test crawl/crawl.spec.ts — or dispatch the e2e workflow with update_crawl_inventory=true and commit the uploaded artifact.",
+  "doc": "Pinned canonical Grafana surface set for the k3d stack, emitted by test/e2e/playwright/crawl/crawl.spec.ts. The k3d crawl lane (dashboard job, .github/workflows/e2e.yml) runs nightly + on manual dispatch at SWEEP_DEPTH=full, so every row is crawled each run; lean=true rows mark the local fast-lane subset only. Regenerate deliberately against a healthy k3d stack (just e2e-up && just e2e-seed-rolling) with: CERBERUS_UPDATE_INVENTORY=1 SWEEP_DEPTH=full CRAWL_STACK=k3d npx playwright test crawl/crawl.spec.ts — or dispatch the e2e workflow with update_crawl_inventory=k3d (or =both) and commit the uploaded grafana-surface-inventory-k3d artifact.",
   "stack": "k3d",
   "surfaces": [
     {


### PR DESCRIPTION
## Summary

- \`crawl.spec.ts:382\` asserts the committed inventory's \`doc\` field equals the live config's \`inventoryDoc\` string for each stack. \`stacks.ts\`'s \`inventoryDoc\` text for both stacks grew a trailing sentence describing the dispatch-driven regen path (#1826) after the committed \`compose.json\` was last synced, and \`k3d.json\`'s \`doc\` field had never been synced to the new choice-type dispatch syntax at all (it still read the old \`update_crawl_inventory=true\` boolean form).
- This is currently breaking \`compose-smoke-shard-info (shard-crawl, …)\` on every PR that touches the crawl shard, including unrelated ones — found while investigating an unrelated PR's crawl-shard failure.
- The \`doc\` field is a pure, unconditional string copy from config (\`crawl.spec.ts:1666\`, \`doc: stack.inventoryDoc\`) — no crawl-derived transformation, unlike the \`surfaces\` array — so syncing just this field to match the current config produces byte-identical output to what a real regen would write for it (invariant 9 compliant).
- Verified against the new \`crawl-surface-inventory-guard.mjs\` (#1674), which confirms both files are now byte-identical to their canonical form.

## Test plan

- [x] \`node .github/scripts/crawl-surface-inventory-guard.mjs\` passes locally: "2 inventory file(s) byte-identical to their canonical form."
- [x] Diff is minimal — 1 line changed per file, only the \`doc\` field value.
- [ ] CI green, including \`compose-smoke-shard-info (shard-crawl, …)\`.