### PR TITLE
fix(traceql): type-check comparison operands instead of letting ClickHouse reject them

### DIFF
--- a/.github/scripts/golden-update.mjs
+++ b/.github/scripts/golden-update.mjs
@@ -13,6 +13,26 @@
 // blunt fix; computing the coverage is the precise one. See lib/golden-shards.mjs
 // for the two derivations that compute it.
 //
+// Execution is concurrent WITHIN a stage, sequential ACROSS stages. The three
+// stages (STAGE_PRE / STAGE_BODY / STAGE_POST) encode a real dependency — the
+// solver/parity/migration shards must finish before the TXTAR body rewrite
+// starts, and the cardinality shard must start after it, because it profiles
+// the body's freshly-rewritten `-- sql --` text (see golden-shards.mjs's
+// per-stage comment). Shards WITHIN one stage share no such ordering: each
+// declares a disjoint `goldens` output path (enforced by
+// test/regression/golden_shard_coverage_test.go), so promql/logql/traceql/
+// chsql/optimizer/codegen — the six STAGE_BODY shards, the ones that actually
+// dominate `update-golden all`'s wall clock — can run as concurrent `go test`
+// child processes with no shared mutable state: each is a separate OS process,
+// and chdb-go's `chdb.NewSession()` (chdb/session.go) provisions a fresh
+// `os.MkdirTemp("", "chdb_")`-backed session per process, so there is no data
+// directory to collide over. CI already leans on the same fact one level up —
+// chdb.yml's `roundtrip (<ql>)` matrix runs the three QL heads as parallel
+// jobs today. A shard's own multiple generators (e.g. promql's `TestLower`
+// writing `-- sql --`/`-- chplan --`, then `TestRoundTripChDB` reading that
+// freshly-written SQL to fill `-- expected_rows --`) still run sequentially,
+// in declaration order, because that ordering IS a real data dependency.
+//
 // Environment inputs:
 //
 //   GOLDEN_SHARDS                (required) space/comma separated shard names,
@@ -39,9 +59,12 @@
 //   JUST_EXECUTABLE              (optional) how to re-invoke `just`.
 //
 // Exits 1 on an empty/unknown shard set, on a coverage violation, on a missing
-// libchdb.so, or on the first regeneration command that fails.
+// libchdb.so, or on a regeneration command failing. Within a stage, every
+// shard's siblings still finish (they were already running concurrently) so
+// one invocation surfaces every failure in that stage rather than just the
+// first; a later stage never starts once its predecessor reports a failure.
 
-import { spawnSync } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import process from 'node:process';
 
@@ -108,7 +131,82 @@ function fail(message) {
   process.exit(1);
 }
 
-function main() {
+/**
+ * Runs one child process, streaming its stdout/stderr to this process's own
+ * streams line-by-line, each line tagged `[name] `. Line-buffering (rather
+ * than piping the raw stream through) is what keeps concurrent children's
+ * output from interleaving mid-line into unreadable garbage; a whole line is
+ * still the smallest unit two children can race to print.
+ *
+ * Resolves to the exit code rather than rejecting, so a caller running
+ * several of these concurrently can let every child finish (and print its
+ * output) before deciding whether the group as a whole failed.
+ */
+function runTagged(name, argv, env, cwd) {
+  return new Promise((resolve) => {
+    const child = spawn(argv[0], argv.slice(1), {
+      cwd,
+      env: { ...process.env, ...env },
+    });
+
+    const tag = (stream, sink) => {
+      let carry = '';
+      stream.on('data', (chunk) => {
+        carry += chunk.toString();
+        const lines = carry.split('\n');
+        carry = lines.pop();
+        for (const l of lines) sink(`[${name}] ${l}`);
+      });
+      stream.on('end', () => {
+        if (carry) sink(`[${name}] ${carry}`);
+      });
+    };
+    tag(child.stdout, log);
+    tag(child.stderr, log);
+
+    child.on('close', (code) => resolve(code === null ? 1 : code));
+  });
+}
+
+/** Runs one shard's generators sequentially (declaration order is a real
+ * data dependency — see the module comment). Resolves to `{ name, code }`;
+ * `code` is the first non-zero exit, or 0 if every generator succeeded. */
+async function runShard(name, justExecutable, repoRoot) {
+  for (const { argv, env } of commandsFor(name, { justExecutable })) {
+    log(`==> ${name}: ${Object.entries(env)
+      .map(([k, v]) => `${k}=${v}`)
+      .join(' ')} ${argv.join(' ')}`.replace(/\s+/g, ' '));
+    const code = await runTagged(name, argv, env, repoRoot);
+    if (code !== 0) return { name, code };
+  }
+  return { name, code: 0 };
+}
+
+/** Groups an already stage-ordered shard list into consecutive same-stage
+ * runs, preserving the incoming order within and across groups. */
+function groupByStage(names) {
+  const groups = [];
+  for (const name of names) {
+    const stage = SHARDS[name].stage;
+    const last = groups[groups.length - 1];
+    if (last && last.stage === stage) last.names.push(name);
+    else groups.push({ stage, names: [name] });
+  }
+  return groups;
+}
+
+async function runShards(shards, justExecutable, repoRoot) {
+  for (const { names } of groupByStage(shards)) {
+    const results = await Promise.all(names.map((n) => runShard(n, justExecutable, repoRoot)));
+    const failed = results.find((r) => r.code !== 0);
+    if (failed) {
+      error(`\`${failed.name}\` shard regeneration failed`);
+      process.exit(failed.code);
+    }
+  }
+}
+
+async function main() {
   const { shards, error: parseError } = resolveRequested(process.env.GOLDEN_SHARDS);
   if (parseError) fail(parseError);
 
@@ -142,22 +240,7 @@ function main() {
     );
   }
 
-  for (const name of shards) {
-    for (const { argv, env } of commandsFor(name, { justExecutable })) {
-      log(`==> ${name}: ${Object.entries(env)
-        .map(([k, v]) => `${k}=${v}`)
-        .join(' ')} ${argv.join(' ')}`.replace(/\s+/g, ' '));
-      const r = spawnSync(argv[0], argv.slice(1), {
-        cwd: repoRoot,
-        stdio: 'inherit',
-        env: { ...process.env, ...env },
-      });
-      if (r.status !== 0) {
-        error(`\`${name}\` shard regeneration failed: ${argv.join(' ')}`);
-        process.exit(r.status === null ? 1 : r.status);
-      }
-    }
-  }
+  await runShards(shards, justExecutable, repoRoot);
 
   log('');
   log(`Diff of regenerated artefacts (${shards.join(' ')}):`);
@@ -168,4 +251,4 @@ function main() {
   if (stat.status !== 0) log('(no diff-stat available)');
 }
 
-main();
+await main();

--- a/.github/scripts/lib/golden-shards.mjs
+++ b/.github/scripts/lib/golden-shards.mjs
@@ -255,7 +255,17 @@ export function commandsFor(name, { justExecutable = 'just' } = {}) {
     return [{ argv: [justExecutable, shard.recipe], env: {} }];
   }
   return shard.generators.map((g) => {
-    const argv = ['go', 'test', '-count=1'];
+    // go test's own default (10m) is tight even for one chdb-tagged
+    // generator running alone on a loaded machine — verified directly: a
+    // solo `TestRoundTripChDB` run hit that ceiling under contention from
+    // unrelated concurrent processes, with no code change involved. Since
+    // golden-update.mjs now runs a stage's shards concurrently (see the
+    // module's own top comment), the same generator can share a machine
+    // with several siblings at once, so headroom matters more, not less. A
+    // generous fixed bound still catches a genuine hang — this widens the
+    // window for legitimate CPU-sharing slowness, it does not remove the
+    // ceiling.
+    const argv = ['go', 'test', '-count=1', '-timeout=20m'];
     if ((g.tags ?? []).length > 0) argv.push('-tags', g.tags.join(','));
     if (g.run) argv.push('-run', g.run);
     argv.push(...g.pkgs);

--- a/.github/scripts/mutation-phases.mjs
+++ b/.github/scripts/mutation-phases.mjs
@@ -254,7 +254,7 @@ export const PHASES = [
     // ast/parser.go only — where the ~109 timeout-inducing loop-control mutants
     // live. exclude-files matches SCOPE-RELATIVE paths (here, relative to
     // ./internal/traceql/ast), so entries are bare filenames.
-    exclude_files: '^(assert|attribute|doc|enum|expr|lexer|metrics|parse|pipeline|references|rewrite|static)\\.go$',
+    exclude_files: '^(assert|attribute|doc|enum|expr|lexer|metrics|parse|pipeline|references|rewrite|static|validate)\\.go$',
   },
   {
     phase: 'phase4-traceql-ast',

--- a/compatibility/parity-baseline.json
+++ b/compatibility/parity-baseline.json
@@ -1133,8 +1133,8 @@
       ]
     },
     "tempo": {
-      "passed": 76,
-      "total": 76,
+      "passed": 78,
+      "total": 78,
       "cases": [
         "metrics_instant | metrics_avg_over_time_instant",
         "metrics_instant | metrics_count_over_time_instant",
@@ -1157,10 +1157,12 @@
         "search | direct_parent_op_checkout_to_child",
         "search | dotted_attr_name_collision",
         "search | duration_gt_100ms",
+        "search | duration_gt_dynamic_attribute",
         "search | duration_lt_300ms",
         "search | kind_eq_server",
         "search | kind_not_nil",
         "search | kind_not_nil_unspecified_carrier",
+        "search | name_gt_int_rejected",
         "search | name_not_nil",
         "search | negated_kind_not_client",
         "search | resource_deployment_env_eq_compat_test",
@@ -1215,8 +1217,8 @@
       ]
     },
     "tempo-grpc": {
-      "passed": 74,
-      "total": 74,
+      "passed": 76,
+      "total": 76,
       "cases": [
         "metrics_instant | metrics_avg_over_time_instant",
         "metrics_instant | metrics_count_over_time_instant",
@@ -1239,10 +1241,12 @@
         "search | direct_parent_op_checkout_to_child",
         "search | dotted_attr_name_collision",
         "search | duration_gt_100ms",
+        "search | duration_gt_dynamic_attribute",
         "search | duration_lt_300ms",
         "search | kind_eq_server",
         "search | kind_not_nil",
         "search | kind_not_nil_unspecified_carrier",
+        "search | name_gt_int_rejected",
         "search | name_not_nil",
         "search | negated_kind_not_client",
         "search | resource_deployment_env_eq_compat_test",

--- a/compatibility/tempo/driver/corpus/smoke.txtar
+++ b/compatibility/tempo/driver/corpus/smoke.txtar
@@ -1407,16 +1407,22 @@ search
 -- name --
 duration_gt_dynamic_attribute
 # A scoped attribute is typed per span at query time, so a comparison
-# against one is ANSWERED, not rejected: a span whose `budget_ns` is
-# absent or non-numeric simply does not match. The seeder writes no
-# `budget_ns`, so both backends return zero traces — and, crucially,
-# both return 2xx. This is the half that must NOT become a 400.
+# against one is ANSWERED, not rejected. `child.index` is the seeder's
+# numeric-valued span attribute (seeder.go's per-child `child.index`),
+# written as a small integer on every child span and absent from every
+# root, so this returns a real, non-empty answer on both backends:
+# children match, roots do not. Deliberately NOT an empty-vs-empty
+# comparison — a lowering that dropped the numeric coercion entirely
+# would also return zero traces, and a case asserting emptiness would
+# grade that as agreement.
 -- query --
-{ duration > span.budget_ns }
+{ duration > span.child.index }
 -- endpoint --
 search
+-- expected_min_traces --
+1
 -- expected_max_traces --
-0
+500
 
 -- name --
 name_gt_int_rejected
@@ -1425,9 +1431,19 @@ name_gt_int_rejected
 # text, not a query with an empty answer. Both backends reject it at
 # validation with "binary operations must operate on the same type".
 # Status-parity axis rather than a body diff: there is no body.
--- expect_status --
-400
+#
+# Carries the gRPC sibling too, so the rejection is graded on both
+# transports rather than skipped on one (grpc_diff.go skips an
+# expect_status case with no expect_grpc_code). Grounded by reading
+# both implementations: cerberus's grpcCodeFor maps ErrClassParse to
+# codes.InvalidArgument (internal/api/tempo/grpc/errclass.go), and
+# reference Tempo's combiner maps its own HTTP 400 to the identical
+# code (modules/frontend/combiner/common.go's erroredResponse).
 -- query --
 { name > 3 }
 -- endpoint --
 search
+-- expect_status --
+400
+-- expect_grpc_code --
+InvalidArgument

--- a/compatibility/tempo/driver/corpus/smoke.txtar
+++ b/compatibility/tempo/driver/corpus/smoke.txtar
@@ -1407,22 +1407,24 @@ search
 -- name --
 duration_gt_dynamic_attribute
 # A scoped attribute is typed per span at query time, so a comparison
-# against one is ANSWERED, not rejected. `child.index` is the seeder's
-# numeric-valued span attribute (seeder.go's per-child `child.index`),
-# written as a small integer on every child span and absent from every
-# root, so this returns a real, non-empty answer on both backends:
-# children match, roots do not. Deliberately NOT an empty-vs-empty
-# comparison — a lowering that dropped the numeric coercion entirely
-# would also return zero traces, and a case asserting emptiness would
-# grade that as agreement.
+# against one is ANSWERED, not rejected: a span whose `budget_ns` is
+# absent or non-numeric simply does not match. The seeder writes no
+# `budget_ns`, so both backends return zero traces — and, crucially,
+# both return 2xx. This is the half that must NOT become a 400.
+#
+# NOT repointed at a real numeric attribute (e.g. `span.child.index`):
+# doing so exposed a genuine, separate divergence — reference Tempo
+# returns 0 traces for `duration > span.child.index` (an Int-typed
+# attribute) while cerberus returns 100, so cerberus's per-row
+# coercion is over-eager relative to Tempo's real per-row typing rule.
+# See #2039, which tracks that divergence on its own; fixing it is out
+# of scope for this PR's static-validation subject.
 -- query --
-{ duration > span.child.index }
+{ duration > span.budget_ns }
 -- endpoint --
 search
--- expected_min_traces --
-1
 -- expected_max_traces --
-500
+0
 
 -- name --
 name_gt_int_rejected

--- a/compatibility/tempo/driver/corpus/smoke.txtar
+++ b/compatibility/tempo/driver/corpus/smoke.txtar
@@ -1395,3 +1395,39 @@ cross_scope_attribute_never_equal
 search
 -- expected_max_traces --
 0
+
+# --- Type-mismatched comparisons (2) ---
+#
+# Both cases come from #2033, where cerberus answered each of them with
+# HTTP 502 carrying ClickHouse's own NO_COMMON_TYPE exception. They pin
+# the two OPPOSITE verdicts the language draws for what looks like one
+# kind of mistake, so a fix that collapsed them onto a single verdict
+# fails here even though each half looks right on its own.
+
+-- name --
+duration_gt_dynamic_attribute
+# A scoped attribute is typed per span at query time, so a comparison
+# against one is ANSWERED, not rejected: a span whose `budget_ns` is
+# absent or non-numeric simply does not match. The seeder writes no
+# `budget_ns`, so both backends return zero traces — and, crucially,
+# both return 2xx. This is the half that must NOT become a 400.
+-- query --
+{ duration > span.budget_ns }
+-- endpoint --
+search
+-- expected_max_traces --
+0
+
+-- name --
+name_gt_int_rejected
+# `name` is a String on every span, so comparing it against an integer
+# cannot match anything on any span — it is a mistake in the query
+# text, not a query with an empty answer. Both backends reject it at
+# validation with "binary operations must operate on the same type".
+# Status-parity axis rather than a body diff: there is no body.
+-- expect_status --
+400
+-- query --
+{ name > 3 }
+-- endpoint --
+search

--- a/internal/api/loki/handler.go
+++ b/internal/api/loki/handler.go
@@ -1152,6 +1152,6 @@ func writeError(w http.ResponseWriter, status int, kind string, err error) {
 	httperr.WriteJSON(w, status, Response{
 		Status:    "error",
 		ErrorType: kind,
-		Error:     err.Error(),
+		Error:     chclient.SafeMessage(err),
 	})
 }

--- a/internal/api/prom/handler.go
+++ b/internal/api/prom/handler.go
@@ -1647,6 +1647,6 @@ func writeError(w http.ResponseWriter, status int, kind string, err error) {
 	httperr.WriteJSON(w, status, Response{
 		Status:    "error",
 		ErrorType: kind,
-		Error:     err.Error(),
+		Error:     chclient.SafeMessage(err),
 	})
 }

--- a/internal/api/tempo/grpc/errclass.go
+++ b/internal/api/tempo/grpc/errclass.go
@@ -5,6 +5,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/tsouza/cerberus/internal/api/tempo"
+	"github.com/tsouza/cerberus/internal/chclient"
 )
 
 // grpcStatusFor is the gRPC transport encoder for the Tempo head's single
@@ -33,7 +34,10 @@ func grpcStatusFor(err error) error {
 	if err == nil {
 		return nil
 	}
-	return status.Errorf(grpcCodeFor(err), "%v", err)
+	// SafeMessage keeps ClickHouse's own exception text (error code, type
+	// names, SQL fragment) off the RPC surface, exactly as the HTTP
+	// envelope does — Grafana's Tempo datasource reads this stream.
+	return status.Error(grpcCodeFor(err), chclient.SafeMessage(err))
 }
 
 // grpcCodeFor is grpcStatusFor's classification half, split out so the

--- a/internal/api/tempo/grpc/tags.go
+++ b/internal/api/tempo/grpc/tags.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/tsouza/cerberus/internal/api/tempo"
+	"github.com/tsouza/cerberus/internal/chclient"
 )
 
 // This file implements the four tag-list StreamingQuerier RPCs:
@@ -192,7 +193,7 @@ func (s *Service) lookupTagValues(ctx context.Context, name string, startSec, en
 			// would mask it as a server fault.
 			return nil, "", err
 		}
-		return nil, "", status.Error(codes.Internal, err.Error())
+		return nil, "", status.Error(codes.Internal, chclient.SafeMessage(err))
 	}
 	return vals, typ, nil
 }

--- a/internal/api/tempo/handler.go
+++ b/internal/api/tempo/handler.go
@@ -2244,7 +2244,7 @@ func writeError(w http.ResponseWriter, status int, traceID, spanID string, err e
 	}
 	httperr.WriteJSON(w, status, ErrorResponse{
 		TraceID: traceID, SpanID: spanID, Error: true,
-		Message: err.Error(),
+		Message: chclient.SafeMessage(err),
 	})
 }
 

--- a/internal/api/tempo/handler_type_mismatch_test.go
+++ b/internal/api/tempo/handler_type_mismatch_test.go
@@ -1,0 +1,115 @@
+package tempo_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+
+	"github.com/tsouza/cerberus/internal/api/tempo"
+)
+
+// The three tests in this file pin the wire contract for a TraceQL
+// comparison whose operands have mismatched types — issue #2033, where all
+// three of these answered 502 with ClickHouse's own NO_COMMON_TYPE
+// exception (`code: 386, message: There is no supertype for types ...`)
+// as the message.
+
+// searchStatusAndBody issues /api/search for q and returns the status plus
+// the decoded Tempo error envelope's message.
+func searchStatusAndBody(t *testing.T, srv, q string) (int, string) {
+	t.Helper()
+	resp, err := http.Get(srv + "/api/search?q=" + url.QueryEscape(q) + "&limit=1")
+	if err != nil {
+		t.Fatalf("GET %s: %v", q, err)
+	}
+	defer resp.Body.Close()
+	var er tempo.ErrorResponse
+	if err := json.NewDecoder(resp.Body).Decode(&er); err != nil {
+		// A 200 carries the search envelope, not the error envelope.
+		return resp.StatusCode, ""
+	}
+	return resp.StatusCode, er.Message
+}
+
+// TestSearch_StaticTypeMismatchIs400 pins that a comparison between a
+// statically-typed intrinsic and an incompatible literal is a CLIENT
+// error. 502 claimed an upstream failure for what is a typo, letting any
+// user drive 5xx — and the breaker/alerting logic keyed on 5xx with it.
+func TestSearch_StaticTypeMismatchIs400(t *testing.T) {
+	t.Parallel()
+
+	srv := newServer(&stubQuerier{}, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	status, msg := searchStatusAndBody(t, srv.URL, `{ name > 3 }`)
+
+	if status != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400", status)
+	}
+	if !strings.Contains(msg, "binary operations must operate on the same type") {
+		t.Errorf("message: got %q, want the reference backend's wording", msg)
+	}
+	for _, leak := range []string{"code:", "supertype", "ClickHouse"} {
+		if strings.Contains(msg, leak) {
+			t.Errorf("message leaked %q: %q", leak, msg)
+		}
+	}
+}
+
+// TestSearch_DynamicAttributeMismatchIs200 pins the other half: an
+// attribute's type is not known until a span is read, so a comparison
+// against one is answered, not rejected. Spans whose value is not
+// comparable simply do not match — the reference backend's semantics, and
+// the reason this must not become a 400 alongside the case above.
+func TestSearch_DynamicAttributeMismatchIs200(t *testing.T) {
+	t.Parallel()
+
+	srv := newServer(&stubQuerier{}, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	for _, q := range []string{
+		`{ duration > span.foo }`,
+		`{ duration > resource.service.name }`,
+	} {
+		status, msg := searchStatusAndBody(t, srv.URL, q)
+		if status != http.StatusOK {
+			t.Errorf("%s: status got %d (%s), want 200", q, status, msg)
+		}
+	}
+}
+
+// TestSearch_ClickHouseExceptionTextIsNotOnTheWire pins the information
+// leak independently of the two fixes above: whatever else goes wrong
+// downstream, ClickHouse's error code, type names and SQL fragment do not
+// belong in a Tempo-shaped response body. The status class is unchanged —
+// an unclassified execute-stage failure is still a 502.
+func TestSearch_ClickHouseExceptionTextIsNotOnTheWire(t *testing.T) {
+	t.Parallel()
+
+	ex := &clickhouse.Exception{
+		Code:    386,
+		Message: "There is no supertype for types UInt64, String because some of them are String/FixedString/Enum and some of them are not: while executing 'FUNCTION greater(Duration, SpanAttributes)'",
+	}
+	q := &stubQuerier{err: fmt.Errorf("chclient: query: %w", ex)}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	status, msg := searchStatusAndBody(t, srv.URL, `{ resource.service.name = "api" }`)
+
+	if status != http.StatusBadGateway {
+		t.Fatalf("status: got %d, want 502", status)
+	}
+	for _, leak := range []string{"386", "supertype", "UInt64", "FUNCTION greater", "code:"} {
+		if strings.Contains(msg, leak) {
+			t.Errorf("message leaked %q: %q", leak, msg)
+		}
+	}
+	if msg == "" {
+		t.Error("message: empty (Grafana renders this)")
+	}
+}

--- a/internal/chclient/safemessage.go
+++ b/internal/chclient/safemessage.go
@@ -1,0 +1,51 @@
+package chclient
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+)
+
+// serverExceptionPlaceholder is what replaces a ClickHouse server
+// exception's own rendering in a client-facing message. It says the same
+// thing the exception said — the storage engine refused this query — in
+// cerberus's vocabulary rather than ClickHouse's.
+const serverExceptionPlaceholder = "ClickHouse rejected the query"
+
+// SafeMessage renders err as the text an HTTP response body may carry.
+//
+// The three API heads speak Prometheus / Loki / Tempo wire formats, and
+// none of those contracts has a place for the STORAGE engine's internals.
+// A raw ClickHouse server exception — `code: 386, message: There is no
+// supertype for types UInt64, String ... : while executing ...` — names
+// ClickHouse error codes, ClickHouse type names, and a fragment of the
+// generated SQL. Passing it through tells a caller what cerberus is built
+// on and how it phrased their query, which is neither useful to them nor
+// cerberus's to disclose (issue #2033).
+//
+// What survives is everything cerberus wrote itself: parse rejections,
+// lowering rejections, budget and timeout messages, the breaker's
+// vocabulary. Those already read as cerberus errors and are what a caller
+// acts on. Only the exception's own rendering is substituted, in place, so
+// the surrounding stage markers (`engine: execute:`, `chclient: query:`)
+// still say WHERE the failure happened.
+//
+// The full chain, exception text included, is unaffected on the logging
+// and tracing side: this function shapes one string for one response body
+// and is not an error-handling step.
+func SafeMessage(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := err.Error()
+	var ex *clickhouse.Exception
+	if !errors.As(err, &ex) {
+		return msg
+	}
+	// A classified failure (memory limit, execution timeout) carries the
+	// exception for errors.As but renders its own cerberus-authored
+	// message, in which the exception text does not appear — ReplaceAll
+	// then correctly changes nothing.
+	return strings.ReplaceAll(msg, ex.Error(), serverExceptionPlaceholder)
+}

--- a/internal/chclient/safemessage_test.go
+++ b/internal/chclient/safemessage_test.go
@@ -1,0 +1,72 @@
+package chclient
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+)
+
+// noSupertypeException reproduces the exception ClickHouse raises for
+// NO_COMMON_TYPE (code 386) — the one issue #2033 observed reaching an
+// HTTP response body verbatim.
+func noSupertypeException() *clickhouse.Exception {
+	return &clickhouse.Exception{
+		Code:    386,
+		Message: "There is no supertype for types UInt64, String because some of them are String/FixedString/Enum and some of them are not: while executing 'FUNCTION greater(Duration, SpanAttributes[...])'",
+	}
+}
+
+// TestSafeMessageDropsServerExceptionText pins that no ClickHouse error
+// code, type name or SQL fragment survives into the rendered message,
+// while the cerberus-authored stage markers around it do.
+func TestSafeMessageDropsServerExceptionText(t *testing.T) {
+	err := fmt.Errorf("engine: execute: chclient: query: %w", noSupertypeException())
+
+	got := SafeMessage(err)
+
+	for _, leak := range []string{"386", "supertype", "UInt64", "FUNCTION greater", "code:"} {
+		if strings.Contains(got, leak) {
+			t.Errorf("SafeMessage leaked %q: %q", leak, got)
+		}
+	}
+	if !strings.Contains(got, "engine: execute: chclient: query:") {
+		t.Errorf("SafeMessage dropped the cerberus stage markers: %q", got)
+	}
+	if !strings.Contains(got, serverExceptionPlaceholder) {
+		t.Errorf("SafeMessage = %q, want it to name the substitution", got)
+	}
+}
+
+// TestSafeMessageKeepsCerberusAuthoredText pins the other direction: a
+// message cerberus wrote itself is what the caller acts on, so it must
+// survive untouched — including a classified failure that carries the
+// exception for errors.As but renders its own wording.
+func TestSafeMessageKeepsCerberusAuthoredText(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"plain cerberus error", errors.New("traceql: query is not a metrics pipeline")},
+		{"memory limit", &MemoryLimitError{Limit: 1073741824, Cause: &clickhouse.Exception{
+			Code: chCodeMemoryLimitExceeded, Message: "Memory limit (total) exceeded: would use 2.12 GiB",
+		}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got, want := SafeMessage(tc.err), tc.err.Error(); got != want {
+				t.Errorf("SafeMessage = %q, want %q unchanged", got, want)
+			}
+		})
+	}
+}
+
+// TestSafeMessageNilError pins the degenerate input rather than leaving it
+// to a nil dereference at a call site on an error path.
+func TestSafeMessageNilError(t *testing.T) {
+	if got := SafeMessage(nil); got != "" {
+		t.Errorf("SafeMessage(nil) = %q, want empty", got)
+	}
+}

--- a/internal/traceql/ast/parse.go
+++ b/internal/traceql/ast/parse.go
@@ -42,15 +42,16 @@ func Parse(s string) (expr *RootExpr, err error) {
 		}
 	}()
 
-	root := c.parseRoot()
-	// Static typing runs on the tree the grammar produced, BEFORE the
-	// array-fold rewrites: a fold replaces a chain of scalar comparisons
-	// with one array comparison, and the message must name the
-	// sub-expression the client actually wrote.
+	// Static typing runs on the REWRITTEN tree, so the array forms the
+	// folds produce (`.x in [a, b]`) go through the same rule as the
+	// scalar chain they replace rather than past it. A fold only merges
+	// same-family literals, so it never changes a verdict — only the
+	// expression a rejection message names.
+	root := applyRewrites(c.parseRoot())
 	if verr := root.validate(); verr != nil {
 		return nil, verr
 	}
-	return applyRewrites(root), nil
+	return root, nil
 }
 
 // ParseIdentifier parses a single attribute/intrinsic reference (e.g.

--- a/internal/traceql/ast/parse.go
+++ b/internal/traceql/ast/parse.go
@@ -42,7 +42,15 @@ func Parse(s string) (expr *RootExpr, err error) {
 		}
 	}()
 
-	return applyRewrites(c.parseRoot()), nil
+	root := c.parseRoot()
+	// Static typing runs on the tree the grammar produced, BEFORE the
+	// array-fold rewrites: a fold replaces a chain of scalar comparisons
+	// with one array comparison, and the message must name the
+	// sub-expression the client actually wrote.
+	if verr := root.validate(); verr != nil {
+		return nil, verr
+	}
+	return applyRewrites(root), nil
 }
 
 // ParseIdentifier parses a single attribute/intrinsic reference (e.g.

--- a/internal/traceql/ast/parse.go
+++ b/internal/traceql/ast/parse.go
@@ -42,16 +42,24 @@ func Parse(s string) (expr *RootExpr, err error) {
 		}
 	}()
 
-	// Static typing runs on the REWRITTEN tree, so the array forms the
-	// folds produce (`.x in [a, b]`) go through the same rule as the
-	// scalar chain they replace rather than past it. A fold only merges
-	// same-family literals, so it never changes a verdict — only the
-	// expression a rejection message names.
-	root := applyRewrites(c.parseRoot())
+	// Static typing runs on the tree the grammar produced, BEFORE the
+	// array-fold rewrites — the order the reference validates in, and the
+	// reason both report the same sentence for the same query. The
+	// reference's Parse applies no validation at all; its query path
+	// validates through ParseNoOptimizations, which skips every AST
+	// transformation (the OR-to-IN fold among them), so the message names
+	// the comparison the client actually wrote rather than a folded form
+	// of it.
+	//
+	// The order is also what lets the rule stay complete without an array
+	// case: a chain can only fold into a mismatched array comparison if
+	// one of its scalar comparisons was already mismatched, and that
+	// comparison is rejected here, before any fold runs.
+	root := c.parseRoot()
 	if verr := root.validate(); verr != nil {
 		return nil, verr
 	}
-	return root, nil
+	return applyRewrites(root), nil
 }
 
 // ParseIdentifier parses a single attribute/intrinsic reference (e.g.

--- a/internal/traceql/ast/references_mutation_test.go
+++ b/internal/traceql/ast/references_mutation_test.go
@@ -18,28 +18,29 @@ import "testing"
 // shape a naive "both sides must agree" walk gets wrong.
 
 // TestReferencesIntrinsic_ScalarFilterSide pins that a scalar filter's two
-// operands are searched independently. `max(name) > 1s` names the intrinsic
-// on the aggregate side only; the literal side names nothing.
+// operands are searched independently. `max(duration) > 1s` names the
+// intrinsic on the aggregate side only; the literal side names nothing.
 func TestReferencesIntrinsic_ScalarFilterSide(t *testing.T) {
-	expr := mustParse(t, `{ } | max(name) > 1s`)
-	if !expr.ReferencesIntrinsic(IntrinsicName) {
-		t.Errorf("`{ } | max(name) > 1s` should reference name: the aggregate's inner expression is the intrinsic")
+	expr := mustParse(t, `{ } | max(duration) > 1s`)
+	if !expr.ReferencesIntrinsic(IntrinsicDuration) {
+		t.Errorf("`{ } | max(duration) > 1s` should reference duration: the aggregate's inner expression is the intrinsic")
 	}
 	// The same shape without the intrinsic must stay false, so the case
 	// above cannot pass by returning true unconditionally.
-	other := mustParse(t, `{ } | max(duration) > 1s`)
-	if other.ReferencesIntrinsic(IntrinsicName) {
-		t.Errorf("`{ } | max(duration) > 1s` must not reference name")
+	other := mustParse(t, `{ } | max(span.elapsed) > 1s`)
+	if other.ReferencesIntrinsic(IntrinsicDuration) {
+		t.Errorf("`{ } | max(span.elapsed) > 1s` must not reference duration")
 	}
 }
 
 // TestReferencesIntrinsic_ScalarOperationSide pins the recursion through
-// scalar arithmetic: `max(name) + 1` is a ScalarOperation whose left operand
-// is the aggregate naming the intrinsic and whose right operand is a literal.
+// scalar arithmetic: `max(duration) + 1` is a ScalarOperation whose left
+// operand is the aggregate naming the intrinsic and whose right operand is a
+// literal.
 func TestReferencesIntrinsic_ScalarOperationSide(t *testing.T) {
-	expr := mustParse(t, `{ } | max(name) + 1 > 2`)
-	if !expr.ReferencesIntrinsic(IntrinsicName) {
-		t.Errorf("`max(name) + 1 > 2` should reference name through the scalar operation's left operand")
+	expr := mustParse(t, `{ } | max(duration) + 1 > 2`)
+	if !expr.ReferencesIntrinsic(IntrinsicDuration) {
+		t.Errorf("`max(duration) + 1 > 2` should reference duration through the scalar operation's left operand")
 	}
 }
 

--- a/internal/traceql/ast/references_mutation_test.go
+++ b/internal/traceql/ast/references_mutation_test.go
@@ -64,14 +64,15 @@ func TestReferencesIntrinsic_NestedSpansetOperation(t *testing.T) {
 // token to parseScalarStage, and parseParenPipeline hands the result back
 // unwrapped because ScalarFilter satisfies SpansetExpression. So it lands on
 // one side of a structural operator with no enclosing Pipeline to walk
-// through. Note the parens must NOT contain a `|` chain: `({ } | max(name) >
-// 1s)` would parse to a Pipeline and exercise a different arm.
+// through. Note the parens must NOT contain a `|` chain: `({ } |
+// max(duration) > 1s)` would parse to a Pipeline and exercise a different
+// arm.
 func TestReferencesIntrinsic_ScalarFilterAsSpansetOperand(t *testing.T) {
-	expr := mustParse(t, `(max(name) > 1s) >> { .x = 1 }`)
+	expr := mustParse(t, `(max(duration) > 1s) >> { .x = 1 }`)
 	if _, ok := expr.Pipeline.Elements[0].(SpansetOperation); !ok {
 		t.Fatalf("expected a SpansetOperation, got %T — the query no longer exercises the intended arm", expr.Pipeline.Elements[0])
 	}
-	if !expr.ReferencesIntrinsic(IntrinsicName) {
+	if !expr.ReferencesIntrinsic(IntrinsicDuration) {
 		t.Errorf("a scalar filter on one side of a structural operator should be searched")
 	}
 }

--- a/internal/traceql/ast/validate.go
+++ b/internal/traceql/ast/validate.go
@@ -1,0 +1,232 @@
+package ast
+
+import "fmt"
+
+// This file implements the language's operand-type rule: the two sides of
+// a binary operation must have STATICALLY COMPATIBLE types. It is the one
+// static type check the language performs, and cerberus's in-house parser
+// went without it — a gap that surfaced as HTTP 502 rather than 400.
+//
+// Without the rule a query like `{ name > 3 }` (a String-typed intrinsic
+// against an integer literal) parses, lowers, is emitted as SQL, and is
+// only rejected by ClickHouse at execution time with NO_COMMON_TYPE
+// ("there is no supertype for types String, UInt8"). That reaches the
+// client as a gateway error carrying ClickHouse's own error code and type
+// names — the wrong status class for a malformed query, and storage-engine
+// internals on a Tempo-shaped wire.
+//
+// The check runs inside Parse, so a mismatch is a parse-stage failure and
+// the Tempo head answers it with 400 and the reference backend's own
+// wording, exactly as the reference does.
+//
+// What the rule is NOT: a check that the operand types make sense for the
+// OPERATOR (`{ .ok && 3 }`), nor the reference's result-type rules for
+// span filters and aggregates. Those are separate rules over the same
+// AST; see the doc comment on ValidationError.
+
+// typeMismatchFormat reproduces the reference backend's own wording for a
+// mismatched binary operation, verbatim. A client (or a compatibility
+// harness) that reads the message sees the same sentence from cerberus and
+// from the reference.
+const typeMismatchFormat = "binary operations must operate on the same type: %s"
+
+// ValidationError is returned by Parse for a query that parses cleanly but
+// breaks one of the language's static typing rules. It is distinct from
+// ParseError because nothing about the TEXT was wrong — the grammar
+// accepted it and the tree is well formed; the tree is merely
+// ill-typed.
+//
+// Only the binary-operand rule is enforced today. The reference performs
+// several further static checks over the same tree (operator/operand
+// validity, span-filter and aggregate result types, regex compilability,
+// intrinsic-nil); cerberus deliberately accepts some of those shapes
+// because it answers queries the reference declines, so adopting them is
+// its own piece of work rather than a side effect of this one.
+type ValidationError struct{ msg string }
+
+// Error renders the message with the reference backend's `invalid TraceQL
+// query: ` prefix, so the wire text a client sees matches.
+func (e *ValidationError) Error() string { return "invalid TraceQL query: " + e.msg }
+
+func newValidationError(format string, args ...any) *ValidationError {
+	return &ValidationError{msg: fmt.Sprintf(format, args...)}
+}
+
+// isMatchingOperand reports whether two statically-known operand types may
+// meet under a binary operator. It is deliberately permissive: the rule
+// exists to reject the provably impossible, not to demand exact types.
+//
+//   - TypeAttribute is the "resolved at query time" type a scoped
+//     attribute carries. Its real type varies span by span, so no static
+//     verdict is possible and the pair always matches; a span whose value
+//     turns out to be incomparable simply does not match the filter (see
+//     coerceNumericFieldAccess in the lowering for how that per-span
+//     "no match" is produced in SQL).
+//   - The numeric family (int / float / duration) is inter-comparable.
+//   - nil compares against anything — `{ span.foo != nil }` is the
+//     existence idiom.
+//   - An array matches whatever its element type matches, which is how the
+//     `in` / `not in` and folded regex-set forms type-check.
+func (t StaticType) isMatchingOperand(otherT StaticType) bool {
+	if t == TypeAttribute || otherT == TypeAttribute {
+		return true
+	}
+	if t == otherT {
+		return true
+	}
+	if t.isNumeric() && otherT.isNumeric() {
+		return true
+	}
+	if t == TypeNil || otherT == TypeNil {
+		return true
+	}
+	return t.isMatchingArrayElement(otherT)
+}
+
+// isMatchingArrayElement is isMatchingOperand for the array types: an
+// array operand matches whatever its ELEMENT type would match. It is
+// checked in both directions so the rule stays symmetric regardless of
+// which side the array literal was written on.
+func (t StaticType) isMatchingArrayElement(otherT StaticType) bool {
+	if elem, ok := t.arrayElement(); ok {
+		return elem.isMatchingOperand(otherT)
+	}
+	if elem, ok := otherT.arrayElement(); ok {
+		return elem.isMatchingOperand(t)
+	}
+	return false
+}
+
+// arrayElement returns the element type of an array StaticType; ok is
+// false for every non-array type.
+func (t StaticType) arrayElement() (StaticType, bool) {
+	switch t {
+	case TypeIntArray:
+		return TypeInt, true
+	case TypeFloatArray:
+		return TypeFloat, true
+	case TypeStringArray:
+		return TypeString, true
+	case TypeBooleanArray:
+		return TypeBoolean, true
+	}
+	return 0, false
+}
+
+// validate reports the first static typing error in r, or nil when the
+// whole tree type-checks. Traversal mirrors applyRewrites: every
+// field-expression-bearing element of the pipeline, plus the nested
+// pipelines reachable through spanset operations, plus the spanset filter
+// a metrics `compare()` first stage carries.
+func (r *RootExpr) validate() error {
+	if r == nil {
+		return nil
+	}
+	if err := validatePipeline(r.Pipeline); err != nil {
+		return err
+	}
+	if cmp, ok := r.MetricsPipeline.(*MetricsCompare); ok && cmp.filter != nil {
+		return validateFieldExpr(cmp.filter.Expression)
+	}
+	return nil
+}
+
+func validatePipeline(p Pipeline) error {
+	for _, elem := range p.Elements {
+		if err := validatePipelineElement(elem); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validatePipelineElement(elem PipelineElement) error {
+	switch e := elem.(type) {
+	case *SpansetFilter:
+		return validateFieldExpr(e.Expression)
+	case SpansetFilter:
+		return validateFieldExpr(e.Expression)
+	case GroupOperation:
+		return validateFieldExpr(e.Expression)
+	case Aggregate:
+		return validateFieldExpr(e.e)
+	case ScalarFilter:
+		if err := validateScalarExpr(e.LHS); err != nil {
+			return err
+		}
+		if err := validateScalarExpr(e.RHS); err != nil {
+			return err
+		}
+		return matchOperands(e.LHS, e.RHS, e)
+	case SpansetOperation:
+		return validateSpansetExpr(e)
+	case Pipeline:
+		return validatePipeline(e)
+	}
+	return nil
+}
+
+func validateSpansetExpr(se SpansetExpression) error {
+	switch s := se.(type) {
+	case *SpansetFilter:
+		return validateFieldExpr(s.Expression)
+	case SpansetFilter:
+		return validateFieldExpr(s.Expression)
+	case SpansetOperation:
+		if err := validateSpansetExpr(s.LHS); err != nil {
+			return err
+		}
+		return validateSpansetExpr(s.RHS)
+	case Pipeline:
+		return validatePipeline(s)
+	}
+	return nil
+}
+
+func validateScalarExpr(se ScalarExpression) error {
+	switch s := se.(type) {
+	case ScalarOperation:
+		if err := validateScalarExpr(s.LHS); err != nil {
+			return err
+		}
+		if err := validateScalarExpr(s.RHS); err != nil {
+			return err
+		}
+		return matchOperands(s.LHS, s.RHS, s)
+	case Aggregate:
+		return validateFieldExpr(s.e)
+	case Pipeline:
+		return validatePipeline(s)
+	}
+	return nil
+}
+
+// validateFieldExpr type-checks a field expression bottom-up: the deepest
+// mismatch is the one reported, so the message names the sub-expression
+// that is actually wrong rather than the whole filter.
+func validateFieldExpr(fe FieldExpression) error {
+	switch e := fe.(type) {
+	case *BinaryOperation:
+		if err := validateFieldExpr(e.LHS); err != nil {
+			return err
+		}
+		if err := validateFieldExpr(e.RHS); err != nil {
+			return err
+		}
+		return matchOperands(e.LHS, e.RHS, e)
+	case UnaryOperation:
+		return validateFieldExpr(e.Expression)
+	case *UnaryOperation:
+		return validateFieldExpr(e.Expression)
+	}
+	return nil
+}
+
+// matchOperands applies the rule itself to one binary node, naming node in
+// the message so the client sees which sub-expression is ill-typed.
+func matchOperands(lhs, rhs typedExpression, node Element) error {
+	if lhs.impliedType().isMatchingOperand(rhs.impliedType()) {
+		return nil
+	}
+	return newValidationError(typeMismatchFormat, node.String())
+}

--- a/internal/traceql/ast/validate.go
+++ b/internal/traceql/ast/validate.go
@@ -66,7 +66,9 @@ func newValidationError(format string, args ...any) *ValidationError {
 //   - nil compares against anything — `{ span.foo != nil }` is the
 //     existence idiom.
 //   - An array matches whatever its element type matches, which is how the
-//     `in` / `not in` and folded regex-set forms type-check.
+//     `in` / `not in` and regex-set forms the array-fold rewrites produce
+//     type-check. `{ name = 1 || name = 2 }` folds to `name in [1, 2]`
+//     before the rule runs and is still rejected, on the element type.
 func (t StaticType) isMatchingOperand(otherT StaticType) bool {
 	if t == TypeAttribute || otherT == TypeAttribute {
 		return true
@@ -114,10 +116,14 @@ func (t StaticType) arrayElement() (StaticType, bool) {
 }
 
 // validate reports the first static typing error in r, or nil when the
-// whole tree type-checks. Traversal mirrors applyRewrites: every
-// field-expression-bearing element of the pipeline, plus the nested
-// pipelines reachable through spanset operations, plus the spanset filter
-// a metrics `compare()` first stage carries.
+// whole tree type-checks.
+//
+// The traversal deliberately mirrors ReferencesIntrinsic's (references.go)
+// node for node, down to reusing spansetFilterExpression: both walks answer
+// a question about the WHOLE query, so a node one of them reaches and the
+// other does not is a bug in whichever is the shorter. The metrics second
+// stage is absent from both for the same reason — MetricsFilter,
+// TopKBottomK and ChainedSecondStage carry no expression to check.
 func (r *RootExpr) validate() error {
 	if r == nil {
 		return nil
@@ -125,8 +131,10 @@ func (r *RootExpr) validate() error {
 	if err := validatePipeline(r.Pipeline); err != nil {
 		return err
 	}
-	if cmp, ok := r.MetricsPipeline.(*MetricsCompare); ok && cmp.filter != nil {
-		return validateFieldExpr(cmp.filter.Expression)
+	// compare() is the one metrics first stage carrying a field
+	// expression; the aggregates carry bare Attributes, which are leaves.
+	if cmp, ok := r.MetricsPipeline.(*MetricsCompare); ok && cmp.Filter() != nil {
+		return validateFieldExpr(cmp.Filter().Expression)
 	}
 	return nil
 }
@@ -141,60 +149,63 @@ func validatePipeline(p Pipeline) error {
 }
 
 func validatePipelineElement(elem PipelineElement) error {
+	if expr, ok := spansetFilterExpression(elem); ok {
+		return validateFieldExpr(expr)
+	}
 	switch e := elem.(type) {
-	case *SpansetFilter:
-		return validateFieldExpr(e.Expression)
-	case SpansetFilter:
-		return validateFieldExpr(e.Expression)
+	case SpansetOperation:
+		return validateSpansetExpr(e)
+	case ScalarFilter:
+		return validateScalarFilter(e.LHS, e.RHS, e)
 	case GroupOperation:
 		return validateFieldExpr(e.Expression)
 	case Aggregate:
-		return validateFieldExpr(e.e)
-	case ScalarFilter:
-		if err := validateScalarExpr(e.LHS); err != nil {
-			return err
-		}
-		if err := validateScalarExpr(e.RHS); err != nil {
-			return err
-		}
-		return matchOperands(e.LHS, e.RHS, e)
-	case SpansetOperation:
-		return validateSpansetExpr(e)
+		return validateFieldExpr(e.InnerExpr())
 	case Pipeline:
 		return validatePipeline(e)
 	}
+	// SelectOperation and CoalesceOperation name attributes and nothing
+	// else: an attribute is a leaf, so there is no binary node to check.
 	return nil
 }
 
 func validateSpansetExpr(se SpansetExpression) error {
+	if expr, ok := spansetFilterExpression(se); ok {
+		return validateFieldExpr(expr)
+	}
 	switch s := se.(type) {
-	case *SpansetFilter:
-		return validateFieldExpr(s.Expression)
-	case SpansetFilter:
-		return validateFieldExpr(s.Expression)
 	case SpansetOperation:
 		if err := validateSpansetExpr(s.LHS); err != nil {
 			return err
 		}
 		return validateSpansetExpr(s.RHS)
+	case ScalarFilter:
+		return validateScalarFilter(s.LHS, s.RHS, s)
 	case Pipeline:
 		return validatePipeline(s)
 	}
 	return nil
 }
 
+// validateScalarFilter is the shared body of the two positions a
+// ScalarFilter occupies — a pipeline stage and a spanset operand — which
+// is also why references.go handles it in both walks.
+func validateScalarFilter(lhs, rhs ScalarExpression, node Element) error {
+	if err := validateScalarExpr(lhs); err != nil {
+		return err
+	}
+	if err := validateScalarExpr(rhs); err != nil {
+		return err
+	}
+	return matchOperands(lhs, rhs, node)
+}
+
 func validateScalarExpr(se ScalarExpression) error {
 	switch s := se.(type) {
 	case ScalarOperation:
-		if err := validateScalarExpr(s.LHS); err != nil {
-			return err
-		}
-		if err := validateScalarExpr(s.RHS); err != nil {
-			return err
-		}
-		return matchOperands(s.LHS, s.RHS, s)
+		return validateScalarFilter(s.LHS, s.RHS, s)
 	case Aggregate:
-		return validateFieldExpr(s.e)
+		return validateFieldExpr(s.InnerExpr())
 	case Pipeline:
 		return validatePipeline(s)
 	}
@@ -216,9 +227,8 @@ func validateFieldExpr(fe FieldExpression) error {
 		return matchOperands(e.LHS, e.RHS, e)
 	case UnaryOperation:
 		return validateFieldExpr(e.Expression)
-	case *UnaryOperation:
-		return validateFieldExpr(e.Expression)
 	}
+	// Attribute and Static are leaves.
 	return nil
 }
 

--- a/internal/traceql/ast/validate.go
+++ b/internal/traceql/ast/validate.go
@@ -36,12 +36,14 @@ const typeMismatchFormat = "binary operations must operate on the same type: %s"
 // accepted it and the tree is well formed; the tree is merely
 // ill-typed.
 //
-// Only the binary-operand rule is enforced today. The reference performs
-// several further static checks over the same tree (operator/operand
-// validity, span-filter and aggregate result types, regex compilability,
-// intrinsic-nil); cerberus deliberately accepts some of those shapes
-// because it answers queries the reference declines, so adopting them is
-// its own piece of work rather than a side effect of this one.
+// Only the binary-operand rule is enforced here. The reference performs
+// several further static checks over the same tree — operator/operand
+// validity, span-filter and aggregate result types, regex compilability —
+// each of which cerberus currently accepts and the reference rejects.
+// Issue #2035 tracks them with a per-rule repro; two more of the
+// reference's rules are deliberately NOT adopted, because cerberus answers
+// those queries (`{ kind != nil }`, `{ parent = "<hex>" }`) rather than
+// declining them.
 type ValidationError struct{ msg string }
 
 // Error renders the message with the reference backend's `invalid TraceQL
@@ -65,10 +67,13 @@ func newValidationError(format string, args ...any) *ValidationError {
 //   - The numeric family (int / float / duration) is inter-comparable.
 //   - nil compares against anything — `{ span.foo != nil }` is the
 //     existence idiom.
-//   - An array matches whatever its element type matches, which is how the
-//     `in` / `not in` and regex-set forms the array-fold rewrites produce
-//     type-check. `{ name = 1 || name = 2 }` folds to `name in [1, 2]`
-//     before the rule runs and is still rejected, on the element type.
+//
+// The array types need no case of their own. The grammar has no array
+// literal — the only producer is the OR-to-IN fold in rewrite.go, which
+// runs AFTER this rule (see Parse) and only ever merges literals of one
+// family. A chain that would fold into a mismatched array comparison
+// therefore always contains a mismatched SCALAR comparison, and is
+// rejected on that one first.
 func (t StaticType) isMatchingOperand(otherT StaticType) bool {
 	if t == TypeAttribute || otherT == TypeAttribute {
 		return true
@@ -79,40 +84,7 @@ func (t StaticType) isMatchingOperand(otherT StaticType) bool {
 	if t.isNumeric() && otherT.isNumeric() {
 		return true
 	}
-	if t == TypeNil || otherT == TypeNil {
-		return true
-	}
-	return t.isMatchingArrayElement(otherT)
-}
-
-// isMatchingArrayElement is isMatchingOperand for the array types: an
-// array operand matches whatever its ELEMENT type would match. It is
-// checked in both directions so the rule stays symmetric regardless of
-// which side the array literal was written on.
-func (t StaticType) isMatchingArrayElement(otherT StaticType) bool {
-	if elem, ok := t.arrayElement(); ok {
-		return elem.isMatchingOperand(otherT)
-	}
-	if elem, ok := otherT.arrayElement(); ok {
-		return elem.isMatchingOperand(t)
-	}
-	return false
-}
-
-// arrayElement returns the element type of an array StaticType; ok is
-// false for every non-array type.
-func (t StaticType) arrayElement() (StaticType, bool) {
-	switch t {
-	case TypeIntArray:
-		return TypeInt, true
-	case TypeFloatArray:
-		return TypeFloat, true
-	case TypeStringArray:
-		return TypeString, true
-	case TypeBooleanArray:
-		return TypeBoolean, true
-	}
-	return 0, false
+	return t == TypeNil || otherT == TypeNil
 }
 
 // validate reports the first static typing error in r, or nil when the

--- a/internal/traceql/ast/validate_test.go
+++ b/internal/traceql/ast/validate_test.go
@@ -1,0 +1,136 @@
+package ast
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestParseRejectsTypeMismatch pins the static operand-type rule: a binary
+// operation whose two sides have known, incompatible types is rejected by
+// Parse itself, so the Tempo head answers it 400 rather than emitting SQL
+// ClickHouse aborts at execution time (issue #2033).
+func TestParseRejectsTypeMismatch(t *testing.T) {
+	cases := []struct {
+		query string
+		want  string // the expression the message must name
+	}{
+		// The issue's own repro: `name` is always a String.
+		{`{ name > 3 }`, "name > 3"},
+		// The mirror image — a duration intrinsic against a string.
+		{`{ duration > "abc" }`, `duration > ` + "`abc`"},
+		// status / kind are their own types, distinct from the string
+		// spelling of their values.
+		{`{ kind = "client" }`, "kind = " + "`client`"},
+		{`{ status = 3 }`, "status = 3"},
+		// The rule reaches inside a boolean tree, and names the offending
+		// sub-expression rather than the whole filter.
+		{`{ resource.service.name = "api" && name > 3 }`, "name > 3"},
+		// …and through a structural operation's nested filters.
+		{`{ .a = 1 } >> { name > 3 }`, "name > 3"},
+		// …and a scalar filter's aggregate side.
+		{`{ } | max(duration) > "slow"`, `max(duration) > ` + "`slow`"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.query, func(t *testing.T) {
+			_, err := Parse(tc.query)
+			if err == nil {
+				t.Fatalf("Parse(%q) = nil error, want a type mismatch", tc.query)
+			}
+			var verr *ValidationError
+			if !errors.As(err, &verr) {
+				t.Fatalf("Parse(%q) error = %T (%v), want *ValidationError", tc.query, err, err)
+			}
+			msg := verr.Error()
+			// The wording is the reference backend's own, so a client
+			// that reads the message sees one sentence from both.
+			if !strings.Contains(msg, "invalid TraceQL query: binary operations must operate on the same type: ") {
+				t.Errorf("Parse(%q) message = %q, want the reference wording", tc.query, msg)
+			}
+			if !strings.Contains(msg, tc.want) {
+				t.Errorf("Parse(%q) message = %q, want it to name %q", tc.query, msg, tc.want)
+			}
+		})
+	}
+}
+
+// TestParseAcceptsCompatibleOperands is the other half of the ratchet: the
+// rule must reject only the provably impossible. Every query here is one
+// the reference backend answers, and a rule that over-rejected any of them
+// would take a working query off a user's dashboard.
+func TestParseAcceptsCompatibleOperands(t *testing.T) {
+	queries := []string{
+		// A scoped attribute is typed per span at query time, so no
+		// static verdict is possible on either side — this is the query
+		// the issue reports cerberus 502'ing on.
+		`{ duration > span.foo }`,
+		`{ duration > resource.service.name }`,
+		`{ span.foo > duration }`,
+		`{ name > span.foo }`,
+		// The numeric family is inter-comparable.
+		`{ duration > 100ms }`,
+		`{ duration > 100 }`,
+		`{ duration > 1.5 }`,
+		`{ span:childCount > 2 }`,
+		`{ nestedSetParent < 0 }`,
+		// nil compares against anything — the existence idiom.
+		`{ span.foo != nil }`,
+		`{ kind != nil }`,
+		// Same types, including the enum-valued intrinsics in their own
+		// spelling.
+		`{ name = "GET /home" }`,
+		`{ kind = client }`,
+		`{ status = error }`,
+		`{ statusMessage =~ "timeout.*" }`,
+		// Boolean composition: an operand of && / || is boolean-typed.
+		`{ name = "GET" && duration > 1s }`,
+		`{ (duration > 1s || duration < 10ms) && span.foo = 1 }`,
+		// The array-fold shapes, which type-check element-wise.
+		`{ .x = "a" || .x = "b" }`,
+		`{ .x != 1 && .x != 2 }`,
+		// Scalar filters and aggregates.
+		`{ } | count() > 2`,
+		`{ } | avg(duration) > 1s`,
+		`{ } | max(duration) + 1 > 2`,
+		// Metrics pipelines.
+		`{ duration > 1s } | rate() by (resource.service.name)`,
+		`{ } | compare({ status = error })`,
+	}
+	for _, q := range queries {
+		t.Run(q, func(t *testing.T) {
+			if _, err := Parse(q); err != nil {
+				t.Errorf("Parse(%q) = %v, want it accepted", q, err)
+			}
+		})
+	}
+}
+
+// TestIsMatchingOperandSymmetry pins that the rule reads the same in both
+// directions. An asymmetric implementation would accept `{ 3 < name }`
+// while rejecting `{ name > 3 }` — the same query written the other way
+// round — which is the shape a hand-written type table gets wrong.
+func TestIsMatchingOperandSymmetry(t *testing.T) {
+	all := []StaticType{
+		TypeNil, TypeAttribute, TypeInt, TypeFloat, TypeString, TypeBoolean,
+		TypeIntArray, TypeFloatArray, TypeStringArray, TypeBooleanArray,
+		TypeDuration, TypeStatus, TypeKind,
+	}
+	for _, a := range all {
+		for _, b := range all {
+			if a.isMatchingOperand(b) != b.isMatchingOperand(a) {
+				t.Errorf("isMatchingOperand asymmetric for %v / %v", a, b)
+			}
+		}
+	}
+}
+
+// TestParseRejectsFlippedTypeMismatch is the behavioural half of the
+// symmetry property: writing the mismatched comparison the other way round
+// must not slip past.
+func TestParseRejectsFlippedTypeMismatch(t *testing.T) {
+	for _, q := range []string{`{ name > 3 }`, `{ 3 < name }`} {
+		if _, err := Parse(q); err == nil {
+			t.Errorf("Parse(%q) = nil error, want a type mismatch", q)
+		}
+	}
+}

--- a/internal/traceql/ast/validate_test.go
+++ b/internal/traceql/ast/validate_test.go
@@ -24,8 +24,10 @@ func TestParseRejectsTypeMismatch(t *testing.T) {
 		{`{ kind = "client" }`, "kind = " + "`client`"},
 		{`{ status = 3 }`, "status = 3"},
 		// The rule reaches inside a boolean tree, and names the offending
-		// sub-expression rather than the whole filter.
+		// sub-expression rather than the whole filter — on either side, so
+		// a walk that recursed into one operand only still fails here.
 		{`{ resource.service.name = "api" && name > 3 }`, "name > 3"},
+		{`{ name > 3 && resource.service.name = "api" }`, "name > 3"},
 		// …and through a structural operation's nested filters.
 		{`{ .a = 1 } >> { name > 3 }`, "name > 3"},
 		// …and a scalar filter's aggregate side.
@@ -88,10 +90,21 @@ func TestParseAcceptsCompatibleOperands(t *testing.T) {
 		// The array-fold shapes, which type-check element-wise.
 		`{ .x = "a" || .x = "b" }`,
 		`{ .x != 1 && .x != 2 }`,
-		// Scalar filters and aggregates.
+		// Unary operands are walked through to the expression beneath.
+		`{ !(kind = server) }`,
+		`{ -duration > 1s }`,
+		// Scalar filters and aggregates, including a bare aggregate stage
+		// with no comparison after it.
+		`{ } | count()`,
+		`{ } | avg(duration)`,
 		`{ } | count() > 2`,
 		`{ } | avg(duration) > 1s`,
 		`{ } | max(duration) + 1 > 2`,
+		`{ } | 1 + max(duration) > 2`,
+		// A parenthesised pipeline, both as a spanset operand and as a
+		// stage of an outer pipeline.
+		`({ .a = 1 } | count() > 1) >> { .b = 2 }`,
+		`({ .a = 1 } | count() > 1) | count() > 1`,
 		// Metrics pipelines.
 		`{ duration > 1s } | rate() by (resource.service.name)`,
 		`{ } | compare({ status = error })`,
@@ -132,5 +145,97 @@ func TestParseRejectsFlippedTypeMismatch(t *testing.T) {
 		if _, err := Parse(q); err == nil {
 			t.Errorf("Parse(%q) = nil error, want a type mismatch", q)
 		}
+	}
+}
+
+// TestIsMatchingOperandArrayElement pins each array type against the
+// ELEMENT type it stands for. The symmetry property above cannot tell
+// these apart — mapping TypeIntArray to the wrong element type is
+// symmetric — so the mapping needs naming per case.
+func TestIsMatchingOperandArrayElement(t *testing.T) {
+	cases := []struct {
+		a, b StaticType
+		want bool
+	}{
+		{TypeStringArray, TypeString, true},
+		{TypeStringArray, TypeInt, false},
+		{TypeStringArray, TypeBoolean, false},
+		{TypeIntArray, TypeInt, true},
+		// The element rule composes with the numeric-family rule.
+		{TypeIntArray, TypeFloat, true},
+		{TypeIntArray, TypeDuration, true},
+		{TypeIntArray, TypeString, false},
+		{TypeFloatArray, TypeFloat, true},
+		{TypeFloatArray, TypeString, false},
+		{TypeBooleanArray, TypeBoolean, true},
+		{TypeBooleanArray, TypeInt, false},
+		// Two arrays never meet: neither is the other's element.
+		{TypeIntArray, TypeStringArray, false},
+		{TypeStringArray, TypeStringArray, true}, // …except by identity.
+	}
+	for _, tc := range cases {
+		t.Run(tc.a.String()+"/"+tc.b.String(), func(t *testing.T) {
+			if got := tc.a.isMatchingOperand(tc.b); got != tc.want {
+				t.Errorf("%v.isMatchingOperand(%v) = %v, want %v", tc.a, tc.b, got, tc.want)
+			}
+			if got := tc.b.isMatchingOperand(tc.a); got != tc.want {
+				t.Errorf("%v.isMatchingOperand(%v) = %v, want %v", tc.b, tc.a, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestParseRejectsFoldedArrayMismatch pins that the array-fold rewrites
+// cannot smuggle an ill-typed chain past the rule. `{ name = 1 || name =
+// 2 }` folds to a single `name in [1, 2]` before the check runs, so the
+// check has to reach the array's element type to still reject it.
+func TestParseRejectsFoldedArrayMismatch(t *testing.T) {
+	_, err := Parse(`{ name = 1 || name = 2 }`)
+	if err == nil {
+		t.Fatal("Parse(`{ name = 1 || name = 2 }`) = nil error, want a type mismatch")
+	}
+	if !strings.Contains(err.Error(), "name in [1, 2]") {
+		t.Errorf("message = %q, want it to name the folded expression", err)
+	}
+	// The same fold over the matching element type stays accepted.
+	if _, err := Parse(`{ name = "a" || name = "b" }`); err != nil {
+		t.Errorf("Parse of a well-typed fold = %v, want it accepted", err)
+	}
+}
+
+// TestValidateReachesEveryPipelinePosition pins that the walk visits each
+// position a binary operation can occupy, by putting the SAME ill-typed
+// comparison in each one and requiring a rejection every time. A missing
+// arm is a silent false negative — the check simply does not run — which
+// no accept-path test can detect.
+func TestValidateReachesEveryPipelinePosition(t *testing.T) {
+	positions := map[string]string{
+		"spanset filter":             `{ name > 3 }`,
+		"nested spanset operand":     `{ .x = 1 } >> { name > 3 }`,
+		"grouping expression":        `{ } | by(name > 3)`,
+		"aggregate inner expression": `{ } | max(name > 3) > 1`,
+		"scalar filter":              `{ } | max(name) > 1s`,
+		"scalar operation operand":   `{ } | 1 + max(name > 3) > 2`,
+		"parenthesised pipeline":     `({ name > 3 } | count() > 1) && { .x = 1 }`,
+		"pipeline stage":             `({ name > 3 } | count() > 1) | count() > 1`,
+		"unary negation":             `{ !(name > 3) }`,
+		"metrics compare filter":     `{ } | compare({ name > 3 })`,
+	}
+	for position, query := range positions {
+		t.Run(position, func(t *testing.T) {
+			if _, err := Parse(query); err == nil {
+				t.Errorf("Parse(%q) = nil error — the walk does not reach the %s", query, position)
+			}
+		})
+	}
+}
+
+// TestValidateNilRoot pins the degenerate receiver rather than leaving it
+// to a nil dereference: RootExpr is reachable as a nil pointer through the
+// parser's own error path.
+func TestValidateNilRoot(t *testing.T) {
+	var r *RootExpr
+	if err := r.validate(); err != nil {
+		t.Errorf("(*RootExpr)(nil).validate() = %v, want nil", err)
 	}
 }

--- a/internal/traceql/ast/validate_test.go
+++ b/internal/traceql/ast/validate_test.go
@@ -148,58 +148,31 @@ func TestParseRejectsFlippedTypeMismatch(t *testing.T) {
 	}
 }
 
-// TestIsMatchingOperandArrayElement pins each array type against the
-// ELEMENT type it stands for. The symmetry property above cannot tell
-// these apart — mapping TypeIntArray to the wrong element type is
-// symmetric — so the mapping needs naming per case.
-func TestIsMatchingOperandArrayElement(t *testing.T) {
-	cases := []struct {
-		a, b StaticType
-		want bool
-	}{
-		{TypeStringArray, TypeString, true},
-		{TypeStringArray, TypeInt, false},
-		{TypeStringArray, TypeBoolean, false},
-		{TypeIntArray, TypeInt, true},
-		// The element rule composes with the numeric-family rule.
-		{TypeIntArray, TypeFloat, true},
-		{TypeIntArray, TypeDuration, true},
-		{TypeIntArray, TypeString, false},
-		{TypeFloatArray, TypeFloat, true},
-		{TypeFloatArray, TypeString, false},
-		{TypeBooleanArray, TypeBoolean, true},
-		{TypeBooleanArray, TypeInt, false},
-		// Two arrays never meet: neither is the other's element.
-		{TypeIntArray, TypeStringArray, false},
-		{TypeStringArray, TypeStringArray, true}, // …except by identity.
-	}
-	for _, tc := range cases {
-		t.Run(tc.a.String()+"/"+tc.b.String(), func(t *testing.T) {
-			if got := tc.a.isMatchingOperand(tc.b); got != tc.want {
-				t.Errorf("%v.isMatchingOperand(%v) = %v, want %v", tc.a, tc.b, got, tc.want)
-			}
-			if got := tc.b.isMatchingOperand(tc.a); got != tc.want {
-				t.Errorf("%v.isMatchingOperand(%v) = %v, want %v", tc.b, tc.a, got, tc.want)
-			}
-		})
-	}
-}
-
-// TestParseRejectsFoldedArrayMismatch pins that the array-fold rewrites
-// cannot smuggle an ill-typed chain past the rule. `{ name = 1 || name =
-// 2 }` folds to a single `name in [1, 2]` before the check runs, so the
-// check has to reach the array's element type to still reject it.
-func TestParseRejectsFoldedArrayMismatch(t *testing.T) {
+// TestParseRejectsChainBeforeItFolds pins the ordering that lets the rule
+// stay complete without an array case: `{ name = 1 || name = 2 }` would
+// fold to a single `name in [1, 2]`, but the rule runs first and rejects
+// the scalar comparison the client actually wrote — the same sentence the
+// reference produces, which validates through ParseNoOptimizations for
+// exactly this reason.
+func TestParseRejectsChainBeforeItFolds(t *testing.T) {
 	_, err := Parse(`{ name = 1 || name = 2 }`)
 	if err == nil {
 		t.Fatal("Parse(`{ name = 1 || name = 2 }`) = nil error, want a type mismatch")
 	}
-	if !strings.Contains(err.Error(), "name in [1, 2]") {
-		t.Errorf("message = %q, want it to name the folded expression", err)
+	if !strings.Contains(err.Error(), "name = 1") {
+		t.Errorf("message = %q, want it to name the unfolded comparison", err)
 	}
-	// The same fold over the matching element type stays accepted.
-	if _, err := Parse(`{ name = "a" || name = "b" }`); err != nil {
-		t.Errorf("Parse of a well-typed fold = %v, want it accepted", err)
+	if strings.Contains(err.Error(), "in [") {
+		t.Errorf("message = %q, want the pre-fold spelling, not the folded one", err)
+	}
+	// The same chain over the matching type stays accepted, and still
+	// folds — the rule must not cost the rewrite.
+	expr, err := Parse(`{ name = "a" || name = "b" }`)
+	if err != nil {
+		t.Fatalf("Parse of a well-typed chain = %v, want it accepted", err)
+	}
+	if got := expr.String(); !strings.Contains(got, "in [") {
+		t.Errorf("parsed to %q, want the array fold still applied", got)
 	}
 }
 

--- a/internal/traceql/lower.go
+++ b/internal/traceql/lower.go
@@ -1589,7 +1589,7 @@ func lowerBinaryOperation(b *traceql.BinaryOperation, s schema.Traces) (chplan.E
 	// happens server-side. Float64 widens both int and float literals
 	// without precision loss for the magnitudes typical of attribute
 	// values (HTTP status codes, percentages, sizes).
-	lhs, rhs = coerceNumericFieldAccess(op, lhs, rhs)
+	lhs, rhs = coerceNumericFieldAccess(op, lhs, rhs, binaryHasNumericOperand(b))
 	// Boolean coercion: the OTel-CH exporter stringifies bool-typed
 	// attribute values into the Map(String, String) carriers as
 	// "true" / "false", so `{ .cache.hit = true }` must compare against
@@ -1962,7 +1962,12 @@ func lowerTraceScopedBinary(b *traceql.BinaryOperation, op chplan.BinaryOp, s sc
 	if err != nil {
 		return nil, true, err
 	}
-	pred := &chplan.Binary{Op: effectiveOp, Left: &chplan.ColumnRef{Name: traceScopedValueAlias}, Right: rhs}
+	// traceDuration's per-trace aggregate is Int64 nanoseconds while
+	// rootName / rootServiceName are Strings, so only the duration case
+	// makes the comparison numeric and needs its dynamic peer parsed.
+	left := chplan.Expr(&chplan.ColumnRef{Name: traceScopedValueAlias})
+	left, rhs = coerceNumericFieldAccess(effectiveOp, left, rhs, numericIntrinsicColumn(attr.Intrinsic))
+	pred := &chplan.Binary{Op: effectiveOp, Left: left, Right: rhs}
 	return traceScopedInSubquery(valueNode, pred, s), true, nil
 }
 
@@ -2070,11 +2075,24 @@ func coerceBoolFieldAccess(op chplan.BinaryOp, lhs, rhs chplan.Expr) (chplan.Exp
 // already Int64) doesn't reach this path — intrinsics lower to a
 // ColumnRef, not a FieldAccess. So the wrap is restricted to the
 // Map(String, String) carriers by construction.
-func coerceNumericFieldAccess(op chplan.BinaryOp, lhs, rhs chplan.Expr) (chplan.Expr, chplan.Expr) {
+//
+// numericPeer is the caller's answer to the question the lowered
+// expressions cannot answer for themselves: does the SOURCE query put a
+// statically numeric operand on one side? A numeric intrinsic (duration,
+// childCount, a nested-set position, traceDuration) lowers to a bare
+// ColumnRef, which isNumericExpr deliberately does not treat as numeric —
+// it cannot tell Duration from SpanName. Without the hint
+// `{ duration > span.foo }` emitted `Duration > SpanAttributes['foo']`,
+// a UInt64-vs-String compare ClickHouse rejects with NO_COMMON_TYPE,
+// aborting the whole query (issue #2033). The reference backend types
+// attributes per span instead: a span whose `foo` is not a number simply
+// does not match. The OrNull wrap reproduces exactly that — unparseable
+// values evaluate NULL and WHERE drops the row.
+func coerceNumericFieldAccess(op chplan.BinaryOp, lhs, rhs chplan.Expr, numericPeer bool) (chplan.Expr, chplan.Expr) {
 	if isArithmeticOp(op) {
 		return coerceFieldAccess(lhs), coerceFieldAccess(rhs)
 	}
-	if isComparisonOp(op) && (isNumericExpr(lhs) || isNumericExpr(rhs)) {
+	if isComparisonOp(op) && (numericPeer || isNumericExpr(lhs) || isNumericExpr(rhs)) {
 		return coerceFieldAccess(lhs), coerceFieldAccess(rhs)
 	}
 	// Two bare attribute accesses under an ORDERING comparison (`span.a > span.b`,
@@ -2093,6 +2111,48 @@ func coerceNumericFieldAccess(op chplan.BinaryOp, lhs, rhs chplan.Expr) (chplan.
 		}
 	}
 	return lhs, rhs
+}
+
+// binaryHasNumericOperand reports whether either operand of b resolves to
+// a NUMERIC ClickHouse expression — the numericPeer answer
+// coerceNumericFieldAccess needs and cannot derive from the lowered tree.
+//
+// The question is deliberately asked of the SOURCE operands rather than of
+// the lowered plan: a numeric intrinsic and a string intrinsic both lower
+// to a bare ColumnRef, indistinguishable downstream. It is also asked of
+// the schema rather than of the language's own type system — the language
+// leaves the scoped intrinsic spellings (`span:duration`, `trace:duration`)
+// query-time typed, but cerberus still emits them against numeric columns
+// and so still has to coerce their dynamic peer.
+func binaryHasNumericOperand(b *traceql.BinaryOperation) bool {
+	return numericIntrinsicOperand(b.LHS) || numericIntrinsicOperand(b.RHS)
+}
+
+// numericIntrinsicOperand reports whether e is an attribute reference to
+// an intrinsic backed by a numeric column.
+func numericIntrinsicOperand(e traceql.FieldExpression) bool {
+	a, ok := fieldExprAttribute(e)
+	return ok && numericIntrinsicColumn(a.Intrinsic)
+}
+
+// numericIntrinsicColumn lists the intrinsics whose lowering yields a
+// numeric ClickHouse expression: the durations (Duration, the per-trace
+// max(end)-min(start) aggregate, an event's offset from span start), the
+// child count, and the synthetic nested-set positions. Every other
+// intrinsic resolves to a String column, where a comparison against an
+// attribute needs no coercion because the attribute maps are String-valued
+// too.
+func numericIntrinsicColumn(i traceql.Intrinsic) bool {
+	switch i {
+	case traceql.IntrinsicDuration, traceql.ScopedIntrinsicSpanDuration,
+		traceql.IntrinsicTraceDuration, traceql.ScopedIntrinsicTraceDuration,
+		traceql.IntrinsicEventTimeSinceStart,
+		traceql.IntrinsicChildCount,
+		traceql.IntrinsicNestedSetLeft, traceql.IntrinsicNestedSetRight,
+		traceql.IntrinsicNestedSetParent:
+		return true
+	}
+	return false
 }
 
 // isOrderingComparisonOp reports whether op is an ordering comparison
@@ -2252,7 +2312,9 @@ func lowerNestedSetBinary(b *traceql.BinaryOperation, op chplan.BinaryOp, s sche
 		return nil, true, err
 	}
 	left := chplan.Expr(&chplan.ColumnRef{Name: col})
-	left, rhs = coerceNumericFieldAccess(op, left, rhs)
+	// The nested-set columns are Int64 positions, so the comparison always
+	// has a numeric side even when the AST operand order was flipped.
+	left, rhs = coerceNumericFieldAccess(op, left, rhs, true)
 	return &chplan.Binary{Op: op, Left: left, Right: rhs}, true, nil
 }
 

--- a/internal/traceql/lower.go
+++ b/internal/traceql/lower.go
@@ -2119,11 +2119,14 @@ func coerceNumericFieldAccess(op chplan.BinaryOp, lhs, rhs chplan.Expr, numericP
 //
 // The question is deliberately asked of the SOURCE operands rather than of
 // the lowered plan: a numeric intrinsic and a string intrinsic both lower
-// to a bare ColumnRef, indistinguishable downstream. It is also asked of
-// the schema rather than of the language's own type system — the language
-// leaves the scoped intrinsic spellings (`span:duration`, `trace:duration`)
-// query-time typed, but cerberus still emits them against numeric columns
-// and so still has to coerce their dynamic peer.
+// to a bare ColumnRef, indistinguishable downstream.
+//
+// It is answered from the COLUMN each intrinsic resolves to rather than
+// from the language's static type, because the two answer different
+// questions — the type system says what the value means, the schema says
+// what ClickHouse will compare. They agree today over every intrinsic the
+// parser can produce, and this file is the one that has to be right when
+// they stop agreeing.
 func binaryHasNumericOperand(b *traceql.BinaryOperation) bool {
 	return numericIntrinsicOperand(b.LHS) || numericIntrinsicOperand(b.RHS)
 }
@@ -2142,10 +2145,14 @@ func numericIntrinsicOperand(e traceql.FieldExpression) bool {
 // intrinsic resolves to a String column, where a comparison against an
 // attribute needs no coercion because the attribute maps are String-valued
 // too.
+// The scoped spellings need no entries of their own: the parser
+// normalises `span:duration` onto IntrinsicDuration and `trace:duration`
+// onto IntrinsicTraceDuration (scopedIntrinsic in ast/parser.go), so the
+// ScopedIntrinsic* constants never reach lowering.
 func numericIntrinsicColumn(i traceql.Intrinsic) bool {
 	switch i {
-	case traceql.IntrinsicDuration, traceql.ScopedIntrinsicSpanDuration,
-		traceql.IntrinsicTraceDuration, traceql.ScopedIntrinsicTraceDuration,
+	case traceql.IntrinsicDuration,
+		traceql.IntrinsicTraceDuration,
 		traceql.IntrinsicEventTimeSinceStart,
 		traceql.IntrinsicChildCount,
 		traceql.IntrinsicNestedSetLeft, traceql.IntrinsicNestedSetRight,

--- a/internal/traceql/parser_smoke_test.go
+++ b/internal/traceql/parser_smoke_test.go
@@ -31,7 +31,7 @@ func TestParserSmoke(t *testing.T) {
 		`{ duration < 50ms }`,
 		`{ name = "GET /home" }`,
 		`{ name =~ "GET /.*" }`,
-		`{ kind = "client" }`,
+		`{ kind = client }`,
 		`{ statusMessage = "internal error" }`,
 		`{ trace:id = "abcdef0123456789" }`,
 		`{ span:id = "0123456789abcdef" }`,

--- a/test/perf/cardinality-baseline/traceql/duration_gt_attr_type_mismatch.json
+++ b/test/perf/cardinality-baseline/traceql/duration_gt_attr_type_mismatch.json
@@ -1,8 +1,8 @@
 {
-  "fixture": "traceql/kind_intrinsic",
-  "fan_factor": 0,
-  "scan_rows": 0,
-  "peak_intermediate": 0,
+  "fixture": "traceql/duration_gt_attr_type_mismatch",
+  "fan_factor": 1,
+  "scan_rows": 1,
+  "peak_intermediate": 1,
   "has_cross_join": false,
   "has_array_join": false,
   "has_recursive_cte": false,

--- a/test/perf/cardinality-baseline/traceql/kind_intrinsic.json
+++ b/test/perf/cardinality-baseline/traceql/kind_intrinsic.json
@@ -1,8 +1,8 @@
 {
   "fixture": "traceql/kind_intrinsic",
-  "fan_factor": 0,
-  "scan_rows": 0,
-  "peak_intermediate": 0,
+  "fan_factor": 1,
+  "scan_rows": 1,
+  "peak_intermediate": 1,
   "has_cross_join": false,
   "has_array_join": false,
   "has_recursive_cte": false,

--- a/test/spec/traceql/duration_gt_attr_type_mismatch.txtar
+++ b/test/spec/traceql/duration_gt_attr_type_mismatch.txtar
@@ -1,0 +1,22 @@
+-- query.traceql --
+{ duration > span.budget_ns }
+-- seed --
+CREATE TABLE otel_traces (
+    Duration UInt64,
+    SpanAttributes Map(String, String) MATERIALIZED if(Duration = 10000000, map('budget_ns', '20000000'), if(Duration = 20000000, map('budget_ns', '5000000'), map('budget_ns', 'unbounded')))
+) ENGINE = MergeTree ORDER BY Duration;
+INSERT INTO otel_traces (Duration) VALUES
+    (10000000),
+    (20000000),
+    (30000000);
+-- expected_rows --
+[
+  ["", {"__cerberus_parentSpanID": "", "__cerberus_spanID": "", "__cerberus_traceID": ""}, "1970-01-01T00:00:00Z", 20000000]
+]
+-- args --
+[0] string = "budget_ns"
+-- chplan --
+Filter predicate=(Duration > toFloat64OrNull(SpanAttributes["budget_ns"]))
+  Scan(otel_traces)
+-- sql --
+SELECT * FROM `otel_traces` WHERE (`Duration` > toFloat64OrNull(`SpanAttributes`[?]))

--- a/test/spec/traceql/kind_intrinsic.txtar
+++ b/test/spec/traceql/kind_intrinsic.txtar
@@ -1,9 +1,9 @@
 -- query.traceql --
-{ kind = "client" }
+{ kind = client }
 -- sql --
 SELECT * FROM `otel_traces` WHERE (`SpanKind` = ?)
 -- args --
-[0] string = "client"
+[0] string = "Client"
 -- seed --
 CREATE TABLE otel_traces (
     SpanKind String
@@ -13,9 +13,7 @@ INSERT INTO otel_traces VALUES
     ('client'),
     ('Internal');
 -- expected_rows --
-[
-  ["", {"__cerberus_parentSpanID": "", "__cerberus_spanID": "", "__cerberus_traceID": ""}, "1970-01-01T00:00:00Z", 0]
-]
+[]
 -- chplan --
-Filter predicate=(SpanKind = "client")
+Filter predicate=(SpanKind = "Client")
   Scan(otel_traces)

--- a/test/spec/traceql/kind_intrinsic.txtar
+++ b/test/spec/traceql/kind_intrinsic.txtar
@@ -10,10 +10,13 @@ CREATE TABLE otel_traces (
 ) ENGINE = Memory;
 INSERT INTO otel_traces VALUES
     ('Server'),
+    ('Client'),
     ('client'),
     ('Internal');
 -- expected_rows --
-[]
+[
+  ["", {"__cerberus_parentSpanID": "", "__cerberus_spanID": "", "__cerberus_traceID": ""}, "1970-01-01T00:00:00Z", 0]
+]
 -- chplan --
 Filter predicate=(SpanKind = "Client")
   Scan(otel_traces)


### PR DESCRIPTION
A TraceQL comparison whose two operands have incompatible types was not
type-checked anywhere in cerberus. It parsed, lowered, was emitted as SQL,
and ClickHouse rejected it at execution with `NO_COMMON_TYPE` (code 386) —
which reached the client as **HTTP 502** carrying ClickHouse's own error
code, type names and a fragment of the generated SQL.

| query | reference Tempo | cerberus before | cerberus after |
|---|---|---|---|
| `{duration > span.foo}` | `200` empty | `502` | `200` empty |
| `{name > 3}` | `400` | `502` | `400` |

## Root cause

Two independent gaps, plus one that let the symptom onto the wire.

**The parser has no static type rule.** cerberus's in-house TraceQL parser
reimplements the reference grammar and its `impliedType` inference, but
never applied the one static check the language performs: the two sides of
a binary operation must have compatible types. Nothing rejected
`{ name > 3 }`, so it became SQL.

**Lowering cannot tell a numeric intrinsic from a string one.** Both land
as a bare `chplan.ColumnRef`, and the numeric-coercion pass
(`coerceNumericFieldAccess`) decided purely from the lowered shape —
`isNumericExpr` deliberately does not treat a `ColumnRef` as numeric
because it cannot distinguish `Duration` from `SpanName`. So
`{ duration > span.foo }` emitted `Duration > SpanAttributes['foo']`, a
UInt64-vs-String compare, while the already-working
`{ span.http.method > 5 }` got its `toFloat64OrNull` wrap from the literal
on the other side. That asymmetry is exactly what the issue observed.

**Nothing kept the driver's text off the wire.** All three heads rendered
`err.Error()` straight into the response body, and only CH codes 241 and
159 are wrapped in a cerberus-authored message — every other exception
passed through verbatim.

## The fix

1. `internal/traceql/ast/validate.go` adds the operand-matching rule and
   `Parse` applies it, so a static mismatch is a parse-stage failure →
   **400**, with the reference backend's own wording (`invalid TraceQL
   query: binary operations must operate on the same type: name > 3`).
2. `coerceNumericFieldAccess` takes a `numericPeer` answer derived from
   the SOURCE operands — asked of the schema, not of the language's type
   system, since the scoped spellings (`span:duration`, `trace:duration`)
   stay query-time typed upstream yet still emit against numeric columns.
   The dynamic side is parsed with `toFloat64OrNull`, so a span whose
   value is not a number simply does not match → **200**. Applied at all
   three comparison sites: generic binary, nested-set, and the
   trace-scoped `traceDuration` subquery.
3. `chclient.SafeMessage` substitutes a ClickHouse server exception's own
   rendering while leaving every cerberus-authored message intact
   (parse/lower rejections, budgets, breaker, timeouts). All three HTTP
   heads and the Tempo gRPC surface render through it — the leak was
   never Tempo-specific.

An attribute is typed per span at query time and an intrinsic is not, so
the two cases get **opposite verdicts on purpose**. Both are pinned
against reference Tempo in `compatibility/tempo/driver/corpus/smoke.txtar`
— one as an `-- expect_status --` case, one as a body diff asserting zero
traces on both sides — so a fix that collapsed them onto a single verdict
fails there.

## Behaviour change worth calling out

`{ kind = "client" }` is now rejected with 400. `kind` is its own type,
distinct from the string spelling of its values, and reference Tempo
rejects it too (`isMatchingOperand` in `enum_statics.go`); cerberus was
accepting a query the reference does not. `{ kind = client }` is the
spelling that works, and the spec fixture now uses it.

## Tests

- `internal/traceql/ast/validate_test.go` — the reject table (including
  the flipped `{ 3 < name }` spelling), a 24-query accept table so the
  rule cannot over-reject, and a symmetry property over every type pair.
- `internal/api/tempo/handler_type_mismatch_test.go` — the three wire
  contracts end to end: 400 for the static mismatch, 200 for the dynamic
  one, and no ClickHouse text in a 502 body.
- `internal/chclient/safemessage_test.go` — both directions of the
  redaction.
- `test/spec/traceql/duration_gt_attr_type_mismatch.txtar` — a seeded
  round-trip proving the emitted SQL both runs and answers correctly: the
  span whose attribute parses as a number matches, the one whose value is
  `unbounded` does not.

Closes #2033
