### PR TITLE
test: close the derived-fact duplication class with a sealed-marker ratchet

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -141,6 +141,7 @@ components:
   # the CH driver. Declared explicitly with its own deps block instead.
   api-reqctx:     { in: api/reqctx }
   chclienttest:   { in: chclienttest }
+  sealedscan:     { in: sealedscan }
   testsql:        { in: testsql }
   qlcommon:       { in: qlcommon }
   # Clean-room in-house Drain log-template miner (replaces the AGPL
@@ -209,6 +210,12 @@ commonComponents:
   - chclienttest
   - qlcommon
   - chopt
+  # sealedscan derives a sealed interface's implementer set from Go
+  # source. Every layer's exhaustiveness ratchets consume it — chplan's
+  # Node and Expr sets, lsyntax's SampleExpr set — so it is common by
+  # construction. It imports nothing but the standard library and knows
+  # nothing about cerberus, which keeps it a true leaf.
+  - sealedscan
 
 deps:
   # chplan is the foundation. No internal dependencies declared — entries

--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -86,6 +86,10 @@ allow:
 # import graph.
 excludeFiles:
   - ".*_test\\.go$"
+  # Fixture packages under testdata are inputs to a test, not part of
+  # the architecture: `go build` never sees them, so they have no place
+  # in the dependency graph and no component to belong to.
+  - ".*/testdata/.*\\.go$"
 
 components:
   # Domain layers.

--- a/internal/chplan/plannode_scan_test.go
+++ b/internal/chplan/plannode_scan_test.go
@@ -1,90 +1,36 @@
 package chplan_test
 
 import (
-	"go/ast"
-	"go/parser"
-	"go/token"
-	"os"
-	"sort"
-	"strings"
 	"testing"
+
+	"github.com/tsouza/cerberus/internal/sealedscan"
 )
 
 // planNodeMarkerMethod is the sealing marker on chplan.Node. A type
 // declaring it IS a plan node — that method declaration is the only
-// definition of the Node set there is, which is why the scan below reads
-// it out of the source rather than trusting any list.
+// definition of the Node set there is, which is why the ratchets read it
+// out of the source rather than trusting any list.
 const planNodeMarkerMethod = "planNode"
 
-// planNodeImplementers parses this package's own non-test sources and
-// returns the sorted names of every type declaring the `planNode()`
-// sealing marker — i.e. the live, complete set of chplan.Node kinds.
+// planNodeImplementers returns the sorted names of every type declaring
+// the `planNode()` sealing marker — i.e. the live, complete set of
+// chplan.Node kinds.
 //
-// Every ratchet over "the Node set" derives from here. A hand-maintained
-// count or list compared against another hand-maintained count or list
-// proves nothing: both are edited together by the same person in the same
-// commit, so neither can catch the type that was added without touching
-// either. Scanning the marker method means adding a Node kind trips the
-// ratchets with no number and no list to bump.
+// Every ratchet in this package over "the Node set" derives from here. A
+// hand-maintained count or list compared against another hand-maintained
+// count or list proves nothing: both are edited together by the same
+// person in the same commit, so neither can catch the type that was
+// added without touching either. Scanning the marker method means adding
+// a Node kind trips the ratchets with no number and no list to bump.
 //
-// Walks the directory and parses each file directly rather than
-// go/parser.ParseDir (deprecated since Go 1.25); this scan needs only
-// declarations from this package's own directory, which is exactly what
-// ParseDir's replacement would add build-tag machinery for.
+// The scan itself lives in internal/sealedscan, which does the same job
+// for every sealed interface in the tree, so the Node ratchets and the
+// Expr ratchets cannot disagree about what "the implementer set" means.
 func planNodeImplementers(t *testing.T) []string {
 	t.Helper()
-
-	entries, err := os.ReadDir(".")
+	names, err := sealedscan.Implementers(".", planNodeMarkerMethod)
 	if err != nil {
-		t.Fatalf("read package directory: %v", err)
+		t.Fatalf("derive the Node set: %v", err)
 	}
-
-	fset := token.NewFileSet()
-	var names []string
-	for _, entry := range entries {
-		name := entry.Name()
-		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
-			continue
-		}
-		file, err := parser.ParseFile(fset, name, nil, 0)
-		if err != nil {
-			t.Fatalf("parse %s: %v", name, err)
-		}
-		ast.Inspect(file, func(n ast.Node) bool {
-			fn, ok := n.(*ast.FuncDecl)
-			if !ok || fn.Name.Name != planNodeMarkerMethod || fn.Recv == nil {
-				return true
-			}
-			if recv := receiverTypeName(fn.Recv); recv != "" {
-				names = append(names, recv)
-			}
-			return true
-		})
-	}
-	if len(names) == 0 {
-		t.Fatalf("scanned the chplan sources and found no %s() declarations — "+
-			"the scan lost its grip on the source shape, so every ratchet built on it is vacuous",
-			planNodeMarkerMethod)
-	}
-	sort.Strings(names)
 	return names
-}
-
-// receiverTypeName returns the bare type name of a method receiver,
-// unwrapping the pointer every plan node's marker uses (`func (*Scan)
-// planNode() {}`). Returns "" for a shape the scan does not recognise so
-// the caller skips it rather than recording a bogus name.
-func receiverTypeName(recv *ast.FieldList) string {
-	if len(recv.List) != 1 {
-		return ""
-	}
-	expr := recv.List[0].Type
-	if star, ok := expr.(*ast.StarExpr); ok {
-		expr = star.X
-	}
-	ident, ok := expr.(*ast.Ident)
-	if !ok {
-		return ""
-	}
-	return ident.Name
 }

--- a/internal/chplan/rewrite_children_exhaustive_test.go
+++ b/internal/chplan/rewrite_children_exhaustive_test.go
@@ -33,9 +33,10 @@ import (
 //
 // A future new Node type that lacks an arm will fall through to the
 // default and be returned unchanged; if it is added to the table below
-// (which it must be — see the count guard) the interior-node assertion
-// fires. The count guard makes "forgot to add the new type to the table"
-// itself a failure.
+// (which it must be — see the coverage guard) the interior-node
+// assertion fires. The coverage guard derives the Node set from the
+// planNode() declarations, so "forgot to add the new type to the table"
+// is itself a failure, named after the type that was forgotten.
 
 // sentinelChild is the recognisable child planted in every interior node
 // in the table. rewriteChildrenFn rewrites exactly this node.
@@ -65,8 +66,9 @@ type nodeExhaustivenessCase struct {
 }
 
 // allNodeCases enumerates EVERY concrete Node implementation. Adding
-// a new Node type to chplan requires adding a row here (the count guard in
-// TestRewriteChildren_TableCoversEveryNodeType fails otherwise) and an arm
+// a new Node type to chplan requires adding a row here (the coverage
+// guard in TestRewriteChildren_TableCoversEveryNodeType diffs this table
+// against the planNode() implementer set and fails otherwise) and an arm
 // to RewriteChildren (the interior-node assertion in
 // TestRewriteChildren_Exhaustive fails otherwise).
 //
@@ -127,35 +129,33 @@ func allNodeCases() []nodeExhaustivenessCase {
 	}
 }
 
-// expectedNodeTypeCount is the number of concrete Node
-// implementations. Cross-checked against
-// `grep -rn 'planNode()' internal/chplan/*.go`. Bump this (and add a table
-// row + a RewriteChildren arm) when a new Node type lands.
-const expectedNodeTypeCount = 32
-
-// TestRewriteChildren_TableCoversEveryNodeType is the count guard. If a new
-// Node type is added without a corresponding allNodeCases() row, the
-// counts diverge and this fails, forcing the author to confront the
-// exhaustiveness contract (and, via TestRewriteChildren_Exhaustive, add the
-// recursion arm).
+// TestRewriteChildren_TableCoversEveryNodeType is the coverage guard. It
+// derives the Node set from the planNode() declarations in this
+// package's source and diffs allNodeCases() against it, so a Node type
+// added without a table row fails here BY NAME — and, via
+// TestRewriteChildren_Exhaustive, drags the missing recursion arm into
+// the same failure.
+//
+// It derives rather than counting. A pinned row count could not catch
+// the failure it existed to catch: the count and the table are both
+// hand-maintained, so they are edited in the same commit or in neither,
+// and a new Node type leaves them agreeing with each other and wrong
+// about the IR.
 func TestRewriteChildren_TableCoversEveryNodeType(t *testing.T) {
 	t.Parallel()
 	cases := allNodeCases()
-	if len(cases) != expectedNodeTypeCount {
-		t.Fatalf("allNodeCases() has %d rows, expected %d concrete Node types; "+
-			"a Node type was added/removed without updating this table", len(cases), expectedNodeTypeCount)
-	}
 	seen := make(map[reflect.Type]string, len(cases))
+	covered := make(map[string]bool, len(cases))
 	for _, c := range cases {
 		ty := reflect.TypeOf(c.node)
 		if prev, dup := seen[ty]; dup {
 			t.Errorf("duplicate node type %v in table (rows %q and %q)", ty, prev, c.name)
 		}
 		seen[ty] = c.name
+		covered[ty.Elem().Name()] = true
 	}
-	if len(seen) != expectedNodeTypeCount {
-		t.Fatalf("table covers %d distinct node types, expected %d", len(seen), expectedNodeTypeCount)
-	}
+	assertCoversEverySealedKind(t, nodeMarkerMethod, covered, "allNodeCases",
+		"add a table row here and a RewriteChildren arm in rewrite.go")
 }
 
 // TestRewriteChildren_Exhaustive is the core contract test. For each node

--- a/internal/chplan/sealed_kinds_test.go
+++ b/internal/chplan/sealed_kinds_test.go
@@ -1,0 +1,101 @@
+package chplan
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/sealedscan"
+)
+
+// The sealing markers on this package's two IR interfaces. A type joins
+// chplan.Node by declaring planNode() and chplan.Expr by declaring
+// exprNode(), and by nothing else — so those declarations, read out of
+// the source, ARE the two sets. Every exhaustiveness ratchet in this
+// package derives from them rather than restating them, because a
+// hand-maintained count compared against a hand-maintained list is two
+// copies of one claim and catches nothing: both get edited in the same
+// commit, or in neither.
+const (
+	nodeMarkerMethod = "planNode"
+	exprMarkerMethod = "exprNode"
+)
+
+// allExprKinds is one zero-value instance of every concrete Expr type.
+//
+// Zero values are all the Expr ratchets need: they assert that each
+// concrete type is *reached* by a traversal or *handled* by a clone
+// switch, neither of which reads the children. Structural equality over
+// populated Exprs is a different contract, covered by the Node clone
+// tests.
+//
+// The list is hand-written because the tests need instances, which no
+// scan can produce — but it is never trusted. Its completeness is
+// asserted against the exprNode() implementer set on every run, so a new
+// Expr type fails here by name with nothing to bump.
+func allExprKinds() []Expr {
+	return []Expr{
+		&ColumnRef{},
+		&LitString{},
+		&InlineString{},
+		&LitInt{},
+		&LitFloat{},
+		&LitBool{},
+		&BareIdent{},
+		&Binary{},
+		&FuncCall{},
+		&InList{},
+		&FieldAccess{},
+		&MapAccess{},
+		&Subscript{},
+		&LineContent{},
+		&LabelJoin{},
+		&LabelReplace{},
+		&Lambda{},
+		&MapWithoutKeys{},
+		&MapWithoutEmptyValues{},
+		&NestedArrayExists{},
+		&ScalarSubquery{},
+		&BoundedTraceScope{},
+		&InSubquery{},
+	}
+}
+
+// sealedKindNames returns the concrete type name of each value, e.g.
+// "ColumnRef".
+func sealedKindNames[T any](values []T) map[string]bool {
+	names := make(map[string]bool, len(values))
+	for _, v := range values {
+		names[reflect.TypeOf(v).Elem().Name()] = true
+	}
+	return names
+}
+
+// assertCoversEverySealedKind is the derive-and-diff ratchet shared by
+// this package's internal tests: the KEYS of covered must be exactly the
+// set of types declaring marker in this package's source. Both
+// directions fail loudly and name the offending type — a missing one
+// means the caller's table went stale under a new IR type, an extra one
+// means a type was deleted or renamed and the table kept its ghost.
+func assertCoversEverySealedKind(t *testing.T, marker string, covered map[string]bool, what, remedy string) {
+	t.Helper()
+
+	kinds, err := sealedscan.Implementers(".", marker)
+	if err != nil {
+		t.Fatalf("derive the %s() set: %v", marker, err)
+	}
+	remaining := make(map[string]bool, len(covered))
+	for name := range covered {
+		remaining[name] = true
+	}
+	for _, kind := range kinds {
+		if !covered[kind] {
+			t.Errorf("%s implements %s() but %s does not cover it — %s",
+				kind, marker, what, remedy)
+		}
+		delete(remaining, kind)
+	}
+	for kind := range remaining {
+		t.Errorf("%s covers %s, which no longer implements %s() — drop it",
+			what, kind, marker)
+	}
+}

--- a/internal/chplan/sliceinvariant_test.go
+++ b/internal/chplan/sliceinvariant_test.go
@@ -7,13 +7,13 @@ import (
 	"github.com/tsouza/cerberus/internal/chplan"
 )
 
-// TestIsSliceInvariant_RegisteredKinds asserts exactly the phase-1 node
-// kinds are registered slice-invariant, and that the registry is driven by
-// node kind (not instance state).
-func TestIsSliceInvariant_RegisteredKinds(t *testing.T) {
-	t.Parallel()
-
-	registered := []chplan.Node{
+// sliceInvariantRegisteredKinds is the phase-1 registered set: the node
+// kinds IsSliceInvariant answers true for. It is a policy declaration,
+// not a restatement of anything derivable — which kinds have a proof of
+// slice-invariance is a decision, and the default-deny complement below
+// is computed from it rather than written down a second time.
+func sliceInvariantRegisteredKinds() []chplan.Node {
+	return []chplan.Node{
 		&chplan.Scan{},
 		&chplan.Filter{},
 		&chplan.Project{},
@@ -25,7 +25,15 @@ func TestIsSliceInvariant_RegisteredKinds(t *testing.T) {
 		&chplan.UnionAll{},
 		&chplan.VectorJoin{},
 	}
-	for _, n := range registered {
+}
+
+// TestIsSliceInvariant_RegisteredKinds asserts exactly the phase-1 node
+// kinds are registered slice-invariant, and that the registry is driven by
+// node kind (not instance state).
+func TestIsSliceInvariant_RegisteredKinds(t *testing.T) {
+	t.Parallel()
+
+	for _, n := range sliceInvariantRegisteredKinds() {
 		if !chplan.IsSliceInvariant(n) {
 			t.Errorf("%T should be registered slice-invariant", n)
 		}
@@ -33,24 +41,16 @@ func TestIsSliceInvariant_RegisteredKinds(t *testing.T) {
 }
 
 // TestIsSliceInvariant_UnregisteredKinds asserts every node kind NOT in the
-// phase-1 set returns false — the default-deny posture. This list is the
-// complement of the registered set over allNodeKinds (defined in
-// clone_test.go); together they cover all 31 node kinds, so adding a node
-// type without a deliberate registry decision fails the count guard below.
+// phase-1 set returns false — the default-deny posture. The unregistered
+// set is the complement of sliceInvariantRegisteredKinds over
+// allNodeKinds (defined in clone_test.go), so adding a node type without
+// a deliberate registry decision fails the guard below.
 func TestIsSliceInvariant_UnregisteredKinds(t *testing.T) {
 	t.Parallel()
 
-	registered := map[reflect.Type]bool{
-		reflect.TypeOf(&chplan.Scan{}):              true,
-		reflect.TypeOf(&chplan.Filter{}):            true,
-		reflect.TypeOf(&chplan.Project{}):           true,
-		reflect.TypeOf(&chplan.Aggregate{}):         true,
-		reflect.TypeOf(&chplan.RangeWindow{}):       true,
-		reflect.TypeOf(&chplan.RangeLWR{}):          true,
-		reflect.TypeOf(&chplan.RangeBucketFanout{}): true,
-		reflect.TypeOf(&chplan.StepGrid{}):          true,
-		reflect.TypeOf(&chplan.UnionAll{}):          true,
-		reflect.TypeOf(&chplan.VectorJoin{}):        true,
+	registered := map[reflect.Type]bool{}
+	for _, n := range sliceInvariantRegisteredKinds() {
+		registered[reflect.TypeOf(n)] = true
 	}
 
 	var unregisteredSeen int
@@ -65,10 +65,14 @@ func TestIsSliceInvariant_UnregisteredKinds(t *testing.T) {
 		}
 	}
 
-	// 32 total node kinds, 10 registered → 22 must be default-denied. If this
-	// drifts, a node kind was added: decide explicitly whether it is
-	// slice-invariant (extend sliceInvariantKinds + the registered set here)
-	// or not (it falls into the default-deny count).
+	// Every node kind the registry does not name must be default-denied.
+	// The expected number is DERIVED — the live planNode() implementer
+	// set minus the registered set — rather than pinned, because a
+	// pinned total is a second copy of the Node set that drifts silently
+	// the moment a node kind lands. If this fails, a node kind was
+	// added: decide explicitly whether it is slice-invariant (extend
+	// sliceInvariantKinds + sliceInvariantRegisteredKinds) or not (it
+	// falls into the default-deny count).
 	//
 	// VectorJoin is now REGISTERED (the step-aligned vector-vector join —
 	// each output row reduces one anchor's window on each arm because the
@@ -88,7 +92,7 @@ func TestIsSliceInvariant_UnregisteredKinds(t *testing.T) {
 	// too: like HistogramQuantileNative, it aggregates bucket columns per
 	// group from its input rather than passing a sliced row stream through
 	// unchanged, and no lowering builds it yet regardless.
-	const wantUnregistered = 32 - 10
+	wantUnregistered := len(planNodeImplementers(t)) - len(registered)
 	if unregisteredSeen != wantUnregistered {
 		t.Fatalf("expected %d default-denied node kinds, saw %d — a node kind was added; "+
 			"make an explicit slice-invariance decision", wantUnregistered, unregisteredSeen)

--- a/internal/chplan/walk_deep_test.go
+++ b/internal/chplan/walk_deep_test.go
@@ -183,11 +183,17 @@ func TestNodeExprs_FindsEveryNodeTypeWithExprSlots(t *testing.T) {
 	t.Parallel()
 	withSlots := map[string]bool{}
 	for _, c := range allNodeCases() {
-		ptr := reflect.New(reflect.TypeOf(c.node).Elem())
+		elem := reflect.TypeOf(c.node).Elem()
+		ptr := reflect.New(elem)
 		var planted []plantedSlot
 		plantExprSlots(t, ptr.Elem(), c.name, &planted, 0)
 		if len(planted) > 0 {
-			withSlots[c.name] = true
+			// Keyed by the CONCRETE TYPE name, which is what the other
+			// side of this comparison reads out of the switch. The
+			// table's row name is a label and nothing pins the two
+			// together, so keying on it would let a descriptive row name
+			// invent a two-sided failure.
+			withSlots[elem.Name()] = true
 		}
 	}
 	// Both sides of this comparison are derived, and they are derived

--- a/internal/chplan/walk_deep_test.go
+++ b/internal/chplan/walk_deep_test.go
@@ -2,6 +2,9 @@ package chplan
 
 import (
 	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"reflect"
 	"testing"
 )
@@ -178,25 +181,103 @@ func TestNodeExprs_Exhaustive(t *testing.T) {
 // TestNodeExprs_Exhaustive cannot pass vacuously by planting nothing.
 func TestNodeExprs_FindsEveryNodeTypeWithExprSlots(t *testing.T) {
 	t.Parallel()
-	withSlots := 0
+	withSlots := map[string]bool{}
 	for _, c := range allNodeCases() {
 		ptr := reflect.New(reflect.TypeOf(c.node).Elem())
 		var planted []plantedSlot
 		plantExprSlots(t, ptr.Elem(), c.name, &planted, 0)
 		if len(planted) > 0 {
-			withSlots++
+			withSlots[c.name] = true
 		}
 	}
-	// Filter, Project, Aggregate, RangeWindow, RangeWindowNative, OrderBy,
-	// TopK, RangeBucketFanout, HistogramQuantile, HistogramQuantileNative,
-	// HistogramProjection, MetricsAggregate, MetricsHistogramOverTime,
-	// MetricsCompare.
-	const wantNodeTypesWithExprSlots = 14
-	if withSlots != wantNodeTypesWithExprSlots {
-		t.Fatalf("reflection found Expr slots on %d Node types, expected %d — the IR gained or lost an "+
-			"Expr-bearing Node type: update nodeExprs in walk_deep.go and this count",
-			withSlots, wantNodeTypesWithExprSlots)
+	// Both sides of this comparison are derived, and they are derived
+	// from different things — that is what makes it an assertion rather
+	// than a restatement. The left side is reflection over the struct
+	// fields: which Node types actually HAVE an Expr-typed slot. The
+	// right side is nodeExprs' own dispatch, read out of walk_deep.go:
+	// which Node types it treats as having one. A pinned number in the
+	// middle could only ever agree with whichever of the two its author
+	// last looked at.
+	//
+	// The failure this catches is a Node type that gains an Expr field
+	// while staying in nodeExprs' no-op arm, which leaves every plan
+	// subtree nested in that slot invisible to WalkDeep.
+	handled := nodeExprsHandledTypes(t)
+	for name := range handled {
+		if !withSlots[name] {
+			t.Errorf("nodeExprs has an Expr-visiting arm for %s, but reflection finds no "+
+				"Expr-typed field on it — the arm is dead, drop it from walk_deep.go", name)
+		}
 	}
+	for name := range withSlots {
+		if !handled[name] {
+			t.Errorf("%s has an Expr-typed field but nodeExprs does not visit it — add an arm "+
+				"for %s in walk_deep.go, or every plan subtree nested in that slot stays "+
+				"invisible to WalkDeep", name, name)
+		}
+	}
+}
+
+// nodeExprsHandledTypes returns the Node type names nodeExprs dispatches
+// on with a non-empty arm, read out of walk_deep.go.
+//
+// The empty arm is meaningful and is deliberately excluded: it is the
+// explicit roster of Node types with no Expr-typed field, and listing
+// them there rather than under a `default` is what makes the switch
+// total. So the arms partition the Node set, and this returns the half
+// that carries Exprs.
+func nodeExprsHandledTypes(t *testing.T) map[string]bool {
+	t.Helper()
+
+	const scannedFile = "walk_deep.go"
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, scannedFile, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", scannedFile, err)
+	}
+
+	handled := map[string]bool{}
+	var arms int
+	ast.Inspect(file, func(n ast.Node) bool {
+		fn, ok := n.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != "nodeExprs" {
+			return true
+		}
+		ast.Inspect(fn, func(inner ast.Node) bool {
+			cc, ok := inner.(*ast.CaseClause)
+			if !ok {
+				return true
+			}
+			arms++
+			if len(cc.Body) == 0 {
+				return true
+			}
+			for _, expr := range cc.List {
+				if name := nodeExprsCaseTypeName(expr); name != "" {
+					handled[name] = true
+				}
+			}
+			return true
+		})
+		return false
+	})
+	if arms == 0 {
+		t.Fatalf("scanned %s and found no case arms in nodeExprs — the scan lost its grip "+
+			"on the source shape, so this ratchet is vacuous", scannedFile)
+	}
+	return handled
+}
+
+// nodeExprsCaseTypeName returns the bare type name of one `case *T:`
+// entry, or "" for a shape the scan does not recognise.
+func nodeExprsCaseTypeName(e ast.Expr) string {
+	if star, ok := e.(*ast.StarExpr); ok {
+		e = star.X
+	}
+	if ident, ok := e.(*ast.Ident); ok {
+		return ident.Name
+	}
+	return ""
 }
 
 // TestWalkDeep_ReachesNodesBehindExprSlots pins the reachability contract

--- a/internal/chplan/walk_expr_test.go
+++ b/internal/chplan/walk_expr_test.go
@@ -12,37 +12,15 @@ import (
 // case would otherwise silently hide a ScalarSubquery nested inside it,
 // blinding the fan-out linter).
 //
-// The set below must list one zero-value instance of every type that
-// implements Expr. Discovery is manual-by-design: there is no registry of
-// Expr types, so the test pins the closed set explicitly.
+// The set under test is allExprKinds(), whose completeness against the
+// exprNode() implementer set is asserted below rather than pinned as a
+// number. `go vet` cannot flag the missing inspectExpr case — the switch
+// has no default-panic — so this derivation is the only thing standing
+// between a new Expr type and a silently unvisited subtree.
 func TestInspectExprExhaustive(t *testing.T) {
 	t.Parallel()
 
-	all := []Expr{
-		&ColumnRef{},
-		&LitString{},
-		&InlineString{},
-		&LitInt{},
-		&LitFloat{},
-		&LitBool{},
-		&BareIdent{},
-		&Binary{},
-		&FuncCall{},
-		&InList{},
-		&FieldAccess{},
-		&MapAccess{},
-		&Subscript{},
-		&LineContent{},
-		&LabelJoin{},
-		&LabelReplace{},
-		&Lambda{},
-		&MapWithoutKeys{},
-		&MapWithoutEmptyValues{},
-		&NestedArrayExists{},
-		&ScalarSubquery{},
-		&BoundedTraceScope{},
-		&InSubquery{},
-	}
+	all := allExprKinds()
 
 	// Each listed type must be reached as a root visit without panicking,
 	// and the set must be free of accidental duplicates.
@@ -66,59 +44,25 @@ func TestInspectExprExhaustive(t *testing.T) {
 		}
 	}
 
-	// The hardcoded count is the real guard: if a new Expr type is added,
-	// `go vet` / compilation won't flag the missing inspectExpr case (the
-	// switch has no default-panic), so this count forces the author to
-	// revisit both the switch AND this list. Keep it in lock-step with the
-	// number of exprNode() implementers under internal/chplan.
-	const wantExprTypes = 23
-	if len(all) != wantExprTypes {
-		t.Fatalf("expected %d Expr types in the exhaustiveness set, listed %d — "+
-			"a new Expr type was added: extend inspectExpr's switch in walk_expr.go AND this list",
-			wantExprTypes, len(all))
-	}
+	assertCoversEverySealedKind(t, exprMarkerMethod, sealedKindNames(all), "allExprKinds",
+		"add a zero-value instance to allExprKinds and an inspectExpr case in walk_expr.go")
 }
 
 // TestCloneExprExhaustive guards cloneExpr's exhaustive switch (which has a
 // default-panic) against a new Expr type silently aliasing into a re-anchored
 // shard plan. Every concrete Expr type must clone without panicking and the
-// clone must be Equal to the original. The hardcoded count is in lock-step
-// with TestInspectExprExhaustive's set — both mirror the exprNode()
-// implementers, so a new type forces the author to extend BOTH switches
+// clone must be Equal to the original. It shares allExprKinds() with
+// TestInspectExprExhaustive — one list, derived against the exprNode()
+// implementers — so a new type forces the author to extend BOTH switches
 // (inspectExpr AND cloneExpr).
 func TestCloneExprExhaustive(t *testing.T) {
 	t.Parallel()
 
-	all := []Expr{
-		&ColumnRef{},
-		&LitString{},
-		&InlineString{},
-		&LitInt{},
-		&LitFloat{},
-		&LitBool{},
-		&BareIdent{},
-		&Binary{},
-		&FuncCall{},
-		&InList{},
-		&FieldAccess{},
-		&MapAccess{},
-		&Subscript{},
-		&LineContent{},
-		&LabelJoin{},
-		&LabelReplace{},
-		&Lambda{},
-		&MapWithoutKeys{},
-		&MapWithoutEmptyValues{},
-		&NestedArrayExists{},
-		&ScalarSubquery{},
-		&BoundedTraceScope{},
-		&InSubquery{},
-	}
-	const wantExprTypes = 23
-	if len(all) != wantExprTypes {
-		t.Fatalf("expected %d Expr types, listed %d — a new Expr type was added: "+
-			"extend cloneExpr's switch in clone.go AND this list", wantExprTypes, len(all))
-	}
+	all := allExprKinds()
+
+	assertCoversEverySealedKind(t, exprMarkerMethod, sealedKindNames(all), "allExprKinds",
+		"add a zero-value instance to allExprKinds and a cloneExpr case in clone.go")
+
 	// Zero-value Exprs (nil children) are fine for this check: we only assert
 	// cloneExpr handles each concrete type (no default-panic) and returns the
 	// same concrete type — NOT structural equality, which would deref the nil

--- a/internal/logql/lsyntax/ast_test.go
+++ b/internal/logql/lsyntax/ast_test.go
@@ -233,7 +233,11 @@ func TestSelector_PropagatesTheStashedError(t *testing.T) {
 	// restated here: a new sample expression that stashes its
 	// constructor error and never gets a row would otherwise leave the
 	// only path the lowering learns about that error untested, silently.
-	assertCoversEverySampleExpr(t, sampleExprTypeNames(cases))
+	covered := make([]SampleExpr, 0, len(cases))
+	for _, tc := range cases {
+		covered = append(covered, tc.expr)
+	}
+	assertCoversEverySampleExpr(t, sampleExprTypeNames(covered))
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/logql/lsyntax/ast_test.go
+++ b/internal/logql/lsyntax/ast_test.go
@@ -228,6 +228,13 @@ func TestSelector_PropagatesTheStashedError(t *testing.T) {
 		{name: "vector()", expr: &VectorExpr{err: wantErr}},
 		{name: "variants", expr: &MultiVariantExpr{err: wantErr}},
 	}
+	// The table must cover every SampleExpr, and the set of SampleExprs
+	// is derived from the isSampleExpr() declarations rather than
+	// restated here: a new sample expression that stashes its
+	// constructor error and never gets a row would otherwise leave the
+	// only path the lowering learns about that error untested, silently.
+	assertCoversEverySampleExpr(t, sampleExprTypeNames(cases))
+
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			sel, err := tc.expr.Selector()

--- a/internal/logql/lsyntax/sample_expr_kinds_test.go
+++ b/internal/logql/lsyntax/sample_expr_kinds_test.go
@@ -1,0 +1,57 @@
+package lsyntax
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/sealedscan"
+)
+
+// sampleExprMarkerMethod is the sealing marker on SampleExpr. A type
+// declaring it IS a sample expression — that declaration is the only
+// definition of the set there is, so the ratchet below reads it out of
+// the source instead of trusting a list that nothing re-derives.
+const sampleExprMarkerMethod = "isSampleExpr"
+
+// sampleExprTypeNames returns the concrete type name of the expr field
+// on each table row, e.g. "BinOpExpr".
+func sampleExprTypeNames(cases []struct {
+	name string
+	expr SampleExpr
+},
+) map[string]bool {
+	names := make(map[string]bool, len(cases))
+	for _, c := range cases {
+		names[reflect.TypeOf(c.expr).Elem().Name()] = true
+	}
+	return names
+}
+
+// assertCoversEverySampleExpr is the derive-and-diff ratchet: covered
+// must hold exactly the types declaring isSampleExpr() in this package.
+// Both directions name the offender — a missing type means the caller's
+// table went stale under a new sample expression, an extra one means a
+// type was deleted or renamed and the table kept its ghost.
+func assertCoversEverySampleExpr(t *testing.T, covered map[string]bool) {
+	t.Helper()
+
+	kinds, err := sealedscan.Implementers(".", sampleExprMarkerMethod)
+	if err != nil {
+		t.Fatalf("derive the SampleExpr set: %v", err)
+	}
+	remaining := make(map[string]bool, len(covered))
+	for name := range covered {
+		remaining[name] = true
+	}
+	for _, kind := range kinds {
+		if !covered[kind] {
+			t.Errorf("%s implements %s() but the table does not cover it — add a row",
+				kind, sampleExprMarkerMethod)
+		}
+		delete(remaining, kind)
+	}
+	for kind := range remaining {
+		t.Errorf("the table covers %s, which no longer implements %s() — drop the row",
+			kind, sampleExprMarkerMethod)
+	}
+}

--- a/internal/logql/lsyntax/sample_expr_kinds_test.go
+++ b/internal/logql/lsyntax/sample_expr_kinds_test.go
@@ -13,16 +13,13 @@ import (
 // the source instead of trusting a list that nothing re-derives.
 const sampleExprMarkerMethod = "isSampleExpr"
 
-// sampleExprTypeNames returns the concrete type name of the expr field
-// on each table row, e.g. "BinOpExpr".
-func sampleExprTypeNames(cases []struct {
-	name string
-	expr SampleExpr
-},
-) map[string]bool {
-	names := make(map[string]bool, len(cases))
-	for _, c := range cases {
-		names[reflect.TypeOf(c.expr).Elem().Name()] = true
+// sampleExprTypeNames returns the concrete type name of each expression,
+// e.g. "BinOpExpr". It takes the expressions rather than the caller's
+// table so that adding a column to that table cannot break it.
+func sampleExprTypeNames(exprs []SampleExpr) map[string]bool {
+	names := make(map[string]bool, len(exprs))
+	for _, e := range exprs {
+		names[reflect.TypeOf(e).Elem().Name()] = true
 	}
 	return names
 }

--- a/internal/sealedscan/sealedscan.go
+++ b/internal/sealedscan/sealedscan.go
@@ -21,6 +21,13 @@
 // go/parser rather than loading it with golang.org/x/tools/go/packages:
 // nothing here needs types, build-tag resolution or import graphs, which
 // is all the heavier loader would buy.
+//
+// Two consequences of parsing rather than type-checking, neither of
+// which any package in this tree runs into today. Markers are keyed by
+// method name alone, so two interfaces in one package sealed by the same
+// unexported niladic method would be reported as one. And the scan is
+// per-directory, so an interface whose implementers live in a different
+// package than its declaration reports no marker at all.
 package sealedscan
 
 import (
@@ -116,6 +123,7 @@ func scan(dir string) (sealed map[string]string, impls map[string][]string, err 
 	}
 	sealed = map[string]string{}
 	impls = map[string][]string{}
+	embedders := map[string][]string{}
 	fset := token.NewFileSet()
 	for _, entry := range entries {
 		name := entry.Name()
@@ -126,16 +134,20 @@ func scan(dir string) (sealed map[string]string, impls map[string][]string, err 
 		if perr != nil {
 			return nil, nil, fmt.Errorf("sealedscan: parse %s: %w", name, perr)
 		}
-		collectFile(file, sealed, impls)
+		collectFile(file, sealed, impls, embedders)
+	}
+	for method, names := range impls {
+		impls[method] = resolveEmbeddedBases(names, embedders)
 	}
 	return sealed, impls, nil
 }
 
-func collectFile(file *ast.File, sealed map[string]string, impls map[string][]string) {
+func collectFile(file *ast.File, sealed map[string]string, impls, embedders map[string][]string) {
 	ast.Inspect(file, func(n ast.Node) bool {
 		switch v := n.(type) {
 		case *ast.TypeSpec:
 			collectInterface(v, sealed)
+			collectEmbedders(v, embedders)
 		case *ast.FuncDecl:
 			if method, recv, ok := markerDecl(v); ok {
 				impls[method] = append(impls[method], recv)
@@ -143,6 +155,63 @@ func collectFile(file *ast.File, sealed map[string]string, impls map[string][]st
 		}
 		return true
 	})
+}
+
+// collectEmbedders records, for each struct type, the named types it
+// embeds — `base -> [types embedding base]`.
+func collectEmbedders(ts *ast.TypeSpec, embedders map[string][]string) {
+	st, ok := ts.Type.(*ast.StructType)
+	if !ok || st.Fields == nil {
+		return
+	}
+	for _, f := range st.Fields.List {
+		if len(f.Names) != 0 {
+			continue // a named field is not an embedding
+		}
+		if base := receiverOrEmbeddedName(f.Type); base != "" {
+			embedders[base] = append(embedders[base], ts.Name.Name)
+		}
+	}
+}
+
+// resolveEmbeddedBases rewrites a marker's receiver list so that a type
+// which exists only to SUPPLY the marker to others is replaced by the
+// types that embed it.
+//
+// Go promotes an embedded type's methods, so a package can seal an
+// interface by declaring the marker once on a shared base struct and
+// embedding that base — internal/logql/lsyntax does exactly this with
+// stageBase. Counting the declaration alone would derive a set of one,
+// which is not merely incomplete but confidently wrong: the vacuity
+// guard cannot fire on a non-empty set, so a ratchet would diff a real
+// table against a fictional set and report the whole table as extra.
+//
+// The base itself drops out. It carries the method but is not a member:
+// nothing constructs a bare stageBase as a StageExpr, and admitting it
+// would make every ratchet over the set demand a row for it.
+func resolveEmbeddedBases(names []string, embedders map[string][]string) []string {
+	out := make([]string, 0, len(names))
+	for _, name := range names {
+		if into := embedders[name]; len(into) > 0 {
+			out = append(out, into...)
+			continue
+		}
+		out = append(out, name)
+	}
+	return dedupe(out)
+}
+
+func dedupe(names []string) []string {
+	seen := make(map[string]bool, len(names))
+	out := make([]string, 0, len(names))
+	for _, n := range names {
+		if seen[n] {
+			continue
+		}
+		seen[n] = true
+		out = append(out, n)
+	}
+	return out
 }
 
 // collectInterface records ts as a sealed interface when it declares an
@@ -177,7 +246,7 @@ func markerDecl(fd *ast.FuncDecl) (method, recv string, ok bool) {
 	if ast.IsExported(fd.Name.Name) || !niladic(fd.Type) {
 		return "", "", false
 	}
-	recv = receiverTypeName(fd.Recv)
+	recv = receiverName(fd.Recv)
 	if recv == "" {
 		return "", "", false
 	}
@@ -188,17 +257,26 @@ func niladic(ft *ast.FuncType) bool {
 	return ft.Params.NumFields() == 0 && ft.Results.NumFields() == 0
 }
 
-// receiverTypeName returns the bare type name of a method receiver,
+// receiverName returns the bare type name of a method receiver,
 // unwrapping the pointer a marker declaration uses (`func (*Scan)
 // planNode() {}`). It returns "" for a shape the scan does not
 // recognise, so the caller skips it rather than recording a bogus name.
-func receiverTypeName(recv *ast.FieldList) string {
+func receiverName(recv *ast.FieldList) string {
 	if len(recv.List) != 1 {
 		return ""
 	}
-	expr := recv.List[0].Type
+	return receiverOrEmbeddedName(recv.List[0].Type)
+}
+
+// receiverOrEmbeddedName reduces a receiver or embedded-field type
+// expression to its bare name, unwrapping a pointer. Generic types are
+// unwrapped to their base name too, so `Box[T]` reads as `Box`.
+func receiverOrEmbeddedName(expr ast.Expr) string {
 	if star, ok := expr.(*ast.StarExpr); ok {
 		expr = star.X
+	}
+	if idx, ok := expr.(*ast.IndexExpr); ok {
+		expr = idx.X
 	}
 	ident, ok := expr.(*ast.Ident)
 	if !ok {

--- a/internal/sealedscan/sealedscan.go
+++ b/internal/sealedscan/sealedscan.go
@@ -1,0 +1,208 @@
+// Package sealedscan derives, from Go source, the implementer set of a
+// sealed marker interface.
+//
+// A sealed interface in this repository is closed by an unexported,
+// niladic marker method with an empty body — `planNode()` on
+// chplan.Node, `exprNode()` on chplan.Expr, `isSampleExpr()` on
+// lsyntax.SampleExpr. The method declarations ARE the definition of the
+// set: there is no registry to consult and no list that could be
+// authoritative, because a type joins the set by declaring the method
+// and by nothing else.
+//
+// This package exists so that every ratchet over such a set reads the
+// same derived answer. A hand-maintained count or list compared against
+// another hand-maintained count or list proves nothing — both are edited
+// together, by the same author, in the same commit, so neither can catch
+// the type that was added without touching either. Scanning for the
+// marker method means adding an implementer trips every ratchet built on
+// it with no number to bump and no list to extend.
+//
+// It parses declarations only, so it reads a package directory with
+// go/parser rather than loading it with golang.org/x/tools/go/packages:
+// nothing here needs types, build-tag resolution or import graphs, which
+// is all the heavier loader would buy.
+package sealedscan
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// minSealedSetSize is the smallest implementer count Markers reports.
+// One implementer is not a set: nothing can enumerate it incorrectly,
+// and any literal mentioning that single type would trivially "cover"
+// it.
+const minSealedSetSize = 2
+
+// Marker is one sealed interface found in a package: the unexported
+// niladic method that seals it, the interface type that declares the
+// method, and the sorted names of the types implementing it.
+type Marker struct {
+	// Method is the sealing method name, e.g. "planNode".
+	Method string
+	// Interface is the interface type declaring Method, e.g. "Node".
+	Interface string
+	// Implementers holds the sorted bare type names declaring Method,
+	// pointer receivers unwrapped, e.g. ["Aggregate", "Filter", …].
+	Implementers []string
+}
+
+// Markers returns every sealed marker interface declared in the package
+// rooted at dir, sorted by method name. Test files are ignored: a marker
+// is a production declaration, and a test-only implementer would inflate
+// the set a ratchet is meant to pin.
+//
+// Only interfaces with at least minSealedSetSize implementers are
+// reported. Below that there is no set to keep in step: an interface
+// with a single implementer cannot be enumerated wrongly, and an
+// unexported niladic method with an empty body on a lone type is far
+// more likely to be an ordinary no-op — a decoder whose close() has
+// nothing to release — than a sealing marker.
+func Markers(dir string) ([]Marker, error) {
+	sealed, impls, err := scan(dir)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]Marker, 0, len(sealed))
+	for method, iface := range sealed {
+		names := impls[method]
+		if len(names) < minSealedSetSize {
+			continue
+		}
+		sort.Strings(names)
+		out = append(out, Marker{Method: method, Interface: iface, Implementers: names})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Method < out[j].Method })
+	return out, nil
+}
+
+// Implementers returns the sorted type names declaring the sealing
+// method in the package rooted at dir.
+//
+// It returns an error when the scan finds none. That is the vacuity
+// guard every caller depends on: a ratchet that silently derives an
+// empty set passes forever while asserting nothing, so losing the grip
+// on the source shape must fail loudly rather than degrade to a
+// no-op.
+func Implementers(dir, method string) ([]string, error) {
+	_, impls, err := scan(dir)
+	if err != nil {
+		return nil, err
+	}
+	names := impls[method]
+	if len(names) == 0 {
+		return nil, fmt.Errorf(
+			"sealedscan: scanned %s and found no %s() declarations — the scan lost its "+
+				"grip on the source shape, so every ratchet built on it is vacuous", dir, method,
+		)
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+// scan parses the package's non-test sources once, returning the sealing
+// methods it declares (method name -> interface name) and the types
+// declaring each (method name -> receiver type names).
+func scan(dir string) (sealed map[string]string, impls map[string][]string, err error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, nil, fmt.Errorf("sealedscan: read package directory: %w", err)
+	}
+	sealed = map[string]string{}
+	impls = map[string][]string{}
+	fset := token.NewFileSet()
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		file, perr := parser.ParseFile(fset, filepath.Join(dir, name), nil, 0)
+		if perr != nil {
+			return nil, nil, fmt.Errorf("sealedscan: parse %s: %w", name, perr)
+		}
+		collectFile(file, sealed, impls)
+	}
+	return sealed, impls, nil
+}
+
+func collectFile(file *ast.File, sealed map[string]string, impls map[string][]string) {
+	ast.Inspect(file, func(n ast.Node) bool {
+		switch v := n.(type) {
+		case *ast.TypeSpec:
+			collectInterface(v, sealed)
+		case *ast.FuncDecl:
+			if method, recv, ok := markerDecl(v); ok {
+				impls[method] = append(impls[method], recv)
+			}
+		}
+		return true
+	})
+}
+
+// collectInterface records ts as a sealed interface when it declares an
+// unexported niladic method — the sealing shape.
+func collectInterface(ts *ast.TypeSpec, sealed map[string]string) {
+	it, ok := ts.Type.(*ast.InterfaceType)
+	if !ok || it.Methods == nil {
+		return
+	}
+	for _, m := range it.Methods.List {
+		ft, ok := m.Type.(*ast.FuncType)
+		if !ok || len(m.Names) != 1 {
+			continue
+		}
+		name := m.Names[0].Name
+		if ast.IsExported(name) || !niladic(ft) {
+			continue
+		}
+		sealed[name] = ts.Name.Name
+	}
+}
+
+// markerDecl reports whether fd is a sealing marker implementation —
+// `func (*T) marker() {}` — and returns the method and bare receiver
+// type names. The empty body is part of the shape: a marker method
+// carries no behaviour, so an unexported niladic method that actually
+// does something (a lifecycle `close()`, say) is not one.
+func markerDecl(fd *ast.FuncDecl) (method, recv string, ok bool) {
+	if fd.Recv == nil || fd.Body == nil || len(fd.Body.List) != 0 {
+		return "", "", false
+	}
+	if ast.IsExported(fd.Name.Name) || !niladic(fd.Type) {
+		return "", "", false
+	}
+	recv = receiverTypeName(fd.Recv)
+	if recv == "" {
+		return "", "", false
+	}
+	return fd.Name.Name, recv, true
+}
+
+func niladic(ft *ast.FuncType) bool {
+	return ft.Params.NumFields() == 0 && ft.Results.NumFields() == 0
+}
+
+// receiverTypeName returns the bare type name of a method receiver,
+// unwrapping the pointer a marker declaration uses (`func (*Scan)
+// planNode() {}`). It returns "" for a shape the scan does not
+// recognise, so the caller skips it rather than recording a bogus name.
+func receiverTypeName(recv *ast.FieldList) string {
+	if len(recv.List) != 1 {
+		return ""
+	}
+	expr := recv.List[0].Type
+	if star, ok := expr.(*ast.StarExpr); ok {
+		expr = star.X
+	}
+	ident, ok := expr.(*ast.Ident)
+	if !ok {
+		return ""
+	}
+	return ident.Name
+}

--- a/internal/sealedscan/sealedscan_test.go
+++ b/internal/sealedscan/sealedscan_test.go
@@ -24,6 +24,9 @@ func TestMarkers_ReportsSealedInterfacesWithTheirImplementers(t *testing.T) {
 	want := []sealedscan.Marker{
 		{Method: "colourNode", Interface: "Colour", Implementers: []string{"Blue", "Red"}},
 		{Method: "shapeNode", Interface: "Shape", Implementers: []string{"Circle", "Square", "Triangle"}},
+		// The base itself is absent and its embedders stand in its
+		// place, by value and by pointer alike.
+		{Method: "soundNode", Interface: "Sound", Implementers: []string{"Bark", "Meow", "Moo"}},
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("Markers = %+v, want %+v", got, want)
@@ -101,28 +104,52 @@ func TestImplementers_MissingDirectoryIsAnError(t *testing.T) {
 	}
 }
 
-// TestMarkers_ScansTheLiveChplanSets is the end-to-end check that the
-// scanner still recognises the real convention it exists for. The
-// assertion is deliberately a lower bound rather than an exact count:
-// pinning the numbers here would reintroduce, in the scanner's own test,
-// exactly the hand-maintained restatement the scanner exists to
-// eliminate.
-func TestMarkers_ScansTheLiveChplanSets(t *testing.T) {
+// TestMarkers_ScansTheLiveSets is the end-to-end check that the scanner
+// still recognises the conventions it exists for, on the real packages
+// that use them.
+//
+// It asserts MEMBERSHIP, not size. Pinning 32 and 23 here would
+// reintroduce, inside the scanner's own test, exactly the restatement
+// the scanner exists to eliminate — but the obvious alternative, a lower
+// bound like "at least two", degrades to "the marker was reported at
+// all" and cannot tell a correct set from a plausible wrong one. That is
+// not hypothetical: before the embedded-base case was handled, lsyntax's
+// Expr set derived to a confident, non-empty, entirely fictional ten
+// names, and a size bound saw nothing wrong. Naming members that must be
+// present costs nothing to maintain — a type is only removed
+// deliberately — and fails loudly when the derivation drifts.
+func TestMarkers_ScansTheLiveSets(t *testing.T) {
 	t.Parallel()
 
-	const chplanDir = "../chplan"
-	got, err := sealedscan.Markers(chplanDir)
-	if err != nil {
-		t.Fatalf("Markers: %v", err)
+	cases := []struct {
+		dir     string
+		method  string
+		members []string
+	}{
+		{"../chplan", "planNode", []string{"Scan", "Filter", "Project", "VectorSetOp"}},
+		{"../chplan", "exprNode", []string{"ColumnRef", "Binary", "ScalarSubquery"}},
+		// The embedded-base users: every one of these acquires its
+		// marker through stageBase rather than declaring it.
+		{"../logql/lsyntax", "isStageExpr", []string{"LineFilterExpr", "LabelFilterExpr", "KeepLabelsExpr"}},
+		{"../logql/lsyntax", "isExpr", []string{"LineFilterExpr", "MatchersExpr", "BinOpExpr"}},
+		{"../logql/lsyntax", "isSampleExpr", []string{"RangeAggregationExpr", "BinOpExpr"}},
+		{"../traceql/ast", "isPipelineElement", []string{"Pipeline", "SpansetFilter"}},
 	}
-	found := map[string]int{}
-	for _, m := range got {
-		found[m.Method] = len(m.Implementers)
-	}
-	for _, method := range []string{"planNode", "exprNode"} {
-		if found[method] < 2 {
-			t.Errorf("scanning %s found %d %s() implementers, want the live set — the scanner "+
-				"no longer recognises the convention it exists for", chplanDir, found[method], method)
+	for _, tc := range cases {
+		got, err := sealedscan.Implementers(tc.dir, tc.method)
+		if err != nil {
+			t.Errorf("Implementers(%s, %s): %v", tc.dir, tc.method, err)
+			continue
+		}
+		have := make(map[string]bool, len(got))
+		for _, name := range got {
+			have[name] = true
+		}
+		for _, member := range tc.members {
+			if !have[member] {
+				t.Errorf("scanning %s: %s() set is %v, missing %s — the scanner no longer "+
+					"recognises the convention it exists for", tc.dir, tc.method, got, member)
+			}
 		}
 	}
 }

--- a/internal/sealedscan/sealedscan_test.go
+++ b/internal/sealedscan/sealedscan_test.go
@@ -1,0 +1,128 @@
+package sealedscan_test
+
+import (
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/sealedscan"
+)
+
+// fixtureDir is a package under testdata whose shape is pinned by the
+// tests below: three Shape implementers, two Colour implementers, and
+// four declarations that look like sealing markers but are not.
+var fixtureDir = filepath.Join("testdata", "sealedpkg")
+
+func TestMarkers_ReportsSealedInterfacesWithTheirImplementers(t *testing.T) {
+	t.Parallel()
+
+	got, err := sealedscan.Markers(fixtureDir)
+	if err != nil {
+		t.Fatalf("Markers: %v", err)
+	}
+	want := []sealedscan.Marker{
+		{Method: "colourNode", Interface: "Colour", Implementers: []string{"Blue", "Red"}},
+		{Method: "shapeNode", Interface: "Shape", Implementers: []string{"Circle", "Square", "Triangle"}},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Markers = %+v, want %+v", got, want)
+	}
+}
+
+// TestMarkers_RefusesNonMarkerShapes pins what the scanner must NOT
+// treat as a sealed set. Each of these would inflate a ratchet's derived
+// set with something that is not a member, which is worse than a stale
+// count: it fails loudly and wrongly, and the fix is to weaken the
+// ratchet.
+func TestMarkers_RefusesNonMarkerShapes(t *testing.T) {
+	t.Parallel()
+
+	got, err := sealedscan.Markers(fixtureDir)
+	if err != nil {
+		t.Fatalf("Markers: %v", err)
+	}
+	seen := map[string]bool{}
+	for _, m := range got {
+		seen[m.Method] = true
+	}
+	for _, method := range []string{
+		// One implementer is below the floor: nothing can enumerate a
+		// one-element set incorrectly.
+		"lonelyNode",
+		// Exported methods are ordinary API, not a sealing convention.
+		"ExportedNode",
+		// A method taking an argument carries data, so it is behaviour.
+		"paramNode",
+		// A non-empty body is behaviour too, however unexported.
+		"busyNode",
+	} {
+		if seen[method] {
+			t.Errorf("Markers reported %s() as a sealing marker; it is not one", method)
+		}
+	}
+}
+
+func TestImplementers_ReturnsTheSortedSet(t *testing.T) {
+	t.Parallel()
+
+	got, err := sealedscan.Implementers(fixtureDir, "shapeNode")
+	if err != nil {
+		t.Fatalf("Implementers: %v", err)
+	}
+	want := []string{"Circle", "Square", "Triangle"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Implementers = %v, want %v", got, want)
+	}
+}
+
+// TestImplementers_UnknownMarkerIsAnError is the vacuity guard, and it
+// is the single most load-bearing behaviour here. Every caller is a
+// ratchet of the form "derive the set, then assert something covers it";
+// if a renamed marker or a moved directory silently yielded an empty
+// set, every one of those ratchets would pass while asserting nothing.
+func TestImplementers_UnknownMarkerIsAnError(t *testing.T) {
+	t.Parallel()
+
+	_, err := sealedscan.Implementers(fixtureDir, "noSuchMarker")
+	if err == nil {
+		t.Fatal("Implementers on an unknown marker returned no error; a vacuous set must fail loudly")
+	}
+	if !strings.Contains(err.Error(), "vacuous") {
+		t.Errorf("error = %q, want it to explain the vacuity it is preventing", err)
+	}
+}
+
+func TestImplementers_MissingDirectoryIsAnError(t *testing.T) {
+	t.Parallel()
+
+	if _, err := sealedscan.Implementers(filepath.Join("testdata", "absent"), "shapeNode"); err == nil {
+		t.Fatal("Implementers on a missing directory returned no error")
+	}
+}
+
+// TestMarkers_ScansTheLiveChplanSets is the end-to-end check that the
+// scanner still recognises the real convention it exists for. The
+// assertion is deliberately a lower bound rather than an exact count:
+// pinning the numbers here would reintroduce, in the scanner's own test,
+// exactly the hand-maintained restatement the scanner exists to
+// eliminate.
+func TestMarkers_ScansTheLiveChplanSets(t *testing.T) {
+	t.Parallel()
+
+	const chplanDir = "../chplan"
+	got, err := sealedscan.Markers(chplanDir)
+	if err != nil {
+		t.Fatalf("Markers: %v", err)
+	}
+	found := map[string]int{}
+	for _, m := range got {
+		found[m.Method] = len(m.Implementers)
+	}
+	for _, method := range []string{"planNode", "exprNode"} {
+		if found[method] < 2 {
+			t.Errorf("scanning %s found %d %s() implementers, want the live set — the scanner "+
+				"no longer recognises the convention it exists for", chplanDir, found[method], method)
+		}
+	}
+}

--- a/internal/sealedscan/testdata/sealedpkg/pkg.go
+++ b/internal/sealedscan/testdata/sealedpkg/pkg.go
@@ -47,3 +47,24 @@ func (*Only) lonelyNode() {}
 // busyNode has a body, so it is ordinary behaviour rather than a
 // sealing marker even though it is unexported and niladic.
 func (*Busy) busyNode() { _ = 1 }
+
+// --- the embedded-base sealing pattern, as internal/logql/lsyntax uses
+// it: the marker is declared ONCE on a shared base struct, and the
+// members embed the base to acquire it by method promotion. Counting
+// declarations alone would derive a set of one here. ---
+
+// Sound is sealed by soundNode(), supplied via soundBase.
+type Sound interface{ soundNode() }
+
+type soundBase struct{}
+
+func (soundBase) soundNode() {}
+
+type (
+	Bark struct {
+		soundBase
+		Loud bool
+	}
+	Meow struct{ soundBase }
+	Moo  struct{ *soundBase }
+)

--- a/internal/sealedscan/testdata/sealedpkg/pkg.go
+++ b/internal/sealedscan/testdata/sealedpkg/pkg.go
@@ -1,0 +1,49 @@
+// Package sealedpkg is a fixture for the sealedscan tests. It is not
+// built as part of cerberus: it lives under testdata precisely so the
+// scanner can be pointed at a known shape, including the shapes it must
+// REFUSE to treat as sealing markers.
+package sealedpkg
+
+// Shape is sealed by shapeNode(): three implementers.
+type Shape interface {
+	shapeNode()
+	Area() int
+}
+
+// Colour is sealed by colourNode(): two implementers, the floor.
+type Colour interface{ colourNode() }
+
+// Lonely has a single implementer and so is below the floor.
+type Lonely interface{ lonelyNode() }
+
+// Exported is not a sealing marker: the method is exported.
+type Exported interface{ ExportedNode() }
+
+// Parametrised is not a sealing marker: the method takes an argument.
+type Parametrised interface{ paramNode(int) }
+
+type (
+	Square   struct{}
+	Circle   struct{}
+	Triangle struct{}
+	Red      struct{}
+	Blue     struct{}
+	Only     struct{}
+	Busy     struct{}
+)
+
+func (*Square) shapeNode()   {}
+func (*Circle) shapeNode()   {}
+func (*Triangle) shapeNode() {}
+func (*Square) Area() int    { return 0 }
+func (*Circle) Area() int    { return 0 }
+func (*Triangle) Area() int  { return 0 }
+
+func (*Red) colourNode()  {}
+func (*Blue) colourNode() {}
+
+func (*Only) lonelyNode() {}
+
+// busyNode has a body, so it is ordinary behaviour rather than a
+// sealing marker even though it is unexported and niladic.
+func (*Busy) busyNode() { _ = 1 }

--- a/test/regression/sealed_marker_derivation_test.go
+++ b/test/regression/sealed_marker_derivation_test.go
@@ -7,40 +7,46 @@ package regression
 // gets restated by hand somewhere else — a count, a mirrored switch, a
 // list of type names — and nothing re-derives the restatement, so it
 // drifts. The drift is silent precisely because the restatement's
-// existence implies a check that is not happening. Every member of the
-// family found so far was a sealed interface's implementer set: the
-// chplan Node kinds restated as `31`, then `32`; the chplan Expr kinds
-// restated as `23` twice over; the derived-shape classifier mirrored
-// into the HTTP layer while a docstring on each copy asserted they
-// agreed.
+// existence implies a check that is not happening.
 //
-// A sealed interface is the sharpest case because the truth is not
-// merely derivable, it is *only* derivable: a type joins chplan.Node by
-// declaring `planNode()` and by nothing else, so the marker method
-// declarations are the set. Any second statement of that set is a copy.
+// The instances of the family that live in TESTS have all been one
+// thing: a restatement of a sealed interface's implementer set. That is
+// the sharpest case, because the truth is not merely derivable but ONLY
+// derivable — a type joins chplan.Node by declaring `planNode()` and by
+// nothing else, so the marker declarations ARE the set and any second
+// statement of it is a copy by construction. The chplan Node kinds were
+// restated as `31`, then `32`; the chplan Expr kinds as `23`, twice
+// over, by a guard that compared the number against the length of the
+// very list it was meant to police.
 //
-// This test therefore derives every sealed marker's implementer set in
-// the tree (internal/sealedscan) and fails on the two shapes a copy
-// takes:
+// So this test derives every sealed marker's implementer set
+// (internal/sealedscan) and fails on the two shapes a copy takes:
 //
-//	Rule A — a test declares an integer constant that restates the
-//	set's cardinality and compares it against a measured count. This is
-//	`const wantExprTypes = 23; if len(all) != wantExprTypes`. Bumping
-//	the number is the entire maintenance protocol, which is why it is
+//	Rule A — a test declares an integer that restates the set's
+//	cardinality and compares it against a measured count. Bumping the
+//	number is the entire maintenance protocol, which is why it is
 //	forgotten.
 //
 //	Rule B — a test hand-enumerates the whole set as a composite
 //	literal without its package deriving that set from source. A hand
-//	list is legitimate (the tests need instances to exercise), but only
-//	with a derivation behind it that diffs the list against the marker
-//	scan; without one it is a mirror with nothing re-deriving it.
+//	list is legitimate (the tests need instances, which no scan can
+//	produce), but only with a derivation behind it that diffs the list
+//	against the marker scan.
 //
 // Neither rule compares a hand-maintained value against another
-// hand-maintained value — the offending set is recomputed from the
-// marker declarations on every run, and both rules name the specific
-// offender. That distinction is the whole point of #1504: a gate that
-// diffs two declarations is how the mirror it was supposed to catch
-// drifted in the first place.
+// hand-maintained value: the offending set is recomputed from the marker
+// declarations on every run, and both rules name the specific offender.
+// That distinction is the whole point of #1504 — a gate diffing two
+// declarations is how this issue's own mirror drifted while a docstring
+// asserted it could not.
+//
+// SCOPE, stated plainly so it is not mistaken for more than it is. Both
+// rules read `_test.go` only, and match a test against the markers
+// declared in its OWN directory. Matching within the directory is what
+// buys the precision: a tree-wide search for the value 3 or 4 would be
+// unusable. A dispatch mirrored between two PRODUCTION files — the shape
+// #1504 itself recorded, closed by unifying on chplan.IsDerivedShape —
+// is outside what this scan can see, and #2031 tracks it.
 
 import (
 	"go/ast"
@@ -57,26 +63,31 @@ import (
 	"github.com/tsouza/cerberus/internal/sealedscan"
 )
 
-const (
-	// sealedScanRoot is the repo root relative to this package's
-	// directory, which is where `go test` runs.
-	sealedScanRoot = "../.."
-	// sealedScanPkg is the import path of the one derivation engine. A
-	// package that hand-enumerates a sealed set is expected to consume
-	// it rather than grow a private copy of the scan.
-	sealedScanPkg = "github.com/tsouza/cerberus/internal/sealedscan"
-)
+// sealedScanPkg is the import path of the one derivation engine. A test
+// package that hand-enumerates a sealed set is expected to consume it
+// rather than grow a private copy of the scan.
+const sealedScanPkg = "github.com/tsouza/cerberus/internal/sealedscan"
 
-// TestSealedMarkerSetsAreDerived is the ratchet. It fails when a test
-// restates a sealed interface's implementer set instead of deriving it.
+// finding is one rule violation: where it is, and what to do about it.
+//
+// The rules RETURN findings rather than reporting them through *testing.T,
+// so that the rules themselves can be driven against fixtures. A
+// scan-and-assert-nothing-matches gate whose detectors have no positive
+// test is the same silent no-op this file exists to prevent — it goes
+// green either because the tree is clean or because the detector broke,
+// and nothing distinguishes the two.
+type finding struct {
+	path string
+	line int
+	msg  string
+}
+
+// TestSealedMarkerSetsAreDerived is the ratchet over the live tree.
 func TestSealedMarkerSetsAreDerived(t *testing.T) {
 	t.Parallel()
 
-	dirs := goPackageDirs(t, sealedScanRoot)
-	var (
-		markersSeen   int
-		testFilesRead int
-	)
+	dirs := goPackageDirs(t, repoRoot)
+	var markersSeen, testFilesRead int
 	for _, dir := range dirs {
 		markers, err := sealedscan.Markers(dir)
 		if err != nil {
@@ -90,18 +101,23 @@ func TestSealedMarkerSetsAreDerived(t *testing.T) {
 		files := parseTestFiles(t, dir)
 		testFilesRead += len(files)
 		for _, m := range markers {
+			var found []finding
 			for _, f := range files {
-				checkRestatedCardinality(t, f, m)
+				found = append(found, restatedCardinality(f, m)...)
 			}
-			checkUnbackedEnumeration(t, dir, files, m)
+			found = append(found, unbackedEnumerations(dir, files, m)...)
+			for _, v := range found {
+				t.Errorf("%s:%d: %s", v.path, v.line, v.msg)
+			}
 		}
 	}
 
-	// Vacuity guard. Both halves of this test are "scan the tree, then
-	// assert nothing matches", which is exactly the shape that passes
-	// forever once the scan stops finding anything. If the marker
-	// convention is renamed or the walk loses the tree, that must fail
-	// here rather than quietly turn the ratchet into a no-op.
+	// Vacuity guard on the WALK. If the marker convention is renamed or
+	// the walk loses the tree, that must fail here rather than quietly
+	// turn the ratchet into a no-op. The vacuity guard on the RULES is
+	// TestSealedMarkerRules_FireOnTheDefectShapes: this one cannot cover
+	// them, because a broken detector and a clean tree produce the same
+	// silence.
 	if markersSeen == 0 {
 		t.Fatal("found no sealed marker interfaces in the tree — the scan lost its grip " +
 			"on the source shape, so this ratchet is vacuous")
@@ -110,6 +126,137 @@ func TestSealedMarkerSetsAreDerived(t *testing.T) {
 		t.Fatal("found sealed marker interfaces but read no _test.go beside them — the " +
 			"scan lost its grip on the source shape, so this ratchet is vacuous")
 	}
+}
+
+// TestSealedMarkerRules_FireOnTheDefectShapes is the guard on the guard.
+// Each fixture package under testdata holds the defect its rule must
+// catch alongside the near-misses it must NOT catch, and the expectation
+// is the exact set of flagged lines — so a rule that stops detecting,
+// and a rule that starts over-detecting, both fail here.
+func TestSealedMarkerRules_FireOnTheDefectShapes(t *testing.T) {
+	t.Parallel()
+
+	allFiles := func(run func(*testFile, sealedscan.Marker) []finding) func(string, []*testFile, sealedscan.Marker) []finding {
+		return func(_ string, files []*testFile, m sealedscan.Marker) []finding {
+			var out []finding
+			for _, f := range files {
+				out = append(out, run(f, m)...)
+			}
+			return out
+		}
+	}
+	cases := []struct {
+		dir string
+		// positive says the fixture holds at least one line the rule
+		// must flag. Without it a fixture whose markers were all deleted
+		// would expect nothing, match a rule that detects nothing, and
+		// pass — the dead-rule case this test exists to prevent.
+		positive bool
+		run      func(dir string, files []*testFile, m sealedscan.Marker) []finding
+	}{
+		// The three spellings of a restated cardinality — const, var,
+		// and short variable declaration — each compared against a
+		// different measurement shape.
+		{dir: "restated", positive: true, run: allFiles(restatedCardinality)},
+		// The same values, none of them a claim about the set: never
+		// compared, compared against a scalar the code returned, and a
+		// counter incremented in a different function.
+		{dir: "restatednearmiss", run: allFiles(restatedCardinality)},
+		// A complete enumeration with no derivation behind it, beside a
+		// deliberate subset that must stay unflagged.
+		{dir: "enumerated", positive: true, run: unbackedEnumerations},
+		// The same complete enumeration, in a package that derives the
+		// marker: the derivation carries the ratchet, so the rule
+		// stands aside.
+		{dir: "derived", run: unbackedEnumerations},
+	}
+	for _, tc := range cases {
+		t.Run(tc.dir, func(t *testing.T) {
+			t.Parallel()
+			dir := filepath.Join("testdata", "sealedrules", tc.dir)
+			markers, err := sealedscan.Markers(dir)
+			if err != nil {
+				t.Fatalf("scan %s: %v", dir, err)
+			}
+			if len(markers) != 1 {
+				t.Fatalf("fixture %s declares %d sealed markers, want exactly 1 — the "+
+					"fixture no longer exercises what it claims to", dir, len(markers))
+			}
+			files := parseTestFiles(t, dir)
+			if len(files) == 0 {
+				t.Fatalf("fixture %s holds no _test.go, so there is nothing to detect", dir)
+			}
+			gotLines := []int{}
+			for _, v := range tc.run(dir, files, markers[0]) {
+				gotLines = append(gotLines, v.line)
+			}
+			sort.Ints(gotLines)
+			want := wantMarkedLines(t, dir)
+			if tc.positive != (len(want) > 0) {
+				t.Fatalf("fixture %s marks %d lines with %s, but positive=%v — the fixture "+
+					"no longer states the case it is named for", dir, len(want), wantMarker, tc.positive)
+			}
+			if tc.positive != (len(want) > 0) {
+				t.Fatalf("fixture %s marks %d lines with %s, but positive=%v — the fixture "+
+					"no longer states the case it is named for", dir, len(want), wantMarker, tc.positive)
+			}
+			if !sameInts(gotLines, want) {
+				t.Errorf("fixture %s: rule flagged lines %v, want %v (the lines marked %s)",
+					dir, gotLines, want, wantMarker)
+			}
+		})
+	}
+}
+
+// wantMarker is the comment a fixture line carries when the rule under
+// test must flag it. Reading the expectation out of the fixture keeps
+// the two from drifting: a new fixture case is one edit, in one file,
+// and there is no list of line numbers to keep in step — which is the
+// mistake this whole file exists to prevent.
+const wantMarker = "// WANT"
+
+// wantMarkedLines returns the sorted fixture lines marked with
+// wantMarker. Whether a fixture is expected to carry any is the caller's
+// business — the negative fixtures deliberately carry none.
+func wantMarkedLines(t *testing.T, dir string) []int {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read %s: %v", dir, err)
+	}
+	lines := []int{}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), "_test.go") {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+		for _, group := range file.Comments {
+			for _, c := range group.List {
+				if strings.TrimSpace(c.Text) == wantMarker {
+					lines = append(lines, fset.Position(c.Pos()).Line)
+				}
+			}
+		}
+	}
+	sort.Ints(lines)
+	return lines
+}
+
+func sameInts(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // testFile is one parsed test file plus what the rules need from it.
@@ -122,82 +269,144 @@ type testFile struct {
 	stringLits map[string]bool
 }
 
-// checkRestatedCardinality implements Rule A: a named integer constant
-// whose value restates |implementers| and which is compared against a
-// measured count.
+// restatedCardinality implements Rule A: an integer declaration whose
+// value restates |implementers| and which is compared against a measured
+// count.
 //
 // Both halves are required. The value alone is a coincidence — a lexer
-// test wanting offset 6 is not a claim about the six LabelFilterer
-// kinds — and the comparison alone is ordinary assertion. Together they
-// are a declaration that the set has N members, checked against a
-// measurement of the same set.
-func checkRestatedCardinality(t *testing.T, f *testFile, m sealedscan.Marker) {
-	t.Helper()
+// test wanting offset 6 is not a claim about the six LabelFilterer kinds
+// — and the comparison alone is ordinary assertion. Together they are a
+// declaration that the set has N members, checked against a measurement
+// of the same set.
+func restatedCardinality(f *testFile, m sealedscan.Marker) []finding {
 	want := len(m.Implementers)
 	measured := measuredCountOperands(f.file)
-	ast.Inspect(f.file, func(n ast.Node) bool {
-		vs, ok := n.(*ast.ValueSpec)
-		if !ok {
-			return true
+	var out []finding
+	for name, decl := range intDeclarations(f.file) {
+		if !measured[name] || !restatesCount(decl.value, want) {
+			continue
 		}
-		for i, name := range vs.Names {
-			if i >= len(vs.Values) || !restatesCount(vs.Values[i], want) {
-				continue
+		out = append(out, finding{
+			path: f.path,
+			line: f.fset.Position(decl.pos).Line,
+			msg: name + " restates the number of " + m.Method + "() implementers (" +
+				strconv.Itoa(want) + ") and is compared against a measured count; derive " +
+				"the set with " + sealedScanPkg + " instead of declaring its size — see " +
+				"the interface " + m.Interface,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].line < out[j].line })
+	return out
+}
+
+// intDecl is one integer-valued declaration: where it is and what it says.
+type intDecl struct {
+	pos   token.Pos
+	value ast.Expr
+}
+
+// intDeclarations returns every name bound to an integer-constant
+// expression in the file, whether by `const`, by `var`, or by a short
+// variable declaration. All three spell the same restatement, and inside
+// a test function the short form is the one an author reaches for.
+func intDeclarations(file *ast.File) map[string]intDecl {
+	out := map[string]intDecl{}
+	record := func(name *ast.Ident, value ast.Expr, pos token.Pos) {
+		if name.Name == "_" || !isIntConstExpr(value) {
+			return
+		}
+		out[name.Name] = intDecl{pos: pos, value: value}
+	}
+	ast.Inspect(file, func(n ast.Node) bool {
+		switch v := n.(type) {
+		case *ast.ValueSpec:
+			for i, name := range v.Names {
+				if i < len(v.Values) {
+					record(name, v.Values[i], v.Pos())
+				}
 			}
-			if !measured[name.Name] {
-				continue
+		case *ast.AssignStmt:
+			if v.Tok != token.DEFINE || len(v.Lhs) != len(v.Rhs) {
+				return true
 			}
-			t.Errorf("%s:%d: %s restates the number of %s() implementers (%d) and is "+
-				"compared against a measured count; derive the set with %s instead of "+
-				"declaring its size — see the interface %s",
-				f.path, f.fset.Position(vs.Pos()).Line, name.Name, m.Method, want,
-				sealedScanPkg, m.Interface)
+			for i, lhs := range v.Lhs {
+				if id, ok := lhs.(*ast.Ident); ok {
+					record(id, v.Rhs[i], v.Pos())
+				}
+			}
 		}
 		return true
 	})
+	return out
 }
 
-// checkUnbackedEnumeration implements Rule B: a composite literal that
-// names every implementer of a marker, in a test package that does not
-// derive that marker's set from source.
+// isIntConstExpr reports whether e is built only from integer literals
+// and arithmetic — the shape a restated cardinality takes, including the
+// `32 - 10` form that states a set's size while subtracting from it.
+func isIntConstExpr(e ast.Expr) bool {
+	switch v := e.(type) {
+	case *ast.BasicLit:
+		return v.Kind == token.INT
+	case *ast.ParenExpr:
+		return isIntConstExpr(v.X)
+	case *ast.BinaryExpr:
+		return isIntConstExpr(v.X) && isIntConstExpr(v.Y)
+	}
+	return false
+}
+
+// unbackedEnumerations implements Rule B: a composite literal that names
+// every implementer of a marker, in a test package that does not derive
+// that marker's set from source.
 //
 // Completeness is what identifies the literal as an enumeration of the
-// set rather than a deliberate subset (the ten slice-invariant-
+// set rather than a deliberate subset — the ten slice-invariant-
 // registered node kinds out of thirty-two are a policy choice, not a
-// mirror of the Node set). Once a package derives the marker, its lists
+// mirror of the Node set. Once a package derives the marker its lists
 // are diffed by that derivation on every run, so this rule steps aside
-// and the derivation carries the ratchet from then on — including for
-// the case this rule cannot see, where the list has already fallen one
-// type behind.
-func checkUnbackedEnumeration(t *testing.T, dir string, files []*testFile, m sealedscan.Marker) {
-	t.Helper()
+// and the derivation carries the ratchet from then on, including for the
+// case this rule cannot see: a list that has already fallen one type
+// behind is no longer complete, so only the derivation can catch it.
+func unbackedEnumerations(dir string, files []*testFile, m sealedscan.Marker) []finding {
 	derived := map[string]bool{}
 	for _, f := range files {
 		if f.imports[sealedScanPkg] && f.stringLits[m.Method] {
 			derived[f.pkg] = true
 		}
 	}
+	var out []finding
 	for _, f := range files {
 		if derived[f.pkg] {
 			continue
 		}
-		for _, pos := range completeEnumerations(f, m) {
-			t.Errorf("%s:%d: this literal names all %d %s() implementers, but package %q "+
-				"in %s never derives that set; import %s and diff the list against "+
-				"sealedscan.Implementers(\".\", %q) so a new %s implementer fails here "+
-				"instead of going unnoticed",
-				f.path, pos, len(m.Implementers), m.Method, f.pkg, dir,
-				sealedScanPkg, m.Method, m.Interface)
+		for _, line := range completeEnumerations(f, m) {
+			out = append(out, finding{
+				path: f.path,
+				line: line,
+				msg: "this literal names all " + strconv.Itoa(len(m.Implementers)) + " " +
+					m.Method + "() implementers, but package " + strconv.Quote(f.pkg) +
+					" in " + dir + " never derives that set; import " + sealedScanPkg +
+					" and diff the list against sealedscan.Implementers(\".\", " +
+					strconv.Quote(m.Method) + ") so a new " + m.Interface +
+					" implementer fails here instead of going unnoticed",
+			})
 		}
 	}
+	sort.Slice(out, func(i, j int) bool { return out[i].line < out[j].line })
+	return out
 }
 
 // completeEnumerations returns the line of every composite literal in f
 // that names each implementer of m at least once. It looks at the
 // concrete types written inside the literal at any depth, so it sees the
-// three shapes the tests use interchangeably: `[]Expr{&ColumnRef{}, …}`,
+// shapes the tests use interchangeably: `[]Expr{&ColumnRef{}, …}`,
 // `map[reflect.Type]bool{reflect.TypeOf(&Scan{}): true, …}`, and a table
 // of structs each carrying a node instance.
+//
+// Only the OUTERMOST covering literal is reported. A literal that covers
+// the set makes every literal enclosing it cover the set too, and the
+// outermost one is the whole table — which is the thing that has to gain
+// a row, and so the line a reader needs to be sent to.
 func completeEnumerations(f *testFile, m sealedscan.Marker) []int {
 	var lines []int
 	ast.Inspect(f.file, func(n ast.Node) bool {
@@ -220,50 +429,59 @@ func completeEnumerations(f *testFile, m sealedscan.Marker) []int {
 			}
 		}
 		lines = append(lines, f.fset.Position(cl.Pos()).Line)
-		// A literal that covers the set makes every literal enclosing
-		// it cover the set too; report the innermost one only, which is
-		// the list the author actually wrote.
 		return false
 	})
 	return lines
 }
 
 // measuredCountOperands returns the names compared against something
-// that counts: `len(x)`, or a variable the same function only ever
-// increments. Those are measurements of a set; a constant compared
+// that counts: `len(x)`, or a variable the SAME function only ever
+// increments. Those are measurements of a set; an integer compared
 // against one is a claim about that set's size.
+//
+// Counters are scoped to the function that increments them. A file-wide
+// scope would let an unrelated `i++` in one function turn a plain
+// expectation in another into a cardinality claim — which is how a gate
+// starts failing on changes it has no business judging, and how it earns
+// the weakening that follows.
 func measuredCountOperands(file *ast.File) map[string]bool {
-	counters := incrementedVars(file)
 	out := map[string]bool{}
-	ast.Inspect(file, func(n ast.Node) bool {
-		be, ok := n.(*ast.BinaryExpr)
-		if !ok || !isComparison(be.Op) {
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			continue
+		}
+		counters := incrementedVars(fn)
+		ast.Inspect(fn, func(n ast.Node) bool {
+			be, ok := n.(*ast.BinaryExpr)
+			if !ok || !isComparison(be.Op) {
+				return true
+			}
+			for _, pair := range [2][2]ast.Expr{{be.X, be.Y}, {be.Y, be.X}} {
+				id, ok := pair[1].(*ast.Ident)
+				if !ok {
+					continue
+				}
+				if isLenCall(pair[0]) {
+					out[id.Name] = true
+					continue
+				}
+				if other, ok := pair[0].(*ast.Ident); ok && counters[other.Name] {
+					out[id.Name] = true
+				}
+			}
 			return true
-		}
-		for _, pair := range [2][2]ast.Expr{{be.X, be.Y}, {be.Y, be.X}} {
-			id, ok := pair[1].(*ast.Ident)
-			if !ok {
-				continue
-			}
-			if isLenCall(pair[0]) {
-				out[id.Name] = true
-				continue
-			}
-			if other, ok := pair[0].(*ast.Ident); ok && counters[other.Name] {
-				out[id.Name] = true
-			}
-		}
-		return true
-	})
+		})
+	}
 	return out
 }
 
-// incrementedVars returns the names targeted by a `x++` anywhere in the
-// file — the running-total shape a reflective or scanning test uses to
-// measure a set it did not build directly.
-func incrementedVars(file *ast.File) map[string]bool {
+// incrementedVars returns the names targeted by an `x++` inside fn — the
+// running-total shape a reflective or scanning test uses to measure a
+// set it did not build directly.
+func incrementedVars(fn *ast.FuncDecl) map[string]bool {
 	out := map[string]bool{}
-	ast.Inspect(file, func(n ast.Node) bool {
+	ast.Inspect(fn, func(n ast.Node) bool {
 		inc, ok := n.(*ast.IncDecStmt)
 		if !ok {
 			return true
@@ -276,10 +494,10 @@ func incrementedVars(file *ast.File) map[string]bool {
 	return out
 }
 
-// restatesCount reports whether e is an integer-constant expression that
-// mentions want. The value is matched anywhere in the expression, not
-// just as the result, because `32 - 10` restates the thirty-two Node
-// kinds every bit as much as a bare `32` does.
+// restatesCount reports whether e mentions want. The value is matched
+// anywhere in the expression, not just as the result, because `32 - 10`
+// restates the thirty-two Node kinds every bit as much as a bare `32`
+// does.
 func restatesCount(e ast.Expr, want int) bool {
 	found := false
 	ast.Inspect(e, func(n ast.Node) bool {
@@ -373,8 +591,15 @@ func parseTestFiles(t *testing.T, dir string) []*testFile {
 	return out
 }
 
+// sealedScanExtraSkips are directories goPackageDirs skips on top of the
+// package-wide skippedDirs: fixture packages (this file keeps its own
+// under testdata, and they hold the defects on purpose), and the agent
+// harness, which in a developer checkout also holds worktrees — whole
+// second copies of this repository the walk must not descend into.
+var sealedScanExtraSkips = map[string]bool{"testdata": true, ".claude": true}
+
 // goPackageDirs returns every directory under root that holds Go
-// sources, sorted, skipping the trees no package lives in.
+// sources, sorted, skipping the trees no cerberus package lives in.
 func goPackageDirs(t *testing.T, root string) []string {
 	t.Helper()
 	seen := map[string]bool{}
@@ -383,13 +608,7 @@ func goPackageDirs(t *testing.T, root string) []string {
 			return err
 		}
 		if d.IsDir() {
-			switch d.Name() {
-			// testdata holds fixture packages, which are shapes under
-			// test rather than code under ratchet. .claude holds the
-			// agent harness, and in a developer checkout also the
-			// worktrees — whole second copies of this repository, which
-			// the walk must not descend into and report twice.
-			case ".git", ".claude", "node_modules", "bin", "vendor", "testdata":
+			if skippedDirs[d.Name()] || sealedScanExtraSkips[d.Name()] {
 				return fs.SkipDir
 			}
 			return nil

--- a/test/regression/sealed_marker_derivation_test.go
+++ b/test/regression/sealed_marker_derivation_test.go
@@ -1,0 +1,411 @@
+package regression
+
+// Class-closing ratchet for the "declared duplicate of a derivable fact"
+// family (#1504).
+//
+// The family is one mechanism: a fact that the code already determines
+// gets restated by hand somewhere else — a count, a mirrored switch, a
+// list of type names — and nothing re-derives the restatement, so it
+// drifts. The drift is silent precisely because the restatement's
+// existence implies a check that is not happening. Every member of the
+// family found so far was a sealed interface's implementer set: the
+// chplan Node kinds restated as `31`, then `32`; the chplan Expr kinds
+// restated as `23` twice over; the derived-shape classifier mirrored
+// into the HTTP layer while a docstring on each copy asserted they
+// agreed.
+//
+// A sealed interface is the sharpest case because the truth is not
+// merely derivable, it is *only* derivable: a type joins chplan.Node by
+// declaring `planNode()` and by nothing else, so the marker method
+// declarations are the set. Any second statement of that set is a copy.
+//
+// This test therefore derives every sealed marker's implementer set in
+// the tree (internal/sealedscan) and fails on the two shapes a copy
+// takes:
+//
+//	Rule A — a test declares an integer constant that restates the
+//	set's cardinality and compares it against a measured count. This is
+//	`const wantExprTypes = 23; if len(all) != wantExprTypes`. Bumping
+//	the number is the entire maintenance protocol, which is why it is
+//	forgotten.
+//
+//	Rule B — a test hand-enumerates the whole set as a composite
+//	literal without its package deriving that set from source. A hand
+//	list is legitimate (the tests need instances to exercise), but only
+//	with a derivation behind it that diffs the list against the marker
+//	scan; without one it is a mirror with nothing re-deriving it.
+//
+// Neither rule compares a hand-maintained value against another
+// hand-maintained value — the offending set is recomputed from the
+// marker declarations on every run, and both rules name the specific
+// offender. That distinction is the whole point of #1504: a gate that
+// diffs two declarations is how the mirror it was supposed to catch
+// drifted in the first place.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/sealedscan"
+)
+
+const (
+	// sealedScanRoot is the repo root relative to this package's
+	// directory, which is where `go test` runs.
+	sealedScanRoot = "../.."
+	// sealedScanPkg is the import path of the one derivation engine. A
+	// package that hand-enumerates a sealed set is expected to consume
+	// it rather than grow a private copy of the scan.
+	sealedScanPkg = "github.com/tsouza/cerberus/internal/sealedscan"
+)
+
+// TestSealedMarkerSetsAreDerived is the ratchet. It fails when a test
+// restates a sealed interface's implementer set instead of deriving it.
+func TestSealedMarkerSetsAreDerived(t *testing.T) {
+	t.Parallel()
+
+	dirs := goPackageDirs(t, sealedScanRoot)
+	var (
+		markersSeen   int
+		testFilesRead int
+	)
+	for _, dir := range dirs {
+		markers, err := sealedscan.Markers(dir)
+		if err != nil {
+			t.Fatalf("scan %s: %v", dir, err)
+		}
+		if len(markers) == 0 {
+			continue
+		}
+		markersSeen += len(markers)
+
+		files := parseTestFiles(t, dir)
+		testFilesRead += len(files)
+		for _, m := range markers {
+			for _, f := range files {
+				checkRestatedCardinality(t, f, m)
+			}
+			checkUnbackedEnumeration(t, dir, files, m)
+		}
+	}
+
+	// Vacuity guard. Both halves of this test are "scan the tree, then
+	// assert nothing matches", which is exactly the shape that passes
+	// forever once the scan stops finding anything. If the marker
+	// convention is renamed or the walk loses the tree, that must fail
+	// here rather than quietly turn the ratchet into a no-op.
+	if markersSeen == 0 {
+		t.Fatal("found no sealed marker interfaces in the tree — the scan lost its grip " +
+			"on the source shape, so this ratchet is vacuous")
+	}
+	if testFilesRead == 0 {
+		t.Fatal("found sealed marker interfaces but read no _test.go beside them — the " +
+			"scan lost its grip on the source shape, so this ratchet is vacuous")
+	}
+}
+
+// testFile is one parsed test file plus what the rules need from it.
+type testFile struct {
+	path       string
+	pkg        string
+	fset       *token.FileSet
+	file       *ast.File
+	imports    map[string]bool
+	stringLits map[string]bool
+}
+
+// checkRestatedCardinality implements Rule A: a named integer constant
+// whose value restates |implementers| and which is compared against a
+// measured count.
+//
+// Both halves are required. The value alone is a coincidence — a lexer
+// test wanting offset 6 is not a claim about the six LabelFilterer
+// kinds — and the comparison alone is ordinary assertion. Together they
+// are a declaration that the set has N members, checked against a
+// measurement of the same set.
+func checkRestatedCardinality(t *testing.T, f *testFile, m sealedscan.Marker) {
+	t.Helper()
+	want := len(m.Implementers)
+	measured := measuredCountOperands(f.file)
+	ast.Inspect(f.file, func(n ast.Node) bool {
+		vs, ok := n.(*ast.ValueSpec)
+		if !ok {
+			return true
+		}
+		for i, name := range vs.Names {
+			if i >= len(vs.Values) || !restatesCount(vs.Values[i], want) {
+				continue
+			}
+			if !measured[name.Name] {
+				continue
+			}
+			t.Errorf("%s:%d: %s restates the number of %s() implementers (%d) and is "+
+				"compared against a measured count; derive the set with %s instead of "+
+				"declaring its size — see the interface %s",
+				f.path, f.fset.Position(vs.Pos()).Line, name.Name, m.Method, want,
+				sealedScanPkg, m.Interface)
+		}
+		return true
+	})
+}
+
+// checkUnbackedEnumeration implements Rule B: a composite literal that
+// names every implementer of a marker, in a test package that does not
+// derive that marker's set from source.
+//
+// Completeness is what identifies the literal as an enumeration of the
+// set rather than a deliberate subset (the ten slice-invariant-
+// registered node kinds out of thirty-two are a policy choice, not a
+// mirror of the Node set). Once a package derives the marker, its lists
+// are diffed by that derivation on every run, so this rule steps aside
+// and the derivation carries the ratchet from then on — including for
+// the case this rule cannot see, where the list has already fallen one
+// type behind.
+func checkUnbackedEnumeration(t *testing.T, dir string, files []*testFile, m sealedscan.Marker) {
+	t.Helper()
+	derived := map[string]bool{}
+	for _, f := range files {
+		if f.imports[sealedScanPkg] && f.stringLits[m.Method] {
+			derived[f.pkg] = true
+		}
+	}
+	for _, f := range files {
+		if derived[f.pkg] {
+			continue
+		}
+		for _, pos := range completeEnumerations(f, m) {
+			t.Errorf("%s:%d: this literal names all %d %s() implementers, but package %q "+
+				"in %s never derives that set; import %s and diff the list against "+
+				"sealedscan.Implementers(\".\", %q) so a new %s implementer fails here "+
+				"instead of going unnoticed",
+				f.path, pos, len(m.Implementers), m.Method, f.pkg, dir,
+				sealedScanPkg, m.Method, m.Interface)
+		}
+	}
+}
+
+// completeEnumerations returns the line of every composite literal in f
+// that names each implementer of m at least once. It looks at the
+// concrete types written inside the literal at any depth, so it sees the
+// three shapes the tests use interchangeably: `[]Expr{&ColumnRef{}, …}`,
+// `map[reflect.Type]bool{reflect.TypeOf(&Scan{}): true, …}`, and a table
+// of structs each carrying a node instance.
+func completeEnumerations(f *testFile, m sealedscan.Marker) []int {
+	var lines []int
+	ast.Inspect(f.file, func(n ast.Node) bool {
+		cl, ok := n.(*ast.CompositeLit)
+		if !ok {
+			return true
+		}
+		named := map[string]bool{}
+		ast.Inspect(cl, func(inner ast.Node) bool {
+			icl, ok := inner.(*ast.CompositeLit)
+			if !ok || icl.Type == nil {
+				return true
+			}
+			named[typeName(icl.Type)] = true
+			return true
+		})
+		for _, impl := range m.Implementers {
+			if !named[impl] {
+				return true
+			}
+		}
+		lines = append(lines, f.fset.Position(cl.Pos()).Line)
+		// A literal that covers the set makes every literal enclosing
+		// it cover the set too; report the innermost one only, which is
+		// the list the author actually wrote.
+		return false
+	})
+	return lines
+}
+
+// measuredCountOperands returns the names compared against something
+// that counts: `len(x)`, or a variable the same function only ever
+// increments. Those are measurements of a set; a constant compared
+// against one is a claim about that set's size.
+func measuredCountOperands(file *ast.File) map[string]bool {
+	counters := incrementedVars(file)
+	out := map[string]bool{}
+	ast.Inspect(file, func(n ast.Node) bool {
+		be, ok := n.(*ast.BinaryExpr)
+		if !ok || !isComparison(be.Op) {
+			return true
+		}
+		for _, pair := range [2][2]ast.Expr{{be.X, be.Y}, {be.Y, be.X}} {
+			id, ok := pair[1].(*ast.Ident)
+			if !ok {
+				continue
+			}
+			if isLenCall(pair[0]) {
+				out[id.Name] = true
+				continue
+			}
+			if other, ok := pair[0].(*ast.Ident); ok && counters[other.Name] {
+				out[id.Name] = true
+			}
+		}
+		return true
+	})
+	return out
+}
+
+// incrementedVars returns the names targeted by a `x++` anywhere in the
+// file — the running-total shape a reflective or scanning test uses to
+// measure a set it did not build directly.
+func incrementedVars(file *ast.File) map[string]bool {
+	out := map[string]bool{}
+	ast.Inspect(file, func(n ast.Node) bool {
+		inc, ok := n.(*ast.IncDecStmt)
+		if !ok {
+			return true
+		}
+		if id, ok := inc.X.(*ast.Ident); ok {
+			out[id.Name] = true
+		}
+		return true
+	})
+	return out
+}
+
+// restatesCount reports whether e is an integer-constant expression that
+// mentions want. The value is matched anywhere in the expression, not
+// just as the result, because `32 - 10` restates the thirty-two Node
+// kinds every bit as much as a bare `32` does.
+func restatesCount(e ast.Expr, want int) bool {
+	found := false
+	ast.Inspect(e, func(n ast.Node) bool {
+		lit, ok := n.(*ast.BasicLit)
+		if !ok || lit.Kind != token.INT {
+			return true
+		}
+		if v, err := strconv.Atoi(lit.Value); err == nil && v == want {
+			found = true
+		}
+		return true
+	})
+	return found
+}
+
+// isComparison reports whether op compares two values. Equality and
+// ordering both count: `len(all) != want` and `seen > want` state the
+// same claim about the same set.
+func isComparison(op token.Token) bool {
+	switch op {
+	case token.EQL, token.NEQ, token.LSS, token.LEQ, token.GTR, token.GEQ:
+		return true
+	}
+	return false
+}
+
+func isLenCall(e ast.Expr) bool {
+	c, ok := e.(*ast.CallExpr)
+	if !ok || len(c.Args) != 1 {
+		return false
+	}
+	id, ok := c.Fun.(*ast.Ident)
+	return ok && id.Name == "len"
+}
+
+func typeName(e ast.Expr) string {
+	switch v := e.(type) {
+	case *ast.Ident:
+		return v.Name
+	case *ast.SelectorExpr:
+		return v.Sel.Name
+	case *ast.StarExpr:
+		return typeName(v.X)
+	}
+	return ""
+}
+
+// parseTestFiles parses every _test.go directly in dir.
+func parseTestFiles(t *testing.T, dir string) []*testFile {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read %s: %v", dir, err)
+	}
+	fset := token.NewFileSet()
+	var out []*testFile
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		path := filepath.Join(dir, name)
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+		tf := &testFile{
+			path:       path,
+			pkg:        file.Name.Name,
+			fset:       fset,
+			file:       file,
+			imports:    map[string]bool{},
+			stringLits: map[string]bool{},
+		}
+		for _, imp := range file.Imports {
+			if p, err := strconv.Unquote(imp.Path.Value); err == nil {
+				tf.imports[p] = true
+			}
+		}
+		ast.Inspect(file, func(n ast.Node) bool {
+			lit, ok := n.(*ast.BasicLit)
+			if ok && lit.Kind == token.STRING {
+				if s, err := strconv.Unquote(lit.Value); err == nil {
+					tf.stringLits[s] = true
+				}
+			}
+			return true
+		})
+		out = append(out, tf)
+	}
+	return out
+}
+
+// goPackageDirs returns every directory under root that holds Go
+// sources, sorted, skipping the trees no package lives in.
+func goPackageDirs(t *testing.T, root string) []string {
+	t.Helper()
+	seen := map[string]bool{}
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			// testdata holds fixture packages, which are shapes under
+			// test rather than code under ratchet. .claude holds the
+			// agent harness, and in a developer checkout also the
+			// worktrees — whole second copies of this repository, which
+			// the walk must not descend into and report twice.
+			case ".git", ".claude", "node_modules", "bin", "vendor", "testdata":
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if strings.HasSuffix(path, ".go") {
+			seen[filepath.Dir(path)] = true
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", root, err)
+	}
+	dirs := make([]string, 0, len(seen))
+	for d := range seen {
+		dirs = append(dirs, d)
+	}
+	sort.Strings(dirs)
+	return dirs
+}

--- a/test/regression/testdata/sealedrules/derived/a_test.go
+++ b/test/regression/testdata/sealedrules/derived/a_test.go
@@ -1,0 +1,21 @@
+package derived
+
+import (
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/sealedscan"
+)
+
+// The same complete enumeration, in a package that derives the marker.
+// The derivation diffs the list on every run, so the rule stands aside.
+
+func TestEveryShape(t *testing.T) {
+	all := []Shape{&Square{}, &Circle{}, &Triangle{}}
+	kinds, err := sealedscan.Implementers(".", "shapeNode")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(kinds) != len(all) {
+		t.Fatal("the list fell behind the sealed set")
+	}
+}

--- a/test/regression/testdata/sealedrules/derived/pkg.go
+++ b/test/regression/testdata/sealedrules/derived/pkg.go
@@ -1,0 +1,16 @@
+// Package derived is a fixture for the sealed-marker rules. It is never
+// compiled: the rules parse it. Three implementers, so the fixture sits
+// above the minimum sealed-set size.
+package derived
+
+type Shape interface{ shapeNode() }
+
+type (
+	Square   struct{}
+	Circle   struct{}
+	Triangle struct{}
+)
+
+func (*Square) shapeNode()   {}
+func (*Circle) shapeNode()   {}
+func (*Triangle) shapeNode() {}

--- a/test/regression/testdata/sealedrules/enumerated/a_test.go
+++ b/test/regression/testdata/sealedrules/enumerated/a_test.go
@@ -1,0 +1,22 @@
+package enumerated
+
+import "testing"
+
+// A complete enumeration with no derivation behind it: the whole set,
+// hand-listed, with nothing re-deriving it.
+
+func TestEveryShape(t *testing.T) {
+	all := []Shape{&Square{}, &Circle{}, &Triangle{}} // WANT
+	for _, s := range all {
+		_ = s
+	}
+}
+
+// A deliberate subset, which must stay unflagged: choosing two of the
+// three is a policy, not a mirror of the set.
+func TestSomeShapes(t *testing.T) {
+	some := []Shape{&Square{}, &Circle{}}
+	for _, s := range some {
+		_ = s
+	}
+}

--- a/test/regression/testdata/sealedrules/enumerated/pkg.go
+++ b/test/regression/testdata/sealedrules/enumerated/pkg.go
@@ -1,0 +1,16 @@
+// Package enumerated is a fixture for the sealed-marker rules. It is never
+// compiled: the rules parse it. Three implementers, so the fixture sits
+// above the minimum sealed-set size.
+package enumerated
+
+type Shape interface{ shapeNode() }
+
+type (
+	Square   struct{}
+	Circle   struct{}
+	Triangle struct{}
+)
+
+func (*Square) shapeNode()   {}
+func (*Circle) shapeNode()   {}
+func (*Triangle) shapeNode() {}

--- a/test/regression/testdata/sealedrules/restated/a_test.go
+++ b/test/regression/testdata/sealedrules/restated/a_test.go
@@ -1,0 +1,33 @@
+package restated
+
+import "testing"
+
+// Each declaration below restates the three-implementer cardinality AND
+// compares it against a measurement, in each of the three spellings.
+
+func TestConstForm(t *testing.T) {
+	all := []Shape{&Square{}, &Circle{}}
+	const wantShapes = 3 // WANT
+	if len(all) != wantShapes {
+		t.Fatal("count drifted")
+	}
+}
+
+func TestVarForm(t *testing.T) {
+	all := []Shape{&Square{}}
+	wantVar := 3 // WANT
+	if len(all) != wantVar {
+		t.Fatal("count drifted")
+	}
+}
+
+func TestShortForm(t *testing.T) {
+	seen := 0
+	for range []int{1, 2} {
+		seen++
+	}
+	wantShort := 3 // WANT
+	if seen != wantShort {
+		t.Fatal("count drifted")
+	}
+}

--- a/test/regression/testdata/sealedrules/restated/pkg.go
+++ b/test/regression/testdata/sealedrules/restated/pkg.go
@@ -1,0 +1,16 @@
+// Package restated is a fixture for the sealed-marker rules. It is never
+// compiled: the rules parse it. Three implementers, so the fixture sits
+// above the minimum sealed-set size.
+package restated
+
+type Shape interface{ shapeNode() }
+
+type (
+	Square   struct{}
+	Circle   struct{}
+	Triangle struct{}
+)
+
+func (*Square) shapeNode()   {}
+func (*Circle) shapeNode()   {}
+func (*Triangle) shapeNode() {}

--- a/test/regression/testdata/sealedrules/restatednearmiss/a_test.go
+++ b/test/regression/testdata/sealedrules/restatednearmiss/a_test.go
@@ -1,0 +1,52 @@
+package restatednearmiss
+
+import "testing"
+
+// The same value, never a claim about the sealed set.
+
+func TestNotCompared(t *testing.T) {
+	// Declared and used, but never against a count.
+	const retries = 3
+	if retries*2 != 6 {
+		t.Fatal("arithmetic")
+	}
+}
+
+func TestComparedAgainstNonCount(t *testing.T) {
+	// A scalar returned by the code under test, not a measurement of a
+	// set. This is the lexer-offset shape the rule must not touch.
+	got := offset()
+	const want = 3
+	if got != want {
+		t.Fatal("offset")
+	}
+}
+
+func TestCounterInAnotherFunction(t *testing.T) {
+	// `seen` is incremented in a DIFFERENT function, so it must not make
+	// this comparison a cardinality claim.
+	const want = 3
+	if offset() != want {
+		t.Fatal("offset")
+	}
+}
+
+func TestHasACounter(t *testing.T) {
+	seen := 0
+	for range []int{1} {
+		seen++
+	}
+	if seen != 1 {
+		t.Fatal("counter")
+	}
+}
+
+func TestDifferentCardinality(t *testing.T) {
+	all := []Shape{&Square{}}
+	const wantOther = 7
+	if len(all) != wantOther {
+		t.Fatal("not the sealed set's size")
+	}
+}
+
+func offset() int { return 3 }

--- a/test/regression/testdata/sealedrules/restatednearmiss/pkg.go
+++ b/test/regression/testdata/sealedrules/restatednearmiss/pkg.go
@@ -1,0 +1,16 @@
+// Package restatednearmiss is a fixture for the sealed-marker rules. It is never
+// compiled: the rules parse it. Three implementers, so the fixture sits
+// above the minimum sealed-set size.
+package restatednearmiss
+
+type Shape interface{ shapeNode() }
+
+type (
+	Square   struct{}
+	Circle   struct{}
+	Triangle struct{}
+)
+
+func (*Square) shapeNode()   {}
+func (*Circle) shapeNode()   {}
+func (*Triangle) shapeNode() {}


### PR DESCRIPTION
Epic #1504's class is "a fact the code already determines, restated by hand somewhere
else, with nothing re-deriving the restatement". All four children are closed, and the
host's own named defect — the derived-shape classifier mirrored between
`internal/api/prom/handler.go` and `internal/chsql/vector_set_op.go` — was collapsed into
`chplan.IsDerivedShape` by #1882. I re-verified that against the current tree before
starting: both call sites now read the one classifier, so there is no duplication left to
delete there.

What remained is the epic's own definition of done: **one meta-test asserting the class
stays closed.**

## Fix shape

The issue offers two shapes and asks for option 1 (delete the duplication) where it is
achievable. Both apply here, in that order.

Every member of this class found so far — #1878's `wantNodeTypes = 31`, this issue's own
classifier mirror, and the six instances below — was a **sealed interface's implementer
set**. That is the sharpest case in the family, because the truth is not merely derivable
but *only* derivable: a type joins `chplan.Node` by declaring `planNode()` and by nothing
else. The marker declarations **are** the set, so any second statement of it is a copy by
construction.

- **`internal/sealedscan`** derives that set from source, once, for every sealed interface
  in the tree. It is the option-1 half: the four private AST scanners that had grown
  around this convention now have one place to come from.
- **`TestSealedMarkerSetsAreDerived`** (`test/regression/`) is the option-2 half — the
  derive-and-diff gate, modelled on `TestGridCarrier_Completeness`'s AST-scan pattern and
  generalised from one hard-coded interface to every sealed marker in the repo.

The gate fails on the two shapes a copy takes:

- **Rule A** — an integer constant restating the set's cardinality *and* compared against a
  measured count (`len(...)`, or a counter the function only increments). Both halves are
  required: the value alone is coincidence (a lexer wanting offset `6` is not a claim about
  the six `LabelFilterer` kinds), and the comparison alone is ordinary assertion.
- **Rule B** — a composite literal naming *every* implementer, in a test package that never
  derives that set. A hand list is legitimate — the tests need instances, which no scan can
  produce — but only with a derivation behind it that diffs it. Completeness is what
  separates an exhaustiveness list from a deliberate subset, so the ten registered
  slice-invariant kinds out of thirty-two are correctly left alone.

Neither rule compares one hand-maintained value against another: the offending set is
recomputed from the marker declarations on every run, and both rules name the specific
offender. That distinction is the whole point of #1504 — a gate diffing two declarations is
exactly how this issue's own mirror drifted while a docstring asserted it could not.

## What the scan found

Six live instances, all fixed here:

| Site | The restatement |
| --- | --- |
| `internal/chplan/walk_expr_test.go` | `wantExprTypes = 23`, **twice**, over two identical 23-element lists |
| `internal/chplan/rewrite_children_exhaustive_test.go` | `expectedNodeTypeCount = 32`, "cross-checked against `grep -rn 'planNode()'`" in a comment |
| `internal/chplan/sliceinvariant_test.go` | `32 - 10`, with its own docstring **already drifted** to "all 31 node kinds" |
| `internal/chplan/walk_deep_test.go` | `wantNodeTypesWithExprSlots = 14` |
| `internal/logql/lsyntax/ast_test.go` | all seven `SampleExpr` kinds hand-listed, nothing asserting the list stayed whole |
| `internal/chplan/plannode_scan_test.go` | a private copy of the AST scan |

The `walk_expr_test.go` pair is worth calling out, because it shows the class doing exactly
what the epic says it does. The guard read:

```go
const wantExprTypes = 23
if len(all) != wantExprTypes { ... }
```

`all` **is** the hand-written list. A new `Expr` type could never have failed this: the list
stays at 23 entries, the constant stays at 23, the two agree with each other and are both
wrong about the IR. It could only catch someone editing the list and forgetting the
number — which is not the failure it was written to prevent.

`walk_deep_test.go` is now derived on *both* sides, from two different things: reflection
over the struct fields (which node types actually *have* an `Expr` slot) against
`nodeExprs`' own switch arms read out of `walk_deep.go` (which ones it *treats* as having
one). The pinned `14` in the middle could only ever agree with whichever of the two its
author last looked at. The failure this now catches — a node gaining an `Expr` field while
staying in the no-op arm, leaving every plan subtree in that slot invisible to `WalkDeep` —
was previously unreachable.

## Absorption demo (revert-and-show-red)

Each of these was run on a scratch edit and reverted.

**1. Rule A — reintroduce a hand-maintained count:**
```
sealed_marker_derivation_test.go:150: internal/chplan/rewrite_children_exhaustive_test.go:145:
  expectedNodeTypeCount restates the number of planNode() implementers (32) and is compared
  against a measured count; derive the set with .../internal/sealedscan instead of declaring
  its size — see the interface Node
```

**2. Rule B — remove a package's derivation:**
```
sealed_marker_derivation_test.go:96: internal/chplan/clone_test.go:21: this literal names all
  32 planNode() implementers, but package "chplan_test" in internal/chplan never derives that
  set; import .../internal/sealedscan and diff the list against sealedscan.Implementers(".",
  "planNode") so a new Node implementer fails here instead of going unnoticed
```

**3. The event the whole class is about — a new IR type lands and nobody updates the list.**
Added a `DemoExpr` declaring `exprNode()`:
```
walk_expr_test.go:47: DemoExpr implements exprNode() but allExprKinds does not cover it —
  add a zero-value instance to allExprKinds and an inspectExpr case in walk_expr.go
walk_expr_test.go:63: DemoExpr implements exprNode() but allExprKinds does not cover it —
  add a zero-value instance to allExprKinds and a cloneExpr case in clone.go
```
This is the case the old `= 23` guard passed silently. The repo-wide gate stayed green
throughout, which is the intended division of labour: the gate's job is to ensure the
derivation exists, and the derivation's job is to catch the drift.

Vacuity is guarded on both layers — `sealedscan.Implementers` errors rather than returning
an empty set, the gate fails if it finds no markers or reads no test files, and
`nodeExprsHandledTypes` fails if it finds no case arms.

## Verification

Run locally, narrowed: `./internal/chplan/`, `./internal/logql/lsyntax/`,
`./internal/sealedscan/`, `./test/regression/` all pass; `forbid-skip` (all five arms),
`forbid-sql-raw`, `doc-counts` clean; `gofumpt -extra` clean. `internal/sealedscan` is
declared in `.go-arch-lint.yml` as a common component (invariant 16) — it imports only the
standard library and knows nothing about cerberus, so it is a true leaf.

Closes #1504
