### PR TITLE
perf(golden): fan the promql round-trip walk out across processes

### DIFF
--- a/.github/scripts/golden-update.mjs
+++ b/.github/scripts/golden-update.mjs
@@ -33,6 +33,16 @@
 // freshly-written SQL to fill `-- expected_rows --`) still run sequentially,
 // in declaration order, because that ordering IS a real data dependency.
 //
+// One generator additionally fans OUT: promql's `TestRoundTripChDB` declares
+// `fanOut: N` (golden-shards.mjs) and arrives here as N commands over disjoint
+// slices of its own corpus, partitioned by test/spec/shard.go. They run
+// concurrently with each other and the next generator waits for all of them, so
+// the fan-out buys parallelism WITHIN one generator without weakening the order
+// between generators. It has to be processes rather than goroutines for the same
+// reason the shards do: chdb-go caches one session per process, and the spec
+// runner tears that singleton down between fixtures for cross-fixture isolation
+// (#1987), so in-process parallelism would race the teardown.
+//
 // Environment inputs:
 //
 //   GOLDEN_SHARDS                (required) space/comma separated shard names,
@@ -73,8 +83,10 @@ import {
   SHARDS,
   commandsFor,
   coverageViolations,
+  flattenSteps,
   needsChdb,
   resolveRequested,
+  stepLabel,
 } from './lib/golden-shards.mjs';
 
 const repoRoot = process.cwd();
@@ -170,14 +182,27 @@ function runTagged(name, argv, env, cwd) {
 
 /** Runs one shard's generators sequentially (declaration order is a real
  * data dependency — see the module comment). Resolves to `{ name, code }`;
- * `code` is the first non-zero exit, or 0 if every generator succeeded. */
+ * `code` is the first non-zero exit, or 0 if every generator succeeded.
+ *
+ * A STEP is one generator, and a step that declared `fanOut: N` arrives as an
+ * array of N commands over disjoint corpus slices. Those run concurrently with
+ * each other and the loop does not advance until every one of them has finished
+ * — the fan-out parallelises one generator, it does not weaken the ordering
+ * between generators. First non-zero exit in the group fails the shard, after
+ * letting its siblings finish, matching the cross-shard semantics above. */
 async function runShard(name, justExecutable, repoRoot) {
-  for (const { argv, env } of commandsFor(name, { justExecutable })) {
-    log(`==> ${name}: ${Object.entries(env)
-      .map(([k, v]) => `${k}=${v}`)
-      .join(' ')} ${argv.join(' ')}`.replace(/\s+/g, ' '));
-    const code = await runTagged(name, argv, env, repoRoot);
-    if (code !== 0) return { name, code };
+  for (const step of commandsFor(name, { justExecutable })) {
+    const group = Array.isArray(step) ? step : [step];
+    for (const { argv, env } of group) {
+      log(`==> ${stepLabel(name, env)}: ${Object.entries(env)
+        .map(([k, v]) => `${k}=${v}`)
+        .join(' ')} ${argv.join(' ')}`.replace(/\s+/g, ' '));
+    }
+    const codes = await Promise.all(
+      group.map(({ argv, env }) => runTagged(stepLabel(name, env), argv, env, repoRoot)),
+    );
+    const failed = codes.find((c) => c !== 0);
+    if (failed !== undefined) return { name, code: failed };
   }
   return { name, code: 0 };
 }
@@ -213,8 +238,11 @@ async function main() {
   const justExecutable = process.env.JUST_EXECUTABLE || 'just';
 
   if (process.env.GOLDEN_UPDATE_PRINT_PLAN === '1') {
+    // One line per COMMAND, fan-outs expanded: the plan is what the run will
+    // execute, and a fan-out that printed as a single line would hide both the
+    // partition it declares and the count it declares it at.
     for (const name of shards) {
-      for (const { argv, env } of commandsFor(name, { justExecutable })) {
+      for (const { argv, env } of flattenSteps(commandsFor(name, { justExecutable }))) {
         const prefix = Object.entries(env).map(([k, v]) => `${k}=${v}`);
         log(`${SHARDS[name].stage} ${name} ${[...prefix, ...argv].join(' ')}`);
       }

--- a/.github/scripts/lib/golden-shards.mjs
+++ b/.github/scripts/lib/golden-shards.mjs
@@ -70,6 +70,40 @@ export const STAGE_BODY = 1;
 export const STAGE_POST = 2;
 
 /**
+ * The env pair a fanned-out generator declares its corpus slice through, read by
+ * `spec.ShardFromEnv` (test/spec/shard.go). Deliberately NOT the perf lane's
+ * PERF_SHARD_* pair: the two partitions cover different corpora at different
+ * counts, and one shared pair would let either narrow the other.
+ */
+const SPEC_SHARD_INDEX_ENV = 'SPEC_SHARD_INDEX';
+const SPEC_SHARD_COUNT_ENV = 'SPEC_SHARD_COUNT';
+
+/**
+ * How many processes the PromQL round-trip generator fans out to.
+ *
+ * `TestRoundTripChDB` walks ~570 chDB-executing TXTAR fixtures in ONE process
+ * and was the single longest step of `just update-golden promql` at ~7 minutes,
+ * with the rest of the recipe an order of magnitude cheaper. It cannot be
+ * parallelised in-process — every subtest shares chdb-go's package-level session
+ * singleton, which the runner tears down and rebuilds between fixtures for
+ * cross-fixture isolation (#1987) — so the only lever is more PROCESSES, each
+ * with its own singleton and its own `os.MkdirTemp`-backed session directory.
+ *
+ * Four rather than the machine's eight cores, because the count was MEASURED
+ * rather than assumed. Regenerating the whole corpus from blanked
+ * `-- expected_rows --` on an 8-core box: 629s in one process, 231s at 4 legs,
+ * 252s at 8. The extra four legs buy nothing and cost a little, because chDB
+ * threads WITHIN a single query as well — a leg already uses more than one core,
+ * so eight of them oversubscribe rather than spread. The margin over the serial
+ * walk (2.7x) is where the win is; the margin between 4 and 8 is contention.
+ *
+ * Four also leaves room for the siblings: during `update-golden all` the five
+ * other STAGE_BODY shards (logql/traceql/chsql/optimizer/codegen) are running
+ * beside these legs, so the promql fan-out is not alone on the machine.
+ */
+const ROUNDTRIP_FANOUT = 4;
+
+/**
  * The shard table: one entry per independently-regenerable artefact group.
  *
  * Each entry declares only facts that are the shard's own definition — what it
@@ -82,7 +116,9 @@ export const STAGE_POST = 2;
  *   recipe     the existing `just` recipe that regenerates it, when it has one.
  *   generators `go test` invocations that regenerate it, and — for every shard,
  *              recipe-backed or not — the packages whose dep closure defines
- *              which source changes can move what it records.
+ *              which source changes can move what it records. A generator may
+ *              declare `fanOut: N` when its corpus walk is partitionable, which
+ *              expands it into N concurrent processes over disjoint slices.
  *   shardTree  a tree of one JSON shard per fixture, whose layout names the
  *              corpus it derives from. Mutually exclusive with `corpus`.
  *   corpus     data-input roots for a shard whose artefacts do not name them.
@@ -93,7 +129,12 @@ export const SHARDS = {
     goldens: ['test/spec/promql'],
     generators: [
       { pkgs: ['./internal/promql/'], run: '^TestLower$' },
-      { pkgs: ['./test/spec/promql/'], tags: ['chdb'], run: '^TestRoundTripChDB$' },
+      {
+        pkgs: ['./test/spec/promql/'],
+        tags: ['chdb'],
+        run: '^TestRoundTripChDB$',
+        fanOut: ROUNDTRIP_FANOUT,
+      },
     ],
   },
   logql: {
@@ -240,14 +281,23 @@ export function needsChdb(names) {
 }
 
 /**
- * The concrete commands that regenerate one shard, in order. A recipe-backed
- * shard delegates to its existing `just` recipe so the command stays defined in
+ * The concrete STEPS that regenerate one shard, in order. A recipe-backed shard
+ * delegates to its existing `just` recipe so the command stays defined in
  * exactly one place; everything else is a scoped `go test`.
  *
  * The scoping is the point of #1898's item 3: the pre-shard body ran
  * `GOLDEN_UPDATE=1 go test ./...`, compiling and running 74 packages to
  * regenerate goldens in five of them — and letting any unrelated failing test
  * abort the regeneration halfway through.
+ *
+ * A step is either a single `{argv, env}` command or an ARRAY of them. The array
+ * form is a fan-out: those commands partition one generator's corpus between
+ * them (`fanOut: N` on the generator), share no output fixture, and are meant to
+ * run concurrently — but still strictly between the step before and the step
+ * after, because a shard's generator ORDER is a real data dependency (promql's
+ * `TestLower` writes the `-- sql --` that `TestRoundTripChDB` then executes).
+ * Callers that cannot run anything concurrently flatten with [flattenSteps] and
+ * get the same total work, serially.
  */
 export function commandsFor(name, { justExecutable = 'just' } = {}) {
   const shard = SHARDS[name];
@@ -269,8 +319,36 @@ export function commandsFor(name, { justExecutable = 'just' } = {}) {
     if ((g.tags ?? []).length > 0) argv.push('-tags', g.tags.join(','));
     if (g.run) argv.push('-run', g.run);
     argv.push(...g.pkgs);
-    return { argv, env: { [GOLDEN_UPDATE_ENV]: '1' } };
+
+    const env = { [GOLDEN_UPDATE_ENV]: '1' };
+    if (!g.fanOut || g.fanOut <= 1) return { argv, env };
+
+    // One command per corpus slice. The INDEX is 1-based and the legs are
+    // contiguous 1..N, because that is what the partition on the Go side
+    // divides by: an index outside [1, N] names a slice that does not exist,
+    // so that leg regenerates nothing while the slice it should have owned is
+    // owned by nobody — and every leg still exits 0.
+    return Array.from({ length: g.fanOut }, (_, i) => ({
+      argv,
+      env: {
+        ...env,
+        [SPEC_SHARD_INDEX_ENV]: String(i + 1),
+        [SPEC_SHARD_COUNT_ENV]: String(g.fanOut),
+      },
+    }));
   });
+}
+
+/** Every command in a step list, fan-outs expanded, order preserved. */
+export function flattenSteps(steps) {
+  return steps.flatMap((step) => (Array.isArray(step) ? step : [step]));
+}
+
+/** A short name distinguishing one command of a fanned-out step: `promql[3/8]`. */
+export function stepLabel(name, env) {
+  const index = env[SPEC_SHARD_INDEX_ENV];
+  const count = env[SPEC_SHARD_COUNT_ENV];
+  return index && count ? `${name}[${index}/${count}]` : name;
 }
 
 // ---------------------------------------------------------------------------

--- a/.github/scripts/post-merge-golden-drift.mjs
+++ b/.github/scripts/post-merge-golden-drift.mjs
@@ -75,6 +75,7 @@ import {
   SHARDS,
   commandsFor,
   corpusRootsFor,
+  flattenSteps,
   generatorPackageDirs,
   impliedShards,
   orderShards,
@@ -237,7 +238,12 @@ function shardsToCheck(changed) {
 
 function regenerate(name) {
   const justExecutable = process.env.JUST_EXECUTABLE || 'just';
-  for (const { argv, env } of commandsFor(name, { justExecutable })) {
+  // Fan-outs are flattened and run one after another here. Each leg covers a
+  // disjoint slice, so the union is identical either way and only the wall
+  // clock differs — and this lane is a drift CHECK on `main` whose output must
+  // stay a single readable stream (stdio is inherited, not line-tagged), which
+  // concurrent children would interleave.
+  for (const { argv, env } of flattenSteps(commandsFor(name, { justExecutable }))) {
     log(`==> ${name}: ${argv.join(' ')}`);
     const r = spawnSync(argv[0], argv.slice(1), {
       cwd: repoRoot,

--- a/Justfile
+++ b/Justfile
@@ -509,6 +509,17 @@ update-coverage-floor:
 #   is silently skipped (#1096 native_resample_offset, #1098
 #   increase_left_edge_scan_bound).
 #
+# Within a shard, generators still run in declaration order, because that order
+# IS a data dependency. One of them — promql's `TestRoundTripChDB`, which walks
+# ~570 fixtures through chDB and was the longest single step of the whole recipe
+# — additionally fans OUT across several processes over disjoint slices of its
+# own corpus, and the next generator waits for all of them. Processes rather than
+# goroutines because chdb-go caches one session per PROCESS and the runner tears
+# that singleton down between fixtures for isolation (#1987), so in-process
+# parallelism would race the teardown. `.github/scripts/lib/golden-shards.mjs`
+# declares the leg count; test/spec/shard.go partitions the corpus by a hash of
+# the fixture name, so enrolling fixtures does not re-shuffle the existing ones.
+#
 # Every chdb-tagged shard (promql, logql, traceql, cardinality) requires
 # libchdb.so (`just chdb-install`); the runner fails fast without it rather than
 # leaving stale `-- expected_rows --` behind (the PR #758 failure mode).

--- a/test/perf/profile/shard.go
+++ b/test/perf/profile/shard.go
@@ -7,157 +7,60 @@
 
 package profile
 
-import (
-	"fmt"
-	"hash/fnv"
-	"os"
-	"strconv"
-)
+import "github.com/tsouza/cerberus/test/spec"
 
-// The shard contract between CI and this package. `perf-guards-shard` in
-// .github/workflows/chdb.yml sets both on every matrix leg — INDEX from
-// `matrix.shard`, COUNT from `strategy.job-total`, so the count is derived from
-// the matrix itself and cannot drift from the number of legs that actually run.
+// This file is the PERF lane's binding of the shared corpus partition, not a
+// second implementation of it. The partition function itself lives in
+// test/spec/shard.go, next to the TXTAR corpus it splits, and is shared with the
+// spec lane's own process-level split (`spec.WalkShard`).
 //
-// Naming mirrors the CRAWL_SHARD_INDEX / CRAWL_SHARD_COUNT contract
-// .github/scripts/dashboard-matrix.mjs documents for the e2e crawl frontier.
+// One implementation is load-bearing rather than tidy. The properties this
+// package's shard_test.go asserts — total disjoint cover, balance, and the
+// PINNED FNV-1a assignments — are the properties both lanes depend on, and a
+// second copy of the arithmetic would satisfy them on the day it was written and
+// then drift silently: the copies only disagree about which fixture lands where,
+// which no test that treats each partition in isolation can see.
 const (
 	ShardIndexEnv = "PERF_SHARD_INDEX"
 	ShardCountEnv = "PERF_SHARD_COUNT"
 )
-
-// shardHashMask clears the top bit of the 32-bit FNV digest, bounding it below
-// 2^31 so it converts to a non-negative int on every platform. See [ShardOf]
-// for why the fold is done in signed arithmetic rather than unsigned.
-const shardHashMask = 1<<31 - 1
 
 // Shard is a deterministic partition of the profiled corpus into Count disjoint
 // pieces, of which this process owns piece Index. Index is 1-BASED so it reads
 // the same as the shard's own CI check name (`perf-guards-shard (3)` owns
 // Shard{Index: 3}) — an off-by-one between the two would silently double-profile
 // one slice and never profile another.
-type Shard struct {
-	Index int
-	Count int
-}
+type Shard = spec.Shard
 
 // WholeCorpus is the unpartitioned corpus: one shard holding everything. It is
 // the default whenever the environment declares no partition, so a local
 // `just perf-chdb`, `just update-cardinality-baseline` and the nightly
 // perf-profile lane all behave exactly as they did before sharding existed.
-var WholeCorpus = Shard{Index: 1, Count: 1}
-
-// IsWhole reports whether this shard is the entire corpus. The baseline WRITER
-// must refuse to run on anything else: `mustWrite` prunes every shard file it
-// was not handed, so regenerating from a partial profile would silently delete
-// the rows belonging to the other shards.
-func (s Shard) IsWhole() bool { return s.Count <= 1 }
-
-// Holds reports whether fixtureID belongs to this shard.
-func (s Shard) Holds(fixtureID string) bool {
-	if s.IsWhole() {
-		return true
-	}
-	return ShardOf(fixtureID, s.Count) == s.Index
-}
-
-func (s Shard) String() string {
-	if s.IsWhole() {
-		return "whole corpus"
-	}
-	return fmt.Sprintf("shard %d/%d", s.Index, s.Count)
-}
+//
+// The baseline WRITER must refuse to run on anything else (`IsWhole`):
+// `mustWrite` prunes every shard file it was not handed, so regenerating from a
+// partial profile would silently delete the rows belonging to the other shards.
+var WholeCorpus = spec.WholeCorpus
 
 // ShardOf is the partition function: the 1-based shard a fixture id belongs to
-// when the corpus is split Count ways.
-//
-// It hashes the fixture ID rather than slicing the SORTED corpus into Count
-// contiguous runs, and that choice is the whole point. A positional partition
-// re-assigns roughly half the corpus every time a fixture is added or removed
-// anywhere but the end — so a shard's membership, and therefore its wall-clock,
-// jitters run to run and a slow shard can never be attributed to anything. A
-// hash of the id is a pure function of that ONE fixture: enrolling 150 new
-// promql fixtures leaves every existing fixture on the shard it was already on,
-// and the new ones spread evenly across all of them.
-//
-// FNV-1a is chosen for being stable ACROSS Go releases (it is a specified
-// algorithm with fixed constants, unlike maphash, whose seed is deliberately
-// per-process) — a partition that changed under a toolchain bump would silently
-// re-shuffle the corpus and make the ratchet's added/removed diff scream on a
-// PR that touched nothing.
-func ShardOf(fixtureID string, count int) int {
-	if count <= 1 {
-		return 1
-	}
-	h := fnv.New32a()
-	// hash.Hash's Write never returns an error (documented on the interface).
-	_, _ = h.Write([]byte(fixtureID))
-	// Fold the digest into the shard range with the modulo taken in SIGNED
-	// arithmetic, so no int -> uint32 conversion happens at all.
-	//
-	// The natural spelling, `h.Sum32() % uint32(count)`, converts count — a
-	// signed int — to unsigned, and gosec rejects it as G115. That rejection
-	// is right rather than pedantic: the conversion silently WRAPS a negative
-	// count into a huge modulus instead of failing, so a caller that got its
-	// count from somewhere unvalidated would get a plausible-looking shard
-	// number out of a nonsensical partition. Restating `count > 0` next to the
-	// conversion does not help, because the value being converted is still of
-	// a type that can hold negatives.
-	//
-	// Masking off the digest's sign bit first is what removes the question.
-	// The result is below 2^31, which fits in an int on every platform Go
-	// supports (int is at least 32 bits), so the remaining `int(...)` widens
-	// rather than truncates and the modulo is plain int arithmetic against
-	// count itself. The cost is one bit of hash width — irrelevant for a
-	// partition into single digits of shards.
-	return int(h.Sum32()&shardHashMask)%count + 1
-}
+// when the corpus is split Count ways. See [spec.ShardOf] for why it hashes the
+// id (FNV-1a) rather than slicing the sorted corpus positionally.
+func ShardOf(fixtureID string, count int) int { return spec.ShardOf(fixtureID, count) }
 
-// ShardFromEnv reads the partition this process owns from the environment.
+// ShardFromEnv reads the partition this process owns from PERF_SHARD_INDEX /
+// PERF_SHARD_COUNT. `perf-guards-shard` in .github/workflows/chdb.yml sets both
+// on every matrix leg — INDEX from `matrix.shard`, COUNT from
+// `strategy.job-total`, so the count is derived from the matrix itself and
+// cannot drift from the number of legs that actually run.
 //
-// Both variables unset means [WholeCorpus] — the local and nightly default.
-// Anything else is validated strictly and returns an error rather than falling
-// back, because every failure mode here is silent in the direction that matters:
-// a shard that quietly widens to the whole corpus turns an 8-way split back into
-// eight serial full runs, and a shard that quietly narrows to nothing reports a
-// green check over a corpus slice nothing profiled.
-func ShardFromEnv() (Shard, error) {
-	rawIndex, hasIndex := os.LookupEnv(ShardIndexEnv)
-	rawCount, hasCount := os.LookupEnv(ShardCountEnv)
+// Both unset means [WholeCorpus]; anything else is validated strictly rather
+// than falling back, because both silent failure modes report green. See
+// [spec.ShardFromEnvNames].
+func ShardFromEnv() (Shard, error) { return spec.ShardFromEnvNames(ShardIndexEnv, ShardCountEnv) }
 
-	switch {
-	case !hasIndex && !hasCount:
-		return WholeCorpus, nil
-	case hasIndex != hasCount:
-		// Half a contract is worse than none: with only COUNT set the index
-		// is unknowable, and with only INDEX set the natural fallback
-		// (count=1) profiles the whole corpus on every leg — the exact
-		// serial-run-times-N outcome the split exists to remove, reported as
-		// N green checks.
-		return Shard{}, fmt.Errorf(
-			"%s and %s must be set together (got %s=%q, %s=%q); a half-declared shard either profiles "+
-				"the whole corpus on every leg or profiles none of it, and both report green",
-			ShardIndexEnv, ShardCountEnv, ShardIndexEnv, rawIndex, ShardCountEnv, rawCount,
-		)
-	}
-
-	count, err := strconv.Atoi(rawCount)
-	if err != nil {
-		return Shard{}, fmt.Errorf("%s=%q is not an integer: %w", ShardCountEnv, rawCount, err)
-	}
-	index, err := strconv.Atoi(rawIndex)
-	if err != nil {
-		return Shard{}, fmt.Errorf("%s=%q is not an integer: %w", ShardIndexEnv, rawIndex, err)
-	}
-	if count < 1 {
-		return Shard{}, fmt.Errorf("%s=%d must be >= 1", ShardCountEnv, count)
-	}
-	if index < 1 || index > count {
-		return Shard{}, fmt.Errorf("%s=%d is outside [1, %s=%d] — the corpus slice it names does not exist, "+
-			"so this leg would profile nothing and pass",
-			ShardIndexEnv, index, ShardCountEnv, count)
-	}
-	return Shard{Index: index, Count: count}, nil
+// FilterShard returns the subset of ids this shard holds, preserving order.
+func FilterShard[T any](s Shard, items []T, idOf func(T) string) []T {
+	return spec.FilterShard(s, items, idOf)
 }
 
 // FilterShardMap returns the entries of a fixture-id-keyed map this shard
@@ -165,28 +68,5 @@ func ShardFromEnv() (Shard, error) {
 // its slice of the corpus against the SAME slice of the committed baseline, or
 // every fixture the leg does not own reads as removed.
 func FilterShardMap[V any](s Shard, m map[string]V) map[string]V {
-	if s.IsWhole() {
-		return m
-	}
-	out := make(map[string]V, len(m)/s.Count+1)
-	for id, v := range m {
-		if s.Holds(id) {
-			out[id] = v
-		}
-	}
-	return out
-}
-
-// FilterShard returns the subset of ids this shard holds, preserving order.
-func FilterShard[T any](s Shard, items []T, idOf func(T) string) []T {
-	if s.IsWhole() {
-		return items
-	}
-	out := make([]T, 0, len(items)/s.Count+1)
-	for _, it := range items {
-		if s.Holds(idOf(it)) {
-			out = append(out, it)
-		}
-	}
-	return out
+	return spec.FilterShardMap(s, m)
 }

--- a/test/regression/golden_shard_fanout_test.go
+++ b/test/regression/golden_shard_fanout_test.go
@@ -1,0 +1,217 @@
+package regression
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// The promql shard's two generators, in the order the shard declares them:
+// `TestLower` writes each fixture's `-- sql --`, and `TestRoundTripChDB` then
+// EXECUTES that freshly-written SQL to fill `-- expected_rows --`. Only the
+// second is fanned out; the ordering between them is a data dependency and the
+// fan-out must not dissolve it.
+// promqlShard is the shard whose round-trip generator is fanned out.
+const promqlShard = "promql"
+
+const (
+	promqlLowerGenerator     = "^TestLower$"
+	promqlRoundTripGenerator = "^TestRoundTripChDB$"
+)
+
+// The env pair the fanned-out legs declare their corpus slice through. These
+// spellings are the CONTRACT between .github/scripts/lib/golden-shards.mjs,
+// which writes them, and test/spec/shard.go's ShardFromEnv, which reads them.
+const (
+	specShardIndexEnv = "SPEC_SHARD_INDEX"
+	specShardCountEnv = "SPEC_SHARD_COUNT"
+)
+
+// specShardSourcePath is the Go side of that contract.
+const specShardSourcePath = "../spec/shard.go"
+
+// specShardTestPath declares the count the partition's cover and balance
+// properties are asserted at.
+const specShardTestPath = "../spec/shard_test.go"
+
+// goldenUpdateShardCountRe reads that count.
+var goldenUpdateShardCountRe = regexp.MustCompile(`(?m)^const goldenUpdateShardCount = (\d+)`)
+
+// planLegs returns the (index, count) pairs of every plan line belonging to the
+// named shard that runs the given generator, in plan order.
+//
+// Scoping to the shard is not cosmetic: `TestRoundTripChDB` is the generator
+// name in ALL THREE head shards, so an unscoped match would pull in the logql
+// and traceql commands — neither of which is fanned out — and read their absent
+// partition as a promql leg that forgot to declare one.
+func planLegs(t *testing.T, plan []string, shard, generator string) (indices, counts []int, lines []string) {
+	t.Helper()
+
+	for _, line := range plan {
+		if !planLineIsShard(line, shard) || !strings.Contains(line, generator) {
+			continue
+		}
+		lines = append(lines, line)
+		index, hasIndex := planEnvValue(line, specShardIndexEnv)
+		count, hasCount := planEnvValue(line, specShardCountEnv)
+		if !hasIndex || !hasCount {
+			continue
+		}
+		i, err := strconv.Atoi(index)
+		if err != nil {
+			t.Fatalf("plan line declares a non-integer %s=%q:\n%s", specShardIndexEnv, index, line)
+		}
+		c, err := strconv.Atoi(count)
+		if err != nil {
+			t.Fatalf("plan line declares a non-integer %s=%q:\n%s", specShardCountEnv, count, line)
+		}
+		indices = append(indices, i)
+		counts = append(counts, c)
+	}
+	return indices, counts, lines
+}
+
+// planLineIsShard reports whether a `<stage> <shard> <command>` plan line
+// belongs to the named shard.
+func planLineIsShard(line, shard string) bool {
+	fields := strings.Fields(line)
+	return len(fields) > 1 && fields[1] == shard
+}
+
+// planEnvValue extracts `NAME=value` from a plan line.
+func planEnvValue(line, name string) (string, bool) {
+	for _, field := range strings.Fields(line) {
+		if after, ok := strings.CutPrefix(field, name+"="); ok {
+			return after, true
+		}
+	}
+	return "", false
+}
+
+// TestGoldenUpdateFansOutTheRoundTripBody pins the split that makes
+// `just update-golden promql` finish in minutes rather than in one long serial
+// walk, and — more importantly — pins the two ways that split can silently stop
+// working while every leg still exits 0.
+//
+// The first is a fan-out that collapsed back to one command: the recipe is then
+// exactly as slow as it was before, and nothing says so. The second is a leg
+// list that is not the contiguous 1..N the partition divides by — an index
+// outside [1, N] names a corpus slice that does not exist, so that leg
+// regenerates nothing while the slice it should have owned is owned by nobody,
+// and `update-golden` returns a diff that only LOOKS complete. That is the #1573
+// staleness trap re-entered through the parallelism.
+func TestGoldenUpdateFansOutTheRoundTripBody(t *testing.T) {
+	t.Parallel()
+
+	plan := goldenUpdatePlan(t)
+	indices, counts, lines := planLegs(t, plan, promqlShard, promqlRoundTripGenerator)
+
+	if len(lines) < 2 {
+		t.Fatalf("the `all` plan runs %s as %d command(s). It walks the ~570-fixture PromQL corpus "+
+			"through chDB and is the longest single step of the recipe; a fan-out that collapsed to "+
+			"one command is the serial walk back, under a name that says otherwise.\n%s",
+			promqlRoundTripGenerator, len(lines), strings.Join(lines, "\n"))
+	}
+	if len(indices) != len(lines) {
+		t.Fatalf("%d of the %d %s commands declare no %s / %s pair. A leg with no partition walks the "+
+			"WHOLE corpus, so every such leg redoes all the work the split exists to divide — and "+
+			"several processes rewrite the same fixture files at once.\n%s",
+			len(lines)-len(indices), len(lines), promqlRoundTripGenerator,
+			specShardIndexEnv, specShardCountEnv, strings.Join(lines, "\n"))
+	}
+
+	sorted := append([]int(nil), indices...)
+	sort.Ints(sorted)
+	want := make([]int, 0, len(sorted))
+	for i := range sorted {
+		want = append(want, i+1)
+	}
+	if fmt.Sprint(sorted) != fmt.Sprint(want) {
+		t.Errorf("the fan-out declares legs %v, which is not the contiguous 1..%d the partition "+
+			"divides by. An index outside [1, %d] owns a slice that does not exist, and some slice "+
+			"that does exist is owned by nobody — with every leg green.\n%s",
+			sorted, len(sorted), len(sorted), strings.Join(lines, "\n"))
+	}
+	for _, c := range counts {
+		if c != len(lines) {
+			t.Errorf("a leg declares %s=%d while the fan-out dispatches %d commands. The count is what "+
+				"the partition divides by, so a mismatch re-slices the corpus into pieces the leg list "+
+				"does not cover.\n%s", specShardCountEnv, c, len(lines), strings.Join(lines, "\n"))
+		}
+	}
+
+	// The fan-out parallelises ONE generator; it must not reorder the shard's
+	// generators against each other. TestRoundTripChDB executes the `-- sql --`
+	// TestLower writes, so a leg that started first would execute the previous
+	// run's SQL — or, for a brand-new fixture, an empty section.
+	lowerAt := -1
+	for i, line := range plan {
+		if planLineIsShard(line, promqlShard) && strings.Contains(line, promqlLowerGenerator) {
+			lowerAt = i
+			break
+		}
+	}
+	if lowerAt == -1 {
+		t.Fatalf("the `all` plan runs no %s step, so nothing writes the `-- sql --` the round-trip "+
+			"legs execute:\n%s", promqlLowerGenerator, strings.Join(plan, "\n"))
+	}
+	for i, line := range plan {
+		if planLineIsShard(line, promqlShard) && strings.Contains(line, promqlRoundTripGenerator) && i < lowerAt {
+			t.Errorf("a round-trip leg runs at plan step %d, before %s at step %d. The legs execute "+
+				"the SQL that step writes.\n%s", i, promqlLowerGenerator, lowerAt, line)
+		}
+	}
+
+	for _, line := range lines {
+		if !strings.Contains(line, goldenUpdateEnvMarker) {
+			t.Errorf("a fanned-out leg does not carry %s, so it ASSERTS the goldens instead of "+
+				"rewriting them — the regeneration silently becomes a check.\n%s",
+				goldenUpdateEnvMarker, line)
+		}
+	}
+}
+
+// TestGoldenUpdateFanOutMatchesTheGoPartition pins the two halves of the split
+// against each other: the .mjs side that WRITES the shard variables and the Go
+// side that READS them.
+//
+// This is the hollow-green case, and it is invisible from either side alone.
+// Rename the pair on one side only and `spec.ShardFromEnv` finds nothing, falls
+// back to the whole corpus by design, and every one of the N legs walks all ~570
+// fixtures: N times the work, N concurrent writers on each fixture file, and N
+// green legs. Nothing in the output distinguishes it from a working fan-out
+// except the wall clock.
+func TestGoldenUpdateFanOutMatchesTheGoPartition(t *testing.T) {
+	t.Parallel()
+
+	src := readFileString(t, specShardSourcePath)
+	for _, env := range []string{specShardIndexEnv, specShardCountEnv} {
+		if !strings.Contains(src, `"`+env+`"`) {
+			t.Errorf("%s does not read %q, but the regeneration plan sets it. A leg whose partition "+
+				"variables the walk does not read falls back to the WHOLE corpus and reports green "+
+				"after redoing every other leg's work.", specShardSourcePath, env)
+		}
+	}
+
+	partitionTest := readFileString(t, specShardTestPath)
+	declared := goldenUpdateShardCountRe.FindStringSubmatch(partitionTest)
+	if declared == nil {
+		t.Fatalf("%s declares no `const goldenUpdateShardCount` — the partition's cover and balance "+
+			"assertions no longer say which leg count they hold at", specShardTestPath)
+	}
+	asserted, err := strconv.Atoi(declared[1])
+	if err != nil {
+		t.Fatalf("%s declares a non-integer goldenUpdateShardCount %q", specShardTestPath, declared[1])
+	}
+
+	_, _, lines := planLegs(t, goldenUpdatePlan(t), promqlShard, promqlRoundTripGenerator)
+	if len(lines) != asserted {
+		t.Errorf("the plan fans out to %d legs while %s asserts the partition's cover and balance at "+
+			"%d. Those properties are evidence about this recipe only while the two agree: let them "+
+			"drift and the balance floor is measured at a split nobody runs.",
+			len(lines), specShardTestPath, asserted)
+	}
+}

--- a/test/spec/promql/roundtrip_chdb_test.go
+++ b/test/spec/promql/roundtrip_chdb_test.go
@@ -20,11 +20,29 @@ import (
 	"github.com/tsouza/cerberus/test/spec"
 )
 
+// TestRoundTripChDB walks the slice of the PromQL corpus this process owns.
+//
+// With SPEC_SHARD_INDEX / SPEC_SHARD_COUNT unset — a hand-typed
+// `go test -tags chdb ./test/spec/promql/`, or CI's `roundtrip (promql)` job —
+// that slice is the whole corpus and this behaves exactly as it did before the
+// partition existed. `just update-golden promql` sets the pair and fans the
+// generator out across several processes instead
+// (.github/scripts/lib/golden-shards.mjs), because this walk is the single
+// longest step in that recipe and it cannot be parallelised in-process: the
+// subtests share chdb-go's package-level session singleton, which
+// spec.resetChDBSession deliberately tears down and rebuilds between fixtures
+// for cross-fixture isolation (#1987), so a t.Parallel() here would race two
+// goroutines against that teardown. A separate process has its own singleton.
 func TestRoundTripChDB(t *testing.T) {
 	t.Parallel()
 
+	shard, err := spec.ShardFromEnv()
+	if err != nil {
+		t.Fatalf("round-trip corpus shard: %v", err)
+	}
+
 	dir := filepath.Join(".")
-	spec.Walk(t, dir, func(t *testing.T, c *spec.Case) {
+	spec.WalkShard(t, dir, shard, func(t *testing.T, c *spec.Case) {
 		// LoadRoundTrip + IsRoundTrip is the opt-in gate; fixtures
 		// without seed/expected_rows are silent no-ops.
 		spec.RunRoundTrip(t, c)

--- a/test/spec/runner.go
+++ b/test/spec/runner.go
@@ -20,6 +20,11 @@ import (
 // regeneration of the expected sections in TXTAR fixtures.
 const envGoldenUpdate = "GOLDEN_UPDATE"
 
+// fixtureExt is the suffix every spec fixture carries. A fixture's NAME — its
+// subtest name, and the id the corpus partition hashes (see shard.go) — is its
+// basename with this trimmed off.
+const fixtureExt = ".txtar"
+
 // Case is a single TXTAR fixture loaded from disk.
 type Case struct {
 	// Path is the absolute path of the fixture file.
@@ -58,32 +63,24 @@ func Load(path string) (*Case, error) {
 		return nil, err
 	}
 	a := txtar.Parse(data)
-	name := strings.TrimSuffix(filepath.Base(path), ".txtar")
-	return &Case{Path: path, Name: name, archive: a}, nil
+	return &Case{Path: path, Name: trimFixtureExt(filepath.Base(path)), archive: a}, nil
+}
+
+// trimFixtureExt turns a fixture filename into the fixture's name.
+func trimFixtureExt(base string) string {
+	return strings.TrimSuffix(base, fixtureExt)
 }
 
 // Walk loads every *.txtar fixture under dir (non-recursive) and calls fn
 // inside a t.Run subtest named after each fixture. Fixtures are visited in
 // sorted order for stable output.
+//
+// This is [WalkShard] over the whole corpus. A caller that wants to spread the
+// walk across several PROCESSES — the only parallelism a chdb-tagged walk can
+// take, see WalkShard — passes a partition there instead.
 func Walk(t *testing.T, dir string, fn func(t *testing.T, c *Case)) {
 	t.Helper()
-	matches, err := filepath.Glob(filepath.Join(dir, "*.txtar"))
-	if err != nil {
-		t.Fatalf("spec.Walk: glob %q: %v", dir, err)
-	}
-	if len(matches) == 0 {
-		t.Fatalf("spec.Walk: no *.txtar fixtures in %s", dir)
-	}
-	sort.Strings(matches)
-	for _, m := range matches {
-		c, err := Load(m)
-		if err != nil {
-			t.Fatalf("spec.Walk: load %s: %v", m, err)
-		}
-		t.Run(c.Name, func(t *testing.T) {
-			fn(t, c)
-		})
-	}
+	WalkShard(t, dir, WholeCorpus, fn)
 }
 
 // Match asserts that each (section, actual) pair matches what's stored on

--- a/test/spec/shard.go
+++ b/test/spec/shard.go
@@ -1,0 +1,252 @@
+// Deliberately NOT `//go:build chdb`. The corpus PARTITION is pure arithmetic
+// over a fixture name — no chDB, no seeding, no SQL — so keeping it untagged
+// means its unit test (shard_test.go) runs in the ordinary `check` lane, where a
+// partition bug is caught in seconds, instead of only inside the chdb-tagged
+// lane the partition exists to speed up.
+
+package spec
+
+import (
+	"fmt"
+	"hash/fnv"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"testing"
+)
+
+// The shard contract between a corpus-walking test and whatever launched it.
+//
+// The names are SPEC_-prefixed rather than shared with the perf lane's
+// PERF_SHARD_INDEX / PERF_SHARD_COUNT (test/perf/profile/shard.go) on purpose:
+// the two partitions cover different corpora at different counts, and a single
+// `go test ./...` can link both. One shared pair of variables would let a
+// `perf-guards-shard (3)` leg silently narrow an unrelated spec walk to a third
+// of its fixtures — a green run over a slice nobody asked to slice.
+const (
+	ShardIndexEnv = "SPEC_SHARD_INDEX"
+	ShardCountEnv = "SPEC_SHARD_COUNT"
+)
+
+// shardHashMask clears the top bit of the 32-bit FNV digest, bounding it below
+// 2^31 so it converts to a non-negative int on every platform. See [ShardOf]
+// for why the fold is done in signed arithmetic rather than unsigned.
+const shardHashMask = 1<<31 - 1
+
+// Shard is a deterministic partition of a fixture corpus into Count disjoint
+// pieces, of which this process owns piece Index. Index is 1-BASED so it reads
+// the same as the leg's own name (`promql[3/8]` owns Shard{Index: 3, Count: 8})
+// — an off-by-one between the two would silently walk one slice twice and never
+// walk another.
+type Shard struct {
+	Index int
+	Count int
+}
+
+// WholeCorpus is the unpartitioned corpus: one shard holding everything. It is
+// the default whenever the environment declares no partition, so a hand-run
+// `go test -tags chdb ./test/spec/promql/` still walks every fixture exactly as
+// it did before sharding existed.
+var WholeCorpus = Shard{Index: 1, Count: 1}
+
+// IsWhole reports whether this shard is the entire corpus.
+func (s Shard) IsWhole() bool { return s.Count <= 1 }
+
+// Holds reports whether fixtureID belongs to this shard.
+func (s Shard) Holds(fixtureID string) bool {
+	if s.IsWhole() {
+		return true
+	}
+	return ShardOf(fixtureID, s.Count) == s.Index
+}
+
+func (s Shard) String() string {
+	if s.IsWhole() {
+		return "whole corpus"
+	}
+	return fmt.Sprintf("shard %d/%d", s.Index, s.Count)
+}
+
+// ShardOf is the partition function: the 1-based shard a fixture id belongs to
+// when the corpus is split Count ways.
+//
+// It hashes the fixture id rather than slicing the SORTED corpus into Count
+// contiguous runs, and that choice is the whole point. A positional partition
+// re-assigns roughly half the corpus every time a fixture is added or removed
+// anywhere but the end — so a shard's membership, and therefore its wall-clock,
+// jitters run to run and a slow shard can never be attributed to anything. A
+// hash of the id is a pure function of that ONE fixture: enrolling 150 new
+// promql fixtures leaves every existing fixture on the shard it was already on,
+// and the new ones spread evenly across all of them.
+//
+// FNV-1a is chosen for being stable ACROSS Go releases (it is a specified
+// algorithm with fixed constants, unlike maphash, whose seed is deliberately
+// per-process) — a partition that changed under a toolchain bump would silently
+// re-shuffle the corpus and move every leg's wall-clock at once, with no diff to
+// explain it.
+func ShardOf(fixtureID string, count int) int {
+	if count <= 1 {
+		return 1
+	}
+	h := fnv.New32a()
+	// hash.Hash's Write never returns an error (documented on the interface).
+	_, _ = h.Write([]byte(fixtureID))
+	// Fold the digest into the shard range with the modulo taken in SIGNED
+	// arithmetic, so no int -> uint32 conversion happens at all.
+	//
+	// The natural spelling, `h.Sum32() % uint32(count)`, converts count — a
+	// signed int — to unsigned, and gosec rejects it as G115. That rejection
+	// is right rather than pedantic: the conversion silently WRAPS a negative
+	// count into a huge modulus instead of failing, so a caller that got its
+	// count from somewhere unvalidated would get a plausible-looking shard
+	// number out of a nonsensical partition.
+	//
+	// Masking off the digest's sign bit first is what removes the question.
+	// The result is below 2^31, which fits in an int on every platform Go
+	// supports (int is at least 32 bits), so the remaining `int(...)` widens
+	// rather than truncates and the modulo is plain int arithmetic against
+	// count itself. The cost is one bit of hash width — irrelevant for a
+	// partition into single digits of shards.
+	return int(h.Sum32()&shardHashMask)%count + 1
+}
+
+// ShardFromEnv reads the partition this process owns from [ShardIndexEnv] /
+// [ShardCountEnv]. See [ShardFromEnvNames] for the validation contract.
+func ShardFromEnv() (Shard, error) {
+	return ShardFromEnvNames(ShardIndexEnv, ShardCountEnv)
+}
+
+// ShardFromEnvNames reads the partition this process owns from the named pair of
+// environment variables. The pair is a parameter because two corpora are
+// partitioned by this function under two different contracts — the spec corpus
+// under SPEC_SHARD_*, the profiled perf corpus under PERF_SHARD_* — and each
+// must be able to declare its own without inheriting the other's.
+//
+// Both variables unset means [WholeCorpus] — the hand-run default. Anything else
+// is validated strictly and returns an error rather than falling back, because
+// every failure mode here is silent in the direction that matters: a shard that
+// quietly widens to the whole corpus turns an 8-way split back into eight serial
+// full runs, and a shard that quietly narrows to nothing reports a green run
+// over a corpus slice nothing walked.
+func ShardFromEnvNames(indexEnv, countEnv string) (Shard, error) {
+	rawIndex, hasIndex := os.LookupEnv(indexEnv)
+	rawCount, hasCount := os.LookupEnv(countEnv)
+
+	switch {
+	case !hasIndex && !hasCount:
+		return WholeCorpus, nil
+	case hasIndex != hasCount:
+		// Half a contract is worse than none: with only COUNT set the index
+		// is unknowable, and with only INDEX set the natural fallback
+		// (count=1) walks the whole corpus on every leg — the exact
+		// serial-run-times-N outcome the split exists to remove, reported as
+		// N green legs.
+		return Shard{}, fmt.Errorf(
+			"%s and %s must be set together (got %s=%q, %s=%q); a half-declared shard either walks "+
+				"the whole corpus on every leg or walks none of it, and both report green",
+			indexEnv, countEnv, indexEnv, rawIndex, countEnv, rawCount,
+		)
+	}
+
+	count, err := strconv.Atoi(rawCount)
+	if err != nil {
+		return Shard{}, fmt.Errorf("%s=%q is not an integer: %w", countEnv, rawCount, err)
+	}
+	index, err := strconv.Atoi(rawIndex)
+	if err != nil {
+		return Shard{}, fmt.Errorf("%s=%q is not an integer: %w", indexEnv, rawIndex, err)
+	}
+	if count < 1 {
+		return Shard{}, fmt.Errorf("%s=%d must be >= 1", countEnv, count)
+	}
+	if index < 1 || index > count {
+		return Shard{}, fmt.Errorf("%s=%d is outside [1, %s=%d] — the corpus slice it names does not exist, "+
+			"so this leg would walk nothing and pass",
+			indexEnv, index, countEnv, count)
+	}
+	return Shard{Index: index, Count: count}, nil
+}
+
+// FilterShard returns the subset of items this shard holds, preserving order.
+func FilterShard[T any](s Shard, items []T, idOf func(T) string) []T {
+	if s.IsWhole() {
+		return items
+	}
+	out := make([]T, 0, len(items)/s.Count+1)
+	for _, it := range items {
+		if s.Holds(idOf(it)) {
+			out = append(out, it)
+		}
+	}
+	return out
+}
+
+// FilterShardMap returns the entries of a fixture-id-keyed map this shard holds.
+func FilterShardMap[V any](s Shard, m map[string]V) map[string]V {
+	if s.IsWhole() {
+		return m
+	}
+	out := make(map[string]V, len(m)/s.Count+1)
+	for id, v := range m {
+		if s.Holds(id) {
+			out[id] = v
+		}
+	}
+	return out
+}
+
+// WalkShard is [Walk] over one slice of a fixture directory: it loads every
+// *.txtar under dir (non-recursive), keeps the ones this shard holds, and calls
+// fn inside a t.Run subtest named after each. Fixtures are visited in sorted
+// order for stable output, exactly as Walk visits them.
+//
+// This is the ONLY safe way to spread a chdb-tagged corpus walk over more CPUs.
+// The in-process route — `t.Parallel()` on the subtests — races two goroutines
+// against chdb-go's process-wide `globalSession` singleton (chdb/session.go),
+// which runner_chdb.go's resetChDBSession deliberately tears down and rebuilds
+// between fixtures for cross-fixture isolation (#1987). Sharding at the PROCESS
+// level sidesteps that entirely: each leg is a separate address space and so
+// gets its own singleton and its own `os.MkdirTemp`-backed session directory.
+//
+// The partition is over the fixture NAME (the basename without `.txtar`), which
+// is unique within one corpus directory, so a leg's membership does not move
+// when a sibling fixture is added or removed.
+func WalkShard(t *testing.T, dir string, shard Shard, fn func(t *testing.T, c *Case)) {
+	t.Helper()
+
+	matches, err := filepath.Glob(filepath.Join(dir, "*"+fixtureExt))
+	if err != nil {
+		t.Fatalf("spec.WalkShard: glob %q: %v", dir, err)
+	}
+	if len(matches) == 0 {
+		t.Fatalf("spec.WalkShard: no *.txtar fixtures in %s", dir)
+	}
+	sort.Strings(matches)
+
+	mine := FilterShard(shard, matches, fixtureIDOfPath)
+	if len(mine) == 0 {
+		// A leg that walks nothing passes in the time it takes to boot, and
+		// reads as a fast green rather than as a slice nobody covered. With a
+		// count above the corpus size that is arithmetic, not a bug in the
+		// partition — but it is still a partition nobody should be running.
+		t.Fatalf("spec.WalkShard: %v holds none of the %d fixtures in %s — this leg would assert "+
+			"nothing and report green; the split is wider than the corpus", shard, len(matches), dir)
+	}
+
+	for _, m := range mine {
+		c, err := Load(m)
+		if err != nil {
+			t.Fatalf("spec.WalkShard: load %s: %v", m, err)
+		}
+		t.Run(c.Name, func(t *testing.T) {
+			fn(t, c)
+		})
+	}
+}
+
+// fixtureIDOfPath is the id [ShardOf] hashes: the fixture's basename without the
+// `.txtar` suffix, matching the name Walk gives its subtest.
+func fixtureIDOfPath(path string) string {
+	return trimFixtureExt(filepath.Base(path))
+}

--- a/test/spec/shard_test.go
+++ b/test/spec/shard_test.go
@@ -1,0 +1,361 @@
+// Untagged on purpose — see shard.go's header. The partition is the one part of
+// the sharded walk that decides WHAT gets walked, so it is also the one part
+// whose bug is invisible: a shard that silently holds the wrong slice rewrites
+// some fixtures' goldens twice and others' never, and every leg exits 0.
+
+package spec
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// shardedCorpusDir is the fixture directory the golden-update fan-out splits:
+// the PromQL corpus, by far the largest of the three heads, and the one whose
+// chdb-tagged round-trip dominates `just update-golden promql`'s wall clock.
+// Asserting the partition against the REAL corpus (rather than synthetic names
+// that would balance by construction) is what makes the balance floor evidence.
+const shardedCorpusDir = "promql"
+
+// goldenUpdateShardCount is the number of concurrent legs
+// `.github/scripts/lib/golden-shards.mjs` fans the promql shard's
+// `TestRoundTripChDB` generator out to. The balance assertion below is only
+// meaningful at the count the fan-out actually runs, and
+// test/regression/golden_shard_fanout_test.go pins the .mjs side to this same
+// number from the other direction.
+const goldenUpdateShardCount = 4
+
+// maxShardImbalance is how far the biggest leg may exceed the smallest, as a
+// ratio, over the real corpus at goldenUpdateShardCount. A hash partition
+// balances STATISTICALLY, not exactly: dropping ~570 names into 4 buckets is a
+// binomial with mean ≈142 and σ = √(569·¼·¾) ≈ 10.3, so a ±3σ swing spans
+// ≈111–173 and a max/min ratio near 1.6 is ordinary sampling noise, not a
+// defect. Today's corpus sits at 1.12 (153/137); a bound fitted to that would
+// fire on the next enrolment wave for no reason, which is how a gate becomes a
+// rubber stamp.
+//
+// So this is not a balance TARGET. It is the floor under "the partition still
+// spreads at all" — a constant hash, a modulus over the wrong value, or a name
+// set FNV clusters would land far outside it, and each of those turns the
+// fan-out's wall-clock back into one big leg while every leg reports green.
+const maxShardImbalance = 2.0
+
+// pinnedAssignments locks the partition FUNCTION, not just its shape. Every
+// property below (total cover, disjointness, balance) is equally satisfied by a
+// different hash — so swapping FNV-1a for anything else would keep them all
+// green while re-shuffling the entire corpus across legs. That re-shuffle is
+// harmless to correctness and expensive in confusion: every leg's wall-clock
+// moves at once and no diff explains it. These are goldens; changing them is the
+// deliberate act of changing the partition.
+//
+// They are also the cross-check on the perf lane's own pin
+// (test/perf/profile/shard_test.go), which hashes head-QUALIFIED ids through
+// this same function: two id shapes, one arithmetic.
+//
+// One fixture per leg, deliberately: a set that happened to cluster on one leg
+// would be satisfied by a partition that had DEGENERATED to that leg — the
+// constant-hash case, which is exactly what the balance floor below and these
+// goldens exist to catch between them.
+var pinnedAssignments = map[string]int{
+	"abs_metric":              1,
+	"agg_by_dotted_source":    2,
+	"absent_binary_no_series": 3,
+	"absent_with_series":      4,
+}
+
+func TestShardOfIsPinnedToFNV1a(t *testing.T) {
+	t.Parallel()
+
+	for name, want := range pinnedAssignments {
+		if got := ShardOf(name, goldenUpdateShardCount); got != want {
+			t.Errorf("ShardOf(%q, %d) = %d, want %d — the partition function changed. Every fixture in "+
+				"the corpus just moved to a different leg; per-leg wall-clock will move with it and "+
+				"nothing in the diff will say why. If the change is deliberate, re-pin these goldens.",
+				name, goldenUpdateShardCount, got, want)
+		}
+	}
+}
+
+func TestShardOfIsInRangeAndDeterministic(t *testing.T) {
+	t.Parallel()
+
+	for _, count := range []int{1, 2, 3, 8, 17} {
+		for i := range 500 {
+			name := fmt.Sprintf("synthetic_fixture_%d", i)
+			got := ShardOf(name, count)
+			if got < 1 || got > count {
+				t.Fatalf("ShardOf(%q, %d) = %d, outside [1, %d]", name, count, got, count)
+			}
+			if again := ShardOf(name, count); again != got {
+				t.Fatalf("ShardOf(%q, %d) is not deterministic: %d then %d", name, count, got, again)
+			}
+		}
+	}
+}
+
+// TestWalkShardIsATotalDisjointCover is THE correctness assertion for the
+// fan-out: the union of what the legs walk must reproduce, exactly, what the
+// unsharded walk walks.
+//
+// Both halves matter and both are silent. A fixture no leg holds never has its
+// `-- expected_rows --` regenerated, so `just update-golden promql` returns a
+// diff that looks complete and is not — the #1573 staleness trap re-entered
+// through the parallelism. A fixture two legs hold is regenerated twice, by two
+// processes, into the same file.
+//
+// This walks the corpus for real (through WalkShard itself, not through a
+// re-derivation of its filter) so the property is asserted about the code path
+// the fan-out runs.
+func TestWalkShardIsATotalDisjointCover(t *testing.T) {
+	t.Parallel()
+
+	whole := walkedNames(t, "whole", WholeCorpus)
+	if len(whole) == 0 {
+		t.Fatalf("the unsharded walk over %s visited no fixtures; every assertion below would hold "+
+			"vacuously", shardedCorpusDir)
+	}
+
+	seen := make(map[string]int, len(whole))
+	for index := 1; index <= goldenUpdateShardCount; index++ {
+		shard := Shard{Index: index, Count: goldenUpdateShardCount}
+		for _, name := range walkedNames(t, fmt.Sprintf("leg%d", index), shard) {
+			seen[name]++
+		}
+	}
+
+	var missing, duplicated []string
+	for _, name := range whole {
+		switch seen[name] {
+		case 1:
+		case 0:
+			missing = append(missing, name)
+		default:
+			duplicated = append(duplicated, name)
+		}
+	}
+	if len(missing) > 0 {
+		t.Errorf("%d fixture(s) belong to NO leg of a %d-way split, so no process regenerates their "+
+			"goldens and `update-golden` reports a diff that only looks complete: %v",
+			len(missing), goldenUpdateShardCount, truncate(missing))
+	}
+	if len(duplicated) > 0 {
+		t.Errorf("%d fixture(s) belong to MORE THAN ONE leg, so two concurrent processes rewrite the "+
+			"same fixture file: %v", len(duplicated), truncate(duplicated))
+	}
+	for name := range seen {
+		if !contains(whole, name) {
+			t.Errorf("a leg walked %q, which the unsharded walk does not visit at all", name)
+		}
+	}
+}
+
+// TestWalkShardBalancesTheRealCorpus asserts the split actually splits. A
+// partition that put 500 of 569 fixtures on one leg satisfies "total disjoint
+// cover" perfectly and delivers none of the wall-clock win the fan-out exists
+// for — the run still takes as long as its biggest leg.
+func TestWalkShardBalancesTheRealCorpus(t *testing.T) {
+	t.Parallel()
+
+	names := corpusNames(t)
+	sizes := make([]int, goldenUpdateShardCount+1)
+	for _, name := range names {
+		sizes[ShardOf(name, goldenUpdateShardCount)]++
+	}
+
+	minSize, maxSize := len(names), 0
+	for index := 1; index <= goldenUpdateShardCount; index++ {
+		minSize = min(minSize, sizes[index])
+		maxSize = max(maxSize, sizes[index])
+	}
+	if minSize == 0 {
+		t.Fatalf("a leg holds ZERO of the %d corpus fixtures (sizes %v) — that process boots chDB, "+
+			"regenerates nothing and exits 0", len(names), sizes[1:])
+	}
+	if ratio := float64(maxSize) / float64(minSize); ratio > maxShardImbalance {
+		t.Errorf("leg sizes %v over %d fixtures are imbalanced %.2fx (max %d / min %d), above the %.2fx "+
+			"floor — the partition has stopped spreading, so the fan-out's wall-clock is the biggest "+
+			"leg rather than the average one", sizes[1:], len(names), ratio, maxSize, minSize, maxShardImbalance)
+	}
+}
+
+// TestWalkShardDefaultsToTheWholeCorpus pins the fallback that keeps a
+// hand-typed `go test -tags chdb ./test/spec/promql/` — and every other
+// spec.Walk caller, none of which declare a partition — walking everything.
+func TestWalkShardDefaultsToTheWholeCorpus(t *testing.T) {
+	t.Parallel()
+
+	if !WholeCorpus.IsWhole() {
+		t.Fatal("WholeCorpus.IsWhole() is false")
+	}
+	walked := walkedNames(t, "default", WholeCorpus)
+	corpus := corpusNames(t)
+	if len(walked) != len(corpus) {
+		t.Fatalf("the whole-corpus walk visited %d of %d fixtures in %s",
+			len(walked), len(corpus), shardedCorpusDir)
+	}
+}
+
+// TestWalkShardRefusesASliceThatHoldsNothing pins the loud end of the failure
+// mode above: a count wider than the corpus leaves legs holding nothing, and a
+// leg that walks nothing finishes fast and green. FilterShard is the decision
+// WalkShard fatals on, asserted here directly because a t.Fatalf inside a
+// subtest cannot be observed from the parent without a subprocess.
+func TestWalkShardRefusesASliceThatHoldsNothing(t *testing.T) {
+	t.Parallel()
+
+	only := []string{"the_only_fixture"}
+	empty := 0
+	const impossiblyWideSplit = 8
+	for index := 1; index <= impossiblyWideSplit; index++ {
+		shard := Shard{Index: index, Count: impossiblyWideSplit}
+		if len(FilterShard(shard, only, func(s string) string { return s })) == 0 {
+			empty++
+		}
+	}
+	if empty != impossiblyWideSplit-1 {
+		t.Fatalf("splitting a 1-fixture corpus %d ways left %d empty slices, want %d — the guard in "+
+			"WalkShard fires on exactly this condition", impossiblyWideSplit, empty, impossiblyWideSplit-1)
+	}
+}
+
+func TestShardFromEnvNames(t *testing.T) {
+	const (
+		indexEnv = "CERBERUS_TEST_SHARD_INDEX"
+		countEnv = "CERBERUS_TEST_SHARD_COUNT"
+	)
+
+	cases := []struct {
+		name        string
+		index       *string
+		count       *string
+		want        Shard
+		wantErrLike string
+	}{
+		{name: "unset defaults to the whole corpus", want: WholeCorpus},
+		{name: "a declared leg", index: ptr("3"), count: ptr("8"), want: Shard{Index: 3, Count: 8}},
+		{name: "single-leg split is the whole corpus", index: ptr("1"), count: ptr("1"), want: Shard{Index: 1, Count: 1}},
+		{name: "last leg", index: ptr("8"), count: ptr("8"), want: Shard{Index: 8, Count: 8}},
+
+		{name: "index without count", index: ptr("3"), wantErrLike: "must be set together"},
+		{name: "count without index", count: ptr("8"), wantErrLike: "must be set together"},
+		{name: "non-integer count", index: ptr("1"), count: ptr("eight"), wantErrLike: "is not an integer"},
+		{name: "non-integer index", index: ptr("first"), count: ptr("8"), wantErrLike: "is not an integer"},
+		{name: "zero count", index: ptr("1"), count: ptr("0"), wantErrLike: "must be >= 1"},
+		{name: "index above count", index: ptr("9"), count: ptr("8"), wantErrLike: "outside"},
+		{name: "zero index", index: ptr("0"), count: ptr("8"), wantErrLike: "outside"},
+		{name: "negative index", index: ptr("-1"), count: ptr("8"), wantErrLike: "outside"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// No t.Parallel(): t.Setenv and the process environment are
+			// global, so these subtests must not overlap.
+			if tc.index != nil {
+				t.Setenv(indexEnv, *tc.index)
+			} else {
+				os.Unsetenv(indexEnv)
+			}
+			if tc.count != nil {
+				t.Setenv(countEnv, *tc.count)
+			} else {
+				os.Unsetenv(countEnv)
+			}
+
+			got, err := ShardFromEnvNames(indexEnv, countEnv)
+			if tc.wantErrLike != "" {
+				if err == nil {
+					t.Fatalf("ShardFromEnvNames() = %v, want an error containing %q", got, tc.wantErrLike)
+				}
+				if !strings.Contains(err.Error(), tc.wantErrLike) {
+					t.Fatalf("ShardFromEnvNames() error = %q, want it to contain %q", err, tc.wantErrLike)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ShardFromEnvNames() unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("ShardFromEnvNames() = %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestShardFromEnvReadsTheSpecContract pins which variables the spec corpus is
+// partitioned by. Sharing PERF_SHARD_* with the perf lane would let a
+// `perf-guards-shard (3)` leg silently narrow an unrelated spec walk.
+func TestShardFromEnvReadsTheSpecContract(t *testing.T) {
+	t.Setenv(ShardIndexEnv, "3")
+	t.Setenv(ShardCountEnv, "8")
+
+	got, err := ShardFromEnv()
+	if err != nil {
+		t.Fatalf("ShardFromEnv() unexpected error: %v", err)
+	}
+	if want := (Shard{Index: 3, Count: 8}); got != want {
+		t.Fatalf("ShardFromEnv() = %+v, want %+v — it does not read %s / %s",
+			got, want, ShardIndexEnv, ShardCountEnv)
+	}
+	if ShardIndexEnv == "PERF_SHARD_INDEX" || ShardCountEnv == "PERF_SHARD_COUNT" {
+		t.Errorf("the spec partition reads the perf lane's variables (%s / %s); a perf shard leg would "+
+			"then narrow every spec walk in the same process", ShardIndexEnv, ShardCountEnv)
+	}
+}
+
+// walkedNames runs WalkShard over the sharded corpus and returns the fixture
+// names it visited, in visit order.
+func walkedNames(t *testing.T, label string, shard Shard) []string {
+	t.Helper()
+
+	var names []string
+	t.Run(label, func(t *testing.T) {
+		WalkShard(t, shardedCorpusDir, shard, func(_ *testing.T, c *Case) {
+			names = append(names, c.Name)
+		})
+	})
+	return names
+}
+
+// corpusNames is the fixture roster read straight off disk, independent of
+// WalkShard, so the cover assertion has something to compare against that
+// WalkShard did not produce.
+func corpusNames(t *testing.T) []string {
+	t.Helper()
+
+	matches, err := filepath.Glob(filepath.Join(shardedCorpusDir, "*"+fixtureExt))
+	if err != nil {
+		t.Fatalf("glob %s: %v", shardedCorpusDir, err)
+	}
+	if len(matches) == 0 {
+		t.Fatalf("no fixtures in %s; the partition assertions would hold vacuously", shardedCorpusDir)
+	}
+	names := make([]string, 0, len(matches))
+	for _, m := range matches {
+		names = append(names, trimFixtureExt(filepath.Base(m)))
+	}
+	sort.Strings(names)
+	return names
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func truncate(names []string) []string {
+	const maxListed = 10
+	if len(names) <= maxListed {
+		return names
+	}
+	return append(names[:maxListed:maxListed], "…")
+}
+
+func ptr(s string) *string { return &s }


### PR DESCRIPTION
## What

`just update-golden promql` spent nearly all of its wall clock in one step:
`TestRoundTripChDB` walking ~570 chDB-executing TXTAR fixtures in a single
process. This splits that walk across processes.

## Why not `t.Parallel()`

Every subtest shares chdb-go's package-level session singleton, and
`test/spec/runner_chdb.go` deliberately tears that singleton down and rebuilds
it between fixtures for cross-fixture isolation (#1987). A `t.Parallel()` on
the walk would race two goroutines against that teardown — reintroducing the
bug class #1987 closed, through a different door. A separate OS process gets
its own singleton and its own `MkdirTemp`-backed session, so process-level
sharding is the only safe lever.

## Mechanism

- **`test/spec/shard.go`** (new, untagged) — the corpus partition: an FNV-1a
  hash of the fixture NAME, so enrolling fixtures leaves every existing one on
  the leg it was already on rather than re-shuffling half the corpus. Plus
  `WalkShard(t, dir, shard, fn)`, which is `Walk` over one slice. `Walk` now
  delegates to it with `WholeCorpus`, so all seven existing callers are
  behaviourally unchanged.
- **`test/perf/profile/shard.go`** — becomes a thin binding over that same
  function (keeping its `PERF_SHARD_*` contract) instead of a second copy of
  the arithmetic. Two copies would satisfy every property each lane asserts in
  isolation while disagreeing about which fixture lands where — a disagreement
  no per-lane test can see.
- **`TestRoundTripChDB`** — reads `SPEC_SHARD_INDEX` / `SPEC_SHARD_COUNT`,
  falling back to the whole corpus when unset, so a hand-typed
  `go test -tags chdb ./test/spec/promql/` and CI's `roundtrip (promql)` job
  behave exactly as before. The pair is deliberately not `PERF_SHARD_*`: one
  shared pair would let a `perf-guards-shard` leg silently narrow an unrelated
  spec walk.
- **`golden-shards.mjs`** — a generator may declare `fanOut: N`. `commandsFor`
  now returns *steps*, where a step is one command or an ARRAY of commands to
  run concurrently.
- **`golden-update.mjs`** — `runShard` runs a step's group under `Promise.all`
  and only advances once all of them finish, so the fan-out parallelises one
  generator without weakening the ordering *between* generators (`TestLower`
  writes the `-- sql --` these legs execute). First non-zero exit in the group
  fails the shard after its siblings finish, matching the existing cross-shard
  semantics. Children are tagged `promql[3/4]`.
- **`post-merge-golden-drift.mjs`** — flattens fan-outs and runs them serially;
  its stdio is inherited rather than line-tagged, and the union is the same
  either way.

## Leg count: measured, not assumed

Regenerating the whole corpus from blanked `-- expected_rows --`:

| mode | wall |
|---|---|
| single process | 629s |
| 4 legs | **231s** |
| 8 legs | 252s |

Eight legs buy nothing and cost a little: chDB threads *within* a single query,
so a leg already uses more than one core and eight of them oversubscribe an
8-core box rather than spread. Four also leaves room for the five sibling
STAGE_BODY shards running beside them during `update-golden all`. Steady-state
(nothing to rewrite) is 221s / 195s against a 452s single-process baseline.

Numbers were taken on a machine shared with other concurrent test runs, so
treat them as an internally-consistent comparison rather than absolute figures.

## Identical output, proved

Blanking every `expected_rows` section forces a real rewrite of all 529
round-trip fixtures. From that same starting state the 4-leg run, the 8-leg run
and the single-process serial run each produced **byte-identical content across
all 569 fixtures** (`cmp` over every file, 0 differing). Two further
back-to-back runs on an in-sync tree finished green with zero fixture churn,
ruling out cross-run staleness from legs starting at slightly different times.

## Tests

- `test/spec/shard_test.go` — total-disjoint-cover through `WalkShard` itself
  (a fixture on no leg is never regenerated and the diff only *looks* complete;
  a fixture on two legs is written by two concurrent processes), balance floor,
  FNV goldens pinned one-per-leg so a degenerate constant hash cannot satisfy
  them, and the env contract.
- `test/regression/golden_shard_fanout_test.go` — the fan-out is live and not
  collapsed, legs are contiguous 1..N, the count matches the Go constant, and
  the env names match what `spec.ShardFromEnv` actually reads. Each was
  verified to FAIL when broken: collapsing the fan-out, renaming the pair on
  the Go side only, and drifting the count.
