### PR TITLE
test(coverage): record the floor for internal/sealedscan

### DIFF
--- a/test/coverage-floor.json
+++ b/test/coverage-floor.json
@@ -47,6 +47,7 @@
   "internal/schema": 94.9,
   "internal/schema/ddl": 93.1,
   "internal/schemaboot": 99,
+  "internal/sealedscan": 93.0,
   "internal/solver": 83.6,
   "internal/spansscan": 97.6,
   "internal/telemetry": 79.5,


### PR DESCRIPTION
Follow-up to #2030, which added `internal/sealedscan` without a coverage-floor entry.

`.github/scripts/coverage-summary.mjs` classifies a package that carries statements but has no floor as `unfloored` and folds that into the failure set. #2030's PR lane ran with `RUN_HEAVY: false`, so the check never executed there; the heavy lane does run it.

Measured at **93.0%** by the package's own tests, which is what the entry records.

Added as a single line rather than by regenerating the ledger with `just update-coverage-floor`. That recipe reads the merged default+chdb profile, and the chdb lane does not currently pass locally (`TestRoundTripChDB` fails), so a regenerated ledger would under-record every package that lane reaches — and because the recipe refuses to lower a floor, it would fail rather than produce a usable file. One reviewable line is the honest form of this change; the Justfile's own comment contemplates exactly that for this file.